### PR TITLE
epson/qx10.cpp: Revert commits that broke zoom handling on the QX10

### DIFF
--- a/src/mame/epson/qx10.cpp
+++ b/src/mame/epson/qx10.cpp
@@ -40,7 +40,6 @@
 #include "bus/rs232/rs232.h"
 #include "cpu/z80/z80.h"
 #include "imagedev/floppy.h"
-#include "imagedev/snapquik.h"
 #include "machine/am9517a.h"
 #include "machine/i8255.h"
 #include "machine/mc146818.h"
@@ -51,12 +50,13 @@
 #include "machine/upd765.h"
 #include "machine/z80sio.h"
 #include "sound/spkrdev.h"
+#include "speaker.h"
 #include "video/upd7220.h"
-
 #include "emupal.h"
+
 #include "screen.h"
 #include "softlist_dev.h"
-#include "speaker.h"
+#include "imagedev/snapquik.h"
 
 
 namespace {
@@ -149,7 +149,7 @@ private:
 
 	DECLARE_QUICKLOAD_LOAD_MEMBER(quickload_cb);
 
-	void palette_init(palette_device &palette) const;
+	void qx10_palette(palette_device &palette) const;
 	void dma_hrq_changed(int state);
 
 	UPD7220_DISPLAY_PIXELS_MEMBER( hgdc_display_pixels );
@@ -184,8 +184,6 @@ private:
 	required_device<screen_device> m_screen;
 	required_device<ram_device> m_ram;
 	required_device<palette_device> m_palette;
-
-	bitmap_rgb32 m_bitmap;
 
 	/* FDD */
 	int     m_fdcint = 0;
@@ -241,8 +239,13 @@ UPD7220_DISPLAY_PIXELS_MEMBER( qx10_state::hgdc_display_pixels )
 		pen = ((gfx[0] >> xi) & 1) ? 1 : 0;
 		pen|= ((gfx[1] >> xi) & 1) ? 2 : 0;
 		pen|= ((gfx[2] >> xi) & 1) ? 4 : 0;
-
-		bitmap.pix(y, x+xi) = palette[pen];
+		for (int z = 0; z <= m_zoom; ++z)
+		{
+			int xval = ((x+xi)*(m_zoom+1))+z;
+			if (xval >= bitmap.cliprect().width() * 2)
+				continue;
+			bitmap.pix(y, xval) = palette[pen];
+		}
 	}
 }
 
@@ -275,8 +278,8 @@ UPD7220_DRAW_TEXT_LINE_MEMBER( qx10_state::hgdc_draw_text )
 
 			for (int xi = 0; xi < 8; xi++)
 			{
-				int res_x = ((x * 8) + xi);
-				int res_y = y + yi;
+				int res_x = ((x * 8) + xi) * (m_zoom + 1);
+				int res_y = y + (yi * (m_zoom + 1));
 
 				// TODO: cpm22mf:flop2 display random character test will go out of bounds here
 				if(!m_screen->visible_area().contains(res_x, res_y))
@@ -288,8 +291,14 @@ UPD7220_DRAW_TEXT_LINE_MEMBER( qx10_state::hgdc_draw_text )
 				else
 					pen = ((tile_data >> xi) & 1) ? color : 0;
 
-				if (pen)
-					bitmap.pix(res_y, res_x) = palette[pen];
+				for (int zx = 0; zx <= m_zoom; ++zx)
+				{
+					for (int zy = 0; zy <= m_zoom; ++zy)
+					{
+						if(pen)
+							bitmap.pix(res_y+zy, res_x+zx) = palette[pen];
+					}
+				}
 			}
 		}
 	}
@@ -297,17 +306,9 @@ UPD7220_DRAW_TEXT_LINE_MEMBER( qx10_state::hgdc_draw_text )
 
 uint32_t qx10_state::screen_update( screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect )
 {
-	m_bitmap.fill(m_palette->black_pen(), cliprect);
+	bitmap.fill(m_palette->black_pen(), cliprect);
 
-	m_hgdc->screen_update(screen, m_bitmap, cliprect);
-	// cpm22mf:flop2 will test this under Zoom Test
-	const u32 pixel_size = 0x10000 / (m_zoom+1);
-	copyrozbitmap(
-		bitmap, cliprect, m_bitmap,
-		0, 0,
-		pixel_size, 0, 0, pixel_size,
-		false
-	);
+	m_hgdc->screen_update(screen, bitmap, cliprect);
 
 	return 0;
 }
@@ -815,7 +816,7 @@ void qx10_state::machine_reset()
 	{
 		int i;
 
-		// TODO: expose to slot monitor option
+		/* TODO: is there a bit that sets this up? */
 		m_color_mode = ioport("CONFIG")->read() & 1;
 
 		if(m_color_mode) //color
@@ -857,12 +858,9 @@ void qx10_state::video_start()
 {
 	// allocate memory
 	m_video_ram = make_unique_clear<uint16_t[]>(0x30000);
-
-	m_screen->register_screen_bitmap(m_bitmap);
-
 }
 
-void qx10_state::palette_init(palette_device &palette) const
+void qx10_state::qx10_palette(palette_device &palette) const
 {
 	// ...
 }
@@ -907,7 +905,7 @@ void qx10_state::qx10(machine_config &config)
 	m_screen->set_screen_update(FUNC(qx10_state::screen_update));
 	m_screen->set_raw(16.67_MHz_XTAL, 872, 152, 792, 421, 4, 404);
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_qx10);
-	PALETTE(config, m_palette, FUNC(qx10_state::palette_init), 8);
+	PALETTE(config, m_palette, FUNC(qx10_state::qx10_palette), 8);
 
 	/* Devices */
 


### PR DESCRIPTION
I noticed when testing #12943 that the zoom diag tests were broken on the QX10, bisecting showed that it was these two commits that broke things.

Revert "epson/qx10.cpp: rectify previous commit"

This reverts commit 35f1ec96be9e097247f13680acb4f62d6e63e538.

Revert "epson/qx10.cpp: use copyrozbitmap for (external to 7220) zoom handling"

This reverts commit a266a60699b4fe34fe14a8d11f2415ee4b48ef46.