### PR TITLE
nintendo/snesb.cpp: fill in missing DIP switches for several games, add continue counter init for Wild Guns

### DIFF
--- a/src/mame/nintendo/snes_m.cpp
+++ b/src/mame/nintendo/snes_m.cpp
@@ -727,7 +727,8 @@ uint8_t snes_state::snes_r_bank1(offs_t offset)
 			}
 			else
 			{
-				logerror("(PC=%06x) snes_r_bank1: Unmapped external chip read: %X\n", m_maincpu->pc(), offset);
+				if (!machine().side_effects_disabled())
+					logerror("(PC=%06x) snes_r_bank1: Unmapped external chip read: %X\n", m_maincpu->pc(), offset);
 				value = snes_open_bus_r();                              /* Reserved */
 			}
 		}
@@ -774,7 +775,8 @@ uint8_t snes_state::snes_r_bank2(offs_t offset)
 				}
 				else
 				{
-					logerror("(PC=%06x) snes_r_bank2: Unmapped external chip read: %X\n", m_maincpu->pc(), offset);
+					if (!machine().side_effects_disabled())
+						logerror("(PC=%06x) snes_r_bank2: Unmapped external chip read: %X\n", m_maincpu->pc(), offset);
 					value = snes_open_bus_r();                              /* Reserved */
 				}
 			}


### PR DESCRIPTION
This adds/verifies the DIP definition for all the SNES bootlegs that had a TODO for them. Defaults are based on the original SNES games, when possible, aside from Wild Guns (the original gives extends at 100k, which isn't an option with this bootleg, so the default is 400k to match current MAME behavior).

Also, Wild Guns now inits the continue counter on boot/reset, which is apparently supposed to be done by whatever's on the other side of the shared RAM. The only times it's initialized by the game itself are when the current counter hits zero or when a second player joins mid-game. I promoted it to working since I didn't encounter any other issues during a full playthrough.