### PR TITLE
sega/segac2.cpp: Print Club Vol. 3

### DIFF
--- a/src/emu/xtal.cpp
+++ b/src/emu/xtal.cpp
@@ -475,6 +475,7 @@ const double XTAL::known_xtals[] = {
 	 51'200'000, /* 51.2_MHz_XTAL          Namco Super System 22 video clock */
 	 52'000'000, /* 52_MHz_XTAL            Cojag */
 	 52'832'000, /* 52.832_MHz_XTAL        Wang PC TIG video controller */
+	 52'867'000, /* 52.867_MHz_XTAL        Atlus Print Club (Sega C2 PCB) */
 	 53'203'424, /* 53.203424_MHz_XTAL     Master System, Mega Drive PAL (12x PAL subcarrier) */
 	 53'693'175, /* 53.693175_MHz_XTAL     PSX-based h/w, Sony ZN1-2-based (15x NTSC subcarrier) */
 	 54'000'000, /* 54_MHz_XTAL            Taito JC */

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -39728,6 +39728,7 @@ ooparts                         // (c) 1992 Success
 pclubj                          //
 pclubjv2                        //
 pclub                           //
+pclubjv3                        //
 pclubjv4                        //
 pclubjv5                        //
 potopoto                        // (c) 1994 Sega


### PR DESCRIPTION
Addition of Print Club Vol. 3 to the Sega C2 driver.

* Print Club Vol. 3 ROM entry added
* Crystal value modified; derivative `pclub` hardware used for all Print Club boards
* Print Club hardware documented in top comments, specifically daughterboards and separate analog board
* Notes about Puyo Puyo 2's link capabilities added in upper comment area

### NOTE FOR REVIEWERS:
NOTE: The protection has not yet been dumped or reversed. I do not know where to begin with this, or if I should be trying to dump the Altera device directly, or what. I am requesting guidance on this matter. For now, I have a stand-in protection function, just copied from the previous volume.