### PR TITLE
use templates for TLCS900 I/O ports

### DIFF
--- a/src/devices/cpu/tlcs900/tmp95c061.cpp
+++ b/src/devices/cpu/tlcs900/tmp95c061.cpp
@@ -14,26 +14,12 @@ DEFINE_DEVICE_TYPE(TMP95C061, tmp95c061_device, "tmp95c061", "Toshiba TMP95C061"
 
 tmp95c061_device::tmp95c061_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	tlcs900h_device(mconfig, TMP95C061, tag, owner, clock),
-	m_port1_read(*this, 0),
-	m_port1_write(*this),
-	m_port2_write(*this),
-	m_port5_read(*this, 0),
-	m_port5_write(*this),
-	m_port6_read(*this, 0),
-	m_port6_write(*this),
-	m_port7_read(*this, 0),
-	m_port7_write(*this),
-	m_port8_read(*this, 0),
-	m_port8_write(*this),
-	m_port9_read(*this, 0),
-	m_porta_read(*this, 0),
-	m_porta_write(*this),
-	m_portb_read(*this, 0),
-	m_portb_write(*this),
 	m_an_read(*this, 0),
-	m_port_latch{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
-	m_port_control{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
-	m_port_function{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+	m_port_read(*this, 0),
+	m_port_write(*this),
+	m_port_latch{ 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+	m_port_control{ 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+	m_port_function{ 0, 0, 0, 0, 0, 0, 0, 0, 0 },
 	m_trun(0),
 	m_t8_reg{ 0, 0, 0, 0 },
 	m_t8_mode{ 0, 0 },
@@ -67,26 +53,79 @@ tmp95c061_device::tmp95c061_device(const machine_config &mconfig, const char *ta
 {
 }
 
+template <Port P>
+void tmp95c061_device::port_w(uint8_t data)
+{
+	m_port_latch[P] = data;
+	m_port_write[P](0, data, 0xff);
+}
+
+template <Port P>
+uint8_t tmp95c061_device::port_r()
+{
+	return m_port_read[P](0);
+}
+
+template <Port P>
+void tmp95c061_device::port_cr_w(uint8_t data)
+{
+	m_port_control[P] = data;
+}
+
+template <Port P>
+void tmp95c061_device::port_fc_w(uint8_t data)
+{
+	m_port_function[P] = data;
+}
+
+template<>
+void tmp95c061_device::port_w <PORT_A> (uint8_t data)
+{
+	m_port_latch[PORT_A] = data;
+	update_porta();
+}
+
+template<>
+void tmp95c061_device::port_cr_w <PORT_A> (uint8_t data)
+{
+	m_port_control[PORT_A] = data;
+	update_porta();
+}
+
+template<>
+void tmp95c061_device::port_fc_w <PORT_A> (uint8_t data)
+{
+	m_port_function[PORT_A] = data;
+	update_porta();
+}
+
+void tmp95c061_device::update_porta()
+{
+	int fc = (m_to1 << 2) | (m_to3 << 3);
+
+	m_port_write[PORT_A](0, ((fc & m_port_function[PORT_A]) | (m_port_latch[PORT_A] & ~m_port_function[PORT_A])) & m_port_control[PORT_A], 0xff);
+}
+
 void tmp95c061_device::internal_mem(address_map &map)
 {
-	map(0x000001, 0x000001).rw(FUNC(tmp95c061_device::p1_r), FUNC(tmp95c061_device::p1_w));
-	map(0x000004, 0x000004).w(FUNC(tmp95c061_device::p1cr_w));
-	map(0x000006, 0x000006).rw(FUNC(tmp95c061_device::p2_r), FUNC(tmp95c061_device::p2_w));
-	map(0x000009, 0x000009).w(FUNC(tmp95c061_device::p2fc_w));
-	map(0x00000d, 0x00000d).rw(FUNC(tmp95c061_device::p5_r), FUNC(tmp95c061_device::p5_w));
-	map(0x000010, 0x000010).w(FUNC(tmp95c061_device::p5cr_w));
-	map(0x000011, 0x000011).w(FUNC(tmp95c061_device::p5fc_w));
-	map(0x000012, 0x000012).rw(FUNC(tmp95c061_device::p6_r), FUNC(tmp95c061_device::p6_w));
-	map(0x000013, 0x000013).rw(FUNC(tmp95c061_device::p7_r), FUNC(tmp95c061_device::p7_w));
-	map(0x000015, 0x000015).w(FUNC(tmp95c061_device::p6fc_w));
-	map(0x000016, 0x000016).w(FUNC(tmp95c061_device::p7cr_w));
-	map(0x000017, 0x000017).w(FUNC(tmp95c061_device::p7fc_w));
-	map(0x000018, 0x000018).rw(FUNC(tmp95c061_device::p8_r), FUNC(tmp95c061_device::p8_w));
-	map(0x000019, 0x000019).r(FUNC(tmp95c061_device::p9_r));
-	map(0x00001a, 0x00001a).w(FUNC(tmp95c061_device::p8cr_w));
-	map(0x00001b, 0x00001b).w(FUNC(tmp95c061_device::p8fc_w));
-	map(0x00001e, 0x00001e).rw(FUNC(tmp95c061_device::pa_r), FUNC(tmp95c061_device::pa_w));
-	map(0x00001f, 0x00001f).rw(FUNC(tmp95c061_device::pb_r), FUNC(tmp95c061_device::pb_w));
+	map(0x000001, 0x000001).rw(FUNC(tmp95c061_device::port_r<PORT_1>), FUNC(tmp95c061_device::port_w<PORT_1>));
+	map(0x000004, 0x000004).w(FUNC(tmp95c061_device::port_cr_w<PORT_1>));
+	map(0x000006, 0x000006).rw(FUNC(tmp95c061_device::port_r<PORT_2>), FUNC(tmp95c061_device::port_w<PORT_2>));
+	map(0x000009, 0x000009).w(FUNC(tmp95c061_device::port_fc_w<PORT_2>));
+	map(0x00000d, 0x00000d).rw(FUNC(tmp95c061_device::port_r<PORT_5>), FUNC(tmp95c061_device::port_w<PORT_5>));
+	map(0x000010, 0x000010).w(FUNC(tmp95c061_device::port_cr_w<PORT_5>));
+	map(0x000011, 0x000011).w(FUNC(tmp95c061_device::port_fc_w<PORT_5>));
+	map(0x000012, 0x000012).rw(FUNC(tmp95c061_device::port_r<PORT_6>), FUNC(tmp95c061_device::port_w<PORT_7>));
+	map(0x000013, 0x000013).rw(FUNC(tmp95c061_device::port_r<PORT_7>), FUNC(tmp95c061_device::port_w<PORT_7>));
+	map(0x000015, 0x000015).w(FUNC(tmp95c061_device::port_fc_w<PORT_6>));
+	map(0x000016, 0x000016).w(FUNC(tmp95c061_device::port_cr_w<PORT_7>));
+	map(0x000017, 0x000017).w(FUNC(tmp95c061_device::port_fc_w<PORT_7>));
+	map(0x000018, 0x000018).rw(FUNC(tmp95c061_device::port_r<PORT_8>), FUNC(tmp95c061_device::port_w<PORT_8>));
+	map(0x000019, 0x000019).r(FUNC(tmp95c061_device::port_r<PORT_9>));
+	map(0x00001a, 0x00001a).w(FUNC(tmp95c061_device::port_cr_w<PORT_8>));
+	map(0x00001b, 0x00001b).w(FUNC(tmp95c061_device::port_fc_w<PORT_8>));
+	map(0x00001e, 0x00001e).rw(FUNC(tmp95c061_device::port_r<PORT_A>), FUNC(tmp95c061_device::port_w<PORT_A>));
+	map(0x00001f, 0x00001f).rw(FUNC(tmp95c061_device::port_r<PORT_B>), FUNC(tmp95c061_device::port_w<PORT_B>));
 	map(0x000020, 0x000020).rw(FUNC(tmp95c061_device::trun_r), FUNC(tmp95c061_device::trun_w));
 	map(0x000022, 0x000023).w(FUNC(tmp95c061_device::treg01_w));
 	map(0x000024, 0x000024).w(FUNC(tmp95c061_device::t01mod_w));
@@ -94,10 +133,10 @@ void tmp95c061_device::internal_mem(address_map &map)
 	map(0x000026, 0x000027).w(FUNC(tmp95c061_device::treg23_w));
 	map(0x000028, 0x000028).w(FUNC(tmp95c061_device::t23mod_w));
 	map(0x000029, 0x000029).rw(FUNC(tmp95c061_device::trdc_r), FUNC(tmp95c061_device::trdc_w));
-	map(0x00002c, 0x00002c).w(FUNC(tmp95c061_device::pacr_w));
-	map(0x00002d, 0x00002d).w(FUNC(tmp95c061_device::pafc_w));
-	map(0x00002e, 0x00002e).w(FUNC(tmp95c061_device::pbcr_w));
-	map(0x00002f, 0x00002f).w(FUNC(tmp95c061_device::pbfc_w));
+	map(0x00002c, 0x00002c).w(FUNC(tmp95c061_device::port_cr_w<PORT_A>));
+	map(0x00002d, 0x00002d).w(FUNC(tmp95c061_device::port_fc_w<PORT_A>));
+	map(0x00002e, 0x00002e).w(FUNC(tmp95c061_device::port_cr_w<PORT_B>));
+	map(0x00002f, 0x00002f).w(FUNC(tmp95c061_device::port_fc_w<PORT_B>));
 	map(0x000030, 0x000033).w(FUNC(tmp95c061_device::treg45_w));
 	map(0x000034, 0x000037).r(FUNC(tmp95c061_device::cap12_r));
 	map(0x000038, 0x000038).rw(FUNC(tmp95c061_device::t4mod_r), FUNC(tmp95c061_device::t4mod_w));
@@ -207,18 +246,18 @@ void tmp95c061_device::device_reset()
 	m_timer_change[2] = 0;
 	m_timer_change[3] = 0;
 
-	m_port_latch[1] = 0x00;
-	m_port_latch[2] = 0xff;
-	m_port_latch[5] = 0x3d;
-	m_port_latch[6] = 0x3b;
-	m_port_latch[7] = 0xff;
-	m_port_latch[8] = 0x3f;
-	m_port_latch[0xa] = 0x0f;
-	m_port_latch[0xb] = 0xff;
-	std::fill_n(&m_port_control[0], 0xc, 0x00);
-	std::fill_n(&m_port_function[0], 0xc, 0x00);
-	m_port_control[0xa] = 0x0c; // HACK ngpc needs this but should be zero
-	m_port_function[0xa] = 0x0c; // HACK ngpc needs this but should be zero
+	m_port_latch[PORT_1] = 0x00;
+	m_port_latch[PORT_2] = 0xff;
+	m_port_latch[PORT_5] = 0x3d;
+	m_port_latch[PORT_6] = 0x3b;
+	m_port_latch[PORT_7] = 0xff;
+	m_port_latch[PORT_8] = 0x3f;
+	m_port_latch[PORT_A] = 0x0f;
+	m_port_latch[PORT_B] = 0xff;
+	std::fill_n(&m_port_control[0], NUM_PORTS, 0x00);
+	std::fill_n(&m_port_function[0], NUM_PORTS, 0x00);
+	m_port_control[PORT_A] = 0x0c; // HACK ngpc needs this but should be zero
+	m_port_function[PORT_A] = 0x0c; // HACK ngpc needs this but should be zero
 	m_trun = 0x00;
 	std::fill_n(&m_t8_mode[0], 2, 0x00);
 	m_t8_invert = 0xcc;
@@ -833,7 +872,7 @@ void tmp95c061_device::execute_set_input(int input, int level)
 		break;
 
 	case TLCS900_INT4:
-		if ( ! ( m_port_control[0xb] & 0x01 ) )
+		if ( ! ( m_port_control[PORT_B] & 0x01 ) )
 		{
 			if ( m_level[TLCS900_INT4] == CLEAR_LINE && level == ASSERT_LINE )
 			{
@@ -844,7 +883,7 @@ void tmp95c061_device::execute_set_input(int input, int level)
 		break;
 
 	case TLCS900_INT5:
-		if ( ! ( m_port_control[0xb] & 0x02 ) )
+		if ( ! ( m_port_control[PORT_B] & 0x02 ) )
 		{
 			if ( m_level[TLCS900_INT5] == CLEAR_LINE && level == ASSERT_LINE )
 			{
@@ -867,175 +906,6 @@ void tmp95c061_device::execute_set_input(int input, int level)
 	}
 	m_check_irqs = 1;
 }
-
-
-uint8_t tmp95c061_device::p1_r()
-{
-	return m_port1_read(0);
-}
-
-void tmp95c061_device::p1_w(uint8_t data)
-{
-	m_port_latch[1] = data;
-	m_port1_write(0, data, 0xff);
-}
-
-void tmp95c061_device::p1cr_w(uint8_t data)
-{
-	m_port_control[1] = data;
-}
-
-uint8_t tmp95c061_device::p2_r()
-{
-	return m_port_latch[2];
-}
-
-void tmp95c061_device::p2_w(uint8_t data)
-{
-	m_port_latch[2] = data;
-	m_port2_write(0, data, 0xff);
-}
-
-void tmp95c061_device::p2fc_w(uint8_t data)
-{
-	m_port_control[2] = data;
-}
-
-uint8_t tmp95c061_device::p5_r()
-{
-	return m_port5_read(0);
-}
-
-void tmp95c061_device::p5_w(uint8_t data)
-{
-	m_port_latch[5] = data;
-	m_port5_write(0, data, 0xff);
-}
-
-void tmp95c061_device::p5cr_w(uint8_t data)
-{
-	m_port_control[5] = data;
-}
-
-void tmp95c061_device::p5fc_w(uint8_t data)
-{
-	m_port_function[5] = data;
-}
-
-uint8_t tmp95c061_device::p6_r()
-{
-	return m_port6_read(0);
-}
-
-void tmp95c061_device::p6_w(uint8_t data)
-{
-	m_port_latch[6] = data;
-	m_port6_write(0, data, 0xff);
-}
-
-void tmp95c061_device::p6fc_w(uint8_t data)
-{
-	m_port_function[6] = data;
-}
-
-uint8_t tmp95c061_device::p7_r()
-{
-	return m_port7_read(0);
-}
-
-void tmp95c061_device::p7_w(uint8_t data)
-{
-	m_port_latch[7] = data;
-	m_port7_write(0, data, 0xff);
-}
-
-void tmp95c061_device::p7cr_w(uint8_t data)
-{
-	m_port_control[7] = data;
-}
-
-void tmp95c061_device::p7fc_w(uint8_t data)
-{
-	m_port_function[7] = data;
-}
-
-uint8_t tmp95c061_device::p8_r()
-{
-	return m_port8_read(0);
-}
-
-void tmp95c061_device::p8_w(uint8_t data)
-{
-	m_port_latch[8] = data;
-	m_port8_write(0, data, 0xff);
-}
-
-void tmp95c061_device::p8cr_w(uint8_t data)
-{
-	m_port_control[8] = data;
-}
-
-void tmp95c061_device::p8fc_w(uint8_t data)
-{
-	m_port_function[8] = data;
-}
-
-uint8_t tmp95c061_device::p9_r()
-{
-	return m_port9_read(0);
-}
-
-uint8_t tmp95c061_device::pa_r()
-{
-	return m_porta_read(0);
-}
-
-void tmp95c061_device::pa_w(uint8_t data)
-{
-	m_port_latch[0xa] = data;
-	update_porta();
-}
-
-void tmp95c061_device::pacr_w(uint8_t data)
-{
-	m_port_control[0xa] = data;
-	update_porta();
-}
-
-void tmp95c061_device::pafc_w(uint8_t data)
-{
-	m_port_function[0xa] = data;
-	update_porta();
-}
-
-void tmp95c061_device::update_porta()
-{
-	int fc = (m_to1 << 2) | (m_to3 << 3);
-
-	m_porta_write(0, ((fc & m_port_function[0xa]) | (m_port_latch[0xa] & ~m_port_function[0xa])) & m_port_control[0xa], 0xff);
-}
-
-uint8_t tmp95c061_device::pb_r()
-{
-	return m_portb_read(0);
-}
-
-void tmp95c061_device::pb_w(uint8_t data)
-{
-	m_port_latch[0xb] = data;
-	m_portb_write(0, data, 0xff);
-}
-
-void tmp95c061_device::pbcr_w(uint8_t data)
-{
-	m_port_control[0xb] = data;
-}
-
-void tmp95c061_device::pbfc_w(uint8_t data)
-{
-	m_port_function[0xb] = data;
-}
-
 
 uint8_t tmp95c061_device::trun_r()
 {

--- a/src/devices/cpu/tlcs900/tmp95c061.cpp
+++ b/src/devices/cpu/tlcs900/tmp95c061.cpp
@@ -78,22 +78,22 @@ void tmp95c061_device::port_fc_w(uint8_t data)
 	m_port_function[P] = data;
 }
 
-template<>
-void tmp95c061_device::port_w <tmp95c061_device::PORT_A> (uint8_t data)
+template <>
+void tmp95c061_device::port_w<tmp95c061_device::PORT_A>(uint8_t data)
 {
 	m_port_latch[PORT_A] = data;
 	update_porta();
 }
 
-template<>
-void tmp95c061_device::port_cr_w <tmp95c061_device::PORT_A> (uint8_t data)
+template <>
+void tmp95c061_device::port_cr_w<tmp95c061_device::PORT_A>(uint8_t data)
 {
 	m_port_control[PORT_A] = data;
 	update_porta();
 }
 
-template<>
-void tmp95c061_device::port_fc_w <tmp95c061_device::PORT_A> (uint8_t data)
+template <>
+void tmp95c061_device::port_fc_w<tmp95c061_device::PORT_A>(uint8_t data)
 {
 	m_port_function[PORT_A] = data;
 	update_porta();

--- a/src/devices/cpu/tlcs900/tmp95c061.cpp
+++ b/src/devices/cpu/tlcs900/tmp95c061.cpp
@@ -53,47 +53,47 @@ tmp95c061_device::tmp95c061_device(const machine_config &mconfig, const char *ta
 {
 }
 
-template <Port P>
+template <uint8_t P>
 void tmp95c061_device::port_w(uint8_t data)
 {
 	m_port_latch[P] = data;
 	m_port_write[P](0, data, 0xff);
 }
 
-template <Port P>
+template <uint8_t P>
 uint8_t tmp95c061_device::port_r()
 {
 	return m_port_read[P](0);
 }
 
-template <Port P>
+template <uint8_t P>
 void tmp95c061_device::port_cr_w(uint8_t data)
 {
 	m_port_control[P] = data;
 }
 
-template <Port P>
+template <uint8_t P>
 void tmp95c061_device::port_fc_w(uint8_t data)
 {
 	m_port_function[P] = data;
 }
 
 template<>
-void tmp95c061_device::port_w <PORT_A> (uint8_t data)
+void tmp95c061_device::port_w <tmp95c061_device::PORT_A> (uint8_t data)
 {
 	m_port_latch[PORT_A] = data;
 	update_porta();
 }
 
 template<>
-void tmp95c061_device::port_cr_w <PORT_A> (uint8_t data)
+void tmp95c061_device::port_cr_w <tmp95c061_device::PORT_A> (uint8_t data)
 {
 	m_port_control[PORT_A] = data;
 	update_porta();
 }
 
 template<>
-void tmp95c061_device::port_fc_w <PORT_A> (uint8_t data)
+void tmp95c061_device::port_fc_w <tmp95c061_device::PORT_A> (uint8_t data)
 {
 	m_port_function[PORT_A] = data;
 	update_porta();

--- a/src/devices/cpu/tlcs900/tmp95c061.h
+++ b/src/devices/cpu/tlcs900/tmp95c061.h
@@ -10,6 +10,19 @@
 
 DECLARE_DEVICE_TYPE(TMP95C061, tmp95c061_device)
 
+enum Port
+{
+	PORT_1, // 8 bit I/O. Shared with D8-D15
+	PORT_2, // 8 bit output only. Shared with A16-A23
+	PORT_5, // 4 bit I/O. Shared with HWR, BUSRQ, BUSAK, RW
+	PORT_6, // 6 bit I/O. Shared with CS0, CS1, CS3/LCAS, RAS, REFOUT
+	PORT_7, // 8 bit I/O. Shared with PG0-OUT, PG1-OUT
+	PORT_8, // 6 bit I/O. Shared with TXD0, TXD1, RXD0, RXD1, CTS0, SCLK0, SCLK1
+	PORT_9, // 4 bit input only. Shared with AN0-AN3
+	PORT_A, // 4 bit I/O. Shared with WAIT, TI0, TO1, TO2
+	PORT_B, // 8 bit I/O. Shared with TI4/INT4, TI5/INT5, TI6/INT6, TI7/INT7, TO4, TO5, TO6
+	NUM_PORTS
+};
 
 class tmp95c061_device : public tlcs900h_device
 {
@@ -18,21 +31,21 @@ public:
 	tmp95c061_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	// configuration helpers
-	auto port1_read()  { return m_port1_read.bind(); }
-	auto port1_write() { return m_port1_write.bind(); }
-	auto port2_write() { return m_port2_write.bind(); }
-	auto port5_read()  { return m_port5_read.bind(); }
-	auto port5_write() { return m_port5_write.bind(); }
-	auto port6_write() { return m_port6_write.bind(); }
-	auto port7_read()  { return m_port7_read.bind(); }
-	auto port7_write() { return m_port7_write.bind(); }
-	auto port8_read()  { return m_port8_read.bind(); }
-	auto port8_write() { return m_port8_write.bind(); }
-	auto port9_read()  { return m_port9_read.bind(); }
-	auto porta_read()  { return m_porta_read.bind(); }
-	auto porta_write() { return m_porta_write.bind(); }
-	auto portb_read()  { return m_portb_read.bind(); }
-	auto portb_write() { return m_portb_write.bind(); }
+	auto port1_read()  { return m_port_read[PORT_1].bind(); }
+	auto port1_write() { return m_port_write[PORT_1].bind(); }
+	auto port2_write() { return m_port_write[PORT_2].bind(); }
+	auto port5_read()  { return m_port_read[PORT_5].bind(); }
+	auto port5_write() { return m_port_write[PORT_5].bind(); }
+	auto port6_write() { return m_port_write[PORT_6].bind(); }
+	auto port7_read()  { return m_port_read[PORT_7].bind(); }
+	auto port7_write() { return m_port_write[PORT_7].bind(); }
+	auto port8_read()  { return m_port_read[PORT_8].bind(); }
+	auto port8_write() { return m_port_write[PORT_8].bind(); }
+	auto port9_read()  { return m_port_read[PORT_9].bind(); }
+	auto porta_read()  { return m_port_read[PORT_A].bind(); }
+	auto porta_write() { return m_port_write[PORT_A].bind(); }
+	auto portb_read()  { return m_port_read[PORT_B].bind(); }
+	auto portb_write() { return m_port_write[PORT_B].bind(); }
 	template <size_t Bit> auto an_read() { return m_an_read[Bit].bind(); }
 
 protected:
@@ -51,36 +64,10 @@ protected:
 	void update_porta();
 
 private:
-	uint8_t p1_r();
-	void p1_w(uint8_t data);
-	void p1cr_w(uint8_t data);
-	uint8_t p2_r();
-	void p2_w(uint8_t data);
-	void p2fc_w(uint8_t data);
-	uint8_t p5_r();
-	void p5_w(uint8_t data);
-	void p5cr_w(uint8_t data);
-	void p5fc_w(uint8_t data);
-	uint8_t p6_r();
-	void p6_w(uint8_t data);
-	void p6fc_w(uint8_t data);
-	uint8_t p7_r();
-	void p7_w(uint8_t data);
-	void p7cr_w(uint8_t data);
-	void p7fc_w(uint8_t data);
-	uint8_t p8_r();
-	void p8_w(uint8_t data);
-	void p8cr_w(uint8_t data);
-	void p8fc_w(uint8_t data);
-	uint8_t p9_r();
-	uint8_t pa_r();
-	void pa_w(uint8_t data);
-	void pacr_w(uint8_t data);
-	void pafc_w(uint8_t data);
-	uint8_t pb_r();
-	void pb_w(uint8_t data);
-	void pbcr_w(uint8_t data);
-	void pbfc_w(uint8_t data);
+	template <Port> uint8_t port_r();
+	template <Port> void port_w(uint8_t data);
+	template <Port> void port_cr_w(uint8_t data);
+	template <Port> void port_fc_w(uint8_t data);
 	uint8_t trun_r();
 	void trun_w(uint8_t data);
 	void treg01_w(offs_t offset, uint8_t data);
@@ -150,47 +137,15 @@ private:
 
 	void internal_mem(address_map &map);
 
-	// Port 1: 8 bit I/O. Shared with D8-D15
-	devcb_read8    m_port1_read;
-	devcb_write8   m_port1_write;
-
-	// Port 2: 8 bit output only. Shared with A16-A23
-	devcb_write8   m_port2_write;
-
-	// Port 5: 4 bit I/O. Shared with HWR, BUSRQ, BUSAK, RW
-	devcb_read8    m_port5_read;
-	devcb_write8   m_port5_write;
-
-	// Port 6: 6 bit I/O. Shared with CS0, CS1, CS3/LCAS, RAS, REFOUT
-	devcb_read8    m_port6_read;
-	devcb_write8   m_port6_write;
-
-	// Port 7: 8 bit I/O. Shared with PG0-OUT, PG1-OUT
-	devcb_read8    m_port7_read;
-	devcb_write8   m_port7_write;
-
-	// Port 8: 6 bit I/O. Shared with TXD0, TXD1, RXD0, RXD1, CTS0, SCLK0, SCLK1
-	devcb_read8    m_port8_read;
-	devcb_write8   m_port8_write;
-
-	// Port 9: 4 bit input only. Shared with AN0-AN3
-	devcb_read8    m_port9_read;
-
-	// Port A: 4 bit I/O. Shared with WAIT, TI0, TO1, TO2
-	devcb_read8    m_porta_read;
-	devcb_write8   m_porta_write;
-
-	// Port B: 8 bit I/O. Shared with TI4/INT4, TI5/INT5, TI6/INT6, TI7/INT7, TO4, TO5, TO6
-	devcb_read8    m_portb_read;
-	devcb_write8   m_portb_write;
-
 	// analogue inputs, sampled at 10 bits
 	devcb_read16::array<4> m_an_read;
 
-	// I/O Port Control
-	uint8_t   m_port_latch[0xc];
-	uint8_t   m_port_control[0xc];
-	uint8_t   m_port_function[0xc];
+	// I/O Ports
+	devcb_read8::array<NUM_PORTS> m_port_read;
+	devcb_write8::array<NUM_PORTS> m_port_write;
+	uint8_t   m_port_latch[NUM_PORTS];
+	uint8_t   m_port_control[NUM_PORTS];
+	uint8_t   m_port_function[NUM_PORTS];
 
 	// Timer Control
 	uint8_t   m_trun;

--- a/src/devices/cpu/tlcs900/tmp95c061.h
+++ b/src/devices/cpu/tlcs900/tmp95c061.h
@@ -10,22 +10,20 @@
 
 DECLARE_DEVICE_TYPE(TMP95C061, tmp95c061_device)
 
-enum Port
-{
-	PORT_1, // 8 bit I/O. Shared with D8-D15
-	PORT_2, // 8 bit output only. Shared with A16-A23
-	PORT_5, // 4 bit I/O. Shared with HWR, BUSRQ, BUSAK, RW
-	PORT_6, // 6 bit I/O. Shared with CS0, CS1, CS3/LCAS, RAS, REFOUT
-	PORT_7, // 8 bit I/O. Shared with PG0-OUT, PG1-OUT
-	PORT_8, // 6 bit I/O. Shared with TXD0, TXD1, RXD0, RXD1, CTS0, SCLK0, SCLK1
-	PORT_9, // 4 bit input only. Shared with AN0-AN3
-	PORT_A, // 4 bit I/O. Shared with WAIT, TI0, TO1, TO2
-	PORT_B, // 8 bit I/O. Shared with TI4/INT4, TI5/INT5, TI6/INT6, TI7/INT7, TO4, TO5, TO6
-	NUM_PORTS
-};
 
 class tmp95c061_device : public tlcs900h_device
 {
+	static constexpr uint8_t PORT_1 = 0; // 8 bit I/O. Shared with D8-D15
+	static constexpr uint8_t PORT_2 = 1; // 8 bit output only. Shared with A16-A23
+	static constexpr uint8_t PORT_5 = 2; // 4 bit I/O. Shared with HWR, BUSRQ, BUSAK, RW
+	static constexpr uint8_t PORT_6 = 3; // 6 bit I/O. Shared with CS0, CS1, CS3/LCAS, RAS, REFOUT
+	static constexpr uint8_t PORT_7 = 4; // 8 bit I/O. Shared with PG0-OUT, PG1-OUT
+	static constexpr uint8_t PORT_8 = 5; // 6 bit I/O. Shared with TXD0, TXD1, RXD0, RXD1, CTS0, SCLK0, SCLK1
+	static constexpr uint8_t PORT_9 = 6; // 4 bit input only. Shared with AN0-AN3
+	static constexpr uint8_t PORT_A = 7; // 4 bit I/O. Shared with WAIT, TI0, TO1, TO2
+	static constexpr uint8_t PORT_B = 8; // 8 bit I/O. Shared with TI4/INT4, TI5/INT5, TI6/INT6, TI7/INT7, TO4, TO5, TO6
+	static constexpr uint8_t NUM_PORTS = 9;
+
 public:
 	// construction/destruction
 	tmp95c061_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
@@ -64,10 +62,10 @@ protected:
 	void update_porta();
 
 private:
-	template <Port> uint8_t port_r();
-	template <Port> void port_w(uint8_t data);
-	template <Port> void port_cr_w(uint8_t data);
-	template <Port> void port_fc_w(uint8_t data);
+	template <uint8_t> uint8_t port_r();
+	template <uint8_t> void port_w(uint8_t data);
+	template <uint8_t> void port_cr_w(uint8_t data);
+	template <uint8_t> void port_fc_w(uint8_t data);
 	uint8_t trun_r();
 	void trun_w(uint8_t data);
 	void treg01_w(offs_t offset, uint8_t data);

--- a/src/devices/cpu/tlcs900/tmp95c063.cpp
+++ b/src/devices/cpu/tlcs900/tmp95c063.cpp
@@ -14,32 +14,12 @@ DEFINE_DEVICE_TYPE(TMP95C063, tmp95c063_device, "tmp95c063", "Toshiba TMP95C063"
 
 tmp95c063_device::tmp95c063_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	tlcs900h_device(mconfig, TMP95C063, tag, owner, clock),
-	m_port1_read(*this, 0),
-	m_port1_write(*this),
-	m_port2_write(*this),
-	m_port5_read(*this, 0),
-	m_port5_write(*this),
-	m_port6_read(*this, 0),
-	m_port6_write(*this),
-	m_port7_read(*this, 0),
-	m_port7_write(*this),
-	m_port8_read(*this, 0),
-	m_port8_write(*this),
-	m_port9_read(*this, 0),
-	m_port9_write(*this),
-	m_porta_read(*this, 0),
-	m_porta_write(*this),
-	m_portb_read(*this, 0),
-	m_portb_write(*this),
-	m_portc_read(*this, 0),
-	m_portd_read(*this, 0),
-	m_portd_write(*this),
-	m_porte_read(*this, 0),
-	m_porte_write(*this),
 	m_an_read(*this, 0),
-	m_port_latch{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
-	m_port_control{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
-	m_port_function{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+	m_port_read(*this, 0),
+	m_port_write(*this),
+	m_port_latch{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+	m_port_control{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+	m_port_function{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
 	m_t8run(0),
 	m_t8_reg{ 0, 0, 0, 0, 0, 0, 0, 0 },
 	m_t8_mode{ 0, 0, 0, 0 },
@@ -74,28 +54,54 @@ tmp95c063_device::tmp95c063_device(const machine_config &mconfig, const char *ta
 {
 }
 
+template <Port P>
+void tmp95c063_device::port_w(uint8_t data)
+{
+	m_port_latch[P] = data;
+	m_port_write[P](0, data, 0xff);
+}
+
+template <Port P>
+uint8_t tmp95c063_device::port_r()
+{
+	return m_port_read[P](0);
+}
+
+template <Port P>
+void tmp95c063_device::port_cr_w(uint8_t data)
+{
+	m_port_control[P] = data;
+}
+
+template <Port P>
+void tmp95c063_device::port_fc_w(uint8_t data)
+{
+	m_port_function[P] = data;
+}
+
+
 void tmp95c063_device::internal_mem(address_map &map)
 {
-	map(0x000001, 0x000001).rw(FUNC(tmp95c063_device::p1_r), FUNC(tmp95c063_device::p1_w));
-	map(0x000004, 0x000004).w(FUNC(tmp95c063_device::p1cr_w));
-	map(0x000006, 0x000006).rw(FUNC(tmp95c063_device::p2_r), FUNC(tmp95c063_device::p2_w));
-	map(0x000009, 0x000009).w(FUNC(tmp95c063_device::p2fc_w));
-	map(0x00000d, 0x00000d).rw(FUNC(tmp95c063_device::p5_r), FUNC(tmp95c063_device::p5_w));
-	map(0x000010, 0x000010).w(FUNC(tmp95c063_device::p5cr_w));
-	map(0x000011, 0x000011).w(FUNC(tmp95c063_device::p5fc_w));
-	map(0x000012, 0x000012).rw(FUNC(tmp95c063_device::p6_r), FUNC(tmp95c063_device::p6_w));
-	map(0x000013, 0x000013).rw(FUNC(tmp95c063_device::p7_r), FUNC(tmp95c063_device::p7_w));
-	map(0x000015, 0x000015).w(FUNC(tmp95c063_device::p6fc_w));
-	map(0x000016, 0x000016).w(FUNC(tmp95c063_device::p7cr_w));
-	map(0x000017, 0x000017).w(FUNC(tmp95c063_device::p7fc_w));
-	map(0x000018, 0x000018).rw(FUNC(tmp95c063_device::p8_r), FUNC(tmp95c063_device::p8_w));
-	map(0x000019, 0x000019).rw(FUNC(tmp95c063_device::p9_r), FUNC(tmp95c063_device::p9_w));
-	map(0x00001a, 0x00001a).w(FUNC(tmp95c063_device::p8cr_w));
-	map(0x00001b, 0x00001b).w(FUNC(tmp95c063_device::p8fc_w));
-	map(0x00001c, 0x00001c).w(FUNC(tmp95c063_device::p9cr_w));
-	map(0x00001d, 0x00001d).w(FUNC(tmp95c063_device::p9fc_w));
-	map(0x00001e, 0x00001e).rw(FUNC(tmp95c063_device::pa_r), FUNC(tmp95c063_device::pa_w));
-	map(0x00001f, 0x00001f).rw(FUNC(tmp95c063_device::pb_r), FUNC(tmp95c063_device::pb_w));
+	map(0x000001, 0x000001).rw(FUNC(tmp95c063_device::port_r<PORT_1>), FUNC(tmp95c063_device::port_w<PORT_1>));
+	map(0x000004, 0x000004).w(FUNC(tmp95c063_device::port_cr_w<PORT_1>));
+	map(0x000006, 0x000006).rw(FUNC(tmp95c063_device::port_r<PORT_2>), FUNC(tmp95c063_device::port_w<PORT_2>));
+	map(0x000009, 0x000009).w(FUNC(tmp95c063_device::port_fc_w<PORT_2>));
+	map(0x00000d, 0x00000d).rw(FUNC(tmp95c063_device::port_r<PORT_5>), FUNC(tmp95c063_device::port_w<PORT_5>));
+	map(0x000010, 0x000010).w(FUNC(tmp95c063_device::port_cr_w<PORT_5>));
+	map(0x000011, 0x000011).w(FUNC(tmp95c063_device::port_fc_w<PORT_5>));
+	map(0x000012, 0x000012).rw(FUNC(tmp95c063_device::port_r<PORT_6>), FUNC(tmp95c063_device::port_w<PORT_6>));
+	map(0x000013, 0x000013).rw(FUNC(tmp95c063_device::port_r<PORT_7>), FUNC(tmp95c063_device::port_w<PORT_7>));
+	map(0x000015, 0x000015).w(FUNC(tmp95c063_device::port_fc_w<PORT_6>));
+	map(0x000016, 0x000016).w(FUNC(tmp95c063_device::port_cr_w<PORT_7>));
+	map(0x000017, 0x000017).w(FUNC(tmp95c063_device::port_fc_w<PORT_7>));
+	map(0x000018, 0x000018).rw(FUNC(tmp95c063_device::port_r<PORT_8>), FUNC(tmp95c063_device::port_w<PORT_8>));
+	map(0x000019, 0x000019).rw(FUNC(tmp95c063_device::port_r<PORT_9>), FUNC(tmp95c063_device::port_w<PORT_9>));
+	map(0x00001a, 0x00001a).w(FUNC(tmp95c063_device::port_cr_w<PORT_8>));
+	map(0x00001b, 0x00001b).w(FUNC(tmp95c063_device::port_fc_w<PORT_8>));
+	map(0x00001c, 0x00001c).w(FUNC(tmp95c063_device::port_cr_w<PORT_9>));
+	map(0x00001d, 0x00001d).w(FUNC(tmp95c063_device::port_fc_w<PORT_9>));
+	map(0x00001e, 0x00001e).rw(FUNC(tmp95c063_device::port_r<PORT_A>), FUNC(tmp95c063_device::port_w<PORT_A>));
+	map(0x00001f, 0x00001f).rw(FUNC(tmp95c063_device::port_r<PORT_A>), FUNC(tmp95c063_device::port_w<PORT_B>));
 	map(0x000020, 0x000020).rw(FUNC(tmp95c063_device::t8run_r), FUNC(tmp95c063_device::t8run_w));
 	map(0x000021, 0x000021).rw(FUNC(tmp95c063_device::trdc_r), FUNC(tmp95c063_device::trdc_w));
 	map(0x000022, 0x000023).w(FUNC(tmp95c063_device::treg01_w));
@@ -140,15 +146,15 @@ void tmp95c063_device::internal_mem(address_map &map)
 	map(0x00006f, 0x00006f).w(FUNC(tmp95c063_device::wdcr_w));
 	map(0x000070, 0x00007e).rw(FUNC(tmp95c063_device::inte_r), FUNC(tmp95c063_device::inte_w));
 	map(0x00007f, 0x00007f).w(FUNC(tmp95c063_device::iimc_w));
-	map(0x000080, 0x000080).w(FUNC(tmp95c063_device::pacr_w));
-	map(0x000081, 0x000081).w(FUNC(tmp95c063_device::pafc_w));
-	map(0x000082, 0x000082).w(FUNC(tmp95c063_device::pbcr_w));
-	map(0x000083, 0x000083).w(FUNC(tmp95c063_device::pbfc_w));
-	map(0x000084, 0x000084).r(FUNC(tmp95c063_device::pc_r));
-	map(0x000085, 0x000085).rw(FUNC(tmp95c063_device::pd_r), FUNC(tmp95c063_device::pd_w));
-	map(0x000088, 0x000088).w(FUNC(tmp95c063_device::pdcr_w));
-	map(0x00008a, 0x00008a).rw(FUNC(tmp95c063_device::pe_r), FUNC(tmp95c063_device::pe_w));
-	map(0x00008c, 0x00008c).w(FUNC(tmp95c063_device::pecr_w));
+	map(0x000080, 0x000080).w(FUNC(tmp95c063_device::port_cr_w<PORT_A>));
+	map(0x000081, 0x000081).w(FUNC(tmp95c063_device::port_fc_w<PORT_A>));
+	map(0x000082, 0x000082).w(FUNC(tmp95c063_device::port_cr_w<PORT_B>));
+	map(0x000083, 0x000083).w(FUNC(tmp95c063_device::port_fc_w<PORT_B>));
+	map(0x000084, 0x000084).r(FUNC(tmp95c063_device::port_r<PORT_C>));
+	map(0x000085, 0x000085).rw(FUNC(tmp95c063_device::port_r<PORT_D>), FUNC(tmp95c063_device::port_w<PORT_D>));
+	map(0x000088, 0x000088).w(FUNC(tmp95c063_device::port_cr_w<PORT_D>));
+	map(0x00008a, 0x00008a).rw(FUNC(tmp95c063_device::port_r<PORT_E>), FUNC(tmp95c063_device::port_w<PORT_E>));
+	map(0x00008c, 0x00008c).w(FUNC(tmp95c063_device::port_cr_w<PORT_E>));
 	map(0x00008f, 0x00008f).w(FUNC(tmp95c063_device::bexcs_w));
 	map(0x000090, 0x000093).w(FUNC(tmp95c063_device::bcs_w));
 	map(0x000094, 0x00009b).rw(FUNC(tmp95c063_device::msar_r), FUNC(tmp95c063_device::msar_w));
@@ -603,16 +609,18 @@ void tmp95c063_device::device_reset()
 	m_timer_change[2] = 0;
 	m_timer_change[3] = 0;
 
-	m_port_latch[1] = 0x00;
-	m_port_latch[2] = 0xff;
-	m_port_latch[5] = 0x3d;
-	m_port_latch[6] = 0x3b;
-	m_port_latch[7] = 0xff;
-	m_port_latch[8] = 0x3f;
-	m_port_latch[0xa] = 0x0f;
-	m_port_latch[0xb] = 0xff;
-	std::fill_n(&m_port_control[0], 0xc, 0x00);
-	std::fill_n(&m_port_function[0], 0xc, 0x00);
+	m_port_latch[PORT_1] = 0x00;
+	m_port_latch[PORT_2] = 0xff;
+	m_port_latch[PORT_5] = 0x3d;
+	m_port_latch[PORT_6] = 0x3b;
+	m_port_latch[PORT_7] = 0xff;
+	m_port_latch[PORT_8] = 0x3f;
+	m_port_latch[PORT_A] = 0x0f;
+	m_port_latch[PORT_B] = 0xff;
+	// FIXME: init ports 9, C, D & E
+	std::fill_n(&m_port_control[0], NUM_PORTS, 0x00);
+	std::fill_n(&m_port_function[0], NUM_PORTS, 0x00);
+
 	m_t8run = 0x00;
 	std::fill_n(&m_t8_mode[0], 4, 0x00);
 	std::fill_n(&m_t8_invert[0], 2, 0xcc);
@@ -651,217 +659,6 @@ void tmp95c063_device::device_reset()
 	for (int i = 0; i < TLCS900_NUM_INPUTS; i++)
 		m_level[i] = CLEAR_LINE;
 }
-
-
-uint8_t tmp95c063_device::p1_r()
-{
-	return m_port1_read(0);
-}
-
-void tmp95c063_device::p1_w(uint8_t data)
-{
-	m_port_latch[1] = data;
-	m_port1_write(0, data, 0xff);
-}
-
-void tmp95c063_device::p1cr_w(uint8_t data)
-{
-	m_port_control[1] = data;
-}
-
-uint8_t tmp95c063_device::p2_r()
-{
-	return m_port_latch[2];
-}
-
-void tmp95c063_device::p2_w(uint8_t data)
-{
-	m_port_latch[2] = data;
-	m_port2_write(0, data, 0xff);
-}
-
-void tmp95c063_device::p2fc_w(uint8_t data)
-{
-	m_port_control[2] = data;
-}
-
-uint8_t tmp95c063_device::p5_r()
-{
-	return m_port5_read(0);
-}
-
-void tmp95c063_device::p5_w(uint8_t data)
-{
-	m_port_latch[5] = data;
-	m_port5_write(0, data, 0xff);
-}
-
-void tmp95c063_device::p5cr_w(uint8_t data)
-{
-	m_port_control[5] = data;
-}
-
-void tmp95c063_device::p5fc_w(uint8_t data)
-{
-	m_port_function[5] = data;
-}
-
-uint8_t tmp95c063_device::p6_r()
-{
-	return m_port6_read(0);
-}
-
-void tmp95c063_device::p6_w(uint8_t data)
-{
-	m_port_latch[6] = data;
-	m_port6_write(0, data, 0xff);
-}
-
-void tmp95c063_device::p6fc_w(uint8_t data)
-{
-	m_port_function[6] = data;
-}
-
-uint8_t tmp95c063_device::p7_r()
-{
-	return m_port7_read(0);
-}
-
-void tmp95c063_device::p7_w(uint8_t data)
-{
-	m_port_latch[7] = data;
-	m_port7_write(0, data, 0xff);
-}
-
-void tmp95c063_device::p7cr_w(uint8_t data)
-{
-	m_port_control[7] = data;
-}
-
-void tmp95c063_device::p7fc_w(uint8_t data)
-{
-	m_port_function[7] = data;
-}
-
-uint8_t tmp95c063_device::p8_r()
-{
-	return m_port8_read(0);
-}
-
-void tmp95c063_device::p8_w(uint8_t data)
-{
-	m_port_latch[8] = data;
-	m_port8_write(0, data, 0xff);
-}
-
-void tmp95c063_device::p8cr_w(uint8_t data)
-{
-	m_port_control[8] = data;
-}
-
-void tmp95c063_device::p8fc_w(uint8_t data)
-{
-	m_port_function[8] = data;
-}
-
-uint8_t tmp95c063_device::p9_r()
-{
-	return m_port9_read(0);
-}
-
-void tmp95c063_device::p9_w(uint8_t data)
-{
-	m_port_latch[0x9] = data;
-}
-
-void tmp95c063_device::p9cr_w(uint8_t data)
-{
-	m_port_control[0x9] = data;
-}
-
-void tmp95c063_device::p9fc_w(uint8_t data)
-{
-	m_port_function[0x9] = data;
-}
-
-uint8_t tmp95c063_device::pa_r()
-{
-	return m_porta_read(0);
-}
-
-void tmp95c063_device::pa_w(uint8_t data)
-{
-	m_port_latch[0xa] = data;
-}
-
-void tmp95c063_device::pacr_w(uint8_t data)
-{
-	m_port_control[0xa] = data;
-}
-
-void tmp95c063_device::pafc_w(uint8_t data)
-{
-	m_port_function[0xa] = data;
-}
-
-uint8_t tmp95c063_device::pb_r()
-{
-	return m_portb_read(0);
-}
-
-void tmp95c063_device::pb_w(uint8_t data)
-{
-	m_port_latch[0xb] = data;
-	m_portb_write(0, data, 0xff);
-}
-
-void tmp95c063_device::pbcr_w(uint8_t data)
-{
-	m_port_control[0xb] = data;
-}
-
-void tmp95c063_device::pbfc_w(uint8_t data)
-{
-	m_port_function[0xb] = data;
-}
-
-uint8_t tmp95c063_device::pc_r()
-{
-	return m_portc_read(0);
-}
-
-uint8_t tmp95c063_device::pd_r()
-{
-	return m_portd_read(0);
-}
-
-void tmp95c063_device::pd_w(uint8_t data)
-{
-	m_port_latch[0xd] = data;
-	m_portd_write(0, data, 0xff);
-}
-
-void tmp95c063_device::pdcr_w(uint8_t data)
-{
-	m_port_control[0xd] = data;
-}
-
-uint8_t tmp95c063_device::pe_r()
-{
-	return m_porte_read(0);
-}
-
-void tmp95c063_device::pe_w(uint8_t data)
-{
-	m_port_latch[0xe] = data;
-	m_porte_write(0, data, 0xff);
-}
-
-void tmp95c063_device::pecr_w(uint8_t data)
-{
-	m_port_control[0xe] = data;
-}
-
 
 uint8_t tmp95c063_device::t8run_r()
 {

--- a/src/devices/cpu/tlcs900/tmp95c063.cpp
+++ b/src/devices/cpu/tlcs900/tmp95c063.cpp
@@ -54,26 +54,26 @@ tmp95c063_device::tmp95c063_device(const machine_config &mconfig, const char *ta
 {
 }
 
-template <Port P>
+template <uint8_t P>
 void tmp95c063_device::port_w(uint8_t data)
 {
 	m_port_latch[P] = data;
 	m_port_write[P](0, data, 0xff);
 }
 
-template <Port P>
+template <uint8_t P>
 uint8_t tmp95c063_device::port_r()
 {
 	return m_port_read[P](0);
 }
 
-template <Port P>
+template <uint8_t P>
 void tmp95c063_device::port_cr_w(uint8_t data)
 {
 	m_port_control[P] = data;
 }
 
-template <Port P>
+template <uint8_t P>
 void tmp95c063_device::port_fc_w(uint8_t data)
 {
 	m_port_function[P] = data;

--- a/src/devices/cpu/tlcs900/tmp95c063.h
+++ b/src/devices/cpu/tlcs900/tmp95c063.h
@@ -10,6 +10,7 @@
 
 DECLARE_DEVICE_TYPE(TMP95C063, tmp95c063_device)
 
+
 class tmp95c063_device : public tlcs900h_device
 {
 	static constexpr uint8_t PORT_1 = 0; // 8 bit I/O. Shared with d8-d15

--- a/src/devices/cpu/tlcs900/tmp95c063.h
+++ b/src/devices/cpu/tlcs900/tmp95c063.h
@@ -10,6 +10,22 @@
 
 DECLARE_DEVICE_TYPE(TMP95C063, tmp95c063_device)
 
+enum Port
+{
+	PORT_1, // 8 bit I/O. Shared with d8-d15
+	PORT_2, // 8 bit output only. Shared with a16-a23
+	PORT_5, // 6 bit I/O
+	PORT_6, // 8 bit I/O. Shared with cs1, cs3 & dram control
+	PORT_7, // 8 bit I/O
+	PORT_8, // 8 bit I/O. Shared with SCOUT, WAIT, NMI2, INT0-INT3
+	PORT_9, // 8 bit I/O. Shared with clock input and output for the 8-bit timers
+	PORT_A, // 8 bit I/O. Shared with serial channels 0/1
+	PORT_B, // 8 bit I/O. Shared with 16bit timers
+	PORT_C, // 8 bit input only. Shared with analogue inputs
+	PORT_D, // 5 bit I/O. Shared with INT8
+	PORT_E, // 8 bit I/O.
+	NUM_PORTS
+};
 
 class tmp95c063_device : public tlcs900h_device
 {
@@ -18,28 +34,28 @@ public:
 	tmp95c063_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	// configuration helpers
-	auto port1_read()  { return m_port1_read.bind(); }
-	auto port1_write() { return m_port1_write.bind(); }
-	auto port2_write() { return m_port2_write.bind(); }
-	auto port5_read()  { return m_port5_read.bind(); }
-	auto port5_write() { return m_port5_write.bind(); }
-	auto port6_read()  { return m_port6_read.bind(); }
-	auto port6_write() { return m_port6_write.bind(); }
-	auto port7_read()  { return m_port7_read.bind(); }
-	auto port7_write() { return m_port7_write.bind(); }
-	auto port8_read()  { return m_port8_read.bind(); }
-	auto port8_write() { return m_port8_write.bind(); }
-	auto port9_read()  { return m_port9_read.bind(); }
-	auto port9_write() { return m_port9_write.bind(); }
-	auto porta_read()  { return m_porta_read.bind(); }
-	auto porta_write() { return m_porta_write.bind(); }
-	auto portb_read()  { return m_portb_read.bind(); }
-	auto portb_write() { return m_portb_write.bind(); }
-	auto portc_read()  { return m_portc_read.bind(); }
-	auto portd_read()  { return m_portd_read.bind(); }
-	auto portd_write() { return m_portd_write.bind(); }
-	auto porte_read()  { return m_porte_read.bind(); }
-	auto porte_write() { return m_porte_write.bind(); }
+	auto port1_read()  { return m_port_read[PORT_1].bind(); }
+	auto port1_write() { return m_port_write[PORT_1].bind(); }
+	auto port2_write() { return m_port_write[PORT_2].bind(); }
+	auto port5_read()  { return m_port_read[PORT_5].bind(); }
+	auto port5_write() { return m_port_write[PORT_5].bind(); }
+	auto port6_read()  { return m_port_read[PORT_6].bind(); }
+	auto port6_write() { return m_port_write[PORT_6].bind(); }
+	auto port7_read()  { return m_port_read[PORT_7].bind(); }
+	auto port7_write() { return m_port_write[PORT_7].bind(); }
+	auto port8_read()  { return m_port_read[PORT_8].bind(); }
+	auto port8_write() { return m_port_write[PORT_8].bind(); }
+	auto port9_read()  { return m_port_read[PORT_9].bind(); }
+	auto port9_write() { return m_port_write[PORT_9].bind(); }
+	auto porta_read()  { return m_port_read[PORT_A].bind(); }
+	auto porta_write() { return m_port_write[PORT_A].bind(); }
+	auto portb_read()  { return m_port_read[PORT_B].bind(); }
+	auto portb_write() { return m_port_write[PORT_B].bind(); }
+	auto portc_read()  { return m_port_read[PORT_C].bind(); }
+	auto portd_read()  { return m_port_read[PORT_D].bind(); }
+	auto portd_write() { return m_port_write[PORT_D].bind(); }
+	auto porte_read()  { return m_port_read[PORT_E].bind(); }
+	auto porte_write() { return m_port_write[PORT_E].bind(); }
 	template <size_t Bit> auto an_read() { return m_an_read[Bit].bind(); }
 
 protected:
@@ -54,46 +70,10 @@ protected:
 	virtual void tlcs900_handle_timers() override;
 
 private:
-	uint8_t p1_r();
-	void p1_w(uint8_t data);
-	void p1cr_w(uint8_t data);
-	uint8_t p2_r();
-	void p2_w(uint8_t data);
-	void p2fc_w(uint8_t data);
-	uint8_t p5_r();
-	void p5_w(uint8_t data);
-	void p5cr_w(uint8_t data);
-	void p5fc_w(uint8_t data);
-	uint8_t p6_r();
-	void p6_w(uint8_t data);
-	void p6fc_w(uint8_t data);
-	uint8_t p7_r();
-	void p7_w(uint8_t data);
-	void p7cr_w(uint8_t data);
-	void p7fc_w(uint8_t data);
-	uint8_t p8_r();
-	void p8_w(uint8_t data);
-	void p8cr_w(uint8_t data);
-	void p8fc_w(uint8_t data);
-	uint8_t p9_r();
-	void p9_w(uint8_t data);
-	void p9cr_w(uint8_t data);
-	void p9fc_w(uint8_t data);
-	uint8_t pa_r();
-	void pa_w(uint8_t data);
-	void pacr_w(uint8_t data);
-	void pafc_w(uint8_t data);
-	uint8_t pb_r();
-	void pb_w(uint8_t data);
-	void pbcr_w(uint8_t data);
-	void pbfc_w(uint8_t data);
-	uint8_t pc_r();
-	uint8_t pd_r();
-	void pd_w(uint8_t data);
-	void pdcr_w(uint8_t data);
-	uint8_t pe_r();
-	void pe_w(uint8_t data);
-	void pecr_w(uint8_t data);
+	template <Port> uint8_t port_r();
+	template <Port> void port_w(uint8_t data);
+	template <Port> void port_cr_w(uint8_t data);
+	template <Port> void port_fc_w(uint8_t data);
 	uint8_t t8run_r();
 	void t8run_w(uint8_t data);
 	void treg01_w(offs_t offset, uint8_t data);
@@ -182,59 +162,15 @@ private:
 
 	void internal_mem(address_map &map);
 
-	// Port 1: 8 bit I/O. Shared with d8-d15
-	devcb_read8    m_port1_read;
-	devcb_write8   m_port1_write;
-
-	// Port 2: 8 bit output only. Shared with a16-a23
-	devcb_write8   m_port2_write;
-
-	// Port 5: 6 bit I/O
-	devcb_read8    m_port5_read;
-	devcb_write8   m_port5_write;
-
-	// Port 6: 8 bit I/O. Shared with cs1, cs3 & dram control
-	devcb_read8    m_port6_read;
-	devcb_write8   m_port6_write;
-
-	// Port 7: 8 bit I/O
-	devcb_read8    m_port7_read;
-	devcb_write8   m_port7_write;
-
-	// Port 8: 8 bit I/O. Shared with SCOUT, WAIT, NMI2, INT0-INT3
-	devcb_read8    m_port8_read;
-	devcb_write8   m_port8_write;
-
-	// Port 9: 8 bit I/O. Shared with clock input and output for the 8-bit timers
-	devcb_read8    m_port9_read;
-	devcb_write8   m_port9_write;
-
-	// Port A: 8 bit I/O. Shared with serial channels 0/1
-	devcb_read8    m_porta_read;
-	devcb_write8   m_porta_write;
-
-	// Port B: 8 bit I/O. Shared with 16bit timers
-	devcb_read8    m_portb_read;
-	devcb_write8   m_portb_write;
-
-	// Port C: 8 bit input only. Shared with analogue inputs
-	devcb_read8    m_portc_read;
-
-	// Port D: 5 bit I/O. Shared with int8_t
-	devcb_read8    m_portd_read;
-	devcb_write8   m_portd_write;
-
-	// Port E: 8 bit I/O.
-	devcb_read8    m_porte_read;
-	devcb_write8   m_porte_write;
-
 	// analogue inputs, sampled at 10 bits
 	devcb_read16::array<8> m_an_read;
 
-	// I/O Port Control
-	uint8_t   m_port_latch[0xf];
-	uint8_t   m_port_control[0xf];
-	uint8_t   m_port_function[0xf];
+	// I/O Ports
+	devcb_read8::array<NUM_PORTS> m_port_read;
+	devcb_write8::array<NUM_PORTS> m_port_write;
+	uint8_t   m_port_latch[NUM_PORTS];
+	uint8_t   m_port_control[NUM_PORTS];
+	uint8_t   m_port_function[NUM_PORTS];
 
 	// Timer Control
 	uint8_t   m_t8run;

--- a/src/devices/cpu/tlcs900/tmp95c063.h
+++ b/src/devices/cpu/tlcs900/tmp95c063.h
@@ -10,25 +10,22 @@
 
 DECLARE_DEVICE_TYPE(TMP95C063, tmp95c063_device)
 
-enum Port
-{
-	PORT_1, // 8 bit I/O. Shared with d8-d15
-	PORT_2, // 8 bit output only. Shared with a16-a23
-	PORT_5, // 6 bit I/O
-	PORT_6, // 8 bit I/O. Shared with cs1, cs3 & dram control
-	PORT_7, // 8 bit I/O
-	PORT_8, // 8 bit I/O. Shared with SCOUT, WAIT, NMI2, INT0-INT3
-	PORT_9, // 8 bit I/O. Shared with clock input and output for the 8-bit timers
-	PORT_A, // 8 bit I/O. Shared with serial channels 0/1
-	PORT_B, // 8 bit I/O. Shared with 16bit timers
-	PORT_C, // 8 bit input only. Shared with analogue inputs
-	PORT_D, // 5 bit I/O. Shared with INT8
-	PORT_E, // 8 bit I/O.
-	NUM_PORTS
-};
-
 class tmp95c063_device : public tlcs900h_device
 {
+	static constexpr uint8_t PORT_1 = 0; // 8 bit I/O. Shared with d8-d15
+	static constexpr uint8_t PORT_2 = 1; // 8 bit output only. Shared with a16-a23
+	static constexpr uint8_t PORT_5 = 2; // 6 bit I/O
+	static constexpr uint8_t PORT_6 = 3; // 8 bit I/O. Shared with cs1, cs3 & dram control
+	static constexpr uint8_t PORT_7 = 4; // 8 bit I/O
+	static constexpr uint8_t PORT_8 = 5; // 8 bit I/O. Shared with SCOUT, WAIT, NMI2, INT0-INT3
+	static constexpr uint8_t PORT_9 = 6; // 8 bit I/O. Shared with clock input and output for the 8-bit timers
+	static constexpr uint8_t PORT_A = 7; // 8 bit I/O. Shared with serial channels 0/1
+	static constexpr uint8_t PORT_B = 8; // 8 bit I/O. Shared with 16bit timers
+	static constexpr uint8_t PORT_C = 9; // 8 bit input only. Shared with analogue inputs
+	static constexpr uint8_t PORT_D = 10; // 5 bit I/O. Shared with INT8
+	static constexpr uint8_t PORT_E = 11; // 8 bit I/O.
+	static constexpr uint8_t NUM_PORTS = 12;
+
 public:
 	// construction/destruction
 	tmp95c063_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
@@ -70,10 +67,10 @@ protected:
 	virtual void tlcs900_handle_timers() override;
 
 private:
-	template <Port> uint8_t port_r();
-	template <Port> void port_w(uint8_t data);
-	template <Port> void port_cr_w(uint8_t data);
-	template <Port> void port_fc_w(uint8_t data);
+	template <uint8_t> uint8_t port_r();
+	template <uint8_t> void port_w(uint8_t data);
+	template <uint8_t> void port_cr_w(uint8_t data);
+	template <uint8_t> void port_fc_w(uint8_t data);
 	uint8_t t8run_r();
 	void t8run_w(uint8_t data);
 	void treg01_w(offs_t offset, uint8_t data);


### PR DESCRIPTION
Based on feedback from @cuavas at https://github.com/mamedev/mame/pull/12684#discussion_r1730040576, this PR uses templates to "avoid copy/pasta".