### PR TITLE
atastorage.h: increase ATA cylinders to u32

### DIFF
--- a/src/devices/machine/atastorage.h
+++ b/src/devices/machine/atastorage.h
@@ -61,7 +61,7 @@ protected:
 	virtual void signature() override;
 
 	int m_can_identify_device;
-	uint16_t          m_num_cylinders;
+	uint32_t          m_num_cylinders;
 	uint8_t           m_num_sectors;
 	uint8_t           m_num_heads;
 


### PR DESCRIPTION
LBA cylinders number is not limited to 0xffff.
![image](https://github.com/mamedev/mame/assets/58155/c1c5514a-e2d7-4476-8405-6214f5fdb0c0)
