### PR TITLE
pcw.cpp: fix clocking of printer data, add bitmap_printer to handle p…

### DIFF
--- a/src/devices/machine/bitmap_printer.h
+++ b/src/devices/machine/bitmap_printer.h
@@ -63,6 +63,14 @@ public:
 	int m_cr_direction; // direction of carriage
 	int m_xpos;
 	int m_ypos;
+public:
+
+	template <typename F>
+		std::enable_if_t<screen_update_rgb32_delegate::supports_callback<F>::value> set_screen_update(F &&callback, const char *name)
+		{
+				m_screen_update_rgb32.set(std::forward<F>(callback), name);
+		}
+
 
 protected:
 	bitmap_printer_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
@@ -78,6 +86,8 @@ private:
 	required_device<screen_device> m_screen;
 	required_device<stepper_device> m_pf_stepper;
 	required_device<stepper_device> m_cr_stepper;
+
+	screen_update_rgb32_delegate m_screen_update_rgb32; // screen update callback
 
 	required_ioport m_top_margin_ioport;
 	required_ioport m_bottom_margin_ioport;
@@ -117,6 +127,14 @@ private:
 	void draw7seg(u8 data, bool is_digit, int x0, int y0, int width, int height, int thick, bitmap_rgb32 &bitmap, u32 color, u32 erasecolor);
 	void draw_number(int number, int x, int y, bitmap_rgb32& bitmap);
 	void draw_inch_marks(bitmap_rgb32& bitmap);
+
+	double lastmovecrtime = -1.0;
+	int lastmovecrpos = 0;
+	double lastmovecrspeed = 0;
+
+public:
+	void trackcrpos();
+	double calccrpos(); // calculate interim positions in between discrete cr stepper steps
 };
 
 DECLARE_DEVICE_TYPE(BITMAP_PRINTER, bitmap_printer_device)

--- a/src/mame/amstrad/pcw.h
+++ b/src/mame/amstrad/pcw.h
@@ -13,6 +13,7 @@
 #include "cpu/mcs48/mcs48.h"
 #include "imagedev/floppy.h"
 #include "machine/upd765.h"
+#include "machine/bitmap_printer.h"
 #include "machine/ram.h"
 #include "machine/timer.h"
 #include "sound/beep.h"
@@ -49,6 +50,7 @@ public:
 		, m_rdbanks(*this, "bank%u", 1U)
 		, m_wrbanks(*this, "bank%u", 5U)
 		, m_iptlines(*this, "LINE%u", 0U)
+		, m_bitmap_printer(*this, "bitmap_printer")
 	{ }
 
 	void pcw(machine_config &config);
@@ -155,6 +157,7 @@ private:
 	required_device<palette_device> m_ppalette;
 	required_memory_bank_array<4> m_rdbanks, m_wrbanks;
 	required_ioport_array<16> m_iptlines;
+	optional_device<bitmap_printer_device> m_bitmap_printer;
 
 	inline void pcw_plot_pixel(bitmap_ind16 &bitmap, int x, int y, uint32_t color);
 	void pcw_update_interrupt_counter();


### PR DESCRIPTION
…rinter

bitmap_printer: add calccrpos for intermediate stepper position, add set_screen_update function


This fixes the clocking in of data to the pcw printer, as previously it was looking for just the clock being high, and not looking for the transition to high.  So multiple writes to the printer with the clock remaining high would clock in data, causing corruption in the printout.

Using the bitmap printer device would allow quite a bit of code in (pcw.cpp) pcw_stepper_callback to be removed, I've left the original printer and stepper code in and it still works to render a second (identical) printing screen.

Also the print key is assigned to the backslash key (so you can do the printer functions, like feeding paper).

I've also added a function to the bitmap printer device for a screen update callback, so a driver using the bitmap printer device can add it's own drawing to the screen (as there's a few other drivers that I'm working on that could use it, for example to render a color ribbon).




Running pcw8256 loco203 allows you to print the readme file, use keypad . to move the cursor down to select the readme, use p to print the document, keypad Enter to accept the dialogs, and backslash to activate the printer menu, where you can feed the paper and continue the print.
