### PR TITLE
sony/news_r3k.cpp, sony/news_r4k.cpp, sony/news_68k.cpp, sony/news_38xx.cpp: Add software list for Sony NEWS systems

### DIFF
--- a/hash/sony_news.xml
+++ b/hash/sony_news.xml
@@ -3,14 +3,14 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="sony_news_risc" description="Sony NEWS RISC (MIPS) software">
+<softwarelist name="sony_news" description="Sony NEWS software">
 
 	<software name="nwf_672rb" supported="partial">
 		<description>NEWS-OS Release 4.1R Version Up Kit</description>
 		<year>1991</year>
 		<publisher>Sony</publisher>
 		<notes>The floppies can boot on both CISC and RISC systems due to some bootloader magic, but the MO image is only for the first wave of RISC NEWS machines (NWS-3000 series)</notes>
-		
+		<sharedfeat name="compatibility" value="RISC" />
 		<!--
 		The installation floppy and MO disk work, but the format disk hangs after printing a few messages on RISC systems. 
 		Therefore, use of this kit requires use of a pre-formatted hard disk image for now.
@@ -44,6 +44,7 @@ license:CC0-1.0
 		<year>1993</year>
 		<publisher>Sony</publisher>
 		<notes>Usable only on NWS-5000 series computers</notes>
+		<sharedfeat name="compatibility" value="RISC" />
 
 		<!-- Source: WinWorld -->
 		<!-- The "STAMP" file has the build date of 05/05/93 -->

--- a/hash/sony_news_risc.xml
+++ b/hash/sony_news_risc.xml
@@ -9,7 +9,7 @@ license:CC0-1.0
 		<description>NEWS-OS Release 4.1R Version Up Kit</description>
 		<year>1991</year>
 		<publisher>Sony</publisher>
-		<notes>The floppies can boot on both CISC and RISC systems due to some bootloader magic, but the MO image is only for RISC machines.</notes>
+		<notes>The floppies can boot on both CISC and RISC systems due to some bootloader magic, but the MO image is only for the first wave of RISC NEWS machines</notes>
 		
 		<!--
 		The installation floppy and MO disk work, but the format disk hangs after printing a few messages on RISC systems. 
@@ -22,19 +22,19 @@ license:CC0-1.0
 		<part name="hdd" interface="scsi_hdd">
 			<feature name="part_id" value="NEWS-OS Install Kit NWF672R Vol.1" />
 			<diskarea name="harddriv">
-				<disk name="nwf_672rb_mo" sha1="0000000000000000000000000000000000000000"/>
+				<disk name="nwf_672rb_mo" sha1="b1c3b2e28d5695385b88f7415ce1e53d647333e4" />
 			</diskarea>
 		</part>
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Format Program" />
-			<dataarea name="flop">
-				<rom name="nwf_672rb_format_program.img" size="1474560" crc="963126cd" sha1="9e7c6dec4a454e630cb7c40dea3f40206e6b4cfb" />
+		<part name="install" interface="floppy_3_5">
+			<feature name="part_id" value="Installation Program" />
+			<dataarea name="flop" size="1474560">
+				<rom name="nwf_672rb_installation_program.img" size="1474560" crc="4fda104d" sha1="ed9499211ccf133570defa136199f331a38368f5" />
 			</dataarea>
 		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Installation Program" />
-			<dataarea name="flop">
-				<rom name="nwf_672rb_installation_program.img" size="1474560" crc="963126cd" sha1="9e7c6dec4a454e630cb7c40dea3f40206e6b4cfb" />
+		<part name="format" interface="floppy_3_5">
+			<feature name="part_id" value="Format Program" />
+			<dataarea name="flop" size="1474560">
+				<rom name="nwf_672rb_format_program.img" size="1474560" crc="690016ec" sha1="64ff03dace6e8b91569bef6f2f8855fa59c39abe" />
 			</dataarea>
 		</part>
 	</software>
@@ -43,10 +43,7 @@ license:CC0-1.0
 		<description>NEWS-OS Release 4.2.1aRD Installation Kit</description>
 		<year>1993</year>
 		<publisher>Sony</publisher>
-		<notes>Bootable and installable only on NWS-5000 series computers. Also contains some netboot kernels for some other RISC and CISC NEWS computers.</notes>
-		<!-- 
-		NWS-3260 driver should be able to read this (but not install it); however, CD-ROM support is not fully working for that driver currently.
-		-->
+		<notes>Usable only on NWS-5000 series computers</notes>
 
 		<!-- Source: WinWorld -->
 		<!-- The "STAMP" file has the build date of 05/05/93 -->

--- a/hash/sony_news_risc.xml
+++ b/hash/sony_news_risc.xml
@@ -20,7 +20,7 @@ license:CC0-1.0
 		<!-- Source: archive.org -->
 		<!-- The "STAMP" file has the build date of 07/23/91 -->
 		<part name="hdd" interface="scsi_hdd">
-			<feature name="part_id" value="NEWS-OS Install Kit NWF672R Vol.1" />
+			<feature name="part_id" value="NEWS-OS Install Kit NWF-672R Vol.1" />
 			<diskarea name="harddriv">
 				<disk name="nwf_672rb_mo" sha1="b1c3b2e28d5695385b88f7415ce1e53d647333e4" />
 			</diskarea>

--- a/hash/sony_news_risc.xml
+++ b/hash/sony_news_risc.xml
@@ -9,7 +9,7 @@ license:CC0-1.0
 		<description>NEWS-OS Release 4.1R Version Up Kit</description>
 		<year>1991</year>
 		<publisher>Sony</publisher>
-		<notes>The floppies can boot on both CISC and RISC systems due to some bootloader magic, but the MO image is only for the first wave of RISC NEWS machines</notes>
+		<notes>The floppies can boot on both CISC and RISC systems due to some bootloader magic, but the MO image is only for the first wave of RISC NEWS machines (NWS-3000 series)</notes>
 		
 		<!--
 		The installation floppy and MO disk work, but the format disk hangs after printing a few messages on RISC systems. 

--- a/hash/sony_news_risc.xml
+++ b/hash/sony_news_risc.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<!--
+license:CC0-1.0
+-->
+<softwarelist name="sony_news_risc" description="Sony NEWS RISC software">
+
+	<software name="nwf_672rb" supported="partial">
+		<description>NEWS-OS Release 4.1R Version Up Kit</description>
+		<year>1991</year>
+		<publisher>Sony</publisher>
+		<notes>The floppies can boot on both CISC and RISC systems due to some bootloader magic, but the MO image is only for RISC machines.</notes>
+		
+		<!--
+		The installation floppy and MO disk work, but the format disk hangs after printing a few messages on RISC systems. 
+		Therefore, use of this kit requires use of a pre-formatted hard disk image for now.
+		The disk image loads on the CISC NEWS driver, so it is most likely an emulation issue, not a disk image issue.
+		-->
+
+		<!-- Source: archive.org -->
+		<!-- The "STAMP" file has the build date of 07/23/91 -->
+		<part name="hdd" interface="scsi_hdd">
+			<feature name="part_id" value="NEWS-OS Install Kit NWF672R Vol.1" />
+			<diskarea name="harddriv">
+				<disk name="nwf_672rb_mo" sha1="0000000000000000000000000000000000000000"/>
+			</diskarea>
+		</part>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Format Program" />
+			<dataarea name="flop">
+				<rom name="nwf_672rb_format_program.img" size="1474560" crc="963126cd" sha1="9e7c6dec4a454e630cb7c40dea3f40206e6b4cfb" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Installation Program" />
+			<dataarea name="flop">
+				<rom name="nwf_672rb_installation_program.img" size="1474560" crc="963126cd" sha1="9e7c6dec4a454e630cb7c40dea3f40206e6b4cfb" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="nwf_683rd1" supported="yes">
+		<description>NEWS-OS Release 4.2.1aRD Installation Kit</description>
+		<year>1993</year>
+		<publisher>Sony</publisher>
+		<notes>Bootable and installable only on NWS-5000 series computers. Also contains some netboot kernels for some other RISC and CISC NEWS computers.</notes>
+		<!-- 
+		NWS-3260 driver should be able to read this (but not install it); however, CD-ROM support is not fully working for that driver currently.
+		-->
+
+		<!-- Source: WinWorld -->
+		<!-- The "STAMP" file has the build date of 05/05/93 -->
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_id" value="NEWS-OS Install Kit NWF-683RD1 Vol.1" />
+			<diskarea name="cdrom">
+				<disk name="nwf_683rd1" sha1="84ade11109e676eaaf20e999c1aa4b5d48d40555" />
+			</diskarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/hash/sony_news_risc.xml
+++ b/hash/sony_news_risc.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="sony_news_risc" description="Sony NEWS RISC software">
+<softwarelist name="sony_news_risc" description="Sony NEWS RISC (MIPS) software">
 
 	<software name="nwf_672rb" supported="partial">
 		<description>NEWS-OS Release 4.1R Version Up Kit</description>

--- a/src/mame/sony/news_38xx.cpp
+++ b/src/mame/sony/news_38xx.cpp
@@ -425,6 +425,8 @@ void news_38xx_state::common(machine_config &config)
 	NEWS_HID_HLE(config, m_hid);
 	m_hid->irq_out<news_hid_hle_device::KEYBOARD>().set(m_serial_irq, FUNC(input_merger_device::in_w<0>));
 	m_hid->irq_out<news_hid_hle_device::MOUSE>().set(m_serial_irq, FUNC(input_merger_device::in_w<1>));
+
+	SOFTWARE_LIST(config, "software_list").set_original("sony_news").set_filter("RISC");
 }
 
 void news_38xx_state::nws3860(machine_config &config)

--- a/src/mame/sony/news_68k.cpp
+++ b/src/mame/sony/news_68k.cpp
@@ -425,6 +425,8 @@ void news_68k_state::common(machine_config &config)
 	m_vram->set_default_size("1MiB");
 	m_vram->set_default_value(0);
 #endif
+
+	SOFTWARE_LIST(config, "software_list").set_original("sony_news").set_filter("CISC");
 }
 
 void news_68k_state::nws1580(machine_config &config)

--- a/src/mame/sony/news_r3k.cpp
+++ b/src/mame/sony/news_r3k.cpp
@@ -547,6 +547,8 @@ void news_r3k_base_state::common(machine_config &config)
 	NEWS_HID_HLE(config, m_hid);
 	m_hid->irq_out<news_hid_hle_device::KEYBOARD>().set(FUNC(news_r3k_base_state::irq_w<KBD>));
 	m_hid->irq_out<news_hid_hle_device::MOUSE>().set(FUNC(news_r3k_base_state::irq_w<MOUSE>));
+
+	SOFTWARE_LIST(config, "software_list").set_original("sony_news_risc");
 }
 
 void nws3260_state::nws3260(machine_config &config)

--- a/src/mame/sony/news_r3k.cpp
+++ b/src/mame/sony/news_r3k.cpp
@@ -548,7 +548,7 @@ void news_r3k_base_state::common(machine_config &config)
 	m_hid->irq_out<news_hid_hle_device::KEYBOARD>().set(FUNC(news_r3k_base_state::irq_w<KBD>));
 	m_hid->irq_out<news_hid_hle_device::MOUSE>().set(FUNC(news_r3k_base_state::irq_w<MOUSE>));
 
-	SOFTWARE_LIST(config, "software_list").set_original("sony_news_risc");
+	SOFTWARE_LIST(config, "software_list").set_original("sony_news").set_filter("RISC");
 }
 
 void nws3260_state::nws3260(machine_config &config)

--- a/src/mame/sony/news_r4k.cpp
+++ b/src/mame/sony/news_r4k.cpp
@@ -524,6 +524,8 @@ void news_r4k_state::machine_common(machine_config &config)
 	m_dmac->dma_w_cb<dmac3_device::CTRL0>().set(m_scsi0, FUNC(spifi3_device::dma_w));
 	m_dmac->dma_r_cb<dmac3_device::CTRL1>().set(m_scsi1, FUNC(spifi3_device::dma_r));
 	m_dmac->dma_w_cb<dmac3_device::CTRL1>().set(m_scsi1, FUNC(spifi3_device::dma_w));
+
+	SOFTWARE_LIST(config, "software_list").set_original("sony_news_risc");
 }
 
 void news_r4k_state::nws5000x(machine_config &config) { machine_common(config); }

--- a/src/mame/sony/news_r4k.cpp
+++ b/src/mame/sony/news_r4k.cpp
@@ -525,7 +525,7 @@ void news_r4k_state::machine_common(machine_config &config)
 	m_dmac->dma_r_cb<dmac3_device::CTRL1>().set(m_scsi1, FUNC(spifi3_device::dma_r));
 	m_dmac->dma_w_cb<dmac3_device::CTRL1>().set(m_scsi1, FUNC(spifi3_device::dma_w));
 
-	SOFTWARE_LIST(config, "software_list").set_original("sony_news_risc");
+	SOFTWARE_LIST(config, "software_list").set_original("sony_news").set_filter("RISC");
 }
 
 void news_r4k_state::nws5000x(machine_config &config) { machine_common(config); }


### PR DESCRIPTION
Because both the r3k and r4k have some level of binary compatibility, I added these into the same software list even though the current entries only work for OS installs on one or the other, so I can change this if having separate ones would be preferred.