### PR TITLE
Casio PV-1000: Border colors are wrong (blue and red are swapped)

### DIFF
--- a/src/mame/casio/pv1000.cpp
+++ b/src/mame/casio/pv1000.cpp
@@ -457,7 +457,7 @@ static const gfx_layout pv1000_3bpp_gfx =
 	8, 8,           /* 8x8 characters */
 	RGN_FRAC(1,1),
 	3,
-	{ 0, 8*8, 16*8 },
+	{ 16*8, 8*8, 0 },
 	{ 0, 1, 2, 3, 4, 5, 6, 7 },
 	{ 0*8, 1*8, 2*8, 3*8, 4*8, 5*8, 6*8, 7*8 },
 	8*8*4
@@ -482,7 +482,7 @@ void pv1000_state::pv1000(machine_config &config)
 	m_screen->set_screen_update(FUNC(pv1000_state::screen_update_pv1000));
 	m_screen->set_palette(m_palette);
 
-	PALETTE(config, m_palette, palette_device::BGR_3BIT);
+	PALETTE(config, m_palette, palette_device::RGB_3BIT);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_pv1000);
 


### PR DESCRIPTION
Research I did a year ago established that Casio's PV-1000 border colors red and blue bits are reversed. 
See https://forums.nesdev.org/viewtopic.php?p=288421#p288421

People on the discord agreed that swapping the palette definition and tiles interpretation structure was cleaner than explicitly bit-reversing the value received during the I/O port writes