### PR TITLE
thinkpad8xx.xml: Fix floppies sizes

### DIFF
--- a/hash/thinkpad8xx.xml
+++ b/hash/thinkpad8xx.xml
@@ -53,8 +53,8 @@ license:CC0-1.0
 		<part name="flop" interface="floppy">
 			<feature name="part_id" value="Solaris MDB Boot 2.5.1 Release PowerPC Platform Edition (IBM Hardware Platform)"/>
 			<feature name="part_number" value="702-4348-06"/>
-			<dataarea name="flop" size="168000">
-				<rom name="solaris_2_5_1_mdb_boot_ppc_ibm.img" size="168000" crc="b45832e2" sha1="be9e11364816ab5f3362396ed0f457d4a2e61188" />
+			<dataarea name="flop" size="1474560">
+				<rom name="solaris_2_5_1_mdb_boot_ppc_ibm.img" size="1474560" crc="b45832e2" sha1="be9e11364816ab5f3362396ed0f457d4a2e61188" />
 			</dataarea>
 		</part>
 		<part name="cdrom1" interface="cdrom">
@@ -79,8 +79,8 @@ license:CC0-1.0
 		<sharedfeat name="compatibility" value="800,820,850" />
 		<part name="flop" interface="floppy">
 			<feature name="part_id" value="Windows NT ARC Boot Firmware v1.51"/>
-			<dataarea name="flop" size="168000">
-				<rom name="winnt_arc_151.img" size="168000" crc="98db8c77" sha1="56be119ce7a0020bf4caabd099d2eae8e249305c" />
+			<dataarea name="flop" size="1474560">
+				<rom name="winnt_arc_151.img" size="1474560" crc="98db8c77" sha1="56be119ce7a0020bf4caabd099d2eae8e249305c" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="cdrom">

--- a/src/mame/ibm/thinkpad8xx.cpp
+++ b/src/mame/ibm/thinkpad8xx.cpp
@@ -88,9 +88,9 @@ void thinkpad8xx_state::thinkpad850(machine_config &config)
 
 ROM_START(thinkpad850)
 	ROM_REGION( 0x80000, "maincpu", 0 )
-	ROM_SYSTEM_BIOS( 0, "91g1671", "v1.01 (91G1671, 09-10-1996)" )
+	ROM_SYSTEM_BIOS( 0, "v101", "v1.01 (91G1671, 09-10-1996)" )
 	ROMX_LOAD( "91g1671_ibm_dakota_v101_mbm29f040a.u21", 0x00000, 0x80000, CRC(5210dbd6) SHA1(8e0bbbe130e6fdb06ef307bb5addbcb993a8a41f), ROM_BIOS(0) ) // Needed for installing Windows NT
-	ROM_SYSTEM_BIOS( 1, "91g0610", "v1.00 (91G0610, 07-03-1995)" )
+	ROM_SYSTEM_BIOS( 1, "v100", "v1.00 (91G0610, 07-03-1995)" )
 	ROMX_LOAD( "91g0610_ibm_dakota_v100_mbm29f040a.u21", 0x00000, 0x80000, CRC(169a79c4) SHA1(da74a2f346b732add62d08ca5f34f192cae5d033), ROM_BIOS(1) )
 
 	ROM_REGION(0xe000, "mcu", 0)


### PR DESCRIPTION
Also change the driver to use BIOS version as tag instead of using the build code