### PR TITLE
Fixes coin bit order in avengers, except for avengersc

### DIFF
--- a/src/mame/capcom/lwings.cpp
+++ b/src/mame/capcom/lwings.cpp
@@ -1032,6 +1032,11 @@ INPUT_PORTS_END
 static INPUT_PORTS_START( avengers )
 	PORT_INCLUDE( lwings_generic )
 
+	// correct bit order for all versions except avengersc
+	PORT_MODIFY("SERVICE")
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_COIN2 )
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_COIN1 )
+
 	PORT_START("DSWA")
 	PORT_SERVICE_DIPLOC( 0x01, IP_ACTIVE_LOW, "SWA:8")
 	PORT_DIPNAME( 0x02, 0x02, DEF_STR( Flip_Screen ) ) PORT_DIPLOCATION("SWA:7")
@@ -1079,7 +1084,6 @@ static INPUT_PORTS_START( avengers )
 	PORT_DIPSETTING(    0x80, "5" )
 	PORT_DIPSETTING(    0x00, "6" )
 INPUT_PORTS_END
-
 
 /*************************************
  *


### PR DESCRIPTION
The coin slot bit order was reversed in all versions of this machine except for avengersc. This change fixes that on five versions of the game but now breaks avengers. As the driver had 5 versions broken/1 good before, I think this is a better balance.

I do not know how to keep the old order just for avengersc. I have tried a couple of things but cannot get the macros to do what I want.