### PR TITLE
apple2e: Apple //c mouse fixes

### DIFF
--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -1037,6 +1037,13 @@ void apple2e_state::machine_start()
 	m_joystick_x1_time = m_joystick_x2_time = m_joystick_y1_time = m_joystick_y2_time = 0;
 	m_reset_latch = false;
 
+	last_mx = 0;
+	last_my = 0;
+	count_x = 0;
+	count_y = 0;
+	m_x0 = false;
+	m_y0 = false;
+
 	// setup save states
 	save_item(NAME(m_speaker_state));
 	save_item(NAME(m_cassette_state));
@@ -1165,12 +1172,6 @@ void apple2e_state::machine_reset()
 	m_xy = false;
 	m_x0edge = false;
 	m_y0edge = false;
-	last_mx = 0;
-	last_my = 0;
-	count_x = 0;
-	count_y = 0;
-	m_x0 = false;
-	m_y0 = false;
 	m_x1 = false;
 	m_y1 = false;
 	m_xirq = false;
@@ -2793,9 +2794,9 @@ void apple2e_state::update_iic_mouse()
 		m_y0 = !m_y0;
 	}
 
-	if (raise_mousexy_irq) {
+	if (raise_mousexy_irq)
+	{
 		raise_irq(IRQ_MOUSEXY);
-		raise_mousexy_irq = false;
 	}
 }
 

--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -1165,6 +1165,14 @@ void apple2e_state::machine_reset()
 	m_xy = false;
 	m_x0edge = false;
 	m_y0edge = false;
+	last_mx = 0;
+	last_my = 0;
+	count_x = 0;
+	count_y = 0;
+	m_x0 = false;
+	m_y0 = false;
+	m_x1 = false;
+	m_y1 = false;
 	m_xirq = false;
 	m_yirq = false;
 	m_mockingboard4c = false;
@@ -2681,6 +2689,7 @@ void apple2e_state::c000_iic_w(offs_t offset, u8 data)
 void apple2e_state::update_iic_mouse()
 {
 	int new_mx, new_my;
+	bool raise_mousexy_irq = false;
 
 	// read the axes and check for changes
 	new_mx = m_mousex->read();
@@ -2750,13 +2759,14 @@ void apple2e_state::update_iic_mouse()
 			if (m_xy)
 			{
 				m_xirq = true;
-				raise_irq(IRQ_MOUSEXY);
+				raise_mousexy_irq = true;
 			}
 		}
 
 		m_x0 = !m_x0;
 	}
-	else if (count_y)
+
+	if (count_y)
 	{
 		if (count_y < 0)
 		{
@@ -2776,11 +2786,16 @@ void apple2e_state::update_iic_mouse()
 			if (m_xy)
 			{
 				m_yirq = true;
-				raise_irq(IRQ_MOUSEXY);
+				raise_mousexy_irq = true;
 			}
 		}
 
 		m_y0 = !m_y0;
+	}
+
+	if (raise_mousexy_irq) {
+		raise_irq(IRQ_MOUSEXY);
+		raise_mousexy_irq = false;
 	}
 }
 
@@ -4374,10 +4389,10 @@ static INPUT_PORTS_START( apple2c )
 	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON1) PORT_NAME("Mouse Button") PORT_CODE(MOUSECODE_BUTTON1)
 
 	PORT_START(MOUSE_XAXIS_TAG) /* Mouse - X AXIS */
-	PORT_BIT( 0xff, 0x00, IPT_MOUSE_X) PORT_SENSITIVITY(20) PORT_KEYDELTA(0) PORT_PLAYER(1)
+	PORT_BIT( 0xff, 0x00, IPT_MOUSE_X) PORT_SENSITIVITY(40) PORT_KEYDELTA(0) PORT_PLAYER(1)
 
 	PORT_START(MOUSE_YAXIS_TAG) /* Mouse - Y AXIS */
-	PORT_BIT( 0xff, 0x00, IPT_MOUSE_Y) PORT_SENSITIVITY(20) PORT_KEYDELTA(0) PORT_PLAYER(1)
+	PORT_BIT( 0xff, 0x00, IPT_MOUSE_Y) PORT_SENSITIVITY(40) PORT_KEYDELTA(0) PORT_PLAYER(1)
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( laser128 )
@@ -4397,10 +4412,10 @@ static INPUT_PORTS_START( laser128 )
 	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON1) PORT_NAME("Mouse Button") PORT_CODE(MOUSECODE_BUTTON1)
 
 	PORT_START(MOUSE_XAXIS_TAG) /* Mouse - X AXIS */
-	PORT_BIT( 0xff, 0x00, IPT_MOUSE_X) PORT_SENSITIVITY(20) PORT_KEYDELTA(0) PORT_PLAYER(1)
+	PORT_BIT( 0xff, 0x00, IPT_MOUSE_X) PORT_SENSITIVITY(40) PORT_KEYDELTA(0) PORT_PLAYER(1)
 
 	PORT_START(MOUSE_YAXIS_TAG) /* Mouse - Y AXIS */
-	PORT_BIT( 0xff, 0x00, IPT_MOUSE_Y) PORT_SENSITIVITY(20) PORT_KEYDELTA(0) PORT_PLAYER(1)
+	PORT_BIT( 0xff, 0x00, IPT_MOUSE_Y) PORT_SENSITIVITY(40) PORT_KEYDELTA(0) PORT_PLAYER(1)
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( ace500 )
@@ -4438,10 +4453,10 @@ static INPUT_PORTS_START( ace500 )
 	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON1) PORT_NAME("Mouse Button") PORT_CODE(MOUSECODE_BUTTON1)
 
 	PORT_START(MOUSE_XAXIS_TAG) /* Mouse - X AXIS */
-	PORT_BIT( 0xff, 0x00, IPT_MOUSE_X) PORT_SENSITIVITY(20) PORT_KEYDELTA(0) PORT_PLAYER(1)
+	PORT_BIT( 0xff, 0x00, IPT_MOUSE_X) PORT_SENSITIVITY(40) PORT_KEYDELTA(0) PORT_PLAYER(1)
 
 	PORT_START(MOUSE_YAXIS_TAG) /* Mouse - Y AXIS */
-	PORT_BIT( 0xff, 0x00, IPT_MOUSE_Y) PORT_SENSITIVITY(20) PORT_KEYDELTA(0) PORT_PLAYER(1)
+	PORT_BIT( 0xff, 0x00, IPT_MOUSE_Y) PORT_SENSITIVITY(40) PORT_KEYDELTA(0) PORT_PLAYER(1)
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( apple2cp )
@@ -4453,10 +4468,10 @@ static INPUT_PORTS_START( apple2cp )
 	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON1) PORT_NAME("Mouse Button") PORT_CODE(MOUSECODE_BUTTON1)
 
 	PORT_START(MOUSE_XAXIS_TAG) /* Mouse - X AXIS */
-	PORT_BIT( 0xff, 0x00, IPT_MOUSE_X) PORT_SENSITIVITY(20) PORT_KEYDELTA(0) PORT_PLAYER(1)
+	PORT_BIT( 0xff, 0x00, IPT_MOUSE_X) PORT_SENSITIVITY(40) PORT_KEYDELTA(0) PORT_PLAYER(1)
 
 	PORT_START(MOUSE_YAXIS_TAG) /* Mouse - Y AXIS */
-	PORT_BIT( 0xff, 0x00, IPT_MOUSE_Y) PORT_SENSITIVITY(20) PORT_KEYDELTA(0) PORT_PLAYER(1)
+	PORT_BIT( 0xff, 0x00, IPT_MOUSE_Y) PORT_SENSITIVITY(40) PORT_KEYDELTA(0) PORT_PLAYER(1)
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( apple2euk )


### PR DESCRIPTION
- Initializes Apple //c mouse related variables
- Sets Y0 interrupt flag on //c mouse Y-axis movement even if X-axis movement is still being processed (allowing both the X0 and Y0 interrupt flags to be set at the same time)
- Increases //c mouse port sensitivity (found in apple2e.cpp) from 20 to 40 to match that of the //e mouse (found in a2bus/mouse.cpp)
