### PR TITLE
hash/ibm5170{,_cdrom}.xml: Pristine Windows NT 3.1 builds

### DIFF
--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -4565,153 +4565,241 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="winnt31w">
-		<description>Windows NT 3.1 Workstation (3.10.511.1)</description>
-		<year>1993</year>
-		<publisher>Microsoft</publisher>
-		<part name="flop" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
-			<dataarea name="flop" size="1474560">
-				<rom name="cdinstall.img" size="1474560" crc="6501bf63" sha1="386d83a2e9fd758272cbbd0beb4148f9e238626e"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="winnt31w_35" cloneof="winnt31w">
+	<software name="winnt31_35">
 		<description>Windows NT 3.1 Workstation (3.10.511.1) [3.5" floppy]</description>
 		<year>1993</year>
 		<publisher>Microsoft</publisher>
 		<info name="version" value="3.1"/>
 		<part name="flop1" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk01.img" size="1474560" crc="56830c42" sha1="7f67917ec99dd798426c2173581b501e9c65c5fc"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk02.img" size="1474560" crc="1f9a3fe0" sha1="7bfba96b69d41132876ff999d46a69d6430e0760"/>
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk03.img" size="1474560" crc="ffd000c8" sha1="dd4a273c79382b6b95b6cd232e939be2c5384928"/>
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk04.img" size="1474560" crc="6ea6b1c9" sha1="d485050a0684c63f4ee1d393a2adda5327be9c25"/>
 			</dataarea>
 		</part>
 		<part name="flop5" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk05.img" size="1474560" crc="f453ba83" sha1="5c1670902c772692129816d9b7746f96c468770e"/>
 			</dataarea>
 		</part>
 		<part name="flop6" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk06.img" size="1474560" crc="d999af2b" sha1="54be6f7a73d0a1aa7c75fb93e54132f9ce66d072"/>
 			</dataarea>
 		</part>
 		<part name="flop7" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk07.img" size="1474560" crc="17473762" sha1="e97aaccf1e55d2e4eb65887e7e112874d562f177"/>
 			</dataarea>
 		</part>
 		<part name="flop8" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk08.img" size="1474560" crc="a3596916" sha1="743fa5e72c69c7fd56145f58839c9ab33e8e805a"/>
 			</dataarea>
 		</part>
 		<part name="flop9" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk09.img" size="1474560" crc="9addd123" sha1="53caf630de5d01ad98ca7ad3ab4e2807f1bb3c87"/>
 			</dataarea>
 		</part>
 		<part name="flop10" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk10.img" size="1474560" crc="fd0e46ad" sha1="81f1e43e186ecd19d1bb76f308557dbf4dc89363"/>
 			</dataarea>
 		</part>
 		<part name="flop11" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk11.img" size="1474560" crc="d1159fa9" sha1="ba5ffb2f8034905530b01fea32d90fbdd68cc133"/>
 			</dataarea>
 		</part>
 		<part name="flop12" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk12.img" size="1474560" crc="c2ae75c7" sha1="c89a99f1936e1f8df53edbf222bb52082afc8051"/>
 			</dataarea>
 		</part>
 		<part name="flop13" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk13.img" size="1474560" crc="8050b640" sha1="db315b0217b4ebb6650d3fb45e0334da4a7acd32"/>
 			</dataarea>
 		</part>
 		<part name="flop14" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk14.img" size="1474560" crc="2b910f46" sha1="27790a24e5bc17b1059af7320b8d8c63e7a89cfc"/>
 			</dataarea>
 		</part>
 		<part name="flop15" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk15.img" size="1474560" crc="26e94721" sha1="ebd315d3eb69e9f2000983bba6dda364e85a2812"/>
 			</dataarea>
 		</part>
 		<part name="flop16" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk16.img" size="1474560" crc="bed8e80b" sha1="670b2824d488cf0a0e6bf0c0e5ec2d88baee482e"/>
 			</dataarea>
 		</part>
 		<part name="flop17" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk17.img" size="1474560" crc="51efa417" sha1="bbfb319f072e3d9b5334bee94fdf2d8494de111c"/>
 			</dataarea>
 		</part>
 		<part name="flop18" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk18.img" size="1474560" crc="ece2ba90" sha1="08f9ccdc1219222f6b6196a9fc197969d215c5cd"/>
 			</dataarea>
 		</part>
 		<part name="flop19" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk19.img" size="1474560" crc="ae06b0c4" sha1="378d10922d159ce3ce0db0a9e4f91bb0f9aeaba0"/>
 			</dataarea>
 		</part>
 		<part name="flop20" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk20.img" size="1474560" crc="44170e6b" sha1="1222d848ac98cf4f5342bf1001733fdb9f83ecc5"/>
 			</dataarea>
 		</part>
 		<part name="flop21" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk21.img" size="1474560" crc="a85335da" sha1="0013baea85052d1422f2829185cc85148adc532d"/>
 			</dataarea>
 		</part>
 		<part name="flop22" interface="floppy_3_5">
-			<!-- Origin: WinWorld -->
 			<dataarea name="flop" size="1474560">
 				<rom name="Disk22.img" size="1474560" crc="3a9c5c11" sha1="f882b09f19ae8fda691860f29cb512c36eb8c597"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="winnt31as_35" cloneof="winnt31_35">
+		<description>Windows NT 3.1 Advanced Server (3.10.511.1) [3.5" floppy]</description>
+		<year>1993</year>
+		<publisher>Microsoft</publisher>
+		<info name="version" value="3.1"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="d4f2ad90" sha1="6cc6ba250e52330284f2ae54f4ec196c95c67a01"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="00f7d527" sha1="d960ba72354bf607c7e2e1e9fe4be6c19a926cdd"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk03.img" size="1474560" crc="1ad79756" sha1="3fcfce126c7a3317749f8b079bb636da2829cb1b"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk04.img" size="1474560" crc="cf35f964" sha1="9be907ee9460a18c9856f0bef0953303f33dd621"/>
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk05.img" size="1474560" crc="ab805fe3" sha1="a27c12d50bddf2910a42bb2fb8b9b513743a2e3a"/>
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk06.img" size="1474560" crc="b80e6873" sha1="9703733540f2a802c2135e0e7eb6658489853e2c"/>
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk07.img" size="1474560" crc="eb748ad9" sha1="380157f7f9b59d989438d1a3f6fdd751feffac1f"/>
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk08.img" size="1474560" crc="2778b205" sha1="58b3fa750344a2768b389ad2d6723365f73486cf"/>
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk09.img" size="1474560" crc="7f21cebd" sha1="a08b112ff1a07cfa1b2df3f12c9acdb594bbf409"/>
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk10.img" size="1474560" crc="a043af7f" sha1="996900d044bd5b21659cbcb4cf4020314e6b92f6"/>
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk11.img" size="1474560" crc="b254429e" sha1="3084fc64ba53870668f13387b71fbe9e0257c02f"/>
+			</dataarea>
+		</part>
+		<part name="flop12" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk12.img" size="1474560" crc="b7233055" sha1="7747cfdc41c8ec8e6379f107183f1fffb7a818e1"/>
+			</dataarea>
+		</part>
+		<part name="flop13" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk13.img" size="1474560" crc="5783591b" sha1="24f7a83ca3d40b14a6e6c47826bd7cfa2add13e0"/>
+			</dataarea>
+		</part>
+		<part name="flop14" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk14.img" size="1474560" crc="127ccec9" sha1="886d62ac0dc0a88901d55170f41c350e2b535498"/>
+			</dataarea>
+		</part>
+		<part name="flop15" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk15.img" size="1474560" crc="1abaa6b7" sha1="cd508917ce12772203ebacafb385632931f7c658"/>
+			</dataarea>
+		</part>
+		<part name="flop16" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk16.img" size="1474560" crc="d06909d5" sha1="3a5ddfa05e90a719bf129f31d9924396eb5492ac"/>
+			</dataarea>
+		</part>
+		<part name="flop17" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk17.img" size="1474560" crc="4344dabf" sha1="b8189f98358a796e95fe9760af4e748f5122d45c"/>
+			</dataarea>
+		</part>
+		<part name="flop18" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk18.img" size="1474560" crc="1eccce9b" sha1="d80cffe88b1ea2494c744aa0f2f576b8b92406ee"/>
+			</dataarea>
+		</part>
+		<part name="flop19" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk19.img" size="1474560" crc="a5679830" sha1="04724f3693f2d07020ffd47b2dd3d8d6bba20dc7"/>
+			</dataarea>
+		</part>
+		<part name="flop20" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk20.img" size="1474560" crc="a3cbae61" sha1="aba4c9c4656fb4247d571b48b0ad97501699bb20"/>
+			</dataarea>
+		</part>
+		<part name="flop21" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk21.img" size="1474560" crc="f1476cc9" sha1="c8f174d5851c0366b3304b2c2f89e99b459ce4f1"/>
+			</dataarea>
+		</part>
+		<part name="flop22" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk22.img" size="1474560" crc="880e94f4" sha1="329a9348135111b6015e31ec4bd1f14a02477396"/>
+			</dataarea>
+		</part>
+		<part name="flop23" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk23.img" size="1474560" crc="3ad2edeb" sha1="fdc15778e7ed8828f27e8cd7c2b6ad0a3e6e547d"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -4566,7 +4566,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="winnt31_35">
-		<description>Windows NT 3.1 Workstation (3.10.511.1) [3.5" floppy]</description>
+		<description>Windows NT 3.1 (3.10.511.1) [3.5" floppy]</description>
 		<year>1993</year>
 		<publisher>Microsoft</publisher>
 		<info name="version" value="3.1"/>
@@ -4683,7 +4683,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="winnt31as_35" cloneof="winnt31_35">
-		<description>Windows NT 3.1 Advanced Server (3.10.511.1) [3.5" floppy]</description>
+		<description>Windows NT Advanced Server 3.1 (3.10.511.1) [3.5" floppy]</description>
 		<year>1993</year>
 		<publisher>Microsoft</publisher>
 		<info name="version" value="3.1"/>

--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -6968,14 +6968,221 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 		</part>
 	</software>
 
-	<software name="winnt31w">
-		<description>Windows NT 3.1 Workstation (3.10.511.1)</description>
+	<software name="winnt31">
+		<description>Windows NT 3.1 (3.10.528.1, MSDN)</description> <!-- This SKU became "Workstation" in 3.5, 3.51, and 4.0 -->
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<notes><![CDATA[
+		This floppy image is actually connected to the 1993 release, but it works.
+		None of the files changed on the CD are part of the floppy disk.
+		]]></notes>
+		<info name="language" value="English"/>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="en_winnt_3.10.528.1_1994" sha1="2076b06f7a975903265a1498b69e7fe4932d196e"/>
+			</diskarea>
+		</part>
+		<part name="flop" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="en-us windows nt 3.10.528.1 3.5.img" size="1474560" crc="1e2c946b" sha1="7928d1cd298b32e724fc33731184b2a7dbd55b7e"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="winnt31o1" cloneof="winnt31">
+		<description>Windows NT 3.1 (3.10.528.1)</description>
 		<year>1993</year>
 		<publisher>Microsoft</publisher>
+		<info name="language" value="English"/>
 		<part name="cdrom" interface="cdrom">
-			<!-- Origin: WinWorld -->
 			<diskarea name="cdrom">
-				<disk name="en_winnt_3_1_wks" sha1="0a542add03b6c9ab130421d24f94731c4992e0a7"/>
+				<disk name="en_winnt_3.10.528.1" sha1="1601864708df96e3f4ff57329bc6e384cd000494"/>
+			</diskarea>
+		</part>
+		<part name="flop" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="en-us windows nt 3.10.528.1 3.5.img" size="1474560" crc="1e2c946b" sha1="7928d1cd298b32e724fc33731184b2a7dbd55b7e"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="winnt31o2" cloneof="winnt31">
+		<description>Windows NT 3.1 (3.10.511.1)</description>
+		<year>1993</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="English"/>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="en-us windows nt 3.10.511.1" sha1="ce0cd139bf0b022e9d46d530b11cf0a7b32fa22b"/>
+			</diskarea>
+		</part>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="winnt_511_35.img" size="1474560" crc="6501bf63" sha1="386d83a2e9fd758272cbbd0beb4148f9e238626e"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<dataarea name="flop" size="1228800">
+				<rom name="winnt_511_525.img" size="1228800" crc="e1c5ab56" sha1="da770baa202d5ef0dc1800bb73bc836c1f0d6730"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="winnt31as" cloneof="winnt31">
+		<description>Windows NT Advanced Server 3.1 (3.10.528.1)</description>
+		<year>1993</year>
+		<publisher>Microsoft</publisher>
+		<notes><![CDATA[
+		While the standard (“Workstation”) edition was included in the MSDN 1994 set,
+		Advanced Server was not.  An updated Advanced Server build may not exist.
+		]]></notes>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="en_winnt_advancedserver_3.10.528.1" sha1="ccdc9056a1343198d95d6513e90f6037f73c7507"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="winnt31aso" cloneof="winnt31">
+		<description>Windows NT Advanced Server 3.1 (3.10.511.1)</description>
+		<year>1993</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="English"/>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="en-us windows nt advanced server 3.10.511.1" sha1="afe907bfd1593a4d86a189ea1dd168cc803b0385"/>
+			</diskarea>
+		</part>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="winntas_511_35.img" size="1474560" crc="986a1b8e" sha1="7a9a549e25a504957523575970c3e01529647d7a"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<dataarea name="flop" size="1228800">
+				<rom name="winntas_511_525.img" size="1228800" crc="5e0a8239" sha1="989a4721e4f57c75131b4c3c746f8e86e73863ec"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Language variants of the client version -->
+	<software name="winnt31_dadk" cloneof="winnt31">
+		<description>Windows NT 3.1 (3.10.528.1, MSDN, da-DK)</description>
+		<year>1993</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="Danish"/>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="da-dk windows nt 3.10.528.1" sha1="ae88ac0bbea68565189b6fdafe86f8e66ff9e9b4"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="winnt31_dede" cloneof="winnt31">
+		<description>Windows NT 3.1 (3.10.511.1, MSDN, de-DE)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="German"/>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="de-de windows nt 3.10.511.1" sha1="5ea4098f8b0bf00bdb00af9d56a0ee2df01fdb13"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="winnt31_eses" cloneof="winnt31">
+		<description>Windows NT 3.1 (3.10.511.1, MSDN, es-ES)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="Spanish"/>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="es-es windows nt 3.10.511.1" sha1="ff032060d15982d3724ea17b683faab8c4c07e27"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="winnt31_fifi" cloneof="winnt31">
+		<description>Windows NT 3.1 (3.10.528.1, MSDN, fi-fi)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="Finnish"/>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="fi-fi windows nt 3.10.528.1" sha1="9249745d9f6ed9bfd0a10e31e53b886adf6c4991"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="winnt31_frfr" cloneof="winnt31">
+		<description>Windows NT 3.1 (3.10.511.1, MSDN, fr-FR)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="French"/>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="fr-fr windows nt 3.10.511.1" sha1="9a6a6ade986a9ebaf2d84d0b47cb904496656e38"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="winnt31_itit" cloneof="winnt31">
+		<description>Windows NT 3.1 (3.10.511.1, MSDN, it-IT)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="Italian"/>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="it-it windows nt 3.10.511.1" sha1="4756551eddc21f000194a63e7659078e945367d7"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="winnt31_nlnl" cloneof="winnt31">
+		<description>Windows NT 3.1 (3.10.511.1, MSDN, nl-NL)</description>
+		<year>1993</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="Dutch"/>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="nl-nl windows nt 3.10.511.1" sha1="572eb82f0c2c964798857b117f96438630ddb99c"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="winnt31_nono" cloneof="winnt31">
+		<description>Windows NT 3.1 (3.10.528.1, MSDN, no-NO)</description>
+		<year>1993</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="Norwegian"/>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="no-no windows nt 3.10.528.1" sha1="fd3c6c2156510b5128da4aba2aa6bad7821bdf30"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="winnt31_ptbr" cloneof="winnt31">
+		<description>Windows NT 3.1 (3.10.528.1, MSDN, pt-BR)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="Portuguese (Brazil)"/>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="pt-br windows nt 3.10.528.1" sha1="20d3cb0168629c019c33a493b1cc8c976c79523f"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="winnt31_svse" cloneof="winnt31">
+		<description>Windows NT 3.1 (3.10.511.1, MSDN, sv-SE)</description>
+		<year>1993</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="Swedish"/>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="sv-se windows nt 3.10.511.1" sha1="1b184f2c14e14a43161201af8a5054fcda886c38"/>
+>>>>>>> 8e9082e9d01 (Move)
 			</diskarea>
 		</part>
 	</software>

--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -6969,7 +6969,7 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 	</software>
 
 	<software name="winnt31">
-		<description>Windows NT 3.1 (3.10.528.1, MSDN)</description> <!-- This SKU became "Workstation" in 3.5, 3.51, and 4.0 -->
+		<description>Windows NT 3.1 (3.10.528.1, MSDN, en-US)</description> <!-- This SKU became "Workstation" in 3.5, 3.51, and 4.0 -->
 		<year>1994</year>
 		<publisher>Microsoft</publisher>
 		<notes><![CDATA[
@@ -6979,7 +6979,7 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 		<info name="language" value="English"/>
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
-				<disk name="en_winnt_3.10.528.1_1994" sha1="2076b06f7a975903265a1498b69e7fe4932d196e"/>
+				<disk name="en-us windows nt 3.10.528.1 1994" sha1="2076b06f7a975903265a1498b69e7fe4932d196e"/>
 			</diskarea>
 		</part>
 		<part name="flop" interface="floppy_3_5">
@@ -6990,13 +6990,13 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 	</software>
 
 	<software name="winnt31o1" cloneof="winnt31">
-		<description>Windows NT 3.1 (3.10.528.1)</description>
+		<description>Windows NT 3.1 (3.10.528.1, en-US)</description>
 		<year>1993</year>
 		<publisher>Microsoft</publisher>
 		<info name="language" value="English"/>
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
-				<disk name="en_winnt_3.10.528.1" sha1="1601864708df96e3f4ff57329bc6e384cd000494"/>
+				<disk name="en-us windows nt 3.10.528.1" sha1="1601864708df96e3f4ff57329bc6e384cd000494"/>
 			</diskarea>
 		</part>
 		<part name="flop" interface="floppy_3_5">
@@ -7007,7 +7007,7 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 	</software>
 
 	<software name="winnt31o2" cloneof="winnt31">
-		<description>Windows NT 3.1 (3.10.511.1)</description>
+		<description>Windows NT 3.1 (3.10.511.1, en-US)</description>
 		<year>1993</year>
 		<publisher>Microsoft</publisher>
 		<info name="language" value="English"/>
@@ -7018,33 +7018,34 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 		</part>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1474560">
-				<rom name="winnt_511_35.img" size="1474560" crc="6501bf63" sha1="386d83a2e9fd758272cbbd0beb4148f9e238626e"/>
+				<rom name="en-us windows nt 3.10.511.1 3.5.img" size="1474560" crc="6501bf63" sha1="386d83a2e9fd758272cbbd0beb4148f9e238626e"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<dataarea name="flop" size="1228800">
-				<rom name="winnt_511_525.img" size="1228800" crc="e1c5ab56" sha1="da770baa202d5ef0dc1800bb73bc836c1f0d6730"/>
+				<rom name="en-us windows nt 3.10.511.1 5.25.img" size="1228800" crc="e1c5ab56" sha1="da770baa202d5ef0dc1800bb73bc836c1f0d6730"/>
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="winnt31as" cloneof="winnt31">
-		<description>Windows NT Advanced Server 3.1 (3.10.528.1)</description>
+		<description>Windows NT Advanced Server 3.1 (3.10.528.1, en-US)</description>
 		<year>1993</year>
 		<publisher>Microsoft</publisher>
 		<notes><![CDATA[
 		While the standard (“Workstation”) edition was included in the MSDN 1994 set,
 		Advanced Server was not.  An updated Advanced Server build may not exist.
 		]]></notes>
+		<info name="language" value="English"/>
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
-				<disk name="en_winnt_advancedserver_3.10.528.1" sha1="ccdc9056a1343198d95d6513e90f6037f73c7507"/>
+				<disk name="en-us windows nt advanced server 3.10.528.1" sha1="ccdc9056a1343198d95d6513e90f6037f73c7507"/>
 			</diskarea>
 		</part>
 	</software>
 
 	<software name="winnt31aso" cloneof="winnt31">
-		<description>Windows NT Advanced Server 3.1 (3.10.511.1)</description>
+		<description>Windows NT Advanced Server 3.1 (3.10.511.1, en-US)</description>
 		<year>1993</year>
 		<publisher>Microsoft</publisher>
 		<info name="language" value="English"/>
@@ -7055,13 +7056,26 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 		</part>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1474560">
-				<rom name="winntas_511_35.img" size="1474560" crc="986a1b8e" sha1="7a9a549e25a504957523575970c3e01529647d7a"/>
+				<rom name="en-us windows nt advanced server 3.10.511.1 3.5.img" size="1474560" crc="986a1b8e" sha1="7a9a549e25a504957523575970c3e01529647d7a"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
 			<dataarea name="flop" size="1228800">
-				<rom name="winntas_511_525.img" size="1228800" crc="5e0a8239" sha1="989a4721e4f57c75131b4c3c746f8e86e73863ec"/>
+				<rom name="en-us windows nt advanced server 3.10.511.1 5.25.img" size="1228800" crc="5e0a8239" sha1="989a4721e4f57c75131b4c3c746f8e86e73863ec"/>
 			</dataarea>
+		</part>
+	</software>
+
+	<!-- Language variants of the client version -->
+	<software name="winnt31_dadk" cloneof="winnt31">
+		<description>Windows NT 3.1 (3.10.528.1, MSDN, da-DK)</description>
+		<year>1993</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="Danish"/>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="en-us windows nt advanced server 3.10.511.1" sha1="afe907bfd1593a4d86a189ea1dd168cc803b0385"/>
+			</diskarea>
 		</part>
 	</software>
 
@@ -7182,7 +7196,6 @@ Incredibly slow in tearing down even on pcipcs7 (bypass with fast forward)
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
 				<disk name="sv-se windows nt 3.10.511.1" sha1="1b184f2c14e14a43161201af8a5054fcda886c38"/>
->>>>>>> 8e9082e9d01 (Move)
 			</diskarea>
 		</part>
 	</software>

--- a/hash/ibm5170_hdd.xml
+++ b/hash/ibm5170_hdd.xml
@@ -320,13 +320,13 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="winnt31w">
-		<description>Windows NT 3.1 Workstation (3.10.511.1)</description>
+	<software name="winnt31">
+		<description>Windows NT 3.1 (3.10.511.1)</description>
 		<year>1993</year>
 		<publisher>Microsoft</publisher>
 		<part name="hdd" interface="ide_hdd">
 			<diskarea name="harddriv">
-				<disk name="winnt31w" sha1="5c1cd3934cfcbd7b22f5f507c23d9b8826678c58" writeable="yes"/>
+				<disk name="winnt31" sha1="5c1cd3934cfcbd7b22f5f507c23d9b8826678c58" writeable="yes"/>
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
The image that was listed here is a hacked-up warez version from 2003 that doesn't function properly (won't install on most computers NT 3.1 should be able to install on).

In its stead, this is a list of pristine images direct out of Microsoft, no modifications have been made to them, and NT 3.1's (admittedly limited) full hardware compatibility is supported.

Taking from the BeOS example, floppy images that are intimately tied to the CD-ROM are listed in the same entry in ibm5170_cdrom.xml, since they are only useful in booting a computer in order to install from CD-ROM (which requires a compatible SCSI controller and SCSI CD-ROM drive).  Installing from MS-DOS is always another possibility.