### PR TITLE
galaxian/galaxian.cpp: 'bongoa' dip switches are memory mapped

### DIFF
--- a/src/mame/galaxian/galaxian.cpp
+++ b/src/mame/galaxian/galaxian.cpp
@@ -1913,6 +1913,12 @@ void galaxian_state::bongo_map(address_map &map)
 	map(0xb800, 0xb800).mirror(0x7ff).nopw(); // written once at start
 }
 
+void galaxian_state::bongoa_map(address_map &map)
+{
+	bongo_map(map);
+	map(0xb000, 0xb000).mirror(0x07ff).portr("DSW");
+}
+
 void galaxian_state::bongo_io_map(address_map &map)
 {
 	map.global_mask(0xff);
@@ -7784,6 +7790,15 @@ void galaxian_state::bongo(machine_config &config)
 	AY8910(config, m_ay8910[0], GALAXIAN_PIXEL_CLOCK/3/4);
 	m_ay8910[0]->port_a_read_callback().set_ioport("DSW");
 	m_ay8910[0]->add_route(ALL_OUTPUTS, "speaker", 0.5);
+}
+
+void galaxian_state::bongoa(machine_config &config)
+{
+	bongo(config);
+
+	// dip switches are read via the memory map instead of the AY8910
+	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::bongoa_map);
+	m_ay8910[0]->port_a_read_callback().set_constant(0xff);
 }
 
 void bmxstunts_state::bmxstunts(machine_config &config)
@@ -16542,7 +16557,7 @@ GAME( 1980, galactica2,  moonal2,  mooncrst,   moonal2,    galaxian_state, init_
 // Larger romspace, interrupt enable moved
 GAME( 198?, thepitm,     thepit,   thepitm,    thepitm,    galaxian_state, init_mooncrsu,   ROT90,  "bootleg (KZH)", "The Pit (bootleg on Moon Quasar hardware)", MACHINE_SUPPORTS_SAVE ) // on an original MQ-2FJ PCB, even if the memory map appears closer to Moon Cresta
 GAME( 1983, bongo,       0,        bongo,      bongo,      galaxian_state, init_kong,       ROT90,  "Jetsoft",       "Bongo (set 1)",                             MACHINE_SUPPORTS_SAVE )
-GAME( 1983, bongoa,      bongo,    bongo,      bongo,      galaxian_state, init_kong,       ROT90,  "Jetsoft",       "Bongo (set 2)",                             MACHINE_SUPPORTS_SAVE ) // on an original Namco PCB
+GAME( 1983, bongoa,      bongo,    bongoa,     bongo,      galaxian_state, init_kong,       ROT90,  "Jetsoft",       "Bongo (set 2)",                             MACHINE_SUPPORTS_SAVE ) // on an original Namco PCB
 
 
 // Crazy Kong & Bagman bootlegs on galaxian/mooncrst hardware

--- a/src/mame/galaxian/galaxian.h
+++ b/src/mame/galaxian/galaxian.h
@@ -311,6 +311,7 @@ public:
 	void thepitm(machine_config &config);
 	void kong(machine_config &config);
 	void bongo(machine_config &config);
+	void bongoa(machine_config &config);
 	void scorpnmc(machine_config &config);
 	void ckongg(machine_config &config);
 	void ckongmc(machine_config &config);
@@ -339,6 +340,7 @@ protected:
 	void astroamb_map(address_map &map);
 	void bigkonggx_map(address_map &map);
 	void bongo_map(address_map &map);
+	void bongoa_map(address_map &map);
 	void bongo_io_map(address_map &map);
 	void checkmaj_sound_map(address_map &map);
 	void checkman_sound_map(address_map &map);


### PR DESCRIPTION
Compared to the parent set, `bongoa` ignores the AY input ports and reads dip switches from a memory-mapped port.

This set also hacks out the code which initializes the AY port direction bits (compare code at $2288 in both sets), which means the 'noise enable' bits are never initialized either, leaving the noise generator enabled on all three channels. Is that actually what's supposed to happen or should the noise output be disabled by default instead?