### PR TITLE
H8 improvements: H8/3437, I2C master and Sun Fire V120 stub

### DIFF
--- a/scripts/src/cpu.lua
+++ b/scripts/src/cpu.lua
@@ -739,6 +739,8 @@ if CPUS["H8"] then
 		MAME_DIR .. "src/devices/cpu/h8/h8_dma.h",
 		MAME_DIR .. "src/devices/cpu/h8/h8_dtc.cpp",
 		MAME_DIR .. "src/devices/cpu/h8/h8_dtc.h",
+		MAME_DIR .. "src/devices/cpu/h8/h8_i2c.cpp",
+		MAME_DIR .. "src/devices/cpu/h8/h8_i2c.h",
 		MAME_DIR .. "src/devices/cpu/h8/h8_intc.cpp",
 		MAME_DIR .. "src/devices/cpu/h8/h8_intc.h",
 		MAME_DIR .. "src/devices/cpu/h8/h8_port.cpp",

--- a/scripts/src/cpu.lua
+++ b/scripts/src/cpu.lua
@@ -721,6 +721,8 @@ if CPUS["H8"] then
 		MAME_DIR .. "src/devices/cpu/h8/h83217.h",
 		MAME_DIR .. "src/devices/cpu/h8/h83337.cpp",
 		MAME_DIR .. "src/devices/cpu/h8/h83337.h",
+		MAME_DIR .. "src/devices/cpu/h8/h83437.cpp",
+		MAME_DIR .. "src/devices/cpu/h8/h83437.h",
 		MAME_DIR .. "src/devices/cpu/h8/h8s2245.cpp",
 		MAME_DIR .. "src/devices/cpu/h8/h8s2245.h",
 		MAME_DIR .. "src/devices/cpu/h8/h8s2319.cpp",

--- a/src/devices/cpu/h8/h83337.cpp
+++ b/src/devices/cpu/h8/h83337.cpp
@@ -26,8 +26,12 @@ DEFINE_DEVICE_TYPE(H83337, h83337_device, "h83337", "Hitachi H8/3337")
 
 h83337_device::h83337_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, address_map_constructor map_delegate, u32 start) :
 	h8_device(mconfig, type, tag, owner, clock, map_delegate),
+	m_scl_w(*this),
+	m_sda_w(*this),
+	m_sda_r(*this, 1),
 	m_intc(*this, "intc"),
 	m_adc(*this, "adc"),
+	m_i2c(*this, "i2c"),
 	m_port1(*this, "port1"),
 	m_port2(*this, "port2"),
 	m_port3(*this, "port3"),
@@ -42,6 +46,7 @@ h83337_device::h83337_device(const machine_config &mconfig, device_type type, co
 	m_timer16(*this, "timer16"),
 	m_timer16_0(*this, "timer16:0"),
 	m_watchdog(*this, "watchdog"),
+	m_sci0_i2c_view(*this, "sci0_i2c_view"),
 	m_ram_start(start)
 {
 }
@@ -124,12 +129,17 @@ void h83337_device::map(address_map &map)
 	map(0xffd2, 0xffd3).rw(m_timer8_1, FUNC(h8_timer8_channel_device::tcor_r), FUNC(h8_timer8_channel_device::tcor_w));
 	map(0xffd4, 0xffd4).rw(m_timer8_1, FUNC(h8_timer8_channel_device::tcnt_r), FUNC(h8_timer8_channel_device::tcnt_w));
 
-	map(0xffd8, 0xffd8).rw(m_sci[0], FUNC(h8_sci_device::smr_r), FUNC(h8_sci_device::smr_w));
-	map(0xffd9, 0xffd9).rw(m_sci[0], FUNC(h8_sci_device::brr_r), FUNC(h8_sci_device::brr_w));
-	map(0xffda, 0xffda).rw(m_sci[0], FUNC(h8_sci_device::scr_r), FUNC(h8_sci_device::scr_w));
-	map(0xffdb, 0xffdb).rw(m_sci[0], FUNC(h8_sci_device::tdr_r), FUNC(h8_sci_device::tdr_w));
-	map(0xffdc, 0xffdc).rw(m_sci[0], FUNC(h8_sci_device::ssr_r), FUNC(h8_sci_device::ssr_w));
-	map(0xffdd, 0xffdd).r(m_sci[0], FUNC(h8_sci_device::rdr_r));
+	map(0xffd8, 0x0ffdf).view(m_sci0_i2c_view);
+	m_sci0_i2c_view[0](0xffd8, 0xffd8).rw(m_sci[0], FUNC(h8_sci_device::smr_r), FUNC(h8_sci_device::smr_w));
+	m_sci0_i2c_view[0](0xffd9, 0xffd9).rw(m_sci[0], FUNC(h8_sci_device::brr_r), FUNC(h8_sci_device::brr_w));
+	m_sci0_i2c_view[0](0xffda, 0xffda).rw(m_sci[0], FUNC(h8_sci_device::scr_r), FUNC(h8_sci_device::scr_w));
+	m_sci0_i2c_view[0](0xffdb, 0xffdb).rw(m_sci[0], FUNC(h8_sci_device::tdr_r), FUNC(h8_sci_device::tdr_w));
+	m_sci0_i2c_view[0](0xffdc, 0xffdc).rw(m_sci[0], FUNC(h8_sci_device::ssr_r), FUNC(h8_sci_device::ssr_w));
+	m_sci0_i2c_view[0](0xffdd, 0xffdd).r(m_sci[0], FUNC(h8_sci_device::rdr_r));
+	m_sci0_i2c_view[1](0xffd8, 0xffd8).rw(m_i2c, FUNC(h8_i2c_device::iccr_r), FUNC(h8_i2c_device::iccr_w));
+	m_sci0_i2c_view[1](0xffd9, 0xffd9).rw(m_i2c, FUNC(h8_i2c_device::icsr_r), FUNC(h8_i2c_device::icsr_w));
+	m_sci0_i2c_view[1](0xffde, 0xffde).rw(m_i2c, FUNC(h8_i2c_device::icdr_r), FUNC(h8_i2c_device::icdr_w));
+	m_sci0_i2c_view[1](0xffdf, 0xffdf).rw(m_i2c, FUNC(h8_i2c_device::icmr_sar_r), FUNC(h8_i2c_device::icmr_sar_w));
 
 	map(0xffe0, 0xffe7).r(m_adc, FUNC(h8_adc_device::addr8_r));
 	map(0xffe8, 0xffe8).rw(m_adc, FUNC(h8_adc_device::adcsr_r), FUNC(h8_adc_device::adcsr_w));
@@ -142,6 +152,12 @@ void h83337_device::device_add_mconfig(machine_config &config)
 {
 	H8_INTC(config, m_intc, *this);
 	H8_ADC_3337(config, m_adc, *this, m_intc, 35);
+
+	H8_I2C(config, m_i2c);
+	m_i2c->scl_cb().set([this](int state) { m_scl_w(state); });
+	m_i2c->sda_cb().set([this](int state) { m_sda_w(state); });
+	m_i2c->sda_out_cb().set([this]() { return m_sda_r(); });
+
 	H8_PORT(config, m_port1, *this, h8_device::PORT_1, 0x00, 0x00);
 	H8_PORT(config, m_port2, *this, h8_device::PORT_2, 0x00, 0x00);
 	H8_PORT(config, m_port3, *this, h8_device::PORT_3, 0x00, 0x00);
@@ -229,6 +245,7 @@ void h83337_device::device_reset()
 	m_wscr = 0x08;
 	m_stcr = 0x00;
 	m_syscr = 0x09;
+	m_sci0_i2c_view.select(0);
 }
 
 u8 h83337_device::syscr_r()
@@ -265,6 +282,12 @@ void h83337_device::stcr_w(u8 data)
 	// ICKS0/1
 	m_timer8_0->set_extra_clock_bit(BIT(data, 0));
 	m_timer8_1->set_extra_clock_bit(BIT(data, 1));
+
+	// IICE (enable access to I2C registers in place of SCI0)
+	if (BIT(data, 4))
+		m_sci0_i2c_view.select(1);
+	else
+		m_sci0_i2c_view.select(0);
 
 	m_stcr = data;
 }

--- a/src/devices/cpu/h8/h83337.cpp
+++ b/src/devices/cpu/h8/h83337.cpp
@@ -24,8 +24,8 @@ DEFINE_DEVICE_TYPE(H83336, h83336_device, "h83336", "Hitachi H8/3336")
 DEFINE_DEVICE_TYPE(H83337, h83337_device, "h83337", "Hitachi H8/3337")
 
 
-h83337_device::h83337_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, u32 start) :
-	h8_device(mconfig, type, tag, owner, clock, address_map_constructor(FUNC(h83337_device::map), this)),
+h83337_device::h83337_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, address_map_constructor map_delegate, u32 start) :
+	h8_device(mconfig, type, tag, owner, clock, map_delegate),
 	m_intc(*this, "intc"),
 	m_adc(*this, "adc"),
 	m_port1(*this, "port1"),
@@ -43,6 +43,11 @@ h83337_device::h83337_device(const machine_config &mconfig, device_type type, co
 	m_timer16_0(*this, "timer16:0"),
 	m_watchdog(*this, "watchdog"),
 	m_ram_start(start)
+{
+}
+
+h83337_device::h83337_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, u32 start) :
+	h83337_device(mconfig, H83337, tag, owner, clock, address_map_constructor(FUNC(h83337_device::map), this), 0xf780)
 {
 }
 
@@ -97,8 +102,8 @@ void h83337_device::map(address_map &map)
 	map(0xffb9, 0xffb9).rw(m_port6, FUNC(h8_port_device::ff_r), FUNC(h8_port_device::ddr_w));
 	map(0xffba, 0xffba).rw(m_port5, FUNC(h8_port_device::port_r), FUNC(h8_port_device::dr_w));
 	map(0xffbb, 0xffbb).rw(m_port6, FUNC(h8_port_device::port_r), FUNC(h8_port_device::dr_w));
-	map(0xffbd, 0xffbd).rw(m_port8, FUNC(h8_port_device::ff_r), FUNC(h8_port_device::ddr_w));
-	map(0xffbe, 0xffbe).rw(m_port7, FUNC(h8_port_device::port_r), FUNC(h8_port_device::dr_w));
+	map(0xffbd, 0xffbd).w(m_port8, FUNC(h8_port_device::ddr_w));
+	map(0xffbe, 0xffbe).r(m_port7, FUNC(h8_port_device::port_r));
 	map(0xffbf, 0xffbf).rw(m_port8, FUNC(h8_port_device::port_r), FUNC(h8_port_device::dr_w));
 	map(0xffc0, 0xffc0).rw(m_port9, FUNC(h8_port_device::ff_r), FUNC(h8_port_device::ddr_w));
 	map(0xffc1, 0xffc1).rw(m_port9, FUNC(h8_port_device::port_r), FUNC(h8_port_device::dr_w));

--- a/src/devices/cpu/h8/h83337.h
+++ b/src/devices/cpu/h8/h83337.h
@@ -26,6 +26,7 @@
 
 #include "h8_intc.h"
 #include "h8_adc.h"
+#include "h8_i2c.h"
 #include "h8_port.h"
 #include "h8_timer8.h"
 #include "h8_timer16.h"
@@ -54,6 +55,10 @@ public:
 	auto read_port9()  { return m_read_port [PORT_9].bind(); }
 	auto write_port9() { return m_write_port[PORT_9].bind(); }
 
+	auto scl_cb() { return m_scl_w.bind(); }
+	auto sda_cb() { return m_sda_w.bind(); }
+	auto sda_out_cb() { return m_sda_r.bind(); }
+
 	u8 wscr_r();
 	void wscr_w(u8 data);
 	u8 stcr_r();
@@ -67,8 +72,13 @@ protected:
 	h83337_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, address_map_constructor map_delegate, u32 start);
 	h83337_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, u32 start);
 
+	devcb_write_line m_scl_w;
+	devcb_write_line m_sda_w;
+	devcb_read_line m_sda_r;
+
 	required_device<h8_intc_device> m_intc;
 	required_device<h8_adc_device> m_adc;
+	required_device<h8_i2c_device> m_i2c;
 	required_device<h8_port_device> m_port1;
 	required_device<h8_port_device> m_port2;
 	required_device<h8_port_device> m_port3;
@@ -83,6 +93,8 @@ protected:
 	required_device<h8_timer16_device> m_timer16;
 	required_device<h8_timer16_channel_device> m_timer16_0;
 	required_device<h8_watchdog_device> m_watchdog;
+
+	memory_view m_sci0_i2c_view;
 
 	u32 m_ram_start;
 	u8 m_wscr;

--- a/src/devices/cpu/h8/h83337.h
+++ b/src/devices/cpu/h8/h83337.h
@@ -64,6 +64,7 @@ public:
 	void mdcr_w(u8 data);
 
 protected:
+	h83337_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, address_map_constructor map_delegate, u32 start);
 	h83337_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, u32 start);
 
 	required_device<h8_intc_device> m_intc;

--- a/src/devices/cpu/h8/h83437.cpp
+++ b/src/devices/cpu/h8/h83437.cpp
@@ -1,0 +1,57 @@
+// license:BSD-3-Clause
+// copyright-holders:Olivier Galibert
+// copyright-holders:Lubomir Rintel
+/***************************************************************************
+
+    h83437.cpp
+
+    H8-3437 family emulation
+
+***************************************************************************/
+
+#include "emu.h"
+#include "h83437.h"
+
+DEFINE_DEVICE_TYPE(H83434, h83434_device, "h83434", "Hitachi H8/3434")
+DEFINE_DEVICE_TYPE(H83436, h83436_device, "h83436", "Hitachi H8/3436")
+DEFINE_DEVICE_TYPE(H83437, h83437_device, "h83437", "Hitachi H8/3437")
+
+
+h83437_device::h83437_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, u32 start) :
+	h83337_device(mconfig, type, tag, owner, clock, address_map_constructor(FUNC(h83437_device::map), this), start),
+	m_porta(*this, "porta"),
+	m_portb(*this, "portb")
+{
+}
+
+h83437_device::h83437_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
+	h83437_device(mconfig, H83437, tag, owner, clock, 0xf780)
+{
+}
+
+h83434_device::h83434_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
+	h83437_device(mconfig, H83434, tag, owner, clock, 0xfb80)
+{
+}
+
+h83436_device::h83436_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
+	h83437_device(mconfig, H83436, tag, owner, clock, 0xf780)
+{
+}
+
+void h83437_device::map(address_map &map)
+{
+	h83337_device::map(map);
+	map(0xffaa, 0xffaa).rw(m_porta, FUNC(h8_port_device::dr_r), FUNC(h8_port_device::dr_w));
+	map(0xffab, 0xffab).rw(m_porta, FUNC(h8_port_device::port_r), FUNC(h8_port_device::ddr_w));
+	map(0xffbc, 0xffbc).rw(m_portb, FUNC(h8_port_device::dr_r), FUNC(h8_port_device::dr_w));
+	map(0xffbd, 0xffbd).r(m_portb, FUNC(h8_port_device::port_r));
+	map(0xffbe, 0xffbe).w(m_portb, FUNC(h8_port_device::ddr_w));
+}
+
+void h83437_device::device_add_mconfig(machine_config &config)
+{
+	h83337_device::device_add_mconfig(config);
+	H8_PORT(config, m_porta, *this, h8_device::PORT_A, 0x00, 0x00);
+	H8_PORT(config, m_portb, *this, h8_device::PORT_B, 0x00, 0x00);
+}

--- a/src/devices/cpu/h8/h83437.h
+++ b/src/devices/cpu/h8/h83437.h
@@ -1,0 +1,60 @@
+// license:BSD-3-Clause
+// copyright-holders:Olivier Galibert
+// copyright-holders:Lubomir Rintel
+/***************************************************************************
+
+    h83437.h
+
+    H8-3437 family emulation
+
+    H8-300-based mcus.
+
+    Variant         ROM        RAM
+    H8/3434         32K         1K
+    H8/3436         48K         2K
+    H8/3437         60K         2K
+
+***************************************************************************/
+
+#ifndef MAME_CPU_H8_H83437_H
+#define MAME_CPU_H8_H83437_H
+
+#pragma once
+
+#include "h83337.h"
+#include "h8_port.h"
+
+class h83437_device : public h83337_device {
+public:
+	h83437_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	auto read_porta()  { return m_read_port [PORT_A].bind(); }
+	auto write_porta() { return m_write_port[PORT_A].bind(); }
+	auto read_portb()  { return m_read_port [PORT_B].bind(); }
+	auto write_portb() { return m_write_port[PORT_B].bind(); }
+
+protected:
+	h83437_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, u32 start);
+
+	required_device<h8_port_device> m_porta;
+	required_device<h8_port_device> m_portb;
+
+	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
+	void map(address_map &map) ATTR_COLD;
+};
+
+class h83434_device : public h83437_device {
+public:
+	h83434_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+};
+
+class h83436_device : public h83437_device {
+public:
+	h83436_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+};
+
+DECLARE_DEVICE_TYPE(H83434, h83434_device)
+DECLARE_DEVICE_TYPE(H83436, h83436_device)
+DECLARE_DEVICE_TYPE(H83437, h83437_device)
+
+#endif // MAME_CPU_H8_H83437_H

--- a/src/devices/cpu/h8/h8_i2c.cpp
+++ b/src/devices/cpu/h8/h8_i2c.cpp
@@ -1,0 +1,197 @@
+// license:BSD-2-Clause
+// copyright-holders:Lubomir Rintel
+
+/***************************************************************************
+
+    H8 I2C controller emulation
+
+    An I2C block present on H8/3337, H8/3437 and probably elsewhere.
+
+    TODO:
+    - Slave mode
+    - Interrupts
+
+***************************************************************************/
+
+#include "emu.h"
+#include "h8_i2c.h"
+
+DEFINE_DEVICE_TYPE(H8_I2C, h8_i2c_device, "h8_i2c", "H8 I2C")
+
+h8_i2c_device::h8_i2c_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
+	device_t(mconfig, H8_I2C, tag, owner, clock),
+	m_scl_w(*this),
+	m_sda_w(*this),
+	m_sda_r(*this, 0)
+{
+}
+
+void h8_i2c_device::iccr_w(u8 data)
+{
+	logerror("iccr_w %02x\n", data);
+	m_iccr = data;
+}
+
+u8 h8_i2c_device::iccr_r()
+{
+	logerror("iccr_r %02x\n", m_iccr);
+	return m_iccr;
+}
+
+void h8_i2c_device::icsr_w(u8 data)
+{
+	logerror("icsr_w %02x\n", data);
+
+	if (BIT(m_iccr, 7)) { // I2C Enabled
+		if (BIT(m_iccr, 5)) { // Master mode
+			if (!BIT(data, 5)) { // Not suppressed
+				if (BIT(data, 7)) {
+					m_sda_w(0);
+				} else {
+					m_scl_w(1);
+					m_sda_w(1);
+				}
+			}
+		} else {
+			logerror("Slave mode not implemented!\n");
+		}
+	}
+
+	// Preserve these bits if we're writing 0 to them
+	data |= m_icsr & (data & 0x4e);
+	// Preserve these bits where they have not been read yet
+	data |= m_icsr & (~m_icsr_read & 0x4e);
+	// Always 1
+	data |= 0x30;
+
+	m_icsr = data;
+}
+
+u8 h8_i2c_device::icsr_r()
+{
+	m_icsr_read = m_icsr;
+	if (BIT(m_iccr, 4)) {
+		// If we're transmitting, ACK bit reflects current line state
+		m_icsr_read &= 0xfe;
+		m_icsr_read |= m_sda_r();
+	}
+	logerror("icsr_r %02x\n", m_icsr_read);
+
+	return m_icsr_read;
+}
+
+void h8_i2c_device::icdr_w(u8 data)
+{
+	logerror("icdr_w %02x\n", data);
+
+	if (BIT(m_iccr, 7)) { // I2C Enabled
+		if (BIT(m_iccr, 5)) { // Master mode
+			if (BIT(m_iccr, 4)) { // Not inhibited
+				logerror("Transmitting [%02x].\n", m_icdr);
+
+				for (int i = 0; i < 8; i++) {
+					m_scl_w(0);
+					m_sda_w((data & 0x80) ? 1 : 0);
+					data = data << 1;
+					m_scl_w(1);
+				}
+
+				// Receive the ACK bit.
+				m_scl_w(0);
+				m_sda_w(1);
+				m_scl_w(1);
+				m_icsr &= ~1;
+				m_icsr |= m_sda_r();
+
+				// Signal an interrupt
+				m_icsr |= 1 << 6;
+			} else {
+				logerror("Data written but transmit not enabled!\n");
+			}
+		} else {
+			logerror("Slave mode not implemented!\n");
+		}
+	}
+
+	m_icdr = data;
+}
+
+u8 h8_i2c_device::icdr_r()
+{
+	u8 data = m_icdr;
+
+	if (BIT(m_iccr, 7)) { // I2C Enabled
+		if (BIT(m_iccr, 5)) { // Master mode
+			if (!BIT(m_iccr, 4)) {	// Not inhibited
+				m_icdr = 0;
+				m_scl_w(0);
+				for (int i = 0; i < 8; i++)
+				{
+					m_scl_w(1);
+					m_icdr <<= 1;
+					m_icdr |= m_sda_r();
+					m_scl_w(0);
+				}
+
+				// ACK if enabled
+				m_sda_w(m_icsr & 1);
+				m_scl_w(1);
+
+				// Signal an interrupt
+				m_icsr |= 1 << 6;
+
+				logerror("Received [%02x].\n", m_icdr);
+			} else {
+				// Do not receive more bytes, just return present one
+				logerror("Not receiving more data.\n");
+			}
+		} else {
+			logerror("Slave mode not implemented!\n");
+		}
+	}
+	logerror("icdr_r %02x\n", data);
+
+	return data;
+}
+
+void h8_i2c_device::icmr_sar_w(u8 data)
+{
+	logerror("icmr_sar_w %02x\n", data);
+
+	// Pick register from the ICE bit
+	if (BIT(m_iccr, 7))
+		m_icmr = data;
+	else
+		m_sar = data;
+}
+
+u8 h8_i2c_device::icmr_sar_r()
+{
+	logerror("icmr_sar_r %02x\n", m_icdr);
+
+	// Pick register from the ICE bit
+	if (BIT(m_iccr, 7))
+		return m_icmr;
+	else
+		return m_sar;
+}
+
+void h8_i2c_device::device_start()
+{
+	save_item(NAME(m_iccr));
+	save_item(NAME(m_icsr));
+	save_item(NAME(m_icdr));
+	save_item(NAME(m_icmr));
+	save_item(NAME(m_sar));
+}
+
+void h8_i2c_device::device_reset()
+{
+	m_icsr_read = 0;
+
+	m_iccr = 0x00;
+	m_icsr = 0x30;
+	m_icdr = 0x00;
+	m_icmr = 0x38;
+	m_sar = 0x00;
+}

--- a/src/devices/cpu/h8/h8_i2c.h
+++ b/src/devices/cpu/h8/h8_i2c.h
@@ -1,0 +1,53 @@
+// license:BSD-2-Clause
+// copyright-holders:Lubomir Rintel
+
+#ifndef MAME_CPU_H8_H8_I2C_H
+#define MAME_CPU_H8_H8_I2C_H
+
+#pragma once
+
+#include "h8.h"
+#include "machine/i2chle.h"
+
+class h8_i2c_device : public device_t {
+public:
+	h8_i2c_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+	h8_i2c_device(const machine_config &mconfig, const char *tag, device_t *owner)
+		: h8_i2c_device(mconfig, tag, owner, 0)
+	{
+	}
+
+	// callback configuration
+	auto scl_cb() { return m_scl_w.bind(); }
+	auto sda_cb() { return m_sda_w.bind(); }
+	auto sda_out_cb() { return m_sda_r.bind(); }
+
+	void iccr_w(u8 data);
+	u8 iccr_r();
+	void icsr_w(u8 data);
+	u8 icsr_r();
+	void icdr_w(u8 data);
+	u8 icdr_r();
+	void icmr_sar_w(u8 data);
+	u8 icmr_sar_r();
+
+protected:
+	devcb_write_line m_scl_w;
+	devcb_write_line m_sda_w;
+	devcb_read_line m_sda_r;
+
+	u8 m_icsr_read;
+
+	u8 m_iccr;
+	u8 m_icsr;
+	u8 m_icdr;
+	u8 m_icmr;
+	u8 m_sar;
+
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+};
+
+DECLARE_DEVICE_TYPE(H8_I2C, h8_i2c_device)
+
+#endif // MAME_CPU_H8_H8_I2C_H

--- a/src/mame/ibm/thinkpad600.cpp
+++ b/src/mame/ibm/thinkpad600.cpp
@@ -65,7 +65,7 @@ Hardware for the 600 model.
 #include "bus/rs232/rs232.h"
 #include "bus/rs232/sun_kbd.h"
 #include "bus/rs232/terminal.h"
-#include "cpu/h8/h83337.h"
+#include "cpu/h8/h83437.h"
 #include "cpu/i386/i386.h"
 #include "machine/pci.h"
 #include "machine/pci-ide.h"
@@ -152,8 +152,8 @@ static void isa_internal_devices(device_slot_interface &device)
 
 void thinkpad600_state::thinkpad600_base(machine_config &config)
 {
-	// TODO: move away, maps on MB resource, bump to H83437
-	h83337_device &mcu(H83337(config, "mcu", XTAL(16'000'000))); // Actually an Hitachi HD64F3437TF, unknown clock
+	// TODO: move away, maps on MB resource
+	h83437_device &mcu(H83437(config, "mcu", XTAL(16'000'000))); // Actually an Hitachi HD64F3437TF, unknown clock
 	mcu.set_addrmap(AS_PROGRAM, &thinkpad600_state::mcu_map);
 //  mcu.set_disable();
 }

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -43399,6 +43399,9 @@ sun4_75                         //
 @source:sun/ultra45.cpp
 ultra45                         //
 
+@source:sun/v120.cpp
+v120                            //
+
 @source:suna/go2000.cpp
 go2000                          // (c) 2000 SA
 

--- a/src/mame/sun/v120.cpp
+++ b/src/mame/sun/v120.cpp
@@ -1,0 +1,159 @@
+#include "emu.h"
+
+#include "cpu/h8/h83437.h"
+#include "bus/rs232/rs232.h"
+#include "machine/input_merger.h"
+#include "machine/i2cmem.h"
+
+#include "speaker.h"
+
+namespace {
+
+class v120_state : public driver_device
+{
+public:
+	v120_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag),
+		m_flashv(0x11),
+		m_lom(*this, "lom"),
+		m_ttya(*this, "ttya"),
+		m_lom_eeprom(*this, "lom_eeprom")
+	{ }
+
+	void v120(machine_config &config);
+
+private:
+	u8 m_flashv;
+
+	required_device<h83437_device> m_lom;
+	required_device<rs232_port_device> m_ttya;
+	required_device<i2cmem_device> m_lom_eeprom;
+
+	void mcu_map(address_map &map);
+	auto sda_read();
+
+	void lom_set_i2c(int state);
+};
+
+void v120_state::mcu_map(address_map &map)
+{
+	map(0x0000, 0xf77f).rom().region("lom", 0);
+
+	// Kludge! Needed sp that the newly booted firmware doesn't think it just
+	// upgraded. Probably needs to be removed altogether with a real ROM dump
+	// as opposed to one from firmware upgrade package.
+	map(0xf77e, 0xf77e).lrw8(NAME([this]() { return m_flashv; }), NAME([this](u8 data) { m_flashv = data; }));
+}
+
+static DEVICE_INPUT_DEFAULTS_START(terminal)
+	DEVICE_INPUT_DEFAULTS("RS232_RXBAUD", 0xff, RS232_BAUD_9600)
+	DEVICE_INPUT_DEFAULTS("RS232_TXBAUD", 0xff, RS232_BAUD_9600)
+	DEVICE_INPUT_DEFAULTS("RS232_DATABITS", 0xff, RS232_DATABITS_8)
+	DEVICE_INPUT_DEFAULTS("RS232_PARITY", 0xff, RS232_PARITY_NONE)
+	DEVICE_INPUT_DEFAULTS("RS232_STOPBITS", 0xff, RS232_STOPBITS_1)
+DEVICE_INPUT_DEFAULTS_END
+
+auto v120_state::sda_read()
+{
+	u8 lom_eeprom_sda = m_lom_eeprom->read_sda();
+	logerror ("sda_read: eeprom=%d\n", lom_eeprom_sda);
+
+	// SDA lines from other devices will be mixed in here
+	return lom_eeprom_sda;
+}
+
+void v120_state::v120(machine_config &config)
+{
+	// Lights-Out Management controller.
+	H83437(config, m_lom, XTAL(14'318'181));
+	m_lom->set_addrmap(AS_PROGRAM, &v120_state::mcu_map);
+	m_lom->write_sci_tx<1>().set(m_ttya, FUNC(rs232_port_device::write_txd));
+
+	RS232_PORT(config, m_ttya, default_rs232_devices, "terminal");
+	m_ttya->rxd_handler().set(m_lom, FUNC(h83437_device::sci_rx_w<1>));
+	m_ttya->set_option_device_input_defaults("terminal", DEVICE_INPUT_DEFAULTS_NAME(terminal));
+
+	// Debug chatter
+	m_lom->scl_cb().set([this](int state) { logerror("scl_write %d\n", state); });
+	m_lom->sda_cb().set([this](int state) { logerror("sda_write %d\n", state); });
+
+	// Shared open collector data line
+	m_lom->sda_out_cb().set(FUNC(v120_state::sda_read));
+
+	// Lights-Out Management controller configuration rom.
+	I2C_24C64(config, m_lom_eeprom);
+	m_lom->scl_cb().append(m_lom_eeprom, FUNC(i2cmem_device::write_scl));
+	m_lom->sda_cb().append(m_lom_eeprom, FUNC(i2cmem_device::write_sda));
+
+	// TODO:
+	// - the actual computer:
+	// - main processor & its peripherals
+}
+
+/*
+ * The ROMs can be dumped from the running system via the LOM shell.
+ * Some undocumented commands have been identified that can help
+ * with that. These are available:
+ *
+ * General/debugging:
+ *
+ * set extra-cmds <val> - Enables all commands documented below.
+ *            <val> is "on" or "off". "God mode".
+ * set gdw <data>   - Sets debugging bitmask. Enables some
+ *            extra debug chatter, apparently dealing
+ *            with the terminal input buffer.
+ *
+ * H8 memory address space access:
+ *
+ * rb <addr>        - Read (8-bit) byte from memory
+ * rw <addr>        - Read (16-bit) word from memory
+ * rl <addr>        - Read (32-bit) long from memory
+ * wb <addr> <data> - Write (8-bit) byte to memory
+ * ww <addr> <data> - Write (16-bit) word to memory
+ * wl <addr> <data> - Write (32-bit) long to memory
+ *
+ * Configuration EEPROM access:
+ *
+ * reb <addr>       - Read (8-bit) byte from eeprom
+ * rew <addr>       - Read (16-bit) word from eeprom
+ * rel <addr>       - Read (32-bit) long from eeprom
+ * web <addr> <data>    - Write (8-bit) byte to eeprom
+ * wew <addr> <data>    - Write (16-bit) word to eeprom
+ * wel <addr> <data>    - Write (32-bit) long to eeprom
+ * eepromreset      - No idea, doesn't seem to do anything
+ *
+ * <addr> and <data> plain hex numbers (no 0x).
+ *
+ * First the memory commands need to be enabled with:
+ *
+ * lom> set extra-cmds on
+ * (Congratulations, you just voided your machine's warranty)
+ *
+ * The "lomlite2-v3.14.bin" can be obtained from a firmware update
+ * package or dumped from main LOM memory addresses 0000 to f780
+ *
+ * lom> rw 0000
+ * lom> rw 0002
+ * ...
+ * lom> rw f77e
+ *
+ * The configuation EEPROM describes which fans, supplies, etc. are
+ * available and stores the console buffer. It's dumped analogously:
+ *
+ * lom> rew 0000
+ * ...
+ * lom> rew 1ffe
+ */
+
+ROM_START(v120)
+	ROM_REGION16_BE(0x0f780, "lom", 0)
+	ROM_LOAD( "lomlite2-v3.14.bin",  0x00000, 0x0f780, CRC(0c6e6eba) SHA1(a3cd00d875cbcdb58060415b0a3ef56df5078631) )
+
+	ROM_REGION( 0x2000, "lom_eeprom", 0 )
+	ROM_LOAD( "lomlite2-eeprom.bin", 0x0000, 0x2000, NO_DUMP)
+ROM_END
+
+} // anonymous namespace
+
+//    YEAR, NAME, PARENT, COMPAT, MACHINE, INPUT, CLASS,      INIT,       COMPANY,            FULLNAME,   FLAGS
+COMP( 1996, v120, 0,      0,      v120,    0,     v120_state, empty_init, "Sun Microsystems", "v120",     MACHINE_IS_SKELETON )


### PR DESCRIPTION
Hi,

I found MAME and its H8 emulation very useful in my effort to understand management controller on mid 2000's Sun Fire V120 server. I'm wondering if anything I've done is useful for MAME:

Here's what I got:

- h8: add H8/3437 emulation
- thinkpad600: replace H8/3337 with H8/3437
- h83337: add I2C controller implementation
  These three are probably useful for the Thinkpad 600.
- sun/v120: add stub of Sun Fire V120 server 
  Not sure if useful. Very minimal skeleton, since I've only been interested in the management microcomputer.

The I2C implementation has also been tested with a skeleton of a fan monitor chip using the i2chle interface, but that is certainly not something that's ready: https://github.com/lkundrak/mame/commits/lr/lomlite-dev/
https://github.com/lkundrak/mame/commits/lr/lomlite-dev/