### PR TITLE
Upgrade checkout and upload-artifacts actions

### DIFF
--- a/.github/workflows/bgfxshaders.yml
+++ b/.github/workflows/bgfxshaders.yml
@@ -23,7 +23,9 @@ jobs:
     - uses: msys2/setup-msys2@v2
       with:
         install: git make mingw-w64-x86_64-gcc mingw-w64-x86_64-python mingw-w64-x86_64-libc++
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
+      with:
+        fetch-depth: 0
     - name: Prevent make from rebuilding GLSL parser source
       run: |
         touch 3rdparty/bgfx/3rdparty/glsl-optimizer/src/glsl/glcpp/glcpp-lex.c
@@ -35,7 +37,8 @@ jobs:
       env:
         MINGW64: "/mingw64"
       run: make shaders
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@main
       with:
         name: mame-bgfx-${{ github.sha }}
         path: bgfx/shaders
+        if-no-files-found: error

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -24,7 +24,6 @@ permissions:
   contents: read
 
 jobs:
-
   build-linux:
     runs-on: ubuntu-latest
     strategy:
@@ -43,7 +42,9 @@ jobs:
             subtarget: mame
             executable: mame
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
+      with:
+        fetch-depth: 0
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -65,10 +66,11 @@ jobs:
       run: ./${{ matrix.executable }} -listxml | python scripts/build/makedep.py reconcilelist -l src/mame/${{ matrix.subtarget }}.lst -
     - name: ORM check
       run: python scripts/minimaws/minimaws.py load --executable ./${{ matrix.executable }} --softwarepath hash
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@main
       with:
         name: ${{ matrix.executable }}-linux-${{ matrix.compiler }}-${{ github.sha }}
         path: |
           ${{ matrix.executable }}
           chdman
           unidasm
+        if-no-files-found: error

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -22,11 +22,12 @@ permissions:
   contents: read
 
 jobs:
-
   build-macos:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
+      with:
+        fetch-depth: 0
     - name: Install dependencies
       run: brew install python3 sdl2
     - name: Build
@@ -36,10 +37,11 @@ jobs:
       run: make -j2
     - name: Validate
       run: ./mame -validate
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@main
       with:
         name: mame-macos-${{ github.sha }}
         path: |
           mame
           chdman
           unidasm
+        if-no-files-found: error

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -22,7 +22,6 @@ permissions:
   contents: read
 
 jobs:
-
   build-windows:
     runs-on: windows-latest
     defaults:
@@ -46,7 +45,9 @@ jobs:
     - uses: msys2/setup-msys2@v2
       with:
         install: git make mingw-w64-x86_64-${{ matrix.compiler }} mingw-w64-x86_64-python mingw-w64-x86_64-lld mingw-w64-x86_64-llvm mingw-w64-x86_64-libc++
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
+      with:
+        fetch-depth: 0
     - name: Build
       env:
         MINGW64: "/mingw64"
@@ -59,10 +60,11 @@ jobs:
       run: make -j3
     - name: Validate
       run: ./${{ matrix.executable }}.exe -validate
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@main
       with:
         name: ${{ matrix.executable }}-windows-${{ matrix.compiler }}-${{ github.sha }}
         path: |
           ${{ matrix.executable }}.exe
           chdman.exe
           unidasm.exe
+        if-no-files-found: error

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,9 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
+      with:
+        fetch-depth: 0
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -27,9 +29,10 @@ jobs:
       run: make -C docs html
     - name: Build PDF
       run: make -C docs latexpdf
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@main
       with:
         name: mame-docs-${{ github.sha }}
         path: |
           docs/build/html
           docs/build/latex/MAME.pdf
+        if-no-files-found: error

--- a/.github/workflows/hash.yml
+++ b/.github/workflows/hash.yml
@@ -21,7 +21,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
+      with:
+        fetch-depth: 0
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -17,10 +17,13 @@ jobs:
   build-language:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
+      with:
+        fetch-depth: 0
     - name: Compile message catalogs
       run: for x in language/*/*.po ; do python scripts/build/msgfmt.py --output-file "`dirname "$x"`/`basename "$x" .po`.mo" "$x" ; done
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@main
       with:
         name: mame-language-${{ github.sha }}
         path: language/*/*.mo
+        if-no-files-found: error


### PR DESCRIPTION
The default branch of checkout and upload-artifact was renamed to `main` years ago:
  * https://github.com/actions/checkout/tree/master
  * https://github.com/actions/upload-artifact/tree/master

upload-artifacts >v1 doesn't error by default if artifacts aren't found: https://github.com/actions/upload-artifact/?tab=readme-ov-file#customization-if-no-files-are-found

checkout >v1 doesn't fetch the entire commit history by default: https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4