### PR TITLE
apple2_flop_orig, apple2_cass: Added latest dumps and improved metadata.

### DIFF
--- a/hash/apple2_cass.xml
+++ b/hash/apple2_cass.xml
@@ -2983,4 +2983,21 @@ To load and run a tape:
 		</part>
 	</software>
 
+	<software name="wheeldeal" supported="no">
+		<description>Wheeler Dealers</description>
+		<year>1978</year>
+		<publisher>Speakeasy Software</publisher>
+		<info name="programmer" value="Danielle Bunten Berry" />
+		<info name="usage" value="Requires a 16K Apple ][ or later. Shipped with special hardware controllers, but joystick or paddeles can be used by defining directional movement (not button press) to each player." />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-05-09-->
+		<!--simulation game-->
+		<part name="cass" interface="apple2_cass">
+			<feature name="part_id" value="Wheeler Dealers" />
+			<dataarea name="cass" size="6462138">
+				<rom name="wheeler dealers (1978) (speakeasy software, ltd.).wav" size="6462138" crc="83abeab4" sha1="5af05f91a712d5e2ccaa03606d269574405fecfa" />
+			</dataarea>
+		</part>
+	</software>
+
 </softwarelist>

--- a/hash/apple2_flop_clcracked.xml
+++ b/hash/apple2_flop_clcracked.xml
@@ -2795,80 +2795,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="animate">
-		<description>Animate (cleanly cracked)</description>
-		<year>1986</year>
-		<publisher>Broderbund Software</publisher>
-		<info name="release" value="2017-06-28"/>
-		<!-- "Animate" is a 1986 graphics program created by Steven Ohmert and distributed by Broderbund Software. -->
-		<!-- Disks re-cracked on August 28th, 2021 due to subtle
-		timing difference between Disk II and IWM hardware that resulted
-		in the previous version not working on some machines. -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="143360">
-				<rom name="animate (4am crack) disk 1.dsk" size="143360" crc="4b89c917" sha1="46a77dfe78c3516362666699542433293aa03260" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="143360">
-				<rom name="animate (4am crack) disk 2.dsk" size="143360" crc="c16d5674" sha1="b4b4f800338b0c87fab7c8df5fba53decc396cfe" />
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 3 - Character Library"/>
-			<dataarea name="flop" size="143360">
-				<rom name="animate (4am crack) disk 3 - character library.dsk" size="143360" crc="6491c465" sha1="403b8534858b9cb74564ea5832e5b72cd055b846" />
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 4 - Background Library"/>
-			<dataarea name="flop" size="143360">
-				<rom name="animate (4am crack) disk 4 - background library.dsk" size="143360" crc="e32a2cd4" sha1="d469e03996f33e2bbe237993e1cb29652e4bd5a2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="animateb" cloneof="animate">
-		<description>Animate (imperfect clean crack)</description>
-		<year>1986</year>
-		<publisher>Broderbund Software</publisher>
-		<info name="release" value="2017-06-28"/>
-		<!-- Disks re-cracked on August 28th, 2021 due to subtle
-		timing difference between Disk II and IWM hardware that resulted
-		in the previous version not working on some machines.
-
-		This 'imperfect crack' version remains in here for
-		documentation purposes. -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="143360">
-				<rom name="animate (imperfect 4am crack) disk 1.dsk" size="143360" crc="ad7eb4c2" sha1="034ac6879ae76c2b26b674718f002ad8eb754b6b" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="143360">
-				<rom name="animate (imperfect 4am crack) disk 2.dsk" size="143360" crc="279a2ba1" sha1="86c74c50ac197ac4aed10ab67cd0c2aae4ba9bec" />
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 3 - Character Library"/>
-			<dataarea name="flop" size="143360">
-				<rom name="animate (imperfect 4am crack) disk 3 - character library.dsk" size="143360" crc="6491c465" sha1="403b8534858b9cb74564ea5832e5b72cd055b846" />
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 4 - Background Library"/>
-			<dataarea name="flop" size="143360">
-				<rom name="animate (imperfect 4am crack) disk 4 - background library.dsk" size="143360" crc="e32a2cd4" sha1="d469e03996f33e2bbe237993e1cb29652e4bd5a2" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="ankh">
 		<description>Ankh (cleanly cracked)</description>
 		<year>1983</year>
@@ -4909,19 +4835,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="commnwin">
-		<description>Persona's Communicate and Win (cleanly cracked)</description>
-		<year>????</year>
-		<publisher>Phoenix Software</publisher>
-		<info name="release" value="2018-10-07"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="143360">
-				<rom name="communicate and win (4am crack).dsk" size="143360" crc="0e983c2d" sha1="a95ce215249c05d37727114f887285ecdf9b854e" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="compnumb">
 		<description>Comparing Numbers (cleanly cracked)</description>
 		<year>1984</year>
@@ -6713,26 +6626,6 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="early emerging rules - plurals (4am crack).dsk" size="143360" crc="1fe05fda" sha1="801e84cefecca5257bf797cbfae4db30a020c3d8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ehbible">
-		<description>Early Heroes of the Bible (cleanly cracked)</description>
-		<year>1984</year>
-		<publisher>Baker Book House</publisher>
-		<info name="release" value="2016-07-13"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A"/>
-			<dataarea name="flop" size="143360">
-				<rom name="early heroes of the bible (4am crack) side a.dsk" size="143360" crc="ee55836a" sha1="a6b2eabf4a3eca66c040e61893342381819161a2" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B"/>
-			<dataarea name="flop" size="143360">
-				<rom name="early heroes of the bible (4am crack) side b.dsk" size="143360" crc="65c85c93" sha1="f3acacc26c8c57ca0c68dab3615865c7f2e0222f" />
 			</dataarea>
 		</part>
 	</software>
@@ -17142,26 +17035,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="masqrde">
-		<description>Masquerade (cleanly cracked)</description>
-		<year>1983</year>
-		<publisher>Phoenix Software</publisher>
-		<info name="release" value="2019-05-08"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A"/>
-			<dataarea name="flop" size="143360">
-				<rom name="masquerade (4am crack) side a.dsk" size="143360" crc="1b8efa1a" sha1="dc664d1d62151b1e3de2bcebf27ce121527d331b" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B"/>
-			<dataarea name="flop" size="143360">
-				<rom name="masquerade (4am crack) side b.dsk" size="143360" crc="c2ee6855" sha1="333418548a0e59b6e1221a60485d4b8a5a42e890" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="mathstgy">
 		<description>Math Strategy (cleanly cracked)</description>
 		<year>1981</year>
@@ -17554,21 +17427,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="zgfx0583">
-		<description>Zoom Grafix (Revision 25-MAY-83) (cleanly cracked)</description>
-		<year>1982</year>
-		<publisher>Phoenix Software</publisher>
-		<info name="release" value="2019-05-05"/>
-		<!-- This version is dated 25-MAY-83 according to comments within the
-		program itself. -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="143360">
-				<rom name="zoom grafix 25-may-83 (4am crack).dsk" size="143360" crc="6692bf9f" sha1="043a588c7fb800b6e913da008ed0327db0046d04" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="apoaresp">
 		<description>A Puff of Air: The Respiratory System (cleanly cracked)</description>
 		<year>1983</year>
@@ -17578,39 +17436,6 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="a puff of air (4am crack).dsk" size="143360" crc="8aa66382" sha1="4fe290084395bc61b58bc4fd61f5e83815a451b5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="weekchng">
-		<description>A Week That Changed The World (cleanly cracked)</description>
-		<year>1986</year>
-		<publisher>Educational Publishing Concepts</publisher>
-		<info name="release" value="2019-02-02"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A"/>
-			<dataarea name="flop" size="143360">
-				<rom name="a week that changed the world (4am crack) side a.dsk" size="143360" crc="d4ed4dfa" sha1="6e434634f0f8911af19edb00e0bb9bca01b3cde7" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B"/>
-			<dataarea name="flop" size="143360">
-				<rom name="a week that changed the world (4am crack) side b.dsk" size="143360" crc="5de32c03" sha1="9da24d2da6528248f40ffb7e625e6495f0b862e7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="batsblfr">
-		<description>Bats in the Belfry (cleanly cracked)</description>
-		<year>1983</year>
-		<publisher>Phoenix Software</publisher>
-		<info name="release" value="2019-02-11"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="143360">
-				<rom name="bats in the belfry (4am crack).dsk" size="143360" crc="6109dac9" sha1="d19344e23610bf6b448fbbc4098a9dbd450ba713" />
 			</dataarea>
 		</part>
 	</software>
@@ -17996,46 +17821,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="moseslhp">
-		<description>Moses Leads His People (cleanly cracked)</description>
-		<year>1986</year>
-		<publisher>Educational Publishing Concepts</publisher>
-		<info name="release" value="2019-02-02"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A"/>
-			<dataarea name="flop" size="143360">
-				<rom name="moses leads his people (4am crack) side a.dsk" size="143360" crc="41a67e27" sha1="e8209f454c1be968d55f597425dbb3bdc1d460b7" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B"/>
-			<dataarea name="flop" size="143360">
-				<rom name="moses leads his people (4am crack) side b.dsk" size="143360" crc="360080a2" sha1="f657b886134ace87161399f228e82bd4b348da39" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="paulmsj">
-		<description>Paul's Missionary Journeys (cleanly cracked)</description>
-		<year>1986</year>
-		<publisher>Educational Publishing Concepts</publisher>
-		<info name="release" value="2019-02-02"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A"/>
-			<dataarea name="flop" size="143360">
-				<rom name="paul's missionary journeys (4am crack) side a.dsk" size="143360" crc="752993ed" sha1="14ddbe52b978cd5d6a2e855ce38ce3093aa32b25" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B"/>
-			<dataarea name="flop" size="143360">
-				<rom name="paul's missionary journeys (4am crack) side b.dsk" size="143360" crc="41c4584a" sha1="148d0ec4865cabc3cfa70b83658b2ded699b030c" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="photar">
 		<description>Photar (cleanly cracked)</description>
 		<year>1981</year>
@@ -18282,36 +18067,6 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="world war iii (4am crack).dsk" size="143360" crc="c10acf2d" sha1="7bff2f75a2784a1ad1bd70b13ec5aa2999226b86" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="zgfx0182">
-		<description>Zoom Grafix (version 26-JAN-82) (cleanly cracked)</description>
-		<year>1982</year>
-		<publisher>Phoenix Software</publisher>
-		<info name="release" value="2019-04-08"/>
-		<!-- This version is dated 26-JAN-82 according to comments within the
-		program itself. -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="143360">
-				<rom name="zoom grafix 26-jan-82 (4am crack).dsk" size="143360" crc="789d302a" sha1="c3c457bc13a2eb4061b9843c54adbc6a3e50644f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="zgfx0482">
-		<description>Zoom Grafix (version 29-APR-82) (cleanly cracked)</description>
-		<year>1982</year>
-		<publisher>Phoenix Software</publisher>
-		<info name="release" value="2019-04-08"/>
-		<!-- This version is dated 29-APR-82 according to comments within the
-		program itself. -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="143360">
-				<rom name="zoom grafix 29-apr-82 (4am crack).dsk" size="143360" crc="dc92bdae" sha1="8cfa992832dcb9abe5b44ce4e2e51bb5bc4491d8" />
 			</dataarea>
 		</part>
 	</software>
@@ -19256,19 +19011,6 @@ license:CC0-1.0
 			<feature name="part_id" value="Disk 2 - Utilities"/>
 			<dataarea name="flop" size="143360">
 				<rom name="terrapin logo 1.2 (4am crack) disk 2 - utilities.dsk" size="143360" crc="a1ffc148" sha1="4a504374ec654fdbe26f5e6fbb6f1f780734505a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="zgfxse">
-		<description>Zoom Grafix Second Edition (cleanly cracked)</description>
-		<year>1982</year>
-		<publisher>Phoenix Software</publisher>
-		<info name="release" value="2014-12-08"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="143360">
-				<rom name="zoom grafix second edition (4am crack).dsk" size="143360" crc="5db0f70f" sha1="d7496eba65e8321ce02223c9dae66a6f51d8601a" />
 			</dataarea>
 		</part>
 	</software>
@@ -22186,46 +21928,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="earlychr">
-		<description>The Early Church (cleanly cracked)</description>
-		<year>1984</year>
-		<publisher>Baker Book House</publisher>
-		<info name="release" value="2016-07-13"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A"/>
-			<dataarea name="flop" size="143360">
-				<rom name="the early church (4am crack) side a.dsk" size="143360" crc="ff674e0a" sha1="34f3d0df13e45ef4f9b9725f3a6223118f5218f8" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B"/>
-			<dataarea name="flop" size="143360">
-				<rom name="the early church (4am crack) side b.dsk" size="143360" crc="43d77d07" sha1="7f5c397fe3f1878acedc0dbd46d44061825d705e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="srchking">
-		<description>Searching for a King (cleanly cracked)</description>
-		<year>1984</year>
-		<publisher>Baker Book House</publisher>
-		<info name="release" value="2016-07-13"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A"/>
-			<dataarea name="flop" size="143360">
-				<rom name="searching for a king (4am crack) side a.dsk" size="143360" crc="1e408ef1" sha1="1a3ec7f6aefb5c4e1052fa4aeb0240d16183f493" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B"/>
-			<dataarea name="flop" size="143360">
-				<rom name="searching for a king (4am crack) side b.dsk" size="143360" crc="7c95ce05" sha1="ee6564179ef110a37cc9737a4a72c5899f104348" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="wndrqst">
 		<description>WonderQuest (cleanly cracked)</description>
 		<year>1984</year>
@@ -23655,19 +23357,6 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="verbal item banks 1-14 (4am crack).dsk" size="143360" crc="1eb53f4e" sha1="a9db9c718ab543d32488d91fa71eaae50fdad104" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rtnherac">
-		<description>Return of Heracles (cleanly cracked)</description>
-		<year>1983</year>
-		<publisher>Electronic Arts</publisher>
-		<info name="release" value="2017-03-02"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="143360">
-				<rom name="return of heracles (4am and san inc crack).dsk" size="143360" crc="87654cb4" sha1="aa3e9ca5e70e5f5f81ece532b8878e60549b354e" />
 			</dataarea>
 		</part>
 	</software>
@@ -26291,19 +25980,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="usurp3">
-		<description>The Usurper Book Three: The Mines of Qyntarr (cleanly cracked)</description>
-		<year>1985</year>
-		<publisher>Sir-Tech</publisher>
-		<info name="release" value="2017-11-26"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="143360">
-				<rom name="the usurper book three - the mines of qyntarr (4am crack).dsk" size="143360" crc="c074f3fd" sha1="6b92b4d1ffaefc44a97121a793948901c9f2ed0b" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="hmact200">
 		<description>The Home Accountant (version 2.0) (cleanly cracked)</description>
 		<year>1981</year>
@@ -27500,19 +27176,6 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="submarine commander (4am crack).dsk" size="143360" crc="eb046f47" sha1="ea4d2fc1ad7f4367b54ec73dd39e3d591cfc3668" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="queenphb">
-		<description>The Queen of Phobos (cleanly cracked)</description>
-		<year>1982</year>
-		<publisher>Phoenix Software</publisher>
-		<info name="release" value="2018-03-18"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="143360">
-				<rom name="the queen of phobos (4am crack).dsk" size="143360" crc="3a6bafb0" sha1="b22f60f8061dbc8d786d627168172441f8b6a6f5" />
 			</dataarea>
 		</part>
 	</software>
@@ -28781,21 +28444,6 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="the chambers of vocab (4am crack).dsk" size="143360" crc="5f8f490d" sha1="4881cc172005af041890c595b5df87951f1e7f08" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="zgfx1083">
-		<description>Zoom Grafix 05-OCT-83 (cleanly cracked)</description>
-		<year>1983</year>
-		<publisher>Phoenix Software</publisher>
-		<info name="release" value="2019-04-08"/>
-		<!-- This version is dated 05-OCT-83 according to comments within the
-		program itself. -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="143360">
-				<rom name="zoom grafix 05-oct-83 (4am crack).dsk" size="143360" crc="72cd3138" sha1="66a6fa3e0cee04fcc222ad61de3e8d22668b6ebd" />
 			</dataarea>
 		</part>
 	</software>
@@ -30124,26 +29772,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="boyjesus">
-		<description>The Boy Jesus (cleanly cracked)</description>
-		<year>1984</year>
-		<publisher>Educational Publishing Concepts</publisher>
-		<info name="release" value="2019-11-23"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A"/>
-			<dataarea name="flop" size="143360">
-				<rom name="the boy jesus (4am crack) side a.dsk" size="143360" crc="88c20d44" sha1="17d9afc0952ea153a502768a1316fe33d5bc699c"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B"/>
-			<dataarea name="flop" size="143360">
-				<rom name="the boy jesus (4am crack) side b.dsk" size="143360" crc="7b549ae0" sha1="d75c8e9301b81b50ec101906016e72692ae83674"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="mchess20">
 		<description>MicroChess (version 2.0) (cleanly cracked)</description>
 		<year>1978</year>
@@ -30292,19 +29920,6 @@ license:CC0-1.0
 			<feature name="part_id" value="Disk 6 - Verbal preparation 4"/>
 			<dataarea name="flop" size="143360">
 				<rom name="barron's computer sat study program (4am crack) disk 6 - verbal preparation 4.dsk" size="143360" crc="df710598" sha1="a726b79315090a9d471083d92bd7a0b8a5f849cd"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wizip201">
-		<description>Wiziprint (version 2.01) (cleanly cracked)</description>
-		<year>1982</year>
-		<publisher>Sir-Tech</publisher>
-		<info name="release" value="2020-01-02"/>
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="143360">
-				<rom name="wiziprint (4am crack).dsk" size="143360" crc="354fab0c" sha1="00ab6c5edc0fd0985ecbf425bb2a5c850d0c7b87"/>
 			</dataarea>
 		</part>
 	</software>
@@ -39936,6 +39551,30 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="weekchng">
+		<description>A Week That Changed The World (4am crack)</description>
+		<year>1986</year>
+		<publisher>Educational Publishing Concepts</publisher>
+		<info name="developer" value="Baker Book House"/>
+		<info name="programmer" value="V. Gilbert Beers and Ronald Beers" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-02-02-->
+		<!--educational program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="143360">
+				<rom name="a week that changed the world (4am crack) side a.dsk" size="143360" crc="d4ed4dfa" sha1="6e434634f0f8911af19edb00e0bb9bca01b3cde7" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="143360">
+				<rom name="a week that changed the world (4am crack) side b.dsk" size="143360" crc="5de32c03" sha1="9da24d2da6528248f40ffb7e625e6495f0b862e7" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="acedetr1" cloneof="acedet">
 		<description>Ace Detective (revision 1) (4am crack)</description>
 		<year>1987</year>
@@ -41013,6 +40652,41 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="animate">
+		<description>Animate (4am crack)</description>
+		<year>1986</year>
+		<publisher>Broderbund Software</publisher>
+		<info name="programmer" value="Steven Ohmert" />
+		<info name="usage" value="Requires a 128K Apple //e or later." />
+		<sharedfeat name="compatibility" value="A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2017-06-28. Redumped: 2021-08-28 due to subtle timing difference between Disk II and IWM hardware that resulted in the previous version not working on some machines.-->
+		<!--graphics program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1"/>
+			<dataarea name="flop" size="143360">
+				<rom name="animate (4am crack) disk 1.dsk" size="143360" crc="4b89c917" sha1="46a77dfe78c3516362666699542433293aa03260" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2"/>
+			<dataarea name="flop" size="143360">
+				<rom name="animate (4am crack) disk 2.dsk" size="143360" crc="c16d5674" sha1="b4b4f800338b0c87fab7c8df5fba53decc396cfe" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3 - Character Library"/>
+			<dataarea name="flop" size="143360">
+				<rom name="animate (4am crack) disk 3 - character library.dsk" size="143360" crc="6491c465" sha1="403b8534858b9cb74564ea5832e5b72cd055b846" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4 - Background Library"/>
+			<dataarea name="flop" size="143360">
+				<rom name="animate (4am crack) disk 4 - background library.dsk" size="143360" crc="e32a2cd4" sha1="d469e03996f33e2bbe237993e1cb29652e4bd5a2" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="adbmastmat">
 		<description>Arcademic Drill Builder: Master Match (4am crack)</description>
 		<year>1983</year>
@@ -41753,6 +41427,22 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="basic number facts- practice (4am crack).dsk" size="143360" crc="9ef63ad3" sha1="b62c6842a4bd4859e698298b9707fa37abc86c4d" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="batsblfr">
+		<description>Bats in the Belfry (4am crack)</description>
+		<year>1983</year>
+		<publisher>Phoenix Software</publisher>
+		<info name="programmer" value="Samuel Moore" />
+		<info name="usage" value="Requires an Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-02-11-->
+		<!--action game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="bats in the belfry (4am crack).dsk" size="143360" crc="6109dac9" sha1="d19344e23610bf6b448fbbc4098a9dbd450ba713" />
 			</dataarea>
 		</part>
 	</software>
@@ -45028,6 +44718,30 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="piece of cake math (4am crack).dsk" size="143360" crc="b73d1855" sha1="1219efb6057136d3cf22f9e27c24d1e16856192d" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ehbible">
+		<description>Early Heroes of the Bible (4am crack)</description>
+		<year>1984</year>
+		<publisher>Educational Publishing Concepts</publisher>
+		<info name="developer" value="Baker Book House"/>
+		<info name="programmer" value="V. Gilbert Beers and Ronald Beers" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2016-07-13-->
+		<!--educational program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="143360">
+				<rom name="early heroes of the bible (4am crack) side a.dsk" size="143360" crc="ee55836a" sha1="a6b2eabf4a3eca66c040e61893342381819161a2" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="143360">
+				<rom name="early heroes of the bible (4am crack) side b.dsk" size="143360" crc="65c85c93" sha1="f3acacc26c8c57ca0c68dab3615865c7f2e0222f" />
 			</dataarea>
 		</part>
 	</software>
@@ -48388,6 +48102,29 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="masqrde">
+		<description>Masquerade (4am crack)</description>
+		<year>1983</year>
+		<publisher>Phoenix Software</publisher>
+		<info name="programmer" value="Dale Johnson and Rick Incrocci" />
+		<info name="usage" value="Requires an Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-05-08-->
+		<!--adventure game-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="143360">
+				<rom name="masquerade (4am crack) side a.dsk" size="143360" crc="1b8efa1a" sha1="dc664d1d62151b1e3de2bcebf27ce121527d331b" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="143360">
+				<rom name="masquerade (4am crack) side b.dsk" size="143360" crc="c2ee6855" sha1="333418548a0e59b6e1221a60485d4b8a5a42e890" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="mmerlyad10" cloneof="mmerlyad">
 		<description>Mastering Math Series 1: Early Addition (A-788 version 1.0) (4am crack)</description>
 		<year>1983</year>
@@ -49997,6 +49734,30 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="moseslhp">
+		<description>Moses Leads His People (4am crack)</description>
+		<year>1986</year>
+		<publisher>Educational Publishing Concepts</publisher>
+		<info name="developer" value="Baker Book House" />
+		<info name="programmer" value="V. Gilbert Beers and Ronald Beers" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-02-02-->
+		<!--educational program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="143360">
+				<rom name="moses leads his people (4am crack) side a.dsk" size="143360" crc="41a67e27" sha1="e8209f454c1be968d55f597425dbb3bdc1d460b7" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="143360">
+				<rom name="moses leads his people (4am crack) side b.dsk" size="143360" crc="360080a2" sha1="f657b886134ace87161399f228e82bd4b348da39" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="mulperev">
 		<description>Multidimensional Personality Evaluation (4am crack)</description>
 		<year>1983</year>
@@ -50367,6 +50128,30 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="paulmsj">
+		<description>Paul's Missionary Journeys (4am crack)</description>
+		<year>1986</year>
+		<publisher>Educational Publishing Concepts</publisher>
+		<info name="developer" value="Baker Book House" />
+		<info name="programmer" value="V. Gilbert Beers and Ronald Beers" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-02-02-->
+		<!--educational program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="143360">
+				<rom name="paul's missionary journeys (4am crack) side a.dsk" size="143360" crc="752993ed" sha1="14ddbe52b978cd5d6a2e855ce38ce3093aa32b25" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="143360">
+				<rom name="paul's missionary journeys (4am crack) side b.dsk" size="143360" crc="41c4584a" sha1="148d0ec4865cabc3cfa70b83658b2ded699b030c" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="pmathmat">
 		<description>Peanuts Math Matcher (4am crack)</description>
 		<year>1985</year>
@@ -50543,6 +50328,21 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="perplexing puzzles (4am crack).dsk" size="143360" crc="4860446c" sha1="3052c8cf0e6416b64988ea351f20769f766abbb7" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pcommnwin">
+		<description>Persona's Communicate and Win (4am crack)</description>
+		<year>????</year>
+		<publisher>Phoenix Software</publisher>
+		<info name="usage" value="Requires an Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2018-10-07-->
+		<!--productivity program-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="communicate and win (4am crack).dsk" size="143360" crc="0e983c2d" sha1="a95ce215249c05d37727114f887285ecdf9b854e" />
 			</dataarea>
 		</part>
 	</software>
@@ -52057,6 +51857,24 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="rtnherac">
+		<description>Return of Heracles (Electronic Arts) (4am and san inc crack)</description>
+		<year>1983</year>
+		<publisher>Electronic Arts</publisher>
+		<info name="original_publisher" value="Quality Software" />
+		<!--Electronic Arts re-release-->
+		<info name="programmer" value="Stuart Smith" />
+		<info name="usage" value="Requires a 48K Apple ][ or later." />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2017-03-02-->
+		<!--adventure game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="return of heracles (4am and san inc crack).dsk" size="143360" crc="87654cb4" sha1="aa3e9ca5e70e5f5f81ece532b8878e60549b354e" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="rtrchrlw">
 		<description>Return to Reading: Charlotte's Web (4am crack)</description>
 		<year>1986</year>
@@ -52649,6 +52467,30 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="scramble (4am crack).dsk" size="143360" crc="d4931983" sha1="7084a4fec4c4705cda0f8e3c5a8d255ce431912a" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="srchking">
+		<description>Searching for a King (4am crack)</description>
+		<year>1984</year>
+		<publisher>Educational Publishing Concepts</publisher>
+		<info name="developer" value="Baker Book House" />
+		<info name="programmer" value="V. Gilbert Beers and Ronald Beers" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2016-07-13-->
+		<!--educational program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="143360">
+				<rom name="searching for a king (4am crack) side a.dsk" size="143360" crc="1e408ef1" sha1="1a3ec7f6aefb5c4e1052fa4aeb0240d16183f493" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="143360">
+				<rom name="searching for a king (4am crack) side b.dsk" size="143360" crc="7c95ce05" sha1="ee6564179ef110a37cc9737a4a72c5899f104348" />
 			</dataarea>
 		</part>
 	</software>
@@ -54830,6 +54672,30 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="boyjesus">
+		<description>The Boy Jesus (4am crack)</description>
+		<year>1984</year>
+		<publisher>Educational Publishing Concepts</publisher>
+		<info name="developer" value="Baker Book House" />
+		<info name="programmer" value="V. Gilbert Beers and Ronald Beers" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-11-23-->
+		<!--educational program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="143360">
+				<rom name="the boy jesus (4am crack) side a.dsk" size="143360" crc="88c20d44" sha1="17d9afc0952ea153a502768a1316fe33d5bc699c"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="143360">
+				<rom name="the boy jesus (4am crack) side b.dsk" size="143360" crc="7b549ae0" sha1="d75c8e9301b81b50ec101906016e72692ae83674"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="tcntbee11" cloneof="tcntbee">
 		<description>The Counting Bee (version 1.1, 26-FEB-82) (4am crack)</description>
 		<year>1981</year>
@@ -54899,6 +54765,30 @@ license:CC0-1.0
 			<feature name="part_id" value="Side B" />
 			<dataarea name="flop" size="143360">
 				<rom name="the dream machine (4am crack) side b.dsk" size="143360" crc="adfe645e" sha1="ab1e0027f723534a20fb3d2bcb228fd16a5f79f8" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="earlychr">
+		<description>The Early Church (4am crack)</description>
+		<year>1984</year>
+		<publisher>Educational Publishing Concepts</publisher>
+		<info name="developer" value="Baker Book House" />
+		<info name="programmer" value="V. Gilbert Beers and Ronald Beers" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2016-07-13-->
+		<!--educational program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="flop" size="143360">
+				<rom name="the early church (4am crack) side a.dsk" size="143360" crc="ff674e0a" sha1="34f3d0df13e45ef4f9b9725f3a6223118f5218f8" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="flop" size="143360">
+				<rom name="the early church (4am crack) side b.dsk" size="143360" crc="43d77d07" sha1="7f5c397fe3f1878acedc0dbd46d44061825d705e" />
 			</dataarea>
 		</part>
 	</software>
@@ -55262,6 +55152,22 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="the newsroom self-running demo (4am crack).dsk" size="143360" crc="14b1d110" sha1="b4e23d018ca83d24e66ac1f63d55cad2df8b1ed7" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="queenphb">
+		<description>The Queen of Phobos (4am crack)</description>
+		<year>1982</year>
+		<publisher>Phoenix Software</publisher>
+		<info name="programmer" value="William R. Crawford, Paul L. Berker, Dav Holle and Adrian Ferret" />
+		<info name="usage" value="Requires an Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2018-03-18-->
+		<!--adventure game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="the queen of phobos (4am crack).dsk" size="143360" crc="3a6bafb0" sha1="b22f60f8061dbc8d786d627168172441f8b6a6f5" />
 			</dataarea>
 		</part>
 	</software>
@@ -55740,6 +55646,22 @@ license:CC0-1.0
 			<feature name="part_id" value="Disk 2 Side B" />
 			<dataarea name="flop" size="143360">
 				<rom name="the trivia arcade (4am crack) disk 2b.dsk" size="143360" crc="9e03d200" sha1="e76db146d770c2c751d0cc9da73feaec3f5673df" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="usurp3">
+		<description>The Usurper Book Three: The Mines of Qyntarr (4am crack)</description>
+		<year>1985</year>
+		<publisher>Sir-Tech Software</publisher>
+		<info name="programmer" value="Scott Thoman" />
+		<info name="usage" value="Requires an Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2017-11-26-->
+		<!--adventure game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="the usurper book three - the mines of qyntarr (4am crack).dsk" size="143360" crc="c074f3fd" sha1="6b92b4d1ffaefc44a97121a793948901c9f2ed0b" />
 			</dataarea>
 		</part>
 	</software>
@@ -57138,6 +57060,23 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="wiziprint">
+		<description>Wiziprint (version 2.01 20-AUG-83) (4am crack)</description>
+		<year>1982</year>
+		<publisher>Sir-Tech Software</publisher>
+		<info name="programmer" value="Andrew Greenberg and Robert Woodhead" />
+		<info name="usage" value="Requires an Apple ][+ or later." />
+		<info name="version" value="2.01 20-AUG-83" />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2020-01-02-->
+		<!--game utility program-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="wiziprint (4am crack).dsk" size="143360" crc="354fab0c" sha1="00ab6c5edc0fd0985ecbf425bb2a5c850d0c7b87"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="wordplc">
 		<description>Word Problems Level C (version 3.1.6) (4am crack)</description>
 		<year>1989</year>
@@ -57396,6 +57335,96 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="143360">
 				<rom name="zoo master rev. 2 (4am crack).dsk" size="143360" crc="c8a682f4" sha1="79534d2e394a16cddf8e68d77cf66e128ac48f68" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="zoomgrafv0182" cloneof="zoomgraf">
+		<description>Zoom Grafix (version 26-JAN-82) (4am crack)</description>
+		<year>1982</year>
+		<publisher>Phoenix Software</publisher>
+		<info name="programmer" value="Dav Holle" />
+		<info name="usage" value="Requires an Apple ][+ or later." />
+		<info name="version" value="26-JAN-82" />
+		<!-- This version is dated 26-JAN-82 according to comments within the program itself. -->
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-04-08-->
+		<!--graphics program-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="zoom grafix 26-jan-82 (4am crack).dsk" size="143360" crc="789d302a" sha1="c3c457bc13a2eb4061b9843c54adbc6a3e50644f" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="zoomgraf0482" cloneof="zoomgraf">
+		<description>Zoom Grafix (version 29-APR-82) (4am crack)</description>
+		<year>1982</year>
+		<publisher>Phoenix Software</publisher>
+		<info name="programmer" value="Dav Holle" />
+		<info name="usage" value="Requires an Apple ][+ or later." />
+		<info name="version" value="29-APR-82" />
+		<!-- This version is dated 29-APR-82 according to comments within the program itself. -->
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-04-08-->
+		<!--graphics program-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="zoom grafix 29-apr-82 (4am crack).dsk" size="143360" crc="dc92bdae" sha1="8cfa992832dcb9abe5b44ce4e2e51bb5bc4491d8" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="zoomgraf0583" cloneof="zoomgraf">
+		<description>Zoom Grafix (version 25-MAY-83) (4am crack)</description>
+		<year>1982</year>
+		<publisher>Phoenix Software</publisher>
+		<info name="programmer" value="Dav Holle" />
+		<info name="usage" value="Requires an Apple ][+ or later." />
+		<info name="version" value="25-MAY-83" />
+		<!-- This version is dated 25-MAY-83 according to comments within the program itself. -->
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-05-05-->
+		<!--graphics program-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="zoom grafix 25-may-83 (4am crack).dsk" size="143360" crc="6692bf9f" sha1="043a588c7fb800b6e913da008ed0327db0046d04" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="zoomgraf">
+		<description>Zoom Grafix (version 05-OCT-83) (4am crack)</description>
+		<year>1983</year>
+		<publisher>Phoenix Software</publisher>
+		<info name="programmer" value="Dav Holle" />
+		<info name="usage" value="Requires an Apple ][+ or later." />
+		<info name="version" value="05-OCT-83" />
+		<!-- This version is dated 05-OCT-83 according to comments within the program itself. -->
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-04-08-->
+		<!--graphics program-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="zoom grafix 05-oct-83 (4am crack).dsk" size="143360" crc="72cd3138" sha1="66a6fa3e0cee04fcc222ad61de3e8d22668b6ebd" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="zgfxse">
+		<description>Zoom Grafix Second Edition (version 05-MAY-83) (4am crack)</description>
+		<year>1982</year>
+		<publisher>Phoenix Software</publisher>
+		<info name="programmer" value="Dav Holle" />
+		<info name="usage" value="Requires an Apple ][+ or later." />
+		<info name="version" value="05-MAY-83" />
+		<!-- This version is dated 05-MAY-83 according to comments within the program itself. -->
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2014-12-08-->
+		<!--graphics program-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="zoom grafix second edition (4am crack).dsk" size="143360" crc="5db0f70f" sha1="d7496eba65e8321ce02223c9dae66a6f51d8601a" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/apple2_flop_orig.xml
+++ b/hash/apple2_flop_orig.xml
@@ -2070,28 +2070,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="pop">
-		<description>Prince of Persia</description>
-		<year>1989</year>
-		<publisher>Brøderbund Software</publisher>
-		<info name="usage" value="Requires a 128K Apple //e, //c, or IIgs." />
-		<sharedfeat name="compatibility" value="A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2018-09-14 -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A" />
-			<dataarea name="flop" size="233481">
-				<rom name="prince of persia side a.woz" size="233481" crc="a3820127" sha1="bf7c7c03fcc93b989a8a7e566ec711888553a9de" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B" />
-			<dataarea name="flop" size="233481">
-				<rom name="prince of persia side b.woz" size="233481" crc="6de94d52" sha1="931e264563390d1e76cef9a7db31492643f45b49" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="radwarr">
 		<description>Rad Warrior</description>
 		<year>1987</year>
@@ -2178,21 +2156,6 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="240149">
 				<rom name="repton.woz" size="240149" crc="0f2eb4c5" sha1="f8f606c751eb1f86cb60cb1e6b538acd30a66ab9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rescraid">
-		<description>Rescue Raiders</description>
-		<year>1984</year>
-		<publisher>Sir-Tech</publisher>
-		<info name="usage" value="Runs on any Apple II with 64K." />
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2018-08-16 -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="233518">
-				<rom name="rescue raiders.woz" size="233518" crc="f2f5bf46" sha1="4ab4e39d593e35c2b1eebc2b5bd1c51b024ef1fb" />
 			</dataarea>
 		</part>
 	</software>
@@ -4072,30 +4035,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="wizrdry3">
-		<description>Wizardry III: Legacy of Llylgamyn (version 4, 20-Aug-1983 update)</description>
-		<year>1983</year>
-		<publisher>Sir-Tech Software</publisher>
-		<info name="programmer" value="Andrew Greenberg and Robert Woodhead" />
-		<info name="usage" value="Requires a 64K Apple ][+ or later." />
-		<info name="version" value="Version 4, 20-Aug-1983 update" />
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!--Dump released: 2019-04-08. Redumped: 2023-09-12-->
-		<!--roleplaying game-->
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A - Master Scenario disk" />
-			<dataarea name="flop" size="234882">
-				<rom name="wizardry iii side a - master scenario disk.woz" size="234882" crc="57366656" sha1="9d59da2fca6c3c42c89ff2e8988d4d66dd1e0143" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B - Boot disk" />
-			<dataarea name="flop" size="234871">
-				<rom name="wizardry iii side b - boot.woz" size="234871" crc="4e0b9951" sha1="ed00134fb1006eeb3cd1299449759beae2218061" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="arcalbm1">
 		<description>Arcade Album #1</description>
 		<year>1983</year>
@@ -4892,21 +4831,6 @@ license:CC0-1.0
 			<feature name="part_id" value="Disk D" />
 			<dataarea name="flop" size="234866">
 				<rom name="the wizard of oz disk d.woz" size="234866" crc="1c0e7e78" sha1="25d7e25b66c475d0881138ba302be722683df6e6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="queenphb">
-		<description>The Queen of Phobos</description>
-		<year>1982</year>
-		<publisher>Phoenix Software</publisher>
-		<info name="usage" value="Requires a 48K Apple ][ or later." />
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2019-06-07 -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="181581">
-				<rom name="the queen of phobos.woz" size="181581" crc="6c31a42a" sha1="7617ff8f126edaab1daf8954ea7d6cac07bb1e77" />
 			</dataarea>
 		</part>
 	</software>
@@ -5792,21 +5716,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="qsrtnhcl">
-		<description>Return of Heracles</description>
-		<year>1983</year>
-		<publisher>Quality Software</publisher>
-		<info name="usage" value="Requires a 48K Apple ][ or later." />
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2019-08-02 -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="235508">
-				<rom name="return of heracles.woz" size="235508" crc="50be7d16" sha1="24e16ab619a269e8cb47d0a3557aec1cf9c35d98" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="racemdnt">
 		<description>Race For Midnight</description>
 		<year>1981</year>
@@ -5967,70 +5876,6 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="228079">
 				<rom name="escape.woz" size="228079" crc="27a73b52" sha1="e2af6129e23aad6fb6ff9025b0694c4c9a97007f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wizrdry5">
-		<description>Wizardry V: Heart of the Maelstrom</description>
-		<year>1988</year>
-		<publisher>Sir-Tech Software</publisher>
-		<info name="usage" value="Requires a 64K Apple ][+ or later." />
-		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2019-08-03 -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk A" />
-			<dataarea name="flop" size="234780">
-				<rom name="wizardry v - heart of the maelstrom - a.woz" size="234780" crc="5c670ca8" sha1="93c05e54ea21596165fb158cfcceaa595ccd38e1" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk B" />
-			<dataarea name="flop" size="234780">
-				<rom name="wizardry v - heart of the maelstrom - b.woz" size="234780" crc="1df4b66f" sha1="5ceb0e45e976111ad9d93a3feb1261ecd207465b" />
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk C" />
-			<dataarea name="flop" size="234780">
-				<rom name="wizardry v - heart of the maelstrom - c.woz" size="234780" crc="60381a85" sha1="68ac614ea0bc52a690d35c9c6a64d425fe775202" />
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Disk D" />
-			<dataarea name="flop" size="234780">
-				<rom name="wizardry v - heart of the maelstrom - d.woz" size="234780" crc="2219894f" sha1="793a5074867136cfee53877113dcfda0c8590b6b" />
-			</dataarea>
-		</part>
-		<part name="flop5" interface="floppy_5_25">
-			<feature name="part_id" value="Disk E" />
-			<dataarea name="flop" size="234780">
-				<rom name="wizardry v - heart of the maelstrom - e.woz" size="234780" crc="0e3d0d38" sha1="4a8a35ea50bf55da877ada12823971c7bb6779c4" />
-			</dataarea>
-		</part>
-		<part name="flop6" interface="floppy_5_25">
-			<feature name="part_id" value="Disk F" />
-			<dataarea name="flop" size="234780">
-				<rom name="wizardry v - heart of the maelstrom - f.woz" size="234780" crc="f0b8294f" sha1="fbed529779a7f1dd70a416f83502dd4468c4d014" />
-			</dataarea>
-		</part>
-		<part name="flop7" interface="floppy_5_25">
-			<feature name="part_id" value="Disk G" />
-			<dataarea name="flop" size="234780">
-				<rom name="wizardry v - heart of the maelstrom - g.woz" size="234780" crc="90979c2d" sha1="a9a115d8f68eefadfe360bb006239fa1773633a8" />
-			</dataarea>
-		</part>
-		<part name="flop8" interface="floppy_5_25">
-			<feature name="part_id" value="Disk H" />
-			<dataarea name="flop" size="234780">
-				<rom name="wizardry v - heart of the maelstrom - h.woz" size="234780" crc="571539b6" sha1="5db3ef18a7a03c775b16577624af3c3ef0637b97" />
-			</dataarea>
-		</part>
-		<part name="flop9" interface="floppy_5_25">
-			<feature name="part_id" value="Disk I" />
-			<dataarea name="flop" size="234780">
-				<rom name="wizardry v - heart of the maelstrom - i.woz" size="234780" crc="690af2ea" sha1="99fc3ba766182e331f8729672711a27b2bfe1509" />
 			</dataarea>
 		</part>
 	</software>
@@ -8570,21 +8415,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="galattk">
-		<description>Galactic Attack</description>
-		<year>1980</year>
-		<publisher>Sir-Tech</publisher>
-		<info name="usage" value="Requires a 64K Apple ][+ or later." />
-		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2019-12-14 -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="234790">
-				<rom name="galactic attack.woz" size="234790" crc="013efc71" sha1="68975194ff1b597ed4e2773649bb8880d050a1cd" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="journey">
 		<description>Journey (version 16)</description>
 		<year>1989</year>
@@ -8636,52 +8466,6 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234863">
 				<rom name="southern command.woz" size="234863" crc="e04bb52c" sha1="bc53a1a66fc347859c17238a28b3bd4a8b178739" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wizrdry4">
-		<description>Wizardry IV: The Return of Werdna</description>
-		<year>1987</year>
-		<publisher>Sir-Tech</publisher>
-		<info name="usage" value="Requires a 64K Apple ][+ or later." />
-		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2019-12-14 -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A" />
-			<dataarea name="flop" size="234833">
-				<rom name="wizardry iv - the return of werdna side a.woz" size="234833" crc="0c6ac6a0" sha1="f465fb3b88eb38c197e24da1ae1962f6d0a58cd9" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B" />
-			<dataarea name="flop" size="234833">
-				<rom name="wizardry iv - the return of werdna side b.woz" size="234833" crc="179d1324" sha1="7bff6956d76129cc82d5e5ac6ba30d8806054bdf" />
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Side C" />
-			<dataarea name="flop" size="234833">
-				<rom name="wizardry iv - the return of werdna side c.woz" size="234833" crc="0493f3d5" sha1="22efb911669d42525a8e8ab35b2a34ca5ef2fdbd" />
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Side D" />
-			<dataarea name="flop" size="234833">
-				<rom name="wizardry iv - the return of werdna side d.woz" size="234833" crc="897eb0dc" sha1="21f4d0bd66d9d3a275678dbfc7cabb0cc023910f" />
-			</dataarea>
-		</part>
-		<part name="flop5" interface="floppy_5_25">
-			<feature name="part_id" value="Side E" />
-			<dataarea name="flop" size="234833">
-				<rom name="wizardry iv - the return of werdna side e.woz" size="234833" crc="0fd25eba" sha1="eb07e89850635da688a5aa1d372eebbc19594c9e" />
-			</dataarea>
-		</part>
-		<part name="flop6" interface="floppy_5_25">
-			<feature name="part_id" value="Side F" />
-			<dataarea name="flop" size="234833">
-				<rom name="wizardry iv - the return of werdna side f.woz" size="234833" crc="3a8a7986" sha1="a2684a58605af6ddbd6554bc99333ab3947dd4e9" />
 			</dataarea>
 		</part>
 	</software>
@@ -9146,67 +8930,6 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="88341">
 				<rom name="star trek - strategic operations simulator.woz" size="88341" crc="4c47c392" sha1="8ac0afa85358e8d9ab4a58daeb3b92a8b0330a55" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wzdryr21">
-		<description>Wizardry: Proving Grounds of the Mad Overlord (version 2.1)</description>
-		<year>1981</year>
-		<publisher>Sir-Tech</publisher>
-		<info name="usage" value="Requires a 48K Apple ][ or later." />
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2020-01-11 -->
-		<!-- Note: some emulators may have difficulty loading this disk because of its especially timing-sensitive copy protection.-->
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1 - Boot disk" />
-			<dataarea name="flop" size="234829">
-				<rom name="wizardry - proving grounds of the mad overlord v2.1 - boot disk.woz" size="234829" crc="29dfa2a6" sha1="6c0416fb7cb91bde8da05df77ecfc5f7b7c645f1" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2 - Scenario master disk" />
-			<dataarea name="flop" size="234829">
-				<rom name="wizardry - proving grounds of the mad overlord v2.1 - scenario master disk.woz" size="234829" crc="7951ca26" sha1="604a416c50ca6fccb39c11142f8be00d51ce627c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wzrdry2">
-		<description>Wizardry II: The Knight of Diamonds (version PV3S2V1/10-MAR-82)</description>
-		<year>1982</year>
-		<publisher>Sir-Tech</publisher>
-		<info name="usage" value="Requires a 48K Apple ][ or later." />
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2020-01-11 -->
-		<!-- This is version PV3S2V1 of 10-MAR-82.Some emulators may have difficulty loading this disk because of its especially timing-sensitive copy protection.-->
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1 - Boot disk" />
-			<dataarea name="flop" size="234854">
-				<rom name="wizardry ii - knight of diamonds - boot disk.woz" size="234854" crc="16a794a8" sha1="db098051302810edb8aa5c56c8a3dd7cc9ab0772" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2 - Master scenario disk" />
-			<dataarea name="flop" size="234865">
-				<rom name="wizardry ii - knight of diamonds - master scenario disk.woz" size="234865" crc="ac3a27d9" sha1="59f7c602c6347c732ddd8222d667622bf8749a29" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wizipr21">
-		<description>Wiziprint (version 2.1)</description>
-		<year>1982</year>
-		<publisher>Sir-Tech</publisher>
-		<info name="usage" value="Requires a 48K Apple ][ or later." />
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2020-01-13 -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="234840">
-				<rom name="wiziprint v2.01.woz" size="234840" crc="593dc847" sha1="d8628dbce3441820cbbd2ef4ac5a94421e514226" />
 			</dataarea>
 		</part>
 	</software>
@@ -10480,21 +10203,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="wizplus">
-		<description>Wizplus</description>
-		<year>1982</year>
-		<publisher>Datamost</publisher>
-		<info name="usage" value="Requires a 64K Apple ][+ or later." />
-		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2020-03-02 -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="234768">
-				<rom name="wizplus.woz" size="234768" crc="f60920a3" sha1="a640aec03dc8bddf434b43318ae80f54d5c1ab8c" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="jelwayqb">
 		<description>John Elway's Quarterback</description>
 		<year>1987</year>
@@ -10770,21 +10478,6 @@ license:CC0-1.0
 			<feature name="part_id" value="Side B - Historical scenarios" />
 			<dataarea name="flop" size="234793">
 				<rom name="kampfgruppe side b - historical senarios.woz" size="234793" crc="43f3a85e" sha1="c045af7378e7dff9a3dac97e26e82543df3da566" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="metinspc">
-		<description>Meteoroids in Space</description>
-		<year>1981</year>
-		<publisher>Quality Software</publisher>
-		<info name="usage" value="Requires a 48K Apple ][ or later." />
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2020-04-08 -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="48405">
-				<rom name="meteoroids in space.woz" size="48405" crc="7beb3c05" sha1="61cdb1028a091a7bd85ac636f1f29087b57b4426" />
 			</dataarea>
 		</part>
 	</software>
@@ -11740,40 +11433,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="scitkp20">
-		<description>Science Toolkit Plus (version 2.0)</description>
-		<year>1989</year>
-		<publisher>Brøderbund Software</publisher>
-		<info name="usage" value="Requires a 128K Apple //e or later." />
-		<sharedfeat name="compatibility" value="A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2020-06-05 -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1 - Master module" />
-			<dataarea name="flop" size="241512">
-				<rom name="science toolkit plus v2.0 disk 1 - master module.woz" size="241512" crc="421c7922" sha1="9c4dbbb09ffcf609a4efe34be3fb6f0753c177b9" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2 - Module 1: Speed and motion" />
-			<dataarea name="flop" size="241523">
-				<rom name="science toolkit plus v2.0 disk 2 - module 1- speed and motion.woz" size="241523" crc="1f24f501" sha1="69d51f5d5663a7a73eddadc81f110575adaeff7e" />
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 3 - Module 2: Earthquake lab" />
-			<dataarea name="flop" size="241523">
-				<rom name="science toolkit plus v2.0 disk 3 - module 2- earthquake lab.woz" size="241523" crc="01807b1e" sha1="d0cd79b8649110c16f8051fb552389463c94e18a" />
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 4 - Module 3: Body lab" />
-			<dataarea name="flop" size="241517">
-				<rom name="science toolkit plus v2.0 disk 4 - module 3- body lab.woz" size="241517" crc="7ede15f2" sha1="79f286fb54c3b806718fa21025c0fa10c720e8f7" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="tycoon21">
 		<description>Tycoon (version 2.1)</description>
 		<year>1985</year>
@@ -11796,21 +11455,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="bgtrck21">
-		<description>Bag of Tricks (version 2.1)</description>
-		<year>1987</year>
-		<publisher>Quality Software</publisher>
-		<info name="usage" value="Requires a 64K Apple ][+ or later." />
-		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2020-06-06 -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="241471">
-				<rom name="bag of tricks v2.1.woz" size="241471" crc="fcac8d4e" sha1="e879a1875a6dc3263bd0d239e130c397458b841e" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="clchess4">
 		<description>Colossus Chess IV</description>
 		<year>1986</year>
@@ -11822,21 +11466,6 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="241413">
 				<rom name="colossus chess iv.woz" size="241413" crc="3d336167" sha1="3b1caa7cca7efef1d5d2da18a1ffd0a62980c4fb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="astinspc">
-		<description>Asteroids in Space</description>
-		<year>1980</year>
-		<publisher>Quality Software</publisher>
-		<info name="usage" value="Runs on any Apple II with 32K and a 13-sector drive." />
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2020-06-06 -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="241425">
-				<rom name="asteroids in space.woz" size="241425" crc="b4e281cb" sha1="a0870556a5e29e79427c4528ff739472a75b6e99" />
 			</dataarea>
 		</part>
 	</software>
@@ -14505,21 +14134,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="batsbelf">
-		<description>Bats in the Belfry</description>
-		<year>1983</year>
-		<publisher>Phoenix Software</publisher>
-		<info name="usage" value="Requires a 48K Apple ][ or later." />
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2020-12-07 -->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="121627">
-				<rom name="bats in the belfry.woz" size="121627" crc="b42681ec" sha1="84d8e3a1cc653faee017a319decdd87d353d7c36" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="alnrain">
 		<description>Alien Rain</description>
 		<year>1980</year>
@@ -15047,22 +14661,6 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234815">
 				<rom name="teddy's playground 1989.woz" size="234815" crc="3adfcaa3" sha1="852e2457948c44681c5e3b598166ce410e3f7b51" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pop35">
-		<description>Prince of Persia (800K 3.5")</description>
-		<year>1989</year>
-		<publisher>Brøderbund Software</publisher>
-		<info name="usage" value="Requires an Apple IIgs, Apple //c+, or 128K enhanced Apple //e with a compatible drive controller card." />
-		<sharedfeat name="compatibility" value="A2EE,A2C,A2GS" />
-		<!-- Dump released: 2021-06-30 -->
-		<!--"Prince of Persia" is a 1989 action game developed by Jordan Mechner and distributed by Brøderbund Software. This version is distributed on a single 3.5-inch (800K) disk. It requires an Apple IIgs, Apple //c+, or 128K enhanced Apple //e with a compatible drive controller card.-->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="1297161">
-				<rom name="prince of persia 800k.woz" size="1297161" crc="e166d56a" sha1="d9558d25a3d3d91542f32abba9e6b0e2f2c75b09" />
 			</dataarea>
 		</part>
 	</software>
@@ -16471,22 +16069,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="bapmnr11">
-		<description>Beneath Apple Manor (version 1.1)</description>
-		<year>1979</year>
-		<publisher>The Software Factory</publisher>
-		<info name="usage" value="Requires a 32K Apple ][ with Integer BASIC in ROM." />
-		<sharedfeat name="compatibility" value="A2" />
-		<!-- Dump released: 2022-02-18 -->
-		<!--"Beneath Apple Manor" is a 1979 adventure game developed by Don Worth and distributed by The Software Factory. This is version 1.1. It requires a 32K Apple ][ with Integer BASIC in ROM.-->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="234800">
-				<rom name="beneath apple manor.woz" size="234800" crc="95533df3" sha1="5db4eb223f9daca74d1b06cfbe7593023818ac14" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="teleport">
 		<description>Teleport</description>
 		<year>1982</year>
@@ -16782,29 +16364,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="cryptmed">
-		<description>Crypt of Medea</description>
-		<year>1983</year>
-		<publisher>Sir-Tech</publisher>
-		<info name="usage" value="Requires a 48K Apple ][+ or later." />
-		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2022-02-11 -->
-		<!--"Crypt of Medea" is a 1983 adventure game developed by Allan Lamb and Arthur Britto II, and distributed by Sir-Tech Software. It requires a 48K Apple ][+ or later.-->
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A" />
-			<dataarea name="flop" size="234815">
-				<rom name="crypt of medea side a.woz" size="234815" crc="aad35539" sha1="041043080b9c2332b2401a6444cb827bf38da4ad" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B" />
-			<dataarea name="flop" size="234815">
-				<rom name="crypt of medea side b.woz" size="234815" crc="406de5eb" sha1="45f9f6695c6466c770d6b4a27d2e80b75d7b95f9" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="handdand">
 		<description>Handy Dandy</description>
 		<year>1983</year>
@@ -16959,22 +16518,6 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="240932">
 				<rom name="zodiac castle.woz" size="240932" crc="d8d95723" sha1="e33a9324298fe3125d94b0eb40ed86bba91ee669" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bapmnrse">
-		<description>Beneath Apple Manor: The Special Edition</description>
-		<year>1982</year>
-		<publisher>Quality Software</publisher>
-		<info name="usage" value="Requires a 48K Apple ][ or later." />
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2022-02-11 -->
-		<!--"Beneath Apple Manor: The Special Edition" is a 1982 adventure game developed by Don Worth and distributed by Quality Software. It runs on any Apple II with 48K.-->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="234826">
-				<rom name="beneath apple manor- the special edition.woz" size="234826" crc="69ad7676" sha1="15992953d222818d96a8a2e87854ebdf32fd62e2" />
 			</dataarea>
 		</part>
 	</software>
@@ -17468,22 +17011,6 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234793">
 				<rom name="skybombers ii.woz" size="234793" crc="ae878da8" sha1="73337e05f4f399a7a89551fa542e87ba58c0b493" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bshipcmd">
-		<description>Battleship Commander</description>
-		<year>1980</year>
-		<publisher>Quality Software</publisher>
-		<info name="usage" value="Requires a 13-sector drive but otherwise runs on any Apple II with 48K." />
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2022-02-24 -->
-		<!--"Battleship Commander" is a 1980 strategy game developed by Erik Kilk and Matthew Jew, and distributed by Quality Software. It requires a 13-sector drive but otherwise runs on any Apple II with 48K.-->
-
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="234809">
-				<rom name="battleship commander.woz" size="234809" crc="e0dbe815" sha1="4e72e84cdf56f7d710dd56c21148019ce3ad46f1" />
 			</dataarea>
 		</part>
 	</software>
@@ -19168,52 +18695,6 @@ license:CC0-1.0
 			<feature name="part_id" value="Side B" />
 			<dataarea name="flop" size="234786">
 				<rom name="columns iie side b.woz" size="234786" crc="5960a425" sha1="1578ecd41c8e3fb8d7a453b18e65fdc0e71101cf" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wzdry0981">
-		<description>Wizardry: Proving Grounds of the Mad Overload (version 05-SEP-81)</description>
-		<year>1981</year>
-		<publisher>Sir-Tech</publisher>
-		<info name="usage" value="Requires a 48K Apple ][ or later." />
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2022-04-02 redump: 2022-05-10 to fix critical data corruption in the saved characters roster that entirely prevented playing.-->
-		<!--"Wizardry: Proving Grounds of the Mad Overload" is a 1981 roleplaying game developed by Andrew Greenberg and Robert Woodhead, and distributed by Sir-Tech. This version is dated 05-SEP-81, the earliest known version. It runs on any Apple ][ with 48K.-->
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A - Scenario disk" />
-			<dataarea name="flop" size="234881">
-				<rom name="wizardry- proving grounds of the mad overlord v05-sep-81 side a - scenario.woz" size="234881" crc="0e955f2e" sha1="47dd791b826c1d952ca78fe209fafd5f6fc30ed8" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B - Boot disk" />
-			<dataarea name="flop" size="234846">
-				<rom name="wizardry- proving grounds of the mad overlord v05-sep-81 side b - boot.woz" size="234846" crc="a7d80c8c" sha1="1f1ad5cb198a29e1934a744901ae71cccc82e300" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wzdry1281">
-		<description>Wizardry: Proving Grounds of the Mad Overload (version 01-DEC-81)</description>
-		<year>1981</year>
-		<publisher>Sir-Tech</publisher>
-		<info name="usage" value="Requires a 48K Apple ][ or later." />
-		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
-		<!-- Dump released: 2022-04-02 -->
-		<!--"Wizardry: Proving Grounds of the Mad Overload" is a 1981 roleplaying game developed by Andrew Greenberg and Robert Woodhead, and distributed by Sir-Tech. This version is dated 01-DEC-81. It runs on any Apple ][ with 48K.-->
-
-		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Side A - Master scenario disk" />
-			<dataarea name="flop" size="234884">
-				<rom name="wizardry- proving grounds of the mad overlord v01-dec-81 side a - master scenario.woz" size="234884" crc="caae12b7" sha1="78b15dbc13bcf61cf9f44a31d3478a565b010b0f" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Side B - Boot disk" />
-			<dataarea name="flop" size="234873">
-				<rom name="wizardry- proving grounds of the mad overlord v01-dec-81 side b - boot.woz" size="234873" crc="0a1eb2ab" sha1="36d42cdb06b5b7452c05ddccf5d6aa8182bdd790" />
 			</dataarea>
 		</part>
 	</software>
@@ -25060,6 +24541,30 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="weekchng">
+		<description>A Week That Changed The World</description>
+		<year>1986</year>
+		<publisher>Educational Publishing Concepts</publisher>
+		<info name="developer" value="Baker Book House"/>
+		<info name="programmer" value="V. Gilbert Beers and Ronald Beers" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-06-18-->
+		<!--educational program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A" />
+			<dataarea name="flop" size="234815">
+				<rom name="a week that changed the world side a.woz" size="234815" crc="e33abc2d" sha1="1cae09d816d7d83e01e4499c76a10bad8a61a618" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B" />
+			<dataarea name="flop" size="234848">
+				<rom name="a week that changed the world side b.woz" size="234848" crc="f7b8c847" sha1="cff76d47ced8cd0e92d7e271bbfc010432b18738" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="acedet_525" cloneof="acedet">
 		<description>Ace Detective (version 1987)</description>
 		<year>1987</year>
@@ -25136,6 +24641,22 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234734">
 				<rom name="advance to boardwalk.woz" size="234734" crc="a7b89d2d" sha1="8cb709d0f8b0f3b6c7a1b6b3c074b944207dda19" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="advtime">
+		<description>Adventure in Time</description>
+		<year>1981</year>
+		<publisher>Phoenix Software</publisher>
+		<info name="programmer" value="Paul L. Berker" />
+		<info name="usage" value="Requires a 48K Apple ][ or later." />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-07-07-->
+		<!--adventure game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234773">
+				<rom name="adventure in time.woz" size="234773" crc="8d6797b1" sha1="9f5f5f4e4e7435dc836b369a70e89ef07dc78d37" />
 			</dataarea>
 		</part>
 	</software>
@@ -25273,6 +24794,53 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="animate">
+		<description>Animate</description>
+		<year>1986</year>
+		<publisher>Brøderbund Software</publisher>
+		<info name="programmer" value="Steven Ohmert" />
+		<info name="usage" value="Requires a 128K Apple //e or later." />
+		<sharedfeat name="compatibility" value="A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-07-05-->
+		<!--graphics program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 Side A - Boot" />
+			<dataarea name="flop" size="234816">
+				<rom name="animate disk 1a - boot.woz" size="234816" crc="64bc3f61" sha1="8097819dc27357be8079f475f2f63917ca3f19c8" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 Side B - Program" />
+			<dataarea name="flop" size="234819">
+				<rom name="animate disk 1b - program.woz" size="234819" crc="884cb3ee" sha1="44409aaaecd66747aa2550613dec1efcd57b37c0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 Side A - Animation Library" />
+			<dataarea name="flop" size="234829">
+				<rom name="animate disk 2a - animation library.woz" size="234829" crc="dd72fdfb" sha1="1cf308ffc2c789a2c9662ab790167453fbf04dd4" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 Side B - Background Library" />
+			<dataarea name="flop" size="234830">
+				<rom name="animate disk 2b - background library.woz" size="234830" crc="fac51096" sha1="306e0a59e9fbd3bd44a4c275b715fad698ff7d51" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3 Side A - Demonstration Show Disk" />
+			<dataarea name="flop" size="234835">
+				<rom name="animate disk 3a - demonstration show disk.woz" size="234835" crc="c6edef3d" sha1="c8f707ee43704a4468a3e9987404813efc4f2907" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3 Side B - Programmer's Aids" />
+			<dataarea name="flop" size="234829">
+				<rom name="animate disk 3b - programmer's aids.woz" size="234829" crc="9dcc9915" sha1="9188dff8c25e046188fd3bc602e21583eb54ce4a" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="arizmix10_525" cloneof="arizmix">
 		<description>Arizona Mix (A-335 version 1.0)</description>
 		<year>1993</year>
@@ -25327,6 +24895,22 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="233449">
 				<rom name="arkanoid.woz" size="233449" crc="ed2ce549" sha1="421e17ac0441f3a513846eda613b234b4b1d756f" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="astinspc">
+		<description>Asteroids in Space</description>
+		<year>1980</year>
+		<publisher>Quality Software</publisher>
+		<info name="programmer" value="Bruce Wallace" />
+		<info name="usage" value="Runs on any Apple II with 32K and a 13-sector drive." />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2020-06-06-->
+		<!--action game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="241425">
+				<rom name="asteroids in space.woz" size="241425" crc="b4e281cb" sha1="a0870556a5e29e79427c4528ff739472a75b6e99" />
 			</dataarea>
 		</part>
 	</software>
@@ -25486,6 +25070,72 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="bagtrks2v20" cloneof="bagtrks2">
+		<description>Bag of Tricks 2 (version 2.0)</description>
+		<year>1985</year>
+		<publisher>Quality Software</publisher>
+		<info name="programmer" value="Don Worth and Peter Lechner" />
+		<info name="usage" value="Requires a 64K Apple ][+ or later." />
+		<info name="version" value="2.0" />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-07-05-->
+		<!--disk utility program-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234837">
+				<rom name="bag of tricks 2.0.woz" size="234837" crc="1f937c7a" sha1="e2e8e2320acd3c2857859a2d42bd9f013e6a479f" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bagtrks2">
+		<description>Bag of Tricks 2 (version 2.1)</description>
+		<year>1987</year>
+		<publisher>Quality Software</publisher>
+		<info name="programmer" value="Don Worth and Peter Lechner" />
+		<info name="usage" value="Requires a 64K Apple ][+ or later." />
+		<info name="version" value="2.1" />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2020-06-06-->
+		<!--disk utility program-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="241471">
+				<rom name="bag of tricks v2.1.woz" size="241471" crc="fcac8d4e" sha1="e879a1875a6dc3263bd0d239e130c397458b841e" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="batsblfr">
+		<description>Bats in the Belfry</description>
+		<year>1983</year>
+		<publisher>Phoenix Software</publisher>
+		<info name="programmer" value="Samuel Moore" />
+		<info name="usage" value="Requires a 48K Apple ][ or later." />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2020-12-07-->
+		<!--action game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="121627">
+				<rom name="bats in the belfry.woz" size="121627" crc="b42681ec" sha1="84d8e3a1cc653faee017a319decdd87d353d7c36" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bshipcmd">
+		<description>Battleship Commander</description>
+		<year>1980</year>
+		<publisher>Quality Software</publisher>
+		<info name="programmer" value="Erik Kilk and Matthew Jew" />
+		<info name="usage" value="Requires a 13-sector drive but otherwise runs on any Apple II with 48K." />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2022-02-24-->
+		<!--strategy game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234809">
+				<rom name="battleship commander.woz" size="234809" crc="e0dbe815" sha1="4e72e84cdf56f7d710dd56c21148019ce3ad46f1" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="beachlnd">
 		<description>Beach Landing</description>
 		<year>1984</year>
@@ -25530,6 +25180,39 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234760">
 				<rom name="beach-head ii.woz" size="234760" crc="b28bb733" sha1="58b13942ffd570223f755f867cf9ba76fc3c689d" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bapmnr">
+		<description>Beneath Apple Manor (version 1.1 30-JUL-1979)</description>
+		<year>1979</year>
+		<publisher>The Software Factory</publisher>
+		<info name="programmer" value="Don Worth" />
+		<info name="usage" value="Requires a 32K Apple ][ with Integer BASIC in ROM." />
+		<info name="version" value="1.1 30-JUL-1979" />
+		<sharedfeat name="compatibility" value="A2" />
+		<!--Dump released: 2022-02-18-->
+		<!--adventure game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234800">
+				<rom name="beneath apple manor.woz" size="234800" crc="95533df3" sha1="5db4eb223f9daca74d1b06cfbe7593023818ac14" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bapmnrse">
+		<description>Beneath Apple Manor: The Special Edition</description>
+		<year>1982</year>
+		<publisher>Quality Software</publisher>
+		<info name="programmer" value="Don Worth" />
+		<info name="usage" value="Requires a 48K Apple ][ or later." />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2022-02-11-->
+		<!--adventure game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234826">
+				<rom name="beneath apple manor- the special edition.woz" size="234826" crc="69ad7676" sha1="15992953d222818d96a8a2e87854ebdf32fd62e2" />
 			</dataarea>
 		</part>
 	</software>
@@ -27232,6 +26915,29 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="cryptmed">
+		<description>Crypt of Medea</description>
+		<year>1983</year>
+		<publisher>Sir-Tech Software</publisher>
+		<info name="programmer" value="Allan Lamb and Arthur Britto II" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2022-02-11-->
+		<!--adventure game-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A" />
+			<dataarea name="flop" size="234815">
+				<rom name="crypt of medea side a.woz" size="234815" crc="aad35539" sha1="041043080b9c2332b2401a6444cb827bf38da4ad" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B" />
+			<dataarea name="flop" size="234815">
+				<rom name="crypt of medea side b.woz" size="234815" crc="406de5eb" sha1="45f9f6695c6466c770d6b4a27d2e80b75d7b95f9" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="cryptqst_525" cloneof="cryptqst">
 		<description>CryptoQuest (A-340 version 1.0)</description>
 		<year>1993</year>
@@ -27689,6 +27395,22 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="daviddos">
+		<description>David-DOS</description>
+		<year>1982</year>
+		<publisher>David Data</publisher>
+		<info name="programmer" value="David Weston" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-07-06-->
+		<!--disk utility program-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234821">
+				<rom name="david-dos.woz" size="234821" crc="da182438" sha1="1bff9a48a799eb9528bbda86540b909839eda0b4" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="desktzoo">
 		<description>Desktop Zoo</description>
 		<year>1989</year>
@@ -27871,6 +27593,30 @@ license:CC0-1.0
 			<feature name="part_id" value="Disk 2 - Stat Disk" />
 			<dataarea name="flop" size="234829">
 				<rom name="earl weaver baseball 1988 baseball stat disk.woz" size="234829" crc="5318c670" sha1="d27dab23ec3962c6a3e4f5defea2e06fc6a4054f" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ehbible">
+		<description>Early Heroes of the Bible</description>
+		<year>1984</year>
+		<publisher>Educational Publishing Concepts</publisher>
+		<info name="developer" value="Baker Book House"/>
+		<info name="programmer" value="V. Gilbert Beers and Ronald Beers" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-06-18-->
+		<!--educational program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A" />
+			<dataarea name="flop" size="234811">
+				<rom name="early heroes of the bible side a.woz" size="234811" crc="a0261c5c" sha1="7f14be83ce3ead8ab6d847b38d932657548e0ebf" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B" />
+			<dataarea name="flop" size="234811">
+				<rom name="early heroes of the bible side b.woz" size="234811" crc="f4ac939a" sha1="c6aa85cea8ac3461cd48a988340e979aa7b813dc" />
 			</dataarea>
 		</part>
 	</software>
@@ -28066,6 +27812,38 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1296174">
 				<rom name="fay- the word hunter 800k.woz" size="1296174" crc="27a0bb82" sha1="299e38511e1f809c28f377d755ebec1aaf747686" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="federat">
+		<description>Federation</description>
+		<year>1982</year>
+		<publisher>Avant-Garde Creations</publisher>
+		<info name="developer" value="Avant-Garde Creations" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-06-04-->
+		<!--arcade game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="241422">
+				<rom name="federation.woz" size="241422" crc="7548b07d" sha1="c345b0eb3f9b47a2a6eea29aa22e000c726579cd" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="galattk">
+		<description>Galactic Attack</description>
+		<year>1980</year>
+		<publisher>Sir-Tech Software</publisher>
+		<info name="programmer" value="Robert J. Woodhead" />
+		<info name="usage" value="Requires a 64K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-12-14-->
+		<!--simulation game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234790">
+				<rom name="galactic attack.woz" size="234790" crc="013efc71" sha1="68975194ff1b597ed4e2773649bb8880d050a1cd" />
 			</dataarea>
 		</part>
 	</software>
@@ -28278,6 +28056,30 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="228095">
 				<rom name="international hockey.woz" size="228095" crc="c9c4e6f4" sha1="539b9dcb39c8a3e762dff56fd93c54a826bc6675" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="israelgy">
+		<description>Israel's Golden Years</description>
+		<year>1986</year>
+		<publisher>Educational Publishing Concepts</publisher>
+		<info name="developer" value="Baker Book House" />
+		<info name="programmer" value="V. Gilbert Beers and Ronald Beers" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-06-18-->
+		<!--educational program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A" />
+			<dataarea name="flop" size="234840">
+				<rom name="israel's golden years side a.woz" size="234840" crc="b3a72fa5" sha1="44d161c3c074d661681c4373f86afecf404e94b5" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B" />
+			<dataarea name="flop" size="234839">
+				<rom name="israel's golden years side b.woz" size="234839" crc="fbc40b04" sha1="39846b51f0bf46d53e7d3c79812310b7398f7625" />
 			</dataarea>
 		</part>
 	</software>
@@ -29004,6 +28806,22 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="metinspc">
+		<description>Meteoroids in Space</description>
+		<year>1981</year>
+		<publisher>Quality Software</publisher>
+		<info name="programmer" value="Bruce Wallace" />
+		<info name="usage" value="Requires a 48K Apple ][ or later." />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2020-04-08-->
+		<!--action game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="48405">
+				<rom name="meteoroids in space.woz" size="48405" crc="7beb3c05" sha1="61cdb1028a091a7bd85ac636f1f29087b57b4426" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="minr2049">
 		<description>Miner 2049er</description>
 		<year>1982</year>
@@ -29101,6 +28919,30 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="233476">
 				<rom name="monster smash.woz" size="233476" crc="a2a01373" sha1="a0aeea2f9b66a1ff725fa5e49a3c5398a3be1273" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="moseslhp">
+		<description>Moses Leads His People</description>
+		<year>1986</year>
+		<publisher>Educational Publishing Concepts</publisher>
+		<info name="developer" value="Baker Book House" />
+		<info name="programmer" value="V. Gilbert Beers and Ronald Beers" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-07-04-->
+		<!--educational program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A" />
+			<dataarea name="flop" size="234808">
+				<rom name="moses leads his people side a.woz" size="234808" crc="37fe4e47" sha1="589c0e20de055605014f1d54edf3b92696fbbd81" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B" />
+			<dataarea name="flop" size="234808">
+				<rom name="moses leads his people side b.woz" size="234808" crc="77c338ad" sha1="25963f6c92f719dd6d67e39e4a2571aca8dfb93d" />
 			</dataarea>
 		</part>
 	</software>
@@ -29263,6 +29105,30 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="paulmsj">
+		<description>Paul's Missionary Journeys</description>
+		<year>1986</year>
+		<publisher>Educational Publishing Concepts</publisher>
+		<info name="developer" value="Baker Book House" />
+		<info name="programmer" value="V. Gilbert Beers and Ronald Beers" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-07-04-->
+		<!--educational program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A" />
+			<dataarea name="flop" size="234844">
+				<rom name="paul's missionary journeys side a.woz" size="234844" crc="344202f1" sha1="d3bfde5d32882c99aa34eaf9b1239cd5c28cb342" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B" />
+			<dataarea name="flop" size="241468">
+				<rom name="paul's missionary journeys side b.woz" size="241468" crc="8c8339b0" sha1="7b0bfe4d5f3df89163e08af6424f43902ad15e6a" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="petshop">
 		<description>Pet Shop (A-347 version 1.0) (800K 3.5")</description>
 		<year>1994</year>
@@ -29317,6 +29183,61 @@ license:CC0-1.0
 			<feature name="part_id" value="Side B" />
 			<dataarea name="flop" size="234796">
 				<rom name="press your luck side b.woz" size="234796" crc="7f400b08" sha1="0f45957be53ff84c9e43ae854d8997c9e8569194" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="popd" cloneof="pop">
+		<description>Prince of Persia (interactive demo)</description>
+		<year>1989</year>
+		<publisher>Brøderbund Software</publisher>
+		<info name="programmer" value=" Jordan Mechner" />
+		<info name="usage" value="Requires a 128K Apple //e or later." />
+		<sharedfeat name="compatibility" value="A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-07-04-->
+		<!--action game demo-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234834">
+				<rom name="prince of persia- interactive demo disk.woz" size="234834" crc="7375b848" sha1="c9489252c3b10c5d77df9ea8d5a45e9800e6fb12" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pop_525" cloneof="pop">
+		<description>Prince of Persia</description>
+		<year>1989</year>
+		<publisher>Brøderbund Software</publisher>
+		<info name="programmer" value=" Jordan Mechner" />
+		<info name="usage" value="Requires a 128K Apple //e or later." />
+		<sharedfeat name="compatibility" value="A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2018-09-14-->
+		<!--action game-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A" />
+			<dataarea name="flop" size="233481">
+				<rom name="prince of persia side a.woz" size="233481" crc="a3820127" sha1="bf7c7c03fcc93b989a8a7e566ec711888553a9de" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B" />
+			<dataarea name="flop" size="233481">
+				<rom name="prince of persia side b.woz" size="233481" crc="6de94d52" sha1="931e264563390d1e76cef9a7db31492643f45b49" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pop">
+		<description>Prince of Persia (800K 3.5")</description>
+		<year>1989</year>
+		<publisher>Brøderbund Software</publisher>
+		<info name="programmer" value=" Jordan Mechner" />
+		<info name="usage" value="Requires an Apple IIgs, Apple //c+, or 128K enhanced Apple //e with a compatible drive controller card." />
+		<sharedfeat name="compatibility" value="A2EE,A2C,A2GS" />
+		<!--Dump released: 2021-06-30-->
+		<!--action game-->
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1297161">
+				<rom name="prince of persia 800k.woz" size="1297161" crc="e166d56a" sha1="d9558d25a3d3d91542f32abba9e6b0e2f2c75b09" />
 			</dataarea>
 		</part>
 	</software>
@@ -29697,6 +29618,38 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="rescraid">
+		<description>Rescue Raiders</description>
+		<year>1984</year>
+		<publisher>Sir-Tech Software</publisher>
+		<info name="programmer" value="Arthur Britto II and Greg Hale" />
+		<info name="usage" value="Requires a 64K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2018-08-16-->
+		<!--action game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="233518">
+				<rom name="rescue raiders.woz" size="233518" crc="f2f5bf46" sha1="4ab4e39d593e35c2b1eebc2b5bd1c51b024ef1fb" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="rtnheracq">
+		<description>Return of Heracles (Quality Software)</description>
+		<year>1983</year>
+		<publisher>Quality Software</publisher>
+		<info name="programmer" value="Stuart Smith" />
+		<info name="usage" value="Requires a 48K Apple ][ or later." />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-08-02-->
+		<!--adventure game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="235508">
+				<rom name="return of heracles.woz" size="235508" crc="50be7d16" sha1="24e16ab619a269e8cb47d0a3557aec1cf9c35d98" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="runforit">
 		<description>Run For It</description>
 		<year>1984</year>
@@ -29709,6 +29662,78 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234841">
 				<rom name="run for it.woz" size="234841" crc="5ac6ea0d" sha1="b7d99b23bd97a6ca0d54cd387ab60d361844af46" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="scitk">
+		<description>Science Toolkit</description>
+		<year>1985</year>
+		<publisher>Brøderbund Software</publisher>
+		<info name="programmer" value="Lauren Elliott, Scott Shumway, Gene Portwood, and Susan Meyers" />
+		<info name="usage" value="Requires a 64K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-07-05-->
+		<!--education program-->
+		<!--Includes master module and all three extension modules (originally sold separately: Speed & Motion, Earthquake Lab, and Body Lab.-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 - Master Module" />
+			<dataarea name="flop" size="221556">
+				<rom name="science toolkit- master module.woz" size="221556" crc="f1b5c545" sha1="265796d74227bc41f1e1f38b43b35173dff9521d" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 - Module 1: Speed &amp; Motion" />
+			<dataarea name="flop" size="234863">
+				<rom name="science toolkit module 1- speed and motion.woz" size="234863" crc="7e906be5" sha1="141579b27d2ca9528b3883b41a4a097828bad1b7" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3 - Module 2: Earthquake Lab" />
+			<dataarea name="flop" size="234863">
+				<rom name="science toolkit module 2- earthquake lab.woz" size="234863" crc="b5fdff05" sha1="a726e4bd793afb2bb78d70b67a23f4d4111d50ae" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4 - Module 3: Body Lab" />
+			<dataarea name="flop" size="234857">
+				<rom name="science toolkit module 3- body lab.woz" size="234857" crc="6aca00f8" sha1="aa1054faf877efa2c5719edef691bd6e235e3be4" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="scitkp">
+		<description>Science Toolkit Plus (version 2.0)</description>
+		<year>1989</year>
+		<publisher>Brøderbund Software</publisher>
+		<info name="programmer" value="Lauren Elliott, Scott Shumway, Michael Wise, Gene Portwood, Leigh Pforsich, and Susan Meyers" />
+		<info name="usage" value="Requires a 128K Apple //e or later." />
+		<info name="version" value="2.0" />
+		<sharedfeat name="compatibility" value="A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2020-06-05-->
+		<!--education program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 - Master module" />
+			<dataarea name="flop" size="241512">
+				<rom name="science toolkit plus v2.0 disk 1 - master module.woz" size="241512" crc="421c7922" sha1="9c4dbbb09ffcf609a4efe34be3fb6f0753c177b9" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 - Module 1: Speed &amp; Motion" />
+			<dataarea name="flop" size="241523">
+				<rom name="science toolkit plus v2.0 disk 2 - module 1- speed and motion.woz" size="241523" crc="1f24f501" sha1="69d51f5d5663a7a73eddadc81f110575adaeff7e" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3 - Module 2: Earthquake Lab" />
+			<dataarea name="flop" size="241523">
+				<rom name="science toolkit plus v2.0 disk 3 - module 2- earthquake lab.woz" size="241523" crc="01807b1e" sha1="d0cd79b8649110c16f8051fb552389463c94e18a" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4 - Module 3: Body Lab" />
+			<dataarea name="flop" size="241517">
+				<rom name="science toolkit plus v2.0 disk 4 - module 3- body lab.woz" size="241517" crc="7ede15f2" sha1="79f286fb54c3b806718fa21025c0fa10c720e8f7" />
 			</dataarea>
 		</part>
 	</software>
@@ -29878,6 +29903,30 @@ license:CC0-1.0
 			<feature name="part_id" value="Side B - Boot Disk" />
 			<dataarea name="flop" size="234855">
 				<rom name="s.a.g.a. 13 - sorcerer of claymorgue castle side b (boot).woz" size="234855" crc="12223084" sha1="54b12aecd5f80b7edc36f925552ec2a2810b5355" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="srchking">
+		<description>Searching for a King</description>
+		<year>1984</year>
+		<publisher>Educational Publishing Concepts</publisher>
+		<info name="developer" value="Baker Book House" />
+		<info name="programmer" value="V. Gilbert Beers and Ronald Beers" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-06-18-->
+		<!--educational program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A" />
+			<dataarea name="flop" size="234838">
+				<rom name="searching for a king side a.woz" size="234838" crc="11c9e72f" sha1="8e2d25a1e32c7f3a27111da2355812d129d51e97" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B" />
+			<dataarea name="flop" size="234838">
+				<rom name="searching for a king side b.woz" size="234838" crc="bfdf9f0f" sha1="4951c4d669723bf2ee61977ff79824ab6c45701b" />
 			</dataarea>
 		</part>
 	</software>
@@ -30630,6 +30679,54 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="boyjesus">
+		<description>The Boy Jesus</description>
+		<year>1984</year>
+		<publisher>Educational Publishing Concepts</publisher>
+		<info name="developer" value="Baker Book House" />
+		<info name="programmer" value="V. Gilbert Beers and Ronald Beers" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-07-04-->
+		<!--educational program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A" />
+			<dataarea name="flop" size="234831">
+				<rom name="the boy jesus side a.woz" size="234831" crc="eaff57c2" sha1="33b198cc5b8b47f6f1e6d8ee01c297c24177ba65" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B" />
+			<dataarea name="flop" size="234831">
+				<rom name="the boy jesus side b.woz" size="234831" crc="0a0e0657" sha1="0814bc10625d2ee80cd849207a448f87042758bd" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="earlychr">
+		<description>The Early Church</description>
+		<year>1984</year>
+		<publisher>Educational Publishing Concepts</publisher>
+		<info name="developer" value="Baker Book House" />
+		<info name="programmer" value="V. Gilbert Beers and Ronald Beers" />
+		<info name="usage" value="Requires a 48K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-07-04-->
+		<!--educational program-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A" />
+			<dataarea name="flop" size="234802">
+				<rom name="the early church side a.woz" size="234802" crc="92f64278" sha1="15afb0283d02c1835d79ca3a8deef16397f39117" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B" />
+			<dataarea name="flop" size="234802">
+				<rom name="the early church side b.woz" size="234802" crc="7159e04e" sha1="f985b18de65fd0f5be56792aea58c4d6584f816c" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="theinsti">
 		<description>The Institute</description>
 		<year>1983</year>
@@ -30649,6 +30746,22 @@ license:CC0-1.0
 			<feature name="part_id" value="Side B" />
 			<dataarea name="flop" size="234818">
 				<rom name="the institute side b.woz" size="234818" crc="90777e40" sha1="2f7c9d6ca142df55fe2b3c6d447571190fd07d88" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="queenphb">
+		<description>The Queen of Phobos</description>
+		<year>1982</year>
+		<publisher>Phoenix Software</publisher>
+		<info name="programmer" value="William R. Crawford, Paul L. Berker, Dav Holle and Adrian Ferret" />
+		<info name="usage" value="Requires a 48K Apple ][ or later." />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-06-07-->
+		<!--adventure game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="181581">
+				<rom name="the queen of phobos.woz" size="181581" crc="6c31a42a" sha1="7617ff8f126edaab1daf8954ea7d6cac07bb1e77" />
 			</dataarea>
 		</part>
 	</software>
@@ -30804,6 +30917,22 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="trapshoot">
+		<description>Trapshoot</description>
+		<year>1980</year>
+		<publisher>On-Line Systems</publisher>
+		<info name="programmer" value=" Kieth Yilt" />
+		<info name="usage" value="Requires a 13-sector drive but otherwise runs on any Apple II with 48K." />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-06-16-->
+		<!--arcade game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="228128">
+				<rom name="trapshoot.woz" size="228128" crc="2f88ae9a" sha1="7082d68d26baec57ca99b10d23674c0030863fb9" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="trlspmth">
 		<description>Troll Sports Math: Math Word Problems for Grades 4 to 6 (800K 3.5")</description>
 		<year>1991</year>
@@ -30911,6 +31040,23 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234765">
 				<rom name="war (adventure international).woz" size="234765" crc="79dbdd18" sha1="059f29a61f8d47a45a16b66c4634eed837860805" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wheeldeal">
+		<description>Wheeler Dealers (DOS 3.3 conversion)</description>
+		<year>1978</year>
+		<publisher>Speakeasy Software</publisher>
+		<info name="programmer" value="Danielle Bunten Berry" />
+		<info name="usage" value="Requires a 48K Apple ][ or later. Shipped with special hardware controllers, but joystick or paddeles can be used by defining directional movement (not button press) to each player." />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-05-09-->
+		<!--This is a digitization of the original cassette, and a non-original conversion to a bootable disk.-->
+		<!--simulation game-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="143360">
+				<rom name="wheeler dealers dos 3.3 conversion.dsk" size="143360" crc="adc3c491" sha1="be1b6cfcb0d39c13d8a945b9746f392a996a5670" />
 			</dataarea>
 		</part>
 	</software>
@@ -31196,13 +31342,13 @@ license:CC0-1.0
 		<!--Dump released: 2024-04-19-->
 		<!--educational game-->
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk  Side " />
+			<feature name="part_id" value="Side A" />
 			<dataarea name="flop" size="234890">
 				<rom name="where in the world is carmen sandiego v2.1 side a.woz" size="234890" crc="ebb9b426" sha1="a96cc5bef8344c02c5d39115cae165cd69ca9666" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk  Side " />
+			<feature name="part_id" value="Side B" />
 			<dataarea name="flop" size="234890">
 				<rom name="where in the world is carmen sandiego v2.1 side b.woz" size="234890" crc="e66e7010" sha1="afaf0ca540bca34c7c8e53a86ca3c4302441d3f3" />
 			</dataarea>
@@ -31375,6 +31521,262 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="wizrdry1v0981" cloneof="wizrdry1">
+		<description>Wizardry: Proving Grounds of the Mad Overload (version 05-SEP-81)</description>
+		<year>1981</year>
+		<publisher>Sir-Tech Software</publisher>
+		<info name="programmer" value="Andrew Greenberg and Robert Woodhead" />
+		<info name="usage" value="Requires a 48K Apple ][ or later. The disks must be loaded as read-only, outside of software list." />
+		<info name="version" value="05-SEP-81" />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2022-04-02. Redumped: 2022-05-10 to fix critical data corruption in the saved characters roster that entirely prevented playing.-->
+		<!--roleplaying game-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A - Scenario disk" />
+			<dataarea name="flop" size="234881">
+				<rom name="wizardry- proving grounds of the mad overlord v05-sep-81 side a - scenario.woz" size="234881" crc="0e955f2e" sha1="47dd791b826c1d952ca78fe209fafd5f6fc30ed8" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B - Boot disk" />
+			<dataarea name="flop" size="234846">
+				<rom name="wizardry- proving grounds of the mad overlord v05-sep-81 side b - boot.woz" size="234846" crc="a7d80c8c" sha1="1f1ad5cb198a29e1934a744901ae71cccc82e300" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wizrdry1v1281" cloneof="wizrdry1">
+		<description>Wizardry: Proving Grounds of the Mad Overload (version 01-DEC-81)</description>
+		<year>1981</year>
+		<publisher>Sir-Tech Software</publisher>
+		<info name="programmer" value="Andrew Greenberg and Robert Woodhead" />
+		<info name="usage" value="Requires a 48K Apple ][ or later. The disks must be loaded as read-only, outside of software list." />
+		<info name="version" value="01-DEC-81" />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2022-04-02-->
+		<!--roleplaying game-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A - Master scenario disk" />
+			<dataarea name="flop" size="234884">
+				<rom name="wizardry- proving grounds of the mad overlord v01-dec-81 side a - master scenario.woz" size="234884" crc="caae12b7" sha1="78b15dbc13bcf61cf9f44a31d3478a565b010b0f" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B - Boot disk" />
+			<dataarea name="flop" size="234873">
+				<rom name="wizardry- proving grounds of the mad overlord v01-dec-81 side b - boot.woz" size="234873" crc="0a1eb2ab" sha1="36d42cdb06b5b7452c05ddccf5d6aa8182bdd790" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wizrdry1v20" cloneof="wizrdry1">
+		<description>Wizardry: Proving Grounds of the Mad Overload (version 2.0 01-JAN-82)</description>
+		<year>1981</year>
+		<publisher>Sir-Tech Software</publisher>
+		<info name="programmer" value="Andrew Greenberg and Robert Woodhead" />
+		<info name="usage" value="Requires a 48K Apple ][ or later. The disks must be loaded as read-only, outside of software list." />
+		<info name="version" value="2.0 01-JAN-82" />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2024-06-04-->
+		<!--roleplaying game-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A - Master scenario disk" />
+			<dataarea name="flop" size="234937">
+				<rom name="wizardry- proving grounds of the mad overlord v2.0 01-jan-82 side a - scenario master disk.woz" size="234937" crc="8a92f261" sha1="b90ced6408a7e15cd177c0aaead773d6da417093" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B - Boot disk" />
+			<dataarea name="flop" size="234896">
+				<rom name="wizardry- proving grounds of the mad overlord v2.0 01-jan-82 side b - boot disk.woz" size="234896" crc="d9c55106" sha1="60bcd0d81ad3fe4a7f6cae4d94e71d5cb01cf3e7" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wizrdry1">
+		<description>Wizardry: Proving Grounds of the Mad Overlord (version 2.1)</description>
+		<year>1981</year>
+		<publisher>Sir-Tech Software</publisher>
+		<info name="programmer" value="Andrew Greenberg and Robert Woodhead" />
+		<info name="usage" value="Requires a 48K Apple ][ or later. The disks must be loaded as read-only, outside of software list." />
+		<info name="version" value="2.1" />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2020-01-11-->
+		<!--roleplaying game-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 - Boot disk" />
+			<dataarea name="flop" size="234829">
+				<rom name="wizardry - proving grounds of the mad overlord v2.1 - boot disk.woz" size="234829" crc="29dfa2a6" sha1="6c0416fb7cb91bde8da05df77ecfc5f7b7c645f1" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 - Scenario master disk" />
+			<dataarea name="flop" size="234829">
+				<rom name="wizardry - proving grounds of the mad overlord v2.1 - scenario master disk.woz" size="234829" crc="7951ca26" sha1="604a416c50ca6fccb39c11142f8be00d51ce627c" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wizrdry2">
+		<description>Wizardry II: The Knight of Diamonds (version PV3S2V1/10-MAR-82)</description>
+		<year>1982</year>
+		<publisher>Sir-Tech Software</publisher>
+		<info name="programmer" value="Andrew Greenberg and Robert Woodhead" />
+		<info name="usage" value="Requires a 48K Apple ][ or later." />
+		<info name="version" value="PV3S2V1/10-MAR-82" />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2020-01-11-->
+		<!--roleplaying game-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1 - Boot disk" />
+			<dataarea name="flop" size="234854">
+				<rom name="wizardry ii - knight of diamonds - boot disk.woz" size="234854" crc="16a794a8" sha1="db098051302810edb8aa5c56c8a3dd7cc9ab0772" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2 - Master scenario disk" />
+			<dataarea name="flop" size="234865">
+				<rom name="wizardry ii - knight of diamonds - master scenario disk.woz" size="234865" crc="ac3a27d9" sha1="59f7c602c6347c732ddd8222d667622bf8749a29" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wizrdry3">
+		<description>Wizardry III: Legacy of Llylgamyn (version 4, 20-Aug-1983 update)</description>
+		<year>1983</year>
+		<publisher>Sir-Tech Software</publisher>
+		<info name="programmer" value="Andrew Greenberg and Robert Woodhead" />
+		<info name="usage" value="Requires a 64K Apple ][+ or later." />
+		<info name="version" value="Version 4, 20-Aug-1983 update" />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-04-08. Redumped: 2023-09-12. Redumped: 2024-05-19 with a cleaner scenario disk and no deleted characters.-->
+		<!--roleplaying game-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A - Master Scenario disk" />
+			<dataarea name="flop" size="234928">
+				<rom name="wizardry iii side a - master scenario disk.woz" size="234928" crc="30d77894" sha1="64d65a39b24a02d1f127db1666a6f3dcd99176f7" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B - Boot disk" />
+			<dataarea name="flop" size="234917">
+				<rom name="wizardry iii side b - boot.woz" size="234917" crc="83b4938b" sha1="0191645b5a833042e47c75ca7544225f3b3cdbab" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wizrdry4">
+		<description>Wizardry IV: The Return of Werdna</description>
+		<year>1987</year>
+		<publisher>Sir-Tech Software</publisher>
+		<info name="programmer" value="Andrew Greenberg, Robert Woodhead, and Roe R. Adams III" />
+		<info name="usage" value="Requires a 64K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-12-14-->
+		<!--roleplaying game-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Side A" />
+			<dataarea name="flop" size="234833">
+				<rom name="wizardry iv - the return of werdna side a.woz" size="234833" crc="0c6ac6a0" sha1="f465fb3b88eb38c197e24da1ae1962f6d0a58cd9" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Side B" />
+			<dataarea name="flop" size="234833">
+				<rom name="wizardry iv - the return of werdna side b.woz" size="234833" crc="179d1324" sha1="7bff6956d76129cc82d5e5ac6ba30d8806054bdf" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Side C" />
+			<dataarea name="flop" size="234833">
+				<rom name="wizardry iv - the return of werdna side c.woz" size="234833" crc="0493f3d5" sha1="22efb911669d42525a8e8ab35b2a34ca5ef2fdbd" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Side D" />
+			<dataarea name="flop" size="234833">
+				<rom name="wizardry iv - the return of werdna side d.woz" size="234833" crc="897eb0dc" sha1="21f4d0bd66d9d3a275678dbfc7cabb0cc023910f" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Side E" />
+			<dataarea name="flop" size="234833">
+				<rom name="wizardry iv - the return of werdna side e.woz" size="234833" crc="0fd25eba" sha1="eb07e89850635da688a5aa1d372eebbc19594c9e" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Side F" />
+			<dataarea name="flop" size="234833">
+				<rom name="wizardry iv - the return of werdna side f.woz" size="234833" crc="3a8a7986" sha1="a2684a58605af6ddbd6554bc99333ab3947dd4e9" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wizrdry5">
+		<description>Wizardry V: Heart of the Maelstrom</description>
+		<year>1988</year>
+		<publisher>Sir-Tech Software</publisher>
+		<info name="programmer" value="David W. Bradley and Andrew Greenberg" />
+		<info name="usage" value="Requires a 64K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2019-08-03-->
+		<!--roleplaying game-->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A" />
+			<dataarea name="flop" size="234780">
+				<rom name="wizardry v - heart of the maelstrom - a.woz" size="234780" crc="5c670ca8" sha1="93c05e54ea21596165fb158cfcceaa595ccd38e1" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B" />
+			<dataarea name="flop" size="234780">
+				<rom name="wizardry v - heart of the maelstrom - b.woz" size="234780" crc="1df4b66f" sha1="5ceb0e45e976111ad9d93a3feb1261ecd207465b" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C" />
+			<dataarea name="flop" size="234780">
+				<rom name="wizardry v - heart of the maelstrom - c.woz" size="234780" crc="60381a85" sha1="68ac614ea0bc52a690d35c9c6a64d425fe775202" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk D" />
+			<dataarea name="flop" size="234780">
+				<rom name="wizardry v - heart of the maelstrom - d.woz" size="234780" crc="2219894f" sha1="793a5074867136cfee53877113dcfda0c8590b6b" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk E" />
+			<dataarea name="flop" size="234780">
+				<rom name="wizardry v - heart of the maelstrom - e.woz" size="234780" crc="0e3d0d38" sha1="4a8a35ea50bf55da877ada12823971c7bb6779c4" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk F" />
+			<dataarea name="flop" size="234780">
+				<rom name="wizardry v - heart of the maelstrom - f.woz" size="234780" crc="f0b8294f" sha1="fbed529779a7f1dd70a416f83502dd4468c4d014" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Disk G" />
+			<dataarea name="flop" size="234780">
+				<rom name="wizardry v - heart of the maelstrom - g.woz" size="234780" crc="90979c2d" sha1="a9a115d8f68eefadfe360bb006239fa1773633a8" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_5_25">
+			<feature name="part_id" value="Disk H" />
+			<dataarea name="flop" size="234780">
+				<rom name="wizardry v - heart of the maelstrom - h.woz" size="234780" crc="571539b6" sha1="5db3ef18a7a03c775b16577624af3c3ef0637b97" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_5_25">
+			<feature name="part_id" value="Disk I" />
+			<dataarea name="flop" size="234780">
+				<rom name="wizardry v - heart of the maelstrom - i.woz" size="234780" crc="690af2ea" sha1="99fc3ba766182e331f8729672711a27b2bfe1509" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="wizcovlad">
 		<description>Wizimore: Catacombs of Vlad</description>
 		<year>1987</year>
@@ -31451,6 +31853,39 @@ license:CC0-1.0
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="234907">
 				<rom name="wizimore - the scarlet brotherhood of hsi ho.woz" size="234907" crc="c52237ac" sha1="aec32fb58baebb34cb1e0578189781fe958ed9bf" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wiziprint">
+		<description>Wiziprint (version 2.01 20-AUG-83)</description>
+		<year>1982</year>
+		<publisher>Sir-Tech Software</publisher>
+		<info name="programmer" value="Andrew Greenberg and Robert Woodhead" />
+		<info name="usage" value="Requires a 48K Apple ][ or later." />
+		<info name="version" value="2.01 20-AUG-83" />
+		<sharedfeat name="compatibility" value="A2,A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2020-01-13-->
+		<!--game utility program-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234840">
+				<rom name="wiziprint v2.01.woz" size="234840" crc="593dc847" sha1="d8628dbce3441820cbbd2ef4ac5a94421e514226" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wizplus">
+		<description>Wizplus</description>
+		<year>1982</year>
+		<publisher>Datamost</publisher>
+		<info name="programmer" value="Thomas A. Conner" />
+		<info name="usage" value="Requires a 64K Apple ][+ or later." />
+		<sharedfeat name="compatibility" value="A2P,A2E,A2EE,A2C,A2GS" />
+		<!--Dump released: 2020-03-02-->
+		<!--game utility program-->
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="234768">
+				<rom name="wizplus.woz" size="234768" crc="f60920a3" sha1="a640aec03dc8bddf434b43318ae80f54d5c1ab8c" />
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
* apple2_flop_orig: Added eighteen working items and updated one item.
* apple2_flop_orig: Improved metadata.
* apple2_flop_clcracked: Removed one imperfect crack.
* apple2_flop_clcracked: Improved metadata.
* apple2_cass: Added one not working item.

New working software list items (apple2_flop_orig.xml)
-------------------------------
A Week That Changed The World [4am, yesterbits, A-Noid]
Adventure in Time [4am, A-Noid]
Animate [4am, A-Noid]
Bag of Tricks 2 (version 2.0) [4am, A-Noid]
David-DOS [4am, A-Noid]
Early Heroes of the Bible [4am, yesterbits, A-Noid] 
Federation [4am, A-Noid]
Israel's Golden Years [4am, yesterbits, A-Noid]
Moses Leads His People [4am, yesterbits, A-Noid]
Paul's Missionary Journeys [4am, yesterbits, A-Noid] 
Prince of Persia (interactive demo) [4am, A2_Canada, A-Noid] 
Science Toolkit [4am, A-Noid]
Searching for a King [4am, yesterbits, A-Noid]
The Boy Jesus [4am, yesterbits, A-Noid]
The Early Church [4am, yesterbits, A-Noid]
Trapshoot [4am, A2_Canada, A-Noid]
Wheeler Dealers (DOS 3.3 conversion) [4am, A2_Canada, A-Noid] 
Wizardry: Proving Grounds of the Mad Overload (version 2.0 01-JAN-82) [4am, A2_Canada, A-Noid]

Redumped software list items (apple2_flop_orig.xml) 
-------------------------------
Wizardry III: Legacy of Llylgamyn (version 4, 20-Aug-1983 update) [4am, A-Noid]

New not working software list items (apple2_cass.xml) 
-------------------------------
Wheeler Dealers [4am, A2_Canada, A-Noid]

Removed (apple2_flop_clcracked.xml)
-------------------------------
Animate (imperfect clean crack)