### PR TITLE
apple/apple2e.cpp: Fix behavior of $c02x softswitches to match behavior of hardware

### DIFF
--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -1778,33 +1778,38 @@ void apple2e_state::do_io(int offset, bool is_iic)
 		return;
 	}
 
+  if ((offset & 0xf0) == 0x20) // tape out / ROM bank on IIc/IIc+
+  {
+  	if (m_cassette)
+		{
+      // Officially Apple only documents this softswitch at $c020 but
+      // all models with a tape interface will respond to any of the $c02x
+      // addresses
+			m_cassette_state ^= 1;
+			m_cassette->output(m_cassette_state ? 1.0f : -1.0f);
+		}
+			
+    if (is_iic)
+		{
+      // Apple IIc Tech Reference 1st edition lists this softswitch at $c028 while
+      // the 2nd edition lists it at $c02x.  Both the IIc and IIc Plus will respond to
+      // $c02x.
+      m_romswitch = !m_romswitch;
+			update_slotrom_banks();
+			lcrom_update();
+
+			// MIG is reset when ROMSWITCH turns off
+			if ((m_isiicplus) && !(m_romswitch))
+			{
+				m_migpage = 0;
+				m_intdrive = false;
+				m_35sel = false;
+			}
+		}
+  }
+
 	switch (offset)
 	{
-		case 0x20:
-			if (m_cassette)
-			{
-				m_cassette_state ^= 1;
-				m_cassette->output(m_cassette_state ? 1.0f : -1.0f);
-			}
-			break;
-
-		case 0x28:
-			if (is_iic)
-			{
-				m_romswitch = !m_romswitch;
-				update_slotrom_banks();
-				lcrom_update();
-
-				// MIG is reset when ROMSWITCH turns off
-				if ((m_isiicplus) && !(m_romswitch))
-				{
-					m_migpage = 0;
-					m_intdrive = false;
-					m_35sel = false;
-				}
-			}
-			break;
-
 		case 0x40:  // utility strobe (not available on IIc)
 			if (!is_iic)
 			{


### PR DESCRIPTION
The $c020 and $c028 softswitches as implemented do not follow what Apple implemented on the IIe, IIc and IIc Plus.  The entire $c02x region should respond, not just $c020 and $c028.  This PR fixes the implementation to match what the hardware does and also to match Apple's documentation (Apple IIc Technical Reference Manual 2nd Ed).

This PR was tested against the behavior of actual Apple IIc Plus hardware.  This PR will break unpatched versions of the game Choplifter, as these are also broken on real Apple IIc Plus hardware running ROM5.  The reason for this is that Choplifter sends its audio out to the cassette out (via $c020) at the same time it sends it to the speaker.  On the IIc and IIc Plus, this toggles the ROM bank being used.  When Choplifter then uses the ROM routine to read the joystick, it will crash on the IIc Plus.  On the IIc, the ROM has a BRK instruction at this location which causes the ROM BRK handler to switch back to the main bank and resume running from that same location.  On the IIc Plus, this area of the alternate bank has been used for diagnostic routines and ends up crashing somewhere in main RAM.

There are versions of Choplifter that work on the IIc Plus, including the one bundled with Total Replay.

Another difference that can be seen without using any additional software is to go into the monitor and attempt to read $c020.  Before this PR, the monitor would give a value for $c020 as A0.  After this PR, the monitor will print the address, but not a value.  This matches the behavior of an Apple IIc Plus.  Address $c028 will behave the same with or without this PR.