### PR TITLE
ussr/bk: attach floppy

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -4748,6 +4748,8 @@ end
 
 if (BUSES["QBUS"]~=null) then
 	files {
+		MAME_DIR .. "src/devices/bus/qbus/bk_kmd.cpp",
+		MAME_DIR .. "src/devices/bus/qbus/bk_kmd.h",
 		MAME_DIR .. "src/devices/bus/qbus/dsd4432.cpp",
 		MAME_DIR .. "src/devices/bus/qbus/dsd4432.h",
 		MAME_DIR .. "src/devices/bus/qbus/dvk_kgd.cpp",

--- a/src/devices/bus/qbus/bk_kmd.cpp
+++ b/src/devices/bus/qbus/bk_kmd.cpp
@@ -1,0 +1,102 @@
+// license:BSD-3-Clause
+// copyright-holders:Sergey Svishchev
+/***************************************************************************
+
+    BK0011 floppy controller (device driver BY.SYS)
+
+    Also compatible with BK0010.
+
+    ROM revisions:
+    - 253 -- shipped with BK0011; supports 10-sector format only (800 KB)
+    - 326 -- shipped with BK0011M; also supports 9-sector format (720 KB)
+    - 327v12 -- 3rd party; also supports PC formats (without Index Mark)
+
+***************************************************************************/
+
+#include "emu.h"
+
+#include "formats/bk0010_dsk.h"
+
+#include "bk_kmd.h"
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(BK_KMD, bk_kmd_device, "bk_kmd", "BK0010 floppy")
+
+ROM_START(bk_kmd)
+	ROM_REGION(0x1000, "maincpu", 0)
+	ROM_DEFAULT_BIOS("326")
+	ROM_SYSTEM_BIOS(0, "253", "mask 253")
+	ROMX_LOAD("disk_253.rom", 0, 0x1000, CRC(7a21b887) SHA1(f2c08147558816c59f0ef59e7c40ccb4b555e887), ROM_BIOS(0))
+	ROM_SYSTEM_BIOS(1, "326", "mask 326")
+	ROMX_LOAD("disk_326.rom", 0, 0x1000, CRC(fde7583d) SHA1(14f29dcb0fa81f7f1a8efade0bda66b042e47aba), ROM_BIOS(1))
+	ROM_SYSTEM_BIOS(2, "327v12", "327 v12") // "FDD/HDD BIOS 327 V12 (c) JD/DWG!" -- modified mask 326
+	ROMX_LOAD("disk_327.rom", 0, 0x1000, CRC(ed8a43ae) SHA1(28eefbb63047b26e4aec104aeeca74e2f9d0276c), ROM_BIOS(2))
+ROM_END
+
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  bk_kmd_device - constructor
+//-------------------------------------------------
+
+bk_kmd_device::bk_kmd_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, BK_KMD, tag, owner, clock)
+	, device_qbus_card_interface(mconfig, *this)
+	, m_fdc(*this, "fdc")
+{
+}
+
+void bk_kmd_device::floppy_formats(format_registration &fr)
+{
+	fr.add_mfm_containers();
+	fr.add(FLOPPY_BK0010_FORMAT);
+}
+
+static void bk_floppies(device_slot_interface &device)
+{
+	device.option_add("525qd", FLOPPY_525_QD);
+}
+
+const tiny_rom_entry *bk_kmd_device::device_rom_region() const
+{
+	return ROM_NAME(bk_kmd);
+}
+
+void bk_kmd_device::device_add_mconfig(machine_config &config)
+{
+	K1801VP128(config, m_fdc, XTAL(4'000'000));
+	m_fdc->ds_in_callback().set(
+			[] (uint16_t data) -> uint16_t
+			{
+				switch (data & 15)
+				{
+					case 1: return 0;
+					case 2: return 1;
+					default: return -1;
+				}
+			});
+	FLOPPY_CONNECTOR(config, "fdc:0", bk_floppies, "525qd", bk_kmd_device::floppy_formats);
+	FLOPPY_CONNECTOR(config, "fdc:1", bk_floppies, "525qd", bk_kmd_device::floppy_formats);
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void bk_kmd_device::device_start()
+{
+	m_bus->install_device(0177130, 0177133,
+		emu::rw_delegate(m_fdc, FUNC(k1801vp128_device::read)),
+		emu::rw_delegate(m_fdc, FUNC(k1801vp128_device::write))
+	);
+	m_bus->program_space().install_rom(0160000, 0167777, memregion(this->subtag("maincpu").c_str())->base());
+}
+

--- a/src/devices/bus/qbus/bk_kmd.h
+++ b/src/devices/bus/qbus/bk_kmd.h
@@ -1,0 +1,48 @@
+// license:BSD-3-Clause
+// copyright-holders:Sergey Svishchev
+/***************************************************************************
+
+    BK0011 floppy controller (device driver BY.SYS)
+
+***************************************************************************/
+
+#ifndef MAME_BUS_QBUS_BK_KMD_H
+#define MAME_BUS_QBUS_BK_KMD_H
+
+#pragma once
+
+#include "machine/1801vp128.h"
+
+#include "qbus.h"
+
+
+/***************************************************************************
+    TYPE DEFINITIONS
+***************************************************************************/
+
+// ======================> bk_kmd_device
+
+class bk_kmd_device : public device_t,
+					public device_qbus_card_interface
+{
+public:
+	// construction/destruction
+	bk_kmd_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_add_mconfig(machine_config &config) override;
+	virtual const tiny_rom_entry *device_rom_region() const override;
+
+	required_device<k1801vp128_device> m_fdc;
+
+private:
+	static void floppy_formats(format_registration &fr);
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(BK_KMD, bk_kmd_device)
+
+#endif

--- a/src/devices/bus/qbus/qbus.cpp
+++ b/src/devices/bus/qbus/qbus.cpp
@@ -11,6 +11,7 @@
 #include "qbus.h"
 
 // Peripheral boards
+#include "bk_kmd.h"
 #include "dsd4432.h"
 #include "dvk_kgd.h"
 #include "dvk_mx.h"
@@ -29,6 +30,7 @@ void qbus_cards(device_slot_interface &device)
 	device.option_add("mx", DVK_MX);
 	device.option_add("mz", UKNC_KMD);
 	device.option_add("qg640", MATROX_QG640);
+	device.option_add("by", BK_KMD);
 }
 
 

--- a/src/devices/bus/qbus/qbus.h
+++ b/src/devices/bus/qbus/qbus.h
@@ -73,6 +73,7 @@ public:
 	template <typename T> void set_space(T &&tag, int spacenum) { m_space.set_tag(std::forward<T>(tag), spacenum); }
 
 	virtual space_config_vector memory_space_config() const override;
+	address_space &program_space() const { return *m_space; }
 
 	auto birq4() { return m_out_birq4_cb.bind(); }
 	auto birq5() { return m_out_birq6_cb.bind(); }

--- a/src/devices/cpu/t11/t11ops.hxx
+++ b/src/devices/cpu/t11/t11ops.hxx
@@ -219,10 +219,10 @@
 #define MFPS_M(d)   int dreg, result, ea; result = PSW; CLR_NZV; SETB_NZ; PUT_DB_##d(result)
 /* MOV: dst = src */
 #define MOV_R(s,d)  int sreg, dreg, source, result;     GET_SW_##s; CLR_NZV; result = source; SETW_NZ; PUT_DW_##d(result)
-#define MOV_M(s,d)  int sreg, dreg, source, result, ea; GET_SW_##s; CLR_NZV; result = source; SETW_NZ; PUT_DWT_##d(result)
+#define MOV_M(s,d)  int sreg, dreg, source, result, ea; GET_SW_##s; CLR_NZV; result = source; SETW_NZ; if (c_insn_set & IS_VM1) { PUT_DW_##d(result); } else { PUT_DWT_##d(result); }
 #define MOVB_R(s,d) int sreg, dreg, source, result;     GET_SB_##s; CLR_NZV; result = source; SETB_NZ; PUT_DW_##d((signed char)result)
 #define MOVB_X(s,d) int sreg, dreg, source, result, ea; GET_SB_##s; CLR_NZV; result = source; SETB_NZ; PUT_DW_##d((signed char)result)
-#define MOVB_M(s,d) int sreg, dreg, source, result, ea; GET_SB_##s; CLR_NZV; result = source; SETB_NZ; PUT_DBT_##d(result)
+#define MOVB_M(s,d) int sreg, dreg, source, result, ea; GET_SB_##s; CLR_NZV; result = source; SETB_NZ; if (c_insn_set & IS_VM1) { PUT_DB_##d(result); } else { PUT_DBT_##d(result); }
 /* MTPS: flags = src */
 #define MTPS_R(d)   int dreg, dest;     GET_DB_##d; PSW = (PSW & ~0xef) | (dest & 0xef); m_check_irqs = true
 #define MTPS_M(d)   int dreg, dest, ea; GET_DB_##d; PSW = (PSW & ~0xef) | (dest & 0xef); m_check_irqs = true

--- a/src/devices/machine/1801vp128.h
+++ b/src/devices/machine/1801vp128.h
@@ -163,7 +163,7 @@ private:
 		fdc_pll_t pll;
 	};
 
-	required_device_array<floppy_connector, 4> m_connectors;
+	optional_device_array<floppy_connector, 4> m_connectors;
 	devcb_read16 m_read_ds;
 
 	std::string ttsn() const;

--- a/src/mame/ussr/bk.h
+++ b/src/mame/ussr/bk.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Miodrag Milanovic
+// copyright-holders:Miodrag Milanovic, Sergey Svishchev
 /*****************************************************************************
  *
  * includes/bk.h
@@ -54,10 +54,6 @@ private:
 	void vid_scroll_w(uint16_t data);
 	void sel1_w(uint16_t data);
 	void trap_w(uint16_t data);
-	uint16_t floppy_cmd_r();
-	void floppy_cmd_w(uint16_t data);
-	uint16_t floppy_data_r();
-	void floppy_data_w(uint16_t data);
 	void reset_w(int state);
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 

--- a/src/mame/ussr/bk_m.cpp
+++ b/src/mame/ussr/bk_m.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Miodrag Milanovic
+// copyright-holders:Miodrag Milanovic, Sergey Svishchev
 /***************************************************************************
 
         BK machine driver by Miodrag Milanovic
@@ -40,6 +40,21 @@ uint16_t bk_state::vid_scroll_r()
 	return m_scroll;
 }
 
+// SEL1 register (0010 and 0010.01)
+//
+// 15-8	R	high byte of cpu start address
+// 7	R	bitbanger cts in
+// 7	W	cassette motor control, 1: off 0: on
+// 6	R	keyboard any key down, 1: no 0: yes
+// 6	W	cassette data and speaker out
+// 5	R	cassette data in
+// 5	W	cassette data and bitbanger rts out
+// 4	R	bitbanger rx
+// 4	W	bitbanger tx
+// 2	R	updated
+//
+// only original 0010 has bitbanger wired to UP connector
+
 uint16_t bk_state::sel1_r()
 {
 	double level = m_cassette->input();
@@ -73,38 +88,6 @@ void bk_state::sel1_w(uint16_t data)
 void bk_state::trap_w(uint16_t data)
 {
 	m_maincpu->pulse_input_line(t11_device::BUS_ERROR, attotime::zero);
-}
-
-uint16_t bk_state::floppy_cmd_r()
-{
-	return 0;
-}
-
-void bk_state::floppy_cmd_w(uint16_t data)
-{
-	if (BIT(data, 0))
-		m_drive = 0;
-
-	if (BIT(data, 1))
-		m_drive = 1;
-
-	if (BIT(data, 2))
-		m_drive = 2;
-
-	if (BIT(data, 3))
-		m_drive = 3;
-
-	if (data == 0)
-		m_drive = -1;
-}
-
-uint16_t bk_state::floppy_data_r()
-{
-	return 0;
-}
-
-void bk_state::floppy_data_w(uint16_t data)
-{
 }
 
 u32 bk_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)


### PR DESCRIPTION
cpu/t11: VM1 does not use RMW bus transaction for MOV and MOVB insns (fixes writing to floppy)