### PR TITLE
konami/konamigq: Remove :image tag from HDD image (MT#08856)

### DIFF
--- a/src/mame/konami/konamigq.cpp
+++ b/src/mame/konami/konamigq.cpp
@@ -492,7 +492,7 @@ ROM_START( cryptklr )
 	ROM_REGION32_LE( 0x080000, "maincpu:rom", 0 ) /* bios */
 	ROM_LOAD( "420b03.27p",   0x0000000, 0x080000, CRC(aab391b1) SHA1(bf9dc7c0c8168c22a4be266fe6a66d3738df916b) )
 
-	DISK_REGION( "scsi:0:harddisk:image" )
+	DISK_REGION( "scsi:0:harddisk" )
 	DISK_IMAGE( "420uaa04", 0, SHA1(67cb1418fc0de2a89fc61847dc9efb9f1bebb347) )
 ROM_END
 


### PR DESCRIPTION
Fixes https://mametesters.org/view.php?id=8856.