### PR TITLE
seibu/sei25x_rise1x_spr.cpp: Device-fied SEI25x/RISE1x sprite hardware, Cleanups

### DIFF
--- a/src/mame/seibu/r2crypt.cpp
+++ b/src/mame/seibu/r2crypt.cpp
@@ -217,7 +217,7 @@ static uint32_t core_decrypt(uint32_t ciphertext, int i1, int i2, int i3, int i4
 
 void raiden2_decrypt_sprites(running_machine &machine)
 {
-	uint32_t *data = (uint32_t *)machine.root_device().memregion("gfx3")->base();
+	uint32_t *data = (uint32_t *)machine.root_device().memregion("sprites")->base();
 	for(int i=0; i<0x800000/4; i++)
 	{
 		data[i] = core_decrypt(data[i],
@@ -237,7 +237,7 @@ void raiden2_decrypt_sprites(running_machine &machine)
 
 void zeroteam_decrypt_sprites(running_machine &machine)
 {
-	uint32_t *data = (uint32_t *)machine.root_device().memregion("gfx3")->base();
+	uint32_t *data = (uint32_t *)machine.root_device().memregion("sprites")->base();
 	for(int i=0; i<0x400000/4; i++)
 	{
 		data[i] = core_decrypt(data[i],

--- a/src/mame/seibu/r2dx_v33.cpp
+++ b/src/mame/seibu/r2dx_v33.cpp
@@ -77,28 +77,25 @@ Then it puts settings at 0x9e08 and 0x9e0a (bp 91acb)
 
 namespace {
 
-class r2dx_v33_state : public raiden2_state
+class nzerotea_state : public raiden2_state
 {
 public:
-	r2dx_v33_state(const machine_config &mconfig, device_type type, const char *tag) :
+	nzerotea_state(const machine_config &mconfig, device_type type, const char *tag) :
 		raiden2_state(mconfig, type, tag),
-		m_r2dxbank(0),
-		m_r2dxgameselect(0),
 		m_eeprom(*this, "eeprom"),
-		m_math(*this, "math"),
-		m_okibank(*this, "okibank")
+		m_math(*this, "math")
 	{
 	}
 
 	void nzerotea(machine_config &config);
-	void rdx_v33(machine_config &config);
 	void zerotm2k(machine_config &config);
 
-	void init_rdx_v33();
 	void init_nzerotea();
 	void init_zerotm2k();
 
-private:
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
 
 	void angle_w(offs_t offset, u16 data, u16 mem_mask);
 	void dx_w(offs_t offset, u16 data, u16 mem_mask);
@@ -110,7 +107,6 @@ private:
 	u16 sin_r();
 	u16 cos_r();
 
-	void tile_bank_w(u8 data);
 	[[maybe_unused]] u16 rdx_v33_unknown_r();
 	[[maybe_unused]] void mcu_xval_w(u16 data);
 	[[maybe_unused]] void mcu_yval_w(u16 data);
@@ -119,49 +115,69 @@ private:
 	void mcu_prog_w(u16 data);
 	void mcu_prog_w2(u16 data);
 	void mcu_prog_offs_w(u16 data);
-	void rdx_v33_eeprom_w(u8 data);
 	void zerotm2k_eeprom_w(u16 data);
-	void r2dx_rom_bank_w(u16 data);
 
 	void tilemapdma_w(address_space &space, u16 data);
 	void paldma_w(address_space &space, u16 data);
-	u16 r2dx_debug_r();
-
-	DECLARE_MACHINE_RESET(r2dx_v33);
-	DECLARE_MACHINE_RESET(nzeroteam);
 
 	void nzerotea_map(address_map &map);
 	void nzeroteam_base_map(address_map &map);
-	void r2dx_oki_map(address_map &map);
-	void rdx_v33_map(address_map &map);
 	void zerotm2k_map(address_map &map);
 
-	virtual void machine_start() override;
-
-	void r2dx_setbanking();
-
-	int m_r2dxbank;
-	int m_r2dxgameselect;
-
-	u16 m_dx, m_dy, m_angle;
-	u32 m_sdist;
-	u16 m_mcu_prog[0x800];
-	int m_mcu_prog_offs;
-	u16 m_mcu_xval, m_mcu_yval;
-	u16 m_mcu_data[9];
+	u16 m_dx = 0, m_dy = 0, m_angle = 0;
+	u32 m_sdist = 0;
+	u16 m_mcu_prog[0x800]{};
+	u16 m_mcu_prog_offs = 0;
+	u16 m_mcu_xval = 0, m_mcu_yval = 0;
+	u16 m_mcu_data[9]{};
 
 	optional_device<eeprom_serial_93cxx_device> m_eeprom;
 	required_region_ptr<u8> m_math;
-
-	optional_memory_bank m_okibank;
 };
 
-void r2dx_v33_state::machine_start()
+class r2dx_v33_state : public nzerotea_state
+{
+public:
+	r2dx_v33_state(const machine_config &mconfig, device_type type, const char *tag) :
+		nzerotea_state(mconfig, type, tag),
+		m_r2dxbank(0),
+		m_r2dxgameselect(0),
+		m_gamebank(*this, "gamebank"),
+		m_okibank(*this, "okibank")
+	{
+	}
+
+	void rdx_v33(machine_config &config);
+
+	void init_rdx_v33();
+
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+private:
+	void tile_bank_w(u8 data);
+	void rdx_v33_eeprom_w(u8 data);
+	void r2dx_rom_bank_w(u16 data);
+
+	u16 r2dx_debug_r();
+
+	void r2dx_oki_map(address_map &map);
+	void rdx_v33_map(address_map &map);
+
+	void r2dx_setbanking();
+
+	u32 m_r2dxbank;
+	u32 m_r2dxgameselect;
+
+	required_memory_bank m_gamebank;
+	required_memory_bank m_okibank;
+};
+
+void nzerotea_state::machine_start()
 {
 	common_save_state();
 
-	save_item(NAME(m_r2dxbank));
-	save_item(NAME(m_r2dxgameselect));
 	save_item(NAME(m_dx));
 	save_item(NAME(m_dy));
 	save_item(NAME(m_angle));
@@ -173,17 +189,25 @@ void r2dx_v33_state::machine_start()
 	save_item(NAME(m_mcu_data));
 }
 
+void r2dx_v33_state::machine_start()
+{
+	nzerotea_state::machine_start();
+
+	save_item(NAME(m_r2dxbank));
+	save_item(NAME(m_r2dxgameselect));
+}
+
 void r2dx_v33_state::tile_bank_w(u8 data)
 {
 	int new_bank;
-	new_bank = ((data & 0x10)>>4);
+	new_bank = BIT(data, 4);
 	if (new_bank != m_bg_bank)
 	{
 		m_bg_bank = new_bank;
 		m_background_layer->mark_all_dirty();
 	}
 
-	new_bank = 2 + ((data & 0x20)>>5);
+	new_bank = 2 + BIT(data, 5);
 	if (new_bank != m_mid_bank)
 	{
 		m_mid_bank = new_bank;
@@ -200,22 +224,22 @@ void r2dx_v33_state::tile_bank_w(u8 data)
 
 void r2dx_v33_state::r2dx_setbanking()
 {
-	m_mainbank[0]->set_entry(m_r2dxgameselect*0x10 + m_r2dxbank);
-	m_mainbank[1]->set_entry(m_r2dxgameselect);
+	m_mainbank->set_entry(m_r2dxgameselect * 0x10 + m_r2dxbank);
+	m_gamebank->set_entry(m_r2dxgameselect);
 }
 
 void r2dx_v33_state::rdx_v33_eeprom_w(u8 data)
 {
-	m_eeprom->clk_write((data & 0x10) ? ASSERT_LINE : CLEAR_LINE);
-	m_eeprom->di_write((data & 0x20) >> 5);
-	m_eeprom->cs_write((data & 0x08) ? ASSERT_LINE : CLEAR_LINE);
+	m_eeprom->clk_write(BIT(data, 4) ? ASSERT_LINE : CLEAR_LINE);
+	m_eeprom->di_write(BIT(data, 5));
+	m_eeprom->cs_write(BIT(data, 3) ? ASSERT_LINE : CLEAR_LINE);
 
-	// 0x40 - coin counter 1?
-	// 0x80 - coin counter 2?
+	// BIT(data, 6) - coin counter 1?
+	// BIT(data, 7) - coin counter 2?
 
 	// 0x04 is active in Raiden DX mode, it could be part of the rom bank (which half of the rom to use) or the FG tile bank (or both?)
 	// the bit gets set if it reads RAIDENDX from the EEPROM
-	m_r2dxgameselect = (data & 0x04) >> 2;
+	m_r2dxgameselect = BIT(data, 2);
 
 	m_tx_bank = m_r2dxgameselect;
 	m_text_layer->mark_all_dirty();
@@ -225,16 +249,16 @@ void r2dx_v33_state::rdx_v33_eeprom_w(u8 data)
 	m_okibank->set_entry(data&3);
 }
 
-/* new zero team uses the copd3 protection... and uploads a 0x400 byte table, probably the mcu code, encrypted */
+// new zero team uses the copd3 protection... and uploads a 0x400 byte table, probably the mcu code, encrypted
 
-void r2dx_v33_state::mcu_prog_w(u16 data)
+void nzerotea_state::mcu_prog_w(u16 data)
 {
-	m_mcu_prog[m_mcu_prog_offs*2] = data;
+	m_mcu_prog[m_mcu_prog_offs * 2] = data;
 }
 
-void r2dx_v33_state::mcu_prog_w2(u16 data)
+void nzerotea_state::mcu_prog_w2(u16 data)
 {
-	m_mcu_prog[m_mcu_prog_offs*2+1] = data;
+	m_mcu_prog[m_mcu_prog_offs * 2 + 1] = data;
 
 	// both new zero team and raiden2/dx v33 version upload the same table..
 #if 0
@@ -253,44 +277,44 @@ void r2dx_v33_state::mcu_prog_w2(u16 data)
 #endif
 }
 
-void r2dx_v33_state::mcu_prog_offs_w(u16 data)
+void nzerotea_state::mcu_prog_offs_w(u16 data)
 {
 	m_mcu_prog_offs = data;
 }
 
-u16 r2dx_v33_state::rdx_v33_unknown_r()
+u16 nzerotea_state::rdx_v33_unknown_r()
 {
 	return machine().rand();
 }
 
 
-/* something sent to the MCU for X/Y global screen calculating ... */
-void r2dx_v33_state::mcu_xval_w(u16 data)
+// something sent to the MCU for X/Y global screen calculating ...
+void nzerotea_state::mcu_xval_w(u16 data)
 {
 	m_mcu_xval = data;
 	//popmessage("%04x %04x",m_mcu_xval,m_mcu_yval);
 }
 
-void r2dx_v33_state::mcu_yval_w(u16 data)
+void nzerotea_state::mcu_yval_w(u16 data)
 {
 	m_mcu_yval = data;
 	//popmessage("%04x %04x",m_mcu_xval,m_mcu_yval);
 }
 
 
-/* 0x400-0x407 seems some DMA hook-up, 0x420-0x427 looks like some x/y sprite calculation routine */
-void r2dx_v33_state::mcu_table_w(offs_t offset, u16 data)
+// 0x400-0x407 seems some DMA hook-up, 0x420-0x427 looks like some x/y sprite calculation routine
+void nzerotea_state::mcu_table_w(offs_t offset, u16 data)
 {
 	m_mcu_data[offset] = data;
 
 	//popmessage("%04x %04x %04x %04x | %04x %04x %04x %04x",m_mcu_data[0/2],m_mcu_data[2/2],m_mcu_data[4/2],m_mcu_data[6/2],m_mcu_data[8/2],m_mcu_data[0xa/2],m_mcu_data[0xc/2],m_mcu_data[0xe/2]);
 }
 
-void r2dx_v33_state::mcu_table2_w(offs_t offset, u16 data)
+void nzerotea_state::mcu_table2_w(offs_t offset, u16 data)
 {
 //  printf("mcu_table2_w %04x\n", data);
 
-	m_mcu_data[offset+4] = data;
+	m_mcu_data[offset + 4] = data;
 
 	//popmessage("%04x %04x %04x %04x | %04x %04x %04x %04x",m_mcu_data[0/2],m_mcu_data[2/2],m_mcu_data[4/2],m_mcu_data[6/2],m_mcu_data[8/2],m_mcu_data[0xa/2],m_mcu_data[0xc/2],m_mcu_data[0xe/2]);
 }
@@ -303,73 +327,73 @@ void r2dx_v33_state::r2dx_rom_bank_w(u16 data)
 
 }
 
-void r2dx_v33_state::angle_w(offs_t offset, u16 data, u16 mem_mask)
+void nzerotea_state::angle_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_angle);
 }
 
-void r2dx_v33_state::dx_w(offs_t offset, u16 data, u16 mem_mask)
+void nzerotea_state::dx_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_dx);
 }
 
-void r2dx_v33_state::dy_w(offs_t offset, u16 data, u16 mem_mask)
+void nzerotea_state::dy_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_dy);
 }
 
-u16 r2dx_v33_state::angle_r()
+u16 nzerotea_state::angle_r()
 {
 	return m_math[((m_dy & 0xff) << 8) | (m_dx & 0xff)];
 }
 
-u16 r2dx_v33_state::dist_r()
+u16 nzerotea_state::dist_r()
 {
 	return sqrt(double(m_sdist));
 }
 
-u16 r2dx_v33_state::sin_r()
+u16 nzerotea_state::sin_r()
 {
-	int off = 65536 + (m_angle & 0xff)*4;
-	return (m_math[off+0]) | (m_math[off+1] << 8);
+	const int off = 65536 + (m_angle & 0xff) * 4;
+	return (m_math[off + 0]) | (m_math[off + 1] << 8);
 }
 
-u16 r2dx_v33_state::cos_r()
+u16 nzerotea_state::cos_r()
 {
-	int off = 65536 + (m_angle & 0xff)*4;
-	return (m_math[off+2]) | (m_math[off+3] << 8);
+	const int off = 65536 + (m_angle & 0xff) * 4;
+	return (m_math[off + 2]) | (m_math[off + 3] << 8);
 }
 
-void r2dx_v33_state::sdistl_w(offs_t offset, u16 data, u16 mem_mask)
+void nzerotea_state::sdistl_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	m_sdist = (m_sdist & (0xffff0000 | u16(~mem_mask))) | (data & mem_mask);
 }
 
-void r2dx_v33_state::sdisth_w(offs_t offset, u16 data, u16 mem_mask)
+void nzerotea_state::sdisth_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	m_sdist = (m_sdist & (0x0000ffff | (u16(~mem_mask)) << 16)) | ((data & mem_mask) << 16);
 }
 
 // these DMA operations seem to use hardcoded addresses on this hardware
-void r2dx_v33_state::tilemapdma_w(address_space &space, u16 data)
+void nzerotea_state::tilemapdma_w(address_space &space, u16 data)
 {
 	int src = 0xd000;
 
 	for (int i = 0; i < 0x2800 / 2; i++)
 	{
-		u16 tileval = space.read_word(src);
+		const u16 tileval = space.read_word(src);
 		src += 2;
 		m_videoram_private_w(i, tileval);
 	}
 }
 
-void r2dx_v33_state::paldma_w(address_space &space, u16 data)
+void nzerotea_state::paldma_w(address_space &space, u16 data)
 {
 	int src = 0x1f000;
 
 	for (int i = 0; i < 0x1000 / 2; i++)
 	{
-		u16 palval = space.read_word(src);
+		const u16 palval = space.read_word(src);
 		src += 2;
 		m_palette->write16(i, palval);
 	}
@@ -438,51 +462,51 @@ void r2dx_v33_state::rdx_v33_map(address_map &map)
 	map(0x0d800, 0x0dfff).ram(); //.w(FUNC(r2dx_v33_state::foreground_w).share("fore_data");
 	map(0x0e000, 0x0e7ff).ram(); //.w(FUNC(r2dx_v33_state::midground_w).share("mid_data");
 	map(0x0e800, 0x0f7ff).ram(); //.w(FUNC(r2dx_v33_state::text_w).share("text_data");
-	map(0x0f800, 0x0ffff).ram(); /* Stack area */
+	map(0x0f800, 0x0ffff).ram(); // Stack area
 	map(0x10000, 0x1efff).ram();
 	map(0x1f000, 0x1ffff).ram(); //.w(m_palette, FUNC(palette_device::write16)).share("palette");
 
-	map(0x20000, 0x2ffff).bankr("mainbank1").nopw();
-	map(0x30000, 0xfffff).bankr("mainbank2").nopw();
+	map(0x20000, 0x2ffff).bankr(m_mainbank).nopw();
+	map(0x30000, 0xfffff).bankr(m_gamebank).nopw();
 }
 
 
-void r2dx_v33_state::nzeroteam_base_map(address_map &map)
+void nzerotea_state::nzeroteam_base_map(address_map &map)
 {
 	map(0x00000, 0x003ff).ram(); //stack area
 
-	map(0x00400, 0x00401).w(FUNC(r2dx_v33_state::tilemapdma_w)); // tilemaps to private buffer
-	map(0x00402, 0x00403).w(FUNC(r2dx_v33_state::paldma_w));  // palettes to private buffer
+	map(0x00400, 0x00401).w(FUNC(nzerotea_state::tilemapdma_w)); // tilemaps to private buffer
+	map(0x00402, 0x00403).w(FUNC(nzerotea_state::paldma_w));  // palettes to private buffer
 	// 0x404 is bank on r2dx, this doesn't need it
-	// map(0x00406, 0x00406).w(FUNC(r2dx_v33_state::tile_bank_w)); // not the same?
+	// map(0x00406, 0x00406).w(FUNC(nzerotea_state::tile_bank_w)); // not the same?
 
 	map(0x00406, 0x00407).noprw(); // always 6022, supposed to be the tile bank but ignores the actual value???
 
-	map(0x00420, 0x00421).w(FUNC(r2dx_v33_state::dx_w));
-	map(0x00422, 0x00423).w(FUNC(r2dx_v33_state::dy_w));
-	map(0x00424, 0x00425).w(FUNC(r2dx_v33_state::sdistl_w));
-	map(0x00426, 0x00427).w(FUNC(r2dx_v33_state::sdisth_w));
-	map(0x00428, 0x00429).w(FUNC(r2dx_v33_state::angle_w));
+	map(0x00420, 0x00421).w(FUNC(nzerotea_state::dx_w));
+	map(0x00422, 0x00423).w(FUNC(nzerotea_state::dy_w));
+	map(0x00424, 0x00425).w(FUNC(nzerotea_state::sdistl_w));
+	map(0x00426, 0x00427).w(FUNC(nzerotea_state::sdisth_w));
+	map(0x00428, 0x00429).w(FUNC(nzerotea_state::angle_w));
 
-	map(0x00430, 0x00431).r(FUNC(r2dx_v33_state::angle_r));
-	map(0x00432, 0x00433).r(FUNC(r2dx_v33_state::dist_r));
-	map(0x00434, 0x00435).r(FUNC(r2dx_v33_state::sin_r));
-	map(0x00436, 0x00437).r(FUNC(r2dx_v33_state::cos_r));
+	map(0x00430, 0x00431).r(FUNC(nzerotea_state::angle_r));
+	map(0x00432, 0x00433).r(FUNC(nzerotea_state::dist_r));
+	map(0x00434, 0x00435).r(FUNC(nzerotea_state::sin_r));
+	map(0x00436, 0x00437).r(FUNC(nzerotea_state::cos_r));
 
 	map(0x00600, 0x0063f).rw("crtc", FUNC(seibu_crtc_device::read), FUNC(seibu_crtc_device::write));
 	//map(0x00640, 0x006bf)rw("obj", FUNC(seibu_encrypted_sprite_device::read), FUNC(seibu_encrypted_sprite_device::write));
 	map(0x0068e, 0x0068f).w(m_spriteram, FUNC(buffered_spriteram16_device::write));
-	map(0x006b0, 0x006b1).w(FUNC(r2dx_v33_state::mcu_prog_w));
-	map(0x006b2, 0x006b3).w(FUNC(r2dx_v33_state::mcu_prog_w2));
+	map(0x006b0, 0x006b1).w(FUNC(nzerotea_state::mcu_prog_w));
+	map(0x006b2, 0x006b3).w(FUNC(nzerotea_state::mcu_prog_w2));
 //  map(0x006b4, 0x006b5).nopw();
 //  map(0x006b6, 0x006b7).nopw();
-	map(0x006bc, 0x006bd).w(FUNC(r2dx_v33_state::mcu_prog_offs_w));
-//  map(0x006d8, 0x006d9).w(FUNC(r2dx_v33_state::bbbbll_w)); // scroll?
-//  map(0x006dc, 0x006dd).r(FUNC(r2dx_v33_state::nzerotea_unknown_r));
-//  map(0x006de, 0x006df).w(FUNC(r2dx_v33_state::mcu_unkaa_w)); // mcu command related?
-//  map(0x00700, 0x00700).w(FUNC(r2dx_v33_state::rdx_v33_eeprom_w));
+	map(0x006bc, 0x006bd).w(FUNC(nzerotea_state::mcu_prog_offs_w));
+//  map(0x006d8, 0x006d9).w(FUNC(nzerotea_state::bbbbll_w)); // scroll?
+//  map(0x006dc, 0x006dd).r(FUNC(nzerotea_state::nzerotea_unknown_r));
+//  map(0x006de, 0x006df).w(FUNC(nzerotea_state::mcu_unkaa_w)); // mcu command related?
+//  map(0x00700, 0x00700).w(FUNC(nzerotea_state::rdx_v33_eeprom_w));
 
-//  map(0x00762, 0x00763).r(FUNC(r2dx_v33_state::nzerotea_unknown_r));
+//  map(0x00762, 0x00763).r(FUNC(nzerotea_state::nzerotea_unknown_r));
 
 	map(0x00780, 0x0079f).lrw8(
 							   NAME([this] (offs_t offset) { return m_seibu_sound->main_r(offset >> 1); }),
@@ -492,18 +516,18 @@ void r2dx_v33_state::nzeroteam_base_map(address_map &map)
 	map(0x01000, 0x0bfff).ram();
 
 	map(0x0c000, 0x0cfff).ram().share("spriteram");
-	map(0x0d000, 0x0d7ff).ram(); //.w(FUNC(r2dx_v33_state::background_w)).share("back_data");
-	map(0x0d800, 0x0dfff).ram(); //.w(FUNC(r2dx_v33_state::foreground_w)).share("fore_data");
-	map(0x0e000, 0x0e7ff).ram(); //.w(FUNC(r2dx_v33_state::midground_w)).share("mid_data");
-	map(0x0e800, 0x0f7ff).ram(); //.w(FUNC(r2dx_v33_state::text_w)).share("text_data");
-	map(0x0f800, 0x0ffff).ram(); /* Stack area */
+	map(0x0d000, 0x0d7ff).ram(); //.w(FUNC(nzerotea_state::background_w)).share("back_data");
+	map(0x0d800, 0x0dfff).ram(); //.w(FUNC(nzerotea_state::foreground_w)).share("fore_data");
+	map(0x0e000, 0x0e7ff).ram(); //.w(FUNC(nzerotea_state::midground_w)).share("mid_data");
+	map(0x0e800, 0x0f7ff).ram(); //.w(FUNC(nzerotea_state::text_w)).share("text_data");
+	map(0x0f800, 0x0ffff).ram(); // Stack area
 	map(0x10000, 0x1efff).ram();
 	map(0x1f000, 0x1ffff).ram(); //.w("palette", FUNC(palette_device::write)).share("palette");
 
 	map(0x20000, 0xfffff).rom().region("maincpu", 0x20000);
 }
 
-void r2dx_v33_state::nzerotea_map(address_map &map)
+void nzerotea_state::nzerotea_map(address_map &map)
 {
 	nzeroteam_base_map(map);
 	map(0x00740, 0x00741).portr("DSW");
@@ -511,22 +535,22 @@ void r2dx_v33_state::nzerotea_map(address_map &map)
 	map(0x0074c, 0x0074d).portr("SYSTEM");
 }
 
-void r2dx_v33_state::zerotm2k_eeprom_w(u16 data)
+void nzerotea_state::zerotm2k_eeprom_w(u16 data)
 {
 //  printf("zerotm2k_eeprom_w %04x\n", data);
 
-	m_eeprom->clk_write((data & 0x02) ? ASSERT_LINE : CLEAR_LINE);
-	m_eeprom->di_write((data & 0x04) >> 2);
-	m_eeprom->cs_write((data & 0x01) ? ASSERT_LINE : CLEAR_LINE);
+	m_eeprom->clk_write(BIT(data, 1) ? ASSERT_LINE : CLEAR_LINE);
+	m_eeprom->di_write(BIT(data, 2));
+	m_eeprom->cs_write(BIT(data, 0) ? ASSERT_LINE : CLEAR_LINE);
 }
 
-void r2dx_v33_state::zerotm2k_map(address_map &map)
+void nzerotea_state::zerotm2k_map(address_map &map)
 {
 	nzeroteam_base_map(map);
 	map(0x00740, 0x00741).portr("P3_P4");
 	map(0x00744, 0x00745).portr("INPUT");
+	map(0x00748, 0x00749).w(FUNC(nzerotea_state::zerotm2k_eeprom_w));
 	map(0x0074c, 0x0074d).portr("SYSTEM");
-	map(0x00748, 0x00749).w(FUNC(r2dx_v33_state::zerotm2k_eeprom_w));
 }
 
 
@@ -566,7 +590,7 @@ INPUT_PORTS_END
 
 
 static INPUT_PORTS_START( nzerotea )
-	SEIBU_COIN_INPUTS_INVERT    /* coin inputs read through sound cpu */
+	SEIBU_COIN_INPUTS_INVERT    // coin inputs read through sound cpu
 
 	PORT_START("SYSTEM")
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_START1 )
@@ -650,7 +674,7 @@ static INPUT_PORTS_START( nzerotea )
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( zerotm2k )
-	SEIBU_COIN_INPUTS_INVERT    /* coin inputs read through sound cpu */
+	SEIBU_COIN_INPUTS_INVERT    // coin inputs read through sound cpu
 
 	PORT_MODIFY("COIN")
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_COIN3 ) PORT_IMPULSE(4)
@@ -705,12 +729,12 @@ static INPUT_PORTS_START( zerotm2k )
 INPUT_PORTS_END
 
 
-MACHINE_RESET_MEMBER(r2dx_v33_state,r2dx_v33)
+void r2dx_v33_state::machine_reset()
 {
 	bank_reset(0,6,2,0);
 }
 
-MACHINE_RESET_MEMBER(r2dx_v33_state,nzeroteam)
+void nzerotea_state::machine_reset()
 {
 	bank_reset(0,2,1,0);
 }
@@ -722,19 +746,17 @@ void r2dx_v33_state::r2dx_oki_map(address_map &map)
 
 void r2dx_v33_state::rdx_v33(machine_config &config)
 {
-	/* basic machine hardware */
+	// basic machine hardware
 	V33(config, m_maincpu, 32000000/2); // ?
 	m_maincpu->set_addrmap(AS_PROGRAM, &r2dx_v33_state::rdx_v33_map);
 	m_maincpu->set_vblank_int("screen", FUNC(r2dx_v33_state::interrupt));
-
-	MCFG_MACHINE_RESET_OVERRIDE(r2dx_v33_state,r2dx_v33)
 
 	EEPROM_93C46_16BIT(config, m_eeprom);
 
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_video_attributes(VIDEO_UPDATE_AFTER_VBLANK);
-	screen.set_refresh_hz(55.47);    /* verified on pcb */
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(500)); /* not accurate */
+	screen.set_refresh_hz(55.47);    // verified on pcb
+	screen.set_vblank_time(ATTOSECONDS_IN_USEC(500)); // not accurate
 	screen.set_size(44*8, 34*8);
 	screen.set_visarea(0*8, 40*8-1, 0, 30*8-1);
 	screen.set_screen_update(FUNC(r2dx_v33_state::screen_update));
@@ -748,7 +770,12 @@ void r2dx_v33_state::rdx_v33(machine_config &config)
 
 	BUFFERED_SPRITERAM16(config, m_spriteram);
 
-	/* sound hardware */
+	SEI25X_RISE1X(config, m_spritegen, 0, m_palette, r2dx_v33_state::gfx_raiden2_spr);
+	m_spritegen->set_pix_raw_shift(4);
+	m_spritegen->set_pri_raw_shift(14);
+	m_spritegen->set_transpen(15);
+
+	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	okim6295_device &oki(OKIM6295(config, "oki", XTAL(28'636'363)/28, okim6295_device::PIN7_HIGH)); // clock frequency & pin 7 not verified
@@ -756,37 +783,40 @@ void r2dx_v33_state::rdx_v33(machine_config &config)
 	oki.add_route(ALL_OUTPUTS, "mono", 0.5);
 }
 
-void r2dx_v33_state::nzerotea(machine_config &config)
+void nzerotea_state::nzerotea(machine_config &config)
 {
-	/* basic machine hardware */
-	V33(config, m_maincpu, XTAL(32'000'000)/2); /* verified on pcb */
-	m_maincpu->set_addrmap(AS_PROGRAM, &r2dx_v33_state::nzerotea_map);
-	m_maincpu->set_vblank_int("screen", FUNC(r2dx_v33_state::interrupt));
-
-	MCFG_MACHINE_RESET_OVERRIDE(r2dx_v33_state,nzeroteam)
+	// basic machine hardware
+	V33(config, m_maincpu, XTAL(32'000'000)/2); // verified on pcb
+	m_maincpu->set_addrmap(AS_PROGRAM, &nzerotea_state::nzerotea_map);
+	m_maincpu->set_vblank_int("screen", FUNC(nzerotea_state::interrupt));
 
 	z80_device &audiocpu(Z80(config, "audiocpu", XTAL(28'636'363)/8));
-	audiocpu.set_addrmap(AS_PROGRAM, &r2dx_v33_state::zeroteam_sound_map);
+	audiocpu.set_addrmap(AS_PROGRAM, &nzerotea_state::zeroteam_sound_map);
 	audiocpu.set_irq_acknowledge_callback("seibu_sound", FUNC(seibu_sound_device::im0_vector_cb));
 
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_video_attributes(VIDEO_UPDATE_AFTER_VBLANK);
-	screen.set_refresh_hz(55.47);    /* verified on pcb */
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(500)); /* not accurate */
+	screen.set_refresh_hz(55.47);    // verified on pcb
+	screen.set_vblank_time(ATTOSECONDS_IN_USEC(500)); // not accurate
 	screen.set_size(44*8, 34*8);
 	screen.set_visarea(0*8, 40*8-1, 0, 32*8-1);
-	screen.set_screen_update(FUNC(r2dx_v33_state::screen_update));
+	screen.set_screen_update(FUNC(nzerotea_state::screen_update));
 
-	GFXDECODE(config, m_gfxdecode, m_palette, r2dx_v33_state::gfx_raiden2);
+	GFXDECODE(config, m_gfxdecode, m_palette, nzerotea_state::gfx_raiden2);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, 2048);
 
 	seibu_crtc_device &crtc(SEIBU_CRTC(config, "crtc", 0));
-	crtc.layer_en_callback().set(FUNC(r2dx_v33_state::tilemap_enable_w));
-	crtc.layer_scroll_callback().set(FUNC(r2dx_v33_state::tile_scroll_w));
+	crtc.layer_en_callback().set(FUNC(nzerotea_state::tilemap_enable_w));
+	crtc.layer_scroll_callback().set(FUNC(nzerotea_state::tile_scroll_w));
 
 	BUFFERED_SPRITERAM16(config, m_spriteram);
 
-	/* sound hardware */
+	SEI25X_RISE1X(config, m_spritegen, 0, m_palette, r2dx_v33_state::gfx_raiden2_spr);
+	m_spritegen->set_pix_raw_shift(4);
+	m_spritegen->set_pri_raw_shift(14);
+	m_spritegen->set_transpen(15);
+
+	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	ym3812_device &ymsnd(YM3812(config, "ymsnd", XTAL(28'636'363)/8));
@@ -804,10 +834,10 @@ void r2dx_v33_state::nzerotea(machine_config &config)
 	m_seibu_sound->ym_write_callback().set("ymsnd", FUNC(ym3812_device::write));
 }
 
-void r2dx_v33_state::zerotm2k(machine_config &config)
+void nzerotea_state::zerotm2k(machine_config &config)
 {
 	nzerotea(config);
-	m_maincpu->set_addrmap(AS_PROGRAM, &r2dx_v33_state::zerotm2k_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &nzerotea_state::zerotm2k_map);
 
 	EEPROM_93C46_16BIT(config, m_eeprom);
 }
@@ -818,22 +848,22 @@ void r2dx_v33_state::init_rdx_v33()
 	static const int spri[5] = { 0, 1, 2, 3, -1 };
 	m_cur_spri = spri;
 
-	m_mainbank[0]->configure_entries(   0, 0x10, memregion("maincpu")->base() + 0x100000, 0x010000); // 0x20000 - 0x2ffff bank for Raiden 2
-	m_mainbank[0]->configure_entries(0x10, 0x10, memregion("maincpu")->base() + 0x300000, 0x010000); // 0x20000 - 0x2ffff bank for Raiden DX
-	m_mainbank[1]->configure_entries(   0,    2, memregion("maincpu")->base() + 0x030000, 0x200000);
+	m_mainbank->configure_entries(   0, 0x10, memregion("maincpu")->base() + 0x100000, 0x010000); // 0x20000 - 0x2ffff bank for Raiden 2
+	m_mainbank->configure_entries(0x10, 0x10, memregion("maincpu")->base() + 0x300000, 0x010000); // 0x20000 - 0x2ffff bank for Raiden DX
+	m_gamebank->configure_entries(   0,    2, memregion("maincpu")->base() + 0x030000, 0x200000);
 
 	raiden2_decrypt_sprites(machine());
 
 //  sensible defaults if booting as R2
-	m_mainbank[0]->set_entry(0);
-	m_mainbank[1]->set_entry(0);
+	m_mainbank->set_entry(0);
+	m_gamebank->set_entry(0);
 
 	m_okibank->configure_entries(0, 4, memregion("oki")->base(), 0x40000);
 	m_okibank->set_entry(0);
 
 }
 
-void r2dx_v33_state::init_nzerotea()
+void nzerotea_state::init_nzerotea()
 {
 	init_blending(zeroteam_blended_colors);
 	static const int spri[5] = { -1, 0, 1, 2, 3 };
@@ -842,7 +872,7 @@ void r2dx_v33_state::init_nzerotea()
 	zeroteam_decrypt_sprites(machine());
 }
 
-void r2dx_v33_state::init_zerotm2k()
+void nzerotea_state::init_zerotm2k()
 {
 	init_blending(zeroteam_blended_colors);
 	static const int spri[5] = { -1, 0, 1, 2, 3 };
@@ -851,7 +881,7 @@ void r2dx_v33_state::init_zerotm2k()
 	// no sprite encryption(!)
 
 	// BG tile rom has 2 lines swapped
-	u8 *src = memregion("gfx2")->base()+0x100000;
+	u8 *src = memregion("tiles")->base()+0x100000;
 	const int len = 0x080000;
 
 	std::vector<u8> buffer(len);
@@ -926,23 +956,23 @@ Notes
 
 
 ROM_START( r2dx_v33 )
-	ROM_REGION( 0x400000, "maincpu", 0 ) /* v33 main cpu */
+	ROM_REGION( 0x400000, "maincpu", 0 ) // v33 main cpu
 	ROM_LOAD("prg.223", 0x000000, 0x400000, CRC(b3dbcf98) SHA1(30d6ec2090531c8c579dff74c4898889902d7d87) )
 
-	ROM_REGION( 0x040000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x040000, "chars", 0 ) // chars
 	ROM_LOAD( "fix.613", 0x000000, 0x040000, CRC(3da27e39) SHA1(3d446990bf36dd0a3f8fadb68b15bed54904c8b5) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "bg.612", 0x000000, 0x400000, CRC(162c61e9) SHA1(bd0a6a29804b84196ba6bf3402e9f30a25da9269) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "obj1.724", 0x000000, 0x400000, CRC(7d218985) SHA1(777241a533defcbea3d7e735f309478d260bad52) )
 	ROM_LOAD32_WORD( "obj2.725", 0x000002, 0x400000, CRC(891b24d6) SHA1(74f89b47b1ba6b84ddd96d1fae92fddad0ace342) )
 
-	ROM_REGION( 0x100000, "oki", 0 ) /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki", 0 ) // ADPCM samples
 	ROM_LOAD( "pcm.099", 0x00000, 0x100000, CRC(97ca2907) SHA1(bfe8189300cf72089d0beaeab8b1a0a1a4f0a5b6) )
 
-	ROM_REGION( 0x20000, "math", 0 ) /* SEI333 (AKA COPX-D3) data */
+	ROM_REGION( 0x20000, "math", 0 ) // SEI333 (AKA COPX-D3) data
 	ROM_LOAD( "copx_d3.357", 0x00000, 0x20000, CRC(fa2cf3ad) SHA1(13eee40704d3333874b6e3da9ee7d969c6dc662a) )
 
 	ROM_REGION16_BE( 0x80, "eeprom", 0 )
@@ -950,23 +980,23 @@ ROM_START( r2dx_v33 )
 ROM_END
 
 ROM_START( r2dx_v33_r2 )
-	ROM_REGION( 0x400000, "maincpu", 0 ) /* v33 main cpu */
+	ROM_REGION( 0x400000, "maincpu", 0 ) // v33 main cpu
 	ROM_LOAD("prg.223", 0x000000, 0x400000, CRC(b3dbcf98) SHA1(30d6ec2090531c8c579dff74c4898889902d7d87) )
 
-	ROM_REGION( 0x040000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x040000, "chars", 0 ) // chars
 	ROM_LOAD( "fix.613", 0x000000, 0x040000, CRC(3da27e39) SHA1(3d446990bf36dd0a3f8fadb68b15bed54904c8b5) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "bg.612", 0x000000, 0x400000, CRC(162c61e9) SHA1(bd0a6a29804b84196ba6bf3402e9f30a25da9269) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "obj1.724", 0x000000, 0x400000, CRC(7d218985) SHA1(777241a533defcbea3d7e735f309478d260bad52) )
 	ROM_LOAD32_WORD( "obj2.725", 0x000002, 0x400000, CRC(891b24d6) SHA1(74f89b47b1ba6b84ddd96d1fae92fddad0ace342) )
 
-	ROM_REGION( 0x100000, "oki", 0 ) /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki", 0 ) // ADPCM samples
 	ROM_LOAD( "pcm.099", 0x00000, 0x100000, CRC(97ca2907) SHA1(bfe8189300cf72089d0beaeab8b1a0a1a4f0a5b6) )
 
-	ROM_REGION( 0x20000, "math", 0 ) /* SEI333 (AKA COPX-D3) data */
+	ROM_REGION( 0x20000, "math", 0 ) // SEI333 (AKA COPX-D3) data
 	ROM_LOAD( "copx_d3.357", 0x00000, 0x20000, CRC(fa2cf3ad) SHA1(13eee40704d3333874b6e3da9ee7d969c6dc662a) )
 
 	ROM_REGION16_BE( 0x80, "eeprom", 0 )
@@ -974,136 +1004,136 @@ ROM_START( r2dx_v33_r2 )
 ROM_END
 
 // uses dipswitches
-ROM_START( nzeroteam ) /* V33 SYSTEM TYPE_B hardware, uses SEI333 (AKA COPX-D3) for protection  */
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* v30 main cpu */
+ROM_START( nzeroteam ) // V33 SYSTEM TYPE_B hardware, uses SEI333 (AKA COPX-D3) for protection 
+	ROM_REGION( 0x100000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("seibu_1.u0224", 0x000000, 0x80000, CRC(ce1bcaf4) SHA1(1c340575e440b716caca8605cc5e1221060e3714) )
 	ROM_LOAD16_BYTE("seibu_2.u0226", 0x000001, 0x80000, CRC(03f6e32d) SHA1(5363f20d515ff84346aa15f7b9d95c5805d81285) )
 
-	ROM_REGION( 0x20000, "math", 0 ) /* SEI333 (AKA COPX-D3) data */
-	ROM_LOAD( "copx-d3.bin", 0x00000, 0x20000, CRC(fa2cf3ad) SHA1(13eee40704d3333874b6e3da9ee7d969c6dc662a) ) /* Not from this set, but same data as Zero Team 2000 & Raiden II New */
+	ROM_REGION( 0x20000, "math", 0 ) // SEI333 (AKA COPX-D3) data
+	ROM_LOAD( "copx-d3.bin", 0x00000, 0x20000, CRC(fa2cf3ad) SHA1(13eee40704d3333874b6e3da9ee7d969c6dc662a) ) // Not from this set, but same data as Zero Team 2000 & Raiden II New
 
-	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
-	ROM_LOAD( "seibu_3.u01019", 0x000000, 0x08000, CRC(7ec1fbc3) SHA1(48299d6530f641b18764cc49e283c347d0918a47) ) /* Same as some of other Zero Team sets */
-	ROM_CONTINUE(               0x010000, 0x08000 )    /* banked stuff */
+	ROM_REGION( 0x20000, "audiocpu", 0 ) // 64k code for sound Z80
+	ROM_LOAD( "seibu_3.u01019", 0x000000, 0x08000, CRC(7ec1fbc3) SHA1(48299d6530f641b18764cc49e283c347d0918a47) ) // Same as some of other Zero Team sets
+	ROM_CONTINUE(               0x010000, 0x08000 )    // banked stuff
 	ROM_COPY( "audiocpu",       0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD16_BYTE( "seibu_5.u0616", 0x000000, 0x010000, CRC(ce68ba3c) SHA1(52830533711ec906bf4fe9d06e065ec80b25b4da) )
 	ROM_LOAD16_BYTE( "seibu_6.u0617", 0x000001, 0x010000, CRC(cf44aea7) SHA1(e8d622fd5c10133fa563402daf0690fdff297f94) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
-	ROM_LOAD( "back-1", 0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) ) /* Same as "MUSHA BACK-1" of other Zero Team sets */
-	ROM_LOAD( "back-2", 0x100000, 0x080000, CRC(ce61c952) SHA1(52a843c8ba428b121fab933dd3b313b2894d80ac) ) /* Same as "MUSHA BACK-2" of other Zero Team sets */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
+	ROM_LOAD( "back-1", 0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) ) // Same as "MUSHA BACK-1" of other Zero Team sets
+	ROM_LOAD( "back-2", 0x100000, 0x080000, CRC(ce61c952) SHA1(52a843c8ba428b121fab933dd3b313b2894d80ac) ) // Same as "MUSHA BACK-2" of other Zero Team sets
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
-	ROM_LOAD32_WORD( "obj-1", 0x000000, 0x200000, CRC(45be8029) SHA1(adc164f9dede9a86b96a4d709e9cba7d2ad0e564) ) /* Same as "MUSHA OBJ-1" of other Zero Team sets */
-	ROM_LOAD32_WORD( "obj-2", 0x000002, 0x200000, CRC(cb61c19d) SHA1(151a2ce9c32f3321a974819e9b165dddc31c8153) ) /* Same as "MUSHA OBJ-2" of other Zero Team sets */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
+	ROM_LOAD32_WORD( "obj-1", 0x000000, 0x200000, CRC(45be8029) SHA1(adc164f9dede9a86b96a4d709e9cba7d2ad0e564) ) // Same as "MUSHA OBJ-1" of other Zero Team sets
+	ROM_LOAD32_WORD( "obj-2", 0x000002, 0x200000, CRC(cb61c19d) SHA1(151a2ce9c32f3321a974819e9b165dddc31c8153) ) // Same as "MUSHA OBJ-2" of other Zero Team sets
 
-	ROM_REGION( 0x100000, "oki", 0 ) /* ADPCM samples */
-	ROM_LOAD( "seibu_4.u099", 0x00000, 0x40000, CRC(48be32b1) SHA1(969d2191a3c46871ee8bf93088b3cecce3eccf0c) ) /* Same as other Zero Team sets */
+	ROM_REGION( 0x100000, "oki", 0 ) // ADPCM samples
+	ROM_LOAD( "seibu_4.u099", 0x00000, 0x40000, CRC(48be32b1) SHA1(969d2191a3c46871ee8bf93088b3cecce3eccf0c) ) // Same as other Zero Team sets
 
-	ROM_REGION( 0x200, "pld", 0 ) /* PLDs */
+	ROM_REGION( 0x200, "pld", 0 ) // PLDs
 	ROM_LOAD( "sysv33b-1.u0222.bin", 0x000, 0x117, CRC(f514a11f) SHA1(dd83ee1f511915d3d5f65375f34583be7fa1158b) )
 	ROM_LOAD( "sysv33b-2.u0227.bin", 0x000, 0x117, CRC(d9f4612f) SHA1(0c507b28dc0f50a67cc12d63092067dc3f7f4679) )
 ROM_END
 
-ROM_START( nzeroteama ) /* V33 SYSTEM TYPE_B hardware, uses SEI333 (AKA COPX-D3) for protection  */
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* v30 main cpu */
+ROM_START( nzeroteama ) // V33 SYSTEM TYPE_B hardware, uses SEI333 (AKA COPX-D3) for protection 
+	ROM_REGION( 0x100000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("seibu_1.u0224", 0x000000, 0x80000, CRC(cb277b46) SHA1(86e99f14f7349bfabb13d1f540d6fa46748379dc) ) // sldh
 	ROM_LOAD16_BYTE("seibu_2.u0226", 0x000001, 0x80000, CRC(6debbf78) SHA1(92d6f3bb59f72b40d3bc6d731866105a135574fb) ) // sldh
 
-	ROM_REGION( 0x20000, "math", 0 ) /* SEI333 (AKA COPX-D3) data */
-	ROM_LOAD( "copx-d3.bin", 0x00000, 0x20000, CRC(fa2cf3ad) SHA1(13eee40704d3333874b6e3da9ee7d969c6dc662a) ) /* Not from this set, but same data as Zero Team 2000 & Raiden II New */
+	ROM_REGION( 0x20000, "math", 0 ) // SEI333 (AKA COPX-D3) data
+	ROM_LOAD( "copx-d3.bin", 0x00000, 0x20000, CRC(fa2cf3ad) SHA1(13eee40704d3333874b6e3da9ee7d969c6dc662a) ) // Not from this set, but same data as Zero Team 2000 & Raiden II New
 
-	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
-	ROM_LOAD( "seibu_3.u01019", 0x000000, 0x08000, CRC(7ec1fbc3) SHA1(48299d6530f641b18764cc49e283c347d0918a47) ) /* Same as some of other Zero Team sets */
-	ROM_CONTINUE(               0x010000, 0x08000 )    /* banked stuff */
+	ROM_REGION( 0x20000, "audiocpu", 0 ) // 64k code for sound Z80
+	ROM_LOAD( "seibu_3.u01019", 0x000000, 0x08000, CRC(7ec1fbc3) SHA1(48299d6530f641b18764cc49e283c347d0918a47) ) // Same as some of other Zero Team sets
+	ROM_CONTINUE(               0x010000, 0x08000 )    // banked stuff
 	ROM_COPY( "audiocpu",       0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD16_BYTE( "seibu_5.u0616", 0x000000, 0x010000, CRC(ce68ba3c) SHA1(52830533711ec906bf4fe9d06e065ec80b25b4da) )
 	ROM_LOAD16_BYTE( "seibu_6.u0617", 0x000001, 0x010000, CRC(cf44aea7) SHA1(e8d622fd5c10133fa563402daf0690fdff297f94) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
-	ROM_LOAD( "back-1", 0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) ) /* Same as "MUSHA BACK-1" of other Zero Team sets */
-	ROM_LOAD( "back-2", 0x100000, 0x080000, CRC(ce61c952) SHA1(52a843c8ba428b121fab933dd3b313b2894d80ac) ) /* Same as "MUSHA BACK-2" of other Zero Team sets */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
+	ROM_LOAD( "back-1", 0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) ) // Same as "MUSHA BACK-1" of other Zero Team sets
+	ROM_LOAD( "back-2", 0x100000, 0x080000, CRC(ce61c952) SHA1(52a843c8ba428b121fab933dd3b313b2894d80ac) ) // Same as "MUSHA BACK-2" of other Zero Team sets
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
-	ROM_LOAD32_WORD( "obj-1", 0x000000, 0x200000, CRC(45be8029) SHA1(adc164f9dede9a86b96a4d709e9cba7d2ad0e564) ) /* Same as "MUSHA OBJ-1" of other Zero Team sets */
-	ROM_LOAD32_WORD( "obj-2", 0x000002, 0x200000, CRC(cb61c19d) SHA1(151a2ce9c32f3321a974819e9b165dddc31c8153) ) /* Same as "MUSHA OBJ-2" of other Zero Team sets */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
+	ROM_LOAD32_WORD( "obj-1", 0x000000, 0x200000, CRC(45be8029) SHA1(adc164f9dede9a86b96a4d709e9cba7d2ad0e564) ) // Same as "MUSHA OBJ-1" of other Zero Team sets
+	ROM_LOAD32_WORD( "obj-2", 0x000002, 0x200000, CRC(cb61c19d) SHA1(151a2ce9c32f3321a974819e9b165dddc31c8153) ) // Same as "MUSHA OBJ-2" of other Zero Team sets
 
-	ROM_REGION( 0x100000, "oki", 0 ) /* ADPCM samples */
-	ROM_LOAD( "seibu_4.u099", 0x00000, 0x40000, CRC(48be32b1) SHA1(969d2191a3c46871ee8bf93088b3cecce3eccf0c) ) /* Same as other Zero Team sets */
+	ROM_REGION( 0x100000, "oki", 0 ) // ADPCM samples
+	ROM_LOAD( "seibu_4.u099", 0x00000, 0x40000, CRC(48be32b1) SHA1(969d2191a3c46871ee8bf93088b3cecce3eccf0c) ) // Same as other Zero Team sets
 
-	ROM_REGION( 0x200, "pld", 0 ) /* PLDs */
+	ROM_REGION( 0x200, "pld", 0 ) // PLDs
 	ROM_LOAD( "sysv33b-1.u0222.bin", 0x000, 0x117, CRC(f514a11f) SHA1(dd83ee1f511915d3d5f65375f34583be7fa1158b) )
 	ROM_LOAD( "sysv33b-2.u0227.bin", 0x000, 0x117, CRC(d9f4612f) SHA1(0c507b28dc0f50a67cc12d63092067dc3f7f4679) )
 ROM_END
 
-ROM_START( nzeroteamb ) /* V33 SYSTEM TYPE_B hardware, uses SEI333 (AKA COPX-D3) for protection  */
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* v30 main cpu */
+ROM_START( nzeroteamb ) // V33 SYSTEM TYPE_B hardware, uses SEI333 (AKA COPX-D3) for protection 
+	ROM_REGION( 0x100000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("prg1", 0x000000, 0x80000, CRC(3c7d9410) SHA1(25f2121b6c2be73f11263934266901ed5d64d2ee) )
 	ROM_LOAD16_BYTE("prg2", 0x000001, 0x80000, CRC(6cba032d) SHA1(bf5d488cd578fff09e62e3650efdee7658033e3f) )
 
-	ROM_REGION( 0x20000, "math", 0 ) /* SEI333 (AKA COPX-D3) data */
-	ROM_LOAD( "copx-d3.bin", 0x00000, 0x20000, CRC(fa2cf3ad) SHA1(13eee40704d3333874b6e3da9ee7d969c6dc662a) ) /* Not from this set, but same data as Zero Team 2000 & Raiden II New */
+	ROM_REGION( 0x20000, "math", 0 ) // SEI333 (AKA COPX-D3) data
+	ROM_LOAD( "copx-d3.bin", 0x00000, 0x20000, CRC(fa2cf3ad) SHA1(13eee40704d3333874b6e3da9ee7d969c6dc662a) ) // Not from this set, but same data as Zero Team 2000 & Raiden II New
 
-	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
-	ROM_LOAD( "sound",    0x000000, 0x08000, CRC(7ec1fbc3) SHA1(48299d6530f641b18764cc49e283c347d0918a47) ) /* Same as some of other Zero Team sets */
-	ROM_CONTINUE(         0x010000, 0x08000 )    /* banked stuff */
+	ROM_REGION( 0x20000, "audiocpu", 0 ) // 64k code for sound Z80
+	ROM_LOAD( "sound",    0x000000, 0x08000, CRC(7ec1fbc3) SHA1(48299d6530f641b18764cc49e283c347d0918a47) ) // Same as some of other Zero Team sets
+	ROM_CONTINUE(         0x010000, 0x08000 )    // banked stuff
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD16_BYTE( "fix1", 0x000000, 0x010000, CRC(0c4895b0) SHA1(f595dbe5a19edb8a06ea60105ee26b95db4a2619) )
 	ROM_LOAD16_BYTE( "fix2", 0x000001, 0x010000, CRC(07d8e387) SHA1(52f54a6a4830592784cdf643a5f255aa3db53e50) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
-	ROM_LOAD( "back-1", 0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) ) /* Same as "MUSHA BACK-1" of other Zero Team sets */
-	ROM_LOAD( "back-2", 0x100000, 0x080000, CRC(ce61c952) SHA1(52a843c8ba428b121fab933dd3b313b2894d80ac) ) /* Same as "MUSHA BACK-2" of other Zero Team sets */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
+	ROM_LOAD( "back-1", 0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) ) // Same as "MUSHA BACK-1" of other Zero Team sets
+	ROM_LOAD( "back-2", 0x100000, 0x080000, CRC(ce61c952) SHA1(52a843c8ba428b121fab933dd3b313b2894d80ac) ) // Same as "MUSHA BACK-2" of other Zero Team sets
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
-	ROM_LOAD32_WORD( "obj-1", 0x000000, 0x200000, CRC(45be8029) SHA1(adc164f9dede9a86b96a4d709e9cba7d2ad0e564) ) /* Same as "MUSHA OBJ-1" of other Zero Team sets */
-	ROM_LOAD32_WORD( "obj-2", 0x000002, 0x200000, CRC(cb61c19d) SHA1(151a2ce9c32f3321a974819e9b165dddc31c8153) ) /* Same as "MUSHA OBJ-2" of other Zero Team sets */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
+	ROM_LOAD32_WORD( "obj-1", 0x000000, 0x200000, CRC(45be8029) SHA1(adc164f9dede9a86b96a4d709e9cba7d2ad0e564) ) // Same as "MUSHA OBJ-1" of other Zero Team sets
+	ROM_LOAD32_WORD( "obj-2", 0x000002, 0x200000, CRC(cb61c19d) SHA1(151a2ce9c32f3321a974819e9b165dddc31c8153) ) // Same as "MUSHA OBJ-2" of other Zero Team sets
 
-	ROM_REGION( 0x100000, "oki", 0 ) /* ADPCM samples */
-	ROM_LOAD( "6.pcm", 0x00000, 0x40000, CRC(48be32b1) SHA1(969d2191a3c46871ee8bf93088b3cecce3eccf0c) ) /* Same as other Zero Team sets */
+	ROM_REGION( 0x100000, "oki", 0 ) // ADPCM samples
+	ROM_LOAD( "6.pcm", 0x00000, 0x40000, CRC(48be32b1) SHA1(969d2191a3c46871ee8bf93088b3cecce3eccf0c) ) // Same as other Zero Team sets
 
-	ROM_REGION( 0x200, "pld", 0 ) /* PLDs */
+	ROM_REGION( 0x200, "pld", 0 ) // PLDs
 	ROM_LOAD( "sysv33b-1.u0222.bin", 0x000, 0x117, CRC(f514a11f) SHA1(dd83ee1f511915d3d5f65375f34583be7fa1158b) )
 	ROM_LOAD( "sysv33b-2.u0227.bin", 0x000, 0x117, CRC(d9f4612f) SHA1(0c507b28dc0f50a67cc12d63092067dc3f7f4679) )
 ROM_END
 
 
 // uses a 93c46a eeprom
-ROM_START( zerotm2k ) /* V33 SYSTEM TYPE_C VER2 hardware, uses SEI333 (AKA COPX-D3) for protection  */
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* v30 main cpu */
-	ROM_LOAD( "mt28f800b1.u0230", 0x000000, 0x100000, CRC(6ab49d8c) SHA1(d94ec9a46ff98a76c3372369246733268474de99) ) /* SMT rom, PCB silkscreened PRG01 */
-	/* PCB has unpopulated socket space for two 27C040 at u0224 silkscreened PRG0 & u0226 silkscreened PRG1) */
+ROM_START( zerotm2k ) // V33 SYSTEM TYPE_C VER2 hardware, uses SEI333 (AKA COPX-D3) for protection 
+	ROM_REGION( 0x100000, "maincpu", 0 ) // v30 main cpu
+	ROM_LOAD( "mt28f800b1.u0230", 0x000000, 0x100000, CRC(6ab49d8c) SHA1(d94ec9a46ff98a76c3372369246733268474de99) ) // SMT rom, PCB silkscreened PRG01
+	// PCB has unpopulated socket space for two 27C040 at u0224 silkscreened PRG0 & u0226 silkscreened PRG1)
 
-	ROM_REGION( 0x20000, "math", 0 ) /* SEI333 (AKA COPX-D3) data */
-	ROM_LOAD( "mx27c1000mc.u0366", 0x00000, 0x20000, CRC(fa2cf3ad) SHA1(13eee40704d3333874b6e3da9ee7d969c6dc662a) ) /* PCB silkscreened 333ROM */
+	ROM_REGION( 0x20000, "math", 0 ) // SEI333 (AKA COPX-D3) data
+	ROM_LOAD( "mx27c1000mc.u0366", 0x00000, 0x20000, CRC(fa2cf3ad) SHA1(13eee40704d3333874b6e3da9ee7d969c6dc662a) ) // PCB silkscreened 333ROM
 
-	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
-	ROM_LOAD( "syz-02.u019", 0x000000, 0x08000, CRC(55371073) SHA1(f6e182fa64630595dc8c25ac820e12983cfbed12) ) /* PCB silkscreened SOUND */
-	ROM_CONTINUE(            0x010000, 0x08000 )   /* banked stuff */
+	ROM_REGION( 0x20000, "audiocpu", 0 ) // 64k code for sound Z80
+	ROM_LOAD( "syz-02.u019", 0x000000, 0x08000, CRC(55371073) SHA1(f6e182fa64630595dc8c25ac820e12983cfbed12) ) // PCB silkscreened SOUND
+	ROM_CONTINUE(            0x010000, 0x08000 )   // banked stuff
 	ROM_COPY( "audiocpu",    0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
-	ROM_LOAD16_BYTE( "syz-04.u0616", 0x000000, 0x010000, CRC(3515a45f) SHA1(a25a7e23a5d9cf5a95a0d0e828848a8d223bdf51) ) /* PCB silkscreened FIX E */
-	ROM_LOAD16_BYTE( "syz-03.u0617", 0x000001, 0x010000, CRC(02fbf9d7) SHA1(6eb4db1f89c9b003e7eed7bf39e6065b1c99447f) ) /* PCB silkscreened FIX O */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
+	ROM_LOAD16_BYTE( "syz-04.u0616", 0x000000, 0x010000, CRC(3515a45f) SHA1(a25a7e23a5d9cf5a95a0d0e828848a8d223bdf51) ) // PCB silkscreened FIX E
+	ROM_LOAD16_BYTE( "syz-03.u0617", 0x000001, 0x010000, CRC(02fbf9d7) SHA1(6eb4db1f89c9b003e7eed7bf39e6065b1c99447f) ) // PCB silkscreened FIX O
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
-	ROM_LOAD( "szy-05.u0614",     0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) ) /* PCB silkscreened BG12, Same as "MUSHA BACK-1" */
-	ROM_LOAD( "mt28f400b1.u0619", 0x100000, 0x080000, CRC(266acee6) SHA1(2a9da66c313a7536c7fb393134b9df0bb122cb2b) ) /* SMT rom, PCB silkscreened BG3 */
-	/* PCB has an unpopulated socket rom space for a LH535A00D at u0615 for alt BG3 location */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
+	ROM_LOAD( "szy-05.u0614",     0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) ) // PCB silkscreened BG12, Same as "MUSHA BACK-1"
+	ROM_LOAD( "mt28f400b1.u0619", 0x100000, 0x080000, CRC(266acee6) SHA1(2a9da66c313a7536c7fb393134b9df0bb122cb2b) ) // SMT rom, PCB silkscreened BG3
+	// PCB has an unpopulated socket rom space for a LH535A00D at u0615 for alt BG3 location
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (NOT encrypted) */
-	ROM_LOAD32_WORD( "musha_obj-1a.u0729", 0x000000, 0x200000, CRC(9b2cf68c) SHA1(cd8cb277091bfa125fd0f68410de39f72f1c7047) ) /* PCB silkscreened OBJ1 */
-	ROM_LOAD32_WORD( "musha_obj-2a.u0730", 0x000002, 0x200000, CRC(fcabee05) SHA1(b2220c0311b3bd2fd44fb56fff7c27bed0816fe9) ) /* PCB silkscreened OBJ2 */
-	/* PCB has unpopulated rom space for two SMT roms at u0734 & u0736 for alt OBJ1 & OBJ2 locations) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (NOT encrypted)
+	ROM_LOAD32_WORD( "musha_obj-1a.u0729", 0x000000, 0x200000, CRC(9b2cf68c) SHA1(cd8cb277091bfa125fd0f68410de39f72f1c7047) ) // PCB silkscreened OBJ1
+	ROM_LOAD32_WORD( "musha_obj-2a.u0730", 0x000002, 0x200000, CRC(fcabee05) SHA1(b2220c0311b3bd2fd44fb56fff7c27bed0816fe9) ) // PCB silkscreened OBJ2
+	// PCB has unpopulated rom space for two SMT roms at u0734 & u0736 for alt OBJ1 & OBJ2 locations)
 
-	ROM_REGION( 0x100000, "oki", 0 ) /* ADPCM samples */
-	ROM_LOAD( "szy-01.u099", 0x00000, 0x40000,  CRC(48be32b1) SHA1(969d2191a3c46871ee8bf93088b3cecce3eccf0c) ) /* PCB silkscreened PCM, Same as other Zero Team sets */
+	ROM_REGION( 0x100000, "oki", 0 ) // ADPCM samples
+	ROM_LOAD( "szy-01.u099", 0x00000, 0x40000,  CRC(48be32b1) SHA1(969d2191a3c46871ee8bf93088b3cecce3eccf0c) ) // PCB silkscreened PCM, Same as other Zero Team sets
 ROM_END
 
 } // anonymous namespace
@@ -1111,19 +1141,19 @@ ROM_END
 
 // newer PCB, with V33 CPU and COPD3 protection, but weak sound hardware. - was marked as Raiden DX New in the rom dump, but boots as Raiden 2 New version, the rom contains both
 // is there a switching method? for now I've split it into 2 sets with different EEPROM, the game checks that on startup and runs different code depending on what it finds
-GAME( 1996, r2dx_v33,    0,        rdx_v33,  rdx_v33,  r2dx_v33_state, init_rdx_v33,   ROT270, "Seibu Kaihatsu", "Raiden II New / Raiden DX (newer V33 PCB) (Raiden DX EEPROM)", MACHINE_SUPPORTS_SAVE)
-GAME( 1996, r2dx_v33_r2, r2dx_v33, rdx_v33,  rdx_v33,  r2dx_v33_state, init_rdx_v33,   ROT270, "Seibu Kaihatsu", "Raiden II New / Raiden DX (newer V33 PCB) (Raiden II EEPROM)", MACHINE_SUPPORTS_SAVE)
+GAME( 1996, r2dx_v33,    0,        rdx_v33,  rdx_v33,  r2dx_v33_state, init_rdx_v33,   ROT270, "Seibu Kaihatsu", "Raiden II New / Raiden DX (newer V33 PCB) (Raiden DX EEPROM)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE)
+GAME( 1996, r2dx_v33_r2, r2dx_v33, rdx_v33,  rdx_v33,  r2dx_v33_state, init_rdx_v33,   ROT270, "Seibu Kaihatsu", "Raiden II New / Raiden DX (newer V33 PCB) (Raiden II EEPROM)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE)
 
 // 'V33 system type_b' - uses V33 CPU, COPX-D3 external protection rom, but still has the proper sound system, DSW for settings
-GAME( 1997, nzeroteam,   zeroteam, nzerotea, nzerotea, r2dx_v33_state, init_nzerotea,  ROT0,   "Seibu Kaihatsu",                                     "New Zero Team (V33 SYSTEM TYPE_B hardware)", MACHINE_SUPPORTS_SAVE)
-GAME( 1997, nzeroteama,  zeroteam, nzerotea, nzerotea, r2dx_v33_state, init_nzerotea,  ROT0,   "Seibu Kaihatsu (Zhongguo Shantou Yihuang license)",  "New Zero Team (V33 SYSTEM TYPE_B hardware, Zhongguo Shantou Yihuang license)", MACHINE_SUPPORTS_SAVE) // license text translated from title screen
-GAME( 1997, nzeroteamb,  zeroteam, nzerotea, nzerotea, r2dx_v33_state, init_nzerotea,  ROT0,   "Seibu Kaihatsu (Haoyunlai Trading Company license)", "New Zero Team (V33 SYSTEM TYPE_B hardware, Haoyunlai Trading Company license)", MACHINE_SUPPORTS_SAVE) // license text translated from title screen
+GAME( 1997, nzeroteam,   zeroteam, nzerotea, nzerotea, nzerotea_state, init_nzerotea,  ROT0,   "Seibu Kaihatsu",                                     "New Zero Team (V33 SYSTEM TYPE_B hardware)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE)
+GAME( 1997, nzeroteama,  zeroteam, nzerotea, nzerotea, nzerotea_state, init_nzerotea,  ROT0,   "Seibu Kaihatsu (Zhongguo Shantou Yihuang license)",  "New Zero Team (V33 SYSTEM TYPE_B hardware, Zhongguo Shantou Yihuang license)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE) // license text translated from title screen
+GAME( 1997, nzeroteamb,  zeroteam, nzerotea, nzerotea, nzerotea_state, init_nzerotea,  ROT0,   "Seibu Kaihatsu (Haoyunlai Trading Company license)", "New Zero Team (V33 SYSTEM TYPE_B hardware, Haoyunlai Trading Company license)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE) // license text translated from title screen
 
 // 'V33 SYSTEM TYPE_C' - uses V33 CPU, basically the same board as TYPE_C VER2
 // there is a version of New Zero Team on "V33 SYSTEM TYPE_C" board with EEPROM rather than dipswitches like Zero Team 2000
 // 1998 release of New Zero team on this hardware also exists, but not dumped: https://youtu.be/8mnFjXCc9BI
 
 // 'V33 SYSTEM TYPE_C VER2' - uses V33 CPU, COPX-D3 external protection rom, but still has the proper sound system, unencrypted sprites, EEPROM for settings.  PCB also seen without 'VER2', looks the same
-GAME( 2000, zerotm2k,    zeroteam, zerotm2k, zerotm2k, r2dx_v33_state, init_zerotm2k,  ROT0,  "Seibu Kaihatsu", "Zero Team 2000", MACHINE_SUPPORTS_SAVE)
+GAME( 2000, zerotm2k,    zeroteam, zerotm2k, zerotm2k, nzerotea_state, init_zerotm2k,  ROT0,  "Seibu Kaihatsu", "Zero Team 2000", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE)
 
 // there is also a 'Raiden 2 2000' on unknown hardware.

--- a/src/mame/seibu/raiden2.cpp
+++ b/src/mame/seibu/raiden2.cpp
@@ -247,7 +247,7 @@ void raiden2_state::combine32(u32 *val, offs_t offset, u16 data, u16 mem_mask)
 
 INTERRUPT_GEN_MEMBER(raiden2_state::interrupt)
 {
-	device.execute().set_input_line_and_vector(0, HOLD_LINE, 0xc0/4);   /* V30 - VBL */
+	device.execute().set_input_line_and_vector(0, HOLD_LINE, 0xc0/4);   // V30 - VBL
 }
 
 
@@ -285,7 +285,7 @@ void raiden2_state::sprcpt_data_3_w(offs_t offset, u16 data, u16 mem_mask)
 	combine32(m_sprcpt_data_3+m_sprcpt_idx, offset, data, mem_mask);
 	if (offset == 1)
 	{
-		m_sprcpt_idx ++;
+		m_sprcpt_idx++;
 		if (m_sprcpt_idx == 6)
 			m_sprcpt_idx = 0;
 	}
@@ -296,7 +296,7 @@ void raiden2_state::sprcpt_data_4_w(offs_t offset, u16 data, u16 mem_mask)
 	combine32(m_sprcpt_data_4+m_sprcpt_idx, offset, data, mem_mask);
 	if (offset == 1)
 	{
-		m_sprcpt_idx ++;
+		m_sprcpt_idx++;
 		if (m_sprcpt_idx == 4)
 			m_sprcpt_idx = 0;
 	}
@@ -328,17 +328,17 @@ void raiden2_state::sprcpt_flags_1_w(offs_t offset, u16 data, u16 mem_mask)
 				logerror("sprcpt_val 1: %08x\n", m_sprcpt_val[0]);
 				logerror("sprcpt_val 2: %08x\n", m_sprcpt_val[1]);
 				logerror("sprcpt_data 1:\n");
-				for (i=0; i<0x100; i++)
+				for (i = 0; i < 0x100; i++)
 				{
 					logerror(" %08x", m_sprcpt_data_1[i]);
-					if (!((i+1) & 7))
+					if (!((i + 1) & 7))
 						logerror("\n");
 				}
 				logerror("sprcpt_data 2:\n");
-				for (i=0; i<0x40; i++)
+				for (i = 0; i < 0x40; i++)
 				{
 					logerror(" %08x", m_sprcpt_data_2[i]);
-					if (!((i+1) & 7))
+					if (!((i + 1) & 7))
 						logerror("\n");
 				}
 			}
@@ -372,8 +372,7 @@ MACHINE_RESET_MEMBER(raiden2_state,raiden2)
 	bank_reset(0,6,1,0);
 	sprcpt_init();
 
-	m_mainbank[0]->set_entry(2);
-	m_mainbank[1]->set_entry(3);
+	m_mainbank->set_entry(1);
 
 	m_prg_bank = 0;
 	//cop_init();
@@ -384,8 +383,7 @@ MACHINE_RESET_MEMBER(raiden2_state,raidendx)
 	bank_reset(0,6,1,0);
 	sprcpt_init();
 
-	m_mainbank[0]->set_entry(16);
-	m_mainbank[1]->set_entry(3);
+	m_mainbank->set_entry(0);
 
 	m_prg_bank = 0x08;
 
@@ -397,8 +395,7 @@ MACHINE_RESET_MEMBER(raiden2_state,zeroteam)
 	bank_reset(0,2,1,0);
 	sprcpt_init();
 
-	m_mainbank[0]->set_entry(2);
-	m_mainbank[1]->set_entry(3);
+	m_mainbank->set_entry(1);
 
 	m_prg_bank = 0;
 	//cop_init();
@@ -412,11 +409,10 @@ MACHINE_RESET_MEMBER(raiden2_state,xsedae)
 
 void raiden2_state::raiden2_bank_w(u8 data)
 {
-	int bb = (~data >> 7) & 1;
-	logerror("select bank %d %04x\n", (data >> 7) & 1, data);
-	m_mainbank[0]->set_entry(bb*2);
-	m_mainbank[1]->set_entry(bb*2+1);
-	m_prg_bank = ((data >> 7) & 1);
+	const int bb = BIT(~data, 7);
+	logerror("select bank %d %04x\n", BIT(data, 7), data);
+	m_mainbank->set_entry(bb);
+	m_prg_bank = BIT(data, 7);
 }
 
 
@@ -445,16 +441,16 @@ u16 raiden2_state::sprite_prot_src_seg_r()
 void raiden2_state::sprite_prot_src_w(address_space &space, u16 data)
 {
 	m_sprite_prot_src_addr[1] = data;
-	u32 src = (m_sprite_prot_src_addr[0]<<4)+m_sprite_prot_src_addr[1];
+	const u32 src = (m_sprite_prot_src_addr[0]<<4)+m_sprite_prot_src_addr[1];
 
-	int x = int16_t((space.read_dword(src+0x08) >> 16) - (m_sprite_prot_x));
-	int y = int16_t((space.read_dword(src+0x04) >> 16) - (m_sprite_prot_y));
+	const int x = s16((space.read_dword(src + 0x08) >> 16) - (m_sprite_prot_x));
+	const int y = s16((space.read_dword(src + 0x04) >> 16) - (m_sprite_prot_y));
 
-	u16 head1 = space.read_word(src+m_cop_spr_off);
-	u16 head2 = space.read_word(src+m_cop_spr_off+2);
+	const u16 head1 = space.read_word(src + m_cop_spr_off);
+	const u16 head2 = space.read_word(src + m_cop_spr_off+2);
 
-	int w = (((head1 >> 8 ) & 7) + 1) << 4;
-	int h = (((head1 >> 12) & 7) + 1) << 4;
+	const int w = (((head1 >> 8 ) & 7) + 1) << 4;
+	const int h = (((head1 >> 12) & 7) + 1) << 4;
 
 	u16 flag = x-w/2 > -w && x-w/2 < m_cop_spr_maxx+w && y-h/2 > -h && y-h/2 < 256+h ? 1 : 0;
 
@@ -504,7 +500,7 @@ void raiden2_state::sprite_prot_off_w(u16 data)
 	m_cop_spr_off = data;
 }
 
-/* MEMORY MAPS */
+// MEMORY MAPS
 void raiden2_state::raiden2_cop_mem(address_map &map)
 {
 	map(0x0041c, 0x0041d).w(m_raiden2cop, FUNC(raiden2cop_device::cop_angle_target_w)); // angle target (for 0x6200 COP macro)
@@ -569,7 +565,7 @@ void raiden2_state::raiden2_cop_mem(address_map &map)
 	map(0x006da, 0x006db).w(FUNC(raiden2_state::sprite_prot_y_w));
 	map(0x006dc, 0x006dd).rw(FUNC(raiden2_state::sprite_prot_maxx_r), FUNC(raiden2_state::sprite_prot_maxx_w));
 	map(0x006de, 0x006df).w(FUNC(raiden2_state::sprite_prot_src_w));
-	/* end video block */
+	// end video block
 
 	map(0x006fc, 0x006fd).w(m_raiden2cop, FUNC(raiden2cop_device::cop_dma_trigger_w));
 	map(0x006fe, 0x006ff).w(m_raiden2cop, FUNC(raiden2cop_device::cop_sort_dma_trig_w)); // sort-DMA trigger
@@ -600,13 +596,12 @@ void raiden2_state::raiden2_mem(address_map &map)
 	map(0x0d800, 0x0dfff).ram(); // .w(FUNC(raiden2_state::foreground_w).share("fore_data");
 	map(0x0e000, 0x0e7ff).ram(); // .w(FUNC(raiden2_state::midground_w).share("mid_data");
 	map(0x0e800, 0x0f7ff).ram(); // .w(FUNC(raiden2_state::text_w).share("text_data");
-	map(0x0f800, 0x0ffff).ram(); /* Stack area */
+	map(0x0f800, 0x0ffff).ram(); // Stack area
 
 	map(0x10000, 0x1efff).ram();
 	map(0x1f000, 0x1ffff).ram(); //.w("palette", palette_device, write).share("palette");
 
-	map(0x20000, 0x2ffff).bankr("mainbank1");
-	map(0x30000, 0x3ffff).bankr("mainbank2");
+	map(0x20000, 0x3ffff).bankr(m_mainbank);
 	map(0x40000, 0xfffff).rom().region("maincpu", 0x40000);
 }
 
@@ -617,6 +612,9 @@ void raiden2_state::raidendx_mem(address_map &map)
 	map(0x004d0, 0x004d7).ram(); //???
 	map(0x00600, 0x0063f).rw("crtc", FUNC(seibu_crtc_device::read_alt), FUNC(seibu_crtc_device::write_alt));
 //  map(0x006ca, 0x006cb).nopw();
+
+	map(0x20000, 0x2ffff).bankr(m_mainbank);
+	map(0x30000, 0xfffff).rom().region("maincpu", 0x30000);
 }
 
 void raiden2_state::zeroteam_mem(address_map &map)
@@ -648,8 +646,7 @@ void raiden2_state::zeroteam_mem(address_map &map)
 	map(0x0f000, 0x0ffff).ram().share("spriteram");
 	map(0x10000, 0x1ffff).ram();
 
-	map(0x20000, 0x2ffff).bankr("mainbank1");
-	map(0x30000, 0x3ffff).bankr("mainbank2");
+	map(0x20000, 0x3ffff).bankr(m_mainbank);
 	map(0x40000, 0xfffff).rom().region("maincpu", 0x40000);
 }
 
@@ -727,12 +724,12 @@ void raiden2_state::zeroteam_sound_map(address_map &map)
 }
 
 
-/* INPUT PORTS */
+// INPUT PORTS
 
 static INPUT_PORTS_START( raiden2 )
-	SEIBU_COIN_INPUTS_INVERT    /* coin inputs read through sound cpu */
+	SEIBU_COIN_INPUTS_INVERT    // coin inputs read through sound cpu
 
-	PORT_START("P1_P2") /* IN0/1 */
+	PORT_START("P1_P2") // IN0/1
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER(1)
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER(1)
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_PLAYER(1)
@@ -750,7 +747,7 @@ static INPUT_PORTS_START( raiden2 )
 	PORT_BIT( 0x4000, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x8000, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("DSW")   /* Dip switches  */
+	PORT_START("DSW")   // Dip switches 
 	PORT_DIPNAME( 0x0007, 0x0007, DEF_STR( Coin_A ) ) PORT_DIPLOCATION("SW1:!1,!2,!3")
 	PORT_DIPSETTING(      0x0001, DEF_STR( 4C_1C ) )
 	PORT_DIPSETTING(      0x0002, DEF_STR( 3C_1C ) )
@@ -793,9 +790,9 @@ static INPUT_PORTS_START( raiden2 )
 	PORT_DIPNAME( 0x4000, 0x4000, "Demo Sound" ) PORT_DIPLOCATION("SW2:!7")
 	PORT_DIPSETTING(      0x0000, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x4000, DEF_STR( On ) )
-	PORT_SERVICE( 0x8000, IP_ACTIVE_LOW ) PORT_DIPLOCATION("SW2:!8") /* Test Mode */
+	PORT_SERVICE( 0x8000, IP_ACTIVE_LOW ) PORT_DIPLOCATION("SW2:!8") // Test Mode
 
-	PORT_START("SYSTEM")    /* START BUTTONS */
+	PORT_START("SYSTEM")    // START BUTTONS
 	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_START1 )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_START2 )
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -806,11 +803,11 @@ INPUT_PORTS_END
 static INPUT_PORTS_START( raidendx )
 	PORT_INCLUDE( raiden2 )
 
-	PORT_MODIFY("DSW")  /* Dip switches  */
-	PORT_DIPNAME( 0x1000, 0x1000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:!5") /* Manual shows "Not Used" */
+	PORT_MODIFY("DSW")  // Dip switches 
+	PORT_DIPNAME( 0x1000, 0x1000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:!5") // Manual shows "Not Used"
 	PORT_DIPSETTING(      0x1000, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x2000, 0x2000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:!6") /* Manual shows "Not Used" */
+	PORT_DIPNAME( 0x2000, 0x2000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:!6") // Manual shows "Not Used"
 	PORT_DIPSETTING(      0x2000, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 
@@ -1014,30 +1011,22 @@ static const gfx_layout tilelayout =
 	128*8
 };
 
-static const gfx_layout spritelayout =
-{
-	16, 16,
-	RGN_FRAC(1,1),
-	4,
-	{ STEP4(0,1) },
-	{ 4, 0, 12, 8, 20, 16, 28, 24, 36, 32, 44, 40, 52, 48, 60, 56 },
-	{ STEP16(0,64) },
-	16*16*4
-};
-
 GFXDECODE_START( raiden2_state::gfx_raiden2 )
-	GFXDECODE_ENTRY( "gfx1", 0x00000, charlayout,   0x700, 0x10 )
-	GFXDECODE_ENTRY( "gfx2", 0x00000, tilelayout,   0x400, 0x30 )
-	GFXDECODE_ENTRY( "gfx3", 0x00000, spritelayout, 0x000, 0x40 ) // really 128, but using the top bits for priority
+	GFXDECODE_ENTRY( "chars",   0, charlayout,             0x700, 0x10 )
+	GFXDECODE_ENTRY( "tiles",   0, tilelayout,             0x400, 0x30 )
+GFXDECODE_END
+
+GFXDECODE_START( raiden2_state::gfx_raiden2_spr )
+	GFXDECODE_ENTRY( "sprites", 0, gfx_16x16x4_packed_lsb, 0x000, 0x40 ) // really 128, but using the top bits for priority
 GFXDECODE_END
 
 
-/* MACHINE DRIVERS */
+// MACHINE DRIVERS
 
 void raiden2_state::raiden2(machine_config &config)
 {
-	/* basic machine hardware */
-	V30(config, m_maincpu, XTAL(32'000'000)/2); /* verified on pcb */
+	// basic machine hardware
+	V30(config, m_maincpu, XTAL(32'000'000)/2); // verified on pcb
 	m_maincpu->set_addrmap(AS_PROGRAM, &raiden2_state::raiden2_mem);
 	m_maincpu->set_vblank_int("screen", FUNC(raiden2_state::interrupt));
 
@@ -1047,10 +1036,10 @@ void raiden2_state::raiden2(machine_config &config)
 	audiocpu.set_addrmap(AS_PROGRAM, &raiden2_state::raiden2_sound_map);
 	audiocpu.set_irq_acknowledge_callback("seibu_sound", FUNC(seibu_sound_device::im0_vector_cb));
 
-	/* video hardware */
+	// video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_video_attributes(VIDEO_UPDATE_BEFORE_VBLANK);
-	screen.set_raw(XTAL(32'000'000)/4, 512, 0, 40*8, 282, 0, 30*8); /* hand-tuned to match ~55.47 */
+	screen.set_raw(XTAL(32'000'000)/4, 512, 0, 40*8, 282, 0, 30*8); // hand-tuned to match ~55.47
 	screen.set_screen_update(FUNC(raiden2_state::screen_update));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, raiden2_state::gfx_raiden2);
@@ -1062,12 +1051,18 @@ void raiden2_state::raiden2(machine_config &config)
 
 	BUFFERED_SPRITERAM16(config, m_spriteram);
 
+	SEI25X_RISE1X(config, m_spritegen, 0, m_palette, raiden2_state::gfx_raiden2_spr);
+	m_spritegen->set_screen("screen");
+	m_spritegen->set_pix_raw_shift(4);
+	m_spritegen->set_pri_raw_shift(14);
+	m_spritegen->set_transpen(15);
+
 	RAIDEN2COP(config, m_raiden2cop, 0);
 	m_raiden2cop->videoramout_cb().set(FUNC(raiden2_state::m_videoram_private_w));
 	m_raiden2cop->paletteramout_cb().set(m_palette, FUNC(palette_device::write16));
 	m_raiden2cop->set_host_cpu_tag(m_maincpu);
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	ym2151_device &ymsnd(YM2151(config, "ymsnd", XTAL(28'636'363)/8));
@@ -1099,8 +1094,8 @@ void raiden2_state::raidendx(machine_config &config)
 
 void raiden2_state::zeroteam(machine_config &config)
 {
-	/* basic machine hardware */
-	V30(config, m_maincpu, XTAL(32'000'000)/2); /* verified on pcb */
+	// basic machine hardware
+	V30(config, m_maincpu, XTAL(32'000'000)/2); // verified on pcb
 	m_maincpu->set_addrmap(AS_PROGRAM, &raiden2_state::zeroteam_mem);
 	m_maincpu->set_vblank_int("screen", FUNC(raiden2_state::interrupt));
 
@@ -1110,11 +1105,11 @@ void raiden2_state::zeroteam(machine_config &config)
 	audiocpu.set_addrmap(AS_PROGRAM, &raiden2_state::zeroteam_sound_map);
 	audiocpu.set_irq_acknowledge_callback("seibu_sound", FUNC(seibu_sound_device::im0_vector_cb));
 
-	/* video hardware */
+	// video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_video_attributes(VIDEO_UPDATE_AFTER_VBLANK);
-//  screen.set_refresh_hz(55.47);    /* verified on pcb */
-	screen.set_raw(XTAL(32'000'000)/4, 512, 0, 40*8, 282, 0, 32*8); /* hand-tuned to match ~55.47 */
+//  screen.set_refresh_hz(55.47);    // verified on pcb
+	screen.set_raw(XTAL(32'000'000)/4, 512, 0, 40*8, 282, 0, 32*8); // hand-tuned to match ~55.47
 	screen.set_screen_update(FUNC(raiden2_state::screen_update));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, raiden2_state::gfx_raiden2);
@@ -1126,16 +1121,22 @@ void raiden2_state::zeroteam(machine_config &config)
 
 	BUFFERED_SPRITERAM16(config, m_spriteram);
 
+	SEI25X_RISE1X(config, m_spritegen, 0, m_palette, raiden2_state::gfx_raiden2_spr);
+	m_spritegen->set_screen("screen");
+	m_spritegen->set_pix_raw_shift(4);
+	m_spritegen->set_pri_raw_shift(14);
+	m_spritegen->set_transpen(15);
+
 	RAIDEN2COP(config, m_raiden2cop, 0);
 	m_raiden2cop->videoramout_cb().set(FUNC(raiden2_state::m_videoram_private_w));
 	m_raiden2cop->paletteramout_cb().set(m_palette, FUNC(palette_device::write16));
 	m_raiden2cop->set_host_cpu_tag(m_maincpu);
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	ym3812_device &ymsnd(YM3812(config, "ymsnd", XTAL(28'636'363)/8));
-	ymsnd.irq_handler().set("seibu_sound", FUNC(seibu_sound_device::fm_irqhandler));
+	ymsnd.irq_handler().set(m_seibu_sound, FUNC(seibu_sound_device::fm_irqhandler));
 	ymsnd.add_route(ALL_OUTPUTS, "mono", 1.0);
 
 	okim6295_device &oki(OKIM6295(config, "oki", XTAL(28'636'363)/28, okim6295_device::PIN7_HIGH));
@@ -1167,7 +1168,7 @@ void raiden2_state::xsedae(machine_config &config)
 	m_seibu_sound->ym_write_callback().set("ymsnd", FUNC(ym2151_device::write));
 }
 
-/* ROM LOADING */
+// ROM LOADING
 /*
 Raiden II
 
@@ -1287,84 +1288,84 @@ differences amongst SND/u1110 ROMs:
 */
 
 ROM_START( raiden2 )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("prg0.u0211",   0x000000, 0x80000, CRC(09475ec4) SHA1(05027f2d8f9e11fcbd485659eda68ada286dae32) )
 	ROM_RELOAD(0x100000, 0x80000)
 	ROM_LOAD16_BYTE("prg1.u0212",   0x000001, 0x80000, CRC(4609b5f2) SHA1(272d2aa75b8ea4d133daddf42c4fc9089093df2e) )
 	ROM_RELOAD(0x100001, 0x80000)
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "snd.u1110",  0x000000, 0x08000, CRC(f51a28f9) SHA1(7ae2e2ba0c8159a544a8fd2bb0c2c694ba849302) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
-	ROM_LOAD( "seibu7.u0724", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) /* PCB silkscreened FX0 */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
+	ROM_LOAD( "seibu7.u0724", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) // PCB silkscreened FX0
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
-	ROM_LOAD( "seibu6.u1017", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) /* PCB silkscreened VOICE1 */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
+	ROM_LOAD( "seibu6.u1017", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) // PCB silkscreened VOICE1
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 ROM_START( raiden2g )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("prg0.u0211",   0x000000, 0x80000, CRC(09475ec4) SHA1(05027f2d8f9e11fcbd485659eda68ada286dae32) ) // rom1 - same code base as raiden2
 	ROM_RELOAD(0x100000, 0x80000)
 	ROM_LOAD16_BYTE("prg1g.u0212",   0x000001, 0x80000, CRC(41001d2e) SHA1(06bece44c081ecbb3b8dac5c515e30c5a5ffc1bf) )
 	ROM_RELOAD(0x100001, 0x80000)
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "snd.u1110",  0x000000, 0x08000, CRC(f51a28f9) SHA1(7ae2e2ba0c8159a544a8fd2bb0c2c694ba849302) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
-	ROM_LOAD( "seibu7.u0724", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) /* PCB silkscreened FX0 - sldh w/raiden2u */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
+	ROM_LOAD( "seibu7.u0724", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) // PCB silkscreened FX0 - sldh w/raiden2u
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
-	ROM_LOAD( "seibu6.u1017", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) /* PCB silkscreened VOICE1 */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
+	ROM_LOAD( "seibu6.u1017", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) // PCB silkscreened VOICE1
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
@@ -1387,44 +1388,44 @@ S5 U0724     27C1024     ROM7        966D
 */
 
 ROM_START( raiden2hk )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("prg0.u0211",   0x000000, 0x80000, CRC(09475ec4) SHA1(05027f2d8f9e11fcbd485659eda68ada286dae32) ) // rom1 - same code base as raiden2
 	ROM_RELOAD(0x100000, 0x80000)
 	ROM_LOAD16_BYTE("rom2e.u0212",  0x000001, 0x80000, CRC(458d619c) SHA1(842bf0eeb5d192a6b188f4560793db8dad697683) )
 	ROM_RELOAD(0x100001, 0x80000)
 
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu5.u1110",  0x000000, 0x08000, CRC(8f130589) SHA1(e58c8beaf9f27f063ffbcb0ab4600123c25ce6f3) ) // sldh w/raiden2u
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
-	ROM_LOAD( "seibu7.u0724", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) /* PCB silkscreened FX0 */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
+	ROM_LOAD( "seibu7.u0724", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) // PCB silkscreened FX0
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
-	ROM_LOAD( "seibu6.u1017", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) /* PCB silkscreened VOICE1 */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
+	ROM_LOAD( "seibu6.u1017", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) // PCB silkscreened VOICE1
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
@@ -1464,295 +1465,295 @@ CUSTOM:       SEI150
 */
 
 ROM_START( raiden2j )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("prg0.u0211",   0x000000, 0x80000, CRC(09475ec4) SHA1(05027f2d8f9e11fcbd485659eda68ada286dae32) ) // rom1 - same code base as raiden2
 	ROM_RELOAD(0x100000, 0x80000)
 	ROM_LOAD16_BYTE("rom2j.u0212",  0x000001, 0x80000, CRC(e4e4fb4c) SHA1(7ccf33fe9a1cddf0c7e80d7ed66d615a828b3bb9) )
 	ROM_RELOAD(0x100001, 0x80000)
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu5.u1110",  0x000000, 0x08000, CRC(8f130589) SHA1(e58c8beaf9f27f063ffbcb0ab4600123c25ce6f3) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
-	ROM_LOAD( "seibu7.u0724", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) /* PCB silkscreened FX0 */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
+	ROM_LOAD( "seibu7.u0724", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) // PCB silkscreened FX0
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
-	ROM_LOAD( "seibu6.u1017", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) /* PCB silkscreened VOICE1 - sldh w/raiden2u */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
+	ROM_LOAD( "seibu6.u1017", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) // PCB silkscreened VOICE1 - sldh w/raiden2u
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 ROM_START( raiden2sw ) // original board with serial # 0008307
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("seibu_1.u0211",   0x000000, 0x80000, CRC(09475ec4) SHA1(05027f2d8f9e11fcbd485659eda68ada286dae32) ) // rom1 - same code base as raiden2 - sldh w/raiden2eu
 	ROM_RELOAD(0x100000, 0x80000)
 	ROM_LOAD16_BYTE("seibu_2.u0212",   0x000001, 0x80000, CRC(59abc2ec) SHA1(45f2dbd2dd46f5da07dae0dc486772f8e61f4c43) ) // sldh w/raiden2eu
 	ROM_RELOAD(0x100001, 0x80000)
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu_5.u1110",  0x000000, 0x08000, CRC(c2028ba2) SHA1(f6a9322b669ff82dea6ecf52ad3bd5d0901cce1b) ) // 99.993896% match
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
-	ROM_LOAD( "seibu_7.u0724", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) /* PCB silkscreened FX0 */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
+	ROM_LOAD( "seibu_7.u0724", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) // PCB silkscreened FX0
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
-	ROM_LOAD( "seibu_6.u1017", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) /* PCB silkscreened VOICE1 */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
+	ROM_LOAD( "seibu_6.u1017", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) // PCB silkscreened VOICE1
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 ROM_START( raiden2f ) // original board with serial # 12476 that matches raiden2nl set except the region and Audio CPU
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("1_u0211.bin",   0x000000, 0x80000, CRC(53be3dd0) SHA1(304d118423e4085eea3b883bd625d90d21bb2054) )   // same code base as raiden2nl & raiden2es
 	ROM_RELOAD(0x100000, 0x80000)
 	ROM_LOAD16_BYTE("seibu2_u0212.bin",  0x000001, 0x80000, CRC(8dcd8a8d) SHA1(be0681d5867d8b4f5fb78946a896d89827a71e8e) )
 	ROM_RELOAD(0x100001, 0x80000)
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu5_u1110.bin",  0x000000, 0x08000, CRC(f51a28f9) SHA1(7ae2e2ba0c8159a544a8fd2bb0c2c694ba849302) )   // == raiden2
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
-	ROM_LOAD( "7_u0724.bin", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) /* PCB silkscreened FX0 */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
+	ROM_LOAD( "7_u0724.bin", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) // PCB silkscreened FX0
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
-	ROM_LOAD( "6_u1017.bin", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) /* PCB silkscreened VOICE1 */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
+	ROM_LOAD( "6_u1017.bin", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) // PCB silkscreened VOICE1
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 ROM_START( raiden2nl )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("1_u0211.bin",   0x000000, 0x80000, CRC(53be3dd0) SHA1(304d118423e4085eea3b883bd625d90d21bb2054) )   // same code base as raiden2f & raiden2es
 	ROM_RELOAD(0x100000, 0x80000)
 	ROM_LOAD16_BYTE("2_u0212.bin",  0x000001, 0x80000, CRC(88829c08) SHA1(ecdfbafeeffcd009bbc4cf5bf797bcd4b5bfcf50) )
 	ROM_RELOAD(0x100001, 0x80000)
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "5_u1110.bin",  0x000000, 0x08000, CRC(8f130589) SHA1(e58c8beaf9f27f063ffbcb0ab4600123c25ce6f3) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
-	ROM_LOAD( "7_u0724.bin", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) /* PCB silkscreened FX0 */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
+	ROM_LOAD( "7_u0724.bin", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) // PCB silkscreened FX0
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
-	ROM_LOAD( "6_u1017.bin", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) /* PCB silkscreened VOICE1 */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
+	ROM_LOAD( "6_u1017.bin", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) // PCB silkscreened VOICE1
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 ROM_START( raiden2es )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("1_u0211.bin",   0x000000, 0x80000, CRC(53be3dd0) SHA1(304d118423e4085eea3b883bd625d90d21bb2054) )   // same code base as raiden2f & raiden2nl
 	ROM_RELOAD(0x100000, 0x80000)
 	ROM_LOAD16_BYTE("2_u0212.rom",  0x000001, 0x80000, CRC(9dbec61c) SHA1(59ed06d9f97d93486dec2c0d8c0f42f59fb19db0) )
 	ROM_RELOAD(0x100001, 0x80000)
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "5_u1110.bin",  0x000000, 0x08000, CRC(8f130589) SHA1(e58c8beaf9f27f063ffbcb0ab4600123c25ce6f3) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
-	ROM_LOAD( "7_u0724.bin", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) /* PCB silkscreened FX0 */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
+	ROM_LOAD( "7_u0724.bin", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) // PCB silkscreened FX0
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
-	ROM_LOAD( "6_u1017.bin", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) /* PCB silkscreened VOICE1 */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
+	ROM_LOAD( "6_u1017.bin", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) // PCB silkscreened VOICE1
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 ROM_START( raiden2u )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("1.u0211",  0x000000, 0x80000, CRC(b16df955) SHA1(9b7fd85cf2f2c9fea657f3c38abafa93673b3933) ) // unique unknown code base
 	ROM_RELOAD(0x100000, 0x80000)
 	ROM_LOAD16_BYTE("2.u0212",  0x000001, 0x80000, CRC(2a14b112) SHA1(84cd9891b5be0b71b2bae3487ad38bed3045305e) )
 	ROM_RELOAD(0x100001, 0x80000)
 
-	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", 0 ) // 64k code for sound Z80
 	ROM_LOAD( "seibu5.u1110", 0x000000, 0x08000, CRC(6d362472) SHA1(a362e500bb9492affde1f7a4da7e08dd16e755df) ) // sldh w/raiden2hk
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "seibu7.u0724", 0x000000, 0x020000, CRC(c7aa4d00) SHA1(9ad99d3891598c1ea3f12318400ee67666da56dd) ) // sldh w/raiden2g
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "seibu6.u1017", 0x00000, 0x40000, CRC(fab9f8e4) SHA1(b1eff154c4f766b2d272ac6a57f8d54c9e39e3bb) ) // sldh w/raiden2j
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 ROM_START( raiden2i )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
-	ROM_LOAD16_BYTE("seibu1.u0211",   0x000000, 0x80000, CRC(c1fc70f5) SHA1(a054f5ae9583972c406d9cf871340d5e072d71a3) ) /* Italian set  - unique unknown code base */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
+	ROM_LOAD16_BYTE("seibu1.u0211",   0x000000, 0x80000, CRC(c1fc70f5) SHA1(a054f5ae9583972c406d9cf871340d5e072d71a3) ) // Italian set  - unique unknown code base
 	ROM_RELOAD(0x100000, 0x80000)
 	ROM_LOAD16_BYTE("seibu2.u0212",   0x000001, 0x80000, CRC(28d5365f) SHA1(21efe29c2d373229c2ff302d86e59c2c94fa6d03) )
 	ROM_RELOAD(0x100001, 0x80000)
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu5.c.u1110",  0x000000, 0x08000, CRC(5db9f922) SHA1(8257aab98657fe44df19d2a48d85fcf65b3d98c6) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
-	ROM_LOAD( "seibu7.u0724", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) /* PCB silkscreened FX0 */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
+	ROM_LOAD( "seibu7.u0724", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) // PCB silkscreened FX0
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
-	ROM_LOAD( "seibu6.u1017", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) /* PCB silkscreened VOICE1 */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
+	ROM_LOAD( "seibu6.u1017", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) // PCB silkscreened VOICE1
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 
 ROM_START( raiden2au )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("1.u0211",   0x000000, 0x80000, CRC(c1fc70f5) SHA1(a054f5ae9583972c406d9cf871340d5e072d71a3) )
 	ROM_RELOAD(                  0x100000, 0x80000)
 	ROM_LOAD16_BYTE("2.u0212",   0x000001, 0x80000, CRC(396410f9) SHA1(a3f737ae1fb6229388d3ebec93e880218d09fed5) ) // Australian set
@@ -1763,74 +1764,74 @@ ROM_START( raiden2au )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "7.u0724", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "6.u1017", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) )
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "voice_2.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 
 ROM_START( raiden2k )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("k1.u0211",   0x000000, 0x80000, CRC(1fcc08cf) SHA1(bff7076ced189120166217d71e2762bb98aad7c8) ) // hand-written
 	ROM_RELOAD(0x100000, 0x80000)
 	ROM_LOAD16_BYTE("k2.u0212",   0x000001, 0x80000, CRC(59a744ca) SHA1(5fdd7dd4049f944df23371e2e2d3133b10c66ab8) ) // hand-written
 	ROM_RELOAD(0x100001, 0x80000)
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "snd.u1110",  0x000000, 0x08000, CRC(f51a28f9) SHA1(7ae2e2ba0c8159a544a8fd2bb0c2c694ba849302) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
-	ROM_LOAD( "seibu7.u0724", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) /* PCB silkscreened FX0 */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
+	ROM_LOAD( "seibu7.u0724", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) // PCB silkscreened FX0
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
-	ROM_LOAD( "seibu6.u1017", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) /* PCB silkscreened VOICE1 */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
+	ROM_LOAD( "seibu6.u1017", 0x00000, 0x40000, CRC(fb0fca23) SHA1(4b2217b121a66c5ab6015537609cf908ffedaf86) ) // PCB silkscreened VOICE1
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
@@ -1852,130 +1853,130 @@ http://www.gamefaqs.com/coinop/arcade/game/10729.html
 */
 
 ROM_START( raiden2e )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("r2_prg_0.u0211",   0x000000, 0x80000, CRC(2abc848c) SHA1(1df4276d0074fcf1267757fa0b525a980a520f3d) )
 	ROM_RELOAD(0x100000, 0x80000)
 	ROM_LOAD16_BYTE("r2_prg_1.u0212",   0x000001, 0x80000, CRC(509ade43) SHA1(7cdee7bb00a6a1c7899d10b96385d54c261f6f5a) )
 	ROM_RELOAD(0x100001, 0x80000)
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "r2_snd.u1110", 0x000000, 0x08000, CRC(6bad0a3e) SHA1(eb7ae42353e1984cd60b569c26cdbc3b025a7da6) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "r2_fx0.u0724",   0x000000, 0x020000, CRC(c709bdf6) SHA1(0468d90412b7590d67eaadc0a5e3537cd5e73943) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "r2_voi1.u1017", 0x00000, 0x40000, CRC(488d050f) SHA1(fde2fd64fea6bc39e1a42885d21d362bc6be2ac2) )
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 ROM_START( raiden2ea )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("r2.1.u0211",  0x000000, 0x80000, CRC(d7041be4) SHA1(3cf97132fba6f7b00c9059265f4e9f0bf1505b71) )
 	ROM_RELOAD(0x100000, 0x80000)
 	ROM_LOAD16_BYTE("r2.2.u0212",  0x000001, 0x80000, CRC(bf7577ec) SHA1(98576af78760b8aef1ef3efe1ba963977c89d225) )
 	ROM_RELOAD(0x100001, 0x80000)
 
-	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", 0 ) // 64k code for sound Z80
 	ROM_LOAD( "r2.5.u1110", 0x000000, 0x08000, CRC(f5f835af) SHA1(5be82ebc582d0da919e9ae1b9e64528bb295efc7) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "r2.7.u0724", 0x000000, 0x020000, CRC(c7aa4d00) SHA1(9ad99d3891598c1ea3f12318400ee67666da56dd) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "r2.6.u1017", 0x00000, 0x40000, CRC(fab9f8e4) SHA1(b1eff154c4f766b2d272ac6a57f8d54c9e39e3bb) )
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 ROM_START( raiden2eu ) // same as raiden2ea, different region
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("seibu_1.u0211",  0x000000, 0x80000, CRC(d7041be4) SHA1(3cf97132fba6f7b00c9059265f4e9f0bf1505b71) ) // sldh w/raiden2sw
 	ROM_RELOAD(0x100000, 0x80000)
 	ROM_LOAD16_BYTE("seibu_2.u0212",  0x000001, 0x80000, CRC(beb71ddb) SHA1(471399ead1cdc27ac2a1139f9616f828efd14626) ) // sldh w/raiden2sw
 	ROM_RELOAD(0x100001, 0x80000)
 
-	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", 0 ) // 64k code for sound Z80
 	ROM_LOAD( "r2.5.u1110", 0x000000, 0x08000, CRC(f5f835af) SHA1(5be82ebc582d0da919e9ae1b9e64528bb295efc7) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "r2.7.u0724", 0x000000, 0x020000, CRC(c7aa4d00) SHA1(9ad99d3891598c1ea3f12318400ee67666da56dd) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "r2.6.u1017", 0x00000, 0x40000, CRC(fab9f8e4) SHA1(b1eff154c4f766b2d272ac6a57f8d54c9e39e3bb) )
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 ROM_START( raiden2eua ) // sort of a mixture of raiden2e easy set with voice ROM of raiden2ea and 2f and a unique sound ROM
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("seibu__1.27c020j.u1210",   0x000000, 0x40000, CRC(ed1514e3) SHA1(296125bfe3c4f3033f7aa319dd8554bc978c4a00) )
 	ROM_RELOAD(0x100000, 0x40000)
 	ROM_LOAD32_BYTE("seibu__2.27c2001.u1211",   0x000001, 0x40000, CRC(bb6ecf2a) SHA1(d4f628e9d0ed2897654f05a8a2541e1ed3faf8dd) )
@@ -1985,42 +1986,42 @@ ROM_START( raiden2eua ) // sort of a mixture of raiden2e easy set with voice ROM
 	ROM_LOAD32_BYTE("seibu__4.27c2001.u1212",   0x000003, 0x40000, CRC(e54bfa37) SHA1(4fabb23503fd9245a10cded15a6880415ca5ffd7) )
 	ROM_RELOAD(0x100003, 0x40000)
 
-	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", 0 ) // 64k code for sound Z80
 	ROM_LOAD( "seibu__5.27c512.u1110", 0x000000, 0x08000, CRC(6d362472) SHA1(a362e500bb9492affde1f7a4da7e08dd16e755df) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "seibu__7.fx0.27c210.u0724", 0x000000, 0x020000, CRC(c7aa4d00) SHA1(9ad99d3891598c1ea3f12318400ee67666da56dd) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "seibu__6.voice1.23c020.u1017", 0x00000, 0x40000, CRC(fab9f8e4) SHA1(b1eff154c4f766b2d272ac6a57f8d54c9e39e3bb) )
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 ROM_START( raiden2eg ) // this is the same code revision as raiden2eua but a german region
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("raiden_2_1.u1210",   0x000000, 0x40000, CRC(ed1514e3) SHA1(296125bfe3c4f3033f7aa319dd8554bc978c4a00) )
 	ROM_RELOAD(0x100000, 0x40000)
 	ROM_LOAD32_BYTE("raiden_2_2.u1211",   0x000001, 0x40000, CRC(bb6ecf2a) SHA1(d4f628e9d0ed2897654f05a8a2541e1ed3faf8dd) )
@@ -2030,42 +2031,42 @@ ROM_START( raiden2eg ) // this is the same code revision as raiden2eua but a ger
 	ROM_LOAD32_BYTE("raiden_2_4.u1212",   0x000003, 0x40000, CRC(81273f33) SHA1(074cedf44cc5286649cc101bce0b48d40234e472) )
 	ROM_RELOAD(0x100003, 0x40000)
 
-	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", 0 ) // 64k code for sound Z80
 	ROM_LOAD( "raiden_2_5.bin", 0x000000, 0x08000, CRC(6d362472) SHA1(a362e500bb9492affde1f7a4da7e08dd16e755df) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "raiden_2_7.bin", 0x000000, 0x020000, CRC(c7aa4d00) SHA1(9ad99d3891598c1ea3f12318400ee67666da56dd) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_6.bin", 0x00000, 0x40000, CRC(fab9f8e4) SHA1(b1eff154c4f766b2d272ac6a57f8d54c9e39e3bb) )
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 ROM_START( raiden2eup )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("prg0 11-16.u1210",   0x000000, 0x40000, CRC(0a68a400) SHA1(7b3baae086ea9604af29eabde358da358d43591f) )
 	ROM_RELOAD(0x100000, 0x40000)
 	ROM_LOAD32_BYTE("prg1 11-16.u1211",   0x000001, 0x40000, CRC(45a01ebe) SHA1(8b114198130ead8a70cc64b195fba5a3507ff6cb) )
@@ -2075,520 +2076,520 @@ ROM_START( raiden2eup )
 	ROM_LOAD32_BYTE("prg3a 11-16.u1212",  0x000003, 0x40000, CRC(42ce511b) SHA1(59f199cb52cb315ddea0373b978541b8efeb57a3) )
 	ROM_RELOAD(0x100003, 0x40000)
 
-	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", 0 ) // 64k code for sound Z80
 	ROM_LOAD( "sound 11-12.bin", 0x000000, 0x08000, CRC(4fac206c) SHA1(47b78b2efe88729df07033a8674ba203cdf2e44c) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "fix.bin", 0x000000, 0x020000, CRC(6a6fa0de) SHA1(4e2ba9e84f5f5684b480e6d7f86bfc08ac9f5337) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "pcm 11-11.bin", 0x00000, 0x40000, CRC(c541c729) SHA1(23f0b454d8d813bfcdb831ee5a8547178892231f) )
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 ROM_START( raiden2eub )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD16_BYTE("r2_prg_0.u0211",   0x000000, 0x80000, CRC(2abc848c) SHA1(1df4276d0074fcf1267757fa0b525a980a520f3d) )
 	ROM_RELOAD(0x100000, 0x80000)
 	ROM_LOAD16_BYTE("r2_prg_1.u0212",   0x000001, 0x80000, CRC(56511ca8) SHA1(1073f9a5dab185b161306d1f0db44ae84865294b) )
 	ROM_RELOAD(0x100001, 0x80000)
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "r2_snd.u1110", 0x000000, 0x08000, CRC(6d362472) SHA1(a362e500bb9492affde1f7a4da7e08dd16e755df) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "r2.7.u0724",   0x000000, 0x020000, CRC(c7aa4d00) SHA1(9ad99d3891598c1ea3f12318400ee67666da56dd) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "r2.6.u1017", 0x00000, 0x40000, CRC(fab9f8e4) SHA1(b1eff154c4f766b2d272ac6a57f8d54c9e39e3bb) )
 
 	// Common Raiden II PALs below
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "jj4b02__ami18cv8-15.u0342",   0x0000, 0x155, CRC(057a9cdc) SHA1(8b46f6673ddf11efbc3394ae423ec89d4a1283bf) )
 	ROM_LOAD( "jj4b01__mmipal16l8bcn.u0341", 0x0000, 0x117, CRC(20931f21) SHA1(95ce9cfbfb280dfc6a326e378684eff3c6f54701) )
 
 	// Common Raiden II soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313", 0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "raiden_2_seibu_bg-1.u0714", 0x000000, 0x200000, CRC(e61ad38e) SHA1(63b06cd38db946ad3fc5c1482dc863ef80b58fec) )
 	ROM_LOAD( "raiden_2_seibu_bg-2.u075",  0x200000, 0x200000, CRC(a694a4bb) SHA1(39c2614d0effc899fe58f735604283097769df77) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-3.u0837", 0x400000, 0x200000, CRC(897a0322) SHA1(abb2737a2446da5b364fc2d96524b43d808f4126) )
 	ROM_LOAD32_WORD( "raiden_2_seibu_obj-4.u0836", 0x400002, 0x200000, CRC(b676e188) SHA1(19cc838f1ccf9c4203cd0e5365e5d99ff3a4ff0f) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
 	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) )
 ROM_END
 
 ROM_START( raiden2dx ) // this set is very weird, it's Raiden II on a Raiden DX board, I'm assuming for now that it uses Raiden DX graphics, but could be wrong.
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("u1210.bin",      0x000000, 0x80000, CRC(413241e0) SHA1(50fa501db91412baea474a8faf8ad483f3a119c7) )
 	ROM_LOAD32_BYTE("prg1_u1211.bin", 0x000001, 0x80000, CRC(93491f56) SHA1(2239980fb7267906e4c3985703c2dc2932b23705) )
 	ROM_LOAD32_BYTE("u129.bin",       0x000002, 0x80000, CRC(e0932b6c) SHA1(04f1ca885d220e802023042438f63e40e4106696) )
 	ROM_LOAD32_BYTE("u1212.bin",      0x000003, 0x80000, CRC(505423f4) SHA1(d8e65580deec05dd84c4cf3074cb690e3764c625) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "u1110.bin",  0x000000, 0x08000,  CRC(b8ad8fe7) SHA1(290896f811f717ef6e3ec2152d4db98a9fe9b310) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	//ROM_LOAD( "fx0_u0724.bin",    0x000000,   0x020000,   CRC(ded3c718) SHA1(c722ec45cd1b2dab23aac14e9113e0e9697830d3) ) // bad dump
-	ROM_LOAD( "7_u0724.bin", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) /* PCB silkscreened FX0 */
+	ROM_LOAD( "7_u0724.bin", 0x000000, 0x020000, CRC(c9ec9469) SHA1(a29f480a1bee073be7a177096ef58e1887a5af24) ) // PCB silkscreened FX0
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "dx_6.3b",   0x00000, 0x40000, CRC(9a9196da) SHA1(3d1ee67fb0d40a231ce04d10718f07ffb76db455) )
 
 	// Common Raiden DX(!) soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
-	ROM_LOAD( "copx-d2.6s",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) /* Shared with original Raiden 2 */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
+	ROM_LOAD( "copx-d2.6s",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) // Shared with original Raiden 2
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "dx_back1.1s",   0x000000, 0x200000, CRC(90970355) SHA1(d71d57cd550a800f583550365102adb7b1b779fc) )
 	ROM_LOAD( "dx_back2.2s",   0x200000, 0x200000, CRC(5799af3e) SHA1(85d6532abd769da77bcba70bd2e77915af40f987) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
-	ROM_LOAD32_WORD( "obj1",        0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) /* Shared with original Raiden 2 */
-	ROM_LOAD32_WORD( "obj2",        0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) /* Shared with original Raiden 2 */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
+	ROM_LOAD32_WORD( "obj1",        0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) // Shared with original Raiden 2
+	ROM_LOAD32_WORD( "obj2",        0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) // Shared with original Raiden 2
 	ROM_LOAD32_WORD( "dx_obj3.4k",  0x400000, 0x200000, CRC(ba381227) SHA1(dfc4d659aca1722a981fa56a31afabe66f444d5d) )
 	ROM_LOAD32_WORD( "dx_obj4.6k",  0x400002, 0x200000, CRC(65e50d19) SHA1(c46147b4132abce7314b46bf419ce4773e024b05) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
-	ROM_LOAD( "dx_pcm.3a", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) /* Shared with original Raiden 2 */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
+	ROM_LOAD( "dx_pcm.3a", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) // Shared with original Raiden 2
 ROM_END
 
-/* Raiden DX sets */
+// Raiden DX sets
 
 ROM_START( raidendx )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("1d.4n",   0x000000, 0x80000, CRC(14d725fc) SHA1(f12806f64f069fdc4ee29b309a32f7ca00b36f93) )
 	ROM_LOAD32_BYTE("2d.4p",   0x000001, 0x80000, CRC(5e7e45cb) SHA1(94eff893b5335c522f1c063c3175b9bac87b0a25) )
 	ROM_LOAD32_BYTE("3d.6n",   0x000002, 0x80000, CRC(f0a47e67) SHA1(8cbd21993077b2e01295db6e343cae9e0e4bfefe) )
 	ROM_LOAD32_BYTE("4d.6p",   0x000003, 0x80000, CRC(2a2003e8) SHA1(f239b351759babe4683d16e745a5ac2f3c2ab06b) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu_5.u1110",  0x000000, 0x08000, CRC(8c46857a) SHA1(8b269cb20adf960ba4eb594d8add7739dbc9a837) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "seibu_7.u0724",    0x000000,   0x020000,   CRC(c73986d4) SHA1(d29345077753bda53560dedc95dd23f329e521d9) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "seibu_6.u1017", 0x00000, 0x40000, CRC(9a9196da) SHA1(3d1ee67fb0d40a231ce04d10718f07ffb76db455) )
 
 	// Common Raiden DX soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
-	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) /* Shared with original Raiden 2 */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
+	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) // Shared with original Raiden 2
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "dx_back-1.u075",  0x000000, 0x200000, CRC(90970355) SHA1(d71d57cd550a800f583550365102adb7b1b779fc) )
 	ROM_LOAD( "dx_back-2.u0714", 0x200000, 0x200000, CRC(5799af3e) SHA1(85d6532abd769da77bcba70bd2e77915af40f987) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
-	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) /* Shared with original Raiden 2 */
-	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) /* Shared with original Raiden 2 */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
+	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) // Shared with original Raiden 2
+	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) // Shared with original Raiden 2
 	ROM_LOAD32_WORD( "dx_obj-3.u0837",       0x400000, 0x200000, CRC(ba381227) SHA1(dfc4d659aca1722a981fa56a31afabe66f444d5d) )
 	ROM_LOAD32_WORD( "dx_obj-4.u0836",       0x400002, 0x200000, CRC(65e50d19) SHA1(c46147b4132abce7314b46bf419ce4773e024b05) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
-	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) /* Mask ROM - Shared with original Raiden 2 */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
+	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) // Mask ROM - Shared with original Raiden 2
 ROM_END
 
 ROM_START( raidendxg )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("1d.u1210", 0x000000, 0x80000, CRC(14d725fc) SHA1(f12806f64f069fdc4ee29b309a32f7ca00b36f93) )
 	ROM_LOAD32_BYTE("2d.u1211", 0x000001, 0x80000, CRC(5e7e45cb) SHA1(94eff893b5335c522f1c063c3175b9bac87b0a25) )
 	ROM_LOAD32_BYTE("3d.u129",  0x000002, 0x80000, CRC(f0a47e67) SHA1(8cbd21993077b2e01295db6e343cae9e0e4bfefe) )
 	ROM_LOAD32_BYTE("4d.u1212", 0x000003, 0x80000, CRC(6bde6edc) SHA1(c3565a55b858c10659fd9b93b1cd92bc39e6446d) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu_5.u1110",  0x000000, 0x08000, CRC(8c46857a) SHA1(8b269cb20adf960ba4eb594d8add7739dbc9a837) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "seibu_7.u0724",    0x000000,   0x020000,   CRC(c73986d4) SHA1(d29345077753bda53560dedc95dd23f329e521d9) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "seibu_6.u1017", 0x00000, 0x40000, CRC(9a9196da) SHA1(3d1ee67fb0d40a231ce04d10718f07ffb76db455) )
 
 	// Common Raiden DX soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
-	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) /* Shared with original Raiden 2 */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
+	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) // Shared with original Raiden 2
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "dx_back-1.u075",  0x000000, 0x200000, CRC(90970355) SHA1(d71d57cd550a800f583550365102adb7b1b779fc) )
 	ROM_LOAD( "dx_back-2.u0714", 0x200000, 0x200000, CRC(5799af3e) SHA1(85d6532abd769da77bcba70bd2e77915af40f987) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
-	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) /* Shared with original Raiden 2 */
-	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) /* Shared with original Raiden 2 */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
+	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) // Shared with original Raiden 2
+	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) // Shared with original Raiden 2
 	ROM_LOAD32_WORD( "dx_obj-3.u0837",       0x400000, 0x200000, CRC(ba381227) SHA1(dfc4d659aca1722a981fa56a31afabe66f444d5d) )
 	ROM_LOAD32_WORD( "dx_obj-4.u0836",       0x400002, 0x200000, CRC(65e50d19) SHA1(c46147b4132abce7314b46bf419ce4773e024b05) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
-	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) /* Mask ROM - Shared with original Raiden 2 */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
+	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) // Mask ROM - Shared with original Raiden 2
 ROM_END
 
 ROM_START( raidendxpt )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("seibu_1d.u1210", 0x000000, 0x80000, CRC(14d725fc) SHA1(f12806f64f069fdc4ee29b309a32f7ca00b36f93) )
 	ROM_LOAD32_BYTE("seibu_2d.u1211", 0x000001, 0x80000, CRC(5e7e45cb) SHA1(94eff893b5335c522f1c063c3175b9bac87b0a25) )
 	ROM_LOAD32_BYTE("seibu_3d.u129",  0x000002, 0x80000, CRC(f0a47e67) SHA1(8cbd21993077b2e01295db6e343cae9e0e4bfefe) )
 	ROM_LOAD32_BYTE("seibu_4d.u1212", 0x000003, 0x80000, CRC(e4fa53ac) SHA1(640257420beba6acaeaf687fde34dd20aef7c41a) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu_5.u1110",  0x000000, 0x08000, CRC(8c46857a) SHA1(8b269cb20adf960ba4eb594d8add7739dbc9a837) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "seibu_7.u0724",    0x000000,   0x020000,   CRC(c73986d4) SHA1(d29345077753bda53560dedc95dd23f329e521d9) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "seibu_6.u1017", 0x00000, 0x40000, CRC(9a9196da) SHA1(3d1ee67fb0d40a231ce04d10718f07ffb76db455) )
 
 	// Common Raiden DX soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
-	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) /* Shared with original Raiden 2 */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
+	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) // Shared with original Raiden 2
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "dx_back-1.u075",  0x000000, 0x200000, CRC(90970355) SHA1(d71d57cd550a800f583550365102adb7b1b779fc) )
 	ROM_LOAD( "dx_back-2.u0714", 0x200000, 0x200000, CRC(5799af3e) SHA1(85d6532abd769da77bcba70bd2e77915af40f987) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
-	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) /* Shared with original Raiden 2 */
-	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) /* Shared with original Raiden 2 */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
+	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) // Shared with original Raiden 2
+	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) // Shared with original Raiden 2
 	ROM_LOAD32_WORD( "dx_obj-3.u0837",       0x400000, 0x200000, CRC(ba381227) SHA1(dfc4d659aca1722a981fa56a31afabe66f444d5d) )
 	ROM_LOAD32_WORD( "dx_obj-4.u0836",       0x400002, 0x200000, CRC(65e50d19) SHA1(c46147b4132abce7314b46bf419ce4773e024b05) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
-	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) /* Mask ROM - Shared with original Raiden 2 */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
+	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) // Mask ROM - Shared with original Raiden 2
 ROM_END
 
 ROM_START( raidendxa1 )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("dx_1h.4n",   0x000000, 0x80000, BAD_DUMP CRC(7624c36b) SHA1(84c17f2988031210d06536710e1eac558f4290a1) ) // bad
 	ROM_LOAD32_BYTE("dx_2h.4p",   0x000001, 0x80000, CRC(4940fdf3) SHA1(c87e307ed7191802583bee443c7c8e4f4e33db25) )
 	ROM_LOAD32_BYTE("dx_3h.6n",   0x000002, 0x80000, CRC(6c495bcf) SHA1(fb6153ecc443dabc829dda6f8d11234ad48de88a) )
 	ROM_LOAD32_BYTE("dx_4h.6k",   0x000003, 0x80000, CRC(9ed6335f) SHA1(66975204b120915f23258a431e19dbc017afd912) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu_5.u1110",  0x000000, 0x08000, CRC(8c46857a) SHA1(8b269cb20adf960ba4eb594d8add7739dbc9a837) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "seibu_7.u0724",    0x000000,   0x020000,   CRC(c73986d4) SHA1(d29345077753bda53560dedc95dd23f329e521d9) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "seibu_6.u1017", 0x00000, 0x40000, CRC(9a9196da) SHA1(3d1ee67fb0d40a231ce04d10718f07ffb76db455) )
 
 	// Common Raiden DX soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
-	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) /* Shared with original Raiden 2 */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
+	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) // Shared with original Raiden 2
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "dx_back-1.u075",  0x000000, 0x200000, CRC(90970355) SHA1(d71d57cd550a800f583550365102adb7b1b779fc) )
 	ROM_LOAD( "dx_back-2.u0714", 0x200000, 0x200000, CRC(5799af3e) SHA1(85d6532abd769da77bcba70bd2e77915af40f987) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
-	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) /* Shared with original Raiden 2 */
-	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) /* Shared with original Raiden 2 */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
+	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) // Shared with original Raiden 2
+	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) // Shared with original Raiden 2
 	ROM_LOAD32_WORD( "dx_obj-3.u0837",       0x400000, 0x200000, CRC(ba381227) SHA1(dfc4d659aca1722a981fa56a31afabe66f444d5d) )
 	ROM_LOAD32_WORD( "dx_obj-4.u0836",       0x400002, 0x200000, CRC(65e50d19) SHA1(c46147b4132abce7314b46bf419ce4773e024b05) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
-	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) /* Mask ROM - Shared with original Raiden 2 */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
+	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) // Mask ROM - Shared with original Raiden 2
 ROM_END
 
 ROM_START( raidendxa2 )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("1d.bin",   0x000000, 0x80000, CRC(22b155ae) SHA1(388151e2c8fb301bd5bc66a974e9fe16816ae0bc) )
 	ROM_LOAD32_BYTE("2d.bin",   0x000001, 0x80000, CRC(2be98ca8) SHA1(491e990405b0ad3de45bdbcc2453af9215ae19c8) )
 	ROM_LOAD32_BYTE("3d.bin",   0x000002, 0x80000, CRC(b4785576) SHA1(aa5eee7b0c635c6d18a7fc1e037bf570a677dd90) )
 	ROM_LOAD32_BYTE("4d.bin",   0x000003, 0x80000, CRC(5a77f7b4) SHA1(aa757e6308893ca63963170c5b1743de7c7ab034) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu_5.u1110",  0x000000, 0x08000, CRC(8c46857a) SHA1(8b269cb20adf960ba4eb594d8add7739dbc9a837) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "seibu_7.u0724",    0x000000,   0x020000,   CRC(c73986d4) SHA1(d29345077753bda53560dedc95dd23f329e521d9) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "seibu_6.u1017", 0x00000, 0x40000, CRC(9a9196da) SHA1(3d1ee67fb0d40a231ce04d10718f07ffb76db455) )
 
 	// Common Raiden DX soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
-	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) /* Shared with original Raiden 2 */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
+	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) // Shared with original Raiden 2
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "dx_back-1.u075",  0x000000, 0x200000, CRC(90970355) SHA1(d71d57cd550a800f583550365102adb7b1b779fc) )
 	ROM_LOAD( "dx_back-2.u0714", 0x200000, 0x200000, CRC(5799af3e) SHA1(85d6532abd769da77bcba70bd2e77915af40f987) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
-	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) /* Shared with original Raiden 2 */
-	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) /* Shared with original Raiden 2 */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
+	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) // Shared with original Raiden 2
+	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) // Shared with original Raiden 2
 	ROM_LOAD32_WORD( "dx_obj-3.u0837",       0x400000, 0x200000, CRC(ba381227) SHA1(dfc4d659aca1722a981fa56a31afabe66f444d5d) )
 	ROM_LOAD32_WORD( "dx_obj-4.u0836",       0x400002, 0x200000, CRC(65e50d19) SHA1(c46147b4132abce7314b46bf419ce4773e024b05) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
-	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) /* Mask ROM - Shared with original Raiden 2 */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
+	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) // Mask ROM - Shared with original Raiden 2
 ROM_END
 
 ROM_START( raidendxk )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("rdxj_1.bin",   0x000000, 0x80000, CRC(b5b32885) SHA1(fb3c592b2436d347103c17bd765176062be95fa2) )
 	ROM_LOAD32_BYTE("rdxj_2.bin",   0x000001, 0x80000, CRC(7efd581d) SHA1(4609a0d8afb3d62a38b461089295efed47beea91) )
 	ROM_LOAD32_BYTE("rdxj_3.bin",   0x000002, 0x80000, CRC(55ec0e1d) SHA1(6be7f268df51311a817c1c329a578b38abb659ae) )
 	ROM_LOAD32_BYTE("rdxj_4.bin",   0x000003, 0x80000, CRC(f8fb31b4) SHA1(b72fd7cbbebcf3d1b2253c309fcfa60674776467) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu_5.u1110",  0x000000, 0x08000, CRC(8c46857a) SHA1(8b269cb20adf960ba4eb594d8add7739dbc9a837) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "seibu_7.u0724",    0x000000,   0x020000,   CRC(c73986d4) SHA1(d29345077753bda53560dedc95dd23f329e521d9) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "seibu_6.u1017", 0x00000, 0x40000, CRC(9a9196da) SHA1(3d1ee67fb0d40a231ce04d10718f07ffb76db455) )
 
 	// Common Raiden DX soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
-	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) /* Shared with original Raiden 2 */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
+	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) // Shared with original Raiden 2
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "dx_back-1.u075",  0x000000, 0x200000, CRC(90970355) SHA1(d71d57cd550a800f583550365102adb7b1b779fc) )
 	ROM_LOAD( "dx_back-2.u0714", 0x200000, 0x200000, CRC(5799af3e) SHA1(85d6532abd769da77bcba70bd2e77915af40f987) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
-	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) /* Shared with original Raiden 2 */
-	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) /* Shared with original Raiden 2 */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
+	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) // Shared with original Raiden 2
+	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) // Shared with original Raiden 2
 	ROM_LOAD32_WORD( "dx_obj-3.u0837",       0x400000, 0x200000, CRC(ba381227) SHA1(dfc4d659aca1722a981fa56a31afabe66f444d5d) )
 	ROM_LOAD32_WORD( "dx_obj-4.u0836",       0x400002, 0x200000, CRC(65e50d19) SHA1(c46147b4132abce7314b46bf419ce4773e024b05) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
-	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) /* Mask ROM - Shared with original Raiden 2 */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
+	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) // Mask ROM - Shared with original Raiden 2
 ROM_END
 
 ROM_START( raidendxu )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("1a.u1210", 0x000000, 0x80000, CRC(53e63194) SHA1(a957330e14649cf46ad27fb99c460576c59e60b1) )
 	ROM_LOAD32_BYTE("2a.u1211", 0x000001, 0x80000, CRC(ec8d1647) SHA1(5ceae132c6c09d6bb8565e9141ee1170bbdfd5fc) )
 	ROM_LOAD32_BYTE("3a.u129",  0x000002, 0x80000, CRC(7dbfd73d) SHA1(43cb1dbc3ccbded64fc300c262d1fd528e0391a2) )
 	ROM_LOAD32_BYTE("4a.u1212", 0x000003, 0x80000, CRC(cb41a459) SHA1(532f0ed00a5b50a7537e5f48884d632aa5b92fb0) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu_5.u1110",  0x000000, 0x08000, CRC(8c46857a) SHA1(8b269cb20adf960ba4eb594d8add7739dbc9a837) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "seibu_7.u0724",    0x000000,   0x020000,   CRC(c73986d4) SHA1(d29345077753bda53560dedc95dd23f329e521d9) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "seibu_6.u1017", 0x00000, 0x40000, CRC(9a9196da) SHA1(3d1ee67fb0d40a231ce04d10718f07ffb76db455) )
 
 	// Common Raiden DX soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
-	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) /* Shared with original Raiden 2 */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
+	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) // Shared with original Raiden 2
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "dx_back-1.u075",  0x000000, 0x200000, CRC(90970355) SHA1(d71d57cd550a800f583550365102adb7b1b779fc) )
 	ROM_LOAD( "dx_back-2.u0714", 0x200000, 0x200000, CRC(5799af3e) SHA1(85d6532abd769da77bcba70bd2e77915af40f987) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
-	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) /* Shared with original Raiden 2 */
-	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) /* Shared with original Raiden 2 */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
+	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) // Shared with original Raiden 2
+	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) // Shared with original Raiden 2
 	ROM_LOAD32_WORD( "dx_obj-3.u0837",       0x400000, 0x200000, CRC(ba381227) SHA1(dfc4d659aca1722a981fa56a31afabe66f444d5d) )
 	ROM_LOAD32_WORD( "dx_obj-4.u0836",       0x400002, 0x200000, CRC(65e50d19) SHA1(c46147b4132abce7314b46bf419ce4773e024b05) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
-	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) /* Mask ROM - Shared with original Raiden 2 */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
+	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) // Mask ROM - Shared with original Raiden 2
 ROM_END
 
 ROM_START( raidendxnl )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("u1210_4n.bin", 0x000000, 0x80000, CRC(c589019a) SHA1(9bdd7f7d0bca16d67ba234d8a1fed5d2c8ab7191) )
 	ROM_LOAD32_BYTE("u1211_4p.bin", 0x000001, 0x80000, CRC(b2222254) SHA1(b0e41d88111a96f0c0fb11b20ea99f436e8d493d) )
 	ROM_LOAD32_BYTE("u129_6n.bin",  0x000002, 0x80000, CRC(60f04634) SHA1(50f1b721a017d879838d920cf5d5355aa024e09b) )
 	ROM_LOAD32_BYTE("u1212_6p.bin", 0x000003, 0x80000, CRC(21ec37cc) SHA1(6da629e2bb5bd4c2192156af017148e99e274544) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu_5.u1110",  0x000000, 0x08000, CRC(8c46857a) SHA1(8b269cb20adf960ba4eb594d8add7739dbc9a837) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "seibu_7.u0724",    0x000000,   0x020000,   CRC(c73986d4) SHA1(d29345077753bda53560dedc95dd23f329e521d9) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "seibu_6.u1017", 0x00000, 0x40000, CRC(9a9196da) SHA1(3d1ee67fb0d40a231ce04d10718f07ffb76db455) )
 
 	// Common Raiden DX soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
-	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) /* Shared with original Raiden 2 */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
+	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) // Shared with original Raiden 2
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "dx_back-1.u075",  0x000000, 0x200000, CRC(90970355) SHA1(d71d57cd550a800f583550365102adb7b1b779fc) )
 	ROM_LOAD( "dx_back-2.u0714", 0x200000, 0x200000, CRC(5799af3e) SHA1(85d6532abd769da77bcba70bd2e77915af40f987) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
-	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) /* Shared with original Raiden 2 */
-	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) /* Shared with original Raiden 2 */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
+	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) // Shared with original Raiden 2
+	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) // Shared with original Raiden 2
 	ROM_LOAD32_WORD( "dx_obj-3.u0837",       0x400000, 0x200000, CRC(ba381227) SHA1(dfc4d659aca1722a981fa56a31afabe66f444d5d) )
 	ROM_LOAD32_WORD( "dx_obj-4.u0836",       0x400002, 0x200000, CRC(65e50d19) SHA1(c46147b4132abce7314b46bf419ce4773e024b05) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
-	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) /* Mask ROM - Shared with original Raiden 2 */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
+	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) // Mask ROM - Shared with original Raiden 2
 ROM_END
 
 ROM_START( raidendxj )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("rdxj_1.u1211", 0x000000, 0x80000, CRC(5af382e1) SHA1(a11fc181da322f484815f55a510ce7e6c7df2d60) )
 	ROM_LOAD32_BYTE("rdxj_2.u0212", 0x000001, 0x80000, CRC(899966fc) SHA1(0f91c2b05a44afb4c4b74e115a8fa530fb6d6414) )
 	ROM_LOAD32_BYTE("rdxj_3.u129",  0x000002, 0x80000, CRC(e7f08013) SHA1(1f99672d8fdbda847c6552da210c417b21ca78ac) )
 	ROM_LOAD32_BYTE("rdxj_4.u1212", 0x000003, 0x80000, CRC(78037e1f) SHA1(8d9c4188ca808e670e330e70e906bb1d27e36492) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu_5.u1110",  0x000000, 0x08000, CRC(8c46857a) SHA1(8b269cb20adf960ba4eb594d8add7739dbc9a837) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "rdxj_7.u0724", 0x000000, 0x020000, CRC(ec31fa10) SHA1(e39c9d95699dbeb21e3661d863eee503c9011bbc) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "seibu_6.u1017", 0x00000, 0x40000, CRC(9a9196da) SHA1(3d1ee67fb0d40a231ce04d10718f07ffb76db455) )
 
 	// Common Raiden DX soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
-	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) /* Shared with original Raiden 2 */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
+	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) // Shared with original Raiden 2
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "dx_back-1.u075",  0x000000, 0x200000, CRC(90970355) SHA1(d71d57cd550a800f583550365102adb7b1b779fc) )
 	ROM_LOAD( "dx_back-2.u0714", 0x200000, 0x200000, CRC(5799af3e) SHA1(85d6532abd769da77bcba70bd2e77915af40f987) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
-	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) /* Shared with original Raiden 2 */
-	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) /* Shared with original Raiden 2 */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
+	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) // Shared with original Raiden 2
+	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) // Shared with original Raiden 2
 	ROM_LOAD32_WORD( "dx_obj-3.u0837",       0x400000, 0x200000, CRC(ba381227) SHA1(dfc4d659aca1722a981fa56a31afabe66f444d5d) )
 	ROM_LOAD32_WORD( "dx_obj-4.u0836",       0x400002, 0x200000, CRC(65e50d19) SHA1(c46147b4132abce7314b46bf419ce4773e024b05) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
-	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) /* Mask ROM - Shared with original Raiden 2 */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
+	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) // Mask ROM - Shared with original Raiden 2
 ROM_END
 
 ROM_START( raidendxja )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("1.bin", 0x000000, 0x80000, CRC(247e21c7) SHA1(69e9a084407f57e8433f832a592cfbba2757631f) )
 	ROM_LOAD32_BYTE("2.bin", 0x000001, 0x80000, CRC(f2e9855a) SHA1(e27ac94cdb4ce8e8a98b342fbaf0fde11d9ab9ef) )
 	ROM_LOAD32_BYTE("3.bin", 0x000002, 0x80000, CRC(fbab727f) SHA1(5415ff87dd967e52b5cf7d754c046223cfa1147b) )
 	ROM_LOAD32_BYTE("4.bin", 0x000003, 0x80000, CRC(a08d5838) SHA1(ec07770503eefa5f22d30f40e3df2a02813908e4) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu_5.u1110",  0x000000, 0x08000, CRC(8c46857a) SHA1(8b269cb20adf960ba4eb594d8add7739dbc9a837) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "rdxj_7.u0724", 0x000000, 0x020000, CRC(ec31fa10) SHA1(e39c9d95699dbeb21e3661d863eee503c9011bbc) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "seibu_6.u1017", 0x00000, 0x40000, CRC(9a9196da) SHA1(3d1ee67fb0d40a231ce04d10718f07ffb76db455) )
 
 	// Common Raiden DX soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
-	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) /* Shared with original Raiden 2 */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
+	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) // Shared with original Raiden 2
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "dx_back-1.u075",  0x000000, 0x200000, CRC(90970355) SHA1(d71d57cd550a800f583550365102adb7b1b779fc) )
 	ROM_LOAD( "dx_back-2.u0714", 0x200000, 0x200000, CRC(5799af3e) SHA1(85d6532abd769da77bcba70bd2e77915af40f987) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
-	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) /* Shared with original Raiden 2 */
-	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) /* Shared with original Raiden 2 */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
+	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) // Shared with original Raiden 2
+	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) // Shared with original Raiden 2
 	ROM_LOAD32_WORD( "dx_obj-3.u0837",       0x400000, 0x200000, CRC(ba381227) SHA1(dfc4d659aca1722a981fa56a31afabe66f444d5d) )
 	ROM_LOAD32_WORD( "dx_obj-4.u0836",       0x400002, 0x200000, CRC(65e50d19) SHA1(c46147b4132abce7314b46bf419ce4773e024b05) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
-	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) /* Mask ROM - Shared with original Raiden 2 */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
+	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) // Mask ROM - Shared with original Raiden 2
 ROM_END
 
 ROM_START( raidendxch )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("rdxc_1.u1210", 0x000000, 0x80000, CRC(2154c6ae) SHA1(dc794f8ddbd8a6267db37fe4e3ed44e06e9b84b7) )
 	ROM_LOAD32_BYTE("rdxc_2.u1211", 0x000001, 0x80000, CRC(73bb74b7) SHA1(2f197adbe89d96c9e75054c568c380fdd2e80162))
 	ROM_LOAD32_BYTE("rdxc_3.u129",  0x000002, 0x80000, CRC(50f0a6aa) SHA1(68579f8e73fe06b458368ac9cac0b33370cf3b4e))
 	ROM_LOAD32_BYTE("rdxc_4.u1212", 0x000003, 0x80000, CRC(00071e70) SHA1(8a03ea0e650936e48cdd21ff84132742649920fe) )
 
 	// no other ROMs present with this set, so the ones below could be wrong
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu_5.u1110",  0x000000, 0x08000, CRC(8c46857a) SHA1(8b269cb20adf960ba4eb594d8add7739dbc9a837) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD( "seibu_7.u0724",    0x000000,   0x020000,   CRC(c73986d4) SHA1(d29345077753bda53560dedc95dd23f329e521d9) )
 
-	ROM_REGION( 0x100000, "oki1", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki1", 0 )   // ADPCM samples
 	ROM_LOAD( "seibu_6.u1017", 0x00000, 0x40000, CRC(9a9196da) SHA1(3d1ee67fb0d40a231ce04d10718f07ffb76db455) )
 
 	// Common Raiden DX soldered mask ROMs below
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
-	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) /* Shared with original Raiden 2 */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
+	ROM_LOAD( "copx-d2.u0313",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) ) // Shared with original Raiden 2
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "dx_back-1.u075",  0x000000, 0x200000, CRC(90970355) SHA1(d71d57cd550a800f583550365102adb7b1b779fc) )
 	ROM_LOAD( "dx_back-2.u0714", 0x200000, 0x200000, CRC(5799af3e) SHA1(85d6532abd769da77bcba70bd2e77915af40f987) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", 0 ) /* sprite gfx (encrypted) */
-	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) /* Shared with original Raiden 2 */
-	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) /* Shared with original Raiden 2 */
+	ROM_REGION32_LE( 0x800000, "sprites", 0 ) // sprite gfx (encrypted)
+	ROM_LOAD32_WORD( "raiden_2_obj-1.u0811", 0x000000, 0x200000, CRC(ff08ef0b) SHA1(a1858430e8171ca8bab785457ef60e151b5e5cf1) ) // Shared with original Raiden 2
+	ROM_LOAD32_WORD( "raiden_2_obj-2.u082",  0x000002, 0x200000, CRC(638eb771) SHA1(9774cc070e71668d7d1d20795502dccd21ca557b) ) // Shared with original Raiden 2
 	ROM_LOAD32_WORD( "dx_obj-3.u0837",       0x400000, 0x200000, CRC(ba381227) SHA1(dfc4d659aca1722a981fa56a31afabe66f444d5d) )
 	ROM_LOAD32_WORD( "dx_obj-4.u0836",       0x400002, 0x200000, CRC(65e50d19) SHA1(c46147b4132abce7314b46bf419ce4773e024b05) )
 
-	ROM_REGION( 0x100000, "oki2", 0 )   /* ADPCM samples */
-	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) /* Mask ROM - Shared with original Raiden 2 */
+	ROM_REGION( 0x100000, "oki2", 0 )   // ADPCM samples
+	ROM_LOAD( "raiden_2_pcm.u1018", 0x00000, 0x40000, CRC(8cf0d17e) SHA1(0fbe0b1e1ca5360c7c8329331408e3d799b4714c) ) // Mask ROM - Shared with original Raiden 2
 ROM_END
 
 
 
-/* Zero Team sets */
+// Zero Team sets
 /* Zero team is slightly older hardware (early 93 instead of late 93) but
 almost identical to raiden 2 with a few key differences:
 Zero Team:                     Raiden 2:
@@ -2680,36 +2681,36 @@ Notes:
 
 
 ROM_START( zeroteam ) // Fabtek, US licensee, displays 'USA' under zero team logo, board had serial 'Seibu Kaihatsu No. 0001468' on it, as well as AAMA 0458657
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("seibu__1.u024.5k",   0x000000, 0x40000, CRC(25aa5ba4) SHA1(40e6047620fbd195c87ac3763569af099096eff9) ) // alternate label "1"
 	ROM_LOAD32_BYTE("seibu__3.u023.6k",   0x000002, 0x40000, CRC(ec79a12b) SHA1(515026a2fca92555284ac49818499af7395783d3) ) // alternate label "3"
 	ROM_LOAD32_BYTE("seibu__2.u025.6l",   0x000001, 0x40000, CRC(54f3d359) SHA1(869744185746d55c60d2f48eabe384a8499e00fd) ) // alternate label "2"
 	ROM_LOAD32_BYTE("seibu__4.u026.5l",   0x000003, 0x40000, CRC(a017b8d0) SHA1(4a93ff1ab18f4b61c7ef580995f64840c19ce6b9) ) // alternate label "4"
 
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313.6n",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu__5.u1110.5b",  0x000000, 0x08000, CRC(7ec1fbc3) SHA1(48299d6530f641b18764cc49e283c347d0918a47) ) // // alternate label "5"
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD16_BYTE( "seibu__7.u072.5s",    0x000000,   0x010000,   CRC(9f6aa0f0) SHA1(1caad7092c07723d12a07aa363ae2aa69cb6be0d) ) // alternate label "7"
 	ROM_LOAD16_BYTE( "seibu__8.u077.5r",    0x000001,   0x010000,   CRC(68f7dddc) SHA1(6938fa974c6ef028751982fdabd6a3820b0d30a8) ) // alternate label "8"
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "musha_back-1.u075.4s",   0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) )
 	ROM_LOAD( "musha_back-2.u0714.2s",   0x100000, 0x080000, CRC(ce61c952) SHA1(52a843c8ba428b121fab933dd3b313b2894d80ac) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", ROMREGION_ERASEFF ) /* sprite gfx (encrypted) (diff encrypt to raiden2? ) */
+	ROM_REGION32_LE( 0x800000, "sprites", ROMREGION_ERASEFF ) // sprite gfx (encrypted) (diff encrypt to raiden2? )
 	ROM_LOAD32_WORD( "musha_obj-1.u0811.6f",  0x000000, 0x200000, CRC(45be8029) SHA1(adc164f9dede9a86b96a4d709e9cba7d2ad0e564) )
 	ROM_LOAD32_WORD( "musha_obj-2.u082.5f",  0x000002, 0x200000, CRC(cb61c19d) SHA1(151a2ce9c32f3321a974819e9b165dddc31c8153) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "seibu__6.u105.4a", 0x00000, 0x40000,  CRC(48be32b1) SHA1(969d2191a3c46871ee8bf93088b3cecce3eccf0c) ) // alternate label "6"
 
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "v3c001.pal.u0310",            0x0000, 0x288, NO_DUMP) // located UNDER v3c004x, unknown pal type
 	ROM_LOAD( "v3c002.tibpal16l8-25.u0322",  0x0000, 0x288, NO_DUMP)
 	ROM_LOAD( "v3c003.ami18cv8p-15.u0619",   0x0000, 0x288, NO_DUMP)
@@ -2717,36 +2718,36 @@ ROM_START( zeroteam ) // Fabtek, US licensee, displays 'USA' under zero team log
 ROM_END
 
 ROM_START( zeroteama ) // No licensee, original japan?
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("1.u024.5k",   0x000000, 0x40000, CRC(bd7b3f3a) SHA1(896413901a429d0efa3290f61920063c81730e9b) )
 	ROM_LOAD32_BYTE("3.u023.6k",   0x000002, 0x40000, CRC(19e02822) SHA1(36c9b887eaa9b9b67d65c55e8f7eefd08fe0be15) )
 	ROM_LOAD32_BYTE("2.u025.6l",   0x000001, 0x40000, CRC(0580b7e8) SHA1(d4416264aa5acdaa781ebcf51f128b3e665cc903) )
 	ROM_LOAD32_BYTE("4.u026.5l",   0x000003, 0x40000, CRC(cc666385) SHA1(23a8878315b6009dcc1f27e49572e5be29f6a1a6) )
 
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313.6n",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "5.a.u1110.5b",  0x000000, 0x08000, CRC(efc484ca) SHA1(c34b8e3e7f4c2967bc6414348993478ed637d338) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD16_BYTE( "7.a.u072.5s", 0x000000,   0x010000, CRC(eb10467f) SHA1(fc7d576dc41bc878ff20f0370e669e19d54fcefb) )
 	ROM_LOAD16_BYTE( "8.a.u077.5r", 0x000001,   0x010000, CRC(a0b2a09a) SHA1(9b1f6c732000b84b1ad635f332ebead5d65cc491) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "musha_back-1.u075.4s",   0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) )
 	ROM_LOAD( "musha_back-2.u0714.2s",   0x100000, 0x080000, CRC(ce61c952) SHA1(52a843c8ba428b121fab933dd3b313b2894d80ac) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", ROMREGION_ERASEFF ) /* sprite gfx (encrypted) (diff encrypt to raiden2? ) */
+	ROM_REGION32_LE( 0x800000, "sprites", ROMREGION_ERASEFF ) // sprite gfx (encrypted) (diff encrypt to raiden2? )
 	ROM_LOAD32_WORD( "musha_obj-1.u0811.6f",  0x000000, 0x200000, CRC(45be8029) SHA1(adc164f9dede9a86b96a4d709e9cba7d2ad0e564) )
 	ROM_LOAD32_WORD( "musha_obj-2.u082.5f",  0x000002, 0x200000, CRC(cb61c19d) SHA1(151a2ce9c32f3321a974819e9b165dddc31c8153) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "6.u105.4a", 0x00000, 0x40000,  CRC(48be32b1) SHA1(969d2191a3c46871ee8bf93088b3cecce3eccf0c) ) // 6.bin
 
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "v3c001.pal.u0310",            0x0000, 0x288, NO_DUMP) // located UNDER v3c004x, unknown pal type
 	ROM_LOAD( "v3c002.tibpal16l8-25.u0322",  0x0000, 0x288, NO_DUMP)
 	ROM_LOAD( "v3c003.ami18cv8p-15.u0619",   0x0000, 0x288, NO_DUMP)
@@ -2761,36 +2762,36 @@ problem of the 3.6v lithium battery dying and the missing keys to cause the spri
 // sets, using the sound and char ROMs from us set and code from later japan set. This would make sense if it was dumped
 // from a 'fixed, suicide free' modified us board where someone swapped in the later suicideless japan code ROMs.
 ROM_START( zeroteamb ) // No licensee, later japan?
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("1b.u024.5k",   0x000000, 0x40000, CRC(157743d0) SHA1(f9c84c9025319f76807ef0e79f1ee1599f915b45) )
 	ROM_LOAD32_BYTE("3b.u023.6k",   0x000002, 0x40000, CRC(fea7e4e8) SHA1(08c4bdff82362ae4bcf86fa56fcfc384bbf82b71) )
 	ROM_LOAD32_BYTE("2b.u025.6l",   0x000001, 0x40000, CRC(21d68f62) SHA1(8aa85b38e8f36057ef6c7dce5a2878958ce93ce8) )
 	ROM_LOAD32_BYTE("4b.u026.5l",   0x000003, 0x40000, CRC(ce8fe6c2) SHA1(69627867c7866e43e771ab85014553117044d18d) )
 
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313.6n",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "5.u1110.5b",  0x000000, 0x08000, CRC(7ec1fbc3) SHA1(48299d6530f641b18764cc49e283c347d0918a47) ) // 5.5c
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD16_BYTE( "7.u072.5s",   0x000000,   0x010000,   CRC(9f6aa0f0) SHA1(1caad7092c07723d12a07aa363ae2aa69cb6be0d) )
 	ROM_LOAD16_BYTE( "8.u077.5r",   0x000001,   0x010000,   CRC(68f7dddc) SHA1(6938fa974c6ef028751982fdabd6a3820b0d30a8) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "musha_back-1.u075.4s",   0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) )
 	ROM_LOAD( "musha_back-2.u0714.2s",   0x100000, 0x080000, CRC(ce61c952) SHA1(52a843c8ba428b121fab933dd3b313b2894d80ac) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", ROMREGION_ERASEFF ) /* sprite gfx (encrypted) (diff encrypt to raiden2? ) */
+	ROM_REGION32_LE( 0x800000, "sprites", ROMREGION_ERASEFF ) // sprite gfx (encrypted) (diff encrypt to raiden2? )
 	ROM_LOAD32_WORD( "musha_obj-1.u0811.6f",  0x000000, 0x200000, CRC(45be8029) SHA1(adc164f9dede9a86b96a4d709e9cba7d2ad0e564) )
 	ROM_LOAD32_WORD( "musha_obj-2.u082.5f",  0x000002, 0x200000, CRC(cb61c19d) SHA1(151a2ce9c32f3321a974819e9b165dddc31c8153) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "6.u105.4a", 0x00000, 0x40000,  CRC(48be32b1) SHA1(969d2191a3c46871ee8bf93088b3cecce3eccf0c) ) // 6.4a
 
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "v3c001.pal.u0310",            0x0000, 0x288, NO_DUMP) // located UNDER v3c004x, unknown pal type
 	ROM_LOAD( "v3c002.tibpal16l8-25.u0322",  0x0000, 0x288, NO_DUMP)
 	ROM_LOAD( "v3c003.ami18cv8p-15.u0619",   0x0000, 0x288, NO_DUMP)
@@ -2798,36 +2799,36 @@ ROM_START( zeroteamb ) // No licensee, later japan?
 ROM_END
 
 ROM_START( zeroteamc ) // Liang Hwa, Taiwan licensee, no special word under logo on title
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("b1.u024.5k",   0x000000, 0x40000, CRC(528de3b9) SHA1(9ca8cdc0212f2540e852d20ab4c04f68b967d024) )
 	ROM_LOAD32_BYTE("b3.u023.6k",   0x000002, 0x40000, CRC(3688739a) SHA1(f98f461fb8e7804b3b4020a5e3762d36d6458a62) )
 	ROM_LOAD32_BYTE("b2.u025.6l",   0x000001, 0x40000, CRC(5176015e) SHA1(6b372564b2f1b1f56cae0c98f4ca588b784bfa3d) )
 	ROM_LOAD32_BYTE("b4.u026.5l",   0x000003, 0x40000, CRC(c79925cb) SHA1(aaff9f626ec61bc0ff038ebd722fe361dccc49fb) )
 
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313.6n",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "5.c.u1110.5b",  0x000000, 0x08000, CRC(efc484ca) SHA1(c34b8e3e7f4c2967bc6414348993478ed637d338) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD16_BYTE( "b7.u072.5s",  0x000000,   0x010000, CRC(30ec0241) SHA1(a0d0be9458bf97cb9764fb85c988bb816710475e) )
 	ROM_LOAD16_BYTE( "b8.u077.5r",  0x000001,   0x010000, CRC(e18b3a75) SHA1(3d52bba8d47d0d9108ee79014fd64d6e856a3fde) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "musha_back-1.u075.4s",   0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) )
 	ROM_LOAD( "musha_back-2.u0714.2s",   0x100000, 0x080000, CRC(ce61c952) SHA1(52a843c8ba428b121fab933dd3b313b2894d80ac) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", ROMREGION_ERASEFF ) /* sprite gfx (encrypted) (diff encrypt to raiden2? ) */
+	ROM_REGION32_LE( 0x800000, "sprites", ROMREGION_ERASEFF ) // sprite gfx (encrypted) (diff encrypt to raiden2? )
 	ROM_LOAD32_WORD( "musha_obj-1.u0811.6f",  0x000000, 0x200000, CRC(45be8029) SHA1(adc164f9dede9a86b96a4d709e9cba7d2ad0e564) )
 	ROM_LOAD32_WORD( "musha_obj-2.u082.5f",  0x000002, 0x200000, CRC(cb61c19d) SHA1(151a2ce9c32f3321a974819e9b165dddc31c8153) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "6.c.u105.4a", 0x00000, 0x40000,  CRC(b4a6e899) SHA1(175ab656db3c3258ff10eede89890f62435d2298) )
 
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "v3c001.pal.u0310",            0x0000, 0x288, NO_DUMP) // located UNDER v3c004x, unknown pal type
 	ROM_LOAD( "v3c002.tibpal16l8-25.u0322",  0x0000, 0x288, NO_DUMP)
 	ROM_LOAD( "v3c003.ami18cv8p-15.u0619",   0x0000, 0x288, NO_DUMP)
@@ -2836,36 +2837,36 @@ ROM_END
 
 ROM_START( zeroteamd ) // Dream Soft, Korea licensee, no special word under logo on title; board had serial 'no 1041' on it.
 	// this is weird, on other zt sets the ROM order is 1 3 2 4, but this one is 1 3 4 2. blame seibu or whoever marked the ROMs, which were labeled in pen
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("1.d.u024.5k",   0x000000, 0x40000, CRC(6cc279be) SHA1(63143ba3105d24d133e60ffdb3edc2ceb2d5dc5b) )
 	ROM_LOAD32_BYTE("3.d.u023.6k",   0x000002, 0x40000, CRC(0212400d) SHA1(28f77b5fddb9d724b735c3ff2255bd518b166e67) )
 	ROM_LOAD32_BYTE("4.d.u025.6l",   0x000001, 0x40000, CRC(08813ebb) SHA1(454779cec2fd0e71b72f7161e7d9334893ee42de) )
 	ROM_LOAD32_BYTE("2.d.u026.5l",   0x000003, 0x40000, CRC(9236129d) SHA1(8561ab62e3593cd9353d9ffddedbdb77e9ae2c45) )
 
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313.6n",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "512kb.u1110.5b",  0x000000, 0x08000, CRC(efc484ca) SHA1(c34b8e3e7f4c2967bc6414348993478ed637d338) ) // this is a soldered mask ROM on this pcb version! the contents match the taiwan version EPROM; the mask ROM has no label
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD16_BYTE( "512kb.u072.5s",   0x000000,   0x010000, CRC(30ec0241) SHA1(a0d0be9458bf97cb9764fb85c988bb816710475e) ) // this is a soldered mask ROM on this pcb version! the contents match the taiwan version EPROM; the mask ROM has no label
 	ROM_LOAD16_BYTE( "512kb.u077.5r",   0x000001,   0x010000, CRC(e18b3a75) SHA1(3d52bba8d47d0d9108ee79014fd64d6e856a3fde) ) // this is a soldered mask ROM on this pcb version! the contents match the taiwan version EPROM; the mask ROM has no label
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "musha_back-1.u075.4s",   0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) )
 	ROM_LOAD( "musha_back-2.u0714.2s",   0x100000, 0x080000, CRC(ce61c952) SHA1(52a843c8ba428b121fab933dd3b313b2894d80ac) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", ROMREGION_ERASEFF ) /* sprite gfx (encrypted) (diff encrypt to raiden2? ) */
+	ROM_REGION32_LE( 0x800000, "sprites", ROMREGION_ERASEFF ) // sprite gfx (encrypted) (diff encrypt to raiden2? )
 	ROM_LOAD32_WORD( "musha_obj-1.u0811.6f",  0x000000, 0x200000, CRC(45be8029) SHA1(adc164f9dede9a86b96a4d709e9cba7d2ad0e564) )
 	ROM_LOAD32_WORD( "musha_obj-2.u082.5f",  0x000002, 0x200000, CRC(cb61c19d) SHA1(151a2ce9c32f3321a974819e9b165dddc31c8153) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "8.u105.4a", 0x00000, 0x40000,  CRC(b4a6e899) SHA1(175ab656db3c3258ff10eede89890f62435d2298) ) // same ROM as '6' labeled one in zeroteamc above but has '8' written on label in pen
 
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "v3c001.pal.u0310",            0x0000, 0x288, NO_DUMP) // located UNDER v3c004x, unknown pal type
 	ROM_LOAD( "v3c002.tibpal16l8-25.u0322",  0x0000, 0x288, NO_DUMP)
 	ROM_LOAD( "v3c003.ami18cv8p-15.u0619",   0x0000, 0x288, NO_DUMP)
@@ -2874,36 +2875,36 @@ ROM_END
 // A version of the above exists (which dr.kitty used to own) which DOES have 'Korea' under the logo on title, needs dumping
 
 ROM_START( zeroteame ) // shares chars ROMs with zeroteama
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("seibu_1_u024.5k",   0x000000, 0x40000, CRC(76e69af5) SHA1(c5a4b2491cee3f4f9694e454f3828fda33fff3ab) )
 	ROM_LOAD32_BYTE("seibu_3_u023.6k",   0x000002, 0x40000, CRC(4a904880) SHA1(4a85a62446ea11d57369dfd65f143475063abc31) )
 	ROM_LOAD32_BYTE("seibu_2_u025.6l",   0x000001, 0x40000, CRC(b97ab448) SHA1(82d9e7aa6b69c214ad82e5ff30a049cecab607c0) )
 	ROM_LOAD32_BYTE("seibu_4_u026.5l",   0x000003, 0x40000, CRC(1d43b9c1) SHA1(b1144d49f8fddf416fe2e3eae4040b369eb212cf) )
 
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313.6n",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "seibu_5_u1110.5b",  0x000000, 0x08000, CRC(efc484ca) SHA1(c34b8e3e7f4c2967bc6414348993478ed637d338) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD16_BYTE( "seibu_7_u072.5s", 0x000000,   0x010000, CRC(eb10467f) SHA1(fc7d576dc41bc878ff20f0370e669e19d54fcefb) )
 	ROM_LOAD16_BYTE( "seibu_8_u077.5r", 0x000001,   0x010000, CRC(a0b2a09a) SHA1(9b1f6c732000b84b1ad635f332ebead5d65cc491) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "musha_back-1.u075.4s",   0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) )
 	ROM_LOAD( "musha_back-2.u0714.2s",   0x100000, 0x080000, CRC(ce61c952) SHA1(52a843c8ba428b121fab933dd3b313b2894d80ac) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", ROMREGION_ERASEFF ) /* sprite gfx (encrypted) (diff encrypt to raiden2? ) */
+	ROM_REGION32_LE( 0x800000, "sprites", ROMREGION_ERASEFF ) // sprite gfx (encrypted) (diff encrypt to raiden2? )
 	ROM_LOAD32_WORD( "musha_obj-1.u0811.6f",  0x000000, 0x200000, CRC(45be8029) SHA1(adc164f9dede9a86b96a4d709e9cba7d2ad0e564) )
 	ROM_LOAD32_WORD( "musha_obj-2.u082.5f",  0x000002, 0x200000, CRC(cb61c19d) SHA1(151a2ce9c32f3321a974819e9b165dddc31c8153) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "seibu_6_u105.4a", 0x00000, 0x40000,  CRC(48be32b1) SHA1(969d2191a3c46871ee8bf93088b3cecce3eccf0c) ) // 6.bin
 
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "v3c001.pal.u0310",            0x0000, 0x288, NO_DUMP) // located UNDER v3c004x, unknown pal type
 	ROM_LOAD( "v3c002.tibpal16l8-25.u0322",  0x0000, 0x288, NO_DUMP)
 	ROM_LOAD( "v3c003.ami18cv8p-15.u0619",   0x0000, 0x288, NO_DUMP)
@@ -2911,36 +2912,36 @@ ROM_START( zeroteame ) // shares chars ROMs with zeroteama
 ROM_END
 
 ROM_START( zeroteams ) // No license, displays 'Selection' under logo
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("1_sel.bin",   0x000000, 0x40000, CRC(d99d6273) SHA1(21dccd5d71c720b8364406835812b3c9defaff6c) )
 	ROM_LOAD32_BYTE("3_sel.bin",   0x000002, 0x40000, CRC(0a9fe0b1) SHA1(3588fe19788f77d07e9b5ab8182b94362ffd0024) )
 	ROM_LOAD32_BYTE("2_sel.bin",   0x000001, 0x40000, CRC(4e114e74) SHA1(fcccbb68c6b7ffe8d109ed3a1ec9120d338398f9) )
 	ROM_LOAD32_BYTE("4_sel.bin",   0x000003, 0x40000, CRC(0df8ba94) SHA1(e07dce6cf3c3cfe1ea3b7f01e18833c1da5ed1dc) )
 
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313.6n",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "5_sel.bin",  0x000000, 0x08000, CRC(ed91046c) SHA1(de815c999aeeb814d3f091d5a9ac34ea9a388ddb) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD16_BYTE( "7.u072.5s",   0x000000,   0x010000,   CRC(9f6aa0f0) SHA1(1caad7092c07723d12a07aa363ae2aa69cb6be0d) )
 	ROM_LOAD16_BYTE( "8.u077.5r",   0x000001,   0x010000,   CRC(68f7dddc) SHA1(6938fa974c6ef028751982fdabd6a3820b0d30a8) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "musha_back-1.u075.4s",   0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) )
 	ROM_LOAD( "musha_back-2.u0714.2s",   0x100000, 0x080000, CRC(ce61c952) SHA1(52a843c8ba428b121fab933dd3b313b2894d80ac) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", ROMREGION_ERASEFF ) /* sprite gfx (encrypted) (diff encrypt to raiden2? ) */
+	ROM_REGION32_LE( 0x800000, "sprites", ROMREGION_ERASEFF ) // sprite gfx (encrypted) (diff encrypt to raiden2? )
 	ROM_LOAD32_WORD( "musha_obj-1.u0811.6f",  0x000000, 0x200000, CRC(45be8029) SHA1(adc164f9dede9a86b96a4d709e9cba7d2ad0e564) )
 	ROM_LOAD32_WORD( "musha_obj-2.u082.5f",  0x000002, 0x200000, CRC(cb61c19d) SHA1(151a2ce9c32f3321a974819e9b165dddc31c8153) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "6.u105.4a", 0x00000, 0x40000,  CRC(48be32b1) SHA1(969d2191a3c46871ee8bf93088b3cecce3eccf0c) ) // 6.bin
 
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "v3c001.pal.u0310",            0x0000, 0x288, NO_DUMP) // located UNDER v3c004x, unknown pal type
 	ROM_LOAD( "v3c002.tibpal16l8-25.u0322",  0x0000, 0x288, NO_DUMP)
 	ROM_LOAD( "v3c003.ami18cv8p-15.u0619",   0x0000, 0x288, NO_DUMP)
@@ -2960,36 +2961,36 @@ Next, turn off power and reinsert the old code ROMs, and the pcb should now have
 */
 
 ROM_START( zeroteamsr )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("zteam1.u24",   0x000000, 0x40000, CRC(c531e009) SHA1(731881fca3dc0a8269ecdd295ba7119d93c892e7) )
 	ROM_LOAD32_BYTE("zteam3.u23",   0x000002, 0x40000, CRC(1f988808) SHA1(b1fcb8c96e57c4942bc032d42408d7289c6a3681) )
 	ROM_LOAD32_BYTE("zteam2.u25",   0x000001, 0x40000, CRC(b7234b93) SHA1(35bc093e8ad4bce1d2130a392ed1b9487a5642a1) )
 	ROM_LOAD32_BYTE("zteam4.u26",   0x000003, 0x40000, CRC(c2d26708) SHA1(d65191b40f5dd7cdbbc004e2de10134db6092fd1) )
 
-	ROM_REGION( 0x40000, "user2", 0 )   /* COPX */
+	ROM_REGION( 0x40000, "math", 0 )   // COPX
 	ROM_LOAD( "copx-d2.u0313.6n",   0x00000, 0x40000, CRC(a6732ff9) SHA1(c4856ec77869d9098da24b1bb3d7d58bb74b4cda) )
 
-	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x20000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "5.5c",  0x000000, 0x08000, CRC(7ec1fbc3) SHA1(48299d6530f641b18764cc49e283c347d0918a47) ) // 5.5c
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD16_BYTE( "7.u072.5s",   0x000000,   0x010000,   CRC(9f6aa0f0) SHA1(1caad7092c07723d12a07aa363ae2aa69cb6be0d) )
 	ROM_LOAD16_BYTE( "8.u077.5r",   0x000001,   0x010000,   CRC(68f7dddc) SHA1(6938fa974c6ef028751982fdabd6a3820b0d30a8) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "musha_back-1.u075.4s",   0x000000, 0x100000, CRC(8b7f9219) SHA1(3412b6f8a4fe245e521ddcf185a53f2f4520eb57) )
 	ROM_LOAD( "musha_back-2.u0714.2s",   0x100000, 0x080000, CRC(ce61c952) SHA1(52a843c8ba428b121fab933dd3b313b2894d80ac) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", ROMREGION_ERASEFF ) /* sprite gfx (encrypted) (diff encrypt to raiden2? ) */
+	ROM_REGION32_LE( 0x800000, "sprites", ROMREGION_ERASEFF ) // sprite gfx (encrypted) (diff encrypt to raiden2? )
 	ROM_LOAD32_WORD( "musha_obj-1.u0811.6f",  0x000000, 0x200000, CRC(45be8029) SHA1(adc164f9dede9a86b96a4d709e9cba7d2ad0e564) )
 	ROM_LOAD32_WORD( "musha_obj-2.u082.5f",  0x000002, 0x200000, CRC(cb61c19d) SHA1(151a2ce9c32f3321a974819e9b165dddc31c8153) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "6.u105.4a", 0x00000, 0x40000,  CRC(48be32b1) SHA1(969d2191a3c46871ee8bf93088b3cecce3eccf0c) ) // 6.4a
 
-	ROM_REGION( 0x10000, "pals", 0 )    /* PALS */
+	ROM_REGION( 0x10000, "pals", 0 )    // PALS
 	ROM_LOAD( "v3c001.pal.u0310",            0x0000, 0x288, NO_DUMP) // located UNDER v3c004x, unknown pal type
 	ROM_LOAD( "v3c002.tibpal16l8-25.u0322",  0x0000, 0x288, NO_DUMP)
 	ROM_LOAD( "v3c003.ami18cv8p-15.u0619",   0x0000, 0x288, NO_DUMP)
@@ -3035,34 +3036,34 @@ Notes:
 */
 
 ROM_START( xsedae )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_REGION( 0x200000, "maincpu", 0 ) // v30 main cpu
 	ROM_LOAD32_BYTE("1.u024",   0x000000, 0x40000, CRC(185437f9) SHA1(e46950b6a549d11dc57105dd7d9cb512a8ecbe70) )
 	ROM_LOAD32_BYTE("2.u025",   0x000001, 0x40000, CRC(a2b052df) SHA1(e8bf9ab3d5d4e601ea9386e1f2d4e017b025407e) )
 	ROM_LOAD32_BYTE("3.u023",   0x000002, 0x40000, CRC(293fd6c1) SHA1(8b1a231f4bedbf9c0f347330e13fdf092b9888b4) )
 	ROM_LOAD32_BYTE("4.u026",   0x000003, 0x40000, CRC(5adf20bf) SHA1(42a0bb5a460c656675b2c432c043fc61a9049276) )
 
-	ROM_REGION( 0x40000, "user2", ROMREGION_ERASEFF )   /* COPX */
-	/* Not populated */
+	ROM_REGION( 0x40000, "math", ROMREGION_ERASEFF )   // COPX
+	// Not populated
 
-	ROM_REGION( 0x30000, "audiocpu", ROMREGION_ERASEFF ) /* 64k code for sound Z80 */
+	ROM_REGION( 0x30000, "audiocpu", ROMREGION_ERASEFF ) // 64k code for sound Z80
 	ROM_LOAD( "8.u1110",  0x000000, 0x08000, CRC(2dc2f81a) SHA1(0f6605042e0e295b4256b43dbdf5d53daebe1a9a) )
 	ROM_CONTINUE(0x10000,0x8000)
 	ROM_CONTINUE(0x20000,0x10000) // TODO
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x020000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x020000, "chars", 0 ) // chars
 	ROM_LOAD16_BYTE( "6.u072.5s",   0x000000,   0x010000, CRC(a788402d) SHA1(8a1ac4760cf75cd2e32c1d15f36ad15cce3d411b) )
 	ROM_LOAD16_BYTE( "5.u077.5r",   0x000001,   0x010000, CRC(478deced) SHA1(88cd72cb76bbc1c4255c3dfae4b9a10af9b050b2) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) /* background gfx */
+	ROM_REGION( 0x400000, "tiles", 0 ) // background gfx
 	ROM_LOAD( "bg-1.u075",   0x000000, 0x100000, CRC(ac087560) SHA1(b6473b20c55ec090961cfc46a024b3c5b707ec25) )
 	ROM_LOAD( "7.u0714",     0x100000, 0x080000, CRC(296105dc) SHA1(c2b80d681646f504b03c2dde13e37b1d820f82d2) )
 
-	ROM_REGION32_LE( 0x800000, "gfx3", ROMREGION_ERASEFF ) /* sprite gfx (not encrypted) */
+	ROM_REGION32_LE( 0x800000, "sprites", ROMREGION_ERASEFF ) // sprite gfx (not encrypted)
 	ROM_LOAD32_WORD( "obj-1.u0811",  0x000000, 0x200000, CRC(6ae993eb) SHA1(d9713c79eacb4b3ce5e82dd3ce39003e3a433d8f) )
 	ROM_LOAD32_WORD( "obj-2.u082",   0x000002, 0x200000, CRC(26c806ee) SHA1(899a76a1b3f933c6f5cb6b5dcdf5b58e1b7e49c6) )
 
-	ROM_REGION( 0x100000, "oki", 0 )   /* ADPCM samples */
+	ROM_REGION( 0x100000, "oki", 0 )   // ADPCM samples
 	ROM_LOAD( "9.u105.4a", 0x00000, 0x40000, CRC(a7a0c5f9) SHA1(7882681ac152642aa4f859071f195842068b214b) )
 ROM_END
 
@@ -3127,8 +3128,7 @@ void raiden2_state::init_raiden2()
 	init_blending(raiden_blended_colors);
 	static const int spri[5] = { 0, 1, 2, 3, -1 };
 	m_cur_spri = spri;
-	m_mainbank[0]->configure_entries(0, 4, memregion("maincpu")->base(), 0x10000);
-	m_mainbank[1]->configure_entries(0, 4, memregion("maincpu")->base(), 0x10000);
+	m_mainbank->configure_entries(0, 2, memregion("maincpu")->base(), 0x20000);
 	raiden2_decrypt_sprites(machine());
 }
 
@@ -3137,8 +3137,7 @@ void raiden2_state::init_raidendx()
 	init_blending(raiden_blended_colors);
 	static const int spri[5] = { 0, 1, 2, 3, -1 };
 	m_cur_spri = spri;
-	m_mainbank[0]->configure_entries(0, 0x20, memregion("maincpu")->base(), 0x10000);
-	m_mainbank[1]->configure_entries(0, 0x20, memregion("maincpu")->base(), 0x10000);
+	m_mainbank->configure_entries(0, 0x10, memregion("maincpu")->base() + 0x100000, 0x10000);
 	raiden2_decrypt_sprites(machine());
 }
 
@@ -3151,7 +3150,7 @@ void raiden2_state::init_xsedae()
 	init_blending(xsedae_blended_colors);
 	static const int spri[5] = { -1, 0, 1, 2, 3 };
 	m_cur_spri = spri;
-	/* doesn't have banking */
+	// doesn't have banking
 }
 
 const u16 raiden2_state::zeroteam_blended_colors[] = {
@@ -3173,12 +3172,11 @@ void raiden2_state::init_zeroteam()
 	init_blending(zeroteam_blended_colors);
 	static const int spri[5] = { -1, 0, 1, 2, 3 };
 	m_cur_spri = spri;
-	m_mainbank[0]->configure_entries(0, 4, memregion("maincpu")->base(), 0x10000);
-	m_mainbank[1]->configure_entries(0, 4, memregion("maincpu")->base(), 0x10000);
+	m_mainbank->configure_entries(0, 2, memregion("maincpu")->base(), 0x20000);
 	zeroteam_decrypt_sprites(machine());
 }
 
-/* GAME DRIVERS */
+// GAME DRIVERS
 
 /* The Raiden 2 / DX sets are sorted by the checksums of the non-regional ROMs (the final program ROM contains the region byte)
 
@@ -3191,79 +3189,79 @@ void raiden2_state::init_zeroteam()
 // Regular version - Sepia high score table background, regular tanks on first bridge
 
 // code rev with first ROM having checksum 09475ec4
-GAME( 1993, raiden2,    0,        raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden II (US, set 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, raiden2g,   raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Tuning license)", "Raiden II (Germany)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, raiden2hk,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Metrotainment license)", "Raiden II (Hong Kong)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, raiden2j,   raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (Japan)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, raiden2sw,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (Switzerland)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, raiden2,    0,        raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden II (US, set 1)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1993, raiden2g,   raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Tuning license)", "Raiden II (Germany)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1993, raiden2hk,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Metrotainment license)", "Raiden II (Hong Kong)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1993, raiden2j,   raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (Japan)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1993, raiden2sw,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (Switzerland)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 // code rev with first ROM having checksum b16df955
-GAME( 1993, raiden2u,   raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden II (US, set 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, raiden2u,   raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden II (US, set 2)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 // code rev with first ROM having checksum 53be3dd0
-GAME( 1993, raiden2f,   raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (France)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, raiden2nl,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (Holland)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, raiden2es,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (Spain)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, raiden2f,   raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (France)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1993, raiden2nl,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (Holland)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1993, raiden2es,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (Spain)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 // code rev with first ROM having checksum c1fc70f5
-GAME( 1993, raiden2i,   raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (Italy)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, raiden2au,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (Australia)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, raiden2i,   raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (Italy)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1993, raiden2au,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (Australia)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
 // Easy version - Coloured high score table background, different enemy placement
 
 // code rev with first ROM having checksum 2abc848c
-GAME( 1993, raiden2e,   raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (easier, Korea)", MACHINE_SUPPORTS_SAVE ) // (Region 0x04) - Korea, if regions are the same as RDX, no license or region message tho
-GAME( 1993, raiden2eub, raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden II (easier, US set 3)", MACHINE_SUPPORTS_SAVE ) // (Region 0x01) - PRG0 is same as raiden2e, but PRG1 has region byte different than raiden2e, other ROMs match raiden2u
+GAME( 1993, raiden2e,   raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (easier, Korea)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) // (Region 0x04) - Korea, if regions are the same as RDX, no license or region message tho
+GAME( 1993, raiden2eub, raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden II (easier, US set 3)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) // (Region 0x01) - PRG0 is same as raiden2e, but PRG1 has region byte different than raiden2e, other ROMs match raiden2u
 // code rev with first ROM having checksum ed1514e3 (using 4x program ROM configuration, not 2) would have crc 2abc848c in 2 ROM config, so same rev as above
-GAME( 1993, raiden2eua, raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden II (easier, US set 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1993, raiden2eg,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Tuning license)", "Raiden II (easier, Germany)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, raiden2eua, raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden II (easier, US set 1)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1993, raiden2eg,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Tuning license)", "Raiden II (easier, Germany)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
 // unique revision (4x program ROM configuration)
-GAME( 1993, raiden2eup, raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden II (easier, US, prototype? 11-16)", MACHINE_SUPPORTS_SAVE ) // program ROMs had 11-16 date
+GAME( 1993, raiden2eup, raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden II (easier, US, prototype? 11-16)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) // program ROMs had 11-16 date
 
 // code rev with first ROM having checksum d7041be4
-GAME( 1993, raiden2ea,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (easier, Japan)", MACHINE_SUPPORTS_SAVE ) // (Region 0x00) - Japan, but the easy sets have no 'FOR USE IN JAPAN ONLY' display even when region is 00
-GAME( 1993, raiden2eu,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden II (easier, US set 2)", MACHINE_SUPPORTS_SAVE ) //  ^
+GAME( 1993, raiden2ea,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (easier, Japan)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) // (Region 0x00) - Japan, but the easy sets have no 'FOR USE IN JAPAN ONLY' display even when region is 00
+GAME( 1993, raiden2eu,  raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden II (easier, US set 2)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) //  ^
 
 // Harder version - Sepia high score table background, red tanks on first bridge
 
 // code rev with first ROM having checksum 1fcc08cf
-GAME( 1993, raiden2k,   raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (harder, Korea)", MACHINE_SUPPORTS_SAVE ) // (Region 0x04) - Korea, no message displayed tho
+GAME( 1993, raiden2k,   raiden2,  raiden2,  raiden2,  raiden2_state, init_raiden2,  ROT270, "Seibu Kaihatsu", "Raiden II (harder, Korea)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) // (Region 0x04) - Korea, no message displayed tho
 // code rev with first ROM having checksum 413241e0 (using 4x program ROM configuration, not 2, on Raiden DX hardware)
-GAME( 1993, raiden2dx,  raiden2,  raidendx, raiden2,  raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu", "Raiden II (harder, Raiden DX hardware, Korea)", MACHINE_SUPPORTS_SAVE ) // ^
+GAME( 1993, raiden2dx,  raiden2,  raidendx, raiden2,  raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu", "Raiden II (harder, Raiden DX hardware, Korea)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) // ^
 
 
 // Raiden DX sets
 
 // code rev with the first 3 ROMs having checksums 14d725fc, 5e7e45cb, f0a47e67
-GAME( 1994, raidendx,   0,        raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu", "Raiden DX (UK)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, raidendxg,  raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu (Tuning license)", "Raiden DX (Germany)", MACHINE_SUPPORTS_SAVE )
-GAME( 1994, raidendxpt, raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu", "Raiden DX (Portugal)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, raidendx,   0,        raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu", "Raiden DX (UK)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1994, raidendxg,  raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu (Tuning license)", "Raiden DX (Germany)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1994, raidendxpt, raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu", "Raiden DX (Portugal)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 // code rev with first 3 ROMs having checksums 7624c36b, 4940fdf3, 6c495bcf
-GAME( 1994, raidendxa1, raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu (Metrotainment license)", "Raiden DX (Hong Kong, set 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, raidendxa1, raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu (Metrotainment license)", "Raiden DX (Hong Kong, set 1)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 // code rev with first 3 ROMs having checksums 22b155ae, 2be98ca8, b4785576
-GAME( 1994, raidendxa2, raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu (Metrotainment license)", "Raiden DX (Hong Kong, set 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, raidendxa2, raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu (Metrotainment license)", "Raiden DX (Hong Kong, set 2)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 // code rev with first 3 ROMs having checksums b5b32885, 7efd581d, 55ec0e1d
-GAME( 1994, raidendxk,  raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu", "Raiden DX (Korea)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, raidendxk,  raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu", "Raiden DX (Korea)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 // code rev with first 3 ROMs having checksums 53e63194, ec8d1647, 7dbfd73d
-GAME( 1994, raidendxu,  raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden DX (US)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, raidendxu,  raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden DX (US)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 // code rev with first 3 ROMs having checksums c589019a, b2222254, 60f04634
-GAME( 1994, raidendxnl, raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu", "Raiden DX (Holland)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, raidendxnl, raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu", "Raiden DX (Holland)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 // code rev with first 3 ROMs having checksums 5af382e1, 899966fc, e7f08013
-GAME( 1994, raidendxj,  raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu", "Raiden DX (Japan, set 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, raidendxj,  raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu", "Raiden DX (Japan, set 1)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 // code rev with first 3 ROMs having checksums 247e21c7, f2e9855a, fbab727f
-GAME( 1994, raidendxja, raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu", "Raiden DX (Japan, set 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, raidendxja, raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu", "Raiden DX (Japan, set 2)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 // code rev with first 3 ROMs having checksums 2154c6ae, 73bb74b7, 50f0a6aa
-GAME( 1994, raidendxch, raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu (Ideal International Development Corp license)", "Raiden DX (China)", MACHINE_SUPPORTS_SAVE ) // Region byte is 0x16, defined as "MAIN LAND CHINA" for this set only
+GAME( 1994, raidendxch, raidendx, raidendx, raidendx, raiden2_state, init_raidendx, ROT270, "Seibu Kaihatsu (Ideal International Development Corp license)", "Raiden DX (China)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) // Region byte is 0x16, defined as "MAIN LAND CHINA" for this set only
 
 
 // Zero Team sets
 
-GAME( 1993, zeroteam,   0,        zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu (Fabtek license)", "Zero Team USA (US)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
-GAME( 1993, zeroteama,  zeroteam, zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu", "Zero Team (Japan?, earlier?, set 1)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
-GAME( 1993, zeroteamb,  zeroteam, zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu", "Zero Team (Japan?, later batteryless)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // reprograms the sprite decrypt data of the SEI251 on every boot, like raiden2 does. hack?
-GAME( 1993, zeroteamc,  zeroteam, zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu (Liang Hwa license)", "Zero Team (Taiwan)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
-GAME( 1993, zeroteamd,  zeroteam, zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu (Dream Soft license)", "Zero Team (Korea)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
-GAME( 1993, zeroteame,  zeroteam, zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu", "Zero Team (Japan?, earlier?, set 2)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
-GAME( 1993, zeroteams,  zeroteam, zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu", "Zero Team Selection", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
-GAME( 1993, zeroteamsr, zeroteam, zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu", "Zero Team Suicide Revival Kit", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // reprograms the sprite decrypt data of the SEI251 only, no game code
+GAME( 1993, zeroteam,   0,        zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu (Fabtek license)", "Zero Team USA (US)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
+GAME( 1993, zeroteama,  zeroteam, zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu", "Zero Team (Japan?, earlier?, set 1)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
+GAME( 1993, zeroteamb,  zeroteam, zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu", "Zero Team (Japan?, later batteryless)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // reprograms the sprite decrypt data of the SEI251 on every boot, like raiden2 does. hack?
+GAME( 1993, zeroteamc,  zeroteam, zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu (Liang Hwa license)", "Zero Team (Taiwan)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
+GAME( 1993, zeroteamd,  zeroteam, zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu (Dream Soft license)", "Zero Team (Korea)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
+GAME( 1993, zeroteame,  zeroteam, zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu", "Zero Team (Japan?, earlier?, set 2)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
+GAME( 1993, zeroteams,  zeroteam, zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu", "Zero Team Selection", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
+GAME( 1993, zeroteamsr, zeroteam, zeroteam, zeroteam, raiden2_state, init_zeroteam, ROT0,   "Seibu Kaihatsu", "Zero Team Suicide Revival Kit", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // reprograms the sprite decrypt data of the SEI251 only, no game code
 
 
 // X Se Dae Quiz sets

--- a/src/mame/seibu/raiden2.h
+++ b/src/mame/seibu/raiden2.h
@@ -7,6 +7,7 @@
 
 #include "seibu_crtc.h"
 #include "seibucop.h"
+#include "sei25x_rise1x_spr.h"
 
 #include "seibusound.h"
 
@@ -29,20 +30,21 @@ public:
 		, m_gfxdecode(*this, "gfxdecode")
 		, m_palette(*this, "palette")
 		, m_screen(*this, "screen")
-		, m_mainbank(*this, "mainbank%u", 1U)
+		, m_spritegen(*this, "spritegen")
+		, m_mainbank(*this, "mainbank")
 		, m_raiden2cop(*this, "raiden2cop")
-
-		, m_sprite_prot_x(0)
-		, m_sprite_prot_y(0)
-		, m_dst1(0)
-		, m_cop_spr_maxx(0)
-		, m_cop_spr_off(0)
 
 		, m_bg_bank(0)
 		, m_fg_bank(0)
 		, m_mid_bank(0)
 		, m_tx_bank(0)
 		, m_tilemap_enable(0)
+
+		, m_sprite_prot_x(0)
+		, m_sprite_prot_y(0)
+		, m_dst1(0)
+		, m_cop_spr_maxx(0)
+		, m_cop_spr_off(0)
 
 		, m_prg_bank(0)
 		, m_cop_bank(0)
@@ -62,20 +64,6 @@ public:
 	void init_raiden2();
 
 protected:
-	std::unique_ptr<u16[]> m_back_data;
-	std::unique_ptr<u16[]> m_fore_data;
-	std::unique_ptr<u16[]> m_mid_data;
-	std::unique_ptr<u16[]> m_text_data; // private buffers, allocated in init
-	std::unique_ptr<u16[]> m_palette_data;
-	required_device<buffered_spriteram16_device> m_spriteram;
-	required_device<cpu_device> m_maincpu;
-	optional_device<seibu_sound_device> m_seibu_sound;
-	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<palette_device> m_palette;
-	required_device<screen_device> m_screen;
-	optional_memory_bank_array<2> m_mainbank;
-	optional_device<raiden2cop_device> m_raiden2cop;
-
 	void sprite_prot_x_w(u16 data);
 	void sprite_prot_y_w(u16 data);
 	void sprite_prot_src_seg_w(u16 data);
@@ -87,9 +75,6 @@ protected:
 	void sprite_prot_dst1_w(u16 data);
 	void sprite_prot_maxx_w(u16 data);
 	void sprite_prot_off_w(u16 data);
-
-	u16 m_sprite_prot_x,m_sprite_prot_y,m_dst1,m_cop_spr_maxx,m_cop_spr_off;
-	u16 m_sprite_prot_src_addr[2];
 
 	INTERRUPT_GEN_MEMBER(interrupt);
 	void common_save_state();
@@ -105,27 +90,8 @@ protected:
 
 	void bank_reset(int bgbank, int fgbank, int midbank, int txbank);
 
-	static u16 const raiden_blended_colors[];
-	static u16 const xsedae_blended_colors[];
-	static u16 const zeroteam_blended_colors[];
-
-	bool m_blend_active[0x800]; // cfg
-
-	tilemap_t *m_background_layer = nullptr;
-	tilemap_t *m_midground_layer = nullptr;
-	tilemap_t *m_foreground_layer = nullptr;
-	tilemap_t *m_text_layer = nullptr;
-
-	int m_bg_bank, m_fg_bank, m_mid_bank, m_tx_bank;
-	u16 m_tilemap_enable;
-
-	u16 m_scrollvals[6];
-
-	void draw_sprites(const rectangle &cliprect);
-
-	const int *m_cur_spri = nullptr; // cfg
-
 	DECLARE_GFXDECODE_MEMBER(gfx_raiden2);
+	DECLARE_GFXDECODE_MEMBER(gfx_raiden2_spr);
 	TILE_GET_INFO_MEMBER(get_back_tile_info);
 	TILE_GET_INFO_MEMBER(get_mid_tile_info);
 	TILE_GET_INFO_MEMBER(get_fore_tile_info);
@@ -137,9 +103,49 @@ protected:
 
 	void init_blending(const u16 *table);
 
-	bitmap_ind16 m_tile_bitmap, m_sprite_bitmap;
-
 	void zeroteam_sound_map(address_map &map);
+
+	// devices
+	required_device<buffered_spriteram16_device> m_spriteram;
+	required_device<cpu_device> m_maincpu;
+	optional_device<seibu_sound_device> m_seibu_sound;
+	required_device<gfxdecode_device> m_gfxdecode;
+	required_device<palette_device> m_palette;
+	required_device<screen_device> m_screen;
+	required_device<sei25x_rise1x_device> m_spritegen;
+	optional_memory_bank m_mainbank;
+	optional_device<raiden2cop_device> m_raiden2cop;
+
+	// video related
+	static u16 const raiden_blended_colors[];
+	static u16 const xsedae_blended_colors[];
+	static u16 const zeroteam_blended_colors[];
+
+	bool m_blend_active[0x800]{}; // cfg
+
+	tilemap_t *m_background_layer = nullptr;
+	tilemap_t *m_midground_layer = nullptr;
+	tilemap_t *m_foreground_layer = nullptr;
+	tilemap_t *m_text_layer = nullptr;
+
+	std::unique_ptr<u16[]> m_back_data;
+	std::unique_ptr<u16[]> m_fore_data;
+	std::unique_ptr<u16[]> m_mid_data;
+	std::unique_ptr<u16[]> m_text_data; // private buffers, allocated in init
+	std::unique_ptr<u16[]> m_palette_data;
+
+	u32 m_bg_bank, m_fg_bank, m_mid_bank, m_tx_bank;
+	u16 m_tilemap_enable;
+
+	u16 m_scrollvals[6];
+
+	const int *m_cur_spri = nullptr; // cfg
+
+	bitmap_ind16 m_tile_bitmap;
+
+	// protection related
+	u16 m_sprite_prot_x, m_sprite_prot_y, m_dst1, m_cop_spr_maxx, m_cop_spr_off;
+	u16 m_sprite_prot_src_addr[2];
 
 private:
 	void raiden2_bank_w(u8 data);
@@ -147,9 +153,6 @@ private:
 	u16 cop_tile_bank_2_r();
 	void cop_tile_bank_2_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void raidendx_cop_bank_2_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-
-	uint8_t m_prg_bank;
-	u16 m_cop_bank;
 
 	void sprcpt_val_1_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void sprcpt_val_2_w(offs_t offset, u16 data, u16 mem_mask = ~0);
@@ -160,12 +163,6 @@ private:
 	void sprcpt_adr_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void sprcpt_flags_1_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void sprcpt_flags_2_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-
-	u32 m_sprcpt_adr = 0, m_sprcpt_idx = 0;
-
-	u32 m_sprcpt_val[2], m_sprcpt_flags1 = 0;
-	u16 m_sprcpt_flags2 = 0;
-	u32 m_sprcpt_data_1[0x100], m_sprcpt_data_2[0x40], m_sprcpt_data_3[6], m_sprcpt_data_4[4];
 
 	virtual void machine_start() override;
 	DECLARE_MACHINE_RESET(raiden2);
@@ -181,6 +178,18 @@ private:
 	void raidendx_mem(address_map &map);
 	void xsedae_mem(address_map &map);
 	void zeroteam_mem(address_map &map);
+
+	// misc
+	u8 m_prg_bank;
+	u16 m_cop_bank;
+
+	// protection related
+	u32 m_sprcpt_adr = 0, m_sprcpt_idx = 0;
+
+	u32 m_sprcpt_val[2]{}, m_sprcpt_flags1 = 0;
+	u16 m_sprcpt_flags2 = 0;
+	u32 m_sprcpt_data_1[0x100]{}, m_sprcpt_data_2[0x40]{}, m_sprcpt_data_3[6]{}, m_sprcpt_data_4[4]{};
+
 };
 
 #endif // MAME_SEIBU_RAIDEN2_H

--- a/src/mame/seibu/sei25x_rise1x_spr.cpp
+++ b/src/mame/seibu/sei25x_rise1x_spr.cpp
@@ -1,0 +1,193 @@
+// license:BSD-3-Clause
+// copyright-holders:Olivier Galibert, Angelo Salese, David Haywood, Tomasz Slanina, Nicola Salmoria, Ville Linde, hap
+/*
+    Seibu Kaihatsu SEI251/SEI252/RISE10/RISE11 Sprite generator emulation
+
+    Used by Seibu Kaihatsu at 1993 onward, these are has encryption function.
+
+    SEI25x and RISE1x has compatible sprite format, but RISE1x has
+	expanded per-line sprite limit and different encryption method.
+    Other chip differences are still unknown.
+
+    Used in:
+        seibu/raiden2.cpp
+        seibu/seibuspi.cpp
+        seibu/seibucats.cpp
+        seibu/feversoc.cpp
+
+    TODO:
+    - flip screen support
+    - Wraparound in raiden2/xsedae is correct?
+    - Encryption
+*/
+
+#include "emu.h"
+#include "sei25x_rise1x_spr.h"
+#include "screen.h"
+
+
+DEFINE_DEVICE_TYPE(SEI25X_RISE1X, sei25x_rise1x_device, "sei25x_rise1x", "Seibu Kaihatsu SEI251/SEI252/RISE10/RISE11 Sprite generator")
+
+sei25x_rise1x_device::sei25x_rise1x_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, type, tag, owner, clock)
+	, device_video_interface(mconfig, *this)
+	, device_gfx_interface(mconfig, *this)
+	, m_pri_cb(*this)
+	, m_gfxbank_cb(*this)
+	, m_xoffset(0)
+	, m_yoffset(0)
+	, m_transpen(0)
+	, m_pix_raw_shift(4)
+{
+}
+
+sei25x_rise1x_device::sei25x_rise1x_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: sei25x_rise1x_device(mconfig, SEI25X_RISE1X, tag, owner, clock)
+{
+}
+
+void sei25x_rise1x_device::device_start()
+{
+	m_pri_cb.resolve();
+	m_gfxbank_cb.resolve();
+}
+
+void sei25x_rise1x_device::device_reset()
+{
+}
+
+void sei25x_rise1x_device::alloc_sprite_bitmap()
+{
+	screen().register_screen_bitmap(m_sprite_bitmap);
+}
+
+/*
+
+===============================================================
+
+Common sprite format (8 byte per sprites)
+
+Offset Bit                 Description
+       fedc ba98 7654 3210
+00     x--- ---- ---- ---- Flip Y
+       -xxx ---- ---- ---- Sprite height
+       ---- x--- ---- ---- Flip X
+       ---- -xxx ---- ---- Sprite width
+       ---- ---- xx-- ---- Priority
+       ---- ---- --xx xxxx Color index
+02     xxxx xxxx xxxx xxxx Tile index
+04     ---x ---- ---- ---- (Optional) Extra tile bank bit
+       ---- ---x xxxx xxxx X position
+06     ---- ---x xxxx xxxx Y position
+
+Unmarked bits are unused/unknown.
+
+===============================================================
+
+*/
+template<class T>
+void sei25x_rise1x_device::draw(screen_device &screen, T &bitmap, const rectangle cliprect, u16* spriteram, u16 size)
+{
+	if (m_sprite_bitmap.valid() && !m_pri_cb.isnull())
+		fatalerror("m_sprite_bitmap && m_pri_cb is invalid\n");
+
+	int start, end, inc;
+	if (m_sprite_bitmap.valid())
+		m_sprite_bitmap.fill(0xffff, cliprect);
+
+	if (!m_pri_cb.isnull())
+	{
+		start = 0;
+		end = (size / 2);
+		inc = 4;
+	}
+	else
+	{
+		start = (size / 2) - 4;
+		end = -4;
+		inc = -4;
+	}
+
+	for (int i = start; i != end; i += inc)
+	{
+		u32 code         = spriteram[i + 1];
+		// TODO: it needs at spi?
+		if (code == 0)
+			continue;
+
+		const bool flipy = BIT(spriteram[i + 0], 15);
+		const u8 sizey   = BIT(spriteram[i + 0], 12,  3) + 1;
+		const bool flipx = BIT(spriteram[i + 0], 11);
+		const u8 sizex   = BIT(spriteram[i + 0],  8,  3) + 1;
+		const u8 pri     = BIT(spriteram[i + 0],  6,  2);
+		u32 color        = BIT(spriteram[i + 0],  0,  6);
+		const u8 ext     = BIT(spriteram[i + 2], 12);
+		s32 x            = BIT(spriteram[i + 2],  0,  9);
+		s32 y            = BIT(spriteram[i + 3],  0,  9);
+
+		if (x >= 0x180) x -= 0x200;
+		if (y >= 0x180) y -= 0x200;
+
+		x += m_xoffset;
+		y += m_yoffset;
+
+		u32 pri_mask = 0;
+
+		if (!m_pri_cb.isnull())
+			pri_mask = m_pri_cb(pri);
+		else if (m_sprite_bitmap.valid())
+			color |= pri << (m_pri_raw_shift - m_pix_raw_shift); // for manual mixing
+
+		if (!m_gfxbank_cb.isnull())
+			code = m_gfxbank_cb(code, ext);
+
+		for (int ax = 0; ax < sizex; ax++)
+		{
+			const int sx = flipx ? (x + 16 * (sizex - ax - 1)) : (x + 16 * ax);
+			for (int ay = 0; ay < sizey; ay++)
+			{
+				const int sy = flipy ? (y + 16 * (sizey - ay - 1)) : (y + 16 * ay);
+				if (!m_sprite_bitmap.valid())
+				{
+					if (!m_pri_cb.isnull())
+					{
+						gfx(0)->prio_transpen(bitmap, cliprect,
+							code++,
+							color,
+							flipx, flipy,
+							sx, sy,
+							screen.priority(), pri_mask, m_transpen);
+					}
+					else
+					{
+						gfx(0)->transpen(bitmap, cliprect,
+							code++,
+							color,
+							flipx, flipy,
+							sx, sy,
+							m_transpen);
+					}
+				}
+				else
+				{
+					gfx(0)->transpen_raw(m_sprite_bitmap, cliprect,
+						code++,
+						color << m_pix_raw_shift,
+						flipx, flipy,
+						sx, sy,
+						m_transpen);
+				}
+			}
+		}
+	}
+}
+
+void sei25x_rise1x_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle cliprect, u16* spriteram, u16 size)
+{
+	draw(screen, bitmap, cliprect, spriteram, size);
+}
+
+void sei25x_rise1x_device::draw_sprites(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle cliprect, u16* spriteram, u16 size)
+{
+	draw(screen, bitmap, cliprect, spriteram, size);
+}

--- a/src/mame/seibu/sei25x_rise1x_spr.h
+++ b/src/mame/seibu/sei25x_rise1x_spr.h
@@ -1,0 +1,63 @@
+// license:BSD-3-Clause
+// copyright-holders:Olivier Galibert, Angelo Salese, David Haywood, Tomasz Slanina, Nicola Salmoria, Ville Linde, hap
+#ifndef MAME_SEIBU_SEI025X_RISE1X_SPR_H
+#define MAME_SEIBU_SEI025X_RISE1X_SPR_H
+
+#pragma once
+
+class sei25x_rise1x_device : public device_t, public device_video_interface, public device_gfx_interface
+{
+public:
+	typedef device_delegate<u32 (u8 pri)> pri_cb_delegate;
+	typedef device_delegate<u32 (u32 code, u8 ext)> gfxbank_cb_delegate;
+
+	sei25x_rise1x_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+	template <typename T> sei25x_rise1x_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, T &&palette_tag, const gfx_decode_entry *gfxinfo)
+		: sei25x_rise1x_device(mconfig, tag, owner, clock)
+	{
+		set_info(gfxinfo);
+		set_palette(std::forward<T>(palette_tag));
+	}
+
+	// configuration
+	template <typename... T> void set_pri_callback(T &&... args) { m_pri_cb.set(std::forward<T>(args)...); }
+	template <typename... T> void set_gfxbank_callback(T &&... args) { m_gfxbank_cb.set(std::forward<T>(args)...); }
+	void set_offset(s32 xoffset, s32 yoffset)
+	{
+		m_xoffset = xoffset;
+		m_yoffset = yoffset;
+	}
+	void set_transpen(u32 transpen) { m_transpen = transpen; }
+	void set_pix_raw_shift(u32 raw_shift) { m_pix_raw_shift = raw_shift; }
+	void set_pri_raw_shift(u32 raw_shift) { m_pri_raw_shift = raw_shift; }
+
+	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle cliprect, u16* spriteram, u16 size);
+	void draw_sprites(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle cliprect, u16* spriteram, u16 size);
+
+	void alloc_sprite_bitmap();
+	bitmap_ind16& get_sprite_temp_bitmap() { assert(m_sprite_bitmap.valid()); return m_sprite_bitmap; }
+
+protected:
+	sei25x_rise1x_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
+
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+private:
+	template<class T>
+	void draw(screen_device &screen, T &bitmap, const rectangle cliprect, u16* spriteram, u16 size);
+
+	pri_cb_delegate     m_pri_cb;
+	gfxbank_cb_delegate m_gfxbank_cb;
+
+	s32 m_xoffset;
+	s32 m_yoffset;
+	u32 m_transpen;
+	u32 m_pix_raw_shift;
+	u32 m_pri_raw_shift;
+	bitmap_ind16 m_sprite_bitmap;
+};
+
+DECLARE_DEVICE_TYPE(SEI25X_RISE1X, sei25x_rise1x_device)
+
+#endif // MAME_SEIBU_SEI025X_RISE1X_SPR_H

--- a/src/mame/seibu/seibuspi.cpp
+++ b/src/mame/seibu/seibuspi.cpp
@@ -891,19 +891,7 @@ Notes:
 #include "speaker.h"
 
 
-// default values written to CRTC (note: SYS386F does not have this chip)
-#define PIXEL_CLOCK  (XTAL(28'636'363)/4)
-
-#define SPI_HTOTAL   (448)
-#define SPI_HBEND    (0)
-#define SPI_HBSTART  (320)
-
-#define SPI_VTOTAL   (296)
-#define SPI_VBEND    (0)
-#define SPI_VBSTART  (240) /* actually 253, but visible area is 240 lines */
-
-
-#define ENABLE_SPEEDUP_HACKS 1 /* speed up at idle loops */
+#define ENABLE_SPEEDUP_HACKS 1 // speed up at idle loops
 
 
 /*****************************************************************************/
@@ -932,9 +920,9 @@ u8 seibuspi_state::spi_ds2404_unknown_r()
 
 void seibuspi_state::eeprom_w(u8 data)
 {
-	m_eeprom->di_write((data & 0x80) ? 1 : 0);
-	m_eeprom->clk_write((data & 0x40) ? ASSERT_LINE : CLEAR_LINE);
-	m_eeprom->cs_write((data & 0x20) ? ASSERT_LINE : CLEAR_LINE);
+	m_eeprom->di_write(BIT(data, 7));
+	m_eeprom->clk_write(BIT(data, 6) ? ASSERT_LINE : CLEAR_LINE);
+	m_eeprom->cs_write(BIT(data, 5) ? ASSERT_LINE : CLEAR_LINE);
 }
 
 void seibuspi_state::spi_layerbanks_eeprom_w(u8 data)
@@ -948,7 +936,7 @@ void seibuspi_state::spi_layerbanks_eeprom_w(u8 data)
 
 void seibuspi_state::oki_bank_w(u8 data)
 {
-	m_oki[1]->set_rom_bank((data >> 2) & 1);
+	m_oki[1]->set_rom_bank(BIT(data, 2));
 }
 
 void seibuspi_state::z80_prg_transfer_w(u8 data)
@@ -997,7 +985,7 @@ void seibuspi_state::ejsakura_input_select_w(u32 data)
 
 void seibuspi_state::base_map(address_map &map)
 {
-	map(0x00000000, 0x0003ffff).ram().share("mainram");
+	map(0x00000000, 0x0003ffff).ram().share(m_mainram);
 	map(0x00000400, 0x0000043f).rw("crtc", FUNC(seibu_crtc_device::read), FUNC(seibu_crtc_device::write));
 	map(0x00000480, 0x00000483).w(FUNC(seibuspi_state::tilemap_dma_start_w));
 	map(0x00000484, 0x00000487).w(FUNC(seibuspi_state::palette_dma_start_w));
@@ -1016,17 +1004,17 @@ void seibuspi_state::sei252_map(address_map &map)
 {
 	//map(0x00000500, 0x0000057f).rw("obj", FUNC(sei252_device::read_xor), FUNC(sei252_device::write_xor));
 	map(0x0000050e, 0x0000050f).w(FUNC(seibuspi_state::sprite_dma_start_w));
-	map(0x00000524, 0x00000527).nopw(); // SEI252 sprite decryption key, see machine/spisprit.c
+	map(0x00000524, 0x00000527).nopw(); // SEI252 sprite decryption key, see seibu/seibuspi_m.cpp
 	map(0x00000528, 0x0000052b).nopw(); // SEI252 sprite decryption unknown
-	map(0x00000530, 0x00000533).nopw(); // SEI252 sprite decryption table key, see machine/spisprit.c
+	map(0x00000530, 0x00000533).nopw(); // SEI252 sprite decryption table key, see seibu/seibuspi_m.cpp
 	map(0x00000534, 0x00000537).nopw(); // SEI252 sprite decryption unknown
-	map(0x0000053c, 0x0000053f).nopw(); // SEI252 sprite decryption table index, see machine/spisprit.c
+	map(0x0000053c, 0x0000053f).nopw(); // SEI252 sprite decryption table index, see seibu/seibuspi_m.cpp
 }
 
 void seibuspi_state::rise_map(address_map &map)
 {
 	//map(0x00000500, 0x0000057f).rw("obj", FUNC(seibu_encrypted_sprite_device::read), FUNC(seibu_encrypted_sprite_device::write));
-	map(0x0000054c, 0x0000054f).nopw(); // RISE10/11 sprite decryption key, see machine/seibuspi.c
+	map(0x0000054c, 0x0000054f).nopw(); // RISE10/11 sprite decryption key, see seibu/seibuspi_m.cpp
 	map(0x00000562, 0x00000563).w(FUNC(seibuspi_state::sprite_dma_start_w));
 }
 
@@ -1035,8 +1023,8 @@ void seibuspi_state::spi_map(address_map &map)
 	base_map(map);
 	sei252_map(map);
 	map(0x00000600, 0x00000603).nopw(); // ?
-	map(0x00000680, 0x00000680).r("soundfifo2", FUNC(fifo7200_device::data_byte_r));
-	map(0x00000680, 0x00000680).w("soundfifo1", FUNC(fifo7200_device::data_byte_w));
+	map(0x00000680, 0x00000680).r(m_soundfifo[1], FUNC(fifo7200_device::data_byte_r));
+	map(0x00000680, 0x00000680).w(m_soundfifo[0], FUNC(fifo7200_device::data_byte_w));
 	map(0x00000684, 0x00000684).r(FUNC(seibuspi_state::sound_fifo_status_r));
 	map(0x00000688, 0x00000688).w(FUNC(seibuspi_state::z80_prg_transfer_w));
 	map(0x0000068c, 0x0000068c).w(FUNC(seibuspi_state::z80_enable_w));
@@ -1054,8 +1042,8 @@ void seibuspi_state::rdft2_map(address_map &map)
 	base_map(map);
 	rise_map(map);
 	map(0x00000600, 0x00000603).nopw(); // ?
-	map(0x00000680, 0x00000680).r("soundfifo2", FUNC(fifo7200_device::data_byte_r));
-	map(0x00000680, 0x00000680).w("soundfifo1", FUNC(fifo7200_device::data_byte_w));
+	map(0x00000680, 0x00000680).r(m_soundfifo[1], FUNC(fifo7200_device::data_byte_r));
+	map(0x00000680, 0x00000680).w(m_soundfifo[0], FUNC(fifo7200_device::data_byte_w));
 	map(0x00000684, 0x00000684).r(FUNC(seibuspi_state::sound_fifo_status_r));
 	map(0x00000688, 0x00000688).w(FUNC(seibuspi_state::z80_prg_transfer_w));
 	map(0x0000068c, 0x0000068c).w(FUNC(seibuspi_state::z80_enable_w));
@@ -1073,7 +1061,7 @@ void seibuspi_state::sxx2e_map(address_map &map)
 	base_map(map);
 	sei252_map(map);
 	map(0x00000680, 0x00000680).r(FUNC(seibuspi_state::sb_coin_r));
-	map(0x00000680, 0x00000680).w("soundfifo1", FUNC(fifo7200_device::data_byte_w));
+	map(0x00000680, 0x00000680).w(m_soundfifo[0], FUNC(fifo7200_device::data_byte_w));
 	map(0x00000684, 0x00000684).r(FUNC(seibuspi_state::sound_fifo_status_r));
 	map(0x00000688, 0x0000068b).noprw(); // ?
 	map(0x0000068c, 0x0000068f).nopw();
@@ -1089,7 +1077,7 @@ void seibuspi_state::sxx2f_map(address_map &map)
 	base_map(map);
 	rise_map(map);
 	map(0x00000680, 0x00000680).r(FUNC(seibuspi_state::sb_coin_r));
-	map(0x00000680, 0x00000680).w("soundfifo1", FUNC(fifo7200_device::data_byte_w));
+	map(0x00000680, 0x00000680).w(m_soundfifo[0], FUNC(fifo7200_device::data_byte_w));
 	map(0x00000684, 0x00000684).r(FUNC(seibuspi_state::sound_fifo_status_r));
 	map(0x00000688, 0x0000068b).noprw(); // ?
 	map(0x0000068e, 0x0000068e).w(FUNC(seibuspi_state::spi_layerbanks_eeprom_w));
@@ -1102,13 +1090,13 @@ void seibuspi_state::sys386i_map(address_map &map)
 	rise_map(map);
 	map(0x0000068e, 0x0000068e).w(FUNC(seibuspi_state::spi_layerbanks_eeprom_w));
 	map(0x0000068f, 0x0000068f).w(FUNC(seibuspi_state::oki_bank_w));
-	map(0x01200000, 0x01200000).rw("oki1", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x01200004, 0x01200004).rw("oki2", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x01200000, 0x01200000).rw(m_oki[0], FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0x01200004, 0x01200004).rw(m_oki[1], FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 }
 
 void seibuspi_state::sys386f_map(address_map &map)
 {
-	map(0x00000000, 0x0003ffff).ram().share("mainram");
+	map(0x00000000, 0x0003ffff).ram().share(m_mainram);
 	rise_map(map);
 	map(0x00000010, 0x00000010).r(FUNC(seibuspi_state::spi_status_r));
 	map(0x00000400, 0x00000403).portr("SYSTEM").w(FUNC(seibuspi_state::ejsakura_input_select_w));
@@ -1151,8 +1139,8 @@ void seibuspi_state::z80_bank_w(u8 data)
 
 void seibuspi_state::spi_coin_w(u8 data)
 {
-	machine().bookkeeping().coin_counter_w(0, data & 1);
-	machine().bookkeeping().coin_counter_w(1, data & 2);
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 0));
+	machine().bookkeeping().coin_counter_w(1, BIT(data, 1));
 
 	// coin latch used by single boards
 	if (data)
@@ -1169,7 +1157,7 @@ void seibuspi_state::sxx2e_soundmap(address_map &map)
 	map(0x4002, 0x4002).nopw(); // ?
 	map(0x4003, 0x4003).nopw(); // ?
 	map(0x4004, 0x4004).w(FUNC(seibuspi_state::spi_coin_w));
-	map(0x4008, 0x4008).r("soundfifo1", FUNC(fifo7200_device::data_byte_r));
+	map(0x4008, 0x4008).r(m_soundfifo[0], FUNC(fifo7200_device::data_byte_r));
 	map(0x4008, 0x4008).nopw(); // ?
 	map(0x4009, 0x4009).r(FUNC(seibuspi_state::z80_soundfifo_status_r));
 	map(0x400b, 0x400b).nopw(); // ?
@@ -1182,15 +1170,15 @@ void seibuspi_state::sxx2e_soundmap(address_map &map)
 void seibuspi_state::spi_soundmap(address_map &map)
 {
 	sxx2e_soundmap(map);
-	map(0x4008, 0x4008).w("soundfifo2", FUNC(fifo7200_device::data_byte_w));
+	map(0x4008, 0x4008).w(m_soundfifo[1], FUNC(fifo7200_device::data_byte_w));
 	map(0x400a, 0x400a).portr("JUMPERS"); // TODO: get these to actually work (only on SXX2C)
 }
 
 void seibuspi_state::spi_ymf271_map(address_map &map)
 {
 	map.global_mask(0x1fffff);
-	map(0x000000, 0x0fffff).rw("soundflash1", FUNC(intel_e28f008sa_device::read), FUNC(intel_e28f008sa_device::write));
-	map(0x100000, 0x1fffff).rw("soundflash2", FUNC(intel_e28f008sa_device::read), FUNC(intel_e28f008sa_device::write));
+	map(0x000000, 0x0fffff).rw(m_soundflash[0], FUNC(intel_e28f008sa_device::read), FUNC(intel_e28f008sa_device::write));
+	map(0x100000, 0x1fffff).rw(m_soundflash[1], FUNC(intel_e28f008sa_device::read), FUNC(intel_e28f008sa_device::write));
 }
 
 
@@ -1445,9 +1433,9 @@ INPUT_PORTS_END
 
 static const gfx_layout spi_charlayout =
 {
-	8,8,        /* 8*8 characters */
-	RGN_FRAC(1,1),       /* 4096 characters */
-	5,          /* 6 bits per pixel */
+	8,8,        // 8*8 characters
+	RGN_FRAC(1,1),       // 4096 characters
+	5,          // 6 bits per pixel
 	{ 4, 8, 12, 16, 20 },
 	{ STEP4(3,-1), STEP4(4*6+3,-1) },
 	{ STEP8(0,4*6*2) },
@@ -1457,9 +1445,9 @@ static const gfx_layout spi_charlayout =
 #if PLANE_CHAR
 static const gfx_layout spi_charlayout0 =
 {
-	8,8,        /* 8*8 characters */
-	RGN_FRAC(1,1),       /* 4096 characters */
-	1,          /* 6 bits per pixel */
+	8,8,        // 8*8 characters
+	RGN_FRAC(1,1),       // 4096 characters
+	1,          // 6 bits per pixel
 	{ 0 },
 	{ STEP4(3,-1), STEP4(4*6+3,-1) },
 	{ STEP8(0,4*6*2) },
@@ -1468,9 +1456,9 @@ static const gfx_layout spi_charlayout0 =
 
 static const gfx_layout spi_charlayout1 =
 {
-	8,8,        /* 8*8 characters */
-	RGN_FRAC(1,1),       /* 4096 characters */
-	1,          /* 6 bits per pixel */
+	8,8,        // 8*8 characters
+	RGN_FRAC(1,1),       // 4096 characters
+	1,          // 6 bits per pixel
 	{ 4 },
 	{ STEP4(3,-1), STEP4(4*6+3,-1) },
 	{ STEP8(0,4*6*2) },
@@ -1479,9 +1467,9 @@ static const gfx_layout spi_charlayout1 =
 
 static const gfx_layout spi_charlayout2 =
 {
-	8,8,        /* 8*8 characters */
-	RGN_FRAC(1,1),       /* 4096 characters */
-	1,          /* 6 bits per pixel */
+	8,8,        // 8*8 characters
+	RGN_FRAC(1,1),       // 4096 characters
+	1,          // 6 bits per pixel
 	{ 8 },
 	{ STEP4(3,-1), STEP4(4*6+3,-1) },
 	{ STEP8(0,4*6*2) },
@@ -1490,9 +1478,9 @@ static const gfx_layout spi_charlayout2 =
 
 static const gfx_layout spi_charlayout3 =
 {
-	8,8,        /* 8*8 characters */
-	RGN_FRAC(1,1),       /* 4096 characters */
-	1,          /* 6 bits per pixel */
+	8,8,        // 8*8 characters
+	RGN_FRAC(1,1),       // 4096 characters
+	1,          // 6 bits per pixel
 	{ 12 },
 	{ STEP4(3,-1), STEP4(4*6+3,-1) },
 	{ STEP8(0,4*6*2) },
@@ -1501,9 +1489,9 @@ static const gfx_layout spi_charlayout3 =
 
 static const gfx_layout spi_charlayout4 =
 {
-	8,8,        /* 8*8 characters */
-	RGN_FRAC(1,1),       /* 4096 characters */
-	1,          /* 6 bits per pixel */
+	8,8,        // 8*8 characters
+	RGN_FRAC(1,1),       // 4096 characters
+	1,          // 6 bits per pixel
 	{ 16 },
 	{ STEP4(3,-1), STEP4(4*6+3,-1) },
 	{ STEP8(0,4*6*2) },
@@ -1512,9 +1500,9 @@ static const gfx_layout spi_charlayout4 =
 
 static const gfx_layout spi_charlayout5 =
 {
-	8,8,        /* 8*8 characters */
-	RGN_FRAC(1,1),       /* 4096 characters */
-	1,          /* 6 bits per pixel */
+	8,8,        // 8*8 characters
+	RGN_FRAC(1,1),       // 4096 characters
+	1,          // 6 bits per pixel
 	{ 20 },
 	{ STEP4(3,-1), STEP4(4*6+3,-1) },
 	{ STEP8(0,4*6*2) },
@@ -1681,16 +1669,15 @@ static const gfx_layout spi_spritelayout5 =
 #endif
 
 static GFXDECODE_START( gfx_spi )
-	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout,  0, 64 )
-	GFXDECODE_ENTRY( "tiles",   0, spi_tilelayout, 4096, 24 )
 	GFXDECODE_ENTRY( "chars",   0, spi_charlayout, 5632, 16 )
-#if PLANE_SPRITE
-	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout0, 0, 6144/2 )
-	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout1, 0, 6144/2 )
-	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout2, 0, 6144/2 )
-	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout3, 0, 6144/2 )
-	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout4, 0, 6144/2 )
-	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout5, 0, 6144/2 )
+	GFXDECODE_ENTRY( "tiles",   0, spi_tilelayout, 4096, 24 )
+#if PLANE_CHAR
+	GFXDECODE_ENTRY( "chars",   0, spi_charlayout0,   0, 6144/2 )
+	GFXDECODE_ENTRY( "chars",   0, spi_charlayout1,   0, 6144/2 )
+	GFXDECODE_ENTRY( "chars",   0, spi_charlayout2,   0, 6144/2 )
+	GFXDECODE_ENTRY( "chars",   0, spi_charlayout3,   0, 6144/2 )
+	GFXDECODE_ENTRY( "chars",   0, spi_charlayout4,   0, 6144/2 )
+	GFXDECODE_ENTRY( "chars",   0, spi_charlayout5,   0, 6144/2 )
 #endif
 #if PLANE_TILE
 	GFXDECODE_ENTRY( "tiles",   0, spi_tilelayout0,   0, 6144/2 )
@@ -1700,13 +1687,17 @@ static GFXDECODE_START( gfx_spi )
 	GFXDECODE_ENTRY( "tiles",   0, spi_tilelayout4,   0, 6144/2 )
 	GFXDECODE_ENTRY( "tiles",   0, spi_tilelayout5,   0, 6144/2 )
 #endif
-#if PLANE_CHAR
-	GFXDECODE_ENTRY( "chars",   0, spi_charlayout0,   0, 6144/2 )
-	GFXDECODE_ENTRY( "chars",   0, spi_charlayout1,   0, 6144/2 )
-	GFXDECODE_ENTRY( "chars",   0, spi_charlayout2,   0, 6144/2 )
-	GFXDECODE_ENTRY( "chars",   0, spi_charlayout3,   0, 6144/2 )
-	GFXDECODE_ENTRY( "chars",   0, spi_charlayout4,   0, 6144/2 )
-	GFXDECODE_ENTRY( "chars",   0, spi_charlayout5,   0, 6144/2 )
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_spi_spr )
+	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout,  0, 64 )
+#if PLANE_SPRITE
+	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout0, 0, 6144/2 )
+	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout1, 0, 6144/2 )
+	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout2, 0, 6144/2 )
+	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout3, 0, 6144/2 )
+	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout4, 0, 6144/2 )
+	GFXDECODE_ENTRY( "sprites", 0, spi_spritelayout5, 0, 6144/2 )
 #endif
 GFXDECODE_END
 
@@ -1739,7 +1730,7 @@ IRQ_CALLBACK_MEMBER(seibuspi_state::spi_irq_callback)
 }
 
 
-/* SPI */
+// SPI
 
 void seibuspi_state::init_spi_common()
 {
@@ -1778,15 +1769,27 @@ MACHINE_RESET_MEMBER(seibuspi_state,spi)
 	m_z80_prg_transfer_pos = 0;
 
 	// fix the magic ID byte so users can't "brick" the machine
-	if (m_soundflash1 && m_soundflash1_region)
+	if (m_soundflash[0] && m_soundflash1_region)
 	{
-		m_soundflash1->write_raw(0, m_soundflash1_region[0]);
+		m_soundflash[0]->write_raw(0, m_soundflash1_region[0]);
 	}
 }
 
+// default values written to CRTC (note: SYS386F does not have this chip)
+static constexpr XTAL PIXEL_CLOCK = 28.636363_MHz_XTAL / 4;
+
+static constexpr u16 SPI_HTOTAL  = 448;
+static constexpr u16 SPI_HBEND   = 0;
+static constexpr u16 SPI_HBSTART = 320;
+
+static constexpr u16 SPI_VTOTAL  = 296;
+static constexpr u16 SPI_VBEND   = 0;
+static constexpr u16 SPI_VBSTART = 240; // actually 253, but visible area is 240 lines
+
+
 void seibuspi_state::spi(machine_config &config)
 {
-	/* basic machine hardware */
+	// basic machine hardware
 	I386(config, m_maincpu, 50_MHz_XTAL / 2); // AMD or Intel 386DX, 25MHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &seibuspi_state::spi_map);
 	m_maincpu->set_vblank_int("screen", FUNC(seibuspi_state::spi_interrupt));
@@ -1804,13 +1807,13 @@ void seibuspi_state::spi(machine_config &config)
 	rtc.ref_month(1);
 	rtc.ref_day(1);
 
-	INTEL_E28F008SA(config, "soundflash1"); // Sharp LH28F008 on newer mainboard revision
-	INTEL_E28F008SA(config, "soundflash2"); // "
+	INTEL_E28F008SA(config, m_soundflash[0]); // Sharp LH28F008 on newer mainboard revision
+	INTEL_E28F008SA(config, m_soundflash[1]); // "
 
 	IDT7201(config, m_soundfifo[0]); // LH5496D, but on single board hw it's one CY7C421
 	IDT7201(config, m_soundfifo[1]); // "
 
-	/* video hardware */
+	// video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_raw(PIXEL_CLOCK, SPI_HTOTAL, SPI_HBEND, SPI_HBSTART, SPI_VTOTAL, SPI_VBEND, SPI_VBSTART);
 	screen.set_screen_update(FUNC(seibuspi_state::screen_update_spi));
@@ -1819,13 +1822,20 @@ void seibuspi_state::spi(machine_config &config)
 
 	PALETTE(config, m_palette, palette_device::BLACK, 6144);
 
+	SEI25X_RISE1X(config, m_spritegen, 0, m_palette, gfx_spi_spr);
+	m_spritegen->set_screen("screen");
+	m_spritegen->set_gfxbank_callback(FUNC(seibuspi_state::gfxbank_callback));
+	m_spritegen->set_pix_raw_shift(6);
+	m_spritegen->set_pri_raw_shift(14);
+	m_spritegen->set_transpen(63);
+
 	seibu_crtc_device &crtc(SEIBU_CRTC(config, "crtc", 0));
 	crtc.decrypt_key_callback().set(FUNC(seibuspi_state::tile_decrypt_key_w));
 	crtc.layer_en_callback().set(FUNC(seibuspi_state::spi_layer_enable_w));
 	crtc.reg_1a_callback().set(FUNC(seibuspi_state::spi_layer_bank_w));
 	crtc.layer_scroll_callback().set(FUNC(seibuspi_state::scroll_w));
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
@@ -1843,7 +1853,7 @@ void seibuspi_state::ejanhs(machine_config &config)
 {
 	spi(config);
 
-	/* video hardware */
+	// video hardware
 	MCFG_VIDEO_START_OVERRIDE(seibuspi_state, ejanhs)
 }
 
@@ -1854,7 +1864,7 @@ void seibuspi_state::rdft2(machine_config &config)
 }
 
 
-/* single boards */
+// single boards
 
 MACHINE_RESET_MEMBER(seibuspi_state,sxx2e)
 {
@@ -1867,7 +1877,7 @@ void seibuspi_state::sxx2e(machine_config &config)
 {
 	spi(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &seibuspi_state::sxx2e_map);
 
 	m_audiocpu->set_addrmap(AS_PROGRAM, &seibuspi_state::sxx2e_soundmap);
@@ -1879,7 +1889,7 @@ void seibuspi_state::sxx2e(machine_config &config)
 
 	config.device_remove("soundfifo2");
 
-	/* sound hardware */
+	// sound hardware
 	// Single PCBs only output mono sound, SXX2E : unverified
 	config.device_remove("lspeaker");
 	config.device_remove("rspeaker");
@@ -1894,7 +1904,7 @@ void seibuspi_state::sxx2f(machine_config &config)
 {
 	sxx2e(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &seibuspi_state::sxx2f_map);
 
 	config.device_remove("ds2404");
@@ -1909,22 +1919,22 @@ void seibuspi_state::sxx2g(machine_config &config) // clocks differ, but otherwi
 {
 	sxx2f(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_clock(28.636363_MHz_XTAL); // AMD AM386DX/DX-40, 28.63636MHz
 	m_audiocpu->set_clock(4.9512_MHz_XTAL); // Z84C0004PCS, 4.9152MHz
 
-	/* sound hardware */
+	// sound hardware
 	ymf271_device &ymf(YMF271(config.replace(), "ymf", 16.384_MHz_XTAL)); // 16.384MHz(!)
 	ymf.irq_handler().set(FUNC(seibuspi_state::ymf_irqhandler));
 	ymf.add_route(ALL_OUTPUTS, "mono", 1.0);
 }
 
 
-/* SYS386I */
+// SYS386I
 
 void seibuspi_state::sys386i(machine_config &config)
 {
-	/* basic machine hardware */
+	// basic machine hardware
 	I386(config, m_maincpu, 40_MHz_XTAL); // AMD 386DX, 40MHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &seibuspi_state::sys386i_map);
 	m_maincpu->set_vblank_int("screen", FUNC(seibuspi_state::spi_interrupt));
@@ -1932,7 +1942,7 @@ void seibuspi_state::sys386i(machine_config &config)
 
 	EEPROM_93C46_16BIT(config, "eeprom");
 
-	/* video hardware */
+	// video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_raw(PIXEL_CLOCK, SPI_HTOTAL, SPI_HBEND, SPI_HBSTART, SPI_VTOTAL, SPI_VBEND, SPI_VBSTART);
 	screen.set_screen_update(FUNC(seibuspi_state::screen_update_spi));
@@ -1941,13 +1951,20 @@ void seibuspi_state::sys386i(machine_config &config)
 
 	PALETTE(config, m_palette, palette_device::BLACK, 6144);
 
+	SEI25X_RISE1X(config, m_spritegen, 0, m_palette, gfx_spi_spr);
+	m_spritegen->set_screen("screen");
+	m_spritegen->set_gfxbank_callback(FUNC(seibuspi_state::gfxbank_callback));
+	m_spritegen->set_pix_raw_shift(6);
+	m_spritegen->set_pri_raw_shift(14);
+	m_spritegen->set_transpen(63);
+
 	seibu_crtc_device &crtc(SEIBU_CRTC(config, "crtc", 0));
 	crtc.decrypt_key_callback().set(FUNC(seibuspi_state::tile_decrypt_key_w));
 	crtc.layer_en_callback().set(FUNC(seibuspi_state::spi_layer_enable_w));
 	crtc.reg_1a_callback().set(FUNC(seibuspi_state::spi_layer_bank_w));
 	crtc.layer_scroll_callback().set(FUNC(seibuspi_state::scroll_w));
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	OKIM6295(config, m_oki[0], 28.636363_MHz_XTAL / 20, okim6295_device::PIN7_HIGH);
@@ -1958,7 +1975,7 @@ void seibuspi_state::sys386i(machine_config &config)
 }
 
 
-/* SYS386F */
+// SYS386F
 
 void seibuspi_state::init_sys386f()
 {
@@ -1980,7 +1997,7 @@ void seibuspi_state::init_sys386f()
 
 void seibuspi_state::sys386f(machine_config &config)
 {
-	/* basic machine hardware */
+	// basic machine hardware
 	I386(config, m_maincpu, XTAL(50'000'000)/2); // Intel i386DX, 25MHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &seibuspi_state::sys386f_map);
 	m_maincpu->set_vblank_int("screen", FUNC(seibuspi_state::spi_interrupt));
@@ -1988,7 +2005,7 @@ void seibuspi_state::sys386f(machine_config &config)
 
 	EEPROM_93C46_16BIT(config, "eeprom");
 
-	/* video hardware */
+	// video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(57.59);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
@@ -1996,13 +2013,17 @@ void seibuspi_state::sys386f(machine_config &config)
 	screen.set_visarea(0*8, 40*8-1, 0*8, 30*8-1);
 	screen.set_screen_update(FUNC(seibuspi_state::screen_update_sys386f));
 
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_sys386f);
-
 	PALETTE(config, m_palette, palette_device::BLACK, 8192);
+
+	SEI25X_RISE1X(config, m_spritegen, 0, m_palette, gfx_sys386f);
+	m_spritegen->set_screen("screen");
+	m_spritegen->set_pix_raw_shift(8);
+	m_spritegen->set_pri_raw_shift(14);
+	m_spritegen->set_transpen(255);
 
 	MCFG_VIDEO_START_OVERRIDE(seibuspi_state, sys386f)
 
-	/* sound hardware */
+	// sound hardware
 	// Single PCBs only output mono sound
 	SPEAKER(config, "mono").front_center();
 
@@ -2078,14 +2099,16 @@ void seibuspi_state::init_rfjet()
 
 u32 seibuspi_state::senkyu_speedup_r()
 {
-	if (m_maincpu->pc()==0x00305bb2) m_maincpu->spin_until_interrupt(); // idle
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc()==0x00305bb2) m_maincpu->spin_until_interrupt(); // idle
 
 	return m_mainram[0x0018cb4/4];
 }
 
 u32 seibuspi_state::senkyua_speedup_r()
 {
-	if (m_maincpu->pc()== 0x30582e) m_maincpu->spin_until_interrupt(); // idle
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc()== 0x30582e) m_maincpu->spin_until_interrupt(); // idle
 
 	return m_mainram[0x0018c9c/4];
 }
@@ -2094,114 +2117,132 @@ u32 seibuspi_state::batlball_speedup_r()
 {
 //  printf("m_maincpu->pc() %06x\n", m_maincpu->pc());
 
-	/* batlbalu */
-	if (m_maincpu->pc()==0x00305996) m_maincpu->spin_until_interrupt(); // idle
+	if (!machine().side_effects_disabled())
+	{
+		// batlbalu
+		if (m_maincpu->pc()==0x00305996) m_maincpu->spin_until_interrupt(); // idle
 
-	/* batlball */
-	if (m_maincpu->pc()==0x003058aa) m_maincpu->spin_until_interrupt(); // idle
+		// batlball
+		if (m_maincpu->pc()==0x003058aa) m_maincpu->spin_until_interrupt(); // idle
+	}
 
 	return m_mainram[0x0018db4/4];
 }
 
 u32 seibuspi_state::viprp1_speedup_r()
 {
-	/* viprp1 */
-	if (m_maincpu->pc()==0x0202769) m_maincpu->spin_until_interrupt(); // idle
+	if (!machine().side_effects_disabled())
+	{
+		// viprp1
+		if (m_maincpu->pc()==0x0202769) m_maincpu->spin_until_interrupt(); // idle
 
-	/* viprp1s */
-	if (m_maincpu->pc()==0x02027e9) m_maincpu->spin_until_interrupt(); // idle
+		// viprp1s
+		if (m_maincpu->pc()==0x02027e9) m_maincpu->spin_until_interrupt(); // idle
 
-	/* viprp1ot */
-	if (m_maincpu->pc()==0x02026bd) m_maincpu->spin_until_interrupt(); // idle
+		// viprp1ot
+		if (m_maincpu->pc()==0x02026bd) m_maincpu->spin_until_interrupt(); // idle
 
-//  osd_printf_debug("%08x\n",m_maincpu->pc());
+		//osd_printf_debug("%08x\n",m_maincpu->pc());
+	}
 
 	return m_mainram[0x001e2e0/4];
 }
 
 u32 seibuspi_state::viprp1o_speedup_r()
 {
-	/* viperp1o */
-	if (m_maincpu->pc()==0x0201f99) m_maincpu->spin_until_interrupt(); // idle
-//  osd_printf_debug("%08x\n",m_maincpu->pc());
+	if (!machine().side_effects_disabled())
+	{
+		// viperp1o
+		if (m_maincpu->pc()==0x0201f99) m_maincpu->spin_until_interrupt(); // idle
+		//osd_printf_debug("%08x\n",m_maincpu->pc());
+	}
 	return m_mainram[0x001d49c/4];
 }
 
 // causes input problems?
 u32 seibuspi_state::ejanhs_speedup_r()
 {
-	if (m_maincpu->pc()==0x03032c7) m_maincpu->spin_until_interrupt(); // idle
-//  osd_printf_debug("%08x\n",m_maincpu->pc());
+	if (!machine().side_effects_disabled())
+	{
+		if (m_maincpu->pc()==0x03032c7) m_maincpu->spin_until_interrupt(); // idle
+		//osd_printf_debug("%08x\n",m_maincpu->pc());
+	}
 	return m_mainram[0x002d224/4];
 }
 
 u32 seibuspi_state::rdft_speedup_r()
 {
-	/* rdft */
-	if (m_maincpu->pc()==0x0203f06) m_maincpu->spin_until_interrupt(); // idle
+	if (!machine().side_effects_disabled())
+	{
+		// rdft
+		if (m_maincpu->pc()==0x0203f06) m_maincpu->spin_until_interrupt(); // idle
 
-	/* rdftj? */
-	if (m_maincpu->pc()==0x0203f0a) m_maincpu->spin_until_interrupt(); // idle
+		// rdftj?
+		if (m_maincpu->pc()==0x0203f0a) m_maincpu->spin_until_interrupt(); // idle
 
-	/* rdftau */
-	if (m_maincpu->pc()==0x0203f16) m_maincpu->spin_until_interrupt(); // idle
+		// rdftau
+		if (m_maincpu->pc()==0x0203f16) m_maincpu->spin_until_interrupt(); // idle
 
-	/* rdftja? */
-	if (m_maincpu->pc()==0x0203f22) m_maincpu->spin_until_interrupt(); // idle
+		// rdftja?
+		if (m_maincpu->pc()==0x0203f22) m_maincpu->spin_until_interrupt(); // idle
 
-	/* rdfta, rdftadi, rdftam, rdftit */
-	if (m_maincpu->pc()==0x0203f46) m_maincpu->spin_until_interrupt(); // idle
+		// rdfta, rdftadi, rdftam, rdftit
+		if (m_maincpu->pc()==0x0203f46) m_maincpu->spin_until_interrupt(); // idle
 
-	/* rdftu */
-	if (m_maincpu->pc()==0x0203f3a) m_maincpu->spin_until_interrupt(); // idle
+		// rdftu
+		if (m_maincpu->pc()==0x0203f3a) m_maincpu->spin_until_interrupt(); // idle
 
-	/* rdftauge */
-	if (m_maincpu->pc()==0x0203f6e) m_maincpu->spin_until_interrupt(); // idle
+		// rdftauge
+		if (m_maincpu->pc()==0x0203f6e) m_maincpu->spin_until_interrupt(); // idle
 
-//  osd_printf_debug("%08x\n",m_maincpu->pc());
-
+		//osd_printf_debug("%08x\n",m_maincpu->pc());
+	}
 	return m_mainram[0x00298d0/4];
 }
 
 u32 seibuspi_state::rf2_speedup_r()
 {
-	/* rdft22kc */
-	if (m_maincpu->pc()==0x0203926) m_maincpu->spin_until_interrupt(); // idle
+	if (!machine().side_effects_disabled())
+	{
+		// rdft22kc
+		if (m_maincpu->pc()==0x0203926) m_maincpu->spin_until_interrupt(); // idle
 
-	/* rdft2, rdft2j */
-	if (m_maincpu->pc()==0x0204372) m_maincpu->spin_until_interrupt(); // idle
+		// rdft2, rdft2j
+		if (m_maincpu->pc()==0x0204372) m_maincpu->spin_until_interrupt(); // idle
 
-	/* rdft2us */
-	if (m_maincpu->pc()==0x020420e) m_maincpu->spin_until_interrupt(); // idle
+		// rdft2us
+		if (m_maincpu->pc()==0x020420e) m_maincpu->spin_until_interrupt(); // idle
 
-	/* rdft2a */
-	if (m_maincpu->pc()==0x0204366) m_maincpu->spin_until_interrupt(); // idle
+		// rdft2a
+		if (m_maincpu->pc()==0x0204366) m_maincpu->spin_until_interrupt(); // idle
 
-//  osd_printf_debug("%08x\n",m_maincpu->pc());
-
+		//osd_printf_debug("%08x\n",m_maincpu->pc());
+	}
 	return m_mainram[0x0282ac/4];
 }
 
 u32 seibuspi_state::rfjet_speedup_r()
 {
-	/* rfjet, rfjetu, rfjeta */
-	if (m_maincpu->pc()==0x0206082) m_maincpu->spin_until_interrupt(); // idle
-
-	/* rfjetus */
-	if (m_maincpu->pc()==0x0205b39)
+	if (!machine().side_effects_disabled())
 	{
-		u32 r;
-		m_maincpu->spin_until_interrupt(); // idle
-		// Hack to enter test mode
-		r = m_mainram[0x002894c/4] & (~0x400);
-		return r | (((ioport("SYSTEM")->read() ^ 0xff)<<8) & 0x400);
+		// rfjet, rfjetu, rfjeta
+		if (m_maincpu->pc()==0x0206082) m_maincpu->spin_until_interrupt(); // idle
+
+		// rfjetus
+		if (m_maincpu->pc()==0x0205b39)
+		{
+			u32 r;
+			m_maincpu->spin_until_interrupt(); // idle
+			// Hack to enter test mode
+			r = m_mainram[0x002894c/4] & (~0x400);
+			return r | (((ioport("SYSTEM")->read() ^ 0xff)<<8) & 0x400);
+		}
+
+		// rfjetj
+		if (m_maincpu->pc()==0x0205f2e) m_maincpu->spin_until_interrupt(); // idle
+
+		//osd_printf_debug("%08x\n",m_maincpu->pc());
 	}
-
-	/* rfjetj */
-	if (m_maincpu->pc()==0x0205f2e) m_maincpu->spin_until_interrupt(); // idle
-
-//  osd_printf_debug("%08x\n",m_maincpu->pc());
-
 	return m_mainram[0x002894c/4];
 }
 
@@ -2212,1167 +2253,1167 @@ u32 seibuspi_state::rfjet_speedup_r()
 #define ROM_LOAD24_WORD(name,offset,length,hash)        ROMX_LOAD(name, offset, length, hash, ROM_GROUPWORD | ROM_SKIP(1) | ROM_REVERSE)
 #define ROM_LOAD24_WORD_SWAP(name,offset,length,hash)   ROMX_LOAD(name, offset, length, hash, ROM_GROUPWORD | ROM_SKIP(1))
 
-/* SPI games */
+// SPI games
 
 ROM_START( senkyu )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("fb_1.211", 0x100000, 0x40000, CRC(20a3e5db) SHA1(f1109aeceac7993abc9093d09429718ffc292c77) )
 	ROM_LOAD32_BYTE("fb_2.212", 0x100001, 0x40000, CRC(38e90619) SHA1(451ab5f4a5935bb779f9c245c1c4358e80d93c15) )
 	ROM_LOAD32_BYTE("fb_3.210", 0x100002, 0x40000, CRC(226f0429) SHA1(69d0fe6671278d7fe215e455bb50abf631cdb484) )
 	ROM_LOAD32_BYTE("fb_4.29",  0x100003, 0x40000, CRC(b46d66b7) SHA1(1acd0fea9384e1488b44661e0c99b9672a3f9803) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("fb_6.413", 0x000000, 0x20000, CRC(b57115c9) SHA1(eb95f416f522032ca949bfb6348f1ff824101f2d) )
 	ROM_LOAD24_BYTE("fb_5.48",  0x000002, 0x10000, CRC(440a9ae3) SHA1(3f57e6da91f0dac2d816c873759f1e1d3259caf1) )
 
-	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("fb_bg-1d.415", 0x000000, 0x200000, CRC(eae7a1fc) SHA1(26d8a9f4e554848977ec1f6a8aad8751b558a8d4) )
 	ROM_LOAD24_BYTE("fb_bg-1p.410", 0x000002, 0x100000, CRC(b46e774e) SHA1(00b6c1d0b0ea37f4354acab543b270c0bf45896d) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("fb_obj-1.322", 0x000000, 0x400000, CRC(29f86f68) SHA1(1afe809ce00a25f8b27543e4188edc3e3e604951) )
 	ROM_LOAD("fb_obj-2.324", 0x400000, 0x400000, CRC(c9e3130b) SHA1(12b5d5363142e8efb3b7fc44289c0afffa5011c6) )
 	ROM_LOAD("fb_obj-3.323", 0x800000, 0x400000, CRC(f6c3bc49) SHA1(d0eb9c6aa3954d94e3a442a48e0fe6cc279f5513) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("fb_pcm-1.215",  0x000000, 0x080000, CRC(1d83891c) SHA1(09502437562275c14c0f3a0e62b19e91bedb4693) )
 	ROM_CONTINUE(                    0x400000, 0x080000 )
 	ROM_LOAD32_BYTE("fb_7.216",      0x800000, 0x080000, CRC(874d7b59) SHA1(0236753636c9a818780b23f5f506697b9f6d93c7) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region01.u1053", 0x000000, 0x100000, CRC(7ae7ab76) SHA1(a2b196f470bf64af94002fc4e2640fadad00418f) )
 ROM_END
 
 ROM_START( senkyua )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("1.bin", 0x100000, 0x40000, CRC(6102c3fb) SHA1(4a55b41d916768f9601513db973b82077bca47c5) )
 	ROM_LOAD32_BYTE("2.bin", 0x100001, 0x40000, CRC(d5b8ce46) SHA1(f6e4b8f51146179efb52ecb2b72fdeaee10b7282) )
 	ROM_LOAD32_BYTE("3.bin", 0x100002, 0x40000, CRC(e27ceccd) SHA1(3d6b8e97e89939c72d1a5a4a3856025b5f548645) )
 	ROM_LOAD32_BYTE("4.bin", 0x100003, 0x40000, CRC(7c6d4549) SHA1(efc6920a2e518afe849fb6fe191e7cd0bc483be5) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("fb_6.413", 0x000000, 0x20000, CRC(b57115c9) SHA1(eb95f416f522032ca949bfb6348f1ff824101f2d) )
 	ROM_LOAD24_BYTE("fb_5.48",  0x000002, 0x10000, CRC(440a9ae3) SHA1(3f57e6da91f0dac2d816c873759f1e1d3259caf1) )
 
-	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("fb_bg-1d.415", 0x000000, 0x200000, CRC(eae7a1fc) SHA1(26d8a9f4e554848977ec1f6a8aad8751b558a8d4) )
 	ROM_LOAD24_BYTE("fb_bg-1p.410", 0x000002, 0x100000, CRC(b46e774e) SHA1(00b6c1d0b0ea37f4354acab543b270c0bf45896d) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("fb_obj-1.322", 0x000000, 0x400000, CRC(29f86f68) SHA1(1afe809ce00a25f8b27543e4188edc3e3e604951) )
 	ROM_LOAD("fb_obj-2.324", 0x400000, 0x400000, CRC(c9e3130b) SHA1(12b5d5363142e8efb3b7fc44289c0afffa5011c6) )
 	ROM_LOAD("fb_obj-3.323", 0x800000, 0x400000, CRC(f6c3bc49) SHA1(d0eb9c6aa3954d94e3a442a48e0fe6cc279f5513) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("fb_pcm-1.215",  0x000000, 0x080000, CRC(1d83891c) SHA1(09502437562275c14c0f3a0e62b19e91bedb4693) )
 	ROM_CONTINUE(                    0x400000, 0x080000 )
 	ROM_LOAD32_BYTE("fb_7.216",      0x800000, 0x080000, CRC(874d7b59) SHA1(0236753636c9a818780b23f5f506697b9f6d93c7) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region01.u1053", 0x000000, 0x100000, CRC(7ae7ab76) SHA1(a2b196f470bf64af94002fc4e2640fadad00418f) )
 ROM_END
 
 ROM_START( batlball )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("1.211", 0x100000, 0x40000, CRC(d4e48f89) SHA1(10e43a9ff3f6f169de6352280a8a06e7f482271a) )
 	ROM_LOAD32_BYTE("2.212", 0x100001, 0x40000, CRC(3077720b) SHA1(b65c3d02ac75eb56e0c5dc1bf6bb6a4e445a41cf) )
 	ROM_LOAD32_BYTE("3.210", 0x100002, 0x40000, CRC(520d31e1) SHA1(998ae968113ab5b2891044187d93793903c13452) )
 	ROM_LOAD32_BYTE("4.029", 0x100003, 0x40000, CRC(22419b78) SHA1(67475a654d4ad94e5dfda88cbe2f9c1b5ba6d2cc) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("fb_6.413", 0x000000, 0x20000, CRC(b57115c9) SHA1(eb95f416f522032ca949bfb6348f1ff824101f2d) )
 	ROM_LOAD24_BYTE("fb_5.48",  0x000002, 0x10000, CRC(440a9ae3) SHA1(3f57e6da91f0dac2d816c873759f1e1d3259caf1) )
 
-	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("fb_bg-1d.415", 0x000000, 0x200000, CRC(eae7a1fc) SHA1(26d8a9f4e554848977ec1f6a8aad8751b558a8d4) )
 	ROM_LOAD24_BYTE("fb_bg-1p.410", 0x000002, 0x100000, CRC(b46e774e) SHA1(00b6c1d0b0ea37f4354acab543b270c0bf45896d) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("fb_obj-1.322", 0x000000, 0x400000, CRC(29f86f68) SHA1(1afe809ce00a25f8b27543e4188edc3e3e604951) )
 	ROM_LOAD("fb_obj-2.324", 0x400000, 0x400000, CRC(c9e3130b) SHA1(12b5d5363142e8efb3b7fc44289c0afffa5011c6) )
 	ROM_LOAD("fb_obj-3.323", 0x800000, 0x400000, CRC(f6c3bc49) SHA1(d0eb9c6aa3954d94e3a442a48e0fe6cc279f5513) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("fb_pcm-1.215",  0x000000, 0x080000, CRC(1d83891c) SHA1(09502437562275c14c0f3a0e62b19e91bedb4693) )
 	ROM_CONTINUE(                    0x400000, 0x080000 )
 	ROM_LOAD32_BYTE("fb_7.216",      0x800000, 0x080000, CRC(874d7b59) SHA1(0236753636c9a818780b23f5f506697b9f6d93c7) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region80.u1053", 0x000000, 0x100000, CRC(e2adaff5) SHA1(9297afaf78209724515d8f78de8cee7bc7cb796b) )
 ROM_END
 
 ROM_START( batlballo ) // Board has a low serial number 000014 and PCB date is 95.10.02
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("seibu_1a.211", 0x100000, 0x40000, CRC(90340e8c) SHA1(303d3c5ffc1a64e1e4aa614105119d9d7768f516) )
 	ROM_LOAD32_BYTE("seibu_2a.212", 0x100001, 0x40000, CRC(db655d3e) SHA1(bfd873e0d0daf3759778c76fe72fcf96e84250a4) )
 	ROM_LOAD32_BYTE("seibu_3a.210", 0x100002, 0x40000, CRC(659a54a2) SHA1(a6c024e42b104a6198829f0f75baaa294fe9de6c) )
 	ROM_LOAD32_BYTE("seibu_4a.029", 0x100003, 0x40000, CRC(51183421) SHA1(d97da1693e429cb7a061f08274070eb3e6966ec0) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("seibu_6.413", 0x000000, 0x20000, CRC(338556f9) SHA1(dfab6e1562dd9c373aa094a3791ecd4cd3c9b6f5) )
 	ROM_LOAD24_BYTE("seibu_5.48",  0x000002, 0x10000, CRC(6ccfb72e) SHA1(825b917ecd8495de23d55d2d2902d9d7c54ce4ed) )
 
-	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("fb_bg-1d.415", 0x000000, 0x200000, CRC(eae7a1fc) SHA1(26d8a9f4e554848977ec1f6a8aad8751b558a8d4) )
 	ROM_LOAD24_BYTE("fb_bg-1p.410", 0x000002, 0x100000, CRC(b46e774e) SHA1(00b6c1d0b0ea37f4354acab543b270c0bf45896d) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("fb_obj-1.322", 0x000000, 0x400000, CRC(29f86f68) SHA1(1afe809ce00a25f8b27543e4188edc3e3e604951) )
 	ROM_LOAD("fb_obj-2.324", 0x400000, 0x400000, CRC(c9e3130b) SHA1(12b5d5363142e8efb3b7fc44289c0afffa5011c6) )
 	ROM_LOAD("fb_obj-3.323", 0x800000, 0x400000, CRC(f6c3bc49) SHA1(d0eb9c6aa3954d94e3a442a48e0fe6cc279f5513) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("fb_pcm-1.215",  0x000000, 0x080000, CRC(1d83891c) SHA1(09502437562275c14c0f3a0e62b19e91bedb4693) )
 	ROM_CONTINUE(                    0x400000, 0x080000 )
 	ROM_LOAD32_BYTE("seibu_7.216",   0x800000, 0x080000, CRC(874d7b59) SHA1(0236753636c9a818780b23f5f506697b9f6d93c7) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region80.u1053", 0x000000, 0x100000, CRC(e2adaff5) SHA1(9297afaf78209724515d8f78de8cee7bc7cb796b) )
 ROM_END
 
 ROM_START( batlballa )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("senkyua1.bin", 0x100000, 0x40000, CRC(ec3c4d4d) SHA1(6c57b8fbb77ce1615850842d06c054e88e240eef) )
 	ROM_LOAD32_BYTE("2.212",        0x100001, 0x40000, CRC(3077720b) SHA1(b65c3d02ac75eb56e0c5dc1bf6bb6a4e445a41cf) )
 	ROM_LOAD32_BYTE("3.210",        0x100002, 0x40000, CRC(520d31e1) SHA1(998ae968113ab5b2891044187d93793903c13452) )
 	ROM_LOAD32_BYTE("4.029",        0x100003, 0x40000, CRC(22419b78) SHA1(67475a654d4ad94e5dfda88cbe2f9c1b5ba6d2cc) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("fb_6.413", 0x000000, 0x20000, CRC(b57115c9) SHA1(eb95f416f522032ca949bfb6348f1ff824101f2d) )
 	ROM_LOAD24_BYTE("fb_5.48",  0x000002, 0x10000, CRC(440a9ae3) SHA1(3f57e6da91f0dac2d816c873759f1e1d3259caf1) )
 
-	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("fb_bg-1d.415", 0x000000, 0x200000, CRC(eae7a1fc) SHA1(26d8a9f4e554848977ec1f6a8aad8751b558a8d4) )
 	ROM_LOAD24_BYTE("fb_bg-1p.410", 0x000002, 0x100000, CRC(b46e774e) SHA1(00b6c1d0b0ea37f4354acab543b270c0bf45896d) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("fb_obj-1.322", 0x000000, 0x400000, CRC(29f86f68) SHA1(1afe809ce00a25f8b27543e4188edc3e3e604951) )
 	ROM_LOAD("fb_obj-2.324", 0x400000, 0x400000, CRC(c9e3130b) SHA1(12b5d5363142e8efb3b7fc44289c0afffa5011c6) )
 	ROM_LOAD("fb_obj-3.323", 0x800000, 0x400000, CRC(f6c3bc49) SHA1(d0eb9c6aa3954d94e3a442a48e0fe6cc279f5513) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("fb_pcm-1.215",  0x000000, 0x080000, CRC(1d83891c) SHA1(09502437562275c14c0f3a0e62b19e91bedb4693) )
 	ROM_CONTINUE(                    0x400000, 0x080000 )
 	ROM_LOAD32_BYTE("fb_7.216",      0x800000, 0x080000, CRC(874d7b59) SHA1(0236753636c9a818780b23f5f506697b9f6d93c7) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region22.u1053", 0x000000, 0x100000, CRC(5fee8413) SHA1(6d6a62fa01293b4ba4b349a39820d024add6ea22) )
 ROM_END
 
-ROM_START( batlballe ) /* Early version, PCB serial number of 19, hand written labels dated 10/16 (Oct 16, 1995) */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( batlballe ) // Early version, PCB serial number of 19, hand written labels dated 10/16 (Oct 16, 1995)
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("1_10-16", 0x100000, 0x40000, CRC(6b1baa07) SHA1(29b8f4016e9bffdcdb6ec405cd443ca0a80de5d5) )
 	ROM_LOAD32_BYTE("2_10-16", 0x100001, 0x40000, CRC(3c890639) SHA1(968c4a5efc5ebbe4e4cc81f834c286c02596c24e) )
 	ROM_LOAD32_BYTE("3_10-16", 0x100002, 0x40000, CRC(8c30180e) SHA1(47b99b04e2e74f1ee5095aed3f45aba66cd3da3f) )
 	ROM_LOAD32_BYTE("4_10-16", 0x100003, 0x40000, CRC(048c7aaa) SHA1(5eca2cdf4e6f077988509c3c42c86408b21ffbf1) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("fb_6.413", 0x000000, 0x20000, CRC(b57115c9) SHA1(eb95f416f522032ca949bfb6348f1ff824101f2d) )
 	ROM_LOAD24_BYTE("fb_5.48",  0x000002, 0x10000, CRC(440a9ae3) SHA1(3f57e6da91f0dac2d816c873759f1e1d3259caf1) )
 
-	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("fb_bg-1d.415", 0x000000, 0x200000, CRC(eae7a1fc) SHA1(26d8a9f4e554848977ec1f6a8aad8751b558a8d4) )
 	ROM_LOAD24_BYTE("fb_bg-1p.410", 0x000002, 0x100000, CRC(b46e774e) SHA1(00b6c1d0b0ea37f4354acab543b270c0bf45896d) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("fb_obj-1.322", 0x000000, 0x400000, CRC(29f86f68) SHA1(1afe809ce00a25f8b27543e4188edc3e3e604951) )
 	ROM_LOAD("fb_obj-2.324", 0x400000, 0x400000, CRC(c9e3130b) SHA1(12b5d5363142e8efb3b7fc44289c0afffa5011c6) )
 	ROM_LOAD("fb_obj-3.323", 0x800000, 0x400000, CRC(f6c3bc49) SHA1(d0eb9c6aa3954d94e3a442a48e0fe6cc279f5513) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("fb_pcm-1.215",  0x000000, 0x080000, CRC(1d83891c) SHA1(09502437562275c14c0f3a0e62b19e91bedb4693) )
 	ROM_CONTINUE(                    0x400000, 0x080000 )
 	ROM_LOAD32_BYTE("fb_7.216",      0x800000, 0x080000, CRC(874d7b59) SHA1(0236753636c9a818780b23f5f506697b9f6d93c7) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region22.u1053", 0x000000, 0x100000, CRC(5fee8413) SHA1(6d6a62fa01293b4ba4b349a39820d024add6ea22) )
 ROM_END
 
 ROM_START( batlballu )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("sen1.bin", 0x100000, 0x40000, CRC(13849bf0) SHA1(ffa829a8b8a05a8fbaf883a30759f2ad8071a85b) )
 	ROM_LOAD32_BYTE("sen2.bin", 0x100001, 0x40000, CRC(2ae5f7e2) SHA1(cef9ddea8b1d21f20a48c2523c9420c1800720c8) )
 	ROM_LOAD32_BYTE("sen3.bin", 0x100002, 0x40000, CRC(98e6f19f) SHA1(433f8463e63bba32730d3c098354f8c95257df3f) )
 	ROM_LOAD32_BYTE("sen4.bin", 0x100003, 0x40000, CRC(1343ec56) SHA1(8ecc8d7b425ff6512ffa969a7f26423fa50ad258) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("fb_6.413", 0x000000, 0x20000, CRC(b57115c9) SHA1(eb95f416f522032ca949bfb6348f1ff824101f2d) )
 	ROM_LOAD24_BYTE("fb_5.48",  0x000002, 0x10000, CRC(440a9ae3) SHA1(3f57e6da91f0dac2d816c873759f1e1d3259caf1) )
 
-	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("fb_bg-1d.415", 0x000000, 0x200000, CRC(eae7a1fc) SHA1(26d8a9f4e554848977ec1f6a8aad8751b558a8d4) )
 	ROM_LOAD24_BYTE("fb_bg-1p.410", 0x000002, 0x100000, CRC(b46e774e) SHA1(00b6c1d0b0ea37f4354acab543b270c0bf45896d) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("fb_obj-1.322", 0x000000, 0x400000, CRC(29f86f68) SHA1(1afe809ce00a25f8b27543e4188edc3e3e604951) )
 	ROM_LOAD("fb_obj-2.324", 0x400000, 0x400000, CRC(c9e3130b) SHA1(12b5d5363142e8efb3b7fc44289c0afffa5011c6) )
 	ROM_LOAD("fb_obj-3.323", 0x800000, 0x400000, CRC(f6c3bc49) SHA1(d0eb9c6aa3954d94e3a442a48e0fe6cc279f5513) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("fb_pcm-1.215",  0x000000, 0x080000, CRC(1d83891c) SHA1(09502437562275c14c0f3a0e62b19e91bedb4693) )
 	ROM_CONTINUE(                    0x400000, 0x080000 )
 	ROM_LOAD32_BYTE("fb_7.216",      0x800000, 0x080000, CRC(874d7b59) SHA1(0236753636c9a818780b23f5f506697b9f6d93c7) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region10.u1053", 0x000000, 0x100000, CRC(4319d998) SHA1(a064ce647453a9b3bccf7f1d6d0d52b5a72e09dd) )
 ROM_END
 
-ROM_START( batlballpt ) /* SXX2C ROM SUB cart - only U0211 labeled with the date 171195 */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( batlballpt ) // SXX2C ROM SUB cart - only U0211 labeled with the date 171195
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("senkyu_prog0_171195.u0211", 0x100000, 0x40000, CRC(dcc227b6) SHA1(10d72ebdd218887521226c82a61c2cdebcd9af99) )
 	ROM_LOAD32_BYTE("2.u0212", 0x100001, 0x40000, CRC(03ab203f) SHA1(de5771883624440a9842b109b764b52811facfad) )
 	ROM_LOAD32_BYTE("3.u0210", 0x100002, 0x40000, CRC(9eb9c8b4) SHA1(fc4f8feac3840776f842d03d86b37a669bba4f12) )
 	ROM_LOAD32_BYTE("4.u029",  0x100003, 0x40000, CRC(c37ae2a5) SHA1(ee33f7baf852ef36b4f7f71a08d82acf1e7460b8) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("fb_6.413", 0x000000, 0x20000, CRC(b57115c9) SHA1(eb95f416f522032ca949bfb6348f1ff824101f2d) )
 	ROM_LOAD24_BYTE("fb_5.48",  0x000002, 0x10000, CRC(440a9ae3) SHA1(3f57e6da91f0dac2d816c873759f1e1d3259caf1) )
 
-	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x300000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("fb_bg-1d.415", 0x000000, 0x200000, CRC(eae7a1fc) SHA1(26d8a9f4e554848977ec1f6a8aad8751b558a8d4) )
 	ROM_LOAD24_BYTE("fb_bg-1p.410", 0x000002, 0x100000, CRC(b46e774e) SHA1(00b6c1d0b0ea37f4354acab543b270c0bf45896d) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("fb_obj-1.322", 0x000000, 0x400000, CRC(29f86f68) SHA1(1afe809ce00a25f8b27543e4188edc3e3e604951) )
 	ROM_LOAD("fb_obj-2.324", 0x400000, 0x400000, CRC(c9e3130b) SHA1(12b5d5363142e8efb3b7fc44289c0afffa5011c6) )
 	ROM_LOAD("fb_obj-3.323", 0x800000, 0x400000, CRC(f6c3bc49) SHA1(d0eb9c6aa3954d94e3a442a48e0fe6cc279f5513) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("fb_pcm-1.215",  0x000000, 0x080000, CRC(1d83891c) SHA1(09502437562275c14c0f3a0e62b19e91bedb4693) )
 	ROM_CONTINUE(                    0x400000, 0x080000 )
 	ROM_LOAD32_BYTE("fb_7.216",      0x800000, 0x080000, CRC(874d7b59) SHA1(0236753636c9a818780b23f5f506697b9f6d93c7) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region96.u1053", 0x000000, 0x100000, CRC(a0ebae75) SHA1(31f7955a529a4e2492b530e54878ed7a13f49c94) )
 ROM_END
 
 
 ROM_START( ejanhs )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("ejan3_1.211", 0x100000, 0x40000, CRC(e626d3d2) SHA1(d23cb5e218a85e09de98fa966afbfd43090b396e) )
 	ROM_LOAD32_BYTE("ejan3_2.212", 0x100001, 0x40000, CRC(83c39da2) SHA1(9526ffb5d5becccf0aa2e338ab4a3c873d575e6f) )
 	ROM_LOAD32_BYTE("ejan3_3.210", 0x100002, 0x40000, CRC(46897b7d) SHA1(a22e0467c016e72bf99df2c1e6ecc792b2151b15) )
 	ROM_LOAD32_BYTE("ejan3_4.29",  0x100003, 0x40000, CRC(b3187a2b) SHA1(7fc11ed5ceb2e45f784e75307fef8b850a981a2e) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("ejan3_6.413", 0x000000, 0x20000, CRC(837e012c) SHA1(815452083b65885d6e66dfc058ceec81bb3e6678) )
 	ROM_LOAD24_BYTE("ejan3_5.48",  0x000002, 0x10000, CRC(d62db7bf) SHA1(c88f1bb6106c59179b914962ed8cdd4095fd9ce8) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("ej3_bg1d.415", 0x000000, 0x200000, CRC(bcacabe0) SHA1(b73581cf923196326b5b0b99e6aedb915bab0880) )
 	ROM_LOAD24_BYTE("ej3_bg1p.410", 0x000002, 0x100000, CRC(1fd0eb5e) SHA1(ca64c8020b246128232f4f6c0a0a2dd9cd3efeae) )
 	ROM_LOAD24_WORD("ej3_bg2d.416", 0x300000, 0x100000, CRC(ea2acd69) SHA1(b796e9e4b7342bf452f5ffdbce32cfefc603ba0f) )
 	ROM_LOAD24_BYTE("ej3_bg2p.49",  0x300002, 0x080000, CRC(a4a9cb0f) SHA1(da177d13bb95bf6b987d3ca13bcdc86570807b2c) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("ej3_obj1.322", 0x000000, 0x400000, CRC(852f180e) SHA1(d4845dace45c05a68f3b38ccb301c5bf5dce4174) )
 	ROM_LOAD("ej3_obj2.324", 0x400000, 0x400000, CRC(1116ad08) SHA1(d5c81383b3f9ede7dd03e6be35487b40740b1f8f) )
 	ROM_LOAD("ej3_obj3.323", 0x800000, 0x400000, CRC(ccfe02b6) SHA1(368bc8efe9d6677ba3d0cfc0f450a4bda32988be) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("ej3_pcm1.215",  0x000000, 0x080000, CRC(a92a3a82) SHA1(b86c27c5a2831ddd2a1c2b071018a99afec14018) )
 	ROM_CONTINUE(                    0x400000, 0x080000 )
 	ROM_LOAD32_BYTE("ejan3_7.216",   0x800000, 0x080000, CRC(c6fc6bcf) SHA1(d4d8c06d295f8eacfa10c21dbab5858f936121f3) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region01.u1053", 0x000000, 0x100000, CRC(7ae7ab76) SHA1(a2b196f470bf64af94002fc4e2640fadad00418f) )
 ROM_END
 
 
 ROM_START( viprp1 )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("seibu1.211", 0x000000, 0x80000, CRC(e5caf4ff) SHA1(7c87a4e8e8dacfb7cc0be8f778352bce2801e59b) )
 	ROM_LOAD32_BYTE("seibu2.212", 0x000001, 0x80000, CRC(688a998e) SHA1(0c48374b6800cd00e3ee96c0fb12119a680b091d) )
 	ROM_LOAD32_BYTE("seibu3.210", 0x000002, 0x80000, CRC(990fa76a) SHA1(7619a631d6f83b3677eb47f984aff684e9518d6d) )
 	ROM_LOAD32_BYTE("seibu4.29",  0x000003, 0x80000, CRC(13e3e343) SHA1(aac0c7450059847f53b5081e4abf26303a50f999) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("seibu5.u0413", 0x000000, 0x20000, CRC(5ece677c) SHA1(b782cf3296f866f79fafa69ff719211c9d4026df) )
 	ROM_LOAD24_BYTE("seibu6.u048",  0x000002, 0x10000, CRC(44844ef8) SHA1(bcbe24d2ffb64f9165ba4ab7de27f44b99b5ff5a) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("v_pcm.215",  0x000000, 0x080000, CRC(e3111b60) SHA1(f7a7747f29c392876e43efcb4e6c0741454082f2) )
 	ROM_CONTINUE(                 0x400000, 0x080000 )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_regionbe.u1053", 0x000000, 0x100000, CRC(a4c181d0) SHA1(0aeea4cac4030f60ee77d62deca6b67c318c0866) )
 ROM_END
 
 ROM_START( viprp1k )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("seibu1.211", 0x000000, 0x80000, CRC(5495c930) SHA1(056237965aefa4c0ea7782e0ee5ba1b58a045d7a) ) // sldh
 	ROM_LOAD32_BYTE("seibu2.212", 0x000001, 0x80000, CRC(e0ad22ae) SHA1(1911d17f0b462a9bada9efee85e531f2445e4ac6) ) // sldh
 	ROM_LOAD32_BYTE("seibu3.210", 0x000002, 0x80000, CRC(db7bcb90) SHA1(45f0a44e24d7b4b996d833e579f405bcf7584563) ) // sldh
 	ROM_LOAD32_BYTE("seibu4.29",  0x000003, 0x80000, CRC(c6188bf9) SHA1(746a205c428a080c36d0daf1d4f6b2b0f8efb977) ) // sldh
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("seibu5.u0413", 0x000000, 0x20000, CRC(1a35f2d8) SHA1(cd9b140f144a8c72756e18913eaef121963be341) ) // sldh
 	ROM_LOAD24_BYTE("seibu6.u048",  0x000002, 0x10000, CRC(e88bf049) SHA1(62f35840dc90b505118ed81ac0d75397a689783b) ) // sldh
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("v_pcm.215",  0x000000, 0x080000, CRC(e3111b60) SHA1(f7a7747f29c392876e43efcb4e6c0741454082f2) )
 	ROM_CONTINUE(                 0x400000, 0x080000 )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region24.u1053", 0x000000, 0x100000, CRC(72a33dc4) SHA1(65a52f576ca4d240418fedd9a4922edcd6c0c8d1) )
 ROM_END
 
 ROM_START( viprp1u )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
-	ROM_LOAD32_BYTE("seibu1.u0211", 0x000000, 0x80000, CRC(3f412b80) SHA1(ccffce101d20971278c0f6c5f4efcf3ab687aba6) ) /* New version, "=U.S.A=" seems part of title */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
+	ROM_LOAD32_BYTE("seibu1.u0211", 0x000000, 0x80000, CRC(3f412b80) SHA1(ccffce101d20971278c0f6c5f4efcf3ab687aba6) ) // New version, "=U.S.A=" seems part of title
 	ROM_LOAD32_BYTE("seibu2.u0212", 0x000001, 0x80000, CRC(2e6c2376) SHA1(b6e660dc7c89cf565c6e055683e84ffcf8179709) )
 	ROM_LOAD32_BYTE("seibu3.u0210", 0x000002, 0x80000, CRC(c38f7b4e) SHA1(d5bf2c7f2f6c812c65005facfd40ac6d3b61f29d) )
 	ROM_LOAD32_BYTE("seibu4.u029",  0x000003, 0x80000, CRC(523cbef3) SHA1(5d15261b8fb108e0ba4dfd14d259984ef81ce877) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("seibu5.u0413", 0x000000, 0x20000, CRC(5ece677c) SHA1(b782cf3296f866f79fafa69ff719211c9d4026df) )
 	ROM_LOAD24_BYTE("seibu6.u048",  0x000002, 0x10000, CRC(44844ef8) SHA1(bcbe24d2ffb64f9165ba4ab7de27f44b99b5ff5a) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("v_pcm.215",  0x000000, 0x080000, CRC(e3111b60) SHA1(f7a7747f29c392876e43efcb4e6c0741454082f2) )
 	ROM_CONTINUE(                 0x400000, 0x080000 )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region10.u1053", 0x000000, 0x100000, CRC(4319d998) SHA1(a064ce647453a9b3bccf7f1d6d0d52b5a72e09dd) )
 ROM_END
 
 ROM_START( viprp1ua )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
-	ROM_LOAD32_BYTE("seibus_1", 0x000000, 0x80000, CRC(882c299c) SHA1(36309b99764c684bd17eb512e661bafd3f3298e2) ) /* New version, "=U.S.A=" seems part of title */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
+	ROM_LOAD32_BYTE("seibus_1", 0x000000, 0x80000, CRC(882c299c) SHA1(36309b99764c684bd17eb512e661bafd3f3298e2) ) // New version, "=U.S.A=" seems part of title
 	ROM_LOAD32_BYTE("seibus_2", 0x000001, 0x80000, CRC(6ce586e9) SHA1(511731996638666cbe81a1d97affce855e255bf7) )
 	ROM_LOAD32_BYTE("seibus_3", 0x000002, 0x80000, CRC(f9dd9128) SHA1(ff7460699424de9e9d953343c42e0ef0fa1f0e30) )
 	ROM_LOAD32_BYTE("seibus_4", 0x000003, 0x80000, CRC(cb06440c) SHA1(c73647fb72c1579f05298fd884d8aeb3765bfff4) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("seibu5.u0413", 0x000000, 0x20000, CRC(5ece677c) SHA1(b782cf3296f866f79fafa69ff719211c9d4026df) )
 	ROM_LOAD24_BYTE("seibu6.u048",  0x000002, 0x10000, CRC(44844ef8) SHA1(bcbe24d2ffb64f9165ba4ab7de27f44b99b5ff5a) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("v_pcm.215",  0x000000, 0x080000, CRC(e3111b60) SHA1(f7a7747f29c392876e43efcb4e6c0741454082f2) )
 	ROM_CONTINUE(                 0x400000, 0x080000 )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region10.u1053", 0x000000, 0x100000, CRC(4319d998) SHA1(a064ce647453a9b3bccf7f1d6d0d52b5a72e09dd) )
 ROM_END
 
 ROM_START( viprp1j )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("v_1-n.211", 0x000000, 0x80000, CRC(55f10b72) SHA1(2a1ebaa969f346bf3659ed8b0f469dce9eaf3b4b) )
 	ROM_LOAD32_BYTE("v_2-n.212", 0x000001, 0x80000, CRC(0f888283) SHA1(7e5ac81279b9c7a06f07cb8ae76938cdd5c9beee) )
 	ROM_LOAD32_BYTE("v_3-n.210", 0x000002, 0x80000, CRC(842434ac) SHA1(982d219c1d329122789c552208db2f4aaa4af7e4) )
 	ROM_LOAD32_BYTE("v_4-n.29",  0x000003, 0x80000, CRC(a3948824) SHA1(fe076951427126c8b7fe81be84ecf0699597225b) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("seibu5.u0413", 0x000000, 0x20000, CRC(5ece677c) SHA1(b782cf3296f866f79fafa69ff719211c9d4026df) )
 	ROM_LOAD24_BYTE("seibu6.u048",  0x000002, 0x10000, CRC(44844ef8) SHA1(bcbe24d2ffb64f9165ba4ab7de27f44b99b5ff5a) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("v_pcm.215",  0x000000, 0x080000, CRC(e3111b60) SHA1(f7a7747f29c392876e43efcb4e6c0741454082f2) )
 	ROM_CONTINUE(                 0x400000, 0x080000 )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region01.u1053", 0x000000, 0x100000, CRC(7ae7ab76) SHA1(a2b196f470bf64af94002fc4e2640fadad00418f) )
 ROM_END
 
 ROM_START( viprp1s )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("viper_prg0.bin", 0x000000, 0x80000, CRC(ed9980b8) SHA1(bc324e9121ee1e55237bd91681f163ec7790de4c) )
 	ROM_LOAD32_BYTE("viper_prg1.bin", 0x000001, 0x80000, CRC(9d4d3486) SHA1(ded6fa32b973046e50c40c40c446590b5f6d0b76) )
 	ROM_LOAD32_BYTE("viper_prg2.bin", 0x000002, 0x80000, CRC(d7ea460b) SHA1(aed10adacd073f7d2b35f12ba4b7876e5c99d142) )
 	ROM_LOAD32_BYTE("viper_prg3.bin", 0x000003, 0x80000, CRC(ca6df094) SHA1(921eec141ce2d449047172fa9cdf39d459b5cc7b) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("seibu5.u0413", 0x000000, 0x20000, CRC(5ece677c) SHA1(b782cf3296f866f79fafa69ff719211c9d4026df) )
 	ROM_LOAD24_BYTE("seibu6.u048",  0x000002, 0x10000, CRC(44844ef8) SHA1(bcbe24d2ffb64f9165ba4ab7de27f44b99b5ff5a) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("v_pcm.215",  0x000000, 0x080000, CRC(e3111b60) SHA1(f7a7747f29c392876e43efcb4e6c0741454082f2) )
 	ROM_CONTINUE(                 0x400000, 0x080000 )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region9c.u1053", 0x000000, 0x100000, CRC(d73d640c) SHA1(61a99af2a153de9d53e28872a2493e2ba797a325) )
 ROM_END
 
 ROM_START( viprp1h )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
-	ROM_LOAD32_BYTE("viper_prg0_010995.u0211", 0x000000, 0x80000, CRC(e42fcc93) SHA1(5b2848a1da0e5d37e04ac646e67bbb84678c0292) ) /* same code as viprp1s, different region byte value */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
+	ROM_LOAD32_BYTE("viper_prg0_010995.u0211", 0x000000, 0x80000, CRC(e42fcc93) SHA1(5b2848a1da0e5d37e04ac646e67bbb84678c0292) ) // same code as viprp1s, different region byte value
 	ROM_LOAD32_BYTE("viper_prg1_010995.u0212", 0x000001, 0x80000, CRC(9d4d3486) SHA1(ded6fa32b973046e50c40c40c446590b5f6d0b76) )
 	ROM_LOAD32_BYTE("viper_prg2_010995.u0210", 0x000002, 0x80000, CRC(d7ea460b) SHA1(aed10adacd073f7d2b35f12ba4b7876e5c99d142) )
 	ROM_LOAD32_BYTE("viper_prg3_010995.u029",  0x000003, 0x80000, CRC(ca6df094) SHA1(921eec141ce2d449047172fa9cdf39d459b5cc7b) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("viper_fix_010995.u0413", 0x000000, 0x20000, CRC(5ece677c) SHA1(b782cf3296f866f79fafa69ff719211c9d4026df) )
 	ROM_LOAD24_BYTE("viper_fixp_010995.u048", 0x000002, 0x10000, CRC(44844ef8) SHA1(bcbe24d2ffb64f9165ba4ab7de27f44b99b5ff5a) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("v_pcm.215",  0x000000, 0x080000, CRC(e3111b60) SHA1(f7a7747f29c392876e43efcb4e6c0741454082f2) )
 	ROM_CONTINUE(                 0x400000, 0x080000 )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region90.u1053", 0x000000, 0x100000, CRC(8da617a2) SHA1(29c6ee05ed1c9a428a89d625b72692296c38424b) )
 ROM_END
 
 ROM_START( viprp1t )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
-	ROM_LOAD32_BYTE("viper_prg0_010995.u0211", 0x000000, 0x80000, CRC(f998dcf7) SHA1(c2dc876e4dc51062caf3d0df7c3c9cc9a5201760) ) /* same code as viprp1s and viprp1h, different region byte value */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
+	ROM_LOAD32_BYTE("viper_prg0_010995.u0211", 0x000000, 0x80000, CRC(f998dcf7) SHA1(c2dc876e4dc51062caf3d0df7c3c9cc9a5201760) ) // same code as viprp1s and viprp1h, different region byte value
 	ROM_LOAD32_BYTE("viper_prg1_010995.u0212", 0x000001, 0x80000, CRC(9d4d3486) SHA1(ded6fa32b973046e50c40c40c446590b5f6d0b76) )
 	ROM_LOAD32_BYTE("viper_prg2_010995.u0210", 0x000002, 0x80000, CRC(d7ea460b) SHA1(aed10adacd073f7d2b35f12ba4b7876e5c99d142) )
 	ROM_LOAD32_BYTE("viper_prg3_010995.u029",  0x000003, 0x80000, CRC(ca6df094) SHA1(921eec141ce2d449047172fa9cdf39d459b5cc7b) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("viper_fix_010995.u0413", 0x000000, 0x20000, CRC(5ece677c) SHA1(b782cf3296f866f79fafa69ff719211c9d4026df) )
 	ROM_LOAD24_BYTE("viper_fixp_010995.u048", 0x000002, 0x10000, CRC(44844ef8) SHA1(bcbe24d2ffb64f9165ba4ab7de27f44b99b5ff5a) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("v_pcm.215",  0x000000, 0x080000, CRC(e3111b60) SHA1(f7a7747f29c392876e43efcb4e6c0741454082f2) )
 	ROM_CONTINUE(                 0x400000, 0x080000 )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region80.u1053", 0x000000, 0x100000, CRC(e2adaff5) SHA1(9297afaf78209724515d8f78de8cee7bc7cb796b) )
 ROM_END
 
-ROM_START( viprp1pt ) /* SXX2C ROM SUB cart */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
-	ROM_LOAD32_BYTE("viper_prg0_010995.u0211", 0x000000, 0x80000, CRC(0d4c69a6) SHA1(d46706419c280838050a44cc27d6e469c021f295) ) /* same code as viprp1s, viprp1h and viprp1t , different region byte value */
+ROM_START( viprp1pt ) // SXX2C ROM SUB cart
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
+	ROM_LOAD32_BYTE("viper_prg0_010995.u0211", 0x000000, 0x80000, CRC(0d4c69a6) SHA1(d46706419c280838050a44cc27d6e469c021f295) ) // same code as viprp1s, viprp1h and viprp1t , different region byte value
 	ROM_LOAD32_BYTE("viper_prg1_010995.u0212", 0x000001, 0x80000, CRC(9d4d3486) SHA1(ded6fa32b973046e50c40c40c446590b5f6d0b76) )
 	ROM_LOAD32_BYTE("viper_prg2_010995.u0210", 0x000002, 0x80000, CRC(d7ea460b) SHA1(aed10adacd073f7d2b35f12ba4b7876e5c99d142) )
 	ROM_LOAD32_BYTE("viper_prg3_010995.u029",  0x000003, 0x80000, CRC(ca6df094) SHA1(921eec141ce2d449047172fa9cdf39d459b5cc7b) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("viper_fix_010995.u0413", 0x000000, 0x20000, CRC(5ece677c) SHA1(b782cf3296f866f79fafa69ff719211c9d4026df) )
 	ROM_LOAD24_BYTE("viper_fixp_010995.u048", 0x000002, 0x10000, CRC(44844ef8) SHA1(bcbe24d2ffb64f9165ba4ab7de27f44b99b5ff5a) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("v_pcm.215",  0x000000, 0x080000, CRC(e3111b60) SHA1(f7a7747f29c392876e43efcb4e6c0741454082f2) )
 	ROM_CONTINUE(                 0x400000, 0x080000 )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region96.u1053", 0x000000, 0x100000, CRC(a0ebae75) SHA1(31f7955a529a4e2492b530e54878ed7a13f49c94) )
 ROM_END
 
 ROM_START( viprp1hk )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
-	ROM_LOAD32_BYTE("seibu_1", 0x000000, 0x80000, CRC(283ba7b7) SHA1(28122e04b72f1163c69f3f845f6a493fdb6ed652) ) /* Old Version, "=HONG KONG=" seems part of title */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
+	ROM_LOAD32_BYTE("seibu_1", 0x000000, 0x80000, CRC(283ba7b7) SHA1(28122e04b72f1163c69f3f845f6a493fdb6ed652) ) // Old Version, "=HONG KONG=" seems part of title
 	ROM_LOAD32_BYTE("seibu_2", 0x000001, 0x80000, CRC(2c4db249) SHA1(a6372c9a3cde5f262ec5ef446945f6d3ad506e88) )
 	ROM_LOAD32_BYTE("seibu_3", 0x000002, 0x80000, CRC(91989503) SHA1(8c215fac200cc693396dbd57e0939e7efe883342) )
 	ROM_LOAD32_BYTE("seibu_4", 0x000003, 0x80000, CRC(12c9582d) SHA1(a79e26514e5ab8703a7a8c3ac39b359cfa4117c1) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
-	ROM_LOAD24_WORD("seibu_5", 0x000000, 0x20000, CRC(80920fed) SHA1(b35ed080925f6d0a0b6d2d1ab4fa919f625b1e6a) ) /* Different from both "new" & "old" versions */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
+	ROM_LOAD24_WORD("seibu_5", 0x000000, 0x20000, CRC(80920fed) SHA1(b35ed080925f6d0a0b6d2d1ab4fa919f625b1e6a) ) // Different from both "new" & "old" versions
 	ROM_LOAD24_BYTE("seibu_6", 0x000002, 0x10000, CRC(e71a8722) SHA1(3e0133fe1f85058ca6d9ac59d731f342c6b50e92) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("v_pcm.215",  0x000000, 0x080000, CRC(e3111b60) SHA1(f7a7747f29c392876e43efcb4e6c0741454082f2) )
 	ROM_CONTINUE(                 0x400000, 0x080000 )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region22.u1053", 0x000000, 0x100000, CRC(5fee8413) SHA1(6d6a62fa01293b4ba4b349a39820d024add6ea22) )
 ROM_END
 
 ROM_START( viprp1oj )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("v_1-o.211", 0x000000, 0x80000, CRC(4430be64) SHA1(96501a490042c289060d8510f6f79fbf64f79c1a) )
 	ROM_LOAD32_BYTE("v_2-o.212", 0x000001, 0x80000, CRC(ffbd88f7) SHA1(cd7f291117dd18bd80fb1130eb87936ff7517ee3) )
 	ROM_LOAD32_BYTE("v_3-o.210", 0x000002, 0x80000, CRC(6146db39) SHA1(04e68bfff320a3ffcb47686fa012a038538adc1a) )
 	ROM_LOAD32_BYTE("v_4-o.29",  0x000003, 0x80000, CRC(dc8dd2b6) SHA1(20970706240c38c54084b4ae24b7ad23b31aa3de) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("v_5-o.413", 0x000000, 0x20000, CRC(6d863acc) SHA1(3e3e14f51b9394b24d7cbf562f1cfffc9ec2216d) )
 	ROM_LOAD24_BYTE("v_6-o.48",  0x000002, 0x10000, CRC(fe7cb8f7) SHA1(55c7ab977c3666c8770deb62718d535673ffd4f8) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("v_pcm.215",  0x000000, 0x080000, CRC(e3111b60) SHA1(f7a7747f29c392876e43efcb4e6c0741454082f2) )
 	ROM_CONTINUE(                 0x400000, 0x080000 )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region01.u1053", 0x000000, 0x100000, CRC(7ae7ab76) SHA1(a2b196f470bf64af94002fc4e2640fadad00418f) )
 ROM_END
 
 ROM_START( viprp1ot )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("ov1.bin", 0x000000, 0x80000, CRC(cbad0e28) SHA1(fbc9b3b243ae0d556f41e8bef5f09489bb9e302b) )
 	ROM_LOAD32_BYTE("ov2.bin", 0x000001, 0x80000, CRC(0e2bbcb5) SHA1(5e53d60357fb0f9efa441261fac79e153eb35f3d) )
 	ROM_LOAD32_BYTE("ov3.bin", 0x000002, 0x80000, CRC(0e86686b) SHA1(0af207ea77ef378364d80d20ecbfba2f043f2405) )
 	ROM_LOAD32_BYTE("ov4.bin", 0x000003, 0x80000, CRC(9d7dd325) SHA1(550a8b5ed60e7ac50c40ec3eaa2cd6462be4a619) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("v_5-o.413", 0x000000, 0x20000, CRC(6d863acc) SHA1(3e3e14f51b9394b24d7cbf562f1cfffc9ec2216d) )
 	ROM_LOAD24_BYTE("v_6-o.48",  0x000002, 0x10000, CRC(fe7cb8f7) SHA1(55c7ab977c3666c8770deb62718d535673ffd4f8) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("v_bg-11.415",  0x000000, 0x200000, CRC(6fc96736) SHA1(12df47d8af2c1febc1bce5bcf3218766447885bd) )
 	ROM_LOAD24_BYTE("v_bg-12.415",  0x000002, 0x100000, CRC(d3c7281c) SHA1(340bca1f31486609b3c34dd7830362a216ff648e) )
 	ROM_LOAD24_WORD("v_bg-21.410",  0x300000, 0x100000, CRC(d65b4318) SHA1(6522970d95ffa7fa2f32e0b5b4f0eb69e0286b36) )
 	ROM_LOAD24_BYTE("v_bg-22.416",  0x300002, 0x080000, CRC(24a0a23a) SHA1(0b0330717620e3f3274a25845d9edaf8023b9db2) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("v_obj-1.322",  0x000000, 0x400000, CRC(3be5b631) SHA1(fd1064428d28ca166a9267b968c0ba846cfed656) )
 	ROM_LOAD("v_obj-2.324",  0x400000, 0x400000, CRC(924153b4) SHA1(db5dadcfb4cd5e6efe9d995085936ce4f4eb4254) )
 	ROM_LOAD("v_obj-3.323",  0x800000, 0x400000, CRC(e9fb9062) SHA1(18e97b4c5cced2b529e6e72d8041c6f78fcec76e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_BYTE("v_pcm.215",  0x000000, 0x080000, CRC(e3111b60) SHA1(f7a7747f29c392876e43efcb4e6c0741454082f2) )
 	ROM_CONTINUE(                 0x400000, 0x080000 )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region80.u1053", 0x000000, 0x100000, CRC(e2adaff5) SHA1(9297afaf78209724515d8f78de8cee7bc7cb796b) )
 ROM_END
 
 
-ROM_START( rdft ) /* SXX2C ROM SUB2 cart */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rdft ) // SXX2C ROM SUB2 cart
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("raiden-fi_prg0_121196.u0211", 0x000000, 0x80000, CRC(adcb5dbc) SHA1(3831becd1e052d81dd00ee098ee630fe35164df8) )
 	ROM_LOAD32_BYTE("raiden-fi_prg1_121196.u0212", 0x000001, 0x80000, CRC(60c5b92e) SHA1(ca67f97f9e7d8a21667dc59e7d390dff91179b08) )
 	ROM_LOAD32_BYTE("raiden-fi_prg2_121196.u0210", 0x000002, 0x80000, CRC(44b86db5) SHA1(bb05c6d27af86084cd3e17a189826c836f229c8b) )
 	ROM_LOAD32_BYTE("raiden-fi_prg3_121196.u029",  0x000003, 0x80000, CRC(e70727ce) SHA1(2e4e896d50cf086e682054cb2e9c223af04cd0cb) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("seibu_5.u0423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("seibu_6.u0424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("seibu_7.u048",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // some mask ROMs might be labeled GD BG1-D ect
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("gun_dogs_pcm.u0217",  0x000000, 0x100000, CRC(31253ad7) SHA1(c81c8d50f8f287f5cbfaec77b30d969b01ce11a9) )
 	ROM_CONTINUE(                          0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("seibu_8.u0216",       0x800000, 0x080000, CRC(f88cb6e4) SHA1(fb35b41307b490d5d08e4b8a70f8ff4ce2ca8105) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region80.u1053", 0x000000, 0x100000, CRC(e2adaff5) SHA1(9297afaf78209724515d8f78de8cee7bc7cb796b) )
 ROM_END
 
 ROM_START( rdftu )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("rdftu_gd_1.211", 0x000000, 0x80000, CRC(47810c48) SHA1(8dc8848d3e7467ea887c50fd5675fba2cc741121) )
 	ROM_LOAD32_BYTE("rdftu_gd_2.212", 0x000001, 0x80000, CRC(13911750) SHA1(8899accb059ed84170924750bb39ae7383ebd959) )
 	ROM_LOAD32_BYTE("rdftu_gd_3.210", 0x000002, 0x80000, CRC(10761b03) SHA1(e67db2e7c2176987419158fc4cee00fd9b99d03f) )
 	ROM_LOAD32_BYTE("rdftu_gd_4.29",  0x000003, 0x80000, CRC(e5a3f01d) SHA1(5ca338f85a020d43d2618f88e798a076d13a5c7f) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("seibu_5.u0423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("seibu_6.u0424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("seibu_7.u048",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // some mask ROMs might be labeled GD BG1-D ect
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("gun_dogs_pcm.u0217",  0x000000, 0x100000, CRC(31253ad7) SHA1(c81c8d50f8f287f5cbfaec77b30d969b01ce11a9) )
 	ROM_CONTINUE(                          0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("seibu_8.u0216",       0x800000, 0x080000, CRC(f88cb6e4) SHA1(fb35b41307b490d5d08e4b8a70f8ff4ce2ca8105) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region10.u1053", 0x000000, 0x100000, CRC(4319d998) SHA1(a064ce647453a9b3bccf7f1d6d0d52b5a72e09dd) )
 ROM_END
 
 ROM_START( rdftj )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("gd_1.211", 0x000000, 0x80000, CRC(f6b2cbdc) SHA1(040c4ff961c8be388c8279b06b777d528c2acc1b) )
 	ROM_LOAD32_BYTE("gd_2.212", 0x000001, 0x80000, CRC(1982f812) SHA1(4f12fc3fd7f7a4beda4d29cc81e3a58d255e441f) )
 	ROM_LOAD32_BYTE("gd_3.210", 0x000002, 0x80000, CRC(b0f59f44) SHA1(d44fe074ddab35cd0190535cd9fbd7f9e49312a4) )
 	ROM_LOAD32_BYTE("gd_4.29",  0x000003, 0x80000, CRC(cd8705bd) SHA1(b19a1486d6b899a134d7b518863ddc8f07967e8b) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("seibu_5.u0423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("seibu_6.u0424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("seibu_7.u048",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // some mask ROMs might be labeled GD BG1-D ect
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("gun_dogs_pcm.u0217",  0x000000, 0x100000, CRC(31253ad7) SHA1(c81c8d50f8f287f5cbfaec77b30d969b01ce11a9) )
 	ROM_CONTINUE(                          0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("seibu_8.u0216",       0x800000, 0x080000, CRC(f88cb6e4) SHA1(fb35b41307b490d5d08e4b8a70f8ff4ce2ca8105) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region01.u1053", 0x000000, 0x100000, CRC(7ae7ab76) SHA1(a2b196f470bf64af94002fc4e2640fadad00418f) )
 ROM_END
 
 ROM_START( rdftja )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("rf1.bin", 0x000000, 0x80000, CRC(46861b75) SHA1(079c589c490d49f7ec97a7e68c5b6e7e37872827) )
 	ROM_LOAD32_BYTE("rf2.bin", 0x000001, 0x80000, CRC(6388ed11) SHA1(aebbccfb0f704cdceb45ea71216275dd83880e15) )
 	ROM_LOAD32_BYTE("rf3.bin", 0x000002, 0x80000, CRC(beafcd24) SHA1(2dbc47ecef6f898a371a841df2c72151da9c5a8d) )
 	ROM_LOAD32_BYTE("rf4.bin", 0x000003, 0x80000, CRC(5236f45f) SHA1(8b05d977d3d07796007a00a52d2396475dc2f7dc) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("seibu_5.u0423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("seibu_6.u0424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("seibu_7.u048",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // some mask ROMs might be labeled GD BG1-D ect
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("gun_dogs_pcm.u0217",  0x000000, 0x100000, CRC(31253ad7) SHA1(c81c8d50f8f287f5cbfaec77b30d969b01ce11a9) )
 	ROM_CONTINUE(                          0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("seibu_8.u0216",       0x800000, 0x080000, CRC(f88cb6e4) SHA1(fb35b41307b490d5d08e4b8a70f8ff4ce2ca8105) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region01.u1053", 0x000000, 0x100000, CRC(7ae7ab76) SHA1(a2b196f470bf64af94002fc4e2640fadad00418f) )
 ROM_END
 
 ROM_START( rdftau )
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("1.u0211", 0x000000, 0x80000, CRC(6339c60d) SHA1(871d5bc9fc695651ceb6fcfdab32084320fe239d) )
 	ROM_LOAD32_BYTE("2.u0212", 0x000001, 0x80000, CRC(a88bda02) SHA1(27dc720d28f56cf443a4eb0bbaaf4bf3b194056d) )
 	ROM_LOAD32_BYTE("3.u0210", 0x000002, 0x80000, CRC(a73e337e) SHA1(93323875c676f38eca3298fcf4a34911db2d78a8) )
 	ROM_LOAD32_BYTE("4.u029",  0x000003, 0x80000, CRC(8cc628f0) SHA1(7534eae8a1ea461adad483002b3cecf132e0e325) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("seibu_5.u0423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("seibu_6.u0424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("seibu_7.u048",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // some mask ROMs might be labeled GD BG1-D ect
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("gun_dogs_pcm.u0217",  0x000000, 0x100000, CRC(31253ad7) SHA1(c81c8d50f8f287f5cbfaec77b30d969b01ce11a9) )
 	ROM_CONTINUE(                          0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("seibu_8.u0216",       0x800000, 0x080000, CRC(f88cb6e4) SHA1(fb35b41307b490d5d08e4b8a70f8ff4ce2ca8105) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region9e.u1053", 0x000000, 0x100000, CRC(7ad6f17e) SHA1(9a2cc77a4f86c00208f739bd53aca4f55adf7ea7) )
 ROM_END
 
-ROM_START( rdftauge )  /* SPI Cart "SXX2C ROM SUB2", Australia region (Tuning license - Evaluation Software For Show, Germany) ~~ SPI PCB "(C)1995 SXX2C-MAIN V2.0" */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rdftauge )  // SPI Cart "SXX2C ROM SUB2", Australia region (Tuning license - Evaluation Software For Show, Germany) ~~ SPI PCB "(C)1995 SXX2C-MAIN V2.0"
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("seibu.1.u0211", 0x000000, 0x80000, CRC(3e79da3c) SHA1(8d33da1dadb791ff97b353532ca647eb462c2ae4) )
 	ROM_LOAD32_BYTE("seibu.2.u0212", 0x000001, 0x80000, CRC(a6fbf98c) SHA1(ce0f5f6f1f5656dbac0a6b977795026276c8fa86) )
 	ROM_LOAD32_BYTE("seibu.3.u0210", 0x000002, 0x80000, CRC(ad31cc17) SHA1(12b735519cad190887cdbc6680d879f791ab3726) )
 	ROM_LOAD32_BYTE("seibu.4.u029",  0x000003, 0x80000, CRC(756d99ae) SHA1(38c234acf3e8204a29a9adb077328d37d97cfd6d) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("seibu_5.u0423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("seibu_6.u0424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("seibu_7.u048",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // some mask ROMs might be labeled GD BG1-D ect
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0416", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("gun_dogs_pcm.u0217", 0x000000, 0x100000, CRC(31253ad7) SHA1(c81c8d50f8f287f5cbfaec77b30d969b01ce11a9) )
 	ROM_CONTINUE(                         0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("seibu_8.u0216",      0x800000, 0x080000, CRC(f88cb6e4) SHA1(fb35b41307b490d5d08e4b8a70f8ff4ce2ca8105) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region9e.u1053", 0x000000, 0x100000, CRC(7ad6f17e) SHA1(9a2cc77a4f86c00208f739bd53aca4f55adf7ea7) )
 ROM_END
 
 // The rest of the following Raiden Fighters sets are based on the same code revision
 ROM_START( rdfta ) // SXX2C ROM SUB2 cart
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("seibu_1.u0211", 0x000000, 0x80000, CRC(c3bb2e58) SHA1(399ac4b387ba38f5fdad5c4172b2d3baeafd8773) ) // sldh
 	ROM_LOAD32_BYTE("seibu_2.u0212", 0x000001, 0x80000, CRC(58ccb10c) SHA1(0cce4057bfada78121d9586574b98d46cdd7dd46) )
 	ROM_LOAD32_BYTE("seibu_3.u0210", 0x000002, 0x80000, CRC(47fc3c96) SHA1(7378f8caa847f89f235b5be6779118721076873b) )
 	ROM_LOAD32_BYTE("seibu_4.u029",  0x000003, 0x80000, CRC(271bdd4b) SHA1(0a805568cbd6a9c18bdb755a41972ff6bba9e6eb) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("seibu_5.u0423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("seibu_6.u0424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("seibu_7.u048",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // some mask ROMs might be labeled GD BG1-D ect
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("gun_dogs_pcm.u0217",  0x000000, 0x100000, CRC(31253ad7) SHA1(c81c8d50f8f287f5cbfaec77b30d969b01ce11a9) )
 	ROM_CONTINUE(                          0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("seibu_8.u0216",       0x800000, 0x080000, CRC(f88cb6e4) SHA1(fb35b41307b490d5d08e4b8a70f8ff4ce2ca8105) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region82.u1053", 0x000000, 0x100000, CRC(4f463a87) SHA1(0e27904745da61a3ba7c48c5b4c7d45989bbd05b) )
 ROM_END
 
 ROM_START( rdftit ) // SXX2C ROM SUB2 cart
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("seibu_1.u0211", 0x000000, 0x80000, CRC(de0c3e3c) SHA1(b00225bad282e46b5825608f76eea6670bfe5527) ) // sldh
 	ROM_LOAD32_BYTE("seibu_2.u0212", 0x000001, 0x80000, CRC(58ccb10c) SHA1(0cce4057bfada78121d9586574b98d46cdd7dd46) )
 	ROM_LOAD32_BYTE("seibu_3.u0210", 0x000002, 0x80000, CRC(47fc3c96) SHA1(7378f8caa847f89f235b5be6779118721076873b) )
 	ROM_LOAD32_BYTE("seibu_4.u029",  0x000003, 0x80000, CRC(271bdd4b) SHA1(0a805568cbd6a9c18bdb755a41972ff6bba9e6eb) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("seibu_5.u0423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("seibu_6.u0424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("seibu_7.u048",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // some mask ROMs might be labeled GD BG1-D ect
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("gun_dogs_pcm.u0217",  0x000000, 0x100000, CRC(31253ad7) SHA1(c81c8d50f8f287f5cbfaec77b30d969b01ce11a9) )
 	ROM_CONTINUE(                          0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("seibu_8.u0216",       0x800000, 0x080000, CRC(f88cb6e4) SHA1(fb35b41307b490d5d08e4b8a70f8ff4ce2ca8105) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region92.u1053", 0x000000, 0x100000, CRC(204d82d0) SHA1(444f4aefa27d8f5d1a2f7f08f826ea84b0ccbd02) )
 ROM_END
 
 ROM_START( rdftgb ) // SXX2C ROM SUB2 cart
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("seibu_1.u0211", 0x000000, 0x80000, CRC(2403035f) SHA1(9763cca3864d6127050e1507b572efa68f664b3c) )
 	ROM_LOAD32_BYTE("seibu_2.u0212", 0x000001, 0x80000, CRC(58ccb10c) SHA1(0cce4057bfada78121d9586574b98d46cdd7dd46) )
 	ROM_LOAD32_BYTE("seibu_3.u0210", 0x000002, 0x80000, CRC(47fc3c96) SHA1(7378f8caa847f89f235b5be6779118721076873b) )
 	ROM_LOAD32_BYTE("seibu_4.u029",  0x000003, 0x80000, CRC(271bdd4b) SHA1(0a805568cbd6a9c18bdb755a41972ff6bba9e6eb) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("seibu_5.u0423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("seibu_6.u0424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("seibu_7.u048",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // some mask ROMs might be labeled GD BG1-D ect
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("gun_dogs_pcm.u0217",  0x000000, 0x100000, CRC(31253ad7) SHA1(c81c8d50f8f287f5cbfaec77b30d969b01ce11a9) )
 	ROM_CONTINUE(                          0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("seibu_8.u0216",       0x800000, 0x080000, CRC(f88cb6e4) SHA1(fb35b41307b490d5d08e4b8a70f8ff4ce2ca8105) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region8c.u1053", 0x000000, 0x100000, CRC(b836dc5b) SHA1(80400429970f8997978ee723d3067a39ebc0e126) )
 ROM_END
 
 ROM_START( rdftgr ) // SXX2C ROM SUB2 cart
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("seibu_1.u0211", 0x000000, 0x80000, CRC(ca0d6273) SHA1(f761d68ec9a49d66d9f3adc663663f716cdd3735) ) // sldh
 	ROM_LOAD32_BYTE("seibu_2.u0212", 0x000001, 0x80000, CRC(58ccb10c) SHA1(0cce4057bfada78121d9586574b98d46cdd7dd46) )
 	ROM_LOAD32_BYTE("seibu_3.u0210", 0x000002, 0x80000, CRC(47fc3c96) SHA1(7378f8caa847f89f235b5be6779118721076873b) )
 	ROM_LOAD32_BYTE("seibu_4.u029",  0x000003, 0x80000, CRC(271bdd4b) SHA1(0a805568cbd6a9c18bdb755a41972ff6bba9e6eb) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("seibu_5.u0423", 0x000000, 0x10000, CRC(8f8d4e14) SHA1(06c803975767ae98f40ba7ac5764a5bc8baa3a30) )
 	ROM_LOAD24_BYTE("seibu_6.u0424", 0x000001, 0x10000, CRC(6ac64968) SHA1(ec395205c24c4f864a1f805bb0d4641562d4faa9) )
 	ROM_LOAD24_BYTE("seibu_7.u048",  0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) )
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // some mask ROMs might be labeled GD BG1-D ect
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) )
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) )
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) )
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) )
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) )
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("gun_dogs_pcm.u0217",  0x000000, 0x100000, CRC(31253ad7) SHA1(c81c8d50f8f287f5cbfaec77b30d969b01ce11a9) )
 	ROM_CONTINUE(                          0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("seibu_8.u0216",       0x800000, 0x080000, CRC(f88cb6e4) SHA1(fb35b41307b490d5d08e4b8a70f8ff4ce2ca8105) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region8e.u1053", 0x000000, 0x100000, CRC(15dd4929) SHA1(e0f68e9e4d775d70e85ea6b5dd29beeb0e940b1c) )
 ROM_END
 
 ROM_START( rdftjb ) // SXX2C ROM SUB4 cart
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("seibu_1.u0211",        0x000000, 0x080000, CRC(b70afcc2) SHA1(70ac545a9fc30df310254997674878fbc2c2d718) ) // socket is silkscreened on pcb PRG0 - sldh
 	ROM_LOAD32_BYTE("raiden-f_prg2.u0212",  0x000001, 0x080000, CRC(58ccb10c) SHA1(0cce4057bfada78121d9586574b98d46cdd7dd46) ) // socket is silkscreened on pcb PRG1
 	ROM_LOAD32_WORD("raiden-f_prg34.u0219", 0x000002, 0x100000, CRC(63f01d17) SHA1(74dbd0417b974583da87fc6c7a081b03fd4e16b8) ) // socket is silkscreened on pcb PRG23
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("raiden-f_fix.u0425", 0x000000, 0x20000, CRC(2be2936b) SHA1(9e719f7328a52af220b6f084c1e0990ca6e2d533) ) // socket is silkscreened on pcb FIX01
 	ROM_LOAD24_BYTE("seibu_7.u048",       0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) ) // socket is silkscreened on pcb FIXP
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // pads are silkscreened on pcb BG12
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) ) // pads are silkscreened on pcb BG12P
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) ) // pads are silkscreened on pcb BG3
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) ) // pads are silkscreened on pcb BG3P
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) ) // pads are silkscreened on pcb OBJ1
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) ) // pads are silkscreened on pcb OBJ2
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) ) // pads are silkscreened on pcb OBJ3
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("raiden-f_pcm2.u0217", 0x000000, 0x100000, CRC(3f8d4a48) SHA1(30664a2908daaeaee58f7e157516b522c952e48d) ) // pads are silkscreened SOUND0
 	ROM_CONTINUE(                          0x400000, 0x100000 )
-	/* SOUND1 socket is unpopulated */
+	// SOUND1 socket is unpopulated
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region01.u1053", 0x000000, 0x100000, CRC(7ae7ab76) SHA1(a2b196f470bf64af94002fc4e2640fadad00418f) )
 ROM_END
 
 ROM_START( rdftua ) // SXX2C ROM SUB4 cart
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("seibu_1.u0211",        0x000000, 0x080000, CRC(ddbadc30) SHA1(d419847db8b7f4ca6f161bfa309314eafeea8b40) ) // socket is silkscreened on pcb PRG0 - sldh
 	ROM_LOAD32_BYTE("raiden-f_prg2.u0212",  0x000001, 0x080000, CRC(58ccb10c) SHA1(0cce4057bfada78121d9586574b98d46cdd7dd46) ) // socket is silkscreened on pcb PRG1
 	ROM_LOAD32_WORD("raiden-f_prg34.u0219", 0x000002, 0x100000, CRC(63f01d17) SHA1(74dbd0417b974583da87fc6c7a081b03fd4e16b8) ) // socket is silkscreened on pcb PRG23
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("raiden-f_fix.u0425", 0x000000, 0x20000, CRC(2be2936b) SHA1(9e719f7328a52af220b6f084c1e0990ca6e2d533) ) // socket is silkscreened on pcb FIX01
 	ROM_LOAD24_BYTE("seibu_7.u048",       0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) ) // socket is silkscreened on pcb FIXP
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // pads are silkscreened on pcb BG12
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) ) // pads are silkscreened on pcb BG12P
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) ) // pads are silkscreened on pcb BG3
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) ) // pads are silkscreened on pcb BG3P
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) ) // pads are silkscreened on pcb OBJ1
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) ) // pads are silkscreened on pcb OBJ2
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) ) // pads are silkscreened on pcb OBJ3
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("raiden-f_pcm2.u0217", 0x000000, 0x100000, CRC(3f8d4a48) SHA1(30664a2908daaeaee58f7e157516b522c952e48d) ) // pads are silkscreened SOUND0
 	ROM_CONTINUE(                          0x400000, 0x100000 )
-	/* SOUND1 socket is unpopulated */
+	// SOUND1 socket is unpopulated
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region10.u1053", 0x000000, 0x100000, CRC(4319d998) SHA1(a064ce647453a9b3bccf7f1d6d0d52b5a72e09dd) )
 ROM_END
 
 ROM_START( rdftadi ) // Dream Island license - SXX2C ROM SUB4 cart
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("seibu_1.u0211",        0x000000, 0x080000, CRC(fc0e2885) SHA1(79621155d992d504e993bd3ee0d6ff3903bd5415) ) // socket is silkscreened on pcb PRG0 - sldh
 	ROM_LOAD32_BYTE("raiden-f_prg2.u0212",  0x000001, 0x080000, CRC(58ccb10c) SHA1(0cce4057bfada78121d9586574b98d46cdd7dd46) ) // socket is silkscreened on pcb PRG1
 	ROM_LOAD32_WORD("raiden-f_prg34.u0219", 0x000002, 0x100000, CRC(63f01d17) SHA1(74dbd0417b974583da87fc6c7a081b03fd4e16b8) ) // socket is silkscreened on pcb PRG23
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("raiden-f_fix.u0425", 0x000000, 0x20000, CRC(2be2936b) SHA1(9e719f7328a52af220b6f084c1e0990ca6e2d533) ) // socket is silkscreened on pcb FIX01
 	ROM_LOAD24_BYTE("seibu_7.u048",       0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) ) // socket is silkscreened on pcb FIXP
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // pads are silkscreened on pcb BG12
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) ) // pads are silkscreened on pcb BG12P
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) ) // pads are silkscreened on pcb BG3
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) ) // pads are silkscreened on pcb BG3P
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) ) // pads are silkscreened on pcb OBJ1
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) ) // pads are silkscreened on pcb OBJ2
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) ) // pads are silkscreened on pcb OBJ3
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("raiden-f_pcm2.u0217", 0x000000, 0x100000, CRC(3f8d4a48) SHA1(30664a2908daaeaee58f7e157516b522c952e48d) ) // pads are silkscreened SOUND0
 	ROM_CONTINUE(                          0x400000, 0x100000 )
-	/* SOUND1 socket is unpopulated */
+	// SOUND1 socket is unpopulated
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region24.u1053", 0x000000, 0x100000, CRC(72a33dc4) SHA1(65a52f576ca4d240418fedd9a4922edcd6c0c8d1) )
 ROM_END
 
 ROM_START( rdftam ) // Metrotainment license - SXX2C ROM SUB4 cart
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("seibu_1.u0211",        0x000000, 0x080000, CRC(156d8db0) SHA1(93662b3ee494e37a56428a7aa3dad7a957835950) ) // socket is silkscreened on pcb PRG0 - sldh
 	ROM_LOAD32_BYTE("raiden-f_prg2.u0212",  0x000001, 0x080000, CRC(58ccb10c) SHA1(0cce4057bfada78121d9586574b98d46cdd7dd46) ) // socket is silkscreened on pcb PRG1
 	ROM_LOAD32_WORD("raiden-f_prg34.u0219", 0x000002, 0x100000, CRC(63f01d17) SHA1(74dbd0417b974583da87fc6c7a081b03fd4e16b8) ) // socket is silkscreened on pcb PRG23
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("raiden-f_fix.u0425", 0x000000, 0x20000, CRC(2be2936b) SHA1(9e719f7328a52af220b6f084c1e0990ca6e2d533) ) // socket is silkscreened on pcb FIX01
 	ROM_LOAD24_BYTE("seibu_7.u048",       0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) ) // socket is silkscreened on pcb FIXP
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0415", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // pads are silkscreened on pcb BG12
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0410", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) ) // pads are silkscreened on pcb BG12P
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0424", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) ) // pads are silkscreened on pcb BG3
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u049",  0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) ) // pads are silkscreened on pcb BG3P
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) ) // pads are silkscreened on pcb OBJ1
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) ) // pads are silkscreened on pcb OBJ2
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) ) // pads are silkscreened on pcb OBJ3
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("raiden-f_pcm2.u0217", 0x000000, 0x100000, CRC(3f8d4a48) SHA1(30664a2908daaeaee58f7e157516b522c952e48d) ) // pads are silkscreened SOUND0
 	ROM_CONTINUE(                          0x400000, 0x100000 )
-	/* SOUND1 socket is unpopulated */
+	// SOUND1 socket is unpopulated
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region22.u1053", 0x000000, 0x100000, CRC(5fee8413) SHA1(6d6a62fa01293b4ba4b349a39820d024add6ea22) )
 ROM_END
 
 
-ROM_START( rdft2 ) /* SPI Cart, Europe */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rdft2 ) // SPI Cart, Europe
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("prg0.tun", 0x000000, 0x80000, CRC(3cb3fdca) SHA1(4b472dfd65c7bbbcb92a295aa73b0fa70581455b) )
 	ROM_LOAD32_BYTE("prg1.bin", 0x000001, 0x80000, CRC(cab55d88) SHA1(246e13880d34b6c7c3f4ab5e18fa8a0547c03d9d) )
 	ROM_LOAD32_BYTE("prg2.bin", 0x000002, 0x80000, CRC(83758b0e) SHA1(63adb2d09e7bd7dba47a55b3b579d543dfb553e3) )
 	ROM_LOAD32_BYTE("prg3.bin", 0x000003, 0x80000, CRC(084fb5e4) SHA1(588bfe091662b88f02f528181a2f1d9c67c7b280) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(6fdf4cf6) SHA1(7e9d4a49e829dfdc373c0f5acfbe8c7a91ac115b) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(69b7899b) SHA1(d3cacd4ef4d2c95d803403101beb9d4be75fae61) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(99a5fece) SHA1(44ae95d650ed6e00202d3438f5f91a5e52e319cb) )
 
-	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3380,41 +3421,41 @@ ROM_START( rdft2 ) /* SPI Cart, Europe */
 	ROM_LOAD("obj1.u0429",  0x0c00000, 0x400000, CRC(c2c50f02) SHA1(b81397b5800c6d49f58b7ac7ff6eac56da3c5257) )
 	ROM_LOAD("obj1b.u0430", 0x1000000, 0x200000, CRC(5259321f) SHA1(3c70c1147e49f81371d0f60f7108d9718d56faf4) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("pcm.u0217",    0x000000, 0x100000, CRC(2edc30b5) SHA1(c25d690d633657fc3687636b9070f36bd305ae06) )
 	ROM_CONTINUE(                   0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("sound1.u0222", 0x800000, 0x080000, CRC(b7bd3703) SHA1(6427a7e6de10d6743d6e64b984a1d1c647f5643a) )
 
-	ROM_REGION( 0x0345, "pals", 0 ) /* pals */
+	ROM_REGION( 0x0345, "pals", 0 ) // pals
 	ROM_LOAD("rm81.u0529.bin", 0x0000, 0x0117, CRC(acd55c8e) SHA1(b965e828fecd61b836aca337637e53d7360d9dc4) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm82.u0330.bin", 0x0117, 0x0117, CRC(64c71423) SHA1(1da3502bec0c843b7198d1d9ab60f9fd4b110a8e) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm83.u0331.bin", 0x022e, 0x0117, CRC(6e10d66b) SHA1(995d2a0da680ec19ee253098c91a4780dd8403c6) ) // AMD PALCE16V8H-15SC/4
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region80.u1053", 0x000000, 0x100000, CRC(e2adaff5) SHA1(9297afaf78209724515d8f78de8cee7bc7cb796b) )
 ROM_END
 
-ROM_START( rdft2u ) /* SPI Cart, USA */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rdft2u ) // SPI Cart, USA
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("1.bin", 0x000000, 0x80000, CRC(b7d6c866) SHA1(eefe63dfc641c3904dd150a10ffeb68137068725) )
 	ROM_LOAD32_BYTE("2.bin", 0x000001, 0x80000, CRC(ff7747c5) SHA1(7481d0484001ff7367af56e8ea99f985cce405f2) )
 	ROM_LOAD32_BYTE("3.bin", 0x000002, 0x80000, CRC(86e3d1a8) SHA1(2757cfda57c82dd0f66427caf54eb1f40e85740d) )
 	ROM_LOAD32_BYTE("4.bin", 0x000003, 0x80000, CRC(2e409a76) SHA1(cf90aa14a07b5aa861f6f7cc9b1968171e532557) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(6fdf4cf6) SHA1(7e9d4a49e829dfdc373c0f5acfbe8c7a91ac115b) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(69b7899b) SHA1(d3cacd4ef4d2c95d803403101beb9d4be75fae61) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(99a5fece) SHA1(44ae95d650ed6e00202d3438f5f91a5e52e319cb) )
 
-	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3422,41 +3463,41 @@ ROM_START( rdft2u ) /* SPI Cart, USA */
 	ROM_LOAD("obj1.u0429",  0x0c00000, 0x400000, CRC(c2c50f02) SHA1(b81397b5800c6d49f58b7ac7ff6eac56da3c5257) )
 	ROM_LOAD("obj1b.u0430", 0x1000000, 0x200000, CRC(5259321f) SHA1(3c70c1147e49f81371d0f60f7108d9718d56faf4) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("pcm.u0217",    0x000000, 0x100000, CRC(2edc30b5) SHA1(c25d690d633657fc3687636b9070f36bd305ae06) )
 	ROM_CONTINUE(                   0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("sound1.u0222", 0x800000, 0x080000, CRC(b7bd3703) SHA1(6427a7e6de10d6743d6e64b984a1d1c647f5643a) )
 
-	ROM_REGION( 0x0345, "pals", 0 ) /* pals */
+	ROM_REGION( 0x0345, "pals", 0 ) // pals
 	ROM_LOAD("rm81.u0529.bin", 0x0000, 0x0117, CRC(acd55c8e) SHA1(b965e828fecd61b836aca337637e53d7360d9dc4) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm82.u0330.bin", 0x0117, 0x0117, CRC(64c71423) SHA1(1da3502bec0c843b7198d1d9ab60f9fd4b110a8e) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm83.u0331.bin", 0x022e, 0x0117, CRC(6e10d66b) SHA1(995d2a0da680ec19ee253098c91a4780dd8403c6) ) // AMD PALCE16V8H-15SC/4
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region10.u1053", 0x000000, 0x100000, CRC(4319d998) SHA1(a064ce647453a9b3bccf7f1d6d0d52b5a72e09dd) )
 ROM_END
 
-ROM_START( rdft2j ) /* SPI Cart, Japan */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rdft2j ) // SPI Cart, Japan
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("prg0.sei", 0x000000, 0x80000, CRC(a60c4e7c) SHA1(7789b029d0ac084c7e5e662a7168edaed8f11633) )
 	ROM_LOAD32_BYTE("prg1.bin", 0x000001, 0x80000, CRC(cab55d88) SHA1(246e13880d34b6c7c3f4ab5e18fa8a0547c03d9d) )
 	ROM_LOAD32_BYTE("prg2.bin", 0x000002, 0x80000, CRC(83758b0e) SHA1(63adb2d09e7bd7dba47a55b3b579d543dfb553e3) )
 	ROM_LOAD32_BYTE("prg3.bin", 0x000003, 0x80000, CRC(084fb5e4) SHA1(588bfe091662b88f02f528181a2f1d9c67c7b280) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(6fdf4cf6) SHA1(7e9d4a49e829dfdc373c0f5acfbe8c7a91ac115b) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(69b7899b) SHA1(d3cacd4ef4d2c95d803403101beb9d4be75fae61) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(99a5fece) SHA1(44ae95d650ed6e00202d3438f5f91a5e52e319cb) )
 
-	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3464,41 +3505,41 @@ ROM_START( rdft2j ) /* SPI Cart, Japan */
 	ROM_LOAD("obj1.u0429",  0x0c00000, 0x400000, CRC(c2c50f02) SHA1(b81397b5800c6d49f58b7ac7ff6eac56da3c5257) )
 	ROM_LOAD("obj1b.u0430", 0x1000000, 0x200000, CRC(5259321f) SHA1(3c70c1147e49f81371d0f60f7108d9718d56faf4) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("pcm.u0217",    0x000000, 0x100000, CRC(2edc30b5) SHA1(c25d690d633657fc3687636b9070f36bd305ae06) )
 	ROM_CONTINUE(                   0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("sound1.u0222", 0x800000, 0x080000, CRC(b7bd3703) SHA1(6427a7e6de10d6743d6e64b984a1d1c647f5643a) )
 
-	ROM_REGION( 0x0345, "pals", 0 ) /* pals */
+	ROM_REGION( 0x0345, "pals", 0 ) // pals
 	ROM_LOAD("rm81.u0529.bin", 0x0000, 0x0117, CRC(acd55c8e) SHA1(b965e828fecd61b836aca337637e53d7360d9dc4) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm82.u0330.bin", 0x0117, 0x0117, CRC(64c71423) SHA1(1da3502bec0c843b7198d1d9ab60f9fd4b110a8e) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm83.u0331.bin", 0x022e, 0x0117, CRC(6e10d66b) SHA1(995d2a0da680ec19ee253098c91a4780dd8403c6) ) // AMD PALCE16V8H-15SC/4
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region01.u1053", 0x000000, 0x100000, CRC(7ae7ab76) SHA1(a2b196f470bf64af94002fc4e2640fadad00418f) )
 ROM_END
 
-ROM_START( rdft2ja ) /* SPI Cart, Japan */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rdft2ja ) // SPI Cart, Japan
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("rf2.1",     0x000000, 0x80000, CRC(391d5057) SHA1(a1849142cbf7344ac1279781597e27b3b8ae6127) )
 	ROM_LOAD32_BYTE("rf2_2.bin", 0x000001, 0x80000, CRC(ec73a767) SHA1(83f3905afe49401793c0ea0193cb31d3ba1e1739) )
 	ROM_LOAD32_BYTE("rf2_3.bin", 0x000002, 0x80000, CRC(e66243b2) SHA1(54e67af37a4586fd1afc79085ed433d599e1bb87) )
 	ROM_LOAD32_BYTE("rf2_4.bin", 0x000003, 0x80000, CRC(92b7b73e) SHA1(128649b2a6a0616113bd0f9846fb6cf814ae326d) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("rf2_5.bin", 0x000001, 0x10000, CRC(377cac2f) SHA1(f7c9323d79b77f6c8c02ba2c6cdca127d6e5cb5c) )
 	ROM_LOAD24_BYTE("rf2_6.bin", 0x000000, 0x10000, CRC(42bd5372) SHA1(c38df85b25070db9640eac541f71c0511bab0c98) )
 	ROM_LOAD24_BYTE("rf2_7.bin", 0x000002, 0x10000, CRC(1efaac7e) SHA1(8252af56dcb7a6306dc3422070176778e3c511c2) )
 
-	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3506,41 +3547,41 @@ ROM_START( rdft2ja ) /* SPI Cart, Japan */
 	ROM_LOAD("obj1.u0429",  0x0c00000, 0x400000, CRC(c2c50f02) SHA1(b81397b5800c6d49f58b7ac7ff6eac56da3c5257) )
 	ROM_LOAD("obj1b.u0430", 0x1000000, 0x200000, CRC(5259321f) SHA1(3c70c1147e49f81371d0f60f7108d9718d56faf4) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("pcm.u0217",    0x000000, 0x100000, CRC(2edc30b5) SHA1(c25d690d633657fc3687636b9070f36bd305ae06) )
 	ROM_CONTINUE(                   0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("sound1.u0222", 0x800000, 0x080000, CRC(b7bd3703) SHA1(6427a7e6de10d6743d6e64b984a1d1c647f5643a) )
 
-	ROM_REGION( 0x0345, "pals", 0 ) /* pals */
+	ROM_REGION( 0x0345, "pals", 0 ) // pals
 	ROM_LOAD("rm81.u0529.bin", 0x0000, 0x0117, CRC(acd55c8e) SHA1(b965e828fecd61b836aca337637e53d7360d9dc4) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm82.u0330.bin", 0x0117, 0x0117, CRC(64c71423) SHA1(1da3502bec0c843b7198d1d9ab60f9fd4b110a8e) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm83.u0331.bin", 0x022e, 0x0117, CRC(6e10d66b) SHA1(995d2a0da680ec19ee253098c91a4780dd8403c6) ) // AMD PALCE16V8H-15SC/4
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region01.u1053", 0x000000, 0x100000, CRC(7ae7ab76) SHA1(a2b196f470bf64af94002fc4e2640fadad00418f) )
 ROM_END
 
-ROM_START( rdft2jb ) /* SPI Cart, Japan */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rdft2jb ) // SPI Cart, Japan
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("prg0.rom", 0x000000, 0x80000, CRC(fc42cab8) SHA1(2e33fc8d77fdc4ee58e93fc191d12f2fe9cc3c65) )
 	ROM_LOAD32_BYTE("prg1.rom", 0x000001, 0x80000, CRC(a0f09dc5) SHA1(e8ad20be1f04752b0884571384d4490813ed82d9) )
 	ROM_LOAD32_BYTE("prg2.rom", 0x000002, 0x80000, CRC(368580e0) SHA1(184036a0cbddbf79b62e388b93cb93b885faee88) )
 	ROM_LOAD32_BYTE("prg3.rom", 0x000003, 0x80000, CRC(7ad45c01) SHA1(d782057658dd000c1cf0a4726a6ed821e6f2be67) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("rf2_5.bin", 0x000001, 0x10000, CRC(377cac2f) SHA1(f7c9323d79b77f6c8c02ba2c6cdca127d6e5cb5c) )
 	ROM_LOAD24_BYTE("rf2_6.bin", 0x000000, 0x10000, CRC(42bd5372) SHA1(c38df85b25070db9640eac541f71c0511bab0c98) )
 	ROM_LOAD24_BYTE("rf2_7.bin", 0x000002, 0x10000, CRC(1efaac7e) SHA1(8252af56dcb7a6306dc3422070176778e3c511c2) )
 
-	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3548,41 +3589,41 @@ ROM_START( rdft2jb ) /* SPI Cart, Japan */
 	ROM_LOAD("obj1.u0429",  0x0c00000, 0x400000, CRC(c2c50f02) SHA1(b81397b5800c6d49f58b7ac7ff6eac56da3c5257) )
 	ROM_LOAD("obj1b.u0430", 0x1000000, 0x200000, CRC(5259321f) SHA1(3c70c1147e49f81371d0f60f7108d9718d56faf4) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("pcm.u0217",    0x000000, 0x100000, CRC(2edc30b5) SHA1(c25d690d633657fc3687636b9070f36bd305ae06) )
 	ROM_CONTINUE(                   0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("sound1.u0222", 0x800000, 0x080000, CRC(b7bd3703) SHA1(6427a7e6de10d6743d6e64b984a1d1c647f5643a) )
 
-	ROM_REGION( 0x0345, "pals", 0 ) /* pals */
+	ROM_REGION( 0x0345, "pals", 0 ) // pals
 	ROM_LOAD("rm81.u0529.bin", 0x0000, 0x0117, CRC(acd55c8e) SHA1(b965e828fecd61b836aca337637e53d7360d9dc4) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm82.u0330.bin", 0x0117, 0x0117, CRC(64c71423) SHA1(1da3502bec0c843b7198d1d9ab60f9fd4b110a8e) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm83.u0331.bin", 0x022e, 0x0117, CRC(6e10d66b) SHA1(995d2a0da680ec19ee253098c91a4780dd8403c6) ) // AMD PALCE16V8H-15SC/4
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region01.u1053", 0x000000, 0x100000, CRC(7ae7ab76) SHA1(a2b196f470bf64af94002fc4e2640fadad00418f) )
 ROM_END
 
-ROM_START( rdft2jc ) /* SPI SXX2C ROM SUB8 Cart, Japan */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rdft2jc ) // SPI SXX2C ROM SUB8 Cart, Japan
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("seibu_1.u0211", 0x000000, 0x80000, CRC(36b6407c) SHA1(b3f5bb3c582aca71e0c7d9da5951b30c7389cc24) )
 	ROM_LOAD32_BYTE("seibu_2.u0212", 0x000001, 0x80000, CRC(65ee556e) SHA1(13311850aabba9fc373adfd5cd590c114505933f) )
 	ROM_LOAD32_BYTE("seibu_3.u0221", 0x000002, 0x80000, CRC(d2458358) SHA1(18a9cfee77a6a09584bc3fb0073c822d12de5bf1) )
 	ROM_LOAD32_BYTE("seibu_4.u0220", 0x000003, 0x80000, CRC(5c4412f9) SHA1(c72603bee3ce14f40d4bf5e3ae3f041b923edd57) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(6fdf4cf6) SHA1(7e9d4a49e829dfdc373c0f5acfbe8c7a91ac115b) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(69b7899b) SHA1(d3cacd4ef4d2c95d803403101beb9d4be75fae61) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(99a5fece) SHA1(44ae95d650ed6e00202d3438f5f91a5e52e319cb) )
 
-	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3590,41 +3631,41 @@ ROM_START( rdft2jc ) /* SPI SXX2C ROM SUB8 Cart, Japan */
 	ROM_LOAD("obj1.u0429",  0x0c00000, 0x400000, CRC(c2c50f02) SHA1(b81397b5800c6d49f58b7ac7ff6eac56da3c5257) )
 	ROM_LOAD("obj1b.u0430", 0x1000000, 0x200000, CRC(5259321f) SHA1(3c70c1147e49f81371d0f60f7108d9718d56faf4) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("pcm.u0217",    0x000000, 0x100000, CRC(2edc30b5) SHA1(c25d690d633657fc3687636b9070f36bd305ae06) )
 	ROM_CONTINUE(                   0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("sound1.u0222", 0x800000, 0x080000, CRC(b7bd3703) SHA1(6427a7e6de10d6743d6e64b984a1d1c647f5643a) )
 
-	ROM_REGION( 0x0345, "pals", 0 ) /* pals */
+	ROM_REGION( 0x0345, "pals", 0 ) // pals
 	ROM_LOAD("rm81.u0529.bin", 0x0000, 0x0117, CRC(acd55c8e) SHA1(b965e828fecd61b836aca337637e53d7360d9dc4) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm82.u0330.bin", 0x0117, 0x0117, CRC(64c71423) SHA1(1da3502bec0c843b7198d1d9ab60f9fd4b110a8e) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm83.u0331.bin", 0x022e, 0x0117, CRC(6e10d66b) SHA1(995d2a0da680ec19ee253098c91a4780dd8403c6) ) // AMD PALCE16V8H-15SC/4
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region01.u1053", 0x000000, 0x100000, CRC(7ae7ab76) SHA1(a2b196f470bf64af94002fc4e2640fadad00418f) )
 ROM_END
 
-ROM_START( rdft2it ) /* SPI Cart, Italy */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rdft2it ) // SPI Cart, Italy
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("seibu1.bin",0x000000, 0x80000, CRC(501b92a9) SHA1(3e1c5cc63906ec7b97a3478557ec2638c515d726) )
 	ROM_LOAD32_BYTE("seibu2.bin",0x000001, 0x80000, CRC(ec73a767) SHA1(83f3905afe49401793c0ea0193cb31d3ba1e1739) )
 	ROM_LOAD32_BYTE("seibu3.bin",0x000002, 0x80000, CRC(e66243b2) SHA1(54e67af37a4586fd1afc79085ed433d599e1bb87) )
 	ROM_LOAD32_BYTE("seibu4.bin",0x000003, 0x80000, CRC(92b7b73e) SHA1(128649b2a6a0616113bd0f9846fb6cf814ae326d) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("seibu5.bin", 0x000001, 0x10000, CRC(377cac2f) SHA1(f7c9323d79b77f6c8c02ba2c6cdca127d6e5cb5c) )
 	ROM_LOAD24_BYTE("seibu6.bin", 0x000000, 0x10000, CRC(42bd5372) SHA1(c38df85b25070db9640eac541f71c0511bab0c98) )
 	ROM_LOAD24_BYTE("seibu7.bin", 0x000002, 0x10000, CRC(1efaac7e) SHA1(8252af56dcb7a6306dc3422070176778e3c511c2) )
 
-	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3632,42 +3673,42 @@ ROM_START( rdft2it ) /* SPI Cart, Italy */
 	ROM_LOAD("obj1.u0429",  0x0c00000, 0x400000, CRC(c2c50f02) SHA1(b81397b5800c6d49f58b7ac7ff6eac56da3c5257) )
 	ROM_LOAD("obj1b.u0430", 0x1000000, 0x200000, CRC(5259321f) SHA1(3c70c1147e49f81371d0f60f7108d9718d56faf4) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("pcm.u0217",    0x000000, 0x100000, CRC(2edc30b5) SHA1(c25d690d633657fc3687636b9070f36bd305ae06) )
 	ROM_CONTINUE(                   0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("seibu8.bin", 0x800000, 0x080000, CRC(b7bd3703) SHA1(6427a7e6de10d6743d6e64b984a1d1c647f5643a) )
 
-	ROM_REGION( 0x0345, "pals", 0 ) /* pals */
+	ROM_REGION( 0x0345, "pals", 0 ) // pals
 	ROM_LOAD("rm81.u0529.bin", 0x0000, 0x0117, CRC(acd55c8e) SHA1(b965e828fecd61b836aca337637e53d7360d9dc4) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm82.u0330.bin", 0x0117, 0x0117, CRC(64c71423) SHA1(1da3502bec0c843b7198d1d9ab60f9fd4b110a8e) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm83.u0331.bin", 0x022e, 0x0117, CRC(6e10d66b) SHA1(995d2a0da680ec19ee253098c91a4780dd8403c6) ) // AMD PALCE16V8H-15SC/4
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region92.u1053", 0x000000, 0x100000, CRC(204d82d0) SHA1(444f4aefa27d8f5d1a2f7f08f826ea84b0ccbd02) )
 ROM_END
 
-ROM_START( rdft2a ) /* SPI Cart, Asia (Metrotainment license); SPI PCB is marked "(C)1997 SXX2C ROM SUB8" */
+ROM_START( rdft2a ) // SPI Cart, Asia (Metrotainment license); SPI PCB is marked "(C)1997 SXX2C ROM SUB8"
 	// The SUB8 board is also capable of having two 23C8100 roms at U0223 and U0219 for PRG instead of the four roms below.
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program, all are 27C040 */
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program, all are 27C040
 	ROM_LOAD32_BYTE("seibu__1.u0211", 0x000000, 0x80000, CRC(046b3f0e) SHA1(033898f658d6007f891828835734422d4af36321) ) // socket is silkscreened on pcb PRG1
 	ROM_LOAD32_BYTE("seibu__2.u0212", 0x000001, 0x80000, CRC(cab55d88) SHA1(246e13880d34b6c7c3f4ab5e18fa8a0547c03d9d) ) // socket is silkscreened on pcb PRG2
 	ROM_LOAD32_BYTE("seibu__3.u0221", 0x000002, 0x80000, CRC(83758b0e) SHA1(63adb2d09e7bd7dba47a55b3b579d543dfb553e3) ) // socket is silkscreened on pcb PRG3
 	ROM_LOAD32_BYTE("seibu__4.u0220", 0x000003, 0x80000, CRC(084fb5e4) SHA1(588bfe091662b88f02f528181a2f1d9c67c7b280) ) // socket is silkscreened on pcb PRG4
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms - all are 27C512 */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms - all are 27C512
 	ROM_LOAD24_BYTE("seibu__5.u0524", 0x000001, 0x10000, CRC(6fdf4cf6) SHA1(7e9d4a49e829dfdc373c0f5acfbe8c7a91ac115b) ) // socket is silkscreened on pcb FIX0
 	ROM_LOAD24_BYTE("seibu__6.u0518", 0x000000, 0x10000, CRC(69b7899b) SHA1(d3cacd4ef4d2c95d803403101beb9d4be75fae61) ) // socket is silkscreened on pcb FIX1
 	ROM_LOAD24_BYTE("seibu__7.u0514", 0x000002, 0x10000, CRC(99a5fece) SHA1(44ae95d650ed6e00202d3438f5f91a5e52e319cb) ) // socket is silkscreened on pcb FIXP
 
-	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms - half are MX semiconductor MX23C3210MC, half are some sort of 23C1610 equivalent with no visible manufacturer name */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) // background layer roms - half are MX semiconductor MX23C3210MC, half are some sort of 23C1610 equivalent with no visible manufacturer name
 	ROM_LOAD24_WORD("raiden-f2bg-1d.u0535",   0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) ) // pads are silkscreened on pcb BG12
 	ROM_LOAD24_BYTE("raiden-f2__bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) ) // pads are silkscreened on pcb BG12P
 	ROM_LOAD24_WORD("raiden-f2bg-2d.u0536",   0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) ) // pads are silkscreened on pcb BG3
 	ROM_LOAD24_BYTE("raiden-f2__bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) ) // pads are silkscreened on pcb BG3P
 
-	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites - all are paired MX semconductor MX23C3210TC and MX23C1610TC mask roms */
+	ROM_REGION( 0x1200000, "sprites", 0 ) // sprites - all are paired MX semconductor MX23C3210TC and MX23C1610TC mask roms
 	ROM_LOAD("raiden-f2obj-3.u0434", 0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) ) // pads are silkscreened on pcb OBJ3
 	ROM_LOAD("raiden-f2obj-6.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) ) // pads are silkscreened on pcb OBJ3B
 	ROM_LOAD("raiden-f2obj-2.u0431", 0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) ) // pads are silkscreened on pcb OBJ2
@@ -3675,41 +3716,41 @@ ROM_START( rdft2a ) /* SPI Cart, Asia (Metrotainment license); SPI PCB is marked
 	ROM_LOAD("raiden-f2obj-1.u0429", 0x0c00000, 0x400000, CRC(c2c50f02) SHA1(b81397b5800c6d49f58b7ac7ff6eac56da3c5257) ) // pads are silkscreened on pcb OBJ1
 	ROM_LOAD("raiden-f2obj-4.u0430", 0x1000000, 0x200000, CRC(5259321f) SHA1(3c70c1147e49f81371d0f60f7108d9718d56faf4) ) // pads are silkscreened on pcb OBJ1B
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms - sound0 is some sort of 23C1610 equivalent with no visible manufacturer name, sound1 is a 27C040 */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms - sound0 is some sort of 23C1610 equivalent with no visible manufacturer name, sound1 is a 27C040
 	ROM_LOAD32_WORD("raiden-f2__pcm.u0217", 0x000000, 0x100000, CRC(2edc30b5) SHA1(c25d690d633657fc3687636b9070f36bd305ae06) ) // pads are silkscreened on pcb SOUND0
 	ROM_CONTINUE(                           0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("seibu__8.u0222",       0x800000, 0x080000, CRC(b7bd3703) SHA1(6427a7e6de10d6743d6e64b984a1d1c647f5643a) ) // socket is silkscreened on pcb SOUND1
 
-	ROM_REGION( 0x0345, "pals", 0 ) /* pals */
+	ROM_REGION( 0x0345, "pals", 0 ) // pals
 	ROM_LOAD("rm81.u0529.bin", 0x0000, 0x0117, CRC(acd55c8e) SHA1(b965e828fecd61b836aca337637e53d7360d9dc4) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm82.u0330.bin", 0x0117, 0x0117, CRC(64c71423) SHA1(1da3502bec0c843b7198d1d9ab60f9fd4b110a8e) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm83.u0331.bin", 0x022e, 0x0117, CRC(6e10d66b) SHA1(995d2a0da680ec19ee253098c91a4780dd8403c6) ) // AMD PALCE16V8H-15SC/4
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region22.u1053", 0x000000, 0x100000, CRC(5fee8413) SHA1(6d6a62fa01293b4ba4b349a39820d024add6ea22) )
 ROM_END
 
-ROM_START( rdft2aa ) /* SPI Cart, Asia (Dream Island license) */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rdft2aa ) // SPI Cart, Asia (Dream Island license)
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("rf2_1.bin", 0x000000, 0x80000, CRC(72198410) SHA1(ca4bc858f6bf247a343b0fdae1d1a3cdabc4a3c3) )
 	ROM_LOAD32_BYTE("rf2_2.bin", 0x000001, 0x80000, CRC(ec73a767) SHA1(83f3905afe49401793c0ea0193cb31d3ba1e1739) )
 	ROM_LOAD32_BYTE("rf2_3.bin", 0x000002, 0x80000, CRC(e66243b2) SHA1(54e67af37a4586fd1afc79085ed433d599e1bb87) )
 	ROM_LOAD32_BYTE("rf2_4.bin", 0x000003, 0x80000, CRC(92b7b73e) SHA1(128649b2a6a0616113bd0f9846fb6cf814ae326d) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("rf2_5.bin", 0x000001, 0x10000, CRC(377cac2f) SHA1(f7c9323d79b77f6c8c02ba2c6cdca127d6e5cb5c) )
 	ROM_LOAD24_BYTE("rf2_6.bin", 0x000000, 0x10000, CRC(42bd5372) SHA1(c38df85b25070db9640eac541f71c0511bab0c98) )
 	ROM_LOAD24_BYTE("rf2_7.bin", 0x000002, 0x10000, CRC(1efaac7e) SHA1(8252af56dcb7a6306dc3422070176778e3c511c2) )
 
-	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3717,41 +3758,41 @@ ROM_START( rdft2aa ) /* SPI Cart, Asia (Dream Island license) */
 	ROM_LOAD("obj1.u0429",  0x0c00000, 0x400000, CRC(c2c50f02) SHA1(b81397b5800c6d49f58b7ac7ff6eac56da3c5257) )
 	ROM_LOAD("obj1b.u0430", 0x1000000, 0x200000, CRC(5259321f) SHA1(3c70c1147e49f81371d0f60f7108d9718d56faf4) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("pcm.u0217",    0x000000, 0x100000, CRC(2edc30b5) SHA1(c25d690d633657fc3687636b9070f36bd305ae06) )
 	ROM_CONTINUE(                   0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("sound1.u0222", 0x800000, 0x080000, CRC(b7bd3703) SHA1(6427a7e6de10d6743d6e64b984a1d1c647f5643a) )
 
-	ROM_REGION( 0x0345, "pals", 0 ) /* pals */
+	ROM_REGION( 0x0345, "pals", 0 ) // pals
 	ROM_LOAD("rm81.u0529.bin", 0x0000, 0x0117, CRC(acd55c8e) SHA1(b965e828fecd61b836aca337637e53d7360d9dc4) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm82.u0330.bin", 0x0117, 0x0117, CRC(64c71423) SHA1(1da3502bec0c843b7198d1d9ab60f9fd4b110a8e) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm83.u0331.bin", 0x022e, 0x0117, CRC(6e10d66b) SHA1(995d2a0da680ec19ee253098c91a4780dd8403c6) ) // AMD PALCE16V8H-15SC/4
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region24.u1053", 0x000000, 0x100000, CRC(72a33dc4) SHA1(65a52f576ca4d240418fedd9a4922edcd6c0c8d1) )
 ROM_END
 
-ROM_START( rdft2t ) /* SPI Cart, Taiwan */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rdft2t ) // SPI Cart, Taiwan
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("prg0", 0x000000, 0x80000, CRC(7e8c3acc) SHA1(63f4f9f7df7fa028737d9f7dfae96795cde58541) )
 	ROM_LOAD32_BYTE("prg1", 0x000001, 0x80000, CRC(22cb5b68) SHA1(35f86ad7771fe9aaac3904ed34a96d0cc10ef21c) )
 	ROM_LOAD32_BYTE("prg2", 0x000002, 0x80000, CRC(3eca68dd) SHA1(98378654adf055d72ae685f90e36643c9d6419d7) )
 	ROM_LOAD32_BYTE("prg3", 0x000003, 0x80000, CRC(4124daa4) SHA1(42f225c0328df59ffeacc215d37010f825bf507e) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("rf2_5.bin", 0x000001, 0x10000, CRC(377cac2f) SHA1(f7c9323d79b77f6c8c02ba2c6cdca127d6e5cb5c) )
 	ROM_LOAD24_BYTE("rf2_6.bin", 0x000000, 0x10000, CRC(42bd5372) SHA1(c38df85b25070db9640eac541f71c0511bab0c98) )
 	ROM_LOAD24_BYTE("rf2_7.bin", 0x000002, 0x10000, CRC(1efaac7e) SHA1(8252af56dcb7a6306dc3422070176778e3c511c2) )
 
-	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj3.u0434",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u0431",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -3759,41 +3800,41 @@ ROM_START( rdft2t ) /* SPI Cart, Taiwan */
 	ROM_LOAD("obj1.u0429",  0x0c00000, 0x400000, CRC(c2c50f02) SHA1(b81397b5800c6d49f58b7ac7ff6eac56da3c5257) )
 	ROM_LOAD("obj1b.u0430", 0x1000000, 0x200000, CRC(5259321f) SHA1(3c70c1147e49f81371d0f60f7108d9718d56faf4) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("pcm.u0217",    0x000000, 0x100000, CRC(2edc30b5) SHA1(c25d690d633657fc3687636b9070f36bd305ae06) )
 	ROM_CONTINUE(                   0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("sound1.u0222", 0x800000, 0x080000, CRC(b7bd3703) SHA1(6427a7e6de10d6743d6e64b984a1d1c647f5643a) )
 
-	ROM_REGION( 0x0345, "pals", 0 ) /* pals */
+	ROM_REGION( 0x0345, "pals", 0 ) // pals
 	ROM_LOAD("rm81.u0529.bin", 0x0000, 0x0117, CRC(acd55c8e) SHA1(b965e828fecd61b836aca337637e53d7360d9dc4) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm82.u0330.bin", 0x0117, 0x0117, CRC(64c71423) SHA1(1da3502bec0c843b7198d1d9ab60f9fd4b110a8e) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm83.u0331.bin", 0x022e, 0x0117, CRC(6e10d66b) SHA1(995d2a0da680ec19ee253098c91a4780dd8403c6) ) // AMD PALCE16V8H-15SC/4
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region20.u1053", 0x000000, 0x100000, CRC(f2051161) SHA1(45cbd5fd9ae0ca0c5c3450bca5f6806ddce3c56f) )
 ROM_END
 
-ROM_START( rdft2s ) /* SPI Cart, Switzerland; SPI PCB is marked "(C)1997 SXX2C ROM SUB8" */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program, all are 27C040 */
+ROM_START( rdft2s ) // SPI Cart, Switzerland; SPI PCB is marked "(C)1997 SXX2C ROM SUB8"
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program, all are 27C040
 	ROM_LOAD32_BYTE("seibu__1.u0211", 0x000000, 0x80000, CRC(28b2a185) SHA1(a42adc166992629e96b1ad2fa0859643689fb5c4) ) // socket is silkscreened on pcb PRG1
 	ROM_LOAD32_BYTE("seibu__2.u0212", 0x000001, 0x80000, CRC(cab55d88) SHA1(246e13880d34b6c7c3f4ab5e18fa8a0547c03d9d) ) // socket is silkscreened on pcb PRG2
 	ROM_LOAD32_BYTE("seibu__3.u0221", 0x000002, 0x80000, CRC(83758b0e) SHA1(63adb2d09e7bd7dba47a55b3b579d543dfb553e3) ) // socket is silkscreened on pcb PRG3
 	ROM_LOAD32_BYTE("seibu__4.u0220", 0x000003, 0x80000, CRC(084fb5e4) SHA1(588bfe091662b88f02f528181a2f1d9c67c7b280) ) // socket is silkscreened on pcb PRG4
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms - all are 27C512 */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms - all are 27C512
 	ROM_LOAD24_BYTE("seibu__5.u0524", 0x000001, 0x10000, CRC(6fdf4cf6) SHA1(7e9d4a49e829dfdc373c0f5acfbe8c7a91ac115b) ) // socket is silkscreened on pcb FIX0
 	ROM_LOAD24_BYTE("seibu__6.u0518", 0x000000, 0x10000, CRC(69b7899b) SHA1(d3cacd4ef4d2c95d803403101beb9d4be75fae61) ) // socket is silkscreened on pcb FIX1
 	ROM_LOAD24_BYTE("seibu__7.u0514", 0x000002, 0x10000, CRC(99a5fece) SHA1(44ae95d650ed6e00202d3438f5f91a5e52e319cb) ) // socket is silkscreened on pcb FIXP
 
-	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms - half are MX semiconductor MX23C3210MC, half are some sort of 23C1610 equivalent with no visible manufacturer name */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) // background layer roms - half are MX semiconductor MX23C3210MC, half are some sort of 23C1610 equivalent with no visible manufacturer name
 	ROM_LOAD24_WORD("raiden-f2bg-1d.u0535",   0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) ) // pads are silkscreened on pcb BG12
 	ROM_LOAD24_BYTE("raiden-f2__bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) ) // pads are silkscreened on pcb BG12P
 	ROM_LOAD24_WORD("raiden-f2bg-2d.u0536",   0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) ) // pads are silkscreened on pcb BG3
 	ROM_LOAD24_BYTE("raiden-f2__bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) ) // pads are silkscreened on pcb BG3P
 
-	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites - all are paired MX semconductor MX23C3210TC and MX23C1610TC mask roms */
+	ROM_REGION( 0x1200000, "sprites", 0 ) // sprites - all are paired MX semconductor MX23C3210TC and MX23C1610TC mask roms
 	ROM_LOAD("raiden-f2obj-3.u0434", 0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) ) // pads are silkscreened on pcb OBJ3
 	ROM_LOAD("raiden-f2obj-6.u0433", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) ) // pads are silkscreened on pcb OBJ3B
 	ROM_LOAD("raiden-f2obj-2.u0431", 0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) ) // pads are silkscreened on pcb OBJ2
@@ -3801,247 +3842,247 @@ ROM_START( rdft2s ) /* SPI Cart, Switzerland; SPI PCB is marked "(C)1997 SXX2C R
 	ROM_LOAD("raiden-f2obj-1.u0429", 0x0c00000, 0x400000, CRC(c2c50f02) SHA1(b81397b5800c6d49f58b7ac7ff6eac56da3c5257) ) // pads are silkscreened on pcb OBJ1
 	ROM_LOAD("raiden-f2obj-4.u0430", 0x1000000, 0x200000, CRC(5259321f) SHA1(3c70c1147e49f81371d0f60f7108d9718d56faf4) ) // pads are silkscreened on pcb OBJ1B
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms - sound0 is some sort of 23C1610 equivalent with no visible manufacturer name, sound1 is a 27C040 */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms - sound0 is some sort of 23C1610 equivalent with no visible manufacturer name, sound1 is a 27C040
 	ROM_LOAD32_WORD("raiden-f2__pcm.u0217", 0x000000, 0x100000, CRC(2edc30b5) SHA1(c25d690d633657fc3687636b9070f36bd305ae06) ) // pads are silkscreened on pcb SOUND0
 	ROM_CONTINUE(                           0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("seibu__8.u0222",       0x800000, 0x080000, CRC(b7bd3703) SHA1(6427a7e6de10d6743d6e64b984a1d1c647f5643a) ) // socket is silkscreened on pcb SOUND1
 
-	ROM_REGION( 0x0345, "pals", 0 ) /* pals */
+	ROM_REGION( 0x0345, "pals", 0 ) // pals
 	ROM_LOAD("rm81.u0529.bin", 0x0000, 0x0117, CRC(acd55c8e) SHA1(b965e828fecd61b836aca337637e53d7360d9dc4) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm82.u0330.bin", 0x0117, 0x0117, CRC(64c71423) SHA1(1da3502bec0c843b7198d1d9ab60f9fd4b110a8e) ) // AMD PALCE16V8H-15SC/4
 	ROM_LOAD("rm83.u0331.bin", 0x022e, 0x0117, CRC(6e10d66b) SHA1(995d2a0da680ec19ee253098c91a4780dd8403c6) ) // AMD PALCE16V8H-15SC/4
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region9c.u1053", 0x000000, 0x100000, CRC(d73d640c) SHA1(61a99af2a153de9d53e28872a2493e2ba797a325) )
 ROM_END
 
 
-ROM_START( rfjet ) /* SPI Cart, Europe */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rfjet ) // SPI Cart, Europe
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("prg0.u0211", 0x000000, 0x80000, CRC(e5a3b304) SHA1(f7285f9c69c589fcc71082dc0b9225fdccec855f) )
 	ROM_LOAD32_BYTE("prg1.u0212", 0x000001, 0x80000, CRC(395e6da7) SHA1(736f777cb1b6bf5541832b8ea89594738ca6d829) )
 	ROM_LOAD32_BYTE("prg2.u0221", 0x000002, 0x80000, CRC(82f7a57e) SHA1(5300015e25d5f2f82eda3ed54bc105d645518498) )
 	ROM_LOAD32_BYTE("prg3.u0220", 0x000003, 0x80000, CRC(cbdf100d) SHA1(c9efd11103429f7f36c1652cadb5384d925cb767) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) )
 
-	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0543", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0544", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0545", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0546", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj-1.u0442", 0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u0443", 0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u0444", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("pcm-d.u0227",  0x000000, 0x100000, CRC(8ee3ff45) SHA1(2801b23495866c91c8f8bebd37d5fcae7a625838) )
 	ROM_CONTINUE(                   0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("sound1.u0222", 0x800000, 0x080000, CRC(d4fc3da1) SHA1(a03bd97e36a21d27a834b9691b27a7eb7ac51ff2) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region80.u1053", 0x000000, 0x100000, CRC(e2adaff5) SHA1(9297afaf78209724515d8f78de8cee7bc7cb796b) )
 ROM_END
 
-ROM_START( rfjetj ) /* SPI Cart, Japan */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rfjetj ) // SPI Cart, Japan
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("prg0.bin", 0x000000, 0x80000, CRC(d82fb71f) SHA1(63a458fd007c353f4fae54a4882f5c565fe1efa4) )
 	ROM_LOAD32_BYTE("prg1.bin", 0x000001, 0x80000, CRC(7e21c669) SHA1(731852e5925dccc9d0d1ae4bcafa238f157f4079) )
 	ROM_LOAD32_BYTE("prg2.bin", 0x000002, 0x80000, CRC(2f402d55) SHA1(d0d852239abb6f4d73e263de5544fc0893e7a7ab) )
 	ROM_LOAD32_BYTE("prg3.bin", 0x000003, 0x80000, CRC(d619e2ad) SHA1(9dbff1babf62c3c5478a84d2a82a428de5949154) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) )
 
-	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0543", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0544", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0545", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0546", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj-1.u0442", 0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u0443", 0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u0444", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("pcm-d.u0227",  0x000000, 0x100000, CRC(8ee3ff45) SHA1(2801b23495866c91c8f8bebd37d5fcae7a625838) )
 	ROM_CONTINUE(                   0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("sound1.u0222", 0x800000, 0x080000, CRC(d4fc3da1) SHA1(a03bd97e36a21d27a834b9691b27a7eb7ac51ff2) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region01.u1053", 0x000000, 0x100000, CRC(7ae7ab76) SHA1(a2b196f470bf64af94002fc4e2640fadad00418f) )
 ROM_END
 
-ROM_START( rfjetu ) /* SPI Cart, US */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rfjetu ) // SPI Cart, US
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("prg0u.u0211", 0x000000, 0x80000, CRC(15ac2040) SHA1(7309a9dd9c91fef0e761dcf8639f421ce7abc97f) )
 	ROM_LOAD32_BYTE("prg1.u0212",  0x000001, 0x80000, CRC(395e6da7) SHA1(736f777cb1b6bf5541832b8ea89594738ca6d829) )
 	ROM_LOAD32_BYTE("prg2.u0221",  0x000002, 0x80000, CRC(82f7a57e) SHA1(5300015e25d5f2f82eda3ed54bc105d645518498) )
 	ROM_LOAD32_BYTE("prg3.u0220",  0x000003, 0x80000, CRC(cbdf100d) SHA1(c9efd11103429f7f36c1652cadb5384d925cb767) )
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) )
 
-	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0543", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0544", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0545", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0546", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj-1.u0442", 0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u0443", 0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u0444", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("pcm-d.u0227",  0x000000, 0x100000, CRC(8ee3ff45) SHA1(2801b23495866c91c8f8bebd37d5fcae7a625838) )
 	ROM_CONTINUE(                   0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("sound1.u0222", 0x800000, 0x080000, CRC(d4fc3da1) SHA1(a03bd97e36a21d27a834b9691b27a7eb7ac51ff2) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region10.u1053", 0x000000, 0x100000, CRC(4319d998) SHA1(a064ce647453a9b3bccf7f1d6d0d52b5a72e09dd) )
 ROM_END
 
-ROM_START( rfjeta ) /* SPI Cart, Asia */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rfjeta ) // SPI Cart, Asia
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("prg0a.u0211", 0x000000, 0x80000, CRC(3418d4f5) SHA1(f8766d7b3708a196de417ee757787220b2a9ced1) )
 	ROM_LOAD32_BYTE("prg1.u0212",  0x000001, 0x80000, CRC(395e6da7) SHA1(736f777cb1b6bf5541832b8ea89594738ca6d829) ) // sldh
 	ROM_LOAD32_BYTE("prg2.u0221",  0x000002, 0x80000, CRC(82f7a57e) SHA1(5300015e25d5f2f82eda3ed54bc105d645518498) ) // sldh
 	ROM_LOAD32_BYTE("prg3.u0220",  0x000003, 0x80000, CRC(cbdf100d) SHA1(c9efd11103429f7f36c1652cadb5384d925cb767) ) // sldh
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) )
 
-	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0543", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0544", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0545", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0546", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj-1.u0442", 0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u0443", 0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u0444", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("pcm-d.u0227",  0x000000, 0x100000, CRC(8ee3ff45) SHA1(2801b23495866c91c8f8bebd37d5fcae7a625838) )
 	ROM_CONTINUE(                   0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("sound1.u0222", 0x800000, 0x080000, CRC(d4fc3da1) SHA1(a03bd97e36a21d27a834b9691b27a7eb7ac51ff2) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region24.u1053", 0x000000, 0x100000, CRC(72a33dc4) SHA1(65a52f576ca4d240418fedd9a4922edcd6c0c8d1) )
 ROM_END
 
-ROM_START( rfjett ) /* SPI Cart, Taiwan */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rfjett ) // SPI Cart, Taiwan
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE( "prg0.u0211",   0x000000, 0x080000, CRC(a4734579) SHA1(dfbd8e2a3178c7cfd7bd3698999f14bc80f5212f) ) // sldh
 	ROM_LOAD32_BYTE( "prg1.u0212",   0x000001, 0x080000, CRC(5e4ad3a4) SHA1(ff66e16f48978b88b298c78e21309208ccb3ff15) ) // sldh
 	ROM_LOAD32_BYTE( "prg2.u0221",   0x000002, 0x080000, CRC(21c9942e) SHA1(ededa05a4b5dae2dec5c4409f22e9a66d2c8e98e) ) // sldh
 	ROM_LOAD32_BYTE( "prg3.u0220",   0x000003, 0x080000, CRC(ea3657f4) SHA1(2291e31243af7d2e79ae727d9b5484e8d49cc7d9) ) // sldh
 
-	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) /* 256K RAM, ROM from Z80 point-of-view */
+	ROM_REGION( 0x40000, "audiocpu", ROMREGION_ERASE00 ) // 256K RAM, ROM from Z80 point-of-view
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) )
 
-	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0543", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0544", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0545", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0546", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj-1.u0442", 0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u0443", 0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u0444", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
 
-	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION32_LE( 0xa00000, "sound01", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD32_WORD("pcm-d.u0227",  0x000000, 0x100000, CRC(8ee3ff45) SHA1(2801b23495866c91c8f8bebd37d5fcae7a625838) )
 	ROM_CONTINUE(                   0x400000, 0x100000 )
 	ROM_LOAD32_BYTE("sound1.u0222", 0x800000, 0x080000, CRC(d4fc3da1) SHA1(a03bd97e36a21d27a834b9691b27a7eb7ac51ff2) )
 
-	ROM_REGION( 0x100000, "soundflash1", 0 ) /* on SPI motherboard */
+	ROM_REGION( 0x100000, "soundflash1", 0 ) // on SPI motherboard
 	ROM_LOAD("flash0_blank_region20.u1053", 0x000000, 0x100000, CRC(f2051161) SHA1(45cbd5fd9ae0ca0c5c3450bca5f6806ddce3c56f) )
 ROM_END
 
 
 /*****************************************************************************/
-/* SXX2E/F/G games */
+// SXX2E/F/G games
 
-ROM_START( rdfts ) /* Single board version SXX2E Ver3.0 */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rdfts ) // Single board version SXX2E Ver3.0
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("seibu_1.u0259",        0x000000, 0x080000, CRC(e278dddd) SHA1(fe54a0d0f9e8596268f7f37e85d71c5c2d8b2846) ) // socket is silkscreened on pcb PRG0
 	ROM_LOAD32_BYTE("raiden-f_prg2.u0258",  0x000001, 0x080000, CRC(58ccb10c) SHA1(0cce4057bfada78121d9586574b98d46cdd7dd46) ) // socket is silkscreened on pcb PRG1
 	ROM_LOAD32_WORD("raiden-f_prg34.u0262", 0x000002, 0x100000, CRC(63f01d17) SHA1(74dbd0417b974583da87fc6c7a081b03fd4e16b8) ) // socket is silkscreened on pcb PRG23
 
-	ROM_REGION( 0x40000, "audiocpu", 0 ) /* 256K ROM for the Z80 */
+	ROM_REGION( 0x40000, "audiocpu", 0 ) // 256K ROM for the Z80
 	ROM_LOAD("seibu_zprg.u1139", 0x000000, 0x20000, CRC(c1fda3e8) SHA1(c1d3a7ba0601a80534ec32249de71d33a828a162) ) // pads are silkscreened ZPRG
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_WORD("raiden-f_fix.u0535", 0x000000, 0x20000, CRC(2be2936b) SHA1(9e719f7328a52af220b6f084c1e0990ca6e2d533) ) // socket is silkscreened on pcb FIX01
 	ROM_LOAD24_BYTE("seibu_fix2.u0528",   0x000002, 0x10000, CRC(4d87e1ea) SHA1(3230e9b643fad773e61ab8ce09c0cd7d4d0558e3) ) // socket is silkscreened on pcb FIX2
 
-	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x600000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("gun_dogs_bg1-d.u0526", 0x000000, 0x200000, CRC(6a68054c) SHA1(5cbfc4ac90045f1401c2dda7a51936558c9de07e) ) // pads are silkscreened on pcb BG12
 	ROM_LOAD24_BYTE("gun_dogs_bg1-p.u0531", 0x000002, 0x100000, CRC(3400794a) SHA1(719808f7442bac612cefd7b7fffcd665e6337ad0) ) // pads are silkscreened on pcb BG12P
 	ROM_LOAD24_WORD("gun_dogs_bg2-d.u0534", 0x300000, 0x200000, CRC(61cd2991) SHA1(bb608e3948bf9ea35b5e1615d2ba6858d029dcbe) ) // pads are silkscreened on pcb BG3
 	ROM_LOAD24_BYTE("gun_dogs_bg2-p.u0530", 0x300002, 0x100000, CRC(502d5799) SHA1(c3a0e1a4f5a7b35572ae1ff31315da4ed08aa2fe) ) // pads are silkscreened on pcb BG3P
 
-	ROM_REGION( 0xc00000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0xc00000, "sprites", 0 ) // sprites
 	ROM_LOAD("gun_dogs_obj-1.u0322", 0x000000, 0x400000, CRC(59d86c99) SHA1(d3c9241e7b51fe21f8351051b063f91dc69bf905) ) // pads are silkscreened on pcb OBJ1
 	ROM_LOAD("gun_dogs_obj-2.u0324", 0x400000, 0x400000, CRC(1ceb0b6f) SHA1(97225a9b3e7be18080aa52f6570af2cce8f25c06) ) // pads are silkscreened on pcb OBJ2
 	ROM_LOAD("gun_dogs_obj-3.u0323", 0x800000, 0x400000, CRC(36e93234) SHA1(51917a80b7da5c32a9434a1076fc2916d62e6a3e) ) // pads are silkscreened on pcb OBJ3
 
-	ROM_REGION( 0x200000, "ymf", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION( 0x200000, "ymf", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD("raiden-f_pcm2.u0975", 0x000000, 0x200000, CRC(3f8d4a48) SHA1(30664a2908daaeaee58f7e157516b522c952e48d) ) // pads are silkscreened SOUND0
-	/* SOUND1 socket is unpopulated */
+	// SOUND1 socket is unpopulated
 ROM_END
 
 
-ROM_START( rdft2us ) /* Single board version SXX2F */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rdft2us ) // Single board version SXX2F
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("prg0.u0259", 0x000000, 0x80000, CRC(ff3eeec1) SHA1(88c1741e4936db9a5b13e562061b0f1cc6fa6b36) )
 	ROM_LOAD32_BYTE("prg1.u0258", 0x000001, 0x80000, CRC(e2cf77d6) SHA1(173cc0e304c9dadea4ed0812ebb64c6c83549912) )
 	ROM_LOAD32_BYTE("prg2.u0265", 0x000002, 0x80000, CRC(cae87e1f) SHA1(e460aad693eb2702ae11f758b11d37f852d00790) )
 	ROM_LOAD32_BYTE("prg3.u0264", 0x000003, 0x80000, CRC(83f4fb5f) SHA1(73f58daa1aae0c4978db409cedd736fb49b15f1c) )
 
-	ROM_REGION( 0x40000, "audiocpu", 0 ) /* 256K ROM for the Z80 */
+	ROM_REGION( 0x40000, "audiocpu", 0 ) // 256K ROM for the Z80
 	ROM_LOAD("zprg.u091", 0x000000, 0x20000, CRC(cc543c4f) SHA1(6e5c93fd3d21c594571b071d4a830211e1f162b2) )
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("fix0.u0524", 0x000001, 0x10000, CRC(6fdf4cf6) SHA1(7e9d4a49e829dfdc373c0f5acfbe8c7a91ac115b) )
 	ROM_LOAD24_BYTE("fix1.u0518", 0x000000, 0x10000, CRC(69b7899b) SHA1(d3cacd4ef4d2c95d803403101beb9d4be75fae61) )
 	ROM_LOAD24_BYTE("fixp.u0514", 0x000002, 0x10000, CRC(99a5fece) SHA1(44ae95d650ed6e00202d3438f5f91a5e52e319cb) )
 
-	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.u0538", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj3.u075",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj3b.u078", 0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.u074",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -4049,41 +4090,41 @@ ROM_START( rdft2us ) /* Single board version SXX2F */
 	ROM_LOAD("obj1.u073",  0x0c00000, 0x400000, CRC(c2c50f02) SHA1(b81397b5800c6d49f58b7ac7ff6eac56da3c5257) )
 	ROM_LOAD("obj1b.u076", 0x1000000, 0x200000, CRC(5259321f) SHA1(3c70c1147e49f81371d0f60f7108d9718d56faf4) )
 
-	ROM_REGION( 0x280000, "ymf", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION( 0x280000, "ymf", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD("pcm.u0103",    0x000000, 0x200000, CRC(2edc30b5) SHA1(c25d690d633657fc3687636b9070f36bd305ae06) )
-	ROM_LOAD("sound1.u0107", 0x200000, 0x080000, CRC(20384b0e) SHA1(9c5d725418543df740f9145974ed6ffbbabee1d0) ) /* Different sound1 than SPI carts */
+	ROM_LOAD("sound1.u0107", 0x200000, 0x080000, CRC(20384b0e) SHA1(9c5d725418543df740f9145974ed6ffbbabee1d0) ) // Different sound1 than SPI carts
 ROM_END
 
 
-ROM_START( rfjets ) /* Single board version SXX2G */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
-	ROM_LOAD32_BYTE("rfj-06.u0259", 0x000000, 0x80000, CRC(c835aa7a) SHA1(291eada97ceb907dfea15688ce6055e63b3aa675) ) /* PRG0 */
-	ROM_LOAD32_BYTE("rfj-07.u0258", 0x000001, 0x80000, CRC(3b6ca1ca) SHA1(9db019c0ddecfb58e2be5c345d78352f700035bf) ) /* PRG1 */
-	ROM_LOAD32_BYTE("rfj-08.u0265", 0x000002, 0x80000, CRC(1f5dd06c) SHA1(6f5a8c9035971a470212cd0a89b94181011602c3) ) /* PRG2 */
-	ROM_LOAD32_BYTE("rfj-09.u0264", 0x000003, 0x80000, CRC(cc71c402) SHA1(b040e600744e7b3f52de0fa852ce3ae08ae49985) ) /* PRG3 */
+ROM_START( rfjets ) // Single board version SXX2G
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
+	ROM_LOAD32_BYTE("rfj-06.u0259", 0x000000, 0x80000, CRC(c835aa7a) SHA1(291eada97ceb907dfea15688ce6055e63b3aa675) ) // PRG0
+	ROM_LOAD32_BYTE("rfj-07.u0258", 0x000001, 0x80000, CRC(3b6ca1ca) SHA1(9db019c0ddecfb58e2be5c345d78352f700035bf) ) // PRG1
+	ROM_LOAD32_BYTE("rfj-08.u0265", 0x000002, 0x80000, CRC(1f5dd06c) SHA1(6f5a8c9035971a470212cd0a89b94181011602c3) ) // PRG2
+	ROM_LOAD32_BYTE("rfj-09.u0264", 0x000003, 0x80000, CRC(cc71c402) SHA1(b040e600744e7b3f52de0fa852ce3ae08ae49985) ) // PRG3
 
-	ROM_REGION( 0x40000, "audiocpu", 0 ) /* 256K ROM for the Z80 */
-	ROM_LOAD("rfj-05.u091", 0x000000, 0x40000, CRC(a55e8799) SHA1(5d4ca9ae920ab54e23ee3b1b33db72711e744516) ) /* ZPRG */
+	ROM_REGION( 0x40000, "audiocpu", 0 ) // 256K ROM for the Z80
+	ROM_LOAD("rfj-05.u091", 0x000000, 0x40000, CRC(a55e8799) SHA1(5d4ca9ae920ab54e23ee3b1b33db72711e744516) ) // ZPRG
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
-	ROM_LOAD24_BYTE("rfj-01.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) ) /* FIX0 */
-	ROM_LOAD24_BYTE("rfj-02.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) ) /* FIX1 */
-	ROM_LOAD24_BYTE("rfj-03.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) ) /* FIXP */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
+	ROM_LOAD24_BYTE("rfj-01.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) ) // FIX0
+	ROM_LOAD24_BYTE("rfj-02.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) ) // FIX1
+	ROM_LOAD24_BYTE("rfj-03.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) ) // FIXP
 
-	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0545", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj-1.u073", 0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u074", 0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u075", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
 
-	ROM_REGION( 0x280000, "ymf", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION( 0x280000, "ymf", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD("pcm-d.u0103",  0x000000, 0x200000, CRC(8ee3ff45) SHA1(2801b23495866c91c8f8bebd37d5fcae7a625838) )
-	ROM_LOAD("rfj-04.u0107", 0x200000, 0x080000, CRC(c050da03) SHA1(1002dac51a3a4932c4f0074c1f3d97a597d98755) ) /* SOUND1 */
+	ROM_LOAD("rfj-04.u0107", 0x200000, 0x080000, CRC(c050da03) SHA1(1002dac51a3a4932c4f0074c1f3d97a597d98755) ) // SOUND1
 
 	ROM_REGION16_BE( 0x80, "eeprom", 0 )
 	ROM_LOAD16_WORD( "st93c46.bin", 0x0000, 0x0080, CRC(8fe8063b) SHA1(afb0141580e1b2bd149092a9cc9e8b4072b1ef10) )
@@ -4097,58 +4138,58 @@ ROM_END
  - Adds Sound Test and EEPROM Test to the Test Mode menu
  - Misc. debug strings and bugs (see MT 5211)
 */
-ROM_START( rfjetsa ) /* Single board version SXX2G */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
-	ROM_LOAD32_BYTE("rfj-06.u0259", 0x000000, 0x80000, CRC(b0c8d47e) SHA1(1dde30d25f9e8eaa301343ae1d272b5c0044bc1f) ) /* PRG0 */ // sldh
-	ROM_LOAD32_BYTE("rfj-07.u0258", 0x000001, 0x80000, CRC(17189b39) SHA1(6471170ae770d762e15f1503ef9a6832c202da6c) ) /* PRG1 */ // sldh
-	ROM_LOAD32_BYTE("rfj-08.u0265", 0x000002, 0x80000, CRC(ab6d724b) SHA1(ef7e42b1bf649a354fe22b0edd00475ced4151be) ) /* PRG2 */ // sldh
-	ROM_LOAD32_BYTE("rfj-09.u0264", 0x000003, 0x80000, CRC(b119a67c) SHA1(4fa7dd0e86a3f7c6efa6ae9cf72991b652c877b9) ) /* PRG3 */ // sldh
+ROM_START( rfjetsa ) // Single board version SXX2G
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
+	ROM_LOAD32_BYTE("rfj-06.u0259", 0x000000, 0x80000, CRC(b0c8d47e) SHA1(1dde30d25f9e8eaa301343ae1d272b5c0044bc1f) ) // PRG0 // sldh
+	ROM_LOAD32_BYTE("rfj-07.u0258", 0x000001, 0x80000, CRC(17189b39) SHA1(6471170ae770d762e15f1503ef9a6832c202da6c) ) // PRG1 // sldh
+	ROM_LOAD32_BYTE("rfj-08.u0265", 0x000002, 0x80000, CRC(ab6d724b) SHA1(ef7e42b1bf649a354fe22b0edd00475ced4151be) ) // PRG2 // sldh
+	ROM_LOAD32_BYTE("rfj-09.u0264", 0x000003, 0x80000, CRC(b119a67c) SHA1(4fa7dd0e86a3f7c6efa6ae9cf72991b652c877b9) ) // PRG3 // sldh
 
-	ROM_REGION( 0x40000, "audiocpu", 0 ) /* 256K ROM for the Z80 */
-	ROM_LOAD("rfj-05.u091", 0x000000, 0x40000, CRC(a55e8799) SHA1(5d4ca9ae920ab54e23ee3b1b33db72711e744516) ) /* ZPRG */
+	ROM_REGION( 0x40000, "audiocpu", 0 ) // 256K ROM for the Z80
+	ROM_LOAD("rfj-05.u091", 0x000000, 0x40000, CRC(a55e8799) SHA1(5d4ca9ae920ab54e23ee3b1b33db72711e744516) ) // ZPRG
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
-	ROM_LOAD24_BYTE("rfj-01.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) ) /* FIX0 */
-	ROM_LOAD24_BYTE("rfj-02.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) ) /* FIX1 */
-	ROM_LOAD24_BYTE("rfj-03.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) ) /* FIXP */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
+	ROM_LOAD24_BYTE("rfj-01.u0524", 0x000001, 0x10000, CRC(8bc080be) SHA1(ad296fb98242c963072346a8de289e704b445ad4) ) // FIX0
+	ROM_LOAD24_BYTE("rfj-02.u0518", 0x000000, 0x10000, CRC(bded85e7) SHA1(ccb8c438ce6b9a742e3ab15be970b1e636783626) ) // FIX1
+	ROM_LOAD24_BYTE("rfj-03.u0514", 0x000002, 0x10000, CRC(015d0748) SHA1(b1e8eaeba63a7914f1dc27d7e3ca5d0b6db202ed) ) // FIXP
 
-	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0x900000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0545", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj-1.u073", 0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u074", 0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u075", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
 
-	ROM_REGION( 0x280000, "ymf", ROMREGION_ERASE00 ) /* sound roms */
+	ROM_REGION( 0x280000, "ymf", ROMREGION_ERASE00 ) // sound roms
 	ROM_LOAD("pcm-d.u0103",  0x000000, 0x200000, CRC(8ee3ff45) SHA1(2801b23495866c91c8f8bebd37d5fcae7a625838) )
-	ROM_LOAD("rfj-04.u0107", 0x200000, 0x080000, CRC(c050da03) SHA1(1002dac51a3a4932c4f0074c1f3d97a597d98755) ) /* SOUND1 */
+	ROM_LOAD("rfj-04.u0107", 0x200000, 0x080000, CRC(c050da03) SHA1(1002dac51a3a4932c4f0074c1f3d97a597d98755) ) // SOUND1
 ROM_END
 
 
 /*****************************************************************************/
-/* SYS386 games */
+// SYS386 games
 
-ROM_START( rdft22kc ) /* SYS386I */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rdft22kc ) // SYS386I
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_WORD("prg0-1.267", 0x000000, 0x100000, CRC(0d7d6eb8) SHA1(3a71e1e0ba5bb500dc026debbb6189723c0c2890) )
 	ROM_LOAD32_WORD("prg2-3.266", 0x000002, 0x100000, CRC(ead53e69) SHA1(b0e2e06f403317054ecb48d2747034424245f129) )
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("fix0.524", 0x000001, 0x10000, CRC(ed11d043) SHA1(fd3a5a33aa4d795941d64c0d23f9d6f8222843e3) )
 	ROM_LOAD24_BYTE("fix1.518", 0x000000, 0x10000, CRC(7036d70a) SHA1(3535b52c0fa1a1158cacc041f8aba2b9a1b43af5) )
 	ROM_LOAD24_BYTE("fix2.514", 0x000002, 0x10000, CRC(29b465da) SHA1(644454ab5e0dc1028e9512f85adfe5d8adb757de) )
 
-	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.535", 0x000000, 0x400000, CRC(6143f576) SHA1(c034923d0663d9ef24357a03098b8cb81dbab9f8) )
 	ROM_LOAD24_BYTE("bg-1p.544", 0x000002, 0x200000, CRC(55e64ef7) SHA1(aae991268948d07342ee8ba1b3761bd180aab8ec) )
 	ROM_LOAD24_WORD("bg-2d.536", 0x600000, 0x400000, CRC(c607a444) SHA1(dc1aa96a42e9394ca6036359670a4ec6f830c96d) )
 	ROM_LOAD24_BYTE("bg-2p.545", 0x600002, 0x200000, CRC(f0830248) SHA1(6075df96b49e70d2243fef691e096119e7a4d044) )
 
-	ROM_REGION( 0x1200000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1200000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj3.075",  0x0000000, 0x400000, CRC(e08f42dc) SHA1(5188d71d4355eaf43ea8893b4cfc4fe80cc24f41) )
 	ROM_LOAD("obj6.078",  0x0400000, 0x200000, CRC(1b6a523c) SHA1(99a420dbc8e22e7832ccda7cec9fa661a2a2687a) )
 	ROM_LOAD("obj2.074",  0x0600000, 0x400000, CRC(7aeadd8e) SHA1(47103c0579240c5b1add4d0b164eaf76f5fa97f0) )
@@ -4156,51 +4197,51 @@ ROM_START( rdft22kc ) /* SYS386I */
 	ROM_LOAD("obj1.073",  0x0c00000, 0x400000, CRC(c2c50f02) SHA1(b81397b5800c6d49f58b7ac7ff6eac56da3c5257) )
 	ROM_LOAD("obj4.076",  0x1000000, 0x200000, CRC(5259321f) SHA1(3c70c1147e49f81371d0f60f7108d9718d56faf4) )
 
-	ROM_REGION( 0x80000, "oki1", 0 ) /* sound data for MSM6295 */
+	ROM_REGION( 0x80000, "oki1", 0 ) // sound data for MSM6295
 	ROM_LOAD("pcm0.1022", 0x000000, 0x80000, CRC(fd599b35) SHA1(00c0307d1b503bd5ce02d7960ce5e1ad600a7290) )
 
-	ROM_REGION( 0x80000, "oki2", 0 ) /* sound data for MSM6295 */
+	ROM_REGION( 0x80000, "oki2", 0 ) // sound data for MSM6295
 	ROM_LOAD("pcm1.1023", 0x000000, 0x80000, CRC(8b716356) SHA1(42ee1896c02518cd1e9cb0dc130321834665a79e) )
 ROM_END
 
 
-ROM_START( rfjet2kc ) /* SYS386I */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( rfjet2kc ) // SYS386I
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_WORD("prg01.u267", 0x000000, 0x100000, CRC(36019fa8) SHA1(28baf0ed4a53b818c1e6986d5d3491373524eca1) )
 	ROM_LOAD32_WORD("prg23.u266", 0x000002, 0x100000, CRC(65695dde) SHA1(1b25dde03bc9319414144fc13b34c455112f4076) )
 
-	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) /* text layer roms */
+	ROM_REGION( 0x30000, "chars", ROMREGION_ERASEFF ) // text layer roms
 	ROM_LOAD24_BYTE("rfj-01.524", 0x000001, 0x10000, CRC(e9d53007) SHA1(29aa7b70d5d5eb5e31426ac84143be44bc0597aa) )
 	ROM_LOAD24_BYTE("rfj-02.518", 0x000000, 0x10000, CRC(dd3eabd3) SHA1(31c8f7a0cd262096a77673b040326605db542ab8) )
 	ROM_LOAD24_BYTE("rfj-03.514", 0x000002, 0x10000, CRC(0daa8aac) SHA1(08a98fb3079ea9f78aa5b950bfeb30b0a805bab7) )
 
-	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) /* background layer roms */
+	ROM_REGION( 0xc00000, "tiles", ROMREGION_ERASEFF ) // background layer roms
 	ROM_LOAD24_WORD("bg-1d.u0535", 0x000000, 0x400000, CRC(edfd96da) SHA1(4813267f104619f569e5777e75b75304321abb49) )
 	ROM_LOAD24_BYTE("bg-1p.u0537", 0x000002, 0x200000, CRC(a4cc4631) SHA1(cc1c4f4de8a078ca774f5a328a9a58291949b1fb) )
 	ROM_LOAD24_WORD("bg-2d.u0536", 0x600000, 0x200000, CRC(731fbb59) SHA1(13cd29ec4d4c73582c5fb363218e737886826e5f) )
 	ROM_LOAD24_BYTE("bg-2p.u0547", 0x600002, 0x100000, CRC(03652c25) SHA1(c0d77285111bc84e008362981ac02a246678ed0a) )
 
-	ROM_REGION( 0x1800000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1800000, "sprites", 0 ) // sprites
 	ROM_LOAD("obj-1.u073",  0x0000000, 0x800000, CRC(58a59896) SHA1(edeaaa69987bd5d08c47ed9bf47a3901e2dcc892) )
 	ROM_LOAD("obj-2.u074",  0x0800000, 0x800000, CRC(a121d1e3) SHA1(1851ae81f2ae9d3404aadd9fbc0ed7f9230290b9) )
 	ROM_LOAD("obj-3.u0749", 0x1000000, 0x800000, CRC(bc2c0c63) SHA1(c8d395722f7012c3be366a0fc9b224c537afabae) )
 
-	ROM_REGION( 0x80000, "oki1", 0 ) /* sound data for MSM6295 */
+	ROM_REGION( 0x80000, "oki1", 0 ) // sound data for MSM6295
 	ROM_LOAD("rfj-05.u1022", 0x000000, 0x80000, CRC(fd599b35) SHA1(00c0307d1b503bd5ce02d7960ce5e1ad600a7290) )
 
-	ROM_REGION( 0x80000, "oki2", 0 ) /* sound data for MSM6295 */
+	ROM_REGION( 0x80000, "oki2", 0 ) // sound data for MSM6295
 	ROM_LOAD("rfj-04.u1023", 0x000000, 0x80000, CRC(1d10cd08) SHA1(c431d3f1a7b580024b083dafb76c53b771c88726) )
 ROM_END
 
 
-ROM_START( ejsakura ) /* SYS386F V2.0 */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( ejsakura ) // SYS386F V2.0
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("prg0.211",  0x100000, 0x40000, CRC(199f2f08) SHA1(096afb23f2763b9aee5e8de3870fe47116a8d134) )
 	ROM_LOAD32_BYTE("prg1.212",  0x100001, 0x40000, CRC(2cb636e6) SHA1(3524231a336de5acc93dff20b0b65ade31e27116) )
 	ROM_LOAD32_BYTE("prg2.221",  0x100002, 0x40000, CRC(98a7b615) SHA1(ea34d8f3e9200a6d84efe9168e2f573ec5c2afd2) )
 	ROM_LOAD32_BYTE("prg3.220",  0x100003, 0x40000, CRC(9c3c037a) SHA1(a802e13a0b827896342d9d34dbb00d1c36cabaff) )
 
-	ROM_REGION( 0x1000000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1000000, "sprites", 0 ) // sprites
 	ROM_LOAD16_WORD_SWAP("chr4.445", 0x000000, 0x400000, CRC(40c6c238) SHA1(0d07b59e25632feb070ce0e572ae75f9bb939893) )
 	ROM_LOAD16_WORD_SWAP("chr3.444", 0x400000, 0x400000, CRC(8e5d1de5) SHA1(c1ccb6b4341ee1e939958ec9e68280c6faa2ef1f) )
 	ROM_LOAD16_WORD_SWAP("chr2.443", 0x800000, 0x400000, CRC(638dc9ae) SHA1(0c11b1e688733fbaeabf83b33410714c22ae53cd) )
@@ -4211,14 +4252,14 @@ ROM_START( ejsakura ) /* SYS386F V2.0 */
 	ROM_LOAD("sound2.84",  0x800000, 0x800000, CRC(ff37e769) SHA1(eb6d260cbc4e4a925a5d8f604ec695e567ac6bb5) )
 ROM_END
 
-ROM_START( ejsakura12 ) /* SYS386F V1.2 */
-	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) /* i386 program */
+ROM_START( ejsakura12 ) // SYS386F V1.2
+	ROM_REGION32_LE( 0x200000, "maincpu", 0 ) // i386 program
 	ROM_LOAD32_BYTE("prg0v1.2.u0211",  0x100000, 0x40000, CRC(c734fde6) SHA1(d4256f0d2be624fc0e5340ae14679679e5e184c8) )
 	ROM_LOAD32_BYTE("prg1v1.2.u0212",  0x100001, 0x40000, CRC(fb7a9e38) SHA1(5a2e02e1b8ed71ffc96dbda871618f5f9cccc8c6) )
 	ROM_LOAD32_BYTE("prg2v1.2.u0221",  0x100002, 0x40000, CRC(e13098ad) SHA1(abf471afd25a08ba1848964c988112c86d1dcfaa) )
 	ROM_LOAD32_BYTE("prg3v1.2.u0220",  0x100003, 0x40000, CRC(29b5460f) SHA1(c9cb0eb421a79b722bf5a0dc428d0f5f8499e170) )
 
-	ROM_REGION( 0x1000000, "sprites", 0 ) /* sprites */
+	ROM_REGION( 0x1000000, "sprites", 0 ) // sprites
 	ROM_LOAD16_WORD_SWAP("chr4.445", 0x000000, 0x400000, CRC(40c6c238) SHA1(0d07b59e25632feb070ce0e572ae75f9bb939893) )
 	ROM_LOAD16_WORD_SWAP("chr3.444", 0x400000, 0x400000, CRC(8e5d1de5) SHA1(c1ccb6b4341ee1e939958ec9e68280c6faa2ef1f) )
 	ROM_LOAD16_WORD_SWAP("chr2.443", 0x800000, 0x400000, CRC(638dc9ae) SHA1(0c11b1e688733fbaeabf83b33410714c22ae53cd) )
@@ -4232,88 +4273,88 @@ ROM_END
 
 /*****************************************************************************/
 
-/* SPI */
-GAME( 1995, senkyu,     0,        spi,     spi_3button, seibuspi_state, init_senkyu,   ROT0,   "Seibu Kaihatsu",                         "Senkyu (Japan, newer)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, senkyua,    senkyu,   spi,     spi_3button, seibuspi_state, init_senkyua,  ROT0,   "Seibu Kaihatsu",                         "Senkyu (Japan, earlier)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, batlball,   senkyu,   spi,     spi_3button, seibuspi_state, init_batlball, ROT0,   "Seibu Kaihatsu (Tuning license)",        "Battle Balls (Germany, newer)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, batlballo,  senkyu,   spi,     spi_3button, seibuspi_state, init_batlball, ROT0,   "Seibu Kaihatsu (Tuning license)",        "Battle Balls (Germany, earlier)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, batlballu,  senkyu,   spi,     spi_3button, seibuspi_state, init_batlball, ROT0,   "Seibu Kaihatsu (Fabtek license)",        "Battle Balls (US)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, batlballa,  senkyu,   spi,     spi_3button, seibuspi_state, init_batlball, ROT0,   "Seibu Kaihatsu (Metrotainment license)", "Battle Balls (Hong Kong)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, batlballe,  senkyu,   spi,     spi_3button, seibuspi_state, init_batlball, ROT0,   "Seibu Kaihatsu (Metrotainment license)", "Battle Balls (Hong Kong, earlier)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, batlballpt, senkyu,   spi,     spi_3button, seibuspi_state, init_senkyua,  ROT0,   "Seibu Kaihatsu",                         "Battle Balls (Portugal)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS ) // 1 program ROM dated 171195
+// SPI
+GAME( 1995, senkyu,     0,        spi,     spi_3button, seibuspi_state, init_senkyu,   ROT0,   "Seibu Kaihatsu",                         "Senkyu (Japan, newer)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, senkyua,    senkyu,   spi,     spi_3button, seibuspi_state, init_senkyua,  ROT0,   "Seibu Kaihatsu",                         "Senkyu (Japan, earlier)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, batlball,   senkyu,   spi,     spi_3button, seibuspi_state, init_batlball, ROT0,   "Seibu Kaihatsu (Tuning license)",        "Battle Balls (Germany, newer)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, batlballo,  senkyu,   spi,     spi_3button, seibuspi_state, init_batlball, ROT0,   "Seibu Kaihatsu (Tuning license)",        "Battle Balls (Germany, earlier)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, batlballu,  senkyu,   spi,     spi_3button, seibuspi_state, init_batlball, ROT0,   "Seibu Kaihatsu (Fabtek license)",        "Battle Balls (US)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, batlballa,  senkyu,   spi,     spi_3button, seibuspi_state, init_batlball, ROT0,   "Seibu Kaihatsu (Metrotainment license)", "Battle Balls (Hong Kong)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, batlballe,  senkyu,   spi,     spi_3button, seibuspi_state, init_batlball, ROT0,   "Seibu Kaihatsu (Metrotainment license)", "Battle Balls (Hong Kong, earlier)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, batlballpt, senkyu,   spi,     spi_3button, seibuspi_state, init_senkyua,  ROT0,   "Seibu Kaihatsu",                         "Battle Balls (Portugal)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS ) // 1 program ROM dated 171195
 
 // these are unique
-GAME( 1995, viprp1,     0,        spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu",                         "Viper Phase 1 (New Version, World)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, viprp1k,    viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu (Dream Island license)",  "Viper Phase 1 (New Version, Korea)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, viprp1u,    viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1o,  ROT270, "Seibu Kaihatsu (Fabtek license)",        "Viper Phase 1 (New Version, US set 1)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS ) /* New version, "=U.S.A=" seems part of title */
-GAME( 1995, viprp1ua,   viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1o,  ROT270, "Seibu Kaihatsu (Fabtek license)",        "Viper Phase 1 (New Version, US set 2)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS ) /* New version, "=U.S.A=" seems part of title */
-GAME( 1995, viprp1j,    viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu",                         "Viper Phase 1 (New Version, Japan)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, viprp1,     0,        spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu",                         "Viper Phase 1 (New Version, World)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, viprp1k,    viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu (Dream Island license)",  "Viper Phase 1 (New Version, Korea)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, viprp1u,    viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1o,  ROT270, "Seibu Kaihatsu (Fabtek license)",        "Viper Phase 1 (New Version, US set 1)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS ) // New version, "=U.S.A=" seems part of title
+GAME( 1995, viprp1ua,   viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1o,  ROT270, "Seibu Kaihatsu (Fabtek license)",        "Viper Phase 1 (New Version, US set 2)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS ) // New version, "=U.S.A=" seems part of title
+GAME( 1995, viprp1j,    viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu",                         "Viper Phase 1 (New Version, Japan)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
 // same code revision (010995 code base) - SXX2C ROM SUB cart
 // counterintuitively this seems to be the oldest code base of the game despite playing with the 'new version' rules, it has various typos not present in other sets eg. 'UPDATEING'
-GAME( 1995, viprp1s,    viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu",                         "Viper Phase 1 (New Version, Switzerland)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, viprp1h,    viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu",                         "Viper Phase 1 (New Version, Holland)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, viprp1t,    viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu (Tuning license)",        "Viper Phase 1 (New Version, Germany)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, viprp1pt,   viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu",                         "Viper Phase 1 (New Version, Portugal)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, viprp1s,    viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu",                         "Viper Phase 1 (New Version, Switzerland)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, viprp1h,    viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu",                         "Viper Phase 1 (New Version, Holland)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, viprp1t,    viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu (Tuning license)",        "Viper Phase 1 (New Version, Germany)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, viprp1pt,   viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu",                         "Viper Phase 1 (New Version, Portugal)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
 // these are unique
-GAME( 1995, viprp1ot,   viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu (Tuning license)",        "Viper Phase 1 (Germany)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, viprp1oj,   viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1o,  ROT270, "Seibu Kaihatsu",                         "Viper Phase 1 (Japan)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, viprp1hk,   viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu (Metrotainment license)", "Viper Phase 1 (Hong Kong)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS ) /* "=HONG KONG=" seems part of title */
+GAME( 1995, viprp1ot,   viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu (Tuning license)",        "Viper Phase 1 (Germany)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, viprp1oj,   viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1o,  ROT270, "Seibu Kaihatsu",                         "Viper Phase 1 (Japan)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, viprp1hk,   viprp1,   spi,     spi_3button, seibuspi_state, init_viprp1,   ROT270, "Seibu Kaihatsu (Metrotainment license)", "Viper Phase 1 (Hong Kong)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS ) // "=HONG KONG=" seems part of title
 
-GAME( 1996, ejanhs,     0,        ejanhs,  spi_ejanhs,  seibuspi_state, init_ejanhs,   ROT0,   "Seibu Kaihatsu",                         "E Jong High School (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1996, ejanhs,     0,        ejanhs,  spi_ejanhs,  seibuspi_state, init_ejanhs,   ROT0,   "Seibu Kaihatsu",                         "E Jong High School (Japan)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
 // these are unique
-GAME( 1996, rdft,       0,        spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu (Tuning license)",        "Raiden Fighters (Germany)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1996, rdftj,      rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Japan, earlier)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1996, rdftja,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Japan, earliest)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1996, rdftu,      rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu (Fabtek license)",        "Raiden Fighters (US, earlier)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1996, rdftauge,   rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu (Tuning license)",        "Raiden Fighters (Evaluation Software For Show, Germany)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, rdft,       0,        spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu (Tuning license)",        "Raiden Fighters (Germany)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, rdftj,      rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Japan, earlier)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, rdftja,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Japan, earliest)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, rdftu,      rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu (Fabtek license)",        "Raiden Fighters (US, earlier)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, rdftauge,   rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu (Tuning license)",        "Raiden Fighters (Evaluation Software For Show, Germany)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
 // this is one revision - SXX2C ROM SUB4 cart
-GAME( 1996, rdftua,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu (Fabtek license)",        "Raiden Fighters (US, newer)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1996, rdftjb,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Japan, newer)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1996, rdftau,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Australia)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1996, rdftam,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu (Metrotainment license)", "Raiden Fighters (Hong Kong)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1996, rdftadi,    rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu (Dream Island license)",  "Raiden Fighters (Korea)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, rdftua,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu (Fabtek license)",        "Raiden Fighters (US, newer)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, rdftjb,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Japan, newer)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, rdftau,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Australia)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, rdftam,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu (Metrotainment license)", "Raiden Fighters (Hong Kong)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, rdftadi,    rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu (Dream Island license)",  "Raiden Fighters (Korea)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
 // same code revision - SXX2C ROM SUB2 cart
-GAME( 1996, rdfta,      rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Austria)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1996, rdftgb,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Great Britain)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1996, rdftgr,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Greece)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1996, rdftit,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Italy)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, rdfta,      rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Austria)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, rdftgb,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Great Britain)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, rdftgr,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Greece)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1996, rdftit,     rdft,     spi,     spi_3button, seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu",                         "Raiden Fighters (Italy)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
 
 // this is one revision
-GAME( 1997, rdft2,      0,        rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu (Tuning license)",        "Raiden Fighters 2 - Operation Hell Dive (Germany)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1997, rdft2j,     rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters 2 - Operation Hell Dive (Japan set 1)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1997, rdft2a,     rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu (Metrotainment license)", "Raiden Fighters 2 - Operation Hell Dive (Hong Kong)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1997, rdft2s,     rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters 2 - Operation Hell Dive (Switzerland)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1997, rdft2,      0,        rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu (Tuning license)",        "Raiden Fighters 2 - Operation Hell Dive (Germany)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1997, rdft2j,     rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters 2 - Operation Hell Dive (Japan set 1)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1997, rdft2a,     rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu (Metrotainment license)", "Raiden Fighters 2 - Operation Hell Dive (Hong Kong)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1997, rdft2s,     rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters 2 - Operation Hell Dive (Switzerland)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
 // this is another
-GAME( 1997, rdft2ja,    rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters 2 - Operation Hell Dive (Japan set 2)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1997, rdft2aa,    rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu (Dream Island license)",  "Raiden Fighters 2 - Operation Hell Dive (Korea)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1997, rdft2it,    rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters 2 - Operation Hell Dive (Italy)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1997, rdft2ja,    rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters 2 - Operation Hell Dive (Japan set 2)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1997, rdft2aa,    rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu (Dream Island license)",  "Raiden Fighters 2 - Operation Hell Dive (Korea)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1997, rdft2it,    rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters 2 - Operation Hell Dive (Italy)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
 // these are unique
-GAME( 1997, rdft2jb,    rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters 2 - Operation Hell Dive (Japan set 3)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1997, rdft2jc,    rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters 2 - Operation Hell Dive (Japan set 4)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1997, rdft2t,     rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters 2 - Operation Hell Dive (Taiwan)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1997, rdft2u,     rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu (Fabtek license)",        "Raiden Fighters 2 - Operation Hell Dive (US)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1997, rdft2jb,    rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters 2 - Operation Hell Dive (Japan set 3)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1997, rdft2jc,    rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters 2 - Operation Hell Dive (Japan set 4)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1997, rdft2t,     rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters 2 - Operation Hell Dive (Taiwan)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1997, rdft2u,     rdft2,    rdft2,   spi_2button, seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu (Fabtek license)",        "Raiden Fighters 2 - Operation Hell Dive (US)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
 
-GAME( 1998, rfjet,      0,        rdft2,   spi_2button, seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu (Tuning license)",        "Raiden Fighters Jet (Germany)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1998, rfjetu,     rfjet,    rdft2,   spi_2button, seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu (Fabtek license)",        "Raiden Fighters Jet (US)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1998, rfjetj,     rfjet,    rdft2,   spi_2button, seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters Jet (Japan)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1998, rfjeta,     rfjet,    rdft2,   spi_2button, seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu (Dream Island license)",  "Raiden Fighters Jet (Korea)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1998, rfjett,     rfjet,    rdft2,   spi_2button, seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters Jet (Taiwan)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1998, rfjet,      0,        rdft2,   spi_2button, seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu (Tuning license)",        "Raiden Fighters Jet (Germany)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1998, rfjetu,     rfjet,    rdft2,   spi_2button, seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu (Fabtek license)",        "Raiden Fighters Jet (US)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1998, rfjetj,     rfjet,    rdft2,   spi_2button, seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters Jet (Japan)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1998, rfjeta,     rfjet,    rdft2,   spi_2button, seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu (Dream Island license)",  "Raiden Fighters Jet (Korea)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1998, rfjett,     rfjet,    rdft2,   spi_2button, seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu",                         "Raiden Fighters Jet (Taiwan)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
 
-/* SXX2E */
-GAME( 1996, rdfts,      rdft,     sxx2e,   sxx2e,       seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu (Explorer System Corp. license)", "Raiden Fighters (Taiwan, single board)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+// SXX2E
+GAME( 1996, rdfts,      rdft,     sxx2e,   sxx2e,       seibuspi_state, init_rdft,     ROT270, "Seibu Kaihatsu (Explorer System Corp. license)", "Raiden Fighters (Taiwan, single board)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
 
-/* SXX2F */
-GAME( 1997, rdft2us,    rdft2,    sxx2f,   sxx2f,       seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden Fighters 2 - Operation Hell Dive (US, single board)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS ) // title screen shows small '.1'
+// SXX2F
+GAME( 1997, rdft2us,    rdft2,    sxx2f,   sxx2f,       seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu (Fabtek license)", "Raiden Fighters 2 - Operation Hell Dive (US, single board)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS ) // title screen shows small '.1'
 
-/* SXX2G */
-GAME( 1999, rfjets,     rfjet,    sxx2g,   sxx2f,       seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu", "Raiden Fighters Jet (US, single board)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS ) // has 1998-99 copyright + planes unlocked
-GAME( 1999, rfjetsa,    rfjet,    sxx2g,   sxx2f,       seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu", "Raiden Fighters Jet (US, single board, test version?)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS ) // maybe test/proto? see notes at romdefs
+// SXX2G
+GAME( 1999, rfjets,     rfjet,    sxx2g,   sxx2f,       seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu", "Raiden Fighters Jet (US, single board)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS ) // has 1998-99 copyright + planes unlocked
+GAME( 1999, rfjetsa,    rfjet,    sxx2g,   sxx2f,       seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu", "Raiden Fighters Jet (US, single board, test version?)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS ) // maybe test/proto? see notes at romdefs
 
-/* SYS386I */
-GAME( 2000, rdft22kc,   rdft2,    sys386i, sys386i,     seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu", "Raiden Fighters 2 - Operation Hell Dive 2000 (China, SYS386I)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 2000, rfjet2kc,   rfjet,    sys386i, sys386i,     seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu", "Raiden Fighters Jet 2000 (China, SYS386I)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+// SYS386I
+GAME( 2000, rdft22kc,   rdft2,    sys386i, sys386i,     seibuspi_state, init_rdft2,    ROT270, "Seibu Kaihatsu", "Raiden Fighters 2 - Operation Hell Dive 2000 (China, SYS386I)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 2000, rfjet2kc,   rfjet,    sys386i, sys386i,     seibuspi_state, init_rfjet,    ROT270, "Seibu Kaihatsu", "Raiden Fighters Jet 2000 (China, SYS386I)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
 
-/* SYS386F */
-GAME( 1999, ejsakura,   0,        sys386f, ejsakura,    seibuspi_state, init_sys386f,  ROT0,   "Seibu Kaihatsu", "E-Jan Sakurasou (Japan, SYS386F V2.0)", MACHINE_SUPPORTS_SAVE )
-GAME( 1999, ejsakura12, ejsakura, sys386f, ejsakura,    seibuspi_state, init_sys386f,  ROT0,   "Seibu Kaihatsu", "E-Jan Sakurasou (Japan, SYS386F V1.2)", MACHINE_SUPPORTS_SAVE )
+// SYS386F
+GAME( 1999, ejsakura,   0,        sys386f, ejsakura,    seibuspi_state, init_sys386f,  ROT0,   "Seibu Kaihatsu", "E-Jan Sakurasou (Japan, SYS386F V2.0)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1999, ejsakura12, ejsakura, sys386f, ejsakura,    seibuspi_state, init_sys386f,  ROT0,   "Seibu Kaihatsu", "E-Jan Sakurasou (Japan, SYS386F V1.2)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/seibu/seibuspi_m.cpp
+++ b/src/mame/seibu/seibuspi_m.cpp
@@ -12,12 +12,12 @@ static u32 partial_carry_sum(u32 add1,u32 add2,u32 carry_mask,int bits)
 	int carry = 0;
 	for (int i = 0; i < bits; i++)
 	{
-		int bit = BIT(add1,i) + BIT(add2,i) + carry;
+		const int bit = BIT(add1, i) + BIT(add2, i) + carry;
 
 		res += (bit & 1) << i;
 
 		// generate carry only if the corresponding bit in carry_mask is 1
-		if (BIT(carry_mask,i))
+		if (BIT(carry_mask, i))
 			carry = bit >> 1;
 		else
 			carry = 0;
@@ -25,24 +25,24 @@ static u32 partial_carry_sum(u32 add1,u32 add2,u32 carry_mask,int bits)
 
 	// wrap around carry from top bit to bit 0
 	if (carry)
-		res ^=1;
+		res ^= 1;
 
 	return res;
 }
 
-u32 partial_carry_sum32(u32 add1,u32 add2,u32 carry_mask)
+u32 partial_carry_sum32(u32 add1, u32 add2, u32 carry_mask)
 {
-	return partial_carry_sum(add1,add2,carry_mask,32);
+	return partial_carry_sum(add1, add2, carry_mask, 32);
 }
 
-u32 partial_carry_sum24(u32 add1,u32 add2,u32 carry_mask)
+u32 partial_carry_sum24(u32 add1, u32 add2, u32 carry_mask)
 {
-	return partial_carry_sum(add1,add2,carry_mask,24);
+	return partial_carry_sum(add1, add2, carry_mask, 24);
 }
 
-static u32 partial_carry_sum16(u32 add1,u32 add2,u32 carry_mask)
+static u32 partial_carry_sum16(u32 add1, u32 add2, u32 carry_mask)
 {
-	return partial_carry_sum(add1,add2,carry_mask,16);
+	return partial_carry_sum(add1, add2, carry_mask, 16);
 }
 
 
@@ -140,10 +140,10 @@ static const u8 spi_bitswap[16][16] =
 };
 
 
-static int key(int table,int addr)
+static int key(int table, int addr)
 {
 	const int xorbit = 8 + ((table & 0xc) >> 2);
-	return BIT(key_table[addr & 0xff] >> 4,table) ^ BIT(addr,xorbit);
+	return BIT(key_table[addr & 0xff] >> 4, table) ^ BIT(addr, xorbit);
 }
 
 
@@ -266,8 +266,8 @@ void seibuspi_sprite_decrypt(u8 *src, int rom_size)
 				   (key( 8,addr) << 30) |
 				   (key( 0,addr) << 31);
 
-		s1 = partial_carry_sum( s1, add1, 0x3a59, 16 ) ^ 0x843a;
-		s2 = partial_carry_sum( s2, add2, 0x28d49cac, 32 ) ^ 0xc8e29f84;
+		s1 = partial_carry_sum(s1, add1, 0x3a59, 16) ^ 0x843a;
+		s2 = partial_carry_sum(s2, add2, 0x28d49cac, 32) ^ 0xc8e29f84;
 
 
 		// reorder the bits in the order MAME expects to decode the graphics
@@ -342,8 +342,8 @@ void seibuspi_rise10_sprite_decrypt(u8 *rom, int size)
 				27,6,15,21,1,28,10,20,
 				7,31,26,0,18,9,19,8);
 
-		plane54   = partial_carry_sum16( plane54, 0xabcb, 0x55aa ) ^ 0x6699;
-		plane3210 = partial_carry_sum32( plane3210, 0x654321d9 ^ 0x42, 0x1d463748 ) ^ 0x0ca352a9;
+		plane54   = partial_carry_sum16(plane54, 0xabcb, 0x55aa) ^ 0x6699;
+		plane3210 = partial_carry_sum32(plane3210, 0x654321d9 ^ 0x42, 0x1d463748) ^ 0x0ca352a9;
 
 		rom[0 * size + 2 * i]     = plane54   >>  8;
 		rom[0 * size + 2 * i + 1] = plane54   >>  0;
@@ -468,10 +468,10 @@ static void seibuspi_rise11_sprite_decrypt(u8 *rom, int size,
 					   (BIT(b1, 5)<<22) |
 					   (BIT(b3,15)<<23);
 
-		plane543 = partial_carry_sum32( plane543, k1, k2 ) ^ k3;
-		plane210 = partial_carry_sum24( plane210,  i, k4 ) ^ k5;
+		plane543 = partial_carry_sum32(plane543, k1, k2) ^ k3;
+		plane210 = partial_carry_sum24(plane210,  i, k4) ^ k5;
 		if (feversoc_kludge)
-			plane210 = partial_carry_sum24( plane210,  1, 0x000001 );
+			plane210 = partial_carry_sum24(plane210,  1, 0x000001);
 
 		rom[0 * size + 2 * i]     = plane543 >> 16;
 		rom[0 * size + 2 * i + 1] = plane543 >>  8;

--- a/src/mame/seibu/seibuspi_v.cpp
+++ b/src/mame/seibu/seibuspi_v.cpp
@@ -178,7 +178,7 @@ void seibuspi_state::spi_layer_bank_w(offs_t offset, u16 data, u16 mem_mask)
 	const u16 prev = m_layer_bank;
 	COMBINE_DATA(&m_layer_bank);
 
-	m_rowscroll_enable = m_layer_bank >> 15 & 1;
+	m_rowscroll_enable = BIT(m_layer_bank, 15);
 	set_layer_offsets();
 
 	if ((prev ^ m_layer_bank) & 0x0800)
@@ -241,8 +241,8 @@ void seibuspi_state::tilemap_dma_start_w(u32 data)
 		return;
 
 	// safety check
-	int dma_length_user = m_rowscroll_enable ? 0x4000 : 0x2800;
-	int dma_length_real = (m_video_dma_length + 1) * 2; // ideally we should be using this, let's check if we have to:
+	const int dma_length_user = m_rowscroll_enable ? 0x4000 : 0x2800;
+	const int dma_length_real = (m_video_dma_length + 1) * 2; // ideally we should be using this, let's check if we have to:
 	if (m_video_dma_length != 0 && dma_length_user != dma_length_real)
 		popmessage("Tile LEN %X %X, contact MAMEdev", dma_length_user, dma_length_real); // shouldn't happen
 	else if (!DWORD_ALIGNED(m_video_dma_address) || (m_video_dma_length & 3) != 3 || (m_video_dma_address + dma_length_user) > 0x40000)
@@ -252,7 +252,7 @@ void seibuspi_state::tilemap_dma_start_w(u32 data)
 
 	int index = m_video_dma_address / 4;
 
-	/* back layer */
+	// back layer
 	for (int i = 0; i < 0x800/4; i++)
 	{
 		const u32 tile = m_mainram[index];
@@ -265,14 +265,14 @@ void seibuspi_state::tilemap_dma_start_w(u32 data)
 		index++;
 	}
 
-	/* back layer row scroll */
+	// back layer row scroll
 	if (m_rowscroll_enable)
 	{
 		std::copy_n(&m_mainram[index], 0x800/4, &m_tilemap_ram[0x800/4]);
 		index += 0x800/4;
 	}
 
-	/* fore layer */
+	// fore layer
 	for (int i = 0; i < 0x800/4; i++)
 	{
 		const u32 tile = m_mainram[index];
@@ -285,14 +285,14 @@ void seibuspi_state::tilemap_dma_start_w(u32 data)
 		index++;
 	}
 
-	/* fore layer row scroll */
+	// fore layer row scroll
 	if (m_rowscroll_enable)
 	{
 		std::copy_n(&m_mainram[index], 0x800/4, &m_tilemap_ram[0x2800/4]);
 		index += 0x800/4;
 	}
 
-	/* middle layer */
+	// middle layer
 	for (int i = 0; i < 0x800/4; i++)
 	{
 		const u32 tile = m_mainram[index];
@@ -305,14 +305,14 @@ void seibuspi_state::tilemap_dma_start_w(u32 data)
 		index++;
 	}
 
-	/* middle layer row scroll */
+	// middle layer row scroll
 	if (m_rowscroll_enable)
 	{
 		std::copy_n(&m_mainram[index], 0x800/4, &m_tilemap_ram[0x1800/4]);
 		index += 0x800/4;
 	}
 
-	/* text layer */
+	// text layer
 	for (int i = 0; i < 0x1000/4; i++)
 	{
 		const u32 tile = m_mainram[index];
@@ -358,194 +358,45 @@ void seibuspi_state::sprite_dma_start_w(u16 data)
 	if (m_video_dma_address < 0x800)
 		logerror("sprite_dma_start_w in I/O area: %X\n", m_video_dma_address);
 
-	std::copy_n(&m_mainram[m_video_dma_address / 4], m_sprite_ram_size / 4, &m_sprite_ram[0]);
+	for (int i = 0; i < m_sprite_ram_size / 4; i++)
+	{
+		m_sprite_ram[i << 1] = m_mainram[(m_video_dma_address / 4) + i] & 0xffff;
+		m_sprite_ram[(i << 1) | 1] = (m_mainram[(m_video_dma_address / 4) + i] >> 16) & 0xffff;
+	}
 }
 
 
 /*****************************************************************************/
 
-void seibuspi_state::drawgfx_blend(bitmap_rgb32 &bitmap, const rectangle &cliprect, gfx_element *gfx, u32 code, u32 color, bool flipx, bool flipy, int sx, int sy, bitmap_ind8 &primap, u8 primask)
+u32 seibuspi_state::gfxbank_callback(u32 code, u8 ext)
 {
-	const int width = gfx->width();
-	const int height = gfx->height();
-
-	int x1 = sx;
-	int x2 = sx + width - 1;
-	int y1 = sy;
-	int y2 = sy + height - 1;
-
-	if (x1 > cliprect.max_x || x2 < cliprect.min_x)
-	{
-		return;
-	}
-	if (y1 > cliprect.max_y || y2 < cliprect.min_y)
-	{
-		return;
-	}
-
-	int px = 0;
-	int py = 0;
-	int xd = 1;
-	int yd = 1;
-
-	if (flipx)
-	{
-		xd = -xd;
-		px = width - 1;
-	}
-	if (flipy)
-	{
-		yd = -yd;
-		py = height - 1;
-	}
-
-	// clip x
-	if (x1 < cliprect.min_x)
-	{
-		if (flipx)
-		{
-			px = width - (cliprect.min_x - x1) - 1;
-		}
-		else
-		{
-			px = (cliprect.min_x - x1);
-		}
-		x1 = cliprect.min_x;
-	}
-	if (x2 > cliprect.max_x)
-	{
-		x2 = cliprect.max_x;
-	}
-
-	// clip y
-	if (y1 < cliprect.min_y)
-	{
-		if (flipy)
-		{
-			py = height - (cliprect.min_y - y1) - 1;
-		}
-		else
-		{
-			py = (cliprect.min_y - y1);
-		}
-		y1 = cliprect.min_y;
-	}
-	if (y2 > cliprect.max_y)
-	{
-		y2 = cliprect.max_y;
-	}
-
-	color = gfx->colorbase() + (color % gfx->colors()) * gfx->granularity();
-	const pen_t *pens = m_palette->pens();
-	const u8 *src = gfx->get_data(code % gfx->elements());
-	const u8 trans_pen = (1 << m_sprite_bpp) - 1;
-
-	// draw
-	for (int y = y1; y <= y2; y++)
-	{
-		u32 *const dest = &bitmap.pix(y);
-		u8 *const pri = &primap.pix(y);
-		int src_i = (py * width) + px;
-		py += yd;
-
-		for (int x = x1; x <= x2; x++)
-		{
-			const u8 pen = src[src_i];
-			if (!(pri[x] & primask) && pen != trans_pen)
-			{
-				pri[x] |= primask;
-				const u16 global_pen = pen + color;
-				if (m_alpha_table[global_pen])
-					dest[x] = alpha_blend_r32(dest[x], pens[global_pen], 0x7f);
-				else
-					dest[x] = pens[global_pen];
-			}
-			src_i += xd;
-		}
-	}
+	return code | (((m_spritegen->gfx(0)->elements() > 0x10000) && ext) ? 0x10000 : 0);
 }
 
-void seibuspi_state::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect, bitmap_ind8 &primap, int priority)
+void seibuspi_state::blend_sprite(bitmap_rgb32 &bitmap, const rectangle &cliprect, int pri)
 {
-	gfx_element *gfx = m_gfxdecode->gfx(0);
-	const bool has_tile_high = (gfx->elements() > 0x10000);
-
-	static const int sprite_xtable[2][8] =
-	{
-		{ 0*16, 1*16, 2*16, 3*16, 4*16, 5*16, 6*16, 7*16 },
-		{ 7*16, 6*16, 5*16, 4*16, 3*16, 2*16, 1*16, 0*16 }
-	};
-	static const int sprite_ytable[2][8] =
-	{
-		{ 0*16, 1*16, 2*16, 3*16, 4*16, 5*16, 6*16, 7*16 },
-		{ 7*16, 6*16, 5*16, 4*16, 3*16, 2*16, 1*16, 0*16 }
-	};
-
-	if (m_layer_enable & 0x10)
+	if (BIT(m_layer_enable, 4))
 		return;
 
-	for (int a = 0; a < (m_sprite_ram_size / 4); a += 2)
+	bitmap_ind16 &sprite_bitmap = m_spritegen->get_sprite_temp_bitmap();
+	pri <<= 14;
+	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{
-		/*
-		    Word 0
-		    xxxxxxxx xxxxxxxx -------- --------  tile_num low
-		    -------- -------- x------- --------  flip_y
-		    -------- -------- -xxx---- --------  height
-		    -------- -------- ----x--- --------  flip_x
-		    -------- -------- -----xxx --------  width
-		    -------- -------- -------- xx------  priority
-		    -------- -------- -------- --xxxxxx  color (highest bit not used on SYS386F)
-
-		    Word 1, unmarked bits have no function
-		    -------x xxxxxxxx -------- --------  ypos
-		    -------- -------- ---x---- --------  tile_num high (only on RISE10/11 chip)
-		    -------- -------- ------xx xxxxxxxx  xpos
-		*/
-		int tile_num = m_sprite_ram[a + 0] >> 16 & 0xffff;
-		if (tile_num == 0)
-			continue;
-
-		if (has_tile_high)
-			tile_num |= m_sprite_ram[a + 1] << 4 & 0x10000;
-
-		if (priority != (m_sprite_ram[a + 0] >> 6 & 0x3))
-			continue;
-		const u8 primask = 1 << priority;
-
-		s16 xpos = util::sext(m_sprite_ram[a + 1], 10);
-		s16 ypos = util::sext(m_sprite_ram[a + 1] >> 16, 9);
-		const int color = m_sprite_ram[a + 0] & 0x3f;
-
-		int width = (m_sprite_ram[a + 0] >> 8 & 0x7) + 1;
-		int height = (m_sprite_ram[a + 0] >> 12 & 0x7) + 1;
-		const int flip_x = m_sprite_ram[a + 0] >> 11 & 0x1;
-		const int flip_y = m_sprite_ram[a + 0] >> 15 & 0x1;
-		int x1 = 0;
-		int y1 = 0;
-
-		if (flip_x)
+		const u16 *src = &sprite_bitmap.pix(y, cliprect.min_x);
+		u32 *dest = &bitmap.pix(y, cliprect.min_x);
+		for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
 		{
-			x1 = 8 - width;
-			width = width + x1;
-		}
-		if (flip_y)
-		{
-			y1 = 8 - height;
-			height = height + y1;
-		}
-
-		for (int x = x1; x < width; x++)
-		{
-			for (int y = y1; y < height; y++)
+			u16 pen = *src++;
+			if (((pen & 0xc000) == pri) && (pen != 0xffff))
 			{
-				drawgfx_blend(bitmap, cliprect, gfx, tile_num, color, flip_x, flip_y, xpos + sprite_xtable[flip_x][x], ypos + sprite_ytable[flip_y][y], primap, primask);
+				pen &= ~0xc000;
 
-				/* xpos seems to wrap-around to 0 at 512 */
-				if ((xpos + (16 * x) + 16) >= 512)
-					drawgfx_blend(bitmap, cliprect, gfx, tile_num, color, flip_x, flip_y, xpos - 512 + sprite_xtable[flip_x][x], ypos + sprite_ytable[flip_y][y], primap, primask);
-
-				tile_num++;
+				if (m_alpha_table[pen])
+					*dest = alpha_blend_r32(*dest, m_palette->pen(pen), 0x7f);
+				else
+					*dest = m_palette->pen(pen);
 			}
+			dest++;
 		}
 	}
 }
@@ -563,7 +414,7 @@ void seibuspi_state::combine_tilemap(bitmap_rgb32 &bitmap, const rectangle &clip
 		if (rowscroll)
 			rx += rowscroll[(y + 19) & yscroll_mask]; // adder value probably not hardcoded but came from CRTC
 
-		u32 *dest = &bitmap.pix(y);
+		u32 *dest = &bitmap.pix(y, cliprect.min_x);
 		const u16 *src = &pen_bitmap.pix((y + sy) & yscroll_mask);
 		const u8 *flags = &flags_bitmap.pix((y + sy) & yscroll_mask);
 		for (int x = cliprect.min_x + rx; x <= cliprect.max_x + rx; x++)
@@ -598,38 +449,39 @@ u32 seibuspi_state::screen_update_spi(screen_device &screen, bitmap_rgb32 &bitma
 		fore_rowscroll = nullptr;
 	}
 
-	screen.priority().fill(0, cliprect);
+	if (BIT(~m_layer_enable, 4))
+		m_spritegen->draw_sprites(screen, bitmap, cliprect, m_sprite_ram.get(), m_sprite_ram_size);
 
-	if (m_layer_enable & 1)
+	if (BIT(m_layer_enable, 0))
 		bitmap.fill(0, cliprect);
 	else
 		combine_tilemap(bitmap, cliprect, m_back_layer, m_scrollram[0], m_scrollram[1], 1, back_rowscroll);
 
-	draw_sprites(bitmap, cliprect, screen.priority(), 0);
+	blend_sprite(bitmap, cliprect, 0);
 
 	// if fore layer is enabled, draw priority 0 sprites behind back layer
 	if ((m_layer_enable & 0x15) == 0)
 		combine_tilemap(bitmap, cliprect, m_back_layer, m_scrollram[0], m_scrollram[1], 0, back_rowscroll);
 
 	// if fore layer is enabled, draw priority 1 sprites behind middle layer
-	if (~m_layer_enable & 4)
-		draw_sprites(bitmap, cliprect, screen.priority(), 1);
+	if (BIT(~m_layer_enable, 2))
+		blend_sprite(bitmap, cliprect, 1);
 
-	if (~m_layer_enable & 2)
+	if (BIT(~m_layer_enable, 1))
 		combine_tilemap(bitmap, cliprect, m_midl_layer, m_scrollram[2], m_scrollram[3], 0, midl_rowscroll);
 
 	// if fore layer is disabled, draw priority 1 sprites above middle layer
-	if (m_layer_enable & 4)
-		draw_sprites(bitmap, cliprect, screen.priority(), 1);
+	if (BIT(m_layer_enable, 2))
+		blend_sprite(bitmap, cliprect, 1);
 
-	draw_sprites(bitmap, cliprect, screen.priority(), 2);
+	blend_sprite(bitmap, cliprect, 2);
 
-	if (~m_layer_enable & 4)
+	if (BIT(~m_layer_enable, 2))
 		combine_tilemap(bitmap, cliprect, m_fore_layer, m_scrollram[4], m_scrollram[5], 0, fore_rowscroll);
 
-	draw_sprites(bitmap, cliprect, screen.priority(), 3);
+	blend_sprite(bitmap, cliprect, 3);
 
-	if (~m_layer_enable & 8)
+	if (BIT(~m_layer_enable, 3))
 		combine_tilemap(bitmap, cliprect, m_text_layer, 0, 0, 0, nullptr);
 
 	return 0;
@@ -637,13 +489,9 @@ u32 seibuspi_state::screen_update_spi(screen_device &screen, bitmap_rgb32 &bitma
 
 u32 seibuspi_state::screen_update_sys386f(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	screen.priority().fill(0, cliprect);
 	bitmap.fill(0, cliprect);
 
-	draw_sprites(bitmap, cliprect, screen.priority(), 0);
-	draw_sprites(bitmap, cliprect, screen.priority(), 1);
-	draw_sprites(bitmap, cliprect, screen.priority(), 2);
-	draw_sprites(bitmap, cliprect, screen.priority(), 3);
+	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_sprite_ram.get(), m_sprite_ram_size);
 
 	return 0;
 }
@@ -653,18 +501,18 @@ u32 seibuspi_state::screen_update_sys386f(screen_device &screen, bitmap_rgb32 &b
 
 TILE_GET_INFO_MEMBER(seibuspi_state::get_text_tile_info)
 {
-	int offs = tile_index / 2;
+	const int offs = tile_index / 2;
 	u32 tile = (m_tilemap_ram[offs + m_text_layer_offset] >> ((tile_index & 0x1) ? 16 : 0)) & 0xffff;
 	const u32 color = (tile >> 12) & 0xf;
 
 	tile &= 0xfff;
 
-	tileinfo.set(2, tile, color, 0);
+	tileinfo.set(0, tile, color, 0);
 }
 
 TILE_GET_INFO_MEMBER(seibuspi_state::get_back_tile_info)
 {
-	int offs = tile_index / 2;
+	const int offs = tile_index / 2;
 	u32 tile = (m_tilemap_ram[offs] >> ((tile_index & 0x1) ? 16 : 0)) & 0xffff;
 	const u32 color = (tile >> 13) & 0x7;
 
@@ -676,7 +524,7 @@ TILE_GET_INFO_MEMBER(seibuspi_state::get_back_tile_info)
 
 TILE_GET_INFO_MEMBER(seibuspi_state::get_midl_tile_info)
 {
-	int offs = tile_index / 2;
+	const int offs = tile_index / 2;
 	u32 tile = (m_tilemap_ram[offs + m_midl_layer_offset] >> ((tile_index & 0x1) ? 16 : 0)) & 0xffff;
 	const u32 color = (tile >> 13) & 0x7;
 
@@ -689,7 +537,7 @@ TILE_GET_INFO_MEMBER(seibuspi_state::get_midl_tile_info)
 
 TILE_GET_INFO_MEMBER(seibuspi_state::get_fore_tile_info)
 {
-	int offs = tile_index / 2;
+	const int offs = tile_index / 2;
 	u32 tile = (m_tilemap_ram[offs + m_fore_layer_offset] >> ((tile_index & 0x1) ? 16 : 0)) & 0xffff;
 	const u32 color = (tile >> 13) & 0x7;
 
@@ -704,6 +552,7 @@ TILE_GET_INFO_MEMBER(seibuspi_state::get_fore_tile_info)
 
 void seibuspi_state::video_start()
 {
+	m_spritegen->alloc_sprite_bitmap();
 	m_video_dma_length = 0;
 	m_video_dma_address = 0;
 	m_layer_enable = 0;
@@ -718,7 +567,7 @@ void seibuspi_state::video_start()
 	m_scrollram[5] = 0;
 	set_layer_offsets();
 
-	u32 region_length = memregion("tiles")->bytes();
+	const u32 region_length = memregion("tiles")->bytes();
 
 	if (region_length <= 0x300000)
 		m_bg_fore_layer_position = 0x2000;
@@ -734,7 +583,7 @@ void seibuspi_state::video_start()
 
 	m_tilemap_ram = make_unique_clear<u32[]>(m_tilemap_ram_size/4);
 	m_palette_ram = make_unique_clear<u32[]>(m_palette_ram_size/4);
-	m_sprite_ram = make_unique_clear<u32[]>(m_sprite_ram_size/4);
+	m_sprite_ram = make_unique_clear<u16[]>(m_sprite_ram_size/2);
 
 	m_palette->basemem().set(&m_palette_ram[0], m_palette_ram_size, 32, ENDIANNESS_LITTLE, 2);
 
@@ -799,7 +648,7 @@ VIDEO_START_MEMBER(seibuspi_state,sys386f)
 
 	m_tilemap_ram = nullptr;
 	m_palette_ram = make_unique_clear<u32[]>(m_palette_ram_size/4);
-	m_sprite_ram = make_unique_clear<u32[]>(m_sprite_ram_size/4);
+	m_sprite_ram = make_unique_clear<u16[]>(m_sprite_ram_size/2);
 
 	m_palette->basemem().set(&m_palette_ram[0], m_palette_ram_size, 32, ENDIANNESS_LITTLE, 2);
 
@@ -810,7 +659,7 @@ VIDEO_START_MEMBER(seibuspi_state,sys386f)
 
 void seibuspi_state::register_video_state()
 {
-	m_gfxdecode->gfx(0)->set_granularity(1 << m_sprite_bpp);
+	m_spritegen->gfx(0)->set_granularity(1 << m_sprite_bpp);
 	save_item(NAME(m_video_dma_length));
 	save_item(NAME(m_video_dma_address));
 	save_item(NAME(m_layer_enable));
@@ -829,5 +678,5 @@ void seibuspi_state::register_video_state()
 
 	if (m_tilemap_ram != nullptr) save_pointer(NAME(m_tilemap_ram), m_tilemap_ram_size/4);
 	save_pointer(NAME(m_palette_ram), m_palette_ram_size/4);
-	save_pointer(NAME(m_sprite_ram), m_sprite_ram_size/4);
+	save_pointer(NAME(m_sprite_ram), m_sprite_ram_size/2);
 }


### PR DESCRIPTION
Demote all systems in feversoc.cpp, raiden2.cpp, r2dx_v33.cpp, seibuspi.cpp driver to MACHINE_NO_COCKTAIL because these are not support flip screen (if exists)

seibu/feversoc.cpp: Cleanups
- Reduce preprocessor defines
- Reduce literal tag usages
- Use C++ style comments for single line comments
- Fix ROM region namings

seibu/r2dx_v33.cpp: Cleanups
- Split driver class for reduce optional finders
- Fix spacings
- Constantize variables
- Use C++ style comments for single line comments
- Fix ROM region namings

seibu/raiden2.cpp: Cleanups
- Use generic gfxdecode layout
- Fix spacings
- Constantize variables
- Use C++ style comments for single line comments
- Fix ROM region namings
- Simplify main CPU ROM bankswitching method

seibu/seibucats.cpp: Cleanups
- Reduce preprocessor defines
- Use C++ style comments for single line comments

seibu/seibuspi.cpp: Cleanups
- Suppress side effects for debugger reads
- Use array for reduce duplicates
- Fix tilemap draw routine with screen cliprect
- Reduce preprocessor defines
- Reduce literal tag usages
- Fix filename
- Use C++ style comments for single line comments
- Constantize variables
- Fix spacing