### PR TITLE
tehkanwc: correct refresh rate

### DIFF
--- a/src/mame/tecmo/tehkanwc.cpp
+++ b/src/mame/tecmo/tehkanwc.cpp
@@ -429,8 +429,8 @@ void tehkanwc_state::shared_mem(address_map &map)
 	map(0xc800, 0xcfff).ram().share("shareram");
 	map(0xd000, 0xd3ff).ram().w(FUNC(tehkanwc_state::videoram_w)).share("videoram");
 	map(0xd400, 0xd7ff).ram().w(FUNC(tehkanwc_state::colorram_w)).share("colorram");
-	map(0xd800, 0xddff).writeonly().w(m_palette, FUNC(palette_device::write8)).share("palette");
-	map(0xde00, 0xdfff).nopw(); // unused part of the palette RAM, I think? Gridiron writes here
+	map(0xd800, 0xddff).ram().w(m_palette, FUNC(palette_device::write8)).share("palette");
+	map(0xde00, 0xdfff).ram(); // unused part of the palette RAM, I think? Gridiron writes here
 	map(0xe000, 0xe7ff).ram().w(FUNC(tehkanwc_state::videoram2_w)).share("videoram2");
 	map(0xe800, 0xebff).ram().share("spriteram");
 	map(0xec00, 0xec01).w(FUNC(tehkanwc_state::scroll_x_w));
@@ -820,8 +820,8 @@ void tehkanwc_state::tehkanwc(machine_config &config)
 
 	/* video hardware */
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
+	screen.set_refresh_hz(60.61);
+	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500));
 	screen.set_size(32*8, 32*8);
 	screen.set_visarea(0*8, 32*8-1, 2*8, 30*8-1);
 	screen.set_screen_update(FUNC(tehkanwc_state::screen_update));

--- a/src/mame/tecmo/tehkanwc.cpp
+++ b/src/mame/tecmo/tehkanwc.cpp
@@ -430,7 +430,7 @@ void tehkanwc_state::shared_mem(address_map &map)
 	map(0xd000, 0xd3ff).ram().w(FUNC(tehkanwc_state::videoram_w)).share("videoram");
 	map(0xd400, 0xd7ff).ram().w(FUNC(tehkanwc_state::colorram_w)).share("colorram");
 	map(0xd800, 0xddff).ram().w(m_palette, FUNC(palette_device::write8)).share("palette");
-	map(0xde00, 0xdfff).ram(); // unused part of the palette RAM, I think? Gridiron writes here
+	map(0xde00, 0xdfff).ram().share("palette2"); // unused part of the palette RAM, I think? Gridiron writes here
 	map(0xe000, 0xe7ff).ram().w(FUNC(tehkanwc_state::videoram2_w)).share("videoram2");
 	map(0xe800, 0xebff).ram().share("spriteram");
 	map(0xec00, 0xec01).w(FUNC(tehkanwc_state::scroll_x_w));


### PR DESCRIPTION
Small edit to:

- confirm that the vblank time is correct (comment removed)
- correct the refresh rate (derived from my extracted schematics)
- make the palette a _ram()_ so it matches the PCB (again, see schematics). It also makes it possible to dump it on MAME debugger (which is convenient for my workflow, please allow it) 

video timing:
![image](https://github.com/user-attachments/assets/cdc9637f-80ed-4c6c-ac4a-3af38cf52a3b)

[schematics](https://github.com/user-attachments/files/17611390/tehkanwch.pdf)  (missing a few signals, work in progress)
