### PR TITLE
hash/gba.xml, hash/nes.xml: add Pin Eight's Lockjaw games

### DIFF
--- a/hash/gba.xml
+++ b/hash/gba.xml
@@ -19476,6 +19476,58 @@ Hangs during cutscene after beating Maxim for best ending path (i.e. before real
 		</part>
 	</software>
 
+	<software name="ljref">
+		<description>LOCKJAW: The Reference</description>
+		<year>2008</year>
+		<publisher>Pin Eight</publisher>
+		<info name="release" value="20081108" />
+		<info name="version" value="0.46a" />
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="73376">
+				<rom name="lockjaw the reference.bin" size="73376" crc="6897efa6" sha1="adb4627516929229054cef024d481f4f49d3469e" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ljtod">
+		<description>LOCKJAW: The Overdose</description>
+		<year>2006</year>
+		<publisher>Pin Eight</publisher>
+		<info name="release" value="20060722" />
+		<info name="version" value="M4" />
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="147200">
+				<rom name="lockjaw the overdose.bin" size="147200" crc="7d286b94" sha1="e5f3eef9d7ed3aa3bf31a33b4b528e8d2384aaa2" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="todm3" cloneof="ljtod">
+		<description>Tetanus on Drugs (Milestone 3)</description>
+		<year>2003</year>
+		<publisher>Pin Eight</publisher>
+		<info name="release" value="20030629" />
+		<info name="version" value="M3" />
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="156032">
+				<rom name="tetanus on drugs m3.bin" size="156032" crc="8ba01ad0" sha1="521b51f252e1c7ef33e1503f55877a7692e174ba" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="todm1" cloneof="ljtod">
+		<description>Tetanus on Drugs (Preview Release 1)</description>
+		<year>2002</year>
+		<publisher>Pin Eight</publisher>
+		<info name="release" value="20020506" />
+		<info name="version" value="PR1" />
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="126064">
+				<rom name="tetanus on drugs pr1.bin" size="126064" crc="2fcadfd3" sha1="9eb41661684af832539b21455d01028ff7053444" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="loonybia">
 		<description>Looney Tunes - Back in Action (Europe, USA)</description>
 		<year>2003</year>

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -22197,6 +22197,181 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="lj65">
+		<description>LJ65 (0.41, NTSC)</description>
+		<year>2009</year>
+		<publisher>Pin Eight</publisher>
+		<info name="release" value="20090602" />
+		<info name="version" value="0.41" />
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="nrom" />
+			<feature name="pcb" value="NES-NROM-128" />
+			<feature name="mirroring" value="horizontal" />
+			<dataarea name="prg" size="32768">
+				<rom name="lj65 0.41 prg" size="16384" crc="2c54109c" sha1="4d27a00707e05dbfe98af524c54e21f28d837641" offset="00000" />
+				<rom size="16384" offset="0x4000" loadflag="reload" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="lj65 0.41 chr" size="8192" crc="de91b2e6" sha1="b1f4389010a908c1cedd2b632b5abace4263899b" offset="00000" />
+			</dataarea>
+			<!-- 8k WRAM on cartridge -->
+			<dataarea name="wram" size="8192" />
+		</part>
+	</software>
+
+	<software name="lj65pal" cloneof="lj65">
+		<description>LJ65 (0.41, PAL)</description>
+		<year>2009</year>
+		<publisher>Pin Eight</publisher>
+		<info name="release" value="20090602" />
+		<info name="version" value="0.41" />
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="nrom" />
+			<feature name="pcb" value="NES-NROM-128" />
+			<feature name="mirroring" value="horizontal" />
+			<dataarea name="prg" size="32768">
+				<rom name="lj65-pal 0.41 prg" size="16384" crc="fffbc8ea" sha1="ccc6bb05aeb9a168097273113e53f2a79a804d73" offset="00000" />
+				<rom size="16384" offset="0x4000" loadflag="reload" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="lj65 0.41 chr" size="8192" crc="de91b2e6" sha1="b1f4389010a908c1cedd2b632b5abace4263899b" offset="00000" />
+			</dataarea>
+			<!-- 8k WRAM on cartridge -->
+			<dataarea name="wram" size="8192" />
+		</part>
+	</software>
+
+	<software name="tetrim30" cloneof="lj65">
+		<description>Tetrimino (0.30, NTSC)</description>
+		<year>2007</year>
+		<publisher>Pin Eight</publisher>
+		<info name="release" value="20070218" />
+		<info name="version" value="0.30" />
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="nrom" />
+			<feature name="pcb" value="NES-NROM-128" />
+			<feature name="mirroring" value="horizontal" />
+			<dataarea name="prg" size="32768">
+				<rom name="tetrimino 0.30 prg" size="16384" crc="546ff8b1" sha1="ced291dc67243d351ed80bb755682ae4fbcd8277" offset="00000" />
+				<rom size="16384" offset="0x4000" loadflag="reload" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="tetrimino 0.30 chr" size="8192" crc="9a4b6cfd" sha1="6cc933bf0df4aa1946106e1d80831c0f8e2c6faa" offset="00000" />
+			</dataarea>
+			<!-- 8k WRAM on cartridge -->
+			<dataarea name="wram" size="8192" />
+		</part>
+	</software>
+
+	<software name="tetrim30pal" cloneof="lj65">
+		<description>Tetrimino (0.30, PAL)</description>
+		<year>2007</year>
+		<publisher>Pin Eight</publisher>
+		<info name="release" value="20070218" />
+		<info name="version" value="0.30" />
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="nrom" />
+			<feature name="pcb" value="NES-NROM-128" />
+			<feature name="mirroring" value="horizontal" />
+			<dataarea name="prg" size="32768">
+				<rom name="tetrimino-pal 0.30 prg" size="16384" crc="22fca23b" sha1="6dec4e7b8ab198637f96f33098f5c0d024d3fcea" offset="00000" />
+				<rom size="16384" offset="0x4000" loadflag="reload" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="tetrimino 0.30 chr" size="8192" crc="9a4b6cfd" sha1="6cc933bf0df4aa1946106e1d80831c0f8e2c6faa" offset="00000" />
+			</dataarea>
+			<!-- 8k WRAM on cartridge -->
+			<dataarea name="wram" size="8192" />
+		</part>
+	</software>
+
+	<software name="tetrim27" cloneof="lj65">
+		<description>Tetrimino (0.27, NTSC)</description>
+		<year>2005</year>
+		<publisher>Pin Eight</publisher>
+		<info name="release" value="20051029" />
+		<info name="version" value="0.27" />
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="nrom" />
+			<feature name="pcb" value="NES-NROM-128" />
+			<feature name="mirroring" value="horizontal" />
+			<dataarea name="prg" size="32768">
+				<rom name="tetrimino 0.27 prg" size="16384" crc="1497769d" sha1="79ae948bc1ca3787738ed6a94e91045ef8f44d55" offset="00000" />
+				<rom size="16384" offset="0x4000" loadflag="reload" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="tetrimino 0.27 chr" size="8192" crc="9b83a887" sha1="6ba81be4e23f3a38a80ddeba69bf11c6efd3476d" offset="00000" />
+			</dataarea>
+			<!-- 8k WRAM on cartridge -->
+			<dataarea name="wram" size="8192" />
+		</part>
+	</software>
+
+	<software name="tetrim27pal" cloneof="lj65">
+		<description>Tetrimino (0.27, PAL)</description>
+		<year>2005</year>
+		<publisher>Pin Eight</publisher>
+		<info name="release" value="20051029" />
+		<info name="version" value="0.27" />
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="nrom" />
+			<feature name="pcb" value="NES-NROM-128" />
+			<feature name="mirroring" value="horizontal" />
+			<dataarea name="prg" size="32768">
+				<rom name="tetrimino-pal 0.27 prg" size="16384" crc="d55a6236" sha1="0b3effe6edc1699dc9d4c3294839591331ae6d1b" offset="00000" />
+				<rom size="16384" offset="0x4000" loadflag="reload" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="tetrimino 0.27 chr" size="8192" crc="9b83a887" sha1="6ba81be4e23f3a38a80ddeba69bf11c6efd3476d" offset="00000" />
+			</dataarea>
+			<!-- 8k WRAM on cartridge -->
+			<dataarea name="wram" size="8192" />
+		</part>
+	</software>
+
+	<software name="tetrim2" cloneof="lj65">
+		<description>Tetrimino (0.2)</description>
+		<year>2003</year>
+		<publisher>Pin Eight</publisher>
+		<info name="release" value="20031217" />
+		<info name="version" value="0.2" />
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="nrom" />
+			<feature name="pcb" value="NES-NROM-256" />
+			<feature name="mirroring" value="horizontal" />
+			<dataarea name="prg" size="32768">
+				<rom name="tetrimino 0.2 prg" size="16384" crc="6b69b03d" sha1="6c92b8c9f5e5ec9be99a96ba9a134e0a85bd1139" offset="00000" />
+				<rom size="16384" offset="0x4000" loadflag="reload" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="tetrimino 0.2 chr" size="8192" crc="f883d794" sha1="b940c8f1dcb19be7b6aefb303b184386c82ca1bc" offset="00000" />
+			</dataarea>
+			<!-- 8k WRAM on cartridge -->
+			<dataarea name="wram" size="8192" />
+		</part>
+	</software>
+
+	<software name="tetrim1" cloneof="lj65">
+		<description>Tetrimino (0.1)</description>
+		<year>2003</year>
+		<publisher>Pin Eight</publisher>
+		<info name="release" value="20031101" />
+		<info name="version" value="0.1" />
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="nrom" />
+			<feature name="pcb" value="NES-NROM-256" />
+			<feature name="mirroring" value="horizontal" />
+			<dataarea name="prg" size="32768">
+				<rom name="tetrimino 0.1 prg" size="32768" crc="80fe53e0" sha1="790bc8d2d844b4f49a5ece72d91d6bcac8414c5b" offset="00000" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="tetrimino 0.1 chr" size="8192" crc="2e87f789" sha1="6544d571d5d0bf1b9dc028fd06aa3dc853c33199" offset="00000" />
+			</dataarea>
+			<!-- 8k WRAM on cartridge -->
+			<dataarea name="wram" size="8192" />
+		</part>
+	</software>
+
 	<software name="lonerang">
 		<description>The Lone Ranger (USA)</description>
 		<year>1991</year>


### PR DESCRIPTION
These titles were retrieved out of the Way Back Machine; some versions were not archived by it, it is unknown if they will surface again.

New working software list items (gba.xml)
-----------------------------------------
LOCKJAW: The Reference
LOCKJAW: The Overdose
Tetanus on Drugs (Milestone 3)
Tetanus on Drugs (Preview Release 1)

New working software list items (nes.xml)
-----------------------------------------
LJ65 (0.41, NTSC)
LJ65 (0.41, PAL)
Tetrimino (0.30, NTSC)
Tetrimino (0.30, PAL)
Tetrimino (0.27, NTSC)
Tetrimino (0.27, PAL)
Tetrimino (0.2)
Tetrimino (0.1)