### PR TITLE
spg2xx: Auto-increment wave address register when channel is playing

### DIFF
--- a/src/devices/machine/spg2xx_audio.h
+++ b/src/devices/machine/spg2xx_audio.h
@@ -112,6 +112,13 @@ protected:
 	uint32_t get_wave_addr(const offs_t channel) const { return ((uint32_t)get_wave_addr_high(channel) << 16) | m_audio_regs[(channel << 4) | AUDIO_WAVE_ADDR]; }
 	uint32_t get_loop_addr(const offs_t channel) const { return ((uint32_t)get_loop_addr_high(channel) << 16) | m_audio_regs[(channel << 4) | AUDIO_LOOP_ADDR]; }
 	uint32_t get_envelope_addr(const offs_t channel) const { return ((uint32_t)get_envelope_addr_high(channel) << 16) | m_audio_regs[(channel << 4) | AUDIO_ENVELOPE_ADDR]; }
+	void inc_wave_addr(const offs_t channel) { set_wave_addr(channel, get_wave_addr(channel) + 1); }
+	void set_wave_addr(const offs_t channel, uint32_t addr)
+	{
+		m_audio_regs[(channel << 4) | AUDIO_MODE] &= ~AUDIO_WADDR_HIGH_MASK;
+		m_audio_regs[(channel << 4) | AUDIO_MODE] |= (addr >> 16) & AUDIO_WADDR_HIGH_MASK;
+		m_audio_regs[(channel << 4) | AUDIO_WAVE_ADDR] = addr & 0xffff;
+	}
 
 	enum // at audio write offset 0x000 in spg2xx
 	{
@@ -354,7 +361,6 @@ protected:
 	uint16_t m_audio_ctrl_regs[0x400];
 	uint8_t m_sample_shift[16];
 	uint32_t m_sample_count[16];
-	uint32_t m_sample_addr[16];
 	double m_channel_rate[16];
 	double m_channel_rate_accum[16];
 	uint32_t m_rampdown_frame[16];


### PR DESCRIPTION
Also discovered from testing in real hardware (V.Smile). Probably not likely to noticeably affect games, but should still be technically more accurate.