### PR TITLE
Allow querying for alternate Qt6 libexec directory

### DIFF
--- a/scripts/src/osd/modules.lua
+++ b/scripts/src/osd/modules.lua
@@ -384,12 +384,16 @@ function qtdebuggerbuild()
 			if _OPTIONS["QT_HOME"]~=nil then
 				MOCTST = backtick(_OPTIONS["QT_HOME"] .. "/bin/moc --version 2>/dev/null")
 				if (MOCTST=='') then
-					MOCTST = backtick(_OPTIONS["QT_HOME"] .. "/libexec/moc --version 2>/dev/null")
+					local qt_host_libexecs = backtick(_OPTIONS["QT_HOME"] .. "/bin/qmake -query QT_HOST_LIBEXECS")
+					if (string.starts(qt_host_libexecs,"/")==false) then
+						qt_host_libexecs = _OPTIONS["QT_HOME"] .. "/libexec"
+					end
+					MOCTST = backtick(qt_host_libexecs .. "/moc --version 2>/dev/null")
 					if (MOCTST=='') then
 						print("Qt's Meta Object Compiler (moc) wasn't found!")
 						os.exit(1)
 					else
-						MOC = _OPTIONS["QT_HOME"] .. "/libexec/moc"
+						MOC = qt_host_libexecs .. "/moc"
 					end
 				else
 					MOC = _OPTIONS["QT_HOME"] .. "/bin/moc"

--- a/scripts/src/osd/modules.lua
+++ b/scripts/src/osd/modules.lua
@@ -16,7 +16,7 @@ end
 function addlibfromstring(str)
 	if (str==nil) then return  end
 	for w in str:gmatch("%S+") do
-		if string.starts(w,"-l")==true then
+		if string.starts(w,"-l") then
 			links {
 				string.sub(w,3)
 			}
@@ -27,7 +27,7 @@ end
 function addoptionsfromstring(str)
 	if (str==nil) then return  end
 	for w in str:gmatch("%S+") do
-		if string.starts(w,"-l")==false then
+		if not string.starts(w,"-l") then
 			linkoptions {
 				w
 			}
@@ -385,11 +385,11 @@ function qtdebuggerbuild()
 				MOCTST = backtick(_OPTIONS["QT_HOME"] .. "/bin/moc --version 2>/dev/null")
 				if (MOCTST=='') then
 					local qt_host_libexecs = backtick(_OPTIONS["QT_HOME"] .. "/bin/qmake -query QT_HOST_LIBEXECS")
-					if (string.starts(qt_host_libexecs,"/")==false) then
+					if not string.starts(qt_host_libexecs,"/") then
 						qt_host_libexecs = _OPTIONS["QT_HOME"] .. "/libexec"
 					end
 					MOCTST = backtick(qt_host_libexecs .. "/moc --version 2>/dev/null")
-					if (MOCTST=='') then
+					if MOCTST=='' then
 						print("Qt's Meta Object Compiler (moc) wasn't found!")
 						os.exit(1)
 					else
@@ -403,7 +403,7 @@ function qtdebuggerbuild()
 				if (MOCTST=='') then
 					MOCTST = backtick("which moc 2>/dev/null")
 				end
-				if (MOCTST=='') then
+				if MOCTST=='' then
 					print("Qt's Meta Object Compiler (moc) wasn't found!")
 					os.exit(1)
 				end


### PR DESCRIPTION
This is closer to how Qt6's moc.prf finds moc, i.e.

```
qtPrepareLibExecTool(QMAKE_MOC, moc)

...

defineTest(qtPrepareLibExecTool) {
    isEmpty(instloc): instloc = "$$[QT_HOST_LIBEXECS]"
    qtPrepareTool($$1, $$2, $$3, $$4, $$instloc)
}
```

---

Specifically adding for Homebrew - https://github.com/Homebrew/homebrew-core/pull/193751

However, I think this will help other repositories/distros that don't use `QT_HOME / libexec / moc`. For example, Arch Linux uses `QT_HOME / moc` and thus needs to modify the script[^1].

Similar handling in Meson[^2] though they also fall back on `QT_INSTALL_LIBEXECS`. Not sure if that is actually needed so left out for now.


[^1]: https://gitlab.archlinux.org/archlinux/packaging/packages/mame/-/blob/main/PKGBUILD?ref_type=heads#L58-59
[^2]: https://github.com/mesonbuild/meson/blob/master/mesonbuild/dependencies/qt.py#L65-L68