### PR TITLE
cdicdic: Fix restarting audio_map after stopping it

### DIFF
--- a/src/mame/philips/cdicdic.cpp
+++ b/src/mame/philips/cdicdic.cpp
@@ -706,7 +706,7 @@ void cdicdic_device::process_audio_map()
 	else
 	{
 		m_decode_addr = 0xffff;
-		m_audio_sector_counter = m_audio_format_sectors;
+		m_audio_sector_counter = 0;
 	}
 
 	if (was_decoding)


### PR DESCRIPTION
Fixes:
https://mametesters.org/view.php?id=8833

I also thought it would fix this one but my assumption was wrong:
https://mametesters.org/view.php?id=8955

Further tests might be needed but I'm not a big fan of Hotel Mario and therefore unable to complete this game as it is quite repetitive.