### PR TITLE
promat/1945kiii.cpp: Use generic gfx decode layout, Cleanups:

### DIFF
--- a/src/mame/promat/1945kiii.cpp
+++ b/src/mame/promat/1945kiii.cpp
@@ -109,8 +109,6 @@ SPR800E on the Solite Spirits PCB silkscreened  PROMAT  SPR800E  ES928
 
 namespace {
 
-#define MASTER_CLOCK    XTAL(16'000'000)
-
 
 class k3_state : public driver_device
 {
@@ -149,13 +147,13 @@ private:
 	void flagrall_map(address_map &map);
 	void k3_base_map(address_map &map);
 
-	/* devices */
+	// devices
 	optional_device_array<okim6295_device, 2> m_oki;
-	/* memory pointers */
+	// memory pointers
 	required_shared_ptr_array<u16, 2> m_spriteram;
 	required_shared_ptr<u16> m_bgram;
 
-	/* video-related */
+	// video-related
 	std::unique_ptr<u16[]> m_spriteram_buffer[2]{};
 	std::unique_ptr<u16[]> m_bgram_buffer{};
 	bool m_refresh = false;
@@ -193,12 +191,12 @@ void k3_state::k3_drawgfx(bitmap_ind16 &dest_bmp,const rectangle &clip,gfx_eleme
 							u32 code,u32 color,bool flipx,bool flipy,int offsx,int offsy,
 							u8 transparent_color, bool flicker)
 {
-	/* Start drawing */
+	// Start drawing
 	const u16 pal = gfx->colorbase() + gfx->granularity() * (color % gfx->colors());
-	const u8 *source_base = gfx->get_data(code % gfx->elements());
+	const u8 *const source_base = gfx->get_data(code % gfx->elements());
 
-	int xinc = flipx ? -1 : 1;
-	int yinc = flipy ? -1 : 1;
+	int const xinc = flipx ? -1 : 1;
+	int const yinc = flipy ? -1 : 1;
 
 	int x_index_base = flipx ? gfx->width() - 1 : 0;
 	int y_index = flipy ? gfx->height() - 1 : 0;
@@ -242,7 +240,7 @@ void k3_state::k3_drawgfx(bitmap_ind16 &dest_bmp,const rectangle &clip,gfx_eleme
 			int x_index = x_index_base;
 			for (int x = sx; x < ex; x++)
 			{
-				u8 c = source[x_index];
+				u8 const c = source[x_index];
 				if (c != transparent_color)
 				{
 					if (flicker) // verified from PCB (reference : https://www.youtube.com/watch?v=ooXyyvpW1O0)
@@ -268,9 +266,9 @@ void k3_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect)
 	const u32 max_cycle = m_screen->width() * m_screen->height(); // max usable cycle for sprites, TODO : related to whole screen?
 	u32 cycle = 0;
 	gfx_element *gfx = m_gfxdecode->gfx(0);
-	u16 *source = m_spriteram_buffer[0].get();
-	u16 *source2 = m_spriteram_buffer[1].get();
-	u16 *finish = source + (m_spriteram[0].bytes() / 2);
+	const u16 *source = m_spriteram_buffer[0].get();
+	const u16 *source2 = m_spriteram_buffer[1].get();
+	const u16 *finish = source + (m_spriteram[0].bytes() / 2);
 
 	while (source < finish)
 	{
@@ -278,10 +276,10 @@ void k3_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect)
 		if (cycle > max_cycle)
 			break;
 
-		int xpos = (source[0] & 0xff00) >> 8 | (source2[0] & 0x0001) << 8;
-		int ypos = (source[0] & 0x00ff) >> 0;
-		u32 tileno = (source2[0] & 0x7ffe) >> 1;
-		bool flicker = BIT(source2[0], 15);
+		const int xpos = (source[0] & 0xff00) >> 8 | (source2[0] & 0x0001) << 8;
+		const int ypos = (source[0] & 0x00ff) >> 0;
+		const u32 tileno = (source2[0] & 0x7ffe) >> 1;
+		const bool flicker = BIT(source2[0], 15);
 
 		k3_drawgfx(bitmap, cliprect, gfx, tileno, 1, false, false, xpos, ypos, 0, flicker);
 		k3_drawgfx(bitmap, cliprect, gfx, tileno, 1, false, false, xpos, ypos - 0x100, 0, flicker); // wrap
@@ -431,7 +429,7 @@ static INPUT_PORTS_START( k3 )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_UNKNOWN )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_START1 )
 	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_START2 )
-	PORT_BIT( 0xfff0, IP_ACTIVE_LOW, IPT_UNKNOWN )  /* Are these used at all? */
+	PORT_BIT( 0xfff0, IP_ACTIVE_LOW, IPT_UNKNOWN )  // Are these used at all?
 
 	PORT_START("DSW")
 	PORT_DIPNAME( 0x007,  0x0007, DEF_STR( Coin_A ) )           PORT_DIPLOCATION("SW1:1,2,3")
@@ -493,7 +491,7 @@ static INPUT_PORTS_START( k3old )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_UNKNOWN )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_START1 )
 	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_START2 )
-	PORT_BIT( 0xfff0, IP_ACTIVE_LOW, IPT_UNKNOWN )  /* Are these used at all? */
+	PORT_BIT( 0xfff0, IP_ACTIVE_LOW, IPT_UNKNOWN )  // Are these used at all?
 
 	PORT_START("DSW")
 	PORT_DIPNAME( 0x007,  0x0007, DEF_STR( Coin_A ) )           PORT_DIPLOCATION("SW1:1,2,3")
@@ -551,7 +549,7 @@ static INPUT_PORTS_START( solite )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_UNKNOWN )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_START1 )
 	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_START2 )
-	PORT_BIT( 0xfff0, IP_ACTIVE_LOW, IPT_UNKNOWN )  /* Are these used at all? */
+	PORT_BIT( 0xfff0, IP_ACTIVE_LOW, IPT_UNKNOWN )  // Are these used at all?
 
 	PORT_START("DSW")
 	PORT_DIPNAME( 0x007,  0x0007, DEF_STR( Coin_A ) )           PORT_DIPLOCATION("SW1:1,2,3")
@@ -645,22 +643,12 @@ static INPUT_PORTS_START( flagrall )
 INPUT_PORTS_END
 
 
-static const gfx_layout k3_layout =
-{
-	16,16,
-	RGN_FRAC(1,1),
-	8,
-	{ STEP8(0,1) },
-	{ STEP16(0,8) },
-	{ STEP16(0,8*16) },
-	16*128,
-};
-
-
 static GFXDECODE_START( gfx_1945kiii )
-	GFXDECODE_ENTRY( "gfx1", 0, k3_layout,   0x000, 2  ) /* sprites */
-	GFXDECODE_ENTRY( "gfx2", 0, k3_layout,   0x000, 2  ) /* bg tiles */
+	GFXDECODE_ENTRY( "sprites", 0, gfx_16x16x8_raw, 0x000, 2 ) // sprites
+	GFXDECODE_ENTRY( "tiles",   0, gfx_16x16x8_raw, 0x000, 2 ) // bg tiles
 GFXDECODE_END
+
+static constexpr XTAL MASTER_CLOCK = XTAL(16'000'000);
 
 
 void k3_state::flagrall(machine_config &config)
@@ -680,7 +668,7 @@ void k3_state::flagrall(machine_config &config)
 
 	SPEAKER(config, "mono").front_center();
 
-	OKIM6295(config, m_oki[0], MASTER_CLOCK/16, okim6295_device::PIN7_HIGH);  /* dividers? */
+	OKIM6295(config, m_oki[0], MASTER_CLOCK/16, okim6295_device::PIN7_HIGH);  // dividers?
 	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 1.0);
 }
 
@@ -691,7 +679,7 @@ void k3_state::k3(machine_config &config)
 
 	m_maincpu->set_addrmap(AS_PROGRAM, &k3_state::k3_map);
 
-	OKIM6295(config, m_oki[1], MASTER_CLOCK/16, okim6295_device::PIN7_HIGH);  /* dividers? */
+	OKIM6295(config, m_oki[1], MASTER_CLOCK/16, okim6295_device::PIN7_HIGH);  // dividers?
 	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 1.0);
 
 	m_screen->set_raw(XTAL(27'000'000)/4, 432, 0, 320, 262, 0, 224); // ~60Hz
@@ -700,65 +688,65 @@ void k3_state::k3(machine_config &config)
 
 
 ROM_START( 1945kiii )
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* 68000 Code */
-	ROM_LOAD16_BYTE( "prg-1.u51", 0x00001, 0x80000, CRC(6b345f27) SHA1(60867fa0e2ea7ebdd4b8046315ee0c83e5cf0d74) ) /* identical halves */
-	ROM_LOAD16_BYTE( "prg-2.u52", 0x00000, 0x80000, CRC(ce09b98c) SHA1(a06bb712b9cf2249cc535de4055b14a21c68e0c5) ) /* identical halves */
+	ROM_REGION( 0x100000, "maincpu", 0 ) // 68000 Code
+	ROM_LOAD16_BYTE( "prg-1.u51", 0x00001, 0x80000, CRC(6b345f27) SHA1(60867fa0e2ea7ebdd4b8046315ee0c83e5cf0d74) ) // identical halves
+	ROM_LOAD16_BYTE( "prg-2.u52", 0x00000, 0x80000, CRC(ce09b98c) SHA1(a06bb712b9cf2249cc535de4055b14a21c68e0c5) ) // identical halves
 
-	ROM_REGION( 0x080000, "oki2", 0 ) /* Samples */
+	ROM_REGION( 0x080000, "oki2", 0 ) // Samples
 	ROM_LOAD( "snd-2.su4", 0x00000, 0x80000, CRC(47e3952e) SHA1(d56524621a3f11981e4434e02f5fdb7e89fff0b4) )
 
-	ROM_REGION( 0x080000, "oki1", 0 ) /* Samples */
+	ROM_REGION( 0x080000, "oki1", 0 ) // Samples
 	ROM_LOAD( "snd-1.su7", 0x00000, 0x80000, CRC(bbb7f0ff) SHA1(458cf3a0c2d42110bc2427db675226c6b8d30999) )
 
-	ROM_REGION( 0x400000, "gfx1", 0 ) // sprites
+	ROM_REGION( 0x400000, "sprites", 0 )
 	ROM_LOAD32_WORD( "m16m-1.u62", 0x000000, 0x200000, CRC(0b9a6474) SHA1(6110ecb17d0fef25935986af9a251fc6e88e3993) )
 	ROM_LOAD32_WORD( "m16m-2.u63", 0x000002, 0x200000, CRC(368a8c2e) SHA1(4b1f360c4a3a86d922035774b2c712be810ec548) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 ) // bg tiles
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD( "m16m-3.u61", 0x00000, 0x200000, CRC(32fc80dd) SHA1(bee32493a250e9f21997114bba26b9535b1b636c) )
 ROM_END
 
 ROM_START( 1945kiiin )
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* 68000 Code */
-	ROM_LOAD16_BYTE( "u34", 0x00001, 0x80000, CRC(d0cf4f03) SHA1(3455927221afae5103c02b12c1b855f416c47e91) ) /* 27C040 ROM had no label - identical halves */
-	ROM_LOAD16_BYTE( "u35", 0x00000, 0x80000, CRC(056c64ed) SHA1(b0eddad9c950676b94316d3aeb32f3ed4b9ade0f) ) /* 27C040 ROM had no label - identical halves */
+	ROM_REGION( 0x100000, "maincpu", 0 ) // 68000 Code
+	ROM_LOAD16_BYTE( "u34", 0x00001, 0x80000, CRC(d0cf4f03) SHA1(3455927221afae5103c02b12c1b855f416c47e91) ) // 27C040 ROM had no label - identical halves
+	ROM_LOAD16_BYTE( "u35", 0x00000, 0x80000, CRC(056c64ed) SHA1(b0eddad9c950676b94316d3aeb32f3ed4b9ade0f) ) // 27C040 ROM had no label - identical halves
 
-	ROM_REGION( 0x080000, "oki2", 0 ) /* Samples */
-	ROM_LOAD( "snd-2.su4", 0x00000, 0x80000, CRC(47e3952e) SHA1(d56524621a3f11981e4434e02f5fdb7e89fff0b4) ) /* ROM had no label, but same data as SND-2.SU4 */
+	ROM_REGION( 0x080000, "oki2", 0 ) // Samples
+	ROM_LOAD( "snd-2.su4", 0x00000, 0x80000, CRC(47e3952e) SHA1(d56524621a3f11981e4434e02f5fdb7e89fff0b4) ) // ROM had no label, but same data as SND-2.SU4
 
-	ROM_REGION( 0x080000, "oki1", 0 ) /* Samples */
-	ROM_LOAD( "snd-1.su7", 0x00000, 0x80000, CRC(bbb7f0ff) SHA1(458cf3a0c2d42110bc2427db675226c6b8d30999) ) /* ROM had no label, but same data as SND-1.SU7 */
+	ROM_REGION( 0x080000, "oki1", 0 ) // Samples
+	ROM_LOAD( "snd-1.su7", 0x00000, 0x80000, CRC(bbb7f0ff) SHA1(458cf3a0c2d42110bc2427db675226c6b8d30999) ) // ROM had no label, but same data as SND-1.SU7
 
-	ROM_REGION( 0x400000, "gfx1", 0 ) // sprites
-	ROM_LOAD32_BYTE( "u5",  0x000000, 0x080000, CRC(f328f85e) SHA1(fe1e1b86a77a9b6da0f69b20da64e69b874d8ef9) ) /* These 4 27C040 ROMs had no label */
+	ROM_REGION( 0x400000, "sprites", 0 )
+	ROM_LOAD32_BYTE( "u5",  0x000000, 0x080000, CRC(f328f85e) SHA1(fe1e1b86a77a9b6da0f69b20da64e69b874d8ef9) ) // These 4 27C040 ROMs had no label
 	ROM_LOAD32_BYTE( "u6",  0x000001, 0x080000, CRC(cfdabf1b) SHA1(9822def10e5213d1b5c86034637481b5349bfb70) )
 	ROM_LOAD32_BYTE( "u7",  0x000002, 0x080000, CRC(59a6a944) SHA1(20a109edddd8ab9530b94b3b2d2f8a85af2c08f8) )
 	ROM_LOAD32_BYTE( "u8",  0x000003, 0x080000, CRC(59995aaf) SHA1(29c2c638b0dd2bf1e79707ea6f5b38b37f45b822) )
 
-	ROM_LOAD32_BYTE( "u58", 0x200000, 0x080000, CRC(6acf2ce4) SHA1(4b18678a9e03beb24494270d19c57bca32a72592) ) /* These 4 27C040  ROMs had no label */
+	ROM_LOAD32_BYTE( "u58", 0x200000, 0x080000, CRC(6acf2ce4) SHA1(4b18678a9e03beb24494270d19c57bca32a72592) ) // These 4 27C040  ROMs had no label
 	ROM_LOAD32_BYTE( "u59", 0x200001, 0x080000, CRC(ca6ff210) SHA1(d7e476bb41c193654495f5ed6ba39980cb3660bc) )
 	ROM_LOAD32_BYTE( "u60", 0x200002, 0x080000, CRC(91eb038a) SHA1(b24082ba1675e87881a321ba87e079a1a027dfa4) )
 	ROM_LOAD32_BYTE( "u61", 0x200003, 0x080000, CRC(1b358c6d) SHA1(1abe6422b420fd064a32ed9ca9a28c85996d4e57) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
-	ROM_LOAD32_BYTE( "5.u102", 0x000000, 0x80000, CRC(91b70a6b) SHA1(e53f62212d6e3ab5f892944b1933385a85e0ba8a) ) /* These 4 ROMs had no label */
-	ROM_LOAD32_BYTE( "6.u103", 0x000001, 0x80000, CRC(7b5bfb85) SHA1(ef59d64513c7f7e6ee3dcc9bb7bb0e14a71ca957) ) /* Same data as M16M-3.U61, just split up */
+	ROM_REGION( 0x200000, "tiles", 0 )
+	ROM_LOAD32_BYTE( "5.u102", 0x000000, 0x80000, CRC(91b70a6b) SHA1(e53f62212d6e3ab5f892944b1933385a85e0ba8a) ) // These 4 ROMs had no label
+	ROM_LOAD32_BYTE( "6.u103", 0x000001, 0x80000, CRC(7b5bfb85) SHA1(ef59d64513c7f7e6ee3dcc9bb7bb0e14a71ca957) ) // Same data as M16M-3.U61, just split up
 	ROM_LOAD32_BYTE( "7.u104", 0x000002, 0x80000, CRC(cdafcedf) SHA1(82becd002a16185220131085db6576eb763429c8) )
 	ROM_LOAD32_BYTE( "8.u105", 0x000003, 0x80000, CRC(2c3895d5) SHA1(ab5837d996c1bb70071db02f07412c182d7547f8) )
 ROM_END
 
 ROM_START( 1945kiiio )
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* 68000 Code */
-	ROM_LOAD16_BYTE( "3.u34", 0x00001, 0x80000, CRC(5515baa0) SHA1(6fd4c9b7cc27035d6baaafa73f5f5930bfde62a4) ) /* 0x40000 to 0x7FFFF 0x00 padded */
-	ROM_LOAD16_BYTE( "4.u35", 0x00000, 0x80000, CRC(fd177664) SHA1(0ea1854be8d88577129546a56d13bcdc4739ae52) ) /* 0x40000 to 0x7FFFF 0x00 padded */
+	ROM_REGION( 0x100000, "maincpu", 0 ) // 68000 Code
+	ROM_LOAD16_BYTE( "3.u34", 0x00001, 0x80000, CRC(5515baa0) SHA1(6fd4c9b7cc27035d6baaafa73f5f5930bfde62a4) ) // 0x40000 to 0x7FFFF 0x00 padded
+	ROM_LOAD16_BYTE( "4.u35", 0x00000, 0x80000, CRC(fd177664) SHA1(0ea1854be8d88577129546a56d13bcdc4739ae52) ) // 0x40000 to 0x7FFFF 0x00 padded
 
-	ROM_REGION( 0x080000, "oki2", 0 ) /* Samples */
+	ROM_REGION( 0x080000, "oki2", 0 ) // Samples
 	ROM_LOAD( "s21.su5", 0x00000, 0x80000, CRC(9d96fd55) SHA1(80025cc2c44e8cd938620818e0b0974026377f5c) )
 
-	ROM_REGION( 0x080000, "oki1", 0 ) /* Samples */
+	ROM_REGION( 0x080000, "oki1", 0 ) // Samples
 	ROM_LOAD( "s13.su4", 0x00000, 0x80000, CRC(d45aec3b) SHA1(fc182a10e19687eb2f2f4a1d2ad976814185f0fc) )
 
-	ROM_REGION( 0x400000, "gfx1", 0 ) // sprites
+	ROM_REGION( 0x400000, "sprites", 0 )
 	ROM_LOAD32_BYTE( "9.u5",   0x000000, 0x080000, CRC(be0f432e) SHA1(7d63f97a8cb38c5351f2cd2f720de16a0c4ab1d7) )
 	ROM_LOAD32_BYTE( "10.u6",  0x000001, 0x080000, CRC(cf9127b2) SHA1(e02f436662f47d8bb5a9d726889c6e86cf64bdcf) )
 	ROM_LOAD32_BYTE( "11.u7",  0x000002, 0x080000, CRC(644ee8cc) SHA1(1742e31ba48a93c005cce0dc575d9b5d739d1dce) )
@@ -769,25 +757,25 @@ ROM_START( 1945kiiio )
 	ROM_LOAD32_BYTE( "15.u60", 0x200002, 0x080000, CRC(86ab6c7c) SHA1(59acaee6ba78a22f1423832a116ad41e19522aa1) )
 	ROM_LOAD32_BYTE( "16.u61", 0x200003, 0x080000, CRC(ff419080) SHA1(542819bdd60976bddfa96570321ba3f7fb6fbf23) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 ) // bg tiles
-	ROM_LOAD32_BYTE( "5.u102", 0x000000, 0x80000, CRC(91b70a6b) SHA1(e53f62212d6e3ab5f892944b1933385a85e0ba8a) ) /* Same data as M16M-3.U61, just split up */
+	ROM_REGION( 0x200000, "tiles", 0 )
+	ROM_LOAD32_BYTE( "5.u102", 0x000000, 0x80000, CRC(91b70a6b) SHA1(e53f62212d6e3ab5f892944b1933385a85e0ba8a) ) // Same data as M16M-3.U61, just split up
 	ROM_LOAD32_BYTE( "6.u103", 0x000001, 0x80000, CRC(7b5bfb85) SHA1(ef59d64513c7f7e6ee3dcc9bb7bb0e14a71ca957) )
 	ROM_LOAD32_BYTE( "7.u104", 0x000002, 0x80000, CRC(cdafcedf) SHA1(82becd002a16185220131085db6576eb763429c8) )
 	ROM_LOAD32_BYTE( "8.u105", 0x000003, 0x80000, CRC(2c3895d5) SHA1(ab5837d996c1bb70071db02f07412c182d7547f8) )
 ROM_END
 
 ROM_START( slspirit )
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* 68000 Code */
+	ROM_REGION( 0x100000, "maincpu", 0 ) // 68000 Code
 	ROM_LOAD16_BYTE( "3.u34", 0x00001, 0x40000, CRC(b5ac3272) SHA1(da223ef3b006be03a11559e00ae9d7bbd2d06ee5) )
 	ROM_LOAD16_BYTE( "4.u35", 0x00000, 0x40000, CRC(86397bcb) SHA1(562dbb82c363039152aa574df72f73e9f71805d9) )
 
-	ROM_REGION( 0x080000, "oki2", 0 ) /* Samples */
+	ROM_REGION( 0x080000, "oki2", 0 ) // Samples
 	ROM_LOAD( "s21.su5", 0x00000, 0x80000, CRC(d4cbc27c) SHA1(feffa530baa4d70788a3598a12761827694a6275) )
 
-	ROM_REGION( 0x080000, "oki1", 0 ) /* Samples */
+	ROM_REGION( 0x080000, "oki1", 0 ) // Samples
 	ROM_LOAD( "s13.su4", 0x00000, 0x80000, CRC(d9c63d55) SHA1(7fd2fc08c859947dd4b1490132597ae23fcbed36) )
 
-	ROM_REGION( 0x400000, "gfx1", 0 ) // sprites
+	ROM_REGION( 0x400000, "sprites", 0 )
 	ROM_LOAD32_BYTE( "9.u5",   0x000000, 0x080000, CRC(4742aa38) SHA1(6e8d53afe7a6a5d60c135dd6a283d5bb47821f48) )
 	ROM_LOAD32_BYTE( "10.u6",  0x000001, 0x080000, CRC(c137fb33) SHA1(6798bc4569bdcab02c2b16315c8827268e5674eb) )
 	ROM_LOAD32_BYTE( "11.u7",  0x000002, 0x080000, CRC(d0593a03) SHA1(544e345e0849239b8156df8c50568bb2e2685bd3) )
@@ -798,7 +786,7 @@ ROM_START( slspirit )
 	ROM_LOAD32_BYTE( "15.u60", 0x200002, 0x080000, CRC(31f9b034) SHA1(d3224d9f11236fcaa65d477b87c46bea8a69db01) )
 	ROM_LOAD32_BYTE( "16.u61", 0x200003, 0x080000, CRC(c1fc95e5) SHA1(2597e8553deb751d1a199c4eb3f321f0564b9c76) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 ) // bg tiles
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD32_BYTE( "5.u102", 0x000000, 0x80000, CRC(9f0855a6) SHA1(13aa54641eb188f604cf32bb462331fab4c1bf68) )
 	ROM_LOAD32_BYTE( "6.u103", 0x000001, 0x80000, CRC(0dda4489) SHA1(cfad31e58adf5aea51c528fb5d7a2f076e6cf0bf) )
 	ROM_LOAD32_BYTE( "7.u104", 0x000002, 0x80000, CRC(6208cdc7) SHA1(242a93db057b6c01f0031cc8fd33da76baf6c879) )
@@ -807,16 +795,16 @@ ROM_END
 
 
 ROM_START( flagrall )
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* 68000 Code */
+	ROM_REGION( 0x100000, "maincpu", 0 ) // 68000 Code
 	ROM_LOAD16_BYTE( "11_u34.bin", 0x00001, 0x40000, CRC(24dd439d) SHA1(88857ad5ed69f29de86702dcc746d35b69b3b93d) )
 	ROM_LOAD16_BYTE( "12_u35.bin", 0x00000, 0x40000, CRC(373b71a5) SHA1(be9ab93129e2ffd9bfe296c341dbdf47f1949ac7) )
 
-	ROM_REGION( 0x100000, "oki1", 0 ) /* Samples */
+	ROM_REGION( 0x100000, "oki1", 0 ) // Samples
 	// 3x banks
 	ROM_LOAD( "13_su4.bin", 0x00000, 0x80000, CRC(7b0630b3) SHA1(c615e6630ffd12c122762751c25c249393bf7abd) )
 	ROM_LOAD( "14_su6.bin", 0x80000, 0x40000, CRC(593b038f) SHA1(b00dcf321fe541ee52c34b79e69c44f3d7a9cd7c) )
 
-	ROM_REGION( 0x300000, "gfx1", 0 ) // sprites
+	ROM_REGION( 0x300000, "sprites", 0 )
 	ROM_LOAD32_BYTE( "1_u5.bin",  0x000000, 0x080000, CRC(9377704b) SHA1(ac516a8ba6d1a70086469504c2a46d47a1f4560b) )
 	ROM_LOAD32_BYTE( "5_u6.bin",  0x000001, 0x080000, CRC(1ac0bd0c) SHA1(ab71bb84e61f5c7168601695f332a8d4a30d9948) )
 	ROM_LOAD32_BYTE( "2_u7.bin",  0x000002, 0x080000, CRC(5f6db2b3) SHA1(84caa019d3b75be30a14d19ccc2f28e5e94028bd) )
@@ -827,7 +815,7 @@ ROM_START( flagrall )
 	ROM_LOAD32_BYTE( "7_u60.bin", 0x200002, 0x040000, CRC(f187a7bf) SHA1(f4ce9ac9fe376250fe426de6ee404fc7841ef08a) )
 	ROM_LOAD32_BYTE( "8_u61.bin", 0x200003, 0x040000, CRC(b73fa441) SHA1(a5a3533563070c870276ead5e2f9cb9aaba303cc))
 
-	ROM_REGION( 0x100000, "gfx2", 0 ) // bg tiles
+	ROM_REGION( 0x100000, "tiles", 0 )
 	ROM_LOAD( "10_u102.bin", 0x00000, 0x80000, CRC(b1fd3279) SHA1(4a75581e13d43bef441ce81eae518c2f6bc1d5f8) )
 	ROM_LOAD( "9_u103.bin",  0x80000, 0x80000, CRC(01e6d654) SHA1(821d61a5b16f5cb76e2a805c8504db1ef38c3a48) )
 ROM_END


### PR DESCRIPTION
Use C++ style comment for single line comments
Reduce preprocessor defines
Constantize variables