### PR TITLE
midway/midvunit.cpp: Split driver state class to reduce optional finders, cleanups:

### DIFF
--- a/src/mame/midway/midvunit.cpp
+++ b/src/mame/midway/midvunit.cpp
@@ -35,7 +35,23 @@
 #include "crusnusa.lh"
 
 
-#define CPU_CLOCK       50000000
+#define LOG_INPUT    (1U << 1)
+#define LOG_CTRL     (1U << 2)
+#define LOG_REGS     (1U << 3)
+#define LOG_COMM     (1U << 4)
+#define LOG_SOUND    (1U << 5)
+
+#define LOG_ALL      (LOG_INPUT | LOG_CTRL | LOG_REGS | LOG_COMM | LOG_SOUND)
+
+#define VERBOSE (0)
+#include "logmacro.h"
+
+#define LOGINPUT(...) LOGMASKED(LOG_INPUT, __VA_ARGS__)
+#define LOGCTRL(...)  LOGMASKED(LOG_CTRL,  __VA_ARGS__)
+#define LOGREGS(...)  LOGMASKED(LOG_REGS,  __VA_ARGS__)
+#define LOGCOMM(...)  LOGMASKED(LOG_COMM,  __VA_ARGS__)
+#define LOGSOUND(...) LOGMASKED(LOG_SOUND, __VA_ARGS__)
+
 
 
 /*************************************
@@ -44,14 +60,24 @@
  *
  *************************************/
 
-void midvunit_state::machine_start()
+void midvunit_base_state::machine_start()
 {
 	save_item(NAME(m_cmos_protected));
 	save_item(NAME(m_control_data));
+	save_item(NAME(m_timer_rate));
+}
+
+
+void midvunit_state::machine_start()
+{
+	midvunit_base_state::machine_start();
+
 	save_item(NAME(m_adc_shift));
 	save_item(NAME(m_last_port0));
 	save_item(NAME(m_shifter_state));
-	save_item(NAME(m_timer_rate));
+	save_item(NAME(m_galil_input_index));
+	save_item(NAME(m_galil_input_length));
+	save_item(NAME(m_galil_output_index));
 	save_item(NAME(m_wheel_board_output));
 	save_item(NAME(m_wheel_board_last));
 	save_item(NAME(m_wheel_board_u8_latch));
@@ -63,23 +89,34 @@ void midvunit_state::machine_start()
 }
 
 
-void midvunit_state::machine_reset()
+void crusnwld_state::machine_start()
+{
+	save_item(NAME(m_bit_index));
+
+	midvunit_state::machine_start();
+}
+
+
+void midvplus_state::machine_start()
+{
+	midvunit_base_state::machine_start();
+	save_item(NAME(m_lastval));
+}
+
+
+void midvunit_base_state::machine_reset()
 {
 	m_dcs->reset_w(0);
 	m_dcs->reset_w(1);
 
-	memcpy(m_ram_base, memregion("user1")->base(), 0x20000*4);
+	memcpy(m_ram_base, memregion("maindata")->base(), 0x20000*4);
 	m_maincpu->reset();
 }
 
 
-MACHINE_RESET_MEMBER(midvunit_state,midvplus)
+void midvplus_state::machine_reset()
 {
-	m_dcs->reset_w(0);
-	m_dcs->reset_w(1);
-
-	memcpy(m_ram_base, memregion("user1")->base(), 0x20000*4);
-	m_maincpu->reset();
+	midvunit_base_state::machine_reset();
 
 	m_ata->reset();
 }
@@ -94,19 +131,22 @@ MACHINE_RESET_MEMBER(midvunit_state,midvplus)
 
 uint32_t midvunit_state::port0_r()
 {
-	uint16_t val = ioport("IN0")->read();
+	uint16_t val = m_in0->read();
 	uint16_t diff = val ^ m_last_port0;
 
-	/* make sure the shift controls are mutually exclusive */
-	if ((diff & 0x0400) && !(val & 0x0400))
-		m_shifter_state = (m_shifter_state == 1) ? 0 : 1;
-	if ((diff & 0x0800) && !(val & 0x0800))
-		m_shifter_state = (m_shifter_state == 2) ? 0 : 2;
-	if ((diff & 0x1000) && !(val & 0x1000))
-		m_shifter_state = (m_shifter_state == 4) ? 0 : 4;
-	if ((diff & 0x2000) && !(val & 0x2000))
-		m_shifter_state = (m_shifter_state == 8) ? 0 : 8;
-	m_last_port0 = val;
+	if (!machine().side_effects_disabled())
+	{
+		// make sure the shift controls are mutually exclusive
+		if ((diff & 0x0400) && !(val & 0x0400))
+			m_shifter_state = (m_shifter_state == 1) ? 0 : 1;
+		if ((diff & 0x0800) && !(val & 0x0800))
+			m_shifter_state = (m_shifter_state == 2) ? 0 : 2;
+		if ((diff & 0x1000) && !(val & 0x1000))
+			m_shifter_state = (m_shifter_state == 4) ? 0 : 4;
+		if ((diff & 0x2000) && !(val & 0x2000))
+			m_shifter_state = (m_shifter_state == 8) ? 0 : 8;
+		m_last_port0 = val;
+	}
 
 	val = (val | 0x3c00) ^ (m_shifter_state << 10);
 
@@ -125,7 +165,10 @@ uint32_t midvunit_state::adc_r()
 	if (!(m_control_data & 0x40))
 		return m_adc->read() << m_adc_shift;
 	else
-		logerror("adc_r without enabling reads!\n");
+	{
+		if (!machine().side_effects_disabled())
+			LOGINPUT("adc_r without enabling reads!\n");
+	}
 
 	return 0xffffffff;
 }
@@ -135,7 +178,7 @@ void midvunit_state::adc_w(uint32_t data)
 	if (!(m_control_data & 0x20))
 		m_adc->write(data >> m_adc_shift);
 	else
-		logerror("adc_w without enabling writes!\n");
+		LOGINPUT("adc_w without enabling writes!\n");
 }
 
 
@@ -146,20 +189,20 @@ void midvunit_state::adc_w(uint32_t data)
  *
  *************************************/
 
-void midvunit_state::midvunit_cmos_protect_w(uint32_t data)
+void midvunit_base_state::cmos_protect_w(uint32_t data)
 {
 	m_cmos_protected = ((data & 0xc00) != 0xc00);
 }
 
 
-void midvunit_state::midvunit_cmos_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+void midvunit_state::cmos_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	if (!m_cmos_protected)
 		COMBINE_DATA(&m_nvram[offset]);
 }
 
 
-uint32_t midvunit_state::midvunit_cmos_r(offs_t offset)
+uint32_t midvunit_state::cmos_r(offs_t offset)
 {
 	return m_nvram[offset];
 }
@@ -172,47 +215,47 @@ uint32_t midvunit_state::midvunit_cmos_r(offs_t offset)
  *
  *************************************/
 
-void midvunit_state::midvunit_control_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+void midvunit_base_state::control_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	uint16_t olddata = m_control_data;
+	uint16_t const olddata = m_control_data;
 	COMBINE_DATA(&m_control_data);
 
-	/* bit 7 is the LED */
+	// bit 7 is the LED
 
-	/* bit 3 is the watchdog */
+	// bit 3 is the watchdog
 	m_watchdog->reset_line_w(BIT(m_control_data, 3));
 
-	/* bit 1 is the DCS sound reset */
+	// bit 1 is the DCS sound reset
 	m_dcs->reset_w(BIT(m_control_data, 1));
 
-	/* log anything unusual */
+	// log anything unusual
 	if ((olddata ^ m_control_data) & ~0x00e8)
-		logerror("midvunit_control_w: old=%04X new=%04X diff=%04X\n", olddata, m_control_data, olddata ^ m_control_data);
+		LOGCTRL("control_w: old=%04X new=%04X diff=%04X\n", olddata, m_control_data, olddata ^ m_control_data);
 }
 
 
-void midvunit_state::crusnwld_control_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+void crusnwld_state::crusnwld_control_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	uint16_t olddata = m_control_data;
+	uint16_t const olddata = m_control_data;
 	COMBINE_DATA(&m_control_data);
 
-	/* bit 11 is the DCS sound reset */
+	// bit 11 is the DCS sound reset
 	m_dcs->reset_w(BIT(m_control_data, 11));
 
-	/* bit 9 is the watchdog */
+	// bit 9 is the watchdog
 	m_watchdog->reset_line_w(BIT(m_control_data, 9));
 
-	/* bit 8 is the LED */
+	// bit 8 is the LED
 
-	/* log anything unusual */
+	// log anything unusual
 	if ((olddata ^ m_control_data) & ~0xe800)
-		logerror("crusnwld_control_w: old=%04X new=%04X diff=%04X\n", olddata, m_control_data, olddata ^ m_control_data);
+		LOGCTRL("crusnwld_control_w: old=%04X new=%04X diff=%04X\n", olddata, m_control_data, olddata ^ m_control_data);
 }
 
 
-void midvunit_state::midvunit_sound_w(uint32_t data)
+void midvunit_base_state::sound_w(uint32_t data)
 {
-	logerror("Sound W = %02X\n", data);
+	LOGSOUND("Sound W = %02X\n", data);
 	m_dcs->data_w(data & 0xff);
 }
 
@@ -224,50 +267,53 @@ void midvunit_state::midvunit_sound_w(uint32_t data)
  *
  *************************************/
 
-uint32_t midvunit_state::tms32031_control_r(offs_t offset)
+uint32_t midvunit_base_state::tms32031_control_r(offs_t offset)
 {
-	/* watch for accesses to the timers */
+	// watch for accesses to the timers
 	if (offset == 0x24 || offset == 0x34)
 	{
-		/* timer is clocked at 100ns */
-		int which = (offset >> 4) & 1;
-		int32_t result = (m_timer[which]->elapsed() * m_timer_rate).as_double();
-//      logerror("%06X:tms32031_control_r(%02X) = %08X\n", m_maincpu->pc(), offset, result);
+		// timer is clocked at 100ns
+		int const which = (offset >> 4) & 1;
+		int32_t const result = (m_timer[which]->elapsed() * m_timer_rate).as_double();
+//      LOGREGS("%06X:tms32031_control_r(%02X) = %08X\n", m_maincpu->pc(), offset, result);
 		return result;
 	}
 
-	/* log anything else except the memory control register */
-	if (offset != 0x64)
-		logerror("%06X:tms32031_control_r(%02X)\n", m_maincpu->pc(), offset);
+	if (!machine().side_effects_disabled())
+	{
+		// log anything else except the memory control register
+		if (offset != 0x64)
+			LOGREGS("%06X:tms32031_control_r(%02X)\n", m_maincpu->pc(), offset);
+	}
 
 	return m_tms32031_control[offset];
 }
 
 
-void midvunit_state::tms32031_control_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+void midvunit_base_state::tms32031_control_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	COMBINE_DATA(&m_tms32031_control[offset]);
 
-	/* ignore changes to the memory control register */
+	// ignore changes to the memory control register
 	if (offset == 0x64)
 		;
 
-	/* watch for accesses to the timers */
+	// watch for accesses to the timers
 	else if (offset == 0x20 || offset == 0x30)
 	{
-		int which = (offset >> 4) & 1;
-//  logerror("%06X:tms32031_control_w(%02X) = %08X\n", m_maincpu->pc(), offset, data);
+		int const which = (offset >> 4) & 1;
+//  LOGREGS("%06X:tms32031_control_w(%02X) = %08X\n", m_maincpu->pc(), offset, data);
 		if (data & 0x40)
 			m_timer[which]->reset();
 
-		/* bit 0x200 selects internal clocking, which is 1/2 the main CPU clock rate */
+		// bit 0x200 selects internal clocking, which is 1/2 the main CPU clock rate
 		if (data & 0x200)
 			m_timer_rate = (double)(m_maincpu->unscaled_clock() * 0.5);
 		else
 			m_timer_rate = 10000000.;
 	}
 	else
-		logerror("%06X:tms32031_control_w(%02X) = %08X\n", m_maincpu->pc(), offset, data);
+		LOGREGS("%06X:tms32031_control_w(%02X) = %08X\n", m_maincpu->pc(), offset, data);
 }
 
 
@@ -278,20 +324,20 @@ void midvunit_state::tms32031_control_w(offs_t offset, uint32_t data, uint32_t m
  *
  *************************************/
 
-uint32_t midvunit_state::crusnwld_serial_status_r()
+uint32_t crusnwld_state::crusnwld_serial_status_r()
 {
-	uint16_t in1 = (m_in1->read() & 0x7fff) | (m_midway_serial_pic2->status_r() << 15);
+	uint16_t const in1 = (m_in1->read() & 0x7fff) | (m_midway_serial_pic2->status_r() << 15);
 	return in1 | in1 << 16;
 }
 
 
-uint32_t midvunit_state::crusnwld_serial_data_r()
+uint32_t crusnwld_state::crusnwld_serial_data_r()
 {
 	return m_midway_serial_pic2->read() << 16;
 }
 
 
-void midvunit_state::crusnwld_serial_data_w(uint32_t data)
+void crusnwld_state::crusnwld_serial_data_w(uint32_t data)
 {
 	m_midway_serial_pic2->write(data >> 16);
 }
@@ -304,7 +350,7 @@ void midvunit_state::crusnwld_serial_data_w(uint32_t data)
  *
  *************************************/
 
-/* values from offset 3, 6, and 10 must add up to 0x904752a2 */
+// values from offset 3, 6, and 10 must add up to 0x904752a2
 static const uint32_t bit_data[0x10] =
 {
 	0x3017c636,0x3017c636,0x3017c636,0x3017c636,
@@ -314,23 +360,23 @@ static const uint32_t bit_data[0x10] =
 };
 
 
-uint32_t midvunit_state::bit_data_r(offs_t offset)
+uint32_t crusnwld_state::bit_data_r(offs_t offset)
 {
-	int bit = (bit_data[m_bit_index / 32] >> (31 - (m_bit_index % 32))) & 1;
+	int const bit = (bit_data[m_bit_index / 32] >> (31 - (m_bit_index % 32))) & 1;
 	m_bit_index = (m_bit_index + 1) % 512;
 	return bit ? m_nvram[offset] : ~m_nvram[offset];
 }
 
 
-void midvunit_state::bit_reset_w(uint32_t data)
+void crusnwld_state::bit_reset_w(uint32_t data)
 {
 	m_bit_index = 0;
 }
 
 
-uint32_t midvunit_state::midvunit_wheel_board_r()
+uint32_t midvunit_state::wheel_board_r()
 {
-	//logerror("midvunit_wheel_board_r: %08X\n", m_wheel_board_output);
+	//LOGINPUT("wheel_board_r: %08X\n", m_wheel_board_output);
 	return m_wheel_board_output << 8;
 }
 
@@ -341,14 +387,14 @@ void midvunit_state::set_input(const char *s)
 	m_galil_input_length = strlen(s);
 }
 
-void midvunit_state::midvunit_wheel_board_w(uint32_t data)
+void midvunit_state::wheel_board_w(uint32_t data)
 {
-	//logerror("midvunit_wheel_board_w: %08X\n", data);
+	//LOGINPUT("wheel_board_w: %08X\n", data);
 
 	// U8 PAL22V10 "DECODE0" TODO: Needs dump "A-19674"
 	if (BIT(data, 11) && !BIT(m_wheel_board_last, 11))
 	{
-		logerror("Wheel board (U8 PAL22V10; DECODE0) = %03X\n", BIT(data, 11) | ((data & 0xF) << 1) | ((data & 0x700) << 1));
+		LOGINPUT("Wheel board (U8 PAL22V10; DECODE0) = %03X\n", BIT(data, 11) | ((data & 0xF) << 1) | ((data & 0x700) << 1));
 		m_wheel_board_u8_latch = 0;
 		m_wheel_board_u8_latch |= BIT(data, 0) << 6; // WA0; A for U9
 		m_wheel_board_u8_latch |= BIT(data, 1) << 5; // WA1; B for U9
@@ -358,16 +404,16 @@ void midvunit_state::midvunit_wheel_board_w(uint32_t data)
 
 	if (!BIT(data, 9))
 	{
-		logerror("Wheel board (U13 74HC245; DCS) = %02X\n", data & 0xFF);
+		LOGINPUT("Wheel board (U13 74HC245; DCS) = %02X\n", data & 0xFF);
 	}
 	else if (!BIT(data, 10)) // G2A for U9
 	{
-		uint8_t arg = data & 0xFF;
-		uint8_t wa = BIT(m_wheel_board_u8_latch, 6) | (BIT(m_wheel_board_u8_latch, 5) << 1) | (BIT(m_wheel_board_u8_latch, 4) << 2);
+		uint8_t const arg = data & 0xFF;
+		uint8_t const wa = BIT(m_wheel_board_u8_latch, 6) | (BIT(m_wheel_board_u8_latch, 5) << 1) | (BIT(m_wheel_board_u8_latch, 4) << 2);
 		if (BIT(m_wheel_board_u8_latch, 3))
 		{
 			// U19 PAL22V10 "GALIL" TODO: Needs dump "A-19675", needs Galil emulation
-			logerror("Wheel board (U19 PAL22V10; GALIL) = %03X\n", (m_wheel_board_u8_latch & 0x78) | ((data & 0x3F) << 6));
+			LOGINPUT("Wheel board (U19 PAL22V10; GALIL) = %03X\n", (m_wheel_board_u8_latch & 0x78) | ((data & 0x3F) << 6));
 			switch (wa)
 			{
 				case 0:
@@ -401,7 +447,7 @@ void midvunit_state::midvunit_wheel_board_w(uint32_t data)
 						    set_input("Q");*/
 						else
 							set_input(":");
-						logerror("Galil Command: %s\n", m_galil_output);
+						LOGINPUT("Galil Command: %s\n", m_galil_output);
 						memset(m_galil_output, 0, m_galil_output_index);
 						m_galil_output_index = 0;
 					}
@@ -424,31 +470,31 @@ void midvunit_state::midvunit_wheel_board_w(uint32_t data)
 			switch (wa)
 			{
 				case 0: // SNDCTLZ
-					logerror("Wheel board (U14 74HC574; DCS Control) = %02X\n", arg);
+					LOGINPUT("Wheel board (U14 74HC574; DCS Control) = %02X\n", arg);
 					break;
 				case 1: // GALCTLZ
-					logerror("Wheel board (U19 PAL22V10; Galil Control) = %02X\n", arg);
+					LOGINPUT("Wheel board (U19 PAL22V10; Galil Control) = %02X\n", arg);
 					break;
 				case 2: // ATODWRZ
-					logerror("Wheel board (ATODWRZ) = %02X\n", arg);
+					LOGINPUT("Wheel board (ATODWRZ) = %02X\n", arg);
 					break;
 				case 3: // ATODRDZ
-					logerror("Wheel board (ATODRDZ) = %02X\n", arg);
+					LOGINPUT("Wheel board (ATODRDZ) = %02X\n", arg);
 					break;
 				case 4: // WHLCTLZ
 					m_wheel_motor = arg;
-					//logerror("Wheel board (U4 74HC574; Motor) = %02X\n", arg);
+					//LOGINPUT("Wheel board (U4 74HC574; Motor) = %02X\n", arg);
 					break;
 				case 5: // DRVCTLZ
 					for (uint8_t bit = 0; bit < 8; bit++)
 						m_optional_drivers[bit] = BIT(data, bit);
-					//logerror("Wheel board (U10 74HC574; Lamps) = %02X\n", arg);
+					//LOGINPUT("Wheel board (U10 74HC574; Lamps) = %02X\n", arg);
 					break;
 				case 6: // PRTCTLZ
-					logerror("Wheel board (PRTCTLZ) = %02X\n", arg);
+					LOGINPUT("Wheel board (PRTCTLZ) = %02X\n", arg);
 					break;
 				case 7: // PRTSTATZ
-					logerror("Wheel board (PRTSTATZ) = %02X\n", arg);
+					LOGINPUT("Wheel board (PRTSTATZ) = %02X\n", arg);
 					break;
 			}
 		}
@@ -458,9 +504,9 @@ void midvunit_state::midvunit_wheel_board_w(uint32_t data)
 }
 
 
-DECLARE_CUSTOM_INPUT_MEMBER(midvunit_state::motion_r)
+DECLARE_CUSTOM_INPUT_MEMBER(crusnusa_state::motion_r)
 {
-	uint8_t status = m_motion->read();
+	uint8_t const status = m_motion->read();
 	for (uint8_t bit = 0; bit < 8; bit++)
 	{
 		if (BIT(status, bit))
@@ -470,7 +516,7 @@ DECLARE_CUSTOM_INPUT_MEMBER(midvunit_state::motion_r)
 }
 
 
-uint32_t midvunit_state::midvunit_intcs_r()
+uint32_t midvunit_state::intcs_r()
 {
 	return 4;
 }
@@ -493,11 +539,12 @@ uint16_t midvunit_state::comm_bus_in()
 	return comm_bus_out();
 }
 
-uint32_t midvunit_state::midvunit_comcs_r(offs_t offset)
+uint32_t midvunit_state::comcs_r(offs_t offset)
 {
 	if (offset != 0)
 	{
-		logerror("midvunit_comcs_r(%d)\n", offset);
+		if (!machine().side_effects_disabled())
+			LOGCOMM("comcs_r(%d)\n", offset);
 		return 0;
 	}
 	else
@@ -511,11 +558,11 @@ uint32_t midvunit_state::midvunit_comcs_r(offs_t offset)
 	}
 }
 
-void midvunit_state::midvunit_comcs_w(offs_t offset, uint32_t data)
+void midvunit_state::comcs_w(offs_t offset, uint32_t data)
 {
 	switch (offset)
 	{
-		default: logerror("midvunit_comcs_w(%d) = %08X\n", offset, data); break;
+		default: LOGCOMM("comcs_w(%d) = %08X\n", offset, data); break;
 		case 0: m_comm_data = data >> 16; break;
 		case 1: m_comm_flags = (data >> 24) & 0xe0; break;
 	}
@@ -528,7 +575,7 @@ void midvunit_state::midvunit_comcs_w(offs_t offset, uint32_t data)
  *
  *************************************/
 
-uint32_t midvunit_state::midvplus_misc_r(offs_t offset)
+uint32_t midvplus_state::midvplus_misc_r(offs_t offset)
 {
 	uint32_t result = m_midvplus_misc[offset];
 
@@ -543,19 +590,22 @@ uint32_t midvunit_state::midvplus_misc_r(offs_t offset)
 			break;
 
 		case 3:
-			/* seems to want loopback */
+			// seems to want loopback
 			break;
 	}
 
-	if (offset != 0 && offset != 3)
-		logerror("%06X:midvplus_misc_r(%d) = %08X\n", m_maincpu->pc(), offset, result);
+	if (!machine().side_effects_disabled())
+	{
+		if (offset != 0 && offset != 3)
+			LOGCTRL("%06X:midvplus_misc_r(%d) = %08X\n", m_maincpu->pc(), offset, result);
+	}
 	return result;
 }
 
 
-void midvunit_state::midvplus_misc_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+void midvplus_state::midvplus_misc_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	uint32_t olddata = m_midvplus_misc[offset];
+	uint32_t const olddata = m_midvplus_misc[offset];
 	bool logit = true;
 
 	COMBINE_DATA(&m_midvplus_misc[offset]);
@@ -563,7 +613,7 @@ void midvunit_state::midvplus_misc_w(offs_t offset, uint32_t data, uint32_t mem_
 	switch (offset)
 	{
 		case 0:
-			/* bit 4 resets watchdog */
+			// bit 4 resets watchdog
 			m_watchdog->reset_line_w(BIT(data, 4));
 
 			logit = bool((olddata ^ m_midvplus_misc[offset]) & ~0x0010);
@@ -575,7 +625,7 @@ void midvunit_state::midvplus_misc_w(offs_t offset, uint32_t data, uint32_t mem_
 	}
 
 	if (logit)
-		logerror("%06X:midvplus_misc_w(%d) = %08X\n", m_maincpu->pc(), offset, data);
+		LOGCTRL("%06X:midvplus_misc_w(%d) = %08X\n", m_maincpu->pc(), offset, data);
 }
 
 
@@ -586,7 +636,7 @@ void midvunit_state::midvplus_misc_w(offs_t offset, uint32_t data, uint32_t mem_
  *
  *************************************/
 
-void midvunit_state::midvplus_xf1_w(uint8_t data)
+void midvplus_state::midvplus_xf1_w(uint8_t data)
 {
 //  osd_printf_debug("xf1_w = %d\n", data);
 
@@ -606,55 +656,72 @@ void midvunit_state::midvplus_xf1_w(uint8_t data)
 
 void midvunit_state::midvunit_map(address_map &map)
 {
-	map(0x000000, 0x01ffff).ram().share("ram_base");
+	map(0x000000, 0x01ffff).ram().share(m_ram_base);
 	map(0x400000, 0x41ffff).ram();
-	map(0x600000, 0x600000).w(FUNC(midvunit_state::midvunit_dma_queue_w));
-	map(0x808000, 0x80807f).rw(FUNC(midvunit_state::tms32031_control_r), FUNC(midvunit_state::tms32031_control_w)).share("32031_control");
-	map(0x900000, 0x97ffff).rw(FUNC(midvunit_state::midvunit_videoram_r), FUNC(midvunit_state::midvunit_videoram_w));
-	map(0x980000, 0x980000).r(FUNC(midvunit_state::midvunit_dma_queue_entries_r));
-	map(0x980020, 0x980020).r(FUNC(midvunit_state::midvunit_scanline_r));
-	map(0x980020, 0x98002b).w(FUNC(midvunit_state::midvunit_video_control_w));
-	map(0x980040, 0x980040).rw(FUNC(midvunit_state::midvunit_page_control_r), FUNC(midvunit_state::midvunit_page_control_w));
+	map(0x600000, 0x600000).w(FUNC(midvunit_state::dma_queue_w));
+	map(0x808000, 0x80807f).rw(FUNC(midvunit_state::tms32031_control_r), FUNC(midvunit_state::tms32031_control_w)).share(m_tms32031_control);
+	map(0x900000, 0x97ffff).rw(FUNC(midvunit_state::videoram_r), FUNC(midvunit_state::videoram_w));
+	map(0x980000, 0x980000).r(FUNC(midvunit_state::dma_queue_entries_r));
+	map(0x980020, 0x980020).r(FUNC(midvunit_state::scanline_r));
+	map(0x980020, 0x98002b).w(FUNC(midvunit_state::video_control_w));
+	map(0x980040, 0x980040).rw(FUNC(midvunit_state::page_control_r), FUNC(midvunit_state::page_control_w));
 	map(0x980080, 0x980080).noprw();
-	map(0x980082, 0x980083).r(FUNC(midvunit_state::midvunit_dma_trigger_r));
-	map(0x990000, 0x990000).r(FUNC(midvunit_state::midvunit_intcs_r));
+	map(0x980082, 0x980083).r(FUNC(midvunit_state::dma_trigger_r));
+	map(0x990000, 0x990000).r(FUNC(midvunit_state::intcs_r));
 	map(0x991030, 0x991030).lr16(NAME([this] () { return uint16_t(m_in1->read()); }));
 //  map(0x991050, 0x991050).readonly(); // seems to be another port
 	map(0x991060, 0x991060).r(FUNC(midvunit_state::port0_r));
 	map(0x992000, 0x992000).lr16(NAME([this] () { return uint16_t(m_dsw->read()); }));
 	map(0x993000, 0x993000).rw(FUNC(midvunit_state::adc_r), FUNC(midvunit_state::adc_w));
-	map(0x994000, 0x994000).w(FUNC(midvunit_state::midvunit_control_w));
-	map(0x995000, 0x995000).rw(FUNC(midvunit_state::midvunit_wheel_board_r), FUNC(midvunit_state::midvunit_wheel_board_w));
-	map(0x995020, 0x995020).w(FUNC(midvunit_state::midvunit_cmos_protect_w));
-	map(0x997000, 0x997008).rw(FUNC(midvunit_state::midvunit_comcs_r), FUNC(midvunit_state::midvunit_comcs_w));
-	map(0x9a0000, 0x9a0000).w(FUNC(midvunit_state::midvunit_sound_w));
-	map(0x9c0000, 0x9c1fff).rw(FUNC(midvunit_state::midvunit_cmos_r), FUNC(midvunit_state::midvunit_cmos_w)).share("nvram");
-	map(0x9e0000, 0x9e7fff).ram().w(FUNC(midvunit_state::midvunit_paletteram_w)).share("paletteram");
-	map(0xa00000, 0xbfffff).rw(FUNC(midvunit_state::midvunit_textureram_r), FUNC(midvunit_state::midvunit_textureram_w)).share("textureram");
-	map(0xc00000, 0xffffff).rom().region("user1", 0);
+	map(0x994000, 0x994000).w(FUNC(midvunit_state::control_w));
+	map(0x995000, 0x995000).rw(FUNC(midvunit_state::wheel_board_r), FUNC(midvunit_state::wheel_board_w));
+	map(0x995020, 0x995020).w(FUNC(midvunit_state::cmos_protect_w));
+	map(0x997000, 0x997008).rw(FUNC(midvunit_state::comcs_r), FUNC(midvunit_state::comcs_w));
+	map(0x9a0000, 0x9a0000).w(FUNC(midvunit_state::sound_w));
+	map(0x9c0000, 0x9c1fff).rw(FUNC(midvunit_state::cmos_r), FUNC(midvunit_state::cmos_w)).share(m_nvram);
+	map(0x9e0000, 0x9e7fff).ram().w(FUNC(midvunit_state::paletteram_w)).share(m_paletteram);
+	map(0xa00000, 0xbfffff).rw(FUNC(midvunit_state::textureram_r), FUNC(midvunit_state::textureram_w)).share(m_textureram);
+	map(0xc00000, 0xffffff).rom().region("maindata", 0);
 }
 
 
-void midvunit_state::midvplus_map(address_map &map)
+void crusnwld_state::offroadc_map(address_map &map)
 {
-	map(0x000000, 0x01ffff).ram().share("ram_base");
-	map(0x400000, 0x41ffff).ram().share("fastram_base");
-	map(0x600000, 0x600000).w(FUNC(midvunit_state::midvunit_dma_queue_w));
-	map(0x808000, 0x80807f).rw(FUNC(midvunit_state::tms32031_control_r), FUNC(midvunit_state::tms32031_control_w)).share("32031_control");
-	map(0x900000, 0x97ffff).rw(FUNC(midvunit_state::midvunit_videoram_r), FUNC(midvunit_state::midvunit_videoram_w));
-	map(0x980000, 0x980000).r(FUNC(midvunit_state::midvunit_dma_queue_entries_r));
-	map(0x980020, 0x980020).r(FUNC(midvunit_state::midvunit_scanline_r));
-	map(0x980020, 0x98002b).w(FUNC(midvunit_state::midvunit_video_control_w));
-	map(0x980040, 0x980040).rw(FUNC(midvunit_state::midvunit_page_control_r), FUNC(midvunit_state::midvunit_page_control_w));
+	midvunit_map(map);
+	map(0x991030, 0x991030).r(FUNC(crusnwld_state::crusnwld_serial_status_r));
+	map(0x994000, 0x994000).w(FUNC(crusnwld_state::crusnwld_control_w));
+	map(0x996000, 0x996000).rw(FUNC(crusnwld_state::crusnwld_serial_data_r), FUNC(crusnwld_state::crusnwld_serial_data_w));
+}
+
+
+void crusnwld_state::crusnwld_map(address_map &map)
+{
+	offroadc_map(map);
+	map(0x9d0000, 0x9d1fff).r(FUNC(crusnwld_state::bit_data_r));
+	map(0x9d0000, 0x9d0000).w(FUNC(crusnwld_state::bit_reset_w));
+}
+
+
+void midvplus_state::midvplus_map(address_map &map)
+{
+	map(0x000000, 0x01ffff).ram().share(m_ram_base);
+	map(0x400000, 0x41ffff).ram().share(m_fastram_base);
+	map(0x600000, 0x600000).w(FUNC(midvplus_state::dma_queue_w));
+	map(0x808000, 0x80807f).rw(FUNC(midvplus_state::tms32031_control_r), FUNC(midvplus_state::tms32031_control_w)).share(m_tms32031_control);
+	map(0x900000, 0x97ffff).rw(FUNC(midvplus_state::videoram_r), FUNC(midvplus_state::videoram_w));
+	map(0x980000, 0x980000).r(FUNC(midvplus_state::dma_queue_entries_r));
+	map(0x980020, 0x980020).r(FUNC(midvplus_state::scanline_r));
+	map(0x980020, 0x98002b).w(FUNC(midvplus_state::video_control_w));
+	map(0x980040, 0x980040).rw(FUNC(midvplus_state::page_control_r), FUNC(midvplus_state::page_control_w));
 	map(0x980080, 0x980080).noprw();
-	map(0x980082, 0x980083).r(FUNC(midvunit_state::midvunit_dma_trigger_r));
+	map(0x980082, 0x980083).r(FUNC(midvplus_state::dma_trigger_r));
 	map(0x990000, 0x99000f).rw(m_midway_ioasic, FUNC(midway_ioasic_device::read), FUNC(midway_ioasic_device::write));
-	map(0x994000, 0x994000).w(FUNC(midvunit_state::midvunit_control_w));
-	map(0x995020, 0x995020).w(FUNC(midvunit_state::midvunit_cmos_protect_w));
-	map(0x9a0000, 0x9a0007).rw("ata", FUNC(ata_interface_device::cs0_r), FUNC(ata_interface_device::cs0_w)).umask32(0x0000ffff);
-	map(0x9c0000, 0x9c7fff).ram().w(FUNC(midvunit_state::midvunit_paletteram_w)).share("paletteram");
-	map(0x9d0000, 0x9d000f).rw(FUNC(midvunit_state::midvplus_misc_r), FUNC(midvunit_state::midvplus_misc_w)).share("midvplus_misc");
-	map(0xa00000, 0xbfffff).rw(FUNC(midvunit_state::midvunit_textureram_r), FUNC(midvunit_state::midvunit_textureram_w)).share("textureram");
+	map(0x994000, 0x994000).w(FUNC(midvplus_state::control_w));
+	map(0x995020, 0x995020).w(FUNC(midvplus_state::cmos_protect_w));
+	map(0x9a0000, 0x9a0007).rw(m_ata, FUNC(ata_interface_device::cs0_r), FUNC(ata_interface_device::cs0_w)).umask32(0x0000ffff);
+	map(0x9c0000, 0x9c7fff).ram().w(FUNC(midvplus_state::paletteram_w)).share(m_paletteram);
+	map(0x9d0000, 0x9d000f).rw(FUNC(midvplus_state::midvplus_misc_r), FUNC(midvplus_state::midvplus_misc_w)).share(m_midvplus_misc);
+	map(0xa00000, 0xbfffff).rw(FUNC(midvplus_state::textureram_r), FUNC(midvplus_state::textureram_w)).share(m_textureram);
 	map(0xc00000, 0xcfffff).ram();
 }
 
@@ -671,37 +738,37 @@ static INPUT_PORTS_START( midvunit )
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_COIN1 )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_COIN2 )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_START1 )
-	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_TILT ) /* Slam Switch */
-	PORT_BIT( 0x0010, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("Enter") PORT_CODE(KEYCODE_F2) /* Test switch */
+	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_TILT ) // Slam Switch
+	PORT_BIT( 0x0010, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("Enter") PORT_CODE(KEYCODE_F2) // Test switch
 	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_SERVICE1 )
 	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_COIN3 )
 	PORT_BIT( 0x0100, IP_ACTIVE_LOW, IPT_VOLUME_DOWN )
 	PORT_BIT( 0x0200, IP_ACTIVE_LOW, IPT_VOLUME_UP )
-	PORT_BIT( 0x0400, IP_ACTIVE_LOW, IPT_BUTTON8 ) PORT_NAME("4th Gear")    /* 4th */
-	PORT_BIT( 0x0800, IP_ACTIVE_LOW, IPT_BUTTON7 ) PORT_NAME("3rd Gear")    /* 3rd */
-	PORT_BIT( 0x1000, IP_ACTIVE_LOW, IPT_BUTTON6 ) PORT_NAME("2nd Gear")    /* 2nd */
-	PORT_BIT( 0x2000, IP_ACTIVE_LOW, IPT_BUTTON5 ) PORT_NAME("1st Gear")    /* 1st */
+	PORT_BIT( 0x0400, IP_ACTIVE_LOW, IPT_BUTTON8 ) PORT_NAME("4th Gear")    // 4th
+	PORT_BIT( 0x0800, IP_ACTIVE_LOW, IPT_BUTTON7 ) PORT_NAME("3rd Gear")    // 3rd
+	PORT_BIT( 0x1000, IP_ACTIVE_LOW, IPT_BUTTON6 ) PORT_NAME("2nd Gear")    // 2nd
+	PORT_BIT( 0x2000, IP_ACTIVE_LOW, IPT_BUTTON5 ) PORT_NAME("1st Gear")    // 1st
 	PORT_BIT( 0x4000, IP_ACTIVE_LOW, IPT_COIN4 )
 	PORT_BIT( 0x8000, IP_ACTIVE_LOW, IPT_UNUSED )
 
 	PORT_START("IN1")
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_UNKNOWN )
-	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_NAME("Radio")   /* radio */
+	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_NAME("Radio")   // radio
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_UNKNOWN )
 	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_UNKNOWN )
-	PORT_BIT( 0x0010, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_NAME("View 1")  /* view 1 */
-	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_NAME("View 2")  /* view 2 */
-	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_BUTTON4 ) PORT_NAME("View 3") /* view 3 */
+	PORT_BIT( 0x0010, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_NAME("View 1")  // view 1
+	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_NAME("View 2")  // view 2
+	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_BUTTON4 ) PORT_NAME("View 3") // view 3
 	PORT_BIT( 0xff80, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("WHEEL")     /* wheel */
+	PORT_START("WHEEL")     // wheel
 	PORT_BIT( 0xff, 0x80, IPT_PADDLE ) PORT_MINMAX(0x10,0xf0) PORT_SENSITIVITY(25) PORT_KEYDELTA(20)
 
-	PORT_START("ACCEL")     /* gas pedal */
+	PORT_START("ACCEL")     // gas pedal
 	PORT_BIT( 0xff, 0x00, IPT_PEDAL ) PORT_SENSITIVITY(25) PORT_KEYDELTA(20)
 
-	PORT_START("BRAKE")     /* brake pedal */
+	PORT_START("BRAKE")     // brake pedal
 	PORT_BIT( 0xff, 0x00, IPT_PEDAL2 ) PORT_SENSITIVITY(25) PORT_KEYDELTA(20)
 INPUT_PORTS_END
 
@@ -725,23 +792,23 @@ static INPUT_PORTS_START( crusnusa )
 	PORT_BIT( 0x0200, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_NAME("Motion Status - Device 2")
 	PORT_BIT( 0x0400, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_NAME("Motion Status - Device 3")
 	PORT_BIT( 0x0800, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_NAME("Motion Status - Device 4")
-	PORT_BIT( 0xf000, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_CUSTOM_MEMBER(midvunit_state, motion_r)
+	PORT_BIT( 0xf000, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_CUSTOM_MEMBER(crusnusa_state, motion_r)
 
 	PORT_START("DSW")
-	/* DSW2 at U97 */
+	// DSW2 at U97
 	PORT_DIPNAME( 0x0001, 0x0000, "Link Status" )       PORT_DIPLOCATION("SW2:8")
 	PORT_DIPSETTING(      0x0000, "Master" )
 	PORT_DIPSETTING(      0x0001, "Slave" )
-	PORT_DIPNAME( 0x0002, 0x0002, "Link???" )       PORT_DIPLOCATION("SW2:7") /* Listed as Not Used in the manual */
+	PORT_DIPNAME( 0x0002, 0x0002, "Link???" )       PORT_DIPLOCATION("SW2:7") // Listed as Not Used in the manual
 	PORT_DIPSETTING(      0x0002, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 	PORT_DIPNAME( 0x0004, 0x0004, "Linking" )       PORT_DIPLOCATION("SW2:6")
 	PORT_DIPSETTING(      0x0004, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0008, 0x0008, DEF_STR( Unknown ) )  PORT_DIPLOCATION("SW2:5") /* Listed as Not Used in the manual */
+	PORT_DIPNAME( 0x0008, 0x0008, DEF_STR( Unknown ) )  PORT_DIPLOCATION("SW2:5") // Listed as Not Used in the manual
 	PORT_DIPSETTING(      0x0008, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0010, 0x0010, "Freeze" )        PORT_DIPLOCATION("SW2:4") /* Listed as Not Used in the manual */
+	PORT_DIPNAME( 0x0010, 0x0010, "Freeze" )        PORT_DIPLOCATION("SW2:4") // Listed as Not Used in the manual
 	PORT_DIPSETTING(      0x0010, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 	PORT_DIPNAME( 0x0020, 0x0020, DEF_STR( Cabinet ) )  PORT_DIPLOCATION("SW2:3")
@@ -750,9 +817,9 @@ static INPUT_PORTS_START( crusnusa )
 	PORT_DIPNAME( 0x0040, 0x0040, "Enable Motion" )     PORT_DIPLOCATION("SW2:2")
 	PORT_DIPSETTING(      0x0040, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_SERVICE_DIPLOC(  0x0080, IP_ACTIVE_LOW, "SW2:1" ) /* Listed as Not Used in the manual */
+	PORT_SERVICE_DIPLOC(  0x0080, IP_ACTIVE_LOW, "SW2:1" ) // Listed as Not Used in the manual
 
-	/* DSW3 at U19 */
+	// DSW3 at U19
 	PORT_DIPNAME( 0x0100, 0x0100, "Coin Counters" )     PORT_DIPLOCATION("SW3:8")
 	PORT_DIPSETTING(      0x0100, "1" )
 	PORT_DIPSETTING(      0x0000, "2" )
@@ -819,7 +886,7 @@ static INPUT_PORTS_START( crusnwld )
 	PORT_INCLUDE( midvunit )
 
 	PORT_START("DSW")
-	/* DSW2 at U97 */
+	// DSW2 at U97
 	PORT_DIPNAME( 0x0003, 0x0000, "Link Number" )       PORT_DIPLOCATION("SW2:8,7")
 	PORT_DIPSETTING(      0x0000, "1" )
 	PORT_DIPSETTING(      0x0001, "2" )
@@ -835,10 +902,10 @@ static INPUT_PORTS_START( crusnwld )
 	PORT_DIPNAME( 0x0020, 0x0020, DEF_STR( Cabinet ) )  PORT_DIPLOCATION("SW2:3")
 	PORT_DIPSETTING(      0x0020, DEF_STR( Upright ) )
 	PORT_DIPSETTING(      0x0000, "Sitdown" )
-	PORT_DIPUNUSED_DIPLOC( 0x0040, 0x0040, "SW2:2" )        /* Manual shows Not Used */
+	PORT_DIPUNUSED_DIPLOC( 0x0040, 0x0040, "SW2:2" )        // Manual shows Not Used
 	PORT_SERVICE_DIPLOC(  0x0080, IP_ACTIVE_LOW, "SW2:1" )
 
-	/* DSW3 at U19 */
+	// DSW3 at U19
 	PORT_DIPNAME( 0x0100, 0x0100, "Coin Counters" )     PORT_DIPLOCATION("SW3:8")
 	PORT_DIPSETTING(      0x0100, "1" )
 	PORT_DIPSETTING(      0x0000, "2" )
@@ -905,8 +972,8 @@ static INPUT_PORTS_START( offroadc )
 	PORT_INCLUDE( midvunit )
 
 	PORT_START("DSW")
-	/* DSW2 at U97 */
-	PORT_DIPUNUSED_DIPLOC( 0x0001, 0x0001, "SW2:8" )        /* Manual shows Not Used & "No Effect" for both On & Off */
+	// DSW2 at U97
+	PORT_DIPUNUSED_DIPLOC( 0x0001, 0x0001, "SW2:8" )        // Manual shows Not Used & "No Effect" for both On & Off
 	PORT_DIPNAME( 0x0002, 0x0000, "Gear Shifter Switch" )       PORT_DIPLOCATION("SW2:7")
 	PORT_DIPSETTING(      0x0002, "Normally Closed" )
 	PORT_DIPSETTING(      0x0000, "Normally Open" )
@@ -916,7 +983,7 @@ static INPUT_PORTS_START( offroadc )
 	PORT_DIPNAME( 0x0008, 0x0008, "Graphic Effects" )       PORT_DIPLOCATION("SW2:5")
 	PORT_DIPSETTING(      0x0008, "Roadkill Present" )
 	PORT_DIPSETTING(      0x0000, "Roadkill Missing" )
-	PORT_DIPUNUSED_DIPLOC( 0x0010, 0x0010, "SW2:4" )        /* Manual shows Not Used & "No Effect" for both On & Off */
+	PORT_DIPUNUSED_DIPLOC( 0x0010, 0x0010, "SW2:4" )        // Manual shows Not Used & "No Effect" for both On & Off
 	PORT_DIPNAME( 0x0020, 0x0020, "Link" )              PORT_DIPLOCATION("SW2:3")
 	PORT_DIPSETTING(      0x0020, "Disabled" )
 	PORT_DIPSETTING(      0x0000, "Enabled" )
@@ -926,9 +993,9 @@ static INPUT_PORTS_START( offroadc )
 	PORT_DIPSETTING(      0x0040, "3" )
 	PORT_DIPSETTING(      0x0000, "4" )
 
-	/* DSW3 at U19 */
-	PORT_DIPUNUSED_DIPLOC( 0x0100, 0x0100, "SW3:8" )    /* Manual states "Switches 6, 7 and 8 are not active. We recommend */
-	PORT_DIPUNUSED_DIPLOC( 0x0200, 0x0200, "SW3:7" )    /* they be set to the facorty default (OFF) positions."            */
+	// DSW3 at U19
+	PORT_DIPUNUSED_DIPLOC( 0x0100, 0x0100, "SW3:8" )    // Manual states "Switches 6, 7 and 8 are not active. We recommend
+	PORT_DIPUNUSED_DIPLOC( 0x0200, 0x0200, "SW3:7" )    // they be set to the facorty default (OFF) positions."           
 	PORT_DIPUNUSED_DIPLOC( 0x0400, 0x0400, "SW3:6" )
 	PORT_DIPNAME( 0xf800, 0xf800, DEF_STR( Coinage ) )      PORT_DIPLOCATION("SW3:5,4,3,2,1")
 	PORT_DIPSETTING(      0xf800, "USA 1" )
@@ -955,13 +1022,13 @@ INPUT_PORTS_END
 
 static INPUT_PORTS_START( wargods )
 	PORT_START("DIPS")
-	PORT_DIPNAME( 0x0001, 0x0001, "CRT Type / Resolution" )     PORT_DIPLOCATION("SW1:1") /* This only works for the Dual Res version */
+	PORT_DIPNAME( 0x0001, 0x0001, "CRT Type / Resolution" )     PORT_DIPLOCATION("SW1:1") // This only works for the Dual Res version
 	PORT_DIPSETTING(      0x0001, "Medium Res (24Khz)" )
 	PORT_DIPSETTING(      0x0000, "Standard Res (15Khz)" )
-	PORT_DIPNAME( 0x0002, 0x0002, DEF_STR( Unknown ) )      PORT_DIPLOCATION("SW1:2") /* Manual shows Not Used (must be Off) */
+	PORT_DIPNAME( 0x0002, 0x0002, DEF_STR( Unknown ) )      PORT_DIPLOCATION("SW1:2") // Manual shows Not Used (must be Off)
 	PORT_DIPSETTING(      0x0002, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0004, 0x0004, DEF_STR( Unknown ) )      PORT_DIPLOCATION("SW1:3") /* Manual shows Not Used (must be Off) */
+	PORT_DIPNAME( 0x0004, 0x0004, DEF_STR( Unknown ) )      PORT_DIPLOCATION("SW1:3") // Manual shows Not Used (must be Off)
 	PORT_DIPSETTING(      0x0004, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 	PORT_DIPNAME( 0x0008, 0x0008, "Blood" )             PORT_DIPLOCATION("SW1:4")
@@ -970,13 +1037,13 @@ static INPUT_PORTS_START( wargods )
 	PORT_DIPNAME( 0x0010, 0x0010, "Graphics" )          PORT_DIPLOCATION("SW1:5")
 	PORT_DIPSETTING(      0x0010, DEF_STR( Normal ) )
 	PORT_DIPSETTING(      0x0000, "Family" )
-	PORT_DIPNAME( 0x0020, 0x0020, DEF_STR( Unknown ) )      PORT_DIPLOCATION("SW1:6") /* Manual shows Not Used */
+	PORT_DIPNAME( 0x0020, 0x0020, DEF_STR( Unknown ) )      PORT_DIPLOCATION("SW1:6") // Manual shows Not Used
 	PORT_DIPSETTING(      0x0020, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0040, 0x0040, DEF_STR( Unknown ) )      PORT_DIPLOCATION("SW1:7") /* Manual shows Not Used */
+	PORT_DIPNAME( 0x0040, 0x0040, DEF_STR( Unknown ) )      PORT_DIPLOCATION("SW1:7") // Manual shows Not Used
 	PORT_DIPSETTING(      0x0040, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0080, 0x0080, DEF_STR( Unknown ) )      PORT_DIPLOCATION("SW1:8") /* Manual shows Not Used */
+	PORT_DIPNAME( 0x0080, 0x0080, DEF_STR( Unknown ) )      PORT_DIPLOCATION("SW1:8") // Manual shows Not Used
 	PORT_DIPSETTING(      0x0080, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 	PORT_DIPNAME( 0x0100, 0x0100, "Coinage Source" )        PORT_DIPLOCATION("SW2:1")
@@ -1004,7 +1071,7 @@ static INPUT_PORTS_START( wargods )
 	PORT_DIPSETTING(      0x1200, "French-12" )
 	PORT_DIPSETTING(      0x1600, "French-ECA" )
 	PORT_DIPSETTING(      0x3000, DEF_STR( Free_Play ) )
-	PORT_DIPNAME( 0x4000, 0x4000, DEF_STR( Unknown ) )      PORT_DIPLOCATION("SW2:7") /* Manual shows Not Used */
+	PORT_DIPNAME( 0x4000, 0x4000, DEF_STR( Unknown ) )      PORT_DIPLOCATION("SW2:7") // Manual shows Not Used
 	PORT_DIPSETTING(      0x4000, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 	PORT_DIPNAME( 0x8000, 0x8000, "Test Switch" )           PORT_DIPLOCATION("SW2:8")
@@ -1015,7 +1082,7 @@ static INPUT_PORTS_START( wargods )
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_COIN1 )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_COIN2 )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_START1 )
-	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_TILT )     /* Slam Switch */
+	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_TILT )     // Slam Switch
 	PORT_SERVICE_NO_TOGGLE( 0x0010, IP_ACTIVE_LOW )
 	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_START2 )
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_SERVICE1 )
@@ -1026,7 +1093,7 @@ static INPUT_PORTS_START( wargods )
 	PORT_BIT( 0x0800, IP_ACTIVE_LOW, IPT_VOLUME_DOWN )
 	PORT_BIT( 0x1000, IP_ACTIVE_LOW, IPT_VOLUME_UP )
 	PORT_BIT( 0x6000, IP_ACTIVE_LOW, IPT_UNUSED )
-	PORT_BIT( 0x8000, IP_ACTIVE_LOW, IPT_BILL1 )    /* Bill */
+	PORT_BIT( 0x8000, IP_ACTIVE_LOW, IPT_BILL1 )    // Bill
 
 	PORT_START("IN1")
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER(1)
@@ -1057,11 +1124,11 @@ static INPUT_PORTS_START( wargods )
 	PORT_BIT( 0xff80, IP_ACTIVE_LOW, IPT_UNUSED )
 INPUT_PORTS_END
 
-static INPUT_PORTS_START( wargodsa ) /* For Medium Res only versions */
+static INPUT_PORTS_START( wargodsa ) // For Medium Res only versions
 	PORT_INCLUDE(wargods)
 
 	PORT_MODIFY("DIPS")
-	PORT_DIPNAME( 0x0001, 0x0001, DEF_STR( Unknown ) )      PORT_DIPLOCATION("SW1:1") /* Manual shows Not Used (must be Off) */
+	PORT_DIPNAME( 0x0001, 0x0001, DEF_STR( Unknown ) )      PORT_DIPLOCATION("SW1:1") // Manual shows Not Used (must be Off)
 	PORT_DIPSETTING(      0x0001, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 INPUT_PORTS_END
@@ -1073,25 +1140,24 @@ INPUT_PORTS_END
  *
  *************************************/
 
-void midvunit_state::midvcommon(machine_config &config)
+void midvunit_base_state::midvcommon(machine_config &config)
 {
-	/* basic machine hardware */
+	constexpr XTAL CPU_CLOCK = 50_MHz_XTAL;
+
+	// basic machine hardware
 	TMS32031(config, m_maincpu, CPU_CLOCK);
-	m_maincpu->set_addrmap(AS_PROGRAM, &midvunit_state::midvunit_map);
 
-	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_1);
-
-	TIMER(config, "timer0").configure_generic(nullptr);
-	TIMER(config, "timer1").configure_generic(nullptr);
+	TIMER(config, m_timer[0]).configure_generic(nullptr);
+	TIMER(config, m_timer[1]).configure_generic(nullptr);
 
 	WATCHDOG_TIMER(config, m_watchdog);
 
-	/* video hardware */
+	// video hardware
 	PALETTE(config, m_palette).set_entries(32768);
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_raw(MIDVUNIT_VIDEO_CLOCK/2, 666, 0, 512, 432, 0, 400);
-	m_screen->set_screen_update(FUNC(midvunit_state::screen_update_midvunit));
+	m_screen->set_screen_update(FUNC(midvunit_base_state::screen_update));
 	m_screen->set_palette(m_palette);
 }
 
@@ -1099,6 +1165,9 @@ void midvunit_state::midvcommon(machine_config &config)
 void midvunit_state::midvunit(machine_config &config)
 {
 	midvcommon(config);
+	m_maincpu->set_addrmap(AS_PROGRAM, &midvunit_state::midvunit_map);
+
+	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_1);
 
 	ADC0844(config, m_adc);
 	m_adc->intr_callback().set_inputline("maincpu", 3);
@@ -1106,7 +1175,7 @@ void midvunit_state::midvunit(machine_config &config)
 	m_adc->ch2_callback().set_ioport("ACCEL");
 	m_adc->ch3_callback().set_ioport("BRAKE");
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	DCS_AUDIO_2K(config, m_dcs, 0);
@@ -1115,34 +1184,37 @@ void midvunit_state::midvunit(machine_config &config)
 }
 
 
-void midvunit_state::crusnwld(machine_config &config)
+void crusnwld_state::crusnwld(machine_config &config)
 {
 	midvunit(config);
-	/* valid values are 450 or 460 */
+
+	m_maincpu->set_addrmap(AS_PROGRAM, &crusnwld_state::crusnwld_map);
+
+	// valid values are 450 or 460
 	MIDWAY_SERIAL_PIC2(config, m_midway_serial_pic2, 0);
 	m_midway_serial_pic2->set_upper(450);
 	m_midway_serial_pic2->set_yearoffs(94);
 }
 
-void midvunit_state::offroadc(machine_config &config)
+void crusnwld_state::offroadc(machine_config &config)
 {
 	midvunit(config);
-	/* valid values are 230 or 234 */
+
+	m_maincpu->set_addrmap(AS_PROGRAM, &crusnwld_state::offroadc_map);
+
+	// valid values are 230 or 234
 	MIDWAY_SERIAL_PIC2(config, m_midway_serial_pic2, 0);
 	m_midway_serial_pic2->set_upper(230);
 	m_midway_serial_pic2->set_yearoffs(94);
 }
 
-void midvunit_state::midvplus(machine_config &config)
+void midvplus_state::midvplus(machine_config &config)
 {
 	midvcommon(config);
 
-	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &midvunit_state::midvplus_map);
-	m_maincpu->xf1().set(FUNC(midvunit_state::midvplus_xf1_w));
-
-	MCFG_MACHINE_RESET_OVERRIDE(midvunit_state,midvplus)
-	config.device_remove("nvram");
+	// basic machine hardware
+	m_maincpu->set_addrmap(AS_PROGRAM, &midvplus_state::midvplus_map);
+	m_maincpu->xf1().set(FUNC(midvplus_state::midvplus_xf1_w));
 
 	ATA_INTERFACE(config, m_ata).options(ata_devices, "hdd", nullptr, true);
 
@@ -1153,10 +1225,10 @@ void midvunit_state::midvplus(machine_config &config)
 	m_midway_ioasic->in_port_cb<3>().set_ioport("IN2");
 	m_midway_ioasic->set_dcs_tag(m_dcs);
 	m_midway_ioasic->set_shuffle(0);
-	m_midway_ioasic->set_upper(452); /* no alternates */
+	m_midway_ioasic->set_upper(452); // no alternates
 	m_midway_ioasic->set_yearoffs(94);
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
@@ -1263,9 +1335,9 @@ Each label had it's corresponding U position and checksum value.
 Also had V4.4 printed sideways at front of the label.
 
 */
-ROM_START( crusnusa ) /* Version 4.5, Tue Apr 11 1995 - 16:06:48 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
-	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u2.u2", 0x000000, 0x80000, CRC(b9338332) SHA1(e5c420e63c4eba0010a68c7e0a57ef210e2c83d2) ) /* also known to be labeled as P2, the P1 revision hasn't been dumped or confirmed to be different */
+ROM_START( crusnusa ) // Version 4.5, Tue Apr 11 1995 - 16:06:48
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
+	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u2.u2", 0x000000, 0x80000, CRC(b9338332) SHA1(e5c420e63c4eba0010a68c7e0a57ef210e2c83d2) ) // also known to be labeled as P2, the P1 revision hasn't been dumped or confirmed to be different
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u3.u3", 0x200000, 0x80000, CRC(cd8325d6) SHA1(d65d7263e056ca1d637adb44cafef523e0831a34) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u4.u4", 0x400000, 0x80000, CRC(fab457f3) SHA1(2b4b647838b7a8100afc25ca1ffdc74ed67ae00a) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u5.u5", 0x600000, 0x80000, CRC(becc92f4) SHA1(6dffa73ff5270155c44f295e443d5e77c03c0338) )
@@ -1274,11 +1346,11 @@ ROM_START( crusnusa ) /* Version 4.5, Tue Apr 11 1995 - 16:06:48 */
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u8.u8", 0xc00000, 0x80000, CRC(03c28199) SHA1(393b009acd3eceb346b8fff45ae2bdf4f53d041f) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u9.u9", 0xe00000, 0x80000, CRC(24ba6371) SHA1(f60a9ff73b3645e2c8bad67e2f6debc61b5e0653) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 ) /* boot screen reports as HEAD 2 HEAD */
-	ROM_LOAD32_BYTE( "v4.5_4-11-95_cruisn_usa_u10_86b3.u10", 0x000000, 0x80000, CRC(b623eab9) SHA1(a523b0ee039904137e274bdd87f1962ea9ab3d38) ) /* V4.5   4/11/95   CRUIS'N USA U10   (C)1995 Midway 86B3 */
-	ROM_LOAD32_BYTE( "v4.5_4-11-95_cruisn_usa_u11_6d73.u11", 0x000001, 0x80000, CRC(2e47ee94) SHA1(6454093c4e77074c8d0ef1050c8b49043c44fe23) ) /* V4.5   4/11/95   CRUIS'N USA U11   (C)1995 Midway 6D73 */
-	ROM_LOAD32_BYTE( "v4.5_4-11-95_cruisn_usa_u12_4b32.u12", 0x000002, 0x80000, CRC(e9197942) SHA1(cfb6a47be35365f9d56721b4bb0bb6ab9163da8f) ) /* V4.5   4/11/95   CRUIS'N USA U12   (C)1995 Midway 4B32 */
-	ROM_LOAD32_BYTE( "v4.5_4-11-95_cruisn_usa_u13_430e.u13", 0x000003, 0x80000, CRC(4a7c434c) SHA1(bf3b4f22aa9445e1b0ebbbd54eebbf14ccaba8d2) ) /* V4.5   4/11/95   CRUIS'N USA U13   (C)1995 Midway 430E */
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 ) // boot screen reports as HEAD 2 HEAD
+	ROM_LOAD32_BYTE( "v4.5_4-11-95_cruisn_usa_u10_86b3.u10", 0x000000, 0x80000, CRC(b623eab9) SHA1(a523b0ee039904137e274bdd87f1962ea9ab3d38) ) // V4.5   4/11/95   CRUIS'N USA U10   (C)1995 Midway 86B3
+	ROM_LOAD32_BYTE( "v4.5_4-11-95_cruisn_usa_u11_6d73.u11", 0x000001, 0x80000, CRC(2e47ee94) SHA1(6454093c4e77074c8d0ef1050c8b49043c44fe23) ) // V4.5   4/11/95   CRUIS'N USA U11   (C)1995 Midway 6D73
+	ROM_LOAD32_BYTE( "v4.5_4-11-95_cruisn_usa_u12_4b32.u12", 0x000002, 0x80000, CRC(e9197942) SHA1(cfb6a47be35365f9d56721b4bb0bb6ab9163da8f) ) // V4.5   4/11/95   CRUIS'N USA U12   (C)1995 Midway 4B32
+	ROM_LOAD32_BYTE( "v4.5_4-11-95_cruisn_usa_u13_430e.u13", 0x000003, 0x80000, CRC(4a7c434c) SHA1(bf3b4f22aa9445e1b0ebbbd54eebbf14ccaba8d2) ) // V4.5   4/11/95   CRUIS'N USA U13   (C)1995 Midway 430E
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u14.u14", 0x200000, 0x80000, CRC(6a4ae622) SHA1(f488e7616371125d5aef2047b8e0fc954ca4b9b4) )
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u15.u15", 0x200001, 0x80000, CRC(1a0ad3b7) SHA1(a5300f3c789a4d9d257fda3a280e882f17f4a99f) )
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u16.u16", 0x200002, 0x80000, CRC(799d4dd6) SHA1(f1208967544477005924f2a553037e0ffbc668ab) )
@@ -1297,17 +1369,17 @@ ROM_START( crusnusa ) /* Version 4.5, Tue Apr 11 1995 - 16:06:48 */
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u29.u29", 0x800003, 0x80000, CRC(cbe52c60) SHA1(3f309ce8ef1784c830f4160cfe76dc3a0b438cac) )
 
 	ROM_REGION( 0x0b33, "pals", 0 ) // all protected
-	ROM_LOAD("a-19993.u38",  0x0000, 0x02e5, BAD_DUMP CRC(7e8b7b0d) SHA1(f9af19da171f949a11c5548da7b4277aecb6f2a8) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19670.u43",  0x0000, 0x0144, BAD_DUMP CRC(acafcc97) SHA1(b6f916838d08590a536fe925ec62d66e6ea3dcbc) ) /* TIBPAL20L8-10CNT */
-	ROM_LOAD("a-19668.u52",  0x0000, 0x0157, BAD_DUMP CRC(7915134e) SHA1(aeb22e46abdc14a9e9b34cfe3b77da3e29b789fe) ) /* GAL20V8B */
-	ROM_LOAD("a-19671.u54",  0x0000, 0x02dd, BAD_DUMP CRC(b9cce038) SHA1(8d1df026bdac66ea5493e9e51c23f8eb182b024e) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19673.u111", 0x0000, 0x02dd, BAD_DUMP CRC(8552977d) SHA1(a1a53d797697682b3f18893a90b6bef39ebb069e) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19672.u114", 0x0000, 0x0001, NO_DUMP ) /* TIBPAL22V10-15BCNT */
+	ROM_LOAD("a-19993.u38",  0x0000, 0x02e5, BAD_DUMP CRC(7e8b7b0d) SHA1(f9af19da171f949a11c5548da7b4277aecb6f2a8) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19670.u43",  0x0000, 0x0144, BAD_DUMP CRC(acafcc97) SHA1(b6f916838d08590a536fe925ec62d66e6ea3dcbc) ) // TIBPAL20L8-10CNT
+	ROM_LOAD("a-19668.u52",  0x0000, 0x0157, BAD_DUMP CRC(7915134e) SHA1(aeb22e46abdc14a9e9b34cfe3b77da3e29b789fe) ) // GAL20V8B
+	ROM_LOAD("a-19671.u54",  0x0000, 0x02dd, BAD_DUMP CRC(b9cce038) SHA1(8d1df026bdac66ea5493e9e51c23f8eb182b024e) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19673.u111", 0x0000, 0x02dd, BAD_DUMP CRC(8552977d) SHA1(a1a53d797697682b3f18893a90b6bef39ebb069e) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19672.u114", 0x0000, 0x0001, NO_DUMP ) // TIBPAL22V10-15BCNT
 ROM_END
 
-ROM_START( crusnusa44 ) /* Version 4.4, Wed Mar 15 1995 - 10:52:28 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
-	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u2.u2", 0x000000, 0x80000, CRC(b9338332) SHA1(e5c420e63c4eba0010a68c7e0a57ef210e2c83d2) ) /* also known to be labeled as P2, the P1 revision hasn't been dumped or confirmed to be different */
+ROM_START( crusnusa44 ) // Version 4.4, Wed Mar 15 1995 - 10:52:28
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
+	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u2.u2", 0x000000, 0x80000, CRC(b9338332) SHA1(e5c420e63c4eba0010a68c7e0a57ef210e2c83d2) ) // also known to be labeled as P2, the P1 revision hasn't been dumped or confirmed to be different
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u3.u3", 0x200000, 0x80000, CRC(cd8325d6) SHA1(d65d7263e056ca1d637adb44cafef523e0831a34) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u4.u4", 0x400000, 0x80000, CRC(fab457f3) SHA1(2b4b647838b7a8100afc25ca1ffdc74ed67ae00a) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u5.u5", 0x600000, 0x80000, CRC(becc92f4) SHA1(6dffa73ff5270155c44f295e443d5e77c03c0338) )
@@ -1316,11 +1388,11 @@ ROM_START( crusnusa44 ) /* Version 4.4, Wed Mar 15 1995 - 10:52:28 */
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u8.u8", 0xc00000, 0x80000, CRC(03c28199) SHA1(393b009acd3eceb346b8fff45ae2bdf4f53d041f) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u9.u9", 0xe00000, 0x80000, CRC(24ba6371) SHA1(f60a9ff73b3645e2c8bad67e2f6debc61b5e0653) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 ) /* boot screen reports as HEAD 2 HEAD */
-	ROM_LOAD32_BYTE( "v4.4_3-15-95_cruisn_usa_u10_87df.u10", 0x000000, 0x80000, CRC(e77e2a0c) SHA1(18fa0f1dccba743b9f0f2bb986c35dfb1cf5852a) ) /* V4.4   3/15/95   CRUIS'N USA U10   (C)1995 Midway 87DF */
-	ROM_LOAD32_BYTE( "v4.4_3-15-95_cruisn_usa_u11_6e35.u11", 0x000001, 0x80000, CRC(6eb3e187) SHA1(f6d26998a302dc7de5a18d811fab90a042f01284) ) /* V4.4   3/15/95   CRUIS'N USA U11   (C)1995 Midway 6E35 */
-	ROM_LOAD32_BYTE( "v4.4_3-15-95_cruisn_usa_u12_4c08.u12", 0x000002, 0x80000, CRC(5942b6d6) SHA1(86b0422a0e1348d1c4136a23d1e17653bc3a1b0e) ) /* V4.4   3/15/95   CRUIS'N USA U12   (C)1995 Midway 4C08 */
-	ROM_LOAD32_BYTE( "v4.4_3-15-95_cruisn_usa_u13_43ea.u13", 0x000003, 0x80000, CRC(9da2124a) SHA1(36d61bbd0c991b415a8c85b58de77d94d2c61bcc) ) /* V4.4   3/15/95   CRUIS'N USA U13   (C)1995 Midway 43EA */
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 ) // boot screen reports as HEAD 2 HEAD
+	ROM_LOAD32_BYTE( "v4.4_3-15-95_cruisn_usa_u10_87df.u10", 0x000000, 0x80000, CRC(e77e2a0c) SHA1(18fa0f1dccba743b9f0f2bb986c35dfb1cf5852a) ) // V4.4   3/15/95   CRUIS'N USA U10   (C)1995 Midway 87DF
+	ROM_LOAD32_BYTE( "v4.4_3-15-95_cruisn_usa_u11_6e35.u11", 0x000001, 0x80000, CRC(6eb3e187) SHA1(f6d26998a302dc7de5a18d811fab90a042f01284) ) // V4.4   3/15/95   CRUIS'N USA U11   (C)1995 Midway 6E35
+	ROM_LOAD32_BYTE( "v4.4_3-15-95_cruisn_usa_u12_4c08.u12", 0x000002, 0x80000, CRC(5942b6d6) SHA1(86b0422a0e1348d1c4136a23d1e17653bc3a1b0e) ) // V4.4   3/15/95   CRUIS'N USA U12   (C)1995 Midway 4C08
+	ROM_LOAD32_BYTE( "v4.4_3-15-95_cruisn_usa_u13_43ea.u13", 0x000003, 0x80000, CRC(9da2124a) SHA1(36d61bbd0c991b415a8c85b58de77d94d2c61bcc) ) // V4.4   3/15/95   CRUIS'N USA U13   (C)1995 Midway 43EA
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u14.u14", 0x200000, 0x80000, CRC(6a4ae622) SHA1(f488e7616371125d5aef2047b8e0fc954ca4b9b4) )
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u15.u15", 0x200001, 0x80000, CRC(1a0ad3b7) SHA1(a5300f3c789a4d9d257fda3a280e882f17f4a99f) )
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u16.u16", 0x200002, 0x80000, CRC(799d4dd6) SHA1(f1208967544477005924f2a553037e0ffbc668ab) )
@@ -1339,17 +1411,17 @@ ROM_START( crusnusa44 ) /* Version 4.4, Wed Mar 15 1995 - 10:52:28 */
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u29.u29", 0x800003, 0x80000, CRC(cbe52c60) SHA1(3f309ce8ef1784c830f4160cfe76dc3a0b438cac) )
 
 	ROM_REGION( 0x0b33, "pals", 0 ) // all protected
-	ROM_LOAD("a-19993.u38",  0x0000, 0x02e5, BAD_DUMP CRC(7e8b7b0d) SHA1(f9af19da171f949a11c5548da7b4277aecb6f2a8) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19670.u43",  0x0000, 0x0144, BAD_DUMP CRC(acafcc97) SHA1(b6f916838d08590a536fe925ec62d66e6ea3dcbc) ) /* TIBPAL20L8-10CNT */
-	ROM_LOAD("a-19668.u52",  0x0000, 0x0157, BAD_DUMP CRC(7915134e) SHA1(aeb22e46abdc14a9e9b34cfe3b77da3e29b789fe) ) /* GAL20V8B */
-	ROM_LOAD("a-19671.u54",  0x0000, 0x02dd, BAD_DUMP CRC(b9cce038) SHA1(8d1df026bdac66ea5493e9e51c23f8eb182b024e) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19673.u111", 0x0000, 0x02dd, BAD_DUMP CRC(8552977d) SHA1(a1a53d797697682b3f18893a90b6bef39ebb069e) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19672.u114", 0x0000, 0x0001, NO_DUMP ) /* TIBPAL22V10-15BCNT */
+	ROM_LOAD("a-19993.u38",  0x0000, 0x02e5, BAD_DUMP CRC(7e8b7b0d) SHA1(f9af19da171f949a11c5548da7b4277aecb6f2a8) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19670.u43",  0x0000, 0x0144, BAD_DUMP CRC(acafcc97) SHA1(b6f916838d08590a536fe925ec62d66e6ea3dcbc) ) // TIBPAL20L8-10CNT
+	ROM_LOAD("a-19668.u52",  0x0000, 0x0157, BAD_DUMP CRC(7915134e) SHA1(aeb22e46abdc14a9e9b34cfe3b77da3e29b789fe) ) // GAL20V8B
+	ROM_LOAD("a-19671.u54",  0x0000, 0x02dd, BAD_DUMP CRC(b9cce038) SHA1(8d1df026bdac66ea5493e9e51c23f8eb182b024e) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19673.u111", 0x0000, 0x02dd, BAD_DUMP CRC(8552977d) SHA1(a1a53d797697682b3f18893a90b6bef39ebb069e) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19672.u114", 0x0000, 0x0001, NO_DUMP ) // TIBPAL22V10-15BCNT
 ROM_END
 
-ROM_START( crusnusa41 ) /* Version 4.1, Mon Feb 13 1995 - 16:53:40 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
-	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u2.u2", 0x000000, 0x80000, CRC(b9338332) SHA1(e5c420e63c4eba0010a68c7e0a57ef210e2c83d2) ) /* also known to be labeled as P2, the P1 revision hasn't been dumped or confirmed to be different */
+ROM_START( crusnusa41 ) // Version 4.1, Mon Feb 13 1995 - 16:53:40
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
+	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u2.u2", 0x000000, 0x80000, CRC(b9338332) SHA1(e5c420e63c4eba0010a68c7e0a57ef210e2c83d2) ) // also known to be labeled as P2, the P1 revision hasn't been dumped or confirmed to be different
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u3.u3", 0x200000, 0x80000, CRC(cd8325d6) SHA1(d65d7263e056ca1d637adb44cafef523e0831a34) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u4.u4", 0x400000, 0x80000, CRC(fab457f3) SHA1(2b4b647838b7a8100afc25ca1ffdc74ed67ae00a) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u5.u5", 0x600000, 0x80000, CRC(becc92f4) SHA1(6dffa73ff5270155c44f295e443d5e77c03c0338) )
@@ -1358,11 +1430,11 @@ ROM_START( crusnusa41 ) /* Version 4.1, Mon Feb 13 1995 - 16:53:40 */
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u8.u8", 0xc00000, 0x80000, CRC(03c28199) SHA1(393b009acd3eceb346b8fff45ae2bdf4f53d041f) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u9.u9", 0xe00000, 0x80000, CRC(24ba6371) SHA1(f60a9ff73b3645e2c8bad67e2f6debc61b5e0653) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 ) /*  boot screen reports as HEAD 2 HEAD - Also known to be labeled as: CRUIS'N LINK   U10 REV. 4.1  (C) 1994 MIDWAY CORP */
-	ROM_LOAD32_BYTE( "l4.1_dual_game_linking_cruisin_u.s.a._u10_game_rom.u10", 0x000000, 0x80000, CRC(eb9372d1) SHA1(ab1e489b23b4540c4e0d1d9a6c9a2c9317f5c099) ) /* L4.1   DUAL GAME LINKING   CRUISIN U.S.A.   U 10 GAME ROM */
-	ROM_LOAD32_BYTE( "l4.1_dual_game_linking_cruisin_u.s.a._u11_game_rom.u11", 0x000001, 0x80000, CRC(76f3cd40) SHA1(52276841944ada54d56ecd2da95998aabd699465) ) /* L4.1   DUAL GAME LINKING   CRUISIN U.S.A.   U 11 GAME ROM */
-	ROM_LOAD32_BYTE( "l4.1_dual_game_linking_cruisin_u.s.a._u12_game_rom.u12", 0x000002, 0x80000, CRC(9021a376) SHA1(6a838d49bec4201e8ead7491e3b6d4a3a52dcb12) ) /* L4.1   DUAL GAME LINKING   CRUISIN U.S.A.   U 12 GAME ROM */
-	ROM_LOAD32_BYTE( "l4.1_dual_game_linking_cruisin_u.s.a._u13_game_rom.u13", 0x000003, 0x80000, CRC(1687c932) SHA1(45947c0c22bd4e6640f792d0c7fd06a1f4483131) ) /* L4.1   DUAL GAME LINKING   CRUISIN U.S.A.   U 13 GAME ROM */
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 ) //  boot screen reports as HEAD 2 HEAD - Also known to be labeled as: CRUIS'N LINK   U10 REV. 4.1  (C) 1994 MIDWAY CORP
+	ROM_LOAD32_BYTE( "l4.1_dual_game_linking_cruisin_u.s.a._u10_game_rom.u10", 0x000000, 0x80000, CRC(eb9372d1) SHA1(ab1e489b23b4540c4e0d1d9a6c9a2c9317f5c099) ) // L4.1   DUAL GAME LINKING   CRUISIN U.S.A.   U 10 GAME ROM
+	ROM_LOAD32_BYTE( "l4.1_dual_game_linking_cruisin_u.s.a._u11_game_rom.u11", 0x000001, 0x80000, CRC(76f3cd40) SHA1(52276841944ada54d56ecd2da95998aabd699465) ) // L4.1   DUAL GAME LINKING   CRUISIN U.S.A.   U 11 GAME ROM
+	ROM_LOAD32_BYTE( "l4.1_dual_game_linking_cruisin_u.s.a._u12_game_rom.u12", 0x000002, 0x80000, CRC(9021a376) SHA1(6a838d49bec4201e8ead7491e3b6d4a3a52dcb12) ) // L4.1   DUAL GAME LINKING   CRUISIN U.S.A.   U 12 GAME ROM
+	ROM_LOAD32_BYTE( "l4.1_dual_game_linking_cruisin_u.s.a._u13_game_rom.u13", 0x000003, 0x80000, CRC(1687c932) SHA1(45947c0c22bd4e6640f792d0c7fd06a1f4483131) ) // L4.1   DUAL GAME LINKING   CRUISIN U.S.A.   U 13 GAME ROM
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u14.u14", 0x200000, 0x80000, CRC(6a4ae622) SHA1(f488e7616371125d5aef2047b8e0fc954ca4b9b4) )
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u15.u15", 0x200001, 0x80000, CRC(1a0ad3b7) SHA1(a5300f3c789a4d9d257fda3a280e882f17f4a99f) )
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u16.u16", 0x200002, 0x80000, CRC(799d4dd6) SHA1(f1208967544477005924f2a553037e0ffbc668ab) )
@@ -1381,18 +1453,18 @@ ROM_START( crusnusa41 ) /* Version 4.1, Mon Feb 13 1995 - 16:53:40 */
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u29.u29", 0x800003, 0x80000, CRC(cbe52c60) SHA1(3f309ce8ef1784c830f4160cfe76dc3a0b438cac) )
 
 	ROM_REGION( 0x0b33, "pals", 0 ) // all protected
-	ROM_LOAD("a-19993.u38",  0x0000, 0x02e5, BAD_DUMP CRC(7e8b7b0d) SHA1(f9af19da171f949a11c5548da7b4277aecb6f2a8) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19670.u43",  0x0000, 0x0144, BAD_DUMP CRC(acafcc97) SHA1(b6f916838d08590a536fe925ec62d66e6ea3dcbc) ) /* TIBPAL20L8-10CNT */
-	ROM_LOAD("a-19668.u52",  0x0000, 0x0157, BAD_DUMP CRC(7915134e) SHA1(aeb22e46abdc14a9e9b34cfe3b77da3e29b789fe) ) /* GAL20V8B */
-	ROM_LOAD("a-19671.u54",  0x0000, 0x02dd, BAD_DUMP CRC(b9cce038) SHA1(8d1df026bdac66ea5493e9e51c23f8eb182b024e) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19673.u111", 0x0000, 0x02dd, BAD_DUMP CRC(8552977d) SHA1(a1a53d797697682b3f18893a90b6bef39ebb069e) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19672.u114", 0x0000, 0x0001, NO_DUMP ) /* TIBPAL22V10-15BCNT */
+	ROM_LOAD("a-19993.u38",  0x0000, 0x02e5, BAD_DUMP CRC(7e8b7b0d) SHA1(f9af19da171f949a11c5548da7b4277aecb6f2a8) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19670.u43",  0x0000, 0x0144, BAD_DUMP CRC(acafcc97) SHA1(b6f916838d08590a536fe925ec62d66e6ea3dcbc) ) // TIBPAL20L8-10CNT
+	ROM_LOAD("a-19668.u52",  0x0000, 0x0157, BAD_DUMP CRC(7915134e) SHA1(aeb22e46abdc14a9e9b34cfe3b77da3e29b789fe) ) // GAL20V8B
+	ROM_LOAD("a-19671.u54",  0x0000, 0x02dd, BAD_DUMP CRC(b9cce038) SHA1(8d1df026bdac66ea5493e9e51c23f8eb182b024e) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19673.u111", 0x0000, 0x02dd, BAD_DUMP CRC(8552977d) SHA1(a1a53d797697682b3f18893a90b6bef39ebb069e) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19672.u114", 0x0000, 0x0001, NO_DUMP ) // TIBPAL22V10-15BCNT
 ROM_END
 
 
-ROM_START( crusnusa40 ) /* Version 4.0, Wed Feb 08 1995 - 10:45:14 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
-	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u2.u2", 0x000000, 0x80000, CRC(b9338332) SHA1(e5c420e63c4eba0010a68c7e0a57ef210e2c83d2) ) /* also known to be labeled as P2, the P1 revision hasn't been dumped or confirmed to be different */
+ROM_START( crusnusa40 ) // Version 4.0, Wed Feb 08 1995 - 10:45:14
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
+	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u2.u2", 0x000000, 0x80000, CRC(b9338332) SHA1(e5c420e63c4eba0010a68c7e0a57ef210e2c83d2) ) // also known to be labeled as P2, the P1 revision hasn't been dumped or confirmed to be different
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u3.u3", 0x200000, 0x80000, CRC(cd8325d6) SHA1(d65d7263e056ca1d637adb44cafef523e0831a34) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u4.u4", 0x400000, 0x80000, CRC(fab457f3) SHA1(2b4b647838b7a8100afc25ca1ffdc74ed67ae00a) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u5.u5", 0x600000, 0x80000, CRC(becc92f4) SHA1(6dffa73ff5270155c44f295e443d5e77c03c0338) )
@@ -1401,7 +1473,7 @@ ROM_START( crusnusa40 ) /* Version 4.0, Wed Feb 08 1995 - 10:45:14 */
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u8.u8", 0xc00000, 0x80000, CRC(03c28199) SHA1(393b009acd3eceb346b8fff45ae2bdf4f53d041f) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u9.u9", 0xe00000, 0x80000, CRC(24ba6371) SHA1(f60a9ff73b3645e2c8bad67e2f6debc61b5e0653) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 ) /* boot screen reports as HEAD 2 HEAD */
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 ) // boot screen reports as HEAD 2 HEAD
 	ROM_LOAD32_BYTE( "l4_cruisin_u.s.a._game_rom_u10.u10", 0x000000, 0x80000, CRC(7526d8bf) SHA1(ef00ea3b6e1923d3e4d10bf3601b080a009fb711) )
 	ROM_LOAD32_BYTE( "l4_cruisin_u.s.a._game_rom_u11.u11", 0x000001, 0x80000, CRC(bfc691b9) SHA1(41d1503c4290e396a49043fea7778851cdf11310) )
 	ROM_LOAD32_BYTE( "l4_cruisin_u.s.a._game_rom_u12.u12", 0x000002, 0x80000, CRC(059c2234) SHA1(145ec1ab3a46c3316f39bd731730dcb57b55b4ec) )
@@ -1424,18 +1496,18 @@ ROM_START( crusnusa40 ) /* Version 4.0, Wed Feb 08 1995 - 10:45:14 */
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u29.u29", 0x800003, 0x80000, CRC(cbe52c60) SHA1(3f309ce8ef1784c830f4160cfe76dc3a0b438cac) )
 
 	ROM_REGION( 0x0b33, "pals", 0 ) // all protected
-	ROM_LOAD("a-19993.u38",  0x0000, 0x02e5, BAD_DUMP CRC(7e8b7b0d) SHA1(f9af19da171f949a11c5548da7b4277aecb6f2a8) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19670.u43",  0x0000, 0x0144, BAD_DUMP CRC(acafcc97) SHA1(b6f916838d08590a536fe925ec62d66e6ea3dcbc) ) /* TIBPAL20L8-10CNT */
-	ROM_LOAD("a-19668.u52",  0x0000, 0x0157, BAD_DUMP CRC(7915134e) SHA1(aeb22e46abdc14a9e9b34cfe3b77da3e29b789fe) ) /* GAL20V8B */
-	ROM_LOAD("a-19671.u54",  0x0000, 0x02dd, BAD_DUMP CRC(b9cce038) SHA1(8d1df026bdac66ea5493e9e51c23f8eb182b024e) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19673.u111", 0x0000, 0x02dd, BAD_DUMP CRC(8552977d) SHA1(a1a53d797697682b3f18893a90b6bef39ebb069e) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19672.u114", 0x0000, 0x0001, NO_DUMP ) /* TIBPAL22V10-15BCNT */
+	ROM_LOAD("a-19993.u38",  0x0000, 0x02e5, BAD_DUMP CRC(7e8b7b0d) SHA1(f9af19da171f949a11c5548da7b4277aecb6f2a8) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19670.u43",  0x0000, 0x0144, BAD_DUMP CRC(acafcc97) SHA1(b6f916838d08590a536fe925ec62d66e6ea3dcbc) ) // TIBPAL20L8-10CNT
+	ROM_LOAD("a-19668.u52",  0x0000, 0x0157, BAD_DUMP CRC(7915134e) SHA1(aeb22e46abdc14a9e9b34cfe3b77da3e29b789fe) ) // GAL20V8B
+	ROM_LOAD("a-19671.u54",  0x0000, 0x02dd, BAD_DUMP CRC(b9cce038) SHA1(8d1df026bdac66ea5493e9e51c23f8eb182b024e) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19673.u111", 0x0000, 0x02dd, BAD_DUMP CRC(8552977d) SHA1(a1a53d797697682b3f18893a90b6bef39ebb069e) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19672.u114", 0x0000, 0x0001, NO_DUMP ) // TIBPAL22V10-15BCNT
 ROM_END
 
 
-ROM_START( crusnusa21 ) /* Version 2.1, Wed Nov 09 1994 - 16:28:10 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
-	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u2.u2", 0x000000, 0x80000, CRC(b9338332) SHA1(e5c420e63c4eba0010a68c7e0a57ef210e2c83d2) ) /* also known to be labeled as P2, the P1 revision hasn't been dumped or confirmed to be different */
+ROM_START( crusnusa21 ) // Version 2.1, Wed Nov 09 1994 - 16:28:10
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
+	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u2.u2", 0x000000, 0x80000, CRC(b9338332) SHA1(e5c420e63c4eba0010a68c7e0a57ef210e2c83d2) ) // also known to be labeled as P2, the P1 revision hasn't been dumped or confirmed to be different
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u3.u3", 0x200000, 0x80000, CRC(cd8325d6) SHA1(d65d7263e056ca1d637adb44cafef523e0831a34) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u4.u4", 0x400000, 0x80000, CRC(fab457f3) SHA1(2b4b647838b7a8100afc25ca1ffdc74ed67ae00a) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u5.u5", 0x600000, 0x80000, CRC(becc92f4) SHA1(6dffa73ff5270155c44f295e443d5e77c03c0338) )
@@ -1444,7 +1516,7 @@ ROM_START( crusnusa21 ) /* Version 2.1, Wed Nov 09 1994 - 16:28:10 */
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u8.u8", 0xc00000, 0x80000, CRC(03c28199) SHA1(393b009acd3eceb346b8fff45ae2bdf4f53d041f) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u9.u9", 0xe00000, 0x80000, CRC(24ba6371) SHA1(f60a9ff73b3645e2c8bad67e2f6debc61b5e0653) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
 	ROM_LOAD32_BYTE( "l2.1_cruisin_u.s.a._game_rom_u10.u10", 0x000000, 0x80000, CRC(bb759945) SHA1(dbf5270503cb58adb0abd34a8aece5933063ec66) )
 	ROM_LOAD32_BYTE( "l2.1_cruisin_u.s.a._game_rom_u11.u11", 0x000001, 0x80000, CRC(4d2da096) SHA1(6ccb9fee095580089f8d43a2e86e0f8a4407dda5) )
 	ROM_LOAD32_BYTE( "l2.1_cruisin_u.s.a._game_rom_u12.u12", 0x000002, 0x80000, CRC(4b66fe5e) SHA1(885d31c06b11209a1154789bc84e75d0ac9e1e8a) )
@@ -1467,18 +1539,18 @@ ROM_START( crusnusa21 ) /* Version 2.1, Wed Nov 09 1994 - 16:28:10 */
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u29.u29", 0x800003, 0x80000, CRC(cbe52c60) SHA1(3f309ce8ef1784c830f4160cfe76dc3a0b438cac) )
 
 	ROM_REGION( 0x0b33, "pals", 0 ) // all protected
-	ROM_LOAD("a-19669.u38",  0x0000, 0x02dd, NO_DUMP ) /* TIBPAL22V10-15BCNT  NOTE: Head to Head games use a different U38 PAL */
-	ROM_LOAD("a-19670.u43",  0x0000, 0x0144, BAD_DUMP CRC(acafcc97) SHA1(b6f916838d08590a536fe925ec62d66e6ea3dcbc) ) /* TIBPAL20L8-10CNT */
-	ROM_LOAD("a-19668.u52",  0x0000, 0x0157, BAD_DUMP CRC(7915134e) SHA1(aeb22e46abdc14a9e9b34cfe3b77da3e29b789fe) ) /* GAL20V8B */
-	ROM_LOAD("a-19671.u54",  0x0000, 0x02dd, BAD_DUMP CRC(b9cce038) SHA1(8d1df026bdac66ea5493e9e51c23f8eb182b024e) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19673.u111", 0x0000, 0x02dd, BAD_DUMP CRC(8552977d) SHA1(a1a53d797697682b3f18893a90b6bef39ebb069e) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19672.u114", 0x0000, 0x0001, NO_DUMP ) /* TIBPAL22V10-15BCNT */
+	ROM_LOAD("a-19669.u38",  0x0000, 0x02dd, NO_DUMP ) // TIBPAL22V10-15BCNT  NOTE: Head to Head games use a different U38 PAL
+	ROM_LOAD("a-19670.u43",  0x0000, 0x0144, BAD_DUMP CRC(acafcc97) SHA1(b6f916838d08590a536fe925ec62d66e6ea3dcbc) ) // TIBPAL20L8-10CNT
+	ROM_LOAD("a-19668.u52",  0x0000, 0x0157, BAD_DUMP CRC(7915134e) SHA1(aeb22e46abdc14a9e9b34cfe3b77da3e29b789fe) ) // GAL20V8B
+	ROM_LOAD("a-19671.u54",  0x0000, 0x02dd, BAD_DUMP CRC(b9cce038) SHA1(8d1df026bdac66ea5493e9e51c23f8eb182b024e) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19673.u111", 0x0000, 0x02dd, BAD_DUMP CRC(8552977d) SHA1(a1a53d797697682b3f18893a90b6bef39ebb069e) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19672.u114", 0x0000, 0x0001, NO_DUMP ) // TIBPAL22V10-15BCNT
 ROM_END
 
 
-ROM_START( crusnusa20 ) /* Version 2.0, Tue Oct 25 1994 - 11:49:09 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
-	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u2.u2", 0x000000, 0x80000, CRC(b9338332) SHA1(e5c420e63c4eba0010a68c7e0a57ef210e2c83d2) ) /* also known to be labeled as P2, the P1 revision hasn't been dumped or confirmed to be different */
+ROM_START( crusnusa20 ) // Version 2.0, Tue Oct 25 1994 - 11:49:09
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
+	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u2.u2", 0x000000, 0x80000, CRC(b9338332) SHA1(e5c420e63c4eba0010a68c7e0a57ef210e2c83d2) ) // also known to be labeled as P2, the P1 revision hasn't been dumped or confirmed to be different
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u3.u3", 0x200000, 0x80000, CRC(cd8325d6) SHA1(d65d7263e056ca1d637adb44cafef523e0831a34) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u4.u4", 0x400000, 0x80000, CRC(fab457f3) SHA1(2b4b647838b7a8100afc25ca1ffdc74ed67ae00a) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u5.u5", 0x600000, 0x80000, CRC(becc92f4) SHA1(6dffa73ff5270155c44f295e443d5e77c03c0338) )
@@ -1487,7 +1559,7 @@ ROM_START( crusnusa20 ) /* Version 2.0, Tue Oct 25 1994 - 11:49:09 */
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u8.u8", 0xc00000, 0x80000, CRC(03c28199) SHA1(393b009acd3eceb346b8fff45ae2bdf4f53d041f) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u9.u9", 0xe00000, 0x80000, CRC(24ba6371) SHA1(f60a9ff73b3645e2c8bad67e2f6debc61b5e0653) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
 	ROM_LOAD32_BYTE( "l2.0_cruisin_u.s.a._game_rom_u10.u10", 0x000000, 0x80000, CRC(5cdeaee9) SHA1(af8efa5969bad1975de67c82b2eec48e27eb9798) )
 	ROM_LOAD32_BYTE( "l2.0_cruisin_u.s.a._game_rom_u11.u11", 0x000001, 0x80000, CRC(87aaaeef) SHA1(79e5a35b7eaa086c693347e266276e2c31647fec) )
 	ROM_LOAD32_BYTE( "l2.0_cruisin_u.s.a._game_rom_u12.u12", 0x000002, 0x80000, CRC(587b01ad) SHA1(776ffff9764356d513ef25377c1805041869a02a) )
@@ -1510,17 +1582,17 @@ ROM_START( crusnusa20 ) /* Version 2.0, Tue Oct 25 1994 - 11:49:09 */
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u29.u29", 0x800003, 0x80000, CRC(cbe52c60) SHA1(3f309ce8ef1784c830f4160cfe76dc3a0b438cac) )
 
 	ROM_REGION( 0x0b33, "pals", 0 ) // all protected
-	ROM_LOAD("a-19669.u38",  0x0000, 0x02dd, NO_DUMP ) /* TIBPAL22V10-15BCNT  NOTE: Head to Head games use a different U38 PAL */
-	ROM_LOAD("a-19670.u43",  0x0000, 0x0144, BAD_DUMP CRC(acafcc97) SHA1(b6f916838d08590a536fe925ec62d66e6ea3dcbc) ) /* TIBPAL20L8-10CNT */
-	ROM_LOAD("a-19668.u52",  0x0000, 0x0157, BAD_DUMP CRC(7915134e) SHA1(aeb22e46abdc14a9e9b34cfe3b77da3e29b789fe) ) /* GAL20V8B */
-	ROM_LOAD("a-19671.u54",  0x0000, 0x02dd, BAD_DUMP CRC(b9cce038) SHA1(8d1df026bdac66ea5493e9e51c23f8eb182b024e) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19673.u111", 0x0000, 0x02dd, BAD_DUMP CRC(8552977d) SHA1(a1a53d797697682b3f18893a90b6bef39ebb069e) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19672.u114", 0x0000, 0x0001, NO_DUMP ) /* TIBPAL22V10-15BCNT */
+	ROM_LOAD("a-19669.u38",  0x0000, 0x02dd, NO_DUMP ) // TIBPAL22V10-15BCNT  NOTE: Head to Head games use a different U38 PAL
+	ROM_LOAD("a-19670.u43",  0x0000, 0x0144, BAD_DUMP CRC(acafcc97) SHA1(b6f916838d08590a536fe925ec62d66e6ea3dcbc) ) // TIBPAL20L8-10CNT
+	ROM_LOAD("a-19668.u52",  0x0000, 0x0157, BAD_DUMP CRC(7915134e) SHA1(aeb22e46abdc14a9e9b34cfe3b77da3e29b789fe) ) // GAL20V8B
+	ROM_LOAD("a-19671.u54",  0x0000, 0x02dd, BAD_DUMP CRC(b9cce038) SHA1(8d1df026bdac66ea5493e9e51c23f8eb182b024e) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19673.u111", 0x0000, 0x02dd, BAD_DUMP CRC(8552977d) SHA1(a1a53d797697682b3f18893a90b6bef39ebb069e) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19672.u114", 0x0000, 0x0001, NO_DUMP ) // TIBPAL22V10-15BCNT
 ROM_END
 
 
-ROM_START( crusnusa11 ) /* Version 1.1, Wed Aug 31 1994 - 18:44:40 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
+ROM_START( crusnusa11 ) // Version 1.1, Wed Aug 31 1994 - 18:44:40
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u2.u2", 0x000000, 0x80000, CRC(b9338332) SHA1(e5c420e63c4eba0010a68c7e0a57ef210e2c83d2) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u3.u3", 0x200000, 0x80000, CRC(cd8325d6) SHA1(d65d7263e056ca1d637adb44cafef523e0831a34) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u4.u4", 0x400000, 0x80000, CRC(fab457f3) SHA1(2b4b647838b7a8100afc25ca1ffdc74ed67ae00a) )
@@ -1530,7 +1602,7 @@ ROM_START( crusnusa11 ) /* Version 1.1, Wed Aug 31 1994 - 18:44:40 */
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u8.u8", 0xc00000, 0x80000, CRC(03c28199) SHA1(393b009acd3eceb346b8fff45ae2bdf4f53d041f) )
 	ROM_LOAD16_BYTE( "l1_cruisin_u.s.a._sound_rom_u9.u9", 0xe00000, 0x80000, CRC(24ba6371) SHA1(f60a9ff73b3645e2c8bad67e2f6debc61b5e0653) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
 	ROM_LOAD32_BYTE( "l1.1_cruisin_u.s.a._game_rom_u10.u10", 0x000000, 0x80000, CRC(44f36b34) SHA1(6180579631319b3748539c79a016e12e5543185a) )
 	ROM_LOAD32_BYTE( "l1.1_cruisin_u.s.a._game_rom_u11.u11", 0x000001, 0x80000, CRC(f0328c25) SHA1(b129f3fb4eb95c5e27119ceced1484077b2fb1f9) )
 	ROM_LOAD32_BYTE( "l1.1_cruisin_u.s.a._game_rom_u12.u12", 0x000002, 0x80000, CRC(0e529551) SHA1(30bc072cd175a6ce85f7688f7bb42bcb2ab1d672) )
@@ -1553,12 +1625,12 @@ ROM_START( crusnusa11 ) /* Version 1.1, Wed Aug 31 1994 - 18:44:40 */
 	ROM_LOAD32_BYTE( "l1_cruisin_u.s.a._game_rom_u29.u29", 0x800003, 0x80000, CRC(cbe52c60) SHA1(3f309ce8ef1784c830f4160cfe76dc3a0b438cac) )
 
 	ROM_REGION( 0x0b33, "pals", 0 ) // all protected
-	ROM_LOAD("a-19669.u38",  0x0000, 0x02dd, NO_DUMP ) /* TIBPAL22V10-15BCNT  NOTE: Head to Head games use a different U38 PAL */
-	ROM_LOAD("a-19670.u43",  0x0000, 0x0144, BAD_DUMP CRC(acafcc97) SHA1(b6f916838d08590a536fe925ec62d66e6ea3dcbc) ) /* TIBPAL20L8-10CNT */
-	ROM_LOAD("a-19668.u52",  0x0000, 0x0157, BAD_DUMP CRC(7915134e) SHA1(aeb22e46abdc14a9e9b34cfe3b77da3e29b789fe) ) /* GAL20V8B */
-	ROM_LOAD("a-19671.u54",  0x0000, 0x02dd, BAD_DUMP CRC(b9cce038) SHA1(8d1df026bdac66ea5493e9e51c23f8eb182b024e) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19673.u111", 0x0000, 0x02dd, BAD_DUMP CRC(8552977d) SHA1(a1a53d797697682b3f18893a90b6bef39ebb069e) ) /* TIBPAL22V10-15BCNT */
-	ROM_LOAD("a-19672.u114", 0x0000, 0x0001, NO_DUMP ) /* TIBPAL22V10-15BCNT */
+	ROM_LOAD("a-19669.u38",  0x0000, 0x02dd, NO_DUMP ) // TIBPAL22V10-15BCNT  NOTE: Head to Head games use a different U38 PAL
+	ROM_LOAD("a-19670.u43",  0x0000, 0x0144, BAD_DUMP CRC(acafcc97) SHA1(b6f916838d08590a536fe925ec62d66e6ea3dcbc) ) // TIBPAL20L8-10CNT
+	ROM_LOAD("a-19668.u52",  0x0000, 0x0157, BAD_DUMP CRC(7915134e) SHA1(aeb22e46abdc14a9e9b34cfe3b77da3e29b789fe) ) // GAL20V8B
+	ROM_LOAD("a-19671.u54",  0x0000, 0x02dd, BAD_DUMP CRC(b9cce038) SHA1(8d1df026bdac66ea5493e9e51c23f8eb182b024e) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19673.u111", 0x0000, 0x02dd, BAD_DUMP CRC(8552977d) SHA1(a1a53d797697682b3f18893a90b6bef39ebb069e) ) // TIBPAL22V10-15BCNT
+	ROM_LOAD("a-19672.u114", 0x0000, 0x0001, NO_DUMP ) // TIBPAL22V10-15BCNT
 ROM_END
 
 
@@ -1575,8 +1647,8 @@ Mask ROMs are in the following format:
 --------------------------------   --------------------------------
 
 */
-ROM_START( crusnwld ) /* Version 2.5, Wed Nov 04 1998 - 15:50:52 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
+ROM_START( crusnwld ) // Version 2.5, Wed Nov 04 1998 - 15:50:52
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u2_sound.u2", 0x000000, 0x80000, CRC(7a233c89) SHA1(ecfad4bc48a69cd3399e3b3266c81574082e0169) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u3_sound.u3", 0x200000, 0x80000, CRC(be9a5ff0) SHA1(98d69dbfa6aa8462cdd46772e991ee418b79c653) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u4_sound.u4", 0x400000, 0x80000, CRC(69f02d84) SHA1(0fb4ff750de78505f241ae6cd18fccf3ddf4223f) )
@@ -1586,11 +1658,11 @@ ROM_START( crusnwld ) /* Version 2.5, Wed Nov 04 1998 - 15:50:52 */
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u8_sound.u8", 0xc00000, 0x80000, CRC(5127c08e) SHA1(4f0eae73817270fa156829100b66f0ff88fa422c) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u9_sound.u9", 0xe00000, 0x80000, CRC(84cdc781) SHA1(62287aa72903698d1890908adde53c39f8bd200c) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
-	ROM_LOAD32_BYTE( "2.5_cruisn_world_automatic_u10.u10", 0x0000000, 0x100000, CRC(fd776872) SHA1(90df230b58b1c60d1ca7545ef177e5df30b4ea9d) ) /* Labeled 2.5 Cruis'n World Automatic U10 */
-	ROM_LOAD32_BYTE( "2.5_cruisn_world_automatic_u11.u11", 0x0000001, 0x100000, CRC(0c99a405) SHA1(14251187f00c198fbaa39817f8c95d1dbec80ec0) ) /* Labeled 2.5 Cruis'n World Automatic U11 */
-	ROM_LOAD32_BYTE( "2.5_cruisn_world_automatic_u12.u12", 0x0000002, 0x100000, CRC(3ba9fad8) SHA1(ac8d0dd4df3c1f1c28d93d615d7e24aed4a4a9b5) ) /* Labeled 2.5 Cruis'n World Automatic U12 */
-	ROM_LOAD32_BYTE( "2.5_cruisn_world_automatic_u13.u13", 0x0000003, 0x100000, CRC(21a79c9a) SHA1(e33f768c2309613e4936416ee5250d3b1690d11d) ) /* Labeled 2.5 Cruis'n World Automatic U13 */
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
+	ROM_LOAD32_BYTE( "2.5_cruisn_world_automatic_u10.u10", 0x0000000, 0x100000, CRC(fd776872) SHA1(90df230b58b1c60d1ca7545ef177e5df30b4ea9d) ) // Labeled 2.5 Cruis'n World Automatic U10
+	ROM_LOAD32_BYTE( "2.5_cruisn_world_automatic_u11.u11", 0x0000001, 0x100000, CRC(0c99a405) SHA1(14251187f00c198fbaa39817f8c95d1dbec80ec0) ) // Labeled 2.5 Cruis'n World Automatic U11
+	ROM_LOAD32_BYTE( "2.5_cruisn_world_automatic_u12.u12", 0x0000002, 0x100000, CRC(3ba9fad8) SHA1(ac8d0dd4df3c1f1c28d93d615d7e24aed4a4a9b5) ) // Labeled 2.5 Cruis'n World Automatic U12
+	ROM_LOAD32_BYTE( "2.5_cruisn_world_automatic_u13.u13", 0x0000003, 0x100000, CRC(21a79c9a) SHA1(e33f768c2309613e4936416ee5250d3b1690d11d) ) // Labeled 2.5 Cruis'n World Automatic U13
 	ROM_LOAD32_BYTE( "1.1_cruisn_world_u14_image.u14", 0x0400000, 0x100000, CRC(ee815091) SHA1(fb8a99bae07f42966f76a3bb073d7d8280d8efcb) )
 	ROM_LOAD32_BYTE( "1.1_cruisn_world_u15_image.u15", 0x0400001, 0x100000, CRC(e2da7bf1) SHA1(9d9a80055ee62476f47c95e30ec9a989d5d0e25b) )
 	ROM_LOAD32_BYTE( "1.1_cruisn_world_u16_image.u16", 0x0400002, 0x100000, CRC(05a7ad2f) SHA1(4bdfde671379ecefa3f8ceb6fc06e8df5d70fc22) )
@@ -1606,8 +1678,8 @@ ROM_START( crusnwld ) /* Version 2.5, Wed Nov 04 1998 - 15:50:52 */
 ROM_END
 
 
-ROM_START( crusnwld24 ) /* Version 2.4, Thu Feb 19 1998 - 13:43:26 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
+ROM_START( crusnwld24 ) // Version 2.4, Thu Feb 19 1998 - 13:43:26
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u2_sound.u2", 0x000000, 0x80000, CRC(7a233c89) SHA1(ecfad4bc48a69cd3399e3b3266c81574082e0169) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u3_sound.u3", 0x200000, 0x80000, CRC(be9a5ff0) SHA1(98d69dbfa6aa8462cdd46772e991ee418b79c653) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u4_sound.u4", 0x400000, 0x80000, CRC(69f02d84) SHA1(0fb4ff750de78505f241ae6cd18fccf3ddf4223f) )
@@ -1617,7 +1689,7 @@ ROM_START( crusnwld24 ) /* Version 2.4, Thu Feb 19 1998 - 13:43:26 */
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u8_sound.u8", 0xc00000, 0x80000, CRC(5127c08e) SHA1(4f0eae73817270fa156829100b66f0ff88fa422c) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u9_sound.u9", 0xe00000, 0x80000, CRC(84cdc781) SHA1(62287aa72903698d1890908adde53c39f8bd200c) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
 	ROM_LOAD32_BYTE( "2.4_cruisn_world_u10_game.u10",  0x0000000, 0x100000, CRC(551ec903) SHA1(f3d983ca5d9a90b2898fb2c3adf8859ab7b43917) )
 	ROM_LOAD32_BYTE( "2.4_cruisn_world_u11_game.u11",  0x0000001, 0x100000, CRC(4c57faf2) SHA1(d5717e6222bb59c5aba782bce04aa52c1d148c49) )
 	ROM_LOAD32_BYTE( "2.4_cruisn_world_u12_game.u12",  0x0000002, 0x100000, CRC(3a4d9a30) SHA1(ac944555340502e9324df8360c3efc538315e474) )
@@ -1637,8 +1709,8 @@ ROM_START( crusnwld24 ) /* Version 2.4, Thu Feb 19 1998 - 13:43:26 */
 ROM_END
 
 
-ROM_START( crusnwld23 ) /* Version 2.3, Fri Jan 09 1998 - 10:25:49 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
+ROM_START( crusnwld23 ) // Version 2.3, Fri Jan 09 1998 - 10:25:49
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u2_sound.u2", 0x000000, 0x80000, CRC(7a233c89) SHA1(ecfad4bc48a69cd3399e3b3266c81574082e0169) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u3_sound.u3", 0x200000, 0x80000, CRC(be9a5ff0) SHA1(98d69dbfa6aa8462cdd46772e991ee418b79c653) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u4_sound.u4", 0x400000, 0x80000, CRC(69f02d84) SHA1(0fb4ff750de78505f241ae6cd18fccf3ddf4223f) )
@@ -1648,7 +1720,7 @@ ROM_START( crusnwld23 ) /* Version 2.3, Fri Jan 09 1998 - 10:25:49 */
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u8_sound.u8", 0xc00000, 0x80000, CRC(5127c08e) SHA1(4f0eae73817270fa156829100b66f0ff88fa422c) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u9_sound.u9", 0xe00000, 0x80000, CRC(84cdc781) SHA1(62287aa72903698d1890908adde53c39f8bd200c) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
 	ROM_LOAD32_BYTE( "2.3_cruisn_world_u10_game.u10",  0x0000000, 0x100000, CRC(956e0642) SHA1(c023d41159bac9b468d6fc411005f66b15b9dff6) )
 	ROM_LOAD32_BYTE( "2.3_cruisn_world_u11_game.u11",  0x0000001, 0x100000, CRC(b4ed2929) SHA1(22afc3c7bcc57b7b24b4156376df0b7fb8f0c9fb) )
 	ROM_LOAD32_BYTE( "2.3_cruisn_world_u12_game.u12",  0x0000002, 0x100000, CRC(cd12528e) SHA1(685e2280448be2cd90a875cca9ef2ab3d2f8d3e1) )
@@ -1668,8 +1740,8 @@ ROM_START( crusnwld23 ) /* Version 2.3, Fri Jan 09 1998 - 10:25:49 */
 ROM_END
 
 
-ROM_START( crusnwld20 ) /* Version 2.0, Tue Mar 18 1997 - 12:32:57 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
+ROM_START( crusnwld20 ) // Version 2.0, Tue Mar 18 1997 - 12:32:57
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u2_sound.u2", 0x000000, 0x80000, CRC(7a233c89) SHA1(ecfad4bc48a69cd3399e3b3266c81574082e0169) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u3_sound.u3", 0x200000, 0x80000, CRC(be9a5ff0) SHA1(98d69dbfa6aa8462cdd46772e991ee418b79c653) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u4_sound.u4", 0x400000, 0x80000, CRC(69f02d84) SHA1(0fb4ff750de78505f241ae6cd18fccf3ddf4223f) )
@@ -1679,7 +1751,7 @@ ROM_START( crusnwld20 ) /* Version 2.0, Tue Mar 18 1997 - 12:32:57 */
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u8_sound.u8", 0xc00000, 0x80000, CRC(5127c08e) SHA1(4f0eae73817270fa156829100b66f0ff88fa422c) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u9_sound.u9", 0xe00000, 0x80000, CRC(84cdc781) SHA1(62287aa72903698d1890908adde53c39f8bd200c) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
 	ROM_LOAD32_BYTE( "2.0_cruisn_world_u10_game.u10",  0x0000000, 0x100000, CRC(2a04da6d) SHA1(0aab4f3dc4853de11234245ac14baa14cb3867f3) )
 	ROM_LOAD32_BYTE( "2.0_cruisn_world_u11_game.u11",  0x0000001, 0x100000, CRC(26a8ad51) SHA1(522ef3499ba83fa808d7cdae71759e056df353bf) )
 	ROM_LOAD32_BYTE( "2.0_cruisn_world_u12_game.u12",  0x0000002, 0x100000, CRC(236caec0) SHA1(f53df733943a52f94878bb1b7d6c877722b3fd82) )
@@ -1699,8 +1771,8 @@ ROM_START( crusnwld20 ) /* Version 2.0, Tue Mar 18 1997 - 12:32:57 */
 ROM_END
 
 
-ROM_START( crusnwld19 ) /* Version 1.9, Sat Mar 08 1997 - 14:48:17 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
+ROM_START( crusnwld19 ) // Version 1.9, Sat Mar 08 1997 - 14:48:17
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u2_sound.u2", 0x000000, 0x80000, CRC(7a233c89) SHA1(ecfad4bc48a69cd3399e3b3266c81574082e0169) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u3_sound.u3", 0x200000, 0x80000, CRC(be9a5ff0) SHA1(98d69dbfa6aa8462cdd46772e991ee418b79c653) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u4_sound.u4", 0x400000, 0x80000, CRC(69f02d84) SHA1(0fb4ff750de78505f241ae6cd18fccf3ddf4223f) )
@@ -1710,7 +1782,7 @@ ROM_START( crusnwld19 ) /* Version 1.9, Sat Mar 08 1997 - 14:48:17 */
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u8_sound.u8", 0xc00000, 0x80000, CRC(5127c08e) SHA1(4f0eae73817270fa156829100b66f0ff88fa422c) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u9_sound.u9", 0xe00000, 0x80000, CRC(84cdc781) SHA1(62287aa72903698d1890908adde53c39f8bd200c) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
 	ROM_LOAD32_BYTE( "1.9_cruisn_world_u10_game.u10",  0x0000000, 0x100000, CRC(c5cf5316) SHA1(f9900526314c1ea2903fd9a01fcdb839609b1858) )
 	ROM_LOAD32_BYTE( "1.9_cruisn_world_u11_game.u11",  0x0000001, 0x100000, CRC(0b183a06) SHA1(06585662abebedc986b22c10fd4f489ed1d94e67) )
 	ROM_LOAD32_BYTE( "1.9_cruisn_world_u12_game.u12",  0x0000002, 0x100000, CRC(e32d1a8d) SHA1(ba5bbcee4fe67194e5e0bd99898116350450e83f) )
@@ -1730,8 +1802,8 @@ ROM_START( crusnwld19 ) /* Version 1.9, Sat Mar 08 1997 - 14:48:17 */
 ROM_END
 
 
-ROM_START( crusnwld17 ) /* Version 1.7, Fri Jan 24 1997 - 16:23:59 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
+ROM_START( crusnwld17 ) // Version 1.7, Fri Jan 24 1997 - 16:23:59
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u2_sound.u2", 0x000000, 0x80000, CRC(7a233c89) SHA1(ecfad4bc48a69cd3399e3b3266c81574082e0169) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u3_sound.u3", 0x200000, 0x80000, CRC(be9a5ff0) SHA1(98d69dbfa6aa8462cdd46772e991ee418b79c653) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u4_sound.u4", 0x400000, 0x80000, CRC(69f02d84) SHA1(0fb4ff750de78505f241ae6cd18fccf3ddf4223f) )
@@ -1741,7 +1813,7 @@ ROM_START( crusnwld17 ) /* Version 1.7, Fri Jan 24 1997 - 16:23:59 */
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u8_sound.u8", 0xc00000, 0x80000, CRC(5127c08e) SHA1(4f0eae73817270fa156829100b66f0ff88fa422c) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u9_sound.u9", 0xe00000, 0x80000, CRC(84cdc781) SHA1(62287aa72903698d1890908adde53c39f8bd200c) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
 	ROM_LOAD32_BYTE( "1.7_cruisn_world_u10_game.u10",  0x0000000, 0x100000, CRC(afca0f15) SHA1(52ed51e31ba7f8ac1a71a7bdb64733b6e95b0669) )
 	ROM_LOAD32_BYTE( "1.7_cruisn_world_u11_game.u11",  0x0000001, 0x100000, CRC(6610af52) SHA1(c6ab7f369bd0b05e0ce28c7829b870f5b6ddf12f) )
 	ROM_LOAD32_BYTE( "1.7_cruisn_world_u12_game.u12",  0x0000002, 0x100000, CRC(ef0107b1) SHA1(350017ab56c220516dda53c8323eaf82d7dee8dd) )
@@ -1761,8 +1833,8 @@ ROM_START( crusnwld17 ) /* Version 1.7, Fri Jan 24 1997 - 16:23:59 */
 ROM_END
 
 
-ROM_START( crusnwld13 ) /* Version 1.3, Mon Nov 25 1996 - 23:22:45 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
+ROM_START( crusnwld13 ) // Version 1.3, Mon Nov 25 1996 - 23:22:45
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u2_sound.u2", 0x000000, 0x80000, CRC(7a233c89) SHA1(ecfad4bc48a69cd3399e3b3266c81574082e0169) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u3_sound.u3", 0x200000, 0x80000, CRC(be9a5ff0) SHA1(98d69dbfa6aa8462cdd46772e991ee418b79c653) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u4_sound.u4", 0x400000, 0x80000, CRC(69f02d84) SHA1(0fb4ff750de78505f241ae6cd18fccf3ddf4223f) )
@@ -1772,7 +1844,7 @@ ROM_START( crusnwld13 ) /* Version 1.3, Mon Nov 25 1996 - 23:22:45 */
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u8_sound.u8", 0xc00000, 0x80000, CRC(5127c08e) SHA1(4f0eae73817270fa156829100b66f0ff88fa422c) )
 	ROM_LOAD16_BYTE( "1.0_cruisn_world_u9_sound.u9", 0xe00000, 0x80000, CRC(84cdc781) SHA1(62287aa72903698d1890908adde53c39f8bd200c) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
 	ROM_LOAD32_BYTE( "1.3_cruisn_world_u10_game.u10",  0x0000000, 0x100000, CRC(d361d17d) SHA1(7f42baec5492c4040e030e6233e500eb54bd9cba) )
 	ROM_LOAD32_BYTE( "1.3_cruisn_world_u11_game.u11",  0x0000001, 0x100000, CRC(b0c0a462) SHA1(22ae081c3eb9f298aea73e99a0124becd540f0df) )
 	ROM_LOAD32_BYTE( "1.3_cruisn_world_u12_game.u12",  0x0000002, 0x100000, CRC(5e7c566b) SHA1(81e6f21309bd3ba8589bc591a9ba5729f301539e) )
@@ -1813,10 +1885,10 @@ Mask ROMs have been seen in two formats:
 --------------------------------   --------------------------------
 
 */
-ROM_START( offroadc ) /* Version 1.63, Tue 03-03-98 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
-	ROM_LOAD16_BYTE( "1.0_off_road_u2_sound.u2", 0x000000, 0x80000, CRC(69976e9d) SHA1(63c886ac2563c43a10840f49f929f8613cd94de2) ) /* generally a M27C4001 EPROM with label */
-	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-01_u3_sound.u3", 0x200000, 0x80000, CRC(2db9b548) SHA1(4f454a3e6a8851b0ef5d325dd28102d57ea11a11) ) /* these are mask ROMs */
+ROM_START( offroadc ) // Version 1.63, Tue 03-03-98
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
+	ROM_LOAD16_BYTE( "1.0_off_road_u2_sound.u2", 0x000000, 0x80000, CRC(69976e9d) SHA1(63c886ac2563c43a10840f49f929f8613cd94de2) ) // generally a M27C4001 EPROM with label
+	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-01_u3_sound.u3", 0x200000, 0x80000, CRC(2db9b548) SHA1(4f454a3e6a8851b0ef5d325dd28102d57ea11a11) ) // these are mask ROMs
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-02_u4_sound.u4", 0x400000, 0x80000, CRC(42bdf9d0) SHA1(04add0f0ee7fa61de1913cc0b988345d3d430cde) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-03_u5_sound.u5", 0x600000, 0x80000, CRC(569cc84b) SHA1(08b917cc41fae6b6a3e9d9461a783d3d2865e72a) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-04_u6_sound.u6", 0x800000, 0x80000, CRC(0896f679) SHA1(dde39ef17834256909ef2c9fcd5b5fb9939d5178) )
@@ -1824,12 +1896,12 @@ ROM_START( offroadc ) /* Version 1.63, Tue 03-03-98 */
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-06_u8_sound.u8", 0xc00000, 0x80000, CRC(5da13f12) SHA1(2bb5e929e8bc6c70cb4475024a6b0bb07ac25244) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-07_u9_sound.u9", 0xe00000, 0x80000, CRC(7ad27f69) SHA1(b33665d0593a95b58d529720aae49e90449bf714) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
-	ROM_LOAD32_BYTE( "1.63_off_road_u10_game.u10", 0x0000000, 0x100000, CRC(faaf81b8) SHA1(d0bd40b2cf5d07db9f668826cc7f0ed84c4e84bf) ) /* Version 1.63 program ROMs */
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
+	ROM_LOAD32_BYTE( "1.63_off_road_u10_game.u10", 0x0000000, 0x100000, CRC(faaf81b8) SHA1(d0bd40b2cf5d07db9f668826cc7f0ed84c4e84bf) ) // Version 1.63 program ROMs
 	ROM_LOAD32_BYTE( "1.63_off_road_u11_game.u11", 0x0000001, 0x100000, CRC(f68e9655) SHA1(e29926ea24cfbd228a2136d04a63a92eba0098d7) )
 	ROM_LOAD32_BYTE( "1.63_off_road_u12_game.u12", 0x0000002, 0x100000, CRC(6a5295b3) SHA1(ac72fe205ffb306598400e8b1d9c98ae67b0bab9) )
 	ROM_LOAD32_BYTE( "1.63_off_road_u13_game.u13", 0x0000003, 0x100000, CRC(cb9233b5) SHA1(2d23b6a2312a75dbaa44de3224512c844aaac7b5) )
-	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-01_u14_video_image.u14", 0x0400000, 0x100000, CRC(1e41d14b) SHA1(3f7c5fae1f8b82ddd811720837fa298785a8dd27) ) /* mask ROMs */
+	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-01_u14_video_image.u14", 0x0400000, 0x100000, CRC(1e41d14b) SHA1(3f7c5fae1f8b82ddd811720837fa298785a8dd27) ) // mask ROMs
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-02_u15_video_image.u15", 0x0400001, 0x100000, CRC(654d623d) SHA1(a944b8f8d71b099d7b5bbd7df6effb90afc3aec8) )
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-03_u16_video_image.u16", 0x0400002, 0x100000, CRC(259774d8) SHA1(90cdf659324b84b3c2c59497cc5611e8f12629a6) )
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-04_u17_video_image.u17", 0x0400003, 0x100000, CRC(50c61434) SHA1(52bc603101b4f88b7d892af683b7c8358cabbf4a) )
@@ -1844,10 +1916,10 @@ ROM_START( offroadc ) /* Version 1.63, Tue 03-03-98 */
 ROM_END
 
 
-ROM_START( offroadc5 ) /* Version 1.50, Tue 10-21-97 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
-	ROM_LOAD16_BYTE( "1.0_off_road_u2_sound.u2", 0x000000, 0x80000, CRC(69976e9d) SHA1(63c886ac2563c43a10840f49f929f8613cd94de2) ) /* generally a M27C4001 EPROM with label */
-	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-01_u3_sound.u3", 0x200000, 0x80000, CRC(2db9b548) SHA1(4f454a3e6a8851b0ef5d325dd28102d57ea11a11) ) /* these are mask ROMs */
+ROM_START( offroadc5 ) // Version 1.50, Tue 10-21-97
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
+	ROM_LOAD16_BYTE( "1.0_off_road_u2_sound.u2", 0x000000, 0x80000, CRC(69976e9d) SHA1(63c886ac2563c43a10840f49f929f8613cd94de2) ) // generally a M27C4001 EPROM with label
+	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-01_u3_sound.u3", 0x200000, 0x80000, CRC(2db9b548) SHA1(4f454a3e6a8851b0ef5d325dd28102d57ea11a11) ) // these are mask ROMs
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-02_u4_sound.u4", 0x400000, 0x80000, CRC(42bdf9d0) SHA1(04add0f0ee7fa61de1913cc0b988345d3d430cde) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-03_u5_sound.u5", 0x600000, 0x80000, CRC(569cc84b) SHA1(08b917cc41fae6b6a3e9d9461a783d3d2865e72a) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-04_u6_sound.u6", 0x800000, 0x80000, CRC(0896f679) SHA1(dde39ef17834256909ef2c9fcd5b5fb9939d5178) )
@@ -1855,12 +1927,12 @@ ROM_START( offroadc5 ) /* Version 1.50, Tue 10-21-97 */
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-06_u8_sound.u8", 0xc00000, 0x80000, CRC(5da13f12) SHA1(2bb5e929e8bc6c70cb4475024a6b0bb07ac25244) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-07_u9_sound.u9", 0xe00000, 0x80000, CRC(7ad27f69) SHA1(b33665d0593a95b58d529720aae49e90449bf714) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
-	ROM_LOAD32_BYTE( "1.5_off_road_u10_game.u10",  0x0000000, 0x100000, CRC(f464be4f) SHA1(da6c04ae49d033f92cdd62f997841365c4a08616) ) /* Version 1.50 program ROMs */
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
+	ROM_LOAD32_BYTE( "1.5_off_road_u10_game.u10",  0x0000000, 0x100000, CRC(f464be4f) SHA1(da6c04ae49d033f92cdd62f997841365c4a08616) ) // Version 1.50 program ROMs
 	ROM_LOAD32_BYTE( "1.5_off_road_u11_game.u11",  0x0000001, 0x100000, CRC(eaddc9ac) SHA1(a6b810bf7460e3257bf6acdc3b79c532fb71ad68) )
 	ROM_LOAD32_BYTE( "1.5_off_road_u12_game.u12",  0x0000002, 0x100000, CRC(a2da68da) SHA1(b8dcc042b9926055bff9020599c1c218f08b1727) )
 	ROM_LOAD32_BYTE( "1.5_off_road_u13_game.u13",  0x0000003, 0x100000, CRC(b4755ee2) SHA1(1c4cde7ca60a6e8bff12aed348e7148e20a8caba) )
-	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-01_u14_video_image.u14", 0x0400000, 0x100000, CRC(1e41d14b) SHA1(3f7c5fae1f8b82ddd811720837fa298785a8dd27) ) /* mask ROMs */
+	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-01_u14_video_image.u14", 0x0400000, 0x100000, CRC(1e41d14b) SHA1(3f7c5fae1f8b82ddd811720837fa298785a8dd27) ) // mask ROMs
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-02_u15_video_image.u15", 0x0400001, 0x100000, CRC(654d623d) SHA1(a944b8f8d71b099d7b5bbd7df6effb90afc3aec8) )
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-03_u16_video_image.u16", 0x0400002, 0x100000, CRC(259774d8) SHA1(90cdf659324b84b3c2c59497cc5611e8f12629a6) )
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-04_u17_video_image.u17", 0x0400003, 0x100000, CRC(50c61434) SHA1(52bc603101b4f88b7d892af683b7c8358cabbf4a) )
@@ -1875,10 +1947,10 @@ ROM_START( offroadc5 ) /* Version 1.50, Tue 10-21-97 */
 ROM_END
 
 
-ROM_START( offroadc4 ) /* Version 1.40, Mon 10-06-97 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
-	ROM_LOAD16_BYTE( "1.0_off_road_u2_sound.u2", 0x000000, 0x80000, CRC(69976e9d) SHA1(63c886ac2563c43a10840f49f929f8613cd94de2) ) /* generally a M27C4001 EPROM with label */
-	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-01_u3_sound.u3", 0x200000, 0x80000, CRC(2db9b548) SHA1(4f454a3e6a8851b0ef5d325dd28102d57ea11a11) ) /* these are mask ROMs */
+ROM_START( offroadc4 ) // Version 1.40, Mon 10-06-97
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
+	ROM_LOAD16_BYTE( "1.0_off_road_u2_sound.u2", 0x000000, 0x80000, CRC(69976e9d) SHA1(63c886ac2563c43a10840f49f929f8613cd94de2) ) // generally a M27C4001 EPROM with label
+	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-01_u3_sound.u3", 0x200000, 0x80000, CRC(2db9b548) SHA1(4f454a3e6a8851b0ef5d325dd28102d57ea11a11) ) // these are mask ROMs
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-02_u4_sound.u4", 0x400000, 0x80000, CRC(42bdf9d0) SHA1(04add0f0ee7fa61de1913cc0b988345d3d430cde) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-03_u5_sound.u5", 0x600000, 0x80000, CRC(569cc84b) SHA1(08b917cc41fae6b6a3e9d9461a783d3d2865e72a) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-04_u6_sound.u6", 0x800000, 0x80000, CRC(0896f679) SHA1(dde39ef17834256909ef2c9fcd5b5fb9939d5178) )
@@ -1886,12 +1958,12 @@ ROM_START( offroadc4 ) /* Version 1.40, Mon 10-06-97 */
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-06_u8_sound.u8", 0xc00000, 0x80000, CRC(5da13f12) SHA1(2bb5e929e8bc6c70cb4475024a6b0bb07ac25244) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-07_u9_sound.u9", 0xe00000, 0x80000, CRC(7ad27f69) SHA1(b33665d0593a95b58d529720aae49e90449bf714) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
-	ROM_LOAD32_BYTE( "1.4_off_road_u10_game.u10",  0x0000000, 0x100000, CRC(d263b078) SHA1(d376e120e05cf8526b002300db345fd0b9775702) ) /* Version 1.40 program ROMs */
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
+	ROM_LOAD32_BYTE( "1.4_off_road_u10_game.u10",  0x0000000, 0x100000, CRC(d263b078) SHA1(d376e120e05cf8526b002300db345fd0b9775702) ) // Version 1.40 program ROMs
 	ROM_LOAD32_BYTE( "1.4_off_road_u11_game.u11",  0x0000001, 0x100000, CRC(1b443a72) SHA1(0e16d923f0e97f21e92c8d5b431fcaa0815b2c87) )
 	ROM_LOAD32_BYTE( "1.4_off_road_u12_game.u12",  0x0000002, 0x100000, CRC(4e82a34b) SHA1(c22a3f638b7e226add511147982339b1f59821e9) )
 	ROM_LOAD32_BYTE( "1.4_off_road_u13_game.u13",  0x0000003, 0x100000, CRC(558b859c) SHA1(b7946a4b44976b08a691622000e1457021267d1a) )
-	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-01_u14_video_image.u14", 0x0400000, 0x100000, CRC(1e41d14b) SHA1(3f7c5fae1f8b82ddd811720837fa298785a8dd27) ) /* mask ROMs */
+	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-01_u14_video_image.u14", 0x0400000, 0x100000, CRC(1e41d14b) SHA1(3f7c5fae1f8b82ddd811720837fa298785a8dd27) ) // mask ROMs
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-02_u15_video_image.u15", 0x0400001, 0x100000, CRC(654d623d) SHA1(a944b8f8d71b099d7b5bbd7df6effb90afc3aec8) )
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-03_u16_video_image.u16", 0x0400002, 0x100000, CRC(259774d8) SHA1(90cdf659324b84b3c2c59497cc5611e8f12629a6) )
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-04_u17_video_image.u17", 0x0400003, 0x100000, CRC(50c61434) SHA1(52bc603101b4f88b7d892af683b7c8358cabbf4a) )
@@ -1906,10 +1978,10 @@ ROM_START( offroadc4 ) /* Version 1.40, Mon 10-06-97 */
 ROM_END
 
 
-ROM_START( offroadc3 ) /* Version 1.30, Mon 09-15-97 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
-	ROM_LOAD16_BYTE( "1.0_off_road_u2_sound.u2", 0x000000, 0x80000, CRC(69976e9d) SHA1(63c886ac2563c43a10840f49f929f8613cd94de2) ) /* generally a M27C4001 EPROM with label */
-	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-01_u3_sound.u3", 0x200000, 0x80000, CRC(2db9b548) SHA1(4f454a3e6a8851b0ef5d325dd28102d57ea11a11) ) /* these are mask ROMs */
+ROM_START( offroadc3 ) // Version 1.30, Mon 09-15-97
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
+	ROM_LOAD16_BYTE( "1.0_off_road_u2_sound.u2", 0x000000, 0x80000, CRC(69976e9d) SHA1(63c886ac2563c43a10840f49f929f8613cd94de2) ) // generally a M27C4001 EPROM with label
+	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-01_u3_sound.u3", 0x200000, 0x80000, CRC(2db9b548) SHA1(4f454a3e6a8851b0ef5d325dd28102d57ea11a11) ) // these are mask ROMs
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-02_u4_sound.u4", 0x400000, 0x80000, CRC(42bdf9d0) SHA1(04add0f0ee7fa61de1913cc0b988345d3d430cde) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-03_u5_sound.u5", 0x600000, 0x80000, CRC(569cc84b) SHA1(08b917cc41fae6b6a3e9d9461a783d3d2865e72a) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-04_u6_sound.u6", 0x800000, 0x80000, CRC(0896f679) SHA1(dde39ef17834256909ef2c9fcd5b5fb9939d5178) )
@@ -1917,12 +1989,12 @@ ROM_START( offroadc3 ) /* Version 1.30, Mon 09-15-97 */
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-06_u8_sound.u8", 0xc00000, 0x80000, CRC(5da13f12) SHA1(2bb5e929e8bc6c70cb4475024a6b0bb07ac25244) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-07_u9_sound.u9", 0xe00000, 0x80000, CRC(7ad27f69) SHA1(b33665d0593a95b58d529720aae49e90449bf714) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
-	ROM_LOAD32_BYTE( "1.3_off_road_u10.u10",  0x0000000, 0x100000, CRC(71c62ce2) SHA1(e6bdbf3df4795f4cf29a08641cc59d90aed73b57) ) /* Version 1.30 program ROMs */
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
+	ROM_LOAD32_BYTE( "1.3_off_road_u10.u10",  0x0000000, 0x100000, CRC(71c62ce2) SHA1(e6bdbf3df4795f4cf29a08641cc59d90aed73b57) ) // Version 1.30 program ROMs
 	ROM_LOAD32_BYTE( "1.3_off_road_u11.u11",  0x0000001, 0x100000, CRC(9e362dbb) SHA1(2480710f1081679ff87239a8e28a9a3f235bd3dc) )
 	ROM_LOAD32_BYTE( "1.3_off_road_u12.u12",  0x0000002, 0x100000, CRC(9e0a5b06) SHA1(63bbe427713fc966c65dab575dd42cdce6b00874) )
 	ROM_LOAD32_BYTE( "1.3_off_road_u13.u13",  0x0000003, 0x100000, CRC(d602db7e) SHA1(48bc762a83baeb382476619f54631ccbe12d1b2c) )
-	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-01_u14_video_image.u14", 0x0400000, 0x100000, CRC(1e41d14b) SHA1(3f7c5fae1f8b82ddd811720837fa298785a8dd27) ) /* mask ROMs */
+	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-01_u14_video_image.u14", 0x0400000, 0x100000, CRC(1e41d14b) SHA1(3f7c5fae1f8b82ddd811720837fa298785a8dd27) ) // mask ROMs
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-02_u15_video_image.u15", 0x0400001, 0x100000, CRC(654d623d) SHA1(a944b8f8d71b099d7b5bbd7df6effb90afc3aec8) )
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-03_u16_video_image.u16", 0x0400002, 0x100000, CRC(259774d8) SHA1(90cdf659324b84b3c2c59497cc5611e8f12629a6) )
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-04_u17_video_image.u17", 0x0400003, 0x100000, CRC(50c61434) SHA1(52bc603101b4f88b7d892af683b7c8358cabbf4a) )
@@ -1937,10 +2009,10 @@ ROM_START( offroadc3 ) /* Version 1.30, Mon 09-15-97 */
 ROM_END
 
 
-ROM_START( offroadc1 ) /* Version 1.10, Mon 08-18-97 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
-	ROM_LOAD16_BYTE( "1.0_off_road_u2_sound.u2", 0x000000, 0x80000, CRC(69976e9d) SHA1(63c886ac2563c43a10840f49f929f8613cd94de2) ) /* generally a M27C4001 EPROM with label */
-	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-01_u3_sound.u3", 0x200000, 0x80000, CRC(2db9b548) SHA1(4f454a3e6a8851b0ef5d325dd28102d57ea11a11) ) /* these are mask ROMs */
+ROM_START( offroadc1 ) // Version 1.10, Mon 08-18-97
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
+	ROM_LOAD16_BYTE( "1.0_off_road_u2_sound.u2", 0x000000, 0x80000, CRC(69976e9d) SHA1(63c886ac2563c43a10840f49f929f8613cd94de2) ) // generally a M27C4001 EPROM with label
+	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-01_u3_sound.u3", 0x200000, 0x80000, CRC(2db9b548) SHA1(4f454a3e6a8851b0ef5d325dd28102d57ea11a11) ) // these are mask ROMs
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-02_u4_sound.u4", 0x400000, 0x80000, CRC(42bdf9d0) SHA1(04add0f0ee7fa61de1913cc0b988345d3d430cde) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-03_u5_sound.u5", 0x600000, 0x80000, CRC(569cc84b) SHA1(08b917cc41fae6b6a3e9d9461a783d3d2865e72a) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-04_u6_sound.u6", 0x800000, 0x80000, CRC(0896f679) SHA1(dde39ef17834256909ef2c9fcd5b5fb9939d5178) )
@@ -1948,12 +2020,12 @@ ROM_START( offroadc1 ) /* Version 1.10, Mon 08-18-97 */
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-06_u8_sound.u8", 0xc00000, 0x80000, CRC(5da13f12) SHA1(2bb5e929e8bc6c70cb4475024a6b0bb07ac25244) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-07_u9_sound.u9", 0xe00000, 0x80000, CRC(7ad27f69) SHA1(b33665d0593a95b58d529720aae49e90449bf714) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
-	ROM_LOAD32_BYTE( "1.1_off_road_u10.u10",  0x0000000, 0x100000, CRC(4729660c) SHA1(0baff6a27015f4eb3fe0a981ecbac33d140e872a) ) /* Version 1.10 program ROMs */
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
+	ROM_LOAD32_BYTE( "1.1_off_road_u10.u10",  0x0000000, 0x100000, CRC(4729660c) SHA1(0baff6a27015f4eb3fe0a981ecbac33d140e872a) ) // Version 1.10 program ROMs
 	ROM_LOAD32_BYTE( "1.1_off_road_u11.u11",  0x0000001, 0x100000, CRC(6272d013) SHA1(860121184282627ed692e56a0dafee8b64562811) )
 	ROM_LOAD32_BYTE( "1.1_off_road_u12.u12",  0x0000002, 0x100000, CRC(9c8326be) SHA1(55f16d14379f57d08ed84d82f9db1a582bc223a1) )
 	ROM_LOAD32_BYTE( "1.1_off_road_u13.u13",  0x0000003, 0x100000, CRC(53bbc181) SHA1(1ab29a27a216eb09d69a9f3d681865de1a904717) )
-	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-01_u14_video_image.u14", 0x0400000, 0x100000, CRC(1e41d14b) SHA1(3f7c5fae1f8b82ddd811720837fa298785a8dd27) ) /* mask ROMs */
+	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-01_u14_video_image.u14", 0x0400000, 0x100000, CRC(1e41d14b) SHA1(3f7c5fae1f8b82ddd811720837fa298785a8dd27) ) // mask ROMs
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-02_u15_video_image.u15", 0x0400001, 0x100000, CRC(654d623d) SHA1(a944b8f8d71b099d7b5bbd7df6effb90afc3aec8) )
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-03_u16_video_image.u16", 0x0400002, 0x100000, CRC(259774d8) SHA1(90cdf659324b84b3c2c59497cc5611e8f12629a6) )
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-04_u17_video_image.u17", 0x0400003, 0x100000, CRC(50c61434) SHA1(52bc603101b4f88b7d892af683b7c8358cabbf4a) )
@@ -1968,10 +2040,10 @@ ROM_START( offroadc1 ) /* Version 1.10, Mon 08-18-97 */
 ROM_END
 
 
-ROM_START( offroadc0 ) /* Version 1.00, Mon 07-28-97 */
-	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  /* sound data */
-	ROM_LOAD16_BYTE( "1.0_off_road_u2_sound.u2", 0x000000, 0x80000, CRC(69976e9d) SHA1(63c886ac2563c43a10840f49f929f8613cd94de2) ) /* generally a M27C4001 EPROM with label */
-	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-01_u3_sound.u3", 0x200000, 0x80000, CRC(2db9b548) SHA1(4f454a3e6a8851b0ef5d325dd28102d57ea11a11) ) /* these are mask ROMs */
+ROM_START( offroadc0 ) // Version 1.00, Mon 07-28-97
+	ROM_REGION16_LE( 0x1000000, "dcs", ROMREGION_ERASEFF )  // sound data
+	ROM_LOAD16_BYTE( "1.0_off_road_u2_sound.u2", 0x000000, 0x80000, CRC(69976e9d) SHA1(63c886ac2563c43a10840f49f929f8613cd94de2) ) // generally a M27C4001 EPROM with label
+	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-01_u3_sound.u3", 0x200000, 0x80000, CRC(2db9b548) SHA1(4f454a3e6a8851b0ef5d325dd28102d57ea11a11) ) // these are mask ROMs
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-02_u4_sound.u4", 0x400000, 0x80000, CRC(42bdf9d0) SHA1(04add0f0ee7fa61de1913cc0b988345d3d430cde) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-03_u5_sound.u5", 0x600000, 0x80000, CRC(569cc84b) SHA1(08b917cc41fae6b6a3e9d9461a783d3d2865e72a) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-04_u6_sound.u6", 0x800000, 0x80000, CRC(0896f679) SHA1(dde39ef17834256909ef2c9fcd5b5fb9939d5178) )
@@ -1979,12 +2051,12 @@ ROM_START( offroadc0 ) /* Version 1.00, Mon 07-28-97 */
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-06_u8_sound.u8", 0xc00000, 0x80000, CRC(5da13f12) SHA1(2bb5e929e8bc6c70cb4475024a6b0bb07ac25244) )
 	ROM_LOAD16_BYTE( "offroad_challenge_5341-15511-07_u9_sound.u9", 0xe00000, 0x80000, CRC(7ad27f69) SHA1(b33665d0593a95b58d529720aae49e90449bf714) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
-	ROM_LOAD32_BYTE( "off_road_u10_game.u10",  0x0000000, 0x100000, CRC(f3535a2c) SHA1(b9578ac9bf3092d983608bc26535127108565062) ) /* Version 1.00 program ROMs  - mask ROMS simply labeled:  OFF ROAD   U1x GAME   1997 Midway */
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
+	ROM_LOAD32_BYTE( "off_road_u10_game.u10",  0x0000000, 0x100000, CRC(f3535a2c) SHA1(b9578ac9bf3092d983608bc26535127108565062) ) // Version 1.00 program ROMs  - mask ROMS simply labeled:  OFF ROAD   U1x GAME   1997 Midway
 	ROM_LOAD32_BYTE( "off_road_u11_game.u11",  0x0000001, 0x100000, CRC(16c904ee) SHA1(ad0a7d9db239cfeb43aba6c4a0a830ba010f397f) )
 	ROM_LOAD32_BYTE( "off_road_u12_game.u12",  0x0000002, 0x100000, CRC(d267d7bf) SHA1(eaafba935392444871c17a06e7f513545846aac5) )
 	ROM_LOAD32_BYTE( "off_road_u13_game.u13",  0x0000003, 0x100000, CRC(e6274bb3) SHA1(3203d0bf6ce01efd8e28114b95ddf31e70df5e6e) )
-	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-01_u14_video_image.u14", 0x0400000, 0x100000, CRC(1e41d14b) SHA1(3f7c5fae1f8b82ddd811720837fa298785a8dd27) ) /* mask ROMs */
+	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-01_u14_video_image.u14", 0x0400000, 0x100000, CRC(1e41d14b) SHA1(3f7c5fae1f8b82ddd811720837fa298785a8dd27) ) // mask ROMs
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-02_u15_video_image.u15", 0x0400001, 0x100000, CRC(654d623d) SHA1(a944b8f8d71b099d7b5bbd7df6effb90afc3aec8) )
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-03_u16_video_image.u16", 0x0400002, 0x100000, CRC(259774d8) SHA1(90cdf659324b84b3c2c59497cc5611e8f12629a6) )
 	ROM_LOAD32_BYTE( "offroad_challenge_5341-15510-04_u17_video_image.u17", 0x0400003, 0x100000, CRC(50c61434) SHA1(52bc603101b4f88b7d892af683b7c8358cabbf4a) )
@@ -2043,11 +2115,11 @@ PCB LAYOUT
 |-----------------------------|  |---------------------------------------|  |---------------------------------------|
 */
 
-ROM_START( wargods ) /* Boot EPROM Version 1.0, Game Type: 452 (11/07/1996) */
-	ROM_REGION16_LE( 0x10000, "dcs", 0 )    /* sound data */
+ROM_START( wargods ) // Boot EPROM Version 1.0, Game Type: 452 (11/07/1996)
+	ROM_REGION16_LE( 0x10000, "dcs", 0 )    // sound data
 	ROM_LOAD16_BYTE( "u2.rom",   0x000000, 0x8000, CRC(bec7d3ae) SHA1(db80aa4a645804a4574b07b9f34dec6b6b64190d) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
 	ROM_LOAD( "u41.rom", 0x000000, 0x20000, CRC(398c54cc) SHA1(6c4b5d6ec5c844dcbf181f9d86a9196a088ed2db) )
 
 	DISK_REGION( "ata:0:hdd" )
@@ -2058,11 +2130,11 @@ ROM_START( wargods ) /* Boot EPROM Version 1.0, Game Type: 452 (11/07/1996) */
 	ROM_LOAD( "452_wargods.u69",  0x0000, 0x2000, CRC(b908f560) SHA1(68b081f0583aa35c2daeedd43e030ebdcea1a54c) )
 ROM_END
 
-ROM_START( wargodsa ) /* Boot EPROM Version 1.0, Game Type: 452 (08/15/1996) */
-	ROM_REGION16_LE( 0x10000, "dcs", 0 )    /* sound data */
+ROM_START( wargodsa ) // Boot EPROM Version 1.0, Game Type: 452 (08/15/1996)
+	ROM_REGION16_LE( 0x10000, "dcs", 0 )    // sound data
 	ROM_LOAD16_BYTE( "u2.rom",   0x000000, 0x8000, CRC(bec7d3ae) SHA1(db80aa4a645804a4574b07b9f34dec6b6b64190d) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
 	ROM_LOAD( "u41.rom", 0x000000, 0x20000, CRC(398c54cc) SHA1(6c4b5d6ec5c844dcbf181f9d86a9196a088ed2db) )
 
 	DISK_REGION( "ata:0:hdd" )
@@ -2072,11 +2144,11 @@ ROM_START( wargodsa ) /* Boot EPROM Version 1.0, Game Type: 452 (08/15/1996) */
 	ROM_LOAD( "452_wargods.u69",  0x0000, 0x2000, CRC(b908f560) SHA1(68b081f0583aa35c2daeedd43e030ebdcea1a54c) )
 ROM_END
 
-ROM_START( wargodsb ) /* Boot EPROM Version 1.0, Game Type: 452 (12/11/1995) */
-	ROM_REGION16_LE( 0x10000, "dcs", 0 )    /* sound data */
+ROM_START( wargodsb ) // Boot EPROM Version 1.0, Game Type: 452 (12/11/1995)
+	ROM_REGION16_LE( 0x10000, "dcs", 0 )    // sound data
 	ROM_LOAD16_BYTE( "u2.rom",   0x000000, 0x8000, CRC(bec7d3ae) SHA1(db80aa4a645804a4574b07b9f34dec6b6b64190d) )
 
-	ROM_REGION32_LE( 0x1000000, "user1", 0 )
+	ROM_REGION32_LE( 0x1000000, "maindata", 0 )
 	ROM_LOAD( "u41.rom", 0x000000, 0x20000, CRC(398c54cc) SHA1(6c4b5d6ec5c844dcbf181f9d86a9196a088ed2db) )
 
 	DISK_REGION( "ata:0:hdd" )
@@ -2094,75 +2166,58 @@ ROM_END
  *
  *************************************/
 
-uint32_t midvunit_state::generic_speedup_r(offs_t offset)
+uint32_t midvunit_base_state::generic_speedup_r(offs_t offset)
 {
-	m_maincpu->eat_cycles(100);
+	if (!machine().side_effects_disabled())
+		m_maincpu->eat_cycles(100);
 	return m_generic_speedup[offset];
 }
 
 
-void midvunit_state::init_crusnusa_common(offs_t speedup)
+void crusnusa_state::init_crusnusa_common(offs_t speedup)
 {
 	m_adc_shift = 24;
 
-	/* speedups */
-	m_maincpu->space(AS_PROGRAM).install_read_handler(speedup, speedup + 1, read32sm_delegate(*this, FUNC(midvunit_state::generic_speedup_r)));
+	// speedups
+	m_maincpu->space(AS_PROGRAM).install_read_handler(speedup, speedup + 1, read32sm_delegate(*this, FUNC(crusnusa_state::generic_speedup_r)));
 	m_generic_speedup = m_ram_base + speedup;
 }
-void midvunit_state::init_crusnusa()  { init_crusnusa_common(0xc93e); }
-void midvunit_state::init_crusnu40()  { init_crusnusa_common(0xc957); }
-void midvunit_state::init_crusnu21()  { init_crusnusa_common(0xc051); }
+void crusnusa_state::init_crusnusa()  { init_crusnusa_common(0xc93e); }
+void crusnusa_state::init_crusnu40()  { init_crusnusa_common(0xc957); }
+void crusnusa_state::init_crusnu21()  { init_crusnusa_common(0xc051); }
 
 
-void midvunit_state::init_crusnwld_common(offs_t speedup)
+void crusnwld_state::init_crusnwld_common(offs_t speedup)
 {
 	m_adc_shift = 16;
 
-	/* control register is different */
-	m_maincpu->space(AS_PROGRAM).install_write_handler(0x994000, 0x994000, write32s_delegate(*this, FUNC(midvunit_state::crusnwld_control_w)));
-
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x991030, 0x991030, read32smo_delegate(*this, FUNC(midvunit_state::crusnwld_serial_status_r)));
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x996000, 0x996000, read32smo_delegate(*this, FUNC(midvunit_state::crusnwld_serial_data_r)));
-	m_maincpu->space(AS_PROGRAM).install_write_handler(0x996000, 0x996000, write32smo_delegate(*this, FUNC(midvunit_state::crusnwld_serial_data_w)));
-
-	/* install strange protection device */
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x9d0000, 0x9d1fff, read32sm_delegate(*this, FUNC(midvunit_state::bit_data_r)));
-	m_maincpu->space(AS_PROGRAM).install_write_handler(0x9d0000, 0x9d0000, write32smo_delegate(*this, FUNC(midvunit_state::bit_reset_w)));
-
-	/* speedups */
+	// speedups
 	if (speedup) {
-		m_maincpu->space(AS_PROGRAM).install_read_handler(speedup, speedup + 1, read32sm_delegate(*this, FUNC(midvunit_state::generic_speedup_r)));
+		m_maincpu->space(AS_PROGRAM).install_read_handler(speedup, speedup + 1, read32sm_delegate(*this, FUNC(crusnwld_state::generic_speedup_r)));
 		m_generic_speedup = m_ram_base + speedup;
 	}
 }
-void midvunit_state::init_crusnwld()  { init_crusnwld_common(0xd4c0); }
+void crusnwld_state::init_crusnwld()  { init_crusnwld_common(0xd4c0); }
 #if 0
 void midvunit_state::init_crusnw20()  { init_crusnwld_common(0xd49c); }
 void midvunit_state::init_crusnw13()  { init_crusnwld_common(0); }
 #endif
 
-void midvunit_state::init_offroadc()
+void crusnwld_state::init_offroadc()
 {
 	m_adc_shift = 16;
 
-	/* control register is different */
-	m_maincpu->space(AS_PROGRAM).install_write_handler(0x994000, 0x994000, write32s_delegate(*this, FUNC(midvunit_state::crusnwld_control_w)));
-
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x991030, 0x991030, read32smo_delegate(*this, FUNC(midvunit_state::crusnwld_serial_status_r)));
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x996000, 0x996000, read32smo_delegate(*this, FUNC(midvunit_state::crusnwld_serial_data_r)));
-	m_maincpu->space(AS_PROGRAM).install_write_handler(0x996000, 0x996000, write32smo_delegate(*this, FUNC(midvunit_state::crusnwld_serial_data_w)));
-
-	/* speedups */
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x195aa, 0x195aa, read32sm_delegate(*this, FUNC(midvunit_state::generic_speedup_r)));
+	// speedups
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x195aa, 0x195aa, read32sm_delegate(*this, FUNC(crusnwld_state::generic_speedup_r)));
 	m_generic_speedup = m_ram_base + 0x195aa;
 }
 
 
-void midvunit_state::init_wargods()
+void midvplus_state::init_wargods()
 {
 	uint8_t default_nvram[256];
 
-	/* we need proper VRAM */
+	// we need proper VRAM
 	memset(default_nvram, 0xff, sizeof(default_nvram));
 	default_nvram[0x0e] = default_nvram[0x2e] = 0x67;
 	default_nvram[0x0f] = default_nvram[0x2f] = 0x32;
@@ -2173,8 +2228,8 @@ void midvunit_state::init_wargods()
 	default_nvram[0x18] = default_nvram[0x38] = 0xe7;
 	m_midway_ioasic->set_default_nvram(default_nvram);
 
-	/* speedups */
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x2f4c, 0x2f4c, read32sm_delegate(*this, FUNC(midvunit_state::generic_speedup_r)));
+	// speedups
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x2f4c, 0x2f4c, read32sm_delegate(*this, FUNC(midvplus_state::generic_speedup_r)));
 	m_generic_speedup = m_ram_base + 0x2f4c;
 }
 
@@ -2186,29 +2241,29 @@ void midvunit_state::init_wargods()
  *
  *************************************/
 
-GAMEL( 1994, crusnusa,   0,        midvunit, crusnusa, midvunit_state, init_crusnusa, ROT0, "Midway", "Cruis'n USA (v4.5)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1994, crusnusa44, crusnusa, midvunit, crusnusa, midvunit_state, init_crusnu40, ROT0, "Midway", "Cruis'n USA (v4.4)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1994, crusnusa41, crusnusa, midvunit, crusnusa, midvunit_state, init_crusnu40, ROT0, "Midway", "Cruis'n USA (v4.1)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1994, crusnusa40, crusnusa, midvunit, crusnusa, midvunit_state, init_crusnu40, ROT0, "Midway", "Cruis'n USA (v4.0)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1994, crusnusa21, crusnusa, midvunit, crusnusa, midvunit_state, init_crusnu21, ROT0, "Midway", "Cruis'n USA (v2.1)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1994, crusnusa20, crusnusa, midvunit, crusnusa, midvunit_state, init_crusnu21, ROT0, "Midway", "Cruis'n USA (v2.0)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1994, crusnusa11, crusnusa, midvunit, crusnusa, midvunit_state, init_crusnu21, ROT0, "Midway", "Cruis'n USA (v1.1)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1994, crusnusa,   0,        midvunit, crusnusa, crusnusa_state, init_crusnusa, ROT0, "Midway", "Cruis'n USA (v4.5)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1994, crusnusa44, crusnusa, midvunit, crusnusa, crusnusa_state, init_crusnu40, ROT0, "Midway", "Cruis'n USA (v4.4)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1994, crusnusa41, crusnusa, midvunit, crusnusa, crusnusa_state, init_crusnu40, ROT0, "Midway", "Cruis'n USA (v4.1)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1994, crusnusa40, crusnusa, midvunit, crusnusa, crusnusa_state, init_crusnu40, ROT0, "Midway", "Cruis'n USA (v4.0)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1994, crusnusa21, crusnusa, midvunit, crusnusa, crusnusa_state, init_crusnu21, ROT0, "Midway", "Cruis'n USA (v2.1)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1994, crusnusa20, crusnusa, midvunit, crusnusa, crusnusa_state, init_crusnu21, ROT0, "Midway", "Cruis'n USA (v2.0)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1994, crusnusa11, crusnusa, midvunit, crusnusa, crusnusa_state, init_crusnu21, ROT0, "Midway", "Cruis'n USA (v1.1)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
 
-GAMEL( 1996, crusnwld,   0,        crusnwld, crusnwld, midvunit_state, init_crusnwld, ROT0, "Midway", "Cruis'n World (v2.5)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1996, crusnwld24, crusnwld, crusnwld, crusnwld, midvunit_state, init_crusnwld, ROT0, "Midway", "Cruis'n World (v2.4)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1996, crusnwld23, crusnwld, crusnwld, crusnwld, midvunit_state, init_crusnwld, ROT0, "Midway", "Cruis'n World (v2.3)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1996, crusnwld20, crusnwld, crusnwld, crusnwld, midvunit_state, init_crusnwld, ROT0, "Midway", "Cruis'n World (v2.0)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1996, crusnwld19, crusnwld, crusnwld, crusnwld, midvunit_state, init_crusnwld, ROT0, "Midway", "Cruis'n World (v1.9)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1996, crusnwld17, crusnwld, crusnwld, crusnwld, midvunit_state, init_crusnwld, ROT0, "Midway", "Cruis'n World (v1.7)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1996, crusnwld13, crusnwld, crusnwld, crusnwld, midvunit_state, init_crusnwld, ROT0, "Midway", "Cruis'n World (v1.3)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1996, crusnwld,   0,        crusnwld, crusnwld, crusnwld_state, init_crusnwld, ROT0, "Midway", "Cruis'n World (v2.5)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1996, crusnwld24, crusnwld, crusnwld, crusnwld, crusnwld_state, init_crusnwld, ROT0, "Midway", "Cruis'n World (v2.4)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1996, crusnwld23, crusnwld, crusnwld, crusnwld, crusnwld_state, init_crusnwld, ROT0, "Midway", "Cruis'n World (v2.3)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1996, crusnwld20, crusnwld, crusnwld, crusnwld, crusnwld_state, init_crusnwld, ROT0, "Midway", "Cruis'n World (v2.0)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1996, crusnwld19, crusnwld, crusnwld, crusnwld, crusnwld_state, init_crusnwld, ROT0, "Midway", "Cruis'n World (v1.9)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1996, crusnwld17, crusnwld, crusnwld, crusnwld, crusnwld_state, init_crusnwld, ROT0, "Midway", "Cruis'n World (v1.7)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1996, crusnwld13, crusnwld, crusnwld, crusnwld, crusnwld_state, init_crusnwld, ROT0, "Midway", "Cruis'n World (v1.3)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
 
-GAMEL( 1997, offroadc,  0,         offroadc, offroadc, midvunit_state, init_offroadc, ROT0, "Midway", "Off Road Challenge (v1.63)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1997, offroadc5, offroadc,  offroadc, offroadc, midvunit_state, init_offroadc, ROT0, "Midway", "Off Road Challenge (v1.50)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1997, offroadc4, offroadc,  offroadc, offroadc, midvunit_state, init_offroadc, ROT0, "Midway", "Off Road Challenge (v1.40)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1997, offroadc3, offroadc,  offroadc, offroadc, midvunit_state, init_offroadc, ROT0, "Midway", "Off Road Challenge (v1.30)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1997, offroadc1, offroadc,  offroadc, offroadc, midvunit_state, init_offroadc, ROT0, "Midway", "Off Road Challenge (v1.10)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
-GAMEL( 1997, offroadc0, offroadc,  offroadc, offroadc, midvunit_state, init_offroadc, ROT0, "Midway", "Off Road Challenge (v1.00)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1997, offroadc,  0,         offroadc, offroadc, crusnwld_state, init_offroadc, ROT0, "Midway", "Off Road Challenge (v1.63)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1997, offroadc5, offroadc,  offroadc, offroadc, crusnwld_state, init_offroadc, ROT0, "Midway", "Off Road Challenge (v1.50)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1997, offroadc4, offroadc,  offroadc, offroadc, crusnwld_state, init_offroadc, ROT0, "Midway", "Off Road Challenge (v1.40)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1997, offroadc3, offroadc,  offroadc, offroadc, crusnwld_state, init_offroadc, ROT0, "Midway", "Off Road Challenge (v1.30)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1997, offroadc1, offroadc,  offroadc, offroadc, crusnwld_state, init_offroadc, ROT0, "Midway", "Off Road Challenge (v1.10)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
+GAMEL( 1997, offroadc0, offroadc,  offroadc, offroadc, crusnwld_state, init_offroadc, ROT0, "Midway", "Off Road Challenge (v1.00)", MACHINE_SUPPORTS_SAVE, layout_crusnusa )
 
-GAME(  1995, wargods,   0,         midvplus, wargods,  midvunit_state, init_wargods,  ROT0, "Midway", "War Gods (HD 10/09/1996 - Dual Resolution)", MACHINE_SUPPORTS_SAVE )
-GAME(  1995, wargodsa,  wargods,   midvplus, wargodsa, midvunit_state, init_wargods,  ROT0, "Midway", "War Gods (HD 08/15/1996)", MACHINE_SUPPORTS_SAVE )
-GAME(  1995, wargodsb,  wargods,   midvplus, wargodsa, midvunit_state, init_wargods,  ROT0, "Midway", "War Gods (HD 12/11/1995)", MACHINE_SUPPORTS_SAVE )
+GAME(  1995, wargods,   0,         midvplus, wargods,  midvplus_state, init_wargods,  ROT0, "Midway", "War Gods (HD 10/09/1996 - Dual Resolution)", MACHINE_SUPPORTS_SAVE )
+GAME(  1995, wargodsa,  wargods,   midvplus, wargodsa, midvplus_state, init_wargods,  ROT0, "Midway", "War Gods (HD 08/15/1996)", MACHINE_SUPPORTS_SAVE )
+GAME(  1995, wargodsb,  wargods,   midvplus, wargodsa, midvplus_state, init_wargods,  ROT0, "Midway", "War Gods (HD 12/11/1995)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/midway/midvunit.h
+++ b/src/mame/midway/midvunit.h
@@ -23,8 +23,6 @@
 #include "emupal.h"
 #include "screen.h"
 
-#define MIDVUNIT_VIDEO_CLOCK    33000000
-
 struct midvunit_object_data
 {
 	uint16_t *    destbase = nullptr;
@@ -33,17 +31,17 @@ struct midvunit_object_data
 	uint8_t       dither = 0;
 };
 
-class midvunit_state;
+class midvunit_base_state;
 
 class midvunit_renderer : public poly_manager<float, midvunit_object_data, 2>
 {
 public:
-	midvunit_renderer(midvunit_state &state);
+	midvunit_renderer(midvunit_base_state &state);
 	void process_dma_queue();
 	void make_vertices_inclusive(vertex_t *vert);
 
 private:
-	midvunit_state &m_state;
+	midvunit_base_state &m_state;
 
 	void render_flat(int32_t scanline, const extent_t &extent, const midvunit_object_data &extradata, int threadid);
 	void render_tex(int32_t scanline, const extent_t &extent, const midvunit_object_data &extradata, int threadid);
@@ -51,48 +49,9 @@ private:
 	void render_textransmask(int32_t scanline, const extent_t &extent, const midvunit_object_data &extradata, int threadid);
 };
 
-class midvunit_state : public driver_device
+class midvunit_base_state : public driver_device
 {
 public:
-	midvunit_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_videoram(*this, "videoram", 0x200000, ENDIANNESS_LITTLE),
-		m_textureram(*this, "textureram"),
-		m_screen(*this, "screen"),
-		m_nvram(*this, "nvram"),
-		m_ram_base(*this, "ram_base"),
-		m_fastram_base(*this, "fastram_base"),
-		m_tms32031_control(*this, "32031_control"),
-		m_midvplus_misc(*this, "midvplus_misc"),
-		m_maincpu(*this, "maincpu"),
-		m_watchdog(*this, "watchdog"),
-		m_palette(*this, "palette"),
-		m_adc(*this, "adc"),
-		m_midway_serial_pic2(*this, "serial_pic2"),
-		m_midway_ioasic(*this, "ioasic"),
-		m_ata(*this, "ata"),
-		m_timer(*this, "timer%u", 0U),
-		m_dcs(*this, "dcs"),
-		m_generic_paletteram_32(*this, "paletteram"),
-		m_optional_drivers(*this, "lamp%u", 0U),
-		m_wheel_motor(*this, "wheel"),
-		m_in1(*this, "IN1"),
-		m_dsw(*this, "DSW"),
-		m_motion(*this, "MOTION") { }
-
-	void midvcommon(machine_config &config);
-	void crusnwld(machine_config &config);
-	void midvplus(machine_config &config);
-	void offroadc(machine_config &config);
-	void midvunit(machine_config &config);
-
-	void init_crusnu40();
-	void init_crusnu21();
-	void init_crusnwld();
-	void init_wargods();
-	void init_offroadc();
-	void init_crusnusa();
-
 	uint16_t m_page_control = 0;
 	uint16_t m_dma_data[16]{};
 	uint8_t m_video_changed = 0;
@@ -101,29 +60,107 @@ public:
 	required_shared_ptr<uint32_t> m_textureram;
 	required_device<screen_device> m_screen;
 
-	DECLARE_CUSTOM_INPUT_MEMBER(motion_r);
+protected:
+	midvunit_base_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_videoram(*this, "videoram", 0x200000, ENDIANNESS_LITTLE)
+		, m_textureram(*this, "textureram")
+		, m_screen(*this, "screen")
+		, m_maincpu(*this, "maincpu")
+		, m_watchdog(*this, "watchdog")
+		, m_palette(*this, "palette")
+		, m_timer(*this, "timer%u", 0U)
+		, m_dcs(*this, "dcs")
+		, m_paletteram(*this, "paletteram")
+		, m_ram_base(*this, "ram_base")
+		, m_tms32031_control(*this, "32031_control")
+	{ }
 
-private:
-	optional_shared_ptr<uint32_t> m_nvram;
+	static constexpr XTAL MIDVUNIT_VIDEO_CLOCK = 33.333333_MHz_XTAL;
+
+	virtual void device_post_load() override;
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+	virtual void video_start() override;
+
+	required_device<tms32031_device> m_maincpu;
+	required_device<watchdog_timer_device> m_watchdog;
+	required_device<palette_device> m_palette;
+	required_device_array<timer_device, 2> m_timer;
+	required_device<dcs_audio_device> m_dcs;
+	required_shared_ptr<uint32_t> m_paletteram;
 	required_shared_ptr<uint32_t> m_ram_base;
-	optional_shared_ptr<uint32_t> m_fastram_base;
 	required_shared_ptr<uint32_t> m_tms32031_control;
-	optional_shared_ptr<uint32_t> m_midvplus_misc;
 
 	uint8_t m_cmos_protected = 0;
 	uint16_t m_control_data = 0;
-	uint8_t m_adc_shift = 0;
-	uint16_t m_last_port0 = 0;
-	uint8_t m_shifter_state = 0;
 	double m_timer_rate = 0;
-	uint16_t m_bit_index = 0;
-	int m_lastval = 0;
 	uint32_t *m_generic_speedup = nullptr;
 	uint16_t m_video_regs[16]{};
 	uint8_t m_dma_data_index = 0;
 	emu_timer *m_scanline_timer = nullptr;
 	emu_timer *m_eoi_timer = nullptr;
 	std::unique_ptr<midvunit_renderer> m_poly;
+
+	void cmos_protect_w(uint32_t data);
+	void dma_queue_w(uint32_t data);
+	uint32_t dma_queue_entries_r();
+	uint32_t dma_trigger_r(offs_t offset);
+	void page_control_w(uint32_t data);
+	uint32_t page_control_r();
+	void video_control_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	uint32_t scanline_r();
+	void videoram_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	uint32_t videoram_r(offs_t offset);
+	void paletteram_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	void textureram_w(offs_t offset, uint32_t data);
+	uint32_t textureram_r(offs_t offset);
+	void control_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	void sound_w(uint32_t data);
+	uint32_t tms32031_control_r(offs_t offset);
+	void tms32031_control_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	uint32_t generic_speedup_r(offs_t offset);
+
+	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+	TIMER_CALLBACK_MEMBER(scanline_timer_cb);
+	TIMER_CALLBACK_MEMBER(eoi_timer_cb);
+
+	void midvcommon(machine_config &config);
+};
+
+class midvunit_state : public midvunit_base_state
+{
+public:
+	void midvunit(machine_config &config);
+
+protected:
+	midvunit_state(const machine_config &mconfig, device_type type, const char *tag)
+		: midvunit_base_state(mconfig, type, tag)
+		, m_adc(*this, "adc")
+		, m_nvram(*this, "nvram")
+		, m_optional_drivers(*this, "lamp%u", 0U)
+		, m_wheel_motor(*this, "wheel")
+		, m_in0(*this, "IN0")
+		, m_in1(*this, "IN1")
+		, m_dsw(*this, "DSW")
+	{ }
+
+	virtual void machine_start() override;
+
+	required_device<adc0844_device> m_adc;
+
+	required_shared_ptr<uint32_t> m_nvram;
+
+	output_finder<8> m_optional_drivers;
+	output_finder<> m_wheel_motor;
+	required_ioport m_in0;
+	required_ioport m_in1;
+	required_ioport m_dsw;
+
+	uint8_t m_adc_shift = 0;
+	uint16_t m_last_port0 = 0;
+	uint8_t m_shifter_state = 0;
 	uint8_t m_galil_input_index = 0;
 	uint8_t m_galil_input_length = 0;
 	const char *m_galil_input = nullptr;
@@ -134,75 +171,110 @@ private:
 	uint32_t m_wheel_board_u8_latch = 0;
 	uint8_t m_comm_flags = 0;
 	uint16_t m_comm_data = 0;
-	void midvunit_dma_queue_w(uint32_t data);
-	uint32_t midvunit_dma_queue_entries_r();
-	uint32_t midvunit_dma_trigger_r(offs_t offset);
-	void midvunit_page_control_w(uint32_t data);
-	uint32_t midvunit_page_control_r();
-	void midvunit_video_control_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	uint32_t midvunit_scanline_r();
-	void midvunit_videoram_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	uint32_t midvunit_videoram_r(offs_t offset);
-	void midvunit_paletteram_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void midvunit_textureram_w(offs_t offset, uint32_t data);
-	uint32_t midvunit_textureram_r(offs_t offset);
+
 	uint32_t port0_r();
 	uint32_t adc_r();
 	void adc_w(uint32_t data);
-	void midvunit_cmos_protect_w(uint32_t data);
-	void midvunit_cmos_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	uint32_t midvunit_cmos_r(offs_t offset);
-	void midvunit_control_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	void cmos_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	uint32_t cmos_r(offs_t offset);
+	uint32_t wheel_board_r();
+	void wheel_board_w(uint32_t data);
+	uint32_t intcs_r();
+	uint32_t comcs_r(offs_t offset);
+	void comcs_w(offs_t offset, uint32_t data);
+	void set_input(const char *s);
+
+	uint16_t comm_bus_out();
+	uint16_t comm_bus_in();
+
+	void midvunit_map(address_map &map);
+};
+
+class crusnusa_state : public midvunit_state
+{
+public:
+	crusnusa_state(const machine_config &mconfig, device_type type, const char *tag)
+		: midvunit_state(mconfig, type, tag)
+		, m_motion(*this, "MOTION")
+	{ }
+
+	void init_crusnu40();
+	void init_crusnu21();
+	void init_crusnusa();
+
+	DECLARE_CUSTOM_INPUT_MEMBER(motion_r);
+
+protected:
+	required_ioport m_motion;
+
+	void init_crusnusa_common(offs_t speedup);
+};
+
+class crusnwld_state : public midvunit_state
+{
+public:
+	crusnwld_state(const machine_config &mconfig, device_type type, const char *tag)
+		: midvunit_state(mconfig, type, tag)
+		, m_midway_serial_pic2(*this, "serial_pic2")
+	{ }
+
+	void crusnwld(machine_config &config);
+	void offroadc(machine_config &config);
+
+	void init_crusnwld();
+	void init_offroadc();
+
+protected:
+	virtual void machine_start() override;
+
+	required_device<midway_serial_pic2_device> m_midway_serial_pic2;
+
+	uint16_t m_bit_index = 0;
+
 	void crusnwld_control_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void midvunit_sound_w(uint32_t data);
-	uint32_t tms32031_control_r(offs_t offset);
-	void tms32031_control_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	uint32_t crusnwld_serial_status_r();
 	uint32_t crusnwld_serial_data_r();
 	void crusnwld_serial_data_w(uint32_t data);
 	uint32_t bit_data_r(offs_t offset);
 	void bit_reset_w(uint32_t data);
+	void init_crusnwld_common(offs_t speedup);
+
+	void crusnwld_map(address_map &map);
+	void offroadc_map(address_map &map);
+};
+
+class midvplus_state : public midvunit_base_state
+{
+public:
+	midvplus_state(const machine_config &mconfig, device_type type, const char *tag)
+		: midvunit_base_state(mconfig, type, tag)
+		, m_midway_ioasic(*this, "ioasic")
+		, m_ata(*this, "ata")
+		, m_fastram_base(*this, "fastram_base")
+		, m_midvplus_misc(*this, "midvplus_misc")
+	{ }
+
+	void midvplus(machine_config &config);
+
+	void init_wargods();
+
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+private:
+	required_device<midway_ioasic_device> m_midway_ioasic;
+	required_device<ata_interface_device> m_ata;
+	required_shared_ptr<uint32_t> m_fastram_base;
+	required_shared_ptr<uint32_t> m_midvplus_misc;
+
+	int m_lastval = 0;
+
 	uint32_t midvplus_misc_r(offs_t offset);
 	void midvplus_misc_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	void midvplus_xf1_w(uint8_t data);
-	uint32_t generic_speedup_r(offs_t offset);
-	uint32_t midvunit_wheel_board_r();
-	void midvunit_wheel_board_w(uint32_t data);
-	uint32_t midvunit_intcs_r();
-	uint32_t midvunit_comcs_r(offs_t offset);
-	void midvunit_comcs_w(offs_t offset, uint32_t data);
-	void set_input(const char *s);
-	void init_crusnwld_common(offs_t speedup);
-	void init_crusnusa_common(offs_t speedup);
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-	DECLARE_MACHINE_RESET(midvplus);
-	uint32_t screen_update_midvunit(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	TIMER_CALLBACK_MEMBER(scanline_timer_cb);
-	TIMER_CALLBACK_MEMBER(eoi_timer_cb);
-	required_device<tms32031_device> m_maincpu;
-	required_device<watchdog_timer_device> m_watchdog;
-	required_device<palette_device> m_palette;
-	optional_device<adc0844_device> m_adc;
-	optional_device<midway_serial_pic2_device> m_midway_serial_pic2;
-	optional_device<midway_ioasic_device> m_midway_ioasic;
-	optional_device<ata_interface_device> m_ata;
-	required_device_array<timer_device, 2> m_timer;
-	required_device<dcs_audio_device> m_dcs;
-	required_shared_ptr<uint32_t> m_generic_paletteram_32;
-	output_finder<8> m_optional_drivers;
-	output_finder<> m_wheel_motor;
-	optional_ioport m_in1;
-	optional_ioport m_dsw;
-	optional_ioport m_motion;
-	void postload();
-
-	uint16_t comm_bus_out();
-	uint16_t comm_bus_in();
 
 	void midvplus_map(address_map &map);
-	void midvunit_map(address_map &map);
 };
 
 #endif // MAME_MIDWAY_MIDVUNIT_H


### PR DESCRIPTION

Suppress side effects for debugger reads
Add missing item to save state
Use logmacro.h for logging function
Fix region naming and variable naming
Fix video clock related to PCB docs (33.3333MHz)
Use C++ style comments for single line comments
Constantize variables