### PR TITLE
konami/ksys573: Initialize m_pccard_cd

### DIFF
--- a/src/mame/konami/ksys573.cpp
+++ b/src/mame/konami/ksys573.cpp
@@ -489,6 +489,7 @@ public:
 		m_image(*this, "ata:0:cr589"),
 		m_pccard1(*this, "pccard1"),
 		m_pccard2(*this, "pccard2"),
+		m_pccard_cd{1, 1},
 		m_h8_response(*this, "h8_response"),
 		m_ram(*this, "maincpu:ram"),
 		m_flashbank(*this, "flashbank"),
@@ -2494,7 +2495,7 @@ void ksys573_state::k573a(machine_config &config)
 void ksys573_state::k573ak(machine_config &config)
 {
 	konami573(config, true);
-   m_maincpu->set_addrmap(AS_PROGRAM, &ksys573_state::konami573ak_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &ksys573_state::konami573ak_map);
 }
 
 void ksys573_state::pccard1_16mb(machine_config &config)


### PR DESCRIPTION
`m_pccard_cd` is in an uninitialized state after the recent PC card changes which is causing some Sys573 games to behave incorrectly (most notably ddrjb freezing on boot), so this PR initializes them to 1. Also fixed a small indentation issue I noticed.