### PR TITLE
midway/midyunit.cpp: Various cleanups

### DIFF
--- a/src/mame/midway/midyunit.h
+++ b/src/mame/midway/midyunit.h
@@ -63,8 +63,6 @@ public:
 	int adpcm_irq_state_r();
 
 protected:
-	virtual void machine_start() override { }
-
 	// protection data types
 	struct protection_data
 	{

--- a/src/mame/midway/midyunit.h
+++ b/src/mame/midway/midyunit.h
@@ -27,66 +27,45 @@ public:
 	midyunit_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
-		, m_audiocpu(*this, "audiocpu")
-		, m_oki(*this, "oki")
 		, m_palette(*this, "palette")
 		, m_narc_sound(*this, "narcsnd")
 		, m_cvsd_sound(*this, "cvsd")
 		, m_adpcm_sound(*this, "adpcm")
-		, m_soundlatch(*this, "soundlatch")
-		, m_term2_adc(*this, "adc")
 		, m_nvram(*this, "nvram")
-		, m_generic_paletteram_16(*this, "paletteram")
+		, m_paletteram(*this, "paletteram")
 		, m_gfx_rom(*this, "gfx_rom", 0x800000, ENDIANNESS_BIG)
 		, m_mainram(*this, "mainram")
 		, m_ports(*this, { { "IN0", "IN1", "IN2", "DSW", "UNK0", "UNK1" } })
-		, m_left_flash(*this, "Left_Flash_%u", 1U)
-		, m_right_flash(*this, "Right_Flash_%u", 1U)
-		, m_left_gun_recoil(*this, "Left_Gun_Recoil")
-		, m_right_gun_recoil(*this, "Right_Gun_Recoil")
-		, m_left_gun_green_led(*this, "Left_Gun_Green_Led")
-		, m_left_gun_red_led(*this, "Left_Gun_Red_Led")
-		, m_right_gun_green_led(*this, "Right_Gun_Green_Led")
-		, m_right_gun_red_led(*this, "Right_Gun_Red_Led")
 	{
 	}
 
-	void term2(machine_config &config);
-	void yunit_cvsd_4bit_fast(machine_config &config);
 	void yunit_adpcm_6bit_fast(machine_config &config);
-	void yunit_cvsd_6bit_slow(machine_config &config);
-	void yunit_cvsd_4bit_slow(machine_config &config);
-	void mkyawdim(machine_config &config);
-	void yunit_core(machine_config &config);
-	void zunit(machine_config &config);
 	void yunit_adpcm_6bit_faster(machine_config &config);
+	void yunit_core(machine_config &config);
+	void yunit_cvsd_4bit_fast(machine_config &config);
+	void yunit_cvsd_4bit_slow(machine_config &config);
+	void yunit_cvsd_6bit_slow(machine_config &config);
+	void zunit(machine_config &config);
 
-	void init_smashtv();
-	void init_strkforc();
-	void init_narc();
-	void init_term2();
-	void init_term2la1();
-	void init_term2la3();
-	void init_mkyunit();
-	void init_trog();
-	void init_totcarn();
-	void init_mkyawdim();
-	void init_mkyawdim2();
-	void init_shimpact();
 	void init_hiimpact();
 	void init_mkla3bl();
 	void init_mkyturbo();
-	void init_term2la2();
+	void init_mkyunit();
+	void init_narc();
+	void init_shimpact();
+	void init_smashtv();
+	void init_strkforc();
+	void init_totcarn();
+	void init_trog();
 
 	int narc_talkback_strobe_r();
 	DECLARE_CUSTOM_INPUT_MEMBER(narc_talkback_data_r);
 	int adpcm_irq_state_r();
 
 protected:
-	virtual void machine_start() override;
+	virtual void machine_start() override { }
 
-private:
-	/* protection data types */
+	// protection data types
 	struct protection_data
 	{
 		uint16_t  reset_sequence[3]{};
@@ -106,28 +85,16 @@ private:
 	};
 
 	required_device<tms34010_device> m_maincpu;
-	optional_device<cpu_device> m_audiocpu;
-	optional_device<okim6295_device> m_oki;
 	required_device<palette_device> m_palette;
 	optional_device<williams_narc_sound_device> m_narc_sound;
 	optional_device<williams_cvsd_sound_device> m_cvsd_sound;
 	optional_device<williams_adpcm_sound_device> m_adpcm_sound;
-	optional_device<generic_latch_8_device> m_soundlatch;
-	optional_device<adc0844_device> m_term2_adc;
 	required_device<nvram_device> m_nvram;
 
-	required_shared_ptr<uint16_t> m_generic_paletteram_16;
+	required_shared_ptr<uint16_t> m_paletteram;
 	memory_share_creator<uint8_t> m_gfx_rom;
 	required_shared_ptr<uint16_t> m_mainram;
 	optional_ioport_array<6> m_ports;
-	output_finder<4> m_left_flash;
-	output_finder<4> m_right_flash;
-	output_finder<> m_left_gun_recoil;
-	output_finder<> m_right_gun_recoil;
-	output_finder<> m_left_gun_green_led;
-	output_finder<> m_left_gun_red_led;
-	output_finder<> m_right_gun_green_led;
-	output_finder<> m_right_gun_red_led;
 
 	std::unique_ptr<uint16_t[]> m_cmos_ram;
 	std::unique_ptr<uint8_t[]> m_hidden_ram;
@@ -138,7 +105,6 @@ private:
 	const struct protection_data *m_prot_data = nullptr;
 	uint8_t m_cmos_w_enable = 0;
 	uint8_t m_chip_type = 0;
-	uint16_t *m_t2_hack_mem = nullptr;
 	uint8_t *m_cvsd_protection_base = nullptr;
 	uint8_t m_autoerase_enable = 0;
 	uint32_t m_palette_mask = 0;
@@ -150,18 +116,13 @@ private:
 	dma_state_t m_dma_state;
 	emu_timer *m_dma_timer = nullptr;
 	emu_timer *m_autoerase_line_timer = nullptr;
+
 	void midyunit_cmos_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	uint16_t midyunit_cmos_r(offs_t offset);
 	void midyunit_cmos_enable_w(address_space &space, uint16_t data);
 	uint16_t midyunit_protection_r();
 	uint16_t midyunit_input_r(offs_t offset);
 	void midyunit_sound_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t term2_input_r(offs_t offset);
-	void term2_sound_w(offs_t offset, uint16_t data);
-	void term2_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void term2la3_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void term2la2_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void term2la1_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void cvsd_protection_w(offs_t offset, uint8_t data);
 	uint16_t mkturbo_prot_r();
 	uint16_t midyunit_gfxrom_r(offs_t offset);
@@ -171,9 +132,6 @@ private:
 	void midyunit_paletteram_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	uint16_t midyunit_dma_r(offs_t offset);
 	void midyunit_dma_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void yawdim_oki_bank_w(uint8_t data);
-	void yawdim2_oki_bank_w(uint8_t data);
-	uint8_t yawdim2_soundlatch_r();
 	TMS340X0_TO_SHIFTREG_CB_MEMBER(to_shiftreg);
 	TMS340X0_FROM_SHIFTREG_CB_MEMBER(from_shiftreg);
 	TMS340X0_SCANLINE_IND16_CB_MEMBER(scanline_update);
@@ -181,18 +139,100 @@ private:
 	DECLARE_VIDEO_START(midzunit);
 	DECLARE_VIDEO_START(midyunit_4bit);
 	DECLARE_VIDEO_START(midyunit_6bit);
-	DECLARE_VIDEO_START(mkyawdim);
 	DECLARE_VIDEO_START(common);
 	TIMER_CALLBACK_MEMBER(dma_callback);
 	TIMER_CALLBACK_MEMBER(autoerase_line);
 
 	void main_map(address_map &map);
-	void yawdim_sound_map(address_map &map);
 
 	void dma_draw(uint16_t command);
 	void init_generic(int bpp, int sound, int prot_start, int prot_end);
 	void install_hidden_ram(mc6809e_device &cpu, int prot_start, int prot_end);
+};
+
+class term2_state : public midyunit_state
+{
+public:
+	term2_state(const machine_config &mconfig, device_type type, const char *tag)
+		: midyunit_state(mconfig, type, tag)
+		, m_adc(*this, "adc")
+		, m_left_flash(*this, "Left_Flash_%u", 1U)
+		, m_right_flash(*this, "Right_Flash_%u", 1U)
+		, m_left_gun_recoil(*this, "Left_Gun_Recoil")
+		, m_right_gun_recoil(*this, "Right_Gun_Recoil")
+		, m_left_gun_green_led(*this, "Left_Gun_Green_Led")
+		, m_left_gun_red_led(*this, "Left_Gun_Red_Led")
+		, m_right_gun_green_led(*this, "Right_Gun_Green_Led")
+		, m_right_gun_red_led(*this, "Right_Gun_Red_Led")
+	{
+	}
+
+	void term2(machine_config &config);
+
+	void init_term2();
+	void init_term2la1();
+	void init_term2la2();
+	void init_term2la3();
+
+protected:
+	virtual void machine_start() override;
+
+private:
+	required_device<adc0844_device> m_adc;
+	
+	output_finder<4> m_left_flash;
+	output_finder<4> m_right_flash;
+	output_finder<> m_left_gun_recoil;
+	output_finder<> m_right_gun_recoil;
+	output_finder<> m_left_gun_green_led;
+	output_finder<> m_left_gun_red_led;
+	output_finder<> m_right_gun_green_led;
+	output_finder<> m_right_gun_red_led;
+
+	uint16_t *m_t2_hack_mem = nullptr;
+
+	uint16_t term2_input_r(offs_t offset);
+	void term2_sound_w(offs_t offset, uint16_t data);
+	void term2_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void term2la3_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void term2la2_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void term2la1_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void term2_init_common(write16s_delegate hack_w);
+};
+
+class mkyawdim_state : public midyunit_state
+{
+public:
+	mkyawdim_state(const machine_config &mconfig, device_type type, const char *tag)
+		: midyunit_state(mconfig, type, tag)
+		, m_audiocpu(*this, "audiocpu")
+		, m_soundlatch(*this, "soundlatch")
+		, m_oki(*this, "oki")
+	{
+	}
+
+	void mkyawdim(machine_config &config);
+	void mkyawdim2(machine_config &config);
+
+	void init_mkyawdim();
+
+protected:
+	virtual void video_start() override;
+
+private:
+	required_device<cpu_device> m_audiocpu;
+	optional_device<generic_latch_8_device> m_soundlatch;
+	required_device<okim6295_device> m_oki;
+
+	void yawdim_oki_bank_w(uint8_t data);
+	void yawdim2_oki_bank_w(uint8_t data);
+	void yawdim_sound_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void yawdim2_sound_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+
+	void yawdim_main_map(address_map &map);
+	void yawdim2_main_map(address_map &map);
+	void yawdim_sound_map(address_map &map);
+	void yawdim2_sound_map(address_map &map);
 };
 
 #endif // MAME_MIDWAY_MIDYUNIT_H

--- a/src/mame/midway/midyunit_m.cpp
+++ b/src/mame/midway/midyunit_m.cpp
@@ -11,17 +11,28 @@
 #include "cpu/m6809/m6809.h"
 #include "midyunit.h"
 
+#define LOG_CMOS     (1U << 1)
+#define LOG_PROT     (1U << 1)
 
-/* constant definitions */
-#define SOUND_NARC                  1
-#define SOUND_CVSD_SMALL            2
-#define SOUND_CVSD                  3
-#define SOUND_ADPCM                 4
-#define SOUND_YAWDIM                5
-#define SOUND_YAWDIM2               6
+#define LOG_ALL      (LOG_CMOS | LOG_PROT)
 
+#define VERBOSE (0)
+#include "logmacro.h"
 
-void midyunit_state::machine_start()
+#define LOGCMOS(...) LOGMASKED(LOG_CMOS, __VA_ARGS__)
+#define LOGPROT(...) LOGMASKED(LOG_PROT, __VA_ARGS__)
+
+// constant definitions
+enum
+{
+	SOUND_NARC = 1,
+	SOUND_CVSD_SMALL,
+	SOUND_CVSD,
+	SOUND_ADPCM,
+	SOUND_YAWDIM
+};
+
+void term2_state::machine_start()
 {
 	m_left_flash.resolve();
 	m_right_flash.resolve();
@@ -41,7 +52,7 @@ void midyunit_state::machine_start()
 
 void midyunit_state::midyunit_cmos_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	logerror("%08x:CMOS Write @ %05X\n", m_maincpu->pc(), offset);
+	LOGCMOS("%08x:CMOS Write @ %05X\n", m_maincpu->pc(), offset);
 	COMBINE_DATA(&m_cmos_ram[offset + m_cmos_page]);
 }
 
@@ -63,46 +74,46 @@ void midyunit_state::midyunit_cmos_enable_w(address_space &space, uint16_t data)
 {
 	m_cmos_w_enable = (~data >> 9) & 1;
 
-	logerror("%08x:Protection write = %04X\n", m_maincpu->pc(), data);
+	LOGPROT("%08x:Protection write = %04X\n", m_maincpu->pc(), data);
 
-	/* only go down this path if we have a data structure */
+	// only go down this path if we have a data structure
 	if (m_prot_data)
 	{
-		/* mask off the data */
+		// mask off the data
 		data &= 0x0f00;
 
-		/* update the FIFO */
+		// update the FIFO
 		m_prot_sequence[0] = m_prot_sequence[1];
 		m_prot_sequence[1] = m_prot_sequence[2];
 		m_prot_sequence[2] = data;
 
-		/* special case: sequence entry 1234 means Strike Force, which is different */
+		// special case: sequence entry 1234 means Strike Force, which is different
 		if (m_prot_data->reset_sequence[0] == 0x1234)
 		{
 			if (data == 0x500)
 			{
 				m_prot_result = space.read_word(0x10a4390) << 4;
-				logerror("  desired result = %04X\n", m_prot_result);
+				LOGPROT("  desired result = %04X\n", m_prot_result);
 			}
 		}
 
-		/* all other games use the same pattern */
+		// all other games use the same pattern
 		else
 		{
-			/* look for a reset */
+			// look for a reset
 			if (m_prot_sequence[0] == m_prot_data->reset_sequence[0] &&
 				m_prot_sequence[1] == m_prot_data->reset_sequence[1] &&
 				m_prot_sequence[2] == m_prot_data->reset_sequence[2])
 			{
-				logerror("Protection reset\n");
+				LOGPROT("Protection reset\n");
 				m_prot_index = 0;
 			}
 
-			/* look for a clock */
+			// look for a clock
 			if ((m_prot_sequence[1] & 0x0800) != 0 && (m_prot_sequence[2] & 0x0800) == 0)
 			{
 				m_prot_result = m_prot_data->data_sequence[m_prot_index++];
-				logerror("Protection clock (new data = %04X)\n", m_prot_result);
+				LOGPROT("Protection clock (new data = %04X)\n", m_prot_result);
 			}
 		}
 	}
@@ -111,8 +122,9 @@ void midyunit_state::midyunit_cmos_enable_w(address_space &space, uint16_t data)
 
 uint16_t midyunit_state::midyunit_protection_r()
 {
-	/* return the most recently clocked value */
-	logerror("%08X:Protection read = %04X\n", m_maincpu->pc(), m_prot_result);
+	// return the most recently clocked value
+	if (!machine().side_effects_disabled())
+		LOGPROT("%08X:Protection read = %04X\n", m_maincpu->pc(), m_prot_result);
 	return m_prot_result;
 }
 
@@ -137,17 +149,17 @@ uint16_t midyunit_state::midyunit_input_r(offs_t offset)
  *
  *************************************/
 
-uint16_t midyunit_state::term2_input_r(offs_t offset)
+uint16_t term2_state::term2_input_r(offs_t offset)
 {
 	if (offset != 2)
 		return m_ports[offset]->read();
 
-	return m_term2_adc->read() | 0xff00;
+	return m_adc->read() | 0xff00;
 }
 
-void midyunit_state::term2_sound_w(offs_t offset, uint16_t data)
+void term2_state::term2_sound_w(offs_t offset, uint16_t data)
 {
-	/* Flash Lamp Output Data */
+	// Flash Lamp Output Data
 	if  ( ((data & 0x800) != 0x800) && ((data & 0x400) == 0x400 ) )
 	{
 		for (int i = 0; i < 4; i++)
@@ -156,7 +168,7 @@ void midyunit_state::term2_sound_w(offs_t offset, uint16_t data)
 			m_right_flash[i] = BIT(data, i + 4);
 	}
 
-	/* Gun Output Data */
+	// Gun Output Data
 	if  ( ((data & 0x800) == 0x800) && ((data & 0x400) != 0x400 ) )
 	{
 		m_left_gun_recoil = BIT(data, 0);
@@ -168,7 +180,7 @@ void midyunit_state::term2_sound_w(offs_t offset, uint16_t data)
 	}
 
 	if (offset == 0)
-		m_term2_adc->write(((data >> 12) & 3) | 4);
+		m_adc->write(((data >> 12) & 3) | 4);
 
 	m_adpcm_sound->reset_write((~data & 0x100) >> 1);
 	m_adpcm_sound->write(data);
@@ -182,7 +194,7 @@ void midyunit_state::term2_sound_w(offs_t offset, uint16_t data)
  *
  *************************************/
 
-void midyunit_state::term2_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void term2_state::term2_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	if (offset == 1 && m_maincpu->pc() == 0xffce6520)
 	{
@@ -192,7 +204,7 @@ void midyunit_state::term2_hack_w(offs_t offset, uint16_t data, uint16_t mem_mas
 	COMBINE_DATA(&m_t2_hack_mem[offset]);
 }
 
-void midyunit_state::term2la3_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void term2_state::term2la3_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	if (offset == 0 && m_maincpu->pc() == 0xffce5230)
 	{
@@ -202,7 +214,7 @@ void midyunit_state::term2la3_hack_w(offs_t offset, uint16_t data, uint16_t mem_
 	COMBINE_DATA(&m_t2_hack_mem[offset]);
 }
 
-void midyunit_state::term2la2_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void term2_state::term2la2_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	if (offset == 0 && m_maincpu->pc() == 0xffce4b80)
 	{
@@ -212,7 +224,7 @@ void midyunit_state::term2la2_hack_w(offs_t offset, uint16_t data, uint16_t mem_
 	COMBINE_DATA(&m_t2_hack_mem[offset]);
 }
 
-void midyunit_state::term2la1_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void term2_state::term2la1_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	if (offset == 0 && m_maincpu->pc() == 0xffce33f0)
 	{
@@ -232,10 +244,10 @@ void midyunit_state::term2la1_hack_w(offs_t offset, uint16_t data, uint16_t mem_
 
 void midyunit_state::cvsd_protection_w(offs_t offset, uint8_t data)
 {
-	/* because the entire CVSD ROM is banked, we have to make sure that writes */
-	/* go to the proper location (i.e., bank 0); currently bank 0 always lives */
-	/* in the 0x10000-0x17fff space, so we just need to add 0x8000 to get the  */
-	/* proper offset */
+	// because the entire CVSD ROM is banked, we have to make sure that writes
+	// go to the proper location (i.e., bank 0); currently bank 0 always lives
+	// in the 0x10000-0x17fff space, so we just need to add 0x8000 to get the 
+	// proper offset
 	m_cvsd_protection_base[offset] = data;
 }
 
@@ -249,16 +261,15 @@ void midyunit_state::install_hidden_ram(mc6809e_device &cpu, int prot_start, int
 
 void midyunit_state::init_generic(int bpp, int sound, int prot_start, int prot_end)
 {
-	offs_t gfx_chunk = m_gfx_rom.bytes() / 4;
+	offs_t const gfx_chunk = m_gfx_rom.bytes() / 4;
 	uint8_t d1, d2, d3, d4, d5, d6;
-	int i;
 
-	/* load graphics ROMs */
-	uint8_t *base = memregion("gfx1")->base();
+	// load graphics ROMs
+	uint8_t const *const base = memregion("gfx")->base();
 	switch (bpp)
 	{
 		case 4:
-			for (i = 0; i < m_gfx_rom.bytes(); i += 2)
+			for (int i = 0; i < m_gfx_rom.bytes(); i += 2)
 			{
 				d1 = ((base[0 * gfx_chunk + (i + 0) / 4]) >> (2 * ((i + 0) % 4))) & 3;
 				d2 = ((base[1 * gfx_chunk + (i + 0) / 4]) >> (2 * ((i + 0) % 4))) & 3;
@@ -271,7 +282,7 @@ void midyunit_state::init_generic(int bpp, int sound, int prot_start, int prot_e
 			break;
 
 		case 6:
-			for (i = 0; i < m_gfx_rom.bytes(); i += 2)
+			for (int i = 0; i < m_gfx_rom.bytes(); i += 2)
 			{
 				d1 = ((base[0 * gfx_chunk + (i + 0) / 4]) >> (2 * ((i + 0) % 4))) & 3;
 				d2 = ((base[1 * gfx_chunk + (i + 0) / 4]) >> (2 * ((i + 0) % 4))) & 3;
@@ -286,7 +297,7 @@ void midyunit_state::init_generic(int bpp, int sound, int prot_start, int prot_e
 			break;
 
 		case 8:
-			for (i = 0; i < m_gfx_rom.bytes(); i += 4)
+			for (int i = 0; i < m_gfx_rom.bytes(); i += 4)
 			{
 				m_gfx_rom[i + 0] = base[0 * gfx_chunk + i / 4];
 				m_gfx_rom[i + 1] = base[1 * gfx_chunk + i / 4];
@@ -296,7 +307,7 @@ void midyunit_state::init_generic(int bpp, int sound, int prot_start, int prot_e
 			break;
 	}
 
-	/* load sound ROMs and set up sound handlers */
+	// load sound ROMs and set up sound handlers
 	m_chip_type = sound;
 	switch (sound)
 	{
@@ -318,7 +329,6 @@ void midyunit_state::init_generic(int bpp, int sound, int prot_start, int prot_e
 			break;
 
 		case SOUND_YAWDIM:
-		case SOUND_YAWDIM2:
 			break;
 	}
 }
@@ -336,7 +346,7 @@ void midyunit_state::init_generic(int bpp, int sound, int prot_start, int prot_e
 
 void midyunit_state::init_narc()
 {
-	/* common init */
+	// common init
 	init_generic(8, SOUND_NARC, 0xcdff, 0xce29);
 }
 
@@ -355,7 +365,7 @@ void midyunit_state::init_narc()
 
 void midyunit_state::init_trog()
 {
-	/* protection */
+	// protection
 	static const struct protection_data trog_protection_data =
 	{
 		{ 0x0f00, 0x0f00, 0x0f00 },
@@ -366,7 +376,7 @@ void midyunit_state::init_trog()
 	};
 	m_prot_data = &trog_protection_data;
 
-	/* common init */
+	// common init
 	init_generic(4, SOUND_CVSD_SMALL, 0x9eaf, 0x9ed9);
 }
 
@@ -375,7 +385,7 @@ void midyunit_state::init_trog()
 
 void midyunit_state::init_smashtv()
 {
-	/* common init */
+	// common init
 	init_generic(6, SOUND_CVSD_SMALL, 0x9cf6, 0x9d21);
 
 	m_prot_data = nullptr;
@@ -386,7 +396,7 @@ void midyunit_state::init_smashtv()
 
 void midyunit_state::init_hiimpact()
 {
-	/* protection */
+	// protection
 	static const struct protection_data hiimpact_protection_data =
 	{
 		{ 0x0b00, 0x0b00, 0x0b00 },
@@ -395,7 +405,7 @@ void midyunit_state::init_hiimpact()
 	};
 	m_prot_data = &hiimpact_protection_data;
 
-	/* common init */
+	// common init
 	init_generic(6, SOUND_CVSD, 0x9b79, 0x9ba3);
 }
 
@@ -404,7 +414,7 @@ void midyunit_state::init_hiimpact()
 
 void midyunit_state::init_shimpact()
 {
-	/* protection */
+	// protection
 	static const struct protection_data shimpact_protection_data =
 	{
 		{ 0x0f00, 0x0e00, 0x0d00 },
@@ -413,7 +423,7 @@ void midyunit_state::init_shimpact()
 	};
 	m_prot_data = &shimpact_protection_data;
 
-	/* common init */
+	// common init
 	init_generic(6, SOUND_CVSD, 0x9c06, 0x9c15);
 }
 
@@ -422,14 +432,14 @@ void midyunit_state::init_shimpact()
 
 void midyunit_state::init_strkforc()
 {
-	/* protection */
+	// protection
 	static const struct protection_data strkforc_protection_data =
 	{
 		{ 0x1234 }
 	};
 	m_prot_data = &strkforc_protection_data;
 
-	/* common init */
+	// common init
 	init_generic(4, SOUND_CVSD_SMALL, 0x9f7d, 0x9fa7);
 }
 
@@ -448,7 +458,7 @@ void midyunit_state::init_strkforc()
 
 void midyunit_state::init_mkyunit()
 {
-	/* protection */
+	// protection
 	static const struct protection_data mk_protection_data =
 	{
 		{ 0x0d00, 0x0c00, 0x0900 },
@@ -458,21 +468,14 @@ void midyunit_state::init_mkyunit()
 	};
 	m_prot_data = &mk_protection_data;
 
-	/* common init */
+	// common init
 	init_generic(6, SOUND_ADPCM, 0xfb9c, 0xfbc6);
 }
 
-void midyunit_state::init_mkyawdim()
+void mkyawdim_state::init_mkyawdim()
 {
-	/* common init */
+	// common init
 	init_generic(6, SOUND_YAWDIM, 0, 0);
-}
-
-void midyunit_state::init_mkyawdim2()
-{
-	m_audiocpu->space(AS_PROGRAM).install_write_handler(0x9000, 0x97ff, write8smo_delegate(*this, FUNC(midyunit_state::yawdim2_oki_bank_w)));
-	m_audiocpu->space(AS_PROGRAM).install_read_handler(0xa000, 0xa7ff, read8smo_delegate(*this, FUNC(midyunit_state::yawdim2_soundlatch_r)));
-	init_mkyawdim();
 }
 
 
@@ -491,7 +494,7 @@ uint16_t midyunit_state::mkturbo_prot_r()
 
 void midyunit_state::init_mkyturbo()
 {
-	/* protection */
+	// protection
 	m_maincpu->space(AS_PROGRAM).install_read_handler(0xfffff400, 0xfffff40f, read16smo_delegate(*this, FUNC(midyunit_state::mkturbo_prot_r)));
 
 	init_mkyunit();
@@ -500,7 +503,7 @@ void midyunit_state::init_mkyturbo()
 void midyunit_state::init_mkla3bl()
 {
 	// rearrange GFX so the driver can deal with them
-	uint8_t *gfxrom = memregion("gfx1")->base();
+	uint8_t *gfxrom = memregion("gfx")->base();
 	std::vector<uint8_t> buffer(0x400000);
 	memcpy(&buffer[0], gfxrom, 0x400000);
 
@@ -523,7 +526,7 @@ void midyunit_state::init_mkla3bl()
 
 /********************** Terminator 2 **********************/
 
-void midyunit_state::term2_init_common(write16s_delegate hack_w)
+void term2_state::term2_init_common(write16s_delegate hack_w)
 {
 	// protection
 	static constexpr struct protection_data term2_protection_data =
@@ -536,9 +539,9 @@ void midyunit_state::term2_init_common(write16s_delegate hack_w)
 	// common init
 	init_generic(6, SOUND_ADPCM, 0xfa8d, 0xfa9c);
 
-	// special inputs */
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x01c00000, 0x01c0005f, read16sm_delegate(*this, FUNC(midyunit_state::term2_input_r)));
-	m_maincpu->space(AS_PROGRAM).install_write_handler(0x01e00000, 0x01e0001f, write16sm_delegate(*this, FUNC(midyunit_state::term2_sound_w)));
+	// special inputs
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x01c00000, 0x01c0005f, read16sm_delegate(*this, FUNC(term2_state::term2_input_r)));
+	m_maincpu->space(AS_PROGRAM).install_write_handler(0x01e00000, 0x01e0001f, write16sm_delegate(*this, FUNC(term2_state::term2_sound_w)));
 
 	// HACK: this prevents the freeze on the movies
 	// until we figure what's causing it, this is better than nothing
@@ -546,10 +549,10 @@ void midyunit_state::term2_init_common(write16s_delegate hack_w)
 	m_t2_hack_mem = m_mainram + (0xaa0e0>>4);
 }
 
-void midyunit_state::init_term2()    { term2_init_common(write16s_delegate(*this, FUNC(midyunit_state::term2_hack_w))); }
-void midyunit_state::init_term2la3() { term2_init_common(write16s_delegate(*this, FUNC(midyunit_state::term2la3_hack_w))); }
-void midyunit_state::init_term2la2() { term2_init_common(write16s_delegate(*this, FUNC(midyunit_state::term2la2_hack_w))); }
-void midyunit_state::init_term2la1() { term2_init_common(write16s_delegate(*this, FUNC(midyunit_state::term2la1_hack_w))); }
+void term2_state::init_term2()    { term2_init_common(write16s_delegate(*this, FUNC(term2_state::term2_hack_w))); }
+void term2_state::init_term2la3() { term2_init_common(write16s_delegate(*this, FUNC(term2_state::term2la3_hack_w))); }
+void term2_state::init_term2la2() { term2_init_common(write16s_delegate(*this, FUNC(term2_state::term2la2_hack_w))); }
+void term2_state::init_term2la1() { term2_init_common(write16s_delegate(*this, FUNC(term2_state::term2la1_hack_w))); }
 
 
 
@@ -557,7 +560,7 @@ void midyunit_state::init_term2la1() { term2_init_common(write16s_delegate(*this
 
 void midyunit_state::init_totcarn()
 {
-	/* protection */
+	// protection
 	static const struct protection_data totcarn_protection_data =
 	{
 		{ 0x0f00, 0x0f00, 0x0f00 },
@@ -566,7 +569,7 @@ void midyunit_state::init_totcarn()
 	};
 	m_prot_data = &totcarn_protection_data;
 
-	/* common init */
+	// common init
 	init_generic(6, SOUND_ADPCM, 0xfc04, 0xfc2e);
 }
 
@@ -580,7 +583,7 @@ void midyunit_state::init_totcarn()
 
 MACHINE_RESET_MEMBER(midyunit_state,midyunit)
 {
-	/* reset sound */
+	// reset sound
 	switch (m_chip_type)
 	{
 		case SOUND_NARC:
@@ -600,7 +603,6 @@ MACHINE_RESET_MEMBER(midyunit_state,midyunit)
 			break;
 
 		case SOUND_YAWDIM:
-		case SOUND_YAWDIM2:
 			break;
 	}
 }
@@ -615,14 +617,14 @@ MACHINE_RESET_MEMBER(midyunit_state,midyunit)
 
 void midyunit_state::midyunit_sound_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	/* check for out-of-bounds accesses */
+	// check for out-of-bounds accesses
 	if (offset)
 	{
 		logerror("%08X:Unexpected write to sound (hi) = %04X\n", m_maincpu->pc(), data);
 		return;
 	}
 
-	/* call through based on the sound type */
+	// call through based on the sound type
 	if (ACCESSING_BITS_0_7 && ACCESSING_BITS_8_15)
 		switch (m_chip_type)
 		{
@@ -640,15 +642,24 @@ void midyunit_state::midyunit_sound_w(offs_t offset, uint16_t data, uint16_t mem
 				m_adpcm_sound->reset_write((~data & 0x100) >> 8);
 				m_adpcm_sound->write(data);
 				break;
-
-			case SOUND_YAWDIM:
-				m_soundlatch->write(data);
-				m_audiocpu->pulse_input_line(INPUT_LINE_NMI, attotime::zero);
-				break;
-
-			case SOUND_YAWDIM2:
-				m_soundlatch->write(data);
-				m_audiocpu->set_input_line(INPUT_LINE_NMI, ASSERT_LINE);
-				break;
 		}
+}
+
+void mkyawdim_state::yawdim_sound_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	// call through based on the sound type
+	if (ACCESSING_BITS_0_7 && ACCESSING_BITS_8_15)
+	{
+		m_soundlatch->write(data);
+		m_audiocpu->pulse_input_line(INPUT_LINE_NMI, attotime::zero);
+	}
+}
+
+void mkyawdim_state::yawdim2_sound_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	// call through based on the sound type
+	if (ACCESSING_BITS_0_7 && ACCESSING_BITS_8_15)
+	{
+		m_soundlatch->write(data);
+	}
 }

--- a/src/mame/midway/midyunit_m.cpp
+++ b/src/mame/midway/midyunit_m.cpp
@@ -34,6 +34,8 @@ enum
 
 void term2_state::machine_start()
 {
+	midyunit_state::machine_start();
+
 	m_left_flash.resolve();
 	m_right_flash.resolve();
 	m_left_gun_recoil.resolve();

--- a/src/mame/midway/midyunit_v.cpp
+++ b/src/mame/midway/midyunit_v.cpp
@@ -12,11 +12,11 @@
 #include "screen.h"
 
 
-/* compile-time options */
-#define LOG_DMA             0       /* DMAs are logged if the 'L' key is pressed */
+// compile-time options
+#define LOG_DMA             0       // DMAs are logged if the 'L' key is pressed
 
 
-/* constants for the DMA chip */
+// constants for the DMA chip
 enum
 {
 	DMA_COMMAND = 0,
@@ -41,7 +41,7 @@ enum
 
 VIDEO_START_MEMBER(midyunit_state,common)
 {
-	/* allocate memory */
+	// allocate memory
 	m_cmos_ram = std::make_unique<uint16_t[]>((0x2000 * 4)/2);
 	m_local_videoram = make_unique_clear<uint16_t[]>(0x80000/2);
 	m_pen_map = std::make_unique<pen_t[]>(65536);
@@ -51,16 +51,16 @@ VIDEO_START_MEMBER(midyunit_state,common)
 	m_dma_timer = timer_alloc(FUNC(midyunit_state::dma_callback), this);
 	m_autoerase_line_timer = timer_alloc(FUNC(midyunit_state::autoerase_line), this);
 
-	/* reset all the globals */
+	// reset all the globals
 	m_cmos_page = 0;
 	m_autoerase_enable = 0;
 	m_yawdim_dma = 0;
 
-	/* reset DMA state */
+	// reset DMA state
 	memset(m_dma_register, 0, sizeof(m_dma_register));
 	m_dma_state = dma_state_t();
 
-	/* register for state saving */
+	// register for state saving
 	save_item(NAME(m_autoerase_enable));
 	save_pointer(NAME(m_local_videoram), 0x80000/2);
 	save_pointer(NAME(m_cmos_ram), (0x2000 * 4)/2);
@@ -71,12 +71,10 @@ VIDEO_START_MEMBER(midyunit_state,common)
 
 VIDEO_START_MEMBER(midyunit_state,midyunit_4bit)
 {
-	int i;
-
 	VIDEO_START_CALL_MEMBER(common);
 
-	/* init for 4-bit */
-	for (i = 0; i < 65536; i++)
+	// init for 4-bit
+	for (int i = 0; i < 65536; i++)
 		m_pen_map[i] = ((i & 0xf000) >> 8) | (i & 0x000f);
 	m_palette_mask = 0x00ff;
 }
@@ -84,18 +82,16 @@ VIDEO_START_MEMBER(midyunit_state,midyunit_4bit)
 
 VIDEO_START_MEMBER(midyunit_state,midyunit_6bit)
 {
-	int i;
-
 	VIDEO_START_CALL_MEMBER(common);
 
-	/* init for 6-bit */
-	for (i = 0; i < 65536; i++)
+	// init for 6-bit
+	for (int i = 0; i < 65536; i++)
 		m_pen_map[i] = ((i & 0xc000) >> 8) | (i & 0x0f3f);
 	m_palette_mask = 0x0fff;
 }
 
 
-VIDEO_START_MEMBER(midyunit_state,mkyawdim)
+void mkyawdim_state::video_start()
 {
 	VIDEO_START_CALL_MEMBER(midyunit_6bit);
 	m_yawdim_dma = 1;
@@ -104,12 +100,10 @@ VIDEO_START_MEMBER(midyunit_state,mkyawdim)
 
 VIDEO_START_MEMBER(midyunit_state,midzunit)
 {
-	int i;
-
 	VIDEO_START_CALL_MEMBER(common);
 
-	/* init for 8-bit */
-	for (i = 0; i < 65536; i++)
+	// init for 8-bit
+	for (int i = 0; i < 65536; i++)
 		m_pen_map[i] = i & 0x1fff;
 	m_palette_mask = 0x1fff;
 }
@@ -234,13 +228,13 @@ void midyunit_state::midyunit_control_w(offs_t offset, uint16_t data, uint16_t m
 
 	if (ACCESSING_BITS_0_7)
 	{
-		/* CMOS page is bits 6-7 */
+		// CMOS page is bits 6-7
 		m_cmos_page = ((data >> 6) & 3) * 0x1000;
 
-		/* video bank select is bit 5 */
+		// video bank select is bit 5
 		m_videobank_select = (data >> 5) & 1;
 
-		/* handle autoerase disable (bit 4) */
+		// handle autoerase disable (bit 4)
 		m_autoerase_enable = ((data & 0x10) == 0);
 	}
 }
@@ -257,8 +251,8 @@ void midyunit_state::midyunit_paletteram_w(offs_t offset, uint16_t data, uint16_
 {
 	int newword;
 
-	COMBINE_DATA(&m_generic_paletteram_16[offset]);
-	newword = m_generic_paletteram_16[offset];
+	COMBINE_DATA(&m_paletteram[offset]);
+	newword = m_paletteram[offset];
 	m_palette->set_pen_color(offset & m_palette_mask, pal5bit(newword >> 10), pal5bit(newword >> 5), pal5bit(newword >> 0));
 }
 
@@ -272,100 +266,98 @@ void midyunit_state::midyunit_paletteram_w(offs_t offset, uint16_t data, uint16_
 
 void midyunit_state::dma_draw(uint16_t command)
 {
-	int dx = (command & 0x10) ? -1 : 1;
-	int height = m_dma_state.height;
-	int width = m_dma_state.width;
-	uint8_t *base = m_gfx_rom;
+	int const dx = (command & 0x10) ? -1 : 1;
+	int const height = m_dma_state.height;
+	int const width = m_dma_state.width;
+	uint8_t const *const base = m_gfx_rom;
 	uint32_t offset = m_dma_state.offset >> 3;
-	uint16_t pal = m_dma_state.palette;
-	uint16_t color = pal | m_dma_state.color;
-	int x, y;
+	uint16_t const pal = m_dma_state.palette;
+	uint16_t const color = pal | m_dma_state.color;
 
-	/* we only need the low 4 bits of the command */
+	// we only need the low 4 bits of the command
 	command &= 0x0f;
 
-	/* loop over the height */
-	for (y = 0; y < height; y++)
+	// loop over the height
+	for (int y = 0; y < height; y++)
 	{
 		int tx = m_dma_state.xpos;
 		int ty = m_dma_state.ypos;
 		uint32_t o = offset;
-		uint16_t *dest;
 
-		/* determine Y position */
+		// determine Y position
 		ty = (ty + y) & 0x1ff;
 		offset += m_dma_state.rowbytes;
 
-		/* determine destination pointer */
-		dest = &m_local_videoram[ty * 512];
+		// determine destination pointer
+		uint16_t *dest = &m_local_videoram[ty * 512];
 
-		/* check for overruns if they are relevant */
+		// check for overruns if they are relevant
 		if (o >= 0x06000000 && command < 0x0c)
 			continue;
 
-		/* switch off the zero/non-zero options */
+		// switch off the zero/non-zero options
 		switch (command)
 		{
-			case 0x00:  /* draw nothing */
+			case 0x00:  // draw nothing
 				break;
 
-			case 0x01:  /* draw only 0 pixels */
-				for (x = 0; x < width; x++, tx += dx)
+			case 0x01:  // draw only 0 pixels
+				for (int x = 0; x < width; x++, tx += dx)
 					if (base[o++] == 0)
 						dest[tx] = pal;
 				break;
 
-			case 0x02:  /* draw only non-0 pixels */
-				for (x = 0; x < width; x++, tx += dx)
+			case 0x02:  // draw only non-0 pixels
+				for (int x = 0; x < width; x++, tx += dx)
 				{
-					int pixel = base[o++];
+					uint8_t const pixel = base[o++];
 					if (pixel != 0)
 						dest[tx] = pal | pixel;
 				}
 				break;
 
-			case 0x03:  /* draw all pixels */
-				for (x = 0; x < width; x++, tx += dx)
+			case 0x03:  // draw all pixels
+				for (int x = 0; x < width; x++, tx += dx)
 					dest[tx] = pal | base[o++];
 				break;
 
-			case 0x04:  /* color only 0 pixels */
-			case 0x05:  /* color only 0 pixels */
-				for (x = 0; x < width; x++, tx += dx)
+			case 0x04:  // color only 0 pixels
+			case 0x05:  // color only 0 pixels
+				for (int x = 0; x < width; x++, tx += dx)
 					if (base[o++] == 0)
 						dest[tx] = color;
 				break;
 
-			case 0x06:  /* color only 0 pixels, copy the rest */
-			case 0x07:  /* color only 0 pixels, copy the rest */
-				for (x = 0; x < width; x++, tx += dx)
+			case 0x06:  // color only 0 pixels, copy the rest
+			case 0x07:  // color only 0 pixels, copy the rest
+				for (int x = 0; x < width; x++, tx += dx)
 				{
-					int pixel = base[o++];
+					uint8_t const pixel = base[o++];
 					dest[tx] = (pixel == 0) ? color : (pal | pixel);
 				}
 				break;
 
-			case 0x08:  /* color only non-0 pixels */
-			case 0x0a:  /* color only non-0 pixels */
-				for (x = 0; x < width; x++, tx += dx)
+			case 0x08:  // color only non-0 pixels
+			case 0x0a:  // color only non-0 pixels
+				for (int x = 0; x < width; x++, tx += dx)
 					if (base[o++] != 0)
 						dest[tx] = color;
 				break;
 
-			case 0x09:  /* color only non-0 pixels, copy the rest */
-			case 0x0b:  /* color only non-0 pixels, copy the rest */
-				for (x = 0; x < width; x++, tx += dx)
+			case 0x09:  // color only non-0 pixels, copy the rest
+			case 0x0b:  // color only non-0 pixels, copy the rest
+				for (int x = 0; x < width; x++, tx += dx)
 				{
-					int pixel = base[o++];
+					uint8_t const pixel = base[o++];
 					dest[tx] = (pixel != 0) ? color : (pal | pixel);
 				}
 				break;
 
-			case 0x0c:  /* color all pixels */
-			case 0x0d:  /* color all pixels */
-			case 0x0e:  /* color all pixels */
-			case 0x0f:  /* color all pixels */
-				for (x = 0; x < width; x++, tx += dx)
+			case 0x0c:  // color all pixels
+			case 0x0d:  // color all pixels
+			case 0x0e:  // color all pixels
+			case 0x0f:  // color all pixels
+				for (int x = 0; x < width; x++, tx += dx)
 					dest[tx] = color;
 				break;
 		}
@@ -382,7 +374,7 @@ void midyunit_state::dma_draw(uint16_t command)
 
 TIMER_CALLBACK_MEMBER(midyunit_state::dma_callback)
 {
-	m_dma_register[DMA_COMMAND] &= ~0x8000; /* tell the cpu we're done */
+	m_dma_register[DMA_COMMAND] &= ~0x8000; // tell the cpu we're done
 	m_maincpu->set_input_line(0, ASSERT_LINE);
 }
 
@@ -434,14 +426,14 @@ uint16_t midyunit_state::midyunit_dma_r(offs_t offset)
 
 void midyunit_state::midyunit_dma_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	/* blend with the current register contents */
+	// blend with the current register contents
 	COMBINE_DATA(&m_dma_register[offset]);
 
-	/* only writes to DMA_COMMAND actually cause actions */
+	// only writes to DMA_COMMAND actually cause actions
 	if (offset != DMA_COMMAND)
 		return;
 
-	/* high bit triggers action */
+	// high bit triggers action
 	int const command = m_dma_register[DMA_COMMAND];
 	m_maincpu->set_input_line(0, CLEAR_LINE);
 	if (!(command & 0x8000))
@@ -465,7 +457,7 @@ void midyunit_state::midyunit_dma_w(offs_t offset, uint16_t data, uint16_t mem_m
 
 	auto profile = g_profiler.start(PROFILER_USER1);
 
-	/* fill in the basic data */
+	// fill in the basic data
 	m_dma_state.rowbytes = (int16_t)m_dma_register[DMA_ROWBYTES];
 	m_dma_state.xpos = (int16_t)m_dma_register[DMA_XSTART];
 	m_dma_state.ypos = (int16_t)m_dma_register[DMA_YSTART];
@@ -474,7 +466,7 @@ void midyunit_state::midyunit_dma_w(offs_t offset, uint16_t data, uint16_t mem_m
 	m_dma_state.palette = m_dma_register[DMA_PALETTE] << 8;
 	m_dma_state.color = m_dma_register[DMA_COLOR] & 0xff;
 
-	/* determine the offset and adjust the rowbytes */
+	// determine the offset and adjust the rowbytes
 	uint32_t gfxoffset = m_dma_register[DMA_OFFSETLO] | (m_dma_register[DMA_OFFSETHI] << 16);
 	if (command & 0x10)
 	{
@@ -490,7 +482,7 @@ void midyunit_state::midyunit_dma_w(offs_t offset, uint16_t data, uint16_t mem_m
 	else
 		m_dma_state.rowbytes = (m_dma_state.rowbytes + m_dma_state.width + 3) & ~3;
 
-	/* apply Y clipping */
+	// apply Y clipping
 	if (m_dma_state.ypos < 0)
 	{
 		m_dma_state.height -= -m_dma_state.ypos;
@@ -500,7 +492,7 @@ void midyunit_state::midyunit_dma_w(offs_t offset, uint16_t data, uint16_t mem_m
 	if (m_dma_state.ypos + m_dma_state.height > 512)
 		m_dma_state.height = 512 - m_dma_state.ypos;
 
-	/* apply X clipping */
+	// apply X clipping
 	if (!(command & 0x10))
 	{
 		if (m_dma_state.xpos < 0)
@@ -524,7 +516,7 @@ void midyunit_state::midyunit_dma_w(offs_t offset, uint16_t data, uint16_t mem_m
 			m_dma_state.width = m_dma_state.xpos;
 	}
 
-	/* determine the location and draw */
+	// determine the location and draw
 	if (gfxoffset < 0x02000000)
 		gfxoffset += 0x02000000;
 	{
@@ -532,7 +524,7 @@ void midyunit_state::midyunit_dma_w(offs_t offset, uint16_t data, uint16_t mem_m
 		dma_draw(command);
 	}
 
-	/* signal we're done */
+	// signal we're done
 	m_dma_timer->adjust(attotime::from_nsec(41 * m_dma_state.width * m_dma_state.height));
 }
 
@@ -559,15 +551,15 @@ TMS340X0_SCANLINE_IND16_CB_MEMBER(midyunit_state::scanline_update)
 	uint16_t *const dest = &bitmap.pix(scanline);
 	int coladdr = params->coladdr << 1;
 
-	/* adjust the display address to account for ignored bits */
+	// adjust the display address to account for ignored bits
 	for (int x = params->heblnk; x < params->hsblnk; x++)
 		dest[x] = m_pen_map[src[coladdr++ & 0x1ff]];
 
-	/* handle autoerase on the previous line */
+	// handle autoerase on the previous line
 	autoerase_line(params->rowaddr - 1);
 
-	/* if this is the last update of the screen, set a timer to clear out the final line */
-	/* (since we update one behind) */
+	// if this is the last update of the screen, set a timer to clear out the final line
+	// (since we update one behind)
 	if (scanline == screen.visible_area().max_y)
 		m_autoerase_line_timer->adjust(screen.time_until_pos(scanline + 1), params->rowaddr);
 }


### PR DESCRIPTION
Split class per devices to reduce optional finders
Fix naming of ROM region, paletteram finder
Fix filename, Reduce defines
Use C++ style comments for single line comments
Use logmacro for logging protection related stuffs
Constantize variables, Use correct typename values
suppress side_effects_disabled() for debugger reading protection result
use soundlatch->data_pending_callback() for mkyawdim2 sound irq
Move driver init to machine_config for mkyawdim2 sound related stuffs