### PR TITLE
itech/itech32.cpp: Various cleanups and updates:

### DIFF
--- a/src/mame/itech/itech32.cpp
+++ b/src/mame/itech/itech32.cpp
@@ -404,14 +404,26 @@ Notes:
 #include "speaker.h"
 
 
-#define FULL_LOGGING                0
 #define LOG_DRIVEDGE_UNINIT_RAM     0
 
+#define LOG_SCREEN  (1U << 1)
+#define LOG_PIA     (1U << 2)
+#define LOG_DSP     (1U << 3)
+
+#define LOG_ALL     (LOG_SCREEN | LOG_PIA | LOG_DSP)
+
+#define VERBOSE (0)
+#include "logmacro.h"
+
+#define LOGSCREEN(...)  LOGMASKED(LOG_SCREEN, __VA_ARGS__)
+#define LOGPIA(...)     LOGMASKED(LOG_PIA, __VA_ARGS__)
+#define LOGDSP(...)     LOGMASKED(LOG_DSP, __VA_ARGS__)
 
 
 #define START_TMS_SPINNING(n)           do { space.device().execute().spin_until_trigger(7351 + n); m_tms_spinning[n] = 1; } while (0)
 #define STOP_TMS_SPINNING(machine, n)   do { (machine).scheduler().trigger(7351 + n); m_tms_spinning[n] = 0; } while (0)
 
+static constexpr XTAL CPU020_CLOCK = XTAL(25'000'000); // clock for 68EC020-based systems
 
 
 /*************************************
@@ -422,14 +434,14 @@ Notes:
 
 void shoottv_state::update_interrupts(int vint, int xint, int qint)
 {
-	/* VINT is ignored on shoottv hardware. */
+	// VINT is ignored on shoottv hardware.
 	itech32_state::update_interrupts(-1, xint, qint);
 }
 
 
 void itech32_state::update_interrupts(int vint, int xint, int qint)
 {
-	/* update the states */
+	// update the states
 	if (vint != -1) m_vint_state = vint;
 	if (xint != -1) m_xint_state = xint;
 	if (qint != -1) m_qint_state = qint;
@@ -444,9 +456,9 @@ void itech32_state::generate_int1(int state)
 {
 	if (state)
 	{
-		/* signal the NMI */
+		// signal the NMI
 		update_interrupts(1, -1, -1);
-		if (FULL_LOGGING) logerror("------------ VBLANK (%d) --------------\n", m_screen->vpos());
+		LOGSCREEN("------------ VBLANK (%d) --------------\n", m_screen->vpos());
 	}
 }
 
@@ -475,15 +487,10 @@ void itech32_state::machine_start()
 	save_item(NAME(m_irq_base));
 	save_item(NAME(m_sound_return));
 	save_item(NAME(m_special_result));
-	save_item(NAME(m_p1_effx));
-	save_item(NAME(m_p1_effy));
-	save_item(NAME(m_p1_lastresult));
-	save_item(NAME(m_p1_lasttime));
-	save_item(NAME(m_p2_effx));
-	save_item(NAME(m_p2_effy));
-	save_item(NAME(m_p2_lastresult));
-	save_item(NAME(m_p2_lasttime));
-	save_item(NAME(m_written));
+	save_item(NAME(m_effx));
+	save_item(NAME(m_effy));
+	save_item(NAME(m_lastresult));
+	save_item(NAME(m_lasttime));
 }
 
 void itech32_state::machine_reset()
@@ -499,6 +506,7 @@ void drivedge_state::machine_start()
 	m_leds.resolve();
 
 	save_item(NAME(m_tms_spinning));
+	save_item(NAME(m_written));
 }
 
 void drivedge_state::machine_reset()
@@ -537,24 +545,17 @@ void itech32_state::color_w(u8 data)
 
 int itech32_state::special_port_r()
 {
-	if (m_soundlatch->pending_r())
+	if ((!machine().side_effects_disabled()) && m_soundlatch->pending_r())
 		m_special_result ^= 1;
 
 	return m_special_result;
 }
 
+template<unsigned Which>
 u8 itech32_state::trackball_r()
 {
-	int lower = ioport("TRACKX1")->read();
-	int upper = ioport("TRACKY1")->read();
-
-	return (lower & 15) | ((upper & 15) << 4);
-}
-
-u8 itech32_state::trackball_p2_r()
-{
-	int lower = ioport("TRACKX2")->read();
-	int upper = ioport("TRACKY2")->read();
+	const u8 lower = m_trackball_x[Which]->read();
+	const u8 upper = m_trackball_y[Which]->read();
 
 	return (lower & 15) | ((upper & 15) << 4);
 }
@@ -562,95 +563,56 @@ u8 itech32_state::trackball_p2_r()
 
 u16 itech32_state::trackball_8bit_r()
 {
-	int lower = ioport("TRACKX1")->read();
-	int upper = ioport("TRACKY1")->read();
+	const u8 lower = m_trackball_x[0]->read();
+	const u8 upper = m_trackball_y[0]->read();
 
-	return (lower & 255) | ((upper & 255) << 8);
+	return (lower & 255) | (u16(upper & 255) << 8);
 }
 
-
-u32 itech32_state::trackball32_4bit_p1_r()
+template<unsigned Which>
+u32 itech32_state::trackball32_4bit_r()
 {
 	attotime curtime = machine().time();
 
-	if ((curtime - m_p1_lasttime) > m_screen->scan_period())
+	if ((curtime - m_lasttime[Which]) > m_screen->scan_period())
 	{
-		int upper, lower;
-		int dx, dy;
+		const s32 curx = m_trackball_x[Which]->read();
+		const s32 cury = m_trackball_y[Which]->read();
 
-		int curx = ioport("TRACKX1")->read();
-		int cury = ioport("TRACKY1")->read();
-
-		dx = curx - m_p1_effx;
+		int dx = curx - m_effx[Which];
 		if (dx < -0x80) dx += 0x100;
 		else if (dx > 0x80) dx -= 0x100;
 		if (dx > 7) dx = 7;
 		else if (dx < -7) dx = -7;
-		m_p1_effx = (m_p1_effx + dx) & 0xff;
-		lower = m_p1_effx & 15;
+		m_effx[Which] = (m_effx[Which] + dx) & 0xff;
+		const u8 lower = m_effx[Which] & 15;
 
-		dy = cury - m_p1_effy;
+		int dy = cury - m_effy[Which];
 		if (dy < -0x80) dy += 0x100;
 		else if (dy > 0x80) dy -= 0x100;
 		if (dy > 7) dy = 7;
 		else if (dy < -7) dy = -7;
-		m_p1_effy = (m_p1_effy + dy) & 0xff;
-		upper = m_p1_effy & 15;
+		m_effy[Which] = (m_effy[Which] + dy) & 0xff;
+		const u8 upper = m_effy[Which] & 15;
 
-		m_p1_lastresult = lower | (upper << 4);
+		m_lastresult[Which] = lower | (upper << 4);
 	}
 
-	m_p1_lasttime = curtime;
-	return m_p1_lastresult | (m_p1_lastresult << 16);
-}
-
-
-u32 itech32_state::trackball32_4bit_p2_r()
-{
-	attotime curtime = machine().time();
-
-	if ((curtime - m_p2_lasttime) > m_screen->scan_period())
-	{
-		int upper, lower;
-		int dx, dy;
-
-		int curx = ioport("TRACKX2")->read();
-		int cury = ioport("TRACKY2")->read();
-
-		dx = curx - m_p2_effx;
-		if (dx < -0x80) dx += 0x100;
-		else if (dx > 0x80) dx -= 0x100;
-		if (dx > 7) dx = 7;
-		else if (dx < -7) dx = -7;
-		m_p2_effx = (m_p2_effx + dx) & 0xff;
-		lower = m_p2_effx & 15;
-
-		dy = cury - m_p2_effy;
-		if (dy < -0x80) dy += 0x100;
-		else if (dy > 0x80) dy -= 0x100;
-		if (dy > 7) dy = 7;
-		else if (dy < -7) dy = -7;
-		m_p2_effy = (m_p2_effy + dy) & 0xff;
-		upper = m_p2_effy & 15;
-
-		m_p2_lastresult = lower | (upper << 4);
-	}
-
-	m_p2_lasttime = curtime;
-	return m_p2_lastresult | (m_p2_lastresult << 16);
+	m_lasttime[Which] = curtime;
+	return m_lastresult[Which] | (u32(m_lastresult[Which]) << 16);
 }
 
 
 u32 itech32_state::trackball32_4bit_combined_r()
 {
-	return trackball32_4bit_p1_r() |
-			(trackball32_4bit_p2_r() << 8);
+	return trackball32_4bit_r<0>() |
+			(trackball32_4bit_r<1>() << 8);
 }
 
 
 u16 drivedge_state::steering_r()
 {
-	int val = m_steer->read() * 2 - 0x100;
+	s32 val = m_steer->read() * 2 - 0x100;
 	if (val < 0) val = 0x100 | (-val);
 	return val;
 }
@@ -684,13 +646,13 @@ u8 itech32_state::itech020_prot_result_r()
 
 u32 itech32_state::gt2kp_prot_result_r()
 {
-	return 0x00010000;  /* 32 bit value at 680000 to 680003 will return the needed value of 0x01 */
+	return 0x00010000;  // 32 bit value at 680000 to 680003 will return the needed value of 0x01
 }
 
 
 u32 itech32_state::gtclass_prot_result_r()
 {
-	return 0x00008000;  /* 32 bit value at 680000 to 680003 will return the needed value of 0x80 */
+	return 0x00008000;  // 32 bit value at 680000 to 680003 will return the needed value of 0x80
 }
 
 
@@ -755,14 +717,14 @@ void itech32_state::sound_control_w(u8 data)
 
 void drivedge_state::portb_out(u8 data)
 {
-//  logerror("PIA port B write = %02x\n", data);
+//  LOGPIA("PIA port B write = %02x\n", data);
 
-	/* bit 0 controls the fan light */
-	/* bit 1 controls the tow light */
-	/* bit 2 controls the horn light */
-	/* bit 4 controls the ticket dispenser */
-	/* bit 5 controls the coin counter */
-	/* bit 6 controls the diagnostic sound LED */
+	// bit 0 controls the fan light
+	// bit 1 controls the tow light
+	// bit 2 controls the horn light
+	// bit 4 controls the ticket dispenser
+	// bit 5 controls the coin counter
+	// bit 6 controls the diagnostic sound LED
 	m_leds[1] = BIT(data, 0);
 	m_leds[2] = BIT(data, 1);
 	m_leds[3] = BIT(data, 2);
@@ -779,11 +741,11 @@ void drivedge_state::turbo_light(int state)
 
 void itech32_state::pia_portb_out(u8 data)
 {
-//  logerror("PIA port B write = %02x\n", data);
+//  LOGPIA("PIA port B write = %02x\n", data);
 
-	/* bit 4 controls the ticket dispenser */
-	/* bit 5 controls the coin counter */
-	/* bit 6 controls the diagnostic sound LED */
+	// bit 4 controls the ticket dispenser
+	// bit 5 controls the coin counter
+	// bit 6 controls the diagnostic sound LED
 	m_ticket->motor_w(BIT(data, 4));
 	machine().bookkeeping().coin_counter_w(0, BIT(data, 5));
 }
@@ -818,7 +780,7 @@ void drivedge_state::tms_reset_assert_w(u32 data)
 
 void drivedge_state::tms_reset_clear_w(u32 data)
 {
-	/* kludge to prevent crash on first boot */
+	// kludge to prevent crash on first boot
 	if ((m_tms1_ram[0] & 0xff000000) == 0)
 	{
 		m_dsp[0]->set_input_line(INPUT_LINE_RESET, CLEAR_LINE);
@@ -888,7 +850,7 @@ u32 drivedge_state::tms2_speedup_r(address_space &space)
 void itech32_state::nvram_init(nvram_device &nvram, void *base, size_t length)
 {
 	// if nvram is the main RAM, don't overwrite exception vectors
-	int start = (!m_main_ram32) && (base == m_nvram32 || base == m_nvram16) ? 0x80 : 0x00;
+	const int start = (!m_main_ram32) && (base == m_nvram32 || base == m_nvram16) ? 0x80 : 0x00;
 	for (int i = start; i < length; i++)
 		((u8 *)base)[i] = machine().rand();
 }
@@ -907,10 +869,10 @@ void drivedge_state::nvram_init(nvram_device &nvram, void *base, size_t length)
  *
  *************************************/
 
-/*------ Time Killers memory layout ------*/
+//------ Time Killers memory layout ------
 void itech32_state::timekill_map(address_map &map)
 {
-	map(0x000000, 0x003fff).ram().share("nvram16");
+	map(0x000000, 0x003fff).ram().share(m_nvram16);
 	map(0x040000, 0x040001).portr("P1");
 	map(0x048000, 0x048001).portr("P2");
 	map(0x050000, 0x050001).portr("SYSTEM");
@@ -918,19 +880,19 @@ void itech32_state::timekill_map(address_map &map)
 	map(0x058000, 0x058001).portr("DIPS").w("watchdog", FUNC(watchdog_timer_device::reset16_w));
 	map(0x060000, 0x060003).w(FUNC(itech32_state::timekill_colora_w));
 	map(0x068000, 0x068003).w(FUNC(itech32_state::timekill_colorbc_w));
-	map(0x070000, 0x070001).nopw();    /* noisy */
+	map(0x070000, 0x070001).nopw();    // noisy
 	map(0x078001, 0x078001).w(FUNC(itech32_state::sound_data_w));
 	map(0x080000, 0x08007f).rw(FUNC(itech32_state::video_r), FUNC(itech32_state::video_w));
 	map(0x0a0000, 0x0a0001).w(FUNC(itech32_state::int1_ack_w));
 	map(0x0c0000, 0x0c7fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x100000, 0x17ffff).rom().region("user1", 0);
+	map(0x100000, 0x17ffff).rom().region("maindata", 0);
 }
 
 
-/*------ BloodStorm and later games memory layout ------*/
+//------ BloodStorm and later games memory layout ------
 void itech32_state::bloodstm_map(address_map &map)
 {
-	map(0x000000, 0x00ffff).ram().share("nvram16");
+	map(0x000000, 0x00ffff).ram().share(m_nvram16);
 	map(0x080000, 0x080001).portr("P1").w(FUNC(itech32_state::int1_ack_w));
 	map(0x100000, 0x100001).portr("P2");
 	map(0x180000, 0x180001).portr("P3");
@@ -944,24 +906,24 @@ void itech32_state::bloodstm_map(address_map &map)
 	map(0x580000, 0x59ffff).ram().w(FUNC(itech32_state::bloodstm_paletteram_w)).share("palette");
 	map(0x700001, 0x700001).w(FUNC(itech32_state::bloodstm_plane_w));
 	map(0x780000, 0x780001).portr("EXTRA");
-	map(0x800000, 0x87ffff).mirror(0x780000).rom().region("user1", 0);
+	map(0x800000, 0x87ffff).mirror(0x780000).rom().region("maindata", 0);
 }
 
 
-/*------ Driver's Edge memory layouts ------*/
+//------ Driver's Edge memory layouts ------
 
 #if LOG_DRIVEDGE_UNINIT_RAM
 
-u32 itech32_state::test1_r(offs_t offset, u32 mem_mask)
+u32 drivedge_state::test1_r(offs_t offset, u32 mem_mask)
 {
-	if (ACCESSING_BITS_24_31 && !m_written[0x100 + offset*4+0]) logerror("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0x100 + offset*4+0);
-	if (ACCESSING_BITS_16_23 && !m_written[0x100 + offset*4+1]) logerror("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0x100 + offset*4+1);
-	if (ACCESSING_BITS_8_15 && !m_written[0x100 + offset*4+2]) logerror("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0x100 + offset*4+2);
-	if (ACCESSING_BITS_0_7 && !m_written[0x100 + offset*4+3]) logerror("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0x100 + offset*4+3);
+	if (ACCESSING_BITS_24_31 && !m_written[0x100 + offset*4+0]) LOGDSP("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0x100 + offset*4+0);
+	if (ACCESSING_BITS_16_23 && !m_written[0x100 + offset*4+1]) LOGDSP("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0x100 + offset*4+1);
+	if (ACCESSING_BITS_8_15 && !m_written[0x100 + offset*4+2]) LOGDSP("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0x100 + offset*4+2);
+	if (ACCESSING_BITS_0_7 && !m_written[0x100 + offset*4+3]) LOGDSP("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0x100 + offset*4+3);
 	return ((u32 *)m_nvram)[0x100/4 + offset];
 }
 
-void itech32_state::test1_w(offs_t offset, u32 data, u32 mem_mask)
+void drivedge_state::test1_w(offs_t offset, u32 data, u32 mem_mask)
 {
 	if (ACCESSING_BITS_24_31) m_written[0x100 + offset*4+0] = 1;
 	if (ACCESSING_BITS_16_23) m_written[0x100 + offset*4+1] = 1;
@@ -970,16 +932,16 @@ void itech32_state::test1_w(offs_t offset, u32 data, u32 mem_mask)
 	COMBINE_DATA(&((u32 *)m_nvram)[0x100/4 + offset]);
 }
 
-u32 itech32_state::test2_r(offs_t offset, u32 mem_mask)
+u32 drivedge_state::test2_r(offs_t offset, u32 mem_mask)
 {
-	if (ACCESSING_BITS_24_31 && !m_written[0xc00 + offset*4+0]) logerror("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0xc00 + offset*4+0);
-	if (ACCESSING_BITS_16_23 && !m_written[0xc00 + offset*4+1]) logerror("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0xc00 + offset*4+1);
-	if (ACCESSING_BITS_8_15 && !m_written[0xc00 + offset*4+2]) logerror("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0xc00 + offset*4+2);
-	if (ACCESSING_BITS_0_7 && !m_written[0xc00 + offset*4+3]) logerror("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0xc00 + offset*4+3);
+	if (ACCESSING_BITS_24_31 && !m_written[0xc00 + offset*4+0]) LOGDSP("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0xc00 + offset*4+0);
+	if (ACCESSING_BITS_16_23 && !m_written[0xc00 + offset*4+1]) LOGDSP("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0xc00 + offset*4+1);
+	if (ACCESSING_BITS_8_15 && !m_written[0xc00 + offset*4+2]) LOGDSP("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0xc00 + offset*4+2);
+	if (ACCESSING_BITS_0_7 && !m_written[0xc00 + offset*4+3]) LOGDSP("%06X:read from uninitialized memory %04X\n", m_maincpu->pc(), 0xc00 + offset*4+3);
 	return ((u32 *)m_nvram)[0xc00/4 + offset];
 }
 
-void itech32_state::test2_w(offs_t offset, u32 data, u32 mem_mask)
+void drivedge_state::test2_w(offs_t offset, u32 data, u32 mem_mask)
 {
 	if (ACCESSING_BITS_24_31) m_written[0xc00 + offset*4+0] = 1;
 	if (ACCESSING_BITS_16_23) m_written[0xc00 + offset*4+1] = 1;
@@ -991,10 +953,10 @@ void itech32_state::test2_w(offs_t offset, u32 data, u32 mem_mask)
 
 void drivedge_state::main_map(address_map &map)
 {
-	map(0x000000, 0x03ffff).mirror(0x40000).ram().share("nvram32");
+	map(0x000000, 0x03ffff).mirror(0x40000).ram().share(m_nvram32);
 #if LOG_DRIVEDGE_UNINIT_RAM
-map(0x000100, 0x0003ff).mirror(0x40000).rw(FUNC(itech32_state::test1_r), FUNC(itech32_state::test1_w));
-map(0x000c00, 0x007fff).mirror(0x40000).rw(FUNC(itech32_state::test2_r), FUNC(itech32_state::test2_w));
+map(0x000100, 0x0003ff).mirror(0x40000).rw(FUNC(drivedge_state::test1_r), FUNC(drivedge_state::test1_w));
+map(0x000c00, 0x007fff).mirror(0x40000).rw(FUNC(drivedge_state::test2_r), FUNC(drivedge_state::test2_w));
 #endif
 	map(0x080000, 0x080003).portr("80000");
 	map(0x082000, 0x082003).portr("82000");
@@ -1005,7 +967,7 @@ map(0x000c00, 0x007fff).mirror(0x40000).rw(FUNC(itech32_state::test2_r), FUNC(it
 	map(0x08a000, 0x08a003).nopw();
 	map(0x08c000, 0x08c003).portr("8c000");
 	map(0x08e000, 0x08e003).portr("8e000").nopw();
-	map(0x100000, 0x10000f).w(FUNC(drivedge_state::zbuf_control_w)).share("zctl");
+	map(0x100000, 0x10000f).w(FUNC(drivedge_state::zbuf_control_w)).share(m_zbuf_control);
 	map(0x180001, 0x180001).w(FUNC(drivedge_state::color_w<0>));
 	map(0x1a0000, 0x1bffff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette");
 	map(0x1c0000, 0x1c0003).nopw();
@@ -1016,27 +978,27 @@ map(0x000c00, 0x007fff).mirror(0x40000).rw(FUNC(itech32_state::test2_r), FUNC(it
 	map(0x280000, 0x280fff).ram().lr32(NAME([this](offs_t offset) { return m_tms1_ram[offset]; })).w(FUNC(drivedge_state::tms1_68k_ram_w));
 	map(0x300000, 0x300fff).ram().lr32(NAME([this](offs_t offset) { return m_tms2_ram[offset]; })).w(FUNC(drivedge_state::tms2_68k_ram_w));
 	map(0x380000, 0x380003).nopw(); // .w("watchdog", FUNC(watchdog_timer_device::reset16_w));
-	map(0x600000, 0x607fff).rom().region("user1", 0);
+	map(0x600000, 0x607fff).rom().region("maindata", 0);
 }
 
 void drivedge_state::tms1_map(address_map &map)
 {
-	map(0x000000, 0x001fff).ram().share("tms1_boot");
-	map(0x008000, 0x0083ff).mirror(0x400).ram().w(FUNC(drivedge_state::tms1_trigger_w)).share("tms1_ram");
+	map(0x000000, 0x001fff).ram().share(m_tms1_boot);
+	map(0x008000, 0x0083ff).mirror(0x400).ram().w(FUNC(drivedge_state::tms1_trigger_w)).share(m_tms1_ram);
 	map(0x080000, 0x0bffff).ram();
 }
 
 void drivedge_state::tms2_map(address_map &map)
 {
-	map(0x000000, 0x0003ff).mirror(0x8400).ram().w(FUNC(drivedge_state::tms2_trigger_w)).share("tms2_ram");
+	map(0x000000, 0x0003ff).mirror(0x8400).ram().w(FUNC(drivedge_state::tms2_trigger_w)).share(m_tms2_ram);
 	map(0x080000, 0x08ffff).ram();
 }
 
 
-/*------ 68EC020-based memory layout ------*/
+//------ 68EC020-based memory layout ------
 void itech32_state::itech020_map(address_map &map)
 {
-	map(0x000000, 0x007fff).ram().share("main_ram");
+	map(0x000000, 0x007fff).ram().share(m_main_ram32);
 	map(0x080000, 0x080003).portr("P1").w(FUNC(itech32_state::int1_ack_w));
 	map(0x100000, 0x100003).portr("P2");
 	map(0x180000, 0x180003).portr("P3");
@@ -1047,14 +1009,14 @@ void itech32_state::itech020_map(address_map &map)
 	map(0x400000, 0x400003).w("watchdog", FUNC(watchdog_timer_device::reset32_w));
 	map(0x480001, 0x480001).w(FUNC(itech32_state::sound_data_w));
 	map(0x500000, 0x5000ff).rw(FUNC(itech32_state::bloodstm_video_r), FUNC(itech32_state::bloodstm_video_w));
-	map(0x578000, 0x57ffff).nopr();             /* touched by protection */
+	map(0x578000, 0x57ffff).nopr();             // touched by protection
 	map(0x580000, 0x59ffff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette");
-	map(0x600000, 0x61ffff).ram().share("nvram32");
+	map(0x600000, 0x61ffff).ram().share(m_nvram32);
 	map(0x680002, 0x680002).r(FUNC(itech32_state::itech020_prot_result_r));
 	map(0x680000, 0x680003).nopw();
-/* ! */ map(0x680800, 0x68083f).readonly().nopw(); /* Serial DUART Channel A/B & Top LED sign - To Do! */
+/* ! */ map(0x680800, 0x68083f).readonly().nopw(); // Serial DUART Channel A/B & Top LED sign - To Do!
 	map(0x700002, 0x700002).w(FUNC(itech32_state::itech020_plane_w));
-	map(0x800000, 0xbfffff).rom().region("user1", 0);
+	map(0x800000, 0xbfffff).rom().region("maindata", 0);
 }
 
 void shoottv_state::shoottv_map(address_map &map)
@@ -1094,22 +1056,22 @@ void itech32_state::pubball_map(address_map &map)
  *
  *************************************/
 
-/*------ Rev 1 sound board memory layout ------*/
+//------ Rev 1 sound board memory layout ------
 void itech32_state::sound_map(address_map &map)
 {
 	map(0x0000, 0x0000).w(FUNC(itech32_state::sound_return_w));
 	map(0x0400, 0x0400).r(m_soundlatch, FUNC(generic_latch_8_device::read));
 	map(0x0800, 0x083f).mirror(0x80).rw("ensoniq", FUNC(es5506_device::read), FUNC(es5506_device::write));
 	map(0x0c00, 0x0c00).w(FUNC(itech32_state::sound_bank_w));
-	map(0x1000, 0x1000).nopw();    /* noisy */
-	map(0x1400, 0x140f).m("via6522_0", FUNC(via6522_device::map));
+	map(0x1000, 0x1000).nopw();    // noisy
+	map(0x1400, 0x140f).m(m_via, FUNC(via6522_device::map));
 	map(0x2000, 0x3fff).ram();
-	map(0x4000, 0x7fff).bankr("soundbank");
+	map(0x4000, 0x7fff).bankr(m_soundbank);
 	map(0x8000, 0xffff).rom();
 }
 
 
-/*------ Rev 2 sound board memory layout ------*/
+//------ Rev 2 sound board memory layout ------
 void itech32_state::sound_020_map(address_map &map)
 {
 	map(0x0000, 0x0000).r(m_soundlatch, FUNC(generic_latch_8_device::read));
@@ -1120,7 +1082,7 @@ void itech32_state::sound_020_map(address_map &map)
 	map(0x1800, 0x1800).r(FUNC(itech32_state::sound_data_buffer_r)).nopw();
 	map(0x1c00, 0x1c00).w(FUNC(itech32_state::sound_control_w));
 	map(0x2000, 0x3fff).ram();
-	map(0x4000, 0x7fff).bankr("soundbank");
+	map(0x4000, 0x7fff).bankr(m_soundbank);
 	map(0x8000, 0xffff).rom();
 }
 
@@ -1133,7 +1095,7 @@ void itech32_state::sound_020_map(address_map &map)
  *************************************/
 
 static INPUT_PORTS_START( timekill )
-	PORT_START("P1")        /* 40000 */
+	PORT_START("P1")        // 40000
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(1)
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(1)
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_PLAYER(1)
@@ -1143,7 +1105,7 @@ static INPUT_PORTS_START( timekill )
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_PLAYER(1)
 	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_PLAYER(1)
 
-	PORT_START("P2")        /* 48000 */
+	PORT_START("P2")        // 48000
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(2)
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(2)
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_PLAYER(2)
@@ -1153,7 +1115,7 @@ static INPUT_PORTS_START( timekill )
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_PLAYER(2)
 	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_PLAYER(2)
 
-	PORT_START("SYSTEM")    /* 50000 */
+	PORT_START("SYSTEM")    // 50000
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_BUTTON5 ) PORT_PLAYER(1)
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_COIN1 )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_START1 )
@@ -1163,7 +1125,7 @@ static INPUT_PORTS_START( timekill )
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_START2 )
 	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("DIPS")      /* 58000 */
+	PORT_START("DIPS")      // 58000
 	PORT_SERVICE_NO_TOGGLE( 0x0001, IP_ACTIVE_LOW )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_SERVICE1 )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_CUSTOM ) PORT_VBLANK("screen")
@@ -1182,7 +1144,7 @@ INPUT_PORTS_END
 
 
 static INPUT_PORTS_START( itech32_base_16bit )
-	PORT_START("P1")    /* 080000 */
+	PORT_START("P1")    // 080000
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_COIN1 )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_START1 )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(1)
@@ -1192,7 +1154,7 @@ static INPUT_PORTS_START( itech32_base_16bit )
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_PLAYER(1)
 	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_PLAYER(1)
 
-	PORT_START("P2")    /* 100000 */
+	PORT_START("P2")    // 100000
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_COIN2 )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_START2 )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(2)
@@ -1202,13 +1164,13 @@ static INPUT_PORTS_START( itech32_base_16bit )
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_PLAYER(2)
 	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_PLAYER(2)
 
-	PORT_START("P3")    /* 180000 */
+	PORT_START("P3")    // 180000
 	PORT_BIT( 0x00ff, IP_ACTIVE_HIGH, IPT_UNUSED )
 
-	PORT_START("P4")    /* 200000 */
+	PORT_START("P4")    // 200000
 	PORT_BIT( 0x00ff, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("DIPS")  /* 280000 */
+	PORT_START("DIPS")  // 280000
 	PORT_SERVICE_NO_TOGGLE( 0x0001, IP_ACTIVE_LOW )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_SERVICE1 )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_CUSTOM ) PORT_VBLANK("screen")
@@ -1224,23 +1186,23 @@ static INPUT_PORTS_START( itech32_base_16bit )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 	PORT_SERVICE_DIPLOC( 0x0080, IP_ACTIVE_HIGH, "SW1:1" )
 
-	PORT_START("EXTRA") /* 78000 */
+	PORT_START("EXTRA") // 78000
 	PORT_BIT( 0x00ff, IP_ACTIVE_LOW, IPT_UNUSED )
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( shoottv )
 	PORT_INCLUDE( itech32_base_16bit )
-	PORT_MODIFY("P1")   /* 080000 */
+	PORT_MODIFY("P1")   // 080000
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_COIN1 )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_START1 )
 	PORT_BIT( 0x00fc, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_MODIFY("P2")   /* 100000 */
+	PORT_MODIFY("P2")   // 100000
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_COIN2 )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_START2 )
 	PORT_BIT( 0x00fc, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_MODIFY("P3")   /* 180000 */
+	PORT_MODIFY("P3")   // 180000
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(1)
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(2)
 	PORT_BIT( 0x00fc, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -1309,7 +1271,7 @@ static INPUT_PORTS_START( hardyard )
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_PLAYER(4)
 	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_PLAYER(4)
 
-	PORT_MODIFY("DIPS") /* 280000 */
+	PORT_MODIFY("DIPS") // 280000
 	PORT_DIPNAME( 0x0020, 0x0000, DEF_STR( Cabinet ) ) PORT_DIPLOCATION("SW1:3")
 	PORT_DIPSETTING(      0x0000, DEF_STR( Upright ) )
 	PORT_DIPNAME( 0x0040, 0x0000, DEF_STR( Players ) ) PORT_DIPLOCATION("SW1:2")
@@ -1380,12 +1342,12 @@ static INPUT_PORTS_START( drivedge )
 
 	PORT_START("82000")
 	PORT_BIT( 0x0000ffff, IP_ACTIVE_HIGH, IPT_UNKNOWN )
-	PORT_BIT( 0x00ff0000, 0x00000000, IPT_PEDAL2 ) PORT_MINMAX(0x00000000,0x00060000) PORT_SENSITIVITY(2) PORT_KEYDELTA(100)    /* Brake */
+	PORT_BIT( 0x00ff0000, 0x00000000, IPT_PEDAL2 ) PORT_MINMAX(0x00000000,0x00060000) PORT_SENSITIVITY(2) PORT_KEYDELTA(100)    // Brake
 
-	PORT_START("STEER")     /* 88000 */
+	PORT_START("STEER")     // 88000
 	PORT_BIT( 0xff, 0x80, IPT_PADDLE ) PORT_MINMAX(0x10,0xf0) PORT_SENSITIVITY(25) PORT_KEYDELTA(5)
 
-	PORT_START("GAS")       /* 8A000 */
+	PORT_START("GAS")       // 8A000
 	PORT_BIT( 0xff, 0x00, IPT_PEDAL ) PORT_MINMAX(0x00,0x0c) PORT_SENSITIVITY(1) PORT_KEYDELTA(20) PORT_PLAYER(1)
 INPUT_PORTS_END
 
@@ -1423,12 +1385,12 @@ static INPUT_PORTS_START( wcbowlj )
 	PORT_MODIFY("DIPS")
 	PORT_DIPNAME( 0x0040, 0x0000, DEF_STR( Controls ) ) PORT_DIPLOCATION("SW1:2")
 	PORT_DIPSETTING(      0x0000, "One Trackball" )
-	PORT_DIPSETTING(      0x0040, "Two Trackballs" )    /* Two Trackballs will work for Upright for "side by side" controls */
+	PORT_DIPSETTING(      0x0040, "Two Trackballs" )    // Two Trackballs will work for Upright for "side by side" controls
 INPUT_PORTS_END
 
 
 static INPUT_PORTS_START( itech32_base_32bit )
-	PORT_START("P1")    /* 080000 */
+	PORT_START("P1")    // 080000
 	PORT_BIT( 0x0000ffff, IP_ACTIVE_HIGH, IPT_UNKNOWN )
 	PORT_BIT( 0x00010000, IP_ACTIVE_LOW, IPT_COIN1 )
 	PORT_BIT( 0x00020000, IP_ACTIVE_LOW, IPT_START1 )
@@ -1439,7 +1401,7 @@ static INPUT_PORTS_START( itech32_base_32bit )
 	PORT_BIT( 0x00400000, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_PLAYER(1)
 	PORT_BIT( 0x00800000, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_PLAYER(1)
 
-	PORT_START("P2")    /* 100000 */
+	PORT_START("P2")    // 100000
 	PORT_BIT( 0x0000ffff, IP_ACTIVE_HIGH, IPT_UNKNOWN )
 	PORT_BIT( 0x00010000, IP_ACTIVE_LOW, IPT_COIN2 )
 	PORT_BIT( 0x00020000, IP_ACTIVE_LOW, IPT_START2 )
@@ -1450,15 +1412,15 @@ static INPUT_PORTS_START( itech32_base_32bit )
 	PORT_BIT( 0x00400000, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_PLAYER(2)
 	PORT_BIT( 0x00800000, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_PLAYER(2)
 
-	PORT_START("P3")    /* 180000 */
+	PORT_START("P3")    // 180000
 	PORT_BIT( 0x0000ffff, IP_ACTIVE_HIGH, IPT_UNKNOWN )
 	PORT_BIT( 0x00ff0000, IP_ACTIVE_HIGH, IPT_UNUSED )
 
-	PORT_START("P4")    /* 200000 */
+	PORT_START("P4")    // 200000
 	PORT_BIT( 0x0000ffff, IP_ACTIVE_HIGH, IPT_UNKNOWN )
 	PORT_BIT( 0x00ff0000, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("DIPS")  /* 280000 */
+	PORT_START("DIPS")  // 280000
 	PORT_BIT( 0x0000ffff, IP_ACTIVE_HIGH, IPT_UNKNOWN )
 	PORT_SERVICE_NO_TOGGLE( 0x00010000, IP_ACTIVE_LOW )
 	PORT_BIT( 0x00020000, IP_ACTIVE_LOW, IPT_SERVICE1 )
@@ -1477,7 +1439,7 @@ static INPUT_PORTS_START( itech32_base_32bit )
 INPUT_PORTS_END
 
 
-static INPUT_PORTS_START( wcbowln ) /* WCB version 1.66 supports cocktail mode */
+static INPUT_PORTS_START( wcbowln ) // WCB version 1.66 supports cocktail mode
 	PORT_INCLUDE( itech32_base_32bit )
 
 	PORT_MODIFY("P1")
@@ -1498,7 +1460,7 @@ static INPUT_PORTS_START( wcbowln ) /* WCB version 1.66 supports cocktail mode *
 	PORT_DIPNAME( 0x00100000, 0x00000000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:4")
 	PORT_DIPSETTING(          0x00000000, DEF_STR( Off ) )
 	PORT_DIPSETTING(          0x00100000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Cabinet ) ) PORT_DIPLOCATION("SW1:3") /* v1.66 ROM sets support Cocktail mode (verified) */
+	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Cabinet ) ) PORT_DIPLOCATION("SW1:3") // v1.66 ROM sets support Cocktail mode (verified)
 	PORT_DIPSETTING(          0x00000000, DEF_STR( Upright ) )
 	PORT_DIPSETTING(          0x00200000, DEF_STR( Cocktail ) )
 	PORT_DIPNAME( 0x00400000, 0x00000000, "Freeze Screen" )  PORT_DIPLOCATION("SW1:2")
@@ -1522,8 +1484,8 @@ INPUT_PORTS_END
 static INPUT_PORTS_START( wcbowldx )
 	PORT_INCLUDE( wcbowln )
 
-	PORT_MODIFY("DIPS") /* 280000 */
-	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Flip_Screen ) ) PORT_DIPLOCATION("SW1:3")    /* Verified */
+	PORT_MODIFY("DIPS") // 280000
+	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Flip_Screen ) ) PORT_DIPLOCATION("SW1:3")    // Verified
 	PORT_DIPSETTING(          0x00000000, DEF_STR( Off ) )
 	PORT_DIPSETTING(          0x00200000, DEF_STR( On ) )
 	PORT_DIPNAME( 0x00400000, 0x00000000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:2")
@@ -1532,11 +1494,11 @@ static INPUT_PORTS_START( wcbowldx )
 INPUT_PORTS_END
 
 
-static INPUT_PORTS_START( wcbowlo ) /* Earlier versions of World Class Bowling do NOT support a cocktail mode */
+static INPUT_PORTS_START( wcbowlo ) // Earlier versions of World Class Bowling do NOT support a cocktail mode
 	PORT_INCLUDE( wcbowln )
 
-	PORT_MODIFY("DIPS") /* 280000 */
-	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Flip_Screen ) ) PORT_DIPLOCATION("SW1:3")    /* Verified */
+	PORT_MODIFY("DIPS") // 280000
+	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Flip_Screen ) ) PORT_DIPLOCATION("SW1:3")    // Verified
 	PORT_DIPSETTING(          0x00000000, DEF_STR( Off ) )
 	PORT_DIPSETTING(          0x00200000, DEF_STR( On ) )
 	PORT_DIPNAME( 0x00400000, 0x00000000, "Freeze Screen" )  PORT_DIPLOCATION("SW1:2")
@@ -1565,7 +1527,7 @@ static INPUT_PORTS_START( sftm )
 INPUT_PORTS_END
 
 
-static INPUT_PORTS_START( shufshot ) /* ShuffleShot v1.39 & v1.40 support cocktail mode */
+static INPUT_PORTS_START( shufshot ) // ShuffleShot v1.39 & v1.40 support cocktail mode
 	PORT_INCLUDE( itech32_base_32bit )
 
 	PORT_MODIFY("P1")
@@ -1583,7 +1545,7 @@ static INPUT_PORTS_START( shufshot ) /* ShuffleShot v1.39 & v1.40 support cockta
 	PORT_BIT( 0x00fb0000, IP_ACTIVE_LOW, IPT_UNUSED )
 
 	PORT_MODIFY("DIPS")
-	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Cabinet ) ) PORT_DIPLOCATION("SW1:3")    /* Verified */
+	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Cabinet ) ) PORT_DIPLOCATION("SW1:3")    // Verified
 	PORT_DIPSETTING(          0x00000000, DEF_STR( Upright ) )
 	PORT_DIPSETTING(          0x00200000, DEF_STR( Cocktail ) )
 
@@ -1601,11 +1563,11 @@ static INPUT_PORTS_START( shufshot ) /* ShuffleShot v1.39 & v1.40 support cockta
 INPUT_PORTS_END
 
 
-static INPUT_PORTS_START( shufshto ) /* Earlier versions of Shuffleshot do NOT support a cocktail mode */
+static INPUT_PORTS_START( shufshto ) // Earlier versions of Shuffleshot do NOT support a cocktail mode
 	PORT_INCLUDE( shufshot )
 
 	PORT_MODIFY("DIPS")
-	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Flip_Screen ) ) PORT_DIPLOCATION("SW1:3")    /* Verified */
+	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Flip_Screen ) ) PORT_DIPLOCATION("SW1:3")    // Verified
 	PORT_DIPSETTING(          0x00000000, DEF_STR( Off ) )
 	PORT_DIPSETTING(          0x00200000, DEF_STR( On ) )
 	PORT_DIPNAME( 0x00400000, 0x00000000, "Freeze Screen" )  PORT_DIPLOCATION("SW1:2")
@@ -1642,7 +1604,7 @@ static INPUT_PORTS_START( gt3d )
 	PORT_DIPSETTING(          0x00200000, "45 Degree Angle" )
 	PORT_DIPNAME( 0x00400000, 0x00000000, DEF_STR( Controls ) ) PORT_DIPLOCATION("SW1:2")
 	PORT_DIPSETTING(          0x00000000, "One Trackball" )
-	PORT_DIPSETTING(          0x00400000, "Two Trackballs" )                    /* Two Trackballs will work for Upright for "side by side" controls */
+	PORT_DIPSETTING(          0x00400000, "Two Trackballs" )                    // Two Trackballs will work for Upright for "side by side" controls
 
 	PORT_START("TRACKX1")
 	PORT_BIT( 0xff, 0x00, IPT_TRACKBALL_X ) PORT_SENSITIVITY(25) PORT_KEYDELTA(32) PORT_REVERSE PORT_PLAYER(1)
@@ -1658,14 +1620,14 @@ static INPUT_PORTS_START( gt3d )
 INPUT_PORTS_END
 
 
-static INPUT_PORTS_START( gt97 ) /* v1.30 is the first known version of GT97 to support Cocktail mode! */
+static INPUT_PORTS_START( gt97 ) // v1.30 is the first known version of GT97 to support Cocktail mode!
 	PORT_INCLUDE(gt3d)
 
 	PORT_MODIFY("DIPS")
 	PORT_DIPNAME( 0x00100000, 0x00000000, "Freeze Screen" ) PORT_DIPLOCATION("SW1:4")
 	PORT_DIPSETTING(          0x00000000, DEF_STR( Off ) )
 	PORT_DIPSETTING(          0x00100000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:3")    /* Seem to have no effect on the game */
+	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:3")    // Seem to have no effect on the game
 	PORT_DIPSETTING(          0x00000000, DEF_STR( Off ) )
 	PORT_DIPSETTING(          0x00200000, DEF_STR( On ) )
 	PORT_DIPNAME( 0x00400000, 0x00000000, DEF_STR( Cabinet ) ) PORT_DIPLOCATION("SW1:2")
@@ -1674,7 +1636,7 @@ static INPUT_PORTS_START( gt97 ) /* v1.30 is the first known version of GT97 to 
 INPUT_PORTS_END
 
 
-static INPUT_PORTS_START( gt97o ) /* Older versions of GT97 do NOT support a cocktail mode */
+static INPUT_PORTS_START( gt97o ) // Older versions of GT97 do NOT support a cocktail mode
 	PORT_INCLUDE(gt3d)
 
 	PORT_MODIFY("DIPS")
@@ -1691,7 +1653,7 @@ static INPUT_PORTS_START( gt97s )
 	PORT_DIPNAME( 0x00100000, 0x00000000, "Freeze Screen" )  PORT_DIPLOCATION("SW1:4")
 	PORT_DIPSETTING(          0x00000000, DEF_STR( Off ) )
 	PORT_DIPSETTING(          0x00100000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x00400000, 0x00000000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:2")    /* Single controller version -  has no effect */
+	PORT_DIPNAME( 0x00400000, 0x00000000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:2")    // Single controller version -  has no effect
 	PORT_DIPSETTING(          0x00000000, DEF_STR( Off ) )
 	PORT_DIPSETTING(          0x00400000, DEF_STR( On ) )
 INPUT_PORTS_END
@@ -1720,10 +1682,10 @@ static INPUT_PORTS_START( gt98s )
 	PORT_INCLUDE(gt3d)
 
 	PORT_MODIFY("DIPS")
-	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:3")    /* Seem to have no effect on the game */
+	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:3")    // Seem to have no effect on the game
 	PORT_DIPSETTING(          0x00000000, DEF_STR( Off ) )
 	PORT_DIPSETTING(          0x00200000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x00400000, 0x00000000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:2")    /* Single controller version -  has no effect */
+	PORT_DIPNAME( 0x00400000, 0x00000000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:2")    // Single controller version -  has no effect
 	PORT_DIPSETTING(          0x00000000, DEF_STR( Off ) )
 	PORT_DIPSETTING(          0x00400000, DEF_STR( On ) )
 INPUT_PORTS_END
@@ -1733,13 +1695,13 @@ static INPUT_PORTS_START( s_ver )
 	PORT_INCLUDE(gt3d)
 
 	PORT_MODIFY("DIPS")
-	PORT_DIPNAME( 0x00100000, 0x00000000, "Trackball Orientation" ) PORT_DIPLOCATION("SW1:4")   /* Determined by actual use / trial & error */
-	PORT_DIPSETTING(          0x00000000, "Normal Mount" )                      /* The manual says "Always on (default)" and "Off -- UNUSED --" */
+	PORT_DIPNAME( 0x00100000, 0x00000000, "Trackball Orientation" ) PORT_DIPLOCATION("SW1:4")   // Determined by actual use / trial & error
+	PORT_DIPSETTING(          0x00000000, "Normal Mount" )                      // The manual says "Always on (default)" and "Off -- UNUSED --"
 	PORT_DIPSETTING(          0x00100000, "45 Degree Angle" )
-	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:3")    /* Single controller version -  has no effect */
+	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:3")    // Single controller version -  has no effect
 	PORT_DIPSETTING(          0x00000000, DEF_STR( Off ) )
 	PORT_DIPSETTING(          0x00200000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x00400000, 0x00000000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:2")    /* Single controller version -  has no effect */
+	PORT_DIPNAME( 0x00400000, 0x00000000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:2")    // Single controller version -  has no effect
 	PORT_DIPSETTING(          0x00000000, DEF_STR( Off ) )
 	PORT_DIPSETTING(          0x00400000, DEF_STR( On ) )
 INPUT_PORTS_END
@@ -1749,12 +1711,12 @@ static INPUT_PORTS_START( aama )
 	PORT_INCLUDE(gt3d)
 
 	PORT_MODIFY("DIPS")
-	PORT_DIPNAME( 0x00100000, 0x00000000, "Trackball Orientation" ) PORT_DIPLOCATION("SW1:4")   /* Determined by actual use / trial & error */
-	PORT_DIPSETTING(          0x00000000, "Normal Mount" )                      /* The manual says "Always on (default)" and "Off -- UNUSED --" */
+	PORT_DIPNAME( 0x00100000, 0x00000000, "Trackball Orientation" ) PORT_DIPLOCATION("SW1:4")   // Determined by actual use / trial & error
+	PORT_DIPSETTING(          0x00000000, "Normal Mount" )                      // The manual says "Always on (default)" and "Off -- UNUSED --"
 	PORT_DIPSETTING(          0x00100000, "45 Degree Angle" )
 	PORT_DIPNAME( 0x00200000, 0x00000000, DEF_STR( Cabinet ) ) PORT_DIPLOCATION("SW1:3")
-	PORT_DIPSETTING(          0x00000000, DEF_STR( Upright ) )                  /* Two Trackballs will work with Upright for "side by side" controls */
-	PORT_DIPSETTING(          0x00200000, DEF_STR( Cocktail ) )                 /* Cocktail mode REQUIRES "Controls" to be set to "Two Trackballs" */
+	PORT_DIPSETTING(          0x00000000, DEF_STR( Upright ) )                  // Two Trackballs will work with Upright for "side by side" controls
+	PORT_DIPSETTING(          0x00200000, DEF_STR( Cocktail ) )                 // Cocktail mode REQUIRES "Controls" to be set to "Two Trackballs"
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( pubball )
@@ -1797,6 +1759,9 @@ INPUT_PORTS_END
  *
  *************************************/
 
+static constexpr XTAL CPU_CLOCK     = XTAL(12'000'000);          // clock for 68000-based systems
+static constexpr XTAL SOUND_CLOCK   = XTAL(16'000'000);          // clock for sound board
+
 void itech32_state::base_devices(machine_config &config)
 {
 	MC6809E(config, m_soundcpu, SOUND_CLOCK/8); // EF68B09EP
@@ -1826,8 +1791,8 @@ void itech32_state::base_devices(machine_config &config)
 	m_ensoniq->set_region1("ensoniq.1");
 	m_ensoniq->set_region2("ensoniq.2");
 	m_ensoniq->set_region3("ensoniq.3");
-	m_ensoniq->set_channels(1);               /* channels */
-	m_ensoniq->add_route(0, "rspeaker", 0.1); /* swapped stereo */
+	m_ensoniq->set_channels(1);               // channels
+	m_ensoniq->add_route(0, "rspeaker", 0.1); // swapped stereo
 	m_ensoniq->add_route(1, "lspeaker", 0.1);
 }
 
@@ -1869,7 +1834,9 @@ void itech32_state::bloodstm(machine_config &config)
 
 void drivedge_state::drivedge(machine_config &config)
 {
-	/* basic machine hardware */
+	static constexpr XTAL TMS_CLOCK     = XTAL(40'000'000);          // TMS320C31 clocks on drivedge
+
+	// basic machine hardware
 	M68EC020(config, m_maincpu, CPU020_CLOCK);
 	m_maincpu->set_addrmap(AS_PROGRAM, &drivedge_state::main_map);
 
@@ -1895,11 +1862,11 @@ void drivedge_state::drivedge(machine_config &config)
 
 	m_screen->screen_vblank().set_nop(); // interrupt not used?
 
-	SPEAKER(config, "left_back").front_left();   /* Sound PCB has hook-ups & AMPs for 5 channels */
-	SPEAKER(config, "right_back").front_right(); /* As per Sound Tests Menu: Left Front, Right Front, Left Rear, Right Rear, Under Seat */
+	SPEAKER(config, "left_back").front_left();   // Sound PCB has hook-ups & AMPs for 5 channels
+	SPEAKER(config, "right_back").front_right(); // As per Sound Tests Menu: Left Front, Right Front, Left Rear, Right Rear, Under Seat
 
 	m_ensoniq->set_channels(2);
-	m_ensoniq->add_route(2, "right_back", 0.1);  /* swapped stereo */
+	m_ensoniq->add_route(2, "right_back", 0.1);  // swapped stereo
 	m_ensoniq->add_route(3, "left_back", 0.1);
 }
 
@@ -1950,133 +1917,133 @@ void itech32_state::pubball(machine_config &config)
  *
  *************************************/
 
-/* Maximum sftm code size */
+// Maximum sftm code size
 #undef  CODE_SIZE
 #define CODE_SIZE   0x0400000
 
 
-ROM_START( timekill ) /* Version 1.32 (3-tier board set: P/N 1050 Rev 1, P/N 1051 Rev 0 &  P/N 1052 Rev 2) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "tk00_v1.32_u54.u54", 0x00000, 0x40000, CRC(68c74b81) SHA1(acdf677f82d7428acc6cf01076d43dd6330e9cb3) ) /* Labeled TK00 V1.32 (U54) */
-	ROM_LOAD16_BYTE( "tk01_v1.32_u53.u53", 0x00001, 0x40000, CRC(2158d8ef) SHA1(14aa66e020a9fa890fadbaf0936dfdc4e272f543) ) /* Labeled TK01 V1.32 (U53) */
+ROM_START( timekill ) // Version 1.32 (3-tier board set: P/N 1050 Rev 1, P/N 1051 Rev 0 &  P/N 1052 Rev 2)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "tk00_v1.32_u54.u54", 0x00000, 0x40000, CRC(68c74b81) SHA1(acdf677f82d7428acc6cf01076d43dd6330e9cb3) ) // Labeled TK00 V1.32 (U54)
+	ROM_LOAD16_BYTE( "tk01_v1.32_u53.u53", 0x00001, 0x40000, CRC(2158d8ef) SHA1(14aa66e020a9fa890fadbaf0936dfdc4e272f543) ) // Labeled TK01 V1.32 (U53)
 
-	ROM_REGION( 0x28000, "soundcpu", 0 ) /* At 0x18002 in ROM: ITSOUND Ver 4.1 OTTO Sound Board 6255 I/O 6/3/92 */
-	ROM_LOAD( "tk_snd_v_4.1_u17.u17", 0x10000, 0x18000, CRC(c699af7b) SHA1(55863513a1c27dcb257dbc20e522cfafa9b92c9d) ) /* labeled TK SND V 4.1 (U17) */
+	ROM_REGION( 0x28000, "soundcpu", 0 ) // At 0x18002 in ROM: ITSOUND Ver 4.1 OTTO Sound Board 6255 I/O 6/3/92
+	ROM_LOAD( "tk_snd_v_4.1_u17.u17", 0x10000, 0x18000, CRC(c699af7b) SHA1(55863513a1c27dcb257dbc20e522cfafa9b92c9d) ) // labeled TK SND V 4.1 (U17)
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 ) /* ROM board P/N 1051 REV0 */
-	ROM_LOAD32_BYTE( "time_killers_0.rom0",   0x000000, 0x200000, CRC(94cbf6f8) SHA1(dac5c4d9c8e42336c236ecc3c72b3b1f8282dc2f) ) /* 42 pin mask ROM */
-	ROM_LOAD32_BYTE( "time_killers_1.rom1",   0x000001, 0x200000, CRC(c07dea98) SHA1(dd8b88beb9781579eb0a17231ad2a274b70ae1bc) ) /* 42 pin mask ROM */
-	ROM_LOAD32_BYTE( "time_killers_2.rom2",   0x000002, 0x200000, CRC(183eed2a) SHA1(3905268fe45ecc47cd4d349666b4d33efda2140b) ) /* 42 pin mask ROM */
-	ROM_LOAD32_BYTE( "time_killers_3.rom3",   0x000003, 0x200000, CRC(b1da1058) SHA1(a1d483701c661d69cecc9d073b23683b119f5ef1) ) /* 42 pin mask ROM */
+	ROM_REGION( 0x880000, "grom", 0 ) // ROM board P/N 1051 REV0
+	ROM_LOAD32_BYTE( "time_killers_0.rom0",   0x000000, 0x200000, CRC(94cbf6f8) SHA1(dac5c4d9c8e42336c236ecc3c72b3b1f8282dc2f) ) // 42 pin mask ROM
+	ROM_LOAD32_BYTE( "time_killers_1.rom1",   0x000001, 0x200000, CRC(c07dea98) SHA1(dd8b88beb9781579eb0a17231ad2a274b70ae1bc) ) // 42 pin mask ROM
+	ROM_LOAD32_BYTE( "time_killers_2.rom2",   0x000002, 0x200000, CRC(183eed2a) SHA1(3905268fe45ecc47cd4d349666b4d33efda2140b) ) // 42 pin mask ROM
+	ROM_LOAD32_BYTE( "time_killers_3.rom3",   0x000003, 0x200000, CRC(b1da1058) SHA1(a1d483701c661d69cecc9d073b23683b119f5ef1) ) // 42 pin mask ROM
 
-	/* NOTE: ROM boards are known to exist and have been verified to list (silkscreen) the above locations as ROM1, ROM2, ROM3 & ROM4 */
+	// NOTE: ROM boards are known to exist and have been verified to list (silkscreen) the above locations as ROM1, ROM2, ROM3 & ROM4
 
 	ROM_LOAD32_BYTE( "timekill_grom01.grom1", 0x800000, 0x020000, CRC(b030c3d9) SHA1(f5c21285ec8ff4f74205e0cf18da67e733e31183) )
 	ROM_LOAD32_BYTE( "timekill_grom02.grom2", 0x800001, 0x020000, CRC(e98492a4) SHA1(fe8fb4bd3900109f3872f2930e8ddc9d19f599fd) )
 	ROM_LOAD32_BYTE( "timekill_grom03.grom3", 0x800002, 0x020000, CRC(6088fa64) SHA1(a3eee10bdef48fefec3836f551172dbe0819acf6) )
 	ROM_LOAD32_BYTE( "timekill_grom04.grom4", 0x800003, 0x020000, CRC(95be2318) SHA1(60580c87d63a114df44e2580e138128388ff447b) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) /* Sound board P/N 1052 REV 4 */
-	ROM_LOAD16_BYTE( "tksrom00_u18.u18", 0x000000, 0x80000, CRC(79d8b83a) SHA1(78934b4d0ccca8fefcf8277e4296eb1d59cd575b) ) /* Labeled TKSROM00 (U18) */
-	ROM_LOAD16_BYTE( "tksrom01_u20.u20", 0x100000, 0x80000, CRC(ec01648c) SHA1(b83c66cf22db5d89b9ed79b79861b79429d8380c) ) /* Labeled TKSROM01 (U20) */
-	ROM_LOAD16_BYTE( "tksrom02_u26.u26", 0x200000, 0x80000, CRC(051ced3e) SHA1(6b63c4837e709806ffea9a37d93933635d356a6e) ) /* Labeled TKSROM02 (U26) */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) // Sound board P/N 1052 REV 4
+	ROM_LOAD16_BYTE( "tksrom00_u18.u18", 0x000000, 0x80000, CRC(79d8b83a) SHA1(78934b4d0ccca8fefcf8277e4296eb1d59cd575b) ) // Labeled TKSROM00 (U18)
+	ROM_LOAD16_BYTE( "tksrom01_u20.u20", 0x100000, 0x80000, CRC(ec01648c) SHA1(b83c66cf22db5d89b9ed79b79861b79429d8380c) ) // Labeled TKSROM01 (U20)
+	ROM_LOAD16_BYTE( "tksrom02_u26.u26", 0x200000, 0x80000, CRC(051ced3e) SHA1(6b63c4837e709806ffea9a37d93933635d356a6e) ) // Labeled TKSROM02 (U26)
 ROM_END
 
-ROM_START( timekill132i ) /* Version 1.32I (3-tier board set: P/N 1050 Rev 1, P/N 1051 Rev 0 &  P/N 1052 Rev 2) - Additional Violence Level:  Level 4 - Limbs, Decapitations, No Blood */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "tk00_v1.32i_u54.u54", 0x00000, 0x40000, CRC(6cef5e8c) SHA1(43cd3e704567be7a60558e12c43f0bb4456ec96d) ) /* Labeled TK00 V1.32I (U54) */
-	ROM_LOAD16_BYTE( "tk01_v1.32i_u53.u53", 0x00001, 0x40000, CRC(3360f6a3) SHA1(37b49928db6d672a2bc9ddf4d35d649655450c08) ) /* Labeled TK01 V1.32I (U53) */
+ROM_START( timekill132i ) // Version 1.32I (3-tier board set: P/N 1050 Rev 1, P/N 1051 Rev 0 &  P/N 1052 Rev 2) - Additional Violence Level:  Level 4 - Limbs, Decapitations, No Blood
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "tk00_v1.32i_u54.u54", 0x00000, 0x40000, CRC(6cef5e8c) SHA1(43cd3e704567be7a60558e12c43f0bb4456ec96d) ) // Labeled TK00 V1.32I (U54)
+	ROM_LOAD16_BYTE( "tk01_v1.32i_u53.u53", 0x00001, 0x40000, CRC(3360f6a3) SHA1(37b49928db6d672a2bc9ddf4d35d649655450c08) ) // Labeled TK01 V1.32I (U53)
 
-	ROM_REGION( 0x28000, "soundcpu", 0 ) /* At 0x18002 in ROM: ITSOUND Ver 4.1 OTTO Sound Board 6255 I/O 6/3/92 */
-	ROM_LOAD( "tk_snd_v_4.1_u17.u17", 0x10000, 0x18000, CRC(c699af7b) SHA1(55863513a1c27dcb257dbc20e522cfafa9b92c9d) ) /* labeled TK SND V 4.1 (U17) */
+	ROM_REGION( 0x28000, "soundcpu", 0 ) // At 0x18002 in ROM: ITSOUND Ver 4.1 OTTO Sound Board 6255 I/O 6/3/92
+	ROM_LOAD( "tk_snd_v_4.1_u17.u17", 0x10000, 0x18000, CRC(c699af7b) SHA1(55863513a1c27dcb257dbc20e522cfafa9b92c9d) ) // labeled TK SND V 4.1 (U17)
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 ) /* ROM board P/N 1051 REV0 */
-	ROM_LOAD32_BYTE( "time_killers_0.rom0",   0x000000, 0x200000, CRC(94cbf6f8) SHA1(dac5c4d9c8e42336c236ecc3c72b3b1f8282dc2f) ) /* 42 pin mask ROM */
-	ROM_LOAD32_BYTE( "time_killers_1.rom1",   0x000001, 0x200000, CRC(c07dea98) SHA1(dd8b88beb9781579eb0a17231ad2a274b70ae1bc) ) /* 42 pin mask ROM */
-	ROM_LOAD32_BYTE( "time_killers_2.rom2",   0x000002, 0x200000, CRC(183eed2a) SHA1(3905268fe45ecc47cd4d349666b4d33efda2140b) ) /* 42 pin mask ROM */
-	ROM_LOAD32_BYTE( "time_killers_3.rom3",   0x000003, 0x200000, CRC(b1da1058) SHA1(a1d483701c661d69cecc9d073b23683b119f5ef1) ) /* 42 pin mask ROM */
+	ROM_REGION( 0x880000, "grom", 0 ) // ROM board P/N 1051 REV0
+	ROM_LOAD32_BYTE( "time_killers_0.rom0",   0x000000, 0x200000, CRC(94cbf6f8) SHA1(dac5c4d9c8e42336c236ecc3c72b3b1f8282dc2f) ) // 42 pin mask ROM
+	ROM_LOAD32_BYTE( "time_killers_1.rom1",   0x000001, 0x200000, CRC(c07dea98) SHA1(dd8b88beb9781579eb0a17231ad2a274b70ae1bc) ) // 42 pin mask ROM
+	ROM_LOAD32_BYTE( "time_killers_2.rom2",   0x000002, 0x200000, CRC(183eed2a) SHA1(3905268fe45ecc47cd4d349666b4d33efda2140b) ) // 42 pin mask ROM
+	ROM_LOAD32_BYTE( "time_killers_3.rom3",   0x000003, 0x200000, CRC(b1da1058) SHA1(a1d483701c661d69cecc9d073b23683b119f5ef1) ) // 42 pin mask ROM
 
-	/* NOTE: ROM boards are known to exist and have been verified to list (silkscreen) the above locations as ROM1, ROM2, ROM3 & ROM4 */
-
-	ROM_LOAD32_BYTE( "timekill_grom01.grom1", 0x800000, 0x020000, CRC(b030c3d9) SHA1(f5c21285ec8ff4f74205e0cf18da67e733e31183) )
-	ROM_LOAD32_BYTE( "timekill_grom02.grom2", 0x800001, 0x020000, CRC(e98492a4) SHA1(fe8fb4bd3900109f3872f2930e8ddc9d19f599fd) )
-	ROM_LOAD32_BYTE( "timekill_grom03.grom3", 0x800002, 0x020000, CRC(6088fa64) SHA1(a3eee10bdef48fefec3836f551172dbe0819acf6) )
-	ROM_LOAD32_BYTE( "timekill_grom04.grom4", 0x800003, 0x020000, CRC(95be2318) SHA1(60580c87d63a114df44e2580e138128388ff447b) )
-
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) /* Sound board P/N 1052 REV 4 */
-	ROM_LOAD16_BYTE( "tksrom00_u18.u18", 0x000000, 0x80000, CRC(79d8b83a) SHA1(78934b4d0ccca8fefcf8277e4296eb1d59cd575b) ) /* Labeled TKSROM00 (U18) */
-	ROM_LOAD16_BYTE( "tksrom01_u20.u20", 0x100000, 0x80000, CRC(ec01648c) SHA1(b83c66cf22db5d89b9ed79b79861b79429d8380c) ) /* Labeled TKSROM01 (U20) */
-	ROM_LOAD16_BYTE( "tksrom02_u26.u26", 0x200000, 0x80000, CRC(051ced3e) SHA1(6b63c4837e709806ffea9a37d93933635d356a6e) ) /* Labeled TKSROM02 (U26) */
-ROM_END
-
-ROM_START( timekill131 ) /* Version 1.31 (3-tier board set: P/N 1050 Rev 1, P/N 1051 Rev 0 &  P/N 1052 Rev 2) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "tk00_v1.31_u54.u54", 0x00000, 0x40000, CRC(e09ae32b) SHA1(b090a38600d0499f7b4cb80a2715f27216d408b0) ) /* Labeled TK00 V1.31 (U54) */
-	ROM_LOAD16_BYTE( "tk01_v1.31_u53.u53", 0x00001, 0x40000, CRC(c29137ec) SHA1(4dcfba13b6f865a256bcb0406b6c83c309b17313) ) /* Labeled TK01 V1.31 (U53) */
-
-	ROM_REGION( 0x28000, "soundcpu", 0 ) /* At 0x18002 in ROM: ITS Ver 4.0 OTTO Sound Board 6255 I/O 6/3/92 */
-	ROM_LOAD( "timekillsnd_u17.u17", 0x10000, 0x18000, CRC(ab1684c3) SHA1(cc7e591fd160b259f8aecddb2c5a3c36e4e37b2f) ) /* Labeled TIMEKILLSND (U17) */
-	ROM_CONTINUE(                    0x08000, 0x08000 )
-
-	ROM_REGION( 0x880000, "gfx1", 0 ) /* ROM board P/N 1051 REV0 */
-	ROM_LOAD32_BYTE( "time_killers_0.rom0",   0x000000, 0x200000, CRC(94cbf6f8) SHA1(dac5c4d9c8e42336c236ecc3c72b3b1f8282dc2f) ) /* 42 pin mask ROM */
-	ROM_LOAD32_BYTE( "time_killers_1.rom1",   0x000001, 0x200000, CRC(c07dea98) SHA1(dd8b88beb9781579eb0a17231ad2a274b70ae1bc) ) /* 42 pin mask ROM */
-	ROM_LOAD32_BYTE( "time_killers_2.rom2",   0x000002, 0x200000, CRC(183eed2a) SHA1(3905268fe45ecc47cd4d349666b4d33efda2140b) ) /* 42 pin mask ROM */
-	ROM_LOAD32_BYTE( "time_killers_3.rom3",   0x000003, 0x200000, CRC(b1da1058) SHA1(a1d483701c661d69cecc9d073b23683b119f5ef1) ) /* 42 pin mask ROM */
-
-	/* NOTE: ROM boards are known to exist and have been verified to list (silkscreen) the above locations as ROM1, ROM2, ROM3 & ROM4 */
+	// NOTE: ROM boards are known to exist and have been verified to list (silkscreen) the above locations as ROM1, ROM2, ROM3 & ROM4
 
 	ROM_LOAD32_BYTE( "timekill_grom01.grom1", 0x800000, 0x020000, CRC(b030c3d9) SHA1(f5c21285ec8ff4f74205e0cf18da67e733e31183) )
 	ROM_LOAD32_BYTE( "timekill_grom02.grom2", 0x800001, 0x020000, CRC(e98492a4) SHA1(fe8fb4bd3900109f3872f2930e8ddc9d19f599fd) )
 	ROM_LOAD32_BYTE( "timekill_grom03.grom3", 0x800002, 0x020000, CRC(6088fa64) SHA1(a3eee10bdef48fefec3836f551172dbe0819acf6) )
 	ROM_LOAD32_BYTE( "timekill_grom04.grom4", 0x800003, 0x020000, CRC(95be2318) SHA1(60580c87d63a114df44e2580e138128388ff447b) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) /* Sound board P/N 1052 REV 4 */
-	ROM_LOAD16_BYTE( "tksrom00_u18.u18", 0x000000, 0x80000, CRC(79d8b83a) SHA1(78934b4d0ccca8fefcf8277e4296eb1d59cd575b) ) /* Labeled TKSROM00 (U18) */
-	ROM_LOAD16_BYTE( "tksrom01_u20.u20", 0x100000, 0x80000, CRC(ec01648c) SHA1(b83c66cf22db5d89b9ed79b79861b79429d8380c) ) /* Labeled TKSROM01 (U20) */
-	ROM_LOAD16_BYTE( "tksrom02_u26.u26", 0x200000, 0x80000, CRC(051ced3e) SHA1(6b63c4837e709806ffea9a37d93933635d356a6e) ) /* Labeled TKSROM02 (U26) */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) // Sound board P/N 1052 REV 4
+	ROM_LOAD16_BYTE( "tksrom00_u18.u18", 0x000000, 0x80000, CRC(79d8b83a) SHA1(78934b4d0ccca8fefcf8277e4296eb1d59cd575b) ) // Labeled TKSROM00 (U18)
+	ROM_LOAD16_BYTE( "tksrom01_u20.u20", 0x100000, 0x80000, CRC(ec01648c) SHA1(b83c66cf22db5d89b9ed79b79861b79429d8380c) ) // Labeled TKSROM01 (U20)
+	ROM_LOAD16_BYTE( "tksrom02_u26.u26", 0x200000, 0x80000, CRC(051ced3e) SHA1(6b63c4837e709806ffea9a37d93933635d356a6e) ) // Labeled TKSROM02 (U26)
 ROM_END
 
-ROM_START( timekill121 ) /* Version 1.21 (3-tier board set: P/N 1050 Rev 1, P/N 1051 Rev 0 &  P/N 1052 Rev 2) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "tk00_v1.21_u54.u54", 0x00000, 0x40000, CRC(4938a940) SHA1(c42c5067ba0536ab22071c80a50434905acd93c2) ) /* Labeled TK00 V1.21 (U54) */
-	ROM_LOAD16_BYTE( "tk01_v1.21_u53.u53", 0x00001, 0x40000, CRC(0bb75c40) SHA1(99829ecb0692ea8b313bd8c2e982258c97599b06) ) /* Labeled TK01 V1.21 (U53) */
+ROM_START( timekill131 ) // Version 1.31 (3-tier board set: P/N 1050 Rev 1, P/N 1051 Rev 0 &  P/N 1052 Rev 2)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "tk00_v1.31_u54.u54", 0x00000, 0x40000, CRC(e09ae32b) SHA1(b090a38600d0499f7b4cb80a2715f27216d408b0) ) // Labeled TK00 V1.31 (U54)
+	ROM_LOAD16_BYTE( "tk01_v1.31_u53.u53", 0x00001, 0x40000, CRC(c29137ec) SHA1(4dcfba13b6f865a256bcb0406b6c83c309b17313) ) // Labeled TK01 V1.31 (U53)
 
-	ROM_REGION( 0x28000, "soundcpu", 0 ) /* At 0x18002 in ROM: ITS Ver 4.0 OTTO Sound Board 6255 I/O 6/3/92 */
-	ROM_LOAD( "timekillsnd_u17.u17", 0x10000, 0x18000, CRC(ab1684c3) SHA1(cc7e591fd160b259f8aecddb2c5a3c36e4e37b2f) ) /* Labeled TIMEKILLSND (U17) */
+	ROM_REGION( 0x28000, "soundcpu", 0 ) // At 0x18002 in ROM: ITS Ver 4.0 OTTO Sound Board 6255 I/O 6/3/92
+	ROM_LOAD( "timekillsnd_u17.u17", 0x10000, 0x18000, CRC(ab1684c3) SHA1(cc7e591fd160b259f8aecddb2c5a3c36e4e37b2f) ) // Labeled TIMEKILLSND (U17)
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 ) /* ROM board P/N 1051 REV0 */
-	ROM_LOAD32_BYTE( "time_killers_0.rom0",   0x000000, 0x200000, CRC(94cbf6f8) SHA1(dac5c4d9c8e42336c236ecc3c72b3b1f8282dc2f) ) /* 42 pin mask ROM */
-	ROM_LOAD32_BYTE( "time_killers_1.rom1",   0x000001, 0x200000, CRC(c07dea98) SHA1(dd8b88beb9781579eb0a17231ad2a274b70ae1bc) ) /* 42 pin mask ROM */
-	ROM_LOAD32_BYTE( "time_killers_2.rom2",   0x000002, 0x200000, CRC(183eed2a) SHA1(3905268fe45ecc47cd4d349666b4d33efda2140b) ) /* 42 pin mask ROM */
-	ROM_LOAD32_BYTE( "time_killers_3.rom3",   0x000003, 0x200000, CRC(b1da1058) SHA1(a1d483701c661d69cecc9d073b23683b119f5ef1) ) /* 42 pin mask ROM */
+	ROM_REGION( 0x880000, "grom", 0 ) // ROM board P/N 1051 REV0
+	ROM_LOAD32_BYTE( "time_killers_0.rom0",   0x000000, 0x200000, CRC(94cbf6f8) SHA1(dac5c4d9c8e42336c236ecc3c72b3b1f8282dc2f) ) // 42 pin mask ROM
+	ROM_LOAD32_BYTE( "time_killers_1.rom1",   0x000001, 0x200000, CRC(c07dea98) SHA1(dd8b88beb9781579eb0a17231ad2a274b70ae1bc) ) // 42 pin mask ROM
+	ROM_LOAD32_BYTE( "time_killers_2.rom2",   0x000002, 0x200000, CRC(183eed2a) SHA1(3905268fe45ecc47cd4d349666b4d33efda2140b) ) // 42 pin mask ROM
+	ROM_LOAD32_BYTE( "time_killers_3.rom3",   0x000003, 0x200000, CRC(b1da1058) SHA1(a1d483701c661d69cecc9d073b23683b119f5ef1) ) // 42 pin mask ROM
 
-	/* NOTE: ROM boards are known to exist and have been verified to list (silkscreen) the above locations as ROM1, ROM2, ROM3 & ROM4 */
+	// NOTE: ROM boards are known to exist and have been verified to list (silkscreen) the above locations as ROM1, ROM2, ROM3 & ROM4
 
 	ROM_LOAD32_BYTE( "timekill_grom01.grom1", 0x800000, 0x020000, CRC(b030c3d9) SHA1(f5c21285ec8ff4f74205e0cf18da67e733e31183) )
 	ROM_LOAD32_BYTE( "timekill_grom02.grom2", 0x800001, 0x020000, CRC(e98492a4) SHA1(fe8fb4bd3900109f3872f2930e8ddc9d19f599fd) )
 	ROM_LOAD32_BYTE( "timekill_grom03.grom3", 0x800002, 0x020000, CRC(6088fa64) SHA1(a3eee10bdef48fefec3836f551172dbe0819acf6) )
 	ROM_LOAD32_BYTE( "timekill_grom04.grom4", 0x800003, 0x020000, CRC(95be2318) SHA1(60580c87d63a114df44e2580e138128388ff447b) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) /* Sound board P/N 1052 REV 4 */
-	ROM_LOAD16_BYTE( "tksrom00_u18.u18", 0x000000, 0x80000, CRC(79d8b83a) SHA1(78934b4d0ccca8fefcf8277e4296eb1d59cd575b) ) /* Labeled TKSROM00 (U18) */
-	ROM_LOAD16_BYTE( "tksrom01_u20.u20", 0x100000, 0x80000, CRC(ec01648c) SHA1(b83c66cf22db5d89b9ed79b79861b79429d8380c) ) /* Labeled TKSROM01 (U20) */
-	ROM_LOAD16_BYTE( "tksrom02_u26.u26", 0x200000, 0x80000, CRC(051ced3e) SHA1(6b63c4837e709806ffea9a37d93933635d356a6e) ) /* Labeled TKSROM02 (U26) */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) // Sound board P/N 1052 REV 4
+	ROM_LOAD16_BYTE( "tksrom00_u18.u18", 0x000000, 0x80000, CRC(79d8b83a) SHA1(78934b4d0ccca8fefcf8277e4296eb1d59cd575b) ) // Labeled TKSROM00 (U18)
+	ROM_LOAD16_BYTE( "tksrom01_u20.u20", 0x100000, 0x80000, CRC(ec01648c) SHA1(b83c66cf22db5d89b9ed79b79861b79429d8380c) ) // Labeled TKSROM01 (U20)
+	ROM_LOAD16_BYTE( "tksrom02_u26.u26", 0x200000, 0x80000, CRC(051ced3e) SHA1(6b63c4837e709806ffea9a37d93933635d356a6e) ) // Labeled TKSROM02 (U26)
 ROM_END
 
-ROM_START( timekill121a ) /* Version 1.21 (3-tier board set: P/N 1050 Rev 1, P/N 1049 Rev 1 &  P/N 1052 Rev 2) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "tk00_v1.21_u54.u54", 0x00000, 0x40000, CRC(4938a940) SHA1(c42c5067ba0536ab22071c80a50434905acd93c2) ) /* Labeled TK00 V1.21 (U54) */
-	ROM_LOAD16_BYTE( "tk01_v1.21_u53.u53", 0x00001, 0x40000, CRC(0bb75c40) SHA1(99829ecb0692ea8b313bd8c2e982258c97599b06) ) /* Labeled TK01 V1.21 (U53) */
+ROM_START( timekill121 ) // Version 1.21 (3-tier board set: P/N 1050 Rev 1, P/N 1051 Rev 0 &  P/N 1052 Rev 2)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "tk00_v1.21_u54.u54", 0x00000, 0x40000, CRC(4938a940) SHA1(c42c5067ba0536ab22071c80a50434905acd93c2) ) // Labeled TK00 V1.21 (U54)
+	ROM_LOAD16_BYTE( "tk01_v1.21_u53.u53", 0x00001, 0x40000, CRC(0bb75c40) SHA1(99829ecb0692ea8b313bd8c2e982258c97599b06) ) // Labeled TK01 V1.21 (U53)
 
-	ROM_REGION( 0x28000, "soundcpu", 0 ) /* At 0x18002 in ROM: ITS Ver 4.0 OTTO Sound Board 6255 I/O 6/3/92 */
-	ROM_LOAD( "timekillsnd_u17.u17", 0x10000, 0x18000, CRC(ab1684c3) SHA1(cc7e591fd160b259f8aecddb2c5a3c36e4e37b2f) ) /* Labeled TIMEKILLSND (U17) */
+	ROM_REGION( 0x28000, "soundcpu", 0 ) // At 0x18002 in ROM: ITS Ver 4.0 OTTO Sound Board 6255 I/O 6/3/92
+	ROM_LOAD( "timekillsnd_u17.u17", 0x10000, 0x18000, CRC(ab1684c3) SHA1(cc7e591fd160b259f8aecddb2c5a3c36e4e37b2f) ) // Labeled TIMEKILLSND (U17)
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 ) /* ROM board P/N 1049 REV1 */
+	ROM_REGION( 0x880000, "grom", 0 ) // ROM board P/N 1051 REV0
+	ROM_LOAD32_BYTE( "time_killers_0.rom0",   0x000000, 0x200000, CRC(94cbf6f8) SHA1(dac5c4d9c8e42336c236ecc3c72b3b1f8282dc2f) ) // 42 pin mask ROM
+	ROM_LOAD32_BYTE( "time_killers_1.rom1",   0x000001, 0x200000, CRC(c07dea98) SHA1(dd8b88beb9781579eb0a17231ad2a274b70ae1bc) ) // 42 pin mask ROM
+	ROM_LOAD32_BYTE( "time_killers_2.rom2",   0x000002, 0x200000, CRC(183eed2a) SHA1(3905268fe45ecc47cd4d349666b4d33efda2140b) ) // 42 pin mask ROM
+	ROM_LOAD32_BYTE( "time_killers_3.rom3",   0x000003, 0x200000, CRC(b1da1058) SHA1(a1d483701c661d69cecc9d073b23683b119f5ef1) ) // 42 pin mask ROM
+
+	// NOTE: ROM boards are known to exist and have been verified to list (silkscreen) the above locations as ROM1, ROM2, ROM3 & ROM4
+
+	ROM_LOAD32_BYTE( "timekill_grom01.grom1", 0x800000, 0x020000, CRC(b030c3d9) SHA1(f5c21285ec8ff4f74205e0cf18da67e733e31183) )
+	ROM_LOAD32_BYTE( "timekill_grom02.grom2", 0x800001, 0x020000, CRC(e98492a4) SHA1(fe8fb4bd3900109f3872f2930e8ddc9d19f599fd) )
+	ROM_LOAD32_BYTE( "timekill_grom03.grom3", 0x800002, 0x020000, CRC(6088fa64) SHA1(a3eee10bdef48fefec3836f551172dbe0819acf6) )
+	ROM_LOAD32_BYTE( "timekill_grom04.grom4", 0x800003, 0x020000, CRC(95be2318) SHA1(60580c87d63a114df44e2580e138128388ff447b) )
+
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) // Sound board P/N 1052 REV 4
+	ROM_LOAD16_BYTE( "tksrom00_u18.u18", 0x000000, 0x80000, CRC(79d8b83a) SHA1(78934b4d0ccca8fefcf8277e4296eb1d59cd575b) ) // Labeled TKSROM00 (U18)
+	ROM_LOAD16_BYTE( "tksrom01_u20.u20", 0x100000, 0x80000, CRC(ec01648c) SHA1(b83c66cf22db5d89b9ed79b79861b79429d8380c) ) // Labeled TKSROM01 (U20)
+	ROM_LOAD16_BYTE( "tksrom02_u26.u26", 0x200000, 0x80000, CRC(051ced3e) SHA1(6b63c4837e709806ffea9a37d93933635d356a6e) ) // Labeled TKSROM02 (U26)
+ROM_END
+
+ROM_START( timekill121a ) // Version 1.21 (3-tier board set: P/N 1050 Rev 1, P/N 1049 Rev 1 &  P/N 1052 Rev 2)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "tk00_v1.21_u54.u54", 0x00000, 0x40000, CRC(4938a940) SHA1(c42c5067ba0536ab22071c80a50434905acd93c2) ) // Labeled TK00 V1.21 (U54)
+	ROM_LOAD16_BYTE( "tk01_v1.21_u53.u53", 0x00001, 0x40000, CRC(0bb75c40) SHA1(99829ecb0692ea8b313bd8c2e982258c97599b06) ) // Labeled TK01 V1.21 (U53)
+
+	ROM_REGION( 0x28000, "soundcpu", 0 ) // At 0x18002 in ROM: ITS Ver 4.0 OTTO Sound Board 6255 I/O 6/3/92
+	ROM_LOAD( "timekillsnd_u17.u17", 0x10000, 0x18000, CRC(ab1684c3) SHA1(cc7e591fd160b259f8aecddb2c5a3c36e4e37b2f) ) // Labeled TIMEKILLSND (U17)
+	ROM_CONTINUE(                    0x08000, 0x08000 )
+
+	ROM_REGION( 0x880000, "grom", 0 ) // ROM board P/N 1049 REV1
 	ROM_LOAD32_BYTE( "timekill_grom00.grom00", 0x000000, 0x080000, CRC(980aab02) SHA1(c5ce18748b1677d7b8fc599355d282d7fb9dda11) )
 	ROM_LOAD32_BYTE( "timekill_grom05.grom05", 0x000001, 0x080000, CRC(0b28ae65) SHA1(854091d312512eedb0f5acc7b31d7033dd138352) )
 	ROM_LOAD32_BYTE( "timekill_grom10.grom10", 0x000002, 0x080000, CRC(6092c59e) SHA1(70be57e2039786f9384f7d39daccfea3028afdd6) )
@@ -2093,55 +2060,55 @@ ROM_START( timekill121a ) /* Version 1.21 (3-tier board set: P/N 1050 Rev 1, P/N
 	ROM_LOAD32_BYTE( "timekill_grom08.grom08", 0x600001, 0x080000, CRC(7d6f7ba9) SHA1(cc4a51a3e883345d3dee600913f3d6ba5b74951e) )
 	ROM_LOAD32_BYTE( "timekill_grom13.grom13", 0x600002, 0x080000, CRC(ecde039d) SHA1(83f5d979e3055ac09b5b652e40115338559f9a53) )
 	ROM_LOAD32_BYTE( "timekill_grom18.grom18", 0x600003, 0x080000, CRC(05cb6d82) SHA1(ddba15ceabcbcce86baf95d844e3ef5e1246d926) )
-	ROM_LOAD32_BYTE( "timekill_grom04.grom04", 0x800000, 0x020000, CRC(b030c3d9) SHA1(f5c21285ec8ff4f74205e0cf18da67e733e31183) ) /* == timekill_grom01.grom1 */
-	ROM_LOAD32_BYTE( "timekill_grom09.grom09", 0x800001, 0x020000, CRC(e98492a4) SHA1(fe8fb4bd3900109f3872f2930e8ddc9d19f599fd) ) /* == timekill_grom02.grom2 */
-	ROM_LOAD32_BYTE( "timekill_grom14.grom14", 0x800002, 0x020000, CRC(6088fa64) SHA1(a3eee10bdef48fefec3836f551172dbe0819acf6) ) /* == timekill_grom03.grom3 */
-	ROM_LOAD32_BYTE( "timekill_grom19.grom19", 0x800003, 0x020000, CRC(95be2318) SHA1(60580c87d63a114df44e2580e138128388ff447b) ) /* == timekill_grom04.grom4 */
+	ROM_LOAD32_BYTE( "timekill_grom04.grom04", 0x800000, 0x020000, CRC(b030c3d9) SHA1(f5c21285ec8ff4f74205e0cf18da67e733e31183) ) // == timekill_grom01.grom1
+	ROM_LOAD32_BYTE( "timekill_grom09.grom09", 0x800001, 0x020000, CRC(e98492a4) SHA1(fe8fb4bd3900109f3872f2930e8ddc9d19f599fd) ) // == timekill_grom02.grom2
+	ROM_LOAD32_BYTE( "timekill_grom14.grom14", 0x800002, 0x020000, CRC(6088fa64) SHA1(a3eee10bdef48fefec3836f551172dbe0819acf6) ) // == timekill_grom03.grom3
+	ROM_LOAD32_BYTE( "timekill_grom19.grom19", 0x800003, 0x020000, CRC(95be2318) SHA1(60580c87d63a114df44e2580e138128388ff447b) ) // == timekill_grom04.grom4
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) /* Sound board P/N 1052 REV 4 */
-	ROM_LOAD16_BYTE( "tksrom00_u18.u18", 0x000000, 0x80000, CRC(79d8b83a) SHA1(78934b4d0ccca8fefcf8277e4296eb1d59cd575b) ) /* Labeled TKSROM00 (U18) */
-	ROM_LOAD16_BYTE( "tksrom01_u20.u20", 0x100000, 0x80000, CRC(ec01648c) SHA1(b83c66cf22db5d89b9ed79b79861b79429d8380c) ) /* Labeled TKSROM01 (U20) */
-	ROM_LOAD16_BYTE( "tksrom02_u26.u26", 0x200000, 0x80000, CRC(051ced3e) SHA1(6b63c4837e709806ffea9a37d93933635d356a6e) ) /* Labeled TKSROM02 (U26) */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) // Sound board P/N 1052 REV 4
+	ROM_LOAD16_BYTE( "tksrom00_u18.u18", 0x000000, 0x80000, CRC(79d8b83a) SHA1(78934b4d0ccca8fefcf8277e4296eb1d59cd575b) ) // Labeled TKSROM00 (U18)
+	ROM_LOAD16_BYTE( "tksrom01_u20.u20", 0x100000, 0x80000, CRC(ec01648c) SHA1(b83c66cf22db5d89b9ed79b79861b79429d8380c) ) // Labeled TKSROM01 (U20)
+	ROM_LOAD16_BYTE( "tksrom02_u26.u26", 0x200000, 0x80000, CRC(051ced3e) SHA1(6b63c4837e709806ffea9a37d93933635d356a6e) ) // Labeled TKSROM02 (U26)
 ROM_END
 
-ROM_START( timekill120 ) /* Version 1.20 (3-tier board set: P/N 1050 Rev 1, P/N 1057 Rev 0 &  P/N 1052 Rev 2) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "tk00_v1.2_u54.u54", 0x00000, 0x40000, CRC(df1ce59d) SHA1(57365da1c7c0bd2f5e342099fecefc8cd9927e81) ) /* Labeled TK00 V1.2 (U54) - service mode shows v1.20 */
-	ROM_LOAD16_BYTE( "tk01_v1.2_u53.u53", 0x00001, 0x40000, CRC(d42b9849) SHA1(d1d01689bdb79624cc13545c5cb0e9af5eebba88) ) /* Labeled TK01 V1.2 (U53) - service mode shows v1.20 */
+ROM_START( timekill120 ) // Version 1.20 (3-tier board set: P/N 1050 Rev 1, P/N 1057 Rev 0 &  P/N 1052 Rev 2)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "tk00_v1.2_u54.u54", 0x00000, 0x40000, CRC(df1ce59d) SHA1(57365da1c7c0bd2f5e342099fecefc8cd9927e81) ) // Labeled TK00 V1.2 (U54) - service mode shows v1.20
+	ROM_LOAD16_BYTE( "tk01_v1.2_u53.u53", 0x00001, 0x40000, CRC(d42b9849) SHA1(d1d01689bdb79624cc13545c5cb0e9af5eebba88) ) // Labeled TK01 V1.2 (U53) - service mode shows v1.20
 
-	ROM_REGION( 0x28000, "soundcpu", 0 ) /* At 0x18002 in ROM: ITS Ver 4.0 OTTO Sound Board 6255 I/O 6/3/92 */
-	ROM_LOAD( "timekillsnd_u17.u17", 0x10000, 0x18000, CRC(ab1684c3) SHA1(cc7e591fd160b259f8aecddb2c5a3c36e4e37b2f) ) /* Labeled TIMEKILLSND (U17) */
+	ROM_REGION( 0x28000, "soundcpu", 0 ) // At 0x18002 in ROM: ITS Ver 4.0 OTTO Sound Board 6255 I/O 6/3/92
+	ROM_LOAD( "timekillsnd_u17.u17", 0x10000, 0x18000, CRC(ab1684c3) SHA1(cc7e591fd160b259f8aecddb2c5a3c36e4e37b2f) ) // Labeled TIMEKILLSND (U17)
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 ) /* ROM board P/N 1057 REV0 */
-	ROM_LOAD32_BYTE( "time_killers_0.rom0",   0x000000, 0x200000, CRC(94cbf6f8) SHA1(dac5c4d9c8e42336c236ecc3c72b3b1f8282dc2f) ) /* 42 pin mask ROM */
-	ROM_LOAD32_BYTE( "time_killers_1.rom1",   0x000001, 0x200000, CRC(c07dea98) SHA1(dd8b88beb9781579eb0a17231ad2a274b70ae1bc) ) /* 42 pin mask ROM */
-	ROM_LOAD32_BYTE( "time_killers_2.rom2",   0x000002, 0x200000, CRC(183eed2a) SHA1(3905268fe45ecc47cd4d349666b4d33efda2140b) ) /* 42 pin mask ROM */
-	ROM_LOAD32_BYTE( "time_killers_3.rom3",   0x000003, 0x200000, CRC(b1da1058) SHA1(a1d483701c661d69cecc9d073b23683b119f5ef1) ) /* 42 pin mask ROM */
+	ROM_REGION( 0x880000, "grom", 0 ) // ROM board P/N 1057 REV0
+	ROM_LOAD32_BYTE( "time_killers_0.rom0",   0x000000, 0x200000, CRC(94cbf6f8) SHA1(dac5c4d9c8e42336c236ecc3c72b3b1f8282dc2f) ) // 42 pin mask ROM
+	ROM_LOAD32_BYTE( "time_killers_1.rom1",   0x000001, 0x200000, CRC(c07dea98) SHA1(dd8b88beb9781579eb0a17231ad2a274b70ae1bc) ) // 42 pin mask ROM
+	ROM_LOAD32_BYTE( "time_killers_2.rom2",   0x000002, 0x200000, CRC(183eed2a) SHA1(3905268fe45ecc47cd4d349666b4d33efda2140b) ) // 42 pin mask ROM
+	ROM_LOAD32_BYTE( "time_killers_3.rom3",   0x000003, 0x200000, CRC(b1da1058) SHA1(a1d483701c661d69cecc9d073b23683b119f5ef1) ) // 42 pin mask ROM
 
-	/* NOTE: The 1057 ROM board has 4 identical sets of the 42 pin mask ROMs at locations ROMA0-ROMA3, ROMB0-ROMB3, ROMC0-ROMC3 & ROMD0-ROMD3 */
+	// NOTE: The 1057 ROM board has 4 identical sets of the 42 pin mask ROMs at locations ROMA0-ROMA3, ROMB0-ROMB3, ROMC0-ROMC3 & ROMD0-ROMD3
 
 	ROM_LOAD32_BYTE( "timekill_grom01.grom1", 0x800000, 0x020000, CRC(b030c3d9) SHA1(f5c21285ec8ff4f74205e0cf18da67e733e31183) )
 	ROM_LOAD32_BYTE( "timekill_grom02.grom2", 0x800001, 0x020000, CRC(e98492a4) SHA1(fe8fb4bd3900109f3872f2930e8ddc9d19f599fd) )
 	ROM_LOAD32_BYTE( "timekill_grom03.grom3", 0x800002, 0x020000, CRC(6088fa64) SHA1(a3eee10bdef48fefec3836f551172dbe0819acf6) )
 	ROM_LOAD32_BYTE( "timekill_grom04.grom4", 0x800003, 0x020000, CRC(95be2318) SHA1(60580c87d63a114df44e2580e138128388ff447b) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) /* Sound board P/N 1052 REV 4 */
-	ROM_LOAD16_BYTE( "tksrom00_u18.u18", 0x000000, 0x80000, CRC(79d8b83a) SHA1(78934b4d0ccca8fefcf8277e4296eb1d59cd575b) ) /* Labeled TKSROM00 (U18) */
-	ROM_LOAD16_BYTE( "tksrom01_u20.u20", 0x100000, 0x80000, CRC(ec01648c) SHA1(b83c66cf22db5d89b9ed79b79861b79429d8380c) ) /* Labeled TKSROM01 (U20) */
-	ROM_LOAD16_BYTE( "tksrom02_u26.u26", 0x200000, 0x80000, CRC(051ced3e) SHA1(6b63c4837e709806ffea9a37d93933635d356a6e) ) /* Labeled TKSROM02 (U26) */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) // Sound board P/N 1052 REV 4
+	ROM_LOAD16_BYTE( "tksrom00_u18.u18", 0x000000, 0x80000, CRC(79d8b83a) SHA1(78934b4d0ccca8fefcf8277e4296eb1d59cd575b) ) // Labeled TKSROM00 (U18)
+	ROM_LOAD16_BYTE( "tksrom01_u20.u20", 0x100000, 0x80000, CRC(ec01648c) SHA1(b83c66cf22db5d89b9ed79b79861b79429d8380c) ) // Labeled TKSROM01 (U20)
+	ROM_LOAD16_BYTE( "tksrom02_u26.u26", 0x200000, 0x80000, CRC(051ced3e) SHA1(6b63c4837e709806ffea9a37d93933635d356a6e) ) // Labeled TKSROM02 (U26)
 ROM_END
 
-ROM_START( timekill100 ) /* Version 1.00? - actual version not shown (3-tier board set: P/N 1050 Rev 1, P/N 1049 Rev 1 &  P/N 1052 Rev 2) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "tk00.bim_u54.u54", 0x00000, 0x40000, CRC(2b379f30) SHA1(7034cb0e6ba49ba9147fdb7ff6cbe34451ed4465) ) /* Labeled TK00.BIM (U54) */
-	ROM_LOAD16_BYTE( "tk01.bim_u53.u53", 0x00001, 0x40000, CRC(e43e029c) SHA1(4bb069fffaa7482674f52eb4106409842f2c2a0e) ) /* Labeled TK01.BIM (U53) */
+ROM_START( timekill100 ) // Version 1.00? - actual version not shown (3-tier board set: P/N 1050 Rev 1, P/N 1049 Rev 1 &  P/N 1052 Rev 2)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "tk00.bim_u54.u54", 0x00000, 0x40000, CRC(2b379f30) SHA1(7034cb0e6ba49ba9147fdb7ff6cbe34451ed4465) ) // Labeled TK00.BIM (U54)
+	ROM_LOAD16_BYTE( "tk01.bim_u53.u53", 0x00001, 0x40000, CRC(e43e029c) SHA1(4bb069fffaa7482674f52eb4106409842f2c2a0e) ) // Labeled TK01.BIM (U53)
 
-	ROM_REGION( 0x28000, "soundcpu", 0 ) /* At 0x18002 in ROM: ITS Ver 4.0 OTTO Sound Board 6255 I/O 6/3/92 */
-	ROM_LOAD( "timekillsnd_u17.u17", 0x10000, 0x18000, CRC(ab1684c3) SHA1(cc7e591fd160b259f8aecddb2c5a3c36e4e37b2f) ) /* Labeled TIMEKILLSND (U17) */
+	ROM_REGION( 0x28000, "soundcpu", 0 ) // At 0x18002 in ROM: ITS Ver 4.0 OTTO Sound Board 6255 I/O 6/3/92
+	ROM_LOAD( "timekillsnd_u17.u17", 0x10000, 0x18000, CRC(ab1684c3) SHA1(cc7e591fd160b259f8aecddb2c5a3c36e4e37b2f) ) // Labeled TIMEKILLSND (U17)
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 ) /* ROM board P/N 1049 REV1 */
+	ROM_REGION( 0x880000, "grom", 0 ) // ROM board P/N 1049 REV1
 	ROM_LOAD32_BYTE( "timekill_grom00.grom00", 0x000000, 0x080000, CRC(980aab02) SHA1(c5ce18748b1677d7b8fc599355d282d7fb9dda11) )
 	ROM_LOAD32_BYTE( "timekill_grom05.grom05", 0x000001, 0x080000, CRC(0b28ae65) SHA1(854091d312512eedb0f5acc7b31d7033dd138352) )
 	ROM_LOAD32_BYTE( "timekill_grom10.grom10", 0x000002, 0x080000, CRC(6092c59e) SHA1(70be57e2039786f9384f7d39daccfea3028afdd6) )
@@ -2158,28 +2125,28 @@ ROM_START( timekill100 ) /* Version 1.00? - actual version not shown (3-tier boa
 	ROM_LOAD32_BYTE( "timekill_grom08.grom08", 0x600001, 0x080000, CRC(7d6f7ba9) SHA1(cc4a51a3e883345d3dee600913f3d6ba5b74951e) )
 	ROM_LOAD32_BYTE( "timekill_grom13.grom13", 0x600002, 0x080000, CRC(ecde039d) SHA1(83f5d979e3055ac09b5b652e40115338559f9a53) )
 	ROM_LOAD32_BYTE( "timekill_grom18.grom18", 0x600003, 0x080000, CRC(05cb6d82) SHA1(ddba15ceabcbcce86baf95d844e3ef5e1246d926) )
-	ROM_LOAD32_BYTE( "timekill_grom04.grom04", 0x800000, 0x020000, CRC(b030c3d9) SHA1(f5c21285ec8ff4f74205e0cf18da67e733e31183) ) /* == timekill_grom01.grom1 */
-	ROM_LOAD32_BYTE( "timekill_grom09.grom09", 0x800001, 0x020000, CRC(e98492a4) SHA1(fe8fb4bd3900109f3872f2930e8ddc9d19f599fd) ) /* == timekill_grom02.grom2 */
-	ROM_LOAD32_BYTE( "timekill_grom14.grom14", 0x800002, 0x020000, CRC(6088fa64) SHA1(a3eee10bdef48fefec3836f551172dbe0819acf6) ) /* == timekill_grom03.grom3 */
-	ROM_LOAD32_BYTE( "timekill_grom19.grom19", 0x800003, 0x020000, CRC(95be2318) SHA1(60580c87d63a114df44e2580e138128388ff447b) ) /* == timekill_grom04.grom4 */
+	ROM_LOAD32_BYTE( "timekill_grom04.grom04", 0x800000, 0x020000, CRC(b030c3d9) SHA1(f5c21285ec8ff4f74205e0cf18da67e733e31183) ) // == timekill_grom01.grom1
+	ROM_LOAD32_BYTE( "timekill_grom09.grom09", 0x800001, 0x020000, CRC(e98492a4) SHA1(fe8fb4bd3900109f3872f2930e8ddc9d19f599fd) ) // == timekill_grom02.grom2
+	ROM_LOAD32_BYTE( "timekill_grom14.grom14", 0x800002, 0x020000, CRC(6088fa64) SHA1(a3eee10bdef48fefec3836f551172dbe0819acf6) ) // == timekill_grom03.grom3
+	ROM_LOAD32_BYTE( "timekill_grom19.grom19", 0x800003, 0x020000, CRC(95be2318) SHA1(60580c87d63a114df44e2580e138128388ff447b) ) // == timekill_grom04.grom4
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) /* Sound board P/N 1052 REV 4 */
-	ROM_LOAD16_BYTE( "tksrom00_u18.u18", 0x000000, 0x80000, CRC(79d8b83a) SHA1(78934b4d0ccca8fefcf8277e4296eb1d59cd575b) ) /* Labeled TKSROM00 (U18) */
-	ROM_LOAD16_BYTE( "tksrom01_u20.u20", 0x100000, 0x80000, CRC(ec01648c) SHA1(b83c66cf22db5d89b9ed79b79861b79429d8380c) ) /* Labeled TKSROM01 (U20) */
-	ROM_LOAD16_BYTE( "tksrom02_u26.u26", 0x200000, 0x80000, CRC(051ced3e) SHA1(6b63c4837e709806ffea9a37d93933635d356a6e) ) /* Labeled TKSROM02 (U26) */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) // Sound board P/N 1052 REV 4
+	ROM_LOAD16_BYTE( "tksrom00_u18.u18", 0x000000, 0x80000, CRC(79d8b83a) SHA1(78934b4d0ccca8fefcf8277e4296eb1d59cd575b) ) // Labeled TKSROM00 (U18)
+	ROM_LOAD16_BYTE( "tksrom01_u20.u20", 0x100000, 0x80000, CRC(ec01648c) SHA1(b83c66cf22db5d89b9ed79b79861b79429d8380c) ) // Labeled TKSROM01 (U20)
+	ROM_LOAD16_BYTE( "tksrom02_u26.u26", 0x200000, 0x80000, CRC(051ced3e) SHA1(6b63c4837e709806ffea9a37d93933635d356a6e) ) // Labeled TKSROM02 (U26)
 ROM_END
 
 
 ROM_START( bloodstm )
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "bld00_v222.u83", 0x00000, 0x40000, CRC(95f36db6) SHA1(72ec5ca93aed8fb12d5e5b7ff3d07c5cf1dab4bb) ) /* Labeled BLD00 V2.22 (U83) */
-	ROM_LOAD16_BYTE( "bld01_v222.u88", 0x00001, 0x40000, CRC(fcc04b93) SHA1(7029d68f20196b6c2c30339500c7da54f2b5b054) ) /* Labeled BLD01 V2.22 (U88) */
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "bld00_v222.u83", 0x00000, 0x40000, CRC(95f36db6) SHA1(72ec5ca93aed8fb12d5e5b7ff3d07c5cf1dab4bb) ) // Labeled BLD00 V2.22 (U83)
+	ROM_LOAD16_BYTE( "bld01_v222.u88", 0x00001, 0x40000, CRC(fcc04b93) SHA1(7029d68f20196b6c2c30339500c7da54f2b5b054) ) // Labeled BLD01 V2.22 (U88)
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "bldsnd_v10.u17", 0x10000, 0x18000, CRC(dddeedbb) SHA1(f8ea786836630fc44bba968845fd2cb42cd81592) ) /* Labeled BLDSND V1.0 (U17) */
+	ROM_LOAD( "bldsnd_v10.u17", 0x10000, 0x18000, CRC(dddeedbb) SHA1(f8ea786836630fc44bba968845fd2cb42cd81592) ) // Labeled BLDSND V1.0 (U17)
 	ROM_CONTINUE(               0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "bsgrom0.bin",  0x000000, 0x080000, CRC(4e10b8c1) SHA1(b80f7dbf32faa97829c735da6dc0ee424dc9ecec) )
 	ROM_LOAD32_BYTE( "bsgrom5.bin",  0x000001, 0x080000, CRC(6333b6ce) SHA1(53b884e09d198f8f53449bd011ba743c28b2c934) )
 	ROM_LOAD32_BYTE( "bsgrom10.bin", 0x000002, 0x080000, CRC(a972a65c) SHA1(7772c2e0aaa0b3183c6287125b95fd1cd0c3775a) )
@@ -2199,7 +2166,7 @@ ROM_START( bloodstm )
 	ROM_FILL(                        0x800000, 0x080000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 */
+	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "bssrom0.bin",  0x000000, 0x80000, CRC(ee4570c8) SHA1(73dd292224bf182770b3cc2d90eb52b7d7b24378) )
@@ -2208,7 +2175,7 @@ ROM_START( bloodstm )
 ROM_END
 
 ROM_START( bloodstm221 ) // this board had generic stickers
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
 	ROM_LOAD16_BYTE( "bld00_v221.u83", 0x00000, 0x40000, CRC(01907aec) SHA1(a954366f2374c0836140e3b75a55ff47e4cfa645) )
 	ROM_LOAD16_BYTE( "bld01_v221.u88", 0x00001, 0x40000, CRC(eeae123e) SHA1(9fdd53d6651cac16402a9c3fe0ae15c9b1baa0db) )
 
@@ -2216,7 +2183,7 @@ ROM_START( bloodstm221 ) // this board had generic stickers
 	ROM_LOAD( "bldsnd_v10.u17", 0x10000, 0x18000, CRC(dddeedbb) SHA1(f8ea786836630fc44bba968845fd2cb42cd81592) )
 	ROM_CONTINUE(               0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "bsgrom0.bin",  0x000000, 0x080000, CRC(4e10b8c1) SHA1(b80f7dbf32faa97829c735da6dc0ee424dc9ecec) )
 	ROM_LOAD32_BYTE( "bsgrom5.bin",  0x000001, 0x080000, CRC(6333b6ce) SHA1(53b884e09d198f8f53449bd011ba743c28b2c934) )
 	ROM_LOAD32_BYTE( "bsgrom10.bin", 0x000002, 0x080000, CRC(a972a65c) SHA1(7772c2e0aaa0b3183c6287125b95fd1cd0c3775a) )
@@ -2245,15 +2212,15 @@ ROM_START( bloodstm221 ) // this board had generic stickers
 ROM_END
 
 ROM_START( bloodstm220 )
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "bld00_v22.u83", 0x00000, 0x40000, CRC(904e9208) SHA1(12e96027724b905140250db969130d90b1afec83) ) /* Labeled BLD00 V2.2 (U83) */
-	ROM_LOAD16_BYTE( "bld01_v22.u88", 0x00001, 0x40000, CRC(78336a7b) SHA1(76002ce4a2d83ceae10d9c9c123013832a081150) ) /* Labeled BLD01 V2.2 (U88) */
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "bld00_v22.u83", 0x00000, 0x40000, CRC(904e9208) SHA1(12e96027724b905140250db969130d90b1afec83) ) // Labeled BLD00 V2.2 (U83)
+	ROM_LOAD16_BYTE( "bld01_v22.u88", 0x00001, 0x40000, CRC(78336a7b) SHA1(76002ce4a2d83ceae10d9c9c123013832a081150) ) // Labeled BLD01 V2.2 (U88)
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "bldsnd_v10.u17", 0x10000, 0x18000, CRC(dddeedbb) SHA1(f8ea786836630fc44bba968845fd2cb42cd81592) ) /* Labeled BLDSND V1.0 (U17) */
+	ROM_LOAD( "bldsnd_v10.u17", 0x10000, 0x18000, CRC(dddeedbb) SHA1(f8ea786836630fc44bba968845fd2cb42cd81592) ) // Labeled BLDSND V1.0 (U17)
 	ROM_CONTINUE(               0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "bsgrom0.bin",  0x000000, 0x080000, CRC(4e10b8c1) SHA1(b80f7dbf32faa97829c735da6dc0ee424dc9ecec) )
 	ROM_LOAD32_BYTE( "bsgrom5.bin",  0x000001, 0x080000, CRC(6333b6ce) SHA1(53b884e09d198f8f53449bd011ba743c28b2c934) )
 	ROM_LOAD32_BYTE( "bsgrom10.bin", 0x000002, 0x080000, CRC(a972a65c) SHA1(7772c2e0aaa0b3183c6287125b95fd1cd0c3775a) )
@@ -2273,7 +2240,7 @@ ROM_START( bloodstm220 )
 	ROM_FILL(                        0x800000, 0x080000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 */
+	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "bssrom0.bin",  0x000000, 0x80000, CRC(ee4570c8) SHA1(73dd292224bf182770b3cc2d90eb52b7d7b24378) )
@@ -2282,15 +2249,15 @@ ROM_START( bloodstm220 )
 ROM_END
 
 ROM_START( bloodstm210 )
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "bld00_v21.u83", 0x00000, 0x40000, CRC(71215c8e) SHA1(ee0f94c3a2619d7e3cc1ba5e1888a97b0c75a3ae) ) /* Labeled BLD00 V2.1 (U83) */
-	ROM_LOAD16_BYTE( "bld01_v21.u88", 0x00001, 0x40000, CRC(da403da6) SHA1(0f09f38ae932acb4ddbb6323bce58be7284cb24b) ) /* Labeled BLD01 V2.1 (U88) */
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "bld00_v21.u83", 0x00000, 0x40000, CRC(71215c8e) SHA1(ee0f94c3a2619d7e3cc1ba5e1888a97b0c75a3ae) ) // Labeled BLD00 V2.1 (U83)
+	ROM_LOAD16_BYTE( "bld01_v21.u88", 0x00001, 0x40000, CRC(da403da6) SHA1(0f09f38ae932acb4ddbb6323bce58be7284cb24b) ) // Labeled BLD01 V2.1 (U88)
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "bldsnd_v10.u17", 0x10000, 0x18000, CRC(dddeedbb) SHA1(f8ea786836630fc44bba968845fd2cb42cd81592) ) /* Labeled BLDSND V1.0 (U17) */
+	ROM_LOAD( "bldsnd_v10.u17", 0x10000, 0x18000, CRC(dddeedbb) SHA1(f8ea786836630fc44bba968845fd2cb42cd81592) ) // Labeled BLDSND V1.0 (U17)
 	ROM_CONTINUE(               0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "bsgrom0.bin",  0x000000, 0x080000, CRC(4e10b8c1) SHA1(b80f7dbf32faa97829c735da6dc0ee424dc9ecec) )
 	ROM_LOAD32_BYTE( "bsgrom5.bin",  0x000001, 0x080000, CRC(6333b6ce) SHA1(53b884e09d198f8f53449bd011ba743c28b2c934) )
 	ROM_LOAD32_BYTE( "bsgrom10.bin", 0x000002, 0x080000, CRC(a972a65c) SHA1(7772c2e0aaa0b3183c6287125b95fd1cd0c3775a) )
@@ -2310,7 +2277,7 @@ ROM_START( bloodstm210 )
 	ROM_FILL(                        0x800000, 0x080000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 */
+	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "bssrom0.bin",  0x000000, 0x80000, CRC(ee4570c8) SHA1(73dd292224bf182770b3cc2d90eb52b7d7b24378) )
@@ -2319,15 +2286,15 @@ ROM_START( bloodstm210 )
 ROM_END
 
 ROM_START( bloodstm110 )
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "bld00_v11.u83", 0x00000, 0x40000, CRC(4fff8f9b) SHA1(90f450497935322b0082a70e10abf758fc441dd0) ) /* Labeled BLD00 V1.1 (U83) */
-	ROM_LOAD16_BYTE( "bld01_v11.u88", 0x00001, 0x40000, CRC(59ce23ea) SHA1(6aa02fff07f5ec6dff4f6db9ea7878a722079f81) ) /* Labeled BLD01 V1.1 (U88) */
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "bld00_v11.u83", 0x00000, 0x40000, CRC(4fff8f9b) SHA1(90f450497935322b0082a70e10abf758fc441dd0) ) // Labeled BLD00 V1.1 (U83)
+	ROM_LOAD16_BYTE( "bld01_v11.u88", 0x00001, 0x40000, CRC(59ce23ea) SHA1(6aa02fff07f5ec6dff4f6db9ea7878a722079f81) ) // Labeled BLD01 V1.1 (U88)
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "bldsnd_v10.u17", 0x10000, 0x18000, CRC(dddeedbb) SHA1(f8ea786836630fc44bba968845fd2cb42cd81592) ) /* Labeled BLDSND V1.0 (U17) */
+	ROM_LOAD( "bldsnd_v10.u17", 0x10000, 0x18000, CRC(dddeedbb) SHA1(f8ea786836630fc44bba968845fd2cb42cd81592) ) // Labeled BLDSND V1.0 (U17)
 	ROM_CONTINUE(               0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "bsgrom0.bin",  0x000000, 0x080000, CRC(4e10b8c1) SHA1(b80f7dbf32faa97829c735da6dc0ee424dc9ecec) )
 	ROM_LOAD32_BYTE( "bsgrom5.bin",  0x000001, 0x080000, CRC(6333b6ce) SHA1(53b884e09d198f8f53449bd011ba743c28b2c934) )
 	ROM_LOAD32_BYTE( "bsgrom10.bin", 0x000002, 0x080000, CRC(a972a65c) SHA1(7772c2e0aaa0b3183c6287125b95fd1cd0c3775a) )
@@ -2347,7 +2314,7 @@ ROM_START( bloodstm110 )
 	ROM_FILL(                        0x800000, 0x080000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 */
+	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "bssrom0.bin",  0x000000, 0x80000, CRC(ee4570c8) SHA1(73dd292224bf182770b3cc2d90eb52b7d7b24378) )
@@ -2356,15 +2323,15 @@ ROM_START( bloodstm110 )
 ROM_END
 
 ROM_START( bloodstm104 )
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "bld00_v10.u83", 0x00000, 0x40000, CRC(a0982119) SHA1(7a55f662db062488714b42aedea56eea3b80aed5) ) /* Labeled BLD00 V1.0 (U83) */
-	ROM_LOAD16_BYTE( "bld01_v10.u88", 0x00001, 0x40000, CRC(65800339) SHA1(379e57bd2c31180fa077b9a6e9fcffacde95280c) ) /* Labeled BLD01 V1.0 (U88) */
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "bld00_v10.u83", 0x00000, 0x40000, CRC(a0982119) SHA1(7a55f662db062488714b42aedea56eea3b80aed5) ) // Labeled BLD00 V1.0 (U83)
+	ROM_LOAD16_BYTE( "bld01_v10.u88", 0x00001, 0x40000, CRC(65800339) SHA1(379e57bd2c31180fa077b9a6e9fcffacde95280c) ) // Labeled BLD01 V1.0 (U88)
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "bldsnd_v10.u17", 0x10000, 0x18000, CRC(dddeedbb) SHA1(f8ea786836630fc44bba968845fd2cb42cd81592) ) /* Labeled BLDSND V1.0 (U17) */
+	ROM_LOAD( "bldsnd_v10.u17", 0x10000, 0x18000, CRC(dddeedbb) SHA1(f8ea786836630fc44bba968845fd2cb42cd81592) ) // Labeled BLDSND V1.0 (U17)
 	ROM_CONTINUE(               0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "bsgrom0.bin",  0x000000, 0x080000, CRC(4e10b8c1) SHA1(b80f7dbf32faa97829c735da6dc0ee424dc9ecec) )
 	ROM_LOAD32_BYTE( "bsgrom5.bin",  0x000001, 0x080000, CRC(6333b6ce) SHA1(53b884e09d198f8f53449bd011ba743c28b2c934) )
 	ROM_LOAD32_BYTE( "bsgrom10.bin", 0x000002, 0x080000, CRC(a972a65c) SHA1(7772c2e0aaa0b3183c6287125b95fd1cd0c3775a) )
@@ -2384,7 +2351,7 @@ ROM_START( bloodstm104 )
 	ROM_FILL(                        0x800000, 0x080000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 */
+	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "bssrom0.bin",  0x000000, 0x80000, CRC(ee4570c8) SHA1(73dd292224bf182770b3cc2d90eb52b7d7b24378) )
@@ -2393,93 +2360,93 @@ ROM_START( bloodstm104 )
 ROM_END
 
 
-ROM_START( hardyard ) /* Version 1.2 (3-tier board set: P/N 1059 Rev 3,  P/N 1061 Rev 1 &  P/N 1060 Rev 0) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "fb00_v1.20_u83.u83", 0x00000, 0x40000, CRC(c7497692) SHA1(6c11535cf011e15dd7ffb5eba8e8da557c38277e) ) /* Labeled FB00 V1.20 (U83) */
-	ROM_LOAD16_BYTE( "fb01_v1.20_u88.u88", 0x00001, 0x40000, CRC(3320c79a) SHA1(d1d32048c541782e60c525d9789fe12607a6df3a) ) /* Labeled FB01 V1.20 (U88) */
+ROM_START( hardyard ) // Version 1.2 (3-tier board set: P/N 1059 Rev 3,  P/N 1061 Rev 1 &  P/N 1060 Rev 0)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "fb00_v1.20_u83.u83", 0x00000, 0x40000, CRC(c7497692) SHA1(6c11535cf011e15dd7ffb5eba8e8da557c38277e) ) // Labeled FB00 V1.20 (U83)
+	ROM_LOAD16_BYTE( "fb01_v1.20_u88.u88", 0x00001, 0x40000, CRC(3320c79a) SHA1(d1d32048c541782e60c525d9789fe12607a6df3a) ) // Labeled FB01 V1.20 (U88)
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "fb_snd_v1.1_u17.u17", 0x10000, 0x18000, CRC(d221b121) SHA1(06f351274a9dcb522f67f58499c9dc2ef5f06c07) ) /* Labeled FB SND V1.1 (U17) */
+	ROM_LOAD( "fb_snd_v1.1_u17.u17", 0x10000, 0x18000, CRC(d221b121) SHA1(06f351274a9dcb522f67f58499c9dc2ef5f06c07) ) // Labeled FB SND V1.1 (U17)
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
-	ROM_LOAD32_BYTE( "footbal_0.grom0.itfb0",  0x000000, 0x100000, CRC(0b7781af) SHA1(0e6b617a5d9a2d0d50a3839231177f2934177b87) ) /* mask ROM, socket silkscreened GROM0/ITFB0 */
-	ROM_LOAD32_BYTE( "footbal_1.grom5.itfb1",  0x000001, 0x100000, CRC(178d0f9b) SHA1(2c13be9063742c24a4b8409fe1d16f6c989f20e0) ) /* mask ROM, socket silkscreened GROM5/ITFB1 */
-	ROM_LOAD32_BYTE( "footbal_2.grom10.itfb2", 0x000002, 0x100000, CRC(0a17231e) SHA1(1499783ac32c3c6956d4084d623a432aecfd7769) ) /* mask ROM, socket silkscreened GROM10/ITFB2 */
-	ROM_LOAD32_BYTE( "footbal_3.grom15.itfb3", 0x000003, 0x100000, CRC(104456af) SHA1(6b6adca80f663cdc8fcbdf58c033d32193e91b4b) ) /* mask ROM, socket silkscreened GROM15/ITFB3 */
-	ROM_LOAD32_BYTE( "footbal_4.grom1.itfb4",  0x400000, 0x100000, CRC(2cb6f454) SHA1(e3af2809d43ddb4f17342a0b63848bf9a579b1eb) ) /* mask ROM, socket silkscreened GROM1/ITFB4 */
-	ROM_LOAD32_BYTE( "footbal_5.grom6.itfb5",  0x400001, 0x100000, CRC(9b19b873) SHA1(4393dce2fd6e1f3c2b855759a985e1e068959e0a) ) /* mask ROM, socket silkscreened GROM6/ITFB5 */
-	ROM_LOAD32_BYTE( "footbal_6.grom11.itfb6", 0x400002, 0x100000, CRC(58694394) SHA1(9b0742d136de9870f50a1f47347071a21283067b) ) /* mask ROM, socket silkscreened GROM11/ITFB6 */
-	ROM_LOAD32_BYTE( "footbal_7.grom16.itfb7", 0x400003, 0x100000, CRC(9b7a2d1a) SHA1(e4aa8d5f76b26d16cabaf88dfa1bfba8052fe99d) ) /* mask ROM, socket silkscreened GROM16/ITFB7 */
-	ROM_LOAD32_BYTE( "itfb-8.grom2.itfb8",     0x800000, 0x020000, CRC(a1656bf8) SHA1(4df05a1cdf5d636956d1c3d1f4f1988b254608d5) ) /* EPROM, socket silkscreened GROM2/ITFB8 */
-	ROM_LOAD32_BYTE( "itfb-9.grom7.itfb9",     0x800001, 0x020000, CRC(2afa9e10) SHA1(d422447fd2fc2f9350af472eb1f1223383a1a259) ) /* EPROM, socket silkscreened GROM7/ITFB9 */
-	ROM_LOAD32_BYTE( "itfb-10.grom12.itfb10",  0x800002, 0x020000, CRC(d5d15b38) SHA1(f414c19d8d88f916fbfa24fc3e16cea2e0acce08) ) /* EPROM, socket silkscreened GROM12/ITFB10 */
-	ROM_LOAD32_BYTE( "itfb-11.grom17.itfb11",  0x800003, 0x020000, CRC(cd4f0df0) SHA1(632eb0cf27d7bf3df09d03f373a3195dd5a702b8) ) /* EPROM, socket silkscreened GROM17/ITFB11 */
+	ROM_REGION( 0x880000, "grom", 0 )
+	ROM_LOAD32_BYTE( "footbal_0.grom0.itfb0",  0x000000, 0x100000, CRC(0b7781af) SHA1(0e6b617a5d9a2d0d50a3839231177f2934177b87) ) // mask ROM, socket silkscreened GROM0/ITFB0
+	ROM_LOAD32_BYTE( "footbal_1.grom5.itfb1",  0x000001, 0x100000, CRC(178d0f9b) SHA1(2c13be9063742c24a4b8409fe1d16f6c989f20e0) ) // mask ROM, socket silkscreened GROM5/ITFB1
+	ROM_LOAD32_BYTE( "footbal_2.grom10.itfb2", 0x000002, 0x100000, CRC(0a17231e) SHA1(1499783ac32c3c6956d4084d623a432aecfd7769) ) // mask ROM, socket silkscreened GROM10/ITFB2
+	ROM_LOAD32_BYTE( "footbal_3.grom15.itfb3", 0x000003, 0x100000, CRC(104456af) SHA1(6b6adca80f663cdc8fcbdf58c033d32193e91b4b) ) // mask ROM, socket silkscreened GROM15/ITFB3
+	ROM_LOAD32_BYTE( "footbal_4.grom1.itfb4",  0x400000, 0x100000, CRC(2cb6f454) SHA1(e3af2809d43ddb4f17342a0b63848bf9a579b1eb) ) // mask ROM, socket silkscreened GROM1/ITFB4
+	ROM_LOAD32_BYTE( "footbal_5.grom6.itfb5",  0x400001, 0x100000, CRC(9b19b873) SHA1(4393dce2fd6e1f3c2b855759a985e1e068959e0a) ) // mask ROM, socket silkscreened GROM6/ITFB5
+	ROM_LOAD32_BYTE( "footbal_6.grom11.itfb6", 0x400002, 0x100000, CRC(58694394) SHA1(9b0742d136de9870f50a1f47347071a21283067b) ) // mask ROM, socket silkscreened GROM11/ITFB6
+	ROM_LOAD32_BYTE( "footbal_7.grom16.itfb7", 0x400003, 0x100000, CRC(9b7a2d1a) SHA1(e4aa8d5f76b26d16cabaf88dfa1bfba8052fe99d) ) // mask ROM, socket silkscreened GROM16/ITFB7
+	ROM_LOAD32_BYTE( "itfb-8.grom2.itfb8",     0x800000, 0x020000, CRC(a1656bf8) SHA1(4df05a1cdf5d636956d1c3d1f4f1988b254608d5) ) // EPROM, socket silkscreened GROM2/ITFB8
+	ROM_LOAD32_BYTE( "itfb-9.grom7.itfb9",     0x800001, 0x020000, CRC(2afa9e10) SHA1(d422447fd2fc2f9350af472eb1f1223383a1a259) ) // EPROM, socket silkscreened GROM7/ITFB9
+	ROM_LOAD32_BYTE( "itfb-10.grom12.itfb10",  0x800002, 0x020000, CRC(d5d15b38) SHA1(f414c19d8d88f916fbfa24fc3e16cea2e0acce08) ) // EPROM, socket silkscreened GROM12/ITFB10
+	ROM_LOAD32_BYTE( "itfb-11.grom17.itfb11",  0x800003, 0x020000, CRC(cd4f0df0) SHA1(632eb0cf27d7bf3df09d03f373a3195dd5a702b8) ) // EPROM, socket silkscreened GROM17/ITFB11
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 */
+	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "fb_srom00.srom0", 0x000000, 0x080000, CRC(b0a76ad2) SHA1(d1125cf96f6b9613840b8d22afa59748fb32ab90) )
 	ROM_LOAD16_BYTE( "fb_srom01.srom1", 0x100000, 0x080000, CRC(9fbf6a02) SHA1(90c86a94767a383895183a25b15084ed62891518) )
 ROM_END
 
-ROM_START( hardyard11 ) /* Version 1.1 (3-tier board set: P/N 1059 Rev 3,  P/N 1061 Rev 1 &  P/N 1060 Rev 0) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "fb00_v1.10_u83.u83", 0x00000, 0x40000, CRC(603f8a03) SHA1(b6c037c960dd09269b948533109ff379e091c62d) ) /* Labeled FB00 V1.10 (U83) */
-	ROM_LOAD16_BYTE( "fb01_v1.10_u88.u88", 0x00001, 0x40000, CRC(7b11db88) SHA1(d45eb5dece4b86b833f0824ffc04ad406a15603d) ) /* Labeled FB01 V1.10 (U88) */
+ROM_START( hardyard11 ) // Version 1.1 (3-tier board set: P/N 1059 Rev 3,  P/N 1061 Rev 1 &  P/N 1060 Rev 0)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "fb00_v1.10_u83.u83", 0x00000, 0x40000, CRC(603f8a03) SHA1(b6c037c960dd09269b948533109ff379e091c62d) ) // Labeled FB00 V1.10 (U83)
+	ROM_LOAD16_BYTE( "fb01_v1.10_u88.u88", 0x00001, 0x40000, CRC(7b11db88) SHA1(d45eb5dece4b86b833f0824ffc04ad406a15603d) ) // Labeled FB01 V1.10 (U88)
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "fb_snd_v1.1_u17.u17", 0x10000, 0x18000, CRC(d221b121) SHA1(06f351274a9dcb522f67f58499c9dc2ef5f06c07) ) /* Labeled FB SND V1.1 (U17) */
+	ROM_LOAD( "fb_snd_v1.1_u17.u17", 0x10000, 0x18000, CRC(d221b121) SHA1(06f351274a9dcb522f67f58499c9dc2ef5f06c07) ) // Labeled FB SND V1.1 (U17)
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
-	ROM_LOAD32_BYTE( "footbal_0.grom0.itfb0",  0x000000, 0x100000, CRC(0b7781af) SHA1(0e6b617a5d9a2d0d50a3839231177f2934177b87) ) /* mask ROM, socket silkscreened GROM0/ITFB0 */
-	ROM_LOAD32_BYTE( "footbal_1.grom5.itfb1",  0x000001, 0x100000, CRC(178d0f9b) SHA1(2c13be9063742c24a4b8409fe1d16f6c989f20e0) ) /* mask ROM, socket silkscreened GROM5/ITFB1 */
-	ROM_LOAD32_BYTE( "footbal_2.grom10.itfb2", 0x000002, 0x100000, CRC(0a17231e) SHA1(1499783ac32c3c6956d4084d623a432aecfd7769) ) /* mask ROM, socket silkscreened GROM10/ITFB2 */
-	ROM_LOAD32_BYTE( "footbal_3.grom15.itfb3", 0x000003, 0x100000, CRC(104456af) SHA1(6b6adca80f663cdc8fcbdf58c033d32193e91b4b) ) /* mask ROM, socket silkscreened GROM15/ITFB3 */
-	ROM_LOAD32_BYTE( "footbal_4.grom1.itfb4",  0x400000, 0x100000, CRC(2cb6f454) SHA1(e3af2809d43ddb4f17342a0b63848bf9a579b1eb) ) /* mask ROM, socket silkscreened GROM1/ITFB4 */
-	ROM_LOAD32_BYTE( "footbal_5.grom6.itfb5",  0x400001, 0x100000, CRC(9b19b873) SHA1(4393dce2fd6e1f3c2b855759a985e1e068959e0a) ) /* mask ROM, socket silkscreened GROM6/ITFB5 */
-	ROM_LOAD32_BYTE( "footbal_6.grom11.itfb6", 0x400002, 0x100000, CRC(58694394) SHA1(9b0742d136de9870f50a1f47347071a21283067b) ) /* mask ROM, socket silkscreened GROM11/ITFB6 */
-	ROM_LOAD32_BYTE( "footbal_7.grom16.itfb7", 0x400003, 0x100000, CRC(9b7a2d1a) SHA1(e4aa8d5f76b26d16cabaf88dfa1bfba8052fe99d) ) /* mask ROM, socket silkscreened GROM16/ITFB7 */
-	ROM_LOAD32_BYTE( "itfb-8.grom2.itfb8",     0x800000, 0x020000, CRC(a1656bf8) SHA1(4df05a1cdf5d636956d1c3d1f4f1988b254608d5) ) /* EPROM, socket silkscreened GROM2/ITFB8 */
-	ROM_LOAD32_BYTE( "itfb-9.grom7.itfb9",     0x800001, 0x020000, CRC(2afa9e10) SHA1(d422447fd2fc2f9350af472eb1f1223383a1a259) ) /* EPROM, socket silkscreened GROM7/ITFB9 */
-	ROM_LOAD32_BYTE( "itfb-10.grom12.itfb10",  0x800002, 0x020000, CRC(d5d15b38) SHA1(f414c19d8d88f916fbfa24fc3e16cea2e0acce08) ) /* EPROM, socket silkscreened GROM12/ITFB10 */
-	ROM_LOAD32_BYTE( "itfb-11.grom17.itfb11",  0x800003, 0x020000, CRC(cd4f0df0) SHA1(632eb0cf27d7bf3df09d03f373a3195dd5a702b8) ) /* EPROM, socket silkscreened GROM17/ITFB11 */
+	ROM_REGION( 0x880000, "grom", 0 )
+	ROM_LOAD32_BYTE( "footbal_0.grom0.itfb0",  0x000000, 0x100000, CRC(0b7781af) SHA1(0e6b617a5d9a2d0d50a3839231177f2934177b87) ) // mask ROM, socket silkscreened GROM0/ITFB0
+	ROM_LOAD32_BYTE( "footbal_1.grom5.itfb1",  0x000001, 0x100000, CRC(178d0f9b) SHA1(2c13be9063742c24a4b8409fe1d16f6c989f20e0) ) // mask ROM, socket silkscreened GROM5/ITFB1
+	ROM_LOAD32_BYTE( "footbal_2.grom10.itfb2", 0x000002, 0x100000, CRC(0a17231e) SHA1(1499783ac32c3c6956d4084d623a432aecfd7769) ) // mask ROM, socket silkscreened GROM10/ITFB2
+	ROM_LOAD32_BYTE( "footbal_3.grom15.itfb3", 0x000003, 0x100000, CRC(104456af) SHA1(6b6adca80f663cdc8fcbdf58c033d32193e91b4b) ) // mask ROM, socket silkscreened GROM15/ITFB3
+	ROM_LOAD32_BYTE( "footbal_4.grom1.itfb4",  0x400000, 0x100000, CRC(2cb6f454) SHA1(e3af2809d43ddb4f17342a0b63848bf9a579b1eb) ) // mask ROM, socket silkscreened GROM1/ITFB4
+	ROM_LOAD32_BYTE( "footbal_5.grom6.itfb5",  0x400001, 0x100000, CRC(9b19b873) SHA1(4393dce2fd6e1f3c2b855759a985e1e068959e0a) ) // mask ROM, socket silkscreened GROM6/ITFB5
+	ROM_LOAD32_BYTE( "footbal_6.grom11.itfb6", 0x400002, 0x100000, CRC(58694394) SHA1(9b0742d136de9870f50a1f47347071a21283067b) ) // mask ROM, socket silkscreened GROM11/ITFB6
+	ROM_LOAD32_BYTE( "footbal_7.grom16.itfb7", 0x400003, 0x100000, CRC(9b7a2d1a) SHA1(e4aa8d5f76b26d16cabaf88dfa1bfba8052fe99d) ) // mask ROM, socket silkscreened GROM16/ITFB7
+	ROM_LOAD32_BYTE( "itfb-8.grom2.itfb8",     0x800000, 0x020000, CRC(a1656bf8) SHA1(4df05a1cdf5d636956d1c3d1f4f1988b254608d5) ) // EPROM, socket silkscreened GROM2/ITFB8
+	ROM_LOAD32_BYTE( "itfb-9.grom7.itfb9",     0x800001, 0x020000, CRC(2afa9e10) SHA1(d422447fd2fc2f9350af472eb1f1223383a1a259) ) // EPROM, socket silkscreened GROM7/ITFB9
+	ROM_LOAD32_BYTE( "itfb-10.grom12.itfb10",  0x800002, 0x020000, CRC(d5d15b38) SHA1(f414c19d8d88f916fbfa24fc3e16cea2e0acce08) ) // EPROM, socket silkscreened GROM12/ITFB10
+	ROM_LOAD32_BYTE( "itfb-11.grom17.itfb11",  0x800003, 0x020000, CRC(cd4f0df0) SHA1(632eb0cf27d7bf3df09d03f373a3195dd5a702b8) ) // EPROM, socket silkscreened GROM17/ITFB11
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 */
+	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "fb_srom00.srom0", 0x000000, 0x080000, CRC(b0a76ad2) SHA1(d1125cf96f6b9613840b8d22afa59748fb32ab90) )
 	ROM_LOAD16_BYTE( "fb_srom01.srom1", 0x100000, 0x080000, CRC(9fbf6a02) SHA1(90c86a94767a383895183a25b15084ed62891518) )
 ROM_END
 
-ROM_START( hardyard10 ) /* Version 1.0 (3-tier board set: P/N 1059 Rev 3, P/N 1061 Rev 1 &  P/N 1060 Rev 0) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
+ROM_START( hardyard10 ) // Version 1.0 (3-tier board set: P/N 1059 Rev 3, P/N 1061 Rev 1 &  P/N 1060 Rev 0)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
 	ROM_LOAD16_BYTE( "fb00_v1.0_u83.u83", 0x00000, 0x40000, CRC(f839393c) SHA1(ba06172bc4781f7738ce43019031715fee4b344c) )
 	ROM_LOAD16_BYTE( "fb01_v1.0_u88.u88", 0x00001, 0x40000, CRC(ca444702) SHA1(49bcc0994da9cd2c31c0cd78b822aceeaffd035f) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "fb_snd_v1.0_u17.u17", 0x10000, 0x18000, CRC(6c6db5b8) SHA1(925e7c7cc7c3d290f4a334f24eef574aaac3150c) ) /* Labeled FB SND V1.0 (U17) */
+	ROM_LOAD( "fb_snd_v1.0_u17.u17", 0x10000, 0x18000, CRC(6c6db5b8) SHA1(925e7c7cc7c3d290f4a334f24eef574aaac3150c) ) // Labeled FB SND V1.0 (U17)
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
-	ROM_LOAD32_BYTE( "footbal_0.grom0.itfb0",  0x000000, 0x100000, CRC(0b7781af) SHA1(0e6b617a5d9a2d0d50a3839231177f2934177b87) ) /* mask ROM, socket silkscreened GROM0/ITFB0 */
-	ROM_LOAD32_BYTE( "footbal_1.grom5.itfb1",  0x000001, 0x100000, CRC(178d0f9b) SHA1(2c13be9063742c24a4b8409fe1d16f6c989f20e0) ) /* mask ROM, socket silkscreened GROM5/ITFB1 */
-	ROM_LOAD32_BYTE( "footbal_2.grom10.itfb2", 0x000002, 0x100000, CRC(0a17231e) SHA1(1499783ac32c3c6956d4084d623a432aecfd7769) ) /* mask ROM, socket silkscreened GROM10/ITFB2 */
-	ROM_LOAD32_BYTE( "footbal_3.grom15.itfb3", 0x000003, 0x100000, CRC(104456af) SHA1(6b6adca80f663cdc8fcbdf58c033d32193e91b4b) ) /* mask ROM, socket silkscreened GROM15/ITFB3 */
-	ROM_LOAD32_BYTE( "footbal_4.grom1.itfb4",  0x400000, 0x100000, CRC(2cb6f454) SHA1(e3af2809d43ddb4f17342a0b63848bf9a579b1eb) ) /* mask ROM, socket silkscreened GROM1/ITFB4 */
-	ROM_LOAD32_BYTE( "footbal_5.grom6.itfb5",  0x400001, 0x100000, CRC(9b19b873) SHA1(4393dce2fd6e1f3c2b855759a985e1e068959e0a) ) /* mask ROM, socket silkscreened GROM6/ITFB5 */
-	ROM_LOAD32_BYTE( "footbal_6.grom11.itfb6", 0x400002, 0x100000, CRC(58694394) SHA1(9b0742d136de9870f50a1f47347071a21283067b) ) /* mask ROM, socket silkscreened GROM11/ITFB6 */
-	ROM_LOAD32_BYTE( "footbal_7.grom16.itfb7", 0x400003, 0x100000, CRC(9b7a2d1a) SHA1(e4aa8d5f76b26d16cabaf88dfa1bfba8052fe99d) ) /* mask ROM, socket silkscreened GROM16/ITFB7 */
-	ROM_LOAD32_BYTE( "itfb-8.grom2.itfb8",     0x800000, 0x020000, CRC(a1656bf8) SHA1(4df05a1cdf5d636956d1c3d1f4f1988b254608d5) ) /* EPROM, socket silkscreened GROM2/ITFB8 */
-	ROM_LOAD32_BYTE( "itfb-9.grom7.itfb9",     0x800001, 0x020000, CRC(2afa9e10) SHA1(d422447fd2fc2f9350af472eb1f1223383a1a259) ) /* EPROM, socket silkscreened GROM7/ITFB9 */
-	ROM_LOAD32_BYTE( "itfb-10.grom12.itfb10",  0x800002, 0x020000, CRC(d5d15b38) SHA1(f414c19d8d88f916fbfa24fc3e16cea2e0acce08) ) /* EPROM, socket silkscreened GROM12/ITFB10 */
-	ROM_LOAD32_BYTE( "itfb-11.grom17.itfb11",  0x800003, 0x020000, CRC(cd4f0df0) SHA1(632eb0cf27d7bf3df09d03f373a3195dd5a702b8) ) /* EPROM, socket silkscreened GROM17/ITFB11 */
+	ROM_REGION( 0x880000, "grom", 0 )
+	ROM_LOAD32_BYTE( "footbal_0.grom0.itfb0",  0x000000, 0x100000, CRC(0b7781af) SHA1(0e6b617a5d9a2d0d50a3839231177f2934177b87) ) // mask ROM, socket silkscreened GROM0/ITFB0
+	ROM_LOAD32_BYTE( "footbal_1.grom5.itfb1",  0x000001, 0x100000, CRC(178d0f9b) SHA1(2c13be9063742c24a4b8409fe1d16f6c989f20e0) ) // mask ROM, socket silkscreened GROM5/ITFB1
+	ROM_LOAD32_BYTE( "footbal_2.grom10.itfb2", 0x000002, 0x100000, CRC(0a17231e) SHA1(1499783ac32c3c6956d4084d623a432aecfd7769) ) // mask ROM, socket silkscreened GROM10/ITFB2
+	ROM_LOAD32_BYTE( "footbal_3.grom15.itfb3", 0x000003, 0x100000, CRC(104456af) SHA1(6b6adca80f663cdc8fcbdf58c033d32193e91b4b) ) // mask ROM, socket silkscreened GROM15/ITFB3
+	ROM_LOAD32_BYTE( "footbal_4.grom1.itfb4",  0x400000, 0x100000, CRC(2cb6f454) SHA1(e3af2809d43ddb4f17342a0b63848bf9a579b1eb) ) // mask ROM, socket silkscreened GROM1/ITFB4
+	ROM_LOAD32_BYTE( "footbal_5.grom6.itfb5",  0x400001, 0x100000, CRC(9b19b873) SHA1(4393dce2fd6e1f3c2b855759a985e1e068959e0a) ) // mask ROM, socket silkscreened GROM6/ITFB5
+	ROM_LOAD32_BYTE( "footbal_6.grom11.itfb6", 0x400002, 0x100000, CRC(58694394) SHA1(9b0742d136de9870f50a1f47347071a21283067b) ) // mask ROM, socket silkscreened GROM11/ITFB6
+	ROM_LOAD32_BYTE( "footbal_7.grom16.itfb7", 0x400003, 0x100000, CRC(9b7a2d1a) SHA1(e4aa8d5f76b26d16cabaf88dfa1bfba8052fe99d) ) // mask ROM, socket silkscreened GROM16/ITFB7
+	ROM_LOAD32_BYTE( "itfb-8.grom2.itfb8",     0x800000, 0x020000, CRC(a1656bf8) SHA1(4df05a1cdf5d636956d1c3d1f4f1988b254608d5) ) // EPROM, socket silkscreened GROM2/ITFB8
+	ROM_LOAD32_BYTE( "itfb-9.grom7.itfb9",     0x800001, 0x020000, CRC(2afa9e10) SHA1(d422447fd2fc2f9350af472eb1f1223383a1a259) ) // EPROM, socket silkscreened GROM7/ITFB9
+	ROM_LOAD32_BYTE( "itfb-10.grom12.itfb10",  0x800002, 0x020000, CRC(d5d15b38) SHA1(f414c19d8d88f916fbfa24fc3e16cea2e0acce08) ) // EPROM, socket silkscreened GROM12/ITFB10
+	ROM_LOAD32_BYTE( "itfb-11.grom17.itfb11",  0x800003, 0x020000, CRC(cd4f0df0) SHA1(632eb0cf27d7bf3df09d03f373a3195dd5a702b8) ) // EPROM, socket silkscreened GROM17/ITFB11
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 */
+	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "fb_srom00.srom0", 0x000000, 0x080000, CRC(b0a76ad2) SHA1(d1125cf96f6b9613840b8d22afa59748fb32ab90) )
@@ -2487,8 +2454,8 @@ ROM_START( hardyard10 ) /* Version 1.0 (3-tier board set: P/N 1059 Rev 3, P/N 10
 ROM_END
 
 
-ROM_START( pairs )  /* Version 1.2 (3-tier board set: P/N 1059 Rev 3, P/N 1061 Rev 1 &  P/N 1060 Rev 0) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
+ROM_START( pairs )  // Version 1.2 (3-tier board set: P/N 1059 Rev 3, P/N 1061 Rev 1 &  P/N 1060 Rev 0)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
 	ROM_LOAD16_BYTE( "pair0_u83_x_v1.2.u83", 0x00000, 0x20000, CRC(a9c761d8) SHA1(2618c9c3f336cf30f760fd88f12c09985cfd4ee7) )
 	ROM_LOAD16_BYTE( "pair1_u88_x_v1.2.u88", 0x00001, 0x20000, CRC(5141eb86) SHA1(3bb10d588e6334a33e5c2c468651699e84f46cdc) )
 
@@ -2496,7 +2463,7 @@ ROM_START( pairs )  /* Version 1.2 (3-tier board set: P/N 1059 Rev 3, P/N 1061 R
 	ROM_LOAD( "pairsnd_u17_v1.u17", 0x10000, 0x18000, CRC(7a514cfd) SHA1(ef5bc74c9560d2c058298051070fa748e58f07e1) )
 	ROM_CONTINUE(                   0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "pairx_grom0_v1.grom0",   0x000000, 0x80000, CRC(baf1c2dd) SHA1(4de50001bce294ea5eea581cee9ca5a966701176) )
 	ROM_LOAD32_BYTE( "pairx_grom5_v1.grom5",   0x000001, 0x80000, CRC(30e993f3) SHA1(fe32aabacbe9d6d9419410faafe048c01988ac78) )
 	ROM_LOAD32_BYTE( "pairx_grom10_v1.grom10", 0x000002, 0x80000, CRC(3f52f50d) SHA1(abb7ec8fa1af0876dacfe04d76fbc8fc18a2b610) )
@@ -2507,14 +2474,14 @@ ROM_START( pairs )  /* Version 1.2 (3-tier board set: P/N 1059 Rev 3, P/N 1061 R
 	ROM_LOAD32_BYTE( "pairx_grom16_v1.grom16", 0x200003, 0x40000, CRC(b2975259) SHA1(aa82f8e855f2ebf1d7178a46f2b515d7c9a26299) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 */
+	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "srom0.bin", 0x000000, 0x80000, CRC(19a857f9) SHA1(2515b4c127191d52d3b5a72477384847d8cabad3) ) /* Unknown label and / or revision */
+	ROM_LOAD16_BYTE( "srom0.bin", 0x000000, 0x80000, CRC(19a857f9) SHA1(2515b4c127191d52d3b5a72477384847d8cabad3) ) // Unknown label and / or revision
 ROM_END
 
-ROM_START( pairsa ) /* Version 1 (3-tier board set: P/N 1059 Rev 3, P/N 1061 Rev 1 &  P/N 1060 Rev 0) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
+ROM_START( pairsa ) // Version 1 (3-tier board set: P/N 1059 Rev 3, P/N 1061 Rev 1 &  P/N 1060 Rev 0)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
 	ROM_LOAD16_BYTE( "pair0_u83_x_v1.u83", 0x00000, 0x20000, CRC(774995a3) SHA1(93df91378b56802d14c105f7f48ed8a4f7bafffd) )
 	ROM_LOAD16_BYTE( "pair1_u83_x_v1.u88", 0x00001, 0x20000, CRC(85d0b73a) SHA1(48a6ac6de94be13e407da13e3e2440d858714b4b) )
 
@@ -2522,7 +2489,7 @@ ROM_START( pairsa ) /* Version 1 (3-tier board set: P/N 1059 Rev 3, P/N 1061 Rev
 	ROM_LOAD( "pairsnd_u17_v1.u17", 0x10000, 0x18000, CRC(7a514cfd) SHA1(ef5bc74c9560d2c058298051070fa748e58f07e1) )
 	ROM_CONTINUE(                   0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "pairx_grom0_v1.grom0",   0x000000, 0x80000, CRC(baf1c2dd) SHA1(4de50001bce294ea5eea581cee9ca5a966701176) )
 	ROM_LOAD32_BYTE( "pairx_grom5_v1.grom5",   0x000001, 0x80000, CRC(30e993f3) SHA1(fe32aabacbe9d6d9419410faafe048c01988ac78) )
 	ROM_LOAD32_BYTE( "pairx_grom10_v1.grom10", 0x000002, 0x80000, CRC(3f52f50d) SHA1(abb7ec8fa1af0876dacfe04d76fbc8fc18a2b610) )
@@ -2533,22 +2500,22 @@ ROM_START( pairsa ) /* Version 1 (3-tier board set: P/N 1059 Rev 3, P/N 1061 Rev
 	ROM_LOAD32_BYTE( "pairx_grom16_v1.grom16", 0x200003, 0x40000, CRC(b2975259) SHA1(aa82f8e855f2ebf1d7178a46f2b515d7c9a26299) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 */
+	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "srom0_pairs_v1.srom0", 0x000000, 0x80000, CRC(1d96c581) SHA1(3b7c84b7db3b098ec28c7058c16f97e9cf0e4733) )
 ROM_END
 
-ROM_START( hotmemry )   /* Version 1.2 (3-tier board set: P/N 1059 Rev 3, P/N 1061 Rev 1 &  P/N 1060 Rev 0) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "hotmem0_u83_v1.2.u83", 0x00000, 0x40000, CRC(5b9d87a2) SHA1(5a1ca7b622832fcb641e081d0c2a49c38ca795cd) ) /* Labeled HOTMEM0 U83 V1.2 */
-	ROM_LOAD16_BYTE( "hotmem1_u88_v1.2.u88", 0x00001, 0x40000, CRC(aeea087c) SHA1(3a8bdc04bc4051691823d0c5a1a3429475692100) ) /* Labeled HOTMEM1 U88 V1.2 */
+ROM_START( hotmemry )   // Version 1.2 (3-tier board set: P/N 1059 Rev 3, P/N 1061 Rev 1 &  P/N 1060 Rev 0)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "hotmem0_u83_v1.2.u83", 0x00000, 0x40000, CRC(5b9d87a2) SHA1(5a1ca7b622832fcb641e081d0c2a49c38ca795cd) ) // Labeled HOTMEM0 U83 V1.2
+	ROM_LOAD16_BYTE( "hotmem1_u88_v1.2.u88", 0x00001, 0x40000, CRC(aeea087c) SHA1(3a8bdc04bc4051691823d0c5a1a3429475692100) ) // Labeled HOTMEM1 U88 V1.2
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "hotmemsnd_u17_v1.u17", 0x10000, 0x18000, CRC(805941c7) SHA1(4a6832d93ff2b986cb54052658af62584782cb59) ) /* Labeled HOTMEMSND U17 V1 */
+	ROM_LOAD( "hotmemsnd_u17_v1.u17", 0x10000, 0x18000, CRC(805941c7) SHA1(4a6832d93ff2b986cb54052658af62584782cb59) ) // Labeled HOTMEMSND U17 V1
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "hotmem_grom0_v1.grom0",   0x000000, 0x80000, CRC(68f279ef) SHA1(66098e68474e692676662b03835d1b74f581b0f4) )
 	ROM_LOAD32_BYTE( "hotmem_grom5_v1.grom5",   0x000001, 0x80000, CRC(295bb43d) SHA1(ccecdbc9dc9ef925fe59a53eeff89135d2ae748d) )
 	ROM_LOAD32_BYTE( "hotmem_grom10_v1.grom10", 0x000002, 0x80000, CRC(f8cc939b) SHA1(cbd35346f057f1e615705acb2595ba550f6d8772) )
@@ -2559,22 +2526,22 @@ ROM_START( hotmemry )   /* Version 1.2 (3-tier board set: P/N 1059 Rev 3, P/N 10
 	ROM_LOAD32_BYTE( "hotmem_grom16_v1.grom16", 0x200003, 0x40000, CRC(4507a895) SHA1(3d6cd6cd81b62545f7be5991f67803cf11c96ee6) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 */
+	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "srom0_hotmem_v1.srom0", 0x000000, 0x80000, CRC(c1103224) SHA1(52cf341ff9092ecb8cb94f66a96ee0c726bf1412) )
 ROM_END
 
-ROM_START( hotmemry11 ) /* Version 1.1 (3-tier board set: P/N 1059 Rev 3, P/N 1061 Rev 1 &  P/N 1060 Rev 0) */
-	ROM_REGION16_BE( 0x80000, "user1", ROMREGION_ERASEFF )
-	ROM_LOAD16_BYTE( "hotmem0_u83_v1.1.u83", 0x00000, 0x20000, CRC(8d614b1b) SHA1(46567b83c595f166573ce6cf93456dbd10ab5b80) ) /* Labeled HOTMEM0 U83 V1.1 */
-	ROM_LOAD16_BYTE( "hotmem1_u88_v1.1.u88", 0x00001, 0x20000, CRC(009639fb) SHA1(8f559a838a12a4e3d39acbea87a9816a66a3f8f8) ) /* Labeled HOTMEM1 U88 V1.1 */
+ROM_START( hotmemry11 ) // Version 1.1 (3-tier board set: P/N 1059 Rev 3, P/N 1061 Rev 1 &  P/N 1060 Rev 0)
+	ROM_REGION16_BE( 0x80000, "maindata", ROMREGION_ERASEFF )
+	ROM_LOAD16_BYTE( "hotmem0_u83_v1.1.u83", 0x00000, 0x20000, CRC(8d614b1b) SHA1(46567b83c595f166573ce6cf93456dbd10ab5b80) ) // Labeled HOTMEM0 U83 V1.1
+	ROM_LOAD16_BYTE( "hotmem1_u88_v1.1.u88", 0x00001, 0x20000, CRC(009639fb) SHA1(8f559a838a12a4e3d39acbea87a9816a66a3f8f8) ) // Labeled HOTMEM1 U88 V1.1
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "hotmemsnd_u17_v1.u17", 0x10000, 0x18000, CRC(805941c7) SHA1(4a6832d93ff2b986cb54052658af62584782cb59) ) /* Labeled HOTMEMSND U17 V1 */
+	ROM_LOAD( "hotmemsnd_u17_v1.u17", 0x10000, 0x18000, CRC(805941c7) SHA1(4a6832d93ff2b986cb54052658af62584782cb59) ) // Labeled HOTMEMSND U17 V1
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "hotmem_grom0_v1.grom0",   0x000000, 0x80000, CRC(68f279ef) SHA1(66098e68474e692676662b03835d1b74f581b0f4) )
 	ROM_LOAD32_BYTE( "hotmem_grom5_v1.grom5",   0x000001, 0x80000, CRC(295bb43d) SHA1(ccecdbc9dc9ef925fe59a53eeff89135d2ae748d) )
 	ROM_LOAD32_BYTE( "hotmem_grom10_v1.grom10", 0x000002, 0x80000, CRC(f8cc939b) SHA1(cbd35346f057f1e615705acb2595ba550f6d8772) )
@@ -2585,51 +2552,51 @@ ROM_START( hotmemry11 ) /* Version 1.1 (3-tier board set: P/N 1059 Rev 3, P/N 10
 	ROM_LOAD32_BYTE( "hotmem_grom16_v1.grom16", 0x200003, 0x40000, CRC(4507a895) SHA1(3d6cd6cd81b62545f7be5991f67803cf11c96ee6) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 */
+	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "srom0_hotmem_v1.srom0", 0x000000, 0x80000, CRC(c1103224) SHA1(52cf341ff9092ecb8cb94f66a96ee0c726bf1412) )
 ROM_END
 
 
-ROM_START( pairsred )   /* Version RED V1.0 (3-tier board set: P/N 1059 Rev 3, P/N 1061 Rev 1 &  P/N 1060 Rev 0) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "pair0_u83_redv1.u83", 0x00000, 0x20000, CRC(cf27b93c) SHA1(4db1d5a756e237d49ace8b5c45d3c4d721a996d5) ) /* Labeled PAIR0 U83 RED V1 */
-	ROM_LOAD16_BYTE( "pair1_u88_redv1.u88", 0x00001, 0x20000, CRC(7ad48e7e) SHA1(ee4c543fbbeb26bcad45a06cda43572f081acb84) ) /* Labeled PAIR1 U88 RED V1 */
+ROM_START( pairsred )   // Version RED V1.0 (3-tier board set: P/N 1059 Rev 3, P/N 1061 Rev 1 &  P/N 1060 Rev 0)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "pair0_u83_redv1.u83", 0x00000, 0x20000, CRC(cf27b93c) SHA1(4db1d5a756e237d49ace8b5c45d3c4d721a996d5) ) // Labeled PAIR0 U83 RED V1
+	ROM_LOAD16_BYTE( "pair1_u88_redv1.u88", 0x00001, 0x20000, CRC(7ad48e7e) SHA1(ee4c543fbbeb26bcad45a06cda43572f081acb84) ) // Labeled PAIR1 U88 RED V1
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "pairsnd_u17_redv1.u17", 0x10000, 0x18000, CRC(198e1743) SHA1(16bd21b2d3cabbd51e4d84f7cf007ae6cd4cf624) ) /* Labeled PAIRSND U17 REDV1 */
+	ROM_LOAD( "pairsnd_u17_redv1.u17", 0x10000, 0x18000, CRC(198e1743) SHA1(16bd21b2d3cabbd51e4d84f7cf007ae6cd4cf624) ) // Labeled PAIRSND U17 REDV1
 	ROM_CONTINUE(                      0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
-	ROM_LOAD32_BYTE( "pair-red_grom0",  0x000000, 0x40000, CRC(1bbcc6c6) SHA1(c31dc5b0bc83455e0ad60fcfa42dba49b91ed1b0) ) /* Labeled PAIR-RED GROM0 V1 */
-	ROM_LOAD32_BYTE( "pair-red_grom5",  0x000001, 0x40000, CRC(eff93bde) SHA1(3b1234146677ca4dd16962411a2607d0eb933c01) ) /* Labeled PAIR-RED GROM5 V1 */
-	ROM_LOAD32_BYTE( "pair-red_grom10", 0x000002, 0x40000, CRC(016f4d19) SHA1(32886b3ecfbebb835d0c311b3135521af3120a77) ) /* Labeled PAIR-RED GROM10 V1 */
-	ROM_LOAD32_BYTE( "pair-red_grom15", 0x000003, 0x40000, CRC(dc95160d) SHA1(218d6c460780aadc0f371b8c1ae2d5fe6b1818c0) ) /* Labeled PAIR-RED GROM15 V1 */
+	ROM_REGION( 0x880000, "grom", 0 )
+	ROM_LOAD32_BYTE( "pair-red_grom0",  0x000000, 0x40000, CRC(1bbcc6c6) SHA1(c31dc5b0bc83455e0ad60fcfa42dba49b91ed1b0) ) // Labeled PAIR-RED GROM0 V1
+	ROM_LOAD32_BYTE( "pair-red_grom5",  0x000001, 0x40000, CRC(eff93bde) SHA1(3b1234146677ca4dd16962411a2607d0eb933c01) ) // Labeled PAIR-RED GROM5 V1
+	ROM_LOAD32_BYTE( "pair-red_grom10", 0x000002, 0x40000, CRC(016f4d19) SHA1(32886b3ecfbebb835d0c311b3135521af3120a77) ) // Labeled PAIR-RED GROM10 V1
+	ROM_LOAD32_BYTE( "pair-red_grom15", 0x000003, 0x40000, CRC(dc95160d) SHA1(218d6c460780aadc0f371b8c1ae2d5fe6b1818c0) ) // Labeled PAIR-RED GROM15 V1
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 */
+	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "srom0_pairs_redv1", 0x000000, 0x80000, CRC(a998e29f) SHA1(fb0556d0e1a6621256e83fb6b0d0ed9885dff1b0) ) /* Labeled SROM0 PAIRS REDV1 */
+	ROM_LOAD16_BYTE( "srom0_pairs_redv1", 0x000000, 0x80000, CRC(a998e29f) SHA1(fb0556d0e1a6621256e83fb6b0d0ed9885dff1b0) ) // Labeled SROM0 PAIRS REDV1
 ROM_END
 
 
-ROM_START( wcbowl ) /* Version 1.66 (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
-	ROM_LOAD32_BYTE( "wcb_prom0_v1.66n.prom0", 0x00000, 0x20000, CRC(f6774112) SHA1(cb09bb3e40490b3cdc3a5f7d18168384b5b29d85) ) /* original labels also found without the "N" */
+ROM_START( wcbowl ) // Version 1.66 (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
+	ROM_LOAD32_BYTE( "wcb_prom0_v1.66n.prom0", 0x00000, 0x20000, CRC(f6774112) SHA1(cb09bb3e40490b3cdc3a5f7d18168384b5b29d85) ) // original labels also found without the "N"
 	ROM_LOAD32_BYTE( "wcb_prom1_v1.66n.prom1", 0x00001, 0x20000, CRC(931821ae) SHA1(328cd78ba70fe3cb0bdbc53833fe6fb153aceaea) )
 	ROM_LOAD32_BYTE( "wcb_prom2_v1.66n.prom2", 0x00002, 0x20000, CRC(c54f5e40) SHA1(2cd92ba1db74b24e908d10f733757801db180dd0) )
 	ROM_LOAD32_BYTE( "wcb_prom3_v1.66n.prom3", 0x00003, 0x20000, CRC(dd72c796) SHA1(4c1542c51848a88a663e56ae0b47bf9d2d9f7d54) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "wcbsnd_u88_4.01.u88", 0x10000, 0x18000, CRC(e97a6d28) SHA1(96d7b7856918abcc460083f2a46582ba2a689288) ) /* actually labeled as "WCBSND(U88)4.01" but may be labeled v4.0 */
+	ROM_LOAD( "wcbsnd_u88_4.01.u88", 0x10000, 0x18000, CRC(e97a6d28) SHA1(96d7b7856918abcc460083f2a46582ba2a689288) ) // actually labeled as "WCBSND(U88)4.01" but may be labeled v4.0
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
 	ROM_REGION( 0x2000, "pic", 0 ) // PIC16C54
 	ROM_LOAD( "itbwl-3 1997 it,inc.1996", 0x0000, 0x1fff, CRC(1461cbe0) SHA1(97cc1f985d9c8bbe3fd829681883b6c4ae15c5bd) ) // not hooked up
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "wcb_grom0_0_s.grm0_0", 0x000000, 0x080000, CRC(6fcb4246) SHA1(91fb5d18ea9494b08251d1e611c80414df3aad66) )
 	ROM_LOAD32_BYTE( "wcb_grom0_1_s.grm0_1", 0x000001, 0x080000, CRC(2ae31f45) SHA1(85218aa9a7ca7c6870427ffbd08b78255813ff90) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2_s.grm0_2", 0x000002, 0x080000, CRC(bccc0f35) SHA1(2389662e881e86f8cdb36eb2a082923d976676c8) )
@@ -2641,29 +2608,29 @@ ROM_START( wcbowl ) /* Version 1.66 (PCB P/N 1083 Rev 2) */
 	ROM_FILL(                                0x400000, 0x480000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "wcb_srom0_s.srom0",  0x000000, 0x080000, CRC(d42dd283) SHA1(8ef75c398d1c51d2d7d299ac309a2352179864d9) ) /* Newer sound sample ROMs */
-	ROM_LOAD16_BYTE( "wcb_srom1_s.srom1",  0x200000, 0x080000, CRC(7a69ab54) SHA1(d1f9194446e235af69c6ff28af0dccc44ab9b5d3) ) /* Newer sound sample ROMs */
+	ROM_LOAD16_BYTE( "wcb_srom0_s.srom0",  0x000000, 0x080000, CRC(d42dd283) SHA1(8ef75c398d1c51d2d7d299ac309a2352179864d9) ) // Newer sound sample ROMs
+	ROM_LOAD16_BYTE( "wcb_srom1_s.srom1",  0x200000, 0x080000, CRC(7a69ab54) SHA1(d1f9194446e235af69c6ff28af0dccc44ab9b5d3) ) // Newer sound sample ROMs
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "wcb_srom2_s.srom2",  0x000000, 0x080000, CRC(346530a2) SHA1(9951971ad6d368fb718027e18331d12f0a72970c) ) /* Newer sound sample ROMs */
-	ROM_LOAD16_BYTE( "wcb_srom3_s.srom3",  0x200000, 0x040000, CRC(1dfe3a31) SHA1(94947f495692288fbf14fc7796a84c5548a2e8a8) ) /* Newer sound sample ROMs, ROM is a 27C020 in this set */
+	ROM_LOAD16_BYTE( "wcb_srom2_s.srom2",  0x000000, 0x080000, CRC(346530a2) SHA1(9951971ad6d368fb718027e18331d12f0a72970c) ) // Newer sound sample ROMs
+	ROM_LOAD16_BYTE( "wcb_srom3_s.srom3",  0x200000, 0x040000, CRC(1dfe3a31) SHA1(94947f495692288fbf14fc7796a84c5548a2e8a8) ) // Newer sound sample ROMs, ROM is a 27C020 in this set
 ROM_END
 
-ROM_START( wcbowl165 )  /* Version 1.65 (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
-	ROM_LOAD32_BYTE( "wcb_prom0_v1.65n.prom0", 0x00000, 0x20000, CRC(cf0f6c25) SHA1(90685288994dce73d5b1070a55fca3f1713c5bb6) ) /* original labels also found without the "N" */
+ROM_START( wcbowl165 )  // Version 1.65 (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
+	ROM_LOAD32_BYTE( "wcb_prom0_v1.65n.prom0", 0x00000, 0x20000, CRC(cf0f6c25) SHA1(90685288994dce73d5b1070a55fca3f1713c5bb6) ) // original labels also found without the "N"
 	ROM_LOAD32_BYTE( "wcb_prom1_v1.65n.prom1", 0x00001, 0x20000, CRC(076ab158) SHA1(e6d8a6726e27ba6916d4711dff88f26f1dc162e1) )
 	ROM_LOAD32_BYTE( "wcb_prom2_v1.65n.prom2", 0x00002, 0x20000, CRC(47259009) SHA1(78a6e70e747030a5ed43d49384061e53f4a77675) )
 	ROM_LOAD32_BYTE( "wcb_prom3_v1.65n.prom3", 0x00003, 0x20000, CRC(4c6b4e4f) SHA1(77f5f4b632dd1919ae210bbdc75042bdbebf6660) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "wcbsnd_u88_4.01.u88", 0x10000, 0x18000, CRC(e97a6d28) SHA1(96d7b7856918abcc460083f2a46582ba2a689288) ) /* actually labeled as "WCBSND(U88)4.01" but may be labeled v4.0 */
+	ROM_LOAD( "wcbsnd_u88_4.01.u88", 0x10000, 0x18000, CRC(e97a6d28) SHA1(96d7b7856918abcc460083f2a46582ba2a689288) ) // actually labeled as "WCBSND(U88)4.01" but may be labeled v4.0
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
 	ROM_REGION( 0x2000, "pic", 0 ) // PIC16C54
 	ROM_LOAD( "itbwl-3 1997 it,inc.1996", 0x0000, 0x1fff, CRC(1461cbe0) SHA1(97cc1f985d9c8bbe3fd829681883b6c4ae15c5bd) ) // not hooked up
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "wcb_grom0_0_s.grm0_0", 0x000000, 0x080000, CRC(6fcb4246) SHA1(91fb5d18ea9494b08251d1e611c80414df3aad66) )
 	ROM_LOAD32_BYTE( "wcb_grom0_1_s.grm0_1", 0x000001, 0x080000, CRC(2ae31f45) SHA1(85218aa9a7ca7c6870427ffbd08b78255813ff90) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2_s.grm0_2", 0x000002, 0x080000, CRC(bccc0f35) SHA1(2389662e881e86f8cdb36eb2a082923d976676c8) )
@@ -2675,29 +2642,29 @@ ROM_START( wcbowl165 )  /* Version 1.65 (PCB P/N 1083 Rev 2) */
 	ROM_FILL(                                0x400000, 0x480000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "wcb_srom0_s.srom0",  0x000000, 0x080000, CRC(d42dd283) SHA1(8ef75c398d1c51d2d7d299ac309a2352179864d9) ) /* Newer sound sample ROMs */
-	ROM_LOAD16_BYTE( "wcb_srom1_s.srom1",  0x200000, 0x080000, CRC(7a69ab54) SHA1(d1f9194446e235af69c6ff28af0dccc44ab9b5d3) ) /* Newer sound sample ROMs */
+	ROM_LOAD16_BYTE( "wcb_srom0_s.srom0",  0x000000, 0x080000, CRC(d42dd283) SHA1(8ef75c398d1c51d2d7d299ac309a2352179864d9) ) // Newer sound sample ROMs
+	ROM_LOAD16_BYTE( "wcb_srom1_s.srom1",  0x200000, 0x080000, CRC(7a69ab54) SHA1(d1f9194446e235af69c6ff28af0dccc44ab9b5d3) ) // Newer sound sample ROMs
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "wcb_srom2_s.srom2",  0x000000, 0x080000, CRC(346530a2) SHA1(9951971ad6d368fb718027e18331d12f0a72970c) ) /* Newer sound sample ROMs */
-	ROM_LOAD16_BYTE( "wcb_srom3_s.srom3",  0x200000, 0x040000, CRC(1dfe3a31) SHA1(94947f495692288fbf14fc7796a84c5548a2e8a8) ) /* Newer sound sample roms, ROM is a 27C020 in this set */
+	ROM_LOAD16_BYTE( "wcb_srom2_s.srom2",  0x000000, 0x080000, CRC(346530a2) SHA1(9951971ad6d368fb718027e18331d12f0a72970c) ) // Newer sound sample ROMs
+	ROM_LOAD16_BYTE( "wcb_srom3_s.srom3",  0x200000, 0x040000, CRC(1dfe3a31) SHA1(94947f495692288fbf14fc7796a84c5548a2e8a8) ) // Newer sound sample roms, ROM is a 27C020 in this set
 ROM_END
 
-ROM_START( wcbowl161 )  /* Version 1.61 (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( wcbowl161 )  // Version 1.61 (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "wcb_prom0_v1.61n.prom0", 0x00000, 0x20000, CRC(b879d4a7) SHA1(8b5af3f4d3522bdb8e1d6092b2e311fbfaec2bd0) )
 	ROM_LOAD32_BYTE( "wcb_prom1_v1.61n.prom1", 0x00001, 0x20000, CRC(49f3ed6a) SHA1(6c6857bd3fbfe0cfeaf0e512bbbd795376a21472) )
 	ROM_LOAD32_BYTE( "wcb_prom2_v1.61n.prom2", 0x00002, 0x20000, CRC(47259009) SHA1(78a6e70e747030a5ed43d49384061e53f4a77675) )
 	ROM_LOAD32_BYTE( "wcb_prom3_v1.61n.prom3", 0x00003, 0x20000, CRC(e5081f85) SHA1(a5513b8dd917a35f1c8b7f833c2d5622353d39f0) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "wcbsnd_u88_v4.0.u88", 0x10000, 0x18000, CRC(194a51d7) SHA1(c67b042008ff2a2713562d3789e5bc3a312fae17) ) /* Version 4.0, may be labeled "WCBSND U88 V4.0T" */
+	ROM_LOAD( "wcbsnd_u88_v4.0.u88", 0x10000, 0x18000, CRC(194a51d7) SHA1(c67b042008ff2a2713562d3789e5bc3a312fae17) ) // Version 4.0, may be labeled "WCBSND U88 V4.0T"
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
 	ROM_REGION( 0x2000, "pic", 0 ) // PIC16C54
 	ROM_LOAD( "itbwl-3 1997 it,inc.1996", 0x0000, 0x1fff, CRC(1461cbe0) SHA1(97cc1f985d9c8bbe3fd829681883b6c4ae15c5bd) ) // not hooked up
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "wcb_grom0_0_s.grm0_0", 0x000000, 0x080000, CRC(6fcb4246) SHA1(91fb5d18ea9494b08251d1e611c80414df3aad66) )
 	ROM_LOAD32_BYTE( "wcb_grom0_1_s.grm0_1", 0x000001, 0x080000, CRC(2ae31f45) SHA1(85218aa9a7ca7c6870427ffbd08b78255813ff90) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2_s.grm0_2", 0x000002, 0x080000, CRC(bccc0f35) SHA1(2389662e881e86f8cdb36eb2a082923d976676c8) )
@@ -2709,29 +2676,29 @@ ROM_START( wcbowl161 )  /* Version 1.61 (PCB P/N 1083 Rev 2) */
 	ROM_FILL(                                0x400000, 0x480000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "wcb_srom0.srom0",  0x000000, 0x080000, CRC(c3821cb5) SHA1(3c2c27d1e577201cbd0d28cc48fc80ae7747faa1) ) /* Older sound sample ROMs */
-	ROM_LOAD16_BYTE( "wcb_srom1.srom1",  0x200000, 0x080000, CRC(37bfa3c7) SHA1(98c98296acaa55e6fd12a62305ff387c863fc5ed) ) /* Older sound sample ROMs */
+	ROM_LOAD16_BYTE( "wcb_srom0.srom0",  0x000000, 0x080000, CRC(c3821cb5) SHA1(3c2c27d1e577201cbd0d28cc48fc80ae7747faa1) ) // Older sound sample ROMs
+	ROM_LOAD16_BYTE( "wcb_srom1.srom1",  0x200000, 0x080000, CRC(37bfa3c7) SHA1(98c98296acaa55e6fd12a62305ff387c863fc5ed) ) // Older sound sample ROMs
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "wcb_srom2.srom2",  0x000000, 0x080000, CRC(f82c08fd) SHA1(8f6f47f5a4b68a31df4c2eb330dc95a9963e55c1) ) /* Older sound sample ROMs */
-	ROM_LOAD16_BYTE( "wcb_srom3.srom3",  0x200000, 0x020000, CRC(1c2efdee) SHA1(d306c9e7f9c4c2662561401170439a10a9ee89ed) ) /* Older sound sample ROMs, ROM is a 27C010 in this set */
+	ROM_LOAD16_BYTE( "wcb_srom2.srom2",  0x000000, 0x080000, CRC(f82c08fd) SHA1(8f6f47f5a4b68a31df4c2eb330dc95a9963e55c1) ) // Older sound sample ROMs
+	ROM_LOAD16_BYTE( "wcb_srom3.srom3",  0x200000, 0x020000, CRC(1c2efdee) SHA1(d306c9e7f9c4c2662561401170439a10a9ee89ed) ) // Older sound sample ROMs, ROM is a 27C010 in this set
 ROM_END
 
-ROM_START( wcbowl16 )   /* Version 1.6 (PCB P/N 1083 Rev 2), This is the first set to move to the single board platform */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( wcbowl16 )   // Version 1.6 (PCB P/N 1083 Rev 2), This is the first set to move to the single board platform
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "wcb_prom0_v1.6n.prom0", 0x00000, 0x20000, CRC(332c558f) SHA1(179b763e2189c11cf6751eb6c419fe4417b288a8) )
 	ROM_LOAD32_BYTE( "wcb_prom1_v1.6n.prom1", 0x00001, 0x20000, CRC(c5750857) SHA1(8121b56d304ab405b06d4aa4c7d2db2f912f0bf2) )
 	ROM_LOAD32_BYTE( "wcb_prom2_v1.6n.prom2", 0x00002, 0x20000, CRC(28f4ee8a) SHA1(a6a2b9cca622df0b9d181c35f4d01e8ab00392a0) )
 	ROM_LOAD32_BYTE( "wcb_prom3_v1.6n.prom3", 0x00003, 0x20000, CRC(f0a58979) SHA1(c837b2a5b0e5ae993f1e453b59e3fbd9ed5de2a7) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "wcbsnd_u88_v3.0n.u88", 0x10000, 0x18000, CRC(45c4f659) SHA1(cfd140b9947654f677409a0fb4fa0c7b65992f95) ) /* Version 3.0N */
+	ROM_LOAD( "wcbsnd_u88_v3.0n.u88", 0x10000, 0x18000, CRC(45c4f659) SHA1(cfd140b9947654f677409a0fb4fa0c7b65992f95) ) // Version 3.0N
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
 	ROM_REGION( 0x2000, "pic", 0 ) // PIC16C54
 	ROM_LOAD( "itbwl-3 1997 it,inc.1996", 0x0000, 0x1fff, CRC(1461cbe0) SHA1(97cc1f985d9c8bbe3fd829681883b6c4ae15c5bd) ) // not hooked up
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "wcb_grom0_0_s.grm0_0", 0x000000, 0x080000, CRC(6fcb4246) SHA1(91fb5d18ea9494b08251d1e611c80414df3aad66) )
 	ROM_LOAD32_BYTE( "wcb_grom0_1_s.grm0_1", 0x000001, 0x080000, CRC(2ae31f45) SHA1(85218aa9a7ca7c6870427ffbd08b78255813ff90) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2_s.grm0_2", 0x000002, 0x080000, CRC(bccc0f35) SHA1(2389662e881e86f8cdb36eb2a082923d976676c8) )
@@ -2743,31 +2710,31 @@ ROM_START( wcbowl16 )   /* Version 1.6 (PCB P/N 1083 Rev 2), This is the first s
 	ROM_FILL(                                0x400000, 0x480000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "wcb_srom0.srom0",  0x000000, 0x080000, CRC(c3821cb5) SHA1(3c2c27d1e577201cbd0d28cc48fc80ae7747faa1) ) /* Older sound sample ROMs */
-	ROM_LOAD16_BYTE( "wcb_srom1.srom1",  0x200000, 0x080000, CRC(37bfa3c7) SHA1(98c98296acaa55e6fd12a62305ff387c863fc5ed) ) /* Older sound sample ROMs */
+	ROM_LOAD16_BYTE( "wcb_srom0.srom0",  0x000000, 0x080000, CRC(c3821cb5) SHA1(3c2c27d1e577201cbd0d28cc48fc80ae7747faa1) ) // Older sound sample ROMs
+	ROM_LOAD16_BYTE( "wcb_srom1.srom1",  0x200000, 0x080000, CRC(37bfa3c7) SHA1(98c98296acaa55e6fd12a62305ff387c863fc5ed) ) // Older sound sample ROMs
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "wcb_srom2.srom2",  0x000000, 0x080000, CRC(f82c08fd) SHA1(8f6f47f5a4b68a31df4c2eb330dc95a9963e55c1) ) /* Older sound sample ROMs */
-	ROM_LOAD16_BYTE( "wcb_srom3.srom3",  0x200000, 0x020000, CRC(1c2efdee) SHA1(d306c9e7f9c4c2662561401170439a10a9ee89ed) ) /* Older sound sample ROMs, ROM is a 27C010 in this set */
+	ROM_LOAD16_BYTE( "wcb_srom2.srom2",  0x000000, 0x080000, CRC(f82c08fd) SHA1(8f6f47f5a4b68a31df4c2eb330dc95a9963e55c1) ) // Older sound sample ROMs
+	ROM_LOAD16_BYTE( "wcb_srom3.srom3",  0x200000, 0x020000, CRC(1c2efdee) SHA1(d306c9e7f9c4c2662561401170439a10a9ee89ed) ) // Older sound sample ROMs, ROM is a 27C010 in this set
 ROM_END
 
-ROM_START( wcbowl15 )   /* Version 1.5 (3-tier board set: P/N 1059 Rev 3, P/N 1079 Rev 1 & P/N 1060 Rev 0) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "wcb_v1.5_u83.u83", 0x00000, 0x20000, CRC(3ca9ab85) SHA1(364946dceb3f7279b7d67d9d685a98ba7f4901aa) ) /* Labeled as "WCB V1.5 (U83)" */
-	ROM_LOAD16_BYTE( "wcb_v1.5_u88.u88", 0x00001, 0x20000, CRC(d43e6fad) SHA1(fd72f6945e7f5ef86dc28503749d18086dd29906) ) /* Labeled as "WCB V1.5 (U88)" */
+ROM_START( wcbowl15 )   // Version 1.5 (3-tier board set: P/N 1059 Rev 3, P/N 1079 Rev 1 & P/N 1060 Rev 0)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "wcb_v1.5_u83.u83", 0x00000, 0x20000, CRC(3ca9ab85) SHA1(364946dceb3f7279b7d67d9d685a98ba7f4901aa) ) // Labeled as "WCB V1.5 (U83)"
+	ROM_LOAD16_BYTE( "wcb_v1.5_u88.u88", 0x00001, 0x20000, CRC(d43e6fad) SHA1(fd72f6945e7f5ef86dc28503749d18086dd29906) ) // Labeled as "WCB V1.5 (U88)"
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "wcb_snd_v2.0.u17", 0x10000, 0x18000, CRC(c14907ba) SHA1(e52fb87c1f9b5847efc0ef15eb7e6c04dcf38110) ) /* Labeled as "WCB SND V2.0" */
+	ROM_LOAD( "wcb_snd_v2.0.u17", 0x10000, 0x18000, CRC(c14907ba) SHA1(e52fb87c1f9b5847efc0ef15eb7e6c04dcf38110) ) // Labeled as "WCB SND V2.0"
 	ROM_CONTINUE(                 0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	/* No known set specifically checks for this, however the GROM data may be in the form of four 8 Meg ROMs:
 	ROM_LOAD32_BYTE( "wcb_grom0_0_+.grm0_0", 0x000000, 0x100000, CRC(40837737) SHA1(f073943ec6f84285a8559553fb292ec1f8a629d0) ) Labeled as "WCB GROM0_0 *" ect
 	ROM_LOAD32_BYTE( "wcb_grom0_1_+.grm0_1", 0x000001, 0x100000, CRC(1615aee8) SHA1(6184919371a894b1d6f2e06a2b328cb55abed4a9) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2_+.grm0_2", 0x000002, 0x100000, CRC(d8e0b06e) SHA1(4981c0cf16df68a1b4da7ebf65ca587c21292478) )
 	ROM_LOAD32_BYTE( "wcb_grom0_3_+.grm0_3", 0x000003, 0x100000, CRC(0348a7f0) SHA1(462f77514c0e9a28da63732a4f31e9483d4c483e) )
 	*/
-	ROM_LOAD32_BYTE( "wcb_grom0_0.grm0_0", 0x000000, 0x080000, CRC(5d79aaae) SHA1(e1bf5c46843f69b8bac41dde73d89ba59b4c8b7f) ) /* May also be labeled as "WCB GRM0_0" ect */
+	ROM_LOAD32_BYTE( "wcb_grom0_0.grm0_0", 0x000000, 0x080000, CRC(5d79aaae) SHA1(e1bf5c46843f69b8bac41dde73d89ba59b4c8b7f) ) // May also be labeled as "WCB GRM0_0" ect
 	ROM_LOAD32_BYTE( "wcb_grom0_1.grm0_1", 0x000001, 0x080000, CRC(e26dcedb) SHA1(15441b97dd3d50d28007062fe28841fa3f762ec9) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2.grm0_2", 0x000002, 0x080000, CRC(32735875) SHA1(4017a8577d8efa8c5b95bd30723ebbf6ecaeba2b) )
 	ROM_LOAD32_BYTE( "wcb_grom0_3.grm0_3", 0x000003, 0x080000, CRC(019d0ab8) SHA1(3281eada296ad746da80ef6e5909c50b03b90d08) )
@@ -2778,30 +2745,30 @@ ROM_START( wcbowl15 )   /* Version 1.5 (3-tier board set: P/N 1059 Rev 3, P/N 10
 	ROM_FILL(                              0x400000, 0x480000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) /* Ensoniq 2MX16U 1350901801 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) // Ensoniq 2MX16U 1350901801 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "wcb__srom0.srom0",  0x000000, 0x080000, CRC(115bcd1f) SHA1(c321bf3145c11de1351c8f9cd554ab3d6600e854) )
 	ROM_LOAD16_BYTE( "wcb__srom1.srom1",  0x100000, 0x080000, CRC(87a4a4d8) SHA1(60db2f466686481857eb39b90ac7a19d0a96adac) )
 ROM_END
 
-ROM_START( wcbowl14 )   /* Version 1.4 (3-tier board set: P/N 1059 Rev 3, P/N 1079 Rev 1 & P/N 1060 Rev 0) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "wcb_v1.4_u83.u83", 0x00000, 0x20000, CRC(7086131f) SHA1(86fe6f725785a5b1a0fc13ca60823f30713253bc) ) /* Labeled as "WCB V1.4 (U83)" */
-	ROM_LOAD16_BYTE( "wcb_v1.4_u88.u88", 0x00001, 0x20000, CRC(0225aac1) SHA1(dd37ff8405e98c61acd042d23be93de24af37884) ) /* Labeled as "WCB V1.4 (U88)" */
+ROM_START( wcbowl14 )   // Version 1.4 (3-tier board set: P/N 1059 Rev 3, P/N 1079 Rev 1 & P/N 1060 Rev 0)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "wcb_v1.4_u83.u83", 0x00000, 0x20000, CRC(7086131f) SHA1(86fe6f725785a5b1a0fc13ca60823f30713253bc) ) // Labeled as "WCB V1.4 (U83)"
+	ROM_LOAD16_BYTE( "wcb_v1.4_u88.u88", 0x00001, 0x20000, CRC(0225aac1) SHA1(dd37ff8405e98c61acd042d23be93de24af37884) ) // Labeled as "WCB V1.4 (U88)"
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "wcb_snd_v2.0.u17", 0x10000, 0x18000, CRC(c14907ba) SHA1(e52fb87c1f9b5847efc0ef15eb7e6c04dcf38110) ) /* Labeled as "WCB SND V2.0" */
+	ROM_LOAD( "wcb_snd_v2.0.u17", 0x10000, 0x18000, CRC(c14907ba) SHA1(e52fb87c1f9b5847efc0ef15eb7e6c04dcf38110) ) // Labeled as "WCB SND V2.0"
 	ROM_CONTINUE(                 0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	/* No known set specifically checks for this, however the GROM data may be in the form of four 8 Meg ROMs:
 	ROM_LOAD32_BYTE( "wcb_grom0_0_+.grm0_0", 0x000000, 0x100000, CRC(40837737) SHA1(f073943ec6f84285a8559553fb292ec1f8a629d0) ) Labeled as "WCB GROM0_0 *" ect
 	ROM_LOAD32_BYTE( "wcb_grom0_1_+.grm0_1", 0x000001, 0x100000, CRC(1615aee8) SHA1(6184919371a894b1d6f2e06a2b328cb55abed4a9) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2_+.grm0_2", 0x000002, 0x100000, CRC(d8e0b06e) SHA1(4981c0cf16df68a1b4da7ebf65ca587c21292478) )
 	ROM_LOAD32_BYTE( "wcb_grom0_3_+.grm0_3", 0x000003, 0x100000, CRC(0348a7f0) SHA1(462f77514c0e9a28da63732a4f31e9483d4c483e) )
 	*/
-	ROM_LOAD32_BYTE( "wcb_grom0_0.grm0_0", 0x000000, 0x080000, CRC(5d79aaae) SHA1(e1bf5c46843f69b8bac41dde73d89ba59b4c8b7f) ) /* May also be labeled as "WCB GRM0_0" ect */
+	ROM_LOAD32_BYTE( "wcb_grom0_0.grm0_0", 0x000000, 0x080000, CRC(5d79aaae) SHA1(e1bf5c46843f69b8bac41dde73d89ba59b4c8b7f) ) // May also be labeled as "WCB GRM0_0" ect
 	ROM_LOAD32_BYTE( "wcb_grom0_1.grm0_1", 0x000001, 0x080000, CRC(e26dcedb) SHA1(15441b97dd3d50d28007062fe28841fa3f762ec9) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2.grm0_2", 0x000002, 0x080000, CRC(32735875) SHA1(4017a8577d8efa8c5b95bd30723ebbf6ecaeba2b) )
 	ROM_LOAD32_BYTE( "wcb_grom0_3.grm0_3", 0x000003, 0x080000, CRC(019d0ab8) SHA1(3281eada296ad746da80ef6e5909c50b03b90d08) )
@@ -2812,30 +2779,30 @@ ROM_START( wcbowl14 )   /* Version 1.4 (3-tier board set: P/N 1059 Rev 3, P/N 10
 	ROM_FILL(                              0x400000, 0x480000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) /* Ensoniq 2MX16U 1350901801 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) // Ensoniq 2MX16U 1350901801 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "wcb__srom0.srom0",  0x000000, 0x080000, CRC(115bcd1f) SHA1(c321bf3145c11de1351c8f9cd554ab3d6600e854) )
 	ROM_LOAD16_BYTE( "wcb__srom1.srom1",  0x100000, 0x080000, CRC(87a4a4d8) SHA1(60db2f466686481857eb39b90ac7a19d0a96adac) )
 ROM_END
 
-ROM_START( wcbowl13 )   /* Version 1.3 (3-tier board set: P/N 1059 Rev 3, P/N 1079 Rev 1 & P/N 1060 Rev 0) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "wcb_v1.3_u83.u83", 0x00000, 0x20000, CRC(2b6d284e) SHA1(339951661509d07b69c670b7249f30a616872bdf) ) /* Labeled as "WCB V1.3 (U83)" */
-	ROM_LOAD16_BYTE( "wcb_v1.3_u88.u88", 0x00001, 0x20000, CRC(039af877) SHA1(2ac9a57e358ab1ccf9a4d18f7992b59f172e31cf) ) /* Labeled as "WCB V1.3 (U88)" */
+ROM_START( wcbowl13 )   // Version 1.3 (3-tier board set: P/N 1059 Rev 3, P/N 1079 Rev 1 & P/N 1060 Rev 0)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "wcb_v1.3_u83.u83", 0x00000, 0x20000, CRC(2b6d284e) SHA1(339951661509d07b69c670b7249f30a616872bdf) ) // Labeled as "WCB V1.3 (U83)"
+	ROM_LOAD16_BYTE( "wcb_v1.3_u88.u88", 0x00001, 0x20000, CRC(039af877) SHA1(2ac9a57e358ab1ccf9a4d18f7992b59f172e31cf) ) // Labeled as "WCB V1.3 (U88)"
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "wcb_snd_v2.0.u17", 0x10000, 0x18000, CRC(c14907ba) SHA1(e52fb87c1f9b5847efc0ef15eb7e6c04dcf38110) ) /* Labeled as "WCB SND V2.0" */
+	ROM_LOAD( "wcb_snd_v2.0.u17", 0x10000, 0x18000, CRC(c14907ba) SHA1(e52fb87c1f9b5847efc0ef15eb7e6c04dcf38110) ) // Labeled as "WCB SND V2.0"
 	ROM_CONTINUE(                 0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	/* No known set specifically checks for this, however the GROM data may be in the form of four 8 Meg ROMs:
 	ROM_LOAD32_BYTE( "wcb_grom0_0_+.grm0_0", 0x000000, 0x100000, CRC(40837737) SHA1(f073943ec6f84285a8559553fb292ec1f8a629d0) ) Labeled as "WCB GROM0_0 *" ect
 	ROM_LOAD32_BYTE( "wcb_grom0_1_+.grm0_1", 0x000001, 0x100000, CRC(1615aee8) SHA1(6184919371a894b1d6f2e06a2b328cb55abed4a9) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2_+.grm0_2", 0x000002, 0x100000, CRC(d8e0b06e) SHA1(4981c0cf16df68a1b4da7ebf65ca587c21292478) )
 	ROM_LOAD32_BYTE( "wcb_grom0_3_+.grm0_3", 0x000003, 0x100000, CRC(0348a7f0) SHA1(462f77514c0e9a28da63732a4f31e9483d4c483e) )
 	*/
-	ROM_LOAD32_BYTE( "wcb_grom0_0.grm0_0", 0x000000, 0x080000, CRC(5d79aaae) SHA1(e1bf5c46843f69b8bac41dde73d89ba59b4c8b7f) ) /* May also be labeled as "WCB GRM0_0" ect */
+	ROM_LOAD32_BYTE( "wcb_grom0_0.grm0_0", 0x000000, 0x080000, CRC(5d79aaae) SHA1(e1bf5c46843f69b8bac41dde73d89ba59b4c8b7f) ) // May also be labeled as "WCB GRM0_0" ect
 	ROM_LOAD32_BYTE( "wcb_grom0_1.grm0_1", 0x000001, 0x080000, CRC(e26dcedb) SHA1(15441b97dd3d50d28007062fe28841fa3f762ec9) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2.grm0_2", 0x000002, 0x080000, CRC(32735875) SHA1(4017a8577d8efa8c5b95bd30723ebbf6ecaeba2b) )
 	ROM_LOAD32_BYTE( "wcb_grom0_3.grm0_3", 0x000003, 0x080000, CRC(019d0ab8) SHA1(3281eada296ad746da80ef6e5909c50b03b90d08) )
@@ -2846,30 +2813,30 @@ ROM_START( wcbowl13 )   /* Version 1.3 (3-tier board set: P/N 1059 Rev 3, P/N 10
 	ROM_FILL(                              0x400000, 0x480000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) /* Ensoniq 2MX16U 1350901801 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) // Ensoniq 2MX16U 1350901801 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "wcb__srom0.srom0",  0x000000, 0x080000, CRC(115bcd1f) SHA1(c321bf3145c11de1351c8f9cd554ab3d6600e854) )
 	ROM_LOAD16_BYTE( "wcb__srom1.srom1",  0x100000, 0x080000, CRC(87a4a4d8) SHA1(60db2f466686481857eb39b90ac7a19d0a96adac) )
 ROM_END
 
-ROM_START( wcbowl13j )  /* Version 1.3 (3-tier board set: P/N 1059 Rev 3, P/N 1079 Rev 1 & P/N 1060 Rev 0) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "wcb_v1.3j_u83.u83", 0x00000, 0x20000, CRC(5805fd92) SHA1(6ec49958364731c9fdac42dfdf515f6a7a91366a) ) /* Labeled as "WCB V1.3J (U83)" */
-	ROM_LOAD16_BYTE( "wcb_v1.3j_u88.u88", 0x00001, 0x20000, CRC(b846660e) SHA1(afb3f459a819afee128849751840db3c02d4762a) ) /* Labeled as "WCB V1.3J (U88)" */
+ROM_START( wcbowl13j )  // Version 1.3 (3-tier board set: P/N 1059 Rev 3, P/N 1079 Rev 1 & P/N 1060 Rev 0)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "wcb_v1.3j_u83.u83", 0x00000, 0x20000, CRC(5805fd92) SHA1(6ec49958364731c9fdac42dfdf515f6a7a91366a) ) // Labeled as "WCB V1.3J (U83)"
+	ROM_LOAD16_BYTE( "wcb_v1.3j_u88.u88", 0x00001, 0x20000, CRC(b846660e) SHA1(afb3f459a819afee128849751840db3c02d4762a) ) // Labeled as "WCB V1.3J (U88)"
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "wcb_snd_v2.0.u17", 0x10000, 0x18000, CRC(c14907ba) SHA1(e52fb87c1f9b5847efc0ef15eb7e6c04dcf38110) ) /* Labeled as "WCB SND V2.0" */
+	ROM_LOAD( "wcb_snd_v2.0.u17", 0x10000, 0x18000, CRC(c14907ba) SHA1(e52fb87c1f9b5847efc0ef15eb7e6c04dcf38110) ) // Labeled as "WCB SND V2.0"
 	ROM_CONTINUE(                 0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	/* No known set specifically checks for this, however the GROM data may be in the form of four 8 Meg roms:
 	ROM_LOAD32_BYTE( "wcb_grom0_0_+.grm0_0", 0x000000, 0x100000, CRC(40837737) SHA1(f073943ec6f84285a8559553fb292ec1f8a629d0) ) Labeled as "WCB GROM0_0 *" ect
 	ROM_LOAD32_BYTE( "wcb_grom0_1_+.grm0_1", 0x000001, 0x100000, CRC(1615aee8) SHA1(6184919371a894b1d6f2e06a2b328cb55abed4a9) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2_+.grm0_2", 0x000002, 0x100000, CRC(d8e0b06e) SHA1(4981c0cf16df68a1b4da7ebf65ca587c21292478) )
 	ROM_LOAD32_BYTE( "wcb_grom0_3_+.grm0_3", 0x000003, 0x100000, CRC(0348a7f0) SHA1(462f77514c0e9a28da63732a4f31e9483d4c483e) )
 	*/
-	ROM_LOAD32_BYTE( "wcb_grom0_0.grm0_0", 0x000000, 0x080000, CRC(5d79aaae) SHA1(e1bf5c46843f69b8bac41dde73d89ba59b4c8b7f) ) /* May also be labeled as "WCB GRM0_0" ect */
+	ROM_LOAD32_BYTE( "wcb_grom0_0.grm0_0", 0x000000, 0x080000, CRC(5d79aaae) SHA1(e1bf5c46843f69b8bac41dde73d89ba59b4c8b7f) ) // May also be labeled as "WCB GRM0_0" ect
 	ROM_LOAD32_BYTE( "wcb_grom0_1.grm0_1", 0x000001, 0x080000, CRC(e26dcedb) SHA1(15441b97dd3d50d28007062fe28841fa3f762ec9) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2.grm0_2", 0x000002, 0x080000, CRC(32735875) SHA1(4017a8577d8efa8c5b95bd30723ebbf6ecaeba2b) )
 	ROM_LOAD32_BYTE( "wcb_grom0_3.grm0_3", 0x000003, 0x080000, CRC(019d0ab8) SHA1(3281eada296ad746da80ef6e5909c50b03b90d08) )
@@ -2880,30 +2847,30 @@ ROM_START( wcbowl13j )  /* Version 1.3 (3-tier board set: P/N 1059 Rev 3, P/N 10
 	ROM_FILL(                              0x400000, 0x480000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) /* Ensoniq 2MX16U 1350901801 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) // Ensoniq 2MX16U 1350901801 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "wcb__srom0.srom0",  0x000000, 0x080000, CRC(115bcd1f) SHA1(c321bf3145c11de1351c8f9cd554ab3d6600e854) )
 	ROM_LOAD16_BYTE( "wcb__srom1.srom1",  0x100000, 0x080000, CRC(87a4a4d8) SHA1(60db2f466686481857eb39b90ac7a19d0a96adac) )
 ROM_END
 
-ROM_START( wcbowl12 )   /* Version 1.2 (3-tier board set: P/N 1059 Rev 3, P/N 1079 Rev 1 & P/N 1060 Rev 0) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "wcb_v1.2_u83.u83", 0x00000, 0x20000, CRC(0602c5ce) SHA1(4339f77301f9c607c6f1dc81270d03681e874e69) ) /* Labeled as "WCB V1.2 (U83)" */
-	ROM_LOAD16_BYTE( "wcb_v1.2_u88.u88", 0x00001, 0x20000, CRC(49573493) SHA1(42813573f4ab951cd830193c0ffe2ce7d79c354b) ) /* Labeled as "WCB V1.2 (U88)" */
+ROM_START( wcbowl12 )   // Version 1.2 (3-tier board set: P/N 1059 Rev 3, P/N 1079 Rev 1 & P/N 1060 Rev 0)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "wcb_v1.2_u83.u83", 0x00000, 0x20000, CRC(0602c5ce) SHA1(4339f77301f9c607c6f1dc81270d03681e874e69) ) // Labeled as "WCB V1.2 (U83)"
+	ROM_LOAD16_BYTE( "wcb_v1.2_u88.u88", 0x00001, 0x20000, CRC(49573493) SHA1(42813573f4ab951cd830193c0ffe2ce7d79c354b) ) // Labeled as "WCB V1.2 (U88)"
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "wcb_snd_v2.0.u17", 0x10000, 0x18000, CRC(c14907ba) SHA1(e52fb87c1f9b5847efc0ef15eb7e6c04dcf38110) ) /* Labeled as "WCB SND V2.0" */
+	ROM_LOAD( "wcb_snd_v2.0.u17", 0x10000, 0x18000, CRC(c14907ba) SHA1(e52fb87c1f9b5847efc0ef15eb7e6c04dcf38110) ) // Labeled as "WCB SND V2.0"
 	ROM_CONTINUE(                 0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	/* No known set specifically checks for this, however the GROM data may be in the form of four 8 Meg ROMs:
 	ROM_LOAD32_BYTE( "wcb_grom0_0_+.grm0_0", 0x000000, 0x100000, CRC(40837737) SHA1(f073943ec6f84285a8559553fb292ec1f8a629d0) ) Labeled as "WCB GROM0_0 *" ect
 	ROM_LOAD32_BYTE( "wcb_grom0_1_+.grm0_1", 0x000001, 0x100000, CRC(1615aee8) SHA1(6184919371a894b1d6f2e06a2b328cb55abed4a9) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2_+.grm0_2", 0x000002, 0x100000, CRC(d8e0b06e) SHA1(4981c0cf16df68a1b4da7ebf65ca587c21292478) )
 	ROM_LOAD32_BYTE( "wcb_grom0_3_+.grm0_3", 0x000003, 0x100000, CRC(0348a7f0) SHA1(462f77514c0e9a28da63732a4f31e9483d4c483e) )
 	*/
-	ROM_LOAD32_BYTE( "wcb_grom0_0.grm0_0", 0x000000, 0x080000, CRC(5d79aaae) SHA1(e1bf5c46843f69b8bac41dde73d89ba59b4c8b7f) ) /* May also be labeled as "WCB GRM0_0" ect */
+	ROM_LOAD32_BYTE( "wcb_grom0_0.grm0_0", 0x000000, 0x080000, CRC(5d79aaae) SHA1(e1bf5c46843f69b8bac41dde73d89ba59b4c8b7f) ) // May also be labeled as "WCB GRM0_0" ect
 	ROM_LOAD32_BYTE( "wcb_grom0_1.grm0_1", 0x000001, 0x080000, CRC(e26dcedb) SHA1(15441b97dd3d50d28007062fe28841fa3f762ec9) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2.grm0_2", 0x000002, 0x080000, CRC(32735875) SHA1(4017a8577d8efa8c5b95bd30723ebbf6ecaeba2b) )
 	ROM_LOAD32_BYTE( "wcb_grom0_3.grm0_3", 0x000003, 0x080000, CRC(019d0ab8) SHA1(3281eada296ad746da80ef6e5909c50b03b90d08) )
@@ -2914,30 +2881,30 @@ ROM_START( wcbowl12 )   /* Version 1.2 (3-tier board set: P/N 1059 Rev 3, P/N 10
 	ROM_FILL(                              0x400000, 0x480000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) /* Ensoniq 2MX16U 1350901801 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) // Ensoniq 2MX16U 1350901801 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "wcb__srom0.srom0",  0x000000, 0x080000, CRC(115bcd1f) SHA1(c321bf3145c11de1351c8f9cd554ab3d6600e854) )
 	ROM_LOAD16_BYTE( "wcb__srom1.srom1",  0x100000, 0x080000, CRC(87a4a4d8) SHA1(60db2f466686481857eb39b90ac7a19d0a96adac) )
 ROM_END
 
-ROM_START( wcbowl11 )   /* Version 1.1 (3-tier board set: P/N 1059 Rev 3, P/N 1079 Rev 1 & P/N 1060 Rev 0) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "wcb_v1.1_u83.u83", 0x00000, 0x20000, CRC(d4902392) SHA1(7dfef3c15a8c6e9eab93742543afce4b39675d0d) ) /* Labeled as "WCB V1.1 (U83)" */
-	ROM_LOAD16_BYTE( "wcb_v1.1_u88.u88", 0x00001, 0x20000, CRC(ea81a95c) SHA1(c36e7b52435c68bec34d6fe22f623eac16879b50) ) /* Labeled as "WCB V1.1 (U88)" */
+ROM_START( wcbowl11 )   // Version 1.1 (3-tier board set: P/N 1059 Rev 3, P/N 1079 Rev 1 & P/N 1060 Rev 0)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "wcb_v1.1_u83.u83", 0x00000, 0x20000, CRC(d4902392) SHA1(7dfef3c15a8c6e9eab93742543afce4b39675d0d) ) // Labeled as "WCB V1.1 (U83)"
+	ROM_LOAD16_BYTE( "wcb_v1.1_u88.u88", 0x00001, 0x20000, CRC(ea81a95c) SHA1(c36e7b52435c68bec34d6fe22f623eac16879b50) ) // Labeled as "WCB V1.1 (U88)"
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "wcb_snd_v1.0.u17", 0x10000, 0x18000, CRC(28f14071) SHA1(fb5d6bb5a0337e93850ef46575601bf377cc0e93) ) /* Labeled as "WCB SND V1.0" */
+	ROM_LOAD( "wcb_snd_v1.0.u17", 0x10000, 0x18000, CRC(28f14071) SHA1(fb5d6bb5a0337e93850ef46575601bf377cc0e93) ) // Labeled as "WCB SND V1.0"
 	ROM_CONTINUE(                 0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	/* No known set specifically checks for this, however the GROM data may be in the form of four 8 Meg ROMs:
 	ROM_LOAD32_BYTE( "wcb_grom0_0_+.grm0_0", 0x000000, 0x100000, CRC(40837737) SHA1(f073943ec6f84285a8559553fb292ec1f8a629d0) ) Labeled as "WCB GROM0_0 *" ect
 	ROM_LOAD32_BYTE( "wcb_grom0_1_+.grm0_1", 0x000001, 0x100000, CRC(1615aee8) SHA1(6184919371a894b1d6f2e06a2b328cb55abed4a9) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2_+.grm0_2", 0x000002, 0x100000, CRC(d8e0b06e) SHA1(4981c0cf16df68a1b4da7ebf65ca587c21292478) )
 	ROM_LOAD32_BYTE( "wcb_grom0_3_+.grm0_3", 0x000003, 0x100000, CRC(0348a7f0) SHA1(462f77514c0e9a28da63732a4f31e9483d4c483e) )
 	*/
-	ROM_LOAD32_BYTE( "wcb_grom0_0.grm0_0", 0x000000, 0x080000, CRC(5d79aaae) SHA1(e1bf5c46843f69b8bac41dde73d89ba59b4c8b7f) ) /* May also be labeled as "WCB GRM0_0" ect */
+	ROM_LOAD32_BYTE( "wcb_grom0_0.grm0_0", 0x000000, 0x080000, CRC(5d79aaae) SHA1(e1bf5c46843f69b8bac41dde73d89ba59b4c8b7f) ) // May also be labeled as "WCB GRM0_0" ect
 	ROM_LOAD32_BYTE( "wcb_grom0_1.grm0_1", 0x000001, 0x080000, CRC(e26dcedb) SHA1(15441b97dd3d50d28007062fe28841fa3f762ec9) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2.grm0_2", 0x000002, 0x080000, CRC(32735875) SHA1(4017a8577d8efa8c5b95bd30723ebbf6ecaeba2b) )
 	ROM_LOAD32_BYTE( "wcb_grom0_3.grm0_3", 0x000003, 0x080000, CRC(019d0ab8) SHA1(3281eada296ad746da80ef6e5909c50b03b90d08) )
@@ -2948,30 +2915,30 @@ ROM_START( wcbowl11 )   /* Version 1.1 (3-tier board set: P/N 1059 Rev 3, P/N 10
 	ROM_FILL(                              0x400000, 0x480000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "wcb__srom0.srom0",  0x000000, 0x080000, CRC(115bcd1f) SHA1(c321bf3145c11de1351c8f9cd554ab3d6600e854) )
 	ROM_LOAD16_BYTE( "wcb__srom1.srom1",  0x100000, 0x080000, CRC(87a4a4d8) SHA1(60db2f466686481857eb39b90ac7a19d0a96adac) )
 ROM_END
 
-ROM_START( wcbowl10 )   /* Version 1.0 (3-tier board set: P/N 1059 Rev 3, P/N 1079 Rev 1 & P/N 1060 Rev 0) */
-	ROM_REGION16_BE( 0x80000, "user1", 0 )
-	ROM_LOAD16_BYTE( "wcb_v1.0_u83.u83", 0x00000, 0x20000, CRC(675ad0b1) SHA1(383fff7b4ad6acf62b76a573ec0fa214eccd7884) ) /* Labeled as "WCB V1.0 (U83)" */
-	ROM_LOAD16_BYTE( "wcb_v1.0_u88.u88", 0x00001, 0x20000, CRC(3afbec1c) SHA1(37f122c7e811354216aab94c274ecc7a0fc73530) ) /* Labeled as "WCB V1.0 (U88)" */
+ROM_START( wcbowl10 )   // Version 1.0 (3-tier board set: P/N 1059 Rev 3, P/N 1079 Rev 1 & P/N 1060 Rev 0)
+	ROM_REGION16_BE( 0x80000, "maindata", 0 )
+	ROM_LOAD16_BYTE( "wcb_v1.0_u83.u83", 0x00000, 0x20000, CRC(675ad0b1) SHA1(383fff7b4ad6acf62b76a573ec0fa214eccd7884) ) // Labeled as "WCB V1.0 (U83)"
+	ROM_LOAD16_BYTE( "wcb_v1.0_u88.u88", 0x00001, 0x20000, CRC(3afbec1c) SHA1(37f122c7e811354216aab94c274ecc7a0fc73530) ) // Labeled as "WCB V1.0 (U88)"
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "wcb_snd_v1.0.u17", 0x10000, 0x18000, CRC(28f14071) SHA1(fb5d6bb5a0337e93850ef46575601bf377cc0e93) ) /* Labeled as "WCB SND V1.0" */
+	ROM_LOAD( "wcb_snd_v1.0.u17", 0x10000, 0x18000, CRC(28f14071) SHA1(fb5d6bb5a0337e93850ef46575601bf377cc0e93) ) // Labeled as "WCB SND V1.0"
 	ROM_CONTINUE(                 0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	/* No known set specifically checks for this, however the GROM data may be in the form of four 8 Meg ROMs:
 	ROM_LOAD32_BYTE( "wcb_grom0_0_+.grm0_0", 0x000000, 0x100000, CRC(40837737) SHA1(f073943ec6f84285a8559553fb292ec1f8a629d0) ) Labeled as "WCB GROM0_0 *" ect
 	ROM_LOAD32_BYTE( "wcb_grom0_1_+.grm0_1", 0x000001, 0x100000, CRC(1615aee8) SHA1(6184919371a894b1d6f2e06a2b328cb55abed4a9) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2_+.grm0_2", 0x000002, 0x100000, CRC(d8e0b06e) SHA1(4981c0cf16df68a1b4da7ebf65ca587c21292478) )
 	ROM_LOAD32_BYTE( "wcb_grom0_3_+.grm0_3", 0x000003, 0x100000, CRC(0348a7f0) SHA1(462f77514c0e9a28da63732a4f31e9483d4c483e) )
 	*/
-	ROM_LOAD32_BYTE( "wcb_grom0_0.grm0_0", 0x000000, 0x080000, CRC(5d79aaae) SHA1(e1bf5c46843f69b8bac41dde73d89ba59b4c8b7f) ) /* May also be labeled as "WCB GRM0_0" ect */
+	ROM_LOAD32_BYTE( "wcb_grom0_0.grm0_0", 0x000000, 0x080000, CRC(5d79aaae) SHA1(e1bf5c46843f69b8bac41dde73d89ba59b4c8b7f) ) // May also be labeled as "WCB GRM0_0" ect
 	ROM_LOAD32_BYTE( "wcb_grom0_1.grm0_1", 0x000001, 0x080000, CRC(e26dcedb) SHA1(15441b97dd3d50d28007062fe28841fa3f762ec9) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2.grm0_2", 0x000002, 0x080000, CRC(32735875) SHA1(4017a8577d8efa8c5b95bd30723ebbf6ecaeba2b) )
 	ROM_LOAD32_BYTE( "wcb_grom0_3.grm0_3", 0x000003, 0x080000, CRC(019d0ab8) SHA1(3281eada296ad746da80ef6e5909c50b03b90d08) )
@@ -2982,25 +2949,25 @@ ROM_START( wcbowl10 )   /* Version 1.0 (3-tier board set: P/N 1059 Rev 3, P/N 10
 	ROM_FILL(                              0x400000, 0x480000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "wcb__srom0.srom0",  0x000000, 0x080000, CRC(115bcd1f) SHA1(c321bf3145c11de1351c8f9cd554ab3d6600e854) )
 	ROM_LOAD16_BYTE( "wcb__srom1.srom1",  0x100000, 0x080000, CRC(87a4a4d8) SHA1(60db2f466686481857eb39b90ac7a19d0a96adac) )
 ROM_END
 
-ROM_START( wcbowldx )   /* Deluxe version 2.00 (PCB P/N 1083 Rev 2), This version is derived from the Tournament v1.40 set, but tournament features have be removed/disabled */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( wcbowldx )   // Deluxe version 2.00 (PCB P/N 1083 Rev 2), This version is derived from the Tournament v1.40 set, but tournament features have be removed/disabled
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "wcbd_prom0_2.00.prom0", 0x00000, 0x20000, CRC(280df7f0) SHA1(dacffe8fc21263093b0f4a4fbf444abd49afbff1) )
 	ROM_LOAD32_BYTE( "wcbd_prom1_2.00.prom1", 0x00001, 0x20000, CRC(526eded0) SHA1(106d5503ed4db2411e1f3446d613eac525a8a9cc) )
 	ROM_LOAD32_BYTE( "wcbd_prom2_2.00.prom2", 0x00002, 0x20000, CRC(cb263173) SHA1(66acafaa9aba375124921774efc152e2a298a464) )
 	ROM_LOAD32_BYTE( "wcbd_prom3_2.00.prom3", 0x00003, 0x20000, CRC(43ecad0b) SHA1(890a843c162c052a790e432db10f968875be835c) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "wcbsnd_u88_4.01.u88", 0x10000, 0x18000, CRC(e97a6d28) SHA1(96d7b7856918abcc460083f2a46582ba2a689288) ) /* actually labeled as "WCBSND(U88)4.01" but may be labeled v4.0 */
+	ROM_LOAD( "wcbsnd_u88_4.01.u88", 0x10000, 0x18000, CRC(e97a6d28) SHA1(96d7b7856918abcc460083f2a46582ba2a689288) ) // actually labeled as "WCBSND(U88)4.01" but may be labeled v4.0
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "wcbd_grom0_0_s.grm0_0", 0x000000, 0x080000, CRC(6fcb4246) SHA1(91fb5d18ea9494b08251d1e611c80414df3aad66) )
 	ROM_LOAD32_BYTE( "wcbd_grom0_1_s.grm0_1", 0x000001, 0x080000, CRC(2ae31f45) SHA1(85218aa9a7ca7c6870427ffbd08b78255813ff90) )
 	ROM_LOAD32_BYTE( "wcbd_grom0_2_s.grm0_2", 0x000002, 0x080000, CRC(bccc0f35) SHA1(2389662e881e86f8cdb36eb2a082923d976676c8) )
@@ -3016,29 +2983,29 @@ ROM_START( wcbowldx )   /* Deluxe version 2.00 (PCB P/N 1083 Rev 2), This versio
 	ROM_FILL(                      0x500000, 0x380000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "wcb_srom0_s.srom0",  0x000000, 0x080000, CRC(d42dd283) SHA1(8ef75c398d1c51d2d7d299ac309a2352179864d9) ) /* Newer sound sample ROMs */
-	ROM_LOAD16_BYTE( "wcb_srom1_s.srom1",  0x200000, 0x080000, CRC(7a69ab54) SHA1(d1f9194446e235af69c6ff28af0dccc44ab9b5d3) ) /* Newer sound sample ROMs */
+	ROM_LOAD16_BYTE( "wcb_srom0_s.srom0",  0x000000, 0x080000, CRC(d42dd283) SHA1(8ef75c398d1c51d2d7d299ac309a2352179864d9) ) // Newer sound sample ROMs
+	ROM_LOAD16_BYTE( "wcb_srom1_s.srom1",  0x200000, 0x080000, CRC(7a69ab54) SHA1(d1f9194446e235af69c6ff28af0dccc44ab9b5d3) ) // Newer sound sample ROMs
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "wcb_srom2_s.srom2",  0x000000, 0x080000, CRC(346530a2) SHA1(9951971ad6d368fb718027e18331d12f0a72970c) ) /* Newer sound sample ROMs */
-	ROM_LOAD16_BYTE( "wcb_srom3_s.srom3",  0x200000, 0x040000, CRC(1dfe3a31) SHA1(94947f495692288fbf14fc7796a84c5548a2e8a8) ) /* Newer sound sample ROMs, ROM is a 27C020 in this set */
+	ROM_LOAD16_BYTE( "wcb_srom2_s.srom2",  0x000000, 0x080000, CRC(346530a2) SHA1(9951971ad6d368fb718027e18331d12f0a72970c) ) // Newer sound sample ROMs
+	ROM_LOAD16_BYTE( "wcb_srom3_s.srom3",  0x200000, 0x040000, CRC(1dfe3a31) SHA1(94947f495692288fbf14fc7796a84c5548a2e8a8) ) // Newer sound sample ROMs, ROM is a 27C020 in this set
 ROM_END
 
-ROM_START( wcbowl140 )  /* Version 1.40 Tournament (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
-	ROM_LOAD32_BYTE( "wcbf_prom0_1.40.prom0", 0x00000, 0x20000, CRC(9d31ceb1) SHA1(d147976a763ba1e18d861351b12c5d275b94a562) ) /* First WCB set to contain the Flash Bowling */
-	ROM_LOAD32_BYTE( "wcbf_prom1_1.40.prom1", 0x00001, 0x20000, CRC(c6669452) SHA1(ba58da7bee5120682e2306454da287c969014899) ) /* Has BLUE background like the WCB Deluxe set */
+ROM_START( wcbowl140 )  // Version 1.40 Tournament (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
+	ROM_LOAD32_BYTE( "wcbf_prom0_1.40.prom0", 0x00000, 0x20000, CRC(9d31ceb1) SHA1(d147976a763ba1e18d861351b12c5d275b94a562) ) // First WCB set to contain the Flash Bowling
+	ROM_LOAD32_BYTE( "wcbf_prom1_1.40.prom1", 0x00001, 0x20000, CRC(c6669452) SHA1(ba58da7bee5120682e2306454da287c969014899) ) // Has BLUE background like the WCB Deluxe set
 	ROM_LOAD32_BYTE( "wcbf_prom2_1.40.prom2", 0x00002, 0x20000, CRC(d2fc4d09) SHA1(17983759ad6137a2e67b8414ea58880865311534) )
 	ROM_LOAD32_BYTE( "wcbf_prom3_1.40.prom3", 0x00003, 0x20000, CRC(c41258a4) SHA1(182e8a25bdb126a4de8a44a1c26fd8b66f06d66e) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "wcbsnd_u88_4.01.u88", 0x10000, 0x18000, CRC(e97a6d28) SHA1(96d7b7856918abcc460083f2a46582ba2a689288) ) /* actually labeled as "WCBSND(U88)4.01" but may be labeled v4.0 */
+	ROM_LOAD( "wcbsnd_u88_4.01.u88", 0x10000, 0x18000, CRC(e97a6d28) SHA1(96d7b7856918abcc460083f2a46582ba2a689288) ) // actually labeled as "WCBSND(U88)4.01" but may be labeled v4.0
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
 	ROM_REGION( 0x2000, "pic", 0 ) // PIC16C54
 	ROM_LOAD( "itbwl-3 1997 it,inc.1996", 0x0000, 0x1fff, CRC(1461cbe0) SHA1(97cc1f985d9c8bbe3fd829681883b6c4ae15c5bd) ) // not hooked up
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "wcb_grom0_0_s.grm0_0", 0x000000, 0x080000, CRC(6fcb4246) SHA1(91fb5d18ea9494b08251d1e611c80414df3aad66) )
 	ROM_LOAD32_BYTE( "wcb_grom0_1_s.grm0_1", 0x000001, 0x080000, CRC(2ae31f45) SHA1(85218aa9a7ca7c6870427ffbd08b78255813ff90) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2_s.grm0_2", 0x000002, 0x080000, CRC(bccc0f35) SHA1(2389662e881e86f8cdb36eb2a082923d976676c8) )
@@ -3054,29 +3021,29 @@ ROM_START( wcbowl140 )  /* Version 1.40 Tournament (PCB P/N 1083 Rev 2) */
 	ROM_FILL(                                0x500000, 0x380000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "wcb_srom0_s.srom0",  0x000000, 0x080000, CRC(d42dd283) SHA1(8ef75c398d1c51d2d7d299ac309a2352179864d9) ) /* Newer sound sample ROMs */
-	ROM_LOAD16_BYTE( "wcb_srom1_s.srom1",  0x200000, 0x080000, CRC(7a69ab54) SHA1(d1f9194446e235af69c6ff28af0dccc44ab9b5d3) ) /* Newer sound sample ROMs */
+	ROM_LOAD16_BYTE( "wcb_srom0_s.srom0",  0x000000, 0x080000, CRC(d42dd283) SHA1(8ef75c398d1c51d2d7d299ac309a2352179864d9) ) // Newer sound sample ROMs
+	ROM_LOAD16_BYTE( "wcb_srom1_s.srom1",  0x200000, 0x080000, CRC(7a69ab54) SHA1(d1f9194446e235af69c6ff28af0dccc44ab9b5d3) ) // Newer sound sample ROMs
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "wcb_srom2_s.srom2",  0x000000, 0x080000, CRC(346530a2) SHA1(9951971ad6d368fb718027e18331d12f0a72970c) ) /* Newer sound sample ROMs */
-	ROM_LOAD16_BYTE( "wcb_srom3_s.srom3",  0x200000, 0x040000, CRC(1dfe3a31) SHA1(94947f495692288fbf14fc7796a84c5548a2e8a8) ) /* Newer sound sample ROMs, ROM is a 27C020 in this set */
+	ROM_LOAD16_BYTE( "wcb_srom2_s.srom2",  0x000000, 0x080000, CRC(346530a2) SHA1(9951971ad6d368fb718027e18331d12f0a72970c) ) // Newer sound sample ROMs
+	ROM_LOAD16_BYTE( "wcb_srom3_s.srom3",  0x200000, 0x040000, CRC(1dfe3a31) SHA1(94947f495692288fbf14fc7796a84c5548a2e8a8) ) // Newer sound sample ROMs, ROM is a 27C020 in this set
 ROM_END
 
-ROM_START( wcbowl130 )  /* Version 1.30 Tournament (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
-	ROM_LOAD32_BYTE( "wcb_prom0_v1.30t.prom0", 0x00000, 0x20000, CRC(fbcde4e0) SHA1(8174c045686305c398f0414e2dea666ee4f9d668) ) /* Does NOT contain the Flash Bowling variation game */
-	ROM_LOAD32_BYTE( "wcb_prom1_v1.30t.prom1", 0x00001, 0x20000, CRC(f4b8e7c3) SHA1(29471a464e783e820d7cde356b49d26b9394f513) ) /* Has RED background like other WCB sets */
+ROM_START( wcbowl130 )  // Version 1.30 Tournament (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
+	ROM_LOAD32_BYTE( "wcb_prom0_v1.30t.prom0", 0x00000, 0x20000, CRC(fbcde4e0) SHA1(8174c045686305c398f0414e2dea666ee4f9d668) ) // Does NOT contain the Flash Bowling variation game
+	ROM_LOAD32_BYTE( "wcb_prom1_v1.30t.prom1", 0x00001, 0x20000, CRC(f4b8e7c3) SHA1(29471a464e783e820d7cde356b49d26b9394f513) ) // Has RED background like other WCB sets
 	ROM_LOAD32_BYTE( "wcb_prom2_v1.30t.prom2", 0x00002, 0x20000, CRC(f441afae) SHA1(31d619e63f951cfb08481474f08d278aeaa15c46) )
 	ROM_LOAD32_BYTE( "wcb_prom3_v1.30t.prom3", 0x00003, 0x20000, CRC(47e26d4b) SHA1(44459daef1ffe19640b26adcf122dfcd4a327a68) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "wcbsnd_u88_4.01.u88", 0x10000, 0x18000, CRC(e97a6d28) SHA1(96d7b7856918abcc460083f2a46582ba2a689288) ) /* actually labeled as "WCBSND(U88)4.01" but may be labeled v4.0 */
+	ROM_LOAD( "wcbsnd_u88_4.01.u88", 0x10000, 0x18000, CRC(e97a6d28) SHA1(96d7b7856918abcc460083f2a46582ba2a689288) ) // actually labeled as "WCBSND(U88)4.01" but may be labeled v4.0
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
 	ROM_REGION( 0x2000, "pic", 0 ) // PIC16C54
 	ROM_LOAD( "itbwl-3 1997 it,inc.1996", 0x0000, 0x1fff, CRC(1461cbe0) SHA1(97cc1f985d9c8bbe3fd829681883b6c4ae15c5bd) ) // not hooked up
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "wcb_grom0_0_s.grm0_0", 0x000000, 0x080000, CRC(6fcb4246) SHA1(91fb5d18ea9494b08251d1e611c80414df3aad66) )
 	ROM_LOAD32_BYTE( "wcb_grom0_1_s.grm0_1", 0x000001, 0x080000, CRC(2ae31f45) SHA1(85218aa9a7ca7c6870427ffbd08b78255813ff90) )
 	ROM_LOAD32_BYTE( "wcb_grom0_2_s.grm0_2", 0x000002, 0x080000, CRC(bccc0f35) SHA1(2389662e881e86f8cdb36eb2a082923d976676c8) )
@@ -3092,28 +3059,28 @@ ROM_START( wcbowl130 )  /* Version 1.30 Tournament (PCB P/N 1083 Rev 2) */
 	ROM_FILL(                                0x500000, 0x380000, 0xff )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "wcb_srom0_s.srom0",  0x000000, 0x080000, CRC(d42dd283) SHA1(8ef75c398d1c51d2d7d299ac309a2352179864d9) ) /* Newer sound sample ROMs */
-	ROM_LOAD16_BYTE( "wcb_srom1_s.srom1",  0x200000, 0x080000, CRC(7a69ab54) SHA1(d1f9194446e235af69c6ff28af0dccc44ab9b5d3) ) /* Newer sound sample ROMs */
+	ROM_LOAD16_BYTE( "wcb_srom0_s.srom0",  0x000000, 0x080000, CRC(d42dd283) SHA1(8ef75c398d1c51d2d7d299ac309a2352179864d9) ) // Newer sound sample ROMs
+	ROM_LOAD16_BYTE( "wcb_srom1_s.srom1",  0x200000, 0x080000, CRC(7a69ab54) SHA1(d1f9194446e235af69c6ff28af0dccc44ab9b5d3) ) // Newer sound sample ROMs
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "wcb_srom2_s.srom2",  0x000000, 0x080000, CRC(346530a2) SHA1(9951971ad6d368fb718027e18331d12f0a72970c) ) /* Newer sound sample ROMs */
-	ROM_LOAD16_BYTE( "wcb_srom3_s.srom3",  0x200000, 0x040000, CRC(1dfe3a31) SHA1(94947f495692288fbf14fc7796a84c5548a2e8a8) ) /* Newer sound sample ROMs, ROM is a 27C020 in this set */
+	ROM_LOAD16_BYTE( "wcb_srom2_s.srom2",  0x000000, 0x080000, CRC(346530a2) SHA1(9951971ad6d368fb718027e18331d12f0a72970c) ) // Newer sound sample ROMs
+	ROM_LOAD16_BYTE( "wcb_srom3_s.srom3",  0x200000, 0x040000, CRC(1dfe3a31) SHA1(94947f495692288fbf14fc7796a84c5548a2e8a8) ) // Newer sound sample ROMs, ROM is a 27C020 in this set
 ROM_END
 
 
 ROM_START( drivedge )
-	ROM_REGION32_BE( 0x8000, "user1", 0 ) /* Main board P/N 1053 REV3 */
-	ROM_LOAD( "itde_er_u130_v1.0.u130", 0x00000, 0x8000, CRC(873579b0) SHA1(ce7fcbea780aee376c2f4c659a75fcf6b7abbdb4) ) /* Labeled as "ITDE ER (U130) V1.0" */
+	ROM_REGION32_BE( 0x8000, "maindata", 0 ) // Main board P/N 1053 REV3
+	ROM_LOAD( "itde_er_u130_v1.0.u130", 0x00000, 0x8000, CRC(873579b0) SHA1(ce7fcbea780aee376c2f4c659a75fcf6b7abbdb4) ) // Labeled as "ITDE ER (U130) V1.0"
 
-	ROM_REGION( 0x28000, "soundcpu", 0 ) /* Sound board P/N 1054 REV2 */
-	ROM_LOAD( "itde_sndu17_v1.2.u17", 0x10000, 0x18000, CRC(6e8ca8bc) SHA1(98ad36877b40123b0396943754234df8de183687) ) /* Labeled as "ITDE SND(U17) V1.2" */
+	ROM_REGION( 0x28000, "soundcpu", 0 ) // Sound board P/N 1054 REV2
+	ROM_LOAD( "itde_sndu17_v1.2.u17", 0x10000, 0x18000, CRC(6e8ca8bc) SHA1(98ad36877b40123b0396943754234df8de183687) ) // Labeled as "ITDE SND(U17) V1.2"
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
-	ROM_REGION( 0x10000, "cpu4", 0 ) /* Network daughterboard P/N 1055 REV3 */
-	ROM_LOAD( "vidnet_v1.0_u7.u7", 0x08000, 0x08000, CRC(dea8b9de) SHA1(46ba3a549522d7e6a32792814a04fd34839c7e55) ) /* Labeled as "VIDNET V1.0 (U7)" */
+	ROM_REGION( 0x10000, "cpu4", 0 ) // Network daughterboard P/N 1055 REV3
+	ROM_LOAD( "vidnet_v1.0_u7.u7", 0x08000, 0x08000, CRC(dea8b9de) SHA1(46ba3a549522d7e6a32792814a04fd34839c7e55) ) // Labeled as "VIDNET V1.0 (U7)"
 
-	ROM_REGION( 0xa00000, "gfx1", 0 ) /* ROM board P/N 1049 REV1 */
-	ROM_LOAD32_BYTE( "grom0_itde_gv1.2.grom0",   0x000000, 0x80000, CRC(7fe5b01b) SHA1(b31e48971253d77e2277434b1b1590cbbea2209f) ) /* These 8 labeled as GV1.2 */
+	ROM_REGION( 0xa00000, "grom", 0 ) // ROM board P/N 1049 REV1
+	ROM_LOAD32_BYTE( "grom0_itde_gv1.2.grom0",   0x000000, 0x80000, CRC(7fe5b01b) SHA1(b31e48971253d77e2277434b1b1590cbbea2209f) ) // These 8 labeled as GV1.2
 	ROM_LOAD32_BYTE( "grom5_itde_gv1.2.grom5",   0x000001, 0x80000, CRC(5ea6dbc2) SHA1(c2de55ec6a527d0555504070a7ecb43b8aa797ea) )
 	ROM_LOAD32_BYTE( "grom10_itde_gv1.2.grom10", 0x000002, 0x80000, CRC(76be06cd) SHA1(b533a07853b531e318c5a85139a74ca3edb9089f) )
 	ROM_LOAD32_BYTE( "grom15_itde_gv1.2.grom15", 0x000003, 0x80000, CRC(119bf46b) SHA1(67f5434581d5f0042c7acd36d2c64ffe69efaa76) )
@@ -3121,41 +3088,41 @@ ROM_START( drivedge )
 	ROM_LOAD32_BYTE( "grom6_itde_gv1.2.grom6",   0x200001, 0x80000, CRC(2cb76b9a) SHA1(0db32cb572121c8a751dcce55b94adc48f9be738) )
 	ROM_LOAD32_BYTE( "grom11_itde_gv1.2.grom11", 0x200002, 0x80000, CRC(5d29018c) SHA1(11f346afedfac4f7b0d5d4995dd38ec2d7fc7777) )
 	ROM_LOAD32_BYTE( "grom16_itde_gv1.2.grom16", 0x200003, 0x80000, CRC(476940fb) SHA1(00dab9aeb0d5cc23e4f78f15cb976ddcafa63b42) )
-	ROM_LOAD32_BYTE( "grom2_itde_dv1.2.grom2",   0x400000, 0x80000, CRC(5ccc4c62) SHA1(fc49bba2208a1157fe0948fcadac79c597f382c4) ) /* These 4 labeled as DV1.2 */
+	ROM_LOAD32_BYTE( "grom2_itde_dv1.2.grom2",   0x400000, 0x80000, CRC(5ccc4c62) SHA1(fc49bba2208a1157fe0948fcadac79c597f382c4) ) // These 4 labeled as DV1.2
 	ROM_LOAD32_BYTE( "grom7_itde_dv1.2.grom7",   0x400001, 0x80000, CRC(45367070) SHA1(c7cf074f95cf287c4caf70d2286608c50ad01044) )
 	ROM_LOAD32_BYTE( "grom12_itde_dv1.2.grom12", 0x400002, 0x80000, CRC(b978ef5a) SHA1(d1fce9c7966b8324ce1a4a99d92cd69ec32f5c47) )
 	ROM_LOAD32_BYTE( "grom17_itde_dv1.2.grom17", 0x400003, 0x80000, CRC(eff8abac) SHA1(83da116368fae05a0c3c12ea72656681912a1175) )
-	ROM_LOAD32_BYTE( "grom3_itde_mv1.2.grom3",   0x600000, 0x20000, CRC(9cd252c9) SHA1(7db6bdeeb2967154cd104ac2e20761cb99046d70) ) /* These 4 labeled as MV1.2 */
+	ROM_LOAD32_BYTE( "grom3_itde_mv1.2.grom3",   0x600000, 0x20000, CRC(9cd252c9) SHA1(7db6bdeeb2967154cd104ac2e20761cb99046d70) ) // These 4 labeled as MV1.2
 	ROM_LOAD32_BYTE( "grom8_itde_mv1.2.grom8",   0x600001, 0x20000, CRC(43f10ca4) SHA1(9eb0e2fd1adc25b334f86582be8e5960de0caba7) )
 	ROM_LOAD32_BYTE( "grom13_itde_mv1.2.grom13", 0x600002, 0x20000, CRC(431d131e) SHA1(efe5a4aa65fde1f094adc6e701db8be94a4b625c) )
 	ROM_LOAD32_BYTE( "grom18_itde_mv1.2.grom18", 0x600003, 0x20000, CRC(b09e0d9c) SHA1(b14ff39b028c0070ccca601c21542896168bd0b7) )
-	ROM_LOAD32_BYTE( "grom4_itde_pv1.6.grom4",   0x800000, 0x20000, CRC(c499cdfa) SHA1(acec47fb606f999f9d88fdce1b5860d5afcd5106) ) /* These 4 labeled as PV1.6 */
+	ROM_LOAD32_BYTE( "grom4_itde_pv1.6.grom4",   0x800000, 0x20000, CRC(c499cdfa) SHA1(acec47fb606f999f9d88fdce1b5860d5afcd5106) ) // These 4 labeled as PV1.6
 	ROM_LOAD32_BYTE( "grom9_itde_pv1.6.grom9",   0x800001, 0x20000, CRC(e5f21566) SHA1(ce41c7e808799eea217e14e9aabe6ce617f87287) )
 	ROM_LOAD32_BYTE( "grom14_itde_pv1.6.grom14", 0x800002, 0x20000, CRC(09dbe382) SHA1(a85ecba433eb9bb75b4060d1b6391f66f4c8146c) )
 	ROM_LOAD32_BYTE( "grom19_itde_pv1.6.grom19", 0x800003, 0x20000, CRC(4ced78e1) SHA1(7995c8684ca28cbdf620d10297850463fa473fe8) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 ) /* Sound board P/N 1054 REV2 */
-	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 ) // Sound board P/N 1054 REV2
+	ROM_LOAD16_BYTE( "ensoniq.2m", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) /* Sound board P/N 1054 REV2 */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) // Sound board P/N 1054 REV2
 	ROM_LOAD16_BYTE( "srom0_itde_v1.0.srom0", 0x000000, 0x80000, CRC(649c685f) SHA1(95d8f257cac621c8bd4abaa88ea5f7b3b8adea4c) )
 	ROM_LOAD16_BYTE( "srom1_itde_v1.0.srom1", 0x100000, 0x80000, CRC(df4fff97) SHA1(3c43623bfc176639417e86a037b92026e84a5dce) )
 ROM_END
 
 
-ROM_START( sftm )   /* Version 1.12, P/N 1064 REV 1 Mainboard, P/N 1073 REV 0 ROM board, P/N 1066 REV 2 Sound board */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( sftm )   // Version 1.12, P/N 1064 REV 1 Mainboard, P/N 1073 REV 0 ROM board, P/N 1066 REV 2 Sound board
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "sfm_prom0_v1.12.prom0", 0x00000, 0x40000, CRC(9d09355c) SHA1(ca8c31d580e4b18b630c38e4ac1c353cf27ab4a2) )
 	ROM_LOAD32_BYTE( "sfm_prom1_v1.12.prom1", 0x00001, 0x40000, CRC(a58ac6a9) SHA1(a481a789c397151efcbec7ad9983daa30f289d4e) )
 	ROM_LOAD32_BYTE( "sfm_prom2_v1.12.prom2", 0x00002, 0x40000, CRC(2f21a4f6) SHA1(66b158c40375a0f729d44fd4c888cf6a5bbe2bf1) )
 	ROM_LOAD32_BYTE( "sfm_prom3_v1.12.prom3", 0x00003, 0x40000, CRC(d26648d9) SHA1(9e3e1fa104da680c4a704d10d6518eea6382f039) )
 
 	ROM_REGION( 0x48000, "soundcpu", 0 )
-	ROM_LOAD( "sfm_snd_v1.u23", 0x10000, 0x38000, CRC(10d85366) SHA1(10d539c3ba37e277642c0c5888cb1886fb0f55fc) ) /* Labeled as "SFM SND V1 U23" */
+	ROM_LOAD( "sfm_snd_v1.u23", 0x10000, 0x38000, CRC(10d85366) SHA1(10d539c3ba37e277642c0c5888cb1886fb0f55fc) ) // Labeled as "SFM SND V1 U23"
 	ROM_CONTINUE(               0x08000, 0x08000 )
 
-	ROM_REGION( 0x2080000, "gfx1", 0 )
-	ROM_LOAD32_BYTE( "rm0-0.grm0_0", 0x0000000, 0x400000, CRC(09ef29cb) SHA1(430da5b00554582391478849d5b1547fe12eedbe) ) /* KM 23C3200AG-12 mask ROMs */
+	ROM_REGION( 0x2080000, "grom", 0 )
+	ROM_LOAD32_BYTE( "rm0-0.grm0_0", 0x0000000, 0x400000, CRC(09ef29cb) SHA1(430da5b00554582391478849d5b1547fe12eedbe) ) // KM 23C3200AG-12 mask ROMs
 	ROM_LOAD32_BYTE( "rm0-1.grm0_1", 0x0000001, 0x400000, CRC(6f5910fa) SHA1(1979d19dd36a9118dfaf021e05302982be5dbe69) )
 	ROM_LOAD32_BYTE( "rm0-2.grm0_2", 0x0000002, 0x400000, CRC(b8a2add5) SHA1(62e5bef936f014ac836c0cd5322eaba7018496b4) )
 	ROM_LOAD32_BYTE( "rm0-3.grm0_3", 0x0000003, 0x400000, CRC(6b6ff867) SHA1(72bc95ef361f9238602f0e03aed0adac8b59d227) )
@@ -3164,7 +3131,7 @@ ROM_START( sftm )   /* Version 1.12, P/N 1064 REV 1 Mainboard, P/N 1073 REV 0 RO
 	ROM_LOAD32_BYTE( "rm1-2.grm1_2", 0x1000002, 0x400000, CRC(903e56c2) SHA1(843ed9855ffdf37b100b3c5614139d552fd9cd6d) )
 	ROM_LOAD32_BYTE( "rm1-3.grm1_3", 0x1000003, 0x400000, CRC(fac35686) SHA1(ba99ab265620575c14c46806dc543d1f9fd24462) )
 
-	/* GROM2_0 through GROM2_3 are unpopulated 23C32000 mask ROM locations */
+	// GROM2_0 through GROM2_3 are unpopulated 23C32000 mask ROM locations
 
 	ROM_LOAD32_BYTE( "sfm_grm3_0.grm3_0", 0x2000000, 0x020000, CRC(3e1f76f7) SHA1(8aefe376e7248a583a6af02e5f9b2a4b48cc91d7) )
 	ROM_LOAD32_BYTE( "sfm_grm3_1.grm3_1", 0x2000001, 0x020000, CRC(578054b6) SHA1(99201959de28dbfd7692cedea4485751d3d4788f) )
@@ -3172,25 +3139,25 @@ ROM_START( sftm )   /* Version 1.12, P/N 1064 REV 1 Mainboard, P/N 1073 REV 0 RO
 	ROM_LOAD32_BYTE( "sfm_grm3_3.grm3_3", 0x2000003, 0x020000, CRC(cd38d1d6) SHA1(0cea60d6897b34eeb13997030f6ee7e1dfb3c833) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "sfm_srom0.srom0", 0x000000, 0x200000, CRC(6ca1d3fc) SHA1(904f4c55a1bc83531a6d87ff706afd8cdfaee83b) ) /* Custom 42 Pin mask ROM sample set */
+	ROM_LOAD16_BYTE( "sfm_srom0.srom0", 0x000000, 0x200000, CRC(6ca1d3fc) SHA1(904f4c55a1bc83531a6d87ff706afd8cdfaee83b) ) // Custom 42 Pin mask ROM sample set
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.3", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "sfm_srom3.srom3", 0x000000, 0x080000, CRC(4f181534) SHA1(e858a33b22558665427146ec79dfba48edc20c2c) )
 ROM_END
 
-ROM_START( sftm111 )   /* Version 1.11, P/N 1064 REV 1 Mainboard, P/N 1073 REV 0 ROM board, P/N 1066 REV 2 Sound board */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
-	ROM_LOAD32_BYTE( "sfm_prom0_v1.11.prom0", 0x00000, 0x40000, CRC(28187ddc) SHA1(7e4fa285be9389c913fca849098a7c0d9404df7a) ) /* CAPCOM labels */
+ROM_START( sftm111 )   // Version 1.11, P/N 1064 REV 1 Mainboard, P/N 1073 REV 0 ROM board, P/N 1066 REV 2 Sound board
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
+	ROM_LOAD32_BYTE( "sfm_prom0_v1.11.prom0", 0x00000, 0x40000, CRC(28187ddc) SHA1(7e4fa285be9389c913fca849098a7c0d9404df7a) ) // CAPCOM labels
 	ROM_LOAD32_BYTE( "sfm_prom1_v1.11.prom1", 0x00001, 0x40000, CRC(ec2ce6fa) SHA1(b79aebb73ba77c2ebe081142853e81473743ac46) )
 	ROM_LOAD32_BYTE( "sfm_prom2_v1.11.prom2", 0x00002, 0x40000, CRC(be20510e) SHA1(52e154fe4b77e461961fa23593383ef9b6dfb92f) )
 	ROM_LOAD32_BYTE( "sfm_prom3_v1.11.prom3", 0x00003, 0x40000, CRC(eead342f) SHA1(b6df89527b527543df5535ef00945e64ff321e09) )
 
 	ROM_REGION( 0x48000, "soundcpu", 0 )
-	ROM_LOAD( "sfm_snd_v1.u23", 0x10000, 0x38000, CRC(10d85366) SHA1(10d539c3ba37e277642c0c5888cb1886fb0f55fc) ) /* Labeled as "SFM SND V1 U23" */
+	ROM_LOAD( "sfm_snd_v1.u23", 0x10000, 0x38000, CRC(10d85366) SHA1(10d539c3ba37e277642c0c5888cb1886fb0f55fc) ) // Labeled as "SFM SND V1 U23"
 	ROM_CONTINUE(               0x08000, 0x08000 )
 
-	ROM_REGION( 0x2080000, "gfx1", 0 )
-	ROM_LOAD32_BYTE( "rm0-0.grm0_0", 0x0000000, 0x400000, CRC(09ef29cb) SHA1(430da5b00554582391478849d5b1547fe12eedbe) ) /* KM 23C3200AG-12 mask ROMs */
+	ROM_REGION( 0x2080000, "grom", 0 )
+	ROM_LOAD32_BYTE( "rm0-0.grm0_0", 0x0000000, 0x400000, CRC(09ef29cb) SHA1(430da5b00554582391478849d5b1547fe12eedbe) ) // KM 23C3200AG-12 mask ROMs
 	ROM_LOAD32_BYTE( "rm0-1.grm0_1", 0x0000001, 0x400000, CRC(6f5910fa) SHA1(1979d19dd36a9118dfaf021e05302982be5dbe69) )
 	ROM_LOAD32_BYTE( "rm0-2.grm0_2", 0x0000002, 0x400000, CRC(b8a2add5) SHA1(62e5bef936f014ac836c0cd5322eaba7018496b4) )
 	ROM_LOAD32_BYTE( "rm0-3.grm0_3", 0x0000003, 0x400000, CRC(6b6ff867) SHA1(72bc95ef361f9238602f0e03aed0adac8b59d227) )
@@ -3199,7 +3166,7 @@ ROM_START( sftm111 )   /* Version 1.11, P/N 1064 REV 1 Mainboard, P/N 1073 REV 0
 	ROM_LOAD32_BYTE( "rm1-2.grm1_2", 0x1000002, 0x400000, CRC(903e56c2) SHA1(843ed9855ffdf37b100b3c5614139d552fd9cd6d) )
 	ROM_LOAD32_BYTE( "rm1-3.grm1_3", 0x1000003, 0x400000, CRC(fac35686) SHA1(ba99ab265620575c14c46806dc543d1f9fd24462) )
 
-	/* GROM2_0 through GROM2_3 are unpopulated 23C32000 mask ROM locations */
+	// GROM2_0 through GROM2_3 are unpopulated 23C32000 mask ROM locations
 
 	ROM_LOAD32_BYTE( "sfm_grm3_0.grm3_0", 0x2000000, 0x020000, CRC(3e1f76f7) SHA1(8aefe376e7248a583a6af02e5f9b2a4b48cc91d7) )
 	ROM_LOAD32_BYTE( "sfm_grm3_1.grm3_1", 0x2000001, 0x020000, CRC(578054b6) SHA1(99201959de28dbfd7692cedea4485751d3d4788f) )
@@ -3207,25 +3174,25 @@ ROM_START( sftm111 )   /* Version 1.11, P/N 1064 REV 1 Mainboard, P/N 1073 REV 0
 	ROM_LOAD32_BYTE( "sfm_grm3_3.grm3_3", 0x2000003, 0x020000, CRC(cd38d1d6) SHA1(0cea60d6897b34eeb13997030f6ee7e1dfb3c833) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "sfm_srom0.srom0", 0x000000, 0x200000, CRC(6ca1d3fc) SHA1(904f4c55a1bc83531a6d87ff706afd8cdfaee83b) ) /* Custom 42 Pin mask ROM sample set */
+	ROM_LOAD16_BYTE( "sfm_srom0.srom0", 0x000000, 0x200000, CRC(6ca1d3fc) SHA1(904f4c55a1bc83531a6d87ff706afd8cdfaee83b) ) // Custom 42 Pin mask ROM sample set
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.3", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "sfm_srom3.srom3", 0x000000, 0x080000, CRC(4f181534) SHA1(e858a33b22558665427146ec79dfba48edc20c2c) )
 ROM_END
 
-ROM_START( sftm110 )   /* Version 1.10, P/N 1064 REV 1 Mainboard, P/N 1073 REV 0 ROM board, P/N 1066 REV 2 Sound board */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
-	ROM_LOAD32_BYTE( "sfm_prom0_v1.1.prom0", 0x00000, 0x40000, CRC(00c0c63c) SHA1(39f614cca51fe7843c2158b6d9abdc52dc1b0bef) ) /* CAPCOM labels */
+ROM_START( sftm110 )   // Version 1.10, P/N 1064 REV 1 Mainboard, P/N 1073 REV 0 ROM board, P/N 1066 REV 2 Sound board
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
+	ROM_LOAD32_BYTE( "sfm_prom0_v1.1.prom0", 0x00000, 0x40000, CRC(00c0c63c) SHA1(39f614cca51fe7843c2158b6d9abdc52dc1b0bef) ) // CAPCOM labels
 	ROM_LOAD32_BYTE( "sfm_prom1_v1.1.prom1", 0x00001, 0x40000, CRC(d4d2a67e) SHA1(88069caf171bb9c5602bc493f1f1dafa26d2fc78) )
 	ROM_LOAD32_BYTE( "sfm_prom2_v1.1.prom2", 0x00002, 0x40000, CRC(d7b36c92) SHA1(fbdb6f3636b84b76cf42351392492b791429a0e4) )
 	ROM_LOAD32_BYTE( "sfm_prom3_v1.1.prom3", 0x00003, 0x40000, CRC(be3efdbd) SHA1(169aff265d1520031988e51083d1f208cf2529b4) )
 
 	ROM_REGION( 0x48000, "soundcpu", 0 )
-	ROM_LOAD( "sfm_snd_v1.u23", 0x10000, 0x38000, CRC(10d85366) SHA1(10d539c3ba37e277642c0c5888cb1886fb0f55fc) ) /* Labeled as "SFM SND V1 U23" */
+	ROM_LOAD( "sfm_snd_v1.u23", 0x10000, 0x38000, CRC(10d85366) SHA1(10d539c3ba37e277642c0c5888cb1886fb0f55fc) ) // Labeled as "SFM SND V1 U23"
 	ROM_CONTINUE(               0x08000, 0x08000 )
 
-	ROM_REGION( 0x2080000, "gfx1", 0 )
-	ROM_LOAD32_BYTE( "rm0-0.grm0_0", 0x0000000, 0x400000, CRC(09ef29cb) SHA1(430da5b00554582391478849d5b1547fe12eedbe) ) /* KM 23C3200AG-12 mask ROMs */
+	ROM_REGION( 0x2080000, "grom", 0 )
+	ROM_LOAD32_BYTE( "rm0-0.grm0_0", 0x0000000, 0x400000, CRC(09ef29cb) SHA1(430da5b00554582391478849d5b1547fe12eedbe) ) // KM 23C3200AG-12 mask ROMs
 	ROM_LOAD32_BYTE( "rm0-1.grm0_1", 0x0000001, 0x400000, CRC(6f5910fa) SHA1(1979d19dd36a9118dfaf021e05302982be5dbe69) )
 	ROM_LOAD32_BYTE( "rm0-2.grm0_2", 0x0000002, 0x400000, CRC(b8a2add5) SHA1(62e5bef936f014ac836c0cd5322eaba7018496b4) )
 	ROM_LOAD32_BYTE( "rm0-3.grm0_3", 0x0000003, 0x400000, CRC(6b6ff867) SHA1(72bc95ef361f9238602f0e03aed0adac8b59d227) )
@@ -3234,7 +3201,7 @@ ROM_START( sftm110 )   /* Version 1.10, P/N 1064 REV 1 Mainboard, P/N 1073 REV 0
 	ROM_LOAD32_BYTE( "rm1-2.grm1_2", 0x1000002, 0x400000, CRC(903e56c2) SHA1(843ed9855ffdf37b100b3c5614139d552fd9cd6d) )
 	ROM_LOAD32_BYTE( "rm1-3.grm1_3", 0x1000003, 0x400000, CRC(fac35686) SHA1(ba99ab265620575c14c46806dc543d1f9fd24462) )
 
-	/* GROM2_0 through GROM2_3 are unpopulated 23C32000 mask ROM locations */
+	// GROM2_0 through GROM2_3 are unpopulated 23C32000 mask ROM locations
 
 	ROM_LOAD32_BYTE( "sfm_grm3_0.grm3_0", 0x2000000, 0x020000, CRC(3e1f76f7) SHA1(8aefe376e7248a583a6af02e5f9b2a4b48cc91d7) )
 	ROM_LOAD32_BYTE( "sfm_grm3_1.grm3_1", 0x2000001, 0x020000, CRC(578054b6) SHA1(99201959de28dbfd7692cedea4485751d3d4788f) )
@@ -3242,27 +3209,27 @@ ROM_START( sftm110 )   /* Version 1.10, P/N 1064 REV 1 Mainboard, P/N 1073 REV 0
 	ROM_LOAD32_BYTE( "sfm_grm3_3.grm3_3", 0x2000003, 0x020000, CRC(cd38d1d6) SHA1(0cea60d6897b34eeb13997030f6ee7e1dfb3c833) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "sfm_srom0.srom0", 0x000000, 0x200000, CRC(6ca1d3fc) SHA1(904f4c55a1bc83531a6d87ff706afd8cdfaee83b) ) /* Custom 42 Pin mask ROM sample set */
+	ROM_LOAD16_BYTE( "sfm_srom0.srom0", 0x000000, 0x200000, CRC(6ca1d3fc) SHA1(904f4c55a1bc83531a6d87ff706afd8cdfaee83b) ) // Custom 42 Pin mask ROM sample set
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.3", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "sfm_srom3.srom3", 0x000000, 0x080000, CRC(4f181534) SHA1(e858a33b22558665427146ec79dfba48edc20c2c) )
 ROM_END
 
-/* There is known to exist a PCB with hand written labels shown as V1.23 */
+// There is known to exist a PCB with hand written labels shown as V1.23
 
-ROM_START( sftmj114 )   /* Version 1.14N (Japan), P/N 1064 REV 1 Mainboard, P/N 1073 REV 0 ROM board, P/N 1066 REV 2 Sound board  */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( sftmj114 )   // Version 1.14N (Japan), P/N 1064 REV 1 Mainboard, P/N 1073 REV 0 ROM board, P/N 1066 REV 2 Sound board 
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "sfmn_prom0_v1.14.prom0", 0x00000, 0x40000, CRC(2a0c0bb7) SHA1(5722a399ed5dff55d47e096fb04a5d5b16de2f9a) )
 	ROM_LOAD32_BYTE( "sfmn_prom1_v1.14.prom1", 0x00001, 0x40000, CRC(088aa12c) SHA1(3c488068edea7ee726b7b837fedeeb0374a7b1ac) )
 	ROM_LOAD32_BYTE( "sfmn_prom2_v1.14.prom2", 0x00002, 0x40000, CRC(7120836e) SHA1(219ca837d1396ec39bb08272d2d9060441e45daf) )
 	ROM_LOAD32_BYTE( "sfmn_prom3_v1.14.prom3", 0x00003, 0x40000, CRC(84eb200d) SHA1(84150d978bd0b9f6363adde35c74fc5c77af6cf1) )
 
 	ROM_REGION( 0x48000, "soundcpu", 0 )
-	ROM_LOAD( "sfm_snd_v1.11.u23", 0x10000, 0x38000, CRC(004854ed) SHA1(7ecb74dc3f45b038cc9904fea5c89d3e74fcbcf3) ) /* Labeled as "SFM SND V1.11 U23" */
+	ROM_LOAD( "sfm_snd_v1.11.u23", 0x10000, 0x38000, CRC(004854ed) SHA1(7ecb74dc3f45b038cc9904fea5c89d3e74fcbcf3) ) // Labeled as "SFM SND V1.11 U23"
 	ROM_CONTINUE(                  0x08000, 0x08000 )
 
-	ROM_REGION( 0x2080000, "gfx1", 0 )
-	ROM_LOAD32_BYTE( "rm0-0.grm0_0", 0x0000000, 0x400000, CRC(09ef29cb) SHA1(430da5b00554582391478849d5b1547fe12eedbe) ) /* KM 23C3200AG-12 mask ROMs */
+	ROM_REGION( 0x2080000, "grom", 0 )
+	ROM_LOAD32_BYTE( "rm0-0.grm0_0", 0x0000000, 0x400000, CRC(09ef29cb) SHA1(430da5b00554582391478849d5b1547fe12eedbe) ) // KM 23C3200AG-12 mask ROMs
 	ROM_LOAD32_BYTE( "rm0-1.grm0_1", 0x0000001, 0x400000, CRC(6f5910fa) SHA1(1979d19dd36a9118dfaf021e05302982be5dbe69) )
 	ROM_LOAD32_BYTE( "rm0-2.grm0_2", 0x0000002, 0x400000, CRC(b8a2add5) SHA1(62e5bef936f014ac836c0cd5322eaba7018496b4) )
 	ROM_LOAD32_BYTE( "rm0-3.grm0_3", 0x0000003, 0x400000, CRC(6b6ff867) SHA1(72bc95ef361f9238602f0e03aed0adac8b59d227) )
@@ -3271,7 +3238,7 @@ ROM_START( sftmj114 )   /* Version 1.14N (Japan), P/N 1064 REV 1 Mainboard, P/N 
 	ROM_LOAD32_BYTE( "rm1-2.grm1_2", 0x1000002, 0x400000, CRC(903e56c2) SHA1(843ed9855ffdf37b100b3c5614139d552fd9cd6d) )
 	ROM_LOAD32_BYTE( "rm1-3.grm1_3", 0x1000003, 0x400000, CRC(fac35686) SHA1(ba99ab265620575c14c46806dc543d1f9fd24462) )
 
-	/* GROM2_0 through GROM2_3 are unpopulated 23C32000 mask ROM locations */
+	// GROM2_0 through GROM2_3 are unpopulated 23C32000 mask ROM locations
 
 	ROM_LOAD32_BYTE( "sfm_grm3_0.grm3_0", 0x2000000, 0x020000, CRC(3e1f76f7) SHA1(8aefe376e7248a583a6af02e5f9b2a4b48cc91d7) )
 	ROM_LOAD32_BYTE( "sfm_grm3_1.grm3_1", 0x2000001, 0x020000, CRC(578054b6) SHA1(99201959de28dbfd7692cedea4485751d3d4788f) )
@@ -3279,25 +3246,25 @@ ROM_START( sftmj114 )   /* Version 1.14N (Japan), P/N 1064 REV 1 Mainboard, P/N 
 	ROM_LOAD32_BYTE( "sfm_grm3_3.grm3_3", 0x2000003, 0x020000, CRC(cd38d1d6) SHA1(0cea60d6897b34eeb13997030f6ee7e1dfb3c833) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "sfm_srom0.srom0", 0x000000, 0x200000, CRC(6ca1d3fc) SHA1(904f4c55a1bc83531a6d87ff706afd8cdfaee83b) ) /* Custom 42 Pin mask ROM sample set */
+	ROM_LOAD16_BYTE( "sfm_srom0.srom0", 0x000000, 0x200000, CRC(6ca1d3fc) SHA1(904f4c55a1bc83531a6d87ff706afd8cdfaee83b) ) // Custom 42 Pin mask ROM sample set
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.3", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "sfm_srom3.srom3", 0x000000, 0x080000, CRC(4f181534) SHA1(e858a33b22558665427146ec79dfba48edc20c2c) )
 ROM_END
 
-ROM_START( sftmj112 )   /* Version 1.12N (Japan), P/N 1064 REV 1 Mainboard, P/N 1073 REV 0 ROM board, P/N 1066 REV 2 Sound board  */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
-	ROM_LOAD32_BYTE( "sfmn_prom0_v1.12.prom0", 0x00000, 0x40000, CRC(640a04a8) SHA1(adc7f5880962cbcc5f9f28e72a84070da6e2ec36) ) /* CAPCOM labels */
+ROM_START( sftmj112 )   // Version 1.12N (Japan), P/N 1064 REV 1 Mainboard, P/N 1073 REV 0 ROM board, P/N 1066 REV 2 Sound board 
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
+	ROM_LOAD32_BYTE( "sfmn_prom0_v1.12.prom0", 0x00000, 0x40000, CRC(640a04a8) SHA1(adc7f5880962cbcc5f9f28e72a84070da6e2ec36) ) // CAPCOM labels
 	ROM_LOAD32_BYTE( "sfmn_prom1_v1.12.prom1", 0x00001, 0x40000, CRC(2a27b690) SHA1(f63c3665ec030ecc2d7a10ead182941ade1c79d0) )
 	ROM_LOAD32_BYTE( "sfmn_prom2_v1.12.prom2", 0x00002, 0x40000, CRC(cec1dd7b) SHA1(4c4cf14bc17ddef216d16a7fbcef2e4694b45eb4) )
 	ROM_LOAD32_BYTE( "sfmn_prom3_v1.12.prom3", 0x00003, 0x40000, CRC(48fa60f4) SHA1(2d8bd4b5e3279af188feb3fb5e52a3d234bedd0a) )
 
 	ROM_REGION( 0x48000, "soundcpu", 0 )
-	ROM_LOAD( "sfm_snd_v1.11.u23", 0x10000, 0x38000, CRC(004854ed) SHA1(7ecb74dc3f45b038cc9904fea5c89d3e74fcbcf3) ) /* Labeled as "SFM SND V1.11 U23" */
+	ROM_LOAD( "sfm_snd_v1.11.u23", 0x10000, 0x38000, CRC(004854ed) SHA1(7ecb74dc3f45b038cc9904fea5c89d3e74fcbcf3) ) // Labeled as "SFM SND V1.11 U23"
 	ROM_CONTINUE(                  0x08000, 0x08000 )
 
-	ROM_REGION( 0x2080000, "gfx1", 0 )
-	ROM_LOAD32_BYTE( "rm0-0.grm0_0", 0x0000000, 0x400000, CRC(09ef29cb) SHA1(430da5b00554582391478849d5b1547fe12eedbe) ) /* KM 23C3200AG-12 mask ROMs */
+	ROM_REGION( 0x2080000, "grom", 0 )
+	ROM_LOAD32_BYTE( "rm0-0.grm0_0", 0x0000000, 0x400000, CRC(09ef29cb) SHA1(430da5b00554582391478849d5b1547fe12eedbe) ) // KM 23C3200AG-12 mask ROMs
 	ROM_LOAD32_BYTE( "rm0-1.grm0_1", 0x0000001, 0x400000, CRC(6f5910fa) SHA1(1979d19dd36a9118dfaf021e05302982be5dbe69) )
 	ROM_LOAD32_BYTE( "rm0-2.grm0_2", 0x0000002, 0x400000, CRC(b8a2add5) SHA1(62e5bef936f014ac836c0cd5322eaba7018496b4) )
 	ROM_LOAD32_BYTE( "rm0-3.grm0_3", 0x0000003, 0x400000, CRC(6b6ff867) SHA1(72bc95ef361f9238602f0e03aed0adac8b59d227) )
@@ -3306,7 +3273,7 @@ ROM_START( sftmj112 )   /* Version 1.12N (Japan), P/N 1064 REV 1 Mainboard, P/N 
 	ROM_LOAD32_BYTE( "rm1-2.grm1_2", 0x1000002, 0x400000, CRC(903e56c2) SHA1(843ed9855ffdf37b100b3c5614139d552fd9cd6d) )
 	ROM_LOAD32_BYTE( "rm1-3.grm1_3", 0x1000003, 0x400000, CRC(fac35686) SHA1(ba99ab265620575c14c46806dc543d1f9fd24462) )
 
-	/* GROM2_0 through GROM2_3 are unpopulated 23C32000 mask ROM locations */
+	// GROM2_0 through GROM2_3 are unpopulated 23C32000 mask ROM locations
 
 	ROM_LOAD32_BYTE( "sfm_grm3_0.grm3_0", 0x2000000, 0x020000, CRC(3e1f76f7) SHA1(8aefe376e7248a583a6af02e5f9b2a4b48cc91d7) )
 	ROM_LOAD32_BYTE( "sfm_grm3_1.grm3_1", 0x2000001, 0x020000, CRC(578054b6) SHA1(99201959de28dbfd7692cedea4485751d3d4788f) )
@@ -3314,25 +3281,25 @@ ROM_START( sftmj112 )   /* Version 1.12N (Japan), P/N 1064 REV 1 Mainboard, P/N 
 	ROM_LOAD32_BYTE( "sfm_grm3_3.grm3_3", 0x2000003, 0x020000, CRC(cd38d1d6) SHA1(0cea60d6897b34eeb13997030f6ee7e1dfb3c833) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "sfm_srom0.srom0", 0x000000, 0x200000, CRC(6ca1d3fc) SHA1(904f4c55a1bc83531a6d87ff706afd8cdfaee83b) ) /* Custom 42 Pin mask ROM sample set */
+	ROM_LOAD16_BYTE( "sfm_srom0.srom0", 0x000000, 0x200000, CRC(6ca1d3fc) SHA1(904f4c55a1bc83531a6d87ff706afd8cdfaee83b) ) // Custom 42 Pin mask ROM sample set
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.3", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "sfm_srom3.srom3", 0x000000, 0x080000, CRC(4f181534) SHA1(e858a33b22558665427146ec79dfba48edc20c2c) )
 ROM_END
 
-ROM_START( sftmk112 )   /* Version 1.12K (Korea), P/N 1064 REV 1 Mainboard, P/N 1073 REV 0 ROM board, P/N 1066 REV 2 Sound board  */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
-	ROM_LOAD32_BYTE( "sfmk_prom0_v1.12.prom0", 0x00000, 0x40000, CRC(1864ca77) SHA1(44702d69a5ee6a11328281943e04bd64b12b02a1) ) /* CAPCOM labels */
+ROM_START( sftmk112 )   // Version 1.12K (Korea), P/N 1064 REV 1 Mainboard, P/N 1073 REV 0 ROM board, P/N 1066 REV 2 Sound board 
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
+	ROM_LOAD32_BYTE( "sfmk_prom0_v1.12.prom0", 0x00000, 0x40000, CRC(1864ca77) SHA1(44702d69a5ee6a11328281943e04bd64b12b02a1) ) // CAPCOM labels
 	ROM_LOAD32_BYTE( "sfmk_prom1_v1.12.prom1", 0x00001, 0x40000, CRC(a93c52aa) SHA1(51539e79cfe8a2826f77b09ec8beeb94c2bb0767) )
 	ROM_LOAD32_BYTE( "sfmk_prom2_v1.12.prom2", 0x00002, 0x40000, CRC(8ddf8a7d) SHA1(63e5b0f7b2d60a8a61b9fccc54f672e48e68b744) )
 	ROM_LOAD32_BYTE( "sfmk_prom3_v1.12.prom3", 0x00003, 0x40000, CRC(9a83e6fe) SHA1(2a6dfaa19d5585c90b67fba025fc94d7fa528847) )
 
 	ROM_REGION( 0x48000, "soundcpu", 0 )
-	ROM_LOAD( "sfm_snd_v1.11.u23", 0x10000, 0x38000, CRC(004854ed) SHA1(7ecb74dc3f45b038cc9904fea5c89d3e74fcbcf3) ) /* Labeled as "SFM SND V1.11 U23" */
+	ROM_LOAD( "sfm_snd_v1.11.u23", 0x10000, 0x38000, CRC(004854ed) SHA1(7ecb74dc3f45b038cc9904fea5c89d3e74fcbcf3) ) // Labeled as "SFM SND V1.11 U23"
 	ROM_CONTINUE(                  0x08000, 0x08000 )
 
-	ROM_REGION( 0x2080000, "gfx1", 0 )
-	ROM_LOAD32_BYTE( "rm0-0.grm0_0", 0x0000000, 0x400000, CRC(09ef29cb) SHA1(430da5b00554582391478849d5b1547fe12eedbe) ) /* KM 23C3200AG-12 mask ROMs */
+	ROM_REGION( 0x2080000, "grom", 0 )
+	ROM_LOAD32_BYTE( "rm0-0.grm0_0", 0x0000000, 0x400000, CRC(09ef29cb) SHA1(430da5b00554582391478849d5b1547fe12eedbe) ) // KM 23C3200AG-12 mask ROMs
 	ROM_LOAD32_BYTE( "rm0-1.grm0_1", 0x0000001, 0x400000, CRC(6f5910fa) SHA1(1979d19dd36a9118dfaf021e05302982be5dbe69) )
 	ROM_LOAD32_BYTE( "rm0-2.grm0_2", 0x0000002, 0x400000, CRC(b8a2add5) SHA1(62e5bef936f014ac836c0cd5322eaba7018496b4) )
 	ROM_LOAD32_BYTE( "rm0-3.grm0_3", 0x0000003, 0x400000, CRC(6b6ff867) SHA1(72bc95ef361f9238602f0e03aed0adac8b59d227) )
@@ -3341,7 +3308,7 @@ ROM_START( sftmk112 )   /* Version 1.12K (Korea), P/N 1064 REV 1 Mainboard, P/N 
 	ROM_LOAD32_BYTE( "rm1-2.grm1_2", 0x1000002, 0x400000, CRC(903e56c2) SHA1(843ed9855ffdf37b100b3c5614139d552fd9cd6d) )
 	ROM_LOAD32_BYTE( "rm1-3.grm1_3", 0x1000003, 0x400000, CRC(fac35686) SHA1(ba99ab265620575c14c46806dc543d1f9fd24462) )
 
-	/* GROM2_0 through GROM2_3 are unpopulated 23C32000 mask ROM locations */
+	// GROM2_0 through GROM2_3 are unpopulated 23C32000 mask ROM locations
 
 	ROM_LOAD32_BYTE( "sfm_grm3_0.grm3_0", 0x2000000, 0x020000, CRC(3e1f76f7) SHA1(8aefe376e7248a583a6af02e5f9b2a4b48cc91d7) )
 	ROM_LOAD32_BYTE( "sfm_grm3_1.grm3_1", 0x2000001, 0x020000, CRC(578054b6) SHA1(99201959de28dbfd7692cedea4485751d3d4788f) )
@@ -3349,25 +3316,25 @@ ROM_START( sftmk112 )   /* Version 1.12K (Korea), P/N 1064 REV 1 Mainboard, P/N 
 	ROM_LOAD32_BYTE( "sfm_grm3_3.grm3_3", 0x2000003, 0x020000, CRC(cd38d1d6) SHA1(0cea60d6897b34eeb13997030f6ee7e1dfb3c833) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "sfm_srom0.srom0", 0x000000, 0x200000, CRC(6ca1d3fc) SHA1(904f4c55a1bc83531a6d87ff706afd8cdfaee83b) ) /* Custom 42 Pin mask ROM sample set */
+	ROM_LOAD16_BYTE( "sfm_srom0.srom0", 0x000000, 0x200000, CRC(6ca1d3fc) SHA1(904f4c55a1bc83531a6d87ff706afd8cdfaee83b) ) // Custom 42 Pin mask ROM sample set
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.3", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "sfm_srom3.srom3", 0x000000, 0x080000, CRC(4f181534) SHA1(e858a33b22558665427146ec79dfba48edc20c2c) )
 ROM_END
 
 
-ROM_START( shufshot )   /* Version 1.40 (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( shufshot )   // Version 1.40 (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "shot_prom0_v1.40.prom0", 0x00000, 0x20000, CRC(33c0c98b) SHA1(9960a1e8131e5dde33450560665f315e5a97dc05) )
 	ROM_LOAD32_BYTE( "shot_prom1_v1.40.prom1", 0x00001, 0x20000, CRC(d30a8831) SHA1(3a7937b542f703dfc2ae74b6fdb2ac6a8e22bdbd) )
 	ROM_LOAD32_BYTE( "shot_prom2_v1.40.prom2", 0x00002, 0x20000, CRC(ea10ada8) SHA1(e8167def9929876f6d2b4771b265114d9b04136e) )
 	ROM_LOAD32_BYTE( "shot_prom3_v1.40.prom3", 0x00003, 0x20000, CRC(4b28f28b) SHA1(602e230cc69ae872e40d72c85ec66f111826c15e) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "shotsnd_u88_v1.1.u88", 0x10000, 0x18000, CRC(e37d599d) SHA1(105f91e968ecf553d910a97726ddc536289bbb2b) ) /* labeled SHOTSND U88 V1.1, also known to be labeled SHOTSND U88 */
+	ROM_LOAD( "shotsnd_u88_v1.1.u88", 0x10000, 0x18000, CRC(e37d599d) SHA1(105f91e968ecf553d910a97726ddc536289bbb2b) ) // labeled SHOTSND U88 V1.1, also known to be labeled SHOTSND U88
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
-	ROM_REGION( 0x800000, "gfx1", 0 )
+	ROM_REGION( 0x800000, "grom", 0 )
 	ROM_LOAD32_BYTE( "shf_grom0_0.grm0_0",  0x000000, 0x80000, CRC(832a3d6a) SHA1(443328fa61b79c93ec6c9d24893b2ec38358a905) )
 	ROM_LOAD32_BYTE( "shf_grom0_1.grm0_1",  0x000001, 0x80000, CRC(155e48a2) SHA1(187d65423ff9a3d6b6c34c885a1b2397fa5371cf) )
 	ROM_LOAD32_BYTE( "shf_grom0_2.grm0_2",  0x000002, 0x80000, CRC(9f2b470d) SHA1(012e917856042cbe00d476e3220a7f9c841bd199) )
@@ -3380,8 +3347,8 @@ ROM_START( shufshot )   /* Version 1.40 (PCB P/N 1083 Rev 2) */
 	ROM_LOAD32_BYTE( "shf_grom2_1.grm2_1",  0x400001, 0x80000, CRC(4b52ab1a) SHA1(5c438df7f2edea8f4d8734408fd94acf9d340755) )
 	ROM_LOAD32_BYTE( "shf_grom2_2.grm2_2",  0x400002, 0x80000, CRC(f45fad03) SHA1(3ff062928ef5bcdce8748ddd972c5da67207227a) )
 	ROM_LOAD32_BYTE( "shf_grom2_3.grm2_3",  0x400003, 0x80000, CRC(1bcb26c8) SHA1(49e730c56c4a3171a2962fa65f3b16481590c636) )
-	ROM_LOAD32_BYTE( "shfa_grom3_0.grm3_0", 0x600000, 0x80000, CRC(c5afc9d1) SHA1(db1f1559b26d2a7c21486f005fffae16e74af1c6) ) /* although different CRC32 values, they match programs internal checksum values */
-	ROM_LOAD32_BYTE( "shfa_grom3_1.grm3_1", 0x600001, 0x80000, CRC(70dd7b68) SHA1(305bfcefb24f68bed4055c0e8819c31c95f7f853) ) /* changed with version 1.38 on IT dev CD */
+	ROM_LOAD32_BYTE( "shfa_grom3_0.grm3_0", 0x600000, 0x80000, CRC(c5afc9d1) SHA1(db1f1559b26d2a7c21486f005fffae16e74af1c6) ) // although different CRC32 values, they match programs internal checksum values
+	ROM_LOAD32_BYTE( "shfa_grom3_1.grm3_1", 0x600001, 0x80000, CRC(70dd7b68) SHA1(305bfcefb24f68bed4055c0e8819c31c95f7f853) ) // changed with version 1.38 on IT dev CD
 	ROM_LOAD32_BYTE( "shfa_grom3_2.grm3_2", 0x600002, 0x80000, CRC(da56512d) SHA1(dce114b079ff06693a8ec8247c3d4e87969d686f) )
 	ROM_LOAD32_BYTE( "shfa_grom3_3.grm3_3", 0x600003, 0x80000, CRC(21727c50) SHA1(db7f16f045f04b3bcb4b968344bc2eb641658add) )
 
@@ -3390,18 +3357,18 @@ ROM_START( shufshot )   /* Version 1.40 (PCB P/N 1083 Rev 2) */
 	ROM_LOAD16_BYTE( "shf_srom1.srom1", 0x200000, 0x80000, CRC(8c89948a) SHA1(1054eca5de352c17f34f31ef16297ba6177a37ba) )
 ROM_END
 
-ROM_START( shufshot139 )   /* Version 1.39 (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( shufshot139 )   // Version 1.39 (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "shot_prom0_v1.39.prom0", 0x00000, 0x20000, CRC(e811fc4a) SHA1(9e1d8f64ac89ac865929f6a23f66d95eeeda3ac9) )
 	ROM_LOAD32_BYTE( "shot_prom1_v1.39.prom1", 0x00001, 0x20000, CRC(f9d120c5) SHA1(f94216f1fb6d810ddee98479e83f0719b30b768f) )
 	ROM_LOAD32_BYTE( "shot_prom2_v1.39.prom2", 0x00002, 0x20000, CRC(9f12414d) SHA1(c1120079173f7ed6118f7105443afd7d38d8af94) )
 	ROM_LOAD32_BYTE( "shot_prom3_v1.39.prom3", 0x00003, 0x20000, CRC(108a69be) SHA1(1b2ebe4767be084707522a90f009d3a70e03d578) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "shotsnd_u88_v1.1.u88", 0x10000, 0x18000, CRC(e37d599d) SHA1(105f91e968ecf553d910a97726ddc536289bbb2b) ) /* labeled SHOTSND U88 V1.1, also known to be labeled SHOTSND U88 */
+	ROM_LOAD( "shotsnd_u88_v1.1.u88", 0x10000, 0x18000, CRC(e37d599d) SHA1(105f91e968ecf553d910a97726ddc536289bbb2b) ) // labeled SHOTSND U88 V1.1, also known to be labeled SHOTSND U88
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
-	ROM_REGION( 0x800000, "gfx1", 0 ) /* some Shuffleshot v1.39 PCBs are known to use the older GROM3_0 through GROM3_3 data */
+	ROM_REGION( 0x800000, "grom", 0 ) // some Shuffleshot v1.39 PCBs are known to use the older GROM3_0 through GROM3_3 data
 	ROM_LOAD32_BYTE( "shf_grom0_0.grm0_0",  0x000000, 0x80000, CRC(832a3d6a) SHA1(443328fa61b79c93ec6c9d24893b2ec38358a905) )
 	ROM_LOAD32_BYTE( "shf_grom0_1.grm0_1",  0x000001, 0x80000, CRC(155e48a2) SHA1(187d65423ff9a3d6b6c34c885a1b2397fa5371cf) )
 	ROM_LOAD32_BYTE( "shf_grom0_2.grm0_2",  0x000002, 0x80000, CRC(9f2b470d) SHA1(012e917856042cbe00d476e3220a7f9c841bd199) )
@@ -3414,8 +3381,8 @@ ROM_START( shufshot139 )   /* Version 1.39 (PCB P/N 1083 Rev 2) */
 	ROM_LOAD32_BYTE( "shf_grom2_1.grm2_1",  0x400001, 0x80000, CRC(4b52ab1a) SHA1(5c438df7f2edea8f4d8734408fd94acf9d340755) )
 	ROM_LOAD32_BYTE( "shf_grom2_2.grm2_2",  0x400002, 0x80000, CRC(f45fad03) SHA1(3ff062928ef5bcdce8748ddd972c5da67207227a) )
 	ROM_LOAD32_BYTE( "shf_grom2_3.grm2_3",  0x400003, 0x80000, CRC(1bcb26c8) SHA1(49e730c56c4a3171a2962fa65f3b16481590c636) )
-	ROM_LOAD32_BYTE( "shfa_grom3_0.grm3_0", 0x600000, 0x80000, CRC(c5afc9d1) SHA1(db1f1559b26d2a7c21486f005fffae16e74af1c6) ) /* although different CRC32 values, they match programs internal checksum values */
-	ROM_LOAD32_BYTE( "shfa_grom3_1.grm3_1", 0x600001, 0x80000, CRC(70dd7b68) SHA1(305bfcefb24f68bed4055c0e8819c31c95f7f853) ) /* changed with version 1.38 on IT dev CD */
+	ROM_LOAD32_BYTE( "shfa_grom3_0.grm3_0", 0x600000, 0x80000, CRC(c5afc9d1) SHA1(db1f1559b26d2a7c21486f005fffae16e74af1c6) ) // although different CRC32 values, they match programs internal checksum values
+	ROM_LOAD32_BYTE( "shfa_grom3_1.grm3_1", 0x600001, 0x80000, CRC(70dd7b68) SHA1(305bfcefb24f68bed4055c0e8819c31c95f7f853) ) // changed with version 1.38 on IT dev CD
 	ROM_LOAD32_BYTE( "shfa_grom3_2.grm3_2", 0x600002, 0x80000, CRC(da56512d) SHA1(dce114b079ff06693a8ec8247c3d4e87969d686f) )
 	ROM_LOAD32_BYTE( "shfa_grom3_3.grm3_3", 0x600003, 0x80000, CRC(21727c50) SHA1(db7f16f045f04b3bcb4b968344bc2eb641658add) )
 
@@ -3424,18 +3391,18 @@ ROM_START( shufshot139 )   /* Version 1.39 (PCB P/N 1083 Rev 2) */
 	ROM_LOAD16_BYTE( "shf_srom1.srom1", 0x200000, 0x80000, CRC(8c89948a) SHA1(1054eca5de352c17f34f31ef16297ba6177a37ba) )
 ROM_END
 
-ROM_START( shufshot138 )   /* Version 1.38 (PCB P/N 1083 Rev 2) - Not offically released? - found on dev CD */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( shufshot138 )   // Version 1.38 (PCB P/N 1083 Rev 2) - Not offically released? - found on dev CD
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "shot_prom0_v1.38.prom0", 0x00000, 0x20000, CRC(68f823ff) SHA1(f9de8e45dd87e39bb256963cd356cbb9f985f3e8) )
 	ROM_LOAD32_BYTE( "shot_prom1_v1.38.prom1", 0x00001, 0x20000, CRC(bdd9a8e9) SHA1(b4c0d3ab5ed66c7f43f309236708df355385ec5e) )
 	ROM_LOAD32_BYTE( "shot_prom2_v1.38.prom2", 0x00002, 0x20000, CRC(92008e13) SHA1(2ed7cde67131e4baf1c127004d61d433d983467e) )
 	ROM_LOAD32_BYTE( "shot_prom3_v1.38.prom3", 0x00003, 0x20000, CRC(723cb9a5) SHA1(2ac209053bce245130b6056fe0ebe048596ae3b4) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "shotsnd_u88_v1.1.u88", 0x10000, 0x18000, CRC(e37d599d) SHA1(105f91e968ecf553d910a97726ddc536289bbb2b) ) /* labeled SHOTSND U88 V1.1, also known to be labeled SHOTSND U88 */
+	ROM_LOAD( "shotsnd_u88_v1.1.u88", 0x10000, 0x18000, CRC(e37d599d) SHA1(105f91e968ecf553d910a97726ddc536289bbb2b) ) // labeled SHOTSND U88 V1.1, also known to be labeled SHOTSND U88
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
-	ROM_REGION( 0x800000, "gfx1", 0 )
+	ROM_REGION( 0x800000, "grom", 0 )
 	ROM_LOAD32_BYTE( "shf_grom0_0.grm0_0",  0x000000, 0x80000, CRC(832a3d6a) SHA1(443328fa61b79c93ec6c9d24893b2ec38358a905) )
 	ROM_LOAD32_BYTE( "shf_grom0_1.grm0_1",  0x000001, 0x80000, CRC(155e48a2) SHA1(187d65423ff9a3d6b6c34c885a1b2397fa5371cf) )
 	ROM_LOAD32_BYTE( "shf_grom0_2.grm0_2",  0x000002, 0x80000, CRC(9f2b470d) SHA1(012e917856042cbe00d476e3220a7f9c841bd199) )
@@ -3448,8 +3415,8 @@ ROM_START( shufshot138 )   /* Version 1.38 (PCB P/N 1083 Rev 2) - Not offically 
 	ROM_LOAD32_BYTE( "shf_grom2_1.grm2_1",  0x400001, 0x80000, CRC(4b52ab1a) SHA1(5c438df7f2edea8f4d8734408fd94acf9d340755) )
 	ROM_LOAD32_BYTE( "shf_grom2_2.grm2_2",  0x400002, 0x80000, CRC(f45fad03) SHA1(3ff062928ef5bcdce8748ddd972c5da67207227a) )
 	ROM_LOAD32_BYTE( "shf_grom2_3.grm2_3",  0x400003, 0x80000, CRC(1bcb26c8) SHA1(49e730c56c4a3171a2962fa65f3b16481590c636) )
-	ROM_LOAD32_BYTE( "shfa_grom3_0.grm3_0", 0x600000, 0x80000, CRC(c5afc9d1) SHA1(db1f1559b26d2a7c21486f005fffae16e74af1c6) ) /* although different CRC32 values, they match programs internal checksum values */
-	ROM_LOAD32_BYTE( "shfa_grom3_1.grm3_1", 0x600001, 0x80000, CRC(70dd7b68) SHA1(305bfcefb24f68bed4055c0e8819c31c95f7f853) ) /* changed with version 1.38 on IT dev CD */
+	ROM_LOAD32_BYTE( "shfa_grom3_0.grm3_0", 0x600000, 0x80000, CRC(c5afc9d1) SHA1(db1f1559b26d2a7c21486f005fffae16e74af1c6) ) // although different CRC32 values, they match programs internal checksum values
+	ROM_LOAD32_BYTE( "shfa_grom3_1.grm3_1", 0x600001, 0x80000, CRC(70dd7b68) SHA1(305bfcefb24f68bed4055c0e8819c31c95f7f853) ) // changed with version 1.38 on IT dev CD
 	ROM_LOAD32_BYTE( "shfa_grom3_2.grm3_2", 0x600002, 0x80000, CRC(da56512d) SHA1(dce114b079ff06693a8ec8247c3d4e87969d686f) )
 	ROM_LOAD32_BYTE( "shfa_grom3_3.grm3_3", 0x600003, 0x80000, CRC(21727c50) SHA1(db7f16f045f04b3bcb4b968344bc2eb641658add) )
 
@@ -3458,18 +3425,18 @@ ROM_START( shufshot138 )   /* Version 1.38 (PCB P/N 1083 Rev 2) - Not offically 
 	ROM_LOAD16_BYTE( "shf_srom1.srom1", 0x200000, 0x80000, CRC(8c89948a) SHA1(1054eca5de352c17f34f31ef16297ba6177a37ba) )
 ROM_END
 
-ROM_START( shufshot137 )   /* Version 1.37 (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( shufshot137 )   // Version 1.37 (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "shot_prom0_v1.37.prom0", 0x00000, 0x20000, CRC(6499c76f) SHA1(60fdaefb09088ac609addd40569bd7fab12593bc) )
 	ROM_LOAD32_BYTE( "shot_prom1_v1.37.prom1", 0x00001, 0x20000, CRC(64fb47a4) SHA1(32ce9d91b16b8aaf545c0a22842ad8d806727a17) )
 	ROM_LOAD32_BYTE( "shot_prom2_v1.37.prom2", 0x00002, 0x20000, CRC(e0df3025) SHA1(edff5c5c4486981ac0783f337a0845854d0217f0) )
 	ROM_LOAD32_BYTE( "shot_prom3_v1.37.prom3", 0x00003, 0x20000, CRC(efa66ad8) SHA1(d8dc754529284e6c06b912e226c8a4520aab49fc) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "shotsnd_u88_v1.1.u88", 0x10000, 0x18000, CRC(e37d599d) SHA1(105f91e968ecf553d910a97726ddc536289bbb2b) ) /* labeled SHOTSND U88 V1.1, also known to be labeled SHOTSND U88 */
+	ROM_LOAD( "shotsnd_u88_v1.1.u88", 0x10000, 0x18000, CRC(e37d599d) SHA1(105f91e968ecf553d910a97726ddc536289bbb2b) ) // labeled SHOTSND U88 V1.1, also known to be labeled SHOTSND U88
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
-	ROM_REGION( 0x800000, "gfx1", 0 )
+	ROM_REGION( 0x800000, "grom", 0 )
 	ROM_LOAD32_BYTE( "shf_grom0_0.grm0_0", 0x000000, 0x80000, CRC(832a3d6a) SHA1(443328fa61b79c93ec6c9d24893b2ec38358a905) )
 	ROM_LOAD32_BYTE( "shf_grom0_1.grm0_1", 0x000001, 0x80000, CRC(155e48a2) SHA1(187d65423ff9a3d6b6c34c885a1b2397fa5371cf) )
 	ROM_LOAD32_BYTE( "shf_grom0_2.grm0_2", 0x000002, 0x80000, CRC(9f2b470d) SHA1(012e917856042cbe00d476e3220a7f9c841bd199) )
@@ -3492,18 +3459,18 @@ ROM_START( shufshot137 )   /* Version 1.37 (PCB P/N 1083 Rev 2) */
 	ROM_LOAD16_BYTE( "shf_srom1.srom1", 0x200000, 0x80000, CRC(8c89948a) SHA1(1054eca5de352c17f34f31ef16297ba6177a37ba) )
 ROM_END
 
-ROM_START( shufshot135 )   /* Version 1.35 (PCB P/N 1083 Rev 2) - Not offically released? - found on dev CD  */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( shufshot135 )   // Version 1.35 (PCB P/N 1083 Rev 2) - Not offically released? - found on dev CD 
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "shot_prom0_v1.35.prom0", 0x00000, 0x20000, CRC(1a1d510c) SHA1(b1919beee499fb4e213a987ad796742dbfbd540b) )
 	ROM_LOAD32_BYTE( "shot_prom1_v1.35.prom1", 0x00001, 0x20000, CRC(5d7d5017) SHA1(8330339bd45c30066650a2a6cc7e12f365c91608) )
 	ROM_LOAD32_BYTE( "shot_prom2_v1.35.prom2", 0x00002, 0x20000, CRC(6f27b111) SHA1(9f9a95948662003edee2aeb2230b64e6401b4e49) )
 	ROM_LOAD32_BYTE( "shot_prom3_v1.35.prom3", 0x00003, 0x20000, CRC(bf6fabbb) SHA1(3f52791b974a6170fad492c0270270f5712c8506) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "shotsnd_u88_v1.1.u88", 0x10000, 0x18000, CRC(e37d599d) SHA1(105f91e968ecf553d910a97726ddc536289bbb2b) ) /* labeled SHOTSND U88 V1.1, also known to be labeled SHOTSND U88 */
+	ROM_LOAD( "shotsnd_u88_v1.1.u88", 0x10000, 0x18000, CRC(e37d599d) SHA1(105f91e968ecf553d910a97726ddc536289bbb2b) ) // labeled SHOTSND U88 V1.1, also known to be labeled SHOTSND U88
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
-	ROM_REGION( 0x800000, "gfx1", 0 )
+	ROM_REGION( 0x800000, "grom", 0 )
 	ROM_LOAD32_BYTE( "shf_grom0_0.grm0_0", 0x000000, 0x80000, CRC(832a3d6a) SHA1(443328fa61b79c93ec6c9d24893b2ec38358a905) )
 	ROM_LOAD32_BYTE( "shf_grom0_1.grm0_1", 0x000001, 0x80000, CRC(155e48a2) SHA1(187d65423ff9a3d6b6c34c885a1b2397fa5371cf) )
 	ROM_LOAD32_BYTE( "shf_grom0_2.grm0_2", 0x000002, 0x80000, CRC(9f2b470d) SHA1(012e917856042cbe00d476e3220a7f9c841bd199) )
@@ -3527,8 +3494,8 @@ ROM_START( shufshot135 )   /* Version 1.35 (PCB P/N 1083 Rev 2) - Not offically 
 ROM_END
 
 
-ROM_START( gt3d )   /* Version 1.93N for the single large type PCB P/N 1083 Rev 2 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt3d )   // Version 1.93N for the single large type PCB P/N 1083 Rev 2
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gtg3_prom0_v1.93n.prom0", 0x00000, 0x80000, CRC(cacacb44) SHA1(747f48a52e140ab3e321b8f6a96f06bc70dc7cfa) )
 	ROM_LOAD32_BYTE( "gtg3_prom1_v1.93n.prom1", 0x00001, 0x80000, CRC(4c172d7f) SHA1(d4217d5d4d561e46e0213e6f8dc8d9a874f86877) )
 	ROM_LOAD32_BYTE( "gtg3_prom2_v1.93n.prom2", 0x00002, 0x80000, CRC(b53fe6f0) SHA1(4fbaa2f2a877c051b06ffa570e40156142d8e6bf) )
@@ -3538,7 +3505,7 @@ ROM_START( gt3d )   /* Version 1.93N for the single large type PCB P/N 1083 Rev 
 	ROM_LOAD( "gtg3nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gtg3_grom0_0.grm0_0",   0x000000, 0x80000, CRC(1b10379d) SHA1(b6d61771e2bc3909ea4229777867b217a3e9e580) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_1.grm0_1",   0x000001, 0x80000, CRC(3b852e1a) SHA1(4b3653d55c52fc2eb5438d1604247a8e68d569a5) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_2.grm0_2",   0x000002, 0x80000, CRC(d43ffb35) SHA1(748be07e03bbbb40cd7a725c708cacc46f33d9ca) )
@@ -3547,7 +3514,7 @@ ROM_START( gt3d )   /* Version 1.93N for the single large type PCB P/N 1083 Rev 
 	ROM_LOAD32_BYTE( "gtg3_grom1_1.grm1_1",   0x200001, 0x80000, CRC(0aadfad2) SHA1(56a283b30a13b77ec53b7ae2b4129d44b7fa25d4) )
 	ROM_LOAD32_BYTE( "gtg3_grom1_2.grm1_2",   0x200002, 0x80000, CRC(27871980) SHA1(fe473d12cb4805e25dcac8f9ae187891936b961b) )
 	ROM_LOAD32_BYTE( "gtg3_grom1_3.grm1_3",   0x200003, 0x80000, CRC(7dbc242b) SHA1(9aa5074cad633446e0110a1a3d9c6e1f2158070a) )
-	ROM_LOAD32_BYTE( "gtg3_grom2_0_t.grm2_0", 0x400000, 0x80000, CRC(80ae7148) SHA1(e19d3390a2a0dad260d770fdbbb64d1f8e43d53f) ) /* actually labeled as "GTG3 GROM2_0 T" ect */
+	ROM_LOAD32_BYTE( "gtg3_grom2_0_t.grm2_0", 0x400000, 0x80000, CRC(80ae7148) SHA1(e19d3390a2a0dad260d770fdbbb64d1f8e43d53f) ) // actually labeled as "GTG3 GROM2_0 T" ect
 	ROM_LOAD32_BYTE( "gtg3_grom2_1_t.grm2_1", 0x400001, 0x80000, CRC(0f85a618) SHA1(d9ced21c20f9ed6b7f19e7645d75b239ea709b79) )
 	ROM_LOAD32_BYTE( "gtg3_grom2_2_t.grm2_2", 0x400002, 0x80000, CRC(09ca5fbf) SHA1(6a6ed4d5d76035d8acc33c6494fba6012194362e) )
 	ROM_LOAD32_BYTE( "gtg3_grom2_3_t.grm2_3", 0x400003, 0x80000, CRC(d136853a) SHA1(0777d6bfab9e3d57c2a61d058fd185fc1f547698) )
@@ -3557,18 +3524,18 @@ ROM_START( gt3d )   /* Version 1.93N for the single large type PCB P/N 1083 Rev 
 	ROM_LOAD16_BYTE( "gtg3_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gt3ds192 ) /* Version 1.92 for the 3 tier type PCB with short ROM board P/N 1069 REV 2 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt3ds192 ) // Version 1.92 for the 3 tier type PCB with short ROM board P/N 1069 REV 2
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gtg3_prom0_v1.92s.prom0", 0x00000, 0x80000, CRC(eee38005) SHA1(3a879dce1abf449e847ba8f45ff5e1d70d13c966) )
 	ROM_LOAD32_BYTE( "gtg3_prom1_v1.92s.prom1", 0x00001, 0x80000, CRC(818ba70e) SHA1(abeadd0efa8ea0d7924ff0951aafe8ee4a5f45d9) )
 	ROM_LOAD32_BYTE( "gtg3_prom2_v1.92s.prom2", 0x00002, 0x80000, CRC(7ab661a1) SHA1(9db0a64c91ba15dad6ca071639d8e2d366dc7756) )
 	ROM_LOAD32_BYTE( "gtg3_prom3_v1.92s.prom3", 0x00003, 0x80000, CRC(f9f96c01) SHA1(037c8d2d0d81c08745c044121c62f05a814db576) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "gtg3-snd_u23_v1.2.u23", 0x10000, 0x18000, CRC(cbbe41f9) SHA1(6a602addff87d32bb6df3ffb0563e8b2d3c4adcc) ) /* actually labeled as "GTG3-SND(U23) v1.2" */
+	ROM_LOAD( "gtg3-snd_u23_v1.2.u23", 0x10000, 0x18000, CRC(cbbe41f9) SHA1(6a602addff87d32bb6df3ffb0563e8b2d3c4adcc) ) // actually labeled as "GTG3-SND(U23) v1.2"
 	ROM_CONTINUE(                      0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gtg3_grom0_0.grm0_0", 0x000000, 0x80000, CRC(1b10379d) SHA1(b6d61771e2bc3909ea4229777867b217a3e9e580) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_1.grm0_1", 0x000001, 0x80000, CRC(3b852e1a) SHA1(4b3653d55c52fc2eb5438d1604247a8e68d569a5) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_2.grm0_2", 0x000002, 0x80000, CRC(d43ffb35) SHA1(748be07e03bbbb40cd7a725c708cacc46f33d9ca) )
@@ -3583,7 +3550,7 @@ ROM_START( gt3ds192 ) /* Version 1.92 for the 3 tier type PCB with short ROM boa
 	ROM_LOAD32_BYTE( "gtg3_grom2_3.grm2_3", 0x400003, 0x80000, CRC(77869bcf) SHA1(dde3b64578b79a94c7e346561a691229bbcfadac) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "gtg3_srom1.srom1", 0x000000, 0x80000, CRC(ac669434) SHA1(6941884c553515f5bc06af772897835a44aa8e4c) )
@@ -3593,18 +3560,18 @@ ROM_START( gt3ds192 ) /* Version 1.92 for the 3 tier type PCB with short ROM boa
 	ROM_LOAD16_BYTE( "gtg3_srom3.srom3", 0x000000, 0x20000, CRC(d2462965) SHA1(45d2c9aaac681315d2e5cb39be151467f278e395) )
 ROM_END
 
-ROM_START( gt3dl192 ) /* Version 1.92 for the 3 tier type PCB with long ROM board P/N 1080 REV 5 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt3dl192 ) // Version 1.92 for the 3 tier type PCB with long ROM board P/N 1080 REV 5
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gtg3_prom0_v1.92l.prom0", 0x00000, 0x80000, CRC(b449b939) SHA1(d5845fa4ed2702c2f05bfd22fe436c3b85ace0f8) )
 	ROM_LOAD32_BYTE( "gtg3_prom1_v1.92l.prom1", 0x00001, 0x80000, CRC(ff986e67) SHA1(1d03aa7bf6a301eedb2beef93d54b58abe4e63a6) )
 	ROM_LOAD32_BYTE( "gtg3_prom2_v1.92l.prom2", 0x00002, 0x80000, CRC(eb959447) SHA1(62a6382c5dc7d97b19c2e21ed47bb87d530cb43d) )
 	ROM_LOAD32_BYTE( "gtg3_prom3_v1.92l.prom3", 0x00003, 0x80000, CRC(0265b798) SHA1(44c73f66f6b29a3cc6208cd7fde00605b61f8f15) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "gtg3-snd_u23_v2.2.u23", 0x10000, 0x18000, CRC(26fe2e92) SHA1(437ca0ea94dc0fa215f5375daa41d3dfe9bb17e0) ) /* actually labeled as "GTG3-SND(U23) v2.2" */
+	ROM_LOAD( "gtg3-snd_u23_v2.2.u23", 0x10000, 0x18000, CRC(26fe2e92) SHA1(437ca0ea94dc0fa215f5375daa41d3dfe9bb17e0) ) // actually labeled as "GTG3-SND(U23) v2.2"
 	ROM_CONTINUE(                      0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gtg3_grom0_0.grm0_0", 0x000000, 0x80000, CRC(1b10379d) SHA1(b6d61771e2bc3909ea4229777867b217a3e9e580) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_1.grm0_1", 0x000001, 0x80000, CRC(3b852e1a) SHA1(4b3653d55c52fc2eb5438d1604247a8e68d569a5) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_2.grm0_2", 0x000002, 0x80000, CRC(d43ffb35) SHA1(748be07e03bbbb40cd7a725c708cacc46f33d9ca) )
@@ -3619,7 +3586,7 @@ ROM_START( gt3dl192 ) /* Version 1.92 for the 3 tier type PCB with long ROM boar
 	ROM_LOAD32_BYTE( "gtg3_grom2_3.grm2_3", 0x400003, 0x80000, CRC(77869bcf) SHA1(dde3b64578b79a94c7e346561a691229bbcfadac) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) /* Ensoniq 2MX16U 1350901801 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) // Ensoniq 2MX16U 1350901801 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "gtg3_srom1.srom1", 0x000000, 0x80000, CRC(ac669434) SHA1(6941884c553515f5bc06af772897835a44aa8e4c) )
@@ -3629,18 +3596,18 @@ ROM_START( gt3dl192 ) /* Version 1.92 for the 3 tier type PCB with long ROM boar
 	ROM_LOAD16_BYTE( "gtg3_srom3.srom3", 0x000000, 0x20000, CRC(d2462965) SHA1(45d2c9aaac681315d2e5cb39be151467f278e395) )
 ROM_END
 
-ROM_START( gt3dl191 ) /* Version 1.91 for the 3 tier type PCB with long ROM board P/N 1080 REV 5 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt3dl191 ) // Version 1.91 for the 3 tier type PCB with long ROM board P/N 1080 REV 5
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gtg3_prom0_v1.91l.prom0", 0x00000, 0x80000, CRC(a3ea30d8) SHA1(675ca44b3a4fb542dfe4e9ce8463d2fc91491405) )
 	ROM_LOAD32_BYTE( "gtg3_prom1_v1.91l.prom1", 0x00001, 0x80000, CRC(3aa87e56) SHA1(67c8bb5a869e1ff816e3d1da74fe4de4b1b3203c) )
 	ROM_LOAD32_BYTE( "gtg3_prom2_v1.91l.prom2", 0x00002, 0x80000, CRC(41720e87) SHA1(c699b9ac892649004f1437bd3fe68a23b5d7ba27) )
 	ROM_LOAD32_BYTE( "gtg3_prom3_v1.91l.prom3", 0x00003, 0x80000, CRC(30946139) SHA1(94ba341e13ffa27b56c12242b156fdf0698ad171) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "gtg3-snd_u23_v2.1.u23", 0x10000, 0x18000, CRC(6ae2646d) SHA1(0c62cc5f2911913167c5391648325409e7a3d892) ) /* actually labeled as "GTG3-SND(U23) v2.1" */
+	ROM_LOAD( "gtg3-snd_u23_v2.1.u23", 0x10000, 0x18000, CRC(6ae2646d) SHA1(0c62cc5f2911913167c5391648325409e7a3d892) ) // actually labeled as "GTG3-SND(U23) v2.1"
 	ROM_CONTINUE(                      0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gtg3_grom0_0.grm0_0", 0x000000, 0x80000, CRC(1b10379d) SHA1(b6d61771e2bc3909ea4229777867b217a3e9e580) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_1.grm0_1", 0x000001, 0x80000, CRC(3b852e1a) SHA1(4b3653d55c52fc2eb5438d1604247a8e68d569a5) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_2.grm0_2", 0x000002, 0x80000, CRC(d43ffb35) SHA1(748be07e03bbbb40cd7a725c708cacc46f33d9ca) )
@@ -3655,7 +3622,7 @@ ROM_START( gt3dl191 ) /* Version 1.91 for the 3 tier type PCB with long ROM boar
 	ROM_LOAD32_BYTE( "gtg3_grom2_3.grm2_3", 0x400003, 0x80000, CRC(77869bcf) SHA1(dde3b64578b79a94c7e346561a691229bbcfadac) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) /* Ensoniq 2MX16U 1350901801 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) // Ensoniq 2MX16U 1350901801 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "gtg3_srom1.srom1", 0x000000, 0x80000, CRC(ac669434) SHA1(6941884c553515f5bc06af772897835a44aa8e4c) )
@@ -3665,18 +3632,18 @@ ROM_START( gt3dl191 ) /* Version 1.91 for the 3 tier type PCB with long ROM boar
 	ROM_LOAD16_BYTE( "gtg3_srom3.srom3", 0x000000, 0x20000, CRC(d2462965) SHA1(45d2c9aaac681315d2e5cb39be151467f278e395) )
 ROM_END
 
-ROM_START( gt3dl19 ) /* Version 1.9 for the 3 tier type PCB with long ROM board P/N 1080 REV 5 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt3dl19 ) // Version 1.9 for the 3 tier type PCB with long ROM board P/N 1080 REV 5
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gtg3_prom0_v1.9l.prom0", 0x00000, 0x80000, CRC(b6293cf6) SHA1(96cc035b004719d3f56f08efe67216474724e83f) )
 	ROM_LOAD32_BYTE( "gtg3_prom1_v1.9l.prom1", 0x00001, 0x80000, CRC(270b7936) SHA1(a101c94535dd3713f0e4c99c1079c2471bcd08d8) )
 	ROM_LOAD32_BYTE( "gtg3_prom2_v1.9l.prom2", 0x00002, 0x80000, CRC(3f892e81) SHA1(523146aa88c3fa4b7fbbf3f8b8c106b3e9c796ab) )
 	ROM_LOAD32_BYTE( "gtg3_prom3_v1.9l.prom3", 0x00003, 0x80000, CRC(b63ef2c0) SHA1(0238aeaa97da877675c94c7ecde1f29d3c9a0251) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "gtg3-snd_u23_v2.0.u23", 0x10000, 0x18000, CRC(3f69a9ea) SHA1(02610aa31f8b3422e15acd7b5e66ecfc4f53aba4) ) /* actually labeled as "GTG3-SND(U23) v2.0" */
+	ROM_LOAD( "gtg3-snd_u23_v2.0.u23", 0x10000, 0x18000, CRC(3f69a9ea) SHA1(02610aa31f8b3422e15acd7b5e66ecfc4f53aba4) ) // actually labeled as "GTG3-SND(U23) v2.0"
 	ROM_CONTINUE(                      0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gtg3_grom0_0.grm0_0", 0x000000, 0x80000, CRC(1b10379d) SHA1(b6d61771e2bc3909ea4229777867b217a3e9e580) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_1.grm0_1", 0x000001, 0x80000, CRC(3b852e1a) SHA1(4b3653d55c52fc2eb5438d1604247a8e68d569a5) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_2.grm0_2", 0x000002, 0x80000, CRC(d43ffb35) SHA1(748be07e03bbbb40cd7a725c708cacc46f33d9ca) )
@@ -3691,7 +3658,7 @@ ROM_START( gt3dl19 ) /* Version 1.9 for the 3 tier type PCB with long ROM board 
 	ROM_LOAD32_BYTE( "gtg3_grom2_3.grm2_3", 0x400003, 0x80000, CRC(77869bcf) SHA1(dde3b64578b79a94c7e346561a691229bbcfadac) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) /* Ensoniq 2MX16U 1350901801 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2mx16u.rom0", 0x000000, 0x200000, CRC(0814ab80) SHA1(e92525f7cf58cf480510c278fea705f67225e58f) ) // Ensoniq 2MX16U 1350901801 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "gtg3_srom1.srom1", 0x000000, 0x80000, CRC(ac669434) SHA1(6941884c553515f5bc06af772897835a44aa8e4c) )
@@ -3701,18 +3668,18 @@ ROM_START( gt3dl19 ) /* Version 1.9 for the 3 tier type PCB with long ROM board 
 	ROM_LOAD16_BYTE( "gtg3_srom3.srom3", 0x000000, 0x20000, CRC(d2462965) SHA1(45d2c9aaac681315d2e5cb39be151467f278e395) )
 ROM_END
 
-ROM_START( gt3dv18 ) /* Version 1.8 for the 3 tier type PCB with short ROM board P/N 1069 REV 2 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt3dv18 ) // Version 1.8 for the 3 tier type PCB with short ROM board P/N 1069 REV 2
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gtg3_prom0_v1.8.prom0", 0x00000, 0x80000, CRC(0fa53c40) SHA1(45e339dede03d749c00f9459eebb26de4965c31c) )
 	ROM_LOAD32_BYTE( "gtg3_prom1_v1.8.prom1", 0x00001, 0x80000, CRC(bef2cbe3) SHA1(ffed58db023d05817bd7a32958699115f4fbf37d) )
 	ROM_LOAD32_BYTE( "gtg3_prom2_v1.8.prom2", 0x00002, 0x80000, CRC(1d5fb128) SHA1(bef5ff44836a5d32431c4ef998c9041b5c769281) )
 	ROM_LOAD32_BYTE( "gtg3_prom3_v1.8.prom3", 0x00003, 0x80000, CRC(5542c335) SHA1(8e906512dc9c14f99c52faaa4315a7839dbd648c) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "gtg3-snd_u23_v1.1.u23", 0x10000, 0x18000, CRC(2f4cde9f) SHA1(571597e992e334e87307830e4a6a439c9d15fa76) ) /* actually labeled as "GTG3-SND(U23) v1.1" */
+	ROM_LOAD( "gtg3-snd_u23_v1.1.u23", 0x10000, 0x18000, CRC(2f4cde9f) SHA1(571597e992e334e87307830e4a6a439c9d15fa76) ) // actually labeled as "GTG3-SND(U23) v1.1"
 	ROM_CONTINUE(                      0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gtg3_grom0_0.grm0_0", 0x000000, 0x80000, CRC(1b10379d) SHA1(b6d61771e2bc3909ea4229777867b217a3e9e580) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_1.grm0_1", 0x000001, 0x80000, CRC(3b852e1a) SHA1(4b3653d55c52fc2eb5438d1604247a8e68d569a5) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_2.grm0_2", 0x000002, 0x80000, CRC(d43ffb35) SHA1(748be07e03bbbb40cd7a725c708cacc46f33d9ca) )
@@ -3727,7 +3694,7 @@ ROM_START( gt3dv18 ) /* Version 1.8 for the 3 tier type PCB with short ROM board
 	ROM_LOAD32_BYTE( "gtg3_grom2_3.grm2_3", 0x400003, 0x80000, CRC(77869bcf) SHA1(dde3b64578b79a94c7e346561a691229bbcfadac) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "gtg3_srom1.srom1", 0x000000, 0x80000, CRC(ac669434) SHA1(6941884c553515f5bc06af772897835a44aa8e4c) )
@@ -3737,18 +3704,18 @@ ROM_START( gt3dv18 ) /* Version 1.8 for the 3 tier type PCB with short ROM board
 	ROM_LOAD16_BYTE( "gtg3_srom3.srom3", 0x000000, 0x20000, CRC(d2462965) SHA1(45d2c9aaac681315d2e5cb39be151467f278e395) )
 ROM_END
 
-ROM_START( gt3dv17 ) /* Version 1.7 for the 3 tier type PCB with short ROM board P/N 1069 REV 2 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt3dv17 ) // Version 1.7 for the 3 tier type PCB with short ROM board P/N 1069 REV 2
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gtg3_prom0_v1.7.prom0", 0x00000, 0x80000, CRC(9a6fc839) SHA1(bd9a98f4a29786a3f28abb4e7eca63f62bb0dcf7) )
 	ROM_LOAD32_BYTE( "gtg3_prom1_v1.7.prom1", 0x00001, 0x80000, CRC(26606578) SHA1(791782d4d99c2239e2967a8cf1467bad831b7500) )
 	ROM_LOAD32_BYTE( "gtg3_prom2_v1.7.prom2", 0x00002, 0x80000, CRC(9c4d348b) SHA1(04167b9c4f3c99c5a1e0396c094cb9185c8d17c1) )
 	ROM_LOAD32_BYTE( "gtg3_prom3_v1.7.prom3", 0x00003, 0x80000, CRC(53b1d6e7) SHA1(f1662275d45316a892d7722cd2fa1c2259acbcfa) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "gtg3-snd_u23_v1.1.u23", 0x10000, 0x18000, CRC(2f4cde9f) SHA1(571597e992e334e87307830e4a6a439c9d15fa76) ) /* actually labeled as "GTG3-SND(U23) v1.1" */
+	ROM_LOAD( "gtg3-snd_u23_v1.1.u23", 0x10000, 0x18000, CRC(2f4cde9f) SHA1(571597e992e334e87307830e4a6a439c9d15fa76) ) // actually labeled as "GTG3-SND(U23) v1.1"
 	ROM_CONTINUE(                      0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gtg3_grom0_0.grm0_0", 0x000000, 0x80000, CRC(1b10379d) SHA1(b6d61771e2bc3909ea4229777867b217a3e9e580) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_1.grm0_1", 0x000001, 0x80000, CRC(3b852e1a) SHA1(4b3653d55c52fc2eb5438d1604247a8e68d569a5) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_2.grm0_2", 0x000002, 0x80000, CRC(d43ffb35) SHA1(748be07e03bbbb40cd7a725c708cacc46f33d9ca) )
@@ -3763,7 +3730,7 @@ ROM_START( gt3dv17 ) /* Version 1.7 for the 3 tier type PCB with short ROM board
 	ROM_LOAD32_BYTE( "gtg3_grom2_3.grm2_3", 0x400003, 0x80000, CRC(77869bcf) SHA1(dde3b64578b79a94c7e346561a691229bbcfadac) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "gtg3_srom1.srom1", 0x000000, 0x80000, CRC(ac669434) SHA1(6941884c553515f5bc06af772897835a44aa8e4c) )
@@ -3773,18 +3740,18 @@ ROM_START( gt3dv17 ) /* Version 1.7 for the 3 tier type PCB with short ROM board
 	ROM_LOAD16_BYTE( "gtg3_srom3.srom3", 0x000000, 0x20000, CRC(d2462965) SHA1(45d2c9aaac681315d2e5cb39be151467f278e395) )
 ROM_END
 
-ROM_START( gt3dv16 ) /* Version 1.6 for the 3 tier type PCB with short ROM board P/N 1069 REV 2 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt3dv16 ) // Version 1.6 for the 3 tier type PCB with short ROM board P/N 1069 REV 2
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gtg3_prom0_v1.6.prom0", 0x00000, 0x80000, CRC(99d9a7e7) SHA1(62621fba9e9b1e1d11038238ebad8755db58ff21) )
 	ROM_LOAD32_BYTE( "gtg3_prom1_v1.6.prom1", 0x00001, 0x80000, CRC(0ec4b307) SHA1(4e425462a32c7b85b02a694d6c65e69a0eb29ce8) )
 	ROM_LOAD32_BYTE( "gtg3_prom2_v1.6.prom2", 0x00002, 0x80000, CRC(02ce6085) SHA1(8148a0d67646ec1ecb440e087ac20d3e64bf525d) )
 	ROM_LOAD32_BYTE( "gtg3_prom3_v1.6.prom3", 0x00003, 0x80000, CRC(e77fa8a2) SHA1(34c6a5e24c115fdbb33d605aad07c7861ee7f3c8) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "gtg3-snd_u23_v1.1.u23", 0x10000, 0x18000, CRC(2f4cde9f) SHA1(571597e992e334e87307830e4a6a439c9d15fa76) ) /* actually labeled as "GTG3-SND(U23) v1.1" */
+	ROM_LOAD( "gtg3-snd_u23_v1.1.u23", 0x10000, 0x18000, CRC(2f4cde9f) SHA1(571597e992e334e87307830e4a6a439c9d15fa76) ) // actually labeled as "GTG3-SND(U23) v1.1"
 	ROM_CONTINUE(                      0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gtg3_grom0_0.grm0_0", 0x000000, 0x80000, CRC(1b10379d) SHA1(b6d61771e2bc3909ea4229777867b217a3e9e580) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_1.grm0_1", 0x000001, 0x80000, CRC(3b852e1a) SHA1(4b3653d55c52fc2eb5438d1604247a8e68d569a5) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_2.grm0_2", 0x000002, 0x80000, CRC(d43ffb35) SHA1(748be07e03bbbb40cd7a725c708cacc46f33d9ca) )
@@ -3799,7 +3766,7 @@ ROM_START( gt3dv16 ) /* Version 1.6 for the 3 tier type PCB with short ROM board
 	ROM_LOAD32_BYTE( "gtg3_grom2_3.grm2_3", 0x400003, 0x80000, CRC(77869bcf) SHA1(dde3b64578b79a94c7e346561a691229bbcfadac) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "gtg3_srom1.srom1", 0x000000, 0x80000, CRC(ac669434) SHA1(6941884c553515f5bc06af772897835a44aa8e4c) )
@@ -3809,18 +3776,18 @@ ROM_START( gt3dv16 ) /* Version 1.6 for the 3 tier type PCB with short ROM board
 	ROM_LOAD16_BYTE( "gtg3_srom3.srom3", 0x000000, 0x20000, CRC(d2462965) SHA1(45d2c9aaac681315d2e5cb39be151467f278e395) )
 ROM_END
 
-ROM_START( gt3dv15 ) /* Version 1.5 for the 3 tier type PCB with short ROM board P/N 1069 REV 2 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt3dv15 ) // Version 1.5 for the 3 tier type PCB with short ROM board P/N 1069 REV 2
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gtg3_prom0_v1.5.prom0", 0x00000, 0x80000, CRC(51a5e811) SHA1(ee5399e6f8ab2955c875adcb8ec7a859e42daa01) )
 	ROM_LOAD32_BYTE( "gtg3_prom1_v1.5.prom1", 0x00001, 0x80000, CRC(1e8744ad) SHA1(2c38857f88f16b881b93db91ef9d15b710f2d40c) )
 	ROM_LOAD32_BYTE( "gtg3_prom2_v1.5.prom2", 0x00002, 0x80000, CRC(e465c813) SHA1(b836cc01c6fb86980dda2d4418cd1ecb9899cb17) )
 	ROM_LOAD32_BYTE( "gtg3_prom3_v1.5.prom3", 0x00003, 0x80000, CRC(3b25e198) SHA1(5b8cd9771126739e8834c11d0d6ae08b2990e3b0) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "gtg3-snd_u23_v1.1.u23", 0x10000, 0x18000, CRC(2f4cde9f) SHA1(571597e992e334e87307830e4a6a439c9d15fa76) ) /* actually labeled as "GTG3-SND(U23) v1.1" */
+	ROM_LOAD( "gtg3-snd_u23_v1.1.u23", 0x10000, 0x18000, CRC(2f4cde9f) SHA1(571597e992e334e87307830e4a6a439c9d15fa76) ) // actually labeled as "GTG3-SND(U23) v1.1"
 	ROM_CONTINUE(                      0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gtg3_grom0_0.grm0_0", 0x000000, 0x80000, CRC(1b10379d) SHA1(b6d61771e2bc3909ea4229777867b217a3e9e580) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_1.grm0_1", 0x000001, 0x80000, CRC(3b852e1a) SHA1(4b3653d55c52fc2eb5438d1604247a8e68d569a5) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_2.grm0_2", 0x000002, 0x80000, CRC(d43ffb35) SHA1(748be07e03bbbb40cd7a725c708cacc46f33d9ca) )
@@ -3835,7 +3802,7 @@ ROM_START( gt3dv15 ) /* Version 1.5 for the 3 tier type PCB with short ROM board
 	ROM_LOAD32_BYTE( "gtg3_grom2_3.grm2_3", 0x400003, 0x80000, CRC(77869bcf) SHA1(dde3b64578b79a94c7e346561a691229bbcfadac) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "gtg3_srom1.srom1", 0x000000, 0x80000, CRC(ac669434) SHA1(6941884c553515f5bc06af772897835a44aa8e4c) )
@@ -3845,18 +3812,18 @@ ROM_START( gt3dv15 ) /* Version 1.5 for the 3 tier type PCB with short ROM board
 	ROM_LOAD16_BYTE( "gtg3_srom3.srom3", 0x000000, 0x20000, CRC(d2462965) SHA1(45d2c9aaac681315d2e5cb39be151467f278e395) )
 ROM_END
 
-ROM_START( gt3dv14 ) /* Version 1.4 for the 3 tier type PCB with short ROM board P/N 1069 REV 2 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt3dv14 ) // Version 1.4 for the 3 tier type PCB with short ROM board P/N 1069 REV 2
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gtg3_prom0_v1.4.prom0", 0x00000, 0x80000, CRC(396934a7) SHA1(061941e7472f6386be7fa0675ba109dfccb6d35f) )
 	ROM_LOAD32_BYTE( "gtg3_prom1_v1.4.prom1", 0x00001, 0x80000, CRC(5ba19b8d) SHA1(31d6c9c89ad231fb99d2ff762660fa390c53e129) )
 	ROM_LOAD32_BYTE( "gtg3_prom2_v1.4.prom2", 0x00002, 0x80000, CRC(23991fcf) SHA1(5ba460ed88cebe1656501cadff27f2c0c90b721c) )
 	ROM_LOAD32_BYTE( "gtg3_prom3_v1.4.prom3", 0x00003, 0x80000, CRC(2f7b5a26) SHA1(d0e676fc03ff7592f2d6bae806bee242e42c4452) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "gtg3-snd_u23_v1.0.u23", 0x10000, 0x18000, CRC(4f106cd1) SHA1(a3c3e6c649084fe6472e0a1f95d538c67d29098c) ) /* actually labeled as "GTG3-SND(U23) v1.0" */
+	ROM_LOAD( "gtg3-snd_u23_v1.0.u23", 0x10000, 0x18000, CRC(4f106cd1) SHA1(a3c3e6c649084fe6472e0a1f95d538c67d29098c) ) // actually labeled as "GTG3-SND(U23) v1.0"
 	ROM_CONTINUE(                      0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gtg3_grom0_0.grm0_0", 0x000000, 0x80000, CRC(1b10379d) SHA1(b6d61771e2bc3909ea4229777867b217a3e9e580) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_1.grm0_1", 0x000001, 0x80000, CRC(3b852e1a) SHA1(4b3653d55c52fc2eb5438d1604247a8e68d569a5) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_2.grm0_2", 0x000002, 0x80000, CRC(d43ffb35) SHA1(748be07e03bbbb40cd7a725c708cacc46f33d9ca) )
@@ -3871,7 +3838,7 @@ ROM_START( gt3dv14 ) /* Version 1.4 for the 3 tier type PCB with short ROM board
 	ROM_LOAD32_BYTE( "gtg3_grom2_3.grm2_3", 0x400003, 0x80000, CRC(77869bcf) SHA1(dde3b64578b79a94c7e346561a691229bbcfadac) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) /* Ensoniq 2m 1350901601 at "ROM0" */
+	ROM_LOAD16_BYTE( "ensoniq_2m.rom0", 0x000000, 0x200000, CRC(9fdc4825) SHA1(71e5255c66d9010be7e6f27916b605441fc53839) ) // Ensoniq 2m 1350901601 at "ROM0"
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "gtg3_srom1.srom1", 0x000000, 0x80000, CRC(ac669434) SHA1(6941884c553515f5bc06af772897835a44aa8e4c) )
@@ -3881,8 +3848,8 @@ ROM_START( gt3dv14 ) /* Version 1.4 for the 3 tier type PCB with short ROM board
 	ROM_LOAD16_BYTE( "gtg3_srom3.srom3", 0x000000, 0x20000, CRC(d2462965) SHA1(45d2c9aaac681315d2e5cb39be151467f278e395) )
 ROM_END
 
-ROM_START( gt3dt231 ) /* Version 2.31 Tournament Edition (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt3dt231 ) // Version 2.31 Tournament Edition (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gtg3_prom0_v2.31t.prom0", 0x00000, 0x100000, CRC(92a5c3e9) SHA1(a20c9ffb9b08eff1d59b77d08e6411275c58d932) )
 	ROM_LOAD32_BYTE( "gtg3_prom1_v2.31t.prom1", 0x00001, 0x100000, CRC(a3b60226) SHA1(2b78fb2917ad66883d2353d82f48b5aeb599d444) )
 	ROM_LOAD32_BYTE( "gtg3_prom2_v2.31t.prom2", 0x00002, 0x100000, CRC(d1659616) SHA1(7035ce46bde63024237e6c4777ddd10b58caeb98) )
@@ -3892,7 +3859,7 @@ ROM_START( gt3dt231 ) /* Version 2.31 Tournament Edition (PCB P/N 1083 Rev 2) */
 	ROM_LOAD( "gtg3nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gtg3_grom0_0.grm0_0",   0x000000, 0x80000, CRC(1b10379d) SHA1(b6d61771e2bc3909ea4229777867b217a3e9e580) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_1.grm0_1",   0x000001, 0x80000, CRC(3b852e1a) SHA1(4b3653d55c52fc2eb5438d1604247a8e68d569a5) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_2.grm0_2",   0x000002, 0x80000, CRC(d43ffb35) SHA1(748be07e03bbbb40cd7a725c708cacc46f33d9ca) )
@@ -3901,7 +3868,7 @@ ROM_START( gt3dt231 ) /* Version 2.31 Tournament Edition (PCB P/N 1083 Rev 2) */
 	ROM_LOAD32_BYTE( "gtg3_grom1_1.grm1_1",   0x200001, 0x80000, CRC(0aadfad2) SHA1(56a283b30a13b77ec53b7ae2b4129d44b7fa25d4) )
 	ROM_LOAD32_BYTE( "gtg3_grom1_2.grm1_2",   0x200002, 0x80000, CRC(27871980) SHA1(fe473d12cb4805e25dcac8f9ae187891936b961b) )
 	ROM_LOAD32_BYTE( "gtg3_grom1_3.grm1_3",   0x200003, 0x80000, CRC(7dbc242b) SHA1(9aa5074cad633446e0110a1a3d9c6e1f2158070a) )
-	ROM_LOAD32_BYTE( "gtg3_grom2_0_t.grm2_0", 0x400000, 0x80000, CRC(80ae7148) SHA1(e19d3390a2a0dad260d770fdbbb64d1f8e43d53f) ) /* actually labeled as "GTG3 GROM2_0 T" ect */
+	ROM_LOAD32_BYTE( "gtg3_grom2_0_t.grm2_0", 0x400000, 0x80000, CRC(80ae7148) SHA1(e19d3390a2a0dad260d770fdbbb64d1f8e43d53f) ) // actually labeled as "GTG3 GROM2_0 T" ect
 	ROM_LOAD32_BYTE( "gtg3_grom2_1_t.grm2_1", 0x400001, 0x80000, CRC(0f85a618) SHA1(d9ced21c20f9ed6b7f19e7645d75b239ea709b79) )
 	ROM_LOAD32_BYTE( "gtg3_grom2_2_t.grm2_2", 0x400002, 0x80000, CRC(09ca5fbf) SHA1(6a6ed4d5d76035d8acc33c6494fba6012194362e) )
 	ROM_LOAD32_BYTE( "gtg3_grom2_3_t.grm2_3", 0x400003, 0x80000, CRC(d136853a) SHA1(0777d6bfab9e3d57c2a61d058fd185fc1f547698) )
@@ -3911,8 +3878,8 @@ ROM_START( gt3dt231 ) /* Version 2.31 Tournament Edition (PCB P/N 1083 Rev 2) */
 	ROM_LOAD16_BYTE( "gtg3_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gt3dt211 ) /* Version 2.11 Tournament Edition (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt3dt211 ) // Version 2.11 Tournament Edition (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gtg3_prom0_v2.11t.prom0", 0x00000, 0x100000, CRC(54360fdf) SHA1(05687f7f41f719458ee72b4517c7be3e33ee80cf) )
 	ROM_LOAD32_BYTE( "gtg3_prom1_v2.11t.prom1", 0x00001, 0x100000, CRC(9142ebb7) SHA1(ae3c9bf1a954c2f790cdb7953a6fea3d1d277aa9) )
 	ROM_LOAD32_BYTE( "gtg3_prom2_v2.11t.prom2", 0x00002, 0x100000, CRC(058b906a) SHA1(ff2cb3b955f7ce8041c967ed08b92e355d9abe2d) )
@@ -3922,8 +3889,8 @@ ROM_START( gt3dt211 ) /* Version 2.11 Tournament Edition (PCB P/N 1083 Rev 2) */
 	ROM_LOAD( "gtg3nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
-	ROM_LOAD32_BYTE( "gtg3_grom0_0++.grm0_0", 0x000000, 0x100000, CRC(22c481b7) SHA1(399bffec5e3b27aec2ebd8d7d49689b92f453e39) ) /* actually labeled "GTG3 GROM0_0**" ect */
+	ROM_REGION( 0x600000, "grom", 0 )
+	ROM_LOAD32_BYTE( "gtg3_grom0_0++.grm0_0", 0x000000, 0x100000, CRC(22c481b7) SHA1(399bffec5e3b27aec2ebd8d7d49689b92f453e39) ) // actually labeled "GTG3 GROM0_0**" ect
 	ROM_LOAD32_BYTE( "gtg3_grom0_1++.grm0_1", 0x000001, 0x100000, CRC(40e4032b) SHA1(e8a39ce415cf2326464efc5af23e9b7921621932) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_2++.grm0_2", 0x000002, 0x100000, CRC(67a02ef9) SHA1(4f9e5217eeaf68fc72af1dc9e3a16d876de8d11d) )
 	ROM_LOAD32_BYTE( "gtg3_grom0_3++.grm0_3", 0x000003, 0x100000, CRC(1173a710) SHA1(1f612c1efbf38796707f5b5fecf9d4044691f031) )
@@ -3931,7 +3898,7 @@ ROM_START( gt3dt211 ) /* Version 2.11 Tournament Edition (PCB P/N 1083 Rev 2) */
 	The above 4 ROMs have the same exact data as the other sets, but in 8 meg ROMs instead of 4 meg ROMs.
 	This is the only set that specifically checks for these ROMs in this format
 	*/
-	ROM_LOAD32_BYTE( "gtg3_grom1_0+.grm1_0", 0x400000, 0x080000, CRC(80ae7148) SHA1(e19d3390a2a0dad260d770fdbbb64d1f8e43d53f) ) /* actually labeled "GTG3 GROM1_0*" ect */
+	ROM_LOAD32_BYTE( "gtg3_grom1_0+.grm1_0", 0x400000, 0x080000, CRC(80ae7148) SHA1(e19d3390a2a0dad260d770fdbbb64d1f8e43d53f) ) // actually labeled "GTG3 GROM1_0*" ect
 	ROM_LOAD32_BYTE( "gtg3_grom1_1+.grm1_1", 0x400001, 0x080000, CRC(0f85a618) SHA1(d9ced21c20f9ed6b7f19e7645d75b239ea709b79) )
 	ROM_LOAD32_BYTE( "gtg3_grom1_2+.grm1_2", 0x400002, 0x080000, CRC(09ca5fbf) SHA1(6a6ed4d5d76035d8acc33c6494fba6012194362e) )
 	ROM_LOAD32_BYTE( "gtg3_grom1_3+.grm1_3", 0x400003, 0x080000, CRC(d136853a) SHA1(0777d6bfab9e3d57c2a61d058fd185fc1f547698) )
@@ -3942,8 +3909,8 @@ ROM_START( gt3dt211 ) /* Version 2.11 Tournament Edition (PCB P/N 1083 Rev 2) */
 ROM_END
 
 
-ROM_START( gt97 ) /* Version 1.30 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt97 ) // Version 1.30
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt97_prom0_v1.30.prom0", 0x00000, 0x80000, CRC(7490ba4e) SHA1(b833d4175617727b3dc80e242457996a2efb844c) )
 	ROM_LOAD32_BYTE( "gt97_prom1_v1.30.prom1", 0x00001, 0x80000, CRC(71f9c5f3) SHA1(c472aa1bcc217656f409614b73f0b7662215c202) )
 	ROM_LOAD32_BYTE( "gt97_prom2_v1.30.prom2", 0x00002, 0x80000, CRC(8292b51a) SHA1(f8167b0aef87fb286006a17043de041c71afe41d) )
@@ -3953,7 +3920,7 @@ ROM_START( gt97 ) /* Version 1.30 */
 	ROM_LOAD( "gt97nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt97_grom0_0.grm0_0", 0x000000, 0x80000, CRC(81784aaf) SHA1(9544ed2087ca5f71c747e3b782513614937a51ed) )
 	ROM_LOAD32_BYTE( "gt97_grom0_1.grm0_1", 0x000001, 0x80000, CRC(345bda44) SHA1(b6d66c99bd68396e1e94ece76989a6190571ae14) )
 	ROM_LOAD32_BYTE( "gt97_grom0_2.grm0_2", 0x000002, 0x80000, CRC(b2beb40d) SHA1(2b955919e7e5f9093eb3a856f93c39684437b371) )
@@ -3972,8 +3939,8 @@ ROM_START( gt97 ) /* Version 1.30 */
 	ROM_LOAD16_BYTE( "gt97_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gt97v122 ) /* Version 1.22 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt97v122 ) // Version 1.22
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt97_prom0_v1.22.prom0", 0x00000, 0x80000, CRC(4a543c99) SHA1(733b904a964c02a118186eaa0e4ff7670fb8ffef) )
 	ROM_LOAD32_BYTE( "gt97_prom1_v1.22.prom1", 0x00001, 0x80000, CRC(27668628) SHA1(f0816f4589536de0dc30aef3eb2b99b2a22ddba4) )
 	ROM_LOAD32_BYTE( "gt97_prom2_v1.22.prom2", 0x00002, 0x80000, CRC(d73a769f) SHA1(41c2416424efbd9d341ab5eea1451402dca1c340) )
@@ -3983,7 +3950,7 @@ ROM_START( gt97v122 ) /* Version 1.22 */
 	ROM_LOAD( "gt97nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt97_grom0_0.grm0_0", 0x000000, 0x80000, CRC(81784aaf) SHA1(9544ed2087ca5f71c747e3b782513614937a51ed) )
 	ROM_LOAD32_BYTE( "gt97_grom0_1.grm0_1", 0x000001, 0x80000, CRC(345bda44) SHA1(b6d66c99bd68396e1e94ece76989a6190571ae14) )
 	ROM_LOAD32_BYTE( "gt97_grom0_2.grm0_2", 0x000002, 0x80000, CRC(b2beb40d) SHA1(2b955919e7e5f9093eb3a856f93c39684437b371) )
@@ -4002,8 +3969,8 @@ ROM_START( gt97v122 ) /* Version 1.22 */
 	ROM_LOAD16_BYTE( "gt97_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gt97v121 ) /* Version 1.21 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt97v121 ) // Version 1.21
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt97_prom0_v1.21.prom0", 0x00000, 0x80000, CRC(a210a2c6) SHA1(40475387d731ab87957e6b46725195a057d42067) )
 	ROM_LOAD32_BYTE( "gt97_prom1_v1.21.prom1", 0x00001, 0x80000, CRC(a60806f8) SHA1(8695a24d7f186462bcfdfaa391896c7518717c57) )
 	ROM_LOAD32_BYTE( "gt97_prom2_v1.21.prom2", 0x00002, 0x80000, CRC(a97ce668) SHA1(b392a3aab1f1887adc31fb802e7d7bedeb36c3c9) )
@@ -4013,7 +3980,7 @@ ROM_START( gt97v121 ) /* Version 1.21 */
 	ROM_LOAD( "gt97nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt97_grom0_0.grm0_0", 0x000000, 0x80000, CRC(81784aaf) SHA1(9544ed2087ca5f71c747e3b782513614937a51ed) )
 	ROM_LOAD32_BYTE( "gt97_grom0_1.grm0_1", 0x000001, 0x80000, CRC(345bda44) SHA1(b6d66c99bd68396e1e94ece76989a6190571ae14) )
 	ROM_LOAD32_BYTE( "gt97_grom0_2.grm0_2", 0x000002, 0x80000, CRC(b2beb40d) SHA1(2b955919e7e5f9093eb3a856f93c39684437b371) )
@@ -4032,21 +3999,21 @@ ROM_START( gt97v121 ) /* Version 1.21 */
 	ROM_LOAD16_BYTE( "gt97_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gt97s121 ) /* Version 1.21S for the 3 tier type PCB with short ROM board P/N 1088 Rev 0 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt97s121 ) // Version 1.21S for the 3 tier type PCB with short ROM board P/N 1088 Rev 0
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt97_prom0_v1.21s.prom0", 0x00000, 0x80000, CRC(1143f45b) SHA1(df1f30d8054133be140f66219d69cd6bff74713a) )
 	ROM_LOAD32_BYTE( "gt97_prom1_v1.21s.prom1", 0x00001, 0x80000, CRC(e7cfb1ea) SHA1(8f6cf3cae920e07e14009a933821abe5b0ec6eb1) )
 	ROM_LOAD32_BYTE( "gt97_prom2_v1.21s.prom2", 0x00002, 0x80000, CRC(0cc24291) SHA1(941cada0f6c34ce8f6a23d5bf3ba052bb0edd9f1) )
 	ROM_LOAD32_BYTE( "gt97_prom3_v1.21s.prom3", 0x00003, 0x80000, CRC(922727c2) SHA1(57f8b772841fdf2fb575301698ed60b119392ec9) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "gtg3_nr_u23_v2.2.u23", 0x10000, 0x18000, CRC(04effd73) SHA1(4277031655f8de851eba0e4134ba619a12f5dd4a) ) /* actually labeled "GTG3 NR(U23) V2.2" */
+	ROM_LOAD( "gtg3_nr_u23_v2.2.u23", 0x10000, 0x18000, CRC(04effd73) SHA1(4277031655f8de851eba0e4134ba619a12f5dd4a) ) // actually labeled "GTG3 NR(U23) V2.2"
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
 	ROM_REGION( 0x2000, "pic", 0 ) // PIC16C54
 	ROM_LOAD( "itgfm-3 1997 it, inc", 0x0000, 0x1fff, CRC(2527dffc) SHA1(e7e1d9f2f813c5770cb0a340e68b700fc5c39991) ) // not hooked up
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt97_grom0_0.grm0_0", 0x000000, 0x80000, CRC(81784aaf) SHA1(9544ed2087ca5f71c747e3b782513614937a51ed) )
 	ROM_LOAD32_BYTE( "gt97_grom0_1.grm0_1", 0x000001, 0x80000, CRC(345bda44) SHA1(b6d66c99bd68396e1e94ece76989a6190571ae14) )
 	ROM_LOAD32_BYTE( "gt97_grom0_2.grm0_2", 0x000002, 0x80000, CRC(b2beb40d) SHA1(2b955919e7e5f9093eb3a856f93c39684437b371) )
@@ -4061,12 +4028,12 @@ ROM_START( gt97s121 ) /* Version 1.21S for the 3 tier type PCB with short ROM bo
 	ROM_LOAD32_BYTE( "gt97_grom2_3.grm2_3", 0x400003, 0x80000, CRC(72e8ae60) SHA1(410da9970c50021f1724c8c51678691322eece92) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "gtg3_srom1_nr++.srom1", 0x000000, 0x100000, CRC(44983bd7) SHA1(a6ac966ec113b079434d7f871e4ce7266206d234) ) /* actually labeled "GTG3 SROM1 NR**" */
-	ROM_LOAD16_BYTE( "gtg3_srom2_nr+.srom2",  0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) ) /* actually labeled "GTG3 SROM2 NR*"  */
+	ROM_LOAD16_BYTE( "gtg3_srom1_nr++.srom1", 0x000000, 0x100000, CRC(44983bd7) SHA1(a6ac966ec113b079434d7f871e4ce7266206d234) ) // actually labeled "GTG3 SROM1 NR**"
+	ROM_LOAD16_BYTE( "gtg3_srom2_nr+.srom2",  0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) ) // actually labeled "GTG3 SROM2 NR*" 
 ROM_END
 
-ROM_START( gt97v120 ) /* Version 1.20 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt97v120 ) // Version 1.20
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt97_prom0_v1.20.prom0", 0x00000, 0x80000, CRC(cdc4226f) SHA1(35ae8514f543f1cf45b303952f34a0a395733268) )
 	ROM_LOAD32_BYTE( "gt97_prom1_v1.20.prom1", 0x00001, 0x80000, CRC(b36fc43f) SHA1(43e5acbb751b216e8da0249eb3e596d8e453b0dc) )
 	ROM_LOAD32_BYTE( "gt97_prom2_v1.20.prom2", 0x00002, 0x80000, CRC(30b0d97e) SHA1(423808f0957cd259a33f5fad43222edbacb445ea) )
@@ -4076,7 +4043,7 @@ ROM_START( gt97v120 ) /* Version 1.20 */
 	ROM_LOAD( "gt97nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt97_grom0_0.grm0_0", 0x000000, 0x80000, CRC(81784aaf) SHA1(9544ed2087ca5f71c747e3b782513614937a51ed) )
 	ROM_LOAD32_BYTE( "gt97_grom0_1.grm0_1", 0x000001, 0x80000, CRC(345bda44) SHA1(b6d66c99bd68396e1e94ece76989a6190571ae14) )
 	ROM_LOAD32_BYTE( "gt97_grom0_2.grm0_2", 0x000002, 0x80000, CRC(b2beb40d) SHA1(2b955919e7e5f9093eb3a856f93c39684437b371) )
@@ -4095,8 +4062,8 @@ ROM_START( gt97v120 ) /* Version 1.20 */
 	ROM_LOAD16_BYTE( "gt97_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gt97t243 ) /* Version 2.43 Tournament Edition (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt97t243 ) // Version 2.43 Tournament Edition (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt97_prom0_v2.43t.prom0", 0x00000, 0x100000, CRC(b8de60f1) SHA1(06b1f8b9d0b878d5a19e6756957e2df19e013ad6) )
 	ROM_LOAD32_BYTE( "gt97_prom1_v2.43t.prom1", 0x00001, 0x100000, CRC(8152e5d3) SHA1(2a4f8acc6a4e33864c97d5974e2230b1cf3632ea) )
 	ROM_LOAD32_BYTE( "gt97_prom2_v2.43t.prom2", 0x00002, 0x100000, CRC(b80061be) SHA1(9a6a6281690b3bd2eabb081467bfda074639fa6a) )
@@ -4106,7 +4073,7 @@ ROM_START( gt97t243 ) /* Version 2.43 Tournament Edition (PCB P/N 1083 Rev 2) */
 	ROM_LOAD( "gt97nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt97_grom0_0.grm0_0", 0x000000, 0x80000, CRC(81784aaf) SHA1(9544ed2087ca5f71c747e3b782513614937a51ed) )
 	ROM_LOAD32_BYTE( "gt97_grom0_1.grm0_1", 0x000001, 0x80000, CRC(345bda44) SHA1(b6d66c99bd68396e1e94ece76989a6190571ae14) )
 	ROM_LOAD32_BYTE( "gt97_grom0_2.grm0_2", 0x000002, 0x80000, CRC(b2beb40d) SHA1(2b955919e7e5f9093eb3a856f93c39684437b371) )
@@ -4125,8 +4092,8 @@ ROM_START( gt97t243 ) /* Version 2.43 Tournament Edition (PCB P/N 1083 Rev 2) */
 	ROM_LOAD16_BYTE( "gt97_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gt97t240 ) /* Version 2.40 Tournament Edition (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt97t240 ) // Version 2.40 Tournament Edition (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt97_prom0_v2.40t.prom0", 0x00000, 0x100000, CRC(88a386d0) SHA1(003dbf784125b1a442f85e18f8161695dcacc3a8) )
 	ROM_LOAD32_BYTE( "gt97_prom1_v2.40t.prom1", 0x00001, 0x100000, CRC(b0d751aa) SHA1(7e6ab9c2bb0bd4f50360655c59f48c44f6135f4f) )
 	ROM_LOAD32_BYTE( "gt97_prom2_v2.40t.prom2", 0x00002, 0x100000, CRC(451be534) SHA1(2f78cdba607c4b936b5cbdb520757d038d9aa7a3) )
@@ -4136,7 +4103,7 @@ ROM_START( gt97t240 ) /* Version 2.40 Tournament Edition (PCB P/N 1083 Rev 2) */
 	ROM_LOAD( "gt97nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt97_grom0_0.grm0_0", 0x000000, 0x80000, CRC(81784aaf) SHA1(9544ed2087ca5f71c747e3b782513614937a51ed) )
 	ROM_LOAD32_BYTE( "gt97_grom0_1.grm0_1", 0x000001, 0x80000, CRC(345bda44) SHA1(b6d66c99bd68396e1e94ece76989a6190571ae14) )
 	ROM_LOAD32_BYTE( "gt97_grom0_2.grm0_2", 0x000002, 0x80000, CRC(b2beb40d) SHA1(2b955919e7e5f9093eb3a856f93c39684437b371) )
@@ -4156,8 +4123,8 @@ ROM_START( gt97t240 ) /* Version 2.40 Tournament Edition (PCB P/N 1083 Rev 2) */
 ROM_END
 
 
-ROM_START( gt98 )   /* Version 1.10 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt98 )   // Version 1.10
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt98_prom0_v1.10.prom0", 0x00000, 0x80000, CRC(dd93ab2a) SHA1(b7eb6331f781422d6d46babcc24a85ae36b25914) )
 	ROM_LOAD32_BYTE( "gt98_prom1_v1.10.prom1", 0x00001, 0x80000, CRC(6ea92960) SHA1(05d22ad6c6027afe7ebb3bc7c70f58d840ed3d4e) )
 	ROM_LOAD32_BYTE( "gt98_prom2_v1.10.prom2", 0x00002, 0x80000, CRC(27a8a15f) SHA1(f1eb7b24f9cb77877ceaa033abfde124e159cb2b) )
@@ -4167,7 +4134,7 @@ ROM_START( gt98 )   /* Version 1.10 */
 	ROM_LOAD( "gt98nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt98_grom0_0.grm0_0", 0x000000, 0x80000, CRC(2d79492b) SHA1(16d66d937c34ddf616f31cba0d285326a31cad85) )
 	ROM_LOAD32_BYTE( "gt98_grom0_1.grm0_1", 0x000001, 0x80000, CRC(79afda1a) SHA1(77a9883f14b58ceece9c76ce88bb900bc4accf25) )
 	ROM_LOAD32_BYTE( "gt98_grom0_2.grm0_2", 0x000002, 0x80000, CRC(8c381f56) SHA1(41a5b70f9e524a1cade031f864350ec75c08c956) )
@@ -4186,8 +4153,8 @@ ROM_START( gt98 )   /* Version 1.10 */
 	ROM_LOAD16_BYTE( "gt98_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gt98v100 )   /* Version 1.00 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt98v100 )   // Version 1.00
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt98_prom0_v1.00.prom0", 0x00000, 0x80000, CRC(f2dc0a6c) SHA1(59f7f8c7feb30c6416cb4ac2299f2c620d4c4e5f) )
 	ROM_LOAD32_BYTE( "gt98_prom1_v1.00.prom1", 0x00001, 0x80000, CRC(b0ca22f3) SHA1(f849b42d449e07a12e0bc20b98693125506c7ed6) )
 	ROM_LOAD32_BYTE( "gt98_prom2_v1.00.prom2", 0x00002, 0x80000, CRC(f940acdc) SHA1(3b5f5f299dbd7d4e0bef4aac8787f955f31754c2) )
@@ -4197,7 +4164,7 @@ ROM_START( gt98v100 )   /* Version 1.00 */
 	ROM_LOAD( "gt98nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt98_grom0_0.grm0_0", 0x000000, 0x80000, CRC(2d79492b) SHA1(16d66d937c34ddf616f31cba0d285326a31cad85) )
 	ROM_LOAD32_BYTE( "gt98_grom0_1.grm0_1", 0x000001, 0x80000, CRC(79afda1a) SHA1(77a9883f14b58ceece9c76ce88bb900bc4accf25) )
 	ROM_LOAD32_BYTE( "gt98_grom0_2.grm0_2", 0x000002, 0x80000, CRC(8c381f56) SHA1(41a5b70f9e524a1cade031f864350ec75c08c956) )
@@ -4216,8 +4183,8 @@ ROM_START( gt98v100 )   /* Version 1.00 */
 	ROM_LOAD16_BYTE( "gt98_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gt98c100 )   /* Version 1.00C */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt98c100 )   // Version 1.00C
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt98_prom0_v1.00c.prom0", 0x00000, 0x80000, CRC(bb508580) SHA1(6ba243386a32dbe9b14b3cef8d9ce9fac8ec4b28) )
 	ROM_LOAD32_BYTE( "gt98_prom1_v1.00c.prom1", 0x00001, 0x80000, CRC(0e414c17) SHA1(08dae822c4e0b3c5c7e7f09e77e01d3663067927) )
 	ROM_LOAD32_BYTE( "gt98_prom2_v1.00c.prom2", 0x00002, 0x80000, CRC(628e84eb) SHA1(b31b74bee1ab4eda7c8f1c4e62bd61837b2c9f1f) )
@@ -4227,7 +4194,7 @@ ROM_START( gt98c100 )   /* Version 1.00C */
 	ROM_LOAD( "gt98nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt98_grom0_0.grm0_0", 0x000000, 0x80000, CRC(2d79492b) SHA1(16d66d937c34ddf616f31cba0d285326a31cad85) )
 	ROM_LOAD32_BYTE( "gt98_grom0_1.grm0_1", 0x000001, 0x80000, CRC(79afda1a) SHA1(77a9883f14b58ceece9c76ce88bb900bc4accf25) )
 	ROM_LOAD32_BYTE( "gt98_grom0_2.grm0_2", 0x000002, 0x80000, CRC(8c381f56) SHA1(41a5b70f9e524a1cade031f864350ec75c08c956) )
@@ -4246,18 +4213,18 @@ ROM_START( gt98c100 )   /* Version 1.00C */
 	ROM_LOAD16_BYTE( "gt98_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gt98s100 ) /* Version 1.00S for the 3 tier type PCB with short ROM board P/N 1088 Rev 0 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt98s100 ) // Version 1.00S for the 3 tier type PCB with short ROM board P/N 1088 Rev 0
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt98_prom0_v1.00s.prom0", 0x00000, 0x80000, CRC(962ff444) SHA1(f9abefaee82f811ef1d3df45782edd5bcb1da23a) )
 	ROM_LOAD32_BYTE( "gt98_prom1_v1.00s.prom1", 0x00001, 0x80000, CRC(be0ac375) SHA1(40b99004a7698866eeb0e2defda52e61be455f36) )
 	ROM_LOAD32_BYTE( "gt98_prom2_v1.00s.prom2", 0x00002, 0x80000, CRC(304e881c) SHA1(582ff2c1c03853eec9830663d5263b499e68f285) )
 	ROM_LOAD32_BYTE( "gt98_prom3_v1.00s.prom3", 0x00003, 0x80000, CRC(ac04ea81) SHA1(f8a7c896cb0af747bab49b3438f52aaa1b0dfc73) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "gtg3_nr_u23_v2.2.u23", 0x10000, 0x18000, CRC(04effd73) SHA1(4277031655f8de851eba0e4134ba619a12f5dd4a) ) /* actually labeled "GTG3 NR(U23) V2.2" */
+	ROM_LOAD( "gtg3_nr_u23_v2.2.u23", 0x10000, 0x18000, CRC(04effd73) SHA1(4277031655f8de851eba0e4134ba619a12f5dd4a) ) // actually labeled "GTG3 NR(U23) V2.2"
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt98_grom0_0.grm0_0", 0x000000, 0x80000, CRC(2d79492b) SHA1(16d66d937c34ddf616f31cba0d285326a31cad85) )
 	ROM_LOAD32_BYTE( "gt98_grom0_1.grm0_1", 0x000001, 0x80000, CRC(79afda1a) SHA1(77a9883f14b58ceece9c76ce88bb900bc4accf25) )
 	ROM_LOAD32_BYTE( "gt98_grom0_2.grm0_2", 0x000002, 0x80000, CRC(8c381f56) SHA1(41a5b70f9e524a1cade031f864350ec75c08c956) )
@@ -4272,12 +4239,12 @@ ROM_START( gt98s100 ) /* Version 1.00S for the 3 tier type PCB with short ROM bo
 	ROM_LOAD32_BYTE( "gt98_grom2_3.grm2_3", 0x400003, 0x80000, CRC(78745131) SHA1(c430be4cb650f1f6265406ca8fcad8df809282f5) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "gtg3_srom1_nr++.srom1", 0x000000, 0x100000, CRC(44983bd7) SHA1(a6ac966ec113b079434d7f871e4ce7266206d234) ) /* actually labeled "GTG3 SROM1 NR**" */
-	ROM_LOAD16_BYTE( "gtg3_srom2_nr+.srom2",  0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) ) /* actually labeled "GTG3 SROM2 NR*"  */
+	ROM_LOAD16_BYTE( "gtg3_srom1_nr++.srom1", 0x000000, 0x100000, CRC(44983bd7) SHA1(a6ac966ec113b079434d7f871e4ce7266206d234) ) // actually labeled "GTG3 SROM1 NR**"
+	ROM_LOAD16_BYTE( "gtg3_srom2_nr+.srom2",  0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) ) // actually labeled "GTG3 SROM2 NR*" 
 ROM_END
 
-ROM_START( gt98t303 )   /* Version 3.03 Tournament Edition (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt98t303 )   // Version 3.03 Tournament Edition (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt98_prom0_v3.03t.prom0", 0x00000, 0x100000, CRC(e3879c30) SHA1(fa9dd2df8969a98a3c87c6a96594e1f49ca7ec91) )
 	ROM_LOAD32_BYTE( "gt98_prom1_v3.03t.prom1", 0x00001, 0x100000, CRC(6a42ab1e) SHA1(9d8c5a48f0b91dcc8898913eec3d09ddded0f43d) )
 	ROM_LOAD32_BYTE( "gt98_prom2_v3.03t.prom2", 0x00002, 0x100000, CRC(a695c1bc) SHA1(e10ce3a97c28ba439c06b2cbd3ebe0cb456687a9) )
@@ -4287,7 +4254,7 @@ ROM_START( gt98t303 )   /* Version 3.03 Tournament Edition (PCB P/N 1083 Rev 2) 
 	ROM_LOAD( "gt98nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt98_grom0_0.grm0_0", 0x000000, 0x80000, CRC(2d79492b) SHA1(16d66d937c34ddf616f31cba0d285326a31cad85) )
 	ROM_LOAD32_BYTE( "gt98_grom0_1.grm0_1", 0x000001, 0x80000, CRC(79afda1a) SHA1(77a9883f14b58ceece9c76ce88bb900bc4accf25) )
 	ROM_LOAD32_BYTE( "gt98_grom0_2.grm0_2", 0x000002, 0x80000, CRC(8c381f56) SHA1(41a5b70f9e524a1cade031f864350ec75c08c956) )
@@ -4306,8 +4273,8 @@ ROM_START( gt98t303 )   /* Version 3.03 Tournament Edition (PCB P/N 1083 Rev 2) 
 	ROM_LOAD16_BYTE( "gt98_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gt98t302 )   /* Version 3.02 Tournament Edition (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt98t302 )   // Version 3.02 Tournament Edition (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt98_prom0_v3.02t.prom0", 0x00000, 0x100000, CRC(744e0d9b) SHA1(affb05390485d3523478199493e15f32359511f1) )
 	ROM_LOAD32_BYTE( "gt98_prom1_v3.02t.prom1", 0x00001, 0x100000, CRC(b25508a1) SHA1(a744a212cb95852e1b7eb3051bb12a448e161ca7) )
 	ROM_LOAD32_BYTE( "gt98_prom2_v3.02t.prom2", 0x00002, 0x100000, CRC(98a3466e) SHA1(a0f8a897cb7b4752c63079c04725e7800e71ae13) )
@@ -4317,7 +4284,7 @@ ROM_START( gt98t302 )   /* Version 3.02 Tournament Edition (PCB P/N 1083 Rev 2) 
 	ROM_LOAD( "gt98nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt98_grom0_0.grm0_0", 0x000000, 0x80000, CRC(2d79492b) SHA1(16d66d937c34ddf616f31cba0d285326a31cad85) )
 	ROM_LOAD32_BYTE( "gt98_grom0_1.grm0_1", 0x000001, 0x80000, CRC(79afda1a) SHA1(77a9883f14b58ceece9c76ce88bb900bc4accf25) )
 	ROM_LOAD32_BYTE( "gt98_grom0_2.grm0_2", 0x000002, 0x80000, CRC(8c381f56) SHA1(41a5b70f9e524a1cade031f864350ec75c08c956) )
@@ -4336,8 +4303,8 @@ ROM_START( gt98t302 )   /* Version 3.02 Tournament Edition (PCB P/N 1083 Rev 2) 
 	ROM_LOAD16_BYTE( "gt98_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gtdiamond )  /* Version 3.05TL Tournament Edition (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gtdiamond )  // Version 3.05TL Tournament Edition (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt98_golf_elc_prom0_v3.05tl.prom0", 0x00000, 0x100000, CRC(b6b0e3b8) SHA1(e2ff88f205ad902d78b8c52ed554eb612c300d3c) )
 	ROM_LOAD32_BYTE( "gt98_golf_elc_prom1_v3.05tl.prom1", 0x00001, 0x100000, CRC(ba15f3a3) SHA1(9ebe81c3f7f8526bf73c6728071905e7803b4101) )
 	ROM_LOAD32_BYTE( "gt98_golf_elc_prom2_v3.05tl.prom2", 0x00002, 0x100000, CRC(015e1c94) SHA1(836f84272133d47a1742488e12a35af1832999bc) )
@@ -4347,7 +4314,7 @@ ROM_START( gtdiamond )  /* Version 3.05TL Tournament Edition (PCB P/N 1083 Rev 2
 	ROM_LOAD( "gt98nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt98_grom0_0.grm0_0", 0x000000, 0x80000, CRC(2d79492b) SHA1(16d66d937c34ddf616f31cba0d285326a31cad85) )
 	ROM_LOAD32_BYTE( "gt98_grom0_1.grm0_1", 0x000001, 0x80000, CRC(79afda1a) SHA1(77a9883f14b58ceece9c76ce88bb900bc4accf25) )
 	ROM_LOAD32_BYTE( "gt98_grom0_2.grm0_2", 0x000002, 0x80000, CRC(8c381f56) SHA1(41a5b70f9e524a1cade031f864350ec75c08c956) )
@@ -4357,9 +4324,9 @@ ROM_START( gtdiamond )  /* Version 3.05TL Tournament Edition (PCB P/N 1083 Rev 2
 	ROM_LOAD32_BYTE( "gt98_grom1_2.grm1_2", 0x200002, 0x80000, CRC(9c113abc) SHA1(8cb23da237dce73bbd283662c6344876d1c352f3) )
 	ROM_LOAD32_BYTE( "gt98_grom1_3.grm1_3", 0x200003, 0x80000, CRC(231bbe58) SHA1(b662a2ffd881a22ec0503810dca8bd61a4994463) )
 
-	/* The Euro version has different GROM2_x compared to the standard US versions. */
+	// The Euro version has different GROM2_x compared to the standard US versions.
 
-	ROM_LOAD32_BYTE( "gt98_grome2_0.grm2_0", 0x400000, 0x80000, CRC(0c898920) SHA1(9e656f94e79fd16a51706559fbe66fd0df1e670c) ) /* actually labeled "GT98 GROME2_0" ect.. */
+	ROM_LOAD32_BYTE( "gt98_grome2_0.grm2_0", 0x400000, 0x80000, CRC(0c898920) SHA1(9e656f94e79fd16a51706559fbe66fd0df1e670c) ) // actually labeled "GT98 GROME2_0" ect..
 	ROM_LOAD32_BYTE( "gt98_grome2_1.grm2_1", 0x400001, 0x80000, CRC(cbe5b2b2) SHA1(f661dbd472775c99a5a4b35965c992b3de6e0984) )
 	ROM_LOAD32_BYTE( "gt98_grome2_2.grm2_2", 0x400002, 0x80000, CRC(71bd4441) SHA1(6cb36aafb50ec0a9193a1a885f31a02d1fdd059d) )
 	ROM_LOAD32_BYTE( "gt98_grome2_3.grm2_3", 0x400003, 0x80000, CRC(86149804) SHA1(32fcde6061c9cea991c8d1d96e32b99a5ef2e825) )
@@ -4370,8 +4337,8 @@ ROM_START( gtdiamond )  /* Version 3.05TL Tournament Edition (PCB P/N 1083 Rev 2
 ROM_END
 
 
-ROM_START( gt99 )   /* Version 1.00 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt99 )   // Version 1.00
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt99_prom0_v1.00.prom0", 0x00000, 0x80000, CRC(1ca05267) SHA1(431788db68122df5b6c0642ffc84954fb3043295) )
 	ROM_LOAD32_BYTE( "gt99_prom1_v1.00.prom1", 0x00001, 0x80000, CRC(4fb757fa) SHA1(9efa6f933b20e5a6de9a5da3c0197cf29c8f1df2) )
 	ROM_LOAD32_BYTE( "gt99_prom2_v1.00.prom2", 0x00002, 0x80000, CRC(3eb2b13a) SHA1(6b6b79c7f07cc345f392d12625548c8fae6a1d42) )
@@ -4381,7 +4348,7 @@ ROM_START( gt99 )   /* Version 1.00 */
 	ROM_LOAD( "gt99nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt99_grom0_0.grm0_0", 0x000000, 0x80000, CRC(c22b50f9) SHA1(9e8acfce6cc30adc150b602d026c00fa1fb7747f) )
 	ROM_LOAD32_BYTE( "gt99_grom0_1.grm0_1", 0x000001, 0x80000, CRC(d6d6be57) SHA1(fda20185e842dd4aa1a1601f95e5cc787644f4c3) )
 	ROM_LOAD32_BYTE( "gt99_grom0_2.grm0_2", 0x000002, 0x80000, CRC(005d4791) SHA1(b03d5835465ccc4fe73f4adb1342ef2b38aad90c) )
@@ -4391,7 +4358,7 @@ ROM_START( gt99 )   /* Version 1.00 */
 	ROM_LOAD32_BYTE( "gt99_grom1_2.grm1_2", 0x200002, 0x80000, CRC(d73d8afc) SHA1(2fced1ee7dd11c6db07750f617356c6608ac0291) )
 	ROM_LOAD32_BYTE( "gt99_grom1_3.grm1_3", 0x200003, 0x80000, CRC(59f48688) SHA1(37b2c84e487f4f3a9145bef34c573a3716b4a6a7) )
 
-	/* GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic */
+	// GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic
 
 	ROM_LOAD32_BYTE( "gt99_grom2_0.grm2_0", 0x400000, 0x80000, CRC(693d9d68) SHA1(c8f0a5ca72b239aed8150a79f330b109bd6c3d95) )
 	ROM_LOAD32_BYTE( "gt99_grom2_1.grm2_1", 0x400001, 0x80000, CRC(2c0b8b8c) SHA1(f36c40b29ad9a4849f12eaa79c6b26aa85ca6ee9) )
@@ -4403,18 +4370,18 @@ ROM_START( gt99 )   /* Version 1.00 */
 	ROM_LOAD16_BYTE( "gt99_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gt99s100 )   /* Version 1.00S for the 3 tier type PCB with short ROM board P/N 1088 Rev 0 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt99s100 )   // Version 1.00S for the 3 tier type PCB with short ROM board P/N 1088 Rev 0
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt99_prom0_v1.00s.prom0", 0x00000, 0x80000, CRC(58e7c4e1) SHA1(2d5e2d841ffb626338f4dd9ffb558d05ed476078) )
 	ROM_LOAD32_BYTE( "gt99_prom1_v1.00s.prom1", 0x00001, 0x80000, CRC(09f8bdf4) SHA1(b933b48e19ca31ead93027ea328c2d9e581cbd31) )
 	ROM_LOAD32_BYTE( "gt99_prom2_v1.00s.prom2", 0x00002, 0x80000, CRC(fd084b68) SHA1(bd39ea7d201892f5583db21685010c75354ac3b9) )
 	ROM_LOAD32_BYTE( "gt99_prom3_v1.00s.prom3", 0x00003, 0x80000, CRC(3ff88ff7) SHA1(ca59f5888932be78434ae9a1b5cb06b01156c8ba) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "gtg3_nr_u23_v2.2.u23", 0x10000, 0x18000, CRC(04effd73) SHA1(4277031655f8de851eba0e4134ba619a12f5dd4a) ) /* actually labeled "GTG3 NR(U23) V2.2" */
+	ROM_LOAD( "gtg3_nr_u23_v2.2.u23", 0x10000, 0x18000, CRC(04effd73) SHA1(4277031655f8de851eba0e4134ba619a12f5dd4a) ) // actually labeled "GTG3 NR(U23) V2.2"
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt99_grom0_0.grm0_0", 0x000000, 0x80000, CRC(c22b50f9) SHA1(9e8acfce6cc30adc150b602d026c00fa1fb7747f) )
 	ROM_LOAD32_BYTE( "gt99_grom0_1.grm0_1", 0x000001, 0x80000, CRC(d6d6be57) SHA1(fda20185e842dd4aa1a1601f95e5cc787644f4c3) )
 	ROM_LOAD32_BYTE( "gt99_grom0_2.grm0_2", 0x000002, 0x80000, CRC(005d4791) SHA1(b03d5835465ccc4fe73f4adb1342ef2b38aad90c) )
@@ -4424,7 +4391,7 @@ ROM_START( gt99s100 )   /* Version 1.00S for the 3 tier type PCB with short ROM 
 	ROM_LOAD32_BYTE( "gt99_grom1_2.grm1_2", 0x200002, 0x80000, CRC(d73d8afc) SHA1(2fced1ee7dd11c6db07750f617356c6608ac0291) )
 	ROM_LOAD32_BYTE( "gt99_grom1_3.grm1_3", 0x200003, 0x80000, CRC(59f48688) SHA1(37b2c84e487f4f3a9145bef34c573a3716b4a6a7) )
 
-	/* GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic */
+	// GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic
 
 	ROM_LOAD32_BYTE( "gt99_grom2_0.grm2_0", 0x400000, 0x80000, CRC(693d9d68) SHA1(c8f0a5ca72b239aed8150a79f330b109bd6c3d95) )
 	ROM_LOAD32_BYTE( "gt99_grom2_1.grm2_1", 0x400001, 0x80000, CRC(2c0b8b8c) SHA1(f36c40b29ad9a4849f12eaa79c6b26aa85ca6ee9) )
@@ -4432,12 +4399,12 @@ ROM_START( gt99s100 )   /* Version 1.00S for the 3 tier type PCB with short ROM 
 	ROM_LOAD32_BYTE( "gt99_grom2_3.grm2_3", 0x400003, 0x80000, CRC(cfccd5c2) SHA1(6d87675e9cdaebc801a6f52688e0a142f578d36d) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "gtg3_srom1_nr++.srom1", 0x000000, 0x100000, CRC(44983bd7) SHA1(a6ac966ec113b079434d7f871e4ce7266206d234) ) /* actually labeled "GTG3 SROM1 NR**" */
-	ROM_LOAD16_BYTE( "gtg3_srom2_nr+.srom2",  0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) ) /* actually labeled "GTG3 SROM2 NR*"  */
+	ROM_LOAD16_BYTE( "gtg3_srom1_nr++.srom1", 0x000000, 0x100000, CRC(44983bd7) SHA1(a6ac966ec113b079434d7f871e4ce7266206d234) ) // actually labeled "GTG3 SROM1 NR**"
+	ROM_LOAD16_BYTE( "gtg3_srom2_nr+.srom2",  0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) ) // actually labeled "GTG3 SROM2 NR*" 
 ROM_END
 
-ROM_START( gt99t400 )   /* Version 4.00 Tournament Edition (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt99t400 )   // Version 4.00 Tournament Edition (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt99_prom0_v4.00t.prom0", 0x00000, 0x100000, CRC(bc58e0a2) SHA1(9e207acb860d532238f6105fd5b0d283056e016f) )
 	ROM_LOAD32_BYTE( "gt99_prom1_v4.00t.prom1", 0x00001, 0x100000, CRC(89d8cc6b) SHA1(ff2a5452c1c3a14c22abe380cb1ce263c23cc071) )
 	ROM_LOAD32_BYTE( "gt99_prom2_v4.00t.prom2", 0x00002, 0x100000, CRC(891e26c1) SHA1(11eeb60160924fbf58e409465541ef1cb15ff933) )
@@ -4447,7 +4414,7 @@ ROM_START( gt99t400 )   /* Version 4.00 Tournament Edition (PCB P/N 1083 Rev 2) 
 	ROM_LOAD( "gt99nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt99_grom0_0.grm0_0", 0x000000, 0x80000, CRC(c22b50f9) SHA1(9e8acfce6cc30adc150b602d026c00fa1fb7747f) )
 	ROM_LOAD32_BYTE( "gt99_grom0_1.grm0_1", 0x000001, 0x80000, CRC(d6d6be57) SHA1(fda20185e842dd4aa1a1601f95e5cc787644f4c3) )
 	ROM_LOAD32_BYTE( "gt99_grom0_2.grm0_2", 0x000002, 0x80000, CRC(005d4791) SHA1(b03d5835465ccc4fe73f4adb1342ef2b38aad90c) )
@@ -4457,7 +4424,7 @@ ROM_START( gt99t400 )   /* Version 4.00 Tournament Edition (PCB P/N 1083 Rev 2) 
 	ROM_LOAD32_BYTE( "gt99_grom1_2.grm1_2", 0x200002, 0x80000, CRC(d73d8afc) SHA1(2fced1ee7dd11c6db07750f617356c6608ac0291) )
 	ROM_LOAD32_BYTE( "gt99_grom1_3.grm1_3", 0x200003, 0x80000, CRC(59f48688) SHA1(37b2c84e487f4f3a9145bef34c573a3716b4a6a7) )
 
-	/* GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic */
+	// GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic
 
 	ROM_LOAD32_BYTE( "gt99_grom2_0.grm2_0", 0x400000, 0x80000, CRC(693d9d68) SHA1(c8f0a5ca72b239aed8150a79f330b109bd6c3d95) )
 	ROM_LOAD32_BYTE( "gt99_grom2_1.grm2_1", 0x400001, 0x80000, CRC(2c0b8b8c) SHA1(f36c40b29ad9a4849f12eaa79c6b26aa85ca6ee9) )
@@ -4469,8 +4436,8 @@ ROM_START( gt99t400 )   /* Version 4.00 Tournament Edition (PCB P/N 1083 Rev 2) 
 	ROM_LOAD16_BYTE( "gt99_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gtroyal )    /* Version 4.02T EDM (Tournament Edition, PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gtroyal )    // Version 4.02T EDM (Tournament Edition, PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gtr_prom0_v4.02t_edm.prom0", 0x00000, 0x100000, CRC(ae499ea3) SHA1(0de651900fd92b2de3fcbc092c1292d546f12819) )
 	ROM_LOAD32_BYTE( "gtr_prom1_v4.02t_edm.prom1", 0x00001, 0x100000, CRC(87ee04b5) SHA1(2c4c4a80073bfd28066bef371fbd1008149cc56c) )
 	ROM_LOAD32_BYTE( "gtr_prom2_v4.02t_edm.prom2", 0x00002, 0x100000, CRC(a925d392) SHA1(07e398279a0abd058a4bda700a7f3fe90737cb04) )
@@ -4480,7 +4447,7 @@ ROM_START( gtroyal )    /* Version 4.02T EDM (Tournament Edition, PCB P/N 1083 R
 	ROM_LOAD( "gt99nr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt99_grom0_0.grm0_0", 0x000000, 0x80000, CRC(c22b50f9) SHA1(9e8acfce6cc30adc150b602d026c00fa1fb7747f) )
 	ROM_LOAD32_BYTE( "gt99_grom0_1.grm0_1", 0x000001, 0x80000, CRC(d6d6be57) SHA1(fda20185e842dd4aa1a1601f95e5cc787644f4c3) )
 	ROM_LOAD32_BYTE( "gt99_grom0_2.grm0_2", 0x000002, 0x80000, CRC(005d4791) SHA1(b03d5835465ccc4fe73f4adb1342ef2b38aad90c) )
@@ -4490,7 +4457,7 @@ ROM_START( gtroyal )    /* Version 4.02T EDM (Tournament Edition, PCB P/N 1083 R
 	ROM_LOAD32_BYTE( "gt99_grom1_2.grm1_2", 0x200002, 0x80000, CRC(d73d8afc) SHA1(2fced1ee7dd11c6db07750f617356c6608ac0291) )
 	ROM_LOAD32_BYTE( "gt99_grom1_3.grm1_3", 0x200003, 0x80000, CRC(59f48688) SHA1(37b2c84e487f4f3a9145bef34c573a3716b4a6a7) )
 
-	/* GT Royal uses the same 12 graphics ROMs as a standard US GT99 version */
+	// GT Royal uses the same 12 graphics ROMs as a standard US GT99 version
 
 	ROM_LOAD32_BYTE( "gt99_grom2_0.grm2_0", 0x400000, 0x80000, CRC(693d9d68) SHA1(c8f0a5ca72b239aed8150a79f330b109bd6c3d95) )
 	ROM_LOAD32_BYTE( "gt99_grom2_1.grm2_1", 0x400001, 0x80000, CRC(2c0b8b8c) SHA1(f36c40b29ad9a4849f12eaa79c6b26aa85ca6ee9) )
@@ -4503,8 +4470,8 @@ ROM_START( gtroyal )    /* Version 4.02T EDM (Tournament Edition, PCB P/N 1083 R
 ROM_END
 
 
-ROM_START( gt2k ) /* Version 1.00 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt2k ) // Version 1.00
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt2k_prom0_v1.00.prom0", 0x00000, 0x80000, CRC(b83d7b67) SHA1(9e3c4f5d09ae63d75f4c9499b0a09acea7b022b2) )
 	ROM_LOAD32_BYTE( "gt2k_prom1_v1.00.prom1", 0x00001, 0x80000, CRC(89bd952d) SHA1(8b49610b9947dbc4cb3ab28f6aed31d8b848a2bf) )
 	ROM_LOAD32_BYTE( "gt2k_prom2_v1.00.prom2", 0x00002, 0x80000, CRC(b603d283) SHA1(dc02b4969f96a089766b07eb45a2eb6be6ae0aad) )
@@ -4514,7 +4481,7 @@ ROM_START( gt2k ) /* Version 1.00 */
 	ROM_LOAD( "gt2knr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt2k_grom0_0.grm0_0", 0x000000, 0x80000, CRC(c22b50f9) SHA1(9e8acfce6cc30adc150b602d026c00fa1fb7747f) )
 	ROM_LOAD32_BYTE( "gt2k_grom0_1.grm0_1", 0x000001, 0x80000, CRC(d6d6be57) SHA1(fda20185e842dd4aa1a1601f95e5cc787644f4c3) )
 	ROM_LOAD32_BYTE( "gt2k_grom0_2.grm0_2", 0x000002, 0x80000, CRC(005d4791) SHA1(b03d5835465ccc4fe73f4adb1342ef2b38aad90c) )
@@ -4524,7 +4491,7 @@ ROM_START( gt2k ) /* Version 1.00 */
 	ROM_LOAD32_BYTE( "gt2k_grom1_2.grm1_2", 0x200002, 0x80000, CRC(d73d8afc) SHA1(2fced1ee7dd11c6db07750f617356c6608ac0291) )
 	ROM_LOAD32_BYTE( "gt2k_grom1_3.grm1_3", 0x200003, 0x80000, CRC(59f48688) SHA1(37b2c84e487f4f3a9145bef34c573a3716b4a6a7) )
 
-	/* GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic */
+	// GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic
 
 	ROM_LOAD32_BYTE( "gt2k_grom2_0.grm2_0", 0x400000, 0x80000, CRC(cc11b93f) SHA1(f281448c8fa23595dd2664cc8c168565b60d4fc1) )
 	ROM_LOAD32_BYTE( "gt2k_grom2_1.grm2_1", 0x400001, 0x80000, CRC(1c3a0126) SHA1(3f9de1239dd64b9f50220842ffcf3e0f8928d2dc) )
@@ -4536,8 +4503,8 @@ ROM_START( gt2k ) /* Version 1.00 */
 	ROM_LOAD16_BYTE( "gt2k_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gt2kp100 ) /* Version 1.00 Infinite Loop Protection */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt2kp100 ) // Version 1.00 Infinite Loop Protection
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt2kprm0.10p", 0x00000, 0x80000, CRC(16e8502d) SHA1(8bdf90793ae6d38dc0638c74a1c804c395ac5868) )
 	ROM_LOAD32_BYTE( "gt2kprm1.10p", 0x00001, 0x80000, CRC(bf47cd95) SHA1(f63ac0dbe2668dfc2ba675862b0b0c754f89a9a8) )
 	ROM_LOAD32_BYTE( "gt2kprm2.10p", 0x00002, 0x80000, CRC(204ddf15) SHA1(395659f4852021ef19967af5f3966c14cef6f327) )
@@ -4547,7 +4514,7 @@ ROM_START( gt2kp100 ) /* Version 1.00 Infinite Loop Protection */
 	ROM_LOAD( "gt2knr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt2k_grom0_0.grm0_0", 0x000000, 0x80000, CRC(c22b50f9) SHA1(9e8acfce6cc30adc150b602d026c00fa1fb7747f) )
 	ROM_LOAD32_BYTE( "gt2k_grom0_1.grm0_1", 0x000001, 0x80000, CRC(d6d6be57) SHA1(fda20185e842dd4aa1a1601f95e5cc787644f4c3) )
 	ROM_LOAD32_BYTE( "gt2k_grom0_2.grm0_2", 0x000002, 0x80000, CRC(005d4791) SHA1(b03d5835465ccc4fe73f4adb1342ef2b38aad90c) )
@@ -4557,7 +4524,7 @@ ROM_START( gt2kp100 ) /* Version 1.00 Infinite Loop Protection */
 	ROM_LOAD32_BYTE( "gt2k_grom1_2.grm1_2", 0x200002, 0x80000, CRC(d73d8afc) SHA1(2fced1ee7dd11c6db07750f617356c6608ac0291) )
 	ROM_LOAD32_BYTE( "gt2k_grom1_3.grm1_3", 0x200003, 0x80000, CRC(59f48688) SHA1(37b2c84e487f4f3a9145bef34c573a3716b4a6a7) )
 
-	/* GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic */
+	// GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic
 
 	ROM_LOAD32_BYTE( "gt2k_grom2_0.grm2_0", 0x400000, 0x80000, CRC(cc11b93f) SHA1(f281448c8fa23595dd2664cc8c168565b60d4fc1) )
 	ROM_LOAD32_BYTE( "gt2k_grom2_1.grm2_1", 0x400001, 0x80000, CRC(1c3a0126) SHA1(3f9de1239dd64b9f50220842ffcf3e0f8928d2dc) )
@@ -4569,18 +4536,18 @@ ROM_START( gt2kp100 ) /* Version 1.00 Infinite Loop Protection */
 	ROM_LOAD16_BYTE( "gt2k_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gt2ks100 )   /* Version 1.00S for the 3 tier type PCB with short ROM board P/N 1088 Rev 0 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
-	ROM_LOAD32_BYTE( "gt2k_kit_prom0_v1.00m.prom0", 0x00000, 0x80000, CRC(3aab67c8) SHA1(c08dcad9e7c2440058ee4d683b2257c6ae42ad4d) ) /* Games shows Golden Tee 2K v1.00S */
+ROM_START( gt2ks100 )   // Version 1.00S for the 3 tier type PCB with short ROM board P/N 1088 Rev 0
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
+	ROM_LOAD32_BYTE( "gt2k_kit_prom0_v1.00m.prom0", 0x00000, 0x80000, CRC(3aab67c8) SHA1(c08dcad9e7c2440058ee4d683b2257c6ae42ad4d) ) // Games shows Golden Tee 2K v1.00S
 	ROM_LOAD32_BYTE( "gt2k_kit_prom1_v1.00m.prom1", 0x00001, 0x80000, CRC(47d4a74d) SHA1(b4f80de1ffea11bf716c891519990e0fe2dfbc23) )
 	ROM_LOAD32_BYTE( "gt2k_kit_prom2_v1.00m.prom2", 0x00002, 0x80000, CRC(77a222cc) SHA1(bab3732c49c388f43db27c3c36c6eba02ec92708) )
 	ROM_LOAD32_BYTE( "gt2k_kit_prom3_v1.00m.prom3", 0x00003, 0x80000, CRC(c3e77ad5) SHA1(3861779c1a60778a686c3cae5b77ea408de1bb1f) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "gtg3_nr_u23_v2.2.u23", 0x10000, 0x18000, CRC(04effd73) SHA1(4277031655f8de851eba0e4134ba619a12f5dd4a) ) /* actually labeled "GTG3 NR(U23) V2.2" */
+	ROM_LOAD( "gtg3_nr_u23_v2.2.u23", 0x10000, 0x18000, CRC(04effd73) SHA1(4277031655f8de851eba0e4134ba619a12f5dd4a) ) // actually labeled "GTG3 NR(U23) V2.2"
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt2k_grom0_0.grm0_0", 0x000000, 0x80000, CRC(c22b50f9) SHA1(9e8acfce6cc30adc150b602d026c00fa1fb7747f) )
 	ROM_LOAD32_BYTE( "gt2k_grom0_1.grm0_1", 0x000001, 0x80000, CRC(d6d6be57) SHA1(fda20185e842dd4aa1a1601f95e5cc787644f4c3) )
 	ROM_LOAD32_BYTE( "gt2k_grom0_2.grm0_2", 0x000002, 0x80000, CRC(005d4791) SHA1(b03d5835465ccc4fe73f4adb1342ef2b38aad90c) )
@@ -4590,7 +4557,7 @@ ROM_START( gt2ks100 )   /* Version 1.00S for the 3 tier type PCB with short ROM 
 	ROM_LOAD32_BYTE( "gt2k_grom1_2.grm1_2", 0x200002, 0x80000, CRC(d73d8afc) SHA1(2fced1ee7dd11c6db07750f617356c6608ac0291) )
 	ROM_LOAD32_BYTE( "gt2k_grom1_3.grm1_3", 0x200003, 0x80000, CRC(59f48688) SHA1(37b2c84e487f4f3a9145bef34c573a3716b4a6a7) )
 
-	/* GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic */
+	// GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic
 
 	ROM_LOAD32_BYTE( "gt2k_grom2_0.grm2_0", 0x400000, 0x80000, CRC(cc11b93f) SHA1(f281448c8fa23595dd2664cc8c168565b60d4fc1) )
 	ROM_LOAD32_BYTE( "gt2k_grom2_1.grm2_1", 0x400001, 0x80000, CRC(1c3a0126) SHA1(3f9de1239dd64b9f50220842ffcf3e0f8928d2dc) )
@@ -4598,12 +4565,12 @@ ROM_START( gt2ks100 )   /* Version 1.00S for the 3 tier type PCB with short ROM 
 	ROM_LOAD32_BYTE( "gt2k_grom2_3.grm2_3", 0x400003, 0x80000, CRC(f0f7373f) SHA1(6d71f338992598feffd9b4ac26bd0cf2f9edb53e) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "gtg3_srom1_nr++.srom1", 0x000000, 0x100000, CRC(44983bd7) SHA1(a6ac966ec113b079434d7f871e4ce7266206d234) ) /* actually labeled "GTG3 SROM1 NR**" */
-	ROM_LOAD16_BYTE( "gtg3_srom2_nr+.srom2",  0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) ) /* actually labeled "GTG3 SROM2 NR*"  */
+	ROM_LOAD16_BYTE( "gtg3_srom1_nr++.srom1", 0x000000, 0x100000, CRC(44983bd7) SHA1(a6ac966ec113b079434d7f871e4ce7266206d234) ) // actually labeled "GTG3 SROM1 NR**"
+	ROM_LOAD16_BYTE( "gtg3_srom2_nr+.srom2",  0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) ) // actually labeled "GTG3 SROM2 NR*" 
 ROM_END
 
-ROM_START( gt2kt500 ) /* Version 5.00 Tournament Edition (PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gt2kt500 ) // Version 5.00 Tournament Edition (PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt2k_prom0_v5.00t.prom0", 0x00000, 0x100000, CRC(8f20f9eb) SHA1(e7b19c34fff39040b8849483146303d4eb394da6) )
 	ROM_LOAD32_BYTE( "gt2k_prom1_v5.00t.prom1", 0x00001, 0x100000, CRC(bdecc1f5) SHA1(f97edb54cffdba68d46dfb86d884192ffaa0d204) )
 	ROM_LOAD32_BYTE( "gt2k_prom2_v5.00t.prom2", 0x00002, 0x100000, CRC(46666c15) SHA1(7a90a8131a68b0b7bc394bdf5ef702be8164c1ee) )
@@ -4613,7 +4580,7 @@ ROM_START( gt2kt500 ) /* Version 5.00 Tournament Edition (PCB P/N 1083 Rev 2) */
 	ROM_LOAD( "gt2knr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt2k_grom0_0.grm0_0", 0x000000, 0x80000, CRC(c22b50f9) SHA1(9e8acfce6cc30adc150b602d026c00fa1fb7747f) )
 	ROM_LOAD32_BYTE( "gt2k_grom0_1.grm0_1", 0x000001, 0x80000, CRC(d6d6be57) SHA1(fda20185e842dd4aa1a1601f95e5cc787644f4c3) )
 	ROM_LOAD32_BYTE( "gt2k_grom0_2.grm0_2", 0x000002, 0x80000, CRC(005d4791) SHA1(b03d5835465ccc4fe73f4adb1342ef2b38aad90c) )
@@ -4623,7 +4590,7 @@ ROM_START( gt2kt500 ) /* Version 5.00 Tournament Edition (PCB P/N 1083 Rev 2) */
 	ROM_LOAD32_BYTE( "gt2k_grom1_2.grm1_2", 0x200002, 0x80000, CRC(d73d8afc) SHA1(2fced1ee7dd11c6db07750f617356c6608ac0291) )
 	ROM_LOAD32_BYTE( "gt2k_grom1_3.grm1_3", 0x200003, 0x80000, CRC(59f48688) SHA1(37b2c84e487f4f3a9145bef34c573a3716b4a6a7) )
 
-	/* GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic */
+	// GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic
 
 	ROM_LOAD32_BYTE( "gt2k_grom2_0.grm2_0", 0x400000, 0x80000, CRC(cc11b93f) SHA1(f281448c8fa23595dd2664cc8c168565b60d4fc1) )
 	ROM_LOAD32_BYTE( "gt2k_grom2_1.grm2_1", 0x400001, 0x80000, CRC(1c3a0126) SHA1(3f9de1239dd64b9f50220842ffcf3e0f8928d2dc) )
@@ -4635,8 +4602,8 @@ ROM_START( gt2kt500 ) /* Version 5.00 Tournament Edition (PCB P/N 1083 Rev 2) */
 	ROM_LOAD16_BYTE( "gt2k_srom1_nr.srom1", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gtsupreme ) /* Version 5.10T ELC S (Tournament Edition, PCB P/N 1083 Rev 2) */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gtsupreme ) // Version 5.10T ELC S (Tournament Edition, PCB P/N 1083 Rev 2)
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gtg_sup_elc_prom0_5.10t.prom0", 0x00000, 0x100000, CRC(a14f7e2b) SHA1(fa913452701e580a9242994020a42e0be7d41a60) )
 	ROM_LOAD32_BYTE( "gtg_sup_elc_prom1_5.10t.prom1", 0x00001, 0x100000, CRC(772f4dc9) SHA1(c44c1893f28386b6457bffd0a85b361c1033a805) )
 	ROM_LOAD32_BYTE( "gtg_sup_elc_prom2_5.10t.prom2", 0x00002, 0x100000, CRC(fbaae916) SHA1(dd436f71a89acf3a6de3feffebf35f071b73ae77) )
@@ -4646,7 +4613,7 @@ ROM_START( gtsupreme ) /* Version 5.10T ELC S (Tournament Edition, PCB P/N 1083 
 	ROM_LOAD( "gt2knr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                    0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt2k_grom0_0.grm0_0", 0x000000, 0x80000, CRC(c22b50f9) SHA1(9e8acfce6cc30adc150b602d026c00fa1fb7747f) )
 	ROM_LOAD32_BYTE( "gt2k_grom0_1.grm0_1", 0x000001, 0x80000, CRC(d6d6be57) SHA1(fda20185e842dd4aa1a1601f95e5cc787644f4c3) )
 	ROM_LOAD32_BYTE( "gt2k_grom0_2.grm0_2", 0x000002, 0x80000, CRC(005d4791) SHA1(b03d5835465ccc4fe73f4adb1342ef2b38aad90c) )
@@ -4656,9 +4623,9 @@ ROM_START( gtsupreme ) /* Version 5.10T ELC S (Tournament Edition, PCB P/N 1083 
 	ROM_LOAD32_BYTE( "gt2k_grom1_2.grm1_2", 0x200002, 0x80000, CRC(d73d8afc) SHA1(2fced1ee7dd11c6db07750f617356c6608ac0291) )
 	ROM_LOAD32_BYTE( "gt2k_grom1_3.grm1_3", 0x200003, 0x80000, CRC(59f48688) SHA1(37b2c84e487f4f3a9145bef34c573a3716b4a6a7) )
 
-	/* GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic */
-	/* The Euro version has different GROM2_x compared to the standard US versions.  GT Supreme PCBs have been seen  */
-	/* with GT 2K mask ROMs as well as all GROMs labeled "GT SUPREME" */
+	// GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic
+	// The Euro version has different GROM2_x compared to the standard US versions.  GT Supreme PCBs have been seen 
+	// with GT 2K mask ROMs as well as all GROMs labeled "GT SUPREME"
 
 	ROM_LOAD32_BYTE( "gt_supreme_grom2_0.grm2_0", 0x400000, 0x80000, CRC(33998a3e) SHA1(53832e37c42155eb9c774eb33b8b36fe387fa162) )
 	ROM_LOAD32_BYTE( "gt_supreme_grom2_1.grm2_1", 0x400001, 0x80000, CRC(afa937ef) SHA1(3a6cb5a6b40ad8c77f1eceeda65afd007c8388d7) )
@@ -4671,8 +4638,8 @@ ROM_START( gtsupreme ) /* Version 5.10T ELC S (Tournament Edition, PCB P/N 1083 
 ROM_END
 
 
-ROM_START( gtclassc ) /* Version 1.00 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gtclassc ) // Version 1.00
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gt_classic_prom0_v1.00.prom0", 0x00000, 0x80000, CRC(a57e6ef0) SHA1(9a67b8d9314a774654f89343df2e6a6fd3cfef01) )
 	ROM_LOAD32_BYTE( "gt_classic_prom1_v1.00.prom1", 0x00001, 0x80000, CRC(15f8a831) SHA1(982675b26f5f19aaf7d8adc73474e05dd82c56a3) )
 	ROM_LOAD32_BYTE( "gt_classic_prom2_v1.00.prom2", 0x00002, 0x80000, CRC(2f260a93) SHA1(b953e003a588e6c1d7d7c065afd6cdfefb526642) )
@@ -4682,7 +4649,7 @@ ROM_START( gtclassc ) /* Version 1.00 */
 	ROM_LOAD( "gt_classicnr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                          0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt_classic_grom0_0.grm0_0", 0x000000, 0x80000, CRC(c22b50f9) SHA1(9e8acfce6cc30adc150b602d026c00fa1fb7747f) )
 	ROM_LOAD32_BYTE( "gt_classic_grom0_1.grm0_1", 0x000001, 0x80000, CRC(d6d6be57) SHA1(fda20185e842dd4aa1a1601f95e5cc787644f4c3) )
 	ROM_LOAD32_BYTE( "gt_classic_grom0_2.grm0_2", 0x000002, 0x80000, CRC(005d4791) SHA1(b03d5835465ccc4fe73f4adb1342ef2b38aad90c) )
@@ -4692,7 +4659,7 @@ ROM_START( gtclassc ) /* Version 1.00 */
 	ROM_LOAD32_BYTE( "gt_classic_grom1_2.grm1_2", 0x200002, 0x80000, CRC(d73d8afc) SHA1(2fced1ee7dd11c6db07750f617356c6608ac0291) )
 	ROM_LOAD32_BYTE( "gt_classic_grom1_3.grm1_3", 0x200003, 0x80000, CRC(59f48688) SHA1(37b2c84e487f4f3a9145bef34c573a3716b4a6a7) )
 
-	/* GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic */
+	// GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic
 
 	ROM_LOAD32_BYTE( "gt_classic_grom2_0.grm2_0", 0x400000, 0x80000, CRC(c4f54398) SHA1(08e57ef5cb56c793edc677d53b2e036acf558564) )
 	ROM_LOAD32_BYTE( "gt_classic_grom2_1.grm2_1", 0x400001, 0x80000, CRC(2c1f83cf) SHA1(a5a8724c59177fbf2a676ece0e93a08a3a1b0d68) )
@@ -4704,8 +4671,8 @@ ROM_START( gtclassc ) /* Version 1.00 */
 	ROM_LOAD16_BYTE( "gt_classic_srom1.nr", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gtclasscp ) /* Version 1.00 Infinite Loop Protection */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
+ROM_START( gtclasscp ) // Version 1.00 Infinite Loop Protection
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
 	ROM_LOAD32_BYTE( "gtcpprm0.100", 0x00000, 0x80000, CRC(21f0e0ea) SHA1(734f5ec7f28451d46656c8a0c2cc96c09c55cf9b) )
 	ROM_LOAD32_BYTE( "gtcpprm1.100", 0x00001, 0x80000, CRC(d2a69fbc) SHA1(a34d87bbfe1d9273d16cb73fe20fbf8ccd04e2b1) )
 	ROM_LOAD32_BYTE( "gtcpprm2.100", 0x00002, 0x80000, CRC(a8dea029) SHA1(b2541879aab7e468da846e464f7f642262db03b3) )
@@ -4715,7 +4682,7 @@ ROM_START( gtclasscp ) /* Version 1.00 Infinite Loop Protection */
 	ROM_LOAD( "gt_classicnr_u88_v1.0.u88", 0x10000, 0x18000, CRC(2cee9e98) SHA1(02edac7abab2335c1cd824d1d9b26aa32238a2de) )
 	ROM_CONTINUE(                          0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt_classic_grom0_0.grm0_0", 0x000000, 0x80000, CRC(c22b50f9) SHA1(9e8acfce6cc30adc150b602d026c00fa1fb7747f) )
 	ROM_LOAD32_BYTE( "gt_classic_grom0_1.grm0_1", 0x000001, 0x80000, CRC(d6d6be57) SHA1(fda20185e842dd4aa1a1601f95e5cc787644f4c3) )
 	ROM_LOAD32_BYTE( "gt_classic_grom0_2.grm0_2", 0x000002, 0x80000, CRC(005d4791) SHA1(b03d5835465ccc4fe73f4adb1342ef2b38aad90c) )
@@ -4725,7 +4692,7 @@ ROM_START( gtclasscp ) /* Version 1.00 Infinite Loop Protection */
 	ROM_LOAD32_BYTE( "gt_classic_grom1_2.grm1_2", 0x200002, 0x80000, CRC(d73d8afc) SHA1(2fced1ee7dd11c6db07750f617356c6608ac0291) )
 	ROM_LOAD32_BYTE( "gt_classic_grom1_3.grm1_3", 0x200003, 0x80000, CRC(59f48688) SHA1(37b2c84e487f4f3a9145bef34c573a3716b4a6a7) )
 
-	/* GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic */
+	// GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic
 
 	ROM_LOAD32_BYTE( "gt_classic_grom2_0.grm2_0", 0x400000, 0x80000, CRC(c4f54398) SHA1(08e57ef5cb56c793edc677d53b2e036acf558564) )
 	ROM_LOAD32_BYTE( "gt_classic_grom2_1.grm2_1", 0x400001, 0x80000, CRC(2c1f83cf) SHA1(a5a8724c59177fbf2a676ece0e93a08a3a1b0d68) )
@@ -4737,18 +4704,18 @@ ROM_START( gtclasscp ) /* Version 1.00 Infinite Loop Protection */
 	ROM_LOAD16_BYTE( "gt_classic_srom1.nr", 0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) )
 ROM_END
 
-ROM_START( gtclasscs )  /* Version 1.00S for the 3 tier type PCB with short ROM board P/N 1088 Rev 0 */
-	ROM_REGION32_BE( CODE_SIZE, "user1", 0 )
-	ROM_LOAD32_BYTE( "gt_classic_prom0_v1.00m.prom0", 0x00000, 0x80000, CRC(1e41884f) SHA1(354baf00ad7cba4cdcd55c3a26dd0171dc39448a) ) /* Games shows Golden Tee Classic v1.00S */
+ROM_START( gtclasscs )  // Version 1.00S for the 3 tier type PCB with short ROM board P/N 1088 Rev 0
+	ROM_REGION32_BE( CODE_SIZE, "maindata", 0 )
+	ROM_LOAD32_BYTE( "gt_classic_prom0_v1.00m.prom0", 0x00000, 0x80000, CRC(1e41884f) SHA1(354baf00ad7cba4cdcd55c3a26dd0171dc39448a) ) // Games shows Golden Tee Classic v1.00S
 	ROM_LOAD32_BYTE( "gt_classic_prom1_v1.00m.prom1", 0x00001, 0x80000, CRC(31c18b2c) SHA1(0ce5ff917b135786354d87aae88f64fdd17b1a47) )
 	ROM_LOAD32_BYTE( "gt_classic_prom2_v1.00m.prom2", 0x00002, 0x80000, CRC(8896efcb) SHA1(59cb9793c610a9e9b3119d8d570a15253a821ede) )
 	ROM_LOAD32_BYTE( "gt_classic_prom3_v1.00m.prom3", 0x00003, 0x80000, CRC(567a9490) SHA1(45379c9a26b82d0a8dbb5da26a9f23dbf1e87fc1) )
 
 	ROM_REGION( 0x28000, "soundcpu", 0 )
-	ROM_LOAD( "gtg3_nr_u23_v2.2.u23", 0x10000, 0x18000, CRC(04effd73) SHA1(4277031655f8de851eba0e4134ba619a12f5dd4a) ) /* actually labeled "GTG3 NR(U23) V2.2" */
+	ROM_LOAD( "gtg3_nr_u23_v2.2.u23", 0x10000, 0x18000, CRC(04effd73) SHA1(4277031655f8de851eba0e4134ba619a12f5dd4a) ) // actually labeled "GTG3 NR(U23) V2.2"
 	ROM_CONTINUE(                     0x08000, 0x08000 )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "grom", 0 )
 	ROM_LOAD32_BYTE( "gt_classic_grom0_0.grm0_0", 0x000000, 0x80000, CRC(c22b50f9) SHA1(9e8acfce6cc30adc150b602d026c00fa1fb7747f) )
 	ROM_LOAD32_BYTE( "gt_classic_grom0_1.grm0_1", 0x000001, 0x80000, CRC(d6d6be57) SHA1(fda20185e842dd4aa1a1601f95e5cc787644f4c3) )
 	ROM_LOAD32_BYTE( "gt_classic_grom0_2.grm0_2", 0x000002, 0x80000, CRC(005d4791) SHA1(b03d5835465ccc4fe73f4adb1342ef2b38aad90c) )
@@ -4758,7 +4725,7 @@ ROM_START( gtclasscs )  /* Version 1.00S for the 3 tier type PCB with short ROM 
 	ROM_LOAD32_BYTE( "gt_classic_grom1_2.grm1_2", 0x200002, 0x80000, CRC(d73d8afc) SHA1(2fced1ee7dd11c6db07750f617356c6608ac0291) )
 	ROM_LOAD32_BYTE( "gt_classic_grom1_3.grm1_3", 0x200003, 0x80000, CRC(59f48688) SHA1(37b2c84e487f4f3a9145bef34c573a3716b4a6a7) )
 
-	/* GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic */
+	// GT99, GT2K & GT Classic all share the above listed 8 graphics ROMs and may be labeled GT99, GT2K or GTClassic
 
 	ROM_LOAD32_BYTE( "gt_classic_grom2_0.grm2_0", 0x400000, 0x80000, CRC(c4f54398) SHA1(08e57ef5cb56c793edc677d53b2e036acf558564) )
 	ROM_LOAD32_BYTE( "gt_classic_grom2_1.grm2_1", 0x400001, 0x80000, CRC(2c1f83cf) SHA1(a5a8724c59177fbf2a676ece0e93a08a3a1b0d68) )
@@ -4766,8 +4733,8 @@ ROM_START( gtclasscs )  /* Version 1.00S for the 3 tier type PCB with short ROM 
 	ROM_LOAD32_BYTE( "gt_classic_grom2_3.grm2_3", 0x400003, 0x80000, CRC(7ad615c1) SHA1(b5360885f775ba5e5e13fa624091cca6e3e6948a) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 )
-	ROM_LOAD16_BYTE( "gtg3_srom1_nr++.srom1", 0x000000, 0x100000, CRC(44983bd7) SHA1(a6ac966ec113b079434d7f871e4ce7266206d234) ) /* actually labeled "GTG3 SROM1 NR**" */
-	ROM_LOAD16_BYTE( "gtg3_srom2_nr+.srom2",  0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) ) /* actually labeled "GTG3 SROM2 NR*"  */
+	ROM_LOAD16_BYTE( "gtg3_srom1_nr++.srom1", 0x000000, 0x100000, CRC(44983bd7) SHA1(a6ac966ec113b079434d7f871e4ce7266206d234) ) // actually labeled "GTG3 SROM1 NR**"
+	ROM_LOAD16_BYTE( "gtg3_srom2_nr+.srom2",  0x200000, 0x080000, CRC(1b3f18b6) SHA1(3b65de6a90c5ede183b5f8ca1875736bc1425772) ) // actually labeled "GTG3 SROM2 NR*" 
 ROM_END
 
 /***************************************************************************
@@ -4781,7 +4748,7 @@ ROM_END
 ****************************************************************************/
 
 ROM_START( shoottv )
-	ROM_REGION32_BE( CODE_SIZE, "user1", ROMREGION_ERASEFF )
+	ROM_REGION32_BE( CODE_SIZE, "maindata", ROMREGION_ERASEFF )
 	ROM_LOAD32_BYTE( "gun_0.bin", 0x00000, 0xc5f9, CRC(1086b219) SHA1(a9e9545911e427e819d4c98885cbfe871ce7e83a) ) // from GUN/roms
 	ROM_LOAD32_BYTE( "gun_1.bin", 0x00001, 0xc5f9, CRC(a0f0e5ea) SHA1(39560d76759d17c34c353dbe202ec22af234238d) )
 	ROM_LOAD32_BYTE( "gun_2.bin", 0x00002, 0xc5f9, CRC(1b84cf05) SHA1(8f4b816ab2808258399072545f5dda0316e554ea) )
@@ -4791,7 +4758,7 @@ ROM_START( shoottv )
 	ROM_LOAD( "gun.bim", 0x10000, 0x18000, CRC(7439569a) SHA1(f02ec03307a2fb8a00d2ab1c7e1a62c0c74a98e9) ) // from GUN/matt back/gun
 	ROM_CONTINUE(        0x08000, 0x08000 )
 
-	ROM_REGION( 0x880000, "gfx1", 0 )
+	ROM_REGION( 0x880000, "grom", 0 )
 	ROM_LOAD32_BYTE( "grom00_0.bin", 0x000000, 0x80000, CRC(9a06d497) SHA1(c92826d2b7f356518e68282eef7c6f42779782f2) ) // from GUN/roms
 	ROM_LOAD32_BYTE( "grom00_1.bin", 0x000001, 0x80000, CRC(018ff629) SHA1(34f9d79832daeeeefd0085bf41ee8ec31bdb6815) )
 	ROM_LOAD32_BYTE( "grom00_2.bin", 0x000002, 0x80000, CRC(f47ea010) SHA1(f83b2457d23095208bd6c200e1d358026ae5ad3a) )
@@ -4808,7 +4775,7 @@ ROM_END
 
 
 ROM_START( pubball )
-	ROM_REGION32_BE( CODE_SIZE, "user1", ROMREGION_ERASEFF )
+	ROM_REGION32_BE( CODE_SIZE, "maindata", ROMREGION_ERASEFF )
 	ROM_LOAD32_BYTE( "bb0.bin", 0x00000, 0x25a91, CRC(f9350590) SHA1(91352373fb6a41495bb04db01d097e76770c5419) ) // from SOURCE
 	ROM_LOAD32_BYTE( "bb1.bin", 0x00001, 0x25a91, CRC(5711f503) SHA1(94765a5e9311fffbf0bc386c3b531c79acd7cada) )
 	ROM_LOAD32_BYTE( "bb2.bin", 0x00002, 0x25a91, CRC(3e202dc6) SHA1(a1a9fdff1957a8e43f002883666f1cd489879258) )
@@ -4818,7 +4785,7 @@ ROM_START( pubball )
 	ROM_LOAD( "bball.bim", 0x10000, 0x18000, CRC(915a9116) SHA1(54dbb9f8eb358c5dbe2022fad86cdd411c893b83) ) // from SOUNDS
 	ROM_CONTINUE(          0x08000, 0x08000 )
 
-	ROM_REGION( 0xE00000, "gfx1", 0 )
+	ROM_REGION( 0xe00000, "grom", 0 )
 	ROM_LOAD32_BYTE( "grom00_0.bin", 0x000000, 0x100000, CRC(46822b0f) SHA1(0b9758a1ccad252973a1fc61dc1a4eb1d0eb1636) ) // from ART
 	ROM_LOAD32_BYTE( "grom00_1.bin", 0x000001, 0x100000, CRC(c11236ce) SHA1(1459646b4d947aa63b037c7c5ab19d3261cbaa19) )
 	ROM_LOAD32_BYTE( "grom00_2.bin", 0x000002, 0x100000, CRC(e6be30f3) SHA1(832aff7b9a42fa57ccff09554c9f65f469e1045d) )
@@ -4831,10 +4798,10 @@ ROM_START( pubball )
 	ROM_LOAD32_BYTE( "grom02_1.bin", 0x800001, 0x100000, CRC(3df38e91) SHA1(f3adf29598481d050258d266a360d5b40d86f665) )
 	ROM_LOAD32_BYTE( "grom02_2.bin", 0x800002, 0x100000, CRC(7c47dde9) SHA1(654656878676278e0ea73e367337eaac5f1f1d50) )
 	ROM_LOAD32_BYTE( "grom02_3.bin", 0x800003, 0x100000, CRC(e6eb01bf) SHA1(f0e7f2372dfd072e005fbf7489f54242523b4a28) )
-	ROM_LOAD32_BYTE( "grom3_0.bin",  0xC00000, 0x080000, CRC(376beb10) SHA1(2dcea69b5e81d010b4c660df189a560742719ce6) )
-	ROM_LOAD32_BYTE( "grom3_1.bin",  0xC00001, 0x080000, CRC(3b3cb8ba) SHA1(eabac9e381dd652a4575f159dac45499406b2702) )
-	ROM_LOAD32_BYTE( "grom3_2.bin",  0xC00002, 0x080000, CRC(3bdfac73) SHA1(64777cdf92bbdfbfb6806039421a28f9810b6b03) )
-	ROM_LOAD32_BYTE( "grom3_3.bin",  0xC00003, 0x080000, CRC(1de04025) SHA1(25ba2fa49cc2423642020e05586662f67943381b) )
+	ROM_LOAD32_BYTE( "grom3_0.bin",  0xc00000, 0x080000, CRC(376beb10) SHA1(2dcea69b5e81d010b4c660df189a560742719ce6) )
+	ROM_LOAD32_BYTE( "grom3_1.bin",  0xc00001, 0x080000, CRC(3b3cb8ba) SHA1(eabac9e381dd652a4575f159dac45499406b2702) )
+	ROM_LOAD32_BYTE( "grom3_2.bin",  0xc00002, 0x080000, CRC(3bdfac73) SHA1(64777cdf92bbdfbfb6806039421a28f9810b6b03) )
+	ROM_LOAD32_BYTE( "grom3_3.bin",  0xc00003, 0x080000, CRC(1de04025) SHA1(25ba2fa49cc2423642020e05586662f67943381b) )
 
 	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )
 	ROM_LOAD16_BYTE( "bbsrom0.bin",  0x000000, 0x0f8b8e, CRC(2a69f77e) SHA1(c98ccdb0d79e77bf87077ac29626d84a811d1326) ) // from SOUNDS
@@ -4910,7 +4877,7 @@ void itech32_state::init_wcbowl()
 	m_vram_height = 1024;
 	m_planes = 1;
 
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x680000, 0x680001, read8smo_delegate(*this, FUNC(itech32_state::trackball_r)), 0x00ff);
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x680000, 0x680001, read8smo_delegate(*this, FUNC(itech32_state::trackball_r<0>)), 0x00ff);
 
 	m_maincpu->space(AS_PROGRAM).nop_read(0x578000, 0x57ffff);
 	m_maincpu->space(AS_PROGRAM).install_read_handler(0x680080, 0x680081, read16smo_delegate(*this, FUNC(itech32_state::wcbowl_prot_result_r)));
@@ -4930,8 +4897,8 @@ void itech32_state::init_wcbowlj()
 	m_vram_height = 1024;
 	m_planes = 1;
 
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x680000, 0x680001, read8smo_delegate(*this, FUNC(itech32_state::trackball_r)), 0x00ff);
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x680040, 0x680041, read8smo_delegate(*this, FUNC(itech32_state::trackball_p2_r)), 0x00ff);
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x680000, 0x680001, read8smo_delegate(*this, FUNC(itech32_state::trackball_r<0>)), 0x00ff);
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x680040, 0x680041, read8smo_delegate(*this, FUNC(itech32_state::trackball_r<1>)), 0x00ff);
 
 	m_maincpu->space(AS_PROGRAM).nop_read(0x578000, 0x57ffff);
 	m_maincpu->space(AS_PROGRAM).install_read_handler(0x680080, 0x680081, read16smo_delegate(*this, FUNC(itech32_state::wcbowl_prot_result_r)));
@@ -4979,8 +4946,8 @@ void itech32_state::init_shuffle_bowl_common(int prot_addr)
 
 	m_maincpu->space(AS_PROGRAM).install_write_handler(0x300000, 0x300003, write8smo_delegate(*this, FUNC(itech32_state::color_w<0>)), 0x000000ff);
 	m_maincpu->space(AS_PROGRAM).install_write_handler(0x380000, 0x380003, write8smo_delegate(*this, FUNC(itech32_state::color_w<1>)), 0x000000ff);
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x180800, 0x180803, read32smo_delegate(*this, FUNC(itech32_state::trackball32_4bit_p1_r)));
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x181000, 0x181003, read32smo_delegate(*this, FUNC(itech32_state::trackball32_4bit_p2_r)));
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x180800, 0x180803, read32smo_delegate(*this, FUNC(itech32_state::trackball32_4bit_r<0>)));
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x181000, 0x181003, read32smo_delegate(*this, FUNC(itech32_state::trackball32_4bit_r<1>)));
 }
 
 
@@ -4992,7 +4959,7 @@ void itech32_state::init_shufshot()
 
 void itech32_state::init_wcbowln()
 {
-	/* The security PROM is NOT interchangeable between the Deluxe and "normal" versions. */
+	// The security PROM is NOT interchangeable between the Deluxe and "normal" versions.
 	init_shuffle_bowl_common(0x1116);
 }
 
@@ -5003,7 +4970,7 @@ void itech32_state::install_timekeeper()
 
 void itech32_state::init_wcbowlt()
 {
-	/* Tournament Version, Same protection memory address as WCB Deluxe, but uses the standard WCB pic ITBWL-3 */
+	// Tournament Version, Same protection memory address as WCB Deluxe, but uses the standard WCB pic ITBWL-3
 	init_shuffle_bowl_common(0x111a);
 
 	install_timekeeper();
@@ -5049,8 +5016,8 @@ void itech32_state::init_aama()
 	    board share the same sound CPU code and sample ROMs.
 	    This board has all versions of GT for it, GT3D through GTClassic
 	*/
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x180800, 0x180803, read32smo_delegate(*this, FUNC(itech32_state::trackball32_4bit_p1_r)));
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x181000, 0x181003, read32smo_delegate(*this, FUNC(itech32_state::trackball32_4bit_p2_r)));
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x180800, 0x180803, read32smo_delegate(*this, FUNC(itech32_state::trackball32_4bit_r<0>)));
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x181000, 0x181003, read32smo_delegate(*this, FUNC(itech32_state::trackball32_4bit_r<1>)));
 	init_gt_common();
 }
 
@@ -5074,7 +5041,7 @@ void itech32_state::init_s_ver()
 	    board: GT97 v1.21S, GT98, GT99, GT2K & GT Classic Versions 1.00S
 	    Trackball info is read through 200202 (actually 200203).
 	*/
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x200200, 0x200203, read32smo_delegate(*this, FUNC(itech32_state::trackball32_4bit_p1_r)));
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x200200, 0x200203, read32smo_delegate(*this, FUNC(itech32_state::trackball32_4bit_r<0>)));
 	init_gt_common();
 }
 
@@ -5095,7 +5062,7 @@ void itech32_state::init_gt3dl()
 
 void itech32_state::init_gt2kp()
 {
-	/* a little extra protection */
+	// a little extra protection
 	m_maincpu->space(AS_PROGRAM).install_read_handler(0x680000, 0x680003, read32smo_delegate(*this, FUNC(itech32_state::gt2kp_prot_result_r)));
 	init_aama();
 
@@ -5116,7 +5083,7 @@ Label1  bne.s       Label1          ; Infinite loop if result isn't 0x01
 
 void itech32_state::init_gtclasscp()
 {
-	/* a little extra protection */
+	// a little extra protection
 	m_maincpu->space(AS_PROGRAM).install_read_handler(0x680000, 0x680003, read32smo_delegate(*this, FUNC(itech32_state::gtclass_prot_result_r)));
 	init_aama();
 
@@ -5143,8 +5110,8 @@ void itech32_state::init_pubball()
 
 	m_maincpu->space(AS_PROGRAM).install_write_handler(0x300000, 0x300003, write8smo_delegate(*this, FUNC(itech32_state::color_w<0>)), 0x000000ff);
 	m_maincpu->space(AS_PROGRAM).install_write_handler(0x380000, 0x380003, write8smo_delegate(*this, FUNC(itech32_state::color_w<1>)), 0x000000ff);
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x180800, 0x180803, read32smo_delegate(*this, FUNC(itech32_state::trackball32_4bit_p1_r)));
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x181000, 0x181003, read32smo_delegate(*this, FUNC(itech32_state::trackball32_4bit_p2_r)));
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x180800, 0x180803, read32smo_delegate(*this, FUNC(itech32_state::trackball32_4bit_r<0>)));
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x181000, 0x181003, read32smo_delegate(*this, FUNC(itech32_state::trackball32_4bit_r<1>)));
 }
 
 
@@ -5154,61 +5121,61 @@ void itech32_state::init_pubball()
  *
  *************************************/
 
-GAME( 1992, timekill,     0,        timekill, timekill, itech32_state,  init_timekill, ROT0, "Strata/Incredible Technologies",   "Time Killers (v1.32)", MACHINE_SUPPORTS_SAVE ) /* P/N 1051 Rev 0 ROM board */
-GAME( 1992, timekill132i, timekill, timekill, timekill, itech32_state,  init_timekill, ROT0, "Strata/Incredible Technologies",   "Time Killers (v1.32I)", MACHINE_SUPPORTS_SAVE ) /* P/N 1051 Rev 0 ROM board */
-GAME( 1992, timekill131,  timekill, timekill, timekill, itech32_state,  init_timekill, ROT0, "Strata/Incredible Technologies",   "Time Killers (v1.31)", MACHINE_SUPPORTS_SAVE ) /* P/N 1051 Rev 0 ROM board */
-GAME( 1992, timekill121,  timekill, timekill, timekill, itech32_state,  init_timekill, ROT0, "Strata/Incredible Technologies",   "Time Killers (v1.21)", MACHINE_SUPPORTS_SAVE ) /* P/N 1051 Rev 0 ROM board */
-GAME( 1992, timekill121a, timekill, timekill, timekill, itech32_state,  init_timekill, ROT0, "Strata/Incredible Technologies",   "Time Killers (v1.21, alternate ROM board)", MACHINE_SUPPORTS_SAVE ) /* P/N 1049 Rev 1 ROM board */
-GAME( 1992, timekill120,  timekill, timekill, timekill, itech32_state,  init_timekill, ROT0, "Strata/Incredible Technologies",   "Time Killers (v1.20, alternate ROM board)", MACHINE_SUPPORTS_SAVE ) /* P/N 1057 Rev 0 ROM board */
-GAME( 1992, timekill100,  timekill, timekill, timekill, itech32_state,  init_timekill, ROT0, "Strata/Incredible Technologies",   "Time Killers (v1.00)", MACHINE_SUPPORTS_SAVE ) /* P/N 1049 Rev 1 ROM board */
+GAME( 1992, timekill,     0,        timekill, timekill, itech32_state,  init_timekill, ROT0, "Strata / Incredible Technologies",                        "Time Killers (v1.32)", MACHINE_SUPPORTS_SAVE ) // P/N 1051 Rev 0 ROM board
+GAME( 1992, timekill132i, timekill, timekill, timekill, itech32_state,  init_timekill, ROT0, "Strata / Incredible Technologies",                        "Time Killers (v1.32I)", MACHINE_SUPPORTS_SAVE ) // P/N 1051 Rev 0 ROM board
+GAME( 1992, timekill131,  timekill, timekill, timekill, itech32_state,  init_timekill, ROT0, "Strata / Incredible Technologies",                        "Time Killers (v1.31)", MACHINE_SUPPORTS_SAVE ) // P/N 1051 Rev 0 ROM board
+GAME( 1992, timekill121,  timekill, timekill, timekill, itech32_state,  init_timekill, ROT0, "Strata / Incredible Technologies",                        "Time Killers (v1.21)", MACHINE_SUPPORTS_SAVE ) // P/N 1051 Rev 0 ROM board
+GAME( 1992, timekill121a, timekill, timekill, timekill, itech32_state,  init_timekill, ROT0, "Strata / Incredible Technologies",                        "Time Killers (v1.21, alternate ROM board)", MACHINE_SUPPORTS_SAVE ) // P/N 1049 Rev 1 ROM board
+GAME( 1992, timekill120,  timekill, timekill, timekill, itech32_state,  init_timekill, ROT0, "Strata / Incredible Technologies",                        "Time Killers (v1.20, alternate ROM board)", MACHINE_SUPPORTS_SAVE ) // P/N 1057 Rev 0 ROM board
+GAME( 1992, timekill100,  timekill, timekill, timekill, itech32_state,  init_timekill, ROT0, "Strata / Incredible Technologies",                        "Time Killers (v1.00)", MACHINE_SUPPORTS_SAVE ) // P/N 1049 Rev 1 ROM board
 
-GAME( 1993, hardyard,     0,        bloodstm, hardyard, itech32_state,  init_hardyard, ROT0, "Strata/Incredible Technologies",   "Hard Yardage (v1.20)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, hardyard11,   hardyard, bloodstm, hardyard, itech32_state,  init_hardyard, ROT0, "Strata/Incredible Technologies",   "Hard Yardage (v1.10)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, hardyard10,   hardyard, bloodstm, hardyard, itech32_state,  init_hardyard, ROT0, "Strata/Incredible Technologies",   "Hard Yardage (v1.00)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, hardyard,     0,        bloodstm, hardyard, itech32_state,  init_hardyard, ROT0, "Strata / Incredible Technologies",                        "Hard Yardage (v1.20)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, hardyard11,   hardyard, bloodstm, hardyard, itech32_state,  init_hardyard, ROT0, "Strata / Incredible Technologies",                        "Hard Yardage (v1.10)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, hardyard10,   hardyard, bloodstm, hardyard, itech32_state,  init_hardyard, ROT0, "Strata / Incredible Technologies",                        "Hard Yardage (v1.00)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1994, bloodstm,     0,        bloodstm, bloodstm, itech32_state,  init_bloodstm, ROT0, "Strata/Incredible Technologies",   "Blood Storm (v2.22)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, bloodstm221,  bloodstm, bloodstm, bloodstm, itech32_state,  init_bloodstm, ROT0, "Strata/Incredible Technologies",   "Blood Storm (v2.21)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, bloodstm220,  bloodstm, bloodstm, bloodstm, itech32_state,  init_bloodstm, ROT0, "Strata/Incredible Technologies",   "Blood Storm (v2.20)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, bloodstm210,  bloodstm, bloodstm, bloodstm, itech32_state,  init_bloodstm, ROT0, "Strata/Incredible Technologies",   "Blood Storm (v2.10)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, bloodstm110,  bloodstm, bloodstm, bloodstm, itech32_state,  init_bloodstm, ROT0, "Strata/Incredible Technologies",   "Blood Storm (v1.10)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, bloodstm104,  bloodstm, bloodstm, bloodstm, itech32_state,  init_bloodstm, ROT0, "Strata/Incredible Technologies",   "Blood Storm (v1.04)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, bloodstm,     0,        bloodstm, bloodstm, itech32_state,  init_bloodstm, ROT0, "Strata / Incredible Technologies",                        "Blood Storm (v2.22)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, bloodstm221,  bloodstm, bloodstm, bloodstm, itech32_state,  init_bloodstm, ROT0, "Strata / Incredible Technologies",                        "Blood Storm (v2.21)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, bloodstm220,  bloodstm, bloodstm, bloodstm, itech32_state,  init_bloodstm, ROT0, "Strata / Incredible Technologies",                        "Blood Storm (v2.20)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, bloodstm210,  bloodstm, bloodstm, bloodstm, itech32_state,  init_bloodstm, ROT0, "Strata / Incredible Technologies",                        "Blood Storm (v2.10)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, bloodstm110,  bloodstm, bloodstm, bloodstm, itech32_state,  init_bloodstm, ROT0, "Strata / Incredible Technologies",                        "Blood Storm (v1.10)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, bloodstm104,  bloodstm, bloodstm, bloodstm, itech32_state,  init_bloodstm, ROT0, "Strata / Incredible Technologies",                        "Blood Storm (v1.04)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1994, pairs,        0,        bloodstm, pairs,    itech32_state,  init_bloodstm, ROT0, "Strata/Incredible Technologies",   "Pairs (V1.2, 09/30/94)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, pairsa,       pairs,    bloodstm, pairs,    itech32_state,  init_bloodstm, ROT0, "Strata/Incredible Technologies",   "Pairs (V1, 09/07/94)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, hotmemry,     pairs,    bloodstm, pairs,    itech32_state,  init_bloodstm, ROT0, "Incredible Technologies (Tuning license)", "Hot Memory (V1.2, Germany, 12/28/94)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, hotmemry11,   pairs,    bloodstm, pairs,    itech32_state,  init_bloodstm, ROT0, "Incredible Technologies (Tuning license)", "Hot Memory (V1.1, Germany, 11/30/94)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, pairs,        0,        bloodstm, pairs,    itech32_state,  init_bloodstm, ROT0, "Strata / Incredible Technologies",                        "Pairs (V1.2, 09/30/94)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, pairsa,       pairs,    bloodstm, pairs,    itech32_state,  init_bloodstm, ROT0, "Strata / Incredible Technologies",                        "Pairs (V1, 09/07/94)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, hotmemry,     pairs,    bloodstm, pairs,    itech32_state,  init_bloodstm, ROT0, "Incredible Technologies (Tuning license)",                "Hot Memory (V1.2, Germany, 12/28/94)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, hotmemry11,   pairs,    bloodstm, pairs,    itech32_state,  init_bloodstm, ROT0, "Incredible Technologies (Tuning license)",                "Hot Memory (V1.1, Germany, 11/30/94)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1994, pairsred,     0,        bloodstm, pairs,    itech32_state,  init_bloodstm, ROT0, "Strata/Incredible Technologies",   "Pairs Redemption (V1.0, 10/25/94)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, pairsred,     0,        bloodstm, pairs,    itech32_state,  init_bloodstm, ROT0, "Strata / Incredible Technologies",                        "Pairs Redemption (V1.0, 10/25/94)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1994, drivedge,     0,        drivedge, drivedge, drivedge_state, empty_init,    ROT0, "Strata/Incredible Technologies",   "Driver's Edge (v1.6)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+GAME( 1994, drivedge,     0,        drivedge, drivedge, drivedge_state, empty_init,    ROT0, "Strata / Incredible Technologies",                        "Driver's Edge (v1.6)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1995, wcbowl,       0,        sftm,     wcbowln,  itech32_state,  init_wcbowln,  ROT0, "Incredible Technologies",          "World Class Bowling (v1.66)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITBWL-3 */
-GAME( 1995, wcbowl165,    wcbowl,   sftm,     wcbowlo,  itech32_state,  init_wcbowln,  ROT0, "Incredible Technologies",          "World Class Bowling (v1.65)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITBWL-3 */
-GAME( 1995, wcbowl161,    wcbowl,   sftm,     wcbowlo,  itech32_state,  init_wcbowln,  ROT0, "Incredible Technologies",          "World Class Bowling (v1.61)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITBWL-3 */
-GAME( 1995, wcbowl16,     wcbowl,   sftm,     wcbowlo,  itech32_state,  init_wcbowln,  ROT0, "Incredible Technologies",          "World Class Bowling (v1.6)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITBWL-3 */
-GAME( 1995, wcbowl15,     wcbowl,   bloodstm, wcbowl,   itech32_state,  init_wcbowl,   ROT0, "Incredible Technologies",          "World Class Bowling (v1.5)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITBWL-1 */
-GAME( 1995, wcbowl14,     wcbowl,   bloodstm, wcbowl,   itech32_state,  init_wcbowl,   ROT0, "Incredible Technologies",          "World Class Bowling (v1.4)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITBWL-1 */
-GAME( 1995, wcbowl13,     wcbowl,   bloodstm, wcbowl,   itech32_state,  init_wcbowl,   ROT0, "Incredible Technologies",          "World Class Bowling (v1.3)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITBWL-1 */
-GAME( 1995, wcbowl13j,    wcbowl,   bloodstm, wcbowlj,  itech32_state,  init_wcbowlj,  ROT0, "Incredible Technologies",          "World Class Bowling (v1.3J, Japan)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITBWL-1 */
-GAME( 1995, wcbowl12,     wcbowl,   bloodstm, wcbowl,   itech32_state,  init_wcbowl,   ROT0, "Incredible Technologies",          "World Class Bowling (v1.2)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITBWL-1 */
-GAME( 1995, wcbowl11,     wcbowl,   bloodstm, wcbowl,   itech32_state,  init_wcbowl,   ROT0, "Incredible Technologies",          "World Class Bowling (v1.1)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITBWL-1 */
-GAME( 1995, wcbowl10,     wcbowl,   bloodstm, wcbowl,   itech32_state,  init_wcbowl,   ROT0, "Incredible Technologies",          "World Class Bowling (v1.0)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITBWL-1 */
-GAME( 1999, wcbowldx,     wcbowl,   sftm,     wcbowldx, itech32_state,  init_shufshot, ROT0, "Incredible Technologies",          "World Class Bowling Deluxe (v2.00)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITBWL-4 */
-GAME( 1997, wcbowl140,    wcbowl,   tourny,   wcbowldx, itech32_state,  init_wcbowlt,  ROT0, "Incredible Technologies",          "World Class Bowling Tournament (v1.40)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITBWL-3 */
-GAME( 1997, wcbowl130,    wcbowl,   tourny,   wcbowlo,  itech32_state,  init_wcbowlt,  ROT0, "Incredible Technologies",          "World Class Bowling Tournament (v1.30)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITBWL-3 */
+GAME( 1995, wcbowl,       0,        sftm,     wcbowln,  itech32_state,  init_wcbowln,  ROT0, "Incredible Technologies",                                 "World Class Bowling (v1.66)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITBWL-3
+GAME( 1995, wcbowl165,    wcbowl,   sftm,     wcbowlo,  itech32_state,  init_wcbowln,  ROT0, "Incredible Technologies",                                 "World Class Bowling (v1.65)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITBWL-3
+GAME( 1995, wcbowl161,    wcbowl,   sftm,     wcbowlo,  itech32_state,  init_wcbowln,  ROT0, "Incredible Technologies",                                 "World Class Bowling (v1.61)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITBWL-3
+GAME( 1995, wcbowl16,     wcbowl,   sftm,     wcbowlo,  itech32_state,  init_wcbowln,  ROT0, "Incredible Technologies",                                 "World Class Bowling (v1.6)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITBWL-3
+GAME( 1995, wcbowl15,     wcbowl,   bloodstm, wcbowl,   itech32_state,  init_wcbowl,   ROT0, "Incredible Technologies",                                 "World Class Bowling (v1.5)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITBWL-1
+GAME( 1995, wcbowl14,     wcbowl,   bloodstm, wcbowl,   itech32_state,  init_wcbowl,   ROT0, "Incredible Technologies",                                 "World Class Bowling (v1.4)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITBWL-1
+GAME( 1995, wcbowl13,     wcbowl,   bloodstm, wcbowl,   itech32_state,  init_wcbowl,   ROT0, "Incredible Technologies",                                 "World Class Bowling (v1.3)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITBWL-1
+GAME( 1995, wcbowl13j,    wcbowl,   bloodstm, wcbowlj,  itech32_state,  init_wcbowlj,  ROT0, "Incredible Technologies (Excellent System Ltd. license)", "World Class Bowling (v1.3J, Japan)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITBWL-1
+GAME( 1995, wcbowl12,     wcbowl,   bloodstm, wcbowl,   itech32_state,  init_wcbowl,   ROT0, "Incredible Technologies",                                 "World Class Bowling (v1.2)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITBWL-1
+GAME( 1995, wcbowl11,     wcbowl,   bloodstm, wcbowl,   itech32_state,  init_wcbowl,   ROT0, "Incredible Technologies",                                 "World Class Bowling (v1.1)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITBWL-1
+GAME( 1995, wcbowl10,     wcbowl,   bloodstm, wcbowl,   itech32_state,  init_wcbowl,   ROT0, "Incredible Technologies",                                 "World Class Bowling (v1.0)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITBWL-1
+GAME( 1999, wcbowldx,     wcbowl,   sftm,     wcbowldx, itech32_state,  init_shufshot, ROT0, "Incredible Technologies",                                 "World Class Bowling Deluxe (v2.00)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITBWL-4
+GAME( 1997, wcbowl140,    wcbowl,   tourny,   wcbowldx, itech32_state,  init_wcbowlt,  ROT0, "Incredible Technologies",                                 "World Class Bowling Tournament (v1.40)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITBWL-3
+GAME( 1997, wcbowl130,    wcbowl,   tourny,   wcbowlo,  itech32_state,  init_wcbowlt,  ROT0, "Incredible Technologies",                                 "World Class Bowling Tournament (v1.30)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITBWL-3
 
-GAME( 1995, sftm,         0,        sftm,     sftm,     itech32_state,  init_sftm,     ROT0, "Capcom / Incredible Technologies", "Street Fighter: The Movie (v1.12)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITSF-1 */
-GAME( 1995, sftm111,      sftm,     sftm,     sftm,     itech32_state,  init_sftm110,  ROT0, "Capcom / Incredible Technologies", "Street Fighter: The Movie (v1.11)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITSF-1 */
-GAME( 1995, sftm110,      sftm,     sftm,     sftm,     itech32_state,  init_sftm110,  ROT0, "Capcom / Incredible Technologies", "Street Fighter: The Movie (v1.10)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITSF-1 */
-GAME( 1995, sftmj114,     sftm,     sftm,     sftm,     itech32_state,  init_sftm,     ROT0, "Capcom / Incredible Technologies", "Street Fighter: The Movie (v1.14N, Japan)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITSF-1 */
-GAME( 1995, sftmj112,     sftm,     sftm,     sftm,     itech32_state,  init_sftm,     ROT0, "Capcom / Incredible Technologies", "Street Fighter: The Movie (v1.12N, Japan)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITSF-1 */
-GAME( 1995, sftmk112,     sftm,     sftm,     sftm,     itech32_state,  init_sftm,     ROT0, "Capcom / Incredible Technologies", "Street Fighter: The Movie (v1.12K, Korea)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITSF-1 */
+GAME( 1995, sftm,         0,        sftm,     sftm,     itech32_state,  init_sftm,     ROT0, "Capcom / Incredible Technologies",                        "Street Fighter: The Movie (v1.12)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITSF-1
+GAME( 1995, sftm111,      sftm,     sftm,     sftm,     itech32_state,  init_sftm110,  ROT0, "Capcom / Incredible Technologies",                        "Street Fighter: The Movie (v1.11)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITSF-1
+GAME( 1995, sftm110,      sftm,     sftm,     sftm,     itech32_state,  init_sftm110,  ROT0, "Capcom / Incredible Technologies",                        "Street Fighter: The Movie (v1.10)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITSF-1
+GAME( 1995, sftmj114,     sftm,     sftm,     sftm,     itech32_state,  init_sftm,     ROT0, "Capcom / Incredible Technologies",                        "Street Fighter: The Movie (v1.14N, Japan)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITSF-1
+GAME( 1995, sftmj112,     sftm,     sftm,     sftm,     itech32_state,  init_sftm,     ROT0, "Capcom / Incredible Technologies",                        "Street Fighter: The Movie (v1.12N, Japan)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITSF-1
+GAME( 1995, sftmk112,     sftm,     sftm,     sftm,     itech32_state,  init_sftm,     ROT0, "Capcom / Incredible Technologies",                        "Street Fighter: The Movie (v1.12K, Korea)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITSF-1
 
-GAME( 1997, shufshot,     0,        sftm,     shufshot, itech32_state,  init_shufshot, ROT0, "Strata/Incredible Technologies",   "Shuffleshot (v1.40)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITSHF-1 */
-GAME( 1997, shufshot139,  shufshot, sftm,     shufshot, itech32_state,  init_shufshot, ROT0, "Strata/Incredible Technologies",   "Shuffleshot (v1.39)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITSHF-1 */
-GAME( 1997, shufshot138,  shufshot, sftm,     shufshto, itech32_state,  init_shufshot, ROT0, "Strata/Incredible Technologies",   "Shuffleshot (v1.38)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITSHF-1 */
-GAME( 1997, shufshot137,  shufshot, sftm,     shufshto, itech32_state,  init_shufshot, ROT0, "Strata/Incredible Technologies",   "Shuffleshot (v1.37)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITSHF-1 */
-GAME( 1997, shufshot135,  shufshot, sftm,     shufshot, itech32_state,  init_shufshot, ROT0, "Strata/Incredible Technologies",   "Shuffleshot (v1.35)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITSHF-1 */
+GAME( 1997, shufshot,     0,        sftm,     shufshot, itech32_state,  init_shufshot, ROT0, "Incredible Technologies",                                 "Shuffleshot (v1.40)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITSHF-1
+GAME( 1997, shufshot139,  shufshot, sftm,     shufshot, itech32_state,  init_shufshot, ROT0, "Incredible Technologies",                                 "Shuffleshot (v1.39)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITSHF-1
+GAME( 1997, shufshot138,  shufshot, sftm,     shufshto, itech32_state,  init_shufshot, ROT0, "Incredible Technologies",                                 "Shuffleshot (v1.38)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITSHF-1
+GAME( 1997, shufshot137,  shufshot, sftm,     shufshto, itech32_state,  init_shufshot, ROT0, "Incredible Technologies",                                 "Shuffleshot (v1.37)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITSHF-1
+GAME( 1997, shufshot135,  shufshot, sftm,     shufshot, itech32_state,  init_shufshot, ROT0, "Incredible Technologies",                                 "Shuffleshot (v1.35)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITSHF-1
 
 /*
     The following naming conventions are used:
@@ -5251,49 +5218,49 @@ NOTE: There is an "8 Meg board" version of the P/N 1083 Rev 2 PCB, so GROM0_0 th
     Parent set will always be gt(year) with the most recent version.  IE: gt97 is Golden Tee '97 v1.30
 
 */
-GAME( 1995, gt3d,      0,        sftm,   gt3d,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.93N)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF-2 */
-GAME( 1995, gt3dl192,  gt3d,     sftm,   gt3d,  itech32_state, init_gt3dl,     ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.92L)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF-2 */
-GAME( 1995, gt3dl191,  gt3d,     sftm,   gt3d,  itech32_state, init_gt3dl,     ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.91L)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF-2 */
-GAME( 1995, gt3dl19,   gt3d,     sftm,   gt3d,  itech32_state, init_gt3dl,     ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.9L)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF-2 */
-GAME( 1995, gt3ds192,  gt3d,     sftm,   gt3d,  itech32_state, init_gt3d,      ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.92S)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF-1 */
-GAME( 1995, gt3dv18,   gt3d,     sftm,   gt3d,  itech32_state, init_gt3d,      ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.8)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF-1 */
-GAME( 1995, gt3dv17,   gt3d,     sftm,   gt3d,  itech32_state, init_gt3d,      ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.7)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF-1 */
-GAME( 1995, gt3dv16,   gt3d,     sftm,   gt3d,  itech32_state, init_gt3d,      ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.6)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF-1 */
-GAME( 1995, gt3dv15,   gt3d,     sftm,   gt3d,  itech32_state, init_gt3d,      ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.5)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF-1 */
-GAME( 1995, gt3dv14,   gt3d,     sftm,   gt3d,  itech32_state, init_gt3d,      ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.4)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF-1 */
-GAME( 1995, gt3dt231,  gt3d,     tourny, gt3d,  itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee 3D Golf Tournament (v2.31)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF-2 */
-GAME( 1995, gt3dt211,  gt3d,     tourny, gt3d,  itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee 3D Golf Tournament (v2.11)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF-2 */
+GAME( 1995, gt3d,      0,        sftm,   gt3d,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.93N)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF-2
+GAME( 1995, gt3dl192,  gt3d,     sftm,   gt3d,  itech32_state, init_gt3dl,     ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.92L)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF-2
+GAME( 1995, gt3dl191,  gt3d,     sftm,   gt3d,  itech32_state, init_gt3dl,     ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.91L)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF-2
+GAME( 1995, gt3dl19,   gt3d,     sftm,   gt3d,  itech32_state, init_gt3dl,     ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.9L)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF-2
+GAME( 1995, gt3ds192,  gt3d,     sftm,   gt3d,  itech32_state, init_gt3d,      ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.92S)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF-1
+GAME( 1995, gt3dv18,   gt3d,     sftm,   gt3d,  itech32_state, init_gt3d,      ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.8)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF-1
+GAME( 1995, gt3dv17,   gt3d,     sftm,   gt3d,  itech32_state, init_gt3d,      ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.7)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF-1
+GAME( 1995, gt3dv16,   gt3d,     sftm,   gt3d,  itech32_state, init_gt3d,      ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.6)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF-1
+GAME( 1995, gt3dv15,   gt3d,     sftm,   gt3d,  itech32_state, init_gt3d,      ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.5)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF-1
+GAME( 1995, gt3dv14,   gt3d,     sftm,   gt3d,  itech32_state, init_gt3d,      ROT0, "Incredible Technologies", "Golden Tee 3D Golf (v1.4)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF-1
+GAME( 1995, gt3dt231,  gt3d,     tourny, gt3d,  itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee 3D Golf Tournament (v2.31)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF-2
+GAME( 1995, gt3dt211,  gt3d,     tourny, gt3d,  itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee 3D Golf Tournament (v2.11)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF-2
 
-GAME( 1997, gt97,      0,        sftm,   gt97,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '97 (v1.30)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGFS-3 */
-GAME( 1997, gt97v122,  gt97,     sftm,   gt97o, itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '97 (v1.22)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGFS-3 */
-GAME( 1997, gt97v121,  gt97,     sftm,   gt97o, itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '97 (v1.21)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGFS-3 */
-GAME( 1997, gt97s121,  gt97,     sftm,   gt97s, itech32_state, init_s_ver,     ROT0, "Incredible Technologies", "Golden Tee '97 (v1.21S)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGFM-3 */
-GAME( 1997, gt97v120,  gt97,     sftm,   gt97o, itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '97 (v1.20)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGFS-3 */
-GAME( 1997, gt97t243,  gt97,     tourny, gt97o, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee '97 Tournament (v2.43)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGFS-3 */
-GAME( 1997, gt97t240,  gt97,     tourny, gt97o, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee '97 Tournament (v2.40)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGFS-3 */
+GAME( 1997, gt97,      0,        sftm,   gt97,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '97 (v1.30)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGFS-3
+GAME( 1997, gt97v122,  gt97,     sftm,   gt97o, itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '97 (v1.22)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGFS-3
+GAME( 1997, gt97v121,  gt97,     sftm,   gt97o, itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '97 (v1.21)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGFS-3
+GAME( 1997, gt97s121,  gt97,     sftm,   gt97s, itech32_state, init_s_ver,     ROT0, "Incredible Technologies", "Golden Tee '97 (v1.21S)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGFM-3
+GAME( 1997, gt97v120,  gt97,     sftm,   gt97o, itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '97 (v1.20)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGFS-3
+GAME( 1997, gt97t243,  gt97,     tourny, gt97o, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee '97 Tournament (v2.43)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGFS-3
+GAME( 1997, gt97t240,  gt97,     tourny, gt97o, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee '97 Tournament (v2.40)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGFS-3
 
-GAME( 1998, gt98,      0,        sftm,   aama,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '98 (v1.10)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF98 */
-GAME( 1998, gt98v100,  gt98,     sftm,   gt98,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '98 (v1.00)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF98 */
-GAME( 1998, gt98c100,  gt98,     sftm,   gt98,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '98 (v1.00C)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF98 */
-GAME( 1998, gt98s100,  gt98,     sftm,   gt98s, itech32_state, init_s_ver,     ROT0, "Incredible Technologies", "Golden Tee '98 (v1.00S)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF98-M */
-GAME( 1998, gt98t303,  gt98,     tourny, gt98s, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee '98 Tournament (v3.03)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF98 */
-GAME( 1998, gt98t302,  gt98,     tourny, gt98s, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee '98 Tournament (v3.02)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF98 */
-GAME( 1998, gtdiamond, gt98,     tourny, gt98s, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee Diamond Edition Tournament (v3.05T ELC)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF98 */
+GAME( 1998, gt98,      0,        sftm,   aama,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '98 (v1.10)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF98
+GAME( 1998, gt98v100,  gt98,     sftm,   gt98,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '98 (v1.00)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF98
+GAME( 1998, gt98c100,  gt98,     sftm,   gt98,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '98 (v1.00C)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF98
+GAME( 1998, gt98s100,  gt98,     sftm,   gt98s, itech32_state, init_s_ver,     ROT0, "Incredible Technologies", "Golden Tee '98 (v1.00S)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF98-M
+GAME( 1998, gt98t303,  gt98,     tourny, gt98s, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee '98 Tournament (v3.03)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF98
+GAME( 1998, gt98t302,  gt98,     tourny, gt98s, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee '98 Tournament (v3.02)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF98
+GAME( 1998, gtdiamond, gt98,     tourny, gt98s, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee Diamond Edition Tournament (v3.05T ELC)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF98
 
-GAME( 1999, gt99,      0,        sftm,   aama,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '99 (v1.00)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF99 */
-GAME( 1999, gt99s100,  gt99,     sftm,   s_ver, itech32_state, init_s_ver,     ROT0, "Incredible Technologies", "Golden Tee '99 (v1.00S)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF99-M */
-GAME( 1999, gt99t400,  gt99,     tourny, gt98s, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee '99 Tournament (v4.00)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF99 */
-GAME( 1999, gtroyal,   gt99,     tourny, gt98s, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee Royal Edition Tournament (v4.02T EDM)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF99I */
+GAME( 1999, gt99,      0,        sftm,   aama,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee '99 (v1.00)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF99
+GAME( 1999, gt99s100,  gt99,     sftm,   s_ver, itech32_state, init_s_ver,     ROT0, "Incredible Technologies", "Golden Tee '99 (v1.00S)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF99-M
+GAME( 1999, gt99t400,  gt99,     tourny, gt98s, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee '99 Tournament (v4.00)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF99
+GAME( 1999, gtroyal,   gt99,     tourny, gt98s, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee Royal Edition Tournament (v4.02T EDM)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF99I
 
-GAME( 2000, gt2k,      0,        sftm,   aama,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee 2K (v1.00)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF2K */
-GAME( 2000, gt2kp100,  gt2k,     sftm,   aama,  itech32_state, init_gt2kp,     ROT0, "Incredible Technologies", "Golden Tee 2K (v1.00) (alt protection)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ???? */
-GAME( 2000, gt2ks100,  gt2k,     sftm,   s_ver, itech32_state, init_s_ver,     ROT0, "Incredible Technologies", "Golden Tee 2K (v1.00S)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF2K-M */
-GAME( 2000, gt2kt500,  gt2k,     tourny, gt98s, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee 2K Tournament (v5.00)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF2K */
-GAME( 2002, gtsupreme, gt2k,     tourny, gt98s, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee Supreme Edition Tournament (v5.10T ELC S)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGF2K-I */
+GAME( 2000, gt2k,      0,        sftm,   aama,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee 2K (v1.00)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF2K
+GAME( 2000, gt2kp100,  gt2k,     sftm,   aama,  itech32_state, init_gt2kp,     ROT0, "Incredible Technologies", "Golden Tee 2K (v1.00) (alt protection)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ????
+GAME( 2000, gt2ks100,  gt2k,     sftm,   s_ver, itech32_state, init_s_ver,     ROT0, "Incredible Technologies", "Golden Tee 2K (v1.00S)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF2K-M
+GAME( 2000, gt2kt500,  gt2k,     tourny, gt98s, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee 2K Tournament (v5.00)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF2K
+GAME( 2002, gtsupreme, gt2k,     tourny, gt98s, itech32_state, init_aamat,     ROT0, "Incredible Technologies", "Golden Tee Supreme Edition Tournament (v5.10T ELC S)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGF2K-I
 
-GAME( 2001, gtclassc,  0,        sftm,   aama,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee Classic (v1.00)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGFCL */
-GAME( 2001, gtclasscp, gtclassc, sftm,   aama,  itech32_state, init_gtclasscp, ROT0, "Incredible Technologies", "Golden Tee Classic (v1.00) (alt protection)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGFCL */
-GAME( 2001, gtclasscs, gtclassc, sftm,   s_ver, itech32_state, init_s_ver,     ROT0, "Incredible Technologies", "Golden Tee Classic (v1.00S)" , MACHINE_SUPPORTS_SAVE ) /* PIC 16C54 labeled as ITGFCL-M */
+GAME( 2001, gtclassc,  0,        sftm,   aama,  itech32_state, init_aama,      ROT0, "Incredible Technologies", "Golden Tee Classic (v1.00)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGFCL
+GAME( 2001, gtclasscp, gtclassc, sftm,   aama,  itech32_state, init_gtclasscp, ROT0, "Incredible Technologies", "Golden Tee Classic (v1.00) (alt protection)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGFCL
+GAME( 2001, gtclasscs, gtclassc, sftm,   s_ver, itech32_state, init_s_ver,     ROT0, "Incredible Technologies", "Golden Tee Classic (v1.00S)" , MACHINE_SUPPORTS_SAVE ) // PIC 16C54 labeled as ITGFCL-M 
 
 GAME( 199?, shoottv,  0,         shoottv, shoottv, shoottv_state, empty_init,  ROT0, "Incredible Technologies", "Must Shoot TV (prototype)" , MACHINE_SUPPORTS_SAVE )
 GAME( 1996, pubball,  0,         pubball, pubball, itech32_state, init_pubball,ROT0, "Midway / Incredible Technologies", "Power Up Baseball (prototype)" , MACHINE_SUPPORTS_SAVE )

--- a/src/mame/itech/itech32.h
+++ b/src/mame/itech/itech32.h
@@ -20,12 +20,7 @@
 #include "emupal.h"
 #include "screen.h"
 
-#define VIDEO_CLOCK     XTAL(8'000'000)           // video (pixel) clock
-#define CPU_CLOCK       XTAL(12'000'000)          // clock for 68000-based systems
-#define CPU020_CLOCK    XTAL(25'000'000)          // clock for 68EC020-based systems
-#define SOUND_CLOCK     XTAL(16'000'000)          // clock for sound board
-#define TMS_CLOCK       XTAL(40'000'000)          // TMS320C31 clocks on drivedge
-
+#define LOG_DRIVEDGE_UNINIT_RAM     0
 
 class itech32_state : public driver_device
 {
@@ -34,7 +29,7 @@ public:
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
 		m_soundcpu(*this, "soundcpu"),
-		m_via(*this, "via6522_0"),
+		m_via(*this, "via6522"),
 		m_ensoniq(*this, "ensoniq"),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
@@ -46,10 +41,12 @@ public:
 		m_nvram32(*this, "nvram32"),
 		m_main_ram32(*this, "main_ram"),
 		m_video(*this, "video", 0x200, ENDIANNESS_BIG),
-		m_main_rom16(*this, "user1"),
-		m_main_rom32(*this, "user1"),
-		m_grom(*this, "gfx1"),
-		m_soundbank(*this, "soundbank")
+		m_main_rom16(*this, "maindata"),
+		m_main_rom32(*this, "maindata"),
+		m_grom(*this, "grom"),
+		m_soundbank(*this, "soundbank"),
+		m_trackball_x(*this, "TRACKX%u", 1U),
+		m_trackball_y(*this, "TRACKY%u", 1U)
 	{ }
 
 	void base_devices(machine_config &config);
@@ -82,6 +79,8 @@ public:
 	int special_port_r();
 
 protected:
+	static constexpr XTAL VIDEO_CLOCK   = XTAL(8'000'000);           // video (pixel) clock
+
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_soundcpu;
 	optional_device<via6522_device> m_via; // sftm, wcbowl and gt games don't have the via
@@ -103,6 +102,9 @@ protected:
 	required_region_ptr<u8> m_grom;
 	required_memory_bank m_soundbank;
 
+	optional_ioport_array<2> m_trackball_x;
+	optional_ioport_array<2> m_trackball_y;
+
 	virtual void nvram_init(nvram_device &nvram, void *base, size_t length);
 
 	std::unique_ptr<u16[]> m_videoram;
@@ -112,16 +114,11 @@ protected:
 	u8 m_irq_base = 0;
 	u8 m_sound_return = 0;
 	offs_t m_itech020_prot_address = 0;
-	int m_special_result = 0;
-	int m_p1_effx = 0;
-	int m_p1_effy = 0;
-	int m_p1_lastresult = 0;
-	attotime m_p1_lasttime{};
-	int m_p2_effx = 0;
-	int m_p2_effy = 0;
-	int m_p2_lastresult = 0;
-	attotime m_p2_lasttime{};
-	u8 m_written[0x8000]{};
+	u8 m_special_result = 0;
+	s32 m_effx[2]{};
+	s32 m_effy[2]{};
+	u8 m_lastresult[2]{};
+	attotime m_lasttime[2]{};
 	u16 m_xfer_xcount = 0;
 	u16 m_xfer_ycount = 0;
 	u16 m_xfer_xcur = 0;
@@ -144,11 +141,9 @@ protected:
 	u32 m_grom_bank_mask = 0;
 
 	void int1_ack_w(u16 data);
-	u8 trackball_r();
-	u8 trackball_p2_r();
+	template<unsigned Which> u8 trackball_r();
 	u16 trackball_8bit_r();
-	u32 trackball32_4bit_p1_r();
-	u32 trackball32_4bit_p2_r();
+	template<unsigned Which> u32 trackball32_4bit_r();
 	u32 trackball32_4bit_combined_r();
 	u16 wcbowl_prot_result_r();
 	u8 itech020_prot_result_r();
@@ -190,7 +185,7 @@ protected:
 	inline void disable_clipping();
 	inline void enable_clipping();
 	virtual void logblit(const char *tag);
-	void update_interrupts(int fast);
+	void update_interrupts();
 	void draw_raw(u16 *base, u16 color);
 	void draw_raw_widthpix(u16 *base, u16 color);
 	virtual void command_blit_raw();
@@ -232,6 +227,7 @@ protected:
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
+private:
 	u16 steering_r();
 	u16 gas_r();
 
@@ -270,6 +266,7 @@ protected:
 	required_ioport m_gas;
 
 	u8 m_tms_spinning[2];
+	u8 m_written[0x8000]{};
 };
 
 class shoottv_state : public itech32_state

--- a/src/mame/itech/itech32.h
+++ b/src/mame/itech/itech32.h
@@ -79,7 +79,7 @@ public:
 	int special_port_r();
 
 protected:
-	static constexpr XTAL VIDEO_CLOCK   = XTAL(8'000'000);           // video (pixel) clock
+	static constexpr XTAL VIDEO_CLOCK = XTAL(8'000'000); // video (pixel) clock
 
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_soundcpu;
@@ -231,6 +231,13 @@ private:
 	u16 steering_r();
 	u16 gas_r();
 
+#if LOG_DRIVEDGE_UNINIT_RAM
+	u32 test1_r(offs_t offset, u32 mem_mask);
+	u32 test2_r(offs_t offset, u32 mem_mask);
+	void test1_w(offs_t offset, u32 data, u32 mem_mask);
+	void test2_w(offs_t offset, u32 data, u32 mem_mask);
+#endif
+
 	u32 tms1_speedup_r(address_space &space);
 	u32 tms2_speedup_r(address_space &space);
 	void tms_reset_assert_w(u32 data);
@@ -266,7 +273,9 @@ private:
 	required_ioport m_gas;
 
 	u8 m_tms_spinning[2];
+#if LOG_DRIVEDGE_UNINIT_RAM
 	u8 m_written[0x8000]{};
+#endif
 };
 
 class shoottv_state : public itech32_state

--- a/src/mame/itech/itech32_v.cpp
+++ b/src/mame/itech/itech32_v.cpp
@@ -10,8 +10,6 @@
 #include "emu.h"
 #include "itech32.h"
 
-#include "cpu/m68000/m68000.h"
-
 #include <algorithm>
 
 
@@ -21,7 +19,16 @@
  *
  *************************************/
 
-#define BLIT_LOGGING            0
+#define LOG_BLITTER (1U << 1)
+#define LOG_SCREEN  (1U << 2)
+
+#define LOG_ALL     (LOG_BLITTER | LOG_SCREEN)
+
+#define VERBOSE (0)
+#include "logmacro.h"
+
+#define LOGBLITTER(...) LOGMASKED(LOG_BLITTER, __VA_ARGS__)
+#define LOGSCREEN(...)  LOGMASKED(LOG_SCREEN, __VA_ARGS__)
 
 
 
@@ -31,96 +38,96 @@
  *
  *************************************/
 
-#define VIDEO_UNKNOWN00         m_video[0x00/2] /* $0087 at startup */
+#define VIDEO_UNKNOWN00         m_video[0x00/2] // $0087 at startup
 #define VIDEO_STATUS            m_video[0x00/2]
 #define VIDEO_INTSTATE          m_video[0x02/2]
 #define VIDEO_INTACK            m_video[0x02/2]
 #define VIDEO_TRANSFER          m_video[0x04/2]
-#define VIDEO_TRANSFER_FLAGS    m_video[0x06/2] /* $5080 at startup (kept at $1512) */
-#define VIDEO_COMMAND           m_video[0x08/2] /* $0005 at startup */
-#define VIDEO_INTENABLE         m_video[0x0a/2] /* $0144 at startup (kept at $1514) */
+#define VIDEO_TRANSFER_FLAGS    m_video[0x06/2] // $5080 at startup (kept at $1512)
+#define VIDEO_COMMAND           m_video[0x08/2] // $0005 at startup
+#define VIDEO_INTENABLE         m_video[0x0a/2] // $0144 at startup (kept at $1514)
 #define VIDEO_TRANSFER_HEIGHT   m_video[0x0c/2]
 #define VIDEO_TRANSFER_WIDTH    m_video[0x0e/2]
 #define VIDEO_TRANSFER_ADDRLO   m_video[0x10/2]
 #define VIDEO_TRANSFER_X        m_video[0x12/2]
 #define VIDEO_TRANSFER_Y        m_video[0x14/2]
-#define VIDEO_SRC_YSTEP         m_video[0x16/2] /* $0011 at startup */
+#define VIDEO_SRC_YSTEP         m_video[0x16/2] // $0011 at startup
 #define VIDEO_SRC_XSTEP         m_video[0x18/2]
 #define VIDEO_DST_XSTEP         m_video[0x1a/2]
 #define VIDEO_DST_YSTEP         m_video[0x1c/2]
 #define VIDEO_YSTEP_PER_X       m_video[0x1e/2]
 #define VIDEO_XSTEP_PER_Y       m_video[0x20/2]
-#define VIDEO_UNKNOWN22         m_video[0x22/2] /* $0033 at startup */
+#define VIDEO_UNKNOWN22         m_video[0x22/2] // $0033 at startup
 #define VIDEO_LEFTCLIP          m_video[0x24/2]
 #define VIDEO_RIGHTCLIP         m_video[0x26/2]
 #define VIDEO_TOPCLIP           m_video[0x28/2]
 #define VIDEO_BOTTOMCLIP        m_video[0x2a/2]
-#define VIDEO_INTSCANLINE       m_video[0x2c/2] /* $00ef at startup */
-#define VIDEO_TRANSFER_ADDRHI   m_video[0x2e/2] /* $0000 at startup */
+#define VIDEO_INTSCANLINE       m_video[0x2c/2] // $00ef at startup
+#define VIDEO_TRANSFER_ADDRHI   m_video[0x2e/2] // $0000 at startup
 
-#define VIDEO_UNKNOWN30         m_video[0x30/2] /* $0040 at startup */
-#define VIDEO_VTOTAL            m_video[0x32/2] /* $0106 at startup */
-#define VIDEO_VSYNC             m_video[0x34/2] /* $0101 at startup */
-#define VIDEO_VBLANK_START      m_video[0x36/2] /* $00f3 at startup */
-#define VIDEO_VBLANK_END        m_video[0x38/2] /* $0003 at startup */
-#define VIDEO_HTOTAL            m_video[0x3a/2] /* $01fc at startup */
-#define VIDEO_HSYNC             m_video[0x3c/2] /* $01e4 at startup */
-#define VIDEO_HBLANK_START      m_video[0x3e/2] /* $01b2 at startup */
-#define VIDEO_HBLANK_END        m_video[0x40/2] /* $0032 at startup */
-#define VIDEO_UNKNOWN42         m_video[0x42/2] /* $0015 at startup */
-#define VIDEO_DISPLAY_YORIGIN1  m_video[0x44/2] /* $0000 at startup */
-#define VIDEO_DISPLAY_YORIGIN2  m_video[0x46/2] /* $0000 at startup */
-#define VIDEO_DISPLAY_YSCROLL2  m_video[0x48/2] /* $0000 at startup */
-#define VIDEO_UNKNOWN4a         m_video[0x4a/2] /* $0000 at startup */
-#define VIDEO_DISPLAY_XORIGIN1  m_video[0x4c/2] /* $0000 at startup */
-#define VIDEO_DISPLAY_XORIGIN2  m_video[0x4e/2] /* $0000 at startup */
-#define VIDEO_DISPLAY_XSCROLL2  m_video[0x50/2] /* $0000 at startup */
-#define VIDEO_UNKNOWN52         m_video[0x52/2] /* $0000 at startup */
-#define VIDEO_UNKNOWN54         m_video[0x54/2] /* $0080 at startup */
-#define VIDEO_UNKNOWN56         m_video[0x56/2] /* $00c0 at startup */
-#define VIDEO_UNKNOWN58         m_video[0x58/2] /* $01c0 at startup */
-#define VIDEO_UNKNOWN5a         m_video[0x5a/2] /* $01c0 at startup */
-#define VIDEO_UNKNOWN5c         m_video[0x5c/2] /* $01cf at startup */
-#define VIDEO_UNKNOWN5e         m_video[0x5e/2] /* $01cf at startup, kept $01bf in running game, $01c3 at testing */
-#define VIDEO_UNKNOWN60         m_video[0x60/2] /* $01e3 at startup */
-#define VIDEO_UNKNOWN62         m_video[0x62/2] /* $01cf at startup */
-#define VIDEO_UNKNOWN64         m_video[0x64/2] /* $01ff at startup */
-#define VIDEO_UNKNOWN66         m_video[0x66/2] /* $0183 at startup, kept $01bf in running game, $1ff at testing */
-#define VIDEO_UNKNOWN68         m_video[0x68/2] /* $01ff at startup */
-#define VIDEO_UNKNOWN6a         m_video[0x6a/2] /* $000f at startup */
-#define VIDEO_UNKNOWN6c         m_video[0x6c/2] /* $018f at startup */
-#define VIDEO_UNKNOWN6e         m_video[0x6e/2] /* $01ff at startup, kept $01ff in running game, $01c3 at testing */
-#define VIDEO_UNKNOWN70         m_video[0x70/2] /* $000f at startup */
-#define VIDEO_UNKNOWN72         m_video[0x72/2] /* $000f at startup */
-#define VIDEO_UNKNOWN74         m_video[0x74/2] /* $01ff at startup */
-#define VIDEO_UNKNOWN76         m_video[0x76/2] /* $01ff at startup */
-#define VIDEO_UNKNOWN78         m_video[0x78/2] /* $01ff at startup */
-#define VIDEO_UNKNOWN7a         m_video[0x7a/2] /* $01ff at startup */
-#define VIDEO_UNKNOWN7c         m_video[0x7c/2] /* $0820 at startup */
-#define VIDEO_UNKNOWN7e         m_video[0x7e/2] /* $0100 at startup */
+#define VIDEO_UNKNOWN30         m_video[0x30/2] // $0040 at startup
+#define VIDEO_VTOTAL            m_video[0x32/2] // $0106 at startup
+#define VIDEO_VSYNC             m_video[0x34/2] // $0101 at startup
+#define VIDEO_VBLANK_START      m_video[0x36/2] // $00f3 at startup
+#define VIDEO_VBLANK_END        m_video[0x38/2] // $0003 at startup
+#define VIDEO_HTOTAL            m_video[0x3a/2] // $01fc at startup
+#define VIDEO_HSYNC             m_video[0x3c/2] // $01e4 at startup
+#define VIDEO_HBLANK_START      m_video[0x3e/2] // $01b2 at startup
+#define VIDEO_HBLANK_END        m_video[0x40/2] // $0032 at startup
+#define VIDEO_UNKNOWN42         m_video[0x42/2] // $0015 at startup
+#define VIDEO_DISPLAY_YORIGIN1  m_video[0x44/2] // $0000 at startup
+#define VIDEO_DISPLAY_YORIGIN2  m_video[0x46/2] // $0000 at startup
+#define VIDEO_DISPLAY_YSCROLL2  m_video[0x48/2] // $0000 at startup
+#define VIDEO_UNKNOWN4a         m_video[0x4a/2] // $0000 at startup
+#define VIDEO_DISPLAY_XORIGIN1  m_video[0x4c/2] // $0000 at startup
+#define VIDEO_DISPLAY_XORIGIN2  m_video[0x4e/2] // $0000 at startup
+#define VIDEO_DISPLAY_XSCROLL2  m_video[0x50/2] // $0000 at startup
+#define VIDEO_UNKNOWN52         m_video[0x52/2] // $0000 at startup
+#define VIDEO_UNKNOWN54         m_video[0x54/2] // $0080 at startup
+#define VIDEO_UNKNOWN56         m_video[0x56/2] // $00c0 at startup
+#define VIDEO_UNKNOWN58         m_video[0x58/2] // $01c0 at startup
+#define VIDEO_UNKNOWN5a         m_video[0x5a/2] // $01c0 at startup
+#define VIDEO_UNKNOWN5c         m_video[0x5c/2] // $01cf at startup
+#define VIDEO_UNKNOWN5e         m_video[0x5e/2] // $01cf at startup, kept $01bf in running game, $01c3 at testing
+#define VIDEO_UNKNOWN60         m_video[0x60/2] // $01e3 at startup
+#define VIDEO_UNKNOWN62         m_video[0x62/2] // $01cf at startup
+#define VIDEO_UNKNOWN64         m_video[0x64/2] // $01ff at startup
+#define VIDEO_UNKNOWN66         m_video[0x66/2] // $0183 at startup, kept $01bf in running game, $1ff at testing
+#define VIDEO_UNKNOWN68         m_video[0x68/2] // $01ff at startup
+#define VIDEO_UNKNOWN6a         m_video[0x6a/2] // $000f at startup
+#define VIDEO_UNKNOWN6c         m_video[0x6c/2] // $018f at startup
+#define VIDEO_UNKNOWN6e         m_video[0x6e/2] // $01ff at startup, kept $01ff in running game, $01c3 at testing
+#define VIDEO_UNKNOWN70         m_video[0x70/2] // $000f at startup
+#define VIDEO_UNKNOWN72         m_video[0x72/2] // $000f at startup
+#define VIDEO_UNKNOWN74         m_video[0x74/2] // $01ff at startup
+#define VIDEO_UNKNOWN76         m_video[0x76/2] // $01ff at startup
+#define VIDEO_UNKNOWN78         m_video[0x78/2] // $01ff at startup
+#define VIDEO_UNKNOWN7a         m_video[0x7a/2] // $01ff at startup
+#define VIDEO_UNKNOWN7c         m_video[0x7c/2] // $0820 at startup
+#define VIDEO_UNKNOWN7e         m_video[0x7e/2] // $0100 at startup
 
-#define VIDEO_STARTSTEP         m_video[0x80/2] /* drivedge only? */
-#define VIDEO_LEFTSTEPLO        m_video[0x82/2] /* drivedge only? */
-#define VIDEO_LEFTSTEPHI        m_video[0x84/2] /* drivedge only? */
-#define VIDEO_RIGHTSTEPLO       m_video[0x86/2] /* drivedge only? */
-#define VIDEO_RIGHTSTEPHI       m_video[0x88/2] /* drivedge only? */
+#define VIDEO_STARTSTEP         m_video[0x80/2] // drivedge only?
+#define VIDEO_LEFTSTEPLO        m_video[0x82/2] // drivedge only?
+#define VIDEO_LEFTSTEPHI        m_video[0x84/2] // drivedge only?
+#define VIDEO_RIGHTSTEPLO       m_video[0x86/2] // drivedge only?
+#define VIDEO_RIGHTSTEPHI       m_video[0x88/2] // drivedge only?
 
-#define VIDEOINT_SCANLINE       0x0004
-#define VIDEOINT_BLITTER        0x0040
+static constexpr u16 VIDEOINT_SCANLINE     = 0x0004;
+static constexpr u16 VIDEOINT_BLITTER      = 0x0040;
 
-#define XFERFLAG_TRANSPARENT    0x0001
-#define XFERFLAG_XFLIP          0x0002
-#define XFERFLAG_YFLIP          0x0004
-#define XFERFLAG_DSTXSCALE      0x0008
-#define XFERFLAG_DYDXSIGN       0x0010
-#define XFERFLAG_DXDYSIGN       0x0020
-#define XFERFLAG_UNKNOWN8       0x0100
-#define XFERFLAG_CLIP           0x0400
-#define XFERFLAG_WIDTHPIX       0x8000
+static constexpr u16 XFERFLAG_TRANSPARENT  = 0x0001;
+static constexpr u16 XFERFLAG_XFLIP        = 0x0002;
+static constexpr u16 XFERFLAG_YFLIP        = 0x0004;
+static constexpr u16 XFERFLAG_DSTXSCALE    = 0x0008;
+static constexpr u16 XFERFLAG_DYDXSIGN     = 0x0010;
+static constexpr u16 XFERFLAG_DXDYSIGN     = 0x0020;
+static constexpr u16 XFERFLAG_UNKNOWN8     = 0x0100;
+static constexpr u16 XFERFLAG_CLIP         = 0x0400;
+static constexpr u16 XFERFLAG_WIDTHPIX     = 0x8000;
 
-#define XFERFLAG_KNOWNFLAGS     (XFERFLAG_TRANSPARENT | XFERFLAG_XFLIP | XFERFLAG_YFLIP | XFERFLAG_DSTXSCALE | XFERFLAG_DYDXSIGN | XFERFLAG_DXDYSIGN | XFERFLAG_CLIP | XFERFLAG_WIDTHPIX)
+static constexpr u16 XFERFLAG_KNOWNFLAGS   = (XFERFLAG_TRANSPARENT | XFERFLAG_XFLIP | XFERFLAG_YFLIP | XFERFLAG_DSTXSCALE | XFERFLAG_DYDXSIGN | XFERFLAG_DXDYSIGN | XFERFLAG_CLIP | XFERFLAG_WIDTHPIX);
 
-#define VRAM_WIDTH              512
+static constexpr int VRAM_WIDTH = 512;
 
 
 
@@ -168,32 +175,30 @@ inline void itech32_state::enable_clipping()
 
 void itech32_state::video_start()
 {
-	int i;
-
-	/* allocate memory */
+	// allocate memory
 	m_videoram = std::make_unique<u16[]>(VRAM_WIDTH * (m_vram_height + 16) * 2);
 	std::fill_n(&m_videoram[0], VRAM_WIDTH * (m_vram_height + 16) * 2, 0xff);
 
-	/* videoplane[0] is the foreground; videoplane[1] is the background */
+	// videoplane[0] is the foreground; videoplane[1] is the background
 	m_videoplane[0] = &m_videoram[0 * VRAM_WIDTH * (m_vram_height + 16) + 8 * VRAM_WIDTH];
 	m_videoplane[1] = &m_videoram[1 * VRAM_WIDTH * (m_vram_height + 16) + 8 * VRAM_WIDTH];
 
-	/* set the masks */
+	// set the masks
 	m_vram_mask = VRAM_WIDTH * m_vram_height - 1;
 	m_vram_xmask = VRAM_WIDTH - 1;
 	m_vram_ymask = m_vram_height - 1;
 
-	/* clear the planes initially */
-	for (i = 0; i < VRAM_WIDTH * m_vram_height; i++)
+	// clear the planes initially
+	for (int i = 0; i < VRAM_WIDTH * m_vram_height; i++)
 		m_videoplane[0][i] = m_videoplane[1][i] = 0xff;
 
-	/* fetch the GROM base */
+	// fetch the GROM base
 	m_grom_bank = 0;
 	m_grom_bank_mask = m_grom.length() >> 24;
 	if (m_grom_bank_mask == 2)
 		m_grom_bank_mask = 3;
 
-	/* reset statics */
+	// reset statics
 	std::fill_n(&m_video[0], m_video.bytes() >> 1, 0);
 
 	m_scanline_timer = timer_alloc(FUNC(itech32_state::scanline_interrupt), this);
@@ -227,8 +232,8 @@ void shoottv_state::video_start()
 
 void itech32_state::timekill_colora_w(u8 data)
 {
-	m_enable_latch[0] = (~data >> 5) & 1;
-	m_enable_latch[1] = (~data >> 7) & 1;
+	m_enable_latch[0] = BIT(~data, 5);
+	m_enable_latch[1] = BIT(~data, 7);
 	m_color_latch[0] = (data & 0x0f) << 8;
 }
 
@@ -249,15 +254,15 @@ void itech32_state::timekill_intensity_w(u8 data)
 
 void itech32_state::bloodstm_plane_w(u8 data)
 {
-	m_enable_latch[0] = (~data >> 1) & 1;
-	m_enable_latch[1] = (~data >> 2) & 1;
+	m_enable_latch[0] = BIT(~data, 1);
+	m_enable_latch[1] = BIT(~data, 2);
 }
 
 
 void itech32_state::itech020_plane_w(u8 data)
 {
-	m_enable_latch[0] = (~data >> 1) & 1;
-	m_enable_latch[1] = (~data >> 2) & 1;
+	m_enable_latch[0] = BIT(~data, 1);
+	m_enable_latch[1] = BIT(~data, 2);
 	m_grom_bank = ((data >> 6) & m_grom_bank_mask) << 24;
 }
 
@@ -271,7 +276,7 @@ void itech32_state::itech020_plane_w(u8 data)
 
 void itech32_state::bloodstm_paletteram_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	/* in test mode, the LSB is used; in game mode, the MSB is used */
+	// in test mode, the LSB is used; in game mode, the MSB is used
 	if (!ACCESSING_BITS_0_7 && (offset & 1))
 	{
 		data >>= 8;
@@ -296,8 +301,8 @@ void drivedge_state::logblit(const char *tag)
 
 	if (VIDEO_TRANSFER_FLAGS == 0x5490)
 	{
-		/* polygon drawing */
-		logerror("%s: e=%d%d f=%04x s=(%03x-%03x,%03x) w=%03x h=%03x b=%02x%04x c=%02x%02x ss=%04x,%04x ds=%04x,%04x ls=%04x%04x rs=%04x%04x u80=%04x", tag,
+		// polygon drawing
+		LOGBLITTER("%s: e=%d%d f=%04x s=(%03x-%03x,%03x) w=%03x h=%03x b=%02x%04x c=%02x%02x ss=%04x,%04x ds=%04x,%04x ls=%04x%04x rs=%04x%04x u80=%04x", tag,
 			m_enable_latch[0], m_enable_latch[1],
 			VIDEO_TRANSFER_FLAGS,
 			VIDEO_TRANSFER_X, VIDEO_RIGHTCLIP, VIDEO_TRANSFER_Y, VIDEO_TRANSFER_WIDTH, VIDEO_TRANSFER_HEIGHT,
@@ -307,7 +312,7 @@ void drivedge_state::logblit(const char *tag)
 			VIDEO_DST_XSTEP, VIDEO_DST_YSTEP,
 			VIDEO_LEFTSTEPHI, VIDEO_LEFTSTEPLO, VIDEO_RIGHTSTEPHI, VIDEO_RIGHTSTEPLO,
 			VIDEO_STARTSTEP);
-		logerror(" v0=%08x v1=%08x v2=%08x v3=%08x\n", m_zbuf_control[0], m_zbuf_control[1], m_zbuf_control[2], m_zbuf_control[3]);
+		LOGBLITTER(" v0=%08x v1=%08x v2=%08x v3=%08x\n", m_zbuf_control[0], m_zbuf_control[1], m_zbuf_control[2], m_zbuf_control[3]);
 	}
 	else
 	{
@@ -324,7 +329,7 @@ void itech32_state::logblit(const char *tag)
 		m_video[0x1a/2] == 0x000 && m_video[0x1c/2] == 0x100 &&
 		m_video[0x1e/2] == 0x000 && m_video[0x20/2] == 0x000)
 	{
-		logerror("%s: e=%d%d f=%04x c=%02x%02x %02x%04x -> (%03x,%03x) %3dx%3dc=(%03x,%03x)-(%03x,%03x)", tag,
+		LOGBLITTER("%s: e=%d%d f=%04x c=%02x%02x %02x%04x -> (%03x,%03x) %3dx%3dc=(%03x,%03x)-(%03x,%03x)", tag,
 				m_enable_latch[0], m_enable_latch[1],
 				VIDEO_TRANSFER_FLAGS,
 				m_color_latch[0] >> 8, m_color_latch[1] >> 8,
@@ -335,7 +340,7 @@ void itech32_state::logblit(const char *tag)
 	}
 	else
 	{
-		logerror("%s: e=%d%d f=%04x c=%02x%02x %02x%04x -> (%03x,%03x) %3dx%d c=(%03x,%03x)-(%03x,%03x) s=%04x %04x %04x %04x %04x %04x", tag,
+		LOGBLITTER("%s: e=%d%d f=%04x c=%02x%02x %02x%04x -> (%03x,%03x) %3dx%d c=(%03x,%03x)-(%03x,%03x) s=%04x %04x %04x %04x %04x %04x", tag,
 				m_enable_latch[0], m_enable_latch[1],
 				VIDEO_TRANSFER_FLAGS,
 				m_color_latch[0] >> 8, m_color_latch[1] >> 8,
@@ -346,7 +351,7 @@ void itech32_state::logblit(const char *tag)
 				m_video[0x16/2], m_video[0x18/2], m_video[0x1a/2],
 				m_video[0x1c/2], m_video[0x1e/2], m_video[0x20/2]);
 	}
-	logerror("\n");
+	LOGBLITTER("\n");
 }
 
 
@@ -357,7 +362,7 @@ void itech32_state::logblit(const char *tag)
  *
  *************************************/
 
-void itech32_state::update_interrupts(int fast)
+void itech32_state::update_interrupts()
 {
 	int scanline_state = 0, blitter_state = 0;
 
@@ -372,21 +377,21 @@ void itech32_state::update_interrupts(int fast)
 
 TIMER_CALLBACK_MEMBER(itech32_state::scanline_interrupt)
 {
-	/* set timer for next frame */
+	// set timer for next frame
 	m_scanline_timer->adjust(m_screen->time_until_pos(VIDEO_INTSCANLINE));
 
-	/* set the interrupt bit in the status reg */
-	//logerror("-------------- (DISPLAY INT @ %d) ----------------\n", m_screen->vpos());
+	// set the interrupt bit in the status reg
+	//LOGSCREEN("-------------- (DISPLAY INT @ %d) ----------------\n", m_screen->vpos());
 	VIDEO_INTSTATE |= VIDEOINT_SCANLINE;
 
-	/* update the interrupt state */
-	update_interrupts(0);
+	// update the interrupt state
+	update_interrupts();
 }
 
 
 TIMER_CALLBACK_MEMBER(shoottv_state::gun_interrupt)
 {
-	s32 vpos = m_screen->vpos();
+	const s32 vpos = m_screen->vpos();
 	if ((vpos & 0x1f) == 0)
 		m_maincpu->set_input_line(5, ASSERT_LINE);
 	if ((vpos & 0x1f) == 16)
@@ -402,58 +407,58 @@ TIMER_CALLBACK_MEMBER(shoottv_state::gun_interrupt)
 
 void itech32_state::draw_raw(u16 *base, u16 color)
 {
-	u8* src = &m_grom[0];// m_grom[(m_grom_bank | ((VIDEO_TRANSFER_ADDRHI & 0xff) << 16) | VIDEO_TRANSFER_ADDRLO) % m_grom.length()];
+	const u8* src = &m_grom[0];// m_grom[(m_grom_bank | ((VIDEO_TRANSFER_ADDRHI & 0xff) << 16) | VIDEO_TRANSFER_ADDRLO) % m_grom.length()];
 	const u32 grom_length = m_grom.length();
 	const u32 grom_base = m_grom_bank | ((VIDEO_TRANSFER_ADDRHI & 0xff) << 16) | VIDEO_TRANSFER_ADDRLO;
-	int transparent_pen = (VIDEO_TRANSFER_FLAGS & XFERFLAG_TRANSPARENT) ? 0xff : -1;
-	int width = VIDEO_TRANSFER_WIDTH << 8;
-	int height = ADJUSTED_HEIGHT(VIDEO_TRANSFER_HEIGHT) << 8;
-	int xsrcstep = VIDEO_SRC_XSTEP;
-	int ysrcstep = VIDEO_SRC_YSTEP;
+	const int transparent_pen = (VIDEO_TRANSFER_FLAGS & XFERFLAG_TRANSPARENT) ? 0xff : -1;
+	const int width = VIDEO_TRANSFER_WIDTH << 8;
+	const int height = ADJUSTED_HEIGHT(VIDEO_TRANSFER_HEIGHT) << 8;
+	const int xsrcstep = VIDEO_SRC_XSTEP;
+	const int ysrcstep = VIDEO_SRC_YSTEP;
 	int sx, sy = (VIDEO_TRANSFER_Y & 0xfff) << 8;
 	int startx = (VIDEO_TRANSFER_X & 0xfff) << 8;
 	int xdststep = 0x100;
 	int ydststep = VIDEO_DST_YSTEP;
 	int x, y;
 
-	/* adjust for (lack of) clipping */
+	// adjust for (lack of) clipping
 	if (!(VIDEO_TRANSFER_FLAGS & XFERFLAG_CLIP))
 		disable_clipping();
 
-	/* adjust for scaling */
+	// adjust for scaling
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_DSTXSCALE)
 		xdststep = VIDEO_DST_XSTEP;
 
-	/* adjust for flipping */
+	// adjust for flipping
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_XFLIP)
 		xdststep = -xdststep;
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_YFLIP)
 		ydststep = -ydststep;
 
-	/* loop over Y in src pixels */
+	// loop over Y in src pixels
 	for (y = 0; y < height; y += ysrcstep, sy += ydststep)
 	{
 		const u32 row_base = (y >> 8) * (width >> 8);
 
-		/* simpler case: VIDEO_YSTEP_PER_X is zero */
+		// simpler case: VIDEO_YSTEP_PER_X is zero
 		if (VIDEO_YSTEP_PER_X == 0)
 		{
-			/* clip in the Y direction */
+			// clip in the Y direction
 			if (sy >= m_scaled_clip_rect.min_y && sy < m_scaled_clip_rect.max_y)
 			{
 				u32 dstoffs;
 
-				/* direction matters here */
+				// direction matters here
 				sx = startx;
 				if (xdststep > 0)
 				{
-					/* skip left pixels */
+					// skip left pixels
 					for (x = 0; x < width && sx < m_scaled_clip_rect.min_x; x += xsrcstep, sx += xdststep) ;
 
-					/* compute the address */
+					// compute the address
 					dstoffs = compute_safe_address(sx >> 8, sy >> 8) - (sx >> 8);
 
-					/* render middle pixels */
+					// render middle pixels
 					for ( ; x < width && sx < m_scaled_clip_rect.max_x; x += xsrcstep, sx += xdststep)
 					{
 						int pixel = src[(grom_base + row_base + (x >> 8)) % grom_length];
@@ -463,13 +468,13 @@ void itech32_state::draw_raw(u16 *base, u16 color)
 				}
 				else
 				{
-					/* skip right pixels */
+					// skip right pixels
 					for (x = 0; x < width && sx >= m_scaled_clip_rect.max_x; x += xsrcstep, sx += xdststep) ;
 
-					/* compute the address */
+					// compute the address
 					dstoffs = compute_safe_address(sx >> 8, sy >> 8) - (sx >> 8);
 
-					/* render middle pixels */
+					// render middle pixels
 					for ( ; x < width && sx >= m_scaled_clip_rect.min_x; x += xsrcstep, sx += xdststep)
 					{
 						int pixel = src[(grom_base + row_base + (x >> 8)) % grom_length];
@@ -480,13 +485,13 @@ void itech32_state::draw_raw(u16 *base, u16 color)
 			}
 		}
 
-		/* slow case: VIDEO_YSTEP_PER_X is non-zero */
+		// slow case: VIDEO_YSTEP_PER_X is non-zero
 		else
 		{
 			int ystep = (VIDEO_TRANSFER_FLAGS & XFERFLAG_DYDXSIGN) ? -VIDEO_YSTEP_PER_X : VIDEO_YSTEP_PER_X;
 			int ty = sy;
 
-			/* render all pixels */
+			// render all pixels
 			sx = startx;
 			for (x = 0; x < width && sx < m_scaled_clip_rect.max_x; x += xsrcstep, sx += xdststep, ty += ystep)
 				if (m_scaled_clip_rect.contains(sx, ty))
@@ -497,50 +502,50 @@ void itech32_state::draw_raw(u16 *base, u16 color)
 				}
 		}
 
-		/* apply skew */
+		// apply skew
 		if (VIDEO_TRANSFER_FLAGS & XFERFLAG_DXDYSIGN)
 			startx += VIDEO_XSTEP_PER_Y;
 		else
 			startx -= VIDEO_XSTEP_PER_Y;
 	}
 
-	/* restore cliprects */
+	// restore cliprects
 	if (!(VIDEO_TRANSFER_FLAGS & XFERFLAG_CLIP))
 		enable_clipping();
 }
 
-/* draw a scaled primitive such that the specified width is in pixel, not scaled, coordinates */
+// draw a scaled primitive such that the specified width is in pixel, not scaled, coordinates
 void itech32_state::draw_raw_widthpix(u16 *base, u16 color)
 {
-	u8* src = &m_grom[0];// m_grom[(m_grom_bank | ((VIDEO_TRANSFER_ADDRHI & 0xff) << 16) | VIDEO_TRANSFER_ADDRLO) % m_grom.length()];
+	const u8* src = &m_grom[0];// m_grom[(m_grom_bank | ((VIDEO_TRANSFER_ADDRHI & 0xff) << 16) | VIDEO_TRANSFER_ADDRLO) % m_grom.length()];
 	const u32 grom_length = m_grom.length();
 	const u32 grom_base = m_grom_bank | ((VIDEO_TRANSFER_ADDRHI & 0xff) << 16) | VIDEO_TRANSFER_ADDRLO;
-	int transparent_pen = (VIDEO_TRANSFER_FLAGS & XFERFLAG_TRANSPARENT) ? 0xff : -1;
-	int width = VIDEO_TRANSFER_WIDTH << 8;
-	int height = ADJUSTED_HEIGHT(VIDEO_TRANSFER_HEIGHT) << 8;
-	int xsrcstep = VIDEO_SRC_XSTEP;
-	int ysrcstep = VIDEO_SRC_YSTEP;
+	const int transparent_pen = (VIDEO_TRANSFER_FLAGS & XFERFLAG_TRANSPARENT) ? 0xff : -1;
+	const int width = VIDEO_TRANSFER_WIDTH << 8;
+	const int height = ADJUSTED_HEIGHT(VIDEO_TRANSFER_HEIGHT) << 8;
+	const int xsrcstep = VIDEO_SRC_XSTEP;
+	const int ysrcstep = VIDEO_SRC_YSTEP;
 	int sx, sy = (VIDEO_TRANSFER_Y & 0xfff) << 8;
 	int startx = (VIDEO_TRANSFER_X & 0xfff) << 8;
 	int xdststep = 0x100;
 	int ydststep = VIDEO_DST_YSTEP;
 	int x, y, px;
 
-	/* adjust for (lack of) clipping */
+	// adjust for (lack of) clipping
 	if (!(VIDEO_TRANSFER_FLAGS & XFERFLAG_CLIP))
 		disable_clipping();
 
-	/* adjust for scaling */
+	// adjust for scaling
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_DSTXSCALE)
 		xdststep = VIDEO_DST_XSTEP;
 
-	/* adjust for flipping */
+	// adjust for flipping
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_XFLIP)
 		xdststep = -xdststep;
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_YFLIP)
 		ydststep = -ydststep;
 
-	/* loop over Y in src pixels */
+	// loop over Y in src pixels
 	for (y = 0; y < height; y += ysrcstep, sy += ydststep)
 	{
 		const u32 row_base = (y >> 8) * (width >> 8);
@@ -548,25 +553,25 @@ void itech32_state::draw_raw_widthpix(u16 *base, u16 color)
 		x = 0;
 		px = 0;
 
-		/* simpler case: VIDEO_YSTEP_PER_X is zero */
+		// simpler case: VIDEO_YSTEP_PER_X is zero
 		if (VIDEO_YSTEP_PER_X == 0)
 		{
-			/* clip in the Y direction */
+			// clip in the Y direction
 			if (sy >= m_scaled_clip_rect.min_y && sy < m_scaled_clip_rect.max_y)
 			{
 				u32 dstoffs;
 
-				/* direction matters here */
+				// direction matters here
 				sx = startx;
 				if (xdststep > 0)
 				{
-					/* skip left pixels */
+					// skip left pixels
 					for ( ; px < width && sx < m_scaled_clip_rect.min_x; x += xsrcstep, px += 0x100, sx += xdststep) ;
 
-					/* compute the address */
+					// compute the address
 					dstoffs = compute_safe_address(sx >> 8, sy >> 8) - (sx >> 8);
 
-					/* render middle pixels */
+					// render middle pixels
 					for ( ; px < width && sx < m_scaled_clip_rect.max_x; x += xsrcstep, px += 0x100, sx += xdststep)
 					{
 						int pixel = src[(grom_base + row_base + (x >> 8)) % grom_length];
@@ -576,13 +581,13 @@ void itech32_state::draw_raw_widthpix(u16 *base, u16 color)
 				}
 				else
 				{
-					/* skip right pixels */
+					// skip right pixels
 					for ( ; px < width && sx >= m_scaled_clip_rect.max_x; x += xsrcstep, px += 0x100, sx += xdststep) ;
 
-					/* compute the address */
+					// compute the address
 					dstoffs = compute_safe_address(sx >> 8, sy >> 8) - (sx >> 8);
 
-					/* render middle pixels */
+					// render middle pixels
 					for ( ; px < width && sx >= m_scaled_clip_rect.min_x; x += xsrcstep, px += 0x100, sx += xdststep)
 					{
 						int pixel = src[(grom_base + row_base + (x >> 8)) % grom_length];
@@ -593,13 +598,13 @@ void itech32_state::draw_raw_widthpix(u16 *base, u16 color)
 			}
 		}
 
-		/* slow case: VIDEO_YSTEP_PER_X is non-zero */
+		// slow case: VIDEO_YSTEP_PER_X is non-zero
 		else
 		{
 			int ystep = (VIDEO_TRANSFER_FLAGS & XFERFLAG_DYDXSIGN) ? -VIDEO_YSTEP_PER_X : VIDEO_YSTEP_PER_X;
 			int ty = sy;
 
-			/* render all pixels */
+			// render all pixels
 			sx = startx;
 			for ( ; px < width && sx < m_scaled_clip_rect.max_x; x += xsrcstep, px += 0x100, sx += xdststep, ty += ystep)
 				if (m_scaled_clip_rect.contains(sx, ty))
@@ -610,82 +615,82 @@ void itech32_state::draw_raw_widthpix(u16 *base, u16 color)
 				}
 		}
 
-		/* apply skew */
+		// apply skew
 		if (VIDEO_TRANSFER_FLAGS & XFERFLAG_DXDYSIGN)
 			startx += VIDEO_XSTEP_PER_Y;
 		else
 			startx -= VIDEO_XSTEP_PER_Y;
 	}
 
-	/* restore cliprects */
+	// restore cliprects
 	if (!(VIDEO_TRANSFER_FLAGS & XFERFLAG_CLIP))
 		enable_clipping();
 }
 
 void drivedge_state::draw_raw(u16 *base, u16 *zbase, u16 color)
 {
-	u8 *src = &m_grom[(m_grom_bank | ((VIDEO_TRANSFER_ADDRHI & 0xff) << 16) | VIDEO_TRANSFER_ADDRLO) % m_grom.length()];
-	int transparent_pen = (VIDEO_TRANSFER_FLAGS & XFERFLAG_TRANSPARENT) ? 0xff : -1;
+	const u8 *src = &m_grom[(m_grom_bank | ((VIDEO_TRANSFER_ADDRHI & 0xff) << 16) | VIDEO_TRANSFER_ADDRLO) % m_grom.length()];
+	const int transparent_pen = (VIDEO_TRANSFER_FLAGS & XFERFLAG_TRANSPARENT) ? 0xff : -1;
 	int width = VIDEO_TRANSFER_WIDTH << 8;
-	int height = ADJUSTED_HEIGHT(VIDEO_TRANSFER_HEIGHT) << 8;
-	int xsrcstep = VIDEO_SRC_XSTEP;
-	int ysrcstep = VIDEO_SRC_YSTEP;
+	const int height = ADJUSTED_HEIGHT(VIDEO_TRANSFER_HEIGHT) << 8;
+	const int xsrcstep = VIDEO_SRC_XSTEP;
+	const int ysrcstep = VIDEO_SRC_YSTEP;
 	int sx, sy = ((VIDEO_TRANSFER_Y & 0xfff) << 8) + 0x80;
 	int startx = ((VIDEO_TRANSFER_X & 0xfff) << 8) + 0x80;
 	int xdststep = 0x100;
 	int ydststep = VIDEO_DST_YSTEP;
-	int32_t z0 = m_zbuf_control[2] & 0x7ff00;
-	int32_t zmatch = (m_zbuf_control[2] & 0x1f) << 11;
-	int32_t srcdelta = 0;
+	s32 z0 = m_zbuf_control[2] & 0x7ff00;
+	const s32 zmatch = (m_zbuf_control[2] & 0x1f) << 11;
+	s32 srcdelta = 0;
 	int x, y;
 
-	/* adjust for (lack of) clipping */
+	// adjust for (lack of) clipping
 	if (!(VIDEO_TRANSFER_FLAGS & XFERFLAG_CLIP))
 		disable_clipping();
 
-	/* adjust for scaling */
+	// adjust for scaling
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_DSTXSCALE)
 		xdststep = VIDEO_DST_XSTEP;
 
-	/* adjust for flipping */
+	// adjust for flipping
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_XFLIP)
 		xdststep = -xdststep;
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_YFLIP)
 		ydststep = -ydststep;
 
-	/* loop over Y in src pixels */
+	// loop over Y in src pixels
 	for (y = 0; y < height; y += ysrcstep, sy += ydststep)
 	{
-		u8 *rowsrc = src + (srcdelta >> 8);
+		const u8 *rowsrc = src + (srcdelta >> 8);
 
-		/* in the polygon case, we don't factor in the Y */
+		// in the polygon case, we don't factor in the Y
 		if (VIDEO_TRANSFER_FLAGS != 0x5490)
 			rowsrc += (y >> 8) * (width >> 8);
 		else
 			width = 1000 << 8;
 
-		/* simpler case: VIDEO_YSTEP_PER_X is zero */
+		// simpler case: VIDEO_YSTEP_PER_X is zero
 		if (VIDEO_YSTEP_PER_X == 0)
 		{
-			/* clip in the Y direction */
+			// clip in the Y direction
 			if (sy >= m_scaled_clip_rect.min_y && sy < m_scaled_clip_rect.max_y)
 			{
 				u32 dstoffs, zbufoffs;
-				int32_t z = z0;
+				s32 z = z0;
 
-				/* direction matters here */
+				// direction matters here
 				sx = startx;
 				if (xdststep > 0)
 				{
-					/* skip left pixels */
+					// skip left pixels
 					for (x = 0; x < width && sx < m_scaled_clip_rect.min_x; x += xsrcstep, sx += xdststep)
-						z += (int32_t)m_zbuf_control[0];
+						z += (s32)m_zbuf_control[0];
 
-					/* compute the address */
+					// compute the address
 					dstoffs = compute_safe_address(sx >> 8, sy >> 8) - (sx >> 8);
 					zbufoffs = compute_safe_address(sx >> 8, sy >> 8) - (sx >> 8);
 
-					/* render middle pixels */
+					// render middle pixels
 					if (m_zbuf_control[3] & 0x8000)
 					{
 						for ( ; x < width && sx < m_scaled_clip_rect.max_x; x += xsrcstep, sx += xdststep)
@@ -696,7 +701,7 @@ void drivedge_state::draw_raw(u16 *base, u16 *zbase, u16 color)
 								base[(dstoffs + (sx >> 8)) & m_vram_mask] = pixel | color;
 								zbase[(zbufoffs + (sx >> 8)) & m_vram_mask] = (z >> 8) | zmatch;
 							}
-							z += (int32_t)m_zbuf_control[0];
+							z += (s32)m_zbuf_control[0];
 						}
 					}
 					else if (m_zbuf_control[3] & 0x4000)
@@ -706,7 +711,7 @@ void drivedge_state::draw_raw(u16 *base, u16 *zbase, u16 color)
 							int pixel = rowsrc[x >> 8];
 							if (pixel != transparent_pen && zmatch == (zbase[(zbufoffs + (sx >> 8)) & m_vram_mask] & (0x1f << 11)))
 								base[(dstoffs + (sx >> 8)) & m_vram_mask] = pixel | color;
-							z += (int32_t)m_zbuf_control[0];
+							z += (s32)m_zbuf_control[0];
 						}
 					}
 					else
@@ -719,21 +724,21 @@ void drivedge_state::draw_raw(u16 *base, u16 *zbase, u16 color)
 								base[(dstoffs + (sx >> 8)) & m_vram_mask] = pixel | color;
 								zbase[(zbufoffs + (sx >> 8)) & m_vram_mask] = (z >> 8) | zmatch;
 							}
-							z += (int32_t)m_zbuf_control[0];
+							z += (s32)m_zbuf_control[0];
 						}
 					}
 				}
 				else
 				{
-					/* skip right pixels */
+					// skip right pixels
 					for (x = 0; x < width && sx >= m_scaled_clip_rect.max_x; x += xsrcstep, sx += xdststep)
-						z += (int32_t)m_zbuf_control[0];
+						z += (s32)m_zbuf_control[0];
 
-					/* compute the address */
+					// compute the address
 					dstoffs = compute_safe_address(sx >> 8, sy >> 8) - (sx >> 8);
 					zbufoffs = compute_safe_address(sx >> 8, sy >> 8) - (sx >> 8);
 
-					/* render middle pixels */
+					// render middle pixels
 					if (m_zbuf_control[3] & 0x8000)
 					{
 						for ( ; x < width && sx >= m_scaled_clip_rect.min_x; x += xsrcstep, sx += xdststep)
@@ -744,7 +749,7 @@ void drivedge_state::draw_raw(u16 *base, u16 *zbase, u16 color)
 								base[(dstoffs + (sx >> 8)) & m_vram_mask] = pixel | color;
 								zbase[(zbufoffs + (sx >> 8)) & m_vram_mask] = (z >> 8) | zmatch;
 							}
-							z += (int32_t)m_zbuf_control[0];
+							z += (s32)m_zbuf_control[0];
 						}
 					}
 					else if (m_zbuf_control[3] & 0x4000)
@@ -754,7 +759,7 @@ void drivedge_state::draw_raw(u16 *base, u16 *zbase, u16 color)
 							int pixel = rowsrc[x >> 8];
 							if (pixel != transparent_pen && zmatch == (zbase[(zbufoffs + (sx >> 8)) & m_vram_mask] & (0x1f << 11)))
 								base[(dstoffs + (sx >> 8)) & m_vram_mask] = pixel | color;
-							z += (int32_t)m_zbuf_control[0];
+							z += (s32)m_zbuf_control[0];
 						}
 					}
 					else
@@ -767,21 +772,21 @@ void drivedge_state::draw_raw(u16 *base, u16 *zbase, u16 color)
 								base[(dstoffs + (sx >> 8)) & m_vram_mask] = pixel | color;
 								zbase[(zbufoffs + (sx >> 8)) & m_vram_mask] = (z >> 8) | zmatch;
 							}
-							z += (int32_t)m_zbuf_control[0];
+							z += (s32)m_zbuf_control[0];
 						}
 					}
 				}
 			}
 		}
 
-		/* slow case: VIDEO_YSTEP_PER_X is non-zero */
+		// slow case: VIDEO_YSTEP_PER_X is non-zero
 		else
 		{
 			int ystep = (VIDEO_TRANSFER_FLAGS & XFERFLAG_DYDXSIGN) ? -VIDEO_YSTEP_PER_X : VIDEO_YSTEP_PER_X;
 			int ty = sy;
-			int32_t z = z0;
+			s32 z = z0;
 
-			/* render all pixels */
+			// render all pixels
 			sx = startx;
 			if (m_zbuf_control[3] & 0x8000)
 			{
@@ -794,7 +799,7 @@ void drivedge_state::draw_raw(u16 *base, u16 *zbase, u16 color)
 							base[compute_safe_address(sx >> 8, ty >> 8)] = pixel | color;
 							zbase[compute_safe_address(sx >> 8, ty >> 8)] = (z >> 8) | zmatch;
 						}
-						z += (int32_t)m_zbuf_control[0];
+						z += (s32)m_zbuf_control[0];
 					}
 			}
 			else if (m_zbuf_control[3] & 0x4000)
@@ -809,7 +814,7 @@ void drivedge_state::draw_raw(u16 *base, u16 *zbase, u16 color)
 							base[compute_safe_address(sx >> 8, ty >> 8)] = pixel | color;
 							*zbuf = (z >> 8) | zmatch;
 						}
-						z += (int32_t)m_zbuf_control[0];
+						z += (s32)m_zbuf_control[0];
 					}
 			}
 			else
@@ -824,32 +829,32 @@ void drivedge_state::draw_raw(u16 *base, u16 *zbase, u16 color)
 							base[compute_safe_address(sx >> 8, ty >> 8)] = pixel | color;
 							*zbuf = (z >> 8) | zmatch;
 						}
-						z += (int32_t)m_zbuf_control[0];
+						z += (s32)m_zbuf_control[0];
 					}
 			}
 		}
 
-		/* apply skew */
+		// apply skew
 		if (VIDEO_TRANSFER_FLAGS & XFERFLAG_DXDYSIGN)
 			startx += VIDEO_XSTEP_PER_Y;
 		else
 			startx -= VIDEO_XSTEP_PER_Y;
 
-		/* update the per-scanline parameters */
+		// update the per-scanline parameters
 		if (VIDEO_TRANSFER_FLAGS == 0x5490)
 		{
-			startx += (int32_t)((VIDEO_LEFTSTEPHI << 16) | VIDEO_LEFTSTEPLO);
-			m_scaled_clip_rect.max_x += (int32_t)((VIDEO_RIGHTSTEPHI << 16) | VIDEO_RIGHTSTEPLO);
-			srcdelta += (int16_t)VIDEO_STARTSTEP;
+			startx += (s32)((VIDEO_LEFTSTEPHI << 16) | VIDEO_LEFTSTEPLO);
+			m_scaled_clip_rect.max_x += (s32)((VIDEO_RIGHTSTEPHI << 16) | VIDEO_RIGHTSTEPLO);
+			srcdelta += (s16)VIDEO_STARTSTEP;
 		}
-		z0 += (int32_t)m_zbuf_control[1];
+		z0 += (s32)m_zbuf_control[1];
 	}
 
-	/* restore cliprects */
+	// restore cliprects
 	if (!(VIDEO_TRANSFER_FLAGS & XFERFLAG_CLIP))
 		enable_clipping();
 
-	/* reflect the final values into registers */
+	// reflect the final values into registers
 	VIDEO_TRANSFER_X = (VIDEO_TRANSFER_X & ~0xfff) | (startx >> 8);
 	VIDEO_RIGHTCLIP = (VIDEO_RIGHTCLIP & ~0xfff) | (m_scaled_clip_rect.max_x >> 8);
 	VIDEO_TRANSFER_Y = (VIDEO_TRANSFER_Y & ~0xfff) | ((VIDEO_TRANSFER_Y + (y >> 8)) & 0xfff);
@@ -906,53 +911,52 @@ do {                                                \
 
 inline void itech32_state::draw_rle_fast(u16 *base, u16 color)
 {
-	u8 *src = &m_grom[(m_grom_bank | ((VIDEO_TRANSFER_ADDRHI & 0xff) << 16) | VIDEO_TRANSFER_ADDRLO) % m_grom.length()];
-	int transparent_pen = (VIDEO_TRANSFER_FLAGS & XFERFLAG_TRANSPARENT) ? 0xff : -1;
+	const u8 *src = &m_grom[(m_grom_bank | ((VIDEO_TRANSFER_ADDRHI & 0xff) << 16) | VIDEO_TRANSFER_ADDRLO) % m_grom.length()];
+	const int transparent_pen = (VIDEO_TRANSFER_FLAGS & XFERFLAG_TRANSPARENT) ? 0xff : -1;
 	int width = VIDEO_TRANSFER_WIDTH;
-	int height = ADJUSTED_HEIGHT(VIDEO_TRANSFER_HEIGHT);
+	const int height = ADJUSTED_HEIGHT(VIDEO_TRANSFER_HEIGHT);
 	int sx = VIDEO_TRANSFER_X & 0xfff;
 	int sy = (VIDEO_TRANSFER_Y & 0xfff) << 8;
 	int xleft, y, count = 0, val = 0, innercount;
 	int ydststep = VIDEO_DST_YSTEP;
-	int lclip, rclip;
 
-	/* determine clipping */
-	lclip = m_clip_rect.min_x - sx;
+	// determine clipping
+	int lclip = m_clip_rect.min_x - sx;
 	if (lclip < 0) lclip = 0;
-	rclip = sx + width - m_clip_rect.max_x;
+	int rclip = sx + width - m_clip_rect.max_x;
 	if (rclip < 0) rclip = 0;
 	width -= lclip + rclip;
 	sx += lclip;
 
-	/* adjust for flipping */
+	// adjust for flipping
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_YFLIP)
 		ydststep = -ydststep;
 
-	/* loop over Y in src pixels */
+	// loop over Y in src pixels
 	for (y = 0; y < height; y++, sy += ydststep)
 	{
 		u32 dstoffs;
 
-		/* clip in the Y direction */
+		// clip in the Y direction
 		if (sy < m_scaled_clip_rect.min_y || sy >= m_scaled_clip_rect.max_y)
 		{
 			SKIP_RLE(width + lclip + rclip, xleft, count, innercount, src);
 			continue;
 		}
 
-		/* compute the address */
+		// compute the address
 		dstoffs = compute_safe_address(sx, sy >> 8);
 
-		/* left clip */
+		// left clip
 		SKIP_RLE(lclip, xleft, count, innercount, src);
 
-		/* loop until gone */
+		// loop until gone
 		for (xleft = width; xleft > 0; )
 		{
-			/* load next RLE chunk if needed */
+			// load next RLE chunk if needed
 			GET_NEXT_RUN(xleft, count, innercount, src);
 
-			/* run of literals */
+			// run of literals
 			if (val == -1)
 				while (innercount--)
 				{
@@ -962,7 +966,7 @@ inline void itech32_state::draw_rle_fast(u16 *base, u16 color)
 					dstoffs++;
 				}
 
-			/* run of non-transparent repeats */
+			// run of non-transparent repeats
 			else if (val != transparent_pen)
 			{
 				val |= color;
@@ -970,12 +974,12 @@ inline void itech32_state::draw_rle_fast(u16 *base, u16 color)
 					base[dstoffs++ & m_vram_mask] = val;
 			}
 
-			/* run of transparent repeats */
+			// run of transparent repeats
 			else
 				dstoffs += innercount;
 		}
 
-		/* right clip */
+		// right clip
 		SKIP_RLE(rclip, xleft, count, innercount, src);
 	}
 }
@@ -983,53 +987,52 @@ inline void itech32_state::draw_rle_fast(u16 *base, u16 color)
 
 inline void itech32_state::draw_rle_fast_xflip(u16 *base, u16 color)
 {
-	u8 *src = &m_grom[(m_grom_bank | ((VIDEO_TRANSFER_ADDRHI & 0xff) << 16) | VIDEO_TRANSFER_ADDRLO) % m_grom.length()];
-	int transparent_pen = (VIDEO_TRANSFER_FLAGS & XFERFLAG_TRANSPARENT) ? 0xff : -1;
+	const u8 *src = &m_grom[(m_grom_bank | ((VIDEO_TRANSFER_ADDRHI & 0xff) << 16) | VIDEO_TRANSFER_ADDRLO) % m_grom.length()];
+	const int transparent_pen = (VIDEO_TRANSFER_FLAGS & XFERFLAG_TRANSPARENT) ? 0xff : -1;
 	int width = VIDEO_TRANSFER_WIDTH;
-	int height = ADJUSTED_HEIGHT(VIDEO_TRANSFER_HEIGHT);
+	const int height = ADJUSTED_HEIGHT(VIDEO_TRANSFER_HEIGHT);
 	int sx = VIDEO_TRANSFER_X & 0xfff;
 	int sy = (VIDEO_TRANSFER_Y & 0xfff) << 8;
 	int xleft, y, count = 0, val = 0, innercount;
 	int ydststep = VIDEO_DST_YSTEP;
-	int lclip, rclip;
 
-	/* determine clipping */
-	lclip = sx - m_clip_rect.max_x;
+	// determine clipping
+	int lclip = sx - m_clip_rect.max_x;
 	if (lclip < 0) lclip = 0;
-	rclip = m_clip_rect.min_x - (sx - width);
+	int rclip = m_clip_rect.min_x - (sx - width);
 	if (rclip < 0) rclip = 0;
 	width -= lclip + rclip;
 	sx -= lclip;
 
-	/* adjust for flipping */
+	// adjust for flipping
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_YFLIP)
 		ydststep = -ydststep;
 
-	/* loop over Y in src pixels */
+	// loop over Y in src pixels
 	for (y = 0; y < height; y++, sy += ydststep)
 	{
 		u32 dstoffs;
 
-		/* clip in the Y direction */
+		// clip in the Y direction
 		if (sy < m_scaled_clip_rect.min_y || sy >= m_scaled_clip_rect.max_y)
 		{
 			SKIP_RLE(width + lclip + rclip, xleft, count, innercount, src);
 			continue;
 		}
 
-		/* compute the address */
+		// compute the address
 		dstoffs = compute_safe_address(sx, sy >> 8);
 
-		/* left clip */
+		// left clip
 		SKIP_RLE(lclip, xleft, count, innercount, src);
 
-		/* loop until gone */
+		// loop until gone
 		for (xleft = width; xleft > 0; )
 		{
-			/* load next RLE chunk if needed */
+			// load next RLE chunk if needed
 			GET_NEXT_RUN(xleft, count, innercount, src);
 
-			/* run of literals */
+			// run of literals
 			if (val == -1)
 				while (innercount--)
 				{
@@ -1039,7 +1042,7 @@ inline void itech32_state::draw_rle_fast_xflip(u16 *base, u16 color)
 					dstoffs--;
 				}
 
-			/* run of non-transparent repeats */
+			// run of non-transparent repeats
 			else if (val != transparent_pen)
 			{
 				val |= color;
@@ -1047,12 +1050,12 @@ inline void itech32_state::draw_rle_fast_xflip(u16 *base, u16 color)
 					base[dstoffs-- & m_vram_mask] = val;
 			}
 
-			/* run of transparent repeats */
+			// run of transparent repeats
 			else
 				dstoffs -= innercount;
 		}
 
-		/* right clip */
+		// right clip
 		SKIP_RLE(rclip, xleft, count, innercount, src);
 	}
 }
@@ -1067,49 +1070,49 @@ inline void itech32_state::draw_rle_fast_xflip(u16 *base, u16 color)
 
 inline void itech32_state::draw_rle_slow(u16 *base, u16 color)
 {
-	u8 *src = &m_grom[(m_grom_bank | ((VIDEO_TRANSFER_ADDRHI & 0xff) << 16) | VIDEO_TRANSFER_ADDRLO) % m_grom.length()];
-	int transparent_pen = (VIDEO_TRANSFER_FLAGS & XFERFLAG_TRANSPARENT) ? 0xff : -1;
-	int width = VIDEO_TRANSFER_WIDTH;
-	int height = ADJUSTED_HEIGHT(VIDEO_TRANSFER_HEIGHT);
+	const u8 *src = &m_grom[(m_grom_bank | ((VIDEO_TRANSFER_ADDRHI & 0xff) << 16) | VIDEO_TRANSFER_ADDRLO) % m_grom.length()];
+	const int transparent_pen = (VIDEO_TRANSFER_FLAGS & XFERFLAG_TRANSPARENT) ? 0xff : -1;
+	const int width = VIDEO_TRANSFER_WIDTH;
+	const int height = ADJUSTED_HEIGHT(VIDEO_TRANSFER_HEIGHT);
 	int sx, sy = (VIDEO_TRANSFER_Y & 0xfff) << 8;
 	int xleft, y, count = 0, val = 0, innercount;
 	int xdststep = 0x100;
 	int ydststep = VIDEO_DST_YSTEP;
 	int startx = (VIDEO_TRANSFER_X & 0xfff) << 8;
 
-	/* adjust for scaling */
+	// adjust for scaling
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_DSTXSCALE)
 		xdststep = VIDEO_DST_XSTEP;
 
-	/* adjust for flipping */
+	// adjust for flipping
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_XFLIP)
 		xdststep = -xdststep;
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_YFLIP)
 		ydststep = -ydststep;
 
-	/* loop over Y in src pixels */
+	// loop over Y in src pixels
 	for (y = 0; y < height; y++, sy += ydststep)
 	{
 		u32 dstoffs;
 
-		/* clip in the Y direction */
+		// clip in the Y direction
 		if (sy < m_scaled_clip_rect.min_y || sy >= m_scaled_clip_rect.max_y)
 		{
 			SKIP_RLE(width, xleft, count, innercount, src);
 			continue;
 		}
 
-		/* compute the address */
+		// compute the address
 		sx = startx;
 		dstoffs = compute_safe_address(m_clip_rect.min_x, sy >> 8) - m_clip_rect.min_x;
 
-		/* loop until gone */
+		// loop until gone
 		for (xleft = width; xleft > 0; )
 		{
-			/* load next RLE chunk if needed */
+			// load next RLE chunk if needed
 			GET_NEXT_RUN(xleft, count, innercount, src);
 
-			/* run of literals */
+			// run of literals
 			if (val == -1)
 				for ( ; innercount--; sx += xdststep)
 				{
@@ -1119,7 +1122,7 @@ inline void itech32_state::draw_rle_slow(u16 *base, u16 color)
 							base[(dstoffs + (sx >> 8)) & m_vram_mask] = color | pixel;
 				}
 
-			/* run of non-transparent repeats */
+			// run of non-transparent repeats
 			else if (val != transparent_pen)
 			{
 				val |= color;
@@ -1128,12 +1131,12 @@ inline void itech32_state::draw_rle_slow(u16 *base, u16 color)
 						base[(dstoffs + (sx >> 8)) & m_vram_mask] = val;
 			}
 
-			/* run of transparent repeats */
+			// run of transparent repeats
 			else
 				sx += xdststep * innercount;
 		}
 
-		/* apply skew */
+		// apply skew
 		if (VIDEO_TRANSFER_FLAGS & XFERFLAG_DXDYSIGN)
 			startx += VIDEO_XSTEP_PER_Y;
 		else
@@ -1145,21 +1148,21 @@ inline void itech32_state::draw_rle_slow(u16 *base, u16 color)
 
 void itech32_state::draw_rle(u16 *base, u16 color)
 {
-	/* adjust for (lack of) clipping */
+	// adjust for (lack of) clipping
 	if (!(VIDEO_TRANSFER_FLAGS & XFERFLAG_CLIP))
 		disable_clipping();
 
-	/* if we have an X scale, draw it slow */
+	// if we have an X scale, draw it slow
 	if (((VIDEO_TRANSFER_FLAGS & XFERFLAG_DSTXSCALE) && VIDEO_DST_XSTEP != 0x100) || VIDEO_XSTEP_PER_Y)
 		draw_rle_slow(base, color);
 
-	/* else draw it fast */
+	// else draw it fast
 	else if (VIDEO_TRANSFER_FLAGS & XFERFLAG_XFLIP)
 		draw_rle_fast_xflip(base, color);
 	else
 		draw_rle_fast(base, color);
 
-	/* restore cliprects */
+	// restore cliprects
 	if (!(VIDEO_TRANSFER_FLAGS & XFERFLAG_CLIP))
 		enable_clipping();
 }
@@ -1179,11 +1182,11 @@ void itech32_state::shiftreg_clear(u16 *base, u16 *zbase)
 	const int sx = VIDEO_TRANSFER_X & 0xfff;
 	int sy = VIDEO_TRANSFER_Y & 0xfff;
 
-	/* first line is the source */
-	u16 *src = &base[compute_safe_address(sx, sy)];
+	// first line is the source
+	const u16 *src = &base[compute_safe_address(sx, sy)];
 	sy += ydir;
 
-	/* loop over height */
+	// loop over height
 	for (int y = 1; y < height; y++)
 	{
 		memcpy(&base[compute_safe_address(sx, sy)], src, 512*2);
@@ -1198,20 +1201,19 @@ void drivedge_state::shiftreg_clear(u16 *base, u16 *zbase)
 	int sx = VIDEO_TRANSFER_X & 0xfff;
 	int sy = VIDEO_TRANSFER_Y & 0xfff;
 
-	/* first line is the source */
-	u16 *src = &base[compute_safe_address(sx, sy)];
+	// first line is the source
+	const u16 *src = &base[compute_safe_address(sx, sy)];
 	sy += ydir;
 
-	/* loop over height */
+	// loop over height
 	for (int y = 1; y < height; y++)
 	{
 		memcpy(&base[compute_safe_address(sx, sy)], src, 512*2);
 		if (zbase)
 		{
-			u16 zval = ((m_zbuf_control[2] >> 8) & 0x7ff) | ((m_zbuf_control[2] & 0x1f) << 11);
+			const u16 zval = ((m_zbuf_control[2] >> 8) & 0x7ff) | ((m_zbuf_control[2] & 0x1f) << 11);
 			u16 *dst = &zbase[compute_safe_address(sx, sy)];
-			int x;
-			for (x = 0; x < 512; x++)
+			for (int x = 0; x < 512; x++)
 				*dst++ = zval;
 		}
 		sy += ydir;
@@ -1228,61 +1230,61 @@ void drivedge_state::shiftreg_clear(u16 *base, u16 *zbase)
 
 void itech32_state::handle_video_command()
 {
-	/* only 6 known commands */
+	// only 6 known commands
 	switch (VIDEO_COMMAND)
 	{
-		/* command 1: blit raw data */
+		// command 1: blit raw data
 		case 1:
 			command_blit_raw();
 			break;
 
-		/* command 2: blit RLE-compressed data */
+		// command 2: blit RLE-compressed data
 		case 2:
 			{
 				auto profile = g_profiler.start(PROFILER_USER2);
-				if (BLIT_LOGGING) logblit("Blit RLE");
+				if (VERBOSE & LOG_BLITTER) logblit("Blit RLE");
 
 				if (m_enable_latch[0]) draw_rle(m_videoplane[0], m_color_latch[0]);
 				if (m_enable_latch[1]) draw_rle(m_videoplane[1], m_color_latch[1]);
 			}
 			break;
 
-		/* command 3: set up raw data transfer */
+		// command 3: set up raw data transfer
 		case 3:
-			if (BLIT_LOGGING) logblit("Raw Xfer");
+			if (VERBOSE & LOG_BLITTER) logblit("Raw Xfer");
 			m_xfer_xcount = VIDEO_TRANSFER_WIDTH;
 			m_xfer_ycount = ADJUSTED_HEIGHT(VIDEO_TRANSFER_HEIGHT);
 			m_xfer_xcur = VIDEO_TRANSFER_X & 0xfff;
 			m_xfer_ycur = VIDEO_TRANSFER_Y & 0xfff;
 			break;
 
-		/* command 4: flush? */
+		// command 4: flush?
 		case 4:
 			break;
 
-		/* command 5: reset? */
+		// command 5: reset?
 		case 5:
 			break;
 
-		/* command 6: perform shift register copy */
+		// command 6: perform shift register copy
 		case 6:
 			command_shift_reg();
 			break;
 
 		default:
-			if (BLIT_LOGGING) logerror("Unknown blit command %d\n", VIDEO_COMMAND);
+			LOGBLITTER("Unknown blit command %d\n", VIDEO_COMMAND);
 			break;
 	}
 
-	/* tell the processor we're done */
+	// tell the processor we're done
 	VIDEO_INTSTATE |= VIDEOINT_BLITTER;
-	update_interrupts(1);
+	update_interrupts();
 }
 
 void itech32_state::command_blit_raw()
 {
 	auto profile = g_profiler.start(PROFILER_USER1);
-	if (BLIT_LOGGING) logblit("Blit Raw");
+	if (VERBOSE & LOG_BLITTER) logblit("Blit Raw");
 
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_WIDTHPIX)
 	{
@@ -1299,7 +1301,7 @@ void itech32_state::command_blit_raw()
 void drivedge_state::command_blit_raw()
 {
 	auto profile = g_profiler.start(PROFILER_USER1);
-	if (BLIT_LOGGING) logblit("Blit Raw");
+	if (VERBOSE & LOG_BLITTER) logblit("Blit Raw");
 
 	if (m_enable_latch[0]) draw_raw(m_videoplane[0], m_videoplane[1], m_color_latch[0]);
 }
@@ -1307,7 +1309,7 @@ void drivedge_state::command_blit_raw()
 void itech32_state::command_shift_reg()
 {
 	auto profile = g_profiler.start(PROFILER_USER3);
-	if (BLIT_LOGGING) logblit("ShiftReg");
+	if (VERBOSE & LOG_BLITTER) logblit("ShiftReg");
 
 	if (m_enable_latch[0]) shiftreg_clear(m_videoplane[0], nullptr);
 	if (m_enable_latch[1]) shiftreg_clear(m_videoplane[1], nullptr);
@@ -1316,7 +1318,7 @@ void itech32_state::command_shift_reg()
 void drivedge_state::command_shift_reg()
 {
 	auto profile = g_profiler.start(PROFILER_USER3);
-	if (BLIT_LOGGING) logblit("ShiftReg");
+	if (VERBOSE & LOG_BLITTER) logblit("ShiftReg");
 
 	if (m_enable_latch[0]) shiftreg_clear(m_videoplane[0], m_videoplane[1]);
 }
@@ -1337,12 +1339,12 @@ void itech32_state::video_w(offs_t offset, u16 data, u16 mem_mask)
 
 	switch (offset)
 	{
-		case 0x02/2:    /* VIDEO_INTACK */
+		case 0x02/2:    // VIDEO_INTACK
 			VIDEO_INTSTATE = old & ~data;
-			update_interrupts(1);
+			update_interrupts();
 			break;
 
-		case 0x04/2:    /* VIDEO_TRANSFER */
+		case 0x04/2:    // VIDEO_TRANSFER
 			if (VIDEO_COMMAND == 3 && m_xfer_ycount)
 			{
 				offs_t addr = compute_safe_address(m_xfer_xcur, m_xfer_ycur);
@@ -1363,45 +1365,45 @@ void itech32_state::video_w(offs_t offset, u16 data, u16 mem_mask)
 			}
 			break;
 
-		case 0x08/2:    /* VIDEO_COMMAND */
+		case 0x08/2:    // VIDEO_COMMAND
 			handle_video_command();
 			break;
 
-		case 0x0a/2:    /* VIDEO_INTENABLE */
-			update_interrupts(1);
+		case 0x0a/2:    // VIDEO_INTENABLE
+			update_interrupts();
 			break;
 
-		case 0x24/2:    /* VIDEO_LEFTCLIP */
+		case 0x24/2:    // VIDEO_LEFTCLIP
 			m_clip_rect.min_x = VIDEO_LEFTCLIP;
 			m_scaled_clip_rect.min_x = VIDEO_LEFTCLIP << 8;
 			break;
 
-		case 0x26/2:    /* VIDEO_RIGHTCLIP */
+		case 0x26/2:    // VIDEO_RIGHTCLIP
 			m_clip_rect.max_x = VIDEO_RIGHTCLIP;
 			m_scaled_clip_rect.max_x = VIDEO_RIGHTCLIP << 8;
 			break;
 
-		case 0x28/2:    /* VIDEO_TOPCLIP */
+		case 0x28/2:    // VIDEO_TOPCLIP
 			m_clip_rect.min_y = VIDEO_TOPCLIP;
 			m_scaled_clip_rect.min_y = VIDEO_TOPCLIP << 8;
 			break;
 
-		case 0x2a/2:    /* VIDEO_BOTTOMCLIP */
+		case 0x2a/2:    // VIDEO_BOTTOMCLIP
 			m_clip_rect.max_y = VIDEO_BOTTOMCLIP;
 			m_scaled_clip_rect.max_y = VIDEO_BOTTOMCLIP << 8;
 			break;
 
-		case 0x2c/2:    /* VIDEO_INTSCANLINE */
+		case 0x2c/2:    // VIDEO_INTSCANLINE
 			m_scanline_timer->adjust(m_screen->time_until_pos(VIDEO_INTSCANLINE));
 			break;
 
-		case 0x32/2:    /* VIDEO_VTOTAL */
-		case 0x36/2:    /* VIDEO_VBLANK_START */
-		case 0x38/2:    /* VIDEO_VBLANK_END */
-		case 0x3a/2:    /* VIDEO_HTOTAL */
-		case 0x3e/2:    /* VIDEO_HBLANK_START */
-		case 0x40/2:    /* VIDEO_HBLANK_END */
-			/* do some sanity checks first */
+		case 0x32/2:    // VIDEO_VTOTAL
+		case 0x36/2:    // VIDEO_VBLANK_START
+		case 0x38/2:    // VIDEO_VBLANK_END
+		case 0x3a/2:    // VIDEO_HTOTAL
+		case 0x3e/2:    // VIDEO_HBLANK_START
+		case 0x40/2:    // VIDEO_HBLANK_END
+			// do some sanity checks first
 			if ((VIDEO_HTOTAL > 0) && (VIDEO_VTOTAL > 0) &&
 				(VIDEO_VBLANK_START != VIDEO_VBLANK_END) &&
 				(VIDEO_HBLANK_START != VIDEO_HBLANK_END) &&
@@ -1422,7 +1424,7 @@ void itech32_state::video_w(offs_t offset, u16 data, u16 mem_mask)
 				else
 					visarea.max_y = VIDEO_VTOTAL - VIDEO_VBLANK_END + VIDEO_VBLANK_START - 1;
 
-				logerror("Configure Screen: HTOTAL: %x  HBSTART: %x  HBEND: %x  VTOTAL: %x  VBSTART: %x  VBEND: %x\n",
+				LOGSCREEN("Configure Screen: HTOTAL: %x  HBSTART: %x  HBEND: %x  VTOTAL: %x  VBSTART: %x  VBEND: %x\n",
 					VIDEO_HTOTAL, VIDEO_HBLANK_START, VIDEO_HBLANK_END, VIDEO_VTOTAL, VIDEO_VBLANK_START, VIDEO_VBLANK_END);
 				m_screen->configure(VIDEO_HTOTAL, VIDEO_VTOTAL, visarea, HZ_TO_ATTOSECONDS(VIDEO_CLOCK) * VIDEO_HTOTAL * VIDEO_VTOTAL);
 			}
@@ -1439,7 +1441,7 @@ u16 itech32_state::video_r(offs_t offset)
 	}
 	else if (offset == 3)
 	{
-		return 0xef;/*m_screen->vpos() - 1;*/
+		return 0xef; // m_screen->vpos() - 1;
 	}
 
 	return m_video[offset];
@@ -1479,22 +1481,19 @@ void drivedge_state::zbuf_control_w(offs_t offset, u32 data, u32 mem_mask)
 
 u32 itech32_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	int y;
-
-	/* loop over height */
-	for (y = cliprect.min_y; y <= cliprect.max_y; y++)
+	// loop over height
+	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{
-		u16 *src1 = &m_videoplane[0][compute_safe_address(VIDEO_DISPLAY_XORIGIN1, VIDEO_DISPLAY_YORIGIN1 + y)];
+		const u16 *src1 = &m_videoplane[0][compute_safe_address(VIDEO_DISPLAY_XORIGIN1, VIDEO_DISPLAY_YORIGIN1 + y)];
 
-		/* handle multi-plane case */
+		// handle multi-plane case
 		if (m_planes > 1)
 		{
-			u16 *src2 = &m_videoplane[1][compute_safe_address(VIDEO_DISPLAY_XORIGIN2 + VIDEO_DISPLAY_XSCROLL2, VIDEO_DISPLAY_YORIGIN2 + VIDEO_DISPLAY_YSCROLL2 + y)];
+			const u16 *src2 = &m_videoplane[1][compute_safe_address(VIDEO_DISPLAY_XORIGIN2 + VIDEO_DISPLAY_XSCROLL2, VIDEO_DISPLAY_YORIGIN2 + VIDEO_DISPLAY_YSCROLL2 + y)];
 			u16 scanline[384];
-			int x;
 
-			/* blend the pixels in the scanline; color xxFF is transparent */
-			for (x = cliprect.min_x; x <= cliprect.max_x; x++)
+			// blend the pixels in the scanline; color xxFF is transparent
+			for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
 			{
 				u16 pixel = src1[x];
 				if ((pixel & 0xff) == 0xff)
@@ -1502,11 +1501,11 @@ u32 itech32_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, co
 				scanline[x] = pixel;
 			}
 
-			/* draw from the buffer */
+			// draw from the buffer
 			draw_scanline16(bitmap, cliprect.min_x, y, cliprect.width(), &scanline[cliprect.min_x], nullptr);
 		}
 
-		/* otherwise, draw directly from VRAM */
+		// otherwise, draw directly from VRAM
 		else
 			draw_scanline16(bitmap, cliprect.min_x, y, cliprect.width(), &src1[cliprect.min_x], nullptr);
 	}


### PR DESCRIPTION
Recuce runtime tag macros
Fix metadatas (ex: shufshot and clones are hasn't strata related stuff (logo, etc)) Use machine().side_effects_disabled() for debug stuffs Use correct, constant typename values
Fix naming for ROM regions
Use logmacro for logging features
Use C++ style comments for single line comments
Reduce defines
Use array for reduce duplicates
Move drivedge specific stuffs into drivedge_state