### PR TITLE
Game Boy: add new BIOS variants and gbplayer (not working GBA clone)

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -34578,6 +34578,7 @@ mduckspa                        // Mega Duck / Super Quique (Spain)
 
 @source:nintendo/gba.cpp
 gba                             // Nintendo Game Boy Advance Handheld
+gbplayer                        // Nintendo Game Boy Player (GameCube add-on)
 robotech                        // Coleco
 
 @source:nintendo/mario.cpp

--- a/src/mame/nintendo/gb.cpp
+++ b/src/mame/nintendo/gb.cpp
@@ -1243,8 +1243,23 @@ ROM_END
 
 ROM_START(gbcolor)
 	ROM_REGION(0x800, "maincpu", 0)
-	ROM_LOAD("gbc_boot.1", 0x0000, 0x0100, CRC(779ea374) SHA1(e4b40c9fd593a97a1618cfb2696f290cf9596a62)) // Bootstrap code part 1
-	ROM_LOAD("gbc_boot.2", 0x0100, 0x0700, CRC(f741807d) SHA1(f943b1e0b640cf1d371e1d8f0ada69af03ebb396)) // Bootstrap code part 2
+
+	// The international Game Boy Color hardware (CGB-001)
+	ROM_SYSTEM_BIOS(0, "cgb-v1", "Game Boy Color v1 CGB-001")
+	ROMX_LOAD("gbc_v1_boot.1", 0x0000, 0x0100, CRC(779ea374) SHA1(e4b40c9fd593a97a1618cfb2696f290cf9596a62), ROM_BIOS(0) ) // Bootstrap code part 1
+	ROMX_LOAD("gbc_v1_boot.2", 0x0100, 0x0700, CRC(f741807d) SHA1(f943b1e0b640cf1d371e1d8f0ada69af03ebb396), ROM_BIOS(0) ) // Bootstrap code part 2
+
+	// (Older?) Japanese units used another version of the BIOS
+	ROM_SYSTEM_BIOS(1, "cgb-v0", "Game Boy Color v0 (Japan) CGB-001")
+	ROMX_LOAD("gbc_v0_boot.1", 0x0000, 0x0100, CRC(7edc621b) SHA1(8fc5f2e25b2cf480d378e4463c89bd0aecdfb21f), ROM_BIOS(1) )
+	ROMX_LOAD("gbc_v0_boot.2", 0x0100, 0x0700, CRC(2a16a329) SHA1(03c0cbfcb7e6a239e25cfb90cafae81087c465f6), ROM_BIOS(1) )
+
+	// Game Boy Advance includes a modified version of the BIOS code.
+	// Some games (shantae, wendy, zeldaage, zeldasea) use CPU register values
+	// set by it to enable GBA-exclusive features.
+	ROM_SYSTEM_BIOS(2, "agb", "Game Boy Advance AGB-001")
+	ROMX_LOAD("gbc_gba_boot.1", 0x0000, 0x0100, CRC(3c2ef5a4) SHA1(8c43360930ebc42a909cff736800606c697d59ea), ROM_BIOS(2) )
+	ROMX_LOAD("gbc_gba_boot.2", 0x0100, 0x0700, CRC(5f940766) SHA1(ba7ab25014e23d8b902b514571e1e21cc42d370f), ROM_BIOS(2) )
 ROM_END
 
 ROM_START(megaduck)

--- a/src/mame/nintendo/gba.cpp
+++ b/src/mame/nintendo/gba.cpp
@@ -8,6 +8,14 @@
 
   By R. Belmont & Ryan Holtz
 
+  Game Boy Player (DOL-017) is a hardware add-on for the GameCube to
+  run GB/GBC/GBA games on the TV, normally requiring a special boot
+  disc in the GameCube to operate.  It is mostly normal GBA hardware
+  with inputs and outputs adjusted for TV player.  This unit is
+  currently not working, as it fails to boot.  The BIOS only differs
+  by a few bytes, but the hardware might need to be initialized in
+  another manner.
+
 ***************************************************************************/
 
 #include "emu.h"
@@ -1496,7 +1504,17 @@ void gba_robotech_state::gbadv_robotech(machine_config &config)
 
 ROM_START( gba )
 	ROM_REGION( 0x4000, "maincpu", 0 )
-	ROM_LOAD( "gba.bin", 0x000000, 0x004000, CRC(81977335) SHA1(300c20df6731a33952ded8c436f7f186d25d3492) )
+
+	ROM_SYSTEM_BIOS(0, "agb-v1", "Game Boy Advance (AGB-001)")
+	ROMX_LOAD( "gba.bin", 0x000000, 0x004000, CRC(81977335) SHA1(300c20df6731a33952ded8c436f7f186d25d3492), ROM_BIOS(0) )
+
+	ROM_SYSTEM_BIOS(1, "agb-beta", "Game Boy Advance (beta)")
+	ROMX_LOAD( "gba-beta.bin", 0x000000, 0x004000, CRC(15e1f676) SHA1(aa98a2ad32b86106340665d1222d7d973a1361c7), ROM_BIOS(1) )
+ROM_END
+
+ROM_START( gbplayer )
+	ROM_REGION ( 0x4000, "maincpu", 0 )
+	ROM_LOAD("gbplayer.bin", 0x000000, 0x004000, CRC(3f02ea8f) SHA1(3d4b5d095576f5b994bf62c00cac9428a88b2b78) )
 ROM_END
 
 ROM_START( robotech )
@@ -1506,6 +1524,7 @@ ROM_END
 
 //   YEAR  NAME       PARENT  COMPAT  MACHINE           INPUT       CLASS               INIT        COMPANY     FULLNAME            FLAGS
 CONS(2001, gba,       0,      0,      gbadv_cons,       gbadv_cons, gba_cons_state,     empty_init, "Nintendo", "Game Boy Advance", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND)
+CONS(2003, gbplayer,  gba,    0,      gbadv_cons,       gbadv_cons, gba_cons_state,     empty_init, "Nintendo", "Game Boy Player",  MACHINE_NOT_WORKING)
 
 // this is a single game reissue of "Robotech - The Macross Saga (Euro, USA)" on the GBA but with double
 // sized ROM (BIOS replacement in first half?) and other mods.  It is unclear how compatible this is with


### PR DESCRIPTION
These files are all floating around the No-Intro sets.

For gbcolor, a Japan-exclusive version of the BIOS is added.  The variant of the BIOS from the Game Boy Advance is also included, which unlocks features in a few games that use it to detect running on GBA hardware.

A beta version of the GBA BIOS has been added, which features a different boot up sound and lacks the ability to escape to network boot mode (start+select in the released console).

The Game Boy Player has been added as a GBA clone.  At least the BIOS checksum is documented here, but it fails to boot in the MAME gba driver.