### PR TITLE
konami/xmen.cpp: Add service switch inputs

### DIFF
--- a/src/mame/konami/xmen.cpp
+++ b/src/mame/konami/xmen.cpp
@@ -20,7 +20,7 @@ The board only has one of each gfx chip, the only additional chip not found
 on the 2/4p board is 053253. This chip is also on Run n Gun which is
 likewise a 2 screen game.
 
-Reference schematics: https://github.com/jotego/jtbin/blob/master/sch/xmen.pdf
+Reverse-engineered schematics: https://github.com/jotego/jtbin/blob/master/sch/xmen.pdf
 
 ***************************************************************************/
 

--- a/src/mame/konami/xmen.cpp
+++ b/src/mame/konami/xmen.cpp
@@ -20,6 +20,8 @@ The board only has one of each gfx chip, the only additional chip not found
 on the 2/4p board is 053253. This chip is also on Run n Gun which is
 likewise a 2 screen game.
 
+Reference schematics: https://github.com/jotego/jtbin/blob/master/sch/xmen.pdf
+
 ***************************************************************************/
 
 #include "emu.h"
@@ -508,7 +510,11 @@ static INPUT_PORTS_START( xmen )
 	KONAMI16_MSB_UDLR(4, IPT_BUTTON3, IPT_COIN4 )
 
 	PORT_START("EEPROM")
-	PORT_BIT( 0x003f, IP_ACTIVE_LOW, IPT_UNKNOWN )  // unused?
+	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_SERVICE1 )
+	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_SERVICE2 )
+	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_SERVICE3 )
+	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_SERVICE4 )
+	PORT_BIT( 0x0030, IP_ACTIVE_LOW, IPT_UNKNOWN )  // unused
 	PORT_BIT( 0x0040, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER("eeprom", eeprom_serial_er5911_device, do_read)
 	PORT_BIT( 0x0080, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER("eeprom", eeprom_serial_er5911_device, ready_read)
 	PORT_BIT( 0x0100, IP_ACTIVE_LOW, IPT_START1 )


### PR DESCRIPTION
Connects service ports, following our [schematic extraction for a GX065 board](https://github.com/jotego/jtbin/blob/master/sch/xmen.pdf) (xmen 2p)

![image](https://github.com/user-attachments/assets/91e5d7c3-8f0c-4566-acdc-ba293cf16ef3)

Note that I am reviewing the schematics and the PDF may change in the coming weeks with corrections.