### PR TITLE
heathzenith/h89.cpp: Add wait states for mms 77316 fdc

### DIFF
--- a/src/mame/heathzenith/h89.cpp
+++ b/src/mame/heathzenith/h89.cpp
@@ -249,14 +249,14 @@ class h89_mms_state : public h89_base_state
 public:
 	h89_mms_state(const machine_config &mconfig, device_type type, const char *tag):
 		h89_base_state(mconfig, type, tag),
-		m_mms(*this, "mms77316")
+		m_mms316(*this, "mms77316")
 	{
 	}
 
 	void h89_mms(machine_config &config);
 
 protected:
-	required_device<mms77316_fdc_device> m_mms;
+	required_device<mms77316_fdc_device> m_mms316;
 
 	void h89_mms_io(address_map &map);
 };
@@ -468,7 +468,7 @@ void h89_mms_state::h89_mms_io(address_map &map)
 	h89_base_state::h89_base_io(map);
 
 	// Add MMS 77316 Double Density Controller
-	map(0x38,0x3f).rw(m_mms, FUNC(mms77316_fdc_device::read), FUNC(mms77316_fdc_device::write));
+	map(0x38,0x3f).rw(m_mms316, FUNC(mms77316_fdc_device::read), FUNC(mms77316_fdc_device::write));
 }
 
 
@@ -1022,10 +1022,10 @@ void h89_mms_state::h89_mms(machine_config &config)
 	m_intr_socket->set_default_option("mms");
 	m_intr_socket->set_fixed(true);
 
-	MMS77316_FDC(config, m_mms);
-	m_mms->drq_cb().set(m_intr_socket, FUNC(heath_intr_socket::set_drq));
-	m_mms->irq_cb().set(m_intr_socket, FUNC(heath_intr_socket::set_irq));
-	m_mms->wait_cb().set(FUNC(h89_mms_state::set_wait_state));
+	MMS77316_FDC(config, m_mms316);
+	m_mms316->drq_cb().set(m_intr_socket, FUNC(heath_intr_socket::set_drq));
+	m_mms316->irq_cb().set(m_intr_socket, FUNC(heath_intr_socket::set_irq));
+	m_mms316->wait_cb().set(FUNC(h89_mms_state::set_wait_state));
 }
 
 

--- a/src/mame/heathzenith/mms77316_fdc.h
+++ b/src/mame/heathzenith/mms77316_fdc.h
@@ -26,6 +26,7 @@ public:
 
 	auto irq_cb() { return m_irq_cb.bind(); }
 	auto drq_cb() { return m_drq_cb.bind(); }
+	auto wait_cb() { return m_wait_cb.bind(); }
 
 protected:
 
@@ -43,12 +44,13 @@ protected:
 	// Burst mode was required for a 2 MHz Z80 to handle 8" DD data rates.
 	// The typical irq/drq was too slow, this utilizes wait states to read the
 	// WD1797 data port once the drq line is high.
-	inline bool burstMode() { return !m_drq_allowed; }
+	inline bool burst_mode_r() { return !m_drq_allowed; }
 
 private:
 
 	devcb_write_line                           m_irq_cb;
 	devcb_write_line                           m_drq_cb;
+	devcb_write_line                           m_wait_cb;
 
 	required_device<fd1797_device>             m_fdc;
 	required_device_array<floppy_connector, 8> m_floppies;


### PR DESCRIPTION
The 77316 FDC requires wait states to work with 8" DD disks, since the 2 MHz Z80 could not handle the data rate of 8" DD disks. The hardware on the card will hold the CPU in wait states until the DRQ state is raised.

Reading and writing is now working correctly with the latest comit.
