### PR TITLE
galaxian/galaxian.cpp: hook up Galaxian discrete sound for 'bongoa', rename set to indicate the different hardware

### DIFF
--- a/src/mame/galaxian/galaxian.cpp
+++ b/src/mame/galaxian/galaxian.cpp
@@ -1929,7 +1929,7 @@ void galaxian_state::bongo_map(address_map &map)
 	map(0xb800, 0xb800).mirror(0x7ff).nopw(); // written once at start
 }
 
-void galaxian_state::bongoa_map(address_map &map)
+void galaxian_state::bongog_map(address_map &map)
 {
 	bongo_map(map);
 	mooncrst_map_discrete(map);
@@ -7809,12 +7809,12 @@ void galaxian_state::bongo(machine_config &config)
 	m_ay8910[0]->add_route(ALL_OUTPUTS, "speaker", 0.5);
 }
 
-void galaxian_state::bongoa(machine_config &config)
+void galaxian_state::bongog(machine_config &config)
 {
 	galaxian_base(config);
 
 	// alternate memory map
-	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::bongoa_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::bongog_map);
 
 	// sound hardware
 	BONGO_SOUND(config, "cust", 0);
@@ -12606,7 +12606,7 @@ ROM_START( bongo )
 	ROM_LOAD( "b-clr.bin",  0x0000, 0x0020, CRC(c4761ada) SHA1(067d12b2d3635ffa6337ed234ba42717447bea00) )
 ROM_END
 
-ROM_START( bongoa )
+ROM_START( bongog )
 	ROM_REGION( 0x6000, "maincpu", 0 )
 	ROM_LOAD( "1-2532.bin", 0x0000, 0x1000, CRC(ebcc50bb) SHA1(6d9deb561c3eb3e21abeda3180a29d21a2848e07) )
 	ROM_LOAD( "2-2532.bin", 0x1000, 0x1000, CRC(a19da662) SHA1(a2674392d489c5e5eeb9abc51572a37cc6045220) )
@@ -16619,8 +16619,8 @@ GAME( 1980, galactica2,  moonal2,  mooncrst,   moonal2,    galaxian_state, init_
 
 // Larger romspace, interrupt enable moved
 GAME( 198?, thepitm,     thepit,   thepitm,    thepitm,    galaxian_state, init_mooncrsu,   ROT90,  "bootleg (KZH)", "The Pit (bootleg on Moon Quasar hardware)", MACHINE_SUPPORTS_SAVE ) // on an original MQ-2FJ PCB, even if the memory map appears closer to Moon Cresta
-GAME( 1983, bongo,       0,        bongo,      bongo,      galaxian_state, init_kong,       ROT90,  "Jetsoft",       "Bongo (set 1)",                             MACHINE_SUPPORTS_SAVE )
-GAME( 1983, bongoa,      bongo,    bongoa,     bongo,      galaxian_state, init_kong,       ROT90,  "Jetsoft",       "Bongo (set 2)",                             MACHINE_SUPPORTS_SAVE ) // on an original Namco PCB
+GAME( 1983, bongo,       0,        bongo,      bongo,      galaxian_state, init_kong,       ROT90,  "Jetsoft",       "Bongo",                                     MACHINE_SUPPORTS_SAVE )
+GAME( 1983, bongog,      bongo,    bongog,     bongo,      galaxian_state, init_kong,       ROT90,  "bootleg?",      "Bongo (Galaxian hardware)",                 MACHINE_SUPPORTS_SAVE ) // on an original Namco PCB
 
 
 // Crazy Kong & Bagman bootlegs on galaxian/mooncrst hardware

--- a/src/mame/galaxian/galaxian.cpp
+++ b/src/mame/galaxian/galaxian.cpp
@@ -1932,6 +1932,7 @@ void galaxian_state::bongo_map(address_map &map)
 void galaxian_state::bongoa_map(address_map &map)
 {
 	bongo_map(map);
+	mooncrst_map_discrete(map);
 	map(0xb000, 0xb000).mirror(0x07ff).portr("DSW");
 }
 
@@ -7810,11 +7811,13 @@ void galaxian_state::bongo(machine_config &config)
 
 void galaxian_state::bongoa(machine_config &config)
 {
-	bongo(config);
+	galaxian_base(config);
 
-	// dip switches are read via the memory map instead of the AY8910
+	// alternate memory map
 	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::bongoa_map);
-	m_ay8910[0]->port_a_read_callback().set_constant(0xff);
+
+	// sound hardware
+	BONGO_SOUND(config, "cust", 0);
 }
 
 void bmxstunts_state::bmxstunts(machine_config &config)

--- a/src/mame/galaxian/galaxian.h
+++ b/src/mame/galaxian/galaxian.h
@@ -312,7 +312,7 @@ public:
 	void thepitm(machine_config &config);
 	void kong(machine_config &config);
 	void bongo(machine_config &config);
-	void bongoa(machine_config &config);
+	void bongog(machine_config &config);
 	void scorpnmc(machine_config &config);
 	void ckongg(machine_config &config);
 	void ckongmc(machine_config &config);
@@ -342,7 +342,7 @@ protected:
 	void astroamb_map(address_map &map);
 	void bigkonggx_map(address_map &map);
 	void bongo_map(address_map &map);
-	void bongoa_map(address_map &map);
+	void bongog_map(address_map &map);
 	void bongo_io_map(address_map &map);
 	void checkmaj_sound_map(address_map &map);
 	void checkman_sound_map(address_map &map);

--- a/src/mame/galaxian/galaxian_a.cpp
+++ b/src/mame/galaxian/galaxian_a.cpp
@@ -476,6 +476,14 @@ static DISCRETE_SOUND_START(mooncrst_discrete)
 DISCRETE_SOUND_END
 
 
+static DISCRETE_SOUND_START(bongo_discrete)
+	DISCRETE_IMPORT(mooncrst_discrete)
+
+	DISCRETE_REPLACE
+	DISCRETE_NOTE(NODE_132, 1, (SOUND_CLOCK/8).dvalue(), GAL_INP_PITCH, 255, 15,  DISC_CLK_IS_FREQ)
+DISCRETE_SOUND_END
+
+
 static DISCRETE_SOUND_START(sbhoei_discrete)
 
 	/************************************************/
@@ -604,6 +612,7 @@ DISCRETE_SOUND_END
 
 DEFINE_DEVICE_TYPE(GALAXIAN_SOUND, galaxian_sound_device, "galaxian_sound", "Galaxian Custom Sound")
 DEFINE_DEVICE_TYPE(MOONCRST_SOUND, mooncrst_sound_device, "mooncrst_sound", "Moon Cresta Custom Sound")
+DEFINE_DEVICE_TYPE(BONGO_SOUND, bongo_sound_device, "bongo_sound", "Bongo Custom Sound")
 DEFINE_DEVICE_TYPE(SBHOEI_SOUND, sbhoei_sound_device, "sbhoei_sound", "Space Battle Custom Sound")
 
 galaxian_sound_device::galaxian_sound_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
@@ -619,6 +628,11 @@ galaxian_sound_device::galaxian_sound_device(const machine_config &mconfig, devi
 
 mooncrst_sound_device::mooncrst_sound_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: galaxian_sound_device(mconfig, MOONCRST_SOUND, tag, owner, clock)
+{
+}
+
+bongo_sound_device::bongo_sound_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: galaxian_sound_device(mconfig, BONGO_SOUND, tag, owner, clock)
 {
 }
 
@@ -658,6 +672,12 @@ void mooncrst_sound_device::device_add_mconfig(machine_config &config)
 {
 	galaxian_sound_device::device_add_mconfig(config);
 	m_discrete->set_intf(mooncrst_discrete);
+}
+
+void bongo_sound_device::device_add_mconfig(machine_config &config)
+{
+	galaxian_sound_device::device_add_mconfig(config);
+	m_discrete->set_intf(bongo_discrete);
 }
 
 void sbhoei_sound_device::device_add_mconfig(machine_config &config)

--- a/src/mame/galaxian/galaxian_a.h
+++ b/src/mame/galaxian/galaxian_a.h
@@ -44,6 +44,16 @@ protected:
 	virtual void device_add_mconfig(machine_config &config) override;
 };
 
+class bongo_sound_device : public galaxian_sound_device
+{
+public:
+	bongo_sound_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	// device-level overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+};
+
 class sbhoei_sound_device : public galaxian_sound_device
 {
 public:
@@ -62,5 +72,6 @@ protected:
 DECLARE_DEVICE_TYPE(GALAXIAN_SOUND, galaxian_sound_device)
 DECLARE_DEVICE_TYPE(MOONCRST_SOUND, mooncrst_sound_device)
 DECLARE_DEVICE_TYPE(SBHOEI_SOUND, sbhoei_sound_device)
+DECLARE_DEVICE_TYPE(BONGO_SOUND, bongo_sound_device)
 
 #endif // MAME_GALAXIAN_GALAXIAN_A_H

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -18494,7 +18494,7 @@ blkhole                         // TDS (Tokyo Denshi Sekkei) & MINTS
 bmxstunts                       // (c) 1985 Jetsoft
 bomber                          //
 bongo                           // (c) 1983 Jetsoft
-bongoa                          // (c) 1983 Jetsoft
+bongog                          // (c) 1983 Jetsoft
 calipso                         // (c) 1982 Tago
 catacomb                        // 1982 MTM Games
 checkman                        // (c) 1982 Zilec-Zenitone


### PR DESCRIPTION
This is a followup to https://github.com/mamedev/mame/pull/12314, using [this video](https://www.youtube.com/watch?v=ANLFKoMLPRI) as a reference. (I haven't attempted to figure out which color PROM the board in that video is using, though)

I was inclined to mark this set as a bootleg since the ROM differences are very clearly hacks on top of the parent set, but I'll wait for a second opinion on that.