### PR TITLE
hiscore: gnw_dkjr: Donkey Kong Jr (New Wide Screen)

### DIFF
--- a/plugins/hiscore/hiscore.dat
+++ b/plugins/hiscore/hiscore.dat
@@ -18865,4 +18865,13 @@ jackrabts:
 @:maincpu,program,60de,1,ff,ff
 @:maincpu,program,60fe,1,ff,ff
 
+; --------------------
+; Game & Watch (gnw_*)
+; --------------------
 
+;Donkey Kong Jr (New Wide Screen)
+gnw_dkjr:
+; game B
+@:maincpu,data,11,6,0,0
+; game A
+@:maincpu,data,51,6,0,0


### PR DESCRIPTION
Support for saving hi scores (game A and B) for Game & Watch Donkey Kong Jr. using hiscore plugin.

Tested in Batocera Linux v39 (MAME v0.261)

EDIT: this is my first contribution - I read the documentation and could get more input as to the best way to add other Game & Watch driver updates to hiscore.dat as I complete & validate them.  Should I just keep adding commits to this branch until it is merged (what I’m planning to do as I don’t expect this pull request to be processed immediately) or create separate pull requests?