### PR TITLE
upd7220: Fix pitch calculation in rdat/wdat routines

### DIFF
--- a/src/devices/video/upd7220.cpp
+++ b/src/devices/video/upd7220.cpp
@@ -467,7 +467,7 @@ inline void upd7220_device::reset_figs_param()
 inline uint16_t upd7220_device::read_vram()
 {
 	uint16_t const data = readword(m_ead);
-	m_ead += x_dir[m_figs.m_dir] + (y_dir[m_figs.m_dir] * m_pitch);
+	m_ead += x_dir[m_figs.m_dir] + (y_dir[m_figs.m_dir] * get_pitch());
 	m_ead &= 0x3ffff;
 
 	return data;
@@ -587,7 +587,7 @@ inline void upd7220_device::wdat(uint8_t type, uint8_t mod)
 	for(int i = 0; i < m_figs.m_dc + 1; i++)
 	{
 		write_vram(type, mod, result);
-		m_ead += x_dir[m_figs.m_dir] + (y_dir[m_figs.m_dir] * m_pitch);
+		m_ead += x_dir[m_figs.m_dir] + (y_dir[m_figs.m_dir] * get_pitch());
 		m_ead &= 0x3ffff;
 	}
 }
@@ -1696,7 +1696,7 @@ void upd7220_device::dack_w(uint8_t data)
 		{
 			m_dma_data = ((m_dma_data & 0xff) | data << 8) & m_mask;
 			write_vram(m_dma_type, m_dma_mod, m_dma_data);
-			m_ead += x_dir[m_figs.m_dir] + (y_dir[m_figs.m_dir] * m_pitch);
+			m_ead += x_dir[m_figs.m_dir] + (y_dir[m_figs.m_dir] * get_pitch());
 			m_ead &= 0x3ffff;
 		}
 		else
@@ -1707,13 +1707,13 @@ void upd7220_device::dack_w(uint8_t data)
 	case 2:
 		m_dma_data = data & (m_mask & 0xff);
 		write_vram(m_dma_type, m_dma_mod, m_dma_data);
-		m_ead += x_dir[m_figs.m_dir] + (y_dir[m_figs.m_dir] * m_pitch);
+		m_ead += x_dir[m_figs.m_dir] + (y_dir[m_figs.m_dir] * get_pitch());
 		m_ead &= 0x3ffff;
 		break;
 	case 3:
 		m_dma_data = (data << 8) & (m_mask & 0xff00);
 		write_vram(m_dma_type, m_dma_mod, m_dma_data);
-		m_ead += x_dir[m_figs.m_dir] + (y_dir[m_figs.m_dir] * m_pitch);
+		m_ead += x_dir[m_figs.m_dir] + (y_dir[m_figs.m_dir] * get_pitch());
 		m_ead &= 0x3ffff;
 		break;
 	default:


### PR DESCRIPTION
When the upd7220 is calculating the next EAD for read or write operation it should look at the GD bit set with the FIGS command and when it is set during mixed mode half the pitch value. This was already being done for the graphics figure drawing functions, but the rdat,wdat and dma read/write functions were using the unmodified pitch. 

This causes a noticeable problem in valdocs on the QX-10 as it uses wdat to draw its block cursor, but the pitch value is set to 80 characters per line, but when drawing graphics needs to be halved to reach the correct next effective address. In valdocs this would show up as the cursor being twice as tall with a gap between every other line.

Writing some test code on my QX-10 that sets mixed mode with a pitch of 80 and then draws a block cursor with and without the GD bit being set seems to support this as well. 

I tested this patch with the following systems and I did not notice any obvious issues:
PC-98 (various games)
VT240
DEC Rainbow (Graphics diagnostics)
NCR Deskmate V (Graphics demos)
