### PR TITLE
heathzenith/h89.cpp: Fix shadow memory writes

### DIFF
--- a/src/mame/heathzenith/h89.cpp
+++ b/src/mame/heathzenith/h89.cpp
@@ -725,8 +725,16 @@ void h89_base_state::machine_start()
 		m_maincpu->space(AS_PROGRAM).install_ram(0x2000, 0xffff, m_ram_ptr);
 
 		// install shadow writing to RAM when in ROM mode
-		m_mem_view[0].install_writeonly(0x0000, 0x1fff, m_ram_ptr + 0xe000);
-		m_mem_view[1].install_writeonly(0x0000, 0x1fff, m_ram_ptr + 0xe000);
+		m_mem_view[0].install_write_tap(0x0000, 0x1fff, "shadow_w", [this](offs_t offset, u8 &data, u8 mem_mask)
+		{
+			u8 *to = m_ram->pointer() + 0xe000;
+			to[offset] = data;
+		});
+		m_mem_view[1].install_write_tap(0x0000, 0x1fff, "shadow_w", [this](offs_t offset, u8 &data, u8 mem_mask)
+		{
+			u8 *to = m_ram->pointer() + 0xe000;
+			to[offset] = data;
+		});
 
 		// Only the CP/M - Org 0 view will have RAM at the lower 8k
 		m_mem_view[2].install_ram(0x0000, 0x1fff, m_ram_ptr + 0xe000);

--- a/src/mame/heathzenith/h89.cpp
+++ b/src/mame/heathzenith/h89.cpp
@@ -716,28 +716,26 @@ void h89_base_state::machine_start()
 	m_maincpu->space(AS_PROGRAM).specific(m_program);
 
 	// update RAM mappings based on RAM size
-	u8 *m_ram_ptr = m_ram->pointer();
-	u32 ram_size  = m_ram->size();
+	u8 *ram_ptr  = m_ram->pointer();
+	u32 ram_size = m_ram->size();
 
 	if (ram_size == 0x10000)
 	{
 		// system has a full 64k
-		m_maincpu->space(AS_PROGRAM).install_ram(0x2000, 0xffff, m_ram_ptr);
+		m_maincpu->space(AS_PROGRAM).install_ram(0x2000, 0xffff, ram_ptr);
 
-		// install shadow writing to RAM when in ROM mode
-		m_mem_view[0].install_write_tap(0x0000, 0x1fff, "shadow_w", [this](offs_t offset, u8 &data, u8 mem_mask)
+		// install shadow writing to RAM when in ROM mode and Floppy RAM is write-protected.
+		m_mem_view[0].install_writeonly(0x0000, 0x1fff, ram_ptr + 0xe000);
+		// when Floppy RAM is in write enable mode, must use write_tap so writes occur to both RAMs
+		// NOTE: the H89 had space reserved for additional RAM (without write protection) in the ROM space, but not aware
+		// it was ever used. If that was added to this emulation, m_mem_view[0] would also need to be a write_tap.
+		m_mem_view[1].install_write_tap(0x0000, 0x1fff, "shadow_w", [ram_ptr](offs_t offset, u8 &data, u8 mem_mask)
 		{
-			u8 *to = m_ram->pointer() + 0xe000;
-			to[offset] = data;
-		});
-		m_mem_view[1].install_write_tap(0x0000, 0x1fff, "shadow_w", [this](offs_t offset, u8 &data, u8 mem_mask)
-		{
-			u8 *to = m_ram->pointer() + 0xe000;
-			to[offset] = data;
+			ram_ptr[0xe000 + offset] = data;
 		});
 
-		// Only the CP/M - Org 0 view will have RAM at the lower 8k
-		m_mem_view[2].install_ram(0x0000, 0x1fff, m_ram_ptr + 0xe000);
+		// The Org-0 (often used for CP/M) view has RAM at the lower 8k
+		m_mem_view[2].install_ram(0x0000, 0x1fff, ram_ptr + 0xe000);
 	}
 	else
 	{
@@ -747,14 +745,14 @@ void h89_base_state::machine_start()
 		// the memory size, since the base starts at 8k.
 		u32 ram_top = ram_size + 0x1fff;
 
-		m_mem_view[0].install_ram(0x2000, ram_top, m_ram_ptr);
-		m_mem_view[1].install_ram(0x2000, ram_top, m_ram_ptr);
+		m_mem_view[0].install_ram(0x2000, ram_top, ram_ptr);
+		m_mem_view[1].install_ram(0x2000, ram_top, ram_ptr);
 
-		// when ROM is not active, memory still starts at 8k, but is 8k smaller
-		m_mem_view[2].install_ram(0x2000, ram_size - 1, m_ram_ptr);
+		// when ROM is not active, memory still starts at 8k, but is 8k smaller so the last 8k can be mapped to addr 0.
+		m_mem_view[2].install_ram(0x2000, ram_size - 1, ram_ptr);
 
 		// remap the top 8k down to addr 0
-		m_mem_view[2].install_ram(0x0000, 0x1fff, m_ram_ptr + ram_size - 0x2000);
+		m_mem_view[2].install_ram(0x0000, 0x1fff, ram_ptr + ram_size - 0x2000);
 	}
 }
 


### PR DESCRIPTION
Fixes shadow writes when in ROM mode. 

- This now properly writes to the floppy RAM which fixes a boot issue with HDOS 2.0.