### PR TITLE
tecmo/gaiden.cpp: Updates & Cleanups

### DIFF
--- a/src/mame/tecmo/gaiden.cpp
+++ b/src/mame/tecmo/gaiden.cpp
@@ -164,9 +164,9 @@ void gaiden_state::drgnbowl_irq_ack_w(uint8_t data)
 
 
 
-/* Wild Fang / Tecmo Knight has a simple protection. It writes codes to 0x07a804, */
-/* and reads the answer from 0x07a007. The returned values contain the address of */
-/* a function to jump to. */
+// Wild Fang / Tecmo Knight has a simple protection. It writes codes to 0x07a804,
+// and reads the answer from 0x07a007. The returned values contain the address of
+// a function to jump to.
 
 static const int wildfang_jumppoints[] =
 {
@@ -175,7 +175,7 @@ static const int wildfang_jumppoints[] =
 	0x1b52
 };
 
-void gaiden_state::wildfang_protection_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void wildfang_state::wildfang_protection_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	if (ACCESSING_BITS_8_15)
 	{
@@ -185,14 +185,14 @@ void gaiden_state::wildfang_protection_w(offs_t offset, uint16_t data, uint16_t 
 
 		switch (data & 0xf0)
 		{
-			case 0x00:  /* init */
+			case 0x00:  // init
 				m_prot = 0x00;
 				break;
-			case 0x10:  /* high 4 bits of jump code */
+			case 0x10:  // high 4 bits of jump code
 				m_jumpcode = (data & 0x0f) << 4;
 				m_prot = 0x10;
 				break;
-			case 0x20:  /* low 4 bits of jump code */
+			case 0x20:  // low 4 bits of jump code
 				m_jumpcode |= data & 0x0f;
 				if (m_jumpcode >= std::size(wildfang_jumppoints))
 				{
@@ -201,23 +201,23 @@ void gaiden_state::wildfang_protection_w(offs_t offset, uint16_t data, uint16_t 
 				}
 				m_prot = 0x20;
 				break;
-			case 0x30:  /* ask for bits 12-15 of function address */
+			case 0x30:  // ask for bits 12-15 of function address
 				m_prot = 0x40 | ((m_jumppoints[m_jumpcode] >> 12) & 0x0f);
 				break;
-			case 0x40:  /* ask for bits 8-11 of function address */
+			case 0x40:  // ask for bits 8-11 of function address
 				m_prot = 0x50 | ((m_jumppoints[m_jumpcode] >> 8) & 0x0f);
 				break;
-			case 0x50:  /* ask for bits 4-7 of function address */
+			case 0x50:  // ask for bits 4-7 of function address
 				m_prot = 0x60 | ((m_jumppoints[m_jumpcode] >> 4) & 0x0f);
 				break;
-			case 0x60:  /* ask for bits 0-3 of function address */
+			case 0x60:  // ask for bits 0-3 of function address
 				m_prot = 0x70 | ((m_jumppoints[m_jumpcode] >> 0) & 0x0f);
 				break;
 		}
 	}
 }
 
-uint16_t gaiden_state::wildfang_protection_r()
+uint16_t wildfang_state::protection_r()
 {
 //  logerror("PC %06x: read prot %02x\n", m_maincpu->pc(), m_prot);
 	return m_prot;
@@ -268,7 +268,7 @@ same commands as some of the above
 
 */
 
-/* these are used during startup */
+// these are used during startup
 static const int raiga_jumppoints_00[0x100] =
 {
 	0x6669,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
@@ -281,7 +281,7 @@ static const int raiga_jumppoints_00[0x100] =
 		-1,    -1,    -1,    -1,    -1,    -1,    -1,    -1
 };
 
-/* these are used the rest of the time */
+// these are used the rest of the time
 static const int raiga_jumppoints_other[0x100] =
 {
 	0x5457,0x494e,0x5f4b,0x4149,0x5345,0x525f,0x4d49,0x5941,
@@ -296,9 +296,6 @@ static const int raiga_jumppoints_other[0x100] =
 
 void gaiden_state::machine_reset()
 {
-	m_prot = 0;
-	m_jumpcode = 0;
-
 	m_tx_scroll_x = 0;
 	m_tx_scroll_y = 0;
 	m_bg_scroll_x = 0;
@@ -312,17 +309,22 @@ void gaiden_state::machine_reset()
 	m_spr_offset_y = 0;
 }
 
-MACHINE_RESET_MEMBER(gaiden_state,raiga)
+void wildfang_state::machine_reset()
 {
 	gaiden_state::machine_reset();
+	m_prot = 0;
+	m_jumpcode = 0;
+}
+
+void raiga_state::machine_reset()
+{
+	wildfang_state::machine_reset();
+	m_protmode = false;
 	m_jumppoints = raiga_jumppoints_00;
 }
 
 void gaiden_state::machine_start()
 {
-	save_item(NAME(m_prot));
-	save_item(NAME(m_jumpcode));
-
 	save_item(NAME(m_tx_scroll_x));
 	save_item(NAME(m_tx_scroll_y));
 	save_item(NAME(m_bg_scroll_x));
@@ -336,7 +338,25 @@ void gaiden_state::machine_start()
 	save_item(NAME(m_spr_offset_y));
 }
 
-void gaiden_state::raiga_protection_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void wildfang_state::machine_start()
+{
+	gaiden_state::machine_start();
+	save_item(NAME(m_prot));
+	save_item(NAME(m_jumpcode));
+}
+
+void raiga_state::machine_start()
+{
+	wildfang_state::machine_start();
+	save_item(NAME(m_protmode));
+}
+
+void raiga_state::device_post_load()
+{
+	m_jumppoints = m_protmode ? raiga_jumppoints_other : raiga_jumppoints_00;
+}
+
+void raiga_state::raiga_protection_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	if (ACCESSING_BITS_8_15)
 	{
@@ -346,19 +366,20 @@ void gaiden_state::raiga_protection_w(offs_t offset, uint16_t data, uint16_t mem
 
 		switch (data & 0xf0)
 		{
-			case 0x00:  /* init */
+			case 0x00:  // init
 				m_prot = 0x00;
 				break;
-			case 0x10:  /* high 4 bits of jump code */
+			case 0x10:  // high 4 bits of jump code
 				m_jumpcode = (data & 0x0f) << 4;
 				m_prot = 0x10;
 				break;
-			case 0x20:  /* low 4 bits of jump code */
+			case 0x20:  // low 4 bits of jump code
 				m_jumpcode |= data & 0x0f;
 				logerror("requested protection jumpcode %02x\n", m_jumpcode);
 //              m_jumpcode = 0;
 				if (m_jumppoints[m_jumpcode] == -2)
 				{
+					m_protmode = true;
 					m_jumppoints = raiga_jumppoints_other;
 				}
 
@@ -370,78 +391,72 @@ void gaiden_state::raiga_protection_w(offs_t offset, uint16_t data, uint16_t mem
 				}
 				m_prot = 0x20;
 				break;
-			case 0x30:  /* ask for bits 12-15 of function address */
+			case 0x30:  // ask for bits 12-15 of function address
 				m_prot = 0x40 | ((m_jumppoints[m_jumpcode] >> 12) & 0x0f);
 				break;
-			case 0x40:  /* ask for bits 8-11 of function address */
+			case 0x40:  // ask for bits 8-11 of function address
 				m_prot = 0x50 | ((m_jumppoints[m_jumpcode] >> 8) & 0x0f);
 				break;
-			case 0x50:  /* ask for bits 4-7 of function address */
+			case 0x50:  // ask for bits 4-7 of function address
 				m_prot = 0x60 | ((m_jumppoints[m_jumpcode] >> 4) & 0x0f);
 				break;
-			case 0x60:  /* ask for bits 0-3 of function address */
+			case 0x60:  // ask for bits 0-3 of function address
 				m_prot = 0x70 | ((m_jumppoints[m_jumpcode] >> 0) & 0x0f);
 				break;
 		}
 	}
 }
 
-uint16_t gaiden_state::raiga_protection_r()
-{
-//  logerror("PC %06x: read prot %02x\n", m_maincpu->pc(), m_prot);
-	return m_prot;
-}
-
 void gaiden_state::gaiden_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();
 	map(0x060000, 0x063fff).ram();
-	map(0x070000, 0x070fff).ram().w(FUNC(gaiden_state::tx_videoram_w)).share("videoram1");
-	map(0x072000, 0x073fff).ram().w(FUNC(gaiden_state::fg_videoram_w)).share("videoram2");
-	map(0x074000, 0x075fff).ram().w(FUNC(gaiden_state::bg_videoram_w)).share("videoram3");
+	map(0x070000, 0x070fff).ram().w(FUNC(gaiden_state::tx_videoram_w)).share(m_videoram[0]);
+	map(0x072000, 0x073fff).ram().w(FUNC(gaiden_state::fg_videoram_w)).share(m_videoram[1]);
+	map(0x074000, 0x075fff).ram().w(FUNC(gaiden_state::bg_videoram_w)).share(m_videoram[2]);
 	map(0x076000, 0x077fff).ram().share("spriteram");
 	map(0x078000, 0x079fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x07a000, 0x07a001).portr("SYSTEM");
-	map(0x07a002, 0x07a003).portr("P1_P2").w(FUNC(gaiden_state::gaiden_sproffsety_w));
+	map(0x07a002, 0x07a003).portr("P1_P2").w(FUNC(gaiden_state::sproffsety_w));
 	map(0x07a004, 0x07a005).portr("DSW");
-	map(0x07a104, 0x07a105).w(FUNC(gaiden_state::gaiden_txscrolly_w));
-	map(0x07a108, 0x07a109).w(FUNC(gaiden_state::gaiden_txoffsety_w));
-	map(0x07a10c, 0x07a10d).w(FUNC(gaiden_state::gaiden_txscrollx_w));
-	map(0x07a204, 0x07a205).w(FUNC(gaiden_state::gaiden_fgscrolly_w));
-	map(0x07a208, 0x07a209).w(FUNC(gaiden_state::gaiden_fgoffsety_w));
-	map(0x07a20c, 0x07a20d).w(FUNC(gaiden_state::gaiden_fgscrollx_w));
-	map(0x07a304, 0x07a305).w(FUNC(gaiden_state::gaiden_bgscrolly_w));
-	map(0x07a308, 0x07a309).w(FUNC(gaiden_state::gaiden_bgoffsety_w));
-	map(0x07a30c, 0x07a30d).w(FUNC(gaiden_state::gaiden_bgscrollx_w));
+	map(0x07a104, 0x07a105).w(FUNC(gaiden_state::txscrolly_w));
+	map(0x07a108, 0x07a109).w(FUNC(gaiden_state::txoffsety_w));
+	map(0x07a10c, 0x07a10d).w(FUNC(gaiden_state::txscrollx_w));
+	map(0x07a204, 0x07a205).w(FUNC(gaiden_state::fgscrolly_w));
+	map(0x07a208, 0x07a209).w(FUNC(gaiden_state::fgoffsety_w));
+	map(0x07a20c, 0x07a20d).w(FUNC(gaiden_state::fgscrollx_w));
+	map(0x07a304, 0x07a305).w(FUNC(gaiden_state::bgscrolly_w));
+	map(0x07a308, 0x07a309).w(FUNC(gaiden_state::bgoffsety_w));
+	map(0x07a30c, 0x07a30d).w(FUNC(gaiden_state::bgscrollx_w));
 	map(0x07a800, 0x07a801).w("watchdog", FUNC(watchdog_timer_device::reset16_w));
 	// Ninja Gaiden writes only to the lower byte; Tecmo Knight and Strato Fighter write to the upper byte instead.
 	// It's not clear which 8 data lines are actually connected, but byte smearing is almost certainly involved.
 	map(0x07a802, 0x07a803).w("soundlatch", FUNC(generic_latch_8_device::write)).umask16(0x00ff).cswidth(16);
 	map(0x07a806, 0x07a807).w(FUNC(gaiden_state::irq_ack_w));
-	map(0x07a808, 0x07a809).w(FUNC(gaiden_state::gaiden_flip_w));
+	map(0x07a808, 0x07a809).w(FUNC(gaiden_state::flip_w));
 }
 
-void gaiden_state::wildfang_map(address_map &map)
+void wildfang_state::wildfang_map(address_map &map)
 {
 	gaiden_map(map);
-	map(0x07a006, 0x07a007).r(FUNC(gaiden_state::wildfang_protection_r));
-	map(0x07a804, 0x07a805).w(FUNC(gaiden_state::wildfang_protection_w));
+	map(0x07a006, 0x07a007).r(FUNC(wildfang_state::protection_r));
+	map(0x07a804, 0x07a805).w(FUNC(wildfang_state::wildfang_protection_w));
 }
 
-void gaiden_state::raiga_map(address_map &map)
+void raiga_state::raiga_map(address_map &map)
 {
 	gaiden_map(map);
-	map(0x07a006, 0x07a007).r(FUNC(gaiden_state::raiga_protection_r));
-	map(0x07a804, 0x07a805).w(FUNC(gaiden_state::raiga_protection_w));
+	map(0x07a006, 0x07a007).r(FUNC(raiga_state::protection_r));
+	map(0x07a804, 0x07a805).w(FUNC(raiga_state::raiga_protection_w));
 }
 
 void gaiden_state::drgnbowl_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();
 	map(0x060000, 0x063fff).ram();
-	map(0x070000, 0x070fff).ram().w(FUNC(gaiden_state::tx_videoram_w)).share("videoram1");
-	map(0x072000, 0x073fff).ram().w(FUNC(gaiden_state::fg_videoram_w)).share("videoram2");
-	map(0x074000, 0x075fff).ram().w(FUNC(gaiden_state::bg_videoram_w)).share("videoram3");
+	map(0x070000, 0x070fff).ram().w(FUNC(gaiden_state::tx_videoram_w)).share(m_videoram[0]);
+	map(0x072000, 0x073fff).ram().w(FUNC(gaiden_state::fg_videoram_w)).share(m_videoram[1]);
+	map(0x074000, 0x075fff).ram().w(FUNC(gaiden_state::bg_videoram_w)).share(m_videoram[2]);
 	map(0x076000, 0x077fff).ram().share("spriteram");
 	map(0x078000, 0x079fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x07a000, 0x07a001).portr("SYSTEM");
@@ -449,21 +464,21 @@ void gaiden_state::drgnbowl_map(address_map &map)
 	map(0x07a004, 0x07a005).portr("DSW");
 	map(0x07a00e, 0x07a00e).w("soundlatch", FUNC(generic_latch_8_device::write));
 	map(0x07e000, 0x07e000).w(FUNC(gaiden_state::drgnbowl_irq_ack_w));
-	map(0x07f000, 0x07f001).w(FUNC(gaiden_state::gaiden_bgscrolly_w));
-	map(0x07f002, 0x07f003).w(FUNC(gaiden_state::gaiden_bgscrollx_w));
-	map(0x07f004, 0x07f005).w(FUNC(gaiden_state::gaiden_fgscrolly_w));
-	map(0x07f006, 0x07f007).w(FUNC(gaiden_state::gaiden_fgscrollx_w));
+	map(0x07f000, 0x07f001).w(FUNC(gaiden_state::bgscrolly_w));
+	map(0x07f002, 0x07f003).w(FUNC(gaiden_state::bgscrollx_w));
+	map(0x07f004, 0x07f005).w(FUNC(gaiden_state::fgscrolly_w));
+	map(0x07f006, 0x07f007).w(FUNC(gaiden_state::fgscrollx_w));
 }
 
 void gaiden_state::sound_map(address_map &map)
 {
 	map(0x0000, 0xdfff).rom();
-	map(0xe000, 0xefff).rom(); /* raiga only */
+	map(0xe000, 0xefff).rom(); // raiga only
 	map(0xf000, 0xf7ff).ram();
 	map(0xf800, 0xf800).rw("oki", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0xf810, 0xf811).w("ym1", FUNC(ym2203_device::write));
 	map(0xf820, 0xf821).w("ym2", FUNC(ym2203_device::write));
-	map(0xfc00, 0xfc00).noprw(); /* ?? */
+	map(0xfc00, 0xfc00).noprw(); // ??
 	map(0xfc20, 0xfc20).r("soundlatch", FUNC(generic_latch_8_device::read));
 }
 
@@ -558,7 +573,7 @@ static INPUT_PORTS_START( drgnbowl )
 	PORT_INCLUDE(  common )
 
 	PORT_MODIFY("DSW")
-	PORT_DIPUNUSED_DIPLOC( 0x0002, 0x0002, "SWA:7" ) /* No Flip Screen */
+	PORT_DIPUNUSED_DIPLOC( 0x0002, 0x0002, "SWA:7" ) // No Flip Screen
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( wildfang )
@@ -569,14 +584,14 @@ static INPUT_PORTS_START( wildfang )
 	PORT_DIPSETTING(      0x8000, "1" )
 	PORT_DIPSETTING(      0xc000, "2" )
 	PORT_DIPSETTING(      0x4000, "3" )
-/*  PORT_DIPSETTING(      0x0000, "2" ) */
-	/* When bit 0 is On,  use bits 4 and 5 for difficulty */
+//  PORT_DIPSETTING(      0x0000, "2" )
+	// When bit 0 is On,  use bits 4 and 5 for difficulty
 	PORT_DIPNAME( 0x3000, 0x3000, "Difficulty (Tecmo Knight)" ) PORT_DIPLOCATION("SWB:4,3")
 	PORT_DIPSETTING(      0x3000, DEF_STR( Easy ) )
 	PORT_DIPSETTING(      0x1000, DEF_STR( Normal ) )
 	PORT_DIPSETTING(      0x2000, DEF_STR( Hard ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( Hardest ) )
-	/* When bit 0 is 0ff, use bits 2 and 3 for difficulty */
+	// When bit 0 is 0ff, use bits 2 and 3 for difficulty
 	PORT_DIPNAME( 0x0c00, 0x0c00, "Difficulty (Wild Fang)" ) PORT_DIPLOCATION("SWB:6,5")
 	PORT_DIPSETTING(      0x0c00, DEF_STR( Easy ) )
 	PORT_DIPSETTING(      0x0400, DEF_STR( Normal ) )
@@ -591,19 +606,19 @@ static INPUT_PORTS_START( tknight )
 	PORT_INCLUDE(  wildfang )
 
 	PORT_MODIFY("DSW")
-	PORT_DIPUNUSED_DIPLOC( 0x2000, 0x2000, "SWB:3" ) /* No separate difficulty option like parent set */
-	PORT_DIPUNUSED_DIPLOC( 0x1000, 0x1000, "SWB:4" ) /* No separate difficulty option like parent set */
-	PORT_DIPUNUSED_DIPLOC( 0x0100, 0x0100, "SWB:8" ) /* No title change option */
+	PORT_DIPUNUSED_DIPLOC( 0x2000, 0x2000, "SWB:3" ) // No separate difficulty option like parent set
+	PORT_DIPUNUSED_DIPLOC( 0x1000, 0x1000, "SWB:4" ) // No separate difficulty option like parent set
+	PORT_DIPUNUSED_DIPLOC( 0x0100, 0x0100, "SWB:8" ) // No title change option
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( raiga )
 	PORT_INCLUDE(  common )
 
-	PORT_MODIFY("P1_P2")    /* Only 2 Buttons */
+	PORT_MODIFY("P1_P2")    // Only 2 Buttons
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_UNKNOWN )
 	PORT_BIT( 0x4000, IP_ACTIVE_LOW, IPT_UNKNOWN )
 
-	/* Dip Switches order fits the first screen */
+	// Dip Switches order fits the first screen
 	PORT_MODIFY("DSW")
 	PORT_DIPNAME( 0x00f0, 0x00f0, DEF_STR( Coin_A ) ) PORT_DIPLOCATION("SWA:4,3,2,1")
 	PORT_DIPSETTING(      0x0000, DEF_STR( 5C_1C ) )
@@ -663,13 +678,13 @@ INPUT_PORTS_END
 
 
 static GFXDECODE_START( gfx_gaiden )
-	GFXDECODE_ENTRY( "txtiles", 0, gfx_8x8x4_packed_msb,               0x100,    16 ) /* tiles 8x8  */
-	GFXDECODE_ENTRY( "bgtiles", 0, gfx_8x8x4_row_2x2_group_packed_msb, 0x000, 0x100 ) /* tiles 16x16 */
-	GFXDECODE_ENTRY( "fgtiles", 0, gfx_8x8x4_row_2x2_group_packed_msb, 0x000, 0x100 ) /* tiles 16x16 (only colors 0x00-0x0f and 0x80-0x8f are used) */
+	GFXDECODE_ENTRY( "txtiles", 0, gfx_8x8x4_packed_msb,               0x100,    16 ) // tiles 8x8 
+	GFXDECODE_ENTRY( "bgtiles", 0, gfx_8x8x4_row_2x2_group_packed_msb, 0x000, 0x100 ) // tiles 16x16
+	GFXDECODE_ENTRY( "fgtiles", 0, gfx_8x8x4_row_2x2_group_packed_msb, 0x000, 0x100 ) // tiles 16x16 (only colors 0x00-0x0f and 0x80-0x8f are used)
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_gaiden_spr )
-	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_packed_msb, 0x000, 0x100 ) /* sprites 8x8 (only colors 0x00-0x0f and 0x80-0x8f are used) */
+	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_packed_msb, 0x000, 0x100 ) // sprites 8x8 (only colors 0x00-0x0f and 0x80-0x8f are used)
 GFXDECODE_END
 
 static const gfx_layout mastninj_tile2layout =
@@ -685,20 +700,20 @@ static const gfx_layout mastninj_tile2layout =
 
 static const gfx_layout mastninj_spritelayout =
 {
-	16,16,    /* tile size */
-	RGN_FRAC(1,4),  /* number of tiles */
-	4,  /* 4 bits per pixel */
+	16,16,    // tile size
+	RGN_FRAC(1,4),  // number of tiles
+	4,  // 4 bits per pixel
 	{ RGN_FRAC(0,4),RGN_FRAC(1,4),RGN_FRAC(2,4),RGN_FRAC(3,4) },
 	{ 0,1,2,3,4,5,6,7,  128+0,128+1,128+2,128+3,128+4,128+5,128+6,128+7 },
 	{ 0*8, 1*8, 2*8, 3*8, 4*8, 5*8, 6*8, 7*8, 8*8, 9*8, 10*8, 11*8, 12*8, 13*8, 14*8, 15*8 },
-	32*8 /* offset to next tile */
+	32*8 // offset to next tile
 };
 
 static GFXDECODE_START( gfx_mastninj )
-	GFXDECODE_ENTRY( "txtiles", 0, gfx_8x8x4_packed_msb,  0x000, 16 )  /* tiles 8x8  */
-	GFXDECODE_ENTRY( "bgtiles", 0, mastninj_tile2layout,  0x300, 16 ) /* tiles 16x16 */
-	GFXDECODE_ENTRY( "fgtiles", 0, mastninj_tile2layout,  0x200, 16 ) /* tiles 16x16 */
-	GFXDECODE_ENTRY( "sprites", 0, mastninj_spritelayout, 0x100, 16 ) /* sprites 16x16 */
+	GFXDECODE_ENTRY( "txtiles", 0, gfx_8x8x4_packed_msb,  0x000, 16 )  // tiles 8x8 
+	GFXDECODE_ENTRY( "bgtiles", 0, mastninj_tile2layout,  0x300, 16 ) // tiles 16x16
+	GFXDECODE_ENTRY( "fgtiles", 0, mastninj_tile2layout,  0x200, 16 ) // tiles 16x16
+	GFXDECODE_ENTRY( "sprites", 0, mastninj_spritelayout, 0x100, 16 ) // sprites 16x16
 GFXDECODE_END
 
 static const gfx_layout drgnbowl_tile2layout =
@@ -724,30 +739,30 @@ static const gfx_layout drgnbowl_spritelayout =
 };
 
 static GFXDECODE_START( gfx_drgnbowl )
-	GFXDECODE_ENTRY( "txtiles", 0,       gfx_8x8x4_packed_msb,      0, 16 )    /* tiles 8x8  */
-	GFXDECODE_ENTRY( "bgtiles", 0x00000, drgnbowl_tile2layout,  0x300, 16 )    /* tiles 16x16 */
-	GFXDECODE_ENTRY( "bgtiles", 0x20000, drgnbowl_tile2layout,  0x200, 16 )    /* tiles 16x16 */
-	GFXDECODE_ENTRY( "sprites", 0,       drgnbowl_spritelayout, 0x100, 16 )    /* sprites 16x16 */
+	GFXDECODE_ENTRY( "txtiles", 0,       gfx_8x8x4_packed_msb,      0, 16 )    // tiles 8x8 
+	GFXDECODE_ENTRY( "bgtiles", 0x00000, drgnbowl_tile2layout,  0x300, 16 )    // tiles 16x16
+	GFXDECODE_ENTRY( "bgtiles", 0x20000, drgnbowl_tile2layout,  0x200, 16 )    // tiles 16x16
+	GFXDECODE_ENTRY( "sprites", 0,       drgnbowl_spritelayout, 0x100, 16 )    // sprites 16x16
 GFXDECODE_END
 
 
 void gaiden_state::shadoww(machine_config &config)
 {
-	/* basic machine hardware */
-	M68000(config, m_maincpu, 18432000/2); /* 9.216 MHz */
+	// basic machine hardware
+	M68000(config, m_maincpu, 18432000 / 2); // 9.216 MHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &gaiden_state::gaiden_map);
 	m_maincpu->set_vblank_int("screen", FUNC(gaiden_state::irq5_line_assert));
 
-	Z80(config, m_audiocpu, 4000000);  /* 4 MHz */
-	m_audiocpu->set_addrmap(AS_PROGRAM, &gaiden_state::sound_map);  /* IRQs are triggered by the YM2203 */
+	Z80(config, m_audiocpu, 4000000);  // 4 MHz
+	m_audiocpu->set_addrmap(AS_PROGRAM, &gaiden_state::sound_map);  // IRQs are triggered by the YM2203
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	BUFFERED_SPRITERAM16(config, m_spriteram);
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
-	m_screen->set_refresh_hz(59.17);   /* verified on pcb */
+	m_screen->set_refresh_hz(59.17);   // verified on pcb
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	m_screen->set_size(32*8, 32*8);
 	m_screen->set_visarea(0*8, 32*8-1, 4*8, 32*8-1);
@@ -768,7 +783,7 @@ void gaiden_state::shadoww(machine_config &config)
 
 	MCFG_VIDEO_START_OVERRIDE(gaiden_state,gaiden)
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	GENERIC_LATCH_8(config, "soundlatch").data_pending_callback().set_inputline(m_audiocpu, INPUT_LINE_NMI);
@@ -790,41 +805,37 @@ void gaiden_state::shadoww(machine_config &config)
 	oki.add_route(ALL_OUTPUTS, "mono", 0.20);
 }
 
-void gaiden_state::wildfang(machine_config &config)
+void wildfang_state::wildfang(machine_config &config)
 {
 	shadoww(config);
-	m_maincpu->set_addrmap(AS_PROGRAM, &gaiden_state::wildfang_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &wildfang_state::wildfang_map);
 
 	I8749(config, "mcu", 4_MHz_XTAL).set_disable();
 }
 
-void gaiden_state::raiga(machine_config &config)
+void raiga_state::raiga(machine_config &config)
 {
 	shadoww(config);
-	m_maincpu->set_addrmap(AS_PROGRAM, &gaiden_state::raiga_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &raiga_state::raiga_map);
 
 	I8749(config, "mcu", 4_MHz_XTAL).set_disable();
 
-	MCFG_MACHINE_RESET_OVERRIDE(gaiden_state,raiga)
-
-	MCFG_VIDEO_START_OVERRIDE(gaiden_state,raiga)
-
-	m_screen->set_screen_update(FUNC(gaiden_state::screen_update_raiga));
-	m_screen->screen_vblank().set(FUNC(gaiden_state::screen_vblank_raiga));
+	m_screen->set_screen_update(FUNC(raiga_state::screen_update_raiga));
+	m_screen->screen_vblank().set(FUNC(raiga_state::screen_vblank_raiga));
 }
 
 void gaiden_state::drgnbowl(machine_config &config)
 {
-	/* basic machine hardware */
-	M68000(config, m_maincpu, 20000000/2); /* 10 MHz */
+	// basic machine hardware
+	M68000(config, m_maincpu, 20000000 / 2); // 10 MHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &gaiden_state::drgnbowl_map);
 	m_maincpu->set_vblank_int("screen", FUNC(gaiden_state::irq5_line_assert));
 
-	Z80(config, m_audiocpu, 12000000/2);   /* 6 MHz */
+	Z80(config, m_audiocpu, 12000000 / 2);   // 6 MHz
 	m_audiocpu->set_addrmap(AS_PROGRAM, &gaiden_state::drgnbowl_sound_map);
 	m_audiocpu->set_addrmap(AS_IO, &gaiden_state::drgnbowl_sound_port_map);
 
-	/* video hardware */
+	// video hardware
 	BUFFERED_SPRITERAM16(config, m_spriteram);
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
@@ -838,11 +849,11 @@ void gaiden_state::drgnbowl(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_drgnbowl);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_444, 4096);
 
-	/* NOT using Tecmo Sprite device - significant changes, maybe a clone of something else */
+	// NOT using Tecmo Sprite device - significant changes, maybe a clone of something else
 
 	MCFG_VIDEO_START_OVERRIDE(gaiden_state,drgnbowl)
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	GENERIC_LATCH_8(config, "soundlatch").data_pending_callback().set_inputline(m_audiocpu, 0);
@@ -898,20 +909,20 @@ Others
 2x      8x2 switches DIP
 */
 
-void gaiden_state::mastninj_sound_map(address_map &map)
+void mastninj_state::mastninj_sound_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
-	map(0x8000, 0xbfff).bankr("adpcm_bank");
+	map(0x8000, 0xbfff).bankr(m_adpcm_bank);
 	map(0xc400, 0xc401).rw("ym1", FUNC(ym2203_device::read), FUNC(ym2203_device::write));
 	map(0xc800, 0xc801).rw("ym2", FUNC(ym2203_device::read), FUNC(ym2203_device::write));
 	map(0xcc00, 0xcc00).r("soundlatch", FUNC(generic_latch_8_device::read));
-	map(0xd000, 0xd000).w("adpcm_select2", FUNC(ls157_device::ba_w));
-	map(0xd400, 0xd400).w(FUNC(gaiden_state::adpcm_bankswitch_w));
-	map(0xd800, 0xd800).w("adpcm_select1", FUNC(ls157_device::ba_w));
+	map(0xd000, 0xd000).w(m_adpcm_select[1], FUNC(ls157_device::ba_w));
+	map(0xd400, 0xd400).w(FUNC(mastninj_state::adpcm_bankswitch_w));
+	map(0xd800, 0xd800).w(m_adpcm_select[0], FUNC(ls157_device::ba_w));
 	map(0xf000, 0xf7ff).ram();
 }
 
-void gaiden_state::vck_flipflop_w(int state)
+void mastninj_state::vck_flipflop_w(int state)
 {
 	if (!state)
 		return;
@@ -922,65 +933,63 @@ void gaiden_state::vck_flipflop_w(int state)
 	m_audiocpu->set_input_line(INPUT_LINE_NMI, m_adpcm_toggle);
 }
 
-void gaiden_state::adpcm_bankswitch_w(uint8_t data)
+void mastninj_state::adpcm_bankswitch_w(uint8_t data)
 {
 	m_msm[0]->reset_w(BIT(data, 3));
 	m_msm[1]->reset_w(BIT(data, 4));
 	m_adpcm_bank->set_entry(data & 7);
 }
 
-MACHINE_START_MEMBER(gaiden_state,mastninj)
+void mastninj_state::machine_start()
 {
 	gaiden_state::machine_start();
 
 	m_adpcm_bank->configure_entries(0, 8, memregion("audiocpu")->base(), 0x4000);
 	m_adpcm_bank->set_entry(0);
 
-	m_adpcm_toggle = 0;
+	m_adpcm_toggle = false;
 	save_item(NAME(m_adpcm_toggle));
 }
 
-void gaiden_state::mastninj_map(address_map &map)
+void mastninj_state::mastninj_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();
 	map(0x060000, 0x063fff).ram();
-	map(0x070000, 0x070fff).ram().w(FUNC(gaiden_state::tx_videoram_w)).share("videoram1");
-	map(0x072000, 0x073fff).ram().w(FUNC(gaiden_state::fg_videoram_w)).share("videoram2");
-	map(0x074000, 0x075fff).ram().w(FUNC(gaiden_state::bg_videoram_w)).share("videoram3");
+	map(0x070000, 0x070fff).ram().w(FUNC(mastninj_state::tx_videoram_w)).share(m_videoram[0]);
+	map(0x072000, 0x073fff).ram().w(FUNC(mastninj_state::fg_videoram_w)).share(m_videoram[1]);
+	map(0x074000, 0x075fff).ram().w(FUNC(mastninj_state::bg_videoram_w)).share(m_videoram[2]);
 	map(0x076000, 0x077fff).ram().share("spriteram");
 	map(0x078000, 0x079fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 //  map(0x078800, 0x079fff).ram();
 	map(0x07a000, 0x07a001).portr("SYSTEM");
 	map(0x07a002, 0x07a003).portr("P1_P2");
 	map(0x07a004, 0x07a005).portr("DSW");
-//  map(0x07a104, 0x07a105).w(FUNC(gaiden_state::gaiden_txscrolly_w));
-//  map(0x07a10c, 0x07a10d).w(FUNC(gaiden_state::gaiden_txscrollx_w));
-	map(0x07f000, 0x07f001).w(FUNC(gaiden_state::gaiden_bgscrolly_w));
-	map(0x07f002, 0x07f003).w(FUNC(gaiden_state::gaiden_bgscrollx_w));
-	map(0x07f004, 0x07f005).w(FUNC(gaiden_state::gaiden_fgscrolly_w));
-	map(0x07f006, 0x07f007).w(FUNC(gaiden_state::gaiden_fgscrollx_w));
+//  map(0x07a104, 0x07a105).w(FUNC(mastninj_state::txscrolly_w));
+//  map(0x07a10c, 0x07a10d).w(FUNC(mastninj_state::txscrollx_w));
+	map(0x07f000, 0x07f001).w(FUNC(mastninj_state::bgscrolly_w));
+	map(0x07f002, 0x07f003).w(FUNC(mastninj_state::bgscrollx_w));
+	map(0x07f004, 0x07f005).w(FUNC(mastninj_state::fgscrolly_w));
+	map(0x07f006, 0x07f007).w(FUNC(mastninj_state::fgscrollx_w));
 	map(0x07a800, 0x07a801).w("watchdog", FUNC(watchdog_timer_device::reset16_w));
 //  map(0x07a806, 0x07a807).nopw();
-//  map(0x07a808, 0x07a809).w(FUNC(gaiden_state::gaiden_flip_w));
+//  map(0x07a808, 0x07a809).w(FUNC(gaiden_state::flip_w));
 	map(0x07a00e, 0x07a00e).w("soundlatch", FUNC(generic_latch_8_device::write));
-	map(0x07e000, 0x07e000).w(FUNC(gaiden_state::drgnbowl_irq_ack_w));
+	map(0x07e000, 0x07e000).w(FUNC(mastninj_state::drgnbowl_irq_ack_w));
 }
 
-void gaiden_state::mastninj(machine_config &config)
+void mastninj_state::mastninj(machine_config &config)
 {
-	/* basic machine hardware */
-	M68000(config, m_maincpu, 10000000);   /* 10 MHz? */
-	m_maincpu->set_addrmap(AS_PROGRAM, &gaiden_state::mastninj_map);
-	m_maincpu->set_vblank_int("screen", FUNC(gaiden_state::irq5_line_assert));
+	// basic machine hardware
+	M68000(config, m_maincpu, 10000000);   // 10 MHz?
+	m_maincpu->set_addrmap(AS_PROGRAM, &mastninj_state::mastninj_map);
+	m_maincpu->set_vblank_int("screen", FUNC(mastninj_state::irq5_line_assert));
 
-	Z80(config, m_audiocpu, 4000000);  /* ?? MHz */
-	m_audiocpu->set_addrmap(AS_PROGRAM, &gaiden_state::mastninj_sound_map);
-
-	MCFG_MACHINE_START_OVERRIDE(gaiden_state,mastninj)
+	Z80(config, m_audiocpu, 4000000);  // ?? MHz
+	m_audiocpu->set_addrmap(AS_PROGRAM, &mastninj_state::mastninj_sound_map);
 
 	WATCHDOG_TIMER(config, "watchdog");
 
-	/* video hardware */
+	// video hardware
 	BUFFERED_SPRITERAM16(config, m_spriteram);
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
@@ -988,17 +997,17 @@ void gaiden_state::mastninj(machine_config &config)
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	m_screen->set_size(32*8, 32*8);
 	m_screen->set_visarea(0*8, 32*8-1, 2*8, 30*8-1);
-	m_screen->set_screen_update(FUNC(gaiden_state::screen_update_drgnbowl));
+	m_screen->set_screen_update(FUNC(mastninj_state::screen_update_drgnbowl));
 	m_screen->set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_mastninj);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_444, 4096);
 
-	/* NOT using Tecmo Sprite device - significant changes, maybe a clone of something else */
+	// NOT using Tecmo Sprite device - significant changes, maybe a clone of something else
 
-	MCFG_VIDEO_START_OVERRIDE(gaiden_state,drgnbowl)
+	MCFG_VIDEO_START_OVERRIDE(mastninj_state,drgnbowl)
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	GENERIC_LATCH_8(config, "soundlatch").data_pending_callback().set_inputline(m_audiocpu, 0);
@@ -1024,7 +1033,7 @@ void gaiden_state::mastninj(machine_config &config)
 
 	MSM5205(config, m_msm[0], 384000);
 	m_msm[0]->vck_callback().set(m_msm[1], FUNC(msm5205_device::vclk_w));
-	m_msm[0]->vck_callback().append(FUNC(gaiden_state::vck_flipflop_w));
+	m_msm[0]->vck_callback().append(FUNC(mastninj_state::vck_flipflop_w));
 	m_msm[0]->set_prescaler_selector(msm5205_device::S96_4B);
 	m_msm[0]->add_route(ALL_OUTPUTS, "mono", 0.20);
 
@@ -1040,15 +1049,15 @@ void gaiden_state::mastninj(machine_config &config)
 ***************************************************************************/
 
 ROM_START( shadoww )
-	ROM_REGION( 0x40000, "maincpu", 0 ) /* 2*128k for 68000 code */
+	ROM_REGION( 0x40000, "maincpu", 0 ) // 2*128k for 68000 code
 	ROM_LOAD16_BYTE( "shadowa_1.3s",     0x00000, 0x20000, CRC(8290d567) SHA1(1e2f80c1548c853ec1127e79438f62eda6592a07) )
 	ROM_LOAD16_BYTE( "shadowa_2.4s",     0x00001, 0x20000, CRC(f3f08921) SHA1(df6bb7302714e0eab12cbd0a7f2a4ca751a600e1) )
 
 	ROM_REGION( 0x10000, "audiocpu", 0 )
-	ROM_LOAD( "gaiden_3.4b",     0x0000, 0x10000, CRC(75fd3e6a) SHA1(3333e84ed4983caa133e60a8e8895fa897ab4949) )   /* Audio CPU is a Z80  */
+	ROM_LOAD( "gaiden_3.4b",     0x0000, 0x10000, CRC(75fd3e6a) SHA1(3333e84ed4983caa133e60a8e8895fa897ab4949) )   // Audio CPU is a Z80 
 
 	ROM_REGION( 0x010000, "txtiles", 0 )
-	ROM_LOAD( "gaiden_5.7a",     0x000000, 0x10000, CRC(8d4035f7) SHA1(3473456cdd24e312e3073586d7e8f24eb71bbea1) )  /* 8x8 tiles */
+	ROM_LOAD( "gaiden_5.7a",     0x000000, 0x10000, CRC(8d4035f7) SHA1(3473456cdd24e312e3073586d7e8f24eb71bbea1) )  // 8x8 tiles
 
 	ROM_REGION( 0x080000, "bgtiles", 0 )
 	ROM_LOAD( "14.3a", 0x000000, 0x20000, CRC(1ecfddaa) SHA1(e71d60ae1a98fe8512498f91cce01c16be9f0871) )
@@ -1063,29 +1072,29 @@ ROM_START( shadoww )
 	ROM_LOAD( "21.4b", 0x060000, 0x20000, CRC(1ac892f5) SHA1(28364266ca9d1955fb7953f5c2d6f35e114beec6) )
 
 	ROM_REGION( 0x100000, "sprites", 0 ) // sprite roms also seen on daughterboard "4M512" with 16 0x10000-sized roms
-	ROM_LOAD16_BYTE( "6.3m",  0x000000, 0x20000, CRC(e7ccdf9f) SHA1(80ffcefc95660471124898a9c2bee55df36bda13) ) /* sprites A1 */
-	ROM_LOAD16_BYTE( "7.1m",  0x000001, 0x20000, CRC(016bec95) SHA1(6a6757c52ca9a2398ea43d1af4a8d5adde6f4cd2) ) /* sprites A2 */
-	ROM_LOAD16_BYTE( "8.3n",  0x040000, 0x20000, CRC(7ef7f880) SHA1(26ba9a76adce24beea3cffa1cb95aeafe6f82f96) ) /* sprites B1 */
-	ROM_LOAD16_BYTE( "9.1n",  0x040001, 0x20000, CRC(6e9b7fd3) SHA1(c86ff61844fc94c02625bb812b9062d0649c8fdf) ) /* sprites B2 */
-	ROM_LOAD16_BYTE( "10.3r", 0x080000, 0x20000, CRC(a6451dec) SHA1(553e7a1453b59055fa0b10ca04125543d9f8987c) ) /* sprites C1 */
-	ROM_LOAD16_BYTE( "11.1r", 0x080001, 0x20000, CRC(7fbfdf5e) SHA1(ab67b72dcadb5f2236d29de751de5bf890a9e423) ) /* sprites C2 */
-	ROM_LOAD16_BYTE( "12.3s", 0x0c0000, 0x20000, CRC(94a836d8) SHA1(55658f4c6cf6aadc4369b943705f5734396b2e43) ) /* sprites D1 */
-	ROM_LOAD16_BYTE( "13.1s", 0x0c0001, 0x20000, CRC(e9caea3b) SHA1(39ef300e7dfd9469f04127d5a06dceb0b7e357f8) ) /* sprites D2 */
+	ROM_LOAD16_BYTE( "6.3m",  0x000000, 0x20000, CRC(e7ccdf9f) SHA1(80ffcefc95660471124898a9c2bee55df36bda13) ) // sprites A1
+	ROM_LOAD16_BYTE( "7.1m",  0x000001, 0x20000, CRC(016bec95) SHA1(6a6757c52ca9a2398ea43d1af4a8d5adde6f4cd2) ) // sprites A2
+	ROM_LOAD16_BYTE( "8.3n",  0x040000, 0x20000, CRC(7ef7f880) SHA1(26ba9a76adce24beea3cffa1cb95aeafe6f82f96) ) // sprites B1
+	ROM_LOAD16_BYTE( "9.1n",  0x040001, 0x20000, CRC(6e9b7fd3) SHA1(c86ff61844fc94c02625bb812b9062d0649c8fdf) ) // sprites B2
+	ROM_LOAD16_BYTE( "10.3r", 0x080000, 0x20000, CRC(a6451dec) SHA1(553e7a1453b59055fa0b10ca04125543d9f8987c) ) // sprites C1
+	ROM_LOAD16_BYTE( "11.1r", 0x080001, 0x20000, CRC(7fbfdf5e) SHA1(ab67b72dcadb5f2236d29de751de5bf890a9e423) ) // sprites C2
+	ROM_LOAD16_BYTE( "12.3s", 0x0c0000, 0x20000, CRC(94a836d8) SHA1(55658f4c6cf6aadc4369b943705f5734396b2e43) ) // sprites D1
+	ROM_LOAD16_BYTE( "13.1s", 0x0c0001, 0x20000, CRC(e9caea3b) SHA1(39ef300e7dfd9469f04127d5a06dceb0b7e357f8) ) // sprites D2
 
-	ROM_REGION( 0x40000, "oki", 0 ) /* 128k for ADPCM samples - sound chip is OKIM6295 */
-	ROM_LOAD( "4.4a",     0x0000, 0x20000, CRC(b0e0faf9) SHA1(2275d2ef5eee356ccf80b9e9644d16fc30a4d107) ) /* samples */
+	ROM_REGION( 0x40000, "oki", 0 ) // 128k for ADPCM samples - sound chip is OKIM6295
+	ROM_LOAD( "4.4a",     0x0000, 0x20000, CRC(b0e0faf9) SHA1(2275d2ef5eee356ccf80b9e9644d16fc30a4d107) ) // samples
 ROM_END
 
 ROM_START( shadowwa )
-	ROM_REGION( 0x40000, "maincpu", 0 ) /* 2*128k for 68000 code */
+	ROM_REGION( 0x40000, "maincpu", 0 ) // 2*128k for 68000 code
 	ROM_LOAD16_BYTE( "shadoww_1.3s",    0x00000, 0x20000, CRC(fefba387) SHA1(20ce28da5877009494c3f3f67488bbe805d91340) )
 	ROM_LOAD16_BYTE( "shadoww_2.4s",    0x00001, 0x20000, CRC(9b9d6b18) SHA1(75068611fb1de61120be8bf840f61d90c0dc86ca) )
 
 	ROM_REGION( 0x10000, "audiocpu", 0 )
-	ROM_LOAD( "gaiden_3.4b",     0x0000, 0x10000, CRC(75fd3e6a) SHA1(3333e84ed4983caa133e60a8e8895fa897ab4949) )   /* Audio CPU is a Z80  */
+	ROM_LOAD( "gaiden_3.4b",     0x0000, 0x10000, CRC(75fd3e6a) SHA1(3333e84ed4983caa133e60a8e8895fa897ab4949) )   // Audio CPU is a Z80 
 
 	ROM_REGION( 0x010000, "txtiles", 0 )
-	ROM_LOAD( "gaiden_5.7a",     0x000000, 0x10000, CRC(8d4035f7) SHA1(3473456cdd24e312e3073586d7e8f24eb71bbea1) )  /* 8x8 tiles */
+	ROM_LOAD( "gaiden_5.7a",     0x000000, 0x10000, CRC(8d4035f7) SHA1(3473456cdd24e312e3073586d7e8f24eb71bbea1) )  // 8x8 tiles
 
 	ROM_REGION( 0x080000, "bgtiles", 0 )
 	ROM_LOAD( "14.3a", 0x000000, 0x20000, CRC(1ecfddaa) SHA1(e71d60ae1a98fe8512498f91cce01c16be9f0871) )
@@ -1100,29 +1109,29 @@ ROM_START( shadowwa )
 	ROM_LOAD( "21.4b", 0x060000, 0x20000, CRC(1ac892f5) SHA1(28364266ca9d1955fb7953f5c2d6f35e114beec6) )
 
 	ROM_REGION( 0x100000, "sprites", 0 ) // sprite roms also seen on daughterboard "4M512" with 16 0x10000-sized roms
-	ROM_LOAD16_BYTE( "6.3m",  0x000000, 0x20000, CRC(e7ccdf9f) SHA1(80ffcefc95660471124898a9c2bee55df36bda13) ) /* sprites A1 */
-	ROM_LOAD16_BYTE( "7.1m",  0x000001, 0x20000, CRC(016bec95) SHA1(6a6757c52ca9a2398ea43d1af4a8d5adde6f4cd2) ) /* sprites A2 */
-	ROM_LOAD16_BYTE( "8.3n",  0x040000, 0x20000, CRC(7ef7f880) SHA1(26ba9a76adce24beea3cffa1cb95aeafe6f82f96) ) /* sprites B1 */
-	ROM_LOAD16_BYTE( "9.1n",  0x040001, 0x20000, CRC(6e9b7fd3) SHA1(c86ff61844fc94c02625bb812b9062d0649c8fdf) ) /* sprites B2 */
-	ROM_LOAD16_BYTE( "10.3r", 0x080000, 0x20000, CRC(a6451dec) SHA1(553e7a1453b59055fa0b10ca04125543d9f8987c) ) /* sprites C1 */
-	ROM_LOAD16_BYTE( "11.1r", 0x080001, 0x20000, CRC(7fbfdf5e) SHA1(ab67b72dcadb5f2236d29de751de5bf890a9e423) ) /* sprites C2 */
-	ROM_LOAD16_BYTE( "12.3s", 0x0c0000, 0x20000, CRC(94a836d8) SHA1(55658f4c6cf6aadc4369b943705f5734396b2e43) ) /* sprites D1 */
-	ROM_LOAD16_BYTE( "13.1s", 0x0c0001, 0x20000, CRC(e9caea3b) SHA1(39ef300e7dfd9469f04127d5a06dceb0b7e357f8) ) /* sprites D2 */
+	ROM_LOAD16_BYTE( "6.3m",  0x000000, 0x20000, CRC(e7ccdf9f) SHA1(80ffcefc95660471124898a9c2bee55df36bda13) ) // sprites A1
+	ROM_LOAD16_BYTE( "7.1m",  0x000001, 0x20000, CRC(016bec95) SHA1(6a6757c52ca9a2398ea43d1af4a8d5adde6f4cd2) ) // sprites A2
+	ROM_LOAD16_BYTE( "8.3n",  0x040000, 0x20000, CRC(7ef7f880) SHA1(26ba9a76adce24beea3cffa1cb95aeafe6f82f96) ) // sprites B1
+	ROM_LOAD16_BYTE( "9.1n",  0x040001, 0x20000, CRC(6e9b7fd3) SHA1(c86ff61844fc94c02625bb812b9062d0649c8fdf) ) // sprites B2
+	ROM_LOAD16_BYTE( "10.3r", 0x080000, 0x20000, CRC(a6451dec) SHA1(553e7a1453b59055fa0b10ca04125543d9f8987c) ) // sprites C1
+	ROM_LOAD16_BYTE( "11.1r", 0x080001, 0x20000, CRC(7fbfdf5e) SHA1(ab67b72dcadb5f2236d29de751de5bf890a9e423) ) // sprites C2
+	ROM_LOAD16_BYTE( "12.3s", 0x0c0000, 0x20000, CRC(94a836d8) SHA1(55658f4c6cf6aadc4369b943705f5734396b2e43) ) // sprites D1
+	ROM_LOAD16_BYTE( "13.1s", 0x0c0001, 0x20000, CRC(e9caea3b) SHA1(39ef300e7dfd9469f04127d5a06dceb0b7e357f8) ) // sprites D2
 
-	ROM_REGION( 0x40000, "oki", 0 ) /* 128k for ADPCM samples - sound chip is OKIM6295 */
-	ROM_LOAD( "4.4a",     0x0000, 0x20000, CRC(b0e0faf9) SHA1(2275d2ef5eee356ccf80b9e9644d16fc30a4d107) ) /* samples */
+	ROM_REGION( 0x40000, "oki", 0 ) // 128k for ADPCM samples - sound chip is OKIM6295
+	ROM_LOAD( "4.4a",     0x0000, 0x20000, CRC(b0e0faf9) SHA1(2275d2ef5eee356ccf80b9e9644d16fc30a4d107) ) // samples
 ROM_END
 
 ROM_START( gaiden )
-	ROM_REGION( 0x40000, "maincpu", 0 ) /* 2*128k for 68000 code */
+	ROM_REGION( 0x40000, "maincpu", 0 ) // 2*128k for 68000 code
 	ROM_LOAD16_BYTE( "gaiden_1.3s",     0x00000, 0x20000, CRC(e037ff7c) SHA1(5418bcb80d4c52f05e3c26668193452fd51f1283) )
 	ROM_LOAD16_BYTE( "gaiden_2.4s",     0x00001, 0x20000, CRC(454f7314) SHA1(231296423870f00ea2e545faf0fbb37577430a4f) )
 
 	ROM_REGION( 0x10000, "audiocpu", 0 )
-	ROM_LOAD( "gaiden_3.4b",     0x0000, 0x10000, CRC(75fd3e6a) SHA1(3333e84ed4983caa133e60a8e8895fa897ab4949) )   /* Audio CPU is a Z80  */
+	ROM_LOAD( "gaiden_3.4b",     0x0000, 0x10000, CRC(75fd3e6a) SHA1(3333e84ed4983caa133e60a8e8895fa897ab4949) )   // Audio CPU is a Z80 
 
 	ROM_REGION( 0x010000, "txtiles", 0 )
-	ROM_LOAD( "gaiden_5.7a",     0x000000, 0x10000, CRC(8d4035f7) SHA1(3473456cdd24e312e3073586d7e8f24eb71bbea1) )  /* 8x8 tiles */
+	ROM_LOAD( "gaiden_5.7a",     0x000000, 0x10000, CRC(8d4035f7) SHA1(3473456cdd24e312e3073586d7e8f24eb71bbea1) )  // 8x8 tiles
 
 	ROM_REGION( 0x080000, "bgtiles", 0 )
 	ROM_LOAD( "14.3a", 0x000000, 0x20000, CRC(1ecfddaa) SHA1(e71d60ae1a98fe8512498f91cce01c16be9f0871) )
@@ -1137,29 +1146,29 @@ ROM_START( gaiden )
 	ROM_LOAD( "21.4b", 0x060000, 0x20000, CRC(1ac892f5) SHA1(28364266ca9d1955fb7953f5c2d6f35e114beec6) )
 
 	ROM_REGION( 0x100000, "sprites", 0 ) // sprite roms also seen on daughterboard "4M512" with 16 0x10000-sized roms
-	ROM_LOAD16_BYTE( "6.3m",  0x000000, 0x20000, CRC(e7ccdf9f) SHA1(80ffcefc95660471124898a9c2bee55df36bda13) ) /* sprites A1 */
-	ROM_LOAD16_BYTE( "7.1m",  0x000001, 0x20000, CRC(016bec95) SHA1(6a6757c52ca9a2398ea43d1af4a8d5adde6f4cd2) ) /* sprites A2 */
-	ROM_LOAD16_BYTE( "8.3n",  0x040000, 0x20000, CRC(7ef7f880) SHA1(26ba9a76adce24beea3cffa1cb95aeafe6f82f96) ) /* sprites B1 */
-	ROM_LOAD16_BYTE( "9.1n",  0x040001, 0x20000, CRC(6e9b7fd3) SHA1(c86ff61844fc94c02625bb812b9062d0649c8fdf) ) /* sprites B2 */
-	ROM_LOAD16_BYTE( "10.3r", 0x080000, 0x20000, CRC(a6451dec) SHA1(553e7a1453b59055fa0b10ca04125543d9f8987c) ) /* sprites C1 */
-	ROM_LOAD16_BYTE( "11.1r", 0x080001, 0x20000, CRC(7fbfdf5e) SHA1(ab67b72dcadb5f2236d29de751de5bf890a9e423) ) /* sprites C2 */
-	ROM_LOAD16_BYTE( "12.3s", 0x0c0000, 0x20000, CRC(90f1e13a) SHA1(3fe9fe62aa9e92c871c791a3b11f96c9a48099a9) ) /* sprites D1 */
-	ROM_LOAD16_BYTE( "13.1s", 0x0c0001, 0x20000, CRC(7d9f5c5e) SHA1(200102532ea9a88c7c708e03f8893c46dff827d1) ) /* sprites D2 */
+	ROM_LOAD16_BYTE( "6.3m",  0x000000, 0x20000, CRC(e7ccdf9f) SHA1(80ffcefc95660471124898a9c2bee55df36bda13) ) // sprites A1
+	ROM_LOAD16_BYTE( "7.1m",  0x000001, 0x20000, CRC(016bec95) SHA1(6a6757c52ca9a2398ea43d1af4a8d5adde6f4cd2) ) // sprites A2
+	ROM_LOAD16_BYTE( "8.3n",  0x040000, 0x20000, CRC(7ef7f880) SHA1(26ba9a76adce24beea3cffa1cb95aeafe6f82f96) ) // sprites B1
+	ROM_LOAD16_BYTE( "9.1n",  0x040001, 0x20000, CRC(6e9b7fd3) SHA1(c86ff61844fc94c02625bb812b9062d0649c8fdf) ) // sprites B2
+	ROM_LOAD16_BYTE( "10.3r", 0x080000, 0x20000, CRC(a6451dec) SHA1(553e7a1453b59055fa0b10ca04125543d9f8987c) ) // sprites C1
+	ROM_LOAD16_BYTE( "11.1r", 0x080001, 0x20000, CRC(7fbfdf5e) SHA1(ab67b72dcadb5f2236d29de751de5bf890a9e423) ) // sprites C2
+	ROM_LOAD16_BYTE( "12.3s", 0x0c0000, 0x20000, CRC(90f1e13a) SHA1(3fe9fe62aa9e92c871c791a3b11f96c9a48099a9) ) // sprites D1
+	ROM_LOAD16_BYTE( "13.1s", 0x0c0001, 0x20000, CRC(7d9f5c5e) SHA1(200102532ea9a88c7c708e03f8893c46dff827d1) ) // sprites D2
 
-	ROM_REGION( 0x40000, "oki", 0 ) /* 128k for ADPCM samples - sound chip is OKIM6295 */
-	ROM_LOAD( "4.4a",     0x0000, 0x20000, CRC(b0e0faf9) SHA1(2275d2ef5eee356ccf80b9e9644d16fc30a4d107) ) /* samples */
+	ROM_REGION( 0x40000, "oki", 0 ) // 128k for ADPCM samples - sound chip is OKIM6295
+	ROM_LOAD( "4.4a",     0x0000, 0x20000, CRC(b0e0faf9) SHA1(2275d2ef5eee356ccf80b9e9644d16fc30a4d107) ) // samples
 ROM_END
 
 ROM_START( ryukendn )
-	ROM_REGION( 0x40000, "maincpu", 0 ) /* 2*128k for 68000 code */
+	ROM_REGION( 0x40000, "maincpu", 0 ) // 2*128k for 68000 code
 	ROM_LOAD16_BYTE( "ryukendn_1.3s",  0x00000, 0x20000, CRC(6203a5e2) SHA1(8cfe05c483a351e938b067ffa642d515e28605a3) )
 	ROM_LOAD16_BYTE( "ryukendn_2.4s",  0x00001, 0x20000, CRC(9e99f522) SHA1(b2277d8934b5e6e2f556aee5092f5d1050774a34) )
 
 	ROM_REGION( 0x10000, "audiocpu", 0 )
-	ROM_LOAD( "3.4b",   0x0000, 0x10000, CRC(6b686b69) SHA1(f0fa553acb3945f8dbbf466073c8bae35a0375ef) )   /* Audio CPU is a Z80  */
+	ROM_LOAD( "3.4b",   0x0000, 0x10000, CRC(6b686b69) SHA1(f0fa553acb3945f8dbbf466073c8bae35a0375ef) )   // Audio CPU is a Z80 
 
 	ROM_REGION( 0x010000, "txtiles", 0 )
-	ROM_LOAD( "hn27512p.7a",   0x000000, 0x10000, CRC(765e7baa) SHA1(4d0a50f091b284739b6d9a8ceb4f81999da445fc) )    /* 8x8 tiles */
+	ROM_LOAD( "hn27512p.7a",   0x000000, 0x10000, CRC(765e7baa) SHA1(4d0a50f091b284739b6d9a8ceb4f81999da445fc) )    // 8x8 tiles
 
 	ROM_REGION( 0x080000, "bgtiles", 0 )
 	ROM_LOAD( "14.3a", 0x000000, 0x20000, CRC(1ecfddaa) SHA1(e71d60ae1a98fe8512498f91cce01c16be9f0871) )
@@ -1174,17 +1183,17 @@ ROM_START( ryukendn )
 	ROM_LOAD( "21.4b", 0x060000, 0x20000, CRC(1ac892f5) SHA1(28364266ca9d1955fb7953f5c2d6f35e114beec6) )
 
 	ROM_REGION( 0x100000, "sprites", 0 ) // sprite roms also seen on daughterboard "4M512" with 16 0x10000-sized roms
-	ROM_LOAD16_BYTE( "6.3m",  0x000000, 0x20000, CRC(e7ccdf9f) SHA1(80ffcefc95660471124898a9c2bee55df36bda13) ) /* sprites A1 */
-	ROM_LOAD16_BYTE( "7.1m",  0x000001, 0x20000, CRC(016bec95) SHA1(6a6757c52ca9a2398ea43d1af4a8d5adde6f4cd2) ) /* sprites A2 */
-	ROM_LOAD16_BYTE( "8.3n",  0x040000, 0x20000, CRC(7ef7f880) SHA1(26ba9a76adce24beea3cffa1cb95aeafe6f82f96) ) /* sprites B1 */
-	ROM_LOAD16_BYTE( "9.1n",  0x040001, 0x20000, CRC(6e9b7fd3) SHA1(c86ff61844fc94c02625bb812b9062d0649c8fdf) ) /* sprites B2 */
-	ROM_LOAD16_BYTE( "10.3r", 0x080000, 0x20000, CRC(a6451dec) SHA1(553e7a1453b59055fa0b10ca04125543d9f8987c) ) /* sprites C1 */
-	ROM_LOAD16_BYTE( "11.1r", 0x080001, 0x20000, CRC(7fbfdf5e) SHA1(ab67b72dcadb5f2236d29de751de5bf890a9e423) ) /* sprites C2 */
-	ROM_LOAD16_BYTE( "12.3s", 0x0c0000, 0x20000, CRC(277204f0) SHA1(918e05f10959f2b50c16b6e0dc62e3076c99250e) ) /* sprites D1 */
-	ROM_LOAD16_BYTE( "13.1s", 0x0c0001, 0x20000, CRC(4e56a508) SHA1(f89a6037e602b26d6ce11859e0b43a602b50d985) ) /* sprites D2 */
+	ROM_LOAD16_BYTE( "6.3m",  0x000000, 0x20000, CRC(e7ccdf9f) SHA1(80ffcefc95660471124898a9c2bee55df36bda13) ) // sprites A1
+	ROM_LOAD16_BYTE( "7.1m",  0x000001, 0x20000, CRC(016bec95) SHA1(6a6757c52ca9a2398ea43d1af4a8d5adde6f4cd2) ) // sprites A2
+	ROM_LOAD16_BYTE( "8.3n",  0x040000, 0x20000, CRC(7ef7f880) SHA1(26ba9a76adce24beea3cffa1cb95aeafe6f82f96) ) // sprites B1
+	ROM_LOAD16_BYTE( "9.1n",  0x040001, 0x20000, CRC(6e9b7fd3) SHA1(c86ff61844fc94c02625bb812b9062d0649c8fdf) ) // sprites B2
+	ROM_LOAD16_BYTE( "10.3r", 0x080000, 0x20000, CRC(a6451dec) SHA1(553e7a1453b59055fa0b10ca04125543d9f8987c) ) // sprites C1
+	ROM_LOAD16_BYTE( "11.1r", 0x080001, 0x20000, CRC(7fbfdf5e) SHA1(ab67b72dcadb5f2236d29de751de5bf890a9e423) ) // sprites C2
+	ROM_LOAD16_BYTE( "12.3s", 0x0c0000, 0x20000, CRC(277204f0) SHA1(918e05f10959f2b50c16b6e0dc62e3076c99250e) ) // sprites D1
+	ROM_LOAD16_BYTE( "13.1s", 0x0c0001, 0x20000, CRC(4e56a508) SHA1(f89a6037e602b26d6ce11859e0b43a602b50d985) ) // sprites D2
 
-	ROM_REGION( 0x40000, "oki", 0 ) /* 128k for ADPCM samples - sound chip is OKIM6295 */
-	ROM_LOAD( "4.4a",     0x0000, 0x20000, CRC(b0e0faf9) SHA1(2275d2ef5eee356ccf80b9e9644d16fc30a4d107) ) /* samples */
+	ROM_REGION( 0x40000, "oki", 0 ) // 128k for ADPCM samples - sound chip is OKIM6295
+	ROM_LOAD( "4.4a",     0x0000, 0x20000, CRC(b0e0faf9) SHA1(2275d2ef5eee356ccf80b9e9644d16fc30a4d107) ) // samples
 ROM_END
 
 /*
@@ -1197,16 +1206,16 @@ Dumped from an original Tecmo board. Board No. 6215-A. Serial A-59488.
 */
 
 ROM_START( ryukendna )
-	ROM_REGION( 0x40000, "maincpu", 0 ) /* 2*128k for 68000 code */
+	ROM_REGION( 0x40000, "maincpu", 0 ) // 2*128k for 68000 code
 	ROM_LOAD16_BYTE( "1.3s",  0x00000, 0x20000, CRC(5532e302) SHA1(8ce48963ba737890d1a46c42a113d9419a3c174c) ) // found on 2 pcbs
 //  ROM_LOAD16_BYTE( "1.3s",  0x00000, 0x20000, CRC(0ed5464c) SHA1(2eab6650ad1c38cd560ec3d084f47156756c97a4) ) 2 bytes different ( 022a : 50 instead of 51, 12f9 : 6b instead of 6a) - possible bad rom
 	ROM_LOAD16_BYTE( "2.4s",  0x00001, 0x20000, CRC(a93a8256) SHA1(6bf6c189f82cb9341d3427a822de83cbaed27bc0) )
 
 	ROM_REGION( 0x10000, "audiocpu", 0 )
-	ROM_LOAD( "3.4b",   0x0000, 0x10000, CRC(6b686b69) SHA1(f0fa553acb3945f8dbbf466073c8bae35a0375ef) )   /* Audio CPU is a Z80  */
+	ROM_LOAD( "3.4b",   0x0000, 0x10000, CRC(6b686b69) SHA1(f0fa553acb3945f8dbbf466073c8bae35a0375ef) )   // Audio CPU is a Z80 
 
 	ROM_REGION( 0x010000, "txtiles", 0 )
-	ROM_LOAD( "hn27512p.7a",   0x000000, 0x10000, CRC(765e7baa) SHA1(4d0a50f091b284739b6d9a8ceb4f81999da445fc) )    /* 8x8 tiles */
+	ROM_LOAD( "hn27512p.7a",   0x000000, 0x10000, CRC(765e7baa) SHA1(4d0a50f091b284739b6d9a8ceb4f81999da445fc) )    // 8x8 tiles
 
 	ROM_REGION( 0x080000, "bgtiles", 0 )
 	ROM_LOAD( "14.3a", 0x000000, 0x20000, CRC(1ecfddaa) SHA1(e71d60ae1a98fe8512498f91cce01c16be9f0871) )
@@ -1221,17 +1230,17 @@ ROM_START( ryukendna )
 	ROM_LOAD( "21.4b", 0x060000, 0x20000, CRC(1ac892f5) SHA1(28364266ca9d1955fb7953f5c2d6f35e114beec6) )
 
 	ROM_REGION( 0x100000, "sprites", 0 ) // sprite roms also seen on daughterboard "4M512" with 16 0x10000-sized roms
-	ROM_LOAD16_BYTE( "6.3m",  0x000000, 0x20000, CRC(e7ccdf9f) SHA1(80ffcefc95660471124898a9c2bee55df36bda13) ) /* sprites A1 */
-	ROM_LOAD16_BYTE( "7.1m",  0x000001, 0x20000, CRC(016bec95) SHA1(6a6757c52ca9a2398ea43d1af4a8d5adde6f4cd2) ) /* sprites A2 */
-	ROM_LOAD16_BYTE( "8.3n",  0x040000, 0x20000, CRC(7ef7f880) SHA1(26ba9a76adce24beea3cffa1cb95aeafe6f82f96) ) /* sprites B1 */
-	ROM_LOAD16_BYTE( "9.1n",  0x040001, 0x20000, CRC(6e9b7fd3) SHA1(c86ff61844fc94c02625bb812b9062d0649c8fdf) ) /* sprites B2 */
-	ROM_LOAD16_BYTE( "10.3r", 0x080000, 0x20000, CRC(a6451dec) SHA1(553e7a1453b59055fa0b10ca04125543d9f8987c) ) /* sprites C1 */
-	ROM_LOAD16_BYTE( "11.1r", 0x080001, 0x20000, CRC(7fbfdf5e) SHA1(ab67b72dcadb5f2236d29de751de5bf890a9e423) ) /* sprites C2 */
-	ROM_LOAD16_BYTE( "12.3s", 0x0c0000, 0x20000, CRC(277204f0) SHA1(918e05f10959f2b50c16b6e0dc62e3076c99250e) ) /* sprites D1 */
-	ROM_LOAD16_BYTE( "13.1s", 0x0c0001, 0x20000, CRC(4e56a508) SHA1(f89a6037e602b26d6ce11859e0b43a602b50d985) ) /* sprites D2 */
+	ROM_LOAD16_BYTE( "6.3m",  0x000000, 0x20000, CRC(e7ccdf9f) SHA1(80ffcefc95660471124898a9c2bee55df36bda13) ) // sprites A1
+	ROM_LOAD16_BYTE( "7.1m",  0x000001, 0x20000, CRC(016bec95) SHA1(6a6757c52ca9a2398ea43d1af4a8d5adde6f4cd2) ) // sprites A2
+	ROM_LOAD16_BYTE( "8.3n",  0x040000, 0x20000, CRC(7ef7f880) SHA1(26ba9a76adce24beea3cffa1cb95aeafe6f82f96) ) // sprites B1
+	ROM_LOAD16_BYTE( "9.1n",  0x040001, 0x20000, CRC(6e9b7fd3) SHA1(c86ff61844fc94c02625bb812b9062d0649c8fdf) ) // sprites B2
+	ROM_LOAD16_BYTE( "10.3r", 0x080000, 0x20000, CRC(a6451dec) SHA1(553e7a1453b59055fa0b10ca04125543d9f8987c) ) // sprites C1
+	ROM_LOAD16_BYTE( "11.1r", 0x080001, 0x20000, CRC(7fbfdf5e) SHA1(ab67b72dcadb5f2236d29de751de5bf890a9e423) ) // sprites C2
+	ROM_LOAD16_BYTE( "12.3s", 0x0c0000, 0x20000, CRC(277204f0) SHA1(918e05f10959f2b50c16b6e0dc62e3076c99250e) ) // sprites D1
+	ROM_LOAD16_BYTE( "13.1s", 0x0c0001, 0x20000, CRC(4e56a508) SHA1(f89a6037e602b26d6ce11859e0b43a602b50d985) ) // sprites D2
 
-	ROM_REGION( 0x40000, "oki", 0 ) /* 128k for ADPCM samples - sound chip is OKIM6295 */
-	ROM_LOAD( "4.4a",     0x0000, 0x20000, CRC(b0e0faf9) SHA1(2275d2ef5eee356ccf80b9e9644d16fc30a4d107) ) /* samples */
+	ROM_REGION( 0x40000, "oki", 0 ) // 128k for ADPCM samples - sound chip is OKIM6295
+	ROM_LOAD( "4.4a",     0x0000, 0x20000, CRC(b0e0faf9) SHA1(2275d2ef5eee356ccf80b9e9644d16fc30a4d107) ) // samples
 ROM_END
 
 ROM_START( mastninj )
@@ -1587,22 +1596,21 @@ ROM_END
 
 void gaiden_state::init_shadoww()
 {
-	m_jumppoints = wildfang_jumppoints;
-	/* sprite size Y = sprite size X */
+	// sprite size Y = sprite size X
 	m_sprite_sizey = 0;
 }
 
-void gaiden_state::init_wildfang()
+void wildfang_state::init_wildfang()
 {
 	m_jumppoints = wildfang_jumppoints;
-	/* sprite size Y = sprite size X */
+	// sprite size Y = sprite size X
 	m_sprite_sizey = 0;
 }
 
-void gaiden_state::init_raiga()
+void raiga_state::init_raiga()
 {
 	m_jumppoints = raiga_jumppoints_00;
-	/* sprite size Y independent from sprite size X */
+	// sprite size Y independent from sprite size X
 	m_sprite_sizey = 2;
 }
 
@@ -1648,21 +1656,19 @@ void gaiden_state::descramble_drgnbowl(int descramble_cpu)
 
 void gaiden_state::init_drgnbowl()
 {
-	m_jumppoints = wildfang_jumppoints;
 	descramble_drgnbowl(1);
 }
 
 void gaiden_state::init_drgnbowla()
 {
-	m_jumppoints = wildfang_jumppoints;
 	descramble_drgnbowl(0);
 }
 
-void gaiden_state::descramble_mastninj_gfx(uint8_t* src)
+void mastninj_state::descramble_mastninj_gfx(uint8_t* src)
 {
 	int len = 0x80000;
 
-	/*  rearrange gfx */
+	//  rearrange gfx
 	{
 		std::vector<uint8_t> buffer(len);
 		int i;
@@ -1696,7 +1702,7 @@ void gaiden_state::descramble_mastninj_gfx(uint8_t* src)
 	}
 }
 
-void gaiden_state::init_mastninj()
+void mastninj_state::init_mastninj()
 {
 	// rearrange the graphic roms into a format that MAME can decode
 	descramble_mastninj_gfx(memregion("bgtiles")->base());
@@ -1705,19 +1711,19 @@ void gaiden_state::init_mastninj()
 }
 
 //    YEAR, NAME,      PARENT,   MACHINE,  INPUT,    STATE,        INIT,           MONITOR,COMPANY,   FULLNAME,FLAGS
-GAME( 1988, shadoww,   0,        shadoww,  common,   gaiden_state, init_shadoww,   ROT0,   "Tecmo",   "Shadow Warriors (World, set 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, shadowwa,  shadoww,  shadoww,  common,   gaiden_state, init_shadoww,   ROT0,   "Tecmo",   "Shadow Warriors (World, set 2)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, gaiden,    shadoww,  shadoww,  common,   gaiden_state, init_shadoww,   ROT0,   "Tecmo",   "Ninja Gaiden (US)",              MACHINE_SUPPORTS_SAVE )
-GAME( 1989, ryukendn,  shadoww,  shadoww,  common,   gaiden_state, init_shadoww,   ROT0,   "Tecmo",   "Ninja Ryukenden (Japan, set 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, ryukendna, shadoww,  shadoww,  common,   gaiden_state, init_shadoww,   ROT0,   "Tecmo",   "Ninja Ryukenden (Japan, set 2)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, mastninj,  shadoww,  mastninj, common,   gaiden_state, init_mastninj,  ROT0,   "bootleg", "Master Ninja (bootleg of Shadow Warriors / Ninja Gaiden)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // sprites need fixing, sound and yscroll too. - it is confirmed the curtains don't scroll on the pcb
-GAME( 1992, drgnbowl,  0,        drgnbowl, drgnbowl, gaiden_state, init_drgnbowl,  ROT0,   "Nics",    "Dragon Bowl (set 1, encrypted program)",   MACHINE_SUPPORTS_SAVE ) // Dragon Bowl is based on Ninja Gaiden code
-GAME( 1992, drgnbowla, drgnbowl, drgnbowl, drgnbowl, gaiden_state, init_drgnbowla, ROT0,   "Nics",    "Dragon Bowl (set 2, unencrypted program)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, shadoww,   0,        shadoww,  common,   gaiden_state,   init_shadoww,   ROT0,   "Tecmo",   "Shadow Warriors (World, set 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, shadowwa,  shadoww,  shadoww,  common,   gaiden_state,   init_shadoww,   ROT0,   "Tecmo",   "Shadow Warriors (World, set 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, gaiden,    shadoww,  shadoww,  common,   gaiden_state,   init_shadoww,   ROT0,   "Tecmo",   "Ninja Gaiden (US)",              MACHINE_SUPPORTS_SAVE )
+GAME( 1989, ryukendn,  shadoww,  shadoww,  common,   gaiden_state,   init_shadoww,   ROT0,   "Tecmo",   "Ninja Ryukenden (Japan, set 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, ryukendna, shadoww,  shadoww,  common,   gaiden_state,   init_shadoww,   ROT0,   "Tecmo",   "Ninja Ryukenden (Japan, set 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, mastninj,  shadoww,  mastninj, common,   mastninj_state, init_mastninj,  ROT0,   "bootleg", "Master Ninja (bootleg of Shadow Warriors / Ninja Gaiden)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // sprites need fixing, sound and yscroll too. - it is confirmed the curtains don't scroll on the pcb
+GAME( 1992, drgnbowl,  0,        drgnbowl, drgnbowl, gaiden_state,   init_drgnbowl,  ROT0,   "Nics",    "Dragon Bowl (set 1, encrypted program)",   MACHINE_SUPPORTS_SAVE ) // Dragon Bowl is based on Ninja Gaiden code
+GAME( 1992, drgnbowla, drgnbowl, drgnbowl, drgnbowl, gaiden_state,   init_drgnbowla, ROT0,   "Nics",    "Dragon Bowl (set 2, unencrypted program)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1989, wildfang,  0,        wildfang, wildfang, gaiden_state, init_wildfang,  ROT0,   "Tecmo",   "Wild Fang / Tecmo Knight", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, wildfangs, wildfang, wildfang, tknight,  gaiden_state, init_wildfang,  ROT0,   "Tecmo",   "Wild Fang",                MACHINE_SUPPORTS_SAVE )
-GAME( 1989, tknight,   wildfang, wildfang, tknight,  gaiden_state, init_wildfang,  ROT0,   "Tecmo",   "Tecmo Knight",             MACHINE_SUPPORTS_SAVE )
-GAME( 1991, wildfangh, wildfang, wildfang, tknight,  gaiden_state, init_wildfang,  ROT0,   "Tecmo",   "Wild Fang (year hack?)",   MACHINE_SUPPORTS_SAVE )
+GAME( 1989, wildfang,  0,        wildfang, wildfang, wildfang_state, init_wildfang,  ROT0,   "Tecmo",   "Wild Fang / Tecmo Knight", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, wildfangs, wildfang, wildfang, tknight,  wildfang_state, init_wildfang,  ROT0,   "Tecmo",   "Wild Fang",                MACHINE_SUPPORTS_SAVE )
+GAME( 1989, tknight,   wildfang, wildfang, tknight,  wildfang_state, init_wildfang,  ROT0,   "Tecmo",   "Tecmo Knight",             MACHINE_SUPPORTS_SAVE )
+GAME( 1991, wildfangh, wildfang, wildfang, tknight,  wildfang_state, init_wildfang,  ROT0,   "Tecmo",   "Wild Fang (year hack?)",   MACHINE_SUPPORTS_SAVE )
 
-GAME( 1991, stratof,   0,        raiga,    raiga,    gaiden_state, init_raiga,     ROT0,   "Tecmo",   "Raiga - Strato Fighter (US)",    MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
-GAME( 1991, raiga,     stratof,  raiga,    raiga,    gaiden_state, init_raiga,     ROT0,   "Tecmo",   "Raiga - Strato Fighter (Japan)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+GAME( 1991, stratof,   0,        raiga,    raiga,    raiga_state,    init_raiga,     ROT0,   "Tecmo",   "Raiga - Strato Fighter (US)",    MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+GAME( 1991, raiga,     stratof,  raiga,    raiga,    raiga_state,    init_raiga,     ROT0,   "Tecmo",   "Raiga - Strato Fighter (Japan)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/tecmo/gaiden_v.cpp
+++ b/src/mame/tecmo/gaiden_v.cpp
@@ -17,8 +17,8 @@
 
 TILE_GET_INFO_MEMBER(gaiden_state::get_bg_tile_info)
 {
-	uint16_t *videoram1 = &m_videoram[2][0x0800];
-	uint16_t *videoram2 = m_videoram[2];
+	uint16_t const *const videoram1 = &m_videoram[2][0x0800];
+	uint16_t const *const videoram2 = m_videoram[2];
 	tileinfo.set(1,
 			videoram1[tile_index] & 0x0fff,
 			(videoram2[tile_index] & 0xf0) >> 4,
@@ -27,8 +27,8 @@ TILE_GET_INFO_MEMBER(gaiden_state::get_bg_tile_info)
 
 TILE_GET_INFO_MEMBER(gaiden_state::get_fg_tile_info)
 {
-	uint16_t *videoram1 = &m_videoram[1][0x0800];
-	uint16_t *videoram2 = m_videoram[1];
+	uint16_t const *const videoram1 = &m_videoram[1][0x0800];
+	uint16_t const *const videoram2 = m_videoram[1];
 	tileinfo.set(2,
 			videoram1[tile_index] & 0x0fff,
 			(videoram2[tile_index] & 0xf0) >> 4,
@@ -37,12 +37,12 @@ TILE_GET_INFO_MEMBER(gaiden_state::get_fg_tile_info)
 
 TILE_GET_INFO_MEMBER(gaiden_state::get_fg_tile_info_raiga)
 {
-	uint16_t *videoram1 = &m_videoram[1][0x0800];
-	uint16_t *videoram2 = m_videoram[1];
+	uint16_t const *const videoram1 = &m_videoram[1][0x0800];
+	uint16_t const *const videoram2 = m_videoram[1];
 
-	int colour = ((videoram2[tile_index] & 0xf0) >> 4);
+	uint32_t colour = ((videoram2[tile_index] & 0xf0) >> 4);
 
-	/* bit 3 controls blending */
+	// bit 3 controls blending
 	if ((videoram2[tile_index] & 0x08))
 		colour += 0x10;
 
@@ -54,8 +54,8 @@ TILE_GET_INFO_MEMBER(gaiden_state::get_fg_tile_info_raiga)
 
 TILE_GET_INFO_MEMBER(gaiden_state::get_tx_tile_info)
 {
-	uint16_t *videoram1 = &m_videoram[0][0x0400];
-	uint16_t *videoram2 = m_videoram[0];
+	uint16_t const *const videoram1 = &m_videoram[0][0x0400];
+	uint16_t const *const videoram2 = m_videoram[0];
 	tileinfo.set(0,
 			videoram1[tile_index] & 0x07ff,
 			(videoram2[tile_index] & 0xf0) >> 4,
@@ -71,7 +71,7 @@ TILE_GET_INFO_MEMBER(gaiden_state::get_tx_tile_info)
 
 VIDEO_START_MEMBER(gaiden_state,gaiden)
 {
-	/* set up tile layers */
+	// set up tile layers
 	m_screen->register_screen_bitmap(m_tile_bitmap_bg);
 	m_screen->register_screen_bitmap(m_tile_bitmap_fg);
 	m_screen->register_screen_bitmap(m_tile_bitmap_tx);
@@ -88,34 +88,34 @@ VIDEO_START_MEMBER(gaiden_state,gaiden)
 	m_foreground->set_scrolldy(0, 33);
 	m_text_layer->set_scrolldy(0, 33);
 
-	/* set up sprites */
+	// set up sprites
 	m_screen->register_screen_bitmap(m_sprite_bitmap);
 }
 
 
-VIDEO_START_MEMBER(gaiden_state,raiga)
+void raiga_state::video_start()
 {
-	/* set up tile layers */
+	// set up tile layers
 	m_screen->register_screen_bitmap(m_tile_bitmap_bg);
 	m_screen->register_screen_bitmap(m_tile_bitmap_fg);
 	m_screen->register_screen_bitmap(m_tile_bitmap_tx);
 
-	m_background = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(gaiden_state::get_bg_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
-	m_foreground = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(gaiden_state::get_fg_tile_info_raiga)), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
-	m_text_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(gaiden_state::get_tx_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_background = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(raiga_state::get_bg_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
+	m_foreground = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(raiga_state::get_fg_tile_info_raiga)), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
+	m_text_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(raiga_state::get_tx_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
 
 //  m_background->set_transparent_pen(0);
 //  m_foreground->set_transparent_pen(0);
 	m_text_layer->set_transparent_pen(0);
 
-	/* set up sprites */
+	// set up sprites
 	m_screen->register_screen_bitmap(m_sprite_bitmap);
 
 }
 
 VIDEO_START_MEMBER(gaiden_state,drgnbowl)
 {
-	/* set up tile layers */
+	// set up tile layers
 	m_background = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(gaiden_state::get_bg_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
 	m_foreground = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(gaiden_state::get_fg_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
 	m_text_layer = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(gaiden_state::get_tx_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
@@ -135,75 +135,79 @@ VIDEO_START_MEMBER(gaiden_state,drgnbowl)
 
 ***************************************************************************/
 
-void gaiden_state::gaiden_flip_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void gaiden_state::flip_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	if (ACCESSING_BITS_0_7)
-		flip_screen_set(data & 1);
+		flip_screen_set(BIT(data, 0));
 }
 
-void gaiden_state::gaiden_txscrollx_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void gaiden_state::txscrollx_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	COMBINE_DATA(&m_tx_scroll_x);
 	m_text_layer->set_scrollx(0, m_tx_scroll_x);
 }
 
-void gaiden_state::gaiden_txscrolly_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void gaiden_state::txscrolly_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	COMBINE_DATA(&m_tx_scroll_y);
 	m_text_layer->set_scrolly(0, (m_tx_scroll_y - m_tx_offset_y) & 0xffff);
 }
 
-void gaiden_state::gaiden_fgscrollx_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void gaiden_state::fgscrollx_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	COMBINE_DATA(&m_fg_scroll_x);
 	m_foreground->set_scrollx(0, m_fg_scroll_x);
 }
 
-void gaiden_state::gaiden_fgscrolly_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void gaiden_state::fgscrolly_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	COMBINE_DATA(&m_fg_scroll_y);
 	m_foreground->set_scrolly(0, (m_fg_scroll_y - m_fg_offset_y) & 0xffff);
 }
 
-void gaiden_state::gaiden_bgscrollx_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void gaiden_state::bgscrollx_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	COMBINE_DATA(&m_bg_scroll_x);
 	m_background->set_scrollx(0, m_bg_scroll_x);
 }
 
-void gaiden_state::gaiden_bgscrolly_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void gaiden_state::bgscrolly_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	COMBINE_DATA(&m_bg_scroll_y);
 	m_background->set_scrolly(0, (m_bg_scroll_y - m_bg_offset_y) & 0xffff);
 }
 
-void gaiden_state::gaiden_txoffsety_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void gaiden_state::txoffsety_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	if (ACCESSING_BITS_0_7) {
+	if (ACCESSING_BITS_0_7)
+	{
 		m_tx_offset_y = data;
 		m_text_layer->set_scrolly(0, (m_tx_scroll_y - m_tx_offset_y) & 0xffff);
 	}
 }
 
-void gaiden_state::gaiden_fgoffsety_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void gaiden_state::fgoffsety_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	if (ACCESSING_BITS_0_7) {
+	if (ACCESSING_BITS_0_7)
+	{
 		m_fg_offset_y = data;
 		m_foreground->set_scrolly(0, (m_fg_scroll_y - m_fg_offset_y) & 0xffff);
 	}
 }
 
-void gaiden_state::gaiden_bgoffsety_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void gaiden_state::bgoffsety_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	if (ACCESSING_BITS_0_7) {
+	if (ACCESSING_BITS_0_7)
+	{
 		m_bg_offset_y = data;
 		m_background->set_scrolly(0, (m_bg_scroll_y - m_bg_offset_y) & 0xffff);
 	}
 }
 
-void gaiden_state::gaiden_sproffsety_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void gaiden_state::sproffsety_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	if (ACCESSING_BITS_0_7) {
+	if (ACCESSING_BITS_0_7)
+	{
 		m_spr_offset_y = data;
 		// handled in draw_sprites
 	}
@@ -257,39 +261,39 @@ void gaiden_state::tx_videoram_w(offs_t offset, uint16_t data, uint16_t mem_mask
 void gaiden_state::drgnbowl_draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	uint16_t const *const spriteram = m_spriteram->live(); // not buffered?
-	int i, code, color, x, y, flipx, flipy, priority_mask;
+	uint32_t priority_mask;
 
-	for( i = 0; i < 0x800/2; i += 4 )
+	for (int i = 0; i < 0x800 / 2; i += 4)
 	{
-		code = (spriteram[i + 0] & 0xff) | ((spriteram[i + 3] & 0x1f) << 8);
-		y = 256 - (spriteram[i + 1] & 0xff) - 12;
-		x = spriteram[i + 2] & 0xff;
-		color = (spriteram[(0x800/2) + i] & 0x0f);
-		flipx = spriteram[i + 3] & 0x40;
-		flipy = spriteram[i + 3] & 0x80;
+		uint32_t const code = (spriteram[i + 0] & 0xff) | ((spriteram[i + 3] & 0x1f) << 8);
+		int const y = 256 - (spriteram[i + 1] & 0xff) - 12;
+		int x = spriteram[i + 2] & 0xff;
+		uint32_t const color = (spriteram[(0x800/2) + i] & 0x0f);
+		bool const flipx = BIT(spriteram[i + 3], 6);
+		bool const flipy = BIT(spriteram[i + 3], 7);
 
-		if(spriteram[(0x800/2) + i] & 0x80)
+		if (BIT(spriteram[(0x800 / 2) + i], 7))
 			x -= 256;
 
 		x += 256;
 
 		if(spriteram[i + 3] & 0x20)
-			priority_mask = 0xf0 | 0xcc; /* obscured by foreground */
+			priority_mask = 0xf0 | 0xcc; // obscured by foreground
 		else
 			priority_mask = 0;
 
-		m_gfxdecode->gfx(3)->prio_transpen_raw(bitmap,cliprect,
+		m_gfxdecode->gfx(3)->prio_transpen_raw(bitmap, cliprect,
 				code,
 				m_gfxdecode->gfx(3)->colorbase() + color * m_gfxdecode->gfx(3)->granularity(),
-				flipx,flipy,x,y,
-				screen.priority(), priority_mask,15);
+				flipx, flipy, x, y,
+				screen.priority(), priority_mask, 15);
 
-		/* wrap x*/
-		m_gfxdecode->gfx(3)->prio_transpen_raw(bitmap,cliprect,
+		// wrap x
+		m_gfxdecode->gfx(3)->prio_transpen_raw(bitmap, cliprect,
 				code,
 				m_gfxdecode->gfx(3)->colorbase() + color * m_gfxdecode->gfx(3)->granularity(),
-				flipx,flipy,x-512,y,
-				screen.priority(), priority_mask,15);
+				flipx, flipy, x - 512, y,
+				screen.priority(), priority_mask, 15);
 
 	}
 }
@@ -313,7 +317,7 @@ uint32_t gaiden_state::screen_update_gaiden(screen_device &screen, bitmap_rgb32 
 	return 0;
 }
 
-uint32_t gaiden_state::screen_update_raiga(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+uint32_t raiga_state::screen_update_raiga(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	m_tile_bitmap_bg.fill(0, cliprect);
 	m_tile_bitmap_fg.fill(0, cliprect);
@@ -340,7 +344,7 @@ uint32_t gaiden_state::screen_update_drgnbowl(screen_device &screen, bitmap_ind1
 	return 0;
 }
 
-void gaiden_state::screen_vblank_raiga(int state)
+void raiga_state::screen_vblank_raiga(int state)
 {
 	if (state)
 	{


### PR DESCRIPTION
- Split driver class for wildfang and raiga via protection methods
- Split driver class for mastninj via MSM5205 controls
- Fix raiga post-load behavior
- Use C++ style single line comments
- Reduce literal tag usage
- Reduce duplications
- Fix function namings
- Make some variables constant
- Fix, Correct type for variables
- Reduce unused functions
- Fix code style consistency