### PR TITLE
drivenum.cpp: fix undefined behavior in find_approximate_matches

### DIFF
--- a/src/emu/drivenum.cpp
+++ b/src/emu/drivenum.cpp
@@ -260,7 +260,7 @@ void driver_enumerator::find_approximate_matches(std::string const &string, std:
 	{
 		// allocate memory to track the penalty value
 		std::vector<std::pair<double, int> > penalty;
-		penalty.reserve(count);
+		penalty.reserve(count + 1);
 		std::u32string const search(ustr_from_utf8(normalize_unicode(string, unicode_normalization_form::D, true)));
 		std::string composed;
 		std::u32string candidate;
@@ -303,9 +303,9 @@ void driver_enumerator::find_approximate_matches(std::string const &string, std:
 				auto const it(std::upper_bound(penalty.begin(), penalty.end(), std::make_pair(curpenalty, index)));
 				if (penalty.end() != it)
 				{
-					if (penalty.size() >= count)
-						penalty.resize(count - 1);
 					penalty.emplace(it, curpenalty, index);
+					if (penalty.size() > count)
+						penalty.pop_back();
 				}
 				else if (penalty.size() < count)
 				{


### PR DESCRIPTION
If `it` points to the last element of `penalty`, the `resize` call invalidates it, and the subsequent call to `emplace` is undefined. This causes a crash in MSVC debug mode.

Fix it by resizing _after_ emplacing.