### PR TITLE
cpu/hcd62121,casio/pickytlk.cpp: Add support for more Picky Talk models

### DIFF
--- a/src/devices/cpu/hcd62121/hcd62121.h
+++ b/src/devices/cpu/hcd62121/hcd62121.h
@@ -83,8 +83,12 @@ private:
 	void op_addb(int size);
 	void op_subb(int size);
 	void op_sub(int size);
+	void op_pushb(u8 source);
 	void op_pushw(u16 source);
+	u8 op_popb();
 	u16 op_popw();
+	void set_reg(u8 i, u8 val) { m_reg[i] = val; /*logerror("R%02X = %02x @ %06X\n", i, val, (m_cseg << 16) | m_ip);*/ }
+	void timer_elapsed();
 
 	address_space_config m_program_config;
 
@@ -98,9 +102,14 @@ private:
 	u8 m_f;
 	u8 m_time;
 	u8 m_time_op;
+	u8 m_unk_f5;
 	s32 m_cycles_until_timeout;
 	bool m_is_timer_started;
+	bool m_is_timer_irq_enabled;
+	bool m_is_timer_irq_asserted;
+	bool m_is_timer_wait_elapsed;
 	bool m_is_infinite_timeout;
+	s32 m_timer_cycles;
 	emu_timer *m_timer;
 	u16 m_lar;
 	u8 m_reg[0x80];

--- a/src/devices/cpu/hcd62121/hcd62121d.cpp
+++ b/src/devices/cpu/hcd62121/hcd62121d.cpp
@@ -157,14 +157,14 @@ const hcd62121_disassembler::dasm hcd62121_disassembler::ops[256] =
 	{ "movb",    ARG_REG,    ARG_CS   }, { "movb",    ARG_REG,    ARG_SS   },
 
 	/* 0xf0 */
-	{ "movb",       ARG_OPT,    ARG_REG  }, { "unF1?",          ARG_I8,     ARG_NONE },
-	{ "movb",       ARG_PORT,   ARG_REG  }, { "unF3?",          ARG_I8,     ARG_NONE },
-	{ "unF4?",      ARG_I8,     ARG_NONE }, { "unF5?",          ARG_I8,     ARG_NONE },
-	{ "unF6?",      ARG_I8,     ARG_NONE }, { "timer_ctrl",     ARG_I8,     ARG_NONE },
-	{ "unF8?",      ARG_NONE,   ARG_NONE }, { "unF9?",          ARG_NONE,   ARG_NONE },
-	{ "unFA?",      ARG_NONE,   ARG_NONE }, { "unFb?",          ARG_NONE,   ARG_NONE },
-	{ "unFC?",      ARG_NONE,   ARG_NONE }, { "timer_wait_low", ARG_NONE,   ARG_NONE },
-	{ "timer_wait", ARG_NONE,   ARG_NONE }, { "nop",            ARG_NONE,   ARG_NONE }
+	{ "movb",        ARG_OPT,    ARG_REG  }, { "unF1?",          ARG_I8,     ARG_NONE },
+	{ "movb",        ARG_PORT,   ARG_REG  }, { "unF3?",          ARG_I8,     ARG_NONE },
+	{ "unF4?",       ARG_I8,     ARG_NONE }, { "unF5?",          ARG_I8,     ARG_NONE },
+	{ "unF6?",       ARG_I8,     ARG_NONE }, { "timer_ctrl",     ARG_I8,     ARG_NONE },
+	{ "unF8?",       ARG_I8,     ARG_NONE }, { "unF9?",          ARG_NONE,   ARG_NONE },
+	{ "unFA?",       ARG_NONE,   ARG_NONE }, { "unFb?",          ARG_NONE,   ARG_NONE },
+	{ "timer_clear", ARG_NONE,   ARG_NONE }, { "timer_wait_low", ARG_NONE,   ARG_NONE },
+	{ "timer_wait",  ARG_NONE,   ARG_NONE }, { "nop",            ARG_NONE,   ARG_NONE }
 };
 
 u32 hcd62121_disassembler::opcode_alignment() const

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -16126,7 +16126,13 @@ pb1000                          // Casio PB-1000
 pb2000c                         // Casio PB-2000C
 
 @source:casio/pickytlk.cpp
-pickytlk                        // Casio Picky Talk
+jd363                           // Casio Picky Talk - Super Denshi Techou
+jd364                           // Casio Color Picky Talk - Super Denshi Techou
+jd368                           // Casio Super Picky Talk - Access Pet
+mk300                           // Casio Plet's (MK-300)
+mk350                           // Casio Plet's (MK-350)
+pickydis                        // Tsukuda Original Disney Characters - Tegaki Electronic Note
+pickytlk                        // Casio Super Picky Talk - Forest of Gurutan
 
 @source:casio/pv1000.cpp
 pv1000                          // Casio PV-1000


### PR DESCRIPTION
* Implement timer state register updates;
* Implement monocolor model tablet inputs;
* Fix invalid copy extension on instruction 0xC5 `movw (lar),i8`;

New systems added as NOT WORKING
---------------------------------------
Picky Talk - Super Denshi Techou [QUFB]
Disney Characters - Tegaki Electronic Note [QUFB]
Color Picky Talk - Super Denshi Techou [QUFB]
Super Picky Talk - Access Pet [QUFB]
Plet's (MK-300) [QUFB]
Plet's (MK-350) [QUFB]