### PR TITLE
konami/konamigv: Remove unused inputs from Tokimeki Memorial Oshiete Your Heart games

### DIFF
--- a/src/mame/konami/konamigv.cpp
+++ b/src/mame/konami/konamigv.cpp
@@ -1139,8 +1139,15 @@ void tokimeki_state::tokimeki_device_check_w(int state)
 static INPUT_PORTS_START( tmosh )
 	PORT_INCLUDE( konamigv )
 
+	PORT_MODIFY("P1")
+	PORT_BIT( 0xffffc3e0, IP_ACTIVE_LOW, IPT_UNUSED )
+
 	PORT_MODIFY("P2")
+	PORT_BIT( 0xfffffbff, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x00000400, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_CUSTOM_MEMBER(tokimeki_state, tokimeki_device_check_r)
+
+	PORT_MODIFY("P3_P4")
+	PORT_BIT( 0xffffffff, IP_ACTIVE_LOW, IPT_UNUSED )
 
 	PORT_MODIFY("EEPROMOUT")
 	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_OUTPUT ) PORT_WRITE_LINE_MEMBER(tokimeki_state, tokimeki_device_check_w)


### PR DESCRIPTION
Clean up input keybinds for these games.

Control panel: https://twitter.com/BEEP_SHOP/status/1759432324473835546

I/O test
![0007](https://github.com/mamedev/mame/assets/63495610/a1580418-6b34-43c9-a860-020500796f6b)
