### PR TITLE
trs/coco.cpp: Fix light gun offset

### DIFF
--- a/src/mame/trs/coco.cpp
+++ b/src/mame/trs/coco.cpp
@@ -863,7 +863,7 @@ void coco_state::diecom_lightgun_clock()
 	/* while in full state 15, prepare to check next video frame for a hit */
 	if (m_dclg_state == 15)
 	{
-		int dclg_vpos = m_diecom_lightgun.input(sel2() ? 1 : 0, 1) - 12;
+		int dclg_vpos = m_diecom_lightgun.input(sel2() ? 1 : 0, 1) + 12;
 		m_dclg_timer = m_diecom_lightgun.input(sel2() ? 1 : 0, 0);
 		int horizontal_pixel = ((m_dclg_timer - 105.) / (420. - 110.0)) * (639.0 - 0.0) + 0.0;
 		attotime dclg_time = m_screen->time_until_pos(dclg_vpos, horizontal_pixel);


### PR DESCRIPTION
Changed offset to align MAME's light gun cursor with what the games expect. I believe this fell out of adjustment with the recent MC6847 changes.