### PR TITLE
floppy.cpp: Use standard drives for hard-sectored systems

### DIFF
--- a/src/devices/bus/s100/vectordualmode.cpp
+++ b/src/devices/bus/s100/vectordualmode.cpp
@@ -334,7 +334,7 @@ void s100_vector_dualmode_device::device_reset()
 
 static void vector4_floppies(device_slot_interface &device)
 {
-	device.option_add("525", FLOPPY_525_QD16);
+	device.option_add("525", FLOPPY_525_QD);
 }
 
 static void vector4_formats(format_registration &fr)
@@ -346,9 +346,13 @@ static void vector4_formats(format_registration &fr)
 void s100_vector_dualmode_device::device_add_mconfig(machine_config &config)
 {
 	FLOPPY_CONNECTOR(config, m_floppy[0], vector4_floppies, "525", vector4_formats).enable_sound(true);
+	m_floppy[0]->set_sectoring_type(floppy_image::H16);
 	FLOPPY_CONNECTOR(config, m_floppy[1], vector4_floppies, "525", vector4_formats).enable_sound(true);
+	m_floppy[1]->set_sectoring_type(floppy_image::H16);
 	FLOPPY_CONNECTOR(config, m_floppy[2], vector4_floppies, "525", vector4_formats).enable_sound(true);
+	m_floppy[2]->set_sectoring_type(floppy_image::H16);
 	FLOPPY_CONNECTOR(config, m_floppy[3], vector4_floppies, "525", vector4_formats).enable_sound(true);
+	m_floppy[3]->set_sectoring_type(floppy_image::H16);
 }
 
 DEFINE_DEVICE_TYPE(S100_VECTOR_DUALMODE, s100_vector_dualmode_device, "vectordualmode", "Vector Dual-Mode Disk Controller")

--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -90,6 +90,8 @@ public:
 	const floppy_image_format_t *get_load_format() const;
 	std::pair<std::error_condition, const floppy_image_format_t *> identify(std::string_view filename);
 	void set_rpm(float rpm);
+	void set_sectoring_type(uint32_t sectoring_type);
+	uint32_t get_sectoring_type();
 
 	void init_fs(const fs_info *fs, const fs::meta_data &meta);
 
@@ -194,6 +196,7 @@ protected:
 	int m_tracks; /* addressable tracks */
 	int m_sides;  /* number of heads */
 	uint32_t m_form_factor; /* 3"5, 5"25, etc */
+	uint32_t m_sectoring_type; /* SOFT, Hard 10/16/32 */
 	bool m_motor_always_on;
 	bool m_dskchg_writable;
 	bool m_has_trk00_sensor;
@@ -255,6 +258,8 @@ protected:
 
 	void register_formats();
 
+	void add_variant(uint32_t variant);
+
 	void check_led();
 	uint32_t find_position(attotime &base, const attotime &when);
 	attotime position_to_time(const attotime &base, int position) const;
@@ -299,7 +304,6 @@ DECLARE_FLOPPY_IMAGE_DEVICE(FLOPPY_525_SSDD,     floppy_525_ssdd,     "floppy_5_
 DECLARE_FLOPPY_IMAGE_DEVICE(FLOPPY_525_DD,       floppy_525_dd,       "floppy_5_25")
 DECLARE_FLOPPY_IMAGE_DEVICE(FLOPPY_525_SSQD,     floppy_525_ssqd,     "floppy_5_25")
 DECLARE_FLOPPY_IMAGE_DEVICE(FLOPPY_525_QD,       floppy_525_qd,       "floppy_5_25")
-DECLARE_FLOPPY_IMAGE_DEVICE(FLOPPY_525_QD16,     floppy_525_qd16,     "floppy_5_25")
 DECLARE_FLOPPY_IMAGE_DEVICE(FLOPPY_525_HD,       floppy_525_hd,       "floppy_5_25")
 DECLARE_FLOPPY_IMAGE_DEVICE(FLOPPY_8_SSSD,       floppy_8_sssd,       "floppy_8")
 DECLARE_FLOPPY_IMAGE_DEVICE(FLOPPY_8_DSSD,       floppy_8_dssd,       "floppy_8")
@@ -460,6 +464,7 @@ public:
 
 	template <typename T> void set_formats(T &&_formats) { formats = std::forward<T>(_formats); }
 	void enable_sound(bool doit) { m_enable_sound = doit; }
+	void set_sectoring_type(uint32_t sectoring_type) { m_sectoring_type = sectoring_type; }
 
 	floppy_image_device *get_device();
 
@@ -470,6 +475,7 @@ protected:
 private:
 	std::function<void (format_registration &fr)> formats;
 	bool m_enable_sound;
+	uint32_t m_sectoring_type;
 };
 
 

--- a/src/lib/formats/flopimg.cpp
+++ b/src/lib/formats/flopimg.cpp
@@ -140,26 +140,28 @@ const char *floppy_image::get_variant_name(uint32_t form_factor, uint32_t varian
 	case SSSD:   return "Single side, single density";
 	case SSSD10: return "Single side, single density, 10-sector";
 	case SSSD16: return "Single side, single density, 16-sector";
+	case SSSD32: return "Single side, single density, 32-sector";
 	case SSDD:   return "Single side, double density";
 	case SSDD10: return "Single side, double density, 10-sector";
 	case SSDD16: return "Single side, double density, 16 hard sector";
+	case SSDD32: return "Single side, double density, 32-sector";
 	case SSQD:   return "Single side, quad density";
 	case SSQD10: return "Single side, quad density, 10-sector";
 	case SSQD16: return "Single side, quad density, 16 hard sector";
-	case DSSD10: return "Doubld side, single density, 10-sector";
+	case DSSD:   return "Double side, single density";
+	case DSSD10: return "Double side, single density, 10-sector";
+	case DSSD16: return "Double side, single density, 16-sector";
+	case DSSD32: return "Double side, single density, 32-sector";
 	case DSDD:   return "Double side, double density";
 	case DSDD10: return "Double side, double density, 10-sector";
 	case DSDD16: return "Double side, double density, 16 hard sector";
+	case DSDD32: return "Double side, double density, 32-sector";
 	case DSQD:   return "Double side, quad density";
 	case DSQD10: return "Double side, quad density, 10-sector";
 	case DSQD16: return "Double side, quad density, 16 hard sector";
 	case DSHD:   return "Double side, high density";
 	case DSED:   return "Double side, extended density";
-	case DSSD16: return "Doubld side, single density, 16-sector";
-	case SSSD32: return "Single side, single density, 32-sector";
-	case SSDD32: return "Single side, double density, 32-sector";
-	case DSSD32: return "Doubld side, single density, 32-sector";
-	case DSDD32: return "Double side, double density, 32-sector";	}
+	}
 	return "Unknown";
 }
 

--- a/src/lib/formats/flopimg.cpp
+++ b/src/lib/formats/flopimg.cpp
@@ -138,17 +138,28 @@ const char *floppy_image::get_variant_name(uint32_t form_factor, uint32_t varian
 {
 	switch(variant) {
 	case SSSD:   return "Single side, single density";
+	case SSSD10: return "Single side, single density, 10-sector";
+	case SSSD16: return "Single side, single density, 16-sector";
 	case SSDD:   return "Single side, double density";
+	case SSDD10: return "Single side, double density, 10-sector";
 	case SSDD16: return "Single side, double density, 16 hard sector";
 	case SSQD:   return "Single side, quad density";
+	case SSQD10: return "Single side, quad density, 10-sector";
 	case SSQD16: return "Single side, quad density, 16 hard sector";
+	case DSSD10: return "Doubld side, single density, 10-sector";
 	case DSDD:   return "Double side, double density";
+	case DSDD10: return "Double side, double density, 10-sector";
 	case DSDD16: return "Double side, double density, 16 hard sector";
 	case DSQD:   return "Double side, quad density";
+	case DSQD10: return "Double side, quad density, 10-sector";
 	case DSQD16: return "Double side, quad density, 16 hard sector";
 	case DSHD:   return "Double side, high density";
 	case DSED:   return "Double side, extended density";
-	}
+	case DSSD16: return "Doubld side, single density, 16-sector";
+	case SSSD32: return "Single side, single density, 32-sector";
+	case SSDD32: return "Single side, double density, 32-sector";
+	case DSSD32: return "Doubld side, single density, 32-sector";
+	case DSDD32: return "Double side, double density, 32-sector";	}
 	return "Unknown";
 }
 

--- a/src/lib/formats/flopimg.h
+++ b/src/lib/formats/flopimg.h
@@ -526,14 +526,26 @@ public:
 	//! Variants
 	enum {
 		SSSD   = 0x44535353, //!< "SSSD", Single-sided single-density
+		SSSD10 = 0x30315353, //!< "SS10", Single-sided single-density 10 hard sector
+		SSSD16 = 0x36315353, //!< "SS16", Single-sided single-density 16 hard sector
+		SSSD32 = 0x32335353, //!< "SS32", Single-sided single-density 32 hard sector
 		SSDD   = 0x44445353, //!< "SSDD", Single-sided double-density
+		SSDD10 = 0x30314453, //!< "SD10", Single-sided double-density 10 hard sector
 		SSDD16 = 0x36314453, //!< "SD16", Single-sided double-density 16 hard sector
+		SSDD32 = 0x32334453, //!< "SD32", Single-sided double-density 32 hard sector
 		SSQD   = 0x44515353, //!< "SSQD", Single-sided quad-density
+		SSQD10 = 0x30315153, //!< "SQ10", Single-sided quad-density 10 hard sector
 		SSQD16 = 0x36315153, //!< "SQ16", Single-sided quad-density 16 hard sector
 		DSSD   = 0x44535344, //!< "DSSD", Double-sided single-density
+		DSSD10 = 0x30315344, //!< "DS10", Double-sided single-density 10 hard sector
+		DSSD16 = 0x36315344, //!< "DS16", Double-sided single-density 16 hard sector
+		DSSD32 = 0x32335344, //!< "DS32", Double-sided single-density 32 hard sector
 		DSDD   = 0x44445344, //!< "DSDD", Double-sided double-density (720K in 3.5, 360K in 5.25)
+		DSDD10 = 0x30314444, //!< "DD10", Double-sided double-density 10 hard sector
 		DSDD16 = 0x36314444, //!< "DD16", Double-sided double-density 16 hard sector (360K in 5.25)
+		DSDD32 = 0x32334444, //!< "DD32", Double-sided double-density 32 hard sector
 		DSQD   = 0x44515344, //!< "DSQD", Double-sided quad-density (720K in 5.25, means DD+80 tracks)
+		DSQD10 = 0x30315144, //!< "DQ10", Double-sided quad-density 10 hard sector
 		DSQD16 = 0x36315144, //!< "DQ16", Double-sided quad-density 16 hard sector (720K in 5.25, means DD+80 tracks)
 		DSHD   = 0x44485344, //!< "DSHD", Double-sided high-density (1440K)
 		DSED   = 0x44455344  //!< "DSED", Double-sided extra-density (2880K)
@@ -544,6 +556,14 @@ public:
 		FM   = 0x2020464D, //!< "  FM", frequency modulation
 		MFM  = 0x204D464D, //!< " MFM", modified frequency modulation
 		M2FM = 0x4D32464D  //!< "M2FM", modified modified frequency modulation
+	};
+
+	//! Sectoring
+	enum {
+		SOFT = 0x54464F53,  //!< "SOFT", Soft-sectored
+		H10  = 0x20303148,  //!< "H10 ", Hard 10-sectored
+		H16  = 0x20363148,  //!< "H16 ", Hard 16-sectored
+		H32  = 0x20323348   //!< "H32 ", Hard 32-sectored (8 inch disk)
 	};
 
 	// construction/destruction
@@ -562,10 +582,14 @@ public:
 	uint32_t get_form_factor() const noexcept { return form_factor; }
 	//! @return the variant.
 	uint32_t get_variant() const noexcept { return variant; }
+	//! @return the disk sectoring.
+	uint32_t get_sectoring() const noexcept { return sectoring; }
 	//! @param v the variant.
 	void set_variant(uint32_t v);
 	//! @param v the variant.
 	void set_form_variant(uint32_t f, uint32_t v) { if(form_factor == FF_UNKNOWN) form_factor = f; set_variant(v); }
+	//! @param s the sectoring.
+	void set_sectoring(uint32_t s) { sectoring = s; }
 
 	//! Find most recent and next index hole for provided angular position.
 	//! The most recent hole may be equal to provided position. The next
@@ -623,7 +647,7 @@ public:
 private:
 	int tracks, heads;
 
-	uint32_t form_factor, variant;
+	uint32_t form_factor, variant, sectoring;
 
 	struct track_info
 	{


### PR DESCRIPTION
Here is an alternate approach for handling hard-sectored floppy drives. Instead of requiring duplicating the existing drives and updating the variants, the sectoring is set during device configuration. This allows the drive to select the proper variants based on the sectoring type.
