### PR TITLE
heathzenith/h89.cpp: Connect write-enable pullup on new h89bus

### DIFF
--- a/src/devices/bus/heathzenith/h89/h89bus.cpp
+++ b/src/devices/bus/heathzenith/h89/h89bus.cpp
@@ -257,12 +257,12 @@ u8 h89bus_device::io_dispatch_r(offs_t offset)
 			{
 				if (entry.m_p506_signals)
 				{
-					// p506 has FLPY but not CASS or LP
+					// p506 does not have CASS or LP
 					retval |= entry.read(decode & ~(H89_CASS | H89_LP), offset & 7);
 				}
 				else
 				{
-					// p504/p505 have CASS and LP but not FLPY
+					// p504/p505 does not have FLPY
 					retval |= entry.read(decode & ~H89_FLPY , offset & 7);
 				}
 			}
@@ -295,12 +295,12 @@ void h89bus_device::io_dispatch_w(offs_t offset, u8 data)
 			{
 				if (entry.m_p506_signals)
 				{
-					// p506 has FLPY but not CASS or LP1
-					entry.write(decode & ~H89_CASS, offset & 7, data);
+					// p506 does not have CASS or LP
+					entry.write(decode &  ~(H89_CASS | H89_LP), offset & 7, data);
 				}
 				else
 				{
-					// p504/p505 have LP1 and CASS but not FLPY
+					// p504/p505 does not have FLPY
 					entry.write(decode & ~H89_FLPY, offset & 7, data);
 				}
 			}

--- a/src/devices/bus/heathzenith/h89/h_88_3.cpp
+++ b/src/devices/bus/heathzenith/h89/h_88_3.cpp
@@ -22,10 +22,10 @@ namespace {
 class h_88_3_device : public device_t, public device_h89bus_right_card_interface
 {
 public:
-		h_88_3_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = XTAL(1'843'200).value());
+	h_88_3_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = XTAL(1'843'200).value());
 
-		virtual void write(u8 select_lines, u8 offset, u8 data) override;
-		virtual u8 read(u8 select_lines, u8 offset) override;
+	virtual void write(u8 select_lines, u8 offset, u8 data) override;
+	virtual u8 read(u8 select_lines, u8 offset) override;
 
 protected:
 	h_88_3_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);

--- a/src/devices/bus/heathzenith/h89/h_88_5.cpp
+++ b/src/devices/bus/heathzenith/h89/h_88_5.cpp
@@ -26,7 +26,7 @@
 #define LOG_LINES (1U << 2)
 #define LOG_CASS  (1U << 3)
 #define LOG_FUNC  (1U << 4)
-#define VERBOSE (0xff)
+#define VERBOSE (0)
 
 #include "logmacro.h"
 

--- a/src/devices/bus/heathzenith/h89/sigmasoft_sound.cpp
+++ b/src/devices/bus/heathzenith/h89/sigmasoft_sound.cpp
@@ -213,4 +213,4 @@ void h89bus_sigmasoft_snd_device::device_add_mconfig(machine_config &config)
 
 }   // anonymous namespace
 
-DEFINE_DEVICE_TYPE_PRIVATE(H89BUS_SIGMASOFT_SND, device_h89bus_right_card_interface, h89bus_sigmasoft_snd_device, "h89sigmasnd", "SigmaSoft Sound Effects Board");
+DEFINE_DEVICE_TYPE_PRIVATE(H89BUS_SIGMASOFT_SND, device_h89bus_right_card_interface, h89bus_sigmasoft_snd_device, "h89_sigma_snd", "SigmaSoft Sound Effects Board");

--- a/src/devices/bus/heathzenith/h89/we_pullup.cpp
+++ b/src/devices/bus/heathzenith/h89/we_pullup.cpp
@@ -2,9 +2,15 @@
 // copyright-holders:Mark Garlanger
 /***************************************************************************
 
-  Heathkit Write enable pull
+  Heathkit Write Enable pull up resistor
 
-    On
+    The H89 has a 1k floppy RAM which can be write protected. With the original
+    equipment, the hard-sector controller card (H-88-1) could control the memory.
+    In later systems, Heath/Zenith wanted to provide a system with only the soft-
+    sectored controller (Z-89-37), but needed to allow writing to the floppy RAM.
+    Heath provided a pullup resistor with the new controller, which allowed the
+    memory to always be write enabled, this was installed on slot P506. Without
+    this, HDOS is not bootable on Z-89-37 soft-sectored controller.
 
 ****************************************************************************/
 


### PR DESCRIPTION
Connect the write-enable pull-up used for floppy RAM in the new h89bus architecture.
- add handler in h89.cpp
- rename flag from m_floppy_ram_wp to m_floppy_ram_we to reflect slot signal name
- complete file comments for bus/heathzenith/h89/we_pullup.cpp

Some minor cleanup of the new h89bus code
- fix write select signal mask for p506
- disable debug logging
- update some comments