### PR TITLE
hash/nes.xml: add Micro Mages to working software list

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -24626,6 +24626,43 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="micromages">
+		<description>Micro Mages</description>
+		<year>2019</year>
+		<publisher>Morphcat Games</publisher>
+		<info name="serial" value="NES-MM-MCG" />
+		<info name="release" value="20190212" />
+		<part name="cart" interface="nes_cart">
+		<feature name="slot" value="nrom" />
+		<feature name="pcb" value="NES-NROM-256" />
+		<feature name="mirroring" value="horizontal" />
+		<dataarea name="prg" size="32768">
+			<rom name="Micro Mages prg" size="32768" crc="1f4aa740" sha1="c1f0e973815687e06086e57a615abc116aa37e61" />
+		</dataarea>
+		<dataarea name="chr" size="8192">
+			<rom name="Micro Mages chr" size="8192" crc="24144d94" sha1="e08bec8c93dce07262be37c7cceb7019817bea69" />
+		</dataarea>
+		</part>
+	</software>
+
+	<software name="micromages2">
+		<description>Micro Mages Second Quest</description>
+		<year>2022</year>
+		<publisher>Morphcat Games</publisher>
+		<info name="release" value="20220915" />
+		<part name="cart" interface="nes_cart">
+		<feature name="slot" value="nrom" />
+		<feature name="pcb" value="NES-NROM-256" />
+		<feature name="mirroring" value="horizontal" />
+		<dataarea name="prg" size="32768">
+			<rom name="Micro Mages Second Quest prg" size="32768" crc="94cd391e" sha1="de626fd4556f8377c2c09928c7c89f333301cbe1" />
+		</dataarea>
+		<dataarea name="chr" size="8192">
+			<rom name="Micro Mages Second Quest chr" size="8192" crc="6f579478" sha1="73dea6d0bd2f8a9fb47e9d6329c9ebb8c9ace37b" />
+		</dataarea>
+		</part>
+	</software>
+
 	<software name="mightmagj" cloneof="mightmag">
 		<description>Might and Magic - Book One - Secret of the Inner Sanctum (Japan)</description>
 		<year>1990</year>


### PR DESCRIPTION
New working software list (nes.xml)
-----------------------------------
Micro Mages
Micro Mages Second Quest

Micro Mages can be purchased in both physical and digital format; http://morphcat.de/micromages/ has links to the store fronts. I've dumped the physical cart and verified it is the same ROM as the digital release. Micro Mages Second Quest is a digital-only release.

I'll attach a photo of the PCB here too, but I don't think it has useful information. If I'm wrong, feel free to use it :)

![IMG_20240910_174516](https://github.com/user-attachments/assets/e160b44e-8842-428e-a312-c87c8fd31d70)
