### PR TITLE
PPC: Fix qnan check

### DIFF
--- a/src/devices/cpu/powerpc/ppccom.cpp
+++ b/src/devices/cpu/powerpc/ppccom.cpp
@@ -492,8 +492,7 @@ static inline int is_qnan_double(double x)
 {
 	uint64_t xi = *(uint64_t*)&x;
 	return( ((xi & DOUBLE_EXP) == DOUBLE_EXP) &&
-			((xi & 0x0007fffffffffffU) == 0x000000000000000U) &&
-			((xi & 0x000800000000000U) == 0x000800000000000U) );
+			((xi & 0x0008000000000000U) == 0x0008000000000000U) );
 }
 
 


### PR DESCRIPTION
a) all constants were one digit too short
b) the payload was always expected to be 0 (which is just a special case qnan (Real Indefinite) though)