### PR TITLE
Correct cluedo.lay license from BSD-3 to CC0-1.0

### DIFF
--- a/src/mame/layout/cluedo.lay
+++ b/src/mame/layout/cluedo.lay
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-license: BSD-3-Clause
+license: CC0-1.0
 -->
 <mamelayout version="2">
 


### PR DESCRIPTION
Corrects the license of the cluedo.lay file from BSD-3 to CC0-1.0 (from https://github.com/mamedev/mame/pull/12879)
