### PR TITLE
osd: better socket handling.

### DIFF
--- a/src/devices/bus/coco/coco_dwsock.cpp
+++ b/src/devices/bus/coco/coco_dwsock.cpp
@@ -143,7 +143,7 @@ u8 beckerport_device::read(offs_t offset)
 			{
 				// Try to read from dws
 				std::error_condition filerr = m_pSocket->read(m_buf, 0, sizeof(m_buf), m_rx_pending);
-				if (filerr && (std::errc::operation_would_block != filerr))
+				if (filerr)
 					osd_printf_error("%s: coco_dwsock.c: beckerport_device::read() socket read operation failed with error %s:%d %s\n", tag(), filerr.category().name(), filerr.value(), filerr.message());
 				else
 					m_head = 0;

--- a/src/osd/modules/file/posixsocket.cpp
+++ b/src/osd/modules/file/posixsocket.cpp
@@ -77,6 +77,10 @@ public:
 				{
 					return std::error_condition(errno, std::generic_category());
 				}
+				else if (result == 0)
+				{
+					return std::errc::connection_reset;
+				}
 				else
 				{
 					actual = std::uint32_t(size_t(result));
@@ -106,7 +110,7 @@ public:
 		{
 			// no data available
 			actual = 0;
-			return std::errc::operation_would_block;
+			return std::error_condition();
 		}
 	}
 

--- a/src/osd/modules/file/winsocket.cpp
+++ b/src/osd/modules/file/winsocket.cpp
@@ -74,6 +74,10 @@ public:
 				{
 					return wsa_error_to_file_error(WSAGetLastError());
 				}
+				else if (result == 0)
+				{
+					return std::errc::connection_reset;
+				}
 				else
 				{
 					actual = result;
@@ -103,7 +107,7 @@ public:
 		{
 			// no data available
 			actual = 0;
-			return std::errc::operation_would_block;
+			return std::error_condition();
 		}
 	}
 


### PR DESCRIPTION
there was a commit (quite some time back) that changed how read operations work (if no data available) -- https://github.com/mamedev/mame/commit/937e416814c9fac8a02efb43ccb4cd2a12b1cf0d

the issue is, that change was made to not confuse "no data available" with "connection closed".
right now, "no data available" will return an error, while "connection closed" returns "no error" (and size of 0)

also it still is confusing, because when a listening socket gets connected to, it ALSO returns "no error" and a size of 0.

as the code already checks if a socket is "readable" via select - and both winsock and posix api state that a recv return value of 0 means a socket was gracefully closed, so rather check for that and return an error.
also "no data available" is - at least for me - not an error at all.

as of my changes, reading "no data" (or a listening socket getting connected) simply returns "no error" with a size of 0 - while reading a closed socket will return connection-reset error.

this makes error handling a lot cleaner (and more logical).