### PR TITLE
nmk/nmk16.cpp: Correct origin of "Many Block"

### DIFF
--- a/src/mame/nmk/nmk16.cpp
+++ b/src/mame/nmk/nmk16.cpp
@@ -4,7 +4,7 @@
 /********************************************************************
 
 Task Force Harrier         1989 UPL        68000 Z80           YM2203 2xOKIM6295
-Many Block                 1991 Bee-Oh     68000 Z80           YM2203 2xOKIM6295 (hack of "Jewels" by UPL)
+Many Block                 1991 Bee-Oh     68000 Z80           YM2203 2xOKIM6295 (hack of "Slot Gal" by UPL)
 Mustang                    1990 UPL        68000 NMK004        YM2203 2xOKIM6295
 Bio-ship Paladin           1990 UPL        68000 NMK004        YM2203 2xOKIM6295
 Vandyke                    1990 UPL        68000 NMK004        YM2203 2xOKIM6295
@@ -152,7 +152,7 @@ Questions / Notes
 
 'manybloc' :
 
-  - This is a bootleg / hack of Jewels by UPL
+  - This is a bootleg / hack of Slot Gal by UPL
   - The MCU code was patched to use standard IO, it may be running code that is no longer used.
   - There are writes to 0x080010.w and 0x080012.w (MCU ?) in code between
     0x005000 to 0x005690, but I see no call to "main" routine at 0x005504 !


### PR DESCRIPTION
According to the former developer's [submission to X](https://twitter.com/shulgee/status/1779508684022026585), "Jewels" was followed by "Slot Gal," which was based on it. 
> "Jewels" was followed by "Slot Gal," which was based on it. The panel patterns that had been jewels in "Jewels" were changed to a slot machine, and pictures of gals were added as a sexy element. I have heard that this change has increased location test income from 300 yen to 500 yen (a whopping 66% increase).


"Many Block" uses tiles with a slot machine pattern and has a title image of "SLOT GAL" inside (though the gal does not appear). Therefore, "Many Block" should be called a "Slot Gal" hack rather than a "Jewels" hack.
![SLOT GAL](https://github.com/mamedev/mame/assets/97546439/76e8b307-f4b6-4a53-a0ac-6db6e9e57333)
