### PR TITLE
nmk/macrossp.cpp: Cleanups:

### DIFF
--- a/src/mame/nmk/macrossp.cpp
+++ b/src/mame/nmk/macrossp.cpp
@@ -343,8 +343,8 @@ private:
 	required_shared_ptr<uint32_t> m_text_linezoom;
 	required_shared_ptr<uint32_t> m_text_videoregs;
 	required_shared_ptr<uint32_t> m_mainram;
-	std::unique_ptr<uint32_t[]>         m_spriteram_old;
-	std::unique_ptr<uint32_t[]>         m_spriteram_old2;
+	std::unique_ptr<uint32_t []> m_spriteram_old;
+	std::unique_ptr<uint32_t []> m_spriteram_old2;
 
 	// video-related
 	tilemap_t  *m_scr_tilemap[3]{};
@@ -428,11 +428,10 @@ void macrossp_state::scr_videoram_w(offs_t offset, uint32_t data, uint32_t mem_m
 template <unsigned Which>
 TILE_GET_INFO_MEMBER(macrossp_state::get_scr_tile_info)
 {
-	uint32_t color;
-
 	uint32_t const attr = m_scr_videoram[Which][tile_index];
 	uint32_t const tileno = attr & 0x0000ffff;
 
+	uint32_t color;
 	switch (m_scr_videoregs[Which][0] & 0x00000c00)
 	{
 		case 0x00000800:
@@ -475,9 +474,9 @@ TILE_GET_INFO_MEMBER(macrossp_state::get_text_tile_info)
 
 void macrossp_state::video_start()
 {
-	uint32_t const sprram_size = m_spriteram.bytes() / 4;
-	m_spriteram_old = make_unique_clear<uint32_t[]>(sprram_size);
-	m_spriteram_old2 = make_unique_clear<uint32_t[]>(sprram_size);
+	uint32_t const sprram_size = m_spriteram.length();
+	m_spriteram_old = make_unique_clear<uint32_t []>(sprram_size);
+	m_spriteram_old2 = make_unique_clear<uint32_t []>(sprram_size);
 
 	m_text_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(macrossp_state::get_text_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
 	m_scr_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(macrossp_state::get_scr_tile_info<0>)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
@@ -729,17 +728,17 @@ uint32_t macrossp_state::screen_update(screen_device &screen, bitmap_rgb32 &bitm
 
 #if 0
 	popmessage  ("scra - %08x %08x %08x\nscrb - %08x %08x %08x\nscrc - %08x %08x %08x",
-	m_scr_videoregs[0][0]&0xffffffff, // yyyyxxxx
-	m_scr_videoregs[0][1], // ??? more scrolling?
-	m_scr_videoregs[0][2], // 08 - 0b
+			m_scr_videoregs[0][0] & 0xffffffff, // yyyyxxxx
+			m_scr_videoregs[0][1], // ??? more scrolling?
+			m_scr_videoregs[0][2], // 08 - 0b
 
-	m_scr_videoregs[1][0]&0xffffffff, // 00 - 03
-	m_scr_videoregs[1][1], // 04 - 07
-	m_scr_videoregs[1][2], // 08 - 0b
+			m_scr_videoregs[1][0] & 0xffffffff, // 00 - 03
+			m_scr_videoregs[1][1], // 04 - 07
+			m_scr_videoregs[1][2], // 08 - 0b
 
-	m_scr_videoregs[2][0]&0xffffffff, // 00 - 03
-	m_scr_videoregs[2][1], // 04 - 07
-	m_scr_videoregs[2][2]);// 08 - 0b
+			m_scr_videoregs[2][0] & 0xffffffff, // 00 - 03
+			m_scr_videoregs[2][1], // 04 - 07
+			m_scr_videoregs[2][2]);// 08 - 0b
 #endif
 	return 0;
 }

--- a/src/mame/nmk/macrossp.cpp
+++ b/src/mame/nmk/macrossp.cpp
@@ -309,17 +309,9 @@ public:
 	macrossp_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_spriteram(*this, "spriteram"),
-		m_scra_videoram(*this, "scra_videoram"),
-		m_scra_linezoom(*this, "scra_linezoom"),
-		m_scra_videoregs(*this, "scra_videoregs"),
-
-		m_scrb_videoram(*this, "scrb_videoram"),
-		m_scrb_linezoom(*this, "scrb_linezoom"),
-		m_scrb_videoregs(*this, "scrb_videoregs"),
-
-		m_scrc_videoram(*this, "scrc_videoram"),
-		m_scrc_linezoom(*this, "scrc_linezoom"),
-		m_scrc_videoregs(*this, "scrc_videoregs"),
+		m_scr_videoram(*this, "scr%u_videoram", 0U),
+		m_scr_linezoom(*this, "scr%u_linezoom", 0U),
+		m_scr_videoregs(*this, "scr%u_videoregs", 0U),
 
 		m_text_videoram(*this, "text_videoram"),
 		m_text_linezoom(*this, "text_linezoom"),
@@ -342,17 +334,11 @@ public:
 	void init_macrossp();
 
 private:
-	/* memory pointers */
+	// memory pointers
 	required_shared_ptr<uint32_t> m_spriteram;
-	required_shared_ptr<uint32_t> m_scra_videoram;
-	required_shared_ptr<uint32_t> m_scra_linezoom;
-	required_shared_ptr<uint32_t> m_scra_videoregs;
-	required_shared_ptr<uint32_t> m_scrb_videoram;
-	required_shared_ptr<uint32_t> m_scrb_linezoom;
-	required_shared_ptr<uint32_t> m_scrb_videoregs;
-	required_shared_ptr<uint32_t> m_scrc_videoram;
-	required_shared_ptr<uint32_t> m_scrc_linezoom;
-	required_shared_ptr<uint32_t> m_scrc_videoregs;
+	required_shared_ptr_array<uint32_t, 3> m_scr_videoram;
+	required_shared_ptr_array<uint32_t, 3> m_scr_linezoom;
+	required_shared_ptr_array<uint32_t, 3> m_scr_videoregs;
 	required_shared_ptr<uint32_t> m_text_videoram;
 	required_shared_ptr<uint32_t> m_text_linezoom;
 	required_shared_ptr<uint32_t> m_text_videoregs;
@@ -360,17 +346,15 @@ private:
 	std::unique_ptr<uint32_t[]>         m_spriteram_old;
 	std::unique_ptr<uint32_t[]>         m_spriteram_old2;
 
-	/* video-related */
-	tilemap_t  *m_scra_tilemap = nullptr;
-	tilemap_t  *m_scrb_tilemap = nullptr;
-	tilemap_t  *m_scrc_tilemap = nullptr;
+	// video-related
+	tilemap_t  *m_scr_tilemap[3]{};
 	tilemap_t  *m_text_tilemap = nullptr;
 
-	/* misc */
-	int              m_sndpending = 0;
-	int              m_snd_toggle = 0;
+	// misc
+	bool    m_sndpending = false;
+	uint8_t m_snd_toggle = 0;
 
-	/* devices */
+	// devices
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_audiocpu;
 	required_device<screen_device> m_screen;
@@ -378,33 +362,29 @@ private:
 	required_device<palette_device> m_palette;
 	required_device<generic_latch_16_device> m_soundlatch;
 
-	uint32_t macrossp_soundstatus_r();
-	void macrossp_soundcmd_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	uint16_t macrossp_soundcmd_r();
+	uint32_t soundstatus_r();
+	void soundcmd_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	uint16_t soundcmd_r();
 	void palette_fade_w(uint16_t data);
 	void macrossp_speedup_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	[[maybe_unused]] void quizmoon_speedup_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void macrossp_scra_videoram_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void macrossp_scrb_videoram_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void macrossp_scrc_videoram_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void macrossp_text_videoram_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	TILE_GET_INFO_MEMBER(get_macrossp_scra_tile_info);
-	TILE_GET_INFO_MEMBER(get_macrossp_scrb_tile_info);
-	TILE_GET_INFO_MEMBER(get_macrossp_scrc_tile_info);
-	TILE_GET_INFO_MEMBER(get_macrossp_text_tile_info);
+	template <unsigned Which> void scr_videoram_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	void text_videoram_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	template <unsigned Which> TILE_GET_INFO_MEMBER(get_scr_tile_info);
+	TILE_GET_INFO_MEMBER(get_text_tile_info);
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 	virtual void video_start() override;
-	uint32_t screen_update_macrossp(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	void screen_vblank_macrossp(int state);
+	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	void screen_vblank(int state);
 	void draw_sprites(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	void draw_layer(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int layer, int linem, int pri);
+	void draw_layer(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int layer, int line, int pri);
 	void irqhandler(int state);
 
-	void macrossp_map(address_map &map);
-	void macrossp_es5506_bank1_map(address_map &map);
-	void macrossp_es5506_bank3_map(address_map &map);
-	void macrossp_sound_map(address_map &map);
+	void es5506_bank1_map(address_map &map);
+	void es5506_bank3_map(address_map &map);
+	void main_map(address_map &map);
+	void sound_map(address_map &map);
 };
 
 
@@ -435,24 +415,25 @@ Interesting test cases (macrossp, quizmoon doesn't use tilemap zoom):
 
 */
 
-/*** SCR A LAYER ***/
+/*** SCR A-C LAYER ***/
 
-void macrossp_state::macrossp_scra_videoram_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+template <unsigned Which>
+void macrossp_state::scr_videoram_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	COMBINE_DATA(&m_scra_videoram[offset]);
+	COMBINE_DATA(&m_scr_videoram[Which][offset]);
 
-	m_scra_tilemap->mark_tile_dirty(offset);
+	m_scr_tilemap[Which]->mark_tile_dirty(offset);
 }
 
-
-TILE_GET_INFO_MEMBER(macrossp_state::get_macrossp_scra_tile_info)
+template <unsigned Which>
+TILE_GET_INFO_MEMBER(macrossp_state::get_scr_tile_info)
 {
-	uint32_t attr, tileno, color;
+	uint32_t color;
 
-	attr = m_scra_videoram[tile_index];
-	tileno = attr & 0x0000ffff;
+	uint32_t const attr = m_scr_videoram[Which][tile_index];
+	uint32_t const tileno = attr & 0x0000ffff;
 
-	switch (m_scra_videoregs[0] & 0x00000c00)
+	switch (m_scr_videoregs[Which][0] & 0x00000c00)
 	{
 		case 0x00000800:
 			color = (attr & 0x000e0000) >> 15;
@@ -467,82 +448,12 @@ TILE_GET_INFO_MEMBER(macrossp_state::get_macrossp_scra_tile_info)
 			break;
 	}
 
-	tileinfo.set(1, tileno, color, TILE_FLIPYX((attr & 0xc0000000) >> 30));
-}
-
-/*** SCR B LAYER ***/
-
-void macrossp_state::macrossp_scrb_videoram_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-	COMBINE_DATA(&m_scrb_videoram[offset]);
-
-	m_scrb_tilemap->mark_tile_dirty(offset);
-}
-
-
-TILE_GET_INFO_MEMBER(macrossp_state::get_macrossp_scrb_tile_info)
-{
-	uint32_t attr, tileno, color;
-
-	attr = m_scrb_videoram[tile_index];
-	tileno = attr & 0x0000ffff;
-
-	switch (m_scrb_videoregs[0] & 0x00000c00)
-	{
-		case 0x00000800:
-			color = (attr & 0x000e0000) >> 15;
-			break;
-
-		case 0x00000400:
-			color = (attr & 0x003e0000) >> 17;
-			break;
-
-		default:
-			color = machine().rand() & 7;
-			break;
-	}
-
-	tileinfo.set(2, tileno, color, TILE_FLIPYX((attr & 0xc0000000) >> 30));
-}
-
-/*** SCR C LAYER ***/
-
-void macrossp_state::macrossp_scrc_videoram_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-	COMBINE_DATA(&m_scrc_videoram[offset]);
-
-	m_scrc_tilemap->mark_tile_dirty(offset);
-}
-
-
-TILE_GET_INFO_MEMBER(macrossp_state::get_macrossp_scrc_tile_info)
-{
-	uint32_t attr, tileno, color;
-
-	attr = m_scrc_videoram[tile_index];
-	tileno = attr & 0x0000ffff;
-
-	switch (m_scrc_videoregs[0] & 0x00000c00)
-	{
-		case 0x00000800:
-			color = (attr & 0x000e0000) >> 15;
-			break;
-
-		case 0x00000400:
-			color = (attr & 0x003e0000) >> 17;
-			break;
-
-		default:
-			color = machine().rand() & 7;
-			break;
-	}
-
-	tileinfo.set(3, tileno, color, TILE_FLIPYX((attr & 0xc0000000) >> 30));
+	tileinfo.set(1 + Which, tileno, color, TILE_FLIPYX((attr & 0xc0000000) >> 30));
 }
 
 /*** TEXT LAYER ***/
 
-void macrossp_state::macrossp_text_videoram_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+void macrossp_state::text_videoram_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	COMBINE_DATA(&m_text_videoram[offset]);
 
@@ -550,12 +461,10 @@ void macrossp_state::macrossp_text_videoram_w(offs_t offset, uint32_t data, uint
 }
 
 
-TILE_GET_INFO_MEMBER(macrossp_state::get_macrossp_text_tile_info)
+TILE_GET_INFO_MEMBER(macrossp_state::get_text_tile_info)
 {
-	uint32_t tileno, colour;
-
-	tileno = m_text_videoram[tile_index] & 0x0000ffff;
-	colour = (m_text_videoram[tile_index] & 0x00fe0000) >> 17;
+	uint32_t const tileno = m_text_videoram[tile_index] & 0x0000ffff;
+	uint32_t const colour = (m_text_videoram[tile_index] & 0x00fe0000) >> 17;
 
 	tileinfo.set(4, tileno, colour, 0);
 }
@@ -566,26 +475,27 @@ TILE_GET_INFO_MEMBER(macrossp_state::get_macrossp_text_tile_info)
 
 void macrossp_state::video_start()
 {
-	m_spriteram_old = make_unique_clear<uint32_t[]>(m_spriteram.bytes() / 4);
-	m_spriteram_old2 = make_unique_clear<uint32_t[]>(m_spriteram.bytes() / 4);
+	uint32_t const sprram_size = m_spriteram.bytes() / 4;
+	m_spriteram_old = make_unique_clear<uint32_t[]>(sprram_size);
+	m_spriteram_old2 = make_unique_clear<uint32_t[]>(sprram_size);
 
-	m_text_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(macrossp_state::get_macrossp_text_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
-	m_scra_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(macrossp_state::get_macrossp_scra_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
-	m_scrb_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(macrossp_state::get_macrossp_scrb_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
-	m_scrc_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(macrossp_state::get_macrossp_scrc_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
+	m_text_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(macrossp_state::get_text_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
+	m_scr_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(macrossp_state::get_scr_tile_info<0>)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
+	m_scr_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(macrossp_state::get_scr_tile_info<1>)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
+	m_scr_tilemap[2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(macrossp_state::get_scr_tile_info<2>)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
 
 	m_text_tilemap->set_transparent_pen(0);
-	m_scra_tilemap->set_transparent_pen(0);
-	m_scrb_tilemap->set_transparent_pen(0);
-	m_scrc_tilemap->set_transparent_pen(0);
+	m_scr_tilemap[0]->set_transparent_pen(0);
+	m_scr_tilemap[1]->set_transparent_pen(0);
+	m_scr_tilemap[2]->set_transparent_pen(0);
 
 	m_gfxdecode->gfx(0)->set_granularity(64);
 	m_gfxdecode->gfx(1)->set_granularity(64);
 	m_gfxdecode->gfx(2)->set_granularity(64);
 	m_gfxdecode->gfx(3)->set_granularity(64);
 
-	save_pointer(NAME(m_spriteram_old), m_spriteram.bytes() / 4);
-	save_pointer(NAME(m_spriteram_old2), m_spriteram.bytes() / 4);
+	save_pointer(NAME(m_spriteram_old), sprram_size);
+	save_pointer(NAME(m_spriteram_old2), sprram_size);
 }
 
 
@@ -594,10 +504,10 @@ void macrossp_state::draw_sprites(screen_device &screen, bitmap_rgb32 &bitmap, c
 {
 	gfx_element *gfx = m_gfxdecode->gfx(0);
 	//  uint32_t *source = m_spriteram;
-	uint32_t *source = (m_spriteram_old2.get() + m_spriteram.bytes() / 4) - 3; /* buffers by two frames */
-	uint32_t *finish = m_spriteram_old2.get();
+	uint32_t const *source = (m_spriteram_old2.get() + m_spriteram.bytes() / 4) - 3; // buffers by two frames
+	uint32_t const *finish = m_spriteram_old2.get();
 
-	/* reverse order */
+	// reverse order
 	while (source >= finish)
 	{
 		/*
@@ -608,37 +518,34 @@ void macrossp_state::draw_sprites(screen_device &screen, bitmap_rgb32 &bitmap, c
 
 		 fFa- pp-- cccc c---   tttt tttt tttt tttt
 
-		 */
+		*/
 
 
-		int wide = (source[0] & 0x00003c00) >> 10;
-		int high = (source[0] & 0x3c000000) >> 26;
+		int const wide = (source[0] & 0x00003c00) >> 10;
+		int const high = (source[0] & 0x3c000000) >> 26;
 
 		int xpos = (source[0] & 0x000003ff) >> 0;
 		int ypos = (source[0] & 0x03ff0000) >> 16;
 
-		int xzoom = (source[1] & 0x000003ff) >> 0; /* 0x100 is zoom factor of 1.0 */
-		int yzoom = (source[1] & 0x03ff0000) >> 16;
+		int const xzoom = (source[1] & 0x000003ff) >> 0; // 0x100 is zoom factor of 1.0
+		int const yzoom = (source[1] & 0x03ff0000) >> 16;
 
 		int col;
-		int tileno = (source[2] & 0x0000ffff) >> 0;
+		int const tileno = (source[2] & 0x0000ffff) >> 0;
 
-		int flipx = (source[2] & 0x40000000) >> 30;
-		int flipy = (source[2] & 0x80000000) >> 31;
+		bool const flipx = BIT(source[2], 30);
+		bool const flipy = BIT(source[2], 31);
 
-		int alpha = (source[2] & 0x20000000)?0x80:0xff; /* alpha blending enable? */
+		int const alpha = BIT(source[2], 29) ? 0x80 : 0xff; // alpha blending enable?
 
 		int loopno = 0;
 
-		int xcnt, ycnt;
-		int xoffset, yoffset;
-
-		int pri = (source[2] & 0x0c000000) >> 26;
-		int primask = 0;
-		if(pri <= 0) primask |= GFX_PMASK_1;
-		if(pri <= 1) primask |= GFX_PMASK_2;
-		if(pri <= 2) primask |= GFX_PMASK_4;
-		if(pri <= 3) primask |= GFX_PMASK_8;
+		int const pri = (source[2] & 0x0c000000) >> 26;
+		uint32_t primask = 0;
+		if (pri <= 0) primask |= GFX_PMASK_1;
+		if (pri <= 1) primask |= GFX_PMASK_2;
+		if (pri <= 2) primask |= GFX_PMASK_4;
+		if (pri <= 3) primask |= GFX_PMASK_8;
 
 		switch (source[0] & 0x0000c000)
 		{
@@ -655,15 +562,16 @@ void macrossp_state::draw_sprites(screen_device &screen, bitmap_rgb32 &bitmap, c
 				break;
 		}
 
-		if (xpos > 0x1ff) xpos -=0x400;
-		if (ypos > 0x1ff) ypos -=0x400;
+		if (xpos > 0x1ff) xpos -= 0x400;
+		if (ypos > 0x1ff) ypos -= 0x400;
 
-		/* loop params */
+		// loop params
 		int ymin = 0;
-		int ymax = high+1;
+		int ymax = high + 1;
 		int yinc = 1;
 		int yoffst = 0;
-		if(flipy) {
+		if (flipy)
+		{
 			yoffst = (high * yzoom * 16);
 			ymin = high;
 			ymax = -1;
@@ -671,125 +579,104 @@ void macrossp_state::draw_sprites(screen_device &screen, bitmap_rgb32 &bitmap, c
 		}
 
 		int xmin = 0;
-		int xmax = wide+1;
+		int xmax = wide + 1;
 		int xinc = 1;
 		int xoffst = 0;
-		if(flipx) {
+		if (flipx)
+		{
 			xoffst = (wide * xzoom * 16);
 			xmin = wide;
 			xmax = -1;
 			xinc = -1;
 		}
 
-		yoffset = yoffst;
-		for (ycnt = ymin; ycnt != ymax; ycnt += yinc)
+		int yoffset = yoffst;
+		for (int ycnt = ymin; ycnt != ymax; ycnt += yinc)
 		{
-			xoffset = xoffst;
-			for (xcnt = xmin; xcnt != xmax; xcnt += xinc)
+			int xoffset = xoffst;
+			for (int xcnt = xmin; xcnt != xmax; xcnt += xinc)
 			{
-				int fudged_xzoom = xzoom<<8;
-				int fudged_yzoom = yzoom<<8;
+				int fudged_xzoom = xzoom << 8;
+				int fudged_yzoom = yzoom << 8;
 
-				/* cover seams as don't know exactly how many pixels on target will cover, and can't specify fractional offsets to start */
-				if(xzoom < 0x100) fudged_xzoom += 0x600;
-				if(yzoom < 0x100) fudged_yzoom += 0x600;
+				// cover seams as don't know exactly how many pixels on target will cover, and can't specify fractional offsets to start
+				if (xzoom < 0x100) fudged_xzoom += 0x600;
+				if (yzoom < 0x100) fudged_yzoom += 0x600;
 
-				gfx->prio_zoom_alpha(bitmap,cliprect,tileno+loopno,col,
-										flipx,flipy,xpos+(xoffset>>8),ypos+(yoffset>>8),
-										fudged_xzoom,fudged_yzoom,
-										screen.priority(),primask,0,alpha);
+				gfx->prio_zoom_alpha(bitmap, cliprect,
+					tileno + loopno, col,
+					flipx, flipy,
+					xpos + (xoffset >> 8), ypos + (yoffset >> 8),
+					fudged_xzoom, fudged_yzoom,
+					screen.priority(), primask, 0, alpha);
 
-				xoffset += ((xzoom*16) * xinc);
+				xoffset += ((xzoom * 16) * xinc);
 				loopno++;
 			}
-			yoffset += ((yzoom*16) * yinc);
+			yoffset += ((yzoom * 16) * yinc);
 		}
-
 		source -= 3;
 	}
 }
 
 
-void macrossp_state::draw_layer( screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int layer, int line, int pri )
+void macrossp_state::draw_layer(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int layer, int line, int pri)
 {
-	tilemap_t *tm;
-	uint32_t *vr;
-	uint32_t *lr;
+	tilemap_t *tm = m_scr_tilemap[layer];
+	uint32_t const *const vr = m_scr_videoregs[layer];
+	uint32_t const *const lr = m_scr_linezoom[layer];
 
-	switch (layer)
+	if ((vr[2] & 0xf0000000) == 0xe0000000) // zoom enable (guess, surely wrong)
 	{
-		case 0:
-		default:
-			tm = m_scra_tilemap;
-			vr = m_scra_videoregs;
-			lr = m_scra_linezoom;
-			break;
+		int incx;
 
-		case 1:
-			tm = m_scrb_tilemap;
-			vr = m_scrb_videoregs;
-			lr = m_scrb_linezoom;
-			break;
+		int startx     = ((vr[0] & 0x000003ff) << 16);
+		int starty     = ((vr[0] & 0x03ff0000) >> 0);
+		int const incy = (vr[2] & 0x01ff0000) >> 6;
 
-		case 2:
-			tm = m_scrc_tilemap;
-			vr = m_scrc_videoregs;
-			lr = m_scrc_linezoom;
-			break;
-	}
-
-	if ((vr[2] & 0xf0000000) == 0xe0000000) /* zoom enable (guess, surely wrong) */
-	{
-		int startx=0, starty=0, incy, incx;
-
-		startx = ((vr[0] & 0x000003ff) << 16 );
-		starty = ((vr[0] & 0x03ff0000) >> 0);
-		incy   = (vr[2] & 0x01ff0000) >> 6;
-
-		if (line&1)
-			incx = (lr[line/2] & 0x0000ffff)>>0;
+		if (line & 1)
+			incx = (lr[line / 2] & 0x0000ffff) >> 0;
 		else
-			incx = (lr[line/2] & 0xffff0000)>>16;
+			incx = (lr[line / 2] & 0xffff0000) >> 16;
 
 		incx <<= 10;
 
-		/* scroll register contain position relative to the center of the screen, so adjust */
-		startx -= (368/2) * (incx - 0x10000);
-		starty -= (240/2) * (incy - 0x10000);
+		// scroll register contain position relative to the center of the screen, so adjust
+		startx -= (368 / 2) * (incx - 0x10000);
+		starty -= (240 / 2) * (incy - 0x10000);
 
 // previous logic, which gives mostly comparable results, vr[1] is now unused
-//      startx = (vr[1] & 0x0000ffff) << 16;
-//      starty = (vr[1] & 0xffff0000) >> 0;
-//      startx -= (368/2) * incx;
-//      starty -= (240/2) * incy;
+//      int startx = (vr[1] & 0x0000ffff) << 16;
+//      int starty = (vr[1] & 0xffff0000) >> 0;
+//      startx -= (368 / 2) * incx;
+//      starty -= (240 / 2) * incy;
 
 		tm->draw_roz(screen, bitmap, cliprect,
 				startx,starty,incx,0,0,incy,
-				1,  /* wraparound */
-				0, 1<<pri);
+				1,  // wraparound
+				0, 1 << pri);
 	}
 	else
 	{
-		tm->set_scrollx(0, ((vr[0] & 0x000003ff) >> 0 ) );
-		tm->set_scrolly(0, ((vr[0] & 0x03ff0000) >> 16) );
+		tm->set_scrollx(0, ((vr[0] & 0x000003ff) >>  0));
+		tm->set_scrolly(0, ((vr[0] & 0x03ff0000) >> 16));
 		tm->draw(screen, bitmap, cliprect, 0, 1<<pri);
 	}
 }
 
-uint32_t macrossp_state::screen_update_macrossp(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+uint32_t macrossp_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	int layerpri[3];
 	int sprites = true;
 	int backgrounds = true;
 
-	rectangle clip;
 	const rectangle &visarea = screen.visible_area();
-	clip = visarea;
+	rectangle clip = visarea;
 
-	/* 0 <= layerpri <= 2 */
-	layerpri[0] = (m_scra_videoregs[0] & 0x0000c000) >> 14;
-	layerpri[1] = (m_scrb_videoregs[0] & 0x0000c000) >> 14;
-	layerpri[2] = (m_scrc_videoregs[0] & 0x0000c000) >> 14;
+	// 0 <= layerpri <= 2
+	layerpri[0] = (m_scr_videoregs[0][0] & 0x0000c000) >> 14;
+	layerpri[1] = (m_scr_videoregs[1][0] & 0x0000c000) >> 14;
+	layerpri[2] = (m_scr_videoregs[2][0] & 0x0000c000) >> 14;
 
 	screen.priority().fill(0, cliprect);
 	bitmap.fill(m_palette->black_pen(), cliprect);
@@ -799,7 +686,7 @@ uint32_t macrossp_state::screen_update_macrossp(screen_device &screen, bitmap_rg
 	bool lay_debug = false;
 	for (int pri = 0; pri <= 4; pri++)
 	{
-		if(machine().input().code_pressed(lay_keys[pri]))
+		if (machine().input().code_pressed(lay_keys[pri]))
 			lay_debug = true;
 	}
 	if (machine().input().code_pressed(KEYCODE_G))
@@ -808,7 +695,7 @@ uint32_t macrossp_state::screen_update_macrossp(screen_device &screen, bitmap_rg
 		backgrounds = false;
 #endif
 
-	for(int pri = 0; pri <= 3; pri++)
+	for (int pri = 0; pri <= 3; pri++)
 	{
 #ifdef DEBUG_KEYS
 		if (lay_debug && !machine().input().code_pressed(lay_keys[pri]))
@@ -818,14 +705,14 @@ uint32_t macrossp_state::screen_update_macrossp(screen_device &screen, bitmap_rg
 		if (!backgrounds)
 			continue;
 
-		for (int y=0; y<240; y++)
+		for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 		{
 			clip.min_y = clip.max_y = y;
 
-			/* quizmoon map requires that layer 2 be drawn over layer 3 when same pri */
-			for(int layer = 2; layer >= 0; layer--)
+			// quizmoon map requires that layer 2 be drawn over layer 3 when same pri
+			for (int layer = 2; layer >= 0; layer--)
 			{
-				if(layerpri[layer] == pri)
+				if (layerpri[layer] == pri)
 					draw_layer(screen, bitmap, clip, layer, y, pri);
 			}
 		}
@@ -842,27 +729,27 @@ uint32_t macrossp_state::screen_update_macrossp(screen_device &screen, bitmap_rg
 
 #if 0
 	popmessage  ("scra - %08x %08x %08x\nscrb - %08x %08x %08x\nscrc - %08x %08x %08x",
-	m_scra_videoregs[0]&0xffffffff, // yyyyxxxx
-	m_scra_videoregs[1], // ??? more scrolling?
-	m_scra_videoregs[2], // 08 - 0b
+	m_scr_videoregs[0][0]&0xffffffff, // yyyyxxxx
+	m_scr_videoregs[0][1], // ??? more scrolling?
+	m_scr_videoregs[0][2], // 08 - 0b
 
-	m_scrb_videoregs[0]&0xffffffff, // 00 - 03
-	m_scrb_videoregs[1], // 04 - 07
-	m_scrb_videoregs[2], // 08 - 0b
+	m_scr_videoregs[1][0]&0xffffffff, // 00 - 03
+	m_scr_videoregs[1][1], // 04 - 07
+	m_scr_videoregs[1][2], // 08 - 0b
 
-	m_scrc_videoregs[0]&0xffffffff, // 00 - 03
-	m_scrc_videoregs[1], // 04 - 07
-	m_scrc_videoregs[2]);// 08 - 0b
+	m_scr_videoregs[2][0]&0xffffffff, // 00 - 03
+	m_scr_videoregs[2][1], // 04 - 07
+	m_scr_videoregs[2][2]);// 08 - 0b
 #endif
 	return 0;
 }
 
-void macrossp_state::screen_vblank_macrossp(int state)
+void macrossp_state::screen_vblank(int state)
 {
 	// rising edge
 	if (state)
 	{
-		/* looks like sprites are *two* frames ahead, like nmk16 */
+		// looks like sprites are *two* frames ahead, like nmk16
 		memcpy(m_spriteram_old2.get(), m_spriteram_old.get(), m_spriteram.bytes());
 		memcpy(m_spriteram_old.get(), m_spriteram, m_spriteram.bytes());
 	}
@@ -871,37 +758,37 @@ void macrossp_state::screen_vblank_macrossp(int state)
 
 /*** VARIOUS READ / WRITE HANDLERS *******************************************/
 
-uint32_t macrossp_state::macrossp_soundstatus_r()
+uint32_t macrossp_state::soundstatus_r()
 {
 	//  logerror("%08x read soundstatus\n", m_maincpu->pc());
 
-	/* bit 1 is sound status */
-	/* bit 0 unknown - it is expected to toggle, vblank? */
+	// bit 1 is sound status
+	// bit 0 unknown - it is expected to toggle, vblank?
 
 	if (!machine().side_effects_disabled())
 		m_snd_toggle ^= 1;
 
-	return (m_sndpending << 1) | m_snd_toggle;
+	return (m_sndpending ? 2 : 0) | m_snd_toggle;
 }
 
-void macrossp_state::macrossp_soundcmd_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+void macrossp_state::soundcmd_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	if (ACCESSING_BITS_16_31)
 	{
 		//logerror("%08x write soundcmd %08x (%08x)\n",m_maincpu->pc(),data,mem_mask);
 		m_soundlatch->write(data >> 16);
-		m_sndpending = 1;
+		m_sndpending = true;
 		m_audiocpu->set_input_line(2, HOLD_LINE);
-		/* spin for a while to let the sound CPU read the command */
+		// spin for a while to let the sound CPU read the command
 		m_maincpu->spin_until_time(attotime::from_usec(50));
 	}
 }
 
-uint16_t macrossp_state::macrossp_soundcmd_r()
+uint16_t macrossp_state::soundcmd_r()
 {
 	//  logerror("%06x read soundcmd\n",m_audiocpu->pc());
 	if (!machine().side_effects_disabled())
-		m_sndpending = 0;
+		m_sndpending = false;
 	return m_soundlatch->read();
 }
 
@@ -911,63 +798,63 @@ void macrossp_state::palette_fade_w(uint16_t data)
 	if (data >> 8 != 0xff)
 	{
 		// range seems to be 40 (brightest) to 252 (darkest)
-		uint8_t fade = ((data >> 8) - 40) / 212.0 * 255.0;
+		uint8_t const fade = ((data >> 8) - 40) / 212.0 * 255.0;
 		m_screen->set_brightness(0xff - fade);
 	}
 }
 
 /*** MEMORY MAPS *************************************************************/
 
-void macrossp_state::macrossp_map(address_map &map)
+void macrossp_state::main_map(address_map &map)
 {
 	map(0x000000, 0x3fffff).rom();
-	map(0x800000, 0x802fff).ram().share("spriteram");
-	/* SCR A Layer */
-	map(0x900000, 0x903fff).ram().w(FUNC(macrossp_state::macrossp_scra_videoram_w)).share("scra_videoram");
-	map(0x904200, 0x9043ff).ram().share("scra_linezoom"); /* W/O? */
-	map(0x905000, 0x90500b).ram().share("scra_videoregs"); /* W/O? */
-	/* SCR B Layer */
-	map(0x908000, 0x90bfff).ram().w(FUNC(macrossp_state::macrossp_scrb_videoram_w)).share("scrb_videoram");
-	map(0x90c200, 0x90c3ff).ram().share("scrb_linezoom"); /* W/O? */
-	map(0x90d000, 0x90d00b).ram().share("scrb_videoregs"); /* W/O? */
-	/* SCR C Layer */
-	map(0x910000, 0x913fff).ram().w(FUNC(macrossp_state::macrossp_scrc_videoram_w)).share("scrc_videoram");
-	map(0x914200, 0x9143ff).ram().share("scrc_linezoom");/* W/O? */
-	map(0x915000, 0x91500b).ram().share("scrc_videoregs"); /* W/O? */
-	/* Text Layer */
-	map(0x918000, 0x91bfff).ram().w(FUNC(macrossp_state::macrossp_text_videoram_w)).share("text_videoram");
-	map(0x91c200, 0x91c3ff).ram().share("text_linezoom"); /* W/O? */
-	map(0x91d000, 0x91d00b).ram().share("text_videoregs"); /* W/O? */
+	map(0x800000, 0x802fff).ram().share(m_spriteram);
+	// SCR A Layer
+	map(0x900000, 0x903fff).ram().w(FUNC(macrossp_state::scr_videoram_w<0>)).share(m_scr_videoram[0]);
+	map(0x904200, 0x9043ff).ram().share(m_scr_linezoom[0]); // W/O?
+	map(0x905000, 0x90500b).ram().share(m_scr_videoregs[0]); // W/O?
+	// SCR B Layer
+	map(0x908000, 0x90bfff).ram().w(FUNC(macrossp_state::scr_videoram_w<1>)).share(m_scr_videoram[1]);
+	map(0x90c200, 0x90c3ff).ram().share(m_scr_linezoom[1]); // W/O?
+	map(0x90d000, 0x90d00b).ram().share(m_scr_videoregs[1]); // W/O?
+	// SCR C Layer
+	map(0x910000, 0x913fff).ram().w(FUNC(macrossp_state::scr_videoram_w<2>)).share(m_scr_videoram[2]);
+	map(0x914200, 0x9143ff).ram().share(m_scr_linezoom[2]);// W/O?
+	map(0x915000, 0x91500b).ram().share(m_scr_videoregs[2]); // W/O?
+	// Text Layer
+	map(0x918000, 0x91bfff).ram().w(FUNC(macrossp_state::text_videoram_w)).share(m_text_videoram);
+	map(0x91c200, 0x91c3ff).ram().share(m_text_linezoom); // W/O?
+	map(0x91d000, 0x91d00b).ram().share(m_text_videoregs); // W/O?
 
 	map(0xa00000, 0xa03fff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette");
 
 	map(0xb00000, 0xb00003).portr("INPUTS");
-	map(0xb00004, 0xb00007).r(FUNC(macrossp_state::macrossp_soundstatus_r)).nopw(); // irq related?
+	map(0xb00004, 0xb00007).r(FUNC(macrossp_state::soundstatus_r)).nopw(); // irq related?
 	map(0xb00008, 0xb0000b).nopw();    // irq related?
 	map(0xb0000c, 0xb0000f).portr("DSW").nopw();
 	map(0xb00012, 0xb00013).w(FUNC(macrossp_state::palette_fade_w));
 	map(0xb00020, 0xb00023).nopw();
 
-	map(0xc00000, 0xc00003).w(FUNC(macrossp_state::macrossp_soundcmd_w));
+	map(0xc00000, 0xc00003).w(FUNC(macrossp_state::soundcmd_w));
 
-	map(0xf00000, 0xf1ffff).ram().share("mainram"); /* Main Ram */
+	map(0xf00000, 0xf1ffff).ram().share(m_mainram); // Main Ram
 //  map(0xfe0000, 0xfe0003).noprw();
 }
 
-void macrossp_state::macrossp_sound_map(address_map &map)
+void macrossp_state::sound_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();
 	map(0x200000, 0x207fff).ram();
 	map(0x400000, 0x40007f).rw("ensoniq", FUNC(es5506_device::read), FUNC(es5506_device::write)).umask16(0x00ff);
-	map(0x600000, 0x600001).r(FUNC(macrossp_state::macrossp_soundcmd_r));
+	map(0x600000, 0x600001).r(FUNC(macrossp_state::soundcmd_r));
 }
 
-void macrossp_state::macrossp_es5506_bank1_map(address_map &map)
+void macrossp_state::es5506_bank1_map(address_map &map)
 {
 	map(0x000000, 0x1fffff).rom().region("ensoniq.0", 0x400000);
 }
 
-void macrossp_state::macrossp_es5506_bank3_map(address_map &map)
+void macrossp_state::es5506_bank3_map(address_map &map)
 {
 	map(0x000000, 0x1fffff).rom().region("ensoniq.2", 0x400000);
 }
@@ -980,9 +867,9 @@ static INPUT_PORTS_START( macrossp )
 	PORT_BIT( 0x00000002, IP_ACTIVE_LOW, IPT_START2 )
 	PORT_BIT( 0x00000004, IP_ACTIVE_LOW, IPT_COIN1 )
 	PORT_BIT( 0x00000008, IP_ACTIVE_LOW, IPT_COIN2 )
-	PORT_BIT( 0x00000010, IP_ACTIVE_LOW, IPT_UNUSED ) /* Unknown use */
+	PORT_BIT( 0x00000010, IP_ACTIVE_LOW, IPT_UNUSED ) // Unknown use
 	PORT_BIT( 0x00000020, IP_ACTIVE_LOW, IPT_SERVICE1 )
-	PORT_BIT( 0x0000ffc0, IP_ACTIVE_LOW, IPT_UNUSED ) /* Unknown use */
+	PORT_BIT( 0x0000ffc0, IP_ACTIVE_LOW, IPT_UNUSED ) // Unknown use
 	PORT_BIT( 0x00010000, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER(1)
 	PORT_BIT( 0x00020000, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER(1)
 	PORT_BIT( 0x00040000, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_PLAYER(1)
@@ -1001,7 +888,7 @@ static INPUT_PORTS_START( macrossp )
 	PORT_BIT( 0x80000000, IP_ACTIVE_LOW, IPT_BUTTON4 ) PORT_PLAYER(2)
 
 	PORT_START("DSW")
-	PORT_BIT( 0x0000ffff, IP_ACTIVE_LOW, IPT_UNUSED ) /* Unknown use, but not dipswitches */
+	PORT_BIT( 0x0000ffff, IP_ACTIVE_LOW, IPT_UNUSED ) // Unknown use, but not dipswitches
 	PORT_DIPNAME( 0x000f0000, 0x000f0000, DEF_STR( Coin_A ) ) PORT_DIPLOCATION("SW1:1,2,3,4")
 	PORT_DIPSETTING(          0x00020000, DEF_STR( 4C_1C ) )
 	PORT_DIPSETTING(          0x00050000, DEF_STR( 3C_1C ) )
@@ -1049,10 +936,10 @@ static INPUT_PORTS_START( macrossp )
 	PORT_DIPNAME( 0x10000000, 0x10000000, DEF_STR( Demo_Sounds ) ) PORT_DIPLOCATION("SW2:5")
 	PORT_DIPSETTING(          0x00000000, DEF_STR( Off ) )
 	PORT_DIPSETTING(          0x10000000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x20000000, 0x20000000, DEF_STR( Flip_Screen ) ) PORT_DIPLOCATION("SW2:6")  /* See above for dips listing.... also in Quiz game's test screens */
+	PORT_DIPNAME( 0x20000000, 0x20000000, DEF_STR( Flip_Screen ) ) PORT_DIPLOCATION("SW2:6")  // See above for dips listing.... also in Quiz game's test screens
 	PORT_DIPSETTING(          0x20000000, DEF_STR( Off ) )
 	PORT_DIPSETTING(          0x00000000, DEF_STR( On ) )
-	PORT_DIPNAME( 0x40000000, 0x00000000, DEF_STR( Language ) ) PORT_DIPLOCATION("SW2:7")  /* See title page for difference :-)  The Manual shows this as UNUSED */
+	PORT_DIPNAME( 0x40000000, 0x00000000, DEF_STR( Language ) ) PORT_DIPLOCATION("SW2:7")  // See title page for difference :-)  The Manual shows this as UNUSED
 	PORT_DIPSETTING(          0x40000000, DEF_STR( Japanese ) )
 	PORT_DIPSETTING(          0x00000000, DEF_STR( English ) )
 	PORT_SERVICE_DIPLOC(  0x80000000, IP_ACTIVE_LOW, "SW2:8" )
@@ -1071,29 +958,17 @@ static INPUT_PORTS_START( quizmoon )
 	PORT_DIPSETTING(          0x00000000, DEF_STR( On ) )
 
 	PORT_MODIFY("DSW")
-	PORT_DIPUNUSED_DIPLOC( 0x40000000, 0x40000000, "SW2:7" ) /* no Language dipswitch for this game */
+	PORT_DIPUNUSED_DIPLOC( 0x40000000, 0x40000000, "SW2:7" ) // no Language dipswitch for this game
 INPUT_PORTS_END
 
 /*** GFX DECODE **************************************************************/
 
-static const gfx_layout macrossp_char16x16x8layout =
-{
-	16,16,
-	RGN_FRAC(1,1),
-	8,
-	{ 0,1,2,3,4,5,6,7 },
-	{ 0, 8, 16, 24, 32, 40, 48, 56, 64+0,64+8,64+16,64+24,64+32,64+40,64+48,64+56 },
-	{ 0*128, 1*128, 2*128, 3*128, 4*128, 5*128, 6*128, 7*128,
-		8*128, 9*128, 10*128,11*128,12*128,13*128,14*128,15*128},
-	16*128
-};
-
 static GFXDECODE_START( gfx_macrossp )
-	GFXDECODE_ENTRY( "gfx1", 0, macrossp_char16x16x8layout,   0x000, 0x20 ) /* 8bpp but 6bpp granularity */
-	GFXDECODE_ENTRY( "gfx2", 0, macrossp_char16x16x8layout,   0x800, 0x20 ) /* 8bpp but 6bpp granularity */
-	GFXDECODE_ENTRY( "gfx3", 0, macrossp_char16x16x8layout,   0x800, 0x20 ) /* 8bpp but 6bpp granularity */
-	GFXDECODE_ENTRY( "gfx4", 0, macrossp_char16x16x8layout,   0x800, 0x20 ) /* 8bpp but 6bpp granularity */
-	GFXDECODE_ENTRY( "gfx5", 0, gfx_16x16x4_packed_msb,       0x800, 0x80 )
+	GFXDECODE_ENTRY( "sprites",  0, gfx_16x16x8_raw,        0x000, 0x20 ) // 8bpp but 6bpp granularity
+	GFXDECODE_ENTRY( "bgtiles0", 0, gfx_16x16x8_raw,        0x800, 0x20 ) // 8bpp but 6bpp granularity
+	GFXDECODE_ENTRY( "bgtiles1", 0, gfx_16x16x8_raw,        0x800, 0x20 ) // 8bpp but 6bpp granularity
+	GFXDECODE_ENTRY( "bgtiles2", 0, gfx_16x16x8_raw,        0x800, 0x20 ) // 8bpp but 6bpp granularity
+	GFXDECODE_ENTRY( "fgtiles",  0, gfx_16x16x4_packed_msb, 0x800, 0x80 )
 GFXDECODE_END
 
 /*** MACHINE DRIVER **********************************************************/
@@ -1115,41 +990,41 @@ void macrossp_state::machine_start()
 
 void macrossp_state::machine_reset()
 {
-	m_sndpending = 0;
+	m_sndpending = false;
 	m_snd_toggle = 0;
 }
 
 void macrossp_state::macrossp(machine_config &config)
 {
-	/* basic machine hardware */
-	M68EC020(config, m_maincpu, 50_MHz_XTAL/2);   /* 25 MHz */
-	m_maincpu->set_addrmap(AS_PROGRAM, &macrossp_state::macrossp_map);
+	// basic machine hardware
+	M68EC020(config, m_maincpu, 50_MHz_XTAL / 2);   // 25 MHz
+	m_maincpu->set_addrmap(AS_PROGRAM, &macrossp_state::main_map);
 	m_maincpu->set_vblank_int("screen", FUNC(macrossp_state::irq3_line_hold)); // there are others ...
 
-	M68000(config, m_audiocpu, 32_MHz_XTAL/2);    /* 16 MHz */
-	m_audiocpu->set_addrmap(AS_PROGRAM, &macrossp_state::macrossp_sound_map);
+	M68000(config, m_audiocpu, 32_MHz_XTAL / 2);    // 16 MHz
+	m_audiocpu->set_addrmap(AS_PROGRAM, &macrossp_state::sound_map);
 
-	/* video hardware */
+	// video hardware
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_refresh_hz(60);
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	m_screen->set_size(32*16, 16*16);
 	m_screen->set_visarea(0*16, 24*16-1, 0*16, 15*16-1);
-	m_screen->set_screen_update(FUNC(macrossp_state::screen_update_macrossp));
-	m_screen->screen_vblank().set(FUNC(macrossp_state::screen_vblank_macrossp));
+	m_screen->set_screen_update(FUNC(macrossp_state::screen_update));
+	m_screen->screen_vblank().set(FUNC(macrossp_state::screen_vblank));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macrossp);
 	PALETTE(config, m_palette).set_format(palette_device::RGBx_888, 4096);
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
 	GENERIC_LATCH_16(config, m_soundlatch);
 
-	es5506_device &ensoniq(ES5506(config, "ensoniq", 32_MHz_XTAL/2));    /* 16 MHz */
+	es5506_device &ensoniq(ES5506(config, "ensoniq", 32_MHz_XTAL / 2));    // 16 MHz
 	ensoniq.set_region0("ensoniq.0");
-	ensoniq.set_addrmap(1, &macrossp_state::macrossp_es5506_bank1_map);
+	ensoniq.set_addrmap(1, &macrossp_state::es5506_bank1_map);
 	ensoniq.set_channels(1);
 	ensoniq.irq_cb().set(FUNC(macrossp_state::irqhandler));
 	ensoniq.add_route(0, "lspeaker", 0.1);
@@ -1163,7 +1038,7 @@ void macrossp_state::quizmoon(machine_config &config)
 
 	es5506_device *ensoniq = subdevice<es5506_device>("ensoniq");
 	ensoniq->set_region2("ensoniq.2");
-	ensoniq->set_addrmap(3, &macrossp_state::macrossp_es5506_bank3_map);
+	ensoniq->set_addrmap(3, &macrossp_state::es5506_bank3_map);
 }
 
 
@@ -1183,34 +1058,34 @@ ROM_START( macrossp )
 	ROM_REGION( 0x20000, "user1", 0 )
 	ROM_LOAD( "bp964a.u49", 0x000000, 0x020000, CRC(ad203f76) SHA1(3eb86eeeb020349dfd88ebc8b4fc9579d1cc50fb) )  // 'BIOS'
 
-	ROM_REGION( 0x1000000, "gfx1", 0 ) /* sprites - 16x16x8 */
+	ROM_REGION( 0x1000000, "sprites", 0 ) // sprites - 16x16x8
 	ROM_LOAD32_BYTE( "bp964a.u9",  0x000003, 0x400000, CRC(bd51a70d) SHA1(3447ae9d368e4e33df2d4e2848b4fd5aa0fc6840) )
 	ROM_LOAD32_BYTE( "bp964a.u10", 0x000002, 0x400000, CRC(ab84bba7) SHA1(d30876b2e45c4b78cda27d3c648100e60f739d9c) )
 	ROM_LOAD32_BYTE( "bp964a.u11", 0x000001, 0x400000, CRC(b9ae1d0b) SHA1(bc541a8bd622c99cf5065b3a793f0b5f6420ac64) )
 	ROM_LOAD32_BYTE( "bp964a.u12", 0x000000, 0x400000, CRC(8dda1052) SHA1(c374335e98859ae98ac392a7cdb44f15b4e1c23a) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) /* backgrounds - 16x16x8 */
+	ROM_REGION( 0x800000, "bgtiles0", 0 ) // backgrounds - 16x16x8
 	ROM_LOAD( "bp964a.u13", 0x000000, 0x400000, CRC(f4d3c5bf) SHA1(82522d276a6d49148da8a4fb11846a039429bcf8) )
 	ROM_LOAD( "bp964a.u14", 0x400000, 0x400000, CRC(4f2dd1b2) SHA1(30a2c9fb26bca8bb27fbc5637878f99e7f6ad8f4) )
 
-	ROM_REGION( 0x800000, "gfx3", 0 ) /* backgrounds - 16x16x8 */
+	ROM_REGION( 0x800000, "bgtiles1", 0 ) // backgrounds - 16x16x8
 	ROM_LOAD( "bp964a.u15", 0x000000, 0x400000, CRC(5b97a870) SHA1(16f3921649b28ecb6d628871214f972333bbeca4) )
 	ROM_LOAD( "bp964a.u16", 0x400000, 0x400000, CRC(c8a0cd64) SHA1(2a30a4d4ec3f94631783eb08c62003b116bb2ee3) )
 
-	ROM_REGION( 0x800000, "gfx4", 0 ) /* backgrounds - 16x16x8 */
+	ROM_REGION( 0x800000, "bgtiles2", 0 ) // backgrounds - 16x16x8
 	ROM_LOAD( "bp964a.u17", 0x000000, 0x400000, CRC(f2470876) SHA1(e683208432f71f3cc19ced245fa5b8a82466d19b) )
 	ROM_LOAD( "bp964a.u18", 0x400000, 0x400000, CRC(52ef21f3) SHA1(08fb1969ad0ffd0c5bf11d3d5448a26112d562b0) )
 
-	ROM_REGION( 0x400000, "gfx5", 0 ) /* foreground - 16x16x4 */
+	ROM_REGION( 0x400000, "fgtiles", 0 ) // foreground - 16x16x4
 	ROM_LOAD( "bp964a.u19", 0x000000, 0x080000, CRC(19c7acd9) SHA1(b7631e74f359c5570c44addf46c3e96c80adc6c3) )
 
 	ROM_REGION16_BE( 0x800000, "ensoniq.0", ROMREGION_ERASEFF )
 	ROM_LOAD16_BYTE( "bp964a.u24", 0x000000, 0x400000, CRC(93f90336) SHA1(75daa2f8cedc732cf5ef98254f61748c94b94aea) )
 
 	ROM_REGION( 0x0600, "plds", 0 )
-	ROM_LOAD( "u8.u8",     0x0000, 0x0117, CRC(99bd3cc1) SHA1(b0d3ac93cb5d2857cf9c184c7a2b4afa0211d588) ) /* unprotected GAL16V8B */
-	ROM_LOAD( "u9.u9",     0x0200, 0x0117, CRC(480f4860) SHA1(7ff3723122cbdda5c0dcea5167508e9a7437f551) ) /* unprotected GAL16V8B */
-	ROM_LOAD( "u200.u200", 0x0400, 0x0117, CRC(9343ad76) SHA1(a2adf2510011078ee9fae65acdd2daa0ffab48f6) ) /* unprotected GAL16V8B */
+	ROM_LOAD( "u8.u8",     0x0000, 0x0117, CRC(99bd3cc1) SHA1(b0d3ac93cb5d2857cf9c184c7a2b4afa0211d588) ) // unprotected GAL16V8B
+	ROM_LOAD( "u9.u9",     0x0200, 0x0117, CRC(480f4860) SHA1(7ff3723122cbdda5c0dcea5167508e9a7437f551) ) // unprotected GAL16V8B
+	ROM_LOAD( "u200.u200", 0x0400, 0x0117, CRC(9343ad76) SHA1(a2adf2510011078ee9fae65acdd2daa0ffab48f6) ) // unprotected GAL16V8B
 ROM_END
 
 ROM_START( quizmoon )
@@ -1231,23 +1106,23 @@ ROM_START( quizmoon )
 	ROM_REGION( 0x20000, "user1", 0 )
 	ROM_LOAD( "u49.bin", 0x000000, 0x020000, CRC(1590ad81) SHA1(04fb8119d9eafc6d2a921700dfb11e9c8b705c88) )  // 'BIOS'
 
-	ROM_REGION( 0x1000000, "gfx1", 0 )
+	ROM_REGION( 0x1000000, "sprites", 0 )
 	ROM_LOAD32_BYTE( "u9.bin",  0x0000003, 0x0400000, CRC(aaaf2ca9) SHA1(b9e59590daf4cdee4b1deeb6d4ecc80eb12a2e18) )
 	ROM_LOAD32_BYTE( "u10.bin", 0x0000002, 0x0400000, CRC(f0349691) SHA1(623a680ad164d407be0af585a15540f0dca995a4) )
 	ROM_LOAD32_BYTE( "u11.bin", 0x0000001, 0x0400000, CRC(893ab178) SHA1(ba68b9a3e81af4c2565715504ada35c7da3f135f) )
 	ROM_LOAD32_BYTE( "u12.bin", 0x0000000, 0x0400000, CRC(39b731b8) SHA1(2bf1d083fc6d8058a0d26b29714945e8be0e2c79) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 )
+	ROM_REGION( 0x400000, "bgtiles0", 0 )
 	ROM_LOAD( "u13.bin", 0x0000000, 0x0400000, CRC(3dcbb041) SHA1(fcff67113707fcf14d49538551724490498c0909) )
 
-	ROM_REGION( 0x400000, "gfx3", 0 )
+	ROM_REGION( 0x400000, "bgtiles1", 0 )
 	ROM_LOAD( "u15.bin", 0x0000000, 0x0400000, CRC(b84224f0) SHA1(7163aec2cc118111b2c5d8deb61133d762a5d74c) )
 
-	ROM_REGION( 0x0200000, "gfx4", 0 )
+	ROM_REGION( 0x0200000, "bgtiles2", 0 )
 	ROM_LOAD( "u17.bin", 0x0000000, 0x0200000, CRC(ff93c949) SHA1(13917d73a6cb70d03d0335bd816bf6b094758d0b) )
 
-	ROM_REGION( 0x400000, "gfx5", ROMREGION_ERASE00 )
-	/* nothing on this game? */
+	ROM_REGION( 0x400000, "fgtiles", ROMREGION_ERASE00 )
+	// nothing on this game?
 
 	ROM_REGION16_BE( 0x800000, "ensoniq.0", 0 )
 	ROM_LOAD16_BYTE( "u26.bin", 0x0000000, 0x0400000, CRC(6c8f30d4) SHA1(7e215589e4a52cbce7f2bb31b333f874a9f83d00) )
@@ -1294,4 +1169,4 @@ void macrossp_state::init_quizmoon()
 
 
 GAME( 1996, macrossp, 0, macrossp, macrossp, macrossp_state, init_macrossp, ROT270, "MOSS / Banpresto", "Macross Plus", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
-GAME( 1997, quizmoon, 0, quizmoon, quizmoon, macrossp_state, init_quizmoon, ROT0,   "Banpresto", "Quiz Bishoujo Senshi Sailor Moon - Chiryoku Tairyoku Toki no Un", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1997, quizmoon, 0, quizmoon, quizmoon, macrossp_state, init_quizmoon, ROT0,   "Banpresto", "Quiz Bishoujo Senshi Sailor Moon - Chiryoku Tairyoku Toki no Un", MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
- Use generic gfx decode layout
- Use array for background tilemaps and related stuffs
- Fix code style consistency
- Use C++ style single line comments
- Reduce literal tag usages
- Make some variables constant
- Use cliprect for background drawing
- Fix ROM region and function namings
- Reduce duplicates
- Fix spacing
- Use correct typename for member variables
- Demote quizmoon MACHINE_IMPERFECT_GRAPHICS and MACHINE_IMPERFECT_SOUND via incorrect blending method and sound in title scene