### PR TITLE
midway/midwayic.cpp: Reduce hardcoded tags, Cleanups:

### DIFF
--- a/src/mame/midway/atlantis.cpp
+++ b/src/mame/midway/atlantis.cpp
@@ -851,6 +851,11 @@ void atlantis_state::mwskins(machine_config &config)
 	m_dcs->add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->set_upper(342); // 325

--- a/src/mame/midway/atlantis.cpp
+++ b/src/mame/midway/atlantis.cpp
@@ -856,7 +856,7 @@ void atlantis_state::mwskins(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_STANDARD);
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->set_upper(342); // 325
 	m_ioasic->irq_handler().set(FUNC(atlantis_state::ioasic_irq));

--- a/src/mame/midway/midvunit.cpp
+++ b/src/mame/midway/midvunit.cpp
@@ -1147,6 +1147,11 @@ void midvunit_state::midvplus(machine_config &config)
 	ATA_INTERFACE(config, m_ata).options(ata_devices, "hdd", nullptr, true);
 
 	MIDWAY_IOASIC(config, m_midway_ioasic, 0);
+	m_midway_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_midway_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_midway_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_midway_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_midway_ioasic->set_dcs_tag(m_dcs);
 	m_midway_ioasic->set_shuffle(0);
 	m_midway_ioasic->set_upper(452); /* no alternates */
 	m_midway_ioasic->set_yearoffs(94);

--- a/src/mame/midway/midwayic.h
+++ b/src/mame/midway/midwayic.h
@@ -161,6 +161,9 @@ public:
 	// construction/destruction
 	midway_ioasic_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
+	template<unsigned Port> auto in_port_cb() { return m_input_cb[Port].bind(); }
+	template <typename T> void set_cage_tag(T &&tag) { m_cage.set_tag(std::forward<T>(tag)); }
+	template <typename T> void set_dcs_tag(T &&tag) { m_dcs.set_tag(std::forward<T>(tag)); }
 	void set_shuffle(uint8_t shuffle) { m_shuffle_type = shuffle; }
 	void set_shuffle_default(uint8_t shuffle) { m_shuffle_default = shuffle; }
 	void set_auto_ack(uint8_t auto_ack) { m_auto_ack = auto_ack; }
@@ -199,10 +202,12 @@ private:
 	void update_ioasic_irq();
 	uint16_t get_fifo_status();
 
-	required_ioport m_io_dips;
-	required_ioport m_io_system;
-	required_ioport m_io_in1;
-	required_ioport m_io_in2;
+	optional_device<atari_cage_device> m_cage;
+	optional_device<dcs_audio_device> m_dcs;
+
+	devcb_write8 m_irq_callback;
+
+	devcb_read32::array<4> m_input_cb;
 
 	devcb_write8    m_serial_tx_cb;
 	devcb_write32   m_aux_output_cb;
@@ -215,7 +220,6 @@ private:
 	uint8_t   m_shuffle_default = 0;
 	uint8_t   m_shuffle_active = 0;
 	const uint8_t *   m_shuffle_map = nullptr;
-	devcb_write8 m_irq_callback;
 	uint8_t   m_irq_state = 0;
 	uint16_t  m_sound_irq_state = 0;
 	uint8_t   m_auto_ack = 0;
@@ -227,8 +231,6 @@ private:
 	uint16_t  m_fifo_bytes = 0;
 	offs_t  m_fifo_force_buffer_empty_pc = 0;
 
-	optional_device<atari_cage_device> m_cage;
-	optional_device<dcs_audio_device> m_dcs;
 };
 
 

--- a/src/mame/midway/midwayic.h
+++ b/src/mame/midway/midwayic.h
@@ -5,11 +5,10 @@
     Emulation of various Midway ICs
 
 ***************************************************************************/
-#ifndef MAME_MIDWAY_MIDWAY_IC_H
-#define MAME_MIDWAY_MIDWAY_IC_H
+#ifndef MAME_MIDWAY_MIDWAYIC_H
+#define MAME_MIDWAY_MIDWAYIC_H
 
 #pragma once
-
 
 #include "cage.h"
 #include "dcs.h"
@@ -17,7 +16,7 @@
 #include "cpu/pic16c5x/pic16c5x.h"
 
 
-/* 1st generation Midway serial PIC - simulation*/
+// 1st generation Midway serial PIC - simulation
 
 class midway_serial_pic_device : public device_t
 {
@@ -35,7 +34,7 @@ public:
 protected:
 	midway_serial_pic_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
-	// device-level overrides
+	// device_t implementation
 	virtual void device_start() override;
 	virtual void device_reset() override;
 	virtual ioport_constructor device_input_ports() const override;
@@ -45,21 +44,18 @@ protected:
 
 	required_ioport m_io_serial_digit;
 
-	uint8_t m_data[16]{}; // reused by other devices
-	int     m_upper = 0;
+	uint8_t m_data[16]; // reused by other devices
+	int     m_upper;
 
 private:
-	uint8_t m_buff = 0;
-	uint8_t m_idx = 0;
-	uint8_t m_status = 0;
-	uint8_t m_bits = 0;
+	uint8_t m_buff;
+	uint8_t m_idx;
+	uint8_t m_status;
+	uint8_t m_bits;
 };
 
 
-// device type definition
-DECLARE_DEVICE_TYPE(MIDWAY_SERIAL_PIC, midway_serial_pic_device)
-
-/* 1st generation Midway serial PIC - emulation */
+// 1st generation Midway serial PIC - emulation
 
 class midway_serial_pic_emu_device : public device_t
 {
@@ -75,7 +71,7 @@ public:
 protected:
 	midway_serial_pic_emu_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
-	// device-level overrides
+	// device_t implementation
 	virtual void device_add_mconfig(machine_config &config) override;
 	virtual void device_start() override;
 
@@ -85,19 +81,15 @@ private:
 	u8 read_c();
 	void write_c(u8 data);
 
-	u8 m_command = 0;
-	u8 m_data_out = 0;
-	u8 m_clk = 0;
-	u8 m_status = 0;
+	u8 m_command;
+	u8 m_data_out;
+	u8 m_clk;
+	u8 m_status;
 };
 
 
-// device type definition
-DECLARE_DEVICE_TYPE(MIDWAY_SERIAL_PIC_EMU, midway_serial_pic_emu_device)
 
-
-
-/* 2nd generation Midway serial/NVRAM/RTC PIC */
+// 2nd generation Midway serial/NVRAM/RTC PIC
 
 // ======================> midway_serial_pic2_device
 
@@ -118,10 +110,10 @@ public:
 protected:
 	midway_serial_pic2_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
-	// device-level overrides
+	// device_t implementation
 	virtual void device_start() override;
 
-	// device_nvram_interface overrides
+	// device_nvram_interface implementation
 	virtual void nvram_default() override;
 	virtual bool nvram_read(util::read_stream &file) override;
 	virtual bool nvram_write(util::write_stream &file) override;
@@ -131,33 +123,43 @@ private:
 	void pic_register_state();
 	TIMER_CALLBACK_MEMBER(reset_timer);
 
-	uint16_t  m_latch = 0;
+	uint16_t  m_latch;
 	attotime  m_latch_expire_time;
-	uint8_t   m_state = 0;
-	uint8_t   m_index = 0;
-	uint8_t   m_total = 0;
-	uint8_t   m_nvram_addr = 0;
-	uint8_t   m_buffer[0x10]{};
-	uint8_t   m_nvram[0x100]{};
-	uint8_t   m_default_nvram[0x100]{};
-	uint8_t   m_time_buf[8]{};
-	uint8_t   m_time_index = 0;
-	uint8_t   m_time_just_written = 0;
-	uint16_t  m_yearoffs = 0;
-	emu_timer *m_time_write_timer = nullptr;
+	uint8_t   m_state;
+	uint8_t   m_index;
+	uint8_t   m_total;
+	uint8_t   m_nvram_addr;
+	uint8_t   m_buffer[0x10];
+	uint8_t   m_nvram[0x100];
+	uint8_t   m_default_nvram[0x100];
+	uint8_t   m_time_buf[8];
+	uint8_t   m_time_index;
+	uint8_t   m_time_just_written;
+	uint16_t  m_yearoffs;
+	emu_timer *m_time_write_timer;
 };
 
 
-// device type definition
-DECLARE_DEVICE_TYPE(MIDWAY_SERIAL_PIC2, midway_serial_pic2_device)
-
-/* I/O ASIC connected to 2nd generation PIC */
+// I/O ASIC connected to 2nd generation PIC
 
 // ======================> midway_ioasic_device
 
 class midway_ioasic_device : public midway_serial_pic2_device
 {
 public:
+	enum
+	{
+		SHUFFLE_STANDARD = 0,
+		SHUFFLE_BLITZ99,
+		SHUFFLE_CARNEVIL,
+		SHUFFLE_CALSPEED,
+		SHUFFLE_MACE,
+		SHUFFLE_GAUNTDL,
+		SHUFFLE_VAPORTRX,
+		SHUFFLE_SFRUSHRK,
+		SHUFFLE_HYPRDRIV
+	};
+
 	// construction/destruction
 	midway_ioasic_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
@@ -194,7 +196,7 @@ public:
 	void ioasic_reset();
 
 protected:
-	// device-level overrides
+	// device_t implementation
 	virtual void device_start() override;
 
 private:
@@ -212,42 +214,29 @@ private:
 	devcb_write8    m_serial_tx_cb;
 	devcb_write32   m_aux_output_cb;
 
-	uint32_t  m_reg[16]{};
-	uint8_t   m_has_dcs = 0;
-	uint8_t   m_has_cage = 0;
-	cpu_device *m_dcs_cpu = nullptr;
-	uint8_t   m_shuffle_type = 0;
-	uint8_t   m_shuffle_default = 0;
-	uint8_t   m_shuffle_active = 0;
-	const uint8_t *   m_shuffle_map = nullptr;
-	uint8_t   m_irq_state = 0;
-	uint16_t  m_sound_irq_state = 0;
-	uint8_t   m_auto_ack = 0;
-	uint8_t   m_force_fifo_full = 0;
+	uint32_t  m_reg[16];
+	cpu_device *m_dcs_cpu;
+	uint8_t   m_shuffle_type;
+	uint8_t   m_shuffle_default;
+	uint8_t   m_shuffle_active;
+	const uint8_t *   m_shuffle_map;
+	uint8_t   m_irq_state;
+	uint16_t  m_sound_irq_state;
+	uint8_t   m_auto_ack;
+	uint8_t   m_force_fifo_full;
 
-	uint16_t  m_fifo[512]{};
-	uint16_t  m_fifo_in = 0;
-	uint16_t  m_fifo_out = 0;
-	uint16_t  m_fifo_bytes = 0;
-	offs_t  m_fifo_force_buffer_empty_pc = 0;
-
+	uint16_t  m_fifo[512];
+	uint16_t  m_fifo_in;
+	uint16_t  m_fifo_out;
+	uint16_t  m_fifo_bytes;
+	offs_t  m_fifo_force_buffer_empty_pc;
 };
 
 
-// device type definition
+// device type declarations
+DECLARE_DEVICE_TYPE(MIDWAY_SERIAL_PIC, midway_serial_pic_device)
+DECLARE_DEVICE_TYPE(MIDWAY_SERIAL_PIC_EMU, midway_serial_pic_emu_device)
+DECLARE_DEVICE_TYPE(MIDWAY_SERIAL_PIC2, midway_serial_pic2_device)
 DECLARE_DEVICE_TYPE(MIDWAY_IOASIC, midway_ioasic_device)
 
-enum
-{
-	MIDWAY_IOASIC_STANDARD = 0,
-	MIDWAY_IOASIC_BLITZ99,
-	MIDWAY_IOASIC_CARNEVIL,
-	MIDWAY_IOASIC_CALSPEED,
-	MIDWAY_IOASIC_MACE,
-	MIDWAY_IOASIC_GAUNTDL,
-	MIDWAY_IOASIC_VAPORTRX,
-	MIDWAY_IOASIC_SFRUSHRK,
-	MIDWAY_IOASIC_HYPRDRIV
-};
-
-#endif // MAME_MIDWAY_MIDWAY_IC_H
+#endif // MAME_MIDWAY_MIDWAYIC_H

--- a/src/mame/midway/midzeus.cpp
+++ b/src/mame/midway/midzeus.cpp
@@ -1295,7 +1295,7 @@ void midzeus_state::midzeus(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag("dcs");
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_STANDARD);
 	m_ioasic->set_yearoffs(94);
 }
 
@@ -1348,7 +1348,7 @@ void midzeus2_state::midzeus2(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag("dcs");
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_STANDARD);
 	m_ioasic->set_yearoffs(99);
 	m_ioasic->set_upper(474);
 

--- a/src/mame/midway/midzeus.cpp
+++ b/src/mame/midway/midzeus.cpp
@@ -1290,6 +1290,11 @@ void midzeus_state::midzeus(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag("dcs");
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
 	m_ioasic->set_yearoffs(94);
 }
@@ -1338,6 +1343,11 @@ void midzeus2_state::midzeus2(machine_config &config)
 
 	/* I/O hardware */
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag("dcs");
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
 	m_ioasic->set_yearoffs(99);
 	m_ioasic->set_upper(474);

--- a/src/mame/midway/seattle.cpp
+++ b/src/mame/midway/seattle.cpp
@@ -2141,7 +2141,7 @@ void seattle_state::wg3dh(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_STANDARD);
 	m_ioasic->set_upper(310); // no alternates
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(seattle_state::ioasic_irq));
@@ -2167,7 +2167,7 @@ void seattle_state::mace(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_MACE);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_MACE);
 	m_ioasic->set_upper(319); // or 314
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(seattle_state::ioasic_irq));
@@ -2198,7 +2198,7 @@ void seattle_state::sfrush(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_cage_tag(m_cage);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_STANDARD);
 	m_ioasic->set_upper(315); // no alternates
 	m_ioasic->set_yearoffs(100);
 	m_ioasic->irq_handler().set(FUNC(seattle_state::ioasic_irq));
@@ -2230,7 +2230,7 @@ void seattle_state::sfrushrk(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_cage_tag(m_cage);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_SFRUSHRK);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_SFRUSHRK);
 	m_ioasic->set_upper(331); // no alternates
 	m_ioasic->set_yearoffs(100);
 	m_ioasic->irq_handler().set(FUNC(seattle_state::ioasic_irq));
@@ -2240,7 +2240,7 @@ void seattle_state::sfrushrk(machine_config &config)
 void seattle_state::sfrushrkw(machine_config &config)
 {
 	sfrushrk(config);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_STANDARD);
 }
 
 void seattle_state::calspeed(machine_config &config)
@@ -2263,7 +2263,7 @@ void seattle_state::calspeed(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_CALSPEED);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_CALSPEED);
 	m_ioasic->set_upper(328); // 328 = 27"; may or may not have a 31" ID
 	m_ioasic->set_yearoffs(100);
 	m_ioasic->irq_handler().set(FUNC(seattle_state::ioasic_irq));
@@ -2290,7 +2290,7 @@ void seattle_state::vaportrx(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_VAPORTRX);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_VAPORTRX);
 	m_ioasic->set_upper(324); // or 334
 	m_ioasic->set_yearoffs(100);
 	m_ioasic->irq_handler().set(FUNC(seattle_state::ioasic_irq));
@@ -2316,7 +2316,7 @@ void seattle_state::biofreak(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_STANDARD);
 	m_ioasic->set_upper(231); // no alternates
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(seattle_state::ioasic_irq));
@@ -2342,7 +2342,7 @@ void seattle_state::blitz(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_BLITZ99);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_BLITZ99);
 	m_ioasic->set_upper(444); // or 528
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(seattle_state::ioasic_irq));
@@ -2369,7 +2369,7 @@ void seattle_state::blitz99(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_BLITZ99);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_BLITZ99);
 	m_ioasic->set_upper(481); // or 484 or 520
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(seattle_state::ioasic_irq));
@@ -2396,7 +2396,7 @@ void seattle_state::blitz2k(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_BLITZ99);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_BLITZ99);
 	m_ioasic->set_upper(494); // or 498
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(seattle_state::ioasic_irq));
@@ -2424,7 +2424,7 @@ void seattle_state::carnevil(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_CARNEVIL);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_CARNEVIL);
 	m_ioasic->set_upper(469); // 469 = 25"; 486 = 39";
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(seattle_state::ioasic_irq));
@@ -2450,7 +2450,7 @@ void seattle_state::hyprdriv(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_HYPRDRIV);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_HYPRDRIV);
 	m_ioasic->set_upper(471); // 471 = 25"; 479 = 31"
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(seattle_state::ioasic_irq));

--- a/src/mame/midway/seattle.cpp
+++ b/src/mame/midway/seattle.cpp
@@ -2128,7 +2128,7 @@ void seattle_state::wg3dh(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, "dcs", 0));
+	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, m_dcs, 0));
 	dcs.set_maincpu_tag(m_maincpu);
 	dcs.set_dram_in_mb(2);
 	dcs.set_polling_offset(0x3839);
@@ -2136,6 +2136,11 @@ void seattle_state::wg3dh(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
 	m_ioasic->set_upper(310); // no alternates
 	m_ioasic->set_yearoffs(80);
@@ -2149,7 +2154,7 @@ void seattle_state::mace(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, "dcs", 0));
+	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, m_dcs, 0));
 	dcs.set_maincpu_tag(m_maincpu);
 	dcs.set_dram_in_mb(2);
 	dcs.set_polling_offset(0x3839);
@@ -2157,6 +2162,11 @@ void seattle_state::mace(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_MACE);
 	m_ioasic->set_upper(319); // or 314
 	m_ioasic->set_yearoffs(80);
@@ -2173,16 +2183,21 @@ void seattle_state::sfrush(machine_config &config)
 	SPEAKER(config, "rrspeaker").headrest_right();
 	//SPEAKER(config, "subwoofer").seat(); Not implemented, Quad Amp PCB output;
 
-	atari_cage_seattle_device &cage(ATARI_CAGE_SEATTLE(config, "cage", 0));
-	cage.set_speedup(0x5236);
-	cage.irq_handler().set(m_ioasic, FUNC(midway_ioasic_device::cage_irq_handler));
+	ATARI_CAGE_SEATTLE(config, m_cage, 0);
+	m_cage->set_speedup(0x5236);
+	m_cage->irq_handler().set(m_ioasic, FUNC(midway_ioasic_device::cage_irq_handler));
 	// TODO: copied from atarigt.cpp; Same configurations as T-Mek?
-	cage.add_route(0, "frspeaker", 1.0); // Foward Right
-	cage.add_route(1, "rlspeaker", 1.0); // Back Left
-	cage.add_route(2, "flspeaker", 1.0); // Foward Left
-	cage.add_route(3, "rrspeaker", 1.0); // Back Right
+	m_cage->add_route(0, "frspeaker", 1.0); // Foward Right
+	m_cage->add_route(1, "rlspeaker", 1.0); // Back Left
+	m_cage->add_route(2, "flspeaker", 1.0); // Foward Left
+	m_cage->add_route(3, "rrspeaker", 1.0); // Back Right
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_cage_tag(m_cage);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
 	m_ioasic->set_upper(315); // no alternates
 	m_ioasic->set_yearoffs(100);
@@ -2200,17 +2215,21 @@ void seattle_state::sfrushrk(machine_config &config)
 	SPEAKER(config, "rrspeaker").headrest_right();
 	//SPEAKER(config, "subwoofer").seat(); Not implemented, Quad Amp PCB output;
 
-	atari_cage_seattle_device &cage(ATARI_CAGE_SEATTLE(config, "cage", 0));
-	cage.set_speedup(0x5329);
-	cage.irq_handler().set(m_ioasic, FUNC(midway_ioasic_device::cage_irq_handler));
+	ATARI_CAGE_SEATTLE(config, m_cage, 0);
+	m_cage->set_speedup(0x5329);
+	m_cage->irq_handler().set(m_ioasic, FUNC(midway_ioasic_device::cage_irq_handler));
 	// TODO: copied from atarigt.cpp; Same configurations as T-Mek?
-	cage.add_route(0, "frspeaker", 1.0); // Foward Right
-	cage.add_route(1, "rlspeaker", 1.0); // Back Left
-	cage.add_route(2, "flspeaker", 1.0); // Foward Left
-	cage.add_route(3, "rrspeaker", 1.0); // Back Right
-
+	m_cage->add_route(0, "frspeaker", 1.0); // Foward Right
+	m_cage->add_route(1, "rlspeaker", 1.0); // Back Left
+	m_cage->add_route(2, "flspeaker", 1.0); // Foward Left
+	m_cage->add_route(3, "rrspeaker", 1.0); // Back Right
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_cage_tag(m_cage);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_SFRUSHRK);
 	m_ioasic->set_upper(331); // no alternates
 	m_ioasic->set_yearoffs(100);
@@ -2231,7 +2250,7 @@ void seattle_state::calspeed(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, "dcs", 0));
+	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, m_dcs, 0));
 	dcs.set_maincpu_tag(m_maincpu);
 	dcs.set_dram_in_mb(2);
 	dcs.set_polling_offset(0x39c0);
@@ -2239,6 +2258,11 @@ void seattle_state::calspeed(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_CALSPEED);
 	m_ioasic->set_upper(328); // 328 = 27"; may or may not have a 31" ID
 	m_ioasic->set_yearoffs(100);
@@ -2253,7 +2277,7 @@ void seattle_state::vaportrx(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, "dcs", 0));
+	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, m_dcs, 0));
 	dcs.set_maincpu_tag(m_maincpu);
 	dcs.set_dram_in_mb(2);
 	dcs.set_polling_offset(0x39c2);
@@ -2261,6 +2285,11 @@ void seattle_state::vaportrx(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_VAPORTRX);
 	m_ioasic->set_upper(324); // or 334
 	m_ioasic->set_yearoffs(100);
@@ -2274,7 +2303,7 @@ void seattle_state::biofreak(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, "dcs", 0));
+	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, m_dcs, 0));
 	dcs.set_maincpu_tag(m_maincpu);
 	dcs.set_dram_in_mb(2);
 	dcs.set_polling_offset(0x3835);
@@ -2282,6 +2311,11 @@ void seattle_state::biofreak(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
 	m_ioasic->set_upper(231); // no alternates
 	m_ioasic->set_yearoffs(80);
@@ -2295,7 +2329,7 @@ void seattle_state::blitz(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, "dcs", 0));
+	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, m_dcs, 0));
 	dcs.set_maincpu_tag(m_maincpu);
 	dcs.set_dram_in_mb(2);
 	dcs.set_polling_offset(0x39c2);
@@ -2303,6 +2337,11 @@ void seattle_state::blitz(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_BLITZ99);
 	m_ioasic->set_upper(444); // or 528
 	m_ioasic->set_yearoffs(80);
@@ -2317,7 +2356,7 @@ void seattle_state::blitz99(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, "dcs", 0));
+	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, m_dcs, 0));
 	dcs.set_maincpu_tag(m_maincpu);
 	dcs.set_dram_in_mb(2);
 	dcs.set_polling_offset(0x0afb);
@@ -2325,6 +2364,11 @@ void seattle_state::blitz99(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_BLITZ99);
 	m_ioasic->set_upper(481); // or 484 or 520
 	m_ioasic->set_yearoffs(80);
@@ -2339,7 +2383,7 @@ void seattle_state::blitz2k(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, "dcs", 0));
+	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, m_dcs, 0));
 	dcs.set_maincpu_tag(m_maincpu);
 	dcs.set_dram_in_mb(2);
 	dcs.set_polling_offset(0x0b5d);
@@ -2347,6 +2391,11 @@ void seattle_state::blitz2k(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_BLITZ99);
 	m_ioasic->set_upper(494); // or 498
 	m_ioasic->set_yearoffs(80);
@@ -2362,7 +2411,7 @@ void seattle_state::carnevil(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, "dcs", 0));
+	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, m_dcs, 0));
 	dcs.set_maincpu_tag(m_maincpu);
 	dcs.set_dram_in_mb(2);
 	dcs.set_polling_offset(0x0af7);
@@ -2370,6 +2419,11 @@ void seattle_state::carnevil(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_CARNEVIL);
 	m_ioasic->set_upper(469); // 469 = 25"; 486 = 39";
 	m_ioasic->set_yearoffs(80);
@@ -2383,7 +2437,7 @@ void seattle_state::hyprdriv(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, "dcs", 0));
+	dcs2_audio_2115_device &dcs(DCS2_AUDIO_2115(config, m_dcs, 0));
 	dcs.set_maincpu_tag(m_maincpu);
 	dcs.set_dram_in_mb(2);
 	dcs.set_polling_offset(0x0af7);
@@ -2391,6 +2445,11 @@ void seattle_state::hyprdriv(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_HYPRDRIV);
 	m_ioasic->set_upper(471); // 471 = 25"; 479 = 31"
 	m_ioasic->set_yearoffs(80);

--- a/src/mame/midway/vegas.cpp
+++ b/src/mame/midway/vegas.cpp
@@ -2054,7 +2054,7 @@ void vegas_state::gauntleg(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_CALSPEED);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_CALSPEED);
 	m_ioasic->set_upper(340); // 340=39", 322=27" others?
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(vegas_state::ioasic_irq));
@@ -2082,7 +2082,7 @@ void vegas_state::gauntdl(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_GAUNTDL);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_GAUNTDL);
 	m_ioasic->set_upper(346); // others?
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(vegas_state::ioasic_irq));
@@ -2109,7 +2109,7 @@ void vegas_state::warfa(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_MACE);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_MACE);
 	m_ioasic->set_upper(337); // others?
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(vegas_state::ioasic_irq));
@@ -2136,7 +2136,7 @@ void vegas_state::tenthdeg(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_GAUNTDL);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_GAUNTDL);
 	m_ioasic->set_upper(330); // others?
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(vegas_state::ioasic_irq));
@@ -2163,7 +2163,7 @@ void vegas_state::roadburn(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_STANDARD);
 	m_ioasic->set_upper(325); // others?
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(vegas_state::ioasic_irq));
@@ -2190,7 +2190,7 @@ void vegas_state::nbashowt(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_MACE);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_MACE);
 	// 528 494 478 development pic, 487 NBA
 	m_ioasic->set_upper(487); // or 478 or 487
 	m_ioasic->set_yearoffs(80);
@@ -2219,7 +2219,7 @@ void vegas_state::nbanfl(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_BLITZ99);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_BLITZ99);
 	m_ioasic->set_upper(498); // or 478 or 487
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(vegas_state::ioasic_irq));
@@ -2252,7 +2252,7 @@ void vegas_state::nbagold(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_GAUNTDL);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_GAUNTDL);
 	m_ioasic->set_upper(109); // 494 109 ???
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(vegas_state::ioasic_irq));
@@ -2286,7 +2286,7 @@ void vegas_state::sf2049(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_STANDARD);
 	m_ioasic->set_upper(336); // others?
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(vegas_state::ioasic_irq));
@@ -2320,7 +2320,7 @@ void vegas_state::sf2049se(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_SFRUSHRK);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_SFRUSHRK);
 	m_ioasic->set_upper(352); // 352 336 others?
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(vegas_state::ioasic_irq));
@@ -2354,7 +2354,7 @@ void vegas_state::sf2049te(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_SFRUSHRK);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_SFRUSHRK);
 	m_ioasic->set_upper(348); // others?
 	m_ioasic->set_yearoffs(80);
 	m_ioasic->irq_handler().set(FUNC(vegas_state::ioasic_irq));
@@ -2381,7 +2381,7 @@ void vegas_state::cartfury(machine_config &config)
 	m_ioasic->in_port_cb<2>().set_ioport("IN1");
 	m_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_ioasic->set_dcs_tag(m_dcs);
-	m_ioasic->set_shuffle(MIDWAY_IOASIC_CARNEVIL);
+	m_ioasic->set_shuffle(midway_ioasic_device::SHUFFLE_CARNEVIL);
 	// 433, 495, 490 Development PIC
 	m_ioasic->set_upper(495/*433,  495 others? */);
 	m_ioasic->set_yearoffs(80);

--- a/src/mame/midway/vegas.cpp
+++ b/src/mame/midway/vegas.cpp
@@ -2049,6 +2049,11 @@ void vegas_state::gauntleg(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_CALSPEED);
 	m_ioasic->set_upper(340); // 340=39", 322=27" others?
 	m_ioasic->set_yearoffs(80);
@@ -2072,6 +2077,11 @@ void vegas_state::gauntdl(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_GAUNTDL);
 	m_ioasic->set_upper(346); // others?
 	m_ioasic->set_yearoffs(80);
@@ -2094,6 +2104,11 @@ void vegas_state::warfa(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_MACE);
 	m_ioasic->set_upper(337); // others?
 	m_ioasic->set_yearoffs(80);
@@ -2116,6 +2131,11 @@ void vegas_state::tenthdeg(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_GAUNTDL);
 	m_ioasic->set_upper(330); // others?
 	m_ioasic->set_yearoffs(80);
@@ -2138,6 +2158,11 @@ void vegas_state::roadburn(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
 	m_ioasic->set_upper(325); // others?
 	m_ioasic->set_yearoffs(80);
@@ -2160,6 +2185,11 @@ void vegas_state::nbashowt(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_MACE);
 	// 528 494 478 development pic, 487 NBA
 	m_ioasic->set_upper(487); // or 478 or 487
@@ -2184,6 +2214,11 @@ void vegas_state::nbanfl(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_BLITZ99);
 	m_ioasic->set_upper(498); // or 478 or 487
 	m_ioasic->set_yearoffs(80);
@@ -2212,6 +2247,11 @@ void vegas_state::nbagold(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_GAUNTDL);
 	m_ioasic->set_upper(109); // 494 109 ???
 	m_ioasic->set_yearoffs(80);
@@ -2241,6 +2281,11 @@ void vegas_state::sf2049(machine_config &config)
 	dcs.add_route(4, "subwoofer", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
 	m_ioasic->set_upper(336); // others?
 	m_ioasic->set_yearoffs(80);
@@ -2270,6 +2315,11 @@ void vegas_state::sf2049se(machine_config &config)
 	dcs.add_route(4, "subwoofer", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_SFRUSHRK);
 	m_ioasic->set_upper(352); // 352 336 others?
 	m_ioasic->set_yearoffs(80);
@@ -2299,6 +2349,11 @@ void vegas_state::sf2049te(machine_config &config)
 	dcs.add_route(4, "subwoofer", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_SFRUSHRK);
 	m_ioasic->set_upper(348); // others?
 	m_ioasic->set_yearoffs(80);
@@ -2321,6 +2376,11 @@ void vegas_state::cartfury(machine_config &config)
 	dcs.add_route(1, "lspeaker", 1.0);
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
+	m_ioasic->in_port_cb<0>().set_ioport("DIPS");
+	m_ioasic->in_port_cb<1>().set_ioport("SYSTEM");
+	m_ioasic->in_port_cb<2>().set_ioport("IN1");
+	m_ioasic->in_port_cb<3>().set_ioport("IN2");
+	m_ioasic->set_dcs_tag(m_dcs);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_CARNEVIL);
 	// 433, 495, 490 Development PIC
 	m_ioasic->set_upper(495/*433,  495 others? */);


### PR DESCRIPTION
Suppress side effects for debugger reads
Use C++ style line comments for single line comments
Reduced use of literal tag