### PR TITLE
vsystem/fromanc2.cpp: Cleanups

### DIFF
--- a/src/mame/vsystem/fromanc2.cpp
+++ b/src/mame/vsystem/fromanc2.cpp
@@ -52,20 +52,12 @@ void fromanc2_base_state::portselect_w(uint16_t data)
 
 uint16_t fromanc2_base_state::keymatrix_r()
 {
-	uint16_t ret;
+	uint16_t ret = 0xffff;
 
-	switch (m_portselect)
-	{
-		case 0x01:  ret = m_in_key[0]->read(); break;
-		case 0x02:  ret = m_in_key[1]->read(); break;
-		case 0x04:  ret = m_in_key[2]->read(); break;
-		case 0x08:  ret = m_in_key[3]->read(); break;
-		default:
-			ret = 0xffff;
-			if (!machine().side_effects_disabled())
-				logerror("PC:%08X unknown %02X\n", m_maincpu->pc(), m_portselect);
-			break;
-	}
+	if BIT(m_portselect, 0) ret &= m_in_key[0]->read(); break;
+	if BIT(m_portselect, 1) ret &= m_in_key[1]->read(); break;
+	if BIT(m_portselect, 2) ret &= m_in_key[2]->read(); break;
+	if BIT(m_portselect, 3) ret &= m_in_key[3]->read(); break;
 
 	return ret;
 }

--- a/src/mame/vsystem/fromanc2.cpp
+++ b/src/mame/vsystem/fromanc2.cpp
@@ -36,7 +36,7 @@
  *
  *************************************/
 
-void fromanc2_state::sndcmd_w(uint16_t data)
+void fromanc2_base_state::sndcmd_w(uint16_t data)
 {
 	m_soundlatch->write((data >> 8) & 0xff);   // 1P (LEFT)
 	m_soundlatch2->write(data & 0xff);         // 2P (RIGHT)
@@ -45,23 +45,25 @@ void fromanc2_state::sndcmd_w(uint16_t data)
 	m_sndcpu_nmi_flag = 0;
 }
 
-void fromanc2_state::portselect_w(uint16_t data)
+void fromanc2_base_state::portselect_w(uint16_t data)
 {
 	m_portselect = data;
 }
 
-uint16_t fromanc2_state::keymatrix_r()
+uint16_t fromanc2_base_state::keymatrix_r()
 {
 	uint16_t ret;
 
 	switch (m_portselect)
 	{
-		case 0x01:  ret = ioport("KEY0")->read(); break;
-		case 0x02:  ret = ioport("KEY1")->read(); break;
-		case 0x04:  ret = ioport("KEY2")->read(); break;
-		case 0x08:  ret = ioport("KEY3")->read(); break;
-		default:    ret = 0xffff;
-			logerror("PC:%08X unknown %02X\n", m_maincpu->pc(), m_portselect);
+		case 0x01:  ret = m_in_key[0]->read(); break;
+		case 0x02:  ret = m_in_key[1]->read(); break;
+		case 0x04:  ret = m_in_key[2]->read(); break;
+		case 0x08:  ret = m_in_key[3]->read(); break;
+		default:
+			ret = 0xffff;
+			if (!machine().side_effects_disabled())
+				logerror("PC:%08X unknown %02X\n", m_maincpu->pc(), m_portselect);
 			break;
 	}
 
@@ -73,7 +75,7 @@ int fromanc2_state::subcpu_int_r()
 	return m_subcpu_int_flag & 0x01;
 }
 
-int fromanc2_state::sndcpu_nmi_r()
+int fromanc2_base_state::sndcpu_nmi_r()
 {
 	return m_sndcpu_nmi_flag & 0x01;
 }
@@ -137,9 +139,10 @@ void fromanc2_state::subcpu_nmi_clr(uint8_t data)
 	m_subcpu_nmi_flag = 1;
 }
 
-uint8_t fromanc2_state::sndcpu_nmi_clr()
+uint8_t fromanc2_base_state::sndcpu_nmi_clr()
 {
-	m_sndcpu_nmi_flag = 1;
+	if (!machine().side_effects_disabled())
+		m_sndcpu_nmi_flag = 1;
 
 	return 0xff;
 }
@@ -147,10 +150,10 @@ uint8_t fromanc2_state::sndcpu_nmi_clr()
 void fromanc2_state::subcpu_rombank_w(uint8_t data)
 {
 	// Change ROM BANK
-	membank("bank1")->set_entry(data & 0x03);
+	m_subrombank->set_entry(data & 0x03);
 
 	// Change RAM BANK
-	membank("bank2")->set_entry((data & 0x0c) >> 2);
+	m_subrambank->set_entry((data & 0x0c) >> 2);
 }
 
 
@@ -223,34 +226,34 @@ void fromanc2_state::fromancr_main_map(address_map &map)
 	map(0xd80000, 0xd8ffff).ram();                                 // WORK RAM
 }
 
-void fromanc2_state::fromanc4_main_map(address_map &map)
+void fromanc4_state::fromanc4_main_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();                             // MAIN ROM
 	map(0x400000, 0x7fffff).rom();                             // DATA ROM
 
 	map(0x800000, 0x81ffff).ram();                             // WORK RAM
 
-	map(0xd00000, 0xd00001).w(FUNC(fromanc2_state::portselect_w));             // PORT SELECT (1P/2P)
+	map(0xd00000, 0xd00001).w(FUNC(fromanc4_state::portselect_w));             // PORT SELECT (1P/2P)
 
 	map(0xd10000, 0xd10001).nopw();                        // ?
 	map(0xd30000, 0xd30001).nopw();                        // ?
 	map(0xd50000, 0xd50001).portw("EEPROMOUT");         // EEPROM DATA
 
-	map(0xd70000, 0xd70001).w(FUNC(fromanc2_state::sndcmd_w));                 // SOUND REQ (1P/2P)
+	map(0xd70000, 0xd70001).w(FUNC(fromanc4_state::sndcmd_w));                 // SOUND REQ (1P/2P)
 
-	map(0xd80000, 0xd8ffff).w(FUNC(fromanc2_state::fromanc4_videoram_0_w));    // VRAM FG (1P/2P)
-	map(0xd90000, 0xd9ffff).w(FUNC(fromanc2_state::fromanc4_videoram_1_w));    // VRAM BG (1P/2P)
-	map(0xda0000, 0xdaffff).w(FUNC(fromanc2_state::fromanc4_videoram_2_w));    // VRAM TEXT (1P/2P)
+	map(0xd80000, 0xd8ffff).w(FUNC(fromanc4_state::fromanc4_videoram_0_w));    // VRAM FG (1P/2P)
+	map(0xd90000, 0xd9ffff).w(FUNC(fromanc4_state::fromanc4_videoram_1_w));    // VRAM BG (1P/2P)
+	map(0xda0000, 0xdaffff).w(FUNC(fromanc4_state::fromanc4_videoram_2_w));    // VRAM TEXT (1P/2P)
 
 	map(0xdb0000, 0xdb0fff).ram().w(m_lpalette, FUNC(palette_device::write16)).share("lpalette"); // PALETTE (1P)
 	map(0xdc0000, 0xdc0fff).ram().w(m_rpalette, FUNC(palette_device::write16)).share("rpalette"); // PALETTE (2P)
 
-	map(0xd10000, 0xd10001).r(FUNC(fromanc2_state::keymatrix_r));               // INPUT KEY MATRIX
+	map(0xd10000, 0xd10001).r(FUNC(fromanc4_state::keymatrix_r));               // INPUT KEY MATRIX
 	map(0xd20000, 0xd20001).portr("SYSTEM");
 
-	map(0xe00000, 0xe0001d).w(FUNC(fromanc2_state::fromanc4_gfxreg_0_w));      // SCROLL, GFXBANK (1P/2P)
-	map(0xe10000, 0xe1001d).w(FUNC(fromanc2_state::fromanc4_gfxreg_1_w));      // SCROLL, GFXBANK (1P/2P)
-	map(0xe20000, 0xe2001d).w(FUNC(fromanc2_state::fromanc4_gfxreg_2_w));      // SCROLL, GFXBANK (1P/2P)
+	map(0xe00000, 0xe0001d).w(FUNC(fromanc4_state::fromanc4_gfxreg_0_w));      // SCROLL, GFXBANK (1P/2P)
+	map(0xe10000, 0xe1001d).w(FUNC(fromanc4_state::fromanc4_gfxreg_1_w));      // SCROLL, GFXBANK (1P/2P)
+	map(0xe20000, 0xe2001d).w(FUNC(fromanc4_state::fromanc4_gfxreg_2_w));      // SCROLL, GFXBANK (1P/2P)
 
 	map(0xe30000, 0xe30013).nopw();                        // ???
 	map(0xe40000, 0xe40013).nopw();                        // ???
@@ -262,9 +265,9 @@ void fromanc2_state::fromanc4_main_map(address_map &map)
 void fromanc2_state::fromanc2_sub_map(address_map &map)
 {
 	map(0x0000, 0x3fff).rom();                                 // ROM
-	map(0x4000, 0x7fff).bankr("bank1");                    // ROM(BANK)
+	map(0x4000, 0x7fff).bankr(m_subrombank);                    // ROM(BANK)
 	map(0x8000, 0xbfff).ram();                                 // RAM(WORK)
-	map(0xc000, 0xffff).bankrw("bank2");                    // RAM(BANK)
+	map(0xc000, 0xffff).bankrw(m_subrambank);                    // RAM(BANK)
 }
 
 void fromanc2_state::fromanc2_sub_io_map(address_map &map)
@@ -277,19 +280,19 @@ void fromanc2_state::fromanc2_sub_io_map(address_map &map)
 }
 
 
-void fromanc2_state::fromanc2_sound_map(address_map &map)
+void fromanc2_base_state::sound_map(address_map &map)
 {
 	map(0x0000, 0xdfff).rom();
 	map(0xe000, 0xffff).ram();
 }
 
-void fromanc2_state::fromanc2_sound_io_map(address_map &map)
+void fromanc2_base_state::sound_io_map(address_map &map)
 {
 	map.global_mask(0xff);
 	map(0x00, 0x00).r(m_soundlatch, FUNC(generic_latch_8_device::read)).nopw();     // snd cmd (1P) / ?
 	map(0x04, 0x04).r(m_soundlatch2, FUNC(generic_latch_8_device::read));                // snd cmd (2P)
 	map(0x08, 0x0b).rw("ymsnd", FUNC(ym2610_device::read), FUNC(ym2610_device::write));
-	map(0x0c, 0x0c).r(FUNC(fromanc2_state::sndcpu_nmi_clr));
+	map(0x0c, 0x0c).r(FUNC(fromanc2_base_state::sndcpu_nmi_clr));
 }
 
 
@@ -406,7 +409,7 @@ static INPUT_PORTS_START( fromanc4 )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_COIN2 )
 	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_COIN3 )
 	PORT_BIT( 0x0010, IP_ACTIVE_LOW, IPT_COIN4 )
-	PORT_BIT( 0x0020, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_MEMBER(fromanc2_state, sndcpu_nmi_r) // SNDCPU NMI FLAG
+	PORT_BIT( 0x0020, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_MEMBER(fromanc4_state, sndcpu_nmi_r) // SNDCPU NMI FLAG
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x0080, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER("eeprom", eeprom_serial_93cxx_device, do_read)
 	PORT_BIT( 0x0100, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -433,21 +436,10 @@ static GFXDECODE_START( gfx_fromanc2 )
 	GFXDECODE_ENTRY( "gfx4", 0, gfx_8x8x4_packed_lsb, 768, 4 )
 GFXDECODE_END
 
-static const gfx_layout fromancr_tilelayout =
-{
-	8, 8,
-	RGN_FRAC(1, 1),
-	8,
-	{ 0, 1, 2, 3, 4, 5, 6, 7 },
-	{ 1*8, 0*8, 3*8, 2*8, 5*8, 4*8, 7*8, 6*8 },
-	{ 0*64, 1*64, 2*64, 3*64, 4*64, 5*64, 6*64, 7*64 },
-	64*8
-};
-
 static GFXDECODE_START( gfx_fromancr )
-	GFXDECODE_ENTRY( "gfx1", 0, fromancr_tilelayout, 512, 1 )
-	GFXDECODE_ENTRY( "gfx2", 0, fromancr_tilelayout, 256, 1 )
-	GFXDECODE_ENTRY( "gfx3", 0, fromancr_tilelayout,   0, 1 )
+	GFXDECODE_ENTRY( "gfx1", 0, gfx_8x8x8_raw, 512, 1 )
+	GFXDECODE_ENTRY( "gfx2", 0, gfx_8x8x8_raw, 256, 1 )
+	GFXDECODE_ENTRY( "gfx3", 0, gfx_8x8x8_raw,   0, 1 )
 GFXDECODE_END
 
 
@@ -457,35 +449,40 @@ GFXDECODE_END
  *
  *************************************/
 
-MACHINE_START_MEMBER(fromanc2_state,fromanc4)
+void fromanc2_base_state::machine_start()
 {
 	save_item(NAME(m_portselect));
 	save_item(NAME(m_sndcpu_nmi_flag));
-	save_item(NAME(m_datalatch1));
-	save_item(NAME(m_datalatch_2h));
-	save_item(NAME(m_datalatch_2l));
 
-	/* video-related elements are saved in video_start */
+	// video-related elements are saved in video_start
 }
 
-MACHINE_START_MEMBER(fromanc2_state,fromanc2)
+void fromanc2_state::machine_start()
 {
 	m_bankedram = std::make_unique<uint8_t[]>(0x4000 * 3);
 
-	membank("bank1")->configure_entries(0, 4, memregion("sub")->base(), 0x4000);
-	membank("bank2")->configure_entry(0, memregion("sub")->base() + 0x08000);
-	membank("bank2")->configure_entries(1, 3, m_bankedram.get(), 0x4000);
+	m_subrombank->configure_entries(0, 4, memregion("sub")->base(), 0x4000);
+	m_subrambank->configure_entry(0, memregion("sub")->base() + 0x08000);
+	m_subrambank->configure_entries(1, 3, m_bankedram.get(), 0x4000);
 
-	MACHINE_START_CALL_MEMBER(fromanc4);
+	fromanc2_base_state::machine_start();
 
+	save_item(NAME(m_datalatch1));
+	save_item(NAME(m_datalatch_2h));
+	save_item(NAME(m_datalatch_2l));
 	save_item(NAME(m_subcpu_int_flag));
 	save_item(NAME(m_subcpu_nmi_flag));
 	save_pointer(NAME(m_bankedram), 0x4000 * 3);
 }
 
-void fromanc2_state::machine_reset()
+void fromanc2_base_state::machine_reset()
 {
 	m_portselect = 0;
+}
+
+void fromanc2_state::machine_reset()
+{
+	fromanc2_base_state::machine_reset();
 	m_datalatch1 = 0;
 	m_datalatch_2h = 0;
 	m_datalatch_2l = 0;
@@ -493,24 +490,22 @@ void fromanc2_state::machine_reset()
 
 void fromanc2_state::fromanc2(machine_config &config)
 {
-	/* basic machine hardware */
-	M68000(config, m_maincpu, 32000000/2);      /* 16.00 MHz */
+	// basic machine hardware
+	M68000(config, m_maincpu, 32000000/2);      // 16.00 MHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &fromanc2_state::fromanc2_main_map);
 	m_maincpu->set_vblank_int("lscreen", FUNC(fromanc2_state::irq1_line_hold));
 
-	Z80(config, m_audiocpu, 32000000/4);        /* 8.00 MHz */
-	m_audiocpu->set_addrmap(AS_PROGRAM, &fromanc2_state::fromanc2_sound_map);
-	m_audiocpu->set_addrmap(AS_IO, &fromanc2_state::fromanc2_sound_io_map);
+	Z80(config, m_audiocpu, 32000000/4);        // 8.00 MHz
+	m_audiocpu->set_addrmap(AS_PROGRAM, &fromanc2_state::sound_map);
+	m_audiocpu->set_addrmap(AS_IO, &fromanc2_state::sound_io_map);
 
-	Z80(config, m_subcpu, 32000000/4);     /* 8.00 MHz */
+	Z80(config, m_subcpu, 32000000/4);     // 8.00 MHz
 	m_subcpu->set_addrmap(AS_PROGRAM, &fromanc2_state::fromanc2_sub_map);
 	m_subcpu->set_addrmap(AS_IO, &fromanc2_state::fromanc2_sub_io_map);
 
-	MCFG_MACHINE_START_OVERRIDE(fromanc2_state,fromanc2)
-
 	EEPROM_93C46_16BIT(config, m_eeprom);
 
-	/* video hardware */
+	// video hardware
 	GFXDECODE(config, m_gfxdecode, m_lpalette, gfx_fromanc2);
 
 	PALETTE(config, m_lpalette).set_format(palette_device::GRBx_555, 2048);
@@ -536,7 +531,7 @@ void fromanc2_state::fromanc2(machine_config &config)
 
 	MCFG_VIDEO_START_OVERRIDE(fromanc2_state,fromanc2)
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	GENERIC_LATCH_8(config, m_soundlatch);
@@ -551,24 +546,22 @@ void fromanc2_state::fromanc2(machine_config &config)
 
 void fromanc2_state::fromancr(machine_config &config)
 {
-	/* basic machine hardware */
-	M68000(config, m_maincpu, 32000000/2);      /* 16.00 MHz */
+	// basic machine hardware
+	M68000(config, m_maincpu, 32000000/2);      // 16.00 MHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &fromanc2_state::fromancr_main_map);
 	m_maincpu->set_vblank_int("lscreen", FUNC(fromanc2_state::irq1_line_hold));
 
-	Z80(config, m_audiocpu, 32000000/4);        /* 8.00 MHz */
-	m_audiocpu->set_addrmap(AS_PROGRAM, &fromanc2_state::fromanc2_sound_map);
-	m_audiocpu->set_addrmap(AS_IO, &fromanc2_state::fromanc2_sound_io_map);
+	Z80(config, m_audiocpu, 32000000/4);        // 8.00 MHz
+	m_audiocpu->set_addrmap(AS_PROGRAM, &fromanc2_state::sound_map);
+	m_audiocpu->set_addrmap(AS_IO, &fromanc2_state::sound_io_map);
 
-	Z80(config, m_subcpu, 32000000/4);     /* 8.00 MHz */
+	Z80(config, m_subcpu, 32000000/4);     // 8.00 MHz
 	m_subcpu->set_addrmap(AS_PROGRAM, &fromanc2_state::fromanc2_sub_map);
 	m_subcpu->set_addrmap(AS_IO, &fromanc2_state::fromanc2_sub_io_map);
 
-	MCFG_MACHINE_START_OVERRIDE(fromanc2_state,fromanc2)
-
 	EEPROM_93C46_16BIT(config, m_eeprom);
 
-	/* video hardware */
+	// video hardware
 	GFXDECODE(config, m_gfxdecode, m_lpalette, gfx_fromancr);
 
 	PALETTE(config, m_lpalette).set_format(palette_device::xGRB_555, 2048);
@@ -594,7 +587,7 @@ void fromanc2_state::fromancr(machine_config &config)
 
 	MCFG_VIDEO_START_OVERRIDE(fromanc2_state,fromancr)
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	GENERIC_LATCH_8(config, m_soundlatch);
@@ -607,18 +600,16 @@ void fromanc2_state::fromancr(machine_config &config)
 	ymsnd.add_route(2, "mono", 0.75);
 }
 
-void fromanc2_state::fromanc4(machine_config &config)
+void fromanc4_state::fromanc4(machine_config &config)
 {
-	/* basic machine hardware */
-	M68000(config, m_maincpu, XTAL(32'000'000)/2);      /* 16.00 MHz */
-	m_maincpu->set_addrmap(AS_PROGRAM, &fromanc2_state::fromanc4_main_map);
-	m_maincpu->set_vblank_int("lscreen", FUNC(fromanc2_state::irq1_line_hold));
+	// basic machine hardware
+	M68000(config, m_maincpu, XTAL(32'000'000)/2);      // 16.00 MHz
+	m_maincpu->set_addrmap(AS_PROGRAM, &fromanc4_state::fromanc4_main_map);
+	m_maincpu->set_vblank_int("lscreen", FUNC(fromanc4_state::irq1_line_hold));
 
-	Z80(config, m_audiocpu, XTAL(32'000'000)/4);        /* 8.00 MHz */
-	m_audiocpu->set_addrmap(AS_PROGRAM, &fromanc2_state::fromanc2_sound_map);
-	m_audiocpu->set_addrmap(AS_IO, &fromanc2_state::fromanc2_sound_io_map);
-
-	MCFG_MACHINE_START_OVERRIDE(fromanc2_state,fromanc4)
+	Z80(config, m_audiocpu, XTAL(32'000'000)/4);        // 8.00 MHz
+	m_audiocpu->set_addrmap(AS_PROGRAM, &fromanc4_state::sound_map);
+	m_audiocpu->set_addrmap(AS_IO, &fromanc4_state::sound_io_map);
 
 	EEPROM_93C46_16BIT(config, m_eeprom);
 
@@ -627,7 +618,7 @@ void fromanc2_state::fromanc4(machine_config &config)
 	//m_uart->out_tx_callback().set("link", FUNC(rs232_port_device::write_txd));
 	//m_uart->out_rts_callback().set("link", FUNC(rs232_port_device::write_rts));
 
-	/* video hardware */
+	// video hardware
 	GFXDECODE(config, m_gfxdecode, m_lpalette, gfx_fromancr);
 
 	PALETTE(config, m_lpalette).set_format(palette_device::xRGB_555, 2048);
@@ -640,7 +631,7 @@ void fromanc2_state::fromanc4(machine_config &config)
 	lscreen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	lscreen.set_size(512, 512);
 	lscreen.set_visarea(0, 352-1, 0, 240-1);
-	lscreen.set_screen_update(FUNC(fromanc2_state::screen_update_left));
+	lscreen.set_screen_update(FUNC(fromanc4_state::screen_update_left));
 	lscreen.set_palette(m_lpalette);
 
 	screen_device &rscreen(SCREEN(config, "rscreen", SCREEN_TYPE_RASTER));
@@ -648,12 +639,10 @@ void fromanc2_state::fromanc4(machine_config &config)
 	rscreen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	rscreen.set_size(512, 512);
 	rscreen.set_visarea(0, 352-1, 0, 240-1);
-	rscreen.set_screen_update(FUNC(fromanc2_state::screen_update_right));
+	rscreen.set_screen_update(FUNC(fromanc4_state::screen_update_right));
 	rscreen.set_palette(m_rpalette);
 
-	MCFG_VIDEO_START_OVERRIDE(fromanc2_state,fromanc4)
-
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	GENERIC_LATCH_8(config, m_soundlatch);
@@ -746,22 +735,22 @@ ROM_START( fromancr )
 	ROM_LOAD( "4-ic1.bin",   0x0000000, 0x010000, CRC(6d02090e) SHA1(08a538f3a578adbf83718e5e592c457b2ad841a6) )
 
 	ROM_REGION( 0x0800000, "gfx1", 0 )  // BG DATA
-	ROM_LOAD( "ic1-3.bin",   0x0000000, 0x400000, CRC(70ad9094) SHA1(534f10478a929e9e0cc4e01573a68474fe696099) )
-	ROM_LOAD( "ic2-4.bin",   0x0400000, 0x400000, CRC(c6c6e8f7) SHA1(315e4e8ae9d1e3d68f4b2cff723d78652dc74e57) )
+	ROM_LOAD16_WORD_SWAP( "ic1-3.bin",   0x0000000, 0x400000, CRC(70ad9094) SHA1(534f10478a929e9e0cc4e01573a68474fe696099) )
+	ROM_LOAD16_WORD_SWAP( "ic2-4.bin",   0x0400000, 0x400000, CRC(c6c6e8f7) SHA1(315e4e8ae9d1e3d68f4b2cff723d78652dc74e57) )
 
 	ROM_REGION( 0x2400000, "gfx2", 0 )  // FG DATA
-	ROM_LOAD( "ic28-13.bin", 0x0000000, 0x400000, CRC(7d7f9f63) SHA1(fe7b7a6bd9610d953f109b5ff8e38aab1c4ffac1) )
-	ROM_LOAD( "ic29-14.bin", 0x0400000, 0x400000, CRC(8ec65f31) SHA1(9b63b18d5ad8f7ec37fa950b21d547fec559d5fa) )
-	ROM_LOAD( "ic31-16.bin", 0x0800000, 0x400000, CRC(e4859534) SHA1(91fbbe0ab8119a954d76d33134290a7f7640e4ba) )
-	ROM_LOAD( "ic32-17.bin", 0x0c00000, 0x400000, CRC(20d767da) SHA1(477d86538e95583238c50e11acee3ed9ed17b75a) )
-	ROM_LOAD( "ic34-19.bin", 0x1000000, 0x400000, CRC(d62a383f) SHA1(0b11a97fa11a0b9657219d70a2ba26843b37d285) )
-	ROM_LOAD( "ic35-20.bin", 0x1400000, 0x400000, CRC(4e697f38) SHA1(66b2e9ecedfcf878defb31528611574c1711e831) )
-	ROM_LOAD( "ic37-22.bin", 0x1800000, 0x400000, CRC(6302bf5f) SHA1(bac8bead71e25e060bc75abd428dce97e5d51ef2) )
-	ROM_LOAD( "ic38-23.bin", 0x1c00000, 0x400000, CRC(c6cffa53) SHA1(41a1c31d921fa92aa285e0a874565e929dba80dc) )
-	ROM_LOAD( "ic40-25.bin", 0x2000000, 0x400000, CRC(af60bd0e) SHA1(0dc3a2e9b06626b3891b60368c3ef4d7ce1bdc6a) )
+	ROM_LOAD16_WORD_SWAP( "ic28-13.bin", 0x0000000, 0x400000, CRC(7d7f9f63) SHA1(fe7b7a6bd9610d953f109b5ff8e38aab1c4ffac1) )
+	ROM_LOAD16_WORD_SWAP( "ic29-14.bin", 0x0400000, 0x400000, CRC(8ec65f31) SHA1(9b63b18d5ad8f7ec37fa950b21d547fec559d5fa) )
+	ROM_LOAD16_WORD_SWAP( "ic31-16.bin", 0x0800000, 0x400000, CRC(e4859534) SHA1(91fbbe0ab8119a954d76d33134290a7f7640e4ba) )
+	ROM_LOAD16_WORD_SWAP( "ic32-17.bin", 0x0c00000, 0x400000, CRC(20d767da) SHA1(477d86538e95583238c50e11acee3ed9ed17b75a) )
+	ROM_LOAD16_WORD_SWAP( "ic34-19.bin", 0x1000000, 0x400000, CRC(d62a383f) SHA1(0b11a97fa11a0b9657219d70a2ba26843b37d285) )
+	ROM_LOAD16_WORD_SWAP( "ic35-20.bin", 0x1400000, 0x400000, CRC(4e697f38) SHA1(66b2e9ecedfcf878defb31528611574c1711e831) )
+	ROM_LOAD16_WORD_SWAP( "ic37-22.bin", 0x1800000, 0x400000, CRC(6302bf5f) SHA1(bac8bead71e25e060bc75abd428dce97e5d51ef2) )
+	ROM_LOAD16_WORD_SWAP( "ic38-23.bin", 0x1c00000, 0x400000, CRC(c6cffa53) SHA1(41a1c31d921fa92aa285e0a874565e929dba80dc) )
+	ROM_LOAD16_WORD_SWAP( "ic40-25.bin", 0x2000000, 0x400000, CRC(af60bd0e) SHA1(0dc3a2e9b06626b3891b60368c3ef4d7ce1bdc6a) )
 
 	ROM_REGION( 0x0200000, "gfx3", 0 )  // TEXT DATA
-	ROM_LOAD( "ic28-29.bin", 0x0000000, 0x200000, CRC(f5e262aa) SHA1(35464d059f4814832bf5cb3bede4b8a600bc8a84) )
+	ROM_LOAD16_WORD_SWAP( "ic28-29.bin", 0x0000000, 0x200000, CRC(f5e262aa) SHA1(35464d059f4814832bf5cb3bede4b8a600bc8a84) )
 
 	ROM_REGION( 0x0400000, "ymsnd:adpcma", 0 ) // SOUND DATA
 	ROM_LOAD( "ic81.bin",    0x0000000, 0x200000, CRC(8ab6e343) SHA1(5ae28e6944edb0a4b8d0071ce48e348b6e927ca9) )
@@ -777,27 +766,27 @@ ROM_START( fromanc4 )
 	ROM_LOAD( "ic79.bin", 0x0000000, 0x020000, CRC(c9587c09) SHA1(e04ee8c3f8519c2b2d3c2bdade1e142974b7fcb1) )
 
 	ROM_REGION( 0x1000000, "gfx1", 0 )  // BG DATA
-	ROM_LOAD16_WORD_SWAP( "em33-c00.59", 0x0000000, 0x400000, CRC(7192bbad) SHA1(d9212860a516106c64e348c78e03091ee766ab23) )
-	ROM_LOAD16_WORD_SWAP( "em33-c01.60", 0x0400000, 0x400000, CRC(d75af19a) SHA1(3a9c4ccf1f832d0302fe115d336e33e006910a8a) )
-	ROM_LOAD16_WORD_SWAP( "em33-c02.61", 0x0800000, 0x400000, CRC(4f4d2735) SHA1(d0b59c8ed285ec9120a89b0198e414e33567729a) )
-	ROM_LOAD16_WORD_SWAP( "em33-c03.62", 0x0c00000, 0x400000, CRC(7ece6ad5) SHA1(c506fc4ea68abf57009d524a17ca487f9c568abd) )
+	ROM_LOAD( "em33-c00.59", 0x0000000, 0x400000, CRC(7192bbad) SHA1(d9212860a516106c64e348c78e03091ee766ab23) )
+	ROM_LOAD( "em33-c01.60", 0x0400000, 0x400000, CRC(d75af19a) SHA1(3a9c4ccf1f832d0302fe115d336e33e006910a8a) )
+	ROM_LOAD( "em33-c02.61", 0x0800000, 0x400000, CRC(4f4d2735) SHA1(d0b59c8ed285ec9120a89b0198e414e33567729a) )
+	ROM_LOAD( "em33-c03.62", 0x0c00000, 0x400000, CRC(7ece6ad5) SHA1(c506fc4ea68abf57009d524a17ca487f9c568abd) )
 
 	ROM_REGION( 0x3000000, "gfx2", 0 )  // FG DATA
-	ROM_LOAD16_WORD_SWAP( "em33-b00.38", 0x0000000, 0x400000, CRC(10b8f90d) SHA1(68b8f197c7be70082f61016824098c1ae3a76b38) )
-	ROM_LOAD16_WORD_SWAP( "em33-b01.39", 0x0400000, 0x400000, CRC(3b3ea291) SHA1(bb80070a19bb1a1febda612ef260f895a8b65ce2) )
-	ROM_LOAD16_WORD_SWAP( "em33-b02.40", 0x0800000, 0x400000, CRC(de88f95b) SHA1(d84a1896a1ef3d9b7fa7de23771168e17c7a450a) )
-	ROM_LOAD16_WORD_SWAP( "em33-b03.41", 0x0c00000, 0x400000, CRC(35c1b398) SHA1(b2141cdd3b7f9e2cbfb0a048c440979b59149be5) )
-	ROM_LOAD16_WORD_SWAP( "em33-b04.42", 0x1000000, 0x400000, CRC(84b8d5db) SHA1(5999a12c24c01ee8673c2c0a9193c8800a490e6f) )
-	ROM_LOAD16_WORD_SWAP( "em33-b05.43", 0x1400000, 0x400000, CRC(b822b57c) SHA1(b50f3b73239a688101027f1c4247fed5ae59b064) )
-	ROM_LOAD16_WORD_SWAP( "em33-b06.44", 0x1800000, 0x400000, CRC(8f1b2b19) SHA1(1e08908758fed104d114fecc9977a4a0eb93fe9b) )
-	ROM_LOAD16_WORD_SWAP( "em33-b07.45", 0x1c00000, 0x400000, CRC(dd4ddcb7) SHA1(0145afa70c1a6f59eec65cf4d8572f2c00cd04a5) )
-	ROM_LOAD16_WORD_SWAP( "em33-b08.46", 0x2000000, 0x400000, CRC(3d8ce018) SHA1(43c3cb4d6c26a8209fc290fcac56297fe66209e3) )
-	ROM_LOAD16_WORD_SWAP( "em33-b09.47", 0x2400000, 0x400000, CRC(4ad79143) SHA1(9240ee46fff8f4a400a2bddaedb9acd258f37e1d) )
-	ROM_LOAD16_WORD_SWAP( "em33-b10.48", 0x2800000, 0x400000, CRC(d6ab74b2) SHA1(1dbff7e997869a00922f6471afbd76d383ec0e2c) )
-	ROM_LOAD16_WORD_SWAP( "em33-b11.49", 0x2c00000, 0x400000, CRC(4aa206b1) SHA1(afee0d8fc02e4f673ecccb9786c6d502dea5cb70) )
+	ROM_LOAD( "em33-b00.38", 0x0000000, 0x400000, CRC(10b8f90d) SHA1(68b8f197c7be70082f61016824098c1ae3a76b38) )
+	ROM_LOAD( "em33-b01.39", 0x0400000, 0x400000, CRC(3b3ea291) SHA1(bb80070a19bb1a1febda612ef260f895a8b65ce2) )
+	ROM_LOAD( "em33-b02.40", 0x0800000, 0x400000, CRC(de88f95b) SHA1(d84a1896a1ef3d9b7fa7de23771168e17c7a450a) )
+	ROM_LOAD( "em33-b03.41", 0x0c00000, 0x400000, CRC(35c1b398) SHA1(b2141cdd3b7f9e2cbfb0a048c440979b59149be5) )
+	ROM_LOAD( "em33-b04.42", 0x1000000, 0x400000, CRC(84b8d5db) SHA1(5999a12c24c01ee8673c2c0a9193c8800a490e6f) )
+	ROM_LOAD( "em33-b05.43", 0x1400000, 0x400000, CRC(b822b57c) SHA1(b50f3b73239a688101027f1c4247fed5ae59b064) )
+	ROM_LOAD( "em33-b06.44", 0x1800000, 0x400000, CRC(8f1b2b19) SHA1(1e08908758fed104d114fecc9977a4a0eb93fe9b) )
+	ROM_LOAD( "em33-b07.45", 0x1c00000, 0x400000, CRC(dd4ddcb7) SHA1(0145afa70c1a6f59eec65cf4d8572f2c00cd04a5) )
+	ROM_LOAD( "em33-b08.46", 0x2000000, 0x400000, CRC(3d8ce018) SHA1(43c3cb4d6c26a8209fc290fcac56297fe66209e3) )
+	ROM_LOAD( "em33-b09.47", 0x2400000, 0x400000, CRC(4ad79143) SHA1(9240ee46fff8f4a400a2bddaedb9acd258f37e1d) )
+	ROM_LOAD( "em33-b10.48", 0x2800000, 0x400000, CRC(d6ab74b2) SHA1(1dbff7e997869a00922f6471afbd76d383ec0e2c) )
+	ROM_LOAD( "em33-b11.49", 0x2c00000, 0x400000, CRC(4aa206b1) SHA1(afee0d8fc02e4f673ecccb9786c6d502dea5cb70) )
 
 	ROM_REGION( 0x0400000, "gfx3", 0 )  // TEXT DATA
-	ROM_LOAD16_WORD_SWAP( "em33-a00.37", 0x0000000, 0x400000, CRC(a3bd4a34) SHA1(78bd5298e83f89c738c18105c8bc809fa6a35206) )
+	ROM_LOAD( "em33-a00.37", 0x0000000, 0x400000, CRC(a3bd4a34) SHA1(78bd5298e83f89c738c18105c8bc809fa6a35206) )
 
 	ROM_REGION( 0x0800000, "ymsnd:adpcma", 0 ) // SOUND DATA
 	ROM_LOAD16_WORD_SWAP( "em33-p00.88", 0x0000000, 0x400000, CRC(1c6418d2) SHA1(c66d6b35f342fcbeca5414dbb2ac038d8a2ec2c4) )
@@ -818,7 +807,7 @@ void fromanc2_state::init_fromanc2()
 	m_sndcpu_nmi_flag = 1;
 }
 
-void fromanc2_state::init_fromanc4()
+void fromanc4_state::init_fromanc4()
 {
 	m_sndcpu_nmi_flag = 1;
 }
@@ -833,4 +822,4 @@ void fromanc2_state::init_fromanc4()
 GAME( 1995, fromanc2,  0,        fromanc2, fromanc2, fromanc2_state, init_fromanc2, ROT0, "Video System Co.", "Taisen Idol-Mahjong Final Romance 2 (Japan, newer)", MACHINE_SUPPORTS_SAVE )
 GAME( 1995, fromanc2o, fromanc2, fromanc2, fromanc2, fromanc2_state, init_fromanc2, ROT0, "Video System Co.", "Taisen Idol-Mahjong Final Romance 2 (Japan, older)", MACHINE_SUPPORTS_SAVE )
 GAME( 1995, fromancr,  0,        fromancr, fromanc2, fromanc2_state, init_fromanc2, ROT0, "Video System Co.", "Taisen Mahjong Final Romance R (Japan)",      MACHINE_SUPPORTS_SAVE )
-GAME( 1998, fromanc4,  0,        fromanc4, fromanc4, fromanc2_state, init_fromanc4, ROT0, "Video System Co.", "Taisen Mahjong Final Romance 4 (Japan)",      MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE )
+GAME( 1998, fromanc4,  0,        fromanc4, fromanc4, fromanc4_state, init_fromanc4, ROT0, "Video System Co.", "Taisen Mahjong Final Romance 4 (Japan)",      MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/vsystem/fromanc2.h
+++ b/src/mame/vsystem/fromanc2.h
@@ -11,73 +11,90 @@
 #include "emupal.h"
 #include "tilemap.h"
 
-class fromanc2_state : public driver_device
+class fromanc2_base_state : public driver_device
 {
 public:
-	fromanc2_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_maincpu(*this, "maincpu"),
-		m_audiocpu(*this, "audiocpu"),
-		m_subcpu(*this, "sub"),
-		m_eeprom(*this, "eeprom"),
-		m_gfxdecode(*this, "gfxdecode"),
-		m_lpalette(*this, "lpalette"),
-		m_rpalette(*this, "rpalette"),
-		m_soundlatch(*this, "soundlatch"),
-		m_soundlatch2(*this, "soundlatch2"),
-		m_uart(*this, "uart")
-	{ }
-
-	void fromanc2(machine_config &config);
-	void fromancr(machine_config &config);
-	void fromanc4(machine_config &config);
-
-	void init_fromanc4();
-	void init_fromanc2();
-
-	int subcpu_int_r();
 	int sndcpu_nmi_r();
-	int subcpu_nmi_r();
 
 protected:
+	fromanc2_base_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_audiocpu(*this, "audiocpu")
+		, m_eeprom(*this, "eeprom")
+		, m_gfxdecode(*this, "gfxdecode")
+		, m_lpalette(*this, "lpalette")
+		, m_rpalette(*this, "rpalette")
+		, m_soundlatch(*this, "soundlatch")
+		, m_soundlatch2(*this, "soundlatch2")
+		, m_in_key(*this, "KEY%u", 0U)
+	{ }
+
+	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
-private:
-	/* memory pointers */
-	std::unique_ptr<uint16_t[]>   m_videoram[2][4]{};
-	std::unique_ptr<uint8_t[]>    m_bankedram{};
+	void sndcmd_w(uint16_t data);
+	void portselect_w(uint16_t data);
+	uint16_t keymatrix_r();
+	uint8_t sndcpu_nmi_clr();
 
-	/* video-related */
-	tilemap_t  *m_tilemap[2][4]{};
-	int      m_scrollx[2][4]{};
-	int      m_scrolly[2][4]{};
-	int      m_gfxbank[2][4]{};
+	template<int VRAM, int Layer> TILE_GET_INFO_MEMBER(fromancr_get_tile_info);
+	uint32_t screen_update_left(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update_right(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
-	/* misc */
-	int      m_portselect = 0;
-	uint8_t    m_subcpu_int_flag = 0U;
-	uint8_t    m_subcpu_nmi_flag = 0U;
-	uint8_t    m_sndcpu_nmi_flag = 0U;
-	uint16_t   m_datalatch1 = 0U;
-	uint8_t    m_datalatch_2h = 0U;
-	uint8_t    m_datalatch_2l = 0U;
+	void sound_io_map(address_map &map);
+	void sound_map(address_map &map);
 
-	/* devices */
+	// devices
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_audiocpu;
-	optional_device<cpu_device> m_subcpu;
 	optional_device<eeprom_serial_93cxx_device> m_eeprom;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_lpalette;
 	required_device<palette_device> m_rpalette;
 	required_device<generic_latch_8_device> m_soundlatch;
 	required_device<generic_latch_8_device> m_soundlatch2;
-	optional_device<ns16550_device> m_uart;
 
-	void sndcmd_w(uint16_t data);
-	void portselect_w(uint16_t data);
-	uint16_t keymatrix_r();
-	void fromancr_gfxbank_eeprom_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	required_ioport_array<4> m_in_key;
+
+	// memory pointers
+	std::unique_ptr<uint16_t[]> m_videoram[2][4]{};
+
+	// video-related
+	tilemap_t  *m_tilemap[2][4]{};
+	int32_t    m_scrollx[2][4]{};
+	int32_t    m_scrolly[2][4]{};
+	uint32_t   m_gfxbank[2][4]{};
+
+	// misc
+	uint16_t m_portselect = 0U;
+	uint8_t  m_sndcpu_nmi_flag = 0U;
+
+};
+
+class fromanc2_state : public fromanc2_base_state
+{
+public:
+	fromanc2_state(const machine_config &mconfig, device_type type, const char *tag)
+		: fromanc2_base_state(mconfig, type, tag)
+		, m_subcpu(*this, "sub")
+		, m_subrombank(*this, "subrombank")
+		, m_subrambank(*this, "subrambank")
+	{ }
+
+	void fromanc2(machine_config &config);
+	void fromancr(machine_config &config);
+
+	void init_fromanc2();
+
+	int subcpu_int_r();
+	int subcpu_nmi_r();
+
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+private:
 	void subcpu_w(uint16_t data);
 	uint16_t subcpu_r();
 	uint8_t maincpu_r_l();
@@ -85,8 +102,8 @@ private:
 	void maincpu_w_l(uint8_t data);
 	void maincpu_w_h(uint8_t data);
 	void subcpu_nmi_clr(uint8_t data);
-	uint8_t sndcpu_nmi_clr();
 	void subcpu_rombank_w(uint8_t data);
+	void fromancr_gfxbank_eeprom_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void fromanc2_videoram_0_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void fromanc2_videoram_1_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void fromanc2_videoram_2_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
@@ -102,6 +119,51 @@ private:
 	void fromancr_videoram_2_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void fromancr_gfxreg_0_w(offs_t offset, uint16_t data);
 	void fromancr_gfxreg_1_w(offs_t offset, uint16_t data);
+
+	template<int VRAM, int Layer> TILE_GET_INFO_MEMBER(fromanc2_get_tile_info);
+	DECLARE_VIDEO_START(fromanc2);
+	DECLARE_VIDEO_START(fromancr);
+
+	inline void fromanc2_dispvram_w(offs_t offset, uint16_t data, uint16_t mem_mask, int vram, int layer);
+	inline void fromancr_vram_w(offs_t offset, uint16_t data, uint16_t mem_mask, int layer );
+	void fromancr_gfxbank_w(int data);
+
+	void fromanc2_main_map(address_map &map);
+	void fromanc2_sub_io_map(address_map &map);
+	void fromanc2_sub_map(address_map &map);
+	void fromancr_main_map(address_map &map);
+
+	// devices
+	required_device<cpu_device> m_subcpu;
+	required_memory_bank m_subrombank;
+	required_memory_bank m_subrambank;
+
+	// memory pointers
+	std::unique_ptr<uint8_t[]> m_bankedram{};
+
+	// misc
+	uint8_t    m_subcpu_int_flag = 0U;
+	uint8_t    m_subcpu_nmi_flag = 0U;
+	uint16_t   m_datalatch1 = 0U;
+	uint8_t    m_datalatch_2h = 0U;
+	uint8_t    m_datalatch_2l = 0U;
+};
+
+class fromanc4_state : public fromanc2_base_state
+{
+public:
+	fromanc4_state(const machine_config &mconfig, device_type type, const char *tag)
+		: fromanc2_base_state(mconfig, type, tag)
+		, m_uart(*this, "uart")
+	{ }
+
+	void fromanc4(machine_config &config);
+
+	void init_fromanc4();
+
+protected:
+	virtual void video_start() override;
+
 	void fromanc4_videoram_0_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void fromanc4_videoram_1_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void fromanc4_videoram_2_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
@@ -109,26 +171,12 @@ private:
 	void fromanc4_gfxreg_1_w(offs_t offset, uint16_t data);
 	void fromanc4_gfxreg_2_w(offs_t offset, uint16_t data);
 
-	template<int VRAM, int Layer> TILE_GET_INFO_MEMBER(fromanc2_get_tile_info);
-	template<int VRAM, int Layer> TILE_GET_INFO_MEMBER(fromancr_get_tile_info);
-	DECLARE_MACHINE_START(fromanc2);
-	DECLARE_VIDEO_START(fromanc2);
-	DECLARE_VIDEO_START(fromancr);
-	DECLARE_MACHINE_START(fromanc4);
-	DECLARE_VIDEO_START(fromanc4);
-	uint32_t screen_update_left(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_right(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	inline void fromanc2_dispvram_w( offs_t offset, uint16_t data, uint16_t mem_mask, int vram, int layer );
-	inline void fromancr_vram_w(offs_t offset, uint16_t data, uint16_t mem_mask, int layer );
-	void fromancr_gfxbank_w( int data );
 	inline void fromanc4_vram_w( offs_t offset, uint16_t data, uint16_t mem_mask, int layer );
-	void fromanc2_main_map(address_map &map);
-	void fromanc2_sound_io_map(address_map &map);
-	void fromanc2_sound_map(address_map &map);
-	void fromanc2_sub_io_map(address_map &map);
-	void fromanc2_sub_map(address_map &map);
+
 	void fromanc4_main_map(address_map &map);
-	void fromancr_main_map(address_map &map);
+
+	// devices
+	required_device<ns16550_device> m_uart;
 };
 
 #endif // MAME_VSYSTEM_FROMANC2_H

--- a/src/mame/vsystem/fromanc2.h
+++ b/src/mame/vsystem/fromanc2.h
@@ -11,6 +11,7 @@
 #include "emupal.h"
 #include "tilemap.h"
 
+
 class fromanc2_base_state : public driver_device
 {
 public:
@@ -38,7 +39,7 @@ protected:
 	uint16_t keymatrix_r();
 	uint8_t sndcpu_nmi_clr();
 
-	template<int VRAM, int Layer> TILE_GET_INFO_MEMBER(fromancr_get_tile_info);
+	template <int VRAM, int Layer> TILE_GET_INFO_MEMBER(fromancr_get_tile_info);
 	uint32_t screen_update_left(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_right(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
@@ -69,8 +70,8 @@ protected:
 	// misc
 	uint16_t m_portselect = 0U;
 	uint8_t  m_sndcpu_nmi_flag = 0U;
-
 };
+
 
 class fromanc2_state : public fromanc2_base_state
 {
@@ -124,8 +125,8 @@ private:
 	DECLARE_VIDEO_START(fromanc2);
 	DECLARE_VIDEO_START(fromancr);
 
-	inline void fromanc2_dispvram_w(offs_t offset, uint16_t data, uint16_t mem_mask, int vram, int layer);
-	inline void fromancr_vram_w(offs_t offset, uint16_t data, uint16_t mem_mask, int layer );
+	void fromanc2_dispvram_w(offs_t offset, uint16_t data, uint16_t mem_mask, int vram, int layer);
+	void fromancr_vram_w(offs_t offset, uint16_t data, uint16_t mem_mask, int layer);
 	void fromancr_gfxbank_w(int data);
 
 	void fromanc2_main_map(address_map &map);
@@ -149,6 +150,7 @@ private:
 	uint8_t    m_datalatch_2l = 0U;
 };
 
+
 class fromanc4_state : public fromanc2_base_state
 {
 public:
@@ -171,7 +173,7 @@ protected:
 	void fromanc4_gfxreg_1_w(offs_t offset, uint16_t data);
 	void fromanc4_gfxreg_2_w(offs_t offset, uint16_t data);
 
-	inline void fromanc4_vram_w( offs_t offset, uint16_t data, uint16_t mem_mask, int layer );
+	void fromanc4_vram_w(offs_t offset, uint16_t data, uint16_t mem_mask, int layer);
 
 	void fromanc4_main_map(address_map &map);
 

--- a/src/mame/vsystem/fromanc2_v.cpp
+++ b/src/mame/vsystem/fromanc2_v.cpp
@@ -20,16 +20,16 @@
 template<int VRAM, int Layer>
 TILE_GET_INFO_MEMBER(fromanc2_state::fromanc2_get_tile_info)
 {
-	int tile  = (m_videoram[VRAM][Layer][tile_index] & 0x3fff) | (m_gfxbank[VRAM][Layer] << 14);
-	int color = (m_videoram[VRAM][Layer][tile_index] & 0xc000) >> 14;
+	int const tile  = (m_videoram[VRAM][Layer][tile_index] & 0x3fff) | (m_gfxbank[VRAM][Layer] << 14);
+	int const color = (m_videoram[VRAM][Layer][tile_index] & 0xc000) >> 14;
 
 	tileinfo.set(Layer, tile, color, 0);
 }
 
 template<int VRAM, int Layer>
-TILE_GET_INFO_MEMBER(fromanc2_state::fromancr_get_tile_info)
+TILE_GET_INFO_MEMBER(fromanc2_base_state::fromancr_get_tile_info)
 {
-	int tile = m_videoram[VRAM][Layer][tile_index] | (m_gfxbank[VRAM][Layer] << 16);
+	int const tile = m_videoram[VRAM][Layer][tile_index] | (m_gfxbank[VRAM][Layer] << 16);
 
 	tileinfo.set(Layer, tile, 0, 0);
 }
@@ -133,7 +133,7 @@ void fromanc2_state::fromanc2_gfxbank_1_w(uint16_t data)
 
 inline void fromanc2_state::fromancr_vram_w(offs_t offset, uint16_t data, uint16_t mem_mask, int layer )
 {
-	int vram = (offset < 0x1000) ? 0 : 1;
+	int const vram = (offset < 0x1000) ? 0 : 1;
 
 	COMBINE_DATA(&m_videoram[vram][layer][offset & 0x0fff]);
 	m_tilemap[vram][layer]->mark_tile_dirty(offset & 0x0fff);
@@ -182,19 +182,19 @@ void fromanc2_state::fromancr_gfxbank_w( int data )
 }
 
 
-inline void fromanc2_state::fromanc4_vram_w( offs_t offset, uint16_t data, uint16_t mem_mask, int layer )
+inline void fromanc4_state::fromanc4_vram_w( offs_t offset, uint16_t data, uint16_t mem_mask, int layer )
 {
-	int vram = (offset < 0x4000) ? 0 : 1;
+	int const vram = (offset < 0x4000) ? 0 : 1;
 
 	COMBINE_DATA(&m_videoram[vram][layer][offset & 0x3fff]);
 	m_tilemap[vram][layer]->mark_tile_dirty(offset & 0x3fff);
 }
 
-void fromanc2_state::fromanc4_videoram_0_w(offs_t offset, uint16_t data, uint16_t mem_mask){ fromanc4_vram_w(offset, data, mem_mask, 2); }
-void fromanc2_state::fromanc4_videoram_1_w(offs_t offset, uint16_t data, uint16_t mem_mask){ fromanc4_vram_w(offset, data, mem_mask, 1); }
-void fromanc2_state::fromanc4_videoram_2_w(offs_t offset, uint16_t data, uint16_t mem_mask){ fromanc4_vram_w(offset, data, mem_mask, 0); }
+void fromanc4_state::fromanc4_videoram_0_w(offs_t offset, uint16_t data, uint16_t mem_mask){ fromanc4_vram_w(offset, data, mem_mask, 2); }
+void fromanc4_state::fromanc4_videoram_1_w(offs_t offset, uint16_t data, uint16_t mem_mask){ fromanc4_vram_w(offset, data, mem_mask, 1); }
+void fromanc4_state::fromanc4_videoram_2_w(offs_t offset, uint16_t data, uint16_t mem_mask){ fromanc4_vram_w(offset, data, mem_mask, 0); }
 
-void fromanc2_state::fromanc4_gfxreg_0_w(offs_t offset, uint16_t data)
+void fromanc4_state::fromanc4_gfxreg_0_w(offs_t offset, uint16_t data)
 {
 	switch (offset)
 	{
@@ -202,17 +202,18 @@ void fromanc2_state::fromanc4_gfxreg_0_w(offs_t offset, uint16_t data)
 		case 0x01:  m_scrolly[0][2] = -(data - 0x1e4); break;
 		case 0x02:  m_scrollx[1][2] = -(data - 0xfbb); break;
 		case 0x03:  m_scrolly[1][2] = -(data - 0x1e4); break;
-		case 0x05:  m_gfxbank[0][2] = (data & 0x000f) >> 0;
-				m_gfxbank[1][2] = (data & 0x0f00) >> 8;
-				m_tilemap[0][2]->mark_all_dirty();
-				m_tilemap[1][2]->mark_all_dirty();
-				break;
+		case 0x05:
+			m_gfxbank[0][2] = (data & 0x000f) >> 0;
+			m_gfxbank[1][2] = (data & 0x0f00) >> 8;
+			m_tilemap[0][2]->mark_all_dirty();
+			m_tilemap[1][2]->mark_all_dirty();
+			break;
 		// offset 0x04, 0x06 - 0x11 unknown
 		default:    break;
 	}
 }
 
-void fromanc2_state::fromanc4_gfxreg_1_w(offs_t offset, uint16_t data)
+void fromanc4_state::fromanc4_gfxreg_1_w(offs_t offset, uint16_t data)
 {
 	switch (offset)
 	{
@@ -220,17 +221,18 @@ void fromanc2_state::fromanc4_gfxreg_1_w(offs_t offset, uint16_t data)
 		case 0x01:  m_scrolly[0][1] = -(data - 0x1e4); break;
 		case 0x02:  m_scrollx[1][1] = -(data - 0xfba); break;
 		case 0x03:  m_scrolly[1][1] = -(data - 0x1e4); break;
-		case 0x05:  m_gfxbank[0][1] = (data & 0x000f) >> 0;
-				m_gfxbank[1][1] = (data & 0x0f00) >> 8;
-				m_tilemap[0][1]->mark_all_dirty();
-				m_tilemap[1][1]->mark_all_dirty();
-				break;
+		case 0x05:
+			m_gfxbank[0][1] = (data & 0x000f) >> 0;
+			m_gfxbank[1][1] = (data & 0x0f00) >> 8;
+			m_tilemap[0][1]->mark_all_dirty();
+			m_tilemap[1][1]->mark_all_dirty();
+			break;
 		// offset 0x04, 0x06 - 0x11 unknown
 		default:    break;
 	}
 }
 
-void fromanc2_state::fromanc4_gfxreg_2_w(offs_t offset, uint16_t data)
+void fromanc4_state::fromanc4_gfxreg_2_w(offs_t offset, uint16_t data)
 {
 	switch (offset)
 	{
@@ -238,11 +240,12 @@ void fromanc2_state::fromanc4_gfxreg_2_w(offs_t offset, uint16_t data)
 		case 0x01:  m_scrolly[0][0] = -(data - 0x1e4); break;
 		case 0x02:  m_scrollx[1][0] = -(data - 0xfbb); break;
 		case 0x03:  m_scrolly[1][0] = -(data - 0x1e4); break;
-		case 0x05:  m_gfxbank[0][0] = (data & 0x000f) >> 0;
-				m_gfxbank[1][0] = (data & 0x0f00) >> 8;
-				m_tilemap[0][0]->mark_all_dirty();
-				m_tilemap[1][0]->mark_all_dirty();
-				break;
+		case 0x05:
+			m_gfxbank[0][0] = (data & 0x000f) >> 0;
+			m_gfxbank[1][0] = (data & 0x0f00) >> 8;
+			m_tilemap[0][0]->mark_all_dirty();
+			m_tilemap[1][0]->mark_all_dirty();
+			break;
 		// offset 0x04, 0x06 - 0x11 unknown
 		default:    break;
 	}
@@ -285,12 +288,9 @@ VIDEO_START_MEMBER(fromanc2_state,fromanc2)
 	save_pointer(NAME(m_videoram[1][1]), (64 * 64));
 	save_pointer(NAME(m_videoram[1][2]), (64 * 64));
 	save_pointer(NAME(m_videoram[1][3]), (64 * 64));
-	save_item(NAME(m_scrollx[0]));
-	save_item(NAME(m_scrollx[1]));
-	save_item(NAME(m_scrolly[0]));
-	save_item(NAME(m_scrolly[1]));
-	save_item(NAME(m_gfxbank[0]));
-	save_item(NAME(m_gfxbank[1]));
+	save_item(NAME(m_scrollx));
+	save_item(NAME(m_scrolly));
+	save_item(NAME(m_gfxbank));
 }
 
 VIDEO_START_MEMBER(fromanc2_state,fromancr)
@@ -321,12 +321,9 @@ VIDEO_START_MEMBER(fromanc2_state,fromancr)
 	save_pointer(NAME(m_videoram[1][0]), (64 * 64));
 	save_pointer(NAME(m_videoram[1][1]), (64 * 64));
 	save_pointer(NAME(m_videoram[1][2]), (64 * 64));
-	save_item(NAME(m_scrollx[0]));
-	save_item(NAME(m_scrollx[1]));
-	save_item(NAME(m_scrolly[0]));
-	save_item(NAME(m_scrolly[1]));
-	save_item(NAME(m_gfxbank[0]));
-	save_item(NAME(m_gfxbank[1]));
+	save_item(NAME(m_scrollx));
+	save_item(NAME(m_scrolly));
+	save_item(NAME(m_gfxbank));
 
 	for (int i = 0; i < 2; i++)
 	{
@@ -335,15 +332,15 @@ VIDEO_START_MEMBER(fromanc2_state,fromancr)
 	}
 }
 
-VIDEO_START_MEMBER(fromanc2_state,fromanc4)
+void fromanc4_state::video_start()
 {
-	m_tilemap[0][0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&fromanc2_state::fromancr_get_tile_info<0, 0>))), TILEMAP_SCAN_ROWS, 8, 8, 256, 64);
-	m_tilemap[0][1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&fromanc2_state::fromancr_get_tile_info<0, 1>))), TILEMAP_SCAN_ROWS, 8, 8, 256, 64);
-	m_tilemap[0][2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&fromanc2_state::fromancr_get_tile_info<0, 2>))), TILEMAP_SCAN_ROWS, 8, 8, 256, 64);
+	m_tilemap[0][0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&fromanc4_state::fromancr_get_tile_info<0, 0>))), TILEMAP_SCAN_ROWS, 8, 8, 256, 64);
+	m_tilemap[0][1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&fromanc4_state::fromancr_get_tile_info<0, 1>))), TILEMAP_SCAN_ROWS, 8, 8, 256, 64);
+	m_tilemap[0][2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&fromanc4_state::fromancr_get_tile_info<0, 2>))), TILEMAP_SCAN_ROWS, 8, 8, 256, 64);
 	m_tilemap[0][3] = nullptr;
-	m_tilemap[1][0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&fromanc2_state::fromancr_get_tile_info<1, 0>))), TILEMAP_SCAN_ROWS, 8, 8, 256, 64);
-	m_tilemap[1][1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&fromanc2_state::fromancr_get_tile_info<1, 1>))), TILEMAP_SCAN_ROWS, 8, 8, 256, 64);
-	m_tilemap[1][2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&fromanc2_state::fromancr_get_tile_info<1, 2>))), TILEMAP_SCAN_ROWS, 8, 8, 256, 64);
+	m_tilemap[1][0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&fromanc4_state::fromancr_get_tile_info<1, 0>))), TILEMAP_SCAN_ROWS, 8, 8, 256, 64);
+	m_tilemap[1][1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&fromanc4_state::fromancr_get_tile_info<1, 1>))), TILEMAP_SCAN_ROWS, 8, 8, 256, 64);
+	m_tilemap[1][2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&fromanc4_state::fromancr_get_tile_info<1, 2>))), TILEMAP_SCAN_ROWS, 8, 8, 256, 64);
 	m_tilemap[1][3] = nullptr;
 
 	for (int screen = 0; screen < 2; screen++)
@@ -363,12 +360,9 @@ VIDEO_START_MEMBER(fromanc2_state,fromanc4)
 	save_pointer(NAME(m_videoram[1][0]), (256 * 64));
 	save_pointer(NAME(m_videoram[1][1]), (256 * 64));
 	save_pointer(NAME(m_videoram[1][2]), (256 * 64));
-	save_item(NAME(m_scrollx[0]));
-	save_item(NAME(m_scrollx[1]));
-	save_item(NAME(m_scrolly[0]));
-	save_item(NAME(m_scrolly[1]));
-	save_item(NAME(m_gfxbank[0]));
-	save_item(NAME(m_gfxbank[1]));
+	save_item(NAME(m_scrollx));
+	save_item(NAME(m_scrolly));
+	save_item(NAME(m_gfxbank));
 }
 
 /******************************************************************************
@@ -377,11 +371,9 @@ VIDEO_START_MEMBER(fromanc2_state,fromanc4)
 
 ******************************************************************************/
 
-uint32_t fromanc2_state::screen_update_left(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t fromanc2_base_state::screen_update_left(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	int i;
-
-	for (i = 0; i < 4; i++)
+	for (int i = 0; i < 4; i++)
 	{
 		if (m_tilemap[0][i])
 		{
@@ -394,11 +386,9 @@ uint32_t fromanc2_state::screen_update_left(screen_device &screen, bitmap_ind16 
 	return 0;
 }
 
-uint32_t fromanc2_state::screen_update_right(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t fromanc2_base_state::screen_update_right(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	int i;
-
-	for (i = 0; i < 4; i++)
+	for (int i = 0; i < 4; i++)
 	{
 		if (m_tilemap[1][i])
 		{


### PR DESCRIPTION
- Split driver state class for reduce optional finders
- Correct type for variables
- Use C++ style comments for single line comments
- Reduce literal tag usage and runtime tag lookups
- Suppress side effects for debugger read
- Use generic gfx decode layout
- Constantize variables
- Fix spacing