### PR TITLE
bus/msx/cart/*: Use arrays of memory views.

### DIFF
--- a/src/devices/bus/msx/cart/dooly.cpp
+++ b/src/devices/bus/msx/cart/dooly.cpp
@@ -11,8 +11,7 @@ public:
 	msx_cart_dooly_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 		: device_t(mconfig, MSX_CART_DOOLY, tag, owner, clock)
 		, msx_cart_interface(mconfig, *this)
-		, m_view1(*this, "view1")
-		, m_view2(*this, "view2")
+		, m_rombank(*this, "bank%u", 0U)
 	{ }
 
 	virtual std::error_condition initialize_cartridge(std::string &message) override;
@@ -27,14 +26,14 @@ private:
 	u8 mode4_page1_r(offs_t offset);
 	u8 mode4_page2_r(offs_t offset);
 
-	memory_view m_view1;
-	memory_view m_view2;
+	std::unique_ptr<u8[]> m_bitswapped;
+	memory_bank_array_creator<2> m_rombank;
 };
 
 void msx_cart_dooly_device::device_reset()
 {
-	m_view1.select(0);
-	m_view2.select(0);
+	m_rombank[0]->set_entry(0);
+	m_rombank[1]->set_entry(0);
 }
 
 std::error_condition msx_cart_dooly_device::initialize_cartridge(std::string &message)
@@ -51,34 +50,29 @@ std::error_condition msx_cart_dooly_device::initialize_cartridge(std::string &me
 		return image_error::INVALIDLENGTH;
 	}
 
-	page(1)->install_view(0x4000, 0x7fff, m_view1);
-	m_view1[0].install_rom(0x4000, 0x7fff, cart_rom_region()->base());
-	m_view1[1].install_read_handler(0x4000, 0x7fff, emu::rw_delegate(*this, FUNC(msx_cart_dooly_device::mode4_page1_r)));
-	page(2)->install_view(0x8000, 0xbfff, m_view2);
-	m_view2[0].install_rom(0x8000, 0xbfff, cart_rom_region()->base() + 0x4000);
-	m_view2[1].install_read_handler(0x8000, 0xbfff, emu::rw_delegate(*this, FUNC(msx_cart_dooly_device::mode4_page2_r)));
+	m_bitswapped = std::make_unique<u8[]>(0x8000);
+	for (int i = 0; i < 0x8000; i++)
+		m_bitswapped[i] = bitswap<8>(cart_rom_region()->base()[i], 7, 6, 5, 4, 3, 1, 0, 2);
 
+	m_rombank[0]->configure_entry(0, cart_rom_region()->base());
+	m_rombank[0]->configure_entry(1, m_bitswapped.get());
+	m_rombank[1]->configure_entry(0, cart_rom_region()->base() + 0x4000);
+	m_rombank[1]->configure_entry(1, m_bitswapped.get() + 0x4000);
+
+	page(1)->install_read_bank(0x4000, 0x7fff, m_rombank[0]);
 	page(1)->install_write_handler(0x4000, 0x7fff, emu::rw_delegate(*this, FUNC(msx_cart_dooly_device::prot_w)));
+	page(2)->install_read_bank(0x8000, 0xbfff, m_rombank[1]);
 	page(2)->install_write_handler(0x8000, 0xbfff, emu::rw_delegate(*this, FUNC(msx_cart_dooly_device::prot_w)));
 
 	return std::error_condition();
 }
 
-u8 msx_cart_dooly_device::mode4_page1_r(offs_t offset)
-{
-	return bitswap<8>(cart_rom_region()->base()[offset], 7, 6, 5, 4, 3, 1, 0, 2);
-}
-
-u8 msx_cart_dooly_device::mode4_page2_r(offs_t offset)
-{
-	return bitswap<8>(cart_rom_region()->base()[0x4000 | offset], 7, 6, 5, 4, 3, 1, 0, 2);
-}
-
 void msx_cart_dooly_device::prot_w(u8 data)
 {
 	data &= 0x07;
-	m_view1.select(BIT(data, 2) ? 1 : 0);
-	m_view2.select(BIT(data, 2) ? 1 : 0);
+	m_rombank[0]->set_entry(BIT(data, 2) ? 1 : 0);
+	m_rombank[1]->set_entry(BIT(data, 2) ? 1 : 0);
+
 	if (data != 0 && data != 4)
 	{
 		logerror("msx_cart_dooly_device: unhandled protection mode %02x\n", data);

--- a/src/devices/bus/msx/cart/halnote.cpp
+++ b/src/devices/bus/msx/cart/halnote.cpp
@@ -12,8 +12,7 @@ public:
 		: device_t(mconfig, MSX_CART_HALNOTE, tag, owner, clock)
 		, msx_cart_interface(mconfig, *this)
 		, m_rombank(*this, "rombank%u", 0U)
-		, m_view0(*this, "view0")
-		, m_view1(*this, "view1")
+		, m_view{ {*this, "view0"}, {*this, "view1"} }
 	{ }
 
 	virtual std::error_condition initialize_cartridge(std::string &message) override;
@@ -26,16 +25,15 @@ protected:
 private:
 	static constexpr u8 BANK_MASK = (0x100000 / 0x2000) - 1;
 
+	template <int Bank> void bank_w(u8 data);
 	void bank0_w(u8 data);
 	void bank1_w(u8 data);
 	void bank2_w(u8 data);
 	void bank3_w(u8 data);
-	void bank4_w(u8 data);
-	void bank5_w(u8 data);
+	template <int Bank> void bank_small_w(u8 data);
 
 	memory_bank_array_creator<6> m_rombank;
-	memory_view m_view0;
-	memory_view m_view1;
+	memory_view m_view[2];
 };
 
 void msx_cart_halnote_device::device_reset()
@@ -43,8 +41,8 @@ void msx_cart_halnote_device::device_reset()
 	for (int i = 0; i < 6; i++)
 		m_rombank[i]->set_entry(0);
 
-	m_view0.disable();
-	m_view1.select(0);
+	m_view[0].disable();
+	m_view[1].select(0);
 }
 
 std::error_condition msx_cart_halnote_device::initialize_cartridge(std::string &message)
@@ -80,60 +78,42 @@ std::error_condition msx_cart_halnote_device::initialize_cartridge(std::string &
 	m_rombank[4]->configure_entries(0, 0x100, cart_rom_region()->base() + 0x80000, 0x800);
 	m_rombank[5]->configure_entries(0, 0x100, cart_rom_region()->base() + 0x80000, 0x800);
 
-	page(0)->install_view(0x0000, 0x3fff, m_view0);
-	m_view0[0];
-	m_view0[1].install_ram(0x0000, 0x3fff, cart_sram_region()->base());
+	page(0)->install_view(0x0000, 0x3fff, m_view[0]);
+	m_view[0][0];
+	m_view[0][1].install_ram(0x0000, 0x3fff, cart_sram_region()->base());
 	page(1)->install_read_bank(0x4000, 0x5fff, m_rombank[0]);
-	page(1)->install_write_handler(0x4fff, 0x4fff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank0_w)));
-	page(1)->install_view(0x6000, 0x7fff, m_view1);
-	m_view1[0].install_read_bank(0x6000, 0x7fff, m_rombank[1]);
-	m_view1[0].install_write_handler(0x6fff, 0x6fff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank1_w)));
-	m_view1[0].install_write_handler(0x77ff, 0x77ff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank4_w)));
-	m_view1[0].install_write_handler(0x7fff, 0x7fff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank5_w)));
-	m_view1[1].install_read_bank(0x6000, 0x6fff, m_rombank[1]);
-	m_view1[1].install_write_handler(0x6fff, 0x6fff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank1_w)));
-	m_view1[1].install_read_bank(0x7000, 0x77ff, m_rombank[4]);
-	m_view1[1].install_write_handler(0x77ff, 0x77ff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank4_w)));
-	m_view1[1].install_read_bank(0x7800, 0x7fff, m_rombank[5]);
-	m_view1[1].install_write_handler(0x7fff, 0x7fff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank5_w)));
+	page(1)->install_write_handler(0x4fff, 0x4fff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank_w<0>)));
+	page(1)->install_view(0x6000, 0x7fff, m_view[1]);
+	m_view[1][0].install_read_bank(0x6000, 0x7fff, m_rombank[1]);
+	m_view[1][0].install_write_handler(0x6fff, 0x6fff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank_w<1>)));
+	m_view[1][0].install_write_handler(0x77ff, 0x77ff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank_small_w<4>)));
+	m_view[1][0].install_write_handler(0x7fff, 0x7fff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank_small_w<5>)));
+	m_view[1][1].install_read_bank(0x6000, 0x6fff, m_rombank[1]);
+	m_view[1][1].install_write_handler(0x6fff, 0x6fff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank_w<1>)));
+	m_view[1][1].install_read_bank(0x7000, 0x77ff, m_rombank[4]);
+	m_view[1][1].install_write_handler(0x77ff, 0x77ff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank_small_w<4>)));
+	m_view[1][1].install_read_bank(0x7800, 0x7fff, m_rombank[5]);
+	m_view[1][1].install_write_handler(0x7fff, 0x7fff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank_small_w<5>)));
 	page(2)->install_read_bank(0x8000, 0x9fff, m_rombank[2]);
-	page(2)->install_write_handler(0x8fff, 0x8fff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank2_w)));
+	page(2)->install_write_handler(0x8fff, 0x8fff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank_w<2>)));
 	page(2)->install_read_bank(0xa000, 0xbfff, m_rombank[3]);
-	page(2)->install_write_handler(0xafff, 0xafff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank3_w)));
+	page(2)->install_write_handler(0xafff, 0xafff, emu::rw_delegate(*this, FUNC(msx_cart_halnote_device::bank_w<3>)));
 
 	return std::error_condition();
 }
 
-void msx_cart_halnote_device::bank0_w(u8 data)
+template <int Bank>
+void msx_cart_halnote_device::bank_w(u8 data)
 {
-	m_rombank[0]->set_entry(data & 0x7f);
-	m_view0.select(BIT(data, 7) ? 1 : 0);
+	m_rombank[Bank]->set_entry(data & 0x7f);
+	if (Bank == 0 || Bank == 3)
+		m_view[Bank ? 1 : 0].select(BIT(data, 7) ? 1 : 0);
 }
 
-void msx_cart_halnote_device::bank1_w(u8 data)
+template <int Bank>
+void msx_cart_halnote_device::bank_small_w(u8 data)
 {
-	m_rombank[1]->set_entry(data & 0x7f);
-}
-
-void msx_cart_halnote_device::bank2_w(u8 data)
-{
-	m_rombank[2]->set_entry(data & 0x7f);
-}
-
-void msx_cart_halnote_device::bank3_w(u8 data)
-{
-	m_rombank[3]->set_entry(data & 0x7f);
-	m_view1.select(BIT(data, 7) ? 1 : 0);
-}
-
-void msx_cart_halnote_device::bank4_w(u8 data)
-{
-	m_rombank[4]->set_entry(data);
-}
-
-void msx_cart_halnote_device::bank5_w(u8 data)
-{
-	m_rombank[5]->set_entry(data);
+	m_rombank[Bank]->set_entry(data);
 }
 
 } // anonymous namespace

--- a/src/devices/bus/msx/cart/slotexpander.cpp
+++ b/src/devices/bus/msx/cart/slotexpander.cpp
@@ -48,10 +48,7 @@ public:
 		, msx_cart_interface(mconfig, *this)
 		, m_cartslot(*this, "cartslot%u", 1)
 		, m_irq_out(*this, "irq_out")
-		, m_view0(*this, "view0")
-		, m_view1(*this, "view1")
-		, m_view2(*this, "view2")
-		, m_view3(*this, "view3")
+		, m_view{ {*this, "view0"}, {*this, "view1"}, {*this, "view2"}, {*this, "view3"} }
 		, m_secondary_slot(0)
 	{ }
 
@@ -68,10 +65,7 @@ private:
 
 	required_device_array<msx_slot_cartridge_device, 4> m_cartslot;
 	required_device<input_merger_any_high_device> m_irq_out;
-	memory_view m_view0;
-	memory_view m_view1;
-	memory_view m_view2;
-	memory_view m_view3;
+	memory_view m_view[4];
 	u8 m_secondary_slot;
 };
 
@@ -114,22 +108,16 @@ void msx_cart_slotexpander_device::device_config_complete()
 
 void msx_cart_slotexpander_device::device_resolve_objects()
 {
-	page(0)->install_view(0x0000, 0x3fff, m_view0);
-	page(1)->install_view(0x4000, 0x7fff, m_view1);
-	page(2)->install_view(0x8000, 0xbfff, m_view2);
-	page(3)->install_view(0xc000, 0xffff, m_view3);
+	for (int pg = 0; pg < 4; pg++)
+		page(pg)->install_view(0x4000 * pg, 0x04000 * pg + 0x3fff, m_view[pg]);
 	page(3)->install_readwrite_handler(0xffff, 0xffff, emu::rw_delegate(*this, FUNC(msx_cart_slotexpander_device::secondary_slot_r)), emu::rw_delegate(*this, FUNC(msx_cart_slotexpander_device::secondary_slot_w)));
 
-	for (int page = 0; page < 4; page++)
-	{
-		m_view0[page];
-		m_view1[page];
-		m_view2[page];
-		m_view3[page];
-	}
+	for (int subslot = 0; subslot < 4; subslot++)
+		for (int page = 0; page < 4; page++)
+			m_view[page][subslot];
 
-	for (int i = 0; i < 4; i++)
-		m_cartslot[i]->install(&m_view0[i], &m_view1[i], &m_view2[i], &m_view3[i]);
+	for (int subslot = 0; subslot < 4; subslot++)
+		m_cartslot[subslot]->install(&m_view[0][subslot], &m_view[1][subslot], &m_view[2][subslot], &m_view[3][subslot]);
 }
 
 void msx_cart_slotexpander_device::device_start()
@@ -137,10 +125,8 @@ void msx_cart_slotexpander_device::device_start()
 	save_item(NAME(m_secondary_slot));
 	m_secondary_slot = 0;
 
-	m_view0.select(0);
-	m_view1.select(0);
-	m_view2.select(0);
-	m_view3.select(0);
+	for (int page = 0; page < 4; page++)
+		m_view[page].select(0);
 }
 
 u8 msx_cart_slotexpander_device::secondary_slot_r()
@@ -150,10 +136,8 @@ u8 msx_cart_slotexpander_device::secondary_slot_r()
 
 void msx_cart_slotexpander_device::secondary_slot_w(u8 data)
 {
-	m_view0.select((data >> 0) & 0x03);
-	m_view1.select((data >> 2) & 0x03);
-	m_view2.select((data >> 4) & 0x03);
-	m_view3.select((data >> 6) & 0x03);
+	for (int page = 0; page < 4; page++)
+		m_view[page].select((data >> (2 * page)) & 0x03);
 	m_secondary_slot = data;
 }
 


### PR DESCRIPTION
bus/msx/cart/dooly.cpp: Use banks instead of views.