### PR TITLE
dectalk: set sample rate of DAC output stream to 10 kHz

### DIFF
--- a/src/devices/bus/isa/dectalk.cpp
+++ b/src/devices/bus/isa/dectalk.cpp
@@ -226,4 +226,5 @@ void dectalk_isa_device::device_reset()
 	m_ctl = 0;
 	m_vol = 63;
 	m_bio = ASSERT_LINE;
+	m_dac->set_sample_rate(10000); // the DSP generates audio with a 10 kHz sample rate
 }

--- a/src/devices/sound/dac.h
+++ b/src/devices/sound/dac.h
@@ -108,6 +108,12 @@ public:
 	}
 	dac_device_base &set_output_range(stream_buffer::sample_t vref) { return set_output_range(-vref, vref); }
 
+	// set the sample rate
+	void set_sample_rate(u32 rate)
+	{
+		m_stream->set_sample_rate(rate);
+	}
+
 private:
 	// internal state
 	sound_stream *m_stream;


### PR DESCRIPTION
On the actual hardware, The DSP generates audio at a 10 kHz sample rate, so it makes sense to run the audio stream at this rate.