### PR TITLE
spg2xx: Fix behavior of audio channel enable/stop flags

### DIFF
--- a/src/devices/machine/spg2xx_audio.h
+++ b/src/devices/machine/spg2xx_audio.h
@@ -338,6 +338,7 @@ protected:
 
 	uint16_t read_space(offs_t offset);
 
+	void start_channel(const uint32_t channel);
 	void stop_channel(const uint32_t channel);
 	bool advance_channel(const uint32_t channel);
 	bool fetch_sample(const uint32_t channel);


### PR DESCRIPTION
Summary of new behavior:
* Automatic stops sets channel stop flag while keeping channel enable flag unchanged (unlike current emulation where it's cleared). 
* Channel is only active (channel status flag true) when enable flag is true and stop flag is false.

This was verified in real hardware by running audio test roms on V.Smile. From what testing I have done so far, the changes don't really affect the games much if at all, but it should be technically more accurate.