### PR TITLE
Add -rtcdate option to set initial date and/or time for RTCs

### DIFF
--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -4068,6 +4068,23 @@ Core Misc Options
 
             mame galaga88 -nonvram_save
 
+.. _mame-commandline-rtcdate:
+
+**-rtcdate** *<string>*
+
+    Specify a date and/or time to initialize real-time clock devices to (for
+    systems that have one) at the start of machine emulation. The full format is
+    ``YYYY-MM-DD hh:mm:ss``, though either the date or time may be omitted
+    altogether (in which case the system date or time will be used), the seconds
+    may be omitted (defaulting to zero), or the year may be specified alone.
+
+    Note that four-digit years must be specified here, even though RTC devices
+    in emulated systems might not keep track of the century.
+
+    Example:
+        .. code-block:: bash
+
+            mame a1010 -rtcdate 23:59:50
 
 .. _mame-commandline-scripting:
 

--- a/scripts/src/emu.lua
+++ b/scripts/src/emu.lua
@@ -152,6 +152,8 @@ files {
 	MAME_DIR .. "src/emu/emuopts.h",
 	MAME_DIR .. "src/emu/emupal.cpp",
 	MAME_DIR .. "src/emu/emupal.h",
+	MAME_DIR .. "src/emu/emutime.cpp",
+	MAME_DIR .. "src/emu/emutime.h",
 	MAME_DIR .. "src/emu/fileio.cpp",
 	MAME_DIR .. "src/emu/fileio.h",
 	MAME_DIR .. "src/emu/http.h",
@@ -273,8 +275,9 @@ files {
 }
 
 pchsource(MAME_DIR .. "src/emu/main.cpp")
--- 2 files do not include emu.h
+-- 3 files do not include emu.h
 nopch(MAME_DIR .. "src/emu/attotime.cpp")
+nopch(MAME_DIR .. "src/emu/emutime.cpp")
 nopch(MAME_DIR .. "src/emu/debug/textbuf.cpp")
 
 dependency {

--- a/src/devices/bus/gameboy/huc3.cpp
+++ b/src/devices/bus/gameboy/huc3.cpp
@@ -109,6 +109,7 @@
 #include "gbxfile.h"
 
 #include "dirtc.h"
+#include "emutime.h"
 
 #include <algorithm>
 #include <cassert>

--- a/src/devices/bus/gameboy/mbc3.cpp
+++ b/src/devices/bus/gameboy/mbc3.cpp
@@ -78,6 +78,7 @@
 #include "gbxfile.h"
 
 #include "dirtc.h"
+#include "emutime.h"
 
 #include "corestr.h"
 

--- a/src/devices/bus/gba/rom.cpp
+++ b/src/devices/bus/gba/rom.cpp
@@ -16,6 +16,8 @@
 #include "emu.h"
 #include "rom.h"
 
+#include "emutime.h"
+
 
 //-------------------------------------------------
 //  gba_rom_device - constructor
@@ -820,9 +822,9 @@ void gba_s3511_device::update_time(int len)
 	if (len == 7)
 	{
 		m_data[0] = convert_to_bcd(curtime.local_time.year);
-		m_data[1] = convert_to_bcd(curtime.local_time.month + 1);
-		m_data[2] = convert_to_bcd(curtime.local_time.mday);
-		m_data[3] = convert_to_bcd(curtime.local_time.weekday);
+		m_data[1] = convert_to_bcd(curtime.local_time.month);
+		m_data[2] = convert_to_bcd(curtime.local_time.day_of_month);
+		m_data[3] = curtime.local_time.day_of_week();
 		m_data[4] = convert_to_bcd(curtime.local_time.hour);
 		m_data[5] = convert_to_bcd(curtime.local_time.minute);
 		m_data[6] = convert_to_bcd(curtime.local_time.second);

--- a/src/devices/bus/snes/bsx.cpp
+++ b/src/devices/bus/snes/bsx.cpp
@@ -13,6 +13,8 @@
 #include "emu.h"
 #include "bsx.h"
 
+#include "emutime.h"
+
 
 //-------------------------------------------------
 //  sns_rom_bsx_device - constructor

--- a/src/devices/bus/snes/rom21.cpp
+++ b/src/devices/bus/snes/rom21.cpp
@@ -10,6 +10,8 @@
 #include "emu.h"
 #include "rom21.h"
 
+#include "emutime.h"
+
 
 //-------------------------------------------------
 //  sns_rom_device - constructor
@@ -110,13 +112,13 @@ void sns_rom21_srtc_device::update_time()
 	m_rtc_ram[3] = systime->local_time.minute / 10;
 	m_rtc_ram[4] = systime->local_time.hour % 10;
 	m_rtc_ram[5] = systime->local_time.hour / 10;
-	m_rtc_ram[6] = systime->local_time.mday % 10;
-	m_rtc_ram[7] = systime->local_time.mday / 10;
+	m_rtc_ram[6] = systime->local_time.day_of_month % 10;
+	m_rtc_ram[7] = systime->local_time.day_of_month / 10;
 	m_rtc_ram[8] = systime->local_time.month;
 	m_rtc_ram[9] = (systime->local_time.year - 1000) % 10;
 	m_rtc_ram[10] = ((systime->local_time.year - 1000) / 10) % 10;
 	m_rtc_ram[11] = (systime->local_time.year - 1000) / 100;
-	m_rtc_ram[12] = systime->local_time.weekday % 7;
+	m_rtc_ram[12] = systime->local_time.day_of_week();
 }
 
 // Returns day-of-week for specified date

--- a/src/devices/bus/snes/spc7110.h
+++ b/src/devices/bus/snes/spc7110.h
@@ -8,6 +8,8 @@
 #include "snes_slot.h"
 #include "rom21.h"
 
+#include "emutime.h"
+
 
 // ======================> sns_rom_spc7110_device
 

--- a/src/devices/machine/ds1315.cpp
+++ b/src/devices/machine/ds1315.cpp
@@ -27,6 +27,9 @@
 
 #include "emu.h"
 #include "ds1315.h"
+
+#include "emutime.h"
+
 #include "coreutil.h"
 
 
@@ -204,9 +207,10 @@ void ds1315_device::fill_raw_data()
 	raw[2] = dec_2_bcd(systime.local_time.minute);
 	raw[3] = dec_2_bcd(systime.local_time.hour);
 
-	raw[4] = dec_2_bcd((systime.local_time.weekday != 0) ? systime.local_time.weekday : 7);
-	raw[5] = dec_2_bcd(systime.local_time.mday);
-	raw[6] = dec_2_bcd(systime.local_time.month + 1);
+	int weekday = systime.local_time.day_of_week();
+	raw[4] = (weekday != 0) ? weekday : 7;
+	raw[5] = dec_2_bcd(systime.local_time.day_of_month);
+	raw[6] = dec_2_bcd(systime.local_time.month);
 	raw[7] = dec_2_bcd(systime.local_time.year - 1900); /* Epoch is 1900 */
 
 	/* Ok now we have the raw bcd bytes. Now we need to push them into our bit array */

--- a/src/devices/machine/mccs1850.cpp
+++ b/src/devices/machine/mccs1850.cpp
@@ -18,6 +18,8 @@
 #include "emu.h"
 #include "mccs1850.h"
 
+#include "emutime.h"
+
 #include "multibyte.h"
 
 //#define VERBOSE 0

--- a/src/devices/machine/spg2xx_io.cpp
+++ b/src/devices/machine/spg2xx_io.cpp
@@ -8,6 +8,8 @@
 #include "emu.h"
 #include "spg2xx_io.h"
 
+#include "emutime.h"
+
 DEFINE_DEVICE_TYPE(SPG24X_IO, spg24x_io_device, "spg24x_io", "SPG240-series System-on-a-Chip I/O")
 DEFINE_DEVICE_TYPE(SPG28X_IO, spg28x_io_device, "spg28x_io", "SPG280-series System-on-a-Chip I/O")
 

--- a/src/emu/dirtc.cpp
+++ b/src/emu/dirtc.cpp
@@ -11,6 +11,8 @@
 #include "emu.h"
 #include "dirtc.h"
 
+#include "emutime.h"
+
 
 //**************************************************************************
 //  MACROS / CONSTANTS
@@ -79,8 +81,8 @@ void device_rtc_interface::set_time(bool update, int year, int month, int day, i
 
 void device_rtc_interface::set_current_time(const system_time &systime)
 {
-	const system_time::full_time &time = m_use_utc ? systime.utc_time : systime.local_time;
-	set_time(true, time.year, time.month + 1, time.mday, time.weekday + 1,
+	const util::arbitrary_datetime &time = m_use_utc ? systime.utc_time : systime.local_time;
+	set_time(true, time.year, time.month, time.day_of_month, time.day_of_week() + 1,
 		time.hour, time.minute, time.second);
 }
 

--- a/src/emu/emufwd.h
+++ b/src/emu/emufwd.h
@@ -141,6 +141,9 @@ class memory_view;
 // declared in emuopts.h
 class emu_options;
 
+// declared in emutime.h
+class system_time;
+
 // declared in fileio.h
 class emu_file;
 

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -212,6 +212,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_UI_MOUSE,                                   "1",         core_options::option_type::BOOLEAN,    "display UI mouse cursor" },
 	{ OPTION_LANGUAGE ";lang",                           "",          core_options::option_type::STRING,     "set UI display language" },
 	{ OPTION_NVRAM_SAVE ";nvwrite",                      "1",         core_options::option_type::BOOLEAN,    "save NVRAM data on exit" },
+	{ OPTION_RTCDATE,                                    "",          core_options::option_type::STRING,     "set RTC to a given date and/or time at start" },
 
 	{ nullptr,                                           nullptr,     core_options::option_type::HEADER,     "SCRIPTING OPTIONS" },
 	{ OPTION_AUTOBOOT_COMMAND ";ab",                     nullptr,     core_options::option_type::STRING,     "command to execute after machine boot" },

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -172,6 +172,7 @@
 #define OPTION_UI                   "ui"
 #define OPTION_RAMSIZE              "ramsize"
 #define OPTION_NVRAM_SAVE           "nvram_save"
+#define OPTION_RTCDATE              "rtcdate"
 
 // core comm options
 #define OPTION_COMM_LOCAL_HOST      "comm_localhost"
@@ -456,6 +457,7 @@ public:
 	ui_option ui() const { return m_ui; }
 	const char *ram_size() const { return value(OPTION_RAMSIZE); }
 	bool nvram_save() const { return bool_value(OPTION_NVRAM_SAVE); }
+	const char *rtcdate() const { return value(OPTION_RTCDATE); }
 
 	// core comm options
 	const char *comm_localhost() const { return value(OPTION_COMM_LOCAL_HOST); }

--- a/src/emu/emutime.cpp
+++ b/src/emu/emutime.cpp
@@ -1,0 +1,134 @@
+// license:BSD-3-Clause
+// copyright-holders:Aaron Giles
+/***************************************************************************
+
+    emutime.cpp
+
+    System time utilities for MAME.
+
+***************************************************************************/
+
+#include "emutime.h"
+#include "osdcore.h"
+
+
+//**************************************************************************
+//  SYSTEM TIME
+//**************************************************************************
+
+//-------------------------------------------------
+//  system_time - constructor
+//-------------------------------------------------
+
+system_time::system_time()
+{
+	set(0);
+}
+
+system_time::system_time(time_t t)
+{
+	set(t);
+}
+
+
+//-------------------------------------------------
+//  set - fills out a system_time structure
+//-------------------------------------------------
+
+void system_time::set(time_t t)
+{
+	// FIXME: this crashes if localtime or gmtime returns nullptr
+	time = t;
+	local_time = util::arbitrary_datetime(*localtime(&t));
+	utc_time = util::arbitrary_datetime(*gmtime(&t));
+}
+
+
+//-------------------------------------------------
+//  customize - check whether string conforms to
+//  YYYY-MM-DD hh:mm:ss format and modify date
+//  and/or time if it does
+//-------------------------------------------------
+
+bool system_time::customize(std::string_view str)
+{
+	int yr = -1, mo = -1, dy = -1, hh = -1, mm = -1, ss = -1;
+	if (str.length() >= 4 && str.find_first_not_of("0123456789") >= 4)
+	{
+		yr = (str[0] - '0') * 1000 + (str[1] - '0') * 100 + (str[2] - '0') * 10 + (str[3] - '0');
+		if (str.length() == 4)
+			str = std::string_view();
+		else
+		{
+			if (str.length() < 10 || str[4] != str[7] || str[4] != '-')
+				return false;
+			if (str[5] < '0' || str[5] > '1' || str[6] < (str[5] == '0' ? '1' : '0') || str[6] > (str[5] == '1' ? '2' : '9'))
+				return false;
+			if (str[8] < '0' || str[8] > '3' || str[9] < (str[8] == '0' ? '1' : '0') || str[9] > (str[8] == '3' ? '1' : '9'))
+				return false;
+			mo = (str[5] - '0') * 10 + (str[6] - '0');
+			dy = (str[8] - '0') * 10 + (str[9] - '0');
+			if (str.length() == 10)
+				str = std::string_view();
+			else
+			{
+				auto pos = str.find_first_not_of(' ', 10);
+				if (pos > 10 && pos != std::string_view::npos)
+					str.remove_prefix(pos);
+				else
+					return false;
+			}
+		}
+	}
+	if (!str.empty())
+	{
+		if (str.length() < 5 || str[2] != ':')
+			return false;
+		if (str[0] < '0' || str[0] > '2' || str[1] < '0' || (str[1] > (str[0] == '2' ? '3' : '9')))
+			return false;
+		if (str[3] < '0' || str[3] > '5' || str[4] < '0' || str[4] > '9')
+			return false;
+		hh = (str[0] - '0') * 10 + (str[1] - '0');
+		mm = (str[3] - '0') * 10 + (str[4] - '0');
+		ss = 0;
+		if (str.length() != 5)
+		{
+			if (str.length() != 8 || str[5] != ':')
+				return false;
+			if (str[6] < '0' || str[6] > '5' || str[7] < '0' || str[7] > '9')
+				return false;
+			ss = (str[6] - '0') * 10 + (str[7] - '0');
+		}
+	}
+
+	if (yr != -1)
+	{
+		local_time.year = utc_time.year = yr;
+		if (mo != -1)
+		{
+			local_time.month = utc_time.month = mo;
+			local_time.day_of_month = utc_time.day_of_month = dy;
+		}
+		else if (!gregorian_is_leap_year(yr))
+		{
+			// Mitigate potential problems of having Leap Day in a non-leap year
+			if (local_time.month == 2 && local_time.day_of_month == 29)
+			{
+				local_time.month = 3;
+				local_time.day_of_month = 1;
+			}
+			if (utc_time.month == 2 && utc_time.day_of_month == 29)
+			{
+				utc_time.month = 3;
+				utc_time.day_of_month = 1;
+			}
+		}
+	}
+	if (hh != -1)
+	{
+		local_time.hour = utc_time.hour = hh;
+		local_time.minute = utc_time.minute = mm;
+		local_time.second = utc_time.second = ss;
+	}
+	return true;
+}

--- a/src/emu/emutime.h
+++ b/src/emu/emutime.h
@@ -1,0 +1,43 @@
+// license:BSD-3-Clause
+// copyright-holders:Aaron Giles
+/***************************************************************************
+
+    emutime.h
+
+    System time utilities for MAME.
+
+***************************************************************************/
+
+#ifndef MAME_EMU_EMUTIME_H
+#define MAME_EMU_EMUTIME_H
+
+#pragma once
+
+#include "timeconv.h"
+
+#include <ctime>
+#include <string_view>
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> system_time
+
+// system time description, both local and UTC
+class system_time
+{
+public:
+	system_time();
+	explicit system_time(time_t t);
+	void set(time_t t);
+
+	bool customize(std::string_view str);
+
+	int64_t                     time;       // number of seconds elapsed since midnight, January 1 1970 UTC
+	util::arbitrary_datetime    local_time; // local time
+	util::arbitrary_datetime    utc_time;   // UTC coordinated time
+};
+
+#endif // MAME_EMU_EMUTIME_H

--- a/src/emu/ioport.cpp
+++ b/src/emu/ioport.cpp
@@ -12,6 +12,7 @@
 
 #include "config.h"
 #include "emuopts.h"
+#include "emutime.h"
 #include "fileio.h"
 #include "inputdev.h"
 #include "main.h"

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -59,38 +59,6 @@ constexpr int DEBUG_FLAG_OSD_ENABLED    = 0x00001000;       // The OSD debugger 
 //  TYPE DEFINITIONS
 //**************************************************************************
 
-// ======================> system_time
-
-// system time description, both local and UTC
-class system_time
-{
-public:
-	system_time();
-	explicit system_time(time_t t);
-	void set(time_t t);
-
-	struct full_time
-	{
-		void set(struct tm &t);
-
-		u8          second;     // seconds (0-59)
-		u8          minute;     // minutes (0-59)
-		u8          hour;       // hours (0-23)
-		u8          mday;       // day of month (1-31)
-		u8          month;      // month (0-11)
-		s32         year;       // year (1=1 AD)
-		u8          weekday;    // day of week (0-6)
-		u16         day;        // day of year (0-365)
-		u8          is_dst;     // is this daylight savings?
-	};
-
-	s64           time;       // number of seconds elapsed since midnight, January 1 1970 UTC
-	full_time       local_time; // local time
-	full_time       utc_time;   // UTC coordinated time
-};
-
-
-
 // ======================> running_machine
 
 typedef delegate<void ()> machine_notify_delegate;

--- a/src/lib/formats/fsmeta.cpp
+++ b/src/lib/formats/fsmeta.cpp
@@ -63,7 +63,7 @@ meta_type meta_value::type() const
 
 util::arbitrary_datetime meta_value::as_date() const
 {
-	util::arbitrary_datetime result = { 0, };
+	util::arbitrary_datetime result;
 
 	std::visit(
 		overloaded

--- a/src/lib/util/timeconv.cpp
+++ b/src/lib/util/timeconv.cpp
@@ -68,23 +68,63 @@ std::chrono::system_clock::duration system_clock_adjustment(calculate_system_clo
     IMPLEMENTATION
 ***************************************************************************/
 
+//-------------------------------------------------
+//  day_of_week - return the weekday (0=Sunday)
+//-------------------------------------------------
+
+int arbitrary_datetime::day_of_week() const
+{
+	return absolute_day(year, month, day_of_month) % 7;
+}
+
+
+//-------------------------------------------------
+//  day_of_year - return the day of year (0-365)
+//-------------------------------------------------
+
+int arbitrary_datetime::day_of_year() const
+{
+	int result = day_of_month - 1;
+
+	for (int i = 1; i < month; i++)
+		result += gregorian_days_in_month(i, year);
+
+	return result;
+}
+
+
 arbitrary_datetime arbitrary_datetime::now()
 {
 	time_t sec;
 	time(&sec);
 	auto t = *localtime(&sec);
 
-	arbitrary_datetime dt;
-	dt.year         = t.tm_year + 1900;
-	dt.month        = t.tm_mon + 1;
-	dt.day_of_month = t.tm_mday;
-	dt.hour         = t.tm_hour;
-	dt.minute       = t.tm_min;
-	dt.second       = t.tm_sec;
-
-	return dt;
+	// FIXME: this crashes if localtime returns nullptr
+	return arbitrary_datetime(t);
 }
 
+
+//-------------------------------------------------
+//  absolute_day - returns the absolute day count
+//  for the specified year/month/day
+//-------------------------------------------------
+
+int64_t arbitrary_datetime::absolute_day(int year, int month, int day)
+{
+	// first factor the year
+	int64_t result = (year - 1) * 365;
+	result += (year - 1) / 4;
+	result -= (year - 1) / 100;
+	result += (year - 1) / 400;
+
+	// then the month
+	for (int i = 1; i < month; i++)
+		result += gregorian_days_in_month(i, year);
+
+	// then the day
+	result += day - 1;
+	return result;
+}
 
 
 // -------------------------------------------------

--- a/src/mame/apple/cuda.cpp
+++ b/src/mame/apple/cuda.cpp
@@ -53,6 +53,7 @@
 #include "emu.h"
 #include "cuda.h"
 #include "cpu/m6805/m6805.h"
+#include "emutime.h"
 
 #define LOG_ADB         (1U << 1)   // low-level ADB details
 #define LOG_I2C         (1U << 2)   // low-level I2C details
@@ -221,8 +222,8 @@ void cuda_device::pc_w(u8 data)
 				cur_time.tm_sec = systime.local_time.second;
 				cur_time.tm_min = systime.local_time.minute;
 				cur_time.tm_hour = systime.local_time.hour;
-				cur_time.tm_mday = systime.local_time.mday;
-				cur_time.tm_mon = systime.local_time.month;
+				cur_time.tm_mday = systime.local_time.day_of_month;
+				cur_time.tm_mon = systime.local_time.month - 1;
 				cur_time.tm_year = systime.local_time.year - 1900;
 				cur_time.tm_isdst = 0;
 

--- a/src/mame/apple/egret.cpp
+++ b/src/mame/apple/egret.cpp
@@ -53,6 +53,7 @@
 
 #include "emu.h"
 #include "egret.h"
+#include "emutime.h"
 
 #define LOG_ADB (1U << 1)      // low-level ADB details
 #define LOG_PRAM (1U << 2)     // PRAM handling info
@@ -259,8 +260,8 @@ void egret_device::pc_w(u8 data)
 				cur_time.tm_sec = systime.local_time.second;
 				cur_time.tm_min = systime.local_time.minute;
 				cur_time.tm_hour = systime.local_time.hour;
-				cur_time.tm_mday = systime.local_time.mday;
-				cur_time.tm_mon = systime.local_time.month;
+				cur_time.tm_mday = systime.local_time.day_of_month;
+				cur_time.tm_mon = systime.local_time.month - 1;
 				cur_time.tm_year = systime.local_time.year - 1900;
 				cur_time.tm_isdst = 0;
 

--- a/src/mame/apple/lisa_m.cpp
+++ b/src/mame/apple/lisa_m.cpp
@@ -40,6 +40,7 @@
 
 #include "emu.h"
 #include "lisa.h"
+#include "emutime.h"
 #include "screen.h"
 
 
@@ -808,13 +809,14 @@ void lisa_state::nvram_init(nvram_device &nvram, void *data, size_t size)
 		/* Now we copy the host clock into the Lisa clock */
 		system_time systime;
 		machine().base_datetime(systime);
+		int day = systime.local_time.day_of_year() + 1;
 
 		m_clock_regs.alarm = 0xfffffL;
 		/* The clock count starts on 1st January 1980 */
 		m_clock_regs.years = (systime.local_time.year - 1980) & 0xf;
-		m_clock_regs.days1 = (systime.local_time.day + 1) / 100;
-		m_clock_regs.days2 = ((systime.local_time.day + 1) / 10) % 10;
-		m_clock_regs.days3 = (systime.local_time.day + 1) % 10;
+		m_clock_regs.days1 = day / 100;
+		m_clock_regs.days2 = (day / 10) % 10;
+		m_clock_regs.days3 = day % 10;
 		m_clock_regs.hours1 = systime.local_time.hour / 10;
 		m_clock_regs.hours2 = systime.local_time.hour % 10;
 		m_clock_regs.minutes1 = systime.local_time.minute / 10;

--- a/src/mame/apple/macprtb.cpp
+++ b/src/mame/apple/macprtb.cpp
@@ -108,6 +108,7 @@
 #include "sound/asc.h"
 
 #include "emupal.h"
+#include "emutime.h"
 #include "screen.h"
 #include "softlist_dev.h"
 #include "speaker.h"
@@ -343,8 +344,8 @@ void macportable_state::pmu_p0_w(u8 data)
 		cur_time.tm_sec = systime.local_time.second;
 		cur_time.tm_min = systime.local_time.minute;
 		cur_time.tm_hour = systime.local_time.hour;
-		cur_time.tm_mday = systime.local_time.mday;
-		cur_time.tm_mon = systime.local_time.month;
+		cur_time.tm_mday = systime.local_time.day_of_month;
+		cur_time.tm_mon = systime.local_time.month - 1;
 		cur_time.tm_year = systime.local_time.year - 1900;
 		cur_time.tm_isdst = 0;
 

--- a/src/mame/canon/x07.cpp
+++ b/src/mame/canon/x07.cpp
@@ -31,6 +31,7 @@
 #include "emu.h"
 #include "x07.h"
 
+#include "emutime.h"
 #include "screen.h"
 #include "softlist_dev.h"
 #include "speaker.h"
@@ -55,9 +56,9 @@ void x07_state::t6834_cmd (uint8_t cmd)
 			machine().current_datetime(systime);
 			m_out.data[m_out.write++] = (systime.local_time.year>>8) & 0xff;
 			m_out.data[m_out.write++] = systime.local_time.year & 0xff;
-			m_out.data[m_out.write++] = systime.local_time.month + 1;
-			m_out.data[m_out.write++] = systime.local_time.mday;
-			m_out.data[m_out.write++] = ~(((0x01 << (7 - systime.local_time.weekday)) - 1) & 0xff);
+			m_out.data[m_out.write++] = systime.local_time.month;
+			m_out.data[m_out.write++] = systime.local_time.day_of_month;
+			m_out.data[m_out.write++] = ~(((0x01 << (7 - systime.local_time.day_of_week())) - 1) & 0xff);
 			m_out.data[m_out.write++] = systime.local_time.hour;
 			m_out.data[m_out.write++] = systime.local_time.minute;
 			m_out.data[m_out.write++] = systime.local_time.second;
@@ -157,7 +158,7 @@ void x07_state::t6834_cmd (uint8_t cmd)
 		{
 				system_time systime;
 				machine().current_datetime(systime);
-				m_out.data[m_out.write++] = systime.local_time.weekday;
+				m_out.data[m_out.write++] = systime.local_time.day_of_week();
 		}
 		break;
 

--- a/src/mame/epson/px4.cpp
+++ b/src/mame/epson/px4.cpp
@@ -25,6 +25,7 @@
 
 #include "diserial.h"
 #include "emupal.h"
+#include "emutime.h"
 #include "screen.h"
 #include "softlist_dev.h"
 #include "speaker.h"
@@ -576,12 +577,12 @@ uint8_t px4_state::sior_r()
 		{
 		case 1: m_sior = (dec_2_bcd(m_time.local_time.year) >> 4) & 0xf; break;
 		case 2: m_sior = dec_2_bcd(m_time.local_time.year) & 0xf; break;
-		case 3: m_sior = dec_2_bcd(m_time.local_time.month + 1); break;
-		case 4: m_sior = dec_2_bcd(m_time.local_time.mday); break;
+		case 3: m_sior = dec_2_bcd(m_time.local_time.month); break;
+		case 4: m_sior = dec_2_bcd(m_time.local_time.day_of_month); break;
 		case 5: m_sior = dec_2_bcd(m_time.local_time.hour); break;
 		case 6: m_sior = dec_2_bcd(m_time.local_time.minute); break;
 		case 7: m_sior = dec_2_bcd(m_time.local_time.second); break;
-		case 8: m_sior = dec_2_bcd(m_time.local_time.weekday); break;
+		case 8: m_sior = dec_2_bcd(m_time.local_time.day_of_week()); break;
 		}
 
 		// done?

--- a/src/mame/itech/iteagle_fpga.cpp
+++ b/src/mame/itech/iteagle_fpga.cpp
@@ -2,6 +2,9 @@
 // copyright-holders:Ted Green
 #include "emu.h"
 #include "iteagle_fpga.h"
+
+#include "emutime.h"
+
 #include "coreutil.h"
 
 #define LOG_FPGA            (1U << 1)
@@ -597,9 +600,10 @@ void iteagle_fpga_device::rtc_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 				raw[2] = dec_2_bcd(systime.local_time.minute);
 				raw[3] = dec_2_bcd(systime.local_time.hour);
 
-				raw[4] = dec_2_bcd((systime.local_time.weekday != 0) ? systime.local_time.weekday : 7);
-				raw[5] = dec_2_bcd(systime.local_time.mday);
-				raw[6] = dec_2_bcd(systime.local_time.month + 1);
+				int weekday = systime.local_time.day_of_week();
+				raw[4] = dec_2_bcd((weekday != 0) ? weekday : 7);
+				raw[5] = dec_2_bcd(systime.local_time.day_of_month);
+				raw[6] = dec_2_bcd(systime.local_time.month);
 				raw[7] = dec_2_bcd(systime.local_time.year - 1900); // Epoch is 1900
 				m_rtc_regs[0x7F8/4] = (raw[3]<<24) | (raw[2]<<16) | (raw[1]<<8) | (raw[0] <<0);
 				m_rtc_regs[0x7FC/4] = (raw[7]<<24) | (raw[6]<<16) | (raw[5]<<8) | (raw[4] <<0);
@@ -845,9 +849,10 @@ uint32_t iteagle_periph_device::ctrl_r(offs_t offset, uint32_t mem_mask)
 					m_rtc_regs[4] = dec_2_bcd(systime.local_time.hour);
 					m_rtc_regs[5] = 0x00; // Hours Alarm
 
-					m_rtc_regs[6] = dec_2_bcd((systime.local_time.weekday != 0) ? systime.local_time.weekday : 7);
-					m_rtc_regs[7] = dec_2_bcd(systime.local_time.mday);
-					m_rtc_regs[8] = dec_2_bcd(systime.local_time.month + 1);
+					int weekday = systime.local_time.day_of_week();
+					m_rtc_regs[6] = dec_2_bcd((weekday != 0) ? weekday : 7);
+					m_rtc_regs[7] = dec_2_bcd(systime.local_time.day_of_month);
+					m_rtc_regs[8] = dec_2_bcd(systime.local_time.month);
 					m_rtc_regs[9] = dec_2_bcd(systime.local_time.year - 1900); // Epoch is 1900
 					//m_rtc_regs[9] = 0x99; // Use 1998
 					//m_rtc_regs[0xa] &= ~0x10; // Reg A Status

--- a/src/mame/koei/pasogo.cpp
+++ b/src/mame/koei/pasogo.cpp
@@ -110,6 +110,7 @@ TODO:
 #include "machine/genpc.h"
 #include "machine/timer.h"
 #include "emupal.h"
+#include "emutime.h"
 #include "screen.h"
 #include "softlist_dev.h"
 

--- a/src/mame/konami/k573mcal.cpp
+++ b/src/mame/konami/k573mcal.cpp
@@ -23,6 +23,7 @@
 #include "k573mcal.h"
 
 #include "machine/timehelp.h"
+#include "emutime.h"
 
 #include "multibyte.h"
 
@@ -89,9 +90,9 @@ int k573mcal_device::handle_message(const uint8_t* send_buffer, uint32_t send_si
 
 		*recv_buffer++ = 0x01; // status, must be 1
 		*recv_buffer++ = uint8_t(systime.local_time.year % 100);
-		*recv_buffer++ = uint8_t(systime.local_time.month + 1);
-		*recv_buffer++ = systime.local_time.mday;
-		*recv_buffer++ = systime.local_time.weekday;
+		*recv_buffer++ = systime.local_time.month;
+		*recv_buffer++ = systime.local_time.day_of_month;
+		*recv_buffer++ = systime.local_time.day_of_week();
 		*recv_buffer++ = systime.local_time.hour;
 		*recv_buffer++ = systime.local_time.minute;
 		*recv_buffer++ = seconds; // Can't be the same value twice in a row

--- a/src/mame/merit/meritm.cpp
+++ b/src/mame/merit/meritm.cpp
@@ -188,6 +188,7 @@ Not all regional versions are available for each Megatouch series
 #include "sound/ay8910.h"
 #include "video/v9938.h"
 
+#include "emutime.h"
 #include "speaker.h"
 
 
@@ -519,9 +520,9 @@ uint8_t meritm_state::ds1644_r(offs_t offset)
 		m_ram[0x7ff9] = binary_to_BCD(systime.local_time.second);
 		m_ram[0x7ffa] = binary_to_BCD(systime.local_time.minute);
 		m_ram[0x7ffb] = binary_to_BCD(systime.local_time.hour);
-		m_ram[0x7ffc] = binary_to_BCD(systime.local_time.weekday+1);
-		m_ram[0x7ffd] = binary_to_BCD(systime.local_time.mday);
-		m_ram[0x7ffe] = binary_to_BCD(systime.local_time.month+1);
+		m_ram[0x7ffc] = systime.local_time.day_of_week() + 1;
+		m_ram[0x7ffd] = binary_to_BCD(systime.local_time.day_of_month);
+		m_ram[0x7ffe] = binary_to_BCD(systime.local_time.month);
 		m_ram[0x7fff] = binary_to_BCD(systime.local_time.year % 100);
 	}
 	return m_ram[rambank*0x2000 + 0x1ff8 + offset];

--- a/src/mame/midway/midwayic.cpp
+++ b/src/mame/midway/midwayic.cpp
@@ -9,6 +9,8 @@
 #include "emu.h"
 #include "midwayic.h"
 
+#include "emutime.h"
+
 #define LOG_IRQ             (1U << 1)
 #define LOG_NVRAM           (1U << 2)
 #define LOG_FIFO            (1U << 3)
@@ -511,9 +513,9 @@ void midway_serial_pic2_device::write(u8 data)
 					m_buffer[m_total++] = make_bcd(systime.local_time.second);
 					m_buffer[m_total++] = make_bcd(systime.local_time.minute);
 					m_buffer[m_total++] = make_bcd(systime.local_time.hour);
-					m_buffer[m_total++] = make_bcd(systime.local_time.weekday + 1);
-					m_buffer[m_total++] = make_bcd(systime.local_time.mday);
-					m_buffer[m_total++] = make_bcd(systime.local_time.month + 1);
+					m_buffer[m_total++] = systime.local_time.day_of_week() + 1;
+					m_buffer[m_total++] = make_bcd(systime.local_time.day_of_month);
+					m_buffer[m_total++] = make_bcd(systime.local_time.month);
 					m_buffer[m_total++] = make_bcd(systime.local_time.year - 1900 - m_yearoffs);
 				}
 				else

--- a/src/mame/midway/tmaster.cpp
+++ b/src/mame/midway/tmaster.cpp
@@ -104,6 +104,7 @@ Chips:
 #include "video/cesblit.h"
 
 #include "emupal.h"
+#include "emutime.h"
 #include "screen.h"
 #include "speaker.h"
 
@@ -246,9 +247,9 @@ uint16_t tmaster_state::rtc_r(offs_t offset)
 	m_rtc_ram[0x1] = binary_to_bcd(systime.local_time.second);
 	m_rtc_ram[0x2] = binary_to_bcd(systime.local_time.minute);
 	m_rtc_ram[0x3] = binary_to_bcd(systime.local_time.hour);
-	m_rtc_ram[0x4] = binary_to_bcd(systime.local_time.weekday);
-	m_rtc_ram[0x5] = binary_to_bcd(systime.local_time.mday);
-	m_rtc_ram[0x6] = binary_to_bcd(systime.local_time.month+1);
+	m_rtc_ram[0x4] = systime.local_time.day_of_week();
+	m_rtc_ram[0x5] = binary_to_bcd(systime.local_time.day_of_month);
+	m_rtc_ram[0x6] = binary_to_bcd(systime.local_time.month);
 	m_rtc_ram[0x7] = binary_to_bcd(systime.local_time.year % 100);
 
 	return m_rtc_ram[offset];

--- a/src/mame/nec/pc9801_memsw.cpp
+++ b/src/mame/nec/pc9801_memsw.cpp
@@ -79,6 +79,8 @@
 #include "emu.h"
 #include "pc9801_memsw.h"
 
+#include "emutime.h"
+
 #include "coreutil.h"
 
 //**************************************************************************

--- a/src/mame/nintendo/n64_m.cpp
+++ b/src/mame/nintendo/n64_m.cpp
@@ -10,7 +10,7 @@
 #include "cpu/mips/mips3.h"
 #include "cpu/mips/mips3com.h"
 
-#include "debugger.h"
+#include "emutime.h"
 #include "screen.h"
 
 #include <algorithm>
@@ -2019,9 +2019,9 @@ int n64_periphs::pif_channel_handle_command(int channel, int slength, uint8_t *s
 					rdata[0] = convert_to_bcd(systime.local_time.second); // Seconds
 					rdata[1] = convert_to_bcd(systime.local_time.minute); // Minutes
 					rdata[2] = 0x80 | convert_to_bcd(systime.local_time.hour); // Hours
-					rdata[3] = convert_to_bcd(systime.local_time.mday); // Day of month
-					rdata[4] = convert_to_bcd(systime.local_time.weekday); // Day of week
-					rdata[5] = convert_to_bcd(systime.local_time.month + 1); // Month
+					rdata[3] = convert_to_bcd(systime.local_time.day_of_month); // Day of month
+					rdata[4] = convert_to_bcd(systime.local_time.day_of_week()); // Day of week
+					rdata[5] = convert_to_bcd(systime.local_time.month); // Month
 					rdata[6] = convert_to_bcd(systime.local_time.year % 100); // Year
 					rdata[7] = convert_to_bcd(systime.local_time.year / 100); // Century
 					rdata[8] = 0x00;
@@ -2608,7 +2608,7 @@ void n64_periphs::dd_reg_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 					system_time systime;
 					machine().base_datetime(systime);
 
-					dd_data_reg = (convert_to_bcd(systime.local_time.mday) << 24) | (convert_to_bcd(systime.local_time.hour) << 16);
+					dd_data_reg = (convert_to_bcd(systime.local_time.day_of_month) << 24) | (convert_to_bcd(systime.local_time.hour) << 16);
 					break;
 				}
 

--- a/src/mame/nintendo/vt1682.cpp
+++ b/src/mame/nintendo/vt1682.cpp
@@ -69,6 +69,7 @@
 #include "machine/timer.h"
 #include "sound/dac.h"
 #include "emupal.h"
+#include "emutime.h"
 #include "screen.h"
 #include "speaker.h"
 

--- a/src/mame/nokia/nokia_3310.cpp
+++ b/src/mame/nokia/nokia_3310.cpp
@@ -19,6 +19,7 @@
 
 #include "debugger.h"
 #include "emupal.h"
+#include "emutime.h"
 #include "screen.h"
 
 #define LOG_MAD2_REGISTER_ACCESS    (1U << 1)
@@ -395,7 +396,7 @@ uint8_t noki3310_state::nokia_ccont_r()
 		case 0x7:       data = systime.local_time.second;           break;
 		case 0x8:       data = systime.local_time.minute;           break;
 		case 0x9:       data = systime.local_time.hour;             break;
-		case 0xa:       data = systime.local_time.mday;             break;
+		case 0xa:       data = systime.local_time.day_of_month;     break;
 		case 0xe:       data |= 0x01;                               break;
 	}
 

--- a/src/mame/pinball/wpc_95.cpp
+++ b/src/mame/pinball/wpc_95.cpp
@@ -49,6 +49,7 @@ ToDo:
 #include "machine/nvram.h"
 #include "machine/timer.h"
 
+#include "emutime.h"
 #include "speaker.h"
 
 namespace {
@@ -230,7 +231,7 @@ uint8_t wpc_95_state::rtc_r(offs_t offset)
 	// This may get wonky if the game is running on year change.  Find
 	// something better to do at that time.
 
-	uint8_t day = (systime.local_time.day - m_rtc_base_day) & 31;
+	uint8_t day = (systime.local_time.day_of_year() - m_rtc_base_day) & 31;
 	uint8_t hour = systime.local_time.hour;
 	uint8_t min = systime.local_time.minute;
 
@@ -299,9 +300,9 @@ void wpc_95_state::machine_reset()
 	machine().base_datetime(systime);
 	m_mainram[0x1800] = systime.local_time.year >> 8;
 	m_mainram[0x1801] = systime.local_time.year;
-	m_mainram[0x1802] = systime.local_time.month+1;
-	m_mainram[0x1803] = systime.local_time.mday;
-	m_mainram[0x1804] = systime.local_time.weekday+1;
+	m_mainram[0x1802] = systime.local_time.month;
+	m_mainram[0x1803] = systime.local_time.day_of_month;
+	m_mainram[0x1804] = systime.local_time.day_of_week() + 1;
 	m_mainram[0x1805] = 0;
 	m_mainram[0x1806] = 1;
 	uint16_t checksum = 0;
@@ -310,7 +311,7 @@ void wpc_95_state::machine_reset()
 	checksum = ~checksum;
 	m_mainram[0x1807] = checksum >> 8;
 	m_mainram[0x1808] = checksum;
-	m_rtc_base_day = systime.local_time.day;
+	m_rtc_base_day = systime.local_time.day_of_year();
 
 	m_serial_clock_state = m_serial_data1_state = m_serial_data2_state = false;
 	m_serial_clock_counter = 0;

--- a/src/mame/pinball/wpc_dcs.cpp
+++ b/src/mame/pinball/wpc_dcs.cpp
@@ -37,6 +37,7 @@ ToDo:
 #include "cpu/m6809/m6809.h"
 #include "machine/nvram.h"
 
+#include "emutime.h"
 #include "speaker.h"
 
 namespace {
@@ -184,7 +185,7 @@ uint8_t wpc_dcs_state::rtc_r(offs_t offset)
 	// This may get wonky if the game is running on year change.  Find
 	// something better to do at that time.
 
-	uint8_t day = (systime.local_time.day - m_rtc_base_day) & 31;
+	uint8_t day = (systime.local_time.day_of_year() - m_rtc_base_day) & 31;
 	uint8_t hour = systime.local_time.hour;
 	uint8_t min = systime.local_time.minute;
 
@@ -256,9 +257,9 @@ void wpc_dcs_state::machine_reset()
 	machine().base_datetime(systime);
 	m_mainram[0x1800] = systime.local_time.year >> 8;
 	m_mainram[0x1801] = systime.local_time.year;
-	m_mainram[0x1802] = systime.local_time.month+1;
-	m_mainram[0x1803] = systime.local_time.mday;
-	m_mainram[0x1804] = systime.local_time.weekday+1;
+	m_mainram[0x1802] = systime.local_time.month;
+	m_mainram[0x1803] = systime.local_time.day_of_month;
+	m_mainram[0x1804] = systime.local_time.day_of_week() + 1;
 	m_mainram[0x1805] = 0;
 	m_mainram[0x1806] = 1;
 	uint16_t checksum = 0;
@@ -267,7 +268,7 @@ void wpc_dcs_state::machine_reset()
 	checksum = ~checksum;
 	m_mainram[0x1807] = checksum >> 8;
 	m_mainram[0x1808] = checksum;
-	m_rtc_base_day = systime.local_time.day;
+	m_rtc_base_day = systime.local_time.day_of_year();
 }
 
 void wpc_dcs_state::init()

--- a/src/mame/pinball/wpc_s.cpp
+++ b/src/mame/pinball/wpc_s.cpp
@@ -49,6 +49,7 @@ ToDo:
 #include "cpu/m6809/m6809.h"
 #include "machine/nvram.h"
 
+#include "emutime.h"
 #include "speaker.h"
 
 namespace {
@@ -214,7 +215,7 @@ uint8_t wpc_s_state::rtc_r(offs_t offset)
 	// This may get wonky if the game is running on year change.  Find
 	// something better to do at that time.
 
-	uint8_t day = (systime.local_time.day - m_rtc_base_day) & 31;
+	uint8_t day = (systime.local_time.day_of_year() - m_rtc_base_day) & 31;
 	uint8_t hour = systime.local_time.hour;
 	uint8_t min = systime.local_time.minute;
 
@@ -285,9 +286,9 @@ void wpc_s_state::machine_reset()
 	machine().base_datetime(systime);
 	m_mainram[0x1800] = systime.local_time.year >> 8;
 	m_mainram[0x1801] = systime.local_time.year;
-	m_mainram[0x1802] = systime.local_time.month+1;
-	m_mainram[0x1803] = systime.local_time.mday;
-	m_mainram[0x1804] = systime.local_time.weekday+1;
+	m_mainram[0x1802] = systime.local_time.month;
+	m_mainram[0x1803] = systime.local_time.day_of_month;
+	m_mainram[0x1804] = systime.local_time.day_of_week() + 1;
 	m_mainram[0x1805] = 0;
 	m_mainram[0x1806] = 1;
 	uint16_t checksum = 0;
@@ -296,7 +297,7 @@ void wpc_s_state::machine_reset()
 	checksum = ~checksum;
 	m_mainram[0x1807] = checksum >> 8;
 	m_mainram[0x1808] = checksum;
-	m_rtc_base_day = systime.local_time.day;
+	m_rtc_base_day = systime.local_time.day_of_year();
 }
 
 void wpc_s_state::init()

--- a/src/mame/sega/sega_beena.cpp
+++ b/src/mame/sega/sega_beena.cpp
@@ -146,6 +146,7 @@
 
 #include "crsshair.h"
 #include "emupal.h"
+#include "emutime.h"
 #include "render.h"
 #include "softlist_dev.h"
 #include "schedule.h"
@@ -1700,9 +1701,9 @@ void sega_9h0_0008_state::update_rtc()
 	m_rtc[0] = systime.local_time.second;
 	m_rtc[1] = systime.local_time.minute;
 	m_rtc[2] = systime.local_time.hour;
-	m_rtc[3] = systime.local_time.mday;
-	m_rtc[4] = systime.local_time.weekday;
-	m_rtc[5] = systime.local_time.month;
+	m_rtc[3] = systime.local_time.day_of_month;
+	m_rtc[4] = systime.local_time.day_of_week();
+	m_rtc[5] = systime.local_time.month - 1;
 	m_rtc[6] = systime.local_time.year - 2000;
 }
 

--- a/src/mame/sharp/x1.cpp
+++ b/src/mame/sharp/x1.cpp
@@ -198,6 +198,7 @@ Notes:
 #include "emu.h"
 #include "x1.h"
 
+#include "emutime.h"
 #include "softlist_dev.h"
 #include "speaker.h"
 
@@ -2143,9 +2144,9 @@ void x1_state::machine_start()
 		system_time systime;
 		machine().base_datetime(systime);
 
-		m_rtc.day = ((systime.local_time.mday / 10)<<4) | ((systime.local_time.mday % 10) & 0xf);
-		m_rtc.month = ((systime.local_time.month+1));
-		m_rtc.wday = ((systime.local_time.weekday % 10) & 0xf);
+		m_rtc.day = ((systime.local_time.day_of_month / 10)<<4) | ((systime.local_time.day_of_month % 10) & 0xf);
+		m_rtc.month = systime.local_time.month;
+		m_rtc.wday = systime.local_time.day_of_week();
 		m_rtc.year = (((systime.local_time.year % 100)/10)<<4) | ((systime.local_time.year % 10) & 0xf);
 		m_rtc.hour = ((systime.local_time.hour / 10)<<4) | ((systime.local_time.hour % 10) & 0xf);
 		m_rtc.min = ((systime.local_time.minute / 10)<<4) | ((systime.local_time.minute % 10) & 0xf);

--- a/src/mame/snk/ngp.cpp
+++ b/src/mame/snk/ngp.cpp
@@ -112,6 +112,7 @@ the Neogeo Pocket.
 #include "sound/dac.h"
 
 #include "dirtc.h"
+#include "emutime.h"
 #include "screen.h"
 #include "softlist_dev.h"
 #include "speaker.h"


### PR DESCRIPTION
* Remove system_time class from emu.h and rebase it on util::arbitrary_datetime
* util/timeconv.cpp: Add struct tm converter and day_of_week and day_of_year functions to arbitrary_datetime