### PR TITLE
Add Comelta's DRAC-1 (AIM 65 based) and it's BASIC [OldComputers ES]

### DIFF
--- a/hash/aim65_cart.xml
+++ b/hash/aim65_cart.xml
@@ -44,6 +44,30 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<!-- Found on a Comelta DRAC-1 machine. -->
+	<software name="basic11a">
+		<description>AIM 65 BASIC v1.1 (alt)</description>
+		<year>1978</year>
+		<publisher>Rockwell/Microsoft</publisher>
+		<info name="usage" value="Load in &quot;cart1&quot; and &quot;cart2&quot;, then press 5 to start"/>
+
+		<part name="z26" interface="aim65_z26_cart">
+			<dataarea name="z26" size="4096">
+				<rom name="r3226.z26" size="4096" crc="36a61f39" sha1="f5ce0126cb594a565e730973fd140d03c298cefa"/>
+			</dataarea>
+		</part>
+		<part name="z25" interface="aim65_z25_cart">
+			<dataarea name="z25" size="4096">
+				<rom name="r3225.z25" size="4096" crc="d7b42d2a" sha1="4bbdb28d332429825adea0266ed9192786d9e392"/>
+			</dataarea>
+		</part>
+		<part name="z24" interface="aim65_z24_cart">
+			<dataarea name="z24" size="4096">
+				<rom name="crosaim_v1.3_b_asse-1_d000.z24" size="4096" crc="b7472a5e" sha1="333630bafa93e7236e3c7a8d14f16f2ba551fd26"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="extbas21">
 		<description>AIM 65/PC100 Extended BASIC v2.1</description>
 		<year>1980</year>

--- a/src/mame/rockwell/aim65.cpp
+++ b/src/mame/rockwell/aim65.cpp
@@ -43,7 +43,6 @@ static constexpr XTAL AIM65_CLOCK(4_MHz_XTAL / 4);
     ADDRESS MAPS
 ***************************************************************************/
 
-// Note: RAM is mapped dynamically in machine/aim65.c
 void aim65_state::mem_map(address_map &map)
 {
 	map(0x1000, 0x3fff).noprw(); // User available expansions
@@ -307,15 +306,25 @@ void aim65_state::aim65(machine_config &config)
 
 ROM_START( aim65 )
 	ROM_REGION(0x10000, "maincpu", 0)
-	ROM_SYSTEM_BIOS(0, "aim65",  "Rockwell AIM-65")
+	ROM_SYSTEM_BIOS(0, "aim65",   "Rockwell AIM-65")
 	ROMX_LOAD("aim65mon.z23", 0xe000, 0x1000, CRC(90e44afe) SHA1(78e38601edf6bfc787b58750555a636b0cf74c5c), ROM_BIOS(0))
 	ROMX_LOAD("aim65mon.z22", 0xf000, 0x1000, CRC(d01914b0) SHA1(e5b5ddd4cd43cce073a718ee4ba5221f2bc84eaf), ROM_BIOS(0))
-	ROM_SYSTEM_BIOS(1, "dynatem",  "Dynatem AIM-65")
-	ROMX_LOAD("dynaim65.z23", 0xe000, 0x1000, CRC(90e44afe) SHA1(78e38601edf6bfc787b58750555a636b0cf74c5c), ROM_BIOS(1))
-	ROMX_LOAD("dynaim65.z22", 0xf000, 0x1000, CRC(83e1c6e7) SHA1(444134043edd83385bd70434cb100269901c4417), ROM_BIOS(1))
-	ROM_SYSTEM_BIOS(2, "spc100",  "Siemens PC100")
-	ROMX_LOAD("pc100.z23",    0xe000, 0x1000, CRC(90e44afe) SHA1(78e38601edf6bfc787b58750555a636b0cf74c5c), ROM_BIOS(2))
-	ROMX_LOAD("pc100.z22",    0xf000, 0x1000, CRC(aa07742a) SHA1(3b9bee24a00cf23b7b50cee97ccc12e3fa9da1ea), ROM_BIOS(2))
+
+	/* DRAC/DRAC-1 is an industrial control computer from the Spanish company Comelta (more info: https://www.oldcomputers.es/drac-1/).
+	   It's based on a standard Rockwell AIM 65 PCB, but can be expanded with several cards and accessories made by Comelta, from CPU and
+	   memory modules to control or interface cards (more info and manuals with schematics: https://www.oldcomputers.es/drac-1-placas-cr/).
+	*/
+	ROM_SYSTEM_BIOS(1, "drac1",   "Comelta DRAC-1")
+	ROMX_LOAD("crosaim_v1.3_b_mone_2b_moni_01_e000.z23", 0xe000, 0x1000, CRC(ae83ba08) SHA1(4ee4157fe6cafda6c763547183be18859bdabc36), ROM_BIOS(1))
+	ROMX_LOAD("crosaim_v1.3_b_monf_2b_f000.z22",         0xf000, 0x1000, CRC(047c2ca8) SHA1(1877be29f7b725ee4fec7f21aa679d857391514b), ROM_BIOS(1))
+
+	ROM_SYSTEM_BIOS(2, "dynatem", "Dynatem AIM-65")
+	ROMX_LOAD("dynaim65.z23", 0xe000, 0x1000, CRC(90e44afe) SHA1(78e38601edf6bfc787b58750555a636b0cf74c5c), ROM_BIOS(2))
+	ROMX_LOAD("dynaim65.z22", 0xf000, 0x1000, CRC(83e1c6e7) SHA1(444134043edd83385bd70434cb100269901c4417), ROM_BIOS(2))
+
+	ROM_SYSTEM_BIOS(3, "spc100",  "Siemens PC100")
+	ROMX_LOAD("pc100.z23",    0xe000, 0x1000, CRC(90e44afe) SHA1(78e38601edf6bfc787b58750555a636b0cf74c5c), ROM_BIOS(3))
+	ROMX_LOAD("pc100.z22",    0xf000, 0x1000, CRC(aa07742a) SHA1(3b9bee24a00cf23b7b50cee97ccc12e3fa9da1ea), ROM_BIOS(3))
 ROM_END
 
 


### PR DESCRIPTION
Add Comelta's DRAC-1 as a new AIM 65 BIOS, and it's BASIC, an alternate version of the AIM 65 BASIC v1.1, as a new software list item.

New working software list items
-------------------------------
aim65_cart.xml:
  AIM 65 BASIC v1.1 (alt) [OldComputers ES]