### PR TITLE
msx/msx.cpp: Small MSX2+ related updates

### DIFF
--- a/src/devices/bus/msx/slot/music.cpp
+++ b/src/devices/bus/msx/slot/music.cpp
@@ -9,6 +9,7 @@ DEFINE_DEVICE_TYPE(MSX_SLOT_MUSIC, msx_slot_music_device, "msx_slot_music", "MSX
 
 msx_slot_music_device::msx_slot_music_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: msx_slot_rom_device(mconfig, MSX_SLOT_MUSIC, tag, owner, clock)
+	, m_ym2413_base(nullptr)
 	, m_ym2413(nullptr)
 	, m_ym2413_tag(nullptr)
 {
@@ -23,7 +24,7 @@ void msx_slot_music_device::device_start()
 		fatalerror("msx_slot_music_device: no YM2413 tag specified\n");
 	}
 
-	m_ym2413 = owner()->subdevice<ym2413_device>(m_ym2413_tag);
+	m_ym2413 = m_ym2413_base->subdevice<ym2413_device>(m_ym2413_tag);
 
 	if (m_ym2413 == nullptr)
 	{

--- a/src/devices/bus/msx/slot/music.cpp
+++ b/src/devices/bus/msx/slot/music.cpp
@@ -9,7 +9,7 @@ DEFINE_DEVICE_TYPE(MSX_SLOT_MUSIC, msx_slot_music_device, "msx_slot_music", "MSX
 
 msx_slot_music_device::msx_slot_music_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: msx_slot_rom_device(mconfig, MSX_SLOT_MUSIC, tag, owner, clock)
-	, m_ym2413(*this, "^ym2413")
+	, m_ym2413(*this, finder_base::DUMMY_TAG)
 {
 }
 

--- a/src/devices/bus/msx/slot/music.cpp
+++ b/src/devices/bus/msx/slot/music.cpp
@@ -9,27 +9,13 @@ DEFINE_DEVICE_TYPE(MSX_SLOT_MUSIC, msx_slot_music_device, "msx_slot_music", "MSX
 
 msx_slot_music_device::msx_slot_music_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: msx_slot_rom_device(mconfig, MSX_SLOT_MUSIC, tag, owner, clock)
-	, m_ym2413_base(nullptr)
-	, m_ym2413(nullptr)
-	, m_ym2413_tag(nullptr)
+	, m_ym2413(*this, "^ym2413")
 {
 }
 
 void msx_slot_music_device::device_start()
 {
 	msx_slot_rom_device::device_start();
-
-	if (m_ym2413_tag == nullptr)
-	{
-		fatalerror("msx_slot_music_device: no YM2413 tag specified\n");
-	}
-
-	m_ym2413 = m_ym2413_base->subdevice<ym2413_device>(m_ym2413_tag);
-
-	if (m_ym2413 == nullptr)
-	{
-		fatalerror("msx_slot_ym2413_device: Unable to find YM2413 with tag '%s'\n", m_ym2413_tag);
-	}
 
 	// Install IO read/write handlers
 	io_space().install_write_handler(0x7c, 0x7d, emu::rw_delegate(*m_ym2413, FUNC(ym2413_device::write)));

--- a/src/devices/bus/msx/slot/music.h
+++ b/src/devices/bus/msx/slot/music.h
@@ -19,12 +19,17 @@ public:
 	msx_slot_music_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	// configuration helpers
-	void set_ym2413_tag(const char *tag) { m_ym2413_tag = tag; }
+	template <class ObjectClass, bool Required>
+	void set_ym2413(const device_finder<ObjectClass, Required> &finder) {
+		m_ym2413_base = &finder.finder_target().first;
+		m_ym2413_tag = finder.finder_target().second;
+	}
 
 protected:
 	virtual void device_start() override;
 
 private:
+	device_t *m_ym2413_base;
 	ym2413_device *m_ym2413;
 	const char *m_ym2413_tag;
 };

--- a/src/devices/bus/msx/slot/music.h
+++ b/src/devices/bus/msx/slot/music.h
@@ -7,7 +7,10 @@
 
 #include "rom.h"
 #include "slot.h"
+
 #include "sound/ymopl.h"
+
+#include <utility>
 
 
 DECLARE_DEVICE_TYPE(MSX_SLOT_MUSIC, msx_slot_music_device)
@@ -17,6 +20,9 @@ class msx_slot_music_device : public msx_slot_rom_device
 {
 public:
 	msx_slot_music_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	// configuration
+	template <typename T> void set_ym2413_tag(T &&tag) { m_ym2413.set_tag(std::forward<T>(tag)); }
 
 protected:
 	virtual void device_start() override;

--- a/src/devices/bus/msx/slot/music.h
+++ b/src/devices/bus/msx/slot/music.h
@@ -18,20 +18,11 @@ class msx_slot_music_device : public msx_slot_rom_device
 public:
 	msx_slot_music_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	// configuration helpers
-	template <class ObjectClass, bool Required>
-	void set_ym2413(const device_finder<ObjectClass, Required> &finder) {
-		m_ym2413_base = &finder.finder_target().first;
-		m_ym2413_tag = finder.finder_target().second;
-	}
-
 protected:
 	virtual void device_start() override;
 
 private:
-	device_t *m_ym2413_base;
-	ym2413_device *m_ym2413;
-	const char *m_ym2413_tag;
+	required_device<ym2413_device> m_ym2413;
 };
 
 

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -32490,10 +32490,6 @@ cpg120                          //
 cx7128                          // 1986 MSX2
 cx7m128                         // 1986 MSX2
 expert20                        // 1986 MSX2 Korea
-expert3i                        //
-expert3t                        //
-expertac                        //
-expertdx                        //
 fpc900                          //
 fs4500                          // 1986 MSX2 Japan
 fs4600f                         // 1986 MSX2 Japan
@@ -32505,19 +32501,11 @@ fsa1                            // 1986 MSX2 Japan
 fsa1a                           // 1986 MSX2 Japan
 fsa1f                           // 1987 MSX2 Japan
 fsa1fm                          // 1988 MSX2 Japan
-fsa1fx                          // 1988 MSX2+ Japan
-fsa1gt                          //
 fsa1mk2                         // 1987 MSX2 Japan
-fsa1st                          //
-fsa1wsx                         // 1989 MSX2+ Japan
-fsa1wx                          // 1988 MSX2+ Japan
-fsa1wxa                         // 1988 MSX2+ Japan
 fstm1                           //
 hbf1                            // 1986 MSX2 Japan
 hbf1ii                          // 1987 MSX2 Japan
 hbf1xd                          // 1987 MSX2 Japan
-hbf1xdj                         // 1988 MSX2+ Japan
-hbf1xv                          // 1989 MSX2+ Japan
 hbf5                            //
 hbf500                          // 1986 MSX2 Japan
 hbf500_2                        //
@@ -32566,10 +32554,7 @@ nms8280f                        //
 nms8280g                        // 1986 MSX2
 phc23                           // 1986 MSX2 Japan
 phc23jb                         // 1987 MSX2 Japan
-phc35j                          // 1989 MSX2+ Japan
 phc55fd2                        //
-phc70fd                         // 1988 MSX2+ Japan
-phc70fd2                        // 1988 MSX2+ Japan
 phc77                           //
 tpc310                          // 1986 MSX2
 tpp311                          //
@@ -32591,6 +32576,23 @@ y805128r2                       //
 y805128r2e                      //
 y805256                         //
 yis604                          //
+
+@source:msx/msx2p.cpp
+expert3i                        //
+expert3t                        //
+expertac                        //
+expertdx                        //
+fsa1fx                          // 1988 MSX2+ Japan
+fsa1gt                          //
+fsa1st                          //
+fsa1wsx                         // 1989 MSX2+ Japan
+fsa1wx                          // 1988 MSX2+ Japan
+fsa1wxa                         // 1988 MSX2+ Japan
+hbf1xdj                         // 1988 MSX2+ Japan
+hbf1xv                          // 1989 MSX2+ Japan
+phc35j                          // 1989 MSX2+ Japan
+phc70fd                         // 1988 MSX2+ Japan
+phc70fd2                        // 1988 MSX2+ Japan
 
 @source:msx/pengadvb.cpp
 pengadvb                        // (c) 1988 Screen

--- a/src/mame/msx/msx.h
+++ b/src/mame/msx/msx.h
@@ -249,7 +249,7 @@ protected:
 	const int m_cpu_xtal_divider;
 
 	virtual void setup_slot_spaces(msx_internal_slot_interface &device);
-	virtual address_space& get_io_space();
+	virtual address_space &get_io_space();
 
 private:
 	// configuration helpers

--- a/src/mame/msx/msx.h
+++ b/src/mame/msx/msx.h
@@ -163,6 +163,8 @@ protected:
 	u8 expanded_slot_r();
 	u8 kanji_r(offs_t offset);
 	void kanji_w(offs_t offset, u8 data);
+	u8 kanji2_r(offs_t offset);
+	void kanji2_w(offs_t offset, u8 data);
 	void ppi_port_a_w(u8 data);
 	void ppi_port_c_w(u8 data);
 	u8 ppi_port_b_r();
@@ -246,15 +248,15 @@ protected:
 	const XTAL m_main_xtal;
 	const int m_cpu_xtal_divider;
 
+	virtual void setup_slot_spaces(msx_internal_slot_interface &device);
+
 private:
 	// configuration helpers
 	template <typename T, typename U>
 	auto &add_base_slot(machine_config &config, T &&type, U &&tag, u8 prim, bool expanded, u8 sec, u8 page, u8 numpages, u32 clock = 0)
 	{
 		auto &device(std::forward<T>(type)(config, std::forward<U>(tag), clock));
-		device.set_memory_space(m_maincpu, AS_PROGRAM);
-		device.set_io_space(m_maincpu, AS_IO);
-		device.set_maincpu(m_maincpu);
+		setup_slot_spaces(device);
 		m_internal_slots.push_back({prim, expanded, sec, page, numpages, &device});
 		return device;
 	}
@@ -328,27 +330,15 @@ private:
 class msx2_base_state : public msx_state
 {
 protected:
-	msx2_base_state(const machine_config &mconfig, device_type type, const char *tag, XTAL main_xtal, int cpu_xtal_divider)
-		: msx_state(mconfig, type, tag, main_xtal, cpu_xtal_divider)
-		, m_v9938(*this, "v9938")
-		, m_v9958(*this, "v9958")
-		, m_rtc(*this, "rtc")
-		, m_rtc_latch(0)
-	{
-	}
+	msx2_base_state(const machine_config &mconfig, device_type type, const char *tag, XTAL main_xtal, int cpu_xtal_divider);
 
 	virtual void machine_start() override;
 
 	void msx2_base(ay8910_type ay8910_type, machine_config &config, const internal_layout &layout);
 	void msx2(ay8910_type ay8910_type, machine_config &config, const internal_layout &layout);
 	void msx2_pal(ay8910_type ay8910_type, machine_config &config, const internal_layout &layout);
-	void msx2plus_base(ay8910_type ay8910_type, machine_config &config, const internal_layout &layout);
-	void msx2plus(ay8910_type ay8910_type, machine_config &config, const internal_layout &layout);
-	void msx2plus_pal(ay8910_type ay8910_type, machine_config &config, const internal_layout &layout);
-	void turbor(ay8910_type ay8910_type, machine_config &config, const internal_layout &layout);
+	void msx2_v9958_base(ay8910_type ay8910_type, machine_config &config, const internal_layout &layout);
 	void msx2_add_softlists(machine_config &config);
-	void msx2plus_add_softlists(machine_config &config);
-	void turbor_add_softlists(machine_config &config);
 	void msx_ym2413(machine_config &config);
 	void msx2_64kb_vram(machine_config &config);
 	u8 rtc_reg_r();
@@ -356,19 +346,42 @@ protected:
 	void rtc_latch_w(u8 data);
 	u8 switched_r(offs_t offset);
 	void switched_w(offs_t offset, u8 data);
-	void turbo_w(int state);
 	void msx2_base_io_map(address_map &map);
 	void msx2_io_map(address_map &map);
-	void msx2plus_io_map(address_map &map);
+	void msx2_v9958_io_map(address_map &map);
 
 	std::vector<msx_switched_interface *> m_switched;
 
 	optional_device<v9938_device> m_v9938;
 	optional_device<v9958_device> m_v9958;
+	optional_device<ym2413_device> m_ym2413;
 	required_device<rp5c01_device> m_rtc;
 
 	// rtc
 	u8 m_rtc_latch = 0;
+};
+
+
+class msx2p_base_state : public msx2_base_state
+{
+protected:
+	msx2p_base_state(const machine_config &mconfig, device_type type, const char *tag, XTAL main_xtal, int cpu_xtal_divider);
+
+	void set_cold_boot_flags(u8 cold_boot_flags) { m_cold_boot_flags = cold_boot_flags; }
+
+	virtual void machine_start() override;
+
+	void msx2plus_base(ay8910_type ay8910_type, machine_config &config, const internal_layout &layout);
+	void msx2plus_pal_base(ay8910_type ay8910_type, machine_config &config, const internal_layout &layout);
+	void msx2plus(ay8910_type ay8910_type, machine_config &config, const internal_layout &layout);
+	void msx2plus_pal(ay8910_type ay8910_type, machine_config &config, const internal_layout &layout);
+	void msx2plus_io_map(address_map &map);
+	void msx2plus_add_softlists(machine_config &config);
+	void turbor_add_softlists(machine_config &config);
+	void turbor(ay8910_type ay8910_type, machine_config &config, const internal_layout &layout);
+
+	u8 m_cold_boot_flags;
+	u8 m_boot_flags;
 };
 
 #endif // MAME_MSX_MSX_H

--- a/src/mame/msx/msx.h
+++ b/src/mame/msx/msx.h
@@ -192,7 +192,7 @@ protected:
 	required_device<speaker_device> m_speaker;
 	required_device<input_merger_any_high_device> m_mainirq;
 	required_device<screen_device> m_screen;
-	optional_memory_region m_region_kanji;
+	optional_region_ptr<u8> m_region_kanji;
 	required_device<msx_general_purpose_port_device> m_gen_port1;
 	required_device<msx_general_purpose_port_device> m_gen_port2;
 	required_ioport_array<11> m_io_key;
@@ -249,6 +249,7 @@ protected:
 	const int m_cpu_xtal_divider;
 
 	virtual void setup_slot_spaces(msx_internal_slot_interface &device);
+	virtual address_space& get_io_space();
 
 private:
 	// configuration helpers

--- a/src/mame/msx/msx2.cpp
+++ b/src/mame/msx/msx2.cpp
@@ -25,7 +25,6 @@
 #include "msx_ar.lh"
 #include "msx_ar_1fdd.lh"
 #include "msx_ar_2fdd.lh"
-#include "msx_en.lh"
 #include "msx_jp.lh"
 #include "msx_jp_1fdd.lh"
 #include "msx_jp_2fdd.lh"
@@ -101,10 +100,6 @@ public:
 	void cx7128(machine_config &config);
 	void cx7m128(machine_config &config);
 	void expert20(machine_config &config);
-	void expert3i(machine_config &config);
-	void expert3t(machine_config &config);
-	void expertac(machine_config &config);
-	void expertdx(machine_config &config);
 	void fpc900(machine_config &config);
 	void kmc5000(machine_config &config);
 	void mbh70(machine_config &config);
@@ -128,19 +123,11 @@ public:
 	void fsa1a(machine_config &config);
 	void fsa1f(machine_config &config);
 	void fsa1fm(machine_config &config);
-	void fsa1fx(machine_config &config);
-	void fsa1gt(machine_config &config);
-	void fsa1st(machine_config &config);
 	void fsa1mk2(machine_config &config);
-	void fsa1wsx(machine_config &config);
-	void fsa1wx(machine_config &config);
-	void fsa1wxa(machine_config &config);
 	void fstm1(machine_config &config);
 	void hbf1(machine_config &config);
 	void hbf1ii(machine_config &config);
 	void hbf1xd(machine_config &config);
-	void hbf1xdj(machine_config &config);
-	void hbf1xv(machine_config &config);
 	void hbf5(machine_config &config);
 	void hbf500(machine_config &config);
 	void hbf500_2(machine_config &config);
@@ -175,10 +162,7 @@ public:
 	void nms8280g(machine_config &config);
 	void phc23(machine_config &config);
 	void phc23jb(machine_config &config);
-	void phc35j(machine_config &config);
 	void phc55fd2(machine_config &config);
-	void phc70fd(machine_config &config);
-	void phc70fd2(machine_config &config);
 	void phc77(machine_config &config);
 	void tpc310(machine_config &config);
 	void tpp311(machine_config &config);
@@ -475,7 +459,7 @@ ROM_END
 
 void msx2_state::cpg120(machine_config &config)
 {
-	// By pressing the turbo button the CPU can switched between 3.579545 and 5.369317 MHz
+	// By pressing the turbo button the CPU can be switched between 3.579545 and 5.369317 MHz
 	// YM2149 (in S1985)
 	// FDC: None, 0 drives
 	// 2 Cartridge slots?
@@ -490,14 +474,15 @@ void msx2_state::cpg120(machine_config &config)
 	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 0, 2, 0, 4).set_total_size(0x20000); // 128KB Mapper RAM
 	add_internal_slot(config, MSX_SLOT_ROM, "saubrom", 0, 3, 0, 2, "subrom");
 	add_cartridge_slot<1>(config, 1);
-	add_internal_slot(config, MSX_SLOT_MUSIC, "mus", 2, 1, 1, "music").set_ym2413_tag("ym2413");
+	add_internal_slot(config, MSX_SLOT_MUSIC, "mus", 2, 1, 1, "music").set_ym2413(m_ym2413);
 	add_cartridge_slot<2>(config, 3);
 
 	MSX_S1985(config, "s1985", 0);
 
 	msx_ym2413(config);
 	m_hw_def.has_printer_port(false);
-	msx2plus(SND_AY8910, config, layout_msx_nocode_nocaps);
+	msx2_v9958_base(SND_AY8910, config, layout_msx_nocode_nocaps);
+	msx2_add_softlists(config);
 }
 
 /* MSX2 - Daisen Sangyo MX-2021 */
@@ -2162,7 +2147,9 @@ void msx2_state::ax370(machine_config &config)
 	add_internal_slot(config, MSX_SLOT_ROM, "painter", 3, 1, 0, 4, "painter");
 	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 3, 0, 4).set_total_size(0x20000).set_unused_bits(0xf8);   // 128KB Mapper RAM
 
-	msx2plus_pal(SND_AY8910, config, layout_msx_ar_1fdd);
+	msx2_v9958_base(SND_AY8910, config, layout_msx_ar_1fdd);
+	m_v9958->set_screen_pal(m_screen);
+	msx2_add_softlists(config);
 }
 
 /* MSX2 - Sakhr AX-500 */
@@ -3985,658 +3972,6 @@ ROM_START(y805128r2e)
 	ROM_LOAD("yis805128r2epaint.rom", 0x00000, 0x10000, CRC(1bda68a3) SHA1(7fd2a28c4fdaeb140f3c8c8fb90271b1472c97b9))
 ROM_END
 
-/********************************  MSX 2+ **********************************/
-
-/* MSX2+ - Ciel Expert 3 IDE */
-
-ROM_START(expert3i)
-	ROM_REGION(0x8000, "mainrom", 0)
-	ROM_LOAD("exp30bios.rom", 0x0000,  0x8000, CRC(a10bb1ce) SHA1(5029cf47031b22bd5d1f68ebfd3be6d6da56dfe9))
-
-	ROM_REGION(0x4000, "subrom", 0)
-	ROM_LOAD("exp30ext.rom", 0x0000, 0x4000, CRC(6bcf4100) SHA1(cc1744c6c513d6409a142b4fb42fbe70a95d9b7f))
-
-	ROM_REGION(0x4000, "diskrom", 0)
-	ROM_LOAD("cieldisk.rom", 0x0000, 0x4000, CRC(bb550b09) SHA1(0274dd9b5096065a7f4ed019101124c9bd1d56b8))
-
-	ROM_REGION(0x4000, "music", 0)
-	ROM_LOAD("exp30mus.rom", 0x0000, 0x4000, CRC(9881b3fd) SHA1(befebc916bfdb5e8057040f0ae82b5517a7750db))
-
-	ROM_REGION(0x10000, "ide", 0)
-	ROM_LOAD("ide240a.rom", 0x00000, 0x10000, CRC(7adf857f) SHA1(8a919dbeed92db8c06a611279efaed8552810239))
-ROM_END
-
-void msx2_state::expert3i(machine_config &config)
-{
-	// AY8910/YM2149?
-	// FDC: wd2793, 1 or 2? drives
-	// 2 Cartridge slots?
-
-	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom");
-	add_cartridge_slot<1>(config, 1);
-	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 1, 1, 0, 1, "subrom");
-	add_internal_slot(config, MSX_SLOT_MUSIC, "music", 1, 1, 1, 1, "music").set_ym2413_tag("ym2413");
-	add_internal_disk_mirrored(config, MSX_SLOT_DISK1_WD2793, "disk", 1, 2, 1, 2, "diskrom");
-	add_internal_slot(config, MSX_SLOT_ROM, "ide", 1, 3, 0, 4, "ide");         /* IDE hardware needs to be emulated */
-	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 2, 0, 4).set_total_size(0x40000);       // 256KB?? Mapper RAM
-	add_cartridge_slot<2>(config, 3);
-
-	msx_ym2413(config);
-
-	msx2plus(SND_AY8910, config, layout_msx_nocode_1fdd);
-}
-
-/* MSX2+ - Ciel Expert 3 Turbo
-This one is a full motherboard by CIEL (not an upgrade kit), created to replace the motherboard of a Gradiente Expert (which means that only the case, the analog boards and the keyboard remains Gradiente). This new motherboard has the following built-in features:
-
-1) MSX2+
-2) Support either 3.57MHz or 7.14MHz natively, switched either by software (*1) or by a hardware-switch on the front panel. Turbo-led included.
-3) Up to 4MB of Memory Mapper (1MB is the most common configuration)
-4) MSX-Music
-5) 4 expansion slots (two external on the front panel, two internal)
-6) Stereo sound (YM2413 channels 0-6 on right, PSG+YM2413 channels 7-9 on left)
-7) Support the V9938 instead of the V9958 by switching some jumpers
-8) The main-ram can be placed on slot 2 or slot 3, using jumpers (slot 2 is the default)
-
-
-*1: A routine hidden inside the BIOS frame-0 is used to switch the turbo.
- */
-
-/* Uses a Z84C0010 - CMOS processor working at 7 MHz */
-ROM_START(expert3t)
-	ROM_REGION(0x8000, "mainrom", 0)
-	ROM_LOAD("exp30bios.rom", 0x0000, 0x8000, CRC(a10bb1ce) SHA1(5029cf47031b22bd5d1f68ebfd3be6d6da56dfe9))
-
-	ROM_REGION(0x4000, "subrom", 0)
-	ROM_LOAD("exp30ext.rom", 0x0000, 0x4000, CRC(6bcf4100) SHA1(cc1744c6c513d6409a142b4fb42fbe70a95d9b7f))
-
-	ROM_REGION(0x4000, "diskrom", 0)
-	ROM_LOAD("cieldisk.rom", 0x0000, 0x4000, CRC(bb550b09) SHA1(0274dd9b5096065a7f4ed019101124c9bd1d56b8))
-
-	ROM_REGION(0x4000, "music", 0)
-	ROM_LOAD("exp30mus.rom", 0x0000, 0x4000, CRC(9881b3fd) SHA1(befebc916bfdb5e8057040f0ae82b5517a7750db))
-
-	ROM_REGION(0x4000, "turbo", 0)
-	ROM_LOAD("turbo.rom", 0x0000, 0x4000, CRC(ab528416) SHA1(d468604269ae7664ac739ea9f922a05e14ffa3d1))
-ROM_END
-
-void msx2_state::expert3t(machine_config &config)
-{
-	// AY8910
-	// FDC: wd2793?, 1 or 2? drives
-	// 4 Cartridge/Expansion slots?
-	// FM/YM2413 built-in
-
-	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom");
-	add_cartridge_slot<1>(config, 1, 0);
-	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 1, 1, 0, 1, "subrom");
-	add_internal_slot(config, MSX_SLOT_MUSIC, "music", 1, 1, 1, 1, "music").set_ym2413_tag("ym2413");
-	add_internal_slot(config, MSX_SLOT_ROM, "turbo", 1, 2, 1, 1, "turbo");          /* Turbo hardware needs to be emulated */
-	add_internal_disk_mirrored(config, MSX_SLOT_DISK1_WD2793, "disk", 1, 3, 1, 2, "diskrom");
-	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 2, 0, 4).set_total_size(0x40000);       // 256KB Mapper RAM
-	add_cartridge_slot<2>(config, 3);
-
-	msx_ym2413(config);
-
-	msx2plus(SND_AY8910, config, layout_msx_nocode_1fdd);
-}
-
-/* MSX2+ - Gradiente Expert AC88+ */
-
-ROM_START(expertac)
-	ROM_REGION(0x8000, "mainrom", 0)
-	ROM_LOAD("ac88bios.rom", 0x0000, 0x8000, CRC(9ce0da44) SHA1(1fc2306911ab6e1ebdf7cb8c3c34a7f116414e88))
-
-	ROM_REGION(0x4000, "subrom", 0)
-	ROM_LOAD("ac88ext.rom", 0x0000, 0x4000, CRC(c74c005c) SHA1(d5528825c7eea2cfeadd64db1dbdbe1344478fc6))
-
-	ROM_REGION(0x4000, "diskrom", 0)
-	ROM_LOAD("panadisk.rom", 0x0000, 0x4000, CRC(17fa392b) SHA1(7ed7c55e0359737ac5e68d38cb6903f9e5d7c2b6))
-
-	ROM_REGION(0x4000, "asm", 0)
-	ROM_LOAD("ac88asm.rom", 0x0000, 0x4000, CRC(a8a955ae) SHA1(91e522473a8470511584df3ee5b325ea5e2b81ef))
-
-	ROM_REGION(0x4000, "xbasic", 0)
-	ROM_LOAD("xbasic2.rom", 0x0000, 0x4000, CRC(2825b1a0) SHA1(47370bec7ca1f0615a54eda548b07fbc0c7ef398))
-ROM_END
-
-void msx2_state::expertac(machine_config &config)
-{
-	// AY8910/YM2149?
-	// FDC: wd2793?, 1 or 2? drives
-	// 2 Cartridge slots?
-
-	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom");
-	add_cartridge_slot<1>(config, 1);
-	add_cartridge_slot<2>(config, 2);
-	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000);   // 64KB Mapper RAM??
-	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "subrom");
-	add_internal_slot(config, MSX_SLOT_ROM, "asm", 3, 1, 1, 1, "asm");
-	add_internal_disk_mirrored(config, MSX_SLOT_DISK1_WD2793, "disk", 3, 2, 1, 2, "diskrom");
-	add_internal_slot(config, MSX_SLOT_ROM, "xbasic", 3, 3, 1, 1, "xbasic");
-
-	msx2plus(SND_AY8910, config, layout_msx_nocode_1fdd);
-}
-
-/* MSX2+ - Gradiente Expert DDX+ */
-
-ROM_START(expertdx)
-	ROM_REGION(0x8000, "mainrom", 0)
-	ROM_LOAD("ddxbios.rom", 0x0000, 0x8000, CRC(e00af3dc) SHA1(5c463dd990582e677c8206f61035a7c54d8c67f0))
-
-	ROM_REGION(0x4000, "subrom", 0)
-	ROM_LOAD("ddxext.rom", 0x0000, 0x4000, CRC(b8ba44d3) SHA1(fe0254cbfc11405b79e7c86c7769bd6322b04995))
-
-	ROM_REGION(0x4000, "diskrom", 0)
-	ROM_LOAD("panadisk.rom", 0x0000, 0x4000, CRC(17fa392b) SHA1(7ed7c55e0359737ac5e68d38cb6903f9e5d7c2b6))
-
-	ROM_REGION(0x4000, "xbasic", 0)
-	ROM_LOAD("xbasic2.rom", 0x0000, 0x4000, CRC(2825b1a0) SHA1(47370bec7ca1f0615a54eda548b07fbc0c7ef398))
-
-	ROM_REGION(0x8000, "kanjirom", 0)
-	ROM_LOAD("kanji.rom", 0x0000, 0x8000, CRC(b4fc574d) SHA1(dcc3a67732aa01c4f2ee8d1ad886444a4dbafe06))
-ROM_END
-
-void msx2_state::expertdx(machine_config &config)
-{
-	// AY8910/YM2149?
-	// FDC: tc8566af, 1 3.5" DSDD drive?
-	// 2 Cartridge slots?
-
-	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom");
-	add_cartridge_slot<1>(config, 1, 0);
-	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 1, 1, 0, 1, "subrom");
-	add_internal_slot(config, MSX_SLOT_ROM, "xbasic", 1, 2, 1, 1, "xbasic");
-	add_internal_disk_mirrored(config, MSX_SLOT_DISK3_TC8566, "disk", 1, 3, 1, 2, "diskrom");
-	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 2, 0, 4).set_total_size(0x10000);   // 64KB Mapper RAM??
-	add_cartridge_slot<2>(config, 3);
-	/* Kanji? */
-
-	msx2plus(SND_AY8910, config, layout_msx_nocode_1fdd);
-}
-
-/* MSX2+ - Panasonic FS-A1FX */
-
-ROM_START(fsa1fx)
-	ROM_REGION(0x40000, "maincpu", 0)
-	ROM_LOAD("a1fx.ic16", 0, 0x40000, CRC(c0b2d882) SHA1(623cbca109b6410df08ee7062150a6bda4b5d5d4))
-
-	// Kanji rom contents are the first half of the single rom
-//  ROM_REGION(0x20000, "kanji", 0)
-	ROM_REGION(0x40000, "kanji", 0)
-	ROM_LOAD("a1fx.ic16", 0, 0x40000, CRC(c0b2d882) SHA1(623cbca109b6410df08ee7062150a6bda4b5d5d4))
-ROM_END
-
-void msx2_state::fsa1fx(machine_config &config)
-{
-	// AY8910 (in T9769)
-	// FDC: tc8566af, 1 3.5" DSDD drive
-	// 2 Cartridge slots
-	// T9769(B)
-	// ren-sha turbo slider
-	// pause button
-	// firmware switch
-
-	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "maincpu", 0x30000);
-	add_cartridge_slot<1>(config, 1);
-	add_cartridge_slot<2>(config, 2);
-	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
-	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "maincpu", 0x38000);
-	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "maincpu", 0x28000);
-	add_internal_disk_mirrored(config, MSX_SLOT_DISK3_TC8566, "disk", 3, 2, 1, 2, "maincpu", 0x3c000);
-	add_internal_slot(config, MSX_SLOT_ROM, "firmware", 3, 3, 1, 2, "maincpu", 0x20000);
-
-	msx_matsushita_device &matsushita(MSX_MATSUSHITA(config, "matsushita", 0));
-	matsushita.turbo_callback().set(FUNC(msx2_state::turbo_w));
-
-	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0xff);
-
-	m_kanji_fsa1fx = true;
-	msx2plus(SND_AY8910, config, layout_msx_jp_1fdd);
-}
-
-/* MSX2+ - Panasonic FS-A1WSX */
-
-ROM_START(fsa1wsx)
-	ROM_REGION(0x8000, "mainrom", 0)
-	ROM_LOAD("a1wsbios.rom", 0x0000, 0x8000, CRC(358ec547) SHA1(f4433752d3bf876bfefb363c749d4d2e08a218b6))
-
-	ROM_REGION(0x4000, "subrom", 0)
-	ROM_LOAD("a1wsext.rom", 0x0000, 0x4000, CRC(b8ba44d3) SHA1(fe0254cbfc11405b79e7c86c7769bd6322b04995))
-
-	ROM_REGION(0x4000, "diskrom", 0)
-	ROM_LOAD("a1wsdisk.rom", 0x0000, 0x4000, CRC(17fa392b) SHA1(7ed7c55e0359737ac5e68d38cb6903f9e5d7c2b6))
-
-	ROM_REGION(0x8000, "kdr", 0)
-	ROM_LOAD("a1wskdr.rom", 0x0000, 0x8000, CRC(b4fc574d) SHA1(dcc3a67732aa01c4f2ee8d1ad886444a4dbafe06))
-
-	ROM_REGION(0x4000, "msxmusic", 0)
-	ROM_LOAD("a1wsmusp.rom", 0x0000, 0x4000, CRC(5c32eb29) SHA1(aad42ba4289b33d8eed225d42cea930b7fc5c228))
-
-	ROM_REGION(0x200000, "firmware", 0)
-	ROM_LOAD("a1wsfirm.rom", 0x000000, 0x200000, CRC(e363595d) SHA1(3330d9b6b76e3c4ccb7cf252496ed15d08b95d3f))
-
-	ROM_REGION(0x40000, "kanji", 0)
-	ROM_LOAD("a1wskfn.rom", 0, 0x40000, CRC(1f6406fb) SHA1(5aff2d9b6efc723bc395b0f96f0adfa83cc54a49))
-ROM_END
-
-void msx2_state::fsa1wsx(machine_config &config)
-{
-	// AY8910 (in T9769)
-	// FDC: tc8566af, 1 3.5" DSDD drive
-	// 2 Cartridge slots
-	// FM built-in
-	// T9769(C)
-	// ren-sha turbo slider
-	// firmware switch
-	// pause button
-
-	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 0, 2, "mainrom");
-	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 0, 2, 1, 1, "msxmusic").set_ym2413_tag("ym2413");
-	add_cartridge_slot<1>(config, 1);
-	add_cartridge_slot<2>(config, 2);
-	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
-	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "subrom");
-	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "kdr");
-	add_internal_disk_mirrored(config, MSX_SLOT_DISK3_TC8566, "disk", 3, 2, 1, 2, "diskrom");
-	add_internal_slot(config, MSX_SLOT_PANASONIC08, "firmware", 3, 3, 0, 4, "firmware");
-
-	msx_matsushita_device &matsushita(MSX_MATSUSHITA(config, "matsushita", 0));
-	matsushita.turbo_callback().set(FUNC(msx2_state::turbo_w));
-
-	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0xff);
-
-	msx_ym2413(config);
-
-	msx2plus(SND_AY8910, config, layout_msx_jp_1fdd);
-}
-
-/* MSX2+ - Panasonic FS-A1WX */
-
-ROM_START(fsa1wx)
-	ROM_REGION(0x8000, "mainrom", 0)
-	ROM_LOAD("a1wxbios.rom", 0x0000, 0x8000, CRC(19771608) SHA1(e90f80a61d94c617850c415e12ad70ac41e66bb7))
-
-	ROM_REGION(0x4000, "subrom", 0)
-	ROM_LOAD("a1wxext.rom", 0x0000, 0x4000, CRC(b8ba44d3) SHA1(fe0254cbfc11405b79e7c86c7769bd6322b04995))
-
-	ROM_REGION(0x4000, "diskrom", 0)
-	ROM_LOAD("a1wxdisk.rom", 0x0000, 0x4000, CRC(905daa1b) SHA1(bb59c849898d46a23fdbd0cc04ab35088e74a18d))
-
-	ROM_REGION(0x8000, "kdr", 0)
-	ROM_LOAD("a1wxkdr.rom", 0x0000, 0x8000, CRC(a068cba9) SHA1(1ef3956f7f918873fb9b031339bba45d1e5e5878))
-
-	ROM_REGION(0x4000, "msxmusic", 0)
-	ROM_LOAD("a1wxmusp.rom", 0x0000, 0x4000, CRC(456e494e) SHA1(6354ccc5c100b1c558c9395fa8c00784d2e9b0a3))
-
-	ROM_REGION(0x200000, "firmware", 0)
-	ROM_LOAD("a1wxfirm.rom", 0x000000, 0x200000, CRC(283f3250) SHA1(d37ab4bd2bfddd8c97476cbe7347ae581a6f2972))
-
-	ROM_REGION(0x40000, "kanji", 0)
-	ROM_LOAD("a1wxkfn.rom", 0, 0x40000, CRC(1f6406fb) SHA1(5aff2d9b6efc723bc395b0f96f0adfa83cc54a49))
-ROM_END
-
-void msx2_state::fsa1wx(machine_config &config)
-{
-	// AY8910 (in T9769)
-	// FDC: tc8566af, 1 3.5" DSDD drive
-	// 2 Cartridge slots
-	// FM built-in
-	// MSX Engine T9769A/B
-	// ren-sha turbo slider
-	// firmware switch
-	// pause button
-
-	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 0, 2, "mainrom");
-	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 0, 2, 1, 1, "msxmusic").set_ym2413_tag("ym2413");
-	add_cartridge_slot<1>(config, 1);
-	add_cartridge_slot<2>(config, 2);
-	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
-	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "subrom");
-	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "kdr");
-	add_internal_disk_mirrored(config, MSX_SLOT_DISK3_TC8566, "disk", 3, 2, 1, 2, "diskrom");
-	add_internal_slot(config, MSX_SLOT_PANASONIC08, "firmware", 3, 3, 0, 4, "firmware");
-
-	msx_matsushita_device &matsushita(MSX_MATSUSHITA(config, "matsushita", 0));
-	matsushita.turbo_callback().set(FUNC(msx2_state::turbo_w));
-
-	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0xff);
-
-	msx_ym2413(config);
-
-	msx2plus(SND_AY8910, config, layout_msx_jp_1fdd);
-}
-
-/* MSX2+ - Panasonic FS-A1WX (a) */
-
-ROM_START(fsa1wxa)
-	ROM_REGION(0x8000, "mainrom", 0)
-	ROM_LOAD("a1wxbios.rom", 0x0000, 0x8000, CRC(19771608) SHA1(e90f80a61d94c617850c415e12ad70ac41e66bb7))
-
-	ROM_REGION(0x4000, "subrom", 0)
-	ROM_LOAD("a1wxext.rom", 0x0000, 0x4000, CRC(b8ba44d3) SHA1(fe0254cbfc11405b79e7c86c7769bd6322b04995))
-
-	ROM_REGION(0x4000, "diskrom", 0)
-	ROM_LOAD("a1wxdisk.rom", 0x0000, 0x4000, CRC(2bda0184) SHA1(2a0d228afde36ac7c5d3c2aac9c7c664dd071a8c))
-
-	ROM_REGION(0x8000, "kdr", 0)
-	ROM_LOAD("a1wxkdr.rom", 0x0000, 0x8000, CRC(a068cba9) SHA1(1ef3956f7f918873fb9b031339bba45d1e5e5878))
-
-	ROM_REGION(0x4000, "msxmusic", 0)
-	ROM_LOAD("a1wxmusp.rom", 0x0000, 0x4000, CRC(456e494e) SHA1(6354ccc5c100b1c558c9395fa8c00784d2e9b0a3))
-
-	ROM_REGION(0x200000, "firmware", 0)
-	ROM_LOAD("a1wxfira.rom", 0x000000, 0x200000, CRC(58440a8e) SHA1(8e0d4a77e7d5736e8225c2df4701509363eb230f))
-
-	ROM_REGION(0x40000, "kanji", 0)
-	ROM_LOAD("a1wxkfn.rom", 0, 0x40000, CRC(1f6406fb) SHA1(5aff2d9b6efc723bc395b0f96f0adfa83cc54a49))
-ROM_END
-
-/* MSX2+ - Sanyo Wavy PHC-35J */
-
-ROM_START(phc35j)
-	ROM_REGION(0x8000, "mainrom", 0)
-	ROM_LOAD("35jbios.rom", 0x0000, 0x8000, CRC(358ec547) SHA1(f4433752d3bf876bfefb363c749d4d2e08a218b6))
-
-	ROM_REGION(0x4000, "subrom", 0)
-	ROM_LOAD("35jext.rom", 0x0000, 0x4000, CRC(b8ba44d3) SHA1(fe0254cbfc11405b79e7c86c7769bd6322b04995))
-
-	ROM_REGION(0x8000, "kdr", 0)
-	ROM_LOAD("35jkdr.rom", 0x0000, 0x8000, CRC(b4fc574d) SHA1(dcc3a67732aa01c4f2ee8d1ad886444a4dbafe06))
-
-	ROM_REGION(0x20000, "kanji", 0)
-	ROM_LOAD("35jkfn.rom", 0, 0x20000, CRC(c9651b32) SHA1(84a645becec0a25d3ab7a909cde1b242699a8662))
-ROM_END
-
-void msx2_state::phc35j(machine_config &config)
-{
-	// AY8910 (in T9769)
-	// FDC: None, 0 drives
-	// 2 Cartridge slots
-	// T9769A
-	// ren-sha turbo slider
-	// pause button
-
-	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom");
-	add_cartridge_slot<1>(config, 1);
-	add_cartridge_slot<2>(config, 2);
-	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
-	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "subrom");
-	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "kdr");
-
-	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0xff);
-	msx2plus(SND_AY8910, config, layout_msx_jp);
-}
-
-/* MSX2+ - Sanyo Wavy PHC-70FD */
-
-ROM_START(phc70fd)
-	ROM_REGION(0x20000, "mainrom", 0)
-	ROM_LOAD("phc-70fd.rom", 0x0000, 0x20000, CRC(d2307ddf) SHA1(b6f2ca2e8a18d6c7cd326cb8d1a1d7d747f23059))
-//  ROM_LOAD("70fdbios.rom", 0x0000, 0x8000, CRC(19771608) SHA1(e90f80a61d94c617850c415e12ad70ac41e66bb7))
-//  ROM_LOAD("70fdext.rom",  0x8000, 0x4000, CRC(b8ba44d3) SHA1(fe0254cbfc11405b79e7c86c7769bd6322b04995))
-//  ROM_LOAD("70fddisk.rom", 0xc000, 0x4000, CRC(db7f1125) SHA1(9efa744be8355675e7bfdd3976bbbfaf85d62e1d))
-//  ROM_LOAD("70fdkdr.rom", 0x10000, 0x8000, CRC(a068cba9) SHA1(1ef3956f7f918873fb9b031339bba45d1e5e5878))
-//  ROM_LOAD("70fdmus.rom", 0x18000, 0x4000, CRC(5c32eb29) SHA1(aad42ba4289b33d8eed225d42cea930b7fc5c228))
-//  ROM_LOAD("70fdbas.rom", 0x1c000, 0x4000, CRC(da7be246) SHA1(22b3191d865010264001b9d896186a9818478a6b))
-
-	ROM_REGION(0x20000, "kanji", 0)
-	ROM_LOAD("70fdkfn.rom", 0, 0x20000, CRC(c9651b32) SHA1(84a645becec0a25d3ab7a909cde1b242699a8662))
-ROM_END
-
-void msx2_state::phc70fd(machine_config &config)
-{
-	// AY8910 (in T9769)
-	// FDC: tc8566af, 1 3.5" DSDD drive
-	// 2 Cartridge slots
-	// T9769
-	// FM built-in
-	// ren-sha turbo slider
-	// pause button
-
-	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom", 0x10000);
-	add_cartridge_slot<1>(config, 1);
-	add_cartridge_slot<2>(config, 2);
-	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
-	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "mainrom", 0x18000);
-	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "mainrom", 0x8000);
-	add_internal_disk_mirrored(config, MSX_SLOT_DISK3_TC8566, "disk", 3, 2, 1, 2, "mainrom", 0x1c000);
-	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "mainrom", 0x00000).set_ym2413_tag("ym2413");
-	add_internal_slot(config, MSX_SLOT_ROM, "basickun", 3, 3, 2, 1, "mainrom", 0x04000);
-
-	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0xff);
-
-	msx_ym2413(config);
-
-	msx2plus(SND_AY8910, config, layout_msx_jp_1fdd);
-}
-
-/* MSX2+ - Sanyo Wavy PHC-70FD2 */
-
-ROM_START(phc70fd2)
-	ROM_REGION(0x20000, "mainrom", 0)
-	ROM_LOAD("70f2bios.rom", 0x0000, 0x8000, CRC(19771608) SHA1(e90f80a61d94c617850c415e12ad70ac41e66bb7))
-
-	ROM_REGION(0x4000, "subrom", 0)
-	ROM_LOAD("70f2ext.rom", 0x0000, 0x4000, CRC(b8ba44d3) SHA1(fe0254cbfc11405b79e7c86c7769bd6322b04995))
-
-	ROM_REGION(0x4000, "diskrom", 0)
-	ROM_LOAD("70f2disk.rom", 0x0000, 0x4000, CRC(db7f1125) SHA1(9efa744be8355675e7bfdd3976bbbfaf85d62e1d))
-
-	ROM_REGION(0x8000, "kdr", 0)
-	ROM_LOAD("70f2kdr.rom", 0x0000, 0x8000, CRC(a068cba9) SHA1(1ef3956f7f918873fb9b031339bba45d1e5e5878))
-
-	ROM_REGION(0x4000, "msxmusic", 0)
-	ROM_LOAD("70f2mus.rom", 0x0000, 0x4000, CRC(5c32eb29) SHA1(aad42ba4289b33d8eed225d42cea930b7fc5c228))
-
-	ROM_REGION(0x4000, "basickun", 0)
-	ROM_LOAD("70f2bas.rom", 0x0000, 0x4000, CRC(da7be246) SHA1(22b3191d865010264001b9d896186a9818478a6b))
-
-	ROM_REGION(0x40000, "kanji", 0)
-	ROM_LOAD("70f2kfn.rom", 0, 0x40000, CRC(9a850db9) SHA1(bcdb4dae303dfe5234f372d70a5e0271d3202c36))
-ROM_END
-
-void msx2_state::phc70fd2(machine_config &config)
-{
-	// AY8910
-	// FDC: tc8566af, 2 3.5" DSDD drives
-	// 2 Cartridge slots
-	// FM built-in
-	// T9769
-
-	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom");
-	add_cartridge_slot<1>(config, 1);
-	add_cartridge_slot<2>(config, 2);
-	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
-	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "subrom");
-	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "kdr");
-	add_internal_disk_mirrored(config, MSX_SLOT_DISK3_TC8566_2_DRIVES, "disk", 3, 2, 1, 2, "diskrom");
-	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "msxmusic").set_ym2413_tag("ym2413");
-	add_internal_slot(config, MSX_SLOT_ROM, "basickun", 3, 3, 2, 1, "basickun");
-
-	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0xff);
-
-	msx_ym2413(config);
-
-	msx2plus(SND_AY8910, config, layout_msx_jp_2fdd);
-}
-
-/* MSX2+ - Sony HB-F1XDJ */
-
-ROM_START(hbf1xdj)
-	ROM_REGION(0x20000, "mainrom", 0)
-	ROM_LOAD("hb-f1xdj_main.rom", 0x0000, 0x20000, CRC(d89bab74) SHA1(f2a1d326d72d4c70ea214d7883838de8847a82b7))
-
-	ROM_REGION(0x100000, "firmware", 0)
-	ROM_LOAD("f1xjfirm.rom", 0x000000, 0x100000, CRC(77be583f) SHA1(ade0c5ba5574f8114d7079050317099b4519e88f))
-
-	ROM_REGION(0x40000, "kanji", 0)
-	ROM_LOAD("f1xjkfn.rom", 0, 0x40000, CRC(7016dfd0) SHA1(218d91eb6df2823c924d3774a9f455492a10aecb))
-ROM_END
-
-void msx2_state::hbf1xdj(machine_config &config)
-{
-	// YM2149 (in S-1985 MSX Engine)
-	// FDC: MB89311, 1 3.5" DSDD drive
-	// 2 Cartridge slots
-	// FM built-in
-	// S-1985 MSX Engine
-	// speed controller
-	// pause button
-	// ren-sha turbo
-
-	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 0, 2, "mainrom");
-	add_internal_slot(config, MSX_SLOT_SONY08, "firmware", 0, 3, 0, 4, "firmware");
-	add_cartridge_slot<1>(config, 1);
-	add_cartridge_slot<2>(config, 2);
-	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
-	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "mainrom", 0x8000);
-	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "mainrom", 0x10000);
-	add_internal_disk_mirrored(config, MSX_SLOT_DISK1_WD2793_N, "disk", 3, 2, 1, 2, "mainrom", 0xc000);
-	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "mainrom", 0x18000).set_ym2413_tag("ym2413");
-
-	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0x00);
-
-	MSX_S1985(config, "s1985", 0);
-
-	msx_ym2413(config);
-
-	msx2plus(SND_YM2149, config, layout_msx_jp_1fdd);
-}
-
-/* MSX2+ - Sony HB-F1XV */
-
-ROM_START(hbf1xv)
-	ROM_REGION(0x20000, "mainrom", 0)
-	ROM_LOAD("hb-f1xdj_main.rom", 0x0000, 0x20000, CRC(d89bab74) SHA1(f2a1d326d72d4c70ea214d7883838de8847a82b7))
-
-	ROM_REGION(0x100000, "firmware", 0)
-	ROM_LOAD("f1xvfirm.rom", 0x0, 0x100000, CRC(77be583f) SHA1(ade0c5ba5574f8114d7079050317099b4519e88f))
-
-	ROM_REGION(0x40000, "kanji", 0)
-	ROM_LOAD("f1xvkfn.rom", 0, 0x40000, CRC(7016dfd0) SHA1(218d91eb6df2823c924d3774a9f455492a10aecb))
-ROM_END
-
-void msx2_state::hbf1xv(machine_config &config)
-{
-	// YM2149 (in S-1985 MSX Engine)
-	// FDC: mb89311, 1 3.5" DSDD drives
-	// 2 Cartridge slots
-	// FM built-in
-	// S-1985 MSX Engine
-	// speed controller
-	// pause button
-	// ren-sha turbo
-
-	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 0, 2, "mainrom");
-	add_internal_slot(config, MSX_SLOT_SONY08, "firmware", 0, 3, 0, 4, "firmware");
-	add_cartridge_slot<1>(config, 1);
-	add_cartridge_slot<2>(config, 2);
-	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
-	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "mainrom", 0x8000);
-	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "mainrom", 0x10000);
-	add_internal_disk_mirrored(config, MSX_SLOT_DISK1_WD2793_N, "disk", 3, 2, 1, 2, "mainrom", 0xc000);
-	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "mainrom", 0x18000).set_ym2413_tag("ym2413");
-
-	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0x00);
-
-	MSX_S1985(config, "s1985", 0);
-
-	msx_ym2413(config);
-
-	msx2plus(SND_YM2149, config, layout_msx_jp_1fdd);
-}
-
-/* MSX Turbo-R - Panasonic FS-A1GT */
-
-ROM_START(fsa1gt)
-	ROM_REGION(0x46c000, "maincpu", 0)
-	ROM_LOAD("a1gtbios.rom",  0x0000,   0x8000, CRC(937c8dbb) SHA1(242e73d8284a012b275c0a266844ebbc4269d787))
-	ROM_LOAD("a1gtext.rom",   0x8000,   0x4000, CRC(70aea0fe) SHA1(018d7a5222f28514908fb1b1513286a6558a6d05))
-	ROM_LOAD("a1gtdos.rom",   0xc000,  0x10000, CRC(bb2a0eae) SHA1(4880bf34f1c86fff5456ec2b4cf70d02339e2caa))
-	ROM_LOAD("a1gtkdr.rom",  0x1c000,   0x8000, CRC(eaf0d125) SHA1(5b39c1ccd3a213b78e02927f56a9abc72cd8c28d))
-	ROM_LOAD("a1gtmus.rom",  0x24000,   0x4000, CRC(f5f93437) SHA1(6aea1aef5ec31c1826c22edf580525f93baad425))
-	ROM_LOAD("a1gtopt.rom",  0x28000,   0x4000, CRC(50d11f60) SHA1(b4433a3975c57dd440d6bf12dbd28b2ac1b90ef4))
-	ROM_LOAD("a1gtkfn.rom",  0x2c000,  0x40000, CRC(1f6406fb) SHA1(5aff2d9b6efc723bc395b0f96f0adfa83cc54a49))
-	ROM_LOAD("a1gtfirm.rom", 0x6c000, 0x400000, CRC(feefeadc) SHA1(e779c338eb91a7dea3ff75f3fde76b8af22c4a3a))
-ROM_END
-
-void msx2_state::fsa1gt(machine_config &config)
-{
-	// AY8910 (in T9769)
-	// FDC: tc8566af, 1 3.5" DSDD drive
-	// 2 Cartridge slots
-	// T9769C + S1990
-	// FM built-in
-	// Microphone
-	// MIDI-in
-	// MIDI-out
-	// firmware switch
-	// pause button
-	// ren-sha turbo slider
-
-	add_internal_slot(config, MSX_SLOT_ROM, "bios", 0, 0, 0, 2, "maincpu");
-	add_internal_slot(config, MSX_SLOT_MUSIC, "mus", 0, 2, 1, 1, "maincpu", 0x24000).set_ym2413_tag("ym2413");
-	add_internal_slot(config, MSX_SLOT_ROM, "opt", 0, 3, 1, 1, "maincpu", 0x28000);
-	add_cartridge_slot<1>(config, 1);
-	add_cartridge_slot<2>(config, 2);
-	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x20000);   // 128KB?? Mapper RAM
-	add_internal_slot(config, MSX_SLOT_ROM, "ext", 3, 1, 0, 1, "maincpu", 0x8000);
-	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "maincpu", 0x1c000);
-	add_internal_disk(config, MSX_SLOT_DISK4_TC8566, "dos", 3, 2, 1, 3, "maincpu", 0xc000);
-	add_internal_slot(config, MSX_SLOT_ROM, "firm", 3, 3, 0, 4, "maincpu", 0x6c000);
-
-	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0x00);
-
-	msx_ym2413(config);
-
-	turbor(SND_AY8910, config, layout_msx_jp_1fdd);
-}
-
-/* MSX Turbo-R - Panasonic FS-A1ST */
-
-ROM_START(fsa1st)
-	ROM_REGION(0x46c000, "maincpu", 0)
-	ROM_LOAD("a1stbios.rom",  0x0000,   0x8000, CRC(77b94ae0) SHA1(f078b5ec56884bfb81481d45c7151418770bff5a))
-	ROM_LOAD("a1stext.rom",   0x8000,   0x4000, CRC(2c2c77a4) SHA1(373412f9c32762de1c3a7e27fc3d80614e0a0c8e))
-	ROM_LOAD("a1stdos.rom",   0xc000,  0x10000, CRC(1fc71407) SHA1(5d2186658adcf4ce0c2d3232384b5712341108e5))
-	ROM_LOAD("a1stkdr.rom",  0x1c000,   0x8000, CRC(eaf0d125) SHA1(5b39c1ccd3a213b78e02927f56a9abc72cd8c28d))
-	ROM_LOAD("a1stmus.rom",  0x24000,   0x4000, CRC(fd7dec41) SHA1(e002a9b426732e6c2d31e548c40cf7c122348ce3))
-	ROM_LOAD("a1stopt.rom",  0x28000,   0x4000, CRC(c6a4a2a1) SHA1(cb06dea7b025745f9d2b87dcf03ded615287ead3))
-	ROM_LOAD("a1stkfn.rom",  0x2c000,  0x40000, CRC(1f6406fb) SHA1(5aff2d9b6efc723bc395b0f96f0adfa83cc54a49))
-	ROM_LOAD("a1stfirm.rom", 0x6c000, 0x400000, CRC(139ac99c) SHA1(c212b11fda13f83dafed688c54d098e7e47ab225))
-ROM_END
-
-void msx2_state::fsa1st(machine_config &config)
-{
-	// AY8910 (in T9769)
-	// FDC: tc8566af, 1 3.5" DSDD drive
-	// T9769C + S1990
-	// 2 Cartridge slots
-	// FM built-in
-	// microphone
-	// firmware switch
-	// pause button
-	// ren-sha turbo slider
-
-	add_internal_slot(config, MSX_SLOT_ROM, "bios", 0, 0, 0, 2, "maincpu");
-	add_internal_slot(config, MSX_SLOT_MUSIC, "mus", 0, 2, 1, 1, "maincpu", 0x24000).set_ym2413_tag("ym2413");
-	add_internal_slot(config, MSX_SLOT_ROM, "opt", 0, 3, 1, 1, "maincpu", 0x28000);
-	add_cartridge_slot<1>(config, 1);
-	add_cartridge_slot<2>(config, 2);
-	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x20000);   // 128KB?? Mapper RAM
-	add_internal_slot(config, MSX_SLOT_ROM, "ext", 3, 1, 0, 1, "maincpu", 0x8000);
-	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "maincpu", 0x1c000);
-	add_internal_disk(config, MSX_SLOT_DISK4_TC8566, "dos", 3, 2, 1, 3, "maincpu", 0xc000);
-	add_internal_slot(config, MSX_SLOT_ROM, "firm", 3, 3, 0, 4, "maincpu", 0x6c000);
-
-	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0x00);
-
-	msx_ym2413(config);
-
-	turbor(SND_AY8910, config, layout_msx_jp_1fdd);
-}
-
 } // anonymous namespace
 
 /* MSX2 */
@@ -4744,23 +4079,3 @@ COMP(1986, y805128,    y805256,  0,     y805128,    msx2jp,   msx2_state, empty_
 COMP(1986, y805128r2,  y805256,  0,     y805128r2,  msx2,     msx2_state, empty_init, "Yamaha", "YIS805/128R2 (MSX2, USSR)", MACHINE_NOT_WORKING) // Network not implemented
 COMP(198?, y805128r2e, y805256,  0,     y805128r2,  y503iir2, msx2_state, empty_init, "Yamaha", "YIS805/128R2 (MSX2, Estonian)", MACHINE_NOT_WORKING) // Network not implemented
 COMP(198?, y805256,    0,        0,     y805256,    msx2jp,   msx2_state, empty_init, "Yamaha", "YIS805/256 (MSX2, Japan)", MACHINE_NOT_WORKING) // Floppy support broken?
-
-/* MSX2+ */
-COMP(19??, expert3i,   0,        0,     expert3i,   msx2,     msx2_state, empty_init, "Ciel", "Expert 3 IDE (MSX2+, Brazil)", MACHINE_NOT_WORKING) // Some hardware not emulated
-COMP(1996, expert3t,   0,        0,     expert3t,   msx2,     msx2_state, empty_init, "Ciel", "Expert 3 Turbo (MSX2+, Brazil)", MACHINE_NOT_WORKING) // Some hardware not emulated
-COMP(19??, expertac,   0,        0,     expertac,   msx2,     msx2_state, empty_init, "Gradiente", "Expert AC88+ (MSX2+, Brazil)", MACHINE_NOT_WORKING) // Some hardware not emulated
-COMP(19??, expertdx,   0,        0,     expertdx,   msx2,     msx2_state, empty_init, "Gradiente", "Expert DDX+ (MSX2+, Brazil)", MACHINE_NOT_WORKING) // Some hardware not emulated
-COMP(1988, fsa1fx,     0,        0,     fsa1fx,     msx2jp,   msx2_state, empty_init, "Panasonic", "FS-A1FX (MSX2+, Japan)", 0)
-COMP(1989, fsa1wsx,    0,        0,     fsa1wsx,    msx2jp,   msx2_state, empty_init, "Panasonic", "FS-A1WSX (MSX2+, Japan)", 0)
-COMP(1988, fsa1wx,     fsa1wxa,  0,     fsa1wx,     msx2jp,   msx2_state, empty_init, "Panasonic", "FS-A1WX / 1st released version (MSX2+, Japan)", 0)
-COMP(1988, fsa1wxa,    0,        0,     fsa1wx,     msx2jp,   msx2_state, empty_init, "Panasonic", "FS-A1WX / 2nd released version (MSX2+, Japan)", 0)
-COMP(1988, phc70fd,    phc70fd2, 0,     phc70fd,    msx2jp,   msx2_state, empty_init, "Sanyo", "PHC-70FD / Wavy70FD (MSX2+, Japan)", 0)
-COMP(1989, phc70fd2,   0,        0,     phc70fd2,   msx2jp,   msx2_state, empty_init, "Sanyo", "PHC-70FD2 / Wavy70FD2 (MSX2+, Japan)", 0)
-COMP(1989, phc35j,     0,        0,     phc35j,     msx2jp,   msx2_state, empty_init, "Sanyo", "PHC-35J / Wavy35 (MSX2+, Japan)", 0)
-COMP(1988, hbf1xdj,    0,        0,     hbf1xdj,    msx2jp,   msx2_state, empty_init, "Sony", "HB-F1XDJ (MSX2+, Japan)", 0)
-COMP(1989, hbf1xv,     0,        0,     hbf1xv,     msx2jp,   msx2_state, empty_init, "Sony", "HB-F1XV (MSX2+, Japan)", 0)
-
-/* MSX Turbo-R */
-/* Temporary placeholders, Turbo-R hardware is not supported yet */
-COMP(1991, fsa1gt,     0,        0,     fsa1gt,     msx2jp,   msx2_state, empty_init, "Panasonic", "FS-A1GT (MSX Turbo-R, Japan)", MACHINE_NOT_WORKING)
-COMP(1991, fsa1st,     0,        0,     fsa1st,     msx2jp,   msx2_state, empty_init, "Panasonic", "FS-A1ST (MSX Turbo-R, Japan)", MACHINE_NOT_WORKING)

--- a/src/mame/msx/msx2.cpp
+++ b/src/mame/msx/msx2.cpp
@@ -474,7 +474,7 @@ void msx2_state::cpg120(machine_config &config)
 	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 0, 2, 0, 4).set_total_size(0x20000); // 128KB Mapper RAM
 	add_internal_slot(config, MSX_SLOT_ROM, "saubrom", 0, 3, 0, 2, "subrom");
 	add_cartridge_slot<1>(config, 1);
-	add_internal_slot(config, MSX_SLOT_MUSIC, "mus", 2, 1, 1, "music").set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_MUSIC, "mus", 2, 1, 1, "music");
 	add_cartridge_slot<2>(config, 3);
 
 	MSX_S1985(config, "s1985", 0);

--- a/src/mame/msx/msx2.cpp
+++ b/src/mame/msx/msx2.cpp
@@ -474,7 +474,7 @@ void msx2_state::cpg120(machine_config &config)
 	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 0, 2, 0, 4).set_total_size(0x20000); // 128KB Mapper RAM
 	add_internal_slot(config, MSX_SLOT_ROM, "saubrom", 0, 3, 0, 2, "subrom");
 	add_cartridge_slot<1>(config, 1);
-	add_internal_slot(config, MSX_SLOT_MUSIC, "mus", 2, 1, 1, "music");
+	add_internal_slot(config, MSX_SLOT_MUSIC, "mus", 2, 1, 1, "music").set_ym2413_tag(m_ym2413);
 	add_cartridge_slot<2>(config, 3);
 
 	MSX_S1985(config, "s1985", 0);

--- a/src/mame/msx/msx2p.cpp
+++ b/src/mame/msx/msx2p.cpp
@@ -88,7 +88,7 @@ void msx2p_state::expert3i(machine_config &config)
 	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom");
 	add_cartridge_slot<1>(config, 1);
 	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 1, 1, 0, 1, "subrom");
-	add_internal_slot(config, MSX_SLOT_MUSIC, "music", 1, 1, 1, 1, "music").set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_MUSIC, "music", 1, 1, 1, 1, "music");
 	add_internal_disk_mirrored(config, MSX_SLOT_DISK1_WD2793, "disk", 1, 2, 1, 2, "diskrom");
 	add_internal_slot(config, MSX_SLOT_ROM, "ide", 1, 3, 0, 4, "ide");         /* IDE hardware needs to be emulated */
 	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 2, 0, 4).set_total_size(0x40000);       // 256KB?? Mapper RAM
@@ -143,7 +143,7 @@ void msx2p_state::expert3t(machine_config &config)
 	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom");
 	add_cartridge_slot<1>(config, 1, 0);
 	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 1, 1, 0, 1, "subrom");
-	add_internal_slot(config, MSX_SLOT_MUSIC, "music", 1, 1, 1, 1, "music").set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_MUSIC, "music", 1, 1, 1, 1, "music");
 	add_internal_slot(config, MSX_SLOT_ROM, "turbo", 1, 2, 1, 1, "turbo");          /* Turbo hardware needs to be emulated */
 	add_internal_disk_mirrored(config, MSX_SLOT_DISK1_WD2793, "disk", 1, 3, 1, 2, "diskrom");
 	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 2, 0, 4).set_total_size(0x40000);       // 256KB Mapper RAM
@@ -310,7 +310,7 @@ void msx2p_state::fsa1wsx(machine_config &config)
 	// pause button
 
 	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 0, 2, "mainrom");
-	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 0, 2, 1, 1, "msxmusic").set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 0, 2, 1, 1, "msxmusic");
 	add_cartridge_slot<1>(config, 1);
 	add_cartridge_slot<2>(config, 2);
 	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
@@ -371,7 +371,7 @@ void msx2p_state::fsa1wx(machine_config &config)
 	// pause button
 
 	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 0, 2, "mainrom");
-	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 0, 2, 1, 1, "msxmusic").set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 0, 2, 1, 1, "msxmusic");
 	add_cartridge_slot<1>(config, 1);
 	add_cartridge_slot<2>(config, 2);
 	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
@@ -490,7 +490,7 @@ void msx2p_state::phc70fd(machine_config &config)
 	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "mainrom", 0x18000);
 	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "mainrom", 0x8000);
 	add_internal_disk_mirrored(config, MSX_SLOT_DISK3_TC8566, "disk", 3, 2, 1, 2, "mainrom", 0x1c000);
-	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "mainrom", 0x00000).set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "mainrom", 0x00000);
 	add_internal_slot(config, MSX_SLOT_ROM, "basickun", 3, 3, 2, 1, "mainrom", 0x04000);
 
 	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0xff);
@@ -541,7 +541,7 @@ void msx2p_state::phc70fd2(machine_config &config)
 	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "subrom");
 	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "kdr");
 	add_internal_disk_mirrored(config, MSX_SLOT_DISK3_TC8566_2_DRIVES, "disk", 3, 2, 1, 2, "diskrom");
-	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "msxmusic").set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "msxmusic");
 	add_internal_slot(config, MSX_SLOT_ROM, "basickun", 3, 3, 2, 1, "basickun");
 
 	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0xff);
@@ -584,7 +584,7 @@ void msx2p_state::hbf1xdj(machine_config &config)
 	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "mainrom", 0x8000);
 	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "mainrom", 0x10000);
 	add_internal_disk_mirrored(config, MSX_SLOT_DISK1_WD2793_N, "disk", 3, 2, 1, 2, "mainrom", 0xc000);
-	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "mainrom", 0x18000).set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "mainrom", 0x18000);
 
 	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0x00);
 
@@ -627,7 +627,7 @@ void msx2p_state::hbf1xv(machine_config &config)
 	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "mainrom", 0x8000);
 	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "mainrom", 0x10000);
 	add_internal_disk_mirrored(config, MSX_SLOT_DISK1_WD2793_N, "disk", 3, 2, 1, 2, "mainrom", 0xc000);
-	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "mainrom", 0x18000).set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "mainrom", 0x18000);
 
 	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0x00);
 
@@ -667,7 +667,7 @@ void msx2p_state::fsa1gt(machine_config &config)
 	// ren-sha turbo slider
 
 	add_internal_slot(config, MSX_SLOT_ROM, "bios", 0, 0, 0, 2, "maincpu");
-	add_internal_slot(config, MSX_SLOT_MUSIC, "mus", 0, 2, 1, 1, "maincpu", 0x24000).set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_MUSIC, "mus", 0, 2, 1, 1, "maincpu", 0x24000);
 	add_internal_slot(config, MSX_SLOT_ROM, "opt", 0, 3, 1, 1, "maincpu", 0x28000);
 	add_cartridge_slot<1>(config, 1);
 	add_cartridge_slot<2>(config, 2);
@@ -710,7 +710,7 @@ void msx2p_state::fsa1st(machine_config &config)
 	// ren-sha turbo slider
 
 	add_internal_slot(config, MSX_SLOT_ROM, "bios", 0, 0, 0, 2, "maincpu");
-	add_internal_slot(config, MSX_SLOT_MUSIC, "mus", 0, 2, 1, 1, "maincpu", 0x24000).set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_MUSIC, "mus", 0, 2, 1, 1, "maincpu", 0x24000);
 	add_internal_slot(config, MSX_SLOT_ROM, "opt", 0, 3, 1, 1, "maincpu", 0x28000);
 	add_cartridge_slot<1>(config, 1);
 	add_cartridge_slot<2>(config, 2);

--- a/src/mame/msx/msx2p.cpp
+++ b/src/mame/msx/msx2p.cpp
@@ -1,0 +1,748 @@
+// license:BSD-3-Clause
+// copyright-holders:Wilbert Pol
+
+#include "emu.h"
+#include "msx.h"
+#include "msx_keyboard.h"
+#include "msx_matsushita.h"
+#include "msx_s1985.h"
+#include "msx_systemflags.h"
+#include "bus/msx/slot/disk.h"
+#include "bus/msx/slot/music.h"
+#include "bus/msx/slot/panasonic08.h"
+#include "bus/msx/slot/ram_mm.h"
+#include "bus/msx/slot/sony08.h"
+#include "softlist_dev.h"
+
+#include "msx_jp.lh"
+#include "msx_jp_1fdd.lh"
+#include "msx_jp_2fdd.lh"
+#include "msx_nocode_1fdd.lh"
+
+using namespace msx_keyboard;
+
+
+/***************************************************************************
+
+  MSX2+ machines
+
+***************************************************************************/
+
+namespace {
+
+class msx2p_state : public msx2p_base_state
+{
+public:
+	msx2p_state(const machine_config &mconfig, device_type type, const char *tag)
+		: msx2p_base_state(mconfig, type, tag, 21.477272_MHz_XTAL, 6)
+	{
+	}
+
+	// MSX2+ machines
+	// Did the expert machines have the f4 boot flags i/o port? (not referenced from system bios)
+	void expert3i(machine_config &config);
+	void expert3t(machine_config &config);
+	void expertac(machine_config &config);
+	void expertdx(machine_config &config);
+	void fsa1fx(machine_config &config);
+	void fsa1wsx(machine_config &config);
+	void fsa1wx(machine_config &config);
+	void fsa1wxa(machine_config &config);
+	void phc70fd(machine_config &config);
+	void phc70fd2(machine_config &config);
+	void phc35j(machine_config &config);
+	void hbf1xdj(machine_config &config);
+	void hbf1xv(machine_config &config);
+
+	void fsa1gt(machine_config &config);
+	void fsa1st(machine_config &config);
+};
+
+/********************************  MSX 2+ **********************************/
+
+/* MSX2+ - Ciel Expert 3 IDE */
+
+ROM_START(expert3i)
+	ROM_REGION(0x8000, "mainrom", 0)
+	ROM_LOAD("exp30bios.rom", 0x0000,  0x8000, CRC(a10bb1ce) SHA1(5029cf47031b22bd5d1f68ebfd3be6d6da56dfe9))
+
+	ROM_REGION(0x4000, "subrom", 0)
+	ROM_LOAD("exp30ext.rom", 0x0000, 0x4000, CRC(6bcf4100) SHA1(cc1744c6c513d6409a142b4fb42fbe70a95d9b7f))
+
+	ROM_REGION(0x4000, "diskrom", 0)
+	ROM_LOAD("cieldisk.rom", 0x0000, 0x4000, CRC(bb550b09) SHA1(0274dd9b5096065a7f4ed019101124c9bd1d56b8))
+
+	ROM_REGION(0x4000, "music", 0)
+	ROM_LOAD("exp30mus.rom", 0x0000, 0x4000, CRC(9881b3fd) SHA1(befebc916bfdb5e8057040f0ae82b5517a7750db))
+
+	ROM_REGION(0x10000, "ide", 0)
+	ROM_LOAD("ide240a.rom", 0x00000, 0x10000, CRC(7adf857f) SHA1(8a919dbeed92db8c06a611279efaed8552810239))
+ROM_END
+
+void msx2p_state::expert3i(machine_config &config)
+{
+	// AY8910/YM2149?
+	// FDC: wd2793, 1 or 2? drives
+	// 2 Cartridge slots?
+
+	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom");
+	add_cartridge_slot<1>(config, 1);
+	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 1, 1, 0, 1, "subrom");
+	add_internal_slot(config, MSX_SLOT_MUSIC, "music", 1, 1, 1, 1, "music").set_ym2413(m_ym2413);
+	add_internal_disk_mirrored(config, MSX_SLOT_DISK1_WD2793, "disk", 1, 2, 1, 2, "diskrom");
+	add_internal_slot(config, MSX_SLOT_ROM, "ide", 1, 3, 0, 4, "ide");         /* IDE hardware needs to be emulated */
+	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 2, 0, 4).set_total_size(0x40000);       // 256KB?? Mapper RAM
+	add_cartridge_slot<2>(config, 3);
+
+	msx_ym2413(config);
+
+	msx2plus(SND_AY8910, config, layout_msx_nocode_1fdd);
+}
+
+/* MSX2+ - Ciel Expert 3 Turbo
+This one is a full motherboard by CIEL (not an upgrade kit), created to replace the motherboard of a Gradiente Expert (which means that only the case, the analog boards and the keyboard remains Gradiente). This new motherboard has the following built-in features:
+
+1) MSX2+
+2) Support either 3.57MHz or 7.14MHz natively, switched either by software (*1) or by a hardware-switch on the front panel. Turbo-led included.
+3) Up to 4MB of Memory Mapper (1MB is the most common configuration)
+4) MSX-Music
+5) 4 expansion slots (two external on the front panel, two internal)
+6) Stereo sound (YM2413 channels 0-6 on right, PSG+YM2413 channels 7-9 on left)
+7) Support the V9938 instead of the V9958 by switching some jumpers
+8) The main-ram can be placed on slot 2 or slot 3, using jumpers (slot 2 is the default)
+
+
+*1: A routine hidden inside the BIOS frame-0 is used to switch the turbo.
+ */
+
+/* Uses a Z84C0010 - CMOS processor working at 7 MHz */
+ROM_START(expert3t)
+	ROM_REGION(0x8000, "mainrom", 0)
+	ROM_LOAD("exp30bios.rom", 0x0000, 0x8000, CRC(a10bb1ce) SHA1(5029cf47031b22bd5d1f68ebfd3be6d6da56dfe9))
+
+	ROM_REGION(0x4000, "subrom", 0)
+	ROM_LOAD("exp30ext.rom", 0x0000, 0x4000, CRC(6bcf4100) SHA1(cc1744c6c513d6409a142b4fb42fbe70a95d9b7f))
+
+	ROM_REGION(0x4000, "diskrom", 0)
+	ROM_LOAD("cieldisk.rom", 0x0000, 0x4000, CRC(bb550b09) SHA1(0274dd9b5096065a7f4ed019101124c9bd1d56b8))
+
+	ROM_REGION(0x4000, "music", 0)
+	ROM_LOAD("exp30mus.rom", 0x0000, 0x4000, CRC(9881b3fd) SHA1(befebc916bfdb5e8057040f0ae82b5517a7750db))
+
+	ROM_REGION(0x4000, "turbo", 0)
+	ROM_LOAD("turbo.rom", 0x0000, 0x4000, CRC(ab528416) SHA1(d468604269ae7664ac739ea9f922a05e14ffa3d1))
+ROM_END
+
+void msx2p_state::expert3t(machine_config &config)
+{
+	// AY8910
+	// FDC: wd2793?, 1 or 2? drives
+	// 4 Cartridge/Expansion slots?
+	// FM/YM2413 built-in
+
+	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom");
+	add_cartridge_slot<1>(config, 1, 0);
+	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 1, 1, 0, 1, "subrom");
+	add_internal_slot(config, MSX_SLOT_MUSIC, "music", 1, 1, 1, 1, "music").set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_ROM, "turbo", 1, 2, 1, 1, "turbo");          /* Turbo hardware needs to be emulated */
+	add_internal_disk_mirrored(config, MSX_SLOT_DISK1_WD2793, "disk", 1, 3, 1, 2, "diskrom");
+	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 2, 0, 4).set_total_size(0x40000);       // 256KB Mapper RAM
+	add_cartridge_slot<2>(config, 3);
+
+	msx_ym2413(config);
+
+	msx2plus(SND_AY8910, config, layout_msx_nocode_1fdd);
+}
+
+/* MSX2+ - Gradiente Expert AC88+ */
+
+ROM_START(expertac)
+	ROM_REGION(0x8000, "mainrom", 0)
+	ROM_LOAD("ac88bios.rom", 0x0000, 0x8000, CRC(9ce0da44) SHA1(1fc2306911ab6e1ebdf7cb8c3c34a7f116414e88))
+
+	ROM_REGION(0x4000, "subrom", 0)
+	ROM_LOAD("ac88ext.rom", 0x0000, 0x4000, CRC(c74c005c) SHA1(d5528825c7eea2cfeadd64db1dbdbe1344478fc6))
+
+	ROM_REGION(0x4000, "diskrom", 0)
+	ROM_LOAD("panadisk.rom", 0x0000, 0x4000, CRC(17fa392b) SHA1(7ed7c55e0359737ac5e68d38cb6903f9e5d7c2b6))
+
+	ROM_REGION(0x4000, "asm", 0)
+	ROM_LOAD("ac88asm.rom", 0x0000, 0x4000, CRC(a8a955ae) SHA1(91e522473a8470511584df3ee5b325ea5e2b81ef))
+
+	ROM_REGION(0x4000, "xbasic", 0)
+	ROM_LOAD("xbasic2.rom", 0x0000, 0x4000, CRC(2825b1a0) SHA1(47370bec7ca1f0615a54eda548b07fbc0c7ef398))
+ROM_END
+
+void msx2p_state::expertac(machine_config &config)
+{
+	// AY8910/YM2149?
+	// FDC: wd2793?, 1 or 2? drives
+	// 2 Cartridge slots?
+
+	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom");
+	add_cartridge_slot<1>(config, 1);
+	add_cartridge_slot<2>(config, 2);
+	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000);   // 64KB Mapper RAM??
+	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "subrom");
+	add_internal_slot(config, MSX_SLOT_ROM, "asm", 3, 1, 1, 1, "asm");
+	add_internal_disk_mirrored(config, MSX_SLOT_DISK1_WD2793, "disk", 3, 2, 1, 2, "diskrom");
+	add_internal_slot(config, MSX_SLOT_ROM, "xbasic", 3, 3, 1, 1, "xbasic");
+
+	msx2plus(SND_AY8910, config, layout_msx_nocode_1fdd);
+}
+
+/* MSX2+ - Gradiente Expert DDX+ */
+
+ROM_START(expertdx)
+	ROM_REGION(0x8000, "mainrom", 0)
+	ROM_LOAD("ddxbios.rom", 0x0000, 0x8000, CRC(e00af3dc) SHA1(5c463dd990582e677c8206f61035a7c54d8c67f0))
+
+	ROM_REGION(0x4000, "subrom", 0)
+	ROM_LOAD("ddxext.rom", 0x0000, 0x4000, CRC(b8ba44d3) SHA1(fe0254cbfc11405b79e7c86c7769bd6322b04995))
+
+	ROM_REGION(0x4000, "diskrom", 0)
+	ROM_LOAD("panadisk.rom", 0x0000, 0x4000, CRC(17fa392b) SHA1(7ed7c55e0359737ac5e68d38cb6903f9e5d7c2b6))
+
+	ROM_REGION(0x4000, "xbasic", 0)
+	ROM_LOAD("xbasic2.rom", 0x0000, 0x4000, CRC(2825b1a0) SHA1(47370bec7ca1f0615a54eda548b07fbc0c7ef398))
+
+	ROM_REGION(0x8000, "kanjirom", 0)
+	ROM_LOAD("kanji.rom", 0x0000, 0x8000, CRC(b4fc574d) SHA1(dcc3a67732aa01c4f2ee8d1ad886444a4dbafe06))
+ROM_END
+
+void msx2p_state::expertdx(machine_config &config)
+{
+	// AY8910/YM2149?
+	// FDC: tc8566af, 1 3.5" DSDD drive?
+	// 2 Cartridge slots?
+
+	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom");
+	add_cartridge_slot<1>(config, 1, 0);
+	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 1, 1, 0, 1, "subrom");
+	add_internal_slot(config, MSX_SLOT_ROM, "xbasic", 1, 2, 1, 1, "xbasic");
+	add_internal_disk_mirrored(config, MSX_SLOT_DISK3_TC8566, "disk", 1, 3, 1, 2, "diskrom");
+	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 2, 0, 4).set_total_size(0x10000);   // 64KB Mapper RAM??
+	add_cartridge_slot<2>(config, 3);
+	/* Kanji? */
+
+	msx2plus(SND_AY8910, config, layout_msx_nocode_1fdd);
+}
+
+/* MSX2+ - Panasonic FS-A1FX */
+
+ROM_START(fsa1fx)
+	ROM_REGION(0x40000, "maincpu", 0)
+	ROM_LOAD("a1fx.ic16", 0, 0x40000, CRC(c0b2d882) SHA1(623cbca109b6410df08ee7062150a6bda4b5d5d4))
+
+	// Kanji rom contents are the first half of the single rom
+//  ROM_REGION(0x20000, "kanji", 0)
+	ROM_REGION(0x40000, "kanji", 0)
+	ROM_LOAD("a1fx.ic16", 0, 0x40000, CRC(c0b2d882) SHA1(623cbca109b6410df08ee7062150a6bda4b5d5d4))
+ROM_END
+
+void msx2p_state::fsa1fx(machine_config &config)
+{
+	// AY8910 (in T9769)
+	// FDC: tc8566af, 1 3.5" DSDD drive
+	// 2 Cartridge slots
+	// T9769(B)
+	// ren-sha turbo slider
+	// pause button
+	// firmware switch
+
+	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "maincpu", 0x30000);
+	add_cartridge_slot<1>(config, 1);
+	add_cartridge_slot<2>(config, 2);
+	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
+	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "maincpu", 0x38000);
+	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "maincpu", 0x28000);
+	add_internal_disk_mirrored(config, MSX_SLOT_DISK3_TC8566, "disk", 3, 2, 1, 2, "maincpu", 0x3c000);
+	add_internal_slot(config, MSX_SLOT_ROM, "firmware", 3, 3, 1, 2, "maincpu", 0x20000);
+
+	msx_matsushita_device &matsushita(MSX_MATSUSHITA(config, "matsushita", 0));
+	matsushita.turbo_callback().set([this] (int state) {
+		// 0 - 5.369317 MHz
+		// 1 - 3.579545 MHz
+		m_maincpu->set_unscaled_clock(m_main_xtal / (state ? 6 : 4));
+	});
+
+	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0xff);
+	set_cold_boot_flags(0xff);
+
+	m_kanji_fsa1fx = true;
+	msx2plus(SND_AY8910, config, layout_msx_jp_1fdd);
+}
+
+/* MSX2+ - Panasonic FS-A1WSX */
+
+ROM_START(fsa1wsx)
+	ROM_REGION(0x8000, "mainrom", 0)
+	ROM_LOAD("a1wsbios.rom", 0x0000, 0x8000, CRC(358ec547) SHA1(f4433752d3bf876bfefb363c749d4d2e08a218b6))
+
+	ROM_REGION(0x4000, "subrom", 0)
+	ROM_LOAD("a1wsext.rom", 0x0000, 0x4000, CRC(b8ba44d3) SHA1(fe0254cbfc11405b79e7c86c7769bd6322b04995))
+
+	ROM_REGION(0x4000, "diskrom", 0)
+	ROM_LOAD("a1wsdisk.rom", 0x0000, 0x4000, CRC(17fa392b) SHA1(7ed7c55e0359737ac5e68d38cb6903f9e5d7c2b6))
+
+	ROM_REGION(0x8000, "kdr", 0)
+	ROM_LOAD("a1wskdr.rom", 0x0000, 0x8000, CRC(b4fc574d) SHA1(dcc3a67732aa01c4f2ee8d1ad886444a4dbafe06))
+
+	ROM_REGION(0x4000, "msxmusic", 0)
+	ROM_LOAD("a1wsmusp.rom", 0x0000, 0x4000, CRC(5c32eb29) SHA1(aad42ba4289b33d8eed225d42cea930b7fc5c228))
+
+	ROM_REGION(0x200000, "firmware", 0)
+	ROM_LOAD("a1wsfirm.rom", 0x000000, 0x200000, CRC(e363595d) SHA1(3330d9b6b76e3c4ccb7cf252496ed15d08b95d3f))
+
+	ROM_REGION(0x40000, "kanji", 0)
+	ROM_LOAD("a1wskfn.rom", 0, 0x40000, CRC(1f6406fb) SHA1(5aff2d9b6efc723bc395b0f96f0adfa83cc54a49))
+ROM_END
+
+void msx2p_state::fsa1wsx(machine_config &config)
+{
+	// AY8910 (in T9769)
+	// FDC: tc8566af, 1 3.5" DSDD drive
+	// 2 Cartridge slots
+	// FM built-in
+	// T9769(C)
+	// ren-sha turbo slider
+	// firmware switch
+	// pause button
+
+	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 0, 2, "mainrom");
+	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 0, 2, 1, 1, "msxmusic").set_ym2413(m_ym2413);
+	add_cartridge_slot<1>(config, 1);
+	add_cartridge_slot<2>(config, 2);
+	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
+	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "subrom");
+	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "kdr");
+	add_internal_disk_mirrored(config, MSX_SLOT_DISK3_TC8566, "disk", 3, 2, 1, 2, "diskrom");
+	add_internal_slot(config, MSX_SLOT_PANASONIC08, "firmware", 3, 3, 0, 4, "firmware");
+
+	msx_matsushita_device &matsushita(MSX_MATSUSHITA(config, "matsushita", 0));
+	matsushita.turbo_callback().set([this] (int state) {
+		// 0 - 5.369317 MHz
+		// 1 - 3.579545 MHz
+		m_maincpu->set_unscaled_clock(m_main_xtal / (state ? 6 : 4));
+	});
+
+	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0xff);
+	set_cold_boot_flags(0xff);
+
+	msx_ym2413(config);
+
+	msx2plus(SND_AY8910, config, layout_msx_jp_1fdd);
+}
+
+/* MSX2+ - Panasonic FS-A1WX */
+
+ROM_START(fsa1wx)
+	ROM_REGION(0x8000, "mainrom", 0)
+	ROM_LOAD("a1wxbios.rom", 0x0000, 0x8000, CRC(19771608) SHA1(e90f80a61d94c617850c415e12ad70ac41e66bb7))
+
+	ROM_REGION(0x4000, "subrom", 0)
+	ROM_LOAD("a1wxext.rom", 0x0000, 0x4000, CRC(b8ba44d3) SHA1(fe0254cbfc11405b79e7c86c7769bd6322b04995))
+
+	ROM_REGION(0x4000, "diskrom", 0)
+	ROM_LOAD("a1wxdisk.rom", 0x0000, 0x4000, CRC(905daa1b) SHA1(bb59c849898d46a23fdbd0cc04ab35088e74a18d))
+
+	ROM_REGION(0x8000, "kdr", 0)
+	ROM_LOAD("a1wxkdr.rom", 0x0000, 0x8000, CRC(a068cba9) SHA1(1ef3956f7f918873fb9b031339bba45d1e5e5878))
+
+	ROM_REGION(0x4000, "msxmusic", 0)
+	ROM_LOAD("a1wxmusp.rom", 0x0000, 0x4000, CRC(456e494e) SHA1(6354ccc5c100b1c558c9395fa8c00784d2e9b0a3))
+
+	ROM_REGION(0x200000, "firmware", 0)
+	ROM_LOAD("a1wxfirm.rom", 0x000000, 0x200000, CRC(283f3250) SHA1(d37ab4bd2bfddd8c97476cbe7347ae581a6f2972))
+
+	ROM_REGION(0x40000, "kanji", 0)
+	ROM_LOAD("a1wxkfn.rom", 0, 0x40000, CRC(1f6406fb) SHA1(5aff2d9b6efc723bc395b0f96f0adfa83cc54a49))
+ROM_END
+
+void msx2p_state::fsa1wx(machine_config &config)
+{
+	// AY8910 (in T9769)
+	// FDC: tc8566af, 1 3.5" DSDD drive
+	// 2 Cartridge slots
+	// FM built-in
+	// MSX Engine T9769A/B
+	// ren-sha turbo slider
+	// firmware switch
+	// pause button
+
+	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 0, 2, "mainrom");
+	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 0, 2, 1, 1, "msxmusic").set_ym2413(m_ym2413);
+	add_cartridge_slot<1>(config, 1);
+	add_cartridge_slot<2>(config, 2);
+	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
+	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "subrom");
+	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "kdr");
+	add_internal_disk_mirrored(config, MSX_SLOT_DISK3_TC8566, "disk", 3, 2, 1, 2, "diskrom");
+	add_internal_slot(config, MSX_SLOT_PANASONIC08, "firmware", 3, 3, 0, 4, "firmware");
+
+	msx_matsushita_device &matsushita(MSX_MATSUSHITA(config, "matsushita", 0));
+	matsushita.turbo_callback().set([this] (int state) {
+		// 0 - 5.369317 MHz
+		// 1 - 3.579545 MHz
+		m_maincpu->set_unscaled_clock(m_main_xtal / (state ? 6 : 4));
+	});
+
+	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0xff);
+	set_cold_boot_flags(0xff);
+
+	msx_ym2413(config);
+
+	msx2plus(SND_AY8910, config, layout_msx_jp_1fdd);
+}
+
+/* MSX2+ - Panasonic FS-A1WX (a) */
+
+ROM_START(fsa1wxa)
+	ROM_REGION(0x8000, "mainrom", 0)
+	ROM_LOAD("a1wxbios.rom", 0x0000, 0x8000, CRC(19771608) SHA1(e90f80a61d94c617850c415e12ad70ac41e66bb7))
+
+	ROM_REGION(0x4000, "subrom", 0)
+	ROM_LOAD("a1wxext.rom", 0x0000, 0x4000, CRC(b8ba44d3) SHA1(fe0254cbfc11405b79e7c86c7769bd6322b04995))
+
+	ROM_REGION(0x4000, "diskrom", 0)
+	ROM_LOAD("a1wxdisk.rom", 0x0000, 0x4000, CRC(2bda0184) SHA1(2a0d228afde36ac7c5d3c2aac9c7c664dd071a8c))
+
+	ROM_REGION(0x8000, "kdr", 0)
+	ROM_LOAD("a1wxkdr.rom", 0x0000, 0x8000, CRC(a068cba9) SHA1(1ef3956f7f918873fb9b031339bba45d1e5e5878))
+
+	ROM_REGION(0x4000, "msxmusic", 0)
+	ROM_LOAD("a1wxmusp.rom", 0x0000, 0x4000, CRC(456e494e) SHA1(6354ccc5c100b1c558c9395fa8c00784d2e9b0a3))
+
+	ROM_REGION(0x200000, "firmware", 0)
+	ROM_LOAD("a1wxfira.rom", 0x000000, 0x200000, CRC(58440a8e) SHA1(8e0d4a77e7d5736e8225c2df4701509363eb230f))
+
+	ROM_REGION(0x40000, "kanji", 0)
+	ROM_LOAD("a1wxkfn.rom", 0, 0x40000, CRC(1f6406fb) SHA1(5aff2d9b6efc723bc395b0f96f0adfa83cc54a49))
+ROM_END
+
+/* MSX2+ - Sanyo Wavy PHC-35J */
+
+ROM_START(phc35j)
+	ROM_REGION(0x8000, "mainrom", 0)
+	ROM_LOAD("35jbios.rom", 0x0000, 0x8000, CRC(358ec547) SHA1(f4433752d3bf876bfefb363c749d4d2e08a218b6))
+
+	ROM_REGION(0x4000, "subrom", 0)
+	ROM_LOAD("35jext.rom", 0x0000, 0x4000, CRC(b8ba44d3) SHA1(fe0254cbfc11405b79e7c86c7769bd6322b04995))
+
+	ROM_REGION(0x8000, "kdr", 0)
+	ROM_LOAD("35jkdr.rom", 0x0000, 0x8000, CRC(b4fc574d) SHA1(dcc3a67732aa01c4f2ee8d1ad886444a4dbafe06))
+
+	ROM_REGION(0x20000, "kanji", 0)
+	ROM_LOAD("35jkfn.rom", 0, 0x20000, CRC(c9651b32) SHA1(84a645becec0a25d3ab7a909cde1b242699a8662))
+ROM_END
+
+void msx2p_state::phc35j(machine_config &config)
+{
+	// AY8910 (in T9769)
+	// FDC: None, 0 drives
+	// 2 Cartridge slots
+	// T9769A
+	// ren-sha turbo slider
+	// pause button
+
+	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom");
+	add_cartridge_slot<1>(config, 1);
+	add_cartridge_slot<2>(config, 2);
+	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
+	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "subrom");
+	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "kdr");
+
+	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0xff);
+	set_cold_boot_flags(0xff);
+	msx2plus(SND_AY8910, config, layout_msx_jp);
+}
+
+/* MSX2+ - Sanyo Wavy PHC-70FD */
+
+ROM_START(phc70fd)
+	ROM_REGION(0x20000, "mainrom", 0)
+	ROM_LOAD("phc-70fd.rom", 0x0000, 0x20000, CRC(d2307ddf) SHA1(b6f2ca2e8a18d6c7cd326cb8d1a1d7d747f23059))
+//  ROM_LOAD("70fdbios.rom", 0x0000, 0x8000, CRC(19771608) SHA1(e90f80a61d94c617850c415e12ad70ac41e66bb7))
+//  ROM_LOAD("70fdext.rom",  0x8000, 0x4000, CRC(b8ba44d3) SHA1(fe0254cbfc11405b79e7c86c7769bd6322b04995))
+//  ROM_LOAD("70fddisk.rom", 0xc000, 0x4000, CRC(db7f1125) SHA1(9efa744be8355675e7bfdd3976bbbfaf85d62e1d))
+//  ROM_LOAD("70fdkdr.rom", 0x10000, 0x8000, CRC(a068cba9) SHA1(1ef3956f7f918873fb9b031339bba45d1e5e5878))
+//  ROM_LOAD("70fdmus.rom", 0x18000, 0x4000, CRC(5c32eb29) SHA1(aad42ba4289b33d8eed225d42cea930b7fc5c228))
+//  ROM_LOAD("70fdbas.rom", 0x1c000, 0x4000, CRC(da7be246) SHA1(22b3191d865010264001b9d896186a9818478a6b))
+
+	ROM_REGION(0x20000, "kanji", 0)
+	ROM_LOAD("70fdkfn.rom", 0, 0x20000, CRC(c9651b32) SHA1(84a645becec0a25d3ab7a909cde1b242699a8662))
+ROM_END
+
+void msx2p_state::phc70fd(machine_config &config)
+{
+	// AY8910 (in T9769)
+	// FDC: tc8566af, 1 3.5" DSDD drive
+	// 2 Cartridge slots
+	// T9769
+	// FM built-in
+	// ren-sha turbo slider
+	// pause button
+
+	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom", 0x10000);
+	add_cartridge_slot<1>(config, 1);
+	add_cartridge_slot<2>(config, 2);
+	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
+	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "mainrom", 0x18000);
+	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "mainrom", 0x8000);
+	add_internal_disk_mirrored(config, MSX_SLOT_DISK3_TC8566, "disk", 3, 2, 1, 2, "mainrom", 0x1c000);
+	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "mainrom", 0x00000).set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_ROM, "basickun", 3, 3, 2, 1, "mainrom", 0x04000);
+
+	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0xff);
+	set_cold_boot_flags(0xff);
+
+	msx_ym2413(config);
+
+	msx2plus(SND_AY8910, config, layout_msx_jp_1fdd);
+}
+
+/* MSX2+ - Sanyo Wavy PHC-70FD2 */
+
+ROM_START(phc70fd2)
+	ROM_REGION(0x20000, "mainrom", 0)
+	ROM_LOAD("70f2bios.rom", 0x0000, 0x8000, CRC(19771608) SHA1(e90f80a61d94c617850c415e12ad70ac41e66bb7))
+
+	ROM_REGION(0x4000, "subrom", 0)
+	ROM_LOAD("70f2ext.rom", 0x0000, 0x4000, CRC(b8ba44d3) SHA1(fe0254cbfc11405b79e7c86c7769bd6322b04995))
+
+	ROM_REGION(0x4000, "diskrom", 0)
+	ROM_LOAD("70f2disk.rom", 0x0000, 0x4000, CRC(db7f1125) SHA1(9efa744be8355675e7bfdd3976bbbfaf85d62e1d))
+
+	ROM_REGION(0x8000, "kdr", 0)
+	ROM_LOAD("70f2kdr.rom", 0x0000, 0x8000, CRC(a068cba9) SHA1(1ef3956f7f918873fb9b031339bba45d1e5e5878))
+
+	ROM_REGION(0x4000, "msxmusic", 0)
+	ROM_LOAD("70f2mus.rom", 0x0000, 0x4000, CRC(5c32eb29) SHA1(aad42ba4289b33d8eed225d42cea930b7fc5c228))
+
+	ROM_REGION(0x4000, "basickun", 0)
+	ROM_LOAD("70f2bas.rom", 0x0000, 0x4000, CRC(da7be246) SHA1(22b3191d865010264001b9d896186a9818478a6b))
+
+	ROM_REGION(0x40000, "kanji", 0)
+	ROM_LOAD("70f2kfn.rom", 0, 0x40000, CRC(9a850db9) SHA1(bcdb4dae303dfe5234f372d70a5e0271d3202c36))
+ROM_END
+
+void msx2p_state::phc70fd2(machine_config &config)
+{
+	// AY8910
+	// FDC: tc8566af, 2 3.5" DSDD drives
+	// 2 Cartridge slots
+	// FM built-in
+	// T9769
+
+	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 2, "mainrom");
+	add_cartridge_slot<1>(config, 1);
+	add_cartridge_slot<2>(config, 2);
+	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
+	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "subrom");
+	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "kdr");
+	add_internal_disk_mirrored(config, MSX_SLOT_DISK3_TC8566_2_DRIVES, "disk", 3, 2, 1, 2, "diskrom");
+	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "msxmusic").set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_ROM, "basickun", 3, 3, 2, 1, "basickun");
+
+	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0xff);
+	set_cold_boot_flags(0xff);
+
+	msx_ym2413(config);
+
+	msx2plus(SND_AY8910, config, layout_msx_jp_2fdd);
+}
+
+/* MSX2+ - Sony HB-F1XDJ */
+
+ROM_START(hbf1xdj)
+	ROM_REGION(0x20000, "mainrom", 0)
+	ROM_LOAD("hb-f1xdj_main.rom", 0x0000, 0x20000, CRC(d89bab74) SHA1(f2a1d326d72d4c70ea214d7883838de8847a82b7))
+
+	ROM_REGION(0x100000, "firmware", 0)
+	ROM_LOAD("f1xjfirm.rom", 0x000000, 0x100000, CRC(77be583f) SHA1(ade0c5ba5574f8114d7079050317099b4519e88f))
+
+	ROM_REGION(0x40000, "kanji", 0)
+	ROM_LOAD("f1xjkfn.rom", 0, 0x40000, CRC(7016dfd0) SHA1(218d91eb6df2823c924d3774a9f455492a10aecb))
+ROM_END
+
+void msx2p_state::hbf1xdj(machine_config &config)
+{
+	// YM2149 (in S-1985 MSX Engine)
+	// FDC: MB89311, 1 3.5" DSDD drive
+	// 2 Cartridge slots
+	// FM built-in
+	// S-1985 MSX Engine
+	// speed controller
+	// pause button
+	// ren-sha turbo
+
+	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 0, 2, "mainrom");
+	add_internal_slot(config, MSX_SLOT_SONY08, "firmware", 0, 3, 0, 4, "firmware");
+	add_cartridge_slot<1>(config, 1);
+	add_cartridge_slot<2>(config, 2);
+	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
+	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "mainrom", 0x8000);
+	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "mainrom", 0x10000);
+	add_internal_disk_mirrored(config, MSX_SLOT_DISK1_WD2793_N, "disk", 3, 2, 1, 2, "mainrom", 0xc000);
+	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "mainrom", 0x18000).set_ym2413(m_ym2413);
+
+	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0x00);
+
+	MSX_S1985(config, "s1985", 0);
+
+	msx_ym2413(config);
+
+	msx2plus(SND_YM2149, config, layout_msx_jp_1fdd);
+}
+
+/* MSX2+ - Sony HB-F1XV */
+
+ROM_START(hbf1xv)
+	ROM_REGION(0x20000, "mainrom", 0)
+	ROM_LOAD("hb-f1xdj_main.rom", 0x0000, 0x20000, CRC(d89bab74) SHA1(f2a1d326d72d4c70ea214d7883838de8847a82b7))
+
+	ROM_REGION(0x100000, "firmware", 0)
+	ROM_LOAD("f1xvfirm.rom", 0x0, 0x100000, CRC(77be583f) SHA1(ade0c5ba5574f8114d7079050317099b4519e88f))
+
+	ROM_REGION(0x40000, "kanji", 0)
+	ROM_LOAD("f1xvkfn.rom", 0, 0x40000, CRC(7016dfd0) SHA1(218d91eb6df2823c924d3774a9f455492a10aecb))
+ROM_END
+
+void msx2p_state::hbf1xv(machine_config &config)
+{
+	// YM2149 (in S-1985 MSX Engine)
+	// FDC: mb89311, 1 3.5" DSDD drives
+	// 2 Cartridge slots
+	// FM built-in
+	// S-1985 MSX Engine
+	// speed controller
+	// pause button
+	// ren-sha turbo
+
+	add_internal_slot(config, MSX_SLOT_ROM, "mainrom", 0, 0, 0, 2, "mainrom");
+	add_internal_slot(config, MSX_SLOT_SONY08, "firmware", 0, 3, 0, 4, "firmware");
+	add_cartridge_slot<1>(config, 1);
+	add_cartridge_slot<2>(config, 2);
+	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x10000).set_unused_bits(0x80);   // 64KB Mapper RAM
+	add_internal_slot(config, MSX_SLOT_ROM, "subrom", 3, 1, 0, 1, "mainrom", 0x8000);
+	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "mainrom", 0x10000);
+	add_internal_disk_mirrored(config, MSX_SLOT_DISK1_WD2793_N, "disk", 3, 2, 1, 2, "mainrom", 0xc000);
+	add_internal_slot(config, MSX_SLOT_MUSIC, "msxmusic", 3, 3, 1, 1, "mainrom", 0x18000).set_ym2413(m_ym2413);
+
+	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0x00);
+
+	MSX_S1985(config, "s1985", 0);
+
+	msx_ym2413(config);
+
+	msx2plus(SND_YM2149, config, layout_msx_jp_1fdd);
+}
+
+/* MSX Turbo-R - Panasonic FS-A1GT */
+
+ROM_START(fsa1gt)
+	ROM_REGION(0x46c000, "maincpu", 0)
+	ROM_LOAD("a1gtbios.rom",  0x0000,   0x8000, CRC(937c8dbb) SHA1(242e73d8284a012b275c0a266844ebbc4269d787))
+	ROM_LOAD("a1gtext.rom",   0x8000,   0x4000, CRC(70aea0fe) SHA1(018d7a5222f28514908fb1b1513286a6558a6d05))
+	ROM_LOAD("a1gtdos.rom",   0xc000,  0x10000, CRC(bb2a0eae) SHA1(4880bf34f1c86fff5456ec2b4cf70d02339e2caa))
+	ROM_LOAD("a1gtkdr.rom",  0x1c000,   0x8000, CRC(eaf0d125) SHA1(5b39c1ccd3a213b78e02927f56a9abc72cd8c28d))
+	ROM_LOAD("a1gtmus.rom",  0x24000,   0x4000, CRC(f5f93437) SHA1(6aea1aef5ec31c1826c22edf580525f93baad425))
+	ROM_LOAD("a1gtopt.rom",  0x28000,   0x4000, CRC(50d11f60) SHA1(b4433a3975c57dd440d6bf12dbd28b2ac1b90ef4))
+	ROM_LOAD("a1gtkfn.rom",  0x2c000,  0x40000, CRC(1f6406fb) SHA1(5aff2d9b6efc723bc395b0f96f0adfa83cc54a49))
+	ROM_LOAD("a1gtfirm.rom", 0x6c000, 0x400000, CRC(feefeadc) SHA1(e779c338eb91a7dea3ff75f3fde76b8af22c4a3a))
+ROM_END
+
+void msx2p_state::fsa1gt(machine_config &config)
+{
+	// AY8910 (in T9769)
+	// FDC: tc8566af, 1 3.5" DSDD drive
+	// 2 Cartridge slots
+	// T9769C + S1990
+	// FM built-in
+	// Microphone
+	// MIDI-in
+	// MIDI-out
+	// firmware switch
+	// pause button
+	// ren-sha turbo slider
+
+	add_internal_slot(config, MSX_SLOT_ROM, "bios", 0, 0, 0, 2, "maincpu");
+	add_internal_slot(config, MSX_SLOT_MUSIC, "mus", 0, 2, 1, 1, "maincpu", 0x24000).set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_ROM, "opt", 0, 3, 1, 1, "maincpu", 0x28000);
+	add_cartridge_slot<1>(config, 1);
+	add_cartridge_slot<2>(config, 2);
+	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x20000);   // 128KB?? Mapper RAM
+	add_internal_slot(config, MSX_SLOT_ROM, "ext", 3, 1, 0, 1, "maincpu", 0x8000);
+	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "maincpu", 0x1c000);
+	add_internal_disk(config, MSX_SLOT_DISK4_TC8566, "dos", 3, 2, 1, 3, "maincpu", 0xc000);
+	add_internal_slot(config, MSX_SLOT_ROM, "firm", 3, 3, 0, 4, "maincpu", 0x6c000);
+	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0x00);
+
+	msx_ym2413(config);
+
+	turbor(SND_AY8910, config, layout_msx_jp_1fdd);
+}
+
+/* MSX Turbo-R - Panasonic FS-A1ST */
+
+ROM_START(fsa1st)
+	ROM_REGION(0x46c000, "maincpu", 0)
+	ROM_LOAD("a1stbios.rom",  0x0000,   0x8000, CRC(77b94ae0) SHA1(f078b5ec56884bfb81481d45c7151418770bff5a))
+	ROM_LOAD("a1stext.rom",   0x8000,   0x4000, CRC(2c2c77a4) SHA1(373412f9c32762de1c3a7e27fc3d80614e0a0c8e))
+	ROM_LOAD("a1stdos.rom",   0xc000,  0x10000, CRC(1fc71407) SHA1(5d2186658adcf4ce0c2d3232384b5712341108e5))
+	ROM_LOAD("a1stkdr.rom",  0x1c000,   0x8000, CRC(eaf0d125) SHA1(5b39c1ccd3a213b78e02927f56a9abc72cd8c28d))
+	ROM_LOAD("a1stmus.rom",  0x24000,   0x4000, CRC(fd7dec41) SHA1(e002a9b426732e6c2d31e548c40cf7c122348ce3))
+	ROM_LOAD("a1stopt.rom",  0x28000,   0x4000, CRC(c6a4a2a1) SHA1(cb06dea7b025745f9d2b87dcf03ded615287ead3))
+	ROM_LOAD("a1stkfn.rom",  0x2c000,  0x40000, CRC(1f6406fb) SHA1(5aff2d9b6efc723bc395b0f96f0adfa83cc54a49))
+	ROM_LOAD("a1stfirm.rom", 0x6c000, 0x400000, CRC(139ac99c) SHA1(c212b11fda13f83dafed688c54d098e7e47ab225))
+ROM_END
+
+void msx2p_state::fsa1st(machine_config &config)
+{
+	// AY8910 (in T9769)
+	// FDC: tc8566af, 1 3.5" DSDD drive
+	// T9769C + S1990
+	// 2 Cartridge slots
+	// FM built-in
+	// microphone
+	// firmware switch
+	// pause button
+	// ren-sha turbo slider
+
+	add_internal_slot(config, MSX_SLOT_ROM, "bios", 0, 0, 0, 2, "maincpu");
+	add_internal_slot(config, MSX_SLOT_MUSIC, "mus", 0, 2, 1, 1, "maincpu", 0x24000).set_ym2413(m_ym2413);
+	add_internal_slot(config, MSX_SLOT_ROM, "opt", 0, 3, 1, 1, "maincpu", 0x28000);
+	add_cartridge_slot<1>(config, 1);
+	add_cartridge_slot<2>(config, 2);
+	add_internal_slot(config, MSX_SLOT_RAM_MM, "ram_mm", 3, 0, 0, 4).set_total_size(0x20000);   // 128KB?? Mapper RAM
+	add_internal_slot(config, MSX_SLOT_ROM, "ext", 3, 1, 0, 1, "maincpu", 0x8000);
+	add_internal_slot(config, MSX_SLOT_ROM, "kdr", 3, 1, 1, 2, "maincpu", 0x1c000);
+	add_internal_disk(config, MSX_SLOT_DISK4_TC8566, "dos", 3, 2, 1, 3, "maincpu", 0xc000);
+	add_internal_slot(config, MSX_SLOT_ROM, "firm", 3, 3, 0, 4, "maincpu", 0x6c000);
+	MSX_SYSTEMFLAGS(config, "sysflags", m_maincpu, 0x00);
+
+	msx_ym2413(config);
+
+	turbor(SND_AY8910, config, layout_msx_jp_1fdd);
+}
+
+} // anonymous namespace
+
+COMP(19??, expert3i,   0,        0,     expert3i,   msx2,     msx2p_state, empty_init, "Ciel", "Expert 3 IDE (MSX2+, Brazil)", MACHINE_NOT_WORKING) // Some hardware not emulated
+COMP(1996, expert3t,   0,        0,     expert3t,   msx2,     msx2p_state, empty_init, "Ciel", "Expert 3 Turbo (MSX2+, Brazil)", MACHINE_NOT_WORKING) // Some hardware not emulated
+COMP(19??, expertac,   0,        0,     expertac,   msx2,     msx2p_state, empty_init, "Gradiente", "Expert AC88+ (MSX2+, Brazil)", MACHINE_NOT_WORKING) // Some hardware not emulated
+COMP(19??, expertdx,   0,        0,     expertdx,   msx2,     msx2p_state, empty_init, "Gradiente", "Expert DDX+ (MSX2+, Brazil)", MACHINE_NOT_WORKING) // Some hardware not emulated
+COMP(1988, fsa1fx,     0,        0,     fsa1fx,     msx2jp,   msx2p_state, empty_init, "Panasonic", "FS-A1FX (MSX2+, Japan)", 0)
+COMP(1989, fsa1wsx,    0,        0,     fsa1wsx,    msx2jp,   msx2p_state, empty_init, "Panasonic", "FS-A1WSX (MSX2+, Japan)", 0)
+COMP(1988, fsa1wx,     fsa1wxa,  0,     fsa1wx,     msx2jp,   msx2p_state, empty_init, "Panasonic", "FS-A1WX / 1st released version (MSX2+, Japan)", 0)
+COMP(1988, fsa1wxa,    0,        0,     fsa1wx,     msx2jp,   msx2p_state, empty_init, "Panasonic", "FS-A1WX / 2nd released version (MSX2+, Japan)", 0)
+COMP(1988, phc70fd,    phc70fd2, 0,     phc70fd,    msx2jp,   msx2p_state, empty_init, "Sanyo", "PHC-70FD / Wavy70FD (MSX2+, Japan)", 0)
+COMP(1989, phc70fd2,   0,        0,     phc70fd2,   msx2jp,   msx2p_state, empty_init, "Sanyo", "PHC-70FD2 / Wavy70FD2 (MSX2+, Japan)", 0)
+COMP(1989, phc35j,     0,        0,     phc35j,     msx2jp,   msx2p_state, empty_init, "Sanyo", "PHC-35J / Wavy35 (MSX2+, Japan)", 0)
+COMP(1988, hbf1xdj,    0,        0,     hbf1xdj,    msx2jp,   msx2p_state, empty_init, "Sony", "HB-F1XDJ (MSX2+, Japan)", 0)
+COMP(1989, hbf1xv,     0,        0,     hbf1xv,     msx2jp,   msx2p_state, empty_init, "Sony", "HB-F1XV (MSX2+, Japan)", 0)
+
+/* MSX Turbo-R */
+/* Temporary placeholders, Turbo-R hardware is not supported yet */
+COMP(1991, fsa1gt,     0,        0,     fsa1gt,     msx2jp,   msx2p_state, empty_init, "Panasonic", "FS-A1GT (MSX Turbo-R, Japan)", MACHINE_NOT_WORKING)
+COMP(1991, fsa1st,     0,        0,     fsa1st,     msx2jp,   msx2p_state, empty_init, "Panasonic", "FS-A1ST (MSX Turbo-R, Japan)", MACHINE_NOT_WORKING)


### PR DESCRIPTION
- Move MSX2+ machines to msx/msx2p.cpp.
- Add support for Kanji level 2 I/O ports.
- Add support for MSX2+ boot flags register.
- Hook up msx2p_cart and msxr_cart software lists.