### PR TITLE
k054539: correctly handles reverb RAM as 32kB during test and initialization

### DIFF
--- a/src/devices/sound/k054539.cpp
+++ b/src/devices/sound/k054539.cpp
@@ -130,7 +130,7 @@ void k054539_device::sound_stream_update(sound_stream &stream, std::vector<read_
 		rbase[reverb_pos] = 0;
 
 		for(int ch=0; ch<8; ch++)
-			if(regs[0x22c] & (1<<ch)) {
+			if(BIT(regs[0x22c], ch)) {
 				unsigned char *base1 = regs + 0x20*ch;
 				unsigned char *base2 = regs + 0x200 + 0x2*ch;
 				channel *chan = channels + ch;
@@ -432,11 +432,10 @@ void k054539_device::write(offs_t offset, u8 data)
 
 		case 0x22d:
 			if(rom_addr == 0x80) {
-				int addr = (cur_ptr&0x3fff) | ((cur_ptr&0x10000)>>2);
+				offs_t const addr = (cur_ptr & 0x3fff) | ((cur_ptr & 0x10000) >> 2);
 				ram[addr] = data;
 			}
-			cur_ptr++;
-			cur_ptr &= 0x1ffff;
+			cur_ptr = (cur_ptr + 1) & 0x1ffff;
 		break;
 
 		case 0x22e:
@@ -475,7 +474,6 @@ void k054539_device::write(offs_t offset, u8 data)
 
 void k054539_device::device_post_load()
 {
-
 }
 
 u8 k054539_device::read(offs_t offset)
@@ -483,13 +481,10 @@ u8 k054539_device::read(offs_t offset)
 	switch(offset) {
 	case 0x22d:
 		if(regs[0x22f] & 0x10) {
-			int ram_addr = (cur_ptr&0x3fff) | ((cur_ptr&0x10000)>>2);
-			uint8_t res = (rom_addr == 0x80) ? ram[ram_addr] : read_byte((0x20000*rom_addr)+cur_ptr);
-			if (!machine().side_effects_disabled())
-			{
-				cur_ptr++;
-				cur_ptr &= 0x1ffff;
-			}
+			offs_t const addr = (cur_ptr & 0x3fff) | ((cur_ptr & 0x10000) >> 2);
+			uint8_t res = (rom_addr == 0x80) ? ram[ram_addr] : read_byte((0x20000*rom_addr) + cur_ptr);
+			if(!machine().side_effects_disabled())
+				cur_ptr = (cur_ptr + 1) & 0x1ffff;
 			return res;
 		} else
 			return 0;

--- a/src/devices/sound/k054539.h
+++ b/src/devices/sound/k054539.h
@@ -93,7 +93,6 @@ private:
 	int reverb_pos;
 
 	int32_t cur_ptr;
-	int cur_limit;
 	uint32_t rom_addr;
 
 	channel channels[8];


### PR DESCRIPTION
The external RAM has indeed 32kB, as comments in the MAME source file say. However, the k054539 class is dealing with it as 16kB. The connection to the chip has the upper address bit connected to the K054539 address bit 16, not the expected 14. Checkout the schematics extracted by my team:

![image](https://github.com/user-attachments/assets/9c4c8fa4-ed45-41d4-b470-7c234614f374)

If you inspect Konami's X-Men test sequence, you will see that it keeps advancing the internal test address register until bit 16 toggles, then it writes test content again. After that, it keeps advancing it until it wraps around and it checks at the two 16kB halves: the one at A16=0 and then A16=1. It stops the test after checking the first 16kB at A16=1 without writting the pointer again (as it is not needed)

This is a simulation of my verilog implementation of X-Men, but you can check the behavior in MAME debugger easily too. See how the orange signal (the test address) is increased until it wraps around and how the test_we signal (indicating writes to the RAM) is active at two specific segments.

![image](https://github.com/user-attachments/assets/fb8c139f-82d7-490e-bb01-20065489317c)

The PR implements this behavior, deleting the different treatment previously given to RAM and ROM checks. I have tested it with X-Men, Run&Gun (RAM & ROM checks) and Pirate Ship (just booting up the game).
