### PR TITLE
TLCS900: reduce usage of preprocessor macros.

### DIFF
--- a/src/devices/cpu/tlcs900/tlcs900.cpp
+++ b/src/devices/cpu/tlcs900/tlcs900.cpp
@@ -70,13 +70,12 @@ std::unique_ptr<util::disasm_interface> tlcs900_device::create_disassembler()
 }
 
 
-/* Flag defines */
-#define FLAG_CF     0x01
-#define FLAG_NF     0x02
-#define FLAG_VF     0x04
-#define FLAG_HF     0x10
-#define FLAG_ZF     0x40
-#define FLAG_SF     0x80
+static constexpr u8 FLAG_CF = 0x01;
+static constexpr u8 FLAG_NF = 0x02;
+static constexpr u8 FLAG_VF = 0x04;
+static constexpr u8 FLAG_HF = 0x10;
+static constexpr u8 FLAG_ZF = 0x40;
+static constexpr u8 FLAG_SF = 0x80;
 
 
 inline uint8_t tlcs900_device::RDOP()

--- a/src/devices/cpu/tlcs900/tmp95c061.cpp
+++ b/src/devices/cpu/tlcs900/tmp95c061.cpp
@@ -257,50 +257,51 @@ void tmp95c061_device::device_reset()
 	}
 }
 
+enum {
+	INTE0AD,
+	INTE45,
+	INTE67,
+	INTET10,
+	INTET32,
+	INTET54,
+	INTET76,
+	INTES0,
+	INTES1,
+	INTETC10,
+	INTETC32
+};
 
-#define TMP95C061_INTE0AD     0x0
-#define TMP95C061_INTE45      0x1
-#define TMP95C061_INTE67      0x2
-#define TMP95C061_INTET10     0x3
-#define TMP95C061_INTET32     0x4
-#define TMP95C061_INTET54     0x5
-#define TMP95C061_INTET76     0x6
-#define TMP95C061_INTES0      0x7
-#define TMP95C061_INTES1      0x8
-#define TMP95C061_INTETC10    0x9
-#define TMP95C061_INTETC32    0xa
-
-#define TMP95C061_NUM_MASKABLE_IRQS   22
 static const struct {
 	uint8_t reg;
 	uint8_t iff;
 	uint8_t vector;
-} tmp95c061_irq_vector_map[TMP95C061_NUM_MASKABLE_IRQS] =
+} tmp95c061_irq_vector_map[] =
 {
-	{ TMP95C061_INTETC32, 0x80, 0x80 },   /* INTTC3 */
-	{ TMP95C061_INTETC32, 0x08, 0x7c },   /* INTTC2 */
-	{ TMP95C061_INTETC10, 0x80, 0x78 },   /* INTTC1 */
-	{ TMP95C061_INTETC10, 0x08, 0x74 },   /* INTTC0 */
-	{ TMP95C061_INTE0AD, 0x80, 0x70 },    /* INTAD */
-	{ TMP95C061_INTES1, 0x80, 0x6c },     /* INTTX1 */
-	{ TMP95C061_INTES1, 0x08, 0x68 },     /* INTRX1 */
-	{ TMP95C061_INTES0, 0x80, 0x64 },     /* INTTX0 */
-	{ TMP95C061_INTES0, 0x08, 0x60 },     /* INTRX0 */
-	{ TMP95C061_INTET76, 0x80, 0x5c },    /* INTTR7 */
-	{ TMP95C061_INTET76, 0x08, 0x58 },    /* INTTR6 */
-	{ TMP95C061_INTET54, 0x80, 0x54 },    /* INTTR5 */
-	{ TMP95C061_INTET54, 0x08, 0x50 },    /* INTTR4 */
-	{ TMP95C061_INTET32, 0x80, 0x4c },    /* INTT3 */
-	{ TMP95C061_INTET32, 0x08, 0x48 },    /* INTT2 */
-	{ TMP95C061_INTET10, 0x80, 0x44 },    /* INTT1 */
-	{ TMP95C061_INTET10, 0x08, 0x40 },    /* INTT0 */
+	{ INTETC32, 0x80, 0x80 },   /* INTTC3 */
+	{ INTETC32, 0x08, 0x7c },   /* INTTC2 */
+	{ INTETC10, 0x80, 0x78 },   /* INTTC1 */
+	{ INTETC10, 0x08, 0x74 },   /* INTTC0 */
+	{ INTE0AD, 0x80, 0x70 },    /* INTAD */
+	{ INTES1, 0x80, 0x6c },     /* INTTX1 */
+	{ INTES1, 0x08, 0x68 },     /* INTRX1 */
+	{ INTES0, 0x80, 0x64 },     /* INTTX0 */
+	{ INTES0, 0x08, 0x60 },     /* INTRX0 */
+	{ INTET76, 0x80, 0x5c },    /* INTTR7 */
+	{ INTET76, 0x08, 0x58 },    /* INTTR6 */
+	{ INTET54, 0x80, 0x54 },    /* INTTR5 */
+	{ INTET54, 0x08, 0x50 },    /* INTTR4 */
+	{ INTET32, 0x80, 0x4c },    /* INTT3 */
+	{ INTET32, 0x08, 0x48 },    /* INTT2 */
+	{ INTET10, 0x80, 0x44 },    /* INTT1 */
+	{ INTET10, 0x08, 0x40 },    /* INTT0 */
 								/* 0x3c - reserved */
-	{ TMP95C061_INTE67, 0x80, 0x38 },     /* INT7 */
-	{ TMP95C061_INTE67, 0x08, 0x34 },     /* INT6 */
-	{ TMP95C061_INTE45, 0x80, 0x30 },     /* INT5 */
-	{ TMP95C061_INTE45, 0x08, 0x2c },     /* INT4 */
-	{ TMP95C061_INTE0AD, 0x08, 0x28 }     /* INT0 */
+	{ INTE67, 0x80, 0x38 },     /* INT7 */
+	{ INTE67, 0x08, 0x34 },     /* INT6 */
+	{ INTE45, 0x80, 0x30 },     /* INT5 */
+	{ INTE45, 0x08, 0x2c },     /* INT4 */
+	{ INTE0AD, 0x08, 0x28 }     /* INT0 */
 };
+static constexpr u8 NUM_MASKABLE_IRQS = sizeof(tmp95c061_irq_vector_map) / 3;
 
 
 int tmp95c061_device::tlcs900_process_hdma( int channel )
@@ -312,11 +313,11 @@ int tmp95c061_device::tlcs900_process_hdma( int channel )
 	{
 		int irq = 0;
 
-		while( irq < TMP95C061_NUM_MASKABLE_IRQS && tmp95c061_irq_vector_map[irq].vector != vector )
+		while( irq < NUM_MASKABLE_IRQS && tmp95c061_irq_vector_map[irq].vector != vector )
 			irq++;
 
 		/* Check if our interrupt flip-flop is set */
-		if ( irq < TMP95C061_NUM_MASKABLE_IRQS && m_int_reg[tmp95c061_irq_vector_map[irq].reg] & tmp95c061_irq_vector_map[irq].iff )
+		if ( irq < NUM_MASKABLE_IRQS && m_int_reg[tmp95c061_irq_vector_map[irq].reg] & tmp95c061_irq_vector_map[irq].iff )
 		{
 			switch( m_dmam[channel].b.l & 0x1f )
 			{
@@ -406,16 +407,16 @@ int tmp95c061_device::tlcs900_process_hdma( int channel )
 				switch( channel )
 				{
 				case 0:
-					m_int_reg[TMP95C061_INTETC10] |= 0x08;
+					m_int_reg[INTETC10] |= 0x08;
 					break;
 				case 1:
-					m_int_reg[TMP95C061_INTETC10] |= 0x80;
+					m_int_reg[INTETC10] |= 0x80;
 					break;
 				case 2:
-					m_int_reg[TMP95C061_INTETC32] |= 0x08;
+					m_int_reg[INTETC32] |= 0x08;
 					break;
 				case 3:
-					m_int_reg[TMP95C061_INTETC32] |= 0x80;
+					m_int_reg[INTETC32] |= 0x80;
 					break;
 				}
 			}
@@ -475,7 +476,7 @@ void tmp95c061_device::tlcs900_check_irqs()
 	}
 
 	/* Check regular irqs */
-	for( i = 0; i < TMP95C061_NUM_MASKABLE_IRQS; i++ )
+	for( i = 0; i < NUM_MASKABLE_IRQS; i++ )
 	{
 		if ( m_int_reg[tmp95c061_irq_vector_map[i].reg] & tmp95c061_irq_vector_map[i].iff )
 		{
@@ -563,7 +564,7 @@ void tmp95c061_device::tlcs900_handle_ad()
 			m_ad_mode &= ~ 0x40;
 			m_ad_mode |= 0x80;
 
-			m_int_reg[TMP95C061_INTE0AD] |= 0x80;
+			m_int_reg[INTE0AD] |= 0x80;
 			m_check_irqs = 1;
 
 			/* AD repeat mode */
@@ -661,7 +662,7 @@ void tmp95c061_device::tlcs900_handle_timers()
 				if ( ( m_t8_mode[0] & 0xc0 ) != 0x40 )
 				{
 					m_timer[0] = 0;
-					m_int_reg[TMP95C061_INTET10] |= 0x08;
+					m_int_reg[INTET10] |= 0x08;
 				}
 			}
 		}
@@ -691,7 +692,7 @@ void tmp95c061_device::tlcs900_handle_timers()
 			if ( m_timer[1] == m_t8_reg[1] )
 			{
 				m_timer[1] = 0;
-				m_int_reg[TMP95C061_INTET10] |= 0x80;
+				m_int_reg[INTET10] |= 0x80;
 
 				if ( m_t8_invert & 0x02 )
 				{
@@ -738,7 +739,7 @@ void tmp95c061_device::tlcs900_handle_timers()
 				if ( ( m_t8_mode[1] & 0xc0 ) != 0x40 )
 				{
 					m_timer[2] = 0;
-					m_int_reg[TMP95C061_INTET32] |= 0x08;
+					m_int_reg[INTET32] |= 0x08;
 				}
 			}
 		}
@@ -768,7 +769,7 @@ void tmp95c061_device::tlcs900_handle_timers()
 			if ( m_timer[3] == m_t8_reg[3] )
 			{
 				m_timer[3] = 0;
-				m_int_reg[TMP95C061_INTET32] |= 0x80;
+				m_int_reg[INTET32] |= 0x80;
 
 				if ( m_t8_invert & 0x20 )
 				{
@@ -815,16 +816,16 @@ void tmp95c061_device::execute_set_input(int input, int level)
 				{
 					/* Leave HALT state */
 					m_halted = 0;
-					m_int_reg[TMP95C061_INTE0AD] |= 0x08;
+					m_int_reg[INTE0AD] |= 0x08;
 				}
 			}
 			else
 			{
 				/* Level detect */
 				if ( level == ASSERT_LINE )
-					m_int_reg[TMP95C061_INTE0AD] |= 0x08;
+					m_int_reg[INTE0AD] |= 0x08;
 				else
-					m_int_reg[TMP95C061_INTE0AD] &= ~ 0x08;
+					m_int_reg[INTE0AD] &= ~ 0x08;
 			}
 		}
 		m_level[TLCS900_INT0] = level;
@@ -835,7 +836,7 @@ void tmp95c061_device::execute_set_input(int input, int level)
 		{
 			if ( m_level[TLCS900_INT4] == CLEAR_LINE && level == ASSERT_LINE )
 			{
-				m_int_reg[TMP95C061_INTE45] |= 0x08;
+				m_int_reg[INTE45] |= 0x08;
 			}
 		}
 		m_level[TLCS900_INT4] = level;
@@ -846,7 +847,7 @@ void tmp95c061_device::execute_set_input(int input, int level)
 		{
 			if ( m_level[TLCS900_INT5] == CLEAR_LINE && level == ASSERT_LINE )
 			{
-				m_int_reg[TMP95C061_INTE45] |= 0x80;
+				m_int_reg[INTE45] |= 0x80;
 			}
 		}
 		m_level[TLCS900_INT5] = level;
@@ -1262,7 +1263,7 @@ uint8_t tmp95c061_device::sc0buf_r()
 void tmp95c061_device::sc0buf_w(uint8_t data)
 {
 	// Fake finish sending data
-	m_int_reg[TMP95C061_INTES0] |= 0x80;
+	m_int_reg[INTES0] |= 0x80;
 	m_check_irqs = 1;
 }
 
@@ -1307,7 +1308,7 @@ uint8_t tmp95c061_device::sc1buf_r()
 void tmp95c061_device::sc1buf_w(uint8_t data)
 {
 	// Fake finish sending data
-	m_int_reg[TMP95C061_INTES1] |= 0x80;
+	m_int_reg[INTES1] |= 0x80;
 	m_check_irqs = 1;
 }
 
@@ -1364,7 +1365,7 @@ uint8_t tmp95c061_device::adreg_r(offs_t offset)
 		return m_ad_result[offset >> 1] >> 2;
 
 	// Reading data from the upper 8 bits clears INTE0AD IADC
-	m_int_reg[TMP95C061_INTE0AD] &= ~0x80;
+	m_int_reg[INTE0AD] &= ~0x80;
 	return m_ad_result[offset >> 1] << 6 | 0x3f;
 }
 

--- a/src/devices/cpu/tlcs900/tmp95c063.cpp
+++ b/src/devices/cpu/tlcs900/tmp95c063.cpp
@@ -176,64 +176,63 @@ void tmp95c063_device::device_config_complete()
 	}
 }
 
+enum {
+	INTE0AD,
+	INTE12,
+	INTE34,
+	INTE56,
+	INTE78,
+	INTET01,
+	INTET23,
+	INTET45,
+	INTET67,
+	INTET89,
+	INTETAB,
+	INTES0,
+	INTES1,
+	INTETC01,
+	INTETC23
+};
 
-
-#define TMP95C063_INTE0AD   0x0
-#define TMP95C063_INTE12    0x1
-#define TMP95C063_INTE34    0x2
-#define TMP95C063_INTE56    0x3
-#define TMP95C063_INTE78    0x4
-#define TMP95C063_INTET01   0x5
-#define TMP95C063_INTET23   0x6
-#define TMP95C063_INTET45   0x7
-#define TMP95C063_INTET67   0x8
-#define TMP95C063_INTET89   0x9
-#define TMP95C063_INTETAB   0xa
-#define TMP95C063_INTES0    0xb
-#define TMP95C063_INTES1    0xc
-#define TMP95C063_INTETC01  0xd
-#define TMP95C063_INTETC23  0xe
-
-
-#define TMP95C063_NUM_MASKABLE_IRQS 30
 static const struct {
 	uint8_t reg;
 	uint8_t iff;
 	uint8_t vector;
-} tmp95c063_irq_vector_map[TMP95C063_NUM_MASKABLE_IRQS] =
+} tmp95c063_irq_vector_map[] =
 {
-	{ TMP95C063_INTETC23, 0x80, 0xa0 },     /* INTTC3 */
-	{ TMP95C063_INTETC23, 0x08, 0x9c },     /* INTTC2 */
-	{ TMP95C063_INTETC01, 0x80, 0x98 },     /* INTTC1 */
-	{ TMP95C063_INTETC01, 0x08, 0x94 },     /* INTTC0 */
-	{ TMP95C063_INTE0AD, 0x80, 0x90 },      /* INTAD */
-	{ TMP95C063_INTES1, 0x80, 0x8c },       /* INTTX1 */
-	{ TMP95C063_INTES1, 0x08, 0x88 },       /* INTRX1 */
-	{ TMP95C063_INTES0, 0x80, 0x84 },       /* INTTX0 */
-	{ TMP95C063_INTES0, 0x08, 0x80 },       /* INTRX0 */
-	{ TMP95C063_INTETAB, 0x80, 0x7c },      /* INTTRB */
-	{ TMP95C063_INTETAB, 0x08, 0x78 },      /* INTTRA */
-	{ TMP95C063_INTET89, 0x80, 0x74 },      /* INTTR9 */
-	{ TMP95C063_INTET89, 0x80, 0x70 },      /* INTTR8 */
-	{ TMP95C063_INTET67, 0x80, 0x6c },      /* INTT7 */
-	{ TMP95C063_INTET67, 0x08, 0x68 },      /* INTT6 */
-	{ TMP95C063_INTET45, 0x80, 0x64 },      /* INTT5 */
-	{ TMP95C063_INTET45, 0x08, 0x60 },      /* INTT4 */
-	{ TMP95C063_INTET23, 0x80, 0x5c },      /* INTT3 */
-	{ TMP95C063_INTET23, 0x08, 0x58 },      /* INTT2 */
-	{ TMP95C063_INTET01, 0x80, 0x54 },      /* INTT1 */
-	{ TMP95C063_INTET01, 0x08, 0x50 },      /* INTT0 */
-	{ TMP95C063_INTE78, 0x80, 0x4c },       /* int8_t */
-	{ TMP95C063_INTE78, 0x08, 0x48 },       /* INT7 */
-	{ TMP95C063_INTE56, 0x80, 0x44 },       /* INT6 */
-	{ TMP95C063_INTE56, 0x08, 0x40 },       /* INT5 */
+	{ INTETC23, 0x80, 0xa0 },     /* INTTC3 */
+	{ INTETC23, 0x08, 0x9c },     /* INTTC2 */
+	{ INTETC01, 0x80, 0x98 },     /* INTTC1 */
+	{ INTETC01, 0x08, 0x94 },     /* INTTC0 */
+	{ INTE0AD, 0x80, 0x90 },      /* INTAD */
+	{ INTES1, 0x80, 0x8c },       /* INTTX1 */
+	{ INTES1, 0x08, 0x88 },       /* INTRX1 */
+	{ INTES0, 0x80, 0x84 },       /* INTTX0 */
+	{ INTES0, 0x08, 0x80 },       /* INTRX0 */
+	{ INTETAB, 0x80, 0x7c },      /* INTTRB */
+	{ INTETAB, 0x08, 0x78 },      /* INTTRA */
+	{ INTET89, 0x80, 0x74 },      /* INTTR9 */
+	{ INTET89, 0x80, 0x70 },      /* INTTR8 */
+	{ INTET67, 0x80, 0x6c },      /* INTT7 */
+	{ INTET67, 0x08, 0x68 },      /* INTT6 */
+	{ INTET45, 0x80, 0x64 },      /* INTT5 */
+	{ INTET45, 0x08, 0x60 },      /* INTT4 */
+	{ INTET23, 0x80, 0x5c },      /* INTT3 */
+	{ INTET23, 0x08, 0x58 },      /* INTT2 */
+	{ INTET01, 0x80, 0x54 },      /* INTT1 */
+	{ INTET01, 0x08, 0x50 },      /* INTT0 */
+	{ INTE78, 0x80, 0x4c },       /* int8_t */
+	{ INTE78, 0x08, 0x48 },       /* INT7 */
+	{ INTE56, 0x80, 0x44 },       /* INT6 */
+	{ INTE56, 0x08, 0x40 },       /* INT5 */
 								/* 0x3c - reserved */
-	{ TMP95C063_INTE34, 0x80, 0x38 },       /* INT4 */
-	{ TMP95C063_INTE34, 0x08, 0x34 },       /* INT3 */
-	{ TMP95C063_INTE12, 0x80, 0x30 },       /* INT2 */
-	{ TMP95C063_INTE12, 0x08, 0x2c },       /* INT1 */
-	{ TMP95C063_INTE0AD, 0x08, 0x28 }       /* INT0 */
+	{ INTE34, 0x80, 0x38 },       /* INT4 */
+	{ INTE34, 0x08, 0x34 },       /* INT3 */
+	{ INTE12, 0x80, 0x30 },       /* INT2 */
+	{ INTE12, 0x08, 0x2c },       /* INT1 */
+	{ INTE0AD, 0x08, 0x28 }       /* INT0 */
 };
+static constexpr u8 NUM_MASKABLE_IRQS = sizeof(tmp95c063_irq_vector_map) / 3;
 
 void tmp95c063_device::tlcs900_handle_timers()
 {
@@ -277,7 +276,7 @@ void tmp95c063_device::tlcs900_handle_timers()
 				if ( ( m_t8_mode[0] & 0xc0 ) != 0x40 )
 				{
 					m_timer[0] = 0;
-					m_int_reg[TMP95C063_INTET01] |= 0x08;
+					m_int_reg[INTET01] |= 0x08;
 				}
 			}
 		}
@@ -307,7 +306,7 @@ void tmp95c063_device::tlcs900_handle_timers()
 			if ( m_timer[1] == m_t8_reg[1] )
 			{
 				m_timer[1] = 0;
-				m_int_reg[TMP95C063_INTET01] |= 0x80;
+				m_int_reg[INTET01] |= 0x80;
 
 				if ( m_t8_invert[0] & 0x02 )
 				{
@@ -354,7 +353,7 @@ void tmp95c063_device::tlcs900_handle_timers()
 				if ( ( m_t8_mode[1] & 0xc0 ) != 0x40 )
 				{
 					m_timer[2] = 0;
-					m_int_reg[TMP95C063_INTET23] |= 0x08;
+					m_int_reg[INTET23] |= 0x08;
 				}
 			}
 		}
@@ -384,7 +383,7 @@ void tmp95c063_device::tlcs900_handle_timers()
 			if ( m_timer[3] == m_t8_reg[3] )
 			{
 				m_timer[3] = 0;
-				m_int_reg[TMP95C063_INTET23] |= 0x80;
+				m_int_reg[INTET23] |= 0x80;
 
 				if ( m_t8_invert[1] & 0x20 )
 				{
@@ -434,7 +433,7 @@ void tmp95c063_device::tlcs900_check_irqs()
 	}
 
 	/* Check regular irqs */
-	for( i = 0; i < TMP95C063_NUM_MASKABLE_IRQS; i++ )
+	for( i = 0; i < NUM_MASKABLE_IRQS; i++ )
 	{
 		if ( m_int_reg[tmp95c063_irq_vector_map[i].reg] & tmp95c063_irq_vector_map[i].iff )
 		{
@@ -544,7 +543,7 @@ void tmp95c063_device::tlcs900_handle_ad()
 			m_ad_mode1 &= ~ 0x40;
 			m_ad_mode1 |= 0x80;
 
-			m_int_reg[TMP95C063_INTE0AD] |= 0x80;
+			m_int_reg[INTE0AD] |= 0x80;
 			m_check_irqs = 1;
 		}
 	}
@@ -1225,7 +1224,7 @@ uint8_t tmp95c063_device::sc0buf_r()
 void tmp95c063_device::sc0buf_w(uint8_t data)
 {
 	// Fake finish sending data
-	m_int_reg[TMP95C063_INTES0] |= 0x80;
+	m_int_reg[INTES0] |= 0x80;
 	m_check_irqs = 1;
 }
 
@@ -1270,7 +1269,7 @@ uint8_t tmp95c063_device::sc1buf_r()
 void tmp95c063_device::sc1buf_w(uint8_t data)
 {
 	// Fake finish sending data
-	m_int_reg[TMP95C063_INTES1] |= 0x80;
+	m_int_reg[INTES1] |= 0x80;
 	m_check_irqs = 1;
 }
 
@@ -1503,16 +1502,16 @@ void tmp95c063_device::execute_set_input(int input, int level)
 				{
 					/* Leave HALT state */
 					m_halted = 0;
-					m_int_reg[TMP95C063_INTE0AD] |= 0x08;
+					m_int_reg[INTE0AD] |= 0x08;
 				}
 			}
 			else
 			{
 				/* Level detect */
 				if (level == ASSERT_LINE)
-					m_int_reg[TMP95C063_INTE0AD] |= 0x08;
+					m_int_reg[INTE0AD] |= 0x08;
 				else
-					m_int_reg[TMP95C063_INTE0AD] &= ~ 0x08;
+					m_int_reg[INTE0AD] &= ~ 0x08;
 			}
 		}
 		m_level[TLCS900_INT0] = level;
@@ -1521,11 +1520,11 @@ void tmp95c063_device::execute_set_input(int input, int level)
 	case TLCS900_INT1:
 		if (m_level[TLCS900_INT1] == CLEAR_LINE && level == ASSERT_LINE)
 		{
-			m_int_reg[TMP95C063_INTE12] |= 0x08;
+			m_int_reg[INTE12] |= 0x08;
 		}
 		else if (m_level[TLCS900_INT1] == ASSERT_LINE && level == CLEAR_LINE)
 		{
-			m_int_reg[TMP95C063_INTE12] &= ~0x08;
+			m_int_reg[INTE12] &= ~0x08;
 		}
 		m_level[TLCS900_INT1] = level;
 		break;
@@ -1533,11 +1532,11 @@ void tmp95c063_device::execute_set_input(int input, int level)
 	case TLCS900_INT2:
 		if (m_level[TLCS900_INT2] == CLEAR_LINE && level == ASSERT_LINE)
 		{
-			m_int_reg[TMP95C063_INTE12] |= 0x80;
+			m_int_reg[INTE12] |= 0x80;
 		}
 		else if (m_level[TLCS900_INT2] == ASSERT_LINE && level == CLEAR_LINE)
 		{
-			m_int_reg[TMP95C063_INTE12] &= ~0x80;
+			m_int_reg[INTE12] &= ~0x80;
 		}
 		m_level[TLCS900_INT2] = level;
 		break;
@@ -1545,11 +1544,11 @@ void tmp95c063_device::execute_set_input(int input, int level)
 	case TLCS900_INT3:
 		if (m_level[TLCS900_INT3] == CLEAR_LINE && level == ASSERT_LINE)
 		{
-			m_int_reg[TMP95C063_INTE34] |= 0x08;
+			m_int_reg[INTE34] |= 0x08;
 		}
 		else if (m_level[TLCS900_INT3] == ASSERT_LINE && level == CLEAR_LINE)
 		{
-			m_int_reg[TMP95C063_INTE34] &= ~0x08;
+			m_int_reg[INTE34] &= ~0x08;
 		}
 		m_level[TLCS900_INT3] = level;
 		break;
@@ -1559,7 +1558,7 @@ void tmp95c063_device::execute_set_input(int input, int level)
 		{
 			if ( m_level[TLCS900_INT4] == CLEAR_LINE && level == ASSERT_LINE )
 			{
-				m_int_reg[TMP95C063_INTE34] |= 0x80;
+				m_int_reg[INTE34] |= 0x80;
 			}
 		}
 		m_level[TLCS900_INT4] = level;
@@ -1570,7 +1569,7 @@ void tmp95c063_device::execute_set_input(int input, int level)
 		{
 			if ( m_level[TLCS900_INT5] == CLEAR_LINE && level == ASSERT_LINE )
 			{
-				m_int_reg[TMP95C063_INTE56] |= 0x08;
+				m_int_reg[INTE56] |= 0x08;
 			}
 		}
 		m_level[TLCS900_INT5] = level;
@@ -1579,11 +1578,11 @@ void tmp95c063_device::execute_set_input(int input, int level)
 	case TLCS900_INT6:
 		if (m_level[TLCS900_INT6] == CLEAR_LINE && level == ASSERT_LINE)
 		{
-			m_int_reg[TMP95C063_INTE56] |= 0x80;
+			m_int_reg[INTE56] |= 0x80;
 		}
 		else if (m_level[TLCS900_INT6] == ASSERT_LINE && level == CLEAR_LINE)
 		{
-			m_int_reg[TMP95C063_INTE56] &= ~0x80;
+			m_int_reg[INTE56] &= ~0x80;
 		}
 		m_level[TLCS900_INT6] = level;
 		break;


### PR DESCRIPTION
Based on feedback from @cuavas at https://github.com/mamedev/mame/pull/12684#discussion_r1730039950, this PR replaces a bunch of `#define`s with `enum` and `static constexpr`.