### PR TITLE
gaelco/mastboy.cpp: Cleanups

### DIFF
--- a/src/emu/emupal.cpp
+++ b/src/emu/emupal.cpp
@@ -198,6 +198,12 @@ palette_device &palette_device::set_format(rgbx_444_t, u32 entries)
 	return *this;
 }
 
+palette_device &palette_device::set_format(grbx_444_t, u32 entries)
+{
+	set_format(2, &raw_to_rgb_converter::standard_rgb_decoder<4,4,4, 8,12,4>, entries);
+	return *this;
+}
+
 palette_device &palette_device::set_format(gbrx_444_t, u32 entries)
 {
 	set_format(2, &raw_to_rgb_converter::standard_rgb_decoder<4,4,4, 4,12,8>, entries);

--- a/src/emu/emupal.h
+++ b/src/emu/emupal.h
@@ -215,6 +215,7 @@ public:
 	enum xbrg_444_t     { xBRG_444, xxxxBBBBRRRRGGGG };
 	enum xbgr_444_t     { xBGR_444, xxxxBBBBGGGGRRRR };
 	enum rgbx_444_t     { RGBx_444, RRRRGGGGBBBBxxxx };
+	enum grbx_444_t     { GRBx_444, GGGGRRRRBBBBxxxx };
 	enum gbrx_444_t     { GBRx_444, GGGGBBBBRRRRxxxx };
 	enum irgb_4444_t    { IRGB_4444, IIIIRRRRGGGGBBBB };
 	enum rgbi_4444_t    { RGBI_4444, RRRRGGGGBBBBIIII };
@@ -301,6 +302,7 @@ public:
 	palette_device &set_format(xbrg_444_t, u32 entries);
 	palette_device &set_format(xbgr_444_t, u32 entries);
 	palette_device &set_format(rgbx_444_t, u32 entries);
+	palette_device &set_format(grbx_444_t, u32 entries);
 	palette_device &set_format(gbrx_444_t, u32 entries);
 	palette_device &set_format(irgb_4444_t, u32 entries);
 	palette_device &set_format(rgbi_4444_t, u32 entries);


### PR DESCRIPTION
- Use set_format for palette format
- Use tilemap_t for tilemap
- Use correct type for variables
- Reduce literal tag usage
- Reduce unused variables
emu/emupal.cpp: Add GRBx_444 palette format