### PR TITLE
hash/nes: fix name of Tetramino (LJ65 prototypes)

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -22241,8 +22241,8 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="tetrim30" cloneof="lj65">
-		<description>Tetrimino (0.30, NTSC)</description>
+	<software name="tetram30" cloneof="lj65">
+		<description>Tetramino (0.30, NTSC)</description>
 		<year>2007</year>
 		<publisher>Pin Eight</publisher>
 		<info name="release" value="20070218" />
@@ -22252,19 +22252,19 @@ license:CC0-1.0
 			<feature name="pcb" value="NES-NROM-128" />
 			<feature name="mirroring" value="horizontal" />
 			<dataarea name="prg" size="32768">
-				<rom name="tetrimino 0.30 prg" size="16384" crc="546ff8b1" sha1="ced291dc67243d351ed80bb755682ae4fbcd8277" offset="00000" />
+				<rom name="tetramino 0.30 prg" size="16384" crc="546ff8b1" sha1="ced291dc67243d351ed80bb755682ae4fbcd8277" offset="00000" />
 				<rom size="16384" offset="0x4000" loadflag="reload" />
 			</dataarea>
 			<dataarea name="chr" size="8192">
-				<rom name="tetrimino 0.30 chr" size="8192" crc="9a4b6cfd" sha1="6cc933bf0df4aa1946106e1d80831c0f8e2c6faa" offset="00000" />
+				<rom name="tetramino 0.30 chr" size="8192" crc="9a4b6cfd" sha1="6cc933bf0df4aa1946106e1d80831c0f8e2c6faa" offset="00000" />
 			</dataarea>
 			<!-- 8k WRAM on cartridge -->
 			<dataarea name="wram" size="8192" />
 		</part>
 	</software>
 
-	<software name="tetrim30pal" cloneof="lj65">
-		<description>Tetrimino (0.30, PAL)</description>
+	<software name="tetram30pal" cloneof="lj65">
+		<description>Tetramino (0.30, PAL)</description>
 		<year>2007</year>
 		<publisher>Pin Eight</publisher>
 		<info name="release" value="20070218" />
@@ -22274,19 +22274,19 @@ license:CC0-1.0
 			<feature name="pcb" value="NES-NROM-128" />
 			<feature name="mirroring" value="horizontal" />
 			<dataarea name="prg" size="32768">
-				<rom name="tetrimino-pal 0.30 prg" size="16384" crc="22fca23b" sha1="6dec4e7b8ab198637f96f33098f5c0d024d3fcea" offset="00000" />
+				<rom name="tetramino-pal 0.30 prg" size="16384" crc="22fca23b" sha1="6dec4e7b8ab198637f96f33098f5c0d024d3fcea" offset="00000" />
 				<rom size="16384" offset="0x4000" loadflag="reload" />
 			</dataarea>
 			<dataarea name="chr" size="8192">
-				<rom name="tetrimino 0.30 chr" size="8192" crc="9a4b6cfd" sha1="6cc933bf0df4aa1946106e1d80831c0f8e2c6faa" offset="00000" />
+				<rom name="tetramino 0.30 chr" size="8192" crc="9a4b6cfd" sha1="6cc933bf0df4aa1946106e1d80831c0f8e2c6faa" offset="00000" />
 			</dataarea>
 			<!-- 8k WRAM on cartridge -->
 			<dataarea name="wram" size="8192" />
 		</part>
 	</software>
 
-	<software name="tetrim27" cloneof="lj65">
-		<description>Tetrimino (0.27, NTSC)</description>
+	<software name="tetram27" cloneof="lj65">
+		<description>Tetramino (0.27, NTSC)</description>
 		<year>2005</year>
 		<publisher>Pin Eight</publisher>
 		<info name="release" value="20051029" />
@@ -22296,19 +22296,19 @@ license:CC0-1.0
 			<feature name="pcb" value="NES-NROM-128" />
 			<feature name="mirroring" value="horizontal" />
 			<dataarea name="prg" size="32768">
-				<rom name="tetrimino 0.27 prg" size="16384" crc="1497769d" sha1="79ae948bc1ca3787738ed6a94e91045ef8f44d55" offset="00000" />
+				<rom name="tetramino 0.27 prg" size="16384" crc="1497769d" sha1="79ae948bc1ca3787738ed6a94e91045ef8f44d55" offset="00000" />
 				<rom size="16384" offset="0x4000" loadflag="reload" />
 			</dataarea>
 			<dataarea name="chr" size="8192">
-				<rom name="tetrimino 0.27 chr" size="8192" crc="9b83a887" sha1="6ba81be4e23f3a38a80ddeba69bf11c6efd3476d" offset="00000" />
+				<rom name="tetramino 0.27 chr" size="8192" crc="9b83a887" sha1="6ba81be4e23f3a38a80ddeba69bf11c6efd3476d" offset="00000" />
 			</dataarea>
 			<!-- 8k WRAM on cartridge -->
 			<dataarea name="wram" size="8192" />
 		</part>
 	</software>
 
-	<software name="tetrim27pal" cloneof="lj65">
-		<description>Tetrimino (0.27, PAL)</description>
+	<software name="tetram27pal" cloneof="lj65">
+		<description>Tetramino (0.27, PAL)</description>
 		<year>2005</year>
 		<publisher>Pin Eight</publisher>
 		<info name="release" value="20051029" />
@@ -22318,19 +22318,19 @@ license:CC0-1.0
 			<feature name="pcb" value="NES-NROM-128" />
 			<feature name="mirroring" value="horizontal" />
 			<dataarea name="prg" size="32768">
-				<rom name="tetrimino-pal 0.27 prg" size="16384" crc="d55a6236" sha1="0b3effe6edc1699dc9d4c3294839591331ae6d1b" offset="00000" />
+				<rom name="tetramino-pal 0.27 prg" size="16384" crc="d55a6236" sha1="0b3effe6edc1699dc9d4c3294839591331ae6d1b" offset="00000" />
 				<rom size="16384" offset="0x4000" loadflag="reload" />
 			</dataarea>
 			<dataarea name="chr" size="8192">
-				<rom name="tetrimino 0.27 chr" size="8192" crc="9b83a887" sha1="6ba81be4e23f3a38a80ddeba69bf11c6efd3476d" offset="00000" />
+				<rom name="tetramino 0.27 chr" size="8192" crc="9b83a887" sha1="6ba81be4e23f3a38a80ddeba69bf11c6efd3476d" offset="00000" />
 			</dataarea>
 			<!-- 8k WRAM on cartridge -->
 			<dataarea name="wram" size="8192" />
 		</part>
 	</software>
 
-	<software name="tetrim2" cloneof="lj65">
-		<description>Tetrimino (0.2)</description>
+	<software name="tetram2" cloneof="lj65">
+		<description>Tetramino (0.2)</description>
 		<year>2003</year>
 		<publisher>Pin Eight</publisher>
 		<info name="release" value="20031217" />
@@ -22340,19 +22340,19 @@ license:CC0-1.0
 			<feature name="pcb" value="NES-NROM-256" />
 			<feature name="mirroring" value="horizontal" />
 			<dataarea name="prg" size="32768">
-				<rom name="tetrimino 0.2 prg" size="16384" crc="6b69b03d" sha1="6c92b8c9f5e5ec9be99a96ba9a134e0a85bd1139" offset="00000" />
+				<rom name="tetramino 0.2 prg" size="16384" crc="6b69b03d" sha1="6c92b8c9f5e5ec9be99a96ba9a134e0a85bd1139" offset="00000" />
 				<rom size="16384" offset="0x4000" loadflag="reload" />
 			</dataarea>
 			<dataarea name="chr" size="8192">
-				<rom name="tetrimino 0.2 chr" size="8192" crc="f883d794" sha1="b940c8f1dcb19be7b6aefb303b184386c82ca1bc" offset="00000" />
+				<rom name="tetramino 0.2 chr" size="8192" crc="f883d794" sha1="b940c8f1dcb19be7b6aefb303b184386c82ca1bc" offset="00000" />
 			</dataarea>
 			<!-- 8k WRAM on cartridge -->
 			<dataarea name="wram" size="8192" />
 		</part>
 	</software>
 
-	<software name="tetrim1" cloneof="lj65">
-		<description>Tetrimino (0.1)</description>
+	<software name="tetram1" cloneof="lj65">
+		<description>Tetramino (0.1)</description>
 		<year>2003</year>
 		<publisher>Pin Eight</publisher>
 		<info name="release" value="20031101" />
@@ -22362,10 +22362,10 @@ license:CC0-1.0
 			<feature name="pcb" value="NES-NROM-256" />
 			<feature name="mirroring" value="horizontal" />
 			<dataarea name="prg" size="32768">
-				<rom name="tetrimino 0.1 prg" size="32768" crc="80fe53e0" sha1="790bc8d2d844b4f49a5ece72d91d6bcac8414c5b" offset="00000" />
+				<rom name="tetramino 0.1 prg" size="32768" crc="80fe53e0" sha1="790bc8d2d844b4f49a5ece72d91d6bcac8414c5b" offset="00000" />
 			</dataarea>
 			<dataarea name="chr" size="8192">
-				<rom name="tetrimino 0.1 chr" size="8192" crc="2e87f789" sha1="6544d571d5d0bf1b9dc028fd06aa3dc853c33199" offset="00000" />
+				<rom name="tetramino 0.1 chr" size="8192" crc="2e87f789" sha1="6544d571d5d0bf1b9dc028fd06aa3dc853c33199" offset="00000" />
 			</dataarea>
 			<!-- 8k WRAM on cartridge -->
 			<dataarea name="wram" size="8192" />


### PR DESCRIPTION
I had misspelled the game's (old) name and copy+pasted the misspelling all the way through. Oops :)