### PR TITLE
HP9816A added

### DIFF
--- a/src/devices/machine/tms9914.cpp
+++ b/src/devices/machine/tms9914.cpp
@@ -543,44 +543,19 @@ void tms9914_device::device_reset()
 	m_sic = false;
 	m_sre = false;
 	m_dai = false;
-	m_pts = false;
-	m_stdl = false;
-	m_shdw = false;
-	m_vstdl = false;
-	m_int_line = false;
-	m_accrq_line = true;    // Ensure change is propagated
-	m_dio = 0;
-
-	m_reg_int0_status = 0;
-	m_reg_int0_mask = 0;
-	m_reg_int1_status = 0;
-	m_reg_int1_mask = 0;
-	m_reg_address = 0;
-	m_reg_serial_p = 0;
-	m_reg_2nd_serial_p = 0;
-	m_reg_parallel_p = 0;
-	m_reg_2nd_parallel_p = 0;
-	m_reg_di = 0;
-	m_reg_do = 0;
-	m_reg_ulpa = false;
-	m_swrst = false;
-	m_hdfa = false;
-	m_hdfe = false;
-	m_rtl = false;
-	m_gts = false;
-	m_rpp = false;
-	m_sic = false;
-	m_sre = false;
-	m_dai = false;
-	m_pts = false;
 	m_stdl = false;
 	m_shdw = false;
 	m_vstdl = false;
 	m_rsvd2 = false;
+	m_int_line = true;
+	m_accrq_line = true;    // Ensure change is propagated
 
-
-	std::fill(std::begin(m_ext_signals), std::end(m_ext_signals), false);
-	std::fill(std::begin(m_signals), std::end(m_signals), false);
+	m_reg_int0_status = 0;
+	m_reg_int1_status = 0;
+	m_reg_serial_p = 0;
+	m_reg_2nd_serial_p = 0;
+	m_reg_parallel_p = 0;
+	m_reg_2nd_parallel_p = 0;
 
 	do_swrst();
 	update_fsm();

--- a/src/mame/hp/hp98x6.cpp
+++ b/src/mame/hp/hp98x6.cpp
@@ -1,0 +1,707 @@
+// license:BSD-3-Clause
+// copyright-holders:F. Ulivi
+
+// **************************
+// Driver for HP 98x6 systems
+// **************************
+//
+// What's in for 9816:
+// - 8MHz M68000 CPU
+// - Boot ROM
+// - Configurable amount of RAM
+// - Text video with attributes
+// - Graphic video
+// - HPIB interface
+// - RS232 interface
+// - HLE of 8041 UPI
+// - Large keyboard (98203B)
+// - Knob
+// - Beeper
+// - ID PROM
+//
+// Main references:
+// - Olivier De Smet's standalone emulator:
+//   https://sites.google.com/site/olivier2smet2/hp_projects/hp98x6
+// - Tony Duell's reverse engineered schematics (available @ hpmuseum.net)
+
+#include "emu.h"
+
+#include "hp98x6_upi.h"
+
+#include "bus/ieee488/ieee488.h"
+#include "bus/rs232/rs232.h"
+#include "cpu/m68000/m68000.h"
+#include "machine/ins8250.h"
+#include "machine/ram.h"
+#include "machine/tms9914.h"
+#include "video/mc6845.h"
+
+#include "emupal.h"
+#include "screen.h"
+
+// Debugging
+#define VERBOSE 0
+#include "logmacro.h"
+
+namespace {
+
+// CPU clock
+constexpr auto CPU_CLOCK = 16_MHz_XTAL / 2;
+
+// Video dot clock
+constexpr unsigned DOT_CLOCK = 19'988'000;
+
+// HPIB and UPI clock
+constexpr auto HPIB_CLOCK = 10_MHz_XTAL / 2;
+
+// UART clock
+constexpr auto UART_CLOCK = 2.4576_MHz_XTAL;
+
+// Bit manipulation
+template<typename T> constexpr T BIT_MASK(unsigned n)
+{
+	return (T)1U << n;
+}
+
+template<typename T> void BIT_CLR(T& w , unsigned n)
+{
+	w &= ~BIT_MASK<T>(n);
+}
+
+template<typename T> void BIT_SET(T& w , unsigned n)
+{
+	w |= BIT_MASK<T>(n);
+}
+
+// +--------------+
+// | hp9816_state |
+// +--------------+
+class hp9816_state : public driver_device
+{
+public:
+	hp9816_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_cpu(*this, "cpu")
+		, m_ram(*this, RAM_TAG)
+		, m_crtc(*this, "crtc")
+		, m_palette(*this, "palette")
+		, m_screen(*this, "screen")
+		, m_upi(*this, "upi")
+		, m_hpib(*this, "hpib")
+		, m_uart(*this, "uart")
+		, m_rs232(*this, "rs232")
+		, m_sw2_dipswitches(*this, "sw2")
+		, m_sw3_dipswitches(*this, "sw3")
+		, m_chargen(*this, "chargen")
+	{
+	}
+
+	void hp9816(machine_config &config);
+
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+	required_device<m68000_device> m_cpu;
+	required_device<ram_device> m_ram;
+	required_device<mc6845_device> m_crtc;
+	required_device<palette_device> m_palette;
+	required_device<screen_device> m_screen;
+	required_device<hp98x6_upi_device> m_upi;
+	required_device<tms9914_device> m_hpib;
+	required_device<ins8250_device> m_uart;
+	required_device<rs232_port_device> m_rs232;
+	required_ioport m_sw2_dipswitches;
+	required_ioport m_sw3_dipswitches;
+
+	// Character generator
+	required_region_ptr<uint8_t> m_chargen;
+
+private:
+	void cpu_mem_map(address_map &map);
+	void diag_led_w(uint8_t data);
+	uint16_t text_r(offs_t offset);
+	void text_w(offs_t offset, uint16_t data, uint16_t mem_mask);
+	uint16_t graphic_r(offs_t offset, uint16_t mem_mask);
+	void graphic_w(offs_t offset, uint16_t data, uint16_t mem_mask);
+	uint8_t hpib_r(offs_t offset);
+	void hpib_w(offs_t offset, uint8_t data);
+	void uart_reset();
+	void uart_update_irq();
+	uint8_t uart_r(offs_t offset);
+	void uart_w(offs_t offset, uint8_t data);
+
+	MC6845_UPDATE_ROW(crtc_update_row);
+
+	void cpu_reset_w(int state);
+	void hpib_irq_w(int state);
+	void upi_irq7_w(int state);
+	void uart_irq_w(int state);
+
+	static constexpr unsigned TEXT_VRAM_SIZE = 2048;
+	uint16_t m_text_vram[ TEXT_VRAM_SIZE ];
+	static constexpr unsigned GRAPHIC_VRAM_SIZE = 16384;
+	uint8_t m_graphic_vram[ GRAPHIC_VRAM_SIZE ];
+	bool m_hsync_en;
+	bool m_graphic_en;
+	bool m_hpib_irq;
+	bool m_hpib_dma_en;
+	bool m_upi_irq7;
+	bool m_uart_int_en;
+	bool m_uart_irq;
+	bool m_uart_ocd3;
+	bool m_uart_ocd4;
+};
+
+void hp9816_state::hp9816(machine_config &config)
+{
+	M68000(config, m_cpu, CPU_CLOCK);
+	m_cpu->set_addrmap(AS_PROGRAM, &hp9816_state::cpu_mem_map);
+	m_cpu->reset_cb().set(FUNC(hp9816_state::cpu_reset_w));
+
+	RAM(config, m_ram).set_default_size("256K").set_extra_options("512K,1M");
+
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER, rgb_t::white());
+	// Parameters for 50 Hz frame rate
+	m_screen->set_raw(DOT_CLOCK, 1040, 0, 800, 384, 0, 300);
+	m_screen->set_screen_update(m_crtc, FUNC(mc6845_device::screen_update));
+
+	PALETTE(config, m_palette, palette_device::MONOCHROME_HIGHLIGHT);
+
+	MC6845(config, m_crtc, DOT_CLOCK / 10);
+	m_crtc->set_char_width(10);
+	m_crtc->set_screen(m_screen);
+	m_crtc->set_update_row_callback(FUNC(hp9816_state::crtc_update_row));
+	m_crtc->set_show_border_area(false);
+
+	HP98X6_UPI(config, m_upi, HPIB_CLOCK);
+	m_upi->irq1_write_cb().set_inputline(m_cpu, M68K_IRQ_1);
+	m_upi->irq7_write_cb().set(FUNC(hp9816_state::upi_irq7_w));
+
+	TMS9914(config, m_hpib, HPIB_CLOCK);
+	m_hpib->int_write_cb().set(FUNC(hp9816_state::hpib_irq_w));
+	m_hpib->dio_read_cb().set(IEEE488_TAG, FUNC(ieee488_device::dio_r));
+	m_hpib->dio_write_cb().set(IEEE488_TAG, FUNC(ieee488_device::host_dio_w));
+	m_hpib->eoi_write_cb().set(IEEE488_TAG, FUNC(ieee488_device::host_eoi_w));
+	m_hpib->dav_write_cb().set(IEEE488_TAG, FUNC(ieee488_device::host_dav_w));
+	m_hpib->nrfd_write_cb().set(IEEE488_TAG, FUNC(ieee488_device::host_nrfd_w));
+	m_hpib->ndac_write_cb().set(IEEE488_TAG, FUNC(ieee488_device::host_ndac_w));
+	m_hpib->ifc_write_cb().set(IEEE488_TAG, FUNC(ieee488_device::host_ifc_w));
+	m_hpib->srq_write_cb().set(IEEE488_TAG, FUNC(ieee488_device::host_srq_w));
+	m_hpib->atn_write_cb().set(IEEE488_TAG, FUNC(ieee488_device::host_atn_w));
+	m_hpib->ren_write_cb().set(IEEE488_TAG, FUNC(ieee488_device::host_ren_w));
+
+	ieee488_device &ieee(IEEE488(config, IEEE488_TAG));
+	ieee.eoi_callback().set(m_hpib , FUNC(tms9914_device::eoi_w));
+	ieee.dav_callback().set(m_hpib , FUNC(tms9914_device::dav_w));
+	ieee.nrfd_callback().set(m_hpib , FUNC(tms9914_device::nrfd_w));
+	ieee.ndac_callback().set(m_hpib , FUNC(tms9914_device::ndac_w));
+	ieee.ifc_callback().set(m_hpib , FUNC(tms9914_device::ifc_w));
+	ieee.srq_callback().set(m_hpib , FUNC(tms9914_device::srq_w));
+	ieee.atn_callback().set(m_hpib , FUNC(tms9914_device::atn_w));
+	ieee.ren_callback().set(m_hpib , FUNC(tms9914_device::ren_w));
+	IEEE488_SLOT(config, "ieee_rem", 0, remote488_devices, nullptr);
+
+	INS8250(config, m_uart, UART_CLOCK);
+	m_uart->out_int_callback().set(FUNC(hp9816_state::uart_irq_w));
+	m_uart->out_tx_callback().set("rs232", FUNC(rs232_port_device::write_txd));
+	m_uart->out_dtr_callback().set("rs232", FUNC(rs232_port_device::write_dtr));
+	m_uart->out_rts_callback().set("rs232", FUNC(rs232_port_device::write_rts));
+	m_uart->out_out1_callback().set("rs232", FUNC(rs232_port_device::write_spds));
+	// OUT2 -> SRTS
+
+	RS232_PORT(config, m_rs232, default_rs232_devices, nullptr);
+	m_rs232->rxd_handler().set(m_uart, FUNC(ins8250_device::rx_w));
+	m_rs232->cts_handler().set(m_uart, FUNC(ins8250_device::cts_w));
+	m_rs232->dsr_handler().set(m_uart, FUNC(ins8250_device::dsr_w));
+	m_rs232->dcd_handler().set(m_uart, FUNC(ins8250_device::dcd_w));
+	m_rs232->ri_handler().set(m_uart, FUNC(ins8250_device::ri_w));
+}
+
+void hp9816_state::machine_start()
+{
+	save_item(NAME(m_text_vram));
+	save_item(NAME(m_graphic_vram));
+	save_item(NAME(m_hsync_en));
+	save_item(NAME(m_graphic_en));
+	save_item(NAME(m_hpib_dma_en));
+	save_item(NAME(m_uart_int_en));
+	save_item(NAME(m_uart_ocd3));
+	save_item(NAME(m_uart_ocd4));
+
+	m_cpu->space(AS_PROGRAM).install_ram(0x1000000 - m_ram->size(), 0xffffff, m_ram->pointer());
+}
+
+void hp9816_state::machine_reset()
+{
+	m_hsync_en = false;
+	m_graphic_en = false;
+	m_hpib_dma_en = false;
+	uart_reset();
+	diag_led_w(0);
+}
+
+void hp9816_state::cpu_mem_map(address_map &map)
+{
+	map.unmap_value_high();
+	// Range           DTACK Device
+	// ==============================
+	// 00'0000-00'ffff *     Boot ROM
+	// 01'0000-01'ffff *     Diagnostic LEDs (write only)
+	// 02'0000-3f'ffff *     None
+	// 40'0000-40'ffff       None
+	// 41'0000-41'ffff *     Text video memory & 6845 (mirror of 51'0000)
+	// 42'0000-42'ffff *     Keyboard UPI
+	// 43'0000-43'ffff *     Graphic video memory (Mirror of 53'0000)
+	// 44'0000-46'ffff       None
+	// 47'0000-47'ffff *     HPIB
+	// 48'0000-50'ffff       None
+	// 51'0000-51'ffff *     Text video memory & 6845
+	// 52'0000-52'ffff *     Keyboard UPI (mirror of 42'0000)
+	// 53'0000-53'ffff *     Graphic video memory
+	// 54'0000-56'ffff       None
+	// 57'0000-57'ffff *     HPIB (mirror of 47'0000)
+	// 58'0000-68'ffff       None
+	// 69'0000-69'ffff *     UART
+	// 6a'0000-fb'ffff       None
+	// fx'0000-ff'ffff *     RAM
+	map(0x000000, 0x00ffff).rom().region("cpu", 0);
+	map(0x010000, 0x01ffff).w(FUNC(hp9816_state::diag_led_w)).umask16(0x00ff);
+	map(0x020000, 0x3fffff).noprw();
+	map(0x400000, 0x40ffff).rw(m_cpu, FUNC(m68000_device::berr_r), FUNC(m68000_device::berr_w));
+	map(0x410000, 0x41ffff).mirror(0x100000).rw(FUNC(hp9816_state::text_r), FUNC(hp9816_state::text_w));
+	map(0x420000, 0x42ffff).mirror(0x100000).mask(3).rw(m_upi, FUNC(hp98x6_upi_device::read), FUNC(hp98x6_upi_device::write)).umask16(0x00ff);
+	map(0x430000, 0x43ffff).mirror(0x100000).rw(FUNC(hp9816_state::graphic_r), FUNC(hp9816_state::graphic_w));
+	map(0x440000, 0x46ffff).rw(m_cpu, FUNC(m68000_device::berr_r), FUNC(m68000_device::berr_w));
+	map(0x470000, 0x47ffff).mirror(0x100000).rw(FUNC(hp9816_state::hpib_r), FUNC(hp9816_state::hpib_w)).umask16(0x00ff);
+	map(0x480000, 0x50ffff).rw(m_cpu, FUNC(m68000_device::berr_r), FUNC(m68000_device::berr_w));
+	map(0x540000, 0x56ffff).rw(m_cpu, FUNC(m68000_device::berr_r), FUNC(m68000_device::berr_w));
+	map(0x580000, 0x68ffff).rw(m_cpu, FUNC(m68000_device::berr_r), FUNC(m68000_device::berr_w));
+	map(0x690000, 0x69ffff).rw(FUNC(hp9816_state::uart_r), FUNC(hp9816_state::uart_w)).umask16(0x00ff);
+	map(0x6a0000, 0xfbffff).rw(m_cpu, FUNC(m68000_device::berr_r), FUNC(m68000_device::berr_w));
+}
+
+void hp9816_state::diag_led_w(uint8_t data)
+{
+	LOG("LEDS=%02x %c%c%c%c %c%c%c%c\n" ,
+		data,
+		BIT(data , 7) ? '.' : '*',
+		BIT(data , 6) ? '.' : '*',
+		BIT(data , 5) ? '.' : '*',
+		BIT(data , 4) ? '.' : '*',
+		BIT(data , 3) ? '.' : '*',
+		BIT(data , 2) ? '.' : '*',
+		BIT(data , 1) ? '.' : '*',
+		BIT(data , 0) ? '.' : '*');
+}
+
+uint16_t hp9816_state::text_r(offs_t offset)
+{
+	if (BIT(offset, 12)) {
+		return m_text_vram[ offset & (TEXT_VRAM_SIZE - 1) ];
+	} else if (BIT(offset, 0)) {
+		return m_crtc->register_r();
+	} else {
+		LOG("Reading from non-existing register of 6845!\n");
+		return 0;
+	}
+}
+
+void hp9816_state::text_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	if (BIT(offset, 12)) {
+		m_hsync_en = !BIT(offset, 14);
+		COMBINE_DATA(&m_text_vram[ offset & (TEXT_VRAM_SIZE - 1) ]);
+	} else if (ACCESSING_BITS_0_7) {
+		if (BIT(offset, 0)) {
+			m_crtc->register_w(uint8_t(data));
+		} else {
+			m_crtc->address_w(uint8_t(data));
+		}
+	} else {
+		LOG("Access to 6845 on top byte!\n");
+	}
+}
+
+uint16_t hp9816_state::graphic_r(offs_t offset, uint16_t mem_mask)
+{
+	m_graphic_en = !BIT(offset, 14);
+
+	if (ACCESSING_BITS_0_7) {
+		return m_graphic_vram[ offset & (GRAPHIC_VRAM_SIZE - 1) ];
+	} else {
+		return m_cpu->berr_r();
+	}
+}
+
+void hp9816_state::graphic_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	m_graphic_en = !BIT(offset, 14);
+
+	if (ACCESSING_BITS_0_7) {
+		m_graphic_vram[ offset & (GRAPHIC_VRAM_SIZE - 1) ] = uint8_t(data);
+	} else {
+		return m_cpu->berr_w(0);
+	}
+}
+
+uint8_t hp9816_state::hpib_r(offs_t offset)
+{
+	uint8_t res = 0;
+
+	if (BIT(offset, 3)) {
+		res = m_hpib->read(offset & 7);
+	} else if (BIT(offset, 1)) {
+		if (BIT(m_sw3_dipswitches->read(), 6)) {
+			BIT_SET(res, 7);
+		}
+		if (!m_hpib->cont_r()) {
+			BIT_SET(res, 6);
+		}
+		if (m_upi_irq7) {
+			BIT_SET(res, 2);
+		}
+		if (BIT(m_sw3_dipswitches->read(), 7)) {
+			BIT_SET(res, 0);
+		}
+	} else {
+		if (BIT(m_sw3_dipswitches->read(), 5)) {
+			BIT_SET(res, 7);
+		}
+		if (m_hpib_irq) {
+			BIT_SET(res, 6);
+		}
+		BIT_SET(res, 2);
+		if (m_hpib_dma_en) {
+			BIT_SET(res, 0);
+		}
+	}
+
+	return res;
+}
+
+void hp9816_state::hpib_w(offs_t offset, uint8_t data)
+{
+	if (BIT(offset, 3)) {
+		m_hpib->write(offset & 7, data);
+	} else {
+		m_hpib_dma_en = BIT(data, 0);
+	}
+}
+
+void hp9816_state::uart_reset()
+{
+	m_uart_int_en = false;
+	m_uart_ocd4 = false;
+	m_uart_ocd3 = false;
+	m_uart->reset();
+	uart_update_irq();
+}
+
+void hp9816_state::uart_update_irq()
+{
+	m_cpu->set_input_line(M68K_IRQ_4, m_uart_irq && m_uart_int_en);
+}
+
+uint8_t hp9816_state::uart_r(offs_t offset)
+{
+	uint8_t res = 0;
+
+	if (BIT(offset, 3)) {
+		res = m_uart->ins8250_r(offset & 7);
+	} else {
+		switch (offset & 3) {
+		case 0:
+			if (BIT(m_sw3_dipswitches->read(), 4)) {
+				BIT_SET(res, 7);
+			}
+			BIT_SET(res, 1);
+			break;
+		case 1:
+			if (m_uart_int_en) {
+				BIT_SET(res, 7);
+			}
+			if (m_uart_irq) {
+				BIT_SET(res, 6);
+			}
+			BIT_SET(res, 4);
+			break;
+		case 2:
+			if (m_uart_ocd3) {
+				BIT_SET(res, 7);
+			}
+			if (m_uart_ocd4) {
+				BIT_SET(res, 6);
+			}
+			res |= (m_sw3_dipswitches->read() & 0x0f);
+			break;
+		case 3:
+			res = uint8_t(m_sw2_dipswitches->read());
+			break;
+		}
+	}
+
+	return res;
+}
+
+void hp9816_state::uart_w(offs_t offset, uint8_t data)
+{
+	if (BIT(offset, 3)) {
+		m_uart->ins8250_w(offset & 7, data);
+	} else {
+		switch (offset & 3) {
+		case 0:
+			uart_reset();
+			break;
+		case 1:
+			m_uart_int_en = BIT(data, 7);
+			uart_update_irq();
+			break;
+		case 2:
+			m_uart_ocd3 = BIT(data, 7);
+			m_uart_ocd4 = BIT(data, 6);
+			break;
+		}
+	}
+}
+
+MC6845_UPDATE_ROW(hp9816_state::crtc_update_row)
+{
+	if (m_hsync_en) {
+		const pen_t *pen = m_palette->pens();
+		bool clen = (ma & 0x3800) != 0x2800;
+		bool glb_blink = (m_screen->frame_number() & 0x30) == 0;
+
+		// Text video
+		for (int i = 0; i < x_count; i++) {
+			uint16_t char_attr = m_text_vram[ (ma + i) & (TEXT_VRAM_SIZE - 1) ];
+			// | Bit(s) | Meaning                    |
+			// |--------+----------------------------|
+			// |     15 | Select alternate char. set |
+			// | 14..12 | N/U                        |
+			// |     11 | Half brightness            |
+			// |     10 | Underline                  |
+			// |      9 | Blink                      |
+			// |      8 | Inverted                   |
+			// |   7..0 | Character code             |
+
+			bool half_bright = BIT(char_attr, 11);
+			bool underline;
+			bool blink = glb_blink && BIT(char_attr, 9);
+			bool invert;
+			uint16_t char_pixels;
+			bool cursor;
+			if (clen) {
+				unsigned chargen_addr = ra | ((char_attr & 0xff) << 4);
+				if (BIT(char_attr, 15)) {
+					BIT_SET(chargen_addr, 12);
+				}
+				char_pixels = uint16_t(m_chargen[ chargen_addr ]) << 1;
+				underline = BIT(char_attr, 10) && ra == 11;
+				invert = BIT(char_attr, 8);
+				cursor = cursor_x == i;
+			} else {
+				char_pixels = 0;
+				underline = false;
+				invert = false;
+				cursor = false;
+			}
+
+			// Truth table of 1st video combiner
+			//
+			// | blink | cursor | underline | out      |
+			// |-------+--------+-----------+----------|
+			// |     0 |      0 |         0 | chargen  |
+			// |     0 |      0 |         1 | ~chargen |
+			// |     0 |      1 |         0 | ~chargen |
+			// |     0 |      1 |         1 | chargen  |
+			// |     1 |      0 |         0 | 0        |
+			// |     1 |      0 |         1 | 0        |
+			// |     1 |      1 |         0 | ~0       |
+			// |     1 |      1 |         1 | ~0       |
+			if (blink) {
+				if (cursor) {
+					char_pixels = ~0;
+				} else {
+					char_pixels = 0;
+				}
+			} else if (cursor ^ underline) {
+				char_pixels = ~char_pixels;
+			}
+
+			// Truth table of 2nd video combiner
+			//
+			// | half_bright | Graphic | invert | Text | out |
+			// |-------------+---------+--------+------+-----|
+			// |           0 |       0 |      0 |    0 | 0   |
+			// |           0 |       0 |      0 |    1 | 2   |
+			// |           0 |       0 |      1 |    0 | 2   |
+			// |           0 |       0 |      1 |    1 | 0   |
+			// |           0 |       1 |      0 |    0 | 2   |
+			// |           0 |       1 |      0 |    1 | 0   |
+			// |           0 |       1 |      1 |    0 | 0   |
+			// |           0 |       1 |      1 |    1 | 2   |
+			// |           1 |       0 |      0 |    0 | 0   |
+			// |           1 |       0 |      0 |    1 | 1   |
+			// |           1 |       0 |      1 |    0 | 1   |
+			// |           1 |       0 |      1 |    1 | 0   |
+			// |           1 |       1 |      0 |    0 | 2   |
+			// |           1 |       1 |      0 |    1 | 2   |
+			// |           1 |       1 |      1 |    0 | 2   |
+			// |           1 |       1 |      1 |    1 | 2   |
+			if (invert) {
+				char_pixels = ~char_pixels;
+			}
+			for (unsigned col = 0; col < 10; col++) {
+				bitmap.pix(y, i * 10 + col) = pen[ BIT(char_pixels, 9 - col) ? (half_bright ? 1 : 2) : 0 ];
+			}
+		}
+
+		// Graphic video
+		if (m_graphic_en) {
+			unsigned g_cols = unsigned(x_count) * 5;
+			// Hw only works correctly when x_count is 80 (-> 50 bytes per graphic line)
+			unsigned g_bytes_per_line = g_cols / 8;
+			unsigned g_addr = y * g_bytes_per_line;
+			for (unsigned i = 0; i < g_bytes_per_line; i++) {
+				uint8_t graph_pixels = m_graphic_vram[ (g_addr + i) & (GRAPHIC_VRAM_SIZE - 1) ];
+				for (unsigned col = 0; col < 8; col++) {
+					if (BIT(graph_pixels, 7 - col)) {
+						// A graphic pixel covers 2 text pixels
+						// Also, the hw seems to offset graphic pixels 1 text pixel to the right
+						// Here this offset is not applied (as rightmost graphic pixel would be clipped)
+						unsigned x_pos = i * 16 + col * 2;
+						{
+							auto &pix = bitmap.pix(y, x_pos);
+							// Overlay rules (see 2nd video combiner table)
+							//
+							// |  Text | Combined |
+							// | video | Video    |
+							// |-------+----------|
+							// |     0 | 2        |
+							// |     1 | 2        |
+							// |     2 | 0        |
+							pix = pen[ (pix == pen[ 2 ]) ? 0 : 2 ];
+						}
+						x_pos++;
+						{
+							auto &pix = bitmap.pix(y, x_pos);
+							pix = pen[ (pix == pen[ 2 ]) ? 0 : 2 ];
+						}
+					}
+				}
+			}
+		}
+	} else {
+		bitmap.fill(rgb_t::black(), rectangle(0, unsigned(x_count) * 10 - 1, y, y));
+	}
+}
+
+void hp9816_state::cpu_reset_w(int state)
+{
+	if (state) {
+		LOG("RESET from CPU\n");
+		m_upi->reset();
+		m_hpib->reset();
+		m_hpib_dma_en = false;
+		uart_reset();
+		//m_crtc->reset();
+		m_hsync_en = false;
+		m_graphic_en = false;
+	}
+}
+
+void hp9816_state::hpib_irq_w(int state)
+{
+	m_hpib_irq = bool(state);
+	m_cpu->set_input_line(M68K_IRQ_3, state);
+}
+
+void hp9816_state::upi_irq7_w(int state)
+{
+	m_upi_irq7 = bool(state);
+	m_cpu->set_input_line(M68K_IRQ_7, state);
+}
+
+void hp9816_state::uart_irq_w(int state)
+{
+	m_uart_irq = bool(state);
+	uart_update_irq();
+}
+
+static INPUT_PORTS_START(hp9816)
+	PORT_START("sw2")
+	PORT_DIPNAME(0x30, 0x00, "Parity type")
+	PORT_DIPLOCATION("S2:4,3")
+	PORT_DIPSETTING(0x00, "Odd")
+	PORT_DIPSETTING(0x10, "Even")
+	PORT_DIPSETTING(0x20, "One")
+	PORT_DIPSETTING(0x30, "Zero")
+	PORT_DIPNAME(0x08, 0x00, "Parity enable")
+	PORT_DIPLOCATION("S2:5")
+	PORT_DIPSETTING(0x00, DEF_STR(Off))
+	PORT_DIPSETTING(0x08, DEF_STR(On))
+	PORT_DIPNAME(0x04, 0x00, "Stop bits")
+	PORT_DIPLOCATION("S2:6")
+	PORT_DIPSETTING(0x00, "1")
+	PORT_DIPSETTING(0x04, "2")
+	PORT_DIPNAME(0x03, 0x03, "Bits/char")
+	PORT_DIPLOCATION("S2:8,7")
+	PORT_DIPSETTING(0x00, "5")
+	PORT_DIPSETTING(0x01, "6")
+	PORT_DIPSETTING(0x02, "7")
+	PORT_DIPSETTING(0x03, "8")
+
+	PORT_START("sw3")
+	PORT_DIPNAME(0x0f, 0x0a, "Baud rate")
+	PORT_DIPLOCATION("S3:4,3,2,1")
+	PORT_DIPSETTING(0x00, "50")
+	PORT_DIPSETTING(0x01, "75")
+	PORT_DIPSETTING(0x02, "110")
+	PORT_DIPSETTING(0x03, "134.5")
+	PORT_DIPSETTING(0x04, "150")
+	PORT_DIPSETTING(0x05, "200")
+	PORT_DIPSETTING(0x06, "300")
+	PORT_DIPSETTING(0x07, "600")
+	PORT_DIPSETTING(0x08, "1200")
+	PORT_DIPSETTING(0x09, "1800")
+	PORT_DIPSETTING(0x0a, "2400")
+	PORT_DIPSETTING(0x0b, "3600")
+	PORT_DIPSETTING(0x0c, "4800")
+	PORT_DIPSETTING(0x0d, "7200")
+	PORT_DIPSETTING(0x0e, "9600")
+	PORT_DIPSETTING(0x0f, "19200")
+	PORT_DIPNAME(0x10, 0x00, "Remote keyboard")
+	PORT_DIPLOCATION("S3:5")
+	PORT_DIPSETTING(0x00, DEF_STR(Off))
+	PORT_DIPSETTING(0x10, DEF_STR(On))
+	PORT_DIPNAME(0x20, 0x20, "Continuous self-test")
+	PORT_DIPLOCATION("S3:6")
+	PORT_DIPSETTING(0x00, DEF_STR(On))
+	PORT_DIPSETTING(0x20, DEF_STR(Off))
+	PORT_DIPNAME(0x40, 0x40, "HPIB Sys controller")
+	PORT_DIPLOCATION("S3:7")
+	PORT_DIPSETTING(0x00, DEF_STR(Off))
+	PORT_DIPSETTING(0x40, DEF_STR(On))
+	PORT_DIPNAME(0x80, 0x80, "CRT refresh rate")
+	PORT_DIPLOCATION("S3:8")
+	PORT_DIPSETTING(0x00, "50 Hz")
+	PORT_DIPSETTING(0x80, "60 Hz")
+
+INPUT_PORTS_END
+
+ROM_START(hp9816a)
+	ROM_REGION(0x2000, "chargen", 0)
+	ROM_LOAD("1818-3171.bin", 0, 0x2000, CRC(9cf4d4e1) SHA1(228484fd7ba7a4b59a051af083858383afe30179))
+
+	ROM_REGION(0x10000, "cpu", 0)
+	ROM_DEFAULT_BIOS("bios40")
+	ROM_SYSTEM_BIOS(0, "bios40",  "BIOS v4.0")
+	ROMX_LOAD("rom40.bin", 0x0000, 0x10000, CRC(36005480) SHA1(645a077ffd95e4c31f05cd8bbd6e4554b12813f1), ROM_BIOS(0))
+	ROM_SYSTEM_BIOS(1, "bios30",  "BIOS v3.0")
+	ROMX_LOAD("rom30.bin", 0x0000, 0x10000, CRC(05c07e75) SHA1(3066a65e6137482041f9a77d09ee2289fe0974aa), ROM_BIOS(1))
+ROM_END
+} // anonymous namespace
+
+//   YEAR  NAME     PARENT  COMPAT  MACHINE INPUT   CLASS        INIT        COMPANY            FULLNAME    FLAGS
+COMP(1982, hp9816a, 0,      0,      hp9816, hp9816, hp9816_state,empty_init, "Hewlett-Packard", "HP 9816A", 0)

--- a/src/mame/hp/hp98x6_upi.cpp
+++ b/src/mame/hp/hp98x6_upi.cpp
@@ -1,0 +1,1049 @@
+// license:BSD-3-Clause
+// copyright-holders:F. Ulivi
+
+// **** High level emulation of 8041 UPI in HP98X6 systems ****
+//
+// Configuration jumpers I identified in RAM_POS_CFG_JUMPERS register:
+//
+// |  Bit | Meaning                                           |
+// |------+---------------------------------------------------|
+// |    7 | ID PROM is installed                              |
+// |    6 | ?                                                 |
+// |    5 | Enter key is named either "ENTER" or "RETURN" (?) |
+// | 4..1 | ?                                                 |
+// |    0 | Large (0) or small (1) keyboard                   |
+//
+// Sequence to read ID PROM:
+//
+// 68k          UPI
+// ===========================================
+// Cmd C1 ->    Set ID PROM address = 0
+// Cmd 01 ->    Read PROM byte @00, address++
+//              <- Byte @00
+// Cmd 01 ->    Read PROM byte @01, address++
+//              <- Byte @01
+// ...
+// Cmd C0 ->    Stop reading ID PROM
+//
+// TODO:
+// - Find if FHS and delay timers are self canceling
+// - Identify more configuration jumpers
+
+#include "emu.h"
+#include "hp98x6_upi.h"
+
+// Debugging
+#define VERBOSE 1
+#include "logmacro.h"
+
+// Bit manipulation
+namespace {
+	template<typename T> constexpr T BIT_MASK(unsigned n)
+	{
+		return (T)1U << n;
+	}
+
+	template<typename T> void BIT_CLR(T& w , unsigned n)
+	{
+		w &= ~BIT_MASK<T>(n);
+	}
+
+	template<typename T> void BIT_SET(T& w , unsigned n)
+	{
+		w |= BIT_MASK<T>(n);
+	}
+}
+
+// Device type definition
+DEFINE_DEVICE_TYPE(HP98X6_UPI, hp98x6_upi_device, "hp98x6_upi", "UPI of HP98x6 systems")
+
+// ID PROM for 9816A (it comes straight from O. De Smet's emulator)
+static const uint8_t id_prom[] = {
+	0x3e,0x38,0x00,0x32,0x30,0x31,0x30,0x41,0x30,0x30,0x30,0x30,0x30,0x30,0x39,0x38,
+	0x31,0x36,0x41,0x20,0x20,0xff,0x01,0x02,0x03,0x04,0xff,0xff,0xff,0xff,0xff,0xff,
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xfe,0x00,0x00,0xff,0xff,0xff,0xff,0xff,0xff,
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x00,
+	0x00,0x00,0x00,0x00,0x00,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff
+};
+
+// Positions in internal RAM
+enum : uint8_t {
+	RAM_POS_0_R0,
+	RAM_POS_0_R1,
+	RAM_POS_0_R2_FLAGS1,
+	RAM_POS_0_R3_CURR_KEY,
+	RAM_POS_0_R4_FLAGS2,
+	RAM_POS_0_R5_FLAGS3,
+	RAM_POS_0_R6_ROLLOVER,
+	RAM_POS_0_R7_KEY_DOWN,
+	RAM_POS_RST_DEB_CNT = 0x10,
+	RAM_POS_CFG_JUMPERS,
+	RAM_POS_LNG_JUMPERS,
+	RAM_POS_OUT_BUFF_1,
+	RAM_POS_OUT_BUFF_2,
+	RAM_POS_OUT_BUFF_3,
+	RAM_POS_OUT_BUFF_4,
+	RAM_POS_OUT_BUFF_5,
+	RAM_POS_1_R0,
+	RAM_POS_1_R1,
+	RAM_POS_1_R2,
+	RAM_POS_1_R3_TIMER_STS,
+	RAM_POS_1_R4_RPG_COUNT,
+	RAM_POS_1_R5_W_PTR,
+	RAM_POS_1_R6_R_PTR,
+	RAM_POS_1_R7_6CTR,
+	RAM_POS_HIGH_RAM_START = 0x20,
+	RAM_POS_AR_WAIT = 0x20,
+	RAM_POS_AR_TIMER,
+	RAM_POS_AR_RATE,
+	RAM_POS_BEEP_TIMER,
+	RAM_POS_BEEP_FREQ,
+	RAM_POS_RPG_TIMER,
+	RAM_POS_RPG_INT_RATE,
+	RAM_POS_TIMER_INT,
+	RAM_POS_READING_PROM,       // Not in HP doc, arbitrarily used for PROM reading
+	RAM_POS_PROM_ADDR,          // Not in HP doc, arbitrarily used for PROM reading
+	RAM_POS_TOD_1 = 0x2d,
+	RAM_POS_TOD_2,
+	RAM_POS_TOD_3,
+	RAM_POS_DAY_1,
+	RAM_POS_DAY_2,
+	RAM_POS_FHS_1,
+	RAM_POS_FHS_2,
+	RAM_POS_MATCH_1,
+	RAM_POS_MATCH_2,
+	RAM_POS_MATCH_3,
+	RAM_POS_DELAY_1,
+	RAM_POS_DELAY_2,
+	RAM_POS_DELAY_3,
+	RAM_POS_CYCLE_1,
+	RAM_POS_CYCLE_2,
+	RAM_POS_CYCLE_3,
+	RAM_POS_CYCLE_SAVE_1,
+	RAM_POS_CYCLE_SAVE_2,
+	RAM_POS_CYCLE_SAVE_3
+};
+
+// Clocks per 10 ms
+constexpr unsigned CLOCKS_PER_10MS = 50000;
+
+// Delays (in device clocks)
+// They are all multiples of 15 as that's the basic instruction cycle of 8041
+constexpr unsigned POR_DELAY1 = 105;
+constexpr unsigned POR_DELAY2 = 100005; // This is a wild guess, real 8041 is mostly checksumming its ROM here
+constexpr unsigned RESET_DELAY = 7500;
+constexpr unsigned INPUT_DELAY = 495;   // Sometimes 68k doesn't like instantaneous consumption of cmd/data bytes
+
+// Bits in status register
+constexpr unsigned STATUS_F1_BIT = 3;
+constexpr unsigned STATUS_F0_BIT = 2;
+constexpr unsigned STATUS_IBF_BIT = 1;
+constexpr unsigned STATUS_OBF_BIT = 0;
+constexpr uint8_t ST_PSI = 0x10;
+constexpr uint8_t ST_TIMER = 0x20;
+constexpr uint8_t ST_REQUESTED_DATA = 0x40;
+constexpr uint8_t ST_POST_OK = 0x70;
+constexpr uint8_t ST_KEY = 0x80;
+constexpr uint8_t ST_RPG = 0xc0;
+
+// Bits in RAM_POS_0_R2_FLAGS1
+constexpr uint8_t R2_FLAGS1_DEB_MASK = 0x07;
+constexpr uint8_t R2_FLAGS1_DEB_INIT = 0x02;
+constexpr unsigned R2_FLAGS1_FHS_BIT = 3;
+constexpr unsigned R2_FLAGS1_CYCLE_BIT = 4;
+constexpr unsigned R2_FLAGS1_DELAY_BIT = 5;
+constexpr unsigned R2_FLAGS1_MATCH_BIT = 6;
+constexpr unsigned R2_FLAGS1_BEEP_BIT = 7;
+
+// Bits in RAM_POS_0_R4_FLAGS2
+constexpr unsigned R4_FLAGS2_AR_BIT = 5;
+constexpr unsigned R4_FLAGS2_FHS_MASK_BIT = 4;
+constexpr unsigned R4_FLAGS2_PSI_MASK_BIT = 3;
+constexpr unsigned R4_FLAGS2_TMR_MASK_BIT = 2;
+constexpr unsigned R4_FLAGS2_RST_MASK_BIT = 1;
+constexpr unsigned R4_FLAGS2_KEY_MASK_BIT = 0;
+
+// Bits in RAM_POS_0_R5_FLAGS3
+constexpr unsigned R5_FLAGS3_FHS_BIT = 7;
+constexpr unsigned R5_FLAGS3_READ_BIT = 5;
+constexpr unsigned R5_FLAGS3_RPG_BIT = 4;
+constexpr unsigned R5_FLAGS3_USER_TMR_BIT = 3;
+constexpr unsigned R5_FLAGS3_PSI_BIT = 2;
+constexpr unsigned R5_FLAGS3_CTRL_UP_BIT = 1;
+constexpr unsigned R5_FLAGS3_SHIFT_UP_BIT = 0;
+
+// Bits in RAM_POS_CFG_JUMPERS
+constexpr unsigned CFG_JUMPERS_PROM_BIT = 7;
+
+// Bits in RAM_POS_1_R3_TIMER_STS
+constexpr unsigned R3_TIMER_STS_MATCH_BIT = 7;
+constexpr unsigned R3_TIMER_STS_DELAY_BIT = 6;
+constexpr unsigned R3_TIMER_STS_CYCLE_BIT = 5;
+constexpr uint8_t R3_TIMER_STS_INT_MASK = 0xe0;
+constexpr uint8_t R3_TIMER_STS_MISSED_CYCLES_MASK = 0x1f;
+
+// Commands
+constexpr uint8_t CMD_MASK = 0xe0;
+constexpr uint8_t CMD_PARAM = 0x1f;
+constexpr uint8_t CMD_RD_RAM_LOW = 0x00;
+constexpr uint8_t CMD_RD_RAM_HIGH = 0x20;
+constexpr uint8_t CMD_SET_INT_MASK = 0x40;
+constexpr uint8_t CMD_WR_RAM_HIGH = 0xa0;
+constexpr uint8_t CMD_RD_PROM_STOP = 0xc0;
+constexpr uint8_t CMD_RD_PROM_START = 0xc1;
+
+// Scancode range
+constexpr uint8_t SCANCODE_NONE = 0;
+constexpr uint8_t MIN_SCANCODE = 0x18;
+constexpr uint8_t MAX_SCANCODE = 0x7f;
+
+// Various constants
+constexpr uint8_t POST_BYTE = 0x8e;
+constexpr uint8_t TOD_1_ONE_DAY = 0;    // One day is 0x83d600 (8'640'000) in TOD counts
+constexpr uint8_t TOD_2_ONE_DAY = 0xd6;
+constexpr uint8_t TOD_3_ONE_DAY = 0x83;
+constexpr unsigned BEEP_SCALING = 15 * 64 * 64;
+constexpr uint8_t PAUSE_SCANCODE = 0x38;    // Reset is Shift+Pause
+
+hp98x6_upi_device::hp98x6_upi_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+: device_t(mconfig, HP98X6_UPI, tag, owner, clock)
+	, m_keys(*this, "KEY%u", 0)
+	, m_shift(*this, "KEY_SHIFT")
+	, m_dial(*this, "DIAL")
+	, m_beep(*this, "beep")
+	, m_10ms_timer(*this, "timer")
+	, m_delay_timer(*this, "dly")
+	, m_input_delay_timer(*this, "inp_dly")
+	, m_irq1_write_func(*this)
+	, m_irq7_write_func(*this)
+{
+}
+
+uint8_t hp98x6_upi_device::read(offs_t offset)
+{
+	uint8_t res;
+
+	if (BIT(offset, 0)) {
+		res = m_status;
+	} else {
+		res = m_data_out;
+		BIT_CLR(m_status, STATUS_OBF_BIT);
+		m_irq1_write_func(false);
+		try_output();
+	}
+	return res;
+}
+
+void hp98x6_upi_device::write(offs_t offset, uint8_t data)
+{
+	m_data_in = data;
+	if (!BIT(m_status, STATUS_IBF_BIT)) {
+		m_ready = false;
+		m_input_delay_timer->adjust(clocks_to_attotime(INPUT_DELAY));
+		BIT_SET(m_status, STATUS_IBF_BIT);
+	}
+	if (BIT(offset, 0)) {
+		BIT_SET(m_status, STATUS_F1_BIT);
+	} else {
+		BIT_CLR(m_status, STATUS_F1_BIT);
+	}
+}
+
+void hp98x6_upi_device::device_add_mconfig(machine_config &config)
+{
+	// Beep
+	SPEAKER(config, "mono").front_center();
+	BEEP(config, m_beep, 0).add_route(ALL_OUTPUTS, "mono", 1.00);
+
+	TIMER(config, m_10ms_timer).configure_periodic(FUNC(hp98x6_upi_device::ten_ms), clocks_to_attotime(CLOCKS_PER_10MS));
+	TIMER(config, m_delay_timer).configure_generic(FUNC(hp98x6_upi_device::delay));
+	TIMER(config, m_input_delay_timer).configure_generic(FUNC(hp98x6_upi_device::input_delay));
+}
+
+#define IOP_MASK(x) BIT_MASK<ioport_value>((x))
+
+static INPUT_PORTS_START(hp98x6_upi_ports)
+	PORT_START("KEY0")
+	PORT_BIT(IOP_MASK(0) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                             // 0,0: N/U
+	PORT_BIT(IOP_MASK(1) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                             // 0,1: N/U
+	PORT_BIT(IOP_MASK(2) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                             // 0,2: N/U
+	PORT_BIT(IOP_MASK(3) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_CAPSLOCK) PORT_NAME("CAPS LOCK")                                        // 0,3: Caps lock
+	PORT_BIT(IOP_MASK(4) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_F3) PORT_CHAR(UCHAR_MAMEKEY(F3)) PORT_NAME("k3")                        // 0,4: k3
+	PORT_BIT(IOP_MASK(5) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("INSLN")                                                                        // 0,5: Insln
+	PORT_BIT(IOP_MASK(6) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("EDIT")                                                                         // 0,6: Edit
+	PORT_BIT(IOP_MASK(7) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("PAUSE")                                                                        // 0,7: Pause
+	PORT_BIT(IOP_MASK(8) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_1_PAD) PORT_CHAR(UCHAR_MAMEKEY(1_PAD))                                  // 0,8: KP 1
+	PORT_BIT(IOP_MASK(9) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_7_PAD) PORT_CHAR(UCHAR_MAMEKEY(7_PAD))                                  // 0,9: KP 7
+	PORT_BIT(IOP_MASK(10) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_1) PORT_CHAR('1') PORT_CHAR('!')                                       // 0,10: 1
+	PORT_BIT(IOP_MASK(11) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_9) PORT_CHAR('9') PORT_CHAR('(')                                       // 0,11: 9
+	PORT_BIT(IOP_MASK(12) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_COMMA) PORT_CHAR(',') PORT_CHAR('<')                                   // 0,12: , <
+	PORT_BIT(IOP_MASK(13) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_Q) PORT_CHAR('q') PORT_CHAR('Q')                                       // 0,13: Q
+	PORT_BIT(IOP_MASK(14) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_A) PORT_CHAR('a') PORT_CHAR('A')                                       // 0,14: A
+	PORT_BIT(IOP_MASK(15) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_Z) PORT_CHAR('z') PORT_CHAR('Z')                                       // 0,15: Z
+	PORT_BIT(IOP_MASK(16) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                            // 1,0: N/U
+	PORT_BIT(IOP_MASK(17) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                            // 1,1: N/U
+	PORT_BIT(IOP_MASK(18) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                            // 1,2: N/U
+	PORT_BIT(IOP_MASK(19) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_TAB) PORT_CHAR('\t')                                                   // 1,3: Tab
+	PORT_BIT(IOP_MASK(20) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_F4) PORT_CHAR(UCHAR_MAMEKEY(F4)) PORT_NAME("k4")                       // 1,4: k4
+	PORT_BIT(IOP_MASK(21) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("DELLN")                                                                       // 1,5: Delln
+	PORT_BIT(IOP_MASK(22) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("ALPHA")                                                                       // 1,6: Alpha
+	PORT_BIT(IOP_MASK(23) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_ENTER) PORT_NAME("ENTER") PORT_CHAR(13)                                // 1,7: Enter
+	PORT_BIT(IOP_MASK(24) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_2_PAD) PORT_CHAR(UCHAR_MAMEKEY(2_PAD))                                 // 1,8: KP 2
+	PORT_BIT(IOP_MASK(25) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_8_PAD) PORT_CHAR(UCHAR_MAMEKEY(8_PAD))                                 // 1,9: KP 8
+	PORT_BIT(IOP_MASK(26) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_2) PORT_CHAR('2') PORT_CHAR('@')                                       // 1,10: 2
+	PORT_BIT(IOP_MASK(27) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_0) PORT_CHAR('0') PORT_CHAR(')')                                       // 1,11: 0
+	PORT_BIT(IOP_MASK(28) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_STOP) PORT_CHAR('.') PORT_CHAR('>')                                    // 1,12: .
+	PORT_BIT(IOP_MASK(29) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_W) PORT_CHAR('w') PORT_CHAR('W')                                       // 1,13: W
+	PORT_BIT(IOP_MASK(30) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_S) PORT_CHAR('s') PORT_CHAR('S')                                       // 1,14: S
+	PORT_BIT(IOP_MASK(31) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_X) PORT_CHAR('x') PORT_CHAR('X')                                       // 1,15: X
+
+	PORT_START("KEY1")
+	PORT_BIT(IOP_MASK(0) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                             // 2,0: N/U
+	PORT_BIT(IOP_MASK(1) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                             // 2,1: N/U
+	PORT_BIT(IOP_MASK(2) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                             // 2,2: N/U
+	PORT_BIT(IOP_MASK(3) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("k0")                                                                           // 2,3: k0
+	PORT_BIT(IOP_MASK(4) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_DOWN) PORT_CHAR(UCHAR_MAMEKEY(DOWN))                                    // 2,4: Down
+	PORT_BIT(IOP_MASK(5) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("RECALL")                                                                       // 2,5: Recall
+	PORT_BIT(IOP_MASK(6) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("GRAPHICS")                                                                     // 2,6: Graphics
+	PORT_BIT(IOP_MASK(7) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("CONTINUE")                                                                     // 2,7: Continue
+	PORT_BIT(IOP_MASK(8) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_3_PAD) PORT_CHAR(UCHAR_MAMEKEY(3_PAD))                                  // 2,8: KP 3
+	PORT_BIT(IOP_MASK(9) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_9_PAD) PORT_CHAR(UCHAR_MAMEKEY(9_PAD))                                  // 2,9: KP 9
+	PORT_BIT(IOP_MASK(10) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_3) PORT_CHAR('3') PORT_CHAR('#')                                       // 2,10: 3
+	PORT_BIT(IOP_MASK(11) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_MINUS) PORT_CHAR('-') PORT_CHAR('_')                                   // 2,11: -
+	PORT_BIT(IOP_MASK(12) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_SLASH) PORT_CHAR('/') PORT_CHAR('?')                                   // 2,12: /
+	PORT_BIT(IOP_MASK(13) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_E) PORT_CHAR('e') PORT_CHAR('E')                                       // 2,13: E
+	PORT_BIT(IOP_MASK(14) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_D) PORT_CHAR('d') PORT_CHAR('D')                                       // 2,14: D
+	PORT_BIT(IOP_MASK(15) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_C) PORT_CHAR('c') PORT_CHAR('C')                                       // 2,15: C
+	PORT_BIT(IOP_MASK(16) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                            // 3,0: N/U
+	PORT_BIT(IOP_MASK(17) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                            // 3,1: N/U
+	PORT_BIT(IOP_MASK(18) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                            // 3,2: N/U
+	PORT_BIT(IOP_MASK(19) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_F1) PORT_CHAR(UCHAR_MAMEKEY(F1)) PORT_NAME("k1")                       // 3,3: k1
+	PORT_BIT(IOP_MASK(20) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_UP) PORT_CHAR(UCHAR_MAMEKEY(UP))                                       // 3,4: Up
+	PORT_BIT(IOP_MASK(21) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("INSCHR")                                                                      // 3,5: Inschr
+	PORT_BIT(IOP_MASK(22) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("STEP")                                                                        // 3,6: Step
+	PORT_BIT(IOP_MASK(23) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("EXECUTE")                                                                     // 3,7: Execute
+	PORT_BIT(IOP_MASK(24) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_MINUS_PAD) PORT_CHAR(UCHAR_MAMEKEY(MINUS_PAD))                         // 3,8: KP -
+	PORT_BIT(IOP_MASK(25) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_SLASH_PAD) PORT_CHAR(UCHAR_MAMEKEY(SLASH_PAD))                         // 3,9: KP /
+	PORT_BIT(IOP_MASK(26) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_4) PORT_CHAR('4') PORT_CHAR('$')                                       // 3,10: 4
+	PORT_BIT(IOP_MASK(27) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_EQUALS) PORT_CHAR('=') PORT_CHAR('+')                                  // 3,11: =
+	PORT_BIT(IOP_MASK(28) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_SPACE) PORT_CHAR(' ')                                                  // 3,12: Space
+	PORT_BIT(IOP_MASK(29) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_R) PORT_CHAR('r') PORT_CHAR('R')                                       // 3,13: R
+	PORT_BIT(IOP_MASK(30) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_F) PORT_CHAR('f') PORT_CHAR('F')                                       // 3,14: F
+	PORT_BIT(IOP_MASK(31) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_V) PORT_CHAR('v') PORT_CHAR('V')                                       // 3,15: V
+
+	PORT_START("KEY2")
+	PORT_BIT(IOP_MASK(0) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                             // 4,0: N/U
+	PORT_BIT(IOP_MASK(1) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                             // 4,1: N/U
+	PORT_BIT(IOP_MASK(2) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                             // 4,2: N/U
+	PORT_BIT(IOP_MASK(3) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_F2) PORT_CHAR(UCHAR_MAMEKEY(F2)) PORT_NAME("k2")                        // 4,3: k2
+	PORT_BIT(IOP_MASK(4) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_F8) PORT_CHAR(UCHAR_MAMEKEY(F8)) PORT_NAME("k8")                        // 4,4: k4
+	PORT_BIT(IOP_MASK(5) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("DELCHR")                                                                       // 4,5: Delchr
+	PORT_BIT(IOP_MASK(6) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("CLRLN")                                                                        // 4,6: Clrln
+	PORT_BIT(IOP_MASK(7) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_0_PAD) PORT_CHAR(UCHAR_MAMEKEY(0_PAD))                                  // 4,7: KP 0
+	PORT_BIT(IOP_MASK(8) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_4_PAD) PORT_CHAR(UCHAR_MAMEKEY(4_PAD))                                  // 4,8: KP 4
+	PORT_BIT(IOP_MASK(9) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("Keypad E")                                                                     // 4,9: KP E
+	PORT_BIT(IOP_MASK(10) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_5) PORT_CHAR('5') PORT_CHAR('%')                                       // 4,10: 5
+	PORT_BIT(IOP_MASK(11) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_OPENBRACE) PORT_CHAR('[') PORT_CHAR('{')                               // 4,11: [
+	PORT_BIT(IOP_MASK(12) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_O) PORT_CHAR('o') PORT_CHAR('O')                                       // 4,12: O
+	PORT_BIT(IOP_MASK(13) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_T) PORT_CHAR('t') PORT_CHAR('T')                                       // 4,13: T
+	PORT_BIT(IOP_MASK(14) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_G) PORT_CHAR('g') PORT_CHAR('G')                                       // 4,14: G
+	PORT_BIT(IOP_MASK(15) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_B) PORT_CHAR('b') PORT_CHAR('B')                                       // 4,15: B
+	PORT_BIT(IOP_MASK(16) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                            // 5,0: N/U
+	PORT_BIT(IOP_MASK(17) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                            // 5,1: N/U
+	PORT_BIT(IOP_MASK(18) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                            // 5,2: N/U
+	PORT_BIT(IOP_MASK(19) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_F5) PORT_CHAR(UCHAR_MAMEKEY(F5)) PORT_NAME("k5")                       // 5,3: k5
+	PORT_BIT(IOP_MASK(20) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_F9) PORT_CHAR(UCHAR_MAMEKEY(F9)) PORT_NAME("k9")                       // 5,4: k9
+	PORT_BIT(IOP_MASK(21) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_END) PORT_NAME("CLR TO END")                                           // 5,5: Clr->endif
+	PORT_BIT(IOP_MASK(22) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("RESULT")                                                                      // 5,6: Result
+	PORT_BIT(IOP_MASK(23) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_DEL_PAD) PORT_CHAR(UCHAR_MAMEKEY(DEL_PAD))                             // 5,7: KP .
+	PORT_BIT(IOP_MASK(24) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_5_PAD) PORT_CHAR(UCHAR_MAMEKEY(5_PAD))                                 // 5,8: KP 5
+	PORT_BIT(IOP_MASK(25) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("Keypad (")                                                                    // 5,9: KP (
+	PORT_BIT(IOP_MASK(26) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_6) PORT_CHAR('6') PORT_CHAR('^')                                       // 5,10: 6
+	PORT_BIT(IOP_MASK(27) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_CLOSEBRACE) PORT_CHAR(']') PORT_CHAR('}')                              // 5,11: ]
+	PORT_BIT(IOP_MASK(28) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_P) PORT_CHAR('p') PORT_CHAR('P')                                       // 5,12: P
+	PORT_BIT(IOP_MASK(29) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_Y) PORT_CHAR('y') PORT_CHAR('Y')                                       // 5,13: Y
+	PORT_BIT(IOP_MASK(30) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_H) PORT_CHAR('h') PORT_CHAR('H')                                       // 5,14: H
+	PORT_BIT(IOP_MASK(31) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_N) PORT_CHAR('n') PORT_CHAR('N')                                       // 5,15: N
+
+	PORT_START("KEY3")
+	PORT_BIT(IOP_MASK(0) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                             // 6,0: N/U
+	PORT_BIT(IOP_MASK(1) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                             // 6,1: N/U
+	PORT_BIT(IOP_MASK(2) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                             // 6,2: N/U
+	PORT_BIT(IOP_MASK(3) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_F6) PORT_CHAR(UCHAR_MAMEKEY(F6)) PORT_NAME("k6")                        // 6,3: k6
+	PORT_BIT(IOP_MASK(4) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_LEFT) PORT_CHAR(UCHAR_MAMEKEY(LEFT))                                    // 6,4: Left
+	PORT_BIT(IOP_MASK(5) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_BACKSPACE) PORT_CHAR(8)                                                 // 6,5: Back space
+	PORT_BIT(IOP_MASK(6) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("PRT ALL")                                                                      // 6,6: Prtall
+	PORT_BIT(IOP_MASK(7) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_COMMA_PAD) PORT_CHAR(UCHAR_MAMEKEY(COMMA_PAD))                          // 6,7: KP ,
+	PORT_BIT(IOP_MASK(8) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_6_PAD) PORT_CHAR(UCHAR_MAMEKEY(6_PAD))                                  // 6,8: KP 6
+	PORT_BIT(IOP_MASK(9) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("Keypad )")                                                                     // 6,9: KP )
+	PORT_BIT(IOP_MASK(10) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_7) PORT_CHAR('7') PORT_CHAR('&')                                       // 6,10: 7
+	PORT_BIT(IOP_MASK(11) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_COLON) PORT_CHAR(';') PORT_CHAR(':')                                   // 6,11: ;
+	PORT_BIT(IOP_MASK(12) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_K) PORT_CHAR('k') PORT_CHAR('K')                                       // 6,12: K
+	PORT_BIT(IOP_MASK(13) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_U) PORT_CHAR('u') PORT_CHAR('U')                                       // 6,13: U
+	PORT_BIT(IOP_MASK(14) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_J) PORT_CHAR('j') PORT_CHAR('J')                                       // 6,14: J
+	PORT_BIT(IOP_MASK(15) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                            // 6,15: N/U
+	PORT_BIT(IOP_MASK(16) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                            // 7,0: N/U
+	PORT_BIT(IOP_MASK(17) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                            // 7,1: N/U
+	PORT_BIT(IOP_MASK(18) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                            // 7,2: N/U
+	PORT_BIT(IOP_MASK(19) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_F7) PORT_CHAR(UCHAR_MAMEKEY(F7)) PORT_NAME("k7")                       // 7,3: k7
+	PORT_BIT(IOP_MASK(20) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_RIGHT) PORT_CHAR(UCHAR_MAMEKEY(RIGHT))                                 // 7,4: Right
+	PORT_BIT(IOP_MASK(21) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("RUN")                                                                         // 7,5: Run
+	PORT_BIT(IOP_MASK(22) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("CLR I/O")                                                                     // 7,6: Clr I/O
+	PORT_BIT(IOP_MASK(23) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_PLUS_PAD) PORT_CHAR(UCHAR_MAMEKEY(PLUS_PAD))                           // 7,7: KP +
+	PORT_BIT(IOP_MASK(24) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_ASTERISK) PORT_CHAR(UCHAR_MAMEKEY(ASTERISK))                           // 7,8: KP *
+	PORT_BIT(IOP_MASK(25) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_NAME("Keypad ^")                                                                    // 7.9: KP ^
+	PORT_BIT(IOP_MASK(26) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_8) PORT_CHAR('8') PORT_CHAR('*')                                       // 7,10: 8
+	PORT_BIT(IOP_MASK(27) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_QUOTE) PORT_CHAR('\'') PORT_CHAR('"')                                  // 7,11: '
+	PORT_BIT(IOP_MASK(28) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_L) PORT_CHAR('l') PORT_CHAR('L')                                       // 7,12: L
+	PORT_BIT(IOP_MASK(29) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_I) PORT_CHAR('i') PORT_CHAR('I')                                       // 7,13: I
+	PORT_BIT(IOP_MASK(30) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_M) PORT_CHAR('m') PORT_CHAR('M')                                       // 7,14: M
+	PORT_BIT(IOP_MASK(31) , IP_ACTIVE_HIGH , IPT_UNUSED)                                                                                            // 7,15: N/U
+
+	PORT_START("KEY_SHIFT")
+	PORT_BIT(IOP_MASK(0) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_LSHIFT) PORT_CHAR(UCHAR_SHIFT_1) // Left and right Shift
+	PORT_BIT(IOP_MASK(1) , IP_ACTIVE_HIGH , IPT_KEYBOARD) PORT_CODE(KEYCODE_LCONTROL) PORT_CHAR(UCHAR_SHIFT_2) // Control
+
+	PORT_START("DIAL")
+	PORT_BIT(0xff, 0x00, IPT_DIAL) PORT_SENSITIVITY(30) PORT_KEYDELTA(15)
+
+INPUT_PORTS_END
+
+ioport_constructor hp98x6_upi_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME(hp98x6_upi_ports);
+}
+
+void hp98x6_upi_device::device_start()
+{
+	save_item(NAME(m_ram));
+	save_item(NAME(m_data_in));
+	save_item(NAME(m_data_out));
+	save_item(NAME(m_status));
+	save_item(NAME(m_ready));
+}
+
+void hp98x6_upi_device::device_reset()
+{
+	m_irq1_write_func(true);
+	m_irq7_write_func(false);
+
+	m_last_dial = m_dial->read();
+	m_beep->set_state(0);
+	m_ram[ RAM_POS_0_R2_FLAGS1 ] = 0;
+	// Mask out all interrupts
+	m_ram[ RAM_POS_0_R4_FLAGS2 ] =
+		BIT_MASK<uint8_t>(R4_FLAGS2_FHS_MASK_BIT) |
+		BIT_MASK<uint8_t>(R4_FLAGS2_PSI_MASK_BIT) |
+		BIT_MASK<uint8_t>(R4_FLAGS2_TMR_MASK_BIT) |
+		BIT_MASK<uint8_t>(R4_FLAGS2_RST_MASK_BIT) |
+		BIT_MASK<uint8_t>(R4_FLAGS2_KEY_MASK_BIT);
+	m_ram[ RAM_POS_0_R5_FLAGS3 ] = 0;
+	m_ram[ RAM_POS_0_R6_ROLLOVER ] = SCANCODE_NONE;
+	m_ram[ RAM_POS_0_R7_KEY_DOWN ] = SCANCODE_NONE;
+	// Assume RESET key is down
+	m_ram[ RAM_POS_RST_DEB_CNT ] = R2_FLAGS1_DEB_INIT;
+	// PROM is present
+	m_ram[ RAM_POS_CFG_JUMPERS ] = BIT_MASK<uint8_t>(CFG_JUMPERS_PROM_BIT);
+	// Assume US English
+	m_ram[ RAM_POS_LNG_JUMPERS ] = 0;
+	m_ram[ RAM_POS_1_R3_TIMER_STS ] = 0;
+	m_ram[ RAM_POS_1_R4_RPG_COUNT ] = 0;
+	m_ram[ RAM_POS_1_R5_W_PTR ] = 0;
+	m_ram[ RAM_POS_READING_PROM ] = 0;
+
+	// Note that RAM is not cleared to avoid losing TOD after an UPI reset
+
+	m_status = 0;
+	m_ready = false;
+	m_fsm_state = FSM_ST::ST_POR_TEST1;
+	m_delay_timer->adjust(clocks_to_attotime(POR_DELAY1));
+	m_input_delay_timer->reset();
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER(hp98x6_upi_device::ten_ms)
+{
+	ten_ms_update_key();
+	ten_ms_update_dial();
+	ten_ms_update_timers();
+	ten_ms_update_beep();
+	try_output();
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER(hp98x6_upi_device::delay)
+{
+	switch (m_fsm_state) {
+	case FSM_ST::ST_POR_TEST1:
+		m_irq1_write_func(false);
+		m_fsm_state = FSM_ST::ST_POR_TEST2;
+		m_delay_timer->adjust(clocks_to_attotime(POR_DELAY2));
+		break;
+
+	case FSM_ST::ST_POR_TEST2:
+		write_ob_st(POST_BYTE, ST_POST_OK);
+		m_fsm_state = FSM_ST::ST_IDLE;
+		update_fsm();
+		break;
+
+	case FSM_ST::ST_RESETTING:
+		// Send NMI to 68k
+		m_irq7_write_func(true);
+		// F0 = 0 means "NMI from RESET key"
+		BIT_CLR(m_status, STATUS_F0_BIT);
+		m_fsm_state = FSM_ST::ST_IDLE;
+		update_fsm();
+		break;
+
+	default:
+		break;
+	}
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER(hp98x6_upi_device::input_delay)
+{
+	m_ready = true;
+	update_fsm();
+}
+
+void hp98x6_upi_device::write_ob_st(uint8_t data, uint8_t st)
+{
+	LOG("UPI out %02x ST=%02x\n", data, st);
+	m_data_out = data;
+	BIT_SET(m_status, STATUS_OBF_BIT);
+	m_irq1_write_func(true);
+	m_status = (m_status & 0x0f) | (st & 0xf0);
+}
+
+bool hp98x6_upi_device::read_ib(uint8_t &data)
+{
+	data = m_data_in;
+	bool res = BIT(m_status, STATUS_IBF_BIT);
+	BIT_CLR(m_status, STATUS_IBF_BIT);
+	return res;
+}
+
+void hp98x6_upi_device::update_fsm()
+{
+	uint8_t in_data;
+
+	// Check for incoming command or data
+	if (m_fsm_state == FSM_ST::ST_IDLE &&
+		m_ready &&
+		read_ib(in_data)) {
+		if (BIT(m_status, STATUS_F1_BIT)) {
+			// Command
+			LOG("UPI cmd %02x\n", in_data);
+			decode_cmd(in_data);
+		} else if (m_ram[ RAM_POS_1_R5_W_PTR ]) {
+			// Data
+			LOG("UPI data %02x\n", in_data);
+			uint8_t w_ptr = m_ram[ RAM_POS_1_R5_W_PTR ];
+			if (w_ptr >= RAM_POS_TOD_1 && w_ptr <= RAM_POS_TOD_3) {
+				// Data written to TOD are summed in, not just stored
+				uint8_t inc[] = { 0, 0, 0 };
+				inc[ w_ptr - RAM_POS_TOD_1 ] = in_data;
+				(void)add_to_ctr(RAM_POS_TOD_1, 3, inc);
+			} else {
+				m_ram[ w_ptr ] = in_data;
+			}
+			// Additional actions triggered by writing at the end of
+			// various counters
+			switch (w_ptr) {
+			case RAM_POS_BEEP_FREQ:
+				// Start/stop beep
+				if (in_data != 0) {
+					m_beep->set_clock((clock() * in_data) / BEEP_SCALING);
+					m_beep->set_state(1);
+					BIT_SET(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_BEEP_BIT);
+				} else {
+					m_beep->set_state(0);
+					BIT_CLR(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_BEEP_BIT);
+				}
+				break;
+			case RAM_POS_RPG_INT_RATE:
+				m_ram[ RAM_POS_RPG_TIMER ] = m_ram[ RAM_POS_RPG_INT_RATE ];
+				break;
+			case RAM_POS_FHS_2:
+				BIT_SET(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_FHS_BIT);
+				break;
+			case RAM_POS_MATCH_3:
+				BIT_SET(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_MATCH_BIT);
+				break;
+			case RAM_POS_DELAY_3:
+				BIT_SET(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_DELAY_BIT);
+				break;
+			case RAM_POS_CYCLE_3:
+				BIT_SET(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_CYCLE_BIT);
+				m_ram[ RAM_POS_CYCLE_SAVE_1 ] = m_ram[ RAM_POS_CYCLE_1 ];
+				m_ram[ RAM_POS_CYCLE_SAVE_2 ] = m_ram[ RAM_POS_CYCLE_2 ];
+				m_ram[ RAM_POS_CYCLE_SAVE_3 ] = m_ram[ RAM_POS_CYCLE_3 ];
+				break;
+			}
+
+			// Increment write pointer
+			w_ptr++;
+			if (w_ptr > 0x3f) {
+				LOG("Write pointer overflow\n");
+			} else {
+				m_ram[ RAM_POS_1_R5_W_PTR ] = w_ptr;
+			}
+		} else {
+			// Not writing, data not expected
+			LOG("Unexpected data %02x\n", in_data);
+		}
+		// Try to send anything that's waiting to be sent
+		try_output();
+	}
+}
+
+void hp98x6_upi_device::decode_cmd(uint8_t cmd)
+{
+	// Not writing to RAM unless we get the write command
+	m_ram[ RAM_POS_1_R5_W_PTR ] = 0;
+
+	// Decode command categories first
+	switch (cmd & CMD_MASK) {
+	case CMD_RD_RAM_LOW:
+		// 000x'xxxx
+		// Read low RAM
+		m_ram[ RAM_POS_1_R6_R_PTR ] = cmd & CMD_PARAM;
+		// Read from ID PROM when enabled
+		if (m_ram[ RAM_POS_READING_PROM ] &&
+			m_ram[ RAM_POS_1_R6_R_PTR ] == RAM_POS_0_R1) {
+			m_ram[ RAM_POS_0_R1 ] = id_prom[ m_ram[ RAM_POS_PROM_ADDR ] ];
+			LOG("PROM @%02x=%02x\n", m_ram[ RAM_POS_PROM_ADDR ], m_ram[ RAM_POS_0_R1 ]);
+			m_ram[ RAM_POS_PROM_ADDR ]++;
+		}
+		BIT_SET(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_READ_BIT);
+		break;
+	case CMD_RD_RAM_HIGH:
+		// 001x'xxxx
+		// Read high RAM
+		{
+			unsigned idx = RAM_POS_HIGH_RAM_START - 4 + (cmd & CMD_PARAM);
+			m_ram[ RAM_POS_OUT_BUFF_1 ] = m_ram[ idx++ ];
+			m_ram[ RAM_POS_OUT_BUFF_2 ] = m_ram[ idx++ ];
+			m_ram[ RAM_POS_OUT_BUFF_3 ] = m_ram[ idx++ ];
+			m_ram[ RAM_POS_OUT_BUFF_4 ] = m_ram[ idx++ ];
+			m_ram[ RAM_POS_OUT_BUFF_5 ] = m_ram[ idx ];
+		}
+		break;
+	case CMD_SET_INT_MASK:
+		// 010x'xxxx
+		// Set interrupt mask
+		m_ram[ RAM_POS_0_R4_FLAGS2 ] &= ~CMD_PARAM;
+		m_ram[ RAM_POS_0_R4_FLAGS2 ] |= (cmd & CMD_PARAM);
+		try_fhs_output();
+		break;
+	case CMD_WR_RAM_HIGH:
+		// 101x'xxxx
+		// Write high RAM
+		m_ram[ RAM_POS_1_R5_W_PTR ] = RAM_POS_HIGH_RAM_START + (cmd & CMD_PARAM);
+		break;
+	default:
+		// Decode single commands
+		switch (cmd) {
+		case CMD_RD_PROM_START:
+			// 1100'0001
+			// Start reading ID PROM
+			LOG("Start PROM read\n");
+			m_ram[ RAM_POS_READING_PROM ] = 1;
+			m_ram[ RAM_POS_PROM_ADDR ] = 0;
+			break;
+		case CMD_RD_PROM_STOP:
+			// 1100'0000
+			// Stop reading ID PROM
+			LOG("Stop PROM read\n");
+			m_ram[ RAM_POS_READING_PROM ] = 0;
+			break;
+		default:
+			LOG("Unknown UPI cmd %02x\n", cmd);
+			break;
+		}
+	}
+
+	// Then decode write commands that require additional actions
+	switch (m_ram[ RAM_POS_1_R5_W_PTR ]) {
+	case RAM_POS_TOD_1:
+		// Set time-of-day
+		m_ram[ RAM_POS_TOD_1 ] = 0;
+		m_ram[ RAM_POS_TOD_2 ] = 0;
+		m_ram[ RAM_POS_TOD_3 ] = 0;
+		break;
+	case RAM_POS_DAY_1 - 1:
+		// Set day
+		m_ram[ RAM_POS_1_R5_W_PTR ] = RAM_POS_DAY_1;
+		break;
+	case RAM_POS_FHS_1:
+		// Set FHS
+		BIT_CLR(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_FHS_BIT);
+		BIT_CLR(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_FHS_BIT);
+		m_irq7_write_func(false);
+		break;
+	case RAM_POS_MATCH_1:
+		BIT_CLR(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_MATCH_BIT);
+		BIT_CLR(m_ram[ RAM_POS_1_R3_TIMER_STS ], R3_TIMER_STS_MATCH_BIT);
+		if ((m_ram[ RAM_POS_1_R3_TIMER_STS ] & R3_TIMER_STS_INT_MASK) == 0) {
+			BIT_CLR(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_USER_TMR_BIT);
+		}
+		break;
+	case RAM_POS_DELAY_1:
+		BIT_CLR(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_DELAY_BIT);
+		BIT_CLR(m_ram[ RAM_POS_1_R3_TIMER_STS ], R3_TIMER_STS_DELAY_BIT);
+		if ((m_ram[ RAM_POS_1_R3_TIMER_STS ] & R3_TIMER_STS_INT_MASK) == 0) {
+			BIT_CLR(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_USER_TMR_BIT);
+		}
+		break;
+	case RAM_POS_CYCLE_1:
+		BIT_CLR(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_CYCLE_BIT);
+		m_ram[ RAM_POS_1_R3_TIMER_STS ] &= ~(R3_TIMER_STS_MISSED_CYCLES_MASK |
+											 BIT_MASK<uint8_t>(R3_TIMER_STS_CYCLE_BIT));
+		if ((m_ram[ RAM_POS_1_R3_TIMER_STS ] & R3_TIMER_STS_INT_MASK) == 0) {
+			BIT_CLR(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_USER_TMR_BIT);
+		}
+		break;
+	}
+}
+
+bool hp98x6_upi_device::add_to_ctr(unsigned ram_idx, unsigned len, const uint8_t *op)
+{
+	unsigned carry = 0;
+
+	for (unsigned i = ram_idx; i < ram_idx + len; i++) {
+		unsigned sum = unsigned(m_ram[ i ]) + carry + *op++;
+		if (sum < 256) {
+			carry = 0;
+			m_ram[ i ] = uint8_t(sum);
+		} else {
+			carry = 1;
+			m_ram[ i ] = uint8_t(sum - 256);
+		}
+	}
+
+	return bool(carry);
+}
+
+void hp98x6_upi_device::ten_ms_update_key()
+{
+	// Acquire shift & control (note that bits in R5_FLAGS3 are inverted)
+	if (BIT(m_shift->read(), 0)) {
+		BIT_CLR(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_SHIFT_UP_BIT);
+	} else {
+		BIT_SET(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_SHIFT_UP_BIT);
+	}
+	if (BIT(m_shift->read(), 1)) {
+		BIT_CLR(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_CTRL_UP_BIT);
+	} else {
+		BIT_SET(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_CTRL_UP_BIT);
+	}
+
+	// Scan keyboard
+	ioport_value keys[ 4 ];
+	acquire_keys(keys);
+
+	for (uint8_t idx = MIN_SCANCODE; idx <= MAX_SCANCODE; idx++) {
+		if (is_key_down(keys, idx)) {
+			// Check for RESET key combo
+			if (!BIT(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_SHIFT_UP_BIT) &&
+				idx == PAUSE_SCANCODE) {
+				if (m_ram[ RAM_POS_RST_DEB_CNT ] == 0 &&
+					!BIT(m_ram[ RAM_POS_0_R4_FLAGS2 ], R4_FLAGS2_RST_MASK_BIT)) {
+					// RESET key pressed: start delay to interrupt 68k
+					LOG("Reset pressed\n");
+					m_fsm_state = FSM_ST::ST_RESETTING;
+					m_delay_timer->adjust(clocks_to_attotime(RESET_DELAY));
+					// Reset cancels FHS timer
+					BIT_CLR(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_FHS_BIT);
+					BIT_CLR(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_FHS_BIT);
+				}
+				m_ram[ RAM_POS_RST_DEB_CNT ] = R2_FLAGS1_DEB_INIT;
+			} else if (idx != m_ram[ RAM_POS_0_R7_KEY_DOWN ]) {
+				if (m_ram[ RAM_POS_0_R7_KEY_DOWN ] == SCANCODE_NONE) {
+					// New key is down
+					LOG("Key %02x\n", idx);
+					set_new_key(idx);
+				} else if (m_ram[ RAM_POS_0_R6_ROLLOVER ] == SCANCODE_NONE) {
+					// Save roll-over key
+					LOG("Rollover key %02x\n", idx);
+					m_ram[ RAM_POS_0_R6_ROLLOVER ] = idx;
+				}
+			} else {
+				// Key kept down, reload debounce counter
+				m_ram[ RAM_POS_0_R2_FLAGS1 ] = (m_ram[ RAM_POS_0_R2_FLAGS1 ] & ~R2_FLAGS1_DEB_MASK) | R2_FLAGS1_DEB_INIT;
+			}
+		}
+	}
+
+	// Debounce RESET key
+	if (m_ram[ RAM_POS_RST_DEB_CNT ] != 0) {
+		m_ram[ RAM_POS_RST_DEB_CNT ]--;
+	}
+
+	// Debounce, auto-repeat and roll-over
+	if (m_ram[ RAM_POS_0_R7_KEY_DOWN ] != SCANCODE_NONE) {
+		// Do debouncing
+		m_ram[ RAM_POS_0_R2_FLAGS1 ]--;
+		if ((m_ram[ RAM_POS_0_R2_FLAGS1 ] & R2_FLAGS1_DEB_MASK) != 0) {
+			// Key still down
+			m_ram[ RAM_POS_AR_TIMER ]++;
+			if (m_ram[ RAM_POS_AR_TIMER ] == 0) {
+				// Repeat key if A/R is enabled
+				m_ram[ RAM_POS_AR_TIMER ] = m_ram[ RAM_POS_AR_RATE ];
+				if (m_ram[ RAM_POS_AR_RATE ]) {
+					LOG("A/R key %02x\n", m_ram[ RAM_POS_0_R7_KEY_DOWN ]);
+					BIT_SET(m_ram[ RAM_POS_0_R4_FLAGS2 ], R4_FLAGS2_AR_BIT);
+				}
+			}
+			// Key is up & debounced, get roll-over key (if any)
+		} else if (m_ram[ RAM_POS_0_R6_ROLLOVER ] != SCANCODE_NONE) {
+			LOG("Shift rollover key %02x\n", m_ram[ RAM_POS_0_R6_ROLLOVER ]);
+			set_new_key(m_ram[ RAM_POS_0_R6_ROLLOVER ]);
+			m_ram[ RAM_POS_0_R6_ROLLOVER ] = SCANCODE_NONE;
+		} else {
+			m_ram[ RAM_POS_0_R7_KEY_DOWN ] = SCANCODE_NONE;
+			BIT_CLR(m_ram[ RAM_POS_0_R4_FLAGS2 ], R4_FLAGS2_AR_BIT);
+		}
+	}
+}
+
+void hp98x6_upi_device::ten_ms_update_dial()
+{
+	ioport_value dial = m_dial->read();
+	if (dial != m_last_dial) {
+		uint8_t diff = uint8_t(m_last_dial) - uint8_t(dial);
+		int diff_int = int(diff);
+		// Sign extension
+		if (BIT(diff_int, 7)) {
+			diff_int -= 256;
+		}
+		LOG("DIAL %d\n", diff_int);
+		int pos = int(m_ram[ RAM_POS_1_R4_RPG_COUNT ]);
+		// Sign extension
+		if (BIT(pos, 7)) {
+			pos -= 256;
+		}
+		pos += diff_int;
+		// clamp pos between [-128 .. +127]
+		if (pos < -128) {
+			pos = -128;
+		} else if (pos > 127) {
+			pos = 127;
+		}
+
+		m_ram[ RAM_POS_1_R4_RPG_COUNT ] = uint8_t(pos);
+		m_last_dial = dial;
+	}
+
+	if (--m_ram[ RAM_POS_RPG_TIMER ] == 0) {
+		// Dial timer expired
+		m_ram[ RAM_POS_RPG_TIMER ] = m_ram[ RAM_POS_RPG_INT_RATE ];
+		if (m_ram[ RAM_POS_1_R4_RPG_COUNT ]) {
+			// Time to send dial movement to 68k
+			BIT_SET(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_RPG_BIT);
+		}
+	}
+}
+
+void hp98x6_upi_device::ten_ms_update_timers()
+{
+	// 10-ms timer is up
+	BIT_SET(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_PSI_BIT);
+
+	// Advance TOD
+	uint8_t one[] = { 1, 0, 0 };
+	(void)add_to_ctr(RAM_POS_TOD_1, 3, one);
+	// Check for one full day of counting
+	if (m_ram[ RAM_POS_TOD_3 ] > TOD_3_ONE_DAY ||
+		(m_ram[ RAM_POS_TOD_3 ] == TOD_3_ONE_DAY &&
+		 (m_ram[ RAM_POS_TOD_2 ] > TOD_2_ONE_DAY ||
+		  (m_ram[ RAM_POS_TOD_2 ] == TOD_2_ONE_DAY &&
+		   m_ram[ RAM_POS_TOD_1 ] >= TOD_1_ONE_DAY)))) {
+		// Clear TOD and advance DAY counter
+		m_ram[ RAM_POS_TOD_1 ] = 0;
+		m_ram[ RAM_POS_TOD_2 ] = 0;
+		m_ram[ RAM_POS_TOD_3 ] = 0;
+		(void)add_to_ctr(RAM_POS_DAY_1, 2, one);
+	}
+
+	// Check if "match" timer matches TOD
+	if (BIT(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_MATCH_BIT) &&
+		m_ram[ RAM_POS_TOD_1 ] == m_ram[ RAM_POS_MATCH_1 ] &&
+		m_ram[ RAM_POS_TOD_2 ] == m_ram[ RAM_POS_MATCH_2 ] &&
+		m_ram[ RAM_POS_TOD_3 ] == m_ram[ RAM_POS_MATCH_3 ]) {
+		BIT_SET(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_USER_TMR_BIT);
+		BIT_SET(m_ram[ RAM_POS_1_R3_TIMER_STS ], R3_TIMER_STS_MATCH_BIT);
+		// Match timer is self-canceling
+		BIT_CLR(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_MATCH_BIT);
+	}
+
+	// Update FHS timer
+	if (BIT(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_FHS_BIT) &&
+		add_to_ctr(RAM_POS_FHS_1, 2, one)) {
+		BIT_SET(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_FHS_BIT);
+		// Is the FHS timer self-canceling?
+		try_fhs_output();
+	}
+
+	// Update cyclic timer
+	if (BIT(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_CYCLE_BIT) &&
+		add_to_ctr(RAM_POS_CYCLE_1, 3, one)) {
+		if (BIT(m_ram[ RAM_POS_1_R3_TIMER_STS ], R3_TIMER_STS_CYCLE_BIT) &&
+			(m_ram[ RAM_POS_1_R3_TIMER_STS ] & R3_TIMER_STS_MISSED_CYCLES_MASK) != R3_TIMER_STS_MISSED_CYCLES_MASK) {
+			// Increment number of missed cycle interrupts
+			m_ram[ RAM_POS_1_R3_TIMER_STS ]++;
+		}
+		BIT_SET(m_ram[ RAM_POS_1_R3_TIMER_STS ], R3_TIMER_STS_CYCLE_BIT);
+		BIT_SET(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_USER_TMR_BIT);
+		// Reload timer
+		m_ram[ RAM_POS_CYCLE_1 ] = m_ram[ RAM_POS_CYCLE_SAVE_1 ];
+		m_ram[ RAM_POS_CYCLE_2 ] = m_ram[ RAM_POS_CYCLE_SAVE_2 ];
+		m_ram[ RAM_POS_CYCLE_3 ] = m_ram[ RAM_POS_CYCLE_SAVE_3 ];
+	}
+
+	// Update delay timer
+	if (BIT(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_DELAY_BIT) &&
+		add_to_ctr(RAM_POS_DELAY_1, 3, one)) {
+		BIT_SET(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_USER_TMR_BIT);
+		BIT_SET(m_ram[ RAM_POS_1_R3_TIMER_STS ], R3_TIMER_STS_DELAY_BIT);
+		// Is the delay timer self-canceling?
+	}
+}
+
+void hp98x6_upi_device::ten_ms_update_beep()
+{
+	if (BIT(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_BEEP_BIT) &&
+		++m_ram[ RAM_POS_BEEP_TIMER ] == 0) {
+		m_beep->set_state(0);
+		BIT_CLR(m_ram[ RAM_POS_0_R2_FLAGS1 ], R2_FLAGS1_BEEP_BIT);
+	}
+}
+
+void hp98x6_upi_device::set_new_key(uint8_t scancode)
+{
+	m_ram[ RAM_POS_0_R7_KEY_DOWN ] = scancode;
+	// Trigger output of key
+	BIT_SET(m_ram[ RAM_POS_0_R4_FLAGS2 ], R4_FLAGS2_AR_BIT);
+	// Set A/R delay counter
+	m_ram[ RAM_POS_AR_TIMER ] = m_ram[ RAM_POS_AR_WAIT ];
+	// Load debounce counter
+	m_ram[ RAM_POS_0_R2_FLAGS1 ] = (m_ram[ RAM_POS_0_R2_FLAGS1 ] & ~R2_FLAGS1_DEB_MASK) | R2_FLAGS1_DEB_INIT;
+}
+
+void hp98x6_upi_device::acquire_keys(ioport_value input[ 4 ])
+{
+	// Search for longest sequence among pressed keys
+	int max_len = 0;
+	unsigned n_pressed = 0;
+	for (unsigned i = 0; i < 4; i++) {
+		input[ i ] = m_keys[ i ]->read();
+		auto w = input[ i ];
+		while (w) {
+			auto mask = BIT_MASK<ioport_value>(31 - count_leading_zeros_32(w));
+			auto len = m_keys[ i ]->field(mask)->seq().length();
+			if (len > max_len) {
+				max_len = len;
+			}
+			w &= ~mask;
+			n_pressed++;
+		}
+	}
+	// Filter out pressed keys with sequences shorter than the longest one
+	if (n_pressed > 1) {
+		for (unsigned i = 0; i < 4; i++) {
+			auto w = input[ i ];
+			while (w) {
+				auto mask = BIT_MASK<ioport_value>(31 - count_leading_zeros_32(w));
+				auto len = m_keys[ i ]->field(mask)->seq().length();
+				if (len < max_len) {
+					input[ i ] &= ~mask;
+				}
+				w &= ~mask;
+			}
+		}
+	}
+}
+
+bool hp98x6_upi_device::is_key_down(const ioport_value input[ 4 ], uint8_t idx)
+{
+	unsigned row = idx % 8;
+	unsigned col = idx / 8;
+	return BIT(input[ row / 2 ], col + ((row & 1) << 4));
+}
+
+uint8_t hp98x6_upi_device::encode_shift_ctrl(uint8_t st) const
+{
+	if (BIT(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_CTRL_UP_BIT)) {
+		BIT_SET(st, 5);
+	}
+	if (BIT(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_SHIFT_UP_BIT)) {
+		BIT_SET(st, 4);
+	}
+	return st;
+}
+
+void hp98x6_upi_device::try_output()
+{
+	if (!BIT(m_status, STATUS_OBF_BIT)) {
+		// Key
+		if (BIT(m_ram[ RAM_POS_0_R4_FLAGS2 ], R4_FLAGS2_AR_BIT) &&
+			!BIT(m_ram[ RAM_POS_0_R4_FLAGS2 ], R4_FLAGS2_KEY_MASK_BIT)) {
+			uint8_t st = encode_shift_ctrl(ST_KEY);
+			write_ob_st(m_ram[ RAM_POS_0_R7_KEY_DOWN ], st);
+			BIT_CLR(m_ram[ RAM_POS_0_R4_FLAGS2 ], R4_FLAGS2_AR_BIT);
+			// If key output is not possible now, autorepeat bit is not cleared
+			// to try again at a later time
+		} else {
+			// PSI and/or timers
+			bool psi = BIT(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_PSI_BIT) &&
+				!BIT(m_ram[ RAM_POS_0_R4_FLAGS2 ], R4_FLAGS2_PSI_MASK_BIT);
+			bool timer = BIT(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_USER_TMR_BIT) &&
+				!BIT(m_ram[ RAM_POS_0_R4_FLAGS2 ], R4_FLAGS2_TMR_MASK_BIT);
+
+			if (psi || timer) {
+				uint8_t st = (psi ? ST_PSI : 0) | (timer ? ST_TIMER : 0);
+				write_ob_st(m_ram[ RAM_POS_1_R3_TIMER_STS ], st);
+				if (psi) {
+					BIT_CLR(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_PSI_BIT);
+				}
+				if (timer) {
+					BIT_CLR(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_USER_TMR_BIT);
+					m_ram[ RAM_POS_1_R3_TIMER_STS ] = 0;
+				}
+			} else if (BIT(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_RPG_BIT) &&
+					   !BIT(m_ram[ RAM_POS_0_R4_FLAGS2 ], R4_FLAGS2_KEY_MASK_BIT)) {
+				// Dial position
+				uint8_t st = encode_shift_ctrl(ST_RPG);
+				write_ob_st(m_ram[ RAM_POS_1_R4_RPG_COUNT ], st);
+				m_ram[ RAM_POS_1_R4_RPG_COUNT ] = 0;
+				BIT_CLR(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_RPG_BIT);
+			} else if (BIT(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_READ_BIT)) {
+				// Read data
+				write_ob_st(m_ram[ m_ram[ RAM_POS_1_R6_R_PTR ] ], ST_REQUESTED_DATA);
+				BIT_CLR(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_READ_BIT);
+			}
+		}
+	}
+}
+
+void hp98x6_upi_device::try_fhs_output()
+{
+	// Check if FHS NMI interrupt is to be raised
+	if (BIT(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_FHS_BIT) &&
+		!BIT(m_ram[ RAM_POS_0_R4_FLAGS2 ], R4_FLAGS2_FHS_MASK_BIT)) {
+		LOG("NMI from FHS\n");
+		BIT_CLR(m_ram[ RAM_POS_0_R5_FLAGS3 ], R5_FLAGS3_FHS_BIT);
+		// F0 = 1 means "NMI from FHS timer"
+		BIT_SET(m_status, STATUS_F0_BIT);
+		m_irq7_write_func(true);
+	}
+}

--- a/src/mame/hp/hp98x6_upi.h
+++ b/src/mame/hp/hp98x6_upi.h
@@ -1,0 +1,93 @@
+// license:BSD-3-Clause
+// copyright-holders:F. Ulivi
+
+// High level emulation of 8041 UPI in HP98X6 systems
+//
+// No known dump is available of this device
+//
+// A functional description is in this doc:
+// HP-1980-Theory of operation-09826-66501 & 09826-66502 mother boards
+// http://www.bitsavers.org/pdf/hp/9000_200/specs/A-09826-90315-1_9826_Mother_Board_Theory_of_Operation_Nov81.pdf
+
+#ifndef MAME_HP_HP98X6_UPI_H
+#define MAME_HP_HP98X6_UPI_H
+
+#pragma once
+
+#include "machine/timer.h"
+#include "sound/beep.h"
+#include "speaker.h"
+
+class hp98x6_upi_device : public device_t
+{
+public:
+	// construction/destruction
+	hp98x6_upi_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	uint8_t read(offs_t offset);
+	void write(offs_t offset, uint8_t data);
+
+	// Set CB for IRQ1 signal
+	auto irq1_write_cb() { return m_irq1_write_func.bind(); }
+	// Set CB for IRQ7 signal
+	auto irq7_write_cb() { return m_irq7_write_func.bind(); }
+
+protected:
+	// device-level overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+	virtual ioport_constructor device_input_ports() const override;
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+private:
+	required_ioport_array<4> m_keys;
+	required_ioport m_shift;
+	required_ioport m_dial;
+	required_device<beep_device> m_beep;
+	required_device<timer_device> m_10ms_timer;
+	required_device<timer_device> m_delay_timer;
+	required_device<timer_device> m_input_delay_timer;
+
+	devcb_write_line m_irq1_write_func;
+	devcb_write_line m_irq7_write_func;
+	uint8_t m_ram[ 64 ];
+	uint8_t m_data_in;
+	uint8_t m_data_out;
+	uint8_t m_status;
+	bool m_ready;
+	ioport_value m_last_dial;
+
+	enum class FSM_ST {
+		ST_IDLE,
+		ST_POR_TEST1,
+		ST_POR_TEST2,
+		ST_RESETTING
+	};
+
+	FSM_ST m_fsm_state;
+
+	TIMER_DEVICE_CALLBACK_MEMBER(ten_ms);
+	TIMER_DEVICE_CALLBACK_MEMBER(delay);
+	TIMER_DEVICE_CALLBACK_MEMBER(input_delay);
+
+	void write_ob_st(uint8_t data, uint8_t st);
+	bool read_ib(uint8_t &data);
+	void update_fsm();
+	void decode_cmd(uint8_t cmd);
+	bool add_to_ctr(unsigned ram_idx, unsigned len, const uint8_t *op);
+	void ten_ms_update_key();
+	void ten_ms_update_dial();
+	void ten_ms_update_timers();
+	void ten_ms_update_beep();
+	void set_new_key(uint8_t scancode);
+	void acquire_keys(ioport_value input[ 4 ]);
+	bool is_key_down(const ioport_value input[ 4 ], uint8_t idx);
+	uint8_t encode_shift_ctrl(uint8_t st) const;
+	void try_output();
+	void try_fhs_output();
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(HP98X6_UPI, hp98x6_upi_device)
+
+#endif /* MAME_HP_HP98X6_UPI_H */

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -19794,6 +19794,9 @@ hp9845t_de                      //
 @source:hp/hp9k.cpp
 hp9816                          //
 
+@source:hp/hp98x6.cpp
+hp9816a                         //
+
 @source:hp/hp9k_3xx.cpp
 hp9k310                         //
 hp9k320                         //


### PR DESCRIPTION
Hi,
with this PR I'm adding the support for HP9816A system. ROM images will follow at the usual mail address.
I got the idea to write a driver for 9816 because I stumbled on my name listed as copyright holder of `hp9k.cpp`. Here this same system was implemented but only at skeleton level. I think someone mistakenly put my name there because I never contributed a single line to that file. Do you think we should remove the old implementation?
Thanks.
--F.Ulivi
