### PR TITLE
MIPS3 fixes for IDT-specific instructions

### DIFF
--- a/src/devices/cpu/mips/mips3.cpp
+++ b/src/devices/cpu/mips/mips3.cpp
@@ -3906,8 +3906,28 @@ void mips3_device::handle_idt(uint32_t op)
 {
 	switch (op & 0x1f)
 	{
+		case 0: /* MAD */
+			if (RSREG != 0 && RTREG != 0)
+			{
+				int64_t temp64 = (int64_t)(int32_t)RSVAL32 * (int64_t)(int32_t)RTVAL32;
+				temp64 += ((int64_t)m_core->r[REG_HI] << 32) | m_core->r[REG_LO];
+				m_core->r[REG_LO] = (int32_t)temp64;
+				m_core->r[REG_HI] = (int32_t)(temp64 >> 32);
+			}
+			m_core->icount -= 3;
+			break;
+		case 1: /* MADU */
+			if (RSREG != 0 && RTREG != 0)
+			{
+				uint64_t temp64 = (uint64_t)RSVAL32 * (uint64_t)RTVAL32;
+				temp64 += ((uint64_t)m_core->r[REG_HI] << 32) | m_core->r[REG_LO];
+				m_core->r[REG_LO] = (uint32_t)temp64;
+				m_core->r[REG_HI] = (uint32_t)(temp64 >> 32);
+			}
+			m_core->icount -= 3;
+			break;
 		case 2: /* MUL */
-			RDVAL64 = (int32_t)((int32_t)RSVAL32 * (int32_t)RTVAL32);
+			if (RDREG) RDVAL64 = (int32_t)((int32_t)RSVAL32 * (int32_t)RTVAL32);
 			m_core->icount -= 3;
 			break;
 		default:

--- a/src/devices/cpu/mips/mips3dsm.cpp
+++ b/src/devices/cpu/mips/mips3dsm.cpp
@@ -406,7 +406,7 @@ uint32_t mips3_disassembler::dasm_idt(uint32_t pc, uint32_t op, std::ostream &st
 	{
 		case 0: util::stream_format(stream, "mad       %s,%s", reg[rs], reg[rt]); break;
 		case 1: util::stream_format(stream, "madu      %s,%s", reg[rs], reg[rt]); break;
-		case 2: util::stream_format(stream, "mul       %s,%s,%s", reg[rs], reg[rt], reg[rd]); break;
+		case 2: util::stream_format(stream, "mul       %s,%s,%s", reg[rd], reg[rs], reg[rt]); break;
 		case 4: util::stream_format(stream, "msub      %s,%s", reg[rs], reg[rt]); break;
 		default:util::stream_format(stream, "dc.l      $%08x [invalid]", op);  break;
 	}


### PR DESCRIPTION
This adds support for MAD/MADU in the interpreter, as well as fixing the implementation and disassembly of the MUL instruction. All are specific to the IDT R4650.