### PR TITLE
a2600_cass.xml: Replaced 19 items. Removed 12 items.

### DIFF
--- a/hash/a2600_cass.xml
+++ b/hash/a2600_cass.xml
@@ -45,20 +45,6 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		</part>
 	</software>
 
-	<software name="commumutpv" cloneof="commumut">
-		<description>Communist Mutants from Space (preview)</description>
-		<year>1982</year>
-		<publisher>Arcadia Corporation</publisher>
-		<info name="serial" value="AR-4101"/>
-		<info name="developer" value="Stephen Harland Landrum"/>
-		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="communist mutants from space (preview) (1982) (arcadia corporation).a26" size="8448" crc="ca6bb788" sha1="ad18885ed38516c3e136293ae565c113f299d223"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="commumute" cloneof="commumut" supported="partial">
 		<description>Communist Mutants from Space (PAL)</description>
 		<year>1982</year>
@@ -76,20 +62,6 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<part name="cassb" interface="a2600_cass">
 			<dataarea name="cass" size="23479401">
 				<rom name="communist mutants from space  - arcadia corporation (pal, side b).flac" size="23479401" crc="1e882029" sha1="6f75541d6362da2124ce5ce9388c258ec0061ee0"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="commumutepv" cloneof="commumut">
-		<description>Communist Mutants from Space (preview) (PAL)</description>
-		<year>1982</year>
-		<publisher>Starpath Corporation</publisher>
-		<info name="serial" value="AR-4101"/>
-		<info name="developer" value="Stephen Harland Landrum"/>
-		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="communist mutants from space (preview) (1982) (starpath corporation) (pal).a26" size="8448" crc="d1a5b3bb" sha1="b0483e5de99833d630433281953a670dd72a0df4"/>
 			</dataarea>
 		</part>
 	</software>
@@ -114,20 +86,6 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		</part>
 	</software>
 
-	<software name="dstomperpv" cloneof="dstomper">
-		<description>Dragonstomper (preview)</description>
-		<year>1982</year>
-		<publisher>Starpath Corporation</publisher>
-		<info name="serial" value="AR-4100"/>
-		<info name="developer" value="Stephen Harland Landrum"/>
-		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="dragonstomper (preview) (1982) (starpath corporation).a26" size="8448" crc="c483f940" sha1="aa63009fb7dc4ece8cda3078d37f4e93b326c4df"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="dstompere" cloneof="dstomper">
 		<description>Dragonstomper (PAL)</description>
 		<year>1982</year>
@@ -144,20 +102,6 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<part name="cassb" interface="a2600_cass">
 			<dataarea name="cass" size="14617426">
 				<rom name="dragonstomper - starpath corporation (pal, side b).flac" size="14617426" crc="0be59b69" sha1="4fac8cebb88936b5e5b290386e0e617dbd04d717"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dstomperepv" cloneof="dstomper">
-		<description>Dragonstomper (preview) (PAL)</description>
-		<year>1982</year>
-		<publisher>Starpath Corporation</publisher>
-		<info name="serial" value="AR-4100"/>
-		<info name="developer" value="Stephen Harland Landrum"/>
-		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="dragonstomper (preview) (1982) (starpath corporation) (pal).a26" size="8448" crc="d610fd7e" sha1="7a893558f01e21b4708622cbc4b4db30c849acc6"/>
 			</dataarea>
 		</part>
 	</software>
@@ -182,20 +126,6 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		</part>
 	</software>
 
-	<software name="mindmstrpv" cloneof="mindmstr">
-		<description>Escape from the Mindmaster (preview)</description>
-		<year>1982</year>
-		<publisher>Starpath Corporation</publisher>
-		<info name="serial" value="AR-4200"/>
-		<info name="developer" value="Dennis Caswell"/>
-		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="escape from the mindmaster (preview) (1982) (starpath corporation).a26" size="8448" crc="5a1deb25" sha1="7a32131911eb04957facc87b4333308b44e02c02"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="mindmstre" cloneof="mindmstr">
 		<description>Escape from the Mindmaster (PAL)</description>
 		<year>1982</year>
@@ -212,20 +142,6 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<part name="cassb" interface="a2600_cass">
 			<dataarea name="cass" size="16763727">
 				<rom name="escape from the mindmaster - starpath corporation (pal, side b).flac" size="16763727" crc="6175157c" sha1="0b26b22099535642ccbd09a98cccd81e1b4bd417"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mindmstrepv" cloneof="mindmstr">
-		<description>Escape from the Mindmaster (preview) (PAL)</description>
-		<year>1982</year>
-		<publisher>Starpath Corporation</publisher>
-		<info name="serial" value="AR-4200"/>
-		<info name="developer" value="Dennis Caswell"/>
-		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="escape from the mindmaster (preview) (1982) (starpath corporation) (pal).a26" size="8448" crc="cd4bc0e0" sha1="65c7016bc60b7035645cdf1cb50bb396fce60aa0"/>
 			</dataarea>
 		</part>
 	</software>
@@ -303,20 +219,6 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		</part>
 	</software>
 
-	<software name="fireballpv" cloneof="fireball">
-		<description>Fireball (preview)</description>
-		<year>1982</year>
-		<publisher>Arcadia Corporation</publisher>
-		<info name="serial" value="AR-4300"/>
-		<info name="developer" value="Scott Nelson"/>
-		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="fireball (preview) (1982) (arcadia corporation).a26" size="8448" crc="962c498f" sha1="20322ad5eb2ad1c11b454d99126ce3b185351e99"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="fireballe" cloneof="fireball" supported="partial">
 		<description>Fireball (PAL)</description>
 		<year>1982</year>
@@ -334,20 +236,6 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<part name="cassb" interface="a2600_cass">
 			<dataarea name="cass" size="23371984">
 				<rom name="fireball - arcadia corporation (pal, side b).flac" size="23371984" crc="db1baf69" sha1="2be1ce5a31ba26b89446fa09490870bd81228020"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fireballepv" cloneof="fireball">
-		<description>Fireball (preview) (PAL)</description>
-		<year>1982</year>
-		<publisher>Starpath Corporation</publisher>
-		<info name="serial" value="AR-4300"/>
-		<info name="developer" value="Scott Nelson"/>
-		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="fireball (preview) (1982) (starpath corporation) (pal).a26" size="8448" crc="138ccbd1" sha1="f7133999d072ac0560c5a9a4ec46fdd94b52dde6"/>
 			</dataarea>
 		</part>
 	</software>
@@ -533,20 +421,6 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		</part>
 	</software>
 
-	<software name="partymixpv" cloneof="partymix">
-		<description>Party Mix (preview)</description>
-		<year>1983</year>
-		<publisher>Starpath Corporation</publisher>
-		<info name="serial" value="AR-4302"/>
-		<info name="developer" value="Dennis Caswell"/>
-		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="party mix (preview) (1983) (starpath corporation).a26" size="8448" crc="fb3fe9b1" sha1="035bad1d6142dbe932eb2f2a4e34bbb64692fa9f"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="partymixe" cloneof="partymix">
 		<description>Party Mix (PAL)</description>
 		<year>1983</year>
@@ -567,20 +441,6 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<part name="cass3" interface="a2600_cass">
 			<dataarea name="cass" size="8448">
 				<rom name="party mix (3 of 3) (1983) (starpath corporation) (pal).a26" size="8448" crc="d619142f" sha1="00c90aea85bd8272cb34ce23fd0e5f0d36a1ea48"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="partymixepv" cloneof="partymix">
-		<description>Party Mix (preview) (PAL)</description>
-		<year>1983</year>
-		<publisher>Starpath Corporation</publisher>
-		<info name="serial" value="AR-4302"/>
-		<info name="developer" value="Dennis Caswell"/>
-		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="party mix (preview) (1983) (starpath corporation) (pal).a26" size="8448" crc="57536159" sha1="55e51e131235123d2ab9f8a0209bcb16a7734622"/>
 			</dataarea>
 		</part>
 	</software>
@@ -675,20 +535,6 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		</part>
 	</software>
 
-	<software name="rabbitpv" cloneof="rabbit">
-		<description>Rabbit Transit (preview)</description>
-		<year>1983</year>
-		<publisher>Starpath Corporation</publisher>
-		<info name="serial" value="AR-4104"/>
-		<info name="developer" value="Brian McGhie"/>
-		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="rabbit transit (preview) (1983) (starpath corporation).a26" size="8448" crc="ba955bb1" sha1="2271944cd9284b499a590cf9fca938560a741990"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="rabbite" cloneof="rabbit">
 		<description>Rabbit Transit (PAL)</description>
 		<year>1983</year>
@@ -730,20 +576,6 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		</part>
 	</software>
 
-	<software name="suicidempv" cloneof="suicidem">
-		<description>Suicide Mission (preview)</description>
-		<year>1982</year>
-		<publisher>Arcadia Corporation</publisher>
-		<info name="serial" value="AR-4102"/>
-		<info name="developer" value="Steve Hales &amp; Stephen Harland Landrum"/>
-		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="suicide mission (preview) (1982) (arcadia corporation).a26" size="8448" crc="4705b9c4" sha1="35061334cd1d26345e2459dfd663d240759eb5f4"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="suicideme" cloneof="suicidem" supported="partial">
 		<description>Suicide Mission (PAL)</description>
 		<year>1982</year>
@@ -761,20 +593,6 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 			<dataarea name="cass" size="22364415">
 				<!-- Escape from the Mindmaster does not load. -->
 				<rom name="suicide mission - starpath corporation (pal, side b).flac" size="22364415" crc="750fafdc" sha1="b99264deeaff3c0e8225b744e9b4dd2fd9563fe3"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="suicidemepv" cloneof="suicidem">
-		<description>Suicide Mission (preview) (PAL)</description>
-		<year>1982</year>
-		<publisher>Starpath Corporation</publisher>
-		<info name="serial" value="AR-4102"/>
-		<info name="developer" value="Steve Hales &amp; Stephen Harland Landrum"/>
-		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="suicide mission (preview) (1982) (starpath corporation) (pal).a26" size="8448" crc="67e4a405" sha1="c15c986f92bd068ec844c9cc3da73ff410ec002a"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/a2600_cass.xml
+++ b/hash/a2600_cass.xml
@@ -257,7 +257,7 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<description>Killer Satellites</description>
 		<year>1983</year>
 		<publisher>Starpath Corporation</publisher>
-		<notes>Also contains preview versions of Escape from the Mindmaster, Dragon Stomper, and Fireball.</notes>
+		<notes>Also contains preview versions of Escape from the Mindmaster, Dragonstomper, and Fireball.</notes>
 		<info name="serial" value="AR-4103"/>
 		<info name="developer" value="Kevin Norman"/>
 		<sharedfeat name="requirement" value="scharger"/>
@@ -351,7 +351,7 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<description>The Official Frogger</description>
 		<year>1983</year>
 		<publisher>Starpath Corporation</publisher>
-		<notes>Also contains preview versions of Rabbit Transit, Party Mix, Escape from the Mindmaster, and Dragon Stomper.</notes>
+		<notes>Also contains preview versions of Rabbit Transit, Party Mix, Escape from the Mindmaster, and Dragonstomper.</notes>
 		<info name="serial" value="AR-4105"/>
 		<info name="developer" value="Stephen Harland Landrum"/>
 		<sharedfeat name="requirement" value="scharger"/>
@@ -519,7 +519,7 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<description>Rabbit Transit</description>
 		<year>1983</year>
 		<publisher>Starpath Corporation</publisher>
-		<notes>Also contains preview versions of Escape from the Mindmaster, Dragon Stomper, Communist Mutants from Space, and Fireball.</notes>
+		<notes>Also contains preview versions of Escape from the Mindmaster, Dragonstomper, Communist Mutants from Space, and Fireball.</notes>
 		<info name="serial" value="AR-4104"/>
 		<info name="developer" value="Brian McGhie"/>
 		<sharedfeat name="requirement" value="scharger"/>

--- a/hash/a2600_cass.xml
+++ b/hash/a2600_cass.xml
@@ -23,6 +23,10 @@ Some games had different titles during development. Some of these are known (and
 - Labyrinth (then released as Escape from the Mindmaster)
 
 MultiLoad (TM) games, i.e. the few games which had separate chunks of data on the tapes, are currently emulated with separate a26 files for each chunk.
+
+
+Side A and B of the tapes have the same content, however the data on Side B has been recorded at a lower speed. Side B was
+meant to be used when there were problems loading the contents from Side A.
 -->
 
 	<software name="commumut">

--- a/hash/a2600_cass.xml
+++ b/hash/a2600_cass.xml
@@ -29,12 +29,18 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<description>Communist Mutants from Space</description>
 		<year>1982</year>
 		<publisher>Arcadia Corporation</publisher>
+		<notes>Also contains preview versions of Suicide Mission and Fireball.</notes>
 		<info name="serial" value="AR-4101"/>
 		<info name="developer" value="Stephen Harland Landrum"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="communist mutants from space (1982) (arcadia corporation).a26" size="8448" crc="d64ec816" sha1="9a113bacc576d1d1f80a26622359c49df97b16bc"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="12642931">
+				<rom name="communist mutants from space - arcadia corporation (side a).flac" size="12642931" crc="a5ad6283" sha1="6494a8baa2a0ed15191759fade832257ab0e2ab1"/>
+			</dataarea>
+		</part>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="13416668">
+				<rom name="communist mutants from space  - arcadia corporation (side b).flac" size="13416668" crc="11ae9530" sha1="a608e395ed2aca8b677046ef6265e93add5d4dd1"/>
 			</dataarea>
 		</part>
 	</software>
@@ -53,16 +59,23 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		</part>
 	</software>
 
-	<software name="commumute" cloneof="commumut">
+	<software name="commumute" cloneof="commumut" supported="partial">
 		<description>Communist Mutants from Space (PAL)</description>
 		<year>1982</year>
 		<publisher>Starpath Corporation</publisher>
+		<notes>Also contains preview versions of Escape from the Mindmaster, Dragonstomper, Fireball, and Suicide Mission.</notes>
 		<info name="serial" value="AR-4101"/>
 		<info name="developer" value="Stephen Harland Landrum"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="communist mutants from space (1982) (starpath corporation) (pal).a26" size="8448" crc="e8c4dc94" sha1="9ab6e90c2a41684f46592b8e2b71fd19e540b055"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="22123599">
+				<!-- Only the first file loads. -->
+				<rom name="communist mutants from space - arcadia corporation (pal, side a).flac" size="22123599" crc="b6331fc6" sha1="065410f9a98471ac7146e66dcd9d5f8c220cc7a2"/>
+			</dataarea>
+		</part>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="23479401">
+				<rom name="communist mutants from space  - arcadia corporation (pal, side b).flac" size="23479401" crc="1e882029" sha1="6f75541d6362da2124ce5ce9388c258ec0061ee0"/>
 			</dataarea>
 		</part>
 	</software>
@@ -85,22 +98,18 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<description>Dragonstomper</description>
 		<year>1982</year>
 		<publisher>Starpath Corporation</publisher>
+		<notes>The software consists of three parts.</notes>
 		<info name="serial" value="AR-4100"/>
 		<info name="developer" value="Stephen Harland Landrum"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass1" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="dragonstomper (1 of 3) (1982) (starpath corporation).a26" size="8448" crc="ff942c31" sha1="9283e892dca1ad463443d347c99826bd623e0fdc"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="18951778">
+				<rom name="dragonstomper - starpath corporation (side a).flac" size="18951778" crc="2d671567" sha1="a98e6eef3607041ca053587f0643b90a5ca3b676"/>
 			</dataarea>
 		</part>
-		<part name="cass2" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="dragonstomper (2 of 3) (1982) (starpath corporation).a26" size="8448" crc="d9734371" sha1="1f00e06ae2f42e59637d73b37b9ccc3b130ede13"/>
-			</dataarea>
-		</part>
-		<part name="cass3" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="dragonstomper (3 of 3) (1982) (starpath corporation).a26" size="8448" crc="fcd8c4ed" sha1="b463d3da55cfa27c4f75550afcd07bcf28683d26"/>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="18827918">
+				<rom name="dragonstomper - starpath corporation (side b).flac" size="18827918" crc="61600cdc" sha1="df8b3e2206b0e643f39bb26f7b1b716d35a4662d"/>
 			</dataarea>
 		</part>
 	</software>
@@ -123,22 +132,18 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<description>Dragonstomper (PAL)</description>
 		<year>1982</year>
 		<publisher>Starpath Corporation</publisher>
+		<notes>The software consists of three parts.</notes>
 		<info name="serial" value="AR-4100"/>
 		<info name="developer" value="Stephen Harland Landrum"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass1" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="dragonstomper (1 of 3) (1982) (starpath corporation) (pal).a26" size="8448" crc="87e14ffb" sha1="0f4bed960092061a5e3a8a118118793b16b902b4"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="13738745">
+				<rom name="dragonstomper - starpath corporation (pal, side a).flac" size="13738745" crc="30ef5580" sha1="7987d87f9b7c915e9e9f56ab52290ac4d1eeb331"/>
 			</dataarea>
 		</part>
-		<part name="cass2" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="dragonstomper (2 of 3) (1982) (starpath corporation) (pal).a26" size="8448" crc="41301d7d" sha1="6080703b9f16357e581be69a6154ac7186a91fac"/>
-			</dataarea>
-		</part>
-		<part name="cass3" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="dragonstomper (3 of 3) (1982) (starpath corporation) (pal).a26" size="8448" crc="a69d86eb" sha1="0450f52c501c1018c7f2b8d6f18767daf17bdadc"/>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="14617426">
+				<rom name="dragonstomper - starpath corporation (pal, side b).flac" size="14617426" crc="0be59b69" sha1="4fac8cebb88936b5e5b290386e0e617dbd04d717"/>
 			</dataarea>
 		</part>
 	</software>
@@ -161,27 +166,18 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<description>Escape from the Mindmaster</description>
 		<year>1982</year>
 		<publisher>Starpath Corporation</publisher>
+		<notes>The software consists of four parts.</notes>
 		<info name="serial" value="AR-4200"/>
 		<info name="developer" value="Dennis Caswell"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass1" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="escape from the mindmaster (1 of 4) (1982) (starpath corporation).a26" size="8448" crc="20817f5d" sha1="aa7179ed05d6afb6ec8bcd06c589d4b137ec1bd6"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="23148011">
+				<rom name="escape from the mindmaster - starpath corporation (side a).flac" size="23148011" crc="32892866" sha1="37608f586688917b5bcee8d4be60b69ae8374b0c"/>
 			</dataarea>
 		</part>
-		<part name="cass2" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="escape from the mindmaster (2 of 4) (1982) (starpath corporation).a26" size="8448" crc="f08aa960" sha1="7cc06554cea3030fc88b537c70f2adb33e4a3f59"/>
-			</dataarea>
-		</part>
-		<part name="cass3" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="escape from the mindmaster (3 of 4) (1982) (starpath corporation).a26" size="8448" crc="b9e64de8" sha1="b7e626c13bc53665a37e465d6beeb5a15e6e526c"/>
-			</dataarea>
-		</part>
-		<part name="cass4" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="escape from the mindmaster (4 of 4) (1982) (starpath corporation).a26" size="8448" crc="abd4967d" sha1="3db8d34567d9c27c41ce560b9eacc6148cd85163"/>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="25478966">
+				<rom name="escape from the mindmaster - starpath corporation (side b).flac" size="25478966" crc="be4ad193" sha1="b111df968e8ba32182e39fe7a5768191d1b4ca72"/>
 			</dataarea>
 		</part>
 	</software>
@@ -204,27 +200,18 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<description>Escape from the Mindmaster (PAL)</description>
 		<year>1982</year>
 		<publisher>Starpath Corporation</publisher>
+		<notes>The software consists of four parts.</notes>
 		<info name="serial" value="AR-4200"/>
 		<info name="developer" value="Dennis Caswell"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass1" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="escape from the mindmaster (1 of 4) (1982) (starpath corporation) (pal).a26" size="8448" crc="191c532a" sha1="e870fbbc07213b1cc552872f3115f33c1f5b351c"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="15611417">
+				<rom name="escape from the mindmaster - starpath corporation (pal, side a).flac" size="15611417" crc="35a50bab" sha1="f400acd8291d9781a7f0b54884e6f3fdd36ddbf2"/>
 			</dataarea>
 		</part>
-		<part name="cass2" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="escape from the mindmaster (2 of 4) (1982) (starpath corporation) (pal).a26" size="8448" crc="9a84b9e2" sha1="a72859502b9437e1e8ccf984f2e61aabc908ed28"/>
-			</dataarea>
-		</part>
-		<part name="cass3" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="escape from the mindmaster (3 of 4) (1982) (starpath corporation) (pal).a26" size="8448" crc="5b363d93" sha1="b4415af06ec8abf01c3127f17864b3d4c1e827db"/>
-			</dataarea>
-		</part>
-		<part name="cass4" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="escape from the mindmaster (4 of 4) (1982) (starpath corporation) (pal).a26" size="8448" crc="7fbcc11f" sha1="49bb0dfaadda7201787ca110b51ef3320963ca9f"/>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="16763727">
+				<rom name="escape from the mindmaster - starpath corporation (pal, side b).flac" size="16763727" crc="6175157c" sha1="0b26b22099535642ccbd09a98cccd81e1b4bd417"/>
 			</dataarea>
 		</part>
 	</software>
@@ -295,16 +282,23 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		</part>
 	</software>
 
-	<software name="fireball">
+	<software name="fireball" supported="partial">
 		<description>Fireball</description>
 		<year>1982</year>
 		<publisher>Arcadia Corporation</publisher>
+		<notes>Also contains preview versions of Communist Mutants from Space and Suicide Mission.</notes>
 		<info name="serial" value="AR-4300"/>
 		<info name="developer" value="Scott Nelson"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="fireball (1982) (arcadia corporation).a26" size="8448" crc="b32ae162" sha1="9fa9ed2622d29636f175b8745892dde48a871fd1"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="12455860">
+				<rom name="fireball - arcadia corporation (side a).flac" size="12455860" crc="96da7cd6" sha1="2e17546eb9d086c9a2afd07a59515b89bb4860ec"/>
+			</dataarea>
+		</part>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="13430407">
+				<!-- files do not load in emulation, works on hardware. -->
+				<rom name="fireball - arcadia corporation (side b).flac" size="13430407" crc="355dd670" sha1="82fca70ec38691fddff321d81f3c91627e88968d"/>
 			</dataarea>
 		</part>
 	</software>
@@ -323,16 +317,23 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		</part>
 	</software>
 
-	<software name="fireballe" cloneof="fireball">
+	<software name="fireballe" cloneof="fireball" supported="partial">
 		<description>Fireball (PAL)</description>
 		<year>1982</year>
 		<publisher>Starpath Corporation</publisher>
+		<notes>Also contains preview versions of Communist Mutants from Space, Escape from the Mindmaster, Dragonstomper and Suicide Mission.</notes>
 		<info name="serial" value="AR-4300"/>
 		<info name="developer" value="Scott Nelson"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="fireball (1982) (starpath corporation) (pal).a26" size="8448" crc="1a382f65" sha1="f936c2ebc26c025e4904ae8d01be5f3e66249adb"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="22314825">
+				<!-- Only the first file loads. -->
+				<rom name="fireball - arcadia corporation (pal, side a).flac" size="22314825" crc="da541b82" sha1="c207d652c78b725d46a95cf10fb80b407e68fa4c"/>
+			</dataarea>
+		</part>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="23371984">
+				<rom name="fireball - arcadia corporation (pal, side b).flac" size="23371984" crc="db1baf69" sha1="2be1ce5a31ba26b89446fa09490870bd81228020"/>
 			</dataarea>
 		</part>
 	</software>
@@ -368,26 +369,39 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<description>Killer Satellites</description>
 		<year>1983</year>
 		<publisher>Starpath Corporation</publisher>
+		<notes>Also contains preview versions of Escape from the Mindmaster, Dragon Stomper, and Fireball.</notes>
 		<info name="serial" value="AR-4103"/>
 		<info name="developer" value="Kevin Norman"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="killer satellites (1983) (starpath corporation).a26" size="8448" crc="bdd932dc" sha1="64125e796f96aa472bb2191367c6501c657712d9"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="18842881">
+				<rom name="killer satellites - starpath corporation (side a).flac" size="18842881" crc="02430599" sha1="662958238a36b2de06ed16a2e56678ae8f1e4ce4"/>
+			</dataarea>
+		</part>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="18766747">
+				<rom name="killer satellites - starpath corporation (side b).flac" size="18766747" crc="fad0b586" sha1="5415992268a04ccdc25121ffcb3516487effdbb7"/>
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="killsate" cloneof="killsat">
+	<software name="killsate" cloneof="killsat" supported="partial">
 		<description>Killer Satellites (PAL)</description>
 		<year>1983</year>
 		<publisher>Starpath Corporation</publisher>
+		<notes>Also contains preview versions of Escape from the Mindmaster, Dragonstomper, Fireball, and Communist Mutants from Space.</notes>
 		<info name="serial" value="AR-4103"/>
 		<info name="developer" value="Kevin Norman"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="killer satellites (1983) (starpath corporation) (pal).a26" size="8448" crc="0b60d857" sha1="7ab5597ca336d3eebd21a7ad82989af366f2dcd3"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="20663264">
+				<!-- Only the first file loads. -->
+				<rom name="killer satellites - starpath corporation (pal, side a).flac" size="20663264" crc="558ce890" sha1="8330bf179cc30519439f4eb5472a07652c362b2d"/>
+			</dataarea>
+		</part>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="22428769">
+				<rom name="killer satellites - starpath corporation (pal, side b).flac" size="22428769" crc="5a1ad9b5" sha1="ea4698e343addc3a58b88954bffee91833032280"/>
 			</dataarea>
 		</part>
 	</software>
@@ -449,12 +463,18 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<description>The Official Frogger</description>
 		<year>1983</year>
 		<publisher>Starpath Corporation</publisher>
+		<notes>Also contains preview versions of Rabbit Transit, Party Mix, Escape from the Mindmaster, and Dragon Stomper.</notes>
 		<info name="serial" value="AR-4105"/>
 		<info name="developer" value="Stephen Harland Landrum"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="official frogger, the (1983) (starpath corporation).a26" size="8448" crc="1228e48c" sha1="f84c15579d22f2536e94f1679642b9dc73b6f2fe"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="21236441">
+				<rom name="the official frogger - starpath corporation (side a).flac" size="21236441" crc="44c6475e" sha1="5e1b8c87bb14171f957b76bb8a323a0ec876a1e0"/>
+			</dataarea>
+		</part>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="22746952">
+				<rom name="the official frogger - starpath corporation (side b).flac" size="22746952" crc="bd600492" sha1="e8e79dd2bd5536b15de60cdfed5baf49ca9d6b81"/>
 			</dataarea>
 		</part>
 	</software>
@@ -477,12 +497,18 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<description>The Official Frogger (PAL)</description>
 		<year>1983</year>
 		<publisher>Starpath Corporation</publisher>
+		<notes>Also contains preview versions of Rabbit Transit, Party Mix, Escape from the Mindmaster, and Dragonstomper.</notes>
 		<info name="serial" value="AR-4105"/>
 		<info name="developer" value="Stephen Harland Landrum"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="official frogger, the (1983) (starpath corporation) (pal).a26" size="8448" crc="e374b94b" sha1="2295b1eb5d30698e0a3a49e959f2a65ae60b4154"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="21559759">
+				<rom name="the official frogger - starpath corporation (pal, side a).flac" size="21559759" crc="e9584352" sha1="ccaf23270e438a14d0ab975c7fe09835e44ef84b"/>
+			</dataarea>
+		</part>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="22712396">
+				<rom name="the official frogger - starpath corporation (pal, side b).flac" size="22712396" crc="4ced8e96" sha1="9961f5ab65aac6490bf1b77b66db4169a206d612"/>
 			</dataarea>
 		</part>
 	</software>
@@ -491,22 +517,18 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<description>Party Mix</description>
 		<year>1983</year>
 		<publisher>Starpath Corporation</publisher>
+		<notes>The software consists of three parts.</notes>
 		<info name="serial" value="AR-4302"/>
 		<info name="developer" value="Dennis Caswell"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass1" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="party mix (1 of 3) (1983) (starpath corporation).a26" size="8448" crc="4724f396" sha1="1b1bcc35bd1120ded54318e63bce05d9c8603a82"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="15046705">
+				<rom name="party mix - starpath corporation (side a).flac" size="15046705" crc="6094b9b9" sha1="1f18850d2da3e6791663e7260333afff68842445"/>
 			</dataarea>
 		</part>
-		<part name="cass2" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="party mix (2 of 3) (1983) (starpath corporation).a26" size="8448" crc="bf14c002" sha1="13e8f09014dd4bebdb782833028504ff8577b035"/>
-			</dataarea>
-		</part>
-		<part name="cass3" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="party mix (3 of 3) (1983) (starpath corporation).a26" size="8448" crc="c1aa60ce" sha1="261c9d149e7908558fb1a5a5898f568ac823dbb1"/>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="15479394">
+				<rom name="party mix - starpath corporation (side b).flac" size="15479394" crc="329a3d05" sha1="01c0a7add96c5f7d4eac9c5589dd9895feeda6de"/>
 			</dataarea>
 		</part>
 	</software>
@@ -563,30 +585,44 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		</part>
 	</software>
 
-	<software name="ppatrol">
+	<software name="ppatrol" supported="partial">
 		<description>Phaser Patrol</description>
 		<year>1982</year>
 		<publisher>Arcadia Corporation</publisher>
+		<notes>Also contains preview versions of Communist Mutants from Space, Fireball, and Suicide Mission.</notes>
 		<info name="serial" value="AR-4000"/>
 		<info name="developer" value="Dennis Caswell"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="phaser patrol (1982) (arcadia corporation).a26" size="8448" crc="eaf31bd7" sha1="21c255e489d126475c3744cdd0d6e8a8e618e3eb"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="16605567">
+				<!-- Only the first file loads. -->
+				<rom name="phaser patrol - arcadia corporation (side a).flac" size="16605567" crc="8d4c52f3" sha1="59711d0c077f077f119c9cf20c2e71e20ca77026"/>
+			</dataarea>
+		</part>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="17995373">
+				<rom name="phaser patrol - arcadia corporation (side b).flac" size="17995373" crc="13945b71" sha1="d2c06d0587b3b820cd79d08b52b8ffd8909bf66b"/>
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="ppatrole" cloneof="ppatrol">
+	<software name="ppatrole" cloneof="ppatrol" supported="partial">
 		<description>Phaser Patrol (PAL)</description>
 		<year>1982</year>
 		<publisher>Starpath Corporation</publisher>
+		<notes>Also contains preview versions of Party Mix, Frogger, Rabbit Transit, and Dragonstomper.</notes>
 		<info name="serial" value="AR-4000"/>
 		<info name="developer" value="Dennis Caswell"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="phaser patrol (1982) (starpath corporation) (pal).a26" size="8448" crc="15550fed" sha1="9734cde5019fad40aef45fe5271f245995027009"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="21757206">
+				<!-- No files load. -->
+				<rom name="phaser patrol - arcadia corporation (pal, side a).flac" size="21757206" crc="4178f8b6" sha1="f1ba0d65561fb4650540f8fcc33f904334afd287"/>
+			</dataarea>
+		</part>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="23760153">
+				<rom name="phaser patrol - arcadia corporation (pal, side b).flac" size="23760153" crc="8f9f014b" sha1="c9de2fc404dd33dc5f034d5645519619a5145f2b"/>
 			</dataarea>
 		</part>
 	</software>
@@ -623,12 +659,18 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<description>Rabbit Transit</description>
 		<year>1983</year>
 		<publisher>Starpath Corporation</publisher>
+		<notes>Also contains preview versions of Escape from the Mindmaster, Dragon Stomper, Communist Mutants from Space, and Fireball.</notes>
 		<info name="serial" value="AR-4104"/>
 		<info name="developer" value="Brian McGhie"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="rabbit transit (1983) (starpath corporation).a26" size="8448" crc="517e5561" sha1="81654cbd6a7262ce0f1abc385ed9adc323a9b6a6"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="23856425">
+				<rom name="rabbit transit - starpath corporation (side a).flac" size="23856425" crc="cfae2657" sha1="59568d91cc7561523d3a67e89e72365dcb250854"/>
+			</dataarea>
+		</part>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="23257740">
+				<rom name="rabbit transit - starpath corporation (side b).flac" size="23257740" crc="d1ba3f71" sha1="653038cf7ddbc375a13a1980d79c1d7ed5376368"/>
 			</dataarea>
 		</part>
 	</software>
@@ -651,26 +693,39 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		<description>Rabbit Transit (PAL)</description>
 		<year>1983</year>
 		<publisher>Starpath Corporation</publisher>
+		<notes>Also contains preview versions of Escape from the Mindmaster, Dragonstomper, Communist Mutants from Space, and Fireball.</notes>
 		<info name="serial" value="AR-4104"/>
 		<info name="developer" value="Brian McGhie"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="rabbit transit (1983) (starpath corporation) (pal).a26" size="8448" crc="ea7f9afd" sha1="a55851ead48c5033a45fb3f1672341146e5b47d9"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="21689583">
+				<rom name="rabbit transit - starpath corporation (pal, side a).flac" size="21689583" crc="c1870508" sha1="40aa59554098af999295ac89d658303204ea6355"/>
+			</dataarea>
+		</part>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="22749697">
+				<rom name="rabbit transit - starpath corporation (pal, side B).flac" size="22749697" crc="d08e6b76" sha1="de3c887243ef15ac6319bc8185594efb1ff1c54d"/>
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="suicidem">
+	<software name="suicidem" supported="partial">
 		<description>Suicide Mission</description>
 		<year>1982</year>
 		<publisher>Arcadia Corporation</publisher>
+		<notes>Also contains preview versions of Communist Mutants from Space and Fireball.</notes>
 		<info name="serial" value="AR-4102"/>
 		<info name="developer" value="Steve Hales &amp; Stephen Harland Landrum"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="suicide mission (1982) (arcadia corporation).a26" size="8448" crc="b92c49e3" sha1="d3919b4dbeedfabfba30126d351eab509b0c1536"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="12398976">
+				<!-- Only the first file loads. -->
+				<rom name="suicide mission - arcadia corporation (side a).flac" size="12398976" crc="f4b9fe5a" sha1="c8228cdab5e19323d773b02495283c70bda1a995"/>
+			</dataarea>
+		</part>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="13063425">
+				<rom name="suicide mission - arcadia corporation (side b).flac" size="13063425" crc="5b4264d9" sha1="8a7877fbfce30200f2e6b18752db585715e84ca7"/>
 			</dataarea>
 		</part>
 	</software>
@@ -689,16 +744,23 @@ MultiLoad (TM) games, i.e. the few games which had separate chunks of data on th
 		</part>
 	</software>
 
-	<software name="suicideme" cloneof="suicidem">
+	<software name="suicideme" cloneof="suicidem" supported="partial">
 		<description>Suicide Mission (PAL)</description>
 		<year>1982</year>
 		<publisher>Starpath Corporation</publisher>
+		<notes>Also contains preview versions of Fireball, Dragonstomper, Communist Mutants from Space, Escape from the Mindmaster.</notes>
 		<info name="serial" value="AR-4102"/>
 		<info name="developer" value="Steve Hales &amp; Stephen Harland Landrum"/>
 		<sharedfeat name="requirement" value="scharger"/>
-		<part name="cass" interface="a2600_cass">
-			<dataarea name="cass" size="8448">
-				<rom name="suicide mission (1982) (starpath corporation) (pal).a26" size="8448" crc="3b2a9c8a" sha1="3b6d664440442f5f1d0220ef01d967a6004bbbdd"/>
+		<part name="cassa" interface="a2600_cass">
+			<dataarea name="cass" size="21008842">
+				<rom name="suicide mission - starpath corporation (pal, side a).flac" size="21008842" crc="3822ff5d" sha1="f472d9ce2adfeab1747889e552a8f75c2a957f0b"/>
+			</dataarea>
+		</part>
+		<part name="cassb" interface="a2600_cass">
+			<dataarea name="cass" size="22364415">
+				<!-- Escape from the Mindmaster does not load. -->
+				<rom name="suicide mission - starpath corporation (pal, side b).flac" size="22364415" crc="750fafdc" sha1="b99264deeaff3c0e8225b744e9b4dd2fd9563fe3"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION

Replaced 19 items with better/real dumps: [bsittler]
Communist Mutants from Space
Communist Mutants from Space (PAL)
Dragonstomper
Dragonstomper (PAL)
Escape from the Mindmaster
Escape from the Mindmaster (PAL)
Fireball
Fireball (PAL)
Killer Satellites
Killer Satellites (PAL)
The Official Frogger
The Official Frogger (PAL)
Party Mix
Phaser Patrol
Phaser Patrol (PAL)
Rabbit Transit
Rabbit Transit (PAL)
Suicide Mission
Suicide Mission (PAL)

Removed 12 preview items that are part of full dumps:
Communist Mutants from Space (preview)
Communist Mutants from Space (preview) (PAL)
Dragonstomper (preview)
Dragonstomper (preview) (PAL)
Escape from the Mindmaster (preview)
Escape from the Mindmaster (preview) (PAL)
Fireball (preview)
Fireball (preview) (PAL)
Party Mix (preview)
Party Mix (preview) (PAL)
Rabbit Transit (preview)
Suicide Mission (preview)
Suicide Mission (preview) (PAL)
