### PR TITLE
seibu/t5182.cpp: Remove hardcoded tags, Cleanups:

### DIFF
--- a/src/mame/seibu/metlfrzr.cpp
+++ b/src/mame/seibu/metlfrzr.cpp
@@ -43,7 +43,8 @@ public:
 		m_vram(*this, "vram"),
 		m_video_regs(*this, "vregs"),
 		m_palette(*this, "palette"),
-		m_gfxdecode(*this, "gfxdecode")
+		m_gfxdecode(*this, "gfxdecode"),
+		m_mainbank(*this, "mainbank")
 	{ }
 
 	void metlfrzr(machine_config &config);
@@ -60,6 +61,11 @@ private:
 	void legacy_obj_draw(bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 	uint32_t screen_update_metlfrzr(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void output_w(uint8_t data);
+	TIMER_DEVICE_CALLBACK_MEMBER(scanline);
+	void decrypted_opcodes_map(address_map &map);
+	void metlfrzr_map(address_map &map);
+
 	required_device<cpu_device> m_maincpu;
 	required_shared_ptr<uint8_t> m_decrypted_opcodes;
 	required_shared_ptr<uint8_t> m_work_ram;
@@ -68,12 +74,10 @@ private:
 	required_device<palette_device> m_palette;
 	required_device<gfxdecode_device> m_gfxdecode;
 
-	void output_w(uint8_t data);
-	TIMER_DEVICE_CALLBACK_MEMBER(scanline);
+	required_memory_bank m_mainbank;
+
 	uint8_t m_fg_tilebank = 0;
 	bool m_rowscroll_enable = false;
-	void decrypted_opcodes_map(address_map &map);
-	void metlfrzr_map(address_map &map);
 };
 
 
@@ -102,34 +106,29 @@ void metlfrzr_state::legacy_bg_draw(bitmap_ind16 &bitmap,const rectangle &clipre
 {
 	gfx_element *gfx = m_gfxdecode->gfx(m_fg_tilebank);
 	const uint16_t vram_mask = (m_vram.length() - 1) >> 1;
-	int count;
-	int x_scroll_base;
-	int x_scroll_shift;
-	uint16_t x_scroll_value;
-	x_scroll_value = m_video_regs[0x17] + ((m_video_regs[0x06] & 1) << 8);
-	x_scroll_base = (x_scroll_value >> 3) * 32;
+	uint16_t x_scroll_value = m_video_regs[0x17] + ((m_video_regs[0x06] & 1) << 8);
+	int x_scroll_base = (x_scroll_value >> 3) * 32;
 
-	for (count=0;count<32*33;count++)
+	for (int count = 0; count< 32 * 33; count++)
 	{
 		int tile_base = count;
-		int y = (count % 32);
-		if(y > 7 || m_rowscroll_enable == false)
+		int y = (count & 0x1f);
+		int x_scroll_shift;
+		if (y > 7 || m_rowscroll_enable == false)
 		{
-			tile_base+= x_scroll_base;
+			tile_base += x_scroll_base;
 			x_scroll_shift = (x_scroll_value & 7);
 		}
 		else
 			x_scroll_shift = 0;
 		tile_base &= vram_mask;
-		int x = (count / 32);
+		int x = (count >> 5);
 
+		const uint16_t tile = m_vram[tile_base * 2 + 0] + ((m_vram[tile_base * 2 + 1] & 0xf0) << 4);
+		const uint8_t color = m_vram[tile_base * 2 + 1] & 0xf;
 
-		uint16_t tile = m_vram[tile_base*2+0] + ((m_vram[tile_base*2+1] & 0xf0) << 4);
-		uint8_t color = m_vram[tile_base*2+1] & 0xf;
-
-		gfx->transpen(bitmap,cliprect,tile,color,0,0,x*8-x_scroll_shift,y*8,0xf);
+		gfx->transpen(bitmap, cliprect, tile, color, 0, 0, x * 8 - x_scroll_shift, y * 8, 0xf);
 	}
-
 }
 
 /*
@@ -149,21 +148,20 @@ void metlfrzr_state::legacy_obj_draw(bitmap_ind16 &bitmap,const rectangle &clipr
 {
 	gfx_element *gfx_2 = m_gfxdecode->gfx(2);
 	gfx_element *gfx_3 = m_gfxdecode->gfx(3);
-	int count;
-	uint8_t *base_spriteram = m_work_ram + 0xe00;
+	uint8_t const *const base_spriteram = m_work_ram + 0xe00;
 
-	for(count=0x200-4;count>-1;count-=4)
+	for (int count = 0x200 - 4; count > -1; count -= 4)
 	{
-		gfx_element *cur_gfx = base_spriteram[count+1] & 0x40 ? gfx_3 : gfx_2;
-		uint8_t tile_bank = (base_spriteram[count+1] & 0x30) >> 4;
-		uint16_t tile = base_spriteram[count] | (tile_bank << 8);
-		uint8_t color = base_spriteram[count+1] & 0xf;
-		int y = base_spriteram[count+2];
-		int x = base_spriteram[count+3];
-		if(base_spriteram[count+1] & 0x80)
-			x-=256;
+		gfx_element *cur_gfx = base_spriteram[count + 1] & 0x40 ? gfx_3 : gfx_2;
+		const uint8_t tile_bank = (base_spriteram[count + 1] & 0x30) >> 4;
+		const uint16_t tile = base_spriteram[count] | (tile_bank << 8);
+		const uint8_t color = base_spriteram[count + 1] & 0xf;
+		int y = base_spriteram[count + 2];
+		int x = base_spriteram[count + 3];
+		if (BIT(base_spriteram[count + 1], 7))
+			x -= 256;
 
-		cur_gfx->transpen(bitmap,cliprect,tile,color,0,0,x,y,0xf);
+		cur_gfx->transpen(bitmap, cliprect, tile, color, 0, 0, x, y, 0xf);
 	}
 }
 
@@ -171,8 +169,8 @@ uint32_t metlfrzr_state::screen_update_metlfrzr(screen_device &screen, bitmap_in
 {
 	bitmap.fill(m_palette->black_pen(), cliprect);
 
-	legacy_bg_draw(bitmap,cliprect);
-	legacy_obj_draw(bitmap,cliprect);
+	legacy_bg_draw(bitmap, cliprect);
+	legacy_obj_draw(bitmap, cliprect);
 	return 0;
 }
 
@@ -185,11 +183,11 @@ void metlfrzr_state::output_w(uint8_t data)
 	// bit 1: enabled during gameplay, rowscroll enable?
 	// bit 0: enabled , unknown purpose (lamp?)
 	// TODO: bits 1-0 might actually be sprite DMA enable mask/request
-	machine().bookkeeping().coin_lockout_w(1, BIT(data,6) );
-	machine().bookkeeping().coin_lockout_w(0, BIT(data,5) );
+	machine().bookkeeping().coin_lockout_w(1, BIT(data, 6));
+	machine().bookkeeping().coin_lockout_w(0, BIT(data, 5));
 	m_fg_tilebank = (data & 0x10) >> 4;
-	membank("bank1")->set_entry((data & 0xc) >> 2);
-	m_rowscroll_enable = bool(BIT(data,1));
+	m_mainbank->set_entry((data & 0xc) >> 2);
+	m_rowscroll_enable = bool(BIT(data, 1));
 
 //  popmessage("%02x %02x",m_fg_tilebank,data & 3);
 }
@@ -197,7 +195,7 @@ void metlfrzr_state::output_w(uint8_t data)
 void metlfrzr_state::metlfrzr_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
-	map(0x8000, 0xbfff).bankr("bank1");
+	map(0x8000, 0xbfff).bankr(m_mainbank);
 	map(0xc000, 0xcfff).ram().share(m_vram);
 	map(0xd000, 0xd1ff).ram().w(m_palette, FUNC(palette_device::write_indirect)).share("palette");
 	map(0xd200, 0xd3ff).ram().w(m_palette, FUNC(palette_device::write_indirect_ext)).share("palette_ext");
@@ -209,7 +207,7 @@ void metlfrzr_state::metlfrzr_map(address_map &map)
 	map(0xd602, 0xd602).portr("START");
 	map(0xd603, 0xd603).portr("DSW1");
 	map(0xd604, 0xd604).portr("DSW2");
-	map(0xd600, 0xd61f).writeonly().share("vregs");
+	map(0xd600, 0xd61f).writeonly().share(m_video_regs);
 
 	map(0xd700, 0xd700).w(FUNC(metlfrzr_state::output_w));
 	map(0xd710, 0xd710).w("t5182", FUNC(t5182_device::sound_irq_w));
@@ -220,14 +218,14 @@ void metlfrzr_state::metlfrzr_map(address_map &map)
 
 	map(0xd800, 0xdfff).ram();
 	map(0xe000, 0xefff).ram();
-	map(0xf000, 0xffff).ram().share("wram");
+	map(0xf000, 0xffff).ram().share(m_work_ram);
 }
 
 void metlfrzr_state::decrypted_opcodes_map(address_map &map)
 {
-	map(0x0000, 0x7fff).rom().share("decrypted_opcodes");
-	map(0x8000, 0xbfff).bankr("bank1");
-	map(0xf000, 0xffff).ram().share("wram"); // executes code at 0xf5d5
+	map(0x0000, 0x7fff).rom().share(m_decrypted_opcodes);
+	map(0x8000, 0xbfff).bankr(m_mainbank);
+	map(0xf000, 0xffff).ram().share(m_work_ram); // executes code at 0xf5d5
 }
 
 
@@ -326,13 +324,12 @@ INPUT_PORTS_END
 
 void metlfrzr_state::machine_start()
 {
-	membank("bank1")->configure_entries(0, 4, memregion("maincpu")->base() + 0x10000, 0x4000);
+	m_mainbank->configure_entries(0, 4, memregion("maincpu")->base() + 0x10000, 0x4000);
 }
 
 void metlfrzr_state::machine_reset()
 {
-	membank("bank1")->set_entry(0);
-
+	m_mainbank->set_entry(0);
 }
 
 
@@ -360,39 +357,41 @@ static const gfx_layout sprite_layout =
 
 
 static GFXDECODE_START(gfx_metlfrzr)
-	GFXDECODE_ENTRY("gfx1", 0, tile_layout, 0x100, 16)
-	GFXDECODE_ENTRY("gfx2", 0, tile_layout, 0x100, 16)
-	GFXDECODE_ENTRY("gfx3", 0, sprite_layout, 0, 16)
-	GFXDECODE_ENTRY("gfx4", 0, sprite_layout, 0, 16)
+	GFXDECODE_ENTRY("tiles1",   0, tile_layout, 0x100, 16)
+	GFXDECODE_ENTRY("tiles2",   0, tile_layout, 0x100, 16)
+	GFXDECODE_ENTRY("sprites1", 0, sprite_layout,   0, 16)
+	GFXDECODE_ENTRY("sprites2", 0, sprite_layout,   0, 16)
 GFXDECODE_END
 
 TIMER_DEVICE_CALLBACK_MEMBER(metlfrzr_state::scanline)
 {
 	int scanline = param;
 
-	if(scanline == 240) // vblank-out irq
-		m_maincpu->set_input_line_and_vector(0, HOLD_LINE,0xd7); /* Z80 - RST 10h */
+	if (scanline == 240) // vblank-out irq
+		m_maincpu->set_input_line_and_vector(0, HOLD_LINE, 0xd7); // Z80 - RST 10h
 
 	// TODO: check this irq.
-	if(scanline == 0) // vblank-in irq
-		m_maincpu->set_input_line_and_vector(0, HOLD_LINE,0xcf); /* Z80 - RST 08h */
+	if (scanline == 0) // vblank-in irq
+		m_maincpu->set_input_line_and_vector(0, HOLD_LINE, 0xcf); // Z80 - RST 08h
 }
 
 void metlfrzr_state::metlfrzr(machine_config &config)
 {
-	/* basic machine hardware */
+	// basic machine hardware
 	Z80(config, m_maincpu, XTAL(12'000'000) / 2);
 	m_maincpu->set_addrmap(AS_PROGRAM, &metlfrzr_state::metlfrzr_map);
 	m_maincpu->set_addrmap(AS_OPCODES, &metlfrzr_state::decrypted_opcodes_map);
 	TIMER(config, "scantimer").configure_scanline(FUNC(metlfrzr_state::scanline), "screen", 0, 1);
 
-	T5182(config, "t5182", 0);
+	t5182_device &t5182(T5182(config, "t5182", XTAL(14'318'181)/4));
+	t5182.ym_read_callback().set("ymsnd", FUNC(ym2151_device::read));
+	t5182.ym_write_callback().set("ymsnd", FUNC(ym2151_device::write));
 
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_444, 0x200).set_indirect_entries(256 * 2);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_metlfrzr);
 
-	/* video hardware */
+	// video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
@@ -401,10 +400,10 @@ void metlfrzr_state::metlfrzr(machine_config &config)
 	screen.set_screen_update(FUNC(metlfrzr_state::screen_update_metlfrzr));
 	screen.set_palette(m_palette);
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
-	ym2151_device &ymsnd(YM2151(config, "ymsnd", XTAL(14'318'181) / 4));    /* 3.579545 MHz */
+	ym2151_device &ymsnd(YM2151(config, "ymsnd", XTAL(14'318'181) / 4));    // 3.579545 MHz
 	ymsnd.irq_handler().set("t5182", FUNC(t5182_device::ym2151_irq_handler));
 	ymsnd.add_route(0, "mono", 0.5);
 	ymsnd.add_route(1, "mono", 0.5);
@@ -417,22 +416,22 @@ ROM_START(metlfrzr)
 	ROM_LOAD("1.15j", 0x00000, 0x08000, CRC(f59b5fa2) SHA1(6033967dad5e64f45afbcb1b45c8eb79e0787afb))
 	ROM_LOAD("2.14j", 0x10000, 0x10000, CRC(21ecc248) SHA1(2fccf7db73890faf7c489bfc43c88ded54d5052d))
 
-	ROM_REGION(0x8000, "t5182_z80", 0) /* Toshiba T5182 external data ROM */
+	ROM_REGION(0x8000, "t5182:external", 0) // Toshiba T5182 external data ROM
 	ROM_LOAD("3.4h", 0x0000, 0x8000, CRC(36f88e54) SHA1(5cbea56c7e547c353ae2f9256caaceb20e5e8503))
 
-	ROM_REGION(0x20000, "gfx1", 0)
+	ROM_REGION(0x20000, "tiles1", 0)
 	ROM_LOAD16_BYTE("10.5a", 0x00001, 0x10000, CRC(3313e74a) SHA1(8622dfb5c013173d5bb037254f4c23b1282404e1))
 	ROM_LOAD16_BYTE("12.7a", 0x00000, 0x10000, CRC(6da5fda9) SHA1(9d7b0b26598f31da589fece3535a4d1405b03fc2))
 
-	ROM_REGION(0x20000, "gfx2", 0)
+	ROM_REGION(0x20000, "tiles2", 0)
 	ROM_LOAD16_BYTE("11.6a", 0x00001, 0x10000, CRC(fa6490b8) SHA1(9a4c1e09b9e8fb256fec0a5ed120fece8a12e1c8))
 	ROM_LOAD16_BYTE("13.9a", 0x00000, 0x10000, CRC(a4f689ec) SHA1(e58bfede3fabf4cfca76c20aafb3e9fb604777c9))
 
-	ROM_REGION(0x20000, "gfx3", 0)
+	ROM_REGION(0x20000, "sprites1", 0)
 	ROM_LOAD16_BYTE("14.13a", 0x00001, 0x10000, CRC(a9cd5225) SHA1(f3d5e29ee08fb563fdc1af3c64128f2cd2feb987))
 	ROM_LOAD16_BYTE("16.11a", 0x00000, 0x10000, CRC(92f2cb49) SHA1(498021d94b0fde216207076491702af2324a2dcc))
 
-	ROM_REGION(0x20000, "gfx4", 0)
+	ROM_REGION(0x20000, "sprites2", 0)
 	ROM_LOAD16_BYTE("15.12a", 0x00001, 0x10000, CRC(ce5c4c8b) SHA1(2351d66ba51e80097ce53bfd448ac24901844cda))
 	ROM_LOAD16_BYTE("17.10a", 0x00000, 0x10000, CRC(3fec33f7) SHA1(af086ba30fc4521a0114da2824f5baa04d225a89))
 
@@ -449,32 +448,32 @@ ROM_END
 
 void metlfrzr_state::init_metlfrzr()
 {
-	// same as cshooter.cpp
+	// same as seibu/airraid.cpp
 	uint8_t *rom = memregion("maincpu")->base();
 
-	for (int A = 0x0000;A < 0x8000;A++)
+	for (int A = 0x0000; A < 0x8000; A++)
 	{
-		/* decode the opcodes */
+		// decode the opcodes
 		m_decrypted_opcodes[A] = rom[A];
 
-		if (BIT(A,5) && !BIT(A,3))
+		if (BIT(A, 5) && !BIT(A, 3))
 			m_decrypted_opcodes[A] ^= 0x40;
 
-		if (BIT(A,10) && !BIT(A,9) && BIT(A,3))
+		if (BIT(A, 10) && !BIT(A, 9) && BIT(A, 3))
 			m_decrypted_opcodes[A] ^= 0x20;
 
-		if ((BIT(A,10) ^ BIT(A,9)) && BIT(A,1))
+		if ((BIT(A, 10) ^ BIT(A, 9)) && BIT(A, 1))
 			m_decrypted_opcodes[A] ^= 0x02;
 
-		if (BIT(A,9) || !BIT(A,5) || BIT(A,3))
-			m_decrypted_opcodes[A] = bitswap<8>(m_decrypted_opcodes[A],7,6,1,4,3,2,5,0);
+		if (BIT(A, 9) || !BIT(A, 5) || BIT(A, 3))
+			m_decrypted_opcodes[A] = bitswap<8>(m_decrypted_opcodes[A], 7, 6, 1, 4, 3, 2, 5, 0);
 
-		/* decode the data */
-		if (BIT(A,5))
+		// decode the data
+		if (BIT(A, 5))
 			rom[A] ^= 0x40;
 
-		if (BIT(A,9) || !BIT(A,5))
-			rom[A] = bitswap<8>(rom[A],7,6,1,4,3,2,5,0);
+		if (BIT(A, 9) || !BIT(A, 5))
+			rom[A] = bitswap<8>(rom[A], 7, 6, 1, 4, 3, 2, 5, 0);
 	}
 }
 

--- a/src/mame/seibu/mustache.cpp
+++ b/src/mame/seibu/mustache.cpp
@@ -150,13 +150,13 @@ void mustache_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprec
 	gfx_element *gfx = m_gfxdecode->gfx(1);
 	const rectangle &visarea = m_screen->visible_area();
 
-	for (int offs = 0;offs < m_spriteram.bytes();offs += 4)
+	for (int offs = 0; offs < m_spriteram.bytes(); offs += 4)
 	{
 		int sy = 240 - m_spriteram[offs];
 		int sx = 240 - m_spriteram[offs + 3];
 		int code = m_spriteram[offs + 2];
 		int const attr = m_spriteram[offs + 1];
-		int const color = (attr & 0xe0)>>5;
+		int const color = (attr & 0xe0) >> 5;
 
 		if (sy == 240) continue;
 
@@ -324,7 +324,9 @@ void mustache_state::mustache(machine_config &config)
 
 	SEI80BU(config, "sei80bu", 0).set_device_rom_tag("maincpu");
 
-	T5182(config, "t5182", 0);
+	t5182_device &t5182(T5182(config, "t5182", 14.318181_MHz_XTAL / 4));
+	t5182.ym_read_callback().set("ymsnd", FUNC(ym2151_device::read));
+	t5182.ym_write_callback().set("ymsnd", FUNC(ym2151_device::write));
 
 	// video hardware
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
@@ -349,25 +351,25 @@ void mustache_state::mustache(machine_config &config)
 }
 
 ROM_START( mustache )
-	ROM_REGION( 0x20000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
 	ROM_LOAD( "mustache.h18", 0x0000, 0x8000, CRC(123bd9b8) SHA1(33a7cba5c3a54b0b1a15dd1e24d298b6f7274321) )
 	ROM_LOAD( "mustache.h16", 0x8000, 0x4000, CRC(62552beb) SHA1(ee10991d7de0596608fa1db48805781cbfbbdb9f) )
 
-	ROM_REGION( 0x8000, "t5182_z80", 0 ) // Toshiba T5182 external ROM
+	ROM_REGION( 0x8000, "t5182:external", 0 ) // Toshiba T5182 external ROM
 	ROM_LOAD( "mustache.e5", 0x0000, 0x8000, CRC(efbb1943) SHA1(3320e9eaeb776d09ed63f7dedc79e720674e6718) )
 
-	ROM_REGION( 0x0c000, "tiles",0)
+	ROM_REGION( 0x0c000, "tiles", 0 )
 	ROM_LOAD( "mustache.a13", 0x0000,  0x4000, CRC(9baee4a7) SHA1(31bcec838789462e67e54ebe7256db9fc4e51b69) )
 	ROM_LOAD( "mustache.a14", 0x4000,  0x4000, CRC(8155387d) SHA1(5f0a394c7671442519a831b0eeeaba4eecd5a406) )
 	ROM_LOAD( "mustache.a16", 0x8000,  0x4000, CRC(4db4448d) SHA1(50a94fd65c263d95fd24b4009dbb87707929fdcb) )
 
-	ROM_REGION( 0x20000, "sprites",0 )
+	ROM_REGION( 0x20000, "sprites", 0 )
 	ROM_LOAD( "mustache.a4", 0x00000,  0x8000, CRC(d5c3bbbf) SHA1(914e3feea54246476701f492c31bd094ad9cea10) )
 	ROM_LOAD( "mustache.a7", 0x08000,  0x8000, CRC(e2a6012d) SHA1(4e4cd1a186870c8a88924d5bff917c6889da953d) )
 	ROM_LOAD( "mustache.a5", 0x10000,  0x8000, CRC(c975fb06) SHA1(4d166bd79e19c7cae422673de3e095ad8101e013) )
 	ROM_LOAD( "mustache.a8", 0x18000,  0x8000, CRC(2e180ee4) SHA1(a5684a25c337aeb4effeda7982164d35bc190af9) )
 
-	ROM_REGION( 0x1300, "proms",0 )
+	ROM_REGION( 0x1300, "proms", 0 )
 	ROM_LOAD( "mustache.c3",0x0000, 0x0100, CRC(68575300) SHA1(bc93a38df91ad8c2f335f9bccc98b52376f9b483) )
 	ROM_LOAD( "mustache.c2",0x0100, 0x0100, CRC(eb008d62) SHA1(a370fbd1affaa489210ea36eb9e365263fb4e232) )
 	ROM_LOAD( "mustache.c1",0x0200, 0x0100, CRC(65da3604) SHA1(e4874d4152a57944d4e47306250833ea5cd0d89b) )
@@ -376,25 +378,25 @@ ROM_START( mustache )
 ROM_END
 
 ROM_START( mustachei )
-	ROM_REGION( 0x20000, "maincpu", 0 )
+	ROM_REGION( 0x10000, "maincpu", 0 )
 	ROM_LOAD( "1.h18", 0x0000, 0x8000, CRC(22893fbc) SHA1(724ea50642aec9be10547bd86fae5e1ebfe54685) )
 	ROM_LOAD( "2.h16", 0x8000, 0x4000, CRC(ec70cfd3) SHA1(0476eab03b907778ea488c802b79da99bf376eb6) )
 
-	ROM_REGION( 0x8000, "t5182_z80", 0 ) // Toshiba T5182 external ROM
+	ROM_REGION( 0x8000, "t5182:external", 0 ) // Toshiba T5182 external ROM
 	ROM_LOAD( "10.e5", 0x0000, 0x8000, CRC(efbb1943) SHA1(3320e9eaeb776d09ed63f7dedc79e720674e6718) )
 
-	ROM_REGION( 0x0c000, "tiles",0)
+	ROM_REGION( 0x0c000, "tiles", 0 )
 	ROM_LOAD( "5.a13", 0x0000,  0x4000, CRC(9baee4a7) SHA1(31bcec838789462e67e54ebe7256db9fc4e51b69) )
 	ROM_LOAD( "4.a15", 0x4000,  0x4000, CRC(8155387d) SHA1(5f0a394c7671442519a831b0eeeaba4eecd5a406) )
 	ROM_LOAD( "3.a16", 0x8000,  0x4000, CRC(4db4448d) SHA1(50a94fd65c263d95fd24b4009dbb87707929fdcb) )
 
-	ROM_REGION( 0x20000, "sprites",0 )
+	ROM_REGION( 0x20000, "sprites", 0 )
 	ROM_LOAD( "6.a4", 0x00000,  0x8000, CRC(4a95a89c) SHA1(b34ebbda9b0e591876988e42bd36fd505452f38c) )
 	ROM_LOAD( "8.a7", 0x08000,  0x8000, CRC(3e6be0fb) SHA1(319ea59107e37953c31f59f5f635fc520682b09f) )
 	ROM_LOAD( "7.a5", 0x10000,  0x8000, CRC(8ad38884) SHA1(e11f1e1db6d5d119afedbe6604d10a6fd6049f12) )
 	ROM_LOAD( "9.a8", 0x18000,  0x8000, CRC(3568c158) SHA1(c3a2120086befe396a112bd62f032638011cb47a) )
 
-	ROM_REGION( 0x1300, "proms",0 )
+	ROM_REGION( 0x1300, "proms", 0 )
 	ROM_LOAD( "d.c3",0x0000, 0x0100, CRC(68575300) SHA1(bc93a38df91ad8c2f335f9bccc98b52376f9b483) )
 	ROM_LOAD( "c.c2",0x0100, 0x0100, CRC(eb008d62) SHA1(a370fbd1affaa489210ea36eb9e365263fb4e232) )
 	ROM_LOAD( "b.c1",0x0200, 0x0100, CRC(65da3604) SHA1(e4874d4152a57944d4e47306250833ea5cd0d89b) )

--- a/src/mame/seibu/panicr.cpp
+++ b/src/mame/seibu/panicr.cpp
@@ -287,7 +287,6 @@ uint32_t panicr_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap
 //  m_infotilemap_2->draw(screen, *m_temprender, m_tempbitmap_clip, 0,0);
 
 	bitmap.fill(m_palette->black_pen(), cliprect);
-	//m_txttilemap->mark_all_dirty();
 
 	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{

--- a/src/mame/seibu/panicr.cpp
+++ b/src/mame/seibu/panicr.cpp
@@ -16,7 +16,7 @@ SEI-8611M (M6100219A)
 
 OSC  : 14.31818MHz,12.0000MHz,16.0000MHz
 CPU  : V20 (Sony CXQ70116D-8) @ 8.000MHz [16/2]
-       Toshiba T5182 @ 3.579545 (14.31818/4]
+       Toshiba T5182 @ 3.579545 [14.31818/4]
 Sound: YM2151 @ 3.579545 [14.31818/4]
     VSync 60Hz
     HSync 15.32kHz
@@ -87,7 +87,9 @@ public:
 		m_mainram(*this, "mainram"),
 		m_spriteram(*this, "spriteram"),
 		m_textram(*this, "textram"),
-		m_spritebank(*this, "spritebank")
+		m_spritebank(*this, "spritebank"),
+		m_tilerom(*this, "tilerom"),
+		m_attrrom(*this, "attrrom")
 	{ }
 
 	void panicr(machine_config &config);
@@ -95,26 +97,7 @@ public:
 	void init_panicr();
 
 private:
-	required_device<cpu_device> m_maincpu;
-	required_device<t5182_device> m_t5182;
-	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<screen_device> m_screen;
-	required_device<palette_device> m_palette;
-
-	required_shared_ptr<uint8_t> m_mainram;
-	required_shared_ptr<uint8_t> m_spriteram;
-	required_shared_ptr<uint8_t> m_textram;
-	required_shared_ptr<uint8_t> m_spritebank;
-
-	tilemap_t *m_bgtilemap = nullptr;
-	tilemap_t *m_infotilemap_2 = nullptr;
-	tilemap_t *m_txttilemap = nullptr;
-
-	int m_scrollx = 0;
-	std::unique_ptr<bitmap_ind16> m_temprender;
-	std::unique_ptr<bitmap_ind16> m_tempbitmap_1;
-	rectangle m_tempbitmap_clip;
-
+	void textram_w(offs_t offset, uint8_t data);
 	uint8_t collision_r(offs_t offset);
 	void scrollx_lo_w(uint8_t data);
 	void scrollx_hi_w(uint8_t data);
@@ -134,12 +117,34 @@ private:
 
 	TIMER_DEVICE_CALLBACK_MEMBER(scanline);
 	void panicr_map(address_map &map);
+
+	required_device<cpu_device> m_maincpu;
+	required_device<t5182_device> m_t5182;
+	required_device<gfxdecode_device> m_gfxdecode;
+	required_device<screen_device> m_screen;
+	required_device<palette_device> m_palette;
+
+	required_shared_ptr<uint8_t> m_mainram;
+	required_shared_ptr<uint8_t> m_spriteram;
+	required_shared_ptr<uint8_t> m_textram;
+	required_shared_ptr<uint8_t> m_spritebank;
+
+	required_region_ptr<uint8_t> m_tilerom;
+	required_region_ptr<uint8_t> m_attrrom;
+
+	tilemap_t *m_bgtilemap = nullptr;
+	tilemap_t *m_infotilemap_2 = nullptr;
+	tilemap_t *m_txttilemap = nullptr;
+
+	int m_scrollx = 0;
+	std::unique_ptr<bitmap_ind16> m_temprender;
+	std::unique_ptr<bitmap_ind16> m_tempbitmap_1;
+	rectangle m_tempbitmap_clip;
+
 };
 
 
-#define MASTER_CLOCK    XTAL(16'000'000)
-#define SOUND_CLOCK     XTAL(14'318'181)
-#define TC15_CLOCK      XTAL(12'000'000)
+//#define TC15_CLOCK      XTAL(12'000'000)
 
 
 /***************************************************************************
@@ -193,11 +198,9 @@ void panicr_state::panicr_palette(palette_device &palette) const
 
 TILE_GET_INFO_MEMBER(panicr_state::get_bgtile_info)
 {
-	int code,attr;
-
-	code=memregion("user1")->base()[tile_index];
-	attr=memregion("user2")->base()[tile_index];
-	code+=((attr&7)<<8);
+	int code = m_tilerom[tile_index];
+	int const attr = m_attrrom[tile_index];
+	code += ((attr & 7) << 8);
 	tileinfo.set(1,
 		code,
 		(attr & 0xf0) >> 4,
@@ -205,14 +208,11 @@ TILE_GET_INFO_MEMBER(panicr_state::get_bgtile_info)
 }
 
 
-
 TILE_GET_INFO_MEMBER(panicr_state::get_infotile_info_2)
 {
-	int code,attr;
-
-	code=memregion("user1")->base()[tile_index];
-	attr=memregion("user2")->base()[tile_index];
-	code+=((attr&7)<<8);
+	int code = m_tilerom[tile_index];
+	int const attr = m_attrrom[tile_index];
+	code += ((attr & 7) << 8);
 	tileinfo.set(3,
 		code,
 		0,
@@ -220,13 +220,11 @@ TILE_GET_INFO_MEMBER(panicr_state::get_infotile_info_2)
 }
 
 
-
-
 TILE_GET_INFO_MEMBER(panicr_state::get_txttile_info)
 {
-	int code=m_textram[tile_index*4];
-	int attr=m_textram[tile_index*4+2];
-	int color = attr & 0x07;
+	int const code = m_textram[tile_index * 4];
+	int const attr = m_textram[tile_index * 4 + 2];
+	int const color = attr & 0x07;
 
 	tileinfo.group = color;
 
@@ -250,36 +248,32 @@ void panicr_state::video_start()
 
 void panicr_state::draw_sprites(bitmap_ind16 &bitmap,const rectangle &cliprect )
 {
-	int offs,flipx,flipy,x,y,color,sprite;
-
-
 	// ssss ssss | Fx-- cccc | yyyy yyyy | xxxx xxxx
 
-	for (offs = m_spriteram.bytes() - 16; offs>=0; offs-=16)
+	for (int offs = m_spriteram.bytes() - 16; offs >= 0; offs -= 16)
 	{
-		flipx = 0;
-		flipy = m_spriteram[offs+1] & 0x80;
-		y = m_spriteram[offs+2];
-		x = m_spriteram[offs+3];
-		if (m_spriteram[offs+1] & 0x40) x -= 0x100;
+		bool const flipx = false;
+		bool const flipy = BIT(m_spriteram[offs + 1], 7);
+		int const y = m_spriteram[offs + 2];
+		int x = m_spriteram[offs + 3];
+		if (BIT(m_spriteram[offs + 1], 6)) x -= 0x100;
 
-		if (m_spriteram[offs+1] & 0x20)
+		if (BIT(m_spriteram[offs + 1], 5))
 		{
 			// often set
 		}
 
-		if (m_spriteram[offs+1] & 0x10)
+		if (BIT(m_spriteram[offs + 1], 4))
 		{
-			popmessage("(spriteram[offs+1] & 0x10) %02x\n", (m_spriteram[offs+1] & 0x10));
+			popmessage("(BIT(spriteram[offs + 1], 4)) %02x\n", BIT(m_spriteram[offs + 1], 4));
 		}
 
-
-		color = m_spriteram[offs+1] & 0x0f;
-		sprite = m_spriteram[offs+0] | (*m_spritebank << 8);
+		uint32_t const color = m_spriteram[offs + 1] & 0x0f;
+		uint32_t const sprite = m_spriteram[offs + 0] | (*m_spritebank << 8);
 
 		m_gfxdecode->gfx(2)->transmask(bitmap,cliprect,
 				sprite,
-				color,flipx,flipy,x,y,
+				color, flipx, flipy, x, y,
 				m_palette->transpen_mask(*m_gfxdecode->gfx(2), color, 0));
 	}
 }
@@ -292,44 +286,36 @@ uint32_t panicr_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap
 //  m_infotilemap_2->set_scrollx(0, m_scrollx);
 //  m_infotilemap_2->draw(screen, *m_temprender, m_tempbitmap_clip, 0,0);
 
-
 	bitmap.fill(m_palette->black_pen(), cliprect);
-	m_txttilemap->mark_all_dirty();
+	//m_txttilemap->mark_all_dirty();
 
-
-
-	for (int y=0;y<256;y++)
+	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{
 		uint16_t const *const srcline = &m_temprender->pix(y);
 		uint16_t *const dstline = &bitmap.pix(y);
 
-		for (int x=0;x<256;x++)
+		for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
 		{
 			uint16_t const dat = srcline[x];
 
 			dstline[x] = ((dat & 0x00f) | ((dat & 0x1e0)>>0)) + 0x200;
-
 		}
-
 	}
 
 	draw_sprites(bitmap,cliprect);
 
-	for (int y=0;y<256;y++)
+	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{
 		uint16_t const *const srcline = &m_temprender->pix(y);
 		uint16_t *const dstline = &bitmap.pix(y);
 
-		for (int x=0;x<256;x++)
+		for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
 		{
 			uint16_t const dat = srcline[x];
 			if (dat & 0x10)
 				dstline[x] = ((dat & 0x00f) | ((dat & 0x1e0)>>0)) + 0x200;
-
 		}
-
 	}
-
 
 	m_txttilemap->draw(screen, bitmap, cliprect, 0,0);
 
@@ -342,6 +328,14 @@ uint32_t panicr_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap
   I/O / Memory
 
 ***************************************************************************/
+
+void panicr_state::textram_w(offs_t offset, uint8_t data)
+{
+	m_textram[offset] = data;
+	if (BIT(~offset, 0))
+		m_txttilemap->mark_tile_dirty(offset >> 2);
+}
+
 
 uint8_t panicr_state::collision_r(offs_t offset)
 {
@@ -357,32 +351,26 @@ uint8_t panicr_state::collision_r(offs_t offset)
 	m_infotilemap_2->set_scrollx(0, m_scrollx & 0xffff);
 	m_infotilemap_2->draw(*m_screen, *m_tempbitmap_1, m_tempbitmap_clip, 0,0);
 
-
-	int actual_column = offset&0x3f;
-	int actual_line = offset >> 6;
-
+	int actual_column = offset & 0x3f;
+	int const actual_line = offset >> 6;
 
 	actual_column = actual_column * 4;
 
 	actual_column -= m_scrollx;
 	actual_column &= 0xff;
 
-
 	uint8_t ret = 0;
 	uint16_t const *const srcline = &m_tempbitmap_1->pix(actual_line);
 
+	ret |= (srcline[(actual_column + 0) & 0xff] & 3) << 6;
+	ret |= (srcline[(actual_column + 1) & 0xff] & 3) << 4;
+	ret |= (srcline[(actual_column + 2) & 0xff] & 3) << 2;
+	ret |= (srcline[(actual_column + 3) & 0xff] & 3) << 0;
 
-	ret |= (srcline[(actual_column+0)&0xff]&3) << 6;
-	ret |= (srcline[(actual_column+1)&0xff]&3) << 4;
-	ret |= (srcline[(actual_column+2)&0xff]&3) << 2;
-	ret |= (srcline[(actual_column+3)&0xff]&3) << 0;
-
-	logerror("%06x: (scroll x upper bits is %04x (full %04x)) read %d %d\n", m_maincpu->pc(), (m_scrollx&0xff00)>>8, m_scrollx,  actual_line, actual_column);
-
+	if (!machine().side_effects_disabled())
+		logerror("%06x: (scroll x upper bits is %04x (full %04x)) read %d %d\n", m_maincpu->pc(), (m_scrollx&0xff00)>>8, m_scrollx,  actual_line, actual_column);
 
 	return ret;
-
-
 }
 
 
@@ -401,8 +389,8 @@ void panicr_state::scrollx_hi_w(uint8_t data)
 void panicr_state::output_w(uint8_t data)
 {
 	// d6, d7: play counter? (it only triggers on 1st coin)
-	machine().bookkeeping().coin_counter_w(0, (data & 0x40) ? 1 : 0);
-	machine().bookkeeping().coin_counter_w(1, (data & 0x80) ? 1 : 0);
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 6));
+	machine().bookkeeping().coin_counter_w(1, BIT(data, 7));
 
 	logerror("output_w %02x\n", data);
 
@@ -426,11 +414,11 @@ void panicr_state::t5182shared_w(offs_t offset, uint8_t data)
 
 void panicr_state::panicr_map(address_map &map)
 {
-	map(0x00000, 0x01fff).ram().share("mainram");
-	map(0x02000, 0x03cff).ram().share("spriteram"); // how big is sprite ram, some places definitely have sprites at 3000+
+	map(0x00000, 0x01fff).ram().share(m_mainram);
+	map(0x02000, 0x03cff).ram().share(m_spriteram); // how big is sprite ram, some places definitely have sprites at 3000+
 	map(0x03d00, 0x03fff).ram();
 	map(0x08000, 0x0bfff).r(FUNC(panicr_state::collision_r));
-	map(0x0c000, 0x0cfff).ram().share("textram");
+	map(0x0c000, 0x0cfff).ram().w(FUNC(panicr_state::textram_w)).share(m_textram);
 	map(0x0d000, 0x0d000).w(m_t5182, FUNC(t5182_device::sound_irq_w));
 	map(0x0d002, 0x0d002).w(m_t5182, FUNC(t5182_device::sharedram_semaphore_main_acquire_w));
 	map(0x0d004, 0x0d004).r(m_t5182, FUNC(t5182_device::sharedram_semaphore_snd_r));
@@ -444,7 +432,7 @@ void panicr_state::panicr_map(address_map &map)
 	map(0x0d802, 0x0d802).w(FUNC(panicr_state::scrollx_hi_w));
 	map(0x0d804, 0x0d804).w(FUNC(panicr_state::scrollx_lo_w));
 	map(0x0d80a, 0x0d80a).w(FUNC(panicr_state::output_w));
-	map(0x0d80c, 0x0d80c).writeonly().share("spritebank");
+	map(0x0d80c, 0x0d80c).writeonly().share(m_spritebank);
 	map(0x0d818, 0x0d818).nopw(); // watchdog?
 	map(0xf0000, 0xfffff).rom();
 }
@@ -586,10 +574,10 @@ static const gfx_layout spritelayout =
 };
 
 static GFXDECODE_START( gfx_panicr )
-	GFXDECODE_ENTRY( "gfx1", 0, charlayout,     0x000,  8 )
-	GFXDECODE_ENTRY( "gfx2", 0, bgtilelayout,   0x200, 32 )
-	GFXDECODE_ENTRY( "gfx3", 0, spritelayout,   0x100, 16 )
-	GFXDECODE_ENTRY( "gfx2", 0, infotilelayout_2, 0x100, 16 ) // palette is just to make it viewable with F4
+	GFXDECODE_ENTRY( "chars",   0, charlayout,       0x000,  8 )
+	GFXDECODE_ENTRY( "tiles",   0, bgtilelayout,     0x200, 32 )
+	GFXDECODE_ENTRY( "sprites", 0, spritelayout,     0x100, 16 )
+	GFXDECODE_ENTRY( "tiles",   0, infotilelayout_2, 0x100, 16 ) // palette is just to make it viewable with F4
 
 GFXDECODE_END
 
@@ -607,11 +595,16 @@ TIMER_DEVICE_CALLBACK_MEMBER(panicr_state::scanline)
 
 void panicr_state::panicr(machine_config &config)
 {
-	V20(config, m_maincpu, MASTER_CLOCK/2); /* Sony 8623h9 CXQ70116D-8 (V20 compatible) */
+	constexpr XTAL MASTER_CLOCK = XTAL(16'000'000);
+	constexpr XTAL SOUND_CLOCK = XTAL(14'318'181);
+
+	V20(config, m_maincpu, MASTER_CLOCK/2); // Sony 8623h9 CXQ70116D-8 (V20 compatible)
 	m_maincpu->set_addrmap(AS_PROGRAM, &panicr_state::panicr_map);
 	TIMER(config, "scantimer").configure_scanline(FUNC(panicr_state::scanline), "screen", 0, 1);
 
-	T5182(config, m_t5182, 0);
+	T5182(config, m_t5182, SOUND_CLOCK/4);
+	m_t5182->ym_read_callback().set("ymsnd", FUNC(ym2151_device::read));
+	m_t5182->ym_write_callback().set("ymsnd", FUNC(ym2151_device::write));
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_refresh_hz(60);
@@ -625,10 +618,10 @@ void panicr_state::panicr(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_panicr);
 	PALETTE(config, m_palette, FUNC(panicr_state::panicr_palette), 256 * 4, 256);
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
-	ym2151_device &ymsnd(YM2151(config, "ymsnd", SOUND_CLOCK/4)); /* 3.579545 MHz */
+	ym2151_device &ymsnd(YM2151(config, "ymsnd", SOUND_CLOCK/4)); // 3.579545 MHz
 	ymsnd.irq_handler().set(m_t5182, FUNC(t5182_device::ym2151_irq_handler));
 	ymsnd.add_route(0, "mono", 1.0);
 	ymsnd.add_route(1, "mono", 1.0);
@@ -636,30 +629,30 @@ void panicr_state::panicr(machine_config &config)
 
 
 ROM_START( panicr )
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v20 main cpu */
+	ROM_REGION( 0x100000, "maincpu", 0 ) // v20 main cpu
 	ROM_LOAD16_BYTE("2.19m",   0x0f0000, 0x08000, CRC(3d48b0b5) SHA1(a6e8b38971a8964af463c16f32bb7dbd301dd314) )
 	ROM_LOAD16_BYTE("1.19n",   0x0f0001, 0x08000, CRC(674131b9) SHA1(63499cd5ad39e79e70f3ba7060680f0aa133f095) )
 
-	ROM_REGION( 0x8000, "t5182_z80", 0 ) /* Toshiba T5182 external ROM */
+	ROM_REGION( 0x8000, "t5182:external", 0 ) // Toshiba T5182 external ROM
 	ROM_LOAD( "22d.bin",   0x0000, 0x8000, CRC(eb1a46e1) SHA1(278859ae4bca9f421247e646d789fa1206dcd8fc) )
 
-	ROM_REGION( 0x04000, "gfx1", 0 )
+	ROM_REGION( 0x04000, "chars", 0 )
 	ROM_LOAD( "13f.bin", 0x000000, 0x2000, CRC(4e6b3c04) SHA1(f388969d5d822df0eaa4d8300cbf9cee47468360) )
 	ROM_LOAD( "15f.bin", 0x002000, 0x2000, CRC(d735b572) SHA1(edcdb6daec97ac01a73c5010727b1694f512be71) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )
+	ROM_REGION( 0x80000, "tiles", 0 )
 	ROM_LOAD( "2a.bin", 0x000000, 0x20000, CRC(3ac0e5b4) SHA1(96b8bdf02002ec8ce87fd47fd21f7797a79d79c9) )
 	ROM_LOAD( "2b.bin", 0x020000, 0x20000, CRC(567d327b) SHA1(762b18ef1627d71074ba02b0eb270bd9a01ac0d8) )
 	ROM_LOAD( "2c.bin", 0x040000, 0x20000, CRC(cd77ec79) SHA1(94b61b7d77c016ae274eddbb1e66e755f312e11d) )
 	ROM_LOAD( "2d.bin", 0x060000, 0x20000, CRC(218d2c3e) SHA1(9503b3b67e71dc63448aed7815845b844e240afe) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 )
+	ROM_REGION( 0x40000, "sprites", 0 )
 	ROM_LOAD( "2j.bin", 0x000000, 0x20000, CRC(80f05923) SHA1(5c886446fd77d3c39cb4fa43ea4beb8c89d20636) )
 	ROM_LOAD( "2k.bin", 0x020000, 0x20000, CRC(35f07bca) SHA1(54e6f82c2e6e1373c3ac1c6138ef738e5a0be6d0) )
 
-	ROM_REGION( 0x04000, "user1", 0 )
+	ROM_REGION( 0x04000, "tilerom", 0 )
 	ROM_LOAD( "5d.bin", 0x00000, 0x4000, CRC(f3466906) SHA1(42b512ba93ba7ac958402d1871c5ae015def3501) ) //tilemaps
-	ROM_REGION( 0x04000, "user2", 0 )
+	ROM_REGION( 0x04000, "attrrom", 0 )
 	ROM_LOAD( "7d.bin", 0x00000, 0x4000, CRC(8032c1e9) SHA1(fcc8579c0117ebe9271cff31e14a30f61a9cf031) ) //attribute maps
 
 	ROM_REGION( 0x0800,  "proms", 0 )
@@ -673,31 +666,31 @@ ROM_START( panicr )
 	ROM_LOAD( "10l.bpr", 0x00700, 0x100, CRC(f3f29695) SHA1(2607e96564a5e6e9a542377a01f399ea86a36c48) ) // unknown
 ROM_END
 
-ROM_START( panicrg ) /* Distributed by TV-Tuning Videospiele GMBH */
-	ROM_REGION( 0x200000, "maincpu", 0 ) /* v20 main cpu */
+ROM_START( panicrg ) // Distributed by TV-Tuning Videospiele GMBH
+	ROM_REGION( 0x100000, "maincpu", 0 ) // v20 main cpu
 	ROM_LOAD16_BYTE("2g.19m",   0x0f0000, 0x08000, CRC(cf759403) SHA1(1a0911c943ecc752e46873c9a5da981745f7562d) )
 	ROM_LOAD16_BYTE("1g.19n",   0x0f0001, 0x08000, CRC(06877f9b) SHA1(8b92209d6422ff2b1f3cb66bd39a3ff84e399eec) )
 
-	ROM_REGION( 0x10000, "t5182_z80", 0 ) /* Toshiba T5182 external ROM */
+	ROM_REGION( 0x10000, "t5182:external", 0 ) // Toshiba T5182 external ROM
 	ROM_LOAD( "22d.bin",   0x0000, 0x8000, CRC(eb1a46e1) SHA1(278859ae4bca9f421247e646d789fa1206dcd8fc) )
 
-	ROM_REGION( 0x04000, "gfx1", 0 )
+	ROM_REGION( 0x04000, "chars", 0 )
 	ROM_LOAD( "13f.bin", 0x000000, 0x2000, CRC(4e6b3c04) SHA1(f388969d5d822df0eaa4d8300cbf9cee47468360) )
 	ROM_LOAD( "15f.bin", 0x002000, 0x2000, CRC(d735b572) SHA1(edcdb6daec97ac01a73c5010727b1694f512be71) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )
+	ROM_REGION( 0x80000, "tiles", 0 )
 	ROM_LOAD( "2a.bin", 0x000000, 0x20000, CRC(3ac0e5b4) SHA1(96b8bdf02002ec8ce87fd47fd21f7797a79d79c9) )
 	ROM_LOAD( "2b.bin", 0x020000, 0x20000, CRC(567d327b) SHA1(762b18ef1627d71074ba02b0eb270bd9a01ac0d8) )
 	ROM_LOAD( "2c.bin", 0x040000, 0x20000, CRC(cd77ec79) SHA1(94b61b7d77c016ae274eddbb1e66e755f312e11d) )
 	ROM_LOAD( "2d.bin", 0x060000, 0x20000, CRC(218d2c3e) SHA1(9503b3b67e71dc63448aed7815845b844e240afe) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 )
+	ROM_REGION( 0x40000, "sprites", 0 )
 	ROM_LOAD( "2j.bin", 0x000000, 0x20000, CRC(80f05923) SHA1(5c886446fd77d3c39cb4fa43ea4beb8c89d20636) )
 	ROM_LOAD( "2k.bin", 0x020000, 0x20000, CRC(35f07bca) SHA1(54e6f82c2e6e1373c3ac1c6138ef738e5a0be6d0) )
 
-	ROM_REGION( 0x04000, "user1", 0 )
+	ROM_REGION( 0x04000, "tilerom", 0 )
 	ROM_LOAD( "5d.bin", 0x00000, 0x4000, CRC(f3466906) SHA1(42b512ba93ba7ac958402d1871c5ae015def3501) ) //tilemaps
-	ROM_REGION( 0x04000, "user2", 0 )
+	ROM_REGION( 0x04000, "attrrom", 0 )
 	ROM_LOAD( "7d.bin", 0x00000, 0x4000, CRC(8032c1e9) SHA1(fcc8579c0117ebe9271cff31e14a30f61a9cf031) ) //attribute maps
 
 	ROM_REGION( 0x0800,  "proms", 0 )
@@ -716,8 +709,8 @@ void panicr_state::init_panicr()
 {
 	std::vector<uint8_t> buf(0x80000);
 
-	uint8_t *rom = memregion("gfx1")->base();
-	int size = memregion("gfx1")->bytes();
+	uint8_t *rom = memregion("chars")->base();
+	int size = memregion("chars")->bytes();
 
 	// text data lines
 	for (int i = 0; i < size / 2; i++)
@@ -735,8 +728,8 @@ void panicr_state::init_panicr()
 		rom[i] = buf[bitswap<24>(i,23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6, 2,3,1,0,5,4)];
 	}
 
-	rom = memregion("gfx2")->base();
-	size = memregion("gfx2")->bytes();
+	rom = memregion("tiles")->base();
+	size = memregion("tiles")->bytes();
 
 	// tiles data lines
 	for (int i = 0; i < size / 4; i++)
@@ -759,8 +752,8 @@ void panicr_state::init_panicr()
 		rom[i] = buf[bitswap<24>(i,23,22,21,20,19,18,17,16,15,14,13,12, 5,4,3,2, 11,10,9,8,7,6, 0,1)];
 	}
 
-	rom = memregion("gfx3")->base();
-	size = memregion("gfx3")->bytes();
+	rom = memregion("sprites")->base();
+	size = memregion("sprites")->bytes();
 
 	// sprites data lines
 	for (int i = 0; i < size / 2; i++)
@@ -779,8 +772,8 @@ void panicr_state::init_panicr()
 	}
 
 	//rearrange  bg tilemaps a bit....
-	rom = memregion("user1")->base();
-	size = memregion("user1")->bytes();
+	rom = memregion("tilerom")->base();
+	size = memregion("tilerom")->bytes();
 	memcpy(&buf[0], rom, size);
 
 	for (int j = 0; j < 16; j++)
@@ -791,8 +784,8 @@ void panicr_state::init_panicr()
 		}
 	}
 
-	rom = memregion("user2")->base();
-	size = memregion("user2")->bytes();
+	rom = memregion("attrrom")->base();
+	size = memregion("attrrom")->bytes();
 	memcpy(&buf[0], rom, size);
 
 	for (int j = 0; j < 16; j++)

--- a/src/mame/seibu/t5182.h
+++ b/src/mame/seibu/t5182.h
@@ -24,6 +24,10 @@ public:
 		CPU_CLEAR
 	};
 
+	// configuration
+	auto ym_read_callback()  { return m_ym_read_cb.bind(); }
+	auto ym_write_callback() { return m_ym_write_cb.bind(); }
+
 	void sound_irq_w(uint8_t data);
 	uint8_t sharedram_semaphore_snd_r();
 	void sharedram_semaphore_main_acquire_w(uint8_t data);
@@ -32,8 +36,6 @@ public:
 	void sharedram_w(offs_t offset, uint8_t data);
 	void ym2151_irq_handler(int state);
 
-	void t5182_io(address_map &map);
-	void t5182_map(address_map &map);
 protected:
 	// device-level overrides
 	virtual void device_start() override;
@@ -42,12 +44,6 @@ protected:
 	virtual void device_add_mconfig(machine_config &config) override;
 
 private:
-	// internal state
-	required_device<cpu_device> m_ourcpu;
-	required_shared_ptr<uint8_t> m_sharedram;
-	int m_irqstate;
-	int m_semaphore_main;
-	int m_semaphore_snd;
 	TIMER_CALLBACK_MEMBER(setirq_callback);
 
 	void sharedram_semaphore_snd_acquire_w(uint8_t data);
@@ -55,6 +51,23 @@ private:
 	uint8_t sharedram_semaphore_main_r();
 	void ym2151_irq_ack_w(uint8_t data);
 	void cpu_irq_ack_w(uint8_t data);
+	uint8_t ym_r(offs_t offset);
+	void ym_w(offs_t offset, uint8_t data);
+
+	void t5182_io(address_map &map);
+	void t5182_map(address_map &map);
+
+	// internal state
+	required_device<cpu_device> m_ourcpu;
+	required_shared_ptr<uint8_t> m_sharedram;
+
+	// device callbacks
+	devcb_read8 m_ym_read_cb;
+	devcb_write8 m_ym_write_cb;
+
+	uint32_t m_irqstate;
+	bool m_semaphore_main;
+	bool m_semaphore_snd;
 };
 
 DECLARE_DEVICE_TYPE(T5182, t5182_device)


### PR DESCRIPTION
- Use DERIVED_CLOCK for Z80 clock input
- Fix spacing
- Correct typename for variables
- Use C++ style comments for single line comments

seibu/darkmist.cpp: Cleanups
- Reduce literal tag usage and runtime tag lookups
- Reduce unnecessary lines
- Fix spacings

seibu/metlfrzr.cpp: Cleanups
- Reduce literal tag usage and runtime tag lookups
- Constantize variables
- Fix spacing
- Fix ROM region namings
- Use C++ style comments for single line comments
- Fix filename in comment

seibu/mustache.cpp: Cleanups
- Fix spacing
- Fix main CPU ROM region size

seibu/panicr.cpp: Cleanups
- Fix typo in comment
- Reduce preprocessor defines
- Reduce literal tag usages and runtime tag lookups
- Use mark_tile_dirty for text tilemap layer mark dirty method
- Fix screen draw routine with cliprect
- Constantize variables
- Fix spacing
- Reduce unnecessary lines
- Suppress side effects for debugger read
- Fix ROM region namings
- Use C++ style comments for single line comments
- Fix main CPU ROM region size