### PR TITLE
konami/konamigv, konami/konamigq, konami/twinkle: Adjust DMA timings

### DIFF
--- a/src/mame/konami/konamigq.cpp
+++ b/src/mame/konami/konamigq.cpp
@@ -287,7 +287,7 @@ void konamigq_state::scsi_dma_read( uint32_t *p_n_psxram, uint32_t n_address, in
 	m_dma_offset = n_address;
 	m_dma_size = n_size * 4;
 	m_dma_is_write = false;
-	m_dma_timer->adjust(attotime::from_usec(10));
+	m_dma_timer->adjust(attotime::zero);
 }
 
 void konamigq_state::scsi_dma_write( uint32_t *p_n_psxram, uint32_t n_address, int32_t n_size )
@@ -296,7 +296,7 @@ void konamigq_state::scsi_dma_write( uint32_t *p_n_psxram, uint32_t n_address, i
 	m_dma_offset = n_address;
 	m_dma_size = n_size * 4;
 	m_dma_is_write = true;
-	m_dma_timer->adjust(attotime::from_usec(10));
+	m_dma_timer->adjust(attotime::zero);
 }
 
 TIMER_CALLBACK_MEMBER(konamigq_state::scsi_dma_transfer)
@@ -313,13 +313,13 @@ TIMER_CALLBACK_MEMBER(konamigq_state::scsi_dma_transfer)
 	}
 
 	if (m_dma_requested && m_dma_size > 0)
-		m_dma_timer->adjust(attotime::from_usec(10));
+		m_dma_timer->adjust(attotime::zero);
 }
 
 void konamigq_state::scsi_drq(int state)
 {
 	if (!m_dma_requested && state)
-		m_dma_timer->adjust(attotime::from_usec(10));
+		m_dma_timer->adjust(attotime::zero);
 
 	m_dma_requested = state;
 }

--- a/src/mame/konami/konamigq.cpp
+++ b/src/mame/konami/konamigq.cpp
@@ -301,7 +301,8 @@ void konamigq_state::scsi_dma_write( uint32_t *p_n_psxram, uint32_t n_address, i
 
 TIMER_CALLBACK_MEMBER(konamigq_state::scsi_dma_transfer)
 {
-	if (m_dma_requested && m_dma_data_ptr != nullptr && m_dma_size > 0)
+	// TODO: Figure out proper DMA timings
+	while (m_dma_requested && m_dma_data_ptr != nullptr && m_dma_size > 0)
 	{
 		if (m_dma_is_write)
 			m_ncr53cf96->dma_w(util::little_endian_cast<const uint8_t>(m_dma_data_ptr)[m_dma_offset]);
@@ -311,9 +312,6 @@ TIMER_CALLBACK_MEMBER(konamigq_state::scsi_dma_transfer)
 		m_dma_offset++;
 		m_dma_size--;
 	}
-
-	if (m_dma_requested && m_dma_size > 0)
-		m_dma_timer->adjust(attotime::zero);
 }
 
 void konamigq_state::scsi_drq(int state)

--- a/src/mame/konami/konamigv.cpp
+++ b/src/mame/konami/konamigv.cpp
@@ -455,7 +455,7 @@ void konamigv_state::scsi_dma_read(uint32_t *p_n_psxram, uint32_t n_address, int
 	m_dma_offset = n_address;
 	m_dma_size = n_size * 4;
 	m_dma_is_write = false;
-	m_dma_timer->adjust(attotime::from_usec(10));
+	m_dma_timer->adjust(attotime::zero);
 }
 
 void konamigv_state::scsi_dma_write(uint32_t *p_n_psxram, uint32_t n_address, int32_t n_size)
@@ -464,7 +464,7 @@ void konamigv_state::scsi_dma_write(uint32_t *p_n_psxram, uint32_t n_address, in
 	m_dma_offset = n_address;
 	m_dma_size = n_size * 4;
 	m_dma_is_write = true;
-	m_dma_timer->adjust(attotime::from_usec(10));
+	m_dma_timer->adjust(attotime::zero);
 }
 
 TIMER_CALLBACK_MEMBER(konamigv_state::scsi_dma_transfer)
@@ -481,13 +481,13 @@ TIMER_CALLBACK_MEMBER(konamigv_state::scsi_dma_transfer)
 	}
 
 	if (m_dma_requested && m_dma_size > 0)
-		m_dma_timer->adjust(attotime::from_usec(10));
+		m_dma_timer->adjust(attotime::zero);
 }
 
 void konamigv_state::scsi_drq(int state)
 {
 	if (!m_dma_requested && state)
-		m_dma_timer->adjust(attotime::from_usec(10));
+		m_dma_timer->adjust(attotime::zero);
 
 	m_dma_requested = state;
 }

--- a/src/mame/konami/konamigv.cpp
+++ b/src/mame/konami/konamigv.cpp
@@ -469,7 +469,8 @@ void konamigv_state::scsi_dma_write(uint32_t *p_n_psxram, uint32_t n_address, in
 
 TIMER_CALLBACK_MEMBER(konamigv_state::scsi_dma_transfer)
 {
-	if (m_dma_requested && m_dma_data_ptr != nullptr && m_dma_size > 0)
+	// TODO: Figure out proper DMA timings
+	while (m_dma_requested && m_dma_data_ptr != nullptr && m_dma_size > 0)
 	{
 		if (m_dma_is_write)
 			m_ncr53cf96->dma_w(util::little_endian_cast<const uint8_t>(m_dma_data_ptr)[m_dma_offset]);
@@ -479,9 +480,6 @@ TIMER_CALLBACK_MEMBER(konamigv_state::scsi_dma_transfer)
 		m_dma_offset++;
 		m_dma_size--;
 	}
-
-	if (m_dma_requested && m_dma_size > 0)
-		m_dma_timer->adjust(attotime::zero);
 }
 
 void konamigv_state::scsi_drq(int state)

--- a/src/mame/konami/twinkle.cpp
+++ b/src/mame/konami/twinkle.cpp
@@ -1088,7 +1088,7 @@ void twinkle_state::scsi_dma_read(uint32_t *p_n_psxram, uint32_t n_address, int3
 	m_dma_offset = n_address;
 	m_dma_size = n_size * 4;
 	m_dma_is_write = false;
-	m_dma_timer->adjust(attotime::from_usec(10));
+	m_dma_timer->adjust(attotime::zero);
 }
 
 void twinkle_state::scsi_dma_write(uint32_t *p_n_psxram, uint32_t n_address, int32_t n_size)
@@ -1097,7 +1097,7 @@ void twinkle_state::scsi_dma_write(uint32_t *p_n_psxram, uint32_t n_address, int
 	m_dma_offset = n_address;
 	m_dma_size = n_size * 4;
 	m_dma_is_write = true;
-	m_dma_timer->adjust(attotime::from_usec(10));
+	m_dma_timer->adjust(attotime::zero);
 }
 
 TIMER_CALLBACK_MEMBER(twinkle_state::scsi_dma_transfer)
@@ -1114,13 +1114,13 @@ TIMER_CALLBACK_MEMBER(twinkle_state::scsi_dma_transfer)
 	}
 
 	if (m_dma_requested && m_dma_size > 0)
-		m_dma_timer->adjust(attotime::from_usec(10));
+		m_dma_timer->adjust(attotime::zero);
 }
 
 void twinkle_state::scsi_drq(int state)
 {
 	if (!m_dma_requested && state)
-		m_dma_timer->adjust(attotime::from_usec(10));
+		m_dma_timer->adjust(attotime::zero);
 
 	m_dma_requested = state;
 }

--- a/src/mame/konami/twinkle.cpp
+++ b/src/mame/konami/twinkle.cpp
@@ -1102,7 +1102,8 @@ void twinkle_state::scsi_dma_write(uint32_t *p_n_psxram, uint32_t n_address, int
 
 TIMER_CALLBACK_MEMBER(twinkle_state::scsi_dma_transfer)
 {
-	if (m_dma_requested && m_dma_data_ptr != nullptr && m_dma_size > 0)
+	// TODO: Figure out proper DMA timings
+	while (m_dma_requested && m_dma_data_ptr != nullptr && m_dma_size > 0)
 	{
 		if (m_dma_is_write)
 			m_ncr53cf96->dma_w(util::little_endian_cast<const uint8_t>(m_dma_data_ptr)[m_dma_offset]);
@@ -1112,9 +1113,6 @@ TIMER_CALLBACK_MEMBER(twinkle_state::scsi_dma_transfer)
 		m_dma_offset++;
 		m_dma_size--;
 	}
-
-	if (m_dma_requested && m_dma_size > 0)
-		m_dma_timer->adjust(attotime::zero);
 }
 
 void twinkle_state::scsi_drq(int state)


### PR DESCRIPTION
The 10usec delay per bytes is too slow and causing issues with games, so this should bring load speeds back closer to what it was with the old code. Should also fix https://mametesters.org/view.php?id=8860.

Previous related commits:
https://github.com/mamedev/mame/commit/a6a81a692955a8abfd41db832ec33cd64fe9323e
https://github.com/mamedev/mame/commit/cb8b90cd389ca928ffade1d8384893fdde87d4d1