### PR TITLE
midway/midtunit.cpp, midtunit_v.cpp, midwunit.cpp, midxunit.cpp: Cleanups

### DIFF
--- a/src/mame/midway/midtunit.cpp
+++ b/src/mame/midway/midtunit.cpp
@@ -25,16 +25,12 @@
 #include "emu.h"
 #include "midtunit.h"
 
-#include "cpu/adsp2100/adsp2100.h"
 #include "machine/nvram.h"
 #include "machine/watchdog.h"
 
 #include "screen.h"
 #include "speaker.h"
 
-
-#define CPU_CLOCK       (50000000)
-#define PIXEL_CLOCK     (8000000/2)
 
 
 
@@ -44,28 +40,42 @@
  *
  *************************************/
 
-void midtunit_state::main_map(address_map &map)
+void midtunit_base_state::main_map(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x00000000, 0x003fffff).rw(m_video, FUNC(midtunit_video_device::midtunit_vram_r), FUNC(midtunit_video_device::midtunit_vram_w));
 	map(0x01000000, 0x013fffff).ram();
-	map(0x01400000, 0x0141ffff).rw(FUNC(midtunit_state::midtunit_cmos_r), FUNC(midtunit_state::midtunit_cmos_w)).share("nvram");
-	map(0x01480000, 0x014fffff).w(FUNC(midtunit_state::midtunit_cmos_enable_w));
+	map(0x01400000, 0x0141ffff).rw(FUNC(midtunit_base_state::cmos_r), FUNC(midtunit_base_state::cmos_w)).share(m_nvram);
+	map(0x01480000, 0x014fffff).w(FUNC(midtunit_base_state::cmos_enable_w));
 	map(0x01600000, 0x0160000f).portr("IN0");
 	map(0x01600010, 0x0160001f).portr("IN1");
 	map(0x01600020, 0x0160002f).portr("IN2");
 	map(0x01600030, 0x0160003f).portr("DSW");
 	map(0x01800000, 0x0187ffff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x01a80000, 0x01a800ff).rw(m_video, FUNC(midtunit_video_device::midtunit_dma_r), FUNC(midtunit_video_device::midtunit_dma_w));
+	map(0x01a80000, 0x01a800ff).rw(m_video, FUNC(midtunit_video_device::dma_r), FUNC(midtunit_video_device::dma_w));
 	map(0x01b00000, 0x01b0001f).w(m_video, FUNC(midtunit_video_device::midtunit_control_w));
-//  map(0x01c00060, 0x01c0007f).w(FUNC(midtunit_state::midtunit_cmos_enable_w));
-	map(0x01d00000, 0x01d0001f).r(FUNC(midtunit_state::midtunit_sound_state_r));
-	map(0x01d01020, 0x01d0103f).rw(FUNC(midtunit_state::midtunit_sound_r), FUNC(midtunit_state::midtunit_sound_w));
+//  map(0x01c00060, 0x01c0007f).w(FUNC(midtunit_base_state::cmos_enable_w));
 	map(0x01d81060, 0x01d8107f).w("watchdog", FUNC(watchdog_timer_device::reset16_w));
 	map(0x01f00000, 0x01f0001f).w(m_video, FUNC(midtunit_video_device::midtunit_control_w));
-	map(0x02000000, 0x07ffffff).r(m_video, FUNC(midtunit_video_device::midtunit_gfxrom_r)).share("gfxrom");
-	map(0x1f800000, 0x1fffffff).rom().region("maincpu", 0); /* mirror used by MK */
+	map(0x02000000, 0x07ffffff).r(m_video, FUNC(midtunit_video_device::midtunit_gfxrom_r)).share("video");
+	map(0x1f800000, 0x1fffffff).rom().region("maincpu", 0); // mirror used by MK
 	map(0xff800000, 0xffffffff).rom().region("maincpu", 0);
+}
+
+void midtunit_adpcm_state::main_adpcm_map(address_map &map)
+{
+	midtunit_base_state::main_map(map);
+	map.unmap_value_high();
+	map(0x01d00000, 0x01d0001f).r(FUNC(midtunit_adpcm_state::sound_state_r));
+	map(0x01d01020, 0x01d0103f).rw(FUNC(midtunit_adpcm_state::sound_r), FUNC(midtunit_adpcm_state::sound_w));
+}
+
+void mk2_state::mk2_map(address_map &map)
+{
+	midtunit_base_state::main_map(map);
+	map.unmap_value_high();
+	map(0x01d00000, 0x01d0001f).r(FUNC(mk2_state::dcs_state_r));
+	map(0x01d01020, 0x01d0103f).rw(FUNC(mk2_state::dcs_r), FUNC(mk2_state::dcs_w));
 }
 
 
@@ -99,7 +109,7 @@ static INPUT_PORTS_START( mk )
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_COIN1 )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_COIN2 )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_START1 )
-	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_TILT ) /* Slam Switch */
+	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_TILT ) // Slam Switch
 	PORT_SERVICE( 0x0010, IP_ACTIVE_LOW )
 	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_START2 )
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_SERVICE1 )
@@ -196,7 +206,7 @@ static INPUT_PORTS_START( mk2 )
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_COIN1 )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_COIN2 )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_START1 )
-	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_TILT ) /* Slam Switch */
+	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_TILT ) // Slam Switch
 	PORT_SERVICE( 0x0010, IP_ACTIVE_LOW )
 	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_START2 )
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_SERVICE1 )
@@ -304,7 +314,7 @@ static INPUT_PORTS_START( jdreddp )
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_COIN1 )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_COIN2 )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_START1 )
-	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_TILT ) /* Slam Switch */
+	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_TILT ) // Slam Switch
 	PORT_SERVICE( 0x0010, IP_ACTIVE_LOW )
 	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_START2 )
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_SERVICE1 )
@@ -327,7 +337,7 @@ static INPUT_PORTS_START( jdreddp )
 	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_BUTTON4 ) PORT_NAME("P3 Crouch") PORT_PLAYER(3)
 	PORT_BIT( 0xff00, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("DSW")       /* DS1 */
+	PORT_START("DSW")       // DS1
 	PORT_DIPNAME( 0x0001, 0x0001, "Test Switch" )
 	PORT_DIPSETTING(      0x0001, DEF_STR( Off ))
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ))
@@ -400,7 +410,7 @@ static INPUT_PORTS_START( nbajam )
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_COIN1 )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_COIN2 )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_START1 )
-	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_TILT ) /* Slam Switch */
+	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_TILT ) // Slam Switch
 	PORT_SERVICE( 0x0010, IP_ACTIVE_LOW )
 	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_START2 )
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_SERVICE1 )
@@ -430,7 +440,7 @@ static INPUT_PORTS_START( nbajam )
 	PORT_BIT( 0x4000, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_NAME("P4 Turbo") PORT_PLAYER(4)
 	PORT_BIT( 0x8000, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("DSW")       /* DS1 */
+	PORT_START("DSW")       // DS1
 	PORT_DIPNAME( 0x0001, 0x0001, "Test Switch" )
 	PORT_DIPSETTING(      0x0001, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
@@ -503,7 +513,7 @@ static INPUT_PORTS_START( nbajamte )
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_COIN1 )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_COIN2 )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_START1 )
-	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_TILT ) /* Slam Switch */
+	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_TILT ) // Slam Switch
 	PORT_SERVICE_NO_TOGGLE( 0x0010, IP_ACTIVE_LOW )
 	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_START2 )
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_SERVICE1 )
@@ -533,7 +543,7 @@ static INPUT_PORTS_START( nbajamte )
 	PORT_BIT( 0x4000, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_NAME("P4 Turbo") PORT_PLAYER(4)
 	PORT_BIT( 0x8000, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("DSW")/* DS1 */
+	PORT_START("DSW")// DS1
 	PORT_DIPNAME( 0x0001, 0x0001, "Test Switch" )
 	PORT_DIPSETTING(      0x0001, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
@@ -590,26 +600,30 @@ INPUT_PORTS_END
  *
  *************************************/
 
-void midtunit_state::tunit_core(machine_config &config)
+void midtunit_base_state::tunit_core(machine_config &config)
 {
-	MIDTUNIT_VIDEO(config, m_video, m_maincpu, m_palette, m_gfxrom);
+	constexpr XTAL CPU_CLOCK = 50_MHz_XTAL;
+	constexpr XTAL PIXEL_CLOCK = 8_MHz_XTAL/2;
 
-	/* basic machine hardware */
+	MIDTUNIT_VIDEO(config, m_video, m_palette);
+	m_video->dma_irq_cb().set_inputline(m_maincpu, 0);
+
+	// basic machine hardware
 	TMS34010(config, m_maincpu, CPU_CLOCK);
-	m_maincpu->set_addrmap(AS_PROGRAM, &midtunit_state::main_map);
-	m_maincpu->set_halt_on_reset(false);     /* halt on reset */
-	m_maincpu->set_pixel_clock(PIXEL_CLOCK); /* pixel clock */
-	m_maincpu->set_pixels_per_clock(2);      /* pixels per clock */
-	m_maincpu->set_scanline_ind16_callback("video", FUNC(midtunit_video_device::scanline_update));  /* scanline updater (indexed16) */
-	m_maincpu->set_shiftreg_in_callback("video", FUNC(midtunit_video_device::to_shiftreg));         /* write to shiftreg function */
-	m_maincpu->set_shiftreg_out_callback("video", FUNC(midtunit_video_device::from_shiftreg));      /* read from shiftreg function */
+	m_maincpu->set_addrmap(AS_PROGRAM, &midtunit_base_state::main_map);
+	m_maincpu->set_halt_on_reset(false);     // halt on reset
+	m_maincpu->set_pixel_clock(PIXEL_CLOCK); // pixel clock
+	m_maincpu->set_pixels_per_clock(2);      // pixels per clock
+	m_maincpu->set_scanline_ind16_callback(m_video, FUNC(midtunit_video_device::scanline_update));  // scanline updater (indexed16)
+	m_maincpu->set_shiftreg_in_callback(m_video, FUNC(midtunit_video_device::to_shiftreg));         // write to shiftreg function
+	m_maincpu->set_shiftreg_out_callback(m_video, FUNC(midtunit_video_device::from_shiftreg));      // read from shiftreg function
 	m_maincpu->set_screen("screen");
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	PALETTE(config, m_palette).set_format(palette_device::xRGB_555, 32768);
 
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
@@ -620,22 +634,28 @@ void midtunit_state::tunit_core(machine_config &config)
 }
 
 
-void midtunit_state::tunit_adpcm(machine_config &config)
+void midtunit_adpcm_state::tunit_adpcm(machine_config &config)
 {
 	tunit_core(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
+	m_maincpu->set_addrmap(AS_PROGRAM, &midtunit_adpcm_state::main_adpcm_map);
+
 	SPEAKER(config, "speaker").front_center();
 
 	WILLIAMS_ADPCM_SOUND(config, m_adpcm_sound, 0).add_route(ALL_OUTPUTS, "speaker", 1.0);
 }
 
 
-void midtunit_state::tunit_dcs(machine_config &config)
+void mk2_state::mk2(machine_config &config)
 {
 	tunit_core(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
+	m_maincpu->set_addrmap(AS_PROGRAM, &mk2_state::mk2_map);
+
+	m_video->set_gfx_rom_large(true);
+
 	SPEAKER(config, "speaker").front_center();
 
 	DCS_AUDIO_2K(config, m_dcs, 0);
@@ -652,20 +672,20 @@ void midtunit_state::tunit_dcs(machine_config &config)
  *************************************/
 
 ROM_START( mk )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 )   /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 )   // sound CPU
 	ROM_LOAD( "sl1_mortal_kombat_u3_sound_rom.u3", 0x10000, 0x40000, CRC(c615844c) SHA1(5732f9053a5f73b0cc3b0166d7dc4430829d5bc7) )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "sl1_mortal_kombat_u12_sound_rom.u12", 0x00000, 0x40000, CRC(258bd7f9) SHA1(463890b23f17350fb9b8a85897b0777c45bc2d54) )
 	ROM_RELOAD(                                      0x40000, 0x40000 )
 	ROM_LOAD( "sl1_mortal_kombat_u13_sound_rom.u13", 0x80000, 0x40000, CRC(7b7ec3b6) SHA1(6eec1b90d4a4855f34a7ebfbf93f3358d5627db4) )
 	ROM_RELOAD(                                      0xc0000, 0x40000 )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l5_mortal_kombat_t-unit_uj12_game_rom.uj12", 0x00000, 0x80000, CRC(f4990bf2) SHA1(796ec84d37c8d20ca36d6439c14dee626fb8481e) )
 	ROM_LOAD16_BYTE( "l5_mortal_kombat_t-unit_ug12_game_rom.ug12", 0x00001, 0x80000, CRC(b06aeac1) SHA1(f66655eeab67c8cf5e496ae42dbae54d6400586f) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_t-unit_ug14_game_rom.ug14", 0x000000, 0x80000, CRC(9e00834e) SHA1(2b97b63f52ba1dba6af6ae56c223519a52b2ab9d) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_t-unit_uj14_game_rom.uj14", 0x000001, 0x80000, CRC(f4b0aaa7) SHA1(4cc6ee34c89e3cde325ad24b29511f70ae6a5a72) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_t-unit_ug19_game_rom.ug19", 0x000002, 0x80000, CRC(2d8c7ba1) SHA1(f891d6eb618dbf3e77f02e0f93da216e20571905) )
@@ -684,20 +704,20 @@ ROM_END
 
 
 ROM_START( mkr4 )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 )   /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 )   // sound CPU
 	ROM_LOAD( "sl1_mortal_kombat_u3_sound_rom.u3", 0x10000, 0x40000, CRC(c615844c) SHA1(5732f9053a5f73b0cc3b0166d7dc4430829d5bc7) )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "sl1_mortal_kombat_u12_sound_rom.u12", 0x00000, 0x40000, CRC(258bd7f9) SHA1(463890b23f17350fb9b8a85897b0777c45bc2d54) )
 	ROM_RELOAD(                                      0x40000, 0x40000 )
 	ROM_LOAD( "sl1_mortal_kombat_u13_sound_rom.u13", 0x80000, 0x40000, CRC(7b7ec3b6) SHA1(6eec1b90d4a4855f34a7ebfbf93f3358d5627db4) )
 	ROM_RELOAD(                                      0xc0000, 0x40000 )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l4_mortal_kombat_t-unit_uj12_game_rom.uj12", 0x00000, 0x80000, CRC(a1b6635a) SHA1(22d396cc9c1e3a14cb01d196de6d3e864f7afc55) )
 	ROM_LOAD16_BYTE( "l4_mortal_kombat_t-unit_ug12_game_rom.ug12", 0x00001, 0x80000, CRC(aa94f7ea) SHA1(bd8957bf52f73b49767cc78fec84ed1109a37701) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_t-unit_ug14_game_rom.ug14", 0x000000, 0x80000, CRC(9e00834e) SHA1(2b97b63f52ba1dba6af6ae56c223519a52b2ab9d) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_t-unit_uj14_game_rom.uj14", 0x000001, 0x80000, CRC(f4b0aaa7) SHA1(4cc6ee34c89e3cde325ad24b29511f70ae6a5a72) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_t-unit_ug19_game_rom.ug19", 0x000002, 0x80000, CRC(2d8c7ba1) SHA1(f891d6eb618dbf3e77f02e0f93da216e20571905) )
@@ -716,21 +736,21 @@ ROM_END
 
 
 ROM_START( mktturbo )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 )   /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 )   // sound CPU
 	ROM_LOAD( "sl1_mortal_kombat_u3_sound_rom.u3", 0x10000, 0x40000, CRC(c615844c) SHA1(5732f9053a5f73b0cc3b0166d7dc4430829d5bc7) )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "sl1_mortal_kombat_u12_sound_rom.u12", 0x00000, 0x40000, CRC(258bd7f9) SHA1(463890b23f17350fb9b8a85897b0777c45bc2d54) )
 	ROM_RELOAD(                                      0x40000, 0x40000 )
 	ROM_LOAD( "sl1_mortal_kombat_u13_sound_rom.u13", 0x80000, 0x40000, CRC(7b7ec3b6) SHA1(6eec1b90d4a4855f34a7ebfbf93f3358d5627db4) )
 	ROM_RELOAD(                                      0xc0000, 0x40000 )
 
-	/* A 'NIBBLE BOARD' daughtercard holding a GAL16V8A-2SP, 27C040 EPROM and a 9.8304MHz XTAL plugs into the UG12 socket */
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	// A 'NIBBLE BOARD' daughtercard holding a GAL16V8A-2SP, 27C040 EPROM and a 9.8304MHz XTAL plugs into the UG12 socket
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "kombo-rom-uj-12.bin", 0x00000, 0x80000, CRC(7a441f2d) SHA1(3b731bcbd73721ea0cc20157ec5181d25922523c) )
 	ROM_LOAD16_BYTE( "kombo-rom-ug-12.bin", 0x00001, 0x80000, CRC(45bed5a1) SHA1(dba2c21878925afdcaf61520c18ebefd5e9617db) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_t-unit_ug14_game_rom.ug14", 0x000000, 0x80000, CRC(9e00834e) SHA1(2b97b63f52ba1dba6af6ae56c223519a52b2ab9d) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_t-unit_uj14_game_rom.uj14", 0x000001, 0x80000, CRC(f4b0aaa7) SHA1(4cc6ee34c89e3cde325ad24b29511f70ae6a5a72) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_t-unit_ug19_game_rom.ug19", 0x000002, 0x80000, CRC(2d8c7ba1) SHA1(f891d6eb618dbf3e77f02e0f93da216e20571905) )
@@ -749,7 +769,7 @@ ROM_END
 
 
 ROM_START( mk2 )
-	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u2.u2", 0x000000, 0x80000, CRC(5f23d71d) SHA1(54c2afef243759e0f3dbe2907edbc4302f5c8bad) )
 	ROM_RELOAD(                                             0x100000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u3.u3", 0x200000, 0x80000, CRC(d6d92bf9) SHA1(397351c6b707f2595e36360471015f9fa494e894) )
@@ -762,13 +782,13 @@ ROM_START( mk2 )
 	ROM_RELOAD(                                             0x900000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u7.u7", 0xa00000, 0x80000, CRC(20387e0a) SHA1(505d05173b2a1f1ee3ebc2898ccd3a95c98dd04a) )
 	ROM_RELOAD(                                             0xb00000, 0x80000 )
-	/* su8 and su9 are unpopulated */
+	// su8 and su9 are unpopulated
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
-	ROM_LOAD16_BYTE( "l3.1_mortal_kombat_ii_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(cf100a75) SHA1(c5cf739fdb08e311f47794eb93a8d34d4bc11cde) ) /* Revision 3.1 */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
+	ROM_LOAD16_BYTE( "l3.1_mortal_kombat_ii_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(cf100a75) SHA1(c5cf739fdb08e311f47794eb93a8d34d4bc11cde) ) // Revision 3.1
 	ROM_LOAD16_BYTE( "l3.1_mortal_kombat_ii_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(582c7dfd) SHA1(f32bd1213ce70f74caa97a2047815cf4baee56b5) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug14.ug14", 0x000000, 0x100000, CRC(01e73af6) SHA1(6598cfd704cc92a7f358a0e1f1c973ab79dcc493) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_uj14.uj14", 0x000001, 0x100000, CRC(d4985cbb) SHA1(367865da7efae38d83de3c0868d02a705177ae63) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug19.ug19", 0x000002, 0x100000, CRC(fec137be) SHA1(f11ecb8a7993f5c4f4449564b4911f69bd6e9bf8) )
@@ -787,7 +807,7 @@ ROM_END
 
 
 ROM_START( mk2r32e )
-	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u2.u2", 0x000000, 0x80000, CRC(5f23d71d) SHA1(54c2afef243759e0f3dbe2907edbc4302f5c8bad) )
 	ROM_RELOAD(                                             0x100000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u3.u3", 0x200000, 0x80000, CRC(d6d92bf9) SHA1(397351c6b707f2595e36360471015f9fa494e894) )
@@ -800,13 +820,13 @@ ROM_START( mk2r32e )
 	ROM_RELOAD(                                             0x900000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u7.u7", 0xa00000, 0x80000, CRC(20387e0a) SHA1(505d05173b2a1f1ee3ebc2898ccd3a95c98dd04a) )
 	ROM_RELOAD(                                             0xb00000, 0x80000 )
-	/* su8 and su9 are unpopulated */
+	// su8 and su9 are unpopulated
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
-	ROM_LOAD16_BYTE( "uj12.l32e", 0x00000, 0x80000, CRC(43f773a6) SHA1(a97b75bac2793f99738abcbd4054f2b860aff574) ) /* Revision 3.2 Euro */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
+	ROM_LOAD16_BYTE( "uj12.l32e", 0x00000, 0x80000, CRC(43f773a6) SHA1(a97b75bac2793f99738abcbd4054f2b860aff574) ) // Revision 3.2 Euro
 	ROM_LOAD16_BYTE( "ug12.l32e", 0x00001, 0x80000, CRC(dcde9619) SHA1(72b39bd68eff5938cd87d3388074172a07bda816) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug14.ug14", 0x000000, 0x100000, CRC(01e73af6) SHA1(6598cfd704cc92a7f358a0e1f1c973ab79dcc493) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_uj14.uj14", 0x000001, 0x100000, CRC(d4985cbb) SHA1(367865da7efae38d83de3c0868d02a705177ae63) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug19.ug19", 0x000002, 0x100000, CRC(fec137be) SHA1(f11ecb8a7993f5c4f4449564b4911f69bd6e9bf8) )
@@ -825,7 +845,7 @@ ROM_END
 
 
 ROM_START( mk2r31e )
-	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u2.u2", 0x000000, 0x80000, CRC(5f23d71d) SHA1(54c2afef243759e0f3dbe2907edbc4302f5c8bad) )
 	ROM_RELOAD(                                             0x100000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u3.u3", 0x200000, 0x80000, CRC(d6d92bf9) SHA1(397351c6b707f2595e36360471015f9fa494e894) )
@@ -838,13 +858,13 @@ ROM_START( mk2r31e )
 	ROM_RELOAD(                                             0x900000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u7.u7", 0xa00000, 0x80000, CRC(20387e0a) SHA1(505d05173b2a1f1ee3ebc2898ccd3a95c98dd04a) )
 	ROM_RELOAD(                                             0xb00000, 0x80000 )
-	/* su8 and su9 are unpopulated */
+	// su8 and su9 are unpopulated
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
-	ROM_LOAD16_BYTE( "uj12.l31e", 0x00000, 0x80000, CRC(f64306d1) SHA1(b1fb8d59400a411498a56a740a7b35e4687ecebd) ) /* Revision 3.1 Euro */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
+	ROM_LOAD16_BYTE( "uj12.l31e", 0x00000, 0x80000, CRC(f64306d1) SHA1(b1fb8d59400a411498a56a740a7b35e4687ecebd) ) // Revision 3.1 Euro
 	ROM_LOAD16_BYTE( "ug12.l31e", 0x00001, 0x80000, CRC(4adeae7e) SHA1(4c9e5c7df3f86cc5c97c7fb70d4acca71d65cab5) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug14.ug14", 0x000000, 0x100000, CRC(01e73af6) SHA1(6598cfd704cc92a7f358a0e1f1c973ab79dcc493) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_uj14.uj14", 0x000001, 0x100000, CRC(d4985cbb) SHA1(367865da7efae38d83de3c0868d02a705177ae63) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug19.ug19", 0x000002, 0x100000, CRC(fec137be) SHA1(f11ecb8a7993f5c4f4449564b4911f69bd6e9bf8) )
@@ -863,7 +883,7 @@ ROM_END
 
 
 ROM_START( mk2r30 )
-	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u2.u2", 0x000000, 0x80000, CRC(5f23d71d) SHA1(54c2afef243759e0f3dbe2907edbc4302f5c8bad) )
 	ROM_RELOAD(                                             0x100000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u3.u3", 0x200000, 0x80000, CRC(d6d92bf9) SHA1(397351c6b707f2595e36360471015f9fa494e894) )
@@ -876,13 +896,13 @@ ROM_START( mk2r30 )
 	ROM_RELOAD(                                             0x900000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u7.u7", 0xa00000, 0x80000, CRC(20387e0a) SHA1(505d05173b2a1f1ee3ebc2898ccd3a95c98dd04a) )
 	ROM_RELOAD(                                             0xb00000, 0x80000 )
-	/* su8 and su9 are unpopulated */
+	// su8 and su9 are unpopulated
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
-	ROM_LOAD16_BYTE( "l3_mortal_kombat_ii_game_rom_uj12.uj12.l30", 0x00000, 0x80000, CRC(93440895) SHA1(e81735db939cd12b3836c7b9507a087e6899cdbd) ) /* Revision 3.0 */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
+	ROM_LOAD16_BYTE( "l3_mortal_kombat_ii_game_rom_uj12.uj12.l30", 0x00000, 0x80000, CRC(93440895) SHA1(e81735db939cd12b3836c7b9507a087e6899cdbd) ) // Revision 3.0
 	ROM_LOAD16_BYTE( "l3_mortal_kombat_ii_game_rom_ug12.ug12.l30", 0x00001, 0x80000, CRC(6153c2d8) SHA1(7b12eecc830f770a9c605a7e8376c8e719c33678) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug14.ug14", 0x000000, 0x100000, CRC(01e73af6) SHA1(6598cfd704cc92a7f358a0e1f1c973ab79dcc493) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_uj14.uj14", 0x000001, 0x100000, CRC(d4985cbb) SHA1(367865da7efae38d83de3c0868d02a705177ae63) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug19.ug19", 0x000002, 0x100000, CRC(fec137be) SHA1(f11ecb8a7993f5c4f4449564b4911f69bd6e9bf8) )
@@ -901,7 +921,7 @@ ROM_END
 
 
 ROM_START( mk2r21 )
-	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u2.u2", 0x000000, 0x80000, CRC(5f23d71d) SHA1(54c2afef243759e0f3dbe2907edbc4302f5c8bad) )
 	ROM_RELOAD(                                             0x100000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u3.u3", 0x200000, 0x80000, CRC(d6d92bf9) SHA1(397351c6b707f2595e36360471015f9fa494e894) )
@@ -914,13 +934,13 @@ ROM_START( mk2r21 )
 	ROM_RELOAD(                                             0x900000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u7.u7", 0xa00000, 0x80000, CRC(20387e0a) SHA1(505d05173b2a1f1ee3ebc2898ccd3a95c98dd04a) )
 	ROM_RELOAD(                                             0xb00000, 0x80000 )
-	/* su8 and su9 are unpopulated */
+	// su8 and su9 are unpopulated
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
-	ROM_LOAD16_BYTE( "l2.1_mortal_kombat_ii_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(d6a35699) SHA1(17feee7886108d6f946bf04669479d35c2edac76) ) /* Revision 2.1 */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
+	ROM_LOAD16_BYTE( "l2.1_mortal_kombat_ii_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(d6a35699) SHA1(17feee7886108d6f946bf04669479d35c2edac76) ) // Revision 2.1
 	ROM_LOAD16_BYTE( "l2.1_mortal_kombat_ii_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(aeb703ff) SHA1(e94cd9e6feb45e3de85661ca12452aff6e14d3ae) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug14.ug14", 0x000000, 0x100000, CRC(01e73af6) SHA1(6598cfd704cc92a7f358a0e1f1c973ab79dcc493) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_uj14.uj14", 0x000001, 0x100000, CRC(d4985cbb) SHA1(367865da7efae38d83de3c0868d02a705177ae63) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug19.ug19", 0x000002, 0x100000, CRC(fec137be) SHA1(f11ecb8a7993f5c4f4449564b4911f69bd6e9bf8) )
@@ -939,7 +959,7 @@ ROM_END
 
 
 ROM_START( mk2r20 )
-	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u2.u2", 0x000000, 0x80000, CRC(5f23d71d) SHA1(54c2afef243759e0f3dbe2907edbc4302f5c8bad) )
 	ROM_RELOAD(                                             0x100000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u3.u3", 0x200000, 0x80000, CRC(d6d92bf9) SHA1(397351c6b707f2595e36360471015f9fa494e894) )
@@ -952,13 +972,13 @@ ROM_START( mk2r20 )
 	ROM_RELOAD(                                             0x900000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u7.u7", 0xa00000, 0x80000, CRC(20387e0a) SHA1(505d05173b2a1f1ee3ebc2898ccd3a95c98dd04a) )
 	ROM_RELOAD(                                             0xb00000, 0x80000 )
-	/* su8 and su9 are unpopulated */
+	// su8 and su9 are unpopulated
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
-	ROM_LOAD16_BYTE( "l2_mortal_kombat_ii_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(72071550) SHA1(af0fb357e423eb054d32a1b2b216fb18437939ed) ) /* Revision 2.0 */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
+	ROM_LOAD16_BYTE( "l2_mortal_kombat_ii_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(72071550) SHA1(af0fb357e423eb054d32a1b2b216fb18437939ed) ) // Revision 2.0
 	ROM_LOAD16_BYTE( "l2_mortal_kombat_ii_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(86c3ce65) SHA1(09d4dd6905911d8febe516f018e445657e929959) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug14.ug14", 0x000000, 0x100000, CRC(01e73af6) SHA1(6598cfd704cc92a7f358a0e1f1c973ab79dcc493) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_uj14.uj14", 0x000001, 0x100000, CRC(d4985cbb) SHA1(367865da7efae38d83de3c0868d02a705177ae63) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug19.ug19", 0x000002, 0x100000, CRC(fec137be) SHA1(f11ecb8a7993f5c4f4449564b4911f69bd6e9bf8) )
@@ -977,7 +997,7 @@ ROM_END
 
 
 ROM_START( mk2r14 )
-	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u2.u2", 0x000000, 0x80000, CRC(5f23d71d) SHA1(54c2afef243759e0f3dbe2907edbc4302f5c8bad) )
 	ROM_RELOAD(                                             0x100000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u3.u3", 0x200000, 0x80000, CRC(d6d92bf9) SHA1(397351c6b707f2595e36360471015f9fa494e894) )
@@ -990,13 +1010,13 @@ ROM_START( mk2r14 )
 	ROM_RELOAD(                                             0x900000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u7.u7", 0xa00000, 0x80000, CRC(20387e0a) SHA1(505d05173b2a1f1ee3ebc2898ccd3a95c98dd04a) )
 	ROM_RELOAD(                                             0xb00000, 0x80000 )
-	/* su8 and su9 are unpopulated */
+	// su8 and su9 are unpopulated
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
-	ROM_LOAD16_BYTE( "l1.4_mortal_kombat_ii_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(6d43bc6d) SHA1(578ea9c60fa94689d6ae583b86769cd56d8db311) ) /* Revision 1.4 */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
+	ROM_LOAD16_BYTE( "l1.4_mortal_kombat_ii_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(6d43bc6d) SHA1(578ea9c60fa94689d6ae583b86769cd56d8db311) ) // Revision 1.4
 	ROM_LOAD16_BYTE( "l1.4_mortal_kombat_ii_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(42b0da21) SHA1(94ef25b04c35b4c26b692c2c3c5f68ba747bef49) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug14.ug14", 0x000000, 0x100000, CRC(01e73af6) SHA1(6598cfd704cc92a7f358a0e1f1c973ab79dcc493) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_uj14.uj14", 0x000001, 0x100000, CRC(d4985cbb) SHA1(367865da7efae38d83de3c0868d02a705177ae63) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug19.ug19", 0x000002, 0x100000, CRC(fec137be) SHA1(f11ecb8a7993f5c4f4449564b4911f69bd6e9bf8) )
@@ -1014,7 +1034,7 @@ ROM_START( mk2r14 )
 ROM_END
 
 ROM_START( mk2r11 )
-	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u2.u2", 0x000000, 0x80000, CRC(5f23d71d) SHA1(54c2afef243759e0f3dbe2907edbc4302f5c8bad) )
 	ROM_RELOAD(                                             0x100000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u3.u3", 0x200000, 0x80000, CRC(d6d92bf9) SHA1(397351c6b707f2595e36360471015f9fa494e894) )
@@ -1027,13 +1047,13 @@ ROM_START( mk2r11 )
 	ROM_RELOAD(                                             0x900000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u7.u7", 0xa00000, 0x80000, CRC(20387e0a) SHA1(505d05173b2a1f1ee3ebc2898ccd3a95c98dd04a) )
 	ROM_RELOAD(                                             0xb00000, 0x80000 )
-	/* su8 and su9 are unpopulated */
+	// su8 and su9 are unpopulated
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
-	ROM_LOAD16_BYTE( "l1.1_mortal_kombat_ii_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(01daff19) SHA1(8b14bf823ecb60c391688c106a52f141f1d291b5) ) /* Revision 1.1 */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
+	ROM_LOAD16_BYTE( "l1.1_mortal_kombat_ii_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(01daff19) SHA1(8b14bf823ecb60c391688c106a52f141f1d291b5) ) // Revision 1.1
 	ROM_LOAD16_BYTE( "l1.1_mortal_kombat_ii_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(54042eb7) SHA1(cda2f940b9c74989450611e6319e7cdadc05c627) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug14.ug14", 0x000000, 0x100000, CRC(01e73af6) SHA1(6598cfd704cc92a7f358a0e1f1c973ab79dcc493) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_uj14.uj14", 0x000001, 0x100000, CRC(d4985cbb) SHA1(367865da7efae38d83de3c0868d02a705177ae63) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug19.ug19", 0x000002, 0x100000, CRC(fec137be) SHA1(f11ecb8a7993f5c4f4449564b4911f69bd6e9bf8) )
@@ -1051,7 +1071,7 @@ ROM_START( mk2r11 )
 ROM_END
 
 ROM_START( mk2r42 )
-	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u2.u2", 0x000000, 0x80000, CRC(5f23d71d) SHA1(54c2afef243759e0f3dbe2907edbc4302f5c8bad) )
 	ROM_RELOAD(                                             0x100000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u3.u3", 0x200000, 0x80000, CRC(d6d92bf9) SHA1(397351c6b707f2595e36360471015f9fa494e894) )
@@ -1064,13 +1084,13 @@ ROM_START( mk2r42 )
 	ROM_RELOAD(                                             0x900000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u7.u7", 0xa00000, 0x80000, CRC(20387e0a) SHA1(505d05173b2a1f1ee3ebc2898ccd3a95c98dd04a) )
 	ROM_RELOAD(                                             0xb00000, 0x80000 )
-	/* su8 and su9 are unpopulated */
+	// su8 and su9 are unpopulated
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "mk242j12.bin", 0x00000, 0x80000, CRC(c7fb1525) SHA1(350be1a6f6da3a6b42764cfceae196696482def2) )
 	ROM_LOAD16_BYTE( "mk242g12.bin", 0x00001, 0x80000, CRC(443d0e0a) SHA1(20e69c266cda59be92d7cd6423f6e03ad65226eb) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug14.ug14", 0x000000, 0x100000, CRC(01e73af6) SHA1(6598cfd704cc92a7f358a0e1f1c973ab79dcc493) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_uj14.uj14", 0x000001, 0x100000, CRC(d4985cbb) SHA1(367865da7efae38d83de3c0868d02a705177ae63) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug19.ug19", 0x000002, 0x100000, CRC(fec137be) SHA1(f11ecb8a7993f5c4f4449564b4911f69bd6e9bf8) )
@@ -1089,7 +1109,7 @@ ROM_END
 
 
 ROM_START( mk2r91 )
-	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u2.u2", 0x000000, 0x80000, CRC(5f23d71d) SHA1(54c2afef243759e0f3dbe2907edbc4302f5c8bad) )
 	ROM_RELOAD(                                             0x100000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u3.u3", 0x200000, 0x80000, CRC(d6d92bf9) SHA1(397351c6b707f2595e36360471015f9fa494e894) )
@@ -1102,13 +1122,13 @@ ROM_START( mk2r91 )
 	ROM_RELOAD(                                             0x900000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u7.u7", 0xa00000, 0x80000, CRC(20387e0a) SHA1(505d05173b2a1f1ee3ebc2898ccd3a95c98dd04a) )
 	ROM_RELOAD(                                             0xb00000, 0x80000 )
-	/* su8 and su9 are unpopulated */
+	// su8 and su9 are unpopulated
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "uj12.l91", 0x00000, 0x80000, CRC(41953903) SHA1(f72f92beb32e724d37e5f951b24539902dc16a9f) )
 	ROM_LOAD16_BYTE( "ug12.l91", 0x00001, 0x80000, CRC(c07f745a) SHA1(049a18bc162274c897cae695032f32c851e57330) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug14.ug14", 0x000000, 0x100000, CRC(01e73af6) SHA1(6598cfd704cc92a7f358a0e1f1c973ab79dcc493) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_uj14.uj14", 0x000001, 0x100000, CRC(d4985cbb) SHA1(367865da7efae38d83de3c0868d02a705177ae63) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug19.ug19", 0x000002, 0x100000, CRC(fec137be) SHA1(f11ecb8a7993f5c4f4449564b4911f69bd6e9bf8) )
@@ -1127,7 +1147,7 @@ ROM_END
 
 
 ROM_START( mk2chal ) // Known as the Challenger Hack because the version number has been replaced with "CHALLENGER.." in the Test Menu
-	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0xc00000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u2.u2", 0x000000, 0x80000, CRC(5f23d71d) SHA1(54c2afef243759e0f3dbe2907edbc4302f5c8bad) )
 	ROM_RELOAD(                                             0x100000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u3.u3", 0x200000, 0x80000, CRC(d6d92bf9) SHA1(397351c6b707f2595e36360471015f9fa494e894) )
@@ -1140,13 +1160,13 @@ ROM_START( mk2chal ) // Known as the Challenger Hack because the version number 
 	ROM_RELOAD(                                             0x900000, 0x80000 )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_ii_sound_rom_u7.u7", 0xa00000, 0x80000, CRC(20387e0a) SHA1(505d05173b2a1f1ee3ebc2898ccd3a95c98dd04a) )
 	ROM_RELOAD(                                             0xb00000, 0x80000 )
-	/* su8 and su9 are unpopulated */
+	// su8 and su9 are unpopulated
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "immortal_kombat_ii_j-12.uj12", 0x00000, 0x80000, CRC(2d5c04e6) SHA1(85947876319c86bdcdeccda99ae1ddbcfb212484) ) // labeled IMMORTAL KOMBAT II J-12
 	ROM_LOAD16_BYTE( "immortal_kombat_ii_g-12.ug12", 0x00001, 0x80000, CRC(3e7a4bad) SHA1(9a8ad99e09badcea7f2bcf80a649c96a883a0463) ) // labeled IMMORTAL KOMBAT II G-12
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug14.ug14", 0x000000, 0x100000, CRC(01e73af6) SHA1(6598cfd704cc92a7f358a0e1f1c973ab79dcc493) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_uj14.uj14", 0x000001, 0x100000, CRC(d4985cbb) SHA1(367865da7efae38d83de3c0868d02a705177ae63) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_ii_game_rom_ug19.ug19", 0x000002, 0x100000, CRC(fec137be) SHA1(f11ecb8a7993f5c4f4449564b4911f69bd6e9bf8) )
@@ -1240,19 +1260,19 @@ NOTE: The current sound ROMs match the L1 checksums listed above. Midway would c
 */
 
 ROM_START( nbajam )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) // sound CPU
 	ROM_LOAD(  "l2_nba_jam_u3_sound_rom.u3", 0x010000, 0x20000, CRC(3a3ea480) SHA1(d12a45cba5c35f046b176661d7877fa4fd0e6c13) )
 	ROM_RELOAD(                              0x030000, 0x20000 )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "l1_nba_jam_u12_sound_rom.u12", 0x000000, 0x80000, CRC(b94847f1) SHA1(e7efa0a379bfa91fe4ffb75f07a5dfbfde9a96b4) ) // may be labeled as L2 revision
 	ROM_LOAD( "l1_nba_jam_u13_sound_rom.u13", 0x080000, 0x80000, CRC(b6fe24bd) SHA1(f70f75b5570a2b368ebc74d2a7d264c618940430) ) // may be labeled as L2 revision
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l3_nba_jam_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(b93e271c) SHA1(b0e9f055376a4a4cd1115a81f71c933903c251b1) )
 	ROM_LOAD16_BYTE( "l3_nba_jam_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(407d3390) SHA1(a319bc890d94310e44fe2ec98bfc95665a662701) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_nba_jam_game_rom_ug14.ug14", 0x000000, 0x80000, CRC(04bb9f64) SHA1(9e1a8c37e14cb6fe67f4aa3caa9022f356f1ca64) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_game_rom_uj14.uj14", 0x000001, 0x80000, CRC(b34b7af3) SHA1(0abb74d2f414bc9da0380a81beb134f3a87c1a0a) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_game_rom_ug19.ug19", 0x000002, 0x80000, CRC(a8f22fbb) SHA1(514208a9d6d0c8c2d7847cc02d4387eac90be659) )
@@ -1276,19 +1296,19 @@ ROM_END
 
 
 ROM_START( nbajamr2 )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) // sound CPU
 	ROM_LOAD(  "l2_nba_jam_u3_sound_rom.u3", 0x010000, 0x20000, CRC(3a3ea480) SHA1(d12a45cba5c35f046b176661d7877fa4fd0e6c13) ) // sound program updated 2-10-93
 	ROM_RELOAD(                              0x030000, 0x20000 )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "l1_nba_jam_u12_sound_rom.u12", 0x000000, 0x80000, CRC(b94847f1) SHA1(e7efa0a379bfa91fe4ffb75f07a5dfbfde9a96b4) ) // may be labeled as L2 revision
 	ROM_LOAD( "l1_nba_jam_u13_sound_rom.u13", 0x080000, 0x80000, CRC(b6fe24bd) SHA1(f70f75b5570a2b368ebc74d2a7d264c618940430) ) // may be labeled as L2 revision
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l2_nba_jam_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(0fe80b36) SHA1(fe6b21dc9b393b25c511b2914b568fa92301d749) )
 	ROM_LOAD16_BYTE( "l2_nba_jam_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(5d106315) SHA1(e2cddd9ed6771e77711e3a4f25fe2d07712d954e) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_nba_jam_game_rom_ug14.ug14", 0x000000, 0x80000, CRC(04bb9f64) SHA1(9e1a8c37e14cb6fe67f4aa3caa9022f356f1ca64) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_game_rom_uj14.uj14", 0x000001, 0x80000, CRC(b34b7af3) SHA1(0abb74d2f414bc9da0380a81beb134f3a87c1a0a) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_game_rom_ug19.ug19", 0x000002, 0x80000, CRC(a8f22fbb) SHA1(514208a9d6d0c8c2d7847cc02d4387eac90be659) )
@@ -1312,19 +1332,19 @@ ROM_END
 
 
 ROM_START( nbajamr1 )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) // sound CPU
 	ROM_LOAD(  "l2_nba_jam_u3_sound_rom.u3", 0x010000, 0x20000, CRC(3a3ea480) SHA1(d12a45cba5c35f046b176661d7877fa4fd0e6c13) ) // missing undumped L1 ROM - should be dated 2/1/93
 	ROM_RELOAD(                              0x030000, 0x20000 )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "l1_nba_jam_u12_sound_rom.u12", 0x000000, 0x80000, CRC(b94847f1) SHA1(e7efa0a379bfa91fe4ffb75f07a5dfbfde9a96b4) )
 	ROM_LOAD( "l1_nba_jam_u13_sound_rom.u13", 0x080000, 0x80000, CRC(b6fe24bd) SHA1(f70f75b5570a2b368ebc74d2a7d264c618940430) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l1_nba_jam_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(4db672ec) SHA1(bb329c552473179f617d3bd038f47fb69d060b55) )
 	ROM_LOAD16_BYTE( "l1_nba_jam_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(ed1df3f7) SHA1(36b0c47758a205719dbef169f0af3e761f557b99) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_nba_jam_game_rom_ug14.ug14", 0x000000, 0x80000, CRC(04bb9f64) SHA1(9e1a8c37e14cb6fe67f4aa3caa9022f356f1ca64) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_game_rom_uj14.uj14", 0x000001, 0x80000, CRC(b34b7af3) SHA1(0abb74d2f414bc9da0380a81beb134f3a87c1a0a) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_game_rom_ug19.ug19", 0x000002, 0x80000, CRC(a8f22fbb) SHA1(514208a9d6d0c8c2d7847cc02d4387eac90be659) )
@@ -1348,21 +1368,21 @@ ROM_END
 
 
 ROM_START( nbajamp2 )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) // sound CPU
 	ROM_LOAD(  "p1_nba_jam_u3_sound_rom.u3", 0x010000, 0x20000, CRC(3d13633c) SHA1(b9597c352f56d67e5fdc958319285bbed0fcfbea) ) // all sound ROMs labeled as P1
 	ROM_RELOAD(                              0x030000, 0x20000 )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "p1_nba_jam_u12_sound_rom.u12", 0x000000, 0x80000, CRC(009aad42) SHA1(6cdef52ca565919626475a9ef5f264c55b899ea6) )
 	ROM_LOAD( "p1_nba_jam_u13_sound_rom.u13", 0x080000, 0x80000, CRC(248800c2) SHA1(c6d7cd7841d751ee188c7bfd1ebbed380a18116e) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "p2_nba_jam_game_rom_uj12.uj12", 0x00000, 0x40000, CRC(4ebdf669) SHA1(8ab0d6084ed39ea7872aa5749148500ab1f1f692) ) // program ROMs labeled as P2
 	ROM_RELOAD(                                       0x80000, 0x40000 )
 	ROM_LOAD16_BYTE( "p2_nba_jam_game_rom_ug12.ug12", 0x00001, 0x40000, CRC(8d6098b6) SHA1(ca2e9be3ae77b379e8aa83b5ef7fda9fdaa3903c) )
 	ROM_RELOAD(                                       0x80001, 0x40000 )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "p1_nba_jam_game_rom_ug14.ug14", 0x000000, 0x80000, CRC(39e16e0b) SHA1(9cd5b4b74d5bdf89a348d37a235df7988f91a133) ) // all graphics ROMs labeled as P1
 	ROM_LOAD32_BYTE( "p1_nba_jam_game_rom_uj14.uj14", 0x000001, 0x80000, CRC(a9ef8b67) SHA1(4d7faf6c0d4fdf98d33c9a01221e15cd5bbdaa88) )
 	ROM_LOAD32_BYTE( "p1_nba_jam_game_rom_ug19.ug19", 0x000002, 0x80000, CRC(a88b961c) SHA1(28d087acedeba67413bcc3fd26a872459fa27161) )
@@ -1386,21 +1406,21 @@ ROM_END
 
 
 ROM_START( nbajamp1 )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) // sound CPU
 	ROM_LOAD(  "p1_nba_jam_u3_sound_rom.u3", 0x010000, 0x20000, CRC(3d13633c) SHA1(b9597c352f56d67e5fdc958319285bbed0fcfbea) ) // all sound ROMs labeled as P1
 	ROM_RELOAD(                              0x030000, 0x20000 )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "p1_nba_jam_u12_sound_rom.u12", 0x000000, 0x80000, CRC(009aad42) SHA1(6cdef52ca565919626475a9ef5f264c55b899ea6) )
 	ROM_LOAD( "p1_nba_jam_u13_sound_rom.u13", 0x080000, 0x80000, CRC(248800c2) SHA1(c6d7cd7841d751ee188c7bfd1ebbed380a18116e) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "p1_nba_jam_game_rom_uj12.uj12", 0x00000, 0x40000, CRC(c0faf310) SHA1(f37d796ab8b06861853fe24a3b4ccfb27a3832b5) ) // program ROMs labeled as P1
 	ROM_RELOAD(                                       0x80000, 0x40000 )
 	ROM_LOAD16_BYTE( "p1_nba_jam_game_rom_ug12.ug12", 0x00001, 0x40000, CRC(5ee68e03) SHA1(eec97375e3ad9b1aa5d2a6793289fa0c002d1343) )
 	ROM_RELOAD(                                       0x80001, 0x40000 )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "p1_nba_jam_game_rom_ug14.ug14", 0x000000, 0x80000, CRC(39e16e0b) SHA1(9cd5b4b74d5bdf89a348d37a235df7988f91a133) ) // all graphics ROMs labeled as P1
 	ROM_LOAD32_BYTE( "p1_nba_jam_game_rom_uj14.uj14", 0x000001, 0x80000, CRC(a9ef8b67) SHA1(4d7faf6c0d4fdf98d33c9a01221e15cd5bbdaa88) )
 	ROM_LOAD32_BYTE( "p1_nba_jam_game_rom_ug19.ug19", 0x000002, 0x80000, CRC(a88b961c) SHA1(28d087acedeba67413bcc3fd26a872459fa27161) )
@@ -1424,19 +1444,19 @@ ROM_END
 
 
 ROM_START( nbajamte )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) // sound CPU
 	ROM_LOAD(  "l1_nba_jam_tournament_u3_sound_rom.u3", 0x010000, 0x20000, CRC(d4551195) SHA1(e8908fbe4339fb8c93f7e74113dfd25dda1667ea) )
 	ROM_RELOAD(                                         0x030000, 0x20000 )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "l1_nba_jam_tournament_u12_sound_rom.u12", 0x000000, 0x80000, CRC(4fac97bc) SHA1(bd88d8c3edab0e35ad9f9350bcbaa17cda61d87a) )
 	ROM_LOAD( "l1_nba_jam_tournament_u13_sound_rom.u13", 0x080000, 0x80000, CRC(6f27b202) SHA1(c1f0db15624d1e7102ce9fd1db49ccf86e8611d6) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l4_nba_jam_tournament_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(d7c21bc4) SHA1(e05f0299b955500df6a08b1c0b24b932a9cdfa6a) ) // sldh - rev 4.0 3/23/94
 	ROM_LOAD16_BYTE( "l4_nba_jam_tournament_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(7ad49229) SHA1(e9ceedb0e620809d8a4d42087d806aa296a4cd59) ) // sldh - rev 4.0 3/23/94
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug14.ug14", 0x000000, 0x80000, CRC(04bb9f64) SHA1(9e1a8c37e14cb6fe67f4aa3caa9022f356f1ca64) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_uj14.uj14", 0x000001, 0x80000, CRC(b34b7af3) SHA1(0abb74d2f414bc9da0380a81beb134f3a87c1a0a) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug19.ug19", 0x000002, 0x80000, CRC(a8f22fbb) SHA1(514208a9d6d0c8c2d7847cc02d4387eac90be659) )
@@ -1460,19 +1480,19 @@ ROM_END
 
 
 ROM_START( nbajamte4 )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) // sound CPU
 	ROM_LOAD(  "l1_nba_jam_tournament_u3_sound_rom.u3", 0x010000, 0x20000, CRC(d4551195) SHA1(e8908fbe4339fb8c93f7e74113dfd25dda1667ea) )
 	ROM_RELOAD(                                         0x030000, 0x20000 )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "l1_nba_jam_tournament_u12_sound_rom.u12", 0x000000, 0x80000, CRC(4fac97bc) SHA1(bd88d8c3edab0e35ad9f9350bcbaa17cda61d87a) )
 	ROM_LOAD( "l1_nba_jam_tournament_u13_sound_rom.u13", 0x080000, 0x80000, CRC(6f27b202) SHA1(c1f0db15624d1e7102ce9fd1db49ccf86e8611d6) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l4_nba_jam_tournament_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(f94074f8) SHA1(0d669a38f33b000ec12352ae15ebdd7849b6ad50) ) // sldh - rev 4.0 3/03/94
 	ROM_LOAD16_BYTE( "l4_nba_jam_tournament_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(2c55890b) SHA1(839492d50474a54a434090a5f06548963773aec7) ) // sldh - rev 4.0 3/03/94
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug14.ug14", 0x000000, 0x80000, CRC(04bb9f64) SHA1(9e1a8c37e14cb6fe67f4aa3caa9022f356f1ca64) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_uj14.uj14", 0x000001, 0x80000, CRC(b34b7af3) SHA1(0abb74d2f414bc9da0380a81beb134f3a87c1a0a) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug19.ug19", 0x000002, 0x80000, CRC(a8f22fbb) SHA1(514208a9d6d0c8c2d7847cc02d4387eac90be659) )
@@ -1496,19 +1516,19 @@ ROM_END
 
 
 ROM_START( nbajamte3 )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) // sound CPU
 	ROM_LOAD(  "l1_nba_jam_tournament_u3_sound_rom.u3", 0x010000, 0x20000, CRC(d4551195) SHA1(e8908fbe4339fb8c93f7e74113dfd25dda1667ea) )
 	ROM_RELOAD(                                         0x030000, 0x20000 )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "l1_nba_jam_tournament_u12_sound_rom.u12", 0x000000, 0x80000, CRC(4fac97bc) SHA1(bd88d8c3edab0e35ad9f9350bcbaa17cda61d87a) )
 	ROM_LOAD( "l1_nba_jam_tournament_u13_sound_rom.u13", 0x080000, 0x80000, CRC(6f27b202) SHA1(c1f0db15624d1e7102ce9fd1db49ccf86e8611d6) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l3_nba_jam_tournament_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(8fdf77b4) SHA1(1a8a178b19d0b8e7a5fd2ddf373a4279321440d0) ) // sldh - rev 3.0 3/04/94
 	ROM_LOAD16_BYTE( "l3_nba_jam_tournament_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(656579ed) SHA1(b038fdc814ebc8d203724fdb2f7501d40f1dc21f) ) // sldh - rev 3.0 3/04/94
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug14.ug14", 0x000000, 0x80000, CRC(04bb9f64) SHA1(9e1a8c37e14cb6fe67f4aa3caa9022f356f1ca64) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_uj14.uj14", 0x000001, 0x80000, CRC(b34b7af3) SHA1(0abb74d2f414bc9da0380a81beb134f3a87c1a0a) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug19.ug19", 0x000002, 0x80000, CRC(a8f22fbb) SHA1(514208a9d6d0c8c2d7847cc02d4387eac90be659) )
@@ -1532,19 +1552,19 @@ ROM_END
 
 
 ROM_START( nbajamte3a )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) // sound CPU
 	ROM_LOAD(  "l1_nba_jam_tournament_u3_sound_rom.u3", 0x010000, 0x20000, CRC(d4551195) SHA1(e8908fbe4339fb8c93f7e74113dfd25dda1667ea) )
 	ROM_RELOAD(                                         0x030000, 0x20000 )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "l1_nba_jam_tournament_u12_sound_rom.u12", 0x000000, 0x80000, CRC(4fac97bc) SHA1(bd88d8c3edab0e35ad9f9350bcbaa17cda61d87a) )
 	ROM_LOAD( "l1_nba_jam_tournament_u13_sound_rom.u13", 0x080000, 0x80000, CRC(6f27b202) SHA1(c1f0db15624d1e7102ce9fd1db49ccf86e8611d6) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l3_nba_jam_tournament_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(83f03079) SHA1(2aa95339edb8b50b38f0842c960ca2adee4db5dd) ) // sldh - rev 3.0 2/26/94
 	ROM_LOAD16_BYTE( "l3_nba_jam_tournament_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(121ccb3a) SHA1(c5e76f34b222f33e7af957bd57b45d30f43cb012) ) // sldh - rev 3.0 2/26/94
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug14.ug14", 0x000000, 0x80000, CRC(04bb9f64) SHA1(9e1a8c37e14cb6fe67f4aa3caa9022f356f1ca64) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_uj14.uj14", 0x000001, 0x80000, CRC(b34b7af3) SHA1(0abb74d2f414bc9da0380a81beb134f3a87c1a0a) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug19.ug19", 0x000002, 0x80000, CRC(a8f22fbb) SHA1(514208a9d6d0c8c2d7847cc02d4387eac90be659) )
@@ -1568,19 +1588,19 @@ ROM_END
 
 
 ROM_START( nbajamte2 )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) // sound CPU
 	ROM_LOAD(  "l1_nba_jam_tournament_u3_sound_rom.u3", 0x010000, 0x20000, CRC(d4551195) SHA1(e8908fbe4339fb8c93f7e74113dfd25dda1667ea) )
 	ROM_RELOAD(                                         0x030000, 0x20000 )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "l1_nba_jam_tournament_u12_sound_rom.u12", 0x000000, 0x80000, CRC(4fac97bc) SHA1(bd88d8c3edab0e35ad9f9350bcbaa17cda61d87a) )
 	ROM_LOAD( "l1_nba_jam_tournament_u13_sound_rom.u13", 0x080000, 0x80000, CRC(6f27b202) SHA1(c1f0db15624d1e7102ce9fd1db49ccf86e8611d6) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l2.1_nba_jam_tournament_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(d009aa29) SHA1(2f9317d3f89488a3593637a37eea4ac68dd1067b) )
 	ROM_LOAD16_BYTE( "l2.1_nba_jam_tournament_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(6c3bfb6a) SHA1(e05cbe33661fb37a929c6a75d9e0f3469cc81d2d) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug14.ug14", 0x000000, 0x80000, CRC(04bb9f64) SHA1(9e1a8c37e14cb6fe67f4aa3caa9022f356f1ca64) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_uj14.uj14", 0x000001, 0x80000, CRC(b34b7af3) SHA1(0abb74d2f414bc9da0380a81beb134f3a87c1a0a) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug19.ug19", 0x000002, 0x80000, CRC(a8f22fbb) SHA1(514208a9d6d0c8c2d7847cc02d4387eac90be659) )
@@ -1604,19 +1624,19 @@ ROM_END
 
 
 ROM_START( nbajamte2a )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) // sound CPU
 	ROM_LOAD(  "l1_nba_jam_tournament_u3_sound_rom.u3", 0x010000, 0x20000, CRC(d4551195) SHA1(e8908fbe4339fb8c93f7e74113dfd25dda1667ea) )
 	ROM_RELOAD(                                         0x030000, 0x20000 )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "l1_nba_jam_tournament_u12_sound_rom.u12", 0x000000, 0x80000, CRC(4fac97bc) SHA1(bd88d8c3edab0e35ad9f9350bcbaa17cda61d87a) )
 	ROM_LOAD( "l1_nba_jam_tournament_u13_sound_rom.u13", 0x080000, 0x80000, CRC(6f27b202) SHA1(c1f0db15624d1e7102ce9fd1db49ccf86e8611d6) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l2_nba_jam_tournament_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(eaa6fb32) SHA1(8c8c0c6ace2b98679d7fe90e1f9284bdf0e14eaf) )
 	ROM_LOAD16_BYTE( "l2_nba_jam_tournament_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(5a694d9a) SHA1(fb74e4242d9adba03f24a81451ea06e8d9b4af96) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug14.ug14", 0x000000, 0x80000, CRC(04bb9f64) SHA1(9e1a8c37e14cb6fe67f4aa3caa9022f356f1ca64) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_uj14.uj14", 0x000001, 0x80000, CRC(b34b7af3) SHA1(0abb74d2f414bc9da0380a81beb134f3a87c1a0a) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug19.ug19", 0x000002, 0x80000, CRC(a8f22fbb) SHA1(514208a9d6d0c8c2d7847cc02d4387eac90be659) )
@@ -1640,19 +1660,19 @@ ROM_END
 
 
 ROM_START( nbajamte1 )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) // sound CPU
 	ROM_LOAD(  "l1_nba_jam_tournament_u3_sound_rom.u3", 0x010000, 0x20000, CRC(d4551195) SHA1(e8908fbe4339fb8c93f7e74113dfd25dda1667ea) )
 	ROM_RELOAD(                                         0x030000, 0x20000 )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "l1_nba_jam_tournament_u12_sound_rom.u12", 0x000000, 0x80000, CRC(4fac97bc) SHA1(bd88d8c3edab0e35ad9f9350bcbaa17cda61d87a) )
 	ROM_LOAD( "l1_nba_jam_tournament_u13_sound_rom.u13", 0x080000, 0x80000, CRC(6f27b202) SHA1(c1f0db15624d1e7102ce9fd1db49ccf86e8611d6) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l1_nba_jam_tournament_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(a9f555ad) SHA1(34f5fc1b003ef8acbb2b38fbacd58d018d20ab1b) )
 	ROM_LOAD16_BYTE( "l1_nba_jam_tournament_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(bd4579b5) SHA1(c893cff931f1e60a1d0d29d2719f514d92fb3490) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug14.ug14", 0x000000, 0x80000, CRC(04bb9f64) SHA1(9e1a8c37e14cb6fe67f4aa3caa9022f356f1ca64) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_uj14.uj14", 0x000001, 0x80000, CRC(b34b7af3) SHA1(0abb74d2f414bc9da0380a81beb134f3a87c1a0a) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug19.ug19", 0x000002, 0x80000, CRC(a8f22fbb) SHA1(514208a9d6d0c8c2d7847cc02d4387eac90be659) )
@@ -1678,19 +1698,19 @@ ROM_END
 // romset contained only the program ROMs and PCB pics are available, so ideally every other one should be checked if another PCB ever shows up
 // not marking them as BAD_DUMP as they pass the ROM test
 ROM_START( nbajamtep2 )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) // sound CPU
 	ROM_LOAD(  "l1_nba_jam_tournament_u3_sound_rom.u3", 0x010000, 0x20000, CRC(d4551195) SHA1(e8908fbe4339fb8c93f7e74113dfd25dda1667ea) )
 	ROM_RELOAD(                                         0x030000, 0x20000 )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "l1_nba_jam_tournament_u12_sound_rom.u12", 0x000000, 0x80000, CRC(4fac97bc) SHA1(bd88d8c3edab0e35ad9f9350bcbaa17cda61d87a) )
 	ROM_LOAD( "l1_nba_jam_tournament_u13_sound_rom.u13", 0x080000, 0x80000, CRC(6f27b202) SHA1(c1f0db15624d1e7102ce9fd1db49ccf86e8611d6) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "p2_nba_jam_tournament_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(f90f7450) SHA1(ecc2b801edd1e0529fe0e52471b7876f748cf296) )
 	ROM_LOAD16_BYTE( "p2_nba_jam_tournament_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(a0d9d49a) SHA1(8fac949b9707d821e35ad2f2decb67b5bab28b40) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug14.ug14", 0x000000, 0x80000, CRC(04bb9f64) SHA1(9e1a8c37e14cb6fe67f4aa3caa9022f356f1ca64) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_uj14.uj14", 0x000001, 0x80000, CRC(b34b7af3) SHA1(0abb74d2f414bc9da0380a81beb134f3a87c1a0a) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug19.ug19", 0x000002, 0x80000, CRC(a8f22fbb) SHA1(514208a9d6d0c8c2d7847cc02d4387eac90be659) )
@@ -1714,19 +1734,19 @@ ROM_END
 
 
 ROM_START( nbajamten )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) // sound CPU
 	ROM_LOAD(  "l1_nba_jam_tournament_u3_sound_rom.u3", 0x010000, 0x20000, CRC(d4551195) SHA1(e8908fbe4339fb8c93f7e74113dfd25dda1667ea) )
 	ROM_RELOAD(                                         0x030000, 0x20000 )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "l1_nba_jam_tournament_u12_sound_rom.u12", 0x000000, 0x80000, CRC(4fac97bc) SHA1(bd88d8c3edab0e35ad9f9350bcbaa17cda61d87a) )
 	ROM_LOAD( "l1_nba_jam_tournament_u13_sound_rom.u13", 0x080000, 0x80000, CRC(6f27b202) SHA1(c1f0db15624d1e7102ce9fd1db49ccf86e8611d6) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "nani-uj12.bin", 0x00000, 0x80000, CRC(a2662e74) SHA1(7a6c18464446baf3d279013eb95bf862b5b3be70) )
 	ROM_LOAD16_BYTE( "nani-ug12.bin", 0x00001, 0x80000, CRC(40cda5b1) SHA1(2ff51f830aa86f6456c626666e221be1f7bfbfa2) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug14.ug14", 0x000000, 0x80000, CRC(04bb9f64) SHA1(9e1a8c37e14cb6fe67f4aa3caa9022f356f1ca64) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_uj14.uj14", 0x000001, 0x80000, CRC(b34b7af3) SHA1(0abb74d2f414bc9da0380a81beb134f3a87c1a0a) )
 	ROM_LOAD32_BYTE( "l1_nba_jam_tournament_game_rom_ug19.ug19", 0x000002, 0x80000, CRC(a8f22fbb) SHA1(514208a9d6d0c8c2d7847cc02d4387eac90be659) )
@@ -1750,19 +1770,19 @@ ROM_END
 
 
 ROM_START( jdreddp )
-	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) /* sound CPU */
+	ROM_REGION( 0x50000, "adpcm:cpu", 0 ) // sound CPU
 	ROM_LOAD(  "t1_judge_dredd_sound_rom_u3.u3", 0x010000, 0x20000, CRC(6154d108) SHA1(54328455ec22ba815de85aa3bfe6405353c64f5c) )
 	ROM_RELOAD(                                  0x030000, 0x20000 )
 
-	ROM_REGION( 0x100000, "adpcm:oki", 0 )  /* ADPCM */
+	ROM_REGION( 0x100000, "adpcm:oki", 0 )  // ADPCM
 	ROM_LOAD( "t1_judge_dredd_sound_rom_u12.u12", 0x000000, 0x80000, CRC(ef32f202) SHA1(16aea085e63496dec259291de1a64fbeab52f039) )
 	ROM_LOAD( "t1_judge_dredd_sound_rom_u13.u13", 0x080000, 0x80000, CRC(3dc70473) SHA1(a3d7210301ff0579889009a075092115d9bf0600) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "t1_judge_dredd_game_rom_uj12.uj12", 0x00000, 0x80000, CRC(7e5c8d5a) SHA1(65c0e887fea01846426067adfc4cf60dce4a1e24) )
 	ROM_LOAD16_BYTE( "t1_judge_dredd_game_rom_ug12.ug12", 0x00001, 0x80000, CRC(a16b8a4a) SHA1(77abb31e7cb3b66c63ef7c1874d8544ae9a02667) )
 
-	ROM_REGION( 0xc00000, "gfxrom", 0 )
+	ROM_REGION( 0xc00000, "video", 0 )
 	ROM_LOAD32_BYTE( "t1_judge_dredd_game_rom_ug14.ug14", 0x000000, 0x80000, CRC(468484d7) SHA1(87e3b87051e3afff097333af90efa0eb4dd61a35) )
 	ROM_LOAD32_BYTE( "t1_judge_dredd_game_rom_uj14.uj14", 0x000001, 0x80000, CRC(fe6ec0ec) SHA1(3e3b1774e1c5cf6629fbd3aeff36cadff1adfbf9) )
 	ROM_LOAD32_BYTE( "t1_judge_dredd_game_rom_ug19.ug19", 0x000002, 0x80000, CRC(e076c08e) SHA1(9b52470feac66b258e62e53dfd6a6a74c1e47ac1) )
@@ -1792,36 +1812,36 @@ ROM_END
  *
  *************************************/
 
-GAME( 1992, mk,         0,        tunit_adpcm, mk,       midtunit_state, init_mktunit,  ROT0, "Midway",   "Mortal Kombat (rev 5.0 T-Unit 03/19/93)", MACHINE_SUPPORTS_SAVE )
-GAME( 1992, mkr4,       mk,       tunit_adpcm, mk,       midtunit_state, init_mktunit,  ROT0, "Midway",   "Mortal Kombat (rev 4.0 T-Unit 02/11/93)", MACHINE_SUPPORTS_SAVE )
-GAME( 1992, mktturbo,   mk,       tunit_adpcm, mk,       midtunit_state, init_mkturbo,  ROT0, "hack",     "Mortal Kombat (Turbo Ninja T-Unit 03/19/93, hack)", MACHINE_SUPPORTS_SAVE )
+GAME( 1992, mk,         0,        tunit_adpcm, mk,       midtunit_adpcm_state, init_mktunit,  ROT0, "Midway",   "Mortal Kombat (rev 5.0 T-Unit 03/19/93)", MACHINE_SUPPORTS_SAVE )
+GAME( 1992, mkr4,       mk,       tunit_adpcm, mk,       midtunit_adpcm_state, init_mktunit,  ROT0, "Midway",   "Mortal Kombat (rev 4.0 T-Unit 02/11/93)", MACHINE_SUPPORTS_SAVE )
+GAME( 1992, mktturbo,   mk,       tunit_adpcm, mk,       midtunit_adpcm_state, init_mkturbo,  ROT0, "hack",     "Mortal Kombat (Turbo Ninja T-Unit 03/19/93, hack)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1993, mk2,        0,        tunit_dcs,   mk2,      midtunit_state, init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L3.1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, mk2r32e,    mk2,      tunit_dcs,   mk2,      midtunit_state, init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L3.2, European)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, mk2r31e,    mk2,      tunit_dcs,   mk2,      midtunit_state, init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L3.1, European)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, mk2r30,     mk2,      tunit_dcs,   mk2,      midtunit_state, init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L3.0)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, mk2r21,     mk2,      tunit_dcs,   mk2,      midtunit_state, init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L2.1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, mk2r20,     mk2,      tunit_dcs,   mk2,      midtunit_state, init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L2.0)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, mk2r14,     mk2,      tunit_dcs,   mk2,      midtunit_state, init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L1.4)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, mk2r11,     mk2,      tunit_dcs,   mk2,      midtunit_state, init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L1.1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, mk2r42,     mk2,      tunit_dcs,   mk2,      midtunit_state, init_mk2,      ROT0, "hack",     "Mortal Kombat II (rev L4.2, hack)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, mk2r91,     mk2,      tunit_dcs,   mk2,      midtunit_state, init_mk2,      ROT0, "hack",     "Mortal Kombat II (rev L9.1, hack)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, mk2chal,    mk2,      tunit_dcs,   mk2,      midtunit_state, init_mk2,      ROT0, "hack",     "Mortal Kombat II Challenger (hack)", MACHINE_SUPPORTS_SAVE ) // program ROMs labeled as IMMORTAL KOMBAT II
+GAME( 1993, mk2,        0,        mk2,         mk2,      mk2_state,            init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L3.1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, mk2r32e,    mk2,      mk2,         mk2,      mk2_state,            init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L3.2, European)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, mk2r31e,    mk2,      mk2,         mk2,      mk2_state,            init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L3.1, European)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, mk2r30,     mk2,      mk2,         mk2,      mk2_state,            init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L3.0)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, mk2r21,     mk2,      mk2,         mk2,      mk2_state,            init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L2.1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, mk2r20,     mk2,      mk2,         mk2,      mk2_state,            init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L2.0)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, mk2r14,     mk2,      mk2,         mk2,      mk2_state,            init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L1.4)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, mk2r11,     mk2,      mk2,         mk2,      mk2_state,            init_mk2,      ROT0, "Midway",   "Mortal Kombat II (rev L1.1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, mk2r42,     mk2,      mk2,         mk2,      mk2_state,            init_mk2,      ROT0, "hack",     "Mortal Kombat II (rev L4.2, hack)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, mk2r91,     mk2,      mk2,         mk2,      mk2_state,            init_mk2,      ROT0, "hack",     "Mortal Kombat II (rev L9.1, hack)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, mk2chal,    mk2,      mk2,         mk2,      mk2_state,            init_mk2,      ROT0, "hack",     "Mortal Kombat II Challenger (hack)", MACHINE_SUPPORTS_SAVE ) // program ROMs labeled as IMMORTAL KOMBAT II
 
-GAME( 1993, jdreddp,    0,        tunit_adpcm, jdreddp,  midtunit_state, init_jdreddp,  ROT0, "Midway",   "Judge Dredd (rev TA1 7/12/92, location test)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, jdreddp,    0,        tunit_adpcm, jdreddp,  midtunit_adpcm_state, init_jdreddp,  ROT0, "Midway",   "Judge Dredd (rev TA1 7/12/92, location test)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1993, nbajam,     0,        tunit_adpcm, nbajam,   midtunit_state, init_nbajam,   ROT0, "Midway",   "NBA Jam (rev 3.01 4/07/93)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, nbajamr2,   nbajam,   tunit_adpcm, nbajam,   midtunit_state, init_nbajam,   ROT0, "Midway",   "NBA Jam (rev 2.00 2/10/93)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, nbajamr1,   nbajam,   tunit_adpcm, nbajam,   midtunit_state, init_nbajam,   ROT0, "Midway",   "NBA Jam (rev 1.00 2/1/93)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, nbajamp2,   nbajam,   tunit_adpcm, nbajam,   midtunit_state, init_nbajam,   ROT0, "Midway",   "NBA Jam (proto v 2.00 1/24/93)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, nbajamp1,   nbajam,   tunit_adpcm, nbajam,   midtunit_state, init_nbajam,   ROT0, "Midway",   "NBA Jam (proto v 1.01 1/23/93)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, nbajam,     0,        tunit_adpcm, nbajam,   midtunit_adpcm_state, init_nbajam,   ROT0, "Midway",   "NBA Jam (rev 3.01 4/07/93)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, nbajamr2,   nbajam,   tunit_adpcm, nbajam,   midtunit_adpcm_state, init_nbajam,   ROT0, "Midway",   "NBA Jam (rev 2.00 2/10/93)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, nbajamr1,   nbajam,   tunit_adpcm, nbajam,   midtunit_adpcm_state, init_nbajam,   ROT0, "Midway",   "NBA Jam (rev 1.00 2/1/93)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, nbajamp2,   nbajam,   tunit_adpcm, nbajam,   midtunit_adpcm_state, init_nbajam,   ROT0, "Midway",   "NBA Jam (proto v 2.00 1/24/93)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, nbajamp1,   nbajam,   tunit_adpcm, nbajam,   midtunit_adpcm_state, init_nbajam,   ROT0, "Midway",   "NBA Jam (proto v 1.01 1/23/93)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1994, nbajamte,   0,        tunit_adpcm, nbajamte, midtunit_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (rev 4.0 3/23/94)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, nbajamte4,  nbajamte, tunit_adpcm, nbajamte, midtunit_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (rev 4.0 3/03/94)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, nbajamte3,  nbajamte, tunit_adpcm, nbajamte, midtunit_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (rev 3.0 3/04/94)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, nbajamte3a, nbajamte, tunit_adpcm, nbajamte, midtunit_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (rev 3.0 2/26/94)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, nbajamte2,  nbajamte, tunit_adpcm, nbajamte, midtunit_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (rev 2.1 2/06/94)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, nbajamte2a, nbajamte, tunit_adpcm, nbajamte, midtunit_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (rev 2.0 1/28/94)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, nbajamte1,  nbajamte, tunit_adpcm, nbajamte, midtunit_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (rev 1.00 1/17/94)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, nbajamtep2, nbajamte, tunit_adpcm, nbajamte, midtunit_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (proto 2.00 12/17/93)", MACHINE_SUPPORTS_SAVE )
-GAME( 1995, nbajamten,  nbajamte, tunit_adpcm, nbajamte, midtunit_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (Nani Edition, rev 5.2 8/11/95, prototype)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, nbajamte,   0,        tunit_adpcm, nbajamte, midtunit_adpcm_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (rev 4.0 3/23/94)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, nbajamte4,  nbajamte, tunit_adpcm, nbajamte, midtunit_adpcm_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (rev 4.0 3/03/94)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, nbajamte3,  nbajamte, tunit_adpcm, nbajamte, midtunit_adpcm_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (rev 3.0 3/04/94)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, nbajamte3a, nbajamte, tunit_adpcm, nbajamte, midtunit_adpcm_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (rev 3.0 2/26/94)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, nbajamte2,  nbajamte, tunit_adpcm, nbajamte, midtunit_adpcm_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (rev 2.1 2/06/94)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, nbajamte2a, nbajamte, tunit_adpcm, nbajamte, midtunit_adpcm_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (rev 2.0 1/28/94)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, nbajamte1,  nbajamte, tunit_adpcm, nbajamte, midtunit_adpcm_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (rev 1.00 1/17/94)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, nbajamtep2, nbajamte, tunit_adpcm, nbajamte, midtunit_adpcm_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (proto 2.00 12/17/93)", MACHINE_SUPPORTS_SAVE )
+GAME( 1995, nbajamten,  nbajamte, tunit_adpcm, nbajamte, midtunit_adpcm_state, init_nbajamte, ROT0, "Midway",   "NBA Jam Tournament Edition (Nani Edition, rev 5.2 8/11/95, prototype)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/midway/midtunit.h
+++ b/src/mame/midway/midtunit.h
@@ -21,79 +21,79 @@
 #include "emupal.h"
 
 
-class midtunit_state : public driver_device
+class midtunit_base_state : public driver_device
 {
-public:
-	midtunit_state(const machine_config &mconfig, device_type type, const char *tag) :
+protected:
+	midtunit_base_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
 		m_video(*this, "video"),
-		m_dcs(*this, "dcs"),
 		m_palette(*this, "palette"),
-		m_gfxrom(*this, "gfxrom"),
-		m_cvsd_sound(*this, "cvsd"),
-		m_adpcm_sound(*this, "adpcm"),
 		m_nvram(*this, "nvram")
 	{ }
 
 	void tunit_core(machine_config &config);
+
+	void machine_start() override;
+
+	required_device<tms340x0_device> m_maincpu;
+	required_device<midtunit_video_device> m_video;
+	required_device<palette_device> m_palette;
+
+	required_shared_ptr<uint16_t> m_nvram;
+
+	void cmos_enable_w(uint16_t data);
+	void cmos_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	uint16_t cmos_r(offs_t offset);
+
+	// CMOS-related variables
+	uint8_t    m_cmos_write_enable = 0;
+
+	void main_map(address_map &map);
+};
+
+class midtunit_adpcm_state : public midtunit_base_state
+{
+public:
+	midtunit_adpcm_state(const machine_config &mconfig, device_type type, const char *tag) :
+		midtunit_base_state(mconfig, type, tag),
+		m_adpcm_sound(*this, "adpcm")
+	{ }
+
 	void tunit_adpcm(machine_config &config);
-	void tunit_dcs(machine_config &config);
 
 	void init_mktunit();
 	void init_mkturbo();
 	void init_nbajamte();
 	void init_nbajam();
 	void init_jdreddp();
-	void init_mk2();
 
 protected:
+	void machine_start() override;
 	void machine_reset() override;
 
-	required_device<tms340x0_device> m_maincpu;
-	required_device<midtunit_video_device> m_video;
-	optional_device<dcs_audio_device> m_dcs;
-	required_device<palette_device> m_palette;
-	required_memory_region m_gfxrom;
-
 private:
-	optional_device<williams_cvsd_sound_device> m_cvsd_sound;
-	optional_device<williams_adpcm_sound_device> m_adpcm_sound;
+	required_device<williams_adpcm_sound_device> m_adpcm_sound;
 
-	required_shared_ptr<uint16_t> m_nvram;
+	uint16_t sound_state_r();
+	uint16_t sound_r();
+	void sound_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 
-	void midtunit_cmos_enable_w(uint16_t data);
-	void midtunit_cmos_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t midtunit_cmos_r(offs_t offset);
-	uint16_t midtunit_sound_state_r();
-	uint16_t midtunit_sound_r();
-	void midtunit_sound_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	uint16_t mk_prot_r(offs_t offset);
 	void mk_prot_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	uint16_t mkturbo_prot_r();
-	uint16_t mk2_prot_const_r();
-	uint16_t mk2_prot_r();
-	uint16_t mk2_prot_shift_r();
-	void mk2_prot_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	uint16_t nbajam_prot_r();
 	void nbajam_prot_w(offs_t offset, uint16_t data);
 	void jdredd_prot_w(offs_t offset, uint16_t data);
 	uint16_t jdredd_prot_r(offs_t offset);
 
-	void register_state_saving();
-	void init_tunit_generic(int sound);
 	void init_nbajam_common(int te_protection);
 
-	/* CMOS-related variables */
-	uint8_t    m_cmos_write_enable = 0;
-
-	/* sound-related variables */
-	uint8_t    m_chip_type = 0;
+	// sound-related variables
 	uint8_t    m_fake_sound_state = 0;
 
-	/* protection */
+	// protection
 	uint8_t    m_mk_prot_index = 0;
-	uint16_t   m_mk2_prot_data = 0;
 	std::unique_ptr<uint8_t[]> m_hidden_ram;
 
 	const uint32_t *m_nbajam_prot_table = nullptr;
@@ -104,7 +104,41 @@ private:
 	uint8_t    m_jdredd_prot_index = 0;
 	uint8_t    m_jdredd_prot_max = 0;
 
-	void main_map(address_map &map);
+	void main_adpcm_map(address_map &map);
+};
+
+class mk2_state : public midtunit_base_state
+{
+public:
+	mk2_state(const machine_config &mconfig, device_type type, const char *tag) :
+		midtunit_base_state(mconfig, type, tag),
+		m_dcs(*this, "dcs")
+	{ }
+
+	void mk2(machine_config &config);
+
+	void init_mk2();
+
+protected:
+	void machine_start() override;
+	void machine_reset() override;
+
+private:
+	required_device<dcs_audio_device> m_dcs;
+
+	uint16_t dcs_state_r();
+	uint16_t dcs_r();
+	void dcs_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+
+	uint16_t mk2_prot_const_r();
+	uint16_t mk2_prot_r();
+	uint16_t mk2_prot_shift_r();
+	void mk2_prot_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+
+	// protection
+	uint16_t   m_mk2_prot_data = 0;
+
+	void mk2_map(address_map &map);
 };
 
 #endif // MAME_MIDWAY_MIDTUNIT_H

--- a/src/mame/midway/midtunit.h
+++ b/src/mame/midway/midtunit.h
@@ -36,20 +36,20 @@ protected:
 
 	void machine_start() override;
 
+	void cmos_enable_w(uint16_t data);
+	void cmos_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	uint16_t cmos_r(offs_t offset);
+
+	void main_map(address_map &map);
+
 	required_device<tms340x0_device> m_maincpu;
 	required_device<midtunit_video_device> m_video;
 	required_device<palette_device> m_palette;
 
 	required_shared_ptr<uint16_t> m_nvram;
 
-	void cmos_enable_w(uint16_t data);
-	void cmos_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t cmos_r(offs_t offset);
-
 	// CMOS-related variables
 	uint8_t    m_cmos_write_enable = 0;
-
-	void main_map(address_map &map);
 };
 
 class midtunit_adpcm_state : public midtunit_base_state
@@ -73,8 +73,6 @@ protected:
 	void machine_reset() override;
 
 private:
-	required_device<williams_adpcm_sound_device> m_adpcm_sound;
-
 	uint16_t sound_state_r();
 	uint16_t sound_r();
 	void sound_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
@@ -88,6 +86,10 @@ private:
 	uint16_t jdredd_prot_r(offs_t offset);
 
 	void init_nbajam_common(int te_protection);
+
+	void main_adpcm_map(address_map &map);
+
+	required_device<williams_adpcm_sound_device> m_adpcm_sound;
 
 	// sound-related variables
 	uint8_t    m_fake_sound_state = 0;
@@ -103,8 +105,6 @@ private:
 	const uint8_t *m_jdredd_prot_table = nullptr;
 	uint8_t    m_jdredd_prot_index = 0;
 	uint8_t    m_jdredd_prot_max = 0;
-
-	void main_adpcm_map(address_map &map);
 };
 
 class mk2_state : public midtunit_base_state
@@ -124,8 +124,6 @@ protected:
 	void machine_reset() override;
 
 private:
-	required_device<dcs_audio_device> m_dcs;
-
 	uint16_t dcs_state_r();
 	uint16_t dcs_r();
 	void dcs_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
@@ -135,10 +133,12 @@ private:
 	uint16_t mk2_prot_shift_r();
 	void mk2_prot_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 
+	void mk2_map(address_map &map);
+
+	required_device<dcs_audio_device> m_dcs;
+
 	// protection
 	uint16_t   m_mk2_prot_data = 0;
-
-	void mk2_map(address_map &map);
 };
 
 #endif // MAME_MIDWAY_MIDTUNIT_H

--- a/src/mame/midway/midtunit_m.cpp
+++ b/src/mame/midway/midtunit_m.cpp
@@ -8,9 +8,11 @@
 **************************************************************************/
 
 #include "emu.h"
-#include "cpu/tms34010/tms34010.h"
-#include "cpu/m6809/m6809.h"
 #include "midtunit.h"
+
+#include "cpu/m6809/m6809.h"
+#include "cpu/tms34010/tms34010.h"
+
 
 #define LOG_PROT    (1U << 1)
 #define LOG_CMOS    (1U << 2)
@@ -498,6 +500,8 @@ void mk2_state::init_mk2()
 
 void midtunit_adpcm_state::machine_reset()
 {
+	midtunit_base_state::machine_reset();
+
 	// reset sound
 	m_adpcm_sound->reset_write(1);
 	m_adpcm_sound->reset_write(0);
@@ -505,6 +509,8 @@ void midtunit_adpcm_state::machine_reset()
 
 void mk2_state::machine_reset()
 {
+	midtunit_base_state::machine_reset();
+
 	// reset sound
 	m_dcs->reset_w(0);
 	m_dcs->reset_w(1);
@@ -522,13 +528,11 @@ uint16_t midtunit_adpcm_state::sound_state_r()
 {
 //  LOGSOUND("%s:Sound status read\n", machine().describe_context());
 
-	if (!machine().side_effects_disabled())
+	if (m_fake_sound_state)
 	{
-		if (m_fake_sound_state)
-		{
+		if (!machine().side_effects_disabled())
 			m_fake_sound_state--;
-			return 0;
-		}
+		return 0;
 	}
 	return ~0;
 }

--- a/src/mame/midway/midtunit_m.cpp
+++ b/src/mame/midway/midtunit_m.cpp
@@ -12,11 +12,18 @@
 #include "cpu/m6809/m6809.h"
 #include "midtunit.h"
 
+#define LOG_PROT    (1U << 1)
+#define LOG_CMOS    (1U << 2)
+#define LOG_SOUND   (1U << 3)
 
-/* constant definitions */
-#define SOUND_ADPCM                 1
-#define SOUND_ADPCM_LARGE           2
-#define SOUND_DCS                   3
+#define LOG_ALL     (LOG_PROT | LOG_CMOS | LOG_SOUND)
+
+#define VERBOSE (0)
+#include "logmacro.h"
+
+#define LOGPROT(...)  LOGMASKED(LOG_PROT,  __VA_ARGS__)
+#define LOGCMOS(...)  LOGMASKED(LOG_CMOS,  __VA_ARGS__)
+#define LOGSOUND(...) LOGMASKED(LOG_SOUND, __VA_ARGS__)
 
 
 /*************************************
@@ -25,16 +32,31 @@
  *
  *************************************/
 
-void midtunit_state::register_state_saving()
+void midtunit_base_state::machine_start()
 {
+	// register for state saving
 	save_item(NAME(m_cmos_write_enable));
+}
+
+void midtunit_adpcm_state::machine_start()
+{
+	midtunit_base_state::machine_start();
+
+	// register for state saving
 	save_item(NAME(m_fake_sound_state));
 	save_item(NAME(m_mk_prot_index));
-	save_item(NAME(m_mk2_prot_data));
 	save_item(NAME(m_nbajam_prot_queue));
 	save_item(NAME(m_nbajam_prot_index));
 	save_item(NAME(m_jdredd_prot_index));
 	save_item(NAME(m_jdredd_prot_max));
+}
+
+void mk2_state::machine_start()
+{
+	midtunit_base_state::machine_start();
+
+	// register for state saving
+	save_item(NAME(m_mk2_prot_data));
 }
 
 
@@ -45,28 +67,28 @@ void midtunit_state::register_state_saving()
  *
  *************************************/
 
-void midtunit_state::midtunit_cmos_enable_w(uint16_t data)
+void midtunit_base_state::cmos_enable_w(uint16_t data)
 {
 	m_cmos_write_enable = 1;
 }
 
 
-void midtunit_state::midtunit_cmos_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void midtunit_base_state::cmos_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	if (1)/*m_cmos_write_enable*/
+	if (1)// m_cmos_write_enable
 	{
 		COMBINE_DATA(m_nvram+offset);
 		m_cmos_write_enable = 0;
 	}
 	else
 	{
-		logerror("%08X:Unexpected CMOS W @ %05X\n", m_maincpu->pc(), offset);
+		LOGCMOS("%08X:Unexpected CMOS W @ %05X\n", m_maincpu->pc(), offset);
 		popmessage("Bad CMOS write");
 	}
 }
 
 
-uint16_t midtunit_state::midtunit_cmos_r(offs_t offset)
+uint16_t midtunit_base_state::cmos_r(offs_t offset)
 {
 	return m_nvram[offset];
 }
@@ -90,28 +112,34 @@ static const uint8_t mk_prot_values[] =
 	0xff
 };
 
-uint16_t midtunit_state::mk_prot_r(offs_t offset)
+uint16_t midtunit_adpcm_state::mk_prot_r(offs_t offset)
 {
-	logerror("%s:Protection R @ %05X = %04X\n", machine().describe_context(), offset, mk_prot_values[m_mk_prot_index] << 9);
+	if (!machine().side_effects_disabled())
+		LOGPROT("%s:Protection R @ %05X = %04X\n", machine().describe_context(), offset, mk_prot_values[m_mk_prot_index] << 9);
 
-	/* just in case */
+	// just in case
 	if (m_mk_prot_index >= sizeof(mk_prot_values))
 	{
-		logerror("%s:Unexpected protection R @ %05X\n", machine().describe_context(), offset);
+		if (!machine().side_effects_disabled())
+			LOGPROT("%s:Unexpected protection R @ %05X\n", machine().describe_context(), offset);
 		m_mk_prot_index = 0;
 	}
 
-	return mk_prot_values[m_mk_prot_index++] << 9;
+	uint16_t const result = mk_prot_values[m_mk_prot_index] << 9;
+	if (!machine().side_effects_disabled())
+		m_mk_prot_index++;
+
+	return result;
 }
 
-void midtunit_state::mk_prot_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void midtunit_adpcm_state::mk_prot_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	if (ACCESSING_BITS_8_15)
 	{
-		int first_val = (data >> 9) & 0x3f;
+		int const first_val = (data >> 9) & 0x3f;
 		int i;
 
-		/* find the desired first value and stop then */
+		// find the desired first value and stop then
 		for (i = 0; i < sizeof(mk_prot_values); i++)
 			if (mk_prot_values[i] == first_val)
 			{
@@ -119,14 +147,14 @@ void midtunit_state::mk_prot_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 				break;
 			}
 
-		/* just in case */
+		// just in case
 		if (i == sizeof(mk_prot_values))
 		{
-			logerror("%s:Unhandled protection W @ %05X = %04X\n", machine().describe_context(), offset, data);
+			LOGPROT("%s:Unhandled protection W @ %05X = %04X\n", machine().describe_context(), offset, data);
 			m_mk_prot_index = 0;
 		}
 
-		logerror("%s:Protection W @ %05X = %04X\n", machine().describe_context(), offset, data);
+		LOGPROT("%s:Protection W @ %05X = %04X\n", machine().describe_context(), offset, data);
 	}
 }
 
@@ -138,10 +166,10 @@ void midtunit_state::mk_prot_w(offs_t offset, uint16_t data, uint16_t mem_mask)
  *
  *************************************/
 
-uint16_t midtunit_state::mkturbo_prot_r()
+uint16_t midtunit_adpcm_state::mkturbo_prot_r()
 {
-	/* the security GAL overlays a counter of some sort at 0xfffff400 in ROM &space.
-	 * A startup protection check expects to read back two different values in succession */
+	// the security GAL overlays a counter of some sort at 0xfffff400 in ROM &space.
+	// A startup protection check expects to read back two different values in succession
 	return machine().rand();
 }
 
@@ -153,22 +181,22 @@ uint16_t midtunit_state::mkturbo_prot_r()
  *
  *************************************/
 
-uint16_t midtunit_state::mk2_prot_const_r()
+uint16_t mk2_state::mk2_prot_const_r()
 {
 	return 2;
 }
 
-uint16_t midtunit_state::mk2_prot_r()
+uint16_t mk2_state::mk2_prot_r()
 {
 	return m_mk2_prot_data;
 }
 
-uint16_t midtunit_state::mk2_prot_shift_r()
+uint16_t mk2_state::mk2_prot_shift_r()
 {
 	return m_mk2_prot_data >> 1;
 }
 
-void midtunit_state::mk2_prot_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void mk2_state::mk2_prot_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	COMBINE_DATA(&m_mk2_prot_data);
 }
@@ -221,18 +249,21 @@ static const uint32_t nbajamte_prot_values[128] =
 	0x381c2e17, 0x393c3e3f, 0x3a3d1e0f, 0x3b1d0e27, 0x3c3e1f2f, 0x3d1e0f07, 0x3e1f2f37, 0x3f3f3f1f
 };
 
-uint16_t midtunit_state::nbajam_prot_r()
+uint16_t midtunit_adpcm_state::nbajam_prot_r()
 {
-	int result = m_nbajam_prot_queue[m_nbajam_prot_index];
-	if (m_nbajam_prot_index < 4)
-		m_nbajam_prot_index++;
+	uint16_t const result = m_nbajam_prot_queue[m_nbajam_prot_index];
+	if (!machine().side_effects_disabled())
+	{
+		if (m_nbajam_prot_index < 4)
+			m_nbajam_prot_index++;
+	}
 	return result;
 }
 
-void midtunit_state::nbajam_prot_w(offs_t offset, uint16_t data)
+void midtunit_adpcm_state::nbajam_prot_w(offs_t offset, uint16_t data)
 {
-	int table_index = (offset >> 6) & 0x7f;
-	uint32_t protval = m_nbajam_prot_table[table_index];
+	int const table_index = (offset >> 6) & 0x7f;
+	uint32_t const protval = m_nbajam_prot_table[table_index];
 
 	m_nbajam_prot_queue[0] = data;
 	m_nbajam_prot_queue[1] = ((protval >> 24) & 0xff) << 9;
@@ -292,9 +323,9 @@ static const uint8_t jdredd_prot_values_80020[] =
 	0x39,0x33,0x00,0x00,0x00,0x00,0x00,0x00
 };
 
-void midtunit_state::jdredd_prot_w(offs_t offset, uint16_t data)
+void midtunit_adpcm_state::jdredd_prot_w(offs_t offset, uint16_t data)
 {
-	logerror("%s:jdredd_prot_w(%04X,%04X)\n", machine().describe_context(), offset*16, data);
+	LOGPROT("%s:jdredd_prot_w(%04X,%04X)\n", machine().describe_context(), offset*16, data);
 
 	switch (offset)
 	{
@@ -302,67 +333,54 @@ void midtunit_state::jdredd_prot_w(offs_t offset, uint16_t data)
 			m_jdredd_prot_index = 0;
 			m_jdredd_prot_table = jdredd_prot_values_10740;
 			m_jdredd_prot_max = sizeof(jdredd_prot_values_10740);
-			logerror("-- reset prot table 10740\n");
+			LOGPROT("-- reset prot table 10740\n");
 			break;
 
 		case 0x1324:
 			m_jdredd_prot_index = 0;
 			m_jdredd_prot_table = jdredd_prot_values_13240;
 			m_jdredd_prot_max = sizeof(jdredd_prot_values_13240);
-			logerror("-- reset prot table 13240\n");
+			LOGPROT("-- reset prot table 13240\n");
 			break;
 
 		case 0x7654:
 			m_jdredd_prot_index = 0;
 			m_jdredd_prot_table = jdredd_prot_values_76540;
 			m_jdredd_prot_max = sizeof(jdredd_prot_values_76540);
-			logerror("-- reset prot table 76540\n");
+			LOGPROT("-- reset prot table 76540\n");
 			break;
 
 		case 0x7776:
 			m_jdredd_prot_index = 0;
 			m_jdredd_prot_table = jdredd_prot_values_77760;
 			m_jdredd_prot_max = sizeof(jdredd_prot_values_77760);
-			logerror("-- reset prot table 77760\n");
+			LOGPROT("-- reset prot table 77760\n");
 			break;
 
 		case 0x8002:
 			m_jdredd_prot_index = 0;
 			m_jdredd_prot_table = jdredd_prot_values_80020;
 			m_jdredd_prot_max = sizeof(jdredd_prot_values_80020);
-			logerror("-- reset prot table 80020\n");
+			LOGPROT("-- reset prot table 80020\n");
 			break;
 	}
 }
 
-uint16_t midtunit_state::jdredd_prot_r(offs_t offset)
+uint16_t midtunit_adpcm_state::jdredd_prot_r(offs_t offset)
 {
 	uint16_t result = 0xffff;
 
 	if (m_jdredd_prot_table && m_jdredd_prot_index < m_jdredd_prot_max)
-		result = m_jdredd_prot_table[m_jdredd_prot_index++] << 9;
+	{
+		result = m_jdredd_prot_table[m_jdredd_prot_index] << 9;
+		if (!machine().side_effects_disabled())
+			m_jdredd_prot_index++;
+	}
 
-	logerror("%s:jdredd_prot_r(%04X) = %04X\n", machine().describe_context(), offset*16, result);
+	if (!machine().side_effects_disabled())
+		LOGPROT("%s:jdredd_prot_r(%04X) = %04X\n", machine().describe_context(), offset*16, result);
 	return result;
 }
-
-
-
-/*************************************
- *
- *  Generic driver init
- *
- *************************************/
-
-void midtunit_state::init_tunit_generic(int sound)
-{
-	/* register for state saving */
-	register_state_saving();
-
-	/* load sound ROMs and set up sound handlers */
-	m_chip_type = sound;
-}
-
 
 
 /*************************************
@@ -373,86 +391,78 @@ void midtunit_state::init_tunit_generic(int sound)
  *
  *************************************/
 
-void midtunit_state::init_mktunit()
+void midtunit_adpcm_state::init_mktunit()
 {
-	/* common init */
-	init_tunit_generic(SOUND_ADPCM);
-
-	/* protection */
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x1b00000, 0x1b6ffff, read16sm_delegate(*this, FUNC(midtunit_state::mk_prot_r)));
-	m_maincpu->space(AS_PROGRAM).install_write_handler(0x1b00000, 0x1b6ffff, write16s_delegate(*this, FUNC(midtunit_state::mk_prot_w)));
+	// protection
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x1b00000, 0x1b6ffff, read16sm_delegate(*this, FUNC(midtunit_adpcm_state::mk_prot_r)));
+	m_maincpu->space(AS_PROGRAM).install_write_handler(0x1b00000, 0x1b6ffff, write16s_delegate(*this, FUNC(midtunit_adpcm_state::mk_prot_w)));
 
 	m_hidden_ram = std::make_unique<uint8_t[]>(43);
 	save_pointer(NAME(m_hidden_ram), 43);
 
-	/* sound chip protection (hidden RAM) */
+	// sound chip protection (hidden RAM)
 	m_adpcm_sound->get_cpu()->space(AS_PROGRAM).install_ram(0xfb9c, 0xfbc6, m_hidden_ram.get());
 }
 
-void midtunit_state::init_mkturbo()
+void midtunit_adpcm_state::init_mkturbo()
 {
-	/* protection */
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0xfffff400, 0xfffff40f, read16smo_delegate(*this, FUNC(midtunit_state::mkturbo_prot_r)));
+	// protection
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0xfffff400, 0xfffff40f, read16smo_delegate(*this, FUNC(midtunit_adpcm_state::mkturbo_prot_r)));
 
 	init_mktunit();
 }
 
 
-void midtunit_state::init_nbajam_common(int te_protection)
+void midtunit_adpcm_state::init_nbajam_common(int te_protection)
 {
-	/* common init */
-	init_tunit_generic(SOUND_ADPCM_LARGE);
-	/* protection */
+	// protection
 	if (!te_protection)
 	{
 		m_nbajam_prot_table = nbajam_prot_values;
-		m_maincpu->space(AS_PROGRAM).install_read_handler(0x1b14020, 0x1b2503f, read16smo_delegate(*this, FUNC(midtunit_state::nbajam_prot_r)));
-		m_maincpu->space(AS_PROGRAM).install_write_handler(0x1b14020, 0x1b2503f, write16sm_delegate(*this, FUNC(midtunit_state::nbajam_prot_w)));
+		m_maincpu->space(AS_PROGRAM).install_read_handler(0x1b14020, 0x1b2503f, read16smo_delegate(*this, FUNC(midtunit_adpcm_state::nbajam_prot_r)));
+		m_maincpu->space(AS_PROGRAM).install_write_handler(0x1b14020, 0x1b2503f, write16sm_delegate(*this, FUNC(midtunit_adpcm_state::nbajam_prot_w)));
 	}
 	else
 	{
 		m_nbajam_prot_table = nbajamte_prot_values;
-		m_maincpu->space(AS_PROGRAM).install_read_handler(0x1b15f40, 0x1b37f5f, read16smo_delegate(*this, FUNC(midtunit_state::nbajam_prot_r)));
-		m_maincpu->space(AS_PROGRAM).install_write_handler(0x1b15f40, 0x1b37f5f, write16sm_delegate(*this, FUNC(midtunit_state::nbajam_prot_w)));
-		m_maincpu->space(AS_PROGRAM).install_read_handler(0x1b95f40, 0x1bb7f5f, read16smo_delegate(*this, FUNC(midtunit_state::nbajam_prot_r)));
-		m_maincpu->space(AS_PROGRAM).install_write_handler(0x1b95f40, 0x1bb7f5f, write16sm_delegate(*this, FUNC(midtunit_state::nbajam_prot_w)));
+		m_maincpu->space(AS_PROGRAM).install_read_handler(0x1b15f40, 0x1b37f5f, read16smo_delegate(*this, FUNC(midtunit_adpcm_state::nbajam_prot_r)));
+		m_maincpu->space(AS_PROGRAM).install_write_handler(0x1b15f40, 0x1b37f5f, write16sm_delegate(*this, FUNC(midtunit_adpcm_state::nbajam_prot_w)));
+		m_maincpu->space(AS_PROGRAM).install_read_handler(0x1b95f40, 0x1bb7f5f, read16smo_delegate(*this, FUNC(midtunit_adpcm_state::nbajam_prot_r)));
+		m_maincpu->space(AS_PROGRAM).install_write_handler(0x1b95f40, 0x1bb7f5f, write16sm_delegate(*this, FUNC(midtunit_adpcm_state::nbajam_prot_w)));
 	}
 
 	m_hidden_ram = std::make_unique<uint8_t[]>(43);
 	save_pointer(NAME(m_hidden_ram), 43);
 
-	/* sound chip protection (hidden RAM) */
+	// sound chip protection (hidden RAM)
 	if (!te_protection)
 		m_adpcm_sound->get_cpu()->space(AS_PROGRAM).install_ram(0xfbaa, 0xfbd4, m_hidden_ram.get());
 	else
 		m_adpcm_sound->get_cpu()->space(AS_PROGRAM).install_ram(0xfbec, 0xfc16, m_hidden_ram.get());
 }
 
-void midtunit_state::init_nbajam()
+void midtunit_adpcm_state::init_nbajam()
 {
 	init_nbajam_common(0);
 }
 
-void midtunit_state::init_nbajamte()
+void midtunit_adpcm_state::init_nbajamte()
 {
 	init_nbajam_common(1);
 }
 
-void midtunit_state::init_jdreddp()
+void midtunit_adpcm_state::init_jdreddp()
 {
-	/* common init */
-	init_tunit_generic(SOUND_ADPCM_LARGE);
-
-	/* looks like the watchdog needs to be disabled */
+	// looks like the watchdog needs to be disabled
 	m_maincpu->space(AS_PROGRAM).nop_write(0x01d81060, 0x01d8107f);
 
-	/* protection */
-	m_maincpu->space(AS_PROGRAM).install_readwrite_handler(0x1b00000, 0x1bfffff, read16sm_delegate(*this, FUNC(midtunit_state::jdredd_prot_r)), write16sm_delegate(*this, FUNC(midtunit_state::jdredd_prot_w)));
+	// protection
+	m_maincpu->space(AS_PROGRAM).install_readwrite_handler(0x1b00000, 0x1bfffff, read16sm_delegate(*this, FUNC(midtunit_adpcm_state::jdredd_prot_r)), write16sm_delegate(*this, FUNC(midtunit_adpcm_state::jdredd_prot_w)));
 
 	m_hidden_ram = std::make_unique<uint8_t[]>(43);
 	save_pointer(NAME(m_hidden_ram), 43);
 
-	/* sound chip protection (hidden RAM) */
+	// sound chip protection (hidden RAM)
 	m_adpcm_sound->get_cpu()->space(AS_PROGRAM).install_ram(0xfbcf, 0xfbf9, m_hidden_ram.get());
 }
 
@@ -466,20 +476,16 @@ void midtunit_state::init_jdreddp()
  *
  *************************************/
 
-void midtunit_state::init_mk2()
+void mk2_state::init_mk2()
 {
-	/* common init */
-	init_tunit_generic(SOUND_DCS);
-	m_video->set_gfx_rom_large(true);
-
-	/* protection */
-	m_maincpu->space(AS_PROGRAM).install_write_handler(0x00f20c60, 0x00f20c7f, write16s_delegate(*this, FUNC(midtunit_state::mk2_prot_w)));
-	m_maincpu->space(AS_PROGRAM).install_write_handler(0x00f42820, 0x00f4283f, write16s_delegate(*this, FUNC(midtunit_state::mk2_prot_w)));
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x01a190e0, 0x01a190ff, read16smo_delegate(*this, FUNC(midtunit_state::mk2_prot_r)));
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x01a191c0, 0x01a191df, read16smo_delegate(*this, FUNC(midtunit_state::mk2_prot_shift_r)));
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x01a3d0c0, 0x01a3d0ff, read16smo_delegate(*this, FUNC(midtunit_state::mk2_prot_r)));
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x01d9d1e0, 0x01d9d1ff, read16smo_delegate(*this, FUNC(midtunit_state::mk2_prot_const_r)));
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x01def920, 0x01def93f, read16smo_delegate(*this, FUNC(midtunit_state::mk2_prot_const_r)));
+	// protection
+	m_maincpu->space(AS_PROGRAM).install_write_handler(0x00f20c60, 0x00f20c7f, write16s_delegate(*this, FUNC(mk2_state::mk2_prot_w)));
+	m_maincpu->space(AS_PROGRAM).install_write_handler(0x00f42820, 0x00f4283f, write16s_delegate(*this, FUNC(mk2_state::mk2_prot_w)));
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x01a190e0, 0x01a190ff, read16smo_delegate(*this, FUNC(mk2_state::mk2_prot_r)));
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x01a191c0, 0x01a191df, read16smo_delegate(*this, FUNC(mk2_state::mk2_prot_shift_r)));
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x01a3d0c0, 0x01a3d0ff, read16smo_delegate(*this, FUNC(mk2_state::mk2_prot_r)));
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x01d9d1e0, 0x01d9d1ff, read16smo_delegate(*this, FUNC(mk2_state::mk2_prot_const_r)));
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x01def920, 0x01def93f, read16smo_delegate(*this, FUNC(mk2_state::mk2_prot_const_r)));
 }
 
 
@@ -490,22 +496,18 @@ void midtunit_state::init_mk2()
  *
  *************************************/
 
-void midtunit_state::machine_reset()
+void midtunit_adpcm_state::machine_reset()
 {
-	/* reset sound */
-	switch (m_chip_type)
-	{
-		case SOUND_ADPCM:
-		case SOUND_ADPCM_LARGE:
-			m_adpcm_sound->reset_write(1);
-			m_adpcm_sound->reset_write(0);
-			break;
+	// reset sound
+	m_adpcm_sound->reset_write(1);
+	m_adpcm_sound->reset_write(0);
+}
 
-		case SOUND_DCS:
-			m_dcs->reset_w(0);
-			m_dcs->reset_w(1);
-			break;
-	}
+void mk2_state::machine_reset()
+{
+	// reset sound
+	m_dcs->reset_w(0);
+	m_dcs->reset_w(1);
 }
 
 
@@ -516,59 +518,78 @@ void midtunit_state::machine_reset()
  *
  *************************************/
 
-uint16_t midtunit_state::midtunit_sound_state_r()
+uint16_t midtunit_adpcm_state::sound_state_r()
 {
-/*  logerror("%s:Sound status read\n", machine().describe_context());*/
+//  LOGSOUND("%s:Sound status read\n", machine().describe_context());
 
-	if (m_chip_type == SOUND_DCS)
-		return m_dcs->control_r() >> 4;
-
-	if (m_fake_sound_state)
+	if (!machine().side_effects_disabled())
 	{
-		m_fake_sound_state--;
-		return 0;
+		if (m_fake_sound_state)
+		{
+			m_fake_sound_state--;
+			return 0;
+		}
 	}
 	return ~0;
 }
 
-uint16_t midtunit_state::midtunit_sound_r()
+uint16_t midtunit_adpcm_state::sound_r()
 {
-	logerror("%08X:Sound data read\n", m_maincpu->pc());
-
-	if (m_chip_type == SOUND_DCS)
-		return m_dcs->data_r() & 0xff;
+	if (!machine().side_effects_disabled())
+		LOGSOUND("%08X:Sound data read\n", m_maincpu->pc());
 
 	return ~0;
 }
 
-void midtunit_state::midtunit_sound_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void midtunit_adpcm_state::sound_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	/* check for out-of-bounds accesses */
+	// check for out-of-bounds accesses
 	if (!offset)
 	{
-		logerror("%08X:Unexpected write to sound (lo) = %04X\n", m_maincpu->pc(), data);
+		LOGSOUND("%08X:Unexpected write to sound (lo) = %04X\n", m_maincpu->pc(), data);
 		return;
 	}
 
-	/* call through based on the sound type */
+	// call through based on the sound type
 	if (ACCESSING_BITS_0_7 && ACCESSING_BITS_8_15)
-		switch (m_chip_type)
-		{
-			case SOUND_ADPCM:
-			case SOUND_ADPCM_LARGE:
-				m_adpcm_sound->reset_write(~data & 0x100);
-				m_adpcm_sound->write(data & 0xff);
+	{
+		m_adpcm_sound->reset_write(~data & 0x100);
+		m_adpcm_sound->write(data & 0xff);
 
-				/* the games seem to check for $82 loops, so this should be just barely enough */
-				m_fake_sound_state = 128;
-				break;
+		// the games seem to check for $82 loops, so this should be just barely enough
+		m_fake_sound_state = 128;
+	}
+}
 
-			case SOUND_DCS:
-				logerror("%08X:Sound write = %04X\n", m_maincpu->pc(), data);
-				m_dcs->reset_w(data & 0x100);
-				m_dcs->data_w(data & 0xff);
-				/* the games seem to check for $82 loops, so this should be just barely enough */
-				m_fake_sound_state = 128;
-				break;
-		}
+uint16_t mk2_state::dcs_state_r()
+{
+//  LOGSOUND("%s:Sound status read\n", machine().describe_context());
+
+	return m_dcs->control_r() >> 4;
+}
+
+uint16_t mk2_state::dcs_r()
+{
+	if (!machine().side_effects_disabled())
+		LOGSOUND("%08X:Sound data read\n", m_maincpu->pc());
+
+	return m_dcs->data_r() & 0xff;
+}
+
+void mk2_state::dcs_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	// check for out-of-bounds accesses
+	if (!offset)
+	{
+		LOGSOUND("%08X:Unexpected write to sound (lo) = %04X\n", m_maincpu->pc(), data);
+		return;
+	}
+
+	// call through based on the sound type
+	if (ACCESSING_BITS_0_7 && ACCESSING_BITS_8_15)
+	{
+		LOGSOUND("%08X:Sound write = %04X\n", m_maincpu->pc(), data);
+		m_dcs->reset_w(data & 0x100);
+		m_dcs->data_w(data & 0xff);
+	}
 }

--- a/src/mame/midway/midtunit_v.cpp
+++ b/src/mame/midway/midtunit_v.cpp
@@ -23,22 +23,40 @@
 #include <rapidjson/prettywriter.h> // Used by JSON logging
 #include <rapidjson/stringbuffer.h> // Used by JSON logging
 
+#include <algorithm>
+
 DEFINE_DEVICE_TYPE(MIDTUNIT_VIDEO, midtunit_video_device, "tunitvid", "Midway T-Unit Video")
 DEFINE_DEVICE_TYPE(MIDWUNIT_VIDEO, midwunit_video_device, "wunitvid", "Midway W-Unit Video")
 DEFINE_DEVICE_TYPE(MIDXUNIT_VIDEO, midxunit_video_device, "xunitvid", "Midway X-Unit Video")
 
-/* compile-time options */
-#define LOG_DMA             0       /* DMAs are logged if the 'L' key is pressed */
+// compile-time options
+#define LOG_DMA             0       // DMAs are logged if the 'L' key is pressed
+
+#define LOG_CTRL    (1U << 1)
+#define LOG_DMACTRL (1U << 2)
+
+#define LOG_ALL     (LOG_CTRL | LOG_DMACTRL)
+
+#define VERBOSE (0)
+#include "logmacro.h"
+
+#define LOGCTRL(...)     LOGMASKED(LOG_CTRL,     __VA_ARGS__)
+#define LOGDMACTRL(...)  LOGMASKED(LOG_DMACTRL,  __VA_ARGS__)
 
 midtunit_video_device::midtunit_video_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, type, tag, owner, clock)
-	, m_maincpu(*this, finder_base::DUMMY_TAG)
 	, m_palette(*this, finder_base::DUMMY_TAG)
-	, m_gfxrom(*this, finder_base::DUMMY_TAG)
+	, m_gfxrom(*this, DEVICE_SELF)
+	, m_midtunit_control(0)
+	, m_gfx_rom_large(false)
+	, m_gfxbank_offset{0x000000, 0x400000}
+	, m_videobank_select(0)
 #if DEBUG_MIDTUNIT_BLITTER
 	, m_debug_palette(*this, "debugpalette")
 #endif
+	, m_dma_irq_cb(*this)
 {
+	std::fill(std::begin(m_dma_register), std::end(m_dma_register), 0);
 }
 
 midtunit_video_device::midtunit_video_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
@@ -49,10 +67,11 @@ midtunit_video_device::midtunit_video_device(const machine_config &mconfig, cons
 midwunit_video_device::midwunit_video_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
 	: midtunit_video_device(mconfig, type, tag, owner, clock)
 {
+	m_gfx_rom_large = true;
 }
 
 midwunit_video_device::midwunit_video_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: midtunit_video_device(mconfig, MIDWUNIT_VIDEO, tag, owner, clock)
+	: midwunit_video_device(mconfig, MIDWUNIT_VIDEO, tag, owner, clock)
 {
 }
 
@@ -171,7 +190,7 @@ void midtunit_video_device::device_start()
 {
 	debug_init();
 
-	/* allocate memory */
+	// allocate memory
 	m_local_videoram = std::make_unique<uint16_t[]>(0x100000/2);
 
 #if DEBUG_MIDTUNIT_BLITTER
@@ -183,15 +202,11 @@ void midtunit_video_device::device_start()
 
 	m_dma_timer = timer_alloc(FUNC(midtunit_video_device::dma_done), this);
 
-	/* reset all the globals */
-	m_gfxbank_offset[0] = 0x000000;
-	m_gfxbank_offset[1] = 0x400000;
-
-	memset(m_dma_register, 0, sizeof(m_dma_register));
+	// reset all the globals
 	memset(&m_dma_state, 0, sizeof(dma_state));
-	m_dma_state.gfxrom = m_gfxrom->base();
+	m_dma_state.gfxrom = &m_gfxrom[0];
 
-	/* register for state saving */
+	// register for state saving
 	save_item(NAME(m_midtunit_control));
 	save_item(NAME(m_gfxbank_offset));
 	save_pointer(NAME(m_local_videoram), 0x100000/sizeof(m_local_videoram[0]));
@@ -202,20 +217,11 @@ void midtunit_video_device::device_start()
 	INIT_TEMPLATED_DMA_DRAW_GROUP(m_dma_draw_noskip_scale,   false, true);
 	INIT_TEMPLATED_DMA_DRAW_GROUP(m_dma_draw_skip_noscale,   true,  false);
 	INIT_TEMPLATED_DMA_DRAW_GROUP(m_dma_draw_noskip_noscale, false, false);
-
-	m_gfx_rom_large = false;
-}
-
-void midwunit_video_device::device_start()
-{
-	midtunit_video_device::device_start();
-	m_gfx_rom_large = true;
 }
 
 void midxunit_video_device::device_start()
 {
-	midtunit_video_device::device_start();
-	m_gfx_rom_large = true;
+	midwunit_video_device::device_start();
 	m_videobank_select = 1;
 }
 
@@ -229,7 +235,7 @@ void midxunit_video_device::device_start()
 
 uint16_t midtunit_video_device::midtunit_gfxrom_r(offs_t offset)
 {
-	uint8_t *base = m_gfxrom->base() + m_gfxbank_offset[(offset >> 21) & 1];
+	uint8_t const *const base = &m_gfxrom[m_gfxbank_offset[(offset >> 21) & 1]];
 	offset = (offset & 0x01fffff) * 2;
 	return base[offset] | (base[offset + 1] << 8);
 }
@@ -237,7 +243,7 @@ uint16_t midtunit_video_device::midtunit_gfxrom_r(offs_t offset)
 
 uint16_t midwunit_video_device::midwunit_gfxrom_r(offs_t offset)
 {
-	uint8_t *base = m_gfxrom->base() + m_gfxbank_offset[0];
+	uint8_t const *const base = &m_gfxrom[m_gfxbank_offset[0]];
 	offset *= 2;
 	return base[offset] | (base[offset + 1] << 8);
 }
@@ -346,17 +352,17 @@ void midtunit_video_device::midtunit_control_w(offs_t offset, uint16_t data, uin
 	    other important bits:
 	        bit 2 (0x0004) is toggled periodically
 	*/
-	logerror("T-unit control = %04X\n", data);
+	LOGCTRL("T-unit control = %04X\n", data);
 
 	COMBINE_DATA(&m_midtunit_control);
 
-	/* gfx bank select is bit 7 */
+	// gfx bank select is bit 7
 	if (!(m_midtunit_control & 0x0080) || !m_gfx_rom_large)
 		m_gfxbank_offset[0] = 0x000000;
 	else
 		m_gfxbank_offset[0] = 0x800000;
 
-	/* video bank select is bit 5 */
+	// video bank select is bit 5
 	m_videobank_select = (m_midtunit_control >> 5) & 1;
 }
 
@@ -367,14 +373,14 @@ void midwunit_video_device::midwunit_control_w(offs_t offset, uint16_t data, uin
 	    other important bits:
 	        bit 2 (0x0004) is toggled periodically
 	*/
-	logerror("Wolf-unit control = %04X\n", data);
+	LOGCTRL("Wolf-unit control = %04X\n", data);
 
 	COMBINE_DATA(&m_midtunit_control);
 
-	/* gfx bank select is bits 8-9 */
+	// gfx bank select is bits 8-9
 	m_gfxbank_offset[0] = 0x800000 * ((m_midtunit_control >> 8) & 3);
 
-	/* video bank select is unknown */
+	// video bank select is unknown
 	m_videobank_select = (m_midtunit_control >> 11) & 1;
 }
 
@@ -425,21 +431,21 @@ uint16_t midxunit_video_device::midxunit_paletteram_r(offs_t offset)
 template <int BitsPerPixel, bool XFlip, bool Skip, bool Scale, midtunit_video_device::op_type_t Zero, midtunit_video_device::op_type_t NonZero>
 void midtunit_video_device::dma_draw()
 {
-	int height = m_dma_state.height << 8;
-	uint8_t *base = m_dma_state.gfxrom;
+	int const height = m_dma_state.height << 8;
+	uint8_t const *const base = m_dma_state.gfxrom;
 	uint32_t offset = m_dma_state.offset;
 	uint16_t pal = m_dma_state.palette;
 	uint16_t color = pal | m_dma_state.color;
 	int sy = m_dma_state.ypos;
 	int iy = 0;
 	int ty;
-	int mask = (1 << BitsPerPixel) - 1;
-	int xstep = Scale ? m_dma_state.xstep : 0x100;
+	int const mask = (1 << BitsPerPixel) - 1;
+	int const xstep = Scale ? m_dma_state.xstep : 0x100;
 
-	/* loop over the height */
+	// loop over the height
 	while (iy < height)
 	{
-		int startskip = m_dma_state.startskip << 8;
+		int const startskip = m_dma_state.startskip << 8;
 		[[maybe_unused]] int endskip = m_dma_state.endskip << 8;
 		int width = m_dma_state.width << 8;
 		int sx = m_dma_state.xpos;
@@ -449,13 +455,13 @@ void midtunit_video_device::dma_draw()
 		int pre, post;
 		uint16_t *d;
 
-		/* handle skipping */
+		// handle skipping
 		if (Skip)
 		{
-			uint8_t value = EXTRACTGEN(0xff);
+			uint8_t const value = EXTRACTGEN(0xff);
 			o += 8;
 
-			/* adjust for preskip */
+			// adjust for preskip
 			pre = (value & 0x0f) << (m_dma_state.preskip + 8);
 			tx = pre / xstep;
 			if (XFlip)
@@ -464,17 +470,17 @@ void midtunit_video_device::dma_draw()
 				sx = (sx + tx) & XPOSMASK;
 			ix += tx * xstep;
 
-			/* adjust for postskip */
+			// adjust for postskip
 			post = ((value >> 4) & 0x0f) << (m_dma_state.postskip + 8);
 			width -= post;
 			endskip -= post;
 		}
 
-		/* handle Y clipping */
+		// handle Y clipping
 		if (sy < m_dma_state.topclip || sy > m_dma_state.botclip)
 			goto clipy;
 
-		/* handle start skip */
+		// handle start skip
 		if (ix < startskip)
 		{
 			tx = ((startskip - ix) / xstep) * xstep;
@@ -482,24 +488,24 @@ void midtunit_video_device::dma_draw()
 			o += (tx >> 8) * BitsPerPixel;
 		}
 
-		/* handle end skip */
+		// handle end skip
 		if ((width >> 8) > m_dma_state.width - m_dma_state.endskip)
 			width = (m_dma_state.width - m_dma_state.endskip) << 8;
 
-		/* determine destination pointer */
+		// determine destination pointer
 #if DEBUG_MIDTUNIT_BLITTER
 		d = m_doing_debug_dma ? &m_debug_videoram[sy * 512] : &m_local_videoram[sy * 512];
 #else
 		d = &m_local_videoram[sy * 512];
 #endif
 
-		/* loop until we draw the entire width */
+		// loop until we draw the entire width
 		while (ix < width)
 		{
-			/* only process if not clipped */
+			// only process if not clipped
 			if (sx >= m_dma_state.leftclip && sx <= m_dma_state.rightclip)
 			{
-				/* special case similar handling of zero/non-zero */
+				// special case similar handling of zero/non-zero
 				if (Zero == NonZero)
 				{
 					if (Zero == PIXEL_COLOR)
@@ -508,12 +514,12 @@ void midtunit_video_device::dma_draw()
 						d[sx] = (EXTRACTGEN(mask)) | pal;
 				}
 
-				/* otherwise, read the pixel and look */
+				// otherwise, read the pixel and look
 				else
 				{
 					int pixel = (EXTRACTGEN(mask));
 
-					/* non-zero pixel case */
+					// non-zero pixel case
 					if (pixel)
 					{
 						if (NonZero == PIXEL_COLOR)
@@ -522,7 +528,7 @@ void midtunit_video_device::dma_draw()
 							d[sx] = pixel | pal;
 					}
 
-					/* zero pixel case */
+					// zero pixel case
 					else
 					{
 						if (Zero == PIXEL_COLOR)
@@ -533,13 +539,13 @@ void midtunit_video_device::dma_draw()
 				}
 			}
 
-			/* update pointers */
+			// update pointers
 			if (XFlip)
 				sx = (sx - 1) & XPOSMASK;
 			else
 				sx = (sx + 1) & XPOSMASK;
 
-			/* advance to the next pixel */
+			// advance to the next pixel
 			if (!Scale)
 			{
 				ix += 0x100;
@@ -555,7 +561,7 @@ void midtunit_video_device::dma_draw()
 		}
 
 	clipy:
-		/* advance to the next row */
+		// advance to the next row
 		if (m_dma_state.yflip)
 			sy = (sy - 1) & YPOSMASK;
 		else
@@ -591,7 +597,7 @@ void midtunit_video_device::dma_draw()
 				if (width > 0) o += width * BitsPerPixel;
 				while (ty--)
 				{
-					uint8_t value = EXTRACTGEN(0xff);
+					uint8_t const value = EXTRACTGEN(0xff);
 					o += 8;
 					pre = (value & 0x0f) << m_dma_state.preskip;
 					post = ((value >> 4) & 0x0f) << m_dma_state.postskip;
@@ -618,8 +624,8 @@ DEFINE_TEMPLATED_DMA_DRAW_GROUP(false, false);
 
 TIMER_CALLBACK_MEMBER(midtunit_video_device::dma_done)
 {
-	m_dma_register[DMA_COMMAND] &= ~0x8000; /* tell the cpu we're done */
-	m_maincpu->set_input_line(0, ASSERT_LINE);
+	m_dma_register[DMA_COMMAND] &= ~0x8000; // tell the cpu we're done
+	m_dma_irq_cb(ASSERT_LINE);
 }
 
 
@@ -630,11 +636,11 @@ TIMER_CALLBACK_MEMBER(midtunit_video_device::dma_done)
  *
  *************************************/
 
-uint16_t midtunit_video_device::midtunit_dma_r(offs_t offset)
+uint16_t midtunit_video_device::dma_r(offs_t offset)
 {
-	/* rmpgwt sometimes reads register 0, expecting it to return the */
-	/* current DMA status; thus we map register 0 to register 1 */
-	/* openice does it as well */
+	// rmpgwt sometimes reads register 0, expecting it to return the
+	// current DMA status; thus we map register 0 to register 1
+	// openice does it as well
 	if (offset == 0)
 		offset = 1;
 	return m_dma_register[offset];
@@ -687,36 +693,36 @@ uint16_t midtunit_video_device::midtunit_dma_r(offs_t offset)
  *           | ----------2----- | select top/bottom or left/right for reg 12/13
  */
 
-void midtunit_video_device::midtunit_dma_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void midtunit_video_device::dma_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	static const uint8_t register_map[2][16] =
 	{
 		{ 0,1,2,3,4,5,6,7,8,9,10,11,16,17,14,15 },
 		{ 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 }
 	};
-	int regbank = (m_dma_register[DMA_CONFIG] >> 5) & 1;
+	int const regbank = (m_dma_register[DMA_CONFIG] >> 5) & 1;
 	int pixels = 0;
 
-	/* blend with the current register contents */
+	// blend with the current register contents
 	int regnum = register_map[regbank][offset];
 	COMBINE_DATA(&m_dma_register[regnum]);
 
-	/* only writes to DMA_COMMAND actually cause actions */
+	// only writes to DMA_COMMAND actually cause actions
 	if (regnum != DMA_COMMAND)
 		return;
 
-	/* high bit triggers action */
-	int command = m_dma_register[DMA_COMMAND];
-	m_maincpu->set_input_line(0, CLEAR_LINE);
+	// high bit triggers action
+	int const command = m_dma_register[DMA_COMMAND];
+	m_dma_irq_cb(CLEAR_LINE);
 	if (!(command & 0x8000))
 		return;
 
 	auto profile = g_profiler.start(PROFILER_USER1);
 
-	/* determine bpp */
-	int bpp = (command >> 12) & 7;
+	// determine bpp
+	int const bpp = (command >> 12) & 7;
 
-	/* fill in the basic data */
+	// fill in the basic data
 	m_dma_state.xpos = m_dma_register[DMA_XSTART] & XPOSMASK;
 	m_dma_state.ypos = m_dma_register[DMA_YSTART] & YPOSMASK;
 	m_dma_state.width = m_dma_register[DMA_WIDTH] & 0x3ff;
@@ -724,27 +730,27 @@ void midtunit_video_device::midtunit_dma_w(offs_t offset, uint16_t data, uint16_
 	m_dma_state.palette = m_dma_register[DMA_PALETTE] & 0x7f00;
 	m_dma_state.color = m_dma_register[DMA_COLOR] & 0xff;
 
-	/* fill in the rev 2 data */
+	// fill in the rev 2 data
 	m_dma_state.yflip = (command & 0x20) >> 5;
 	m_dma_state.preskip = (command >> 8) & 3;
 	m_dma_state.postskip = (command >> 10) & 3;
 	m_dma_state.xstep = m_dma_register[DMA_SCALE_X] ? m_dma_register[DMA_SCALE_X] : 0x100;
 	m_dma_state.ystep = m_dma_register[DMA_SCALE_Y] ? m_dma_register[DMA_SCALE_Y] : 0x100;
 
-	/* clip the clippers */
+	// clip the clippers
 	m_dma_state.topclip = m_dma_register[DMA_TOPCLIP] & 0x1ff;
 	m_dma_state.botclip = m_dma_register[DMA_BOTCLIP] & 0x1ff;
 	m_dma_state.leftclip = m_dma_register[DMA_LEFTCLIP] & 0x3ff;
 	m_dma_state.rightclip = m_dma_register[DMA_RIGHTCLIP] & 0x3ff;
 
-	/* determine the offset */
+	// determine the offset
 	uint32_t gfxoffset = m_dma_register[DMA_OFFSETLO] | (m_dma_register[DMA_OFFSETHI] << 16);
 
-	/* special case: drawing mode C doesn't need to know about any pixel data */
+	// special case: drawing mode C doesn't need to know about any pixel data
 	if ((command & 0x0f) == 0x0c)
 		gfxoffset = 0;
 
-	/* determine the location */
+	// determine the location
 	if (!m_gfx_rom_large && gfxoffset >= 0x2000000)
 		gfxoffset -= 0x2000000;
 	if (gfxoffset >= 0xf8000000)
@@ -753,7 +759,7 @@ void midtunit_video_device::midtunit_dma_w(offs_t offset, uint16_t data, uint16_
 		m_dma_state.offset = gfxoffset;
 	else
 	{
-		logerror("DMA source out of range: %08X\n", gfxoffset);
+		LOGDMACTRL("DMA source out of range: %08X\n", gfxoffset);
 		goto skipdma;
 	}
 
@@ -774,11 +780,11 @@ void midtunit_video_device::midtunit_dma_w(offs_t offset, uint16_t data, uint16_
 		}
 	}
 
-	/* there seems to be two types of behavior for the DMA chip */
-	/* for MK1 and MK2, the upper byte of the LRSKIP is the     */
-	/* starting skip value, and the lower byte is the ending    */
-	/* skip value; for the NBA Jam, Hangtime, and Open Ice, the */
-	/* full word seems to be the starting skip value.           */
+	// there seems to be two types of behavior for the DMA chip
+	// for MK1 and MK2, the upper byte of the LRSKIP is the    
+	// starting skip value, and the lower byte is the ending   
+	// skip value; for the NBA Jam, Hangtime, and Open Ice, the
+	// full word seems to be the starting skip value.          
 	if (command & 0x40)
 	{
 		m_dma_state.startskip = m_dma_register[DMA_LRSKIP] & 0xff;
@@ -802,7 +808,7 @@ void midtunit_video_device::midtunit_dma_w(offs_t offset, uint16_t data, uint16_
 		}
 	}
 
-	/* then draw */
+	// then draw
 	if (m_dma_state.xstep == 0x100 && m_dma_state.ystep == 0x100)
 	{
 		if (command & 0x80)
@@ -825,7 +831,7 @@ void midtunit_video_device::midtunit_dma_w(offs_t offset, uint16_t data, uint16_
 			pixels = 0;
 	}
 
-	/* signal we're done */
+	// signal we're done
 skipdma:
 	m_dma_timer->adjust(attotime::from_nsec(41 * pixels));
 }
@@ -844,7 +850,7 @@ TMS340X0_SCANLINE_IND16_CB_MEMBER(midtunit_video_device::scanline_update)
 	uint16_t *const dest = &bitmap.pix(scanline);
 	int coladdr = params->coladdr << 1;
 
-	/* copy the non-blanked portions of this scanline */
+	// copy the non-blanked portions of this scanline
 	for (int x = params->heblnk; x < params->hsblnk; x++)
 		dest[x] = src[coladdr++ & 0x1ff] & 0x7fff;
 }
@@ -855,14 +861,14 @@ TMS340X0_SCANLINE_IND16_CB_MEMBER(midxunit_video_device::scanline_update)
 	uint16_t const *const src = &m_local_videoram[fulladdr & 0x3fe00];
 	uint16_t *const dest = &bitmap.pix(scanline);
 
-	/* copy the non-blanked portions of this scanline */
+	// copy the non-blanked portions of this scanline
 	for (int x = params->heblnk; x < params->hsblnk; x++)
 		dest[x] = src[fulladdr++ & 0x1ff] & 0x7fff;
 }
 
 void midtunit_video_device::log_bitmap(int command, int bpp, bool Skip)
 {
-	const uint32_t raw_offset = m_dma_register[DMA_OFFSETLO] | (m_dma_register[DMA_OFFSETHI] << 16);
+	uint32_t const raw_offset = m_dma_register[DMA_OFFSETLO] | (m_dma_register[DMA_OFFSETHI] << 16);
 	if (m_logged_rom[raw_offset >> 6] & (1ULL << (raw_offset & 0x3f)))
 		return;
 
@@ -903,16 +909,16 @@ void midtunit_video_device::log_bitmap(int command, int bpp, bool Skip)
 	m_log_bitmap.allocate(m_dma_state.width, m_dma_state.height);
 	m_log_bitmap.fill(0);
 
-	uint8_t *base = m_dma_state.gfxrom;
+	uint8_t const *const base = m_dma_state.gfxrom;
 	uint32_t offset = m_dma_state.offset;
-	uint16_t pal = m_dma_state.palette;
-	uint16_t color = pal | m_dma_state.color;
-	int mask = (1 << bpp) - 1;
+	uint16_t const pal = m_dma_state.palette;
+	uint16_t const color = pal | m_dma_state.color;
+	int const mask = (1 << bpp) - 1;
 
-	/* loop over the height */
+	// loop over the height
 	for (int y = 0; y < m_dma_state.height; y++)
 	{
-		int startskip = m_dma_state.startskip;
+		int const startskip = m_dma_state.startskip;
 		[[maybe_unused]] int endskip = m_dma_state.endskip;
 		int width = m_dma_state.width;
 		int ix = 0;
@@ -920,24 +926,24 @@ void midtunit_video_device::log_bitmap(int command, int bpp, bool Skip)
 		uint32_t o = offset;
 		int pre = 0, post = 0;
 
-		/* handle skipping */
+		// handle skipping
 		if (Skip)
 		{
-			uint8_t value = EXTRACTGEN(0xff);
+			uint8_t const value = EXTRACTGEN(0xff);
 			o += 8;
 
-			/* adjust for preskip */
+			// adjust for preskip
 			pre = (value & 0x0f) << m_dma_state.preskip;
 			tx = pre;
 			ix += tx;
 
-			/* adjust for postskip */
+			// adjust for postskip
 			post = ((value >> 4) & 0x0f) << m_dma_state.postskip;
 			width -= post;
 			endskip -= post;
 		}
 
-		/* handle start skip */
+		// handle start skip
 		if (ix < startskip)
 		{
 			tx = (startskip - ix);
@@ -945,18 +951,18 @@ void midtunit_video_device::log_bitmap(int command, int bpp, bool Skip)
 			o += tx * bpp;
 		}
 
-		/* handle end skip */
+		// handle end skip
 		if (width > m_dma_state.width - m_dma_state.endskip)
 			width = m_dma_state.width - m_dma_state.endskip;
 
 		bitmap_rgb32::pixel_t *d = &m_log_bitmap.pix(y, ix);
 
-		/* determine destination pointer */
+		// determine destination pointer
 
-		/* loop until we draw the entire width */
+		// loop until we draw the entire width
 		while (ix < width)
 		{
-			/* special case similar handling of zero/non-zero */
+			// special case similar handling of zero/non-zero
 			if (Zero == NonZero)
 			{
 				if (Zero == PIXEL_COLOR)
@@ -965,12 +971,12 @@ void midtunit_video_device::log_bitmap(int command, int bpp, bool Skip)
 					*d = m_palette->palette()->entry_list_raw()[(EXTRACTGEN(mask)) | pal];
 			}
 
-			/* otherwise, read the pixel and look */
+			// otherwise, read the pixel and look
 			else
 			{
-				int pixel = (EXTRACTGEN(mask));
+				int const pixel = (EXTRACTGEN(mask));
 
-				/* non-zero pixel case */
+				// non-zero pixel case
 				if (pixel)
 				{
 					if (NonZero == PIXEL_COLOR)
@@ -979,7 +985,7 @@ void midtunit_video_device::log_bitmap(int command, int bpp, bool Skip)
 						*d = m_palette->palette()->entry_list_raw()[pixel | pal];
 				}
 
-				/* zero pixel case */
+				// zero pixel case
 				else
 				{
 					if (Zero == PIXEL_COLOR)
@@ -989,13 +995,13 @@ void midtunit_video_device::log_bitmap(int command, int bpp, bool Skip)
 				}
 			}
 
-			/* advance to the next pixel */
+			// advance to the next pixel
 			ix++;
 			d++;
 			o += bpp;
 		}
 
-		/* advance to the next row */
+		// advance to the next row
 		width = m_dma_state.width;
 		if (Skip)
 		{

--- a/src/mame/midway/midwunit.cpp
+++ b/src/mame/midway/midwunit.cpp
@@ -98,13 +98,10 @@ Notes:
 #include "midwunit.h"
 
 #include "cpu/tms34010/tms34010.h"
-#include "cpu/adsp2100/adsp2100.h"
 #include "machine/nvram.h"
 
 #include "screen.h"
 #include "speaker.h"
-
-#define PIXEL_CLOCK     (8000000)
 
 
 /*************************************
@@ -116,14 +113,14 @@ Notes:
 void midwunit_state::main_map(address_map &map)
 {
 	map(0x00000000, 0x003fffff).rw(m_video, FUNC(midwunit_video_device::midtunit_vram_r), FUNC(midwunit_video_device::midtunit_vram_w));
-	map(0x01000000, 0x013fffff).ram().share("mainram");
-	map(0x01400000, 0x0145ffff).rw(FUNC(midwunit_state::midwunit_cmos_r), FUNC(midwunit_state::midwunit_cmos_w)).share("nvram");
-	map(0x01480000, 0x014fffff).w(FUNC(midwunit_state::midwunit_cmos_enable_w));
-	map(0x01600000, 0x0160001f).rw(FUNC(midwunit_state::midwunit_security_r), FUNC(midwunit_state::midwunit_security_w));
-	map(0x01680000, 0x0168001f).rw(FUNC(midwunit_state::midwunit_sound_r), FUNC(midwunit_state::midwunit_sound_w));
-	map(0x01800000, 0x0187ffff).rw(FUNC(midwunit_state::midwunit_io_r), FUNC(midwunit_state::midwunit_io_w));
+	map(0x01000000, 0x013fffff).ram().share(m_mainram);
+	map(0x01400000, 0x0145ffff).rw(FUNC(midwunit_state::cmos_r), FUNC(midwunit_state::cmos_w)).share(m_nvram);
+	map(0x01480000, 0x014fffff).w(FUNC(midwunit_state::cmos_enable_w));
+	map(0x01600000, 0x0160001f).rw(FUNC(midwunit_state::security_r), FUNC(midwunit_state::security_w));
+	map(0x01680000, 0x0168001f).rw(FUNC(midwunit_state::sound_r), FUNC(midwunit_state::sound_w));
+	map(0x01800000, 0x0187ffff).rw(FUNC(midwunit_state::io_r), FUNC(midwunit_state::io_w));
 	map(0x01880000, 0x018fffff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x01a00000, 0x01a000ff).mirror(0x00080000).rw(m_video, FUNC(midwunit_video_device::midtunit_dma_r), FUNC(midwunit_video_device::midtunit_dma_w));
+	map(0x01a00000, 0x01a000ff).mirror(0x00080000).rw(m_video, FUNC(midwunit_video_device::dma_r), FUNC(midwunit_video_device::dma_w));
 	map(0x01b00000, 0x01b0001f).rw(m_video, FUNC(midwunit_video_device::midwunit_control_r), FUNC(midwunit_video_device::midwunit_control_w));
 	map(0x02000000, 0x06ffffff).r(m_video, FUNC(midwunit_video_device::midwunit_gfxrom_r));
 	map(0xff800000, 0xffffffff).rom().region("maincpu", 0);
@@ -625,30 +622,33 @@ INPUT_PORTS_END
 
 void midwunit_state::wunit(machine_config &config)
 {
-	MIDWUNIT_VIDEO(config, m_video, m_maincpu, m_palette, m_gfxrom);
+	constexpr XTAL PIXEL_CLOCK = 8_MHz_XTAL;
 
-	TMS34010(config, m_maincpu, 50000000);
+	MIDWUNIT_VIDEO(config, m_video, m_palette);
+	m_video->dma_irq_cb().set_inputline(m_maincpu, 0);
+
+	TMS34010(config, m_maincpu, 50_MHz_XTAL);
 	m_maincpu->set_addrmap(AS_PROGRAM, &midwunit_state::main_map);
-	m_maincpu->set_halt_on_reset(false);     /* halt on reset */
-	m_maincpu->set_pixel_clock(PIXEL_CLOCK); /* pixel clock */
-	m_maincpu->set_pixels_per_clock(1);      /* pixels per clock */
-	m_maincpu->set_scanline_ind16_callback("video", FUNC(midtunit_video_device::scanline_update));  /* scanline updater (indexed16) */
-	m_maincpu->set_shiftreg_in_callback("video", FUNC(midtunit_video_device::to_shiftreg));         /* write to shiftreg function */
-	m_maincpu->set_shiftreg_out_callback("video", FUNC(midtunit_video_device::from_shiftreg));      /* read from shiftreg function */
+	m_maincpu->set_halt_on_reset(false);     // halt on reset
+	m_maincpu->set_pixel_clock(PIXEL_CLOCK); // pixel clock
+	m_maincpu->set_pixels_per_clock(1);      // pixels per clock
+	m_maincpu->set_scanline_ind16_callback(m_video, FUNC(midtunit_video_device::scanline_update));  // scanline updater (indexed16)
+	m_maincpu->set_shiftreg_in_callback(m_video, FUNC(midtunit_video_device::to_shiftreg));         // write to shiftreg function
+	m_maincpu->set_shiftreg_out_callback(m_video, FUNC(midtunit_video_device::from_shiftreg));      // read from shiftreg function
 	m_maincpu->set_screen("screen");
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
-	/* video hardware */
-	PALETTE(config, "palette").set_format(palette_device::xRGB_555, 32768);
+	// video hardware
+	PALETTE(config, m_palette).set_format(palette_device::xRGB_555, 32768);
 
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	// from TMS340 registers
 	screen.set_raw(PIXEL_CLOCK, 506, 101, 501, 289, 20, 274);
-	screen.set_screen_update("maincpu", FUNC(tms34010_device::tms340x0_ind16));
+	screen.set_screen_update(m_maincpu, FUNC(tms34010_device::tms340x0_ind16));
 	screen.set_palette(m_palette);
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	DCS_AUDIO_8K(config, m_dcs, 0);
@@ -712,18 +712,18 @@ A83E 4/6/95  MORTAL KOMBAT III  U117  AM.0
 7F0B 4/6/95  MORTAL KOMBAT III  U114  AM.3
 */
 ROM_START( mk3 )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u2_music_spch.u2", 0x000000, 0x100000, CRC(5273436f) SHA1(e1735842a0159eafe79d878d44e3828df9bfa5bb) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u3_music_spch.u3", 0x200000, 0x100000, CRC(856fe411) SHA1(6165ebecfce7500e948d84492ffa19eed7f47091) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u4_music_spch.u4", 0x400000, 0x100000, CRC(428a406f) SHA1(e70ec83cd054de0da1e178720ed0035b8887f797) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u5_music_spch.u5", 0x600000, 0x100000, CRC(3b98a09f) SHA1(edf1d02a56dcf3349e6b4bb4097acfe7592305f4) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "mk321u54.bin",  0x00000, 0x80000, CRC(9e344401) SHA1(5760b355f0a5c27c9746f33abfdedf4302f1af38) )
 	ROM_LOAD16_BYTE( "mk321u63.bin",  0x00001, 0x80000, CRC(64d34776) SHA1(d8f09e1e946dc13fec5e9f83fdaf61d4076ba9ea) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
-	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u133_game_rom.u133",  0x0000000, 0x100000, CRC(79b94667) SHA1(31bba640c351fdccc6685cadb74dd79a3f910ce8) ) /* all GAME ROMs here are also known to be labeled as P1.0 */
+	ROM_REGION( 0x2000000, "video", 0 )
+	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u133_game_rom.u133",  0x0000000, 0x100000, CRC(79b94667) SHA1(31bba640c351fdccc6685cadb74dd79a3f910ce8) ) // all GAME ROMs here are also known to be labeled as P1.0
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u132_game_rom.u132",  0x0000001, 0x100000, CRC(13e95228) SHA1(405b05f5a5a55667c2be17d4b399129bdacefd90) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u131_game_rom.u131",  0x0000002, 0x100000, CRC(41001e30) SHA1(2cec91116771951c0380cec5debf4cbb40c14c61) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u130_game_rom.u130",  0x0000003, 0x100000, CRC(49379dd7) SHA1(e6dfab4e23d9cc38ae56c1bbf10ccd160e8fad5e) )
@@ -751,18 +751,18 @@ ROM_END
 
 
 ROM_START( mk3r20 )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u2_music_spch.u2", 0x000000, 0x100000, CRC(5273436f) SHA1(e1735842a0159eafe79d878d44e3828df9bfa5bb) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u3_music_spch.u3", 0x200000, 0x100000, CRC(856fe411) SHA1(6165ebecfce7500e948d84492ffa19eed7f47091) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u4_music_spch.u4", 0x400000, 0x100000, CRC(428a406f) SHA1(e70ec83cd054de0da1e178720ed0035b8887f797) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u5_music_spch.u5", 0x600000, 0x100000, CRC(3b98a09f) SHA1(edf1d02a56dcf3349e6b4bb4097acfe7592305f4) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "mk320u54.bin",  0x00000, 0x80000, CRC(453da302) SHA1(d9a4814e7abb49ac0eb306ad05adcceac68df6a5) )
 	ROM_LOAD16_BYTE( "mk320u63.bin",  0x00001, 0x80000, CRC(f8dc0600) SHA1(6eb689d92619c751252155b40af119ad47e94cfa) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
-	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u133_game_rom.u133",  0x0000000, 0x100000, CRC(79b94667) SHA1(31bba640c351fdccc6685cadb74dd79a3f910ce8) ) /* all GAME ROMs here are also known to be labeled as P1.0 */
+	ROM_REGION( 0x2000000, "video", 0 )
+	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u133_game_rom.u133",  0x0000000, 0x100000, CRC(79b94667) SHA1(31bba640c351fdccc6685cadb74dd79a3f910ce8) ) // all GAME ROMs here are also known to be labeled as P1.0
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u132_game_rom.u132",  0x0000001, 0x100000, CRC(13e95228) SHA1(405b05f5a5a55667c2be17d4b399129bdacefd90) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u131_game_rom.u131",  0x0000002, 0x100000, CRC(41001e30) SHA1(2cec91116771951c0380cec5debf4cbb40c14c61) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u130_game_rom.u130",  0x0000003, 0x100000, CRC(49379dd7) SHA1(e6dfab4e23d9cc38ae56c1bbf10ccd160e8fad5e) )
@@ -790,18 +790,18 @@ ROM_END
 
 
 ROM_START( mk3r10 )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u2_music_spch.u2", 0x000000, 0x100000, CRC(5273436f) SHA1(e1735842a0159eafe79d878d44e3828df9bfa5bb) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u3_music_spch.u3", 0x200000, 0x100000, CRC(856fe411) SHA1(6165ebecfce7500e948d84492ffa19eed7f47091) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u4_music_spch.u4", 0x400000, 0x100000, CRC(428a406f) SHA1(e70ec83cd054de0da1e178720ed0035b8887f797) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u5_music_spch.u5", 0x600000, 0x100000, CRC(3b98a09f) SHA1(edf1d02a56dcf3349e6b4bb4097acfe7592305f4) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "mk310u54.bin",  0x00000, 0x80000, CRC(41829228) SHA1(5686b50a08b528d41b28ef578cfb171da9905c45) )
 	ROM_LOAD16_BYTE( "mk310u63.bin",  0x00001, 0x80000, CRC(b074e1e8) SHA1(fe1a6f622614b1ebd8edc3edeec442d39ba2924c) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
-	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u133_game_rom.u133",  0x0000000, 0x100000, CRC(79b94667) SHA1(31bba640c351fdccc6685cadb74dd79a3f910ce8) ) /* all GAME ROMs here are also known to be labeled as P1.0 */
+	ROM_REGION( 0x2000000, "video", 0 )
+	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u133_game_rom.u133",  0x0000000, 0x100000, CRC(79b94667) SHA1(31bba640c351fdccc6685cadb74dd79a3f910ce8) ) // all GAME ROMs here are also known to be labeled as P1.0
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u132_game_rom.u132",  0x0000001, 0x100000, CRC(13e95228) SHA1(405b05f5a5a55667c2be17d4b399129bdacefd90) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u131_game_rom.u131",  0x0000002, 0x100000, CRC(41001e30) SHA1(2cec91116771951c0380cec5debf4cbb40c14c61) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u130_game_rom.u130",  0x0000003, 0x100000, CRC(49379dd7) SHA1(e6dfab4e23d9cc38ae56c1bbf10ccd160e8fad5e) )
@@ -829,18 +829,18 @@ ROM_END
 
 
 ROM_START( mk3p40 )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u2_music_spch.u2", 0x000000, 0x100000, CRC(5273436f) SHA1(e1735842a0159eafe79d878d44e3828df9bfa5bb) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u3_music_spch.u3", 0x200000, 0x100000, CRC(856fe411) SHA1(6165ebecfce7500e948d84492ffa19eed7f47091) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u4_music_spch.u4", 0x400000, 0x100000, CRC(428a406f) SHA1(e70ec83cd054de0da1e178720ed0035b8887f797) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u5_music_spch.u5", 0x600000, 0x100000, CRC(3b98a09f) SHA1(edf1d02a56dcf3349e6b4bb4097acfe7592305f4) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "mk3p40.u54",  0x00000, 0x80000, CRC(4dfb0748) SHA1(8c628a51642c940de8abb795be36123e4008ce15) )
 	ROM_LOAD16_BYTE( "mk3p40.u63",  0x00001, 0x80000, CRC(f25a8083) SHA1(ff11462d23d9e16f6ee0d77bf85caa996df32618) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
-	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u133_game_rom.u133",  0x0000000, 0x100000, CRC(79b94667) SHA1(31bba640c351fdccc6685cadb74dd79a3f910ce8) ) /* all GAME ROMs here are also known to be labeled as P1.0 */
+	ROM_REGION( 0x2000000, "video", 0 )
+	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u133_game_rom.u133",  0x0000000, 0x100000, CRC(79b94667) SHA1(31bba640c351fdccc6685cadb74dd79a3f910ce8) ) // all GAME ROMs here are also known to be labeled as P1.0
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u132_game_rom.u132",  0x0000001, 0x100000, CRC(13e95228) SHA1(405b05f5a5a55667c2be17d4b399129bdacefd90) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u131_game_rom.u131",  0x0000002, 0x100000, CRC(41001e30) SHA1(2cec91116771951c0380cec5debf4cbb40c14c61) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u130_game_rom.u130",  0x0000003, 0x100000, CRC(49379dd7) SHA1(e6dfab4e23d9cc38ae56c1bbf10ccd160e8fad5e) )
@@ -868,21 +868,21 @@ ROM_END
 
 
 ROM_START( umk3 )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
-	ROM_LOAD16_BYTE( "l2.0_mortal_kombat_3_u2_ultimate.u2", 0x000000, 0x100000, CRC(3838cfe5) SHA1(e3d2901f3bae1362742fc6ee0aa31c9f63b4dfa3) ) /* verified labeled as L2.0 */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
+	ROM_LOAD16_BYTE( "l2.0_mortal_kombat_3_u2_ultimate.u2", 0x000000, 0x100000, CRC(3838cfe5) SHA1(e3d2901f3bae1362742fc6ee0aa31c9f63b4dfa3) ) // verified labeled as L2.0
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u3_music_spch.u3", 0x200000, 0x100000, CRC(856fe411) SHA1(6165ebecfce7500e948d84492ffa19eed7f47091) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u4_music_spch.u4", 0x400000, 0x100000, CRC(428a406f) SHA1(e70ec83cd054de0da1e178720ed0035b8887f797) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u5_music_spch.u5", 0x600000, 0x100000, CRC(3b98a09f) SHA1(edf1d02a56dcf3349e6b4bb4097acfe7592305f4) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l1.2_mortal_kombat_3_u54_ultimate.u54",  0x00000, 0x80000, CRC(712b4db6) SHA1(7015a55f3d745c6aeb8630903e2d5cd9554b2766) )
 	ROM_LOAD16_BYTE( "l1.2_mortal_kombat_3_u63_ultimate.u63",  0x00001, 0x80000, CRC(6d301faf) SHA1(18a8e29cc3e8ce5cc0e10f8386d43e7f44fd7b75) )
 
-	ROM_REGION( 0x1009, "serial_security:pic", 0 )   /* security PIC (provides game ID code and serial number) */
+	ROM_REGION( 0x1009, "serial_security:pic", 0 )   // security PIC (provides game ID code and serial number)
 	ROM_LOAD( "463_mk3_ultimate.u64",  0x0000, 0x1009, CRC(4f425218) SHA1(7f26045ed2c9ca94fadcb673ce10f28208aa720e) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
-	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u133_game_rom.u133",  0x0000000, 0x100000, CRC(79b94667) SHA1(31bba640c351fdccc6685cadb74dd79a3f910ce8) ) /* all GAME ROMs here are also known to be labeled as P1.0 */
+	ROM_REGION( 0x2000000, "video", 0 )
+	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u133_game_rom.u133",  0x0000000, 0x100000, CRC(79b94667) SHA1(31bba640c351fdccc6685cadb74dd79a3f910ce8) ) // all GAME ROMs here are also known to be labeled as P1.0
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u132_game_rom.u132",  0x0000001, 0x100000, CRC(13e95228) SHA1(405b05f5a5a55667c2be17d4b399129bdacefd90) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u131_game_rom.u131",  0x0000002, 0x100000, CRC(41001e30) SHA1(2cec91116771951c0380cec5debf4cbb40c14c61) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u130_game_rom.u130",  0x0000003, 0x100000, CRC(49379dd7) SHA1(e6dfab4e23d9cc38ae56c1bbf10ccd160e8fad5e) )
@@ -897,12 +897,12 @@ ROM_START( umk3 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u123_game_rom.u123",  0x0800002, 0x100000, CRC(f0ab88a8) SHA1(cdc9dc12e162255845c6627b1e35182b7e8502d0) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u122_game_rom.u122",  0x0800003, 0x100000, CRC(9b87cdac) SHA1(a5f8db559293978f23e6f105543d8b2e170a2e0d) )
 
-	ROM_LOAD32_BYTE( "umk-u121.bin",  0x0c00000, 0x100000, CRC(cc4b95db) SHA1(3d53180eec649e9616c4b87db55573f12d9bfee3) ) /* PCB pictures show EPROMs labeled as: */
-	ROM_LOAD32_BYTE( "umk-u120.bin",  0x0c00001, 0x100000, CRC(1c8144cd) SHA1(77cdc1eaf630ccb7233f5532f8b08191d00f0816) ) /* L2.0 MORTAL KOMBAT 3 Uxxx ULTIMATE   */
-	ROM_LOAD32_BYTE( "umk-u119.bin",  0x0c00002, 0x100000, CRC(5f10c543) SHA1(24dc83b7aa531ebd399258ffa7b2e028f1c4a28e) ) /* currently unverified if these are the same as for v1.0 & v1.1 UMK3 */
+	ROM_LOAD32_BYTE( "umk-u121.bin",  0x0c00000, 0x100000, CRC(cc4b95db) SHA1(3d53180eec649e9616c4b87db55573f12d9bfee3) ) // PCB pictures show EPROMs labeled as:
+	ROM_LOAD32_BYTE( "umk-u120.bin",  0x0c00001, 0x100000, CRC(1c8144cd) SHA1(77cdc1eaf630ccb7233f5532f8b08191d00f0816) ) // L2.0 MORTAL KOMBAT 3 Uxxx ULTIMATE  
+	ROM_LOAD32_BYTE( "umk-u119.bin",  0x0c00002, 0x100000, CRC(5f10c543) SHA1(24dc83b7aa531ebd399258ffa7b2e028f1c4a28e) ) // currently unverified if these are the same as for v1.0 & v1.1 UMK3
 	ROM_LOAD32_BYTE( "umk-u118.bin",  0x0c00003, 0x100000, CRC(de0c4488) SHA1(227cab34798c440b2a45223567113df5f17d913f) )
 
-	/* sockets U114 through U117 are left empty for this version */
+	// sockets U114 through U117 are left empty for this version
 
 	ROM_LOAD32_BYTE( "umk-u113.bin",  0x1400000, 0x100000, CRC(99d74a1e) SHA1(ed3068afa98287ea290d1f537f5009d3b6d683da) )
 	ROM_LOAD32_BYTE( "umk-u112.bin",  0x1400001, 0x100000, CRC(b5a46488) SHA1(dbf22e55d200eb9ff550f48b223cf0c6114a9357) )
@@ -912,21 +912,21 @@ ROM_END
 
 
 ROM_START( umk3r11 )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
-	ROM_LOAD16_BYTE( "l2.0_mortal_kombat_3_u2_ultimate.u2", 0x000000, 0x100000, CRC(3838cfe5) SHA1(e3d2901f3bae1362742fc6ee0aa31c9f63b4dfa3) ) /* verified labeled as L2.0 */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
+	ROM_LOAD16_BYTE( "l2.0_mortal_kombat_3_u2_ultimate.u2", 0x000000, 0x100000, CRC(3838cfe5) SHA1(e3d2901f3bae1362742fc6ee0aa31c9f63b4dfa3) ) // verified labeled as L2.0
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u3_music_spch.u3", 0x200000, 0x100000, CRC(856fe411) SHA1(6165ebecfce7500e948d84492ffa19eed7f47091) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u4_music_spch.u4", 0x400000, 0x100000, CRC(428a406f) SHA1(e70ec83cd054de0da1e178720ed0035b8887f797) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u5_music_spch.u5", 0x600000, 0x100000, CRC(3b98a09f) SHA1(edf1d02a56dcf3349e6b4bb4097acfe7592305f4) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l1.1_mortal_kombat_3_u54_ultimate.u54",  0x00000, 0x80000, CRC(8bb27659) SHA1(a3ffe3d8f21c261b36c7510d620d691a8bbf665b) )
 	ROM_LOAD16_BYTE( "l1.1_mortal_kombat_3_u63_ultimate.u63",  0x00001, 0x80000, CRC(ea731783) SHA1(2915626090650c4b5adf5b26e736c3ec91ce81a6) )
 
-	ROM_REGION( 0x1009, "serial_security:pic", 0 )   /* security PIC (provides game ID code and serial number) */
+	ROM_REGION( 0x1009, "serial_security:pic", 0 )   // security PIC (provides game ID code and serial number)
 	ROM_LOAD( "463_mk3_ultimate.u64",  0x0000, 0x1009, CRC(4f425218) SHA1(7f26045ed2c9ca94fadcb673ce10f28208aa720e) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
-	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u133_game_rom.u133",  0x0000000, 0x100000, CRC(79b94667) SHA1(31bba640c351fdccc6685cadb74dd79a3f910ce8) ) /* all GAME ROMs here are also known to be labeled as P1.0 */
+	ROM_REGION( 0x2000000, "video", 0 )
+	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u133_game_rom.u133",  0x0000000, 0x100000, CRC(79b94667) SHA1(31bba640c351fdccc6685cadb74dd79a3f910ce8) ) // all GAME ROMs here are also known to be labeled as P1.0
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u132_game_rom.u132",  0x0000001, 0x100000, CRC(13e95228) SHA1(405b05f5a5a55667c2be17d4b399129bdacefd90) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u131_game_rom.u131",  0x0000002, 0x100000, CRC(41001e30) SHA1(2cec91116771951c0380cec5debf4cbb40c14c61) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u130_game_rom.u130",  0x0000003, 0x100000, CRC(49379dd7) SHA1(e6dfab4e23d9cc38ae56c1bbf10ccd160e8fad5e) )
@@ -941,12 +941,12 @@ ROM_START( umk3r11 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u123_game_rom.u123",  0x0800002, 0x100000, CRC(f0ab88a8) SHA1(cdc9dc12e162255845c6627b1e35182b7e8502d0) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u122_game_rom.u122",  0x0800003, 0x100000, CRC(9b87cdac) SHA1(a5f8db559293978f23e6f105543d8b2e170a2e0d) )
 
-	ROM_LOAD32_BYTE( "mortal_kombat_iii_ultimate_u121_video_image.u121",  0x0c00000, 0x100000, CRC(cc4b95db) SHA1(3d53180eec649e9616c4b87db55573f12d9bfee3) ) /* Both v1.0 & v1.1 have been found with mask roms  */
+	ROM_LOAD32_BYTE( "mortal_kombat_iii_ultimate_u121_video_image.u121",  0x0c00000, 0x100000, CRC(cc4b95db) SHA1(3d53180eec649e9616c4b87db55573f12d9bfee3) ) // Both v1.0 & v1.1 have been found with mask roms 
 	ROM_LOAD32_BYTE( "mortal_kombat_iii_ultimate_u120_video_image.u120",  0x0c00001, 0x100000, CRC(1c8144cd) SHA1(77cdc1eaf630ccb7233f5532f8b08191d00f0816) )
 	ROM_LOAD32_BYTE( "mortal_kombat_iii_ultimate_u119_video_image.u119",  0x0c00002, 0x100000, CRC(5f10c543) SHA1(24dc83b7aa531ebd399258ffa7b2e028f1c4a28e) )
 	ROM_LOAD32_BYTE( "mortal_kombat_iii_ultimate_u118_video_image.u118",  0x0c00003, 0x100000, CRC(de0c4488) SHA1(227cab34798c440b2a45223567113df5f17d913f) )
 
-	/* sockets U114 through U117 are left empty for this version */
+	// sockets U114 through U117 are left empty for this version
 
 	ROM_LOAD32_BYTE( "mortal_kombat_iii_ultimate_u113_video_image.u113",  0x1400000, 0x100000, CRC(99d74a1e) SHA1(ed3068afa98287ea290d1f537f5009d3b6d683da) )
 	ROM_LOAD32_BYTE( "mortal_kombat_iii_ultimate_u112_video_image.u112",  0x1400001, 0x100000, CRC(b5a46488) SHA1(dbf22e55d200eb9ff550f48b223cf0c6114a9357) )
@@ -956,21 +956,21 @@ ROM_END
 
 
 ROM_START( umk3r10 )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
-	ROM_LOAD16_BYTE( "l1.0_mortal_kombat_3_u2_ultimate.u2", 0x000000, 0x100000, CRC(3838cfe5) SHA1(e3d2901f3bae1362742fc6ee0aa31c9f63b4dfa3) ) /* verified labeled as L1.0 */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
+	ROM_LOAD16_BYTE( "l1.0_mortal_kombat_3_u2_ultimate.u2", 0x000000, 0x100000, CRC(3838cfe5) SHA1(e3d2901f3bae1362742fc6ee0aa31c9f63b4dfa3) ) // verified labeled as L1.0
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u3_music_spch.u3", 0x200000, 0x100000, CRC(856fe411) SHA1(6165ebecfce7500e948d84492ffa19eed7f47091) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u4_music_spch.u4", 0x400000, 0x100000, CRC(428a406f) SHA1(e70ec83cd054de0da1e178720ed0035b8887f797) )
 	ROM_LOAD16_BYTE( "l1_mortal_kombat_3_u5_music_spch.u5", 0x600000, 0x100000, CRC(3b98a09f) SHA1(edf1d02a56dcf3349e6b4bb4097acfe7592305f4) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l1.0_mortal_kombat_3_u54_ultimate.u54",  0x00000, 0x80000, CRC(dfd735da) SHA1(bcb6d80dbde407d0042ec2f225b2f98740a79203) )
 	ROM_LOAD16_BYTE( "l1.0_mortal_kombat_3_u63_ultimate.u63",  0x00001, 0x80000, CRC(2dff0c83) SHA1(8942ffa3addf134085ea8d77d56e82593312e7a5) )
 
-	ROM_REGION( 0x1009, "serial_security:pic", 0 )   /* security PIC (provides game ID code and serial number) */
+	ROM_REGION( 0x1009, "serial_security:pic", 0 )   // security PIC (provides game ID code and serial number)
 	ROM_LOAD( "463_mk3_ultimate.u64",  0x0000, 0x1009, CRC(4f425218) SHA1(7f26045ed2c9ca94fadcb673ce10f28208aa720e) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
-	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u133_game_rom.u133",  0x0000000, 0x100000, CRC(79b94667) SHA1(31bba640c351fdccc6685cadb74dd79a3f910ce8) ) /* all GAME ROMs here are also known to be labeled as P1.0 */
+	ROM_REGION( 0x2000000, "video", 0 )
+	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u133_game_rom.u133",  0x0000000, 0x100000, CRC(79b94667) SHA1(31bba640c351fdccc6685cadb74dd79a3f910ce8) ) // all GAME ROMs here are also known to be labeled as P1.0
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u132_game_rom.u132",  0x0000001, 0x100000, CRC(13e95228) SHA1(405b05f5a5a55667c2be17d4b399129bdacefd90) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u131_game_rom.u131",  0x0000002, 0x100000, CRC(41001e30) SHA1(2cec91116771951c0380cec5debf4cbb40c14c61) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u130_game_rom.u130",  0x0000003, 0x100000, CRC(49379dd7) SHA1(e6dfab4e23d9cc38ae56c1bbf10ccd160e8fad5e) )
@@ -985,12 +985,12 @@ ROM_START( umk3r10 )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u123_game_rom.u123",  0x0800002, 0x100000, CRC(f0ab88a8) SHA1(cdc9dc12e162255845c6627b1e35182b7e8502d0) )
 	ROM_LOAD32_BYTE( "l1_mortal_kombat_3_u122_game_rom.u122",  0x0800003, 0x100000, CRC(9b87cdac) SHA1(a5f8db559293978f23e6f105543d8b2e170a2e0d) )
 
-	ROM_LOAD32_BYTE( "mortal_kombat_iii_ultimate_u121_video_image.u121",  0x0c00000, 0x100000, CRC(cc4b95db) SHA1(3d53180eec649e9616c4b87db55573f12d9bfee3) ) /* Both v1.0 & v1.1 have been found with mask roms  */
+	ROM_LOAD32_BYTE( "mortal_kombat_iii_ultimate_u121_video_image.u121",  0x0c00000, 0x100000, CRC(cc4b95db) SHA1(3d53180eec649e9616c4b87db55573f12d9bfee3) ) // Both v1.0 & v1.1 have been found with mask roms 
 	ROM_LOAD32_BYTE( "mortal_kombat_iii_ultimate_u120_video_image.u120",  0x0c00001, 0x100000, CRC(1c8144cd) SHA1(77cdc1eaf630ccb7233f5532f8b08191d00f0816) )
 	ROM_LOAD32_BYTE( "mortal_kombat_iii_ultimate_u119_video_image.u119",  0x0c00002, 0x100000, CRC(5f10c543) SHA1(24dc83b7aa531ebd399258ffa7b2e028f1c4a28e) )
 	ROM_LOAD32_BYTE( "mortal_kombat_iii_ultimate_u118_video_image.u118",  0x0c00003, 0x100000, CRC(de0c4488) SHA1(227cab34798c440b2a45223567113df5f17d913f) )
 
-	/* sockets U114 through U117 are left empty for this version */
+	// sockets U114 through U117 are left empty for this version
 
 	ROM_LOAD32_BYTE( "mortal_kombat_iii_ultimate_u113_video_image.u113",  0x1400000, 0x100000, CRC(99d74a1e) SHA1(ed3068afa98287ea290d1f537f5009d3b6d683da) )
 	ROM_LOAD32_BYTE( "mortal_kombat_iii_ultimate_u112_video_image.u112",  0x1400001, 0x100000, CRC(b5a46488) SHA1(dbf22e55d200eb9ff550f48b223cf0c6114a9357) )
@@ -1000,85 +1000,85 @@ ROM_END
 
 
 ROM_START( openice )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
-	ROM_LOAD16_BYTE( "open_ice_l1.2.u2", 0x000000, 0x100000, CRC(8adb5aab) SHA1(4c25bc051c90947f3366f83ac5ca8dc78e26b8a4) ) /* This one labeled as L1.2 */
-	ROM_LOAD16_BYTE( "open_ice_l1.u3",   0x200000, 0x100000, CRC(11c61ad6) SHA1(324621d6b486399b6d5ede1fed39d4e448cdeb32) ) /* This one labeled as L1 */
-	ROM_LOAD16_BYTE( "open_ice_l1.u4",   0x400000, 0x100000, CRC(04279290) SHA1(daf1e57137ae1c3434194054e69809bfe3ed1fc3) ) /* This one labeled as L1 */
-	ROM_LOAD16_BYTE( "open_ice_l1.u5",   0x600000, 0x100000, CRC(e90ad61f) SHA1(59eeabcae7e0e70cdb4472cde64b8a28b07ede98) ) /* This one labeled as L1 */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
+	ROM_LOAD16_BYTE( "open_ice_l1.2.u2", 0x000000, 0x100000, CRC(8adb5aab) SHA1(4c25bc051c90947f3366f83ac5ca8dc78e26b8a4) ) // This one labeled as L1.2
+	ROM_LOAD16_BYTE( "open_ice_l1.u3",   0x200000, 0x100000, CRC(11c61ad6) SHA1(324621d6b486399b6d5ede1fed39d4e448cdeb32) ) // This one labeled as L1
+	ROM_LOAD16_BYTE( "open_ice_l1.u4",   0x400000, 0x100000, CRC(04279290) SHA1(daf1e57137ae1c3434194054e69809bfe3ed1fc3) ) // This one labeled as L1
+	ROM_LOAD16_BYTE( "open_ice_l1.u5",   0x600000, 0x100000, CRC(e90ad61f) SHA1(59eeabcae7e0e70cdb4472cde64b8a28b07ede98) ) // This one labeled as L1
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
-	ROM_LOAD16_BYTE( "open_ice_l1.21.u54", 0x00000, 0x80000, CRC(e4225284) SHA1(d5e267cf35826c106bb0a800363849ed4d489e56) ) /* Labeled as L1.21 */
-	ROM_LOAD16_BYTE( "open_ice_l1.21.u63", 0x00001, 0x80000, CRC(97d308a3) SHA1(0a517fab77bc2277884587c7e29e392bb360d27b) ) /* Labeled as L1.21 */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
+	ROM_LOAD16_BYTE( "open_ice_l1.21.u54", 0x00000, 0x80000, CRC(e4225284) SHA1(d5e267cf35826c106bb0a800363849ed4d489e56) ) // Labeled as L1.21
+	ROM_LOAD16_BYTE( "open_ice_l1.21.u63", 0x00001, 0x80000, CRC(97d308a3) SHA1(0a517fab77bc2277884587c7e29e392bb360d27b) ) // Labeled as L1.21
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
-	ROM_LOAD32_BYTE( "open_ice_l1.2.u133", 0x0000000, 0x100000, CRC(8a81605c) SHA1(cf397b8da242566b21579b90528857ccd2f93141) ) /* These 4 are labeled as L1.2 */
+	ROM_REGION( 0x2000000, "video", 0 )
+	ROM_LOAD32_BYTE( "open_ice_l1.2.u133", 0x0000000, 0x100000, CRC(8a81605c) SHA1(cf397b8da242566b21579b90528857ccd2f93141) ) // These 4 are labeled as L1.2
 	ROM_LOAD32_BYTE( "open_ice_l1.2.u132", 0x0000001, 0x100000, CRC(cfdd6702) SHA1(0198d2cc2de93a8aa345ba0af8d92713d798be8a) )
 	ROM_LOAD32_BYTE( "open_ice_l1.2.u131", 0x0000002, 0x100000, CRC(cc428eb7) SHA1(ff2403077453f24bd1b176f57b17649b1b64bccf) )
 	ROM_LOAD32_BYTE( "open_ice_l1.2.u130", 0x0000003, 0x100000, CRC(74c2d50c) SHA1(7880a28b003aa44878384efcb72b98833383f67e) )
 
-	ROM_LOAD32_BYTE( "open_ice_l1.2.u129", 0x0400000, 0x100000, CRC(9e2ff012) SHA1(35160ab239f0d8efcb2dc67dee4bd8d204226e3d) ) /* These 4 are labeled as L1.2 */
+	ROM_LOAD32_BYTE( "open_ice_l1.2.u129", 0x0400000, 0x100000, CRC(9e2ff012) SHA1(35160ab239f0d8efcb2dc67dee4bd8d204226e3d) ) // These 4 are labeled as L1.2
 	ROM_LOAD32_BYTE( "open_ice_l1.2.u128", 0x0400001, 0x100000, CRC(35d2e610) SHA1(c4bd18f44592299f120344ecaf1464a8b31d80c8) )
 	ROM_LOAD32_BYTE( "open_ice_l1.2.u127", 0x0400002, 0x100000, CRC(bcbf19fe) SHA1(e28f0238ef020b75b10318e5c3dd4c5472b3638a) )
 	ROM_LOAD32_BYTE( "open_ice_l1.2.u126", 0x0400003, 0x100000, CRC(8e3106ae) SHA1(58d1fd097e23578195d28671f22cfa3ed161c0f5) )
 
-	ROM_LOAD32_BYTE( "open_ice_l1.u125",   0x0800000, 0x100000, CRC(a7b54550) SHA1(83e3627c4e84466ec10023b0e2259ad86b791fd7) ) /* Yes, these 4 are labeled as L1, NOT L1.2 */
+	ROM_LOAD32_BYTE( "open_ice_l1.u125",   0x0800000, 0x100000, CRC(a7b54550) SHA1(83e3627c4e84466ec10023b0e2259ad86b791fd7) ) // Yes, these 4 are labeled as L1, NOT L1.2
 	ROM_LOAD32_BYTE( "open_ice_l1.u124",   0x0800001, 0x100000, CRC(7c02cb50) SHA1(92d24bcfd66396c52c823b816118eed39c4ef9cd) )
 	ROM_LOAD32_BYTE( "open_ice_l1.u123",   0x0800002, 0x100000, CRC(d543bd9d) SHA1(a9ff8589fe185ea058b549c2ed4e71f6c50e9638) )
 	ROM_LOAD32_BYTE( "open_ice_l1.u122",   0x0800003, 0x100000, CRC(3744d291) SHA1(e4484f377a66c4c64b015ef461419d956b6e23e4) )
 
-	ROM_LOAD32_BYTE( "open_ice_l1.2.u121", 0x0c00000, 0x100000, CRC(acd2f7c7) SHA1(82d6f09e63a825b118c36d668427011cd8892eaa) ) /* These 4 are labeled as L1.2 */
+	ROM_LOAD32_BYTE( "open_ice_l1.2.u121", 0x0c00000, 0x100000, CRC(acd2f7c7) SHA1(82d6f09e63a825b118c36d668427011cd8892eaa) ) // These 4 are labeled as L1.2
 	ROM_LOAD32_BYTE( "open_ice_l1.2.u120", 0x0c00001, 0x100000, CRC(4295686a) SHA1(2522e57335bb8cca6d76942d2fd62560f88e37a6) )
 	ROM_LOAD32_BYTE( "open_ice_l1.2.u119", 0x0c00002, 0x100000, CRC(948b9b27) SHA1(62d031410f491d557e27ba055d3db9d36d5a153c) )
 	ROM_LOAD32_BYTE( "open_ice_l1.2.u118", 0x0c00003, 0x100000, CRC(9eaaf93e) SHA1(56bd881df5282f659ac68ace960a3b085c13dd9d) )
 ROM_END
 
 
-ROM_START( openicea ) /* PCB had alternate ROM labels showing the dates & checksums */
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
-	ROM_LOAD16_BYTE( "open_ice_l1.2.u2", 0x000000, 0x100000, CRC(8adb5aab) SHA1(4c25bc051c90947f3366f83ac5ca8dc78e26b8a4) ) /* U2  OPEN ICE HOCKEY  R1.2  10/10/95  1900 */
-	ROM_LOAD16_BYTE( "open_ice_l1.u3",   0x200000, 0x100000, CRC(11c61ad6) SHA1(324621d6b486399b6d5ede1fed39d4e448cdeb32) ) /* U3  OPEN ICE HOCKEY  9/1/95  4D00 */
-	ROM_LOAD16_BYTE( "open_ice_l1.u4",   0x400000, 0x100000, CRC(04279290) SHA1(daf1e57137ae1c3434194054e69809bfe3ed1fc3) ) /* U4  OPEN ICE HOCKEY  9/1/95  4700 */
-	ROM_LOAD16_BYTE( "open_ice_l1.u5",   0x600000, 0x100000, CRC(e90ad61f) SHA1(59eeabcae7e0e70cdb4472cde64b8a28b07ede98) ) /* U5  OPEN ICE HOCKEY  9/1/95  C200 */
+ROM_START( openicea ) // PCB had alternate ROM labels showing the dates & checksums
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
+	ROM_LOAD16_BYTE( "open_ice_l1.2.u2", 0x000000, 0x100000, CRC(8adb5aab) SHA1(4c25bc051c90947f3366f83ac5ca8dc78e26b8a4) ) // U2  OPEN ICE HOCKEY  R1.2  10/10/95  1900
+	ROM_LOAD16_BYTE( "open_ice_l1.u3",   0x200000, 0x100000, CRC(11c61ad6) SHA1(324621d6b486399b6d5ede1fed39d4e448cdeb32) ) // U3  OPEN ICE HOCKEY  9/1/95  4D00
+	ROM_LOAD16_BYTE( "open_ice_l1.u4",   0x400000, 0x100000, CRC(04279290) SHA1(daf1e57137ae1c3434194054e69809bfe3ed1fc3) ) // U4  OPEN ICE HOCKEY  9/1/95  4700
+	ROM_LOAD16_BYTE( "open_ice_l1.u5",   0x600000, 0x100000, CRC(e90ad61f) SHA1(59eeabcae7e0e70cdb4472cde64b8a28b07ede98) ) // U5  OPEN ICE HOCKEY  9/1/95  C200
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
-	ROM_LOAD16_BYTE( "open_ice_781c_r1.2a.u54", 0x00000, 0x80000, CRC(63296053) SHA1(9f6fcb1f95a09165c211b569001563b56d06876c) ) /* hand written as  781C  R1.21 - game reports as Revision 1.2A */
-	ROM_LOAD16_BYTE( "open_ice_6937_r1.2a.u63", 0x00001, 0x80000, CRC(04441034) SHA1(d0af6305749a26adddb17aabb512e0347fcac767) ) /* hand written as  6937  R1.21 - game reports as Revision 1.2A */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
+	ROM_LOAD16_BYTE( "open_ice_781c_r1.2a.u54", 0x00000, 0x80000, CRC(63296053) SHA1(9f6fcb1f95a09165c211b569001563b56d06876c) ) // hand written as  781C  R1.21 - game reports as Revision 1.2A
+	ROM_LOAD16_BYTE( "open_ice_6937_r1.2a.u63", 0x00001, 0x80000, CRC(04441034) SHA1(d0af6305749a26adddb17aabb512e0347fcac767) ) // hand written as  6937  R1.21 - game reports as Revision 1.2A
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 ) /* label for U133 is likely for v1.1 with different data for that bank of 4 roms dated 9/14/95 */
-	ROM_LOAD32_BYTE( "open_ice_l1.2.u133", 0x0000000, 0x100000, CRC(8a81605c) SHA1(cf397b8da242566b21579b90528857ccd2f93141) ) /* 2M.0  U133  OPEN ICE HOCKEY  9/14/95  EE39 - however, this should be: 2M.0  U133  OPEN ICE HOCKEY  10/17/95  04E5 - Same as parent */
-	ROM_LOAD32_BYTE( "open_ice_l1.2.u132", 0x0000001, 0x100000, CRC(cfdd6702) SHA1(0198d2cc2de93a8aa345ba0af8d92713d798be8a) ) /* 2M.1  U132  OPEN ICE HOCKEY  10/17/95  595E */
-	ROM_LOAD32_BYTE( "open_ice_l1.2.u131", 0x0000002, 0x100000, CRC(cc428eb7) SHA1(ff2403077453f24bd1b176f57b17649b1b64bccf) ) /* 2M.2  U131  OPEN ICE HOCKEY  10/17/95  B2BF */
-	ROM_LOAD32_BYTE( "open_ice_l1.2.u130", 0x0000003, 0x100000, CRC(74c2d50c) SHA1(7880a28b003aa44878384efcb72b98833383f67e) ) /* 2M.3  U130  OPEN ICE HOCKEY  10/17/95  D784 */
+	ROM_REGION( 0x2000000, "video", 0 ) // label for U133 is likely for v1.1 with different data for that bank of 4 roms dated 9/14/95
+	ROM_LOAD32_BYTE( "open_ice_l1.2.u133", 0x0000000, 0x100000, CRC(8a81605c) SHA1(cf397b8da242566b21579b90528857ccd2f93141) ) // 2M.0  U133  OPEN ICE HOCKEY  9/14/95  EE39 - however, this should be: 2M.0  U133  OPEN ICE HOCKEY  10/17/95  04E5 - Same as parent
+	ROM_LOAD32_BYTE( "open_ice_l1.2.u132", 0x0000001, 0x100000, CRC(cfdd6702) SHA1(0198d2cc2de93a8aa345ba0af8d92713d798be8a) ) // 2M.1  U132  OPEN ICE HOCKEY  10/17/95  595E
+	ROM_LOAD32_BYTE( "open_ice_l1.2.u131", 0x0000002, 0x100000, CRC(cc428eb7) SHA1(ff2403077453f24bd1b176f57b17649b1b64bccf) ) // 2M.2  U131  OPEN ICE HOCKEY  10/17/95  B2BF
+	ROM_LOAD32_BYTE( "open_ice_l1.2.u130", 0x0000003, 0x100000, CRC(74c2d50c) SHA1(7880a28b003aa44878384efcb72b98833383f67e) ) // 2M.3  U130  OPEN ICE HOCKEY  10/17/95  D784
 
-	ROM_LOAD32_BYTE( "open_ice_l1.2.u129", 0x0400000, 0x100000, CRC(9e2ff012) SHA1(35160ab239f0d8efcb2dc67dee4bd8d204226e3d) ) /* 4M.0  U129  OPEN ICE HOCKEY  9/14/95  97E0 */
-	ROM_LOAD32_BYTE( "open_ice_l1.2.u128", 0x0400001, 0x100000, CRC(35d2e610) SHA1(c4bd18f44592299f120344ecaf1464a8b31d80c8) ) /* 4M.1  U128  OPEN ICE HOCKEY  9/14/95  96FC */
-	ROM_LOAD32_BYTE( "open_ice_l1.2.u127", 0x0400002, 0x100000, CRC(bcbf19fe) SHA1(e28f0238ef020b75b10318e5c3dd4c5472b3638a) ) /* 4M.2  U127  OPEN ICE HOCKEY  9/14/95  6A67 */
-	ROM_LOAD32_BYTE( "open_ice_l1.2.u126", 0x0400003, 0x100000, CRC(8e3106ae) SHA1(58d1fd097e23578195d28671f22cfa3ed161c0f5) ) /* 4M.3  U126  OPEN ICE HOCKEY  9/14/95  E92F */
+	ROM_LOAD32_BYTE( "open_ice_l1.2.u129", 0x0400000, 0x100000, CRC(9e2ff012) SHA1(35160ab239f0d8efcb2dc67dee4bd8d204226e3d) ) // 4M.0  U129  OPEN ICE HOCKEY  9/14/95  97E0
+	ROM_LOAD32_BYTE( "open_ice_l1.2.u128", 0x0400001, 0x100000, CRC(35d2e610) SHA1(c4bd18f44592299f120344ecaf1464a8b31d80c8) ) // 4M.1  U128  OPEN ICE HOCKEY  9/14/95  96FC
+	ROM_LOAD32_BYTE( "open_ice_l1.2.u127", 0x0400002, 0x100000, CRC(bcbf19fe) SHA1(e28f0238ef020b75b10318e5c3dd4c5472b3638a) ) // 4M.2  U127  OPEN ICE HOCKEY  9/14/95  6A67
+	ROM_LOAD32_BYTE( "open_ice_l1.2.u126", 0x0400003, 0x100000, CRC(8e3106ae) SHA1(58d1fd097e23578195d28671f22cfa3ed161c0f5) ) // 4M.3  U126  OPEN ICE HOCKEY  9/14/95  E92F
 
-	ROM_LOAD32_BYTE( "open_ice_l1.u125",   0x0800000, 0x100000, CRC(a7b54550) SHA1(83e3627c4e84466ec10023b0e2259ad86b791fd7) ) /* 6M.0  U125  OPEN ICE HOCKEY  7/11/95  23F8 */
-	ROM_LOAD32_BYTE( "open_ice_l1.u124",   0x0800001, 0x100000, CRC(7c02cb50) SHA1(92d24bcfd66396c52c823b816118eed39c4ef9cd) ) /* 6M.1  U124  OPEN ICE HOCKEY  7/11/95  A90C */
-	ROM_LOAD32_BYTE( "open_ice_l1.u123",   0x0800002, 0x100000, CRC(d543bd9d) SHA1(a9ff8589fe185ea058b549c2ed4e71f6c50e9638) ) /* 6M.2  U123  OPEN ICE HOCKEY  7/11/95  EA1C */
-	ROM_LOAD32_BYTE( "open_ice_l1.u122",   0x0800003, 0x100000, CRC(3744d291) SHA1(e4484f377a66c4c64b015ef461419d956b6e23e4) ) /* 6M.3  U122  OPEN ICE HOCKEY  7/11/95  AA6B */
+	ROM_LOAD32_BYTE( "open_ice_l1.u125",   0x0800000, 0x100000, CRC(a7b54550) SHA1(83e3627c4e84466ec10023b0e2259ad86b791fd7) ) // 6M.0  U125  OPEN ICE HOCKEY  7/11/95  23F8
+	ROM_LOAD32_BYTE( "open_ice_l1.u124",   0x0800001, 0x100000, CRC(7c02cb50) SHA1(92d24bcfd66396c52c823b816118eed39c4ef9cd) ) // 6M.1  U124  OPEN ICE HOCKEY  7/11/95  A90C
+	ROM_LOAD32_BYTE( "open_ice_l1.u123",   0x0800002, 0x100000, CRC(d543bd9d) SHA1(a9ff8589fe185ea058b549c2ed4e71f6c50e9638) ) // 6M.2  U123  OPEN ICE HOCKEY  7/11/95  EA1C
+	ROM_LOAD32_BYTE( "open_ice_l1.u122",   0x0800003, 0x100000, CRC(3744d291) SHA1(e4484f377a66c4c64b015ef461419d956b6e23e4) ) // 6M.3  U122  OPEN ICE HOCKEY  7/11/95  AA6B
 
-	ROM_LOAD32_BYTE( "open_ice_l1.2.u121", 0x0c00000, 0x100000, CRC(acd2f7c7) SHA1(82d6f09e63a825b118c36d668427011cd8892eaa) ) /* 8M.0  U121  OPEN ICE HOCKEY  9/14/95  0A39 */
-	ROM_LOAD32_BYTE( "open_ice_l1.2.u120", 0x0c00001, 0x100000, CRC(4295686a) SHA1(2522e57335bb8cca6d76942d2fd62560f88e37a6) ) /* 8M.1  U120  OPEN ICE HOCKEY  9/14/95  64AD */
-	ROM_LOAD32_BYTE( "open_ice_l1.2.u119", 0x0c00002, 0x100000, CRC(948b9b27) SHA1(62d031410f491d557e27ba055d3db9d36d5a153c) ) /* 8M.2  U119  OPEN ICE HOCKEY  9/14/95  3446 */
-	ROM_LOAD32_BYTE( "open_ice_l1.2.u118", 0x0c00003, 0x100000, CRC(9eaaf93e) SHA1(56bd881df5282f659ac68ace960a3b085c13dd9d) ) /* 8M.3  U118  OPEN ICE HOCKEY  9/14/95  3FD9 */
+	ROM_LOAD32_BYTE( "open_ice_l1.2.u121", 0x0c00000, 0x100000, CRC(acd2f7c7) SHA1(82d6f09e63a825b118c36d668427011cd8892eaa) ) // 8M.0  U121  OPEN ICE HOCKEY  9/14/95  0A39
+	ROM_LOAD32_BYTE( "open_ice_l1.2.u120", 0x0c00001, 0x100000, CRC(4295686a) SHA1(2522e57335bb8cca6d76942d2fd62560f88e37a6) ) // 8M.1  U120  OPEN ICE HOCKEY  9/14/95  64AD
+	ROM_LOAD32_BYTE( "open_ice_l1.2.u119", 0x0c00002, 0x100000, CRC(948b9b27) SHA1(62d031410f491d557e27ba055d3db9d36d5a153c) ) // 8M.2  U119  OPEN ICE HOCKEY  9/14/95  3446
+	ROM_LOAD32_BYTE( "open_ice_l1.2.u118", 0x0c00003, 0x100000, CRC(9eaaf93e) SHA1(56bd881df5282f659ac68ace960a3b085c13dd9d) ) // 8M.3  U118  OPEN ICE HOCKEY  9/14/95  3FD9
 ROM_END
 
 
 ROM_START( nbahangt )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_2_music_spch.u2", 0x000000, 0x100000, CRC(3f0b0d0a) SHA1(e3b8a264686ce7359d86e4926237d8cf17612991) ) // Labeled: L1.0  NBA HANGTIME  U 2 MUSIC/SPCH
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_3_music_spch.u3", 0x200000, 0x100000, CRC(ec1db988) SHA1(1cf06d0b75f20ded7db648070e85c056043765bb) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_4_music_spch.u4", 0x400000, 0x100000, CRC(c7f847a3) SHA1(c50175dffa3563ccd5792c59a6b44523f4014544) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_5_music_spch.u5", 0x600000, 0x100000, CRC(ef19316a) SHA1(d41ae87ab45630a37c73684de42f7f6e0ed8f13b) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l1.3_nba_hangtime_u_54_game_rom.u54", 0x00000, 0x80000, CRC(fd9ccca2) SHA1(fc38d2440dd0712d7d5e2d2cca9635efd63a3d85) )
 	ROM_LOAD16_BYTE( "l1.3_nba_hangtime_u_63_game_rom.u63", 0x00001, 0x80000, CRC(57de886f) SHA1(7cc127c7db7a68ea716914f7ddbbaf1356937f97) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
+	ROM_REGION( 0x2000000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_133_image_rom.u133", 0x0000000, 0x100000, CRC(3163feed) SHA1(eb7f128de306933929a0933e36e57760459cb0a1) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_132_image_rom.u132", 0x0000001, 0x100000, CRC(428eaf44) SHA1(2897efef4ab1653870b5bebb2762ea85549da03a) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_131_image_rom.u131", 0x0000002, 0x100000, CRC(5f7c5111) SHA1(14337f50b7b98254b54250af00f8a4a46bd7ee8d) )
@@ -1109,17 +1109,17 @@ ROM_END
 
 
 ROM_START( nbahangtm13 )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_2_music_spch.u2", 0x000000, 0x100000, CRC(3f0b0d0a) SHA1(e3b8a264686ce7359d86e4926237d8cf17612991) ) // Labeled: L1.0  NBA HANGTIME  U 2 MUSIC/SPCH
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_3_music_spch.u3", 0x200000, 0x100000, CRC(ec1db988) SHA1(1cf06d0b75f20ded7db648070e85c056043765bb) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_4_music_spch.u4", 0x400000, 0x100000, CRC(c7f847a3) SHA1(c50175dffa3563ccd5792c59a6b44523f4014544) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_5_music_spch.u5", 0x600000, 0x100000, CRC(ef19316a) SHA1(d41ae87ab45630a37c73684de42f7f6e0ed8f13b) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "m1.3_nba_hangtime_u_54_game_rom.u54", 0x00000, 0x80000, CRC(3ee3a9f4) SHA1(e5c2ab23f03af5aa493fcc3250f6e9bf38040793) )
 	ROM_LOAD16_BYTE( "m1.3_nba_hangtime_u_63_game_rom.u63", 0x00001, 0x80000, CRC(42e6aeca) SHA1(468ad4095ea54be77e59def04b78fd5fed0616e5) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
+	ROM_REGION( 0x2000000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_133_image_rom.u133", 0x0000000, 0x100000, CRC(3163feed) SHA1(eb7f128de306933929a0933e36e57760459cb0a1) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_132_image_rom.u132", 0x0000001, 0x100000, CRC(428eaf44) SHA1(2897efef4ab1653870b5bebb2762ea85549da03a) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_131_image_rom.u131", 0x0000002, 0x100000, CRC(5f7c5111) SHA1(14337f50b7b98254b54250af00f8a4a46bd7ee8d) )
@@ -1150,17 +1150,17 @@ ROM_END
 
 
 ROM_START( nbahangtl12 )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_2_music_spch.u2", 0x000000, 0x100000, CRC(3f0b0d0a) SHA1(e3b8a264686ce7359d86e4926237d8cf17612991) ) // Labeled: L1.0  NBA HANGTIME  U 2 MUSIC/SPCH
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_3_music_spch.u3", 0x200000, 0x100000, CRC(ec1db988) SHA1(1cf06d0b75f20ded7db648070e85c056043765bb) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_4_music_spch.u4", 0x400000, 0x100000, CRC(c7f847a3) SHA1(c50175dffa3563ccd5792c59a6b44523f4014544) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_5_music_spch.u5", 0x600000, 0x100000, CRC(ef19316a) SHA1(d41ae87ab45630a37c73684de42f7f6e0ed8f13b) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l1.2_nba_hangtime_u_54_game_rom.u54", 0x00000, 0x80000, CRC(c90dc3cd) SHA1(62d74e3f9ca290c2cdf0fdc7dbcd7f4004454d46) )
 	ROM_LOAD16_BYTE( "l1.2_nba_hangtime_u_63_game_rom.u63", 0x00001, 0x80000, CRC(1883c461) SHA1(6e72b4d55041cc8d50f2591013b75dd75aa8a9dd) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
+	ROM_REGION( 0x2000000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_133_image_rom.u133", 0x0000000, 0x100000, CRC(3163feed) SHA1(eb7f128de306933929a0933e36e57760459cb0a1) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_132_image_rom.u132", 0x0000001, 0x100000, CRC(428eaf44) SHA1(2897efef4ab1653870b5bebb2762ea85549da03a) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_131_image_rom.u131", 0x0000002, 0x100000, CRC(5f7c5111) SHA1(14337f50b7b98254b54250af00f8a4a46bd7ee8d) )
@@ -1191,17 +1191,17 @@ ROM_END
 
 
 ROM_START( nbahangtm12 )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_2_music_spch.u2", 0x000000, 0x100000, CRC(3f0b0d0a) SHA1(e3b8a264686ce7359d86e4926237d8cf17612991) ) // Labeled: L1.0  NBA HANGTIME  U 2 MUSIC/SPCH
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_3_music_spch.u3", 0x200000, 0x100000, CRC(ec1db988) SHA1(1cf06d0b75f20ded7db648070e85c056043765bb) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_4_music_spch.u4", 0x400000, 0x100000, CRC(c7f847a3) SHA1(c50175dffa3563ccd5792c59a6b44523f4014544) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_5_music_spch.u5", 0x600000, 0x100000, CRC(ef19316a) SHA1(d41ae87ab45630a37c73684de42f7f6e0ed8f13b) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "m1.2_nba_hangtime_u_54_game_rom.u54", 0x00000, 0x80000, CRC(3be47f64) SHA1(71b54037b89c11c031c1db0e3112ae08f7f28e8c) )
 	ROM_LOAD16_BYTE( "m1.2_nba_hangtime_u_63_game_rom.u63", 0x00001, 0x80000, CRC(ba4344ae) SHA1(86557a21411c18136ac4383cc7e0da78b6f01235) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
+	ROM_REGION( 0x2000000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_133_image_rom.u133", 0x0000000, 0x100000, CRC(3163feed) SHA1(eb7f128de306933929a0933e36e57760459cb0a1) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_132_image_rom.u132", 0x0000001, 0x100000, CRC(428eaf44) SHA1(2897efef4ab1653870b5bebb2762ea85549da03a) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_131_image_rom.u131", 0x0000002, 0x100000, CRC(5f7c5111) SHA1(14337f50b7b98254b54250af00f8a4a46bd7ee8d) )
@@ -1232,17 +1232,17 @@ ROM_END
 
 
 ROM_START( nbahangtl11 )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_2_music_spch.u2", 0x000000, 0x100000, CRC(3f0b0d0a) SHA1(e3b8a264686ce7359d86e4926237d8cf17612991) ) // Labeled: L1.0  NBA HANGTIME  U 2 MUSIC/SPCH
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_3_music_spch.u3", 0x200000, 0x100000, CRC(ec1db988) SHA1(1cf06d0b75f20ded7db648070e85c056043765bb) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_4_music_spch.u4", 0x400000, 0x100000, CRC(c7f847a3) SHA1(c50175dffa3563ccd5792c59a6b44523f4014544) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_5_music_spch.u5", 0x600000, 0x100000, CRC(ef19316a) SHA1(d41ae87ab45630a37c73684de42f7f6e0ed8f13b) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l1.1_nba_hangtime_u_54_game_rom.u54", 0x00000, 0x80000, CRC(c2875d98) SHA1(3f88f6f5c15ae03bedda39f71a1deaf549a55516) )
 	ROM_LOAD16_BYTE( "l1.1_nba_hangtime_u_63_game_rom.u63", 0x00001, 0x80000, CRC(6f4728c3) SHA1(c059f4aa72cc5c3edc41e72428b3ebba97cc9417) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
+	ROM_REGION( 0x2000000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_133_image_rom.u133", 0x0000000, 0x100000, CRC(3163feed) SHA1(eb7f128de306933929a0933e36e57760459cb0a1) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_132_image_rom.u132", 0x0000001, 0x100000, CRC(428eaf44) SHA1(2897efef4ab1653870b5bebb2762ea85549da03a) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_131_image_rom.u131", 0x0000002, 0x100000, CRC(5f7c5111) SHA1(14337f50b7b98254b54250af00f8a4a46bd7ee8d) )
@@ -1273,17 +1273,17 @@ ROM_END
 
 
 ROM_START( nbahangtm11 )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_2_music_spch.u2", 0x000000, 0x100000, CRC(3f0b0d0a) SHA1(e3b8a264686ce7359d86e4926237d8cf17612991) ) // Labeled: L1.0  NBA HANGTIME  U 2 MUSIC/SPCH
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_3_music_spch.u3", 0x200000, 0x100000, CRC(ec1db988) SHA1(1cf06d0b75f20ded7db648070e85c056043765bb) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_4_music_spch.u4", 0x400000, 0x100000, CRC(c7f847a3) SHA1(c50175dffa3563ccd5792c59a6b44523f4014544) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_5_music_spch.u5", 0x600000, 0x100000, CRC(ef19316a) SHA1(d41ae87ab45630a37c73684de42f7f6e0ed8f13b) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "m1.1_nba_hangtime_u_54_game_rom.u54", 0x00000, 0x80000, CRC(113b37f4) SHA1(61fac820a6f6bf9ca74a52d7d4f718e08fc58a36) )
 	ROM_LOAD16_BYTE( "m1.1_nba_hangtime_u_63_game_rom.u63", 0x00001, 0x80000, CRC(beaa3e92) SHA1(86b2c8278f200fea3df3f4b9e5ceea37cb0e6191) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
+	ROM_REGION( 0x2000000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_133_image_rom.u133", 0x0000000, 0x100000, CRC(3163feed) SHA1(eb7f128de306933929a0933e36e57760459cb0a1) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_132_image_rom.u132", 0x0000001, 0x100000, CRC(428eaf44) SHA1(2897efef4ab1653870b5bebb2762ea85549da03a) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_131_image_rom.u131", 0x0000002, 0x100000, CRC(5f7c5111) SHA1(14337f50b7b98254b54250af00f8a4a46bd7ee8d) )
@@ -1323,17 +1323,17 @@ There are known "M" versions (EX: MAX HANGTIME - VER M1.0 11/08/96 ), but it's n
   those and a standard "L" version.  In fact the ROM labels specifically state they are "L" Version ROMs
 */
 ROM_START( nbamht )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_2_music_spch.u2", 0x000000, 0x100000, CRC(3f0b0d0a) SHA1(e3b8a264686ce7359d86e4926237d8cf17612991) ) // Uses NBA Hangtime MUSIC/SPCH ROMs - verified correct
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_3_music_spch.u3", 0x200000, 0x100000, CRC(ec1db988) SHA1(1cf06d0b75f20ded7db648070e85c056043765bb) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_4_music_spch.u4", 0x400000, 0x100000, CRC(c7f847a3) SHA1(c50175dffa3563ccd5792c59a6b44523f4014544) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_5_music_spch.u5", 0x600000, 0x100000, CRC(ef19316a) SHA1(d41ae87ab45630a37c73684de42f7f6e0ed8f13b) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l1.03_maximum_hangtime_u54_l_version.u54",  0x00000, 0x80000, CRC(21b0d9e1) SHA1(34fa928bdb222fba1fec2a9f37b853f77922250f) ) // Labeled: L1.03  Maximum Hangtime  U54 "L" Version
 	ROM_LOAD16_BYTE( "l1.03_maximum_hangtime_u63_l_version.u63",  0x00001, 0x80000, CRC(c6fdbb97) SHA1(e6cf0c6a94441befdde40b620a182877c11582a5) ) // Labeled: L1.03  Maximum Hangtime  U63 "L" Version
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
+	ROM_REGION( 0x2000000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_133_image_rom.u133", 0x0000000, 0x100000, CRC(3163feed) SHA1(eb7f128de306933929a0933e36e57760459cb0a1) ) // Uses NBA Hangtime IMAGE ROMs - verified correct
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_132_image_rom.u132", 0x0000001, 0x100000, CRC(428eaf44) SHA1(2897efef4ab1653870b5bebb2762ea85549da03a) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_131_image_rom.u131", 0x0000002, 0x100000, CRC(5f7c5111) SHA1(14337f50b7b98254b54250af00f8a4a46bd7ee8d) )
@@ -1364,17 +1364,17 @@ ROM_END
 
 
 ROM_START( nbamhtl10 )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_2_music_spch.u2", 0x000000, 0x100000, CRC(3f0b0d0a) SHA1(e3b8a264686ce7359d86e4926237d8cf17612991) ) // Uses NBA Hangtime MUSIC/SPCH ROMs - verified correct
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_3_music_spch.u3", 0x200000, 0x100000, CRC(ec1db988) SHA1(1cf06d0b75f20ded7db648070e85c056043765bb) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_4_music_spch.u4", 0x400000, 0x100000, CRC(c7f847a3) SHA1(c50175dffa3563ccd5792c59a6b44523f4014544) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_5_music_spch.u5", 0x600000, 0x100000, CRC(ef19316a) SHA1(d41ae87ab45630a37c73684de42f7f6e0ed8f13b) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l1.0_maximum_hangtime_u54_l_version.u54", 0x00000, 0x80000, CRC(dfb6b3ae) SHA1(1dc59a2d89bf9764a47cebf71b9657c6ae7ce959) ) // Labeled: L1.0  Maximum Hangtime  U54 "L" Version
 	ROM_LOAD16_BYTE( "l1.0_maximum_hangtime_u63_l_version.u63", 0x00001, 0x80000, CRC(78da472c) SHA1(b4573ff19dc0d8a99f1bceace872e4999d53317a) ) // Labeled: L1.0  Maximum Hangtime  U63 "L" Version
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
+	ROM_REGION( 0x2000000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_133_image_rom.u133", 0x0000000, 0x100000, CRC(3163feed) SHA1(eb7f128de306933929a0933e36e57760459cb0a1) ) // Uses NBA Hangtime IMAGE ROMs - verified correct
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_132_image_rom.u132", 0x0000001, 0x100000, CRC(428eaf44) SHA1(2897efef4ab1653870b5bebb2762ea85549da03a) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_131_image_rom.u131", 0x0000002, 0x100000, CRC(5f7c5111) SHA1(14337f50b7b98254b54250af00f8a4a46bd7ee8d) )
@@ -1405,17 +1405,17 @@ ROM_END
 
 
 ROM_START( nbamhtm10 )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_2_music_spch.u2", 0x000000, 0x100000, CRC(3f0b0d0a) SHA1(e3b8a264686ce7359d86e4926237d8cf17612991) ) // Uses NBA Hangtime MUSIC/SPCH ROMs - verified correct
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_3_music_spch.u3", 0x200000, 0x100000, CRC(ec1db988) SHA1(1cf06d0b75f20ded7db648070e85c056043765bb) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_4_music_spch.u4", 0x400000, 0x100000, CRC(c7f847a3) SHA1(c50175dffa3563ccd5792c59a6b44523f4014544) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_5_music_spch.u5", 0x600000, 0x100000, CRC(ef19316a) SHA1(d41ae87ab45630a37c73684de42f7f6e0ed8f13b) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "m1.0_maximum_hangtime_u54_m_version.u54", 0x00000, 0x80000, CRC(e4e665d5) SHA1(8111536e041f69ec35284bf3cae40a85a48d7331) ) // Labeled: L1.0  Maximum Hangtime  U54 "M" Version
 	ROM_LOAD16_BYTE( "m1.0_maximum_hangtime_u63_m_version.u63", 0x00001, 0x80000, CRC(51cfda55) SHA1(e8c8326fd57af9916a7fb8159b1d0901f30fd331) ) // Labeled: L1.0  Maximum Hangtime  U63 "M" Version
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
+	ROM_REGION( 0x2000000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_133_image_rom.u133", 0x0000000, 0x100000, CRC(3163feed) SHA1(eb7f128de306933929a0933e36e57760459cb0a1) ) // Uses NBA Hangtime IMAGE ROMs - verified correct
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_132_image_rom.u132", 0x0000001, 0x100000, CRC(428eaf44) SHA1(2897efef4ab1653870b5bebb2762ea85549da03a) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_131_image_rom.u131", 0x0000002, 0x100000, CRC(5f7c5111) SHA1(14337f50b7b98254b54250af00f8a4a46bd7ee8d) )
@@ -1446,17 +1446,17 @@ ROM_END
 
 
 ROM_START( nbamhtp )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_2_music_spch.u2", 0x000000, 0x100000, CRC(3f0b0d0a) SHA1(e3b8a264686ce7359d86e4926237d8cf17612991) ) // Uses NBA Hangtime MUSIC/SPCH ROMs - verified correct
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_3_music_spch.u3", 0x200000, 0x100000, CRC(ec1db988) SHA1(1cf06d0b75f20ded7db648070e85c056043765bb) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_4_music_spch.u4", 0x400000, 0x100000, CRC(c7f847a3) SHA1(c50175dffa3563ccd5792c59a6b44523f4014544) )
 	ROM_LOAD16_BYTE( "l1.0_nba_hangtime_u_5_music_spch.u5", 0x600000, 0x100000, CRC(ef19316a) SHA1(d41ae87ab45630a37c73684de42f7f6e0ed8f13b) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "l0.9_maximum_hangtime_u54_l_version.u54", 0x00000, 0x80000, CRC(0fbed60e) SHA1(a017d498a901c1608ffecfe0fb2ec82c7a23f4ea) )
 	ROM_LOAD16_BYTE( "l0.9_maximum_hangtime_u63_l_version.u63", 0x00001, 0x80000, CRC(a064645a) SHA1(43dba6f64ef1d940f1d1b1764addf40359fcdb51) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
+	ROM_REGION( 0x2000000, "video", 0 )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_133_image_rom.u133", 0x0000000, 0x100000, CRC(3163feed) SHA1(eb7f128de306933929a0933e36e57760459cb0a1) ) // Uses NBA Hangtime IMAGE ROMs - verified correct
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_132_image_rom.u132", 0x0000001, 0x100000, CRC(428eaf44) SHA1(2897efef4ab1653870b5bebb2762ea85549da03a) )
 	ROM_LOAD32_BYTE( "l1.0_nba_hangtime_u_131_image_rom.u131", 0x0000002, 0x100000, CRC(5f7c5111) SHA1(14337f50b7b98254b54250af00f8a4a46bd7ee8d) )
@@ -1487,20 +1487,20 @@ ROM_END
 
 
 ROM_START( rmpgwt )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "1.0_rampage_world_tour_u2_sound.u2",  0x000000, 0x100000, CRC(0e82f83d) SHA1(215eebb6c229ef9ad0fcbcbc6e4e07300c05654f) )
 	ROM_LOAD16_BYTE( "1.0_rampage_world_tour_u3_sound.u3",  0x200000, 0x100000, CRC(3ff54d15) SHA1(827805602091313ec68ea1bccf667bd3b3fc6b8b) )
 	ROM_LOAD16_BYTE( "1.0_rampage_world_tour_u4_sound.u4",  0x400000, 0x100000, CRC(5c7f5656) SHA1(6c9d692bad539fec8b5aa0bfb56de3ef3719c68a) )
 	ROM_LOAD16_BYTE( "1.0_rampage_world_tour_u5_sound.u5",  0x600000, 0x100000, CRC(fd9aaf24) SHA1(d60dc076e72618c99ecac9d081d8c49d337b90c7) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "1.3_rampage_world_u54_game.u54",  0x00000, 0x80000, CRC(2a8f6e1e) SHA1(7a87ad37fa1d1228c4cdd4704ff0aee42e9c86cb) )
 	ROM_LOAD16_BYTE( "1.3_rampage_world_u63_game.u63",  0x00001, 0x80000, CRC(403ae41e) SHA1(c08d9352efe63849f5d10c1bd1efe2b9dd7382e0) )
 
-	ROM_REGION( 0x1009, "serial_security:pic", 0 )   /* security PIC (provides game ID code and serial number) */
+	ROM_REGION( 0x1009, "serial_security:pic", 0 )   // security PIC (provides game ID code and serial number)
 	ROM_LOAD( "465_rampage_wt.u64",  0x0000, 0x1009, CRC(5c14d850) SHA1(f57aef8350e477252bff1fa0f930c1b5d0ceb03f) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
+	ROM_REGION( 0x2000000, "video", 0 )
 	ROM_LOAD32_BYTE( "1.0_rampage_world_tour_u133_image.u133",  0x0000000, 0x100000, CRC(5b5ac449) SHA1(1c01dde9a9dbd9f4a6cd30aea9f6410cab13c2c9) )
 	ROM_LOAD32_BYTE( "1.0_rampage_world_tour_u132_image.u132",  0x0000001, 0x100000, CRC(7b3f09c6) SHA1(477658481ee96d5ce462d5e198d80faff4d4352c) )
 	ROM_LOAD32_BYTE( "1.0_rampage_world_tour_u131_image.u131",  0x0000002, 0x100000, CRC(fdecf12e) SHA1(bcbd29009dabed484e2357dc75c38c7d7bade251) )
@@ -1524,20 +1524,20 @@ ROM_END
 
 
 ROM_START( rmpgwt11 )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
 	ROM_LOAD16_BYTE( "1.0_rampage_world_tour_u2_sound.u2",  0x000000, 0x100000, CRC(0e82f83d) SHA1(215eebb6c229ef9ad0fcbcbc6e4e07300c05654f) )
 	ROM_LOAD16_BYTE( "1.0_rampage_world_tour_u3_sound.u3",  0x200000, 0x100000, CRC(3ff54d15) SHA1(827805602091313ec68ea1bccf667bd3b3fc6b8b) )
 	ROM_LOAD16_BYTE( "1.0_rampage_world_tour_u4_sound.u4",  0x400000, 0x100000, CRC(5c7f5656) SHA1(6c9d692bad539fec8b5aa0bfb56de3ef3719c68a) )
 	ROM_LOAD16_BYTE( "1.0_rampage_world_tour_u5_sound.u5",  0x600000, 0x100000, CRC(fd9aaf24) SHA1(d60dc076e72618c99ecac9d081d8c49d337b90c7) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
 	ROM_LOAD16_BYTE( "1.1_rampage_world_u54_game.u54",  0x00000, 0x80000, CRC(3aa514eb) SHA1(4ed8db55f257da6d872586d0f9f0cdf1c30e0d22) )
 	ROM_LOAD16_BYTE( "1.1_rampage_world_u63_game.u63",  0x00001, 0x80000, CRC(031c908f) SHA1(531669b13c33921ff199be1e841dd337c86fec50) )
 
-	ROM_REGION( 0x1009, "serial_security:pic", 0 )   /* security PIC (provides game ID code and serial number) */
+	ROM_REGION( 0x1009, "serial_security:pic", 0 )   // security PIC (provides game ID code and serial number)
 	ROM_LOAD( "465_rampage_wt.u64",  0x0000, 0x1009, CRC(5c14d850) SHA1(f57aef8350e477252bff1fa0f930c1b5d0ceb03f) )
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
+	ROM_REGION( 0x2000000, "video", 0 )
 	ROM_LOAD32_BYTE( "1.0_rampage_world_tour_u133_image.u133",  0x0000000, 0x100000, CRC(5b5ac449) SHA1(1c01dde9a9dbd9f4a6cd30aea9f6410cab13c2c9) )
 	ROM_LOAD32_BYTE( "1.0_rampage_world_tour_u132_image.u132",  0x0000001, 0x100000, CRC(7b3f09c6) SHA1(477658481ee96d5ce462d5e198d80faff4d4352c) )
 	ROM_LOAD32_BYTE( "1.0_rampage_world_tour_u131_image.u131",  0x0000002, 0x100000, CRC(fdecf12e) SHA1(bcbd29009dabed484e2357dc75c38c7d7bade251) )
@@ -1592,18 +1592,18 @@ U63 WRESTLEMANIA Rev1.3 8/9/95 9EFE
 8M.3  U118  WRESTLEMANIA REV1.0 6/5/95  E4F1
 */
 ROM_START( wwfmania )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
-	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u2", 0x000000, 0x100000, CRC(a9acb250) SHA1(c1a7773ffdb86dc2c1c90c220482ed6330fcbb55) ) /* These 4 are labeled as L1 */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
+	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u2", 0x000000, 0x100000, CRC(a9acb250) SHA1(c1a7773ffdb86dc2c1c90c220482ed6330fcbb55) ) // These 4 are labeled as L1
 	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u3", 0x200000, 0x100000, CRC(9442b6c9) SHA1(1f887c05ab9ca99078be584d7e9e6c59c8ec1818) )
 	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u4", 0x400000, 0x100000, CRC(cee78fac) SHA1(c37d3b4aef47dc80d864497b3013f03220d45482) )
 	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u5", 0x600000, 0x100000, CRC(5b31fd40) SHA1(35dcf19b223029e17616357d29dd04bbfeb83491) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
-	ROM_LOAD16_BYTE( "wwf_game_rom_l1.30.u54", 0x00000, 0x80000, CRC(eeb7bf58) SHA1(d93df59aed1672ab38af231d909d9df1a8e30f44) ) /* Labeled as L1.30 */
-	ROM_LOAD16_BYTE( "wwf_game_rom_l1.30.u63", 0x00001, 0x80000, CRC(09759529) SHA1(cf548ff199428a93b9bc5f4fc1347c4a3cbdf106) ) /* Labeled as L1.30 */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
+	ROM_LOAD16_BYTE( "wwf_game_rom_l1.30.u54", 0x00000, 0x80000, CRC(eeb7bf58) SHA1(d93df59aed1672ab38af231d909d9df1a8e30f44) ) // Labeled as L1.30
+	ROM_LOAD16_BYTE( "wwf_game_rom_l1.30.u63", 0x00001, 0x80000, CRC(09759529) SHA1(cf548ff199428a93b9bc5f4fc1347c4a3cbdf106) ) // Labeled as L1.30
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
-	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u133", 0x0000000, 0x100000, CRC(5e1b1e3d) SHA1(55f54e4b0dc775058699b1c0abdd7241ffca0e76) ) /* All graphics roms labeled as L1 */
+	ROM_REGION( 0x2000000, "video", 0 )
+	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u133", 0x0000000, 0x100000, CRC(5e1b1e3d) SHA1(55f54e4b0dc775058699b1c0abdd7241ffca0e76) ) // All graphics roms labeled as L1
 	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u132", 0x0000001, 0x100000, CRC(5943b3b2) SHA1(8ba0b20e7993769736c961d0fda97b2850d1446b) )
 	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u131", 0x0000002, 0x100000, CRC(0815db22) SHA1(ebd6a8c4f0e8d979af7f173b3f139d91e4857f6b) )
 	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u130", 0x0000003, 0x100000, CRC(9ee9a145) SHA1(caeb8506e1414e8c58e3031d4a2e0619ef3922b7) )
@@ -1626,18 +1626,18 @@ ROM_END
 
 
 ROM_START( wwfmaniab )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
-	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u2", 0x000000, 0x100000, CRC(a9acb250) SHA1(c1a7773ffdb86dc2c1c90c220482ed6330fcbb55) ) /* These 4 are labeled as L1 */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
+	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u2", 0x000000, 0x100000, CRC(a9acb250) SHA1(c1a7773ffdb86dc2c1c90c220482ed6330fcbb55) ) // These 4 are labeled as L1
 	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u3", 0x200000, 0x100000, CRC(9442b6c9) SHA1(1f887c05ab9ca99078be584d7e9e6c59c8ec1818) )
 	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u4", 0x400000, 0x100000, CRC(cee78fac) SHA1(c37d3b4aef47dc80d864497b3013f03220d45482) )
 	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u5", 0x600000, 0x100000, CRC(5b31fd40) SHA1(35dcf19b223029e17616357d29dd04bbfeb83491) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
-	ROM_LOAD16_BYTE( "wwf_game_rom_l1.20.u54",  0x00000, 0x80000, CRC(1b2dce48) SHA1(f70b6c5b56f9fc15cedfd8e0a95f983f3ea6dbb7) ) /* Labeled as L1.20 */
-	ROM_LOAD16_BYTE( "wwf_game_rom_l1.20.u63",  0x00001, 0x80000, CRC(1262f0bb) SHA1(e97a5939f10532f7815d08b1a7d63a7554d47d4f) ) /* Labeled as L1.20 */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
+	ROM_LOAD16_BYTE( "wwf_game_rom_l1.20.u54",  0x00000, 0x80000, CRC(1b2dce48) SHA1(f70b6c5b56f9fc15cedfd8e0a95f983f3ea6dbb7) ) // Labeled as L1.20
+	ROM_LOAD16_BYTE( "wwf_game_rom_l1.20.u63",  0x00001, 0x80000, CRC(1262f0bb) SHA1(e97a5939f10532f7815d08b1a7d63a7554d47d4f) ) // Labeled as L1.20
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
-	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u133", 0x0000000, 0x100000, CRC(5e1b1e3d) SHA1(55f54e4b0dc775058699b1c0abdd7241ffca0e76) ) /* All graphics roms labeled as L1 */
+	ROM_REGION( 0x2000000, "video", 0 )
+	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u133", 0x0000000, 0x100000, CRC(5e1b1e3d) SHA1(55f54e4b0dc775058699b1c0abdd7241ffca0e76) ) // All graphics roms labeled as L1
 	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u132", 0x0000001, 0x100000, CRC(5943b3b2) SHA1(8ba0b20e7993769736c961d0fda97b2850d1446b) )
 	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u131", 0x0000002, 0x100000, CRC(0815db22) SHA1(ebd6a8c4f0e8d979af7f173b3f139d91e4857f6b) )
 	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u130", 0x0000003, 0x100000, CRC(9ee9a145) SHA1(caeb8506e1414e8c58e3031d4a2e0619ef3922b7) )
@@ -1660,18 +1660,18 @@ ROM_END
 
 
 ROM_START( wwfmaniac )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
-	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u2", 0x000000, 0x100000, CRC(a9acb250) SHA1(c1a7773ffdb86dc2c1c90c220482ed6330fcbb55) ) /* These 4 are labeled as L1 */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
+	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u2", 0x000000, 0x100000, CRC(a9acb250) SHA1(c1a7773ffdb86dc2c1c90c220482ed6330fcbb55) ) // These 4 are labeled as L1
 	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u3", 0x200000, 0x100000, CRC(9442b6c9) SHA1(1f887c05ab9ca99078be584d7e9e6c59c8ec1818) )
 	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u4", 0x400000, 0x100000, CRC(cee78fac) SHA1(c37d3b4aef47dc80d864497b3013f03220d45482) )
 	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u5", 0x600000, 0x100000, CRC(5b31fd40) SHA1(35dcf19b223029e17616357d29dd04bbfeb83491) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
-	ROM_LOAD16_BYTE( "wwf_game_rom_l1.10.u54",  0x00000, 0x80000, CRC(ae1a3195) SHA1(89ce1e3dc46b4da2d723b61e868889d05f7d5162) ) /* Labeled as L1.10, test menu shows REV 1.1 */
-	ROM_LOAD16_BYTE( "wwf_game_rom_l1.10.u63",  0x00001, 0x80000, CRC(d809eb60) SHA1(9531009fb6e245548ab52ac1cbb6c736d6357cb5) ) /* Labeled as L1.10, test menu shows REV 1.1 */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
+	ROM_LOAD16_BYTE( "wwf_game_rom_l1.10.u54",  0x00000, 0x80000, CRC(ae1a3195) SHA1(89ce1e3dc46b4da2d723b61e868889d05f7d5162) ) // Labeled as L1.10, test menu shows REV 1.1
+	ROM_LOAD16_BYTE( "wwf_game_rom_l1.10.u63",  0x00001, 0x80000, CRC(d809eb60) SHA1(9531009fb6e245548ab52ac1cbb6c736d6357cb5) ) // Labeled as L1.10, test menu shows REV 1.1
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
-	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u133", 0x0000000, 0x100000, CRC(5e1b1e3d) SHA1(55f54e4b0dc775058699b1c0abdd7241ffca0e76) ) /* All graphics roms labeled as L1 */
+	ROM_REGION( 0x2000000, "video", 0 )
+	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u133", 0x0000000, 0x100000, CRC(5e1b1e3d) SHA1(55f54e4b0dc775058699b1c0abdd7241ffca0e76) ) // All graphics roms labeled as L1
 	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u132", 0x0000001, 0x100000, CRC(5943b3b2) SHA1(8ba0b20e7993769736c961d0fda97b2850d1446b) )
 	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u131", 0x0000002, 0x100000, CRC(0815db22) SHA1(ebd6a8c4f0e8d979af7f173b3f139d91e4857f6b) )
 	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u130", 0x0000003, 0x100000, CRC(9ee9a145) SHA1(caeb8506e1414e8c58e3031d4a2e0619ef3922b7) )
@@ -1694,18 +1694,18 @@ ROM_END
 
 
 ROM_START( wwfmaniap )
-	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   /* sound data */
-	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u2", 0x000000, 0x100000, CRC(a9acb250) SHA1(c1a7773ffdb86dc2c1c90c220482ed6330fcbb55) ) /* These 4 are labeled as L1 */
+	ROM_REGION16_LE( 0x800000, "dcs", ROMREGION_ERASEFF )   // sound data
+	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u2", 0x000000, 0x100000, CRC(a9acb250) SHA1(c1a7773ffdb86dc2c1c90c220482ed6330fcbb55) ) // These 4 are labeled as L1
 	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u3", 0x200000, 0x100000, CRC(9442b6c9) SHA1(1f887c05ab9ca99078be584d7e9e6c59c8ec1818) )
 	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u4", 0x400000, 0x100000, CRC(cee78fac) SHA1(c37d3b4aef47dc80d864497b3013f03220d45482) )
 	ROM_LOAD16_BYTE( "wwf_music-spch_l1.u5", 0x600000, 0x100000, CRC(5b31fd40) SHA1(35dcf19b223029e17616357d29dd04bbfeb83491) )
 
-	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   /* 34010 code */
-	ROM_LOAD16_BYTE( "wwf_game_rom_p2.01.u54",  0x00000, 0x80000, CRC(a3d0b6d1) SHA1(974e0d40e3852b4c3233098079ded95110cca62e) ) /* missing labels */
-	ROM_LOAD16_BYTE( "wwf_game_rom_p2.01.u63",  0x00001, 0x80000, CRC(22b80ae4) SHA1(4e160df9caf43fcf43ce002af4c88c2a324c4d86) ) /* missing labels */
+	ROM_REGION16_LE( 0x100000, "maincpu", 0 )   // 34010 code
+	ROM_LOAD16_BYTE( "wwf_game_rom_p2.01.u54",  0x00000, 0x80000, CRC(a3d0b6d1) SHA1(974e0d40e3852b4c3233098079ded95110cca62e) ) // missing labels
+	ROM_LOAD16_BYTE( "wwf_game_rom_p2.01.u63",  0x00001, 0x80000, CRC(22b80ae4) SHA1(4e160df9caf43fcf43ce002af4c88c2a324c4d86) ) // missing labels
 
-	ROM_REGION( 0x2000000, "gfxrom", 0 )
-	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u133", 0x0000000, 0x100000, CRC(5e1b1e3d) SHA1(55f54e4b0dc775058699b1c0abdd7241ffca0e76) ) /* All graphics roms labeled as L1 */
+	ROM_REGION( 0x2000000, "video", 0 )
+	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u133", 0x0000000, 0x100000, CRC(5e1b1e3d) SHA1(55f54e4b0dc775058699b1c0abdd7241ffca0e76) ) // All graphics roms labeled as L1
 	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u132", 0x0000001, 0x100000, CRC(5943b3b2) SHA1(8ba0b20e7993769736c961d0fda97b2850d1446b) )
 	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u131", 0x0000002, 0x100000, CRC(0815db22) SHA1(ebd6a8c4f0e8d979af7f173b3f139d91e4857f6b) )
 	ROM_LOAD32_BYTE( "wwf_image_rom_l1.u130", 0x0000003, 0x100000, CRC(9ee9a145) SHA1(caeb8506e1414e8c58e3031d4a2e0619ef3922b7) )

--- a/src/mame/midway/midwunit.h
+++ b/src/mame/midway/midwunit.h
@@ -28,7 +28,6 @@ public:
 		, m_video(*this, "video")
 		, m_dcs(*this, "dcs")
 		, m_palette(*this, "palette")
-		, m_gfxrom(*this, "gfxrom")
 		, m_midway_serial_pic(*this, "serial_security_sim")
 		, m_midway_serial_pic_emu(*this, "serial_security")
 		, m_nvram(*this, "nvram")
@@ -55,16 +54,16 @@ protected:
 	virtual void machine_reset() override;
 
 private:
-	void midwunit_cmos_enable_w(uint16_t data);
-	void midwunit_cmos_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t midwunit_cmos_r(offs_t offset);
-	void midwunit_io_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t midwunit_io_r(offs_t offset);
-	uint16_t midwunit_security_r();
-	void midwunit_security_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t midwunit_sound_r();
-	uint16_t midwunit_sound_state_r();
-	void midwunit_sound_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void cmos_enable_w(uint16_t data);
+	void cmos_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	uint16_t cmos_r(offs_t offset);
+	void io_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	uint16_t io_r(offs_t offset);
+	uint16_t security_r();
+	void security_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	uint16_t sound_r();
+	uint16_t sound_state_r();
+	void sound_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void umk3_palette_hack_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void wwfmania_io_0_w(uint16_t data);
 
@@ -75,7 +74,6 @@ private:
 	required_device<midtunit_video_device> m_video;
 	required_device<dcs_audio_device> m_dcs;
 	required_device<palette_device> m_palette;
-	required_memory_region m_gfxrom;
 
 	optional_device<midway_serial_pic_device> m_midway_serial_pic;
 	optional_device<midway_serial_pic_emu_device> m_midway_serial_pic_emu;

--- a/src/mame/midway/midwunit_m.cpp
+++ b/src/mame/midway/midwunit_m.cpp
@@ -23,13 +23,13 @@
  *
  *************************************/
 
-void midwunit_state::midwunit_cmos_enable_w(uint16_t data)
+void midwunit_state::cmos_enable_w(uint16_t data)
 {
 	m_cmos_write_enable = 1;
 }
 
 
-void midwunit_state::midwunit_cmos_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void midwunit_state::cmos_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	if (m_cmos_write_enable)
 	{
@@ -45,7 +45,7 @@ void midwunit_state::midwunit_cmos_w(offs_t offset, uint16_t data, uint16_t mem_
 
 
 
-uint16_t midwunit_state::midwunit_cmos_r(offs_t offset)
+uint16_t midwunit_state::cmos_r(offs_t offset)
 {
 	return m_nvram[offset];
 }
@@ -58,14 +58,14 @@ uint16_t midwunit_state::midwunit_cmos_r(offs_t offset)
  *
  *************************************/
 
-void midwunit_state::midwunit_io_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void midwunit_state::io_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	// apply I/O shuffling
 	offset = m_ioshuffle[offset % 16];
 
 	offset %= 8;
-	int oldword = m_iodata[offset];
-	int newword = oldword;
+	uint16_t const oldword = m_iodata[offset];
+	uint16_t newword = oldword;
 	COMBINE_DATA(&newword);
 
 	switch (offset)
@@ -73,18 +73,18 @@ void midwunit_state::midwunit_io_w(offs_t offset, uint16_t data, uint16_t mem_ma
 		case 1:
 			LOGMASKED(LOG_IO, "%s: Control W @ %05X = %04X\n", machine().describe_context(), offset, data);
 
-			/* bit 4 reset sound CPU */
+			// bit 4 reset sound CPU
 			m_dcs->reset_w(~newword & 0x10);
 
-			/* bit 5 (active low) reset security chip */
+			// bit 5 (active low) reset security chip
 			if (m_midway_serial_pic) m_midway_serial_pic->reset_w(newword & 0x20);
 			if (m_midway_serial_pic_emu) m_midway_serial_pic_emu->reset_w(newword & 0x20);
 			break;
 
 		case 3:
-			/* watchdog reset */
-			/* MK3 resets with this enabled */
-/*          watchdog_reset_w(0,0);*/
+			// watchdog reset
+			// MK3 resets with this enabled
+			// watchdog_reset_w(0,0);
 			break;
 
 		default:
@@ -102,9 +102,9 @@ void midwunit_state::midwunit_io_w(offs_t offset, uint16_t data, uint16_t mem_ma
  *
  *************************************/
 
-uint16_t midwunit_state::midwunit_io_r(offs_t offset)
+uint16_t midwunit_state::io_r(offs_t offset)
 {
-	/* apply I/O shuffling */
+	// apply I/O shuffling
 	offset = m_ioshuffle[offset % 16];
 
 	switch (offset)
@@ -121,10 +121,11 @@ uint16_t midwunit_state::midwunit_io_r(offs_t offset)
 			if (m_midway_serial_pic) picret = m_midway_serial_pic->status_r();
 			if (m_midway_serial_pic_emu) picret = m_midway_serial_pic_emu->status_r();
 
-			return (picret << 12) | midwunit_sound_state_r();
+			return (picret << 12) | sound_state_r();
 		}
 		default:
-			LOGMASKED(LOG_IO | LOG_UNKNOWN, "%s: Unknown I/O read from %d\n", machine().describe_context(), offset);
+			if (!machine().side_effects_disabled())
+				LOGMASKED(LOG_IO | LOG_UNKNOWN, "%s: Unknown I/O read from %d\n", machine().describe_context(), offset);
 			break;
 	}
 	return ~0;
@@ -183,12 +184,12 @@ void midwunit_state::umk3_palette_hack_w(offs_t offset, uint16_t data, uint16_t 
 	*/
 	COMBINE_DATA(&m_umk3_palette[offset]);
 	m_maincpu->adjust_icount(-100);
-/*  printf("in=%04X%04X  out=%04X%04X\n", m_umk3_palette[3], m_umk3_palette[2], m_umk3_palette[1], m_umk3_palette[0]); */
+//  printf("in=%04X%04X  out=%04X%04X\n", m_umk3_palette[3], m_umk3_palette[2], m_umk3_palette[1], m_umk3_palette[0]);
 }
 
 void midwunit_state::init_mk3_common()
 {
-	/* serial prefixes 439, 528 */
+	// serial prefixes 439, 528
 	//midway_serial_pic_init(machine(), 528);
 }
 
@@ -226,7 +227,7 @@ void midwunit_state::init_umk3r11()
 
 void midwunit_state::init_openice()
 {
-	/* serial prefixes 438, 528 */
+	// serial prefixes 438, 528
 	//midway_serial_pic_init(machine(), 528);
 }
 
@@ -235,7 +236,7 @@ void midwunit_state::init_openice()
 
 void midwunit_state::init_nbahangt()
 {
-	/* serial prefixes 459, 470, 528 */
+	// serial prefixes 459, 470, 528
 	//midway_serial_pic_init(machine(), 528);
 }
 
@@ -245,11 +246,11 @@ void midwunit_state::init_nbahangt()
 // note: other game's PCBs probably shuffle I/O addresses too, but only WWF game code use/require this.
 void midwunit_state::wwfmania_io_0_w(uint16_t data)
 {
-	/* start with the originals */
+	// start with the originals
 	for (int i = 0; i < 16; i++)
 		m_ioshuffle[i] = i % 8;
 
-	/* based on the data written, shuffle */
+	// based on the data written, shuffle
 	switch (data)
 	{
 		case 0:
@@ -292,10 +293,10 @@ void midwunit_state::wwfmania_io_0_w(uint16_t data)
 
 void midwunit_state::init_wwfmania()
 {
-	/* enable I/O shuffling */
+	// enable I/O shuffling
 	m_maincpu->space(AS_PROGRAM).install_write_handler(0x01800000, 0x0180000f, write16smo_delegate(*this, FUNC(midwunit_state::wwfmania_io_0_w)));
 
-	/* serial prefixes 430, 528 */
+	// serial prefixes 430, 528
 	//midway_serial_pic_init(machine(), 528);
 }
 
@@ -304,7 +305,7 @@ void midwunit_state::init_wwfmania()
 
 void midwunit_state::init_rmpgwt()
 {
-	/* serial prefixes 465, 528 */
+	// serial prefixes 465, 528
 	//midway_serial_pic_init(machine(), 528);
 }
 
@@ -317,11 +318,11 @@ void midwunit_state::init_rmpgwt()
 
 void midwunit_state::machine_reset()
 {
-	/* reset sound */
+	// reset sound
 	m_dcs->reset_w(0);
 	m_dcs->reset_w(1);
 
-	/* reset I/O shuffling */
+	// reset I/O shuffling
 	for (int i = 0; i < 16; i++)
 		m_ioshuffle[i] = i % 8;
 }
@@ -334,7 +335,7 @@ void midwunit_state::machine_reset()
  *
  *************************************/
 
-uint16_t midwunit_state::midwunit_security_r()
+uint16_t midwunit_state::security_r()
 {
 	uint16_t picret = 0;
 	if (m_midway_serial_pic) picret = m_midway_serial_pic->read();
@@ -343,7 +344,7 @@ uint16_t midwunit_state::midwunit_security_r()
 }
 
 
-void midwunit_state::midwunit_security_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void midwunit_state::security_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	if (offset == 0 && ACCESSING_BITS_0_7)
 	{
@@ -360,30 +361,31 @@ void midwunit_state::midwunit_security_w(offs_t offset, uint16_t data, uint16_t 
  *
  *************************************/
 
-uint16_t midwunit_state::midwunit_sound_r()
+uint16_t midwunit_state::sound_r()
 {
-	LOGMASKED(LOG_SOUND, "%s: Sound read\n", machine().describe_context());
+	if (!machine().side_effects_disabled())
+		LOGMASKED(LOG_SOUND, "%s: Sound read\n", machine().describe_context());
 
 	return m_dcs->data_r() & 0xff;
 }
 
 
-uint16_t midwunit_state::midwunit_sound_state_r()
+uint16_t midwunit_state::sound_state_r()
 {
 	return m_dcs->control_r();
 }
 
 
-void midwunit_state::midwunit_sound_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void midwunit_state::sound_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	/* check for out-of-bounds accesses */
+	// check for out-of-bounds accesses
 	if (offset)
 	{
 		LOGMASKED(LOG_SOUND | LOG_UNKNOWN, "%s: Unexpected write to sound (hi) = %04X\n", machine().describe_context(), data);
 		return;
 	}
 
-	/* call through based on the sound type */
+	// call through based on the sound type
 	if (ACCESSING_BITS_0_7)
 	{
 		LOGMASKED(LOG_SOUND, "%s: Sound write = %04X\n", machine().describe_context(), data);

--- a/src/mame/midway/midxunit.h
+++ b/src/mame/midway/midxunit.h
@@ -30,7 +30,6 @@ public:
 		, m_video(*this, "video")
 		, m_dcs(*this, "dcs")
 		, m_palette(*this, "palette")
-		, m_gfxrom(*this, "gfxrom")
 		, m_nvram(*this, "nvram")
 		, m_pic(*this, "pic")
 		, m_gun_recoil(*this, "Player%u_Gun_Recoil", 1U)
@@ -44,20 +43,20 @@ protected:
 	virtual void machine_reset() override;
 
 private:
-	uint8_t midxunit_cmos_r(offs_t offset);
-	void midxunit_cmos_w(offs_t offset, uint8_t data);
-	void midxunit_io_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void midxunit_unknown_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	uint8_t cmos_r(offs_t offset);
+	void cmos_w(offs_t offset, uint8_t data);
+	void io_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void unknown_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void adc_int_w(int state);
-	uint32_t midxunit_status_r();
-	uint8_t midxunit_uart_r(offs_t offset);
-	void midxunit_uart_w(offs_t offset, uint8_t data);
-	uint32_t midxunit_security_r();
-	void midxunit_security_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void midxunit_security_clock_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void midxunit_dcs_output_full(int state);
-	uint32_t midxunit_dma_r(offs_t offset, uint32_t mem_mask = ~0);
-	void midxunit_dma_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	uint32_t status_r();
+	uint8_t uart_r(offs_t offset);
+	void uart_w(offs_t offset, uint8_t data);
+	uint32_t security_r();
+	void security_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	void security_clock_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	void dcs_output_full(int state);
+	uint32_t dma_r(offs_t offset, uint32_t mem_mask = ~0);
+	void dma_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 
 	void main_map(address_map &map);
 
@@ -65,7 +64,6 @@ private:
 	required_device<midtunit_video_device> m_video;
 	required_device<dcs_audio_device> m_dcs;
 	required_device<palette_device> m_palette;
-	required_memory_region m_gfxrom;
 
 	required_device<nvram_device> m_nvram;
 	required_device<pic16c57_device> m_pic;


### PR DESCRIPTION
midtunit_v.cpp:
Use devcb_write_line for DMA IRQ handling
Reduce hardcoded tags
Reduce unnecessary DUMMY_TAG
Initialize variables in constructor
Constantize variables
Use logmacro.h for logging
Fix function name

midtunit.cpp:
Split class related to sound system
Reduce defines
Reduce literal tag usage
Use logmacro.h for logging
Fix function name
Suppress side effects for debugger read
Reduce unnecessary functions
Reduce unnecessary finders

midwunit.cpp:
Reduce defines
Constantize variables
Reduce literal tag usages
Suppress side effects for debugger read
Fix function naming
Reduce unnecessary finders

midxunit.cpp:
Reduce defines
Constantize variables
Reduce literal tag usages
Suppress side effects for debugger read
Fix function naming