### PR TITLE
kaneko/kaneko_spr.cpp, kaneko/kaneko_tmap.cpp: Use generic gfx layout, Reduce unnecessary finder

### DIFF
--- a/src/mame/kaneko/kaneko_spr.h
+++ b/src/mame/kaneko/kaneko_spr.h
@@ -85,13 +85,12 @@ protected:
 	// them in a different order
 	virtual void get_sprite_attributes(struct tempsprite_t *s, u16 attr) =0;
 
-	required_memory_region m_gfx_region;
 	u16 m_colbase;
 
 private:
 	// registers
-	u16 m_sprite_flipx;
-	u16 m_sprite_flipy;
+	bool m_sprite_flipx;
+	bool m_sprite_flipy;
 	std::unique_ptr<u16[]> m_sprites_regs;
 
 	std::unique_ptr<struct tempsprite_t[]> m_first_sprite;
@@ -128,6 +127,9 @@ public:
 
 protected:
 	virtual void device_start() override ATTR_COLD;
+
+private:
+	DECLARE_GFXDECODE_MEMBER(gfxinfo);
 };
 
 DECLARE_DEVICE_TYPE(KANEKO_VU002_SPRITE, kaneko_vu002_sprite_device)
@@ -147,6 +149,9 @@ public:
 
 protected:
 	virtual void device_start() override ATTR_COLD;
+
+private:
+	DECLARE_GFXDECODE_MEMBER(gfxinfo);
 };
 
 DECLARE_DEVICE_TYPE(KANEKO_KC002_SPRITE, kaneko_kc002_sprite_device)

--- a/src/mame/kaneko/kaneko_tmap.h
+++ b/src/mame/kaneko/kaneko_tmap.h
@@ -32,7 +32,7 @@ public:
 
 	template <typename... T> void set_tile_callback(T &&... args) { m_view2_cb.set(std::forward<T>(args)...); }
 
-	void vram_w(int _N_, offs_t offset, u16 data, u16 mem_mask = u16(~0));
+	void vram_w(int i, offs_t offset, u16 data, u16 mem_mask = u16(~0));
 
 	// call to do the rendering etc.
 	template<class BitmapClass>
@@ -76,11 +76,12 @@ protected:
 
 private:
 	template<unsigned Layer> TILE_GET_INFO_MEMBER(get_tile_info);
+	DECLARE_GFXDECODE_MEMBER(gfxinfo);
+
 	required_shared_ptr_array<u16, 2> m_vram;
 	required_shared_ptr_array<u16, 2> m_vscroll;
 
 	// set when creating device
-	required_memory_region m_gfxrom;
 	u16 m_colbase;
 	int m_dx, m_dy, m_xdim, m_ydim;
 	int m_invert_flip;


### PR DESCRIPTION
kaneko/kaneko_spr.cpp: Fix typename for boolean flags