### PR TITLE
konami/konamigv: Add printer support for Tokimeki Memorial Oshiete Your Heart

### DIFF
--- a/src/mame/konami/konamigv.cpp
+++ b/src/mame/konami/konamigv.cpp
@@ -386,7 +386,7 @@ private:
 	uint32_t m_printer_current_image;
 	bool m_printer_is_manual_layout;
 	bool m_printer_page_is_dirty;
-	int m_printer_video_last_vblank_state;
+	uint8_t m_printer_video_last_vblank_state;
 
 	bitmap_rgb32 m_page_bitmap;
 

--- a/src/mame/konami/konamigv.cpp
+++ b/src/mame/konami/konamigv.cpp
@@ -531,7 +531,8 @@ void tokimeki_state::machine_start()
 	m_heartbeat_timer->adjust(attotime::zero);
 
 	m_printer_printing_status_timeout = timer_alloc(FUNC(tokimeki_state::printing_status_timeout), this);
-	m_printer_printing_status_timeout->adjust(attotime::never);
+
+	m_page_bitmap.allocate(PRINTER_PAGE_WIDTH, PRINTER_PAGE_HEIGHT);
 }
 
 void tokimeki_state::machine_reset()
@@ -553,7 +554,6 @@ void tokimeki_state::machine_reset()
 
 	std::fill(std::begin(m_printer_data), std::end(m_printer_data), 0);
 
-	m_page_bitmap.allocate(PRINTER_PAGE_WIDTH, PRINTER_PAGE_HEIGHT);
 	m_page_bitmap.fill(0xffffffff);
 }
 


### PR DESCRIPTION
HLE implementation of the printer Sony UP-1200 analog video printer used by Tokimeki Memorial Oshiete Your Heart. The printer receives an S-Video signal from the subboard PCB and separately a communication line to control the machine. `tmosh` and `tmoshs` only take and print one picture, but `tmoshsp` takes 16 different pictures and uses the 16 image layout setting of the printer.

The printer output is shown as a second screen as can be seen in the example pictures below.

tmosh (1 large image):
![0022](https://github.com/mamedev/mame/assets/63495610/e8c58608-337b-43ef-8587-b3ab019d3b4b)

tmoshs (Konami logo position changes, text and icon in the very center of the picture):
![0007](https://github.com/mamedev/mame/assets/63495610/bb6d8b1b-cce1-40d0-93e4-92e482fd7a59)

tmoshsp (Konami logo and Tokimeki Memorial logo are always in the same spot):
![0059](https://github.com/mamedev/mame/assets/63495610/3320699b-88ce-443f-9ad4-972432b400ea)

Here's a picture of multiple prints from both the `tmosh` version and the `tmoshsp` version for layout reference.
![image](https://github.com/mamedev/mame/assets/63495610/45bb4d36-b5a8-48d4-a1db-7022bb88f6c4)


This PR also promotes the games to working, except for the `tmoshspa` clone which has a note about the CD being damaged.
```
Tokimeki Memorial Oshiete Your Heart (GQ673 JAA)
Tokimeki Memorial Oshiete Your Heart Seal Version (GE755 JAA)
Tokimeki Memorial Oshiete Your Heart Seal Version Plus (GE756 JAB)
```