### PR TITLE
CI: use more CPUs for building

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -58,7 +58,7 @@ jobs:
         ARCHOPTS: ${{ matrix.archopts }}
         SUBTARGET: ${{ matrix.subtarget }}
         TOOLS: 1
-      run: make -j2
+      run: make -j4
     - name: Validate
       run: ./${{ matrix.executable }} -validate
     - name: Reconcile driver list

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -33,7 +33,7 @@ jobs:
       env:
         USE_LIBSDL: 1
         TOOLS: 1
-      run: make -j2
+      run: make -j3
     - name: Validate
       run: ./mame -validate
     - uses: actions/upload-artifact@master

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -56,7 +56,7 @@ jobs:
         ARCHOPTS: "-fuse-ld=lld"
         SUBTARGET: ${{ matrix.subtarget }}
         TOOLS: 1
-      run: make -j2
+      run: make -j4
     - name: Validate
       run: ./${{ matrix.executable }}.exe -validate
     - uses: actions/upload-artifact@master


### PR DESCRIPTION
The standard GitHub runners have 3 to 4 CPUs, depending on the OS: <https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories>. Increase the number of Make jobs to utilize those CPUs better.