### PR TITLE
Fix missing and or incorrect sounds with a player 2 game in Title Fight

### DIFF
--- a/src/mame/sega/segas32.cpp
+++ b/src/mame/sega/segas32.cpp
@@ -5926,6 +5926,7 @@ void segas32_state::init_jleague()
 void segas32_state::init_titlef()
 {
 	segas32_common_init();
+	m_soundcpu->space(AS_PROGRAM).install_write_handler(0xb0, 0xbf, write8smo_delegate(*this, FUNC(segas32_state::scross_bank_w)));
 	m_sw1_output = &segas32_state::titlef_sw1_output;
 	m_sw2_output = &segas32_state::titlef_sw2_output;
 }


### PR DESCRIPTION
The game requires the same mono style banking which is used by Stadium Cross, with thanks to mahoneyt944 who spotted the issues