### PR TITLE
gt913: fix 16-bit output port (used by ctk530 display)

### DIFF
--- a/src/devices/cpu/h8/gt913.cpp
+++ b/src/devices/cpu/h8/gt913.cpp
@@ -31,6 +31,7 @@ gt913_device::gt913_device(const machine_config &mconfig, const char *tag, devic
 	device_mixer_interface(mconfig, *this, 2),
 	m_rom(*this, DEVICE_SELF),
 	m_data_config("data", ENDIANNESS_BIG, 16, 22, 0),
+	m_write_ple(*this),
 	m_intc(*this, "intc"),
 	m_sound(*this, "gt_sound"),
 	m_kbd(*this, "kbd"),
@@ -54,7 +55,7 @@ void gt913_device::map(address_map &map)
 	/* ctk530 writes here to latch LED matrix data, which generates an active high strobe on pin 99 (PLE/P16)
 	   there's otherwise no external address decoding (or the usual read/write strobes) used for the LED latches.
 	   just treat as a 16-bit write-only port for now */
-	map(0xe000, 0xe001).lw16(NAME([this](u16 data) { do_write_port(h8_device::PORT_4, data, ~0); }));
+	map(0xe000, 0xe001).lw16(NAME([this](u16 data) { m_write_ple(data); }));
 
 	map(0xfac0, 0xffbf).ram();
 

--- a/src/devices/cpu/h8/gt913.h
+++ b/src/devices/cpu/h8/gt913.h
@@ -33,8 +33,7 @@ public:
 	auto write_port2() { return m_write_port[PORT_2].bind(); }
 	auto read_port3()  { return m_read_port [PORT_3].bind(); }
 	auto write_port3() { return m_write_port[PORT_3].bind(); }
-	auto read_port4()  { return m_read_port [PORT_4].bind(); }
-	auto write_port4() { return m_write_port[PORT_4].bind(); }
+	auto write_ple()   { return m_write_ple.bind(); }
 
 	void uart_rate_w(u8 data);
 	void uart_control_w(offs_t offset, u8 data);
@@ -91,6 +90,7 @@ protected:
 
 	address_space_config m_data_config;
 	memory_access<32, 1, 0, ENDIANNESS_BIG>::specific m_data;
+	devcb_write16 m_write_ple;
 	u16 m_banknum;
 	u8 m_syscr;
 

--- a/src/mame/casio/ctk551.cpp
+++ b/src/mame/casio/ctk551.cpp
@@ -459,8 +459,7 @@ void ctk551_state::ap10(machine_config& config)
 	m_maincpu->write_port2().set_nop();
 	m_maincpu->read_port3().set_constant(0);
 	m_maincpu->write_port3().set_nop();
-	m_maincpu->read_port4().set_constant(0);
-	m_maincpu->write_port4().set_nop();
+	m_maincpu->write_ple().set_nop();
 
 	NVRAM(config, "nvram");
 
@@ -495,8 +494,7 @@ void ctk551_state::ctk530(machine_config& config)
 	m_maincpu->read_port2().set_constant(0);
 	m_maincpu->write_port2().set_nop();
 	m_maincpu->read_port3().set_constant(0);
-	m_maincpu->write_port3().set_nop();
-	m_maincpu->write_port4().set_ioport("PLE");
+	m_maincpu->write_ple().set_ioport("PLE");
 
 	// MIDI
 	auto& mdin(MIDI_PORT(config, "mdin"));
@@ -532,8 +530,7 @@ void ctk551_state::gz70sp(machine_config& config)
 	m_maincpu->write_port2().set_ioport("P2");
 	m_maincpu->read_port3().set_constant(0);
 	m_maincpu->write_port3().set_nop();
-	m_maincpu->read_port4().set_constant(0);
-	m_maincpu->write_port4().set_nop();
+	m_maincpu->write_ple().set_nop();
 
 	// MIDI (sci0 for RS232/422, sci1 for standard MIDI)
 	auto& mdin(MIDI_PORT(config, "mdin"));
@@ -559,8 +556,7 @@ void ctk551_state::ctk601(machine_config& config)
 	m_maincpu->write_port2().set_ioport("P2");
 	m_maincpu->read_port3().set_constant(0); // port 3 pins are shared w/ key matrix
 	m_maincpu->write_port3().set_nop();
-	m_maincpu->read_port4().set_constant(0);
-	m_maincpu->write_port4().set_nop();
+	m_maincpu->write_ple().set_nop();
 
 	// TODO: DSP
 
@@ -604,8 +600,7 @@ void ctk551_state::ctk551(machine_config &config)
 	m_maincpu->write_port2().set_ioport("P2");
 	m_maincpu->read_port3().set_constant(0); // port 3 pins are shared w/ key matrix
 	m_maincpu->write_port3().set_nop();
-	m_maincpu->read_port4().set_constant(0);
-	m_maincpu->write_port4().set_nop();
+	m_maincpu->write_ple().set_nop();
 
 	// MIDI
 	auto &mdin(MIDI_PORT(config, "mdin"));


### PR DESCRIPTION
At some point the H8/300 parent class changed all its ports to 8-bit, but the GT913 still has a 16-bit port (technically just a special write strobe meant to latch the data bus) that the ctk530 LED matrix uses.