### PR TITLE
hash/nes.xml: Add 8-bit Xmas 2023, NOT WORKING

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -79584,6 +79584,22 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
+	<software name="xmas23" supported="no">
+		<description>8-bit Xmas 2023</description>
+		<year>2023</year>
+		<publisher>retroUSB</publisher>
+		<info name="serial" value="RET-Y3-GBL"/>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="8bitxmas" />
+			<feature name="mirroring" value="vertical" />
+			<dataarea name="prg" size="0x20000">
+				<rom name="xmas23demo.prg" size="0x20000" crc="7c30674c" sha1="b1aa0d0ab8dab24f7dda27036d8dd12f1d6b7bea" />
+			</dataarea>
+			<!-- 32k VRAM on cartridge? -->
+			<dataarea name="vram" size="0x8000" />
+		</part>
+	</software>
+
 	<software name="musicpow">
 		<description>8Bit Music Power</description>
 		<year>2016</year>


### PR DESCRIPTION
New NOT WORKING software list additions
---------------------------------------
8-bit Xmas 2023

ROM can be downloaded from https://www.retrousb.com/product/8-bit-xmas-2023/33?cp=true&sa=false&sbp=false&q=false&category_id=W4OKTBSUZRS2F3DC6WNNJ476

Game doesn't function in MAME presently; maybe a new mapper is required? Very similar graphical bugs as xmas16, perhaps they are related.