### PR TITLE
rs232: Add Mouse Systems serial mouse to default rs232 list.

### DIFF
--- a/src/devices/bus/rs232/rs232.cpp
+++ b/src/devices/bus/rs232/rs232.cpp
@@ -155,6 +155,7 @@ device_rs232_port_interface::~device_rs232_port_interface()
 
 
 #include "ie15.h"
+#include "hlemouse.h"
 #include "keyboard.h"
 #include "loopback.h"
 #include "mboardd.h"
@@ -179,6 +180,7 @@ void default_rs232_devices(device_slot_interface &device)
 	device.option_add("keyboard",      SERIAL_KEYBOARD);
 	device.option_add("loopback",      RS232_LOOPBACK);
 	device.option_add("mockingboard",  SERIAL_MOCKINGBOARD_D);
+	device.option_add("msystems_mouse",MSYSTEMS_HLE_SERIAL_MOUSE);
 	device.option_add("nss_tvi",       NSS_TVINTERFACE);
 	device.option_add("null_modem",    NULL_MODEM);
 	device.option_add("patch",         RS232_PATCH_BOX);

--- a/src/mame/dec/rainbow.cpp
+++ b/src/mame/dec/rainbow.cpp
@@ -3301,7 +3301,6 @@ void rainbow_base_state::rainbow_base(machine_config &config)
 
 	m_comm_port->option_add("microsoft_mouse", MSFT_HLE_SERIAL_MOUSE);
 	m_comm_port->option_add("logitech_mouse", LOGITECH_HLE_SERIAL_MOUSE);
-	m_comm_port->option_add("msystems_mouse", MSYSTEMS_HLE_SERIAL_MOUSE);
 	m_comm_port->set_default_option("logitech_mouse");
 
 	printer.set_default_option("printer");

--- a/src/mame/falco/falco500.cpp
+++ b/src/mame/falco/falco500.cpp
@@ -609,13 +609,11 @@ void falco500_state::falco500(machine_config &config)
 	porta.rxd_handler().set("sio", FUNC(z80sio_device::rxa_w));
 	porta.cts_handler().set("sio", FUNC(z80sio_device::ctsa_w));
 	porta.option_add("microsoft_mouse", MSFT_HLE_SERIAL_MOUSE);
-	porta.option_add("msystems_mouse", MSYSTEMS_HLE_SERIAL_MOUSE);
 
 	rs232_port_device &portb(RS232_PORT(config, "portb", default_rs232_devices, nullptr));
 	portb.rxd_handler().set("sio", FUNC(z80sio_device::rxb_w));
 	portb.cts_handler().set("sio", FUNC(z80sio_device::ctsb_w));
 	portb.option_add("microsoft_mouse", MSFT_HLE_SERIAL_MOUSE);
-	portb.option_add("msystems_mouse", MSYSTEMS_HLE_SERIAL_MOUSE);
 
 	SPEAKER(config, "mono").front_center();
 


### PR DESCRIPTION
This adds the support for using the Mouse Systems serial mouse in the QX-10 emulation. Valdocs supported this mouse when using programs like valpaint and valdraw.