### PR TITLE
toaplan/mjsister.cpp: Minor cleanups

### DIFF
--- a/src/mame/toaplan/mjsister.cpp
+++ b/src/mame/toaplan/mjsister.cpp
@@ -21,7 +21,6 @@
 
 namespace {
 
-#define MCLK 12000000
 
 
 class mjsister_state : public driver_device
@@ -34,6 +33,8 @@ public:
 		m_palette(*this, "palette"),
 		m_crtc(*this, "crtc"),
 		m_dac(*this, "dac"),
+		m_io_key(*this, "KEY%u", 0U),
+		m_samples_region(*this, "samples"),
 		m_rombank(*this, "rombank"),
 		m_vrambank(*this, "vrambank")
 	{ }
@@ -45,32 +46,40 @@ protected:
 	virtual void machine_reset() override ATTR_COLD;
 
 private:
-	/* video-related */
-	bool m_video_enable;
-	int  m_colorbank;
+	static constexpr XTAL MCLK = XTAL(12'000'000);
 
-	/* misc */
-	int  m_input_sel1;
-	int  m_input_sel2;
-	bool m_irq_enable;
-
-	uint32_t m_dac_adr;
-	uint32_t m_dac_bank;
-	uint32_t m_dac_adr_s;
-	uint32_t m_dac_adr_e;
-	uint32_t m_dac_busy;
-
-	/* devices */
+	// devices
 	required_device<cpu_device> m_maincpu;
 	required_device_array<ls259_device, 2> m_mainlatch;
 	required_device<palette_device> m_palette;
 	required_device<hd6845s_device> m_crtc;
 	required_device<dac_byte_interface> m_dac;
+	required_ioport_array<6> m_io_key;
 
-	/* memory */
+	// memory
+	required_region_ptr<uint8_t> m_samples_region;
 	required_memory_bank m_rombank;
 	required_memory_bank m_vrambank;
+
 	std::unique_ptr<uint8_t[]> m_vram;
+
+	// video-related
+	bool    m_video_enable;
+	uint8_t m_colorbank;
+
+	// misc
+	uint8_t m_input_sel1;
+	uint8_t m_input_sel2;
+	bool    m_irq_enable;
+
+	uint32_t m_dac_adr;
+	uint32_t m_dac_bank;
+	uint32_t m_dac_adr_s;
+	uint32_t m_dac_adr_e;
+	bool     m_dac_busy;
+
+	emu_timer *m_dac_timer;
+
 	void dac_adr_s_w(uint8_t data);
 	void dac_adr_e_w(uint8_t data);
 	void rombank_w(int state);
@@ -87,12 +96,10 @@ private:
 	INTERRUPT_GEN_MEMBER(interrupt);
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
-	void mjsister_io_map(address_map &map) ATTR_COLD;
-	void mjsister_map(address_map &map) ATTR_COLD;
-
-	emu_timer *m_dac_timer;
-
 	MC6845_UPDATE_ROW(crtc_update_row);
+
+	void io_map(address_map &map) ATTR_COLD;
+	void main_map(address_map &map) ATTR_COLD;
 };
 
 
@@ -131,16 +138,16 @@ MC6845_UPDATE_ROW( mjsister_state::crtc_update_row )
 		}
 
 		// background layer
-		uint8_t data_bg = m_vram[0x400 + ((ma << 3) | (ra << 7) | i)];
+		const uint8_t data_bg = m_vram[0x400 + ((ma << 3) | (ra << 7) | i)];
 
 		bitmap.pix(y, x1) = pen[m_colorbank << 5 | ((data_bg & 0x0f) >> 0)];
 		bitmap.pix(y, x2) = pen[m_colorbank << 5 | ((data_bg & 0xf0) >> 4)];
 
 		// foreground layer
-		uint8_t data_fg = m_vram[0x8000 | (0x400 + ((ma << 3) | (ra << 7) | i))];
+		const uint8_t data_fg = m_vram[0x8000 | (0x400 + ((ma << 3) | (ra << 7) | i))];
 
-		uint8_t c1 = ((data_fg & 0x0f) >> 0);
-		uint8_t c2 = ((data_fg & 0xf0) >> 4);
+		const uint8_t c1 = ((data_fg & 0x0f) >> 0);
+		const uint8_t c2 = ((data_fg & 0xf0) >> 4);
 
 		// 0 is transparent
 		if (c1) bitmap.pix(y, x1) = pen[m_colorbank << 5 | 0x10 | c1];
@@ -157,14 +164,12 @@ MC6845_UPDATE_ROW( mjsister_state::crtc_update_row )
 
 TIMER_CALLBACK_MEMBER(mjsister_state::dac_callback)
 {
-	uint8_t *DACROM = memregion("samples")->base();
-
-	m_dac->write(DACROM[(m_dac_bank * 0x10000 + m_dac_adr++) & 0x1ffff]);
+	m_dac->write(m_samples_region[(m_dac_bank * 0x10000 + m_dac_adr++) & 0x1ffff]);
 
 	if (((m_dac_adr & 0xff00 ) >> 8) !=  m_dac_adr_e)
 		m_dac_timer->adjust(attotime::from_hz(MCLK) * 1024);
 	else
-		m_dac_busy = 0;
+		m_dac_busy = false;
 }
 
 void mjsister_state::dac_adr_s_w(uint8_t data)
@@ -177,10 +182,10 @@ void mjsister_state::dac_adr_e_w(uint8_t data)
 	m_dac_adr_e = data;
 	m_dac_adr = m_dac_adr_s << 8;
 
-	if (m_dac_busy == 0)
+	if (!m_dac_busy)
 		m_dac_timer->adjust(attotime::zero);
 
-	m_dac_busy = 1;
+	m_dac_busy = true;
 }
 
 void mjsister_state::rombank_w(int state)
@@ -232,16 +237,14 @@ void mjsister_state::input_sel2_w(uint8_t data)
 
 uint8_t mjsister_state::keys_r()
 {
-	int p, i, ret = 0;
-	static const char *const keynames[] = { "KEY0", "KEY1", "KEY2", "KEY3", "KEY4", "KEY5" };
-
-	p = m_input_sel1 & 0x3f;
+	uint8_t ret = 0;
+	const uint8_t p = m_input_sel1 & 0x3f;
 	//  p |= ((m_input_sel2 & 8) << 4) | ((m_input_sel2 & 0x20) << 1);
 
-	for (i = 0; i < 6; i++)
+	for (int i = 0; i < 6; i++)
 	{
 		if (BIT(p, i))
-			ret |= ioport(keynames[i])->read();
+			ret |= m_io_key[i]->read();
 	}
 
 	return ret;
@@ -253,14 +256,14 @@ uint8_t mjsister_state::keys_r()
  *
  *************************************/
 
-void mjsister_state::mjsister_map(address_map &map)
+void mjsister_state::main_map(address_map &map)
 {
 	map(0x0000, 0x77ff).rom();
 	map(0x7800, 0x7fff).ram();
-	map(0x8000, 0xffff).bankr("rombank").bankw("vrambank");
+	map(0x8000, 0xffff).bankr(m_rombank).bankw(m_vrambank);
 }
 
-void mjsister_state::mjsister_io_map(address_map &map)
+void mjsister_state::io_map(address_map &map)
 {
 	map.global_mask(0xff);
 	map(0x00, 0x00).w(m_crtc, FUNC(hd6845s_device::address_w));
@@ -270,8 +273,8 @@ void mjsister_state::mjsister_io_map(address_map &map)
 	map(0x12, 0x12).w("aysnd", FUNC(ay8910_device::data_w));
 	map(0x20, 0x20).r(FUNC(mjsister_state::keys_r));
 	map(0x21, 0x21).portr("IN0");
-	map(0x30, 0x30).w("mainlatch1", FUNC(ls259_device::write_nibble_d0));
-	map(0x31, 0x31).w("mainlatch2", FUNC(ls259_device::write_nibble_d0));
+	map(0x30, 0x30).w(m_mainlatch[0], FUNC(ls259_device::write_nibble_d0));
+	map(0x31, 0x31).w(m_mainlatch[1], FUNC(ls259_device::write_nibble_d0));
 	map(0x32, 0x32).w(FUNC(mjsister_state::input_sel1_w));
 	map(0x33, 0x33).w(FUNC(mjsister_state::input_sel2_w));
 	map(0x34, 0x34).w(FUNC(mjsister_state::dac_adr_s_w));
@@ -310,7 +313,7 @@ static INPUT_PORTS_START( mjsister )
 	PORT_DIPSETTING(    0x80, DEF_STR( Off ) )
 	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
 
-	PORT_START("DSW2")      /* not on PCB */
+	PORT_START("DSW2")      // not on PCB
 	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
 
 	PORT_START("IN0")
@@ -389,6 +392,8 @@ void mjsister_state::machine_start()
 
 	m_dac_timer = timer_alloc(FUNC(mjsister_state::dac_callback), this);
 
+	m_irq_enable = false;
+
 	save_pointer(NAME(m_vram), 0x10000);
 	save_item(NAME(m_dac_busy));
 	save_item(NAME(m_video_enable));
@@ -404,14 +409,14 @@ void mjsister_state::machine_start()
 
 void mjsister_state::machine_reset()
 {
-	m_dac_busy = 0;
-	m_video_enable = 0;
+	m_video_enable = false;
 	m_input_sel1 = 0;
 	m_input_sel2 = 0;
 	m_dac_adr = 0;
 	m_dac_bank = 0;
 	m_dac_adr_s = 0;
 	m_dac_adr_e = 0;
+	m_dac_busy = false;
 }
 
 INTERRUPT_GEN_MEMBER(mjsister_state::interrupt)
@@ -422,10 +427,10 @@ INTERRUPT_GEN_MEMBER(mjsister_state::interrupt)
 
 void mjsister_state::mjsister(machine_config &config)
 {
-	/* basic machine hardware */
-	Z80(config, m_maincpu, MCLK/2); /* 6.000 MHz */
-	m_maincpu->set_addrmap(AS_PROGRAM, &mjsister_state::mjsister_map);
-	m_maincpu->set_addrmap(AS_IO, &mjsister_state::mjsister_io_map);
+	// basic machine hardware
+	Z80(config, m_maincpu, MCLK / 2); // 6.000 MHz
+	m_maincpu->set_addrmap(AS_PROGRAM, &mjsister_state::main_map);
+	m_maincpu->set_addrmap(AS_IO, &mjsister_state::io_map);
 	m_maincpu->set_periodic_int(FUNC(mjsister_state::interrupt), attotime::from_hz(2*60));
 
 	LS259(config, m_mainlatch[0]);
@@ -443,28 +448,28 @@ void mjsister_state::mjsister(machine_config &config)
 	m_mainlatch[1]->q_out_cb<5>().set(FUNC(mjsister_state::dac_bank_w));
 	m_mainlatch[1]->q_out_cb<6>().set(FUNC(mjsister_state::rombank_w));
 
-	/* video hardware */
+	// video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_raw(MCLK/2, 384, 0, 256, 268, 0, 240); // 6 MHz?
+	screen.set_raw(MCLK / 2, 384, 0, 256, 268, 0, 240); // 6 MHz?
 	screen.set_screen_update(FUNC(mjsister_state::screen_update));
 
 	PALETTE(config, m_palette, palette_device::RGB_444_PROMS, "proms", 256);
 
-	HD6845S(config, m_crtc, MCLK/4); // 3 MHz?
+	HD6845S(config, m_crtc, MCLK / 4); // 3 MHz?
 	m_crtc->set_screen("screen");
 	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(2);
 	m_crtc->set_update_row_callback(FUNC(mjsister_state::crtc_update_row));
 
-	/* sound hardware */
+	// sound hardware
 	SPEAKER(config, "speaker").front_center();
 
-	ay8910_device &aysnd(AY8910(config, "aysnd", MCLK/8));
+	ay8910_device &aysnd(AY8910(config, "aysnd", MCLK / 8));
 	aysnd.port_a_read_callback().set_ioport("DSW1");
 	aysnd.port_b_read_callback().set_ioport("DSW2");
 	aysnd.add_route(ALL_OUTPUTS, "speaker", 0.15);
 
-	DAC_8BIT_R2R(config, "dac", 0).add_route(ALL_OUTPUTS, "speaker", 0.5); // unknown DAC
+	DAC_8BIT_R2R(config, m_dac, 0).add_route(ALL_OUTPUTS, "speaker", 0.5); // unknown DAC
 }
 
 /*************************************
@@ -474,16 +479,16 @@ void mjsister_state::mjsister(machine_config &config)
  *************************************/
 
 ROM_START( mjsister )
-	ROM_REGION( 0x30000, "maincpu", 0 )   /* CPU */
+	ROM_REGION( 0x30000, "maincpu", 0 )   // CPU
 	ROM_LOAD( "ms00.bin",  0x00000, 0x08000, CRC(9468c33b) SHA1(63aecdcaa8493d58549dfd1d217743210cf953bc) )
-	ROM_LOAD( "ms01t.bin", 0x10000, 0x10000, CRC(a7b6e530) SHA1(fda9bea214968a8814d2c43226b3b32316581050) ) /* banked */
-	ROM_LOAD( "ms02t.bin", 0x20000, 0x10000, CRC(7752b5ba) SHA1(84dcf27a62eb290ba07c85af155897ec72f320a8) ) /* banked */
+	ROM_LOAD( "ms01t.bin", 0x10000, 0x10000, CRC(a7b6e530) SHA1(fda9bea214968a8814d2c43226b3b32316581050) ) // banked
+	ROM_LOAD( "ms02t.bin", 0x20000, 0x10000, CRC(7752b5ba) SHA1(84dcf27a62eb290ba07c85af155897ec72f320a8) ) // banked
 
-	ROM_REGION( 0x20000, "samples", 0 ) /* samples */
+	ROM_REGION( 0x20000, "samples", 0 ) // samples
 	ROM_LOAD( "ms03.bin", 0x00000,  0x10000, CRC(10a68e5e) SHA1(a0e2fa34c1c4f34642f65fbf17e9da9c2554a0c6) )
 	ROM_LOAD( "ms04.bin", 0x10000,  0x10000, CRC(641b09c1) SHA1(15cde906175bcb5190d36cc91cbef003ef91e425) )
 
-	ROM_REGION( 0x00400, "proms", 0 ) /* color PROMs */
+	ROM_REGION( 0x00400, "proms", 0 ) // color PROMs
 	ROM_LOAD( "ms05.bpr", 0x0000,  0x0100, CRC(dd231a5f) SHA1(be008593ac8ba8f5a1dd5b188dc7dc4c03016805) ) // R
 	ROM_LOAD( "ms06.bpr", 0x0100,  0x0100, CRC(df8e8852) SHA1(842a891440aef55a560d24c96f249618b9f4b97f) ) // G
 	ROM_LOAD( "ms07.bpr", 0x0200,  0x0100, CRC(6cb3a735) SHA1(468ae3d40552dc2ec24f5f2988850093d73948a6) ) // B


### PR DESCRIPTION
- Reduce literal tag usages, Runtime tag lookups
- Make some variables constant
- Reduce preprocessor defines
- Use C++ style single line comments
- Fix typename value for boolean flags
- Fix initializations, save states
- Fix namings