### PR TITLE
Update megadriv.xml for ESPN Hockey Night

### DIFF
--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -16674,7 +16674,7 @@ https://segaretro.org/Elitserien_96
 		<part name="cart" interface="megadriv_cart">
 			<feature name="slot" value="rom_sram"/>
 			<dataarea name="rom" width="16" endianness="big" size="2097152">
-				<rom name="espn national hockey night (usa).bin" size="2097152" crc="1d08828c" sha1="cfd65e3ffb17e1718356ef8de7c527e2c9fd8940"/>
+				<rom name="espn national hockey night (usa).bin" size="2097152" crc="401dc618" sha1="cb312d6617574f5b9cccd56a83a0a45b734671ed"/>
 			</dataarea>
 			<dataarea name="sram" size="16384">
 			</dataarea>


### PR DESCRIPTION
I've been looking into this ROM as the trusted dump and scene dumps on no-intro did not match and were marked bad as Mame considers them bad. I did my own testing, as I don't think one db should rely on another or why be separate? Dumping 3 copies on Sanni's OSCR reader, plus desoldering a chip and dumping it with a Backbit chip tester, I get the hashes I'm updating it to here.

While I don't think MAME should consider it bad because No-intro does or vice-versa, I'm the dumper and glad to answer any questions to both projects. If I should be noting this elsewhere please let me know.