### PR TITLE
cpu/t11, ussr/bk: Improve interrupt handling on 1801VM1, misc fixes.

### DIFF
--- a/src/devices/cpu/t11/t11dasm.cpp
+++ b/src/devices/cpu/t11/t11dasm.cpp
@@ -19,7 +19,7 @@ const char *const t11_disassembler::regs[8] = { "R0", "R1", "R2", "R3", "R4", "R
 
 u16 t11_disassembler::r16p(offs_t &pc, const data_buffer &opcodes)
 {
-	u16 r = opcodes.r16(pc);
+	u16 r = opcodes.r16(pc & ~1);
 	pc += 2;
 	return r;
 }

--- a/src/devices/cpu/t11/t11dasm.cpp
+++ b/src/devices/cpu/t11/t11dasm.cpp
@@ -19,7 +19,7 @@ const char *const t11_disassembler::regs[8] = { "R0", "R1", "R2", "R3", "R4", "R
 
 u16 t11_disassembler::r16p(offs_t &pc, const data_buffer &opcodes)
 {
-	u16 r = opcodes.r16(pc & ~1);
+	u16 r = opcodes.r16(pc);
 	pc += 2;
 	return r;
 }

--- a/src/devices/cpu/t11/t11ops.hxx
+++ b/src/devices/cpu/t11/t11ops.hxx
@@ -352,13 +352,13 @@ void t11_device::halt(uint16_t op)
 void t11_device::illegal(uint16_t op)
 {
 	m_icount -= 48;
-	trap_to(0x08);
+	trap_to(T11_ILLINST);
 }
 
 void t11_device::illegal4(uint16_t op)
 {
 	m_icount -= 48;
-	trap_to(0x04);
+	trap_to(T11_TIMEOUT);
 }
 
 void t11_device::mark(uint16_t op)
@@ -963,13 +963,13 @@ void t11_device::bcs(uint16_t op)           { m_icount -= 12; { BR( GET_C); } }
 void t11_device::emt(uint16_t op)
 {
 	m_icount -= 48;
-	trap_to(0x18);
+	trap_to(T11_EMT);
 }
 
 void t11_device::trap(uint16_t op)
 {
 	m_icount -= 48;
-	trap_to(0x1c);
+	trap_to(T11_TRAP);
 }
 
 void t11_device::clrb_rg(uint16_t op)       { m_icount -= 12; { CLRB_R(RG);  } }

--- a/src/devices/machine/pdp11.h
+++ b/src/devices/machine/pdp11.h
@@ -24,10 +24,10 @@ enum : uint16_t
 
 
 #define clear_virq(_callback, _csr, _ie, _intrq) \
-	if ((_csr) & (_ie)) { (_intrq) = CLEAR_LINE; }
+	do { if ((_csr) & (_ie)) { (_intrq) = CLEAR_LINE; } } while (0)
 
 #define raise_virq(_callback, _csr, _ie, _intrq) \
-	if ((_csr) & (_ie)) { (_intrq) = ASSERT_LINE; _callback (ASSERT_LINE); }
+	do { if ((_csr) & (_ie)) { (_intrq) = ASSERT_LINE; _callback (ASSERT_LINE); } } while (0)
 
 
 #define UPDATE_16BIT(_storage, _data, _mask) \

--- a/src/mame/ussr/bk.cpp
+++ b/src/mame/ussr/bk.cpp
@@ -98,7 +98,6 @@ void bk_state::bk0010(machine_config &config)
 	m_kbd->keydown_wr_callback().set(
 			[this] (int state)
 			{
-				m_sel1 |= SEL1_UPDATED;
 				if (state)
 					m_sel1 &= ~SEL1_KEYDOWN;
 				else

--- a/src/mame/ussr/bk_m.cpp
+++ b/src/mame/ussr/bk_m.cpp
@@ -44,7 +44,8 @@ uint16_t bk_state::sel1_r()
 {
 	double level = m_cassette->input();
 	uint16_t data = 0100000 | m_sel1 | ((level < 0) ? 0 : SEL1_RX_CAS);
-	m_sel1 &= ~SEL1_UPDATED;
+	if (!machine().side_effects_disabled())
+		m_sel1 &= ~SEL1_UPDATED;
 
 	return data;
 }


### PR DESCRIPTION
Allows bus error handlers on BK to deal with interrupt from STOP key (which causes a HALT-mode IRQ and triggers access to unmapped region at 177674).