### PR TITLE
gaelco/gaelco_wrally_sprites.cpp: Updates & Cleanups

### DIFF
--- a/src/mame/gaelco/gaelco_wrally_sprites.cpp
+++ b/src/mame/gaelco/gaelco_wrally_sprites.cpp
@@ -9,8 +9,8 @@ DEFINE_DEVICE_TYPE(BLMBYCAR_SPRITES, blmbycar_sprites_device, "blmbycar_sprites"
 
 gaelco_wrally_sprites_device::gaelco_wrally_sprites_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, type, tag, owner, clock)
-	, m_gfxdecode(*this, finder_base::DUMMY_TAG)
-	, m_screen(*this, finder_base::DUMMY_TAG)
+	, device_gfx_interface(mconfig, *this)
+	, device_video_interface(mconfig, *this)
 {
 }
 
@@ -21,7 +21,7 @@ gaelco_wrally_sprites_device::gaelco_wrally_sprites_device(const machine_config 
 
 void gaelco_wrally_sprites_device::device_start()
 {
-	m_screen->register_screen_bitmap(m_temp_bitmap_sprites);
+	screen().register_screen_bitmap(m_temp_bitmap_sprites);
 }
 
 void gaelco_wrally_sprites_device::device_reset()
@@ -71,10 +71,9 @@ void gaelco_wrally_sprites_device::draw_sprites(const rectangle &cliprect, uint1
 {
 	m_temp_bitmap_sprites.fill(0, cliprect);
 
-	int i;
-	gfx_element *gfx = m_gfxdecode->gfx(0);
+	gfx_element *sprgfx = gfx(0);
 
-	for (i = 6 / 2; i < (0x1000 - 6) / 2; i += 4)
+	for (int i = 6 / 2; i < (0x1000 - 6) / 2; i += 4)
 	{
 		int sx, sy, number, color, attr, end, color_effect, high_priority;
 
@@ -83,8 +82,8 @@ void gaelco_wrally_sprites_device::draw_sprites(const rectangle &cliprect, uint1
 		if (end)
 			break;
 
-		int xflip = attr & 0x20;
-		int yflip = attr & 0x40;
+		const bool xflip = BIT(attr, 5);
+		const bool yflip = BIT(attr, 6);
 		color = color & 0x0f;
 
 		if (flip_screen)
@@ -93,27 +92,27 @@ void gaelco_wrally_sprites_device::draw_sprites(const rectangle &cliprect, uint1
 		}
 
 		// wrally adjusts sx by 0x0f, blmbycar implementation was 0x10
-		const uint8_t *gfx_src = gfx->get_data(number % gfx->elements());
+		uint8_t const *const gfx_src = sprgfx->get_data(number % sprgfx->elements());
 
-		for (int py = 0; py < gfx->height(); py++)
+		for (int py = 0; py < sprgfx->height(); py++)
 		{
 			/* get a pointer to the current line in the screen bitmap */
-			int ypos = ((sy + py) & 0x1ff);
+			const int ypos = ((sy + py) & 0x1ff);
 			uint16_t *const srcy = &m_temp_bitmap_sprites.pix(ypos);
 
-			int gfx_py = yflip ? (gfx->height() - 1 - py) : py;
+			const int gfx_py = yflip ? (sprgfx->height() - 1 - py) : py;
 
 			if ((ypos < cliprect.min_y) || (ypos > cliprect.max_y)) continue;
 
-			for (int px = 0; px < gfx->width(); px++)
+			for (int px = 0; px < sprgfx->width(); px++)
 			{
 				/* get current pixel */
-				int xpos = (((sx + px) & 0x3ff) - 0x0f) & 0x3ff;
+				const int xpos = (((sx + px) & 0x3ff) - 0x0f) & 0x3ff;
 				uint16_t *const pixel = srcy + xpos;
-				int gfx_px = xflip ? (gfx->width() - 1 - px) : px;
+				const int gfx_px = xflip ? (sprgfx->width() - 1 - px) : px;
 
 				/* get asociated pen for the current sprite pixel */
-				int gfx_pen = gfx_src[gfx->rowbytes()*gfx_py + gfx_px];
+				const int gfx_pen = gfx_src[sprgfx->rowbytes() * gfx_py + gfx_px];
 
 				if ((xpos < cliprect.min_x) || (xpos > cliprect.max_x)) continue;
 
@@ -162,11 +161,11 @@ void gaelco_wrally_sprites_device::mix_sprites(bitmap_ind16 &bitmap, const recta
 				// this is how we've packed the bits here
 				// ssss --ez PPPP pppp  s = shadow multiplier e = shadow enabled, z = priority, P = palette select, p = pen
 
-				const int pridat = (spriteptr[x] & 0x100) >> 8;
+				const int pridat = BIT(spriteptr[x], 8);
 
 				if (pridat == priority)
 				{
-					const int shadow = (spriteptr[x] & 0x200) >> 9;
+					const int shadow = BIT(spriteptr[x], 9);
 
 					if (!shadow)
 					{
@@ -184,7 +183,7 @@ void gaelco_wrally_sprites_device::mix_sprites(bitmap_ind16 &bitmap, const recta
 						}
 						else
 						{
-							dstptr[x] = (dstptr[x]&0x3ff) + (shadowlevel * 0x400);
+							dstptr[x] = (dstptr[x] & 0x3ff) + (shadowlevel * 0x400);
 						}
 					}
 				}
@@ -230,7 +229,7 @@ void blmbycar_sprites_device::get_sprites_info(uint16_t* spriteram, int& sx, int
 	// bytes are swapped around and color attribute is moved
 	sx = spriteram[3] & 0x03ff;
 	sy = (spriteram[0] & 0x01ff);
-	sy   = 0xf0 - ((sy & 0xff)  - (sy & 0x100)); // check if this logic works for wrally
+	sy = 0xf0 - ((sy & 0xff)  - (sy & 0x100)); // check if this logic works for wrally
 
 	number = spriteram[1] & 0x3fff;
 	color = (spriteram[2] & 0x000f) >> 0; // note moved
@@ -239,5 +238,5 @@ void blmbycar_sprites_device::get_sprites_info(uint16_t* spriteram, int& sx, int
 	attr = (spriteram[2] & 0xfe00) >> 9;
 	end = (spriteram[0] & 0x8000); // does wrally have this too?
 
-	high_priority = (~(color >> 3))&1;
+	high_priority = (~(color >> 3)) & 1;
 }

--- a/src/mame/gaelco/gaelco_wrally_sprites.h
+++ b/src/mame/gaelco/gaelco_wrally_sprites.h
@@ -7,13 +7,16 @@
 
 #include "screen.h"
 
-class gaelco_wrally_sprites_device : public device_t
+class gaelco_wrally_sprites_device : public device_t, public device_gfx_interface, public device_video_interface
 {
 public:
 	gaelco_wrally_sprites_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-	template <typename T> void set_gfxdecode_tag(T &&tag) { m_gfxdecode.set_tag(std::forward<T>(tag)); }
-	template <typename T> void set_screen_tag(T &&tag) { m_screen.set_tag(std::forward<T>(tag)); }
+	template <typename T> gaelco_wrally_sprites_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&palette_tag, const gfx_decode_entry *gfxinfo)
+		: gaelco_wrally_sprites_device(mconfig, tag, owner, clock)
+	{
+		set_info(gfxinfo);
+		set_palette(std::forward<T>(palette_tag));
+	}
 
 	void draw_sprites(const rectangle &cliprect, uint16_t* spriteram, int flip_screen);
 	void mix_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, int priority);
@@ -27,9 +30,6 @@ protected:
 	virtual void get_sprites_info(uint16_t* spriteram, int& sx, int& sy, int& number, int& color, int& color_effect, int& attr, int& high_priotiy, int &end);
 
 private:
-	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<screen_device> m_screen;
-
 	bitmap_ind16 m_temp_bitmap_sprites;
 };
 
@@ -37,6 +37,12 @@ class blmbycar_sprites_device : public gaelco_wrally_sprites_device
 {
 public:
 	blmbycar_sprites_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	template <typename T> blmbycar_sprites_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&palette_tag, const gfx_decode_entry *gfxinfo)
+		: blmbycar_sprites_device(mconfig, tag, owner, clock)
+	{
+		set_info(gfxinfo);
+		set_palette(std::forward<T>(palette_tag));
+	}
 
 protected:
 	virtual void get_sprites_info(uint16_t* spriteram, int& sx, int& sy, int& number, int& color, int& color_effect, int& attr, int& high_priotiy, int &end) override;

--- a/src/mame/gaelco/wrally.cpp
+++ b/src/mame/gaelco/wrally.cpp
@@ -239,11 +239,11 @@ private:
 template <int Layer>
 TILE_GET_INFO_MEMBER(wrally_state::get_tile_info)
 {
-	int const data = m_videoram[(Layer * 0x2000 / 2) + (tile_index << 1)];
-	int const data2 = m_videoram[(Layer * 0x2000 / 2) + (tile_index << 1) + 1];
-	int const code = data & 0x3fff;
+	uint16_t const data = m_videoram[(Layer * 0x2000 / 2) + (tile_index << 1)];
+	uint16_t const data2 = m_videoram[(Layer * 0x2000 / 2) + (tile_index << 1) + 1];
+	uint32_t const code = data & 0x3fff;
 
-	tileinfo.category = (data2 >> 5) & 0x01;
+	tileinfo.category = BIT(data2, 5);
 
 	tileinfo.set(0, code, data2 & 0x1f, TILE_FLIPYX((data2 >> 6) & 0x03));
 }
@@ -358,7 +358,7 @@ void wrally_state::coin_lockout_w(int state)
 template <int N>
 int wrally_state::analog_bit_r()
 {
-	return (m_analog_ports[N] >> 7) & 0x01;
+	return BIT(m_analog_ports[N], 7);
 }
 
 void wrally_state::adc_clk(int state)
@@ -542,9 +542,8 @@ void wrally_state::wrally(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_wrally);
 	PALETTE(config, m_palette).set_format(palette_device::xBRG_444, 1024*8);
 
-	GAELCO_WRALLY_SPRITES(config, m_sprites, 0);
-	m_sprites->set_gfxdecode_tag("gfxdecode");
-	m_sprites->set_screen_tag("screen");
+	GAELCO_WRALLY_SPRITES(config, m_sprites, 0, m_palette, gfx_wrally);
+	m_sprites->set_screen("screen");
 
 	LS259(config, m_outlatch);
 	m_outlatch->q_out_cb<0>().set(FUNC(wrally_state::coin_lockout_w<0>));
@@ -585,7 +584,7 @@ ROM_START( wrally )
 	ROM_LOAD16_BYTE( "worldr19.i09", 0x100000, 0x080000, CRC(018b35bb) SHA1(ca789e23d18cc7d7e48b6858e6b61e03bf88b475) )
 	ROM_LOAD16_BYTE( "worldr18.i07", 0x100001, 0x080000, CRC(b37c807e) SHA1(9e6155a2b5206c0d4dca669d24d9fe9830027651) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples - sound chip is OKIM6295
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "worldr14.c01",   0x000000, 0x080000, CRC(e931c2ee) SHA1(ea1cf8ad52713e5136a370e289567eea9e6403d6) )
 	// 0x00000-0x2ffff is fixed, 0x30000-0x3ffff is bank switched from all the ROMs
 	ROM_LOAD( "worldr15.c03",   0x080000, 0x080000, CRC(11f0fe2c) SHA1(96c2a04874fa036576b7cfc5559bb0e33582ffd2) )
@@ -618,7 +617,7 @@ ROM_START( wrallya )
 	ROM_LOAD16_BYTE( "worldr19.i09", 0x100000, 0x080000, CRC(018b35bb) SHA1(ca789e23d18cc7d7e48b6858e6b61e03bf88b475) )
 	ROM_LOAD16_BYTE( "worldr18.i07", 0x100001, 0x080000, CRC(b37c807e) SHA1(9e6155a2b5206c0d4dca669d24d9fe9830027651) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples - sound chip is OKIM6295
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "worldr14.c01",   0x000000, 0x080000, CRC(e931c2ee) SHA1(ea1cf8ad52713e5136a370e289567eea9e6403d6) )
 	// 0x00000-0x2ffff is fixed, 0x30000-0x3ffff is bank switched from all the ROMs
 	ROM_LOAD( "worldr15.c03",   0x080000, 0x080000, CRC(11f0fe2c) SHA1(96c2a04874fa036576b7cfc5559bb0e33582ffd2) )
@@ -649,7 +648,7 @@ ROM_START( wrallyb )
 	ROM_LOAD( "rally h-12.h12", 0x000000, 0x100000, CRC(3353dc00) SHA1(db3b1686751dcaa231d66c08b5be81fcfe299ad9) ) // Same data, different layout
 	ROM_LOAD( "rally h-8.h8",   0x100000, 0x100000, CRC(58dcd024) SHA1(384ff296d3c7c8e0c4469231d1940de3cea89fc2) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples - sound chip is OKIM6295
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "sound c-1.c1", 0x000000, 0x100000, CRC(2d69c9b8) SHA1(328cb3c928dc6921c0c3f0277f59bca6c747c504) ) // Same data in a single ROM
 
 	ROM_REGION( 0x0514, "plds", 0 ) // PALs and GALs
@@ -680,7 +679,7 @@ ROM_START( wrallyc )
 	ROM_LOAD16_BYTE( "rally i9.i9",   0x100000, 0x080000, CRC(018b35bb) SHA1(ca789e23d18cc7d7e48b6858e6b61e03bf88b475) )
 	ROM_LOAD16_BYTE( "rally i7.i7",   0x100001, 0x080000, CRC(b37c807e) SHA1(9e6155a2b5206c0d4dca669d24d9fe9830027651) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples - sound chip is OKIM6295
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "rally c1.c1",   0x000000, 0x080000, CRC(e931c2ee) SHA1(ea1cf8ad52713e5136a370e289567eea9e6403d6) )
 	// 0x00000-0x2ffff is fixed, 0x30000-0x3ffff is bank switched from all the ROMs
 	ROM_LOAD( "rally c3.c3",   0x080000, 0x080000, CRC(11f0fe2c) SHA1(96c2a04874fa036576b7cfc5559bb0e33582ffd2) )
@@ -711,7 +710,7 @@ ROM_START( wrallyat ) // Board Marked 930217, Atari License
 	ROM_LOAD( "rally h-12.h12", 0x000000, 0x100000, CRC(3353dc00) SHA1(db3b1686751dcaa231d66c08b5be81fcfe299ad9) ) // Same data, different layout
 	ROM_LOAD( "rally h-8.h8",   0x100000, 0x100000, CRC(58dcd024) SHA1(384ff296d3c7c8e0c4469231d1940de3cea89fc2) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples - sound chip is OKIM6295
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "sound c-1.c1", 0x000000, 0x100000, CRC(2d69c9b8) SHA1(328cb3c928dc6921c0c3f0277f59bca6c747c504) ) // Same data in a single ROM
 
 	ROM_REGION( 0x0514, "plds", 0 ) // PALs and GALs


### PR DESCRIPTION
- Use device_gfx_interface and device_video_interface for gfx decode and screen
- Fix spacing
- Make some variables constant
- Reduce unnecessary line

gaelco/blmbycar.cpp: Cleanups
- Fix spacing
- Suppress side effects for debugger read
- Use C++ style single line comments
- Fix comments

gaelco/wrally.cpp: Cleanups
- Correct type for variables
- Fix comments