### PR TITLE
machine/am9513.cpp: fixed wrong log message for cascading TCs

### DIFF
--- a/src/devices/machine/am9513.cpp
+++ b/src/devices/machine/am9513.cpp
@@ -33,6 +33,7 @@
 #define LOG_INPUT (1U << 2)
 #define LOG_TC    (1U << 3)
 //#define VERBOSE (LOG_GENERAL | LOG_MODE)
+#define VERBOSE -1
 
 #include "logmacro.h"
 
@@ -442,7 +443,7 @@ void am9513_device::set_counter_mode(int c, u16 data)
 		else if (source >= 6 && source <= 10)
 			LOGMASKED(LOG_MODE, "Counter %d: Count on %s edge of GATE %d\n", c + 1, BIT(data, 12) ? "falling" : "rising", source - 5);
 		else if (source == 0)
-			LOGMASKED(LOG_MODE, "Counter %d: Count on %s edge of TC%d\n", c + 1, BIT(data, 12) ? "falling" : "rising", c - 1);
+			LOGMASKED(LOG_MODE, "Counter %d: Count on %s edge of TC%d\n", c + 1, BIT(data, 12) ? "falling" : "rising", c );
 		else
 			LOGMASKED(LOG_MODE, "Counter %d: Count on %s edge of SRC %d\n", c + 1, BIT(data, 12) ? "falling" : "rising", source);
 	}

--- a/src/devices/machine/am9513.cpp
+++ b/src/devices/machine/am9513.cpp
@@ -33,7 +33,6 @@
 #define LOG_INPUT (1U << 2)
 #define LOG_TC    (1U << 3)
 //#define VERBOSE (LOG_GENERAL | LOG_MODE)
-#define VERBOSE -1
 
 #include "logmacro.h"
 


### PR DESCRIPTION
Logging wants to show previous channel number but because channels when printed start at 1,  cliche is to always print 'c+1' meaning previous channel number is (c-1)+1  aka c  not c-1.
