### PR TITLE
emucore.h: fix build error on VC++

### DIFF
--- a/src/emu/emucore.h
+++ b/src/emu/emucore.h
@@ -233,7 +233,7 @@ public:
 	emu_fatalerror(util::format_argument_pack<char> const &args);
 	emu_fatalerror(int _exitcode, util::format_argument_pack<char> const &args);
 
-	template <typename Format, typename... Params>
+	template <typename Format, typename... Params, typename = std::enable_if_t<!std::is_base_of_v<emu_fatalerror, std::remove_reference_t<Format>>>>
 	emu_fatalerror(Format &&fmt, Params &&... args)
 		: emu_fatalerror(static_cast<util::format_argument_pack<char> const &>(util::make_format_argument_pack(std::forward<Format>(fmt), std::forward<Params>(args)...)))
 	{


### PR DESCRIPTION
This compiler requires exception classes to be copyable, because it copies the exception object as part of `std::current_exception()`. This means that code like the following has to work:

    emu_fatalerror e1(...);
    emu_fatalerror e2(e1);

However, it doesn't, because in this case the perfect-forwarding constructor is a better match than the copy constructor. So the compiler tries to instantiate the perfect-forwarding constructor with `Format`=`emu_fatalerror &`, which fails, since that's not a valid format string type.

To fix this, disable the perfect-forwarding constructor when `Format` is a subclass of `emu_fatalerror`.

Fixes #11316