### PR TITLE
seta/seta2.cpp: Cleanups

### DIFF
--- a/src/mame/seta/seta2.cpp
+++ b/src/mame/seta/seta2.cpp
@@ -246,34 +246,24 @@ void mj4simai_state::machine_start()
 
 uint16_t mj4simai_state::mj4simai_p1_r()
 {
-	switch (m_keyboard_row)
-	{
-		case 0x01: return m_p1_key[0]->read();
-		case 0x02: return m_p1_key[1]->read();
-		case 0x04: return m_p1_key[2]->read();
-		case 0x08: return m_p1_key[3]->read();
-		case 0x10: return m_p1_key[4]->read();
-		default:
-			if (!machine().side_effects_disabled())
-				LOGIO("p1_r with keyboard_row = %02x\n", m_keyboard_row);
-			return 0xffff;
-	}
+	uint16_t result = 0xffff;
+	if (BIT(m_keyboard_row, 0)) result &= m_p1_key[0]->read();
+	if (BIT(m_keyboard_row, 1)) result &= m_p1_key[1]->read();
+	if (BIT(m_keyboard_row, 2)) result &= m_p1_key[2]->read();
+	if (BIT(m_keyboard_row, 3)) result &= m_p1_key[3]->read();
+	if (BIT(m_keyboard_row, 4)) result &= m_p1_key[4]->read();
+	return result;
 }
 
 uint16_t mj4simai_state::mj4simai_p2_r()
 {
-	switch (m_keyboard_row)
-	{
-		case 0x01: return m_p2_key[0]->read();
-		case 0x02: return m_p2_key[1]->read();
-		case 0x04: return m_p2_key[2]->read();
-		case 0x08: return m_p2_key[3]->read();
-		case 0x10: return m_p2_key[4]->read();
-		default:
-			if (!machine().side_effects_disabled())
-				LOGIO("p2_r with keyboard_row = %02x\n", m_keyboard_row);
-			return 0xffff;
-	}
+	uint16_t result = 0xffff;
+	if (BIT(m_keyboard_row, 0)) result &= m_p2_key[0]->read();
+	if (BIT(m_keyboard_row, 1)) result &= m_p2_key[1]->read();
+	if (BIT(m_keyboard_row, 2)) result &= m_p2_key[2]->read();
+	if (BIT(m_keyboard_row, 3)) result &= m_p2_key[3]->read();
+	if (BIT(m_keyboard_row, 4)) result &= m_p2_key[4]->read();
+	return result;
 }
 
 void mj4simai_state::mj4simai_map(address_map &map)

--- a/src/mame/seta/seta2.cpp
+++ b/src/mame/seta/seta2.cpp
@@ -102,6 +102,17 @@ funcube series:
 #include "diserial.h"
 #include "speaker.h"
 
+#define LOG_IO      (1U << 1)
+#define LOG_DEBUG   (1U << 2)
+
+#define LOG_ALL     (LOG_IO)
+
+#define VERBOSE (0)
+#include "logmacro.h"
+
+#define LOGIO(...)     LOGMASKED(LOG_IO, __VA_ARGS__)
+#define LOGDEBUG(...)  LOGMASKED(LOG_DEBUG, __VA_ARGS__)
+
 
 /***************************************************************************
 
@@ -141,14 +152,14 @@ void seta2_state::sound_bank_w(offs_t offset, uint8_t data)
 
 void seta2_state::x1_map(address_map &map)
 {
-	map(0x00000, 0x1ffff).bankr("x1_bank_1");
-	map(0x20000, 0x3ffff).bankr("x1_bank_2");
-	map(0x40000, 0x5ffff).bankr("x1_bank_3");
-	map(0x60000, 0x7ffff).bankr("x1_bank_4");
-	map(0x80000, 0x9ffff).bankr("x1_bank_5");
-	map(0xa0000, 0xbffff).bankr("x1_bank_6");
-	map(0xc0000, 0xdffff).bankr("x1_bank_7");
-	map(0xe0000, 0xfffff).bankr("x1_bank_8");
+	map(0x00000, 0x1ffff).bankr(m_x1_bank[0]);
+	map(0x20000, 0x3ffff).bankr(m_x1_bank[1]);
+	map(0x40000, 0x5ffff).bankr(m_x1_bank[2]);
+	map(0x60000, 0x7ffff).bankr(m_x1_bank[3]);
+	map(0x80000, 0x9ffff).bankr(m_x1_bank[4]);
+	map(0xa0000, 0xbffff).bankr(m_x1_bank[5]);
+	map(0xc0000, 0xdffff).bankr(m_x1_bank[6]);
+	map(0xe0000, 0xfffff).bankr(m_x1_bank[7]);
 }
 
 
@@ -159,9 +170,9 @@ void seta2_state::x1_map(address_map &map)
 void seta2_state::grdians_lockout_w(uint8_t data)
 {
 	// initially 0, then either $25 (coin 1) or $2a (coin 2)
-	machine().bookkeeping().coin_counter_w(0,data & 0x01);   // or 0x04
-	machine().bookkeeping().coin_counter_w(1,data & 0x02);   // or 0x08
-	//popmessage("%04X", data & 0xff);
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 0));   // or 0x04
+	machine().bookkeeping().coin_counter_w(1, BIT(data, 1));   // or 0x08
+	//LOGIO("%04X\n", data & 0xff);
 }
 
 void seta2_state::grdians_map(address_map &map)
@@ -190,14 +201,14 @@ void seta2_state::grdians_map(address_map &map)
 
 uint16_t seta2_state::gundamex_eeprom_r()
 {
-	return ((m_eeprom->do_read() & 1)) << 3;
+	return (m_eeprom->do_read() & 1) << 3;
 }
 
 void seta2_state::gundamex_eeprom_w(uint16_t data)
 {
-	m_eeprom->clk_write((data & 0x2) ? ASSERT_LINE : CLEAR_LINE);
-	m_eeprom->di_write(data & 0x1);
-	m_eeprom->cs_write((data & 0x4) ? ASSERT_LINE : CLEAR_LINE);
+	m_eeprom->clk_write(BIT(data, 1) ? ASSERT_LINE : CLEAR_LINE);
+	m_eeprom->di_write(BIT(data, 0));
+	m_eeprom->cs_write(BIT(data, 2) ? ASSERT_LINE : CLEAR_LINE);
 }
 
 void seta2_state::gundamex_map(address_map &map)
@@ -233,49 +244,55 @@ void mj4simai_state::machine_start()
 	save_item(NAME(m_keyboard_row));
 }
 
-uint16_t seta2_state::mj4simai_p1_r()
+uint16_t mj4simai_state::mj4simai_p1_r()
 {
 	switch (m_keyboard_row)
 	{
-		case 0x01: return ioport("P1_KEY0")->read();
-		case 0x02: return ioport("P1_KEY1")->read();
-		case 0x04: return ioport("P1_KEY2")->read();
-		case 0x08: return ioport("P1_KEY3")->read();
-		case 0x10: return ioport("P1_KEY4")->read();
-		default:   logerror("p1_r with keyboard_row = %02x\n", m_keyboard_row); return 0xffff;
+		case 0x01: return m_p1_key[0]->read();
+		case 0x02: return m_p1_key[1]->read();
+		case 0x04: return m_p1_key[2]->read();
+		case 0x08: return m_p1_key[3]->read();
+		case 0x10: return m_p1_key[4]->read();
+		default:
+			if (!machine().side_effects_disabled())
+				LOGIO("p1_r with keyboard_row = %02x\n", m_keyboard_row);
+			return 0xffff;
 	}
 }
 
-uint16_t seta2_state::mj4simai_p2_r()
+uint16_t mj4simai_state::mj4simai_p2_r()
 {
 	switch (m_keyboard_row)
 	{
-		case 0x01: return ioport("P2_KEY0")->read();
-		case 0x02: return ioport("P2_KEY1")->read();
-		case 0x04: return ioport("P2_KEY2")->read();
-		case 0x08: return ioport("P2_KEY3")->read();
-		case 0x10: return ioport("P2_KEY4")->read();
-		default:   logerror("p2_r with keyboard_row = %02x\n", m_keyboard_row); return 0xffff;
+		case 0x01: return m_p2_key[0]->read();
+		case 0x02: return m_p2_key[1]->read();
+		case 0x04: return m_p2_key[2]->read();
+		case 0x08: return m_p2_key[3]->read();
+		case 0x10: return m_p2_key[4]->read();
+		default:
+			if (!machine().side_effects_disabled())
+				LOGIO("p2_r with keyboard_row = %02x\n", m_keyboard_row);
+			return 0xffff;
 	}
 }
 
-void seta2_state::mj4simai_map(address_map &map)
+void mj4simai_state::mj4simai_map(address_map &map)
 {
 	map(0x000000, 0x1fffff).rom();                             // ROM
 	map(0x200000, 0x20ffff).ram();                             // RAM
-	map(0x600000, 0x600001).r(FUNC(seta2_state::mj4simai_p1_r));             // P1
-	map(0x600002, 0x600003).r(FUNC(seta2_state::mj4simai_p2_r));             // P2
+	map(0x600000, 0x600001).r(FUNC(mj4simai_state::mj4simai_p1_r));             // P1
+	map(0x600002, 0x600003).r(FUNC(mj4simai_state::mj4simai_p2_r));             // P2
 	map(0x600005, 0x600005).lw8(NAME([this] (u8 data){ m_keyboard_row = data; }));      // select keyboard row to read
 	map(0x600006, 0x600007).r("watchdog", FUNC(watchdog_timer_device::reset16_r));
 	map(0x600100, 0x600101).portr("SYSTEM");             //
 	map(0x600200, 0x600201).nopw();                        // Leds? Coins?
 	map(0x600300, 0x600301).portr("DSW1");               // DSW 1
 	map(0x600302, 0x600303).portr("DSW2");               // DSW 2
-	map(0x600300, 0x60030f).w(FUNC(seta2_state::sound_bank_w)).umask16(0x00ff);       // Samples Banks
+	map(0x600300, 0x60030f).w(FUNC(mj4simai_state::sound_bank_w)).umask16(0x00ff);       // Samples Banks
 	map(0xb00000, 0xb03fff).rw("x1snd", FUNC(x1_010_device::word_r), FUNC(x1_010_device::word_w));   // Sound
 	map(0xc00000, 0xc3ffff).ram().share("spriteram");   // Sprites
 	map(0xc40000, 0xc4ffff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");    // Palette
-	map(0xc60000, 0xc6003f).ram().w(FUNC(seta2_state::vregs_w)).share("vregs");  // Video Registers
+	map(0xc60000, 0xc6003f).ram().w(FUNC(mj4simai_state::vregs_w)).share("vregs");  // Video Registers
 }
 
 
@@ -333,19 +350,19 @@ void seta2_state::myangel2_map(address_map &map)
     The offset to use is stored in RAM at address 0x20BA16 */
 uint16_t seta2_state::pzlbowl_protection_r(address_space &space)
 {
-	uint32_t address = (space.read_word(0x20ba16) << 16) | space.read_word(0x20ba18);
+	const uint32_t address = (space.read_word(0x20ba16) << 16) | space.read_word(0x20ba18);
 	return memregion("maincpu")->base()[address - 2];
 }
 
 uint8_t seta2_state::pzlbowl_coins_r()
 {
-	return ioport("SYSTEM")->read() | (machine().rand() & 0x80 );
+	return m_in_system->read() | (machine().rand() & 0x80);
 }
 
 void seta2_state::pzlbowl_coin_counter_w(uint8_t data)
 {
-	machine().bookkeeping().coin_counter_w(0,data & 0x10);
-	machine().bookkeeping().coin_counter_w(1,data & 0x20);
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 4));
+	machine().bookkeeping().coin_counter_w(1, BIT(data, 5));
 }
 
 void seta2_state::pzlbowl_map(address_map &map)
@@ -430,18 +447,18 @@ void seta2_state::reelquak_leds_w(offs_t offset, uint16_t data, uint16_t mem_mas
 		m_dispenser->motor_w(BIT(data, 8)); // ticket dispenser
 	}
 
-	//popmessage("LED %04X", data);
+	//LOGIO("LED %04X\n", data);
 }
 
 void seta2_state::reelquak_coin_w(uint8_t data)
 {
-	machine().bookkeeping().coin_counter_w(0, data & 0x01);  // coin in
-	machine().bookkeeping().coin_counter_w(1, data & 0x02);  // coin in
-	machine().bookkeeping().coin_counter_w(2, data & 0x04);  // pay out
-	machine().bookkeeping().coin_counter_w(3, data & 0x08);  // key in
-	// data & 0x10); // Sound IRQ Ack.? 1->0
-	// data & 0x20); // Vblank IRQ.? 1
-	//popmessage("COIN %04X", data & 0xff);
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 0));  // coin in
+	machine().bookkeeping().coin_counter_w(1, BIT(data, 1));  // coin in
+	machine().bookkeeping().coin_counter_w(2, BIT(data, 2));  // pay out
+	machine().bookkeeping().coin_counter_w(3, BIT(data, 3));  // key in
+	// BIT(data, 4)); // Sound IRQ Ack.? 1->0
+	// BIT(data, 5)); // Vblank IRQ.? 1
+	//LOGIO("COIN %04X\n", data & 0xff);
 }
 
 void seta2_state::reelquak_map(address_map &map)
@@ -484,13 +501,13 @@ void seta2_state::namcostr_map(address_map &map)
 
 void seta2_state::samshoot_coin_w(uint8_t data)
 {
-	machine().bookkeeping().coin_counter_w(0, data & 0x10);
-	machine().bookkeeping().coin_counter_w(1, data & 0x20);
+	machine().bookkeeping().coin_counter_w(0, BIT( data, 4));
+	machine().bookkeeping().coin_counter_w(1, BIT( data, 5));
 
 	// Are these connected? They are set in I/O test
-	machine().bookkeeping().coin_lockout_w(0,~data & 0x40);
-	machine().bookkeeping().coin_lockout_w(1,~data & 0x80);
-	//popmessage("%04x",data);
+	machine().bookkeeping().coin_lockout_w(0, BIT(~data, 6));
+	machine().bookkeeping().coin_lockout_w(1, BIT(~data, 7));
+	//LOGIO("%04x\n",data);
 }
 
 void seta2_state::samshoot_map(address_map &map)
@@ -529,7 +546,7 @@ void seta2_state::samshoot_map(address_map &map)
 
 void staraudi_state::staraudi_debug_outputs()
 {
-	//popmessage("L1: %04X L2: %04X CAM: %04X", m_lamps1, m_lamps2, m_cam);
+	//LOGDEBUG("L1: %04X L2: %04X CAM: %04X\n", m_lamps1, m_lamps2, m_cam);
 }
 
 void staraudi_state::lamps1_w(offs_t offset, uint8_t data, uint8_t mem_mask)
@@ -538,14 +555,14 @@ void staraudi_state::lamps1_w(offs_t offset, uint8_t data, uint8_t mem_mask)
 	m_leds[0] = BIT(data, 0); // Lamp 1 |
 	m_leds[1] = BIT(data, 1); // Lamp 2 |- Camera Lamps
 	m_leds[2] = BIT(data, 2); // Lamp 3 |
-	// data & 0x08 );  // Degauss
+	// BIT(data, 3) );  // Degauss
 	staraudi_debug_outputs();
 }
 
 void staraudi_state::lamps2_w(offs_t offset, uint8_t data, uint8_t mem_mask)
 {
 	COMBINE_DATA(&m_lamps2);
-	// data & 0x20 ); // ? Always On
+	// BIT(data, 5) ); // ? Always On
 	m_leds[3] = BIT(data, 6); // 2P Switch Lamp
 	m_leds[4] = BIT(data, 7); // 1P Switch Lamp
 	staraudi_debug_outputs();
@@ -554,10 +571,10 @@ void staraudi_state::lamps2_w(offs_t offset, uint8_t data, uint8_t mem_mask)
 void staraudi_state::camera_w(offs_t offset, uint8_t data, uint8_t mem_mask)
 {
 	COMBINE_DATA(&m_cam);
-	// data & 0x01 ); // ? Always On
-	// data & 0x02 ); // ? Print Test
-	// data & 0x08 ); // Camera On (Test Mode)
-	// data & 0x20 ); // ?
+	// BIT(data, 0) ); // ? Always On
+	// BIT(data, 1) ); // ? Print Test
+	// BIT(data, 3) ); // Camera On (Test Mode)
+	// BIT(data, 5) ); // ?
 	staraudi_debug_outputs();
 }
 
@@ -588,7 +605,7 @@ void staraudi_state::staraudi_map(address_map &map)
 
 //  map(0x500000, 0x53ffff).ram();                             // Camera RAM (r8g8)
 //  map(0x540000, 0x57ffff).ram();                             // Camera RAM (00b8)
-	map(0x500000, 0x57ffff).ram().share("rgbram");
+	map(0x500000, 0x57ffff).ram().share(m_rgbram);
 
 	map(0x600001, 0x600001).w(FUNC(staraudi_state::camera_w));        // Camera Outputs
 
@@ -623,7 +640,7 @@ void seta2_state::telpacfl_lamp1_w(uint8_t data)
 	for (int i = 0; i <= 7; i++)
 		m_lamps[i] = BIT(data, i);
 
-	//popmessage("LAMP1 %04X", data);
+	//LOGIO("LAMP1 %04X\n", data);
 }
 
 void seta2_state::telpacfl_lamp2_w(uint8_t data)
@@ -631,21 +648,21 @@ void seta2_state::telpacfl_lamp2_w(uint8_t data)
 	m_lamps[8] = BIT(data, 0); // on/off lamp (throughout)
 	m_lamps[9] = BIT(data, 1); // bet lamp
 	m_lamps[10] = BIT(data, 2); // payout lamp
-	m_dispenser->motor_w(data & 0x08); // coin out motor
-	machine().bookkeeping().coin_counter_w(0, data & 0x10); // coin out counter
-	// data & 0x20 ); // on credit increase
+	m_dispenser->motor_w(BIT(data, 3)); // coin out motor
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 4)); // coin out counter
+	// BIT(data, 5) ); // on credit increase
 
-	//popmessage("LAMP2 %04X", data);
+	//LOGIO("LAMP2 %04X\n", data);
 }
 
 void seta2_state::telpacfl_lockout_w(uint8_t data)
 {
-	machine().bookkeeping().coin_counter_w(1,  data & 0x02); // 100yen in
-	machine().bookkeeping().coin_lockout_w(0, ~data & 0x04); // coin blocker
-	machine().bookkeeping().coin_lockout_w(1, ~data & 0x08); // 100yen blocker
+	machine().bookkeeping().coin_counter_w(1, BIT( data, 1)); // 100yen in
+	machine().bookkeeping().coin_lockout_w(0, BIT(~data, 2)); // coin blocker
+	machine().bookkeeping().coin_lockout_w(1, BIT(~data, 3)); // 100yen blocker
 	// bits 0x30 ?
 
-	//popmessage("LOCK %04X", data);
+	//LOGIO("LOCK %04X\n", data);
 }
 
 void seta2_state::telpacfl_map(address_map &map)
@@ -757,7 +774,7 @@ void funcube_touchscreen_device::device_reset()
 
 TIMER_CALLBACK_MEMBER(funcube_touchscreen_device::read_buttons)
 {
-	uint8_t button_state = m_btn->read();
+	const uint8_t button_state = m_btn->read();
 	if (m_button_state != button_state)
 	{
 		m_button_state = button_state;
@@ -786,7 +803,7 @@ void funcube_touchscreen_device::tra_callback()
 
 uint32_t funcube_state::debug_r()
 {
-	uint32_t ret = ioport("DEBUG")->read();
+	uint32_t ret = m_in_debug->read();
 
 	// This bits let you move the crosshair in the inputs / touch panel test with a joystick
 	if (!(m_screen->frame_number() % 3))
@@ -850,33 +867,39 @@ void funcube_state::funcube_sub_map(address_map &map)
 
 // Simulate coin drop through two sensors
 
-#define FUNCUBE_SUB_CPU_CLOCK (XTAL(14'745'600))
+static constexpr XTAL FUNCUBE_SUB_CPU_CLOCK = XTAL(14'745'600);
 
 uint8_t funcube_state::coins_r()
 {
-	uint8_t ret = ioport("SWITCH")->read();
+	uint8_t ret = m_in_switch->read();
 	uint8_t coin_bit0 = 1; // active low
 	uint8_t coin_bit1 = 1;
 
-	uint8_t hopper_bit = (m_hopper_motor && !(m_screen->frame_number() % 20)) ? 1 : 0;
+	const uint8_t hopper_bit = (m_hopper_motor && !(m_screen->frame_number() % 20)) ? 1 : 0;
 
 	const uint64_t coin_total_cycles = FUNCUBE_SUB_CPU_CLOCK.value() / (1000/10);
 
 	if (m_coin_start_cycles)
 	{
-		uint64_t elapsed = m_sub->total_cycles() - m_coin_start_cycles;
+		const uint64_t elapsed = m_sub->total_cycles() - m_coin_start_cycles;
 
 		if (elapsed < coin_total_cycles/2)
 			coin_bit0 = 0;
 		else if (elapsed < coin_total_cycles)
 			coin_bit1 = 0;
 		else
-			m_coin_start_cycles = 0;
+		{
+			if (!machine().side_effects_disabled())
+				m_coin_start_cycles = 0;
+		}
 	}
 	else
 	{
-		if (!(ret & 1))
-			m_coin_start_cycles = m_sub->total_cycles();
+		if (!machine().side_effects_disabled())
+		{
+			if (!(ret & 1))
+				m_coin_start_cycles = m_sub->total_cycles();
+		}
 	}
 
 	return (ret & ~7) | (hopper_bit << 2) | (coin_bit1 << 1) | coin_bit0;
@@ -884,7 +907,7 @@ uint8_t funcube_state::coins_r()
 
 void funcube_state::funcube_debug_outputs()
 {
-	//popmessage("LED: %02x OUT: %02x", m_funcube_leds, m_outputs);
+	//LOGDEBUG("LED: %02x OUT: %02x\n", m_funcube_leds, m_outputs);
 }
 
 void funcube_state::leds_w(uint8_t data)
@@ -916,7 +939,7 @@ void funcube_state::outputs_w(uint8_t data)
 	// Bits 0,1,3 written
 
 	// Bit 0: hopper motor
-	m_hopper_motor = (~data) & 0x01;
+	m_hopper_motor = BIT(~data, 0);
 
 	// Bit 1: high on pay out
 
@@ -928,7 +951,7 @@ void funcube_state::outputs_w(uint8_t data)
 
 uint8_t funcube_state::battery_r()
 {
-	return ioport("BATTERY")->read() ? 0x40 : 0x00;
+	return m_in_battery->read() ? 0x40 : 0x00;
 }
 
 
@@ -952,14 +975,14 @@ static INPUT_PORTS_START( gundamex )
 	PORT_DIPSETTING(      0x0006, DEF_STR( Normal ) )
 	PORT_DIPSETTING(      0x0002, DEF_STR( Hard ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( Hardest ) )
-	PORT_DIPUNUSED_DIPLOC( 0x0008, 0x0008, "SW1:4" ) /* Listed as "Unused" */
+	PORT_DIPUNUSED_DIPLOC( 0x0008, 0x0008, "SW1:4" ) // Listed as "Unused"
 	PORT_DIPNAME( 0x0010, 0x0010, DEF_STR( Flip_Screen ) ) PORT_DIPLOCATION("SW1:5")
 	PORT_DIPSETTING(      0x0010, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0020, 0x0020, "Freeze" ) PORT_DIPLOCATION("SW1:6")  /* Listed as "Unused" */
+	PORT_DIPNAME( 0x0020, 0x0020, "Freeze" ) PORT_DIPLOCATION("SW1:6")  // Listed as "Unused"
 	PORT_DIPSETTING(      0x0020, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x0040, 0x0040, "Show Targets" ) PORT_DIPLOCATION("SW1:7") /* Listed as "Unused" */
+	PORT_DIPNAME( 0x0040, 0x0040, "Show Targets" ) PORT_DIPLOCATION("SW1:7") // Listed as "Unused"
 	PORT_DIPSETTING(      0x0040, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 	PORT_SERVICE_DIPLOC(  0x0080, IP_ACTIVE_LOW, "SW1:8" )
@@ -1072,7 +1095,7 @@ static INPUT_PORTS_START( grdians )
 	PORT_DIPSETTING(      0x0030, "2" )
 	PORT_DIPSETTING(      0x0010, "3" )
 	PORT_DIPSETTING(      0x0000, "4" )
-	PORT_SERVICE_DIPLOC(  0x0040, IP_ACTIVE_LOW, "SW1:7" ) /* NOTE: Test mode shows player 3 & 4 controls, but it's a two player game */
+	PORT_SERVICE_DIPLOC(  0x0040, IP_ACTIVE_LOW, "SW1:7" ) // NOTE: Test mode shows player 3 & 4 controls, but it's a two player game
 	PORT_DIPNAME( 0x0080, 0x0080, DEF_STR( Demo_Sounds ) ) PORT_DIPLOCATION("SW1:8")
 	PORT_DIPSETTING(      0x0000, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0080, DEF_STR( On ) )
@@ -1313,8 +1336,8 @@ INPUT_PORTS_END
 static INPUT_PORTS_START( myangel )
 	PORT_START("DSW1")  // $700300.w
 	PORT_SERVICE_DIPLOC(  0x0001, IP_ACTIVE_LOW, "SW1:1" )
-	PORT_DIPUNUSED_DIPLOC( 0x0002, 0x0002, "SW1:2" ) /* Listed as "Unused" */
-	PORT_DIPUNUSED_DIPLOC( 0x0004, 0x0004, "SW1:3" ) /* Listed as "Unused" */
+	PORT_DIPUNUSED_DIPLOC( 0x0002, 0x0002, "SW1:2" ) // Listed as "Unused"
+	PORT_DIPUNUSED_DIPLOC( 0x0004, 0x0004, "SW1:3" ) // Listed as "Unused"
 	PORT_DIPNAME( 0x0008, 0x0008, "Increase Lives While Playing" ) PORT_DIPLOCATION("SW1:4")
 	PORT_DIPSETTING(      0x0000, DEF_STR( No ) )
 	PORT_DIPSETTING(      0x0008, DEF_STR( Yes ) )
@@ -1349,9 +1372,9 @@ static INPUT_PORTS_START( myangel )
 	PORT_DIPSETTING(      0x000a, DEF_STR( 1C_6C ) )
 	PORT_DIPSETTING(      0x0009, DEF_STR( 1C_7C ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( Free_Play ) )
-	PORT_DIPUNUSED_DIPLOC( 0x0010, 0x0010, "SW2:5" ) /* Listed as "Unused" */
-	PORT_DIPUNUSED_DIPLOC( 0x0020, 0x0020, "SW2:6" ) /* Listed as "Unused" */
-	PORT_DIPUNUSED_DIPLOC( 0x0040, 0x0040, "SW2:7" ) /* Listed as "Unused" */
+	PORT_DIPUNUSED_DIPLOC( 0x0010, 0x0010, "SW2:5" ) // Listed as "Unused"
+	PORT_DIPUNUSED_DIPLOC( 0x0020, 0x0020, "SW2:6" ) // Listed as "Unused"
+	PORT_DIPUNUSED_DIPLOC( 0x0040, 0x0040, "SW2:7" ) // Listed as "Unused"
 	PORT_DIPNAME( 0x0080, 0x0080, "Push Start To Freeze (Cheat)") PORT_DIPLOCATION("SW2:8")
 	PORT_DIPSETTING(      0x0080, DEF_STR( No ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( Yes ) )
@@ -1399,8 +1422,8 @@ INPUT_PORTS_END
 static INPUT_PORTS_START( myangel2 )
 	PORT_START("DSW1") //$600300.w
 	PORT_SERVICE_DIPLOC(  0x0001, IP_ACTIVE_LOW, "SW1:1" )
-	PORT_DIPUNUSED_DIPLOC( 0x0002, 0x0002, "SW1:2" ) /* Listed as "Unused" */
-	PORT_DIPUNUSED_DIPLOC( 0x0004, 0x0004, "SW1:3" ) /* Listed as "Unused" */
+	PORT_DIPUNUSED_DIPLOC( 0x0002, 0x0002, "SW1:2" ) // Listed as "Unused"
+	PORT_DIPUNUSED_DIPLOC( 0x0004, 0x0004, "SW1:3" ) // Listed as "Unused"
 	PORT_DIPNAME( 0x0008, 0x0008, "Increase Lives While Playing" ) PORT_DIPLOCATION("SW1:4")
 	PORT_DIPSETTING(      0x0000, DEF_STR( No ) )
 	PORT_DIPSETTING(      0x0008, DEF_STR( Yes ) )
@@ -1435,10 +1458,10 @@ static INPUT_PORTS_START( myangel2 )
 	PORT_DIPSETTING(      0x000a, DEF_STR( 1C_6C ) )
 	PORT_DIPSETTING(      0x0009, DEF_STR( 1C_7C ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( Free_Play ) )
-	PORT_DIPUNUSED_DIPLOC( 0x0010, 0x0010, "SW2:5" ) /* Listed as "Unused" */
-	PORT_DIPUNUSED_DIPLOC( 0x0020, 0x0020, "SW2:6" ) /* Listed as "Unused" */
-	PORT_DIPUNUSED_DIPLOC( 0x0040, 0x0040, "SW2:7" ) /* Listed as "Unused" */
-	PORT_DIPUNUSED_DIPLOC( 0x0080, 0x0080, "SW2:8" ) /* Listed as "Unused" */
+	PORT_DIPUNUSED_DIPLOC( 0x0010, 0x0010, "SW2:5" ) // Listed as "Unused"
+	PORT_DIPUNUSED_DIPLOC( 0x0020, 0x0020, "SW2:6" ) // Listed as "Unused"
+	PORT_DIPUNUSED_DIPLOC( 0x0040, 0x0040, "SW2:7" ) // Listed as "Unused"
+	PORT_DIPUNUSED_DIPLOC( 0x0080, 0x0080, "SW2:8" ) // Listed as "Unused"
 	PORT_BIT(             0xff00, IP_ACTIVE_LOW, IPT_UNKNOWN )
 
 	PORT_START("P1") //$600000.w
@@ -1500,7 +1523,7 @@ static INPUT_PORTS_START( pzlbowl )
 	PORT_DIPSETTING(      0x0000, DEF_STR( Hardest ) )
 	PORT_DIPNAME( 0x00c0, 0x00c0, "Winning Rounds (Player VS Player)" ) PORT_DIPLOCATION("SW1:7,8")
 	PORT_DIPSETTING(      0x0040, "1" )
-	PORT_DIPSETTING(      0x00c0, "2" )     /* This setting is not defined in the manual */
+	PORT_DIPSETTING(      0x00c0, "2" )     // This setting is not defined in the manual
 	PORT_DIPSETTING(      0x0080, "3" )
 	PORT_DIPSETTING(      0x0000, "5" )
 	PORT_BIT(             0xff00, IP_ACTIVE_LOW, IPT_UNKNOWN )
@@ -1510,14 +1533,14 @@ static INPUT_PORTS_START( pzlbowl )
 	PORT_DIPSETTING(      0x0005, DEF_STR( 3C_1C ) )
 	PORT_DIPSETTING(      0x0008, DEF_STR( 2C_1C ) )
 	PORT_DIPSETTING(      0x0004, DEF_STR( 3C_2C ) )
-//  PORT_DIPSETTING(      0x0002, DEF_STR( 1C_1C ) )        /* This setting is not defined in the manual */
+//  PORT_DIPSETTING(      0x0002, DEF_STR( 1C_1C ) )        // This setting is not defined in the manual
 	PORT_DIPSETTING(      0x000f, DEF_STR( 1C_1C ) )
 	PORT_DIPSETTING(      0x0003, DEF_STR( 3C_4C ) )
 	PORT_DIPSETTING(      0x0007, DEF_STR( 2C_3C ) )
 	PORT_DIPSETTING(      0x000e, DEF_STR( 1C_2C ) )
 	PORT_DIPSETTING(      0x0006, DEF_STR( 2C_5C ) )
 	PORT_DIPSETTING(      0x000d, DEF_STR( 1C_3C ) )
-//  PORT_DIPSETTING(      0x0001, DEF_STR( 1C_3C ) )        /* This setting is not defined in the manual */
+//  PORT_DIPSETTING(      0x0001, DEF_STR( 1C_3C ) )        // This setting is not defined in the manual
 	PORT_DIPSETTING(      0x000c, DEF_STR( 1C_4C ) )
 	PORT_DIPSETTING(      0x000b, DEF_STR( 1C_5C ) )
 	PORT_DIPSETTING(      0x000a, DEF_STR( 1C_6C ) )
@@ -1626,7 +1649,7 @@ static INPUT_PORTS_START( penbros )
 	PORT_BIT(  0x0008, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_PLAYER(1)
 	PORT_BIT(  0x0010, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(1)
 	PORT_BIT(  0x0020, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(1)
-	PORT_BIT(  0x0040, IP_ACTIVE_LOW, IPT_UNKNOWN ) /* Player 1 button 3 is unused */
+	PORT_BIT(  0x0040, IP_ACTIVE_LOW, IPT_UNKNOWN ) // Player 1 button 3 is unused
 	PORT_BIT(  0x0080, IP_ACTIVE_LOW, IPT_START1 )
 	PORT_BIT(  0xff00, IP_ACTIVE_LOW, IPT_UNKNOWN )
 
@@ -1637,7 +1660,7 @@ static INPUT_PORTS_START( penbros )
 	PORT_BIT(  0x0008, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_PLAYER(2)
 	PORT_BIT(  0x0010, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(2)
 	PORT_BIT(  0x0020, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(2)
-	PORT_BIT(  0x0040, IP_ACTIVE_LOW, IPT_UNKNOWN ) /* Player 2 button 3 is unused */
+	PORT_BIT(  0x0040, IP_ACTIVE_LOW, IPT_UNKNOWN ) // Player 2 button 3 is unused
 	PORT_BIT(  0x0080, IP_ACTIVE_LOW, IPT_START2 )
 	PORT_BIT(  0xff00, IP_ACTIVE_LOW, IPT_UNKNOWN )
 
@@ -2003,7 +2026,7 @@ static INPUT_PORTS_START( trophyh )
 	PORT_INCLUDE(wschamp)
 
 	PORT_MODIFY("DSW2") // fffd0a.w
-	PORT_DIPNAME( 0x0020, 0x0020, "Blood Color" ) PORT_DIPLOCATION("SW2:6") /* WSChamp doesn't use Blood Color, so add it back in */
+	PORT_DIPNAME( 0x0020, 0x0020, "Blood Color" ) PORT_DIPLOCATION("SW2:6") // WSChamp doesn't use Blood Color, so add it back in
 	PORT_DIPSETTING(      0x0020, "Red" )
 	PORT_DIPSETTING(      0x0000, "Yellow" )
 INPUT_PORTS_END
@@ -2012,7 +2035,7 @@ static INPUT_PORTS_START( trophyht )
 	PORT_INCLUDE(wschamp)
 
 	PORT_MODIFY("DSW2") // fffd0a.w
-	PORT_DIPNAME( 0x0020, 0x0020, "Blood Color" ) PORT_DIPLOCATION("SW2:6") /* WSChamp doesn't use Blood Color, so add it back in */
+	PORT_DIPNAME( 0x0020, 0x0020, "Blood Color" ) PORT_DIPLOCATION("SW2:6") // WSChamp doesn't use Blood Color, so add it back in
 	PORT_DIPSETTING(      0x0020, "Red" )
 	PORT_DIPSETTING(      0x0000, "Yellow" )
 	PORT_DIPNAME( 0x0080, 0x0000, "Gun Type (Leave on Hand Gun)" ) PORT_DIPLOCATION("SW2:8")
@@ -2231,7 +2254,6 @@ GFXDECODE_END
 void seta2_state::seta2(machine_config &config)
 {
 	TMP68301(config, m_maincpu, XTAL(50'000'000)/3);   // Verified on some PCBs
-	m_maincpu->set_addrmap(AS_PROGRAM, &seta2_state::mj4simai_map);
 
 	WATCHDOG_TIMER(config, "watchdog");
 
@@ -2304,6 +2326,13 @@ void seta2_state::grdiansa(machine_config &config)
 {
 	grdians(config);
 	seta2_32m(config);
+}
+
+
+void mj4simai_state::mj4simai(machine_config &config)
+{
+	seta2(config);
+	m_maincpu->set_addrmap(AS_PROGRAM, &mj4simai_state::mj4simai_map);
 }
 
 
@@ -2387,7 +2416,7 @@ void staraudi_state::staraudi(machine_config &config)
 	seta2(config);
 	m_maincpu->set_addrmap(AS_PROGRAM, &staraudi_state::staraudi_map);
 
-	SHARP_LH28F016S_16BIT(config, "flash");
+	SHARP_LH28F016S_16BIT(config, m_flash);
 	UPD4992(config, m_rtc, 32'768);
 
 	// video hardware
@@ -2423,10 +2452,10 @@ TIMER_DEVICE_CALLBACK_MEMBER(funcube_state::funcube_interrupt)
 {
 	int scanline = param;
 
-	if(scanline == 368)
+	if (scanline == 368)
 		m_maincpu->set_input_line(1, HOLD_LINE);
 
-	if(scanline == 0)
+	if (scanline == 0)
 		m_maincpu->set_input_line(2, HOLD_LINE);
 }
 
@@ -2500,14 +2529,6 @@ void funcube_state::funcube2(machine_config &config)
 
 	m_sub->read_port4().set([]() -> u8 { return 0; }); // unused
 
-	// video hardware
-	m_screen->set_visarea(0x0, 0x140-1, 0x00, 0xf0-1);
-}
-
-
-void funcube_state::funcube3(machine_config &config)
-{
-	funcube2(config);
 	// video hardware
 	m_screen->set_visarea(0x0, 0x140-1, 0x00, 0xf0-1);
 }
@@ -2946,7 +2967,7 @@ JP1 - JP4 single wire connections for power
 
 ***************************************************************************/
 
-ROM_START( grdians ) /* P-FG01-1 PCB */
+ROM_START( grdians ) // P-FG01-1 PCB
 	ROM_REGION( 0x200000, "maincpu", 0 )    // TMP68301 Code
 	ROM_LOAD16_BYTE( "u2.bin", 0x000000, 0x080000, CRC(36adc6f2) SHA1(544e87f88179fe1342e7a06a8948ac1828e85108) )
 	ROM_LOAD16_BYTE( "u3.bin", 0x000001, 0x080000, CRC(2704f416) SHA1(9081a12cbb9927d36e1c50b52aa2c6003810ee42) )
@@ -2971,7 +2992,7 @@ ROM_START( grdians ) /* P-FG01-1 PCB */
 	ROM_LOAD( "u32.bin", 0x000000, 0x100000, CRC(cf0f3017) SHA1(8376d3a674f71aec72f52c72758fbc53d9feb1a1) )
 ROM_END
 
-ROM_START( grdiansa ) /* P0-113A PCB */
+ROM_START( grdiansa ) // P0-113A PCB
 	ROM_REGION( 0x200000, "maincpu", 0 )    // TMP68301 Code
 	ROM_LOAD16_BYTE( "ka2_001_001.u2", 0x000000, 0x080000, CRC(36adc6f2) SHA1(544e87f88179fe1342e7a06a8948ac1828e85108) ) // same program code as P-FG01-1 PCB above
 	ROM_LOAD16_BYTE( "ka2_001_004.u3", 0x000001, 0x080000, CRC(2704f416) SHA1(9081a12cbb9927d36e1c50b52aa2c6003810ee42) )
@@ -4082,10 +4103,10 @@ Trophy Hunting - Bear & Moose:
     CEEF                E01
 ***************************************************************************/
 
-ROM_START( deerhunt ) /* Deer Hunting USA V4.3 (11/1/2000) - The "E05" breaks version label conventions but is correct & verified */
+ROM_START( deerhunt ) // Deer Hunting USA V4.3 (11/1/2000) - The "E05" breaks version label conventions but is correct & verified
 	ROM_REGION( 0x200000, "maincpu", 0 )    // TMP68301 Code
-	ROM_LOAD16_BYTE( "as0906_e05_u6_694e.u06", 0x000000, 0x100000, CRC(20c81f17) SHA1(d41d93d6ee88738cec55f7bf3ce6be1dbec68e09) ) /* checksum 694E printed on label */
-	ROM_LOAD16_BYTE( "as0907_e05_u7_5d89.u07", 0x000001, 0x100000, CRC(1731aa2a) SHA1(cffae7a99a7f960a62ef0c4454884df17a93c1a6) ) /* checksum 5D89 printed on label */
+	ROM_LOAD16_BYTE( "as0906_e05_u6_694e.u06", 0x000000, 0x100000, CRC(20c81f17) SHA1(d41d93d6ee88738cec55f7bf3ce6be1dbec68e09) ) // checksum 694E printed on label
+	ROM_LOAD16_BYTE( "as0907_e05_u7_5d89.u07", 0x000001, 0x100000, CRC(1731aa2a) SHA1(cffae7a99a7f960a62ef0c4454884df17a93c1a6) ) // checksum 5D89 printed on label
 
 	ROM_REGION( 0x2000000, "sprites", 0 )   // Sprites
 	ROM_LOAD64_WORD( "as0901m01.u38", 0x0000000, 0x800000, CRC(1d6acf8f) SHA1(6f61fe21bebb7c87e8e6c3ef3ba73b8cf327dde9) )
@@ -4097,10 +4118,10 @@ ROM_START( deerhunt ) /* Deer Hunting USA V4.3 (11/1/2000) - The "E05" breaks ve
 	ROM_LOAD( "as0905m01.u18", 0x000000, 0x400000, CRC(8d8165bb) SHA1(aca7051613d260734ee787b4c3db552c336bd600) )
 ROM_END
 
-ROM_START( deerhunta ) /* Deer Hunting USA V4.2 (xx/x/2000) */
+ROM_START( deerhunta ) // Deer Hunting USA V4.2 (xx/x/2000)
 	ROM_REGION( 0x200000, "maincpu", 0 )    // TMP68301 Code
-	ROM_LOAD16_BYTE( "as0906_e04_u6_6640.u06", 0x000000, 0x100000, CRC(bb3af36f) SHA1(f04071347e8ad361bf666fcb6c0136e522f19d47) ) /* checksum 6640 printed on label */
-	ROM_LOAD16_BYTE( "as0907_e04_u7_595a.u07", 0x000001, 0x100000, CRC(83f02117) SHA1(70fc2291bc93af3902aae88688be6a8078f7a07e) ) /* checksum 595A printed on label */
+	ROM_LOAD16_BYTE( "as0906_e04_u6_6640.u06", 0x000000, 0x100000, CRC(bb3af36f) SHA1(f04071347e8ad361bf666fcb6c0136e522f19d47) ) // checksum 6640 printed on label
+	ROM_LOAD16_BYTE( "as0907_e04_u7_595a.u07", 0x000001, 0x100000, CRC(83f02117) SHA1(70fc2291bc93af3902aae88688be6a8078f7a07e) ) // checksum 595A printed on label
 
 	ROM_REGION( 0x2000000, "sprites", 0 )   // Sprites
 	ROM_LOAD64_WORD( "as0901m01.u38", 0x0000000, 0x800000, CRC(1d6acf8f) SHA1(6f61fe21bebb7c87e8e6c3ef3ba73b8cf327dde9) )
@@ -4112,10 +4133,10 @@ ROM_START( deerhunta ) /* Deer Hunting USA V4.2 (xx/x/2000) */
 	ROM_LOAD( "as0905m01.u18", 0x000000, 0x400000, CRC(8d8165bb) SHA1(aca7051613d260734ee787b4c3db552c336bd600) )
 ROM_END
 
-ROM_START( deerhuntb ) /* Deer Hunting USA V4.0 (6/15/2000) */
+ROM_START( deerhuntb ) // Deer Hunting USA V4.0 (6/15/2000)
 	ROM_REGION( 0x200000, "maincpu", 0 )        // TMP68301 Code
-	ROM_LOAD16_BYTE( "as_0906_e04.u06", 0x000000, 0x100000, CRC(07d9b64a) SHA1(f9aac644aab920bbac84b14836ee589ccd51f6db) ) /* also commonly labeled as: Deer Hunting USA U6 Ver 4.0 2000.6.15 - SUM16 = 7BBB */
-	ROM_LOAD16_BYTE( "as_0907_e04.u07", 0x000001, 0x100000, CRC(19973d08) SHA1(da1cc02ce480a62ccaf94d0af1246a340f054b43) ) /* also commonly labeled as: Deer Hunting USA U7 Ver 4.0 2000.6.15 - SUM16 = 4C78 */
+	ROM_LOAD16_BYTE( "as_0906_e04.u06", 0x000000, 0x100000, CRC(07d9b64a) SHA1(f9aac644aab920bbac84b14836ee589ccd51f6db) ) // also commonly labeled as: Deer Hunting USA U6 Ver 4.0 2000.6.15 - SUM16 = 7BBB
+	ROM_LOAD16_BYTE( "as_0907_e04.u07", 0x000001, 0x100000, CRC(19973d08) SHA1(da1cc02ce480a62ccaf94d0af1246a340f054b43) ) // also commonly labeled as: Deer Hunting USA U7 Ver 4.0 2000.6.15 - SUM16 = 4C78
 
 	ROM_REGION( 0x2000000, "sprites", 0 )   // Sprites
 	ROM_LOAD64_WORD( "as0901m01.u38", 0x0000000, 0x800000, CRC(1d6acf8f) SHA1(6f61fe21bebb7c87e8e6c3ef3ba73b8cf327dde9) )
@@ -4127,12 +4148,12 @@ ROM_START( deerhuntb ) /* Deer Hunting USA V4.0 (6/15/2000) */
 	ROM_LOAD( "as0905m01.u18", 0x000000, 0x400000, CRC(8d8165bb) SHA1(aca7051613d260734ee787b4c3db552c336bd600) )
 ROM_END
 
-	/* Are there versions 3.x of Deer Hunting USA with labels "AS0906 E03 U06" & "AS0907 E03 U07" ?? */
+	// Are there versions 3.x of Deer Hunting USA with labels "AS0906 E03 U06" & "AS0907 E03 U07" ??
 
-ROM_START( deerhuntc ) /* These rom labels break label conventions but is correct & verified. Version in program code is listed as 0.00 */
+ROM_START( deerhuntc ) // These rom labels break label conventions but is correct & verified. Version in program code is listed as 0.00
 	ROM_REGION( 0x200000, "maincpu", 0 )    // TMP68301 Code
-	ROM_LOAD16_BYTE( "as_0937_e01.u06", 0x000000, 0x100000, CRC(8d74088e) SHA1(cb11ffaf4c0267cc8cbe01accc3daeed910a3af3) ) /* SUM16 = C2CD - same as version dated 2000.5.31? */
-	ROM_LOAD16_BYTE( "as_0938_e01.u07", 0x000001, 0x100000, CRC(c7657889) SHA1(4cc707c8abbc0862457375a9a910d3c338859193) ) /* SUM16 = 27D7 - same as version dated 2000.5.31?  */
+	ROM_LOAD16_BYTE( "as_0937_e01.u06", 0x000000, 0x100000, CRC(8d74088e) SHA1(cb11ffaf4c0267cc8cbe01accc3daeed910a3af3) ) // SUM16 = C2CD - same as version dated 2000.5.31?
+	ROM_LOAD16_BYTE( "as_0938_e01.u07", 0x000001, 0x100000, CRC(c7657889) SHA1(4cc707c8abbc0862457375a9a910d3c338859193) ) // SUM16 = 27D7 - same as version dated 2000.5.31? 
 
 	ROM_REGION( 0x2000000, "sprites", 0 )   // Sprites
 	ROM_LOAD64_WORD( "as0901m01.u38", 0x0000000, 0x800000, CRC(1d6acf8f) SHA1(6f61fe21bebb7c87e8e6c3ef3ba73b8cf327dde9) )
@@ -4144,10 +4165,10 @@ ROM_START( deerhuntc ) /* These rom labels break label conventions but is correc
 	ROM_LOAD( "as0905m01.u18", 0x000000, 0x400000, CRC(8d8165bb) SHA1(aca7051613d260734ee787b4c3db552c336bd600) )
 ROM_END
 
-ROM_START( deerhuntd ) /* Deer Hunting USA V2.x - No version number is printed to screen but "E02" in EPROM label signifies V2 */
+ROM_START( deerhuntd ) // Deer Hunting USA V2.x - No version number is printed to screen but "E02" in EPROM label signifies V2
 	ROM_REGION( 0x200000, "maincpu", 0 )    // TMP68301 Code
-	ROM_LOAD16_BYTE( "as_0906_e02.u06", 0x000000, 0x100000, CRC(190cca42) SHA1(aef63f5e8c71ed0156b8b0104c5d23872c119167) ) /* Version in program code is listed as 0.00 */
-	ROM_LOAD16_BYTE( "as_0907_e02.u07", 0x000001, 0x100000, CRC(9de2b901) SHA1(d271bc54c41e30c0d9962eedd22f3ef2b7b8c9e5) ) /* Verified with two different sets of chips */
+	ROM_LOAD16_BYTE( "as_0906_e02.u06", 0x000000, 0x100000, CRC(190cca42) SHA1(aef63f5e8c71ed0156b8b0104c5d23872c119167) ) // Version in program code is listed as 0.00
+	ROM_LOAD16_BYTE( "as_0907_e02.u07", 0x000001, 0x100000, CRC(9de2b901) SHA1(d271bc54c41e30c0d9962eedd22f3ef2b7b8c9e5) ) // Verified with two different sets of chips
 
 	ROM_REGION( 0x2000000, "sprites", 0 )   // Sprites
 	ROM_LOAD64_WORD( "as0901m01.u38", 0x0000000, 0x800000, CRC(1d6acf8f) SHA1(6f61fe21bebb7c87e8e6c3ef3ba73b8cf327dde9) )
@@ -4159,10 +4180,10 @@ ROM_START( deerhuntd ) /* Deer Hunting USA V2.x - No version number is printed t
 	ROM_LOAD( "as0905m01.u18", 0x000000, 0x400000, CRC(8d8165bb) SHA1(aca7051613d260734ee787b4c3db552c336bd600) )
 ROM_END
 
-ROM_START( deerhunte ) /* Deer Hunting USA V1.x - No version number is printed to screen but "E01" in EPROM label signifies V1 */
+ROM_START( deerhunte ) // Deer Hunting USA V1.x - No version number is printed to screen but "E01" in EPROM label signifies V1
 	ROM_REGION( 0x200000, "maincpu", 0 )    // TMP68301 Code
-	ROM_LOAD16_BYTE( "as_0906_e01.u06", 0x000000, 0x100000, CRC(103e3ba3) SHA1(677d912ea9ed2ee1f26cdcac1687ce8ef416a96f) ) /* Version in program code is listed as 0.00 */
-	ROM_LOAD16_BYTE( "as_0907_e01.u07", 0x000001, 0x100000, CRC(ddeb0f97) SHA1(a2578071f3506d69057d2256685b969adc50d275) ) /* Verified with two different sets of chips */
+	ROM_LOAD16_BYTE( "as_0906_e01.u06", 0x000000, 0x100000, CRC(103e3ba3) SHA1(677d912ea9ed2ee1f26cdcac1687ce8ef416a96f) ) // Version in program code is listed as 0.00
+	ROM_LOAD16_BYTE( "as_0907_e01.u07", 0x000001, 0x100000, CRC(ddeb0f97) SHA1(a2578071f3506d69057d2256685b969adc50d275) ) // Verified with two different sets of chips
 
 	ROM_REGION( 0x2000000, "sprites", 0 )   // Sprites
 	ROM_LOAD64_WORD( "as0901m01.u38", 0x0000000, 0x800000, CRC(1d6acf8f) SHA1(6f61fe21bebb7c87e8e6c3ef3ba73b8cf327dde9) )
@@ -4174,9 +4195,9 @@ ROM_START( deerhunte ) /* Deer Hunting USA V1.x - No version number is printed t
 	ROM_LOAD( "as0905m01.u18", 0x000000, 0x400000, CRC(8d8165bb) SHA1(aca7051613d260734ee787b4c3db552c336bd600) )
 ROM_END
 
-ROM_START( deerhuntj ) /* Higher ROM labels indicate a specific version / region - No specific "For use in Japan" warning */
+ROM_START( deerhuntj ) // Higher ROM labels indicate a specific version / region - No specific "For use in Japan" warning
 	ROM_REGION( 0x200000, "maincpu", 0 )    // TMP68301 Code
-	ROM_LOAD16_BYTE( "as0_908e01_u6_jdh.u06", 0x000000, 0x100000, CRC(52f037da) SHA1(72afb4461be059655a2fe9b138e9feef19ecaa84) ) /* Version shows as VER .4.4.1 */
+	ROM_LOAD16_BYTE( "as0_908e01_u6_jdh.u06", 0x000000, 0x100000, CRC(52f037da) SHA1(72afb4461be059655a2fe9b138e9feef19ecaa84) ) // Version shows as VER .4.4.1
 	ROM_LOAD16_BYTE( "as0_909e01_u7_jdh.u07", 0x000001, 0x100000, CRC(b391bc87) SHA1(eb62e18b6ac9b0198911ec6684de73102c1d6df0) )
 
 	ROM_REGION( 0x2000000, "sprites", 0 )   // Sprites
@@ -4189,10 +4210,10 @@ ROM_START( deerhuntj ) /* Higher ROM labels indicate a specific version / region
 	ROM_LOAD( "as0905m01.u18", 0x000000, 0x400000, CRC(8d8165bb) SHA1(aca7051613d260734ee787b4c3db552c336bd600) )
 ROM_END
 
-ROM_START( turkhunt ) /* V1.0 is currently the only known version */
+ROM_START( turkhunt ) // V1.0 is currently the only known version
 	ROM_REGION( 0x200000, "maincpu", 0 )    // TMP68301 Code
-	ROM_LOAD16_BYTE( "asx_906e01_th.u06", 0x000000, 0x100000, CRC(c96266e1) SHA1(0ca462b3b0f27198e36384eee6ea5c5d4e7e1293) ) /* also commonly labeled as: Turkey U6 Ver 1.00 E510 */
-	ROM_LOAD16_BYTE( "asx_907e01_th.u07", 0x000001, 0x100000, CRC(7c67b502) SHA1(6a0e8883a115dac4095d86897e7eca2a007a1c71) ) /* also commonly labeled as: Turkey U7 Ver 1.00 AB40 */
+	ROM_LOAD16_BYTE( "asx_906e01_th.u06", 0x000000, 0x100000, CRC(c96266e1) SHA1(0ca462b3b0f27198e36384eee6ea5c5d4e7e1293) ) // also commonly labeled as: Turkey U6 Ver 1.00 E510
+	ROM_LOAD16_BYTE( "asx_907e01_th.u07", 0x000001, 0x100000, CRC(7c67b502) SHA1(6a0e8883a115dac4095d86897e7eca2a007a1c71) ) // also commonly labeled as: Turkey U7 Ver 1.00 AB40
 
 	ROM_REGION( 0x2000000, "sprites", 0 )   // Sprites
 	ROM_LOAD64_WORD( "asx901m01.u38", 0x0000000, 0x800000, CRC(eabd3f44) SHA1(5a1ac986d11a8b019e18761cf4ea0a6f49fbdbfc) )
@@ -4204,10 +4225,10 @@ ROM_START( turkhunt ) /* V1.0 is currently the only known version */
 	ROM_LOAD( "asx905m01.u18", 0x000000, 0x400000, CRC(8d9dd9a9) SHA1(1fc2f3688d2c24c720dca7357bca6bf5f4016c53) )
 ROM_END
 
-ROM_START( wschamp ) /* Wing Shooting Championship V2.00 (01/23/2002) - The "E03" breaks version label conventions but is correct & verified */
+ROM_START( wschamp ) // Wing Shooting Championship V2.00 (01/23/2002) - The "E03" breaks version label conventions but is correct & verified
 	ROM_REGION( 0x200000, "maincpu", 0 )    // TMP68301 Code
-	ROM_LOAD16_BYTE( "as_1006_e03.u06", 0x000000, 0x100000, CRC(0ad01677) SHA1(63e09b9f7cc8b781af1756f86caa0cc0962ae584) ) /* also commonly labeled as: WSC U6 Ver 2.00 421E */
-	ROM_LOAD16_BYTE( "as_1007_e03.u07", 0x000001, 0x100000, CRC(572624f0) SHA1(0c2f67daa22f4edd66a2be990dc6cd999faff0fa) ) /* also commonly labeled as: WSC U7 Ver 2.00 A48F */
+	ROM_LOAD16_BYTE( "as_1006_e03.u06", 0x000000, 0x100000, CRC(0ad01677) SHA1(63e09b9f7cc8b781af1756f86caa0cc0962ae584) ) // also commonly labeled as: WSC U6 Ver 2.00 421E
+	ROM_LOAD16_BYTE( "as_1007_e03.u07", 0x000001, 0x100000, CRC(572624f0) SHA1(0c2f67daa22f4edd66a2be990dc6cd999faff0fa) ) // also commonly labeled as: WSC U7 Ver 2.00 A48F
 
 	ROM_REGION( 0x2000000, "sprites", 0 )   // Sprites
 	ROM_LOAD64_WORD( "as1001m01.u38", 0x0000000, 0x800000, CRC(92595579) SHA1(75a7131aedb18b7103677340c3cca7c91aaca2bf) )
@@ -4219,10 +4240,10 @@ ROM_START( wschamp ) /* Wing Shooting Championship V2.00 (01/23/2002) - The "E03
 	ROM_LOAD( "as1005m01.u18", 0x000000, 0x400000, CRC(e4b137b8) SHA1(4d8d15073c51f7d383282cc5755ae5b2eab6226c) )
 ROM_END
 
-ROM_START( wschampa ) /* Wing Shooting Championship V1.01 */
+ROM_START( wschampa ) // Wing Shooting Championship V1.01
 	ROM_REGION( 0x200000, "maincpu", 0 )    // TMP68301 Code
-	ROM_LOAD16_BYTE( "as_1006_e02.u06", 0x000000, 0x100000, CRC(d3d3b2b5) SHA1(2d036d795b40a4ed78bb9f7751f875cfc76276a9) ) /* SUM16 = 31EF */
-	ROM_LOAD16_BYTE( "as_1007_e02.u07", 0x000001, 0x100000, CRC(78ede6d9) SHA1(e6d10f52cd4c6bf97288df44911f23bb64fc012c) ) /* SUM16 = 615E */
+	ROM_LOAD16_BYTE( "as_1006_e02.u06", 0x000000, 0x100000, CRC(d3d3b2b5) SHA1(2d036d795b40a4ed78bb9f7751f875cfc76276a9) ) // SUM16 = 31EF
+	ROM_LOAD16_BYTE( "as_1007_e02.u07", 0x000001, 0x100000, CRC(78ede6d9) SHA1(e6d10f52cd4c6bf97288df44911f23bb64fc012c) ) // SUM16 = 615E
 
 	ROM_REGION( 0x2000000, "sprites", 0 )   // Sprites
 	ROM_LOAD64_WORD( "as1001m01.u38", 0x0000000, 0x800000, CRC(92595579) SHA1(75a7131aedb18b7103677340c3cca7c91aaca2bf) )
@@ -4234,10 +4255,10 @@ ROM_START( wschampa ) /* Wing Shooting Championship V1.01 */
 	ROM_LOAD( "as1005m01.u18", 0x000000, 0x400000, CRC(e4b137b8) SHA1(4d8d15073c51f7d383282cc5755ae5b2eab6226c) )
 ROM_END
 
-ROM_START( wschampb ) /* Wing Shooting Championship V1.00, dumps match listed checksum but shows as "NG" on boot screen - need to verify correct at some point if possible */
+ROM_START( wschampb ) // Wing Shooting Championship V1.00, dumps match listed checksum but shows as "NG" on boot screen - need to verify correct at some point if possible
 	ROM_REGION( 0x200000, "maincpu", 0 )    // TMP68301 Code
-	ROM_LOAD16_BYTE( "as10u6.u06", 0x000000, 0x100000, CRC(70a18bef) SHA1(3fb2e8a4db790dd732115d7d3d991b2d6c54feb9) ) /* checksum 3F38 & 10/26 16:00 hand written on label */
-	ROM_LOAD16_BYTE( "as10u7.u07", 0x000001, 0x100000, CRC(cf23be7d) SHA1(b9130757466ff0d41d261b1c2435d36d2452df54) ) /* checksum 1537 & 10/26 16:00 hand written on label */
+	ROM_LOAD16_BYTE( "as10u6.u06", 0x000000, 0x100000, CRC(70a18bef) SHA1(3fb2e8a4db790dd732115d7d3d991b2d6c54feb9) ) // checksum 3F38 & 10/26 16:00 hand written on label
+	ROM_LOAD16_BYTE( "as10u7.u07", 0x000001, 0x100000, CRC(cf23be7d) SHA1(b9130757466ff0d41d261b1c2435d36d2452df54) ) // checksum 1537 & 10/26 16:00 hand written on label
 
 	ROM_REGION( 0x2000000, "sprites", 0 )   // Sprites
 	ROM_LOAD64_WORD( "as1001m01.u38", 0x0000000, 0x800000, CRC(92595579) SHA1(75a7131aedb18b7103677340c3cca7c91aaca2bf) )
@@ -4249,10 +4270,10 @@ ROM_START( wschampb ) /* Wing Shooting Championship V1.00, dumps match listed ch
 	ROM_LOAD( "as1005m01.u18", 0x000000, 0x400000, CRC(e4b137b8) SHA1(4d8d15073c51f7d383282cc5755ae5b2eab6226c) )
 ROM_END
 
-ROM_START( trophyh ) /* Version 1.00 - v: Thu Mar 28 12:35:50 2002 JST-9 - on a B0-010A PCB with all mask ROMs */
+ROM_START( trophyh ) // Version 1.00 - v: Thu Mar 28 12:35:50 2002 JST-9 - on a B0-010A PCB with all mask ROMs
 	ROM_REGION( 0x200000, "maincpu", 0 )    // TMP68301 Code
-	ROM_LOAD16_BYTE( "as_1106_e01.u06", 0x000000, 0x100000, CRC(b4950882) SHA1(2749f7ffc5b543c9f39815f0913a1d1e385b63f4) ) /* also commonly labeled as: Trophy U6 Ver 1.00 D8DA */
-	ROM_LOAD16_BYTE( "as_1107_e01.u07", 0x000001, 0x100000, CRC(19ee67cb) SHA1(e75ce66d3ff5aad46ba997c09d6514260e617f55) ) /* also commonly labeled as: Trophy U7 Ver 1.00 CEEF */
+	ROM_LOAD16_BYTE( "as_1106_e01.u06", 0x000000, 0x100000, CRC(b4950882) SHA1(2749f7ffc5b543c9f39815f0913a1d1e385b63f4) ) // also commonly labeled as: Trophy U6 Ver 1.00 D8DA
+	ROM_LOAD16_BYTE( "as_1107_e01.u07", 0x000001, 0x100000, CRC(19ee67cb) SHA1(e75ce66d3ff5aad46ba997c09d6514260e617f55) ) // also commonly labeled as: Trophy U7 Ver 1.00 CEEF
 
 	ROM_REGION( 0x2000000, "sprites", 0 )   // Sprites
 	ROM_LOAD64_WORD( "as1101m01.u38", 0x0000000, 0x800000, CRC(855ed675) SHA1(84ce229a9feb6331413253a5aed10b362e8102e5) )
@@ -4264,14 +4285,14 @@ ROM_START( trophyh ) /* Version 1.00 - v: Thu Mar 28 12:35:50 2002 JST-9 - on a 
 	ROM_LOAD( "as1105m01.u18", 0x000000, 0x400000, CRC(633d0df8) SHA1(3401c424f5c207ef438a9269e0c0e7d482771fed) )
 ROM_END
 
-ROM_START( trophyht ) /* V1.00 Location Test - v: Tue Feb 26 18:18:43 2002 JST-9 - on a P0-145-1 main PCB with a P1-115A flash ROM board */
+ROM_START( trophyht ) // V1.00 Location Test - v: Tue Feb 26 18:18:43 2002 JST-9 - on a P0-145-1 main PCB with a P1-115A flash ROM board
 	ROM_REGION( 0x200000, "maincpu", 0 )    // TMP68301 Code
-	ROM_LOAD16_BYTE( "trophy_2-26_u6_2e9c.u06", 0x000000, 0x100000, CRC(74496d65) SHA1(8af7bce528557efe68e0ed8be8b60d0ba4409c35) ) /* hand written label:  Trophy 2/26 U6  2E9C */
-	ROM_LOAD16_BYTE( "trophy_2-26_u6_de45.u07", 0x000001, 0x100000, CRC(9ae364f6) SHA1(9df8352345e59f1e0a5cb66a8b43d5ad7785ca29) ) /* hand written label:  Trophy 2/26 U7  DE45 */
+	ROM_LOAD16_BYTE( "trophy_2-26_u6_2e9c.u06", 0x000000, 0x100000, CRC(74496d65) SHA1(8af7bce528557efe68e0ed8be8b60d0ba4409c35) ) // hand written label:  Trophy 2/26 U6  2E9C
+	ROM_LOAD16_BYTE( "trophy_2-26_u6_de45.u07", 0x000001, 0x100000, CRC(9ae364f6) SHA1(9df8352345e59f1e0a5cb66a8b43d5ad7785ca29) ) // hand written label:  Trophy 2/26 U7  DE45
 
 	ROM_REGION( 0x2000000, "sprites", 0 )   // Sprites
-	ROM_LOAD( "lh28f016sat.u20", 0x0000000, 0x200000, NO_DUMP ) /* None of the 28F016 flash ROMs are dumped */
-	ROM_LOAD( "lh28f016sat.u21", 0x0200000, 0x200000, NO_DUMP ) /* The correct loading order is unknown    */
+	ROM_LOAD( "lh28f016sat.u20", 0x0000000, 0x200000, NO_DUMP ) // None of the 28F016 flash ROMs are dumped
+	ROM_LOAD( "lh28f016sat.u21", 0x0200000, 0x200000, NO_DUMP ) // The correct loading order is unknown   
 	ROM_LOAD( "lh28f016sat.u22", 0x0400000, 0x200000, NO_DUMP )
 	ROM_LOAD( "lh28f016sat.u23", 0x0600000, 0x200000, NO_DUMP )
 	ROM_LOAD( "lh28f016sat.u24", 0x0800000, 0x200000, NO_DUMP )
@@ -4286,13 +4307,13 @@ ROM_START( trophyht ) /* V1.00 Location Test - v: Tue Feb 26 18:18:43 2002 JST-9
 	ROM_LOAD( "lh28f016sat.u33", 0x1a00000, 0x200000, NO_DUMP )
 	ROM_LOAD( "lh28f016sat.u34", 0x1c00000, 0x200000, NO_DUMP )
 	ROM_LOAD( "lh28f016sat.u35", 0x1e00000, 0x200000, NO_DUMP )
-	ROM_LOAD64_WORD( "as1101m01.u38",   0x0000000, 0x800000, CRC(855ed675) SHA1(84ce229a9feb6331413253a5aed10b362e8102e5) ) /* Load these in until the flash ROMs are dumped */
-	ROM_LOAD64_WORD( "as1102m01.u39",   0x0000002, 0x800000, CRC(d186d271) SHA1(3c54438b35adfab8be91df0a633270d6db49beef) ) /* Load these in until the flash ROMs are dumped */
-	ROM_LOAD64_WORD( "as1103m01.u40",   0x0000004, 0x800000, CRC(adf8a54e) SHA1(bb28bf219d18082246f7964851a5c49b9c0ba7f5) ) /* Load these in until the flash ROMs are dumped */
-	ROM_LOAD64_WORD( "as1104m01.u41",   0x0000006, 0x800000, CRC(387882e9) SHA1(0fdd0c77dabd1066c6f3bd64e357236a76f524ab) ) /* Load these in until the flash ROMs are dumped */
+	ROM_LOAD64_WORD( "as1101m01.u38",   0x0000000, 0x800000, CRC(855ed675) SHA1(84ce229a9feb6331413253a5aed10b362e8102e5) ) // Load these in until the flash ROMs are dumped
+	ROM_LOAD64_WORD( "as1102m01.u39",   0x0000002, 0x800000, CRC(d186d271) SHA1(3c54438b35adfab8be91df0a633270d6db49beef) ) // Load these in until the flash ROMs are dumped
+	ROM_LOAD64_WORD( "as1103m01.u40",   0x0000004, 0x800000, CRC(adf8a54e) SHA1(bb28bf219d18082246f7964851a5c49b9c0ba7f5) ) // Load these in until the flash ROMs are dumped
+	ROM_LOAD64_WORD( "as1104m01.u41",   0x0000006, 0x800000, CRC(387882e9) SHA1(0fdd0c77dabd1066c6f3bd64e357236a76f524ab) ) // Load these in until the flash ROMs are dumped
 
 	ROM_REGION( 0x400000, "x1snd", 0 )  // Samples
-	ROM_LOAD( "as1105m01.u18", 0x000000, 0x400000, CRC(633d0df8) SHA1(3401c424f5c207ef438a9269e0c0e7d482771fed) ) /* unlabeled 27C322 with same data as AS1105M01 mask ROM */
+	ROM_LOAD( "as1105m01.u18", 0x000000, 0x400000, CRC(633d0df8) SHA1(3401c424f5c207ef438a9269e0c0e7d482771fed) ) // unlabeled 27C322 with same data as AS1105M01 mask ROM
 ROM_END
 
 /***************************************************************************
@@ -4402,7 +4423,7 @@ GAME( 1995, grdians,   0,        grdians,  grdians,  seta2_state,    empty_init,
 GAME( 1995, grdiansa,  grdians,  grdiansa, grdians,  seta2_state,    empty_init,    ROT0,   "Winkysoft (Banpresto license)", "Guardians / Denjin Makai II (P0-113A PCB)",   MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS )
 GAME( 1998, grdiansbl, grdians,  grdiansa, grdians,  seta2_state,    empty_init,    ROT0,   "bootleg (Intac Japan)",         "Guardians / Denjin Makai II (bootleg)",       MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS )
 
-GAME( 1996, mj4simai,  0,        seta2,    mj4simai, mj4simai_state, empty_init,    ROT0,   "Maboroshi Ware",        "Wakakusamonogatari Mahjong Yonshimai (Japan)",        MACHINE_NO_COCKTAIL )
+GAME( 1996, mj4simai,  0,        mj4simai, mj4simai, mj4simai_state, empty_init,    ROT0,   "Maboroshi Ware",        "Wakakusamonogatari Mahjong Yonshimai (Japan)",        MACHINE_NO_COCKTAIL )
 
 GAME( 1996, myangel,   0,        myangel,  myangel,  seta2_state,    empty_init,    ROT0,   "MOSS / Namco",          "Kosodate Quiz My Angel (Japan)",                      MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS )
 
@@ -4446,7 +4467,7 @@ GAME( 2000, funcube,   0,        funcube,  funcube,  funcube_state,  init_funcub
 
 GAME( 2001, funcube2,  0,        funcube2, funcube,  funcube_state,  init_funcube2, ROT0,   "Namco",                 "Funcube 2 (v1.1)",                                    MACHINE_NO_COCKTAIL )
 
-GAME( 2001, funcube3,  0,        funcube3, funcube,  funcube_state,  init_funcube3, ROT0,   "Namco",                 "Funcube 3 (v1.1)",                                    MACHINE_NO_COCKTAIL )
+GAME( 2001, funcube3,  0,        funcube2, funcube,  funcube_state,  init_funcube3, ROT0,   "Namco",                 "Funcube 3 (v1.1)",                                    MACHINE_NO_COCKTAIL )
 
 GAME( 2001, funcube4,  0,        funcube2, funcube,  funcube_state,  init_funcube2, ROT0,   "Namco",                 "Funcube 4 (v1.0)",                                    MACHINE_NO_COCKTAIL )
 

--- a/src/mame/seta/seta2.h
+++ b/src/mame/seta/seta2.h
@@ -37,12 +37,12 @@ public:
 		m_x1_bank(*this, "x1_bank_%u", 1U),
 		m_spriteram(*this, "spriteram", 0x40000, ENDIANNESS_BIG),
 		m_vregs(*this, "vregs", 0x40, ENDIANNESS_BIG),
+
+		m_in_system(*this, "SYSTEM"),
 		m_leds(*this, "led%u", 0U),
 		m_lamps(*this, "lamp%u", 0U)
 	{ }
 
-	void seta2(machine_config &config);
-	void seta2_32m(machine_config &config);
 	void grdians(machine_config &config);
 	void grdiansa(machine_config &config);
 	void myangel(machine_config &config);
@@ -63,9 +63,6 @@ protected:
 	virtual void video_start() override;
 
 	void grdians_lockout_w(uint8_t data);
-
-	uint16_t mj4simai_p1_r();
-	uint16_t mj4simai_p2_r();
 
 	uint16_t pzlbowl_protection_r(address_space &space);
 	uint8_t pzlbowl_coins_r();
@@ -88,8 +85,8 @@ protected:
 	uint16_t spriteram_r(offs_t offset);
 	void spriteram_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 
-	int calculate_global_xoffset(int nozoom_fixedpalette_fixedposition);
-	int calculate_global_yoffset(int nozoom_fixedpalette_fixedposition);
+	int calculate_global_xoffset(bool nozoom_fixedpalette_fixedposition);
+	int calculate_global_yoffset(bool nozoom_fixedpalette_fixedposition);
 	void draw_sprites_line(bitmap_ind16 &bitmap, const rectangle &cliprect, int scanline, int realscanline, int xoffset, uint32_t xzoom, bool xzoominverted);
 	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect);
 
@@ -101,7 +98,6 @@ protected:
 	void ablastb_map(address_map &map);
 	void grdians_map(address_map &map);
 	void gundamex_map(address_map &map);
-	void mj4simai_map(address_map &map);
 	void myangel2_map(address_map &map);
 	void myangel_map(address_map &map);
 	void namcostr_map(address_map &map);
@@ -112,6 +108,9 @@ protected:
 	void samshoot_map(address_map &map);
 	void telpacfl_map(address_map &map);
 	void x1_map(address_map &map);
+
+	void seta2(machine_config &config);
+	void seta2_32m(machine_config &config);
 
 	required_device<cpu_device> m_maincpu;
 	optional_device<h83007_device> m_sub;
@@ -127,23 +126,23 @@ protected:
 	optional_memory_bank_array<8> m_x1_bank;
 	memory_share_creator<uint16_t> m_spriteram;
 	memory_share_creator<uint16_t> m_vregs;
+	optional_ioport m_in_system;
 	output_finder<7> m_leds;
 	output_finder<11> m_lamps;
 
-	int m_keyboard_row;
 	std::unique_ptr<uint16_t[]> m_private_spriteram;
 
 private:
-	void drawgfx_line(bitmap_ind16 &bitmap, const rectangle &cliprect, int gfx, const uint8_t* const addr, const uint32_t realcolor, int flipx, int flipy, int base_sx, uint32_t xzoom, int shadow, int screenline, int line, int opaque);
-	inline void get_tile(uint16_t* spriteram, int is_16x16, int x, int y, int page, int& code, int& attr, int& flipx, int& flipy, int& color);
+	void drawgfx_line(bitmap_ind16 &bitmap, const rectangle &cliprect, int gfx, const uint8_t* const addr, const uint32_t realcolor, bool flipx, bool flipy, int base_sx, uint32_t xzoom, bool shadow, int screenline, int line, bool opaque);
+	inline void get_tile(uint16_t* spriteram, bool is_16x16, int x, int y, int page, int& code, int& attr, bool& flipx, bool& flipy, int& color);
 
 	std::unique_ptr<uint32_t[]> m_realtilenumber;
 	gfx_element *m_spritegfx;
 
-	uint16_t m_rasterposition;
-	uint16_t m_rasterenabled;
+	uint16_t m_rasterposition = 0;
+	uint16_t m_rasterenabled = 0;
 	TIMER_CALLBACK_MEMBER(raster_timer_done);
-	emu_timer *m_raster_timer;
+	emu_timer *m_raster_timer = nullptr;
 };
 
 
@@ -152,10 +151,25 @@ class mj4simai_state : public seta2_state
 public:
 	mj4simai_state(const machine_config &mconfig, device_type type, const char *tag)
 		: seta2_state(mconfig, type, tag)
+		, m_p1_key(*this, "P1_KEY%u", 0U)
+		, m_p2_key(*this, "P2_KEY%u", 0U)
 	{ }
+
+	void mj4simai(machine_config &config);
 
 protected:
 	virtual void machine_start() override;
+
+private:
+	uint16_t mj4simai_p1_r();
+	uint16_t mj4simai_p2_r();
+
+	void mj4simai_map(address_map &map);
+
+	required_ioport_array<5> m_p1_key;
+	required_ioport_array<5> m_p2_key;
+
+	uint8_t m_keyboard_row = 0;
 };
 
 
@@ -165,19 +179,19 @@ public:
 	funcube_state(const machine_config &mconfig, device_type type, const char *tag)
 		: seta2_state(mconfig, type, tag)
 		, m_nvram(*this, "nvram", 0x180, ENDIANNESS_BIG)
+		, m_in_debug(*this, "DEBUG")
+		, m_in_switch(*this, "SWITCH")
+		, m_in_battery(*this, "BATTERY")
 	{ }
 
 	void funcube(machine_config &config);
-	void funcube3(machine_config &config);
 	void funcube2(machine_config &config);
 
-	void init_funcube3();
 	void init_funcube();
 	void init_funcube2();
+	void init_funcube3();
 
 private:
-	memory_share_creator<uint8_t> m_nvram;
-
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
@@ -199,7 +213,13 @@ private:
 
 	void funcube_debug_outputs();
 
-	uint8_t m_outputs, m_funcube_leds;
+	memory_share_creator<uint8_t> m_nvram;
+
+	required_ioport m_in_debug;
+	required_ioport m_in_switch;
+	required_ioport m_in_battery;
+
+	uint8_t m_outputs = 0, m_funcube_leds = 0;
 	uint64_t m_coin_start_cycles = 0;
 	uint8_t m_hopper_motor = 0;
 };

--- a/src/mame/seta/seta2.h
+++ b/src/mame/seta/seta2.h
@@ -134,14 +134,15 @@ protected:
 
 private:
 	void drawgfx_line(bitmap_ind16 &bitmap, const rectangle &cliprect, int gfx, const uint8_t* const addr, const uint32_t realcolor, bool flipx, bool flipy, int base_sx, uint32_t xzoom, bool shadow, int screenline, int line, bool opaque);
-	inline void get_tile(uint16_t* spriteram, bool is_16x16, int x, int y, int page, int& code, int& attr, bool& flipx, bool& flipy, int& color);
+	inline void get_tile(uint16_t *spriteram, bool is_16x16, int x, int y, int page, int &code, int &attr, bool &flipx, bool &flipy, int &color);
+
+	TIMER_CALLBACK_MEMBER(raster_timer_done);
 
 	std::unique_ptr<uint32_t[]> m_realtilenumber;
 	gfx_element *m_spritegfx;
 
 	uint16_t m_rasterposition = 0;
 	uint16_t m_rasterenabled = 0;
-	TIMER_CALLBACK_MEMBER(raster_timer_done);
 	emu_timer *m_raster_timer = nullptr;
 };
 
@@ -149,10 +150,10 @@ private:
 class mj4simai_state : public seta2_state
 {
 public:
-	mj4simai_state(const machine_config &mconfig, device_type type, const char *tag)
-		: seta2_state(mconfig, type, tag)
-		, m_p1_key(*this, "P1_KEY%u", 0U)
-		, m_p2_key(*this, "P2_KEY%u", 0U)
+	mj4simai_state(const machine_config &mconfig, device_type type, const char *tag) :
+		seta2_state(mconfig, type, tag),
+		m_p1_key(*this, "P1_KEY%u", 0U),
+		m_p2_key(*this, "P2_KEY%u", 0U)
 	{ }
 
 	void mj4simai(machine_config &config);
@@ -176,12 +177,12 @@ private:
 class funcube_state : public seta2_state
 {
 public:
-	funcube_state(const machine_config &mconfig, device_type type, const char *tag)
-		: seta2_state(mconfig, type, tag)
-		, m_nvram(*this, "nvram", 0x180, ENDIANNESS_BIG)
-		, m_in_debug(*this, "DEBUG")
-		, m_in_switch(*this, "SWITCH")
-		, m_in_battery(*this, "BATTERY")
+	funcube_state(const machine_config &mconfig, device_type type, const char *tag) :
+		seta2_state(mconfig, type, tag),
+		m_nvram(*this, "nvram", 0x180, ENDIANNESS_BIG),
+		m_in_debug(*this, "DEBUG"),
+		m_in_switch(*this, "SWITCH"),
+		m_in_battery(*this, "BATTERY")
 	{ }
 
 	void funcube(machine_config &config);

--- a/src/mame/seta/seta2_v.cpp
+++ b/src/mame/seta/seta2_v.cpp
@@ -89,6 +89,22 @@
 #include "emu.h"
 #include "seta2.h"
 
+#define LOG_VREG    (1U << 1)
+#define LOG_VIDEO   (1U << 2)
+#define LOG_SPRITE  (1U << 3)
+#define LOG_OFFSET  (1U << 4)
+
+#define LOG_ALL     (LOG_IO)
+
+#define VERBOSE (0)
+#include "logmacro.h"
+
+#define LOGVREG(...)   LOGMASKED(LOG_VREG, __VA_ARGS__)
+#define LOGVIDEO(...)  LOGMASKED(LOG_VIDEO, __VA_ARGS__)
+#define LOGSPRITE(...) LOGMASKED(LOG_SPRITE, __VA_ARGS__)
+#define LOGOFFSET(...) LOGMASKED(LOG_OFFSET, __VA_ARGS__)
+
+
 /***************************************************************************
 
                                 Video Registers
@@ -170,35 +186,34 @@ void seta2_state::vregs_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 	           grdians =  019a
 	*/
 
-	uint16_t olddata = m_vregs[offset];
+	const uint16_t olddata = m_vregs[offset];
 
 	COMBINE_DATA(&m_vregs[offset]);
 
-
 	if (m_vregs[offset] != olddata)
-		logerror("CPU #0 PC %06X: Video Reg %02X <- %04X\n", m_maincpu->pc(), offset * 2, data);
+		LOGVREG("CPU #0 PC %06X: Video Reg %02X <- %04X\n", m_maincpu->pc(), offset * 2, data);
 
 	switch (offset * 2)
 	{
 	case 0x1a:
-		logerror("%s: Register 1a write (vertical offset?) %04X (%04x)\n", machine().describe_context(), data, mem_mask);
+		LOGVREG("%s: Register 1a write (vertical offset?) %04X (%04x)\n", machine().describe_context(), data, mem_mask);
 		break;
 
 	case 0x1c:  // FLIP SCREEN (myangel)    <- this is actually zoom
-		flip_screen_set(data & 1);
-		if (data & ~1)  logerror("CPU #0 PC %06X: flip screen unknown bits %04X\n", m_maincpu->pc(), data);
+		flip_screen_set(BIT(data, 0));
+		if (data & ~1)  LOGVREG("CPU #0 PC %06X: flip screen unknown bits %04X\n", m_maincpu->pc(), data);
 		break;
 	case 0x2a:  // FLIP X (pzlbowl)
-		flip_screen_x_set(data & 1);
-		if (data & ~1)  logerror("CPU #0 PC %06X: flipx unknown bits %04X\n", m_maincpu->pc(), data);
+		flip_screen_x_set(BIT(data, 0));
+		if (data & ~1)  LOGVREG("CPU #0 PC %06X: flipx unknown bits %04X\n", m_maincpu->pc(), data);
 		break;
 	case 0x2c:  // FLIP Y (pzlbowl)
-		flip_screen_y_set(data & 1);
-		if (data & ~1)  logerror("CPU #0 PC %06X: flipy unknown bits %04X\n", m_maincpu->pc(), data);
+		flip_screen_y_set(BIT(data, 0));
+		if (data & ~1)  LOGVREG("CPU #0 PC %06X: flipy unknown bits %04X\n", m_maincpu->pc(), data);
 		break;
 
 	case 0x30:  // BLANK SCREEN (pzlbowl, myangel)
-		if (data & ~1)  logerror("CPU #0 PC %06X: blank unknown bits %04X\n", m_maincpu->pc(), data);
+		if (data & ~1)  LOGVREG("CPU #0 PC %06X: blank unknown bits %04X\n", m_maincpu->pc(), data);
 		break;
 
 	case 0x24: // funcube3 and staraudi write here instead, why? mirror or different meaning?
@@ -218,12 +233,12 @@ void seta2_state::vregs_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 				m_private_spriteram[i + 1] = m_spriteram[(0x3000 / 2) + i + 1];
 				m_private_spriteram[i + 2] = m_spriteram[(0x3000 / 2) + i + 2];
 
-				int sprite = m_spriteram[(0x3000 / 2) + i + 3];
+				const int sprite = m_spriteram[(0x3000 / 2) + i + 3];
 				m_private_spriteram[i + 3] = ((current_sprite_entry / 4) & 0x7fff) | (sprite & 0x8000);
 
-				int list2addr = (sprite & 0x7fff) * 4;
+				const int list2addr = (sprite & 0x7fff) * 4;
 
-				num &=0xff;
+				num &= 0xff;
 
 				for (int j = 0; j <= num; j++)
 				{
@@ -237,14 +252,12 @@ void seta2_state::vregs_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 					}
 				}
 
-				if (m_private_spriteram[i + 0] & 0x8000) // end of list marker, mj4simai must draw the sprite this covers for the company logo, title screen etc.
+				if (BIT(m_private_spriteram[i + 0], 15)) // end of list marker, mj4simai must draw the sprite this covers for the company logo, title screen etc.
 				{
 					// HACK: however penbros has a dummy sprite entry there which points to 0x0000 as the tile source, and causes garbage with the rearranged format,
 					// so change it to something that's invalid where we can filter it later.  This strongly indicates that the current approach is incorrect however.
 					if (sprite == 0x00)
-					{
 						m_private_spriteram[i + 3] |= 0x4000;
-					}
 
 					break;
 				}
@@ -254,24 +267,24 @@ void seta2_state::vregs_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 		break;
 
 	case 0x3c: // Raster IRQ related
-		//logerror("%s: Register 3c write (raster enable?) current vpos is %d  :   %04X (%04x)\n",machine().describe_context(),m_screen->vpos(), data, mem_mask);
+		//LOGVREG("%s: Register 3c write (raster enable?) current vpos is %d  :   %04X (%04x)\n",machine().describe_context(),m_screen->vpos(), data, mem_mask);
 		COMBINE_DATA(&m_rasterenabled);
 
-		//if (m_rasterenabled & 1)
+		//if (BIT(m_rasterenabled, 0))
 		{
 			int hpos = 0;
-			int vpos = m_rasterposition;
+			const int vpos = m_rasterposition;
 
 			// in the vblank it specifies line 0, the first raster interrupt then specifies line 0 again before the subsequent ones use the real line numbers?
 			// It seems more likely that the raster IRQ stays asserted for the entire line, thus triggering a second interrupt unless the line number is changed?
 			if (m_rasterposition == m_screen->vpos()) hpos = m_screen->hpos() + 0x100;
-			//logerror("setting raster to %d %d\n", vpos, hpos);
+			//LOGVREG("setting raster to %d %d\n", vpos, hpos);
 			m_raster_timer->adjust(m_screen->time_until_pos(vpos, hpos), 0);
 		}
 		break;
 
 	case 0x3e: // Raster IRQ related
-		//logerror("%s: Register 3e write (raster position?) %04X (%04x)\n",machine().describe_context(),data, mem_mask);
+		//LOGVREG("%s: Register 3e write (raster position?) %04X (%04x)\n",machine().describe_context(),data, mem_mask);
 		COMBINE_DATA(&m_rasterposition);
 		break;
 	}
@@ -295,7 +308,7 @@ void seta2_state::spriteram_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 
 ***************************************************************************/
 
-inline void seta2_state::drawgfx_line(bitmap_ind16& bitmap, const rectangle& cliprect, int which_gfx, const uint8_t* const addr, const uint32_t realcolor, int flipx, int flipy, int base_sx, uint32_t xzoom, int use_shadow, int screenline, int line, int opaque)
+inline void seta2_state::drawgfx_line(bitmap_ind16& bitmap, const rectangle& cliprect, int which_gfx, const uint8_t* const addr, const uint32_t realcolor, bool flipx, bool flipy, int base_sx, uint32_t xzoom, bool use_shadow, int screenline, int line, bool opaque)
 {
 	struct drawmodes
 	{
@@ -317,21 +330,21 @@ inline void seta2_state::drawgfx_line(bitmap_ind16& bitmap, const rectangle& cli
 	};
 
 	int shadow = BPP_MASK_TABLE[(which_gfx & 0x0700) >> 8].shadow;
-	int gfx_mask = BPP_MASK_TABLE[(which_gfx & 0x0700) >> 8].gfx_mask;
-	int gfx_shift = BPP_MASK_TABLE[(which_gfx & 0x0700) >> 8].gfx_shift;
+	const int gfx_mask = BPP_MASK_TABLE[(which_gfx & 0x0700) >> 8].gfx_mask;
+	const int gfx_shift = BPP_MASK_TABLE[(which_gfx & 0x0700) >> 8].gfx_shift;
 
 	if (!use_shadow)
 		shadow = 0;
 
 	uint16_t *const dest = &bitmap.pix(screenline);
 
-	int minx = cliprect.min_x << 16;
-	int maxx = (cliprect.max_x + 1) << 16;
+	const int minx = cliprect.min_x << 16;
+	const int maxx = (cliprect.max_x + 1) << 16;
 
 	if (xzoom < 0x10000) // shrink
 	{
-		int x0 = flipx ? (base_sx + (8 * xzoom) - xzoom) : (base_sx);
-		int x1 = flipx ? (base_sx - xzoom) : (x0 + (8 * xzoom));
+		const int x0 = flipx ? (base_sx + (8 * xzoom) - xzoom) : (base_sx);
+		const int x1 = flipx ? (base_sx - xzoom) : (x0 + (8 * xzoom));
 		const int dx = flipx ? (-xzoom) : (xzoom);
 
 		const uint8_t* const source = flipy ? addr + (7 - line) * 8 : addr + line * 8;
@@ -339,23 +352,20 @@ inline void seta2_state::drawgfx_line(bitmap_ind16& bitmap, const rectangle& cli
 
 		for (int sx = x0; sx != x1; sx += dx)
 		{
-			uint8_t pen = (source[column++] & gfx_mask) >> gfx_shift;
-
+			const uint8_t pen = (source[column++] & gfx_mask) >> gfx_shift;
 
 			if (sx >= minx && sx < maxx)
 			{
-				int realsx = sx >> 16;
+				const int realsx = sx >> 16;
 
 				if (pen || opaque)
 				{
 					if (!shadow)
-					{
 						dest[realsx] = (realcolor + pen) & 0x7fff;
-					}
 					else
 					{
-						int pen_shift = 15 - shadow;
-						int pen_mask = (1 << pen_shift) - 1;
+						const int pen_shift = 15 - shadow;
+						const int pen_mask = (1 << pen_shift) - 1;
 						dest[realsx] = ((dest[realsx] & pen_mask) | (pen << pen_shift)) & 0x7fff;
 					}
 				}
@@ -366,38 +376,32 @@ inline void seta2_state::drawgfx_line(bitmap_ind16& bitmap, const rectangle& cli
 	{
 		const uint8_t* const source = flipy ? addr + (7 - line) * 8 : addr + line * 8;
 
-		int x0 = (base_sx);
-		int x1 = (x0 + (8 * xzoom));
+		const int x0 = (base_sx);
+		const int x1 = (x0 + (8 * xzoom));
 
 		int column;
 		if (!flipx)
-		{
 			column = 0;
-		}
 		else
-		{
 			column = 7;
-		}
 
 		uint32_t countx = 0;
 		for (int sx = x0; sx < x1; sx += 0x10000)
 		{
-			uint8_t pen = (source[column] & gfx_mask) >> gfx_shift;
+			const uint8_t pen = (source[column] & gfx_mask) >> gfx_shift;
 
 			if (sx >= minx && sx < maxx)
 			{
-				int realsx = sx >> 16;
+				const int realsx = sx >> 16;
 
 				if (pen || opaque)
 				{
 					if (!shadow)
-					{
 						dest[realsx] = (realcolor + pen) & 0x7fff;
-					}
 					else
 					{
-						int pen_shift = 15 - shadow;
-						int pen_mask = (1 << pen_shift) - 1;
+						const int pen_shift = 15 - shadow;
+						const int pen_mask = (1 << pen_shift) - 1;
 						dest[realsx] = ((dest[realsx] & pen_mask) | (pen << pen_shift)) & 0x7fff;
 					}
 				}
@@ -407,13 +411,9 @@ inline void seta2_state::drawgfx_line(bitmap_ind16& bitmap, const rectangle& cli
 			if (countx >= xzoom)
 			{
 				if (!flipx)
-				{
 					column++;
-				}
 				else
-				{
 					column--;
-				}
 
 				countx -= xzoom;
 			}
@@ -423,19 +423,19 @@ inline void seta2_state::drawgfx_line(bitmap_ind16& bitmap, const rectangle& cli
 
 
 // takes an x/y pixel position in the virtual tilemap and returns the code + attributes etc. for it
-inline void seta2_state::get_tile(uint16_t* spriteram, int is_16x16, int x, int y, int page, int& code, int& attr, int& flipx, int& flipy, int& color)
+inline void seta2_state::get_tile(uint16_t* spriteram, bool is_16x16, int x, int y, int page, int& code, int& attr, bool& flipx, bool& flipy, int& color)
 {
-	int xtile = x >> (is_16x16 ? 4 : 3);
+	const int xtile = x >> (is_16x16 ? 4 : 3);
 	int ytile = y >> (is_16x16 ? 4 : 3);
 
 	// yes the tilemap in RAM is flipped?!
 	ytile ^= 0x1f;
 
-	uint16_t *s3 = &spriteram[2 * ((page * 0x2000 / 4) + ((ytile & 0x1f) << 6) + ((xtile) & 0x03f))];
+	const uint16_t *s3 = &spriteram[2 * ((page * 0x2000 / 4) + ((ytile & 0x1f) << 6) + (xtile & 0x03f))];
 	attr = s3[0];
 	code = s3[1] + ((attr & 0x0007) << 16);
-	flipx = (attr & 0x0010);
-	flipy = (attr & 0x0008);
+	flipx = BIT(attr, 4);
+	flipy = BIT(attr, 3);
 	color = (attr & 0xffe0) >> 5;
 	if (is_16x16)
 	{
@@ -443,37 +443,29 @@ inline void seta2_state::get_tile(uint16_t* spriteram, int is_16x16, int x, int 
 
 		if (!flipx)
 		{
-			if (x & 8)
-			{
+			if (BIT(x, 3))
 				code += 1;
-			}
 		}
 		else
 		{
-			if (!(x & 8))
-			{
+			if (BIT(~x, 3))
 				code += 1;
-			}
 		}
 
 		if (!flipy)
 		{
-			if (y & 8)
-			{
+			if (BIT(y, 3))
 				code += 2;
-			}
 		}
 		else
 		{
-			if (!(y & 8))
-			{
+			if (BIT(~y, 3))
 				code += 2;
-			}
 		}
 	}
 }
 
-int seta2_state::calculate_global_xoffset(int nozoom_fixedpalette_fixedposition)
+int seta2_state::calculate_global_xoffset(bool nozoom_fixedpalette_fixedposition)
 {
 	/*
 	int global_xoffset = (m_vregs[0x12/2] & 0x7ff); // and 0x10/2 for low bits
@@ -501,7 +493,7 @@ int seta2_state::calculate_global_xoffset(int nozoom_fixedpalette_fixedposition)
 	return global_xoffset;
 }
 
-int seta2_state::calculate_global_yoffset(int nozoom_fixedpalette_fixedposition)
+int seta2_state::calculate_global_yoffset(bool nozoom_fixedpalette_fixedposition)
 {
 	// Sprites list
 	//int global_yoffset = (m_vregs[0x1a / 2] & 0x7ff); // and 0x18/2 for low bits
@@ -520,51 +512,46 @@ int seta2_state::calculate_global_yoffset(int nozoom_fixedpalette_fixedposition)
 
 void seta2_state::draw_sprites_line(bitmap_ind16 &bitmap, const rectangle &cliprect, int scanline, int realscanline, int xoffset, uint32_t xzoom, bool xzoominverted)
 {
-	uint16_t* spriteram = m_spriteram;
-
-	uint16_t *s1 = m_private_spriteram.get();
+	const uint16_t *s1 = m_private_spriteram.get();
 
 	int sprite_debug_count = 0;
 
-	for (; s1 < &m_private_spriteram[0x1000 / 2]; s1 += 4,sprite_debug_count++)
+	for (; s1 < &m_private_spriteram[0x1000 / 2]; s1 += 4, sprite_debug_count++)
 	{
 		int num = s1[0];
 
 		int xoffs = s1[1];
 		int yoffs = s1[2];
-		int sprite = s1[3];
+		const int sprite = s1[3];
 
 		// Single-sprite address
-		uint16_t *s2 = &spriteram[(sprite & 0x7fff) * 4];
-		uint16_t *end = &spriteram[m_spriteram.bytes() / 2];
+		const uint16_t *s2 = &m_spriteram[(sprite & 0x7fff) * 4];
+		const uint16_t *end = &m_spriteram[m_spriteram.bytes() / 2];
 
 		// Single-sprite size
-		int global_sizex = xoffs & 0xfc00;
-		int global_sizey = yoffs & 0xfc00;
+		const int global_sizex = xoffs & 0xfc00;
+		const int global_sizey = yoffs & 0xfc00;
 
-
-		int nozoom_fixedpalette_fixedposition = num & 0x4000; // ignore various things including global offsets, zoom.  different palette selection too?
-		bool opaque = num & 0x2000;
-		int use_global_size = num & 0x1000;
-		int use_shadow = num & 0x0800;
-		int which_gfx = num & 0x0700;
+		const bool nozoom_fixedpalette_fixedposition = BIT(num, 14); // ignore various things including global offsets, zoom.  different palette selection too?
+		const bool opaque = BIT(num, 13);
+		const bool use_global_size = BIT(num, 12);
+		bool use_shadow = BIT(num, 11);
+		const int which_gfx = num & 0x0700;
 		xoffs &= 0x3ff;
 		yoffs &= 0x3ff;
-
-
 
 		if (yoffs & 0x200)
 			yoffs -= 0x400;
 
-		int global_xoffset = calculate_global_xoffset(nozoom_fixedpalette_fixedposition);
-		int global_yoffset = calculate_global_yoffset(nozoom_fixedpalette_fixedposition);
+		const int global_xoffset = calculate_global_xoffset(nozoom_fixedpalette_fixedposition);
+		const int global_yoffset = calculate_global_yoffset(nozoom_fixedpalette_fixedposition);
 		int usedscanline;
 		int usedxoffset;
 		uint32_t usedxzoom;
 
 		if (nozoom_fixedpalette_fixedposition)
 		{
-			use_shadow = 0;
+			use_shadow = false;
 			//which_gfx = 4 << 8;
 			usedscanline = realscanline; // no zooming?
 			usedxzoom = 0x10000;
@@ -581,15 +568,14 @@ void seta2_state::draw_sprites_line(bitmap_ind16 &bitmap, const rectangle &clipr
 		num = (num & 0x00ff) + 1;
 
 		// all sprites, except invalid ones should have a pointer <0x3000 in the reformatted list
-		if ((sprite&0x7fff) < 0x3000 / 2 / 4)
+		if ((sprite & 0x7fff) < 0x3000 / 2 / 4)
 		{
 			for (; num > 0; num--, s2 += 4)
 			{
 				if (s2 >= end)  break;
 
-				if (sprite & 0x8000)
+				if (BIT(sprite, 15))
 				{
-
 					// "floating tilemap" sprite
 					// the 'floating tilemap sprites' are just a window into the tilemap, the position of the sprite does not change the scroll values
 
@@ -600,7 +586,7 @@ void seta2_state::draw_sprites_line(bitmap_ind16 &bitmap, const rectangle &clipr
 					if (sy & 0x200)
 						sy -= 0x400;
 
-					int local_sizey = s2[1] & 0xfc00;
+					const int local_sizey = s2[1] & 0xfc00;
 
 					int height = use_global_size ? global_sizey : local_sizey;
 					height = ((height & 0xfc00) >> 10) + 1;
@@ -631,7 +617,7 @@ void seta2_state::draw_sprites_line(bitmap_ind16 &bitmap, const rectangle &clipr
 
 					// get everything we need to calculate if sprite is actually within the x co-ordinates of the screen
 					int sx = s2[0];
-					int local_sizex = sx & 0xfc00;
+					const int local_sizex = sx & 0xfc00;
 					sx &= 0x3ff;
 					sx -= global_xoffset;
 
@@ -642,41 +628,41 @@ void seta2_state::draw_sprites_line(bitmap_ind16 &bitmap, const rectangle &clipr
 
 					int firstcolumn = (sx + xoffs);
 					firstcolumn = (firstcolumn & 0x1ff) - (firstcolumn & 0x200);
-					int lastcolumn = firstcolumn + width * 0x10 - 1;
+					const int lastcolumn = firstcolumn + width * 0x10 - 1;
 
 					// if the sprite isn't within the x-coordinates of the screen, bail
 					if (firstcolumn > cliprect.max_x)    continue;
 					if (lastcolumn < cliprect.min_x)    continue;
 
-
 					// otherwise get the rest of the things we need to draw
 					int scrolly = s2[3];
 					scrolly &= 0x1ff;
 					scrolly += global_yoffset;
-					int sourceline = (usedscanline - scrolly) & 0x1ff;
+					const int sourceline = (usedscanline - scrolly) & 0x1ff;
 
 					int scrollx = s2[2];
-					int is_16x16 = (scrollx & 0x8000) >> 15;
-					int page = (scrollx & 0x7c00) >> 10;
+					const bool is_16x16 = BIT(scrollx, 15);
+					const int page = (scrollx & 0x7c00) >> 10;
 					scrollx &= 0x3ff;
 
 					// we treat 16x16 tiles as 4 8x8 tiles, so while the tilemap is 0x40 tiles wide in memory, that becomes 0x80 tiles in 16x16 mode, with the data wrapping in 8x8 mode
 					for (int x = 0; x < 0x80; x++)
 					{
-						int code, attr, flipx, flipy, color;
+						int code, attr, color;
+						bool flipx, flipy;
 						// tilemap data is NOT buffered?
-						get_tile(spriteram, is_16x16, x * 8, sourceline, page, code, attr, flipx, flipy, color);
+						get_tile(m_spriteram, is_16x16, x * 8, sourceline, page, code, attr, flipx, flipy, color);
 
-						int tileline = sourceline & 0x07;
-						int dx = sx + (scrollx & 0x3ff) + xoffs + 0x10;
-						int px = (((dx + x * 8) + 0x10) & 0x3ff) - 0x10;
+						const int tileline = sourceline & 0x07;
+						const int dx = sx + (scrollx & 0x3ff) + xoffs + 0x10;
+						const int px = (((dx + x * 8) + 0x10) & 0x3ff) - 0x10;
 						int dst_x = px & 0x3ff;
 						dst_x = (dst_x & 0x1ff) - (dst_x & 0x200);
 
 						if ((dst_x >= firstcolumn - 8) && (dst_x <= lastcolumn)) // reelnquak reels are heavily glitched without this check
 						{
 							uint32_t realsx = dst_x;
-							realsx -= usedxoffset>>16; // need to refactor, this causes loss of lower 16 bits of offset which are important in zoomed cases for precision
+							realsx -= usedxoffset >> 16; // need to refactor, this causes loss of lower 16 bits of offset which are important in zoomed cases for precision
 							realsx = realsx * usedxzoom;
 							drawgfx_line(bitmap, cliprect, which_gfx, m_spritegfx->get_data(m_realtilenumber[code]), color << 4, flipx, flipy, realsx, usedxzoom, use_shadow, realscanline, tileline, opaque);
 						}
@@ -693,10 +679,9 @@ void seta2_state::draw_sprites_line(bitmap_ind16 &bitmap, const rectangle &clipr
 					sy += global_yoffset;
 					sy &= 0x3ff;
 
-
 					if (realscanline == 128)
 					{
-					//  printf("%04x %02x %d %d\n", sprite_debug_count, num, yoffs, sy);
+						//LOGSPRITE("%04x %02x %d %d\n", sprite_debug_count, num, yoffs, sy);
 					}
 
 					int sizey = use_global_size ? global_sizey : s2[1] & 0xfc00;
@@ -715,7 +700,6 @@ void seta2_state::draw_sprites_line(bitmap_ind16 &bitmap, const rectangle &clipr
 					if (endline & 0x200)
 						endline -= 0x400;
 
-
 					// if the sprite doesn't cover this scanline, bail now
 					if (endline >= firstline)
 					{
@@ -730,10 +714,10 @@ void seta2_state::draw_sprites_line(bitmap_ind16 &bitmap, const rectangle &clipr
 					}
 
 					// otherwise get the rest of the things we need to draw
-					int attr = s2[2];
+					const int attr = s2[2];
 					int code = s2[3] + ((attr & 0x0007) << 16);
-					int flipx = (attr & 0x0010);
-					int flipy = (attr & 0x0008);
+					const bool flipx = BIT(attr, 4);
+					const bool flipy = BIT(attr, 3);
 					int color = (attr & 0xffe0) >> 5;
 
 					int sx = s2[0];
@@ -744,11 +728,10 @@ void seta2_state::draw_sprites_line(bitmap_ind16 &bitmap, const rectangle &clipr
 					sx = (sx & 0x1ff) - (sx & 0x200);
 					sx -= global_xoffset;
 
-					int basecode = code &= ~((sizex + 1) * (sizey + 1) - 1);   // see myangel, myangel2 and grdians
-
+					const int basecode = code &= ~((sizex + 1) * (sizey + 1) - 1);   // see myangel, myangel2 and grdians
 
 					int line = usedscanline - firstline;
-					int y = (line >> 3);
+					const int y = (line >> 3);
 					line &= 0x7;
 
 					if (nozoom_fixedpalette_fixedposition)
@@ -759,9 +742,9 @@ void seta2_state::draw_sprites_line(bitmap_ind16 &bitmap, const rectangle &clipr
 
 					for (int x = 0; x <= sizex; x++)
 					{
-						int realcode = (basecode + (flipy ? sizey - y : y)*(sizex + 1)) + (flipx ? sizex - x : x);
+						const int realcode = (basecode + (flipy ? sizey - y : y)*(sizex + 1)) + (flipx ? sizex - x : x);
 						uint32_t realsx = (sx + x * 8);
-						realsx -= usedxoffset>>16; // need to refactor, this causes loss of lower 16 bits of offset which are important in zoomed cases for precision
+						realsx -= usedxoffset >> 16; // need to refactor, this causes loss of lower 16 bits of offset which are important in zoomed cases for precision
 						realsx = realsx * usedxzoom;
 						drawgfx_line(bitmap, cliprect, which_gfx, m_spritegfx->get_data(m_realtilenumber[realcode]), color << 4, flipx, flipy, realsx, usedxzoom, use_shadow, realscanline, line, opaque);
 					}
@@ -769,7 +752,7 @@ void seta2_state::draw_sprites_line(bitmap_ind16 &bitmap, const rectangle &clipr
 				}
 			}
 		}
-		if (s1[0] & 0x8000) break;  // end of list marker
+		if (BIT(s1[0], 15)) break;  // end of list marker
 	}   // sprite list
 }
 
@@ -779,10 +762,10 @@ TIMER_CALLBACK_MEMBER(seta2_state::raster_timer_done)
 	auto *tmp68301 = dynamic_cast<tmp68301_device *>(m_maincpu.target());
 	if (tmp68301)
 	{
-		if (m_rasterenabled & 1)
+		if (BIT(m_rasterenabled, 0))
 		{
 			tmp68301->set_input_line(1, HOLD_LINE);
-			logerror("external int (vpos is %d)\n", m_screen->vpos());
+			LOGVIDEO("external int (vpos is %d)\n", m_screen->vpos());
 			m_screen->update_partial(m_screen->vpos() - 1);
 		}
 	}
@@ -791,7 +774,7 @@ TIMER_CALLBACK_MEMBER(seta2_state::raster_timer_done)
 
 void seta2_state::draw_sprites(bitmap_ind16& bitmap, const rectangle& cliprect)
 {
-	//printf("yoffset: %04x%04x yzoom: %04x%04x | xoffset: %04x%04x xzoom: %04x%04x  \n", m_vregs[0x1a/2],  m_vregs[0x18/2],  m_vregs[0x1e/2],  m_vregs[0x1c/2]   ,   m_vregs[0x12/2],  m_vregs[0x10/2],  m_vregs[0x16/2],  m_vregs[0x14/2]);
+	//LOGOFFSET("yoffset: %04x%04x yzoom: %04x%04x | xoffset: %04x%04x xzoom: %04x%04x  \n", m_vregs[0x1a/2],  m_vregs[0x18/2],  m_vregs[0x1e/2],  m_vregs[0x1c/2]   ,   m_vregs[0x12/2],  m_vregs[0x10/2],  m_vregs[0x16/2],  m_vregs[0x14/2]);
 
 	uint32_t yoffset = (m_vregs[0x1a / 2] << 16) | m_vregs[0x18 / 2];
 	yoffset &= 0x07ffffff;
@@ -807,7 +790,6 @@ void seta2_state::draw_sprites(bitmap_ind16& bitmap, const rectangle& cliprect)
 		yzoom = 0x8000000 - yzoom;
 		yzoominverted = true;
 	}
-
 
 	int xoffset = (m_vregs[0x12 / 2] << 16) | m_vregs[0x10 / 2];
 	xoffset &= 0x07ffffff;
@@ -825,15 +807,14 @@ void seta2_state::draw_sprites(bitmap_ind16& bitmap, const rectangle& cliprect)
 		xzoominverted = true;
 	}
 
-
 	if (!xzoom)
 		return;
 
-	uint64_t inc = 0x100000000ULL;
+	const uint64_t inc = 0x100000000ULL;
 
-	uint32_t inc2 = inc / xzoom;
+	const uint32_t inc2 = inc / xzoom;
 
-	//printf("xinc is %04x xoom %04x xoffset is %4x\n", inc2, xzoom, xoffset);
+	//LOGOFFSET("xinc is %04x xoom %04x xoffset is %4x\n", inc2, xzoom, xoffset);
 
 	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{
@@ -844,9 +825,7 @@ void seta2_state::draw_sprites(bitmap_ind16& bitmap, const rectangle& cliprect)
 		int yy;
 
 		if (!yzoominverted)
-		{
 			yy = y; // not handled yet (this is using negative yzoom to do flipscreen...)
-		}
 		else
 		{
 			yy = y * yzoom;
@@ -854,11 +833,10 @@ void seta2_state::draw_sprites(bitmap_ind16& bitmap, const rectangle& cliprect)
 			yy &= 0x07ffffff;
 			yy >>= 16;
 
-			//printf("line %04x yline requested %04x\n", y, yy);
+			//LOGOFFSET("line %04x yline requested %04x\n", y, yy);
 
 			if (yy & 0x400)
 				yy -= 0x800;
-
 		}
 
 		draw_sprites_line(bitmap, tempcliprect, yy, y, xoffset, inc2, xzoominverted);
@@ -885,9 +863,7 @@ void seta2_state::video_start()
 
 	m_spritegfx = m_gfxdecode->gfx(0);
 	for (int i = 0; i < 0x80000; i++)
-	{
 		m_realtilenumber[i] = i % m_spritegfx->elements();
-	}
 
 	m_raster_timer = timer_alloc(FUNC(seta2_state::raster_timer_done), this);
 
@@ -899,7 +875,7 @@ uint32_t seta2_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap,
 	// Black or pen 0?
 	bitmap.fill(m_palette->pen(0), cliprect);
 
-	if ((m_vregs[0x30/2] & 1) == 0)   // 1 = BLANK SCREEN
+	if (BIT(~m_vregs[0x30/2], 0))   // 1 = BLANK SCREEN
 		draw_sprites(bitmap, cliprect);
 
 	return 0;
@@ -907,7 +883,7 @@ uint32_t seta2_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap,
 
 void seta2_state::screen_vblank(int state)
 {
-	//popmessage("yoffset: %04x%04x yzoom: %04x%04x | xoffset: %04x%04x xzoom: %04x%04x  \n", m_vregs[0x1a/2],  m_vregs[0x18/2],  m_vregs[0x1e/2],  m_vregs[0x1c/2]   ,   m_vregs[0x12/2],  m_vregs[0x10/2],  m_vregs[0x16/2],  m_vregs[0x14/2]);
+	//LOGVIDEO("yoffset: %04x%04x yzoom: %04x%04x | xoffset: %04x%04x xzoom: %04x%04x  \n", m_vregs[0x1a/2], m_vregs[0x18/2], m_vregs[0x1e/2], m_vregs[0x1c/2], m_vregs[0x12/2], m_vregs[0x10/2], m_vregs[0x16/2], m_vregs[0x14/2]);
 }
 
 // staraudi
@@ -920,12 +896,13 @@ void staraudi_state::draw_rgbram(bitmap_ind16 &bitmap)
 	{
 		for (int x = 0; x < 0x200; ++x)
 		{
-			int offs = x * 2/2 + y * 0x400/2;
-			uint32_t data = ((m_rgbram[offs + 0x40000/2] & 0xff) << 16) | m_rgbram[offs];
+			const int offs = x * 2/2 + y * 0x400/2;
+			const uint32_t data = ((m_rgbram[offs + 0x40000/2] & 0xff) << 16) | m_rgbram[offs];
 			bitmap.pix(y, x) = (data & 0x7fff);
 		}
 	}
 }
+
 uint32_t staraudi_state::staraudi_screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen_update(screen, bitmap, cliprect);

--- a/src/mame/seta/seta2_v.cpp
+++ b/src/mame/seta/seta2_v.cpp
@@ -397,7 +397,9 @@ inline void seta2_state::drawgfx_line(bitmap_ind16& bitmap, const rectangle& cli
 				if (pen || opaque)
 				{
 					if (!shadow)
+					{
 						dest[realsx] = (realcolor + pen) & 0x7fff;
+					}
 					else
 					{
 						const int pen_shift = 15 - shadow;
@@ -423,7 +425,16 @@ inline void seta2_state::drawgfx_line(bitmap_ind16& bitmap, const rectangle& cli
 
 
 // takes an x/y pixel position in the virtual tilemap and returns the code + attributes etc. for it
-inline void seta2_state::get_tile(uint16_t* spriteram, bool is_16x16, int x, int y, int page, int& code, int& attr, bool& flipx, bool& flipy, int& color)
+inline void seta2_state::get_tile(
+		uint16_t *spriteram,
+		bool is_16x16,
+		int x,
+		int y, int page,
+		int &code,
+		int &attr,
+		bool &flipx,
+		bool &flipy,
+		int &color)
 {
 	const int xtile = x >> (is_16x16 ? 4 : 3);
 	int ytile = y >> (is_16x16 ? 4 : 3);
@@ -431,7 +442,7 @@ inline void seta2_state::get_tile(uint16_t* spriteram, bool is_16x16, int x, int
 	// yes the tilemap in RAM is flipped?!
 	ytile ^= 0x1f;
 
-	const uint16_t *s3 = &spriteram[2 * ((page * 0x2000 / 4) + ((ytile & 0x1f) << 6) + (xtile & 0x03f))];
+	uint16_t const *const s3 = &spriteram[2 * ((page * 0x2000 / 4) + ((ytile & 0x1f) << 6) + (xtile & 0x03f))];
 	attr = s3[0];
 	code = s3[1] + ((attr & 0x0007) << 16);
 	flipx = BIT(attr, 4);
@@ -525,8 +536,8 @@ void seta2_state::draw_sprites_line(bitmap_ind16 &bitmap, const rectangle &clipr
 		const int sprite = s1[3];
 
 		// Single-sprite address
-		const uint16_t *s2 = &m_spriteram[(sprite & 0x7fff) * 4];
-		const uint16_t *end = &m_spriteram[m_spriteram.bytes() / 2];
+		uint16_t const *s2 = &m_spriteram[(sprite & 0x7fff) * 4];
+		uint16_t const *const end = &m_spriteram[m_spriteram.bytes() / 2];
 
 		// Single-sprite size
 		const int global_sizex = xoffs & 0xfc00;
@@ -703,8 +714,8 @@ void seta2_state::draw_sprites_line(bitmap_ind16 &bitmap, const rectangle &clipr
 					// if the sprite doesn't cover this scanline, bail now
 					if (endline >= firstline)
 					{
-						if (firstline > usedscanline)    continue;
-						if (endline < usedscanline)    continue;
+						if ((firstline > usedscanline) || (endline < usedscanline))
+							continue;
 					}
 					else
 					{


### PR DESCRIPTION
- Use logmacro for logging functions
- Reduce runtime tag lookups
- Move mj4simai specific stuffs into mj4simai_state class
- Constantize variables
- Fix spacing
- Use correct typename values
- Reduce unnecessary lines
- Reduce duplicates
- Reduce literal tag usages
- Suppress side effects for debugger reads
- Reduce preprocessor defines
- USe C++ style comments for single line comments
- Fix initialization