### PR TITLE
ap2_dsk.cpp: add read-only support for the D13 format

### DIFF
--- a/src/devices/bus/a2bus/a2diskiing.cpp
+++ b/src/devices/bus/a2bus/a2diskiing.cpp
@@ -64,6 +64,7 @@ ROM_END
 
 void diskiing_device::floppy_formats(format_registration &fr)
 {
+	fr.add(FLOPPY_A213S_FORMAT);
 	fr.add(FLOPPY_A216S_DOS_FORMAT);
 	fr.add(FLOPPY_A216S_PRODOS_FORMAT);
 	fr.add(FLOPPY_RWTS18_FORMAT);
@@ -76,6 +77,7 @@ void diskiing_device::floppy_formats(format_registration &fr)
 
 void a2bus_diskiing13_device::floppy_formats(format_registration &fr)
 {
+	fr.add(FLOPPY_A213S_FORMAT);
 	fr.add(FLOPPY_EDD_FORMAT);
 	fr.add(FLOPPY_WOZ_FORMAT);
 	fr.add(FLOPPY_NIB_FORMAT);

--- a/src/lib/formats/all.cpp
+++ b/src/lib/formats/all.cpp
@@ -785,6 +785,7 @@ void mame_formats_full_list(mame_formats_enumerator &en)
 	en.add(fs::PRODOS);
 #endif
 #ifdef HAS_FORMATS_AP2_DSK
+	en.add(FLOPPY_A213S_FORMAT); // ap2_dsk.h
 	en.add(FLOPPY_A216S_DOS_FORMAT); // ap2_dsk.h
 	en.add(FLOPPY_A216S_PRODOS_FORMAT); // ap2_dsk.h
 	en.add(FLOPPY_RWTS18_FORMAT); // ap2_dsk.h

--- a/src/lib/formats/ap2_dsk.h
+++ b/src/lib/formats/ap2_dsk.h
@@ -29,6 +29,25 @@
 #define APPLE2_SECTOR_SIZE 256
 
 /**************************************************************************/
+class a2_13sect_format : public floppy_image_format_t
+{
+public:
+	a2_13sect_format();
+
+	virtual int identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const override;
+	virtual bool load(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants, floppy_image &image) const override;
+
+	virtual const char *name() const noexcept override;
+	virtual const char *description() const noexcept override;
+	virtual const char *extensions() const noexcept override;
+	virtual bool supports_save() const noexcept override;
+
+private:
+	static uint8_t gb(const std::vector<bool> &buf, int &pos, int &wrap);
+};
+
+extern const a2_13sect_format FLOPPY_A213S_FORMAT;
+
 class a2_16sect_format : public floppy_image_format_t
 {
 public:


### PR DESCRIPTION
This is the equivalent of DSK used for 13-sector disks.

While `diskiing` cannot directly boot from 13-sector disks, you can still access such disks with it (for example, using the BOOT13 and MUFFIN programs from the DOS master disk), so list the format as supported by both `diskiing13` and `diskiing`.