### PR TITLE
hash/nes.xml: add three working NES homebrew games

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -45963,6 +45963,57 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		</part>
 	</software>
 
+	<software name="dpadheroa" cloneof="dpadhero">
+	  <description>D-Pad Hero (version 1.0)</description>
+	  <year>2009</year>
+	  <publisher>D-Pad Hero Team</publisher>
+	  <info name="release" value="20090131" />
+	  <part name="cart" interface="nes_cart">
+		<feature name="slot" value="txrom" />
+		<feature name="pcb" value="NES-TLROM" /> <!-- original download is an iNES file -->
+		<dataarea name="prg" size="131072">
+		  <rom name="dpadhero-1.0 prg" size="131072" crc="b824fa19" sha1="c80a2acb8b39982c0764d84051736dd799854712" />
+		</dataarea>
+		<dataarea name="chr" size="131072">
+		  <rom name="dpadhero chr" size="131072" crc="85db1444" sha1="6384b0eb3e036287393ef98811949252e37233bf" />
+		</dataarea>
+	  </part>
+	</software>
+
+	<software name="dpadhero">
+	  <description>D-Pad Hero (version 1.1)</description>
+	  <year>2009</year>
+	  <publisher>D-Pad Hero Team</publisher>
+	  <info name="release" value="20090204" />
+	  <part name="cart" interface="nes_cart">
+		<feature name="slot" value="txrom" />
+		<feature name="pcb" value="NES-TLROM" /> <!-- original download is an iNES file -->
+		<dataarea name="prg" size="131072">
+		  <rom name="dpadhero prg" size="131072" crc="9afe169b" sha1="7b7804e4bcfa0d8c389789a404d7cd62a4f9ed9f" />
+		</dataarea>
+		<dataarea name="chr" size="131072">
+		  <rom name="dpadhero chr" size="131072" crc="85db1444" sha1="6384b0eb3e036287393ef98811949252e37233bf" />
+		</dataarea>
+	  </part>
+	</software>
+
+	<software name="dpadhero2">
+	  <description>D-Pad Hero II</description>
+	  <year>2010</year>
+	  <publisher>D-Pad Hero Team</publisher>
+	  <info name="release" value="20100514" />
+	  <part name="cart" interface="nes_cart">
+		<feature name="slot" value="txrom" />
+		<feature name="pcb" value="NES-TLROM" /> <!-- original download is an iNES file -->
+		<dataarea name="prg" size="131072">
+		  <rom name="dpadhero2 prg" size="131072" crc="0105cfe8" sha1="2a97bc3951777c2f8249c7b565b8b7e38eea93c6" />
+		</dataarea>
+		<dataarea name="chr" size="131072">
+		  <rom name="dpadhero2 chr" size="131072" crc="f44a6f24" sha1="8db48088aae7b93a8cccfffe07bb86ba23c14051" />
+		</dataarea>
+	  </part>
+	</software>
+
 	<software name="drmariop2" cloneof="drmario">
 		<description>Dr. Mario (prototype, alt 2)</description>
 		<year>1990</year>


### PR DESCRIPTION
New working software list items (nes.xml)
-----------------------------------------
D-Pad Hero (version 1.0)
D-Pad Hero (version 1.1)
D-Pad Hero II

The latest version of the games are available at https://dpadhero.com/Download.html

D-Pad Hero 1 1.0 can be found on the wayback machine at https://web.archive.org/web/20100110052408/https://dpadhero.com/Download.html