### PR TITLE
midway/williams.cpp, wmg.cpp: Various cleanups

### DIFF
--- a/src/mame/midway/williams.cpp
+++ b/src/mame/midway/williams.cpp
@@ -500,9 +500,6 @@ Reference videos: https://www.youtube.com/watch?v=R5OeC6Wc_yI
 #include "speaker.h"
 
 
-#define MASTER_CLOCK        (XTAL(12'000'000))
-#define SOUND_CLOCK         (XTAL(3'579'545))
-
 
 
 /*************************************
@@ -513,7 +510,7 @@ Reference videos: https://www.youtube.com/watch?v=R5OeC6Wc_yI
 
 void defender_state::main_map(address_map &map)
 {
-	map(0x0000, 0xbfff).ram().share("videoram");
+	map(0x0000, 0xbfff).ram().share(m_videoram);
 	map(0xc000, 0xcfff).m(m_bankc000, FUNC(address_map_bank_device::amap8));
 	map(0xd000, 0xdfff).w(FUNC(defender_state::bank_select_w));
 	map(0xd000, 0xffff).rom();
@@ -521,7 +518,7 @@ void defender_state::main_map(address_map &map)
 
 void defender_state::bankc000_map(address_map &map)
 {
-	map(0x0000, 0x000f).mirror(0x03e0).writeonly().share("paletteram");
+	map(0x0000, 0x000f).mirror(0x03e0).writeonly().share(m_paletteram);
 	map(0x03ff, 0x03ff).w(FUNC(defender_state::watchdog_reset_w));
 	map(0x0010, 0x001f).mirror(0x03e0).w(FUNC(defender_state::video_control_w));
 	map(0x0400, 0x04ff).mirror(0x0300).ram().w(FUNC(defender_state::cmos_w)).share("nvram");
@@ -554,9 +551,10 @@ void mayday_state::main_map(address_map &map)
 
 void williams_state::main_map(address_map &map)
 {
-	map(0x0000, 0xbfff).ram().share("videoram");
-	map(0x0000, 0x8fff).bankr("mainbank");
-	map(0xc000, 0xc00f).mirror(0x03f0).writeonly().share("paletteram");
+	map(0x0000, 0xbfff).ram().share(m_videoram);
+	map(0x0000, 0x8fff).view(m_rom_view);
+	m_rom_view[0](0x0000, 0x8fff).rom().region("maincpu", 0x00000);
+	map(0xc000, 0xc00f).mirror(0x03f0).writeonly().share(m_paletteram);
 	map(0xc804, 0xc807).mirror(0x00f0).rw(m_pia[0], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0xc80c, 0xc80f).mirror(0x00f0).rw(m_pia[1], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0xc900, 0xc9ff).w(FUNC(williams_state::vram_select_w));
@@ -612,10 +610,11 @@ void spdball_state::main_map(address_map &map)
 
 void blaster_state::main_map(address_map &map)
 {
-	map(0x0000, 0xbfff).ram().share("videoram");
-	map(0x0000, 0x3fff).bankr("mainbank");
-	map(0x4000, 0x8fff).bankr("blaster_bankb");
-	map(0xc000, 0xc00f).mirror(0x03f0).writeonly().share("paletteram");
+	map(0x0000, 0xbfff).ram().share(m_videoram);
+	map(0x0000, 0x8fff).view(m_rom_view);
+	m_rom_view[0](0x0000, 0x3fff).bankr(m_mainbank);
+	m_rom_view[0](0x4000, 0x8fff).rom().region("maincpu", 0x04000);
+	map(0xc000, 0xc00f).mirror(0x03f0).writeonly().share(m_paletteram);
 	map(0xc804, 0xc807).mirror(0x00f0).rw(m_pia[0], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0xc80c, 0xc80f).mirror(0x00f0).rw(m_pia[1], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0xc900, 0xc93f).w(FUNC(blaster_state::vram_select_w));
@@ -639,10 +638,12 @@ void blaster_state::main_map(address_map &map)
 
 void williams2_state::common_map(address_map &map)
 {
-	map(0x0000, 0xbfff).ram().share("videoram");
-	map(0x0000, 0x7fff).bankr("mainbank");
-	map(0x8000, 0x87ff).m(m_bank8000, FUNC(address_map_bank_device::amap8));
-	map(0xc000, 0xc7ff).ram().w(FUNC(williams2_state::tileram_w)).share("williams2_tile");
+	map(0x0000, 0xbfff).ram().share(m_videoram);
+	map(0x0000, 0x7fff).view(m_rom_view);
+	m_rom_view[0](0x0000, 0x7fff).bankr(m_mainbank);
+	map(0x8000, 0x87ff).view(m_palette_view);
+	m_palette_view[0](0x8000, 0x87ff).ram().w(FUNC(williams2_state::paletteram_w)).share(m_paletteram);
+	map(0xc000, 0xc7ff).ram().w(FUNC(williams2_state::tileram_w)).share(m_tileram);
 	map(0xc800, 0xc87f).w(FUNC(williams2_state::bank_select_w));
 	map(0xc880, 0xc887).mirror(0x0078).w(FUNC(williams2_state::blitter_w));
 	map(0xc900, 0xc97f).w(FUNC(williams2_state::watchdog_reset_w));
@@ -657,12 +658,6 @@ void williams2_state::common_map(address_map &map)
 	map(0xcba0, 0xcbbf).w(FUNC(williams2_state::blit_window_enable_w));
 	map(0xcbe0, 0xcbef).r(FUNC(williams2_state::video_counter_r));
 	map(0xcc00, 0xcfff).ram().w(FUNC(williams2_state::cmos_w)).share("nvram");
-}
-
-void williams2_state::bank8000_map(address_map &map)
-{
-	map(0x0000, 0x07ff).bankrw("vram8000");
-	map(0x0800, 0x0fff).ram().w(FUNC(williams2_state::paletteram_w)).share("paletteram");
 }
 
 // mysticm and inferno: D000-DFFF is RAM
@@ -1532,7 +1527,7 @@ static const gfx_layout williams2_layout =
 
 
 static GFXDECODE_START( gfx_williams2 )
-	GFXDECODE_ENTRY( "gfx1", 0, williams2_layout, 0, 64 )
+	GFXDECODE_ENTRY( "tiles", 0, williams2_layout, 0, 64 )
 GFXDECODE_END
 
 
@@ -1542,6 +1537,9 @@ GFXDECODE_END
  *  Machine driver
  *
  *************************************/
+
+static constexpr XTAL MASTER_CLOCK = (XTAL(12'000'000));
+static constexpr XTAL SOUND_CLOCK = (XTAL(3'579'545));
 
 void williams_state::williams_base(machine_config &config)
 {
@@ -1818,8 +1816,6 @@ void williams2_state::williams2_base(machine_config &config)
 
 	M6808(config, m_soundcpu, MASTER_CLOCK/3); // yes, this is different from the older games
 	m_soundcpu->set_addrmap(AS_PROGRAM, &williams2_state::sound_map);
-
-	ADDRESS_MAP_BANK(config, "bank8000").set_map(&williams2_state::bank8000_map).set_options(ENDIANNESS_BIG, 8, 12, 0x800);
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0); // 5114 + battery
 
@@ -2419,10 +2415,10 @@ It appears to use the sound ROM from Defender.
 
 */
 ROM_START( conquest )
-	ROM_REGION( 0x19000, "maincpu", ROMREGION_ERASE00 )
+	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD( "conquest_a.bin", 0x00000, 0x4000, CRC(a384f4a2) SHA1(819df35281216b8be2ba066602fc7d19a860e69e) )
 	ROM_LOAD( "conquest_b.bin", 0x0e000, 0x1000, CRC(9aab5516) SHA1(a71ce8f24fd7ffda8800d1af8c164085b0e2ec0a) )
 	ROM_RELOAD(                 0x0f000, 0x1000 )
-	ROM_LOAD( "conquest_a.bin", 0x10000, 0x4000, CRC(a384f4a2) SHA1(819df35281216b8be2ba066602fc7d19a860e69e) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "video_sound_rom_1.ic12", 0xf800, 0x0800, CRC(fefd5b48) SHA1(ceb0d18483f0691978c604db94417e6941ad7ff2) )
@@ -2499,19 +2495,19 @@ Wire W1 & W3 with Zero Ohm resistors for 2732 ROMs
 
 */
 ROM_START( stargate ) // "B" ROMs labeled 3002-13 through 3002-24, identical data
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "stargate_rom_1-a_3002-1.e4",   0x00000, 0x1000, CRC(88824d18) SHA1(f003a5a9319c4eb8991fa2aae3f10c72d6b8e81a) )
+	ROM_LOAD( "stargate_rom_2-a_3002-2.c4",   0x01000, 0x1000, CRC(afc614c5) SHA1(087c6da93318e8dc922d3d22e0a2af7b9759701c) )
+	ROM_LOAD( "stargate_rom_3-a_3002-3.a4",   0x02000, 0x1000, CRC(15077a9d) SHA1(7badb4318b208f49d7fa65e915d0aa22a1e37915) )
+	ROM_LOAD( "stargate_rom_4-a_3002-4.e5",   0x03000, 0x1000, CRC(a8b4bf0f) SHA1(6b4d47c2899fe9f14f9dab5928499f12078c437d) )
+	ROM_LOAD( "stargate_rom_5-a_3002-5.c5",   0x04000, 0x1000, CRC(2d306074) SHA1(54f871983699113e31bb756d4ca885c26c2d66b4) )
+	ROM_LOAD( "stargate_rom_6-a_3002-6.a5",   0x05000, 0x1000, CRC(53598dde) SHA1(54b02d944caf95283c9b6f0160e75ea8c4ccc97b) )
+	ROM_LOAD( "stargate_rom_7-a_3002-7.e6",   0x06000, 0x1000, CRC(23606060) SHA1(a487ffcd4920d1056b87469735f7e1002f6a2e49) )
+	ROM_LOAD( "stargate_rom_8-a_3002-8.c6",   0x07000, 0x1000, CRC(4ec490c7) SHA1(8726ebaf048db9608dfe365bf434ed5ca9452db7) )
+	ROM_LOAD( "stargate_rom_9-a_3002-9.a6",   0x08000, 0x1000, CRC(88187b64) SHA1(efacc4a6d4b2af9a236c9d520de6d605c79cc5a8) )
 	ROM_LOAD( "stargate_rom_10-a_3002-10.a7", 0x0d000, 0x1000, CRC(60b07ff7) SHA1(ba833f48ddfc1bd04ddb41b1d1c840d66ee7da30) )
 	ROM_LOAD( "stargate_rom_11-a_3002-11.c7", 0x0e000, 0x1000, CRC(7d2c5daf) SHA1(6ca39f493eb8b370154ad46ef01976d352c929e1) )
 	ROM_LOAD( "stargate_rom_12-a_3002-12.e7", 0x0f000, 0x1000, CRC(a0396670) SHA1(c46872550e0ca031453c6513f8f0448ecc9b5572) )
-	ROM_LOAD( "stargate_rom_1-a_3002-1.e4",   0x10000, 0x1000, CRC(88824d18) SHA1(f003a5a9319c4eb8991fa2aae3f10c72d6b8e81a) )
-	ROM_LOAD( "stargate_rom_2-a_3002-2.c4",   0x11000, 0x1000, CRC(afc614c5) SHA1(087c6da93318e8dc922d3d22e0a2af7b9759701c) )
-	ROM_LOAD( "stargate_rom_3-a_3002-3.a4",   0x12000, 0x1000, CRC(15077a9d) SHA1(7badb4318b208f49d7fa65e915d0aa22a1e37915) )
-	ROM_LOAD( "stargate_rom_4-a_3002-4.e5",   0x13000, 0x1000, CRC(a8b4bf0f) SHA1(6b4d47c2899fe9f14f9dab5928499f12078c437d) )
-	ROM_LOAD( "stargate_rom_5-a_3002-5.c5",   0x14000, 0x1000, CRC(2d306074) SHA1(54f871983699113e31bb756d4ca885c26c2d66b4) )
-	ROM_LOAD( "stargate_rom_6-a_3002-6.a5",   0x15000, 0x1000, CRC(53598dde) SHA1(54b02d944caf95283c9b6f0160e75ea8c4ccc97b) )
-	ROM_LOAD( "stargate_rom_7-a_3002-7.e6",   0x16000, 0x1000, CRC(23606060) SHA1(a487ffcd4920d1056b87469735f7e1002f6a2e49) )
-	ROM_LOAD( "stargate_rom_8-a_3002-8.c6",   0x17000, 0x1000, CRC(4ec490c7) SHA1(8726ebaf048db9608dfe365bf434ed5ca9452db7) )
-	ROM_LOAD( "stargate_rom_9-a_3002-9.a6",   0x18000, 0x1000, CRC(88187b64) SHA1(efacc4a6d4b2af9a236c9d520de6d605c79cc5a8) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "video_sound_rom_2_std_744.ic12", 0xf800, 0x0800, CRC(2fcf6c4d) SHA1(9c4334ac3ff15d94001b22fc367af40f9deb7d57) ) // P/N A-5342-09809
@@ -2628,19 +2624,19 @@ Wired W1 & W3 with Zero Ohm resistors for 2732 ROMs
 
 */
 ROM_START( robotron ) // Solid Blue labels, "B" type ROMs labeled 3005-13 through 3005-24
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "2084_rom_1b_3005-13.e4",  0x00000, 0x1000, CRC(66c7d3ef) SHA1(f6d60e26c209c1df2cc01ac07ad5559daa1b7118) ) // == 2084_rom_1b_3005-1.e4
+	ROM_LOAD( "2084_rom_2b_3005-14.c4",  0x01000, 0x1000, CRC(5bc6c614) SHA1(4d6e82bc29f49100f7751ccfc6a9ff35695b84b3) ) // == 2084_rom_2b_3005-2.c4
+	ROM_LOAD( "2084_rom_3b_3005-15.a4",  0x02000, 0x1000, CRC(e99a82be) SHA1(06a8c8dd0b4726eb7f0bb0e89c8533931d75fc1c) )
+	ROM_LOAD( "2084_rom_4b_3005-16.e5",  0x03000, 0x1000, CRC(afb1c561) SHA1(aaf89c19fd8f4e8750717169eb1af476aef38a5e) )
+	ROM_LOAD( "2084_rom_5b_3005-17.c5",  0x04000, 0x1000, CRC(62691e77) SHA1(79b4680ce19bd28882ae823f0e7b293af17cbb91) )
+	ROM_LOAD( "2084_rom_6b_3005-18.a5",  0x05000, 0x1000, CRC(bd2c853d) SHA1(f76ec5432a7939b33a27be1c6855e2dbe6d9fdc8) )
+	ROM_LOAD( "2084_rom_7b_3005-19.e6",  0x06000, 0x1000, CRC(49ac400c) SHA1(06eae5138254723819a5e93cfd9e9f3285fcddf5) ) // == 2084_rom_7b_3005-7.e6
+	ROM_LOAD( "2084_rom_8b_3005-20.c6",  0x07000, 0x1000, CRC(3a96e88c) SHA1(7ae38a609ed9a6f62ca003cab719740ed7651b7c) ) // == 2084_rom_8b_3005-8.c6
+	ROM_LOAD( "2084_rom_9b_3005-21.a6",  0x08000, 0x1000, CRC(b124367b) SHA1(fd9d75b866f0ebbb723f84889337e6814496a103) ) // == 2084_rom_9b_3005-9.a6
 	ROM_LOAD( "2084_rom_10b_3005-22.a7", 0x0d000, 0x1000, CRC(13797024) SHA1(d426a50e75dabe936de643c83a548da5e399331c) )
 	ROM_LOAD( "2084_rom_11b_3005-23.c7", 0x0e000, 0x1000, CRC(7e3c1b87) SHA1(f8c6cbe3688f256f41a121255fc08f575f6a4b4f) )
 	ROM_LOAD( "2084_rom_12b_3005-24.e7", 0x0f000, 0x1000, CRC(645d543e) SHA1(fad7cea868ebf17347c4bc5193d647bbd8f9517b) )
-	ROM_LOAD( "2084_rom_1b_3005-13.e4",  0x10000, 0x1000, CRC(66c7d3ef) SHA1(f6d60e26c209c1df2cc01ac07ad5559daa1b7118) ) // == 2084_rom_1b_3005-1.e4
-	ROM_LOAD( "2084_rom_2b_3005-14.c4",  0x11000, 0x1000, CRC(5bc6c614) SHA1(4d6e82bc29f49100f7751ccfc6a9ff35695b84b3) ) // == 2084_rom_2b_3005-2.c4
-	ROM_LOAD( "2084_rom_3b_3005-15.a4",  0x12000, 0x1000, CRC(e99a82be) SHA1(06a8c8dd0b4726eb7f0bb0e89c8533931d75fc1c) )
-	ROM_LOAD( "2084_rom_4b_3005-16.e5",  0x13000, 0x1000, CRC(afb1c561) SHA1(aaf89c19fd8f4e8750717169eb1af476aef38a5e) )
-	ROM_LOAD( "2084_rom_5b_3005-17.c5",  0x14000, 0x1000, CRC(62691e77) SHA1(79b4680ce19bd28882ae823f0e7b293af17cbb91) )
-	ROM_LOAD( "2084_rom_6b_3005-18.a5",  0x15000, 0x1000, CRC(bd2c853d) SHA1(f76ec5432a7939b33a27be1c6855e2dbe6d9fdc8) )
-	ROM_LOAD( "2084_rom_7b_3005-19.e6",  0x16000, 0x1000, CRC(49ac400c) SHA1(06eae5138254723819a5e93cfd9e9f3285fcddf5) ) // == 2084_rom_7b_3005-7.e6
-	ROM_LOAD( "2084_rom_8b_3005-20.c6",  0x17000, 0x1000, CRC(3a96e88c) SHA1(7ae38a609ed9a6f62ca003cab719740ed7651b7c) ) // == 2084_rom_8b_3005-8.c6
-	ROM_LOAD( "2084_rom_9b_3005-21.a6",  0x18000, 0x1000, CRC(b124367b) SHA1(fd9d75b866f0ebbb723f84889337e6814496a103) ) // == 2084_rom_9b_3005-9.a6
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "video_sound_rom_3_std_767.ic12", 0xf000, 0x1000, CRC(c56c1d28) SHA1(15afefef11bfc3ab78f61ab046701db78d160ec3) ) // P/N A-5342-09910
@@ -2651,19 +2647,19 @@ ROM_START( robotron ) // Solid Blue labels, "B" type ROMs labeled 3005-13 throug
 ROM_END
 
 ROM_START( robotronyo ) // Yellow label / Red stripe & Black print or Yellow label / Red stripe & Green print "B" type ROMs numbered 3005-13 through 3005-24
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "2084_rom_1b_3005-1.e4",   0x00000, 0x1000, CRC(66c7d3ef) SHA1(f6d60e26c209c1df2cc01ac07ad5559daa1b7118) )
+	ROM_LOAD( "2084_rom_2b_3005-2.c4",   0x01000, 0x1000, CRC(5bc6c614) SHA1(4d6e82bc29f49100f7751ccfc6a9ff35695b84b3) )
+	ROM_LOAD( "2084_rom_3b_3005-3.a4",   0x02000, 0x1000, CRC(67a369bc) SHA1(5a912d485e686de5e3175d3fc0e5daad36f4b836) )
+	ROM_LOAD( "2084_rom_4b_3005-4.e5",   0x03000, 0x1000, CRC(b0de677a) SHA1(02013e00513dd74e878a01791cbcca92712e2c80) )
+	ROM_LOAD( "2084_rom_5b_3005-5.c5",   0x04000, 0x1000, CRC(24726007) SHA1(8b4ed881f64e3ce73ac1a9ae2c184721c1ab37cc) )
+	ROM_LOAD( "2084_rom_6b_3005-6.a5",   0x05000, 0x1000, CRC(028181a6) SHA1(41c4d9ece2ae8a103b7151fc4ff576796303318d) )
+	ROM_LOAD( "2084_rom_7b_3005-7.e6",   0x06000, 0x1000, CRC(4dfcceae) SHA1(46fe1b1162d6054eb502852d065fc2e8c694b09d) )
+	ROM_LOAD( "2084_rom_8b_3005-8.c6",   0x07000, 0x1000, CRC(3a96e88c) SHA1(7ae38a609ed9a6f62ca003cab719740ed7651b7c) )
+	ROM_LOAD( "2084_rom_9b_3005-9.a6",   0x08000, 0x1000, CRC(b124367b) SHA1(fd9d75b866f0ebbb723f84889337e6814496a103) )
 	ROM_LOAD( "2084_rom_10b_3005-10.a7", 0x0d000, 0x1000, CRC(4a9d5f52) SHA1(d5ae801e60ed829e7ef5c54a18aefca54eae827f) ) // originally printed as "A" ROMs, the A is overwitten with "B"
 	ROM_LOAD( "2084_rom_11b_3005-11.c7", 0x0e000, 0x1000, CRC(2afc5e7f) SHA1(f3405be9ad2287f3921e7dbd9c5313c91fa7f8d6) )
 	ROM_LOAD( "2084_rom_12b_3005-12.e7", 0x0f000, 0x1000, CRC(45da9202) SHA1(81b3b2a72a3c871e8d7b9348056622c90a20d876) )
-	ROM_LOAD( "2084_rom_1b_3005-1.e4",   0x10000, 0x1000, CRC(66c7d3ef) SHA1(f6d60e26c209c1df2cc01ac07ad5559daa1b7118) )
-	ROM_LOAD( "2084_rom_2b_3005-2.c4",   0x11000, 0x1000, CRC(5bc6c614) SHA1(4d6e82bc29f49100f7751ccfc6a9ff35695b84b3) )
-	ROM_LOAD( "2084_rom_3b_3005-3.a4",   0x12000, 0x1000, CRC(67a369bc) SHA1(5a912d485e686de5e3175d3fc0e5daad36f4b836) )
-	ROM_LOAD( "2084_rom_4b_3005-4.e5",   0x13000, 0x1000, CRC(b0de677a) SHA1(02013e00513dd74e878a01791cbcca92712e2c80) )
-	ROM_LOAD( "2084_rom_5b_3005-5.c5",   0x14000, 0x1000, CRC(24726007) SHA1(8b4ed881f64e3ce73ac1a9ae2c184721c1ab37cc) )
-	ROM_LOAD( "2084_rom_6b_3005-6.a5",   0x15000, 0x1000, CRC(028181a6) SHA1(41c4d9ece2ae8a103b7151fc4ff576796303318d) )
-	ROM_LOAD( "2084_rom_7b_3005-7.e6",   0x16000, 0x1000, CRC(4dfcceae) SHA1(46fe1b1162d6054eb502852d065fc2e8c694b09d) )
-	ROM_LOAD( "2084_rom_8b_3005-8.c6",   0x17000, 0x1000, CRC(3a96e88c) SHA1(7ae38a609ed9a6f62ca003cab719740ed7651b7c) )
-	ROM_LOAD( "2084_rom_9b_3005-9.a6",   0x18000, 0x1000, CRC(b124367b) SHA1(fd9d75b866f0ebbb723f84889337e6814496a103) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "video_sound_rom_3_std_767.ic12", 0xf000, 0x1000, CRC(c56c1d28) SHA1(15afefef11bfc3ab78f61ab046701db78d160ec3) ) // P/N A-5342-09910
@@ -2674,19 +2670,19 @@ ROM_START( robotronyo ) // Yellow label / Red stripe & Black print or Yellow lab
 ROM_END
 
 ROM_START( robotronun )
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "roboun11.1b",  0x00000, 0x1000, CRC(66c7d3ef) SHA1(f6d60e26c209c1df2cc01ac07ad5559daa1b7118) )
+	ROM_LOAD( "roboun11.2b",  0x01000, 0x1000, CRC(5bc6c614) SHA1(4d6e82bc29f49100f7751ccfc6a9ff35695b84b3) )
+	ROM_LOAD( "roboun11.3b",  0x02000, 0x1000, CRC(e99a82be) SHA1(06a8c8dd0b4726eb7f0bb0e89c8533931d75fc1c) )
+	ROM_LOAD( "roboun11.4b",  0x03000, 0x1000, CRC(afb1c561) SHA1(aaf89c19fd8f4e8750717169eb1af476aef38a5e) )
+	ROM_LOAD( "roboun11.5b",  0x04000, 0x1000, CRC(62691e77) SHA1(79b4680ce19bd28882ae823f0e7b293af17cbb91) )
+	ROM_LOAD( "roboun11.6b",  0x05000, 0x1000, CRC(bd2c853d) SHA1(f76ec5432a7939b33a27be1c6855e2dbe6d9fdc8) )
+	ROM_LOAD( "roboun11.7b",  0x06000, 0x1000, CRC(8981a43b) SHA1(8ecab99093d42cb66e177dfa7cf7e352667930ca) ) //
+	ROM_LOAD( "roboun11.8b",  0x07000, 0x1000, CRC(3a96e88c) SHA1(7ae38a609ed9a6f62ca003cab719740ed7651b7c) )
+	ROM_LOAD( "roboun11.9b",  0x08000, 0x1000, CRC(b124367b) SHA1(fd9d75b866f0ebbb723f84889337e6814496a103) )
 	ROM_LOAD( "roboun11.10b", 0x0d000, 0x1000, CRC(13797024) SHA1(d426a50e75dabe936de643c83a548da5e399331c) )
 	ROM_LOAD( "roboun11.11b", 0x0e000, 0x1000, CRC(7e3c1b87) SHA1(f8c6cbe3688f256f41a121255fc08f575f6a4b4f) )
 	ROM_LOAD( "roboun11.12b", 0x0f000, 0x1000, CRC(645d543e) SHA1(fad7cea868ebf17347c4bc5193d647bbd8f9517b) )
-	ROM_LOAD( "roboun11.1b",  0x10000, 0x1000, CRC(66c7d3ef) SHA1(f6d60e26c209c1df2cc01ac07ad5559daa1b7118) )
-	ROM_LOAD( "roboun11.2b",  0x11000, 0x1000, CRC(5bc6c614) SHA1(4d6e82bc29f49100f7751ccfc6a9ff35695b84b3) )
-	ROM_LOAD( "roboun11.3b",  0x12000, 0x1000, CRC(e99a82be) SHA1(06a8c8dd0b4726eb7f0bb0e89c8533931d75fc1c) )
-	ROM_LOAD( "roboun11.4b",  0x13000, 0x1000, CRC(afb1c561) SHA1(aaf89c19fd8f4e8750717169eb1af476aef38a5e) )
-	ROM_LOAD( "roboun11.5b",  0x14000, 0x1000, CRC(62691e77) SHA1(79b4680ce19bd28882ae823f0e7b293af17cbb91) )
-	ROM_LOAD( "roboun11.6b",  0x15000, 0x1000, CRC(bd2c853d) SHA1(f76ec5432a7939b33a27be1c6855e2dbe6d9fdc8) )
-	ROM_LOAD( "roboun11.7b",  0x16000, 0x1000, CRC(8981a43b) SHA1(8ecab99093d42cb66e177dfa7cf7e352667930ca) ) //
-	ROM_LOAD( "roboun11.8b",  0x17000, 0x1000, CRC(3a96e88c) SHA1(7ae38a609ed9a6f62ca003cab719740ed7651b7c) )
-	ROM_LOAD( "roboun11.9b",  0x18000, 0x1000, CRC(b124367b) SHA1(fd9d75b866f0ebbb723f84889337e6814496a103) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "video_sound_rom_3_std_767.ic12", 0xf000, 0x1000, CRC(c56c1d28) SHA1(15afefef11bfc3ab78f61ab046701db78d160ec3) ) // P/N A-5342-09910
@@ -2697,19 +2693,19 @@ ROM_START( robotronun )
 ROM_END
 
 ROM_START( robotron87 ) // Patch by Christian Gingras in 1987 fixing 7 bugs, AKA "Shot in the corner" bug fix
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "2084_rom_1b_3005-13.e4",  0x00000, 0x1000, CRC(66c7d3ef) SHA1(f6d60e26c209c1df2cc01ac07ad5559daa1b7118) )
+	ROM_LOAD( "2084_rom_2b_3005-14.c4",  0x01000, 0x1000, CRC(5bc6c614) SHA1(4d6e82bc29f49100f7751ccfc6a9ff35695b84b3) )
+	ROM_LOAD( "2084_rom_3b_3005-15.a4",  0x02000, 0x1000, CRC(e99a82be) SHA1(06a8c8dd0b4726eb7f0bb0e89c8533931d75fc1c) )
+	ROM_LOAD( "2084_rom_4b_3005-16.e5",  0x03000, 0x1000, CRC(afb1c561) SHA1(aaf89c19fd8f4e8750717169eb1af476aef38a5e) )
+	ROM_LOAD( "fixrobo_rom_5b.c5",       0x04000, 0x1000, CRC(827cb5c9) SHA1(1732d16cd88e0662f1cffce1aeda5c8aa8c31338) ) // fixes the enforcer explosion “reset” bug
+	ROM_LOAD( "2084_rom_6b_3005-18.a5",  0x05000, 0x1000, CRC(bd2c853d) SHA1(f76ec5432a7939b33a27be1c6855e2dbe6d9fdc8) )
+	ROM_LOAD( "2084_rom_7b_3005-19.e6",  0x06000, 0x1000, CRC(49ac400c) SHA1(06eae5138254723819a5e93cfd9e9f3285fcddf5) )
+	ROM_LOAD( "2084_rom_8b_3005-20.c6",  0x07000, 0x1000, CRC(3a96e88c) SHA1(7ae38a609ed9a6f62ca003cab719740ed7651b7c) )
+	ROM_LOAD( "2084_rom_9b_3005-21.a6",  0x08000, 0x1000, CRC(b124367b) SHA1(fd9d75b866f0ebbb723f84889337e6814496a103) )
 	ROM_LOAD( "2084_rom_10b_3005-22.a7", 0x0d000, 0x1000, CRC(13797024) SHA1(d426a50e75dabe936de643c83a548da5e399331c) )
 	ROM_LOAD( "fixrobo_rom_11b.c7",      0x0e000, 0x1000, CRC(e83a2eda) SHA1(4a62fcd2f91dfb609c3d2c300bd9e6cb60edf52e) ) //
 	ROM_LOAD( "2084_rom_12b_3005-24.e7", 0x0f000, 0x1000, CRC(645d543e) SHA1(fad7cea868ebf17347c4bc5193d647bbd8f9517b) )
-	ROM_LOAD( "2084_rom_1b_3005-13.e4",  0x10000, 0x1000, CRC(66c7d3ef) SHA1(f6d60e26c209c1df2cc01ac07ad5559daa1b7118) )
-	ROM_LOAD( "2084_rom_2b_3005-14.c4",  0x11000, 0x1000, CRC(5bc6c614) SHA1(4d6e82bc29f49100f7751ccfc6a9ff35695b84b3) )
-	ROM_LOAD( "2084_rom_3b_3005-15.a4",  0x12000, 0x1000, CRC(e99a82be) SHA1(06a8c8dd0b4726eb7f0bb0e89c8533931d75fc1c) )
-	ROM_LOAD( "2084_rom_4b_3005-16.e5",  0x13000, 0x1000, CRC(afb1c561) SHA1(aaf89c19fd8f4e8750717169eb1af476aef38a5e) )
-	ROM_LOAD( "fixrobo_rom_5b.c5",       0x14000, 0x1000, CRC(827cb5c9) SHA1(1732d16cd88e0662f1cffce1aeda5c8aa8c31338) ) // fixes the enforcer explosion “reset” bug
-	ROM_LOAD( "2084_rom_6b_3005-18.a5",  0x15000, 0x1000, CRC(bd2c853d) SHA1(f76ec5432a7939b33a27be1c6855e2dbe6d9fdc8) )
-	ROM_LOAD( "2084_rom_7b_3005-19.e6",  0x16000, 0x1000, CRC(49ac400c) SHA1(06eae5138254723819a5e93cfd9e9f3285fcddf5) )
-	ROM_LOAD( "2084_rom_8b_3005-20.c6",  0x17000, 0x1000, CRC(3a96e88c) SHA1(7ae38a609ed9a6f62ca003cab719740ed7651b7c) )
-	ROM_LOAD( "2084_rom_9b_3005-21.a6",  0x18000, 0x1000, CRC(b124367b) SHA1(fd9d75b866f0ebbb723f84889337e6814496a103) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "video_sound_rom_3_std_767.ic12", 0xf000, 0x1000, CRC(c56c1d28) SHA1(15afefef11bfc3ab78f61ab046701db78d160ec3) ) // P/N A-5342-09910
@@ -2724,19 +2720,19 @@ ROM_START( robotron87 ) // Patch by Christian Gingras in 1987 fixing 7 bugs, AKA
 ROM_END
 
 ROM_START( robotron12 )
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "2084_rom_1b_3005-13.e4",  0x00000, 0x1000, CRC(66c7d3ef) SHA1(f6d60e26c209c1df2cc01ac07ad5559daa1b7118) )
+	ROM_LOAD( "2084_rom_2b_3005-14.c4",  0x01000, 0x1000, CRC(5bc6c614) SHA1(4d6e82bc29f49100f7751ccfc6a9ff35695b84b3) )
+	ROM_LOAD( "wave201.a4",              0x02000, 0x1000, CRC(85eb583e) SHA1(b6c4280415515de6f56b358206dc3bd93a12bfce) ) // wave 201 patch
+	ROM_LOAD( "2084_rom_4b_3005-16.e5",  0x03000, 0x1000, CRC(afb1c561) SHA1(aaf89c19fd8f4e8750717169eb1af476aef38a5e) )
+	ROM_LOAD( "fixrobo_rom_5b.c5",       0x04000, 0x1000, CRC(827cb5c9) SHA1(1732d16cd88e0662f1cffce1aeda5c8aa8c31338) ) // fixes the enforcer explosion “reset” bug
+	ROM_LOAD( "2084_rom_6b_3005-18.a5",  0x05000, 0x1000, CRC(bd2c853d) SHA1(f76ec5432a7939b33a27be1c6855e2dbe6d9fdc8) )
+	ROM_LOAD( "2084_rom_7b_3005-19.e6",  0x06000, 0x1000, CRC(49ac400c) SHA1(06eae5138254723819a5e93cfd9e9f3285fcddf5) )
+	ROM_LOAD( "2084_rom_8b_3005-20.c6",  0x07000, 0x1000, CRC(3a96e88c) SHA1(7ae38a609ed9a6f62ca003cab719740ed7651b7c) )
+	ROM_LOAD( "2084_rom_9b_3005-21.a6",  0x08000, 0x1000, CRC(b124367b) SHA1(fd9d75b866f0ebbb723f84889337e6814496a103) )
 	ROM_LOAD( "2084_rom_10b_3005-22.a7", 0x0d000, 0x1000, CRC(13797024) SHA1(d426a50e75dabe936de643c83a548da5e399331c) )
 	ROM_LOAD( "fixrobo_rom_11b.c7",      0x0e000, 0x1000, CRC(e83a2eda) SHA1(4a62fcd2f91dfb609c3d2c300bd9e6cb60edf52e) ) //
 	ROM_LOAD( "2084_rom_12b_3005-24.e7", 0x0f000, 0x1000, CRC(645d543e) SHA1(fad7cea868ebf17347c4bc5193d647bbd8f9517b) )
-	ROM_LOAD( "2084_rom_1b_3005-13.e4",  0x10000, 0x1000, CRC(66c7d3ef) SHA1(f6d60e26c209c1df2cc01ac07ad5559daa1b7118) )
-	ROM_LOAD( "2084_rom_2b_3005-14.c4",  0x11000, 0x1000, CRC(5bc6c614) SHA1(4d6e82bc29f49100f7751ccfc6a9ff35695b84b3) )
-	ROM_LOAD( "wave201.a4",              0x12000, 0x1000, CRC(85eb583e) SHA1(b6c4280415515de6f56b358206dc3bd93a12bfce) ) // wave 201 patch
-	ROM_LOAD( "2084_rom_4b_3005-16.e5",  0x13000, 0x1000, CRC(afb1c561) SHA1(aaf89c19fd8f4e8750717169eb1af476aef38a5e) )
-	ROM_LOAD( "fixrobo_rom_5b.c5",       0x14000, 0x1000, CRC(827cb5c9) SHA1(1732d16cd88e0662f1cffce1aeda5c8aa8c31338) ) // fixes the enforcer explosion “reset” bug
-	ROM_LOAD( "2084_rom_6b_3005-18.a5",  0x15000, 0x1000, CRC(bd2c853d) SHA1(f76ec5432a7939b33a27be1c6855e2dbe6d9fdc8) )
-	ROM_LOAD( "2084_rom_7b_3005-19.e6",  0x16000, 0x1000, CRC(49ac400c) SHA1(06eae5138254723819a5e93cfd9e9f3285fcddf5) )
-	ROM_LOAD( "2084_rom_8b_3005-20.c6",  0x17000, 0x1000, CRC(3a96e88c) SHA1(7ae38a609ed9a6f62ca003cab719740ed7651b7c) )
-	ROM_LOAD( "2084_rom_9b_3005-21.a6",  0x18000, 0x1000, CRC(b124367b) SHA1(fd9d75b866f0ebbb723f84889337e6814496a103) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "video_sound_rom_3_std_767.ic12", 0xf000, 0x1000, CRC(c56c1d28) SHA1(15afefef11bfc3ab78f61ab046701db78d160ec3) ) // P/N A-5342-09910
@@ -2747,19 +2743,19 @@ ROM_START( robotron12 )
 ROM_END
 
 ROM_START( robotrontd ) // Tie-Die version starts with a "Solid Blue label" set
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "2084_rom_1b_3005-13.e4",  0x00000, 0x1000, CRC(66c7d3ef) SHA1(f6d60e26c209c1df2cc01ac07ad5559daa1b7118) ) // == 2084_rom_1b_3005-1.e4
+	ROM_LOAD( "2084_rom_2b_3005-14.c4",  0x01000, 0x1000, CRC(5bc6c614) SHA1(4d6e82bc29f49100f7751ccfc6a9ff35695b84b3) ) // == 2084_rom_2b_3005-2.c4
+	ROM_LOAD( "2084_rom_3b_3005-15.a4",  0x02000, 0x1000, CRC(e99a82be) SHA1(06a8c8dd0b4726eb7f0bb0e89c8533931d75fc1c) )
+	ROM_LOAD( "tiedie_rom_4b.e5",        0x03000, 0x1000, CRC(e8238019) SHA1(0ce29f4bf6bdee677c8e80c2d5e66fc556ba349f) )
+	ROM_LOAD( "fixrobo_rom_5b.c5",       0x04000, 0x1000, CRC(827cb5c9) SHA1(1732d16cd88e0662f1cffce1aeda5c8aa8c31338) ) // fixes the enforcer explosion “reset” bug
+	ROM_LOAD( "2084_rom_6b_3005-18.a5",  0x05000, 0x1000, CRC(bd2c853d) SHA1(f76ec5432a7939b33a27be1c6855e2dbe6d9fdc8) )
+	ROM_LOAD( "tiedie_rom_7b.e6",        0x06000, 0x1000, CRC(3ecf4620) SHA1(3c670a1f8df35d18451c82f220a02448bf5ef5ac) )
+	ROM_LOAD( "tiedie_rom_8b.c6",        0x07000, 0x1000, CRC(752d7a46) SHA1(85dd58d14d527ca75d6c546d6271bf8ee5a82c8c) )
+	ROM_LOAD( "2084_rom_9b_3005-21.a6",  0x08000, 0x1000, CRC(b124367b) SHA1(fd9d75b866f0ebbb723f84889337e6814496a103) ) // == 2084_rom_9b_3005-9.a6
 	ROM_LOAD( "tiedie_rom_10b.a7",       0x0d000, 0x1000, CRC(952bea55) SHA1(80f51d8e7ec62518afad7e56a47e0756f83f813c) )
 	ROM_LOAD( "tiedie_rom_11b.c7",       0x0e000, 0x1000, CRC(4c05fd3c) SHA1(0d727458454826fd8222e4022b755d686ccb065f) )
 	ROM_LOAD( "2084_rom_12b_3005-24.e7", 0x0f000, 0x1000, CRC(645d543e) SHA1(fad7cea868ebf17347c4bc5193d647bbd8f9517b) )
-	ROM_LOAD( "2084_rom_1b_3005-13.e4",  0x10000, 0x1000, CRC(66c7d3ef) SHA1(f6d60e26c209c1df2cc01ac07ad5559daa1b7118) ) // == 2084_rom_1b_3005-1.e4
-	ROM_LOAD( "2084_rom_2b_3005-14.c4",  0x11000, 0x1000, CRC(5bc6c614) SHA1(4d6e82bc29f49100f7751ccfc6a9ff35695b84b3) ) // == 2084_rom_2b_3005-2.c4
-	ROM_LOAD( "2084_rom_3b_3005-15.a4",  0x12000, 0x1000, CRC(e99a82be) SHA1(06a8c8dd0b4726eb7f0bb0e89c8533931d75fc1c) )
-	ROM_LOAD( "tiedie_rom_4b.e5",        0x13000, 0x1000, CRC(e8238019) SHA1(0ce29f4bf6bdee677c8e80c2d5e66fc556ba349f) )
-	ROM_LOAD( "fixrobo_rom_5b.c5",       0x14000, 0x1000, CRC(827cb5c9) SHA1(1732d16cd88e0662f1cffce1aeda5c8aa8c31338) ) // fixes the enforcer explosion “reset” bug
-	ROM_LOAD( "2084_rom_6b_3005-18.a5",  0x15000, 0x1000, CRC(bd2c853d) SHA1(f76ec5432a7939b33a27be1c6855e2dbe6d9fdc8) )
-	ROM_LOAD( "tiedie_rom_7b.e6",        0x16000, 0x1000, CRC(3ecf4620) SHA1(3c670a1f8df35d18451c82f220a02448bf5ef5ac) )
-	ROM_LOAD( "tiedie_rom_8b.c6",        0x17000, 0x1000, CRC(752d7a46) SHA1(85dd58d14d527ca75d6c546d6271bf8ee5a82c8c) )
-	ROM_LOAD( "2084_rom_9b_3005-21.a6",  0x18000, 0x1000, CRC(b124367b) SHA1(fd9d75b866f0ebbb723f84889337e6814496a103) ) // == 2084_rom_9b_3005-9.a6
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "video_sound_rom_3_std_767.ic12", 0xf000, 0x1000, CRC(c56c1d28) SHA1(15afefef11bfc3ab78f61ab046701db78d160ec3) ) // P/N A-5342-09910
@@ -2882,19 +2878,19 @@ Wire W2 & W4 with Zero Ohm resistors for 2532 ROMs
 
 */
 ROM_START( joust ) // Solid green labels - contains the same data as the white label with green stripe 3006-52 through 3006-63 set
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "joust_rom_1b_3006-13.e4",  0x00000, 0x1000, CRC(fe41b2af) SHA1(0443e00ae2eb3e66cf805562ee04309487bb0ba4) ) // == joust_rom_1a_3006-1.e4
+	ROM_LOAD( "joust_rom_2b_3006-14.c4",  0x01000, 0x1000, CRC(501c143c) SHA1(5fda266d43cbbf42eeae1a078b5209d9408ab99f) ) // == joust_rom_2a_3006-2.c4
+	ROM_LOAD( "joust_rom_3b_3006-15.a4",  0x02000, 0x1000, CRC(43f7161d) SHA1(686da120aa4bd4a41f3d93e8c79ebb343977851a) ) // == joust_rom_3a_3006-3.a4
+	ROM_LOAD( "joust_rom_4b_3006-16.e5",  0x03000, 0x1000, CRC(db5571b6) SHA1(cb1c3285344e2cfbe0a81ab9b51758c40da8a23f) ) // == joust_rom_4a_3006-4.e5
+	ROM_LOAD( "joust_rom_5b_3006-17.c5",  0x04000, 0x1000, CRC(c686bb6b) SHA1(d9cac4c46820e1a451a145864bca7a35cfab7d37) ) // == joust_rom_5a_3006-5.c5
+	ROM_LOAD( "joust_rom_6b_3006-18.a5",  0x05000, 0x1000, CRC(fac5f2cf) SHA1(febaa8cf5c3a0af901cd12d0b7909f6fec3beadd) ) // == joust_rom_6a_3006-6.a5
+	ROM_LOAD( "joust_rom_7b_3006-19.e6",  0x06000, 0x1000, CRC(81418240) SHA1(5ad14aa65e71c3856dcdb04c99edda92e406a3e3) )
+	ROM_LOAD( "joust_rom_8b_3006-20.c6",  0x07000, 0x1000, CRC(ba5359ba) SHA1(f4ee13d5a95ed3e1050a3927a3a0ccf86ed7752d) ) // == joust_rom_8a_3006-8.c6
+	ROM_LOAD( "joust_rom_9b_3006-21.a6",  0x08000, 0x1000, CRC(39643147) SHA1(d95d3b746133eac9dcc9ee05eabecb797023f1a5) ) // == joust_rom_9a_3006-9.a6
 	ROM_LOAD( "joust_rom_10b_3006-22.a7", 0x0d000, 0x1000, CRC(3f1c4f89) SHA1(90864a8ab944df45287bf0f68ad3a85194077a82) )
 	ROM_LOAD( "joust_rom_11b_3006-23.c7", 0x0e000, 0x1000, CRC(ea48b359) SHA1(6d38003d56bebeb1f5b4d2287d587342847aa195) ) // == joust_rom_11a_3006-11.c7
 	ROM_LOAD( "joust_rom_12b_3006-24.e7", 0x0f000, 0x1000, CRC(c710717b) SHA1(7d01764e8251c60b3cab96f7dc6dcc1c624f9d12) ) // == joust_rom_12a_3006-12.e7
-	ROM_LOAD( "joust_rom_1b_3006-13.e4",  0x10000, 0x1000, CRC(fe41b2af) SHA1(0443e00ae2eb3e66cf805562ee04309487bb0ba4) ) // == joust_rom_1a_3006-1.e4
-	ROM_LOAD( "joust_rom_2b_3006-14.c4",  0x11000, 0x1000, CRC(501c143c) SHA1(5fda266d43cbbf42eeae1a078b5209d9408ab99f) ) // == joust_rom_2a_3006-2.c4
-	ROM_LOAD( "joust_rom_3b_3006-15.a4",  0x12000, 0x1000, CRC(43f7161d) SHA1(686da120aa4bd4a41f3d93e8c79ebb343977851a) ) // == joust_rom_3a_3006-3.a4
-	ROM_LOAD( "joust_rom_4b_3006-16.e5",  0x13000, 0x1000, CRC(db5571b6) SHA1(cb1c3285344e2cfbe0a81ab9b51758c40da8a23f) ) // == joust_rom_4a_3006-4.e5
-	ROM_LOAD( "joust_rom_5b_3006-17.c5",  0x14000, 0x1000, CRC(c686bb6b) SHA1(d9cac4c46820e1a451a145864bca7a35cfab7d37) ) // == joust_rom_5a_3006-5.c5
-	ROM_LOAD( "joust_rom_6b_3006-18.a5",  0x15000, 0x1000, CRC(fac5f2cf) SHA1(febaa8cf5c3a0af901cd12d0b7909f6fec3beadd) ) // == joust_rom_6a_3006-6.a5
-	ROM_LOAD( "joust_rom_7b_3006-19.e6",  0x16000, 0x1000, CRC(81418240) SHA1(5ad14aa65e71c3856dcdb04c99edda92e406a3e3) )
-	ROM_LOAD( "joust_rom_8b_3006-20.c6",  0x17000, 0x1000, CRC(ba5359ba) SHA1(f4ee13d5a95ed3e1050a3927a3a0ccf86ed7752d) ) // == joust_rom_8a_3006-8.c6
-	ROM_LOAD( "joust_rom_9b_3006-21.a6",  0x18000, 0x1000, CRC(39643147) SHA1(d95d3b746133eac9dcc9ee05eabecb797023f1a5) ) // == joust_rom_9a_3006-9.a6
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "video_sound_rom_4_std_780.ic12", 0xf000, 0x1000, CRC(f1835bdd) SHA1(af7c066d2949d36b87ea8c425ca7d12f82b5c653) ) // P/N A-5343-09973
@@ -2905,19 +2901,19 @@ ROM_START( joust ) // Solid green labels - contains the same data as the white l
 ROM_END
 
 ROM_START( jousty ) // Solid yellow labels
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "joust_rom_1a_3006-1.e4",   0x00000, 0x1000, CRC(fe41b2af) SHA1(0443e00ae2eb3e66cf805562ee04309487bb0ba4) )
+	ROM_LOAD( "joust_rom_2a_3006-2.c4",   0x01000, 0x1000, CRC(501c143c) SHA1(5fda266d43cbbf42eeae1a078b5209d9408ab99f) )
+	ROM_LOAD( "joust_rom_3a_3006-3.a4",   0x02000, 0x1000, CRC(43f7161d) SHA1(686da120aa4bd4a41f3d93e8c79ebb343977851a) )
+	ROM_LOAD( "joust_rom_4a_3006-4.e5",   0x03000, 0x1000, CRC(db5571b6) SHA1(cb1c3285344e2cfbe0a81ab9b51758c40da8a23f) )
+	ROM_LOAD( "joust_rom_5a_3006-5.c5",   0x04000, 0x1000, CRC(c686bb6b) SHA1(d9cac4c46820e1a451a145864bca7a35cfab7d37) )
+	ROM_LOAD( "joust_rom_6a_3006-6.a5",   0x05000, 0x1000, CRC(fac5f2cf) SHA1(febaa8cf5c3a0af901cd12d0b7909f6fec3beadd) )
+	ROM_LOAD( "joust_rom_7a_3006-7.e6",   0x06000, 0x1000, CRC(e6f439c4) SHA1(ff8f1d54f3ac91101ab9f5f115baeca4f2670186) )
+	ROM_LOAD( "joust_rom_8a_3006-8.c6",   0x07000, 0x1000, CRC(ba5359ba) SHA1(f4ee13d5a95ed3e1050a3927a3a0ccf86ed7752d) )
+	ROM_LOAD( "joust_rom_9a_3006-9.a6",   0x08000, 0x1000, CRC(39643147) SHA1(d95d3b746133eac9dcc9ee05eabecb797023f1a5) )
 	ROM_LOAD( "joust_rom_10a_3006-10.a7", 0x0d000, 0x1000, CRC(2039014a) SHA1(b9a76ecf01404585f833f76c54aa5a88a0215715) )
 	ROM_LOAD( "joust_rom_11a_3006-11.c7", 0x0e000, 0x1000, CRC(ea48b359) SHA1(6d38003d56bebeb1f5b4d2287d587342847aa195) )
 	ROM_LOAD( "joust_rom_12a_3006-12.e7", 0x0f000, 0x1000, CRC(c710717b) SHA1(7d01764e8251c60b3cab96f7dc6dcc1c624f9d12) )
-	ROM_LOAD( "joust_rom_1a_3006-1.e4",   0x10000, 0x1000, CRC(fe41b2af) SHA1(0443e00ae2eb3e66cf805562ee04309487bb0ba4) )
-	ROM_LOAD( "joust_rom_2a_3006-2.c4",   0x11000, 0x1000, CRC(501c143c) SHA1(5fda266d43cbbf42eeae1a078b5209d9408ab99f) )
-	ROM_LOAD( "joust_rom_3a_3006-3.a4",   0x12000, 0x1000, CRC(43f7161d) SHA1(686da120aa4bd4a41f3d93e8c79ebb343977851a) )
-	ROM_LOAD( "joust_rom_4a_3006-4.e5",   0x13000, 0x1000, CRC(db5571b6) SHA1(cb1c3285344e2cfbe0a81ab9b51758c40da8a23f) )
-	ROM_LOAD( "joust_rom_5a_3006-5.c5",   0x14000, 0x1000, CRC(c686bb6b) SHA1(d9cac4c46820e1a451a145864bca7a35cfab7d37) )
-	ROM_LOAD( "joust_rom_6a_3006-6.a5",   0x15000, 0x1000, CRC(fac5f2cf) SHA1(febaa8cf5c3a0af901cd12d0b7909f6fec3beadd) )
-	ROM_LOAD( "joust_rom_7a_3006-7.e6",   0x16000, 0x1000, CRC(e6f439c4) SHA1(ff8f1d54f3ac91101ab9f5f115baeca4f2670186) )
-	ROM_LOAD( "joust_rom_8a_3006-8.c6",   0x17000, 0x1000, CRC(ba5359ba) SHA1(f4ee13d5a95ed3e1050a3927a3a0ccf86ed7752d) )
-	ROM_LOAD( "joust_rom_9a_3006-9.a6",   0x18000, 0x1000, CRC(39643147) SHA1(d95d3b746133eac9dcc9ee05eabecb797023f1a5) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "video_sound_rom_4_std_780.ic12", 0xf000, 0x1000, CRC(f1835bdd) SHA1(af7c066d2949d36b87ea8c425ca7d12f82b5c653) ) // P/N A-5343-09973
@@ -2928,19 +2924,19 @@ ROM_START( jousty ) // Solid yellow labels
 ROM_END
 
 ROM_START( joustr ) // Solid red labels
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "joust_rom_1a_3006-28.e4",  0x00000, 0x1000, CRC(fe41b2af) SHA1(0443e00ae2eb3e66cf805562ee04309487bb0ba4) ) // == joust_rom_1a_3006-1.e4
+	ROM_LOAD( "joust_rom_2a_3006-29.c4",  0x01000, 0x1000, CRC(501c143c) SHA1(5fda266d43cbbf42eeae1a078b5209d9408ab99f) ) // == joust_rom_2a_3006-2.c4
+	ROM_LOAD( "joust_rom_3a_3006-30.a4",  0x02000, 0x1000, CRC(43f7161d) SHA1(686da120aa4bd4a41f3d93e8c79ebb343977851a) ) // == joust_rom_3a_3006-3.a4
+	ROM_LOAD( "joust_rom_4a_3006-31.e5",  0x03000, 0x1000, CRC(ab347170) SHA1(ad50c83fcfa958f2673cae04bd811095f9ee08c0) )
+	ROM_LOAD( "joust_rom_5a_3006-32.c5",  0x04000, 0x1000, CRC(c686bb6b) SHA1(d9cac4c46820e1a451a145864bca7a35cfab7d37) ) // == joust_rom_5a_3006-5.c5
+	ROM_LOAD( "joust_rom_6a_3006-33.a5",  0x05000, 0x1000, CRC(3d9a6fac) SHA1(0c81394ae96a2fcfa4c953d38e43f3ef415fe4fc) )
+	ROM_LOAD( "joust_rom_7a_3006-34.e6",  0x06000, 0x1000, CRC(0a70b3d1) SHA1(eb78b694aa29f777f3c7e7104e568f865930c0ec) )
+	ROM_LOAD( "joust_rom_8a_3006-35.c6",  0x07000, 0x1000, CRC(a7f01504) SHA1(0ca3211d060befc102bda2e97d163de7fb12a6f6) )
+	ROM_LOAD( "joust_rom_9a_3006-36.a6",  0x08000, 0x1000, CRC(978687ad) SHA1(25e651af3e3be08d6293aab427a0843e9333a629) )
 	ROM_LOAD( "joust_rom_10a_3006-37.a7", 0x0d000, 0x1000, CRC(c0c6e52a) SHA1(f14ff16195027f3e199e79e43741f0849c17fd10) )
 	ROM_LOAD( "joust_rom_11a_3006-38.c7", 0x0e000, 0x1000, CRC(ab11bcf9) SHA1(efb09e92a621d6c4d6cde2f166e8c988c64d81ae) )
 	ROM_LOAD( "joust_rom_12a_3006-39.e7", 0x0f000, 0x1000, CRC(ea14574b) SHA1(7572d118b2343646054e558f0bd48e4959d84ce7) )
-	ROM_LOAD( "joust_rom_1a_3006-28.e4",  0x10000, 0x1000, CRC(fe41b2af) SHA1(0443e00ae2eb3e66cf805562ee04309487bb0ba4) ) // == joust_rom_1a_3006-1.e4
-	ROM_LOAD( "joust_rom_2a_3006-29.c4",  0x11000, 0x1000, CRC(501c143c) SHA1(5fda266d43cbbf42eeae1a078b5209d9408ab99f) ) // == joust_rom_2a_3006-2.c4
-	ROM_LOAD( "joust_rom_3a_3006-30.a4",  0x12000, 0x1000, CRC(43f7161d) SHA1(686da120aa4bd4a41f3d93e8c79ebb343977851a) ) // == joust_rom_3a_3006-3.a4
-	ROM_LOAD( "joust_rom_4a_3006-31.e5",  0x13000, 0x1000, CRC(ab347170) SHA1(ad50c83fcfa958f2673cae04bd811095f9ee08c0) )
-	ROM_LOAD( "joust_rom_5a_3006-32.c5",  0x14000, 0x1000, CRC(c686bb6b) SHA1(d9cac4c46820e1a451a145864bca7a35cfab7d37) ) // == joust_rom_5a_3006-5.c5
-	ROM_LOAD( "joust_rom_6a_3006-33.a5",  0x15000, 0x1000, CRC(3d9a6fac) SHA1(0c81394ae96a2fcfa4c953d38e43f3ef415fe4fc) )
-	ROM_LOAD( "joust_rom_7a_3006-34.e6",  0x16000, 0x1000, CRC(0a70b3d1) SHA1(eb78b694aa29f777f3c7e7104e568f865930c0ec) )
-	ROM_LOAD( "joust_rom_8a_3006-35.c6",  0x17000, 0x1000, CRC(a7f01504) SHA1(0ca3211d060befc102bda2e97d163de7fb12a6f6) )
-	ROM_LOAD( "joust_rom_9a_3006-36.a6",  0x18000, 0x1000, CRC(978687ad) SHA1(25e651af3e3be08d6293aab427a0843e9333a629) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "video_sound_rom_4_std_780.ic12", 0xf000, 0x1000, CRC(f1835bdd) SHA1(af7c066d2949d36b87ea8c425ca7d12f82b5c653) ) // P/N A-5343-09973
@@ -3038,19 +3034,19 @@ For the sound ROM:
 
 */
 ROM_START( bubbles )
-	ROM_REGION( 0x19000, "maincpu", 0 ) // Solid red Label "B" ROMs numbers 16-3012-40 through 16-3012-51
+	ROM_REGION( 0x10000, "maincpu", 0 ) // Solid red Label "B" ROMs numbers 16-3012-40 through 16-3012-51
+	ROM_LOAD( "bubbles_rom_1b_16-3012-40.4e",  0x00000, 0x1000, CRC(8234f55c) SHA1(4d60942320c03ae50b0b17267062a321cf49e240) )
+	ROM_LOAD( "bubbles_rom_2b_16-3012-41.4c",  0x01000, 0x1000, CRC(4a188d6a) SHA1(2788c4a21659799e59ab82bc8d1864a3abe3b6d7) )
+	ROM_LOAD( "bubbles_rom_3b_16-3012-42.4a",  0x02000, 0x1000, CRC(7728f07f) SHA1(2a2c6dd8c2196dcd5e71b38554a56ee03d2aa454) )
+	ROM_LOAD( "bubbles_rom_4b_16-3012-43.5e",  0x03000, 0x1000, CRC(040be7f9) SHA1(de4d212cd2967b2dcd7b2c09dea2c1b06ce4c5bd) )
+	ROM_LOAD( "bubbles_rom_5b_16-3012-44.5c",  0x04000, 0x1000, CRC(0b5f29e0) SHA1(ae52f8c69c8b821abb458288c8ee0bc6c28fe535) )
+	ROM_LOAD( "bubbles_rom_6b_16-3012-45.5a",  0x05000, 0x1000, CRC(4dd0450d) SHA1(d55aa8fb8f2974ce5ba7155b01bc3e3622f202af) )
+	ROM_LOAD( "bubbles_rom_7b_16-3012-46.6e",  0x06000, 0x1000, CRC(e0a26ec0) SHA1(2da6213df6c15735a8bbd6750cfb1a1b6232a6f5) )
+	ROM_LOAD( "bubbles_rom_8b_16-3012-47.6c",  0x07000, 0x1000, CRC(4fd23d8d) SHA1(9d71caa30bc3f4151789279d21651e5a4fe4a484) )
+	ROM_LOAD( "bubbles_rom_9b_16-3012-48.6a",  0x08000, 0x1000, CRC(b48559fb) SHA1(551a49a12353044dbbf28dba2bd860c2d00c50bd) )
 	ROM_LOAD( "bubbles_rom_10b_16-3012-49.a7", 0x0d000, 0x1000, CRC(26e7869b) SHA1(db428e79fc325ae3c8cab460267c27cdbc35a3bd) )
 	ROM_LOAD( "bubbles_rom_11b_16-3012-50.c7", 0x0e000, 0x1000, CRC(5a5b572f) SHA1(f0c3a330abf9c8cfb6007ee372409450d2a15a93) )
 	ROM_LOAD( "bubbles_rom_12b_16-3012-51.e7", 0x0f000, 0x1000, CRC(ce22d2e2) SHA1(be4b9800c846660ce2b2ddd75ad872dcf174979a) )
-	ROM_LOAD( "bubbles_rom_1b_16-3012-40.4e",  0x10000, 0x1000, CRC(8234f55c) SHA1(4d60942320c03ae50b0b17267062a321cf49e240) )
-	ROM_LOAD( "bubbles_rom_2b_16-3012-41.4c",  0x11000, 0x1000, CRC(4a188d6a) SHA1(2788c4a21659799e59ab82bc8d1864a3abe3b6d7) )
-	ROM_LOAD( "bubbles_rom_3b_16-3012-42.4a",  0x12000, 0x1000, CRC(7728f07f) SHA1(2a2c6dd8c2196dcd5e71b38554a56ee03d2aa454) )
-	ROM_LOAD( "bubbles_rom_4b_16-3012-43.5e",  0x13000, 0x1000, CRC(040be7f9) SHA1(de4d212cd2967b2dcd7b2c09dea2c1b06ce4c5bd) )
-	ROM_LOAD( "bubbles_rom_5b_16-3012-44.5c",  0x14000, 0x1000, CRC(0b5f29e0) SHA1(ae52f8c69c8b821abb458288c8ee0bc6c28fe535) )
-	ROM_LOAD( "bubbles_rom_6b_16-3012-45.5a",  0x15000, 0x1000, CRC(4dd0450d) SHA1(d55aa8fb8f2974ce5ba7155b01bc3e3622f202af) )
-	ROM_LOAD( "bubbles_rom_7b_16-3012-46.6e",  0x16000, 0x1000, CRC(e0a26ec0) SHA1(2da6213df6c15735a8bbd6750cfb1a1b6232a6f5) )
-	ROM_LOAD( "bubbles_rom_8b_16-3012-47.6c",  0x17000, 0x1000, CRC(4fd23d8d) SHA1(9d71caa30bc3f4151789279d21651e5a4fe4a484) )
-	ROM_LOAD( "bubbles_rom_9b_16-3012-48.6a",  0x18000, 0x1000, CRC(b48559fb) SHA1(551a49a12353044dbbf28dba2bd860c2d00c50bd) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "video_sound_rom_5_std_771.ic12",  0xf000, 0x1000, CRC(689ce2aa) SHA1(b70d2553f731f9a20ddaf9af2f93b7e9c44d4d99) )
@@ -3061,19 +3057,19 @@ ROM_START( bubbles )
 ROM_END
 
 ROM_START( bubblesr )
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "bubblesr.1b",  0x00000, 0x1000, CRC(dda4e782) SHA1(ad6825ebc05931942ce1042f18e18e3873083abc) )
+	ROM_LOAD( "bubblesr.2b",  0x01000, 0x1000, CRC(3c8fa7f5) SHA1(fd3db6c2abab7000d586ef1a4e425329da292144) )
+	ROM_LOAD( "bubblesr.3b",  0x02000, 0x1000, CRC(f869bb9c) SHA1(ce276fc33136a527eefbbf35c2bcf1f0b9858740) )
+	ROM_LOAD( "bubblesr.4b",  0x03000, 0x1000, CRC(0c65eaab) SHA1(c622906cbda07421a7024955f3b9e8d173f4b6cb) )
+	ROM_LOAD( "bubblesr.5b",  0x04000, 0x1000, CRC(7ece4e13) SHA1(c6ec7145c2d3bf51877c7fb995d9732b09e04cf0) )
+	ROM_LOAD( "bubbles.6b",   0x05000, 0x1000, CRC(4dd0450d) SHA1(d55aa8fb8f2974ce5ba7155b01bc3e3622f202af) )
+	ROM_LOAD( "bubbles.7b",   0x06000, 0x1000, CRC(e0a26ec0) SHA1(2da6213df6c15735a8bbd6750cfb1a1b6232a6f5) ) // = bub_prot.7b
+	ROM_LOAD( "bubblesr.8b",  0x07000, 0x1000, CRC(598b9bd6) SHA1(993cc3fac58310d0e617e58e3a0753002b987df1) )
+	ROM_LOAD( "bubbles.9b",   0x08000, 0x1000, CRC(b48559fb) SHA1(551a49a12353044dbbf28dba2bd860c2d00c50bd) )
 	ROM_LOAD( "bubblesr.10b", 0x0d000, 0x1000, CRC(8b396db0) SHA1(88cab59ce7f07dfa15d1485d12ebab96d777ca65) )
 	ROM_LOAD( "bubblesr.11b", 0x0e000, 0x1000, CRC(096af43e) SHA1(994e60c1e684ae46ea791b274995d21ff5052e56) )
 	ROM_LOAD( "bubblesr.12b", 0x0f000, 0x1000, CRC(5c1244ef) SHA1(25b0f359c28291894381d73f4ba3a2b991a547f0) )
-	ROM_LOAD( "bubblesr.1b",  0x10000, 0x1000, CRC(dda4e782) SHA1(ad6825ebc05931942ce1042f18e18e3873083abc) )
-	ROM_LOAD( "bubblesr.2b",  0x11000, 0x1000, CRC(3c8fa7f5) SHA1(fd3db6c2abab7000d586ef1a4e425329da292144) )
-	ROM_LOAD( "bubblesr.3b",  0x12000, 0x1000, CRC(f869bb9c) SHA1(ce276fc33136a527eefbbf35c2bcf1f0b9858740) )
-	ROM_LOAD( "bubblesr.4b",  0x13000, 0x1000, CRC(0c65eaab) SHA1(c622906cbda07421a7024955f3b9e8d173f4b6cb) )
-	ROM_LOAD( "bubblesr.5b",  0x14000, 0x1000, CRC(7ece4e13) SHA1(c6ec7145c2d3bf51877c7fb995d9732b09e04cf0) )
-	ROM_LOAD( "bubbles.6b",   0x15000, 0x1000, CRC(4dd0450d) SHA1(d55aa8fb8f2974ce5ba7155b01bc3e3622f202af) )
-	ROM_LOAD( "bubbles.7b",   0x16000, 0x1000, CRC(e0a26ec0) SHA1(2da6213df6c15735a8bbd6750cfb1a1b6232a6f5) ) // = bub_prot.7b
-	ROM_LOAD( "bubblesr.8b",  0x17000, 0x1000, CRC(598b9bd6) SHA1(993cc3fac58310d0e617e58e3a0753002b987df1) )
-	ROM_LOAD( "bubbles.9b",   0x18000, 0x1000, CRC(b48559fb) SHA1(551a49a12353044dbbf28dba2bd860c2d00c50bd) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "video_sound_rom_5_std_771.ic12",  0xf000, 0x1000, CRC(689ce2aa) SHA1(b70d2553f731f9a20ddaf9af2f93b7e9c44d4d99) )
@@ -3084,19 +3080,19 @@ ROM_START( bubblesr )
 ROM_END
 
 ROM_START( bubblesp )
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "bub_prot.1b",  0x00000, 0x1000, CRC(6466a746) SHA1(ed67d879d82ef05bcd2b655f761f84bc0cf08897) )
+	ROM_LOAD( "bub_prot.2b",  0x01000, 0x1000, CRC(cca04357) SHA1(98f879675c02e7ad5532da30f663714913a059b9) )
+	ROM_LOAD( "bub_prot.3b",  0x02000, 0x1000, CRC(7aaff9e5) SHA1(8b377ec5c595a4e062bdc8fb8ca99b52a6bd9298) )
+	ROM_LOAD( "bub_prot.4b",  0x03000, 0x1000, CRC(4e264f01) SHA1(a6fd2d0613f78c45b3873e06efa2dd99530ed0c8) )
+	ROM_LOAD( "bub_prot.5b",  0x04000, 0x1000, CRC(121b0be6) SHA1(75ed718b9e83c32390ee0fe2c34e0300ecd98a85) )
+	ROM_LOAD( "bub_prot.6b",  0x05000, 0x1000, CRC(80e90b25) SHA1(92c83b4333f4f0f65638b1827ace01b02c490339) )
+	ROM_LOAD( "bub_prot.7b",  0x06000, 0x1000, CRC(e0a26ec0) SHA1(2da6213df6c15735a8bbd6750cfb1a1b6232a6f5) )
+	ROM_LOAD( "bub_prot.8b",  0x07000, 0x1000, CRC(96fb19c8) SHA1(3b1720e5efe2adc1f633216419bdf00c7e7b817d) )
+	ROM_LOAD( "bub_prot.9b",  0x08000, 0x1000, CRC(be7e1028) SHA1(430b33c8d83ee6756a3ef9298792b71066c88326) )
 	ROM_LOAD( "bub_prot.10b", 0x0d000, 0x1000, CRC(89a565df) SHA1(1f02c17222f7303218962fada6c6f867414551cf) )
 	ROM_LOAD( "bub_prot.11b", 0x0e000, 0x1000, CRC(5a0c36a7) SHA1(2b9dd9006e57ff8214ad4e6b10a4b72e736d472c) )
 	ROM_LOAD( "bub_prot.12b", 0x0f000, 0x1000, CRC(2bfd3438) SHA1(2427a5614e98a9499e4d19f9d6e25f2b73896bf5) )
-	ROM_LOAD( "bub_prot.1b",  0x10000, 0x1000, CRC(6466a746) SHA1(ed67d879d82ef05bcd2b655f761f84bc0cf08897) )
-	ROM_LOAD( "bub_prot.2b",  0x11000, 0x1000, CRC(cca04357) SHA1(98f879675c02e7ad5532da30f663714913a059b9) )
-	ROM_LOAD( "bub_prot.3b",  0x12000, 0x1000, CRC(7aaff9e5) SHA1(8b377ec5c595a4e062bdc8fb8ca99b52a6bd9298) )
-	ROM_LOAD( "bub_prot.4b",  0x13000, 0x1000, CRC(4e264f01) SHA1(a6fd2d0613f78c45b3873e06efa2dd99530ed0c8) )
-	ROM_LOAD( "bub_prot.5b",  0x14000, 0x1000, CRC(121b0be6) SHA1(75ed718b9e83c32390ee0fe2c34e0300ecd98a85) )
-	ROM_LOAD( "bub_prot.6b",  0x15000, 0x1000, CRC(80e90b25) SHA1(92c83b4333f4f0f65638b1827ace01b02c490339) )
-	ROM_LOAD( "bub_prot.7b",  0x16000, 0x1000, CRC(e0a26ec0) SHA1(2da6213df6c15735a8bbd6750cfb1a1b6232a6f5) )
-	ROM_LOAD( "bub_prot.8b",  0x17000, 0x1000, CRC(96fb19c8) SHA1(3b1720e5efe2adc1f633216419bdf00c7e7b817d) )
-	ROM_LOAD( "bub_prot.9b",  0x18000, 0x1000, CRC(be7e1028) SHA1(430b33c8d83ee6756a3ef9298792b71066c88326) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "video_sound_rom_5_std_771.ic12",  0xf000, 0x1000, CRC(689ce2aa) SHA1(b70d2553f731f9a20ddaf9af2f93b7e9c44d4d99) )
@@ -3138,19 +3134,19 @@ Uses a standard D-9144 ROM Board Assembly, see Joust or Robotron above
 
 */
 ROM_START( splat ) // Solid Brown labels
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "splat_rom_1b_16-3011-1.e4",   0x00000, 0x1000, CRC(1cf26e48) SHA1(6ba4de6cc7d1359ed450da7bae1000552373f873) )
+	ROM_LOAD( "splat_rom_2b_16-3011-2.c4",   0x01000, 0x1000, CRC(ac0d4276) SHA1(710aba98909d5d63c4b9b08579021f9c026b3111) )
+	ROM_LOAD( "splat_rom_3b_16-3011-3.a4",   0x02000, 0x1000, CRC(74873e59) SHA1(727c9da682fd10353f3969ef02e9f1826d8cb77a) )
+	ROM_LOAD( "splat_rom_4b_16-3011-4.e5",   0x03000, 0x1000, CRC(70a7064e) SHA1(7e6440585462b68b62d6d571d83635bf17149f1a) )
+	ROM_LOAD( "splat_rom_5b_16-3011-5.c5",   0x04000, 0x1000, CRC(c6895221) SHA1(6f88ba8ac72d9301760d6e2512549f70b5373c65) )
+	ROM_LOAD( "splat_rom_6b_16-3011-6.a5",   0x05000, 0x1000, CRC(ea4ab7fd) SHA1(288a361691a7f147ff3346627a10531d613ad017) )
+	ROM_LOAD( "splat_rom_7b_16-3011-7.e6",   0x06000, 0x1000, CRC(82fd8713) SHA1(c4d42b111a0357700ac2bf700117d75ffb3c5be5) )
+	ROM_LOAD( "splat_rom_8b_16-3011-8.c6",   0x07000, 0x1000, CRC(7dded1b4) SHA1(73df546dd60870f63a8c3deffea2b2d13149a48b) )
+	ROM_LOAD( "splat_rom_9b_16-3011-9.a6",   0x08000, 0x1000, CRC(71cbfe5a) SHA1(bf22bedeceffdccc340637098070b32e9c13cf68) )
 	ROM_LOAD( "splat_rom_10b_16-3011-10.a7", 0x0d000, 0x1000, CRC(d1a1f632) SHA1(de4f5ba2b92c47757dfd2ca810bf8f87338223f7) )
 	ROM_LOAD( "splat_rom_11b_16-3011-11.c7", 0x0e000, 0x1000, CRC(ca8cde95) SHA1(8e12f6d9eaf397646691ec5d02963b32973cb32e) )
 	ROM_LOAD( "splat_rom_12b_16-3011-12.e7", 0x0f000, 0x1000, CRC(5bee3e60) SHA1(b4ee99fb6c353093faf1e088bab82fec66e785bc) )
-	ROM_LOAD( "splat_rom_1b_16-3011-1.e4",   0x10000, 0x1000, CRC(1cf26e48) SHA1(6ba4de6cc7d1359ed450da7bae1000552373f873) )
-	ROM_LOAD( "splat_rom_2b_16-3011-2.c4",   0x11000, 0x1000, CRC(ac0d4276) SHA1(710aba98909d5d63c4b9b08579021f9c026b3111) )
-	ROM_LOAD( "splat_rom_3b_16-3011-3.a4",   0x12000, 0x1000, CRC(74873e59) SHA1(727c9da682fd10353f3969ef02e9f1826d8cb77a) )
-	ROM_LOAD( "splat_rom_4b_16-3011-4.e5",   0x13000, 0x1000, CRC(70a7064e) SHA1(7e6440585462b68b62d6d571d83635bf17149f1a) )
-	ROM_LOAD( "splat_rom_5b_16-3011-5.c5",   0x14000, 0x1000, CRC(c6895221) SHA1(6f88ba8ac72d9301760d6e2512549f70b5373c65) )
-	ROM_LOAD( "splat_rom_6b_16-3011-6.a5",   0x15000, 0x1000, CRC(ea4ab7fd) SHA1(288a361691a7f147ff3346627a10531d613ad017) )
-	ROM_LOAD( "splat_rom_7b_16-3011-7.e6",   0x16000, 0x1000, CRC(82fd8713) SHA1(c4d42b111a0357700ac2bf700117d75ffb3c5be5) )
-	ROM_LOAD( "splat_rom_8b_16-3011-8.c6",   0x17000, 0x1000, CRC(7dded1b4) SHA1(73df546dd60870f63a8c3deffea2b2d13149a48b) )
-	ROM_LOAD( "splat_rom_9b_16-3011-9.a6",   0x18000, 0x1000, CRC(71cbfe5a) SHA1(bf22bedeceffdccc340637098070b32e9c13cf68) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "video_sound_rom_13_std.ic12", 0xf000, 0x1000, CRC(a878d5f3) SHA1(f3347a354cb54ca228fe0971f0ae3bc778e2aecf) ) // Instruction Manual 16-3011-101 states "ROM 13" P/N A-5342-10127
@@ -3202,18 +3198,18 @@ If you disconnect the speech ROMs from the upright sound board, Video Sound ROM 
 
 */
 ROM_START( sinistar ) // rev. 3
-	ROM_REGION( 0x19000, "maincpu", 0 ) // solid RED labels with final production part numbers
+	ROM_REGION( 0x10000, "maincpu", 0 ) // solid RED labels with final production part numbers
+	ROM_LOAD( "sinistar_rom_1-b_16-3004-53.1d",  0x00000, 0x1000, CRC(f6f3a22c) SHA1(026d8cab07734fa294a5645edbe65a904bcbc302) )
+	ROM_LOAD( "sinistar_rom_2-b_16-3004-54.1c",  0x01000, 0x1000, CRC(cab3185c) SHA1(423d1e3b0c07333ec582529bc4d0b7baf591820a) )
+	ROM_LOAD( "sinistar_rom_3-b_16-3004-55.1a",  0x02000, 0x1000, CRC(1ce1b3cc) SHA1(5bc03d7249529d827dc60c087e074ab3e4ea7361) )
+	ROM_LOAD( "sinistar_rom_4-b_16-3004-56.2d",  0x03000, 0x1000, CRC(6da632ba) SHA1(72c0c3d5a5ca87ca4d95fcedaf834206e4633950) )
+	ROM_LOAD( "sinistar_rom_5-b_16-3004-57.2c",  0x04000, 0x1000, CRC(b662e8fc) SHA1(828a89d2ea13d8a362dae708f86bff54cb231887) )
+	ROM_LOAD( "sinistar_rom_6-b_16-3004-58.2a",  0x05000, 0x1000, CRC(2306183d) SHA1(703e29e6446856615760a4897c0f5d79cc7bdfb2) )
+	ROM_LOAD( "sinistar_rom_7-b_16-3004-59.3d",  0x06000, 0x1000, CRC(e5dd918e) SHA1(bf4e2ada6a59d246218544d822ba5355da925924) )
+	ROM_LOAD( "sinistar_rom_8-b_16-3004-60.3c",  0x07000, 0x1000, CRC(4785a787) SHA1(8c7eca656b2c23b0da41a8c7ce51a2735cab85a4) )
+	ROM_LOAD( "sinistar_rom_9-b_16-3004-61.3a",  0x08000, 0x1000, CRC(50cb63ad) SHA1(96e28e4fef98fff2649741a266fa590e0313e3b0) )
 	ROM_LOAD( "sinistar_rom_10-b_16-3004-62.4c", 0x0e000, 0x1000, CRC(3d670417) SHA1(81802622bee8dbea5c0f08019d87d941dcdbe292) )
 	ROM_LOAD( "sinistar_rom_11-b_16-3004-63.4a", 0x0f000, 0x1000, CRC(3162bc50) SHA1(2f38e572ab9c731e38dfe9bad3cc8222a775c5ea) )
-	ROM_LOAD( "sinistar_rom_1-b_16-3004-53.1d",  0x10000, 0x1000, CRC(f6f3a22c) SHA1(026d8cab07734fa294a5645edbe65a904bcbc302) )
-	ROM_LOAD( "sinistar_rom_2-b_16-3004-54.1c",  0x11000, 0x1000, CRC(cab3185c) SHA1(423d1e3b0c07333ec582529bc4d0b7baf591820a) )
-	ROM_LOAD( "sinistar_rom_3-b_16-3004-55.1a",  0x12000, 0x1000, CRC(1ce1b3cc) SHA1(5bc03d7249529d827dc60c087e074ab3e4ea7361) )
-	ROM_LOAD( "sinistar_rom_4-b_16-3004-56.2d",  0x13000, 0x1000, CRC(6da632ba) SHA1(72c0c3d5a5ca87ca4d95fcedaf834206e4633950) )
-	ROM_LOAD( "sinistar_rom_5-b_16-3004-57.2c",  0x14000, 0x1000, CRC(b662e8fc) SHA1(828a89d2ea13d8a362dae708f86bff54cb231887) )
-	ROM_LOAD( "sinistar_rom_6-b_16-3004-58.2a",  0x15000, 0x1000, CRC(2306183d) SHA1(703e29e6446856615760a4897c0f5d79cc7bdfb2) )
-	ROM_LOAD( "sinistar_rom_7-b_16-3004-59.3d",  0x16000, 0x1000, CRC(e5dd918e) SHA1(bf4e2ada6a59d246218544d822ba5355da925924) )
-	ROM_LOAD( "sinistar_rom_8-b_16-3004-60.3c",  0x17000, 0x1000, CRC(4785a787) SHA1(8c7eca656b2c23b0da41a8c7ce51a2735cab85a4) )
-	ROM_LOAD( "sinistar_rom_9-b_16-3004-61.3a",  0x18000, 0x1000, CRC(50cb63ad) SHA1(96e28e4fef98fff2649741a266fa590e0313e3b0) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "3004_speech_ic7_r1_16-3004-52.ic7", 0xb000, 0x1000, CRC(e1019568) SHA1(442f4f3ccd2e1db2136d2ffb121ea442921f87ca) )
@@ -3228,18 +3224,18 @@ ROM_START( sinistar ) // rev. 3
 ROM_END
 
 ROM_START( sinistarc ) // rev. 3
-	ROM_REGION( 0x19000, "maincpu", 0 ) // solid RED labels with final production part numbers
+	ROM_REGION( 0x10000, "maincpu", 0 ) // solid RED labels with final production part numbers
+	ROM_LOAD( "sinistar_rom_1-b_16-3004-53.1d",  0x00000, 0x1000, CRC(f6f3a22c) SHA1(026d8cab07734fa294a5645edbe65a904bcbc302) )
+	ROM_LOAD( "sinistar_rom_2-b_16-3004-54.1c",  0x01000, 0x1000, CRC(cab3185c) SHA1(423d1e3b0c07333ec582529bc4d0b7baf591820a) )
+	ROM_LOAD( "sinistar_rom_3-b_16-3004-55.1a",  0x02000, 0x1000, CRC(1ce1b3cc) SHA1(5bc03d7249529d827dc60c087e074ab3e4ea7361) )
+	ROM_LOAD( "sinistar_rom_4-b_16-3004-56.2d",  0x03000, 0x1000, CRC(6da632ba) SHA1(72c0c3d5a5ca87ca4d95fcedaf834206e4633950) )
+	ROM_LOAD( "sinistar_rom_5-b_16-3004-57.2c",  0x04000, 0x1000, CRC(b662e8fc) SHA1(828a89d2ea13d8a362dae708f86bff54cb231887) )
+	ROM_LOAD( "sinistar_rom_6-b_16-3004-58.2a",  0x05000, 0x1000, CRC(2306183d) SHA1(703e29e6446856615760a4897c0f5d79cc7bdfb2) )
+	ROM_LOAD( "sinistar_rom_7-b_16-3004-59.3d",  0x06000, 0x1000, CRC(e5dd918e) SHA1(bf4e2ada6a59d246218544d822ba5355da925924) )
+	ROM_LOAD( "sinistar_rom_8-b_16-3004-60.3c",  0x07000, 0x1000, CRC(4785a787) SHA1(8c7eca656b2c23b0da41a8c7ce51a2735cab85a4) )
+	ROM_LOAD( "sinistar_rom_9-b_16-3004-61.3a",  0x08000, 0x1000, CRC(50cb63ad) SHA1(96e28e4fef98fff2649741a266fa590e0313e3b0) )
 	ROM_LOAD( "sinistar_rom_10-b_16-3004-62.4c", 0x0e000, 0x1000, CRC(3d670417) SHA1(81802622bee8dbea5c0f08019d87d941dcdbe292) )
 	ROM_LOAD( "sinistar_rom_11-b_16-3004-63.4a", 0x0f000, 0x1000, CRC(3162bc50) SHA1(2f38e572ab9c731e38dfe9bad3cc8222a775c5ea) )
-	ROM_LOAD( "sinistar_rom_1-b_16-3004-53.1d",  0x10000, 0x1000, CRC(f6f3a22c) SHA1(026d8cab07734fa294a5645edbe65a904bcbc302) )
-	ROM_LOAD( "sinistar_rom_2-b_16-3004-54.1c",  0x11000, 0x1000, CRC(cab3185c) SHA1(423d1e3b0c07333ec582529bc4d0b7baf591820a) )
-	ROM_LOAD( "sinistar_rom_3-b_16-3004-55.1a",  0x12000, 0x1000, CRC(1ce1b3cc) SHA1(5bc03d7249529d827dc60c087e074ab3e4ea7361) )
-	ROM_LOAD( "sinistar_rom_4-b_16-3004-56.2d",  0x13000, 0x1000, CRC(6da632ba) SHA1(72c0c3d5a5ca87ca4d95fcedaf834206e4633950) )
-	ROM_LOAD( "sinistar_rom_5-b_16-3004-57.2c",  0x14000, 0x1000, CRC(b662e8fc) SHA1(828a89d2ea13d8a362dae708f86bff54cb231887) )
-	ROM_LOAD( "sinistar_rom_6-b_16-3004-58.2a",  0x15000, 0x1000, CRC(2306183d) SHA1(703e29e6446856615760a4897c0f5d79cc7bdfb2) )
-	ROM_LOAD( "sinistar_rom_7-b_16-3004-59.3d",  0x16000, 0x1000, CRC(e5dd918e) SHA1(bf4e2ada6a59d246218544d822ba5355da925924) )
-	ROM_LOAD( "sinistar_rom_8-b_16-3004-60.3c",  0x17000, 0x1000, CRC(4785a787) SHA1(8c7eca656b2c23b0da41a8c7ce51a2735cab85a4) )
-	ROM_LOAD( "sinistar_rom_9-b_16-3004-61.3a",  0x18000, 0x1000, CRC(50cb63ad) SHA1(96e28e4fef98fff2649741a266fa590e0313e3b0) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "3004_speech_ic7_r1_16-3004-52.ic7", 0xb000, 0x1000, CRC(e1019568) SHA1(442f4f3ccd2e1db2136d2ffb121ea442921f87ca) )
@@ -3257,18 +3253,18 @@ ROM_START( sinistarc ) // rev. 3
 ROM_END
 
 ROM_START( sinistar2 ) // rev. 2
-	ROM_REGION( 0x19000, "maincpu", 0 ) // solid RED labels with final production part numbers
+	ROM_REGION( 0x10000, "maincpu", 0 ) // solid RED labels with final production part numbers
+	ROM_LOAD( "sinistar_rom_1-b_16-3004-38.1d",  0x00000, 0x1000, CRC(f6f3a22c) SHA1(026d8cab07734fa294a5645edbe65a904bcbc302) ) //  == rev. 3 PN 16-3004-53
+	ROM_LOAD( "sinistar_rom_2-b_16-3004-39.1c",  0x01000, 0x1000, CRC(cab3185c) SHA1(423d1e3b0c07333ec582529bc4d0b7baf591820a) ) //  == rev. 3 PN 16-3004-54
+	ROM_LOAD( "sinistar_rom_3-b_16-3004-40.1a",  0x02000, 0x1000, CRC(1ce1b3cc) SHA1(5bc03d7249529d827dc60c087e074ab3e4ea7361) ) //  == rev. 3 PN 16-3004-55
+	ROM_LOAD( "sinistar_rom_4-b_16-3004-41.2d",  0x03000, 0x1000, CRC(6da632ba) SHA1(72c0c3d5a5ca87ca4d95fcedaf834206e4633950) ) //  == rev. 3 PN 16-3004-56
+	ROM_LOAD( "sinistar_rom_5-b_16-3004-42.2c",  0x04000, 0x1000, CRC(b662e8fc) SHA1(828a89d2ea13d8a362dae708f86bff54cb231887) ) //  == rev. 3 PN 16-3004-57
+	ROM_LOAD( "sinistar_rom_6-b_16-3004-43.2a",  0x05000, 0x1000, CRC(2306183d) SHA1(703e29e6446856615760a4897c0f5d79cc7bdfb2) ) //  == rev. 3 PN 16-3004-57
+	ROM_LOAD( "sinistar_rom_7-b_16-3004-44.3d",  0x06000, 0x1000, CRC(e5dd918e) SHA1(bf4e2ada6a59d246218544d822ba5355da925924) ) //  == rev. 3 PN 16-3004-59
+	ROM_LOAD( "sinistar_rom_8-b_16-3004-45.3c",  0x07000, 0x1000, CRC(d7ecee45) SHA1(f9552035409bce0a36ed93a677b28f8cd361f8f1) ) //  unique to rev. 2
+	ROM_LOAD( "sinistar_rom_9-b_16-3004-46.3a",  0x08000, 0x1000, CRC(50cb63ad) SHA1(96e28e4fef98fff2649741a266fa590e0313e3b0) ) //  == rev. 3 PN 16-3004-61
 	ROM_LOAD( "sinistar_rom_10-b_16-3004-47.4c", 0x0e000, 0x1000, CRC(3d670417) SHA1(81802622bee8dbea5c0f08019d87d941dcdbe292) ) //  == rev. 3 PN 16-3004-62
 	ROM_LOAD( "sinistar_rom_11-b_16-3004-48.4a", 0x0f000, 0x1000, CRC(792c8b00) SHA1(1f847ca8a67595927c36d69cead02813c2431c7b) ) //  unique to rev. 2
-	ROM_LOAD( "sinistar_rom_1-b_16-3004-38.1d",  0x10000, 0x1000, CRC(f6f3a22c) SHA1(026d8cab07734fa294a5645edbe65a904bcbc302) ) //  == rev. 3 PN 16-3004-53
-	ROM_LOAD( "sinistar_rom_2-b_16-3004-39.1c",  0x11000, 0x1000, CRC(cab3185c) SHA1(423d1e3b0c07333ec582529bc4d0b7baf591820a) ) //  == rev. 3 PN 16-3004-54
-	ROM_LOAD( "sinistar_rom_3-b_16-3004-40.1a",  0x12000, 0x1000, CRC(1ce1b3cc) SHA1(5bc03d7249529d827dc60c087e074ab3e4ea7361) ) //  == rev. 3 PN 16-3004-55
-	ROM_LOAD( "sinistar_rom_4-b_16-3004-41.2d",  0x13000, 0x1000, CRC(6da632ba) SHA1(72c0c3d5a5ca87ca4d95fcedaf834206e4633950) ) //  == rev. 3 PN 16-3004-56
-	ROM_LOAD( "sinistar_rom_5-b_16-3004-42.2c",  0x14000, 0x1000, CRC(b662e8fc) SHA1(828a89d2ea13d8a362dae708f86bff54cb231887) ) //  == rev. 3 PN 16-3004-57
-	ROM_LOAD( "sinistar_rom_6-b_16-3004-43.2a",  0x15000, 0x1000, CRC(2306183d) SHA1(703e29e6446856615760a4897c0f5d79cc7bdfb2) ) //  == rev. 3 PN 16-3004-57
-	ROM_LOAD( "sinistar_rom_7-b_16-3004-44.3d",  0x16000, 0x1000, CRC(e5dd918e) SHA1(bf4e2ada6a59d246218544d822ba5355da925924) ) //  == rev. 3 PN 16-3004-59
-	ROM_LOAD( "sinistar_rom_8-b_16-3004-45.3c",  0x17000, 0x1000, CRC(d7ecee45) SHA1(f9552035409bce0a36ed93a677b28f8cd361f8f1) ) //  unique to rev. 2
-	ROM_LOAD( "sinistar_rom_9-b_16-3004-46.3a",  0x18000, 0x1000, CRC(50cb63ad) SHA1(96e28e4fef98fff2649741a266fa590e0313e3b0) ) //  == rev. 3 PN 16-3004-61
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "3004_speech_ic7_r1_16-3004-52.ic7", 0xb000, 0x1000, CRC(e1019568) SHA1(442f4f3ccd2e1db2136d2ffb121ea442921f87ca) )
@@ -3283,18 +3279,18 @@ ROM_START( sinistar2 ) // rev. 2
 ROM_END
 
 ROM_START( sinistarc2 ) // rev. 2
-	ROM_REGION( 0x19000, "maincpu", 0 ) // solid RED labels with final production part numbers
+	ROM_REGION( 0x10000, "maincpu", 0 ) // solid RED labels with final production part numbers
+	ROM_LOAD( "sinistar_rom_1-b_16-3004-38.1d",  0x00000, 0x1000, CRC(f6f3a22c) SHA1(026d8cab07734fa294a5645edbe65a904bcbc302) ) //  == rev. 3 PN 16-3004-53
+	ROM_LOAD( "sinistar_rom_2-b_16-3004-39.1c",  0x01000, 0x1000, CRC(cab3185c) SHA1(423d1e3b0c07333ec582529bc4d0b7baf591820a) ) //  == rev. 3 PN 16-3004-54
+	ROM_LOAD( "sinistar_rom_3-b_16-3004-40.1a",  0x02000, 0x1000, CRC(1ce1b3cc) SHA1(5bc03d7249529d827dc60c087e074ab3e4ea7361) ) //  == rev. 3 PN 16-3004-55
+	ROM_LOAD( "sinistar_rom_4-b_16-3004-41.2d",  0x03000, 0x1000, CRC(6da632ba) SHA1(72c0c3d5a5ca87ca4d95fcedaf834206e4633950) ) //  == rev. 3 PN 16-3004-56
+	ROM_LOAD( "sinistar_rom_5-b_16-3004-42.2c",  0x04000, 0x1000, CRC(b662e8fc) SHA1(828a89d2ea13d8a362dae708f86bff54cb231887) ) //  == rev. 3 PN 16-3004-57
+	ROM_LOAD( "sinistar_rom_6-b_16-3004-43.2a",  0x05000, 0x1000, CRC(2306183d) SHA1(703e29e6446856615760a4897c0f5d79cc7bdfb2) ) //  == rev. 3 PN 16-3004-57
+	ROM_LOAD( "sinistar_rom_7-b_16-3004-44.3d",  0x06000, 0x1000, CRC(e5dd918e) SHA1(bf4e2ada6a59d246218544d822ba5355da925924) ) //  == rev. 3 PN 16-3004-59
+	ROM_LOAD( "sinistar_rom_8-b_16-3004-45.3c",  0x07000, 0x1000, CRC(d7ecee45) SHA1(f9552035409bce0a36ed93a677b28f8cd361f8f1) ) //  unique to rev. 2
+	ROM_LOAD( "sinistar_rom_9-b_16-3004-46.3a",  0x08000, 0x1000, CRC(50cb63ad) SHA1(96e28e4fef98fff2649741a266fa590e0313e3b0) ) //  == rev. 3 PN 16-3004-61
 	ROM_LOAD( "sinistar_rom_10-b_16-3004-47.4c", 0x0e000, 0x1000, CRC(3d670417) SHA1(81802622bee8dbea5c0f08019d87d941dcdbe292) ) //  == rev. 3 PN 16-3004-62
 	ROM_LOAD( "sinistar_rom_11-b_16-3004-48.4a", 0x0f000, 0x1000, CRC(792c8b00) SHA1(1f847ca8a67595927c36d69cead02813c2431c7b) ) //  unique to rev. 2
-	ROM_LOAD( "sinistar_rom_1-b_16-3004-38.1d",  0x10000, 0x1000, CRC(f6f3a22c) SHA1(026d8cab07734fa294a5645edbe65a904bcbc302) ) //  == rev. 3 PN 16-3004-53
-	ROM_LOAD( "sinistar_rom_2-b_16-3004-39.1c",  0x11000, 0x1000, CRC(cab3185c) SHA1(423d1e3b0c07333ec582529bc4d0b7baf591820a) ) //  == rev. 3 PN 16-3004-54
-	ROM_LOAD( "sinistar_rom_3-b_16-3004-40.1a",  0x12000, 0x1000, CRC(1ce1b3cc) SHA1(5bc03d7249529d827dc60c087e074ab3e4ea7361) ) //  == rev. 3 PN 16-3004-55
-	ROM_LOAD( "sinistar_rom_4-b_16-3004-41.2d",  0x13000, 0x1000, CRC(6da632ba) SHA1(72c0c3d5a5ca87ca4d95fcedaf834206e4633950) ) //  == rev. 3 PN 16-3004-56
-	ROM_LOAD( "sinistar_rom_5-b_16-3004-42.2c",  0x14000, 0x1000, CRC(b662e8fc) SHA1(828a89d2ea13d8a362dae708f86bff54cb231887) ) //  == rev. 3 PN 16-3004-57
-	ROM_LOAD( "sinistar_rom_6-b_16-3004-43.2a",  0x15000, 0x1000, CRC(2306183d) SHA1(703e29e6446856615760a4897c0f5d79cc7bdfb2) ) //  == rev. 3 PN 16-3004-57
-	ROM_LOAD( "sinistar_rom_7-b_16-3004-44.3d",  0x16000, 0x1000, CRC(e5dd918e) SHA1(bf4e2ada6a59d246218544d822ba5355da925924) ) //  == rev. 3 PN 16-3004-59
-	ROM_LOAD( "sinistar_rom_8-b_16-3004-45.3c",  0x17000, 0x1000, CRC(d7ecee45) SHA1(f9552035409bce0a36ed93a677b28f8cd361f8f1) ) //  unique to rev. 2
-	ROM_LOAD( "sinistar_rom_9-b_16-3004-46.3a",  0x18000, 0x1000, CRC(50cb63ad) SHA1(96e28e4fef98fff2649741a266fa590e0313e3b0) ) //  == rev. 3 PN 16-3004-61
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "3004_speech_ic7_r1_16-3004-52.ic7", 0xb000, 0x1000, CRC(e1019568) SHA1(442f4f3ccd2e1db2136d2ffb121ea442921f87ca) )
@@ -3312,18 +3308,18 @@ ROM_START( sinistarc2 ) // rev. 2
 ROM_END
 
 ROM_START( sinistarp ) // solid pink labels - 1982 AMOA prototype
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "sinistar_rom_1-b_16-3004-12.1d",  0x00000, 0x1000, CRC(3810d7b8) SHA1(dcd690cbc958a2f97f022765315d77fb7c7d8e8b) )
+	ROM_LOAD( "sinistar_rom_2-b_16-3004-13.1c",  0x01000, 0x1000, CRC(cab3185c) SHA1(423d1e3b0c07333ec582529bc4d0b7baf591820a) ) // only this one ROM remains the same through to rev. 3
+	ROM_LOAD( "sinistar_rom_3-b_16-3004-14.1a",  0x02000, 0x1000, CRC(7c984ca9) SHA1(b32b7d15194051db5d29acf95b049e2eccf6d393) )
+	ROM_LOAD( "sinistar_rom_4-b_16-3004-15.2d",  0x03000, 0x1000, CRC(cc6c4f24) SHA1(b4375544e02a19458c6fcc85edb31025c0b8eb71) )
+	ROM_LOAD( "sinistar_rom_5-b_16-3004-16.2c",  0x04000, 0x1000, CRC(12285bfe) SHA1(6d433103332ddda2f2af23febc0b15aa93db1f31) )
+	ROM_LOAD( "sinistar_rom_6-b_16-3004-17.2a",  0x05000, 0x1000, CRC(7a675f35) SHA1(3a7e9fdb2aef52dc29d33799694737038802b6e0) )
+	ROM_LOAD( "sinistar_rom_7-b_16-3004-18.3d",  0x06000, 0x1000, CRC(b0463243) SHA1(95d597856a1942bd176f5f62db0d691f8f2f2932) )
+	ROM_LOAD( "sinistar_rom_8-b_16-3004-19.3c",  0x07000, 0x1000, CRC(909040d4) SHA1(5361cc378bdace0799227e901341747dce9bb029) )
+	ROM_LOAD( "sinistar_rom_9-b_16-3004-20.3a",  0x08000, 0x1000, CRC(cc949810) SHA1(2d2d1cccd7e43b63e424c34ab5215a412e2b9809) )
 	ROM_LOAD( "sinistar_rom_10-b_16-3004-21.4c", 0x0e000, 0x1000, CRC(ea87a53f) SHA1(4e4bad5315a8f5740c926ee5681879919a5be37f) )
 	ROM_LOAD( "sinistar_rom_11-b_16-3004-22.4a", 0x0f000, 0x1000, CRC(88d36e80) SHA1(bb9adaf5b73f9874e52dc2f5fd35e22f8b4fc258) )
-	ROM_LOAD( "sinistar_rom_1-b_16-3004-12.1d",  0x10000, 0x1000, CRC(3810d7b8) SHA1(dcd690cbc958a2f97f022765315d77fb7c7d8e8b) )
-	ROM_LOAD( "sinistar_rom_2-b_16-3004-13.1c",  0x11000, 0x1000, CRC(cab3185c) SHA1(423d1e3b0c07333ec582529bc4d0b7baf591820a) ) // only this one ROM remains the same through to rev. 3
-	ROM_LOAD( "sinistar_rom_3-b_16-3004-14.1a",  0x12000, 0x1000, CRC(7c984ca9) SHA1(b32b7d15194051db5d29acf95b049e2eccf6d393) )
-	ROM_LOAD( "sinistar_rom_4-b_16-3004-15.2d",  0x13000, 0x1000, CRC(cc6c4f24) SHA1(b4375544e02a19458c6fcc85edb31025c0b8eb71) )
-	ROM_LOAD( "sinistar_rom_5-b_16-3004-16.2c",  0x14000, 0x1000, CRC(12285bfe) SHA1(6d433103332ddda2f2af23febc0b15aa93db1f31) )
-	ROM_LOAD( "sinistar_rom_6-b_16-3004-17.2a",  0x15000, 0x1000, CRC(7a675f35) SHA1(3a7e9fdb2aef52dc29d33799694737038802b6e0) )
-	ROM_LOAD( "sinistar_rom_7-b_16-3004-18.3d",  0x16000, 0x1000, CRC(b0463243) SHA1(95d597856a1942bd176f5f62db0d691f8f2f2932) )
-	ROM_LOAD( "sinistar_rom_8-b_16-3004-19.3c",  0x17000, 0x1000, CRC(909040d4) SHA1(5361cc378bdace0799227e901341747dce9bb029) )
-	ROM_LOAD( "sinistar_rom_9-b_16-3004-20.3a",  0x18000, 0x1000, CRC(cc949810) SHA1(2d2d1cccd7e43b63e424c34ab5215a412e2b9809) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "3004_speech_ic7_r1.ic7",    0xb000, 0x1000, CRC(e1019568) SHA1(442f4f3ccd2e1db2136d2ffb121ea442921f87ca) ) // same data as later sets, but no official part number assigned yet
@@ -3339,19 +3335,19 @@ ROM_END
 
 
 ROM_START( playball )
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "playball.01", 0x00000, 0x1000, CRC(7ba8fd71) SHA1(9b77996238c67aead8c2cfc7f964f8cf9c6182eb) )
+	ROM_LOAD( "playball.02", 0x01000, 0x1000, CRC(2387c3d4) SHA1(19d9da6af317595d0f3336e886154e0b8467cb3e) )
+	ROM_LOAD( "playball.03", 0x02000, 0x1000, CRC(d34cc5fd) SHA1(d1f6d321c1a6a04a06813c77a3e079836a05956c) )
+	ROM_LOAD( "playball.04", 0x03000, 0x1000, CRC(f68c3a8e) SHA1(f9cc7250254b9adceff883d3f6ee01c475d859ec) )
+	ROM_LOAD( "playball.05", 0x04000, 0x1000, CRC(a3f20810) SHA1(678d2a5a06263cc5f74f4cb92287cf4d7a8b934f) )
+	ROM_LOAD( "playball.06", 0x05000, 0x1000, CRC(f213e48e) SHA1(05b54f5121a887bc24fbe30f322277ae94474c14) )
+	ROM_LOAD( "playball.07", 0x06000, 0x1000, CRC(9b5574e9) SHA1(1dddd33cd3f13694d7ba6a73e5090594c6677d5b) )
+	ROM_LOAD( "playball.08", 0x07000, 0x1000, CRC(b2d2074a) SHA1(2defb2ffaca782606f792020f9c96d41abd77518) )
+	ROM_LOAD( "playball.09", 0x08000, 0x1000, CRC(c4566d0f) SHA1(7848ea87d2d1693ade9129846024fbedc4145cbb) )
 	ROM_LOAD( "playball.10", 0x0d000, 0x1000, CRC(18787b52) SHA1(621754c1eab68de12763616b7bf01948cdce0221) )
 	ROM_LOAD( "playball.11", 0x0e000, 0x1000, CRC(1dd5c8f2) SHA1(17d0380ea05d9ddd17576691d0e5179ae7a71200) )
 	ROM_LOAD( "playball.12", 0x0f000, 0x1000, CRC(a700597b) SHA1(5ba07409ae9315b9ee65530f61155c394bfc69ad) )
-	ROM_LOAD( "playball.01", 0x10000, 0x1000, CRC(7ba8fd71) SHA1(9b77996238c67aead8c2cfc7f964f8cf9c6182eb) )
-	ROM_LOAD( "playball.02", 0x11000, 0x1000, CRC(2387c3d4) SHA1(19d9da6af317595d0f3336e886154e0b8467cb3e) )
-	ROM_LOAD( "playball.03", 0x12000, 0x1000, CRC(d34cc5fd) SHA1(d1f6d321c1a6a04a06813c77a3e079836a05956c) )
-	ROM_LOAD( "playball.04", 0x13000, 0x1000, CRC(f68c3a8e) SHA1(f9cc7250254b9adceff883d3f6ee01c475d859ec) )
-	ROM_LOAD( "playball.05", 0x14000, 0x1000, CRC(a3f20810) SHA1(678d2a5a06263cc5f74f4cb92287cf4d7a8b934f) )
-	ROM_LOAD( "playball.06", 0x15000, 0x1000, CRC(f213e48e) SHA1(05b54f5121a887bc24fbe30f322277ae94474c14) )
-	ROM_LOAD( "playball.07", 0x16000, 0x1000, CRC(9b5574e9) SHA1(1dddd33cd3f13694d7ba6a73e5090594c6677d5b) )
-	ROM_LOAD( "playball.08", 0x17000, 0x1000, CRC(b2d2074a) SHA1(2defb2ffaca782606f792020f9c96d41abd77518) )
-	ROM_LOAD( "playball.09", 0x18000, 0x1000, CRC(c4566d0f) SHA1(7848ea87d2d1693ade9129846024fbedc4145cbb) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "speech.ic4",   0xb000, 0x1000, CRC(7e4fc798) SHA1(4636ab25238503370063f51f86f37d0e49c0d3b6) )
@@ -3363,26 +3359,26 @@ ROM_END
 
 
 ROM_START( blaster ) // 20 Level version - Each ROM label had an additional "PROTO5" or "PROTO6" sticker attached (verified on multiple PCBs)
-	ROM_REGION( 0x54000, "maincpu", 0 )
+	ROM_REGION( 0x50000, "maincpu", 0 )
+	ROM_LOAD( "proto6_blaster_3021_rom_11.ic25", 0x04000, 0x2000, CRC(6371e62f) SHA1(dc4173d2ee88757a6ac0838acaee325eadc2c4fb) ) // labeled:  BLASTER   (3021) ROM 11   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO6
+	ROM_LOAD( "proto6_blaster_3021_rom_12.ic26", 0x06000, 0x2000, CRC(9804faac) SHA1(e61218fe190ad268af48d611d140d8f4cd38e4c7) ) // labeled:  BLASTER   (3021) ROM 12   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO6
+	ROM_LOAD( "proto6_blaster_3021_rom_17.ic41", 0x08000, 0x1000, CRC(bf96182f) SHA1(e25a02508eecf79ea1ae5d45278a60becc6c7dcc) ) // labeled:  BLASTER   (3021) ROM 17   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO6
+
 	ROM_LOAD( "proto6_blaster_3021_rom_16.ic39", 0x0d000, 0x1000, CRC(54a40b21) SHA1(663c7b539e6f1f065a4ecae7bb0477c71951223f) ) // labeled:  BLASTER   (3021) ROM 16   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO6
 	ROM_LOAD( "proto6_blaster_3021_rom_13.ic27", 0x0e000, 0x2000, CRC(f4dae4c8) SHA1(211dcbe085a30419d649afe10ca7c4017d909bd7) ) // labeled:  BLASTER   (3021) ROM 13   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO6
 
-	ROM_LOAD( "proto6_blaster_3021_rom_11.ic25", 0x10000, 0x2000, CRC(6371e62f) SHA1(dc4173d2ee88757a6ac0838acaee325eadc2c4fb) ) // labeled:  BLASTER   (3021) ROM 11   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO6
-	ROM_LOAD( "proto6_blaster_3021_rom_12.ic26", 0x12000, 0x2000, CRC(9804faac) SHA1(e61218fe190ad268af48d611d140d8f4cd38e4c7) ) // labeled:  BLASTER   (3021) ROM 12   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO6
-	ROM_LOAD( "proto6_blaster_3021_rom_17.ic41", 0x14000, 0x1000, CRC(bf96182f) SHA1(e25a02508eecf79ea1ae5d45278a60becc6c7dcc) ) // labeled:  BLASTER   (3021) ROM 17   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO6
-
-	ROM_LOAD( "proto5_blaster_3021_rom_15.ic38", 0x18000, 0x4000, CRC(1ad146a4) SHA1(5ab3d9618023b59bc329a9eeef986901867a639b) ) // labeled:  BLASTER   (3021) ROM 15   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
-	ROM_LOAD( "proto5_blaster_3021_rom_8.ic20",  0x1c000, 0x4000, CRC(f110bbb0) SHA1(314dea232a3706509399348c7415f933c64cea1b) ) // labeled:  BLASTER   (3021) ROM 8   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
-	ROM_LOAD( "proto5_blaster_3021_rom_9.ic22",  0x20000, 0x4000, CRC(5c5b0f8a) SHA1(224f89c85b2b1ca511d006180b8d994fccbdfb6b) ) // labeled:  BLASTER   (3021) ROM 9   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
-	ROM_LOAD( "proto5_blaster_3021_rom_10.ic24", 0x24000, 0x4000, CRC(d47eb67f) SHA1(5dcde8be1a7b1927b90ffab3219dc47c5b2f20e4) ) // labeled:  BLASTER   (3021) ROM 10   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
-	ROM_LOAD( "proto5_blaster_3021_rom_6.ic13",  0x28000, 0x4000, CRC(47fc007e) SHA1(3a80b9b7ae460e9732f7c1cdd465a5b06ded970f) ) // labeled:  BLASTER   (3021) ROM 6   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
-	ROM_LOAD( "proto5_blaster_3021_rom_5.ic11",  0x2c000, 0x4000, CRC(15c1b94d) SHA1(5d97628541eb8933870c3ffd3646b7aaf8af6af5) ) // labeled:  BLASTER   (3021) ROM 5   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
-	ROM_LOAD( "proto5_blaster_3021_rom_14.ic35", 0x30000, 0x4000, CRC(aea6b846) SHA1(04cb4b5eb000471a0cec377a5236ac8c83529528) ) // labeled:  BLASTER   (3021) ROM 14   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
-	ROM_LOAD( "proto6_blaster_3021_rom_7.ic15",  0x34000, 0x4000, CRC(7a101181) SHA1(5f1581911ea7fe3e63ce1b9c50b1d3bf081dbf81) ) // labeled:  BLASTER   (3021) ROM 7   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO6
-	ROM_LOAD( "proto5_blaster_3021_rom_1.ic1",   0x38000, 0x4000, CRC(8d0ea9e7) SHA1(34f8e2e99748bed29285f7e4929bb920960ab03e) ) // labeled:  BLASTER   (3021) ROM 1   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
-	ROM_LOAD( "proto5_blaster_3021_rom_2.ic3",   0x3c000, 0x4000, CRC(03c4012c) SHA1(53f0adc91e5f1ac58b08b3a6d2de8de5a40bebab) ) // labeled:  BLASTER   (3021) ROM 2   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
-	ROM_LOAD( "proto6_blaster_3021_rom_4.ic7",   0x40000, 0x4000, CRC(fc9d39fb) SHA1(126d43a64471bbf4b40aeda8913d50e82d254f9c) ) // labeled:  BLASTER   (3021) ROM 4   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO6
-	ROM_LOAD( "proto6_blaster_3021_rom_3.ic6",   0x44000, 0x4000, CRC(253690fb) SHA1(06cb2ef95bb06b3618392e298aa690e1f75bc977) ) // labeled:  BLASTER   (3021) ROM 3   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO6
+	ROM_LOAD( "proto5_blaster_3021_rom_15.ic38", 0x10000, 0x4000, CRC(1ad146a4) SHA1(5ab3d9618023b59bc329a9eeef986901867a639b) ) // labeled:  BLASTER   (3021) ROM 15   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
+	ROM_LOAD( "proto5_blaster_3021_rom_8.ic20",  0x14000, 0x4000, CRC(f110bbb0) SHA1(314dea232a3706509399348c7415f933c64cea1b) ) // labeled:  BLASTER   (3021) ROM 8   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
+	ROM_LOAD( "proto5_blaster_3021_rom_9.ic22",  0x18000, 0x4000, CRC(5c5b0f8a) SHA1(224f89c85b2b1ca511d006180b8d994fccbdfb6b) ) // labeled:  BLASTER   (3021) ROM 9   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
+	ROM_LOAD( "proto5_blaster_3021_rom_10.ic24", 0x1c000, 0x4000, CRC(d47eb67f) SHA1(5dcde8be1a7b1927b90ffab3219dc47c5b2f20e4) ) // labeled:  BLASTER   (3021) ROM 10   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
+	ROM_LOAD( "proto5_blaster_3021_rom_6.ic13",  0x20000, 0x4000, CRC(47fc007e) SHA1(3a80b9b7ae460e9732f7c1cdd465a5b06ded970f) ) // labeled:  BLASTER   (3021) ROM 6   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
+	ROM_LOAD( "proto5_blaster_3021_rom_5.ic11",  0x24000, 0x4000, CRC(15c1b94d) SHA1(5d97628541eb8933870c3ffd3646b7aaf8af6af5) ) // labeled:  BLASTER   (3021) ROM 5   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
+	ROM_LOAD( "proto5_blaster_3021_rom_14.ic35", 0x28000, 0x4000, CRC(aea6b846) SHA1(04cb4b5eb000471a0cec377a5236ac8c83529528) ) // labeled:  BLASTER   (3021) ROM 14   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
+	ROM_LOAD( "proto6_blaster_3021_rom_7.ic15",  0x2c000, 0x4000, CRC(7a101181) SHA1(5f1581911ea7fe3e63ce1b9c50b1d3bf081dbf81) ) // labeled:  BLASTER   (3021) ROM 7   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO6
+	ROM_LOAD( "proto5_blaster_3021_rom_1.ic1",   0x30000, 0x4000, CRC(8d0ea9e7) SHA1(34f8e2e99748bed29285f7e4929bb920960ab03e) ) // labeled:  BLASTER   (3021) ROM 1   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
+	ROM_LOAD( "proto5_blaster_3021_rom_2.ic3",   0x34000, 0x4000, CRC(03c4012c) SHA1(53f0adc91e5f1ac58b08b3a6d2de8de5a40bebab) ) // labeled:  BLASTER   (3021) ROM 2   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
+	ROM_LOAD( "proto6_blaster_3021_rom_4.ic7",   0x38000, 0x4000, CRC(fc9d39fb) SHA1(126d43a64471bbf4b40aeda8913d50e82d254f9c) ) // labeled:  BLASTER   (3021) ROM 4   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO6
+	ROM_LOAD( "proto6_blaster_3021_rom_3.ic6",   0x3c000, 0x4000, CRC(253690fb) SHA1(06cb2ef95bb06b3618392e298aa690e1f75bc977) ) // labeled:  BLASTER   (3021) ROM 3   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO6
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "proto5_blaster_3021_rom_18.sb13", 0xf000, 0x1000, CRC(c33a3145) SHA1(6ffe2da7b70c0b576fbc1790a33eecdbb9ee3d02) ) // labeled:  BLASTER   (3021) ROM 18   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
@@ -3397,26 +3393,26 @@ ROM_START( blaster ) // 20 Level version - Each ROM label had an additional "PRO
 ROM_END
 
 ROM_START( blastero ) // 30 Level version
-	ROM_REGION( 0x54000, "maincpu", 0 )
+	ROM_REGION( 0x50000, "maincpu", 0 )
+	ROM_LOAD( "proto5_blaster_3021_rom_11.ic25", 0x04000, 0x2000, CRC(bc2d7eda) SHA1(831e9ecb75b143f9770eab1939136092a29e64f7) ) // assumed to be PROTO5 revision
+	ROM_LOAD( "proto5_blaster_3021_rom_12.ic26", 0x06000, 0x2000, CRC(8a215017) SHA1(ee9233134907c03f7a1221d9daa84fe047c2db94) ) // assumed to be PROTO5 revision
+	ROM_LOAD( "proto5_blaster_3021_rom_17.ic41", 0x08000, 0x1000, CRC(b308f0e5) SHA1(262e25be40dff66e65a0fe34c9d013a750b90876) ) // assumed to be PROTO5 revision
+
 	ROM_LOAD( "proto5_blaster_3021_rom_16.ic39", 0x0d000, 0x1000, CRC(2db032d2) SHA1(287769361639695b1c1ceae0fe6899d83b4575d5) ) // assumed to be PROTO5 revision
 	ROM_LOAD( "proto5_blaster_3021_rom_13.ic27", 0x0e000, 0x2000, CRC(c99213c7) SHA1(d1c1549c053de3d862d8ef3ebca02811ed289464) ) // assumed to be PROTO5 revision
 
-	ROM_LOAD( "proto5_blaster_3021_rom_11.ic25", 0x10000, 0x2000, CRC(bc2d7eda) SHA1(831e9ecb75b143f9770eab1939136092a29e64f7) ) // assumed to be PROTO5 revision
-	ROM_LOAD( "proto5_blaster_3021_rom_12.ic26", 0x12000, 0x2000, CRC(8a215017) SHA1(ee9233134907c03f7a1221d9daa84fe047c2db94) ) // assumed to be PROTO5 revision
-	ROM_LOAD( "proto5_blaster_3021_rom_17.ic41", 0x14000, 0x1000, CRC(b308f0e5) SHA1(262e25be40dff66e65a0fe34c9d013a750b90876) ) // assumed to be PROTO5 revision
-
-	ROM_LOAD( "proto5_blaster_3021_rom_15.ic38", 0x18000, 0x4000, CRC(1ad146a4) SHA1(5ab3d9618023b59bc329a9eeef986901867a639b) )
-	ROM_LOAD( "proto5_blaster_3021_rom_8.ic20",  0x1c000, 0x4000, CRC(f110bbb0) SHA1(314dea232a3706509399348c7415f933c64cea1b) )
-	ROM_LOAD( "proto5_blaster_3021_rom_9.ic22",  0x20000, 0x4000, CRC(5c5b0f8a) SHA1(224f89c85b2b1ca511d006180b8d994fccbdfb6b) )
-	ROM_LOAD( "proto5_blaster_3021_rom_10.ic24", 0x24000, 0x4000, CRC(d47eb67f) SHA1(5dcde8be1a7b1927b90ffab3219dc47c5b2f20e4) )
-	ROM_LOAD( "proto5_blaster_3021_rom_6.ic13",  0x28000, 0x4000, CRC(47fc007e) SHA1(3a80b9b7ae460e9732f7c1cdd465a5b06ded970f) )
-	ROM_LOAD( "proto5_blaster_3021_rom_5.ic11",  0x2c000, 0x4000, CRC(15c1b94d) SHA1(5d97628541eb8933870c3ffd3646b7aaf8af6af5) )
-	ROM_LOAD( "proto5_blaster_3021_rom_14.ic35", 0x30000, 0x4000, CRC(aea6b846) SHA1(04cb4b5eb000471a0cec377a5236ac8c83529528) )
-	ROM_LOAD( "proto5_blaster_3021_rom_7.ic15",  0x34000, 0x4000, CRC(a1c4db77) SHA1(7a878d44b6ca7444ecbb6c8f75e5e91de149daf3) ) // assumed to be PROTO5 revision
-	ROM_LOAD( "proto5_blaster_3021_rom_1.ic1",   0x38000, 0x4000, CRC(8d0ea9e7) SHA1(34f8e2e99748bed29285f7e4929bb920960ab03e) )
-	ROM_LOAD( "proto5_blaster_3021_rom_2.ic3",   0x3c000, 0x4000, CRC(03c4012c) SHA1(53f0adc91e5f1ac58b08b3a6d2de8de5a40bebab) )
-	ROM_LOAD( "proto5_blaster_3021_rom_4.ic7",   0x40000, 0x4000, CRC(39d2a32c) SHA1(33707877e841ef86a11b47ffabddce7f3d2a7030) ) // assumed to be PROTO5 revision
-	ROM_LOAD( "proto5_blaster_3021_rom_3.ic6",   0x44000, 0x4000, CRC(054c9f1c) SHA1(c21e3493f1ae506ab9fd28ed9ecc67d3305e9d7a) ) // assumed to be PROTO5 revision
+	ROM_LOAD( "proto5_blaster_3021_rom_15.ic38", 0x10000, 0x4000, CRC(1ad146a4) SHA1(5ab3d9618023b59bc329a9eeef986901867a639b) )
+	ROM_LOAD( "proto5_blaster_3021_rom_8.ic20",  0x14000, 0x4000, CRC(f110bbb0) SHA1(314dea232a3706509399348c7415f933c64cea1b) )
+	ROM_LOAD( "proto5_blaster_3021_rom_9.ic22",  0x18000, 0x4000, CRC(5c5b0f8a) SHA1(224f89c85b2b1ca511d006180b8d994fccbdfb6b) )
+	ROM_LOAD( "proto5_blaster_3021_rom_10.ic24", 0x1c000, 0x4000, CRC(d47eb67f) SHA1(5dcde8be1a7b1927b90ffab3219dc47c5b2f20e4) )
+	ROM_LOAD( "proto5_blaster_3021_rom_6.ic13",  0x20000, 0x4000, CRC(47fc007e) SHA1(3a80b9b7ae460e9732f7c1cdd465a5b06ded970f) )
+	ROM_LOAD( "proto5_blaster_3021_rom_5.ic11",  0x24000, 0x4000, CRC(15c1b94d) SHA1(5d97628541eb8933870c3ffd3646b7aaf8af6af5) )
+	ROM_LOAD( "proto5_blaster_3021_rom_14.ic35", 0x28000, 0x4000, CRC(aea6b846) SHA1(04cb4b5eb000471a0cec377a5236ac8c83529528) )
+	ROM_LOAD( "proto5_blaster_3021_rom_7.ic15",  0x2c000, 0x4000, CRC(a1c4db77) SHA1(7a878d44b6ca7444ecbb6c8f75e5e91de149daf3) ) // assumed to be PROTO5 revision
+	ROM_LOAD( "proto5_blaster_3021_rom_1.ic1",   0x30000, 0x4000, CRC(8d0ea9e7) SHA1(34f8e2e99748bed29285f7e4929bb920960ab03e) )
+	ROM_LOAD( "proto5_blaster_3021_rom_2.ic3",   0x34000, 0x4000, CRC(03c4012c) SHA1(53f0adc91e5f1ac58b08b3a6d2de8de5a40bebab) )
+	ROM_LOAD( "proto5_blaster_3021_rom_4.ic7",   0x38000, 0x4000, CRC(39d2a32c) SHA1(33707877e841ef86a11b47ffabddce7f3d2a7030) ) // assumed to be PROTO5 revision
+	ROM_LOAD( "proto5_blaster_3021_rom_3.ic6",   0x3c000, 0x4000, CRC(054c9f1c) SHA1(c21e3493f1ae506ab9fd28ed9ecc67d3305e9d7a) ) // assumed to be PROTO5 revision
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "proto5_blaster_3021_rom_18.sb13", 0xf000, 0x1000, CRC(c33a3145) SHA1(6ffe2da7b70c0b576fbc1790a33eecdbb9ee3d02) ) // labeled:  BLASTER   (3021) ROM 18   (c) 1983 WILLIAMS   ELECTRONICS, INC.   PROTO5
@@ -3431,26 +3427,26 @@ ROM_START( blastero ) // 30 Level version
 ROM_END
 
 ROM_START( blasterkit ) // 20 Level version with single sound board & mono sound
-	ROM_REGION( 0x54000, "maincpu", 0 )
+	ROM_REGION( 0x50000, "maincpu", 0 )
+	ROM_LOAD( "blastkit_rom_11.ic25", 0x04000, 0x2000, CRC(b7df4914) SHA1(81f7a89dfde06c160f2c8974eec701f2298ec434) ) // unique to this set
+	ROM_LOAD( "blastkit_rom_12.ic26", 0x06000, 0x2000, CRC(8b1e26ab) SHA1(7d30800a9302f5a83792499d8df536693d01f75d) ) // unique to this set
+	ROM_LOAD( "blastkit_rom_17.ic41", 0x08000, 0x1000, CRC(577d1e9a) SHA1(0064124a65490e0473dfb0081ec28b7ee43a04b5) ) // unique to this set
+
 	ROM_LOAD( "blastkit_rom_16.ic39", 0x0d000, 0x1000, CRC(414b2abf) SHA1(2bde972d225d6e93e44751f542cee584d57f7983) ) // unique to this set
 	ROM_LOAD( "blastkit_rom_13.ic27", 0x0e000, 0x2000, CRC(9c64db76) SHA1(c14508cb2f964af93631779db3adaa960fcc7559) ) // unique to this set
 
-	ROM_LOAD( "blastkit_rom_11.ic25", 0x10000, 0x2000, CRC(b7df4914) SHA1(81f7a89dfde06c160f2c8974eec701f2298ec434) ) // unique to this set
-	ROM_LOAD( "blastkit_rom_12.ic26", 0x12000, 0x2000, CRC(8b1e26ab) SHA1(7d30800a9302f5a83792499d8df536693d01f75d) ) // unique to this set
-	ROM_LOAD( "blastkit_rom_17.ic41", 0x14000, 0x1000, CRC(577d1e9a) SHA1(0064124a65490e0473dfb0081ec28b7ee43a04b5) ) // unique to this set
-
-	ROM_LOAD( "blastkit_rom_15.ic38", 0x18000, 0x4000, CRC(1ad146a4) SHA1(5ab3d9618023b59bc329a9eeef986901867a639b) )
-	ROM_LOAD( "blastkit_rom_8.ic20",  0x1c000, 0x4000, CRC(f110bbb0) SHA1(314dea232a3706509399348c7415f933c64cea1b) )
-	ROM_LOAD( "blastkit_rom_9.ic22",  0x20000, 0x4000, CRC(5c5b0f8a) SHA1(224f89c85b2b1ca511d006180b8d994fccbdfb6b) )
-	ROM_LOAD( "blastkit_rom_10.ic24", 0x24000, 0x4000, CRC(d47eb67f) SHA1(5dcde8be1a7b1927b90ffab3219dc47c5b2f20e4) )
-	ROM_LOAD( "blastkit_rom_6.ic13",  0x28000, 0x4000, CRC(47fc007e) SHA1(3a80b9b7ae460e9732f7c1cdd465a5b06ded970f) )
-	ROM_LOAD( "blastkit_rom_5.ic11",  0x2c000, 0x4000, CRC(15c1b94d) SHA1(5d97628541eb8933870c3ffd3646b7aaf8af6af5) )
-	ROM_LOAD( "blastkit_rom_14.ic35", 0x30000, 0x4000, CRC(aea6b846) SHA1(04cb4b5eb000471a0cec377a5236ac8c83529528) )
-	ROM_LOAD( "blastkit_rom_7.ic15",  0x34000, 0x4000, CRC(6fcc2153) SHA1(00e7b6846c15400315d94e2c7d1c99b1a737c285) ) // unique to this set
-	ROM_LOAD( "blastkit_rom_1.ic1",   0x38000, 0x4000, CRC(8d0ea9e7) SHA1(34f8e2e99748bed29285f7e4929bb920960ab03e) )
-	ROM_LOAD( "blastkit_rom_2.ic3",   0x3c000, 0x4000, CRC(03c4012c) SHA1(53f0adc91e5f1ac58b08b3a6d2de8de5a40bebab) )
-	ROM_LOAD( "blastkit_rom_4.ic7",   0x40000, 0x4000, CRC(f80e9ff5) SHA1(e232d96b6e07c7b4240fa4dd2cb9be4745a1be4b) ) // unique to this set
-	ROM_LOAD( "blastkit_rom_3.ic6",   0x44000, 0x4000, CRC(20e851f9) SHA1(efc288ef0333812a6282f22aade8e43e9a827533) ) // unique to this set
+	ROM_LOAD( "blastkit_rom_15.ic38", 0x10000, 0x4000, CRC(1ad146a4) SHA1(5ab3d9618023b59bc329a9eeef986901867a639b) )
+	ROM_LOAD( "blastkit_rom_8.ic20",  0x14000, 0x4000, CRC(f110bbb0) SHA1(314dea232a3706509399348c7415f933c64cea1b) )
+	ROM_LOAD( "blastkit_rom_9.ic22",  0x18000, 0x4000, CRC(5c5b0f8a) SHA1(224f89c85b2b1ca511d006180b8d994fccbdfb6b) )
+	ROM_LOAD( "blastkit_rom_10.ic24", 0x1c000, 0x4000, CRC(d47eb67f) SHA1(5dcde8be1a7b1927b90ffab3219dc47c5b2f20e4) )
+	ROM_LOAD( "blastkit_rom_6.ic13",  0x20000, 0x4000, CRC(47fc007e) SHA1(3a80b9b7ae460e9732f7c1cdd465a5b06ded970f) )
+	ROM_LOAD( "blastkit_rom_5.ic11",  0x24000, 0x4000, CRC(15c1b94d) SHA1(5d97628541eb8933870c3ffd3646b7aaf8af6af5) )
+	ROM_LOAD( "blastkit_rom_14.ic35", 0x28000, 0x4000, CRC(aea6b846) SHA1(04cb4b5eb000471a0cec377a5236ac8c83529528) )
+	ROM_LOAD( "blastkit_rom_7.ic15",  0x2c000, 0x4000, CRC(6fcc2153) SHA1(00e7b6846c15400315d94e2c7d1c99b1a737c285) ) // unique to this set
+	ROM_LOAD( "blastkit_rom_1.ic1",   0x30000, 0x4000, CRC(8d0ea9e7) SHA1(34f8e2e99748bed29285f7e4929bb920960ab03e) )
+	ROM_LOAD( "blastkit_rom_2.ic3",   0x34000, 0x4000, CRC(03c4012c) SHA1(53f0adc91e5f1ac58b08b3a6d2de8de5a40bebab) )
+	ROM_LOAD( "blastkit_rom_4.ic7",   0x38000, 0x4000, CRC(f80e9ff5) SHA1(e232d96b6e07c7b4240fa4dd2cb9be4745a1be4b) ) // unique to this set
+	ROM_LOAD( "blastkit_rom_3.ic6",   0x3c000, 0x4000, CRC(20e851f9) SHA1(efc288ef0333812a6282f22aade8e43e9a827533) ) // unique to this set
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "blastkit_rom_18", 0xf000, 0x1000, CRC(c33a3145) SHA1(6ffe2da7b70c0b576fbc1790a33eecdbb9ee3d02) )
@@ -3463,19 +3459,19 @@ ROM_END
 
 
 ROM_START( spdball )
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "speedbal.01", 0x00000, 0x1000, CRC(7f4801bb) SHA1(8f22396170571189b1d088d73331d6a713c76f41) )
+	ROM_LOAD( "speedbal.02", 0x01000, 0x1000, CRC(5cd5e489) SHA1(83c1bce945ecbaa4a59e0023198e574d9069680c) )
+	ROM_LOAD( "speedbal.03", 0x02000, 0x1000, CRC(280e11a4) SHA1(4ef321e1744955a9a54c1e4b1f88c01c01e7b7c8) )
+	ROM_LOAD( "speedbal.04", 0x03000, 0x1000, CRC(3469cbbf) SHA1(70b46cf686438441484ffeca0fa1398c15c8811e) )
+	ROM_LOAD( "speedbal.05", 0x04000, 0x1000, CRC(87373c89) SHA1(a3cd72f4b517d5d727059a7d911b79ced27e9f93) )
+	ROM_LOAD( "speedbal.06", 0x05000, 0x1000, CRC(48779a0d) SHA1(9cdfc12d1021b5d66acd38ab61f385219be39f4f) )
+	ROM_LOAD( "speedbal.07", 0x06000, 0x1000, CRC(2e5d8db6) SHA1(7a13d60267ce12a6a4b20322c2ed1f39762bc663) )
+	ROM_LOAD( "speedbal.08", 0x07000, 0x1000, CRC(c173cedf) SHA1(603c4c7cdc712d54a86b59470651d00b369293d8) )
+	ROM_LOAD( "speedbal.09", 0x08000, 0x1000, CRC(415f424b) SHA1(f7e59385a67319ba152488762af1b42fc62ab264) )
 	ROM_LOAD( "speedbal.10", 0x0d000, 0x1000, CRC(4a3add93) SHA1(6939dd6cb6751a0406f364223029eff99040f9e2) )
 	ROM_LOAD( "speedbal.11", 0x0e000, 0x1000, CRC(1fbcfaa5) SHA1(fccdebbab172b141bbaec6f520b378d21c72f67a) )
 	ROM_LOAD( "speedbal.12", 0x0f000, 0x1000, CRC(f3458f41) SHA1(366fb880b4dc68849d6ea7a9dab55efa9c566123) )
-	ROM_LOAD( "speedbal.01", 0x10000, 0x1000, CRC(7f4801bb) SHA1(8f22396170571189b1d088d73331d6a713c76f41) )
-	ROM_LOAD( "speedbal.02", 0x11000, 0x1000, CRC(5cd5e489) SHA1(83c1bce945ecbaa4a59e0023198e574d9069680c) )
-	ROM_LOAD( "speedbal.03", 0x12000, 0x1000, CRC(280e11a4) SHA1(4ef321e1744955a9a54c1e4b1f88c01c01e7b7c8) )
-	ROM_LOAD( "speedbal.04", 0x13000, 0x1000, CRC(3469cbbf) SHA1(70b46cf686438441484ffeca0fa1398c15c8811e) )
-	ROM_LOAD( "speedbal.05", 0x14000, 0x1000, CRC(87373c89) SHA1(a3cd72f4b517d5d727059a7d911b79ced27e9f93) )
-	ROM_LOAD( "speedbal.06", 0x15000, 0x1000, CRC(48779a0d) SHA1(9cdfc12d1021b5d66acd38ab61f385219be39f4f) )
-	ROM_LOAD( "speedbal.07", 0x16000, 0x1000, CRC(2e5d8db6) SHA1(7a13d60267ce12a6a4b20322c2ed1f39762bc663) )
-	ROM_LOAD( "speedbal.08", 0x17000, 0x1000, CRC(c173cedf) SHA1(603c4c7cdc712d54a86b59470651d00b369293d8) )
-	ROM_LOAD( "speedbal.09", 0x18000, 0x1000, CRC(415f424b) SHA1(f7e59385a67319ba152488762af1b42fc62ab264) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "speedbal.snd", 0xf000, 0x1000, CRC(78de20e2) SHA1(ece6e04b1d57167faf7aaee0829e7c31eb560437) )
@@ -3486,38 +3482,38 @@ ROM_END
 
 
 ROM_START( alienar )
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "aarom01",   0x00000, 0x1000, CRC(bb0c21be) SHA1(dbf122870adaa49cd99e2c1e9fa4b78fb74ef2c1) )
+	ROM_LOAD( "aarom02",   0x01000, 0x1000, CRC(165acd37) SHA1(12466c94bcf5a98f154a639ecc2e95d5193cbab2) )
+	ROM_LOAD( "aarom03",   0x02000, 0x1000, CRC(e5d51d92) SHA1(598c928499e977a30906319c97ffa1ef2b9395d1) )
+	ROM_LOAD( "aarom04",   0x03000, 0x1000, CRC(24f6feb8) SHA1(c1b7d764785b4edfe80a90ffdc52a67c8dbbfea5) )
+	ROM_LOAD( "aarom05",   0x04000, 0x1000, CRC(5b1ac59b) SHA1(9b312eb419e994a006fda2ae61c58c31f048bace) )
+	ROM_LOAD( "aarom06",   0x05000, 0x1000, CRC(da7195a2) SHA1(ef2c2750c504176fd6a11e8463278d97cac9a5c5) )
+	ROM_LOAD( "aarom07",   0x06000, 0x1000, CRC(f9812be4) SHA1(5f116345f09cd79790612672aa48ede63fc91f56) )
+	ROM_LOAD( "aarom08",   0x07000, 0x1000, CRC(cd7f3a87) SHA1(59577059308931139ecc036d06953660a148d91c) )
+	ROM_LOAD( "aarom09",   0x08000, 0x1000, CRC(e6ce77b4) SHA1(bd4354100067654d0ad2e590591582dbdfb845b6) )
 	ROM_LOAD( "aarom10",   0x0d000, 0x1000, CRC(6feb0314) SHA1(5cf30f097bc695cbd388cb408e78394926362a7b) )
 	ROM_LOAD( "aarom11",   0x0e000, 0x1000, CRC(ae3a270e) SHA1(867fff32062bc876390e8ca6bd7cedae47cd92c9) )
 	ROM_LOAD( "aarom12",   0x0f000, 0x1000, CRC(6be9f09e) SHA1(98821c9b94301c5fd6e7f5d9e4bc9c1bdbab53ec) )
-	ROM_LOAD( "aarom01",   0x10000, 0x1000, CRC(bb0c21be) SHA1(dbf122870adaa49cd99e2c1e9fa4b78fb74ef2c1) )
-	ROM_LOAD( "aarom02",   0x11000, 0x1000, CRC(165acd37) SHA1(12466c94bcf5a98f154a639ecc2e95d5193cbab2) )
-	ROM_LOAD( "aarom03",   0x12000, 0x1000, CRC(e5d51d92) SHA1(598c928499e977a30906319c97ffa1ef2b9395d1) )
-	ROM_LOAD( "aarom04",   0x13000, 0x1000, CRC(24f6feb8) SHA1(c1b7d764785b4edfe80a90ffdc52a67c8dbbfea5) )
-	ROM_LOAD( "aarom05",   0x14000, 0x1000, CRC(5b1ac59b) SHA1(9b312eb419e994a006fda2ae61c58c31f048bace) )
-	ROM_LOAD( "aarom06",   0x15000, 0x1000, CRC(da7195a2) SHA1(ef2c2750c504176fd6a11e8463278d97cac9a5c5) )
-	ROM_LOAD( "aarom07",   0x16000, 0x1000, CRC(f9812be4) SHA1(5f116345f09cd79790612672aa48ede63fc91f56) )
-	ROM_LOAD( "aarom08",   0x17000, 0x1000, CRC(cd7f3a87) SHA1(59577059308931139ecc036d06953660a148d91c) )
-	ROM_LOAD( "aarom09",   0x18000, 0x1000, CRC(e6ce77b4) SHA1(bd4354100067654d0ad2e590591582dbdfb845b6) )
 
 	ROM_REGION( 0x10000, "soundcpu", ROMREGION_ERASE00 )
 ROM_END
 
 
 ROM_START( alienaru )
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "aarom01",   0x00000, 0x1000, CRC(bb0c21be) SHA1(dbf122870adaa49cd99e2c1e9fa4b78fb74ef2c1) )
+	ROM_LOAD( "aarom02",   0x01000, 0x1000, CRC(165acd37) SHA1(12466c94bcf5a98f154a639ecc2e95d5193cbab2) )
+	ROM_LOAD( "aarom03",   0x02000, 0x1000, CRC(e5d51d92) SHA1(598c928499e977a30906319c97ffa1ef2b9395d1) )
+	ROM_LOAD( "aarom04",   0x03000, 0x1000, CRC(24f6feb8) SHA1(c1b7d764785b4edfe80a90ffdc52a67c8dbbfea5) )
+	ROM_LOAD( "aarom05",   0x04000, 0x1000, CRC(5b1ac59b) SHA1(9b312eb419e994a006fda2ae61c58c31f048bace) )
+	ROM_LOAD( "aarom06",   0x05000, 0x1000, CRC(da7195a2) SHA1(ef2c2750c504176fd6a11e8463278d97cac9a5c5) )
+	ROM_LOAD( "aarom07",   0x06000, 0x1000, CRC(f9812be4) SHA1(5f116345f09cd79790612672aa48ede63fc91f56) )
+	ROM_LOAD( "aarom08",   0x07000, 0x1000, CRC(cd7f3a87) SHA1(59577059308931139ecc036d06953660a148d91c) )
+	ROM_LOAD( "aarom09",   0x08000, 0x1000, CRC(e6ce77b4) SHA1(bd4354100067654d0ad2e590591582dbdfb845b6) )
 	ROM_LOAD( "aarom10",   0x0d000, 0x1000, CRC(6feb0314) SHA1(5cf30f097bc695cbd388cb408e78394926362a7b) )
 	ROM_LOAD( "aarom11",   0x0e000, 0x1000, CRC(ae3a270e) SHA1(867fff32062bc876390e8ca6bd7cedae47cd92c9) )
 	ROM_LOAD( "aarom12",   0x0f000, 0x1000, CRC(6be9f09e) SHA1(98821c9b94301c5fd6e7f5d9e4bc9c1bdbab53ec) )
-	ROM_LOAD( "aarom01",   0x10000, 0x1000, CRC(bb0c21be) SHA1(dbf122870adaa49cd99e2c1e9fa4b78fb74ef2c1) )
-	ROM_LOAD( "aarom02",   0x11000, 0x1000, CRC(165acd37) SHA1(12466c94bcf5a98f154a639ecc2e95d5193cbab2) )
-	ROM_LOAD( "aarom03",   0x12000, 0x1000, CRC(e5d51d92) SHA1(598c928499e977a30906319c97ffa1ef2b9395d1) )
-	ROM_LOAD( "aarom04",   0x13000, 0x1000, CRC(24f6feb8) SHA1(c1b7d764785b4edfe80a90ffdc52a67c8dbbfea5) )
-	ROM_LOAD( "aarom05",   0x14000, 0x1000, CRC(5b1ac59b) SHA1(9b312eb419e994a006fda2ae61c58c31f048bace) )
-	ROM_LOAD( "aarom06",   0x15000, 0x1000, CRC(da7195a2) SHA1(ef2c2750c504176fd6a11e8463278d97cac9a5c5) )
-	ROM_LOAD( "aarom07",   0x16000, 0x1000, CRC(f9812be4) SHA1(5f116345f09cd79790612672aa48ede63fc91f56) )
-	ROM_LOAD( "aarom08",   0x17000, 0x1000, CRC(cd7f3a87) SHA1(59577059308931139ecc036d06953660a148d91c) )
-	ROM_LOAD( "aarom09",   0x18000, 0x1000, CRC(e6ce77b4) SHA1(bd4354100067654d0ad2e590591582dbdfb845b6) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "sg.snd",    0xf800, 0x0800, CRC(2fcf6c4d) SHA1(9c4334ac3ff15d94001b22fc367af40f9deb7d57) )
@@ -3529,19 +3525,19 @@ ROM_END
 
 
 ROM_START( lottofun )
-	ROM_REGION( 0x19000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "vl4e.dat",    0x00000, 0x1000, CRC(5e9af236) SHA1(6f26c9be6da6f1195a4569f003a010d3f2e0c24d) )
+	ROM_LOAD( "vl4c.dat",    0x01000, 0x1000, CRC(4b134ae2) SHA1(86756e1d8de113571857818a98d347789c003339) )
+	ROM_LOAD( "vl4a.dat",    0x02000, 0x1000, CRC(b2f1f95a) SHA1(89166cdf4aff5e5a8cc4ea6ba589ce095de82f57) )
+	ROM_LOAD( "vl5e.dat",    0x03000, 0x1000, CRC(c8681c55) SHA1(ac63e53a958f63bd0a05f36303c1aa777aee799d) )
+	ROM_LOAD( "vl5c.dat",    0x04000, 0x1000, CRC(eb9351e0) SHA1(c66477ca0b3ed95708eb478fb992833beda1a4f8) )
+	ROM_LOAD( "vl5a.dat",    0x05000, 0x1000, CRC(534f2fa1) SHA1(c034aa037ef6bc7cd2ed85da7531fd8efb7083e4) )
+	ROM_LOAD( "vl6e.dat",    0x06000, 0x1000, CRC(befac592) SHA1(548cb1f0bc178eeada144c443545f7545c90b6a6) )
+	ROM_LOAD( "vl6c.dat",    0x07000, 0x1000, CRC(a73d7f13) SHA1(833ff14c33635b61e1bd45b2878a4f6c9e18bf82) )
+	ROM_LOAD( "vl6a.dat",    0x08000, 0x1000, CRC(5730a43d) SHA1(8acadf105dc373bf2b3087ccc1667b872452c913) )
 	ROM_LOAD( "vl7a.dat",    0x0d000, 0x1000, CRC(fb2aec2c) SHA1(73dc6a6dfe9ba51e3612b6d912bd7af1d5782296) )
 	ROM_LOAD( "vl7c.dat",    0x0e000, 0x1000, CRC(9a496519) SHA1(ae98dadcb63a33c796a3e3083d4b5bc957873cbc) )
 	ROM_LOAD( "vl7e.dat",    0x0f000, 0x1000, CRC(032cab4b) SHA1(87bdd0fd58b12e39efaadcf6e82744886a9292e9) )
-	ROM_LOAD( "vl4e.dat",    0x10000, 0x1000, CRC(5e9af236) SHA1(6f26c9be6da6f1195a4569f003a010d3f2e0c24d) )
-	ROM_LOAD( "vl4c.dat",    0x11000, 0x1000, CRC(4b134ae2) SHA1(86756e1d8de113571857818a98d347789c003339) )
-	ROM_LOAD( "vl4a.dat",    0x12000, 0x1000, CRC(b2f1f95a) SHA1(89166cdf4aff5e5a8cc4ea6ba589ce095de82f57) )
-	ROM_LOAD( "vl5e.dat",    0x13000, 0x1000, CRC(c8681c55) SHA1(ac63e53a958f63bd0a05f36303c1aa777aee799d) )
-	ROM_LOAD( "vl5c.dat",    0x14000, 0x1000, CRC(eb9351e0) SHA1(c66477ca0b3ed95708eb478fb992833beda1a4f8) )
-	ROM_LOAD( "vl5a.dat",    0x15000, 0x1000, CRC(534f2fa1) SHA1(c034aa037ef6bc7cd2ed85da7531fd8efb7083e4) )
-	ROM_LOAD( "vl6e.dat",    0x16000, 0x1000, CRC(befac592) SHA1(548cb1f0bc178eeada144c443545f7545c90b6a6) )
-	ROM_LOAD( "vl6c.dat",    0x17000, 0x1000, CRC(a73d7f13) SHA1(833ff14c33635b61e1bd45b2878a4f6c9e18bf82) )
-	ROM_LOAD( "vl6a.dat",    0x18000, 0x1000, CRC(5730a43d) SHA1(8acadf105dc373bf2b3087ccc1667b872452c913) )
 
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "vl2532.snd",   0xf000, 0x1000, CRC(214b8a04) SHA1(45f06b44a605cca6b293b20cfea4763b469254b8) )
@@ -3549,7 +3545,7 @@ ROM_END
 
 
 ROM_START( mysticm )
-	ROM_REGION( 0x50000, "maincpu", 0 )
+	ROM_REGION( 0x30000, "maincpu", 0 )
 	ROM_LOAD( "mm02_2.a09", 0x0e000, 0x1000, CRC(3a776ea8) SHA1(1fef5f5cef5e10606c97ac9c365f000a88d51314) ) // IC9
 	ROM_LOAD( "mm03_2.a10", 0x0f000, 0x1000, CRC(6e247c75) SHA1(4daf5206d29b887cd1a78528fac4b0cd8ec7f39b) ) // IC10
 
@@ -3558,25 +3554,25 @@ ROM_START( mysticm )
 	ROM_LOAD( "mm07_1.a14", 0x14000, 0x2000, CRC(ea2a2a68) SHA1(71855c874cd5032f47fafc67e2d1667f956cd9b5) ) // IC14
 	ROM_LOAD( "mm05_1.a12", 0x16000, 0x2000, CRC(b514eef3) SHA1(0f9309768c416dd98e9c02121cc750993a2923ea) ) // IC12
 
-	ROM_LOAD( "mm18_1.a26", 0x20000, 0x2000, CRC(9b391a81) SHA1(b3f34e5d468fe4a4de2d4e771e2fa08de6596f26) ) // IC26
-	ROM_LOAD( "mm16_1.a24", 0x22000, 0x2000, CRC(399e175d) SHA1(e17301e4159e5a6d83c3ca62c93eb70f34b948df) ) // IC24
-	ROM_LOAD( "mm14_1.a22", 0x24000, 0x2000, CRC(191153b1) SHA1(fcd8aa6ad6506ba51a01f777f6a3b94e9c051b1c) ) // IC22
+	ROM_LOAD( "mm18_1.a26", 0x18000, 0x2000, CRC(9b391a81) SHA1(b3f34e5d468fe4a4de2d4e771e2fa08de6596f26) ) // IC26
+	ROM_LOAD( "mm16_1.a24", 0x1a000, 0x2000, CRC(399e175d) SHA1(e17301e4159e5a6d83c3ca62c93eb70f34b948df) ) // IC24
+	ROM_LOAD( "mm14_1.a22", 0x1c000, 0x2000, CRC(191153b1) SHA1(fcd8aa6ad6506ba51a01f777f6a3b94e9c051b1c) ) // IC22
 
-	ROM_LOAD( "mm10_1.a17", 0x30000, 0x2000, CRC(d6a37509) SHA1(4b1f52954ca208ccc040c017873777fbf7fbd1f2) ) // IC17
-	ROM_LOAD( "mm08_1.a15", 0x32000, 0x2000, CRC(6f1a64f2) SHA1(4183b658b257d7fe35e1d7271f76d3358df5a7a2) ) // IC15
-	ROM_LOAD( "mm06_1.a13", 0x34000, 0x2000, CRC(2e6795d4) SHA1(8b074f6a7a4b5a9705de498684180815581faea2) ) // IC13
-	ROM_LOAD( "mm04_1.a11", 0x36000, 0x2000, CRC(c222fb64) SHA1(b4c51d2b1664ef3267df1dee9e4888acf847c286) ) // IC11
+	ROM_LOAD( "mm10_1.a17", 0x20000, 0x2000, CRC(d6a37509) SHA1(4b1f52954ca208ccc040c017873777fbf7fbd1f2) ) // IC17
+	ROM_LOAD( "mm08_1.a15", 0x22000, 0x2000, CRC(6f1a64f2) SHA1(4183b658b257d7fe35e1d7271f76d3358df5a7a2) ) // IC15
+	ROM_LOAD( "mm06_1.a13", 0x24000, 0x2000, CRC(2e6795d4) SHA1(8b074f6a7a4b5a9705de498684180815581faea2) ) // IC13
+	ROM_LOAD( "mm04_1.a11", 0x26000, 0x2000, CRC(c222fb64) SHA1(b4c51d2b1664ef3267df1dee9e4888acf847c286) ) // IC11
 
-	ROM_LOAD( "mm17_1.a25", 0x40000, 0x2000, CRC(d36f0a96) SHA1(9830955ca7e46b5b0dba98b4d2ea325bbbebe3c7) ) // IC25
-	ROM_LOAD( "mm15_1.a23", 0x42000, 0x2000, CRC(cd5d99da) SHA1(41a37903503c14fb9c801c51afa2f97c83b79f8b) ) // IC23
-	ROM_LOAD( "mm13_1.a21", 0x44000, 0x2000, CRC(ef4b79db) SHA1(346057cb8c4593df44fb36771553e60610fe1a0c) ) // IC21
-	ROM_LOAD( "mm12_1.a19", 0x46000, 0x2000, CRC(a1f04bf0) SHA1(389bdb7c9e395af9275abfb20c3ab51bc12dc4db) ) // IC19
+	ROM_LOAD( "mm17_1.a25", 0x28000, 0x2000, CRC(d36f0a96) SHA1(9830955ca7e46b5b0dba98b4d2ea325bbbebe3c7) ) // IC25
+	ROM_LOAD( "mm15_1.a23", 0x2a000, 0x2000, CRC(cd5d99da) SHA1(41a37903503c14fb9c801c51afa2f97c83b79f8b) ) // IC23
+	ROM_LOAD( "mm13_1.a21", 0x2c000, 0x2000, CRC(ef4b79db) SHA1(346057cb8c4593df44fb36771553e60610fe1a0c) ) // IC21
+	ROM_LOAD( "mm12_1.a19", 0x2e000, 0x2000, CRC(a1f04bf0) SHA1(389bdb7c9e395af9275abfb20c3ab51bc12dc4db) ) // IC19
 
 	// sound CPU
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "mm01_1.a08", 0x0e000, 0x2000, CRC(65339512) SHA1(144625d2905c953383bcc90cd2435d332394883f) ) // IC8
 
-	ROM_REGION( 0x6000, "gfx1", 0 )
+	ROM_REGION( 0x6000, "tiles", 0 )
 	ROM_LOAD( "mm20_1.b57", 0x00000, 0x2000, CRC(5c0f4f46) SHA1(7dedbbeda2f34a2eac9fb14277874d9d66f468c7) ) // IC57
 	ROM_LOAD( "mm21_1.b58", 0x02000, 0x2000, CRC(cb90b3c5) SHA1(f28cca2c3ff23d6c9e2952a1b08ab2875655ec70) ) // IC58
 	ROM_LOAD( "mm19_1.b41", 0x04000, 0x2000, CRC(e274df86) SHA1(9876a487c5efa350ced31acbc39df22c8d414677) ) // IC41
@@ -3588,7 +3584,7 @@ ROM_START( mysticm )
 ROM_END
 
 ROM_START( mysticmp )
-	ROM_REGION( 0x50000, "maincpu", 0 )
+	ROM_REGION( 0x30000, "maincpu", 0 )
 	ROM_LOAD( "cpu_2732_ic9_rom2_proto6.d4",    0x0e000, 0x1000, CRC(3e4f53dd) SHA1(ebe36af7367b7f1037f5d7d55817e5580db6f10f) ) // ic9, different
 	ROM_LOAD( "cpu_2732_ic10_rom3_proto6.f4",   0x0f000, 0x1000, CRC(6a25ee4b) SHA1(0668a0f3d6ddcf413d8b1f4f8f5b9a2dc9c4edc1) ) // ic10, different
 
@@ -3597,25 +3593,25 @@ ROM_START( mysticmp )
 	ROM_LOAD( "cpu_2764_ic14_rom7_proto5.j6",   0x14000, 0x2000, CRC(ea2a2a68) SHA1(71855c874cd5032f47fafc67e2d1667f956cd9b5) ) // ic14
 	ROM_LOAD( "cpu_2764_ic12_rom5_proto5.h6",   0x16000, 0x2000, CRC(b514eef3) SHA1(0f9309768c416dd98e9c02121cc750993a2923ea) ) // ic12
 
-	ROM_LOAD( "cpu_2764_ic26_rom18_proto5.j10", 0x20000, 0x2000, CRC(9b391a81) SHA1(b3f34e5d468fe4a4de2d4e771e2fa08de6596f26) ) // ic26
-	ROM_LOAD( "cpu_2764_ic24_rom16_proto5.h10", 0x22000, 0x2000, CRC(399e175d) SHA1(e17301e4159e5a6d83c3ca62c93eb70f34b948df) ) // ic24
-	ROM_LOAD( "cpu_2764_ic22_rom14_proto5.j9",  0x24000, 0x2000, CRC(191153b1) SHA1(fcd8aa6ad6506ba51a01f777f6a3b94e9c051b1c) ) // ic22
+	ROM_LOAD( "cpu_2764_ic26_rom18_proto5.j10", 0x18000, 0x2000, CRC(9b391a81) SHA1(b3f34e5d468fe4a4de2d4e771e2fa08de6596f26) ) // ic26
+	ROM_LOAD( "cpu_2764_ic24_rom16_proto5.h10", 0x1a000, 0x2000, CRC(399e175d) SHA1(e17301e4159e5a6d83c3ca62c93eb70f34b948df) ) // ic24
+	ROM_LOAD( "cpu_2764_ic22_rom14_proto5.j9",  0x1c000, 0x2000, CRC(191153b1) SHA1(fcd8aa6ad6506ba51a01f777f6a3b94e9c051b1c) ) // ic22
 
-	ROM_LOAD( "cpu_2764_ic17_rom10_proto4.i8",  0x30000, 0x2000, CRC(d6a37509) SHA1(4b1f52954ca208ccc040c017873777fbf7fbd1f2) ) // ic17
-	ROM_LOAD( "cpu_2764_ic15_rom8_proto4.g8",   0x32000, 0x2000, CRC(6f1a64f2) SHA1(4183b658b257d7fe35e1d7271f76d3358df5a7a2) ) // ic15
-	ROM_LOAD( "cpu_2764_ic13_rom6_proto4.i6",   0x34000, 0x2000, CRC(2e6795d4) SHA1(8b074f6a7a4b5a9705de498684180815581faea2) ) // ic13
-	ROM_LOAD( "cpu_2764_ic11_rom4_proto4.g6",   0x36000, 0x2000, CRC(c222fb64) SHA1(b4c51d2b1664ef3267df1dee9e4888acf847c286) ) // ic11
+	ROM_LOAD( "cpu_2764_ic17_rom10_proto4.i8",  0x20000, 0x2000, CRC(d6a37509) SHA1(4b1f52954ca208ccc040c017873777fbf7fbd1f2) ) // ic17
+	ROM_LOAD( "cpu_2764_ic15_rom8_proto4.g8",   0x22000, 0x2000, CRC(6f1a64f2) SHA1(4183b658b257d7fe35e1d7271f76d3358df5a7a2) ) // ic15
+	ROM_LOAD( "cpu_2764_ic13_rom6_proto4.i6",   0x24000, 0x2000, CRC(2e6795d4) SHA1(8b074f6a7a4b5a9705de498684180815581faea2) ) // ic13
+	ROM_LOAD( "cpu_2764_ic11_rom4_proto4.g6",   0x26000, 0x2000, CRC(c222fb64) SHA1(b4c51d2b1664ef3267df1dee9e4888acf847c286) ) // ic11
 
-	ROM_LOAD( "cpu_2764_ic25_rom17_proto6.i10", 0x40000, 0x2000, CRC(7acc9995) SHA1(a996cbd65cf7efd1cdf9b5750b5c743c5edda4dd) ) // ic25, different
-	ROM_LOAD( "cpu_2764_ic23_rom15_proto6.g10", 0x42000, 0x2000, CRC(c32d1ce5) SHA1(0df3eafbb558699382eb729a3059e99305e2e8c8) ) // ic23, different
-	ROM_LOAD( "cpu_2764_ic21_rom13_proto6.i9",  0x44000, 0x2000, CRC(e387a785) SHA1(de98d503f4d2c947c701ff96628114b34da45f93) ) // ic21, different
-	ROM_LOAD( "cpu_2764_ic19_rom12_proto6.g9",  0x46000, 0x2000, CRC(a1f04bf0) SHA1(389bdb7c9e395af9275abfb20c3ab51bc12dc4db) ) // ic19
+	ROM_LOAD( "cpu_2764_ic25_rom17_proto6.i10", 0x28000, 0x2000, CRC(7acc9995) SHA1(a996cbd65cf7efd1cdf9b5750b5c743c5edda4dd) ) // ic25, different
+	ROM_LOAD( "cpu_2764_ic23_rom15_proto6.g10", 0x2a000, 0x2000, CRC(c32d1ce5) SHA1(0df3eafbb558699382eb729a3059e99305e2e8c8) ) // ic23, different
+	ROM_LOAD( "cpu_2764_ic21_rom13_proto6.i9",  0x2c000, 0x2000, CRC(e387a785) SHA1(de98d503f4d2c947c701ff96628114b34da45f93) ) // ic21, different
+	ROM_LOAD( "cpu_2764_ic19_rom12_proto6.g9",  0x2e000, 0x2000, CRC(a1f04bf0) SHA1(389bdb7c9e395af9275abfb20c3ab51bc12dc4db) ) // ic19
 
 	// sound CPU
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "cpu_2764_ic8_rom1_proto4.f0", 0x0e000, 0x2000, CRC(65339512) SHA1(144625d2905c953383bcc90cd2435d332394883f) )    // ic8
 
-	ROM_REGION( 0x6000, "gfx1", 0 )
+	ROM_REGION( 0x6000, "tiles", 0 )
 	ROM_LOAD( "ram_2764_ic57_rom20_rev1.f9",  0x00000, 0x2000, CRC(5c0f4f46) SHA1(7dedbbeda2f34a2eac9fb14277874d9d66f468c7) )   // ic57
 	ROM_LOAD( "ram_2764_ic58_rom21_rev1.f10", 0x02000, 0x2000, CRC(cb90b3c5) SHA1(f28cca2c3ff23d6c9e2952a1b08ab2875655ec70) )   // ic58
 	ROM_LOAD( "ram_2764_ic41_rom19_rev1.d10", 0x04000, 0x2000, CRC(e274df86) SHA1(9876a487c5efa350ced31acbc39df22c8d414677) )   // ic41
@@ -3623,7 +3619,7 @@ ROM_END
 
 
 ROM_START( tshoot )
-	ROM_REGION( 0x50000, "maincpu", 0 )
+	ROM_REGION( 0x30000, "maincpu", 0 )
 	ROM_LOAD( "rom18.ic55", 0x0d000, 0x1000, CRC(effc33f1) SHA1(cd1b16b4a4a46ce9d550d10b465b8cf1ab3c5273) )  // IC55
 	ROM_LOAD( "rom2.ic9",   0x0e000, 0x1000, CRC(fd982687) SHA1(70be1ea57ea0a1e75b1bd988492a9c0244e8b91f) )  // IC9
 	ROM_LOAD( "rom3.ic10",  0x0f000, 0x1000, CRC(9617054d) SHA1(8795b97a6391aa3804f68dc2d2b33866dc17f34c) )  // IC10
@@ -3633,24 +3629,24 @@ ROM_START( tshoot )
 	ROM_LOAD( "rom7.ic14",  0x14000, 0x2000, CRC(f25505e6) SHA1(d075ff89b6379ad7a47d9723ed1c21468b9d1dae) )  // IC14
 	ROM_LOAD( "rom5.ic12",  0x16000, 0x2000, CRC(94a7c0ed) SHA1(11f46e1ca7d79b4244ea0f60e0fba44186f1ebde) )  // IC12
 
-	ROM_LOAD( "rom17.ic26", 0x20000, 0x2000, CRC(b02d1ccd) SHA1(b08b6d9affb6f3e50a11fd9397fe4255927de3b6) )  // IC26
-	ROM_LOAD( "rom15.ic24", 0x22000, 0x2000, CRC(11709935) SHA1(ae25bbadbbcab9f3cba2bb4bb92d5217705b38e3) )  // IC24
+	ROM_LOAD( "rom17.ic26", 0x18000, 0x2000, CRC(b02d1ccd) SHA1(b08b6d9affb6f3e50a11fd9397fe4255927de3b6) )  // IC26
+	ROM_LOAD( "rom15.ic24", 0x1a000, 0x2000, CRC(11709935) SHA1(ae25bbadbbcab9f3cba2bb4bb92d5217705b38e3) )  // IC24
 
-	ROM_LOAD( "rom10.ic17", 0x30000, 0x2000, CRC(0f32bad8) SHA1(7a2f559697d252ceec3a2f55fe51bc755e4bb65a) )  // IC17
-	ROM_LOAD( "rom8.ic15",  0x32000, 0x2000, CRC(e9b6cbf7) SHA1(6cd6b1e1c5e8e253e779afff8ad1ff90d6116fc9) )  // IC15
-	ROM_LOAD( "rom6.ic13",  0x34000, 0x2000, CRC(a49f617f) SHA1(759d25e33a09204664880329b86724805a1fe0e8) )  // IC13
-	ROM_LOAD( "rom4.ic11",  0x36000, 0x2000, CRC(b026dc00) SHA1(8a068997aa19e152d64db47528893046d338389c) )  // IC11
+	ROM_LOAD( "rom10.ic17", 0x20000, 0x2000, CRC(0f32bad8) SHA1(7a2f559697d252ceec3a2f55fe51bc755e4bb65a) )  // IC17
+	ROM_LOAD( "rom8.ic15",  0x22000, 0x2000, CRC(e9b6cbf7) SHA1(6cd6b1e1c5e8e253e779afff8ad1ff90d6116fc9) )  // IC15
+	ROM_LOAD( "rom6.ic13",  0x24000, 0x2000, CRC(a49f617f) SHA1(759d25e33a09204664880329b86724805a1fe0e8) )  // IC13
+	ROM_LOAD( "rom4.ic11",  0x26000, 0x2000, CRC(b026dc00) SHA1(8a068997aa19e152d64db47528893046d338389c) )  // IC11
 
-	ROM_LOAD( "rom16.ic25", 0x40000, 0x2000, CRC(69ce38f8) SHA1(a2cd678e71bfa5e6a3594d8699660c7fa8b52001) )  // IC25
-	ROM_LOAD( "rom14.ic23", 0x42000, 0x2000, CRC(769a4ae5) SHA1(1cdfae2d889848d69f68f990714d027cfbca1853) )  // IC23
-	ROM_LOAD( "rom13.ic21", 0x44000, 0x2000, CRC(ec016c9b) SHA1(f2e40abd14b8b4944b792dd453ebe92eb64355ae) )  // IC21
-	ROM_LOAD( "rom12.ic19", 0x46000, 0x2000, CRC(98ae7afa) SHA1(6a904408419f576352bd2f895727fd17c0541ff8) )  // IC19
+	ROM_LOAD( "rom16.ic25", 0x28000, 0x2000, CRC(69ce38f8) SHA1(a2cd678e71bfa5e6a3594d8699660c7fa8b52001) )  // IC25
+	ROM_LOAD( "rom14.ic23", 0x2a000, 0x2000, CRC(769a4ae5) SHA1(1cdfae2d889848d69f68f990714d027cfbca1853) )  // IC23
+	ROM_LOAD( "rom13.ic21", 0x2c000, 0x2000, CRC(ec016c9b) SHA1(f2e40abd14b8b4944b792dd453ebe92eb64355ae) )  // IC21
+	ROM_LOAD( "rom12.ic19", 0x2e000, 0x2000, CRC(98ae7afa) SHA1(6a904408419f576352bd2f895727fd17c0541ff8) )  // IC19
 
 	// sound CPU
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "rom1.ic8",   0xe000, 0x2000, CRC(011a94a7) SHA1(9f54a742a87ba56b9517e33e556f57dce6eb2eab) )    // IC8
 
-	ROM_REGION( 0x6000, "gfx1", 0 )
+	ROM_REGION( 0x6000, "tiles", 0 )
 	ROM_LOAD( "rom20.ic57", 0x00000, 0x2000, CRC(c6e1d253) SHA1(c408a29f75ba2958e229996f903400b3d95e3bd3) )  // IC57
 	ROM_LOAD( "rom21.ic58", 0x02000, 0x2000, CRC(9874e90f) SHA1(85282823cc862341adf9642d2d5d05972da6dff0) )  // IC58
 	ROM_LOAD( "rom19.ic41", 0x04000, 0x2000, CRC(b9ce4d2a) SHA1(af5332f340d3c3ae02e77923d6e8f0dd92547728) )  // IC41
@@ -3663,7 +3659,7 @@ ROM_END
 
 
 ROM_START( inferno )
-	ROM_REGION( 0x50000, "maincpu", 0 )
+	ROM_REGION( 0x30000, "maincpu", 0 )
 	ROM_LOAD( "ic9.inf",  0x0e000, 0x1000, CRC(1a013185) SHA1(9079c082ec043714f9d8ea92bc81d0b93d2ce715) )   // IC9
 	ROM_LOAD( "ic10.inf", 0x0f000, 0x1000, CRC(dbf64a36) SHA1(54326bc527797f0a3a55764073eb40030aec1aae) )   // IC10
 
@@ -3672,21 +3668,21 @@ ROM_START( inferno )
 	ROM_LOAD( "ic14.inf", 0x14000, 0x2000, CRC(a70508a7) SHA1(930bb9af3b6ba9fdf3e7c32f6b5ffae9acd6cee3) )   // IC14
 	ROM_LOAD( "ic12.inf", 0x16000, 0x2000, CRC(7ffb87f9) SHA1(469f5ae39ad8531c4c11e9d10ab57686e7f54aef) )   // IC12
 
-	ROM_LOAD( "ic17.inf", 0x30000, 0x2000, CRC(b4684139) SHA1(c1d6ecd3dc8191250ef70e6972dad234c0d8f739) )   // IC17
-	ROM_LOAD( "ic15.inf", 0x32000, 0x2000, CRC(128a6ad6) SHA1(357438e50663d6cb96dabfa5110c17836584e15f) )   // IC15
-	ROM_LOAD( "ic13.inf", 0x34000, 0x2000, CRC(83a9e4d6) SHA1(4937e4d1c516da837213e40a1da862578c8dd272) )   // IC13
-	ROM_LOAD( "ic11.inf", 0x36000, 0x2000, CRC(c2e9c909) SHA1(21f0b9bf6ef3a9466ea9afde1c7efde9ed04ce5b) )   // IC11
+	ROM_LOAD( "ic17.inf", 0x20000, 0x2000, CRC(b4684139) SHA1(c1d6ecd3dc8191250ef70e6972dad234c0d8f739) )   // IC17
+	ROM_LOAD( "ic15.inf", 0x22000, 0x2000, CRC(128a6ad6) SHA1(357438e50663d6cb96dabfa5110c17836584e15f) )   // IC15
+	ROM_LOAD( "ic13.inf", 0x24000, 0x2000, CRC(83a9e4d6) SHA1(4937e4d1c516da837213e40a1da862578c8dd272) )   // IC13
+	ROM_LOAD( "ic11.inf", 0x26000, 0x2000, CRC(c2e9c909) SHA1(21f0b9bf6ef3a9466ea9afde1c7efde9ed04ce5b) )   // IC11
 
-	ROM_LOAD( "ic25.inf", 0x40000, 0x2000, CRC(103a5951) SHA1(57c8caa1e9d5e245052822d08add9343fd622e04) )   // IC25
-	ROM_LOAD( "ic23.inf", 0x42000, 0x2000, CRC(c04749a0) SHA1(b203e8d1df556e10b4ecad4733448f889c63e261) )   // IC23
-	ROM_LOAD( "ic21.inf", 0x44000, 0x2000, CRC(c405f853) SHA1(6bd74d065a6043849e083c2822925b82c6fedb00) )   // IC21
-	ROM_LOAD( "ic19.inf", 0x46000, 0x2000, CRC(ade7645a) SHA1(bfaab1840e3171df895a2333a30b9dac214b3351) )   // IC19
+	ROM_LOAD( "ic25.inf", 0x28000, 0x2000, CRC(103a5951) SHA1(57c8caa1e9d5e245052822d08add9343fd622e04) )   // IC25
+	ROM_LOAD( "ic23.inf", 0x2a000, 0x2000, CRC(c04749a0) SHA1(b203e8d1df556e10b4ecad4733448f889c63e261) )   // IC23
+	ROM_LOAD( "ic21.inf", 0x2c000, 0x2000, CRC(c405f853) SHA1(6bd74d065a6043849e083c2822925b82c6fedb00) )   // IC21
+	ROM_LOAD( "ic19.inf", 0x2e000, 0x2000, CRC(ade7645a) SHA1(bfaab1840e3171df895a2333a30b9dac214b3351) )   // IC19
 
 	// sound CPU
 	ROM_REGION( 0x10000, "soundcpu", 0 )
 	ROM_LOAD( "ic8.inf", 0x0e000, 0x2000, CRC(4e3123b8) SHA1(f453feed3ae3b6430db49eb4325f62eecfee9f5e) )    // IC8
 
-	ROM_REGION( 0x6000, "gfx1", 0 )
+	ROM_REGION( 0x6000, "tiles", 0 )
 	ROM_LOAD( "ic57.inf", 0x00000, 0x2000, CRC(65a4ef79) SHA1(270c58901e83665bc388cd9cb92022c55e8eae50) )   // IC57
 	ROM_LOAD( "ic58.inf", 0x02000, 0x2000, CRC(4bb1c2a0) SHA1(9e8d214b8d1dbe4c2369e4047e165c9e692098a5) )   // IC58
 	ROM_LOAD( "ic41.inf", 0x04000, 0x2000, CRC(f3f7238f) SHA1(3810f1afd318ec37271c099c989b142b85d8da51) )   // IC41
@@ -3699,7 +3695,7 @@ ROM_END
 
 
 ROM_START( joust2 )
-	ROM_REGION( 0x50000, "maincpu", 0 )
+	ROM_REGION( 0x30000, "maincpu", 0 )
 	ROM_LOAD( "cpu_2732_ic55_rom2_rev1.4c",   0x0d000, 0x1000, CRC(08b0d5bd) SHA1(b58da478aef36ae20fcfee48151d5d556e16b7b9) )
 	ROM_LOAD( "cpu_2732_ic9_rom3_rev2.4d",    0x0e000, 0x1000, CRC(951175ce) SHA1(ac70df125bb438f9fccc082276df4a76ff693e16) )
 	ROM_LOAD( "cpu_2732_ic10_rom4_rev2.4f",   0x0f000, 0x1000, CRC(ba6e0f6c) SHA1(431cbf38e919011d030f41008e1ad45e7e0ec38b) )
@@ -3709,23 +3705,23 @@ ROM_START( joust2 )
 	ROM_LOAD( "cpu_2732_ic14_rom7_rev2.6j",   0x14000, 0x2000, CRC(f3bce576) SHA1(30ee1b212879b3b55b47c9064f123fb77c8f3089) )
 	ROM_LOAD( "cpu_2732_ic12_rom5_rev2.6h",   0x16000, 0x2000, CRC(5f8b4919) SHA1(1215a314c07ef4f244e862743035626cac1d9538) )
 
-	ROM_LOAD( "cpu_2732_ic26_rom19_rev1.10j", 0x20000, 0x2000, CRC(4ef5e805) SHA1(98b93388ab4a4fa6eeceee3386fa46f5a307b8cb) )
-	ROM_LOAD( "cpu_2732_ic24_rom17_rev1.10h", 0x22000, 0x2000, CRC(4861f063) SHA1(6db00cce230bf4bdfdfbfe59e0dc2d916b84d0dc) )
-	ROM_LOAD( "cpu_2732_ic22_rom15_rev1.9j",  0x24000, 0x2000, CRC(421aafa8) SHA1(06187ba8fef3e89eb399d7040015212bd5f86853) )
-	ROM_LOAD( "cpu_2732_ic20_rom13_rev1.9h",  0x26000, 0x2000, CRC(3432ff55) SHA1(aec0f83b92369de8a830ec298ac490a51bc29f26) )
+	ROM_LOAD( "cpu_2732_ic26_rom19_rev1.10j", 0x18000, 0x2000, CRC(4ef5e805) SHA1(98b93388ab4a4fa6eeceee3386fa46f5a307b8cb) )
+	ROM_LOAD( "cpu_2732_ic24_rom17_rev1.10h", 0x1a000, 0x2000, CRC(4861f063) SHA1(6db00cce230bf4bdfdfbfe59e0dc2d916b84d0dc) )
+	ROM_LOAD( "cpu_2732_ic22_rom15_rev1.9j",  0x1c000, 0x2000, CRC(421aafa8) SHA1(06187ba8fef3e89eb399d7040015212bd5f86853) )
+	ROM_LOAD( "cpu_2732_ic20_rom13_rev1.9h",  0x1e000, 0x2000, CRC(3432ff55) SHA1(aec0f83b92369de8a830ec298ac490a51bc29f26) )
 
-	ROM_LOAD( "cpu_2732_ic17_rom10_rev1.8i",  0x30000, 0x2000, CRC(3e01b597) SHA1(17d09482636d6cda2f3266152396f0461121e748) )
-	ROM_LOAD( "cpu_2732_ic15_rom8_rev1.8g",   0x32000, 0x2000, CRC(ff26fb29) SHA1(5ad498db71c384c1928ec965ba3cad48af428f19) )
-	ROM_LOAD( "cpu_2732_ic13_rom6_rev2.6i",   0x34000, 0x2000, CRC(5f107db5) SHA1(c413a2e58853ccda602515b9668a6a620294ba49) )
+	ROM_LOAD( "cpu_2732_ic17_rom10_rev1.8i",  0x20000, 0x2000, CRC(3e01b597) SHA1(17d09482636d6cda2f3266152396f0461121e748) )
+	ROM_LOAD( "cpu_2732_ic15_rom8_rev1.8g",   0x22000, 0x2000, CRC(ff26fb29) SHA1(5ad498db71c384c1928ec965ba3cad48af428f19) )
+	ROM_LOAD( "cpu_2732_ic13_rom6_rev2.6i",   0x24000, 0x2000, CRC(5f107db5) SHA1(c413a2e58853ccda602515b9668a6a620294ba49) )
 
-	ROM_LOAD( "cpu_2732_ic25_rom18_rev1.10i", 0x40000, 0x2000, CRC(47580af5) SHA1(d2728f32f02b549c7e9691c668f0097e327a1d2d) )
-	ROM_LOAD( "cpu_2732_ic23_rom16_rev1.10g", 0x42000, 0x2000, CRC(869b5942) SHA1(a3f4bab4c0db71589e9be2bbf1f94052ef2f56da) )
-	ROM_LOAD( "cpu_2732_ic21_rom14_rev1.9i",  0x44000, 0x2000, CRC(0bbd867c) SHA1(f2db9fc57b6afb762715617345e8c3dcb89b6cc2) )
-	ROM_LOAD( "cpu_2732_ic19_rom12_rev1.9g",  0x46000, 0x2000, CRC(b9221ed1) SHA1(428ea8f3e2fa58d875f581f5de6e0d05ed855a45) )
+	ROM_LOAD( "cpu_2732_ic25_rom18_rev1.10i", 0x28000, 0x2000, CRC(47580af5) SHA1(d2728f32f02b549c7e9691c668f0097e327a1d2d) )
+	ROM_LOAD( "cpu_2732_ic23_rom16_rev1.10g", 0x2a000, 0x2000, CRC(869b5942) SHA1(a3f4bab4c0db71589e9be2bbf1f94052ef2f56da) )
+	ROM_LOAD( "cpu_2732_ic21_rom14_rev1.9i",  0x2c000, 0x2000, CRC(0bbd867c) SHA1(f2db9fc57b6afb762715617345e8c3dcb89b6cc2) )
+	ROM_LOAD( "cpu_2732_ic19_rom12_rev1.9g",  0x2e000, 0x2000, CRC(b9221ed1) SHA1(428ea8f3e2fa58d875f581f5de6e0d05ed855a45) )
 
 	// sound CPU
 	ROM_REGION( 0x10000, "soundcpu", 0 )
-	ROM_LOAD( "cpu_2764_ic8_rom1_rev1.0f", 0x0E000, 0x2000, CRC(84517c3c) SHA1(de0b6473953783c091ddcc7aaa89fc1ec3b9d378) )
+	ROM_LOAD( "cpu_2764_ic8_rom1_rev1.0f", 0x0e000, 0x2000, CRC(84517c3c) SHA1(de0b6473953783c091ddcc7aaa89fc1ec3b9d378) )
 
 	// sound board
 	ROM_REGION( 0x80000, "bg:cpu", 0 )
@@ -3742,7 +3738,7 @@ ROM_START( joust2 )
 	ROM_RELOAD(             0x50000, 0x8000 )
 	ROM_RELOAD(             0x58000, 0x8000 )
 
-	ROM_REGION( 0xc000, "gfx1", 0 )
+	ROM_REGION( 0xc000, "tiles", 0 )
 	ROM_LOAD( "vid_27128_ic57_rom20_rev1.8f", 0x00000, 0x4000, CRC(572c6b01) SHA1(651df3223c1dc42543f57a7204ae492eb15a4999) )
 	ROM_LOAD( "vid_27128_ic58_rom21_rev1.9f", 0x04000, 0x4000, CRC(aa94bf05) SHA1(3412dd181e2c12dc2dd1caabfe7e737005b0ccd7) )
 	ROM_LOAD( "vid_27128_ic41_rom22_rev1.9d", 0x08000, 0x4000, CRC(c41e3daa) SHA1(fafe76bebd6eaf2cd124c1030e3a58eb5a6cddc6) )
@@ -3755,7 +3751,7 @@ ROM_END
 
 
 ROM_START( joust2r1 )
-	ROM_REGION( 0x50000, "maincpu", 0 )
+	ROM_REGION( 0x30000, "maincpu", 0 )
 	ROM_LOAD( "cpu_2732_ic55_rom2_rev1.4c",   0x0d000, 0x1000, CRC(08b0d5bd) SHA1(b58da478aef36ae20fcfee48151d5d556e16b7b9) )
 	ROM_LOAD( "cpu_2732_ic9_rom3_rev1.4d",    0x0e000, 0x1000, CRC(6f319644) SHA1(1a9bc121b830277c42bac816ec26758c915b49dd) )
 	ROM_LOAD( "cpu_2732_ic10_rom4_rev1.4f",   0x0f000, 0x1000, CRC(027b9f0c) SHA1(8c4631fc42ed0b87b2bb0326c48b92d73cdd2f42) )
@@ -3765,23 +3761,23 @@ ROM_START( joust2r1 )
 	ROM_LOAD( "cpu_2732_ic14_rom7_rev1.6j",   0x14000, 0x2000, CRC(fb9455ca) SHA1(8963832f2ab6f5b2f31611e768cab636672f398c) )
 	ROM_LOAD( "cpu_2732_ic12_rom5_rev1.6h",   0x16000, 0x2000, CRC(31248a0d) SHA1(a27a252b353f99748aacfeb29c8bbbd8b3a833f2) )
 
-	ROM_LOAD( "cpu_2732_ic26_rom19_rev1.10j", 0x20000, 0x2000, CRC(4ef5e805) SHA1(98b93388ab4a4fa6eeceee3386fa46f5a307b8cb) )
-	ROM_LOAD( "cpu_2732_ic24_rom17_rev1.10h", 0x22000, 0x2000, CRC(4861f063) SHA1(6db00cce230bf4bdfdfbfe59e0dc2d916b84d0dc) )
-	ROM_LOAD( "cpu_2732_ic22_rom15_rev1.9j",  0x24000, 0x2000, CRC(421aafa8) SHA1(06187ba8fef3e89eb399d7040015212bd5f86853) )
-	ROM_LOAD( "cpu_2732_ic20_rom13_rev1.9h",  0x26000, 0x2000, CRC(3432ff55) SHA1(aec0f83b92369de8a830ec298ac490a51bc29f26) )
+	ROM_LOAD( "cpu_2732_ic26_rom19_rev1.10j", 0x18000, 0x2000, CRC(4ef5e805) SHA1(98b93388ab4a4fa6eeceee3386fa46f5a307b8cb) )
+	ROM_LOAD( "cpu_2732_ic24_rom17_rev1.10h", 0x1a000, 0x2000, CRC(4861f063) SHA1(6db00cce230bf4bdfdfbfe59e0dc2d916b84d0dc) )
+	ROM_LOAD( "cpu_2732_ic22_rom15_rev1.9j",  0x1c000, 0x2000, CRC(421aafa8) SHA1(06187ba8fef3e89eb399d7040015212bd5f86853) )
+	ROM_LOAD( "cpu_2732_ic20_rom13_rev1.9h",  0x1e000, 0x2000, CRC(3432ff55) SHA1(aec0f83b92369de8a830ec298ac490a51bc29f26) )
 
-	ROM_LOAD( "cpu_2732_ic17_rom10_rev1.8i",  0x30000, 0x2000, CRC(3e01b597) SHA1(17d09482636d6cda2f3266152396f0461121e748) )
-	ROM_LOAD( "cpu_2732_ic15_rom8_rev1.8g",   0x32000, 0x2000, CRC(ff26fb29) SHA1(5ad498db71c384c1928ec965ba3cad48af428f19) )
-	ROM_LOAD( "cpu_2732_ic13_rom6_rev1.6i",   0x34000, 0x2000, CRC(6a8c87d7) SHA1(ba66cd8f23a249470c612890829d40d070bbd1e9) )
+	ROM_LOAD( "cpu_2732_ic17_rom10_rev1.8i",  0x20000, 0x2000, CRC(3e01b597) SHA1(17d09482636d6cda2f3266152396f0461121e748) )
+	ROM_LOAD( "cpu_2732_ic15_rom8_rev1.8g",   0x22000, 0x2000, CRC(ff26fb29) SHA1(5ad498db71c384c1928ec965ba3cad48af428f19) )
+	ROM_LOAD( "cpu_2732_ic13_rom6_rev1.6i",   0x24000, 0x2000, CRC(6a8c87d7) SHA1(ba66cd8f23a249470c612890829d40d070bbd1e9) )
 
-	ROM_LOAD( "cpu_2732_ic25_rom18_rev1.10i", 0x40000, 0x2000, CRC(47580af5) SHA1(d2728f32f02b549c7e9691c668f0097e327a1d2d) )
-	ROM_LOAD( "cpu_2732_ic23_rom16_rev1.10g", 0x42000, 0x2000, CRC(869b5942) SHA1(a3f4bab4c0db71589e9be2bbf1f94052ef2f56da) )
-	ROM_LOAD( "cpu_2732_ic21_rom14_rev1.9i",  0x44000, 0x2000, CRC(0bbd867c) SHA1(f2db9fc57b6afb762715617345e8c3dcb89b6cc2) )
-	ROM_LOAD( "cpu_2732_ic19_rom12_rev1.9g",  0x46000, 0x2000, CRC(b9221ed1) SHA1(428ea8f3e2fa58d875f581f5de6e0d05ed855a45) )
+	ROM_LOAD( "cpu_2732_ic25_rom18_rev1.10i", 0x28000, 0x2000, CRC(47580af5) SHA1(d2728f32f02b549c7e9691c668f0097e327a1d2d) )
+	ROM_LOAD( "cpu_2732_ic23_rom16_rev1.10g", 0x2a000, 0x2000, CRC(869b5942) SHA1(a3f4bab4c0db71589e9be2bbf1f94052ef2f56da) )
+	ROM_LOAD( "cpu_2732_ic21_rom14_rev1.9i",  0x2c000, 0x2000, CRC(0bbd867c) SHA1(f2db9fc57b6afb762715617345e8c3dcb89b6cc2) )
+	ROM_LOAD( "cpu_2732_ic19_rom12_rev1.9g",  0x2e000, 0x2000, CRC(b9221ed1) SHA1(428ea8f3e2fa58d875f581f5de6e0d05ed855a45) )
 
 	// sound CPU
 	ROM_REGION( 0x10000, "soundcpu", 0 )
-	ROM_LOAD( "cpu_2764_ic8_rom1_rev1.0f", 0x0E000, 0x2000, CRC(84517c3c) SHA1(de0b6473953783c091ddcc7aaa89fc1ec3b9d378) )
+	ROM_LOAD( "cpu_2764_ic8_rom1_rev1.0f", 0x0e000, 0x2000, CRC(84517c3c) SHA1(de0b6473953783c091ddcc7aaa89fc1ec3b9d378) )
 
 	// sound board
 	ROM_REGION( 0x80000, "bg:cpu", 0 )
@@ -3798,7 +3794,7 @@ ROM_START( joust2r1 )
 	ROM_RELOAD(             0x50000, 0x8000 )
 	ROM_RELOAD(             0x58000, 0x8000 )
 
-	ROM_REGION( 0xc000, "gfx1", 0 )
+	ROM_REGION( 0xc000, "tiles", 0 )
 	ROM_LOAD( "vid_27128_ic57_rom20_rev1.8f", 0x00000, 0x4000, CRC(572c6b01) SHA1(651df3223c1dc42543f57a7204ae492eb15a4999) )
 	ROM_LOAD( "vid_27128_ic58_rom21_rev1.9f", 0x04000, 0x4000, CRC(aa94bf05) SHA1(3412dd181e2c12dc2dd1caabfe7e737005b0ccd7) )
 	ROM_LOAD( "vid_27128_ic41_rom22_rev1.9d", 0x08000, 0x4000, CRC(c41e3daa) SHA1(fafe76bebd6eaf2cd124c1030e3a58eb5a6cddc6) )
@@ -3819,7 +3815,7 @@ ROM_END
 
 void defender_state::init_defndjeu()
 {
-	uint8_t *rom = memregion("maincpu")->base();
+	uint8_t *const rom = memregion("maincpu")->base();
 
 	// apply simple decryption by swapping bits 0 and 7
 	for (int i = 0xd000; i < 0x19000; i++)
@@ -3862,7 +3858,7 @@ GAME( 1980, attackf,    defender, defender,         defender, defender_state,  e
 GAME( 1981, galwars2,   defender, defender_6802snd, defender, defender_state,  empty_init,    ROT0,   "bootleg (Sonic)",                      "Galaxy Wars II (bootleg of Defender)",     MACHINE_SUPPORTS_SAVE ) // Sega Sonic - Sega S.A., only displays Sonic on title screen
 
 GAME( 1980, mayday,     0,        defender,         mayday,   mayday_state,    empty_init,    ROT0,   "Hoei",                 "Mayday (set 1)",                  MACHINE_SUPPORTS_SAVE | MACHINE_UNEMULATED_PROTECTION ) // \  original by Hoei, which one of these 3 sets is bootleg/licensed/original is unknown
-GAME( 1980, maydaya,    mayday,   defender,         mayday,   mayday_state,    empty_init,    ROT0,   "Hoei",                 "Mayday (set 2)",                  MACHINE_SUPPORTS_SAVE | MACHINE_UNEMULATED_PROTECTION ) //  > these games have an unemulated protection chip of some sort which is hacked around in /machine/williams.cpp "protection_r" function
+GAME( 1980, maydaya,    mayday,   defender,         mayday,   mayday_state,    empty_init,    ROT0,   "Hoei",                 "Mayday (set 2)",                  MACHINE_SUPPORTS_SAVE | MACHINE_UNEMULATED_PROTECTION ) //  > these games have an unemulated protection chip of some sort which is hacked around in /midway/williams_m.cpp "protection_r" function
 GAME( 1980, maydayb,    mayday,   defender,         mayday,   mayday_state,    empty_init,    ROT0,   "Hoei",                 "Mayday (set 3)",                  MACHINE_SUPPORTS_SAVE | MACHINE_UNEMULATED_PROTECTION ) // /
 GAME( 1980, batlzone,   mayday,   defender,         mayday,   mayday_state,    empty_init,    ROT0,   "bootleg (Video Game)", "Battle Zone (bootleg of Mayday)", MACHINE_SUPPORTS_SAVE ) // the bootleg may or may not use the same protection chip, or some hack around it.
 

--- a/src/mame/midway/williams.h
+++ b/src/mame/midway/williams.h
@@ -66,7 +66,6 @@ public:
 	void palette_init(palette_device &palette) const;
 
 protected:
-	virtual void machine_start() override { }
 	virtual void machine_reset() override;
 	virtual void video_start() override;
 

--- a/src/mame/midway/williams.h
+++ b/src/mame/midway/williams.h
@@ -33,16 +33,19 @@ class williams_state : public driver_device
 public:
 	williams_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
-		m_nvram(*this, "nvram"),
-		m_videoram(*this, "videoram"),
-		m_mainbank(*this, "mainbank"),
 		m_maincpu(*this, "maincpu"),
 		m_soundcpu(*this, "soundcpu"),
 		m_watchdog(*this, "watchdog"),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
 		m_paletteram(*this, "paletteram"),
-		m_pia(*this, "pia_%u", 0U)
+		m_pia(*this, "pia_%u", 0U),
+		m_nvram(*this, "nvram"),
+		m_videoram(*this, "videoram"),
+		m_mainbank(*this, "mainbank"),
+		m_rom_view(*this, "rom_view"),
+		m_49way_x(*this, "49WAYX"),
+		m_49way_y(*this, "49WAYY")
 	{ }
 
 	void williams_base(machine_config &config);
@@ -63,7 +66,8 @@ public:
 	void palette_init(palette_device &palette) const;
 
 protected:
-	virtual void machine_start() override;
+	virtual void machine_start() override { }
+	virtual void machine_reset() override;
 	virtual void video_start() override;
 
 	// blitter type
@@ -87,9 +91,23 @@ protected:
 		WMS_BLITTER_CONTROLBYTE_SRC_STRIDE_256 = 0x01
 	};
 
+	required_device<cpu_device> m_maincpu;
+	required_device<cpu_device> m_soundcpu;
+	required_device<watchdog_timer_device> m_watchdog;
+	required_device<screen_device> m_screen;
+	optional_device<palette_device> m_palette;
+	optional_shared_ptr<uint8_t> m_paletteram;
+	optional_device_array<pia6821_device, 4> m_pia;
+
 	required_shared_ptr<uint8_t> m_nvram;
 	required_shared_ptr<uint8_t> m_videoram;
 	optional_memory_bank m_mainbank;
+
+	memory_view m_rom_view;
+
+	optional_ioport m_49way_x;
+	optional_ioport m_49way_y;
+
 	uint8_t m_blitter_config;
 	uint16_t m_blitter_clip_address;
 	uint8_t m_blitter_window_enable;
@@ -100,6 +118,7 @@ protected:
 	uint8_t m_blitter_remap_index;
 	const uint8_t *m_blitter_remap;
 	std::unique_ptr<uint8_t[]> m_blitter_remap_lookup;
+
 	virtual void vram_select_w(u8 data);
 	virtual void cmos_w(offs_t offset, u8 data);
 	void blitter_w(address_space &space, offs_t offset, u8 data);
@@ -111,14 +130,6 @@ protected:
 	void blitter_init(int blitter_config, const uint8_t *remap_prom);
 	inline void blit_pixel(address_space &space, int dstaddr, int srcdata, int controlbyte);
 	int blitter_core(address_space &space, int sstart, int dstart, int w, int h, int data);
-
-	required_device<cpu_device> m_maincpu;
-	required_device<cpu_device> m_soundcpu;
-	required_device<watchdog_timer_device> m_watchdog;
-	required_device<screen_device> m_screen;
-	optional_device<palette_device> m_palette;
-	optional_shared_ptr<uint8_t> m_paletteram;
-	optional_device_array<pia6821_device, 4> m_pia;
 
 	virtual void main_map(address_map &map);
 	virtual void sound_map(address_map &map);
@@ -274,7 +285,6 @@ class blaster_state : public williams_state
 public:
 	blaster_state(const machine_config &mconfig, device_type type, const char *tag) :
 		williams_state(mconfig, type, tag),
-		m_bankb(*this, "blaster_bankb"),
 		m_muxa(*this, "mux_a"),
 		m_muxb(*this, "mux_b")
 	{ }
@@ -282,18 +292,17 @@ public:
 	void blastkit(machine_config &config);
 	void blaster(machine_config &config);
 
-private:
+protected:
 	virtual void machine_start() override;
+	virtual void machine_reset() override;
 	virtual void video_start() override;
 
-	optional_memory_bank m_bankb;
+private:
 	required_device<ls157_x2_device> m_muxa;
 	optional_device<ls157_device> m_muxb;
 
 	rgb_t m_color0;
 	uint8_t m_video_control;
-	uint8_t m_vram_bank;
-	uint8_t m_rom_bank;
 
 	virtual void vram_select_w(u8 data) override;
 	void bank_select_w(u8 data);
@@ -304,8 +313,6 @@ private:
 
 	virtual uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect) override;
 
-	inline void update_blaster_banking();
-
 	virtual void main_map(address_map &map) override;
 };
 
@@ -315,9 +322,9 @@ class williams2_state : public williams_state
 public:
 	williams2_state(const machine_config &mconfig, device_type type, const char *tag) :
 		williams_state(mconfig, type, tag),
-		m_bank8000(*this, "bank8000"),
 		m_gfxdecode(*this, "gfxdecode"),
-		m_tileram(*this, "williams2_tile"),
+		m_tileram(*this, "tileram"),
+		m_palette_view(*this, "palette_view"),
 		m_gain(  { 0.25f, 0.25f, 0.25f }),
 		m_offset({ 0.00f, 0.00f, 0.00f })
 	{ }
@@ -338,9 +345,10 @@ protected:
 	virtual void machine_reset() override;
 	virtual void video_start() override;
 
-	required_device<address_map_bank_device> m_bank8000;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_shared_ptr<uint8_t> m_tileram;
+
+	memory_view m_palette_view;
 
 	tilemap_t *m_bg_tilemap = nullptr;
 	uint16_t m_tilemap_xscroll = 0;
@@ -371,7 +379,6 @@ protected:
 
 	virtual uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect) override;
 
-	void bank8000_map(address_map &map);
 	void common_map(address_map &map);
 	virtual void sound_map(address_map &map) override;
 

--- a/src/mame/midway/williams_m.cpp
+++ b/src/mame/midway/williams_m.cpp
@@ -86,6 +86,8 @@ TIMER_DEVICE_CALLBACK_MEMBER(williams2_state::endscreen_callback)
 
 void williams2_state::machine_start()
 {
+	williams_state::machine_start();
+
 	/* configure memory banks */
 	m_mainbank->configure_entries(0, 4, memregion("maincpu")->base() + 0x10000, 0x8000);
 }
@@ -93,6 +95,8 @@ void williams2_state::machine_start()
 
 void williams2_state::machine_reset()
 {
+	williams_state::machine_reset();
+
 	/* make sure our banking is reset */
 	bank_select_w(0);
 }
@@ -309,6 +313,8 @@ void williams2_state::segments_w(u8 data)
 
 void defender_state::machine_reset()
 {
+	williams_state::machine_reset();
+
 	bank_select_w(0);
 }
 
@@ -386,13 +392,16 @@ void sinistar_state::cockpit_snd_cmd_w(u8 data)
 
 void blaster_state::machine_start()
 {
+	williams_state::machine_start();
+
 	/* banking is different for blaster */
 	m_mainbank->configure_entries(0, 16, memregion("maincpu")->base() + 0x10000, 0x4000);
 }
 
 void blaster_state::machine_reset()
 {
-	m_rom_view.disable();
+	williams_state::machine_reset();
+
 	m_mainbank->set_entry(0);
 }
 
@@ -458,6 +467,7 @@ void williams2_state::video_control_w(u8 data)
 void tshoot_state::machine_start()
 {
 	williams2_state::machine_start();
+
 	m_grenade_lamp.resolve();
 	m_gun_lamp.resolve();
 	m_p1_gun_recoil.resolve();
@@ -495,6 +505,7 @@ void tshoot_state::lamp_w(u8 data)
 void joust2_state::machine_start()
 {
 	williams2_state::machine_start();
+
 	save_item(NAME(m_current_sound_data));
 }
 

--- a/src/mame/midway/williams_m.cpp
+++ b/src/mame/midway/williams_m.cpp
@@ -18,7 +18,7 @@
 
 TIMER_DEVICE_CALLBACK_MEMBER(williams_state::va11_callback)
 {
-	int scanline = param;
+	int const scanline = param;
 
 	// must not fire at line 256
 	if (scanline == 256)
@@ -31,7 +31,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(williams_state::va11_callback)
 
 TIMER_DEVICE_CALLBACK_MEMBER(williams_state::count240_callback)
 {
-	int scanline = param;
+	int const scanline = param;
 
 	// the COUNT240 signal comes into CA1, and is set to the logical AND of VA10-VA13
 	m_pia[1]->ca1_w(scanline >= 240 ? 1 : 0);
@@ -44,11 +44,9 @@ TIMER_DEVICE_CALLBACK_MEMBER(williams_state::count240_callback)
  *
  *************************************/
 
-void williams_state::machine_start()
+void williams_state::machine_reset()
 {
-	/* configure the memory bank */
-	m_mainbank->configure_entry(1, memregion("maincpu")->base() + 0x10000);
-	m_mainbank->configure_entry(0, m_videoram);
+	m_rom_view.disable();
 }
 
 
@@ -60,7 +58,7 @@ void williams_state::machine_start()
 
 TIMER_DEVICE_CALLBACK_MEMBER(williams2_state::va11_callback)
 {
-	int scanline = param;
+	int const scanline = param;
 	if (scanline == 256)
 		return;
 
@@ -72,7 +70,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(williams2_state::va11_callback)
 
 TIMER_DEVICE_CALLBACK_MEMBER(williams2_state::endscreen_callback)
 {
-	int scanline = param;
+	int const scanline = param;
 
 	// the /ENDSCREEN signal comes into CA1
 	m_pia[0]->ca1_w(scanline >= 254 ? 0 : 1);
@@ -89,9 +87,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(williams2_state::endscreen_callback)
 void williams2_state::machine_start()
 {
 	/* configure memory banks */
-	m_mainbank->configure_entries(1, 4, memregion("maincpu")->base() + 0x10000, 0x10000);
-	m_mainbank->configure_entry(0, m_videoram);
-	membank("vram8000")->set_base(&m_videoram[0x8000]);
+	m_mainbank->configure_entries(0, 4, memregion("maincpu")->base() + 0x10000, 0x8000);
 }
 
 
@@ -112,10 +108,13 @@ void williams2_state::machine_reset()
 void williams_state::vram_select_w(u8 data)
 {
 	/* VRAM/ROM banking from bit 0 */
-	m_mainbank->set_entry(data & 0x01);
+	if (BIT(data, 0))
+		m_rom_view.select(0);
+	else
+		m_rom_view.disable();
 
 	/* cocktail flip from bit 1 */
-	m_cocktail = data & 0x02;
+	m_cocktail = BIT(data, 1);
 }
 
 
@@ -126,21 +125,23 @@ void williams2_state::bank_select_w(u8 data)
 	{
 		/* page 0 is video ram */
 		case 0:
-			m_mainbank->set_entry(0);
-			m_bank8000->set_bank(0);
+			m_rom_view.disable();
+			m_palette_view.disable();
 			break;
 
 		/* pages 1 and 2 are ROM */
 		case 1:
 		case 2:
-			m_mainbank->set_entry(1 + ((data & 6) >> 1));
-			m_bank8000->set_bank(0);
+			m_mainbank->set_entry((data & 6) >> 1);
+			m_rom_view.select(0);
+			m_palette_view.disable();
 			break;
 
 		/* page 3 accesses palette RAM; the remaining areas are as if page 1 ROM was selected */
 		case 3:
-			m_mainbank->set_entry(1 + ((data & 4) >> 1));
-			m_bank8000->set_bank(1);
+			m_mainbank->set_entry((data & 4) >> 1);
+			m_rom_view.select(0);
+			m_palette_view.select(0);
 			break;
 	}
 }
@@ -210,7 +211,7 @@ void williams2_state::snd_cmd_w(u8 data)
 u8 williams_state::port_0_49way_r()
 {
 	static const uint8_t translate49[7] = { 0x0, 0x4, 0x6, 0x7, 0xb, 0x9, 0x8 };
-	return (translate49[ioport("49WAYX")->read() >> 4] << 4) | translate49[ioport("49WAYY")->read() >> 4];
+	return (translate49[m_49way_x->read() >> 4] << 4) | translate49[m_49way_y->read() >> 4];
 }
 
 
@@ -314,7 +315,7 @@ void defender_state::machine_reset()
 
 void defender_state::video_control_w(u8 data)
 {
-	m_cocktail = data & 0x01;
+	m_cocktail = BIT(data, 0);
 }
 
 
@@ -355,7 +356,7 @@ void sinistar_state::vram_select_w(u8 data)
 	williams_state::vram_select_w(data);
 
 	/* window enable from bit 2 (clips to 0x7400) */
-	m_blitter_window_enable = data & 0x04;
+	m_blitter_window_enable = BIT(data, 2);
 }
 
 
@@ -386,53 +387,42 @@ void sinistar_state::cockpit_snd_cmd_w(u8 data)
 void blaster_state::machine_start()
 {
 	/* banking is different for blaster */
-	m_mainbank->configure_entries(1, 16, memregion("maincpu")->base() + 0x18000, 0x4000);
-	m_mainbank->configure_entry(0, m_videoram);
-
-	m_bankb->configure_entries(1, 16, memregion("maincpu")->base() + 0x10000, 0x0000);
-	m_bankb->configure_entry(0, &m_videoram[0x4000]);
-
-	/* register for save states */
-	save_item(NAME(m_vram_bank));
-	save_item(NAME(m_rom_bank));
-
-	m_vram_bank = 0;
-	m_rom_bank = 0;
+	m_mainbank->configure_entries(0, 16, memregion("maincpu")->base() + 0x10000, 0x4000);
 }
 
-
-inline void blaster_state::update_blaster_banking()
+void blaster_state::machine_reset()
 {
-	m_mainbank->set_entry(m_vram_bank * (m_rom_bank + 1));
-	m_bankb->set_entry(m_vram_bank * (m_rom_bank + 1));
+	m_rom_view.disable();
+	m_mainbank->set_entry(0);
 }
 
 
 void blaster_state::vram_select_w(u8 data)
 {
 	/* VRAM/ROM banking from bit 0 */
-	m_vram_bank = data & 0x01;
-	update_blaster_banking();
+	if (BIT(data, 0))
+		m_rom_view.select(0);
+	else
+		m_rom_view.disable();
 
 	/* cocktail flip from bit 1 */
-	m_cocktail = data & 0x02;
+	m_cocktail = BIT(data, 1);
 
 	/* window enable from bit 2 (clips to 0x9700) */
-	m_blitter_window_enable = data & 0x04;
+	m_blitter_window_enable = BIT(data, 2);
 }
 
 
 void blaster_state::bank_select_w(u8 data)
 {
-	m_rom_bank = data & 0x0f;
-	update_blaster_banking();
+	m_mainbank->set_entry(data & 0x0f);
 }
 
 
 TIMER_CALLBACK_MEMBER(blaster_state::deferred_snd_cmd_w)
 {
-	uint8_t l_data = param | 0x80;
-	uint8_t r_data = (param >> 1 & 0x40) | (param & 0x3f) | 0x80;
+	uint8_t const l_data = param | 0x80;
+	uint8_t const r_data = (param >> 1 & 0x40) | (param & 0x3f) | 0x80;
 
 	m_pia[2]->portb_w(l_data); m_pia[2]->cb1_w((l_data == 0xff) ? 0 : 1);
 	m_pia[3]->portb_w(r_data); m_pia[3]->cb1_w((r_data == 0xff) ? 0 : 1);
@@ -454,7 +444,7 @@ void blaster_state::blaster_snd_cmd_w(u8 data)
 
 void williams2_state::video_control_w(u8 data)
 {
-	m_cocktail = data & 0x01;
+	m_cocktail = BIT(data, 0);
 }
 
 

--- a/src/mame/midway/williams_v.cpp
+++ b/src/mame/midway/williams_v.cpp
@@ -225,7 +225,7 @@ uint32_t williams_state::screen_update(screen_device &screen, bitmap_rgb32 &bitm
 		/* loop over columns */
 		for (int x = cliprect.min_x & ~1; x <= cliprect.max_x; x += 2)
 		{
-			int const pix = source[(x/2) * 256];
+			uint8_t const pix = source[(x/2) * 256];
 			dest[x+0] = pens[pix >> 4];
 			dest[x+1] = pens[pix & 0x0f];
 		}
@@ -236,8 +236,8 @@ uint32_t williams_state::screen_update(screen_device &screen, bitmap_rgb32 &bitm
 
 uint32_t blaster_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	uint8_t *palette_0 = &m_videoram[0xbb00];
-	uint8_t *scanline_control = &m_videoram[0xbc00];
+	uint8_t const *const palette_0 = &m_videoram[0xbb00];
+	uint8_t const *const scanline_control = &m_videoram[0xbc00];
 	rgb_t pens[16];
 
 	/* precompute the palette */
@@ -251,7 +251,7 @@ uint32_t blaster_state::screen_update(screen_device &screen, bitmap_rgb32 &bitma
 	/* loop over rows */
 	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{
-		int erase_behind = m_video_control & scanline_control[y] & 2;
+		int const erase_behind = m_video_control & scanline_control[y] & 2;
 		uint8_t *const source = &m_videoram[y];
 		uint32_t *const dest = &bitmap.pix(y);
 
@@ -262,7 +262,7 @@ uint32_t blaster_state::screen_update(screen_device &screen, bitmap_rgb32 &bitma
 		/* loop over columns */
 		for (int x = cliprect.min_x & ~1; x <= cliprect.max_x; x += 2)
 		{
-			int const pix = source[(x/2) * 256];
+			uint8_t const pix = source[(x/2) * 256];
 
 			/* clear behind us if requested */
 			if (erase_behind)
@@ -297,7 +297,7 @@ uint32_t williams2_state::screen_update(screen_device &screen, bitmap_rgb32 &bit
 		/* loop over columns */
 		for (int x = cliprect.min_x & ~1; x <= cliprect.max_x; x += 2)
 		{
-			int const pix = source[(x/2) * 256];
+			uint8_t const pix = source[(x/2) * 256];
 
 			if (pix & 0xf0)
 				dest[x+0] = pens[pix >> 4];
@@ -331,7 +331,7 @@ uint32_t mysticm_state::screen_update(screen_device &screen, bitmap_rgb32 &bitma
 		/* loop over columns */
 		for (int x = cliprect.min_x & ~1; x <= cliprect.max_x; x += 2)
 		{
-			int const pix = source[(x/2) * 256];
+			uint8_t const pix = source[(x/2) * 256];
 
 			if (pix & 0xf0)
 				dest[x+0] = pens[pix >> 4];
@@ -463,14 +463,12 @@ rgb_t williams2_state::calc_col(uint16_t lo, uint16_t hi)
 
 void williams2_state::paletteram_w(offs_t offset, u8 data)
 {
-	uint16_t entry_lo, entry_hi;
-
 	/* set the new value */
 	m_paletteram[offset] = data;
 
 	/* pull the associated low/high bytes */
-	entry_lo = m_paletteram[offset & ~1];
-	entry_hi = m_paletteram[offset |  1];
+	uint16_t entry_lo = m_paletteram[offset & ~1];
+	uint16_t entry_hi = m_paletteram[offset |  1];
 
 	m_bg_tilemap->mark_all_dirty();
 
@@ -480,7 +478,7 @@ void williams2_state::paletteram_w(offs_t offset, u8 data)
 
 void williams2_state::rebuild_palette()
 {
-	for (offs_t i=0; i<2048; i++)
+	for (offs_t i = 0; i < 2048; i++)
 		paletteram_w(i, m_paletteram[i]);
 }
 
@@ -522,12 +520,12 @@ u8 williams2_state::video_counter_r()
 
 TILE_GET_INFO_MEMBER(williams2_state::get_tile_info)
 {
-	int mask = m_gfxdecode->gfx(0)->elements() - 1;
-	int data = m_tileram[tile_index];
-	int y = (tile_index >> 1) & 7;
+	int const mask = m_gfxdecode->gfx(0)->elements() - 1;
+	int const data = m_tileram[tile_index];
+	int const y = (tile_index >> 1) & 7;
 
 	/* On tshoot and inferno, IC79 is a 74LS157 selector jumpered to be enabled */
-	int color = y;
+	int const color = y;
 
 	tileinfo.set(0, data & mask, color, (data & ~mask) ? TILE_FLIPX : 0);
 }
@@ -535,10 +533,10 @@ TILE_GET_INFO_MEMBER(williams2_state::get_tile_info)
 
 int mysticm_state::color_decode(uint8_t base_col, int sig_J1, int y)
 {
-	int v = y << 6;
-	int sig_W11 = (v >> 11) & 1;
-	int sig_W12 = (v >> 12) & 1;
-	int sig_W13 = (v >> 13) & 1;
+	int const v = y << 6;
+	int const sig_W11 = (v >> 11) & 1;
+	int const sig_W12 = (v >> 12) & 1;
+	int const sig_W13 = (v >> 13) & 1;
 
 	// There are four "jumpers" in the schematics.
 	// J3 and J4 allow to turn off background tilemaps completely.
@@ -556,9 +554,9 @@ int mysticm_state::color_decode(uint8_t base_col, int sig_J1, int y)
 	// FIXME: Investigate further.
 
 	/* IC79 is a 74LS85 comparator that controls the low bit */
-	int a = 1 | ((base_col & 1) << 2) | ((base_col & 1) << 3);
-	int b = (sig_W12 << 0) | (sig_W13 << 1) | (0 << 2) | (sig_J1 << 3);
-	int color = (a > b) || ((a == b) && !sig_W11);
+	int const a = 1 | ((base_col & 1) << 2) | ((base_col & 1) << 3);
+	int const b = (sig_W12 << 0) | (sig_W13 << 1) | (0 << 2) | (sig_J1 << 3);
+	int const color = (a > b) || ((a == b) && !sig_W11);
 
 	// mysticm schematics show Page1 and Page2 crossed, i.e.
 	// Page1 -> B2 (IC80) and Page2 -> B1 (IC80)
@@ -571,10 +569,10 @@ int mysticm_state::color_decode(uint8_t base_col, int sig_J1, int y)
 
 TILE_GET_INFO_MEMBER(mysticm_state::get_tile_info)
 {
-	int color = color_decode(m_bg_color, 0, (tile_index << 4) & 0xff);
+	int const color = color_decode(m_bg_color, 0, (tile_index << 4) & 0xff);
 
-	int mask = m_gfxdecode->gfx(0)->elements() - 1;
-	int data = m_tileram[tile_index];
+	int const mask = m_gfxdecode->gfx(0)->elements() - 1;
+	int const data = m_tileram[tile_index];
 
 	//m_bg_tilemap->set_palette_offset((color & 0x3e) << 4);
 	//tileinfo.set(0, data & mask, color & 1, (data & ~mask) ? TILE_FLIPX : 0);
@@ -588,11 +586,11 @@ TILE_GET_INFO_MEMBER(mysticm_state::get_tile_info)
 
 TILE_GET_INFO_MEMBER(joust2_state::get_tile_info)
 {
-	int mask = m_gfxdecode->gfx(0)->elements() - 1;
-	int data = m_tileram[tile_index];
+	int const mask = m_gfxdecode->gfx(0)->elements() - 1;
+	int const data = m_tileram[tile_index];
 
 	/* IC79 is a 74LS157 selector jumpered to be disabled */
-	int color = 0;
+	int const color = 0;
 
 	tileinfo.set(0, data & mask, color, (data & ~mask) ? TILE_FLIPX : 0);
 }
@@ -713,7 +711,7 @@ void williams_state::blitter_w(address_space &space, offs_t offset, u8 data)
 	if (h == 0) h = 1;
 
 	/* do the actual blit */
-	int accesses = blitter_core(space, sstart, dstart, w, h, data);
+	int const accesses = blitter_core(space, sstart, dstart, w, h, data);
 
 	/* based on the number of memory accesses needed to do the blit, compute how long the blit will take */
 	int estimated_clocks_at_4MHz = 4;
@@ -741,7 +739,7 @@ void williams_state::blitter_w(address_space &space, offs_t offset, u8 data)
 
 void williams2_state::blit_window_enable_w(u8 data)
 {
-	m_blitter_window_enable = data & 0x01;
+	m_blitter_window_enable = BIT(data, 0);
 }
 
 
@@ -757,7 +755,7 @@ inline void williams_state::blit_pixel(address_space &space, int dstaddr, int sr
 	/* always read from video RAM regardless of the bank setting */
 	int curpix = (dstaddr < 0xc000) ? m_videoram[dstaddr] : space.read_byte(dstaddr); // current pixel values at dest
 
-	int solid = m_blitterram[1];
+	int const solid = m_blitterram[1];
 	unsigned char keepmask = 0xff; // what part of original dst byte should be kept, based on NO_EVEN and NO_ODD flags
 
 	// even pixel (D7-D4)
@@ -803,10 +801,10 @@ int williams_state::blitter_core(address_space &space, int sstart, int dstart, i
 	int accesses = 0;
 
 	/* compute how much to advance in the x and y loops */
-	int sxadv = (controlbyte & WMS_BLITTER_CONTROLBYTE_SRC_STRIDE_256) ? 0x100 : 1;
-	int syadv = (controlbyte & WMS_BLITTER_CONTROLBYTE_SRC_STRIDE_256) ? 1 : w;
-	int dxadv = (controlbyte & WMS_BLITTER_CONTROLBYTE_DST_STRIDE_256) ? 0x100 : 1;
-	int dyadv = (controlbyte & WMS_BLITTER_CONTROLBYTE_DST_STRIDE_256) ? 1 : w;
+	int const sxadv = (controlbyte & WMS_BLITTER_CONTROLBYTE_SRC_STRIDE_256) ? 0x100 : 1;
+	int const syadv = (controlbyte & WMS_BLITTER_CONTROLBYTE_SRC_STRIDE_256) ? 1 : w;
+	int const dxadv = (controlbyte & WMS_BLITTER_CONTROLBYTE_DST_STRIDE_256) ? 0x100 : 1;
+	int const dyadv = (controlbyte & WMS_BLITTER_CONTROLBYTE_DST_STRIDE_256) ? 1 : w;
 
 	int pixdata = 0;
 

--- a/src/mame/midway/wmg.cpp
+++ b/src/mame/midway/wmg.cpp
@@ -504,11 +504,12 @@ u8 wmg_state::wmg_pia_0_r(offs_t offset)
  *  Machine Driver
  *
  *************************************/
-static constexpr XTAL MASTER_CLOCK = (XTAL(12'000'000));
-static constexpr XTAL SOUND_CLOCK = (XTAL(3'579'545));
 
 void wmg_state::wmg(machine_config &config)
 {
+	constexpr XTAL MASTER_CLOCK = 12_MHz_XTAL;
+	constexpr XTAL SOUND_CLOCK = 3.579545_MHz_XTAL;
+
 	/* basic machine hardware */
 	MC6809E(config, m_maincpu, MASTER_CLOCK/3/4);
 	m_maincpu->set_addrmap(AS_PROGRAM, &wmg_state::wmg_cpu1);

--- a/src/mame/midway/wmg.cpp
+++ b/src/mame/midway/wmg.cpp
@@ -80,8 +80,6 @@ of save-state is also needed.
 
 namespace {
 
-#define MASTER_CLOCK        (XTAL(12'000'000))
-#define SOUND_CLOCK         (XTAL(3'579'545))
 
 class wmg_state : public defender_state
 {
@@ -98,7 +96,20 @@ public:
 
 	template <int N> DECLARE_CUSTOM_INPUT_MEMBER(wmg_mux_r);
 
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
 private:
+	required_shared_ptr<uint8_t> m_p_ram;
+	required_ioport_array<17> m_keyboard;
+	required_memory_bank m_codebank;
+	required_memory_bank m_soundbank;
+
+	uint8_t m_wmg_c400 = 0U;
+	uint8_t m_wmg_d000 = 0U;
+	uint8_t m_port_select = 0U;
+
 	u8 wmg_nvram_r(offs_t offset);
 	void wmg_nvram_w(offs_t offset, u8 data);
 	u8 wmg_pia_0_r(offs_t offset);
@@ -113,17 +124,6 @@ private:
 	void wmg_cpu2(address_map &map);
 	void wmg_banked_map(address_map &map);
 
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-
-	uint8_t m_wmg_c400 = 0U;
-	uint8_t m_wmg_d000 = 0U;
-	uint8_t m_wmg_port_select = 0U;
-	uint8_t m_wmg_vram_bank = 0U;
-	required_shared_ptr<uint8_t> m_p_ram;
-	required_ioport_array<17> m_keyboard;
-	required_memory_bank m_codebank;
-	required_memory_bank m_soundbank;
 };
 
 
@@ -135,10 +135,11 @@ private:
  *************************************/
 void wmg_state::wmg_cpu1(address_map &map)
 {
-	map(0x0000, 0xbfff).ram().share("videoram");
-	map(0x0000, 0x8fff).bankr("mainbank");
+	map(0x0000, 0xbfff).ram().share(m_videoram);
+	map(0x0000, 0x8fff).view(m_rom_view);
+	m_rom_view[0](0x0000, 0x8fff).bankr(m_mainbank);
 	map(0xc000, 0xcfff).m(m_bankc000, FUNC(address_map_bank_device::amap8));
-	map(0xd000, 0xffff).bankr("codebank");
+	map(0xd000, 0xffff).bankr(m_codebank);
 	map(0xd000, 0xd000).w(FUNC(wmg_state::wmg_d000_w));
 }
 
@@ -147,12 +148,12 @@ void wmg_state::wmg_cpu2(address_map &map)
 	map(0x0000, 0x007f).ram();     /* internal RAM */
 	map(0x0080, 0x00ff).ram();     /* MC6810 RAM */
 	map(0x0400, 0x0403).mirror(0x8000).rw(m_pia[2], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0xf000, 0xffff).bankr("soundbank");
+	map(0xf000, 0xffff).bankr(m_soundbank);
 }
 
 void wmg_state::wmg_banked_map(address_map &map)
 {
-	map(0x0000, 0x000f).mirror(0x03e0).writeonly().share("paletteram");
+	map(0x0000, 0x000f).mirror(0x03e0).writeonly().share(m_paletteram);
 	map(0x0010, 0x001f).mirror(0x03e0).w(FUNC(wmg_state::video_control_w));
 	map(0x0400, 0x0400).w(FUNC(wmg_state::wmg_c400_w));
 	map(0x0401, 0x0401).w(FUNC(wmg_state::wmg_sound_reset_w));
@@ -363,7 +364,7 @@ void wmg_state::wmg_c400_w(u8 data)
 	{
 		m_wmg_c400 = data;
 		wmg_d000_w(0); // select i/o
-		m_mainbank->set_entry(m_wmg_vram_bank ? (1+m_wmg_c400) : 0);      // Gfx etc
+		m_mainbank->set_entry(data);      // Gfx etc
 		m_codebank->set_entry(data);      // Code
 		m_soundbank->set_entry(data);      // Sound
 		m_soundcpu->reset();
@@ -379,8 +380,10 @@ void wmg_state::wmg_sound_reset_w(u8 data)
 void wmg_state::wmg_vram_select_w(u8 data)
 {
 	/* VRAM/ROM banking from bit 0 */
-	m_wmg_vram_bank = BIT(data, 0);
-	m_mainbank->set_entry(m_wmg_vram_bank ? (1+m_wmg_c400) : 0);
+	if (BIT(data, 0))
+		m_rom_view.select(0);
+	else
+		m_rom_view.disable();
 
 	/* cocktail flip from bit 1 */
 	m_cocktail = BIT(data, 1);
@@ -431,23 +434,21 @@ void wmg_state::machine_start()
 {
 	uint8_t *cpu = memregion("maincpu")->base();
 	uint8_t *snd = memregion("soundcpu")->base();
-	m_mainbank->configure_entry(0, m_videoram);
-	m_mainbank->configure_entries(1, 8, &cpu[0x00000], 0x10000);  // Gfx etc
+	m_mainbank->configure_entries(0, 8, &cpu[0x00000], 0x10000);  // Gfx etc
 	m_codebank->configure_entries(0, 8, &cpu[0x0d000], 0x10000);  // Code
 	m_soundbank->configure_entries(0, 8, &snd[0x00000], 0x1000);  // Sound
 
 	save_item(NAME(m_wmg_c400));
 	save_item(NAME(m_wmg_d000));
-	save_item(NAME(m_wmg_port_select));
-	save_item(NAME(m_wmg_vram_bank));
+	save_item(NAME(m_port_select));
 }
 
 void wmg_state::machine_reset()
 {
-	m_wmg_c400=0xff;
-	m_wmg_d000=0xff;
-	m_wmg_port_select=0;
-	m_wmg_vram_bank=0;
+	m_wmg_c400 = 0xff;
+	m_wmg_d000 = 0xff;
+	m_port_select = 0;
+	m_rom_view.disable();
 	wmg_c400_w(0);
 	m_maincpu->reset();
 }
@@ -460,7 +461,7 @@ void wmg_state::machine_reset()
 
 void wmg_state::wmg_port_select_w(int state)
 {
-	m_wmg_port_select = state | (m_wmg_c400 << 1);
+	m_port_select = state | (m_wmg_c400 << 1);
 }
 
 template <int N>
@@ -468,13 +469,13 @@ CUSTOM_INPUT_MEMBER(wmg_state::wmg_mux_r)
 {
 	if (N == 0)
 	{
-		uint8_t ports[17] = { 0,0,2,2,5,4,7,7,9,9,11,11,14,13,9,9 };
-		return m_keyboard[ports[m_wmg_port_select]]->read();
+		uint8_t const ports[17] = { 0,0,2,2,5,4,7,7,9,9,11,11,14,13,9,9 };
+		return m_keyboard[ports[m_port_select]]->read();
 	}
 	else
 	{
-		uint8_t ports[17] = { 1,1,3,3,6,6,8,8,10,10,12,12,16,15,10,10 };
-		return m_keyboard[ports[m_wmg_port_select]]->read();
+		uint8_t const ports[17] = { 1,1,3,3,6,6,8,8,10,10,12,12,16,15,10,10 };
+		return m_keyboard[ports[m_port_select]]->read();
 	}
 }
 
@@ -484,12 +485,15 @@ u8 wmg_state::wmg_pia_0_r(offs_t offset)
     Since there is no code in rom to handle this, it must be a hardware feature
     which probably just resets the cpu. */
 
-	uint8_t data = m_pia[0]->read(offset);
+	uint8_t const data = m_pia[0]->read(offset);
 
-	if ((m_wmg_c400) && (offset == 0) && ((data & 0x30) == 0x30))   // P1 and P2 pressed
+	if (!machine().side_effects_disabled())
 	{
-		wmg_c400_w(0);
-		m_maincpu->reset();
+		if ((m_wmg_c400) && (offset == 0) && ((data & 0x30) == 0x30))   // P1 and P2 pressed
+		{
+			wmg_c400_w(0);
+			m_maincpu->reset();
+		}
 	}
 
 	return data;
@@ -500,6 +504,9 @@ u8 wmg_state::wmg_pia_0_r(offs_t offset)
  *  Machine Driver
  *
  *************************************/
+static constexpr XTAL MASTER_CLOCK = (XTAL(12'000'000));
+static constexpr XTAL SOUND_CLOCK = (XTAL(3'579'545));
+
 void wmg_state::wmg(machine_config &config)
 {
 	/* basic machine hardware */
@@ -511,7 +518,7 @@ void wmg_state::wmg(machine_config &config)
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
-	ADDRESS_MAP_BANK(config, "bankc000").set_map(&wmg_state::wmg_banked_map).set_options(ENDIANNESS_BIG, 8, 16, 0x1000);
+	ADDRESS_MAP_BANK(config, m_bankc000).set_map(&wmg_state::wmg_banked_map).set_options(ENDIANNESS_BIG, 8, 16, 0x1000);
 
 	// set a timer to go off every 32 scanlines, to toggle the VA11 line and update the screen
 	TIMER(config, "scan_timer").configure_scanline(FUNC(wmg_state::va11_callback), "screen", 0, 32);


### PR DESCRIPTION
Use memory_view for ROM/Palette overlay
Reduce unnecessary devices, variables
Reduce ROM region size, rearrange ROM offsets
Fix naming for tile ROM region
Reduce runtime tag lookups
suppress machine().side_effects_disabled() for debugger reading PIA constantize variables