### PR TITLE
misc/coolpool.cpp: Cleanups

### DIFF
--- a/src/mame/misc/coolpool.cpp
+++ b/src/mame/misc/coolpool.cpp
@@ -41,7 +41,7 @@
 #include <algorithm>
 
 #define LOG_PORT    (1U << 1)
-#define LOG_INPUT   (1U << 1)
+#define LOG_INPUT   (1U << 2)
 
 #define LOG_ALL     (LOG_PORT | LOG_INPUT)
 
@@ -164,6 +164,7 @@ void amerdart_state::machine_start()
 {
 	coolpool_base_state::machine_start();
 
+	m_lastresult = 0xffff;
 	save_item(NAME(m_old_cmd));
 }
 
@@ -1103,11 +1104,6 @@ ROM_END
  *
  *************************************/
 
-void amerdart_state::init_amerdart()
-{
-	m_lastresult = 0xffff;
-}
-
 
 void _9ballsht_state::init_9ballsht()
 {
@@ -1151,10 +1147,10 @@ void _9ballsht_state::init_9ballsht()
  *
  *************************************/
 
-GAME( 1989, amerdart,  0,        amerdart,  amerdart, amerdart_state, init_amerdart, ROT0, "Ameri",                               "AmeriDarts (set 1)",           MACHINE_SUPPORTS_SAVE )
-GAME( 1989, amerdart2, amerdart, amerdart,  amerdart, amerdart_state, init_amerdart, ROT0, "Ameri",                               "AmeriDarts (set 2)",           MACHINE_SUPPORTS_SAVE )
-GAME( 1989, amerdart3, amerdart, amerdart,  amerdart, amerdart_state, init_amerdart, ROT0, "Ameri",                               "AmeriDarts (set 3)",           MACHINE_SUPPORTS_SAVE )
-GAME( 1992, coolpool,  0,        coolpool,  coolpool, coolpool_state, empty_init,    ROT0, "Catalina",                            "Cool Pool",                    0 )
+GAME( 1989, amerdart,  0,        amerdart,  amerdart, amerdart_state,  empty_init,    ROT0, "Ameri",                               "AmeriDarts (set 1)",           MACHINE_SUPPORTS_SAVE )
+GAME( 1989, amerdart2, amerdart, amerdart,  amerdart, amerdart_state,  empty_init,    ROT0, "Ameri",                               "AmeriDarts (set 2)",           MACHINE_SUPPORTS_SAVE )
+GAME( 1989, amerdart3, amerdart, amerdart,  amerdart, amerdart_state,  empty_init,    ROT0, "Ameri",                               "AmeriDarts (set 3)",           MACHINE_SUPPORTS_SAVE )
+GAME( 1992, coolpool,  0,        coolpool,  coolpool, coolpool_state,  empty_init,    ROT0, "Catalina",                            "Cool Pool",                    0 )
 GAME( 1993, 9ballsht,  0,        _9ballsht, 9ballsht, _9ballsht_state, init_9ballsht, ROT0, "E-Scape EnterMedia (Bundra license)", "9-Ball Shootout (set 1)",      0 )
 GAME( 1993, 9ballsht2, 9ballsht, _9ballsht, 9ballsht, _9ballsht_state, init_9ballsht, ROT0, "E-Scape EnterMedia (Bundra license)", "9-Ball Shootout (set 2)",      0 )
 GAME( 1993, 9ballsht3, 9ballsht, _9ballsht, 9ballsht, _9ballsht_state, init_9ballsht, ROT0, "E-Scape EnterMedia (Bundra license)", "9-Ball Shootout (set 3)",      0 )

--- a/src/mame/misc/coolpool.cpp
+++ b/src/mame/misc/coolpool.cpp
@@ -9,7 +9,7 @@
     driver by Nicola Salmoria and Aaron Giles
 
 
-    The main cpu is a TMS34010; it is encrypted in 9 Ball Shootout.
+    The main CPU is a TMS34010; it is encrypted in 9 Ball Shootout.
 
     The second CPU in AmeriDarts is a TMS32015; it controls sound and
     the trackball inputs.
@@ -24,7 +24,6 @@
       4U/8U it is actually reading 4U/8U/3U/7U, when testing 3U/7U it
       actually reads 2U/6U/1U/5U. The placement cannot therefore be exactly
       determined by the check passing.
-
 
 ***************************************************************************/
 
@@ -302,7 +301,6 @@ int amerdart_state::amerdart_trackball_direction(int num, int data)
 	uint16_t result_x = (data & 0x0c) >> 2;
 	uint16_t result_y = (data & 0x03) >> 0;
 
-
 	if ((m_dx[num] == 0) && (m_dy[num] < 0))        // Up
 	{
 		if (!machine().side_effects_disabled())
@@ -411,7 +409,6 @@ uint16_t amerdart_state::amerdart_trackball_r(offs_t offset)
 
 */
 
-
 	if (!machine().side_effects_disabled())
 	{
 		m_result = (m_lastresult | 0x00ff);
@@ -465,7 +462,6 @@ void _9ballsht_state::misc_w(uint16_t data)
  *  (from IOP side)
  *
  *************************************/
-
 
 uint16_t _9ballsht_state::dsp_bio_line_r()
 {
@@ -1103,7 +1099,6 @@ ROM_END
  *  Driver init
  *
  *************************************/
-
 
 void _9ballsht_state::init_9ballsht()
 {

--- a/src/mame/misc/coolpool.cpp
+++ b/src/mame/misc/coolpool.cpp
@@ -38,7 +38,18 @@
 #include "screen.h"
 #include "speaker.h"
 
+#include <algorithm>
 
+#define LOG_PORT    (1U << 1)
+#define LOG_INPUT   (1U << 1)
+
+#define LOG_ALL     (LOG_PORT | LOG_INPUT)
+
+#define VERBOSE (0)
+#include "logmacro.h"
+
+#define LOGPORT(...)  LOGMASKED(LOG_PORT,  __VA_ARGS__)
+#define LOGINPUT(...) LOGMASKED(LOG_INPUT, __VA_ARGS__)
 
 /*************************************
  *
@@ -60,24 +71,24 @@ static const uint16_t nvram_unlock_seq[] =
  *
  *************************************/
 
-TMS340X0_SCANLINE_RGB32_CB_MEMBER(coolpool_state::amerdart_scanline)
+TMS340X0_SCANLINE_RGB32_CB_MEMBER(amerdart_state::scanline)
 {
 	uint16_t const *const vram = &m_vram_base[(params->rowaddr << 8) & 0xff00];
 	uint32_t *const dest = &bitmap.pix(scanline);
-	rgb_t pens[16];
 	int coladdr = params->coladdr;
 
-	/* update the palette */
+	// update the palette
 	if (scanline < 256)
 		for (int x = 0; x < 16; x++)
 		{
-			uint16_t pal = m_vram_base[x];
-			pens[x] = rgb_t(pal4bit(pal >> 4), pal4bit(pal >> 8), pal4bit(pal >> 12));
+			uint16_t const pal = m_vram_base[x];
+			m_palette->set_pen_color(x, rgb_t(pal4bit(pal >> 4), pal4bit(pal >> 8), pal4bit(pal >> 12)));
 		}
 
+	pen_t const *const pens = m_palette->pens();
 	for (int x = params->heblnk; x < params->hsblnk; x += 4)
 	{
-		uint16_t pixels = vram[coladdr++ & 0xff];
+		uint16_t const pixels = vram[coladdr++ & 0xff];
 		dest[x + 0] = pens[(pixels >> 0) & 15];
 		dest[x + 1] = pens[(pixels >> 4) & 15];
 		dest[x + 2] = pens[(pixels >> 8) & 15];
@@ -86,7 +97,7 @@ TMS340X0_SCANLINE_RGB32_CB_MEMBER(coolpool_state::amerdart_scanline)
 }
 
 
-TMS340X0_SCANLINE_RGB32_CB_MEMBER(coolpool_state::coolpool_scanline)
+TMS340X0_SCANLINE_RGB32_CB_MEMBER(_9ballsht_state::scanline)
 {
 	uint16_t const *const vram = &m_vram_base[(params->rowaddr << 8) & 0x1ff00];
 	uint32_t *const dest = &bitmap.pix(scanline);
@@ -95,7 +106,7 @@ TMS340X0_SCANLINE_RGB32_CB_MEMBER(coolpool_state::coolpool_scanline)
 
 	for (int x = params->heblnk; x < params->hsblnk; x += 2)
 	{
-		uint16_t pixels = vram[coladdr++ & 0xff];
+		uint16_t const pixels = vram[coladdr++ & 0xff];
 		dest[x + 0] = pens[pixels & 0xff];
 		dest[x + 1] = pens[pixels >> 8];
 	}
@@ -109,13 +120,13 @@ TMS340X0_SCANLINE_RGB32_CB_MEMBER(coolpool_state::coolpool_scanline)
  *
  *************************************/
 
-TMS340X0_TO_SHIFTREG_CB_MEMBER(coolpool_state::to_shiftreg)
+TMS340X0_TO_SHIFTREG_CB_MEMBER(coolpool_base_state::to_shiftreg)
 {
 	memcpy(shiftreg, &m_vram_base[(address & ~0xfff) >> 4], 0x200);
 }
 
 
-TMS340X0_FROM_SHIFTREG_CB_MEMBER(coolpool_state::from_shiftreg)
+TMS340X0_FROM_SHIFTREG_CB_MEMBER(coolpool_base_state::from_shiftreg)
 {
 	memcpy(&m_vram_base[(address & ~0xfff) >> 4], shiftreg, 0x200);
 }
@@ -128,17 +139,39 @@ TMS340X0_FROM_SHIFTREG_CB_MEMBER(coolpool_state::from_shiftreg)
  *
  *************************************/
 
-MACHINE_RESET_MEMBER(coolpool_state,amerdart)
+void coolpool_base_state::machine_start()
 {
-	m_nvram_write_enable = 0;
+	// assumes it can make an address mask with m_dsp_rom.length() - 1
+	assert(!(m_dsp_rom.length() & (m_dsp_rom.length() - 1)));
+
+	save_item(NAME(m_newx));
+	save_item(NAME(m_newy));
+	save_item(NAME(m_oldx));
+	save_item(NAME(m_oldy));
+	save_item(NAME(m_dx));
+	save_item(NAME(m_dy));
+	save_item(NAME(m_result));
+	save_item(NAME(m_lastresult));
+
+	save_item(NAME(m_nvram_write_seq));
+	save_item(NAME(m_nvram_write_enable));
+	save_item(NAME(m_same_cmd_count));
+
+	save_item(NAME(m_iop_romaddr));
+}
+
+void amerdart_state::machine_start()
+{
+	coolpool_base_state::machine_start();
+
+	save_item(NAME(m_old_cmd));
 }
 
 
-MACHINE_RESET_MEMBER(coolpool_state,coolpool)
+void coolpool_base_state::machine_reset()
 {
 	m_nvram_write_enable = 0;
 }
-
 
 
 /*************************************
@@ -147,19 +180,19 @@ MACHINE_RESET_MEMBER(coolpool_state,coolpool)
  *
  *************************************/
 
-TIMER_DEVICE_CALLBACK_MEMBER(coolpool_state::nvram_write_timeout)
+TIMER_DEVICE_CALLBACK_MEMBER(coolpool_base_state::nvram_write_timeout)
 {
 	m_nvram_write_enable = 0;
 }
 
 
-void coolpool_state::nvram_thrash_w(offs_t offset, uint16_t data)
+void coolpool_base_state::nvram_thrash_w(offs_t offset, uint16_t data)
 {
-	/* keep track of the last few writes */
+	// keep track of the last few writes
 	memmove(&m_nvram_write_seq[0], &m_nvram_write_seq[1], (NVRAM_UNLOCK_SEQ_LEN - 1) * sizeof(m_nvram_write_seq[0]));
 	m_nvram_write_seq[NVRAM_UNLOCK_SEQ_LEN - 1] = offset & 0x3ff;
 
-	/* if they match the unlock sequence, enable writes and set a timeout */
+	// if they match the unlock sequence, enable writes and set a timeout
 	if (!memcmp(nvram_unlock_seq, m_nvram_write_seq, sizeof(nvram_unlock_seq)))
 	{
 		m_nvram_write_enable = 1;
@@ -168,9 +201,9 @@ void coolpool_state::nvram_thrash_w(offs_t offset, uint16_t data)
 }
 
 
-void coolpool_state::nvram_data_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void coolpool_base_state::nvram_data_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	/* only the low 8 bits matter */
+	// only the low 8 bits matter
 	if (ACCESSING_BITS_0_7)
 	{
 		if (m_nvram_write_enable)
@@ -181,7 +214,7 @@ void coolpool_state::nvram_data_w(offs_t offset, uint16_t data, uint16_t mem_mas
 }
 
 
-void coolpool_state::nvram_thrash_data_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void coolpool_base_state::nvram_thrash_data_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	nvram_data_w(offset, data, mem_mask);
 	nvram_thrash_w(offset, data);
@@ -195,40 +228,42 @@ void coolpool_state::nvram_thrash_data_w(offs_t offset, uint16_t data, uint16_t 
  *
  *************************************/
 
-TIMER_DEVICE_CALLBACK_MEMBER(coolpool_state::amerdart_audio_int_gen)
+TIMER_DEVICE_CALLBACK_MEMBER(amerdart_state::amerdart_audio_int_gen)
 {
 	m_dsp->set_input_line(0, ASSERT_LINE);
 	m_dsp->set_input_line(0, CLEAR_LINE);
 }
 
 
-void coolpool_state::amerdart_misc_w(uint16_t data)
+void amerdart_state::misc_w(uint16_t data)
 {
-	logerror("%08x:IOP_system_w %04x\n",m_maincpu->pc(),data);
+	LOGPORT("%08x:IOP_system_w %04x\n",m_maincpu->pc(),data);
 
-	machine().bookkeeping().coin_counter_w(0, ~data & 0x0001);
-	machine().bookkeeping().coin_counter_w(1, ~data & 0x0002);
+	machine().bookkeeping().coin_counter_w(0, BIT(~data, 0));
+	machine().bookkeeping().coin_counter_w(1, BIT(~data, 1));
 
-	/* bits 10-15 are counted down over time */
+	// bits 10-15 are counted down over time
 
-	m_dsp->set_input_line(INPUT_LINE_RESET, (data & 0x0400) ? ASSERT_LINE : CLEAR_LINE);
+	m_dsp->set_input_line(INPUT_LINE_RESET, BIT(data, 10) ? ASSERT_LINE : CLEAR_LINE);
 }
 
-int coolpool_state::amerdart_dsp_bio_line_r()
+int amerdart_state::dsp_bio_line_r()
 {
-	/* Skip idle checking */
-	if (m_old_cmd == m_main2dsp->pending_r())
-		m_same_cmd_count += 1;
-	else
-		m_same_cmd_count = 0;
-
-	if (m_same_cmd_count >= 5)
+	// Skip idle checking
+	if (!machine().side_effects_disabled())
 	{
-		m_same_cmd_count = 5;
-		m_dsp->spin();
-	}
-	m_old_cmd = m_main2dsp->pending_r();
+		if (m_old_cmd == m_main2dsp->pending_r())
+			m_same_cmd_count += 1;
+		else
+			m_same_cmd_count = 0;
 
+		if (m_same_cmd_count >= 5)
+		{
+			m_same_cmd_count = 5;
+			m_dsp->spin();
+		}
+		m_old_cmd = m_main2dsp->pending_r();
+	}
 	return m_main2dsp->pending_r() ? CLEAR_LINE : ASSERT_LINE;
 }
 
@@ -240,7 +275,7 @@ int coolpool_state::amerdart_dsp_bio_line_r()
 
 static int amerdart_trackball_inc(int data)
 {
-	switch (data & 0x03)    /* Bits of opposite track direction must both change with identical levels */
+	switch (data & 0x03)    // Bits of opposite track direction must both change with identical levels
 	{
 		case 0x00:  data ^= 0x03;   break;
 		case 0x01:  data ^= 0x01;   break;
@@ -251,7 +286,7 @@ static int amerdart_trackball_inc(int data)
 }
 static int amerdart_trackball_dec(int data)
 {
-	switch (data & 0x03)    /* Bits of opposite track direction must both change with opposing levels */
+	switch (data & 0x03)    // Bits of opposite track direction must both change with opposing levels
 	{
 		case 0x00:  data ^= 0x01;   break;
 		case 0x01:  data ^= 0x03;   break;
@@ -261,50 +296,74 @@ static int amerdart_trackball_dec(int data)
 	return data;
 }
 
-int coolpool_state::amerdart_trackball_direction(int num, int data)
+int amerdart_state::amerdart_trackball_direction(int num, int data)
 {
 	uint16_t result_x = (data & 0x0c) >> 2;
 	uint16_t result_y = (data & 0x03) >> 0;
 
 
-	if ((m_dx[num] == 0) && (m_dy[num] < 0)) {        /* Up */
-		m_oldy[num]--;
+	if ((m_dx[num] == 0) && (m_dy[num] < 0))        // Up
+	{
+		if (!machine().side_effects_disabled())
+			m_oldy[num]--;
 		result_x = amerdart_trackball_inc(result_x);
 		result_y = amerdart_trackball_inc(result_y);
 	}
-	if ((m_dx[num] == 0) && (m_dy[num] > 0)) {        /* Down */
-		m_oldy[num]++;
+	if ((m_dx[num] == 0) && (m_dy[num] > 0))        // Down
+	{
+		if (!machine().side_effects_disabled())
+			m_oldy[num]++;
 		result_x = amerdart_trackball_dec(result_x);
 		result_y = amerdart_trackball_dec(result_y);
 	}
-	if ((m_dx[num] < 0) && (m_dy[num] == 0)) {        /* Left */
-		m_oldx[num]--;
+	if ((m_dx[num] < 0) && (m_dy[num] == 0))        // Left
+	{
+		if (!machine().side_effects_disabled())
+			m_oldx[num]--;
 		result_x = amerdart_trackball_inc(result_x);
 		result_y = amerdart_trackball_dec(result_y);
 	}
-	if ((m_dx[num] > 0) && (m_dy[num] == 0)) {        /* Right */
-		m_oldx[num]++;
+	if ((m_dx[num] > 0) && (m_dy[num] == 0))        // Right
+	{
+		if (!machine().side_effects_disabled())
+			m_oldx[num]++;
 		result_x = amerdart_trackball_dec(result_x);
 		result_y = amerdart_trackball_inc(result_y);
 	}
-	if ((m_dx[num] < 0) && (m_dy[num] < 0)) {         /* Left & Up */
-		m_oldx[num]--;
-		m_oldy[num]--;
+	if ((m_dx[num] < 0) && (m_dy[num] < 0))         // Left & Up
+	{
+		if (!machine().side_effects_disabled())
+		{
+			m_oldx[num]--;
+			m_oldy[num]--;
+		}
 		result_x = amerdart_trackball_inc(result_x);
 	}
-	if ((m_dx[num] < 0) && (m_dy[num] > 0)) {         /* Left & Down */
-		m_oldx[num]--;
-		m_oldy[num]++;
+	if ((m_dx[num] < 0) && (m_dy[num] > 0))         // Left & Down
+	{
+		if (!machine().side_effects_disabled())
+		{
+			m_oldx[num]--;
+			m_oldy[num]++;
+		}
 		result_y = amerdart_trackball_dec(result_y);
 	}
-	if ((m_dx[num] > 0) && (m_dy[num] < 0)) {         /* Right & Up */
-		m_oldx[num]++;
-		m_oldy[num]--;
+	if ((m_dx[num] > 0) && (m_dy[num] < 0))         // Right & Up
+	{
+		if (!machine().side_effects_disabled())
+		{
+			m_oldx[num]++;
+			m_oldy[num]--;
+		}
 		result_y = amerdart_trackball_inc(result_y);
 	}
-	if ((m_dx[num] > 0) && (m_dy[num] > 0)) {         /* Right & Down */
-		m_oldx[num]++;
-		m_oldy[num]++;
+	if ((m_dx[num] > 0) && (m_dy[num] > 0))         // Right & Down
+	{
+		if (!machine().side_effects_disabled())
+		{
+			m_oldx[num]++;
+			m_oldy[num]++;
+		}
 		result_x = amerdart_trackball_dec(result_x);
 	}
 
@@ -314,7 +373,7 @@ int coolpool_state::amerdart_trackball_direction(int num, int data)
 }
 
 
-uint16_t coolpool_state::amerdart_trackball_r(offs_t offset)
+uint16_t amerdart_state::amerdart_trackball_r(offs_t offset)
 {
 /*
     Trackballs seem to be handled as though they're rotated 45 degrees anti-clockwise.
@@ -352,29 +411,31 @@ uint16_t coolpool_state::amerdart_trackball_r(offs_t offset)
 */
 
 
+	if (!machine().side_effects_disabled())
+	{
+		m_result = (m_lastresult | 0x00ff);
 
-	m_result = (m_lastresult | 0x00ff);
+		m_newx[1] = m_in_xaxis[0]->read();   // Trackball 1  Left - Right
+		m_newy[1] = m_in_yaxis[0]->read();   // Trackball 1   Up  - Down 
+		m_newx[2] = m_in_xaxis[1]->read();   // Trackball 2  Left - Right
+		m_newy[2] = m_in_yaxis[1]->read();   // Trackball 2   Up  - Down 
 
-	m_newx[1] = ioport("XAXIS1")->read();   /* Trackball 1  Left - Right */
-	m_newy[1] = ioport("YAXIS1")->read();   /* Trackball 1   Up  - Down  */
-	m_newx[2] = ioport("XAXIS2")->read();   /* Trackball 2  Left - Right */
-	m_newy[2] = ioport("YAXIS2")->read();   /* Trackball 2   Up  - Down  */
+		m_dx[1] = (int8_t)(m_newx[1] - m_oldx[1]);
+		m_dy[1] = (int8_t)(m_newy[1] - m_oldy[1]);
+		m_dx[2] = (int8_t)(m_newx[2] - m_oldx[2]);
+		m_dy[2] = (int8_t)(m_newy[2] - m_oldy[2]);
 
-	m_dx[1] = (int8_t)(m_newx[1] - m_oldx[1]);
-	m_dy[1] = (int8_t)(m_newy[1] - m_oldy[1]);
-	m_dx[2] = (int8_t)(m_newx[2] - m_oldx[2]);
-	m_dy[2] = (int8_t)(m_newy[2] - m_oldy[2]);
+		// Determine Trackball 1 direction state
+		m_result = (m_result & 0xf0ff) | (amerdart_trackball_direction(1, ((m_result >>  8) & 0xf)) <<  8);
 
-	/* Determine Trackball 1 direction state */
-	m_result = (m_result & 0xf0ff) | (amerdart_trackball_direction(1, ((m_result >>  8) & 0xf)) <<  8);
-
-	/* Determine Trackball 2 direction state */
-	m_result = (m_result & 0x0fff) | (amerdart_trackball_direction(2, ((m_result >> 12) & 0xf)) << 12);
+		// Determine Trackball 2 direction state
+		m_result = (m_result & 0x0fff) | (amerdart_trackball_direction(2, ((m_result >> 12) & 0xf)) << 12);
 
 
-//  logerror("%08X:read port 6 (X=%02X Y=%02X oldX=%02X oldY=%02X oldRes=%04X Res=%04X)\n", m_dsp->pc(), m_newx, m_newy, m_oldx, m_oldy, m_lastresult, m_result);
+//  LOGINPUT("%08X:read port 6 (X=%02X Y=%02X oldX=%02X oldY=%02X oldRes=%04X Res=%04X)\n", m_dsp->pc(), m_newx, m_newy, m_oldx, m_oldy, m_lastresult, m_result);
 
-	m_lastresult = m_result;
+		m_lastresult = m_result;
+	}
 
 	return m_result;
 }
@@ -386,14 +447,14 @@ uint16_t coolpool_state::amerdart_trackball_r(offs_t offset)
  *
  *************************************/
 
-void coolpool_state::coolpool_misc_w(uint16_t data)
+void _9ballsht_state::misc_w(uint16_t data)
 {
-	logerror("%08x:IOP_system_w %04x\n",m_maincpu->pc(),data);
+	LOGPORT("%08x:IOP_system_w %04x\n",m_maincpu->pc(),data);
 
-	machine().bookkeeping().coin_counter_w(0, ~data & 0x0001);
-	machine().bookkeeping().coin_counter_w(1, ~data & 0x0002);
+	machine().bookkeeping().coin_counter_w(0, BIT(~data, 0));
+	machine().bookkeeping().coin_counter_w(1, BIT(~data, 1));
 
-	m_dsp->set_input_line(INPUT_LINE_RESET, (data & 0x0400) ? ASSERT_LINE : CLEAR_LINE);
+	m_dsp->set_input_line(INPUT_LINE_RESET, BIT(data, 10) ? ASSERT_LINE : CLEAR_LINE);
 }
 
 
@@ -405,15 +466,15 @@ void coolpool_state::coolpool_misc_w(uint16_t data)
  *************************************/
 
 
-uint16_t coolpool_state::dsp_bio_line_r()
+uint16_t _9ballsht_state::dsp_bio_line_r()
 {
 	return m_main2dsp->pending_r() ? CLEAR_LINE : ASSERT_LINE;
 }
 
 
-uint16_t coolpool_state::dsp_hold_line_r()
+uint16_t _9ballsht_state::dsp_hold_line_r()
 {
-	return CLEAR_LINE;  /* ??? */
+	return CLEAR_LINE;  // ???
 }
 
 
@@ -423,13 +484,13 @@ uint16_t coolpool_state::dsp_hold_line_r()
  *
  *************************************/
 
-uint16_t coolpool_state::dsp_rom_r()
+uint16_t coolpool_base_state::dsp_rom_r()
 {
 	return m_dsp_rom[m_iop_romaddr & (m_dsp_rom.length() - 1)];
 }
 
 
-void coolpool_state::dsp_romaddr_w(offs_t offset, uint16_t data)
+void coolpool_base_state::dsp_romaddr_w(offs_t offset, uint16_t data)
 {
 	switch (offset)
 	{
@@ -453,61 +514,64 @@ void coolpool_state::dsp_romaddr_w(offs_t offset, uint16_t data)
 
 uint16_t coolpool_state::coolpool_input_r(offs_t offset)
 {
-	m_result = (ioport("IN1")->read() & 0x00ff) | (m_lastresult & 0xff00);
-	m_newx[1] = ioport("XAXIS")->read();
-	m_newy[1] = ioport("YAXIS")->read();
-	m_dx[1] = (int8_t)(m_newx[1] - m_oldx[1]);
-	m_dy[1] = (int8_t)(m_newy[1] - m_oldy[1]);
+	if (!machine().side_effects_disabled())
+	{
+		m_result = (m_in1->read() & 0x00ff) | (m_lastresult & 0xff00);
+		m_newx[1] = m_xaxis->read();
+		m_newy[1] = m_yaxis->read();
+		m_dx[1] = (int8_t)(m_newx[1] - m_oldx[1]);
+		m_dy[1] = (int8_t)(m_newy[1] - m_oldy[1]);
 
-	if (m_dx[1] < 0)
-	{
-		m_oldx[1]--;
-		switch (m_result & 0x300)
+		if (m_dx[1] < 0)
 		{
-			case 0x000: m_result ^= 0x200;  break;
-			case 0x100: m_result ^= 0x100;  break;
-			case 0x200: m_result ^= 0x100;  break;
-			case 0x300: m_result ^= 0x200;  break;
+			m_oldx[1]--;
+			switch (m_result & 0x300)
+			{
+				case 0x000: m_result ^= 0x200;  break;
+				case 0x100: m_result ^= 0x100;  break;
+				case 0x200: m_result ^= 0x100;  break;
+				case 0x300: m_result ^= 0x200;  break;
+			}
 		}
-	}
-	if (m_dx[1] > 0)
-	{
-		m_oldx[1]++;
-		switch (m_result & 0x300)
+		if (m_dx[1] > 0)
 		{
-			case 0x000: m_result ^= 0x100;  break;
-			case 0x100: m_result ^= 0x200;  break;
-			case 0x200: m_result ^= 0x200;  break;
-			case 0x300: m_result ^= 0x100;  break;
+			m_oldx[1]++;
+			switch (m_result & 0x300)
+			{
+				case 0x000: m_result ^= 0x100;  break;
+				case 0x100: m_result ^= 0x200;  break;
+				case 0x200: m_result ^= 0x200;  break;
+				case 0x300: m_result ^= 0x100;  break;
+			}
 		}
-	}
 
-	if (m_dy[1] < 0)
-	{
-		m_oldy[1]--;
-		switch (m_result & 0xc00)
+		if (m_dy[1] < 0)
 		{
-			case 0x000: m_result ^= 0x800;  break;
-			case 0x400: m_result ^= 0x400;  break;
-			case 0x800: m_result ^= 0x400;  break;
-			case 0xc00: m_result ^= 0x800;  break;
+			m_oldy[1]--;
+			switch (m_result & 0xc00)
+			{
+				case 0x000: m_result ^= 0x800;  break;
+				case 0x400: m_result ^= 0x400;  break;
+				case 0x800: m_result ^= 0x400;  break;
+				case 0xc00: m_result ^= 0x800;  break;
+			}
 		}
-	}
-	if (m_dy[1] > 0)
-	{
-		m_oldy[1]++;
-		switch (m_result & 0xc00)
+		if (m_dy[1] > 0)
 		{
-			case 0x000: m_result ^= 0x400;  break;
-			case 0x400: m_result ^= 0x800;  break;
-			case 0x800: m_result ^= 0x800;  break;
-			case 0xc00: m_result ^= 0x400;  break;
+			m_oldy[1]++;
+			switch (m_result & 0xc00)
+			{
+				case 0x000: m_result ^= 0x400;  break;
+				case 0x400: m_result ^= 0x800;  break;
+				case 0x800: m_result ^= 0x800;  break;
+				case 0xc00: m_result ^= 0x400;  break;
+			}
 		}
-	}
 
-//  logerror("%08X:read port 7 (X=%02X Y=%02X oldX=%02X oldY=%02X res=%04X)\n", m_dsp->pc(),
+//  LOGINPUT("%08X:read port 7 (X=%02X Y=%02X oldX=%02X oldY=%02X res=%04X)\n", m_dsp->pc(),
 //      m_newx[1], m_newy[1], m_oldx[1], m_oldy[1], m_result);
-	m_lastresult = m_result;
+		m_lastresult = m_result;
+	}
 	return m_result;
 }
 
@@ -519,12 +583,12 @@ uint16_t coolpool_state::coolpool_input_r(offs_t offset)
  *
  *************************************/
 
-void coolpool_state::amerdart_map(address_map &map)
+void amerdart_state::main_map(address_map &map)
 {
 	map(0x00000000, 0x000fffff).ram().share(m_vram_base);
-	map(0x04000000, 0x0400000f).w(FUNC(coolpool_state::amerdart_misc_w));
+	map(0x04000000, 0x0400000f).w(FUNC(amerdart_state::misc_w));
 	map(0x05000000, 0x0500000f).r(m_dsp2main, FUNC(generic_latch_16_device::read)).w(m_main2dsp, FUNC(generic_latch_16_device::write));
-	map(0x06000000, 0x06007fff).ram().w(FUNC(coolpool_state::nvram_thrash_data_w)).share("nvram");
+	map(0x06000000, 0x06007fff).ram().w(FUNC(amerdart_state::nvram_thrash_data_w)).share("nvram");
 	map(0xffb00000, 0xffffffff).rom().region("maincpu", 0);
 }
 
@@ -534,21 +598,21 @@ void coolpool_state::coolpool_map(address_map &map)
 	map(0x00000000, 0x001fffff).ram().share(m_vram_base);
 	map(0x01000000, 0x010000ff).rw(m_tlc34076, FUNC(tlc34076_device::read), FUNC(tlc34076_device::write)).umask16(0x00ff);    // IMSG176P-40
 	map(0x02000000, 0x020000ff).r(m_dsp2main, FUNC(generic_latch_16_device::read)).w(m_main2dsp, FUNC(generic_latch_16_device::write));
-	map(0x03000000, 0x0300000f).w(FUNC(coolpool_state::coolpool_misc_w));
-	map(0x03000000, 0x03ffffff).rom().region("gfx1", 0);
+	map(0x03000000, 0x0300000f).w(FUNC(coolpool_state::misc_w));
+	map(0x03000000, 0x03ffffff).rom().region("maingfx", 0);
 	map(0x06000000, 0x06007fff).ram().w(FUNC(coolpool_state::nvram_thrash_data_w)).share("nvram");
 	map(0xffe00000, 0xffffffff).rom().region("maincpu", 0);
 }
 
 
-void coolpool_state::nballsht_map(address_map &map)
+void _9ballsht_state::nballsht_map(address_map &map)
 {
-	map(0x00000000, 0x001fffff).ram().share("vram_base");
+	map(0x00000000, 0x001fffff).ram().share(m_vram_base);
 	map(0x02000000, 0x020000ff).r(m_dsp2main, FUNC(generic_latch_16_device::read)).w(m_main2dsp, FUNC(generic_latch_16_device::write));
-	map(0x03000000, 0x0300000f).w(FUNC(coolpool_state::coolpool_misc_w));
+	map(0x03000000, 0x0300000f).w(FUNC(_9ballsht_state::misc_w));
 	map(0x04000000, 0x040000ff).rw(m_tlc34076, FUNC(tlc34076_device::read), FUNC(tlc34076_device::write)).umask16(0x00ff);    // IMSG176P-40
-	map(0x06000000, 0x0601ffff).mirror(0x00020000).ram().w(FUNC(coolpool_state::nvram_thrash_data_w)).share("nvram");
-	map(0xff000000, 0xff7fffff).rom().region("gfx1", 0);
+	map(0x06000000, 0x0601ffff).mirror(0x00020000).ram().w(FUNC(_9ballsht_state::nvram_thrash_data_w)).share("nvram");
+	map(0xff000000, 0xff7fffff).rom().region("maingfx", 0);
 	map(0xffc00000, 0xffffffff).rom().region("maincpu", 0);
 }
 
@@ -560,51 +624,51 @@ void coolpool_state::nballsht_map(address_map &map)
  *
  *************************************/
 
-void coolpool_state::amerdart_dsp_pgm_map(address_map &map)
+void amerdart_state::dsp_pgm_map(address_map &map)
 {
 	map(0x000, 0x0fff).rom();
 }
-	/* 000 - 0FF  TMS32015 Internal Data RAM (256 words) in Data Address Space */
+	// 000 - 0FF  TMS32015 Internal Data RAM (256 words) in Data Address Space
 
 
-void coolpool_state::amerdart_dsp_io_map(address_map &map)
+void amerdart_state::dsp_io_map(address_map &map)
 {
-	map(0x00, 0x01).w(FUNC(coolpool_state::dsp_romaddr_w));
+	map(0x00, 0x01).w(FUNC(amerdart_state::dsp_romaddr_w));
 	map(0x02, 0x02).w(m_dsp2main, FUNC(generic_latch_16_device::write));
 	map(0x03, 0x03).w("dac", FUNC(dac_word_interface::data_w));
-	map(0x04, 0x04).r(FUNC(coolpool_state::dsp_rom_r));
+	map(0x04, 0x04).r(FUNC(amerdart_state::dsp_rom_r));
 	map(0x05, 0x05).portr("IN0");
-	map(0x06, 0x06).r(FUNC(coolpool_state::amerdart_trackball_r));
+	map(0x06, 0x06).r(FUNC(amerdart_state::amerdart_trackball_r));
 	map(0x07, 0x07).r(m_main2dsp, FUNC(generic_latch_16_device::read));
 }
 
 
-void coolpool_state::coolpool_dsp_pgm_map(address_map &map)
+void _9ballsht_state::dsp_pgm_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
 }
 
 
-void coolpool_state::coolpool_dsp_io_base_map(address_map &map)
+void _9ballsht_state::dsp_io_base_map(address_map &map)
 {
-	map(0x00, 0x01).w(FUNC(coolpool_state::dsp_romaddr_w));
+	map(0x00, 0x01).w(FUNC(_9ballsht_state::dsp_romaddr_w));
 	map(0x02, 0x02).r(m_main2dsp, FUNC(generic_latch_16_device::read)).w(m_dsp2main, FUNC(generic_latch_16_device::write));
 	map(0x03, 0x03).w("dac", FUNC(dac_word_interface::data_w));
-	map(0x04, 0x04).r(FUNC(coolpool_state::dsp_rom_r));
+	map(0x04, 0x04).r(FUNC(_9ballsht_state::dsp_rom_r));
 	map(0x05, 0x05).portr("IN0");
 }
 
 
 void coolpool_state::coolpool_dsp_io_map(address_map &map)
 {
-	coolpool_dsp_io_base_map(map);
+	dsp_io_base_map(map);
 	map(0x07, 0x07).r(FUNC(coolpool_state::coolpool_input_r));
 }
 
 
-void coolpool_state::nballsht_dsp_io_map(address_map &map)
+void _9ballsht_state::nballsht_dsp_io_map(address_map &map)
 {
-	coolpool_dsp_io_base_map(map);
+	dsp_io_base_map(map);
 	map(0x07, 0x07).portr("IN1");
 }
 
@@ -707,41 +771,86 @@ INPUT_PORTS_END
  *
  *************************************/
 
-void coolpool_state::amerdart(machine_config &config)
+void amerdart_state::amerdart(machine_config &config)
 {
-	/* basic machine hardware */
+	// basic machine hardware
 	TMS34010(config, m_maincpu, XTAL(40'000'000));
-	m_maincpu->set_addrmap(AS_PROGRAM, &coolpool_state::amerdart_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &amerdart_state::main_map);
 	m_maincpu->set_halt_on_reset(false);
 	m_maincpu->set_pixel_clock(XTAL(40'000'000)/12);
 	m_maincpu->set_pixels_per_clock(2);
-	m_maincpu->set_scanline_rgb32_callback(FUNC(coolpool_state::amerdart_scanline));
-	m_maincpu->set_shiftreg_in_callback(FUNC(coolpool_state::to_shiftreg));
-	m_maincpu->set_shiftreg_out_callback(FUNC(coolpool_state::from_shiftreg));
+	m_maincpu->set_scanline_rgb32_callback(FUNC(amerdart_state::scanline));
+	m_maincpu->set_shiftreg_in_callback(FUNC(amerdart_state::to_shiftreg));
+	m_maincpu->set_shiftreg_out_callback(FUNC(amerdart_state::from_shiftreg));
 
 	tms32015_device &dsp(TMS32015(config, m_dsp, XTAL(40'000'000)/2));
-	dsp.set_addrmap(AS_PROGRAM, &coolpool_state::amerdart_dsp_pgm_map);
-	/* Data Map is internal to the CPU */
-	dsp.set_addrmap(AS_IO, &coolpool_state::amerdart_dsp_io_map);
-	dsp.bio().set(FUNC(coolpool_state::amerdart_dsp_bio_line_r));
+	dsp.set_addrmap(AS_PROGRAM, &amerdart_state::dsp_pgm_map);
+	// Data Map is internal to the CPU
+	dsp.set_addrmap(AS_IO, &amerdart_state::dsp_io_map);
+	dsp.bio().set(FUNC(amerdart_state::dsp_bio_line_r));
 
-	TIMER(config, "audioint").configure_scanline(FUNC(coolpool_state::amerdart_audio_int_gen), "screen", 0, 1);
+	TIMER(config, "audioint").configure_scanline(FUNC(amerdart_state::amerdart_audio_int_gen), "screen", 0, 1);
 
 	GENERIC_LATCH_16(config, m_main2dsp);
 	GENERIC_LATCH_16(config, m_dsp2main);
 	m_dsp2main->data_pending_callback().set_inputline(m_maincpu, 1);
 
-	MCFG_MACHINE_RESET_OVERRIDE(coolpool_state,amerdart)
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
-	TIMER(config, m_nvram_timer).configure_generic(FUNC(coolpool_state::nvram_write_timeout));
+	TIMER(config, m_nvram_timer).configure_generic(FUNC(amerdart_state::nvram_write_timeout));
 
-	/* video hardware */
+	// video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_raw(XTAL(40'000'000)/6, 212*2, 0, 161*2, 262, 0, 241);
-	screen.set_screen_update("maincpu", FUNC(tms34010_device::tms340x0_rgb32));
+	screen.set_screen_update(m_maincpu, FUNC(tms34010_device::tms340x0_rgb32));
 
-	/* sound hardware */
+	PALETTE(config, m_palette).set_entries(16);
+
+	// sound hardware
+	SPEAKER(config, "speaker").front_center();
+	MP1210(config, "dac", 0).add_route(ALL_OUTPUTS, "speaker", 1.0);
+}
+
+
+void _9ballsht_state::_9ballsht(machine_config &config)
+{
+	// basic machine hardware
+	TMS34010(config, m_maincpu, XTAL(40'000'000));
+	m_maincpu->set_addrmap(AS_PROGRAM, &_9ballsht_state::nballsht_map);
+	m_maincpu->set_halt_on_reset(false);
+	m_maincpu->set_pixel_clock(XTAL(40'000'000)/6);
+	m_maincpu->set_pixels_per_clock(1);
+	m_maincpu->set_scanline_rgb32_callback(FUNC(_9ballsht_state::scanline));
+	m_maincpu->set_shiftreg_in_callback(FUNC(_9ballsht_state::to_shiftreg));
+	m_maincpu->set_shiftreg_out_callback(FUNC(_9ballsht_state::from_shiftreg));
+
+	tms32026_device& dsp(TMS32026(config, m_dsp, XTAL(40'000'000)));
+	dsp.set_addrmap(AS_PROGRAM, &_9ballsht_state::dsp_pgm_map);
+	dsp.set_addrmap(AS_IO, &_9ballsht_state::nballsht_dsp_io_map);
+	dsp.bio_in_cb().set(FUNC(_9ballsht_state::dsp_bio_line_r));
+	dsp.hold_in_cb().set(FUNC(_9ballsht_state::dsp_hold_line_r));
+//  dsp.hold_ack_out_cb().set(FUNC(_9ballsht_state::dsp_HOLDA_signal_w));
+
+	GENERIC_LATCH_16(config, m_main2dsp);
+	m_main2dsp->data_pending_callback().set_inputline(m_dsp, 0); // ???  I have no idea who should generate this!
+															// the DSP polls the status bit so it isn't strictly
+															// necessary to also have an IRQ
+
+	GENERIC_LATCH_16(config, m_dsp2main);
+	m_dsp2main->data_pending_callback().set_inputline(m_maincpu, 1);
+
+	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
+
+	TIMER(config, m_nvram_timer).configure_generic(FUNC(_9ballsht_state::nvram_write_timeout));
+
+	// video hardware
+	TLC34076(config, m_tlc34076, tlc34076_device::TLC34076_6_BIT);
+
+	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
+	screen.set_raw(XTAL(40'000'000)/6, 424, 0, 320, 262, 0, 240);
+	screen.set_screen_update(m_maincpu, FUNC(tms34010_device::tms340x0_rgb32));
+
+	// sound hardware
 	SPEAKER(config, "speaker").front_center();
 	MP1210(config, "dac", 0).add_route(ALL_OUTPUTS, "speaker", 1.0);
 }
@@ -749,54 +858,9 @@ void coolpool_state::amerdart(machine_config &config)
 
 void coolpool_state::coolpool(machine_config &config)
 {
-	/* basic machine hardware */
-	TMS34010(config, m_maincpu, XTAL(40'000'000));
+	_9ballsht(config);
 	m_maincpu->set_addrmap(AS_PROGRAM, &coolpool_state::coolpool_map);
-	m_maincpu->set_halt_on_reset(false);
-	m_maincpu->set_pixel_clock(XTAL(40'000'000)/6);
-	m_maincpu->set_pixels_per_clock(1);
-	m_maincpu->set_scanline_rgb32_callback(FUNC(coolpool_state::coolpool_scanline));
-	m_maincpu->set_shiftreg_in_callback(FUNC(coolpool_state::to_shiftreg));
-	m_maincpu->set_shiftreg_out_callback(FUNC(coolpool_state::from_shiftreg));
-
-	tms32026_device& dsp(TMS32026(config, m_dsp, XTAL(40'000'000)));
-	dsp.set_addrmap(AS_PROGRAM, &coolpool_state::coolpool_dsp_pgm_map);
-	dsp.set_addrmap(AS_IO, &coolpool_state::coolpool_dsp_io_map);
-	dsp.bio_in_cb().set(FUNC(coolpool_state::dsp_bio_line_r));
-	dsp.hold_in_cb().set(FUNC(coolpool_state::dsp_hold_line_r));
-//  dsp.hold_ack_out_cb().set(FUNC(coolpool_state::dsp_HOLDA_signal_w));
-
-	GENERIC_LATCH_16(config, m_main2dsp);
-	m_main2dsp->data_pending_callback().set_inputline(m_dsp, 0); /* ???  I have no idea who should generate this! */
-															/* the DSP polls the status bit so it isn't strictly */
-															/* necessary to also have an IRQ */
-
-	GENERIC_LATCH_16(config, m_dsp2main);
-	m_dsp2main->data_pending_callback().set_inputline(m_maincpu, 1);
-
-	MCFG_MACHINE_RESET_OVERRIDE(coolpool_state,coolpool)
-	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
-
-	TIMER(config, m_nvram_timer).configure_generic(FUNC(coolpool_state::nvram_write_timeout));
-
-	/* video hardware */
-	TLC34076(config, m_tlc34076, tlc34076_device::TLC34076_6_BIT);
-
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_raw(XTAL(40'000'000)/6, 424, 0, 320, 262, 0, 240);
-	screen.set_screen_update("maincpu", FUNC(tms34010_device::tms340x0_rgb32));
-
-	/* sound hardware */
-	SPEAKER(config, "speaker").front_center();
-	MP1210(config, "dac", 0).add_route(ALL_OUTPUTS, "speaker", 1.0);
-}
-
-
-void coolpool_state::_9ballsht(machine_config &config)
-{
-	coolpool(config);
-	m_maincpu->set_addrmap(AS_PROGRAM, &coolpool_state::nballsht_map);
-	m_dsp->set_addrmap(AS_IO, &coolpool_state::nballsht_dsp_io_map);
+	m_dsp->set_addrmap(AS_IO, &coolpool_state::coolpool_dsp_io_map);
 }
 
 
@@ -807,8 +871,8 @@ void coolpool_state::_9ballsht(machine_config &config)
  *
  *************************************/
 
-ROM_START( amerdart ) /* You need to check the sum16 values listed on the labels to determine different sets */
-	ROM_REGION16_LE( 0x0a0000, "maincpu", 0 ) /* 34010 code */
+ROM_START( amerdart ) // You need to check the sum16 values listed on the labels to determine different sets
+	ROM_REGION16_LE( 0x0a0000, "maincpu", 0 ) // 34010 code
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u31 4e74", 0x000001, 0x10000, CRC(9628c422) SHA1(46b71acc746760962e34e9d7876f9499ea7d5c7c) )
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u32 0ef7", 0x000000, 0x10000, CRC(2d651ed0) SHA1(e2da2c3d8f25c17e26fd435c75983b2db8691993) )
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u38 10b4", 0x020001, 0x10000, CRC(1eb8c887) SHA1(220f566043535c54ad1cf2216966c7f42099e50b) )
@@ -817,14 +881,14 @@ ROM_START( amerdart ) /* You need to check the sum16 values listed on the labels
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u46 1f84", 0x040000, 0x10000, CRC(1188047e) SHA1(249f25582ab72eeee37798418460de312053660e) )
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u52 cdfd", 0x060001, 0x10000, CRC(5ac2f06d) SHA1(b3a5d0cd94bdffdbf5bd17dbb30c07bfad3fa5d0) )
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u53 d432", 0x060000, 0x10000, CRC(4bd25cf0) SHA1(d1092cc3b6172d6567acd21f79b22043380102b7) )
-	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u57 6016", 0x080001, 0x10000, CRC(f620f935) SHA1(bf891fce1f04f3ad5b8b72d43d041ceacb0b65bc) ) /* Different then set 2 or 3 */
-	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u58 48af", 0x080000, 0x10000, CRC(f1b3d7c4) SHA1(7b897230d110be7a5eb05eda927d00561ebb9ce3) ) /* Different then set 2 or 3 */
+	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u57 6016", 0x080001, 0x10000, CRC(f620f935) SHA1(bf891fce1f04f3ad5b8b72d43d041ceacb0b65bc) ) // Different then set 2 or 3
+	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u58 48af", 0x080000, 0x10000, CRC(f1b3d7c4) SHA1(7b897230d110be7a5eb05eda927d00561ebb9ce3) ) // Different then set 2 or 3
 
-	ROM_REGION( 0x10000, "dsp", 0 ) /* TMS32015 code  */
-	ROM_LOAD16_WORD( "tms320e15.bin", 0x0000, 0x2000, CRC(375db4ea) SHA1(11689c89ce62f44f43cb8973b4ec6e6b0024ed14) ) /* Passes internal checksum routine */
+	ROM_REGION( 0x10000, "dsp", 0 ) // TMS32015 code 
+	ROM_LOAD16_WORD( "tms320e15.bin", 0x0000, 0x2000, CRC(375db4ea) SHA1(11689c89ce62f44f43cb8973b4ec6e6b0024ed14) ) // Passes internal checksum routine
 
-	ROM_REGION( 0x100000, "dspdata", 0 )              /* TMS32015 audio sample data */
-	ROM_LOAD16_WORD( "ameri corp copyright 1989 u1 4461",  0x000000, 0x10000, CRC(3f459482) SHA1(d9d489efd0d9217fceb3bf1a3b37a78d6823b4d9) ) /* Different then set 2 or 3 */
+	ROM_REGION( 0x100000, "dspdata", 0 )              // TMS32015 audio sample data
+	ROM_LOAD16_WORD( "ameri corp copyright 1989 u1 4461",  0x000000, 0x10000, CRC(3f459482) SHA1(d9d489efd0d9217fceb3bf1a3b37a78d6823b4d9) ) // Different then set 2 or 3
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u16 abd6", 0x010000, 0x10000, CRC(7437e8bf) SHA1(754be4822cd586590f09e706d7eb48e5ba8c8817) )
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u2 cae4",  0x020000, 0x10000, CRC(a587fffd) SHA1(f33f511d1bf1d6eb3c42535593a9718571174c4b) )
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u17 b791", 0x030000, 0x10000, CRC(e32bdd0f) SHA1(0662abbe84f0bad2631566b506ef016fcd79b9ee) )
@@ -839,11 +903,11 @@ ROM_START( amerdart ) /* You need to check the sum16 values listed on the labels
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u7 2671",  0x0c0000, 0x10000, CRC(147083a2) SHA1(c04c38145ab159bd519e6325477a3f7d0eebbda1) )
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u22 8fd7", 0x0d0000, 0x10000, CRC(4b92588a) SHA1(eea262c1a122015364a0046ff2bc7816f5f6821d) )
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u8 961c",  0x0e0000, 0x10000, CRC(975b368c) SHA1(1d637ce8c5d60833bb25aab2610e1a856720235e) )
-	ROM_LOAD16_WORD( "ameri corp copyright 1989 u23 abef", 0x0f0000, 0x10000, CRC(d7c2b13b) SHA1(3561e08011f649e4d0c47792745b2a014167e816) ) /* Different then set 2 or 3 */
+	ROM_LOAD16_WORD( "ameri corp copyright 1989 u23 abef", 0x0f0000, 0x10000, CRC(d7c2b13b) SHA1(3561e08011f649e4d0c47792745b2a014167e816) ) // Different then set 2 or 3
 ROM_END
 
-ROM_START( amerdart2 ) /* You need to check the sum16 values listed on the labels to determine different sets */
-	ROM_REGION16_LE( 0x0a0000, "maincpu", 0 ) /* 34010 code */
+ROM_START( amerdart2 ) // You need to check the sum16 values listed on the labels to determine different sets
+	ROM_REGION16_LE( 0x0a0000, "maincpu", 0 ) // 34010 code
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u31 4e74", 0x000001, 0x10000, CRC(9628c422) SHA1(46b71acc746760962e34e9d7876f9499ea7d5c7c) )
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u32 0ef7", 0x000000, 0x10000, CRC(2d651ed0) SHA1(e2da2c3d8f25c17e26fd435c75983b2db8691993) )
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u38 10b4", 0x020001, 0x10000, CRC(1eb8c887) SHA1(220f566043535c54ad1cf2216966c7f42099e50b) )
@@ -852,14 +916,14 @@ ROM_START( amerdart2 ) /* You need to check the sum16 values listed on the label
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u46 1f84", 0x040000, 0x10000, CRC(1188047e) SHA1(249f25582ab72eeee37798418460de312053660e) )
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u52 cdfd", 0x060001, 0x10000, CRC(5ac2f06d) SHA1(b3a5d0cd94bdffdbf5bd17dbb30c07bfad3fa5d0) )
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u53 d432", 0x060000, 0x10000, CRC(4bd25cf0) SHA1(d1092cc3b6172d6567acd21f79b22043380102b7) )
-	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u57 1a0c", 0x080001, 0x10000, CRC(8a70f849) SHA1(dfd4cf90de2ab8cbeff458f0fd20110c1ed009e9) ) /* Different then set 1 or 3 */
-	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u58 0d81", 0x080000, 0x10000, CRC(8bb81975) SHA1(b7666572ab543991c7deaa0ebefb8b4526a7e386) ) /* Different then set 1 or 3 */
+	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u57 1a0c", 0x080001, 0x10000, CRC(8a70f849) SHA1(dfd4cf90de2ab8cbeff458f0fd20110c1ed009e9) ) // Different then set 1 or 3
+	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u58 0d81", 0x080000, 0x10000, CRC(8bb81975) SHA1(b7666572ab543991c7deaa0ebefb8b4526a7e386) ) // Different then set 1 or 3
 
-	ROM_REGION( 0x10000, "dsp", 0 ) /* TMS32015 code  */
-	ROM_LOAD16_WORD( "tms320e15.bin", 0x0000, 0x2000, CRC(375db4ea) SHA1(11689c89ce62f44f43cb8973b4ec6e6b0024ed14) ) /* Passes internal checksum routine */
+	ROM_REGION( 0x10000, "dsp", 0 ) // TMS32015 code 
+	ROM_LOAD16_WORD( "tms320e15.bin", 0x0000, 0x2000, CRC(375db4ea) SHA1(11689c89ce62f44f43cb8973b4ec6e6b0024ed14) ) // Passes internal checksum routine
 
-	ROM_REGION( 0x100000, "dspdata", 0 )              /* TMS32015 audio sample data */
-	ROM_LOAD16_WORD( "ameri corp copyright 1989 u1 222f",  0x000000, 0x10000, CRC(e2bb7f54) SHA1(39eeb61a852b93331f445cc1c993727e52959660) ) /* Different then set 1 */
+	ROM_REGION( 0x100000, "dspdata", 0 )              // TMS32015 audio sample data
+	ROM_LOAD16_WORD( "ameri corp copyright 1989 u1 222f",  0x000000, 0x10000, CRC(e2bb7f54) SHA1(39eeb61a852b93331f445cc1c993727e52959660) ) // Different then set 1
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u16 abd6", 0x010000, 0x10000, CRC(7437e8bf) SHA1(754be4822cd586590f09e706d7eb48e5ba8c8817) )
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u2 cae4",  0x020000, 0x10000, CRC(a587fffd) SHA1(f33f511d1bf1d6eb3c42535593a9718571174c4b) )
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u17 b791", 0x030000, 0x10000, CRC(e32bdd0f) SHA1(0662abbe84f0bad2631566b506ef016fcd79b9ee) )
@@ -874,11 +938,11 @@ ROM_START( amerdart2 ) /* You need to check the sum16 values listed on the label
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u7 2671",  0x0c0000, 0x10000, CRC(147083a2) SHA1(c04c38145ab159bd519e6325477a3f7d0eebbda1) )
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u22 8fd7", 0x0d0000, 0x10000, CRC(4b92588a) SHA1(eea262c1a122015364a0046ff2bc7816f5f6821d) )
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u8 961c",  0x0e0000, 0x10000, CRC(975b368c) SHA1(1d637ce8c5d60833bb25aab2610e1a856720235e) )
-	ROM_LOAD16_WORD( "ameri corp copyright 1989 u23 b806", 0x0f0000, 0x10000, CRC(7c1e6f2e) SHA1(21ae530e4bd7c0c9f1a84f01f136c71952c8adc4) ) /* Different then set 1 */
+	ROM_LOAD16_WORD( "ameri corp copyright 1989 u23 b806", 0x0f0000, 0x10000, CRC(7c1e6f2e) SHA1(21ae530e4bd7c0c9f1a84f01f136c71952c8adc4) ) // Different then set 1
 ROM_END
 
-ROM_START( amerdart3 ) /* You need to check the sum16 values listed on the labels to determine different sets */
-	ROM_REGION16_LE( 0x0a0000, "maincpu", 0 ) /* 34010 code */
+ROM_START( amerdart3 ) // You need to check the sum16 values listed on the labels to determine different sets
+	ROM_REGION16_LE( 0x0a0000, "maincpu", 0 ) // 34010 code
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u31 4e74", 0x000001, 0x10000, CRC(9628c422) SHA1(46b71acc746760962e34e9d7876f9499ea7d5c7c) )
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u32 0ef7", 0x000000, 0x10000, CRC(2d651ed0) SHA1(e2da2c3d8f25c17e26fd435c75983b2db8691993) )
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u38 10b4", 0x020001, 0x10000, CRC(1eb8c887) SHA1(220f566043535c54ad1cf2216966c7f42099e50b) )
@@ -887,14 +951,14 @@ ROM_START( amerdart3 ) /* You need to check the sum16 values listed on the label
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u46 1f84", 0x040000, 0x10000, CRC(1188047e) SHA1(249f25582ab72eeee37798418460de312053660e) )
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u52 cdfd", 0x060001, 0x10000, CRC(5ac2f06d) SHA1(b3a5d0cd94bdffdbf5bd17dbb30c07bfad3fa5d0) )
 	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u53 d432", 0x060000, 0x10000, CRC(4bd25cf0) SHA1(d1092cc3b6172d6567acd21f79b22043380102b7) )
-	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u57 4cac", 0x080001, 0x10000, CRC(2d653c7b) SHA1(0feebe6440aabe844049013aa063ed0259b7bec4) ) /* Different then set 2 or 3 */
-	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u58 729e", 0x080000, 0x10000, CRC(8cef479a) SHA1(80002e215416a11ff071523ee67218a1aabe155b) ) /* Different then set 2 or 3 */
+	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u57 4cac", 0x080001, 0x10000, CRC(2d653c7b) SHA1(0feebe6440aabe844049013aa063ed0259b7bec4) ) // Different then set 2 or 3
+	ROM_LOAD16_BYTE( "ameri corp copyright 1989 u58 729e", 0x080000, 0x10000, CRC(8cef479a) SHA1(80002e215416a11ff071523ee67218a1aabe155b) ) // Different then set 2 or 3
 
-	ROM_REGION( 0x10000, "dsp", 0 ) /* TMS32015 code  */
-	ROM_LOAD16_WORD( "tms320e15.bin", 0x0000, 0x2000, CRC(375db4ea) SHA1(11689c89ce62f44f43cb8973b4ec6e6b0024ed14) ) /* Passes internal checksum routine */
+	ROM_REGION( 0x10000, "dsp", 0 ) // TMS32015 code 
+	ROM_LOAD16_WORD( "tms320e15.bin", 0x0000, 0x2000, CRC(375db4ea) SHA1(11689c89ce62f44f43cb8973b4ec6e6b0024ed14) ) // Passes internal checksum routine
 
-	ROM_REGION( 0x100000, "dspdata", 0 )              /* TMS32015 audio sample data */
-	ROM_LOAD16_WORD( "ameri corp copyright 1989 u1 222f",  0x000000, 0x10000, CRC(e2bb7f54) SHA1(39eeb61a852b93331f445cc1c993727e52959660) ) /* Same as set 2 */
+	ROM_REGION( 0x100000, "dspdata", 0 )              // TMS32015 audio sample data
+	ROM_LOAD16_WORD( "ameri corp copyright 1989 u1 222f",  0x000000, 0x10000, CRC(e2bb7f54) SHA1(39eeb61a852b93331f445cc1c993727e52959660) ) // Same as set 2
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u16 abd6", 0x010000, 0x10000, CRC(7437e8bf) SHA1(754be4822cd586590f09e706d7eb48e5ba8c8817) )
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u2 cae4",  0x020000, 0x10000, CRC(a587fffd) SHA1(f33f511d1bf1d6eb3c42535593a9718571174c4b) )
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u17 b791", 0x030000, 0x10000, CRC(e32bdd0f) SHA1(0662abbe84f0bad2631566b506ef016fcd79b9ee) )
@@ -909,16 +973,16 @@ ROM_START( amerdart3 ) /* You need to check the sum16 values listed on the label
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u7 2671",  0x0c0000, 0x10000, CRC(147083a2) SHA1(c04c38145ab159bd519e6325477a3f7d0eebbda1) )
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u22 8fd7", 0x0d0000, 0x10000, CRC(4b92588a) SHA1(eea262c1a122015364a0046ff2bc7816f5f6821d) )
 	ROM_LOAD16_WORD( "ameri corp copyright 1989 u8 961c",  0x0e0000, 0x10000, CRC(975b368c) SHA1(1d637ce8c5d60833bb25aab2610e1a856720235e) )
-	ROM_LOAD16_WORD( "ameri corp copyright 1989 u23 b806", 0x0f0000, 0x10000, CRC(7c1e6f2e) SHA1(21ae530e4bd7c0c9f1a84f01f136c71952c8adc4) ) /* Same as set 2 */
+	ROM_LOAD16_WORD( "ameri corp copyright 1989 u23 b806", 0x0f0000, 0x10000, CRC(7c1e6f2e) SHA1(21ae530e4bd7c0c9f1a84f01f136c71952c8adc4) ) // Same as set 2
 ROM_END
 
 
 ROM_START( coolpool )
-	ROM_REGION16_LE( 0x40000, "maincpu", 0 )  /* 34010 code */
+	ROM_REGION16_LE( 0x40000, "maincpu", 0 )  // 34010 code
 	ROM_LOAD16_BYTE( "u112b",        0x00000, 0x20000, CRC(aa227769) SHA1(488e357a7aad07369cade3110cde14ba8562c66c) )
 	ROM_LOAD16_BYTE( "u113b",        0x00001, 0x20000, CRC(5b5f82f1) SHA1(82afb6a8d94cf09960b962d5208aab451b56feae) )
 
-	ROM_REGION16_LE( 0x200000, "gfx1", 0 )  /* gfx data read by main CPU */
+	ROM_REGION16_LE( 0x200000, "maingfx", 0 )  // gfx data read by main CPU
 	ROM_LOAD16_BYTE( "u04",          0x000000, 0x20000, CRC(66a9940e) SHA1(7fa587280ecfad6b06194868de09cbdd57cf517f) )
 	ROM_CONTINUE(                    0x100000, 0x20000 )
 	ROM_LOAD16_BYTE( "u08",          0x000001, 0x20000, CRC(56789cf4) SHA1(5ad867d5029fdac9dccd01a6979171aa30d9a6eb) )
@@ -936,11 +1000,11 @@ ROM_START( coolpool )
 	ROM_LOAD16_BYTE( "u05",          0x0c0001, 0x20000, CRC(616965e2) SHA1(588ea3c5c7838c50b2157ff1074f629d9d85791c) )
 	ROM_CONTINUE(                    0x1c0001, 0x20000 )
 
-	ROM_REGION( 0x40000, "dsp", 0 ) /* TMS320C26 */
+	ROM_REGION( 0x40000, "dsp", 0 ) // TMS320C26
 	ROM_LOAD16_BYTE( "u34",          0x00000, 0x08000, CRC(dc1df70b) SHA1(e42fa7e34e50e0bd2aaeea5c55d750ed3286610d) )
 	ROM_LOAD16_BYTE( "u35",          0x00001, 0x08000, CRC(ac999431) SHA1(7e4c2dcaedcb7e7c67072a179e4b8488d2bbdac7) )
 
-	ROM_REGION( 0x200000, "dspdata", 0 )  /* TMS32026 data */
+	ROM_REGION( 0x200000, "dspdata", 0 )  // TMS32026 data
 	ROM_LOAD( "u17c",         0x000000, 0x40000, CRC(ea3cc41d) SHA1(e703e789dfbcfaec878a990031ce839164c51253) )
 	ROM_LOAD( "u16c",         0x040000, 0x40000, CRC(2e6680ea) SHA1(cb30dc789039aab491428d075fee9e0bc04fd2ce) )
 	ROM_LOAD( "u15c",         0x080000, 0x40000, CRC(8e5f248e) SHA1(a954d3c20dc0b70f83c4c238db30a33285fcb353) )
@@ -953,19 +1017,19 @@ ROM_END
 
 
 ROM_START( 9ballsht )
-	ROM_REGION16_LE( 0x80000, "maincpu", 0 )  /* 34010 code */
+	ROM_REGION16_LE( 0x80000, "maincpu", 0 )  // 34010 code
 	ROM_LOAD16_BYTE( "u112",         0x00000, 0x40000, CRC(b3855e59) SHA1(c3175df24b85897783169bcaccd61630e512f7f6) )
 	ROM_LOAD16_BYTE( "u113",         0x00001, 0x40000, CRC(30cbf462) SHA1(64b2e2d40c2a92c4f4823dc866e5464792954ac3) )
 
-	ROM_REGION16_LE( 0x100000, "gfx1", 0 )  /* gfx data read by main CPU */
+	ROM_REGION16_LE( 0x100000, "maingfx", 0 )  // gfx data read by main CPU
 	ROM_LOAD16_BYTE( "e-scape =c=1994 c316.u110", 0x00000, 0x80000, CRC(890ed5c0) SHA1(eaf06ee5b6c5ed0103b535396b4517012818a416) )
 	ROM_LOAD16_BYTE( "e-scape =c=1994 13f2.u111", 0x00001, 0x80000, CRC(1a9f1145) SHA1(ba52a6d1aca26484c320518f69c66ce3ceb4adcf) )
 
-	ROM_REGION( 0x40000, "dsp", 0 ) /* TMS320C26 */
+	ROM_REGION( 0x40000, "dsp", 0 ) // TMS320C26
 	ROM_LOAD16_BYTE( "e-scape =c=1994 89bc.u34", 0x00000, 0x08000, CRC(dc1df70b) SHA1(e42fa7e34e50e0bd2aaeea5c55d750ed3286610d) )
 	ROM_LOAD16_BYTE( "e-scape =c=1994 af4a.u35", 0x00001, 0x08000, CRC(ac999431) SHA1(7e4c2dcaedcb7e7c67072a179e4b8488d2bbdac7) )
 
-	ROM_REGION( 0x100000, "dspdata", 0 )  /* TMS32026 data */
+	ROM_REGION( 0x100000, "dspdata", 0 )  // TMS32026 data
 	ROM_LOAD( "u54",          0x00000, 0x80000, CRC(1be5819c) SHA1(308b5b1fe05634419d03956ae1b2e5a61206900f) )
 	ROM_LOAD( "u53",          0x80000, 0x80000, CRC(d401805d) SHA1(f4bcb2bdc45c3bc5ca423e518cdea8b3a7e8d60e) )
 ROM_END
@@ -975,37 +1039,37 @@ ROM_END
   I assume the others are the same.
  */
 ROM_START( 9ballsht2 )
-	ROM_REGION16_LE( 0x80000, "maincpu", 0 )  /* 34010 code */
+	ROM_REGION16_LE( 0x80000, "maincpu", 0 )  // 34010 code
 	ROM_LOAD16_BYTE( "e-scape.112",  0x00000, 0x40000, CRC(aee8114f) SHA1(a0d0e9e3a879393585b85ac6d04e31a7d4221179) )
 	ROM_LOAD16_BYTE( "e-scape.113",  0x00001, 0x40000, CRC(ccd472a7) SHA1(d074080e987c233b26b3c72248411c575f7a2293) )
 
-	ROM_REGION16_LE( 0x100000, "gfx1", 0 )  /* gfx data read by main CPU */
+	ROM_REGION16_LE( 0x100000, "maingfx", 0 )  // gfx data read by main CPU
 	ROM_LOAD16_BYTE( "e-scape =c=1994 c316.u110", 0x00000, 0x80000, CRC(890ed5c0) SHA1(eaf06ee5b6c5ed0103b535396b4517012818a416) )
 	ROM_LOAD16_BYTE( "e-scape =c=1994 13f2.u111", 0x00001, 0x80000, CRC(1a9f1145) SHA1(ba52a6d1aca26484c320518f69c66ce3ceb4adcf) )
 
-	ROM_REGION( 0x40000, "dsp", 0 ) /* TMS320C26 */
+	ROM_REGION( 0x40000, "dsp", 0 ) // TMS320C26
 	ROM_LOAD16_BYTE( "e-scape =c=1994 89bc.u34", 0x00000, 0x08000, CRC(dc1df70b) SHA1(e42fa7e34e50e0bd2aaeea5c55d750ed3286610d) )
 	ROM_LOAD16_BYTE( "e-scape =c=1994 af4a.u35", 0x00001, 0x08000, CRC(ac999431) SHA1(7e4c2dcaedcb7e7c67072a179e4b8488d2bbdac7) )
 
-	ROM_REGION( 0x100000, "dspdata", 0 )  /* TMS32026 data */
+	ROM_REGION( 0x100000, "dspdata", 0 )  // TMS32026 data
 	ROM_LOAD( "u54",          0x00000, 0x80000, CRC(1be5819c) SHA1(308b5b1fe05634419d03956ae1b2e5a61206900f) )
 	ROM_LOAD( "u53",          0x80000, 0x80000, CRC(d401805d) SHA1(f4bcb2bdc45c3bc5ca423e518cdea8b3a7e8d60e) )
 ROM_END
 
 ROM_START( 9ballsht3 )
-	ROM_REGION16_LE( 0x80000, "maincpu", 0 )  /* 34010 code */
+	ROM_REGION16_LE( 0x80000, "maincpu", 0 )  // 34010 code
 	ROM_LOAD16_BYTE( "8e_1826.112",  0x00000, 0x40000, CRC(486f7a8b) SHA1(635e3b1e7a21a86dd3d0ea994e9b923b06df587e) )
 	ROM_LOAD16_BYTE( "8e_6166.113",  0x00001, 0x40000, CRC(c41db70a) SHA1(162112f9f5bb6345920a45c41da6a249796bd21f) )
 
-	ROM_REGION16_LE( 0x100000, "gfx1", 0 )  /* gfx data read by main CPU */
+	ROM_REGION16_LE( 0x100000, "maingfx", 0 )  // gfx data read by main CPU
 	ROM_LOAD16_BYTE( "e-scape =c=1994 c316.u110", 0x00000, 0x80000, CRC(890ed5c0) SHA1(eaf06ee5b6c5ed0103b535396b4517012818a416) )
 	ROM_LOAD16_BYTE( "e-scape =c=1994 13f2.u111", 0x00001, 0x80000, CRC(1a9f1145) SHA1(ba52a6d1aca26484c320518f69c66ce3ceb4adcf) )
 
-	ROM_REGION( 0x40000, "dsp", 0 ) /* TMS320C26 */
+	ROM_REGION( 0x40000, "dsp", 0 ) // TMS320C26
 	ROM_LOAD16_BYTE( "e-scape =c=1994 89bc.u34", 0x00000, 0x08000, CRC(dc1df70b) SHA1(e42fa7e34e50e0bd2aaeea5c55d750ed3286610d) )
 	ROM_LOAD16_BYTE( "e-scape =c=1994 af4a.u35", 0x00001, 0x08000, CRC(ac999431) SHA1(7e4c2dcaedcb7e7c67072a179e4b8488d2bbdac7) )
 
-	ROM_REGION( 0x100000, "dspdata", 0 )  /* TMS32026 data */
+	ROM_REGION( 0x100000, "dspdata", 0 )  // TMS32026 data
 	ROM_LOAD( "u54",          0x00000, 0x80000, CRC(1be5819c) SHA1(308b5b1fe05634419d03956ae1b2e5a61206900f) )
 	ROM_LOAD( "u53",          0x80000, 0x80000, CRC(d401805d) SHA1(f4bcb2bdc45c3bc5ca423e518cdea8b3a7e8d60e) )
 ROM_END
@@ -1013,19 +1077,19 @@ ROM_END
 
 // all checksums correctly match sum16 printed on rom labels
 ROM_START( 9ballshtc )
-	ROM_REGION16_LE( 0x80000, "maincpu", 0 )  /* 34010 code */
+	ROM_REGION16_LE( 0x80000, "maincpu", 0 )  // 34010 code
 	ROM_LOAD16_BYTE( "e-scape =c=1994 3990.u112",  0x00000, 0x40000, CRC(7ba2749a) SHA1(e2ddc2600234dbebbb423f201cc4061fd0b9911a) )
 	ROM_LOAD16_BYTE( "e-scape =c=1994 b72f.u113",  0x00001, 0x40000, CRC(1e0f3c62) SHA1(3c24a38dcb553fd84b0b44a5a8d93a14435e22b0) )
 
-	ROM_REGION16_LE( 0x100000, "gfx1", 0 )  /* gfx data read by main CPU */
+	ROM_REGION16_LE( 0x100000, "maingfx", 0 )  // gfx data read by main CPU
 	ROM_LOAD16_BYTE( "e-scape =c=1994 c316.u110", 0x00000, 0x80000, CRC(890ed5c0) SHA1(eaf06ee5b6c5ed0103b535396b4517012818a416) )
 	ROM_LOAD16_BYTE( "e-scape =c=1994 13f2.u111", 0x00001, 0x80000, CRC(1a9f1145) SHA1(ba52a6d1aca26484c320518f69c66ce3ceb4adcf) )
 
-	ROM_REGION( 0x40000, "dsp", 0 ) /* TMS320C26 */
+	ROM_REGION( 0x40000, "dsp", 0 ) // TMS320C26
 	ROM_LOAD16_BYTE( "e-scape =c=1994 89bc.u34", 0x00000, 0x08000, CRC(dc1df70b) SHA1(e42fa7e34e50e0bd2aaeea5c55d750ed3286610d) )
 	ROM_LOAD16_BYTE( "e-scape =c=1994 af4a.u35", 0x00001, 0x08000, CRC(ac999431) SHA1(7e4c2dcaedcb7e7c67072a179e4b8488d2bbdac7) )
 
-	ROM_REGION( 0x100000, "dspdata", 0 )  /* TMS32026 data */
+	ROM_REGION( 0x100000, "dspdata", 0 )  // TMS32026 data
 	ROM_LOAD( "e-scape =c=1994 0000.u54", 0x00000, 0x80000, CRC(04b509a0) SHA1(093343741a3d8d0786fd443e68dd85b414c6cf9e) )
 	ROM_LOAD( "e-scape =c=1994 2df8.u53", 0x80000, 0x80000, CRC(c8a7b576) SHA1(7eb71dd791fdcbfe71764a454f0a1d3130d8a57e) )
 ROM_END
@@ -1039,36 +1103,21 @@ ROM_END
  *
  *************************************/
 
-void coolpool_state::machine_start()
-{
-	// assumes it can make an address mask with m_dsp_rom.length() - 1
-	assert(!(m_dsp_rom.length() & (m_dsp_rom.length() - 1)));
-
-	save_item(NAME(m_oldx));
-	save_item(NAME(m_oldy));
-	save_item(NAME(m_result));
-	save_item(NAME(m_lastresult));
-
-	save_item(NAME(m_iop_romaddr));
-}
-
-
-
-void coolpool_state::init_amerdart()
+void amerdart_state::init_amerdart()
 {
 	m_lastresult = 0xffff;
 }
 
 
-void coolpool_state::init_9ballsht()
+void _9ballsht_state::init_9ballsht()
 {
 	// decrypt the main program ROMs
 	uint16_t *rom = (uint16_t *)memregion("maincpu")->base();
 	int len = memregion("maincpu")->bytes();
 	for (int a = 0; a < len/2; a++)
 	{
-		int hi = rom[a] >> 8;
-		int lo = rom[a] & 0xff;
+		uint16_t const hi = rom[a] >> 8;
+		uint16_t const lo = rom[a] & 0xff;
 
 		int nhi = bitswap<8>(hi,5,2,0,7,6,4,3,1) ^ 0x29;
 		if (hi & 0x01) nhi ^= 0x03;
@@ -1090,9 +1139,7 @@ void coolpool_state::init_9ballsht()
 	for (int a = 1; a < len/2; a += 4)
 	{
 		// just swap bits 1 and 2 of the address
-		uint16_t tmp = rom[a];
-		rom[a] = rom[a+1];
-		rom[a+1] = tmp;
+		std::swap<uint16_t>(rom[a], rom[a+1]);
 	}
 }
 
@@ -1104,11 +1151,11 @@ void coolpool_state::init_9ballsht()
  *
  *************************************/
 
-GAME( 1989, amerdart,  0,        amerdart,  amerdart, coolpool_state, init_amerdart, ROT0, "Ameri",                               "AmeriDarts (set 1)",           MACHINE_SUPPORTS_SAVE )
-GAME( 1989, amerdart2, amerdart, amerdart,  amerdart, coolpool_state, init_amerdart, ROT0, "Ameri",                               "AmeriDarts (set 2)",           MACHINE_SUPPORTS_SAVE )
-GAME( 1989, amerdart3, amerdart, amerdart,  amerdart, coolpool_state, init_amerdart, ROT0, "Ameri",                               "AmeriDarts (set 3)",           MACHINE_SUPPORTS_SAVE )
+GAME( 1989, amerdart,  0,        amerdart,  amerdart, amerdart_state, init_amerdart, ROT0, "Ameri",                               "AmeriDarts (set 1)",           MACHINE_SUPPORTS_SAVE )
+GAME( 1989, amerdart2, amerdart, amerdart,  amerdart, amerdart_state, init_amerdart, ROT0, "Ameri",                               "AmeriDarts (set 2)",           MACHINE_SUPPORTS_SAVE )
+GAME( 1989, amerdart3, amerdart, amerdart,  amerdart, amerdart_state, init_amerdart, ROT0, "Ameri",                               "AmeriDarts (set 3)",           MACHINE_SUPPORTS_SAVE )
 GAME( 1992, coolpool,  0,        coolpool,  coolpool, coolpool_state, empty_init,    ROT0, "Catalina",                            "Cool Pool",                    0 )
-GAME( 1993, 9ballsht,  0,        _9ballsht, 9ballsht, coolpool_state, init_9ballsht, ROT0, "E-Scape EnterMedia (Bundra license)", "9-Ball Shootout (set 1)",      0 )
-GAME( 1993, 9ballsht2, 9ballsht, _9ballsht, 9ballsht, coolpool_state, init_9ballsht, ROT0, "E-Scape EnterMedia (Bundra license)", "9-Ball Shootout (set 2)",      0 )
-GAME( 1993, 9ballsht3, 9ballsht, _9ballsht, 9ballsht, coolpool_state, init_9ballsht, ROT0, "E-Scape EnterMedia (Bundra license)", "9-Ball Shootout (set 3)",      0 )
-GAME( 1993, 9ballshtc, 9ballsht, _9ballsht, 9ballsht, coolpool_state, init_9ballsht, ROT0, "E-Scape EnterMedia (Bundra license)", "9-Ball Shootout Championship", 0 )
+GAME( 1993, 9ballsht,  0,        _9ballsht, 9ballsht, _9ballsht_state, init_9ballsht, ROT0, "E-Scape EnterMedia (Bundra license)", "9-Ball Shootout (set 1)",      0 )
+GAME( 1993, 9ballsht2, 9ballsht, _9ballsht, 9ballsht, _9ballsht_state, init_9ballsht, ROT0, "E-Scape EnterMedia (Bundra license)", "9-Ball Shootout (set 2)",      0 )
+GAME( 1993, 9ballsht3, 9ballsht, _9ballsht, 9ballsht, _9ballsht_state, init_9ballsht, ROT0, "E-Scape EnterMedia (Bundra license)", "9-Ball Shootout (set 3)",      0 )
+GAME( 1993, 9ballshtc, 9ballsht, _9ballsht, 9ballsht, _9ballsht_state, init_9ballsht, ROT0, "E-Scape EnterMedia (Bundra license)", "9-Ball Shootout Championship", 0 )

--- a/src/mame/misc/coolpool.h
+++ b/src/mame/misc/coolpool.h
@@ -14,7 +14,7 @@
 
 class coolpool_base_state : public driver_device
 {
-public:
+protected:
 	coolpool_base_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
@@ -27,7 +27,6 @@ public:
 		, m_dsp_rom(*this, "dspdata")
 	{ }
 
-protected:
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
@@ -85,8 +84,6 @@ public:
 	{ }
 
 	void amerdart(machine_config &config);
-
-	void init_amerdart();
 
 protected:
 	virtual void machine_start() override;

--- a/src/mame/misc/coolpool.h
+++ b/src/mame/misc/coolpool.h
@@ -10,14 +10,15 @@
 #include "machine/timer.h"
 #include "video/tlc34076.h"
 
-class coolpool_state : public driver_device
+#include "emupal.h"
+
+class coolpool_base_state : public driver_device
 {
 public:
-	coolpool_state(const machine_config &mconfig, device_type type, const char *tag)
+	coolpool_base_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
 		, m_dsp(*this, "dsp")
-		, m_tlc34076(*this, "tlc34076")
 		, m_main2dsp(*this, "main2dsp")
 		, m_dsp2main(*this, "dsp2main")
 		, m_nvram_timer(*this, "nvram_timer")
@@ -26,22 +27,14 @@ public:
 		, m_dsp_rom(*this, "dspdata")
 	{ }
 
-	void _9ballsht(machine_config &config);
-	void coolpool(machine_config &config);
-	void amerdart(machine_config &config);
-
-	void init_amerdart();
-	void init_9ballsht();
-
 protected:
 	virtual void machine_start() override;
+	virtual void machine_reset() override;
 
-private:
 	static constexpr unsigned NVRAM_UNLOCK_SEQ_LEN = 10;
 
 	required_device<tms34010_device> m_maincpu;
 	required_device<cpu_device> m_dsp;
-	optional_device<tlc34076_device> m_tlc34076;
 
 	required_device<generic_latch_16_device> m_main2dsp;
 	required_device<generic_latch_16_device> m_dsp2main;
@@ -66,45 +59,111 @@ private:
 
 	uint16_t m_nvram_write_seq[NVRAM_UNLOCK_SEQ_LEN]{};
 	uint8_t m_nvram_write_enable = 0U;
-	bool m_old_cmd = false;
 	uint8_t m_same_cmd_count = 0U;
 
 	void nvram_thrash_w(offs_t offset, uint16_t data);
 	void nvram_data_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void nvram_thrash_data_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 
-	void amerdart_misc_w(uint16_t data);
-	int amerdart_dsp_bio_line_r();
-	uint16_t amerdart_trackball_r(offs_t offset);
-	void coolpool_misc_w(uint16_t data);
-	uint16_t dsp_bio_line_r();
-	uint16_t dsp_hold_line_r();
 	uint16_t dsp_rom_r();
 	void dsp_romaddr_w(offs_t offset, uint16_t data);
-	uint16_t coolpool_input_r(offs_t offset);
 
 	TMS340X0_TO_SHIFTREG_CB_MEMBER(to_shiftreg);
 	TMS340X0_FROM_SHIFTREG_CB_MEMBER(from_shiftreg);
-	TMS340X0_SCANLINE_RGB32_CB_MEMBER(amerdart_scanline);
-	TMS340X0_SCANLINE_RGB32_CB_MEMBER(coolpool_scanline);
-
-	DECLARE_MACHINE_RESET(amerdart);
-	DECLARE_MACHINE_RESET(coolpool);
 
 	TIMER_DEVICE_CALLBACK_MEMBER(nvram_write_timeout);
+};
+
+class amerdart_state : public coolpool_base_state
+{
+public:
+	amerdart_state(const machine_config &mconfig, device_type type, const char *tag)
+		: coolpool_base_state(mconfig, type, tag)
+		, m_palette(*this, "palette")
+		, m_in_xaxis(*this, "XAXIS%u", 1U)
+		, m_in_yaxis(*this, "YAXIS%u", 1U)
+	{ }
+
+	void amerdart(machine_config &config);
+
+	void init_amerdart();
+
+protected:
+	virtual void machine_start() override;
+
+private:
+	required_device<palette_device> m_palette;
+
+	required_ioport_array<2> m_in_xaxis;
+	required_ioport_array<2> m_in_yaxis;
+
+	bool m_old_cmd = false;
+
+	void misc_w(uint16_t data);
+	int dsp_bio_line_r();
+	uint16_t amerdart_trackball_r(offs_t offset);
+
+	TMS340X0_SCANLINE_RGB32_CB_MEMBER(scanline);
+
 	TIMER_DEVICE_CALLBACK_MEMBER(amerdart_audio_int_gen);
 
 	int amerdart_trackball_direction(int num, int data);
 
-	void amerdart_dsp_io_map(address_map &map);
-	void amerdart_dsp_pgm_map(address_map &map);
-	void amerdart_map(address_map &map);
-	void coolpool_dsp_io_map(address_map &map);
-	void coolpool_dsp_io_base_map(address_map &map);
-	void coolpool_dsp_pgm_map(address_map &map);
-	void coolpool_map(address_map &map);
+	void dsp_io_map(address_map &map);
+	void dsp_pgm_map(address_map &map);
+	void main_map(address_map &map);
+};
+
+class _9ballsht_state : public coolpool_base_state
+{
+public:
+	_9ballsht_state(const machine_config &mconfig, device_type type, const char *tag)
+		: coolpool_base_state(mconfig, type, tag)
+		, m_tlc34076(*this, "tlc34076")
+	{ }
+
+	void _9ballsht(machine_config &config);
+
+	void init_9ballsht();
+
+protected:
+	required_device<tlc34076_device> m_tlc34076;
+
+	void misc_w(uint16_t data);
+	uint16_t dsp_bio_line_r();
+	uint16_t dsp_hold_line_r();
+
+	TMS340X0_SCANLINE_RGB32_CB_MEMBER(scanline);
+
+	void dsp_io_base_map(address_map &map);
+	void dsp_pgm_map(address_map &map);
+
+private:
 	void nballsht_dsp_io_map(address_map &map);
 	void nballsht_map(address_map &map);
+};
+
+class coolpool_state : public _9ballsht_state
+{
+public:
+	coolpool_state(const machine_config &mconfig, device_type type, const char *tag)
+		: _9ballsht_state(mconfig, type, tag)
+		, m_in1(*this, "IN1")
+		, m_xaxis(*this, "XAXIS")
+		, m_yaxis(*this, "YAXIS")
+	{ }
+
+	void coolpool(machine_config &config);
+
+private:
+	required_ioport m_in1;
+	required_ioport m_xaxis;
+	required_ioport m_yaxis;
+
+	uint16_t coolpool_input_r(offs_t offset);
+
+	void coolpool_dsp_io_map(address_map &map);
+	void coolpool_map(address_map &map);
 };
 
 #endif // MAME_MISC_COOLPOOL_H


### PR DESCRIPTION
Split driver state to reduce optional finders
Use palette_device for amerdart palette
Suppress side effects for debugger read
Constantize variables
Use logmacro.h for logging functions
Use C++ style comments for single line comments
Use std::swap for swap function