### PR TITLE
imagedev/floppy.cpp: fix out-of-bounds access to the seek sample

### DIFF
--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -1639,6 +1639,9 @@ void floppy_sound_device::step(int zone)
 						}
 					}
 				}
+
+				// Start the new seek sound from the beginning.
+				m_seek_samplepos = 0;
 			}
 
 			// Changing the pitch does not always sound convincing


### PR DESCRIPTION
Currently, when `floppy_sound_device::step` selects a new seek sample, the value of `m_seek_samplepos` remains the same as it was the last time a seek sample was played. This might be an invalid position for the new sample, since the seek samples have different lengths. When this is the case, the next call to `floppy_sound_device::sound_stream_update` makes an out-of-bounds memory access as it reads the sample data.

Fix this by resetting `m_seek_samplepos` to 0 when a new seek sample is selected.

This also makes the seek sounds more consistent, since previously they would start from a semi-random position each time.