### PR TITLE
new NOT WORKING Software List entries (CocoPad)

### DIFF
--- a/hash/leapfrog_leappad_cart.xml
+++ b/hash/leapfrog_leappad_cart.xml
@@ -995,9 +995,10 @@ license:CC0-1.0
 	<!-- CocoPad (Japanese) cartridges -->
 
 	<software name="ecchello1" supported="no">
-		<description>ECC Junior Say Hello 1 (Japan)</description>
+		<description>ECC Junior no hajimete eikaiwa! 1 Eigo de tanoshiku Say Hello! (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
+		<info name="alt_title" value="ECCジュニアのはじめて英会話！１　英語でたのしくSay Hello!" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p4-0085a.u1" size="0x200000" crc="453d216d" sha1="a5c716dde0269fa7a0d96656f0348d6ef1c3cdf3" />
@@ -1006,9 +1007,10 @@ license:CC0-1.0
 	</software>
 
 	<software name="funtogeth" supported="no">
-		<description>Have Fun Together (Japan)</description>
+		<description>Minna de tanoshiku! CoCoPad (Otameshi soft) (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
+		<info name="alt_title" value="みんなでたのしく！ココパッド　おためしソフト" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p4-0092b.u1" size="0x200000" crc="3dc3d95d" sha1="0b2adb553b0349f7447778b00e9d2728eed88e64" />
@@ -1017,9 +1019,10 @@ license:CC0-1.0
 	</software>
 
 	<software name="bennyeng2" supported="no">
-		<description>Benny and Friends English Book Volume 2 (Japan)</description>
+		<description>Benny and Friends English Book Vol. 2 -Majo to taiketsu! Daibouken- (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
+		<info name="alt_title" value="Benny and Friends English Book Vol. 2 -魔女と対決！大冒険-" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p4-0122.u1" size="0x200000" crc="d0491a22" sha1="b37a778028cd6cb5c40843cf429eea2aad41bd57" />
@@ -1028,9 +1031,10 @@ license:CC0-1.0
 	</software>
 
 	<software name="thomasj" supported="no">
-		<description>Thomas and Friends (Japan)</description>
+		<description>Kikansha Thomas to nakamatachi - Kikansha Thomas Yakunitatsu kikansha (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
+		<info name="alt_title" value="きかんしゃトーマスとなかまたち - きかんしゃトーマス　やくにたつきかんしゃ" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p4-0181.u1" size="0x200000" crc="e31a6683" sha1="5f2896cfea18860c0b7dc73cf5b47f2b35149c7b" />
@@ -1039,9 +1043,10 @@ license:CC0-1.0
 	</software>
 
 	<software name="multy2j" supported="no">
-		<description>Multiplication Year 2 (Japan)</description>
+		<description>Shinkenzemi Challenge 2 nensei Korasho to issho ni kuku o oboeyou! (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
+		<info name="alt_title" value="進研ゼミ・チャレンジ2年生 コラショといっしょに九九をおぼえよう！" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p4-0190.u1" size="0x200000" crc="041c1679" sha1="593df29aad1103d386c389fd3ede60bb18ac8a1a" />
@@ -1050,9 +1055,10 @@ license:CC0-1.0
 	</software>
 
 	<software name="anpapinj" supported="no">
-		<description>Anpanman's Pinocchio (Japan)</description>
+		<description>Anpanman no CoCoPad de aiueo kyoushitsu Pinocchio (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
+		<info name="alt_title" value="アンパンマンのココパッドであいうえお教室 Pinocchio" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p4-0105a.u1" size="0x200000" crc="c5a6557b" sha1="167b29deed25a3ceca8c373f9a76e97b474fb95f" />
@@ -1061,9 +1067,10 @@ license:CC0-1.0
 	</software>
 
 	<software name="mozartj" supported="no">
-		<description>Mozart (Japan)</description>
+		<description>Idainaru sakkyokutachi (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
+		<info name="alt_title" value="偉大なる作曲家たち" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x400000">
 				<rom name="9p4-0088a.u1" size="0x400000" crc="249a2705" sha1="1faf543902c4c5064777a911b1e914ba695981f1" />
@@ -1072,9 +1079,10 @@ license:CC0-1.0
 	</software>
 
 	<software name="anpanmnj" supported="no">
-		<description>Anpanman (Japan)</description>
+		<description>Yuuki Rinrin Anpunch! (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
+		<info name="alt_title" value="ゆうきリンリンアンパンチ！" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p4-0114a.u1" size="0x200000" crc="e4e3fa62" sha1="348d54920b146a921b59c50a246a4b1a7adf93ae" />
@@ -1083,9 +1091,10 @@ license:CC0-1.0
 	</software>
 
 	<software name="helkitj" supported="no">
-		<description>Hello Kitty (Japan)</description>
+		<description>Hello Kitty no gakkou no ichinichi (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
+		<info name="alt_title" value="ハローキティのがっこうのいちにち" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p0-0091a.u1" size="0x200000" crc="1b31d902" sha1="aa48ed1b6bc868fb4b4c4b60ad11f590b0cc026b" />
@@ -1097,6 +1106,7 @@ license:CC0-1.0
 		<description>Disney Princess (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
+		<info name="alt_title" value="" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="500-01449.u1" size="0x200000" crc="9f9c9858" sha1="c3ca1290f29a24b6bfa5d815ef9f58ad24f0f0fe" />
@@ -1105,9 +1115,10 @@ license:CC0-1.0
 	</software>
 
 	<software name="poohj" supported="no">
-		<description>Winnie the Pooh (Japan)</description>
+		<description>Kuma no Pooh-san Hachimitsu no tsubo ga ippai Pooh-san to kazu・katachi (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
+		<info name="alt_title" value="くまのプーさん　はちみつのつぼがいっぱい　プーさんとかず・かたち" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="500-01453.u1" size="0x200000" crc="233ea836" sha1="ce3fa3fdd84427356e87134b1b1c44140c18d2aa" />
@@ -1116,9 +1127,9 @@ license:CC0-1.0
 	</software>
 
 	<software name="disbf1" supported="no">
-		<description>Disney's World of English - Birthday Fun 1 (Japan)</description>
+		<description>Disney's World of English 1: Birthday Fun (Japan)</description>
 		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<publisher>LeapFrog</publisher>	
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x800000">
 				<rom name="500-10047.u1" size="0x800000" crc="d8c1afd1" sha1="05f9628a24d8fd62d09a3698ff347112d2610955" />
@@ -1127,7 +1138,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="dispic2" supported="no">
-		<description>Disney's World of English - The Picnic 2 (Japan)</description>
+		<description>Disney's World of English 2: The Picnic (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
 		<part name="cart" interface="leapfrog_leappad_cart">
@@ -1138,7 +1149,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="discirc3" supported="no">
-		<description>Disney's World of English - The Circus 3 (Japan)</description>
+		<description>Disney's World of English 3: The Circus (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
 		<part name="cart" interface="leapfrog_leappad_cart">
@@ -1149,7 +1160,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="diszoo4" supported="no">
-		<description>Disney's World of English - The Zoo 4 (Japan)</description>
+		<description>Disney's World of English 4: The Zoo (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
 		<part name="cart" interface="leapfrog_leappad_cart">
@@ -1159,10 +1170,11 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="eatnoodj" supported="no">
-		<description>Please Keep Eating the Noodles - 3 March 2007, 5 May 2007 (Japan)</description>
+	<software name="k3mar07" supported="no">
+		<description>CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (3 March 2007 - 5 May 2007) (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
+		<info name="alt_title" value="ココパッドロムカッセット　このめんをうえにしていれてね！ (3 March 2007 - 5 May 2007)" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x400000">
 				<rom name="500-12524.u1" size="0x400000" crc="0b61e024" sha1="51c36c8a199f58983b7979d18b4a5d302d78b4b3" />
@@ -1170,10 +1182,11 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="noodtopj" supported="no">
-		<description>Keep the Noodles on Top - 7 July 2007, 9 September 2007 (Japan)</description>
+	<software name="k7jul07" supported="no">
+		<description>CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (7 July 2007, 9 September 2007) (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
+		<info name="alt_title" value="ココパッドロムカッセット　このめんをうえにしていれてね！ (7 July 2007, 9 September 2007)" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="500-12789.u1" size="0x200000" crc="445316c9" sha1="9ad7b6a17b9c246ac197ffab034f2e31d8ad74a2" />
@@ -1181,10 +1194,11 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="eatnod2j" supported="no">
-		<description>Please Keep Eating the Noodles - 11 November 2007, 1 January 2008 (Japan)</description>
+	<software name="k11nov07" supported="no">
+		<description>CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (11 November 2007, 1 January 2008) (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
+		<info name="alt_title" value="ココパッドロムカッセット　このめんをうえにしていれてね！ (11 November 2007, 1 January 2008)" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x400000">
 				<rom name="500-12818.u1" size="0x400000" crc="4709b3e3" sha1="972aa48cf5194d902851197c601344d31d825c8c" />
@@ -1193,9 +1207,10 @@ license:CC0-1.0
 	</software>
 
 	<software name="abcj" supported="no">
-		<description>ABC - 3 March 2008,  5 May 2008 (Japan)</description>
+		<description>Kodomo Challenge English CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (2008/3 March - Shimajirou to Libby no ABC Adventure, 2008/5 May - Shimajirou to Libby no Touch and step game de asobou) (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
+		<info name="alt_title" value="こどもちゃれんじ English ココパッドロムカッセット　このめんをうえにしていれてね！ (2008/3 March - しまじろうとリビーのABCアドベンチャー, 2008/5 May - しまじろうとリビーのタッチアンドステップゲームであそぼう)" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x400000">
 				<rom name="500-13250.u1" size="0x400000" crc="331df5fc" sha1="ea563ded2223f2e99c89d89c53d19f36497665dc" />

--- a/hash/leapfrog_leappad_cart.xml
+++ b/hash/leapfrog_leappad_cart.xml
@@ -997,7 +997,7 @@ license:CC0-1.0
 	<software name="ecchello1" supported="no">
 		<description>ECC Junior no hajimete eikaiwa! 1 Eigo de tanoshiku Say Hello! (Japan)</description>
 		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="ECCジュニアのはじめて英会話！１　英語でたのしくSay Hello!" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
@@ -1009,7 +1009,7 @@ license:CC0-1.0
 	<software name="funtogeth" supported="no">
 		<description>Minna de tanoshiku! CoCoPad (Otameshi soft) (Japan)</description>
 		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="みんなでたのしく！ココパッド　おためしソフト" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
@@ -1021,7 +1021,7 @@ license:CC0-1.0
 	<software name="bennyeng2" supported="no">
 		<description>Benny and Friends English Book Vol. 2 -Majo to taiketsu! Daibouken- (Japan)</description>
 		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<publisher>LeapFrog / Sega Toys / Benesse</publisher>
 		<info name="alt_title" value="Benny and Friends English Book Vol. 2 -魔女と対決！大冒険-" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
@@ -1032,8 +1032,8 @@ license:CC0-1.0
 
 	<software name="thomasj" supported="no">
 		<description>Kikansha Thomas to nakamatachi - Kikansha Thomas Yakunitatsu kikansha (Japan)</description>
-		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<year>2004</year>
+		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="きかんしゃトーマスとなかまたち - きかんしゃトーマス　やくにたつきかんしゃ" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
@@ -1044,8 +1044,8 @@ license:CC0-1.0
 
 	<software name="multy2j" supported="no">
 		<description>Shinkenzemi Challenge 2 nensei Korasho to issho ni kuku o oboeyou! (Japan)</description>
-		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<year>2004</year>
+		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="進研ゼミ・チャレンジ2年生 コラショといっしょに九九をおぼえよう！" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
@@ -1069,7 +1069,7 @@ license:CC0-1.0
 	<software name="mozartj" supported="no">
 		<description>Idainaru sakkyokutachi (Japan)</description>
 		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="偉大なる作曲家たち" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x400000">
@@ -1081,7 +1081,7 @@ license:CC0-1.0
 	<software name="anpanmnj" supported="no">
 		<description>Yuuki Rinrin Anpunch! (Japan)</description>
 		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<publisher>LeapFrog / Bandai</publisher>
 		<info name="alt_title" value="ゆうきリンリンアンパンチ！" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
@@ -1093,7 +1093,7 @@ license:CC0-1.0
 	<software name="helkitj" supported="no">
 		<description>Hello Kitty no gakkou no ichinichi (Japan)</description>
 		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="ハローキティのがっこうのいちにち" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
@@ -1104,8 +1104,8 @@ license:CC0-1.0
 
 	<software name="disprinj" supported="no">
 		<description>Disney Princess (Japan)</description>
-		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<year>2003</year>
+		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
@@ -1116,8 +1116,8 @@ license:CC0-1.0
 
 	<software name="poohj" supported="no">
 		<description>Kuma no Pooh-san Hachimitsu no tsubo ga ippai Pooh-san to kazu・katachi (Japan)</description>
-		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<year>2003</year>
+		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="くまのプーさん　はちみつのつぼがいっぱい　プーさんとかず・かたち" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
@@ -1128,8 +1128,8 @@ license:CC0-1.0
 
 	<software name="disbf1" supported="no">
 		<description>Disney's World of English 1: Birthday Fun (Japan)</description>
-		<year>2002</year>
-		<publisher>LeapFrog</publisher>	
+		<year>200?</year>
+		<publisher>LeapFrog / Disney</publisher>	
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x800000">
 				<rom name="500-10047.u1" size="0x800000" crc="d8c1afd1" sha1="05f9628a24d8fd62d09a3698ff347112d2610955" />
@@ -1139,8 +1139,8 @@ license:CC0-1.0
 
 	<software name="dispic2" supported="no">
 		<description>Disney's World of English 2: The Picnic (Japan)</description>
-		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<year>200?</year>
+		<publisher>LeapFrog / Disney</publisher>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x800000">
 				<rom name="500-10504.u1" size="0x800000" crc="e4202417" sha1="d47a21db544354b44cff8d9151b852c36761ca49" />
@@ -1150,8 +1150,8 @@ license:CC0-1.0
 
 	<software name="discirc3" supported="no">
 		<description>Disney's World of English 3: The Circus (Japan)</description>
-		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<year>200?</year>
+		<publisher>LeapFrog / Disney</publisher>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x800000">
 				<rom name="500-10765.u1" size="0x800000" crc="555796f6" sha1="c814b736583afbbb1d92c86c62372038a8ca470d" />
@@ -1161,8 +1161,8 @@ license:CC0-1.0
 
 	<software name="diszoo4" supported="no">
 		<description>Disney's World of English 4: The Zoo (Japan)</description>
-		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<year>200?</year>
+		<publisher>LeapFrog / Disney</publisher>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x800000">
 				<rom name="500-11760.u1" size="0x800000" crc="32a59d3f" sha1="48cedaca3e88f865a032fdfed2fdae966dba7aed" />
@@ -1172,8 +1172,8 @@ license:CC0-1.0
 
 	<software name="k3mar07" supported="no">
 		<description>CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (3 March 2007 - 5 May 2007) (Japan)</description>
-		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<year>2007</year>
+		<publisher>LeapFrog / Benesse</publisher>
 		<info name="alt_title" value="ココパッドロムカッセット　このめんをうえにしていれてね！ (3 March 2007 - 5 May 2007)" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x400000">
@@ -1184,8 +1184,8 @@ license:CC0-1.0
 
 	<software name="k7jul07" supported="no">
 		<description>CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (7 July 2007, 9 September 2007) (Japan)</description>
-		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<year>2007</year>
+		<publisher>LeapFrog / Benesse</publisher>
 		<info name="alt_title" value="ココパッドロムカッセット　このめんをうえにしていれてね！ (7 July 2007, 9 September 2007)" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
@@ -1196,8 +1196,8 @@ license:CC0-1.0
 
 	<software name="k11nov07" supported="no">
 		<description>CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (11 November 2007, 1 January 2008) (Japan)</description>
-		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<year>2007</year>
+		<publisher>LeapFrog / Benesse</publisher>
 		<info name="alt_title" value="ココパッドロムカッセット　このめんをうえにしていれてね！ (11 November 2007, 1 January 2008)" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x400000">
@@ -1208,8 +1208,8 @@ license:CC0-1.0
 
 	<software name="abcj" supported="no">
 		<description>Kodomo Challenge English CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (2008/3 March - Shimajirou to Libby no ABC Adventure, 2008/5 May - Shimajirou to Libby no Touch and step game de asobou) (Japan)</description>
-		<year>2002</year>
-		<publisher>LeapFrog</publisher>
+		<year>2008</year>
+		<publisher>LeapFrog / Benesse</publisher>
 		<info name="alt_title" value="こどもちゃれんじ English ココパッドロムカッセット　このめんをうえにしていれてね！ (2008/3 March - しまじろうとリビーのABCアドベンチャー, 2008/5 May - しまじろうとリビーのタッチアンドステップゲームであそぼう)" />
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x400000">

--- a/hash/leapfrog_leappad_cart.xml
+++ b/hash/leapfrog_leappad_cart.xml
@@ -1087,7 +1087,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="idainaru" supported="no">
-		<description>Idainaru sakkyokutachi (Japan)</description>
+		<description>Idainaru Sakkyokukatachi (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="偉大なる作曲家たち" />
@@ -1137,10 +1137,11 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="pooh2j" supported="no">
-		<description>Winnie the Pooh 0086a (Japan)</description>
+	<software name="poohhach" supported="no">
+		<description>Kuma no Pooh-san: Pooh-san to Hachimitsu (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog / Sega Toys</publisher>
+		<info name="alt_title" value="くまのプーさん プーさんとはちみつ" />
 		<info name="serial" value="9P4-0086A"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
@@ -1149,10 +1150,11 @@ license:CC0-1.0
 		</part>
 	</software>
 	
-	<software name="lantern" supported="no">
-		<description>Goo Chocolate Lantern (Japan)</description>
+	<software name="goochoco" supported="no">
+		<description>Okaasan to Issho: Goo Choco Lantan: Spoo no Fushigi na Oto no Daibouken! (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog / Bandai</publisher>
+		<info name="alt_title" value="おかあさんといっしょ ぐ〜チョコランタン スプーのふしぎなおとのだいぼうけん!" />
 		<info name="serial" value="9P4-0113A"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">

--- a/hash/leapfrog_leappad_cart.xml
+++ b/hash/leapfrog_leappad_cart.xml
@@ -999,6 +999,7 @@ license:CC0-1.0
 		<year>2002</year>
 		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="ECCジュニアのはじめて英会話！１　英語でたのしくSay Hello!" />
+		<info name="serial" value="9P4-0085A"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p4-0085a.u1" size="0x200000" crc="453d216d" sha1="a5c716dde0269fa7a0d96656f0348d6ef1c3cdf3" />
@@ -1006,11 +1007,12 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="funtogeth" supported="no">
+	<software name="minnatan" supported="no">
 		<description>Minna de tanoshiku! CoCoPad (Otameshi soft) (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="みんなでたのしく！ココパッド　おためしソフト" />
+		<info name="serial" value="9P4-0092B"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p4-0092b.u1" size="0x200000" crc="3dc3d95d" sha1="0b2adb553b0349f7447778b00e9d2728eed88e64" />
@@ -1023,6 +1025,7 @@ license:CC0-1.0
 		<year>2002</year>
 		<publisher>LeapFrog / Sega Toys / Benesse</publisher>
 		<info name="alt_title" value="Benny and Friends English Book Vol. 2 -魔女と対決！大冒険-" />
+		<info name="serial" value="501-00852 / 9P4-0122"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p4-0122.u1" size="0x200000" crc="d0491a22" sha1="b37a778028cd6cb5c40843cf429eea2aad41bd57" />
@@ -1035,6 +1038,7 @@ license:CC0-1.0
 		<year>2004</year>
 		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="きかんしゃトーマスとなかまたち - きかんしゃトーマス　やくにたつきかんしゃ" />
+		<info name="serial" value="500-10677 / 9P4-0181"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p4-0181.u1" size="0x200000" crc="e31a6683" sha1="5f2896cfea18860c0b7dc73cf5b47f2b35149c7b" />
@@ -1042,11 +1046,12 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="multy2j" supported="no">
+	<software name="shinch2j" supported="no">
 		<description>Shinkenzemi Challenge 2 nensei Korasho to issho ni kuku o oboeyou! (Japan)</description>
 		<year>2004</year>
-		<publisher>LeapFrog / Sega Toys</publisher>
+		<publisher>LeapFrog / Sega Toys / Benesse</publisher>
 		<info name="alt_title" value="進研ゼミ・チャレンジ2年生 コラショといっしょに九九をおぼえよう！" />
+		<info name="serial" value="9P4-0190"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p4-0190.u1" size="0x200000" crc="041c1679" sha1="593df29aad1103d386c389fd3ede60bb18ac8a1a" />
@@ -1054,11 +1059,12 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="anpapinj" supported="no">
+	<software name="anpapino" supported="no">
 		<description>Anpanman no CoCoPad de aiueo kyoushitsu Pinocchio (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
 		<info name="alt_title" value="アンパンマンのココパッドであいうえお教室 Pinocchio" />
+		<info name="serial" value="500-00762 / 9P4-0105A"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p4-0105a.u1" size="0x200000" crc="c5a6557b" sha1="167b29deed25a3ceca8c373f9a76e97b474fb95f" />
@@ -1066,11 +1072,12 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="mozartj" supported="no">
+	<software name="idainaru" supported="no">
 		<description>Idainaru sakkyokutachi (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="偉大なる作曲家たち" />
+		<info name="serial" value="9P4-0088A"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x400000">
 				<rom name="9p4-0088a.u1" size="0x400000" crc="249a2705" sha1="1faf543902c4c5064777a911b1e914ba695981f1" />
@@ -1078,11 +1085,12 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="anpanmnj" supported="no">
+	<software name="anpunchj" supported="no">
 		<description>Yuuki Rinrin Anpunch! (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog / Bandai</publisher>
 		<info name="alt_title" value="ゆうきリンリンアンパンチ！" />
+		<info name="serial" value="9P4-0114A"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p4-0114a.u1" size="0x200000" crc="e4e3fa62" sha1="348d54920b146a921b59c50a246a4b1a7adf93ae" />
@@ -1095,6 +1103,7 @@ license:CC0-1.0
 		<year>2002</year>
 		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="ハローキティのがっこうのいちにち" />
+		<info name="serial" value="500-00873 / 9P0-0091A"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="9p0-0091a.u1" size="0x200000" crc="1b31d902" sha1="aa48ed1b6bc868fb4b4c4b60ad11f590b0cc026b" />
@@ -1105,8 +1114,8 @@ license:CC0-1.0
 	<software name="disprinj" supported="no">
 		<description>Disney Princess (Japan)</description>
 		<year>2003</year>
-		<publisher>LeapFrog / Sega Toys</publisher>
-		<info name="alt_title" value="" />
+		<publisher>LeapFrog / Sega Toys / Disney</publisher>
+		<info name="serial" value="500-01449"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="500-01449.u1" size="0x200000" crc="9f9c9858" sha1="c3ca1290f29a24b6bfa5d815ef9f58ad24f0f0fe" />
@@ -1114,11 +1123,12 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="poohj" supported="no">
+	<software name="kumpoohj" supported="no">
 		<description>Kuma no Pooh-san Hachimitsu no tsubo ga ippai Pooh-san to kazu・katachi (Japan)</description>
 		<year>2003</year>
 		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="くまのプーさん　はちみつのつぼがいっぱい　プーさんとかず・かたち" />
+		<info name="serial" value="500-01453"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="500-01453.u1" size="0x200000" crc="233ea836" sha1="ce3fa3fdd84427356e87134b1b1c44140c18d2aa" />
@@ -1126,10 +1136,11 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="disbf1" supported="no">
+	<software name="dis1bf" supported="no">
 		<description>Disney's World of English 1: Birthday Fun (Japan)</description>
 		<year>200?</year>
 		<publisher>LeapFrog / Disney</publisher>	
+		<info name="serial" value="500-10047"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x800000">
 				<rom name="500-10047.u1" size="0x800000" crc="d8c1afd1" sha1="05f9628a24d8fd62d09a3698ff347112d2610955" />
@@ -1137,10 +1148,11 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="dispic2" supported="no">
+	<software name="dis2pic" supported="no">
 		<description>Disney's World of English 2: The Picnic (Japan)</description>
 		<year>200?</year>
 		<publisher>LeapFrog / Disney</publisher>
+		<info name="serial" value="500-10504"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x800000">
 				<rom name="500-10504.u1" size="0x800000" crc="e4202417" sha1="d47a21db544354b44cff8d9151b852c36761ca49" />
@@ -1148,10 +1160,11 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="discirc3" supported="no">
+	<software name="dis3circ" supported="no">
 		<description>Disney's World of English 3: The Circus (Japan)</description>
 		<year>200?</year>
 		<publisher>LeapFrog / Disney</publisher>
+		<info name="serial" value="500-10765"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x800000">
 				<rom name="500-10765.u1" size="0x800000" crc="555796f6" sha1="c814b736583afbbb1d92c86c62372038a8ca470d" />
@@ -1159,10 +1172,11 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="diszoo4" supported="no">
+	<software name="dis4zoo" supported="no">
 		<description>Disney's World of English 4: The Zoo (Japan)</description>
 		<year>200?</year>
 		<publisher>LeapFrog / Disney</publisher>
+		<info name="serial" value="500-11760"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x800000">
 				<rom name="500-11760.u1" size="0x800000" crc="32a59d3f" sha1="48cedaca3e88f865a032fdfed2fdae966dba7aed" />
@@ -1175,6 +1189,7 @@ license:CC0-1.0
 		<year>2007</year>
 		<publisher>LeapFrog / Benesse</publisher>
 		<info name="alt_title" value="ココパッドロムカッセット　このめんをうえにしていれてね！ (3 March 2007 - 5 May 2007)" />
+		<info name="serial" value="500-12524"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x400000">
 				<rom name="500-12524.u1" size="0x400000" crc="0b61e024" sha1="51c36c8a199f58983b7979d18b4a5d302d78b4b3" />
@@ -1187,6 +1202,7 @@ license:CC0-1.0
 		<year>2007</year>
 		<publisher>LeapFrog / Benesse</publisher>
 		<info name="alt_title" value="ココパッドロムカッセット　このめんをうえにしていれてね！ (7 July 2007, 9 September 2007)" />
+		<info name="serial" value="500-12789"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="500-12789.u1" size="0x200000" crc="445316c9" sha1="9ad7b6a17b9c246ac197ffab034f2e31d8ad74a2" />
@@ -1199,6 +1215,7 @@ license:CC0-1.0
 		<year>2007</year>
 		<publisher>LeapFrog / Benesse</publisher>
 		<info name="alt_title" value="ココパッドロムカッセット　このめんをうえにしていれてね！ (11 November 2007, 1 January 2008)" />
+		<info name="serial" value="500-12818"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x400000">
 				<rom name="500-12818.u1" size="0x400000" crc="4709b3e3" sha1="972aa48cf5194d902851197c601344d31d825c8c" />
@@ -1211,6 +1228,7 @@ license:CC0-1.0
 		<year>2008</year>
 		<publisher>LeapFrog / Benesse</publisher>
 		<info name="alt_title" value="こどもちゃれんじ English ココパッドロムカッセット　このめんをうえにしていれてね！ (2008/3 March - しまじろうとリビーのABCアドベンチャー, 2008/5 May - しまじろうとリビーのタッチアンドステップゲームであそぼう)" />
+		<info name="serial" value="500-13250"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<dataarea name="rom" size="0x400000">
 				<rom name="500-13250.u1" size="0x400000" crc="331df5fc" sha1="ea563ded2223f2e99c89d89c53d19f36497665dc" />

--- a/hash/leapfrog_leappad_cart.xml
+++ b/hash/leapfrog_leappad_cart.xml
@@ -1061,7 +1061,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="shinch2j" supported="no">
-		<description>Shinkenzemi Challenge 2 nensei Korasho to issho ni kuku o oboeyou! (Japan)</description>
+		<description>Shinkenzemi Challenge 2-nensei Korasho to issho ni kuku o oboeyou! (Japan)</description>
 		<year>2004</year>
 		<publisher>LeapFrog / Sega Toys / Benesse</publisher>
 		<info name="alt_title" value="進研ゼミ・チャレンジ2年生 コラショといっしょに九九をおぼえよう！" />
@@ -1074,7 +1074,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="anpapino" supported="no">
-		<description>Anpanman no CoCoPad de aiueo kyoushitsu Pinocchio (Japan)</description>
+		<description>Anpanman no CoCoPad de AIUEO kyoushitsu Pinocchio (Japan)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
 		<info name="alt_title" value="アンパンマンのココパッドであいうえお教室 Pinocchio" />
@@ -1164,7 +1164,7 @@ license:CC0-1.0
 	</software>	
 
 	<software name="kumpoohj" supported="no">
-		<description>Kuma no Pooh-san Hachimitsu no tsubo ga ippai Pooh-san to kazu・katachi (Japan)</description>
+		<description>Kuma no Pooh-san Hachimitsu no tsubo ga ippai Pooh-san to kazu·katachi (Japan)</description>
 		<year>2003</year>
 		<publisher>LeapFrog / Sega Toys</publisher>
 		<info name="alt_title" value="くまのプーさん　はちみつのつぼがいっぱい　プーさんとかず・かたち" />
@@ -1225,7 +1225,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="k3mar07" supported="no">
-		<description>CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (3 March 2007 - 5 May 2007) (Japan)</description>
+		<description>CoCoPad ROM Cassette Kono men o ue ni shiteirete ne! (3 March 2007 - 5 May 2007) (Japan)</description>
 		<year>2007</year>
 		<publisher>LeapFrog / Benesse</publisher>
 		<info name="alt_title" value="ココパッドロムカッセット　このめんをうえにしていれてね！ (3 March 2007 - 5 May 2007)" />
@@ -1238,7 +1238,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="k7jul07" supported="no">
-		<description>CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (7 July 2007, 9 September 2007) (Japan)</description>
+		<description>CoCoPad ROM Cassette Kono men o ue ni shiteirete ne! (7 July 2007, 9 September 2007) (Japan)</description>
 		<year>2007</year>
 		<publisher>LeapFrog / Benesse</publisher>
 		<info name="alt_title" value="ココパッドロムカッセット　このめんをうえにしていれてね！ (7 July 2007, 9 September 2007)" />
@@ -1251,7 +1251,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="k11nov07" supported="no">
-		<description>CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (11 November 2007, 1 January 2008) (Japan)</description>
+		<description>CoCoPad ROM Cassette Kono men o ue ni shiteirete ne! (11 November 2007, 1 January 2008) (Japan)</description>
 		<year>2007</year>
 		<publisher>LeapFrog / Benesse</publisher>
 		<info name="alt_title" value="ココパッドロムカッセット　このめんをうえにしていれてね！ (11 November 2007, 1 January 2008)" />
@@ -1264,7 +1264,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="abcj" supported="no">
-		<description>Kodomo Challenge English CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (2008/3 March - Shimajirou to Libby no ABC Adventure, 2008/5 May - Shimajirou to Libby no Touch and step game de asobou) (Japan)</description>
+		<description>Kodomo Challenge English CoCoPad ROM Cassette Kono men o ue ni shiteirete ne! (2008/3 March - Shimajirou to Libby no ABC Adventure, 2008/5 May - Shimajirou to Libby no Touch and step game de asobou) (Japan)</description>
 		<year>2008</year>
 		<publisher>LeapFrog / Benesse</publisher>
 		<info name="alt_title" value="こどもちゃれんじ English ココパッドロムカッセット　このめんをうえにしていれてね！ (2008/3 March - しまじろうとリビーのABCアドベンチャー, 2008/5 May - しまじろうとリビーのタッチアンドステップゲームであそぼう)" />

--- a/hash/leapfrog_leappad_cart.xml
+++ b/hash/leapfrog_leappad_cart.xml
@@ -199,6 +199,20 @@ license:CC0-1.0
 			</dataarea>
 		</part>
 	</software>
+	
+	<software name="smartguid4" supported="no">
+		<description>FUN-damentals Series - Smart Guide to 4rd Grade (UK)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-00534"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb_rev" value="REV.A"/>
+			<feature name="u1" value="LeapFrog 2002 32M DIE ROM"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-00534.u1" size="0x400000" crc="0944792f" sha1="f013394ebddb6d89c2feeb3d645c170e2d7be746" />
+			</dataarea>
+		</part>
+	</software>	
 
 	<software name="smartguid5" supported="no">
 		<description>FUN-damentals Series - Smart Guide to 5th Grade (UK)</description>
@@ -1122,6 +1136,30 @@ license:CC0-1.0
 			</dataarea>
 		</part>
 	</software>
+
+	<software name="pooh2j" supported="no">
+		<description>Winnie the Pooh 0086a (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog / Sega Toys</publisher>
+		<info name="serial" value="9P4-0086A"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="9p4-0086a.u1" size="0x200000" crc="4aa4df02" sha1="5b66a9e46da71e983b72f3aff049b217b197b37f" />
+			</dataarea>
+		</part>
+	</software>
+	
+	<software name="lantern" supported="no">
+		<description>Goo Chocolate Lantern (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog / Bandai</publisher>
+		<info name="serial" value="9P4-0113A"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="9p4-0113a.u1" size="0x200000" crc="04c4174a" sha1="c9e4a1f22a69f7d60e1d1b11bca8338546e52271" />
+			</dataarea>
+		</part>
+	</software>	
 
 	<software name="kumpoohj" supported="no">
 		<description>Kuma no Pooh-san Hachimitsu no tsubo ga ippai Pooh-san to kazu・katachi (Japan)</description>

--- a/hash/leapfrog_leappad_cart.xml
+++ b/hash/leapfrog_leappad_cart.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="leapfrog_leappad_cart" description="LeapFrog LeapPad cartridges">
+<softwarelist name="leapfrog_leappad_cart" description="LeapFrog LeapPad / CocoPad cartridges">
 
 	<software name="tiggerbnca" cloneof="tiggerbnc" supported="no">
 		<description>Disney's Bounce, Tigger, Bounce (UK)</description>
@@ -988,6 +988,217 @@ license:CC0-1.0
 			<feature name="u1" value="JS28F320"/>
 			<dataarea name="rom" size="0x400000">
 				<rom name="500-13044 UBL - Sed de Saber - English as a Second Language Edition - Book 6 - How do you say... .bin" size="0x400000" crc="5ed699f6" sha1="902c70e0437525de94a8febab794e46b8a55f5c1" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- CocoPad (Japanese) cartridges -->
+
+	<software name="ecchello1" supported="no">
+		<description>ECC Junior Say Hello 1 (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="9p4-0085a.u1" size="0x200000" crc="453d216d" sha1="a5c716dde0269fa7a0d96656f0348d6ef1c3cdf3" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="funtogeth" supported="no">
+		<description>Have Fun Together (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="9p4-0092b.u1" size="0x200000" crc="3dc3d95d" sha1="0b2adb553b0349f7447778b00e9d2728eed88e64" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bennyeng2" supported="no">
+		<description>Benny and Friends English Book Volume 2 (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="9p4-0122.u1" size="0x200000" crc="d0491a22" sha1="b37a778028cd6cb5c40843cf429eea2aad41bd57" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="thomasj" supported="no">
+		<description>Thomas and Friends (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="9p4-0181.u1" size="0x200000" crc="e31a6683" sha1="5f2896cfea18860c0b7dc73cf5b47f2b35149c7b" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="multy2j" supported="no">
+		<description>Multiplication Year 2 (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="9p4-0190.u1" size="0x200000" crc="041c1679" sha1="593df29aad1103d386c389fd3ede60bb18ac8a1a" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="anpapinj" supported="no">
+		<description>Anpanman's Pinocchio (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="9p4-0105a.u1" size="0x200000" crc="c5a6557b" sha1="167b29deed25a3ceca8c373f9a76e97b474fb95f" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mozartj" supported="no">
+		<description>Mozart (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x400000">
+				<rom name="9p4-0088a.u1" size="0x400000" crc="249a2705" sha1="1faf543902c4c5064777a911b1e914ba695981f1" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="anpanmnj" supported="no">
+		<description>Anpanman (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="9p4-0114a.u1" size="0x200000" crc="e4e3fa62" sha1="348d54920b146a921b59c50a246a4b1a7adf93ae" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="helkitj" supported="no">
+		<description>Hello Kitty (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="9p0-0091a.u1" size="0x200000" crc="1b31d902" sha1="aa48ed1b6bc868fb4b4c4b60ad11f590b0cc026b" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="disprinj" supported="no">
+		<description>Disney Princess (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="500-01449.u1" size="0x200000" crc="9f9c9858" sha1="c3ca1290f29a24b6bfa5d815ef9f58ad24f0f0fe" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="poohj" supported="no">
+		<description>Winnie the Pooh (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="500-01453.u1" size="0x200000" crc="233ea836" sha1="ce3fa3fdd84427356e87134b1b1c44140c18d2aa" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="disbf1" supported="no">
+		<description>Disney's World of English - Birthday Fun 1 (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-10047.u1" size="0x800000" crc="d8c1afd1" sha1="05f9628a24d8fd62d09a3698ff347112d2610955" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dispic2" supported="no">
+		<description>Disney's World of English - The Picnic 2 (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-10504.u1" size="0x800000" crc="e4202417" sha1="d47a21db544354b44cff8d9151b852c36761ca49" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="discirc3" supported="no">
+		<description>Disney's World of English - The Circus 3 (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-10765.u1" size="0x800000" crc="555796f6" sha1="c814b736583afbbb1d92c86c62372038a8ca470d" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="diszoo4" supported="no">
+		<description>Disney's World of English - The Zoo 4 (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11760.u1" size="0x800000" crc="32a59d3f" sha1="48cedaca3e88f865a032fdfed2fdae966dba7aed" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="eatnoodj" supported="no">
+		<description>Please Keep Eating the Noodles - 3 March 2007, 5 May 2007 (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12524.u1" size="0x400000" crc="0b61e024" sha1="51c36c8a199f58983b7979d18b4a5d302d78b4b3" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="noodtopj" supported="no">
+		<description>Keep the Noodles on Top - 7 July 2007, 9 September 2007 (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="500-12789.u1" size="0x200000" crc="445316c9" sha1="9ad7b6a17b9c246ac197ffab034f2e31d8ad74a2" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="eatnod2j" supported="no">
+		<description>Please Keep Eating the Noodles - 11 November 2007, 1 January 2008 (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12818.u1" size="0x400000" crc="4709b3e3" sha1="972aa48cf5194d902851197c601344d31d825c8c" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="abcj" supported="no">
+		<description>ABC - 3 March 2008,  5 May 2008 (Japan)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-13250.u1" size="0x400000" crc="331df5fc" sha1="ea563ded2223f2e99c89d89c53d19f36497665dc" />
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
new NOT WORKING Software List entries
--------------------------

leapfrog_leappad_cart.xml  [David Haywood, Team Europe]

ecchello1: ECC Junior no hajimete eikaiwa! 1 Eigo de tanoshiku Say Hello! (Japan)
funtogeth: Minna de tanoshiku! CoCoPad (Otameshi soft) (Japan)
bennyeng2: Benny and Friends English Book Vol. 2 -Majo to taiketsu! Daibouken- (Japan)
thomasj: Kikansha Thomas to nakamatachi - Kikansha Thomas Yakunitatsu kikansha (Japan)
multy2j: Shinkenzemi Challenge 2 nensei Korasho to issho ni kuku o oboeyou! (Japan)
anpapinj: Anpanman no CoCoPad de aiueo kyoushitsu Pinocchio (Japan)
idainaru: Idainaru Sakkyokukatachi (Japan)
anpanmnj: Yuuki Rinrin Anpunch! (Japan)
helkitj: Hello Kitty no gakkou no ichinichi (Japan)
disprinj: Disney Princess (Japan)
poohj: Kuma no Pooh-san Hachimitsu no tsubo ga ippai Pooh-san to kazu・katachi (Japan)
disbf1: Disney's World of English 1: Birthday Fun (Japan)
dispic2: Disney's World of English 2: The Picnic (Japan)
discirc3: Disney's World of English 3: The Circus (Japan)
diszoo4: Disney's World of English 4: The Zoo (Japan)
k3mar07: CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (3 March 2007 - 5 May 2007) (Japan)
k7jul07: CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (7 July 2007, 9 September 2007) (Japan)
k11nov07: CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (11 November 2007, 1 January 2008) (Japan)
abcj: Kodomo Challenge English CoCoPad Rom Cassette Kono men o ue ni shiteirete ne! (2008/3 March - Shimajirou to Libby no ABC Adventure, 2008/5 May - Shimajirou to Libby no Touch and step game de asobou) (Japan)
smartguid4 - FUN-damentals Series - Smart Guide to 4rd Grade (UK)
goochoco- Okaasan to Issho: Goo Choco Lantan: Spoo no Fushigi na Oto no Daibouken! (Japan)
poohhach- Kuma no Pooh-san: Pooh-san to Hachimitsu (Japan)