### PR TITLE
7 new WORKING plug and Play Units, 17 NOT WORKING Plug and Play Units, 3 Software List additions, 8 promotions

### DIFF
--- a/hash/hikara.xml
+++ b/hash/hikara.xml
@@ -57,10 +57,11 @@ license:CC0-1.0
 
 	        * Pocket Monsters Special                       -none-      Yellow
 	        * Ciao Special                                  CC0907001   Translucent Pink - came with the 2009/06 issue of the Ciao (ちゃお) manga
+	        * PIZZA-LA                                      PZ0909001   Translucent Pink
 
 	        4 User Cartridge (5 Capacity)                   n/a         Translucent Grey/White
 	        2 User Cartridge (10 Capacity)                  n/a         Translucent Pink
-	        2 User Cartridge (20 Capacity)                  n/a         Translucent Blue
+	        3 User Cartridge (20 Capacity)                  n/a         Translucent Blue
 	-->
 
 	<!-- this one has some songs programmed into it:
@@ -169,6 +170,17 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="user20" supported="no">
+		<description>Hi-kara 20-song capacity user cartridge (blank) (Japan)</description>
+		<year>2008</year>
+		<publisher>Takara Tomy</publisher>
+		<part name="cart" interface="ekara_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="hikara_usercart20.u1" size="0x200000" crc="70147ead" sha1="d7274312700cf90e54135695d10b6a5108a980ab"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<!-- this one has some songs programmed into it:
 	    一番綺麗な私を                  中島美嘉                        Ichiban Kireina Watashi o       Nakajima Mika
 	    わかれうた                      中島みゆき                      Wakareuta                       Nakajima Miyuki
@@ -190,7 +202,7 @@ license:CC0-1.0
 	    天体観測                        BUMP OF CHICKEN                 Tentai Kansoku                  BUMP OF CHICKEN
 	    情熱の薔薇                      THE BLUE HEARTS                 Jōnetsu no Bara                 THE BLUE HEARTS
 	    ありがとう                      いきものがかり                  Arigatō                         Ikimonogakari -->
-	<software name="user20" supported="no">
+	<software name="user20a" cloneof="user20" supported="no">
 		<description>Hi-kara 20-song capacity user cartridge (used, with 20 songs, set 1) (Japan)</description>
 		<year>2008</year>
 		<publisher>Takara Tomy</publisher>
@@ -222,7 +234,7 @@ license:CC0-1.0
 	    炎神戦隊ゴーオンジャー                  高橋秀幸(Project.R)             ENGINE SENTAI GO-ONGER                      Takahashi Hideyuki
 	    いつも何度でも                          木村弓                          Itsumo Nandodemo                            Kimura Yumi
 	    ニホンノミカタ-ネバダカラキマシタ-      矢島美容室                      Nihon no Mikata -Nevada kara Kimashita-     Yajima Biyōshitsu -->
-	<software name="user20a" cloneof="user20" supported="no">
+	<software name="user20b" cloneof="user20" supported="no">
 		<description>Hi-kara 20-song capacity user cartridge (used, with 20 songs, set 2) (Japan)</description>
 		<year>2008</year>
 		<publisher>Takara Tomy</publisher>
@@ -349,6 +361,19 @@ license:CC0-1.0
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="cc0907001.u1" size="0x200000" crc="45f6b2a3" sha1="b3b1b3f269b128a2b09aa932f77d53da53f6130f"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- the presentation on this is almost the same as a 10 song user cartridge, but it's a standalone, non-reprogrammable release -->
+	<!-- 2009 date is from cart label, shows 2008 when running -->
+	<software name="pizzala" supported="no">
+		<description>Hi-kara PIZZA-LA</description>
+		<year>2009</year>
+		<publisher>Takara Tomy</publisher>
+		<part name="cart" interface="ekara_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="pz0909001.u1" size="0x200000" crc="1c759eaf" sha1="bcab1f0b16c2866501c9cdeea9df7b9878bbda2a"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/super_tv_pc_cart.xml
+++ b/hash/super_tv_pc_cart.xml
@@ -71,7 +71,7 @@ license:CC0-1.0
 		<description>Doraemon Excite Ping-Pong</description>
 		<year>2006</year>
 		<publisher>Epoch</publisher>
-		<info name="alt_title" value="Doraemon Excite Ping-Pong (but in Japanese, obviously)" />
+		<info name="alt_title" value="ドラえもんエキサイトピンポン" />
 		<part name="cart" interface="super_tv_pc_cart">
 			<dataarea name="prg" size="0x200000">
 				<rom name="c-06.u1" size="0x200000" crc="bdf25763" sha1="f3f20e8476d086d26152cdd46164b4cad736e3ed" />

--- a/hash/super_tv_pc_cart.xml
+++ b/hash/super_tv_pc_cart.xml
@@ -71,6 +71,7 @@ license:CC0-1.0
 		<description>Doraemon Excite Ping-Pong</description>
 		<year>2006</year>
 		<publisher>Epoch</publisher>
+		<info name="alt_title" value="Doraemon Excite Ping-Pong (but in Japanese, obviously)" />
 		<part name="cart" interface="super_tv_pc_cart">
 			<dataarea name="prg" size="0x200000">
 				<rom name="c-06.u1" size="0x200000" crc="bdf25763" sha1="f3f20e8476d086d26152cdd46164b4cad736e3ed" />

--- a/hash/super_tv_pc_cart.xml
+++ b/hash/super_tv_pc_cart.xml
@@ -4,10 +4,6 @@
 license:CC0-1.0
 -->
 
-<!-- also known to exist
-ドラえもんエキサイトピンポン (Doraemon Excite Ping-Pong)
--->
-
 <softwarelist name="super_tv_pc_cart" description="Epoch Super TV-PC cartridges">
 
 	<!-- these appear to require the system BIOS as they access above the 4MB mark for audio during the boot screen -->
@@ -71,7 +67,16 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<!-- C-06 -->
+	<software name="doraepp" supported="no">
+		<description>Doraemon Excite Ping-Pong</description>
+		<year>2006</year>
+		<publisher>Epoch</publisher>
+		<part name="cart" interface="super_tv_pc_cart">
+			<dataarea name="prg" size="0x200000">
+				<rom name="c-06.u1" size="0x200000" crc="bdf25763" sha1="f3f20e8476d086d26152cdd46164b4cad736e3ed" />
+			</dataarea>
+		</part>
+	</software>
 
 	<software name="link" supported="no">
 		<description>Pet Keitai Link</description>

--- a/src/devices/machine/generalplus_gpl16250soc.h
+++ b/src/devices/machine/generalplus_gpl16250soc.h
@@ -62,6 +62,7 @@ public:
 	//void set_pal_back_hack(int pal_back) { m_spg_video->set_pal_back(pal_back); }
 	void set_alt_extrasprite_hack(int alt_extrasprite_hack) { m_spg_video->set_alt_extrasprite(alt_extrasprite_hack); }
 	void set_legacy_video_mode() { m_spg_video->set_legacy_video_mode(); }
+	void set_disallow_resolution_control() { m_spg_video->set_disallow_resolution_control(); }
 
 	void set_romtype(int romtype) { m_romtype = romtype; }
 

--- a/src/devices/machine/generalplus_gpl16250soc_video.cpp
+++ b/src/devices/machine/generalplus_gpl16250soc_video.cpp
@@ -39,6 +39,7 @@ gcm394_base_video_device::gcm394_base_video_device(const machine_config &mconfig
 	m_alt_extrasprite_hack(0),
 	m_alt_tile_addressing(0),
 	m_use_legacy_mode(false),
+	m_disallow_resolution_control(false),
 	m_renderer(*this, "renderer")
 {
 }
@@ -379,16 +380,19 @@ uint32_t gcm394_base_video_device::screen_update(screen_device &screen, bitmap_r
 
 	//const uint16_t bgcol = 0x7c1f; // magenta
 //  const uint16_t bgcol = 0x0000; // black
-	bool highres;
-	if (m_707f & 0x0010)
+	bool highres = false;
+	if (!m_disallow_resolution_control)
 	{
-		highres = true;
-		m_screen->set_visible_area(0, 640-1, 0, 480-1);
-	}
-	else
-	{
-		highres = false;
-		m_screen->set_visible_area(0, 320-1, 0, 240-1);
+		if (m_707f & 0x0010)
+		{
+			highres = true;
+			m_screen->set_visible_area(0, 640 - 1, 0, 480 - 1);
+		}
+		else
+		{
+			highres = false;
+			m_screen->set_visible_area(0, 320 - 1, 0, 240 - 1);
+		}
 	}
 
 	address_space &mem = m_cpu->space(AS_PROGRAM);

--- a/src/devices/machine/generalplus_gpl16250soc_video.h
+++ b/src/devices/machine/generalplus_gpl16250soc_video.h
@@ -35,6 +35,7 @@ public:
 	void set_alt_tile_addressing(int alt_tile_addressing) { m_alt_tile_addressing = alt_tile_addressing; }
 	void set_alt_extrasprite(int alt_extrasprite_hack) { m_alt_extrasprite_hack = alt_extrasprite_hack; }
 	void set_legacy_video_mode() { m_use_legacy_mode = true; }
+	void set_disallow_resolution_control() { m_disallow_resolution_control = true; }
 
 	void set_video_spaces(address_space& cpuspace, address_space& cs_space, int csbase) { m_cpuspace = &cpuspace; m_cs_space = &cs_space; m_csbase = csbase; }
 
@@ -233,6 +234,7 @@ protected:
 	int m_alt_extrasprite_hack;
 	int m_alt_tile_addressing;
 	bool m_use_legacy_mode; // could be related to the 'unused' bits in the palete bank select being set, but uncertain
+	bool m_disallow_resolution_control;
 
 	required_device<spg_renderer_device> m_renderer;
 

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -34742,6 +34742,7 @@ mog_m320
 myarccn
 nubsupmf
 otrail
+pcmx11
 q5_500in1
 rd5_240
 red5mam
@@ -39351,10 +39352,13 @@ vtennis3                        //
 32xj                            //
 aiwamcd                         // 1994 AIWA Mega-CD CSD-G1M (Japan)
 cdx                             // 1994 Sega CDX (USA)
+dcat16                          //
+gen_nomd                        // 1995 Sega Genesis Nomad (USA)
 genesis                         // 1989 Sega Genesis (USA)
 genesis_tmss                    //
 laseract                        // 1993 Pioneer LaserActive (USA)
 laseractj                       // 1993 Pioneer LaserActive (Japan)
+mahg156
 megacd                          // 1993 Sega Mega-CD (Europe)
 megacd2                         // 1993 Sega Mega-CD 2 (Europe)
 megacd2j                        // 1993 Sega Mega-CD 2 (Japan)
@@ -39362,15 +39366,13 @@ megacda                         // 1993 Sega Mega-CD (Asia)
 megacdj                         // 1991 Sega Mega-CD (Japan)
 megadrij                        // 1988 Sega Mega Drive (Japan)
 megadriv                        // 1990 Sega Mega Drive (Europe)
+megajet                         // 1993 Sega Mega Jet (Japan)
 multmega                        // 1994 Sega Multi-Mega (Europe)
 segacd                          // 1992 Sega Sega CD (USA)
 segacd2                         // 1993 Sega Sega CD 2 (USA)
 wmega                           // 1992 Sega Wondermega (Japan)
 wmegam2                         // 1993 Victor Wondermega M2 (Japan)
 xeye                            // 1993 JVC X'eye (USA)
-dcat16                          //
-gen_nomd                        // 1995 Sega Genesis Nomad (USA)
-megajet                         // 1993 Sega Mega Jet (Japan)
 
 @source:sega/megadriv_acbl.cpp
 aladmdb
@@ -39391,6 +39393,8 @@ twinktmb
 @source:sega/megadriv_rad.cpp
 dgunl3227
 mdtvp1j
+mdtvp2j
+mdtvp3j
 msi_sf2
 ra145
 rad_gen1                        // (c)2004 Radica
@@ -42168,6 +42172,9 @@ elzet80p                        //
 
 @source:skeleton/epic14e.cpp
 epic14e                         //
+
+@source:skeleton/epoch_tv_globe.cpp
+eptvglob
 
 @source:skeleton/esprit.cpp
 esprit                          // Hazeltine Esprit
@@ -45441,6 +45448,7 @@ beambox
 
 @source:tvgames/generalplus_gpl16250_rom.cpp
 beijuehh
+gameu50
 gormiti
 imgame
 myac220
@@ -45490,6 +45498,8 @@ jak_ddhp
 jak_prhp
 kidizmb
 kidizmp
+pocketmp
+pocketmr
 zippity
 zippityuk
 
@@ -45541,6 +45551,7 @@ zone3d
 @source:tvgames/spg2xx.cpp
 ablkickb
 abltenni                        //
+anpantv
 comil                           //
 ddr33v
 decathln
@@ -45719,14 +45730,15 @@ tvgogo                          //
 vii                             // KenSingTon / Jungle Soft / Siatronics Vii
 
 @source:tvgames/spg2xx_wiwi.cpp
-wiwi18                          //
+265games
+ddmmeg12
+ddmsup
 foxsport
+guitrbus
 lexifit
 marc101
 marc250
-guitrbus
-ddmsup
-ddmmeg12
+wiwi18                          //
 
 @source:tvgames/spg2xx_zone.cpp
 wirels60                        // Wireless 60
@@ -45741,17 +45753,20 @@ react
 
 @source:tvgames/st2302u_bbl_rom.cpp
 bbl338
+class200
 dphh8213
 
 @source:tvgames/st2302u_bbl_spi.cpp
-bbl380
-mc_cb203
-rhhc152
-ragc153
-dphh8630
-dgun2953
-supreme
 arcade10
+bbl380
+dgun2953
+dphh8630
+mc_cb203
+pg118
+ragc153
+rhhc152
+supreme
+toumapet
 
 @source:tvgames/titan_soc.cpp
 colecofl
@@ -45771,6 +45786,7 @@ trkfldch                        // (c) 2007 Konami
 tvgame                          // 2011
 
 @source:tvgames/xavix.cpp
+bistro                          //
 ddrfammt                        //
 ekara                           //
 ekaraa                          //
@@ -45788,7 +45804,11 @@ epo_epp2
 epo_epp3                        //
 epo_eppk                        //
 epo_esdx                        //
+epo_esht                        //
 epo_guru                        //
+epo_mms                         //
+epo_mmsp                        //
+epo_quiz                        //
 epo_tenn                        //
 epo_tfp2                        //
 evio                            //
@@ -45834,12 +45854,14 @@ taikodp                         //
 taitons1                        //
 taitons2                        //
 tak_daig
+tak_gin                         //
 tak_geig                        //
 tcarnavi                        //
 tomcpin                         //
 tomshoot                        //
 tomplc                          //
 tvpc_dor
+tvpc_ham
 tvpc_tom
 
 @source:tvgames/xavix2.cpp
@@ -45852,6 +45874,7 @@ duelmast                        //
 epo_ebox                        //
 epo_bowl                        //
 epo_sdb                         //
+tom_dpgm                        //
 ttv_sw                          //
 ttv_lotr                        //
 ttv_mx                          //

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -45806,9 +45806,11 @@ epo_eppk                        //
 epo_esdx                        //
 epo_esht                        //
 epo_guru                        //
+epo_hamd                        //
 epo_mms                         //
 epo_mmsp                        //
 epo_quiz                        //
+epo_strk                        //
 epo_tenn                        //
 epo_tfp2                        //
 evio                            //
@@ -45853,6 +45855,7 @@ rad_ssxp                        //
 taikodp                         //
 taitons1                        //
 taitons2                        //
+tak_comt                        //
 tak_daig
 tak_gin                         //
 tak_geig                        //

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -881,6 +881,10 @@ ROM_START( otrail )
 	ROM_LOAD( "t24c04a.bin", 0x000, 0x200, CRC(ce1fad6f) SHA1(82878996765739edba42042b6336460d5c8f8096) )
 ROM_END
 
+ROM_START( pcmx11 )
+	ROM_REGION( 0x800000, "mainrom", 0 )
+	ROM_LOAD( "pcmx11.bin", 0x000000, 0x800000, CRC(e1f3590b) SHA1(f78f7fc4f9a4474b5a9717dfbfc3199a5bc994ba) )
+ROM_END
 
 void nes_vt369_vtunknown_state::init_lxcmcypp()
 {
@@ -991,6 +995,10 @@ CONS( 201?, 240in1ar,  0,  0,  nes_vt369_vtunknown_cy_bigger, nes_vt369_vtunknow
 // is one of these bad? where do they fit? the former boots, but banking is wrong (incorrect games selected, gfx corruption) the 2nd looks encrypted or bad
 CONS( 2019, unk2019hh,  0,        0,  nes_vt369_vtunknown_hh_8mb, nes_vt369_vtunknown, nes_vt369_vtunknown_unk_state, empty_init, "<unknown>", "unknown VTxx based GameBoy style handheld (2019 PCB)", MACHINE_NOT_WORKING )
 CONS( 2020, unk2020hh,  unk2019hh,0,  nes_vt369_vtunknown_hh_8mb, nes_vt369_vtunknown, nes_vt369_vtunknown_unk_state, empty_init, "<unknown>", "unknown VTxx based GameBoy style handheld (2020 PCB)", MACHINE_NOT_WORKING )
+
+// might be VT-09 or VT-162, uses a ROM glob on a sub-board, data lines seem scrambled at least?
+// NOT the same as the (undumped) vertical handheld console of the same name with Jungletac / Nice Code games, that one has unique games
+CONS( 2009, pcmx11,     0,        0,  nes_vt369_vtunknown_hh_8mb, nes_vt369_vtunknown, nes_vt369_vtunknown_unk_state, empty_init, "Premier Portfolio International",    "Classic Max Pocket PCMX11 - 12 in 1 Colour Games Console (France)", MACHINE_NOT_WORKING )
 
 /*****************************************************************************
 * below are VT369? games that use flash ROM

--- a/src/mame/sega/mdconsole.cpp
+++ b/src/mame/sega/mdconsole.cpp
@@ -323,6 +323,48 @@ ROM_START(dcat16)
 	ROM_REGION( 0x10000, "soundcpu", ROMREGION_ERASEFF)
 ROM_END
 
+
+ROM_START(mahg156)
+	ROM_REGION(0x8000000, "mainrom", ROMREGION_ERASEFF)
+	ROM_LOAD16_WORD_SWAP( "md156.u3", 0x0000,  0x8000000, CRC(665fc68c) SHA1(6b765f96716c4a0abf3d27252ec82be6b0d9a985) )
+
+	ROM_REGION(0x8000000, "maincpu", ROMREGION_ERASEFF)
+//  the Megadrive ROMs for the most part appear to be hacked versions of the games / old scene dumps
+//  some are region locked to differing regions (not all games present in ROM appear on the menu)
+//  ROM_COPY( "mainrom", 0x0000000, 0, 0x080000) // FORGOTTEN WORLDS
+//  ROM_COPY( "mainrom", 0x0080000, 0, 0x080000) // FIRE PRO WRESTLING
+//  ROM_COPY( "mainrom", 0x0100000, 0, 0x080000) // GHOST BUSTERS
+//  ROM_COPY( "mainrom", 0x0180000, 0, 0x080000) // DICK TRACY
+//  ROM_COPY( "mainrom", 0x0200000, 0, 0x080000) // DEVIL CRASH
+//  ROM_COPY( "mainrom", 0x0280000, 0, 0x080000) // DECAP ATTACK
+//  ROM_COPY( "mainrom", 0x0300000, 0, 0x080000) // DARWIN 4081
+//  ROM_COPY( "mainrom", 0x0380000, 0, 0x080000) // CRACK DOWN
+//  ROM_COPY( "mainrom", 0x0400000, 0, 0x080000) // CAPTAIN PLANET
+//  ROM_COPY( "mainrom", 0x0480000, 0, 0x080000) // CALIFORNIA GAMES
+//  ROM_COPY( "mainrom", 0x0500000, 0, 0x080000) // CADASH
+//  ROM_COPY( "mainrom", 0x0580000, 0, 0x080000) // BOOGIE WOOGIE BOWLING
+//  ROM_COPY( "mainrom", 0x0600000, 0, 0x080000) // BIMINI RUN
+//  ROM_COPY( "mainrom", 0x0700000, 0, 0x080000) // BATTLE TOADS
+//  ROM_COPY( "mainrom", 0x0780000, 0, 0x080000) // TROUBLE SHOOTER
+//  ROM_COPY( "mainrom", 0x0800000, 0, 0x080000) // BURNING FORCE
+//  ROM_COPY( "mainrom", 0x0880000, 0, 0x080000) // FAERY TALE ADVENTURE
+//  ROM_COPY( "mainrom", 0x0900000, 0, 0x080000) // E-SWAT
+//  ROM_COPY( "mainrom", 0x0980000, 0, 0x080000) // ELEMENTAL MASTER
+//  ROM_COPY( "mainrom", 0x0a00000, 0, 0x080000) // EA HOCKEY
+//  ROM_COPY( "mainrom", 0x0a80000, 0, 0x080000) // DARK CASTLE
+//  ROM_COPY( "mainrom", 0x0b00000, 0, 0x080000) // CYBORG JUSTICE (CENSOR)
+//  ROM_COPY( "mainrom", 0x0b80000, 0, 0x080000) // LITTLE MERMAID
+//  ROM_COPY( "mainrom", 0x0c00000, 0, 0x080000) // DORAEMON
+//  ROM_COPY( "mainrom", 0x0c80000, 0, 0x080000) // SONIC
+//  ROM_COPY( "mainrom", 0x0d00000, 0, 0x080000) // WANI WANI WORLD
+//  ROM_COPY( "mainrom", 0x0d80000, 0, 0x080000) // GOLDEN AXE 2
+//  etc.
+	ROM_COPY( "mainrom", 0x7800000, 0x00000, 0x200000) // DMC RedKid (Menu, requires unusual rendering mode?)
+
+	ROM_REGION( 0x10000, "soundcpu", ROMREGION_ERASEFF)
+ROM_END
+
+
 ROM_START(megajet)
 	ROM_REGION(MD_CPU_REGION_SIZE, "maincpu", ROMREGION_ERASEFF)
 	ROM_REGION( 0x10000, "soundcpu", ROMREGION_ERASEFF)
@@ -1043,3 +1085,5 @@ CONS( 1993, laseractj,    laseract, 0,      mdj_scd,         md,       md_cons_c
 
 /* clone hardware - not sure if this hardware is running some kind of emulator, or enhanced MD clone, or just custom banking */
 CONS( 200?, dcat16,       0,        0,      dcat16_megadriv, md,       md_cons_slot_state, init_genesis, "Firecore",   "D-CAT16 (Mega Drive handheld)",  MACHINE_NOT_WORKING )
+// seems to be based on the AT games units, requires custom mode for menu?
+CONS( 201?, mahg156,      0,        0,      dcat16_megadriv, md,       md_cons_slot_state, init_genesis, "<unknown>",   "Mini Arcade Handheld Game Console 2.8 Inch Screen Built in 156 Retro Games (Mega Drive handheld)",  MACHINE_NOT_WORKING )

--- a/src/mame/sega/megadriv_rad.cpp
+++ b/src/mame/sega/megadriv_rad.cpp
@@ -524,6 +524,11 @@ ROM_START( rad_sf2uk )
 	ROM_LOAD16_WORD_SWAP( "radica_megadrive_streetfighter2_uk.bin", 0x000000, 0x400000,  CRC(868afb44) SHA1(f4339e36272c18b1d49aa4095127ed18e0961df6) )
 ROM_END
 
+ROM_START( mdtvp3j )
+	ROM_REGION( 0x400000, "maincpu", 0 )
+	ROM_LOAD16_WORD_SWAP( "playtv_vol3.bin", 0x000000, 0x400000,  CRC(d2daf376) SHA1(147b88d7aff834146c649077b43312c71b973298) )
+ROM_END
+
 ROM_START( rad_gen1 )
 	ROM_REGION( 0x400000, "maincpu", 0 )
 	ROM_LOAD16_WORD_SWAP( "radica_megadrive_vol1_blue_usa.bin", 0x000000, 0x400000,  CRC(3b4c8438) SHA1(5ed9c053f9ebc8d4bf571d57e562cf347585d158) )
@@ -552,6 +557,11 @@ ROM_END
 ROM_START( rad_md2uk )
 	ROM_REGION( 0x400000, "maincpu", 0 )
 	ROM_LOAD16_WORD_SWAP( "radica_megadrive_vol2_red_uk.bin", 0x000000, 0x400000, CRC(b68fd025) SHA1(b8f9c505653d6dd2b62840f078f828360faf8abc) )
+ROM_END
+
+ROM_START( mdtvp2j )
+	ROM_REGION( 0x400000, "maincpu", 0 )
+	ROM_LOAD16_WORD_SWAP( "playtv_vol2.bin", 0x000000, 0x400000, CRC(4d887d12) SHA1(b7f70abd12c3a3c68d1ad127a1475b704e898f51) )
 ROM_END
 
 ROM_START( rad_ssoc )
@@ -709,7 +719,6 @@ void megadriv_ra145_state::init_ra145()
 // US versions show 'Genesis' on the menu,    show a www.radicagames.com splash screen, and use NTSC versions of the ROMs, sometimes region locked
 // EU versions show 'Mega Drive' on the menu, show a www.radicagames.com splash screen, and use PAL versions of the ROMs, sometimes region locked
 // UK versions show "Mega Drive' on the menu, show a www.radicauk.com splash screen,    and use PAL versions of the ROMs, sometimes region locked
-// Japanese releases have been seen for at least one of these Radica collections (SF2), those presumably have a different ROM too (NTSC, locked to Japan?)
 
 CONS( 2004, rad_gen1,  0,        0, megadriv_radica_3button_ntsc, radica_3button_1player, megadriv_radica_state, init_megadriv, "Radica / Sega",                     "Genesis Collection Volume 1 (Radica, Arcade Legends) (USA)", 0)
 CONS( 2004, rad_md1,   rad_gen1, 0, megadriv_radica_3button_pal,  radica_3button_1player, megadriv_radica_state, init_megadrie, "Radica / Sega",                     "Mega Drive Collection Volume 1 (Radica, Arcade Legends) (Europe)", 0)
@@ -719,6 +728,7 @@ CONS( 2004, mdtvp1j,   rad_gen1, 0, megadriv_radica_3button_ntsc, radica_3button
 CONS( 2004, rad_gen2,  0,        0, megadriv_radica_3button_ntsc, radica_3button_1player, megadriv_radica_state, init_megadriv, "Radica / Sega",                     "Genesis Collection Volume 2 (Radica, Arcade Legends) (USA)", 0)
 CONS( 2004, rad_md2uk, rad_gen2, 0, megadriv_radica_3button_pal,  radica_3button_1player, megadriv_radica_state, init_megadrie, "Radica / Sega",                     "Mega Drive Collection Volume 2 (Radica, Arcade Legends) (UK)", 0)
 // is there a Europe version with Radica Games boot screen and Mega Drive text?
+CONS( 2004, mdtvp2j,   rad_gen2, 0, megadriv_radica_3button_ntsc, radica_3button_1player, megadriv_radica_state, init_megadriv, "Sega Toys",                         "Mega Drive Play TV 2 (Japan)", 0)
 
 // box calls this Volume 3
 CONS( 2004, rad_sonic,  0,        0, megadriv_radica_3button_ntsc, radica_3button_1player, megadriv_radica_state, init_megadriv, "Radica / Sega",                     "Super Sonic Gold (Radica Plug & Play) (USA)", 0)
@@ -728,6 +738,7 @@ CONS( 2004, rad_sonicuk,rad_sonic,0, megadriv_radica_3button_pal,  radica_3butto
 CONS( 2004, rad_sf2,   0,        0, megadriv_radica_6button_ntsc, radica_6button,         megadriv_radica_state, init_megadriv, "Radica / Capcom / Sega",            "Street Fighter II: Special Champion Edition [Ghouls'n Ghosts] (Radica, Arcade Legends) (USA)", 0)
 CONS( 2004, rad_sf2uk, rad_sf2,  0, megadriv_radica_6button_pal,  radica_6button,         megadriv_radica_state, init_megadrie, "Radica / Capcom / Sega",            "Street Fighter II: Special Champion Edition [Ghouls'n Ghosts] (Radica, Arcade Legends) (UK)", 0)
 // is there a Europe version with Radica Games boot screen and Mega Drive text?
+CONS( 2004, mdtvp3j,   rad_sf2,  0, megadriv_radica_6button_ntsc, radica_6button,         megadriv_radica_state, init_megadriv, "Sega Toys",                         "Mega Drive Play TV 3 (Japan)", 0) // This one does contain the Japanese ROM for SF2 (but the World release of GnG) so SF2 runs in Japanese, but GnG runs in English
 
 // still branded as Arcade Legends even if none of these were ever arcade games, European exclusive
 CONS( 2004, rad_ssoc,  0,        0, megadriv_radica_3button_pal,  radica_3button,         megadriv_radica_state, init_megadrie, "Radica / Sensible Software / Sega", "Sensible Soccer plus [Cannon Fodder, Mega lo Mania] (Radica, Arcade Legends) (UK)", 0)

--- a/src/mame/skeleton/epoch_tv_globe.cpp
+++ b/src/mame/skeleton/epoch_tv_globe.cpp
@@ -1,0 +1,105 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+/******************************************************************************
+
+main SoC is marked
+
+PONTO
+PONTO-1
+QHLL3.03
+TAIWAN 0915
+
+main PCB is marked
+
+LCT REV1.9
+20-K5410100G2
+Tiger-Main
+KTG-KZ003-08
+
+*******************************************************************************/
+
+#include "emu.h"
+
+#include "cpu/arm7/arm7.h"
+
+#include "screen.h"
+#include "speaker.h"
+
+
+namespace {
+
+class epoch_tv_globe_state : public driver_device
+{
+public:
+	epoch_tv_globe_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_screen(*this, "screen")
+	{ }
+
+	void epoch_tv_globe(machine_config &config);
+
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+private:
+	required_device<cpu_device> m_maincpu;
+	required_device<screen_device> m_screen;
+
+	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+
+	void arm_map(address_map &map);
+};
+
+uint32_t epoch_tv_globe_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	return 0;
+}
+
+void epoch_tv_globe_state::machine_start()
+{
+
+}
+
+void epoch_tv_globe_state::machine_reset()
+{
+}
+
+static INPUT_PORTS_START( epoch_tv_globe )
+INPUT_PORTS_END
+
+void epoch_tv_globe_state::arm_map(address_map &map)
+{
+	map(0x00000000, 0x0001ffff).rom().region("maincpu", 0);
+}
+
+
+void epoch_tv_globe_state::epoch_tv_globe(machine_config &config)
+{
+	ARM9(config, m_maincpu, 24000000 * 4); // unknown ARM core, unknown frequency (24Mhz XTAL)
+	m_maincpu->set_addrmap(AS_PROGRAM, &epoch_tv_globe_state::arm_map);
+
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
+	m_screen->set_refresh_hz(60);
+	m_screen->set_size(320, 262);
+	m_screen->set_visarea(0, 320-1, 0, 240-1);
+	m_screen->set_screen_update(FUNC(epoch_tv_globe_state::screen_update));
+
+	SPEAKER(config, "lspeaker").front_left();
+	SPEAKER(config, "rspeaker").front_right();
+}
+
+ROM_START( eptvglob )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASEFF )
+	ROM_LOAD( "a25l010.ic4", 0x000000, 0x20000, CRC(2e28c7a6) SHA1(ea26f8ccb9882e21f3d415af59fc04bdde36db6a) )
+
+	// was also an ATMLH904 device at IC7, but it was empty
+
+	ROM_REGION( 0x8400000, "nand", ROMREGION_ERASEFF )
+	ROM_LOAD( "k9f1g08u0b.ic8", 0x000000, 0x8400000, CRC(f1880c56) SHA1(c50f01f799b3296cda56d05a02a59aa78e0c8422) )
+ROM_END
+
+} // anonymous namespace
+
+CONS( 201?, eptvglob,       0,              0,      epoch_tv_globe, epoch_tv_globe, epoch_tv_globe_state, empty_init, "Epoch", "TV Globe (Japan)", MACHINE_IS_SKELETON )

--- a/src/mame/tvgames/generalplus_gpl16250.h
+++ b/src/mame/tvgames/generalplus_gpl16250.h
@@ -141,4 +141,37 @@ private:
 };
 
 
+class gameu_handheld_game_state : public gcm394_game_state
+{
+public:
+	gameu_handheld_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+		gcm394_game_state(mconfig, type, tag)
+	{
+	}
+
+	virtual uint16_t cs0_r(offs_t offset) override;
+
+	void gameu(machine_config &config);
+
+	void init_gameu();
+
+protected:
+
+	virtual void machine_reset() override;
+
+private:
+	uint32_t m_upperbase = 0U;
+
+	void gameu_porta_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void gameu_portb_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void gameu_portc_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void gameu_portd_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+
+	uint16_t m_porta_data = 0U;
+	uint16_t m_portb_data = 0U;
+	uint16_t m_portc_data = 0U;
+	uint16_t m_portd_data = 0U;
+};
+
+
 #endif // MAME_TVGAMES_SUNPLUS_GCM394_H

--- a/src/mame/tvgames/generalplus_gpl16250.h
+++ b/src/mame/tvgames/generalplus_gpl16250.h
@@ -157,20 +157,20 @@ public:
 
 protected:
 
+	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
 private:
-	uint32_t m_upperbase = 0U;
-
 	void gameu_porta_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void gameu_portb_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void gameu_portc_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void gameu_portd_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 
-	uint16_t m_porta_data = 0U;
-	uint16_t m_portb_data = 0U;
-	uint16_t m_portc_data = 0U;
-	uint16_t m_portd_data = 0U;
+	uint32_t m_upperbase;
+	uint16_t m_porta_data;
+	uint16_t m_portb_data;
+	uint16_t m_portc_data;
+	uint16_t m_portd_data;
 };
 
 

--- a/src/mame/tvgames/generalplus_gpl16250_rom.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_rom.cpp
@@ -484,7 +484,6 @@ ROM_END
 
 ROM_START( gameu50 )
 	ROM_REGION( 0x2000000, "maincpu", ROMREGION_ERASEFF )
-	// ROM seems to be divided into 2MByte banks, so could be external banking
 	ROM_LOAD16_WORD_SWAP( "gameu.bin", 0x000000, 0x2000000, CRC(13c42bce) SHA1(f769ceabb8ab4e60c0d663dffd5cca91c6aec206) )
 ROM_END
 
@@ -524,7 +523,6 @@ uint16_t tkmag220_game_state::cs0_r(offs_t offset)
 	// [:] installing cs0 handler start_address 00000000 end_address 007fffff
 	return m_romregion[(offset & 0x07fffff) + m_upperbase];
 }
-
 
 void tkmag220_game_state::machine_reset()
 {
@@ -639,9 +637,6 @@ void gameu_handheld_game_state::gameu(machine_config &config)
 {
 	gcm394_game_state::base(config);
 
-//  m_maincpu->portb_out().set(FUNC(gameu_handheld_game_state::gameu_portb_w)); // portb is very busy on startup
-	// portd is very busy on startup
-
 	m_maincpu->porta_out().set(FUNC(gameu_handheld_game_state::gameu_porta_w));
 	m_maincpu->portb_out().set(FUNC(gameu_handheld_game_state::gameu_portb_w));
 	m_maincpu->portc_out().set(FUNC(gameu_handheld_game_state::gameu_portc_w));
@@ -694,6 +689,20 @@ void gameu_handheld_game_state::gameu_portd_w(offs_t offset, uint16_t data, uint
 	}
 
 }
+void gameu_handheld_game_state::machine_start()
+{
+	m_upperbase = 0;
+	m_porta_data = 0;
+	m_portb_data = 0;
+	m_portc_data = 0;
+	m_portd_data = 0;
+
+	save_item(NAME(m_upperbase));
+	save_item(NAME(m_porta_data));
+	save_item(NAME(m_portb_data));
+	save_item(NAME(m_portc_data));
+	save_item(NAME(m_portd_data));
+}
 
 void gameu_handheld_game_state::machine_reset()
 {
@@ -711,10 +720,8 @@ void gameu_handheld_game_state::init_gameu()
 	{
 		ROM[i] = ROM[i] ^ 0x3b90;
 
-		ROM[i] = bitswap<16>(ROM[i], 8, 7, 13,  15,  4,  5,  12,  10,
-									 3,  1,  11,  9,  6,  14,  0, 2);
-
-		ROM[i] = ((ROM[i] & 0xff00) >> 8) | ((ROM[i] & 0x00ff) << 8);
+		ROM[i] = bitswap<16>(ROM[i], 3, 1, 11, 9,  6, 14, 0,  2,
+									 8, 7, 13, 15, 4, 5,  12, 10);
 	}
 
 	m_maincpu->set_alt_tile_addressing_hack(0);

--- a/src/mame/tvgames/generalplus_gpl16250_rom.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_rom.cpp
@@ -366,6 +366,25 @@ static INPUT_PORTS_START( tkmag220 )
 INPUT_PORTS_END
 
 
+static INPUT_PORTS_START( gameu )
+	PORT_START("IN0")
+	PORT_BIT( 0xffff, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START("IN1")
+	PORT_BIT( 0xffff, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START("IN2") // P2 inputs are listed in test mode, but unit has no 2nd set of controls
+	PORT_BIT( 0x001f, IP_ACTIVE_LOW, IPT_UNUSED )
+	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_JOYSTICK_UP )
+	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN )
+	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT )
+	PORT_BIT( 0x0100, IP_ACTIVE_LOW, IPT_JOYSTICK_RIGHT )
+	PORT_BIT( 0x0200, IP_ACTIVE_LOW, IPT_START1 )
+	PORT_BIT( 0x0400, IP_ACTIVE_LOW, IPT_BUTTON1 )
+	PORT_BIT( 0x0800, IP_ACTIVE_LOW, IPT_BUTTON2 )
+	PORT_BIT( 0x1000, IP_ACTIVE_LOW, IPT_BUTTON3 )
+	PORT_BIT( 0xe000, IP_ACTIVE_LOW, IPT_UNUSED )
+INPUT_PORTS_END
 
 static INPUT_PORTS_START( beijuehh )
 	PORT_START("IN0")
@@ -461,6 +480,15 @@ ROM_START( beijuehh )
 	ROM_REGION( 0x8000000, "maincpu", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "beijeu.bin", 0x0000000, 0x8000000, CRC(e7b968af) SHA1(a39a3a70e6e0827e4395e09e55983eb9e9348e4a) ) // some address lines might be swapped
 ROM_END
+
+
+ROM_START( gameu50 )
+	ROM_REGION( 0x2000000, "maincpu", ROMREGION_ERASEFF )
+	// ROM seems to be divided into 2MByte banks, so could be external banking
+	ROM_LOAD16_WORD_SWAP( "gameu.bin", 0x000000, 0x2000000, CRC(13c42bce) SHA1(f769ceabb8ab4e60c0d663dffd5cca91c6aec206) )
+ROM_END
+
+
 
 void tkmag220_game_state::tkmag220(machine_config &config)
 {
@@ -607,14 +635,108 @@ void beijuehh_game_state::machine_reset()
 
 
 
+void gameu_handheld_game_state::gameu(machine_config &config)
+{
+	gcm394_game_state::base(config);
 
+//  m_maincpu->portb_out().set(FUNC(gameu_handheld_game_state::gameu_portb_w)); // portb is very busy on startup
+	// portd is very busy on startup
 
+	m_maincpu->porta_out().set(FUNC(gameu_handheld_game_state::gameu_porta_w));
+	m_maincpu->portb_out().set(FUNC(gameu_handheld_game_state::gameu_portb_w));
+	m_maincpu->portc_out().set(FUNC(gameu_handheld_game_state::gameu_portc_w));
+	m_maincpu->portd_out().set(FUNC(gameu_handheld_game_state::gameu_portd_w));
+
+	m_screen->set_refresh_hz(30); // too fast at 60, but maybe it's for other reasons?
+	m_screen->set_visarea(0, (160)-1, 0, (128)-1); // appears to be the correct resolution for the LCD panel
+}
 
 void gormiti_game_state::machine_reset()
 {
 	gcm394_game_state::machine_reset();
 	m_maincpu->set_alt_tile_addressing_hack(1);
 }
+
+uint16_t gameu_handheld_game_state::cs0_r(offs_t offset)
+{
+	return m_romregion[(offset & 0x00fffff) + m_upperbase];
+}
+
+void gameu_handheld_game_state::gameu_porta_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	logerror("%s: porta write %04x\n", machine().describe_context(), data);
+	m_porta_data = data;
+}
+
+void gameu_handheld_game_state::gameu_portb_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	logerror("%s: portb write %04x\n", machine().describe_context(), data);
+	m_portb_data = data;
+}
+
+void gameu_handheld_game_state::gameu_portc_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	logerror("%s: portc write %04x\n", machine().describe_context(), data);
+	m_portc_data = data;
+}
+
+void gameu_handheld_game_state::gameu_portd_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	// hacky, maybe we need better direction/attribute handling on the ports in the core?
+	m_portd_data = data;
+	//int pc = m_maincpu->pc();
+	//if ((pc != 0x2b49) && (pc != 0x2b34) && (pc != 0x2b8b) && (pc != 0x2bc0))
+	{
+		logerror("%s: portd write %04x %04x\n", machine().describe_context(), data, mem_mask);
+
+		m_upperbase = (data & 0xfc00) >> 10;
+		m_upperbase *= 0x40000;
+	}
+
+}
+
+void gameu_handheld_game_state::machine_reset()
+{
+	gcm394_game_state::machine_reset();
+	m_maincpu->set_alt_tile_addressing_hack(1);
+	m_upperbase = 0;
+}
+
+void gameu_handheld_game_state::init_gameu()
+{
+	uint16_t *ROM = (uint16_t*)memregion("maincpu")->base();
+	int size = memregion("maincpu")->bytes();
+
+	for (int i = 0; i < size/2; i++)
+	{
+		ROM[i] = ROM[i] ^ 0x3b90;
+
+		ROM[i] = bitswap<16>(ROM[i], 8, 7, 13,  15,  4,  5,  12,  10,
+									 3,  1,  11,  9,  6,  14,  0, 2);
+
+		ROM[i] = ((ROM[i] & 0xff00) >> 8) | ((ROM[i] & 0x00ff) << 8);
+	}
+
+	m_maincpu->set_alt_tile_addressing_hack(0);
+	m_maincpu->set_disallow_resolution_control();
+
+	// why do we need these? it will jump to 0 after the menu selection (prior to fadeout and bank select) otherwise, which can't be correct
+
+	ROM[0x19c9a / 2] = 0xF165;
+	ROM[0x19c9c / 2] = 0xF165;
+	ROM[0x19c9e / 2] = 0xF165;
+
+	ROM[0x19cb8 / 2] = 0xF165;
+	ROM[0x19cba / 2] = 0xF165;
+	ROM[0x19cbc / 2] = 0xF165;
+
+	ROM[0x19cd4 / 2] = 0xF165;
+	ROM[0x19cd6 / 2] = 0xF165;
+	ROM[0x19cd8 / 2] = 0xF165;
+
+
+}
+
 
 
 // the JAKKS ones of these seem to be known as 'Generalplus GPAC500' hardware?
@@ -641,3 +763,6 @@ CONS(201?, beijuehh,    0,       0, beijuehh, beijuehh, beijuehh_game_state,  em
 CONS(2013, gormiti,   0, 0, base, gormiti,  gormiti_game_state, empty_init, "Giochi Preziosi", "Gormiti Game Arena (Spain)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
 // Fun 2 Learn 3-in-1 SMART SPORTS  ?
+
+// unit looks a bit like a knock-off Wii-U tablet, but much smaller
+CONS( 201?, gameu50,       0,              0,      gameu, gameu, gameu_handheld_game_state, init_gameu, "YSN", "Play Portable Color GameU+ (50-in-1) (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )

--- a/src/mame/tvgames/generalplus_gpl16250_rom.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_rom.cpp
@@ -722,19 +722,17 @@ void gameu_handheld_game_state::init_gameu()
 
 	// why do we need these? it will jump to 0 after the menu selection (prior to fadeout and bank select) otherwise, which can't be correct
 
-	ROM[0x19c9a / 2] = 0xF165;
-	ROM[0x19c9c / 2] = 0xF165;
-	ROM[0x19c9e / 2] = 0xF165;
+	ROM[0x19c9a / 2] = 0xf165;
+	ROM[0x19c9c / 2] = 0xf165;
+	ROM[0x19c9e / 2] = 0xf165;
 
-	ROM[0x19cb8 / 2] = 0xF165;
-	ROM[0x19cba / 2] = 0xF165;
-	ROM[0x19cbc / 2] = 0xF165;
+	ROM[0x19cb8 / 2] = 0xf165;
+	ROM[0x19cba / 2] = 0xf165;
+	ROM[0x19cbc / 2] = 0xf165;
 
-	ROM[0x19cd4 / 2] = 0xF165;
-	ROM[0x19cd6 / 2] = 0xF165;
-	ROM[0x19cd8 / 2] = 0xF165;
-
-
+	ROM[0x19cd4 / 2] = 0xf165;
+	ROM[0x19cd6 / 2] = 0xf165;
+	ROM[0x19cd8 / 2] = 0xf165;
 }
 
 

--- a/src/mame/tvgames/generalplus_gpl16250_rom.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_rom.cpp
@@ -689,8 +689,8 @@ void gameu_handheld_game_state::gameu_portd_w(offs_t offset, uint16_t data, uint
 	{
 		logerror("%s: portd write %04x %04x\n", machine().describe_context(), data, mem_mask);
 
-		m_upperbase = (data & 0xfc00) >> 10;
-		m_upperbase *= 0x40000;
+		uint8_t bank = (data & 0xfc00) >> 10;
+		m_upperbase = bank * 0x40000;
 	}
 
 }

--- a/src/mame/tvgames/generalplus_gpl32612.cpp
+++ b/src/mame/tvgames/generalplus_gpl32612.cpp
@@ -45,6 +45,7 @@ public:
 	void gpl32612(machine_config &config);
 
 	void nand_init840();
+	void nand_init880();
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
@@ -264,25 +265,34 @@ ROM_END
 
 // uncertain hardware type, ARM based, has GPNAND strings
 ROM_START( zippity )
-	ROM_REGION( 0x10800000, "nandrom", ROMREGION_ERASE00 )
+	ROM_REGION( 0x10800000, "nand", ROMREGION_ERASE00 )
 	ROM_LOAD( "zippity_mt29f2g08aacwp_2cda8015.bin", 0x0000, 0x10800000, CRC(16248b63) SHA1(3607337588a68052ef5c495b496aa3e0449d3eb6) )
 ROM_END
 
 ROM_START( zippityuk )
-	ROM_REGION( 0x10800000, "nandrom", ROMREGION_ERASE00 )
+	ROM_REGION( 0x10800000, "nand", ROMREGION_ERASE00 )
 	ROM_LOAD( "29f2c08aacwp.u2", 0x0000, 0x10800000, CRC(27d172ae) SHA1(9ade19d7aa28fba13581e6879b39e3a7702260b0) )
 ROM_END
 
 ROM_START( kidizmp )
-	ROM_REGION( 0x10800000, "nandrom", ROMREGION_ERASE00 )
+	ROM_REGION( 0x10800000, "nand", ROMREGION_ERASE00 )
 	ROM_LOAD( "s34ml02g1_withspare.u13", 0x0000, 0x10800000, CRC(c5d55bdc) SHA1(073fc3fd56c532750b4e2020abe27d3448999d56) )
 ROM_END
 
 ROM_START( kidizmb )
-	ROM_REGION(  0x8400000, "nandrom", ROMREGION_ERASE00 )
+	ROM_REGION(  0x8400000, "nand", ROMREGION_ERASE00 )
 	ROM_LOAD( "hy27uf081g2a_withspare.bin", 0x0000, 0x8400000, CRC(b87861c4) SHA1(8b5cc2557b54a37928be818430b91c48db98758f) )
 ROM_END
 
+ROM_START( pocketmp )
+	ROM_REGION(  0x8800000, "nand", ROMREGION_ERASE00 )
+	ROM_LOAD( "tc58nvg0s3hta00.u3", 0x0000, 0x8800000, CRC(aabf2deb) SHA1(ee3118377c21b1fb28ff262484c9b587b394bd80) )
+ROM_END
+
+ROM_START( pocketmr )
+	ROM_REGION(  0x8800000, "nand", ROMREGION_ERASE00 )
+	ROM_LOAD( "tc58nvg0s3hta00_withspare.u6", 0x0000, 0x8800000, CRC(ec839dde) SHA1(18b77c7e1cf3c66787ccfde9f450671e3d1b0e36) )
+ROM_END
 
 
 void generalplus_gpl32612_game_state::nand_init(int blocksize, int blocksize_stripped)
@@ -324,6 +334,12 @@ void generalplus_gpl32612_game_state::nand_init840()
 	bootstrap();
 }
 
+void generalplus_gpl32612_game_state::nand_init880()
+{
+	nand_init(0x880, 0x800);
+	bootstrap();
+}
+
 } // anonymous namespace
 
 
@@ -340,6 +356,9 @@ CONS( 201?, zippity,         0,       0,      zippity, gpl32612, generalplus_zip
 CONS( 201?, zippityuk,       zippity, 0,      zippity, gpl32612, generalplus_zippity_game_state, empty_init,  "LeapFrog",         "Zippity (UK)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
 
 // GP32C01 (maybe, picture is unclear) - Camera for kids
-CONS( 2013, kidizmp,         0,        0,      zippity, gpl32612, generalplus_zippity_game_state, empty_init,  "VTech",         "Kidizoom Connect (Germany, pink camera)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS( 2013, kidizmp,         0,        0,      gpl32612, gpl32612, generalplus_gpl32612_game_state, empty_init,  "VTech",         "Kidizoom Connect (Germany, pink camera)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
 // seems to be older tech, just glob + ROM, assuming it's a GP32 series based on above and due to having ARM code
-CONS( 201?, kidizmb,         0,        0,      zippity, gpl32612, generalplus_zippity_game_state, empty_init,  "VTech",         "Kidizoom (Germany, blue camera)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS( 201?, kidizmb,         0,        0,      gpl32612, gpl32612, generalplus_gpl32612_game_state, empty_init,  "VTech",         "Kidizoom (Germany, blue camera)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+
+CONS( 2019, pocketmp,        0,        0,      gpl32612, gpl32612, generalplus_gpl32612_game_state, nand_init880,  "Takara Tomy",        "Pocket Monsters PC",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS( 2019, pocketmr,        0,        0,      gpl32612, gpl32612, generalplus_gpl32612_game_state, nand_init880,  "Takara Tomy",        "Pocket Monsters Rotom Tablet",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)

--- a/src/mame/tvgames/spg2xx.cpp
+++ b/src/mame/tvgames/spg2xx.cpp
@@ -2325,6 +2325,10 @@ ROM_START( ddr33v )
 	ROM_LOAD16_WORD_SWAP( "ddr33v.bin", 0x000000, 0x800000, CRC(56c7015c) SHA1(a1faef2ab6eb191dea1497f8cfd4ccbd8c504e6d) )
 ROM_END
 
+ROM_START( anpantv )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "anpanman_tv.bin", 0x000000, 0x800000, CRC(5e32dc1a) SHA1(bae260ffc56f5315cdafd5bc40966ec6d31e267f) )
+ROM_END
 
 void spg2xx_game_state::init_crc()
 {
@@ -2503,3 +2507,6 @@ CONS( 200?, virtten,    0,        0, spg2xx,    virtten,   spg2xx_game_state,   
 // 2007 ingame, 2008 on box.  Hyperkin is mentioned as being the registered trademark holder alongside DDRGame on the box.
 // Songs "composed by Kenneth Baylon"
 CONS( 2008, ddr33v,     0,        0, spg2xx,    ddr33v,    spg2xx_game_ddr33v_state,   init_ddr33v,   "DDRGame / Hyperkin",                                    "16-bit TV Dance Pad with 15 songs / Dance Dance Party Mix (DDRGame)",   MACHINE_IMPERFECT_SOUND )
+
+// PCB has 'Anpanman TV 2006 Ver 1.4' printed on it, ROM has SPG260 header.  Uses custom built-in keyboard, no display built into the unit.
+CONS( 2006, anpantv,    0,        0, spg2xx,    spg2xx,    spg2xx_game_state,          empty_init,    "Bandai",                                                "Anpanman TV (Japan)",                                                   MACHINE_NOT_WORKING )

--- a/src/mame/tvgames/spg2xx_wiwi.cpp
+++ b/src/mame/tvgames/spg2xx_wiwi.cpp
@@ -818,7 +818,7 @@ void spg2xx_game_marc250_state::init_m527()
 	//rom[((17 * 0x800000) / 2) | 0x015e58] = 0x0003;
 	// cliff overhang / gym dancing
 	//rom[((18 * 0x800000) / 2) | 0x01cab4] = 0x0003;
-	rom[((18 * 0x800000) / 2) | 0x021e25] = 0xffff; // secondary 'turn off'
+	rom[((18 * 0x800000) / 2) | 0x021e25] = 0xffff; // secondary 'turn off' on gym dancing
 	// jump chess
 	//rom[((19 * 0x800000) / 2) | 0x012c3a] = 0x0003;
 	// boxing, basketball etc.
@@ -969,6 +969,12 @@ ROM_START( marc250 )
 	ROM_LOAD16_WORD_SWAP( "m527.u6", 0x0000000, 0x10000000, CRC(4b856cab) SHA1(41c66bbdb0bb1442d7e11da18e9e6b20048445ba) )
 ROM_END
 
+ROM_START( 265games )
+	ROM_REGION( 0x10000000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "265games.bin", 0x0000000, 0x10000000, CRC(761c92cb) SHA1(3e32bc6079610861bedafe8703302ed9620c9120) )
+ROM_END
+
+
 ROM_START( guitrbus )
 	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "winfunguitar.bin", 0x000000, 0x400000, CRC(17419a27) SHA1(19377fcd18b08d3ae8e20de0244b3aaef1b5a66a) )
@@ -1004,7 +1010,9 @@ CONS( 200?, ddmsup,      0,        0, ddmsup, ddmsup,  spg2xx_game_ddmsup_state,
 
 CONS( 2007, ddmmeg12,    0,        0, ddmsup, ddmsup,  spg2xx_game_ddmsup_state,  empty_init,    "Senario",  "Double Dance Mania: Mega 12",  MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 
-CONS( 2015, marc250,     0,        0, marc101, m489,  spg2xx_game_marc250_state, init_m527, "Millennium 2000 GmbH", "Millennium Arcade 250 (M527)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+CONS( 2015, marc250,     0,        0, marc101, m489,  spg2xx_game_marc250_state, init_m527, "Millennium 2000 GmbH", "Millennium Arcade 250 (M527)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+
+CONS( 201?, 265games,    0,        0, marc101, m489,  spg2xx_game_marc250_state, init_m527, "<unknown>", "265-in-1 Handheld Game (SPG2xx based)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 
 // has the following strings at the start of the ROM
 // "Copyright(C) 2009-2012 ShenZhen Multi-Content Software CO., LTD"

--- a/src/mame/tvgames/st2302u_bbl_rom.cpp
+++ b/src/mame/tvgames/st2302u_bbl_rom.cpp
@@ -380,11 +380,20 @@ ROM_START( dphh8213 )
 	ROM_FILL( 0x00009f, 2, 0xea ) // NOP out SPI check
 ROM_END
 
+ROM_START( class200 )
+	// uncertain if internal area is used
+
+	ROM_REGION( 0x400000, "maincpu", 0 )
+	ROM_LOAD( "m29w320eb.bin", 0x000000, 0x400000, CRC(3067b5f6) SHA1(9a159b16898054a74cfb32b5c597b505132f004e) )
+ROM_END
+
 } // anonymous namespace
 
 
 // this is uses a higher resolution display than the common units, but not as high as the SunPlus based ones
-COMP( 201?, bbl338, 0,      0,      st22xx_bbl338, dphh8213, st22xx_bbl338_sim_state, empty_init, "BaoBaoLong", "Portable Game Player BBL-338 (BaoBaoLong, 48-in-1)", MACHINE_IS_SKELETON )
+COMP( 201?, bbl338,   0,      0,      st22xx_bbl338, dphh8213, st22xx_bbl338_sim_state, empty_init, "BaoBaoLong", "Portable Game Player BBL-338 (BaoBaoLong, 48-in-1)", MACHINE_IS_SKELETON )
+// also appears to be the higher resolution display
+COMP( 201?, class200, 0,      0,      st22xx_dphh8213, dphh8213, st22xx_bbl338_state, empty_init, "<unknown>", "Color LCD Classic Game 200-in-1", MACHINE_IS_SKELETON ) // no manufacturer name or product code anywhere
 
 // Language controlled by port bit, set at factory, low resolution
 COMP( 201?, dphh8213, 0,      0,      st22xx_dphh8213, dphh8213, st22xx_bbl338_state, empty_init, "<unknown>", "Digital Pocket Hand Held System 20-in-1 - Model 8213", MACHINE_IS_SKELETON )

--- a/src/mame/tvgames/st2302u_bbl_spi.cpp
+++ b/src/mame/tvgames/st2302u_bbl_spi.cpp
@@ -367,26 +367,49 @@ ROM_START(supreme)
 	ROM_LOAD("25q32.bin", 0x000000, 0x400000, CRC(93072a3d) SHA1(9f8770839032922e64d5ddd8864441357623c45f))
 ROM_END
 
+ROM_START(pg118)
+	ROM_REGION(0x800000, "maincpu", ROMREGION_ERASEFF)
+	ROM_LOAD("st2x_internal.bin", 0x002000, 0x002000, BAD_DUMP CRC(f4dc1fc2) SHA1(bbc11539c48eb612ebae50da45e03b6fde440941)) // internal OTPROM BIOS, dumped from dgun2953 PCB, 6000-7fff range
+
+	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_LOAD("25vq32.bin", 0x000000, 0x400000, CRC(e99f1621) SHA1(f907c36a1a884d892331b7de294a8fd58f7bf9d5) )
+ROM_END
+
+ROM_START(toumapet)
+	ROM_REGION(0x800000, "maincpu", ROMREGION_ERASEFF)
+	ROM_LOAD("st2x_internal.bin", 0x002000, 0x002000, BAD_DUMP CRC(f4dc1fc2) SHA1(bbc11539c48eb612ebae50da45e03b6fde440941)) // internal OTPROM BIOS, dumped from dgun2953 PCB, 6000-7fff range
+
+	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_LOAD("p25d32sh.bin", 0x000000, 0x400000, CRC(25498f00) SHA1(c5c410e29f540d7f1fd4bbb333467f8a3eaccc15) )
+ROM_END
+
+
 } // anonymous namespace
 
 
 // older releases (primarily for Asian market?)
 
-CONS( 201?, bbl380,        0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "BaoBaoLong", "BBL380 - 180 in 1", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+CONS( 201?, bbl380,        0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "BaoBaoLong", "BBL380 - 180 in 1", MACHINE_NOT_WORKING )
 
-CONS( 201?, mc_cb203,      0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Coolboy", "Coolboy RS-17 - 203 in 1", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+CONS( 201?, mc_cb203,      0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Coolboy", "Coolboy RS-17 - 203 in 1", MACHINE_NOT_WORKING )
 
 // newer releases (more heavily censored, for export markets?) internal ROM was changed for these
 
-CONS( 201?, dphh8630,      0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "<unknown>", "Digital Pocket Hand Held System 230-in-1 - Model 8630 / Model 8633", MACHINE_NOT_WORKING | MACHINE_NO_SOUND ) // sometimes sold as PCP.  Model 8630/8633 are same ROM, different case
+CONS( 201?, dphh8630,      0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "<unknown>", "Digital Pocket Hand Held System 230-in-1 - Model 8630 / Model 8633", MACHINE_NOT_WORKING ) // sometimes sold as PCP.  Model 8630/8633 are same ROM, different case
 
-CONS( 201?, rhhc152,       0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Orb", "Retro Handheld Console 152-in-1", MACHINE_NOT_WORKING | MACHINE_NO_SOUND ) // looks like a mini GameBoy - 'Over 150 games' on box
+CONS( 201?, rhhc152,       0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Orb", "Retro Handheld Console 152-in-1", MACHINE_IMPERFECT_SOUND ) // looks like a mini GameBoy - 'Over 150 games' on box
 
-CONS( 201?, ragc153,       0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Orb", "Retro Arcade Game Controller 153-in-1", MACHINE_NOT_WORKING | MACHINE_NO_SOUND ) // looks like a Game & Watch
+CONS( 201?, ragc153,       0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Orb", "Retro Arcade Game Controller 153-in-1", MACHINE_IMPERFECT_SOUND ) // looks like a Game & Watch
 
-CONS( 201?, dgun2953,      0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "dreamGEAR", "My Arcade Gamer Mini 160-in-1 (DGUN-2953)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+CONS( 201?, dgun2953,      0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "dreamGEAR", "My Arcade Gamer Mini 160-in-1 (DGUN-2953)", MACHINE_IMPERFECT_SOUND )
 
-CONS( 201?, arcade10,      0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Fizz Creations", "Mini Arcade Console (Arcade 10-in-1)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+CONS( 201?, arcade10,      0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Fizz Creations", "Mini Arcade Console (Arcade 10-in-1)", MACHINE_IMPERFECT_SOUND )
 
-CONS( 201?, supreme,       0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Fizz Creations", "Arcade Classics Mini Handheld Arcade (Supreme 150)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+CONS( 201?, supreme,       0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Fizz Creations", "Arcade Classics Mini Handheld Arcade (Supreme 150)", MACHINE_IMPERFECT_SOUND )
+
+// these are for the Japanese market, the ROM is the same between the Pocket Game and Game Computer but the form factor is different.
+// they have the 0xE4 XOR on the SPI data like many of the above units, but don't currently boot - need to verify if the internal ROM part should be the same or not
+CONS( 2019, pg118,         0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Pocket Game / Game Computer", "Pocket Game 118-in-1 / Game Computer 118-in-1", MACHINE_NOT_WORKING )
+// also has the 0xE4 XOR, also doesn't currently boot
+CONS( 2021, toumapet,      0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Shenzhen Shiji New Technology", "Tou ma Pet", MACHINE_NOT_WORKING )
 

--- a/src/mame/tvgames/xavix.cpp
+++ b/src/mame/tvgames/xavix.cpp
@@ -2342,14 +2342,14 @@ CONS( 2001, rad_bassp, rad_bass,   0,  xavixp,           rad_bassp,xavix_state, 
 CONS( 2001, rad_snow,  0,          0,  xavix_nv,         rad_snow, xavix_state,          init_xavix,    "Radica / SSD Company LTD",                     "Play TV Snowboarder (Blue) (NTSC)", MACHINE_IMPERFECT_SOUND )
 CONS( 2001, rad_snowp, rad_snow,   0,  xavixp_nv,        rad_snowp,xavix_state,          init_xavix,    "Radica / SSD Company LTD",                     "ConnecTV Snowboarder (Blue) (PAL)", MACHINE_IMPERFECT_SOUND )
 
-CONS( 2003, rad_madf,  0,          0,  xavix_madfb,      rad_fb,   xavix_madfb_state,    init_xavix,    "Radica / Electronics Arts / SSD Company LTD",  "EA Sports Madden Football (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND ) // no Play TV branding, USA only release?
+CONS( 2003, rad_madf,  0,          0,  xavix_madfb,      rad_fb,   xavix_madfb_state,    init_xavix,    "Radica / Electronic Arts / SSD Company LTD",  "EA Sports Madden Football (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND ) // no Play TV branding, USA only release?
 
 CONS( 200?, rad_fb,    0,          0,  xavix_madfb,      rad_fb,   xavix_madfb_state,    init_xavix,    "Radica / SSD Company LTD",                     "Play TV Football (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND ) // USA only release? doesn't change logo for PAL.
 
 CONS( 200?, rad_rh,    0,          0,  xavix,            rad_rh,   xavix_state,          init_xavix,    "Radica / Fisher-Price / SSD Company LTD",      "Play TV Rescue Heroes (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
-CONS( 2004, rad_ssx,   0,          0,  xavix,            rad_snow, xavix_state,          init_xavix,    "Radica / Electronics Arts / SSD Company LTD",  "Play TV SSX Snowboarder (NTSC)", MACHINE_IMPERFECT_SOUND )
-CONS( 2004, rad_ssxp,  rad_ssx,    0,  xavixp,           rad_snowp,xavix_state,          init_xavix,    "Radica / Electronics Arts / SSD Company LTD",  "ConnecTV SSX Snowboarder (PAL)", MACHINE_IMPERFECT_SOUND )
+CONS( 2004, rad_ssx,   0,          0,  xavix,            rad_snow, xavix_state,          init_xavix,    "Radica / Electronic Arts / SSD Company LTD",  "Play TV SSX Snowboarder (NTSC)", MACHINE_IMPERFECT_SOUND )
+CONS( 2004, rad_ssxp,  rad_ssx,    0,  xavixp,           rad_snowp,xavix_state,          init_xavix,    "Radica / Electronic Arts / SSD Company LTD",  "ConnecTV SSX Snowboarder (PAL)", MACHINE_IMPERFECT_SOUND )
 
 // basically a reissue of SSX but without the license
 CONS( 2006, rad_sbw,   0,          0,  xavix,            rad_snow, xavix_state,          init_xavix,    "Radica / SSD Company LTD",                     "Play TV Snowboarder (White) (NTSC)", MACHINE_IMPERFECT_SOUND )

--- a/src/mame/tvgames/xavix.cpp
+++ b/src/mame/tvgames/xavix.cpp
@@ -2359,20 +2359,20 @@ CONS( 2002, epo_dmon, 0,           0,  xavix_i2c_24c02,  xavix_i2c,xavix_i2c_sta
 CONS( 2003, epo_crok,  0,          0,  xavix_i2c_24lc04, xavix_i2c,xavix_i2c_state,      init_xavix,    "Epoch / SSD Company LTD",                      "Croket! Itada Kinka! Banker Battle!! (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // ミニモニ。ステージ！ダンスだぴょん！
-CONS( 2002, epo_mms,   0,          0,  xavix_i2c_24c02,  epo_mms,  xavix_i2c_state,      init_xavix,    "Epoch / SSD Company LTD",                      "Mini-Moni Stage! Dance Dapyon! (Japan)",  MACHINE_IMPERFECT_SOUND )
+CONS( 2002, epo_mms,   0,          0,  xavix_i2c_24c02,  epo_mms,  xavix_i2c_state,      init_xavix,    "Epoch / SSD Company LTD",                      "mini-moni Stage! Dance Dapyon! (Japan)",  MACHINE_IMPERFECT_SOUND )
 
 // ミニモニ。ステージ！ダンスだぴょん！ぷらすっ
-CONS( 2003, epo_mmsp,  0,          0,  xavix_i2c_24c02,  epo_mms,  xavix_i2c_state,      init_xavix,    "Epoch / SSD Company LTD",                      "Mini-Moni Stage! Dance Dapyon! Plus (Japan)",  MACHINE_IMPERFECT_SOUND )
+CONS( 2003, epo_mmsp,  0,          0,  xavix_i2c_24c02,  epo_mms,  xavix_i2c_state,      init_xavix,    "Epoch / SSD Company LTD",                      "mini-moni Stage! Dance Dapyon! Plus (Japan)",  MACHINE_IMPERFECT_SOUND )
 
 // オールスター感謝祭　超豪華！クイズ決定版～赤坂５丁目体感スタジオ～
-CONS( 2004, epo_quiz,  0,          0,  xavix,            epo_quiz, xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "All-Star Thanksgiving Super Luxurious! Definitive Quiz Edition ~ Akasaka 5-Chome Experience Studio", MACHINE_IMPERFECT_SOUND )
+CONS( 2004, epo_quiz,  0,          0,  xavix,            epo_quiz, xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "All-Star Kansha-sai Chou Gouka! Quiz Kettieban: Akasaka 5-choume Taikan Studio (Japan)", MACHINE_IMPERFECT_SOUND )
 
 CONS( 2005, has_wamg,  0,          0,  xavix,            has_wamg, xavix_state,          init_xavix,    "Hasbro / Milton Bradley / SSD Company LTD",    "TV Wild Adventure Mini Golf (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 CONS( 2002, tak_geig,  0,          0,  xavix_nv,         tak_geig, xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "Geigeki Go Go Shooting (Japan)", MACHINE_IMPERFECT_SOUND )
 
 // 爆進スノボ ギンギンボーダーズ
-CONS( 2001, tak_gin,   0,          0,  xavix,            tak_gin,  xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "Gin-gin Boarders (Japan)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_COLORS )
+CONS( 2001, tak_gin,   0,          0,  xavix,            tak_gin,  xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "Bakushin Sno-Bo - Gingin Boarders (Japan)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_COLORS )
 
 // was also distributed by Atlus as an arcade cabinet in 2005, ROM almost certainly different (this one will auto-power off after inactivity, an arcade wouldn't do that)
 CONS( 2003, jarajal,   0,          0,  xavix_nv,         jarajal,  xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "Jara-Ja Land (Japan, home version)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )

--- a/src/mame/tvgames/xavix.cpp
+++ b/src/mame/tvgames/xavix.cpp
@@ -2359,7 +2359,7 @@ CONS( 2002, rad_bdp,   0,          0,  xavix,            rad_bdp,  xavix_state, 
 
 CONS( 2002, rad_socr,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Radica / Epoch / SSD Company LTD",             "Play TV Soccer", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 // ゴール決めるぜ！ エキサイトストライカー
-CONS( 2001, epo_strk,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Striker (Japan", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+CONS( 2001, epo_strk,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Striker (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 // A UK branded Epoch version (no Radica involvement) also exists, but so far all units seen have been 'no TSOP pads' cases
 
 CONS( 2002, rad_jcon,  0,          0,  xavix,            rad_jcon, xavix_state,          init_xavix,    "Radica / Takara / SSD Company LTD",            "Play TV Jr. Construction", MACHINE_IMPERFECT_SOUND )

--- a/src/mame/tvgames/xavix.cpp
+++ b/src/mame/tvgames/xavix.cpp
@@ -2304,12 +2304,16 @@ ROM_END
 
 */
 
+// Let's!TVプレイCLASSIC タイトーノスタルジア1 
 CONS( 2006, taitons1,  0,          0,  xavix_i2c_24lc04, nostalgia,xavix_i2c_state,      init_xavix,    "Bandai / SSD Company LTD / Taito",             "Let's! TV Play Classic - Taito Nostalgia 1 (Japan)", MACHINE_IMPERFECT_SOUND )
 
+// Let's!TVプレイCLASSIC タイトーノスタルジア2
 CONS( 2006, taitons2,  0,          0,  xavix_i2c_24lc04, nostalgia,xavix_i2c_state,      init_xavix,    "Bandai / SSD Company LTD / Taito",             "Let's! TV Play Classic - Taito Nostalgia 2 (Japan)", MACHINE_IMPERFECT_SOUND )
 
+// Let's!TVプレイCLASSIC ナムコノスタルジア1
 CONS( 2006, namcons1,  0,          0,  xavix_i2c_24lc04, nostalgia,xavix_i2c_state,      init_xavix,    "Bandai / SSD Company LTD / Namco",             "Let's! TV Play Classic - Namco Nostalgia 1 (Japan)", MACHINE_IMPERFECT_SOUND )
 
+// Let's!TVプレイCLASSIC ナムコノスタルジア2
 CONS( 2006, namcons2,  0,          0,  xavix_i2c_24lc04, nostalgia,xavix_i2c_state,      init_xavix,    "Bandai / SSD Company LTD / Namco",             "Let's! TV Play Classic - Namco Nostalgia 2 (Japan)", MACHINE_IMPERFECT_SOUND )
 
 CONS( 2000, rad_ping,  0,          0,  xavix,            rad_ping, xavix_state,          init_xavix,    "Radica / SSD Company LTD / Simmer Technology", "Play TV Ping Pong (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND ) // "Simmer Technology" is also known as "Hummer Technology Co., Ltd"
@@ -2396,6 +2400,7 @@ CONS( 2005, epo_guru,  0,          0,  xavix_guru,       epo_guru, xavix_guru_st
 // ドラえもん こえでドカン！わくわくくうきほう！！
 CONS( 2002, epo_dmon, 0,           0,  xavix_i2c_24c02,  xavix_i2c,xavix_i2c_state,      init_xavix,    "Epoch / SSD Company LTD",                      "Doraemon Wakuwaku Kuukihou (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND ) // full / proper title?
 
+// コロッケ！いただ禁貨！バンカーバトル!! 
 CONS( 2003, epo_crok,  0,          0,  xavix_i2c_24lc04, xavix_i2c,xavix_i2c_state,      init_xavix,    "Epoch / SSD Company LTD",                      "Croket! Itada Kinka! Banker Battle!! (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // ミニモニ。ステージ！ダンスだぴょん！
@@ -2425,10 +2430,13 @@ CONS( 2003, jarajal,   0,          0,  xavix_nv,         jarajal,  xavix_state, 
 // 射的王
 CONS( 2002, tomshoot, 0,           0,  xavix_i2c_24c02,  tomshoot,xavix_i2c_tomshoot_state,  init_xavix,    "Tomy / SSD Company LTD",                       "Shooting King (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
+// トミカ カーナビドライブ / トミー 
 CONS( 2003, tcarnavi,  0,          0,  xavix_nv,         tcarnavi, xavix_state,          init_xavix,    "Tomy / SSD Company LTD",                       "Tomica Carnavi Drive (Japan)", MACHINE_IMPERFECT_SOUND )
 
+// ちゃんぴよんピンボール
 CONS( 2003, tomcpin,   0,          0,  xavix_i2c_24c08,  tomcpin,  xavix_i2c_state,      init_xavix,    "Tomy / SSD Company LTD",                       "Champiyon Pinball (Japan)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 
+// 日本一周 僕はプラレール運転士
 CONS( 2004, tomplc,    0,          0,  xavix_i2c_24c02_43mhz,tomplc,xavix_i2c_state,     init_xavix,    "Tomy / SSD Company LTD",                       "Nihon Isshuu - Boku wa Plarail Untenshi (Japan)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 
 // ガンガンアドベンチャー 
@@ -2458,16 +2466,23 @@ CONS( 2003, epitch,   0,           0,  xavix_cart_ekara, ekara,    xavix_ekara_s
 // e-kara mix was another unit that allowed you to connect to a PC, unlike e-kara web it also functions as a regular device
 CONS( 200?, ekaramix, 0,           0,  xavix_cart_ekara, ekara,    xavix_ekara_state,    init_xavix,    "Takara / SSD Company LTD",                     "e-kara Mix (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND /*| MACHINE_IS_BIOS_ROOT*/ )
 
+// ダンスダンスレボリューション　ふぁみマット
 CONS( 2001, ddrfammt, 0,           0,  xavix_cart_ddrfammt,ddrfammt, xavix_cart_state,   init_xavix,    "Takara / Konami / SSD Company LTD",            "Dance Dance Revolution Family Mat (Japan)", MACHINE_IMPERFECT_SOUND/*|MACHINE_IS_BIOS_ROOT*/ )
 
+// ポピラ
 CONS( 2000, popira,   0,           0,  xavix_cart_popira,popira,   xavix_cart_state,     init_xavix,    "Takara / SSD Company LTD",                     "Popira (Japan)", MACHINE_IMPERFECT_SOUND/*|MACHINE_IS_BIOS_ROOT*/ ) // The original Popira is a single yellow unit
+// a Korean version exists from Sonokong brand, with different songs
 
+// ポピラ2 
 CONS( 2002, popira2,  0,           0,  xavix_cart_popira2,popira2,  xavix_popira2_cart_state, init_xavix,    "Takara / SSD Company LTD",                 "Popira 2 (Japan)", MACHINE_IMPERFECT_SOUND/*|MACHINE_IS_BIOS_ROOT*/ ) // Popira 2 is a set of 2 blue & green linked units (2nd unit is just a controller, no CPU or TV out)
 
+// たいこでポピラ
 CONS( 2003, taikodp,  0,           0,  xavix_i2c_taiko,  taikodp,  xavix_i2c_cart_state, init_xavix,    "Takara / SSD Company LTD",                     "Taiko de Popira (Japan)", MACHINE_IMPERFECT_SOUND /*|MACHINE_IS_BIOS_ROOT*/ ) // inputs? are the drums analog?
 
+// ジャンピンポピラ
 CONS( 2004, jpopira,  0,           0,  xavix_i2c_jpopira,jpopira,  xavix_i2c_cart_state, init_xavix,    "Takara / SSD Company LTD",                     "Jumping Popira (Japan)", MACHINE_IMPERFECT_SOUND /*|MACHINE_IS_BIOS_ROOT*/ )
 
+// evio
 CONS( 2003, evio,     0,           0,  xavix_cart_evio,  evio,     xavix_evio_cart_state,init_xavix,    "Tomy / SSD Company LTD",                       "Evio (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND /*|MACHINE_IS_BIOS_ROOT*/ ) // inputs? it's a violin controller
 
 
@@ -2482,8 +2497,12 @@ CONS( 2006, ltv_tam,  0,           0,  xavix_i2c_24lc04_tam,  ltv_tam,xavix_i2c_
 
 CONS( 2008, hikara,   0,           0,  xavix_cart_hikara, hikara,    xavix_hikara_state,    init_xavix,    "Takara Tomy / SSD Company LTD",            "Hi-kara (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND /*| MACHINE_IS_BIOS_ROOT*/ )
 
+// 東京フレンドパーク2 
 CONS( 2003, epo_tfp2,  0,          0,  xavix_i2c_24c08,  epo_tfp2, xavix_i2c_state, init_xavix, "Epoch / SSD Company LTD", "Tokyo Friend Park 2 (Japan)", MACHINE_IMPERFECT_SOUND) // uses in24lc08b
 
+// きかんしゃトーマス テレビパソコン
 CONS( 2005, tvpc_tom,  0,          0,  xavix_i2c_24c16,  tvpc_tom, xavix_i2c_state, init_xavix, "Epoch / SSD Company LTD", "TV-PC Thomas & Friends (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+// ドラえもん テレビパソコン
 CONS( 2003, tvpc_dor,  0,          0,  xavix_i2c_24c16,  tvpc_tom, xavix_i2c_state, init_xavix, "Epoch / SSD Company LTD", "TV-PC Doraemon (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+// とっとこハム太郎 テレビパソコン
 CONS( 2003, tvpc_ham,  0,          0,  xavix_i2c_24c16,  tvpc_tom, xavix_i2c_state, init_xavix, "Epoch / SSD Company LTD", "TV-PC Tottoko Hamutaro (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)

--- a/src/mame/tvgames/xavix.cpp
+++ b/src/mame/tvgames/xavix.cpp
@@ -1076,6 +1076,14 @@ static INPUT_PORTS_START( tak_geig )
 
 INPUT_PORTS_END
 
+static INPUT_PORTS_START( tak_comt )
+	PORT_INCLUDE(xavix)
+
+	PORT_MODIFY("IN1")
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_UNKNOWN ) // needed to boot, might read inputs through this bit
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_POWER_OFF ) PORT_NAME("Power Switch") // pressing this will turn the game off.
+INPUT_PORTS_END
+
 static INPUT_PORTS_START( tak_gin )
 	PORT_INCLUDE(xavix)
 
@@ -2011,6 +2019,12 @@ ROM_START( rad_socr )
 	ROM_LOAD("soccer.u4", 0x400000, 0x200000, CRC(e0e2c488) SHA1(907511d945dec51782af268a94b372dfeb7517c5) )
 ROM_END
 
+ROM_START( epo_strk )
+	ROM_REGION(0x800000, "bios", ROMREGION_ERASE00)
+	ROM_LOAD("excitestriker.u5", 0x000000, 0x100000, CRC(fa3f95fd) SHA1(d3bc7f2f321b81a7783887b29218bf711c0d5518) )
+	ROM_LOAD("excitestriker.u4", 0x400000, 0x200000, CRC(0f37ca15) SHA1(b35aaf7f5adddba57c898538f157146bb4d1f9b4) )
+ROM_END
+
 ROM_START( rad_jcon )
 	ROM_REGION(0x800000, "bios", ROMREGION_ERASE00)
 	ROM_LOAD("jrconstr_u5.bin", 0x000000, 0x200000, CRC(306699d2) SHA1(121b04bb598d4531db53e497be9270449bb8ffe4) )
@@ -2060,6 +2074,11 @@ ROM_END
 ROM_START( tak_geig )
 	ROM_REGION(0x400000, "bios", ROMREGION_ERASE00)
 	ROM_LOAD("geigeki.bin", 0x000000, 0x400000, CRC(bd0c3576) SHA1(06f614dbec0225ce4ed866b98450912986d72faf) )
+ROM_END
+
+ROM_START( tak_comt )
+	ROM_REGION(0x200000, "bios", ROMREGION_ERASE00)
+	ROM_LOAD("comet.u3", 0x000000, 0x200000, CRC(407c5566) SHA1(41d73c34af8cc3d07a34fcac0bc1856442c94200) )
 ROM_END
 
 ROM_START( jarajal )
@@ -2245,6 +2264,12 @@ ROM_START( epo_tenn )
 	ROM_LOAD( "excitetennis.u2", 0x400000, 0x200000, CRC(6c2cdc90) SHA1(3c5b391e5e7b4a9a73038ef619df564143724437) )
 ROM_END
 
+ROM_START( epo_hamd )
+	ROM_REGION(0x800000, "bios", ROMREGION_ERASE00)
+	ROM_LOAD( "hamster.u2", 0x000000, 0x100000, CRC(6c2d9d98) SHA1(89a8e6d236ea3dadb882e3ecf12e41bd50222710) )
+	ROM_LOAD( "hamster.u3", 0x400000, 0x200000, CRC(e437c8d0) SHA1(f57c54a73ed38826f4b98610a0aa1f15cf95614d) )
+ROM_END
+
 ROM_START( tvpc_tom )
 	ROM_REGION(0x400000, "bios", ROMREGION_ERASE00 )
 	ROM_LOAD( "tvpc_thomas.u1", 0x000000, 0x400000, CRC(507f334e) SHA1(d66efd13f166fcd2a66133dc981c8a67b2a26d5f) )
@@ -2333,27 +2358,42 @@ CONS( 2006, rad_sbw,   0,          0,  xavix,            rad_snow, xavix_state, 
 CONS( 2002, rad_bdp,   0,          0,  xavix,            rad_bdp,  xavix_state,          init_xavix,    "Radica / Mattel / SSD Company LTD",            "Barbie Dance Party", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 
 CONS( 2002, rad_socr,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Radica / Epoch / SSD Company LTD",             "Play TV Soccer", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+// ゴール決めるぜ！ エキサイトストライカー
+CONS( 2001, epo_strk,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Striker (Japan", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+// A UK branded Epoch version (no Radica involvement) also exists, but so far all units seen have been 'no TSOP pads' cases
 
 CONS( 2002, rad_jcon,  0,          0,  xavix,            rad_jcon, xavix_state,          init_xavix,    "Radica / Takara / SSD Company LTD",            "Play TV Jr. Construction", MACHINE_IMPERFECT_SOUND )
 
+// 勝負しようぜ！ エキサイトスタジアムDX
 CONS( 2002, epo_esdx,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Stadium DX (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
+// 阪神タイガース エキサイトスタジアムＤＸ
 CONS( 2003, epo_esht,  0,          0,  xavix_nv,         epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Stadium DX - Hanshin Tigers (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // interrupt issues after the title screen cause it to hang
+// エースきめるぜ！エキサイトテニス
 CONS( 2002, epo_tenn,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Tennis (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
+// ハムちゃんず大集合 ダンスするのだ！走るのだ！
+CONS( 2001, epo_hamd,  0,          0,  xavix,            xavix,    xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Ham-chans Gather Together to Dance! Run! (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+
+// 卓球やろうぜ！ エキサイトピンポン
 CONS( 2000, epo_epp,   0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Ping Pong (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 CONS( 2000, epo_eppk,  epo_epp,    0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD / Sonokong",           "Real Ping Pong (Korea)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
+// 卓球やろうぜ！ エキサイトピンポン2
 CONS( 2003, epo_epp2,   0,         0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Ping Pong 2 (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
+// 愛ちゃんに挑戦！エキサイトピンポン
 CONS( 2006, epo_epp3,   0,         0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Challenge Ai-chan! Excite Ping Pong (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
+// 大モノ釣ろうぜ！ エキサイトフィッシングＤＸ 
 CONS( 2003, epo_efdx,  0,          0,  xavix_i2c_24c08,  epo_efdx, xavix_i2c_state,      init_xavix,    "Epoch / SSD Company LTD",                      "Excite Fishing DX (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
+// ぐるりんワールド 
 CONS( 2005, epo_guru,  0,          0,  xavix_guru,       epo_guru, xavix_guru_state,     init_xavix,    "Epoch / SSD Company LTD",                      "Gururin World (Japan)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 
+// ドラえもん こえでドカン！わくわくくうきほう！！
 CONS( 2002, epo_dmon, 0,           0,  xavix_i2c_24c02,  xavix_i2c,xavix_i2c_state,      init_xavix,    "Epoch / SSD Company LTD",                      "Doraemon Wakuwaku Kuukihou (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND ) // full / proper title?
 
 CONS( 2003, epo_crok,  0,          0,  xavix_i2c_24lc04, xavix_i2c,xavix_i2c_state,      init_xavix,    "Epoch / SSD Company LTD",                      "Croket! Itada Kinka! Banker Battle!! (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
@@ -2369,14 +2409,20 @@ CONS( 2004, epo_quiz,  0,          0,  xavix,            epo_quiz, xavix_state, 
 
 CONS( 2005, has_wamg,  0,          0,  xavix,            has_wamg, xavix_state,          init_xavix,    "Hasbro / Milton Bradley / SSD Company LTD",    "TV Wild Adventure Mini Golf (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
+// GEIGEKI ゴーゴーシューティング
 CONS( 2002, tak_geig,  0,          0,  xavix_nv,         tak_geig, xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "Geigeki Go Go Shooting (Japan)", MACHINE_IMPERFECT_SOUND )
+
+// コメットさん☆ラブリンバトン 
+CONS( 2001, tak_comt,  0,          0,  xavix_nv,         tak_comt,  xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "Comet-san Lovelin Baton (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // 爆進スノボ ギンギンボーダーズ
 CONS( 2001, tak_gin,   0,          0,  xavix,            tak_gin,  xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "Bakushin Sno-Bo - Gingin Boarders (Japan)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_COLORS )
 
 // was also distributed by Atlus as an arcade cabinet in 2005, ROM almost certainly different (this one will auto-power off after inactivity, an arcade wouldn't do that)
+// ジャラジャランド
 CONS( 2003, jarajal,   0,          0,  xavix_nv,         jarajal,  xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "Jara-Ja Land (Japan, home version)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
+// 射的王
 CONS( 2002, tomshoot, 0,           0,  xavix_i2c_24c02,  tomshoot,xavix_i2c_tomshoot_state,  init_xavix,    "Tomy / SSD Company LTD",                       "Shooting King (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 CONS( 2003, tcarnavi,  0,          0,  xavix_nv,         tcarnavi, xavix_state,          init_xavix,    "Tomy / SSD Company LTD",                       "Tomica Carnavi Drive (Japan)", MACHINE_IMPERFECT_SOUND )
@@ -2385,10 +2431,13 @@ CONS( 2003, tomcpin,   0,          0,  xavix_i2c_24c08,  tomcpin,  xavix_i2c_sta
 
 CONS( 2004, tomplc,    0,          0,  xavix_i2c_24c02_43mhz,tomplc,xavix_i2c_state,     init_xavix,    "Tomy / SSD Company LTD",                       "Nihon Isshuu - Boku wa Plarail Untenshi (Japan)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 
+// ガンガンアドベンチャー 
 CONS( 2001, gungunad,  0,          0,  xavix_nv,         xavix,    xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "Gun Gun Adventure (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
+// ガンガンレボリューション
 CONS( 2004, gungunrv,  0,          0,  xavix_i2c_24lc04, gungunrv, xavix_i2c_state,      init_xavix,    "Takara / SSD Company LTD",                     "Gun Gun Revolution (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
+// ビストロキッズ ぼくもわたしもコックさん！
 CONS( 2001, bistro,    0,          0,  xavix,            xavix,    xavix_state,          init_xavix,    "Sega Toys / SSD Company LTD",                  "Bistro Kids (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 

--- a/src/mame/tvgames/xavix.cpp
+++ b/src/mame/tvgames/xavix.cpp
@@ -2363,36 +2363,36 @@ CONS( 2002, rad_bdp,   0,          0,  xavix,            rad_bdp,  xavix_state, 
 
 CONS( 2002, rad_socr,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Radica / Epoch / SSD Company LTD",             "Play TV Soccer", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 // ゴール決めるぜ！ エキサイトストライカー
-CONS( 2001, epo_strk,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Striker (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+CONS( 2001, epo_strk,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Goal Kimeruze! Excite Striker (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 // A UK branded Epoch version (no Radica involvement) also exists, but so far all units seen have been 'no TSOP pads' cases
 
 CONS( 2002, rad_jcon,  0,          0,  xavix,            rad_jcon, xavix_state,          init_xavix,    "Radica / Takara / SSD Company LTD",            "Play TV Jr. Construction", MACHINE_IMPERFECT_SOUND )
 
 // 勝負しようぜ！ エキサイトスタジアムDX
-CONS( 2002, epo_esdx,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Stadium DX (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+CONS( 2002, epo_esdx,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Shoubu Shiyouze! Excite Stadium DX (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // 阪神タイガース エキサイトスタジアムＤＸ
-CONS( 2003, epo_esht,  0,          0,  xavix_nv,         epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Stadium DX - Hanshin Tigers (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+CONS( 2003, epo_esht,  0,          0,  xavix_nv,         epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Hanshin Tigers Excite Stadium DX (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // interrupt issues after the title screen cause it to hang
 // エースきめるぜ！エキサイトテニス
-CONS( 2002, epo_tenn,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Tennis (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+CONS( 2002, epo_tenn,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Ace Kimeruze! Excite Tennis (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // ハムちゃんず大集合 ダンスするのだ！走るのだ！
-CONS( 2001, epo_hamd,  0,          0,  xavix,            xavix,    xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Ham-chans Gather Together to Dance! Run! (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+CONS( 2001, epo_hamd,  0,          0,  xavix,            xavix,    xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Ham-chans Dai Shuugou Dance Surunoda! Hashirunoda! (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // 卓球やろうぜ！ エキサイトピンポン
-CONS( 2000, epo_epp,   0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Ping Pong (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+CONS( 2000, epo_epp,   0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Takkyuu Yarouze! Excite Ping Pong (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 CONS( 2000, epo_eppk,  epo_epp,    0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD / Sonokong",           "Real Ping Pong (Korea)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // 卓球やろうぜ！ エキサイトピンポン2
-CONS( 2003, epo_epp2,   0,         0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Ping Pong 2 (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+CONS( 2003, epo_epp2,   0,         0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Takkyuu Yarouze! Excite Ping Pong 2 (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // 愛ちゃんに挑戦！エキサイトピンポン
-CONS( 2006, epo_epp3,   0,         0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Challenge Ai-chan! Excite Ping Pong (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+CONS( 2006, epo_epp3,   0,         0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Ai-chan ni Chousen! Excite Ping Pong (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // 大モノ釣ろうぜ！ エキサイトフィッシングＤＸ 
-CONS( 2003, epo_efdx,  0,          0,  xavix_i2c_24c08,  epo_efdx, xavix_i2c_state,      init_xavix,    "Epoch / SSD Company LTD",                      "Excite Fishing DX (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+CONS( 2003, epo_efdx,  0,          0,  xavix_i2c_24c08,  epo_efdx, xavix_i2c_state,      init_xavix,    "Epoch / SSD Company LTD",                      "Dai Mono Tsurouze! Excite Fishing DX (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // ぐるりんワールド 
 CONS( 2005, epo_guru,  0,          0,  xavix_guru,       epo_guru, xavix_guru_state,     init_xavix,    "Epoch / SSD Company LTD",                      "Gururin World (Japan)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
@@ -2446,7 +2446,7 @@ CONS( 2001, gungunad,  0,          0,  xavix_nv,         xavix,    xavix_state, 
 CONS( 2004, gungunrv,  0,          0,  xavix_i2c_24lc04, gungunrv, xavix_i2c_state,      init_xavix,    "Takara / SSD Company LTD",                     "Gun Gun Revolution (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // ビストロキッズ ぼくもわたしもコックさん！
-CONS( 2001, bistro,    0,          0,  xavix,            xavix,    xavix_state,          init_xavix,    "Sega Toys / SSD Company LTD",                  "Bistro Kids (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+CONS( 2001, bistro,    0,          0,  xavix,            xavix,    xavix_state,          init_xavix,    "Sega Toys / SSD Company LTD",                  "Bistro Kids: Boku mo Watashi mo Kok-san! (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 
 /* Music titles: Emulation note:

--- a/src/mame/tvgames/xavix.cpp
+++ b/src/mame/tvgames/xavix.cpp
@@ -326,7 +326,7 @@ void xavix_state::xavix_lowbus_map(address_map &map)
 	map(0x6ffb, 0x6ffb).ram().w(FUNC(xavix_state::dispctrl_posirq_y_w)).share("posirq_y"); // increases / decreases when you jump in snowboard (snowboard, used to blank ground)
 
 	// Lightgun / pen 1 control
-	// map(0x6ffc, 0x6fff)
+	map(0x6ffc, 0x6fff).r(FUNC(xavix_state::lightgun_r));
 
 	// Sound RAM (tested by Gun Gun Revolution, games don't write here, so it's probably just RAM the sound hardware makes use of directly when mixing)
 	map(0x7400, 0x757f).ram();
@@ -541,6 +541,32 @@ static INPUT_PORTS_START( xavix_i2c )
 
 	PORT_MODIFY("IN1")
 	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER("i2cmem", i2cmem_device, read_sda)
+INPUT_PORTS_END
+
+static INPUT_PORTS_START( epo_mms )
+	PORT_INCLUDE(xavix_i2c)
+
+	PORT_MODIFY("IN0")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_NAME("Pad 1 - Pink")
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_NAME("Pad 2 - Orange")
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_NAME("Pad 3 - Purple")
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_BUTTON4 ) PORT_NAME("Pad 4 - Green")
+
+INPUT_PORTS_END
+
+static INPUT_PORTS_START( tomshoot )
+	PORT_INCLUDE(xavix_i2c)
+
+	PORT_MODIFY("IN0")
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER(1)
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER(2)
+
+	PORT_START("GUN1_0")
+	PORT_BIT( 0xff, 0x80, IPT_LIGHTGUN_X ) PORT_CROSSHAIR(X, 1.0, 0.0, 0) PORT_SENSITIVITY(35) PORT_KEYDELTA(15) PORT_PLAYER(1)
+
+	PORT_START("GUN1_1")
+	PORT_BIT( 0xff, 0x80, IPT_LIGHTGUN_Y ) PORT_CROSSHAIR(Y, 1.0, 0.0, 0) PORT_SENSITIVITY(35) PORT_KEYDELTA(15) PORT_PLAYER(1)
+
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( gungunrv )
@@ -1050,6 +1076,15 @@ static INPUT_PORTS_START( tak_geig )
 
 INPUT_PORTS_END
 
+static INPUT_PORTS_START( tak_gin )
+	PORT_INCLUDE(xavix)
+
+	PORT_MODIFY("IN0")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP )
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN )
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT )
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT )
+INPUT_PORTS_END
 
 static INPUT_PORTS_START( rad_bb )
 	PORT_INCLUDE(xavix)
@@ -1368,6 +1403,40 @@ static INPUT_PORTS_START( tcarnavi )
 	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_POWER_OFF ) PORT_NAME("Power Switch") // pressing this will turn the game off.
 INPUT_PORTS_END
 
+
+static INPUT_PORTS_START( epo_quiz )
+	PORT_INCLUDE(xavix)
+
+	PORT_MODIFY("IN0")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER(1) PORT_NAME("P1 A / 1 / Red / Down")
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER(1) PORT_NAME("P1 B / 2 / Blue / Select")
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER(1) PORT_NAME("P1 C / 3 / Yellow / Left")
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_BUTTON4 ) PORT_PLAYER(1) PORT_NAME("P1 D / 4 / Green / Right")
+
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER(2) PORT_NAME("P2 A / 1 / Red / Down")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER(2) PORT_NAME("P2 B / 2 / Blue / Select")
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER(2) PORT_NAME("P2 C / 3 / Yellow / Left")
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_BUTTON4 ) PORT_PLAYER(2) PORT_NAME("P2 D / 4 / Green / Right")
+
+	PORT_MODIFY("IN1")
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER(3) PORT_NAME("P3 A / 1 / Red / Down")
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER(3) PORT_NAME("P3 B / 2 / Blue / Select")
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER(3) PORT_NAME("P3 C / 3 / Yellow / Left")
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_BUTTON4 ) PORT_PLAYER(3) PORT_NAME("P3 D / 4 / Green / Right")
+
+	PORT_MODIFY("AN0")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER(4) PORT_NAME("P4 A / 1 / Red / Down")
+	PORT_MODIFY("AN6")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER(4) PORT_NAME("P4 B / 2 / Blue / Select")
+	PORT_MODIFY("AN1")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER(4) PORT_NAME("P4 C / 3 / Yellow / Left")
+	PORT_MODIFY("AN4")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_BUTTON4 ) PORT_PLAYER(4) PORT_NAME("P4 D / 4 / Green / Right")
+
+	//PORT_MODIFY("AN7")
+	//PORT_BIT( 0xff, IP_ACTIVE_HIGH, IPT_BUTTON8 ) // battery status
+
+INPUT_PORTS_END
 
 /* correct, 4bpp gfxs */
 static const gfx_layout char16layout =
@@ -1910,6 +1979,11 @@ ROM_START( epo_esdx )
 	ROM_LOAD("baseballdx.bin", 0x000000, 0x400000, CRC(fe2e832e) SHA1(e6343f5e5f52316538d918d0d67c15764aa40f65) )
 ROM_END
 
+ROM_START( epo_esht ) // ESTJ-MAIN REV:0 PCB
+	ROM_REGION(0x400000, "bios", ROMREGION_ERASE00)
+	ROM_LOAD("tigers.u3", 0x000000, 0x400000, CRC(51a17ef3) SHA1(864190e91775716218be3ac0699570844d67d3e7) )
+ROM_END
+
 ROM_START( epo_epp )
 	ROM_REGION(0x100000, "bios", ROMREGION_ERASE00)
 	ROM_LOAD("excitepingpong.bin", 0x000000, 0x100000, CRC(1fdb9cbd) SHA1(8ed0c1f6d2708ab6e79f0b9553e587c6446e8338) )
@@ -1973,6 +2047,16 @@ ROM_START( epo_crok )
 	ROM_LOAD("sgm3244.u2", 0x000000, 0x400000, CRC(a801779b) SHA1(e6e4235dc7c7db3073737b10ba4bc5b00deca2c3) )
 ROM_END
 
+ROM_START( epo_mms )
+	ROM_REGION( 0x400000, "bios", ROMREGION_ERASE00)
+	ROM_LOAD("mmnj-main-4.u4", 0x000000, 0x400000, CRC(22f14ca2) SHA1(122e735eb7c54a22de16f65cd43d2cae788e0102) )
+ROM_END
+
+ROM_START( epo_mmsp )
+	ROM_REGION( 0x400000, "bios", ROMREGION_ERASE00)
+	ROM_LOAD("mm1j main-00.u1", 0x000000, 0x400000, CRC(65b40a27) SHA1(8f88973122277fe8f31bacb3a070609fde062946) )
+ROM_END
+
 ROM_START( tak_geig )
 	ROM_REGION(0x400000, "bios", ROMREGION_ERASE00)
 	ROM_LOAD("geigeki.bin", 0x000000, 0x400000, CRC(bd0c3576) SHA1(06f614dbec0225ce4ed866b98450912986d72faf) )
@@ -2023,6 +2107,10 @@ ROM_START( gungunrv )
 	ROM_LOAD("gungunrevolution.u1", 0x000000, 0x400000, CRC(4e34f624) SHA1(7acdd0991df78ecffd156381817ed4f85f6aef09) )
 ROM_END
 
+ROM_START( bistro )
+	ROM_REGION(0x200000, "bios", ROMREGION_ERASE00)
+	ROM_LOAD("bistro.u2", 0x000000, 0x200000, CRC(40865e05) SHA1(597a615c61f29c6f6e7ce997a229175cb151242f) )
+ROM_END
 
 /*
     The e-kara cartridges require the BIOS rom to map into 2nd external bus space as they fetch palette data from
@@ -2133,6 +2221,12 @@ ROM_START( tak_daig )
 	ROM_RELOAD(0x000000, 0x200000)
 ROM_END
 
+// ASKJ MAIN-09 PCB
+ROM_START( epo_quiz )
+	ROM_REGION( 0x800000, "bios", ROMREGION_ERASE00 )
+	ROM_LOAD( "quizmaster.u1", 0x000000, 0x400000, CRC(e91868b8) SHA1(0128603d755731dafe328b142292dc6e5fe00d78) )
+ROM_END
+
 
 // ガチンコ勝負！ パチスロTV
 ROM_START( gcslottv )
@@ -2160,6 +2254,18 @@ ROM_START( tvpc_dor )
 	ROM_REGION(0x400000, "bios", ROMREGION_ERASE00 )
 	ROM_LOAD( "tvpc_doreamon.u3", 0x000000, 0x400000, CRC(6f2edbb2) SHA1(98fa86f85e00aa40e7a585ff0bc930cb5ca88362) )
 ROM_END
+
+ROM_START( tvpc_ham )
+	ROM_REGION(0x400000, "bios", ROMREGION_ERASE00 )
+	ROM_LOAD( "hpcj.u3", 0x000000, 0x400000, CRC(76e8c854) SHA1(5998c03292a16107d0d7ae00f77677582680f323) )
+ROM_END
+
+ROM_START( tak_gin ) // dumped from a PCB with 1x ROM Glob with TSOP pads, 1x unknown glob, 1x CPU glob.  It also exists in a configuration with just 1x ROM glob (no pads) and 1x CPU glob - unknown if code is the same
+	ROM_REGION(0x200000, "bios", ROMREGION_ERASE00 )
+	ROM_LOAD( "snowboard.bin", 0x000000, 0x200000, CRC(79fdeae3) SHA1(ab08790e95cdccf3541ecbddb87ebf0dedb3718b) )
+ROM_END
+
+
 
 /* XaviX hardware titles (1st Generation)
 
@@ -2232,6 +2338,8 @@ CONS( 2002, rad_jcon,  0,          0,  xavix,            rad_jcon, xavix_state, 
 
 CONS( 2002, epo_esdx,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Stadium DX (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
+CONS( 2003, epo_esht,  0,          0,  xavix_nv,         epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Stadium DX - Hanshin Tigers (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+
 // interrupt issues after the title screen cause it to hang
 CONS( 2002, epo_tenn,  0,          0,  xavix,            epo_epp,  xavix_state,          init_xavix,    "Epoch / SSD Company LTD",                      "Excite Tennis (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
@@ -2250,14 +2358,26 @@ CONS( 2002, epo_dmon, 0,           0,  xavix_i2c_24c02,  xavix_i2c,xavix_i2c_sta
 
 CONS( 2003, epo_crok,  0,          0,  xavix_i2c_24lc04, xavix_i2c,xavix_i2c_state,      init_xavix,    "Epoch / SSD Company LTD",                      "Croket! Itada Kinka! Banker Battle!! (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
+// ミニモニ。ステージ！ダンスだぴょん！
+CONS( 2002, epo_mms,   0,          0,  xavix_i2c_24c02,  epo_mms,  xavix_i2c_state,      init_xavix,    "Epoch / SSD Company LTD",                      "Mini-Moni Stage! Dance Dapyon! (Japan)",  MACHINE_IMPERFECT_SOUND )
+
+// ミニモニ。ステージ！ダンスだぴょん！ぷらすっ
+CONS( 2003, epo_mmsp,  0,          0,  xavix_i2c_24c02,  epo_mms,  xavix_i2c_state,      init_xavix,    "Epoch / SSD Company LTD",                      "Mini-Moni Stage! Dance Dapyon! Plus (Japan)",  MACHINE_IMPERFECT_SOUND )
+
+// オールスター感謝祭　超豪華！クイズ決定版～赤坂５丁目体感スタジオ～
+CONS( 2004, epo_quiz,  0,          0,  xavix,            epo_quiz, xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "All-Star Thanksgiving Super Luxurious! Definitive Quiz Edition ~ Akasaka 5-Chome Experience Studio", MACHINE_IMPERFECT_SOUND )
+
 CONS( 2005, has_wamg,  0,          0,  xavix,            has_wamg, xavix_state,          init_xavix,    "Hasbro / Milton Bradley / SSD Company LTD",    "TV Wild Adventure Mini Golf (NTSC)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 CONS( 2002, tak_geig,  0,          0,  xavix_nv,         tak_geig, xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "Geigeki Go Go Shooting (Japan)", MACHINE_IMPERFECT_SOUND )
 
+// 爆進スノボ ギンギンボーダーズ
+CONS( 2001, tak_gin,   0,          0,  xavix,            tak_gin,  xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "Gin-gin Boarders (Japan)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_COLORS )
+
 // was also distributed by Atlus as an arcade cabinet in 2005, ROM almost certainly different (this one will auto-power off after inactivity, an arcade wouldn't do that)
 CONS( 2003, jarajal,   0,          0,  xavix_nv,         jarajal,  xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "Jara-Ja Land (Japan, home version)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
-CONS( 2002, tomshoot, 0,           0,  xavix_i2c_24c02,  xavix_i2c,xavix_i2c_state,      init_xavix,    "Tomy / SSD Company LTD",                       "Shooting King (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+CONS( 2002, tomshoot, 0,           0,  xavix_i2c_24c02,  tomshoot,xavix_i2c_tomshoot_state,  init_xavix,    "Tomy / SSD Company LTD",                       "Shooting King (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 CONS( 2003, tcarnavi,  0,          0,  xavix_nv,         tcarnavi, xavix_state,          init_xavix,    "Tomy / SSD Company LTD",                       "Tomica Carnavi Drive (Japan)", MACHINE_IMPERFECT_SOUND )
 
@@ -2268,6 +2388,9 @@ CONS( 2004, tomplc,    0,          0,  xavix_i2c_24c02_43mhz,tomplc,xavix_i2c_st
 CONS( 2001, gungunad,  0,          0,  xavix_nv,         xavix,    xavix_state,          init_xavix,    "Takara / SSD Company LTD",                     "Gun Gun Adventure (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 CONS( 2004, gungunrv,  0,          0,  xavix_i2c_24lc04, gungunrv, xavix_i2c_state,      init_xavix,    "Takara / SSD Company LTD",                     "Gun Gun Revolution (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+
+CONS( 2001, bistro,    0,          0,  xavix,            xavix,    xavix_state,          init_xavix,    "Sega Toys / SSD Company LTD",                  "Bistro Kids (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+
 
 /* Music titles: Emulation note:
    Timers might not be 100%, PAL stuff uses different ways to do timing.
@@ -2292,11 +2415,12 @@ CONS( 2000, popira,   0,           0,  xavix_cart_popira,popira,   xavix_cart_st
 
 CONS( 2002, popira2,  0,           0,  xavix_cart_popira2,popira2,  xavix_popira2_cart_state, init_xavix,    "Takara / SSD Company LTD",                 "Popira 2 (Japan)", MACHINE_IMPERFECT_SOUND/*|MACHINE_IS_BIOS_ROOT*/ ) // Popira 2 is a set of 2 blue & green linked units (2nd unit is just a controller, no CPU or TV out)
 
-CONS( 2003, taikodp,  0,           0,  xavix_i2c_taiko,  taikodp,  xavix_i2c_cart_state, init_xavix,    "Takara / SSD Company LTD",                     "Taiko de Popira (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND /*|MACHINE_IS_BIOS_ROOT*/ ) // inputs? are the drums analog?
+CONS( 2003, taikodp,  0,           0,  xavix_i2c_taiko,  taikodp,  xavix_i2c_cart_state, init_xavix,    "Takara / SSD Company LTD",                     "Taiko de Popira (Japan)", MACHINE_IMPERFECT_SOUND /*|MACHINE_IS_BIOS_ROOT*/ ) // inputs? are the drums analog?
 
 CONS( 2004, jpopira,  0,           0,  xavix_i2c_jpopira,jpopira,  xavix_i2c_cart_state, init_xavix,    "Takara / SSD Company LTD",                     "Jumping Popira (Japan)", MACHINE_IMPERFECT_SOUND /*|MACHINE_IS_BIOS_ROOT*/ )
 
 CONS( 2003, evio,     0,           0,  xavix_cart_evio,  evio,     xavix_evio_cart_state,init_xavix,    "Tomy / SSD Company LTD",                       "Evio (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND /*|MACHINE_IS_BIOS_ROOT*/ ) // inputs? it's a violin controller
+
 
 // 2 ROM expansion cartridges were available for this, in the form of other robots (the heads acts as cartridges) see takara_daigunder_dx_cart.xml
 // a number of other robots were also available, but those act as controllers and don't plug into the ROM slot (presumably the signal sent is used to determine the character)
@@ -2313,4 +2437,4 @@ CONS( 2003, epo_tfp2,  0,          0,  xavix_i2c_24c08,  epo_tfp2, xavix_i2c_sta
 
 CONS( 2005, tvpc_tom,  0,          0,  xavix_i2c_24c16,  tvpc_tom, xavix_i2c_state, init_xavix, "Epoch / SSD Company LTD", "TV-PC Thomas & Friends (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 CONS( 2003, tvpc_dor,  0,          0,  xavix_i2c_24c16,  tvpc_tom, xavix_i2c_state, init_xavix, "Epoch / SSD Company LTD", "TV-PC Doraemon (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-// A Hamtaro TV-PC also exists
+CONS( 2003, tvpc_ham,  0,          0,  xavix_i2c_24c16,  tvpc_tom, xavix_i2c_state, init_xavix, "Epoch / SSD Company LTD", "TV-PC Tottoko Hamutaro (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)

--- a/src/mame/tvgames/xavix.h
+++ b/src/mame/tvgames/xavix.h
@@ -85,6 +85,7 @@ public:
 		m_mouse0y(*this, "MOUSE0Y"),
 		m_mouse1x(*this, "MOUSE1X"),
 		m_mouse1y(*this, "MOUSE1Y"),
+		m_lightgun(*this, "GUN1_%u", 0U),
 		m_maincpu(*this, "maincpu"),
 		m_nvram(*this, "nvram"),
 		m_screen(*this, "screen"),
@@ -133,6 +134,8 @@ public:
 	void ioevent_trg02(int state);
 	void ioevent_trg04(int state);
 	void ioevent_trg08(int state);
+
+	virtual void xavix_interrupt_extra() { }
 
 	int m_rgnlen = 0;
 	uint8_t* m_rgn = nullptr;
@@ -202,6 +205,7 @@ protected:
 	optional_ioport m_mouse0y;
 	optional_ioport m_mouse1x;
 	optional_ioport m_mouse1y;
+	optional_ioport_array<2> m_lightgun;
 	required_device<xavix_device> m_maincpu;
 	optional_device<nvram_device> m_nvram;
 	required_device<screen_device> m_screen;
@@ -419,6 +423,8 @@ private:
 
 	uint8_t pal_ntsc_r();
 
+	virtual uint8_t lightgun_r(offs_t offset) { logerror("%s: unhandled lightgun_r %d\n", machine().describe_context(), offset); return 0xff;  }
+
 	uint8_t xavix_memoryemu_txarray_r(offs_t offset);
 	void xavix_memoryemu_txarray_w(offs_t offset, uint8_t data);
 	uint8_t m_txarray[3]{};
@@ -633,6 +639,38 @@ protected:
 	required_device<i2cmem_device> m_i2cmem;
 };
 
+class xavix_i2c_tomshoot_state : public xavix_i2c_state
+{
+public:
+	xavix_i2c_tomshoot_state(const machine_config& mconfig, device_type type, const char* tag)
+		: xavix_i2c_state(mconfig, type, tag)
+	{ }
+
+	void xavix_interrupt_extra() override
+	{
+		ioevent_trg01(1); // causes reads from the lightgun 1 port
+		//ioevent_trg02(1); // causes reads from the lightgun 2 port
+	}
+
+
+private:
+	virtual uint8_t lightgun_r(offs_t offset) override
+	{
+		uint16_t ret = m_lightgun[offset>>1]->read();
+
+		if (offset & 1)
+			ret >>= 8;
+		else
+			ret &= 0xff;
+
+		if (offset == 0)
+			ret += 0x20;
+
+		return ret;
+	}
+
+};
+
 class xavix_i2c_ltv_tam_state : public xavix_i2c_state
 {
 public:
@@ -651,24 +689,6 @@ private:
 	uint8_t tam_anport2_r() { return m_mouse1x->read()^0x7f; }
 	uint8_t tam_anport3_r() { return m_mouse1y->read()^0x7f; }
 };
-
-
-
-class xavix_i2c_lotr_state : public xavix_i2c_state
-{
-public:
-	xavix_i2c_lotr_state(const machine_config &mconfig, device_type type, const char *tag)
-		: xavix_i2c_state(mconfig, type, tag)
-	{ }
-
-	int camera_r();
-
-protected:
-	//virtual void write_io1(uint8_t data, uint8_t direction) override;
-};
-
-
-
 
 class xavix_mtrk_state : public xavix_state
 {
@@ -1009,17 +1029,6 @@ protected:
 	required_ioport m_extra2;
 	required_ioport m_extra3;
 
-};
-
-class xavix_duelmast_state : public xavix_i2c_state
-{
-public:
-	xavix_duelmast_state(const machine_config &mconfig, device_type type, const char *tag)
-		: xavix_i2c_state(mconfig, type, tag)
-	{ }
-
-protected:
-	virtual uint8_t read_io1(uint8_t direction) override;
 };
 
 

--- a/src/mame/tvgames/xavix.h
+++ b/src/mame/tvgames/xavix.h
@@ -639,6 +639,30 @@ protected:
 	required_device<i2cmem_device> m_i2cmem;
 };
 
+class xavix_i2c_lotr_state : public xavix_i2c_state
+{
+public:
+	xavix_i2c_lotr_state(const machine_config &mconfig, device_type type, const char *tag)
+		: xavix_i2c_state(mconfig, type, tag)
+	{ }
+
+	int camera_r();
+
+protected:
+	//virtual void write_io1(uint8_t data, uint8_t direction) override;
+};
+
+class xavix_duelmast_state : public xavix_i2c_state
+{
+public:
+	xavix_duelmast_state(const machine_config &mconfig, device_type type, const char *tag)
+		: xavix_i2c_state(mconfig, type, tag)
+	{ }
+
+protected:
+	virtual uint8_t read_io1(uint8_t direction) override;
+};
+
 class xavix_i2c_tomshoot_state : public xavix_i2c_state
 {
 public:

--- a/src/mame/tvgames/xavix_2000.cpp
+++ b/src/mame/tvgames/xavix_2000.cpp
@@ -200,11 +200,6 @@ static INPUT_PORTS_START( ttv_mx )
 	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_NAME("Motion Right")
 INPUT_PORTS_END
 
-int xavix_i2c_lotr_state::camera_r() // seems to be some kind of camera status bits
-{
-	return machine().rand();
-}
-
 void xavix_state::xavix2000(machine_config &config)
 {
 	xavix(config);

--- a/src/mame/tvgames/xavix_2000.cpp
+++ b/src/mame/tvgames/xavix_2000.cpp
@@ -200,6 +200,10 @@ static INPUT_PORTS_START( ttv_mx )
 	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_NAME("Motion Right")
 INPUT_PORTS_END
 
+int xavix_i2c_lotr_state::camera_r() // seems to be some kind of camera status bits
+{
+	return machine().rand();
+}
 
 void xavix_state::xavix2000(machine_config &config)
 {
@@ -296,6 +300,10 @@ ROM_START( duelmast )
 	ROM_LOAD("duelmasters.u4", 0x000000, 0x200000, CRC(2f11fcd7) SHA1(d8849c74833e77b8b309e845523f2cdc7ac68054) )
 ROM_END
 
+ROM_START( tom_dpgm )
+	ROM_REGION(0x400000, "bios", ROMREGION_ERASE00)
+	ROM_LOAD("disney.bin", 0x000000, 0x400000, CRC(1dc181b3) SHA1(fa30069d17705f27e4ff45e7f6ccf06986e138f3) )
+ROM_END
 
 // doesn't use extra opcodes?
 CONS( 2002, epo_ebox, 0, 0, xavix2000_nv,        epo_ebox,    xavix_state,             init_xavix, "Epoch / SSD Company LTD",       "Excite Boxing (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND ) // doesn't use XaviX2000 extra opcodes, but had that type of CPU
@@ -316,3 +324,6 @@ CONS( 2003, drgqst,   0, 0, xavix2000_i2c_24c08, ttv_lotr,    xavix_i2c_lotr_sta
 
 // hangs after starting a game, check why
 CONS( 2004, ban_onep, 0, 0, xavix2000_i2c_24c04, ttv_lotr,    xavix_i2c_lotr_state, init_xavix, "Bandai / SSD Company LTD",         "Let's! TV Play One Piece Punch Battle (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+
+// ディズニープリンセス　キラキラ魔法のレッスン
+CONS( 2004, tom_dpgm, 0, 0, xavix2000_i2c_24c08, ttv_lotr,    xavix_i2c_lotr_state, init_xavix, "Tomy / SSD Company LTD",         "Disney Princess Glitter Magic Lesson (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )

--- a/src/mame/tvgames/xavix_2000.cpp
+++ b/src/mame/tvgames/xavix_2000.cpp
@@ -200,6 +200,7 @@ static INPUT_PORTS_START( ttv_mx )
 	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_NAME("Motion Right")
 INPUT_PORTS_END
 
+
 void xavix_state::xavix2000(machine_config &config)
 {
 	xavix(config);
@@ -299,6 +300,7 @@ ROM_START( tom_dpgm )
 	ROM_REGION(0x400000, "bios", ROMREGION_ERASE00)
 	ROM_LOAD("disney.bin", 0x000000, 0x400000, CRC(1dc181b3) SHA1(fa30069d17705f27e4ff45e7f6ccf06986e138f3) )
 ROM_END
+
 
 // doesn't use extra opcodes?
 CONS( 2002, epo_ebox, 0, 0, xavix2000_nv,        epo_ebox,    xavix_state,             init_xavix, "Epoch / SSD Company LTD",       "Excite Boxing (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND ) // doesn't use XaviX2000 extra opcodes, but had that type of CPU

--- a/src/mame/tvgames/xavix_2000.cpp
+++ b/src/mame/tvgames/xavix_2000.cpp
@@ -326,4 +326,4 @@ CONS( 2003, drgqst,   0, 0, xavix2000_i2c_24c08, ttv_lotr,    xavix_i2c_lotr_sta
 CONS( 2004, ban_onep, 0, 0, xavix2000_i2c_24c04, ttv_lotr,    xavix_i2c_lotr_state, init_xavix, "Bandai / SSD Company LTD",         "Let's! TV Play One Piece Punch Battle (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // ディズニープリンセス　キラキラ魔法のレッスン
-CONS( 2004, tom_dpgm, 0, 0, xavix2000_i2c_24c08, ttv_lotr,    xavix_i2c_lotr_state, init_xavix, "Tomy / SSD Company LTD",         "Disney Princess Glitter Magic Lesson (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+CONS( 2004, tom_dpgm, 0, 0, xavix2000_i2c_24c08, ttv_lotr,    xavix_i2c_lotr_state, init_xavix, "Tomy / SSD Company LTD",         "Disney Princess Kirakira Mahou no Lesson (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )

--- a/src/mame/tvgames/xavix_2000.h
+++ b/src/mame/tvgames/xavix_2000.h
@@ -24,29 +24,4 @@ private:
 	uint8_t sdb_anport3_r() { return m_mouse1y->read()^0x7f; }
 };
 
-class xavix_i2c_lotr_state : public xavix_i2c_state
-{
-public:
-	xavix_i2c_lotr_state(const machine_config &mconfig, device_type type, const char *tag)
-		: xavix_i2c_state(mconfig, type, tag)
-	{ }
-
-	int camera_r();
-
-protected:
-	//virtual void write_io1(uint8_t data, uint8_t direction) override;
-};
-
-class xavix_duelmast_state : public xavix_i2c_state
-{
-public:
-	xavix_duelmast_state(const machine_config &mconfig, device_type type, const char *tag)
-		: xavix_i2c_state(mconfig, type, tag)
-	{ }
-
-protected:
-	virtual uint8_t read_io1(uint8_t direction) override;
-};
-
-
 #endif // MAME_TVGAMES_XAVIX_2000_H

--- a/src/mame/tvgames/xavix_2000.h
+++ b/src/mame/tvgames/xavix_2000.h
@@ -24,4 +24,29 @@ private:
 	uint8_t sdb_anport3_r() { return m_mouse1y->read()^0x7f; }
 };
 
+class xavix_i2c_lotr_state : public xavix_i2c_state
+{
+public:
+	xavix_i2c_lotr_state(const machine_config &mconfig, device_type type, const char *tag)
+		: xavix_i2c_state(mconfig, type, tag)
+	{ }
+
+	int camera_r();
+
+protected:
+	//virtual void write_io1(uint8_t data, uint8_t direction) override;
+};
+
+class xavix_duelmast_state : public xavix_i2c_state
+{
+public:
+	xavix_duelmast_state(const machine_config &mconfig, device_type type, const char *tag)
+		: xavix_i2c_state(mconfig, type, tag)
+	{ }
+
+protected:
+	virtual uint8_t read_io1(uint8_t direction) override;
+};
+
+
 #endif // MAME_TVGAMES_XAVIX_2000_H

--- a/src/mame/tvgames/xavix_2002.cpp
+++ b/src/mame/tvgames/xavix_2002.cpp
@@ -309,11 +309,6 @@ void xavix_i2c_jmat_state::write_extended_io2(uint8_t data)
 	LOG("%s: io2_data_w %02x\n", machine().describe_context(), data);
 }
 
-int xavix_i2c_lotr_state::camera_r() // seems to be some kind of camera status bits
-{
-	return machine().rand();
-}
-
 int xavix_i2c_bowl_state::camera_r() // seems to be some kind of camera status bits
 {
 	return machine().rand();

--- a/src/mame/tvgames/xavix_2002.cpp
+++ b/src/mame/tvgames/xavix_2002.cpp
@@ -309,6 +309,11 @@ void xavix_i2c_jmat_state::write_extended_io2(uint8_t data)
 	LOG("%s: io2_data_w %02x\n", machine().describe_context(), data);
 }
 
+int xavix_i2c_lotr_state::camera_r() // seems to be some kind of camera status bits
+{
+	return machine().rand();
+}
+
 int xavix_i2c_bowl_state::camera_r() // seems to be some kind of camera status bits
 {
 	return machine().rand();

--- a/src/mame/tvgames/xavix_m.cpp
+++ b/src/mame/tvgames/xavix_m.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:David Haywood
 
 #include "emu.h"
-#include "xavix.h"
+#include "xavix_2000.h"
 
 // #define VERBOSE 1
 #include "logmacro.h"
@@ -265,6 +265,8 @@ INTERRUPT_GEN_MEMBER(xavix_state::interrupt)
 		m_maincpu->set_input_line(INPUT_LINE_NMI, ASSERT_LINE);
 		m_video_ctrl |= 0x80;
 	}
+
+	xavix_interrupt_extra();
 }
 
 

--- a/src/mame/tvgames/xavix_m.cpp
+++ b/src/mame/tvgames/xavix_m.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:David Haywood
 
 #include "emu.h"
-#include "xavix_2000.h"
+#include "xavix.h"
 
 // #define VERBOSE 1
 #include "logmacro.h"

--- a/src/mame/tvgames/xavix_v.cpp
+++ b/src/mame/tvgames/xavix_v.cpp
@@ -182,6 +182,14 @@ void xavix_state::update_pen(int pen, uint8_t shval, uint8_t lval)
 	double g1 = (g0 - z) * c + y;
 	double b1 = (b0 - z) * c + y;
 
+
+	// lower overall brightness slightly, or some palette entries in tak_gin end up washed out / with identical colours, losing details
+	// the darkest colours in certain flags still look wrong however, and appear nearly black
+	// this might suggest the overall palette conversion needs work
+	r1 = r1 * 0.92f;
+	g1 = g1 * 0.92f;
+	b1 = b1 * 0.92f;
+
 	if(r1 < 0)
 		r1 = 0;
 	else if(r1 > 1)


### PR DESCRIPTION
This is a squashed version of https://github.com/mamedev/mame/pull/12812

new WORKING machines
-------------------------------
All-Star Thanksgiving Super Luxurious! Definitive Quiz Edition ~ Akasaka 5-Chome Experience Studio [David Haywood, TeamEurope, Peter Wilhelmsen]
Mini-Moni Stage! Dance Dapyon! (Japan) [David Haywood, TeamEurope, Peter Wilhelmsen]
Mini-Moni Stage! Dance Dapyon! Plus (Japan) [David Haywood, TeamEurope]
Gin-gin Boarders (Japan) [David Haywood, TeamEurope, Peter Wilhelmsen]
Mega Drive Play TV 2 (Japan) [David Haywood, TeamEurope]
Mega Drive Play TV 3 (Japan) [David Haywood, TeamEurope]
265-in-1 Handheld Game (SPG2xx based) [David Haywood, TeamEurope]

new Software List additions
-----------------------------------
hikara.xml
Hi-kara PIZZA-LA [David Haywood, TeamEurope]
Hi-kara 20-song capacity user cartridge (blank) (Japan) [David Haywood, TeamEurope]
super_tv_pc.xml
Doraemon Excite Ping-Pong [David Haywood, TeamEurope]

new NOT WORKING machines
------------------------------------
Bistro Kids (Japan) [David Haywood, TeamEurope, Peter Wilhelmsen]
Excite Stadium DX - Hanshin Tigers (Japan) [David Haywood, TeamEurope, Peter Wilhelmsen]
Disney Princess Glitter Magic Lesson (Japan) [David Haywood, TeamEurope]
Pocket Monsters PC [TeamEurope, Peter Wilhelmsen]
Pocket Monsters Rotom Tablet [TeamEurope, Peter Wilhelmsen]
Color LCD Classic Game 200-in-1 [David Haywood, TeamEurope]
Pocket Game 118-in-1 / Game Computer 118-in-1 [David Haywood, TeamEurope]
Tou ma Pet [David Haywood, TeamEurope]
Mini Arcade Handheld Game Console 2.8 Inch Screen Built in 156 Retro Games (Mega Drive handheld) [David Haywood, TeamEurope]
TV Globe (Japan) [David Haywood, TeamEurope]
Anpanman TV (Japan) [David Haywood, TeamEurope]
Classic Max Pocket PCMX11 - 12 in 1 Colour Games Console (France) [David Haywood, TeamEurope]
TV-PC Tottoko Hamutaro (Japan) [David Haywood, TeamEurope]
Play Portable Color GameU+ (50-in-1) (Japan) [David Haywood, TeamEurope]
Comet-san Lovelin Baton (Japan) [David Haywood, TeamEurope]
Ham-chans Gather Together to Dance! Run! (Japan) [David Haywood, TeamEurope]
Excite Striker (Japan) [David Haywood, TeamEurope]

machines promoted to WORKING
------------------------------------
Taiko de Popira (Japan) [David Haywood]
Millennium Arcade 250 (M527) [David Haywood]
Digital Pocket Hand Held System 230-in-1 - Model 8630 / Model 8633 [David Haywood]
Retro Handheld Console 152-in-1 [David Haywood]
Retro Arcade Game Controller 153-in-1 [David Haywood]
My Arcade Gamer Mini 160-in-1 (DGUN-2953) [David Haywood]
Mini Arcade Console (Arcade 10-in-1) [David Haywood]
Arcade Classics Mini Handheld Arcade (Supreme 150) [David Haywood]
