### PR TITLE
jking02,  crzybugs - add IGS027A internal ROM dumps [Peter Wilhelmsen]

### DIFF
--- a/src/mame/igs/igs017_igs031.cpp
+++ b/src/mame/igs/igs017_igs031.cpp
@@ -330,7 +330,8 @@ void igs017_igs031_device::draw_sprites(bitmap_ind16 &bitmap,const rectangle &cl
 	{
 		const int y     =   s[0] + (s[1] << 8);
 		int x           =   s[2] + (s[3] << 8);
-		u32 addr        =   (s[4] >> 6) | (s[5] << 2) | (s[6] << 10) | ((s[7] & 0x07) << 18);
+		u32 addr        =   (s[4] >> 6) | (s[5] << 2) | (s[6] << 10) | ((s[7] & 0x07 /* 0x0f? */) << 18);
+
 		addr            *=  3;
 
 		const int flipx =   s[7] & 0x10;
@@ -580,14 +581,14 @@ void igs017_igs031_device::tarzan_decrypt_sprites(size_t max_size)
 	}
 }
 
-void igs017_igs031_device::starzan_decrypt_sprites()
+void igs017_igs031_device::starzan_decrypt_sprites(size_t max_size)
 {
-	tarzan_decrypt_sprites(0x200000);
+	tarzan_decrypt_sprites(max_size);
 
 	// Overlay rom:
 
 	const int rom_size = 0x80000;
-	u8 *rom = memregion("sprites")->base() + 0x200000;
+	u8 *rom = memregion("sprites")->base() + max_size;
 	std::unique_ptr<u8[]> tmp = std::make_unique<u8[]>(rom_size);
 
 	// address lines swap

--- a/src/mame/igs/igs017_igs031.cpp
+++ b/src/mame/igs/igs017_igs031.cpp
@@ -330,7 +330,7 @@ void igs017_igs031_device::draw_sprites(bitmap_ind16 &bitmap,const rectangle &cl
 	{
 		const int y     =   s[0] + (s[1] << 8);
 		int x           =   s[2] + (s[3] << 8);
-		u32 addr        =   (s[4] >> 6) | (s[5] << 2) | (s[6] << 10) | ((s[7] & 0x07 /* 0x0f? */) << 18);
+		u32 addr        =   (s[4] >> 6) | (s[5] << 2) | (s[6] << 10) | ((s[7] & 0x0f) << 18);
 
 		addr            *=  3;
 

--- a/src/mame/igs/igs017_igs031.cpp
+++ b/src/mame/igs/igs017_igs031.cpp
@@ -14,6 +14,8 @@ providing the interface to the 8255, or is it coincidence?
 #include "emu.h"
 #include "igs017_igs031.h"
 
+#include "multibyte.h"
+
 void igs017_igs031_device::map(address_map &map)
 {
 	map(0x1000, 0x17ff).ram().share("spriteram");
@@ -438,4 +440,204 @@ void igs017_igs031_device::irq_enable_w(u8 data)
 	m_irq_enable = data & 1;
 	if (data != 0 && data != 1 && data != 0xff)
 		logerror("%s: irq_enable = %02x\n", machine().describe_context(), data);
+}
+
+
+// Are these decryption a programmable function of the 031?
+
+void igs017_igs031_device::mgcs_decrypt_tiles()
+{
+	const int rom_size = memregion("tilemaps")->bytes();
+	u8 * const rom = memregion("tilemaps")->base();
+	std::unique_ptr<u8[]> tmp = std::make_unique<u8[]>(rom_size);
+
+	memcpy(&tmp[0], rom, rom_size);
+	for (int i = 0; i < rom_size; i++)
+	{
+		int addr = (i & ~0xffff) | bitswap<16>(i,15,14,13,12,11,10,6,7,8,9,5,4,3,2,1,0);
+		rom[i^1] = bitswap<8>(tmp[addr],0,1,2,3,4,5,6,7);
+	}
+}
+
+void igs017_igs031_device::slqz2_decrypt_tiles()
+{
+	const int rom_size = memregion("tilemaps")->bytes();
+	u8 * const rom = memregion("tilemaps")->base();
+	std::unique_ptr<u8[]> tmp = std::make_unique<u8[]>(rom_size);
+
+	memcpy(&tmp[0], rom, rom_size);
+	for (int i = 0; i < rom_size; i++)
+	{
+		int addr = (i & ~0xff) | bitswap<8>(i,7,4,5,6,3,2,1,0);
+		rom[i] = tmp[addr];
+	}
+}
+
+void igs017_igs031_device::tarzan_decrypt_tiles(int address_xor)
+{
+	const int rom_size = memregion("tilemaps")->bytes();
+	u8 * const rom = memregion("tilemaps")->base();
+	std::unique_ptr<u8[]> tmp = std::make_unique<u8[]>(rom_size);
+
+	memcpy(&tmp[0], rom, rom_size);
+	for (int i = 0; i < rom_size; i++)
+	{
+		int addr = (i & ~0xffff) | (bitswap<16>(i,15,14,13,12,11, 7,8,6,10,9, 5,4,3,2,1,0) ^ address_xor);
+		rom[i] = bitswap<8>(tmp[addr],0,1,2,3,4,5,6,7);
+	}
+}
+
+void igs017_igs031_device::lhzb2_decrypt_tiles()
+{
+	const int rom_size = memregion("tilemaps")->bytes();
+	u8 * const rom = memregion("tilemaps")->base();
+	std::unique_ptr<u8[]> tmp = std::make_unique<u8[]>(rom_size);
+
+	memcpy(&tmp[0], rom, rom_size);
+	for (int i = 0; i < rom_size; i++)
+	{
+		int addr = (i & ~0xffffff) | bitswap<24>(i,23,22,21,20,19,18,17,1,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,0);
+		rom[i] = tmp[addr];
+	}
+}
+
+void igs017_igs031_device::sdwx_gfx_decrypt()
+{
+	unsigned rom_size = 0x80000;
+	u8 *src = (u8 *) (memregion("tilemaps")->base());
+	std::vector<u8> result_data(rom_size);
+
+	for (int i = 0; i < rom_size; i++)
+		result_data[i] = src[bitswap<24>(i, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 8, 7, 6, 10, 9, 5, 4, 3, 2, 1, 0)];
+
+	for (int i = 0; i < rom_size; i += 0x200)
+	{
+		memcpy(src + i + 0x000, &result_data[i + 0x000], 0x80);
+		memcpy(src + i + 0x080, &result_data[i + 0x100], 0x80);
+		memcpy(src + i + 0x100, &result_data[i + 0x080], 0x80);
+		memcpy(src + i + 0x180, &result_data[i + 0x180], 0x80);
+	}
+}
+
+
+void igs017_igs031_device::mgcs_flip_sprites()
+{
+	const int rom_size = memregion("sprites")->bytes();
+	u8 * const rom = memregion("sprites")->base();
+
+	for (int i = 0; i < rom_size; i+=2)
+	{
+		u16 pixels = get_u16le(&rom[i]);
+
+		// flip bits
+		pixels = bitswap<16>(pixels,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15);
+
+		// flip pixels
+		pixels = bitswap<16>(pixels,15, 0,1,2,3,4, 5,6,7,8,9, 10,11,12,13,14);
+
+		put_u16le(&rom[i], pixels);
+	}
+}
+
+
+void igs017_igs031_device::tjsb_decrypt_sprites()
+{
+	const int rom_size = memregion("sprites")->bytes();
+	u8 * const rom = memregion("sprites")->base();
+	std::unique_ptr<u8[]> tmp = std::make_unique<u8[]>(rom_size);
+
+	// address lines swap
+	memcpy(tmp.get(), rom, rom_size);
+	for (int i = 0; i < rom_size; i++)
+	{
+		int addr = (i & ~0xff) | bitswap<8>(i,7,6,5,2,1,4,3,0);
+		rom[i] = tmp[addr];
+	}
+
+	// data lines swap
+	for (int i = 0; i < rom_size; i += 2)
+	{
+		u16 data = get_u16le(&rom[i]); // x-22222-11111-00000
+		data = bitswap<16>(data, 15, 14,13,12,11,10, 9,1,7,6,5, 4,3,2,8,0);
+		put_u16le(&rom[i], data);
+	}
+}
+
+void igs017_igs031_device::tarzan_decrypt_sprites(size_t max_size)
+{
+	mgcs_flip_sprites();
+
+	const int rom_size = max_size ? max_size : memregion("sprites")->bytes();
+	u8 *rom = memregion("sprites")->base();
+	std::unique_ptr<u8[]> tmp = std::make_unique<u8[]>(rom_size);
+
+	// address lines swap
+	memcpy(tmp.get(), rom, rom_size);
+	for (int i = 0; i < rom_size; i++)
+	{
+		int addr = (i & ~0xffff) | bitswap<16>(i,15,14,13, 9,10,11,12, 5,6,7,8, 4,3,2,1,0);
+		rom[i] = tmp[addr];
+	}
+}
+
+void igs017_igs031_device::starzan_decrypt_sprites()
+{
+	tarzan_decrypt_sprites(0x200000);
+
+	// Overlay rom:
+
+	const int rom_size = 0x80000;
+	u8 *rom = memregion("sprites")->base() + 0x200000;
+	std::unique_ptr<u8[]> tmp = std::make_unique<u8[]>(rom_size);
+
+	// address lines swap
+	memcpy(tmp.get(), rom, rom_size);
+	for (int i = 0; i < rom_size; i++)
+	{
+		int addr = (i & ~0xffff) | bitswap<16>(i,15,14,13,12,11,10,9,  6,5, 8,7, 1,2,3,4, 0);
+		rom[i] = tmp[addr];
+	}
+}
+
+void igs017_igs031_device::spkrform_decrypt_sprites()
+{
+	const int rom_size = memregion("sprites")->bytes();
+	u8 * const rom = memregion("sprites")->base();
+	std::unique_ptr<u8[]> tmp = std::make_unique<u8[]>(rom_size);
+
+	// address lines swap
+	memcpy(tmp.get(), rom, rom_size);
+	for (int i = 0; i < rom_size; i++)
+	{
+		int addr;
+		if (i & 0x80000)
+			addr = (i & ~0xff) | bitswap<8>(i,7,6,3,4,5,2,1,0);
+		else
+			addr = (i & ~0xffff) | bitswap<16>(i,15,14,13,12,11,10, 4, 8,7,6,5, 9,3,2,1,0);
+
+		rom[i] = tmp[addr];
+	}
+}
+
+void igs017_igs031_device::lhzb2_decrypt_sprites()
+{
+	const int rom_size = memregion("sprites")->bytes();
+	u8 * const rom = memregion("sprites")->base();
+	std::unique_ptr<u8[]> tmp = std::make_unique<u8[]>(rom_size);
+
+	// address lines swap
+	memcpy(tmp.get(), rom, rom_size);
+	for (int i = 0; i < rom_size; i++)
+	{
+		int addr = (i & ~0xffff) | bitswap<16>(i,15,14,13,6,7,10,9,8,11,12,5,4,3,2,1,0);
+		rom[i] = tmp[addr];
+	}
+
+	// data lines swap
+	for (int i = 0; i < rom_size; i+=2)
+	{
+		u16 data = get_u16le(&rom[i]); // x-22222-11111-00000
+		data = bitswap<16>(data, 15, 7,6,5,4,3, 2,1,0,14,13, 12,11,10,9,8);
+		put_u16le(&rom[i], data);
+	}
 }

--- a/src/mame/igs/igs017_igs031.h
+++ b/src/mame/igs/igs017_igs031.h
@@ -68,7 +68,7 @@ public:
 	void lhzb2_decrypt_sprites();
 	void tarzan_decrypt_sprites(size_t max_size);
 	void spkrform_decrypt_sprites();
-	void starzan_decrypt_sprites();
+	void starzan_decrypt_sprites(size_t max_size);
 	void tjsb_decrypt_sprites();
 
 

--- a/src/mame/igs/igs017_igs031.h
+++ b/src/mame/igs/igs017_igs031.h
@@ -58,6 +58,20 @@ public:
 	void irq_enable_w(u8 data);
 	virtual void video_start();
 
+	void lhzb2_decrypt_tiles();
+	void mgcs_decrypt_tiles();
+	void tarzan_decrypt_tiles(int address_xor);
+	void slqz2_decrypt_tiles();
+	void sdwx_gfx_decrypt();
+
+	void mgcs_flip_sprites();
+	void lhzb2_decrypt_sprites();
+	void tarzan_decrypt_sprites(size_t max_size);
+	void spkrform_decrypt_sprites();
+	void starzan_decrypt_sprites();
+	void tjsb_decrypt_sprites();
+
+
 protected:
 	virtual void device_add_mconfig(machine_config &config) override;
 	virtual void device_start() override;

--- a/src/mame/igs/igs_m027.cpp
+++ b/src/mame/igs/igs_m027.cpp
@@ -1329,7 +1329,8 @@ void igs_m027_state::init_jking02()
 {
 	jking02_decrypt(machine());
 	m_igs017_igs031->sdwx_gfx_decrypt();
-	m_igs017_igs031->starzan_decrypt_sprites(0x400000); // not 100% correect?
+	m_igs017_igs031->tarzan_decrypt_sprites(0x400000); // not 100% correect?
+	// the ROM at 0x400000 doesn't decrypt with the above?
 }
 
 void igs_m027_state::init_lthy()

--- a/src/mame/igs/igs_m027.cpp
+++ b/src/mame/igs/igs_m027.cpp
@@ -290,7 +290,7 @@ void igs_m027_state::igs_mahjong(machine_config &config)
 	screen.set_refresh_hz(60);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	screen.set_size(512, 256);
-	screen.set_visarea(0, 512-1, 0, 256-1);
+	screen.set_visarea(0, 512-1, 0, 240-1);
 	screen.set_screen_update("igs017_igs031", FUNC(igs017_igs031_device::screen_update));
 	screen.set_palette("igs017_igs031:palette");
 	screen.screen_vblank().set(FUNC(igs_m027_state::vblank_irq));

--- a/src/mame/igs/igs_m027.cpp
+++ b/src/mame/igs/igs_m027.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders: Xing Xing
+// copyright-holders: Xing Xing, David Haywood
 
 /* IGS ARM7 (IGS027A) based Mahjong / Gambling platform(s)
  Driver by Xing Xing
@@ -15,13 +15,6 @@
  To emulate these games the Internal ROM will need dumping
  There are at least 20 other games on this and similar platforms.
 
- Many of these also seem to have a 80C51 based MCU, also covered by
- a holographic sticker, this appears to be unprotected but has only been
- read for a few sets, it probably either acts as a secondary protection
- device or as a main CPU instructing the ARM.
- For Crazy Bugs, MCUs with stickers J9 and F9 have been dumped and both
- contained the same data, despite the different sticker.
-
 */
 
 #include "emu.h"
@@ -31,12 +24,10 @@
 
 #include "cpu/arm7/arm7.h"
 #include "cpu/arm7/arm7core.h"
-#include "cpu/xa/xa.h"
 
 #include "machine/i8255.h"
 #include "machine/nvram.h"
 
-#include "multibyte.h"
 #include "screen.h"
 
 namespace {
@@ -48,13 +39,11 @@ public:
 		driver_device(mconfig, type, tag),
 		m_igs_mainram(*this, "igs_mainram"),
 		m_maincpu(*this, "maincpu"),
-		m_xa(*this, "xa"),
 		m_ppi(*this, "ppi8255"),
 		m_igs017_igs031(*this, "igs017_igs031")
 	{ }
 
 	void igs_mahjong(machine_config &config);
-	void igs_mahjong_xa(machine_config &config);
 
 	void init_sdwx();
 	void init_chessc2();
@@ -63,7 +52,6 @@ public:
 	void init_lhzb3();
 	void init_gonefsh2();
 	void init_sddz();
-	void init_hauntedh();
 	void init_zhongguo();
 	void init_klxyj();
 	void init_slqz3();
@@ -74,15 +62,11 @@ public:
 	void init_qlgs();
 	void init_mgzz();
 	void init_mgcs3();
-	void init_crzybugs();
-	void init_crzybugsj();
 	void init_jking02();
+	void init_lhdmg();
+	void init_lthy();
 	void init_luckycrs();
 	void init_olympic5();
-	void init_tripfev();
-	void init_wldfruit();
-	void init_lthy();
-	[[maybe_unused]] void init_no_dec();
 
 protected:
 	virtual void video_start() override;
@@ -90,7 +74,6 @@ protected:
 private:
 	optional_shared_ptr<u32> m_igs_mainram;
 	required_device<cpu_device> m_maincpu;
-	optional_device<mx10exa_cpu_device> m_xa;
 	optional_device<i8255_device> m_ppi;
 	required_device<igs017_igs031_device> m_igs017_igs031;
 
@@ -243,7 +226,7 @@ static const u8 sdwx_tab[] =
 
 ***************************************************************************/
 
-static INPUT_PORTS_START( sdwx )
+static INPUT_PORTS_START( base )
 
 	PORT_START("TEST0")
 	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -257,7 +240,7 @@ static INPUT_PORTS_START( sdwx )
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( amazonia )
-	PORT_INCLUDE(sdwx)
+	PORT_INCLUDE(base)
 
 	PORT_START("DSW1")
 // Credits proportion
@@ -377,14 +360,6 @@ void igs_m027_state::igs_mahjong(machine_config &config)
 	// sound hardware
 	// OK6295
 }
-
-void igs_m027_state::igs_mahjong_xa(machine_config &config)
-{
-	igs_mahjong(config);
-
-	MX10EXA(config, m_xa, 10000000); // MX10EXAQC (Philips 80C51 XA) unknown frequency
-}
-
 
 /***************************************************************************
 
@@ -1161,164 +1136,6 @@ ROM_START( chessc2 )
 ROM_END
 
 
-
-// prg at u34
-// text at u15
-// cg at u32 / u12
-// samples at u3
-
-ROM_START( haunthig )
-	ROM_REGION( 0x04000, "maincpu", 0 )
-	// Internal ROM of IGS027A ARM based MCU
-	ROM_LOAD( "haunthig_igs027a", 0x00000, 0x4000, NO_DUMP )
-
-	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
-	ROM_LOAD( "hauntedhouse_ver-109us.u34", 0x000000, 0x80000, CRC(300fed78) SHA1(afa4c8855cd780c57d4f92ea6131ed4e77063268) )
-
-	ROM_REGION( 0x10000, "xa", 0 )
-	ROM_LOAD( "hauntedhouse.u17", 0x000000, 0x10000, BAD_DUMP CRC(3c76b157) SHA1(d8d3a434fd649577a30d5855e3fb34998041f4e5) ) // not dumped for this set
-
-	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )
-	ROM_LOAD( "haunted-h_text.u15", 0x000000, 0x80000, CRC(c23f48c8) SHA1(0cb1b6c61611a081ae4a3c0be51812045ff632fe) )
-
-	// are these PGM-like sprites?
-	ROM_REGION( 0x800000, "igs017_igs031:sprites", 0 )
-	ROM_LOAD( "haunted-h_cg.u32",  0x000000, 0x400000, BAD_DUMP CRC(e0ea10e6) SHA1(e81be78fea93e72d4b1f4c0b58560bda46cf7948) ) // not dumped for this set, FIXED BITS (xxxxxxx0xxxxxxxx)
-	ROM_LOAD( "haunted-h_ext.u12", 0x400000, 0x400000, BAD_DUMP CRC(662eb883) SHA1(831ebe29e1e7a8b2c2fff7fbc608975771c3486c) ) // not dumped for this set, FIXED BITS (xxxxxxxx0xxxxxxx)
-
-	ROM_REGION( 0x200000, "samples", 0 ) // Oki M6295 samples, missing sample table, bad?
-	ROM_LOAD( "haunted-h_sp.u3", 0x00000, 0x200000,  BAD_DUMP CRC(fe3fcddf) SHA1(ac57ab6d4e4883747c093bd19d0025cf6588cb2c) ) // not dumped for this set
-
-	ROM_REGION( 0x500, "plds", ROMREGION_ERASE00 )
-	ROM_LOAD( "hu_u38a.u38", 0x000, 0x117, NO_DUMP ) // ATF16V8B, protected
-	ROM_LOAD( "hu_u39.u39",  0x200, 0x2dd, CRC(75f58b46) SHA1(7cb136a41899ddd50c95a67ca6353ce5d8d92149) ) // AT22V10
-ROM_END
-
-ROM_START( haunthiga ) // IGS PCB-0575-04-HU - Has IGS027A, MX10EXAQC, IGS031, Oki M6295, 2x 8-dip banks
-	ROM_REGION( 0x04000, "maincpu", 0 )
-	// Internal ROM of IGS027A ARM based MCU
-	ROM_LOAD( "haunthig_igs027a", 0x00000, 0x4000, NO_DUMP ) // sticker marked 'H2'
-
-	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
-	ROM_LOAD( "hauntedhouse_ver-101us.u34", 0x000000, 0x80000, CRC(4bf045d4) SHA1(78c848fd69961df8d9b75f92ad57c3534fbf08db) )
-
-	ROM_REGION( 0x10000, "xa", 0 )
-	ROM_LOAD( "hauntedhouse.u17", 0x000000, 0x10000, CRC(3c76b157) SHA1(d8d3a434fd649577a30d5855e3fb34998041f4e5) ) // MX10EXAQC (80C51 XA based MCU) marked J9, not read protected?
-
-	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )
-	ROM_LOAD( "haunted-h_text.u15", 0x000000, 0x80000, CRC(c23f48c8) SHA1(0cb1b6c61611a081ae4a3c0be51812045ff632fe) )
-
-	// are these PGM-like sprites?
-	ROM_REGION( 0x800000, "igs017_igs031:sprites", 0 )
-	ROM_LOAD( "haunted-h_cg.u32",  0x000000, 0x400000, CRC(e0ea10e6) SHA1(e81be78fea93e72d4b1f4c0b58560bda46cf7948) ) // FIXED BITS (xxxxxxx0xxxxxxxx)
-	ROM_LOAD( "haunted-h_ext.u12", 0x400000, 0x400000, CRC(662eb883) SHA1(831ebe29e1e7a8b2c2fff7fbc608975771c3486c) ) // FIXED BITS (xxxxxxxx0xxxxxxx)
-
-	ROM_REGION( 0x200000, "samples", 0 ) // Oki M6295 samples, missing sample table, bad?
-	ROM_LOAD( "haunted-h_sp.u3", 0x00000, 0x200000,  CRC(fe3fcddf) SHA1(ac57ab6d4e4883747c093bd19d0025cf6588cb2c) )
-
-	ROM_REGION( 0x500, "plds", ROMREGION_ERASE00 )
-	ROM_LOAD( "hu_u38a.u38", 0x000, 0x117, NO_DUMP ) // ATF16V8B, protected
-	ROM_LOAD( "hu_u39.u39",  0x200, 0x2dd, CRC(75f58b46) SHA1(7cb136a41899ddd50c95a67ca6353ce5d8d92149) ) // AT22V10
-ROM_END
-
-ROM_START( crzybugs ) // IGS PCB-0447-05-GM - Has IGS027A, MX10EXAQC, IGS031, Oki M6295, 3x 8-DIP banks
-	ROM_REGION( 0x04000, "maincpu", 0 )
-	// Internal ROM of IGS027A ARM based MCU
-	ROM_LOAD( "m7.u37", 0x00000, 0x4000, NO_DUMP ) // sticker marked 'M7'
-
-	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
-	ROM_LOAD( "crazy_bugs_v-204us.u23", 0x000000, 0x80000, CRC(d1232462) SHA1(685a292f39bf57a80d6ef31289cf9f673ba06dd4) ) // MX27C4096
-
-	ROM_REGION( 0x10000, "xa", 0 ) // MX10EXAQC (80C51 XA based MCU) marked J9
-	ROM_LOAD( "j9.u27", 0x00000, 0x10000, CRC(3c76b157) SHA1(d8d3a434fd649577a30d5855e3fb34998041f4e5) )
-
-	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )  // not dumped for this set
-	ROM_LOAD( "crazy_bugs_text_u10.u10", 0x000000, 0x80000, BAD_DUMP CRC(db0d679a) SHA1(c5d039aa4fa2218b6f574ccb5b6da983b8d4067d) )
-
-	// are these PGM-like sprites?
-	ROM_REGION( 0x200000, "igs017_igs031:sprites", 0 ) // not dumped for this set
-	ROM_LOAD( "crazy_bugs_cg.u19",  0x000000, 0x200000, BAD_DUMP CRC(9d53ad47) SHA1(46690a37acf8bd88c7fbe973db2faf5ef0cff805) ) // FIXED BITS (xxxxxxx0xxxxxxxx)
-	// u18 not populated
-
-	ROM_REGION( 0x200000, "samples", 0 ) // plain Oki M6295 samples
-	ROM_LOAD( "crazy_bugs_sp.u15", 0x000000, 0x200000, CRC(b15974a1) SHA1(82509902bbb33a2120d815e7879b9b8591a29976) ) // M27C160
-ROM_END
-
-ROM_START( crzybugsa )
-	ROM_REGION( 0x04000, "maincpu", 0 )
-	// Internal ROM of IGS027A ARM based MCU
-	ROM_LOAD( "crzybugsa.u37", 0x00000, 0x4000, NO_DUMP )
-
-	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
-	ROM_LOAD( "crazy_bugs_v-202us.u23", 0x000000, 0x80000, CRC(210da1e6) SHA1(c726497bebd25d6a9053e331b4c26acc7e2db0b2) ) // MX27C4096
-
-	ROM_REGION( 0x10000, "xa", 0 ) // MX10EXAQC (80C51 XA based MCU)
-	ROM_LOAD( "j9.u27", 0x00000, 0x10000, CRC(3c76b157) SHA1(d8d3a434fd649577a30d5855e3fb34998041f4e5) )
-
-	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )
-	ROM_LOAD( "crazy_bugs_text_u10.u10", 0x000000, 0x80000, CRC(db0d679a) SHA1(c5d039aa4fa2218b6f574ccb5b6da983b8d4067d) ) // M27C4002
-
-	// are these PGM-like sprites?
-	ROM_REGION( 0x200000, "igs017_igs031:sprites", 0 )
-	ROM_LOAD( "crazy_bugs_cg.u19",  0x000000, 0x200000, CRC(9d53ad47) SHA1(46690a37acf8bd88c7fbe973db2faf5ef0cff805) ) // M27C160, FIXED BITS (xxxxxxx0xxxxxxxx)
-	// u18 not populated
-
-	ROM_REGION( 0x200000, "samples", 0 ) // plain Oki M6295 samples
-	ROM_LOAD( "crazy_bugs_sp.u15", 0x000000, 0x200000, CRC(591b315b) SHA1(fda1816d83e202170dba4afc6e7898b706a76087) ) // M27C160
-ROM_END
-
-ROM_START( crzybugsb )
-	ROM_REGION( 0x04000, "maincpu", 0 )
-	// Internal ROM of IGS027A ARM based MCU
-	ROM_LOAD( "crzybugsb.u37", 0x00000, 0x4000, NO_DUMP )
-
-	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
-	ROM_LOAD( "crazy_bugs_v-202us.u23", 0x000000, 0x80000, CRC(129e36e9) SHA1(53f20bc3792249de8ef276f84283baa9abd30acd) ) // MX27C4096
-
-	ROM_REGION( 0x10000, "xa", 0 ) // MX10EXAQC (80C51 XA based MCU)
-	ROM_LOAD( "j9.u27", 0x00000, 0x10000, CRC(3c76b157) SHA1(d8d3a434fd649577a30d5855e3fb34998041f4e5) )
-
-	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )
-	ROM_LOAD( "crazy_bugs_text_u10.u10", 0x000000, 0x80000, BAD_DUMP CRC(db0d679a) SHA1(c5d039aa4fa2218b6f574ccb5b6da983b8d4067d) ) // not dumped for this set
-
-	// are these PGM-like sprites?
-	ROM_REGION( 0x200000, "igs017_igs031:sprites", 0 )
-	ROM_LOAD( "crazy_bugs_cg.u19",  0x000000, 0x200000, BAD_DUMP CRC(9d53ad47) SHA1(46690a37acf8bd88c7fbe973db2faf5ef0cff805) ) // not dumped for this set, FIXED BITS (xxxxxxx0xxxxxxxx)
-	// u18 not populated
-
-	ROM_REGION( 0x200000, "samples", 0 ) // plain Oki M6295 samples
-	ROM_LOAD( "crazy_bugs_sp.u15", 0x000000, 0x200000, BAD_DUMP CRC(591b315b) SHA1(fda1816d83e202170dba4afc6e7898b706a76087) ) // not dumped for this set
-ROM_END
-
-ROM_START( crzybugsj ) // IGS PCB-0575-04-HU - Has IGS027A, MX10EXAQC, IGS031, Oki M6295, 2x 8-dip banks
-	ROM_REGION( 0x04000, "maincpu", 0 )
-	// Internal ROM of IGS027A ARM based MCU
-	ROM_LOAD( "m6.u42", 0x00000, 0x4000, NO_DUMP ) // sticker marked 'M6'
-
-	ROM_REGION32_LE( 0x200000, "user1", 0 ) // external ARM data / prg
-	ROM_LOAD( "crazy_bugs_v-103jp.u34", 0x000000, 0x200000, CRC(1e35ed79) SHA1(0e4f8b706cdfcaf2aacdc40eec422df9d865b311) )
-
-	ROM_REGION( 0x10000, "xa", 0 )
-	ROM_LOAD( "e9.u17", 0x00000, 0x10000, CRC(3c76b157) SHA1(d8d3a434fd649577a30d5855e3fb34998041f4e5) ) // MX10EXAQC (80C51 XA based MCU) marked E9, same as haunthig
-
-	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )
-	ROM_LOAD( "crazy_bugs_text_u15.u15", 0x000000, 0x80000, CRC(db0d679a) SHA1(c5d039aa4fa2218b6f574ccb5b6da983b8d4067d) )
-	// u14 not populated
-
-	// are these PGM-like sprites?
-	ROM_REGION( 0x200000, "igs017_igs031:sprites", 0 )
-	ROM_LOAD( "crazy_bugs_ani-cg-u32.u32",  0x000000, 0x200000, CRC(9d53ad47) SHA1(46690a37acf8bd88c7fbe973db2faf5ef0cff805) ) // FIXED BITS (xxxxxxx0xxxxxxxx)
-	// u12 not populated
-
-	ROM_REGION( 0x200000, "samples", 0 ) // plain Oki M6295 samples
-	ROM_LOAD( "crazy_bugs_sp_u3.u3", 0x000000, 0x200000,  CRC(b15974a1) SHA1(82509902bbb33a2120d815e7879b9b8591a29976) )
-
-	ROM_REGION( 0x500, "plds", ROMREGION_ERASE00 )
-	ROM_LOAD( "hu_u38.u38", 0x000, 0x117, NO_DUMP ) // ATF16V8B, protected
-	ROM_LOAD( "hu_u39.u39", 0x200, 0x2dd, CRC(75f58b46) SHA1(7cb136a41899ddd50c95a67ca6353ce5d8d92149) ) // AT22V10
-ROM_END
-
-
 // Games with prg at u17
 // text at u27
 // cg at u28
@@ -1417,50 +1234,6 @@ ROM_START( extradrw ) // IGS PCB 0326-05-DV-1
 	ROM_LOAD( "igs s3002.u18", 0x00000, 0x200000, CRC(48601c32) SHA1(8ef3bad80931f4b1badf0598463e15508602f104) ) // BADADDR   --xxxxxxxxxxxxxxxxxxx
 ROM_END
 
-ROM_START( tripfev ) // IGS PCB-0447-05-GM - Has IGS027A, MX10EXAQC, IGS031, Oki M6295, 3x 8-DIP banks
-	ROM_REGION( 0x04000, "maincpu", 0 )
-	// Internal ROM of IGS027A ARM based MCU
-	ROM_LOAD( "w1.u37", 0x00000, 0x4000, NO_DUMP ) // sticker marked 'W1'
-
-	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
-	ROM_LOAD( "triple_fever_u23_v107_us.u23", 0x000000, 0x80000, CRC(aa56d888) SHA1(0b8b2765079259b76ea803289841d867c33c8cb2) ) // 27C4096
-
-	ROM_REGION( 0x10000, "xa", 0 ) // MX10EXAQC (80C51 XA based MCU) marked P7
-	ROM_LOAD( "p7.u27", 0x00000, 0x10000, NO_DUMP )
-
-	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )
-	ROM_LOAD( "triple_fever_u10_text.u10", 0x000000, 0x80000, CRC(522a1030) SHA1(9a7a5ba9b26bceb0d251be6139c10e4655fc19ec) ) // M27C4002
-
-	ROM_REGION( 0x400000, "igs017_igs031:sprites", 0 )
-	ROM_LOAD( "triple_fever_u19_cg.u19",  0x000000, 0x400000, CRC(cd45bbf2) SHA1(7f1cf270245bbe4604de2cacade279ab13584dbd) ) // M27C322, FIXED BITS (xxxxxxx0xxxxxxxx)
-	// u18 not populated
-
-	ROM_REGION( 0x200000, "samples", 0 ) // plain Oki M6295 samples
-	ROM_LOAD( "triplef_sp_u15.u15", 0x000000, 0x200000, CRC(98b9cafd) SHA1(3bf3971f0d9520c98fc6b1c2e77ab9c178d21c62) ) // M27C160
-ROM_END
-
-ROM_START( wldfruit ) // IGS PCB-0447-05-GM - Has IGS027A, MX10EXAQC, IGS031, Oki M6295, 3x 8-DIP banks
-	ROM_REGION( 0x04000, "maincpu", 0 )
-	// Internal ROM of IGS027A ARM based MCU
-	ROM_LOAD( "w1.u37", 0x00000, 0x4000, NO_DUMP ) // sticker marked 'W1'
-
-	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
-	ROM_LOAD( "wild_fruit_v-208us.u23", 0x000000, 0x80000, CRC(d43398f1) SHA1(ecc4bd5cb6da16b35c63b843cf7beec1ab84ed9d) ) // M27C4002
-
-	ROM_REGION( 0x10000, "xa", 0 ) // MX10EXAQC (80C51 XA based MCU) marked J9
-	ROM_LOAD( "j9.u27", 0x00000, 0x10000, CRC(3c76b157) SHA1(d8d3a434fd649577a30d5855e3fb34998041f4e5) )
-
-	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )
-	ROM_LOAD( "wild_fruit_text.u10", 0x000000, 0x80000, CRC(d6f0fd58) SHA1(5ddae5d4df53504dbb2e0fe9f7caea961c961ef8) ) // 27C4096
-
-	ROM_REGION( 0x400000, "igs017_igs031:sprites", 0 )
-	ROM_LOAD( "wild_fruit_cg.u19",  0x000000, 0x400000, CRC(119686a8) SHA1(22583c1a1018cfdd20f0ef696d91fa1f6e01ab00) ) // M27C322, FIXED BITS (xxxxxxx0xxxxxxxx)
-	// u18 not populated
-
-	ROM_REGION( 0x200000, "samples", 0 ) // plain Oki M6295 samples
-	ROM_LOAD( "wild_fruit_sp.u15", 0x000000, 0x200000, CRC(9da3e9dd) SHA1(7e447492713549e6be362d4aca6d223dad20771a) ) // M27C160
-ROM_END
-
 
 void igs_m027_state::pgm_create_dummy_internal_arm_region()
 {
@@ -1485,12 +1258,6 @@ void igs_m027_state::pgm_create_dummy_internal_arm_region()
 	temp16[(0x0092) / 2] = 0x1000;
 }
 
-
-void igs_m027_state::init_no_dec()
-{
-	pgm_create_dummy_internal_arm_region();
-}
-
 void igs_m027_state::init_sdwx()
 {
 	sdwx_decrypt(machine());
@@ -1511,15 +1278,6 @@ void igs_m027_state::init_chessc2()
 	//m_igs017_igs031->sdwx_gfx_decrypt(machine());
 	pgm_create_dummy_internal_arm_region();
 }
-
-void igs_m027_state::init_hauntedh()
-{
-	hauntedh_decrypt(machine());
-	//m_igs017_igs031->sdwx_gfx_decrypt(machine());
-	pgm_create_dummy_internal_arm_region();
-}
-
-
 
 void igs_m027_state::init_lhzb4()
 {
@@ -1619,25 +1377,18 @@ void igs_m027_state::init_mgcs3()
 	pgm_create_dummy_internal_arm_region();
 }
 
-void igs_m027_state::init_crzybugs()
-{
-	crzybugs_decrypt(machine());
-	//qlgs_gfx_decrypt(machine());
-	pgm_create_dummy_internal_arm_region();
-}
-
-void igs_m027_state::init_crzybugsj()
-{
-	crzybugsj_decrypt(machine());
-	//qlgs_gfx_decrypt(machine());
-	pgm_create_dummy_internal_arm_region();
-}
-
 void igs_m027_state::init_jking02()
 {
 	jking02_decrypt(machine());
 	m_igs017_igs031->sdwx_gfx_decrypt();
 	m_igs017_igs031->tarzan_decrypt_sprites(0); // not 100% correect?
+}
+
+void igs_m027_state::init_lthy()
+{
+	lthy_decrypt(machine());
+	//qlgs_gfx_decrypt(machine());
+	pgm_create_dummy_internal_arm_region();
 }
 
 void igs_m027_state::init_luckycrs()
@@ -1654,23 +1405,9 @@ void igs_m027_state::init_olympic5()
 	pgm_create_dummy_internal_arm_region();
 }
 
-void igs_m027_state::init_tripfev()
+void igs_m027_state::init_lhdmg()
 {
-	tripfev_decrypt(machine());
-	//qlgs_gfx_decrypt(machine());
-	pgm_create_dummy_internal_arm_region();
-}
-
-void igs_m027_state::init_wldfruit()
-{
-	wldfruit_decrypt(machine());
-	//qlgs_gfx_decrypt(machine());
-	pgm_create_dummy_internal_arm_region();
-}
-
-void igs_m027_state::init_lthy()
-{
-	lthy_decrypt(machine());
+	//lhdmg_decrypt(machine());
 	//qlgs_gfx_decrypt(machine());
 	pgm_create_dummy_internal_arm_region();
 }
@@ -1684,41 +1421,30 @@ void igs_m027_state::init_lthy()
 
 ***************************************************************************/
 
-GAME( 1999, slqz3,     0,        igs_mahjong, sdwx,     igs_m027_state, init_slqz3,    ROT0, "IGS", "Mahjong Shuang Long Qiang Zhu 3 (China, VS107C)", MACHINE_IS_SKELETON )
-GAME( 1999, qlgs,      0,        igs_mahjong, sdwx,     igs_m027_state, init_qlgs,     ROT0, "IGS", "Que Long Gao Shou", MACHINE_IS_SKELETON )
+GAME( 1999, slqz3,     0,        igs_mahjong, base,     igs_m027_state, init_slqz3,    ROT0, "IGS", "Mahjong Shuang Long Qiang Zhu 3 (China, VS107C)", MACHINE_IS_SKELETON )
+GAME( 1999, qlgs,      0,        igs_mahjong, base,     igs_m027_state, init_qlgs,     ROT0, "IGS", "Que Long Gao Shou", MACHINE_IS_SKELETON )
 GAME( 1999, amazonia,  0,        igs_mahjong, amazonia, igs_m027_state, init_amazonia, ROT0, "IGS", "Amazonia King (V104BR)", MACHINE_IS_SKELETON )
 GAME( 1999, amazonkp,  amazonia, igs_mahjong, amazonia, igs_m027_state, init_amazonia, ROT0, "IGS", "Amazonia King Plus (V204BR)", MACHINE_IS_SKELETON )
-GAME( 1999, fruitpar,  0,        igs_mahjong, sdwx,     igs_m027_state, init_fruitpar, ROT0, "IGS", "Fruit Paradise (V214)", MACHINE_IS_SKELETON )
-GAME( 1999, oceanpar,  0,        igs_mahjong, sdwx,     igs_m027_state, init_oceanpar, ROT0, "IGS", "Ocean Paradise (V105US)", MACHINE_IS_SKELETON ) // 1999 copyright in ROM
-GAME( 1999, oceanpara, oceanpar, igs_mahjong, sdwx,     igs_m027_state, init_oceanpar, ROT0, "IGS", "Ocean Paradise (V101US)", MACHINE_IS_SKELETON ) // 1999 copyright in ROM
-GAME( 1999, lthy,      0,        igs_mahjong, sdwx,     igs_m027_state, init_lthy,     ROT0, "IGS", "Long Teng Hu Yue", MACHINE_IS_SKELETON )
-GAME( 1999, lhdmg,     0,        igs_mahjong, sdwx,     igs_m027_state, init_no_dec,   ROT0, "IGS", "Long Hu Da Man Guan", MACHINE_IS_SKELETON )
-GAME( 1999, lhdmgp,    lhdmg,    igs_mahjong, sdwx,     igs_m027_state, init_no_dec,   ROT0, "IGS", "Long Hu Da Man Guan Plus", MACHINE_IS_SKELETON )
-GAME( 200?, luckycrs,  0,        igs_mahjong, sdwx,     igs_m027_state, init_luckycrs, ROT0, "IGS", "Lucky Cross (V106SA)", MACHINE_IS_SKELETON )
-GAME( 2002, sdwx,      0,        igs_mahjong, sdwx,     igs_m027_state, init_sdwx,     ROT0, "IGS", "Sheng Dan Wu Xian", MACHINE_IS_SKELETON ) // aka Christmas 5 Line? (or Amazonia King II, shares roms at least?)
-GAME( 200?, jking02,   0,        igs_mahjong, sdwx,     igs_m027_state, init_jking02,  ROT0, "IGS", "Jungle King 2002 (V209US)", MACHINE_IS_SKELETON )
-GAME( 2005, olympic5,  0,        igs_mahjong, sdwx,     igs_m027_state, init_olympic5, ROT0, "IGS", "Olympic 5 (V112US)", MACHINE_IS_SKELETON ) // IGS FOR V112US 2005 02 14
-GAME( 2003, olympic5a, olympic5, igs_mahjong, sdwx,     igs_m027_state, init_olympic5, ROT0, "IGS", "Olympic 5 (V107US)", MACHINE_IS_SKELETON ) // IGS FOR V107US 2003 10 2
-GAME( 2003, amazoni2,  0,        igs_mahjong, sdwx,     igs_m027_state, init_amazoni2, ROT0, "IGS", "Amazonia King II (V202BR)", MACHINE_IS_SKELETON )
-GAME( 200?, sddz,      0,        igs_mahjong, sdwx,     igs_m027_state, init_sddz,     ROT0, "IGS", "Super Dou Di Zhu", MACHINE_IS_SKELETON )
-GAME( 2000, zhongguo,  0,        igs_mahjong, sdwx,     igs_m027_state, init_zhongguo, ROT0, "IGS", "Zhong Guo Chu Da D", MACHINE_IS_SKELETON )
-GAME( 200?, lhzb3,     0,        igs_mahjong, sdwx,     igs_m027_state, init_lhzb3,    ROT0, "IGS", "Long Hu Zhengba III", MACHINE_IS_SKELETON ) // 龙虎争霸Ⅲ
-GAME( 2004, lhzb4,     0,        igs_mahjong, sdwx,     igs_m027_state, init_lhzb4,    ROT0, "IGS", "Long Hu Zhengba 4", MACHINE_IS_SKELETON ) // 龙虎争霸4
-GAME( 200?, klxyj,     0,        igs_mahjong, sdwx,     igs_m027_state, init_klxyj,    ROT0, "IGS", "Kuai Le Xi You Ji", MACHINE_IS_SKELETON )
-GAME( 2000, mgfx,      0,        igs_mahjong, sdwx,     igs_m027_state, init_mgfx,     ROT0, "IGS", "Man Guan Fu Xing", MACHINE_IS_SKELETON )
-GAME( 200?, gonefsh2,  0,        igs_mahjong, sdwx,     igs_m027_state, init_gonefsh2, ROT0, "IGS", "Gone Fishing 2", MACHINE_IS_SKELETON )
-GAME( 2002, chessc2,   0,        igs_mahjong, sdwx,     igs_m027_state, init_chessc2,  ROT0, "IGS", "Chess Challenge II", MACHINE_IS_SKELETON )
-GAME( 200?, extradrw,  0,        igs_mahjong, sdwx,     igs_m027_state, init_qlgs,     ROT0, "IGS", "Extra Draw", MACHINE_IS_SKELETON )
-GAME( 2003, mgzz,      0,        igs_mahjong, sdwx,     igs_m027_state, init_mgzz,     ROT0, "IGS", "Man Guan Zhi Zun (V100CN)", MACHINE_IS_SKELETON )
-GAME( 2007, mgcs3,     0,        igs_mahjong, sdwx,     igs_m027_state, init_mgcs3,    ROT0, "IGS", "Man Guan Caishen 3 (V101CN)", MACHINE_IS_SKELETON )
-
-// These use the MX10EXAQC (80c51XA from Philips) and maybe don't belong in here
-// the PCBs are closer to igs_fear.cpp in terms of layout
-GAME( 2008, haunthig,  0,        igs_mahjong_xa, sdwx,     igs_m027_state, init_hauntedh,  ROT0, "IGS", "Haunted House (IGS, V109US)", MACHINE_IS_SKELETON ) // IGS FOR V109US 2008 10 14
-GAME( 2006, haunthiga, haunthig, igs_mahjong_xa, sdwx,     igs_m027_state, init_hauntedh,  ROT0, "IGS", "Haunted House (IGS, V101US)", MACHINE_IS_SKELETON ) // IGS FOR V101US 2006 08 23
-GAME( 2009, crzybugs,  0,        igs_mahjong_xa, sdwx,     igs_m027_state, init_crzybugs,  ROT0, "IGS", "Crazy Bugs (V204US)", MACHINE_IS_SKELETON ) // IGS FOR V204US 2009 5 19
-GAME( 2006, crzybugsa, crzybugs, igs_mahjong_xa, sdwx,     igs_m027_state, init_crzybugs,  ROT0, "IGS", "Crazy Bugs (V202US)", MACHINE_IS_SKELETON ) // IGS FOR V100US 2006 3 29 but also V202US string
-GAME( 2005, crzybugsb, crzybugs, igs_mahjong_xa, sdwx,     igs_m027_state, init_crzybugs,  ROT0, "IGS", "Crazy Bugs (V200US)", MACHINE_IS_SKELETON ) // FOR V100US 2005 7 20 but also V200US string
-GAME( 2007, crzybugsj, crzybugs, igs_mahjong_xa, sdwx,     igs_m027_state, init_crzybugsj, ROT0, "IGS", "Crazy Bugs (V103JP)", MACHINE_IS_SKELETON ) // IGS FOR V101JP 2007 06 08
-GAME( 2006, tripfev,   0,        igs_mahjong_xa, sdwx,     igs_m027_state, init_tripfev,   ROT0, "IGS", "Triple Fever (V107US)", MACHINE_IS_SKELETON ) // IGS FOR V107US 2006 09 07
-GAME( 200?, wldfruit,  0,        igs_mahjong_xa, sdwx,     igs_m027_state, init_wldfruit,  ROT0, "IGS", "Wild Fruit (V208US)", MACHINE_IS_SKELETON ) // IGS-----97----V208US
+GAME( 1999, fruitpar,  0,        igs_mahjong, base,     igs_m027_state, init_fruitpar, ROT0, "IGS", "Fruit Paradise (V214)", MACHINE_IS_SKELETON )
+GAME( 1999, oceanpar,  0,        igs_mahjong, base,     igs_m027_state, init_oceanpar, ROT0, "IGS", "Ocean Paradise (V105US)", MACHINE_IS_SKELETON ) // 1999 copyright in ROM
+GAME( 1999, oceanpara, oceanpar, igs_mahjong, base,     igs_m027_state, init_oceanpar, ROT0, "IGS", "Ocean Paradise (V101US)", MACHINE_IS_SKELETON ) // 1999 copyright in ROM
+GAME( 1999, lthy,      0,        igs_mahjong, base,     igs_m027_state, init_lthy,     ROT0, "IGS", "Long Teng Hu Yue", MACHINE_IS_SKELETON )
+GAME( 1999, lhdmg,     0,        igs_mahjong, base,     igs_m027_state, init_lhdmg,    ROT0, "IGS", "Long Hu Da Man Guan", MACHINE_IS_SKELETON )
+GAME( 1999, lhdmgp,    lhdmg,    igs_mahjong, base,     igs_m027_state, init_lhdmg,    ROT0, "IGS", "Long Hu Da Man Guan Plus", MACHINE_IS_SKELETON )
+GAME( 200?, luckycrs,  0,        igs_mahjong, base,     igs_m027_state, init_luckycrs, ROT0, "IGS", "Lucky Cross (V106SA)", MACHINE_IS_SKELETON )
+GAME( 2002, sdwx,      0,        igs_mahjong, base,     igs_m027_state, init_sdwx,     ROT0, "IGS", "Sheng Dan Wu Xian", MACHINE_IS_SKELETON ) // aka Christmas 5 Line? (or Amazonia King II, shares roms at least?)
+GAME( 200?, jking02,   0,        igs_mahjong, base,     igs_m027_state, init_jking02,  ROT0, "IGS", "Jungle King 2002 (V209US)", MACHINE_IS_SKELETON )
+GAME( 2005, olympic5,  0,        igs_mahjong, base,     igs_m027_state, init_olympic5, ROT0, "IGS", "Olympic 5 (V112US)", MACHINE_IS_SKELETON ) // IGS FOR V112US 2005 02 14
+GAME( 2003, olympic5a, olympic5, igs_mahjong, base,     igs_m027_state, init_olympic5, ROT0, "IGS", "Olympic 5 (V107US)", MACHINE_IS_SKELETON ) // IGS FOR V107US 2003 10 2
+GAME( 2003, amazoni2,  0,        igs_mahjong, base,     igs_m027_state, init_amazoni2, ROT0, "IGS", "Amazonia King II (V202BR)", MACHINE_IS_SKELETON )
+GAME( 200?, sddz,      0,        igs_mahjong, base,     igs_m027_state, init_sddz,     ROT0, "IGS", "Super Dou Di Zhu", MACHINE_IS_SKELETON )
+GAME( 2000, zhongguo,  0,        igs_mahjong, base,     igs_m027_state, init_zhongguo, ROT0, "IGS", "Zhong Guo Chu Da D", MACHINE_IS_SKELETON )
+GAME( 200?, lhzb3,     0,        igs_mahjong, base,     igs_m027_state, init_lhzb3,    ROT0, "IGS", "Long Hu Zhengba III", MACHINE_IS_SKELETON ) // 龙虎争霸Ⅲ
+GAME( 2004, lhzb4,     0,        igs_mahjong, base,     igs_m027_state, init_lhzb4,    ROT0, "IGS", "Long Hu Zhengba 4", MACHINE_IS_SKELETON ) // 龙虎争霸4
+GAME( 200?, klxyj,     0,        igs_mahjong, base,     igs_m027_state, init_klxyj,    ROT0, "IGS", "Kuai Le Xi You Ji", MACHINE_IS_SKELETON )
+GAME( 2000, mgfx,      0,        igs_mahjong, base,     igs_m027_state, init_mgfx,     ROT0, "IGS", "Man Guan Fu Xing", MACHINE_IS_SKELETON )
+GAME( 200?, gonefsh2,  0,        igs_mahjong, base,     igs_m027_state, init_gonefsh2, ROT0, "IGS", "Gone Fishing 2", MACHINE_IS_SKELETON )
+GAME( 2002, chessc2,   0,        igs_mahjong, base,     igs_m027_state, init_chessc2,  ROT0, "IGS", "Chess Challenge II", MACHINE_IS_SKELETON )
+GAME( 200?, extradrw,  0,        igs_mahjong, base,     igs_m027_state, init_qlgs,     ROT0, "IGS", "Extra Draw", MACHINE_IS_SKELETON )
+GAME( 2003, mgzz,      0,        igs_mahjong, base,     igs_m027_state, init_mgzz,     ROT0, "IGS", "Man Guan Zhi Zun (V100CN)", MACHINE_IS_SKELETON )
+GAME( 2007, mgcs3,     0,        igs_mahjong, base,     igs_m027_state, init_mgcs3,    ROT0, "IGS", "Man Guan Caishen 3 (V101CN)", MACHINE_IS_SKELETON )

--- a/src/mame/igs/igs_m027.cpp
+++ b/src/mame/igs/igs_m027.cpp
@@ -1329,7 +1329,7 @@ void igs_m027_state::init_jking02()
 {
 	jking02_decrypt(machine());
 	m_igs017_igs031->sdwx_gfx_decrypt();
-	m_igs017_igs031->tarzan_decrypt_sprites(0); // not 100% correect?
+	m_igs017_igs031->starzan_decrypt_sprites(0x400000); // not 100% correect?
 }
 
 void igs_m027_state::init_lthy()

--- a/src/mame/igs/igs_m027.cpp
+++ b/src/mame/igs/igs_m027.cpp
@@ -88,58 +88,6 @@ private:
 	void igs_mahjong_map(address_map &map);
 };
 
-
-
-/***************************************************************************
-
-    Video
-
-    0x38001000, 0x380017ff      CG_CONTROL,8 byte per object, 0x100 in total
-    0x38001800, 0x380019ff      PALETTE RAM,2 byte per color, 0x100 in total
-    0x38004000, 0x38005FFF      TX Video RAM????????1E00??????512x240??????
-    0x38006000, 0x38007FFF      BG Video RAM????????1E00??????512x240??????
-
-***************************************************************************/
-
-
-
-// CGLayer
-#if 0
-void igs_m027_state::igs_cg_videoram_w(offs_t offset, u32_t data, u32_t mem_mask)
-{
-	COMBINE_DATA(&m_igs_cg_videoram[offset]);
-	// if(data != 0)
-	logerror("PC(%08X) CG @%x = %x!\n", m_maincpu->pc(), offset , m_igs_cg_videoram[offset]);
-
-	/*
-	ROM:08020520                 DCW 0x3E                                           ddd1        y
-	ROM:08020522                 DCW 0x29                                           ddd2        x
-	ROM:08020524                 DCD 0x190BB6                                       ddd3        n
-	ROM:08020528                 DCW 0xC                                            ddd4        Y
-	ROM:0802052A                 DCW 0xA6                                           ddd5        X
-
-	(ddd5+?)??10bit
-	ddd2??9bit
-	(ddd4+?)??11bit
-	ddd1??8bit
-	ddd3??10bit
-
-	8060a4a6 2642ed8f
-	A6A46080 8FED4226
-
-	XXXX-XXXX
-	XXxx-xxxx
-	xxxY-YYYY
-	YYYY-YYyy
-
-	yyyy-yynn
-	nnnn-nnnn
-	*/
-}
-#endif
-
-
-
 void igs_m027_state::video_start()
 {
 	m_igs017_igs031->video_start();

--- a/src/mame/igs/igs_m027.cpp
+++ b/src/mame/igs/igs_m027.cpp
@@ -107,7 +107,7 @@ void igs_m027_state::igs_mahjong_map(address_map &map)
 	map(0x10000000, 0x100003ff).ram().share("igs_mainram"); // main RAM for ASIC?
 	map(0x18000000, 0x18007fff).ram();
 
-	map(0x38000000, 0x38007fff).rw(m_igs017_igs031, FUNC(igs017_igs031_device::read), FUNC(igs017_igs031_device::write)); // guess based on below
+	map(0x38000000, 0x38007fff).rw(m_igs017_igs031, FUNC(igs017_igs031_device::read), FUNC(igs017_igs031_device::write));
 
 	map(0x38008000, 0x38008003).r(FUNC(igs_m027_state::unk_r));
 

--- a/src/mame/igs/igs_m027xa.cpp
+++ b/src/mame/igs/igs_m027xa.cpp
@@ -82,14 +82,15 @@ void igs_m027xa_state::igs_mahjong_map(address_map &map)
 	map(0x10000000, 0x100003ff).ram().share("igs_mainram"); // main RAM for ASIC?
 	map(0x18000000, 0x18007fff).ram();
 
-	map(0x38000000, 0x38007fff).rw(m_igs017_igs031, FUNC(igs017_igs031_device::read), FUNC(igs017_igs031_device::write)); // guess based on below
+	map(0x38000000, 0x38007fff).rw(m_igs017_igs031, FUNC(igs017_igs031_device::read), FUNC(igs017_igs031_device::write));
 
 	map(0x70000200, 0x70000203).ram();     //??????????????
 	map(0x50000000, 0x500003ff).nopw(); // uploads XOR table to external ROM here
 	map(0xf0000000, 0xf000000f).nopw(); // magic registers
 }
 
-static INPUT_PORTS_START( base )	PORT_START("TEST0")
+static INPUT_PORTS_START( base )
+	PORT_START("TEST0")
 	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
 
 	PORT_START("TEST1")

--- a/src/mame/igs/igs_m027xa.cpp
+++ b/src/mame/igs/igs_m027xa.cpp
@@ -39,6 +39,7 @@ public:
 	void igs_mahjong_xa(machine_config &config);
 
 	void init_crzybugs();
+	void init_crzybugsa();
 	void init_crzybugsj();
 	void init_hauntedh();
 	void init_tripfev();
@@ -220,7 +221,7 @@ ROM_END
 ROM_START( crzybugsa )
 	ROM_REGION( 0x04000, "maincpu", 0 )
 	// Internal ROM of IGS027A ARM based MCU
-	ROM_LOAD( "m7_igs27a.u37", 0x00000, 0x4000, CRC(1b20532c) SHA1(e08d0110a843915a8ba8627ae6d3947cccc22048) ) // sticker marked 'M7'
+	ROM_LOAD( "unknown_crzybugsa_igs27a.u37", 0x00000, 0x4000, NO_DUMP ) // sticker marked '??'
 
 	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
 	ROM_LOAD( "crazy_bugs_v-202us.u23", 0x000000, 0x80000, CRC(210da1e6) SHA1(c726497bebd25d6a9053e331b4c26acc7e2db0b2) ) // MX27C4096
@@ -243,7 +244,7 @@ ROM_END
 ROM_START( crzybugsb )
 	ROM_REGION( 0x04000, "maincpu", 0 )
 	// Internal ROM of IGS027A ARM based MCU
-	ROM_LOAD( "m7_igs27a.u37", 0x00000, 0x4000, CRC(1b20532c) SHA1(e08d0110a843915a8ba8627ae6d3947cccc22048) ) // sticker marked 'M7'
+	ROM_LOAD( "unknown_crzybugsb_igs27a.u37", 0x00000, 0x4000, NO_DUMP ) // sticker marked '??'
 
 	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
 	ROM_LOAD( "crazy_bugs_v-202us.u23", 0x000000, 0x80000, CRC(129e36e9) SHA1(53f20bc3792249de8ef276f84283baa9abd30acd) ) // MX27C4096
@@ -374,6 +375,12 @@ void igs_m027xa_state::init_crzybugs()
 	m_igs017_igs031->tarzan_decrypt_sprites(0); // wrong?
 }
 
+void igs_m027xa_state::init_crzybugsa()
+{
+	crzybugs_decrypt(machine());
+	pgm_create_dummy_internal_arm_region();
+}
+
 void igs_m027xa_state::init_crzybugsj()
 {
 	crzybugsj_decrypt(machine());
@@ -402,8 +409,8 @@ void igs_m027xa_state::init_wldfruit()
 GAME( 2008, haunthig,  0,        igs_mahjong_xa, base,     igs_m027xa_state, init_hauntedh,  ROT0, "IGS", "Haunted House (IGS, V109US)", MACHINE_IS_SKELETON ) // IGS FOR V109US 2008 10 14
 GAME( 2006, haunthiga, haunthig, igs_mahjong_xa, base,     igs_m027xa_state, init_hauntedh,  ROT0, "IGS", "Haunted House (IGS, V101US)", MACHINE_IS_SKELETON ) // IGS FOR V101US 2006 08 23
 GAME( 2009, crzybugs,  0,        igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugs,  ROT0, "IGS", "Crazy Bugs (V204US)", MACHINE_IS_SKELETON ) // IGS FOR V204US 2009 5 19
-GAME( 2006, crzybugsa, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugs,  ROT0, "IGS", "Crazy Bugs (V202US)", MACHINE_IS_SKELETON ) // IGS FOR V100US 2006 3 29 but also V202US string
-GAME( 2005, crzybugsb, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugs,  ROT0, "IGS", "Crazy Bugs (V200US)", MACHINE_IS_SKELETON ) // FOR V100US 2005 7 20 but also V200US string
+GAME( 2006, crzybugsa, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugsa, ROT0, "IGS", "Crazy Bugs (V202US)", MACHINE_IS_SKELETON ) // IGS FOR V100US 2006 3 29 but also V202US string
+GAME( 2005, crzybugsb, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugsa, ROT0, "IGS", "Crazy Bugs (V200US)", MACHINE_IS_SKELETON ) // FOR V100US 2005 7 20 but also V200US string
 GAME( 2007, crzybugsj, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugsj, ROT0, "IGS", "Crazy Bugs (V103JP)", MACHINE_IS_SKELETON ) // IGS FOR V101JP 2007 06 08
 GAME( 2006, tripfev,   0,        igs_mahjong_xa, base,     igs_m027xa_state, init_tripfev,   ROT0, "IGS", "Triple Fever (V107US)", MACHINE_IS_SKELETON ) // IGS FOR V107US 2006 09 07
 GAME( 200?, wldfruit,  0,        igs_mahjong_xa, base,     igs_m027xa_state, init_wldfruit,  ROT0, "IGS", "Wild Fruit (V208US)", MACHINE_IS_SKELETON ) // IGS-----97----V208US

--- a/src/mame/igs/igs_m027xa.cpp
+++ b/src/mame/igs/igs_m027xa.cpp
@@ -433,8 +433,8 @@ void igs_m027xa_state::init_wldfruit()
 GAME( 2008, haunthig,  0,        igs_mahjong_xa, base,     igs_m027xa_state, init_hauntedh,  ROT0, "IGS", "Haunted House (IGS, V109US)", MACHINE_IS_SKELETON ) // IGS FOR V109US 2008 10 14
 GAME( 2006, haunthiga, haunthig, igs_mahjong_xa, base,     igs_m027xa_state, init_hauntedh,  ROT0, "IGS", "Haunted House (IGS, V101US)", MACHINE_IS_SKELETON ) // IGS FOR V101US 2006 08 23
 GAME( 2009, crzybugs,  0,        igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugs,  ROT0, "IGS", "Crazy Bugs (V204US)", MACHINE_IS_SKELETON ) // IGS FOR V204US 2009 5 19
-GAME( 2006, crzybugsa, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugs, ROT0, "IGS", "Crazy Bugs (V202US)", MACHINE_IS_SKELETON ) // IGS FOR V100US 2006 3 29 but also V202US string
-GAME( 2005, crzybugsb, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugs, ROT0, "IGS", "Crazy Bugs (V200US)", MACHINE_IS_SKELETON ) // FOR V100US 2005 7 20 but also V200US string
+GAME( 2006, crzybugsa, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugs,  ROT0, "IGS", "Crazy Bugs (V202US)", MACHINE_IS_SKELETON ) // IGS FOR V100US 2006 3 29 but also V202US string
+GAME( 2005, crzybugsb, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugs,  ROT0, "IGS", "Crazy Bugs (V200US)", MACHINE_IS_SKELETON ) // FOR V100US 2005 7 20 but also V200US string
 GAME( 2007, crzybugsj, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugsj, ROT0, "IGS", "Crazy Bugs (V103JP)", MACHINE_IS_SKELETON ) // IGS FOR V101JP 2007 06 08
 GAME( 2006, tripfev,   0,        igs_mahjong_xa, base,     igs_m027xa_state, init_tripfev,   ROT0, "IGS", "Triple Fever (V107US)", MACHINE_IS_SKELETON ) // IGS FOR V107US 2006 09 07
 GAME( 200?, wldfruit,  0,        igs_mahjong_xa, base,     igs_m027xa_state, init_wldfruit,  ROT0, "IGS", "Wild Fruit (V208US)", MACHINE_IS_SKELETON ) // IGS-----97----V208US

--- a/src/mame/igs/igs_m027xa.cpp
+++ b/src/mame/igs/igs_m027xa.cpp
@@ -64,6 +64,7 @@ private:
 
 void igs_m027xa_state::video_start()
 {
+	m_igs017_igs031->video_start();
 }
 
 
@@ -369,7 +370,7 @@ void igs_m027xa_state::init_hauntedh()
 void igs_m027xa_state::init_crzybugs()
 {
 	crzybugs_decrypt(machine());
-	m_igs017_igs031->sdwx_gfx_decrypt(); // wrong
+	m_igs017_igs031->sdwx_gfx_decrypt();
 	m_igs017_igs031->tarzan_decrypt_sprites(0); // wrong?
 }
 

--- a/src/mame/igs/igs_m027xa.cpp
+++ b/src/mame/igs/igs_m027xa.cpp
@@ -1,0 +1,408 @@
+// license:BSD-3-Clause
+// copyright-holders: Xing Xing, David Haywood
+
+/*
+
+IGS ARM7 (IGS027A) based Mahjong / Gambling platform(s) with XA sub-cpu
+These games use the IGS027A processor.
+
+*/
+
+#include "emu.h"
+
+#include "igs017_igs031.h"
+#include "pgmcrypt.h"
+
+#include "cpu/arm7/arm7.h"
+#include "cpu/arm7/arm7core.h"
+#include "cpu/xa/xa.h"
+
+#include "machine/i8255.h"
+#include "machine/nvram.h"
+
+#include "screen.h"
+
+namespace {
+
+class igs_m027xa_state : public driver_device
+{
+public:
+	igs_m027xa_state(const machine_config &mconfig, device_type type, const char *tag) :
+		driver_device(mconfig, type, tag),
+		m_igs_mainram(*this, "igs_mainram"),
+		m_maincpu(*this, "maincpu"),
+		m_xa(*this, "xa"),
+		m_ppi(*this, "ppi8255"),
+		m_igs017_igs031(*this, "igs017_igs031")
+	{ }
+
+	void igs_mahjong_xa(machine_config &config);
+
+	void init_crzybugs();
+	void init_crzybugsj();
+	void init_hauntedh();
+	void init_tripfev();
+	void init_wldfruit();
+
+protected:
+	virtual void video_start() override;
+
+private:
+	optional_shared_ptr<u32> m_igs_mainram;
+	required_device<cpu_device> m_maincpu;
+	required_device<mx10exa_cpu_device> m_xa;
+	required_device<i8255_device> m_ppi;
+	required_device<igs017_igs031_device> m_igs017_igs031;
+
+	void vblank_irq(int state);
+
+	void pgm_create_dummy_internal_arm_region();
+	void igs_mahjong_map(address_map &map);
+};
+
+
+
+void igs_m027xa_state::video_start()
+{
+}
+
+
+/***************************************************************************
+
+    Memory Maps
+
+***************************************************************************/
+
+void igs_m027xa_state::igs_mahjong_map(address_map &map)
+{
+	map(0x00000000, 0x00003fff).rom(); // Internal ROM
+	map(0x08000000, 0x0807ffff).rom().region("user1", 0); // Game ROM
+	map(0x10000000, 0x100003ff).ram().share("igs_mainram"); // main RAM for ASIC?
+	map(0x18000000, 0x18007fff).ram();
+
+	map(0x38000000, 0x38007fff).rw(m_igs017_igs031, FUNC(igs017_igs031_device::read), FUNC(igs017_igs031_device::write)); // guess based on below
+
+	map(0x70000200, 0x70000203).ram();     //??????????????
+	map(0x50000000, 0x500003ff).nopw(); // uploads XOR table to external ROM here
+	map(0xf0000000, 0xf000000f).nopw(); // magic registers
+}
+
+static INPUT_PORTS_START( base )	PORT_START("TEST0")
+	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START("TEST1")
+	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START("TEST2")
+	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
+INPUT_PORTS_END
+
+void igs_m027xa_state::vblank_irq(int state)
+{
+	if (state)
+		m_maincpu->pulse_input_line(ARM7_FIRQ_LINE, m_maincpu->minimum_quantum_time());
+}
+
+void igs_m027xa_state::igs_mahjong_xa(machine_config &config)
+{
+	ARM7(config, m_maincpu, 20000000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &igs_m027xa_state::igs_mahjong_map);
+
+//  NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
+
+	MX10EXA(config, m_xa, 10000000); // MX10EXAQC (Philips 80C51 XA) unknown frequency
+
+	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
+	screen.set_refresh_hz(60);
+	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
+	screen.set_size(512, 256);
+	screen.set_visarea(0, 512-1, 0, 256-1);
+	screen.set_screen_update("igs017_igs031", FUNC(igs017_igs031_device::screen_update));
+	screen.set_palette("igs017_igs031:palette");
+	screen.screen_vblank().set(FUNC(igs_m027xa_state::vblank_irq));
+
+	I8255A(config, m_ppi);
+	m_ppi->in_pa_callback().set_ioport("TEST0");
+	m_ppi->in_pb_callback().set_ioport("TEST1");
+	m_ppi->in_pc_callback().set_ioport("TEST2");
+
+	IGS017_IGS031(config, m_igs017_igs031, 0);
+	m_igs017_igs031->set_text_reverse_bits();
+	m_igs017_igs031->set_i8255_tag("ppi8255");
+
+	// sound hardware
+	// OK6295
+}
+
+// prg at u34
+// text at u15
+// cg at u32 / u12
+// samples at u3
+
+ROM_START( haunthig )
+	ROM_REGION( 0x04000, "maincpu", 0 )
+	// Internal ROM of IGS027A ARM based MCU
+	ROM_LOAD( "haunthig_igs027a", 0x00000, 0x4000, NO_DUMP )
+
+	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
+	ROM_LOAD( "hauntedhouse_ver-109us.u34", 0x000000, 0x80000, CRC(300fed78) SHA1(afa4c8855cd780c57d4f92ea6131ed4e77063268) )
+
+	ROM_REGION( 0x10000, "xa", 0 )
+	ROM_LOAD( "hauntedhouse.u17", 0x000000, 0x10000, BAD_DUMP CRC(3c76b157) SHA1(d8d3a434fd649577a30d5855e3fb34998041f4e5) ) // not dumped for this set
+
+	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )
+	ROM_LOAD( "haunted-h_text.u15", 0x000000, 0x80000, CRC(c23f48c8) SHA1(0cb1b6c61611a081ae4a3c0be51812045ff632fe) )
+
+	// are these PGM-like sprites?
+	ROM_REGION( 0x800000, "igs017_igs031:sprites", 0 )
+	ROM_LOAD( "haunted-h_cg.u32",  0x000000, 0x400000, BAD_DUMP CRC(e0ea10e6) SHA1(e81be78fea93e72d4b1f4c0b58560bda46cf7948) ) // not dumped for this set, FIXED BITS (xxxxxxx0xxxxxxxx)
+	ROM_LOAD( "haunted-h_ext.u12", 0x400000, 0x400000, BAD_DUMP CRC(662eb883) SHA1(831ebe29e1e7a8b2c2fff7fbc608975771c3486c) ) // not dumped for this set, FIXED BITS (xxxxxxxx0xxxxxxx)
+
+	ROM_REGION( 0x200000, "samples", 0 ) // Oki M6295 samples, missing sample table, bad?
+	ROM_LOAD( "haunted-h_sp.u3", 0x00000, 0x200000,  BAD_DUMP CRC(fe3fcddf) SHA1(ac57ab6d4e4883747c093bd19d0025cf6588cb2c) ) // not dumped for this set
+
+	ROM_REGION( 0x500, "plds", ROMREGION_ERASE00 )
+	ROM_LOAD( "hu_u38a.u38", 0x000, 0x117, NO_DUMP ) // ATF16V8B, protected
+	ROM_LOAD( "hu_u39.u39",  0x200, 0x2dd, CRC(75f58b46) SHA1(7cb136a41899ddd50c95a67ca6353ce5d8d92149) ) // AT22V10
+ROM_END
+
+ROM_START( haunthiga ) // IGS PCB-0575-04-HU - Has IGS027A, MX10EXAQC, IGS031, Oki M6295, 2x 8-dip banks
+	ROM_REGION( 0x04000, "maincpu", 0 )
+	// Internal ROM of IGS027A ARM based MCU
+	ROM_LOAD( "haunthig_igs027a", 0x00000, 0x4000, NO_DUMP ) // sticker marked 'H2'
+
+	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
+	ROM_LOAD( "hauntedhouse_ver-101us.u34", 0x000000, 0x80000, CRC(4bf045d4) SHA1(78c848fd69961df8d9b75f92ad57c3534fbf08db) )
+
+	ROM_REGION( 0x10000, "xa", 0 )
+	ROM_LOAD( "hauntedhouse.u17", 0x000000, 0x10000, CRC(3c76b157) SHA1(d8d3a434fd649577a30d5855e3fb34998041f4e5) ) // MX10EXAQC (80C51 XA based MCU) marked J9, not read protected?
+
+	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )
+	ROM_LOAD( "haunted-h_text.u15", 0x000000, 0x80000, CRC(c23f48c8) SHA1(0cb1b6c61611a081ae4a3c0be51812045ff632fe) )
+
+	// are these PGM-like sprites?
+	ROM_REGION( 0x800000, "igs017_igs031:sprites", 0 )
+	ROM_LOAD( "haunted-h_cg.u32",  0x000000, 0x400000, CRC(e0ea10e6) SHA1(e81be78fea93e72d4b1f4c0b58560bda46cf7948) ) // FIXED BITS (xxxxxxx0xxxxxxxx)
+	ROM_LOAD( "haunted-h_ext.u12", 0x400000, 0x400000, CRC(662eb883) SHA1(831ebe29e1e7a8b2c2fff7fbc608975771c3486c) ) // FIXED BITS (xxxxxxxx0xxxxxxx)
+
+	ROM_REGION( 0x200000, "samples", 0 ) // Oki M6295 samples, missing sample table, bad?
+	ROM_LOAD( "haunted-h_sp.u3", 0x00000, 0x200000, BAD_DUMP CRC(fe3fcddf) SHA1(ac57ab6d4e4883747c093bd19d0025cf6588cb2c) )
+
+	ROM_REGION( 0x500, "plds", ROMREGION_ERASE00 )
+	ROM_LOAD( "hu_u38a.u38", 0x000, 0x117, NO_DUMP ) // ATF16V8B, protected
+	ROM_LOAD( "hu_u39.u39",  0x200, 0x2dd, CRC(75f58b46) SHA1(7cb136a41899ddd50c95a67ca6353ce5d8d92149) ) // AT22V10
+ROM_END
+
+ROM_START( crzybugs ) // IGS PCB-0447-05-GM - Has IGS027A, MX10EXAQC, IGS031, Oki M6295, 3x 8-DIP banks
+	ROM_REGION( 0x04000, "maincpu", 0 )
+	// Internal ROM of IGS027A ARM based MCU
+	ROM_LOAD( "m7_igs27a.u37", 0x00000, 0x4000, CRC(1b20532c) SHA1(e08d0110a843915a8ba8627ae6d3947cccc22048) ) // sticker marked 'M7'
+
+	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
+	ROM_LOAD( "crazy_bugs_v-204us.u23", 0x000000, 0x80000, CRC(d1232462) SHA1(685a292f39bf57a80d6ef31289cf9f673ba06dd4) ) // MX27C4096
+
+	ROM_REGION( 0x10000, "xa", 0 ) // MX10EXAQC (80C51 XA based MCU) marked J9
+	ROM_LOAD( "j9.u27", 0x00000, 0x10000, CRC(3c76b157) SHA1(d8d3a434fd649577a30d5855e3fb34998041f4e5) )
+
+	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )  // not dumped for this set
+	ROM_LOAD( "crazy_bugs_text_u10.u10", 0x000000, 0x80000, BAD_DUMP CRC(db0d679a) SHA1(c5d039aa4fa2218b6f574ccb5b6da983b8d4067d) )
+
+	// are these PGM-like sprites?
+	ROM_REGION( 0x200000, "igs017_igs031:sprites", 0 ) // not dumped for this set
+	ROM_LOAD( "crazy_bugs_cg.u19",  0x000000, 0x200000, BAD_DUMP CRC(9d53ad47) SHA1(46690a37acf8bd88c7fbe973db2faf5ef0cff805) ) // FIXED BITS (xxxxxxx0xxxxxxxx)
+	// u18 not populated
+
+	ROM_REGION( 0x200000, "samples", 0 ) // plain Oki M6295 samples
+	ROM_LOAD( "crazy_bugs_sp.u15", 0x000000, 0x200000, CRC(b15974a1) SHA1(82509902bbb33a2120d815e7879b9b8591a29976) ) // M27C160
+ROM_END
+
+ROM_START( crzybugsa )
+	ROM_REGION( 0x04000, "maincpu", 0 )
+	// Internal ROM of IGS027A ARM based MCU
+	ROM_LOAD( "m7_igs27a.u37", 0x00000, 0x4000, CRC(1b20532c) SHA1(e08d0110a843915a8ba8627ae6d3947cccc22048) ) // sticker marked 'M7'
+
+	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
+	ROM_LOAD( "crazy_bugs_v-202us.u23", 0x000000, 0x80000, CRC(210da1e6) SHA1(c726497bebd25d6a9053e331b4c26acc7e2db0b2) ) // MX27C4096
+
+	ROM_REGION( 0x10000, "xa", 0 ) // MX10EXAQC (80C51 XA based MCU)
+	ROM_LOAD( "j9.u27", 0x00000, 0x10000, CRC(3c76b157) SHA1(d8d3a434fd649577a30d5855e3fb34998041f4e5) )
+
+	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )
+	ROM_LOAD( "crazy_bugs_text_u10.u10", 0x000000, 0x80000, CRC(db0d679a) SHA1(c5d039aa4fa2218b6f574ccb5b6da983b8d4067d) ) // M27C4002
+
+	// are these PGM-like sprites?
+	ROM_REGION( 0x200000, "igs017_igs031:sprites", 0 )
+	ROM_LOAD( "crazy_bugs_cg.u19",  0x000000, 0x200000, CRC(9d53ad47) SHA1(46690a37acf8bd88c7fbe973db2faf5ef0cff805) ) // M27C160, FIXED BITS (xxxxxxx0xxxxxxxx)
+	// u18 not populated
+
+	ROM_REGION( 0x200000, "samples", 0 ) // plain Oki M6295 samples
+	ROM_LOAD( "crazy_bugs_sp.u15", 0x000000, 0x200000, CRC(591b315b) SHA1(fda1816d83e202170dba4afc6e7898b706a76087) ) // M27C160
+ROM_END
+
+ROM_START( crzybugsb )
+	ROM_REGION( 0x04000, "maincpu", 0 )
+	// Internal ROM of IGS027A ARM based MCU
+	ROM_LOAD( "m7_igs27a.u37", 0x00000, 0x4000, CRC(1b20532c) SHA1(e08d0110a843915a8ba8627ae6d3947cccc22048) ) // sticker marked 'M7'
+
+	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
+	ROM_LOAD( "crazy_bugs_v-202us.u23", 0x000000, 0x80000, CRC(129e36e9) SHA1(53f20bc3792249de8ef276f84283baa9abd30acd) ) // MX27C4096
+
+	ROM_REGION( 0x10000, "xa", 0 ) // MX10EXAQC (80C51 XA based MCU)
+	ROM_LOAD( "j9.u27", 0x00000, 0x10000, CRC(3c76b157) SHA1(d8d3a434fd649577a30d5855e3fb34998041f4e5) )
+
+	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )
+	ROM_LOAD( "crazy_bugs_text_u10.u10", 0x000000, 0x80000, BAD_DUMP CRC(db0d679a) SHA1(c5d039aa4fa2218b6f574ccb5b6da983b8d4067d) ) // not dumped for this set
+
+	// are these PGM-like sprites?
+	ROM_REGION( 0x200000, "igs017_igs031:sprites", 0 )
+	ROM_LOAD( "crazy_bugs_cg.u19",  0x000000, 0x200000, BAD_DUMP CRC(9d53ad47) SHA1(46690a37acf8bd88c7fbe973db2faf5ef0cff805) ) // not dumped for this set, FIXED BITS (xxxxxxx0xxxxxxxx)
+	// u18 not populated
+
+	ROM_REGION( 0x200000, "samples", 0 ) // plain Oki M6295 samples
+	ROM_LOAD( "crazy_bugs_sp.u15", 0x000000, 0x200000, BAD_DUMP CRC(591b315b) SHA1(fda1816d83e202170dba4afc6e7898b706a76087) ) // not dumped for this set
+ROM_END
+
+ROM_START( crzybugsj ) // IGS PCB-0575-04-HU - Has IGS027A, MX10EXAQC, IGS031, Oki M6295, 2x 8-dip banks
+	ROM_REGION( 0x04000, "maincpu", 0 )
+	// Internal ROM of IGS027A ARM based MCU
+	ROM_LOAD( "m6.u42", 0x00000, 0x4000, NO_DUMP ) // sticker marked 'M6'
+
+	ROM_REGION32_LE( 0x200000, "user1", 0 ) // external ARM data / prg
+	ROM_LOAD( "crazy_bugs_v-103jp.u34", 0x000000, 0x200000, CRC(1e35ed79) SHA1(0e4f8b706cdfcaf2aacdc40eec422df9d865b311) )
+
+	ROM_REGION( 0x10000, "xa", 0 )
+	ROM_LOAD( "e9.u17", 0x00000, 0x10000, CRC(3c76b157) SHA1(d8d3a434fd649577a30d5855e3fb34998041f4e5) ) // MX10EXAQC (80C51 XA based MCU) marked E9, same as haunthig
+
+	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )
+	ROM_LOAD( "crazy_bugs_text_u15.u15", 0x000000, 0x80000, CRC(db0d679a) SHA1(c5d039aa4fa2218b6f574ccb5b6da983b8d4067d) )
+	// u14 not populated
+
+	// are these PGM-like sprites?
+	ROM_REGION( 0x200000, "igs017_igs031:sprites", 0 )
+	ROM_LOAD( "crazy_bugs_ani-cg-u32.u32",  0x000000, 0x200000, CRC(9d53ad47) SHA1(46690a37acf8bd88c7fbe973db2faf5ef0cff805) ) // FIXED BITS (xxxxxxx0xxxxxxxx)
+	// u12 not populated
+
+	ROM_REGION( 0x200000, "samples", 0 ) // plain Oki M6295 samples
+	ROM_LOAD( "crazy_bugs_sp_u3.u3", 0x000000, 0x200000,  CRC(b15974a1) SHA1(82509902bbb33a2120d815e7879b9b8591a29976) )
+
+	ROM_REGION( 0x500, "plds", ROMREGION_ERASE00 )
+	ROM_LOAD( "hu_u38.u38", 0x000, 0x117, NO_DUMP ) // ATF16V8B, protected
+	ROM_LOAD( "hu_u39.u39", 0x200, 0x2dd, CRC(75f58b46) SHA1(7cb136a41899ddd50c95a67ca6353ce5d8d92149) ) // AT22V10
+ROM_END
+
+ROM_START( tripfev ) // IGS PCB-0447-05-GM - Has IGS027A, MX10EXAQC, IGS031, Oki M6295, 3x 8-DIP banks
+	ROM_REGION( 0x04000, "maincpu", 0 )
+	// Internal ROM of IGS027A ARM based MCU
+	ROM_LOAD( "w1.u37", 0x00000, 0x4000, NO_DUMP ) // sticker marked 'W1'
+
+	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
+	ROM_LOAD( "triple_fever_u23_v107_us.u23", 0x000000, 0x80000, CRC(aa56d888) SHA1(0b8b2765079259b76ea803289841d867c33c8cb2) ) // 27C4096
+
+	ROM_REGION( 0x10000, "xa", 0 ) // MX10EXAQC (80C51 XA based MCU) marked P7
+	ROM_LOAD( "p7.u27", 0x00000, 0x10000, NO_DUMP )
+
+	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )
+	ROM_LOAD( "triple_fever_u10_text.u10", 0x000000, 0x80000, CRC(522a1030) SHA1(9a7a5ba9b26bceb0d251be6139c10e4655fc19ec) ) // M27C4002
+
+	ROM_REGION( 0x400000, "igs017_igs031:sprites", 0 )
+	ROM_LOAD( "triple_fever_u19_cg.u19",  0x000000, 0x400000, CRC(cd45bbf2) SHA1(7f1cf270245bbe4604de2cacade279ab13584dbd) ) // M27C322, FIXED BITS (xxxxxxx0xxxxxxxx)
+	// u18 not populated
+
+	ROM_REGION( 0x200000, "samples", 0 ) // plain Oki M6295 samples
+	ROM_LOAD( "triplef_sp_u15.u15", 0x000000, 0x200000, CRC(98b9cafd) SHA1(3bf3971f0d9520c98fc6b1c2e77ab9c178d21c62) ) // M27C160
+ROM_END
+
+ROM_START( wldfruit ) // IGS PCB-0447-05-GM - Has IGS027A, MX10EXAQC, IGS031, Oki M6295, 3x 8-DIP banks
+	ROM_REGION( 0x04000, "maincpu", 0 )
+	// Internal ROM of IGS027A ARM based MCU
+	ROM_LOAD( "w1.u37", 0x00000, 0x4000, NO_DUMP ) // sticker marked 'W1'
+
+	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
+	ROM_LOAD( "wild_fruit_v-208us.u23", 0x000000, 0x80000, CRC(d43398f1) SHA1(ecc4bd5cb6da16b35c63b843cf7beec1ab84ed9d) ) // M27C4002
+
+	ROM_REGION( 0x10000, "xa", 0 ) // MX10EXAQC (80C51 XA based MCU) marked J9
+	ROM_LOAD( "j9.u27", 0x00000, 0x10000, CRC(3c76b157) SHA1(d8d3a434fd649577a30d5855e3fb34998041f4e5) )
+
+	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )
+	ROM_LOAD( "wild_fruit_text.u10", 0x000000, 0x80000, CRC(d6f0fd58) SHA1(5ddae5d4df53504dbb2e0fe9f7caea961c961ef8) ) // 27C4096
+
+	ROM_REGION( 0x400000, "igs017_igs031:sprites", 0 )
+	ROM_LOAD( "wild_fruit_cg.u19",  0x000000, 0x400000, CRC(119686a8) SHA1(22583c1a1018cfdd20f0ef696d91fa1f6e01ab00) ) // M27C322, FIXED BITS (xxxxxxx0xxxxxxxx)
+	// u18 not populated
+
+	ROM_REGION( 0x200000, "samples", 0 ) // plain Oki M6295 samples
+	ROM_LOAD( "wild_fruit_sp.u15", 0x000000, 0x200000, CRC(9da3e9dd) SHA1(7e447492713549e6be362d4aca6d223dad20771a) ) // M27C160
+ROM_END
+
+
+void igs_m027xa_state::pgm_create_dummy_internal_arm_region()
+{
+	u16 *temp16 = (u16 *)memregion("maincpu")->base();
+
+	// fill with RX 14
+	for (int i = 0; i < 0x4000 / 2; i += 2)
+	{
+		temp16[i] = 0xff1e;
+		temp16[ i +1] = 0xe12f;
+
+	}
+
+	// jump straight to external area
+	temp16[(0x0000) / 2] = 0xd088;
+	temp16[(0x0002) / 2] = 0xe59f;
+	temp16[(0x0004) / 2] = 0x0680;
+	temp16[(0x0006) / 2] = 0xe3a0;
+	temp16[(0x0008) / 2] = 0xff10;
+	temp16[(0x000a) / 2] = 0xe12f;
+	temp16[(0x0090) / 2] = 0x0400;
+	temp16[(0x0092) / 2] = 0x1000;
+}
+
+
+void igs_m027xa_state::init_hauntedh()
+{
+	hauntedh_decrypt(machine());
+	//m_igs017_igs031->sdwx_gfx_decrypt(machine());
+	pgm_create_dummy_internal_arm_region();
+}
+
+void igs_m027xa_state::init_crzybugs()
+{
+	crzybugs_decrypt(machine());
+	m_igs017_igs031->sdwx_gfx_decrypt(); // wrong
+	m_igs017_igs031->tarzan_decrypt_sprites(0); // wrong?
+}
+
+void igs_m027xa_state::init_crzybugsj()
+{
+	crzybugsj_decrypt(machine());
+	//qlgs_gfx_decrypt(machine());
+	pgm_create_dummy_internal_arm_region();
+}
+
+void igs_m027xa_state::init_tripfev()
+{
+	tripfev_decrypt(machine());
+	//qlgs_gfx_decrypt(machine());
+	pgm_create_dummy_internal_arm_region();
+}
+
+void igs_m027xa_state::init_wldfruit()
+{
+	wldfruit_decrypt(machine());
+	//qlgs_gfx_decrypt(machine());
+	pgm_create_dummy_internal_arm_region();
+}
+
+} // anonymous namespace
+
+// These use the MX10EXAQC (80c51XA from Philips) and maybe don't belong in here
+// the PCBs are closer to igs_fear.cpp in terms of layout
+GAME( 2008, haunthig,  0,        igs_mahjong_xa, base,     igs_m027xa_state, init_hauntedh,  ROT0, "IGS", "Haunted House (IGS, V109US)", MACHINE_IS_SKELETON ) // IGS FOR V109US 2008 10 14
+GAME( 2006, haunthiga, haunthig, igs_mahjong_xa, base,     igs_m027xa_state, init_hauntedh,  ROT0, "IGS", "Haunted House (IGS, V101US)", MACHINE_IS_SKELETON ) // IGS FOR V101US 2006 08 23
+GAME( 2009, crzybugs,  0,        igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugs,  ROT0, "IGS", "Crazy Bugs (V204US)", MACHINE_IS_SKELETON ) // IGS FOR V204US 2009 5 19
+GAME( 2006, crzybugsa, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugs,  ROT0, "IGS", "Crazy Bugs (V202US)", MACHINE_IS_SKELETON ) // IGS FOR V100US 2006 3 29 but also V202US string
+GAME( 2005, crzybugsb, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugs,  ROT0, "IGS", "Crazy Bugs (V200US)", MACHINE_IS_SKELETON ) // FOR V100US 2005 7 20 but also V200US string
+GAME( 2007, crzybugsj, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugsj, ROT0, "IGS", "Crazy Bugs (V103JP)", MACHINE_IS_SKELETON ) // IGS FOR V101JP 2007 06 08
+GAME( 2006, tripfev,   0,        igs_mahjong_xa, base,     igs_m027xa_state, init_tripfev,   ROT0, "IGS", "Triple Fever (V107US)", MACHINE_IS_SKELETON ) // IGS FOR V107US 2006 09 07
+GAME( 200?, wldfruit,  0,        igs_mahjong_xa, base,     igs_m027xa_state, init_wldfruit,  ROT0, "IGS", "Wild Fruit (V208US)", MACHINE_IS_SKELETON ) // IGS-----97----V208US

--- a/src/mame/igs/igs_m027xa.cpp
+++ b/src/mame/igs/igs_m027xa.cpp
@@ -237,16 +237,16 @@ ROM_START( crzybugs ) // IGS PCB-0447-05-GM - Has IGS027A, MX10EXAQC, IGS031, Ok
 	ROM_REGION( 0x10000, "xa", 0 ) // MX10EXAQC (80C51 XA based MCU) marked J9
 	ROM_LOAD( "j9.u27", 0x00000, 0x10000, CRC(3c76b157) SHA1(d8d3a434fd649577a30d5855e3fb34998041f4e5) )
 
-	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )  // not dumped for this set
-	ROM_LOAD( "crazy_bugs_text_u10.u10", 0x000000, 0x80000, BAD_DUMP CRC(db0d679a) SHA1(c5d039aa4fa2218b6f574ccb5b6da983b8d4067d) )
+	ROM_REGION( 0x80000, "igs017_igs031:tilemaps", 0 )
+	ROM_LOAD( "crazy_bugs_text_u10.u10", 0x000000, 0x80000, CRC(db0d679a) SHA1(c5d039aa4fa2218b6f574ccb5b6da983b8d4067d) )
 
 	// are these PGM-like sprites?
-	ROM_REGION( 0x200000, "igs017_igs031:sprites", 0 ) // not dumped for this set
-	ROM_LOAD( "crazy_bugs_cg.u19",  0x000000, 0x200000, BAD_DUMP CRC(9d53ad47) SHA1(46690a37acf8bd88c7fbe973db2faf5ef0cff805) ) // FIXED BITS (xxxxxxx0xxxxxxxx)
+	ROM_REGION( 0x200000, "igs017_igs031:sprites", 0 )
+	ROM_LOAD( "crazy_bugs_cg.u19",  0x000000, 0x200000, CRC(9d53ad47) SHA1(46690a37acf8bd88c7fbe973db2faf5ef0cff805) ) // FIXED BITS (xxxxxxx0xxxxxxxx)
 	// u18 not populated
 
 	ROM_REGION( 0x200000, "samples", 0 ) // plain Oki M6295 samples
-	ROM_LOAD( "crazy_bugs_sp.u15", 0x000000, 0x200000, CRC(b15974a1) SHA1(82509902bbb33a2120d815e7879b9b8591a29976) ) // M27C160
+	ROM_LOAD( "crazybugs_sp.u15", 0x000000, 0x200000, CRC(591b315b) SHA1(fda1816d83e202170dba4afc6e7898b706a76087) ) // M27C160
 ROM_END
 
 ROM_START( crzybugsa )

--- a/src/mame/igs/igs_m027xa.cpp
+++ b/src/mame/igs/igs_m027xa.cpp
@@ -40,7 +40,6 @@ public:
 	void igs_mahjong_xa(machine_config &config);
 
 	void init_crzybugs();
-	void init_crzybugsa();
 	void init_crzybugsj();
 	void init_hauntedh();
 	void init_tripfev();
@@ -252,7 +251,7 @@ ROM_END
 ROM_START( crzybugsa )
 	ROM_REGION( 0x04000, "maincpu", 0 )
 	// Internal ROM of IGS027A ARM based MCU
-	ROM_LOAD( "unknown_crzybugsa_igs27a.u37", 0x00000, 0x4000, NO_DUMP ) // sticker marked '??'
+	ROM_LOAD( "m7_igs27a.u37", 0x00000, 0x4000, CRC(1b20532c) SHA1(e08d0110a843915a8ba8627ae6d3947cccc22048) ) // sticker marked 'M7' (not verified for this set)
 
 	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
 	ROM_LOAD( "crazy_bugs_v-202us.u23", 0x000000, 0x80000, CRC(210da1e6) SHA1(c726497bebd25d6a9053e331b4c26acc7e2db0b2) ) // MX27C4096
@@ -275,7 +274,7 @@ ROM_END
 ROM_START( crzybugsb )
 	ROM_REGION( 0x04000, "maincpu", 0 )
 	// Internal ROM of IGS027A ARM based MCU
-	ROM_LOAD( "unknown_crzybugsb_igs27a.u37", 0x00000, 0x4000, NO_DUMP ) // sticker marked '??'
+	ROM_LOAD( "m7_igs27a.u37", 0x00000, 0x4000, CRC(1b20532c) SHA1(e08d0110a843915a8ba8627ae6d3947cccc22048) ) // sticker marked 'M7' (not verified for this set)
 
 	ROM_REGION32_LE( 0x80000, "user1", 0 ) // external ARM data / prg
 	ROM_LOAD( "crazy_bugs_v-202us.u23", 0x000000, 0x80000, CRC(129e36e9) SHA1(53f20bc3792249de8ef276f84283baa9abd30acd) ) // MX27C4096
@@ -406,12 +405,6 @@ void igs_m027xa_state::init_crzybugs()
 	m_igs017_igs031->tarzan_decrypt_sprites(0); // ok?
 }
 
-void igs_m027xa_state::init_crzybugsa()
-{
-	crzybugs_decrypt(machine());
-	pgm_create_dummy_internal_arm_region();
-}
-
 void igs_m027xa_state::init_crzybugsj()
 {
 	crzybugsj_decrypt(machine());
@@ -440,8 +433,8 @@ void igs_m027xa_state::init_wldfruit()
 GAME( 2008, haunthig,  0,        igs_mahjong_xa, base,     igs_m027xa_state, init_hauntedh,  ROT0, "IGS", "Haunted House (IGS, V109US)", MACHINE_IS_SKELETON ) // IGS FOR V109US 2008 10 14
 GAME( 2006, haunthiga, haunthig, igs_mahjong_xa, base,     igs_m027xa_state, init_hauntedh,  ROT0, "IGS", "Haunted House (IGS, V101US)", MACHINE_IS_SKELETON ) // IGS FOR V101US 2006 08 23
 GAME( 2009, crzybugs,  0,        igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugs,  ROT0, "IGS", "Crazy Bugs (V204US)", MACHINE_IS_SKELETON ) // IGS FOR V204US 2009 5 19
-GAME( 2006, crzybugsa, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugsa, ROT0, "IGS", "Crazy Bugs (V202US)", MACHINE_IS_SKELETON ) // IGS FOR V100US 2006 3 29 but also V202US string
-GAME( 2005, crzybugsb, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugsa, ROT0, "IGS", "Crazy Bugs (V200US)", MACHINE_IS_SKELETON ) // FOR V100US 2005 7 20 but also V200US string
+GAME( 2006, crzybugsa, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugs, ROT0, "IGS", "Crazy Bugs (V202US)", MACHINE_IS_SKELETON ) // IGS FOR V100US 2006 3 29 but also V202US string
+GAME( 2005, crzybugsb, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugs, ROT0, "IGS", "Crazy Bugs (V200US)", MACHINE_IS_SKELETON ) // FOR V100US 2005 7 20 but also V200US string
 GAME( 2007, crzybugsj, crzybugs, igs_mahjong_xa, base,     igs_m027xa_state, init_crzybugsj, ROT0, "IGS", "Crazy Bugs (V103JP)", MACHINE_IS_SKELETON ) // IGS FOR V101JP 2007 06 08
 GAME( 2006, tripfev,   0,        igs_mahjong_xa, base,     igs_m027xa_state, init_tripfev,   ROT0, "IGS", "Triple Fever (V107US)", MACHINE_IS_SKELETON ) // IGS FOR V107US 2006 09 07
 GAME( 200?, wldfruit,  0,        igs_mahjong_xa, base,     igs_m027xa_state, init_wldfruit,  ROT0, "IGS", "Wild Fruit (V208US)", MACHINE_IS_SKELETON ) // IGS-----97----V208US

--- a/src/mame/igs/igs_m027xa.cpp
+++ b/src/mame/igs/igs_m027xa.cpp
@@ -46,6 +46,7 @@ public:
 	void init_wldfruit();
 
 protected:
+	virtual void machine_start() override;
 	virtual void video_start() override;
 
 private:
@@ -62,7 +63,7 @@ private:
 	void igs_mahjong_map(address_map &map);
 
 	void igs_70000100_w(u32 data);
-	u32 igs_70000100;
+	u32 m_igs_70000100 = 0;
 
 	u32 rand_r()
 	{
@@ -72,6 +73,11 @@ private:
 
 
 
+void igs_m027xa_state::machine_start()
+{
+	save_item(NAME(m_igs_70000100));
+}
+
 void igs_m027xa_state::video_start()
 {
 	m_igs017_igs031->video_start();
@@ -79,7 +85,7 @@ void igs_m027xa_state::video_start()
 
 void igs_m027xa_state::igs_70000100_w(u32 data)
 {
-	igs_70000100 = data;
+	m_igs_70000100 = data;
 }
 
 
@@ -124,7 +130,7 @@ void igs_m027xa_state::vblank_irq(int state)
 	if (state)
 	{
 		// hack
-		if (igs_70000100 == 0x55) // IRQ can't be enabled during RAM check, this might not be the enable flag though
+		if (m_igs_70000100 == 0x55) // IRQ can't be enabled during RAM check, this might not be the enable flag though
 		{
 			if (m_screen->frame_number() & 1)
 				m_maincpu->pulse_input_line(ARM7_FIRQ_LINE, m_maincpu->minimum_quantum_time());

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -20219,15 +20219,9 @@ amazoni2                        // (c) 2002
 amazonia                        // (c) 1999
 amazonkp                        // (c) 1999
 chessc2                         // (c) 200?
-crzybugs                        // (c) 2009
-crzybugsa                       // (c) 2006
-crzybugsb                       // (c) 2005
-crzybugsj                       // (c) 2007
 extradrw                        // (c) 200?
 fruitpar                        // (c) 200?
 gonefsh2                        // (c) 200?
-haunthig                        // (c) 2008
-haunthiga                       // (c) 2006
 jking02                         // (c) 200?
 klxyj                           // (c) 200?
 lhdmg                           // (c) 1999
@@ -20247,9 +20241,17 @@ qlgs                            // (c) 1999
 sddz                            // (c) 200?
 sdwx                            // (c) 2002
 slqz3                           // (c) 1999
+zhongguo                        // (c) 2000
+
+@source:igs/igs_m027xa.cpp
+crzybugs                        // (c) 2009
+crzybugsa                       // (c) 2006
+crzybugsb                       // (c) 2005
+crzybugsj                       // (c) 2007
+haunthig                        // (c) 2008
+haunthiga                       // (c) 2006
 tripfev                         // (c) 2006
 wldfruit                        // (c) 200?
-zhongguo                        // (c) 2000
 
 @source:igs/igs_m036.cpp
 cjddzsp                         // (c) 200?


### PR DESCRIPTION
jking02,  crzybugs - add IGS027A internal ROM dumps [Peter Wilhelmsen]

I've also moved the sprite/tile gfx decryptions out of igs017.cpp driver file, and into the video device, as I think it must be a configurable behavior of the 031 (many IGS encryptions are configurable, and it needs to be shared between drivers too)

The machines with an XA have also been split out to a different driver for now

