### PR TITLE
seta/ssv.cpp: Cleanups

### DIFF
--- a/src/mame/seta/ssv.cpp
+++ b/src/mame/seta/ssv.cpp
@@ -294,14 +294,14 @@ void gdfs_state::adc_int_w(int state)
 */
 void ssv_state::lockout_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-//  popmessage("%02X",data & 0xff);
+//  logerror("%s - Unknown lockout bit written %02X\n", machine().describe_context(), data & 0xff);
 	if (ACCESSING_BITS_0_7)
 	{
 		machine().bookkeeping().coin_lockout_w(1, BIT(~data, 0));
 		machine().bookkeeping().coin_lockout_w(0, BIT(~data, 1));
 		machine().bookkeeping().coin_counter_w(1, BIT( data, 2));
 		machine().bookkeeping().coin_counter_w(0, BIT( data, 3));
-//                        data & 0x40?
+//      Bit 6 is unknown
 		enable_video(BIT(data, 7));
 	}
 }
@@ -309,14 +309,14 @@ void ssv_state::lockout_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 // Same as above but with inverted lockout lines
 void ssv_state::lockout_inv_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-//  popmessage("%02X",data & 0xff);
+//  logerror("%s - Unknown lockout bit written %02X\n", machine().describe_context(), data & 0xff);
 	if (ACCESSING_BITS_0_7)
 	{
 		machine().bookkeeping().coin_lockout_w(1, BIT(data, 0));
 		machine().bookkeeping().coin_lockout_w(0, BIT(data, 1));
 		machine().bookkeeping().coin_counter_w(1, BIT(data, 2));
 		machine().bookkeeping().coin_counter_w(0, BIT(data, 3));
-//                        data & 0x40?
+//      Bit 6 is unknown
 		enable_video(BIT(data, 7));
 	}
 }
@@ -458,7 +458,7 @@ uint16_t gdfs_state::eeprom_r()
 void gdfs_state::eeprom_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	if (data & ~0x7b00)
-		logerror("%s - Unknown EEPROM bit written %04X\n",machine().describe_context(),data);
+		logerror("%s - Unknown EEPROM bit written %04X\n", machine().describe_context(), data);
 
 	if (ACCESSING_BITS_8_15)
 	{
@@ -2793,9 +2793,6 @@ void drifto94_state::stmblade(machine_config &config)
 	UPD96050(config, m_dsp, 10000000);
 	m_dsp->set_addrmap(AS_PROGRAM, &drifto94_state::dsp_prg_map);
 	m_dsp->set_addrmap(AS_DATA, &drifto94_state::dsp_data_map);
-
-	// don't need this, game just does a simple check at boot then the DSP stalls into a tight loop.
-	//config.set_perfect_quantum(m_maincpu);
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 

--- a/src/mame/seta/ssv.cpp
+++ b/src/mame/seta/ssv.cpp
@@ -31,14 +31,14 @@ STA-0001    STS-0001    93  Dramatic Adventure Quiz Keith & Lucy    Visco
 STA-0001    STS-0001    93  Pastel Island                           Visco
 STA-0001    SAM-5127    93  Survival Arts                           Sammy
 STA-0001    SAM-5127    93  Dyna Gears                              Sammy
-STA-0001B   VISCO-001B  94  Drift Out '94                           Visco
+STA-0001B   VISCO-001B  94  Drift Out '94 (1)                       Visco
 STA-0001B   GOLF ROM    94  Eagle Shot Golf                         Sammy
 STA-0001B   STS0003     94  Twin Eagle II - The Rescue Mission (1)  Seta
 STA-0001B   VISCO       95  Mobil Suit Gundam Final Shooting (2)    Banpresto
 STA-0001B   P1-102A     95  Mahjong Hyper Reaction                  Sammy
 ?           ?           95  Ultra X Weapons / Ultra Keibitai        Banpresto / Tsuburaya Prod.
 STA-0001B   VISCO-JJ1   96  Lovely Pop Mahjong JangJang Shimasho    Visco
-STA-0001B   VISCO-001B  96  Storm Blade                             Visco
+STA-0001B   VISCO-001B  96  Storm Blade (1)                         Visco
 STA-0001B   P1-105A     96? Meosis Magic                            Sammy
 STA-0001B   ?           97  Joryuu Syougi Kyoushitsu (3)            Visco
 STA-0001B   VISCO-JJ1   97  Koi Koi Shimasho 2                      Visco
@@ -48,7 +48,7 @@ STA-0001    dedicated   97  Super Real Mahjong P7                   Seta
 STA-0001B   VISCO-JJ1   98  Gourmet Battle Quiz Ryorioh CooKing     Visco
 STA-0001B   P1-112C     98  Pachinko Sexy Reaction                  Sammy
 STA-0001B   B1-001A     99  Pachinko Sexy Reaction 2                Sammy
-STA-0001B   P1-112C     99  Change Air Blade                        Visco
+STA-0001B   P1-112C     99  Change Air Blade                        Sammy
 STA-0001B   VISCO-JJ1   00  Lovely Pop Mahjong JangJang Shimasho 2  Visco
 STA-0001B   SSV_SUB     00  Vasara                                  Visco
 STA-0001B   SSV_SUB     01  Vasara 2                                Visco
@@ -180,7 +180,7 @@ Notes:
 
 ***************************************************************************/
 
-/* Update the IRQ state based on all possible causes */
+// Update the IRQ state based on all possible causes
 void ssv_state::update_irq_state()
 {
 	m_maincpu->set_input_line(0, (m_requested_int & m_irq_enable)? ASSERT_LINE : CLEAR_LINE);
@@ -190,9 +190,9 @@ IRQ_CALLBACK_MEMBER(ssv_state::irq_callback)
 {
 	for (int i = 0; i <= 7; i++)
 	{
-		if (m_requested_int & (1 << i))
+		if (BIT(m_requested_int, i))
 		{
-			uint16_t vector = m_irq_vectors[i * (16/2)] & 7;
+			const uint16_t vector = m_irq_vectors[i * (16/2)] & 7;
 			return vector;
 		}
 	}
@@ -201,7 +201,7 @@ IRQ_CALLBACK_MEMBER(ssv_state::irq_callback)
 
 void ssv_state::irq_ack_w(offs_t offset, uint16_t data)
 {
-	int level = ((offset * 2) & 0x70) >> 4;
+	const int level = ((offset * 2) & 0x70) >> 4;
 
 	m_requested_int &= ~(1 << level);
 
@@ -233,7 +233,7 @@ void ssv_state::irq_enable_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 
 TIMER_DEVICE_CALLBACK_MEMBER(ssv_state::interrupt)
 {
-	int scanline = param;
+	const int scanline = param;
 
 	if (scanline == 0)
 	{
@@ -297,27 +297,27 @@ void ssv_state::lockout_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 //  popmessage("%02X",data & 0xff);
 	if (ACCESSING_BITS_0_7)
 	{
-		machine().bookkeeping().coin_lockout_w(1,~data & 0x01);
-		machine().bookkeeping().coin_lockout_w(0,~data & 0x02);
-		machine().bookkeeping().coin_counter_w(1, data & 0x04);
-		machine().bookkeeping().coin_counter_w(0, data & 0x08);
+		machine().bookkeeping().coin_lockout_w(1, BIT(~data, 0));
+		machine().bookkeeping().coin_lockout_w(0, BIT(~data, 1));
+		machine().bookkeeping().coin_counter_w(1, BIT( data, 2));
+		machine().bookkeeping().coin_counter_w(0, BIT( data, 3));
 //                        data & 0x40?
-		enable_video(data & 0x80);
+		enable_video(BIT(data, 7));
 	}
 }
 
-/* Same as above but with inverted lockout lines */
+// Same as above but with inverted lockout lines
 void ssv_state::lockout_inv_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 //  popmessage("%02X",data & 0xff);
 	if (ACCESSING_BITS_0_7)
 	{
-		machine().bookkeeping().coin_lockout_w(1, data & 0x01);
-		machine().bookkeeping().coin_lockout_w(0, data & 0x02);
-		machine().bookkeeping().coin_counter_w(1, data & 0x04);
-		machine().bookkeeping().coin_counter_w(0, data & 0x08);
+		machine().bookkeeping().coin_lockout_w(1, BIT(data, 0));
+		machine().bookkeeping().coin_lockout_w(0, BIT(data, 1));
+		machine().bookkeeping().coin_counter_w(1, BIT(data, 2));
+		machine().bookkeeping().coin_counter_w(0, BIT(data, 3));
 //                        data & 0x40?
-		enable_video(data & 0x80);
+		enable_video(BIT(data, 7));
 	}
 }
 
@@ -335,34 +335,34 @@ void ssv_state::machine_reset()
 
 ***************************************************************************/
 
-void ssv_state::dsp_prg_map(address_map &map)
+void drifto94_state::dsp_prg_map(address_map &map)
 {
 	map(0x0000, 0x3fff).rom().region("dspprg", 0);
 }
 
-void ssv_state::dsp_data_map(address_map &map)
+void drifto94_state::dsp_data_map(address_map &map)
 {
 	map(0x0000, 0x07ff).rom().region("dspdata", 0);
 }
 
-uint16_t ssv_state::dsp_dr_r()
+uint16_t drifto94_state::dsp_dr_r()
 {
 	return m_dsp->snesdsp_read(true);
 }
 
-void ssv_state::dsp_dr_w(uint16_t data)
+void drifto94_state::dsp_dr_w(uint16_t data)
 {
 	m_dsp->snesdsp_write(true, data);
 }
 
-uint16_t ssv_state::dsp_r(offs_t offset)
+uint16_t drifto94_state::dsp_r(offs_t offset)
 {
-	uint16_t temp = m_dsp->dataram_r(offset/2);
+	const uint16_t temp = m_dsp->dataram_r(offset / 2);
 	uint16_t res;
 
-	if (offset & 1)
+	if (BIT(offset, 0))
 	{
-		res = temp>>8;
+		res = temp >> 8;
 	}
 	else
 	{
@@ -372,14 +372,14 @@ uint16_t ssv_state::dsp_r(offs_t offset)
 	return res;
 }
 
-void ssv_state::dsp_w(offs_t offset, uint16_t data)
+void drifto94_state::dsp_w(offs_t offset, uint16_t data)
 {
-	uint16_t temp = m_dsp->dataram_r(offset/2);
+	uint16_t temp = m_dsp->dataram_r(offset / 2);
 
-	if (offset & 1)
+	if (BIT(offset, 0))
 	{
 		temp &= 0xff;
-		temp |= data<<8;
+		temp |= data << 8;
 	}
 	else
 	{
@@ -387,7 +387,7 @@ void ssv_state::dsp_w(offs_t offset, uint16_t data)
 		temp |= data;
 	}
 
-	m_dsp->dataram_w(offset/2, temp);
+	m_dsp->dataram_w(offset / 2, temp);
 }
 
 /***************************************************************************
@@ -402,46 +402,46 @@ uint16_t ssv_state::fake_r(offs_t offset) { return m_scroll[offset]; }
 
 void ssv_state::ssv_map(address_map &map, u32 rom)
 {
-	map(0x000000, 0x00ffff).ram().share("mainram");                                                                  /*  RAM     */
-	map(0x100000, 0x13ffff).ram().share("spriteram");                                                                /*  Sprites */
-	map(0x140000, 0x15ffff).ram().w("palette", FUNC(palette_device::write16)).share("palette");                      /*  Palette */
-	map(0x160000, 0x17ffff).ram();                                                                                   /*          */
-	map(0x1c0000, 0x1c007f).ram().w(FUNC(ssv_state::scroll_w)).share("scroll");                                      /*  Scroll  */
-	map(0x1c0000, 0x1c0001).r(FUNC(ssv_state::vblank_r));                                                      /*  Vblank? */
+	map(0x000000, 0x00ffff).ram().share(m_mainram);                                                                  //  RAM    
+	map(0x100000, 0x13ffff).ram().share(m_spriteram);                                                                //  Sprites
+	map(0x140000, 0x15ffff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");                      //  Palette
+	map(0x160000, 0x17ffff).ram();                                                                                   //         
+	map(0x1c0000, 0x1c007f).ram().w(FUNC(ssv_state::scroll_w)).share(m_scroll);                                      //  Scroll 
+	map(0x1c0000, 0x1c0001).r(FUNC(ssv_state::vblank_r));                                                            //  Vblank?
 	map(0x210002, 0x210003).portr("DSW1");
 	map(0x210004, 0x210005).portr("DSW2");
 	map(0x210008, 0x210009).portr("P1");
 	map(0x21000a, 0x21000b).portr("P2");
 	map(0x21000c, 0x21000d).portr("SYSTEM");
-	map(0x21000e, 0x21000f).nopr().w(FUNC(ssv_state::lockout_w));                                              /*  Lockout */
+	map(0x21000e, 0x21000f).nopr().w(FUNC(ssv_state::lockout_w));                                                    //  Lockout
 	map(0x210010, 0x210011).nopw();
-	map(0x230000, 0x230071).writeonly().share("irq_vectors");                                                        /*  IRQ Vec */
-	map(0x240000, 0x240071).w(FUNC(ssv_state::irq_ack_w));                                                     /*  IRQ Ack */
-	map(0x260000, 0x260001).w(FUNC(ssv_state::irq_enable_w));                                                  /*  IRQ En  */
-	map(0x300000, 0x30007f).rw("ensoniq", FUNC(es5506_device::read), FUNC(es5506_device::write)).umask16(0x00ff);    /*  Sound   */
-	map(rom, 0xffffff).rom().region("maincpu", 0);                                                                   /*  ROM     */
+	map(0x230000, 0x230071).writeonly().share(m_irq_vectors);                                                        //  IRQ Vec
+	map(0x240000, 0x240071).w(FUNC(ssv_state::irq_ack_w));                                                           //  IRQ Ack
+	map(0x260000, 0x260001).w(FUNC(ssv_state::irq_enable_w));                                                        //  IRQ En 
+	map(0x300000, 0x30007f).rw(m_ensoniq, FUNC(es5506_device::read), FUNC(es5506_device::write)).umask16(0x00ff);    //  Sound  
+	map(rom, 0xffffff).rom().region("maincpu", 0);                                                                   //  ROM    
 }
 
 /***************************************************************************
                                 Drift Out '94
 ***************************************************************************/
 
-uint16_t ssv_state::drifto94_unknown_r()
+uint16_t drifto94_state::drifto94_unknown_r()
 {
 	return machine().rand() & 0xffff;
 }
 
-void ssv_state::drifto94_map(address_map &map)
+void drifto94_state::drifto94_map(address_map &map)
 {
 	ssv_map(map, 0xc00000);
 //  map(0x210002, 0x210003).nopw();                                      // ? 1 at the start
 	map(0x400000, 0x47ffff).nopw();                                       // ?
-	map(0x480000, 0x480001).rw(FUNC(ssv_state::dsp_dr_r), FUNC(ssv_state::dsp_dr_w));
-	map(0x482000, 0x482fff).rw(FUNC(ssv_state::dsp_r), FUNC(ssv_state::dsp_w));
+	map(0x480000, 0x480001).rw(FUNC(drifto94_state::dsp_dr_r), FUNC(drifto94_state::dsp_dr_w));
+	map(0x482000, 0x482fff).rw(FUNC(drifto94_state::dsp_r), FUNC(drifto94_state::dsp_w));
 	map(0x483000, 0x485fff).nopw();                                        // ?
 	map(0x500000, 0x500001).nopw();                                        // ??
-	map(0x510000, 0x510001).r(FUNC(ssv_state::drifto94_unknown_r));                       // ??
-	map(0x520000, 0x520001).r(FUNC(ssv_state::drifto94_unknown_r));                       // ??
+	map(0x510000, 0x510001).r(FUNC(drifto94_state::drifto94_unknown_r));                       // ??
+	map(0x520000, 0x520001).r(FUNC(drifto94_state::drifto94_unknown_r));                       // ??
 	map(0x580000, 0x5807ff).ram().share("nvram");   // NVRAM
 }
 
@@ -460,7 +460,7 @@ void gdfs_state::eeprom_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 	if (data & ~0x7b00)
 		logerror("%s - Unknown EEPROM bit written %04X\n",machine().describe_context(),data);
 
-	if ( ACCESSING_BITS_8_15 )
+	if (ACCESSING_BITS_8_15)
 	{
 //      data & 0x8000 ? (near palette writes)
 //      data & 0x0001 ?
@@ -483,9 +483,9 @@ void gdfs_state::eeprom_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 void gdfs_state::gdfs_map(address_map &map)
 {
 	ssv_map(map, 0xc00000);
-	map(0x400000, 0x41ffff).ram().w(FUNC(gdfs_state::tmapram_w)).share("gdfs_tmapram");
+	map(0x400000, 0x41ffff).ram().w(FUNC(gdfs_state::tmapram_w)).share(m_tmapram);
 	map(0x420000, 0x43ffff).ram();
-	map(0x440000, 0x44003f).ram().share("gdfs_tmapscroll");
+	map(0x440000, 0x44003f).ram().share(m_tmapscroll);
 	map(0x500000, 0x500001).w(FUNC(gdfs_state::eeprom_w));
 	map(0x540000, 0x540001).r(FUNC(gdfs_state::eeprom_r));
 	map(0x600000, 0x600fff).ram();
@@ -509,13 +509,14 @@ void gdfs_state::gdfs_map(address_map &map)
 
 uint16_t ssv_state::hypreact_input_r()
 {
-	uint16_t input_sel = *m_input_sel;
+	const uint16_t input_sel = *m_input_sel;
 
-	if (input_sel & 0x0001) return m_io_key[0]->read();
-	if (input_sel & 0x0002) return m_io_key[1]->read();
-	if (input_sel & 0x0004) return m_io_key[2]->read();
-	if (input_sel & 0x0008) return m_io_key[3]->read();
-	logerror("CPU #0 PC %06X: unknown input read: %04X\n",m_maincpu->pc(),input_sel);
+	if (BIT(input_sel, 0)) return m_io_key[0]->read();
+	if (BIT(input_sel, 1)) return m_io_key[1]->read();
+	if (BIT(input_sel, 2)) return m_io_key[2]->read();
+	if (BIT(input_sel, 3)) return m_io_key[3]->read();
+	if (!machine().side_effects_disabled())
+		logerror("CPU #0 PC %06X: unknown input read: %04X\n", m_maincpu->pc(), input_sel);
 	return 0xffff;
 }
 
@@ -527,7 +528,7 @@ void ssv_state::hypreact_map(address_map &map)
 	map(0x21000e, 0x21000f).w(FUNC(ssv_state::lockout_inv_w));            // Inverted lockout lines
 //  map(0x280000, 0x280001).nopr();                       // ? read at the start, value not used
 	map(0xc00000, 0xc00001).r(FUNC(ssv_state::hypreact_input_r));              // Inputs
-	map(0xc00006, 0xc00007).ram().share("input_sel");           //
+	map(0xc00006, 0xc00007).ram().share(m_input_sel);           //
 	map(0xc00008, 0xc00009).noprw();                                 //
 }
 
@@ -545,7 +546,7 @@ void ssv_state::hypreac2_map(address_map &map)
 //  map(0x280000, 0x280001).nopr();                           // ? read at the start, value not used
 	map(0x500000, 0x500001).r(FUNC(ssv_state::hypreact_input_r));                  // Inputs
 	map(0x500002, 0x500003).r(FUNC(ssv_state::hypreact_input_r));                  // (again?)
-	map(0x520000, 0x520001).writeonly().share("input_sel"); // Inputs
+	map(0x520000, 0x520001).writeonly().share(m_input_sel); // Inputs
 //  0x540000, 0x540003  communication with other units
 }
 
@@ -562,7 +563,7 @@ void ssv_state::janjans1_map(address_map &map)
 	map(0x210000, 0x210001).nopw();                            // koikois2 but not janjans1
 //  map(0x210002, 0x210003).nopw();                          // ? 1 at the start
 	map(0x210006, 0x210007).nopr();
-	map(0x800000, 0x800001).writeonly().share("input_sel"); // Inputs
+	map(0x800000, 0x800001).writeonly().share(m_input_sel); // Inputs
 	map(0x800002, 0x800003).r(FUNC(ssv_state::srmp4_input_r));                     // Inputs
 }
 
@@ -599,7 +600,7 @@ void ssv_state::meosism_map(address_map &map)
                                 Monster Slider
 ***************************************************************************/
 
-/* Monster Slider needs the RAM mirrored for the gameplay logic to work correctly */
+// Monster Slider needs the RAM mirrored for the gameplay logic to work correctly
 
 uint16_t ssv_state::mainram_r(offs_t offset)
 {
@@ -639,13 +640,14 @@ void ssv_state::ryorioh_map(address_map &map)
 
 uint16_t ssv_state::srmp4_input_r()
 {
-	uint16_t input_sel = *m_input_sel;
+	const uint16_t input_sel = *m_input_sel;
 
-	if (input_sel & 0x0002) return m_io_key[0]->read();
-	if (input_sel & 0x0004) return m_io_key[1]->read();
-	if (input_sel & 0x0008) return m_io_key[2]->read();
-	if (input_sel & 0x0010) return m_io_key[3]->read();
-	logerror("CPU #0 PC %06X: unknown input read: %04X\n",m_maincpu->pc(),input_sel);
+	if (BIT(input_sel, 1)) return m_io_key[0]->read();
+	if (BIT(input_sel, 2)) return m_io_key[1]->read();
+	if (BIT(input_sel, 3)) return m_io_key[2]->read();
+	if (BIT(input_sel, 4)) return m_io_key[3]->read();
+	if (!machine().side_effects_disabled())
+		logerror("CPU #0 PC %06X: unknown input read: %04X\n", m_maincpu->pc(), input_sel);
 	return 0xffff;
 }
 
@@ -655,7 +657,7 @@ void ssv_state::srmp4_map(address_map &map)
 	map(0x210000, 0x210001).r("watchdog", FUNC(watchdog_timer_device::reset16_r));
 //  map(0x210002, 0x210003).nopw();                          // ? 1,5 at the start
 	map(0xc0000a, 0xc0000b).r(FUNC(ssv_state::srmp4_input_r));                     // Inputs
-	map(0xc0000e, 0xc0000f).writeonly().share("input_sel"); // Inputs
+	map(0xc0000e, 0xc0000f).writeonly().share(m_input_sel); // Inputs
 	map(0xc00010, 0xc00011).nopw();                            //
 }
 
@@ -683,18 +685,6 @@ void ssv_state::srmp7_sound_bank_w(offs_t offset, uint16_t data, uint16_t mem_ma
 //  popmessage("%04X",data);
 }
 
-uint16_t ssv_state::srmp7_input_r()
-{
-	uint16_t input_sel = *m_input_sel;
-
-	if (input_sel & 0x0002) return m_io_key[0]->read();
-	if (input_sel & 0x0004) return m_io_key[1]->read();
-	if (input_sel & 0x0008) return m_io_key[2]->read();
-	if (input_sel & 0x0010) return m_io_key[3]->read();
-	logerror("CPU #0 PC %06X: unknown input read: %04X\n",m_maincpu->pc(),input_sel);
-	return 0xffff;
-}
-
 void ssv_state::srmp7_map(address_map &map)
 {
 	ssv_map(map, 0xc00000);
@@ -705,8 +695,8 @@ void ssv_state::srmp7_map(address_map &map)
 	map(0x300076, 0x300077).r(FUNC(ssv_state::srmp7_irqv_r));                      // Sound
 //  0x540000, 0x540003, related to lev 5 irq?
 	map(0x580000, 0x580001).w(FUNC(ssv_state::srmp7_sound_bank_w));               // Sound Bank
-	map(0x600000, 0x600001).r(FUNC(ssv_state::srmp7_input_r));                     // Inputs
-	map(0x680000, 0x680001).writeonly().share("input_sel"); // Inputs
+	map(0x600000, 0x600001).r(FUNC(ssv_state::srmp4_input_r));                     // Inputs
+	map(0x680000, 0x680001).writeonly().share(m_input_sel); // Inputs
 }
 
 void ssv_state::srmp7_es5506_bank2_map(address_map &map)
@@ -788,15 +778,15 @@ void sxyreact_state::sxyreact_map(address_map &map)
                                 Twin Eagle II
 ***************************************************************************/
 
-/* comes as either a standalone board or a standard SSV ROM board (verified) */
+// comes as either a standalone board or a standard SSV ROM board (verified)
 
-void ssv_state::twineag2_map(address_map &map)
+void drifto94_state::twineag2_map(address_map &map)
 {
 	ssv_map(map, 0xe00000);
 	map(0x010000, 0x03ffff).ram();                         // More RAM
 	map(0x210000, 0x210001).r("watchdog", FUNC(watchdog_timer_device::reset16_r)); // Watchdog (also value is cmp.b with mem 8)
-	map(0x480000, 0x480001).rw(FUNC(ssv_state::dsp_dr_r), FUNC(ssv_state::dsp_dr_w));
-	map(0x482000, 0x482fff).rw(FUNC(ssv_state::dsp_r), FUNC(ssv_state::dsp_w));
+	map(0x480000, 0x480001).rw(FUNC(drifto94_state::dsp_dr_r), FUNC(drifto94_state::dsp_dr_w));
+	map(0x482000, 0x482fff).rw(FUNC(drifto94_state::dsp_r), FUNC(drifto94_state::dsp_w));
 }
 
 
@@ -804,7 +794,7 @@ void ssv_state::twineag2_map(address_map &map)
                                     Ultra X
 ***************************************************************************/
 
-/* standalone board based on SSV hardware */
+// standalone board based on SSV hardware
 
 void ssv_state::ultrax_map(address_map &map)
 {
@@ -818,35 +808,41 @@ void ssv_state::ultrax_map(address_map &map)
             Joryuu Syougi Kyoushitsu
 ***************************************************************************/
 
-/* from simple_st0016.cpp */
+// from simple_st0016.cpp
 
 uint32_t ssv_state::latch32_r(offs_t offset)
 {
-	if(!offset)
-		m_latches[2]&=~2;
+	if (!machine().side_effects_disabled())
+	{
+		if (!offset)
+			m_latches[2] &= ~2;
+	}
 	return m_latches[offset];
 }
 
 void ssv_state::latch32_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	if(!offset)
-		m_latches[2]|=1;
+	if (!offset)
+		m_latches[2] |= 1;
 	COMBINE_DATA(&m_latches[offset]);
 	machine().scheduler().synchronize();
 }
 
 uint16_t ssv_state::latch16_r(offs_t offset)
 {
-	if(!offset)
-		m_latches[2]&=~1;
+	if (!machine().side_effects_disabled())
+	{
+		if (!offset)
+			m_latches[2] &= ~1;
+	}
 	return m_latches[offset];
 }
 
 void ssv_state::latch16_w(offs_t offset, uint16_t data)
 {
-	if(!offset)
-		m_latches[2]|=2;
-	m_latches[offset]=data;
+	if (!offset)
+		m_latches[2] |= 2;
+	m_latches[offset] = data;
 	machine().scheduler().synchronize();
 }
 
@@ -876,7 +872,7 @@ void ssv_state::jsk_v810_mem(address_map &map)
 
 void eaglshot_state::gfxrom_bank_w(uint8_t data)
 {
-	membank("gfxrom")->set_entry(data < 6 ? data : 6);
+	m_gfxrom_bank->set_entry(data < 6 ? data : 6);
 }
 
 void eaglshot_state::trackball_w(uint8_t data)
@@ -913,7 +909,7 @@ void eaglshot_state::eaglshot_map(address_map &map)
 	map(0x21000e, 0x21000f).w(FUNC(eaglshot_state::lockout_inv_w));                            // Inverted lockout lines
 	map(0x800000, 0x800000).w(FUNC(eaglshot_state::gfxrom_bank_w));
 	map(0x900000, 0x900000).w(FUNC(eaglshot_state::trackball_w));
-	map(0xa00000, 0xbfffff).bankr("gfxrom");
+	map(0xa00000, 0xbfffff).bankr(m_gfxrom_bank);
 	map(0xc00000, 0xc007ff).ram().share("nvram");   // NVRAM
 	map(0xd00000, 0xd00000).r(m_upd4701, FUNC(upd4701_device::d_r));
 }
@@ -983,10 +979,10 @@ void eaglshot_state::eaglshot_map(address_map &map)
 
 static INPUT_PORTS_START( ssv_joystick )
 	PORT_START("DSW1")  // IN0 - $210002
-	PORT_BIT( 0x00ff, IP_ACTIVE_LOW, IPT_UNKNOWN )      /* Modified below */
+	PORT_BIT( 0x00ff, IP_ACTIVE_LOW, IPT_UNKNOWN )      // Modified below
 
 	PORT_START("DSW2")  // IN1 - $210004
-	PORT_BIT( 0x00ff, IP_ACTIVE_LOW, IPT_UNKNOWN )      /* Modified below */
+	PORT_BIT( 0x00ff, IP_ACTIVE_LOW, IPT_UNKNOWN )      // Modified below
 
 	PORT_START("P1")    // IN2 - $210008
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_START1 )
@@ -1073,7 +1069,7 @@ INPUT_PORTS_END
 
 static INPUT_PORTS_START( ssv_quiz )
 	PORT_START("DSW1")  // IN0 - $210002
-	PORT_DIPUNUSED_DIPLOC( 0x0001, 0x0001, "DSW1:1" ) /* Manual states this dip is "Unused" */
+	PORT_DIPUNUSED_DIPLOC( 0x0001, 0x0001, "DSW1:1" ) // Manual states this dip is "Unused"
 	PORT_DIPNAME( 0x0002, 0x0002, DEF_STR( Flip_Screen ) )  PORT_DIPLOCATION( "DSW1:2" )
 	PORT_DIPSETTING(      0x0002, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
@@ -1082,15 +1078,15 @@ static INPUT_PORTS_START( ssv_quiz )
 	PORT_DIPSETTING(      0x0000, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0008, DEF_STR( On ) )
 	SSV_COINAGE_BASIC( 4, 0x03, DEF_STR( Coin_A ), "DSW1:5,6" )
-	PORT_BIT( 0x00c0, IP_ACTIVE_LOW, IPT_UNKNOWN )  /* Modified below */
+	PORT_BIT( 0x00c0, IP_ACTIVE_LOW, IPT_UNKNOWN )  // Modified below
 
 	PORT_START("DSW2")  // IN1 - $210004
 	PORT_DIPNAME( 0x0003, 0x0003, DEF_STR( Difficulty ) )   PORT_DIPLOCATION( "DSW2:1,2" )
-	PORT_DIPSETTING(      0x0002, DEF_STR( Easy ) )     /* 15 sec */
-	PORT_DIPSETTING(      0x0003, DEF_STR( Normal ) )   /* 12 sec */
-	PORT_DIPSETTING(      0x0001, DEF_STR( Hard ) )     /* 10 sec */
-	PORT_DIPSETTING(      0x0000, DEF_STR( Hardest ) )  /* 8 sec */
-	PORT_BIT( 0x00fc, IP_ACTIVE_LOW, IPT_UNKNOWN )      /* Modified below */
+	PORT_DIPSETTING(      0x0002, DEF_STR( Easy ) )     // 15 sec
+	PORT_DIPSETTING(      0x0003, DEF_STR( Normal ) )   // 12 sec
+	PORT_DIPSETTING(      0x0001, DEF_STR( Hard ) )     // 10 sec
+	PORT_DIPSETTING(      0x0000, DEF_STR( Hardest ) )  // 8 sec
+	PORT_BIT( 0x00fc, IP_ACTIVE_LOW, IPT_UNKNOWN )      // Modified below
 
 	PORT_START("P1")    // IN2 - $210008
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_START1  )
@@ -1131,8 +1127,8 @@ static INPUT_PORTS_START( cairblad )
 	PORT_MODIFY("DSW1") // IN0
 	SSV_COINAGE_STANDARD( 0, 0x07, DEF_STR( Coin_A ), "DSW1:1,2,3" )
 	SSV_COINAGE_STANDARD( 3, 0x07, DEF_STR( Coin_B ), "DSW1:4,5,6" )
-	PORT_DIPUNUSED_DIPLOC( 0x0040, 0x0040, "DSW1:7" ) /* Manual lists this dip as "Unused" */
-	PORT_DIPUNUSED_DIPLOC( 0x0080, 0x0080, "DSW1:8" ) /* Manual lists this dip as "Unused" */
+	PORT_DIPUNUSED_DIPLOC( 0x0040, 0x0040, "DSW1:7" ) // Manual lists this dip as "Unused"
+	PORT_DIPUNUSED_DIPLOC( 0x0080, 0x0080, "DSW1:8" ) // Manual lists this dip as "Unused"
 
 	PORT_MODIFY("DSW2") // IN1
 	PORT_DIPNAME( 0x0001, 0x0001, DEF_STR( Flip_Screen ) )  PORT_DIPLOCATION( "DSW2:1" )
@@ -1185,7 +1181,7 @@ static INPUT_PORTS_START( drifto94 )
 	PORT_DIPSETTING(      0x0002, DEF_STR( Easy ) )
 	PORT_DIPSETTING(      0x0001, DEF_STR( Hard ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( Hardest ) )
-	PORT_DIPUNKNOWN_DIPLOC( 0x0004, 0x0004, "DSW2:3" ) /* Manual lists these dips as "Unused" */
+	PORT_DIPUNKNOWN_DIPLOC( 0x0004, 0x0004, "DSW2:3" ) // Manual lists these dips as "Unused"
 	PORT_DIPUNKNOWN_DIPLOC( 0x0008, 0x0008, "DSW2:4" )
 	PORT_DIPNAME( 0x0010, 0x0010, "Music Volume" )          PORT_DIPLOCATION( "DSW2:5" )
 	PORT_DIPSETTING(      0x0000, "Quiet" )
@@ -1196,7 +1192,7 @@ static INPUT_PORTS_START( drifto94 )
 	PORT_DIPNAME( 0x0040, 0x0040, "Save Best Time" )        PORT_DIPLOCATION( "DSW2:7" )
 	PORT_DIPSETTING(      0x0000, DEF_STR( No ) )
 	PORT_DIPSETTING(      0x0040, DEF_STR( Yes ) )
-	PORT_DIPUNUSED_DIPLOC( 0x0080, 0x0080, "DSW2:8" ) /* Manual lists this dip as "Unused" */
+	PORT_DIPUNUSED_DIPLOC( 0x0080, 0x0080, "DSW2:8" ) // Manual lists this dip as "Unused"
 INPUT_PORTS_END
 
 
@@ -1328,7 +1324,7 @@ static INPUT_PORTS_START( eaglshot )
 	PORT_DIPSETTING(      0x0008, DEF_STR( Easy ) )
 	PORT_DIPSETTING(      0x000c, DEF_STR( Normal ) )
 	PORT_DIPSETTING(      0x0004, DEF_STR( Hard ) )
-	/*PORT_DIPSETTING(      0x0000, "???" ) - No listed value for ON & ON */
+	// PORT_DIPSETTING(      0x0000, "???" ) - No listed value for ON & ON
 	PORT_DIPNAME( 0x0010, 0x0010, DEF_STR( Demo_Sounds ) )      PORT_DIPLOCATION( "DSW2:5" )
 	PORT_DIPSETTING(      0x0000, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0010, DEF_STR( On ) )
@@ -1362,11 +1358,11 @@ static INPUT_PORTS_START( gdfs )
 	PORT_DIPNAME( 0x0002, 0x0002, "Light Gun Calibration" ) PORT_DIPLOCATION( "DSW1:2" )
 	PORT_DIPSETTING(      0x0002, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0004, 0x0004, DEF_STR( Level_Select ) ) PORT_DIPLOCATION( "DSW1:3" ) /* Manual lists this dip as "Unused" */
+	PORT_DIPNAME( 0x0004, 0x0004, DEF_STR( Level_Select ) ) PORT_DIPLOCATION( "DSW1:3" ) // Manual lists this dip as "Unused"
 	PORT_DIPSETTING(      0x0004, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 	PORT_DIPNAME( 0x0018, 0x0018, DEF_STR( Coinage ) )  PORT_DIPLOCATION( "DSW1:4,5" )
-//  PORT_DIPSETTING(      0x0000, DEF_STR( 2C_1C ) ) /* 2 Coins to Start, 1 Coin to Continue??? */
+//  PORT_DIPSETTING(      0x0000, DEF_STR( 2C_1C ) ) // 2 Coins to Start, 1 Coin to Continue???
 	PORT_DIPSETTING(      0x0010, DEF_STR( 2C_1C ) )
 	PORT_DIPSETTING(      0x0018, DEF_STR( 1C_1C ) )
 	PORT_DIPSETTING(      0x0008, DEF_STR( 1C_2C ) )
@@ -1376,14 +1372,14 @@ static INPUT_PORTS_START( gdfs )
 	PORT_DIPNAME( 0x0040, 0x0040, DEF_STR( Flip_Screen ) )  PORT_DIPLOCATION( "DSW1:7" )
 	PORT_DIPSETTING(      0x0040, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPUNUSED_DIPLOC( 0x0080, 0x0080, "DSW1:8" )   /* Manual lists this dip as "Unused" */
+	PORT_DIPUNUSED_DIPLOC( 0x0080, 0x0080, "DSW1:8" )   // Manual lists this dip as "Unused"
 
 	PORT_MODIFY("DSW2") // IN1 - $210004
 	PORT_DIPNAME( 0x0001, 0x0001, "Invert X Axis" )     PORT_DIPLOCATION( "DSW2:1" )
 	PORT_DIPSETTING(      0x0001, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPUNUSED_DIPLOC( 0x0002, 0x0002, "DSW2:2" )   /* Manual lists this dip as "Unused" */
-	PORT_DIPUNUSED_DIPLOC( 0x0004, 0x0004, "DSW2:3" )   /* Manual lists this dip as "Unused" */
+	PORT_DIPUNUSED_DIPLOC( 0x0002, 0x0002, "DSW2:2" )   // Manual lists this dip as "Unused"
+	PORT_DIPUNUSED_DIPLOC( 0x0004, 0x0004, "DSW2:3" )   // Manual lists this dip as "Unused"
 	PORT_DIPNAME( 0x0008, 0x0000, DEF_STR( Language ) ) PORT_DIPLOCATION( "DSW2:4" )
 	PORT_DIPSETTING(      0x0000, DEF_STR( English ) )
 	PORT_DIPSETTING(      0x0008, DEF_STR( Japanese ) )
@@ -1759,8 +1755,8 @@ static INPUT_PORTS_START( keithlcy )
 	PORT_DIPSETTING(      0x0020, "Every 150k" )        //150
 	PORT_DIPSETTING(      0x0010, "100k & Every 200K" ) //100
 	PORT_DIPSETTING(      0x0000, "Every 200k" )        //200
-	PORT_DIPUNUSED_DIPLOC( 0x0040, 0x0040, "DSW2:7" ) /* Manual lists these dips as "Unused" */
-	PORT_DIPUNUSED_DIPLOC( 0x0080, 0x0080, "DSW2:8" ) /* Manual lists these dips as "Unused" */
+	PORT_DIPUNUSED_DIPLOC( 0x0040, 0x0040, "DSW2:7" ) // Manual lists these dips as "Unused"
+	PORT_DIPUNUSED_DIPLOC( 0x0080, 0x0080, "DSW2:8" ) // Manual lists these dips as "Unused"
 INPUT_PORTS_END
 
 
@@ -1898,7 +1894,7 @@ static INPUT_PORTS_START( mslider )
 	SSV_COINAGE_STANDARD( 0, 0x07, DEF_STR( Coin_A ), "DSW1:1,2,3" )
 	SSV_COINAGE_STANDARD( 3, 0x07, DEF_STR( Coin_B ), "DSW1:4,5,6" )
 	PORT_SERVICE_DIPLOC( 0x0040, IP_ACTIVE_LOW, "DSW1:7" )
-	PORT_DIPUNUSED_DIPLOC( 0x0080, 0x0080, "DSW1:8" ) /* Manual lists this dip as "Unused" */
+	PORT_DIPUNUSED_DIPLOC( 0x0080, 0x0080, "DSW1:8" ) // Manual lists this dip as "Unused"
 
 	PORT_MODIFY("DSW2") // IN1 - $210004
 	PORT_DIPNAME( 0x0001, 0x0000, DEF_STR( Flip_Screen ) )  PORT_DIPLOCATION( "DSW2:1" )
@@ -1917,7 +1913,7 @@ static INPUT_PORTS_START( mslider )
 	PORT_DIPSETTING(      0x0030, "2" )
 	PORT_DIPSETTING(      0x0020, "3" )
 	PORT_DIPSETTING(      0x0010, "4" )
-	PORT_DIPUNUSED_DIPLOC( 0x0040, 0x0040, "DSW2:7" ) /* Manual lists these dips as "Unused" */
+	PORT_DIPUNUSED_DIPLOC( 0x0040, 0x0040, "DSW2:7" ) // Manual lists these dips as "Unused"
 	PORT_DIPUNUSED_DIPLOC( 0x0080, 0x0080, "DSW2:8" )
 INPUT_PORTS_END
 
@@ -1930,11 +1926,11 @@ static INPUT_PORTS_START( ryorioh )
 	PORT_INCLUDE(ssv_quiz)
 
 	PORT_MODIFY("DSW1") // IN0 - $210002
-	PORT_DIPUNUSED_DIPLOC( 0x0040, 0x0040, "DSW1:7" ) /* Manual states this dip is "Unused" */
+	PORT_DIPUNUSED_DIPLOC( 0x0040, 0x0040, "DSW1:7" ) // Manual states this dip is "Unused"
 	PORT_DIPUNKNOWN_DIPLOC( 0x0080, 0x0080, "DSW1:8" )
 
 	PORT_MODIFY("DSW2") // IN1 - $210004
-	PORT_DIPUNUSED_DIPLOC( 0x0004, 0x0004, "DSW2:3" ) /* Manual states dips 3-8 are "Unused" */
+	PORT_DIPUNUSED_DIPLOC( 0x0004, 0x0004, "DSW2:3" ) // Manual states dips 3-8 are "Unused"
 	PORT_DIPUNUSED_DIPLOC( 0x0008, 0x0008, "DSW2:4" )
 	PORT_DIPUNUSED_DIPLOC( 0x0010, 0x0010, "DSW2:5" )
 	PORT_DIPUNUSED_DIPLOC( 0x0020, 0x0020, "DSW2:6" )
@@ -2119,7 +2115,7 @@ static INPUT_PORTS_START( stmblade )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 
 	PORT_MODIFY("DSW2") // IN1 - $210004
-	PORT_DIPNAME( 0x0001, 0x0000, DEF_STR( Flip_Screen ) )  PORT_DIPLOCATION( "DSW2:1" ) /* works opposite of expected, emulation issue?? */
+	PORT_DIPNAME( 0x0001, 0x0000, DEF_STR( Flip_Screen ) )  PORT_DIPLOCATION( "DSW2:1" ) // works opposite of expected, emulation issue??
 	PORT_DIPSETTING(      0x0001, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 	PORT_DIPNAME( 0x0002, 0x0002, DEF_STR( Demo_Sounds ) )  PORT_DIPLOCATION( "DSW2:2" )
@@ -2466,7 +2462,7 @@ static const gfx_layout layout_16x8x8 =
 };
 
 static GFXDECODE_START( gfx_ssv )
-	GFXDECODE_ENTRY( "gfx1", 0, layout_16x8x8, 0, 0x8000/64 ) // [0] Sprites (256 colors)
+	GFXDECODE_ENTRY( "sprites", 0, layout_16x8x8, 0, 0x8000/64 ) // [0] Sprites (256 colors)
 GFXDECODE_END
 
 static const gfx_layout layout_16x8x8_ram =
@@ -2484,20 +2480,9 @@ static GFXDECODE_START( gfx_eaglshot )
 	GFXDECODE_ENTRY( nullptr, 0, layout_16x8x8_ram, 0, 0x8000/64 ) // [0] Sprites (256 colors, decoded from RAM)
 GFXDECODE_END
 
-static const gfx_layout layout_16x16x8 =
-{
-	16,16,
-	RGN_FRAC(1,1),
-	8,
-	{   STEP8(0,1)      },
-	{   STEP16(0,8)     },
-	{   STEP16(0,16*8)  },
-	16*16*8
-};
-
 static GFXDECODE_START( gfx_gdfs )
-	GFXDECODE_ENTRY( "gfx1", 0, layout_16x8x8,   0, 0x8000/64  ) // [0] Sprites (256 colors)
-	GFXDECODE_ENTRY( "gfx3", 0, layout_16x16x8,  0, 0x8000/256 ) // [3] Tilemap
+	GFXDECODE_ENTRY( "sprites", 0, layout_16x8x8,   0, 0x8000/64  ) // [0] Sprites (256 colors)
+	GFXDECODE_ENTRY( "tiles",   0, gfx_16x16x8_raw, 0, 0x8000/256 ) // [1] Tilemap
 GFXDECODE_END
 
 /***************************************************************************
@@ -2525,7 +2510,7 @@ void ssv_state::init_ssv()
 		m_tile_code[i] = bitswap<4>(i,0,1,2,3) << 16;
 
 	enable_video(1);
-	m_interrupt_ultrax = 0;
+	m_interrupt_ultrax = false;
 
 	save_item(NAME(m_requested_int));
 	save_item(NAME(m_irq_enable));
@@ -2541,7 +2526,7 @@ void ssv_state::init_ssv_tilescram()
 
 
 // srmp4
-//  ((uint16_t *)memregion("maincpu")->base())[0x2b38/2] = 0x037a;   /* patch to see gal test mode */
+//  ((uint16_t *)memregion("maincpu")->base())[0x2b38/2] = 0x037a;   // patch to see gal test mode
 
 void sxyreact_state::init_sexy()
 {
@@ -2551,7 +2536,7 @@ void sxyreact_state::init_sexy()
 void eaglshot_state::init_eaglshot()
 {
 	init_ssv_tilescram();
-	membank("gfxrom")->configure_entries(0, 6+1, memregion("gfxdata")->base(), 0x200000);
+	m_gfxrom_bank->configure_entries(0, 6+1, memregion("gfxdata")->base(), 0x200000);
 }
 
 void ssv_state::init_jsk()
@@ -2569,7 +2554,7 @@ void ssv_state::init_pastelis()
 void ssv_state::init_ssv_irq1()
 {
 	init_ssv();
-	m_interrupt_ultrax = 1;
+	m_interrupt_ultrax = true;
 }
 
 void ssv_state::init_srmp7()
@@ -2582,27 +2567,27 @@ void ssv_state::init_srmp7()
 }
 
 
-#define SSV_MASTER_CLOCK XTAL(48'000'000)/3
+static constexpr XTAL SSV_MASTER_CLOCK = XTAL(48'000'000)/3;
 
-#define SSV_PIXEL_CLOCK XTAL(42'954'545)/6
-#define SSV_HTOTAL 0x1c6
-#define SSV_HBEND 0
-#define SSV_HBSTART 0x150
-#define SSV_VTOTAL 0x106
-#define SSV_VBEND 0
-#define SSV_VBSTART 0xf0
+static constexpr XTAL SSV_PIXEL_CLOCK  = XTAL(42'954'545)/6;
+static constexpr uint32_t SSV_HTOTAL = 0x1c6;
+static constexpr uint32_t SSV_HBEND = 0;
+static constexpr uint32_t SSV_HBSTART = 0x150;
+static constexpr uint32_t SSV_VTOTAL = 0x106;
+static constexpr uint32_t SSV_VBEND = 0;
+static constexpr uint32_t SSV_VBSTART = 0xf0;
 
 void ssv_state::ssv(machine_config &config)
 {
-	/* basic machine hardware */
-	V60(config, m_maincpu, SSV_MASTER_CLOCK); /* Based on STA-0001 & STA-0001B System boards */
+	// basic machine hardware
+	V60(config, m_maincpu, SSV_MASTER_CLOCK); // Based on STA-0001 & STA-0001B System boards
 	m_maincpu->set_irq_acknowledge_callback(FUNC(ssv_state::irq_callback));
 
 	TIMER(config, "scantimer").configure_scanline(FUNC(ssv_state::interrupt), "screen", 0, 1);
 
-	/* video hardware */
+	// video hardware
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
-	m_screen->set_raw(SSV_PIXEL_CLOCK,SSV_HTOTAL,SSV_HBEND,SSV_HBSTART,SSV_VTOTAL,SSV_VBEND,SSV_VBSTART);
+	m_screen->set_raw(SSV_PIXEL_CLOCK, SSV_HTOTAL, SSV_HBEND, SSV_HBSTART, SSV_VTOTAL, SSV_VBEND, SSV_VBSTART);
 	m_screen->set_screen_update(FUNC(ssv_state::screen_update));
 	m_screen->set_palette(m_palette);
 	//m_screen->set_video_attributes(VIDEO_UPDATE_SCANLINE);
@@ -2610,7 +2595,7 @@ void ssv_state::ssv(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_ssv);
 	PALETTE(config, m_palette).set_format(palette_device::xRGB_888, 0x8000);
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
@@ -2624,22 +2609,22 @@ void ssv_state::ssv(machine_config &config)
 	m_ensoniq->add_route(1, "rspeaker", 0.1);
 }
 
-void ssv_state::drifto94(machine_config &config)
+void drifto94_state::drifto94(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::drifto94_map);
+	// basic machine hardware
+	m_maincpu->set_addrmap(AS_PROGRAM, &drifto94_state::drifto94_map);
 
-	UPD96050(config, m_dsp, 10000000); /* TODO: correct? */
-	m_dsp->set_addrmap(AS_PROGRAM, &ssv_state::dsp_prg_map);
-	m_dsp->set_addrmap(AS_DATA, &ssv_state::dsp_data_map);
+	UPD96050(config, m_dsp, 10000000); // TODO: correct?
+	m_dsp->set_addrmap(AS_PROGRAM, &drifto94_state::dsp_prg_map);
+	m_dsp->set_addrmap(AS_DATA, &drifto94_state::dsp_data_map);
 
 	config.set_perfect_quantum(m_maincpu);
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xcd-0x25)*2-1, 0, (0x101-0x13)-1);
 }
 
@@ -2647,7 +2632,7 @@ void gdfs_state::gdfs(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &gdfs_state::gdfs_map);
 
 	EEPROM_93C46_16BIT(config, m_eeprom);
@@ -2659,7 +2644,7 @@ void gdfs_state::gdfs(machine_config &config)
 	m_adc->in_callback<3>().set_ioport("GUNY2");
 	m_adc->eoc_callback().set(FUNC(gdfs_state::adc_int_w));
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xd5-0x2c)*2-1, 0, (0x102-0x12)-1);
 	m_screen->set_screen_update(FUNC(gdfs_state::screen_update));
 
@@ -2673,12 +2658,12 @@ void ssv_state::hypreact(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::hypreact_map);
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xcb-0x22)*2-1, 0, (0xfe - 0x0e)-1);
 }
 
@@ -2686,12 +2671,12 @@ void ssv_state::hypreac2(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::hypreac2_map);
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xcb-0x22)*2-1, 0, (0xfe - 0x0e)-1);
 }
 
@@ -2699,10 +2684,10 @@ void ssv_state::janjans1(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::janjans1_map);
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xcb-0x23)*2-1, 0, (0xfe - 0x0e)-1);
 }
 
@@ -2710,10 +2695,10 @@ void ssv_state::keithlcy(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::keithlcy_map);
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xcd-0x25)*2-1, 0, (0x101 - 0x13)-1);
 }
 
@@ -2721,14 +2706,14 @@ void ssv_state::meosism(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::meosism_map);
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xd5-0x2c)*2-1, 0, (0xfe - 0x12)-1);
 }
 
@@ -2736,10 +2721,10 @@ void ssv_state::mslider(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::mslider_map);
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xd6-0x26)*2-1, 0, (0xfe - 0x0e)-1);
 }
 
@@ -2747,12 +2732,12 @@ void ssv_state::ryorioh(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::ryorioh_map);
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xcb-0x23)*2-1, 0, (0xfe - 0x0e)-1);
 }
 
@@ -2760,12 +2745,12 @@ void ssv_state::vasara(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::ryorioh_map);
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xcc-0x24)*2-1, 0,(0xfe - 0x0e)-1);
 }
 
@@ -2773,12 +2758,12 @@ void ssv_state::srmp4(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::srmp4_map);
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xd4-0x2c)*2-1, 0, (0x102 - 0x12)-1);
 }
 
@@ -2786,35 +2771,35 @@ void ssv_state::srmp7(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::srmp7_map);
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xd4-0x2c)*2-1, 0, (0xfd - 0x0e)-1);
 
 	m_ensoniq->set_addrmap(2, &ssv_state::srmp7_es5506_bank2_map);
 	m_ensoniq->set_addrmap(3, &ssv_state::srmp7_es5506_bank3_map);
 }
 
-void ssv_state::stmblade(machine_config &config)
+void drifto94_state::stmblade(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::drifto94_map);
+	// basic machine hardware
+	m_maincpu->set_addrmap(AS_PROGRAM, &drifto94_state::drifto94_map);
 
 	UPD96050(config, m_dsp, 10000000);
-	m_dsp->set_addrmap(AS_PROGRAM, &ssv_state::dsp_prg_map);
-	m_dsp->set_addrmap(AS_DATA, &ssv_state::dsp_data_map);
+	m_dsp->set_addrmap(AS_PROGRAM, &drifto94_state::dsp_prg_map);
+	m_dsp->set_addrmap(AS_DATA, &drifto94_state::dsp_data_map);
 
-	/* don't need this, game just does a simple check at boot then the DSP stalls into a tight loop. */
+	// don't need this, game just does a simple check at boot then the DSP stalls into a tight loop.
 	//config.set_perfect_quantum(m_maincpu);
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xd6-0x26)*2-1, 0, (0xfe - 0x0e)-1);
 }
 
@@ -2822,12 +2807,12 @@ void ssv_state::survarts(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::survarts_map);
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xd4-0x2c)*2-1, 0, (0x102 - 0x12)-1);
 }
 
@@ -2835,7 +2820,7 @@ void ssv_state::dynagear(machine_config &config)
 {
 	survarts(config);
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xd4-0x2c)*2-1, 0, (0x102 - 0x12)-1);
 }
 
@@ -2843,7 +2828,7 @@ void eaglshot_state::eaglshot(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &eaglshot_state::eaglshot_map);
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
@@ -2854,7 +2839,7 @@ void eaglshot_state::eaglshot(machine_config &config)
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xca - 0x2a)*2-1, 0, (0xf6 - 0x16)-1);
 	m_screen->set_screen_update(FUNC(eaglshot_state::screen_update));
 
@@ -2865,7 +2850,7 @@ void sxyreact_state::sxyreact(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &sxyreact_state::sxyreact_map);
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
@@ -2877,7 +2862,7 @@ void sxyreact_state::sxyreact(machine_config &config)
 	m_sxyreact_adc->dl_w(1);
 	m_sxyreact_adc->si_w(0);
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xcb - 0x22)*2-1, 0, (0xfe - 0x0e)-1);
 }
 
@@ -2885,7 +2870,7 @@ void sxyreact_state::sxyreac2(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &sxyreact_state::sxyreact_map);
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
@@ -2895,7 +2880,7 @@ void sxyreact_state::sxyreac2(machine_config &config)
 	UPD7001(config, m_sxyreact_adc, 1'500'000); // FIXME: runs too fast because CPU doesn't wait long enough
 	m_sxyreact_adc->a0_callback().set_ioport("PADDLE");
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xcb - 0x23)*2-1, 0, (0xfe - 0x0e)-1);
 }
 
@@ -2903,33 +2888,33 @@ void ssv_state::cairblad(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::cairblad_map);
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xcb - 0x22)*2-1, 0, (0xfe - 0x0e)-1);
 }
 
-void ssv_state::twineag2(machine_config &config)
+void drifto94_state::twineag2(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::twineag2_map);
+	// basic machine hardware
+	m_maincpu->set_addrmap(AS_PROGRAM, &drifto94_state::twineag2_map);
 
 	UPD96050(config, m_dsp, 10000000);
-	m_dsp->set_addrmap(AS_PROGRAM, &ssv_state::dsp_prg_map);
-	m_dsp->set_addrmap(AS_DATA, &ssv_state::dsp_data_map);
+	m_dsp->set_addrmap(AS_PROGRAM, &drifto94_state::dsp_prg_map);
+	m_dsp->set_addrmap(AS_DATA, &drifto94_state::dsp_data_map);
 
 	config.set_perfect_quantum(m_maincpu);
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xd4 - 0x2c)*2-1, 0, (0x102 - 0x12)-1);
 }
 
@@ -2937,12 +2922,12 @@ void ssv_state::ultrax(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::ultrax_map);
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xd4 - 0x2c)*2-1, 0, (0x102 - 0x12)-1);
 }
 
@@ -2950,14 +2935,14 @@ void ssv_state::jsk(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::jsk_map);
 
 	V810(config, "sub", 25000000).set_addrmap(AS_PROGRAM, &ssv_state::jsk_v810_mem);
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xca - 0x22)*2-1, 0, (0xfe - 0x0e)-1);
 }
 
@@ -2965,10 +2950,10 @@ void ssv_state::pastelis(machine_config &config)
 {
 	ssv(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &ssv_state::keithlcy_map);
 
-	/* video hardware */
+	// video hardware
 	m_screen->set_visarea(0, (0xd6-0x26)*2-1, 0, (0xfe - 0x0e)-1);
 }
 
@@ -3016,10 +3001,10 @@ AC1810E01.U32   27C160
 ***************************************************************************/
 
 ROM_START( cairblad )
-	ROM_REGION( 0x200000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x200000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_WORD( "ac1810e0.u32",  0x000000, 0x200000, CRC(13a0b4c2) SHA1(3498303e9b186ab329ee761cee9d4cb8ed552455) ) // AC1810E01.U32    27C160
 
-	ROM_REGION( 0x2000000, "gfx1", 0 )  /* Sprites */
+	ROM_REGION( 0x2000000, "sprites", ROMREGION_ERASE00 )
 	ROM_LOAD( "ac1801m0.u6",  0x0000000, 0x400000, CRC(1b2b6943) SHA1(95c5dc0ed1d533b2285452c8546346d96a90d097) ) // AC1801M01.U6    32M Mask
 	ROM_LOAD( "ac1802m0.u9",  0x0400000, 0x400000, CRC(e053b087) SHA1(9569e79c6363e8f97c27aacaa29d25cf32c4b4c1) ) // AC1802M01.U9    32M Mask
 
@@ -3029,9 +3014,7 @@ ROM_START( cairblad )
 	ROM_LOAD( "ac1805m0.u8",  0x1000000, 0x400000, CRC(19771f43) SHA1(d6a05392c58d3f60d666e08b3a82f06fa2c8e3a3) ) // AC1805M01.U8    32M Mask
 	ROM_LOAD( "ac1806m0.u11", 0x1400000, 0x400000, CRC(816b97dc) SHA1(3737cb37a4db720901661fa9b4e30c44181efb94) ) // AC1806M01.U11   32M Mask
 
-	ROM_FILL(                 0x1800000, 0x800000, 0x000000)
-
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "ac1410m0.u41", 0x000000, 0x400000, CRC(ecf1f255) SHA1(984b1529b8f0c7d94ea713c85d71df00f54eba79) ) // AC1807M01.U41   32M Mask
 ROM_END
 
@@ -3120,14 +3103,14 @@ ADC0809CCN: 8bit microprocessor compatible A/D converters with 8-Channel Multipl
 ***************************************************************************/
 
 ROM_START( drifto94 )
-	ROM_REGION( 0x400000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x400000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_WORD( "vg003-19.u26", 0x000000, 0x200000, CRC(238e5e2b) SHA1(fe58f571857804263642d7d089df962327a007b6) ) // "SoundDriverV1.1a"
 	ROM_LOAD16_BYTE( "visco-37.u37", 0x200000, 0x080000, CRC(78fa3ccb) SHA1(0c79ff1aa31e7ca1eeb14fbef7774278fa83ba44) )
 	ROM_RELOAD(                      0x300000, 0x080000)
 	ROM_LOAD16_BYTE( "visco-33.u33", 0x200001, 0x080000, CRC(88351146) SHA1(1decce44b5d244b57676177f417e4937d7088124) )
 	ROM_RELOAD(                      0x300001, 0x080000)
 
-	ROM_REGION( 0x2000000, "gfx1", 0 )  /* Sprites */
+	ROM_REGION( 0x2000000, "sprites", 0 )
 	ROM_LOAD( "vg003-01.a0", 0x0000000, 0x200000, CRC(2812aa1a) SHA1(5046fe51a4ea50051a19cfeeb091c87f0f217fb8) )
 	ROM_LOAD( "vg003-05.a1", 0x0200000, 0x200000, CRC(1a1dd910) SHA1(f2252e4cd1b6269036ed02cec9d5a224736c1bce) )
 	ROM_LOAD( "vg003-09.a2", 0x0400000, 0x200000, CRC(198f1c06) SHA1(7df5d51aa62f0b609cd1d296a3cfeeb38fbcd9d0) )
@@ -3148,10 +3131,10 @@ ROM_START( drifto94 )
 	ROM_LOAD( "vg003-12.d2", 0x1c00000, 0x200000, CRC(ac0fd855) SHA1(992ae0d02bcefaa2fad7462b211a49fbd1338b62) )
 	ROM_LOAD( "vg003-16.d3", 0x1e00000, 0x200000, CRC(1a5fd312) SHA1(1e67ffa51408de107be75c9c63df6fd1bb6ce6b1) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "vg003-17.u22", 0x000000, 0x200000, CRC(6f9294ce) SHA1(b097defd95eb1d8f00e107d7669f9d33148e75c1) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "vg003-18.u15", 0x000000, 0x200000, CRC(511b3e93) SHA1(09eda175c8f1b21c18645519cc6e89c6ca1fc5de) )
 
 	ROM_REGION( 0x11000, "st010", 0)
@@ -3243,11 +3226,11 @@ This chip is used for the trackball trigger / reading / converting values
 ***************************************************************************/
 
 ROM_START( eaglshot )
-	ROM_REGION( 0x100000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x100000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_BYTE( "si003-09.u18",  0x000000, 0x080000, CRC(219c71ce) SHA1(4f8996b4c5b267a90073d67857358147732f8c0d) )
 	ROM_LOAD16_BYTE( "si003-10.u20",  0x000001, 0x080000, CRC(c8872e48) SHA1(c8e1e712d5fa380f8fc1447502f21d2ae592811a) )
 
-	ROM_REGION16_LE( 0xe00000, "gfxdata", ROMREGION_ERASEFF ) /* Sprites - Read by the CPU */
+	ROM_REGION16_LE( 0xe00000, "gfxdata", ROMREGION_ERASEFF ) // Sprites - Read by the CPU
 	ROM_LOAD( "si003-01.u13", 0x0000000, 0x200000, CRC(d7df0d52) SHA1(d7b79a186f4272334c2297666c52f32c05787c29) )
 	ROM_LOAD( "si003-02.u12", 0x0200000, 0x200000, CRC(92b4d50d) SHA1(9dc2f2961b088824d8370ac83dff796345fe4158) )
 	ROM_LOAD( "si003-03.u11", 0x0400000, 0x200000, CRC(6ede4012) SHA1(6663990c6ee8e500cb8c51ad2102761ee0b3351d) )
@@ -3255,26 +3238,26 @@ ROM_START( eaglshot )
 	ROM_LOAD( "si003-05.u30", 0x0800000, 0x200000, CRC(daf52d56) SHA1(108419ef7d3716a3890b0d8bcbfddc1585daaae8) )
 	ROM_LOAD( "si003-06.u31", 0x0a00000, 0x200000, CRC(449f9ae5) SHA1(b3e664eb88d14d1e25a0cfc8dcccc8270ca778c9) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "si003-07.u23", 0x000000, 0x200000, CRC(81679fd6) SHA1(ca3b07a87781278b5c7c85951728bbe5dfcbe042) )
 	ROM_LOAD16_WORD_SWAP( "si003-08.u24", 0x200000, 0x200000, CRC(d0122ba2) SHA1(96230fb690cf144cd873f7d51c0304736a698316) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", 0 ) // Samples
 	ROM_COPY( "ensoniq.0", 0x000000, 0x000000, 0x400000 )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
 	ROM_COPY( "ensoniq.0", 0x000000, 0x000000, 0x400000 )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.3", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.3", 0 ) // Samples
 	ROM_COPY( "ensoniq.0", 0x000000, 0x000000, 0x400000 )
 ROM_END
 
 ROM_START( eaglshotj )
-	ROM_REGION( 0x100000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x100000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_BYTE( "sammygolf.u18",  0x000000, 0x080000, CRC(b6d6869c) SHA1(7528751fad783e9b0fd217d2fac2ab408814a583) ) // handwritten labels on prg ROMs, other ROMS had no labels.
 	ROM_LOAD16_BYTE( "sammygolf.u20",  0x000001, 0x080000, CRC(c8872e48) SHA1(c8e1e712d5fa380f8fc1447502f21d2ae592811a) )
 
-	ROM_REGION16_LE( 0xe00000, "gfxdata", ROMREGION_ERASEFF ) /* Sprites - Read by the CPU */
+	ROM_REGION16_LE( 0xe00000, "gfxdata", ROMREGION_ERASEFF ) // Sprites - Read by the CPU
 	ROM_LOAD( "si003-01.u13", 0x0000000, 0x200000, CRC(d7df0d52) SHA1(d7b79a186f4272334c2297666c52f32c05787c29) )
 	ROM_LOAD( "si003-02.u12", 0x0200000, 0x200000, CRC(92b4d50d) SHA1(9dc2f2961b088824d8370ac83dff796345fe4158) )
 	ROM_LOAD( "si003-03.u11", 0x0400000, 0x200000, CRC(6ede4012) SHA1(6663990c6ee8e500cb8c51ad2102761ee0b3351d) )
@@ -3282,17 +3265,17 @@ ROM_START( eaglshotj )
 	ROM_LOAD( "si003-05.u30", 0x0800000, 0x200000, CRC(daf52d56) SHA1(108419ef7d3716a3890b0d8bcbfddc1585daaae8) )
 	ROM_LOAD( "si003-06.u31", 0x0a00000, 0x200000, CRC(449f9ae5) SHA1(b3e664eb88d14d1e25a0cfc8dcccc8270ca778c9) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "si003-07.u23", 0x000000, 0x200000, CRC(81679fd6) SHA1(ca3b07a87781278b5c7c85951728bbe5dfcbe042) )
 	ROM_LOAD16_WORD_SWAP( "si003-08.u24", 0x200000, 0x200000, CRC(d0122ba2) SHA1(96230fb690cf144cd873f7d51c0304736a698316) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", 0 ) // Samples
 	ROM_COPY( "ensoniq.0", 0x000000, 0x000000, 0x400000 )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
 	ROM_COPY( "ensoniq.0", 0x000000, 0x000000, 0x400000 )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.3", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.3", 0 ) // Samples
 	ROM_COPY( "ensoniq.0", 0x000000, 0x000000, 0x400000 )
 ROM_END
 
@@ -3309,11 +3292,11 @@ P1-102A (ROM board)
 ***************************************************************************/
 
 ROM_START( hypreact )
-	ROM_REGION( 0x100000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x100000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_BYTE( "s14-1-02.u2", 0x000000, 0x080000, CRC(d90a383c) SHA1(9945f60ce6e1f50c24c2ae3c2c5d0df9ec3b8926) )
 	ROM_LOAD16_BYTE( "s14-1-01.u1", 0x000001, 0x080000, CRC(80481401) SHA1(4b1b7050893b6659762297d0f6496c7193ea6c4e) )
 
-	ROM_REGION( 0x1800000, "gfx1", 0 )  /* Sprites */
+	ROM_REGION( 0x1800000, "sprites", ROMREGION_ERASE00 )
 	ROM_LOAD( "s14-1-07.u7",  0x0000000, 0x200000, CRC(6c429fd0) SHA1(de1bbcd4a20410328d88a3b246afa8e1a6a6f232) )
 	ROM_LOAD( "s14-1-05.u13", 0x0200000, 0x200000, CRC(2ff72f98) SHA1(92bd5042e19e1dae1252305413684f9cff4bd0ac) )
 	ROM_LOAD( "s14-1-06.u10", 0x0400000, 0x200000, CRC(f470ec42) SHA1(f31e9c3f3daa212226b9eea14aa1d01367fa348f) )
@@ -3326,11 +3309,9 @@ ROM_START( hypreact )
 	ROM_LOAD( "s14-1-11.u14", 0x0e00000, 0x200000, CRC(6d8e7bae) SHA1(93258663ceb6174917560bb66d72a42ba0f96c0e) )
 	ROM_LOAD( "s14-1-12.u11", 0x1000000, 0x200000, CRC(233a8e23) SHA1(0c813ec80ac63aa342c8ea57d9e38cada74456d9) )
 
-	ROM_FILL(                 0x1200000, 0x600000, 0x000000          )
-
 //  The chip seems to use REGION1 too, but produces no sound from there.
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "s14-1-04.u4", 0x000000, 0x200000, CRC(a5955336) SHA1(1ac0f5d27224e93acfe449d8ca5c3ab3b7f5dd8c) )
 	ROM_LOAD16_WORD_SWAP( "s14-1-03.u5", 0x200000, 0x200000, CRC(283a6ec2) SHA1(766c685384ea8d801c53a2ae36b4980318aff06b) )
 ROM_END
@@ -3347,13 +3328,13 @@ P1-112A (ROM board)
 ***************************************************************************/
 
 ROM_START( hypreac2 )
-	ROM_REGION( 0x200000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x200000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_BYTE( "u2.bin",  0x000000, 0x080000, CRC(05c93266) SHA1(0833e80f67ccb4ac17e771fa04dc6f433554a34f) )
 	ROM_LOAD16_BYTE( "u1.bin",  0x000001, 0x080000, CRC(80cf9e59) SHA1(7025321539891e1a3354ca233255f5395d716933) )
 	ROM_LOAD16_BYTE( "u47.bin", 0x100000, 0x080000, CRC(a3e9bfee) SHA1(1e897646bafd07ab48eda2883926506c6bedab87) )
 	ROM_LOAD16_BYTE( "u46.bin", 0x100001, 0x080000, CRC(68c41235) SHA1(6ec32aa6ab6074a8db63a76a3d1a0ec2dc8f8aae) )
 
-	ROM_REGION( 0x2800000, "gfx1", 0 )  /* Sprites */
+	ROM_REGION( 0x2800000, "sprites", ROMREGION_ERASE00 )
 	ROM_LOAD( "s16-1-16.u6",  0x0000000, 0x400000, CRC(b308ac34) SHA1(409652bc5a537650cab1f3709a2c2be206f72a78) )
 	ROM_LOAD( "s16-1-15.u9",  0x0400000, 0x400000, CRC(2c8e381e) SHA1(a8681620809d3d9dc62b443232b6e4c4c4209248) )
 	ROM_LOAD( "s16-1-14.u12", 0x0800000, 0x200000, CRC(afe9d187) SHA1(802df8b1bbb94e4451a6b97c852fa555a6cf5837) )
@@ -3366,15 +3347,13 @@ ROM_START( hypreac2 )
 	ROM_LOAD( "s16-1-12.u11", 0x1800000, 0x400000, CRC(87d9c748) SHA1(1332db901e50e2fd25d3323920f99e0ef0b0533d) )
 	ROM_LOAD( "s16-1-11.u14", 0x1c00000, 0x200000, CRC(70b3c0a0) SHA1(009e2f2f292ed6f10a9d54557861294156664e72) )
 
-	ROM_FILL(                 0x1e00000,0x0a00000, 0x000000)
-
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "s16-1-06.u41", 0x000000, 0x400000, CRC(626e8a81) SHA1(45ef5b630aed575acd160ede1413e0370f4f9761) )
 
-	ROM_REGION16_BE( 0x600000, "ensoniq.1", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x600000, "ensoniq.1", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "s16-1-07.u42", 0x200000, 0x400000, CRC(42bcb41b) SHA1(060312b19bd52770410cec1f77e5d8d6478d80eb) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "s16-1-07.u42", 0x000000, 0x400000, CRC(42bcb41b) SHA1(060312b19bd52770410cec1f77e5d8d6478d80eb) )
 ROM_END
 
@@ -3388,14 +3367,14 @@ ROM_END
 ***************************************************************************/
 
 ROM_START( janjans1 )
-	ROM_REGION( 0x400000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x400000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_WORD( "jj1-data.bin", 0x000000, 0x200000, CRC(6734537e) SHA1(a40f84479141a6f33ce465e66ba9313b54915002) )
 	ROM_LOAD16_BYTE( "jj1-prol.bin", 0x200000, 0x080000, CRC(4231d928) SHA1(820d1233cd1a8d0c4ece15b94bd9be976b383fe2) )
 	ROM_RELOAD(                      0x300000, 0x080000)
 	ROM_LOAD16_BYTE( "jj1-proh.bin", 0x200001, 0x080000, CRC(651383c6) SHA1(8291f86b230eee3a2ebcc926a8370777ee21ec47) )
 	ROM_RELOAD(                      0x300001, 0x080000)
 
-	ROM_REGION( 0x2800000, "gfx1", 0 )  /* Sprites */
+	ROM_REGION( 0x2800000, "sprites", 0 )
 	ROM_LOAD( "jj1-a0.bin", 0x0000000, 0x400000, CRC(39bbbc46) SHA1(77c6b5e9d4315671ea79ec838baa7ae043bcd8c4) )
 	ROM_LOAD( "jj1-a1.bin", 0x0400000, 0x400000, CRC(26020133) SHA1(32c834655d885431d466f25a729aee2d589ade1b) )
 	ROM_LOAD( "jj1-a2.bin", 0x0800000, 0x200000, CRC(e993251e) SHA1(6cea12bbfc170ad4ecdc09c1728f88ec7534270a) )
@@ -3412,10 +3391,10 @@ ROM_START( janjans1 )
 	ROM_LOAD( "jj1-d1.bin", 0x2200000, 0x400000, CRC(f24c0d36) SHA1(212969b456bfd7cc00081f65c03c1e167186891a) )
 	ROM_LOAD( "jj1-d2.bin", 0x2600000, 0x200000, CRC(481b3be8) SHA1(cd1bcaca8c236cebba72d315e759b2e9d243aca8) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "jj1-snd0.bin", 0x000000, 0x200000, CRC(4f7d620a) SHA1(edded130ce7bb0f37e1f59b2771ae6a10a061f9e) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "jj1-snd1.bin", 0x000000, 0x200000, CRC(9b3a7ae5) SHA1(193743fcce779c4a8a73a44c54b5391d08116331) )
 ROM_END
 
@@ -3435,14 +3414,14 @@ NEC D71051 (DIP28)
 ***************************************************************************/
 
 ROM_START( janjans2 )
-	ROM_REGION( 0x400000, "maincpu", 0 )        /* V60 Code */
+	ROM_REGION( 0x400000, "maincpu", 0 )        // V60 Code
 	ROM_LOAD16_WORD( "jan2-dat.u28",  0x000000, 0x200000, CRC(0c9c62bf) SHA1(17c6eea7cec05860c238cc22706fec1a8e3d9263) )
 	ROM_LOAD16_BYTE( "jan2-prol.u26", 0x200000, 0x080000, CRC(758a7249) SHA1(1126e8527bad000bdfbd59da46d72ed256cb0fa9) )
 	ROM_RELOAD(                       0x300000, 0x080000)
 	ROM_LOAD16_BYTE( "jan2-proh.u27", 0x200001, 0x080000, CRC(fcd5da62) SHA1(e0243e41e4ec25e82b0316f1189ed069c369e7b1) )
 	ROM_RELOAD(                       0x300001, 0x080000)
 
-	ROM_REGION( 0x2000000, "gfx1", 0 )    /* Sprites */
+	ROM_REGION( 0x2000000, "sprites", 0 )  
 	ROM_LOAD( "jan2-a0.u13", 0x0000000, 0x400000, CRC(37869bea) SHA1(6259e8584775ca702ef4e9e460c6d874980ffecb) )
 	ROM_LOAD( "jan2-a1.u14", 0x0400000, 0x400000, CRC(8189e74f) SHA1(ea083a7ef0858dac59e14a77f10a9900b20447f3) )
 
@@ -3455,10 +3434,10 @@ ROM_START( janjans2 )
 	ROM_LOAD( "jan2-d0.u34", 0x1800000, 0x400000, CRC(479fdb54) SHA1(667d89518877a3b501a87c9c765b85b9a0b23517) )
 	ROM_LOAD( "jan2-d1.u35", 0x1c00000, 0x400000, CRC(c0148895) SHA1(f89482a6ef475ca44d570332d05201b34887afbb) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )    /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )    // Samples
 	ROM_LOAD16_BYTE( "jan2-snd0.u29", 0x000000, 0x200000, CRC(22cc054e) SHA1(4926dd9f8f85880d6c1d14f93d68f330898b473a) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )    /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )    // Samples
 	ROM_LOAD16_BYTE( "jan2-snd1.u33", 0x000000, 0x200000, CRC(cbcac4a6) SHA1(f0c57fa6784e910bdb94f046d09e58e26921773b) )
 ROM_END
 
@@ -3518,22 +3497,22 @@ ROM_START( jsk )
 	ROM_LOAD32_BYTE( "jsk-u24.bin", 0x00002, 0x20000, CRC(1fa6e156) SHA1(4daedf660d89c185c945d4a526312f6528fe7b17) )
 	ROM_LOAD32_BYTE( "jsk-u4.bin",  0x00003, 0x20000, CRC(ec22fb41) SHA1(c0d6b0a92075214a91da78be52d273771cb9f646) )
 
-	ROM_REGION( 0x1000000, "gfx1", 0 )  /* Sprites */
+	ROM_REGION( 0x1000000, "sprites", 0 )
 	ROM_LOAD( "jsk-a0.bin", 0x0000000, 0x400000, CRC(18981a19) SHA1(b4bf93f38099963350b9e5e64890ce7adc1bc983) )
 	ROM_LOAD( "jsk-b0.bin", 0x0400000, 0x400000, CRC(f6df0ff9) SHA1(d7736e4ae6e099aef320a59668d7f17590c346b9) )
 	ROM_LOAD( "jsk-c0.bin", 0x0800000, 0x400000, CRC(b8282939) SHA1(d041fb013e5011bf6b9d9bc2c816b2f3969723b7) )
 	ROM_LOAD( "jsk-d0.bin", 0x0c00000, 0x400000, CRC(fc733e0c) SHA1(951060f6600b8b677ad2f41f59071c375ea9d4cf) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE )   // Samples
 	ROM_LOAD16_BYTE( "jsk-s0.u65", 0x000000, 0x200000, CRC(8d1a9aeb) SHA1(37316bd3e8cbe2a84239e1a11a56d4fe4723ae1a) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", 0 ) // Samples
 	ROM_COPY( "ensoniq.0", 0x000000, 0x000000, 0x400000 )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
 	ROM_COPY( "ensoniq.0", 0x000000, 0x000000, 0x400000 )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.3", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.3", 0 ) // Samples
 	ROM_COPY( "ensoniq.0", 0x000000, 0x000000, 0x400000 )
 ROM_END
 
@@ -3549,18 +3528,18 @@ STS-0001 (ROM board)
 ***************************************************************************/
 
 ROM_START( keithlcy )
-	ROM_REGION( 0x200000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x200000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_WORD( "vg002-07.u28", 0x000000, 0x100000, CRC(57f80ff5) SHA1(9dcc35a79d3799407190d113e0f1b57864d6c56a) ) // "SETA SoundDriver"
 	ROM_LOAD16_BYTE( "kl-p0l.u26",   0x100000, 0x080000, CRC(d7b177fb) SHA1(2a3533b952a7b2404720916662743c144e870c0b) )
 	ROM_LOAD16_BYTE( "kl-p0h.u27",   0x100001, 0x080000, CRC(9de7add4) SHA1(16f4405b12734cb6a83cff8be21d03bb3c2e2266) )
 
-	ROM_REGION( 0x800000, "gfx1", 0 )   /* Sprites */
+	ROM_REGION( 0x800000, "sprites", 0 ) 
 	ROM_LOAD( "vg002-01.u13", 0x000000, 0x200000, CRC(b44d85b2) SHA1(cf78d46f9f2594a23af08a898afbf5dd609abcec) )
 	ROM_LOAD( "vg002-02.u16", 0x200000, 0x200000, CRC(aa05fd14) SHA1(9144e9668788fcd45bd6c8464f9b4f865397f783) )
 	ROM_LOAD( "vg002-03.u21", 0x400000, 0x200000, CRC(299a8a7d) SHA1(b24d8ffba01d345f48f47f92e58e9b2a9ec62526) )
 	ROM_LOAD( "vg002-04.u34", 0x600000, 0x200000, CRC(d3633f9b) SHA1(250a25b75a4810a676a02c390bb597b6f1cd7494) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "vg002-05.u29", 0x000000, 0x200000, CRC(66aecd79) SHA1(7735034b8fb35ad5e7916acd0c2e224a7c62e195) )
 	ROM_LOAD16_WORD_SWAP( "vg002-06.u33", 0x200000, 0x200000, CRC(75d8c8ea) SHA1(545768ac6d8953cd3044680953476276337a94b9) )
 ROM_END
@@ -3574,12 +3553,12 @@ STS-0001 (ROM board)
 ***************************************************************************/
 
 ROM_START( pastelis )
-	ROM_REGION( 0x400000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x400000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD( "data.u28",  0x000000, 0x200000, CRC(e71dcc02) SHA1(38a66255c8fbf8f1a49a2180719bfaf26fd37ccf) ) // 27c160 - 1ST AND 2ND HALF IDENTICAL (but correct, 2nd half unused)
 	ROM_LOAD16_BYTE( "prg_l.u26", 0x100000, 0x080000, CRC(96c9d4d7) SHA1(27ba8218f667ae12f8d1b14db259c0797220126f) ) // 27c040
 	ROM_LOAD16_BYTE( "prg_h.u27", 0x100001, 0x080000, CRC(a513733b) SHA1(c3caeb0d1b9c56a61552865815cddf67b649d435) ) // 27c040
 
-	ROM_REGION( 0x0a00000, "gfx1", ROMREGION_ERASEFF )  /* Sprites */
+	ROM_REGION( 0x0a00000, "sprites", ROMREGION_ERASEFF )
 	ROM_LOAD( "a0.u13", 0x0000000, 0x200000, CRC(61688d29) SHA1(e5cb96ea9190bc20ad9c10e9d0773350f7defc3f) ) // 27c160
 	ROM_LOAD( "a1.u14", 0x0200000, 0x080000, CRC(d38b9805) SHA1(3b573f7e6b70ce68389001c1e119d4d8dd1cde3d) ) // 27c4100
 	ROM_LOAD( "b0.u16", 0x0280000, 0x200000, CRC(fc93f7bb) SHA1(86baddd1809adc9b4a48919db58ddd008af3aa99) ) // 27c160
@@ -3589,7 +3568,7 @@ ROM_START( pastelis )
 	ROM_LOAD( "d0.u34", 0x0780000, 0x200000, CRC(4f79415a) SHA1(af70656f5a0f46f773a238260e53f646efb2d238) ) // 27c160
 	ROM_LOAD( "d1.u35", 0x0980000, 0x080000, CRC(d3c75994) SHA1(08ff739181e4316f55f3ba50513f8fdb16db7116) ) // 27c4100 - FIXED BITS (xxxxxxxx00000000) (but correct, just lower bpp) (used for startup logo animation only)
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "snd_0.u29", 0x000000, 0x200000, CRC(8bc0dde9) SHA1(4dffef4d709da02d6dfd15b5266ed529e148c024) ) // 27c160
 	ROM_LOAD16_WORD_SWAP( "snd_1.u33", 0x200000, 0x200000, CRC(f958e0ea) SHA1(699ea44a0ef9f9a969e4eb692592b07d629923d1) ) // 27c160
 
@@ -3629,14 +3608,14 @@ KK2_SND1.BIN [e5a963e1] /
 ***************************************************************************/
 
 ROM_START( koikois2 )
-	ROM_REGION( 0x400000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x400000, "maincpu", 0 )     // V60 Code
 //  socket for DATA ROM is empty
 	ROM_LOAD16_BYTE( "u26.bin", 0x200000, 0x080000, CRC(4be937a1) SHA1(b2c22ec12fc110984bd1914f8e3e16a8cb866816) )
 	ROM_RELOAD(                 0x300000, 0x080000)
 	ROM_LOAD16_BYTE( "u27.bin", 0x200001, 0x080000, CRC(25f39d93) SHA1(a36bc2fe5657f6ceada724fd42843e19408b39b8) )
 	ROM_RELOAD(                 0x300001, 0x080000)
 
-	ROM_REGION( 0x2000000, "gfx1", 0 ) /* Sprites */
+	ROM_REGION( 0x2000000, "sprites", 0 )
 	ROM_LOAD( "kk2-a0.bin", 0x0000000, 0x400000, CRC(b94b76c2) SHA1(07ce3e3946669c1bd2f022da9861164625be9c1b) )
 	ROM_LOAD( "kk2-a1.bin", 0x0400000, 0x200000, CRC(a7c99f56) SHA1(de341e99f76446fab4d7f09c2d8a6f18554b5d2f) )
 
@@ -3649,16 +3628,16 @@ ROM_START( koikois2 )
 	ROM_LOAD( "kk2-d0.bin", 0x1800000, 0x400000, CRC(0e3005a4) SHA1(fa8da58308d58bb6b2e8beb8ee8f7ea08b18f4d9) )
 	ROM_LOAD( "kk2-d1.bin", 0x1c00000, 0x200000, CRC(17a02252) SHA1(c7aa61e27f197b3c497a65a9369e3a6a20c9f82a) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "kk2_snd0.bin", 0x000000, 0x200000, CRC(b27eaa94) SHA1(05baaef683a1fcd9eb8a7cfd5b280c05108e832f) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "kk2_snd1.bin", 0x000000, 0x200000, CRC(e5a963e1) SHA1(464ffd53ac2e6db62225b18d12bfea93160771ec) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
 	ROM_COPY( "ensoniq.0", 0x000000, 0x000000, 0x400000 )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.3", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.3", 0 ) // Samples
 	ROM_COPY( "ensoniq.1", 0x000000, 0x000000, 0x400000 )
 ROM_END
 
@@ -3679,11 +3658,11 @@ Others:     M62X42B (RTC?)
 ***************************************************************************/
 
 ROM_START( meosism )
-	ROM_REGION( 0x100000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x100000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_BYTE( "s15-2-2.u47", 0x000000, 0x080000, CRC(2ab0373f) SHA1(826aec3b9698ec5db5d7a72c3a24b1ef779fb227) )
 	ROM_LOAD16_BYTE( "s15-2-1.u46", 0x000001, 0x080000, CRC(a4bce148) SHA1(17ec4d91e215bd38258329b1a71e7f135c5733ad) )
 
-	ROM_REGION( 0x800000, "gfx1", 0 )   /* Sprites */
+	ROM_REGION( 0x800000, "sprites", 0 ) 
 	ROM_LOAD( "s15-1-7.u7", 0x000000, 0x200000, CRC(ec5023cb) SHA1(3406f5143a40c8dcd2d45b44ea91c737810ab05b) )
 	ROM_LOAD( "s15-1-8.u6", 0x200000, 0x200000, CRC(f04b0836) SHA1(83678427cd0ed0d68ff770baa2693226b391f6c8) )
 	ROM_LOAD( "s15-1-5.u9", 0x400000, 0x200000, CRC(c0414b97) SHA1(3ca8423e04f606981d158065e38431f2509e1daa) )
@@ -3691,7 +3670,7 @@ ROM_START( meosism )
 
 //  The chip seems to use REGION1 too, but produces no sound from there.
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "s15-1-4.u45", 0x000000, 0x200000, CRC(0c6738a7) SHA1(acf9056bb052db7a11cf903d77ab16425d813835) )
 	ROM_LOAD16_WORD_SWAP( "s15-1-3.u43", 0x200000, 0x200000, CRC(d7e83178) SHA1(74e5c09f6d3b2c8e1c1cc2b0eab0490b5bbc9099) )
 ROM_END
@@ -3728,11 +3707,11 @@ Other parts:    uPD71051
 ***************************************************************************/
 
 ROM_START( mslider )
-	ROM_REGION( 0x100000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x100000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_BYTE( "ms-pl.bin", 0x000000, 0x080000, CRC(70b2a05d) SHA1(387cf67e3e505c4cc1b5cd0b6c9fb3bc27d07e24) )
 	ROM_LOAD16_BYTE( "ms-ph.bin", 0x000001, 0x080000, CRC(34a64e9f) SHA1(acf3d8490f3ec99b6171e71328a991fcc9c5a8b1) )
 
-	ROM_REGION( 0xa00000, "gfx1", 0 )   /* Sprites */
+	ROM_REGION( 0xa00000, "sprites", ROMREGION_ERASE00 ) 
 	ROM_LOAD( "ms-a0.bin", 0x000000, 0x200000, CRC(7ed38ccc) SHA1(9c584a5f6b3aad8646d155a56e4070cfed4af540) )
 	ROM_LOAD( "ms-a1.bin", 0x200000, 0x080000, CRC(83f5995f) SHA1(33ae99a96702d4aba422eaf454b86c96aaf88426) )
 
@@ -3742,9 +3721,7 @@ ROM_START( mslider )
 	ROM_LOAD( "ms-c0.bin", 0x500000, 0x200000, CRC(f9d3e052) SHA1(4cdde756b24ee980f3c79a35a1fe071861fdeef9) )
 	ROM_LOAD( "ms-c1.bin", 0x700000, 0x080000, CRC(7f910c5a) SHA1(23ea13b6c07d3d31a25c21704d6a3e506578b199) )
 
-	ROM_FILL(              0x780000, 0x280000, 0x000000)
-
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "ms-snd0.bin", 0x000000, 0x200000, CRC(cda6e3a5) SHA1(28ad8f34bc4f907654582f3522b377b97234eba8) )
 	ROM_LOAD16_WORD_SWAP( "ms-snd1.bin", 0x200000, 0x200000, CRC(8f484b35) SHA1(cbf3ee7ec6337915f9d90a5b43d2de1eaa5537d0) )
 ROM_END
@@ -3759,14 +3736,14 @@ ROM_END
 ***************************************************************************/
 
 ROM_START( ryorioh )
-	ROM_REGION( 0x400000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x400000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD( "ryorioh.dat",      0x000000, 0x200000, CRC(d1335a6a) SHA1(a5670ab3c399736232baaabc59573bdb3bf762da) )
 	ROM_LOAD16_BYTE( "ryorioh.l", 0x200000, 0x080000, CRC(9ad60e7d) SHA1(572b84bab08eb8293d93e03182d9871d8973b7dd) )
 	ROM_RELOAD(                   0x300000, 0x080000)
 	ROM_LOAD16_BYTE( "ryorioh.h", 0x200001, 0x080000, CRC(0655fcff) SHA1(2c088e42323f87e01b65f9f523e258f881d4e773) )
 	ROM_RELOAD(                   0x300001, 0x080000)
 
-	ROM_REGION( 0x2000000, "gfx1", 0 )  /* Sprites */
+	ROM_REGION( 0x2000000, "sprites", 0 )
 	ROM_LOAD( "ryorioh.a0", 0x0000000, 0x400000, CRC(f76ee003) SHA1(04022238dcfd5cf0e4f97c3c3b24df574ec6b609) )
 	ROM_LOAD( "ryorioh.a1", 0x0400000, 0x400000, CRC(ca44d66d) SHA1(d5ed2bbc9831182b212533bd67bb3831f655110a) )
 
@@ -3779,7 +3756,7 @@ ROM_START( ryorioh )
 	ROM_LOAD( "ryorioh.d0", 0x1800000, 0x400000, CRC(ffa14ef1) SHA1(22a6992f6217d8ef2140e72063290fa34cb45683) )
 	ROM_LOAD( "ryorioh.d1", 0x1c00000, 0x400000, CRC(ae6055e8) SHA1(ee20a7b3c4f899404ca259991509728d3a0f96b9) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "ryorioh.snd", 0x000000, 0x200000, CRC(7bd38b76) SHA1(d8490b4af839ef0802b8b2a47277fcd4091e4d37) )
 
 	ROM_REGION( 0x400, "plds", 0 )
@@ -3824,11 +3801,11 @@ ST-0007 (System controller)
 ***************************************************************************/
 
 ROM_START( srmp4 )
-	ROM_REGION( 0x100000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x100000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_BYTE( "sx001-14.prl", 0x000000, 0x080000, CRC(19aaf46e) SHA1(0c0f5acc1880971c56e7e2c2e3ad7c2932b82d4b) )
 	ROM_LOAD16_BYTE( "sx001-15.prh", 0x000001, 0x080000, CRC(dbd31399) SHA1(a77dc85f481454b10223d7f4e0395e07d2f8d4f3) )
 
-	ROM_REGION( 0x1800000, "gfx1", 0 )  /* Sprites */
+	ROM_REGION( 0x1800000, "sprites", ROMREGION_ERASE00 )
 	ROM_LOAD( "sx001-01.a0", 0x0000000, 0x200000, CRC(94ee9203) SHA1(a0e944a375f94e9dd668b06f15580384902d0fe1) )
 	ROM_LOAD( "sx001-04.a1", 0x0200000, 0x200000, CRC(38c9c49a) SHA1(c392d1cf5d16a348bdaa7222f2420a61a831a50a) )
 	ROM_LOAD( "sx001-07.a2", 0x0400000, 0x200000, CRC(ee66021e) SHA1(f4df2bdf8100a3bd39bb61f9bb4807ca9e13537a) )
@@ -3841,19 +3818,17 @@ ROM_START( srmp4 )
 	ROM_LOAD( "sx001-06.c1", 0x0e00000, 0x200000, CRC(6fe7229e) SHA1(e1432aa500460f79b5b78ee4b249d8fc9f566ce1) )
 	ROM_LOAD( "sx001-09.c2", 0x1000000, 0x200000, CRC(91dd8218) SHA1(a500dca9eefbf93187b1dfde7ddff1d22b886d44) )
 
-	ROM_FILL(                0x1200000, 0x600000, 0x000000)
-
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "sx001-10.sd0", 0x000000, 0x200000, CRC(45409ef1) SHA1(327d0a63deac6f0f8b9a408a321c03dd4e965569) )
 	ROM_RELOAD(                           0x200000, 0x200000)
 ROM_END
 
 ROM_START( srmp4o )
-	ROM_REGION( 0x100000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x100000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_BYTE( "sx001-11.prl", 0x000000, 0x080000, CRC(dede3e64) SHA1(6fe998babfd2ad8f268c59bd365115a2d7cfc8f9) )
 	ROM_LOAD16_BYTE( "sx001-12.prh", 0x000001, 0x080000, CRC(739c53c3) SHA1(68f12cf42177df208ff6499ccc7ccc1423e3ad5f) )
 
-	ROM_REGION( 0x1800000, "gfx1", 0 )  /* Sprites */
+	ROM_REGION( 0x1800000, "sprites", ROMREGION_ERASE00 )
 	ROM_LOAD( "sx001-01.a0", 0x0000000, 0x200000, CRC(94ee9203) SHA1(a0e944a375f94e9dd668b06f15580384902d0fe1) )
 	ROM_LOAD( "sx001-04.a1", 0x0200000, 0x200000, CRC(38c9c49a) SHA1(c392d1cf5d16a348bdaa7222f2420a61a831a50a) )
 	ROM_LOAD( "sx001-07.a2", 0x0400000, 0x200000, CRC(ee66021e) SHA1(f4df2bdf8100a3bd39bb61f9bb4807ca9e13537a) )
@@ -3866,9 +3841,7 @@ ROM_START( srmp4o )
 	ROM_LOAD( "sx001-06.c1", 0x0e00000, 0x200000, CRC(6fe7229e) SHA1(e1432aa500460f79b5b78ee4b249d8fc9f566ce1) )
 	ROM_LOAD( "sx001-09.c2", 0x1000000, 0x200000, CRC(91dd8218) SHA1(a500dca9eefbf93187b1dfde7ddff1d22b886d44) )
 
-	ROM_FILL(                0x1200000, 0x600000, 0x000000)
-
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "sx001-10.sd0", 0x000000, 0x200000, CRC(45409ef1) SHA1(327d0a63deac6f0f8b9a408a321c03dd4e965569) )
 	ROM_RELOAD(                           0x200000, 0x200000)
 ROM_END
@@ -3883,14 +3856,14 @@ ROM_END
 ***************************************************************************/
 
 ROM_START( srmp7 )
-	ROM_REGION( 0x400000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x400000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_WORD( "sx015-10.dat", 0x000000, 0x200000, CRC(fad3ac6a) SHA1(9a4695c06bc74ca4de0c1a83bdf38f6651c0e2a1) )
 	ROM_LOAD16_BYTE( "sx015-07.pr0", 0x200000, 0x080000, CRC(08d7f841) SHA1(67567acff0ce278576290a896005de0397605eef) )
 	ROM_RELOAD(                      0x300000, 0x080000)
 	ROM_LOAD16_BYTE( "sx015-08.pr1", 0x200001, 0x080000, CRC(90307825) SHA1(13b3f82c8854808684bd41deb0bbd442efe7b685) )
 	ROM_RELOAD(                      0x300001, 0x080000)
 
-	ROM_REGION( 0x4000000, "gfx1", 0 )  /* Sprites */
+	ROM_REGION( 0x4000000, "sprites", 0 )
 	ROM_LOAD( "sx015-26.a0", 0x0000000, 0x400000, CRC(a997be9d) SHA1(37470af24531557113f953f727f6b8cab602a7d3) )
 	ROM_LOAD( "sx015-25.a1", 0x0400000, 0x400000, CRC(29ac4211) SHA1(32edf3982b0e27077cc17cd38b67a27d36dc3ad8) )
 	ROM_LOAD( "sx015-24.a2", 0x0800000, 0x400000, CRC(b8fea3da) SHA1(9c3a53348f72f39d84d078068c62b10920854cd0) )
@@ -3911,17 +3884,17 @@ ROM_START( srmp7 )
 	ROM_LOAD( "sx015-12.d2", 0x3800000, 0x400000, CRC(80336523) SHA1(ec66e21fe1401fdb438e03657542a7b6b0cbc5ce) )
 	ROM_LOAD( "sx015-11.d3", 0x3c00000, 0x400000, CRC(134c8e28) SHA1(669118b58f27d5e2e08052debe904f95d9ab32a3) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "sx015-06.s0", 0x000000, 0x200000, CRC(0d5a206c) SHA1(2fdaf2a56b6608f20a788eb79a8426102ff33e14) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "sx015-05.s1", 0x000000, 0x200000, CRC(bb8cebe2) SHA1(3691e5fb4e963f69c1fe01cb5d968433029c4833) )
 
-	ROM_REGION16_BE( 0x800000, "ensoniq.2", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x800000, "ensoniq.2", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "sx015-04.s2", 0x000000, 0x200000, CRC(f6e933df) SHA1(7cb69515a0ffc62fbac2be3a5fb322538560bd38) )
 	ROM_LOAD16_BYTE( "sx015-02.s4", 0x400000, 0x200000, CRC(6567bc3e) SHA1(e902f22f1499edc6a0e2c8b6cc26460d66a3bdbe) )
 
-	ROM_REGION16_BE( 0x800000, "ensoniq.3", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x800000, "ensoniq.3", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "sx015-03.s3", 0x000000, 0x200000, CRC(5b51ab21) SHA1(cf3e86e41f7984208984d6486b04cec117dadc18) )
 	ROM_LOAD16_BYTE( "sx015-01.s5", 0x400000, 0x200000, CRC(481b00ed) SHA1(2c3d158dd5be9af0ee57fd5dd94d2ec75e28b182) )
 ROM_END
@@ -4030,93 +4003,87 @@ SAM-5127
 ***************************************************************************/
 
 ROM_START( survarts )
-	ROM_REGION( 0x100000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x100000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_BYTE( "prl-r6.u4", 0x000000, 0x080000, CRC(ef5f6e17) SHA1(1857beb15d2214c7ecb60b59e696ba24b2791734) )
 	ROM_LOAD16_BYTE( "prh-r5.u3", 0x000001, 0x080000, CRC(d446f010) SHA1(fb6c349edb2e6d1fcf8ed360dbe82be6d74f91d2) )
 
-	ROM_REGION( 0x1800000, "gfx1", 0 )  /* Sprites */
-	ROM_LOAD( "si001-01.u27", 0x0000000, 0x200000, CRC(8b38fbab) SHA1(c4a67b24b33d4eef7b0f885bd69cae6c67bd3981) ) /* A0 */
-	ROM_LOAD( "si001-04.u26", 0x0200000, 0x200000, CRC(34248b54) SHA1(077198f8de1622b71c580e34d5ad1b6bf3229fe9) ) /* A1 */
-	ROM_LOAD( "si001-07.u25", 0x0400000, 0x200000, CRC(497d6151) SHA1(a9860c75943c0fd2991660ce2a9505edc6c2fa46) ) /* A2 */
+	ROM_REGION( 0x1800000, "sprites", ROMREGION_ERASE00 )
+	ROM_LOAD( "si001-01.u27", 0x0000000, 0x200000, CRC(8b38fbab) SHA1(c4a67b24b33d4eef7b0f885bd69cae6c67bd3981) ) // A0
+	ROM_LOAD( "si001-04.u26", 0x0200000, 0x200000, CRC(34248b54) SHA1(077198f8de1622b71c580e34d5ad1b6bf3229fe9) ) // A1
+	ROM_LOAD( "si001-07.u25", 0x0400000, 0x200000, CRC(497d6151) SHA1(a9860c75943c0fd2991660ce2a9505edc6c2fa46) ) // A2
 
-	ROM_LOAD( "si001-02.u23", 0x0600000, 0x200000, CRC(cb4a2dbd) SHA1(26cdd1b54a3fa1dc3c3a8945d1a3562e9c62ace6) ) /* B0 */
-	ROM_LOAD( "si001-05.u22", 0x0800000, 0x200000, CRC(8f092381) SHA1(6c49f1f5b3c31bd7c6a93ba0450d9f64fd512633) ) /* B1 */
-	ROM_LOAD( "si001-08.u21", 0x0a00000, 0x200000, CRC(182b88c4) SHA1(a5b6a3e1fd67f036b1255385e81b6a3eb69f9f3f) ) /* B2 */
+	ROM_LOAD( "si001-02.u23", 0x0600000, 0x200000, CRC(cb4a2dbd) SHA1(26cdd1b54a3fa1dc3c3a8945d1a3562e9c62ace6) ) // B0
+	ROM_LOAD( "si001-05.u22", 0x0800000, 0x200000, CRC(8f092381) SHA1(6c49f1f5b3c31bd7c6a93ba0450d9f64fd512633) ) // B1
+	ROM_LOAD( "si001-08.u21", 0x0a00000, 0x200000, CRC(182b88c4) SHA1(a5b6a3e1fd67f036b1255385e81b6a3eb69f9f3f) ) // B2
 
-	ROM_LOAD( "si001-03.u17", 0x0c00000, 0x200000, CRC(92fdf652) SHA1(cf7aeb3a1e8ffe34cf24cb919a0ab3cc90202fa9) ) /* C0 */
-	ROM_LOAD( "si001-06.u16", 0x0e00000, 0x200000, CRC(9a62f532) SHA1(7e7ba1224e52b33a9bd14058230efc871178c4f8) ) /* C1 */
-	ROM_LOAD( "si001-09.u15", 0x1000000, 0x200000, CRC(0955e393) SHA1(0be9134190706eaee49177034b0536b05c4bc7ac) ) /* C2 */
-
-	ROM_FILL(                0x1200000, 0x600000, 0x000000)
+	ROM_LOAD( "si001-03.u17", 0x0c00000, 0x200000, CRC(92fdf652) SHA1(cf7aeb3a1e8ffe34cf24cb919a0ab3cc90202fa9) ) // C0
+	ROM_LOAD( "si001-06.u16", 0x0e00000, 0x200000, CRC(9a62f532) SHA1(7e7ba1224e52b33a9bd14058230efc871178c4f8) ) // C1
+	ROM_LOAD( "si001-09.u15", 0x1000000, 0x200000, CRC(0955e393) SHA1(0be9134190706eaee49177034b0536b05c4bc7ac) ) // C2
 
 //  The chip seems to use REGION1 too, but produces no sound from there.
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
-	ROM_LOAD16_WORD_SWAP( "si001-10.u9", 0x000000, 0x100000, CRC(5642b333) SHA1(84936af8b3882e116b279e422075f35aabdd232f) ) /* S0 */
-	ROM_LOAD16_WORD_SWAP( "si001-11.u8", 0x100000, 0x100000, CRC(a81e6ea6) SHA1(499f070500895ed7b6785b42fb6bbf973fc6dc04) ) /* S1 */
-	ROM_LOAD16_WORD_SWAP( "si001-12.u7", 0x200000, 0x100000, CRC(e9b2b45b) SHA1(17fd27cdb8a0b9932cb1e71e0547c0d9d6fc7d06) ) /* S2 */
-	ROM_LOAD16_WORD_SWAP( "si001-13.u6", 0x300000, 0x100000, CRC(d66a7e26) SHA1(57b659daef00421b6742963f792bd5e020f625c9) ) /* S3 */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
+	ROM_LOAD16_WORD_SWAP( "si001-10.u9", 0x000000, 0x100000, CRC(5642b333) SHA1(84936af8b3882e116b279e422075f35aabdd232f) ) // S0
+	ROM_LOAD16_WORD_SWAP( "si001-11.u8", 0x100000, 0x100000, CRC(a81e6ea6) SHA1(499f070500895ed7b6785b42fb6bbf973fc6dc04) ) // S1
+	ROM_LOAD16_WORD_SWAP( "si001-12.u7", 0x200000, 0x100000, CRC(e9b2b45b) SHA1(17fd27cdb8a0b9932cb1e71e0547c0d9d6fc7d06) ) // S2
+	ROM_LOAD16_WORD_SWAP( "si001-13.u6", 0x300000, 0x100000, CRC(d66a7e26) SHA1(57b659daef00421b6742963f792bd5e020f625c9) ) // S3
 
 	ROM_REGION( 0x0200, "plds", 0 )
 	ROM_LOAD( "gal16v8b.u5",   0x0000, 0x0117, CRC(378ce368) SHA1(cc068c9b63e6f91165f9caec581645ad45b2d3d0) )
 ROM_END
 
 ROM_START( survartsu )
-	ROM_REGION( 0x100000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x100000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_BYTE( "usa-pr-l.u4", 0x000000, 0x080000, CRC(fa328673) SHA1(f7217eaa2a8d3fb7f706fa1aecaaa5b1b8d5e32c) )
 	ROM_LOAD16_BYTE( "usa-pr-h.u3", 0x000001, 0x080000, CRC(6bee2635) SHA1(a2d0517bf599331ef47beb8a902589039e4502e0) )
 
-	ROM_REGION( 0x1800000, "gfx1", 0 )  /* Sprites */
-	ROM_LOAD( "si001-01.u27", 0x0000000, 0x200000, CRC(8b38fbab) SHA1(c4a67b24b33d4eef7b0f885bd69cae6c67bd3981) ) /* A0 */
-	ROM_LOAD( "si001-04.u26", 0x0200000, 0x200000, CRC(34248b54) SHA1(077198f8de1622b71c580e34d5ad1b6bf3229fe9) ) /* A1 */
-	ROM_LOAD( "si001-07.u25", 0x0400000, 0x200000, CRC(497d6151) SHA1(a9860c75943c0fd2991660ce2a9505edc6c2fa46) ) /* A2 */
+	ROM_REGION( 0x1800000, "sprites", ROMREGION_ERASE00 )
+	ROM_LOAD( "si001-01.u27", 0x0000000, 0x200000, CRC(8b38fbab) SHA1(c4a67b24b33d4eef7b0f885bd69cae6c67bd3981) ) // A0
+	ROM_LOAD( "si001-04.u26", 0x0200000, 0x200000, CRC(34248b54) SHA1(077198f8de1622b71c580e34d5ad1b6bf3229fe9) ) // A1
+	ROM_LOAD( "si001-07.u25", 0x0400000, 0x200000, CRC(497d6151) SHA1(a9860c75943c0fd2991660ce2a9505edc6c2fa46) ) // A2
 
-	ROM_LOAD( "si001-02.u23", 0x0600000, 0x200000, CRC(cb4a2dbd) SHA1(26cdd1b54a3fa1dc3c3a8945d1a3562e9c62ace6) ) /* B0 */
-	ROM_LOAD( "si001-05.u22", 0x0800000, 0x200000, CRC(8f092381) SHA1(6c49f1f5b3c31bd7c6a93ba0450d9f64fd512633) ) /* B1 */
-	ROM_LOAD( "si001-08.u21", 0x0a00000, 0x200000, CRC(182b88c4) SHA1(a5b6a3e1fd67f036b1255385e81b6a3eb69f9f3f) ) /* B2 */
+	ROM_LOAD( "si001-02.u23", 0x0600000, 0x200000, CRC(cb4a2dbd) SHA1(26cdd1b54a3fa1dc3c3a8945d1a3562e9c62ace6) ) // B0
+	ROM_LOAD( "si001-05.u22", 0x0800000, 0x200000, CRC(8f092381) SHA1(6c49f1f5b3c31bd7c6a93ba0450d9f64fd512633) ) // B1
+	ROM_LOAD( "si001-08.u21", 0x0a00000, 0x200000, CRC(182b88c4) SHA1(a5b6a3e1fd67f036b1255385e81b6a3eb69f9f3f) ) // B2
 
-	ROM_LOAD( "si001-03.u17", 0x0c00000, 0x200000, CRC(92fdf652) SHA1(cf7aeb3a1e8ffe34cf24cb919a0ab3cc90202fa9) ) /* C0 */
-	ROM_LOAD( "si001-06.u16", 0x0e00000, 0x200000, CRC(9a62f532) SHA1(7e7ba1224e52b33a9bd14058230efc871178c4f8) ) /* C1 */
-	ROM_LOAD( "si001-09.u15", 0x1000000, 0x200000, CRC(0955e393) SHA1(0be9134190706eaee49177034b0536b05c4bc7ac) ) /* C2 */
-
-	ROM_FILL(                0x1200000, 0x600000, 0x000000)
+	ROM_LOAD( "si001-03.u17", 0x0c00000, 0x200000, CRC(92fdf652) SHA1(cf7aeb3a1e8ffe34cf24cb919a0ab3cc90202fa9) ) // C0
+	ROM_LOAD( "si001-06.u16", 0x0e00000, 0x200000, CRC(9a62f532) SHA1(7e7ba1224e52b33a9bd14058230efc871178c4f8) ) // C1
+	ROM_LOAD( "si001-09.u15", 0x1000000, 0x200000, CRC(0955e393) SHA1(0be9134190706eaee49177034b0536b05c4bc7ac) ) // C2
 
 //  The chip seems to use REGION1 too, but produces no sound from there.
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
-	ROM_LOAD16_WORD_SWAP( "si001-10.u9", 0x000000, 0x100000, CRC(5642b333) SHA1(84936af8b3882e116b279e422075f35aabdd232f) ) /* S0 */
-	ROM_LOAD16_WORD_SWAP( "si001-11.u8", 0x100000, 0x100000, CRC(a81e6ea6) SHA1(499f070500895ed7b6785b42fb6bbf973fc6dc04) ) /* S1 */
-	ROM_LOAD16_WORD_SWAP( "si001-12.u7", 0x200000, 0x100000, CRC(e9b2b45b) SHA1(17fd27cdb8a0b9932cb1e71e0547c0d9d6fc7d06) ) /* S2 */
-	ROM_LOAD16_WORD_SWAP( "si001-13.u6", 0x300000, 0x100000, CRC(d66a7e26) SHA1(57b659daef00421b6742963f792bd5e020f625c9) ) /* S3 */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
+	ROM_LOAD16_WORD_SWAP( "si001-10.u9", 0x000000, 0x100000, CRC(5642b333) SHA1(84936af8b3882e116b279e422075f35aabdd232f) ) // S0
+	ROM_LOAD16_WORD_SWAP( "si001-11.u8", 0x100000, 0x100000, CRC(a81e6ea6) SHA1(499f070500895ed7b6785b42fb6bbf973fc6dc04) ) // S1
+	ROM_LOAD16_WORD_SWAP( "si001-12.u7", 0x200000, 0x100000, CRC(e9b2b45b) SHA1(17fd27cdb8a0b9932cb1e71e0547c0d9d6fc7d06) ) // S2
+	ROM_LOAD16_WORD_SWAP( "si001-13.u6", 0x300000, 0x100000, CRC(d66a7e26) SHA1(57b659daef00421b6742963f792bd5e020f625c9) ) // S3
 ROM_END
 
 ROM_START( survartsj )
-	ROM_REGION( 0x100000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x100000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_BYTE( "jpn-pr-l.u4", 0x000000, 0x080000, CRC(e5a52e8c) SHA1(0a51c16d23d99c3e6a12f8a96c62fe8c72179a22) )
 	ROM_LOAD16_BYTE( "jan-pr-h.u3", 0x000001, 0x080000, CRC(051c9bca) SHA1(b8a7c5e4cb12cb0f05b5ba15394bd1fcf0476bf0) )  // jan typo on sticker
 
-	ROM_REGION( 0x1800000, "gfx1", 0 )  /* Sprites */
-	ROM_LOAD( "si001-01.u27", 0x0000000, 0x200000, CRC(8b38fbab) SHA1(c4a67b24b33d4eef7b0f885bd69cae6c67bd3981) ) /* A0 */
-	ROM_LOAD( "si001-04.u26", 0x0200000, 0x200000, CRC(34248b54) SHA1(077198f8de1622b71c580e34d5ad1b6bf3229fe9) ) /* A1 */
-	ROM_LOAD( "si001-07.u25", 0x0400000, 0x200000, CRC(497d6151) SHA1(a9860c75943c0fd2991660ce2a9505edc6c2fa46) ) /* A2 */
+	ROM_REGION( 0x1800000, "sprites", ROMREGION_ERASE00 )
+	ROM_LOAD( "si001-01.u27", 0x0000000, 0x200000, CRC(8b38fbab) SHA1(c4a67b24b33d4eef7b0f885bd69cae6c67bd3981) ) // A0
+	ROM_LOAD( "si001-04.u26", 0x0200000, 0x200000, CRC(34248b54) SHA1(077198f8de1622b71c580e34d5ad1b6bf3229fe9) ) // A1
+	ROM_LOAD( "si001-07.u25", 0x0400000, 0x200000, CRC(497d6151) SHA1(a9860c75943c0fd2991660ce2a9505edc6c2fa46) ) // A2
 
-	ROM_LOAD( "si001-02.u23", 0x0600000, 0x200000, CRC(cb4a2dbd) SHA1(26cdd1b54a3fa1dc3c3a8945d1a3562e9c62ace6) ) /* B0 */
-	ROM_LOAD( "si001-05.u22", 0x0800000, 0x200000, CRC(8f092381) SHA1(6c49f1f5b3c31bd7c6a93ba0450d9f64fd512633) ) /* B1 */
-	ROM_LOAD( "si001-08.u21", 0x0a00000, 0x200000, CRC(182b88c4) SHA1(a5b6a3e1fd67f036b1255385e81b6a3eb69f9f3f) ) /* B2 */
+	ROM_LOAD( "si001-02.u23", 0x0600000, 0x200000, CRC(cb4a2dbd) SHA1(26cdd1b54a3fa1dc3c3a8945d1a3562e9c62ace6) ) // B0
+	ROM_LOAD( "si001-05.u22", 0x0800000, 0x200000, CRC(8f092381) SHA1(6c49f1f5b3c31bd7c6a93ba0450d9f64fd512633) ) // B1
+	ROM_LOAD( "si001-08.u21", 0x0a00000, 0x200000, CRC(182b88c4) SHA1(a5b6a3e1fd67f036b1255385e81b6a3eb69f9f3f) ) // B2
 
-	ROM_LOAD( "si001-03.u17", 0x0c00000, 0x200000, CRC(92fdf652) SHA1(cf7aeb3a1e8ffe34cf24cb919a0ab3cc90202fa9) ) /* C0 */
-	ROM_LOAD( "si001-06.u16", 0x0e00000, 0x200000, CRC(9a62f532) SHA1(7e7ba1224e52b33a9bd14058230efc871178c4f8) ) /* C1 */
-	ROM_LOAD( "si001-09.u15", 0x1000000, 0x200000, CRC(0955e393) SHA1(0be9134190706eaee49177034b0536b05c4bc7ac) ) /* C2 */
-
-	ROM_FILL(                0x1200000, 0x600000, 0x000000)
+	ROM_LOAD( "si001-03.u17", 0x0c00000, 0x200000, CRC(92fdf652) SHA1(cf7aeb3a1e8ffe34cf24cb919a0ab3cc90202fa9) ) // C0
+	ROM_LOAD( "si001-06.u16", 0x0e00000, 0x200000, CRC(9a62f532) SHA1(7e7ba1224e52b33a9bd14058230efc871178c4f8) ) // C1
+	ROM_LOAD( "si001-09.u15", 0x1000000, 0x200000, CRC(0955e393) SHA1(0be9134190706eaee49177034b0536b05c4bc7ac) ) // C2
 
 //  The chip seems to use REGION1 too, but produces no sound from there.
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
-	ROM_LOAD16_WORD_SWAP( "si001-10.u9", 0x000000, 0x100000, CRC(5642b333) SHA1(84936af8b3882e116b279e422075f35aabdd232f) ) /* S0 */
-	ROM_LOAD16_WORD_SWAP( "si001-11.u8", 0x100000, 0x100000, CRC(a81e6ea6) SHA1(499f070500895ed7b6785b42fb6bbf973fc6dc04) ) /* S1 */
-	ROM_LOAD16_WORD_SWAP( "si001-12.u7", 0x200000, 0x100000, CRC(e9b2b45b) SHA1(17fd27cdb8a0b9932cb1e71e0547c0d9d6fc7d06) ) /* S2 */
-	ROM_LOAD16_WORD_SWAP( "si001-13.u6", 0x300000, 0x100000, CRC(d66a7e26) SHA1(57b659daef00421b6742963f792bd5e020f625c9) ) /* S3 */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
+	ROM_LOAD16_WORD_SWAP( "si001-10.u9", 0x000000, 0x100000, CRC(5642b333) SHA1(84936af8b3882e116b279e422075f35aabdd232f) ) // S0
+	ROM_LOAD16_WORD_SWAP( "si001-11.u8", 0x100000, 0x100000, CRC(a81e6ea6) SHA1(499f070500895ed7b6785b42fb6bbf973fc6dc04) ) // S1
+	ROM_LOAD16_WORD_SWAP( "si001-12.u7", 0x200000, 0x100000, CRC(e9b2b45b) SHA1(17fd27cdb8a0b9932cb1e71e0547c0d9d6fc7d06) ) // S2
+	ROM_LOAD16_WORD_SWAP( "si001-13.u6", 0x300000, 0x100000, CRC(d66a7e26) SHA1(57b659daef00421b6742963f792bd5e020f625c9) ) // S3
 ROM_END
 
 /***************************************************************************
@@ -4164,11 +4131,11 @@ SAM-5127
 ***************************************************************************/
 
 ROM_START( dynagear )
-	ROM_REGION( 0x100000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x100000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_BYTE( "si002-prl.u4", 0x000000, 0x080000, CRC(71ba29c6) SHA1(ef43ab665daa4fc9ee01996d03f2f0b4c74c8435) )
 	ROM_LOAD16_BYTE( "si002-prh.u3", 0x000001, 0x080000, CRC(d0947a12) SHA1(95b54ed9dc51c952ad123103b8633a821cde05e9) )
 
-	ROM_REGION( 0x1000000, "gfx1", 0 )  /* Sprites */
+	ROM_REGION( 0x1000000, "sprites", ROMREGION_ERASE00 )
 	ROM_LOAD( "si002-01.u27", 0x0000000, 0x200000, CRC(0060a521) SHA1(10cdb967e6cb4fc7c23c1ac40b24e35262060f5c) )
 	ROM_LOAD( "si002-04.u26", 0x0200000, 0x200000, CRC(6140f47d) SHA1(49dcebe724990acdac76746886efe88b68ce956f) )
 
@@ -4178,11 +4145,9 @@ ROM_START( dynagear )
 	ROM_LOAD( "si002-03.u17", 0x0800000, 0x200000, CRC(4261a6b8) SHA1(df163faa84a86f126d5d405aef316ff9dd3c05eb) )
 	ROM_LOAD( "si002-06.u16", 0x0a00000, 0x200000, CRC(0e1f23f6) SHA1(ea35c75776b75131ef9133a16a36d95132dc6776) )
 
-	ROM_FILL(                0xc00000, 0x400000, 0x000000)
-
 //  The chip seems to use REGION1 too, but produces no sound from there.
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "si002-07.u9", 0x000000, 0x100000, CRC(30d2bf11) SHA1(263e9a4e6a77aa451daf6d1225071cc1147a6541) )
 	ROM_LOAD16_WORD_SWAP( "si002-08.u8", 0x100000, 0x100000, CRC(253704ee) SHA1(887ebca2af497fc59b274838cdf284223cc92c97) )
 	ROM_LOAD16_WORD_SWAP( "si002-09.u7", 0x200000, 0x100000, CRC(1ea86db7) SHA1(e887ea5be99f753e73355a45e37dfddb2a1d6cf6) )
@@ -4205,13 +4170,13 @@ Chips:  DX-102 x2
 ***************************************************************************/
 
 ROM_START( sxyreact )
-	ROM_REGION( 0x200000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x200000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_BYTE( "ac414e00.u2",  0x000000, 0x080000, CRC(d5dd7593) SHA1(ad1c7c2f27e0423ab346172a5c91316c9c0b3620) )
 	ROM_LOAD16_BYTE( "ac413e00.u1",  0x000001, 0x080000, CRC(f46aee4a) SHA1(8336304797987321903977373dec027cfca2e211) )
 	ROM_LOAD16_BYTE( "ac416e00.u47", 0x100000, 0x080000, CRC(e0f7bba9) SHA1(5eafd72c9fa4588f18fa02113a93abdcaf8d8693) )
 	ROM_LOAD16_BYTE( "ac415e00.u46", 0x100001, 0x080000, CRC(92de1b5f) SHA1(69e30ffc0c59e7dafe3f9c76bfee782028dab042) )
 
-	ROM_REGION( 0x2800000, "gfx1", 0 )  /* Sprites */
+	ROM_REGION( 0x2800000, "sprites", ROMREGION_ERASE00 )
 	ROM_LOAD( "ac1401m0.u6",  0x0000000, 0x400000, CRC(0b7b693c) SHA1(1e65c3f55cf3aa63d4229d30b5894c89b83cdf3e) )
 	ROM_LOAD( "ac1402m0.u9",  0x0400000, 0x400000, CRC(9d593303) SHA1(c02037fabe8a74f01a25357ffdd3ce01b930008b) )
 	ROM_LOAD( "ac1403m0.u12", 0x0800000, 0x200000, CRC(af433eca) SHA1(dfd83eba390171d93bc6888cc1d24a9a38d900bd) )
@@ -4224,17 +4189,15 @@ ROM_START( sxyreact )
 	ROM_LOAD( "ac1408m0.u11", 0x1800000, 0x400000, CRC(c45bab47) SHA1(d00802005e091088eabeb672a6428417db43cb66) )
 	ROM_LOAD( "ac1409m0.u14", 0x1c00000, 0x200000, CRC(be1c66c2) SHA1(6d7b60d3b4286a768eac122c3d163e6e5287adc3) )
 
-	ROM_FILL(                 0x1e00000, 0xa00000, 0x000000)
-
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "ac1410m0.u41", 0x000000, 0x400000, CRC(2a880afc) SHA1(193235bccde28a7d693a1a1f0159260a3a63a7d5) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "ac1411m0.u42", 0x200000, 0x200000, CRC(2ba4ca43) SHA1(9cddf57094e68d3840a37f44fbdf2f43f539ba11) )
 	ROM_CONTINUE( 0x000000, 0x200000 )  // this will go in region 3
 
 	// a few sparse samples are played from here
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
 	ROM_COPY( "ensoniq.1", 0x000000,    0x200000, 0x200000 )
 ROM_END
 
@@ -4293,10 +4256,10 @@ Notes:
 ***************************************************************************/
 
 ROM_START( sxyreac2 )
-	ROM_REGION( 0x200000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x200000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_WORD( "ac1714e00.u32",  0x000000, 0x200000, CRC(78075d70) SHA1(05c84bb32c6f97fceb5436d192c14cac79d9ab07) )
 
-	ROM_REGION( 0x2000000, "gfx1", 0 )  /* Sprites */
+	ROM_REGION( 0x2000000, "sprites", ROMREGION_ERASE00 )
 	ROM_LOAD( "ac1701t00.u6",  0x0000000, 0x400000, CRC(e14611c2) SHA1(0eaf28b27b879b6ce99bea03b286717a2d6f60f4) )
 	ROM_LOAD( "ac1702t00.u9",  0x0400000, 0x400000, CRC(2c8b07f8) SHA1(e4128075c207d03206085f58b5aa8ebd28d3c2a9) )
 
@@ -4306,16 +4269,14 @@ ROM_START( sxyreac2 )
 	ROM_LOAD( "ac1705t00.u8",  0x1000000, 0x400000, CRC(2dff0652) SHA1(3c68ec3b233f248208ea80e4799a9504318b4e7c) )
 	ROM_LOAD( "ac1706t00.u11", 0x1400000, 0x400000, CRC(e7a168e0) SHA1(b4e19cc3a1fd0f18db7476ebe7cbb397c60e01b3) )
 
-	ROM_FILL(                 0x1800000, 0x800000, 0x000000)
-
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "ac1707t00.u41", 0x000000, 0x400000, CRC(28999bc4) SHA1(4cddaa4a155cc03d456e6edb20dd207f7ff3d9c4) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", 0 ) // Samples
 	ROM_LOAD16_WORD_SWAP( "ac1708t00.u42", 0x200000, 0x200000, CRC(7001eec0) SHA1(cc568ef90ec7201a73e9dc217d72cfbc3860e6b8) )
 	ROM_CONTINUE( 0x000000, 0x200000 )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
 	ROM_COPY( "ensoniq.1", 0x000000,    0x200000, 0x200000 )
 
 	ROM_REGION( 0x200, "plds", 0 )
@@ -4389,14 +4350,14 @@ U26 = 8 meg mask ROM
 ***************************************************************************/
 
 ROM_START( stmblade )
-	ROM_REGION( 0x400000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x400000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_WORD( "sb-pd0.u26",  0x000000, 0x100000, CRC(91c4fbf7) SHA1(68e57ea2a9756a95a81c6688905352d631e9f2de) )
 	ROM_LOAD16_BYTE( "s-blade.u37", 0x200000, 0x080000, CRC(a6a42cc7) SHA1(4bff79ff03b81a7ed96d3ad285242580146976be) )
 	ROM_RELOAD(                     0x300000, 0x080000)
 	ROM_LOAD16_BYTE( "s-blade.u33", 0x200001, 0x080000, CRC(16104ca6) SHA1(63835051c358dce33d92974d1de911b98835a3d9) )
 	ROM_RELOAD(                     0x300001, 0x080000)
 
-	ROM_REGION( 0x1800000, "gfx1", 0 ) /* Sprites */
+	ROM_REGION( 0x1800000, "sprites", ROMREGION_ERASE00 )
 	ROM_LOAD( "sb-a0.u41", 0x0000000, 0x200000, CRC(2a327b51) SHA1(fb1e92b7f740a80cb0c977e106d0c4bfee092dad) )
 	ROM_LOAD( "sb-a1.u35", 0x0200000, 0x200000, CRC(246f6f28) SHA1(09171f04452fbcf9e3333c135288fd6e5b8244f7) )
 	ROM_LOAD( "sb-a2.u32", 0x0400000, 0x080000, CRC(2049acf3) SHA1(3982b4650921da0563336060887767627f8679ab) )
@@ -4406,9 +4367,8 @@ ROM_START( stmblade )
 	ROM_LOAD( "sb-c0.u11", 0x0c00000, 0x200000, CRC(825dd8f1) SHA1(39d32f54c97e21f92598442f05fd91ae2403a0d2) )
 	ROM_LOAD( "sb-c1.u7",  0x0e00000, 0x200000, CRC(744afcd7) SHA1(db716a1a2ad5864ebdb4865430cb637fb94ed34f) )
 	ROM_LOAD( "sb-c2.u4",  0x1000000, 0x080000, CRC(fd1d2a92) SHA1(957a8a52b79e252c7f1a4b6383107ae609dce5ef) )
-	ROM_FILL(              0x1200000, 0x600000, 0x000000)
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "sb-snd0.u22", 0x000000, 0x200000, CRC(4efd605b) SHA1(9c97be105c923c7db847d9b9aea37025edb685a0) )
 
 	ROM_REGION( 0x11000, "st010", 0)
@@ -4420,14 +4380,14 @@ ROM_START( stmblade )
 ROM_END
 
 ROM_START( stmbladej )
-	ROM_REGION( 0x400000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x400000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_WORD( "sb-pd0.u26",  0x000000, 0x100000, CRC(91c4fbf7) SHA1(68e57ea2a9756a95a81c6688905352d631e9f2de) )
 	ROM_LOAD16_BYTE( "u37j.u37", 0x200000, 0x080000, CRC(dce20df8) SHA1(d589bf7bebbf6b3c76ddb4b1f8d0c7d6bee34561) )
 	ROM_RELOAD(                  0x300000, 0x080000)
 	ROM_LOAD16_BYTE( "u33j.u33", 0x200001, 0x080000, CRC(12f68940) SHA1(c50caee87cdcbb3a4af3a139234ed12942cfab72) )
 	ROM_RELOAD(                  0x300001, 0x080000)
 
-	ROM_REGION( 0x1800000, "gfx1", 0 ) /* Sprites */
+	ROM_REGION( 0x1800000, "sprites", ROMREGION_ERASE00 )
 	ROM_LOAD( "sb-a0.u41", 0x0000000, 0x200000, CRC(2a327b51) SHA1(fb1e92b7f740a80cb0c977e106d0c4bfee092dad) )
 	ROM_LOAD( "sb-a1.u35", 0x0200000, 0x200000, CRC(246f6f28) SHA1(09171f04452fbcf9e3333c135288fd6e5b8244f7) )
 	ROM_LOAD( "sb-a2.u32", 0x0400000, 0x080000, CRC(2049acf3) SHA1(3982b4650921da0563336060887767627f8679ab) )
@@ -4437,9 +4397,8 @@ ROM_START( stmbladej )
 	ROM_LOAD( "sb-c0.u11", 0x0c00000, 0x200000, CRC(825dd8f1) SHA1(39d32f54c97e21f92598442f05fd91ae2403a0d2) )
 	ROM_LOAD( "sb-c1.u7",  0x0e00000, 0x200000, CRC(744afcd7) SHA1(db716a1a2ad5864ebdb4865430cb637fb94ed34f) )
 	ROM_LOAD( "sb-c2.u4",  0x1000000, 0x080000, CRC(fd1d2a92) SHA1(957a8a52b79e252c7f1a4b6383107ae609dce5ef) )
-	ROM_FILL(              0x1200000, 0x600000, 0x000000)
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "sb-snd0.u22", 0x000000, 0x200000, CRC(4efd605b) SHA1(9c97be105c923c7db847d9b9aea37025edb685a0) )
 
 	ROM_REGION( 0x11000, "st010", 0)
@@ -4489,34 +4448,32 @@ All ROMs are 16M mask ROMs
 ***************************************************************************/
 
 ROM_START( twineag2 )
-	ROM_REGION( 0x200000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x200000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_WORD( "sx002-12.u22", 0x000000, 0x200000, CRC(846044dc) SHA1(c1c85de1c466fb7c3580824baa1571cd0fed6ec6) )
 
-	ROM_REGION( 0x1800000, "gfx1", 0 )  /* Sprites */
-	ROM_LOAD( "sx002-01.u32", 0x0000000, 0x200000, CRC(6d6896b5) SHA1(e8efd29b9f951bff6664e47cb5fd67f1d8f40608) ) /* A0 */
-	ROM_LOAD( "sx002-02.u28", 0x0200000, 0x200000, CRC(3f47e97a) SHA1(5b0fdc762cf704c8bd92c4a4a42dba4a127b3d49) ) /* A1 */
-	ROM_LOAD( "sx002-03.u25", 0x0400000, 0x200000, CRC(544f18bf) SHA1(539e6df1ded4e9ac8974c697215cc1e5c5a40cda) ) /* A2, A3 is unpopulated */
+	ROM_REGION( 0x1800000, "sprites", ROMREGION_ERASE00 )
+	ROM_LOAD( "sx002-01.u32", 0x0000000, 0x200000, CRC(6d6896b5) SHA1(e8efd29b9f951bff6664e47cb5fd67f1d8f40608) ) // A0
+	ROM_LOAD( "sx002-02.u28", 0x0200000, 0x200000, CRC(3f47e97a) SHA1(5b0fdc762cf704c8bd92c4a4a42dba4a127b3d49) ) // A1
+	ROM_LOAD( "sx002-03.u25", 0x0400000, 0x200000, CRC(544f18bf) SHA1(539e6df1ded4e9ac8974c697215cc1e5c5a40cda) ) // A2, A3 is unpopulated
 
-	ROM_LOAD( "sx002-04.u19", 0x0600000, 0x200000, CRC(58c270e2) SHA1(7629ba978b18252f375bdc16ed62388d64a35ca1) ) /* B0 */
-	ROM_LOAD( "sx002-05.u16", 0x0800000, 0x200000, CRC(3c310229) SHA1(9a8b81d5f17ce3078627a697aaf07f1b3ba6e08c) ) /* B1 */
-	ROM_LOAD( "sx002-06.u13", 0x0a00000, 0x200000, CRC(46d5b1f3) SHA1(3ec03eddb159eb391ccdce5a0a867a54b3350150) ) /* B2, B3 is unpopulated */
+	ROM_LOAD( "sx002-04.u19", 0x0600000, 0x200000, CRC(58c270e2) SHA1(7629ba978b18252f375bdc16ed62388d64a35ca1) ) // B0
+	ROM_LOAD( "sx002-05.u16", 0x0800000, 0x200000, CRC(3c310229) SHA1(9a8b81d5f17ce3078627a697aaf07f1b3ba6e08c) ) // B1
+	ROM_LOAD( "sx002-06.u13", 0x0a00000, 0x200000, CRC(46d5b1f3) SHA1(3ec03eddb159eb391ccdce5a0a867a54b3350150) ) // B2, B3 is unpopulated
 
-	ROM_LOAD( "sx002-07.u6",  0x0c00000, 0x200000, CRC(c30fa397) SHA1(d4575868c1b63f9e94bf24539a3fd8a85df93d0b) ) /* C0 */
-	ROM_LOAD( "sx002-08.u3",  0x0e00000, 0x200000, CRC(64edcefa) SHA1(55a71afe87da93e35c5ba291e970bdcd91b52a7a) ) /* C1 */
-	ROM_LOAD( "sx002-09.u2",  0x1000000, 0x200000, CRC(51527c56) SHA1(378155a585e5b847bd8ae1f17cb651138d844e33) ) /* C2, C3 is unpopulated */
+	ROM_LOAD( "sx002-07.u6",  0x0c00000, 0x200000, CRC(c30fa397) SHA1(d4575868c1b63f9e94bf24539a3fd8a85df93d0b) ) // C0
+	ROM_LOAD( "sx002-08.u3",  0x0e00000, 0x200000, CRC(64edcefa) SHA1(55a71afe87da93e35c5ba291e970bdcd91b52a7a) ) // C1
+	ROM_LOAD( "sx002-09.u2",  0x1000000, 0x200000, CRC(51527c56) SHA1(378155a585e5b847bd8ae1f17cb651138d844e33) ) // C2, C3 is unpopulated
 
-	ROM_FILL(             0x1200000, 0x600000, 0x000000          )
-
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 ) // Samples
 	ROM_LOAD16_BYTE( "sx002-10.u14", 0x000000, 0x200000, CRC(b0669dfa) SHA1(ff805f59864ac4ccee3e249c06804d844d3df59c) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 ) // Samples
 	ROM_LOAD16_BYTE( "sx002-11.u7",  0x000000, 0x200000, CRC(b8dd621a) SHA1(f9b43e018f2bb121e4f4e9554419cd32b870556b) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
 	ROM_COPY( "ensoniq.0", 0x000000, 0x000000, 0x400000 )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.3", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.3", 0 ) // Samples
 	ROM_COPY( "ensoniq.1", 0x000000, 0x000000, 0x400000 )
 
 	ROM_REGION( 0x11000, "st010", 0)
@@ -4538,61 +4495,59 @@ Hardware is almost identical to SSV system
 ****************************************************************************/
 
 ROM_START( ultrax )
-	ROM_REGION( 0x200000, "maincpu", 0 )  /* V60 Code */
+	ROM_REGION( 0x200000, "maincpu", 0 )  // V60 Code
 	ROM_LOAD16_BYTE( "71047-11.u64", 0x000000, 0x080000, CRC(593b2678) SHA1(3b24b59a21386a4688502c5f0a2dd4eb0ec92544) )
 	ROM_LOAD16_BYTE( "71047-09.u65", 0x000001, 0x080000, CRC(08ea8d91) SHA1(5d2672f6c96fbbe9d80bd6539c1400b62745892a) )
 	ROM_LOAD16_BYTE( "71047-12.u62", 0x100000, 0x080000, CRC(76a77ab2) SHA1(0cf2f293defc23c807556ff92ea99f963fafed40) )
 	ROM_LOAD16_BYTE( "71047-10.u63", 0x100001, 0x080000, CRC(7c79faf9) SHA1(40c1420eeae355efa628bbcfd69e0dd18d343fd9) )
 
-	ROM_REGION( 0xc00000, "gfx1", 0 ) /* Sprites */
+	ROM_REGION( 0xc00000, "sprites", ROMREGION_ERASE00 )
 	ROM_LOAD( "71047-01.u73", 0x0000000, 0x200000, CRC(66662b08) SHA1(0cb683e5f85ffe21bd3367af4d3e48a484dbd4c3) )
 	ROM_LOAD( "71047-02.u74", 0x0200000, 0x100000, CRC(6b00dc0c) SHA1(6af8ceed72d13f9979175c0d907a4a8c127ca1ad) )
 	ROM_LOAD( "71047-03.u76", 0x0300000, 0x200000, CRC(00fcd6c2) SHA1(61d13cbafbc0fd6ff62cd08aa88591ed0fd0b182) )
 	ROM_LOAD( "71047-04.u77", 0x0500000, 0x100000, CRC(d9e710d1) SHA1(063459a247f9ff81cb558802e9943b3ea8a2ea3a) )
 	ROM_LOAD( "71047-05.u75", 0x0600000, 0x200000, CRC(10848193) SHA1(40b7ebb6011dc703bbf620cd22cd678c10ec67a4) )
 	ROM_LOAD( "71047-06.u88", 0x0800000, 0x100000, CRC(b8ac2942) SHA1(3e85e8f5669d469dd3114455248546d32a642315) )
-	ROM_FILL(                 0x0900000, 0x300000, 0x000000 )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 ) // Samples
 	ROM_LOAD16_BYTE( "71047-07.u59", 0x000000, 0x200000, CRC(d9828b62) SHA1(f66a388d7a00b3a45d386671c061f5b840453451) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 ) // Samples
 	ROM_LOAD16_BYTE( "71047-08.u60", 0x000000, 0x200000, CRC(30ebff6d) SHA1(53824c1fc37e22b545fd68b59722f7968f0ca1e2) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
 	ROM_COPY( "ensoniq.0", 0x000000, 0x000000, 0x400000 )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.3", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.3", 0 ) // Samples
 	ROM_COPY( "ensoniq.1", 0x000000, 0x000000, 0x400000 )
 ROM_END
 
 
 ROM_START( ultraxg )
-	ROM_REGION( 0x200000, "maincpu", 0 )  /* V60 Code */
-	ROM_LOAD16_BYTE( "sx010-11.5h", 0x000000, 0x080000, CRC(58554bdd) SHA1(4b35fbaca0cb458e3b21c43e4b4dfd708a7b9397) ) /* hand written label with date 2/27 & checksum "44B4" */
-	ROM_LOAD16_BYTE( "sx010-09.5c", 0x000001, 0x080000, CRC(153e79b2) SHA1(e0278267e345ebd81f66fbb9d262cbd78df2d01b) ) /* hand written label with date 2/27 & checksum "449B" */
-	ROM_LOAD16_BYTE( "sx010-12.5k", 0x100000, 0x080000, CRC(14ad58c9) SHA1(d6be82044a22eb21cac8f7e961a198e369743962) ) /* hand written label with date 2/27 & checksum "3CCF" */
-	ROM_LOAD16_BYTE( "sx010-10.5d", 0x100001, 0x080000, CRC(7e64473e) SHA1(2444ac4d95563b18c8aec077e742b0f84fd38f43) ) /* hand written label with date 2/27 & checksum "0CC5" */
+	ROM_REGION( 0x200000, "maincpu", 0 )  // V60 Code
+	ROM_LOAD16_BYTE( "sx010-11.5h", 0x000000, 0x080000, CRC(58554bdd) SHA1(4b35fbaca0cb458e3b21c43e4b4dfd708a7b9397) ) // hand written label with date 2/27 & checksum "44B4"
+	ROM_LOAD16_BYTE( "sx010-09.5c", 0x000001, 0x080000, CRC(153e79b2) SHA1(e0278267e345ebd81f66fbb9d262cbd78df2d01b) ) // hand written label with date 2/27 & checksum "449B"
+	ROM_LOAD16_BYTE( "sx010-12.5k", 0x100000, 0x080000, CRC(14ad58c9) SHA1(d6be82044a22eb21cac8f7e961a198e369743962) ) // hand written label with date 2/27 & checksum "3CCF"
+	ROM_LOAD16_BYTE( "sx010-10.5d", 0x100001, 0x080000, CRC(7e64473e) SHA1(2444ac4d95563b18c8aec077e742b0f84fd38f43) ) // hand written label with date 2/27 & checksum "0CC5"
 
-	ROM_REGION( 0xc00000, "gfx1", 0 ) /* Sprites */
+	ROM_REGION( 0xc00000, "sprites", ROMREGION_ERASE00 )
 	ROM_LOAD( "71047-01.u73", 0x0000000, 0x200000, CRC(66662b08) SHA1(0cb683e5f85ffe21bd3367af4d3e48a484dbd4c3) )
 	ROM_LOAD( "71047-02.u74", 0x0200000, 0x100000, CRC(6b00dc0c) SHA1(6af8ceed72d13f9979175c0d907a4a8c127ca1ad) )
 	ROM_LOAD( "71047-03.u76", 0x0300000, 0x200000, CRC(00fcd6c2) SHA1(61d13cbafbc0fd6ff62cd08aa88591ed0fd0b182) )
 	ROM_LOAD( "71047-04.u77", 0x0500000, 0x100000, CRC(d9e710d1) SHA1(063459a247f9ff81cb558802e9943b3ea8a2ea3a) )
 	ROM_LOAD( "71047-05.u75", 0x0600000, 0x200000, CRC(10848193) SHA1(40b7ebb6011dc703bbf620cd22cd678c10ec67a4) )
 	ROM_LOAD( "71047-06.u88", 0x0800000, 0x100000, CRC(b8ac2942) SHA1(3e85e8f5669d469dd3114455248546d32a642315) )
-	ROM_FILL(                 0x0900000, 0x300000, 0x000000 )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 ) // Samples
 	ROM_LOAD16_BYTE( "71047-07.u59", 0x000000, 0x200000, CRC(d9828b62) SHA1(f66a388d7a00b3a45d386671c061f5b840453451) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 ) // Samples
 	ROM_LOAD16_BYTE( "71047-08.u60", 0x000000, 0x200000, CRC(30ebff6d) SHA1(53824c1fc37e22b545fd68b59722f7968f0ca1e2) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", 0 ) // Samples
 	ROM_COPY( "ensoniq.0", 0x000000, 0x000000, 0x400000 )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.3", 0 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.3", 0 ) // Samples
 	ROM_COPY( "ensoniq.1", 0x000000, 0x000000, 0x400000 )
 ROM_END
 
@@ -4683,65 +4638,65 @@ Vasara 2 has a secret character code like the Raizing games:
 ****************************************************************************/
 
 ROM_START( vasara )
-	ROM_REGION( 0x400000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x400000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_WORD( "data.u34",  0x000000, 0x200000, CRC(7704cc7e) SHA1(62bb018b7f0c7ee67fee37de17bb22a73bb9e420) )
 	ROM_LOAD16_BYTE( "prg-l.u30", 0x200000, 0x080000, CRC(f0547886) SHA1(6a3717f8b89575d3cb4c7d56dd9df5052faa3c7f) )
 	ROM_RELOAD(                   0x300000, 0x080000)
 	ROM_LOAD16_BYTE( "prg-h.u31", 0x200001, 0x080000, CRC(6a39bba9) SHA1(05ede167150307d7bf59037f264b1d140f6646da) )
 	ROM_RELOAD(                   0x300001, 0x080000)
 
-	ROM_REGION( 0x2000000, "gfx1", 0 ) /* Sprites */
+	ROM_REGION( 0x2000000, "sprites", 0 )
 	ROM_LOAD( "a0.u1", 0x0000000, 0x800000, CRC(673230a6) SHA1(a9d1a108c0737b709854bae199499577f5ae359e) )
 	ROM_LOAD( "b0.u2", 0x0800000, 0x800000, CRC(31a2da7f) SHA1(5efec60affb2ed2b73a6694ac794d41375220609) )
 	ROM_LOAD( "c0.u3", 0x1000000, 0x800000, CRC(d110dacf) SHA1(6f33bf6ce8c06f0b823b5478a56dc95095385181) )
 	ROM_LOAD( "d0.u4", 0x1800000, 0x800000, CRC(82d0ca55) SHA1(5ac07df713504329fbc8e8b5374c04e53745230e) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "s0.u36", 0x000000, 0x200000, CRC(754fca02) SHA1(5b2810a36183e0d4f42f0fb4a09be033ad0db40d) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "s1.u37", 0x000000, 0x200000, CRC(5f303698) SHA1(bd6495f912aa9d761d245ef0a1566d9d7bdbb2ad) )
 ROM_END
 
 ROM_START( vasara2 )
-	ROM_REGION( 0x400000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x400000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_WORD( "data.u34",  0x000000, 0x200000, CRC(493d0103) SHA1(fda68fb089328cabb3bbd52f8703b445a9509bf1) )
 	ROM_LOAD16_BYTE( "prg-l.u30", 0x200000, 0x080000, CRC(40e6f5f6) SHA1(05fee4535ffe8403e86ba92a58e5f2d040489c8e) )
 	ROM_RELOAD(                   0x300000, 0x080000)
 	ROM_LOAD16_BYTE( "prg-h.u31", 0x200001, 0x080000, CRC(c958e146) SHA1(568878526cef76ac0ce4feeaa46e7039291e5f77) )
 	ROM_RELOAD(                   0x300001, 0x080000)
 
-	ROM_REGION( 0x2000000, "gfx1", 0 ) /* Sprites */
+	ROM_REGION( 0x2000000, "sprites", 0 )
 	ROM_LOAD( "a0.u1", 0x0000000, 0x800000, CRC(a6306c75) SHA1(bad715e53426a295d3571c025e0539d5f81ce5ab) )
 	ROM_LOAD( "b0.u2", 0x0800000, 0x800000, CRC(227cbd9f) SHA1(a02787943b659508ce1589cdc7a372cc02826a10) )
 	ROM_LOAD( "c0.u3", 0x1000000, 0x800000, CRC(54ede017) SHA1(4a7ff7ff8ec5843837016f35a588983b5ace06ff) )
 	ROM_LOAD( "d0.u4", 0x1800000, 0x800000, CRC(4be8479d) SHA1(cbb5943dfae86f4d571459263199a63399dedc20) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "s0.u36", 0x000000, 0x200000, CRC(2b381b33) SHA1(b9dd13651e4b8d0b9e3bc4c592022f31ea634d19) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "s1.u37", 0x000000, 0x200000, CRC(11cd7098) SHA1(f75288b5c89df039dfb41d66bd275cda8605e75a) )
 ROM_END
 
 ROM_START( vasara2a )
-	ROM_REGION( 0x400000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x400000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_WORD( "data.u34",     0x000000, 0x200000, CRC(493d0103) SHA1(fda68fb089328cabb3bbd52f8703b445a9509bf1) )
 	ROM_LOAD16_BYTE( "basara-l.u30", 0x200000, 0x080000, CRC(fd88b068) SHA1(a86e3ffc870e6f6f7f18273428b24d938d6b9c3d) )
 	ROM_RELOAD(                      0x300000, 0x080000)
 	ROM_LOAD16_BYTE( "basara-h.u31", 0x200001, 0x080000, CRC(91d641e6) SHA1(4987d1771a90c9f1ce45c2dd2de5b2922d5d19c5) )
 	ROM_RELOAD(                      0x300001, 0x080000)
 
-	ROM_REGION( 0x2000000, "gfx1", 0 ) /* Sprites */
+	ROM_REGION( 0x2000000, "sprites", 0 )
 	ROM_LOAD( "a0.u1", 0x0000000, 0x800000, CRC(a6306c75) SHA1(bad715e53426a295d3571c025e0539d5f81ce5ab) )
 	ROM_LOAD( "b0.u2", 0x0800000, 0x800000, CRC(227cbd9f) SHA1(a02787943b659508ce1589cdc7a372cc02826a10) )
 	ROM_LOAD( "c0.u3", 0x1000000, 0x800000, CRC(54ede017) SHA1(4a7ff7ff8ec5843837016f35a588983b5ace06ff) )
 	ROM_LOAD( "d0.u4", 0x1800000, 0x800000, CRC(4be8479d) SHA1(cbb5943dfae86f4d571459263199a63399dedc20) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "s0.u36", 0x000000, 0x200000, CRC(2b381b33) SHA1(b9dd13651e4b8d0b9e3bc4c592022f31ea634d19) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )   /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 )   // Samples
 	ROM_LOAD16_BYTE( "s1.u37", 0x000000, 0x200000, CRC(11cd7098) SHA1(f75288b5c89df039dfb41d66bd275cda8605e75a) )
 ROM_END
 
@@ -4801,7 +4756,7 @@ Notes:
 ****************************************************************************/
 
 ROM_START( gdfs )
-	ROM_REGION( 0x400000, "maincpu", 0 )     /* V60 Code */
+	ROM_REGION( 0x400000, "maincpu", 0 )     // V60 Code
 	ROM_LOAD16_WORD( "vg004-14.u3",   0x000000, 0x100000, CRC(d88254df) SHA1(ccdfd42e4ce3941018f83e300da8bf7a5950f65c) )
 	ROM_RELOAD(                       0x100000, 0x100000)
 	ROM_LOAD16_BYTE( "ssv2set0.u1",   0x200000, 0x080000, CRC(c23b9e2c) SHA1(9026e065252981fb403255ddc5782359c0088e8a) )
@@ -4809,7 +4764,7 @@ ROM_START( gdfs )
 	ROM_LOAD16_BYTE( "ssv2set1.u2",   0x200001, 0x080000, CRC(d7d52570) SHA1(12e7531519a0a4331e409991265908fb518286ef) )
 	ROM_RELOAD(                       0x300001, 0x80000)
 
-	ROM_REGION( 0x800000, "gfx1", 0 )
+	ROM_REGION( 0x800000, "sprites", ROMREGION_ERASE00 )
 	ROM_LOAD( "vg004-09.u43", 0x000000, 0x200000, CRC(b7382cfa) SHA1(df735470181c16f8aac0e3be76e1ed53a32dbb9c) )
 	ROM_LOAD( "vg004-10.u45", 0x200000, 0x200000, CRC(b3c6b1cb) SHA1(c601213e35d8dfd1244921da5c093f82145706d2) )
 	ROM_LOAD( "vg004-11.u48", 0x400000, 0x200000, CRC(1491def1) SHA1(344043302c81b4118cac4f692375b8af7ea68570) )
@@ -4824,19 +4779,19 @@ ROM_START( gdfs )
 	ROM_LOAD( "vg004-07.u39", 0x0c00000, 0x200000, CRC(5e89fcf9) SHA1(db727ec8117e84c98037c756715e28fd5e39972a) )
 	ROM_LOAD( "vg004-08.u40", 0x0e00000, 0x200000, CRC(6b1746dc) SHA1(35e5ee02975474985a4a611dcc439fc3050b7f94) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    // Tilemap
+	ROM_REGION( 0x80000, "tiles", 0 )
 	ROM_LOAD( "ssvv7.u16",    0x0000000, 0x080000, CRC(f1c3ab6f) SHA1(b7f54f7ae60650fee7570aa4dd4266c629149673) )
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.0", ROMREGION_ERASE00 ) // Samples
 	ROM_LOAD16_BYTE( "vg004-12.u4", 0x000000, 0x200000, CRC(eb41a4ef) SHA1(f4d0844a3c00cf90faa59ae982744b7f0bcbe218) ) // music
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.1", ROMREGION_ERASE00 ) // Samples
 	ROM_LOAD16_BYTE( "vg004-13.u5", 0x000000, 0x200000, CRC(a4ed3977) SHA1(5843d56f69789e70ce0201a693ffae322b628459) ) // credit sound, gunshots etc.
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.2", ROMREGION_ERASE00 ) // Samples
 	ROM_COPY( "ensoniq.0", 0x000000, 0x000000, 0x400000 ) // nothing played from here?
 
-	ROM_REGION16_BE( 0x400000, "ensoniq.3", ROMREGION_ERASE00 ) /* Samples */
+	ROM_REGION16_BE( 0x400000, "ensoniq.3", ROMREGION_ERASE00 ) // Samples
 	ROM_COPY( "ensoniq.1", 0x000000, 0x000000, 0x400000 ) // nothing played from here?
 ROM_END
 
@@ -4850,62 +4805,62 @@ ROM_END
 
 //    year   rom        clone     machine   inputs    init                           monitor manufacturer          title                                                                     flags
 
-GAME( 1993,  dynagear,  0,        dynagear, dynagear, ssv_state, init_ssv,           ROT0,   "Sammy",              "Dyna Gear",                                                              MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+GAME( 1993,  dynagear,  0,        dynagear, dynagear, ssv_state,      init_ssv,           ROT0,   "Sammy",                                    "Dyna Gear",                                                              MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1993,  keithlcy,  0,        keithlcy, keithlcy, ssv_state, init_ssv,           ROT0,   "Visco",              "Dramatic Adventure Quiz Keith & Lucy (Japan)",                           MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1993,  keithlcy,  0,        keithlcy, keithlcy, ssv_state,      init_ssv,           ROT0,   "Visco",                                    "Dramatic Adventure Quiz Keith & Lucy (Japan)",                           MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1993,  pastelis,  0,        pastelis, pastelis, ssv_state, init_pastelis,      ROT0,   "Visco",              "Pastel Island (Japan, prototype)",                                       MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE ) // imperfect raster effects in ending credits and shadows
+GAME( 1993,  pastelis,  0,        pastelis, pastelis, ssv_state,      init_pastelis,      ROT0,   "Visco",                                    "Pastel Island (Japan, prototype)",                                       MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE ) // imperfect raster effects in ending credits and shadows
 
-GAME( 1993,  srmp4,     0,        srmp4,    srmp4,    ssv_state, init_ssv,           ROT0,   "Seta",               "Super Real Mahjong PIV (Japan)",                                         MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
-GAME( 1993,  srmp4o,    srmp4,    srmp4,    srmp4,    ssv_state, init_ssv,           ROT0,   "Seta",               "Super Real Mahjong PIV (Japan, older set)",                              MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) // by the numbering of the program ROMs this should be older
+GAME( 1993,  srmp4,     0,        srmp4,    srmp4,    ssv_state,      init_ssv,           ROT0,   "Seta",                                     "Super Real Mahjong PIV (Japan)",                                         MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1993,  srmp4o,    srmp4,    srmp4,    srmp4,    ssv_state,      init_ssv,           ROT0,   "Seta",                                     "Super Real Mahjong PIV (Japan, older set)",                              MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) // by the numbering of the program ROMs this should be older
 
-GAME( 1993,  survarts,  0,        survarts, survarts, ssv_state, init_ssv,           ROT0,   "Sammy",              "Survival Arts (World)",                                                  MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
-GAME( 1993,  survartsu, survarts, survarts, survarts, ssv_state, init_ssv,           ROT0,   "American Sammy",     "Survival Arts (USA)",                                                    MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
-GAME( 1993,  survartsj, survarts, survarts, survarts, ssv_state, init_ssv,           ROT0,   "Sammy",              "Survival Arts (Japan)",                                                  MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1993,  survarts,  0,        survarts, survarts, ssv_state,      init_ssv,           ROT0,   "Sammy",                                    "Survival Arts (World)",                                                  MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1993,  survartsu, survarts, survarts, survarts, ssv_state,      init_ssv,           ROT0,   "American Sammy",                           "Survival Arts (USA)",                                                    MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1993,  survartsj, survarts, survarts, survarts, ssv_state,      init_ssv,           ROT0,   "Sammy",                                    "Survival Arts (Japan)",                                                  MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1994,  drifto94,  0,        drifto94, drifto94, ssv_state, init_ssv,           ROT0,   "Visco",              "Drift Out '94 - The Hard Order (Japan)",                                 MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1994,  drifto94,  0,        drifto94, drifto94, drifto94_state, init_ssv,           ROT0,   "Visco",                                    "Drift Out '94 - The Hard Order (Japan)",                                 MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1994,  eaglshot,  0,        eaglshot, eaglshot, eaglshot_state, init_eaglshot, ROT0,   "Sammy",              "Eagle Shot Golf (US)",                                                   MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
-GAME( 1994,  eaglshotj, eaglshot, eaglshot, eaglshot, eaglshot_state, init_eaglshot, ROT0,   "Sammy",              "Eagle Shot Golf (Japan, bootleg?)",                                      MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE ) // from a bootleg ROM board with no proper Seta / Sammy markings, possibly original ROM tho?
+GAME( 1994,  eaglshot,  0,        eaglshot, eaglshot, eaglshot_state, init_eaglshot,      ROT0,   "Sammy",                                    "Eagle Shot Golf (US)",                                                   MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+GAME( 1994,  eaglshotj, eaglshot, eaglshot, eaglshot, eaglshot_state, init_eaglshot,      ROT0,   "Sammy",                                    "Eagle Shot Golf (Japan, bootleg?)",                                      MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE ) // from a bootleg ROM board with no proper Seta / Sammy markings, possibly original ROM tho?
 
-GAME( 1995,  hypreact,  0,        hypreact, hypreact, ssv_state, init_ssv,           ROT0,   "Sammy",              "Mahjong Hyper Reaction (Japan)",                                         MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1995,  hypreact,  0,        hypreact, hypreact, ssv_state,      init_ssv,           ROT0,   "Sammy",                                    "Mahjong Hyper Reaction (Japan)",                                         MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1994,  twineag2,  0,        twineag2, twineag2, ssv_state, init_ssv_irq1,      ROT270, "Seta",               "Twin Eagle II - The Rescue Mission",                                     MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1994,  twineag2,  0,        twineag2, twineag2, drifto94_state, init_ssv_irq1,      ROT270, "Seta",                                     "Twin Eagle II - The Rescue Mission",                                     MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1995,  gdfs,      0,        gdfs,     gdfs,     gdfs_state, init_ssv,          ROT0,   "Banpresto",          "Mobile Suit Gundam Final Shooting (Japan)",                              MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) // title screen spells the title "Mobil" but standardized spelling is "Mobile" it also lists the company name as "Banprest" instead of "Banpresto"
+GAME( 1995,  gdfs,      0,        gdfs,     gdfs,     gdfs_state,     init_ssv,           ROT0,   "Banpresto",                                "Mobile Suit Gundam Final Shooting (Japan)",                              MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) // title screen spells the title "Mobil" but standardized spelling is "Mobile" it also lists the company name as "Banprest" instead of "Banpresto"
 
 // Ultra X Weapon: "developed by Seta" in ending screen
-GAME( 1995,  ultrax,    0,        ultrax,   ultrax,   ssv_state, init_ssv_irq1,      ROT270, "Banpresto / Tsuburaya Productions / Seta", "Ultra X Weapons / Ultra Keibitai",                        MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE ) // 95-01-30 13:27:15 on startup
-GAME( 1995,  ultraxg,   ultrax,   ultrax,   ultrax,   ssv_state, init_ssv_irq1,      ROT270, "Banpresto / Tsuburaya Productions / Seta", "Ultra X Weapons / Ultra Keibitai (Gamest review build)",  MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE ) // 95-02-16 15:30:24 on startup (newer, but could have pause functionality due to being a review build so left as clone)
+GAME( 1995,  ultrax,    0,        ultrax,   ultrax,   ssv_state,      init_ssv_irq1,      ROT270, "Banpresto / Tsuburaya Productions / Seta", "Ultra X Weapons / Ultra Keibitai",                                       MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE ) // 95-01-30 13:27:15 on startup
+GAME( 1995,  ultraxg,   ultrax,   ultrax,   ultrax,   ssv_state,      init_ssv_irq1,      ROT270, "Banpresto / Tsuburaya Productions / Seta", "Ultra X Weapons / Ultra Keibitai (Gamest review build)",                 MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE ) // 95-02-16 15:30:24 on startup (newer, but could have pause functionality due to being a review build so left as clone)
 
-GAME( 1996,  janjans1,  0,        janjans1, janjans1, ssv_state, init_ssv,           ROT0,   "Visco",              "Lovely Pop Mahjong JangJang Shimasho (Japan)",                           MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+GAME( 1996,  janjans1,  0,        janjans1, janjans1, ssv_state,      init_ssv,           ROT0,   "Visco",                                    "Lovely Pop Mahjong JangJang Shimasho (Japan)",                           MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1996?, meosism,   0,        meosism,  meosism,  ssv_state, init_ssv,           ROT0,   "Sammy",              "Meosis Magic (Japan)",                                                   MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1996?, meosism,   0,        meosism,  meosism,  ssv_state,      init_ssv,           ROT0,   "Sammy",                                    "Meosis Magic (Japan)",                                                   MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1996,  stmblade,  0,        stmblade, stmblade, ssv_state, init_ssv,           ROT270, "Visco",              "Storm Blade (US)",                                                       MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
-GAME( 1996,  stmbladej, stmblade, stmblade, stmblade, ssv_state, init_ssv,           ROT270, "Visco",              "Storm Blade (Japan)",                                                    MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+GAME( 1996,  stmblade,  0,        stmblade, stmblade, drifto94_state, init_ssv,           ROT270, "Visco",                                    "Storm Blade (US)",                                                       MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+GAME( 1996,  stmbladej, stmblade, stmblade, stmblade, drifto94_state, init_ssv,           ROT270, "Visco",                                    "Storm Blade (Japan)",                                                    MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1997,  hypreac2,  0,        hypreac2, hypreac2, ssv_state, init_ssv_tilescram, ROT0,   "Sammy",              "Mahjong Hyper Reaction 2 (Japan)",                                       MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1997,  hypreac2,  0,        hypreac2, hypreac2, ssv_state,      init_ssv_tilescram, ROT0,   "Sammy",                                    "Mahjong Hyper Reaction 2 (Japan)",                                       MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1997,  jsk,       0,        jsk,      jsk,      ssv_state, init_jsk,           ROT0,   "Visco",              "Joryuu Syougi Kyoushitsu (Japan)",                                       MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1997,  jsk,       0,        jsk,      jsk,      ssv_state,      init_jsk,           ROT0,   "Visco",                                    "Joryuu Syougi Kyoushitsu (Japan)",                                       MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1997,  koikois2,  0,        janjans1, koikois2, ssv_state, init_ssv,           ROT0,   "Visco",              "Koi Koi Shimasho 2 - Super Real Hanafuda (Japan)",                       MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1997,  koikois2,  0,        janjans1, koikois2, ssv_state,      init_ssv,           ROT0,   "Visco",                                    "Koi Koi Shimasho 2 - Super Real Hanafuda (Japan)",                       MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1997,  mslider,   0,        mslider,  mslider,  ssv_state, init_ssv,           ROT0,   "Visco / Datt Japan", "Monster Slider (Japan)",                                                 MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1997,  mslider,   0,        mslider,  mslider,  ssv_state,      init_ssv,           ROT0,   "Visco / Datt Japan",                       "Monster Slider (Japan)",                                                 MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1997,  srmp7,     0,        srmp7,    srmp7,    ssv_state, init_srmp7,         ROT0,   "Seta",               "Super Real Mahjong P7 (Japan)",                                          MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME( 1997,  srmp7,     0,        srmp7,    srmp7,    ssv_state,      init_srmp7,         ROT0,   "Seta",                                     "Super Real Mahjong P7 (Japan)",                                          MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1998,  ryorioh,   0,        ryorioh,  ryorioh,  ssv_state, init_ssv,           ROT0,   "Visco",              "Gourmet Battle Quiz Ryohrioh CooKing (Japan)",                           MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1998,  ryorioh,   0,        ryorioh,  ryorioh,  ssv_state,      init_ssv,           ROT0,   "Visco",                                    "Gourmet Battle Quiz Ryohrioh CooKing (Japan)",                           MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1998,  sxyreact,  0,        sxyreact, sxyreact, sxyreact_state, init_sexy,     ROT0,   "Sammy",              "Pachinko Sexy Reaction (Japan)",                                         MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1998,  sxyreact,  0,        sxyreact, sxyreact, sxyreact_state, init_sexy,          ROT0,   "Sammy",                                    "Pachinko Sexy Reaction (Japan)",                                         MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1999,  sxyreac2,  0,        sxyreac2, sxyreact, sxyreact_state, init_sexy,     ROT0,   "Sammy",              "Pachinko Sexy Reaction 2 (Japan)",                                       MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1999,  sxyreac2,  0,        sxyreac2, sxyreact, sxyreact_state, init_sexy,          ROT0,   "Sammy",                                    "Pachinko Sexy Reaction 2 (Japan)",                                       MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
-GAME( 1999,  cairblad,  0,        cairblad, cairblad, ssv_state, init_ssv_tilescram, ROT270, "Sammy",              "Change Air Blade (Japan)",                                               MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1999,  cairblad,  0,        cairblad, cairblad, ssv_state,      init_ssv_tilescram, ROT270, "Sammy",                                    "Change Air Blade (Japan)",                                               MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
-GAME( 2000,  janjans2,  0,        janjans1, janjans2, ssv_state, init_ssv,           ROT0,   "Visco",              "Lovely Pop Mahjong JangJang Shimasho 2 (Japan)",                         MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+GAME( 2000,  janjans2,  0,        janjans1, janjans2, ssv_state,      init_ssv,           ROT0,   "Visco",                                    "Lovely Pop Mahjong JangJang Shimasho 2 (Japan)",                         MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
 
-GAME( 2000,  vasara,    0,        vasara,   vasara,   ssv_state, init_ssv,           ROT270, "Visco",              "Vasara",                                                                 MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 2000,  vasara,    0,        vasara,   vasara,   ssv_state,      init_ssv,           ROT270, "Visco",                                    "Vasara",                                                                 MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
-GAME( 2001,  vasara2,   0,        vasara,   vasara2,  ssv_state, init_ssv,           ROT270, "Visco",              "Vasara 2 (set 1)",                                                       MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
-GAME( 2001,  vasara2a,  vasara2,  vasara,   vasara2,  ssv_state, init_ssv,           ROT270, "Visco",              "Vasara 2 (set 2)",                                                       MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 2001,  vasara2,   0,        vasara,   vasara2,  ssv_state,      init_ssv,           ROT270, "Visco",                                    "Vasara 2 (set 1)",                                                       MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 2001,  vasara2a,  vasara2,  vasara,   vasara2,  ssv_state,      init_ssv,           ROT270, "Visco",                                    "Vasara 2 (set 2)",                                                       MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/seta/ssv.h
+++ b/src/mame/seta/ssv.h
@@ -24,29 +24,25 @@ public:
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
 		m_ensoniq(*this, "ensoniq"),
-		m_dsp(*this, "dsp"),
 		m_mainram(*this, "mainram"),
 		m_spriteram(*this, "spriteram"),
 		m_scroll(*this, "scroll"),
 		m_irq_vectors(*this, "irq_vectors"),
 		m_input_sel(*this, "input_sel"),
 		m_srmp7_esbank(*this, "esbank_%u", 2U),
-		m_raster_interrupt_enabled(false),
-		m_io_key(*this, "KEY%u", 0U),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_screen(*this, "screen"),
-		m_palette(*this, "palette")
+		m_palette(*this, "palette"),
+		m_io_key(*this, "KEY%u", 0U),
+		m_raster_interrupt_enabled(false)
 	{ }
 
 	void ssv(machine_config &config);
 	void dynagear(machine_config &config);
 	void hypreac2(machine_config &config);
 	void meosism(machine_config &config);
-	void drifto94(machine_config &config);
-	void stmblade(machine_config &config);
 	void srmp4(machine_config &config);
 	void srmp7(machine_config &config);
-	void twineag2(machine_config &config);
 	void ryorioh(machine_config &config);
 	void janjans1(machine_config &config);
 	void survarts(machine_config &config);
@@ -67,44 +63,20 @@ public:
 	void init_pastelis();
 
 protected:
-	required_device<cpu_device> m_maincpu;
-	required_device<es5506_device> m_ensoniq;
-	optional_device<upd96050_device> m_dsp;
-
-	required_shared_ptr<uint16_t> m_mainram;
-	required_shared_ptr<uint16_t> m_spriteram;
-	required_shared_ptr<uint16_t> m_scroll;
-	required_shared_ptr<uint16_t> m_irq_vectors;
-	optional_shared_ptr<uint16_t> m_input_sel;
-	optional_memory_bank_array<2> m_srmp7_esbank;
-
-	int m_tile_code[16]{};
-	int m_enable_video = 0;
-	int m_shadow_pen_mask = 0;
-	int m_shadow_pen_shift = 0;
-	uint8_t m_requested_int = 0;
-	uint16_t m_irq_enable = 0;
-	int m_interrupt_ultrax = 0;
-	bool m_raster_interrupt_enabled;
-	uint32_t m_latches[8]{};
+	virtual void machine_reset() override;
+	virtual void video_start() override;
 
 	void irq_ack_w(offs_t offset, uint16_t data);
 	void irq_enable_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void lockout_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void lockout_inv_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t dsp_dr_r();
-	void dsp_dr_w(uint16_t data);
-	uint16_t dsp_r(offs_t offset);
 	[[maybe_unused]] uint16_t fake_r(offs_t offset);
-	void dsp_w(offs_t offset, uint16_t data);
-	uint16_t drifto94_unknown_r();
 	uint16_t hypreact_input_r();
 	uint16_t mainram_r(offs_t offset);
 	void mainram_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	uint16_t srmp4_input_r();
 	uint16_t srmp7_irqv_r();
 	void srmp7_sound_bank_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t srmp7_input_r();
 	uint32_t latch32_r(offs_t offset);
 	void latch32_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	uint16_t latch16_r(offs_t offset);
@@ -112,31 +84,25 @@ protected:
 	uint16_t vblank_r();
 	void scroll_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 	TIMER_DEVICE_CALLBACK_MEMBER(interrupt);
 	void update_irq_state();
 	IRQ_CALLBACK_MEMBER(irq_callback);
 
-	void drawgfx_line(bitmap_ind16 &bitmap, const rectangle &cliprect, int gfx, uint32_t code, uint32_t color, int flipx, int flipy, int base_sx, int base_sy, int shadow, int realline, int line);
-	void drawgfx(bitmap_ind16 &bitmap, const rectangle &cliprect, int gfx,uint32_t code, uint32_t color, int flipx, int flipy, int base_sx, int base_sy,int shadow);
+	void drawgfx_line(bitmap_ind16 &bitmap, const rectangle &cliprect, int gfx, uint32_t code, uint32_t color, bool flipx, bool flipy, int base_sx, int base_sy, int shadow, int realline, int line);
+	void drawgfx(bitmap_ind16 &bitmap, const rectangle &cliprect, int gfx, uint32_t code, uint32_t color, bool flipx, bool flipy, int base_sx, int base_sy,int shadow);
 
-	void draw_16x16_tile_line(bitmap_ind16 &bitmap, const rectangle &cliprect, int flipx, int flipy, int mode, int code, int color, int sx, int sy, int realline, int line);
-	void get_tile(int x, int y, int size, int page, int& code, int& attr, int& flipx, int& flipy);
+	void draw_16x16_tile_line(bitmap_ind16 &bitmap, const rectangle &cliprect, bool flipx, bool flipy, int mode, int code, int color, int sx, int sy, int realline, int line);
+	void get_tile(int x, int y, int size, int page, int& code, int& attr, bool& flipx, bool& flipy);
 	void draw_row_64pixhigh(bitmap_ind16 &bitmap, const rectangle &cliprect, int in_sy, int scroll);
-	void draw_layer(bitmap_ind16 &bitmap, const rectangle &cliprect, int  nr);
+	void draw_layer(bitmap_ind16 &bitmap, const rectangle &cliprect, int nr);
 
-	void draw_sprites_tiles(bitmap_ind16 &bitmap, const rectangle &cliprect, int code, int flipx, int flipy, int gfx, int shadow, int color, int sx, int sy, int xnum, int ynum);
+	void draw_sprites_tiles(bitmap_ind16 &bitmap, const rectangle &cliprect, int code, bool flipx, bool flipy, int gfx, int shadow, int color, int sx, int sy, int xnum, int ynum);
 	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void enable_video(int enable);
+	void enable_video(bool enable);
 
 	void cairblad_map(address_map &map);
-	void drifto94_map(address_map &map);
-	void dsp_data_map(address_map &map);
-	void dsp_prg_map(address_map &map);
 	void hypreac2_map(address_map &map);
 	void hypreact_map(address_map &map);
 	void janjans1_map(address_map &map);
@@ -151,15 +117,62 @@ protected:
 	void srmp7_es5506_bank2_map(address_map &map);
 	void srmp7_es5506_bank3_map(address_map &map);
 	void survarts_map(address_map &map);
-	void twineag2_map(address_map &map);
 	void ultrax_map(address_map &map);
 
-	optional_ioport_array<4> m_io_key;
+	void ssv_map(address_map &map, u32 rom);
+
+	required_device<cpu_device> m_maincpu;
+	required_device<es5506_device> m_ensoniq;
+
+	required_shared_ptr<uint16_t> m_mainram;
+	required_shared_ptr<uint16_t> m_spriteram;
+	required_shared_ptr<uint16_t> m_scroll;
+	required_shared_ptr<uint16_t> m_irq_vectors;
+	optional_shared_ptr<uint16_t> m_input_sel;
+	optional_memory_bank_array<2> m_srmp7_esbank;
+
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 
-	void ssv_map(address_map &map, u32 rom);
+	optional_ioport_array<4> m_io_key;
+
+	uint32_t m_tile_code[16]{};
+	bool m_enable_video = false;
+	uint32_t m_shadow_pen_mask = 0;
+	uint32_t m_shadow_pen_shift = 0;
+	uint8_t m_requested_int = 0;
+	uint16_t m_irq_enable = 0;
+	bool m_interrupt_ultrax = false;
+	bool m_raster_interrupt_enabled;
+	uint32_t m_latches[8]{};
+};
+
+class drifto94_state : public ssv_state
+{
+public:
+	drifto94_state(const machine_config &mconfig, device_type type, const char *tag) :
+		ssv_state(mconfig, type, tag),
+		m_dsp(*this, "dsp")
+	{ }
+
+	void drifto94(machine_config &config);
+	void stmblade(machine_config &config);
+	void twineag2(machine_config &config);
+
+private:
+	uint16_t dsp_dr_r();
+	void dsp_dr_w(uint16_t data);
+	uint16_t dsp_r(offs_t offset);
+	void dsp_w(offs_t offset, uint16_t data);
+	uint16_t drifto94_unknown_r();
+
+	void drifto94_map(address_map &map);
+	void dsp_data_map(address_map &map);
+	void dsp_prg_map(address_map &map);
+	void twineag2_map(address_map &map);
+
+	required_device<upd96050_device> m_dsp;
 };
 
 class gdfs_state : public ssv_state
@@ -187,7 +200,7 @@ private:
 
 	void gdfs_map(address_map &map);
 
-	TILE_GET_INFO_MEMBER(get_tile_info_0);
+	TILE_GET_INFO_MEMBER(get_tile_info);
 	void tmapram_w(offs_t offset, uint16_t data, uint16_t mem_mask);
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
@@ -205,7 +218,8 @@ class eaglshot_state : public ssv_state
 public:
 	eaglshot_state(const machine_config &mconfig, device_type type, const char *tag) :
 		ssv_state(mconfig, type, tag),
-		m_upd4701(*this, "upd4701")
+		m_upd4701(*this, "upd4701"),
+		m_gfxrom_bank(*this, "gfxrom_bank")
 	{ }
 
 	void eaglshot(machine_config &config);
@@ -226,6 +240,7 @@ private:
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 	required_device<upd4701_device> m_upd4701;
+	required_memory_bank m_gfxrom_bank;
 
 	std::unique_ptr<uint16_t[]> m_gfxram;
 };

--- a/src/mame/seta/ssv_v.cpp
+++ b/src/mame/seta/ssv_v.cpp
@@ -401,9 +401,7 @@ void ssv_state::scroll_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 	m_screen->update_partial(m_screen->vpos() - 1); // pastelis FOR USE IN JAPAN screen polls the vblank / hblank to do a raster effect
 	COMBINE_DATA(m_scroll + offset);
 
-//  offsets 60-7f: CRT Controller  
-//  if(((offset*2) & 0x70) == 0x60)
-//      printf("%04x %04x\n",data,offset*2);
+//  offsets 60-7f: CRT Controller
 }
 
 /***************************************************************************

--- a/src/mame/seta/ssv_v.cpp
+++ b/src/mame/seta/ssv_v.cpp
@@ -137,7 +137,7 @@
 #include "ssv.h"
 
 
-void ssv_state::drawgfx_line(bitmap_ind16 &bitmap, const rectangle &cliprect, int gfx, uint32_t code, uint32_t color, int flipx, int flipy, int base_sx, int base_sy, int shadow, int realline, int line)
+void ssv_state::drawgfx_line(bitmap_ind16 &bitmap, const rectangle &cliprect, int gfx, uint32_t code, uint32_t color, bool flipx, bool flipy, int base_sx, int base_sy, int shadow, int realline, int line)
 {
 	gfx_element *gfxelement = m_gfxdecode->gfx(0);
 
@@ -193,18 +193,16 @@ void ssv_state::drawgfx_line(bitmap_ind16 &bitmap, const rectangle &cliprect, in
 	}
 }
 
-void ssv_state::drawgfx(bitmap_ind16 &bitmap, const rectangle &cliprect, int gfx, uint32_t code, uint32_t color, int flipx, int flipy, int base_sx, int base_sy, int shadow)
+void ssv_state::drawgfx(bitmap_ind16 &bitmap, const rectangle &cliprect, int gfx, uint32_t code, uint32_t color, bool flipx, bool flipy, int base_sx, int base_sy, int shadow)
 {
 	for (int line = 0; line < 8; line++)
-	{
 		drawgfx_line(bitmap, cliprect, gfx, code, color, flipx, flipy, base_sx, base_sy, shadow, base_sy+line, line);
-	}
 }
 
 
 void ssv_state::video_start()
 {
-	m_gfxdecode->gfx(0)->set_granularity(64); /* 256 colour sprites with palette selectable on 64 colour boundaries */
+	m_gfxdecode->gfx(0)->set_granularity(64); // 256 colour sprites with palette selectable on 64 colour boundaries
 
 	save_item(NAME(m_enable_video));
 	save_item(NAME(m_shadow_pen_mask));
@@ -215,16 +213,16 @@ void eaglshot_state::video_start()
 {
 	ssv_state::video_start();
 
-	m_gfxram       =   std::make_unique<uint16_t[]>(16 * 0x40000 / 2);
+	m_gfxram = std::make_unique<uint16_t[]>(16 * 0x40000 / 2);
 
 	m_gfxdecode->gfx(0)->set_source((uint8_t *)m_gfxram.get());
 
 	save_pointer(NAME(m_gfxram), 16 * 0x40000 / 2);
 }
 
-TILE_GET_INFO_MEMBER(gdfs_state::get_tile_info_0)
+TILE_GET_INFO_MEMBER(gdfs_state::get_tile_info)
 {
-	uint16_t tile = m_tmapram[tile_index];
+	const uint16_t tile = m_tmapram[tile_index];
 
 	tileinfo.set(1, tile, 0, TILE_FLIPXY( tile >> 14 ));
 }
@@ -239,7 +237,7 @@ void gdfs_state::video_start()
 {
 	ssv_state::video_start();
 
-	m_tmap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(gdfs_state::get_tile_info_0)), TILEMAP_SCAN_ROWS, 16,16, 0x100,0x100);
+	m_tmap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(gdfs_state::get_tile_info)), TILEMAP_SCAN_ROWS, 16,16, 0x100,0x100);
 
 	m_tmap->set_transparent_pen(0);
 }
@@ -403,7 +401,7 @@ void ssv_state::scroll_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 	m_screen->update_partial(m_screen->vpos() - 1); // pastelis FOR USE IN JAPAN screen polls the vblank / hblank to do a raster effect
 	COMBINE_DATA(m_scroll + offset);
 
-/*  offsets 60-7f: CRT Controller   */
+//  offsets 60-7f: CRT Controller  
 //  if(((offset*2) & 0x70) == 0x60)
 //      printf("%04x %04x\n",data,offset*2);
 }
@@ -594,12 +592,12 @@ From the above some noteworthy cases are:
 
 **************************************************************************/
 
-/* Draw a tilemap sprite */
+// Draw a tilemap sprite
 
 
-void ssv_state::draw_16x16_tile_line(bitmap_ind16 &bitmap, const rectangle &cliprect, int flipx, int flipy, int mode, int code, int color, int sx, int sy, int realline, int line)
+void ssv_state::draw_16x16_tile_line(bitmap_ind16 &bitmap, const rectangle &cliprect, bool flipx, bool flipy, int mode, int code, int color, int sx, int sy, int realline, int line)
 {
-	/* Force 16x16 tiles ? */
+	// Force 16x16 tiles ?
 	int realcode;
 	if (flipy)
 	{
@@ -615,52 +613,50 @@ void ssv_state::draw_16x16_tile_line(bitmap_ind16 &bitmap, const rectangle &clip
 		else
 			realcode = code;
 	}
-	int tileline = line & 7;
+	const int tileline = line & 7;
 
-	int shadow = (mode & 0x0800);
-	/* Select 256 or 64 color tiles */
-	int gfx = ((mode & 0x0700) >> 8);
+	const int shadow = BIT(mode, 11);
+	// Select 256 or 64 color tiles
+	const int gfx = ((mode & 0x0700) >> 8);
 
 	drawgfx_line(bitmap, cliprect, gfx, realcode, color, flipx, flipy, sx, sy, shadow, realline, tileline);
 
 }
 
-inline void ssv_state::get_tile(int x, int y, int size, int page, int& code, int& attr, int& flipx, int& flipy)
+inline void ssv_state::get_tile(int x, int y, int size, int page, int& code, int& attr, bool& flipx, bool& flipy)
 {
-	uint16_t* s3 = &m_spriteram[page * (size * ((0x1000 / 0x200) / 2)) +
+	const uint16_t *const s3 = &m_spriteram[page * (size * ((0x1000 / 0x200) / 2)) +
 		((x & ((size - 1) & ~0xf)) << 2) +
 		((y & ((0x200 - 1) & ~0xf)) >> 3)];
 
 	code = s3[0];  // code high bits
 	attr = s3[1];  // code low  bits + color
 
-	/* Code's high bits are scrambled */
+	// Code's high bits are scrambled
 	code += m_tile_code[(attr & 0x3c00) >> 10];
-	flipy = (attr & 0x4000);
-	flipx = (attr & 0x8000);
+	flipy = BIT(attr, 14);
+	flipx = BIT(attr, 15);
 
-	if ((m_scroll[0x74 / 2] & 0x1000) && ((m_scroll[0x74 / 2] & 0x2000) == 0))
-	{
-		if (flipx == 0) flipx = 1; else flipx = 0;
-	}
-	if ((m_scroll[0x74 / 2] & 0x4000) && ((m_scroll[0x74 / 2] & 0x2000) == 0))
-	{
-		if (flipy == 0) flipy = 1; else flipy = 0;
-	}
+	if (BIT(m_scroll[0x74 / 2], 12) && BIT(~m_scroll[0x74 / 2], 13))
+		flipx = !flipx;
+
+	if (BIT(m_scroll[0x74 / 2], 14) && BIT(~m_scroll[0x74 / 2], 13))
+		flipy = !flipy;
+
 }
 
 void ssv_state::draw_row_64pixhigh(bitmap_ind16 &bitmap, const rectangle &cliprect, int in_sy, int scrollreg)
 {
 	scrollreg &= 0x7;      // scroll register index
 
-	/* in_sy will always be 0x00, 0x40, 0x80, 0xc0 in 'draw layer' */
+	// in_sy will always be 0x00, 0x40, 0x80, 0xc0 in 'draw layer'
 	in_sy = (in_sy & 0x1ff) - (in_sy & 0x200);
 
-	/* Set up a clipping region for the tilemap slice .. */
+	// Set up a clipping region for the tilemap slice ..
 	rectangle outclip;
 	outclip.set(0, 0x20/*width in tiles*/ * 0x10, in_sy, in_sy + 0x8/*height in tiles, always 64 pixels*/ * 0x8);
 
-	/* .. and clip it against the visible screen */
+	// .. and clip it against the visible screen
 
 	if (outclip.min_x > cliprect.max_x)    return;
 	if (outclip.min_y > cliprect.max_y)    return;
@@ -675,71 +671,72 @@ void ssv_state::draw_row_64pixhigh(bitmap_ind16 &bitmap, const rectangle &clipre
 		rectangle clip;
 		clip.set(outclip.min_x, outclip.max_x, line, line);
 
-		/* Get the scroll data */
+		// Get the scroll data
 		int tilemap_scrollx = m_scroll[scrollreg * 4 + 0];    // x scroll
 		int tilemap_scrolly = m_scroll[scrollreg * 4 + 1];    // y scroll
-		int unknown = m_scroll[scrollreg * 4 + 2];    // ???
-		int mode = m_scroll[scrollreg * 4 + 3];    // layer disabled, shadow, depth etc.
+		const int unknown = m_scroll[scrollreg * 4 + 2];    // ???
+		const int mode = m_scroll[scrollreg * 4 + 3];    // layer disabled, shadow, depth etc.
 
-		/* Background layer disabled */
+		// Background layer disabled
 		if ((mode & 0xe000) == 0)
 			return;
 
-		/* Decide the actual size of the tilemap */
-		int size = 1 << (8 + ((mode & 0xe000) >> 13));
-		int page = (tilemap_scrollx & 0x7fff) / size;
+		// Decide the actual size of the tilemap
+		const int size = 1 << (8 + ((mode & 0xe000) >> 13));
+		const int page = (tilemap_scrollx & 0x7fff) / size;
 
-		/* Given a fixed scroll value, the portion of tilemap displayed changes with the sprite position */
+		// Given a fixed scroll value, the portion of tilemap displayed changes with the sprite position
 		tilemap_scrolly += in_sy;
 
-		/* Tweak the scroll values */
+		// Tweak the scroll values
 		tilemap_scrolly += ((m_scroll[0x70 / 2] & 0x1ff) - (m_scroll[0x70 / 2] & 0x200) + m_scroll[0x6a / 2] + 2);
 
 		// Kludge for eaglshot
 		if ((unknown & 0x05ff) == 0x0440) tilemap_scrollx += -0x10;
 		if ((unknown & 0x05ff) == 0x0401) tilemap_scrollx += -0x20;
 
-		int realy = tilemap_scrolly + (line - in_sy);
+		const int realy = tilemap_scrolly + (line - in_sy);
 
-		if ((mode & 0x1000))
+		if (BIT(mode, 12))
 		{
-			uint32_t scrolltable_base = ((mode & 0x00ff) * 0x400 ) /2;
+			const uint32_t scrolltable_base = ((mode & 0x00ff) * 0x400) / 2;
 			//logerror("line %d realy %04x: scrolltable base is %08x\n", line,realy&0x1ff, scrolltable_base*2);
-			tilemap_scrollx += m_spriteram[(scrolltable_base+(realy&0x1ff)) & 0x1ffff];
+			tilemap_scrollx += m_spriteram[(scrolltable_base + (realy & 0x1ff)) & 0x1ffff];
 		}
 
-		/* Draw the rows */
-		int sx1 = 0 - (tilemap_scrollx & 0xf);
+		// Draw the rows
+		const int sx1 = 0 - (tilemap_scrollx & 0xf);
 		int x = tilemap_scrollx;
 		for (int sx = sx1; sx <= clip.max_x; sx += 0x10)
 		{
-			int code, attr, flipx, flipy;
+			int code, attr;
+			bool flipx, flipy;
 			get_tile(x, realy, size, page, code, attr, flipx, flipy);
 			draw_16x16_tile_line(bitmap, clip, flipx, flipy, mode, code, attr, sx, realy, line,realy & 0xf);
 			x += 0x10;
-		} /* sx */
-	} /* line */
+		} // sx
+	} // line
 }
 
-/* Draw the "background layer" using multiple tilemap sprites */
+// Draw the "background layer" using multiple tilemap sprites
 
-void ssv_state::draw_layer(bitmap_ind16 &bitmap, const rectangle &cliprect, int  nr)
+void ssv_state::draw_layer(bitmap_ind16 &bitmap, const rectangle &cliprect, int nr)
 {
-	for ( int sy = 0; sy <= m_screen->visible_area().max_y; sy += 0x40 )
+	for (int sy = 0; sy <= m_screen->visible_area().max_y; sy += 0x40)
 		draw_row_64pixhigh(bitmap, cliprect, sy, nr);
 }
 
-void ssv_state::draw_sprites_tiles(bitmap_ind16 &bitmap, const rectangle &cliprect, int code, int flipx, int flipy, int gfx, int shadow, int color, int sx, int sy, int xnum, int ynum)
+void ssv_state::draw_sprites_tiles(bitmap_ind16 &bitmap, const rectangle &cliprect, int code, bool flipx, bool flipy, int gfx, int shadow, int color, int sx, int sy, int xnum, int ynum)
 {
 	int xstart, xend, xinc;
 	int ystart, yend, yinc;
 
-	/* Draw the tiles */
+	// Draw the tiles
 	if (flipx) { xstart = xnum - 1;  xend = -1;    xinc = -1; }
-	else { xstart = 0;       xend = xnum;  xinc = +1; }
+	else       { xstart = 0;         xend = xnum;  xinc = +1; }
 
 	if (flipy) { ystart = ynum - 1;  yend = -1;    yinc = -1; }
-	else { ystart = 0;       yend = ynum;  yinc = +1; }
+	else       { ystart = 0;         yend = ynum;  yinc = +1; }
 
 	for (int x = xstart; x != xend; x += xinc)
 	{
@@ -756,60 +753,58 @@ void ssv_state::draw_sprites_tiles(bitmap_ind16 &bitmap, const rectangle &clipre
 }
 
 
-/* Draw sprites in the sprites list */
+// Draw sprites in the sprites list
 
 void ssv_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	/* Sprites list */
-	uint16_t *spritelist_global = m_spriteram;
-	uint16_t *spritelist_global_end = m_spriteram + 0x02000 / 2;
+	// Sprites list
+	const uint16_t *spritelist_global = m_spriteram;
+	const uint16_t *spritelist_global_end = m_spriteram + 0x02000 / 2;
 
 	for (; spritelist_global < spritelist_global_end; spritelist_global += 4)
 	{
-		int sprite = spritelist_global[1];
+		const int sprite = spritelist_global[1];
 
-		/* Last sprite */
-		if (sprite & 0x8000) break;
+		// Last sprite
+		if (BIT(sprite, 15)) break;
 
-		/* Single-sprite address */
-		uint16_t* spritelist_local = &m_spriteram[(sprite & 0x7fff) * 4];
+		// Single-sprite address
+		const uint16_t *spritelist_local = &m_spriteram[(sprite & 0x7fff) * 4];
 		int tilemaps_offsy = ((spritelist_local[3] & 0x1ff) - (spritelist_local[3] & 0x200));
 
-		int mode = spritelist_global[0];
+		const int mode = spritelist_global[0];
 
-		/* Number of single-sprites int local list (1-32) */
-		int local_num = (mode & 0x001f);
+		// Number of single-sprites int local list (1-32)
+		const int local_num = (mode & 0x001f);
 
 		for (int count = 0; count <= local_num; count++, spritelist_local += 4)
 		{
-			uint16_t *spritelist_local_end = m_spriteram + 0x40000 / 2;
+			const uint16_t *spritelist_local_end = m_spriteram + 0x40000 / 2;
 
 			if (spritelist_local >= spritelist_local_end) break;
 
 			int sx = spritelist_local[2];
 			int sy = spritelist_local[3];
 
-			/* do we use local sizes (set here) or global ones (set in previous list) */
-			int use_local = m_scroll[0x76 / 2] & 0x4000;
+			// do we use local sizes (set here) or global ones (set in previous list)
+			const int use_local = BIT(m_scroll[0x76 / 2], 14);
 
 			int xnum = use_local ? (sx & 0x0c00) : (mode & 0x0c00);
 			int ynum = use_local ? (sy & 0x0c00) : (mode & 0x0300) << 2;
-			int depth = use_local ? (sx & 0xf000) : (mode & 0xf000);
+			const int depth = use_local ? (sx & 0xf000) : (mode & 0xf000);
 
 			if (spritelist_local[0] <= 7 && spritelist_local[1] == 0 && xnum == 0 && ynum == 0x0c00)
 			{
 				// Tilemap Sprite
-				int scroll;
+				const int scroll = spritelist_local[0];    // scroll index
 
-				scroll = spritelist_local[0];    // scroll index
-
-				if (m_scroll[0x76 / 2] & 0x1000)
+				if (BIT(m_scroll[0x76 / 2], 12))
 					sy -= 0x20;                     // eaglshot
 				else
 				{
-					if (m_scroll[0x7a / 2] & 0x0800)
+					if (BIT(m_scroll[0x7a / 2], 11))
 					{
-						if (m_scroll[0x7a / 2] & 0x1000)    // drifto94, dynagear, keithlcy, mslider, stmblade, gdfs, ultrax, twineag2
+						if (BIT(m_scroll[0x7a / 2], 12))    // drifto94, dynagear, keithlcy, mslider, stmblade, gdfs, ultrax, twineag2
 							sy -= tilemaps_offsy;
 						else                        // srmp4
 							sy += tilemaps_offsy;
@@ -819,9 +814,7 @@ void ssv_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect)
 				if (local_num != 0)
 				{
 					if (spritelist_local[0] != 0) // index 0 is the 'always automatically drawn background layer' so don't draw it twice even if it's specified later?
-					{
 						draw_row_64pixhigh(bitmap, cliprect, sy, scroll);
-					}
 				}
 			}
 			else
@@ -837,58 +830,53 @@ void ssv_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect)
 				*/
 
 				int code = spritelist_local[0];  // code high bits
-				int attr = spritelist_local[1];  // code low  bits + color
+				const int attr = spritelist_local[1];  // code low  bits + color
 
-				/* Code's high bits are scrambled */
+				// Code's high bits are scrambled
 				code += m_tile_code[(attr & 0x3c00) >> 10];
-				int flipy = (attr & 0x4000);
-				int flipx = (attr & 0x8000);
+				bool flipy = BIT(attr, 14);
+				bool flipx = BIT(attr, 15);
 
-				if ((m_scroll[0x74 / 2] & 0x1000) && ((m_scroll[0x74 / 2] & 0x2000) == 0))
-				{
-					if (flipx == 0) flipx = 1; else flipx = 0;
-				}
-				if ((m_scroll[0x74 / 2] & 0x4000) && ((m_scroll[0x74 / 2] & 0x2000) == 0))
-				{
-					if (flipy == 0) flipy = 1; else flipy = 0;
-				}
+				if (BIT(m_scroll[0x74 / 2], 12) && BIT(~m_scroll[0x74 / 2], 13))
+					flipx = !flipx;
 
-				/* Select 256 or 64 color tiles */
-				int gfx = (depth & 0x7000) >>12;
-				int shadow = (depth & 0x8000);
+				if (BIT(m_scroll[0x74 / 2], 14) && BIT(~m_scroll[0x74 / 2], 13))
+					flipy = !flipy;
+
+				// Select 256 or 64 color tiles
+				const int gfx = (depth & 0x7000) >> 12;
+				const int shadow = BIT(depth, 15);
 
 				/* Every single sprite is offset by x & yoffs, and additionally
 				by one of the 8 x & y offsets in the 1c0040-1c005f area   */
 
-				/* Apply global offsets */
-				int scrollreg = ((mode & 0x00e0) >> 4);
+				// Apply global offsets
+				const int scrollreg = ((mode & 0x00e0) >> 4);
 
 				sx += spritelist_global[2] + m_scroll[scrollreg + (0x40 / 2)];
 				sy += spritelist_global[3] + m_scroll[scrollreg + (0x42 / 2)];
 
-				/* Sign extend the position */
+				// Sign extend the position
 				sx = (sx & 0x1ff) - (sx & 0x200);
 				sy = (sy & 0x1ff) - (sy & 0x200);
 
-				int sprites_offsx = ((m_scroll[0x74 / 2] & 0x7f) - (m_scroll[0x74 / 2] & 0x80));
+				const int sprites_offsx = ((m_scroll[0x74 / 2] & 0x7f) - (m_scroll[0x74 / 2] & 0x80));
 
-				int sprites_offsy = -((m_scroll[0x70 / 2] & 0x1ff) - (m_scroll[0x70 / 2] & 0x200) + m_scroll[0x6a / 2] + 1);
+				const int sprites_offsy = -((m_scroll[0x70 / 2] & 0x1ff) - (m_scroll[0x70 / 2] & 0x200) + m_scroll[0x6a / 2] + 1);
 
-				if (m_scroll[0x74 / 2] & 0x4000) // flipscreen y
+				if (BIT(m_scroll[0x74 / 2], 14)) // flipscreen y
 				{
 					sy = -sy;
-					if (m_scroll[0x74 / 2] & 0x8000)
+					if (BIT(m_scroll[0x74 / 2], 15))
 						sy += 0x00;         //
 					else
 						sy -= 0x10;         // vasara (hack)
 				}
 
-				if (m_scroll[0x74 / 2] & 0x1000) // flipscreen x
-				{
+				if (BIT(m_scroll[0x74 / 2], 12)) // flipscreen x
 					sx = -sx + 0x100;
-				}
 
-				/* Single-sprite tile size */
+				// Single-sprite tile size
 				xnum = 1 << (xnum >> 10);   // 1, 2, 4 or 8 tiles
 				ynum = 1 << (ynum >> 10);   // 1, 2, 4 tiles (8 means tilemap sprite?)
 
@@ -900,7 +888,7 @@ void ssv_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect)
 					sx = sprites_offsx + sx;
 					sy = sprites_offsy - sy;
 				}
-				else if (m_scroll[0x7a / 2] & 0x0800)
+				else if (BIT(m_scroll[0x7a / 2], 11))
 				{
 					// dynagear, drifto94, eaglshot, keithlcy, mslider, srmp4, stmblade, twineag2, ultrax
 					sx = sprites_offsx + sx - (xnum * 8);
@@ -914,19 +902,14 @@ void ssv_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect)
 				}
 
 
-				/* Sprite code masking */
+				// Sprite code masking
 				if (xnum == 2 && ynum == 4) // needed by hypreact
-				{
 					code &= ~7;
-				}
 
 				draw_sprites_tiles(bitmap, cliprect, code, flipx, flipy, gfx, shadow, attr, sx, sy, xnum, ynum);
-
-			}       /* sprite type */
-
-		}   /* single-sprites */
-
-	}   /* sprites list */
+			}       // sprite type
+		}   // single-sprites
+	}   // sprites list
 }
 
 
@@ -957,7 +940,7 @@ uint32_t gdfs_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, 
 	return 0;
 }
 
-void ssv_state::enable_video(int enable)
+void ssv_state::enable_video(bool enable)
 {
 	m_enable_video = enable;
 }
@@ -965,7 +948,6 @@ void ssv_state::enable_video(int enable)
 uint32_t ssv_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	rectangle clip;
-
 
 	// Shadow
 	if (m_scroll[0x76/2] & 0x0080)
@@ -980,7 +962,7 @@ uint32_t ssv_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, c
 	}
 	m_shadow_pen_mask = (1 << m_shadow_pen_shift) - 1;
 
-	/* The background color is the first one in the palette */
+	// The background color is the first one in the palette
 	bitmap.fill(0, cliprect);
 
 	// used by twineag2 and ultrax
@@ -999,7 +981,6 @@ uint32_t ssv_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, c
 	draw_layer(bitmap, clip, 0); // "background layer"
 
 	draw_sprites(bitmap, clip);  // sprites list
-
 
 	return 0;
 }


### PR DESCRIPTION
 - Split driver state class for with DSP
- Use C++ style comments for single line comments
- Suppress side effects for debugger read
- Reduce preprocessor defines
- Reduce duplicate
- Fix spacing
- Reduce unnecessary lines
- Constantize variables
- Fix typename values
- Fix document
- Reduce usage of literal tags
- Reduce runtime tag lookup
- Use generic gfx decode layout for gdfs tilemap
- Fix naming for ROM region and tags