### PR TITLE
Add more FreeDOS versions

### DIFF
--- a/hash/ibm5150.xml
+++ b/hash/ibm5150.xml
@@ -6187,6 +6187,33 @@ Stalls or throws either "Bad command or file name", "disk read error" or "divide
 		</part>
 	</software>
 
+	<!--
+		This is not an official FreeDOS distribution, it is modified
+		to run more optimally on the original IBM PC model 5150.
+
+		More information about this distribution is available at:
+		* https://www.youtube.com/watch?v=EOVLlMQs9f8
+		* https://archive.org/details/free-dos-1.3-8086-minimized
+	-->
+	<software name="freedos13_8086">
+		<description>FreeDOS 1.3 8086 Minimized</description>
+		<year>2022</year>
+		<publisher>AkBKukU</publisher>
+		<info name="version" value="1.3" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="368640">
+				<rom name="FD13-D1.IMG" size="368640" crc="404e9fc4" sha1="cdda744071928b3daeecd472e7a5eead840372bb" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="368640">
+				<rom name="FD13-D2.IMG" size="368640" crc="f1c6c004" sha1="89b6b937d24182abc7a729d5740c36abbec90b7b" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="k16auto">
 		<description>Kaypro 16 Autoload</description>
 		<year>1984</year>

--- a/hash/ibm5150.xml
+++ b/hash/ibm5150.xml
@@ -6041,6 +6041,152 @@ Stalls or throws either "Bad command or file name", "disk read error" or "divide
 		</part>
 	</software>
 
+	<software name="freedos13rc5_720">
+		<description>FreeDOS 1.3 Release Candidate 5 (Floppy-Only Edition, 3.5" 720k)</description>
+		<year>2021</year>
+		<publisher>The FreeDOS Project</publisher>
+		<info name="version" value="1.3" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installer" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86BOOT.img" size="737280" crc="c2629e1c" sha1="285e4a73f68d5a2da7157647ec3740b93c245cb0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK01.img" size="737280" crc="ec1e9458" sha1="1702765d067af2a70ea3f69b1000415c58d6e08f" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK02.img" size="737280" crc="3c4c8b14" sha1="921d2cbf6ade6f1eaeb23c4dcbc41a39238d4851" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK03.img" size="737280" crc="6718aec2" sha1="f48357837ef6090e46f426f6946b97d79bbe0472" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 4" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK04.img" size="737280" crc="d6759230" sha1="481b599f2d0683b0ad30e233575f77d1d09d79ac" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 5" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK05.img" size="737280" crc="84c74a95" sha1="a30de6340e6f2193b9b1b2b096cf6531021e714a" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 6" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK06.img" size="737280" crc="fdede6f2" sha1="35c0d8fcecf1327b0aa9353ce0ae8122da434a70" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 7" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK07.img" size="737280" crc="b56182c9" sha1="edd5c36cf9609d2f05f397572a8af2c12cb58f54" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 8" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK08.img" size="737280" crc="4b3b5444" sha1="52e9dc36e8a1e8f12dba9f524afcf217c24ce478" />
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 9" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK09.img" size="737280" crc="be55df75" sha1="e7e75a32ee0abe684d0bec33473ef031e2ae5023" />
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 10" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK10.img" size="737280" crc="433abad8" sha1="9c6c8f2b513f98261a6e9f84a82b0b627427e3b5" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="freedos13_720">
+		<description>FreeDOS 1.3 (Floppy-Only Edition, 3.5" 720k)</description>
+		<year>2022</year>
+		<publisher>The FreeDOS Project</publisher>
+		<info name="version" value="1.3" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installer" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86BOOT.img" size="737280" crc="2e041131" sha1="1a13bd1faa929ec5a7fe822b94176e18a5365e68" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK01.img" size="737280" crc="82108a6d" sha1="291cd575f0027d6df09188535d558107d994c393" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK02.img" size="737280" crc="b3c96023" sha1="4d1acb7a109dbb0cb8972cecafbd4247429621d7" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK03.img" size="737280" crc="c6c11cc4" sha1="acd3e378244c66b28fd6eba17e29ff6f36b38db7" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 4" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK04.img" size="737280" crc="fbcb473b" sha1="3f9d8fbe7bef6835f7d30bc96f6b94831fad4d81" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 5" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK05.img" size="737280" crc="dac40b03" sha1="6acb0c098adda46cb95c97dec5925914c554f7c2" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 6" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK06.img" size="737280" crc="d2d099ba" sha1="3f6c0c9b58c604a9dfd5876d0d5599ddd22f1812" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 7" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK07.img" size="737280" crc="b31385a3" sha1="ce304879b15af67822a53f1f766a9a94f722e518" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 8" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK08.img" size="737280" crc="d56308a5" sha1="c7ab56898a0e03b014cc2990075d5388d1fbe91e" />
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 9" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK09.img" size="737280" crc="9caf050d" sha1="b7cc644185803f14164d7fbc421006d275686643" />
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 10" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK10.img" size="737280" crc="fa2d6b85" sha1="bd21fd336d38409f082e6cab908d6ada798f0f9d" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="k16auto">
 		<description>Kaypro 16 Autoload</description>
 		<year>1984</year>

--- a/hash/ibm5150_hdd.xml
+++ b/hash/ibm5150_hdd.xml
@@ -5,6 +5,17 @@ license:CC0-1.0
 -->
 <softwarelist name="ibm5150_hdd" description="IBM PC hard disk images">
 
+	<software name="freedos13_8086">
+		<description>FreeDOS 1.3 8086 Minimized</description>
+		<year>2022</year>
+		<publisher>AkBKukU</publisher>
+		<part name="hdd" interface="st_hdd">
+			<diskarea name="harddriv">
+				<disk name="freedos13_8086" sha1="3dbb02c6d051d6de1647e20a4639512775f58c78" writeable="yes" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="msdos211">
 		<description>AT&amp;T Personal Computer 6300 DOS Release 2.0 (MS-DOS 2.11)</description>
 		<year>1984</year>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -566,67 +566,7 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="freedos10">
-		<description>FreeDOS 1.0 (bootdisk)</description>
-		<year>2006</year>
-		<publisher>The FreeDOS Project</publisher>
-		<info name="version" value="1.0"/>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size = "1474560">
-				<rom name="fdboot.img" size="1474560" crc="5160c4c9" sha1="813fa09f2278b0b83b67c6d2bda68a46cd83234d"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="freedos12">
-		<description>FreeDOS 1.2 (bootdisk)</description>
-		<year>2016</year>
-		<publisher>The FreeDOS Project</publisher>
-		<info name="version" value="1.2"/>
-		<part name="flop" interface="floppy_3_5">
-			<dataarea name="flop" size="1474560">
-				<rom name="FLOPPY.img" size="1474560" crc="e8b32691" sha1="2dd8bb9751176533dd7d00160a5eed0d8cbb4725"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="freedos13rc1">
-		<description>FreeDOS 1.3 Release Candidate 1 (bootdisk)</description>
-		<year>2019</year>
-		<publisher>The FreeDOS Project</publisher>
-		<info name="version" value="1.3-RC1"/>
-		<part name="flop" interface="floppy_3_5">
-			<dataarea name="flop" size="1474560">
-				<rom name="FD13FLOP.IMG" size="1474560" crc="27efbe97" sha1="7a4e3b21c7c6eacd38fadd5b4f43db0c7a756dd8"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="freedos13rc2">
-		<description>FreeDOS 1.3 Release Candidate 2 (bootdisk)</description>
-		<year>2019</year>
-		<publisher>The FreeDOS Project</publisher>
-		<info name="version" value="1.3-RC2"/>
-		<part name="flop" interface="floppy_3_5">
-			<dataarea name="flop" size="1474560">
-				<rom name="FD13FLOP.IMG" size="1474560" crc="280b9f4a" sha1="8d03e815712e3f885e7beb849552bb16d60a3b58"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="freedos13rc3">
-		<description>FreeDOS 1.3 Release Candidate 3 (bootdisk)</description>
-		<year>2020</year>
-		<publisher>The FreeDOS Project</publisher>
-		<info name="version" value="1.3-RC3"/>
-		<part name="flop" interface="floppy_3_5">
-			<dataarea name="flop" size="1474560">
-				<rom name="FD13FLOP.IMG" size="1474560" crc="128677ac" sha1="1adc07c319efd8976913cb29f1050401d12ff505"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="freedos13rc3_35" cloneof="freedos13rc3">
+	<software name="freedos13rc3_35">
 		<description>FreeDOS 1.3 Release Candidate 3 (Floppy-Only Edition)</description>
 		<year>2020</year>
 		<publisher>The FreeDOS Project</publisher>
@@ -675,19 +615,7 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="freedos13rc4">
-		<description>FreeDOS 1.3 Release Candidate 4 (bootdisk)</description>
-		<year>2021</year>
-		<publisher>The FreeDOS Project</publisher>
-		<info name="version" value="1.3-RC4"/>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size = "1474560">
-				<rom name="FD13FLOP.img" size="1474560" crc="866dceed" sha1="7dfeecef443b2f0f69de0d508e5a17490961ebcf"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="freedos13rc4_120" cloneof="freedos13rc4">
+	<software name="freedos13rc4_120" cloneof="freedos13rc4_144">
 		<description>FreeDOS 1.3 Release Candidate 4 (Floppy-Only Edition, 5.25" 1.2MB)</description>
 		<year>2021</year>
 		<publisher>The FreeDOS Project</publisher>
@@ -754,7 +682,7 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="freedos13rc4_144" cloneof="freedos13rc4">
+	<software name="freedos13rc4_144">
 		<description>FreeDOS 1.3 Release Candidate 4 (Floppy-Only Edition, 3.5" 1.44MB)</description>
 		<year>2021</year>
 		<publisher>The FreeDOS Project</publisher>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -809,6 +809,190 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="freedos13rc5_120" cloneof="freedos13rc5_144">
+		<description>FreeDOS 1.3 Release Candidate 5 (Floppy-Only Edition, 5.25" 1.2MB)</description>
+		<year>2021</year>
+		<publisher>The FreeDOS Project</publisher>
+		<info name="version" value="1.3-RC5" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Installer" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86BOOT.img" size="1228800" crc="25cf9bef" sha1="0c0dd504bdc30df3dda8583c4938e859421617f2" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK01.img" size="1228800" crc="f99281c8" sha1="8288bcca2bbdb631ef6cdd22b3d0fc4e3d42d217" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK02.img" size="1228800" crc="4742a3ba" sha1="08bb8dbf9080b6720a58b30ff63b3a3759c267fc" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK03.img" size="1228800" crc="463829eb" sha1="a80aa9cc94b7c71e1bffbc2d85c8285cd9dbbb7e" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK04.img" size="1228800" crc="097a6c7c" sha1="a8af7e9755710d132875238a036c5e50aa0152b6" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 5" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK05.img" size="1228800" crc="4be05057" sha1="0c63cafe348d5ea417f5303228de6b13a0bc909c" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 6" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK06.img" size="1228800" crc="691fff4d" sha1="4b9fcbe2b78b7b54e960fc9b9802f52af6d79b0b" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="freedos13rc5_144">
+		<description>FreeDOS 1.3 Release Candidate 5 (Floppy-Only Edition, 3.5" 1.44MB)</description>
+		<year>2021</year>
+		<publisher>The FreeDOS Project</publisher>
+		<info name="version" value="1.3-RC5" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installer" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86BOOT.img" size="1474560" crc="57091652" sha1="43601d2b5f9c374490178290cb6618411b052991" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK01.img" size="1474560" crc="4926b4cf" sha1="f307505a0dd4031c1234918b189f7d89fb358811" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK02.img" size="1474560" crc="4a61e43f" sha1="be3a9bddba789d7a8cff4a4e4dd7c4e7b151b973" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK03.img" size="1474560" crc="7a6dec58" sha1="67c99ea40fb7103cb88b9236f1faa8367567e519" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK04.img" size="1474560" crc="dba0f18a" sha1="8f52c14fee0ab08b96eb25a8f862c5fd134399ff" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK05.img" size="1474560" crc="4f39fb4e" sha1="79c335d3e3b84aae62734381ed47ea33c643cc9b" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="freedos13_120" cloneof="freedos13_144">
+		<description>FreeDOS 1.3 (Floppy-Only Edition, 5.25" 1.2MB)</description>
+		<year>2022</year>
+		<publisher>The FreeDOS Project</publisher>
+		<info name="version" value="1.3" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Installer" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86BOOT.img" size="1228800" crc="a819423e" sha1="5aec2c84293a3939eacbe67c70f6e27a6f27ca3d" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK01.img" size="1228800" crc="171a38a0" sha1="aaf2c753fc306ade3973dc63b39253d6e4729f06" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK02.img" size="1228800" crc="db021279" sha1="58ce155e371ae1c181a800e8f02adc055e5b9c9f" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK03.img" size="1228800" crc="96243ef3" sha1="f3ebec3d47fe866685eae0c9908d91cbb367d32a" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK04.img" size="1228800" crc="13654150" sha1="1ef596bf5cc9a1b898f24be01160dc3064a43ef6" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 5" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK05.img" size="1228800" crc="94347568" sha1="267e49e30303d597046c0d4387b8d8dba7df53e0" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 6" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK06.img" size="1228800" crc="998bc8e4" sha1="8ed59283ca57fba3d5b7d1be1b8d4fbeffcb30c6" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="freedos13_144">
+		<description>FreeDOS 1.3 (Floppy-Only Edition, 3.5" 1.44MB)</description>
+		<year>2022</year>
+		<publisher>The FreeDOS Project</publisher>
+		<info name="version" value="1.3" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installer" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86BOOT.img" size="1474560" crc="136d3418" sha1="7f687f2d0b89ab2e4992b4800c89b8fb2c251a6a" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK01.img" size="1474560" crc="f91d97d6" sha1="8a4fe73720371d7d1771134ca0558ca40f5559ba" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK02.img" size="1474560" crc="0be95607" sha1="b1a3df3f294c026a4557c909295186e05ebf9189" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK03.img" size="1474560" crc="c959f717" sha1="a5d22214218ac549d58673bddc9e5213b4f9f611" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK04.img" size="1474560" crc="da8b62b9" sha1="6530926b2af5f18df8d293e2727ea0faf5325473" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK05.img" size="1474560" crc="73ffe00e" sha1="291a97e3d4423f2551bdb35bba9ce45296e1cc15" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="gem11">
 		<description>GEM Desktop 1.1</description>
 		<year>1985</year>

--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -6790,7 +6790,6 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 		</part>
 	</software>
 
-
 	<software name="freedos10">
 		<description>FreeDOS 1.0</description>
 		<year>2006</year>
@@ -6819,6 +6818,12 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 			<diskarea name="cdrom">
 				<disk name="fd10fullws" sha1="bfdfe1b9e3c4d697e69ea47dd436b6d291bee5bd"/>
 			</diskarea>
+		</part>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot Floppy" />
+			<dataarea name="flop" size = "1474560">
+				<rom name="fdboot.img" size="1474560" crc="5160c4c9" sha1="813fa09f2278b0b83b67c6d2bda68a46cd83234d"/>
+			</dataarea>
 		</part>
 	</software>
 
@@ -6882,6 +6887,12 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 				<disk name="fd12lgcy" sha1="86ff1e0c49029c68ad24a0110e32929ec26b2760"/>
 			</diskarea>
 		</part>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot Floppy" />
+			<dataarea name="flop" size="1474560">
+				<rom name="FLOPPY.img" size="1474560" crc="e8b32691" sha1="2dd8bb9751176533dd7d00160a5eed0d8cbb4725"/>
+			</dataarea>
+		</part>
 	</software>
 
 	<software name="freedos13rc1">
@@ -6907,6 +6918,12 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 				<disk name="fd13lgcy" sha1="6e7f457b161df9400c0f1dde0e0a209c6edb21d6"/>
 			</diskarea>
 		</part>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot Floppy" />
+			<dataarea name="flop" size="1474560">
+				<rom name="FD13FLOP.IMG" size="1474560" crc="27efbe97" sha1="7a4e3b21c7c6eacd38fadd5b4f43db0c7a756dd8"/>
+			</dataarea>
+		</part>
 	</software>
 
 	<software name="freedos13rc2">
@@ -6926,6 +6943,12 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 				<disk name="fd13lgcy" sha1="5a6bd7eed9700e18b3207c4af828b6da7138db60"/>
 			</diskarea>
 		</part>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot Floppy" />
+			<dataarea name="flop" size="1474560">
+				<rom name="FD13FLOP.IMG" size="1474560" crc="280b9f4a" sha1="8d03e815712e3f885e7beb849552bb16d60a3b58"/>
+			</dataarea>
+		</part>
 	</software>
 
 	<software name="freedos13rc3">
@@ -6944,6 +6967,12 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 			<diskarea name="cdrom">
 				<disk name="fd13lgcy" sha1="4f8c9809b335e5f8910edf4ce9c6fd1e5c53ebf5"/>
 			</diskarea>
+		</part>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot Floppy" />
+			<dataarea name="flop" size="1474560">
+				<rom name="FD13FLOP.IMG" size="1474560" crc="128677ac" sha1="1adc07c319efd8976913cb29f1050401d12ff505"/>
+			</dataarea>
 		</part>
 	</software>
 
@@ -6969,6 +6998,12 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 			<diskarea name="cdrom">
 				<disk name="fd13bns" sha1="1fe2a984fffe11c4587e625f845200c219a0893d"/>
 			</diskarea>
+		</part>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot Floppy" />
+			<dataarea name="flop" size = "1474560">
+				<rom name="FD13FLOP.img" size="1474560" crc="866dceed" sha1="7dfeecef443b2f0f69de0d508e5a17490961ebcf"/>
+			</dataarea>
 		</part>
 	</software>
 

--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -6972,6 +6972,68 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 		</part>
 	</software>
 
+	<software name="freedos13rc5">
+		<description>FreeDOS 1.3 Release Candidate 5</description>
+		<year>2021</year>
+		<publisher>The FreeDOS Project</publisher>
+		<info name="version" value="1.3-RC5" />
+		<part name="cdrom1" interface="cdrom">
+			<feature name="part_id" value="LiveCD" />
+			<diskarea name="cdrom">
+				<disk name="fd13live" sha1="628ff96887541f357d458138f99efffe1a73e219" />
+			</diskarea>
+		</part>
+		<part name="cdrom2" interface="cdrom">
+			<feature name="part_id" value="Legacy CD"/>
+			<diskarea name="cdrom">
+				<disk name="fd13lgcy" sha1="9b5e8143d9a32da94fbf06dfe406e3cd4aa41999" />
+			</diskarea>
+		</part>
+		<part name="cdrom3" interface="cdrom">
+			<feature name="part_id" value="Bonus CD"/>
+			<diskarea name="cdrom">
+				<disk name="fd13bns" sha1="46e472fce064db14c94d52c969f0610e1ae11922" />
+			</diskarea>
+		</part>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot Floppy" />
+			<dataarea name="flop" size="1474560">
+				<rom name="FD13BOOT.img" size="1474560" crc="d36ffc0c" sha1="0fcc214d055ef6216204a8697ca0b8e41ff3f4da" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="freedos13">
+		<description>FreeDOS 1.3</description>
+		<year>2022</year>
+		<publisher>The FreeDOS Project</publisher>
+		<info name="version" value="1.3" />
+		<part name="cdrom1" interface="cdrom">
+			<feature name="part_id" value="LiveCD" />
+			<diskarea name="cdrom">
+				<disk name="fd13live" sha1="ada640e575887a8088cb159067d2c746a9c8968a" />
+			</diskarea>
+		</part>
+		<part name="cdrom2" interface="cdrom">
+			<feature name="part_id" value="Legacy CD" />
+			<diskarea name="cdrom">
+				<disk name="fd13lgcy" sha1="4d9faeb8bbc76b0bffb8e834ec156345e069c861" />
+			</diskarea>
+		</part>
+		<part name="cdrom3" interface="cdrom">
+			<feature name="part_id" value="Bonus CD" />
+			<diskarea name="cdrom">
+				<disk name="fd13bns" sha1="46d858e5f98ea166d8137fbd86b9939d7b7250cd" />
+			</diskarea>
+		</part>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot Floppy" />
+			<dataarea name="flop" size="1474560">
+				<rom name="FD13BOOT.img" size="1474560" crc="5c647576" sha1="ec08f57f36b0bbc4d2b7613dc0857f0b43fd08e5" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="nasfdu12">
 		<description>NASLite NAS Server Operating System (v1.x)</description>
 		<year>2004</year>

--- a/hash/ibm5170_hdd.xml
+++ b/hash/ibm5170_hdd.xml
@@ -43,6 +43,21 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="freedos13">
+		<description>FreeDOS 1.3</description>
+		<year>2022</year>
+		<publisher>The FreeDOS Project</publisher>
+		<notes><![CDATA[
+		See https://gitlab.com/FreeDOS/issue-reporting/-/issues/26 for the upstream
+		issue report about VINFO.]]></notes>
+		<info name="usage" value="FreeDOS contains a CPU detection bug in VINFO.COM, always reporting a 80186.  Edit C:\FDAUTO.BAT to remove calls to VINFO and always run Support286 or Support386 routines to work around the problem." />
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="freedos13" sha1="72eef7bf0ad53b8a240ce05244173df54db923f0" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="msdos331">
 		<description>MS-DOS (Version 3.31)</description>
 		<year>1987</year>


### PR DESCRIPTION
Official releases: 1.3-RC5 and 1.3 were missing, I've added those in the first commit.

I've also added an unofficial 5150-optimized version from https://archive.org/details/free-dos-1.3-8086-minimized. While I'm wary of including an unofficial release too, it is very useful to making FreeDOS usable on the ibm5150 driver, the regular version being much more optimized for the 486/Pentium era of computers. It also only comes in two 360K floppy disks, instead of a dozen 720K disks. The second commit can easily be omitted if it's not suitable for the MAME software list.