### PR TITLE
new NOT WORKING machines (Disney Classic Handheld Karaoke Player)

### DIFF
--- a/hash/easy_karaoke_cart.xml
+++ b/hash/easy_karaoke_cart.xml
@@ -264,4 +264,56 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<!--
+	Bare Necessities                            The Jungle Book
+	Call Me, Beep Me                            Kim Possible
+	Hakuna Matata                               The Lion King
+	Home                                        Beauty and the Beast - Musical
+	Oo-De-Lally                                 Robin Hood
+	Put It Together                             Cinderella
+	So This Is Love                             Cinderella
+	What Dreams Are Made Of                     Lizzie McGuire
+	You Can Fly! You Can Fly! You Can Fly!      Peter Pan
+	You'll Be In My Heart                       Tarzan
+	-->
+	<software name="dkp2" supported="no">
+		<description>Disney Princess 10-Song Karaoke Cartridge II (DK-P2)</description>
+		<year>2003</year>
+		<publisher>IVL Technologies / Memcorp Inc / Disney</publisher>
+		<part name="cart" interface="easy_karaoke_cart">
+			<dataarea name="rom" size="0x80000">
+				<rom name="dk-p2.bin" size="0x80000" crc="d9d340c5" sha1="da906d7f22a2ea8bc62171c833985b81d71410a3" />
+			</dataarea>
+			<dataarea name="mcu" size="0x2000">
+				<rom name="IC89LV52A-24PQ.U1" size="0x2000" status="nodump" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!--
+	Cruella De Vil                              101 Dalmations
+	He's A Tramp                                Lady And The Tramp
+	I Wan'na Be Like You (The Monkey Song)      The Jungle Book
+	If I Didn't Have You                        Monsters Inc.
+	It's A Small World                          New York World's Fair
+	Open Your Eyes (To Love)                    Lizzie McGuire
+	Part Of Your World                          The Little Mermaid
+	Something There                             Beauty and the Beast
+	You've Got A Friend In Me                   Toy Story
+	Zip-A-Dee-Do-Dah                            Song of the South
+	-->
+	<software name="dkp3" supported="no">
+		<description>Disney Princess 10-Song Karaoke Cartridge III (DK-P3)</description>
+		<year>2003</year>
+		<publisher>IVL Technologies / Memcorp Inc / Disney</publisher>
+		<part name="cart" interface="easy_karaoke_cart">
+			<dataarea name="rom" size="0x80000">
+				<rom name="dk-p3.bin" size="0x80000" crc="2c9ec515" sha1="0efb1b7f513cc27084a3ef7c18290456f903decd" />
+			</dataarea>
+			<dataarea name="mcu" size="0x2000">
+				<rom name="IC89LV52A-24PQ.U1" size="0x2000" status="nodump" />
+			</dataarea>
+		</part>
+	</software>
+
 </softwarelist>

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -41939,6 +41939,7 @@ e100                            //
 
 @source:skeleton/easy_karaoke.cpp
 bkarast
+dks7000c
 easykara
 karams
 karatvst

--- a/src/mame/skeleton/easy_karaoke.cpp
+++ b/src/mame/skeleton/easy_karaoke.cpp
@@ -535,6 +535,43 @@ ROM_START( karams )
 	ROM_LOAD( "ics0300-a.u9", 0x000000, 0x800000, CRC(32a7a429) SHA1(ed219bc9201b45f67c5e7dbe3fb3db70823c59f0) )
 ROM_END
 
+/*
+The 'dks7000c' set has the following 25 songs built in.
+
+A Spoonful of Sugar                         Mary Poppins
+A Whole New World                           Disney
+Bare Necessities                            The Jungle Book
+Be Our Guest                                Beauty and the Beast
+Bibbidi-Bobbidi-Boo                         Disney
+Can You Feel The Love Tonight               The Lion King
+Chim Chim Cheree                            Disney
+Circle of Life                              The Lion King
+Colors of the Wind                          Pocahontas
+Cruella De Vil                              101 Dalmations
+Hakuna Matata                               The Lion King
+I Just Can't Wait To Be King                The Lion King
+I Wan'na Be Like You (The Monkey Song)      The Jungle Book
+I Won't Say (I'm In Love)                   Hercules
+I'll Make A Man Out Of You                  Mulan
+If I Didn't Have You                        Monsters Inc.
+It's A Small World                          New York World's Fair
+Kiss The Girl                               The Little Mermaid
+Part Of Your World                          The Little Mermaid
+Supercalifragilisticexpialidocious          Disney
+Yo Ho! (A Pirate's Life For Me)             Pirates of the Caribbean
+You Can Fly! You Can Fly! You Can Fly!      Peter Pan
+You'll Be In My Heart                       Tarzan
+You've Got A Friend In Me                   Toy Story
+Zip-A-Dee-Do-Dah                            Song of the South
+
+*/
+ROM_START( dks7000c )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASEFF )
+	ROM_LOAD( "dks7000c.bin", 0x000000, 0x400000, CRC(1c03e59e) SHA1(617d13a9b353fb648f10e136bc07c496a424b953) )
+ROM_END
+
+
+
 } // anonymous namespace
 
 // This is the original US release, there's no cartridge slot, but it has a NAND Flash inside, and in addition to 50 built-in songs, advertises
@@ -546,8 +583,10 @@ CONS( 2002, karatvsta,     karatvst,       0,      ivl_karaoke_base, ivl_karaoke
 CONS( 2002, mks4001,       0,              0,      ivl_karaoke_base, ivl_karaoke, ivl_karaoke_state, empty_init, "IVL Technologies (Memorex license)", "Star Singer Karaoke (MKS4001)", MACHINE_IS_SKELETON ) // 50 songs built in, appears to have around 54 downloads, including a test download
 
 // Bandai's Japanese release also lacks a cartridge slot, relying on downloads for additional songs. It also comes with a CD containing the PC-side software.  The external microphone design differs slightly.
-CONS( 2002, bkarast,       karatvst,       0,      ivl_karaoke_base, ivl_karaoke, ivl_karaoke_state, empty_init, "IVL Technologies (Bandai license)", "Karaoke Station (Japan)", MACHINE_IS_SKELETON )
+CONS( 2002, bkarast,       0,              0,      ivl_karaoke_base, ivl_karaoke, ivl_karaoke_state, empty_init, "IVL Technologies (Bandai license)", "Karaoke Station (Japan)", MACHINE_IS_SKELETON )
 
 // The European releases take cartridges rather than relying on a download service
-CONS( 2004, easykara,      karatvst,       0,      easy_karaoke, ivl_karaoke, easy_karaoke_cartslot_state, empty_init, "IVL Technologies (Easy Karaoke license)", "Easy Karaoke Groove Station (UK)", MACHINE_IS_SKELETON )
-CONS( 2003, karams,        karatvst,       0,      easy_karaoke, ivl_karaoke, easy_karaoke_cartslot_state, empty_init, "IVL Technologies (Lexibook license)",     "KaraokeMicro Star (France)", MACHINE_IS_SKELETON )
+CONS( 2004, easykara,      0,              0,      easy_karaoke, ivl_karaoke, easy_karaoke_cartslot_state, empty_init, "IVL Technologies (Easy Karaoke license)", "Easy Karaoke Groove Station (UK)", MACHINE_IS_SKELETON )
+CONS( 2003, karams,        0,              0,      easy_karaoke, ivl_karaoke, easy_karaoke_cartslot_state, empty_init, "IVL Technologies (Lexibook license)",     "KaraokeMicro Star (France)", MACHINE_IS_SKELETON )
+
+CONS( 2003, dks7000c,      0,              0,      easy_karaoke, ivl_karaoke, easy_karaoke_cartslot_state, empty_init, "IVL Technologies (Disney / Memcorp Inc license)", "Disney Classic Handheld Karaoke Player (DKS7000-C)", MACHINE_IS_SKELETON )


### PR DESCRIPTION
new NOT WORKING machines
------------------------
Disney Classic Handheld Karaoke Player (DKS7000-C) [Sean Riddle, David Haywood]

new NOT WORKING software list entries
-------------------------------------

easy_karaoke_cart.xml
dkp2: Disney Princess 10-Song Karaoke Cartridge II (DK-P2)  [Sean Riddle, David Haywood]
dkp3: Disney Princess 10-Song Karaoke Cartridge III (DK-P3)  [Sean Riddle, David Haywood]

(also removed the parent/clone relationships from most of these, as they're distinct products in reality)