### PR TITLE
Replace a few complaint with compliant (Part 1)

### DIFF
--- a/src/devices/bus/pci/pdc20262.cpp
+++ b/src/devices/bus/pci/pdc20262.cpp
@@ -4,7 +4,7 @@
 
 Promise PDC20262 FastTrak66/UDMA66 IDE controller
 
-No documentation, ATA4 complaint
+No documentation, ATA4 compliant
 
 TODO:
 - how it sets compatible/native modes? Subvendor ID list suggests it can switch at will;

--- a/src/devices/machine/sis7018_audio.cpp
+++ b/src/devices/machine/sis7018_audio.cpp
@@ -2,7 +2,7 @@
 // copyright-holders: Angelo Salese
 /**************************************************************************************************
 
-SiS 7018 Audio device (AC97 complaint)
+SiS 7018 Audio device (AC97 compliant)
 
 TODO:
 - Stub interface, to be improved;

--- a/src/devices/machine/sis950_lpc.cpp
+++ b/src/devices/machine/sis950_lpc.cpp
@@ -430,7 +430,7 @@ void sis950_lpc_device::io_map(address_map &map)
 	map(0x0060, 0x0060).rw(m_keybc, FUNC(ps2_keyboard_controller_device::data_r), FUNC(ps2_keyboard_controller_device::data_w));
 	// map(0x0061, 0x0061) NMI Status Register
 	map(0x0061, 0x0061).rw(FUNC(sis950_lpc_device::nmi_status_r), FUNC(sis950_lpc_device::nmi_control_w));
-	// undocumented but read, assume LPC complaint
+	// undocumented but read, assume LPC compliant
 	map(0x0064, 0x0064).rw(m_keybc, FUNC(ps2_keyboard_controller_device::status_r), FUNC(ps2_keyboard_controller_device::command_w));
 	// map(0x0070, 0x0070) CMOS and NMI Mask
 	map(0x0070, 0x0070).w(FUNC(sis950_lpc_device::rtc_index_w));

--- a/src/mame/konami/viper.cpp
+++ b/src/mame/konami/viper.cpp
@@ -82,9 +82,9 @@
       ds2430.
     - Voodoo 3 has issues with LOD minimums, cfr. mocapglf where card check don't display a bar
       near the percentage;
-    - convert i2c to be a real i2c-complaint device;
+    - convert i2c to be a real i2c-compliant device;
     - hookup adc0838, reads from i2c;
-    - convert epic to be a device, make it input_merger/irq_callback complaint;
+    - convert epic to be a device, make it input_merger/irq_callback compliant;
     - (more intermediate steps for proper PCI conversions here)
     - jpark3: attract mode demo play acts weird, the dinosaur gets submerged
       and camera doesn't really know what to do, CPU core bug?

--- a/src/mame/nec/pce_cd.cpp
+++ b/src/mame/nec/pce_cd.cpp
@@ -23,7 +23,7 @@ TODO:
 - Audio CD player rewind/fast forward don't work properly
   \- never go past 1 minute mark, underflows;
 - Fader feature is sketchy and unchecked against real HW;
-- Implement proper check condition errors (non-SCSI complaint);
+- Implement proper check condition errors (non-SCSI compliant);
 
 **************************************************************************************************/
 

--- a/src/mame/pc/sis630.cpp
+++ b/src/mame/pc/sis630.cpp
@@ -10,8 +10,8 @@ TODO (main):
 \- fan monitor, cfr. I/O $294 reads in shutms11 BIOS fan tests;
 \- FDC doesn't work, moans on first boot;
 - '900 Ethernet PXE (missing ROM dump);
-- USB controllers (OpenHCI complaint);
-- ACPI is not fully lpc-acpi complaint;
+- USB controllers (OpenHCI compliant);
+- ACPI is not fully lpc-acpi compliant;
 - EISA slots;
 - SMBus;
 - PS/2 mouse is unstable, worked around by disabling and using a serial mouse instead.
@@ -316,7 +316,7 @@ void sis630_state::sis630(machine_config &config)
 	serport1.ri_handler().set("superio:it8705f", FUNC(it8705f_device::nri2_w));
 	serport1.cts_handler().set("superio:it8705f", FUNC(it8705f_device::ncts2_w));
 
-	// TODO: AMR (Audio/modem riser) + UPT (Panel Link-TV out), assume [E]ISA complaint, needs specific slot options
+	// TODO: AMR (Audio/modem riser) + UPT (Panel Link-TV out), assume [E]ISA compliant, needs specific slot options
 //  ISA16_SLOT(config, "isa1", 0, "pci:01.0:isabus", pc_isa16_cards, nullptr, false);
 //  ISA16_SLOT(config, "isa2", 0, "pci:01.0:isabus", pc_isa16_cards, nullptr, false);
 }


### PR DESCRIPTION
Replacing the typo word complaint with compliant to help make a little more sense for certain pieces.