### PR TITLE
floptool: fix HP 9121 format #4

### DIFF
--- a/src/lib/formats/fs_hplif.cpp
+++ b/src/lib/formats/fs_hplif.cpp
@@ -120,10 +120,10 @@ const char *fs::hplif_image::description() const
 
 void fs::hplif_image::enumerate_f(floppy_enumerator &fe) const
 {
-	fe.add(FLOPPY_HP300_FORMAT, floppy_image::FF_35, floppy_image::DSDD,  630784,  "hp_lif_9121_format_1",   "HP 9212 LIF 3.5\" dual-sided double density Format 1");
+	fe.add(FLOPPY_HP300_FORMAT, floppy_image::FF_35, floppy_image::DSDD,  630784,  "hp_lif_9121_format_1",   "HP 9121 LIF 3.5\" dual-sided double density Format 1");
 	fe.add(FLOPPY_HP300_FORMAT, floppy_image::FF_35, floppy_image::DSDD,  709632,  "hp_lif_9121_format_2",   "HP 9121 LIF 3.5\" dual-sided double density Format 2");
 	fe.add(FLOPPY_HP300_FORMAT, floppy_image::FF_35, floppy_image::DSDD,  788480,  "hp_lif_9121_format_3",   "HP 9121 LIF 3.5\" dual-sided double density Format 3");
-	fe.add(FLOPPY_HP300_FORMAT, floppy_image::FF_35, floppy_image::SSDD,  286720,  "hp_lif_9121_format_4",   "HP 9121 LIF 3.5\" single-sided double density Format 4");
+	fe.add(FLOPPY_HP300_FORMAT, floppy_image::FF_35, floppy_image::SSDD,  270336,  "hp_lif_9121_format_4",   "HP 9121 LIF 3.5\" single-sided double density Format 4");
 	fe.add(FLOPPY_HP300_FORMAT, floppy_image::FF_35, floppy_image::DSDD,  737280,  "hp_lif_9121_format_16",  "HP 9121 LIF 3.5\" dual-sided double density Format 16");
 
 	fe.add(FLOPPY_HP300_FORMAT, floppy_image::FF_35, floppy_image::DSHD, 1261568, "hp_lif_9122_format_014", "HP 9122 LIF 3.5\" dual-sided high density Format 0, 1, 4");

--- a/src/lib/formats/hp300_dsk.cpp
+++ b/src/lib/formats/hp300_dsk.cpp
@@ -30,11 +30,11 @@ const char *hp300_format::extensions() const noexcept
 }
 
 const hp300_format::format hp300_format::formats[] = {
+	{ floppy_image::FF_35,  floppy_image::SSDD, floppy_image::MFM, 2000,  16, 66, 1,  256,  {}, 0, {}, 32,  22,  46 }, // FORMAT 4
 	// HP 9121S, 9121D or 9133A
 	{ floppy_image::FF_35,  floppy_image::DSDD, floppy_image::MFM, 2000,  16, 77, 2,  256,  {}, 1, {}, 50,  22,  54 }, // FORMAT 0,1
 	{ floppy_image::FF_35,  floppy_image::DSDD, floppy_image::MFM, 2000,   9, 77, 2,  512,  {}, 1, {}, 50,  22,  89 }, // FORMAT 2
 	{ floppy_image::FF_35,  floppy_image::DSDD, floppy_image::MFM, 2000,   5, 77, 2, 1024,  {}, 1, {}, 50,  22, 108 }, // FORMAT 3
-	{ floppy_image::FF_35,  floppy_image::DSSD, floppy_image::MFM, 2000,  16, 70, 1,  256,  {}, 1, {}, 32,  22,  46 }, // FORMAT 4
 	{ floppy_image::FF_35,  floppy_image::DSDD, floppy_image::MFM, 2000,   9, 80, 2,  512,  {}, 1, {}, 146, 22,  81 }, // FORMAT 16
 	// HP9122C/D, 9123D, 9133D/H/L or 9153A/B
 	{ floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM, 2000,  32, 77, 2,  256,  {}, 1, {}, 50,  22,  59 }, // FORMAT 0,1,4


### PR DESCRIPTION
With this change, all the SSDD disks from hpmuseum can be read, and the size of the disk matches. While at it, also fix a typo.