### PR TITLE
Add a skeleton driver for Cubieboard4 (CC A-80) single board computer

### DIFF
--- a/hash/cubieboard4.xml
+++ b/hash/cubieboard4.xml
@@ -23,7 +23,7 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 		</part>
 	</software>
 
-	<software name="cb4_linarodstcrd">
+	<software name="cb4_linardstcrd">
 		<description>Linaro desktop for Cubieboard4 (v1.0)</description>
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
@@ -35,7 +35,7 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 		</part>
 	</software>
 
-	<software name="cb4_linarosvrcrdh">
+	<software name="cb4_linarsvrcrdh">
 		<description>Linaro server for Cubieboard4 (v2.0, HDMI)</description>
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
@@ -47,7 +47,7 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 		</part>
 	</software>
 
-	<software name="cb4_linarosvrcrdv">
+	<software name="cb4_linarsvrcrdv">
 		<description>Linaro server for Cubieboard4 (v2.0, VGA)</description>
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>

--- a/hash/cubieboard4.xml
+++ b/hash/cubieboard4.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<!--
+license:CC0-1.0
+
+Software list for Cubieboard4 (CC A-20) external SD card slot.
+
+-->
+
+<softwarelist name="cubieboard4" description="Cubieboard4 software (for external SD card)">
+
+	<!-- "Official" images from cubieboard.org -->
+
+	<software name="cb4_debiansvrcrd">
+		<description>Debian server for Cubieboard4 (v1.0)</description>
+		<year>20??</year>
+		<publisher>cubieboard.org</publisher>
+		<part name="image" interface="cubieboard4_sdcard">
+			<diskarea name="image">
+				<feature name="video" value="hdmi" />
+				<disk name="cb4-debian-server-hdmi-card-v1.0" sha1="3e98a28e72c913afa5883e040731e17b5f90aad2" writeable="yes" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="cb4_linarodstcrd">
+		<description>Linaro desktop for Cubieboard4 (v1.0)</description>
+		<year>20??</year>
+		<publisher>cubieboard.org</publisher>
+		<part name="image" interface="cubieboard4_sdcard">
+			<diskarea name="image">
+				<feature name="video" value="hdmi" />
+				<disk name="linaro-desktop-cb4-card-hdmi-v1.0" sha1="db646cd4191c3dbbf72764846d6ae5ef32687554" writeable="yes" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="cb4_linarosvrcrdh">
+		<description>Linaro server for Cubieboard4 (v2.0, HDMI)</description>
+		<year>20??</year>
+		<publisher>cubieboard.org</publisher>
+		<part name="image" interface="cubieboard4_sdcard">
+			<diskarea name="image">
+				<feature name="video" value="hdmi" />
+				<disk name="linaro-server-cb4-card-hdmi-v2.0" sha1="18a3ca934b3536209bdece46fcdfc3de97135c5b" writeable="yes" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="cb4_linarosvrcrdv">
+		<description>Linaro server for Cubieboard4 (v2.0, VGA)</description>
+		<year>20??</year>
+		<publisher>cubieboard.org</publisher>
+		<part name="image" interface="cubieboard4_sdcard">
+			<diskarea name="image">
+				<feature name="video" value="vga" />
+				<disk name="linaro-server-cb4-card-vga-v2.0" sha1="df8fd2c8178420a77e14b0be5197eeafe7bf96de" writeable="yes" />
+			</diskarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/hash/cubieboard4.xml
+++ b/hash/cubieboard4.xml
@@ -16,8 +16,8 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
 		<part name="image" interface="cubieboard4_sdcard">
+			<feature name="video" value="hdmi" />
 			<diskarea name="image">
-				<feature name="video" value="hdmi" />
 				<disk name="cb4-debian-server-hdmi-card-v1.0" sha1="3e98a28e72c913afa5883e040731e17b5f90aad2" writeable="yes" />
 			</diskarea>
 		</part>

--- a/hash/cubieboard4.xml
+++ b/hash/cubieboard4.xml
@@ -7,54 +7,104 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 
 -->
 
-<softwarelist name="cubieboard4" description="Cubieboard4 software (for external SD card)">
+<softwarelist name="cubieboard4" description="Cubieboard4 software">
 
-	<!-- "Official" images from cubieboard.org -->
+	<!-- "Official" images from cubieboard.org for the MicroSD card -->
 
 	<software name="cb4_debiansvrcrd">
-		<description>Debian server for Cubieboard4 (v1.0)</description>
+		<description>Debian server for Cubieboard4 (v1.0, MicroSD card)</description>
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
-		<part name="image" interface="cubieboard4_sdcard">
-			<feature name="video" value="hdmi" />
+		<part name="image" interface="sdcard">
 			<diskarea name="image">
+				<feature name="video" value="hdmi" />
 				<disk name="cb4-debian-server-hdmi-card-v1.0" sha1="3e98a28e72c913afa5883e040731e17b5f90aad2" writeable="yes" />
 			</diskarea>
 		</part>
 	</software>
 
-	<software name="cb4_linardstcrd">
-		<description>Linaro desktop for Cubieboard4 (v1.0)</description>
+	<software name="cb4_linardstcrdh">
+		<description>Linaro desktop for Cubieboard4 (v1.0, HDMI, MicroSD card)</description>
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
-		<part name="image" interface="cubieboard4_sdcard">
-			<feature name="video" value="hdmi" />
+		<part name="image" interface="sdcard">
 			<diskarea name="image">
+				<feature name="video" value="hdmi" />
 				<disk name="linaro-desktop-cb4-card-hdmi-v1.0" sha1="db646cd4191c3dbbf72764846d6ae5ef32687554" writeable="yes" />
 			</diskarea>
 		</part>
 	</software>
 
 	<software name="cb4_linarsvrcrdh">
-		<description>Linaro server for Cubieboard4 (v2.0, HDMI)</description>
+		<description>Linaro server for Cubieboard4 (v2.0, HDMI, MicroSD card)</description>
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
-		<part name="image" interface="cubieboard4_sdcard">
-			<feature name="video" value="hdmi" />
+		<part name="image" interface="sdcard">
 			<diskarea name="image">
+				<feature name="video" value="hdmi" />
 				<disk name="linaro-server-cb4-card-hdmi-v2.0" sha1="18a3ca934b3536209bdece46fcdfc3de97135c5b" writeable="yes" />
 			</diskarea>
 		</part>
 	</software>
 
 	<software name="cb4_linarsvrcrdv">
-		<description>Linaro server for Cubieboard4 (v2.0, VGA)</description>
+		<description>Linaro server for Cubieboard4 (v2.0, VGA, MicroSD card)</description>
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
-		<part name="image" interface="cubieboard4_sdcard">
-			<feature name="video" value="vga" />
+		<part name="image" interface="sdcard">
 			<diskarea name="image">
+				<feature name="video" value="vga" />
 				<disk name="linaro-server-cb4-card-vga-v2.0" sha1="df8fd2c8178420a77e14b0be5197eeafe7bf96de" writeable="yes" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- "Official" images from cubieboard.org for the internal eMMC -->
+
+	<software name="cb4_android41mmc">
+		<description>Android 4.1.20161119 for Cubieboard4 (v4.4, internal eMMC)</description>
+		<year>20??</year>
+		<publisher>cubieboard.org</publisher>
+		<part name="image" interface="emmc">
+			<diskarea name="image">
+				<feature name="video" value="hdmi" />
+				<disk name="android4.4-cb4-emmc-v4.1.20161119" sha1="ccf854e17936e3c57a1701f9edb3c63b704d4d59" writeable="yes" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="cb4_android43mmc">
+		<description>Android 4.3.20170717 for Cubieboard4 (v4.4, internal eMMC)</description>
+		<year>20??</year>
+		<publisher>cubieboard.org</publisher>
+		<part name="image" interface="emmc">
+			<diskarea name="image">
+				<feature name="video" value="hdmi" />
+				<disk name="android4.4-cb4-emmc-v4.3.20170717" sha1="bb386ce76686698ad7f25b0469970c58abf4745e" writeable="yes" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="cb4_debiansvrmmc">
+		<description>Debian server for Cubieboard4 (v1.0, internal eMMC)</description>
+		<year>20??</year>
+		<publisher>cubieboard.org</publisher>
+		<part name="image" interface="emmc">
+			<diskarea name="image">
+				<feature name="video" value="hdmi" />
+				<disk name="cb4-debian-server-hdmi-emmc-v1.0" sha1="31db5866016cfd6f1be331c70859cdb27022a7aa" writeable="yes" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="cb4_linardstmmeh">
+		<description>Linaro desktop for Cubieboard4 (v1.1, HDMI, internal eMMC)</description>
+		<year>20??</year>
+		<publisher>cubieboard.org</publisher>
+		<part name="image" interface="emmc">
+			<diskarea name="image">
+				<feature name="video" value="hdmi" />
+				<disk name="linaro-desktop-cb4-emmc-hdmi-v1.1" sha1="249095e6faaee11e330eaf59285c2e68d0b5a30f" writeable="yes" />
 			</diskarea>
 		</part>
 	</software>

--- a/hash/cubieboard4.xml
+++ b/hash/cubieboard4.xml
@@ -16,8 +16,8 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
 		<part name="image" interface="sdcard">
+			<feature name="video" value="hdmi" />
 			<diskarea name="image">
-				<feature name="video" value="hdmi" />
 				<disk name="cb4-debian-server-hdmi-card-v1.0" sha1="3e98a28e72c913afa5883e040731e17b5f90aad2" writeable="yes" />
 			</diskarea>
 		</part>
@@ -28,8 +28,8 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
 		<part name="image" interface="sdcard">
+			<feature name="video" value="hdmi" />
 			<diskarea name="image">
-				<feature name="video" value="hdmi" />
 				<disk name="linaro-desktop-cb4-card-hdmi-v1.0" sha1="db646cd4191c3dbbf72764846d6ae5ef32687554" writeable="yes" />
 			</diskarea>
 		</part>
@@ -40,8 +40,8 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
 		<part name="image" interface="sdcard">
+			<feature name="video" value="hdmi" />
 			<diskarea name="image">
-				<feature name="video" value="hdmi" />
 				<disk name="linaro-server-cb4-card-hdmi-v2.0" sha1="18a3ca934b3536209bdece46fcdfc3de97135c5b" writeable="yes" />
 			</diskarea>
 		</part>
@@ -52,8 +52,8 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
 		<part name="image" interface="sdcard">
+			<feature name="video" value="vga" />
 			<diskarea name="image">
-				<feature name="video" value="vga" />
 				<disk name="linaro-server-cb4-card-vga-v2.0" sha1="df8fd2c8178420a77e14b0be5197eeafe7bf96de" writeable="yes" />
 			</diskarea>
 		</part>
@@ -67,7 +67,6 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 		<publisher>cubieboard.org</publisher>
 		<part name="image" interface="emmc">
 			<diskarea name="image">
-				<feature name="video" value="hdmi" />
 				<disk name="android4.4-cb4-emmc-v4.1.20161119" sha1="ccf854e17936e3c57a1701f9edb3c63b704d4d59" writeable="yes" />
 			</diskarea>
 		</part>
@@ -79,7 +78,6 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 		<publisher>cubieboard.org</publisher>
 		<part name="image" interface="emmc">
 			<diskarea name="image">
-				<feature name="video" value="hdmi" />
 				<disk name="android4.4-cb4-emmc-v4.3.20170717" sha1="bb386ce76686698ad7f25b0469970c58abf4745e" writeable="yes" />
 			</diskarea>
 		</part>
@@ -90,8 +88,8 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
 		<part name="image" interface="emmc">
+			<feature name="video" value="hdmi" />
 			<diskarea name="image">
-				<feature name="video" value="hdmi" />
 				<disk name="cb4-debian-server-hdmi-emmc-v1.0" sha1="31db5866016cfd6f1be331c70859cdb27022a7aa" writeable="yes" />
 			</diskarea>
 		</part>
@@ -102,8 +100,8 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
 		<part name="image" interface="emmc">
+			<feature name="video" value="hdmi" />
 			<diskarea name="image">
-				<feature name="video" value="hdmi" />
 				<disk name="linaro-desktop-cb4-emmc-hdmi-v1.1" sha1="249095e6faaee11e330eaf59285c2e68d0b5a30f" writeable="yes" />
 			</diskarea>
 		</part>

--- a/hash/cubieboard4.xml
+++ b/hash/cubieboard4.xml
@@ -28,8 +28,8 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
 		<part name="image" interface="cubieboard4_sdcard">
+			<feature name="video" value="hdmi" />
 			<diskarea name="image">
-				<feature name="video" value="hdmi" />
 				<disk name="linaro-desktop-cb4-card-hdmi-v1.0" sha1="db646cd4191c3dbbf72764846d6ae5ef32687554" writeable="yes" />
 			</diskarea>
 		</part>
@@ -40,8 +40,8 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
 		<part name="image" interface="cubieboard4_sdcard">
+			<feature name="video" value="hdmi" />
 			<diskarea name="image">
-				<feature name="video" value="hdmi" />
 				<disk name="linaro-server-cb4-card-hdmi-v2.0" sha1="18a3ca934b3536209bdece46fcdfc3de97135c5b" writeable="yes" />
 			</diskarea>
 		</part>
@@ -52,8 +52,8 @@ Software list for Cubieboard4 (CC A-20) external SD card slot.
 		<year>20??</year>
 		<publisher>cubieboard.org</publisher>
 		<part name="image" interface="cubieboard4_sdcard">
+			<feature name="video" value="vga" />
 			<diskarea name="image">
-				<feature name="video" value="vga" />
 				<disk name="linaro-server-cb4-card-vga-v2.0" sha1="df8fd2c8178420a77e14b0be5197eeafe7bf96de" writeable="yes" />
 			</diskarea>
 		</part>

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -41701,6 +41701,9 @@ cp1                             //
 @source:skeleton/ct909e_segadvd.cpp
 megatrix
 
+@source:skeleton/cubieboard4.cpp
+monkeyjmp                       // (c) 20?? Falgas
+
 @source:skeleton/cxhumax.cpp
 hxhdci2k                        //
 

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -41706,6 +41706,7 @@ cb4_android41                   //
 cb4_android43                   //
 cb4_debiansvr                   //
 cb4_linarodst                   //
+cubieboard4                     //
 monkeyjmp                       // (c) 20?? Falgas
 
 @source:skeleton/cxhumax.cpp

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -41702,6 +41702,10 @@ cp1                             //
 megatrix
 
 @source:skeleton/cubieboard4.cpp
+cb4_android41                   //
+cb4_android43                   //
+cb4_debiansvr                   //
+cb4_linarodst                   //
 monkeyjmp                       // (c) 20?? Falgas
 
 @source:skeleton/cxhumax.cpp

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -41702,10 +41702,6 @@ cp1                             //
 megatrix
 
 @source:skeleton/cubieboard4.cpp
-cb4_android41                   //
-cb4_android43                   //
-cb4_debiansvr                   //
-cb4_linarodst                   //
 cubieboard4                     //
 monkeyjmp                       // (c) 20?? Falgas
 

--- a/src/mame/skeleton/cubieboard4.cpp
+++ b/src/mame/skeleton/cubieboard4.cpp
@@ -1,0 +1,79 @@
+// license:BSD-3-Clause
+// copyright-holders:
+/***********************************************************************************************
+
+Skeleton driver for "Cubieboard4" (CC A-80) and arcade games based on it.
+
+Cubieboard4, also named CC-A80, is a open source mini PC or single board computer.
+The main chipset Allwinner A80 is a 28nm Octa-Core A15/A7 big.LITTLE architecture application processor
+with a CPU dominant frequency of 2GHz. It also has the GPU 64-core GPU graphics core PowerVR G6230 which
+supports openGL ES, OpenGL, and OpenCL.
+CC-A80 has the standard interfaces like desktop computer, such as HDMI & VGA, 100M/1000M RJ45, 4 USB2.0
+host ports, 1 USB3.0 OTG port, audio output, microphone input, dual-band wifi and bluetooth 4.0, micro SD
+card. It has 2GB DDR3 on-board memory and support Li-Po battery UPS powerinput.
+
+Main Cubieboard4 components:
+-Allwinner A80.
+-Realtek RTL8211E integrated Ethernet transceiver.
+-AMPAK Technology AP6330 WiFi + Bluetooth 4.0(HS) + FM Rx Module.
+-SKhynix KLM4G1YEMD-B031 (embedded MultiMediaCard Ver. 5.0 compatible, soldered to the back side of the PCB).
+-4 x H5TQ4G63AFR 4Gb DDR3 SDRAM.
+-X-Powers AXP809 PMIC.
+-X-Powers AC100 audio codec and RTC subsystem.
+
+***********************************************************************************************/
+
+#include "emu.h"
+#include "cpu/arm7/arm7.h"
+#include "softlist_dev.h"
+
+namespace {
+
+class cubiecca80_state : public driver_device
+{
+public:
+	cubiecca80_state(const machine_config &mconfig, device_type type, const char *tag) :
+		driver_device(mconfig, type, tag),
+		m_maincpu(*this, "maincpu")
+	{ }
+
+	void cubiecca80(machine_config &config);
+
+private:
+	required_device<cpu_device> m_maincpu;
+};
+
+static INPUT_PORTS_START( cubiecca80 )
+INPUT_PORTS_END
+
+void cubiecca80_state::cubiecca80(machine_config &config)
+{
+	// Basic machine hardware
+	ARM9(config, m_maincpu, 200'000'000); // Actually an Allwinner A80 2 GHz
+
+	// Video hardware
+	//SCREEN(...)
+
+	// Audio hardware
+	//SPEAKER(...)
+
+	// Software list for adding other compatible software (Linux distros, etc.).
+	SOFTWARE_LIST(config, "software_list").set_original("cubieboard4");
+}
+
+/* Monkey Jump. Android-based arcade by the Spanish company Falgas.
+   Has a separate I/O board, with a PIC18F46K22, connected by USB to the Cubieboard4 (using a RS-232 to USB adapter).
+   More info: https://www.recreativas.org/monkey-jump-4029-falgas */
+ROM_START( monkeyjmp )
+	DISK_REGION( "nand" )
+	DISK_IMAGE( "mmcblk1", 0, SHA1(5c005005b2ca17b916b2cccd48d291b19337d4cc) )
+
+	ROM_REGION( 0x2000, "io", 0 )
+	ROM_LOAD( "pic18f46k22.bin", 0x0000, 0x2000, NO_DUMP ) // 1024 bytes internal ROM
+ROM_END
+
+} // anonymous namespace
+
+
+//    YEAR  NAME       PARENT  MACHINE     INPUT       CLASS             INIT        ROT    COMPANY   FULLNAME       FLAGS
+GAME( 20??, monkeyjmp, 0,      cubiecca80, cubiecca80, cubiecca80_state, empty_init, ROT90, "Falgas", "Monkey Jump", MACHINE_IS_SKELETON )

--- a/src/mame/skeleton/cubieboard4.cpp
+++ b/src/mame/skeleton/cubieboard4.cpp
@@ -25,6 +25,8 @@ Main Cubieboard4 components:
 
 #include "emu.h"
 #include "cpu/arm7/arm7.h"
+#include "bus/generic/slot.h"
+#include "bus/generic/carts.h"
 #include "softlist_dev.h"
 
 namespace {
@@ -34,10 +36,15 @@ class cubiecca80_state : public driver_device
 public:
 	cubiecca80_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
+		m_cart(*this, "cartslot"),
 		m_maincpu(*this, "maincpu")
+
 	{ }
 
 	void cubiecca80(machine_config &config);
+
+protected:
+	optional_device<generic_slot_device> m_cart;
 
 private:
 	required_device<cpu_device> m_maincpu;
@@ -57,11 +64,20 @@ void cubiecca80_state::cubiecca80(machine_config &config)
 	// Audio hardware
 	//SPEAKER(...)
 
+	GENERIC_CARTSLOT(config, m_cart, generic_plain_slot, "cubieboard4_sdcard");
+
 	// Software list for adding other compatible software (Linux distros, etc.).
 	SOFTWARE_LIST(config, "software_list").set_original("cubieboard4");
 }
 
-/* Monkey Jump. Android-based arcade by the Spanish company Falgas.
+// Main machine, for booting SD card images from the software list
+
+ROM_START( cubieboard4 )
+ROM_END
+
+// Arcade games
+
+/* Monkey Jump. Android-based arcade from the Spanish company Falgas.
    Has a separate I/O board, with a PIC18F46K22, connected by USB to the Cubieboard4 (using a RS-232 to USB adapter).
    More info: https://www.recreativas.org/monkey-jump-4029-falgas */
 ROM_START( monkeyjmp )
@@ -72,8 +88,40 @@ ROM_START( monkeyjmp )
 	ROM_LOAD( "pic18f46k22.bin", 0x0000, 0x2000, NO_DUMP ) // 1024 bytes internal ROM
 ROM_END
 
+// Other "official" software (from cubieboard.org) for the internal eMMC
+
+ROM_START( cb4_android41 )
+	DISK_REGION( "nand" )
+	DISK_IMAGE( "android4.4-cb4-emmc-v4.1.20161119", 0, SHA1(ccf854e17936e3c57a1701f9edb3c63b704d4d59) )
+ROM_END
+
+ROM_START( cb4_android43 )
+	DISK_REGION( "nand" )
+	DISK_IMAGE( "android4.4-cb4-emmc-v4.3.20170717", 0, SHA1(bb386ce76686698ad7f25b0469970c58abf4745e) )
+ROM_END
+
+ROM_START( cb4_debiansvr )
+	DISK_REGION( "nand" )
+	DISK_IMAGE( "cb4-debian-server-hdmi-emmc-v1.0",  0, SHA1(31db5866016cfd6f1be331c70859cdb27022a7aa) )
+ROM_END
+
+ROM_START( cb4_linarodst )
+	DISK_REGION( "nand" )
+	DISK_IMAGE( "linaro-desktop-cb4-emmc-hdmi-v1.1", 0, SHA1(249095e6faaee11e330eaf59285c2e68d0b5a30f) )
+ROM_END
+
+
 } // anonymous namespace
 
 
-//    YEAR  NAME       PARENT  MACHINE     INPUT       CLASS             INIT        ROT    COMPANY   FULLNAME       FLAGS
-GAME( 20??, monkeyjmp, 0,      cubiecca80, cubiecca80, cubiecca80_state, empty_init, ROT90, "Falgas", "Monkey Jump", MACHINE_IS_SKELETON )
+// Main machine
+COMP( 20??, cubieboard4, 0, 0, cubiecca80, cubiecca80, cubiecca80_state, empty_init, "Cubietech Limited", "Cubieboard4 (CC A-20)", MACHINE_IS_SKELETON )
+
+// Arcade games
+GAME( 20??, monkeyjmp, cubieboard4, cubiecca80, cubiecca80, cubiecca80_state, empty_init, ROT90, "Falgas", "Monkey Jump", MACHINE_IS_SKELETON )
+
+// Other software for the internal eMMC
+COMP( 20??, cb4_android41, cubieboard4, 0, cubiecca80, cubiecca80, cubiecca80_state, empty_init, "cubieboard.org", "Android 4.1.20161119 for Cubieboard4", MACHINE_IS_SKELETON )
+COMP( 20??, cb4_android43, cubieboard4, 0, cubiecca80, cubiecca80, cubiecca80_state, empty_init, "cubieboard.org", "Android 4.3.20170717 for Cubieboard4", MACHINE_IS_SKELETON )
+COMP( 20??, cb4_debiansvr, cubieboard4, 0, cubiecca80, cubiecca80, cubiecca80_state, empty_init, "cubieboard.org", "Debian server for Cubieboard4",        MACHINE_IS_SKELETON )
+COMP( 20??, cb4_linarodst, cubieboard4, 0, cubiecca80, cubiecca80, cubiecca80_state, empty_init, "cubieboard.org", "Linaro desktop for Cubieboard4",       MACHINE_IS_SKELETON )

--- a/src/mame/skeleton/cubieboard4.cpp
+++ b/src/mame/skeleton/cubieboard4.cpp
@@ -36,7 +36,8 @@ class cubiecca80_state : public driver_device
 public:
 	cubiecca80_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
-		m_cart(*this, "cartslot"),
+		m_cart_sdcard(*this, "emmcslot"),
+		m_cart_emmc(*this, "sdcardslot"),
 		m_maincpu(*this, "maincpu")
 
 	{ }
@@ -44,7 +45,8 @@ public:
 	void cubiecca80(machine_config &config);
 
 protected:
-	optional_device<generic_slot_device> m_cart;
+	optional_device<generic_slot_device> m_cart_sdcard;
+	optional_device<generic_slot_device> m_cart_emmc;
 
 private:
 	required_device<cpu_device> m_maincpu;
@@ -64,13 +66,14 @@ void cubiecca80_state::cubiecca80(machine_config &config)
 	// Audio hardware
 	//SPEAKER(...)
 
-	GENERIC_CARTSLOT(config, m_cart, generic_plain_slot, "cubieboard4_sdcard");
+	GENERIC_CARTSLOT(config, m_cart_sdcard, generic_plain_slot, "sdcard"); // Removable MicroSD
+	GENERIC_CARTSLOT(config, m_cart_emmc, generic_plain_slot, "emmc");   // Internal eMMC
 
 	// Software list for adding other compatible software (Linux distros, etc.).
 	SOFTWARE_LIST(config, "software_list").set_original("cubieboard4");
 }
 
-// Main machine, for booting SD card images from the software list
+// Main machine, for booting SD card and eMMC images from the software list
 
 ROM_START( cubieboard4 )
 ROM_END
@@ -88,40 +91,10 @@ ROM_START( monkeyjmp )
 	ROM_LOAD( "pic18f46k22.bin", 0x0000, 0x2000, NO_DUMP ) // 1024 bytes internal ROM
 ROM_END
 
-// Other "official" software (from cubieboard.org) for the internal eMMC
-
-ROM_START( cb4_android41 )
-	DISK_REGION( "nand" )
-	DISK_IMAGE( "android4.4-cb4-emmc-v4.1.20161119", 0, SHA1(ccf854e17936e3c57a1701f9edb3c63b704d4d59) )
-ROM_END
-
-ROM_START( cb4_android43 )
-	DISK_REGION( "nand" )
-	DISK_IMAGE( "android4.4-cb4-emmc-v4.3.20170717", 0, SHA1(bb386ce76686698ad7f25b0469970c58abf4745e) )
-ROM_END
-
-ROM_START( cb4_debiansvr )
-	DISK_REGION( "nand" )
-	DISK_IMAGE( "cb4-debian-server-hdmi-emmc-v1.0",  0, SHA1(31db5866016cfd6f1be331c70859cdb27022a7aa) )
-ROM_END
-
-ROM_START( cb4_linarodst )
-	DISK_REGION( "nand" )
-	DISK_IMAGE( "linaro-desktop-cb4-emmc-hdmi-v1.1", 0, SHA1(249095e6faaee11e330eaf59285c2e68d0b5a30f) )
-ROM_END
-
-
 } // anonymous namespace
-
 
 // Main machine
 COMP( 20??, cubieboard4, 0, 0, cubiecca80, cubiecca80, cubiecca80_state, empty_init, "Cubietech Limited", "Cubieboard4 (CC A-20)", MACHINE_IS_SKELETON )
 
 // Arcade games
 GAME( 20??, monkeyjmp, cubieboard4, cubiecca80, cubiecca80, cubiecca80_state, empty_init, ROT90, "Falgas", "Monkey Jump", MACHINE_IS_SKELETON )
-
-// Other software for the internal eMMC
-COMP( 20??, cb4_android41, cubieboard4, 0, cubiecca80, cubiecca80, cubiecca80_state, empty_init, "cubieboard.org", "Android 4.1.20161119 for Cubieboard4", MACHINE_IS_SKELETON )
-COMP( 20??, cb4_android43, cubieboard4, 0, cubiecca80, cubiecca80, cubiecca80_state, empty_init, "cubieboard.org", "Android 4.3.20170717 for Cubieboard4", MACHINE_IS_SKELETON )
-COMP( 20??, cb4_debiansvr, cubieboard4, 0, cubiecca80, cubiecca80, cubiecca80_state, empty_init, "cubieboard.org", "Debian server for Cubieboard4",        MACHINE_IS_SKELETON )
-COMP( 20??, cb4_linarodst, cubieboard4, 0, cubiecca80, cubiecca80, cubiecca80_state, empty_init, "cubieboard.org", "Linaro desktop for Cubieboard4",       MACHINE_IS_SKELETON )

--- a/src/mame/skeleton/cubieboard4.cpp
+++ b/src/mame/skeleton/cubieboard4.cpp
@@ -36,8 +36,8 @@ class cubiecca80_state : public driver_device
 public:
 	cubiecca80_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
-		m_cart_sdcard(*this, "emmcslot"),
-		m_cart_emmc(*this, "sdcardslot"),
+		m_cart_ext(*this, "emmcslot"),
+		m_cart_int(*this, "sdcardslot"),
 		m_maincpu(*this, "maincpu")
 
 	{ }
@@ -45,8 +45,8 @@ public:
 	void cubiecca80(machine_config &config);
 
 protected:
-	optional_device<generic_slot_device> m_cart_sdcard;
-	optional_device<generic_slot_device> m_cart_emmc;
+	optional_device<generic_slot_device> m_cart_ext;
+	optional_device<generic_slot_device> m_cart_int;
 
 private:
 	required_device<cpu_device> m_maincpu;
@@ -66,8 +66,8 @@ void cubiecca80_state::cubiecca80(machine_config &config)
 	// Audio hardware
 	//SPEAKER(...)
 
-	GENERIC_CARTSLOT(config, m_cart_sdcard, generic_plain_slot, "sdcard"); // Removable MicroSD
-	GENERIC_CARTSLOT(config, m_cart_emmc, generic_plain_slot, "emmc");   // Internal eMMC
+	GENERIC_CARTSLOT(config, m_cart_ext, generic_plain_slot, "sdcard"); // Removable MicroSD
+	GENERIC_CARTSLOT(config, m_cart_int, generic_plain_slot, "emmc");   // Internal eMMC
 
 	// Software list for adding other compatible software (Linux distros, etc.).
 	SOFTWARE_LIST(config, "software_list").set_original("cubieboard4");


### PR DESCRIPTION
New not working machines
------------------------------
Monkey Jump [Museo del Recreativo, Recreativas.org]

New not working software list additions
--------------------------------------------
cubieboard4.xml:
  Android 4.1.20161119 for Cubieboard4 (v4.4, internal eMMC) [ClawGrip]
  Android 4.3.20170717 for Cubieboard4 (v4.4, internal eMMC) [ClawGrip]
  Debian server for Cubieboard4 (v1.0, internal eMMC) [ClawGrip]
  Debian server for Cubieboard4 (v1.0, MicroSD card) [ClawGrip]
  Linaro desktop for Cubieboard4 (v1.1, HDMI, internal eMMC) [ClawGrip]
  Linaro desktop for Cubieboard4 (v1.0, HDMI, MicroSD card) [ClawGrip]
  Linaro server for Cubieboard4 (v2.0, HDMI, MicroSD card) [ClawGrip]
  Linaro server for Cubieboard4 (v2.0, VGA, MicroSD card) [ClawGrip]

