### PR TITLE
machine/wd_fdc.cpp: lower drq at the end of track write

### DIFF
--- a/src/devices/machine/wd_fdc.cpp
+++ b/src/devices/machine/wd_fdc.cpp
@@ -919,6 +919,7 @@ void wd_fdc_device_base::write_track_continue()
 				format_description_string += buf;
 			}
 			LOGDESC("track description %s\n", format_description_string.c_str());
+			drop_drq();
 			command_end();
 			return;
 


### PR DESCRIPTION
When testing formatting disks with the new MMS controller in https://github.com/mamedev/mame/pull/12413, the formatting would fail after writing the first track. The code was checking the status byte, and expecting S1 Data Request to be 0. By adding this drop_drq() at the end of the command, it allowed the formatting to complete successfully.
