### PR TITLE
shared/decospr.cpp: Use device_gfx_interface for gfx decode functions, Cleanups:

### DIFF
--- a/src/mame/dataeast/backfire.cpp
+++ b/src/mame/dataeast/backfire.cpp
@@ -13,15 +13,17 @@
 */
 
 #include "emu.h"
-#include "machine/adc0808.h"
-#include "decocrpt.h"
 #include "deco156_m.h"
+#include "deco16ic.h"
+#include "decocrpt.h"
+#include "decospr.h"
+
+#include "cpu/arm/arm.h"
+#include "machine/adc0808.h"
 #include "machine/eepromser.h"
 #include "sound/okim6295.h"
 #include "sound/ymz280b.h"
-#include "cpu/arm/arm.h"
-#include "deco16ic.h"
-#include "decospr.h"
+
 #include "emupal.h"
 #include "layout/generic.h"
 #include "screen.h"

--- a/src/mame/dataeast/backfire.cpp
+++ b/src/mame/dataeast/backfire.cpp
@@ -35,6 +35,8 @@ class backfire_state : public driver_device
 public:
 	backfire_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
+		m_spriteram(*this, "spriteram%u", 1U, 0x1000U, ENDIANNESS_LITTLE),
+		m_pf_rowscroll(*this, "pf%u_rowscroll", 1U, 0x800U, ENDIANNESS_LITTLE),
 		m_mainram(*this, "mainram"),
 		m_left_priority(*this, "left_priority"),
 		m_right_priority(*this, "right_priority"),
@@ -59,8 +61,6 @@ private:
 	uint32_t backfire_speedup_r();
 	void eeprom_w(uint8_t data);
 	uint32_t pot_select_r(offs_t offset);
-	virtual void machine_start() override;
-	virtual void video_start() override;
 	uint32_t screen_update_left(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_right(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void vbl_interrupt(int state);
@@ -72,8 +72,8 @@ private:
 	void backfire_map(address_map &map);
 
 	/* memory pointers */
-	std::unique_ptr<uint16_t[]>  m_spriteram[2];
-	std::unique_ptr<uint16_t[]>  m_pf_rowscroll[4];
+	memory_share_array_creator<uint16_t, 2> m_spriteram;
+	memory_share_array_creator<uint16_t, 4> m_pf_rowscroll;
 	required_shared_ptr<uint32_t> m_mainram;
 	required_shared_ptr<uint32_t> m_left_priority;
 	required_shared_ptr<uint32_t> m_right_priority;
@@ -92,38 +92,16 @@ private:
 
 //uint32_t *backfire_180010, *backfire_188010;
 
-/* I'm using the functions in deco16ic.c ... same chips, why duplicate code? */
-void backfire_state::video_start()
-{
-	m_spriteram[0] = std::make_unique<uint16_t[]>(0x2000/4);
-	m_spriteram[1] = std::make_unique<uint16_t[]>(0x2000/4);
-
-	/* and register the allocated ram so that save states still work */
-	m_pf_rowscroll[0] = std::make_unique<uint16_t[]>(0x1000/4);
-	m_pf_rowscroll[1] = std::make_unique<uint16_t[]>(0x1000/4);
-	m_pf_rowscroll[2] = std::make_unique<uint16_t[]>(0x1000/4);
-	m_pf_rowscroll[3] = std::make_unique<uint16_t[]>(0x1000/4);
-
-	save_pointer(NAME(m_spriteram[0]), 0x2000/4);
-	save_pointer(NAME(m_spriteram[1]), 0x2000/4);
-
-	save_pointer(NAME(m_pf_rowscroll[0]), 0x1000/4);
-	save_pointer(NAME(m_pf_rowscroll[1]), 0x1000/4);
-	save_pointer(NAME(m_pf_rowscroll[2]), 0x1000/4);
-	save_pointer(NAME(m_pf_rowscroll[3]), 0x1000/4);
-}
-
-
 
 uint32_t backfire_state::screen_update_left(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	// sprites are flipped relative to tilemaps
 	m_sprgen[0]->set_flip_screen(true);
 
-	/* screen 1 uses pf1 as the forground and pf3 as the background */
+	/* screen 1 uses pf1 as the foreground and pf3 as the background */
 	/* screen 2 uses pf2 as the foreground and pf4 as the background */
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0].get(), m_pf_rowscroll[1].get());
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2].get(), m_pf_rowscroll[3].get());
+	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
+	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2], m_pf_rowscroll[3]);
 
 	screen.priority().fill(0);
 	bitmap.fill(0x100, cliprect);
@@ -132,13 +110,13 @@ uint32_t backfire_state::screen_update_left(screen_device &screen, bitmap_ind16 
 	{
 		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 1);
 		m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
-		m_sprgen[0]->draw_sprites(bitmap, cliprect, m_spriteram[0].get(), 0x2000/4);
+		m_sprgen[0]->draw_sprites(bitmap, cliprect, m_spriteram[0], 0x2000/4);
 	}
 	else if (m_left_priority[0] == 2)
 	{
 		m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
 		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
-		m_sprgen[0]->draw_sprites(bitmap, cliprect, m_spriteram[0].get(), 0x2000/4);
+		m_sprgen[0]->draw_sprites(bitmap, cliprect, m_spriteram[0], 0x2000/4);
 	}
 	else
 		popmessage( "unknown left priority %08x", m_left_priority[0]);
@@ -151,10 +129,10 @@ uint32_t backfire_state::screen_update_right(screen_device &screen, bitmap_ind16
 	// sprites are flipped relative to tilemaps
 	m_sprgen[1]->set_flip_screen(true);
 
-	/* screen 1 uses pf1 as the forground and pf3 as the background */
+	/* screen 1 uses pf1 as the foreground and pf3 as the background */
 	/* screen 2 uses pf2 as the foreground and pf4 as the background */
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0].get(), m_pf_rowscroll[1].get());
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2].get(), m_pf_rowscroll[3].get());
+	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
+	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2], m_pf_rowscroll[3]);
 
 	screen.priority().fill(0);
 	bitmap.fill(0x500, cliprect);
@@ -163,13 +141,13 @@ uint32_t backfire_state::screen_update_right(screen_device &screen, bitmap_ind16
 	{
 		m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 1);
 		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
-		m_sprgen[1]->draw_sprites(bitmap, cliprect, m_spriteram[1].get(), 0x2000/4);
+		m_sprgen[1]->draw_sprites(bitmap, cliprect, m_spriteram[1], 0x2000/4);
 	}
 	else if (m_right_priority[0] == 2)
 	{
 		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
 		m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
-		m_sprgen[1]->draw_sprites(bitmap, cliprect, m_spriteram[1].get(), 0x2000/4);
+		m_sprgen[1]->draw_sprites(bitmap, cliprect, m_spriteram[1], 0x2000/4);
 	}
 	else
 		popmessage( "unknown right priority %08x", m_right_priority[0]);
@@ -230,7 +208,7 @@ void backfire_state::backfire_map(address_map &map)
 	map(0x150000, 0x150fff).rw(FUNC(backfire_state::pf_rowscroll_r<2>), FUNC(backfire_state::pf_rowscroll_w<2>));
 	map(0x154000, 0x154fff).rw(FUNC(backfire_state::pf_rowscroll_r<3>), FUNC(backfire_state::pf_rowscroll_w<3>));
 	map(0x160000, 0x161fff).rw(m_palette, FUNC(palette_device::read16), FUNC(palette_device::write16)).umask32(0x0000ffff).share("palette");
-	map(0x170000, 0x177fff).ram().share("mainram");// main ram
+	map(0x170000, 0x177fff).ram().share(m_mainram);// main ram
 	map(0x180010, 0x180013).nopw(); // always 180010 ?
 	map(0x184000, 0x185fff).rw(FUNC(backfire_state::spriteram_r<0>), FUNC(backfire_state::spriteram_w<0>));
 	map(0x188010, 0x188013).nopw(); // always 188010 ?
@@ -238,11 +216,11 @@ void backfire_state::backfire_map(address_map &map)
 	map(0x190000, 0x190003).portr("IN0");
 	map(0x194000, 0x194003).portr("IN1");
 	map(0x1a4000, 0x1a4000).w(FUNC(backfire_state::eeprom_w));
-	map(0x1a8000, 0x1a8003).ram().share("left_priority");
-	map(0x1ac000, 0x1ac003).ram().share("right_priority");
+	map(0x1a8000, 0x1a8003).ram().share(m_left_priority);
+	map(0x1ac000, 0x1ac003).ram().share(m_right_priority);
 	map(0x1b0000, 0x1b0003).w(FUNC(backfire_state::irq_ack_w));
 	map(0x1c0000, 0x1c0007).rw("ymz", FUNC(ymz280b_device::read), FUNC(ymz280b_device::write)).umask32(0x000000ff);
-	map(0x1e4000, 0x1e4000).r("adc", FUNC(adc0808_device::data_r));
+	map(0x1e4000, 0x1e4000).r(m_adc, FUNC(adc0808_device::data_r));
 	map(0x1e8000, 0x1e8007).r(FUNC(backfire_state::pot_select_r));
 }
 
@@ -318,12 +296,18 @@ static const gfx_layout tilelayout =
 
 
 static GFXDECODE_START( gfx_backfire )
-	GFXDECODE_ENTRY( "gfx1", 0, charlayout,     0, 128 )   /* Characters 8x8 */
-	GFXDECODE_ENTRY( "gfx1", 0, tilelayout,     0, 128 )   /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "gfx2", 0, charlayout,     0, 128 )   /* Characters 8x8 */
-	GFXDECODE_ENTRY( "gfx2", 0, tilelayout,     0, 128 )   /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "gfx3", 0, tilelayout, 0x200,  32 )   /* Sprites 16x16 (screen 1) */
-	GFXDECODE_ENTRY( "gfx4", 0, tilelayout, 0x600,  32 )   /* Sprites 16x16 (screen 2) */
+	GFXDECODE_ENTRY( "tiles1", 0, charlayout,     0, 128 )   /* Characters 8x8 */
+	GFXDECODE_ENTRY( "tiles1", 0, tilelayout,     0, 128 )   /* Tiles 16x16 */
+	GFXDECODE_ENTRY( "tiles2", 0, charlayout,     0, 128 )   /* Characters 8x8 */
+	GFXDECODE_ENTRY( "tiles2", 0, tilelayout,     0, 128 )   /* Tiles 16x16 */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_backfire_spr1 )
+	GFXDECODE_ENTRY( "sprites1", 0, tilelayout, 0x200,  32 )   /* Sprites 16x16 (screen 1) */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_backfire_spr2 )
+	GFXDECODE_ENTRY( "sprites2", 0, tilelayout, 0x600,  32 )   /* Sprites 16x16 (screen 2) */
 GFXDECODE_END
 
 
@@ -341,7 +325,7 @@ void backfire_state::irq_ack_w(uint32_t data)
 
 DECO16IC_BANK_CB_MEMBER(backfire_state::bank_callback)
 {
-	//  osd_printf_debug("bank callback %04x\n",bank); // bit 1 gets set too?
+	//  logerror("bank callback %04x\n",bank); // bit 1 gets set too?
 	bank = bank >> 4;
 	bank = (bank & 1) | ((bank & 4) >> 1) | ((bank & 2) << 1);
 
@@ -358,10 +342,6 @@ DECOSPR_PRIORITY_CB_MEMBER(backfire_state::pri_callback)
 		case 0xc000: return 0xf0; // car wheels in race?
 	}
 	return 0;
-}
-
-void backfire_state::machine_start()
-{
 }
 
 void backfire_state::backfire(machine_config &config)
@@ -427,17 +407,13 @@ void backfire_state::backfire(machine_config &config)
 	m_deco_tilegen[1]->set_pf12_16x16_bank(3);
 	m_deco_tilegen[1]->set_gfxdecode_tag("gfxdecode");
 
-	DECO_SPRITE(config, m_sprgen[0], 0);
+	DECO_SPRITE(config, m_sprgen[0], 0, m_palette, gfx_backfire_spr1);
 	m_sprgen[0]->set_screen(m_lscreen);
-	m_sprgen[0]->set_gfx_region(4);
 	m_sprgen[0]->set_pri_callback(FUNC(backfire_state::pri_callback));
-	m_sprgen[0]->set_gfxdecode_tag("gfxdecode");
 
-	DECO_SPRITE(config, m_sprgen[1], 0);
+	DECO_SPRITE(config, m_sprgen[1], 0, m_palette, gfx_backfire_spr2);
 	m_sprgen[1]->set_screen("rscreen");
-	m_sprgen[1]->set_gfx_region(5);
 	m_sprgen[1]->set_pri_callback(FUNC(backfire_state::pri_callback));
-	m_sprgen[1]->set_gfxdecode_tag("gfxdecode");
 
 	/* sound hardware */
 	SPEAKER(config, "lspeaker").front_left();
@@ -508,7 +484,7 @@ ROM_START( backfire )
 	ROM_LOAD32_WORD( "ra00-0.2j",    0x000002, 0x080000, CRC(790da069) SHA1(84fd90fb1833b97459cb337fdb92f7b6e93b5936) )
 	ROM_LOAD32_WORD( "ra01-0.3j",    0x000000, 0x080000, CRC(447cb57b) SHA1(1d503b9cf1cadd3fdd7c9d6d59d4c40a59fa25ab))
 
-	ROM_REGION( 0x400000, "gfx1", 0 ) /* Tiles 1 */
+	ROM_REGION( 0x400000, "tiles1", 0 ) /* Tiles 1 */
 	ROM_LOAD( "mbz-00.9a",    0x000000, 0x080000, CRC(1098d504) SHA1(1fecd26b92faffce0b59a8a9646bfd457c17c87c) )
 	ROM_CONTINUE( 0x200000, 0x080000)
 	ROM_CONTINUE( 0x100000, 0x080000)
@@ -518,14 +494,14 @@ ROM_START( backfire )
 	ROM_CONTINUE( 0x180000, 0x080000)
 	ROM_CONTINUE( 0x380000, 0x080000)
 
-	ROM_REGION( 0x100000, "gfx2", 0 ) /* Tiles 2 */
+	ROM_REGION( 0x100000, "tiles2", 0 ) /* Tiles 2 */
 	ROM_LOAD( "mbz-02.12a",    0x000000, 0x100000, CRC(2bd2b0a1) SHA1(8fcb37728f3248ad55e48f2d398b014b36c9ec05) )
 
-	ROM_REGION( 0x400000, "gfx3", 0 ) /* Sprites 1 */
+	ROM_REGION( 0x400000, "sprites1", 0 ) /* Sprites 1 */
 	ROM_LOAD( "mbz-03.15a",    0x000000, 0x200000, CRC(2e818569) SHA1(457c1cad25d9b21459262be8b5788969f566a996) )
 	ROM_LOAD( "mbz-04.16a",    0x200000, 0x200000, CRC(67bdafb1) SHA1(9729c18f3153e4bba703a6f46ad0b886c52d84e2) )
 
-	ROM_REGION( 0x400000, "gfx4", 0 ) /* Sprites 2 */
+	ROM_REGION( 0x400000, "sprites2", 0 ) /* Sprites 2 */
 	ROM_LOAD( "mbz-03.18a",    0x000000, 0x200000, CRC(2e818569) SHA1(457c1cad25d9b21459262be8b5788969f566a996) )
 	ROM_LOAD( "mbz-04.19a",    0x200000, 0x200000, CRC(67bdafb1) SHA1(9729c18f3153e4bba703a6f46ad0b886c52d84e2) )
 
@@ -545,7 +521,7 @@ ROM_START( backfirea )
 	ROM_LOAD32_WORD( "rb-00h.h2",    0x000002, 0x080000, CRC(60973046) SHA1(e70d9be9cb172920da2a2ac9d317768b1438c59d) )
 	ROM_LOAD32_WORD( "rb-01l.h3",    0x000000, 0x080000, CRC(27472f60) SHA1(d73b1e68dc51e28b1148db39ce22bd2e93f6fd0a) )
 
-	ROM_REGION( 0x400000, "gfx1", 0 ) /* Tiles 1 */
+	ROM_REGION( 0x400000, "tiles1", 0 ) /* Tiles 1 */
 	ROM_LOAD( "mbz-00.9a",    0x000000, 0x080000, CRC(1098d504) SHA1(1fecd26b92faffce0b59a8a9646bfd457c17c87c) )
 	ROM_CONTINUE( 0x200000, 0x080000)
 	ROM_CONTINUE( 0x100000, 0x080000)
@@ -555,14 +531,14 @@ ROM_START( backfirea )
 	ROM_CONTINUE( 0x180000, 0x080000)
 	ROM_CONTINUE( 0x380000, 0x080000)
 
-	ROM_REGION( 0x100000, "gfx2", 0 ) /* Tiles 2 */
+	ROM_REGION( 0x100000, "tiles2", 0 ) /* Tiles 2 */
 	ROM_LOAD( "mbz-02.12a",    0x000000, 0x100000, CRC(2bd2b0a1) SHA1(8fcb37728f3248ad55e48f2d398b014b36c9ec05) )
 
-	ROM_REGION( 0x400000, "gfx3", 0 ) /* Sprites 1 */
+	ROM_REGION( 0x400000, "sprites1", 0 ) /* Sprites 1 */
 	ROM_LOAD( "mbz-03.15a",    0x000000, 0x200000, CRC(2e818569) SHA1(457c1cad25d9b21459262be8b5788969f566a996) )
 	ROM_LOAD( "mbz-04.16a",    0x200000, 0x200000, CRC(67bdafb1) SHA1(9729c18f3153e4bba703a6f46ad0b886c52d84e2) )
 
-	ROM_REGION( 0x400000, "gfx4", 0 ) /* Sprites 2 */
+	ROM_REGION( 0x400000, "sprites2", 0 ) /* Sprites 2 */
 	ROM_LOAD( "mbz-03.18a",    0x000000, 0x200000, CRC(2e818569) SHA1(457c1cad25d9b21459262be8b5788969f566a996) )
 	ROM_LOAD( "mbz-04.19a",    0x200000, 0x200000, CRC(67bdafb1) SHA1(9729c18f3153e4bba703a6f46ad0b886c52d84e2) )
 
@@ -597,10 +573,14 @@ void backfire_state::descramble_sound()
 
 uint32_t backfire_state::backfire_speedup_r()
 {
-	//osd_printf_debug( "%08x\n",m_maincpu->pc());
 
-	if (m_maincpu->pc() == 0xce44) m_maincpu->spin_until_time(attotime::from_usec(400)); // backfire
-	if (m_maincpu->pc() == 0xcee4) m_maincpu->spin_until_time(attotime::from_usec(400)); // backfirea
+	if (!machine().side_effects_disabled())
+	{
+		//logerror( "%08x\n",m_maincpu->pc());
+
+		if (m_maincpu->pc() == 0xce44) m_maincpu->spin_until_time(attotime::from_usec(400)); // backfire
+		if (m_maincpu->pc() == 0xcee4) m_maincpu->spin_until_time(attotime::from_usec(400)); // backfirea
+	}
 
 	return m_mainram[0x18/4];
 }
@@ -608,8 +588,8 @@ uint32_t backfire_state::backfire_speedup_r()
 
 void backfire_state::init_backfire()
 {
-	deco56_decrypt_gfx(machine(), "gfx1"); /* 141 */
-	deco56_decrypt_gfx(machine(), "gfx2"); /* 141 */
+	deco56_decrypt_gfx(machine(), "tiles1"); /* 141 */
+	deco56_decrypt_gfx(machine(), "tiles2"); /* 141 */
 	deco156_decrypt(machine());
 	m_maincpu->set_clock_scale(4.0f); /* core timings aren't accurate */
 	descramble_sound();

--- a/src/mame/dataeast/boogwing.h
+++ b/src/mame/dataeast/boogwing.h
@@ -61,8 +61,8 @@ private:
 	virtual void video_start() override;
 	uint32_t screen_update_boogwing(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void mix_boogwing(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	uint16_t boogwing_protection_region_0_104_r(offs_t offset);
-	void boogwing_protection_region_0_104_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	uint16_t ioprot_r(offs_t offset);
+	void ioprot_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 
 	DECO16IC_BANK_CB_MEMBER(bank_callback);
 	DECO16IC_BANK_CB_MEMBER(bank_callback2);

--- a/src/mame/dataeast/boogwing_v.cpp
+++ b/src/mame/dataeast/boogwing_v.cpp
@@ -255,8 +255,8 @@ void boogwing_state::mix_boogwing(screen_device &screen, bitmap_rgb32 &bitmap, c
 
 uint32_t boogwing_state::screen_update_boogwing(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	uint16_t flip = m_deco_tilegen[0]->pf_control_r(0);
-	uint16_t priority = m_priority;
+	uint16_t const flip = m_deco_tilegen[0]->pf_control_r(0);
+	uint16_t const priority = m_priority;
 
 	// sprites are flipped relative to tilemaps
 	flip_screen_set(BIT(flip, 7));

--- a/src/mame/dataeast/cbuster.cpp
+++ b/src/mame/dataeast/cbuster.cpp
@@ -378,6 +378,9 @@ static GFXDECODE_START( gfx_cbuster )
 	GFXDECODE_ENTRY( "tiles1",  0, charlayout,     0, 128 )  // Characters 8x8
 	GFXDECODE_ENTRY( "tiles1",  0, tilelayout,     0, 128 )  // Tiles 16x16
 	GFXDECODE_ENTRY( "tiles2",  0, tilelayout,     0, 128 )  // Tiles 16x16
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_cbuster_spr )
 	GFXDECODE_ENTRY( "sprites", 0, tilelayout, 0x100,  80 )  // Sprites 16x16
 GFXDECODE_END
 
@@ -450,9 +453,7 @@ void cbuster_state::twocrude(machine_config &config)
 	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
 	m_deco_tilegen[1]->set_gfxdecode_tag("gfxdecode");
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(3);
-	m_sprgen->set_gfxdecode_tag("gfxdecode");
+	DECO_SPRITE(config, m_sprgen, 0, m_palette, gfx_cbuster_spr);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/dataeast/cninja.cpp
+++ b/src/mame/dataeast/cninja.cpp
@@ -66,17 +66,17 @@ void cninja_state::cninja_pf_control_w(offs_t offset, uint16_t data, uint16_t me
 
 uint16_t cninja_state::cninja_protection_region_0_104_r(offs_t offset)
 {
-	int real_address = 0 + (offset *2);
-	int deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
+	int const real_address = 0 + (offset * 2);
+	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	uint8_t cs = 0;
-	uint16_t data = m_ioprot->read_data( deco146_addr, cs );
+	uint16_t const data = m_ioprot->read_data( deco146_addr, cs );
 	return data;
 }
 
 void cninja_state::cninja_protection_region_0_104_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	int real_address = 0 + (offset *2);
-	int deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
+	int const real_address = 0 + (offset * 2);
+	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	uint8_t cs = 0;
 	m_ioprot->write_data( deco146_addr, data, mem_mask, cs );
 }
@@ -95,14 +95,14 @@ void cninja_state::cninja_map(address_map &map)
 	map(0x140000, 0x14000f).w(FUNC(cninja_state::cninja_pf_control_w<0>));
 	map(0x144000, 0x144fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
 	map(0x146000, 0x146fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x14c000, 0x14c7ff).writeonly().share("pf1_rowscroll");
-	map(0x14e000, 0x14e7ff).ram().share("pf2_rowscroll");
+	map(0x14c000, 0x14c7ff).writeonly().share(m_pf_rowscroll[0]);
+	map(0x14e000, 0x14e7ff).ram().share(m_pf_rowscroll[1]);
 
 	map(0x150000, 0x15000f).w(FUNC(cninja_state::cninja_pf_control_w<1>));
 	map(0x154000, 0x154fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
 	map(0x156000, 0x156fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x15c000, 0x15c7ff).ram().share("pf3_rowscroll");
-	map(0x15e000, 0x15e7ff).ram().share("pf4_rowscroll");
+	map(0x15c000, 0x15c7ff).ram().share(m_pf_rowscroll[2]);
+	map(0x15e000, 0x15e7ff).ram().share(m_pf_rowscroll[3]);
 
 	map(0x184000, 0x187fff).ram();
 	map(0x190000, 0x190007).m("irq", FUNC(deco_irq_device::map)).umask16(0x00ff);
@@ -124,14 +124,14 @@ void cninja_state::cninjabl_map(address_map &map)
 	map(0x140000, 0x14000f).w(FUNC(cninja_state::cninja_pf_control_w<0>));
 	map(0x144000, 0x144fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
 	map(0x146000, 0x146fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x14c000, 0x14c7ff).writeonly().share("pf1_rowscroll");
-	map(0x14e000, 0x14e7ff).ram().share("pf2_rowscroll");
+	map(0x14c000, 0x14c7ff).writeonly().share(m_pf_rowscroll[0]);
+	map(0x14e000, 0x14e7ff).ram().share(m_pf_rowscroll[1]);
 
 	map(0x150000, 0x15000f).w(FUNC(cninja_state::cninja_pf_control_w<1>));    // not used / incorrect on this
 	map(0x154000, 0x154fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
 	map(0x156000, 0x156fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x15c000, 0x15c7ff).ram().share("pf3_rowscroll");
-	map(0x15e000, 0x15e7ff).ram().share("pf4_rowscroll");
+	map(0x15c000, 0x15c7ff).ram().share(m_pf_rowscroll[2]);
+	map(0x15e000, 0x15e7ff).ram().share(m_pf_rowscroll[3]);
 
 	map(0x17ff22, 0x17ff23).portr("DSW");
 	map(0x17ff28, 0x17ff29).portr("SYSTEM");
@@ -156,17 +156,17 @@ void cninja_state::cninjabl2_map(address_map &map)
 
 uint16_t cninja_state::edrandy_protection_region_8_146_r(offs_t offset)
 {
-	int real_address = 0x1a0000 + (offset *2);
-	int deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
+	int const real_address = 0x1a0000 + (offset * 2);
+	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	uint8_t cs = 0;
-	uint16_t data = m_ioprot->read_data( deco146_addr, cs );
+	uint16_t const data = m_ioprot->read_data( deco146_addr, cs );
 	return data;
 }
 
 void cninja_state::edrandy_protection_region_8_146_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	int real_address = 0x1a0000 + (offset *2);
-	int deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
+	int const real_address = 0x1a0000 + (offset * 2);
+	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	uint8_t cs = 0;
 	m_ioprot->write_data( deco146_addr, data, mem_mask, cs );
 }
@@ -175,11 +175,10 @@ uint16_t cninja_state::edrandy_protection_region_6_146_r(offs_t offset)
 {
 //  uint16_t realdat = deco16_60_prot_r(space,offset&0x3ff,mem_mask);
 
-	int real_address = 0x198000 + (offset *2);
-	int deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
+	int const real_address = 0x198000 + (offset * 2);
+	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	uint8_t cs = 0;
-	uint16_t data = m_ioprot->read_data( deco146_addr, cs );
-
+	uint16_t const data = m_ioprot->read_data( deco146_addr, cs );
 
 //  if ((realdat & mem_mask) != (data & mem_mask))
 //      printf("returned %04x instead of %04x (real address %08x)\n", data, realdat, real_address);
@@ -191,9 +190,8 @@ void cninja_state::edrandy_protection_region_6_146_w(offs_t offset, uint16_t dat
 {
 //  deco16_60_prot_w(space,offset&0x3ff,data,mem_mask);
 
-
-	int real_address = 0x198000 + (offset *2);
-	int deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
+	int const real_address = 0x198000 + (offset * 2);
+	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	uint8_t cs = 0;
 	m_ioprot->write_data( deco146_addr, data, mem_mask, cs );
 }
@@ -205,14 +203,14 @@ void cninja_state::edrandy_map(address_map &map)
 	map(0x140000, 0x14000f).w(FUNC(cninja_state::cninja_pf_control_w<0>));
 	map(0x144000, 0x144fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
 	map(0x146000, 0x146fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x14c000, 0x14c7ff).ram().share("pf1_rowscroll");
-	map(0x14e000, 0x14e7ff).ram().share("pf2_rowscroll");
+	map(0x14c000, 0x14c7ff).ram().share(m_pf_rowscroll[0]);
+	map(0x14e000, 0x14e7ff).ram().share(m_pf_rowscroll[1]);
 
 	map(0x150000, 0x15000f).w(FUNC(cninja_state::cninja_pf_control_w<1>));
 	map(0x154000, 0x154fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
 	map(0x156000, 0x156fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x15c000, 0x15c7ff).ram().share("pf3_rowscroll");
-	map(0x15e000, 0x15e7ff).ram().share("pf4_rowscroll");
+	map(0x15c000, 0x15c7ff).ram().share(m_pf_rowscroll[2]);
+	map(0x15e000, 0x15e7ff).ram().share(m_pf_rowscroll[3]);
 
 	map(0x188000, 0x189fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x194000, 0x197fff).ram(); /* Main ram */
@@ -239,14 +237,14 @@ void cninja_state::robocop2_map(address_map &map)
 	map(0x140000, 0x14000f).w(FUNC(cninja_state::cninja_pf_control_w<0>));
 	map(0x144000, 0x144fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
 	map(0x146000, 0x146fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x14c000, 0x14c7ff).ram().share("pf1_rowscroll");
-	map(0x14e000, 0x14e7ff).ram().share("pf2_rowscroll");
+	map(0x14c000, 0x14c7ff).ram().share(m_pf_rowscroll[0]);
+	map(0x14e000, 0x14e7ff).ram().share(m_pf_rowscroll[1]);
 
 	map(0x150000, 0x15000f).w(FUNC(cninja_state::cninja_pf_control_w<1>));
 	map(0x154000, 0x154fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
 	map(0x156000, 0x156fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x15c000, 0x15c7ff).ram().share("pf3_rowscroll");
-	map(0x15e000, 0x15e7ff).ram().share("pf4_rowscroll");
+	map(0x15c000, 0x15c7ff).ram().share(m_pf_rowscroll[2]);
+	map(0x15e000, 0x15e7ff).ram().share(m_pf_rowscroll[3]);
 
 	map(0x180000, 0x1807ff).ram().share("spriteram1");
 //  map(0x18c000, 0x18c0ff).w(FUNC(cninja_state::cninja_loopback_w)) /* Protection writes */
@@ -265,17 +263,17 @@ void cninja_state::robocop2_map(address_map &map)
 
 uint16_t cninja_state::mutantf_protection_region_0_146_r(offs_t offset)
 {
-	int real_address = 0 + (offset *2);
-	int deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
+	int const real_address = 0 + (offset * 2);
+	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	uint8_t cs = 0;
-	uint16_t data = m_ioprot->read_data( deco146_addr, cs );
+	uint16_t const data = m_ioprot->read_data( deco146_addr, cs );
 	return data;
 }
 
 void cninja_state::mutantf_protection_region_0_146_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	int real_address = 0 + (offset *2);
-	int deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
+	int const real_address = 0 + (offset * 2);
+	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	uint8_t cs = 0;
 	m_ioprot->write_data( deco146_addr, data, mem_mask, cs );
 }
@@ -301,14 +299,14 @@ void cninja_state::mutantf_map(address_map &map)
 	map(0x300000, 0x30000f).w(FUNC(cninja_state::cninja_pf_control_w<0>));
 	map(0x304000, 0x305fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
 	map(0x306000, 0x307fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x308000, 0x3087ff).ram().share("pf1_rowscroll");
-	map(0x30a000, 0x30a7ff).ram().share("pf2_rowscroll");
+	map(0x308000, 0x3087ff).ram().share(m_pf_rowscroll[0]);
+	map(0x30a000, 0x30a7ff).ram().share(m_pf_rowscroll[1]);
 
 	map(0x310000, 0x31000f).w(FUNC(cninja_state::cninja_pf_control_w<1>));
 	map(0x314000, 0x315fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
 	map(0x316000, 0x317fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x318000, 0x3187ff).ram().share("pf3_rowscroll");
-	map(0x31a000, 0x31a7ff).ram().share("pf4_rowscroll");
+	map(0x318000, 0x3187ff).ram().share(m_pf_rowscroll[2]);
+	map(0x31a000, 0x31a7ff).ram().share(m_pf_rowscroll[3]);
 
 	map(0xad00ac, 0xad00ff).nopr(); /* Reads from here seem to be a game code bug */
 }
@@ -367,7 +365,7 @@ void cninja_state::cninjabl2_s_map(address_map &map)
 void cninja_state::cninjabl2_oki_map(address_map &map)
 {
 	map(0x00000, 0x2ffff).rom().region("oki1", 0);
-	map(0x30000, 0x3ffff).bankr("okibank");
+	map(0x30000, 0x3ffff).bankr(m_okibank);
 }
 
 /***********************************************************
@@ -678,6 +676,16 @@ static GFXDECODE_START( gfx_cninja )
 	GFXDECODE_ENTRY( "chars",    0, charlayout,   0, 32 )  /* Characters 8x8 */
 	GFXDECODE_ENTRY( "tiles1",   0, tilelayout,   0, 32 )  /* Tiles 16x16 */
 	GFXDECODE_ENTRY( "tiles2",   0, tilelayout, 512, 64 )  /* Tiles 16x16 */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_cninja_spr )
+	GFXDECODE_ENTRY( "sprites1", 0, tilelayout, 768, 32 )  /* Sprites 16x16 */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_cninjabl )
+	GFXDECODE_ENTRY( "chars",    0, charlayout,   0, 32 )  /* Characters 8x8 */
+	GFXDECODE_ENTRY( "tiles1",   0, tilelayout,   0, 32 )  /* Tiles 16x16 */
+	GFXDECODE_ENTRY( "tiles2",   0, tilelayout, 512, 64 )  /* Tiles 16x16 */
 	GFXDECODE_ENTRY( "sprites1", 0, tilelayout, 768, 32 )  /* Sprites 16x16 */
 GFXDECODE_END
 
@@ -685,7 +693,13 @@ static GFXDECODE_START( gfx_mutantf )
 	GFXDECODE_ENTRY( "chars",    0, charlayout, 0,  64 )  /* Characters 8x8 */
 	GFXDECODE_ENTRY( "tiles1",   0, tilelayout, 0,  64 )  /* Tiles 16x16 */
 	GFXDECODE_ENTRY( "tiles2",   0, tilelayout, 0,  80 )  /* Tiles 16x16 */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_mutantf_spr1 )
 	GFXDECODE_ENTRY( "sprites1", 0, tilelayout, 0, 128 )  /* Sprites 16x16 */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_mutantf_spr2 )
 	GFXDECODE_ENTRY( "sprites2", 0, tilelayout, 0,  16 )  /* Sprites 16x16 */
 GFXDECODE_END
 
@@ -809,10 +823,8 @@ void cninja_state::cninja(machine_config &config)
 	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
 	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_SPRITE(config, m_sprgen[0], 0);
-	m_sprgen[0]->set_gfx_region(3);
+	DECO_SPRITE(config, m_sprgen[0], 0, m_palette, gfx_cninja_spr);
 	m_sprgen[0]->set_pri_callback(FUNC(cninja_state::pri_callback));
-	m_sprgen[0]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO104PROT(config, m_ioprot, 0);
 	m_ioprot->port_a_cb().set_ioport("INPUTS");
@@ -892,10 +904,8 @@ void cninja_state::stoneage(machine_config &config)
 	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
 	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_SPRITE(config, m_sprgen[0], 0);
-	m_sprgen[0]->set_gfx_region(3);
+	DECO_SPRITE(config, m_sprgen[0], 0, m_palette, gfx_cninja_spr);
 	m_sprgen[0]->set_pri_callback(FUNC(cninja_state::pri_callback));
-	m_sprgen[0]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO104PROT(config, m_ioprot, 0);
 	m_ioprot->port_a_cb().set_ioport("INPUTS");
@@ -955,7 +965,7 @@ void cninja_state::cninjabl(machine_config &config)
 	m_screen->set_screen_update(FUNC(cninja_state::screen_update_cninjabl));
 	m_screen->set_palette(m_palette);
 
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_cninja);
+	GFXDECODE(config, m_gfxdecode, m_palette, gfx_cninjabl);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_888, 2048);
 
 	BUFFERED_SPRITERAM16(config, m_spriteram[0]);
@@ -1050,10 +1060,8 @@ void cninja_state::edrandy(machine_config &config)
 	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
 	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_SPRITE(config, m_sprgen[0], 0);
-	m_sprgen[0]->set_gfx_region(3);
+	DECO_SPRITE(config, m_sprgen[0], 0, m_palette, gfx_cninja_spr);
 	m_sprgen[0]->set_pri_callback(FUNC(cninja_state::pri_callback));
-	m_sprgen[0]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO146PROT(config, m_ioprot, 0);
 	m_ioprot->port_a_cb().set_ioport("INPUTS");
@@ -1134,10 +1142,8 @@ void cninja_state::robocop2(machine_config &config)
 	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
 	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_SPRITE(config, m_sprgen[0], 0);
-	m_sprgen[0]->set_gfx_region(3);
+	DECO_SPRITE(config, m_sprgen[0], 0, m_palette, gfx_cninja_spr);
 	m_sprgen[0]->set_pri_callback(FUNC(cninja_state::pri_callback));
-	m_sprgen[0]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO146PROT(config, m_ioprot, 0);
 	m_ioprot->port_a_cb().set_ioport("INPUTS");
@@ -1215,13 +1221,11 @@ void cninja_state::mutantf(machine_config &config)
 	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
 	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_SPRITE(config, m_sprgen[0], 0);
-	m_sprgen[0]->set_gfx_region(3);
-	m_sprgen[0]->set_gfxdecode_tag(m_gfxdecode);
+	DECO_SPRITE(config, m_sprgen[0], 0, m_palette, gfx_mutantf_spr1);
+	m_sprgen[0]->set_alt_format(true);
 
-	DECO_SPRITE(config, m_sprgen[1], 0);
-	m_sprgen[1]->set_gfx_region(4);
-	m_sprgen[1]->set_gfxdecode_tag(m_gfxdecode);
+	DECO_SPRITE(config, m_sprgen[1], 0, m_palette, gfx_mutantf_spr2);
+	m_sprgen[1]->set_alt_format(true);
 
 	DECO146PROT(config, m_ioprot, 0);
 	m_ioprot->port_a_cb().set_ioport("INPUTS");

--- a/src/mame/dataeast/cninja_v.cpp
+++ b/src/mame/dataeast/cninja_v.cpp
@@ -128,7 +128,7 @@ void cninja_state::cninjabl_draw_sprites( screen_device &screen, bitmap_ind16 &b
 
 uint32_t cninja_state::screen_update_cninja(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t flip = m_deco_tilegen[0]->pf_control_r(0);
+	uint16_t const flip = m_deco_tilegen[0]->pf_control_r(0);
 
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen[0]->set_flip_screen(BIT(flip, 7));
@@ -160,7 +160,7 @@ uint32_t cninja_state::screen_update_cninjabl2(screen_device &screen, bitmap_ind
 
 uint32_t cninja_state::screen_update_cninjabl(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t flip = m_deco_tilegen[0]->pf_control_r(0);
+	uint16_t const flip = m_deco_tilegen[0]->pf_control_r(0);
 
 	/* force layers to be enabled */
 	m_deco_tilegen[1]->set_enable(0, 1 );
@@ -184,7 +184,7 @@ uint32_t cninja_state::screen_update_cninjabl(screen_device &screen, bitmap_ind1
 
 uint32_t cninja_state::screen_update_edrandy(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t flip = m_deco_tilegen[0]->pf_control_r(0);
+	uint16_t const flip = m_deco_tilegen[0]->pf_control_r(0);
 
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen[0]->set_flip_screen(BIT(flip, 7));
@@ -203,8 +203,8 @@ uint32_t cninja_state::screen_update_edrandy(screen_device &screen, bitmap_ind16
 
 uint32_t cninja_state::screen_update_robocop2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t flip = m_deco_tilegen[0]->pf_control_r(0);
-	uint16_t priority = m_priority;
+	uint16_t const flip = m_deco_tilegen[0]->pf_control_r(0);
+	uint16_t const priority = m_priority;
 
 	/* Update playfields */
 	flip_screen_set(BIT(flip, 7));
@@ -253,8 +253,8 @@ VIDEO_START_MEMBER(cninja_state,mutantf)
 
 uint32_t cninja_state::screen_update_mutantf(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	uint16_t flip = m_deco_tilegen[0]->pf_control_r(0);
-	uint16_t priority = m_priority;
+	uint16_t const flip = m_deco_tilegen[0]->pf_control_r(0);
+	uint16_t const priority = m_priority;
 
 	// sprites are flipped relative to tilemaps
 	flip_screen_set(BIT(flip, 7));
@@ -267,8 +267,6 @@ uint32_t cninja_state::screen_update_mutantf(screen_device &screen, bitmap_rgb32
 	/* Draw playfields */
 	bitmap.fill(0x400, cliprect); /* Confirmed */
 
-	m_sprgen[0]->set_alt_format(true);
-	m_sprgen[1]->set_alt_format(true);
 	m_sprgen[1]->draw_sprites(bitmap, cliprect, m_spriteram[1]->buffer(), 0x400);
 	m_sprgen[0]->draw_sprites(bitmap, cliprect, m_spriteram[0]->buffer(), 0x400);
 

--- a/src/mame/dataeast/darkseal.cpp
+++ b/src/mame/dataeast/darkseal.cpp
@@ -129,7 +129,7 @@ void darkseal_state::palette_ext_w(offs_t offset, uint16_t data, uint16_t mem_ma
 
 uint32_t darkseal_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t flip = m_deco_tilegen[1]->pf_control_r(0);
+	uint16_t const flip = m_deco_tilegen[1]->pf_control_r(0);
 	flip_screen_set(!BIT(flip, 7));
 	m_sprgen->set_flip_screen(!BIT(flip, 7));
 
@@ -178,9 +178,9 @@ void darkseal_state::main_map(address_map &map)
 	map(0x202000, 0x203fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
 	map(0x240000, 0x24000f).w(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_w));
 
-	map(0x220000, 0x220fff).ram().share("pf1_rowscroll");
+	map(0x220000, 0x220fff).ram().share(m_pf1_rowscroll);
 	// pf2 & 4 rowscrolls are where? (maybe don't exist?)
-	map(0x222000, 0x222fff).ram().share("pf3_rowscroll");
+	map(0x222000, 0x222fff).ram().share(m_pf3_rowscroll);
 
 	map(0x260000, 0x261fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
 	map(0x262000, 0x263fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
@@ -307,6 +307,9 @@ static GFXDECODE_START( gfx_darkseal )
 	GFXDECODE_ENTRY( "chars",   0, charlayout,    0, 16 )  // 8x8
 	GFXDECODE_ENTRY( "tiles1",  0, seallayout,  768, 16 )  // 16x16
 	GFXDECODE_ENTRY( "tiles2",  0, seallayout, 1024, 16 )  // 16x16
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_darkseal_spr )
 	GFXDECODE_ENTRY( "sprites", 0, seallayout,  256, 32 )  // 16x16
 GFXDECODE_END
 
@@ -360,9 +363,7 @@ void darkseal_state::darkseal(machine_config &config)
 	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
 	m_deco_tilegen[1]->set_gfxdecode_tag("gfxdecode");
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(3);
-	m_sprgen->set_gfxdecode_tag("gfxdecode");
+	DECO_SPRITE(config, m_sprgen, 0, m_palette, gfx_darkseal_spr);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/dataeast/dassault.cpp
+++ b/src/mame/dataeast/dassault.cpp
@@ -705,7 +705,13 @@ static GFXDECODE_START( gfx_dassault )
 	GFXDECODE_ENTRY( "tiles1",   0, charlayout,     0,  32 )      // 8x8
 	GFXDECODE_ENTRY( "tiles1",   0, tilelayout,     0,  32 )      // 16x16
 	GFXDECODE_ENTRY( "tiles2",   0, tilelayout,   512,  32 )      // 16x16
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_dassault_spr1 )
 	GFXDECODE_ENTRY( "sprites1", 0, tilelayout,  0/*1024*/,  64 ) // 16x16
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_dassault_spr2 )
 	GFXDECODE_ENTRY( "sprites2", 0, tilelayout,  0/*2048*/,  64 ) // 16x16
 GFXDECODE_END
 
@@ -789,13 +795,8 @@ void dassault_state::dassault(machine_config &config)
 	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
 	m_deco_tilegen[1]->set_gfxdecode_tag("gfxdecode");
 
-	DECO_SPRITE(config, m_sprgen[0], 0);
-	m_sprgen[0]->set_gfx_region(3);
-	m_sprgen[0]->set_gfxdecode_tag("gfxdecode");
-
-	DECO_SPRITE(config, m_sprgen[1], 0);
-	m_sprgen[1]->set_gfx_region(4);
-	m_sprgen[1]->set_gfxdecode_tag("gfxdecode");
+	DECO_SPRITE(config, m_sprgen[0], 0, m_palette, gfx_dassault_spr1);
+	DECO_SPRITE(config, m_sprgen[1], 0, m_palette, gfx_dassault_spr2);
 
 	// sound hardware
 	SPEAKER(config, "lspeaker").front_left();

--- a/src/mame/dataeast/deco156.cpp
+++ b/src/mame/dataeast/deco156.cpp
@@ -39,6 +39,9 @@ public:
 		, m_oki2(*this, "oki2")
 		, m_sprgen(*this, "spritegen")
 		, m_palette(*this, "palette")
+		, m_pf_rowscroll(*this, "pf%u_rowscroll", 1U, 0x800U, ENDIANNESS_LITTLE)
+		, m_spriteram(*this, "spriteram", 0x1000U, ENDIANNESS_LITTLE)
+		, m_io_eepromout(*this, "EEPROMOUT")
 	{ }
 
 	void init_hvysmsh();
@@ -49,14 +52,11 @@ public:
 
 private:
 	void hvysmsh_eeprom_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	uint32_t pf1_rowscroll_r(offs_t offset);
-	uint32_t pf2_rowscroll_r(offs_t offset);
+	template<unsigned Layer> uint32_t pf_rowscroll_r(offs_t offset);
+	template<unsigned Layer> void pf_rowscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	uint32_t spriteram_r(offs_t offset);
-	void pf1_rowscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void pf2_rowscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	void spriteram_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	void hvysmsh_oki_0_bank_w(uint32_t data);
-	virtual void video_start() override;
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void vblank_interrupt(int state);
 	void descramble_sound(const char *tag);
@@ -75,21 +75,11 @@ private:
 	required_device<palette_device> m_palette;
 
 	/* memory */
-	uint16_t   m_pf1_rowscroll[0x800/2];
-	uint16_t   m_pf2_rowscroll[0x800/2];
-	std::unique_ptr<uint16_t[]> m_spriteram;
+	memory_share_array_creator<uint16_t, 2> m_pf_rowscroll;
+	memory_share_creator<uint16_t> m_spriteram;
+
+	required_ioport m_io_eepromout;
 };
-
-
-void deco156_state::video_start()
-{
-	m_spriteram = std::make_unique<uint16_t[]>(0x2000/2);
-
-	/* and register the allocated ram so that save states still work */
-	save_item(NAME(m_pf1_rowscroll));
-	save_item(NAME(m_pf2_rowscroll));
-	save_pointer(NAME(m_spriteram), 0x2000/2);
-}
 
 
 uint32_t deco156_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
@@ -100,10 +90,10 @@ uint32_t deco156_state::screen_update(screen_device &screen, bitmap_rgb32 &bitma
 	screen.priority().fill(0);
 	bitmap.fill(0);
 
-	m_deco_tilegen->pf_update(m_pf1_rowscroll, m_pf2_rowscroll);
+	m_deco_tilegen->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
 
 	m_deco_tilegen->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram.get(), 0x800);
+	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram, 0x800);
 	m_deco_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
@@ -115,7 +105,7 @@ void deco156_state::hvysmsh_eeprom_w(offs_t offset, uint32_t data, uint32_t mem_
 	if (ACCESSING_BITS_0_7)
 	{
 		m_oki2->set_rom_bank(data & 0x7);
-		ioport("EEPROMOUT")->write(data, 0xff);
+		m_io_eepromout->write(data, 0xff);
 	}
 }
 
@@ -124,11 +114,11 @@ void deco156_state::hvysmsh_oki_0_bank_w(uint32_t data)
 	m_oki1->set_rom_bank(data & 1);
 }
 
-uint32_t deco156_state::pf1_rowscroll_r(offs_t offset) { return m_pf1_rowscroll[offset] ^ 0xffff0000; }
-uint32_t deco156_state::pf2_rowscroll_r(offs_t offset) { return m_pf2_rowscroll[offset] ^ 0xffff0000; }
+template<unsigned Layer>
+uint32_t deco156_state::pf_rowscroll_r(offs_t offset) { return m_pf_rowscroll[Layer][offset] ^ 0xffff0000; }
+template<unsigned Layer>
+void deco156_state::pf_rowscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask) { data &= 0x0000ffff; mem_mask &= 0x0000ffff; COMBINE_DATA(&m_pf_rowscroll[Layer][offset]); }
 uint32_t deco156_state::spriteram_r(offs_t offset) { return m_spriteram[offset] ^ 0xffff0000; }
-void deco156_state::pf1_rowscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask) { data &= 0x0000ffff; mem_mask &= 0x0000ffff; COMBINE_DATA(&m_pf1_rowscroll[offset]); }
-void deco156_state::pf2_rowscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask) { data &= 0x0000ffff; mem_mask &= 0x0000ffff; COMBINE_DATA(&m_pf2_rowscroll[offset]); }
 void deco156_state::spriteram_w(offs_t offset, uint32_t data, uint32_t mem_mask) { data &= 0x0000ffff; mem_mask &= 0x0000ffff; COMBINE_DATA(&m_spriteram[offset]); }
 
 
@@ -146,8 +136,8 @@ void deco156_state::hvysmsh_map(address_map &map)
 	map(0x180000, 0x18001f).rw(m_deco_tilegen, FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
 	map(0x190000, 0x191fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
 	map(0x194000, 0x195fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
-	map(0x1a0000, 0x1a0fff).rw(FUNC(deco156_state::pf1_rowscroll_r), FUNC(deco156_state::pf1_rowscroll_w));
-	map(0x1a4000, 0x1a4fff).rw(FUNC(deco156_state::pf2_rowscroll_r), FUNC(deco156_state::pf2_rowscroll_w));
+	map(0x1a0000, 0x1a0fff).rw(FUNC(deco156_state::pf_rowscroll_r<0>), FUNC(deco156_state::pf_rowscroll_w<0>));
+	map(0x1a4000, 0x1a4fff).rw(FUNC(deco156_state::pf_rowscroll_r<1>), FUNC(deco156_state::pf_rowscroll_w<1>));
 	map(0x1c0000, 0x1c0fff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette");
 	map(0x1d0010, 0x1d002f).nopr(); // Check for DMA complete?
 	map(0x1e0000, 0x1e1fff).rw(FUNC(deco156_state::spriteram_r), FUNC(deco156_state::spriteram_w));
@@ -159,8 +149,8 @@ void deco156_state::wcvol95_map(address_map &map)
 	map(0x100000, 0x10001f).rw(m_deco_tilegen, FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
 	map(0x110000, 0x111fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
 	map(0x114000, 0x115fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
-	map(0x120000, 0x120fff).rw(FUNC(deco156_state::pf1_rowscroll_r), FUNC(deco156_state::pf1_rowscroll_w));
-	map(0x124000, 0x124fff).rw(FUNC(deco156_state::pf2_rowscroll_r), FUNC(deco156_state::pf2_rowscroll_w));
+	map(0x120000, 0x120fff).rw(FUNC(deco156_state::pf_rowscroll_r<0>), FUNC(deco156_state::pf_rowscroll_w<0>));
+	map(0x124000, 0x124fff).rw(FUNC(deco156_state::pf_rowscroll_r<1>), FUNC(deco156_state::pf_rowscroll_w<1>));
 	map(0x130000, 0x137fff).ram();
 	map(0x140000, 0x140003).portr("INPUTS");
 	map(0x150000, 0x150003).portw("EEPROMOUT");
@@ -283,9 +273,12 @@ static const gfx_layout tilelayout =
 };
 
 static GFXDECODE_START( gfx_hvysmsh )
-	GFXDECODE_ENTRY( "gfx1", 0, charlayout,   0, 32 )    /* Characters 8x8 */
-	GFXDECODE_ENTRY( "gfx1", 0, tilelayout,   0, 32 )    /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "gfx2", 0, tilelayout, 512, 32 )    /* Sprites 16x16 */
+	GFXDECODE_ENTRY( "tiles", 0, charlayout,   0, 32 )    /* Characters 8x8 */
+	GFXDECODE_ENTRY( "tiles", 0, tilelayout,   0, 32 )    /* Tiles 16x16 */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_hvysmsh_spr )
+	GFXDECODE_ENTRY( "sprites", 0, tilelayout, 512, 32 )    /* Sprites 16x16 */
 GFXDECODE_END
 
 
@@ -346,22 +339,17 @@ void deco156_state::hvysmsh(machine_config &config)
 	m_deco_tilegen->set_pf12_16x16_bank(1);
 	m_deco_tilegen->set_gfxdecode_tag("gfxdecode");
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(2);
+	DECO_SPRITE(config, m_sprgen, 0, m_palette, gfx_hvysmsh_spr);
 	m_sprgen->set_pri_callback(FUNC(deco156_state::pri_callback));
-	m_sprgen->set_gfxdecode_tag("gfxdecode");
 
 	/* sound hardware */
-	SPEAKER(config, "lspeaker").front_left();
-	SPEAKER(config, "rspeaker").front_right();
+	SPEAKER(config, "mono").front_center();
 
 	OKIM6295(config, m_oki1, 28000000/28, okim6295_device::PIN7_HIGH);
-	m_oki1->add_route(ALL_OUTPUTS, "lspeaker", 1.0);
-	m_oki1->add_route(ALL_OUTPUTS, "rspeaker", 1.0);
+	m_oki1->add_route(ALL_OUTPUTS, "mono", 1.0);
 
 	OKIM6295(config, m_oki2, 28000000/14, okim6295_device::PIN7_HIGH);
-	m_oki2->add_route(ALL_OUTPUTS, "lspeaker", 0.35);
-	m_oki2->add_route(ALL_OUTPUTS, "rspeaker", 0.35);
+	m_oki2->add_route(ALL_OUTPUTS, "mono", 0.35);
 }
 
 void deco156_state::wcvol95(machine_config &config)
@@ -396,10 +384,8 @@ void deco156_state::wcvol95(machine_config &config)
 	m_deco_tilegen->set_pf12_16x16_bank(1);
 	m_deco_tilegen->set_gfxdecode_tag("gfxdecode");
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(2);
+	DECO_SPRITE(config, m_sprgen, 0, m_palette, gfx_hvysmsh_spr);
 	m_sprgen->set_pri_callback(FUNC(deco156_state::pri_callback));
-	m_sprgen->set_gfxdecode_tag("gfxdecode");
 
 	/* sound hardware */
 	SPEAKER(config, "lspeaker").front_left();
@@ -471,13 +457,13 @@ ROM_START( hvysmsh ) /* Europe -2  1993/06/30 */
 	ROM_LOAD32_WORD( "lt00-2.2j", 0x000002, 0x080000, CRC(f6e10fc0) SHA1(76189260ca0a79500d62c4aa8e3aed6cfca3e102) )
 	ROM_LOAD32_WORD( "lt01-2.3j", 0x000000, 0x080000, CRC(ce2a75e2) SHA1(4119a3175d7c394041197f01523a6eaa3d9ba398) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD( "mbg-00.9a",  0x000000, 0x080000, CRC(7d94eb16) SHA1(31cf5302eba37e935865822aebd76c700bc51eaf) )
 	ROM_CONTINUE( 0x100000, 0x080000)
 	ROM_CONTINUE( 0x080000, 0x080000)
 	ROM_CONTINUE( 0x180000, 0x080000)
 
-	ROM_REGION( 0x800000, "gfx2", 0 )
+	ROM_REGION( 0x800000, "sprites", 0 )
 	ROM_LOAD( "mbg-01.10a", 0x400000, 0x200000, CRC(bcd7fb29) SHA1(a54a813b5adcb4df0bfdd58285b1f8e17fbbb7a2) )
 	ROM_LOAD( "mbg-02.11a", 0x000000, 0x200000, CRC(0cc16440) SHA1(1cbf620a9d875ec87dd28a97a256584b6ef277cd) )
 
@@ -496,13 +482,13 @@ ROM_START( hvysmshj ) /* Japan -2  1993/06/30 */
 	ROM_LOAD32_WORD( "lp00-2.2j", 0x000002, 0x080000, CRC(3f8fd724) SHA1(8efb27b96dbdc58715eb44c7846f30d485e1ded4) )
 	ROM_LOAD32_WORD( "lp01-2.3j", 0x000000, 0x080000, CRC(a6fe282a) SHA1(10295b740ced35b3bb1f48ca3af2e985912405ec) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD( "mbg-00.9a",  0x000000, 0x080000, CRC(7d94eb16) SHA1(31cf5302eba37e935865822aebd76c700bc51eaf) )
 	ROM_CONTINUE( 0x100000, 0x080000)
 	ROM_CONTINUE( 0x080000, 0x080000)
 	ROM_CONTINUE( 0x180000, 0x080000)
 
-	ROM_REGION( 0x800000, "gfx2", 0 )
+	ROM_REGION( 0x800000, "sprites", 0 )
 	ROM_LOAD( "mbg-01.10a", 0x400000, 0x200000, CRC(bcd7fb29) SHA1(a54a813b5adcb4df0bfdd58285b1f8e17fbbb7a2) )
 	ROM_LOAD( "mbg-02.11a", 0x000000, 0x200000, CRC(0cc16440) SHA1(1cbf620a9d875ec87dd28a97a256584b6ef277cd) )
 
@@ -521,13 +507,13 @@ ROM_START( hvysmsha ) /* Asia -4  1993/09/06 */
 	ROM_LOAD32_WORD( "xx00-4.2j", 0x000002, 0x080000, CRC(333a92c1) SHA1(b7e174ea081febb765298aa1c6533b2f9f162bce) ) /* "xx" is NOT the correct region code, this needs */
 	ROM_LOAD32_WORD( "xx01-4.3j", 0x000000, 0x080000, CRC(8c24c5ed) SHA1(ab9689530f4f4a6015ce0a6f8e0d796b0618cd79) ) /* to be verified and corrected at some point */
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD( "mbg-00.9a",  0x000000, 0x080000, CRC(7d94eb16) SHA1(31cf5302eba37e935865822aebd76c700bc51eaf) )
 	ROM_CONTINUE( 0x100000, 0x080000)
 	ROM_CONTINUE( 0x080000, 0x080000)
 	ROM_CONTINUE( 0x180000, 0x080000)
 
-	ROM_REGION( 0x800000, "gfx2", 0 )
+	ROM_REGION( 0x800000, "sprites", 0 )
 	ROM_LOAD( "mbg-01.10a", 0x400000, 0x200000, CRC(bcd7fb29) SHA1(a54a813b5adcb4df0bfdd58285b1f8e17fbbb7a2) )
 	ROM_LOAD( "mbg-02.11a", 0x000000, 0x200000, CRC(0cc16440) SHA1(1cbf620a9d875ec87dd28a97a256584b6ef277cd) )
 
@@ -585,10 +571,10 @@ ROM_START( wcvol95 )
 	ROM_LOAD32_WORD( "pw00-0.2f",    0x000002, 0x080000, CRC(86765209) SHA1(f78d073610b630ba6aa2352da9b394ef8b8ef628) )
 	ROM_LOAD32_WORD( "pw01-0.4f",    0x000000, 0x080000, CRC(3a0ee861) SHA1(568ab26e9985b0a63b10bb0f57d45e1f15593047) )
 
-	ROM_REGION( 0x080000, "gfx1", 0 )
+	ROM_REGION( 0x080000, "tiles", 0 )
 	ROM_LOAD( "mbx-00.9a",    0x000000, 0x080000, CRC(a0b24204) SHA1(cec8089c6c635f23b3a4aeeef2c43f519568ad70) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "sprites", 0 )
 	ROM_LOAD( "mbx-01.12a",    0x100000, 0x100000, CRC(73deb3f1) SHA1(c0cabecfd88695afe0f27c5bb115b4973907207d) )
 	ROM_LOAD( "mbx-02.13a",    0x000000, 0x100000, CRC(3204d324) SHA1(44102f71bae44bf3a9bd2de7e5791d959a2c9bdd) )
 
@@ -609,10 +595,10 @@ ROM_START( wcvol95j )
 	ROM_LOAD32_WORD( "pn00-0.2f",    0x000002, 0x080000, CRC(c9ed2006) SHA1(cee93eafc42c4de7a1453c85e7d6bca8d62cdc7b) )
 	ROM_LOAD32_WORD( "pn01-0.4f",    0x000000, 0x080000, CRC(1c3641c3) SHA1(60dddc3585e4dedb485f7505fee03495f615c0c0) )
 
-	ROM_REGION( 0x080000, "gfx1", 0 )
+	ROM_REGION( 0x080000, "tiles", 0 )
 	ROM_LOAD( "mbx-00.9a",    0x000000, 0x080000, CRC(a0b24204) SHA1(cec8089c6c635f23b3a4aeeef2c43f519568ad70) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "sprites", 0 )
 	ROM_LOAD( "mbx-01.12a",    0x100000, 0x100000, CRC(73deb3f1) SHA1(c0cabecfd88695afe0f27c5bb115b4973907207d) )
 	ROM_LOAD( "mbx-02.13a",    0x000000, 0x100000, CRC(3204d324) SHA1(44102f71bae44bf3a9bd2de7e5791d959a2c9bdd) )
 
@@ -634,10 +620,10 @@ ROM_START( wcvol95x )
 	ROM_LOAD32_WORD( "2f.bin",    0x000002, 0x080000, CRC(ac06633d) SHA1(5d37ca3050f35d5fc06f70e91b1522e325471585) )
 	ROM_LOAD32_WORD( "4f.bin",    0x000000, 0x080000, CRC(e211f67a) SHA1(d008c2b809482f17ada608134357fa1205d767d4) )
 
-	ROM_REGION( 0x080000, "gfx1", 0 )
+	ROM_REGION( 0x080000, "tiles", 0 )
 	ROM_LOAD( "mbx-00.9a",    0x000000, 0x080000, CRC(a0b24204) SHA1(cec8089c6c635f23b3a4aeeef2c43f519568ad70) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "sprites", 0 )
 	ROM_LOAD( "mbx-01.12a",    0x100000, 0x100000, CRC(73deb3f1) SHA1(c0cabecfd88695afe0f27c5bb115b4973907207d) )
 	ROM_LOAD( "mbx-02.13a",    0x000000, 0x100000, CRC(3204d324) SHA1(44102f71bae44bf3a9bd2de7e5791d959a2c9bdd) )
 
@@ -678,14 +664,14 @@ void deco156_state::descramble_sound( const char *tag )
 
 void deco156_state::init_hvysmsh()
 {
-	deco56_decrypt_gfx(machine(), "gfx1"); /* 141 */
+	deco56_decrypt_gfx(machine(), "tiles"); /* 141 */
 	deco156_decrypt(machine());
 	descramble_sound("oki2");
 }
 
 void deco156_state::init_wcvol95()
 {
-	deco56_decrypt_gfx(machine(), "gfx1"); /* 141 */
+	deco56_decrypt_gfx(machine(), "tiles"); /* 141 */
 	deco156_decrypt(machine());
 	descramble_sound("ymz");
 }

--- a/src/mame/dataeast/deco156.cpp
+++ b/src/mame/dataeast/deco156.cpp
@@ -16,17 +16,22 @@
 */
 
 #include "emu.h"
-#include "cpu/arm/arm.h"
-#include "decocrpt.h"
 #include "deco156_m.h"
+#include "deco16ic.h"
+#include "decocrpt.h"
+#include "decospr.h"
+
+#include "cpu/arm/arm.h"
 #include "machine/eepromser.h"
 #include "sound/okim6295.h"
 #include "sound/ymz280b.h"
-#include "deco16ic.h"
-#include "decospr.h"
+
 #include "emupal.h"
 #include "screen.h"
 #include "speaker.h"
+
+
+namespace {
 
 class deco156_state : public driver_device
 {
@@ -52,8 +57,8 @@ public:
 
 private:
 	void hvysmsh_eeprom_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	template<unsigned Layer> uint32_t pf_rowscroll_r(offs_t offset);
-	template<unsigned Layer> void pf_rowscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	template <unsigned Layer> uint32_t pf_rowscroll_r(offs_t offset);
+	template <unsigned Layer> void pf_rowscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	uint32_t spriteram_r(offs_t offset);
 	void spriteram_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	void hvysmsh_oki_0_bank_w(uint32_t data);
@@ -114,12 +119,12 @@ void deco156_state::hvysmsh_oki_0_bank_w(uint32_t data)
 	m_oki1->set_rom_bank(data & 1);
 }
 
-template<unsigned Layer>
-uint32_t deco156_state::pf_rowscroll_r(offs_t offset) { return m_pf_rowscroll[Layer][offset] ^ 0xffff0000; }
-template<unsigned Layer>
-void deco156_state::pf_rowscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask) { data &= 0x0000ffff; mem_mask &= 0x0000ffff; COMBINE_DATA(&m_pf_rowscroll[Layer][offset]); }
-uint32_t deco156_state::spriteram_r(offs_t offset) { return m_spriteram[offset] ^ 0xffff0000; }
-void deco156_state::spriteram_w(offs_t offset, uint32_t data, uint32_t mem_mask) { data &= 0x0000ffff; mem_mask &= 0x0000ffff; COMBINE_DATA(&m_spriteram[offset]); }
+template <unsigned Layer>
+uint32_t deco156_state::pf_rowscroll_r(offs_t offset) { return m_pf_rowscroll[Layer][offset] | 0xffff0000; }
+template <unsigned Layer>
+void deco156_state::pf_rowscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask) { mem_mask &= 0x0000ffff; COMBINE_DATA(&m_pf_rowscroll[Layer][offset]); }
+uint32_t deco156_state::spriteram_r(offs_t offset) { return m_spriteram[offset] | 0xffff0000; }
+void deco156_state::spriteram_w(offs_t offset, uint32_t data, uint32_t mem_mask) { mem_mask &= 0x0000ffff; COMBINE_DATA(&m_spriteram[offset]); }
 
 
 void deco156_state::hvysmsh_map(address_map &map)
@@ -675,6 +680,8 @@ void deco156_state::init_wcvol95()
 	deco156_decrypt(machine());
 	descramble_sound("ymz");
 }
+
+} // anonymous namespace
 
 
 /**********************************************************************************/

--- a/src/mame/dataeast/deco32.cpp
+++ b/src/mame/dataeast/deco32.cpp
@@ -379,6 +379,7 @@ NOTE: There are several unpopulated locations (denoted by *) for additional rom 
 #include "cpu/m6809/m6809.h"
 #include "cpu/z80/z80.h"
 #include "machine/input_merger.h"
+
 #include "speaker.h"
 
 #include <algorithm>
@@ -707,7 +708,7 @@ void dragngun_state::lockloadu_sound_map(address_map &map)
 u16 deco32_state::ioprot_r(offs_t offset)
 {
 	const offs_t real_address = 0 + (offset * 2);
-	const offs_t deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
+	const offs_t deco146_addr = (BIT(real_address, 14, 4) << 11) | BIT(real_address, 0, 11); // NC 31-18, 13-11
 	u8 cs = 0;
 
 	return m_ioprot->read_data(deco146_addr, cs);
@@ -716,10 +717,10 @@ u16 deco32_state::ioprot_r(offs_t offset)
 void deco32_state::ioprot_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	const offs_t real_address = 0 + (offset * 2);
-	const offs_t deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
+	const offs_t deco146_addr = (BIT(real_address, 14, 4) << 11) | BIT(real_address, 0, 11); // NC 31-18, 13-11
 	u8 cs = 0;
 
-	m_ioprot->write_data( deco146_addr, data, mem_mask, cs );
+	m_ioprot->write_data(deco146_addr, data, mem_mask, cs);
 }
 
 
@@ -731,7 +732,7 @@ void deco32_state::volume_w(u8 data)
 {
 	// TODO: assume linear with a 0.0-1.0 dB scale for now
 	const u8 raw_vol = 0xff - data;
-	const float vol_output = ((float)raw_vol) / 255.0f;
+	const float vol_output = float(raw_vol) / 255.0f;
 
 	m_ym2151->set_output_gain(ALL_OUTPUTS, vol_output);
 	m_oki[0]->set_output_gain(ALL_OUTPUTS, vol_output);

--- a/src/mame/dataeast/deco32.cpp
+++ b/src/mame/dataeast/deco32.cpp
@@ -405,15 +405,15 @@ void captaven_state::captaven_map(address_map &map)
 	map(0x168002, 0x168002).lr8(NAME([this] () { return m_io_dsw[2]->read(); }));
 	map(0x168003, 0x168003).r(FUNC(captaven_state::captaven_soundcpu_status_r));
 	map(0x178000, 0x178003).w(FUNC(captaven_state::pri_w));
-	map(0x180000, 0x18001f).rw("tilegen1", FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x190000, 0x191fff).rw("tilegen1", FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x192000, 0x193fff).rw("tilegen1", FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w)); // Mirror address - bug in program code
-	map(0x194000, 0x195fff).rw("tilegen1", FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
+	map(0x180000, 0x18001f).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x190000, 0x191fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
+	map(0x192000, 0x193fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w)); // Mirror address - bug in program code
+	map(0x194000, 0x195fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
 	map(0x1a0000, 0x1a3fff).ram().w(FUNC(captaven_state::pf_rowscroll_w<0>)).share("pf1_rowscroll32");
 	map(0x1a4000, 0x1a5fff).ram().w(FUNC(captaven_state::pf_rowscroll_w<1>)).share("pf2_rowscroll32");
-	map(0x1c0000, 0x1c001f).rw("tilegen2", FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x1d0000, 0x1d1fff).rw("tilegen2", FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x1d4000, 0x1d5fff).rw("tilegen2", FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w)); // unused
+	map(0x1c0000, 0x1c001f).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x1d0000, 0x1d1fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
+	map(0x1d4000, 0x1d5fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w)); // unused
 	map(0x1e0000, 0x1e3fff).ram().w(FUNC(captaven_state::pf_rowscroll_w<2>)).share("pf3_rowscroll32");
 	map(0x1e4000, 0x1e5fff).ram().w(FUNC(captaven_state::pf_rowscroll_w<3>)).share("pf4_rowscroll32"); // unused
 }
@@ -437,16 +437,16 @@ void fghthist_state::fghthist_map(address_map &map)
 	map(0x178000, 0x179fff).rw(FUNC(fghthist_state::spriteram_r<0>), FUNC(fghthist_state::spriteram_w<0>));
 	map(0x17c010, 0x17c013).w(FUNC(fghthist_state::buffer_spriteram_w<0>));
 	map(0x17c020, 0x17c023).r(FUNC(fghthist_state::unk_status_r));
-	map(0x182000, 0x183fff).rw("tilegen1", FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x184000, 0x185fff).rw("tilegen1", FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
+	map(0x182000, 0x183fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
+	map(0x184000, 0x185fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
 	map(0x192000, 0x193fff).ram().w(FUNC(fghthist_state::pf_rowscroll_w<0>)).share("pf1_rowscroll32");
 	map(0x194000, 0x195fff).ram().w(FUNC(fghthist_state::pf_rowscroll_w<1>)).share("pf2_rowscroll32");
-	map(0x1a0000, 0x1a001f).rw("tilegen1", FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x1c2000, 0x1c3fff).rw("tilegen2", FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x1c4000, 0x1c5fff).rw("tilegen2", FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
+	map(0x1a0000, 0x1a001f).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x1c2000, 0x1c3fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
+	map(0x1c4000, 0x1c5fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
 	map(0x1d2000, 0x1d3fff).ram().w(FUNC(fghthist_state::pf_rowscroll_w<2>)).share("pf3_rowscroll32");
 	map(0x1d4000, 0x1d5fff).ram().w(FUNC(fghthist_state::pf_rowscroll_w<3>)).share("pf4_rowscroll32");
-	map(0x1e0000, 0x1e001f).rw("tilegen2", FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x1e0000, 0x1e001f).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
 	map(0x200000, 0x207fff).rw(FUNC(fghthist_state::ioprot_r), FUNC(fghthist_state::ioprot_w)).umask32(0xffff0000).share("prot32ram"); // only maps on 16-bits
 	map(0x208800, 0x208803).nopw(); // ?
 }
@@ -464,28 +464,28 @@ void fghthist_state::fghthsta_memmap(address_map &map)
 	map(0x178000, 0x179fff).rw(FUNC(fghthist_state::spriteram_r<0>), FUNC(fghthist_state::spriteram_w<0>));
 	map(0x17c010, 0x17c013).w(FUNC(fghthist_state::buffer_spriteram_w<0>));
 	map(0x17c020, 0x17c023).r(FUNC(fghthist_state::unk_status_r));
-	map(0x182000, 0x183fff).rw("tilegen1", FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x184000, 0x185fff).rw("tilegen1", FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
+	map(0x182000, 0x183fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
+	map(0x184000, 0x185fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
 	map(0x192000, 0x193fff).ram().w(FUNC(fghthist_state::pf_rowscroll_w<0>)).share("pf1_rowscroll32");
 	map(0x194000, 0x195fff).ram().w(FUNC(fghthist_state::pf_rowscroll_w<1>)).share("pf2_rowscroll32");
-	map(0x1a0000, 0x1a001f).rw("tilegen1", FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x1c2000, 0x1c3fff).rw("tilegen2", FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x1c4000, 0x1c5fff).rw("tilegen2", FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
+	map(0x1a0000, 0x1a001f).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x1c2000, 0x1c3fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
+	map(0x1c4000, 0x1c5fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
 	map(0x1d2000, 0x1d3fff).ram().w(FUNC(fghthist_state::pf_rowscroll_w<2>)).share("pf3_rowscroll32");
 	map(0x1d4000, 0x1d5fff).ram().w(FUNC(fghthist_state::pf_rowscroll_w<3>)).share("pf4_rowscroll32");
-	map(0x1e0000, 0x1e001f).rw("tilegen2", FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x1e0000, 0x1e001f).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
 	map(0x200000, 0x207fff).rw(FUNC(fghthist_state::ioprot_r), FUNC(fghthist_state::ioprot_w)).umask32(0xffff0000).share("prot32ram"); // only maps on 16-bits
 }
 
 void dragngun_state::namcosprite_map(address_map &map)
 {
-	map(0x204800, 0x204fff).ram().share("spclip");// (all entries set to 320x256 here)
-	map(0x208000, 0x208fff).ram().share("lay0");
-	map(0x20c000, 0x20cfff).ram().share("lay1");
-	map(0x210000, 0x217fff).ram().share("look0");
-	map(0x218000, 0x21ffff).ram().share("look1");
+	map(0x204800, 0x204fff).ram().share(m_sprite_cliptable);// (all entries set to 320x256 here)
+	map(0x208000, 0x208fff).ram().share(m_sprite_spriteformat[0]);
+	map(0x20c000, 0x20cfff).ram().share(m_sprite_spriteformat[1]);
+	map(0x210000, 0x217fff).ram().share(m_sprite_spritetile[0]);
+	map(0x218000, 0x21ffff).ram().share(m_sprite_spritetile[1]);
 	map(0x220000, 0x221fff).ram().share("spriteram"); // Main spriteram
-	map(0x228000, 0x2283ff).ram().share("spindex"); // sprite index (just a table 0x00-0xff here)
+	map(0x228000, 0x2283ff).ram().share(m_sprite_indextable); // sprite index (just a table 0x00-0xff here)
 	map(0x230000, 0x230003).w(FUNC(dragngun_state::spriteram_dma_w));
 }
 
@@ -507,14 +507,14 @@ void dragngun_state::dragngun_map(address_map &map)
 	map(0x0170038, 0x017003b).nopw();
 	map(0x017002C, 0x017002f).nopw();
 	map(0x0170224, 0x0170227).nopw();
-	map(0x0180000, 0x018001f).rw("tilegen1", FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x0190000, 0x0191fff).rw("tilegen1", FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x0194000, 0x0195fff).rw("tilegen1", FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
+	map(0x0180000, 0x018001f).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x0190000, 0x0191fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
+	map(0x0194000, 0x0195fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
 	map(0x01a0000, 0x01a3fff).ram().w(FUNC(dragngun_state::pf_rowscroll_w<0>)).share("pf1_rowscroll32");
 	map(0x01a4000, 0x01a5fff).ram().w(FUNC(dragngun_state::pf_rowscroll_w<1>)).share("pf2_rowscroll32");
-	map(0x01c0000, 0x01c001f).rw("tilegen2", FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x01d0000, 0x01d1fff).rw("tilegen2", FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x01d4000, 0x01d5fff).rw("tilegen2", FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w)); // unused
+	map(0x01c0000, 0x01c001f).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x01d0000, 0x01d1fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
+	map(0x01d4000, 0x01d5fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w)); // unused
 	map(0x01e0000, 0x01e3fff).ram().w(FUNC(dragngun_state::pf_rowscroll_w<2>)).share("pf3_rowscroll32");
 	map(0x01e4000, 0x01e5fff).ram().w(FUNC(dragngun_state::pf_rowscroll_w<3>)).share("pf4_rowscroll32"); // unused
 
@@ -554,14 +554,14 @@ void dragngun_state::lockload_map(address_map &map)
 	map(0x138008, 0x13800b).w(FUNC(dragngun_state::palette_dma_w));
 	map(0x170000, 0x170007).r(FUNC(dragngun_state::lockload_gun_mirror_r)); // Not on Dragongun
 	map(0x178008, 0x17800f).w(FUNC(dragngun_state::gun_irq_ack_w)); // Gun read ACK's
-	map(0x180000, 0x18001f).rw("tilegen1", FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x190000, 0x191fff).rw("tilegen1", FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x194000, 0x195fff).rw("tilegen1", FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
+	map(0x180000, 0x18001f).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x190000, 0x191fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
+	map(0x194000, 0x195fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
 	map(0x1a0000, 0x1a3fff).ram().w(FUNC(dragngun_state::pf_rowscroll_w<0>)).share("pf1_rowscroll32");
 	map(0x1a4000, 0x1a5fff).ram().w(FUNC(dragngun_state::pf_rowscroll_w<1>)).share("pf2_rowscroll32");
-	map(0x1c0000, 0x1c001f).rw("tilegen2", FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x1d0000, 0x1d1fff).rw("tilegen2", FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x1d4000, 0x1d5fff).rw("tilegen2", FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w)); // unused
+	map(0x1c0000, 0x1c001f).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x1d0000, 0x1d1fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
+	map(0x1d4000, 0x1d5fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w)); // unused
 	map(0x1e0000, 0x1e3fff).ram().w(FUNC(dragngun_state::pf_rowscroll_w<2>)).share("pf3_rowscroll32");
 	map(0x1e4000, 0x1e5fff).ram().w(FUNC(dragngun_state::pf_rowscroll_w<3>)).share("pf4_rowscroll32"); // unused
 
@@ -601,16 +601,16 @@ void tattass_state::tattass_map(address_map &map)
 	map(0x17c000, 0x17c003).nopw(); // Sprite DMA mode (2)
 	map(0x17c010, 0x17c013).w(FUNC(tattass_state::buffer_spriteram_w<1>));
 	map(0x17c018, 0x17c01b).nopw(); // Sprite 'CPU' (unused)
-	map(0x182000, 0x183fff).rw("tilegen1", FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x184000, 0x185fff).rw("tilegen1", FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
+	map(0x182000, 0x183fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
+	map(0x184000, 0x185fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
 	map(0x192000, 0x193fff).ram().w(FUNC(tattass_state::pf_rowscroll_w<0>)).share("pf1_rowscroll32");
 	map(0x194000, 0x195fff).ram().w(FUNC(tattass_state::pf_rowscroll_w<1>)).share("pf2_rowscroll32");
-	map(0x1a0000, 0x1a001f).rw("tilegen1", FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x1c2000, 0x1c3fff).rw("tilegen2", FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x1c4000, 0x1c5fff).rw("tilegen2", FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
+	map(0x1a0000, 0x1a001f).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x1c2000, 0x1c3fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
+	map(0x1c4000, 0x1c5fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
 	map(0x1d2000, 0x1d3fff).ram().w(FUNC(tattass_state::pf_rowscroll_w<2>)).share("pf3_rowscroll32");
 	map(0x1d4000, 0x1d5fff).ram().w(FUNC(tattass_state::pf_rowscroll_w<3>)).share("pf4_rowscroll32");
-	map(0x1e0000, 0x1e001f).rw("tilegen2", FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x1e0000, 0x1e001f).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
 	map(0x200000, 0x207fff).rw(FUNC(tattass_state::ioprot_r), FUNC(tattass_state::ioprot_w)).umask32(0xffff0000);
 	map(0x200000, 0x207fff).r(FUNC(tattass_state::nslasher_debug_r)).umask32(0x0000ffff);
 }
@@ -639,16 +639,16 @@ void nslasher_state::nslasher_map(address_map &map)
 	map(0x17c000, 0x17c003).nopw(); // Sprite DMA mode (2)
 	map(0x17c010, 0x17c013).w(FUNC(nslasher_state::buffer_spriteram_w<1>));
 	map(0x17c018, 0x17c01b).nopw(); // Sprite 'CPU' (unused)
-	map(0x182000, 0x183fff).rw("tilegen1", FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x184000, 0x185fff).rw("tilegen1", FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
+	map(0x182000, 0x183fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
+	map(0x184000, 0x185fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
 	map(0x192000, 0x193fff).ram().w(FUNC(nslasher_state::pf_rowscroll_w<0>)).share("pf1_rowscroll32");
 	map(0x194000, 0x195fff).ram().w(FUNC(nslasher_state::pf_rowscroll_w<1>)).share("pf2_rowscroll32");
-	map(0x1a0000, 0x1a001f).rw("tilegen1", FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x1c2000, 0x1c3fff).rw("tilegen2", FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x1c4000, 0x1c5fff).rw("tilegen2", FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
+	map(0x1a0000, 0x1a001f).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x1c2000, 0x1c3fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
+	map(0x1c4000, 0x1c5fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
 	map(0x1d2000, 0x1d3fff).ram().w(FUNC(nslasher_state::pf_rowscroll_w<2>)).share("pf3_rowscroll32");
 	map(0x1d4000, 0x1d5fff).ram().w(FUNC(nslasher_state::pf_rowscroll_w<3>)).share("pf4_rowscroll32");
-	map(0x1e0000, 0x1e001f).rw("tilegen2", FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x1e0000, 0x1e001f).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
 	map(0x200000, 0x207fff).rw(FUNC(nslasher_state::ioprot_r), FUNC(nslasher_state::ioprot_w)).umask32(0xffff0000);
 	map(0x200000, 0x207fff).r(FUNC(nslasher_state::nslasher_debug_r)).umask32(0x0000ffff); // seems to be debug switches / code activated by this?
 }
@@ -706,8 +706,8 @@ void dragngun_state::lockloadu_sound_map(address_map &map)
 
 u16 deco32_state::ioprot_r(offs_t offset)
 {
-	offs_t real_address = 0 + (offset * 2);
-	offs_t deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
+	const offs_t real_address = 0 + (offset * 2);
+	const offs_t deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	u8 cs = 0;
 
 	return m_ioprot->read_data(deco146_addr, cs);
@@ -715,8 +715,8 @@ u16 deco32_state::ioprot_r(offs_t offset)
 
 void deco32_state::ioprot_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	offs_t real_address = 0 + (offset * 2);
-	offs_t deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
+	const offs_t real_address = 0 + (offset * 2);
+	const offs_t deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	u8 cs = 0;
 
 	m_ioprot->write_data( deco146_addr, data, mem_mask, cs );
@@ -731,7 +731,7 @@ void deco32_state::volume_w(u8 data)
 {
 	// TODO: assume linear with a 0.0-1.0 dB scale for now
 	const u8 raw_vol = 0xff - data;
-	float vol_output = ((float)raw_vol) / 255.0f;
+	const float vol_output = ((float)raw_vol) / 255.0f;
 
 	m_ym2151->set_output_gain(ALL_OUTPUTS, vol_output);
 	m_oki[0]->set_output_gain(ALL_OUTPUTS, vol_output);
@@ -774,8 +774,8 @@ LC7535_VOLUME_CHANGED( dragngun_state::volume_main_changed )
 	logerror("Main speaker volume: left = %d dB, right %d dB, loudness = %s\n", attenuation_left, attenuation_right, loudness ? "on" :"off");
 
 	// convert to 0.0 - 1.0
-	float gain_l = m_vol_main->normalize(attenuation_left);
-	float gain_r = m_vol_main->normalize(attenuation_right);
+	const float gain_l = m_vol_main->normalize(attenuation_left);
+	const float gain_r = m_vol_main->normalize(attenuation_right);
 
 	m_ym2151->set_output_gain(0, gain_l);
 	m_ym2151->set_output_gain(1, gain_r); // left and right are always set to the same value
@@ -1204,8 +1204,8 @@ u32 captaven_state::_71_r()
 
 void captaven_state::init_captaven()
 {
-	deco56_decrypt_gfx(machine(), "gfx1");
-	deco56_decrypt_gfx(machine(), "gfx2");
+	deco56_decrypt_gfx(machine(), "tiles1");
+	deco56_decrypt_gfx(machine(), "tiles2");
 }
 
 extern void process_dvi_data(device_t *device,u8* dvi_data, int offset, int regionsize);
@@ -1255,12 +1255,12 @@ int dragngun_state::sprite_bank_callback(int sprite)
 
 void dragngun_state::dragngun_init_common()
 {
-	const u8 *SRC_RAM = memregion("gfx1")->base();
-	u8 *DST_RAM = memregion("gfx2")->base();
+	const u8 *SRC_RAM = memregion("tiles1")->base();
+	u8 *DST_RAM = memregion("tiles2")->base();
 
-	deco74_decrypt_gfx(machine(), "gfx1");
-	deco74_decrypt_gfx(machine(), "gfx2");
-	deco74_decrypt_gfx(machine(), "gfx3");
+	deco74_decrypt_gfx(machine(), "tiles1");
+	deco74_decrypt_gfx(machine(), "tiles2");
+	deco74_decrypt_gfx(machine(), "tiles3");
 
 	std::copy(&SRC_RAM[0x00000], &SRC_RAM[0x10000], &DST_RAM[0x080000]);
 	std::copy(&SRC_RAM[0x10000], &SRC_RAM[0x20000], &DST_RAM[0x110000]);
@@ -1308,17 +1308,17 @@ void dragngun_state::init_dragngunj()
 
 void fghthist_state::init_fghthist()
 {
-	deco56_decrypt_gfx(machine(), "gfx1");
-	deco74_decrypt_gfx(machine(), "gfx2");
+	deco56_decrypt_gfx(machine(), "tiles1");
+	deco74_decrypt_gfx(machine(), "tiles2");
 }
 
 void dragngun_state::init_lockload()
 {
 //  u32 *ROM = (u32 *)memregion("maincpu")->base();
 
-	deco74_decrypt_gfx(machine(), "gfx1");
-	deco74_decrypt_gfx(machine(), "gfx2");
-	deco74_decrypt_gfx(machine(), "gfx3");
+	deco74_decrypt_gfx(machine(), "tiles1");
+	deco74_decrypt_gfx(machine(), "tiles2");
+	deco74_decrypt_gfx(machine(), "tiles3");
 
 //  ROM[0x1fe3c0/4] = 0xe1a00000;//  NOP test switch lock
 //  ROM[0x1fe3cc/4] = 0xe1a00000;//  NOP test switch lock
@@ -1331,7 +1331,7 @@ void dragngun_state::init_lockload()
 
 void tattass_state::init_tattass()
 {
-	u8 *RAM = memregion("gfx1")->base();
+	u8 *RAM = memregion("tiles1")->base();
 	std::vector<u8> tmp(0x80000);
 
 	// Reorder bitplanes to make decoding easier
@@ -1339,13 +1339,13 @@ void tattass_state::init_tattass()
 	std::copy(&RAM[0x100000], &RAM[0x180000], &RAM[0x080000]);
 	std::copy(tmp.begin(),    tmp.end(),      &RAM[0x100000]);
 
-	RAM = memregion("gfx2")->base();
+	RAM = memregion("tiles2")->base();
 	std::copy(&RAM[0x080000], &RAM[0x100000], tmp.begin());
 	std::copy(&RAM[0x100000], &RAM[0x180000], &RAM[0x080000]);
 	std::copy(tmp.begin(),    tmp.end(),      &RAM[0x100000]);
 
-	deco56_decrypt_gfx(machine(), "gfx1"); // 141
-	deco56_decrypt_gfx(machine(), "gfx2"); // 141
+	deco56_decrypt_gfx(machine(), "tiles1"); // 141
+	deco56_decrypt_gfx(machine(), "tiles2"); // 141
 
 	save_item(NAME(m_tattass_eprom_bit));
 	save_item(NAME(m_last_clock));
@@ -1358,7 +1358,7 @@ void tattass_state::init_tattass()
 
 void nslasher_state::init_nslasher()
 {
-	u8 *RAM = memregion("gfx1")->base();
+	u8 *RAM = memregion("tiles1")->base();
 	std::vector<u8> tmp(0x80000);
 
 	// Reorder bitplanes to make decoding easier
@@ -1366,13 +1366,13 @@ void nslasher_state::init_nslasher()
 	std::copy(&RAM[0x100000], &RAM[0x180000], &RAM[0x080000]);
 	std::copy(tmp.begin(),    tmp.end(),      &RAM[0x100000]);
 
-	RAM = memregion("gfx2")->base();
+	RAM = memregion("tiles2")->base();
 	std::copy(&RAM[0x080000], &RAM[0x100000], tmp.begin());
 	std::copy(&RAM[0x100000], &RAM[0x180000], &RAM[0x080000]);
 	std::copy(tmp.begin(),    tmp.end(),      &RAM[0x100000]);
 
-	deco56_decrypt_gfx(machine(), "gfx1"); // 141
-	deco74_decrypt_gfx(machine(), "gfx2");
+	deco56_decrypt_gfx(machine(), "tiles1"); // 141
+	deco74_decrypt_gfx(machine(), "tiles2");
 
 	deco156_decrypt(machine());
 
@@ -1853,31 +1853,43 @@ static const gfx_layout tilelayout_5bpp =
 };
 
 static GFXDECODE_START( gfx_captaven )
-	GFXDECODE_ENTRY( "gfx1", 0, charlayout,      0, 128 ) // Characters 8x8
-	GFXDECODE_ENTRY( "gfx1", 0, tilelayout,      0, 128 ) // Tiles 16x16
-	GFXDECODE_ENTRY( "gfx2", 0, tilelayout_8bpp, 0,   8 ) // Tiles 16x16
-	GFXDECODE_ENTRY( "gfx3", 0, tilelayout,      0,  32 ) // Sprites 16x16
+	GFXDECODE_ENTRY( "tiles1", 0, charlayout,      0, 128 ) // Characters 8x8
+	GFXDECODE_ENTRY( "tiles1", 0, tilelayout,      0, 128 ) // Tiles 16x16
+	GFXDECODE_ENTRY( "tiles2", 0, tilelayout_8bpp, 0,   8 ) // Tiles 16x16
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_captaven_spr )
+	GFXDECODE_ENTRY( "sprites1", 0, tilelayout,      0,  32 ) // Sprites 16x16
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_fghthist )
-	GFXDECODE_ENTRY( "gfx1", 0, charlayout,    0, 128 ) // Characters 8x8
-	GFXDECODE_ENTRY( "gfx1", 0, tilelayout,    0, 128 ) // Tiles 16x16
-	GFXDECODE_ENTRY( "gfx2", 0, tilelayout,    0, 128 ) // Tiles 16x16
-	GFXDECODE_ENTRY( "gfx3", 0, tilelayout, 1024,  32 ) // Sprites 16x16
+	GFXDECODE_ENTRY( "tiles1", 0, charlayout,    0, 128 ) // Characters 8x8
+	GFXDECODE_ENTRY( "tiles1", 0, tilelayout,    0, 128 ) // Tiles 16x16
+	GFXDECODE_ENTRY( "tiles2", 0, tilelayout,    0, 128 ) // Tiles 16x16
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_fghthist_spr )
+	GFXDECODE_ENTRY( "sprites1", 0, tilelayout, 1024,  32 ) // Sprites 16x16
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_dragngun )
-	GFXDECODE_ENTRY( "gfx1", 0, charlayout,      0, 64 ) // Characters 8x8
-	GFXDECODE_ENTRY( "gfx2", 0, tilelayout,      0, 64 ) // Tiles 16x16
-	GFXDECODE_ENTRY( "gfx3", 0, tilelayout_8bpp, 0,  8 ) // Tiles 16x16
+	GFXDECODE_ENTRY( "tiles1", 0, charlayout,      0, 64 ) // Characters 8x8
+	GFXDECODE_ENTRY( "tiles2", 0, tilelayout,      0, 64 ) // Tiles 16x16
+	GFXDECODE_ENTRY( "tiles3", 0, tilelayout_8bpp, 0,  8 ) // Tiles 16x16
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_nslasher )
-	GFXDECODE_ENTRY( "gfx1", 0, charlayout,  0x800, 128 ) // Characters 8x8
-	GFXDECODE_ENTRY( "gfx1", 0, tilelayout,      0, 128 ) // Tiles 16x16
-	GFXDECODE_ENTRY( "gfx2", 0, tilelayout,      0, 128 ) // Tiles 16x16
-	GFXDECODE_ENTRY( "gfx3", 0, tilelayout_5bpp, 0,  16 ) // Sprites 16x16
-	GFXDECODE_ENTRY( "gfx4", 0, tilelayout,      0,  16 ) // Sprites 16x16
+	GFXDECODE_ENTRY( "tiles1", 0, charlayout,  0x800, 128 ) // Characters 8x8
+	GFXDECODE_ENTRY( "tiles1", 0, tilelayout,      0, 128 ) // Tiles 16x16
+	GFXDECODE_ENTRY( "tiles2", 0, tilelayout,      0, 128 ) // Tiles 16x16
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_nslasher_spr1 )
+	GFXDECODE_ENTRY( "sprites1", 0, tilelayout_5bpp, 0,  16 ) // Sprites 16x16
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_nslasher_spr2 )
+	GFXDECODE_ENTRY( "sprites2", 0, tilelayout,      0,  16 ) // Sprites 16x16
 GFXDECODE_END
 
 
@@ -1936,10 +1948,9 @@ void captaven_state::captaven(machine_config &config)
 	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
 	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_SPRITE(config, m_sprgen[0], 0);
-	m_sprgen[0]->set_gfx_region(3);
+	DECO_SPRITE(config, m_sprgen[0], 0, m_palette, gfx_captaven_spr);
 	m_sprgen[0]->set_pri_callback(FUNC(captaven_state::captaven_pri_callback));
-	m_sprgen[0]->set_gfxdecode_tag(m_gfxdecode);
+	m_sprgen[0]->set_alt_format(true);
 
 	DECO146PROT(config, m_ioprot, 0);
 	m_ioprot->port_a_cb().set_ioport("IN0");
@@ -2013,10 +2024,8 @@ void fghthist_state::fghthist(machine_config &config)
 	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
 	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_SPRITE(config, m_sprgen[0], 0);
-	m_sprgen[0]->set_gfx_region(3);
+	DECO_SPRITE(config, m_sprgen[0], 0, m_palette, gfx_fghthist_spr);
 	m_sprgen[0]->set_pri_callback(FUNC(fghthist_state::fghthist_pri_callback));
-	m_sprgen[0]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO146PROT(config, m_ioprot, 0);
 	m_ioprot->port_a_cb().set_ioport("IN0");
@@ -2348,13 +2357,8 @@ void tattass_state::tattass(machine_config &config)
 	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
 	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_SPRITE(config, m_sprgen[0], 0);
-	m_sprgen[0]->set_gfx_region(3);
-	m_sprgen[0]->set_gfxdecode_tag(m_gfxdecode);
-
-	DECO_SPRITE(config, m_sprgen[1], 0);
-	m_sprgen[1]->set_gfx_region(4);
-	m_sprgen[1]->set_gfxdecode_tag(m_gfxdecode);
+	DECO_SPRITE(config, m_sprgen[0], 0, m_deco_ace, gfx_nslasher_spr1);
+	DECO_SPRITE(config, m_sprgen[1], 0, m_deco_ace, gfx_nslasher_spr2);
 
 	GFXDECODE(config, m_gfxdecode, m_deco_ace, gfx_nslasher);
 
@@ -2424,13 +2428,8 @@ void nslasher_state::nslasher(machine_config &config)
 	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
 	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_SPRITE(config, m_sprgen[0], 0);
-	m_sprgen[0]->set_gfx_region(3);
-	m_sprgen[0]->set_gfxdecode_tag(m_gfxdecode);
-
-	DECO_SPRITE(config, m_sprgen[1], 0);
-	m_sprgen[1]->set_gfx_region(4);
-	m_sprgen[1]->set_gfxdecode_tag(m_gfxdecode);
+	DECO_SPRITE(config, m_sprgen[0], 0, m_deco_ace, gfx_nslasher_spr1);
+	DECO_SPRITE(config, m_sprgen[1], 0, m_deco_ace, gfx_nslasher_spr2);
 
 	GFXDECODE(config, m_gfxdecode, m_deco_ace, gfx_nslasher);
 
@@ -2502,10 +2501,10 @@ ROM_START( captaven ) // DE-0351-x PCB (x=3 or 4)
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "hj_08.17k",  0x00000,  0x10000,  CRC(361fbd16) SHA1(c4bbaf74e09c263044be74bb2c98caf6cfcab618) )
 
-	ROM_REGION( 0x80000, "gfx1", 0 )
+	ROM_REGION( 0x80000, "tiles1", 0 )
 	ROM_LOAD( "man-00.8a",  0x000000,  0x80000,  CRC(7855a607) SHA1(fa0be080515482281e5a12fe172eeb9a21af0820) ) // Encrypted tiles
 
-	ROM_REGION( 0x500000, "gfx2", 0 )
+	ROM_REGION( 0x500000, "tiles2", 0 )
 	ROM_LOAD( "man-05.16a", 0x000000,  0x40000,  CRC(d44d1995) SHA1(e88e1a59a4b24ad058f21538f6e9bbba94a166b4) ) // Encrypted tiles
 	ROM_CONTINUE(           0x140000,  0x40000 )
 	ROM_CONTINUE(           0x280000,  0x40000 )
@@ -2527,7 +2526,7 @@ ROM_START( captaven ) // DE-0351-x PCB (x=3 or 4)
 	ROM_CONTINUE(           0x380000,  0x40000 )
 	ROM_CONTINUE(           0x4c0000,  0x40000 )
 
-	ROM_REGION( 0x400000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x400000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "man-06.17a",  0x200000,  0x100000,  CRC(a9a64297) SHA1(e4cb441207b1907461c90c32c05a461c9bd30756) )
 	ROM_LOAD( "man-07.18a",  0x000000,  0x100000,  CRC(b1db200c) SHA1(970bb15e90194dd285f53594aca5dec3405e75d5) )
 	ROM_LOAD( "man-08.17c",  0x300000,  0x100000,  CRC(28e98e66) SHA1(55dbbd945eada81f7dcc874fdcb0b9e62ea453f0) )
@@ -2559,10 +2558,10 @@ ROM_START( captavena ) // DE-0351-x PCB (x=3 or 4)
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "hj_08.17k",  0x00000,  0x10000,  CRC(361fbd16) SHA1(c4bbaf74e09c263044be74bb2c98caf6cfcab618) )
 
-	ROM_REGION( 0x80000, "gfx1", 0 )
+	ROM_REGION( 0x80000, "tiles1", 0 )
 	ROM_LOAD( "man-00.8a",  0x000000,  0x80000,  CRC(7855a607) SHA1(fa0be080515482281e5a12fe172eeb9a21af0820) ) // Encrypted tiles
 
-	ROM_REGION( 0x500000, "gfx2", 0 )
+	ROM_REGION( 0x500000, "tiles2", 0 )
 	ROM_LOAD( "man-05.16a", 0x000000,  0x40000,  CRC(d44d1995) SHA1(e88e1a59a4b24ad058f21538f6e9bbba94a166b4) ) // Encrypted tiles
 	ROM_CONTINUE(           0x140000,  0x40000 )
 	ROM_CONTINUE(           0x280000,  0x40000 )
@@ -2584,7 +2583,7 @@ ROM_START( captavena ) // DE-0351-x PCB (x=3 or 4)
 	ROM_CONTINUE(           0x380000,  0x40000 )
 	ROM_CONTINUE(           0x4c0000,  0x40000 )
 
-	ROM_REGION( 0x400000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x400000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "man-06.17a",  0x200000,  0x100000,  CRC(a9a64297) SHA1(e4cb441207b1907461c90c32c05a461c9bd30756) )
 	ROM_LOAD( "man-07.18a",  0x000000,  0x100000,  CRC(b1db200c) SHA1(970bb15e90194dd285f53594aca5dec3405e75d5) )
 	ROM_LOAD( "man-08.17c",  0x300000,  0x100000,  CRC(28e98e66) SHA1(55dbbd945eada81f7dcc874fdcb0b9e62ea453f0) )
@@ -2616,10 +2615,10 @@ ROM_START( captavene ) // DE-0351-x PCB (x=3 or 4)
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "hj_08.17k",  0x00000,  0x10000,  CRC(361fbd16) SHA1(c4bbaf74e09c263044be74bb2c98caf6cfcab618) )
 
-	ROM_REGION( 0x80000, "gfx1", 0 )
+	ROM_REGION( 0x80000, "tiles1", 0 )
 	ROM_LOAD( "man-00.8a",  0x000000,  0x80000,  CRC(7855a607) SHA1(fa0be080515482281e5a12fe172eeb9a21af0820) ) // Encrypted tiles
 
-	ROM_REGION( 0x500000, "gfx2", 0 )
+	ROM_REGION( 0x500000, "tiles2", 0 )
 	ROM_LOAD( "man-05.16a", 0x000000,  0x40000,  CRC(d44d1995) SHA1(e88e1a59a4b24ad058f21538f6e9bbba94a166b4) ) // Encrypted tiles
 	ROM_CONTINUE(           0x140000,  0x40000 )
 	ROM_CONTINUE(           0x280000,  0x40000 )
@@ -2641,7 +2640,7 @@ ROM_START( captavene ) // DE-0351-x PCB (x=3 or 4)
 	ROM_CONTINUE(           0x380000,  0x40000 )
 	ROM_CONTINUE(           0x4c0000,  0x40000 )
 
-	ROM_REGION( 0x400000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x400000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "man-06.17a",  0x200000,  0x100000,  CRC(a9a64297) SHA1(e4cb441207b1907461c90c32c05a461c9bd30756) )
 	ROM_LOAD( "man-07.18a",  0x000000,  0x100000,  CRC(b1db200c) SHA1(970bb15e90194dd285f53594aca5dec3405e75d5) )
 	ROM_LOAD( "man-08.17c",  0x300000,  0x100000,  CRC(28e98e66) SHA1(55dbbd945eada81f7dcc874fdcb0b9e62ea453f0) )
@@ -2674,10 +2673,10 @@ ROM_START( captavenu ) // DE-0351-x PCB (x=3 or 4)
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "hj_08.17k",  0x00000,  0x10000,  CRC(361fbd16) SHA1(c4bbaf74e09c263044be74bb2c98caf6cfcab618) )
 
-	ROM_REGION( 0x80000, "gfx1", 0 )
+	ROM_REGION( 0x80000, "tiles1", 0 )
 	ROM_LOAD( "man-00.8a",  0x000000,  0x80000,  CRC(7855a607) SHA1(fa0be080515482281e5a12fe172eeb9a21af0820) ) // Encrypted tiles
 
-	ROM_REGION( 0x500000, "gfx2", 0 )
+	ROM_REGION( 0x500000, "tiles2", 0 )
 	ROM_LOAD( "man-05.16a", 0x000000,  0x40000,  CRC(d44d1995) SHA1(e88e1a59a4b24ad058f21538f6e9bbba94a166b4) ) // Encrypted tiles
 	ROM_CONTINUE(           0x140000,  0x40000 )
 	ROM_CONTINUE(           0x280000,  0x40000 )
@@ -2699,7 +2698,7 @@ ROM_START( captavenu ) // DE-0351-x PCB (x=3 or 4)
 	ROM_CONTINUE(           0x380000,  0x40000 )
 	ROM_CONTINUE(           0x4c0000,  0x40000 )
 
-	ROM_REGION( 0x400000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x400000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "man-06.17a",  0x200000,  0x100000,  CRC(a9a64297) SHA1(e4cb441207b1907461c90c32c05a461c9bd30756) )
 	ROM_LOAD( "man-07.18a",  0x000000,  0x100000,  CRC(b1db200c) SHA1(970bb15e90194dd285f53594aca5dec3405e75d5) )
 	ROM_LOAD( "man-08.17c",  0x300000,  0x100000,  CRC(28e98e66) SHA1(55dbbd945eada81f7dcc874fdcb0b9e62ea453f0) )
@@ -2731,10 +2730,10 @@ ROM_START( captavenuu ) // DE-0351-x PCB (x=3 or 4)
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "hj_08.17k",  0x00000,  0x10000,  CRC(361fbd16) SHA1(c4bbaf74e09c263044be74bb2c98caf6cfcab618) )
 
-	ROM_REGION( 0x80000, "gfx1", 0 )
+	ROM_REGION( 0x80000, "tiles1", 0 )
 	ROM_LOAD( "man-00.8a",  0x000000,  0x80000,  CRC(7855a607) SHA1(fa0be080515482281e5a12fe172eeb9a21af0820) ) // Encrypted tiles
 
-	ROM_REGION( 0x500000, "gfx2", 0 )
+	ROM_REGION( 0x500000, "tiles2", 0 )
 	ROM_LOAD( "man-05.16a", 0x000000,  0x40000,  CRC(d44d1995) SHA1(e88e1a59a4b24ad058f21538f6e9bbba94a166b4) ) // Encrypted tiles
 	ROM_CONTINUE(           0x140000,  0x40000 )
 	ROM_CONTINUE(           0x280000,  0x40000 )
@@ -2756,7 +2755,7 @@ ROM_START( captavenuu ) // DE-0351-x PCB (x=3 or 4)
 	ROM_CONTINUE(           0x380000,  0x40000 )
 	ROM_CONTINUE(           0x4c0000,  0x40000 )
 
-	ROM_REGION( 0x400000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x400000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "man-06.17a",  0x200000,  0x100000,  CRC(a9a64297) SHA1(e4cb441207b1907461c90c32c05a461c9bd30756) )
 	ROM_LOAD( "man-07.18a",  0x000000,  0x100000,  CRC(b1db200c) SHA1(970bb15e90194dd285f53594aca5dec3405e75d5) )
 	ROM_LOAD( "man-08.17c",  0x300000,  0x100000,  CRC(28e98e66) SHA1(55dbbd945eada81f7dcc874fdcb0b9e62ea453f0) )
@@ -2788,10 +2787,10 @@ ROM_START( captavenua ) // DE-0351-x PCB (x=3 or 4)
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "hj_08.17k",  0x00000,  0x10000,  CRC(361fbd16) SHA1(c4bbaf74e09c263044be74bb2c98caf6cfcab618) )
 
-	ROM_REGION( 0x80000, "gfx1", 0 )
+	ROM_REGION( 0x80000, "tiles1", 0 )
 	ROM_LOAD( "man-00.8a",  0x000000,  0x80000,  CRC(7855a607) SHA1(fa0be080515482281e5a12fe172eeb9a21af0820) ) // Encrypted tiles
 
-	ROM_REGION( 0x500000, "gfx2", 0 )
+	ROM_REGION( 0x500000, "tiles2", 0 )
 	ROM_LOAD( "man-05.16a", 0x000000,  0x40000,  CRC(d44d1995) SHA1(e88e1a59a4b24ad058f21538f6e9bbba94a166b4) ) // Encrypted tiles
 	ROM_CONTINUE(           0x140000,  0x40000 )
 	ROM_CONTINUE(           0x280000,  0x40000 )
@@ -2813,7 +2812,7 @@ ROM_START( captavenua ) // DE-0351-x PCB (x=3 or 4)
 	ROM_CONTINUE(           0x380000,  0x40000 )
 	ROM_CONTINUE(           0x4c0000,  0x40000 )
 
-	ROM_REGION( 0x400000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x400000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "man-06.17a",  0x200000,  0x100000,  CRC(a9a64297) SHA1(e4cb441207b1907461c90c32c05a461c9bd30756) )
 	ROM_LOAD( "man-07.18a",  0x000000,  0x100000,  CRC(b1db200c) SHA1(970bb15e90194dd285f53594aca5dec3405e75d5) )
 	ROM_LOAD( "man-08.17c",  0x300000,  0x100000,  CRC(28e98e66) SHA1(55dbbd945eada81f7dcc874fdcb0b9e62ea453f0) )
@@ -2845,10 +2844,10 @@ ROM_START( captavenj ) // DE-0351-x PCB (x=3 or 4)
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "hj_08.17k",  0x00000,  0x10000,  CRC(361fbd16) SHA1(c4bbaf74e09c263044be74bb2c98caf6cfcab618) )
 
-	ROM_REGION( 0x80000, "gfx1", 0 )
+	ROM_REGION( 0x80000, "tiles1", 0 )
 	ROM_LOAD( "man-00.8a",  0x000000,  0x80000,  CRC(7855a607) SHA1(fa0be080515482281e5a12fe172eeb9a21af0820) ) // Encrypted tiles
 
-	ROM_REGION( 0x500000, "gfx2", 0 )
+	ROM_REGION( 0x500000, "tiles2", 0 )
 	ROM_LOAD( "man-05.16a", 0x000000,  0x40000,  CRC(d44d1995) SHA1(e88e1a59a4b24ad058f21538f6e9bbba94a166b4) ) // Encrypted tiles
 	ROM_CONTINUE(           0x140000,  0x40000 )
 	ROM_CONTINUE(           0x280000,  0x40000 )
@@ -2870,7 +2869,7 @@ ROM_START( captavenj ) // DE-0351-x PCB (x=3 or 4)
 	ROM_CONTINUE(           0x380000,  0x40000 )
 	ROM_CONTINUE(           0x4c0000,  0x40000 )
 
-	ROM_REGION( 0x400000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x400000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "man-06.17a",  0x200000,  0x100000,  CRC(a9a64297) SHA1(e4cb441207b1907461c90c32c05a461c9bd30756) )
 	ROM_LOAD( "man-07.18a",  0x000000,  0x100000,  CRC(b1db200c) SHA1(970bb15e90194dd285f53594aca5dec3405e75d5) )
 	ROM_LOAD( "man-08.17c",  0x300000,  0x100000,  CRC(28e98e66) SHA1(55dbbd945eada81f7dcc874fdcb0b9e62ea453f0) )
@@ -2902,15 +2901,15 @@ ROM_START( dragngun )
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "kb10.n25",  0x00000,  0x10000,  CRC(ec56f560) SHA1(feb9491683ba7f1000edebb568d6b3471fcc87fb) )
 
-	ROM_REGION( 0x020000, "gfx1", 0 )
+	ROM_REGION( 0x020000, "tiles1", 0 )
 	ROM_LOAD16_BYTE( "kb08.a15",  0x00000,  0x10000,  CRC(8fe4e5f5) SHA1(922b94f8ce0c35e965259c11e95891ef4be913d4) ) // Encrypted tiles
 	ROM_LOAD16_BYTE( "kb09.a17",  0x00001,  0x10000,  CRC(e9dcac3f) SHA1(0621e601ffae73bbf69623042c9c8ab0526c3de6) )
 
-	ROM_REGION( 0x120000, "gfx2", 0 )
+	ROM_REGION( 0x120000, "tiles2", 0 )
 	ROM_LOAD( "mar-00.bin",    0x000000,  0x80000,  CRC(d0491a37) SHA1(cc0ae1e9e5f42ba30159fb79bccd2e237cd037d0) ) // Encrypted tiles
 	ROM_LOAD( "mar-01.bin",    0x090000,  0x80000,  CRC(d5970365) SHA1(729baf1efbef15c9f3e1d700717f5ba4f10d3014) )
 
-	ROM_REGION( 0x400000, "gfx3", 0 )
+	ROM_REGION( 0x400000, "tiles3", 0 )
 	ROM_LOAD( "mar-02.bin",  0x000000, 0x40000,  CRC(c6cd4baf) SHA1(350286829a330b64f463d0a9cbbfdb71eecf5188) ) // Encrypted tiles 0/4
 	ROM_CONTINUE(            0x100000, 0x40000 ) // 2 bpp per 0x40000 chunk, 1/4
 	ROM_CONTINUE(            0x200000, 0x40000 ) // 2/4
@@ -2982,15 +2981,15 @@ ROM_START( dragngunj )
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "ka-10.n25",  0x00000,  0x10000,  CRC(ec56f560) SHA1(feb9491683ba7f1000edebb568d6b3471fcc87fb) )
 
-	ROM_REGION( 0x020000, "gfx1", 0 )
+	ROM_REGION( 0x020000, "tiles1", 0 )
 	ROM_LOAD16_BYTE( "ka-08.a15",  0x00000,  0x10000,  CRC(8fe4e5f5) SHA1(922b94f8ce0c35e965259c11e95891ef4be913d4) ) // Encrypted tiles
 	ROM_LOAD16_BYTE( "ka-09.a17",  0x00001,  0x10000,  CRC(e9dcac3f) SHA1(0621e601ffae73bbf69623042c9c8ab0526c3de6) )
 
-	ROM_REGION( 0x120000, "gfx2", 0 )
+	ROM_REGION( 0x120000, "tiles2", 0 )
 	ROM_LOAD( "mar-00.bin",    0x000000,  0x80000,  CRC(d0491a37) SHA1(cc0ae1e9e5f42ba30159fb79bccd2e237cd037d0) ) // Encrypted tiles
 	ROM_LOAD( "mar-01.bin",    0x090000,  0x80000,  CRC(d5970365) SHA1(729baf1efbef15c9f3e1d700717f5ba4f10d3014) )
 
-	ROM_REGION( 0x400000, "gfx3", 0 )
+	ROM_REGION( 0x400000, "tiles3", 0 )
 	ROM_LOAD( "mar-02.bin",  0x000000, 0x40000,  CRC(c6cd4baf) SHA1(350286829a330b64f463d0a9cbbfdb71eecf5188) ) // Encrypted tiles 0/4
 	ROM_CONTINUE(            0x100000, 0x40000 ) // 2 bpp per 0x40000 chunk, 1/4
 	ROM_CONTINUE(            0x200000, 0x40000 ) // 2/4
@@ -3050,13 +3049,13 @@ ROM_START( fghthist ) // DE-0395-1 PCB
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "lc02-1.18k",  0x00000,  0x10000,  CRC(5fd2309c) SHA1(2fb7af54d5cd9bf7dd6fb4f6b82aa52b03294f1f) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles1", 0 )
 	ROM_LOAD( "mbf00-8.8a",  0x000000,  0x100000,  CRC(d3e9b580) SHA1(fc4676e0ecc6c32441ff66fa1f990cc3158237db) ) // Encrypted tiles
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "tiles2", 0 )
 	ROM_LOAD( "mbf01-8.9a",  0x000000,  0x100000,  CRC(0c6ed2eb) SHA1(8e37ef4b1f0b6d3370a08758bfd602cb5f221282) ) // Encrypted tiles
 
-	ROM_REGION( 0x800000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x800000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "mbf02-16.16d",  0x000000,  0x200000,  CRC(c19c5953) SHA1(e6ed26f932c6c86bbd1fc4c000aa2f510c268009) )
 	ROM_LOAD( "mbf03-16.17d",  0x200000,  0x200000,  CRC(37d25c75) SHA1(8219d31091b4317190618edd8acc49f97cba6a1e) )
 	ROM_LOAD( "mbf04-16.18d",  0x400000,  0x200000,  CRC(f6a23fd7) SHA1(74e5559f17cd591aa25d2ed6c34ac9ed89e2e9ba) )
@@ -3085,13 +3084,13 @@ ROM_START( fghthista ) // DE-0380-2 PCB
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "kx02.18k",  0x00000,  0x10000,  CRC(5fd2309c) SHA1(2fb7af54d5cd9bf7dd6fb4f6b82aa52b03294f1f) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles1", 0 )
 	ROM_LOAD( "mbf00-8.8a",  0x000000,  0x100000,  CRC(d3e9b580) SHA1(fc4676e0ecc6c32441ff66fa1f990cc3158237db) ) // Encrypted tiles
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "tiles2", 0 )
 	ROM_LOAD( "mbf01-8.9a",  0x000000,  0x100000,  CRC(0c6ed2eb) SHA1(8e37ef4b1f0b6d3370a08758bfd602cb5f221282) ) // Encrypted tiles
 
-	ROM_REGION( 0x800000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x800000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "mbf02-16.16d",  0x000000,  0x200000,  CRC(c19c5953) SHA1(e6ed26f932c6c86bbd1fc4c000aa2f510c268009) )
 	ROM_LOAD( "mbf03-16.17d",  0x200000,  0x200000,  CRC(37d25c75) SHA1(8219d31091b4317190618edd8acc49f97cba6a1e) )
 	ROM_LOAD( "mbf04-16.18d",  0x400000,  0x200000,  CRC(f6a23fd7) SHA1(74e5559f17cd591aa25d2ed6c34ac9ed89e2e9ba) )
@@ -3119,13 +3118,13 @@ ROM_START( fghthistb ) // DE-0380-2 PCB
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "kx02.18k",  0x00000,  0x10000,  CRC(5fd2309c) SHA1(2fb7af54d5cd9bf7dd6fb4f6b82aa52b03294f1f) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles1", 0 )
 	ROM_LOAD( "mbf00-8.8a",  0x000000,  0x100000,  CRC(d3e9b580) SHA1(fc4676e0ecc6c32441ff66fa1f990cc3158237db) ) // Encrypted tiles
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "tiles2", 0 )
 	ROM_LOAD( "mbf01-8.9a",  0x000000,  0x100000,  CRC(0c6ed2eb) SHA1(8e37ef4b1f0b6d3370a08758bfd602cb5f221282) ) // Encrypted tiles
 
-	ROM_REGION( 0x800000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x800000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "mbf02-16.16d",  0x000000,  0x200000,  CRC(c19c5953) SHA1(e6ed26f932c6c86bbd1fc4c000aa2f510c268009) )
 	ROM_LOAD( "mbf03-16.17d",  0x200000,  0x200000,  CRC(37d25c75) SHA1(8219d31091b4317190618edd8acc49f97cba6a1e) )
 	ROM_LOAD( "mbf04-16.18d",  0x400000,  0x200000,  CRC(f6a23fd7) SHA1(74e5559f17cd591aa25d2ed6c34ac9ed89e2e9ba) )
@@ -3154,13 +3153,13 @@ ROM_START( fghthistu ) // DE-0396-0 PCB
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "lj02-.17k",  0x00000,  0x10000,  CRC(146a1063) SHA1(d16734c2443bf38add54040b9dd2628ba523638d) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles1", 0 )
 	ROM_LOAD( "mbf00-8.8a",  0x000000,  0x100000,  CRC(d3e9b580) SHA1(fc4676e0ecc6c32441ff66fa1f990cc3158237db) ) // Encrypted tiles
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "tiles2", 0 )
 	ROM_LOAD( "mbf01-8.9a",  0x000000,  0x100000,  CRC(0c6ed2eb) SHA1(8e37ef4b1f0b6d3370a08758bfd602cb5f221282) ) // Encrypted tiles
 
-	ROM_REGION( 0x800000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x800000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "mbf02-16.16d",  0x000000,  0x200000,  CRC(c19c5953) SHA1(e6ed26f932c6c86bbd1fc4c000aa2f510c268009) )
 	ROM_LOAD( "mbf03-16.17d",  0x200000,  0x200000,  CRC(37d25c75) SHA1(8219d31091b4317190618edd8acc49f97cba6a1e) )
 	ROM_LOAD( "mbf04-16.18d",  0x400000,  0x200000,  CRC(f6a23fd7) SHA1(74e5559f17cd591aa25d2ed6c34ac9ed89e2e9ba) )
@@ -3189,13 +3188,13 @@ ROM_START( fghthistua ) // DE-0395-1 PCB
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "le02.18k",  0x00000,  0x10000,  CRC(5fd2309c) SHA1(2fb7af54d5cd9bf7dd6fb4f6b82aa52b03294f1f) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles1", 0 )
 	ROM_LOAD( "mbf00-8.8a",  0x000000,  0x100000,  CRC(d3e9b580) SHA1(fc4676e0ecc6c32441ff66fa1f990cc3158237db) ) // Encrypted tiles
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "tiles2", 0 )
 	ROM_LOAD( "mbf01-8.9a",  0x000000,  0x100000,  CRC(0c6ed2eb) SHA1(8e37ef4b1f0b6d3370a08758bfd602cb5f221282) ) // Encrypted tiles
 
-	ROM_REGION( 0x800000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x800000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "mbf02-16.16d",  0x000000,  0x200000,  CRC(c19c5953) SHA1(e6ed26f932c6c86bbd1fc4c000aa2f510c268009) )
 	ROM_LOAD( "mbf03-16.17d",  0x200000,  0x200000,  CRC(37d25c75) SHA1(8219d31091b4317190618edd8acc49f97cba6a1e) )
 	ROM_LOAD( "mbf04-16.18d",  0x400000,  0x200000,  CRC(f6a23fd7) SHA1(74e5559f17cd591aa25d2ed6c34ac9ed89e2e9ba) )
@@ -3224,13 +3223,13 @@ ROM_START( fghthistub ) // DE-0395-1 PCB
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "le02.18k",  0x00000,  0x10000,  CRC(5fd2309c) SHA1(2fb7af54d5cd9bf7dd6fb4f6b82aa52b03294f1f) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles1", 0 )
 	ROM_LOAD( "mbf00-8.8a",  0x000000,  0x100000,  CRC(d3e9b580) SHA1(fc4676e0ecc6c32441ff66fa1f990cc3158237db) ) // Encrypted tiles
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "tiles2", 0 )
 	ROM_LOAD( "mbf01-8.9a",  0x000000,  0x100000,  CRC(0c6ed2eb) SHA1(8e37ef4b1f0b6d3370a08758bfd602cb5f221282) ) // Encrypted tiles
 
-	ROM_REGION( 0x800000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x800000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "mbf02-16.16d",  0x000000,  0x200000,  CRC(c19c5953) SHA1(e6ed26f932c6c86bbd1fc4c000aa2f510c268009) )
 	ROM_LOAD( "mbf03-16.17d",  0x200000,  0x200000,  CRC(37d25c75) SHA1(8219d31091b4317190618edd8acc49f97cba6a1e) )
 	ROM_LOAD( "mbf04-16.18d",  0x400000,  0x200000,  CRC(f6a23fd7) SHA1(74e5559f17cd591aa25d2ed6c34ac9ed89e2e9ba) )
@@ -3259,13 +3258,13 @@ ROM_START( fghthistuc ) // DE-0380-2 PCB
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "kz02.18k",  0x00000,  0x10000,  CRC(5fd2309c) SHA1(2fb7af54d5cd9bf7dd6fb4f6b82aa52b03294f1f) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles1", 0 )
 	ROM_LOAD( "mbf00-8.8a",  0x000000,  0x100000,  CRC(d3e9b580) SHA1(fc4676e0ecc6c32441ff66fa1f990cc3158237db) ) // Encrypted tiles
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "tiles2", 0 )
 	ROM_LOAD( "mbf01-8.9a",  0x000000,  0x100000,  CRC(0c6ed2eb) SHA1(8e37ef4b1f0b6d3370a08758bfd602cb5f221282) ) // Encrypted tiles
 
-	ROM_REGION( 0x800000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x800000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "mbf02-16.16d",  0x000000,  0x200000,  CRC(c19c5953) SHA1(e6ed26f932c6c86bbd1fc4c000aa2f510c268009) )
 	ROM_LOAD( "mbf03-16.17d",  0x200000,  0x200000,  CRC(37d25c75) SHA1(8219d31091b4317190618edd8acc49f97cba6a1e) )
 	ROM_LOAD( "mbf04-16.18d",  0x400000,  0x200000,  CRC(f6a23fd7) SHA1(74e5559f17cd591aa25d2ed6c34ac9ed89e2e9ba) )
@@ -3294,13 +3293,13 @@ ROM_START( fghthistj ) // DE-0395-1 PCB
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "lb02.18k",  0x00000,  0x10000,  CRC(5fd2309c) SHA1(2fb7af54d5cd9bf7dd6fb4f6b82aa52b03294f1f) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles1", 0 )
 	ROM_LOAD( "mbf00-8.8a",  0x000000,  0x100000,  CRC(d3e9b580) SHA1(fc4676e0ecc6c32441ff66fa1f990cc3158237db) ) // Encrypted tiles
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "tiles2", 0 )
 	ROM_LOAD( "mbf01-8.9a",  0x000000,  0x100000,  CRC(0c6ed2eb) SHA1(8e37ef4b1f0b6d3370a08758bfd602cb5f221282) ) // Encrypted tiles
 
-	ROM_REGION( 0x800000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x800000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "mbf02-16.16d",  0x000000,  0x200000,  CRC(c19c5953) SHA1(e6ed26f932c6c86bbd1fc4c000aa2f510c268009) )
 	ROM_LOAD( "mbf03-16.17d",  0x200000,  0x200000,  CRC(37d25c75) SHA1(8219d31091b4317190618edd8acc49f97cba6a1e) )
 	ROM_LOAD( "mbf04-16.18d",  0x400000,  0x200000,  CRC(f6a23fd7) SHA1(74e5559f17cd591aa25d2ed6c34ac9ed89e2e9ba) )
@@ -3329,13 +3328,13 @@ ROM_START( fghthistja ) // DE-0380-2 PCB
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "kw02-.18k",  0x00000,  0x10000,  CRC(5fd2309c) SHA1(2fb7af54d5cd9bf7dd6fb4f6b82aa52b03294f1f) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles1", 0 )
 	ROM_LOAD( "mbf00-8.8a",  0x000000,  0x100000,  CRC(d3e9b580) SHA1(fc4676e0ecc6c32441ff66fa1f990cc3158237db) ) // Encrypted tiles
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "tiles2", 0 )
 	ROM_LOAD( "mbf01-8.9a",  0x000000,  0x100000,  CRC(0c6ed2eb) SHA1(8e37ef4b1f0b6d3370a08758bfd602cb5f221282) ) // Encrypted tiles
 
-	ROM_REGION( 0x800000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x800000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "mbf02-16.16d",  0x000000,  0x200000,  CRC(c19c5953) SHA1(e6ed26f932c6c86bbd1fc4c000aa2f510c268009) )
 	ROM_LOAD( "mbf03-16.17d",  0x200000,  0x200000,  CRC(37d25c75) SHA1(8219d31091b4317190618edd8acc49f97cba6a1e) )
 	ROM_LOAD( "mbf04-16.18d",  0x400000,  0x200000,  CRC(f6a23fd7) SHA1(74e5559f17cd591aa25d2ed6c34ac9ed89e2e9ba) )
@@ -3364,13 +3363,13 @@ ROM_START( fghthistjb ) // DE-0380-1 PCB
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "kw02-.18k",  0x00000,  0x10000,  CRC(5fd2309c) SHA1(2fb7af54d5cd9bf7dd6fb4f6b82aa52b03294f1f) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles1", 0 )
 	ROM_LOAD( "mbf00-8.8a",  0x000000,  0x100000,  CRC(d3e9b580) SHA1(fc4676e0ecc6c32441ff66fa1f990cc3158237db) ) // Encrypted tiles
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "tiles2", 0 )
 	ROM_LOAD( "mbf01-8.9a",  0x000000,  0x100000,  CRC(0c6ed2eb) SHA1(8e37ef4b1f0b6d3370a08758bfd602cb5f221282) ) // Encrypted tiles
 
-	ROM_REGION( 0x800000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x800000, "sprites1", 0 ) // Sprites
 	ROM_LOAD( "mbf02-16.16d",  0x000000,  0x200000,  CRC(c19c5953) SHA1(e6ed26f932c6c86bbd1fc4c000aa2f510c268009) )
 	ROM_LOAD( "mbf03-16.17d",  0x200000,  0x200000,  CRC(37d25c75) SHA1(8219d31091b4317190618edd8acc49f97cba6a1e) )
 	ROM_LOAD( "mbf04-16.18d",  0x400000,  0x200000,  CRC(f6a23fd7) SHA1(74e5559f17cd591aa25d2ed6c34ac9ed89e2e9ba) )
@@ -3401,15 +3400,15 @@ ROM_START( lockload ) // Board No. DE-0420-1 + Bottom board DE-0421-0 slightly d
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "nm-06-.p22",  0x00000,  0x10000,  CRC(31d1c245) SHA1(326e35e7ebd8ea761d90e856c50d86512327f2a5) )
 
-	ROM_REGION( 0x020000, "gfx1", 0 )
+	ROM_REGION( 0x020000, "tiles1", 0 )
 	ROM_LOAD16_BYTE( "nl-04-.a15",  0x00000,  0x10000,  CRC(f097b3d9) SHA1(5748de9a796afddd78dad7f5c184269ee533c51c) ) // Encrypted tiles
 	ROM_LOAD16_BYTE( "nl-05-.a17",  0x00001,  0x10000,  CRC(448fec1e) SHA1(9a107959621cbb3688fd3ad9a8320aa5584f7d13) )
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "tiles2", 0 )
 	ROM_LOAD( "mbm-00.d15",  0x00000, 0x80000,  CRC(b97de8ff) SHA1(59508f7135af22c2ac89db78874b1e8a68c53434) ) // Encrypted tiles
 	ROM_LOAD( "mbm-01.d17",  0x80000, 0x80000,  CRC(6d4b8fa0) SHA1(56e2b9adb4d010ba2592eccba654a24141441141) )
 
-	ROM_REGION( 0x800000, "gfx3", 0 )
+	ROM_REGION( 0x800000, "tiles3", 0 )
 	ROM_LOAD( "mbm-02.b21",  0x000000, 0x40000,  CRC(e723019f) SHA1(15361d3e6db5707a7f0ead4254463c50163c864c) ) // Encrypted tiles 0/4
 	ROM_CONTINUE(            0x200000, 0x40000 ) // 2 bpp per 0x40000 chunk, 1/4
 	ROM_CONTINUE(            0x400000, 0x40000 ) // 2/4
@@ -3470,15 +3469,15 @@ ROM_START( gunhard ) // Board No. DE-0420-1 + Bottom board DE-0421-0 slightly di
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "nj-06-1.p22",  0x00000,  0x10000,  CRC(31d1c245) SHA1(326e35e7ebd8ea761d90e856c50d86512327f2a5) )
 
-	ROM_REGION( 0x020000, "gfx1", 0 )
+	ROM_REGION( 0x020000, "tiles1", 0 )
 	ROM_LOAD16_BYTE( "nf-04-1.a15",  0x00000,  0x10000,  CRC(f097b3d9) SHA1(5748de9a796afddd78dad7f5c184269ee533c51c) ) // Encrypted tiles
 	ROM_LOAD16_BYTE( "nf-05-1.a17",  0x00001,  0x10000,  CRC(448fec1e) SHA1(9a107959621cbb3688fd3ad9a8320aa5584f7d13) )
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "tiles2", 0 )
 	ROM_LOAD( "mbm-00.d15",  0x00000, 0x80000,  CRC(b97de8ff) SHA1(59508f7135af22c2ac89db78874b1e8a68c53434) ) // Encrypted tiles
 	ROM_LOAD( "mbm-01.d17",  0x80000, 0x80000,  CRC(6d4b8fa0) SHA1(56e2b9adb4d010ba2592eccba654a24141441141) )
 
-	ROM_REGION( 0x800000, "gfx3", 0 )
+	ROM_REGION( 0x800000, "tiles3", 0 )
 	ROM_LOAD( "mbm-02.b21",  0x000000, 0x40000,  CRC(e723019f) SHA1(15361d3e6db5707a7f0ead4254463c50163c864c) ) // Encrypted tiles 0/4
 	ROM_CONTINUE(            0x200000, 0x40000 ) // 2 bpp per 0x40000 chunk, 1/4
 	ROM_CONTINUE(            0x400000, 0x40000 ) // 2/4
@@ -3539,15 +3538,15 @@ ROM_START( lockloadu ) // Board No. DE-0359-2 + Bottom board DE-0360-4, a Dragon
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "nh-06-0.n25",  0x00000,  0x10000,  CRC(7a1af51d) SHA1(54e6b16d3f5b787d3c6eb7203d8854e6e0fb9803) )
 
-	ROM_REGION( 0x020000, "gfx1", 0 )
+	ROM_REGION( 0x020000, "tiles1", 0 )
 	ROM_LOAD16_BYTE( "nh-04-0.b15",  0x00000,  0x10000,  CRC(f097b3d9) SHA1(5748de9a796afddd78dad7f5c184269ee533c51c) ) // Encrypted tiles
 	ROM_LOAD16_BYTE( "nh-05-0.b17",  0x00001,  0x10000,  CRC(448fec1e) SHA1(9a107959621cbb3688fd3ad9a8320aa5584f7d13) )
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "tiles2", 0 )
 	ROM_LOAD( "mbm-00.d15",  0x00000, 0x80000,  CRC(b97de8ff) SHA1(59508f7135af22c2ac89db78874b1e8a68c53434) ) // Encrypted tiles
 	ROM_LOAD( "mbm-01.d17",  0x80000, 0x80000,  CRC(6d4b8fa0) SHA1(56e2b9adb4d010ba2592eccba654a24141441141) )
 
-	ROM_REGION( 0x800000, "gfx3", 0 )
+	ROM_REGION( 0x800000, "tiles3", 0 )
 	ROM_LOAD( "mbm-02.b23",  0x000000, 0x40000,  CRC(e723019f) SHA1(15361d3e6db5707a7f0ead4254463c50163c864c) ) // Encrypted tiles 0/4
 	ROM_CONTINUE(            0x200000, 0x40000 ) // 2 bpp per 0x40000 chunk, 1/4
 	ROM_CONTINUE(            0x400000, 0x40000 ) // 2/4
@@ -3624,19 +3623,19 @@ ROM_START( tattass )
 	ROM_REGION(0x10000, "decobsmt:soundcpu", 0 ) // Sound CPU
 	ROM_LOAD( "u7.snd",  0x00000, 0x10000,  CRC(6947be8a) SHA1(4ac6c3c7f54501f23c434708cea6bf327bc8cf95) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles1", 0 )
 	ROM_LOAD16_BYTE( "abak_b01.s02",  0x000000, 0x80000,  CRC(bc805680) SHA1(ccdbca23fc843ef82a3524020999542f43b3c618) )
 	ROM_LOAD16_BYTE( "abak_b01.s13",  0x000001, 0x80000,  CRC(350effcd) SHA1(0452d95be9fc28bd00d846a2cc5828899d69601e) )
 	ROM_LOAD16_BYTE( "abak_b23.s02",  0x100000, 0x80000,  CRC(91abdc21) SHA1(ba08e59bc0417e863d35ea295cf58cfe8faf57b5) )
 	ROM_LOAD16_BYTE( "abak_b23.s13",  0x100001, 0x80000,  CRC(80eb50fe) SHA1(abfe1a5417ceff9d6d52372d11993bf9b1db9432) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "tiles2", 0 )
 	ROM_LOAD16_BYTE( "bbak_b01.s02",  0x000000, 0x80000,  CRC(611be9a6) SHA1(86263c8beb562e0607a65aa30fbbe030a044cd75) )
 	ROM_LOAD16_BYTE( "bbak_b01.s13",  0x000001, 0x80000,  CRC(097e0604) SHA1(6ae241b37b6bb15fc66679cf66f500b8f8a19f44) )
 	ROM_LOAD16_BYTE( "bbak_b23.s02",  0x100000, 0x80000,  CRC(3836531a) SHA1(57bead820ac396ee0ed8fb2ac5c15929896d75bf) )
 	ROM_LOAD16_BYTE( "bbak_b23.s13",  0x100001, 0x80000,  CRC(1210485a) SHA1(9edc4c96f389e231066ef164a7b2851cd7ade038) )
 
-	ROM_REGION( 0xa00000, "gfx3", 0 )
+	ROM_REGION( 0xa00000, "sprites1", 0 )
 	ROM_LOAD40_BYTE( "ob1_c0.b0",  0x000004, 0x80000,  CRC(053fecca) SHA1(319efc71042238d9012d2c3dddab9d11205decc6) )
 	ROM_LOAD40_BYTE( "ob1_c1.b0",  0x000003, 0x80000,  CRC(e183e6bc) SHA1(d9cce277861967f403a882879e1baefa84696bdc) )
 	ROM_LOAD40_BYTE( "ob1_c2.b0",  0x000002, 0x80000,  CRC(1314f828) SHA1(6a91543d4e70af30de287ba775c69ffb1cde719d) )
@@ -3661,7 +3660,7 @@ ROM_START( tattass )
 	ROM_LOAD40_BYTE( "ob1_c3.b3",  0x780001, 0x80000,  CRC(fc3ccb7a) SHA1(4436fcbd830912589bd6c838eb63b7d41a2bb56e) )
 	ROM_LOAD40_BYTE( "ob1_c4.b3",  0x780000, 0x80000,  CRC(dfdfd0ff) SHA1(79dc686351d41d635359936efe97c7ade305dc84) )
 
-	ROM_REGION( 0x800000, "gfx4", 0 )
+	ROM_REGION( 0x800000, "sprites2", 0 )
 	ROM_LOAD16_BYTE( "ob2_c0.b0",  0x000000, 0x80000,  CRC(9080ebe4) SHA1(1cfabe045532e16f203fe054449149451a280f56) )
 	ROM_LOAD16_BYTE( "ob2_c1.b0",  0x000001, 0x80000,  CRC(c0464970) SHA1(2bd87c9a7ed0742a8f1ee0c0de225e18a0351168) )
 	ROM_LOAD16_BYTE( "ob2_c2.b0",  0x400000, 0x80000,  CRC(35a2e621) SHA1(ff7687e30c379cbcee4f80c0c737cef891509881) )
@@ -3697,19 +3696,19 @@ ROM_START( tattassa )
 	ROM_REGION(0x10000, "decobsmt:soundcpu", 0 ) // Sound CPU
 	ROM_LOAD( "u7.snd",  0x00000, 0x10000,  CRC(6947be8a) SHA1(4ac6c3c7f54501f23c434708cea6bf327bc8cf95) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles1", 0 )
 	ROM_LOAD16_BYTE( "abak_b01.s02",  0x000000, 0x80000,  CRC(bc805680) SHA1(ccdbca23fc843ef82a3524020999542f43b3c618) )
 	ROM_LOAD16_BYTE( "abak_b01.s13",  0x000001, 0x80000,  CRC(350effcd) SHA1(0452d95be9fc28bd00d846a2cc5828899d69601e) )
 	ROM_LOAD16_BYTE( "abak_b23.s02",  0x100000, 0x80000,  CRC(91abdc21) SHA1(ba08e59bc0417e863d35ea295cf58cfe8faf57b5) )
 	ROM_LOAD16_BYTE( "abak_b23.s13",  0x100001, 0x80000,  CRC(80eb50fe) SHA1(abfe1a5417ceff9d6d52372d11993bf9b1db9432) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "tiles2", 0 )
 	ROM_LOAD16_BYTE( "bbak_b01.s02",  0x000000, 0x80000,  CRC(611be9a6) SHA1(86263c8beb562e0607a65aa30fbbe030a044cd75) )
 	ROM_LOAD16_BYTE( "bbak_b01.s13",  0x000001, 0x80000,  CRC(097e0604) SHA1(6ae241b37b6bb15fc66679cf66f500b8f8a19f44) )
 	ROM_LOAD16_BYTE( "bbak_b23.s02",  0x100000, 0x80000,  CRC(3836531a) SHA1(57bead820ac396ee0ed8fb2ac5c15929896d75bf) )
 	ROM_LOAD16_BYTE( "bbak_b23.s13",  0x100001, 0x80000,  CRC(1210485a) SHA1(9edc4c96f389e231066ef164a7b2851cd7ade038) )
 
-	ROM_REGION( 0xa00000, "gfx3", 0 )
+	ROM_REGION( 0xa00000, "sprites1", 0 )
 	ROM_LOAD40_BYTE( "ob1_c0.b0",  0x000004, 0x80000,  CRC(053fecca) SHA1(319efc71042238d9012d2c3dddab9d11205decc6) )
 	ROM_LOAD40_BYTE( "ob1_c1.b0",  0x000003, 0x80000,  CRC(e183e6bc) SHA1(d9cce277861967f403a882879e1baefa84696bdc) )
 	ROM_LOAD40_BYTE( "ob1_c2.b0",  0x000002, 0x80000,  CRC(1314f828) SHA1(6a91543d4e70af30de287ba775c69ffb1cde719d) )
@@ -3734,7 +3733,7 @@ ROM_START( tattassa )
 	ROM_LOAD40_BYTE( "ob1_c3.b3",  0x780001, 0x80000,  CRC(fc3ccb7a) SHA1(4436fcbd830912589bd6c838eb63b7d41a2bb56e) )
 	ROM_LOAD40_BYTE( "ob1_c4.b3",  0x780000, 0x80000,  CRC(dfdfd0ff) SHA1(79dc686351d41d635359936efe97c7ade305dc84) )
 
-	ROM_REGION( 0x800000, "gfx4", 0 )
+	ROM_REGION( 0x800000, "sprites2", 0 )
 	ROM_LOAD16_BYTE( "ob2_c0.b0",  0x000000, 0x80000,  CRC(9080ebe4) SHA1(1cfabe045532e16f203fe054449149451a280f56) )
 	ROM_LOAD16_BYTE( "ob2_c1.b0",  0x000001, 0x80000,  CRC(c0464970) SHA1(2bd87c9a7ed0742a8f1ee0c0de225e18a0351168) )
 	ROM_LOAD16_BYTE( "ob2_c2.b0",  0x400000, 0x80000,  CRC(35a2e621) SHA1(ff7687e30c379cbcee4f80c0c737cef891509881) )
@@ -3770,13 +3769,13 @@ ROM_START( nslasher ) // DE-0397-0 PCB
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "sndprg.17l",  0x00000,  0x10000,  CRC(18939e92) SHA1(50b37a78d9d2259d4b140dd17393c4e5ca92bca5) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles1", 0 )
 	ROM_LOAD( "mbh-00.8c",  0x000000,  0x200000,  CRC(a877f8a3) SHA1(79253525f360a73161894f31e211e4d6b38d307a) ) // Encrypted tiles
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "tiles2", 0 )
 	ROM_LOAD( "mbh-01.9c",  0x000000,  0x200000,  CRC(1853dafc) SHA1(b1183c0db301cbed9f079c782202dbfc553b198e) ) // Encrypted tiles
 
-	ROM_REGION( 0x640000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x640000, "sprites1", 0 ) // Sprites
 	ROM_LOAD40_WORD_SWAP( "mbh-02.14c",  0x000003,  0x200000, CRC(b2f158a1) SHA1(4f8c0b324813db198fe1dad7fff4185b828b94de) )
 	ROM_LOAD40_WORD_SWAP( "mbh-04.16c",  0x000001,  0x200000, CRC(eecfe06d) SHA1(2df817fe5e2ea31207b217bb03dc58979c05d0d2) )
 	ROM_LOAD40_BYTE(      "mbh-06.18c",  0x000000,  0x100000, CRC(038c2127) SHA1(5bdb215305f1a419fde27a83b623a38b9328e560) )
@@ -3784,7 +3783,7 @@ ROM_START( nslasher ) // DE-0397-0 PCB
 	ROM_LOAD40_WORD_SWAP( "mbh-05.17c",  0x500001,  0x080000, CRC(1d2b7c17) SHA1(ae0b8e0448a1a8180fb424fb0bc8a4302f8ff602) )
 	ROM_LOAD40_BYTE(      "mbh-07.19c",  0x500000,  0x040000, CRC(bbd22323) SHA1(6ab665b2e6d04cdadc48c52e15098e978b61fe10) )
 
-	ROM_REGION( 0x100000, "gfx4", 0 ) // Sprites
+	ROM_REGION( 0x100000, "sprites2", 0 ) // Sprites
 	ROM_LOAD( "mbh-08.16e",  0x000000,  0x80000,  CRC(cdd7f8cb) SHA1(910bbe8783c0ba722e9d6399b332d658fa059fdb) )
 	ROM_LOAD( "mbh-09.18e",  0x080000,  0x80000,  CRC(33fa2121) SHA1(eb0e99d29b1ad9995df28e5b7cfc89d53efb53c3) )
 
@@ -3811,13 +3810,13 @@ ROM_START( nslasherj ) // DE-0397-0 PCB
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "sndprg.17l",  0x00000,  0x10000,  CRC(18939e92) SHA1(50b37a78d9d2259d4b140dd17393c4e5ca92bca5) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles1", 0 )
 	ROM_LOAD( "mbh-00.8c",  0x000000,  0x200000,  CRC(a877f8a3) SHA1(79253525f360a73161894f31e211e4d6b38d307a) ) // Encrypted tiles
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "tiles2", 0 )
 	ROM_LOAD( "mbh-01.9c",  0x000000,  0x200000,  CRC(1853dafc) SHA1(b1183c0db301cbed9f079c782202dbfc553b198e) ) // Encrypted tiles
 
-	ROM_REGION( 0x640000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x640000, "sprites1", 0 ) // Sprites
 	ROM_LOAD40_WORD_SWAP( "mbh-02.14c",  0x000003,  0x200000, CRC(b2f158a1) SHA1(4f8c0b324813db198fe1dad7fff4185b828b94de) )
 	ROM_LOAD40_WORD_SWAP( "mbh-04.16c",  0x000001,  0x200000, CRC(eecfe06d) SHA1(2df817fe5e2ea31207b217bb03dc58979c05d0d2) )
 	ROM_LOAD40_BYTE(      "mbh-06.18c",  0x000000,  0x100000, CRC(038c2127) SHA1(5bdb215305f1a419fde27a83b623a38b9328e560) )
@@ -3825,7 +3824,7 @@ ROM_START( nslasherj ) // DE-0397-0 PCB
 	ROM_LOAD40_WORD_SWAP( "mbh-05.17c",  0x500001,  0x080000, CRC(1d2b7c17) SHA1(ae0b8e0448a1a8180fb424fb0bc8a4302f8ff602) )
 	ROM_LOAD40_BYTE(      "mbh-07.19c",  0x500000,  0x040000, CRC(bbd22323) SHA1(6ab665b2e6d04cdadc48c52e15098e978b61fe10) )
 
-	ROM_REGION( 0x100000, "gfx4", 0 ) // Sprites
+	ROM_REGION( 0x100000, "sprites2", 0 ) // Sprites
 	ROM_LOAD( "mbh-08.16e",  0x000000,  0x80000,  CRC(cdd7f8cb) SHA1(910bbe8783c0ba722e9d6399b332d658fa059fdb) )
 	ROM_LOAD( "mbh-09.18e",  0x080000,  0x80000,  CRC(33fa2121) SHA1(eb0e99d29b1ad9995df28e5b7cfc89d53efb53c3) )
 
@@ -3852,13 +3851,13 @@ ROM_START( nslashers ) // DE-0397-0 PCB
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "sndprg.17l",  0x00000,  0x10000,  CRC(18939e92) SHA1(50b37a78d9d2259d4b140dd17393c4e5ca92bca5) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles1", 0 )
 	ROM_LOAD( "mbh-00.8c",  0x000000,  0x200000,  CRC(a877f8a3) SHA1(79253525f360a73161894f31e211e4d6b38d307a) ) // Encrypted tiles
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "tiles2", 0 )
 	ROM_LOAD( "mbh-01.9c",  0x000000,  0x200000,  CRC(1853dafc) SHA1(b1183c0db301cbed9f079c782202dbfc553b198e) ) // Encrypted tiles
 
-	ROM_REGION( 0x640000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x640000, "sprites1", 0 ) // Sprites
 	ROM_LOAD40_WORD_SWAP( "mbh-02.14c",  0x000003,  0x200000, CRC(b2f158a1) SHA1(4f8c0b324813db198fe1dad7fff4185b828b94de) )
 	ROM_LOAD40_WORD_SWAP( "mbh-04.16c",  0x000001,  0x200000, CRC(eecfe06d) SHA1(2df817fe5e2ea31207b217bb03dc58979c05d0d2) )
 	ROM_LOAD40_BYTE(      "mbh-06.18c",  0x000000,  0x100000, CRC(038c2127) SHA1(5bdb215305f1a419fde27a83b623a38b9328e560) )
@@ -3866,7 +3865,7 @@ ROM_START( nslashers ) // DE-0397-0 PCB
 	ROM_LOAD40_WORD_SWAP( "mbh-05.17c",  0x500001,  0x080000, CRC(1d2b7c17) SHA1(ae0b8e0448a1a8180fb424fb0bc8a4302f8ff602) )
 	ROM_LOAD40_BYTE(      "mbh-07.19c",  0x500000,  0x040000, CRC(bbd22323) SHA1(6ab665b2e6d04cdadc48c52e15098e978b61fe10) )
 
-	ROM_REGION( 0x100000, "gfx4", 0 ) // Sprites
+	ROM_REGION( 0x100000, "sprites2", 0 ) // Sprites
 	ROM_LOAD( "mbh-08.16e",  0x000000,  0x80000,  CRC(cdd7f8cb) SHA1(910bbe8783c0ba722e9d6399b332d658fa059fdb) )
 	ROM_LOAD( "mbh-09.18e",  0x080000,  0x80000,  CRC(33fa2121) SHA1(eb0e99d29b1ad9995df28e5b7cfc89d53efb53c3) )
 
@@ -3893,13 +3892,13 @@ ROM_START( nslasheru ) // DE-0395-1 PCB
 	ROM_REGION(0x10000, "audiocpu", 0 ) // Sound CPU
 	ROM_LOAD( "02.l18",  0x00000,  0x10000, CRC(5e63bd91) SHA1(a6ac3c8c50f44cf2e6cf029aef1c974d1fc16ed5) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles1", 0 )
 	ROM_LOAD( "mbh-00.8c",  0x000000,  0x200000,  CRC(a877f8a3) SHA1(79253525f360a73161894f31e211e4d6b38d307a) ) // Encrypted tiles
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "tiles2", 0 )
 	ROM_LOAD( "mbh-01.9c",  0x000000,  0x200000,  CRC(1853dafc) SHA1(b1183c0db301cbed9f079c782202dbfc553b198e) ) // Encrypted tiles
 
-	ROM_REGION( 0x640000, "gfx3", 0 ) // Sprites
+	ROM_REGION( 0x640000, "sprites1", 0 ) // Sprites
 	ROM_LOAD40_WORD_SWAP( "mbh-02.14c",  0x000003,  0x200000, CRC(b2f158a1) SHA1(4f8c0b324813db198fe1dad7fff4185b828b94de) )
 	ROM_LOAD40_WORD_SWAP( "mbh-04.16c",  0x000001,  0x200000, CRC(eecfe06d) SHA1(2df817fe5e2ea31207b217bb03dc58979c05d0d2) )
 	ROM_LOAD40_BYTE(      "mbh-06.18c",  0x000000,  0x100000, CRC(038c2127) SHA1(5bdb215305f1a419fde27a83b623a38b9328e560) )
@@ -3907,7 +3906,7 @@ ROM_START( nslasheru ) // DE-0395-1 PCB
 	ROM_LOAD40_WORD_SWAP( "mbh-05.17c",  0x500001,  0x080000, CRC(1d2b7c17) SHA1(ae0b8e0448a1a8180fb424fb0bc8a4302f8ff602) )
 	ROM_LOAD40_BYTE(      "mbh-07.19c",  0x500000,  0x040000, CRC(bbd22323) SHA1(6ab665b2e6d04cdadc48c52e15098e978b61fe10) )
 
-	ROM_REGION( 0x100000, "gfx4", 0 ) // Sprites
+	ROM_REGION( 0x100000, "sprites2", 0 ) // Sprites
 	ROM_LOAD( "mbh-08.16e",  0x000000,  0x80000,  CRC(cdd7f8cb) SHA1(910bbe8783c0ba722e9d6399b332d658fa059fdb) )
 	ROM_LOAD( "mbh-09.18e",  0x080000,  0x80000,  CRC(33fa2121) SHA1(eb0e99d29b1ad9995df28e5b7cfc89d53efb53c3) )
 

--- a/src/mame/dataeast/deco32_v.cpp
+++ b/src/mame/dataeast/deco32_v.cpp
@@ -61,12 +61,12 @@ void nslasher_state::tilemap_color_bank_w(u8 data)
 
 void nslasher_state::sprite1_color_bank_w(u8 data)
 {
-	m_gfxdecode->gfx(3)->set_colorbase((data & 7) << 8);
+	m_sprgen[0]->gfx(0)->set_colorbase((data & 7) << 8);
 }
 
 void nslasher_state::sprite2_color_bank_w(u8 data)
 {
-	m_gfxdecode->gfx(4)->set_colorbase((data & 7) << 8);
+	m_sprgen[1]->gfx(0)->set_colorbase((data & 7) << 8);
 }
 
 /******************************************************************************/
@@ -170,7 +170,6 @@ u32 captaven_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, c
 
 	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
 
-	m_sprgen[0]->set_alt_format(true);
 	m_sprgen[0]->draw_sprites(bitmap, cliprect, m_spriteram16_buffered[0].get(), 0x400); // only low half of sprite ram is used?
 
 	return 0;
@@ -501,7 +500,7 @@ u32 nslasher_state::screen_update_nslasher(screen_device &screen, bitmap_rgb32 &
 		}
 	}
 
-	mix_nslasher(screen, bitmap, cliprect, m_gfxdecode->gfx(3), m_gfxdecode->gfx(4), alphaTilemap);
+	mix_nslasher(screen, bitmap, cliprect, m_sprgen[0]->gfx(0), m_sprgen[1]->gfx(0), alphaTilemap);
 
 	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
@@ -703,7 +702,7 @@ u32 tattass_state::screen_update_tattass(screen_device &screen, bitmap_rgb32 &bi
 		}
 	}
 
-	mix_tattass(screen, bitmap, cliprect, m_gfxdecode->gfx(3), m_gfxdecode->gfx(4), alphaTilemap);
+	mix_tattass(screen, bitmap, cliprect, m_sprgen[0]->gfx(0), m_sprgen[1]->gfx(0), alphaTilemap);
 
 	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;

--- a/src/mame/dataeast/funkyjet.cpp
+++ b/src/mame/dataeast/funkyjet.cpp
@@ -144,8 +144,8 @@ private:
 
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
-	uint16_t protection_region_0_146_r(offs_t offset);
-	void protection_region_0_146_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	uint16_t ioprot_r(offs_t offset);
+	void ioprot_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void maincpu_map(address_map &map);
 	void sound_map(address_map &map);
 };
@@ -154,7 +154,7 @@ private:
 
 uint32_t funkyjet_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	// Similar to chinatwn and tumblep, see video/supbtime.cpp
+	// Similar to chinatwn and tumblep, see dataeast/supbtime.cpp
 	//
 	// This causes a 2 pixel gap on the left side of the first stage of all worlds in funkyjet
 	// but allows subsequent stages to be centered and avoids corruption on the world select
@@ -170,7 +170,7 @@ uint32_t funkyjet_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 	m_deco_tilegen->set_scrolldx(1, 0, 1, 1);
 	m_deco_tilegen->set_scrolldx(1, 1, 1, 1);
 
-	uint16_t flip = m_deco_tilegen->pf_control_r(0);
+	uint16_t const flip = m_deco_tilegen->pf_control_r(0);
 
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen->set_flip_screen(BIT(flip, 7));
@@ -183,14 +183,14 @@ uint32_t funkyjet_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 	return 0;
 }
 
-uint16_t funkyjet_state::protection_region_0_146_r(offs_t offset)
+uint16_t funkyjet_state::ioprot_r(offs_t offset)
 {
 //  uint16_t realdat = deco16_146_funkyjet_prot_r(space,offset&0x3ff,mem_mask);
 
-	int real_address = 0 + (offset *2);
-	int deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,  /* note, same bitswap as fghthist */      10,  9,  8,  7,  6,   5,  4,  3,  2,  1,    0) & 0x7fff;
+	int const real_address = 0 + (offset *2);
+	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,  /* note, same bitswap as fghthist */      10,  9,  8,  7,  6,   5,  4,  3,  2,  1,    0) & 0x7fff;
 	uint8_t cs = 0;
-	uint16_t data = m_deco146->read_data( deco146_addr, cs );
+	uint16_t const data = m_deco146->read_data( deco146_addr, cs );
 
 //  if ((realdat & mem_mask) != (data & mem_mask))
 //      printf("returned %04x instead of %04x (real address %08x swapped addr %08x)\n", data, realdat, real_address, deco146_addr);
@@ -198,12 +198,12 @@ uint16_t funkyjet_state::protection_region_0_146_r(offs_t offset)
 	return data;
 }
 
-void funkyjet_state::protection_region_0_146_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void funkyjet_state::ioprot_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 //  deco16_146_funkyjet_prot_w(space,offset&0x3ff,data,mem_mask);
 
-	int real_address = 0 + (offset *2);
-	int deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14, /* note, same bitswap as fghthist */       10,  9,  8,  7,  6,   5,  4,  3,  2,  1,    0) & 0x7fff;
+	int const real_address = 0 + (offset *2);
+	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14, /* note, same bitswap as fghthist */       10,  9,  8,  7,  6,   5,  4,  3,  2,  1,    0) & 0x7fff;
 	uint8_t cs = 0;
 	m_deco146->write_data( deco146_addr, data, mem_mask, cs );
 }
@@ -215,7 +215,7 @@ void funkyjet_state::maincpu_map(address_map &map)
 	map(0x120000, 0x1207ff).ram().w("palette", FUNC(palette_device::write16)).share("palette");
 	map(0x140000, 0x143fff).ram();
 	map(0x160000, 0x1607ff).ram().share(m_spriteram);
-	map(0x180000, 0x183fff).rw(FUNC(funkyjet_state::protection_region_0_146_r), FUNC(funkyjet_state::protection_region_0_146_w)).share("prot16ram"); // Protection device, unlikely to be cs0 region
+	map(0x180000, 0x183fff).rw(FUNC(funkyjet_state::ioprot_r), FUNC(funkyjet_state::ioprot_w)).share("prot16ram"); // Protection device, unlikely to be cs0 region
 	map(0x184000, 0x184001).nopw();
 	map(0x188000, 0x188001).nopw();
 	map(0x300000, 0x30000f).w(m_deco_tilegen, FUNC(deco16ic_device::pf_control_w));
@@ -388,6 +388,9 @@ static const gfx_layout tile_layout =
 static GFXDECODE_START( gfx_funkyjet )
 	GFXDECODE_ENTRY( "chars", 0, charlayout,  256, 32 )  // Characters 8x8
 	GFXDECODE_ENTRY( "chars", 0, tile_layout, 256, 32 )  // Tiles 16x16
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_funkyjet_spr )
 	GFXDECODE_ENTRY( "sprites", 0, tile_layout,   0, 16 )  // Sprites 16x16
 GFXDECODE_END
 
@@ -435,9 +438,7 @@ void funkyjet_state::funkyjet(machine_config &config)
 	m_deco_tilegen->set_pf12_16x16_bank(1);
 	m_deco_tilegen->set_gfxdecode_tag("gfxdecode");
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(2);
-	m_sprgen->set_gfxdecode_tag("gfxdecode");
+	DECO_SPRITE(config, m_sprgen, 0, "palette", gfx_funkyjet_spr);
 
 	// sound hardware
 	SPEAKER(config, "lspeaker").front_left();

--- a/src/mame/dataeast/funkyjet.cpp
+++ b/src/mame/dataeast/funkyjet.cpp
@@ -95,11 +95,11 @@ Notes:
 
 #include "deco146.h"
 #include "deco16ic.h"
+#include "decocrpt.h"
 #include "decospr.h"
 
 #include "cpu/h6280/h6280.h"
 #include "cpu/m68000/m68000.h"
-#include "decocrpt.h"
 #include "machine/gen_latch.h"
 #include "sound/okim6295.h"
 #include "sound/ymopm.h"
@@ -187,10 +187,10 @@ uint16_t funkyjet_state::ioprot_r(offs_t offset)
 {
 //  uint16_t realdat = deco16_146_funkyjet_prot_r(space,offset&0x3ff,mem_mask);
 
-	int const real_address = 0 + (offset *2);
-	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,  /* note, same bitswap as fghthist */      10,  9,  8,  7,  6,   5,  4,  3,  2,  1,    0) & 0x7fff;
+	int const real_address = 0 + (offset * 2);
+	int const deco146_addr = (BIT(real_address, 14, 4) << 11) | BIT(real_address, 0, 11); // NC 31-18, 13-11 note, same bitswap as fghthist
 	uint8_t cs = 0;
-	uint16_t const data = m_deco146->read_data( deco146_addr, cs );
+	uint16_t const data = m_deco146->read_data(deco146_addr, cs);
 
 //  if ((realdat & mem_mask) != (data & mem_mask))
 //      printf("returned %04x instead of %04x (real address %08x swapped addr %08x)\n", data, realdat, real_address, deco146_addr);
@@ -203,9 +203,9 @@ void funkyjet_state::ioprot_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 //  deco16_146_funkyjet_prot_w(space,offset&0x3ff,data,mem_mask);
 
 	int const real_address = 0 + (offset *2);
-	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14, /* note, same bitswap as fghthist */       10,  9,  8,  7,  6,   5,  4,  3,  2,  1,    0) & 0x7fff;
+	int const deco146_addr = (BIT(real_address, 14, 4) << 11) | BIT(real_address, 0, 11); // NC 31-18, 13-11 note, same bitswap as fghthist
 	uint8_t cs = 0;
-	m_deco146->write_data( deco146_addr, data, mem_mask, cs );
+	m_deco146->write_data(deco146_addr, data, mem_mask, cs);
 }
 
 

--- a/src/mame/dataeast/mirage.cpp
+++ b/src/mame/dataeast/mirage.cpp
@@ -39,13 +39,15 @@ MR_01-.3A    [a0b758aa]
 ***********************************************************************************************/
 
 #include "emu.h"
-#include "cpu/m68000/m68000.h"
-#include "decocrpt.h"
-#include "machine/eepromser.h"
 #include "deco16ic.h"
+#include "decocrpt.h"
+#include "decospr.h"
+
+#include "cpu/m68000/m68000.h"
+#include "machine/eepromser.h"
 #include "sound/okim6295.h"
 #include "video/bufsprite.h"
-#include "decospr.h"
+
 #include "emupal.h"
 #include "screen.h"
 #include "speaker.h"
@@ -133,16 +135,13 @@ void miragemj_state::mjmux_w(uint16_t data)
 
 uint16_t miragemj_state::mjmux_r()
 {
-	switch (m_mux_data & 0x1f)
+	uint16_t result = 0xffff;
+	for (int i = 0; m_io_key.size() > i; ++i)
 	{
-		case 0x01: return m_io_key[0]->read();
-		case 0x02: return m_io_key[1]->read();
-		case 0x04: return m_io_key[2]->read();
-		case 0x08: return m_io_key[3]->read();
-		case 0x10: return m_io_key[4]->read();
+		if (BIT(m_mux_data, i))
+			result &= m_io_key[i]->read();
 	}
-
-	return 0xffff;
+	return result;
 }
 
 void miragemj_state::okim1_rombank_w(uint16_t data)

--- a/src/mame/dataeast/mirage.cpp
+++ b/src/mame/dataeast/mirage.cpp
@@ -64,18 +64,29 @@ public:
 		m_oki_sfx(*this, "oki_sfx"),
 		m_oki_bgm(*this, "oki_bgm"),
 		m_spriteram(*this, "spriteram") ,
-		m_pf1_rowscroll(*this, "pf1_rowscroll"),
-		m_pf2_rowscroll(*this, "pf2_rowscroll"),
-		m_sprgen(*this, "spritegen")
+		m_pf_rowscroll(*this, "pf%u_rowscroll", 1U),
+		m_sprgen(*this, "spritegen"),
+		m_io_key(*this, "KEY%u", 0U)
 	{ }
 
 	void mirage(machine_config &config);
 
 	void init_mirage();
 
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
 private:
-	/* misc */
-	uint8_t m_mux_data = 0;
+	void mjmux_w(uint16_t data);
+	uint16_t mjmux_r();
+	void okim1_rombank_w(uint16_t data);
+	void okim0_rombank_w(uint16_t data);
+	DECOSPR_PRIORITY_CB_MEMBER(pri_callback);
+
+	uint32_t screen_update_mirage(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	void mirage_map(address_map &map);
 
 	/* devices */
 	required_device<m68000_device> m_maincpu;
@@ -84,37 +95,26 @@ private:
 	required_device<okim6295_device> m_oki_sfx;
 	required_device<okim6295_device> m_oki_bgm;
 	required_device<buffered_spriteram16_device> m_spriteram;
+
 	/* memory pointers */
-	required_shared_ptr<uint16_t> m_pf1_rowscroll;
-	required_shared_ptr<uint16_t> m_pf2_rowscroll;
+	required_shared_ptr_array<uint16_t, 2> m_pf_rowscroll;
 	optional_device<decospr_device> m_sprgen;
 
-	void mjmux_w(uint16_t data);
-	uint16_t mjmux_r();
-	void okim1_rombank_w(uint16_t data);
-	void okim0_rombank_w(uint16_t data);
-	DECOSPR_PRIORITY_CB_MEMBER(pri_callback);
+	required_ioport_array<5> m_io_key;
 
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-	uint32_t screen_update_mirage(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
-	void mirage_map(address_map &map);
+	/* misc */
+	uint8_t m_mux_data = 0;
+
 };
-
-void miragemj_state::video_start()
-{
-}
 
 uint32_t miragemj_state::screen_update_mirage(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	uint16_t flip = m_deco_tilegen->pf_control_r(0);
+	uint16_t const flip = m_deco_tilegen->pf_control_r(0);
 
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen->set_flip_screen(BIT(flip, 7));
 
-	m_deco_tilegen->pf_update(m_pf1_rowscroll, m_pf2_rowscroll);
+	m_deco_tilegen->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
 
 	screen.priority().fill(0, cliprect);
 	bitmap.fill(256, cliprect); /* not verified */
@@ -135,11 +135,11 @@ uint16_t miragemj_state::mjmux_r()
 {
 	switch (m_mux_data & 0x1f)
 	{
-		case 0x01: return ioport("KEY0")->read();
-		case 0x02: return ioport("KEY1")->read();
-		case 0x04: return ioport("KEY2")->read();
-		case 0x08: return ioport("KEY3")->read();
-		case 0x10: return ioport("KEY4")->read();
+		case 0x01: return m_io_key[0]->read();
+		case 0x02: return m_io_key[1]->read();
+		case 0x04: return m_io_key[2]->read();
+		case 0x08: return m_io_key[3]->read();
+		case 0x10: return m_io_key[4]->read();
 	}
 
 	return 0xffff;
@@ -156,7 +156,7 @@ void miragemj_state::okim0_rombank_w(uint16_t data)
 	m_eeprom->di_write(BIT(data, 4));
 	m_eeprom->cs_write(BIT(data, 6) ? ASSERT_LINE : CLEAR_LINE);
 
-	/*bits 4-6 used on POST? */
+	/* bits 4-6 used on POST? */
 	m_oki_bgm->set_rom_bank(data & 0x7);
 }
 
@@ -167,8 +167,8 @@ void miragemj_state::mirage_map(address_map &map)
 	map(0x100000, 0x101fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w)); // 0x100000 - 0x101fff tested
 	map(0x102000, 0x103fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w)); // 0x102000 - 0x102fff tested
 	/* linescroll */
-	map(0x110000, 0x110bff).ram().share("pf1_rowscroll");
-	map(0x112000, 0x112bff).ram().share("pf2_rowscroll");
+	map(0x110000, 0x110bff).ram().share(m_pf_rowscroll[0]);
+	map(0x112000, 0x112bff).ram().share(m_pf_rowscroll[1]);
 	map(0x120000, 0x1207ff).ram().share("spriteram");
 	map(0x130000, 0x1307ff).ram().w("palette", FUNC(palette_device::write16)).share("palette");
 	map(0x140000, 0x14000f).rw(m_oki_sfx, FUNC(okim6295_device::read), FUNC(okim6295_device::write)).umask16(0x00ff);
@@ -257,9 +257,12 @@ static const gfx_layout tile_16x16_layout =
 };
 
 static GFXDECODE_START( gfx_mirage )
-	GFXDECODE_ENTRY("gfx1", 0, tile_8x8_layout,   0x000, 32)  /* Tiles (8x8) */
-	GFXDECODE_ENTRY("gfx1", 0, tile_16x16_layout, 0x000, 32)  /* Tiles (16x16) */
-	GFXDECODE_ENTRY("gfx2", 0, tile_16x16_layout, 0x200, 32)  /* Sprites (16x16) */
+	GFXDECODE_ENTRY("tiles", 0, tile_8x8_layout,   0x000, 32)  /* Tiles (8x8) */
+	GFXDECODE_ENTRY("tiles", 0, tile_16x16_layout, 0x000, 32)  /* Tiles (16x16) */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_mirage_spr )
+	GFXDECODE_ENTRY("sprites", 0, tile_16x16_layout, 0x200, 32)  /* Sprites (16x16) */
 GFXDECODE_END
 
 
@@ -323,10 +326,8 @@ void miragemj_state::mirage(machine_config &config)
 	m_deco_tilegen->set_pf12_16x16_bank(1);
 	m_deco_tilegen->set_gfxdecode_tag("gfxdecode");
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(2);
+	DECO_SPRITE(config, m_sprgen, 0, "palette", gfx_mirage_spr);
 	m_sprgen->set_pri_callback(FUNC(miragemj_state::pri_callback));
-	m_sprgen->set_gfxdecode_tag("gfxdecode");
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -342,10 +343,10 @@ ROM_START( mirage )
 	ROM_LOAD16_BYTE( "mr_00-.2a", 0x00000, 0x40000, CRC(3a53f33d) SHA1(0f654021dcd64202b41e0ef5ef3cdf5dd274f8a5) )
 	ROM_LOAD16_BYTE( "mr_01-.3a", 0x00001, 0x40000, CRC(a0b758aa) SHA1(7fb5faf6fb57cd72a3ac24b8af1f33e504ac8398) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 ) /* Tiles - Encrypted */
+	ROM_REGION( 0x100000, "tiles", 0 ) /* Tiles - Encrypted */
 	ROM_LOAD( "mbl-00.7a", 0x000000, 0x100000, CRC(2e258b7b) SHA1(2dbd7d16a1eda97ae3de149b67e80e511aa9d0ba) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* Sprites */
+	ROM_REGION( 0x400000, "sprites", 0 ) /* Sprites */
 	ROM_LOAD( "mbl-01.11a", 0x200000, 0x200000, CRC(895be69a) SHA1(541d8f37fb4cf99312b80a0eb0d729fbbeab5f4f) )
 	ROM_LOAD( "mbl-02.12a", 0x000000, 0x200000, CRC(474f6104) SHA1(ff81b32b90192c3d5f27c436a9246aa6caaeeeee) )
 
@@ -364,7 +365,7 @@ ROM_END
 
 void miragemj_state::init_mirage()
 {
-	deco56_decrypt_gfx(machine(), "gfx1");
+	deco56_decrypt_gfx(machine(), "tiles");
 }
 
 } // anonymous namespace

--- a/src/mame/dataeast/simpl156.cpp
+++ b/src/mame/dataeast/simpl156.cpp
@@ -1037,8 +1037,8 @@ u32 simpl156_state::joemacr_speedup_r()
 {
 	if (!machine().side_effects_disabled())
 	{
-	if (m_maincpu->pc() == 0x284)
-		m_maincpu->spin_until_time(attotime::from_usec(400));
+		if (m_maincpu->pc() == 0x284)
+			m_maincpu->spin_until_time(attotime::from_usec(400));
 	}
 	return m_systemram[0x18/4];
 }

--- a/src/mame/dataeast/simpl156.cpp
+++ b/src/mame/dataeast/simpl156.cpp
@@ -165,12 +165,11 @@ void simpl156_state::eeprom_w(u32 data)
 
 u32 simpl156_state::spriteram_r(offs_t offset)
 {
-	return m_spriteram[offset] ^ 0xffff0000;
+	return m_spriteram[offset] | 0xffff0000;
 }
 
 void simpl156_state::spriteram_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	data &= 0x0000ffff;
 	mem_mask &= 0x0000ffff;
 
 	COMBINE_DATA(&m_spriteram[offset]);
@@ -179,12 +178,11 @@ void simpl156_state::spriteram_w(offs_t offset, u32 data, u32 mem_mask)
 
 u32 simpl156_state::mainram_r(offs_t offset)
 {
-	return m_mainram[offset] ^ 0xffff0000;
+	return m_mainram[offset] | 0xffff0000;
 }
 
 void simpl156_state::mainram_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	data &= 0x0000ffff;
 	mem_mask &= 0x0000ffff;
 
 	COMBINE_DATA(&m_mainram[offset]);
@@ -193,13 +191,12 @@ void simpl156_state::mainram_w(offs_t offset, u32 data, u32 mem_mask)
 template<unsigned Layer>
 u32 simpl156_state::rowscroll_r(offs_t offset)
 {
-	return m_rowscroll[Layer][offset] ^ 0xffff0000;
+	return m_rowscroll[Layer][offset] | 0xffff0000;
 }
 
 template<unsigned Layer>
 void simpl156_state::rowscroll_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	data &= 0x0000ffff;
 	mem_mask &= 0x0000ffff;
 
 	COMBINE_DATA(&m_rowscroll[Layer][offset]);

--- a/src/mame/dataeast/simpl156.cpp
+++ b/src/mame/dataeast/simpl156.cpp
@@ -212,14 +212,14 @@ void simpl156_state::base_map(address_map &map)
 	map.unmap_value_high();
 	map(0x000000, 0x07ffff).rom(); // rom (32-bit)
 	map(0x200000, 0x200003).portr("IN0");
-	map(0x201000, 0x201fff).ram().share("systemram").mirror(0x002000); // work ram (32-bit)
+	map(0x201000, 0x201fff).ram().share(m_systemram).mirror(0x002000); // work ram (32-bit)
 }
 
 /* Joe and Mac Returns */
 void simpl156_state::joemacr_map(address_map &map)
 {
 	base_map(map);
-	map(0x100000, 0x107fff).rw(FUNC(simpl156_state::mainram_r), FUNC(simpl156_state::mainram_w)).share("mainram"); // main ram
+	map(0x100000, 0x107fff).rw(FUNC(simpl156_state::mainram_r), FUNC(simpl156_state::mainram_w)); // main ram
 	map(0x110000, 0x111fff).rw(FUNC(simpl156_state::spriteram_r), FUNC(simpl156_state::spriteram_w));
 	map(0x120000, 0x120fff).rw(m_palette, FUNC(palette_device::read16), FUNC(palette_device::write16)).umask32(0x0000ffff).share("palette");
 	map(0x130000, 0x130003).portr("IN1").w(FUNC(simpl156_state::eeprom_w));
@@ -240,7 +240,7 @@ void simpl156_state::chainrec_map(address_map &map)
 {
 	base_map(map);
 	map(0x3c0000, 0x3c0000).rw(m_okimusic, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x400000, 0x407fff).rw(FUNC(simpl156_state::mainram_r), FUNC(simpl156_state::mainram_w)).share("mainram"); // main ram?
+	map(0x400000, 0x407fff).rw(FUNC(simpl156_state::mainram_r), FUNC(simpl156_state::mainram_w)); // main ram?
 	map(0x410000, 0x411fff).rw(FUNC(simpl156_state::spriteram_r), FUNC(simpl156_state::spriteram_w));
 	map(0x420000, 0x420fff).rw(m_palette, FUNC(palette_device::read16), FUNC(palette_device::write16)).umask32(0x0000ffff).share("palette");
 	map(0x430000, 0x430003).portr("IN1").w(FUNC(simpl156_state::eeprom_w));
@@ -260,7 +260,7 @@ void simpl156_state::magdrop_map(address_map &map)
 {
 	base_map(map);
 	map(0x340000, 0x340000).rw(m_okimusic, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x380000, 0x387fff).rw(FUNC(simpl156_state::mainram_r), FUNC(simpl156_state::mainram_w)).share("mainram"); // main ram?
+	map(0x380000, 0x387fff).rw(FUNC(simpl156_state::mainram_r), FUNC(simpl156_state::mainram_w)); // main ram?
 	map(0x390000, 0x391fff).rw(FUNC(simpl156_state::spriteram_r), FUNC(simpl156_state::spriteram_w));
 	map(0x3a0000, 0x3a0fff).rw(m_palette, FUNC(palette_device::read16), FUNC(palette_device::write16)).umask32(0x0000ffff).share("palette");
 	map(0x3b0000, 0x3b0003).portr("IN1").w(FUNC(simpl156_state::eeprom_w));
@@ -280,7 +280,7 @@ void simpl156_state::magdropp_map(address_map &map)
 {
 	base_map(map);
 	map(0x4c0000, 0x4c0000).rw(m_okimusic, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x680000, 0x687fff).rw(FUNC(simpl156_state::mainram_r), FUNC(simpl156_state::mainram_w)).share("mainram"); // main ram?
+	map(0x680000, 0x687fff).rw(FUNC(simpl156_state::mainram_r), FUNC(simpl156_state::mainram_w)); // main ram?
 	map(0x690000, 0x691fff).rw(FUNC(simpl156_state::spriteram_r), FUNC(simpl156_state::spriteram_w));
 	map(0x6a0000, 0x6a0fff).rw(m_palette, FUNC(palette_device::read16), FUNC(palette_device::write16)).umask32(0x0000ffff).share("palette");
 	map(0x6b0000, 0x6b0003).portr("IN1").w(FUNC(simpl156_state::eeprom_w));
@@ -301,7 +301,7 @@ void simpl156_state::mitchell156_map(address_map &map)
 	base_map(map);
 	map(0x100000, 0x100000).rw("okisfx", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0x140000, 0x140000).rw(m_okimusic, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x180000, 0x187fff).rw(FUNC(simpl156_state::mainram_r), FUNC(simpl156_state::mainram_w)).share("mainram"); // main ram
+	map(0x180000, 0x187fff).rw(FUNC(simpl156_state::mainram_r), FUNC(simpl156_state::mainram_w)); // main ram
 	map(0x190000, 0x191fff).rw(FUNC(simpl156_state::spriteram_r), FUNC(simpl156_state::spriteram_w));
 	map(0x1a0000, 0x1a0fff).rw(m_palette, FUNC(palette_device::read16), FUNC(palette_device::write16)).umask32(0x0000ffff).share("palette");
 	map(0x1b0000, 0x1b0003).portr("IN1").w(FUNC(simpl156_state::eeprom_w));
@@ -338,9 +338,12 @@ static const gfx_layout tile_16x16_layout =
 };
 
 static GFXDECODE_START( gfx_simpl156 )
-	GFXDECODE_ENTRY( "gfx1", 0, tile_8x8_layout,       0, 32 )    /* Tiles (8x8) */
-	GFXDECODE_ENTRY( "gfx1", 0, tile_16x16_layout,     0, 32 )    /* Tiles (16x16) */
-	GFXDECODE_ENTRY( "gfx2", 0, tile_16x16_layout, 0x200, 32 )    /* Sprites (16x16) */
+	GFXDECODE_ENTRY( "tiles", 0, tile_8x8_layout,       0, 32 )    /* Tiles (8x8) */
+	GFXDECODE_ENTRY( "tiles", 0, tile_16x16_layout,     0, 32 )    /* Tiles (16x16) */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_simpl156_spr )
+	GFXDECODE_ENTRY( "sprites", 0, tile_16x16_layout, 0x200, 32 )    /* Sprites (16x16) */
 GFXDECODE_END
 
 void simpl156_state::vblank_interrupt(int state)
@@ -387,7 +390,7 @@ void simpl156_state::chainrec(machine_config &config)
 	screen.screen_vblank().set(FUNC(simpl156_state::vblank_interrupt));
 
 	PALETTE(config, m_palette);
-	m_palette->set_format(palette_device::xBGR_555, 4096);
+	m_palette->set_format(palette_device::xBGR_555, 4096/4);
 	m_palette->set_membits(16);
 
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_simpl156);
@@ -405,21 +408,16 @@ void simpl156_state::chainrec(machine_config &config)
 	m_deco_tilegen->set_pf12_16x16_bank(1);
 	m_deco_tilegen->set_gfxdecode_tag("gfxdecode");
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(2);
+	DECO_SPRITE(config, m_sprgen, 0, m_palette, gfx_simpl156_spr);
 	m_sprgen->set_pri_callback(FUNC(simpl156_state::pri_callback));
-	m_sprgen->set_gfxdecode_tag("gfxdecode");
 
-	SPEAKER(config, "lspeaker").front_left();
-	SPEAKER(config, "rspeaker").front_right();
+	SPEAKER(config, "mono").front_center();
 
 	okim6295_device &okisfx(OKIM6295(config, "okisfx", 28_MHz_XTAL / 28, okim6295_device::PIN7_HIGH)); // divider not verified
-	okisfx.add_route(ALL_OUTPUTS, "lspeaker", 0.6);
-	okisfx.add_route(ALL_OUTPUTS, "rspeaker", 0.6);
+	okisfx.add_route(ALL_OUTPUTS, "mono", 0.6);
 
 	OKIM6295(config, m_okimusic, 28_MHz_XTAL / 14, okim6295_device::PIN7_HIGH); // divider not verified
-	m_okimusic->add_route(ALL_OUTPUTS, "lspeaker", 0.2);
-	m_okimusic->add_route(ALL_OUTPUTS, "rspeaker", 0.2);
+	m_okimusic->add_route(ALL_OUTPUTS, "mono", 0.2);
 }
 
 void simpl156_state::magdrop(machine_config &config)
@@ -493,15 +491,15 @@ ROM_START( joemacr )
 	ROM_REGION( 0x80000, "maincpu", 0 ) /* DE156 code (encrypted) */
 	ROM_LOAD( "05.u29",    0x000000, 0x080000,  CRC(74e9a158) SHA1(eee447303ac0884e152b89f59a9694afade87336) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles", 0 )
 	ROM_LOAD( "01.u8l",    0x000000, 0x080000,  CRC(4da4a2c1) SHA1(1ed4bd4337d8b185b56e326e662a8715e4d09e17) )
 	ROM_LOAD( "02.u8h",    0x080000, 0x080000,  CRC(642c08db) SHA1(9a541fd56ae34c24f803e08869702be6fafd81d1) )
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "sprites", 0 )
 	ROM_LOAD( "mbn01",    0x080000, 0x080000, CRC(a3a37353) SHA1(c4509c8268afb647c20e71b42ae8ebd2bdf075e6) ) /* 03.u11 */
 	ROM_LOAD( "mbn02",    0x000000, 0x080000, CRC(aa2230c5) SHA1(43b7ac5c69cde1840a5255a8897e1c5d5f89fd7b) ) /* 04.u12 */
 
-	ROM_REGION( 0x80000, "okisfx", 0 ) /* Oki samples */
+	ROM_REGION( 0x40000, "okisfx", 0 ) /* Oki samples */
 	ROM_LOAD( "mbn04",    0x00000, 0x40000,  CRC(dcbd4771) SHA1(2a1ab6b0fc372333c7eb17aab077fe1ca5ba1dea) ) /* 07.u46 */
 
 	ROM_REGION( 0x200000, "okimusic", 0 ) /* samples? (banked?) */
@@ -530,14 +528,14 @@ ROM_START( joemacra )
 	ROM_REGION( 0x80000, "maincpu", 0 ) /* DE156 code (encrypted) */
 	ROM_LOAD( "mw00",    0x000000, 0x080000,  CRC(e1b78f40) SHA1(e611c317ada5a049a5e05d69c051e22a43fa2845) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 ) // rebuilt with roms from other set
+	ROM_REGION( 0x100000, "tiles", 0 ) // rebuilt with roms from other set
 	ROM_LOAD( "mbn00",    0x000000, 0x100000, CRC(11b2dac7) SHA1(71a50f606caddeb0ef266e2d3df9e429a4873f21) )
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "sprites", 0 )
 	ROM_LOAD( "mbn01",    0x080000, 0x080000, CRC(a3a37353) SHA1(c4509c8268afb647c20e71b42ae8ebd2bdf075e6) )
 	ROM_LOAD( "mbn02",    0x000000, 0x080000, CRC(aa2230c5) SHA1(43b7ac5c69cde1840a5255a8897e1c5d5f89fd7b) )
 
-	ROM_REGION( 0x80000, "okisfx", 0 ) /* Oki samples */
+	ROM_REGION( 0x40000, "okisfx", 0 ) /* Oki samples */
 	ROM_LOAD( "mbn04",    0x00000, 0x40000,  CRC(dcbd4771) SHA1(2a1ab6b0fc372333c7eb17aab077fe1ca5ba1dea) )
 
 	ROM_REGION( 0x200000, "okimusic", 0 ) /* samples? (banked?) */
@@ -548,14 +546,14 @@ ROM_START( joemacrj )
 	ROM_REGION( 0x80000, "maincpu", 0 ) /* DE156 code (encrypted) */
 	ROM_LOAD( "my00-.e1",    0x000000, 0x080000,  CRC(2c184981) SHA1(976fbb554de96aa6405f6f64cd75b633439fe583) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 ) // rebuilt with roms from other set
+	ROM_REGION( 0x100000, "tiles", 0 ) // rebuilt with roms from other set
 	ROM_LOAD( "mbn00",    0x000000, 0x100000, CRC(11b2dac7) SHA1(71a50f606caddeb0ef266e2d3df9e429a4873f21) )
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "sprites", 0 )
 	ROM_LOAD( "mbn01",    0x080000, 0x080000, CRC(a3a37353) SHA1(c4509c8268afb647c20e71b42ae8ebd2bdf075e6) )
 	ROM_LOAD( "mbn02",    0x000000, 0x080000, CRC(aa2230c5) SHA1(43b7ac5c69cde1840a5255a8897e1c5d5f89fd7b) )
 
-	ROM_REGION( 0x80000, "okisfx", 0 ) /* Oki samples */
+	ROM_REGION( 0x40000, "okisfx", 0 ) /* Oki samples */
 	ROM_LOAD( "mbn04",    0x00000, 0x40000,  CRC(dcbd4771) SHA1(2a1ab6b0fc372333c7eb17aab077fe1ca5ba1dea) )
 
 	ROM_REGION( 0x200000, "okimusic", 0 ) /* samples? (banked?) */
@@ -595,16 +593,16 @@ ROM_START( chainrec )
 	ROM_REGION( 0x80000, "maincpu", 0 ) /* DE156 code (encrypted) */
 	ROM_LOAD( "e1",    0x000000, 0x080000, CRC(8a8340ef) SHA1(4aaee56127b73453b862ff2a33dc241eeabf5658) ) /* No DECO ID number on label */
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles", 0 )
 	ROM_LOAD( "mcc-00",    0x000000, 0x100000, CRC(646b03ec) SHA1(9a2fc11b1575032b5a784d88c3a90913068d1e69) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "sprites", 0 )
 	ROM_LOAD16_BYTE( "u3",    0x000000, 0x080000, CRC(92659721) SHA1(b446ce98ec9c2c16375ef00639cfb463b365b8f7) ) /* No DECO ID numbers on labels */
 	ROM_LOAD16_BYTE( "u4",    0x000001, 0x080000, CRC(e304eb32) SHA1(61a647ec89695a6b25ff924bdc6d29cbd7aca82b) )
 	ROM_LOAD16_BYTE( "u5",    0x100000, 0x080000, CRC(1b6f01ea) SHA1(753fc670707432e317d035b09b0bad0762fea731) )
 	ROM_LOAD16_BYTE( "u6",    0x100001, 0x080000, CRC(531a56f2) SHA1(89602bb873a3b110bffc216f921ba228e53380f9) )
 
-	ROM_REGION( 0x80000, "okisfx", 0 ) /* Oki samples */
+	ROM_REGION( 0x40000, "okisfx", 0 ) /* Oki samples */
 	ROM_LOAD( "mcc-04",    0x00000, 0x40000,  CRC(86ee6ade) SHA1(56ad3f432c7f430f19fcba7c89940c63da165906) )
 
 	ROM_REGION( 0x200000, "okimusic", 0 ) /* samples? (banked?) */
@@ -642,14 +640,14 @@ ROM_START( magdrop )
 	ROM_REGION( 0x80000, "maincpu", 0 ) /* DE156 code (encrypted) */
 	ROM_LOAD( "re00-2.e1",    0x000000, 0x080000,  CRC(7138f10f) SHA1(ca93c3c2dc9a7dd6901c8429a6bf6883076a9b8f) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles", 0 )
 	ROM_LOAD( "mcc-00",    0x000000, 0x100000, CRC(646b03ec) SHA1(9a2fc11b1575032b5a784d88c3a90913068d1e69) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "sprites", 0 )
 	ROM_LOAD( "mcc-01.a13",    0x100000, 0x100000, CRC(13d88745) SHA1(0ce4ec1481f31be860ee80322de6e32f9a566229) )
 	ROM_LOAD( "mcc-02.a14",    0x000000, 0x100000, CRC(d0f97126) SHA1(3848a6f00d0e57aaf383298c4d111eb63a88b073) )
 
-	ROM_REGION( 0x80000, "okisfx", 0 ) /* Oki samples */
+	ROM_REGION( 0x40000, "okisfx", 0 ) /* Oki samples */
 	ROM_LOAD( "mcc-04",    0x00000, 0x40000,  CRC(86ee6ade) SHA1(56ad3f432c7f430f19fcba7c89940c63da165906) )
 
 	ROM_REGION( 0x200000, "okimusic", 0 ) /* samples? (banked?) */
@@ -663,14 +661,14 @@ ROM_START( magdropp )
 	ROM_REGION( 0x80000, "maincpu", 0 ) /* DE156 code (encrypted) */
 	ROM_LOAD( "rz00-1.e1",    0x000000, 0x080000,  CRC(28caf639) SHA1(a17e792c82e65009e21680094acf093c0c4f1021) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles", 0 )
 	ROM_LOAD( "mcc-00",    0x000000, 0x100000, CRC(646b03ec) SHA1(9a2fc11b1575032b5a784d88c3a90913068d1e69) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "sprites", 0 )
 	ROM_LOAD( "mcc-01.a13",    0x100000, 0x100000, CRC(13d88745) SHA1(0ce4ec1481f31be860ee80322de6e32f9a566229) )
 	ROM_LOAD( "mcc-02.a14",    0x000000, 0x100000, CRC(d0f97126) SHA1(3848a6f00d0e57aaf383298c4d111eb63a88b073) )
 
-	ROM_REGION( 0x80000, "okisfx", 0 ) /* Oki samples */
+	ROM_REGION( 0x40000, "okisfx", 0 ) /* Oki samples */
 	ROM_LOAD( "mcc-04",    0x00000, 0x40000,  CRC(86ee6ade) SHA1(56ad3f432c7f430f19fcba7c89940c63da165906) )
 
 	ROM_REGION( 0x200000, "okimusic", 0 ) /* samples? (banked?) */
@@ -726,17 +724,17 @@ ROM_START( charlien )
 	ROM_REGION( 0x80000, "maincpu", 0 ) /* DE156 code (encrypted) */
 	ROM_LOAD( "nd00-1.1e",    0x000000, 0x080000,  CRC(f18f4b23) SHA1(cb0c159b4dde3a3c5f295f270485996811e5e4d2) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD( "mbr-00.9a",    0x000000, 0x080000, CRC(ecf2c7f0) SHA1(3c735a4eef2bc49f16ac9365a5689101f43c13e9) )
 	ROM_CONTINUE( 0x100000, 0x080000)
 	ROM_CONTINUE( 0x080000, 0x080000)
 	ROM_CONTINUE( 0x180000, 0x080000)
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "sprites", 0 )
 	ROM_LOAD( "mbr-01.14a",    0x100000, 0x100000, CRC(46c90215) SHA1(152acdeea34ec1db3f761066a0c1ff6e43e47f9d) )
 	ROM_LOAD( "mbr-03.14h",    0x000000, 0x100000, CRC(c448a68a) SHA1(4b607dfee269abdfeb710b74b73ef87dc2b30e8c) )
 
-	ROM_REGION( 0x80000, "okisfx", 0 ) /* Oki samples */
+	ROM_REGION( 0x40000, "okisfx", 0 ) /* Oki samples */
 	ROM_LOAD( "nd01-0.13h",    0x00000, 0x40000,  CRC(635a100a) SHA1(f6ec70890892e7557097ccd519de37247bb8c98d) )
 
 	ROM_REGION( 0x200000, "okimusic", 0 ) /* samples? (banked?) */
@@ -807,19 +805,19 @@ ROM_START( prtytime )
 	ROM_REGION( 0x80000, "maincpu", 0 ) /* DE156 code (encrypted) */
 	ROM_LOAD( "pz_00-0.1e",    0x000000, 0x080000, CRC(ec715c87) SHA1(c9f28399d59b37977f31a5c67cb97af6c58947ae) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD( "mcb-00.9a",    0x000000, 0x080000, CRC(c48a4f2b) SHA1(2dee5f8507b2a7e6f7e44b14f9abca36d0ebf78b) )
 	ROM_CONTINUE( 0x100000, 0x080000)
 	ROM_CONTINUE( 0x080000, 0x080000)
 	ROM_CONTINUE( 0x180000, 0x080000)
 
-	ROM_REGION( 0x800000, "gfx2", 0 )
+	ROM_REGION( 0x800000, "sprites", 0 )
 	ROM_LOAD( "mcb-01.13a",    0x600000, 0x200000, CRC(06f40a57) SHA1(896f1d373e911dcff7223bf21756ad35b28b4c5d) )
 	ROM_LOAD( "mcb-02.14a",    0x400000, 0x200000, CRC(423cfb38) SHA1(b8c772a8ab471c365a11a88c85e1c8c7d2ad6e80) )
 	ROM_LOAD( "mcb-03.14d",    0x200000, 0x200000, CRC(0aef73af) SHA1(76cf13f53da5202da80820f98660edee1eef7f1a) )
 	ROM_LOAD( "mcb-05.14h",    0x000000, 0x200000, CRC(81540cfb) SHA1(6f7bc62c3c4d4a29eb1e0cfb261ace461bbca57c) )
 
-	ROM_REGION( 0x80000, "okisfx", 0 ) /* Oki samples */
+	ROM_REGION( 0x40000, "okisfx", 0 ) /* Oki samples */
 	ROM_LOAD( "pz_01-0.13h",    0x00000, 0x40000,  CRC(8925bce2) SHA1(0ff2d5db7a24a2af30bd753eba274572c32cc2e7) )
 
 	ROM_REGION( 0x200000, "okimusic", 0 ) /* samples? (banked?) */
@@ -833,19 +831,19 @@ ROM_START( gangonta )
 	ROM_REGION( 0x80000, "maincpu", 0 ) /* DE156 code (encrypted) */
 	ROM_LOAD( "rd_00-0.1e",    0x000000, 0x080000, CRC(f80f43bb) SHA1(f9d26829eb90d41a6c410d4d673fe9595f814868) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD( "mcb-00.9a",    0x000000, 0x080000, CRC(c48a4f2b) SHA1(2dee5f8507b2a7e6f7e44b14f9abca36d0ebf78b) )
 	ROM_CONTINUE( 0x100000, 0x080000)
 	ROM_CONTINUE( 0x080000, 0x080000)
 	ROM_CONTINUE( 0x180000, 0x080000)
 
-	ROM_REGION( 0x800000, "gfx2", 0 )
+	ROM_REGION( 0x800000, "sprites", 0 )
 	ROM_LOAD( "mcb-01.13a",    0x600000, 0x200000, CRC(06f40a57) SHA1(896f1d373e911dcff7223bf21756ad35b28b4c5d) )
 	ROM_LOAD( "mcb-02.14a",    0x400000, 0x200000, CRC(423cfb38) SHA1(b8c772a8ab471c365a11a88c85e1c8c7d2ad6e80) )
 	ROM_LOAD( "mcb-03.14d",    0x200000, 0x200000, CRC(0aef73af) SHA1(76cf13f53da5202da80820f98660edee1eef7f1a) )
 	ROM_LOAD( "mcb-05.14h",    0x000000, 0x200000, CRC(81540cfb) SHA1(6f7bc62c3c4d4a29eb1e0cfb261ace461bbca57c) )
 
-	ROM_REGION( 0x80000, "okisfx", 0 ) /* Oki samples */
+	ROM_REGION( 0x40000, "okisfx", 0 ) /* Oki samples */
 	ROM_LOAD( "rd_01-0.13h",    0x00000, 0x40000,  CRC(70fd18c6) SHA1(368cd8e10c5f5a13eb3813974a7e6b46a4fa6b6c) )
 
 	ROM_REGION( 0x200000, "okimusic", 0 ) /* samples? (banked?) */
@@ -898,19 +896,19 @@ ROM_START( osman )
 	ROM_REGION( 0x80000, "maincpu", 0 ) /* DE156 code (encrypted) */
 	ROM_LOAD( "sa00-0.1e",    0x000000, 0x080000, CRC(ec6b3257) SHA1(10a42a680ce122ab030eaa2ccd99d302cb77854e) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD( "mcf-00.9a",    0x000000, 0x080000, CRC(247712dc) SHA1(bcb765afd7e756b68131c97c30d210de115d6b50) )
 	ROM_CONTINUE( 0x100000, 0x080000)
 	ROM_CONTINUE( 0x080000, 0x080000)
 	ROM_CONTINUE( 0x180000, 0x080000)
 
-	ROM_REGION( 0x800000, "gfx2", 0 )
+	ROM_REGION( 0x800000, "sprites", 0 )
 	ROM_LOAD( "mcf-01.13a",    0x600000, 0x200000, CRC(83881e25) SHA1(ae82cf0f704e6efea94c6c1d276d4e3e5b3ebe43) )
 	ROM_LOAD( "mcf-02.14a",    0x400000, 0x200000, CRC(21251b33) SHA1(d252fe5c6eef8cbc9327e4176b4868b1cb17a738) )
 	ROM_LOAD( "mcf-03.14d",    0x200000, 0x200000, CRC(faf1d51d) SHA1(675dbbfe15b8010d54b2b3af26d42cdd753c2ce2) )
 	ROM_LOAD( "mcf-04.14h",    0x000000, 0x200000, CRC(4fa55577) SHA1(e229ba9cce46b92ce255aa33b974e19b214c4017) )
 
-	ROM_REGION( 0x80000, "okisfx", 0 ) /* Oki samples */
+	ROM_REGION( 0x40000, "okisfx", 0 ) /* Oki samples */
 	ROM_LOAD( "sa01-0.13h",    0x00000, 0x40000,  CRC(cea8368e) SHA1(1fcc641381fdc29bd50d3a4b23e67647f79e505a))
 
 	ROM_REGION( 0x200000, "okimusic", 0 ) /* samples? (banked?) */
@@ -926,19 +924,19 @@ ROM_START( candance )
 	ROM_REGION( 0x80000, "maincpu", 0 ) /* DE156 code (encrypted) */
 	ROM_LOAD( "sa00-0.1e",    0x000000, 0x080000, CRC(ec6b3257) SHA1(10a42a680ce122ab030eaa2ccd99d302cb77854e) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD( "mcf-00.9a",    0x000000, 0x080000, CRC(247712dc) SHA1(bcb765afd7e756b68131c97c30d210de115d6b50) )
 	ROM_CONTINUE( 0x100000, 0x080000)
 	ROM_CONTINUE( 0x080000, 0x080000)
 	ROM_CONTINUE( 0x180000, 0x080000)
 
-	ROM_REGION( 0x800000, "gfx2", 0 )
+	ROM_REGION( 0x800000, "sprites", 0 )
 	ROM_LOAD( "mcf-01.13a",    0x600000, 0x200000, CRC(83881e25) SHA1(ae82cf0f704e6efea94c6c1d276d4e3e5b3ebe43) )
 	ROM_LOAD( "mcf-02.14a",    0x400000, 0x200000, CRC(21251b33) SHA1(d252fe5c6eef8cbc9327e4176b4868b1cb17a738) )
 	ROM_LOAD( "mcf-03.14d",    0x200000, 0x200000, CRC(faf1d51d) SHA1(675dbbfe15b8010d54b2b3af26d42cdd753c2ce2) )
 	ROM_LOAD( "mcf-04.14h",    0x000000, 0x200000, CRC(4fa55577) SHA1(e229ba9cce46b92ce255aa33b974e19b214c4017) )
 
-	ROM_REGION( 0x80000, "okisfx", 0 ) /* Oki samples */
+	ROM_REGION( 0x40000, "okisfx", 0 ) /* Oki samples */
 	ROM_LOAD( "sa01-0.13h",    0x00000, 0x40000,  CRC(cea8368e) SHA1(1fcc641381fdc29bd50d3a4b23e67647f79e505a))
 
 	ROM_REGION( 0x200000, "okimusic", 0 ) /* samples? (banked?) */
@@ -1030,15 +1028,18 @@ void simpl156_state::init_simpl156()
 
 	memcpy(rom, &buf1[0], length);
 
-	deco56_decrypt_gfx(machine(), "gfx1");
+	deco56_decrypt_gfx(machine(), "tiles");
 	deco156_decrypt(machine());
 }
 
 /* Everything seems more stable if we run the CPU speed x4 and use Idle skips.. maybe it has an internal multiplier? */
 u32 simpl156_state::joemacr_speedup_r()
 {
+	if (!machine().side_effects_disabled())
+	{
 	if (m_maincpu->pc() == 0x284)
 		m_maincpu->spin_until_time(attotime::from_usec(400));
+	}
 	return m_systemram[0x18/4];
 }
 
@@ -1051,8 +1052,11 @@ void simpl156_state::init_joemacr()
 
 u32 simpl156_state::chainrec_speedup_r()
 {
-	if (m_maincpu->pc() == 0x2d4)
-		m_maincpu->spin_until_time(attotime::from_usec(400));
+	if (!machine().side_effects_disabled())
+	{
+		if (m_maincpu->pc() == 0x2d4)
+			m_maincpu->spin_until_time(attotime::from_usec(400));
+	}
 	return m_systemram[0x18/4];
 }
 
@@ -1064,8 +1068,11 @@ void simpl156_state::init_chainrec()
 
 u32 simpl156_state::prtytime_speedup_r()
 {
-	if (m_maincpu->pc() == 0x4f0)
-		m_maincpu->spin_until_time(attotime::from_usec(400));
+	if (!machine().side_effects_disabled())
+	{
+		if (m_maincpu->pc() == 0x4f0)
+			m_maincpu->spin_until_time(attotime::from_usec(400));
+	}
 	return m_systemram[0xae0/4];
 }
 
@@ -1078,8 +1085,11 @@ void simpl156_state::init_prtytime()
 
 u32 simpl156_state::charlien_speedup_r()
 {
-	if (m_maincpu->pc() == 0xc8c8)
-		m_maincpu->spin_until_time(attotime::from_usec(400));
+	if (!machine().side_effects_disabled())
+	{
+		if (m_maincpu->pc() == 0xc8c8)
+			m_maincpu->spin_until_time(attotime::from_usec(400));
+	}
 	return m_systemram[0x10/4];
 }
 
@@ -1091,8 +1101,11 @@ void simpl156_state::init_charlien()
 
 u32 simpl156_state::osman_speedup_r()
 {
-	if (m_maincpu->pc() == 0x5974)
-		m_maincpu->spin_until_time(attotime::from_usec(400));
+	if (!machine().side_effects_disabled())
+	{
+		if (m_maincpu->pc() == 0x5974)
+			m_maincpu->spin_until_time(attotime::from_usec(400));
+	}
 	return m_systemram[0x10/4];
 }
 

--- a/src/mame/dataeast/simpl156.h
+++ b/src/mame/dataeast/simpl156.h
@@ -15,17 +15,17 @@
 class simpl156_state : public driver_device
 {
 public:
-	simpl156_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
+	simpl156_state(const machine_config &mconfig, device_type type, const char *tag) :
+		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
 		m_deco_tilegen(*this, "tilegen"),
 		m_eeprom(*this, "eeprom"),
 		m_okimusic(*this, "okimusic"),
+		m_sprgen(*this, "spritegen"),
+		m_palette(*this, "palette"),
 		m_rowscroll(*this, "rowscroll_%u", 1U, 0x1000U, ENDIANNESS_LITTLE),
 		m_mainram(*this, "mainram", 0x4000U, ENDIANNESS_LITTLE),
 		m_systemram(*this, "systemram"),
-		m_sprgen(*this, "spritegen"),
-		m_palette(*this, "palette"),
 		m_spriteram(*this, "spriteram", 0x1000U, ENDIANNESS_LITTLE) { }
 
 	void joemacr(machine_config &config);
@@ -76,13 +76,13 @@ private:
 	required_device<deco16ic_device> m_deco_tilegen;
 	required_device<eeprom_serial_93cxx_device> m_eeprom;
 	required_device<okim6295_device> m_okimusic;
+	required_device<decospr_device> m_sprgen;
+	required_device<palette_device> m_palette;
 
 	/* memory pointers */
 	memory_share_array_creator<u16, 2> m_rowscroll;
 	memory_share_creator<u16> m_mainram;
 	required_shared_ptr<u32> m_systemram;
-	required_device<decospr_device> m_sprgen;
-	required_device<palette_device> m_palette;
 	memory_share_creator<u16> m_spriteram;
 
 	size_t m_spriteram_size = 0;

--- a/src/mame/dataeast/simpl156.h
+++ b/src/mame/dataeast/simpl156.h
@@ -20,11 +20,13 @@ public:
 		m_maincpu(*this, "maincpu"),
 		m_deco_tilegen(*this, "tilegen"),
 		m_eeprom(*this, "eeprom"),
-		m_okimusic(*this, "okimusic") ,
-		m_mainram(*this, "mainram"),
+		m_okimusic(*this, "okimusic"),
+		m_rowscroll(*this, "rowscroll_%u", 1U, 0x1000U, ENDIANNESS_LITTLE),
+		m_mainram(*this, "mainram", 0x4000U, ENDIANNESS_LITTLE),
 		m_systemram(*this, "systemram"),
 		m_sprgen(*this, "spritegen"),
-		m_palette(*this, "palette") { }
+		m_palette(*this, "palette"),
+		m_spriteram(*this, "spriteram", 0x1000U, ENDIANNESS_LITTLE) { }
 
 	void joemacr(machine_config &config);
 	void magdrop(machine_config &config);
@@ -39,20 +41,10 @@ public:
 	void init_osman();
 	void init_chainrec();
 
+protected:
+	virtual void video_start() override;
+
 private:
-	/* devices */
-	required_device<cpu_device> m_maincpu;
-	required_device<deco16ic_device> m_deco_tilegen;
-	required_device<eeprom_serial_93cxx_device> m_eeprom;
-	required_device<okim6295_device> m_okimusic;
-	/* memory pointers */
-	std::unique_ptr<u16[]>  m_rowscroll[2];
-	required_shared_ptr<u32> m_mainram;
-	required_shared_ptr<u32> m_systemram;
-	optional_device<decospr_device> m_sprgen;
-	required_device<palette_device> m_palette;
-	std::unique_ptr<u16[]> m_spriteram;
-	size_t m_spriteram_size = 0;
 	DECO16IC_BANK_CB_MEMBER(bank_callback);
 	DECOSPR_PRIORITY_CB_MEMBER(pri_callback);
 
@@ -69,7 +61,6 @@ private:
 	u32 charlien_speedup_r();
 	u32 osman_speedup_r();
 
-	virtual void video_start() override;
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void vblank_interrupt(int state);
 
@@ -79,4 +70,20 @@ private:
 	void magdrop_map(address_map &map);
 	void magdropp_map(address_map &map);
 	void mitchell156_map(address_map &map);
+
+	/* devices */
+	required_device<cpu_device> m_maincpu;
+	required_device<deco16ic_device> m_deco_tilegen;
+	required_device<eeprom_serial_93cxx_device> m_eeprom;
+	required_device<okim6295_device> m_okimusic;
+
+	/* memory pointers */
+	memory_share_array_creator<u16, 2> m_rowscroll;
+	memory_share_creator<u16> m_mainram;
+	required_shared_ptr<u32> m_systemram;
+	required_device<decospr_device> m_sprgen;
+	required_device<palette_device> m_palette;
+	memory_share_creator<u16> m_spriteram;
+
+	size_t m_spriteram_size = 0;
 };

--- a/src/mame/dataeast/simpl156.h
+++ b/src/mame/dataeast/simpl156.h
@@ -23,10 +23,10 @@ public:
 		m_okimusic(*this, "okimusic"),
 		m_sprgen(*this, "spritegen"),
 		m_palette(*this, "palette"),
-		m_rowscroll(*this, "rowscroll_%u", 1U, 0x1000U, ENDIANNESS_LITTLE),
+		m_rowscroll(*this, "rowscroll_%u", 1U, 0x800U, ENDIANNESS_LITTLE),
 		m_mainram(*this, "mainram", 0x4000U, ENDIANNESS_LITTLE),
 		m_systemram(*this, "systemram"),
-		m_spriteram(*this, "spriteram", 0x1000U, ENDIANNESS_LITTLE) { }
+		m_spriteram(*this, "spriteram", 0x2000U, ENDIANNESS_LITTLE) { }
 
 	void joemacr(machine_config &config);
 	void magdrop(machine_config &config);

--- a/src/mame/dataeast/simpl156.h
+++ b/src/mame/dataeast/simpl156.h
@@ -26,7 +26,8 @@ public:
 		m_rowscroll(*this, "rowscroll_%u", 1U, 0x800U, ENDIANNESS_LITTLE),
 		m_mainram(*this, "mainram", 0x4000U, ENDIANNESS_LITTLE),
 		m_systemram(*this, "systemram"),
-		m_spriteram(*this, "spriteram", 0x2000U, ENDIANNESS_LITTLE) { }
+		m_spriteram(*this, "spriteram", 0x1000U, ENDIANNESS_LITTLE)
+	{ }
 
 	void joemacr(machine_config &config);
 	void magdrop(machine_config &config);

--- a/src/mame/dataeast/simpl156_v.cpp
+++ b/src/mame/dataeast/simpl156_v.cpp
@@ -7,28 +7,18 @@
 #include "emu.h"
 #include "simpl156.h"
 #include "screen.h"
-
+#include <algorithm>
 
 void simpl156_state::video_start()
 {
-	/* allocate the ram as 16-bit (we do it here because the CPU is 32-bit) */
-	m_rowscroll[0] = make_unique_clear<u16[]>(0x800/2);
-	m_rowscroll[1] = make_unique_clear<u16[]>(0x800/2);
-	m_spriteram = make_unique_clear<u16[]>(0x2000/2);
-
-	memset(m_spriteram.get(), 0xff, 0x2000);
-
-	/* and register the allocated ram so that save states still work */
-	save_pointer(NAME(m_rowscroll[0]), 0x800/2);
-	save_pointer(NAME(m_rowscroll[1]), 0x800/2);
-	save_pointer(NAME(m_spriteram), 0x2000/2);
+	std::fill_n(&m_spriteram[0], m_spriteram.length(), 0xff);
 }
 
 u32 simpl156_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen.priority().fill(0);
 
-	m_deco_tilegen->pf_update(m_rowscroll[0].get(), m_rowscroll[1].get());
+	m_deco_tilegen->pf_update(m_rowscroll[0], m_rowscroll[1]);
 
 	bitmap.fill(256, cliprect);
 
@@ -38,6 +28,6 @@ u32 simpl156_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, c
 	// sprites are flipped relative to tilemaps
 	m_sprgen->set_flip_screen(true);
 
-	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram.get(), 0x1400/4); // 0x1400/4 seems right for charlien (doesn't initialize any more RAM, so will draw a garbage 0 with more)
+	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram, 0x1400/4); // 0x1400/4 seems right for charlien (doesn't initialize any more RAM, so will draw a garbage 0 with more)
 	return 0;
 }

--- a/src/mame/dataeast/simpl156_v.cpp
+++ b/src/mame/dataeast/simpl156_v.cpp
@@ -5,13 +5,17 @@
 */
 
 #include "emu.h"
+
 #include "simpl156.h"
+
 #include "screen.h"
+
 #include <algorithm>
+
 
 void simpl156_state::video_start()
 {
-	std::fill_n(&m_spriteram[0], m_spriteram.length(), 0xff);
+	std::fill_n(&m_spriteram[0], m_spriteram.length(), 0xffff);
 }
 
 u32 simpl156_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)

--- a/src/mame/dataeast/sshangha.cpp
+++ b/src/mame/dataeast/sshangha.cpp
@@ -507,7 +507,13 @@ static const gfx_layout tilelayout =
 static GFXDECODE_START( gfx_sshangha )
 	GFXDECODE_ENTRY( "tiles",    0, charlayout,  0x000, 64 ) // 8x8
 	GFXDECODE_ENTRY( "tiles",    0, tilelayout,  0x000, 64 ) // 16x16
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_sshangha_spr1 )
 	GFXDECODE_ENTRY( "sprites1", 0, tilelayout,  0x000, 64 ) // 16x16
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_sshangha_spr2 )
 	GFXDECODE_ENTRY( "sprites2", 0, tilelayout,  0x000, 64 ) // 16x16
 GFXDECODE_END
 
@@ -563,13 +569,8 @@ void sshangha_state::sshangha(machine_config &config)
 	m_tilegen->set_pf12_16x16_bank(1);
 	m_tilegen->set_gfxdecode_tag("gfxdecode");
 
-	DECO_SPRITE(config, m_sprgen[0], 0);
-	m_sprgen[0]->set_gfx_region(2);
-	m_sprgen[0]->set_gfxdecode_tag("gfxdecode");
-
-	DECO_SPRITE(config, m_sprgen[1], 0);
-	m_sprgen[1]->set_gfx_region(3);
-	m_sprgen[1]->set_gfxdecode_tag("gfxdecode");
+	DECO_SPRITE(config, m_sprgen[0], 0, m_palette, gfx_sshangha_spr1);
+	DECO_SPRITE(config, m_sprgen[1], 0, m_palette, gfx_sshangha_spr2);
 
 	DECO146PROT(config, m_deco146, 0);
 	m_deco146->port_a_cb().set_ioport(m_inputs);

--- a/src/mame/dataeast/supbtime.cpp
+++ b/src/mame/dataeast/supbtime.cpp
@@ -317,6 +317,9 @@ static const gfx_layout tile_16x16_layout =
 static GFXDECODE_START( gfx_supbtime )
 	GFXDECODE_ENTRY( "tiles",   0, tile_8x8_layout,   256, 32 ) // 8x8
 	GFXDECODE_ENTRY( "tiles",   0, tile_16x16_layout, 256, 32 ) // 16x16
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_supbtime_spr )
 	GFXDECODE_ENTRY( "sprites", 0, tile_16x16_layout,   0, 16 ) // 16x16
 GFXDECODE_END
 
@@ -355,9 +358,7 @@ void supbtime_state::supbtime(machine_config &config)
 	m_deco_tilegen->set_pf12_16x16_bank(1);
 	m_deco_tilegen->set_gfxdecode_tag("gfxdecode");
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(2);
-	m_sprgen->set_gfxdecode_tag("gfxdecode");
+	DECO_SPRITE(config, m_sprgen, 0, "palette", gfx_supbtime_spr);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/dataeast/tumbleb.cpp
+++ b/src/mame/dataeast/tumbleb.cpp
@@ -2069,10 +2069,8 @@ static const gfx_layout tlayout =
 	RGN_FRAC(1,2),
 	4,
 	{ RGN_FRAC(1,2)+8, RGN_FRAC(1,2)+0, 8, 0 },
-	{ 32*8+0, 32*8+1, 32*8+2, 32*8+3, 32*8+4, 32*8+5, 32*8+6, 32*8+7,
-			0, 1, 2, 3, 4, 5, 6, 7 },
-	{ 0*16, 1*16, 2*16, 3*16, 4*16, 5*16, 6*16, 7*16,
-			8*16, 9*16, 10*16, 11*16, 12*16, 13*16, 14*16, 15*16 },
+	{ STEP8(16*8*2, 1), STEP8(0, 1) },
+	{ STEP16(0, 8*2) },
 	64*8
 };
 
@@ -2094,20 +2092,25 @@ static GFXDECODE_START( gfx_tumbleb )
 	GFXDECODE_ENTRY( "tilegfx", 0, tcharlayout, 256, 16 )  /* Characters 8x8 */
 	GFXDECODE_ENTRY( "tilegfx", 0, tlayout,     512, 16 )  /* Tiles 16x16 */
 	GFXDECODE_ENTRY( "tilegfx", 0, tlayout,     256, 16 )  /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "sprgfx", 0, tlayout,       0, 16 )  /* Sprites 16x16 */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_tumbleb_spr )
+	GFXDECODE_ENTRY( "sprgfx", 0, tlayout, 0, 16 )  /* Sprites 16x16 */
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_suprtrio )
 	GFXDECODE_ENTRY( "tilegfx", 0, tcharlayout,        256, 16 )   /* Characters 8x8 */
 	GFXDECODE_ENTRY( "tilegfx", 0, suprtrio_tlayout,   512, 16 )   /* Tiles 16x16 */
 	GFXDECODE_ENTRY( "tilegfx", 0, suprtrio_tlayout,   256, 16 )   /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "sprgfx",  0, tlayout,            0, 16 )   /* Sprites 16x16 */
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_fncywld )
 	GFXDECODE_ENTRY( "tilegfx", 0, tcharlayout, 0x400, 0x40 )  /* Characters 8x8 */
 	GFXDECODE_ENTRY( "tilegfx", 0, tlayout,     0x400, 0x40 )  /* Tiles 16x16 */
 	GFXDECODE_ENTRY( "tilegfx", 0, tlayout,     0x200, 0x40 )  /* Tiles 16x16 */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_fncywld_spr )
 	GFXDECODE_ENTRY( "sprgfx",  0, tlayout,     0x000, 0x40 )  /* Sprites 16x16 */
 GFXDECODE_END
 
@@ -2153,10 +2156,8 @@ void tumbleb_state::tumblepb(machine_config &config)
 	m_screen->set_screen_update(FUNC(tumbleb_state::screen_update_tumblepb));
 	m_screen->set_palette(m_palette);
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(3);
+	DECO_SPRITE(config, m_sprgen, 0, m_palette, gfx_tumbleb_spr);
 	m_sprgen->set_is_bootleg(true);
-	m_sprgen->set_gfxdecode_tag(m_gfxdecode);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_tumbleb);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_444, 1024);
@@ -2194,10 +2195,8 @@ void tumbleb_state::tumbleb2(machine_config &config)
 	m_screen->set_screen_update(FUNC(tumbleb_state::screen_update_tumblepb));
 	m_screen->set_palette(m_palette);
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(3);
+	DECO_SPRITE(config, m_sprgen, 0, m_palette, gfx_tumbleb_spr);
 	m_sprgen->set_is_bootleg(true);
-	m_sprgen->set_gfxdecode_tag(m_gfxdecode);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_tumbleb);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_444, 1024);
@@ -2252,10 +2251,8 @@ void tumbleb_state::jumpkids(machine_config &config) // OSCs: 12MHz, 8MHz & 14.3
 	m_screen->set_screen_update(FUNC(tumbleb_state::screen_update_jumpkids));
 	m_screen->set_palette(m_palette);
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(3);
+	DECO_SPRITE(config, m_sprgen, 0, m_palette, gfx_tumbleb_spr);
 	m_sprgen->set_is_bootleg(true);
-	m_sprgen->set_gfxdecode_tag(m_gfxdecode);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_tumbleb);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_444, 1024);
@@ -2289,11 +2286,9 @@ void tumbleb_state::fncywld(machine_config &config) // OSCs: 12MHz, 4MHz & 28.63
 	m_screen->set_screen_update(FUNC(tumbleb_state::screen_update_fncywld));
 	m_screen->set_palette(m_palette);
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(3);
+	DECO_SPRITE(config, m_sprgen, 0, m_palette, gfx_fncywld_spr);
 	m_sprgen->set_is_bootleg(true);
 	m_sprgen->set_transpen(15);
-	m_sprgen->set_gfxdecode_tag(m_gfxdecode);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_fncywld);
 	PALETTE(config, m_palette).set_format(palette_device::xRGB_444, 0x800);
@@ -2327,11 +2322,9 @@ void tumbleb_state::magipur(machine_config &config) // OSCs: 12MHz, 4MHz, 28.636
 	m_screen->set_screen_update(FUNC(tumbleb_state::screen_update_fncywld));
 	m_screen->set_palette(m_palette);
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(3);
+	DECO_SPRITE(config, m_sprgen, 0, m_palette, gfx_fncywld_spr);
 	m_sprgen->set_is_bootleg(true);
 	m_sprgen->set_transpen(15);
-	m_sprgen->set_gfxdecode_tag(m_gfxdecode);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_fncywld);
 	PALETTE(config, m_palette).set_format(palette_device::xRGB_444, 0x800);
@@ -2384,10 +2377,8 @@ void tumbleb_state::htchctch(machine_config &config) // OSCs: 15MHz, 4.096MHz
 	m_screen->set_screen_update(FUNC(tumbleb_state::screen_update_semicom));
 	m_screen->set_palette(m_palette);
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(3);
+	DECO_SPRITE(config, m_sprgen, 0, m_palette, gfx_tumbleb_spr);
 	m_sprgen->set_is_bootleg(true);
-	m_sprgen->set_gfxdecode_tag(m_gfxdecode);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_tumbleb);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, 1024);
@@ -2501,10 +2492,8 @@ void tumbleb_state::suprtrio(machine_config &config) // OSCs: 14MHz, 12MHz & 8MH
 	m_screen->set_screen_update(FUNC(tumbleb_state::screen_update_suprtrio));
 	m_screen->set_palette("palette");
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(3);
+	DECO_SPRITE(config, m_sprgen, 0, m_palette, gfx_tumbleb_spr);
 	m_sprgen->set_is_bootleg(true);
-	m_sprgen->set_gfxdecode_tag(m_gfxdecode);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_suprtrio);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, 1024);
@@ -2539,10 +2528,8 @@ void tumbleb_state::pangpang(machine_config &config) // OSCs: 14MHz, 12MHz & 8MH
 	m_screen->set_screen_update(FUNC(tumbleb_state::screen_update_pangpang));
 	m_screen->set_palette(m_palette);
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(3);
+	DECO_SPRITE(config, m_sprgen, 0, m_palette, gfx_tumbleb_spr);
 	m_sprgen->set_is_bootleg(true);
-	m_sprgen->set_gfxdecode_tag(m_gfxdecode);
 
 	GFXDECODE(config, m_gfxdecode, "palette", gfx_tumbleb);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_444, 1024);

--- a/src/mame/f32/crospang.cpp
+++ b/src/mame/f32/crospang.cpp
@@ -218,7 +218,7 @@ TILE_GET_INFO_MEMBER(crospang_state::get_bg_tile_info)
 	tile = tile + (m_tilebank[tilebank] << 10);
 	int const color = (data >> 12) & 0x0f;
 
-	tileinfo.set(1, tile, color + 0x20, 0);
+	tileinfo.set(0, tile, color + 0x20, 0);
 }
 
 TILE_GET_INFO_MEMBER(crospang_state::get_fg_tile_info)
@@ -229,7 +229,7 @@ TILE_GET_INFO_MEMBER(crospang_state::get_fg_tile_info)
 	tile = tile + (m_tilebank[tilebank] << 10);
 	int const color = (data >> 12) & 0x0f;
 
-	tileinfo.set(1, tile, color + 0x10, 0);
+	tileinfo.set(0, tile, color + 0x10, 0);
 }
 
 
@@ -635,8 +635,11 @@ static const gfx_layout tlayout_alt =
 
 
 static GFXDECODE_START( gfx_crospang )
-	GFXDECODE_ENTRY( "sprites", 0, tlayout,       0, 64 )  // 16x16
 	GFXDECODE_ENTRY( "tiles",   0, tlayout_alt,   0, 64 )  // 16x16
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_crospang_spr )
+	GFXDECODE_ENTRY( "sprites", 0, tlayout,       0, 64 )  // 16x16
 GFXDECODE_END
 
 void crospang_state::machine_start()
@@ -678,11 +681,9 @@ void crospang_state::crospang(machine_config &config)
 	PALETTE(config, "palette").set_format(palette_device::xRGB_555, 0x300);
 	GFXDECODE(config, m_gfxdecode, "palette", gfx_crospang);
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(0);
+	DECO_SPRITE(config, m_sprgen, 0, "palette", gfx_crospang_spr);
 	m_sprgen->set_is_bootleg(true);
 	m_sprgen->set_offsets(5, 7);
-	m_sprgen->set_gfxdecode_tag(m_gfxdecode);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/misc/esd16.cpp
+++ b/src/mame/misc/esd16.cpp
@@ -108,7 +108,7 @@ void esd16_state::vram_w(offs_t offset, u16 data, u16 mem_mask)
 
 void esd16_state::hedpanic_platform_w(u16 data)
 {
-	int offsets = m_headpanic_platform_x[0] + 0x40 * m_headpanic_platform_y[0];
+	int const offsets = m_headpanic_platform_x[0] + 0x40 * m_headpanic_platform_y[0];
 
 	m_vram[1][offsets] = data;
 	m_tilemap[1]->mark_tile_dirty(offsets);
@@ -657,15 +657,21 @@ static const gfx_layout hedpanic_layout_16x16x8 =
 
 
 static GFXDECODE_START( gfx_esd16 )
-	GFXDECODE_ENTRY( "spr", 0, hedpanic_sprite_16x16x5, 0x200, 8 )      // [0] Sprites
 	GFXDECODE_ENTRY( "bgs", 0, gfx_8x8x8_raw,           0x000, 2 )      // [1] Layers
 	GFXDECODE_ENTRY( "bgs", 0, hedpanic_layout_16x16x8, 0x000, 2 )      // [1] Layers
 GFXDECODE_END
 
+static GFXDECODE_START( gfx_esd16_spr )
+	GFXDECODE_ENTRY( "spr", 0, hedpanic_sprite_16x16x5, 0x200, 8 )      // [0] Sprites
+GFXDECODE_END
+
 static GFXDECODE_START( gfx_jumppop )
-	GFXDECODE_ENTRY( "spr", 0, jumppop_sprite_16x16x4,  0x000, 0x40 )   // Sprites 16x16 - has 4bpp sprites, unlike the others
 	GFXDECODE_ENTRY( "bgs", 0, gfx_8x8x8_raw,           0x000, 4 )      // Characters 8x8
 	GFXDECODE_ENTRY( "bgs", 0, hedpanic_layout_16x16x8, 0x000, 4 )      // Tiles 16x16
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_jumppop_spr )
+	GFXDECODE_ENTRY( "spr", 0, jumppop_sprite_16x16x4,  0x000, 0x40 )   // Sprites 16x16 - has 4bpp sprites, unlike the others
 GFXDECODE_END
 
 
@@ -718,12 +724,10 @@ void esd16_state::esd16_nosound(machine_config &config)
 	screen.set_screen_update(FUNC(esd16_state::screen_update));
 	screen.set_palette("palette");
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(0);
+	DECO_SPRITE(config, m_sprgen, 0, "palette", gfx_esd16_spr);
 	m_sprgen->set_is_bootleg(true);
 	m_sprgen->set_pri_callback(FUNC(esd16_state::pri_callback));
 	m_sprgen->set_flipallx(1);
-	m_sprgen->set_gfxdecode_tag(m_gfxdecode);
 
 	GFXDECODE(config, m_gfxdecode, "palette", gfx_esd16);
 	PALETTE(config, "palette").set_format(palette_device::xRGB_555, 0x1000/2);
@@ -780,6 +784,7 @@ void esd16_state::jumppop(machine_config &config)
 
 	m_audiocpu->set_clock(XTAL(14'000'000)/4); /* 3.5MHz - Verified */
 
+	m_sprgen->set_info(gfx_jumppop_spr);
 	m_gfxdecode->set_info(gfx_jumppop);
 
 	subdevice<ym3812_device>("ymsnd")->set_clock(XTAL(14'000'000)/4); /* 3.5MHz - Verified */

--- a/src/mame/misc/esd16_v.cpp
+++ b/src/mame/misc/esd16_v.cpp
@@ -57,7 +57,7 @@ template<unsigned Layer>
 TILE_GET_INFO_MEMBER(esd16_state::get_tile_info)
 {
 	const u16 code = m_vram[Layer][tile_index];
-	tileinfo.set(1,
+	tileinfo.set(0,
 			code,
 			m_tilemap_color[Layer],
 			0);
@@ -67,7 +67,7 @@ template<unsigned Layer>
 TILE_GET_INFO_MEMBER(esd16_state::get_tile_info_16x16)
 {
 	const u16 code = m_vram[Layer][tile_index];
-	tileinfo.set(2,
+	tileinfo.set(1,
 			code,
 			m_tilemap_color[Layer],
 			0);
@@ -80,7 +80,7 @@ void esd16_state::tilemap0_color_w(u16 data)
 	m_tilemap[0]->mark_all_dirty();
 	m_tilemap_16x16[0]->mark_all_dirty();
 
-	bool flip = BIT(data, 7);
+	bool const flip = BIT(data, 7);
 	flip_screen_set(flip);
 	m_sprgen->set_flip_screen(flip);
 }
@@ -91,7 +91,7 @@ void esd16_state::tilemap0_color_jumppop_w(u16 data)
 	m_tilemap_color[0] = 2;
 	m_tilemap_color[1] = 1;
 
-	bool flip = BIT(data, 7);
+	bool const flip = BIT(data, 7);
 	flip_screen_set(flip);
 	m_sprgen->set_flip_screen(flip);
 }

--- a/src/mame/misc/gotcha.cpp
+++ b/src/mame/misc/gotcha.cpp
@@ -206,10 +206,8 @@ static const gfx_layout tilelayout =
 	RGN_FRAC(1,4),
 	4,
 	{ RGN_FRAC(0,4), RGN_FRAC(1,4), RGN_FRAC(2,4), RGN_FRAC(3,4) },
-	{ 0, 1, 2, 3, 4, 5, 6, 7,
-			16*8+0, 16*8+1, 16*8+2, 16*8+3, 16*8+4, 16*8+5, 16*8+6, 16*8+7 },
-	{ 0*8, 1*8, 2*8, 3*8, 4*8, 5*8, 6*8, 7*8,
-			8*8, 9*8, 10*8, 11*8, 12*8, 13*8, 14*8, 15*8 },
+	{ STEP8(0,1), STEP8(8*16,1) },
+	{ STEP16(0,8) },
 	16*16
 };
 
@@ -219,15 +217,16 @@ static const gfx_layout spritelayout =
 	RGN_FRAC(1,4),
 	4,
 	{ RGN_FRAC(0,4), RGN_FRAC(1,4), RGN_FRAC(2,4), RGN_FRAC(3,4) },
-	{ 16*8+0, 16*8+1, 16*8+2, 16*8+3, 16*8+4, 16*8+5, 16*8+6, 16*8+7,
-			0, 1, 2, 3, 4, 5, 6, 7 },
-	{ 0*8, 1*8, 2*8, 3*8, 4*8, 5*8, 6*8, 7*8,
-			8*8, 9*8, 10*8, 11*8, 12*8, 13*8, 14*8, 15*8 },
+	{ STEP8(8*16,1), STEP8(0,1) },
+	{ STEP16(0,8) },
 	16*16
 };
 
 static GFXDECODE_START( gfx_gotcha )
 	GFXDECODE_ENTRY( "tiles", 0, tilelayout, 0x100, 32 )
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_gotcha_spr )
 	GFXDECODE_ENTRY( "sprites", 0, spritelayout, 0x000, 16 )
 GFXDECODE_END
 
@@ -279,11 +278,9 @@ void gotcha_state::gotcha(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, "palette", gfx_gotcha);
 	PALETTE(config, "palette").set_format(palette_device::xRGB_555, 768);
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(1);
+	DECO_SPRITE(config, m_sprgen, 0, "palette", gfx_gotcha_spr);
 	m_sprgen->set_is_bootleg(true);
 	m_sprgen->set_offsets(5, -1); // aligned to 2nd instruction screen in attract
-	m_sprgen->set_gfxdecode_tag(m_gfxdecode);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/shared/decospr.cpp
+++ b/src/mame/shared/decospr.cpp
@@ -19,31 +19,31 @@
 
    used by:
 
-   dblewing.c
-   tumblep.c
-   dietgo.c
-   supbtime.c
-   simpl156.c
-   deco156.c
-   pktgaldx.c
-   backfire.c
-   darkseal.c
-   sshangha.c (could probably use pdrawgfx, not m_sprite_bitmap)
-   cbuster.c (could probably use pdrawgfx, not m_sprite_bitmap)
-   mirage.c (could probably use pdrawgfx, not m_sprite_bitmap)
-   cninja.c
-   lemmings.c
-   deco32.c
-   rohga.c
-   dassault.c
-   boogwing.c
+   backfire.cpp
+   boogwing.cpp
+   cbuster.cpp (could probably use pdrawgfx, not m_sprite_bitmap)
+   cninja.cpp
+   darkseal.cpp
+   dassault.cpp
+   dblewing.cpp
+   deco32.cpp
+   deco156.cpp
+   dietgo.cpp
+   funkyjet.cpp
+   lemmings.cpp
+   mirage.cpp (could probably use pdrawgfx, not m_sprite_bitmap)
+   pktgaldx.cpp
+   rohga.cpp
+   simpl156.cpp
+   sshangha.cpp (could probably use pdrawgfx, not m_sprite_bitmap)
+   supbtime.cpp
 
-   (bootleg) esd16.c
-   (bootleg) nmg5.c
-   (bootleg) tumbleb.c
-   (bootleg) crospang.c
-   (bootleg) silvmil.c
-   (bootleg) gotcha.c
+   (bootleg) crospang.cpp
+   (bootleg) esd16.cpp
+   (bootleg) gotcha.cpp
+   (bootleg) nmg5.cpp
+   (bootleg) silvmil.cpp
+   (bootleg) tumbleb.cpp
 
    to convert:
 
@@ -127,7 +127,7 @@ tttttttt tttttttt
 
 t = sprite tile
 
-todo: the priority callback for using pdrawgfx should really pack those 8 bits, and pass them instead of currently just
+TODO: the priority callback for using pdrawgfx should really pack those 8 bits, and pass them instead of currently just
 passing offs+2 which lacks the extra priority bit
 
 */
@@ -146,16 +146,19 @@ DEFINE_DEVICE_TYPE(DECO_SPRITE, decospr_device, "decospr", "DECO 52 Sprite")
 decospr_device::decospr_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, DECO_SPRITE, tag, owner, clock)
 	, device_video_interface(mconfig, *this)
-	, m_gfxregion(0)
+	, device_gfx_interface(mconfig, *this)
 	, m_pri_cb(*this)
 	, m_col_cb(*this, DEVICE_SELF, FUNC(decospr_device::default_col_cb)) // default color callback
+	, m_alt_format(false)
+	, m_pixmask(0xf)
+	, m_raw_shift(4) // set to 8 on tattass / nslashers for the custom mixing (because they have 5bpp sprites, and shifting by 4 isn't good enough)
+	, m_flip_screen(false)
 	, m_is_bootleg(false)
 	, m_bootleg_type(0)
 	, m_x_offset(0)
 	, m_y_offset(0)
 	, m_flipallx(0)
 	, m_transpen(0)
-	, m_gfxdecode(*this, finder_base::DUMMY_TAG)
 {
 }
 
@@ -164,17 +167,12 @@ void decospr_device::device_start()
 	m_pri_cb.resolve();
 	m_col_cb.resolve();
 
-	m_alt_format = 0;
-	m_pixmask = 0xf;
-	m_raw_shift = 4; // set to 8 on tattass / nslashers for the custom mixing (because they have 5bpp sprites, and shifting by 4 isn't good enough)
-
-	m_flip_screen = false;
 	save_item(NAME(m_flip_screen));
 }
 
 void decospr_device::device_reset()
 {
-	//printf("decospr_device::device_reset()\n");
+	//logerror("decospr_device::device_reset()\n");
 }
 
 void decospr_device::alloc_sprite_bitmap()
@@ -185,7 +183,7 @@ void decospr_device::alloc_sprite_bitmap()
 template<class BitmapClass>
 void decospr_device::draw_sprites_common(BitmapClass &bitmap, const rectangle &cliprect, uint16_t* spriteram, int sizewords)
 {
-	//printf("cliprect %04x, %04x\n", cliprect.top(), cliprect.bottom());
+	//logerror("cliprect %04x, %04x\n", cliprect.top(), cliprect.bottom());
 
 	if (m_sprite_bitmap.valid() && !m_pri_cb.isnull())
 		fatalerror("m_sprite_bitmap && m_pri_cb is invalid\n");
@@ -193,15 +191,13 @@ void decospr_device::draw_sprites_common(BitmapClass &bitmap, const rectangle &c
 	if (m_sprite_bitmap.valid())
 		m_sprite_bitmap.fill(0, cliprect);
 
-
 	int offs, end, incr;
 
-	bool flipscreen = m_flip_screen;
-
+	bool const flipscreen = m_flip_screen;
 
 	if (!m_pri_cb.isnull())
 	{
-		offs = sizewords-4;
+		offs = sizewords - 4;
 		end = -4;
 		incr = -4;
 	}
@@ -212,7 +208,7 @@ void decospr_device::draw_sprites_common(BitmapClass &bitmap, const rectangle &c
 		incr = 4;
 	}
 
-	while (offs!=end)
+	while (offs != end)
 	{
 		int x, y, sprite, colour, multi, mult2, fx, fy, inc, flash, mult, h, w, pri;
 
@@ -222,61 +218,50 @@ void decospr_device::draw_sprites_common(BitmapClass &bitmap, const rectangle &c
 			y = spriteram[offs];
 
 			if (m_is_bootleg && (m_bootleg_type == 1))
-			{
-				flash = y & 0x0400;
-			}
+				flash = BIT(y, 10);
 			else
-			{
-				flash = y & 0x1000;
-			}
+				flash = BIT(y, 12);
 
-			w = y & 0x0800;
-
+			w = BIT(y, 11);
 
 			if (!(flash && (screen().frame_number() & 1)))
 			{
 				x = spriteram[offs + 2];
 
 				if (!m_sprite_bitmap.valid())
-				{
-					colour = m_col_cb(x, y & 0x8000);
-				}
+					colour = m_col_cb(x, BIT(y, 15));
 				else
 				{
 					colour = (x >> 9) & 0x7f;
-					if (y&0x8000) colour |= 0x80; // fghthist uses this to mark priority
+					if (BIT(y, 15)) colour |= 0x80; // fghthist uses this to mark priority
 				}
 
-
 				if (!m_pri_cb.isnull())
-					pri = m_pri_cb(x, y & 0x8000);
+					pri = m_pri_cb(x, BIT(y, 15));
 				else
 					pri = 0;
 
-				fx = y & 0x2000;
-				fy = y & 0x4000;
+				fx = BIT(y, 13);
+				fy = BIT(y, 14);
 
 				int tempwidth = 0;
 
-				if (m_is_bootleg && (m_bootleg_type==1))  // puzzlove
+				if (m_is_bootleg && (m_bootleg_type == 1))  // puzzlove
 				{
 					tempwidth = (y & 0x1000) >> 12;
 					tempwidth |= (y & 0x0200) >> 8;
 				}
 				else
-				{
 					tempwidth |= (y & 0x0600) >> 9;
-				}
 
-				multi = (1 << (tempwidth)) - 1; /* 1x, 2x, 4x, 8x height */
+				multi = (1 << (tempwidth)) - 1; // 1x, 2x, 4x, 8x height
 
-				/* bootleg support (esd16.c) */
-				if (flipscreen) x = ((x&0x1ff) - m_x_offset)&0x1ff;
-				else x = ((x&0x1ff) + m_x_offset)&0x1ff;
-				y = ((y&0x1ff) + m_y_offset)&0x1ff;
+				// bootleg support (misc/esd16.cpp)
+				if (flipscreen) x = ((x & 0x1ff) - m_x_offset) & 0x1ff;
+				else x = ((x & 0x1ff) + m_x_offset) & 0x1ff;
+				y = ((y & 0x1ff) + m_y_offset) & 0x1ff;
 
-
-				if (cliprect.right()>256)
+				if (cliprect.right() > 256)
 				{
 					x = x & 0x01ff;
 					y = y & 0x01ff;
@@ -294,7 +279,6 @@ void decospr_device::draw_sprites_common(BitmapClass &bitmap, const rectangle &c
 					y = 240 - y;
 					x = 240 - x;
 				}
-
 
 				//if (x <= 320)
 				{
@@ -328,33 +312,30 @@ void decospr_device::draw_sprites_common(BitmapClass &bitmap, const rectangle &c
 						if (fx) fx = 0; else fx = 1;
 					}
 
-
-
 					mult2 = multi + 1;
 
 					while (multi >= 0)
 					{
-						int ypos;
-						ypos = y + mult * multi;
-						if ((ypos<=cliprect.bottom()) && (ypos>=(cliprect.top())-16))
+						const int ypos = y + mult * multi;
+						if ((ypos <= cliprect.bottom()) && (ypos >= (cliprect.top()) - 16))
 						{
-							if(!m_sprite_bitmap.valid())
+							if (!m_sprite_bitmap.valid())
 							{
-								if ((ypos<=cliprect.bottom()) && (ypos>=(cliprect.top())-16))
+								if ((ypos <= cliprect.bottom()) && (ypos >= (cliprect.top()) - 16))
 								{
 									if (!m_pri_cb.isnull())
-										m_gfxdecode->gfx(m_gfxregion)->prio_transpen(bitmap,cliprect,
+										gfx(0)->prio_transpen(bitmap, cliprect,
 											sprite - multi * inc,
 											colour,
-											fx,fy,
-											x,ypos,
-											screen().priority(),pri,m_transpen);
+											fx, fy,
+											x, ypos,
+											screen().priority(), pri, m_transpen);
 									else
-										m_gfxdecode->gfx(m_gfxregion)->transpen(bitmap,cliprect,
+										gfx(0)->transpen(bitmap, cliprect,
 											sprite - multi * inc,
 											colour,
-											fx,fy,
-											x,ypos,
+											fx, fy,
+											x, ypos,
 											m_transpen);
 								}
 
@@ -362,37 +343,37 @@ void decospr_device::draw_sprites_common(BitmapClass &bitmap, const rectangle &c
 								if (w)
 								{
 									if (!m_pri_cb.isnull())
-										m_gfxdecode->gfx(m_gfxregion)->prio_transpen(bitmap,cliprect,
-												(sprite - multi * inc)-mult2,
+										gfx(0)->prio_transpen(bitmap, cliprect,
+												(sprite - multi * inc) - mult2,
 												colour,
-												fx,fy,
-												!flipscreen ? x-16 : x+16,ypos,
-												screen().priority(),pri,m_transpen);
+												fx, fy,
+												!flipscreen ? x - 16 : x + 16, ypos,
+												screen().priority(), pri, m_transpen);
 									else
-										m_gfxdecode->gfx(m_gfxregion)->transpen(bitmap,cliprect,
-												(sprite - multi * inc)-mult2,
+										gfx(0)->transpen(bitmap, cliprect,
+												(sprite - multi * inc) - mult2,
 												colour,
-												fx,fy,
-												!flipscreen ? x-16 : x+16,ypos,
+												fx, fy,
+												!flipscreen ? x - 16 : x + 16, ypos,
 												m_transpen);
 								}
 							}
 							else
 							{
 								// if we have a sprite bitmap draw raw data to it for manual mixing
-								m_gfxdecode->gfx(m_gfxregion)->transpen_raw(m_sprite_bitmap,cliprect,
+								gfx(0)->transpen_raw(m_sprite_bitmap, cliprect,
 									sprite - multi * inc,
-									colour<<m_raw_shift,
-									fx,fy,
-									x,ypos,
+									colour << m_raw_shift,
+									fx, fy,
+									x, ypos,
 									m_transpen);
 								if (w)
 								{
-									m_gfxdecode->gfx(m_gfxregion)->transpen_raw(m_sprite_bitmap,cliprect,
-										(sprite - multi * inc)-mult2,
-										colour<<m_raw_shift,
-										fx,fy,
-										!flipscreen ? x-16 : x+16,ypos,
+									gfx(0)->transpen_raw(m_sprite_bitmap, cliprect,
+										(sprite - multi * inc) - mult2,
+										colour << m_raw_shift,
+										fx, fy,
+										!flipscreen ? x - 16 : x + 16, ypos,
 										m_transpen);
 								}
 
@@ -406,138 +387,139 @@ void decospr_device::draw_sprites_common(BitmapClass &bitmap, const rectangle &c
 		}
 		else // m_alt_format
 		{
-			y = spriteram[offs+0];
-			sprite = spriteram[offs+3] & 0xffff;
-
+			y = spriteram[offs + 0];
+			sprite = spriteram[offs + 3] & 0xffff;
 
 			if (!m_pri_cb.isnull())
-				pri = m_pri_cb(spriteram[offs+2]&0x00ff, false);
+				pri = m_pri_cb(spriteram[offs + 2] & 0x00ff, false);
 			else
 				pri = 0;
 
-			x = spriteram[offs+1];
+			x = spriteram[offs + 1];
 
-			if (!((y&0x2000) && (screen().frame_number() & 1)))
+			if (!(BIT(y, 13) && (screen().frame_number() & 1)))
 			{
 				if (!m_sprite_bitmap.valid())
-					colour = (spriteram[offs+2] >>0) & 0x1f;
+					colour = (spriteram[offs + 2] >> 0) & 0x1f;
 				else
-					colour = (spriteram[offs+2] >>0) & 0xff; // store all bits for manual mixing
+					colour = (spriteram[offs + 2] >> 0) & 0xff; // store all bits for manual mixing
 
+				h = (spriteram[offs + 2] & 0xf000) >> 12;
+				w = (spriteram[offs + 2] & 0x0f00) >>  8;
+				fx = BIT(~spriteram[offs + 0], 14);
+				fy = BIT(~spriteram[offs + 0], 15);
 
-				h = (spriteram[offs+2]&0xf000)>>12;
-				w = (spriteram[offs+2]&0x0f00)>> 8;
-				fx = !(spriteram[offs+0]&0x4000);
-				fy = !(spriteram[offs+0]&0x8000);
-
-				if (!flipscreen) {
+				if (!flipscreen)
+				{
 					x = x & 0x01ff;
 					y = y & 0x01ff;
-					if (x>0x180) x=-(0x200 - x);
-					if (y>0x180) y=-(0x200 - y);
+					if (x > 0x180) x = -(0x200 - x);
+					if (y > 0x180) y = -(0x200 - y);
 
-					if (fx) { mult=-16; x+=16*w; } else { mult=16; x-=16; }
-					if (fy) { mult2=-16; y+=16*h; } else { mult2=16; y-=16; }
-				} else {
-					if (fx) fx=0; else fx=1;
-					if (fy) fy=0; else fy=1;
+					if (fx) { mult = -16; x += 16 * w; } else { mult = 16; x -= 16; }
+					if (fy) { mult2 = -16; y += 16 * h; } else { mult2 = 16; y -= 16; }
+				}
+				else
+				{
+					if (fx) fx = 0; else fx = 1;
+					if (fy) fy = 0; else fy = 1;
 
 					x = x & 0x01ff;
 					y = y & 0x01ff;
-					if (x&0x100) x=-(0x100 - (x&0xff));
-					if (y&0x100) y=-(0x100 - (y&0xff));
+					if (x & 0x100) x = -(0x100 - (x & 0xff));
+					if (y & 0x100) y = -(0x100 - (y & 0xff));
 					x = 304 - x;
 					y = 240 - y;
 					if (x >= 432) x -= 512;
 					if (y >= 384) y -= 512;
-					if (fx) { mult=-16; x+=16; } else { mult=16; x-=16*w; }
-					if (fy) { mult2=-16; y+=16; } else { mult2=16; y-=16*h; }
+					if (fx) { mult = -16; x += 16; } else { mult = 16; x -= 16 * w; }
+					if (fy) { mult2 = -16; y += 16; } else { mult2 = 16; y -= 16 * h; }
 				}
 				int ypos;
 
-				for (int xx=0; xx<w; xx++)
+				for (int xx = 0; xx < w; xx++)
 				{
-					for (int yy=0; yy<h; yy++)
+					for (int yy = 0; yy < h; yy++)
 					{
-						if(!m_sprite_bitmap.valid())
+						if (!m_sprite_bitmap.valid())
 						{
 							if (!m_pri_cb.isnull())
 							{
-								ypos = y + mult2 * (h-yy);
+								ypos = y + mult2 * (h - yy);
 
-								if ((ypos<=cliprect.bottom()) && (ypos>=(cliprect.top())-16))
+								if ((ypos <= cliprect.bottom()) && (ypos >= (cliprect.top()) - 16))
 								{
-									m_gfxdecode->gfx(m_gfxregion)->prio_transpen(bitmap,cliprect,
+									gfx(0)->prio_transpen(bitmap, cliprect,
 											sprite + yy + h * xx,
 											colour,
-											fx,fy,
-												x + mult * (w-xx),ypos,
-											screen().priority(),pri,m_transpen);
+											fx, fy,
+											x + mult * (w - xx), ypos,
+											screen().priority(), pri, m_transpen);
 								}
 
 								ypos -= 512; // wrap-around y
 
-								if ((ypos<=cliprect.bottom()) && (ypos>=(cliprect.top()-16)))
+								if ((ypos <= cliprect.bottom()) && (ypos >= (cliprect.top() - 16)))
 								{
-									m_gfxdecode->gfx(m_gfxregion)->prio_transpen(bitmap,cliprect,
+									gfx(0)->prio_transpen(bitmap, cliprect,
 											sprite + yy + h * xx,
 											colour,
-											fx,fy,
-											x + mult * (w-xx),ypos,
-											screen().priority(),pri,m_transpen);
+											fx, fy,
+											x + mult * (w - xx), ypos,
+											screen().priority(), pri, m_transpen);
 								}
 
 							}
 							else
 							{
-								ypos = y + mult2 * (h-yy);
+								ypos = y + mult2 * (h - yy);
 
-								if ((ypos<=cliprect.bottom()) && (ypos>=(cliprect.top())-16))
+								if ((ypos <= cliprect.bottom()) && (ypos >= (cliprect.top()) - 16))
 								{
-									m_gfxdecode->gfx(m_gfxregion)->transpen(bitmap,cliprect,
+									gfx(0)->transpen(bitmap, cliprect,
 											sprite + yy + h * xx,
 											colour,
-											fx,fy,
-											x + mult * (w-xx),ypos,
+											fx, fy,
+											x + mult * (w - xx), ypos,
 											m_transpen);
 								}
 
 								ypos -= 512; // wrap-around y
 
-								if ((ypos<=cliprect.bottom()) && (ypos>=(cliprect.top()-16)))
+								if ((ypos <= cliprect.bottom()) && (ypos >= (cliprect.top() - 16)))
 								{
-									m_gfxdecode->gfx(m_gfxregion)->transpen(bitmap,cliprect,
+									gfx(0)->transpen(bitmap, cliprect,
 											sprite + yy + h * xx,
 											colour,
-											fx,fy,
-											x + mult * (w-xx),ypos,
+											fx, fy,
+											x + mult * (w - xx), ypos,
 											m_transpen);
 								}
 							}
 						}
 						else
 						{
-							ypos = y + mult2 * (h-yy);
+							ypos = y + mult2 * (h - yy);
 
-							if ((ypos<=cliprect.bottom()) && (ypos>=(cliprect.top())-16))
+							if ((ypos <= cliprect.bottom()) && (ypos >= (cliprect.top()) - 16))
 							{
-								m_gfxdecode->gfx(m_gfxregion)->transpen_raw(m_sprite_bitmap,cliprect,
+								gfx(0)->transpen_raw(m_sprite_bitmap,cliprect,
 										sprite + yy + h * xx,
-										colour<<m_raw_shift,
-										fx,fy,
-										x + mult * (w-xx),ypos,
+										colour << m_raw_shift,
+										fx, fy,
+										x + mult * (w - xx), ypos,
 										m_transpen);
 							}
 
 							ypos -= 512; // wrap-around y
 
-							if ((ypos<=cliprect.bottom()) && (ypos>=(cliprect.top()-16)))
+							if ((ypos <= cliprect.bottom()) && (ypos >= (cliprect.top() - 16)))
 							{
-								m_gfxdecode->gfx(m_gfxregion)->transpen_raw(m_sprite_bitmap,cliprect,
+								gfx(0)->transpen_raw(m_sprite_bitmap,cliprect,
 										sprite + yy + h * xx,
-										colour<<m_raw_shift,
-										fx,fy,
-										x + mult * (w-xx),ypos,
+										colour << m_raw_shift,
+										fx, fy,
+										x + mult * (w - xx), ypos,
 										m_transpen);
 							}
 						}
@@ -546,7 +528,7 @@ void decospr_device::draw_sprites_common(BitmapClass &bitmap, const rectangle &c
 			}
 		}
 
-		offs+=incr;
+		offs += incr;
 	}
 }
 
@@ -563,39 +545,37 @@ void decospr_device::inefficient_copy_sprite_bitmap(bitmap_rgb32 &bitmap, const 
 	if (!m_sprite_bitmap.valid())
 		fatalerror("decospr_device::inefficient_copy_sprite_bitmap with no m_sprite_bitmap\n");
 
-	pen_t const *const paldata = m_gfxdecode->palette().pens();
+	pen_t const *const paldata = palette().pens();
 
-	for (int y=cliprect.top();y<=cliprect.bottom();y++)
+	for (int y = cliprect.top(); y <= cliprect.bottom(); y++)
 	{
-		uint16_t const *const srcline= &m_sprite_bitmap.pix(y);
-		uint32_t *const dstline= &bitmap.pix(y);
+		uint16_t const *const srcline = &m_sprite_bitmap.pix(y);
+		uint32_t *const dstline = &bitmap.pix(y);
 
-		if (alpha==0xff)
+		if (alpha == 0xff)
 		{
-			for (int x=cliprect.left();x<=cliprect.right();x++)
+			for (int x = cliprect.left(); x <= cliprect.right(); x++)
 			{
 				uint16_t const pix = srcline[x];
 
-				if (pix&0xf)
+				if (pix & 0xf)
 				{
 					if ((pix & priority_mask) == pri)
-					{
-						dstline[x] = paldata[(pix&palmask) + colbase];
-					}
+						dstline[x] = paldata[(pix & palmask) + colbase];
 				}
 			}
 		}
 		else
 		{
-			for (int x=cliprect.left();x<=cliprect.right();x++)
+			for (int x = cliprect.left(); x <= cliprect.right(); x++)
 			{
 				uint16_t const pix = srcline[x];
 
-				if (pix&m_pixmask)
+				if (pix & m_pixmask)
 				{
 					if ((pix & priority_mask) == pri)
 					{
-						uint32_t const pal1 = paldata[(pix&palmask) + colbase];
+						uint32_t const pal1 = paldata[(pix & palmask) + colbase];
 						uint32_t const pal2 = dstline[x];
 						dstline[x] = alpha_blend_r32(pal2, pal1, alpha);
 					}

--- a/src/mame/shared/decospr.cpp
+++ b/src/mame/shared/decospr.cpp
@@ -19,31 +19,31 @@
 
    used by:
 
-   backfire.cpp
-   boogwing.cpp
-   cbuster.cpp (could probably use pdrawgfx, not m_sprite_bitmap)
-   cninja.cpp
-   darkseal.cpp
-   dassault.cpp
-   dblewing.cpp
-   deco32.cpp
-   deco156.cpp
-   dietgo.cpp
-   funkyjet.cpp
-   lemmings.cpp
-   mirage.cpp (could probably use pdrawgfx, not m_sprite_bitmap)
-   pktgaldx.cpp
-   rohga.cpp
-   simpl156.cpp
-   sshangha.cpp (could probably use pdrawgfx, not m_sprite_bitmap)
-   supbtime.cpp
+   dataeast/backfire.cpp
+   dataeast/boogwing.cpp
+   dataeast/cbuster.cpp (could probably use pdrawgfx, not m_sprite_bitmap)
+   dataeast/cninja.cpp
+   dataeast/darkseal.cpp
+   dataeast/dassault.cpp
+   dataeast/dblewing.cpp
+   dataeast/deco32.cpp
+   dataeast/deco156.cpp
+   dataeast/dietgo.cpp
+   dataeast/funkyjet.cpp
+   dataeast/lemmings.cpp
+   dataeast/mirage.cpp (could probably use pdrawgfx, not m_sprite_bitmap)
+   dataeast/pktgaldx.cpp
+   dataeast/rohga.cpp
+   dataeast/simpl156.cpp
+   dataeast/sshangha.cpp (could probably use pdrawgfx, not m_sprite_bitmap)
+   dataeast/supbtime.cpp
 
-   (bootleg) crospang.cpp
-   (bootleg) esd16.cpp
-   (bootleg) gotcha.cpp
-   (bootleg) nmg5.cpp
-   (bootleg) silvmil.cpp
-   (bootleg) tumbleb.cpp
+   (bootleg) dataeast/tumbleb.cpp
+   (bootleg) f32/crospang.cpp
+   (bootleg) f32/silvmil.cpp
+   (bootleg) misc/esd16.cpp
+   (bootleg) misc/gotcha.cpp
+   (bootleg) yunsung/nmg5.cpp
 
    to convert:
 

--- a/src/mame/yunsung/nmg5.cpp
+++ b/src/mame/yunsung/nmg5.cpp
@@ -930,8 +930,8 @@ static const gfx_layout nmg5_layout_8x8x8 =
 	RGN_FRAC(1,8),
 	8,
 	{ RGN_FRAC(7,8),RGN_FRAC(6,8),RGN_FRAC(5,8),RGN_FRAC(4,8),RGN_FRAC(3,8),RGN_FRAC(2,8),RGN_FRAC(1,8),RGN_FRAC(0,8) },
-	{ 0,1,2,3,4,5,6,7 },
-	{ 0*8,1*8,2*8,3*8,4*8,5*8,6*8,7*8 },
+	{ STEP8(0,1) },
+	{ STEP8(0,8) },
 	8*8
 };
 
@@ -941,8 +941,8 @@ static const gfx_layout pclubys_layout_8x8x8 =
 	RGN_FRAC(1,4),
 	8,
 	{ RGN_FRAC(1,4)+8,RGN_FRAC(2,4)+0,RGN_FRAC(0,4)+8,RGN_FRAC(0,4)+0,RGN_FRAC(3,4)+8,RGN_FRAC(3,4)+0,RGN_FRAC(2,4)+8,RGN_FRAC(1,4)+0 },
-	{ 0,1,2,3,4,5,6,7 },
-	{ 0*16,1*16,2*16,3*16,4*16,5*16,6*16,7*16 },
+	{ STEP8(0,1) },
+	{ STEP8(0,8*2) },
 	8*16
 };
 
@@ -952,19 +952,21 @@ static const gfx_layout layout_16x16x5 =
 	RGN_FRAC(1,5),
 	5,
 	{ RGN_FRAC(2,5),RGN_FRAC(3,5),RGN_FRAC(1,5),RGN_FRAC(4,5),RGN_FRAC(0,5) },
-	{ 128,129,130,131,132,133,134,135, 0,1,2,3,4,5,6,7, },
-	{ 0*8,1*8,2*8,3*8,4*8,5*8,6*8,7*8,8*8,9*8,10*8,11*8,12*8,13*8,14*8,15*8 },
+	{ STEP8(8*16,1), STEP8(0,1) },
+	{ STEP16(0,8) },
 	32*8
 };
 
 static GFXDECODE_START( gfx_nmg5 )
-	GFXDECODE_ENTRY( "gfx1", 0, nmg5_layout_8x8x8, 0x000,  2 )
-	GFXDECODE_ENTRY( "gfx2", 0, layout_16x16x5,    0x200, 16 )
+	GFXDECODE_ENTRY( "tiles", 0, nmg5_layout_8x8x8, 0x000,  2 )
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_nmg5_spr )
+	GFXDECODE_ENTRY( "sprites", 0, layout_16x16x5,    0x200, 16 )
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_pclubys )
-	GFXDECODE_ENTRY( "gfx1", 0, pclubys_layout_8x8x8, 0x000,  2 )
-	GFXDECODE_ENTRY( "gfx2", 0, layout_16x16x5,       0x200, 16 )
+	GFXDECODE_ENTRY( "tiles", 0, pclubys_layout_8x8x8, 0x000,  2 )
 GFXDECODE_END
 
 
@@ -1007,12 +1009,10 @@ void nmg5_state::nmg5(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, "palette", gfx_nmg5);
 	PALETTE(config, "palette").set_format(palette_device::xBGR_555, 0x400);
 
-	DECO_SPRITE(config, m_sprgen, 0);
-	m_sprgen->set_gfx_region(1);
+	DECO_SPRITE(config, m_sprgen, 0, "palette", gfx_nmg5_spr);
 	m_sprgen->set_is_bootleg(true);
 	m_sprgen->set_flipallx(1);
 	m_sprgen->set_offsets(0, 8);
-	m_sprgen->set_gfxdecode_tag(m_gfxdecode);
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -1098,7 +1098,7 @@ ROM_START( nmg5 )
 	ROM_REGION( 0x10000, "soundcpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "xh15.bin", 0x00000, 0x10000, CRC(12d047c4) SHA1(3123b1856219380ff598a2fad97a66863e30d80f) )
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* 8x8x8 */
+	ROM_REGION( 0x400000, "tiles", 0 )   /* 8x8x8 */
 	ROM_LOAD( "srom1.bin", 0x000000, 0x80000, CRC(6771b694) SHA1(115e5eb45bb05f7a8021b3af3b8e709bbdcae55e) )
 	ROM_LOAD( "srom2.bin", 0x080000, 0x80000, CRC(362d33af) SHA1(abf66ab9eabdd40fcd47bc291d60e7e4903cde74) )
 	ROM_LOAD( "srom3.bin", 0x100000, 0x80000, CRC(8bad69d1) SHA1(c68d6b318e86b6deb64cc0cd5b51a2ea3ce04fb8) )
@@ -1108,7 +1108,7 @@ ROM_START( nmg5 )
 	ROM_LOAD( "srom7.bin", 0x300000, 0x80000, CRC(bd2b9036) SHA1(28c2d86c9645e6738811f3ece7c2fa02cd6ae4a1) )
 	ROM_LOAD( "srom8.bin", 0x380000, 0x80000, CRC(dd38360e) SHA1(be7cb62369513b972c4370adf78df6fcf8caea0a) )
 
-	ROM_REGION( 0x140000, "gfx2", 0 )   /* 16x16x5 */
+	ROM_REGION( 0x140000, "sprites", 0 )   /* 16x16x5 */
 	ROM_LOAD( "uf1.bin", 0x000000, 0x40000, CRC(9a9fb6f4) SHA1(4541d33493b9bba11b8e5ed35431271790763db4) )
 	ROM_LOAD( "uf2.bin", 0x040000, 0x40000, CRC(66954d63) SHA1(62a315640beb8b063886ea6ed1433a18f75e8d0d) )
 	ROM_LOAD( "ufa1.bin",0x080000, 0x40000, CRC(ba73ed2d) SHA1(efd2548fb0ada11ff98b73335689d2394cbf42a4) )
@@ -1127,7 +1127,7 @@ ROM_START( nmg5a )
 	ROM_REGION( 0x10000, "soundcpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "m5_sndcpu.xh15", 0x00000, 0x10000, CRC(12d047c4) SHA1(3123b1856219380ff598a2fad97a66863e30d80f) )
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* 8x8x8 */
+	ROM_REGION( 0x400000, "tiles", 0 )   /* 8x8x8 */
 	ROM_LOAD( "m5_12.srom1", 0x000000, 0x80000, CRC(3adff261) SHA1(c72d45a91cc03872fd3c5e1c7328097a48aac115) )
 	ROM_LOAD( "m5_8.srom2",  0x080000, 0x80000, CRC(b0736b66) SHA1(c8223aca5ef03348c132ff0625a43a7e56eccaee) )
 	ROM_LOAD( "m5_13.srom3", 0x100000, 0x80000, CRC(8e904919) SHA1(f6b0b92ccfaaf1b1129c433f6a54399fc0c0ad44) )
@@ -1137,7 +1137,7 @@ ROM_START( nmg5a )
 	ROM_LOAD( "m5_7.srom7",  0x300000, 0x80000, CRC(acb00d15) SHA1(b03d5f960ed527ac1132dbaa01539462cb325aa6) )
 	ROM_LOAD( "m5_11.srom8", 0x380000, 0x80000, CRC(0ba74fce) SHA1(62215eee4eb7100029ae3344e5a6d03da523eede))
 
-	ROM_REGION( 0x140000, "gfx2", 0 )   /* 16x16x5 */ // same as parent set
+	ROM_REGION( 0x140000, "sprites", 0 )   /* 16x16x5 */ // same as parent set
 	ROM_LOAD( "m5_3.uf1", 0x000000, 0x40000, CRC(9a9fb6f4) SHA1(4541d33493b9bba11b8e5ed35431271790763db4) )
 	ROM_LOAD( "m5_5.uf2", 0x040000, 0x40000, CRC(66954d63) SHA1(62a315640beb8b063886ea6ed1433a18f75e8d0d) )
 	ROM_LOAD( "m5_1.ufa1",0x080000, 0x40000, CRC(ba73ed2d) SHA1(efd2548fb0ada11ff98b73335689d2394cbf42a4) )
@@ -1156,7 +1156,7 @@ ROM_START( nmg5e )
 	ROM_REGION( 0x10000, "soundcpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "xh15.bin", 0x00000, 0x10000, CRC(12d047c4) SHA1(3123b1856219380ff598a2fad97a66863e30d80f) )
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* 8x8x8 */
+	ROM_REGION( 0x400000, "tiles", 0 )   /* 8x8x8 */
 	ROM_LOAD( "srom1.rom", 0x000000, 0x80000, CRC(6df3e0c2) SHA1(855e7d3a75d18c92cfb18ddbe7d110ae6879870d) )
 	ROM_LOAD( "srom2.rom", 0x080000, 0x80000, CRC(3caf65f9) SHA1(da0d417ab6b57fb33e7ed62d4e00b47698764e11) )
 	ROM_LOAD( "srom3.rom", 0x100000, 0x80000, CRC(812f3f87) SHA1(157270343674265ef7d6415a970084ba05daf061) )
@@ -1166,7 +1166,7 @@ ROM_START( nmg5e )
 	ROM_LOAD( "srom7.rom", 0x300000, 0x80000, CRC(b7a9c660) SHA1(d4f39e99813cd2635a95bd05a3776587a2f9351b) )
 	ROM_LOAD( "srom8.rom", 0x380000, 0x80000, CRC(d7ba6058) SHA1(31739fc233ad9b565631b72aab7f9f5a70eca15f) )
 
-	ROM_REGION( 0x140000, "gfx2", 0 )   /* 16x16x5 */
+	ROM_REGION( 0x140000, "sprites", 0 )   /* 16x16x5 */
 	ROM_LOAD( "uf1.rom", 0x000000, 0x40000, CRC(502dbd65) SHA1(b44c7fa61180c807b55f5fd12ef9cba82b0fe18b) )
 	ROM_LOAD( "uf2.rom", 0x040000, 0x40000, CRC(6744cca0) SHA1(f1a45c9b5cd6f4131511910199f71e98a79a4d97) )
 	ROM_LOAD( "ufa1.rom",0x080000, 0x40000, CRC(7110677f) SHA1(8a644223bbf87af446796347d6b0309b439b43dc) )
@@ -1185,7 +1185,7 @@ ROM_START( searchey )
 	ROM_REGION( 0x10000, "soundcpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "u128.bin", 0x00000, 0x10000, CRC(85bae10c) SHA1(a1e58d8b8c8718cc346aae400bb4eadf6873b86d) )
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* 8x8x8 */
+	ROM_REGION( 0x400000, "tiles", 0 )   /* 8x8x8 */
 	ROM_LOAD( "u63.bin", 0x000000, 0x80000, CRC(1b0b7b7d) SHA1(092855407fef95da69fcd6e608b8b3aa720d8bcd) )
 	ROM_LOAD( "u68.bin", 0x080000, 0x80000, CRC(ae18b2aa) SHA1(f1b2d3c1bafe99ec8b7e8e587ae0a0f9fa410a5a) )
 	ROM_LOAD( "u73.bin", 0x100000, 0x80000, CRC(ab7f8716) SHA1(c8cc3c1e9c37add31af28c43130b66f7fdd28042) )
@@ -1195,7 +1195,7 @@ ROM_START( searchey )
 	ROM_LOAD( "u74.bin", 0x300000, 0x80000, CRC(e6134d84) SHA1(d639f44ef404e206b25a0b4f71ded3854836c60f) )
 	ROM_LOAD( "u80.bin", 0x380000, 0x80000, CRC(9a160918) SHA1(aac63dcb6005eaad7088d4e4e584825a6e232764) )
 
-	ROM_REGION( 0x0a0000, "gfx2", 0 )   /* 16x16x5 */
+	ROM_REGION( 0x0a0000, "sprites", 0 )   /* 16x16x5 */
 	ROM_LOAD( "u83.bin", 0x000000, 0x20000, CRC(c5a1c647) SHA1(c8d1cc631b0286a4caa35dce6552c4206e58b620) )
 	ROM_LOAD( "u82.bin", 0x020000, 0x20000, CRC(25b2ae62) SHA1(02a1bd8719ca1792c2e4ff52fd5d4845e19fedb7) )
 	ROM_LOAD( "u105.bin",0x040000, 0x20000, CRC(b4207ef0) SHA1(e70a73b98e5399221208d81a324fab6b942470c8) )
@@ -1214,7 +1214,7 @@ ROM_START( searcheya )
 	ROM_REGION( 0x10000, "soundcpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "u128.bin", 0x00000, 0x10000, CRC(85bae10c) SHA1(a1e58d8b8c8718cc346aae400bb4eadf6873b86d) )
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* 8x8x8 */
+	ROM_REGION( 0x400000, "tiles", 0 )   /* 8x8x8 */
 	ROM_LOAD( "u63.bin", 0x000000, 0x80000, CRC(1b0b7b7d) SHA1(092855407fef95da69fcd6e608b8b3aa720d8bcd) )
 	ROM_LOAD( "u68.bin", 0x080000, 0x80000, CRC(ae18b2aa) SHA1(f1b2d3c1bafe99ec8b7e8e587ae0a0f9fa410a5a) )
 	ROM_LOAD( "u73.bin", 0x100000, 0x80000, CRC(ab7f8716) SHA1(c8cc3c1e9c37add31af28c43130b66f7fdd28042) )
@@ -1224,7 +1224,7 @@ ROM_START( searcheya )
 	ROM_LOAD( "u74.bin", 0x300000, 0x80000, CRC(e6134d84) SHA1(d639f44ef404e206b25a0b4f71ded3854836c60f) )
 	ROM_LOAD( "u80.bin", 0x380000, 0x80000, CRC(9a160918) SHA1(aac63dcb6005eaad7088d4e4e584825a6e232764) )
 
-	ROM_REGION( 0x0a0000, "gfx2", 0 )   /* 16x16x5 */
+	ROM_REGION( 0x0a0000, "sprites", 0 )   /* 16x16x5 */
 	ROM_LOAD( "u83.bin", 0x000000, 0x20000, CRC(c5a1c647) SHA1(c8d1cc631b0286a4caa35dce6552c4206e58b620) )
 	ROM_LOAD( "u82.bin", 0x020000, 0x20000, CRC(25b2ae62) SHA1(02a1bd8719ca1792c2e4ff52fd5d4845e19fedb7) )
 	ROM_LOAD( "u105.bin",0x040000, 0x20000, CRC(b4207ef0) SHA1(e70a73b98e5399221208d81a324fab6b942470c8) )
@@ -1286,13 +1286,13 @@ ROM_START( searchp2 )
 	ROM_REGION( 0x10000, "soundcpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "u128", 0x00000, 0x10000, CRC(85bae10c) SHA1(a1e58d8b8c8718cc346aae400bb4eadf6873b86d) )
 
-	ROM_REGION( 0x1000000, "gfx1", 0 )  /* 8x8x8 */
+	ROM_REGION( 0x1000000, "tiles", 0 )  /* 8x8x8 */
 	ROM_LOAD( "0.u1", 0x000000, 0x400000, CRC(28a50dcf) SHA1(d00992675115e0187a9ca2193edfccdc6e03a0ed) )
 	ROM_LOAD( "2.u3", 0x400000, 0x400000, CRC(30d46e19) SHA1(e3b3d0c5eed29e104f2ecf89541fb74da4f2980f) )
 	ROM_LOAD( "1.u2", 0x800000, 0x400000, CRC(f9c4e824) SHA1(2b3216054060bc349dba87401ce9d8c5e0b60101) )
 	ROM_LOAD( "3.u4", 0xc00000, 0x400000, CRC(619f142f) SHA1(6568e8b2d103bf6aded1314f270c2d288700815e) )
 
-	ROM_REGION( 0x140000, "gfx2", 0 )   /* 16x16x5 */
+	ROM_REGION( 0x140000, "sprites", 0 )   /* 16x16x5 */
 	ROM_LOAD( "u83", 0x000000, 0x40000, CRC(2bae34cb) SHA1(8d18ca44033e064dbf20381158f5bd53931a7362) )
 	ROM_LOAD( "u82", 0x040000, 0x40000, CRC(5cb773f0) SHA1(f3b69073998c9521661c3cffa5d6d022172f30e6) )
 	ROM_LOAD( "u105",0x080000, 0x40000, CRC(e8adb15e) SHA1(f80a030c394fa4e48d569bbcfe945bb22551d542) )
@@ -1350,13 +1350,13 @@ ROM_START( pclubys )
 	ROM_REGION( 0x10000, "soundcpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "rom1.128", 0x00000, 0x10000, CRC(25cd27f8) SHA1(97af1368381234361bbd97f4552209c435652372) )
 
-	ROM_REGION( 0x1000000, "gfx1", 0 )  /* 8x8x8 */
+	ROM_REGION( 0x1000000, "tiles", 0 )  /* 8x8x8 */
 	ROM_LOAD( "rom10.167", 0x000000, 0x400000, CRC(d67e8e84) SHA1(197d1bdb321cf7ac986b5dbfa061494ffd4db6e4) )
 	ROM_LOAD( "rom12.165", 0x400000, 0x400000, CRC(6be8b733) SHA1(bdbbec77938828ac9831537c00abd5c31dc56284) )
 	ROM_LOAD( "rom11.166", 0x800000, 0x400000, CRC(672501a4) SHA1(193e1965c2f21f469e5c6c514d3cdcab3ffdf629) )
 	ROM_LOAD( "rom13.164", 0xc00000, 0x400000, CRC(fc725ce7) SHA1(d997a31a975ae67efa071720c58235c738ebbbe3) )
 
-	ROM_REGION( 0x280000, "gfx2", 0 )   /* 16x16x5 */
+	ROM_REGION( 0x280000, "sprites", 0 )   /* 16x16x5 */
 	ROM_LOAD( "rom8.83", 0x000000, 0x80000, CRC(651af101) SHA1(350698bd7ee65fc1ed084382db7f66ffb83c23c6) )
 	ROM_LOAD( "rom9.82", 0x080000, 0x80000, CRC(2535b4d6) SHA1(85af6a042e83f8a7abb78c5edfd4497a9018ed68) )
 	ROM_LOAD( "rom7.105",0x100000, 0x80000, CRC(f7536c52) SHA1(546976f52c6f064f5172736988ada053c1c1183f) )
@@ -1375,13 +1375,13 @@ ROM_START( pclubysa )
 	ROM_REGION( 0x10000, "soundcpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "rom1.128", 0x00000, 0x10000, CRC(25cd27f8) SHA1(97af1368381234361bbd97f4552209c435652372) )
 
-	ROM_REGION( 0x1000000, "gfx1", 0 )  /* 8x8x8 */
+	ROM_REGION( 0x1000000, "tiles", 0 )  /* 8x8x8 */
 	ROM_LOAD( "rom10.167", 0x000000, 0x400000, CRC(d67e8e84) SHA1(197d1bdb321cf7ac986b5dbfa061494ffd4db6e4) )
 	ROM_LOAD( "rom12.165", 0x400000, 0x400000, CRC(6be8b733) SHA1(bdbbec77938828ac9831537c00abd5c31dc56284) )
 	ROM_LOAD( "rom11.166", 0x800000, 0x400000, CRC(672501a4) SHA1(193e1965c2f21f469e5c6c514d3cdcab3ffdf629) )
 	ROM_LOAD( "rom13.164", 0xc00000, 0x400000, CRC(fc725ce7) SHA1(d997a31a975ae67efa071720c58235c738ebbbe3) )
 
-	ROM_REGION( 0x280000, "gfx2", 0 )   /* 16x16x5 */
+	ROM_REGION( 0x280000, "sprites", 0 )   /* 16x16x5 */
 	ROM_LOAD( "rom8.83", 0x000000, 0x80000, CRC(651af101) SHA1(350698bd7ee65fc1ed084382db7f66ffb83c23c6) )
 	ROM_LOAD( "rom9.82", 0x080000, 0x80000, CRC(2535b4d6) SHA1(85af6a042e83f8a7abb78c5edfd4497a9018ed68) )
 	ROM_LOAD( "rom7.105",0x100000, 0x80000, CRC(f7536c52) SHA1(546976f52c6f064f5172736988ada053c1c1183f) )
@@ -1400,7 +1400,7 @@ ROM_START( wondstck )
 	ROM_REGION( 0x10000, "soundcpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "u128.bin", 0x00000, 0x10000, CRC(86dba085) SHA1(6dedfb4bcf890490848409b6d9bce69e72bf1bba) )
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* 8x8x8 */
+	ROM_REGION( 0x400000, "tiles", 0 )   /* 8x8x8 */
 	ROM_LOAD( "u63.bin", 0x000000, 0x80000, CRC(c6cf09b4) SHA1(d3341c1effa7874b0554e5c79985b32198571767) )
 	ROM_LOAD( "u68.bin", 0x080000, 0x80000, CRC(2e9e9a5e) SHA1(27bae2d913ad4c569f4c476d954c47665456e818) )
 	ROM_LOAD( "u73.bin", 0x100000, 0x80000, CRC(3a828604) SHA1(562ecfc1b485218b861512c62225e7d0e148a6df) )
@@ -1410,7 +1410,7 @@ ROM_START( wondstck )
 	ROM_LOAD( "u74.bin", 0x300000, 0x80000, CRC(7eff8e2f) SHA1(a08d188fc1a549ba684e69adb277ef684c6d875c) )
 	ROM_LOAD( "u80.bin", 0x380000, 0x80000, CRC(1160a0c2) SHA1(b23f6fb256b927a5606a1aacf004727b984807de) )
 
-	ROM_REGION( 0x280000, "gfx2", 0 )   /* 16x16x5 */
+	ROM_REGION( 0x280000, "sprites", 0 )   /* 16x16x5 */
 	ROM_LOAD( "u83.bin", 0x000000, 0x80000, CRC(f51cf9c6) SHA1(6d0fc749bab918ff6a9d7fae8be7c65823349283) )
 	ROM_LOAD( "u82.bin", 0x080000, 0x80000, CRC(ddd3c60c) SHA1(19b68a44c877d0bf630d07b18541ef9636f5adac) )
 	ROM_LOAD( "u105.bin",0x100000, 0x80000, CRC(a7fc624d) SHA1(b336ab6e16555db30f9366bf5b797b5ba3ea767c) )
@@ -1429,7 +1429,7 @@ ROM_START( wondstcka )
 	ROM_REGION( 0x10000, "soundcpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "1.u128", 0x00000, 0x10000, CRC(86dba085) SHA1(6dedfb4bcf890490848409b6d9bce69e72bf1bba) )
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* 8x8x8 */
+	ROM_REGION( 0x400000, "tiles", 0 )   /* 8x8x8 */
 	ROM_LOAD( "7.u63", 0x000000, 0x80000, CRC(25ee44ce) SHA1(bf1cad9d89af764d54eb9d35b1656208b8e0b594) )
 	ROM_LOAD( "2.u68", 0x080000, 0x80000, CRC(b26afb40) SHA1(f6c96d0ea72bfdf5b153fd599a67703c3c7609b1) )
 	ROM_LOAD( "8.u73", 0x100000, 0x80000, CRC(7cf46203) SHA1(97bd5fdc9004726846d9577ca7b4bc078d3731e8) )
@@ -1439,7 +1439,7 @@ ROM_START( wondstcka )
 	ROM_LOAD( "6.u74", 0x300000, 0x80000, CRC(9795ff80) SHA1(e369844382e8cb99d6d37eb40cdd62266b4031f2) )
 	ROM_LOAD( "3.u80", 0x380000, 0x80000, CRC(553c5781) SHA1(d5f694f6a50f51c80845a15e58d263fa629c3522) )
 
-	ROM_REGION( 0x280000, "gfx2", 0 )   /* 16x16x5 */
+	ROM_REGION( 0x280000, "sprites", 0 )   /* 16x16x5 */
 	ROM_LOAD( "8.u83",   0x000000, 0x80000, CRC(f51cf9c6) SHA1(6d0fc749bab918ff6a9d7fae8be7c65823349283) )
 //  ROM_LOAD( "9.u82",   0x080000, 0x80000, CRC(8c6cff4d) SHA1(5a217ff60f10bf5c58091c189b3509d1361a16b3) ) // bad dump
 	ROM_LOAD( "9.u82",   0x080000, 0x80000, CRC(ddd3c60c) SHA1(19b68a44c877d0bf630d07b18541ef9636f5adac) )
@@ -1460,7 +1460,7 @@ ROM_START( garogun )
 	ROM_REGION( 0x10000, "soundcpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "rom.u128", 0x00000, 0x10000,  CRC(117b31ce) SHA1(1681aea60111274599c86b7050d46ea497878f9e) )
 
-	ROM_REGION( 0x400000, "gfx1", 0 )   /* 8x8x8 */
+	ROM_REGION( 0x400000, "tiles", 0 )   /* 8x8x8 */
 	ROM_LOAD( "8.u63",  0x000000, 0x80000, CRC(2d152d32) SHA1(7dd3b0bb9db8cec8ff8a75099375fbad51ee5676) )
 	ROM_LOAD( "11.u68", 0x080000, 0x80000, CRC(60ec7f67) SHA1(9c6c3f5a5be244fe5ac24da3642fd666def11120) )
 	ROM_LOAD( "9.u73",  0x100000, 0x80000, CRC(a4b16319) SHA1(8f7976f58ecbccd728cf1a01d0fcd1cef6b90d47) )
@@ -1470,7 +1470,7 @@ ROM_START( garogun )
 	ROM_LOAD( "7.u74",  0x300000, 0x80000, CRC(a0574f8d) SHA1(3016dd5ee2c78eb2e16b396cedcdc69151312a06) )
 	ROM_LOAD( "12.u80", 0x380000, 0x80000, CRC(94d66169) SHA1(4a84d46caa7da98ac376965d6e1ebe1d26fda542) )
 
-	ROM_REGION( 0x280000, "gfx2", 0 )   /* 16x16x5 */
+	ROM_REGION( 0x280000, "sprites", 0 )   /* 16x16x5 */
 	ROM_LOAD( "4.u83", 0x000000, 0x40000, CRC(3d1d46ff) SHA1(713beb8cb5b105900d59380f760d759e94f4b0b2) )
 	ROM_LOAD( "5.u82", 0x080000, 0x40000, CRC(2a7b2fb5) SHA1(f860047d78f625592605f425e9e066c3e595be62) )
 	ROM_LOAD( "3.u105",0x100000, 0x40000, CRC(cd20e39c) SHA1(beb129a44223cc542906f96e5bb17aabfe4c4c49) )
@@ -1529,7 +1529,7 @@ ROM_START( 7ordi )
 	ROM_REGION( 0x10000, "soundcpu", 0 )        /* Z80 Code */
 	ROM_LOAD( "4.u128", 0x00000, 0x10000, CRC(ed73b565) SHA1(cb473b2b4ca9b9facf3bcb033f1ca9667bb5c587) )
 
-	ROM_REGION( 0x400000, "gfx1", 0 ) /* 8x8x8 */
+	ROM_REGION( 0x400000, "tiles", 0 ) /* 8x8x8 */
 	ROM_LOAD( "8.u63",  0x000000, 0x80000, CRC(ed8dfe5d) SHA1(a4ac6bf80682b978158c44a62c8abb117f25c4db) )
 	ROM_LOAD( "11.u68", 0x080000, 0x80000, CRC(742764a7) SHA1(c38a7ea76034d5c34d30f6caa6dc12b1253de2a8) )
 	ROM_LOAD( "9.u73",  0x100000, 0x80000, CRC(2b76efd0) SHA1(3ae0b708a94ed04516f451be833ea02d9ee8d645) )
@@ -1539,7 +1539,7 @@ ROM_START( 7ordi )
 	ROM_LOAD( "7.u74",  0x300000, 0x80000, CRC(6910f754) SHA1(b0c29a205e66f21ff1bebac79505d1d3170d923f) )
 	ROM_LOAD( "12.u80", 0x380000, 0x80000, CRC(4c5dd9ef) SHA1(e22b2d5652ad97c8d84168f8c4851437e3f07c97) )
 
-	ROM_REGION( 0x280000, "gfx2", 0 )   /* 16x16x5 */
+	ROM_REGION( 0x280000, "sprites", 0 )   /* 16x16x5 */
 	ROM_LOAD( "4.u83",  0x000000, 0x80000, CRC(a2569cf4) SHA1(7f65a0ea79c38aa89d06466b0ce5e3846073c676) )
 	ROM_LOAD( "5.u82",  0x080000, 0x80000, CRC(045e548e) SHA1(7135ce56c3987f3d7e0514670836603fc95dfc84) )
 	ROM_LOAD( "3.u105", 0x100000, 0x80000, CRC(04c1dbf9) SHA1(afca98aeac6095992611eaaa958952a40a0ffd23) )


### PR DESCRIPTION
- Reduce unnecessary lines
- Constantize variables
- Use Bit macros for bitfields
- Use C++ style comment for single line comments
- Fix spacing
- Move sprite configuration related stuff into machine config
- Fix file directory, Sort to Alphabetical order

dataeast/minor cleanups for various drivers
- Constantize values
- Reduce literal tags and runtime tag lookups
- Fix ROM region namings
- Suppress side effects for debugger read
- Simplify deco146/104 related function namings
- Reduce duplicates
- Reduce unnecessary lines
- Fix sound routing if chip and/or PCB supports mono sound only
- Fix palette entries

dataeast/backfire.cpp, deco156.cpp, simpl156.cpp:
- Use memory_share_creator instead unique_ptr/array

dataeast/boogwing.cpp:
- Reduce preprocessor defines

dataeast/pktgaldx.cpp:
- Simplify gfxdecode layout
- Fix metadata for bootleg set (title screen says (c)1993 Data West)

f32/silvmil.cpp:
- Fix ROM region namings
- Reduce literal tag usage

misc/esd16.cpp:
- Constantize variables

misc/gotcha.cpp:
- Simplify gfx decode layout

yunsung/nmg5.cpp:
- Fix ROM region naming
- Simplify gfx decode layout