### PR TITLE
machine/ncr5385.cpp: raise IRQ for INT_INVALID_CMD

### DIFF
--- a/src/devices/machine/ncr5385.cpp
+++ b/src/devices/machine/ncr5385.cpp
@@ -23,7 +23,7 @@
 #define LOG_DMA      (1U << 4)
 #define LOG_COMMAND  (1U << 5)
 
-//#define VERBOSE (LOG_GENERAL|LOG_REGW|LOG_REGR|LOG_STATE|LOG_DMA|LOG_COMMAND)
+#define VERBOSE (LOG_GENERAL|LOG_REGW|LOG_REGR|LOG_STATE|LOG_DMA|LOG_COMMAND)
 #include "logmacro.h"
 
 DEFINE_DEVICE_TYPE(NCR5385, ncr5385_device, "ncr5385", "NCR 5385 SCSI Protocol Controller")
@@ -421,6 +421,8 @@ void ncr5385_device::cmd_w(u8 data)
 		case 0x18: case 0x19: case 0x1a: case 0x1b:
 		case 0x1c: case 0x1d: case 0x1e: case 0x1f:
 			// reserved
+			m_int_status |= INT_INVALID_CMD;
+			update_int();
 			break;
 		}
 	}

--- a/src/devices/machine/ncr5385.cpp
+++ b/src/devices/machine/ncr5385.cpp
@@ -421,6 +421,7 @@ void ncr5385_device::cmd_w(u8 data)
 		case 0x18: case 0x19: case 0x1a: case 0x1b:
 		case 0x1c: case 0x1d: case 0x1e: case 0x1f:
 			// reserved
+			LOGMASKED(LOG_COMMAND, "reserved / invalid cmd\n");
 			m_int_status |= INT_INVALID_CMD;
 			update_int();
 			break;
@@ -816,7 +817,9 @@ void ncr5385_device::set_dreq(bool dreq)
 
 void ncr5385_device::update_int()
 {
-	bool const int_state = m_int_status & 0x5f;
+	bool const int_state = m_int_status & (INT_FUNC_COMPLETE | INT_BUS_SERVICE |
+																				INT_DISCONNECTED | INT_SELECTED |
+																				INT_RESELECTED |INT_INVALID_CMD);
 
 	if (m_int_state != int_state)
 	{

--- a/src/devices/machine/ncr5385.cpp
+++ b/src/devices/machine/ncr5385.cpp
@@ -23,7 +23,7 @@
 #define LOG_DMA      (1U << 4)
 #define LOG_COMMAND  (1U << 5)
 
-#define VERBOSE (LOG_GENERAL|LOG_REGW|LOG_REGR|LOG_STATE|LOG_DMA|LOG_COMMAND)
+//#define VERBOSE (LOG_GENERAL|LOG_REGW|LOG_REGR|LOG_STATE|LOG_DMA|LOG_COMMAND)
 #include "logmacro.h"
 
 DEFINE_DEVICE_TYPE(NCR5385, ncr5385_device, "ncr5385", "NCR 5385 SCSI Protocol Controller")
@@ -818,8 +818,7 @@ void ncr5385_device::set_dreq(bool dreq)
 void ncr5385_device::update_int()
 {
 	bool const int_state = m_int_status & (INT_FUNC_COMPLETE | INT_BUS_SERVICE |
-																				INT_DISCONNECTED | INT_SELECTED |
-																				INT_RESELECTED |INT_INVALID_CMD);
+			INT_DISCONNECTED | INT_SELECTED | INT_RESELECTED | INT_INVALID_CMD);
 
 	if (m_int_state != int_state)
 	{


### PR DESCRIPTION
- Tek4404 issues cmd=0xff which expects an IRQ even though its an INT_INVALID_CMD
- minor readability; replaced magic hex value with symbolic names