### PR TITLE
machine/spi_sdcard.cpp: fix write data leaking into cmd buffer

### DIFF
--- a/src/devices/machine/spi_sdcard.cpp
+++ b/src/devices/machine/spi_sdcard.cpp
@@ -136,30 +136,18 @@ void spi_sdcard_device::latch_in()
 	if (m_cur_bit == 8)
 	{
 		LOGMASKED(LOG_SPI, "SDCARD: got %02x\n", m_in_latch);
-		for (u8 i = 0; i < 5; i++)
+		if (m_state == SD_STATE_WRITE_WAITFE)
 		{
-			m_cmd[i] = m_cmd[i + 1];
-		}
-		m_cmd[5] = m_in_latch;
-
-		switch (m_state)
-		{
-		case SD_STATE_IDLE:
-			do_command();
-			break;
-
-		case SD_STATE_WRITE_WAITFE:
 			if (m_in_latch == 0xfe)
 			{
 				m_state = SD_STATE_WRITE_DATA;
 				m_out_latch = 0xff;
 				m_write_ptr = 0;
 			}
-			break;
-
-		case SD_STATE_WRITE_DATA:
+		}
+		else if (m_state == SD_STATE_WRITE_DATA)
+		{
 			m_data[m_write_ptr++] = m_in_latch;
-			m_cmd[5] = 0xff; // avoid writing to cmd buffer
 			if (m_write_ptr == (m_blksize + 2))
 			{
 				LOG("writing LBA %x, data %02x %02x %02x %02x\n", m_blknext, m_data[0], m_data[1], m_data[2], m_data[3]);
@@ -175,26 +163,28 @@ void spi_sdcard_device::latch_in()
 
 				send_data(2, SD_STATE_IDLE);
 			}
-			break;
+		}
+		else // receive CMD
+		{
+			std::memmove(m_cmd, m_cmd + 1, 5);
+			m_cmd[5] = m_in_latch;
 
-		case SD_STATE_DATA_MULTI:
-			do_command();
-			if (m_state == SD_STATE_DATA_MULTI && m_out_count == 0)
+			if (m_state == SD_STATE_DATA_MULTI)
 			{
-				m_data[0] = 0xfe; // data token
-				m_image->read(m_blknext++, &m_data[1]);
-				util::crc16_t crc16 = util::crc16_creator::simple(&m_data[1], m_blksize);
-				put_u16be(&m_data[m_blksize + 1], crc16);
-				send_data(1 + m_blksize + 2, SD_STATE_DATA_MULTI);
+				do_command();
+				if (m_state == SD_STATE_DATA_MULTI && m_out_count == 0)
+				{
+					m_data[0] = 0xfe; // data token
+					m_image->read(m_blknext++, &m_data[1]);
+					util::crc16_t crc16 = util::crc16_creator::simple(&m_data[1], m_blksize);
+					put_u16be(&m_data[m_blksize + 1], crc16);
+					send_data(1 + m_blksize + 2, SD_STATE_DATA_MULTI);
+				}
 			}
-			break;
-
-		default:
-			if (((m_cmd[0] & 0x70) == 0x40) || (m_out_count == 0)) // CMD0 - GO_IDLE_STATE
+			else if ((m_state == SD_STATE_IDLE) || (((m_cmd[0] & 0x70) == 0x40) || (m_out_count == 0))) // CMD0 - GO_IDLE_STATE
 			{
 				do_command();
 			}
-			break;
 		}
 	}
 }
@@ -452,22 +442,10 @@ void spi_sdcard_device::do_command()
 		}
 
 		// if this is command 55, that's a prefix indicating the next command is an "app command" or "ACMD"
-		if ((m_cmd[0] & 0x3f) == 55)
-		{
-			m_bACMD = true;
-		}
-		else
-		{
-			m_bACMD = false;
-		}
+		m_bACMD = (m_cmd[0] & 0x3f) == 55;
 
 		if (clean_cmd)
-		{
-			for (u8 i = 0; i < 6; i++)
-			{
-				m_cmd[i] = 0xff;
-			}
-		}
+			memset(m_cmd, 0xff, 6);
 	}
 }
 

--- a/src/devices/machine/spi_sdcard.cpp
+++ b/src/devices/machine/spi_sdcard.cpp
@@ -159,6 +159,7 @@ void spi_sdcard_device::latch_in()
 
 		case SD_STATE_WRITE_DATA:
 			m_data[m_write_ptr++] = m_in_latch;
+			m_cmd[5] = 0xff; // avoid writing to cmd buffer
 			if (m_write_ptr == (m_blksize + 2))
 			{
 				LOG("writing LBA %x, data %02x %02x %02x %02x\n", m_blknext, m_data[0], m_data[1], m_data[2], m_data[3]);
@@ -445,7 +446,7 @@ void spi_sdcard_device::do_command()
 			break;
 
 		default:
-			LOGMASKED(LOG_COMMAND, "SDCARD: Unsupported %02x\n", m_cmd[0] & 0x3f);
+			LOGMASKED(LOG_COMMAND, "SDCARD: Unsupported CMD%02d\n", m_cmd[0] & 0x3f);
 			clean_cmd = false;
 			break;
 		}


### PR DESCRIPTION
somehow related to MT08855 - but it's unclear how "wrong" spi commands can kill entire emu memory.