### PR TITLE
heathkit/h89.cpp and h19.cpp: Temporary remove gp19 option for tlbc slot

### DIFF
--- a/src/mame/heathkit/h19.cpp
+++ b/src/mame/heathkit/h19.cpp
@@ -38,7 +38,8 @@ private:
 static void tlb_options(device_slot_interface &device)
 {
 	device.option_add("heath", HEATH_TLB);
-	device.option_add("gp19", HEATH_GP19);
+	// temporary disable GP19 due not initializing properly after commit 1af40e3a1c828e8394d51b8f3b611d39a2b4bb5e 
+	// device.option_add("gp19", HEATH_GP19);
 	device.option_add("imaginator", HEATH_IMAGINATOR);
 	device.option_add("super19", HEATH_SUPER19);
 	device.option_add("superset", HEATH_SUPERSET);

--- a/src/mame/heathkit/h89.cpp
+++ b/src/mame/heathkit/h89.cpp
@@ -810,7 +810,8 @@ void h89_base_state::port_f2_w(uint8_t data)
 static void tlb_options(device_slot_interface &device)
 {
 	device.option_add("heath", HEATH_TLB);
-	device.option_add("gp19", HEATH_GP19);
+	// temporary disable GP19 due not initializing properly after commit 1af40e3a1c828e8394d51b8f3b611d39a2b4bb5e 
+	// device.option_add("gp19", HEATH_GP19);
 	device.option_add("imaginator", HEATH_IMAGINATOR);
 	device.option_add("super19", HEATH_SUPER19);
 	device.option_add("superset", HEATH_SUPERSET);


### PR DESCRIPTION
Currently gp19 option is not working. I narrowed it down to commit 1af40e3a1c828e8394d51b8f3b611d39a2b4bb5e, but it is not obvious what causing the system from not coming up. Temporarily remove the option until issue can be resolved. 