### PR TITLE
taito/taito_f3_v.cpp: regain performance after major rewrite

### DIFF
--- a/src/mame/taito/taito_f3.h
+++ b/src/mame/taito/taito_f3.h
@@ -242,10 +242,10 @@ protected:
 	};
 
 	struct mix_pix { // per-pixel information for the blending circuit
-		u16 src_pal{0};
-		u16 dst_pal{0};
-		u8  src_blend{0x00};
-		u8  dst_blend{0xff};
+		u16 src_pal[H_TOTAL];
+		u16 dst_pal[H_TOTAL];
+		u8  src_blend[H_TOTAL];
+		u8  dst_blend[H_TOTAL];
 	};
 
 	struct f3_line_inf;
@@ -337,10 +337,10 @@ protected:
 	};
 
 	struct pri_mode {
-		u8 src_prio{0};
-		u8 dst_prio{0};
-		u8 src_blendmode{0xff};
-		u8 dst_blendmode{0xff};
+		u8 src_prio[H_TOTAL]{};
+		u8 dst_prio[H_TOTAL]{};
+		u8 src_blendmode[H_TOTAL]{};
+		u8 dst_blendmode[H_TOTAL]{};
 	};
 
 	struct f3_line_inf {
@@ -421,12 +421,12 @@ protected:
 	void draw_sprites(const rectangle &cliprect);
 	void get_pf_scroll(int pf_num, fixed8 &reg_sx, fixed8 &reg_sy);
 	void read_line_ram(f3_line_inf &line, int y);
-	void render_line(pen_t *dst, const mix_pix (&z)[432]);
+	void render_line(pen_t *dst, const mix_pix &z);
 	void scanline_draw(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	template<typename Mix>
 	std::vector<clip_plane_inf> calc_clip(const clip_plane_inf (&clip)[NUM_CLIPPLANES], const Mix line);
 	template<typename Mix>
-	bool mix_line(Mix &gfx, mix_pix *z, pri_mode *pri, const f3_line_inf &line, const clip_plane_inf &range);
+	bool mix_line(const Mix &gfx, mix_pix &z, pri_mode &pri, const f3_line_inf &line, const clip_plane_inf &range);
 
 private:
 	optional_device<taito_en_device> m_taito_en;

--- a/src/mame/taito/taito_f3.h
+++ b/src/mame/taito/taito_f3.h
@@ -255,16 +255,17 @@ protected:
 		bool x_sample_enable{false};
 		u16 mix_value{0};
 		u8 prio{0};
+		u8 blend_mode;
 
 		u8 debug_index{0};
 
-		void set_mix(u16 v) { mix_value = v; prio = v & 0xf; }
-		void set_prio(u8 p) { mix_value = (mix_value & 0xfff0) | p; prio = p; }
+		void set_mix(u16 v) { mix_value = v; prio = v & 0xf; blend_mode = BIT(mix_value, 14, 2); };
+		void set_prio(u8 p) { mix_value = (mix_value & 0xfff0) | p; prio = p; };
+		void set_blend(u8 b) { mix_value = (mix_value & 0x3fff) | (b << 14); blend_mode = b; };
 		auto clip_inv() const { return std::bitset<4>(mix_value >> 4); }
 		auto clip_enable() const { return std::bitset<4>(mix_value >> 8); }
 		bool clip_inv_mode() const { return mix_value & 0x1000; }
 		bool layer_enable() const;
-		u8 blend_mask() const { return BIT(mix_value, 14, 2); }
 		bool blend_a() const { return mix_value & 0x4000; }
 		bool blend_b() const { return mix_value & 0x8000; }
 
@@ -328,11 +329,13 @@ protected:
 		fixed8 reg_fx_x{0};
 
 		u16 width_mask{0};
+		u8 (*pf_row_usage)[32]{nullptr};
 
 		u16 palette_adjust(u16 pal) const;
 		int y_index(int y) const;
 		int x_index(int x) const;
 		bool blend_select(const u8 *line_flags, int x) const { return BIT(line_flags[x], 0); }
+		inline bool used(int y) const;
 		static const char *debug_name() { return "PF"; }
 	};
 
@@ -377,6 +380,7 @@ protected:
 	u16 *m_pf_data[8]{};
 	int m_sprite_lag = 0;
 	u8 m_sprite_pri_row_usage[256]{};
+	u8 m_tilemap_row_usage[4][32]{};
 	bitmap_ind8 m_pri_alp_bitmap;
 	bitmap_ind16 m_sprite_framebuffer{};
 	u16 m_width_mask = 0;

--- a/src/mame/taito/taito_f3.h
+++ b/src/mame/taito/taito_f3.h
@@ -257,7 +257,7 @@ protected:
 		u8 prio{0};
 		u8 blend_mode;
 
-		u8 debug_index{0};
+		u8 index{0};
 
 		void set_mix(u16 v) { mix_value = v; prio = v & 0xf; blend_mode = BIT(mix_value, 14, 2); };
 		void set_prio(u8 p) { mix_value = (mix_value & 0xfff0) | p; prio = p; };
@@ -277,7 +277,6 @@ protected:
 		int x_index(int x) const;
 		bool blend_select(const u8 *line_flags, int x) const { return false; }
 
-		bool used(int y) const { return true; }
 		static const char *debug_name() { return "MX"; }
 	};
 
@@ -292,7 +291,6 @@ protected:
 		bool blend_select(const u8 *line_flags, int x) const { return blend_select_v; }
 		bool layer_enable() const;
 
-		bool used(int y) const { return BIT((*sprite_pri_usage)[y], debug_index); }
 		static const char *debug_name() { return "SP"; };
 	};
 
@@ -329,13 +327,11 @@ protected:
 		fixed8 reg_fx_x{0};
 
 		u16 width_mask{0};
-		u8 (*pf_row_usage)[32]{nullptr};
 
 		u16 palette_adjust(u16 pal) const;
 		int y_index(int y) const;
 		int x_index(int x) const;
 		bool blend_select(const u8 *line_flags, int x) const { return BIT(line_flags[x], 0); }
-		inline bool used(int y) const;
 		static const char *debug_name() { return "PF"; }
 	};
 
@@ -379,8 +375,9 @@ protected:
 	bool m_sprite_trails = false;
 	u16 *m_pf_data[8]{};
 	int m_sprite_lag = 0;
+	u8 m_textram_row_usage[64]{};
 	u8 m_sprite_pri_row_usage[256]{};
-	u8 m_tilemap_row_usage[4][32]{};
+	u8 m_tilemap_row_usage[8][32]{};
 	bitmap_ind8 m_pri_alp_bitmap;
 	bitmap_ind16 m_sprite_framebuffer{};
 	u16 m_width_mask = 0;
@@ -428,7 +425,10 @@ protected:
 	void render_line(pen_t *dst, const mix_pix &z);
 	void scanline_draw(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	template<typename Mix>
-	std::vector<clip_plane_inf> calc_clip(const clip_plane_inf (&clip)[NUM_CLIPPLANES], const Mix line);
+	std::vector<clip_plane_inf> calc_clip(const clip_plane_inf (&clip)[NUM_CLIPPLANES], const Mix &layer);
+	inline bool used(const pivot_inf &layer, int y) const;
+	inline bool used(const sprite_inf &layer, int y) const;
+	inline bool used(const playfield_inf &layer, int y) const;
 	template<typename Mix>
 	bool mix_line(const Mix &gfx, mix_pix &z, pri_mode &pri, const f3_line_inf &line, const clip_plane_inf &range);
 

--- a/src/mame/taito/taito_f3.h
+++ b/src/mame/taito/taito_f3.h
@@ -346,7 +346,7 @@ protected:
 	struct f3_line_inf {
 		int y{0};
 		int screen_y{0};
-		pri_mode pri_alp[432]{};
+		pri_mode pri_alp{};
 		// 5000/4000
 		clip_plane_inf clip[NUM_CLIPPLANES];
 		// 6000 - pivot_control, sprite alpha
@@ -385,7 +385,7 @@ protected:
 	std::unique_ptr<tempsprite[]> m_spritelist;
 	const tempsprite *m_sprite_end = nullptr;
 	bool m_sprite_bank = 0;
-	//f3_line_inf m_line_inf;
+	//f3_line_inf m_line_data{};
 	const F3config *m_game_config = nullptr;
 
 	u16 spriteram_r(offs_t offset);

--- a/src/mame/taito/taito_f3.h
+++ b/src/mame/taito/taito_f3.h
@@ -377,7 +377,7 @@ protected:
 	int m_sprite_lag = 0;
 	u8 m_textram_row_usage[64]{};
 	u8 m_sprite_pri_row_usage[256]{};
-	u8 m_tilemap_row_usage[8][32]{};
+	u8 m_tilemap_row_usage[32][8]{};
 	bitmap_ind8 m_pri_alp_bitmap;
 	bitmap_ind16 m_sprite_framebuffer{};
 	u16 m_width_mask = 0;

--- a/src/mame/taito/taito_f3.h
+++ b/src/mame/taito/taito_f3.h
@@ -378,7 +378,7 @@ protected:
 	int m_sprite_lag = 0;
 	u8 m_sprite_pri_row_usage[256]{};
 	bitmap_ind8 m_pri_alp_bitmap;
-	bitmap_ind16 m_sprite_framebuffers[NUM_SPRITEGROUPS]{};
+	bitmap_ind16 m_sprite_framebuffer{};
 	u16 m_width_mask = 0;
 	u8 m_twidth_mask = 0;
 	u8 m_twidth_mask_bit = 0;

--- a/src/mame/taito/taito_f3.h
+++ b/src/mame/taito/taito_f3.h
@@ -276,6 +276,7 @@ protected:
 		int y_index(int y) const;
 		int x_index(int x) const;
 		bool blend_select(const u8 *line_flags, int x) const { return false; }
+		bool inactive_group(u16 color) const { return false; }
 
 		static const char *debug_name() { return "MX"; }
 	};
@@ -290,6 +291,7 @@ protected:
 
 		bool blend_select(const u8 *line_flags, int x) const { return blend_select_v; }
 		bool layer_enable() const;
+		bool inactive_group(u16 color) const { return BIT(color, 10, 2) != index; }
 
 		static const char *debug_name() { return "SP"; };
 	};

--- a/src/mame/taito/taito_f3_v.cpp
+++ b/src/mame/taito/taito_f3_v.cpp
@@ -688,7 +688,7 @@ void taito_f3_state::read_line_ram(f3_line_inf &line, int y)
 		if (const offs_t where = latched_addr(0, i)) {
 			const u16 colscroll = m_line_ram[where];
 			line.pf[i].colscroll   = colscroll & 0x1ff;
-			line.pf[i].alt_tilemap = colscroll & 0x200;
+			line.pf[i].alt_tilemap = !m_extend && colscroll & 0x200;
 			line.clip[2*(i-2) + 0].set_upper(BIT(colscroll, 12), BIT(colscroll, 13));
 			line.clip[2*(i-2) + 1].set_upper(BIT(colscroll, 14), BIT(colscroll, 15));
 		}
@@ -1111,8 +1111,7 @@ inline bool taito_f3_state::used(const sprite_inf &layer, int y) const
 }
 inline bool taito_f3_state::used(const playfield_inf &layer, int y) const
 {
-	// BROKEN
-	const int y_adj = m_flipscreen ? (32*16 - 1) - layer.y_index(y) : layer.y_index(y);
+	const int y_adj = m_flipscreen ? 0x1ff - layer.y_index(y) : layer.y_index(y);
 	return m_tilemap_row_usage[layer.index + (2 * layer.alt_tilemap)][y_adj >> 4] > 0;
 }
 

--- a/src/mame/taito/taito_f3_v.cpp
+++ b/src/mame/taito/taito_f3_v.cpp
@@ -506,7 +506,7 @@ void taito_f3_state::video_start()
 	m_sprite_end = &m_spritelist[0];
 	m_vram_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(taito_f3_state::get_tile_info_text)), TILEMAP_SCAN_ROWS, 8, 8, 64, 64);
 	m_pixel_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(taito_f3_state::get_tile_info_pixel)), TILEMAP_SCAN_COLS, 8, 8, 64, 32);
-	std::fill_n(m_textram_row_usage, 32, 0);
+	std::fill_n(m_textram_row_usage, 64, 0);
 
 	m_screen->register_screen_bitmap(m_sprite_framebuffer);
 
@@ -1111,6 +1111,7 @@ inline bool taito_f3_state::used(const sprite_inf &layer, int y) const
 }
 inline bool taito_f3_state::used(const playfield_inf &layer, int y) const
 {
+	// BROKEN
 	const int y_adj = m_flipscreen ? (32*16 - 1) - layer.y_index(y) : layer.y_index(y);
 	return m_tilemap_row_usage[layer.index + (2 * layer.alt_tilemap)][y_adj >> 4] > 0;
 }

--- a/src/mame/taito/taito_f3_v.cpp
+++ b/src/mame/taito/taito_f3_v.cpp
@@ -1044,14 +1044,17 @@ void taito_f3_state::render_line(pen_t *RESTRICT dst, const mix_pix &z)
 	for (int x = H_START; x < H_START + H_VIS; x++) {
 		rgb_t s_rgb = clut[z.src_pal[x]];
 		rgb_t d_rgb = clut[z.dst_pal[x]];
+
+		// source_color * src_blend + dest_color * dst_blend
+		// by the way, any time i touch this code i lose 10-20% speed. - ywy
 		u16 r1 = s_rgb.r();
 		u16 g1 = s_rgb.g();
 		u16 b1 = s_rgb.b();
 		u16 r2 = d_rgb.r();
 		u16 g2 = d_rgb.g();
 		u16 b2 = d_rgb.b();
-		r1 *= z.src_blend[x];
-		g1 *= z.src_blend[x];
+		r1 *= z.src_blend[x]; // these blend contributions have fixed3 precision
+		g1 *= z.src_blend[x]; // i.e. 0 (b0'000) to 8 (b1'000) represents 0.0 to 1.0
 		b1 *= z.src_blend[x];
 		r2 *= z.dst_blend[x];
 		g2 *= z.dst_blend[x];
@@ -1059,12 +1062,13 @@ void taito_f3_state::render_line(pen_t *RESTRICT dst, const mix_pix &z)
 		r1 += r2;
 		g1 += g2;
 		b1 += b2;
+
 		r1 >>= 3;
 		g1 >>= 3;
 		b1 >>= 3;
-		r1 = std::min(r1, (u16)255);
-		g1 = std::min(g1, (u16)255);
-		b1 = std::min(b1, (u16)255);
+		r1 = std::min(r1, static_cast<u16>(255));
+		g1 = std::min(g1, static_cast<u16>(255));
+		b1 = std::min(b1, static_cast<u16>(255));
 
 		dst[x] = rgb_t(r1, g1, b1);
 	}

--- a/src/mame/taito/taito_f3_v.cpp
+++ b/src/mame/taito/taito_f3_v.cpp
@@ -1110,9 +1110,9 @@ void taito_f3_state::render_line(pen_t *RESTRICT dst, const mix_pix &z)
 		r1 >>= 3;
 		g1 >>= 3;
 		b1 >>= 3;
-		r1 = std::min(r1, static_cast<u16>(255));
-		g1 = std::min(g1, static_cast<u16>(255));
-		b1 = std::min(b1, static_cast<u16>(255));
+		r1 = std::min<u16>(r1, 255);
+		g1 = std::min<u16>(g1, 255);
+		b1 = std::min<u16>(b1, 255);
 
 		dst[x] = rgb_t(r1, g1, b1);
 	}

--- a/src/mame/taito/taito_f3_v.cpp
+++ b/src/mame/taito/taito_f3_v.cpp
@@ -1185,7 +1185,7 @@ void taito_f3_state::scanline_draw(bitmap_rgb32 &bitmap, const rectangle &clipre
 		pri_mode line_pri{};
 		// background palette -- what contributions should this default to?
 		std::fill_n(line_buf.dst_pal, H_TOTAL, line_data.bg_palette);
-		std::fill_n(line_buf.dst_blend, H_TOTAL, 0xff);
+		std::fill_n(line_buf.dst_blend, H_TOTAL, 8); // 100%
 		// set an invalid blend mode as it affects mixing
 		std::fill_n(line_pri.src_blendmode, H_TOTAL, 0xff);
 		std::fill_n(line_pri.dst_blendmode, H_TOTAL, 0xff);

--- a/src/mame/taito/taito_f3_v.cpp
+++ b/src/mame/taito/taito_f3_v.cpp
@@ -470,6 +470,7 @@ void taito_f3_state::create_tilemaps(bool extend)
 	for (int i = 0; i < 8; i++) {
 		if (m_tilemap[i])
 			m_tilemap[i]->set_transparent_pen(0);
+		std::fill_n(m_tilemap_row_usage[i], 32, 0);
 	}
 
 	if (m_extend) {
@@ -505,6 +506,7 @@ void taito_f3_state::video_start()
 	m_sprite_end = &m_spritelist[0];
 	m_vram_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(taito_f3_state::get_tile_info_text)), TILEMAP_SCAN_ROWS, 8, 8, 64, 64);
 	m_pixel_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(taito_f3_state::get_tile_info_pixel)), TILEMAP_SCAN_COLS, 8, 8, 64, 32);
+	std::fill_n(m_textram_row_usage, 32, 0);
 
 	m_screen->register_screen_bitmap(m_sprite_framebuffer);
 
@@ -519,11 +521,6 @@ void taito_f3_state::video_start()
 	m_sprite_bank = false;
 	m_sprite_trails = false;
 	memset(&m_spriteram[0], 0, 0x10000);
-
-	std::fill_n(m_tilemap_row_usage[0], 32, 0);
-	std::fill_n(m_tilemap_row_usage[1], 32, 0);
-	std::fill_n(m_tilemap_row_usage[2], 32, 0);
-	std::fill_n(m_tilemap_row_usage[3], 32, 0);
 
 	save_item(NAME(m_control_0));
 	save_item(NAME(m_control_1));
@@ -548,8 +545,7 @@ void taito_f3_state::pf_ram_w(offs_t offset, u16 data, u16 mem_mask)
 	if (offset & 1 && offset < 0x4000) {
 		const int row  = m_extend ? BIT(offset, 7, 5) : BIT(offset, 6, 5);
 		const u16 prev_tile = m_pf_ram[offset];
-		int tmap = m_extend ? offset >> 12 : offset >> 11;
-		if (tmap >= 4) tmap -= 2;
+		const int tmap = m_extend ? offset >> 12 : offset >> 11;
 
 		if (prev_tile == 0 && data != 0)
 			m_tilemap_row_usage[tmap][row] += 1;
@@ -596,6 +592,13 @@ u16 taito_f3_state::textram_r(offs_t offset)
 
 void taito_f3_state::textram_w(offs_t offset, u16 data, u16 mem_mask)
 {
+	const int row  = BIT(offset, 6, 6);
+	const u16 prev_tile = m_textram[offset];
+	if (prev_tile == 0 && data != 0)
+		m_textram_row_usage[row] += 1;
+	else if (prev_tile != 0 && data == 0)
+		m_textram_row_usage[row] -= 1;
+
 	COMBINE_DATA(&m_textram[offset]);
 
 	m_vram_layer->mark_tile_dirty(offset);
@@ -871,14 +874,14 @@ template<typename Mix>
 std::vector<taito_f3_state::clip_plane_inf>
 taito_f3_state::calc_clip(
 		const clip_plane_inf (&clip)[NUM_CLIPPLANES],
-		const Mix line)
+		const Mix &layer)
 {
 	constexpr s16 INF_L = H_START;
 	constexpr s16 INF_R = H_START + H_VIS;
 
-	std::bitset<4> normal_planes = line->clip_enable() & ~line->clip_inv();
-	std::bitset<4> invert_planes = line->clip_enable() & line->clip_inv();
-	if (!line->clip_inv_mode())
+	std::bitset<4> normal_planes = layer.clip_enable() & ~layer.clip_inv();
+	std::bitset<4> invert_planes = layer.clip_enable() & layer.clip_inv();
+	if (!layer.clip_inv_mode())
 		std::swap(normal_planes, invert_planes);
 
 	// start with a visible region spanning the entire space
@@ -963,10 +966,6 @@ inline int taito_f3_state::playfield_inf::y_index(int y) const
 {
 	return ((reg_fx_y >> 8) + colscroll) & 0x1ff;
 }
-inline bool taito_f3_state::playfield_inf::used(int y) const
-{
-	return (*pf_row_usage)[y_index(y) / 16] > 0;
-}
 inline int taito_f3_state::pivot_inf::x_index(int x) const
 {
 	return (x + reg_sx) & 0x1FF;
@@ -990,8 +989,8 @@ bool taito_f3_state::mix_line(const Mix &gfx, mix_pix &z, pri_mode &pri, const f
 		const int real_x = gfx.x_sample_enable ? mosaic(x, line.x_sample) : x;
 		const int gfx_x = gfx.x_index(real_x);
 
-		if constexpr (std::is_same_v<Mix, sprite_inf*>) {
-			if (BIT(src[gfx_x], 10, 2) != gfx.debug_index)
+		if constexpr (std::is_same_v<Mix, sprite_inf>) {
+			if (BIT(src[gfx_x], 10, 2) != gfx.index)
 				continue;
 		}
 
@@ -1001,7 +1000,8 @@ bool taito_f3_state::mix_line(const Mix &gfx, mix_pix &z, pri_mode &pri, const f
 
 		if (gfx.prio > pri.src_prio[x]) {
 			// submit src pix
-			if (const u16 pal = gfx.palette_adjust(src[gfx_x])) {
+			if (const u16 c = src[gfx_x]) {
+				const u16 pal = gfx.palette_adjust(c);
 				// could be pulled out of loop for pivot and sprite
 				u8 sel = gfx.blend_select(flags, gfx_x);
 
@@ -1030,7 +1030,8 @@ bool taito_f3_state::mix_line(const Mix &gfx, mix_pix &z, pri_mode &pri, const f
 			}
 		} else if (gfx.prio >= pri.dst_prio[x]) {
 			// submit dest pix
-			if (const u16 pal = gfx.palette_adjust(src[gfx_x])) {
+			if (const u16 c = src[gfx_x]) {
+				const u16 pal = gfx.palette_adjust(c);
 				if (gfx.prio != pri.dst_prio[x])
 					z.dst_pal[x] = pal;
 				else // prio conflict = color line conflict? (dariusg, bubblem)
@@ -1053,7 +1054,7 @@ bool taito_f3_state::mix_line(const Mix &gfx, mix_pix &z, pri_mode &pri, const f
 	constexpr int DEBUG_Y = 180 + V_START;
 	if (TAITOF3_VIDEO_DEBUG && line.y == DEBUG_Y) {
 		logerror("[%X] %s%d: %d,%d (%d)\n   {pal: %x/%x, blend: %x/%x, prio: %x/%x}\n",
-				 gfx.prio, gfx.debug_name(), gfx.debug_index,
+				 gfx.prio, gfx.debug_name(), gfx.index,
 				 gfx.blend_b(), gfx.blend_a(), gfx.blend_select(flags, 82),
 				 z.src_pal[DEBUG_X], z.dst_pal[DEBUG_X],
 				 z.src_blend[DEBUG_X], z.dst_blend[DEBUG_X],
@@ -1099,6 +1100,21 @@ void taito_f3_state::render_line(pen_t *RESTRICT dst, const mix_pix &z)
 	}
 }
 
+
+inline bool taito_f3_state::used(const pivot_inf &layer, int y) const
+{
+	return layer.use_pix() || (m_textram_row_usage[layer.y_index(y) >> 3] > 0);
+}
+inline bool taito_f3_state::used(const sprite_inf &layer, int y) const
+{
+	return m_sprite_pri_row_usage[y] & (1 << layer.index);
+}
+inline bool taito_f3_state::used(const playfield_inf &layer, int y) const
+{
+	const int y_adj = m_flipscreen ? (32*16 - 1) - layer.y_index(y) : layer.y_index(y);
+	return m_tilemap_row_usage[layer.index + (2 * layer.alt_tilemap)][y_adj >> 4] > 0;
+}
+
 void taito_f3_state::scanline_draw(bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	auto prio = [] (const auto &obj) -> u8 { return obj->prio; };
@@ -1107,16 +1123,14 @@ void taito_f3_state::scanline_draw(bitmap_rgb32 &bitmap, const rectangle &clipre
 	f3_line_inf line_data{};
 	for (int i=0; i < NUM_SPRITEGROUPS; i++) {
 		line_data.sp[i].bitmap = draw_source(&m_sprite_framebuffer);
-		line_data.sp[i].sprite_pri_usage = &m_sprite_pri_row_usage;
-		line_data.sp[i].debug_index = i;
+		line_data.sp[i].index = i;
 	}
 	for (int pf = 0; pf < NUM_PLAYFIELDS; ++pf) {
 		get_pf_scroll(pf, line_data.pf[pf].reg_sx, line_data.pf[pf].reg_sy);
 
 		line_data.pf[pf].reg_fx_y = line_data.pf[pf].reg_sy;
 		line_data.pf[pf].width_mask = m_width_mask;
-		line_data.pf[pf].pf_row_usage = &m_tilemap_row_usage[pf];
-		line_data.pf[pf].debug_index = pf;
+		line_data.pf[pf].index = pf;
 	}
 	if (m_flipscreen) {
 		line_data.pivot.reg_sx = m_control_1[4] - 12;
@@ -1177,10 +1191,11 @@ void taito_f3_state::scanline_draw(bitmap_rgb32 &bitmap, const rectangle &clipre
 			for (auto gfx : layers) {
 				std::visit(
 						[this, &line_data, &line_buf, &line_pri] (auto &&arg) {
-							if (arg->layer_enable() && arg->used(line_data.y)) {
-								const auto clip_ranges = calc_clip(line_data.clip, arg);
+							const auto &layer = *arg;
+							if (layer.layer_enable() && used(layer, line_data.y)) {
+								const auto clip_ranges = calc_clip(line_data.clip, layer);
 								for (const auto &clip : clip_ranges) {
-									mix_line(*arg, line_buf, line_pri, line_data, clip);
+									mix_line(layer, line_buf, line_pri, line_data, clip);
 								}
 							}
 						},

--- a/src/mame/taito/taito_f3_v.cpp
+++ b/src/mame/taito/taito_f3_v.cpp
@@ -1121,7 +1121,8 @@ void taito_f3_state::render_line(pen_t *RESTRICT dst, const mix_pix &z)
 
 inline bool taito_f3_state::used(const pivot_inf &layer, int y) const
 {
-	return layer.use_pix() || (m_textram_row_usage[layer.y_index(y) >> 3] > 0);
+	const int y_adj = m_flipscreen ? 0x1ff - layer.y_index(y) : layer.y_index(y);
+	return layer.use_pix() || (m_textram_row_usage[y_adj >> 3] > 0);
 }
 inline bool taito_f3_state::used(const sprite_inf &layer, int y) const
 {


### PR DESCRIPTION
addresses my own concerns with #11811 speed regression against previous implementation.

 * switch AoS z buffers and per-pix blend info to SoA
 * allow vectorization of line blending operation
 * regains empty line optimization by tracking tilemap row usage
 * consolidate sprite framebuffers (we still pull from it multiple times for each sprite priority group)
 * other minor wins from safe logic reorderings