### PR TITLE
Wrap tilemap - fix harddunk background in attract

### DIFF
--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -33,10 +33,6 @@
       effect to draw the boxing ring over NBG0.
       Same deal for ga2 when in stage 2 cave a wall torch is lit.
 
-    - harddunk draws solid white in attract mode when the players are presented.
-      NBG0 is set with $200 on center X/Y, same as above or perhaps missing
-      tilemap wraparound?
-
     - Wrong priority cases (parenthesis for the level setup):
       dbzvrvs: draws text layer ($e) behind sprite-based gauges ($f).
       dbzvrvs: Sheng-Long speech balloon during Piccoro ending (fixme: check levels).
@@ -744,7 +740,7 @@ void segas32_state::update_tilemap_zoom(screen_device &screen, segas32_state::la
 	srcy += (m_videoram[0x1ff14/2 + 4 * bgnum] & 0xfe00) << 4;
 
 	/* then account for the destination center coordinates */
-	srcx_start -= util::sext(m_videoram[0x1ff30/2 + 2 * bgnum], 10) * srcxstep;
+	srcx_start -= util::sext(m_videoram[0x1ff30/2 + 2 * bgnum] & 0x1ff, 10) * srcxstep;
 	srcy -= util::sext(m_videoram[0x1ff32/2 + 2 * bgnum], 9) * srcystep;
 
 	/* finally, account for destination top,left coordinates */


### PR DESCRIPTION
Hi, 

Referencing the open question removed in this commit, adding wraparound on X correctly displays the background when the players are presented during attract mode.

Should this also be added to the Y?

Thank you.