### PR TITLE
suprterminal: fix unpredictable memory map due to uninitialized value

### DIFF
--- a/src/devices/bus/a2bus/suprterminal.cpp
+++ b/src/devices/bus/a2bus/suprterminal.cpp
@@ -125,6 +125,7 @@ void a2bus_suprterminal_device::device_start()
 	m_vram = std::make_unique<u8[]>(0x800); // 4 2114 DRAMs
 	m_fontram = std::make_unique<u8[]>(0x400); // 2 2114 DRAMs
 
+	m_bC800IsRAM = false;
 	m_bRasterRAM = true;
 	m_bCharBank1 = false;
 


### PR DESCRIPTION
Poking CFFF and then C300 is supposed to map the C800 range to the Sup'R'Terminal extension ROM.

But if you do that right after bootup, then the CFFF poke will not run `a2bus_suprterminal_device::write_c800`, because the C800 range is not yet assigned to the Sup'R'Terminal. (IOW, `apple2_state:m_cnxx_slot` is still -1.) Because of that, `m_bC800IsRAM` will remain uninitialized.

The C300 poke will then assign the C800 range to the Sup'R'Terminal, but since `m_bC800IsRAM` is uninitialized, it will be unpredictable whether accesses to that range go to the extension ROM or RAM.

Fix this by initializing `m_bC800IsRAM` in `a2bus_suprterminal_device::device_start`.