### PR TITLE
Fixes/ROMs for Roland stuff

### DIFF
--- a/scripts/src/sound.lua
+++ b/scripts/src/sound.lua
@@ -1610,14 +1610,26 @@ if (SOUNDS["XT446"]~=null) then
 end
 
 ---------------------------------------------------
--- Roland sample players
---@src/devices/sound/rolandpcm.h,SOUNDS["ROLANDPCM"] = true
+-- Roland LP-based sample players
+--@src/devices/sound/roland_lp.h,SOUNDS["ROLANDLP"] = true
 ---------------------------------------------------
 
-if (SOUNDS["ROLANDPCM"]~=null) then
+if (SOUNDS["ROLANDLP"]~=null) then
 	files {
-		MAME_DIR .. "src/devices/sound/rolandpcm.cpp",
-		MAME_DIR .. "src/devices/sound/rolandpcm.h",
+		MAME_DIR .. "src/devices/sound/roland_lp.cpp",
+		MAME_DIR .. "src/devices/sound/roland_lp.h",
+	}
+end
+
+---------------------------------------------------
+-- Roland GP-based sample players
+--@src/devices/sound/roland_gp.h,SOUNDS["ROLANDGP"] = true
+---------------------------------------------------
+
+if (SOUNDS["ROLANDGP"]~=null) then
+	files {
+		MAME_DIR .. "src/devices/sound/roland_gp.cpp",
+		MAME_DIR .. "src/devices/sound/roland_gp.h",
 	}
 end
 

--- a/src/devices/sound/roland_gp.cpp
+++ b/src/devices/sound/roland_gp.cpp
@@ -1,0 +1,78 @@
+// license:BSD-3-Clause
+// copyright-holders:giulioz
+
+// Initial skeleton based on the RE work by nukeykt
+
+#include "emu.h"
+#include "roland_gp.h"
+
+// Original chip (GP-2) TODO
+// DEFINE_DEVICE_TYPE(TC24SC201AF, tc6116_device, "tc24sc201af", "Roland GP TC24SC201AF PCM")
+
+// Newer chip (GP-4) including bugfixes and H8/500 cpu glue logic
+DEFINE_DEVICE_TYPE(TC6116, tc6116_device, "tc6116", "Roland GP TC6116 PCM")
+
+
+tc6116_device::tc6116_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, TC6116, tag, owner, clock)
+	, device_sound_interface(mconfig, *this)
+	, device_rom_interface(mconfig, *this)
+	, m_int_callback(*this)
+	, m_clock(0)
+	, m_rate(0)
+	, m_stream(nullptr)
+	, m_sel_chn(0)
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void tc6116_device::device_start()
+{
+	m_clock = clock() / 2;
+	m_rate = m_clock / 512; // usually 32 KHz
+
+	m_stream = stream_alloc(0, 2, m_rate);
+
+	logerror("Roland GP: Clock %u, Rate %u\n", m_clock, m_rate);
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void tc6116_device::device_reset()
+{
+	m_int_callback(CLEAR_LINE);
+}
+
+//-------------------------------------------------
+//  rom_bank_pre_change - refresh the stream if the
+//  ROM banking changes
+//-------------------------------------------------
+
+void tc6116_device::rom_bank_pre_change()
+{
+	// unused right now
+	m_stream->update();
+}
+
+
+u8 tc6116_device::read(offs_t offset)
+{
+	return 0xff;
+}
+
+void tc6116_device::write(offs_t offset, u8 data)
+{
+}
+
+//-------------------------------------------------
+//  sound_stream_update - handle a stream update
+//-------------------------------------------------
+
+void tc6116_device::sound_stream_update(sound_stream &stream, std::vector<read_stream_view> const &inputs, std::vector<write_stream_view> &outputs)
+{
+}

--- a/src/devices/sound/roland_gp.h
+++ b/src/devices/sound/roland_gp.h
@@ -1,0 +1,84 @@
+// license:BSD-3-Clause
+// copyright-holders:giulioz
+#ifndef MAME_SOUND_ROLANDGP_H
+#define MAME_SOUND_ROLANDGP_H
+
+#pragma once
+
+#include "dirom.h"
+
+class tc6116_device : public device_t, public device_sound_interface, public device_rom_interface<23>
+{
+public:
+	tc6116_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	auto int_callback() { return m_int_callback.bind(); }
+
+	u8 read(offs_t offset);
+	void write(offs_t offset, u8 data);
+
+protected:
+	// device_t implementation
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// device_sound_interface implementation
+	virtual void sound_stream_update(sound_stream &stream, std::vector<read_stream_view> const &inputs, std::vector<write_stream_view> &outputs) override;
+
+	// device_rom_interface implementation
+	virtual void rom_bank_pre_change() override;
+
+private:
+	static constexpr unsigned NUM_CHANNELS = 28;
+
+	struct pcm_channel
+	{
+		pcm_channel() { }
+
+		// registers
+		uint8_t pitch_coarse;
+		uint8_t pitch_fine;
+		uint8_t pan_l;
+		uint8_t pan_r;
+		uint8_t rev_send;
+		uint8_t chorus_send;
+		uint8_t volume1;
+		uint8_t volume1_speed;
+		uint8_t volume2;
+		uint8_t volume2_speed;
+		uint8_t cutoff;
+		uint8_t cutoff_speed;
+
+    bool irq_enable; // 0
+    bool filter_mode; // 1 (0:lpf, 1:hpf)
+    uint8_t resonance_flags; // 8-15
+
+    uint8_t sub_phase_addr; // 0-4
+		bool key; // 5
+		bool alt_loop; // 6
+		bool reverse_play; // 7
+    uint8_t hiaddr; // 8-11
+    uint8_t nibble; // 2-15
+    
+		// work variables
+    uint16_t sub_phase_state; // 0-13
+		bool irq_disable; // 14
+		bool alt_loop_state; // 15
+
+    uint16_t volume1_tv;
+    uint16_t volume2_tv;
+    uint16_t cutoff_tv;
+	};
+
+	devcb_write_line m_int_callback;
+
+	uint32_t m_clock;                   // clock
+	uint32_t m_rate;                    // sample rate (usually 32000 Hz)
+	sound_stream* m_stream;             // stream handle
+	pcm_channel m_chns[NUM_CHANNELS];   // channel memory
+	[[maybe_unused]] uint8_t m_sel_chn;                  // selected channel
+};
+
+DECLARE_DEVICE_TYPE(TC6116, tc6116_device)
+
+#endif // MAME_SOUND_ROLANDGP_H

--- a/src/devices/sound/roland_lp.cpp
+++ b/src/devices/sound/roland_lp.cpp
@@ -21,10 +21,10 @@
 //  02/03 - ?? (read after writing to 10/12)
 
 #include "emu.h"
-#include "rolandpcm.h"
+#include "roland_lp.h"
 
 
-DEFINE_DEVICE_TYPE(MB87419_MB87420, mb87419_mb87420_device, "mb87419_mb87420", "Roland MB87419/MB87420 PCM")
+DEFINE_DEVICE_TYPE(MB87419_MB87420, mb87419_mb87420_device, "mb87419_mb87420", "Roland LP MB87419/MB87420 PCM")
 
 mb87419_mb87420_device::mb87419_mb87420_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, MB87419_MB87420, tag, owner, clock)

--- a/src/devices/sound/roland_lp.h
+++ b/src/devices/sound/roland_lp.h
@@ -1,7 +1,7 @@
 // license:BSD-3-Clause
 // copyright-holders:Valley Bell
-#ifndef MAME_SOUND_ROLANDPCM_H
-#define MAME_SOUND_ROLANDPCM_H
+#ifndef MAME_SOUND_ROLANDLP_H
+#define MAME_SOUND_ROLANDLP_H
 
 #pragma once
 
@@ -66,4 +66,4 @@ private:
 
 DECLARE_DEVICE_TYPE(MB87419_MB87420, mb87419_mb87420_device)
 
-#endif // MAME_SOUND_ROLANDPCM_H
+#endif // MAME_SOUND_ROLANDLP_H

--- a/src/devices/video/t6963c.cpp
+++ b/src/devices/video/t6963c.cpp
@@ -5,6 +5,12 @@
     Toshiba T6963C Dot Matrix LCD Controller
     Sharp LM24014H Dot Matrix LCD Unit
 
+		TODO:
+		- cursor
+		- screen peek
+		- screen copy
+		- auto read mode
+
 **********************************************************************/
 
 #include "emu.h"
@@ -51,6 +57,7 @@ t6963c_device::t6963c_device(const machine_config &mconfig, const char *tag, dev
 	, m_font_size(6)
 	, m_number_cols(40)
 	, m_number_lines(8)
+	, m_read_data(0)
 {
 }
 
@@ -89,6 +96,7 @@ void t6963c_device::device_start()
 	save_item(NAME(m_font_size));
 	save_item(NAME(m_number_cols));
 	save_item(NAME(m_number_lines));
+	save_item(NAME(m_read_data));
 }
 
 
@@ -117,7 +125,7 @@ void t6963c_device::device_reset()
 
 u8 t6963c_device::read(offs_t offset)
 {
-	return BIT(offset, 0) ? 0x2b : 0x00;
+	return BIT(offset, 0) ? 0x2b : m_read_data;
 }
 
 
@@ -219,7 +227,7 @@ void t6963c_device::do_command(u8 cmd)
 		if (cmd == 0x90)
 			LOG("%s: Display off\n", machine().describe_context());
 		else
-			LOG("%s: Text %s, graphic %s, cursor %s, blink %s\n",
+			LOG("%s: Graphic %s, text %s, cursor %s, blink %s\n",
 				machine().describe_context(),
 				BIT(cmd, 3) ? "on" : "off",
 				BIT(cmd, 2) ? "on" : "off",
@@ -230,6 +238,7 @@ void t6963c_device::do_command(u8 cmd)
 	else if ((cmd & 0xf8) == 0xa0)
 	{
 		logerror("%s: Select %d-line cursor\n", machine().describe_context(), (cmd & 0x07) + 1);
+		printf("Select %d-line cursor\n", (cmd & 0x07) + 1);
 	}
 	else if ((cmd & 0xfe) == 0xb0)
 	{
@@ -251,6 +260,7 @@ void t6963c_device::do_command(u8 cmd)
 					: (cmd & 0x0e) == 0x02 ? "decrement"
 					: (cmd & 0x0e) == 0x04 ? "nonvariable"
 					: "invalid");
+			m_read_data = m_display_ram->read_byte(m_adp);
 		}
 		else
 		{
@@ -327,7 +337,7 @@ uint32_t t6963c_device::screen_update(screen_device &screen, bitmap_ind16 &bitma
 	bitmap.fill(0, cliprect);
 
 	// Text layer
-	if (BIT(m_display_mode, 3))
+	if (BIT(m_display_mode, 2))
 	{
 		offs = m_text_home;
 		for(int y=0; y<m_number_lines; y++)
@@ -354,7 +364,7 @@ uint32_t t6963c_device::screen_update(screen_device &screen, bitmap_ind16 &bitma
 			}
 	}
 	// Graphic layer
-	if (BIT(m_display_mode, 2))
+	if (BIT(m_display_mode, 3))
 	{
 		offs = m_graphic_home;
 		for(int y=0; y<m_number_lines*8; y++)

--- a/src/devices/video/t6963c.cpp
+++ b/src/devices/video/t6963c.cpp
@@ -238,7 +238,6 @@ void t6963c_device::do_command(u8 cmd)
 	else if ((cmd & 0xf8) == 0xa0)
 	{
 		logerror("%s: Select %d-line cursor\n", machine().describe_context(), (cmd & 0x07) + 1);
-		printf("Select %d-line cursor\n", (cmd & 0x07) + 1);
 	}
 	else if ((cmd & 0xfe) == 0xb0)
 	{

--- a/src/devices/video/t6963c.h
+++ b/src/devices/video/t6963c.h
@@ -78,6 +78,7 @@ private:
 	u8 m_font_size;
 	u8 m_number_cols;
 	u8 m_number_lines;
+	u8 m_read_data;
 };
 
 // ======================> lm24014h_device

--- a/src/mame/roland/roland_cm32p.cpp
+++ b/src/mame/roland/roland_cm32p.cpp
@@ -256,7 +256,7 @@ Some routine locations
 #include "cpu/mcs96/i8x9x.h"
 #include "machine/ram.h"
 #include "machine/timer.h"
-#include "sound/rolandpcm.h"
+#include "sound/roland_lp.h"
 #include "video/msm6222b.h"
 #include "bus/generic/slot.h"
 #include "bus/generic/carts.h"

--- a/src/mame/roland/roland_d50.cpp
+++ b/src/mame/roland/roland_d50.cpp
@@ -122,7 +122,7 @@ ROM_START(d50) // Newer PCB with silkscreen "Roland || D-50, D-550 || MAIN BOARD
 	// missing 2.00
 
 	ROM_REGION(0x2000, "maincpu", 0)
-	ROM_LOAD("d78312g-022_15179266.ic25", 0x0000, 0x2000, NO_DUMP) // 8-digit Roland part number not printed on IC
+	ROM_LOAD("d78312g-022_15179266.ic25", 0x0000, 0x2000, CRC(9564903f) SHA1(f68ed97a06764ee000fe6e9d7b39017165f0efc4)) // 8-digit Roland part number not printed on IC
 	ROM_COPY("progrom", 0x0000, 0x0000, 0x2000)
 
 	ROM_REGION(0x80000, "pcm", 0)

--- a/src/mame/roland/roland_d70.cpp
+++ b/src/mame/roland/roland_d70.cpp
@@ -352,12 +352,12 @@ void roland_d70_state::dsp_io_w(offs_t offset, u8 data) {
 }
 
 u8 roland_d70_state::tvf_io_r(offs_t offset) {
-	logerror("tvf read %x\n", offset);
+	logerror("tvf read %04x\n", offset);
 	return 0;
 }
 
 void roland_d70_state::tvf_io_w(offs_t offset, u8 data) {
-	logerror("twf write $x= %x\n", offset, data);
+	logerror("tvf write %04x= %02x\n", offset, data);
 }
 
 u8 roland_d70_state::snd_io_r(offs_t offset) {
@@ -494,11 +494,11 @@ void roland_d70_state::init_d70() {
 	u8 *dst = reinterpret_cast<u8 *>(memregion("pcm")->base());
 	// descramble internal ROMs
 	descramble_rom_internal(&dst[0x000000], &src[0x000000]);
+	descramble_rom_internal(&dst[0x080000], &src[0x080000]);
 	descramble_rom_internal(&dst[0x100000], &src[0x100000]);
+	descramble_rom_internal(&dst[0x180000], &src[0x180000]);
 	descramble_rom_internal(&dst[0x200000], &src[0x200000]);
 	descramble_rom_internal(&dst[0x300000], &src[0x300000]);
-	descramble_rom_internal(&dst[0x400000], &src[0x400000]);
-	descramble_rom_internal(&dst[0x500000], &src[0x500000]);
 }
 
 void roland_d70_state::descramble_rom_internal(u8 *dst, const u8 *src) {
@@ -515,11 +515,11 @@ ROM_START(d70)
 
 	ROM_REGION(0x600000, "pcmorg", 0) // ROMs before descrambling
 	ROM_LOAD("roland_d70_waverom-a.bin", 0x000000, 0x80000, CRC(8e53b2a3) SHA1(4872530870d5079776e80e477febe425dc0ec1df))
+	ROM_LOAD("roland_d70_waverom-e.bin", 0x080000, 0x80000, CRC(d46cc7a4) SHA1(d378ac89a5963e37f7c157b3c8e71892c334fd7b))
 	ROM_LOAD("roland_d70_waverom-b.bin", 0x100000, 0x80000, CRC(c8220761) SHA1(49e55fa672020f95fd9c858ceaae94d6db93df7d))
+	ROM_LOAD("roland_d70_waverom-f.bin", 0x180000, 0x80000, CRC(d4b01f5e) SHA1(acd867d68e49e5f59f1006ed14a7ca197b6dc4af))
 	ROM_LOAD("roland_d70_waverom-c.bin", 0x200000, 0x80000, CRC(733c4054) SHA1(9b6b59ab74e5bf838702abb087c408aaa85b7b1f))
 	ROM_LOAD("roland_d70_waverom-d.bin", 0x300000, 0x80000, CRC(b6c662d2) SHA1(3fcbcfd0d8d0fa419c710304c12482e2f79a907f))
-	ROM_LOAD("roland_d70_waverom-e.bin", 0x400000, 0x80000, CRC(d46cc7a4) SHA1(d378ac89a5963e37f7c157b3c8e71892c334fd7b))
-	ROM_LOAD("roland_d70_waverom-f.bin", 0x500000, 0x80000, CRC(d4b01f5e) SHA1(acd867d68e49e5f59f1006ed14a7ca197b6dc4af))
 	ROM_REGION(0x600000, "pcm", ROMREGION_ERASEFF) // ROMs after descrambling
 
 	ROM_REGION(0x400, "lcd:cgrom", 0)

--- a/src/mame/roland/roland_d70.cpp
+++ b/src/mame/roland/roland_d70.cpp
@@ -16,7 +16,7 @@
 #include "cpu/mcs96/i8x9x.h"
 #include "cpu/mcs96/i8xc196.h"
 #include "machine/timer.h"
-#include "sound/rolandpcm.h"
+#include "sound/roland_lp.h"
 #include "video/t6963c.h"
 
 #include "emupal.h"

--- a/src/mame/roland/roland_jv80.cpp
+++ b/src/mame/roland/roland_jv80.cpp
@@ -37,7 +37,7 @@ private:
 
 void roland_jv80_state::jv880_mem_map(address_map &map)
 {
-	map(0x00000, 0x08000).rom().region("maincpu", 0);
+	map(0x00000, 0x07fff).rom().region("maincpu", 0);
 	map(0x08000, 0x0dfff).ram().mirror(0xa0000);
 	map(0x0f000, 0x0f3ff).rw(m_pcm, FUNC(tc6116_device::read), FUNC(tc6116_device::write));
 	map(0x10000, 0x3ffff).rom().region("progrom", 0x10000);

--- a/src/mame/roland/roland_jv80.cpp
+++ b/src/mame/roland/roland_jv80.cpp
@@ -2,13 +2,15 @@
 // copyright-holders:AJR
 /****************************************************************************
 
-    Skeleton driver for Roland JV-80 & JV-880 synthesizers.
+    Skeleton driver for Roland JV-80, JV-880 and related synthesizers.
 
 ****************************************************************************/
 
 #include "emu.h"
+#include "cpu/h8500/h8510.h"
 #include "cpu/h8500/h8532.h"
 #include "machine/nvram.h"
+#include "sound/roland_gp.h"
 
 
 namespace {
@@ -19,25 +21,30 @@ public:
 	roland_jv80_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
+		, m_pcm(*this, "pcm")
 	{
 	}
 
 	void jv880(machine_config &config);
 
 private:
-	void mem_map(address_map &map);
+	void jv880_mem_map(address_map &map);
 
 	required_device<h8532_device> m_maincpu;
+	required_device<tc6116_device> m_pcm;
 };
 
 
-void roland_jv80_state::mem_map(address_map &map)
+void roland_jv80_state::jv880_mem_map(address_map &map)
 {
-	map(0x08000, 0x09fff).ram();
+	map(0x00000, 0x08000).rom().region("maincpu", 0);
+	map(0x08000, 0x0dfff).ram().mirror(0xa0000);
+	map(0x0f000, 0x0f3ff).rw(m_pcm, FUNC(tc6116_device::read), FUNC(tc6116_device::write));
 	map(0x10000, 0x3ffff).rom().region("progrom", 0x10000);
 	map(0x40000, 0x4ffff).rom().region("progrom", 0);
-	map(0xa0000, 0xa7fff).ram();
-	map(0xe0000, 0xe7fff).ram().share("nvram");
+	map(0xa0000, 0xbffff).ram();
+	map(0xc0000, 0xd7fff).ram().share("nvram");
+	// map(0xe0000, 0xf7fff).ram().share("cardram");
 }
 
 static INPUT_PORTS_START(jv880)
@@ -46,11 +53,61 @@ INPUT_PORTS_END
 void roland_jv80_state::jv880(machine_config &config)
 {
 	HD6435328(config, m_maincpu, 20_MHz_XTAL);
-	m_maincpu->set_addrmap(AS_PROGRAM, &roland_jv80_state::mem_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &roland_jv80_state::jv880_mem_map);
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0); // LC36256AML-10 (IC18) + CR2032 battery
 
-	//TC6116(config, "pcm", 23.2_MHz_XTAL);
+	TC6116(config, "pcm", 23.2_MHz_XTAL);
+}
+
+class roland_rd500_state : public driver_device
+{
+public:
+	roland_rd500_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_pcm(*this, "pcm")
+	{
+	}
+
+	void rd500(machine_config &config);
+
+private:
+	void rd500_mem_map(address_map &map);
+
+	u8 keyscan_r(offs_t offset);
+	void keyscan_w(offs_t offset, u8 data);
+
+	required_device<h8510_device> m_maincpu;
+	required_device<tc6116_device> m_pcm;
+};
+
+void roland_rd500_state::rd500_mem_map(address_map &map)
+{
+	map(0x000000, 0x8fffff).rom().region("progrom", 0);
+	map(0x900000, 0x90ffff).ram();
+	map(0xa00000, 0xa0ffff).rw(m_pcm, FUNC(tc6116_device::read), FUNC(tc6116_device::write));
+	map(0xc00000, 0xc0ffff).rw(FUNC(roland_rd500_state::keyscan_r), FUNC(roland_rd500_state::keyscan_w));
+}
+
+u8 roland_rd500_state::keyscan_r(offs_t offset)
+{
+	return 0;
+}
+
+void roland_rd500_state::keyscan_w(offs_t offset, u8 data)
+{
+}
+
+static INPUT_PORTS_START(rd500)
+INPUT_PORTS_END
+
+void roland_rd500_state::rd500(machine_config &config)
+{
+	HD6415108(config, m_maincpu, 20_MHz_XTAL);
+	m_maincpu->set_addrmap(AS_PROGRAM, &roland_rd500_state::rd500_mem_map);
+
+	TC6116(config, "pcm", 23.2_MHz_XTAL);
 }
 
 ROM_START(jv880)
@@ -70,8 +127,20 @@ ROM_START(jv880)
 	ROM_LOAD("roland-b_r15209313_lh5375n3.ic25", 0x200000, 0x200000, CRC(d55fcf90) SHA1(963ce75b6668dab377d3a2fd895630a745491be5))
 ROM_END
 
+ROM_START(rd500)
+	ROM_REGION(0x80000, "progrom", 0)
+	ROM_LOAD("rd500_rom.bin", 0x00000, 0x80000, CRC(668fc7e9) SHA1(59e28d3e2190902dd6fd02a9820f96e383781178))
+
+	ROM_REGION(0x400000, "waverom", 0)
+	ROM_LOAD("roland-a_r00342978.ic4", 0x000000, 0x200000, CRC(c885bf4f) SHA1(e14f0f4a8181e09fae7db10130e4ed3cd6bf5a34))
+	ROM_LOAD("roland-b_r00343012.ic5", 0x200000, 0x200000, CRC(ceb02d33) SHA1(9f6969d94598c68902188085d0c91fb8b300d762))
+	ROM_LOAD("roland-c_r00343023.ic6", 0x400000, 0x200000, CRC(f627cdb7) SHA1(7b834fee5db5a7377ec7f66172d0fa3096cefbc9))
+	ROM_LOAD("roland-d_r00343034.ic7", 0x600000, 0x200000, CRC(c06be973) SHA1(2e7ce8a91a6f92648f73d7ff8c1d608f62df9aab))
+ROM_END
+
 } // anonymous namespace
 
 
 //SYST(1992, jv80, 0, 0, jv80, jv80, roland_jv80_state, empty_init, "Roland", "JV-80 Multi Timbral Synthesizer", MACHINE_IS_SKELETON)
 SYST(1992, jv880, 0, 0, jv880, jv880, roland_jv80_state, empty_init, "Roland", "JV-880 Multi Timbral Synthesizer Module", MACHINE_IS_SKELETON)
+SYST(1994, rd500, 0, 0, rd500, rd500, roland_rd500_state, empty_init, "Roland", "RD-500 Digital Piano", MACHINE_IS_SKELETON)

--- a/src/mame/roland/roland_r8.cpp
+++ b/src/mame/roland/roland_r8.cpp
@@ -79,7 +79,7 @@ R8 mkII doesn't seem to store the tone list in the program ROM.
 #include "bus/generic/slot.h"
 #include "cpu/upd78k/upd78k2.h"
 #include "machine/nvram.h"
-#include "sound/rolandpcm.h"
+#include "sound/roland_lp.h"
 
 #include "softlist_dev.h"
 #include "speaker.h"

--- a/src/mame/roland/roland_u20.cpp
+++ b/src/mame/roland/roland_u20.cpp
@@ -8,7 +8,7 @@
 
 #include "emu.h"
 #include "cpu/mcs96/i8x9x.h"
-#include "sound/rolandpcm.h"
+#include "sound/roland_lp.h"
 #include "speaker.h"
 
 


### PR DESCRIPTION
- Renames `rolandpcm` into `roland_lp` to make it distinct from other PCM chips
- Adds a skeleton for the GP (TC6116) chip
- Fixes the T6963C LCD controller by adding ram read support and correct text/graphics enable register handling. This makes the Roland D-70 behave correctly with message popups
   <img width="997" alt="image" src="https://github.com/mamedev/mame/assets/1353142/f510de21-3808-4d2e-b880-f83ce2b0dbb4">

- Fixes the allocation of waveroms in the Roland D-70
- Adds the first ever dump of the internal mask ROM of the Roland D-50 CPU
- Fixes the memory map of the JV80 and wires up the PCM chip skeleton
- Adds a skeleton and ROM dumps for the RD-500