### PR TITLE
misc/compucranes.cpp: Fix ROM sizes, year, comments, etc. and add a new game

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -29328,7 +29328,8 @@ comebaby                        // (c) 2000 ExPotato
 mastcrane                       // (c) 199? Compumatic
 mastcranea                      // (c) 199? Compumatic
 mastcraneb                      // (c) 199? Compumatic
-octopussy                       // (c) 1990 Covielsa
+octopussy                       // (c) 2000 Covielsa
+toyshop                         // (c) 2012 OM Vending
 
 @source:misc/coolpool.cpp
 9ballsht                        // (c) 1993 E-Scape EnterMedia + "marketed by Bundra Games"

--- a/src/mame/misc/compucranes.cpp
+++ b/src/mame/misc/compucranes.cpp
@@ -1,9 +1,9 @@
 // license:BSD-3-Clause
 // copyright-holders:
-/***************************************************************************
+/********************************************************************************
 
  Skeleton driver for MCS51-based crane coinops from Compumatic.
- The same PCB was used on machines from different manufacturers, like OMVending
+ The same PCB was used on machines from different manufacturers, like OM Vending
  and Covielsa.
 
  Display is just a four digits 7-segments (on a small PCB called "Plumadig").
@@ -32,7 +32,7 @@
  | ________________    ____     ____  oo|
  || EPROM         | TL7705ACP         oo|
  ||_______________|    ____           oo|<- ATX Power
- |                    24C64           oo|   Supply conn
+ |                    24C16           oo|   Supply conn
  | ___________________   Xtal         oo|
  || 80C32            |   12MHz  TEST  oo|
  ||__________________|           SW   oo|
@@ -41,14 +41,12 @@
   DISPLAY SENSOR SPK SELECT JOYSTICK
           +V RET
 
- The MCU on the older PCBs can differ between 80C32 compatible models
- (found with a Winbond W78C32C-40 and with a TS80C32X2-MCA).
-
- V2 uses a 24C16 SEEPROM, while later models use a 24C64.
+ The MCU on the older PCBs can differ between 80C32 compatible models (found
+ with a Winbond W78C32C-40 and with a TS80C32X2-MCA).
 
  "GANCHONEW" V1 PCB has a different layout.
 
-***************************************************************************/
+********************************************************************************/
 
 #include "emu.h"
 #include "cpu/mcs51/mcs51.h"
@@ -77,15 +75,15 @@ INPUT_PORTS_END
 
 void compucranes_state::ganchonew(machine_config &config)
 {
-	I80C32(config, m_maincpu, 6_MHz_XTAL);
+	I80C32(config, m_maincpu, 12_MHz_XTAL/2);
 
 	SPEAKER(config, "mono").front_center();
 }
 
-// "GANCHONEW V8" PCB with ATX PSU connector
+// "GANCHONEW V8" PCB with ATX PSU connector. TS80C32X2-MCA CPU.
 ROM_START(mastcrane)
 	ROM_REGION(0x80000, "maincpu", 0)
-	ROM_LOAD("v8.ic3",      0x00000, 0x20000, CRC(c47d11ad) SHA1(b0e784b7f68492f2872c06674f92d582def9cd26))
+	ROM_LOAD("v8.ic3",      0x00000, 0x40000, CRC(733dfcbc) SHA1(d18d7945e9b8f189f2169d3d90c3cfea97d3b39c)) // 1ST AND 2ND HALF IDENTICAL
 
 	ROM_REGION(0x00117, "pld", 0)
 	ROM_LOAD("gal16v8.ic4", 0x00000, 0x00117, CRC(4d665a06) SHA1(504f0107482f636cd216579e982c6162c0b120a7)) // Verified to be the same on all known PCB revisions
@@ -94,19 +92,19 @@ ROM_END
 // "GANCHONEW V7" PCB with AT PSU connector
 ROM_START(mastcranea)
 	ROM_REGION(0x80000, "maincpu", 0)
-	ROM_LOAD("v7.ic3",      0x00000, 0x20000, CRC(c3a5a2fe) SHA1(1f89508420b8eb829081bdee17b3248030063d20))
+	ROM_LOAD("v7.ic3",      0x00000, 0x40000, CRC(733dfcbc) SHA1(d18d7945e9b8f189f2169d3d90c3cfea97d3b39c)) // 1ST AND 2ND HALF IDENTICAL (W29C020C)
 
 	ROM_REGION(0x00117, "pld", 0)
 	ROM_LOAD("atf16v8.ic4", 0x00000, 0x00117, CRC(4d665a06) SHA1(504f0107482f636cd216579e982c6162c0b120a7)) // Verified to be the same on all known PCB revisions
 ROM_END
 
-// "GANCHONEW V2" PCB with AT PSU connector
+// "GANCHONEW V2" PCB with AT PSU connector. W78C32C-40 CPU.
 ROM_START(mastcraneb)
 	ROM_REGION(0x80000, "maincpu", 0)
 	ROM_LOAD("505.ic3",     0x00000, 0x20000, CRC(3dbb83f1) SHA1(3536762937332add0ca942283cc22ff301884a4a))
 
 	ROM_REGION(0x00117, "pld", 0)
-	ROM_LOAD("gal16v8.ic4", 0x00000, 0x00117, CRC(4d665a06) SHA1(504f0107482f636cd216579e982c6162c0b120a7)) // Verified to be the same on all known PCB revisions
+	ROM_LOAD("atf168b.ic4", 0x00000, 0x00117, CRC(4d665a06) SHA1(504f0107482f636cd216579e982c6162c0b120a7)) // Verified to be the same on all known PCB revisions
 ROM_END
 
 // "GANCHONEW V2" PCB with AT PSU connector
@@ -118,10 +116,21 @@ ROM_START(octopussy)
 	ROM_LOAD("atf16v8.ic4", 0x00000, 0x00117, CRC(4d665a06) SHA1(504f0107482f636cd216579e982c6162c0b120a7))
 ROM_END
 
+/* Direct clone of the GANCHONEW PCB by OM Vending, silkcreened as "CPU GRUA V2  O. M. VENDING".
+   Atmel AT89AS52 as CPU, probably the internal ROM is not used, but should be confirmed. 12 MHz xtal. 24C16 SEEPROM. */
+ROM_START(toyshop)
+	ROM_REGION(0x80000, "maincpu", 0)
+	ROM_LOAD("39sf040.ic3", 0x00000, 0x80000, CRC(0d9d157d) SHA1(e70f095d3524e3a4c8d5d07857bb2692b6260cc1))
+
+	ROM_REGION(0x00117, "pld", 0)
+	ROM_LOAD("atf16v8.ic4", 0x00000, 0x00117, NO_DUMP)
+ROM_END
+
 } // anonymous namespace
 
 //    YEAR  NAME        PARENT     MACHINE    INPUT      CLASS              INIT        ROT   COMPANY       FULLNAME                FLAGS
 GAME( 199?, mastcrane,  0,         ganchonew, ganchonew, compucranes_state, empty_init, ROT0, "Compumatic", "Master Crane (set 1)", MACHINE_IS_SKELETON_MECHANICAL )
 GAME( 199?, mastcranea, mastcrane, ganchonew, ganchonew, compucranes_state, empty_init, ROT0, "Compumatic", "Master Crane (set 2)", MACHINE_IS_SKELETON_MECHANICAL )
 GAME( 199?, mastcraneb, mastcrane, ganchonew, ganchonew, compucranes_state, empty_init, ROT0, "Compumatic", "Master Crane (set 3)", MACHINE_IS_SKELETON_MECHANICAL )
-GAME( 1990, octopussy,  mastcrane, ganchonew, ganchonew, compucranes_state, empty_init, ROT0, "Covielsa",   "Octopussy",            MACHINE_IS_SKELETON_MECHANICAL )
+GAME( 2000, octopussy,  mastcrane, ganchonew, ganchonew, compucranes_state, empty_init, ROT0, "Covielsa",   "Octopussy",            MACHINE_IS_SKELETON_MECHANICAL )
+GAME( 2012, toyshop,    0,         ganchonew, ganchonew, compucranes_state, empty_init, ROT0, "OM Vending", "Toy Shop",             MACHINE_IS_SKELETON_MECHANICAL )


### PR DESCRIPTION
New systems marked not working
------------------------------
OM Vending Toy Shop

* No credits for the new set (anonymous).
* Fix ROM sizes for 'mastcrane' and 'mastcrane'.
* Fix year for 'octopussy'.
* Fix hardware notes: All SEPROMs are 24C16, CPU types, etc.
* Fix xtal value (it's 12 MHz, not 6).