### PR TITLE
tetrisp2.cpp: Use memory_bank finder for sound bankswitching, Cleanups:

### DIFF
--- a/src/mame/jaleco/tetrisp2.cpp
+++ b/src/mame/jaleco/tetrisp2.cpp
@@ -82,20 +82,12 @@ u16 rockn_state::rockn_adpcmbank_r()
 void rockn_state::rockn_adpcmbank_w(u16 data)
 {
 	m_rockn_adpcmbank = data;
-	int bank = ((data & 0x001f) >> 2);
-
-	if (bank > 7)
-	{
-		popmessage("!!!!! ADPCM BANK OVER:%01X (%04X) !!!!!", bank, data);
-		bank = 0;
-	}
-
-	m_ymzbank[0]->set_entry(bank);
+	m_ymzbank[0]->set_entry((data >> 2) & 0x07);
 }
 
 void rockn_state::rockn2_adpcmbank_w(u16 data)
 {
-	char banktable[9][3]=
+	const uint8_t banktable[9][3]=
 	{
 		{  0,  1,  2 },     // bank $00
 		{  3,  4,  5 },     // bank $04

--- a/src/mame/jaleco/tetrisp2.cpp
+++ b/src/mame/jaleco/tetrisp2.cpp
@@ -74,18 +74,15 @@ stepstag:
 
 ***************************************************************************/
 
-u16 tetrisp2_state::rockn_adpcmbank_r()
+u16 rockn_state::rockn_adpcmbank_r()
 {
 	return ((m_rockn_adpcmbank & 0xf0ff) | (m_rockn_protectdata << 8));
 }
 
-void tetrisp2_state::rockn_adpcmbank_w(u16 data)
+void rockn_state::rockn_adpcmbank_w(u16 data)
 {
-	u8 *SNDROM = memregion("ymz")->base();
-	int bank;
-
 	m_rockn_adpcmbank = data;
-	bank = ((data & 0x001f) >> 2);
+	int bank = ((data & 0x001f) >> 2);
 
 	if (bank > 7)
 	{
@@ -93,14 +90,11 @@ void tetrisp2_state::rockn_adpcmbank_w(u16 data)
 		bank = 0;
 	}
 
-	memcpy(&SNDROM[0x0400000], &SNDROM[0x1000000 + (0x0c00000 * bank)], 0x0c00000);
+	m_ymzbank[0]->set_entry(bank);
 }
 
-void tetrisp2_state::rockn2_adpcmbank_w(u16 data)
+void rockn_state::rockn2_adpcmbank_w(u16 data)
 {
-	u8 *SNDROM = memregion("ymz")->base();
-	int bank;
-
 	char banktable[9][3]=
 	{
 		{  0,  1,  2 },     // bank $00
@@ -115,7 +109,7 @@ void tetrisp2_state::rockn2_adpcmbank_w(u16 data)
 	};
 
 	m_rockn_adpcmbank = data;
-	bank = ((data & 0x003f) >> 2);
+	int bank = ((data & 0x003f) >> 2);
 
 	if (bank > 8)
 	{
@@ -123,46 +117,40 @@ void tetrisp2_state::rockn2_adpcmbank_w(u16 data)
 		bank = 0;
 	}
 
-	memcpy(&SNDROM[0x0400000], &SNDROM[0x1000000 + (0x0400000 * banktable[bank][0] )], 0x0400000);
-	memcpy(&SNDROM[0x0800000], &SNDROM[0x1000000 + (0x0400000 * banktable[bank][1] )], 0x0400000);
-	memcpy(&SNDROM[0x0c00000], &SNDROM[0x1000000 + (0x0400000 * banktable[bank][2] )], 0x0400000);
+	for (int i = 0; i < 3; i++)
+		m_ymzbank[i]->set_entry(banktable[bank][i]);
 }
 
 
-u16 tetrisp2_state::rockn_soundvolume_r()
+u16 rockn_state::rockn_soundvolume_r()
 {
 	return 0xffff;
 }
 
-void tetrisp2_state::rockn_soundvolume_w(u16 data)
+void rockn_state::rockn_soundvolume_w(u16 data)
 {
 	m_rockn_soundvolume = data;
 	// TODO: unemulated
 }
 
 
-void tetrisp2_state::nndmseal_sound_bank_w(offs_t offset, u16 data, u16 mem_mask)
+void nndmseal_state::nndmseal_sound_bank_w(u8 data)
 {
-	if (ACCESSING_BITS_0_7)
+	if (BIT(data, 2))
 	{
-		u8 *rom = memregion("okisource")->base();
+		m_bank_lo = data & 0x03;
 
-		if (data & 0x04)
-		{
-			m_bank_lo = data & 0x03;
+		m_okibank[0]->set_entry(m_bank_lo);
+		m_okibank[1]->set_entry((m_bank_lo * 4) + m_bank_hi);
 
-			memcpy(memregion("oki")->base(), rom + (m_bank_lo * 0x80000), 0x20000);
+//      logerror("PC:%06X sound bank_lo = %02X\n",m_maincpu->pc(),m_bank_lo);
+	}
+	else
+	{
+		m_bank_hi = data & 0x03;
+		m_okibank[1]->set_entry((m_bank_lo * 4) + m_bank_hi);
 
-//          logerror("PC:%06X sound bank_lo = %02X\n",m_maincpu->pc(),m_bank_lo);
-		}
-		else
-		{
-			m_bank_hi = data & 0x03;
-
-			memcpy(memregion("oki")->base() + 0x20000, rom + (m_bank_lo * 0x80000) + (m_bank_hi * 0x20000), 0x20000);
-
-//          logerror("PC:%06X sound bank_hi = %02X\n",m_maincpu->pc(),m_bank_hi);
-		}
+//      logerror("PC:%06X sound bank_hi = %02X\n",m_maincpu->pc(),m_bank_hi);
 	}
 }
 
@@ -176,9 +164,9 @@ void tetrisp2_state::nndmseal_sound_bank_w(offs_t offset, u16 data, u16 mem_mask
 
 u16 tetrisp2_state::tetrisp2_ip_1_word_r()
 {
-	return  ( ioport("SYSTEM")->read() &  0xfcff ) |
-			(           machine().rand() & ~0xfcff ) |
-			(      1 << (8 + (machine().rand()&1)) );
+	return  (m_io_system->read() &  0xfcff) |
+			(   machine().rand() & ~0xfcff) |
+			(1 << (8 + (machine().rand() & 1)));
 }
 
 
@@ -195,18 +183,18 @@ u16 tetrisp2_state::tetrisp2_ip_1_word_r()
 /* The game only ever writes even bytes and reads odd bytes */
 u16 tetrisp2_state::tetrisp2_nvram_r(offs_t offset)
 {
-	return  ( (m_nvram[offset] >> 8) & 0x00ff ) |
-			( (m_nvram[offset] << 8) & 0xff00 ) ;
+	return  ((m_nvram[offset] >> 8) & 0x00ff) |
+			((m_nvram[offset] << 8) & 0xff00);
 }
 
-void tetrisp2_state::tetrisp2_nvram_w(offs_t offset, u16 data, u16 mem_mask)
+void tetrisp2_state::nvram_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_nvram[offset]);
 }
 
-u16 tetrisp2_state::rockn_nvram_r(offs_t offset)
+u16 rockn_state::rockn_nvram_r(offs_t offset)
 {
-	return  m_nvram[offset];
+	return m_nvram[offset];
 }
 
 
@@ -219,32 +207,32 @@ u16 tetrisp2_state::rockn_nvram_r(offs_t offset)
 ***************************************************************************/
 
 
-u16 rocknms_state::rocknms_main2sub_r()
+u16 rocknms_state::main2sub_r()
 {
-	return m_rocknms_main2sub;
+	return m_main2sub;
 }
 
-void rocknms_state::rocknms_main2sub_w(offs_t offset, u16 data, u16 mem_mask)
+void rocknms_state::main2sub_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (ACCESSING_BITS_0_7)
-		m_rocknms_main2sub = (data ^ 0xffff);
+		m_main2sub = (data ^ 0xffff);
 }
 
-ioport_value rocknms_state::rocknms_main2sub_status_r()
+ioport_value rocknms_state::main2sub_status_r()
 {
-	return m_rocknms_sub2main & 0x0003;
+	return m_sub2main & 0x0003;
 }
 
-void rocknms_state::rocknms_sub2main_w(offs_t offset, u16 data, u16 mem_mask)
+void rocknms_state::sub2main_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (ACCESSING_BITS_0_7)
-		m_rocknms_sub2main = (data ^ 0xffff);
+		m_sub2main = (data ^ 0xffff);
 }
 
 
 void tetrisp2_state::tetrisp2_coincounter_w(u16 data)
 {
-	machine().bookkeeping().coin_counter_w(0, (data & 0x0001));
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 0));
 }
 
 
@@ -260,26 +248,26 @@ void tetrisp2_state::tetrisp2_coincounter_w(u16 data)
 void tetrisp2_state::tetrisp2_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();                                                         // ROM
-	map(0x100000, 0x103fff).ram().share("spriteram");           // Object RAM
+	map(0x100000, 0x103fff).ram().share(m_spriteram);           // Object RAM
 	map(0x104000, 0x107fff).ram();                                                         // Spare Object RAM
 	map(0x108000, 0x10ffff).ram();                                                         // Work RAM
-	map(0x200000, 0x23ffff).rw(FUNC(tetrisp2_state::tetrisp2_priority_r), FUNC(tetrisp2_state::tetrisp2_priority_w));
-	map(0x300000, 0x31ffff).ram().w(FUNC(tetrisp2_state::tetrisp2_palette_w)).share("paletteram");        // Palette
-	map(0x400000, 0x403fff).ram().w(FUNC(tetrisp2_state::tetrisp2_vram_fg_w)).share("vram_fg");   // Foreground
-	map(0x404000, 0x407fff).ram().w(FUNC(tetrisp2_state::tetrisp2_vram_bg_w)).share("vram_bg");   // Background
+	map(0x200000, 0x23ffff).rw(FUNC(tetrisp2_state::priority_r), FUNC(tetrisp2_state::priority_w));
+	map(0x300000, 0x31ffff).ram().w(FUNC(tetrisp2_state::palette_w)).share(m_paletteram);        // Palette
+	map(0x400000, 0x403fff).ram().w(FUNC(tetrisp2_state::vram_fg_w)).share(m_vram_fg);   // Foreground
+	map(0x404000, 0x407fff).ram().w(FUNC(tetrisp2_state::vram_bg_w)).share(m_vram_bg);   // Background
 	map(0x408000, 0x409fff).ram();                                                         // ???
 	map(0x500000, 0x50ffff).ram();                                                         // Line
-	map(0x600000, 0x60ffff).ram().w(FUNC(tetrisp2_state::tetrisp2_vram_rot_w)).share("vram_rot"); // Rotation
-	map(0x650000, 0x651fff).ram().w(FUNC(tetrisp2_state::tetrisp2_vram_rot_w));                              // Rotation (mirror)
+	map(0x600000, 0x60ffff).ram().w(FUNC(tetrisp2_state::vram_rot_w)).share(m_vram_rot); // Rotation
+	map(0x650000, 0x651fff).ram().w(FUNC(tetrisp2_state::vram_rot_w));                              // Rotation (mirror)
 	map(0x800000, 0x800003).rw("ymz", FUNC(ymz280b_device::read), FUNC(ymz280b_device::write)).umask16(0x00ff);   // Sound
-	map(0x900000, 0x903fff).r(FUNC(tetrisp2_state::tetrisp2_nvram_r)).w(FUNC(tetrisp2_state::tetrisp2_nvram_w)).share("nvram"); // NVRAM
-	map(0x904000, 0x907fff).r(FUNC(tetrisp2_state::tetrisp2_nvram_r)).w(FUNC(tetrisp2_state::tetrisp2_nvram_w));               // NVRAM (mirror)
+	map(0x900000, 0x903fff).r(FUNC(tetrisp2_state::tetrisp2_nvram_r)).w(FUNC(tetrisp2_state::nvram_w)).share("nvram"); // NVRAM
+	map(0x904000, 0x907fff).r(FUNC(tetrisp2_state::tetrisp2_nvram_r)).w(FUNC(tetrisp2_state::nvram_w));               // NVRAM (mirror)
 	map(0xb00000, 0xb00001).w(FUNC(tetrisp2_state::tetrisp2_coincounter_w));                               // Coin Counter
 	map(0xb20000, 0xb20001).nopw();                                                    // ???
-	map(0xb40000, 0xb4000b).writeonly().share("scroll_fg");                     // Foreground Scrolling
-	map(0xb40010, 0xb4001b).writeonly().share("scroll_bg");                     // Background Scrolling
+	map(0xb40000, 0xb4000b).writeonly().share(m_scroll_fg);                     // Foreground Scrolling
+	map(0xb40010, 0xb4001b).writeonly().share(m_scroll_bg);                     // Background Scrolling
 	map(0xb4003e, 0xb4003f).nopw();                                                    // scr_size
-	map(0xb60000, 0xb6002f).writeonly().share("rotregs");                       // Rotation Registers
+	map(0xb60000, 0xb6002f).writeonly().share(m_rotregs);                       // Rotation Registers
 	map(0xba0000, 0xba001f).m(m_sysctrl, FUNC(jaleco_ms32_sysctrl_device::amap));
 	map(0xbe0000, 0xbe0001).nopr();                                                     // INT-level1 dummy read
 	map(0xbe0002, 0xbe0003).portr("PLAYERS");                                        // Inputs
@@ -289,13 +277,13 @@ void tetrisp2_state::tetrisp2_map(address_map &map)
 }
 
 
-void tetrisp2_state::nndmseal_coincounter_w(offs_t offset, u16 data, u16 mem_mask)
+void nndmseal_state::nndmseal_coincounter_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (ACCESSING_BITS_0_7)
 	{
-		machine().bookkeeping().coin_counter_w(0,  data  & 0x0001 );
-		//                  data  & 0x0004 ?
-		machine().bookkeeping().coin_lockout_w(0,(~data) & 0x0008 );
+		machine().bookkeeping().coin_counter_w(0, BIT( data, 0));
+		//                  BIT(data, 2) ?
+		machine().bookkeeping().coin_lockout_w(0, BIT(~data, 3));
 	}
 	if (ACCESSING_BITS_8_15)
 	{
@@ -307,43 +295,43 @@ void tetrisp2_state::nndmseal_coincounter_w(offs_t offset, u16 data, u16 mem_mas
 //  popmessage("%04x",data);
 }
 
-void tetrisp2_state::nndmseal_b20000_w(u16 data)
+void nndmseal_state::nndmseal_b20000_w(u16 data)
 {
 	// leds?
 //  popmessage("%04x",data);
 }
 
-void tetrisp2_state::nndmseal_map(address_map &map)
+void nndmseal_state::nndmseal_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
-	map(0x100000, 0x103fff).ram().share("spriteram");   // Object RAM
+	map(0x100000, 0x103fff).ram().share(m_spriteram);   // Object RAM
 	map(0x104000, 0x107fff).ram(); // Spare Object RAM
 	map(0x108000, 0x10ffff).ram(); // Work RAM
-	map(0x200000, 0x23ffff).rw(FUNC(tetrisp2_state::tetrisp2_priority_r), FUNC(tetrisp2_state::tetrisp2_priority_w));
-	map(0x300000, 0x31ffff).ram().w(FUNC(tetrisp2_state::tetrisp2_palette_w)).share("paletteram");    // Palette
-	map(0x400000, 0x403fff).ram().w(FUNC(tetrisp2_state::tetrisp2_vram_fg_w)).share("vram_fg");   // Foreground
-	map(0x404000, 0x407fff).ram().w(FUNC(tetrisp2_state::tetrisp2_vram_bg_w)).share("vram_bg");   // Background
+	map(0x200000, 0x23ffff).rw(FUNC(nndmseal_state::priority_r), FUNC(nndmseal_state::priority_w));
+	map(0x300000, 0x31ffff).ram().w(FUNC(nndmseal_state::palette_w)).share(m_paletteram);    // Palette
+	map(0x400000, 0x403fff).ram().w(FUNC(nndmseal_state::vram_fg_w)).share(m_vram_fg);   // Foreground
+	map(0x404000, 0x407fff).ram().w(FUNC(nndmseal_state::vram_bg_w)).share(m_vram_bg);   // Background
 
 	map(0x408000, 0x409fff).ram(); // ???
 	map(0x500000, 0x50ffff).ram(); // Line
 
-	map(0x600000, 0x60ffff).ram().w(FUNC(tetrisp2_state::tetrisp2_vram_rot_w)).share("vram_rot"); // Rotation
-	map(0x650000, 0x651fff).ram().w(FUNC(tetrisp2_state::tetrisp2_vram_rot_w));  // Rotation (mirror)
+	map(0x600000, 0x60ffff).ram().w(FUNC(nndmseal_state::vram_rot_w)).share(m_vram_rot); // Rotation
+	map(0x650000, 0x651fff).ram().w(FUNC(nndmseal_state::vram_rot_w));  // Rotation (mirror)
 
 	map(0x800000, 0x800003).rw("oki", FUNC(okim6295_device::read), FUNC(okim6295_device::write)).umask16(0x00ff); // Sound
 
-	map(0x900000, 0x903fff).rw(FUNC(tetrisp2_state::tetrisp2_nvram_r), FUNC(tetrisp2_state::tetrisp2_nvram_w)).share("nvram"); // NVRAM
+	map(0x900000, 0x903fff).rw(FUNC(nndmseal_state::tetrisp2_nvram_r), FUNC(nndmseal_state::nvram_w)).share("nvram"); // NVRAM
 
-	map(0xb00000, 0xb00001).w(FUNC(tetrisp2_state::nndmseal_coincounter_w));   // Coin Counter
-	map(0xb20000, 0xb20001).w(FUNC(tetrisp2_state::nndmseal_b20000_w));        // ???
+	map(0xb00000, 0xb00001).w(FUNC(nndmseal_state::nndmseal_coincounter_w));   // Coin Counter
+	map(0xb20000, 0xb20001).w(FUNC(nndmseal_state::nndmseal_b20000_w));        // ???
 
-	map(0xb40000, 0xb4000b).writeonly().share("scroll_fg"); // Foreground Scrolling
-	map(0xb40010, 0xb4001b).writeonly().share("scroll_bg"); // Background Scrolling
+	map(0xb40000, 0xb4000b).writeonly().share(m_scroll_fg); // Foreground Scrolling
+	map(0xb40010, 0xb4001b).writeonly().share(m_scroll_bg); // Background Scrolling
 	map(0xb4003e, 0xb4003f).nopw();    // scr_size
 
-	map(0xb60000, 0xb6002f).writeonly().share("rotregs");   // Rotation Registers
+	map(0xb60000, 0xb6002f).writeonly().share(m_rotregs);   // Rotation Registers
 
-	map(0xb80000, 0xb80001).w(FUNC(tetrisp2_state::nndmseal_sound_bank_w));
+	map(0xb80001, 0xb80001).w(FUNC(nndmseal_state::nndmseal_sound_bank_w));
 
 	map(0xba0000, 0xba001f).m(m_sysctrl, FUNC(jaleco_ms32_sysctrl_device::amap));
 
@@ -356,31 +344,37 @@ void tetrisp2_state::nndmseal_map(address_map &map)
 	map(0xbe000a, 0xbe000b).r("watchdog", FUNC(watchdog_timer_device::reset16_r));
 }
 
+void nndmseal_state::nndmseal_oki_map(address_map &map)
+{
+	map(0x00000, 0x1ffff).bankr(m_okibank[0]);
+	map(0x20000, 0x3ffff).bankr(m_okibank[1]);
+}
 
-void tetrisp2_state::rockn1_map(address_map &map)
+
+void rockn_state::rockn1_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();                                                         // ROM
-	map(0x100000, 0x103fff).ram().share("spriteram");           // Object RAM
+	map(0x100000, 0x103fff).ram().share(m_spriteram);           // Object RAM
 	map(0x104000, 0x107fff).ram();                                                         // Spare Object RAM
 	map(0x108000, 0x10ffff).ram();                                                         // Work RAM
-	map(0x200000, 0x23ffff).rw(FUNC(tetrisp2_state::tetrisp2_priority_r), FUNC(tetrisp2_state::tetrisp2_priority_w));
-	map(0x300000, 0x31ffff).ram().w(FUNC(tetrisp2_state::tetrisp2_palette_w)).share("paletteram");        // Palette
-	map(0x400000, 0x403fff).ram().w(FUNC(tetrisp2_state::tetrisp2_vram_fg_w)).share("vram_fg");   // Foreground
-	map(0x404000, 0x407fff).ram().w(FUNC(tetrisp2_state::tetrisp2_vram_bg_w)).share("vram_bg");   // Background
+	map(0x200000, 0x23ffff).rw(FUNC(rockn_state::priority_r), FUNC(rockn_state::priority_w));
+	map(0x300000, 0x31ffff).ram().w(FUNC(rockn_state::palette_w)).share(m_paletteram);        // Palette
+	map(0x400000, 0x403fff).ram().w(FUNC(rockn_state::vram_fg_w)).share(m_vram_fg);   // Foreground
+	map(0x404000, 0x407fff).ram().w(FUNC(rockn_state::vram_bg_w)).share(m_vram_bg);   // Background
 	map(0x408000, 0x409fff).ram();                                                         // ???
 	map(0x500000, 0x50ffff).ram();                                                         // Line
-	map(0x600000, 0x60ffff).ram().w(FUNC(tetrisp2_state::tetrisp2_vram_rot_w)).share("vram_rot"); // Rotation
-	map(0x900000, 0x903fff).r(FUNC(tetrisp2_state::rockn_nvram_r)).w(FUNC(tetrisp2_state::tetrisp2_nvram_w)).share("nvram");    // NVRAM
-	map(0xa30000, 0xa30001).rw(FUNC(tetrisp2_state::rockn_soundvolume_r), FUNC(tetrisp2_state::rockn_soundvolume_w));         // Sound Volume
+	map(0x600000, 0x60ffff).ram().w(FUNC(rockn_state::vram_rot_w)).share(m_vram_rot); // Rotation
+	map(0x900000, 0x903fff).r(FUNC(rockn_state::rockn_nvram_r)).w(FUNC(rockn_state::nvram_w)).share("nvram");    // NVRAM
+	map(0xa30000, 0xa30001).rw(FUNC(rockn_state::rockn_soundvolume_r), FUNC(rockn_state::rockn_soundvolume_w));         // Sound Volume
 	map(0xa40000, 0xa40003).rw("ymz", FUNC(ymz280b_device::read), FUNC(ymz280b_device::write)).umask16(0x00ff);   // Sound
-	map(0xa44000, 0xa44001).rw(FUNC(tetrisp2_state::rockn_adpcmbank_r), FUNC(tetrisp2_state::rockn_adpcmbank_w));             // Sound Bank
+	map(0xa44000, 0xa44001).rw(FUNC(rockn_state::rockn_adpcmbank_r), FUNC(rockn_state::rockn_adpcmbank_w));             // Sound Bank
 	map(0xa48000, 0xa48001).noprw();                                                         // YMZ280 Reset
-	map(0xb00000, 0xb00001).w(FUNC(tetrisp2_state::tetrisp2_coincounter_w));                               // Coin Counter
+	map(0xb00000, 0xb00001).w(FUNC(rockn_state::tetrisp2_coincounter_w));                               // Coin Counter
 	map(0xb20000, 0xb20001).noprw();                                                         // ???
-	map(0xb40000, 0xb4000b).writeonly().share("scroll_fg");                     // Foreground Scrolling
-	map(0xb40010, 0xb4001b).writeonly().share("scroll_bg");                     // Background Scrolling
+	map(0xb40000, 0xb4000b).writeonly().share(m_scroll_fg);                     // Foreground Scrolling
+	map(0xb40010, 0xb4001b).writeonly().share(m_scroll_bg);                     // Background Scrolling
 	map(0xb4003e, 0xb4003f).nopw();                                                    // scr_size
-	map(0xb60000, 0xb6002f).writeonly().share("rotregs");                       // Rotation Registers
+	map(0xb60000, 0xb6002f).writeonly().share(m_rotregs);                       // Rotation Registers
 	map(0xba0000, 0xba001f).m(m_sysctrl, FUNC(jaleco_ms32_sysctrl_device::amap));
 	map(0xbe0000, 0xbe0001).nopr();                                                     // INT-level1 dummy read
 	map(0xbe0002, 0xbe0003).portr("PLAYERS");                                        // Inputs
@@ -389,65 +383,79 @@ void tetrisp2_state::rockn1_map(address_map &map)
 	map(0xbe000a, 0xbe000b).r("watchdog", FUNC(watchdog_timer_device::reset16_r));       // Watchdog
 }
 
+void rockn_state::rockn1_ymz_map(address_map &map)
+{
+	map(0x000000, 0x3fffff).rom().region("ymz", 0);
+	map(0x400000, 0xffffff).bankr(m_ymzbank[0]);
+}
 
-void tetrisp2_state::rockn2_map(address_map &map)
+
+void rockn_state::rockn2_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();                                                         // ROM
-	map(0x100000, 0x103fff).ram().share("spriteram");           // Object RAM
+	map(0x100000, 0x103fff).ram().share(m_spriteram);           // Object RAM
 	map(0x104000, 0x107fff).ram();                                                         // Spare Object RAM
 	map(0x108000, 0x10ffff).ram();                                                         // Work RAM
-	map(0x200000, 0x23ffff).rw(FUNC(tetrisp2_state::tetrisp2_priority_r), FUNC(tetrisp2_state::tetrisp2_priority_w));
-	map(0x300000, 0x31ffff).ram().w(FUNC(tetrisp2_state::tetrisp2_palette_w)).share("paletteram");        // Palette
+	map(0x200000, 0x23ffff).rw(FUNC(rockn_state::priority_r), FUNC(rockn_state::priority_w));
+	map(0x300000, 0x31ffff).ram().w(FUNC(rockn_state::palette_w)).share(m_paletteram);        // Palette
 	map(0x500000, 0x50ffff).ram();                                                         // Line
-	map(0x600000, 0x60ffff).ram().w(FUNC(tetrisp2_state::tetrisp2_vram_rot_w)).share("vram_rot"); // Rotation
-	map(0x800000, 0x803fff).ram().w(FUNC(tetrisp2_state::tetrisp2_vram_fg_w)).share("vram_fg");   // Foreground
-	map(0x804000, 0x807fff).ram().w(FUNC(tetrisp2_state::tetrisp2_vram_bg_w)).share("vram_bg");   // Background
+	map(0x600000, 0x60ffff).ram().w(FUNC(rockn_state::vram_rot_w)).share(m_vram_rot); // Rotation
+	map(0x800000, 0x803fff).ram().w(FUNC(rockn_state::vram_fg_w)).share(m_vram_fg);   // Foreground
+	map(0x804000, 0x807fff).ram().w(FUNC(rockn_state::vram_bg_w)).share(m_vram_bg);   // Background
 	map(0x808000, 0x809fff).ram();                                                         // ???
-	map(0x900000, 0x903fff).r(FUNC(tetrisp2_state::rockn_nvram_r)).w(FUNC(tetrisp2_state::tetrisp2_nvram_w)).share("nvram");    // NVRAM
-	map(0xa30000, 0xa30001).rw(FUNC(tetrisp2_state::rockn_soundvolume_r), FUNC(tetrisp2_state::rockn_soundvolume_w));         // Sound Volume
+	map(0x900000, 0x903fff).r(FUNC(rockn_state::rockn_nvram_r)).w(FUNC(rockn_state::nvram_w)).share("nvram");    // NVRAM
+	map(0xa30000, 0xa30001).rw(FUNC(rockn_state::rockn_soundvolume_r), FUNC(rockn_state::rockn_soundvolume_w));         // Sound Volume
 	map(0xa40000, 0xa40003).rw("ymz", FUNC(ymz280b_device::read), FUNC(ymz280b_device::write)).umask16(0x00ff);   // Sound
-	map(0xa44000, 0xa44001).rw(FUNC(tetrisp2_state::rockn_adpcmbank_r), FUNC(tetrisp2_state::rockn2_adpcmbank_w));            // Sound Bank
+	map(0xa44000, 0xa44001).rw(FUNC(rockn_state::rockn_adpcmbank_r), FUNC(rockn_state::rockn2_adpcmbank_w));            // Sound Bank
 	map(0xa48000, 0xa48001).nopw();                                                    // YMZ280 Reset
-	map(0xb00000, 0xb00001).w(FUNC(tetrisp2_state::tetrisp2_coincounter_w));                               // Coin Counter
+	map(0xb00000, 0xb00001).w(FUNC(rockn_state::tetrisp2_coincounter_w));                               // Coin Counter
 	map(0xb20000, 0xb20001).nopw();                                                    // ???
-	map(0xb40000, 0xb4000b).writeonly().share("scroll_fg");                 // Foreground Scrolling
-	map(0xb40010, 0xb4001b).writeonly().share("scroll_bg");                 // Background Scrolling
+	map(0xb40000, 0xb4000b).writeonly().share(m_scroll_fg);                 // Foreground Scrolling
+	map(0xb40010, 0xb4001b).writeonly().share(m_scroll_bg);                 // Background Scrolling
 	map(0xb4003e, 0xb4003f).nopw();                                                    // scr_size
-	map(0xb60000, 0xb6002f).writeonly().share("rotregs");                   // Rotation Registers
+	map(0xb60000, 0xb6002f).writeonly().share(m_rotregs);                   // Rotation Registers
 	map(0xba0000, 0xba001f).m(m_sysctrl, FUNC(jaleco_ms32_sysctrl_device::amap));
 	map(0xbe0000, 0xbe0001).nopr();                                                     // INT-level1 dummy read
 	map(0xbe0002, 0xbe0003).portr("PLAYERS");                                        // Inputs
 	map(0xbe0004, 0xbe0005).portr("SYSTEM");                                         // Inputs
 	map(0xbe0008, 0xbe0009).portr("DSW");                                            // Inputs
 	map(0xbe000a, 0xbe000b).r("watchdog", FUNC(watchdog_timer_device::reset16_r));       // Watchdog
+}
+
+void rockn_state::rockn2_ymz_map(address_map &map)
+{
+	map(0x000000, 0x3fffff).rom().region("ymz", 0);
+	map(0x400000, 0x7fffff).bankr(m_ymzbank[0]);
+	map(0x800000, 0xbfffff).bankr(m_ymzbank[1]);
+	map(0xc00000, 0xffffff).bankr(m_ymzbank[2]);
 }
 
 
 void rocknms_state::rocknms_main_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();                                                         // ROM
-	map(0x100000, 0x103fff).ram().share("spriteram");           // Object RAM
+	map(0x100000, 0x103fff).ram().share(m_spriteram);           // Object RAM
 	map(0x104000, 0x107fff).ram();                                                         // Spare Object RAM
 	map(0x108000, 0x10ffff).ram();                                                         // Work RAM
-	map(0x200000, 0x23ffff).rw(FUNC(rocknms_state::tetrisp2_priority_r), FUNC(rocknms_state::tetrisp2_priority_w));
-	map(0x300000, 0x31ffff).ram().w(FUNC(rocknms_state::tetrisp2_palette_w)).share("paletteram");        // Palette
+	map(0x200000, 0x23ffff).rw(FUNC(rocknms_state::priority_r), FUNC(rocknms_state::priority_w));
+	map(0x300000, 0x31ffff).ram().w(FUNC(rocknms_state::palette_w)).share(m_paletteram);        // Palette
 //  map(0x500000, 0x50ffff).ram();                                                         // Line
-	map(0x600000, 0x60ffff).ram().w(FUNC(rocknms_state::tetrisp2_vram_rot_w)).share("vram_rot"); // Rotation
-	map(0x800000, 0x803fff).ram().w(FUNC(rocknms_state::tetrisp2_vram_fg_w)).share("vram_fg");   // Foreground
-	map(0x804000, 0x807fff).ram().w(FUNC(rocknms_state::tetrisp2_vram_bg_w)).share("vram_bg");   // Background
+	map(0x600000, 0x60ffff).ram().w(FUNC(rocknms_state::vram_rot_w)).share(m_vram_rot); // Rotation
+	map(0x800000, 0x803fff).ram().w(FUNC(rocknms_state::vram_fg_w)).share(m_vram_fg);   // Foreground
+	map(0x804000, 0x807fff).ram().w(FUNC(rocknms_state::vram_bg_w)).share(m_vram_bg);   // Background
 //  map(0x808000, 0x809fff).ram();                                                         // ???
-	map(0x900000, 0x903fff).r(FUNC(rocknms_state::rockn_nvram_r)).w(FUNC(rocknms_state::tetrisp2_nvram_w)).share("nvram");    // NVRAM
+	map(0x900000, 0x903fff).r(FUNC(rocknms_state::rockn_nvram_r)).w(FUNC(rocknms_state::nvram_w)).share("nvram");    // NVRAM
 	map(0xa30000, 0xa30001).rw(FUNC(rocknms_state::rockn_soundvolume_r), FUNC(rocknms_state::rockn_soundvolume_w));         // Sound Volume
 	map(0xa40000, 0xa40003).rw("ymz", FUNC(ymz280b_device::read), FUNC(ymz280b_device::write)).umask16(0x00ff);   // Sound
 	map(0xa44000, 0xa44001).rw(FUNC(rocknms_state::rockn_adpcmbank_r), FUNC(rocknms_state::rockn_adpcmbank_w));             // Sound Bank
 	map(0xa48000, 0xa48001).nopw();                                                    // YMZ280 Reset
-	map(0xa00000, 0xa00001).w(FUNC(rocknms_state::rocknms_main2sub_w));                                   // MAIN -> SUB Communication
+	map(0xa00000, 0xa00001).w(FUNC(rocknms_state::main2sub_w));                                   // MAIN -> SUB Communication
 	map(0xb00000, 0xb00001).w(FUNC(rocknms_state::tetrisp2_coincounter_w));                               // Coin Counter
 	map(0xb20000, 0xb20001).nopw();                                                    // ???
-	map(0xb40000, 0xb4000b).writeonly().share("scroll_fg");                     // Foreground Scrolling
-	map(0xb40010, 0xb4001b).writeonly().share("scroll_bg");                     // Background Scrolling
+	map(0xb40000, 0xb4000b).writeonly().share(m_scroll_fg);                     // Foreground Scrolling
+	map(0xb40010, 0xb4001b).writeonly().share(m_scroll_bg);                     // Background Scrolling
 	map(0xb4003e, 0xb4003f).nopw();                                                    // scr_size
-	map(0xb60000, 0xb6002f).writeonly().share("rotregs");                       // Rotation Registers
+	map(0xb60000, 0xb6002f).writeonly().share(m_rotregs);                       // Rotation Registers
 	map(0xba0000, 0xba001f).m(m_sysctrl, FUNC(jaleco_ms32_sysctrl_device::amap));
 	map(0xbe0000, 0xbe0001).nopr();                                                     // INT-level1 dummy read
 	map(0xbe0002, 0xbe0003).portr("PLAYERS");
@@ -460,30 +468,30 @@ void rocknms_state::rocknms_main_map(address_map &map)
 void rocknms_state::rocknms_sub_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();                                                         // ROM
-	map(0x100000, 0x103fff).ram().share("spriteram2");      // Object RAM
+	map(0x100000, 0x103fff).ram().share(m_spriteram2);      // Object RAM
 	map(0x104000, 0x107fff).ram();                                                         // Spare Object RAM
 	map(0x108000, 0x10ffff).ram();                                                         // Work RAM
-	map(0x200000, 0x23ffff).ram().w(FUNC(rocknms_state::rocknms_sub_priority_w)).share("sub_priority"); // Priority
-	map(0x300000, 0x31ffff).ram().w(FUNC(rocknms_state::rocknms_sub_palette_w)).share("sub_paletteram");    // Palette
+	map(0x200000, 0x23ffff).ram().w(FUNC(rocknms_state::sub_priority_w)).share(m_sub_priority); // Priority
+	map(0x300000, 0x31ffff).ram().w(FUNC(rocknms_state::sub_palette_w)).share(m_sub_paletteram);    // Palette
 //  map(0x500000, 0x50ffff).ram();                                                         // Line
-	map(0x600000, 0x60ffff).ram().w(FUNC(rocknms_state::rocknms_sub_vram_rot_w)).share("sub_vram_rot"); // Rotation
-	map(0x800000, 0x803fff).ram().w(FUNC(rocknms_state::rocknms_sub_vram_fg_w)).share("sub_vram_fg"); // Foreground
-	map(0x804000, 0x807fff).ram().w(FUNC(rocknms_state::rocknms_sub_vram_bg_w)).share("sub_vram_bg"); // Background
+	map(0x600000, 0x60ffff).ram().w(FUNC(rocknms_state::sub_vram_rot_w)).share(m_sub_vram_rot); // Rotation
+	map(0x800000, 0x803fff).ram().w(FUNC(rocknms_state::sub_vram_fg_w)).share(m_sub_vram_fg); // Foreground
+	map(0x804000, 0x807fff).ram().w(FUNC(rocknms_state::sub_vram_bg_w)).share(m_sub_vram_bg); // Background
 //  map(0x808000, 0x809fff).ram();                                                         // ???
 	map(0x900000, 0x907fff).ram();                                                         // NVRAM
 	map(0xa30000, 0xa30001).w(FUNC(rocknms_state::rockn_soundvolume_w));                                  // Sound Volume
 	map(0xa40000, 0xa40003).w("ymz", FUNC(ymz280b_device::write)).umask16(0x00ff);             // Sound
 	map(0xa44000, 0xa44001).w(FUNC(rocknms_state::rockn_adpcmbank_w));                                    // Sound Bank
 	map(0xa48000, 0xa48001).nopw();                                                    // YMZ280 Reset
-	map(0xb00000, 0xb00001).w(FUNC(rocknms_state::rocknms_sub2main_w));                                   // MAIN <- SUB Communication
+	map(0xb00000, 0xb00001).w(FUNC(rocknms_state::sub2main_w));                                   // MAIN <- SUB Communication
 	map(0xb20000, 0xb20001).nopw();                                                    // ???
-	map(0xb40000, 0xb4000b).writeonly().share("sub_scroll_fg");                 // Foreground Scrolling
-	map(0xb40010, 0xb4001b).writeonly().share("sub_scroll_bg");                 // Background Scrolling
+	map(0xb40000, 0xb4000b).writeonly().share(m_sub_scroll_fg);                 // Foreground Scrolling
+	map(0xb40010, 0xb4001b).writeonly().share(m_sub_scroll_bg);                 // Background Scrolling
 	map(0xb4003e, 0xb4003f).nopw();                                                    // scr_size
-	map(0xb60000, 0xb6002f).writeonly().share("sub_rotregs");                       // Rotation Registers
+	map(0xb60000, 0xb6002f).writeonly().share(m_sub_rotregs);                       // Rotation Registers
 	map(0xba0000, 0xba001f).m(m_sub_sysctrl, FUNC(jaleco_ms32_sysctrl_device::amap));
 //  map(0xbe0000, 0xbe0001).nopr();                                                     // INT-level1 dummy read
-	map(0xbe0002, 0xbe0003).rw(FUNC(rocknms_state::rocknms_main2sub_r), FUNC(rocknms_state::rocknms_sub2main_w));           // MAIN <-> SUB Communication
+	map(0xbe0002, 0xbe0003).rw(FUNC(rocknms_state::main2sub_r), FUNC(rocknms_state::sub2main_w));           // MAIN <-> SUB Communication
 	map(0xbe000a, 0xbe000b).r("watchdog", FUNC(watchdog_timer_device::reset16_r));       // Watchdog
 }
 
@@ -496,31 +504,31 @@ void rocknms_state::rocknms_sub_map(address_map &map)
 
 u16 stepstag_state::stepstag_soundvolume_r()
 {
-	uint8_t vr1 = (64 - m_soundvr[0]->read()) << 2;
-	uint8_t vr2 = m_soundvr[1] ? (64 - m_soundvr[1]->read()) << 2 : 0; // Doesn't exist in Stepping Stage
+	const u8 vr1 = (64 - m_soundvr[0]->read()) << 2;
+	const u8 vr2 = m_soundvr[1] ? (64 - m_soundvr[1]->read()) << 2 : 0; // Doesn't exist in Stepping Stage
 	return (vr2 << 8) | vr1;
 }
 
 u16 stepstag_state::stepstag_coins_r()
 {
 	// bits 8 & 9?
-	return  ( ioport("COINS")->read() &  0xfcff ) |
-			( vj_upload_fini ? 0x300 : 0x100  );
+	return  (m_io_coins->read() &  0xfcff) |
+			(m_vj_upload_fini ? 0x300 : 0x100);
 }
 
 void stepstag_state::stepstag_b20000_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (ACCESSING_BITS_0_7)
-		vj_upload_idx++;
+		m_vj_upload_idx++;
 
-	if (vj_upload_idx >= 0xa1a8)  // 0x14350/2
-		vj_upload_fini = true;
+	if (m_vj_upload_idx >= 0xa1a8)  // 0x14350/2
+		m_vj_upload_fini = true;
 }
 
 void stepstag_state::stepstag_b00000_w(u16 data)
 {
-	vj_upload_idx = 0;
-	vj_upload_fini = false;
+	m_vj_upload_idx = 0;
+	m_vj_upload_fini = false;
 }
 
 u16 stepstag_state::stepstag_sprite_status_status_r()
@@ -893,17 +901,17 @@ void stepstag_state::adv7176a_w(u16 data)
 void stepstag_state::stepstag_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();
-	map(0x100000, 0x103fff).ram().share("spriteram");                                   // Object RAM
+	map(0x100000, 0x103fff).ram().share(m_spriteram);                                   // Object RAM
 	map(0x108000, 0x10ffff).ram();                                                         // Work RAM
-	map(0x200000, 0x23ffff).rw(FUNC(stepstag_state::tetrisp2_priority_r), FUNC(stepstag_state::tetrisp2_priority_w));
-	map(0x300000, 0x31ffff).ram().w(FUNC(stepstag_state::tetrisp2_palette_w)).share("paletteram");        // Palette
-	map(0x400000, 0x403fff).ram().w(FUNC(stepstag_state::tetrisp2_vram_fg_w)).share("vram_fg");           // Foreground
-	map(0x404000, 0x407fff).ram().w(FUNC(stepstag_state::tetrisp2_vram_bg_w)).share("vram_bg");           // Background
+	map(0x200000, 0x23ffff).rw(FUNC(stepstag_state::priority_r), FUNC(stepstag_state::priority_w));
+	map(0x300000, 0x31ffff).ram().w(FUNC(stepstag_state::palette_w)).share(m_paletteram);        // Palette
+	map(0x400000, 0x403fff).ram().w(FUNC(stepstag_state::vram_fg_w)).share(m_vram_fg);           // Foreground
+	map(0x404000, 0x407fff).ram().w(FUNC(stepstag_state::vram_bg_w)).share(m_vram_bg);           // Background
 //  map(0x408000, 0x409fff).ram();                                                         // ???
 	map(0x500000, 0x50ffff).ram();                                                         // Line
-	map(0x600000, 0x60ffff).ram().w(FUNC(stepstag_state::tetrisp2_vram_rot_w)).share("vram_rot");         // Rotation
-	map(0x900000, 0x903fff).rw(FUNC(stepstag_state::rockn_nvram_r), FUNC(stepstag_state::tetrisp2_nvram_w)).share("nvram"); // NVRAM
-//  map(0x904000, 0x907fff).rw(FUNC(stepstag_state::rockn_nvram_r), FUNC(stepstag_state::tetrisp2_nvram_w);                 // NVRAM (mirror)
+	map(0x600000, 0x60ffff).ram().w(FUNC(stepstag_state::vram_rot_w)).share(m_vram_rot);         // Rotation
+	map(0x900000, 0x903fff).rw(FUNC(stepstag_state::rockn_nvram_r), FUNC(stepstag_state::nvram_w)).share("nvram"); // NVRAM
+//  map(0x904000, 0x907fff).rw(FUNC(stepstag_state::rockn_nvram_r), FUNC(stepstag_state::nvram_w);                 // NVRAM (mirror)
 	map(0xa00000, 0xa00001).nopr().w(FUNC(stepstag_state::stepstag_neon_w));  // Neon??
 	map(0xa10000, 0xa10001).portr("RHYTHM").w(FUNC(stepstag_state::stepstag_step_leds_w));          // I/O
 	map(0xa20000, 0xa20001).nopr().w(FUNC(stepstag_state::stepstag_button_leds_w));                    // I/O
@@ -917,10 +925,10 @@ void stepstag_state::stepstag_map(address_map &map)
 
 	map(0xb00000, 0xb00001).w(FUNC(stepstag_state::stepstag_b00000_w));                                    // init xilinx uploading??
 	map(0xb20000, 0xb20001).w(FUNC(stepstag_state::stepstag_b20000_w));                                    // 98343 interface board xilinx uploading?
-	map(0xb40000, 0xb4000b).writeonly().share("scroll_fg");                             // Foreground Scrolling
-	map(0xb40010, 0xb4001b).writeonly().share("scroll_bg");                             // Background Scrolling
+	map(0xb40000, 0xb4000b).writeonly().share(m_scroll_fg);                             // Foreground Scrolling
+	map(0xb40010, 0xb4001b).writeonly().share(m_scroll_bg);                             // Background Scrolling
 	map(0xb4003e, 0xb4003f).ram();                                                         // scr_size
-	map(0xb60000, 0xb6002f).writeonly().share("rotregs");                               // Rotation Registers
+	map(0xb60000, 0xb6002f).writeonly().share(m_rotregs);                               // Rotation Registers
 	map(0xba0000, 0xba001f).m(m_sysctrl, FUNC(jaleco_ms32_sysctrl_device::amap));
 	map(0xbe0000, 0xbe0001).nopr();                                                     // INT-level1 dummy read
 	map(0xbe0002, 0xbe0003).portr("BUTTONS");                                        // Inputs
@@ -935,9 +943,9 @@ void stepstag_state::stepstag_sub_map(address_map &map)
 	map(0x000000, 0x0fffff).rom();
 	map(0x200000, 0x20ffff).ram();
 
-	map(0x300000, 0x33ffff).ram().w(FUNC(stepstag_state::stepstag_palette_left_w)).share("paletteram1");
-	map(0x400000, 0x43ffff).ram().w(FUNC(stepstag_state::stepstag_palette_mid_w)).share("paletteram2");
-	map(0x500000, 0x53ffff).ram().w(FUNC(stepstag_state::stepstag_palette_right_w)).share("paletteram3");
+	map(0x300000, 0x33ffff).ram().w(FUNC(stepstag_state::palette_left_w)).share(m_vj_paletteram_l);
+	map(0x400000, 0x43ffff).ram().w(FUNC(stepstag_state::palette_mid_w)).share(m_vj_paletteram_m);
+	map(0x500000, 0x53ffff).ram().w(FUNC(stepstag_state::palette_right_w)).share(m_vj_paletteram_r);
 
 	map(0x700000, 0x700001).w(m_jaleco_vj_pc, FUNC(jaleco_vj_pc_device::video_mix_w<0>));
 	map(0x700002, 0x700003).w(m_jaleco_vj_pc, FUNC(jaleco_vj_pc_device::video_mix_w<1>));
@@ -945,19 +953,19 @@ void stepstag_state::stepstag_sub_map(address_map &map)
 	map(0x700006, 0x700007).w(m_jaleco_vj_pc, FUNC(jaleco_vj_pc_device::video_control_w));
 
 	// left screen sprites
-	map(0x800000, 0x8007ff).ram().share("spriteram1");      // Object RAM
+	map(0x800000, 0x8007ff).ram().share(m_spriteram1);      // Object RAM
 	map(0x800800, 0x87ffff).ram();
 	map(0x880000, 0x880001).w(FUNC(stepstag_state::stepstag_spriteram1_updated_w));
 //  map(0x8c0000, 0x8c0001).nopw(); // cleared at boot
 
 	// middle screen sprites
-	map(0x900000, 0x9007ff).ram().share("spriteram2");      // Object RAM
+	map(0x900000, 0x9007ff).ram().share(m_spriteram2);      // Object RAM
 	map(0x900800, 0x97ffff).ram();
 	map(0x980000, 0x980001).w(FUNC(stepstag_state::stepstag_spriteram2_updated_w));
 //  map(0x9c0000, 0x9c0001).nopw(); // cleared at boot
 
 	// right screen sprites
-	map(0xa00000, 0xa007ff).ram().share("spriteram3");      // Object RAM
+	map(0xa00000, 0xa007ff).ram().share(m_spriteram3);      // Object RAM
 	map(0xa00800, 0xa7ffff).ram();
 	map(0xa80000, 0xa80001).w(FUNC(stepstag_state::stepstag_spriteram3_updated_w));
 //  map(0xac0000, 0xac0001).nopw(); // cleared at boot
@@ -1326,7 +1334,7 @@ INPUT_PORTS_END
 
 static INPUT_PORTS_START( rocknms )
 	PORT_START("PLAYERS")   // IN0 - $be0002.w
-	PORT_BIT( 0x0003, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_CUSTOM_MEMBER(FUNC(rocknms_state::rocknms_main2sub_status_r)) // MAIN -> SUB Communication
+	PORT_BIT( 0x0003, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_CUSTOM_MEMBER(FUNC(rocknms_state::main2sub_status_r)) // MAIN -> SUB Communication
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT ) PORT_PLAYER(1)
 	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_PLAYER(1)
 	PORT_BIT( 0x0010, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER(1)
@@ -1666,42 +1674,16 @@ INPUT_PORTS_END
 
 ***************************************************************************/
 
-
-/* 8x8x8 tiles */
-static const gfx_layout layout_8x8x8 =
-{
-	8,8,
-	RGN_FRAC(1,1),
-	8,
-	{ STEP8(0,1) },
-	{ STEP8(0,8) },
-	{ STEP8(0,8*8) },
-	8*8*8
-};
-
-/* 16x16x8 tiles */
-static const gfx_layout layout_16x16x8 =
-{
-	16,16,
-	RGN_FRAC(1,1),
-	8,
-	{ STEP8(0,1) },
-	{ STEP16(0,8) },
-	{ STEP16(0,16*8) },
-	16*16*8
-};
-
-
 static GFXDECODE_START( gfx_tetrisp2 )
-	GFXDECODE_ENTRY( "gfx2", 0, layout_16x16x8, 0x1000, 0x10 ) // [1] Background
-	GFXDECODE_ENTRY( "gfx3", 0, layout_16x16x8, 0x2000, 0x10 ) // [2] Rotation
-	GFXDECODE_ENTRY( "gfx4", 0, layout_8x8x8,   0x6000, 0x10 ) // [3] Foreground
+	GFXDECODE_ENTRY( "tiles_bg", 0, gfx_16x16x8_raw, 0x1000, 0x10 ) // [1] Background
+	GFXDECODE_ENTRY( "tiles_rot", 0, gfx_16x16x8_raw, 0x2000, 0x10 ) // [2] Rotation
+	GFXDECODE_ENTRY( "tiles_fg", 0, gfx_8x8x8_raw,   0x6000, 0x10 ) // [3] Foreground
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_rocknms_sub )
-	GFXDECODE_ENTRY( "gfx6", 0, layout_16x16x8, 0x1000, 0x10 ) // [1] Background
-	GFXDECODE_ENTRY( "gfx7", 0, layout_16x16x8, 0x2000, 0x10 ) // [2] Rotation
-	GFXDECODE_ENTRY( "gfx8", 0, layout_8x8x8,   0x6000, 0x10 ) // [3] Foreground
+	GFXDECODE_ENTRY( "sub_tiles_bg", 0, gfx_16x16x8_raw, 0x1000, 0x10 ) // [1] Background
+	GFXDECODE_ENTRY( "sub_tiles_rot", 0, gfx_16x16x8_raw, 0x2000, 0x10 ) // [2] Rotation
+	GFXDECODE_ENTRY( "sub_tiles_fg", 0, gfx_8x8x8_raw,   0x6000, 0x10 ) // [3] Foreground
 GFXDECODE_END
 
 /***************************************************************************
@@ -1712,42 +1694,72 @@ GFXDECODE_END
 
 ***************************************************************************/
 
-void tetrisp2_state::init_rockn_timer()
+void nndmseal_state::machine_start()
 {
+	tetrisp2_state::machine_start();
+
+	m_okibank[0]->configure_entries(0, 4, memregion("oki")->base(), 0x80000);
+	m_okibank[1]->configure_entries(0, 16, memregion("oki")->base(), 0x20000);
+	m_okibank[0]->set_entry(0);
+	m_okibank[1]->set_entry(0);
+
+	m_bank_hi = 0;
+	m_bank_lo = 0;
+
+	save_item(NAME(m_bank_lo));
+	save_item(NAME(m_bank_hi));
+}
+
+void rockn_state::machine_start()
+{
+	tetrisp2_state::machine_start();
+
 	save_item(NAME(m_rockn_protectdata));
 	save_item(NAME(m_rockn_adpcmbank));
 	save_item(NAME(m_rockn_soundvolume));
 }
 
-void tetrisp2_state::init_rockn()
+void rocknms_state::machine_start()
 {
-	init_rockn_timer();
+	rockn_state::machine_start();
+
+	save_item(NAME(m_main2sub));
+	save_item(NAME(m_sub2main));
+}
+
+void rockn_state::init_rockn()
+{
+	m_ymzbank[0]->configure_entries(0, 8, memregion("ymz")->base() + 0x400000, 0xc00000);
+	m_ymzbank[0]->set_entry(0);
 	m_rockn_protectdata = 1;
 }
 
-void tetrisp2_state::init_rockn1()
+void rockn_state::init_rockn2()
 {
-	init_rockn_timer();
-	m_rockn_protectdata = 1;
-}
-
-void tetrisp2_state::init_rockn2()
-{
-	init_rockn_timer();
+	m_ymzbank[0]->configure_entries(0, 21, memregion("ymz")->base() + 0x400000, 0x400000);
+	m_ymzbank[1]->configure_entries(0, 21, memregion("ymz")->base() + 0x400000, 0x400000);
+	m_ymzbank[2]->configure_entries(0, 21, memregion("ymz")->base() + 0x400000, 0x400000);
+	m_ymzbank[0]->set_entry(0);
+	m_ymzbank[1]->set_entry(1);
+	m_ymzbank[2]->set_entry(2);
 	m_rockn_protectdata = 2;
 }
 
 void rocknms_state::init_rocknms()
 {
-	init_rockn_timer();
+	m_ymzbank[0]->configure_entries(0, 8, memregion("ymz")->base() + 0x400000, 0xc00000);
+	m_ymzbank[0]->set_entry(0);
 	m_rockn_protectdata = 3;
-	save_item(NAME(m_rocknms_main2sub));
-	save_item(NAME(m_rocknms_sub2main));
 }
 
-void tetrisp2_state::init_rockn3()
+void rockn_state::init_rockn3()
 {
-	init_rockn_timer();
+	m_ymzbank[0]->configure_entries(0, 21, memregion("ymz")->base() + 0x400000, 0x400000);
+	m_ymzbank[1]->configure_entries(0, 21, memregion("ymz")->base() + 0x400000, 0x400000);
+	m_ymzbank[2]->configure_entries(0, 21, memregion("ymz")->base() + 0x400000, 0x400000);
+	m_ymzbank[0]->set_entry(0);
+	m_ymzbank[1]->set_entry(1);
+	m_ymzbank[2]->set_entry(2);
 	m_rockn_protectdata = 4;
 }
 
@@ -1814,8 +1826,6 @@ void tetrisp2_state::tetrisp2(machine_config &config)
 	setup_main_sprite(config, pixel_clock);
 	setup_main_sysctrl(config, XTAL(48'000'000));
 
-	MCFG_VIDEO_START_OVERRIDE(tetrisp2_state,tetrisp2)
-
 	/* sound hardware */
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
@@ -1826,11 +1836,11 @@ void tetrisp2_state::tetrisp2(machine_config &config)
 }
 
 
-void tetrisp2_state::nndmseal(machine_config &config)
+void nndmseal_state::nndmseal(machine_config &config)
 {
 	/* basic machine hardware */
 	M68000(config, m_maincpu, XTAL(12'000'000)); // 12MHz
-	m_maincpu->set_addrmap(AS_PROGRAM, &tetrisp2_state::nndmseal_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &nndmseal_state::nndmseal_map);
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
@@ -1842,7 +1852,7 @@ void tetrisp2_state::nndmseal(machine_config &config)
 	constexpr XTAL pixel_clock = XTAL(42'954'545)/6;
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_raw(pixel_clock, 455, 0, 384, 262, 0, 240);
-	m_screen->set_screen_update(FUNC(tetrisp2_state::screen_update_tetrisp2));
+	m_screen->set_screen_update(FUNC(nndmseal_state::screen_update_tetrisp2));
 	m_screen->set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_tetrisp2);
@@ -1851,20 +1861,20 @@ void tetrisp2_state::nndmseal(machine_config &config)
 	setup_main_sprite(config, pixel_clock);
 	setup_main_sysctrl(config, XTAL(42'954'545));
 
-	MCFG_VIDEO_START_OVERRIDE(tetrisp2_state,nndmseal)  // bg layer offset
-
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
 
-	OKIM6295(config, "oki", XTAL(2'000'000), okim6295_device::PIN7_HIGH).add_route(ALL_OUTPUTS, "mono", 1.0); // 2MHz
+	okim6295_device &oki(OKIM6295(config, "oki", XTAL(2'000'000), okim6295_device::PIN7_HIGH));
+	oki.set_addrmap(0, &nndmseal_state::nndmseal_oki_map);
+	oki.add_route(ALL_OUTPUTS, "mono", 1.0); // 2MHz
 }
 
 
-void tetrisp2_state::rockn(machine_config &config)
+void rockn_state::rockn(machine_config &config)
 {
 	/* basic machine hardware */
 	M68000(config, m_maincpu, XTAL(12'000'000)); // 12MHz
-	m_maincpu->set_addrmap(AS_PROGRAM, &tetrisp2_state::rockn1_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &rockn_state::rockn1_map);
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
@@ -1874,7 +1884,7 @@ void tetrisp2_state::rockn(machine_config &config)
 	constexpr XTAL pixel_clock = XTAL(48'000'000)/8;
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_raw(pixel_clock, 384, 0, 320, 263, 0, 224);
-	m_screen->set_screen_update(FUNC(tetrisp2_state::screen_update_rockntread));
+	m_screen->set_screen_update(FUNC(rockn_state::screen_update_rockntread));
 	m_screen->set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_tetrisp2);
@@ -1883,23 +1893,22 @@ void tetrisp2_state::rockn(machine_config &config)
 	setup_main_sprite(config, pixel_clock);
 	setup_main_sysctrl(config, XTAL(48'000'000));
 
-	MCFG_VIDEO_START_OVERRIDE(tetrisp2_state,rockntread)
-
 	/* sound hardware */
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
 	ymz280b_device &ymz(YMZ280B(config, "ymz", XTAL(16'934'400))); // 16.9344MHz
+	ymz.set_addrmap(0, &rockn_state::rockn1_ymz_map);
 	ymz.add_route(0, "lspeaker", 1.0);
 	ymz.add_route(1, "rspeaker", 1.0);
 }
 
 
-void tetrisp2_state::rockn2(machine_config &config)
+void rockn_state::rockn2(machine_config &config)
 {
 	/* basic machine hardware */
 	M68000(config, m_maincpu, XTAL(12'000'000)); // 12MHz
-	m_maincpu->set_addrmap(AS_PROGRAM, &tetrisp2_state::rockn2_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &rockn_state::rockn2_map);
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
@@ -1909,7 +1918,7 @@ void tetrisp2_state::rockn2(machine_config &config)
 	constexpr XTAL pixel_clock = XTAL(48'000'000)/8;
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_raw(pixel_clock, 384, 0, 320, 263, 0, 224);
-	m_screen->set_screen_update(FUNC(tetrisp2_state::screen_update_rockntread));
+	m_screen->set_screen_update(FUNC(rockn_state::screen_update_rockntread));
 	m_screen->set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_tetrisp2);
@@ -1918,13 +1927,12 @@ void tetrisp2_state::rockn2(machine_config &config)
 	setup_main_sprite(config, pixel_clock);
 	setup_main_sysctrl(config, XTAL(48'000'000));
 
-	MCFG_VIDEO_START_OVERRIDE(tetrisp2_state,rockntread)
-
 	/* sound hardware */
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
 	ymz280b_device &ymz(YMZ280B(config, "ymz", XTAL(16'934'400))); // 16.9344MHz
+	ymz.set_addrmap(0, &rockn_state::rockn2_ymz_map);
 	ymz.add_route(0, "lspeaker", 1.0);
 	ymz.add_route(1, "rspeaker", 1.0);
 }
@@ -1970,12 +1978,12 @@ void rocknms_state::rocknms(machine_config &config)
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_orientation(ROT0);
 	m_screen->set_raw(pixel_clock, 384, 0, 320, 263, 0, 224);
-	m_screen->set_screen_update(FUNC(rocknms_state::screen_update_rocknms_left));
+	m_screen->set_screen_update(FUNC(rocknms_state::screen_update_top));
 
 	SCREEN(config, m_sub_screen, SCREEN_TYPE_RASTER);
 	m_sub_screen->set_orientation(ROT270);
 	m_sub_screen->set_raw(pixel_clock, 384, 0, 320, 263, 0, 224);
-	m_sub_screen->set_screen_update(FUNC(rocknms_state::screen_update_rocknms_right));
+	m_sub_screen->set_screen_update(FUNC(rocknms_state::screen_update_bottom));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_tetrisp2);
 	PALETTE(config, m_palette).set_entries(0x8000);
@@ -1985,11 +1993,11 @@ void rocknms_state::rocknms(machine_config &config)
 
 	setup_main_sprite(config, pixel_clock);
 
-	JALECO_MEGASYSTEM32_SPRITE(config, m_rocknms_sub_sprite, pixel_clock); // 48MHz for video?
-	m_rocknms_sub_sprite->set_palette(m_sub_palette);
-	m_rocknms_sub_sprite->set_color_base(0);
-	m_rocknms_sub_sprite->set_color_entries(16);
-	m_rocknms_sub_sprite->set_zoom(false);
+	JALECO_MEGASYSTEM32_SPRITE(config, m_sub_sprite, pixel_clock); // 48MHz for video?
+	m_sub_sprite->set_palette(m_sub_palette);
+	m_sub_sprite->set_color_base(0);
+	m_sub_sprite->set_color_entries(16);
+	m_sub_sprite->set_zoom(false);
 
 	setup_main_sysctrl(config, XTAL(48'000'000));
 
@@ -2000,13 +2008,12 @@ void rocknms_state::rocknms(machine_config &config)
 	m_sub_sysctrl->prg_timer_cb().set(FUNC(rocknms_state::sub_timer_irq_w));
 	m_sub_sysctrl->sound_reset_cb().set(FUNC(rocknms_state::sub_sound_reset_line_w));
 
-	MCFG_VIDEO_START_OVERRIDE(rocknms_state,rocknms)
-
 	/* sound hardware */
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
 	ymz280b_device &ymz(YMZ280B(config, "ymz", XTAL(16'934'400))); // 16.9344MHz
+	ymz.set_addrmap(0, &rocknms_state::rockn1_ymz_map);
 	ymz.add_route(0, "lspeaker", 1.0);
 	ymz.add_route(1, "rspeaker", 1.0);
 }
@@ -2216,7 +2223,7 @@ void stepstag_state::vjdash(machine_config &config)    // 4 Screens
 
 void stepstag_state::machine_start()
 {
-	tetrisp2_state::machine_start();
+	rockn_state::machine_start();
 
 	m_spriteram1_data = std::make_unique<uint16_t[]>(0x400);
 	m_spriteram2_data = std::make_unique<uint16_t[]>(0x400);
@@ -2319,15 +2326,15 @@ ROM_START( tetrisp2 ) /* Version 2.8 */
 	/* If t2p_m01&2 from this board were correctly read, since they hold the same data of the above but with swapped halves, it
 	       means they had to invert the top bit of the "page select" register in the sprite's hardware on this board! */
 
-	ROM_REGION( 0x800000, "gfx2", 0 )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x800000, "tiles_bg", 0 )   /* 16x16x8 (Background) */
 	ROM_LOAD( "96019-06.13", 0x000000, 0x400000, CRC(16f7093c) SHA1(2be77c6a692c5d762f5553ae24e8c415ab194cc6) )
 	//ROM_LOAD( "96019-04.6",  0x400000, 0x100000, CRC(b849dec9) SHA1(fa7ac00fbe587a74c3fb8c74a0f91f7afeb8682f) )
 
-	ROM_REGION( 0x100000, "gfx3", 0 )   /* 16x16x8 (Rotation) */
-	ROM_COPY( "gfx2",        0x400000, 0x000000, 0x100000 )
+	ROM_REGION( 0x100000, "tiles_rot", 0 )   /* 16x16x8 (Rotation) */
+	ROM_COPY( "tiles_bg",        0x400000, 0x000000, 0x100000 )
 	ROM_LOAD( "96019-04.6",  0x000000, 0x100000, CRC(b849dec9) SHA1(fa7ac00fbe587a74c3fb8c74a0f91f7afeb8682f) )
 
-	ROM_REGION( 0x080000, "gfx4", 0 )   /* 8x8x8 (Foreground) */
+	ROM_REGION( 0x080000, "tiles_fg", 0 )   /* 8x8x8 (Foreground) */
 	ROM_LOAD( "tetp2-10.ic27", 0x000000, 0x080000, CRC(34dd1bad) SHA1(9bdf1dde11f82839676400de5dd7acb06ea8cdb2) )   // 11111xxxxxxxxxxxxxx = 0xFF
 
 	ROM_REGION( 0x400000, "ymz", 0 )    /* Samples */
@@ -2346,15 +2353,15 @@ ROM_START( tetrisp2a ) /* Version 2.7 */
 	/* If t2p_m01&2 from this board were correctly read, since they hold the same data of the above but with swapped halves, it
 	       means they had to invert the top bit of the "page select" register in the sprite's hardware on this board! */
 
-	ROM_REGION( 0x800000, "gfx2", 0 )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x800000, "tiles_bg", 0 )   /* 16x16x8 (Background) */
 	ROM_LOAD( "96019-06.13", 0x000000, 0x400000, CRC(16f7093c) SHA1(2be77c6a692c5d762f5553ae24e8c415ab194cc6) )
 	//ROM_LOAD( "96019-04.6",  0x400000, 0x100000, CRC(b849dec9) SHA1(fa7ac00fbe587a74c3fb8c74a0f91f7afeb8682f) )
 
-	ROM_REGION( 0x100000, "gfx3", 0 )   /* 16x16x8 (Rotation) */
-	ROM_COPY( "gfx2",        0x400000, 0x000000, 0x100000 )
+	ROM_REGION( 0x100000, "tiles_rot", 0 )   /* 16x16x8 (Rotation) */
+	ROM_COPY( "tiles_bg",        0x400000, 0x000000, 0x100000 )
 	ROM_LOAD( "96019-04.6",  0x000000, 0x100000, CRC(b849dec9) SHA1(fa7ac00fbe587a74c3fb8c74a0f91f7afeb8682f) )
 
-	ROM_REGION( 0x080000, "gfx4", 0 )   /* 8x8x8 (Foreground) */
+	ROM_REGION( 0x080000, "tiles_fg", 0 )   /* 8x8x8 (Foreground) */
 	ROM_LOAD( "tetp2-10.ic27", 0x000000, 0x080000, CRC(34dd1bad) SHA1(9bdf1dde11f82839676400de5dd7acb06ea8cdb2) )   // 11111xxxxxxxxxxxxxx = 0xFF
 
 	ROM_REGION( 0x400000, "ymz", 0 )    /* Samples */
@@ -2370,13 +2377,13 @@ ROM_START( tetrisp2j ) /* Version 2.2 */
 	ROM_LOAD32_WORD( "96019-01.9", 0x000000, 0x400000, CRC(06f7dc64) SHA1(722c51b707b9854c0293afdff18b27ec7cae6719) )
 	ROM_LOAD32_WORD( "96019-02.8", 0x000002, 0x400000, CRC(3e613bed) SHA1(038b5e43fa3d69654107c8093126eeb2e8fa4ddc) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x400000, "tiles_bg", 0 )   /* 16x16x8 (Background) */
 	ROM_LOAD( "96019-06.13", 0x000000, 0x400000, CRC(16f7093c) SHA1(2be77c6a692c5d762f5553ae24e8c415ab194cc6) )
 
-	ROM_REGION( 0x100000, "gfx3", 0 )   /* 16x16x8 (Rotation) */
+	ROM_REGION( 0x100000, "tiles_rot", 0 )   /* 16x16x8 (Rotation) */
 	ROM_LOAD( "96019-04.6",  0x000000, 0x100000, CRC(b849dec9) SHA1(fa7ac00fbe587a74c3fb8c74a0f91f7afeb8682f) )
 
-	ROM_REGION( 0x080000, "gfx4", 0 )   /* 8x8x8 (Foreground) */
+	ROM_REGION( 0x080000, "tiles_fg", 0 )   /* 8x8x8 (Foreground) */
 	ROM_LOAD( "tetp2-10.ic27", 0x000000, 0x080000, CRC(34dd1bad) SHA1(9bdf1dde11f82839676400de5dd7acb06ea8cdb2) )   // 11111xxxxxxxxxxxxxx = 0xFF
 
 	ROM_REGION( 0x400000, "ymz", 0 )    /* Samples */
@@ -2393,13 +2400,13 @@ ROM_START( tetrisp2ja ) /* Version 2.1 */
 	ROM_LOAD32_WORD( "96019-01.9", 0x000000, 0x400000, CRC(06f7dc64) SHA1(722c51b707b9854c0293afdff18b27ec7cae6719) )
 	ROM_LOAD32_WORD( "96019-02.8", 0x000002, 0x400000, CRC(3e613bed) SHA1(038b5e43fa3d69654107c8093126eeb2e8fa4ddc) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x400000, "tiles_bg", 0 )   /* 16x16x8 (Background) */
 	ROM_LOAD( "96019-06.13", 0x000000, 0x400000, CRC(16f7093c) SHA1(2be77c6a692c5d762f5553ae24e8c415ab194cc6) )
 
-	ROM_REGION( 0x100000, "gfx3", 0 )   /* 16x16x8 (Rotation) */
+	ROM_REGION( 0x100000, "tiles_rot", 0 )   /* 16x16x8 (Rotation) */
 	ROM_LOAD( "96019-04.6",  0x000000, 0x100000, CRC(b849dec9) SHA1(fa7ac00fbe587a74c3fb8c74a0f91f7afeb8682f) )
 
-	ROM_REGION( 0x080000, "gfx4", 0 )   /* 8x8x8 (Foreground) */
+	ROM_REGION( 0x080000, "tiles_fg", 0 )   /* 8x8x8 (Foreground) */
 	ROM_LOAD( "tetp2-10.ic27", 0x000000, 0x080000, CRC(34dd1bad) SHA1(9bdf1dde11f82839676400de5dd7acb06ea8cdb2) )   // 11111xxxxxxxxxxxxxx = 0xFF
 
 	ROM_REGION( 0x400000, "ymz", 0 )    /* Samples */
@@ -2471,20 +2478,17 @@ ROM_START( nndmseal )
 	ROM_REGION( 0x100000, "sprite", ROMREGION_ERASE )    /* 8x8x8 (Sprites) */
 /* This game doesn't use sprites, but the region needs to be a valid size for at least one sprite 'page' for the init to work. */
 
-	ROM_REGION( 0x400000, "gfx2", 0 )   // 16x16x8 (Background)
+	ROM_REGION( 0x400000, "tiles_bg", 0 )   // 16x16x8 (Background)
 	ROM_LOAD( "mr97006-02.5", 0x000000, 0x200000, CRC(4793f84e) SHA1(05acba6cc8a527a6050af79a460b08c4676287aa) )
 	ROM_LOAD( "mr97001-01.6", 0x200000, 0x200000, CRC(dd648e8a) SHA1(7036ab30d0ea179c59d74c1fbe4372968722ec0f) )
 
-	ROM_REGION( 0x200000, "gfx3", 0 )   // 16x16x8 (Rotation)
+	ROM_REGION( 0x200000, "tiles_rot", 0 )   // 16x16x8 (Rotation)
 	ROM_LOAD( "mr97006-01.2", 0x000000, 0x200000, CRC(32283485) SHA1(14ccd25389b97825d9a727809c3a1de803687c16) )
 
-	ROM_REGION( 0x100000, "gfx4", 0 )   // 8x8x8 (Foreground)
+	ROM_REGION( 0x100000, "tiles_fg", 0 )   // 8x8x8 (Foreground)
 	ROM_LOAD( "mr97006-04.8", 0x000000, 0x100000, CRC(6726a25b) SHA1(4ea49c014477229eaf9de4a0b9bf83021b82c095) )
 
-	ROM_REGION( 0x40000, "oki", ROMREGION_ERASE )   // Samples
-	// filled in from "okisource"
-
-	ROM_REGION( 0x200000, "okisource", 0 )  // Samples
+	ROM_REGION( 0x200000, "oki", 0 )  // Samples
 	ROM_LOAD( "mr96017-04.9", 0x000000, 0x200000, CRC(c2e7b444) SHA1(e2b9d3d94720d01beff1108ef3dfbff805ddd1fd) )
 ROM_END
 
@@ -2496,20 +2500,17 @@ ROM_START( nndmseal11 )
 	ROM_REGION( 0x100000, "sprite", ROMREGION_ERASE )    /* 8x8x8 (Sprites) */
 /* This game doesn't use sprites, but the region needs to be a valid size for at least one sprite 'page' for the init to work. */
 
-	ROM_REGION( 0x400000, "gfx2", 0 )   // 16x16x8 (Background)
+	ROM_REGION( 0x400000, "tiles_bg", 0 )   // 16x16x8 (Background)
 	ROM_LOAD( "mr97006-02.5", 0x000000, 0x200000, CRC(4793f84e) SHA1(05acba6cc8a527a6050af79a460b08c4676287aa) )
 	ROM_LOAD( "mr97001-01.6", 0x200000, 0x200000, CRC(dd648e8a) SHA1(7036ab30d0ea179c59d74c1fbe4372968722ec0f) )
 
-	ROM_REGION( 0x200000, "gfx3", 0 )   // 16x16x8 (Rotation)
+	ROM_REGION( 0x200000, "tiles_rot", 0 )   // 16x16x8 (Rotation)
 	ROM_LOAD( "mr97006-01.2", 0x000000, 0x200000, CRC(32283485) SHA1(14ccd25389b97825d9a727809c3a1de803687c16) )
 
-	ROM_REGION( 0x100000, "gfx4", 0 )   // 8x8x8 (Foreground)
+	ROM_REGION( 0x100000, "tiles_fg", 0 )   // 8x8x8 (Foreground)
 	ROM_LOAD( "mr97006-04.8", 0x000000, 0x100000, CRC(6726a25b) SHA1(4ea49c014477229eaf9de4a0b9bf83021b82c095) )
 
-	ROM_REGION( 0x40000, "oki", ROMREGION_ERASE )   // Samples
-	// filled in from "okisource"
-
-	ROM_REGION( 0x200000, "okisource", 0 )  // Samples
+	ROM_REGION( 0x200000, "oki", 0 )  // Samples
 	ROM_LOAD( "mr96017-04.9", 0x000000, 0x200000, CRC(c2e7b444) SHA1(e2b9d3d94720d01beff1108ef3dfbff805ddd1fd) )
 ROM_END
 
@@ -2556,19 +2557,16 @@ ROM_START( nndmseala )
 	ROM_REGION( 0x100000, "sprite", ROMREGION_ERASE )    /* 8x8x8 (Sprites) */
 /* This game doesn't use sprites, but the region needs to be a valid size for at least one sprite 'page' for the init to work. */
 
-	ROM_REGION( 0x200000, "gfx2", 0 )   // 16x16x8 (Background)
+	ROM_REGION( 0x200000, "tiles_bg", 0 )   // 16x16x8 (Background)
 	ROM_LOAD( "mr97032-02.ic5", 0x000000, 0x200000, CRC(460f16bd) SHA1(cdc4efa9897060d2ae3b21915dba68661e76ec03) )
 
-	ROM_REGION( 0x400000, "gfx3", 0 )   // 16x16x8 (Rotation)
+	ROM_REGION( 0x400000, "tiles_rot", 0 )   // 16x16x8 (Rotation)
 	ROM_LOAD( "mr97032-01.ic2", 0x000000, 0x400000, CRC(18c1a394) SHA1(491a2eb190efb5684f5eddb317adacd55afa727c) )
 
-	ROM_REGION( 0x100000, "gfx4", 0 )   // 8x8x8 (Foreground)
+	ROM_REGION( 0x100000, "tiles_fg", 0 )   // 8x8x8 (Foreground)
 	ROM_LOAD( "mr97032-03.ic8", 0x000000, 0x100000, CRC(5678a378) SHA1(306a3238590fa6e274e3c2ad334f5f210738dd7d) )
 
-	ROM_REGION( 0x40000, "oki", ROMREGION_ERASE )   // Samples
-	// filled in from "okisource"
-
-	ROM_REGION( 0x200000, "okisource", 0 )  // Samples
+	ROM_REGION( 0x200000, "oki", 0 )  // Samples
 	ROM_LOAD( "mr97016-04.ic9", 0x000000, 0x200000, CRC(f421232b) SHA1(d9cdc911566e795e6968d4b349c008b47132bea3) )
 ROM_END
 
@@ -2580,19 +2578,16 @@ ROM_START( nndmsealb ) // NS-96205 96017 + NS-97211 97005
 	ROM_REGION( 0x100000, "sprite", ROMREGION_ERASE )    // 8x8x8 (Sprites)
 // This game doesn't use sprites, but the region needs to be a valid size for at least one sprite 'page' for the init to work.
 
-	ROM_REGION( 0x200000, "gfx2", 0 )   // 16x16x8 (Background)
+	ROM_REGION( 0x200000, "tiles_bg", 0 )   // 16x16x8 (Background)
 	ROM_LOAD( "mr98009-02.ic6", 0x000000, 0x200000, CRC(94f1a8ba) SHA1(a9b627d27aac7c548977d0f799b1d7389801c8d8) )
 
-	ROM_REGION( 0x400000, "gfx3", 0 )   // 16x16x8 (Rotation)
+	ROM_REGION( 0x400000, "tiles_rot", 0 )   // 16x16x8 (Rotation)
 	ROM_LOAD( "mr98009-01.ic2", 0x000000, 0x400000, CRC(b3451bd0) SHA1(84c879b417c2042810f310ff366da7790afd1f81) )
 
-	ROM_REGION( 0x100000, "gfx4", 0 )   // 8x8x8 (Foreground)
+	ROM_REGION( 0x100000, "tiles_fg", 0 )   // 8x8x8 (Foreground)
 	ROM_LOAD( "mr98009-03.ic10", 0x000000, 0x100000, CRC(f0574f06) SHA1(42ff312dde90406b0aa355ff455765b12bbd6e6c) )
 
-	ROM_REGION( 0x40000, "oki", ROMREGION_ERASE )   // Samples
-	// filled in from "okisource"
-
-	ROM_REGION( 0x200000, "okisource", 0 )  // Samples
+	ROM_REGION( 0x200000, "oki", 0 )  // Samples
 	ROM_LOAD( "mr97016-04.ic12", 0x000000, 0x200000, CRC(f421232b) SHA1(d9cdc911566e795e6968d4b349c008b47132bea3) )
 ROM_END
 
@@ -2604,19 +2599,16 @@ ROM_START( nndmsealc ) // NS-96205 96017 + NS-96206A 96017
 	ROM_REGION( 0x100000, "sprite", ROMREGION_ERASE )    // 8x8x8 (Sprites)
 // This game doesn't use sprites, but the region needs to be a valid size for at least one sprite 'page' for the init to work.
 
-	ROM_REGION( 0x400000, "gfx2", 0 )   // 16x16x8 (Background)
+	ROM_REGION( 0x400000, "tiles_bg", 0 )   // 16x16x8 (Background)
 	ROM_LOAD( "mr98058-02.ic7", 0x000000, 0x400000, CRC(9d8401e3) SHA1(4b113f47c94b113d680c5420cdd5709e5b93b069) )
 
-	ROM_REGION( 0x400000, "gfx3", 0 )   // 16x16x8 (Rotation)
+	ROM_REGION( 0x400000, "tiles_rot", 0 )   // 16x16x8 (Rotation)
 	ROM_LOAD( "mr98058-01.ic2", 0x000000, 0x400000, CRC(a10848f0) SHA1(e86ed4fe85658046572903c6903e6ac9d885b85c) )
 
-	ROM_REGION( 0x100000, "gfx4", 0 )   // 8x8x8 (Foreground)
+	ROM_REGION( 0x100000, "tiles_fg", 0 )   // 8x8x8 (Foreground)
 	ROM_LOAD( "mr98058-03.ic10", 0x000000, 0x100000, CRC(4696609b) SHA1(6810483426b4c94e5d8b6fff4cbbbf3d953e26a7) )
 
-	ROM_REGION( 0x40000, "oki", ROMREGION_ERASE )   // Samples
-	// filled in from "okisource"
-
-	ROM_REGION( 0x200000, "okisource", 0 )  // Samples
+	ROM_REGION( 0x200000, "oki", 0 )  // Samples
 	ROM_LOAD( "mr97016-04.ic16", 0x000000, 0x200000, CRC(f421232b) SHA1(d9cdc911566e795e6968d4b349c008b47132bea3) )
 ROM_END
 
@@ -2698,33 +2690,32 @@ ROM_START( rockn )
 	ROM_LOAD32_WORD( "rock_n_1_vj-98344_8.bin", 0x000002, 0x200000, CRC(fa3f6f9c) SHA1(586dcc690a1a4aa7c97932ad496382def6a074a4) )
 	ROM_LOAD32_WORD( "rock_n_1_vj-98344_9.bin", 0x000000, 0x200000, CRC(3d12a688) SHA1(356b2ea81d960838b604c5a17cc77e79fb0e40ce) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x200000, "tiles_bg", 0 )   /* 16x16x8 (Background) */
 	ROM_LOAD16_WORD( "rock_n_1_vj-98344_13.bin", 0x000000, 0x200000, CRC(261b99a0) SHA1(7b3c768ae9d7429e2559fe32c1a4ff220d727e7e) )
 
-	ROM_REGION( 0x100000, "gfx3", 0 )   /* 16x16x8 (Rotation) */
+	ROM_REGION( 0x100000, "tiles_rot", 0 )   /* 16x16x8 (Rotation) */
 	ROM_LOAD( "rock_n_1_vj-98344_6.bin", 0x000000, 0x100000, CRC(5551717f) SHA1(64943a9a68ad4074f3f5128d7796e4f03baa14d5) )
 
-	ROM_REGION( 0x080000, "gfx4", 0 )   /* 8x8x8 (Foreground) */
+	ROM_REGION( 0x080000, "tiles_fg", 0 )   /* 8x8x8 (Foreground) */
 	ROM_LOAD( "rock_n_1_vj-98344_10.bin", 0x000000, 0x080000, CRC(918663a8) SHA1(aedacb741c986ef8159385cfef866cb7e3ef6cb6) )
 
 	/* from the bootleg set, are they right for this? */
-	ROM_REGION( 0x7000000, "ymz", 0 )   /* Samples */
+	ROM_REGION( 0x6400000, "ymz", ROMREGION_ERASEFF )   /* Samples */
 	ROM_LOAD( "sound00", 0x0000000, 0x0400000, CRC(c354f753) SHA1(bf538c02e2162a93d8c6793a1211e21480156223)  ) // COMMON AREA
-	ROM_FILL(                 0x0400000, 0x0c00000, 0xff ) // BANK AREA
-	ROM_LOAD( "sound01", 0x1000000, 0x0400000, CRC(5b42999e) SHA1(376c773f292eae8b75db11bad3cb6ec5fe48392e)  ) // bank 0
-	ROM_LOAD( "sound02", 0x1400000, 0x0400000, CRC(8306f302) SHA1(8c0437d7ab8d74d4d15f4a641d30602e39cdd99d)  ) // bank 0
-	ROM_LOAD( "sound03", 0x1800000, 0x0400000, CRC(3fda842c) SHA1(2b9e7c548b689bab491237e36a2dcf4782a81d79)  ) // bank 0
-	ROM_LOAD( "sound04", 0x1c00000, 0x0400000, CRC(86d4f289) SHA1(908490ab0cf8d33cf3e127f71edee3bece70b86d)  ) // bank 1
-	ROM_LOAD( "sound05", 0x2000000, 0x0400000, CRC(f8dbf47d) SHA1(f19f7ae26e3b8af17a4e66e6722dd2f5c36d33f8)  ) // bank 1
-	ROM_LOAD( "sound06", 0x2400000, 0x0400000, CRC(525aff97) SHA1(b18e5bdf67d3a89f39c59f4f9bd3bb608dacc7f7)  ) // bank 1
-	ROM_LOAD( "sound07", 0x2800000, 0x0400000, CRC(5bd8bb95) SHA1(3b33c42778f7d50ca1513d37e7bc4a4efcc3cf82)  ) // bank 2
-	ROM_LOAD( "sound08", 0x2c00000, 0x0400000, CRC(304c1643) SHA1(0be090077e00d4b9abce2fac4821c630b6a40f22)  ) // bank 2
-	ROM_LOAD( "sound09", 0x3000000, 0x0400000, CRC(78c22c56) SHA1(eb48d188d25538a1d381ca760f8e98096ee12bfe)  ) // bank 2
-	ROM_LOAD( "sound10", 0x3400000, 0x0400000, CRC(d5e8d8a5) SHA1(df7db3c8b110ce1aa85e627537afb744c98877bd)  ) // bank 3
-	ROM_LOAD( "sound11", 0x3800000, 0x0400000, CRC(569ef4dd) SHA1(777f8a3aef741655555364d00a1eaa472ac4b922)  ) // bank 3
-	ROM_LOAD( "sound12", 0x3c00000, 0x0400000, CRC(aae8d59c) SHA1(ccca1f511ce0ea8d452f3b1d24350b5cee402ad2)  ) // bank 3
-	ROM_LOAD( "sound13", 0x4000000, 0x0400000, CRC(9ec1459b) SHA1(10e08a47636dec431cdb8e105cf61287fe9c6637)  ) // bank 4
-	ROM_LOAD( "sound14", 0x4400000, 0x0400000, CRC(b26f9a81) SHA1(0d1c8e382eb5877f9a748ff289be97cbdb73b0cc)  ) // bank 4
+	ROM_LOAD( "sound01", 0x0400000, 0x0400000, CRC(5b42999e) SHA1(376c773f292eae8b75db11bad3cb6ec5fe48392e)  ) // bank 0
+	ROM_LOAD( "sound02", 0x0800000, 0x0400000, CRC(8306f302) SHA1(8c0437d7ab8d74d4d15f4a641d30602e39cdd99d)  ) // bank 0
+	ROM_LOAD( "sound03", 0x0c00000, 0x0400000, CRC(3fda842c) SHA1(2b9e7c548b689bab491237e36a2dcf4782a81d79)  ) // bank 0
+	ROM_LOAD( "sound04", 0x1000000, 0x0400000, CRC(86d4f289) SHA1(908490ab0cf8d33cf3e127f71edee3bece70b86d)  ) // bank 1
+	ROM_LOAD( "sound05", 0x1400000, 0x0400000, CRC(f8dbf47d) SHA1(f19f7ae26e3b8af17a4e66e6722dd2f5c36d33f8)  ) // bank 1
+	ROM_LOAD( "sound06", 0x1800000, 0x0400000, CRC(525aff97) SHA1(b18e5bdf67d3a89f39c59f4f9bd3bb608dacc7f7)  ) // bank 1
+	ROM_LOAD( "sound07", 0x1c00000, 0x0400000, CRC(5bd8bb95) SHA1(3b33c42778f7d50ca1513d37e7bc4a4efcc3cf82)  ) // bank 2
+	ROM_LOAD( "sound08", 0x2000000, 0x0400000, CRC(304c1643) SHA1(0be090077e00d4b9abce2fac4821c630b6a40f22)  ) // bank 2
+	ROM_LOAD( "sound09", 0x2400000, 0x0400000, CRC(78c22c56) SHA1(eb48d188d25538a1d381ca760f8e98096ee12bfe)  ) // bank 2
+	ROM_LOAD( "sound10", 0x2800000, 0x0400000, CRC(d5e8d8a5) SHA1(df7db3c8b110ce1aa85e627537afb744c98877bd)  ) // bank 3
+	ROM_LOAD( "sound11", 0x2c00000, 0x0400000, CRC(569ef4dd) SHA1(777f8a3aef741655555364d00a1eaa472ac4b922)  ) // bank 3
+	ROM_LOAD( "sound12", 0x3000000, 0x0400000, CRC(aae8d59c) SHA1(ccca1f511ce0ea8d452f3b1d24350b5cee402ad2)  ) // bank 3
+	ROM_LOAD( "sound13", 0x3400000, 0x0400000, CRC(9ec1459b) SHA1(10e08a47636dec431cdb8e105cf61287fe9c6637)  ) // bank 4
+	ROM_LOAD( "sound14", 0x3800000, 0x0400000, CRC(b26f9a81) SHA1(0d1c8e382eb5877f9a748ff289be97cbdb73b0cc)  ) // bank 4
 ROM_END
 
 ROM_START( rockna )
@@ -2736,32 +2727,31 @@ ROM_START( rockna )
 	ROM_LOAD32_WORD( "rock_n_1_vj-98344_8.bin", 0x000002, 0x200000, CRC(fa3f6f9c) SHA1(586dcc690a1a4aa7c97932ad496382def6a074a4) )
 	ROM_LOAD32_WORD( "rock_n_1_vj-98344_9.bin", 0x000000, 0x200000, CRC(3d12a688) SHA1(356b2ea81d960838b604c5a17cc77e79fb0e40ce) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x200000, "tiles_bg", 0 )   /* 16x16x8 (Background) */
 	ROM_LOAD16_WORD( "rock_n_1_vj-98344_13.bin", 0x000000, 0x200000, CRC(261b99a0) SHA1(7b3c768ae9d7429e2559fe32c1a4ff220d727e7e) )
 
-	ROM_REGION( 0x100000, "gfx3", 0 )   /* 16x16x8 (Rotation) */
+	ROM_REGION( 0x100000, "tiles_rot", 0 )   /* 16x16x8 (Rotation) */
 	ROM_LOAD( "rock_n_1_vj-98344_6.bin", 0x000000, 0x100000, CRC(5551717f) SHA1(64943a9a68ad4074f3f5128d7796e4f03baa14d5) )
 
-	ROM_REGION( 0x080000, "gfx4", 0 )   /* 8x8x8 (Foreground) */
+	ROM_REGION( 0x080000, "tiles_fg", 0 )   /* 8x8x8 (Foreground) */
 	ROM_LOAD( "rock_n_1_vj-98344_10.bin", 0x000000, 0x080000, CRC(918663a8) SHA1(aedacb741c986ef8159385cfef866cb7e3ef6cb6) )
 
-	ROM_REGION( 0x7000000, "ymz", 0 )   /* Samples */
+	ROM_REGION( 0x6400000, "ymz", ROMREGION_ERASEFF )   /* Samples */
 	ROM_LOAD( "sound00", 0x0000000, 0x0400000, CRC(c354f753) SHA1(bf538c02e2162a93d8c6793a1211e21480156223)  ) // COMMON AREA
-	ROM_FILL(                 0x0400000, 0x0c00000, 0xff ) // BANK AREA
-	ROM_LOAD( "sound01", 0x1000000, 0x0400000, CRC(5b42999e) SHA1(376c773f292eae8b75db11bad3cb6ec5fe48392e)  ) // bank 0
-	ROM_LOAD( "sound02", 0x1400000, 0x0400000, CRC(8306f302) SHA1(8c0437d7ab8d74d4d15f4a641d30602e39cdd99d)  ) // bank 0
-	ROM_LOAD( "sound03", 0x1800000, 0x0400000, CRC(3fda842c) SHA1(2b9e7c548b689bab491237e36a2dcf4782a81d79)  ) // bank 0
-	ROM_LOAD( "sound04", 0x1c00000, 0x0400000, CRC(86d4f289) SHA1(908490ab0cf8d33cf3e127f71edee3bece70b86d)  ) // bank 1
-	ROM_LOAD( "sound05", 0x2000000, 0x0400000, CRC(f8dbf47d) SHA1(f19f7ae26e3b8af17a4e66e6722dd2f5c36d33f8)  ) // bank 1
-	ROM_LOAD( "sound06", 0x2400000, 0x0400000, CRC(525aff97) SHA1(b18e5bdf67d3a89f39c59f4f9bd3bb608dacc7f7)  ) // bank 1
-	ROM_LOAD( "sound07", 0x2800000, 0x0400000, CRC(5bd8bb95) SHA1(3b33c42778f7d50ca1513d37e7bc4a4efcc3cf82)  ) // bank 2
-	ROM_LOAD( "sound08", 0x2c00000, 0x0400000, CRC(304c1643) SHA1(0be090077e00d4b9abce2fac4821c630b6a40f22)  ) // bank 2
-	ROM_LOAD( "sound09", 0x3000000, 0x0400000, CRC(78c22c56) SHA1(eb48d188d25538a1d381ca760f8e98096ee12bfe)  ) // bank 2
-	ROM_LOAD( "sound10", 0x3400000, 0x0400000, CRC(d5e8d8a5) SHA1(df7db3c8b110ce1aa85e627537afb744c98877bd)  ) // bank 3
-	ROM_LOAD( "sound11", 0x3800000, 0x0400000, CRC(569ef4dd) SHA1(777f8a3aef741655555364d00a1eaa472ac4b922)  ) // bank 3
-	ROM_LOAD( "sound12", 0x3c00000, 0x0400000, CRC(aae8d59c) SHA1(ccca1f511ce0ea8d452f3b1d24350b5cee402ad2)  ) // bank 3
-	ROM_LOAD( "sound13", 0x4000000, 0x0400000, CRC(9ec1459b) SHA1(10e08a47636dec431cdb8e105cf61287fe9c6637)  ) // bank 4
-	ROM_LOAD( "sound14", 0x4400000, 0x0400000, CRC(b26f9a81) SHA1(0d1c8e382eb5877f9a748ff289be97cbdb73b0cc)  ) // bank 4
+	ROM_LOAD( "sound01", 0x0400000, 0x0400000, CRC(5b42999e) SHA1(376c773f292eae8b75db11bad3cb6ec5fe48392e)  ) // bank 0
+	ROM_LOAD( "sound02", 0x0800000, 0x0400000, CRC(8306f302) SHA1(8c0437d7ab8d74d4d15f4a641d30602e39cdd99d)  ) // bank 0
+	ROM_LOAD( "sound03", 0x0c00000, 0x0400000, CRC(3fda842c) SHA1(2b9e7c548b689bab491237e36a2dcf4782a81d79)  ) // bank 0
+	ROM_LOAD( "sound04", 0x1000000, 0x0400000, CRC(86d4f289) SHA1(908490ab0cf8d33cf3e127f71edee3bece70b86d)  ) // bank 1
+	ROM_LOAD( "sound05", 0x1400000, 0x0400000, CRC(f8dbf47d) SHA1(f19f7ae26e3b8af17a4e66e6722dd2f5c36d33f8)  ) // bank 1
+	ROM_LOAD( "sound06", 0x1800000, 0x0400000, CRC(525aff97) SHA1(b18e5bdf67d3a89f39c59f4f9bd3bb608dacc7f7)  ) // bank 1
+	ROM_LOAD( "sound07", 0x1c00000, 0x0400000, CRC(5bd8bb95) SHA1(3b33c42778f7d50ca1513d37e7bc4a4efcc3cf82)  ) // bank 2
+	ROM_LOAD( "sound08", 0x2000000, 0x0400000, CRC(304c1643) SHA1(0be090077e00d4b9abce2fac4821c630b6a40f22)  ) // bank 2
+	ROM_LOAD( "sound09", 0x2400000, 0x0400000, CRC(78c22c56) SHA1(eb48d188d25538a1d381ca760f8e98096ee12bfe)  ) // bank 2
+	ROM_LOAD( "sound10", 0x2800000, 0x0400000, CRC(d5e8d8a5) SHA1(df7db3c8b110ce1aa85e627537afb744c98877bd)  ) // bank 3
+	ROM_LOAD( "sound11", 0x2c00000, 0x0400000, CRC(569ef4dd) SHA1(777f8a3aef741655555364d00a1eaa472ac4b922)  ) // bank 3
+	ROM_LOAD( "sound12", 0x3000000, 0x0400000, CRC(aae8d59c) SHA1(ccca1f511ce0ea8d452f3b1d24350b5cee402ad2)  ) // bank 3
+	ROM_LOAD( "sound13", 0x3400000, 0x0400000, CRC(9ec1459b) SHA1(10e08a47636dec431cdb8e105cf61287fe9c6637)  ) // bank 4
+	ROM_LOAD( "sound14", 0x3800000, 0x0400000, CRC(b26f9a81) SHA1(0d1c8e382eb5877f9a748ff289be97cbdb73b0cc)  ) // bank 4
 ROM_END
 
 ROM_START( rockn2 )
@@ -2773,42 +2763,41 @@ ROM_START( rockn2 )
 	ROM_LOAD32_WORD( "rock_n_2_vj-98344_8_v1.0", 0x000002, 0x200000, CRC(673ce2c2) SHA1(6c0a13de386b02a7f3a86e8128374938ede2525c) )
 	ROM_LOAD32_WORD( "rock_n_2_vj-98344_9_v1.0", 0x000000, 0x200000, CRC(9d3968cf) SHA1(11c96e7685ab8c1b416396238ec5c12e7819385f) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x200000, "tiles_bg", 0 )   /* 16x16x8 (Background) */
 	ROM_LOAD16_WORD( "rock_n_2_vj-98344_13_v1.0", 0x000000, 0x200000, CRC(e35c55b3) SHA1(a18367c28befc3f71823f1d4ab2126ad6f8a28fc)  )
 
-	ROM_REGION( 0x200000, "gfx3", 0 )   /* 16x16x8 (Rotation) */
+	ROM_REGION( 0x200000, "tiles_rot", 0 )   /* 16x16x8 (Rotation) */
 	ROM_LOAD( "rock_n_2_vj-98344_6_v1.0", 0x000000, 0x200000, CRC(241d7449) SHA1(9fcc2d128d7be273836460313c0e73c81e33c9cb)  )
 
-	ROM_REGION( 0x080000, "gfx4", 0 )   /* 8x8x8 (Foreground) */
+	ROM_REGION( 0x080000, "tiles_fg", 0 )   /* 8x8x8 (Foreground) */
 	ROM_LOAD( "rock_n_2_vj-98344_10_v1.0", 0x000000, 0x080000, CRC(ae74d5b3) SHA1(07aa6ee540a783e3f2a8710a7095d922cff1d443)  )
 
-	ROM_REGION( 0x7000000, "ymz", 0 )   /* Samples */
+	ROM_REGION( 0x6400000, "ymz", ROMREGION_ERASEFF )   /* Samples */
 	ROM_LOAD( "sound00", 0x0000000, 0x0400000, CRC(4e9611a3) SHA1(2a9b1d5afc0ea9a3285f9fc6b49a1c3abd8cd2a5)  ) // COMMON AREA
-	ROM_FILL(            0x0400000, 0x0c00000, 0xff )       // BANK AREA
-	ROM_LOAD( "sound01", 0x1000000, 0x0400000, CRC(ec600f13) SHA1(151cb0a16782c8bba223d0f6881b80c1e43bc9bc)  ) // bank 0
-	ROM_LOAD( "sound02", 0x1400000, 0x0400000, CRC(8306f302) SHA1(8c0437d7ab8d74d4d15f4a641d30602e39cdd99d)  ) // bank 0
-	ROM_LOAD( "sound03", 0x1800000, 0x0400000, CRC(3fda842c) SHA1(2b9e7c548b689bab491237e36a2dcf4782a81d79)  ) // bank 0
-	ROM_LOAD( "sound04", 0x1c00000, 0x0400000, CRC(86d4f289) SHA1(908490ab0cf8d33cf3e127f71edee3bece70b86d)  ) // bank 1
-	ROM_LOAD( "sound05", 0x2000000, 0x0400000, CRC(f8dbf47d) SHA1(f19f7ae26e3b8af17a4e66e6722dd2f5c36d33f8)  ) // bank 1
-	ROM_LOAD( "sound06", 0x2400000, 0x0400000, CRC(06f7bd63) SHA1(d8b27212ebba99f5129483550aeac5b86ff2a1d2)  ) // bank 1
-	ROM_LOAD( "sound07", 0x2800000, 0x0400000, CRC(22f042f6) SHA1(649bdf43dd698150992e68b23fd758bca56c615b)  ) // bank 2
-	ROM_LOAD( "sound08", 0x2c00000, 0x0400000, CRC(dd294d8e) SHA1(49d889d341ab6167d9741340eb27902923b6cb42)  ) // bank 2
-	ROM_LOAD( "sound09", 0x3000000, 0x0400000, CRC(8fedee6e) SHA1(540c01d1c5f410abb1f86f33a5a532208946cb7c)  ) // bank 2
-	ROM_LOAD( "sound10", 0x3400000, 0x0400000, CRC(01292f11) SHA1(da88b14bf8df34e7574cf8c9f5dd385db13ab34c)  ) // bank 3
-	ROM_LOAD( "sound11", 0x3800000, 0x0400000, CRC(20dc76ba) SHA1(078397f2de54d4ca91035dce11419ac0d934fbfa)  ) // bank 3
-	ROM_LOAD( "sound12", 0x3c00000, 0x0400000, CRC(11fff0bc) SHA1(2767fcc3a5d3200750b011c97a83073719a9325f)  ) // bank 3
-	ROM_LOAD( "sound13", 0x4000000, 0x0400000, CRC(2367dd18) SHA1(b58f757ce4c832c5462637f4e08d7be511ca0c96)  ) // bank 4
-	ROM_LOAD( "sound14", 0x4400000, 0x0400000, CRC(75ced8c0) SHA1(fda17464767be073a36c117f5212411b66197dd9)  ) // bank 4
-	ROM_LOAD( "sound15", 0x4800000, 0x0400000, CRC(aeaca380) SHA1(1c389911aa766abec389b1c79a1542759ac58b9f)  ) // bank 4
-	ROM_LOAD( "sound16", 0x4c00000, 0x0400000, CRC(21d50e32) SHA1(24eaceb7c0b868b6e8fc16b403dae2427e422bf6)  ) // bank 5
-	ROM_LOAD( "sound17", 0x5000000, 0x0400000, CRC(de785a2a) SHA1(1f5ae46ac9476a31a431ce0f0cf124e1c8c930a6)  ) // bank 5
-	ROM_LOAD( "sound18", 0x5400000, 0x0400000, CRC(18cabb1e) SHA1(c769820e2e84eff0e4ce956236656ae757e3299c)  ) // bank 5
-	ROM_LOAD( "sound19", 0x5800000, 0x0400000, CRC(33c89e53) SHA1(7d216f5db6b30c9b05a9a77030498ff68ae6fbad)  ) // bank 6
-	ROM_LOAD( "sound20", 0x5c00000, 0x0400000, CRC(89c1b088) SHA1(9b4118815959a5fb65b2a293015f592a46f4126f)  ) // bank 6
-	ROM_LOAD( "sound21", 0x6000000, 0x0400000, CRC(13db74bd) SHA1(ab87438bbac97d46b1b8195b61dca1d72172a621)  ) // bank 6
-//  ROM_LOAD( "sound22", 0x6400000, 0x0400000 ) // bank 7 ( ** unpopulated **  -  IC24)
-//  ROM_LOAD( "sound23", 0x6800000, 0x0400000 ) // bank 7 ( ** unpopulated **  -  IC25)
-//  ROM_LOAD( "sound24", 0x6c00000, 0x0400000 ) // bank 7 ( ** unpopulated **  -  IC26)
+	ROM_LOAD( "sound01", 0x0400000, 0x0400000, CRC(ec600f13) SHA1(151cb0a16782c8bba223d0f6881b80c1e43bc9bc)  ) // bank 0
+	ROM_LOAD( "sound02", 0x0800000, 0x0400000, CRC(8306f302) SHA1(8c0437d7ab8d74d4d15f4a641d30602e39cdd99d)  ) // bank 0
+	ROM_LOAD( "sound03", 0x0c00000, 0x0400000, CRC(3fda842c) SHA1(2b9e7c548b689bab491237e36a2dcf4782a81d79)  ) // bank 0
+	ROM_LOAD( "sound04", 0x1000000, 0x0400000, CRC(86d4f289) SHA1(908490ab0cf8d33cf3e127f71edee3bece70b86d)  ) // bank 1
+	ROM_LOAD( "sound05", 0x1400000, 0x0400000, CRC(f8dbf47d) SHA1(f19f7ae26e3b8af17a4e66e6722dd2f5c36d33f8)  ) // bank 1
+	ROM_LOAD( "sound06", 0x1800000, 0x0400000, CRC(06f7bd63) SHA1(d8b27212ebba99f5129483550aeac5b86ff2a1d2)  ) // bank 1
+	ROM_LOAD( "sound07", 0x1c00000, 0x0400000, CRC(22f042f6) SHA1(649bdf43dd698150992e68b23fd758bca56c615b)  ) // bank 2
+	ROM_LOAD( "sound08", 0x2000000, 0x0400000, CRC(dd294d8e) SHA1(49d889d341ab6167d9741340eb27902923b6cb42)  ) // bank 2
+	ROM_LOAD( "sound09", 0x2400000, 0x0400000, CRC(8fedee6e) SHA1(540c01d1c5f410abb1f86f33a5a532208946cb7c)  ) // bank 2
+	ROM_LOAD( "sound10", 0x2800000, 0x0400000, CRC(01292f11) SHA1(da88b14bf8df34e7574cf8c9f5dd385db13ab34c)  ) // bank 3
+	ROM_LOAD( "sound11", 0x2c00000, 0x0400000, CRC(20dc76ba) SHA1(078397f2de54d4ca91035dce11419ac0d934fbfa)  ) // bank 3
+	ROM_LOAD( "sound12", 0x3000000, 0x0400000, CRC(11fff0bc) SHA1(2767fcc3a5d3200750b011c97a83073719a9325f)  ) // bank 3
+	ROM_LOAD( "sound13", 0x3400000, 0x0400000, CRC(2367dd18) SHA1(b58f757ce4c832c5462637f4e08d7be511ca0c96)  ) // bank 4
+	ROM_LOAD( "sound14", 0x3800000, 0x0400000, CRC(75ced8c0) SHA1(fda17464767be073a36c117f5212411b66197dd9)  ) // bank 4
+	ROM_LOAD( "sound15", 0x3c00000, 0x0400000, CRC(aeaca380) SHA1(1c389911aa766abec389b1c79a1542759ac58b9f)  ) // bank 4
+	ROM_LOAD( "sound16", 0x4000000, 0x0400000, CRC(21d50e32) SHA1(24eaceb7c0b868b6e8fc16b403dae2427e422bf6)  ) // bank 5
+	ROM_LOAD( "sound17", 0x4400000, 0x0400000, CRC(de785a2a) SHA1(1f5ae46ac9476a31a431ce0f0cf124e1c8c930a6)  ) // bank 5
+	ROM_LOAD( "sound18", 0x4800000, 0x0400000, CRC(18cabb1e) SHA1(c769820e2e84eff0e4ce956236656ae757e3299c)  ) // bank 5
+	ROM_LOAD( "sound19", 0x4c00000, 0x0400000, CRC(33c89e53) SHA1(7d216f5db6b30c9b05a9a77030498ff68ae6fbad)  ) // bank 6
+	ROM_LOAD( "sound20", 0x5000000, 0x0400000, CRC(89c1b088) SHA1(9b4118815959a5fb65b2a293015f592a46f4126f)  ) // bank 6
+	ROM_LOAD( "sound21", 0x5400000, 0x0400000, CRC(13db74bd) SHA1(ab87438bbac97d46b1b8195b61dca1d72172a621)  ) // bank 6
+//  ROM_LOAD( "sound22", 0x5800000, 0x0400000 ) // bank 7 ( ** unpopulated **  -  IC24)
+//  ROM_LOAD( "sound23", 0x5c00000, 0x0400000 ) // bank 7 ( ** unpopulated **  -  IC25)
+//  ROM_LOAD( "sound24", 0x6000000, 0x0400000 ) // bank 7 ( ** unpopulated **  -  IC26)
 ROM_END
 
 /***************************************************************************
@@ -2851,42 +2840,42 @@ ROM_START( rockn3 )
 	ROM_LOAD32_WORD( "rock_n_3_vj-98344_8_v1.0", 0x000002, 0x200000, CRC(468bf696) SHA1(d58e399ff876ab0f4ef52aaa85d86d72db307b6a) ) /* IC32 (alt PCB number 8) */
 	ROM_LOAD32_WORD( "rock_n_3_vj-98344_9_v1.0", 0x000000, 0x200000, CRC(8a61fc18) SHA1(4e895a2014e711d044ed5d8bff8a91766f14b307) ) /* IC33 (alt PCB number 9) */
 
-	ROM_REGION( 0x200000, "gfx2", 0 )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x200000, "tiles_bg", 0 )   /* 16x16x8 (Background) */
 	ROM_LOAD16_WORD( "rock_n_3_vj-98344_13_v1.0", 0x000000, 0x200000, CRC(e01bf471) SHA1(4485c71770bdb8800ded4afb37814c2d287b78be)  ) /* IC10 (alt PCB number 13) */
 
-	ROM_REGION( 0x200000, "gfx3", 0 )   /* 16x16x8 (Rotation) */
+	ROM_REGION( 0x200000, "tiles_rot", 0 )   /* 16x16x8 (Rotation) */
 	ROM_LOAD( "rock_n_3_vj-98344_6_v1.0", 0x000000, 0x200000, CRC(4e146de5) SHA1(5971cbb91da5fde652786d82d0143197518bad9b)  ) /* IC38 (alt PCB number 6) */
 
-	ROM_REGION( 0x080000, "gfx4", 0 )   /* 8x8x8 (Foreground) */
+	ROM_REGION( 0x080000, "tiles_fg", 0 )   /* 8x8x8 (Foreground) */
 	ROM_LOAD( "rock_n_3_vj-98344_10_v1.0", 0x000000, 0x080000, CRC(8100039e) SHA1(e07b1e2f3cbcb1c086edd628d20423ecd4f74860)  ) /* IC19 (alt PCB number 10) */
 
-	ROM_REGION( 0x7000000, "ymz", 0 )   /* Samples - On separate ROM board with YMZ280B-F sound chip */
+	ROM_REGION( 0x6400000, "ymz", ROMREGION_ERASEFF )   /* Samples - On separate ROM board with YMZ280B-F sound chip */
 	ROM_LOAD( "mr99029-01.ic28", 0x0000000, 0x0400000, CRC(e2f69042) SHA1(deb361a53ed6a9033e21c2f805f327cc3e9b11c6)  ) // COMMON AREA  (alt PCB number 25)
-	ROM_FILL(                    0x0400000, 0x0c00000, 0xff )       // BANK AREA (unpopulated IC29, IC36 & IC37 (alt PCB numbers 26, 27 & 28 repectively)
-	ROM_LOAD( "mr99029-02.ic1",  0x1000000, 0x0400000, CRC(b328b18f) SHA1(22edebcabd6c8ed65d8c9e501621991d404c430d)  ) // bank 0 (alt PCB number 1)
-	ROM_LOAD( "mr99029-03.ic2",  0x1400000, 0x0400000, CRC(f46438e3) SHA1(718f54fc0e3689f5ab29bef2ec13eb2aa9b117fc)  ) // bank 0 (alt PCB number 2)
-	ROM_LOAD( "mr99029-04.ic3",  0x1800000, 0x0400000, CRC(b979e887) SHA1(10852ceb1b9e24fb87cf9339bc9fb4ae066a1221)  ) // bank 0 (alt PCB number 3)
-	ROM_LOAD( "mr99029-05.ic4",  0x1c00000, 0x0400000, CRC(0bb2c212) SHA1(4f8ab3c96c3e1aa337a3fe871cffc04ec603f8c0)  ) // bank 1 (alt PCB number 4)
-	ROM_LOAD( "mr99029-06.ic5",  0x2000000, 0x0400000, CRC(3116e437) SHA1(f1b06592a6f0eba92eb4511d3ca03a3bb51e8c9d)  ) // bank 1 (alt PCB number 5)
-	ROM_LOAD( "mr99029-07.ic6",  0x2400000, 0x0400000, CRC(26b37ef6) SHA1(f7090f3ec81f0c651c53d460b476e63f52dd06dc)  ) // bank 1 (alt PCB number 6)
-	ROM_LOAD( "mr99029-08.ic7",  0x2800000, 0x0400000, CRC(1dd3f4e3) SHA1(8474e00b962368164c717e5fe2e926852f3b4426)  ) // bank 2 (alt PCB number 7)
-	ROM_LOAD( "mr99029-09.ic8",  0x2c00000, 0x0400000, CRC(a1b03d67) SHA1(95f89a37e97d62706e15fd5571ff2e70dd98fee2)  ) // bank 2 (alt PCB number 8)
-	ROM_LOAD( "mr99029-10.ic10", 0x3000000, 0x0400000, CRC(35107aac) SHA1(d56a66e15c46c33cf6c9c28edf48b730b681d21a)  ) // bank 2 (alt PCB number 9)
-	ROM_LOAD( "mr99029-11.ic11", 0x3400000, 0x0400000, CRC(059ec592) SHA1(205210af558eb7e8e1399b2a506ef0285c5feda3)  ) // bank 3 (alt PCB number 10)
-	ROM_LOAD( "mr99029-12.ic12", 0x3800000, 0x0400000, CRC(84d4badb) SHA1(fc20f97a008f000a49e7cadd559789516643704a)  ) // bank 3 (alt PCB number 11)
-	ROM_LOAD( "mr99029-13.ic13", 0x3c00000, 0x0400000, CRC(4527a9b7) SHA1(a73ebece5c84bf14f8d25bbd869b7b43b1fcd042)  ) // bank 3 (alt PCB number 12)
-	ROM_LOAD( "mr99029-14.ic14", 0x4000000, 0x0400000, CRC(bfa4b7ce) SHA1(4100f2deabb8994e8e3ff897a1db13693ab64c11)  ) // bank 4 (alt PCB number 13)
-	ROM_LOAD( "mr99029-15.ic15", 0x4400000, 0x0400000, CRC(a2ccd2ce) SHA1(fc6325219f7b8e68c22a129f5ec4e900e326fb9d)  ) // bank 4 (alt PCB number 14)
-	ROM_LOAD( "mr99029-16.ic16", 0x4800000, 0x0400000, CRC(95baf678) SHA1(f7b39a3379f16df0560a22d4f42165ebbe05cebe)  ) // bank 4 (alt PCB number 15)
-	ROM_LOAD( "mr99029-17.ic17", 0x4c00000, 0x0400000, CRC(5883c84b) SHA1(54aec4e1e2f5edc198aebc4788caf5062f9a5b6c)  ) // bank 5 (alt PCB number 16)
-	ROM_LOAD( "mr99029-18.ic19", 0x5000000, 0x0400000, CRC(f92098ce) SHA1(9b13cd37ad5d7baf36b20218c4bced956084ec45)  ) // bank 5 (alt PCB number 17)
-	ROM_LOAD( "mr99029-19.ic20", 0x5400000, 0x0400000, CRC(dbb2c228) SHA1(f7cd24026236e2c616376c695b9e986cc221f36d)  ) // bank 5 (alt PCB number 18)
-	ROM_LOAD( "mr99029-20.ic21", 0x5800000, 0x0400000, CRC(9efdae1c) SHA1(6158a1804fbaa9ce27ae7e12cfda5f49084b4998)  ) // bank 6 (alt PCB number 19)
-	ROM_LOAD( "mr99029-21.ic22", 0x5c00000, 0x0400000, CRC(5f301b83) SHA1(e24e85c43a62871360545aa42dfa439045334b79)  ) // bank 6 (alt PCB number 20)
-//  ROM_LOAD( "ic23",            0x6000000, 0x0400000 ) // bank 6 ( ** unpopulated **  -  alt PCB number 21)
-//  ROM_LOAD( "ic24",            0x6400000, 0x0400000 ) // bank 7 ( ** unpopulated **  -  alt PCB number 22)
-//  ROM_LOAD( "ic25",            0x6800000, 0x0400000 ) // bank 7 ( ** unpopulated **  -  alt PCB number 23)
-//  ROM_LOAD( "ic26",            0x6c00000, 0x0400000 ) // bank 7 ( ** unpopulated **  -  alt PCB number 24)
+	// BANK AREA (unpopulated IC29, IC36 & IC37 (alt PCB numbers 26, 27 & 28 repectively)
+	ROM_LOAD( "mr99029-02.ic1",  0x0400000, 0x0400000, CRC(b328b18f) SHA1(22edebcabd6c8ed65d8c9e501621991d404c430d)  ) // bank 0 (alt PCB number 1)
+	ROM_LOAD( "mr99029-03.ic2",  0x0800000, 0x0400000, CRC(f46438e3) SHA1(718f54fc0e3689f5ab29bef2ec13eb2aa9b117fc)  ) // bank 0 (alt PCB number 2)
+	ROM_LOAD( "mr99029-04.ic3",  0x0c00000, 0x0400000, CRC(b979e887) SHA1(10852ceb1b9e24fb87cf9339bc9fb4ae066a1221)  ) // bank 0 (alt PCB number 3)
+	ROM_LOAD( "mr99029-05.ic4",  0x1000000, 0x0400000, CRC(0bb2c212) SHA1(4f8ab3c96c3e1aa337a3fe871cffc04ec603f8c0)  ) // bank 1 (alt PCB number 4)
+	ROM_LOAD( "mr99029-06.ic5",  0x1400000, 0x0400000, CRC(3116e437) SHA1(f1b06592a6f0eba92eb4511d3ca03a3bb51e8c9d)  ) // bank 1 (alt PCB number 5)
+	ROM_LOAD( "mr99029-07.ic6",  0x1800000, 0x0400000, CRC(26b37ef6) SHA1(f7090f3ec81f0c651c53d460b476e63f52dd06dc)  ) // bank 1 (alt PCB number 6)
+	ROM_LOAD( "mr99029-08.ic7",  0x1c00000, 0x0400000, CRC(1dd3f4e3) SHA1(8474e00b962368164c717e5fe2e926852f3b4426)  ) // bank 2 (alt PCB number 7)
+	ROM_LOAD( "mr99029-09.ic8",  0x2000000, 0x0400000, CRC(a1b03d67) SHA1(95f89a37e97d62706e15fd5571ff2e70dd98fee2)  ) // bank 2 (alt PCB number 8)
+	ROM_LOAD( "mr99029-10.ic10", 0x2400000, 0x0400000, CRC(35107aac) SHA1(d56a66e15c46c33cf6c9c28edf48b730b681d21a)  ) // bank 2 (alt PCB number 9)
+	ROM_LOAD( "mr99029-11.ic11", 0x2800000, 0x0400000, CRC(059ec592) SHA1(205210af558eb7e8e1399b2a506ef0285c5feda3)  ) // bank 3 (alt PCB number 10)
+	ROM_LOAD( "mr99029-12.ic12", 0x2c00000, 0x0400000, CRC(84d4badb) SHA1(fc20f97a008f000a49e7cadd559789516643704a)  ) // bank 3 (alt PCB number 11)
+	ROM_LOAD( "mr99029-13.ic13", 0x3000000, 0x0400000, CRC(4527a9b7) SHA1(a73ebece5c84bf14f8d25bbd869b7b43b1fcd042)  ) // bank 3 (alt PCB number 12)
+	ROM_LOAD( "mr99029-14.ic14", 0x3400000, 0x0400000, CRC(bfa4b7ce) SHA1(4100f2deabb8994e8e3ff897a1db13693ab64c11)  ) // bank 4 (alt PCB number 13)
+	ROM_LOAD( "mr99029-15.ic15", 0x3800000, 0x0400000, CRC(a2ccd2ce) SHA1(fc6325219f7b8e68c22a129f5ec4e900e326fb9d)  ) // bank 4 (alt PCB number 14)
+	ROM_LOAD( "mr99029-16.ic16", 0x3c00000, 0x0400000, CRC(95baf678) SHA1(f7b39a3379f16df0560a22d4f42165ebbe05cebe)  ) // bank 4 (alt PCB number 15)
+	ROM_LOAD( "mr99029-17.ic17", 0x4000000, 0x0400000, CRC(5883c84b) SHA1(54aec4e1e2f5edc198aebc4788caf5062f9a5b6c)  ) // bank 5 (alt PCB number 16)
+	ROM_LOAD( "mr99029-18.ic19", 0x4400000, 0x0400000, CRC(f92098ce) SHA1(9b13cd37ad5d7baf36b20218c4bced956084ec45)  ) // bank 5 (alt PCB number 17)
+	ROM_LOAD( "mr99029-19.ic20", 0x4800000, 0x0400000, CRC(dbb2c228) SHA1(f7cd24026236e2c616376c695b9e986cc221f36d)  ) // bank 5 (alt PCB number 18)
+	ROM_LOAD( "mr99029-20.ic21", 0x4c00000, 0x0400000, CRC(9efdae1c) SHA1(6158a1804fbaa9ce27ae7e12cfda5f49084b4998)  ) // bank 6 (alt PCB number 19)
+	ROM_LOAD( "mr99029-21.ic22", 0x5000000, 0x0400000, CRC(5f301b83) SHA1(e24e85c43a62871360545aa42dfa439045334b79)  ) // bank 6 (alt PCB number 20)
+//  ROM_LOAD( "ic23",            0x5400000, 0x0400000 ) // bank 6 ( ** unpopulated **  -  alt PCB number 21)
+//  ROM_LOAD( "ic24",            0x5800000, 0x0400000 ) // bank 7 ( ** unpopulated **  -  alt PCB number 22)
+//  ROM_LOAD( "ic25",            0x5c00000, 0x0400000 ) // bank 7 ( ** unpopulated **  -  alt PCB number 23)
+//  ROM_LOAD( "ic26",            0x6000000, 0x0400000 ) // bank 7 ( ** unpopulated **  -  alt PCB number 24)
 ROM_END
 
 ROM_START( rockn4 ) /* Prototype */
@@ -2898,27 +2887,26 @@ ROM_START( rockn4 ) /* Prototype */
 	ROM_LOAD32_WORD( "rock_n_4_vj-98344_8.bin", 0x000002, 0x200000, CRC(5eeae537) SHA1(6bb8c658a2985c3919f0590a0147eead995c01c9) )
 	ROM_LOAD32_WORD( "rock_n_4_vj-98344_9.bin", 0x000000, 0x200000, CRC(3fedddc9) SHA1(4bd8f402ecf8e6255326927e825179fa6d300e73) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x200000, "tiles_bg", 0 )   /* 16x16x8 (Background) */
 	ROM_LOAD16_WORD( "rock_n_4_vj-98344_13.bin", 0x000000, 0x200000, CRC(ead41e79) SHA1(9c24b1e52b6ed43d5b5a1caf48f2974b8fa61f4a)  )
 
-	ROM_REGION( 0x200000, "gfx3", 0 )   /* 16x16x8 (Rotation) */
+	ROM_REGION( 0x200000, "tiles_rot", 0 )   /* 16x16x8 (Rotation) */
 	ROM_LOAD( "rock_n_4_vj-98344_6.bin", 0x000000, 0x200000, CRC(eb16fc67) SHA1(5be40f2c9a5693785268eafcfcf348f147533463)  )
 
-	ROM_REGION( 0x100000, "gfx4", 0 )   /* 8x8x8 (Foreground) */
+	ROM_REGION( 0x100000, "tiles_fg", 0 )   /* 8x8x8 (Foreground) */
 	ROM_LOAD( "rock_n_4_vj-98344_10.bin", 0x000000, 0x100000, CRC(37d50259) SHA1(fd02f98a981470c47889f0b2f813ce59373a4b42)  )
 
-	ROM_REGION( 0x7000000, "ymz", 0 )   /* Samples */
+	ROM_REGION( 0x6400000, "ymz", ROMREGION_ERASEFF )   /* Samples */
 	ROM_LOAD( "sound00", 0x0000000, 0x0400000, CRC(918ea8eb) SHA1(0cd82859634635b6ce49db36fb91ed3365a101eb)  ) // COMMON AREA
-	ROM_FILL(            0x0400000, 0x0c00000, 0xff )         // BANK AREA
-	ROM_LOAD( "sound01", 0x1000000, 0x0400000, CRC(c548e51e) SHA1(4fe1e35c9ed4366dce98b4f4c00f94e202ef15dc)  ) // bank 0
-	ROM_LOAD( "sound02", 0x1400000, 0x0400000, CRC(ffda0253) SHA1(9b8ae98accc2f72a1cd881086f89e647e4904ad9)  ) // bank 0
-	ROM_LOAD( "sound03", 0x1800000, 0x0400000, CRC(1f813af5) SHA1(a72d842e39b9fc955a2fc6721673b34b1b591e4a)  ) // bank 0
-	ROM_LOAD( "sound04", 0x1c00000, 0x0400000, CRC(035c4ff3) SHA1(9290c49244dc45ad5d6543775c5f2cc507e54e77)  ) // bank 1
-	ROM_LOAD( "sound05", 0x2000000, 0x0400000, CRC(0f01f7b0) SHA1(e0c6daa1606dd5aaac59a7ae75d76e937e9c0151)  ) // bank 1
-	ROM_LOAD( "sound06", 0x2400000, 0x0400000, CRC(31574b1c) SHA1(a08b50b4c4f2be32892b7534f2192101f8af6762)  ) // bank 1
-	ROM_LOAD( "sound07", 0x2800000, 0x0400000, CRC(388e2c91) SHA1(493ef760858a82cbc38de59c4db3f273c0ddfdfb)  ) // bank 2
-	ROM_LOAD( "sound08", 0x2c00000, 0x0400000, CRC(6e7e3f23) SHA1(4b9b959f79254d0633f1c4324b7ee6a17e222308)  ) // bank 2
-	ROM_LOAD( "sound09", 0x3000000, 0x0400000, CRC(39fa512f) SHA1(d07426bc74492496756b67b8ded1b507726720c7)  ) // bank 2
+	ROM_LOAD( "sound01", 0x0400000, 0x0400000, CRC(c548e51e) SHA1(4fe1e35c9ed4366dce98b4f4c00f94e202ef15dc)  ) // bank 0
+	ROM_LOAD( "sound02", 0x0800000, 0x0400000, CRC(ffda0253) SHA1(9b8ae98accc2f72a1cd881086f89e647e4904ad9)  ) // bank 0
+	ROM_LOAD( "sound03", 0x0c00000, 0x0400000, CRC(1f813af5) SHA1(a72d842e39b9fc955a2fc6721673b34b1b591e4a)  ) // bank 0
+	ROM_LOAD( "sound04", 0x1000000, 0x0400000, CRC(035c4ff3) SHA1(9290c49244dc45ad5d6543775c5f2cc507e54e77)  ) // bank 1
+	ROM_LOAD( "sound05", 0x1400000, 0x0400000, CRC(0f01f7b0) SHA1(e0c6daa1606dd5aaac59a7ae75d76e937e9c0151)  ) // bank 1
+	ROM_LOAD( "sound06", 0x1800000, 0x0400000, CRC(31574b1c) SHA1(a08b50b4c4f2be32892b7534f2192101f8af6762)  ) // bank 1
+	ROM_LOAD( "sound07", 0x1c00000, 0x0400000, CRC(388e2c91) SHA1(493ef760858a82cbc38de59c4db3f273c0ddfdfb)  ) // bank 2
+	ROM_LOAD( "sound08", 0x2000000, 0x0400000, CRC(6e7e3f23) SHA1(4b9b959f79254d0633f1c4324b7ee6a17e222308)  ) // bank 2
+	ROM_LOAD( "sound09", 0x2400000, 0x0400000, CRC(39fa512f) SHA1(d07426bc74492496756b67b8ded1b507726720c7)  ) // bank 2
 ROM_END
 
 ROM_START( rocknms )
@@ -2934,51 +2922,50 @@ ROM_START( rocknms )
 	ROM_LOAD32_WORD( "mast_spr1", 0x000002, 0x400000, CRC(520152dc) SHA1(619a55352c0dab914f6188d66272a24495b5d1d4)  )
 	ROM_LOAD32_WORD( "mast_spr0", 0x000000, 0x400000, CRC(1caad02a) SHA1(00c3fc849d1f633874fee30f7d0caf0c62735c50)  )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x200000, "tiles_bg", 0 )   /* 16x16x8 (Background) */
 	ROM_LOAD16_WORD( "mast_back", 0x000000, 0x200000, CRC(1ca30e3f) SHA1(763c9dd287c186b6ca8ecb88c3ce29d68fea9179)  )
 
-	ROM_REGION( 0x200000, "gfx3", 0 )   /* 16x16x8 (Rotation) */
+	ROM_REGION( 0x200000, "tiles_rot", 0 )   /* 16x16x8 (Rotation) */
 	ROM_LOAD( "mast_rot", 0x000000, 0x200000, CRC(1f29b622) SHA1(aab6aafb98fa732266675daa63dc4c0d2084bcbd)  )
 
-	ROM_REGION( 0x080000, "gfx4", 0 )   /* 8x8x8 (Foreground) */
+	ROM_REGION( 0x080000, "tiles_fg", 0 )   /* 8x8x8 (Foreground) */
 	ROM_LOAD( "mast_front", 0x000000, 0x080000, CRC(a4717579) SHA1(cf28c0f19713ebf9f8fd5d55d654c1cd2e8cd73d)  )
 
 	ROM_REGION( 0x800000, "sub_sprite", 0 )   /* 8x8x8 (Sprites) */
 	ROM_LOAD32_WORD( "slav_spr1", 0x000002, 0x400000, CRC(3f8124b0) SHA1(c9ab89f559551d2298d28e107b2d44d312e53216) )
 	ROM_LOAD32_WORD( "slav_spr0", 0x000000, 0x400000, CRC(48a7f5b1) SHA1(4724856bde3cf975efc3be407b60693a69a39365) )
 
-	ROM_REGION( 0x200000, "gfx6", 0 )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x200000, "sub_tiles_bg", 0 )   /* 16x16x8 (Background) */
 	ROM_LOAD16_WORD( "slav_back", 0x000000, 0x200000, CRC(f0a28e32) SHA1(517b98dee6ec201bab02a3c81b0937ed462a626e) )
 
-	ROM_REGION( 0x200000, "gfx7", 0 )   /* 16x16x8 (Rotation) */
+	ROM_REGION( 0x200000, "sub_tiles_rot", 0 )   /* 16x16x8 (Rotation) */
 	ROM_LOAD( "slav_rot", 0x000000, 0x200000, CRC(0bab21f4) SHA1(afd3f32d7bb99b3f566b302fce11059ae8788715) )
 
-	ROM_REGION( 0x080000, "gfx8", 0 )   /* 8x8x8 (Foreground) */
+	ROM_REGION( 0x080000, "sub_tiles_fg", 0 )   /* 8x8x8 (Foreground) */
 	ROM_LOAD( "slav_front", 0x000000, 0x080000,  CRC(b65734a7) SHA1(80190e260ed32cb3355f0604722b85eb659483d0) )
 
-	ROM_REGION( 0x7000000, "ymz", 0 )   /* Samples */
+	ROM_REGION( 0x6400000, "ymz", ROMREGION_ERASEFF )   /* Samples */
 	ROM_LOAD( "sound00", 0x0000000, 0x0400000, CRC(8bafae71) SHA1(db74accd4bc1bfeb4a3341a0fd572b81287f1278)  ) // COMMON AREA
-	ROM_FILL(                0x0400000, 0x0c00000, 0xff )       // BANK AREA
-	ROM_LOAD( "sound01", 0x1000000, 0x0400000, CRC(eec0589b) SHA1(f54c1c7e7741100a1398ebd45aef4755171d9965)  ) // bank 0
-	ROM_LOAD( "sound02", 0x1400000, 0x0400000, CRC(564aa972) SHA1(b19e960fd79647e5bcca509982c9887decb92bc6)  ) // bank 0
-	ROM_LOAD( "sound03", 0x1800000, 0x0400000, CRC(940302d0) SHA1(b28c2bb1a9b8cea0b6963ffa5d3ac26d90b0bffc)  ) // bank 0
-	ROM_LOAD( "sound04", 0x1c00000, 0x0400000, CRC(766db7f8) SHA1(41cfcac2e8d4307f75c56d57431b841e6d64b23c)  ) // bank 1
-	ROM_LOAD( "sound05", 0x2000000, 0x0400000, CRC(3a3002f9) SHA1(27b24b8a34a0b919e051e81a10e87aa300b11d8f)  ) // bank 1
-	ROM_LOAD( "sound06", 0x2400000, 0x0400000, CRC(06b04df9) SHA1(4bfc7c05843b4533f238f5360230cb71d7a66d56)  ) // bank 1
-	ROM_LOAD( "sound07", 0x2800000, 0x0400000, CRC(da74305e) SHA1(9dfb744f36ac8b3661006921dc482e941711f389)  ) // bank 2
-	ROM_LOAD( "sound08", 0x2c00000, 0x0400000, CRC(b5a0aa48) SHA1(2deb2c1c97c259f5e79e9dc3cd8859548549a189)  ) // bank 2
-	ROM_LOAD( "sound09", 0x3000000, 0x0400000, CRC(0fd4a088) SHA1(5c1ea8a14dee7ee885ce0c86fb463741599db44d)  ) // bank 2
-	ROM_LOAD( "sound10", 0x3400000, 0x0400000, CRC(33c89e53) SHA1(7d216f5db6b30c9b05a9a77030498ff68ae6fbad)  ) // bank 3
-	ROM_LOAD( "sound11", 0x3800000, 0x0400000, CRC(f9256a3f) SHA1(a3ec0845497d349c97222a1f986c252c8ca781e7)  ) // bank 3
-	ROM_LOAD( "sound12", 0x3c00000, 0x0400000, CRC(b0a09f3e) SHA1(d2e37eb935d7ef7e887ff79a49bc11da11c31f3c)  ) // bank 3
-	ROM_LOAD( "sound13", 0x4000000, 0x0400000, CRC(d5cee673) SHA1(85194c73c43b69bccbcc895f147d5251bb039c2a)  ) // bank 4
-	ROM_LOAD( "sound14", 0x4400000, 0x0400000, CRC(b394aa8a) SHA1(68541d5d98e2d59d6a3096f0c10b74b6f5803722)  ) // bank 4
-	ROM_LOAD( "sound15", 0x4800000, 0x0400000, CRC(6c791501) SHA1(8c67f070651493d6f7a2ef7b8a5f9e12c0181f67)  ) // bank 4
-	ROM_LOAD( "sound16", 0x4c00000, 0x0400000, CRC(fe80159e) SHA1(b6a980d4f62dfeaa6f51a99518aa4d483fe338e5)  ) // bank 5
-	ROM_LOAD( "sound17", 0x5000000, 0x0400000, CRC(142c1159) SHA1(dfabbe69119c84040d6368561e93514ce7bb91db)  ) // bank 5
-	ROM_LOAD( "sound18", 0x5400000, 0x0400000, CRC(cc595d85) SHA1(5f725771d79e71d62b64bb18e2a51b839a6e4c7f)  ) // bank 5
-	ROM_LOAD( "sound19", 0x5800000, 0x0400000, CRC(82b085a3) SHA1(5a5f2ed90d659bbad710c23b9df2a7dbb3c9acfe)  ) // bank 6
-	ROM_LOAD( "sound20", 0x5c00000, 0x0400000, CRC(dd5e9680) SHA1(5a2826641ad75757ce4a583e0ea901d54d20ffca)  ) // bank 6
+	ROM_LOAD( "sound01", 0x0400000, 0x0400000, CRC(eec0589b) SHA1(f54c1c7e7741100a1398ebd45aef4755171d9965)  ) // bank 0
+	ROM_LOAD( "sound02", 0x0800000, 0x0400000, CRC(564aa972) SHA1(b19e960fd79647e5bcca509982c9887decb92bc6)  ) // bank 0
+	ROM_LOAD( "sound03", 0x0c00000, 0x0400000, CRC(940302d0) SHA1(b28c2bb1a9b8cea0b6963ffa5d3ac26d90b0bffc)  ) // bank 0
+	ROM_LOAD( "sound04", 0x1000000, 0x0400000, CRC(766db7f8) SHA1(41cfcac2e8d4307f75c56d57431b841e6d64b23c)  ) // bank 1
+	ROM_LOAD( "sound05", 0x1400000, 0x0400000, CRC(3a3002f9) SHA1(27b24b8a34a0b919e051e81a10e87aa300b11d8f)  ) // bank 1
+	ROM_LOAD( "sound06", 0x1800000, 0x0400000, CRC(06b04df9) SHA1(4bfc7c05843b4533f238f5360230cb71d7a66d56)  ) // bank 1
+	ROM_LOAD( "sound07", 0x1c00000, 0x0400000, CRC(da74305e) SHA1(9dfb744f36ac8b3661006921dc482e941711f389)  ) // bank 2
+	ROM_LOAD( "sound08", 0x2000000, 0x0400000, CRC(b5a0aa48) SHA1(2deb2c1c97c259f5e79e9dc3cd8859548549a189)  ) // bank 2
+	ROM_LOAD( "sound09", 0x2400000, 0x0400000, CRC(0fd4a088) SHA1(5c1ea8a14dee7ee885ce0c86fb463741599db44d)  ) // bank 2
+	ROM_LOAD( "sound10", 0x2800000, 0x0400000, CRC(33c89e53) SHA1(7d216f5db6b30c9b05a9a77030498ff68ae6fbad)  ) // bank 3
+	ROM_LOAD( "sound11", 0x2c00000, 0x0400000, CRC(f9256a3f) SHA1(a3ec0845497d349c97222a1f986c252c8ca781e7)  ) // bank 3
+	ROM_LOAD( "sound12", 0x3000000, 0x0400000, CRC(b0a09f3e) SHA1(d2e37eb935d7ef7e887ff79a49bc11da11c31f3c)  ) // bank 3
+	ROM_LOAD( "sound13", 0x3400000, 0x0400000, CRC(d5cee673) SHA1(85194c73c43b69bccbcc895f147d5251bb039c2a)  ) // bank 4
+	ROM_LOAD( "sound14", 0x3800000, 0x0400000, CRC(b394aa8a) SHA1(68541d5d98e2d59d6a3096f0c10b74b6f5803722)  ) // bank 4
+	ROM_LOAD( "sound15", 0x3c00000, 0x0400000, CRC(6c791501) SHA1(8c67f070651493d6f7a2ef7b8a5f9e12c0181f67)  ) // bank 4
+	ROM_LOAD( "sound16", 0x4000000, 0x0400000, CRC(fe80159e) SHA1(b6a980d4f62dfeaa6f51a99518aa4d483fe338e5)  ) // bank 5
+	ROM_LOAD( "sound17", 0x4400000, 0x0400000, CRC(142c1159) SHA1(dfabbe69119c84040d6368561e93514ce7bb91db)  ) // bank 5
+	ROM_LOAD( "sound18", 0x4800000, 0x0400000, CRC(cc595d85) SHA1(5f725771d79e71d62b64bb18e2a51b839a6e4c7f)  ) // bank 5
+	ROM_LOAD( "sound19", 0x4c00000, 0x0400000, CRC(82b085a3) SHA1(5a5f2ed90d659bbad710c23b9df2a7dbb3c9acfe)  ) // bank 6
+	ROM_LOAD( "sound20", 0x5000000, 0x0400000, CRC(dd5e9680) SHA1(5a2826641ad75757ce4a583e0ea901d54d20ffca)  ) // bank 6
 ROM_END
 
 
@@ -3116,17 +3103,17 @@ ROM_START( vjslap )
 	ROM_LOAD( "mr98053-13.ic11", 0x1800000, 0x400000, CRC(a38af3a1) SHA1(ce7b2d7518f9de050293f3b9a073a1cedbc444fa) )
 	ROM_LOAD( "mr98053-16.ic10", 0x1c00000, 0x400000, CRC(9c7f5964) SHA1(4e8d0a14c2459774204a8b24ea23a65520d3fc29) )
 
-	ROM_REGION( 0x080000, "gfx4", 0 )   /* 8x8x8 (Foreground) */
+	ROM_REGION( 0x080000, "tiles_fg", 0 )   /* 8x8x8 (Foreground) */
 	ROM_LOAD( "vj10_ver1.0.ic27", 0x000000, 0x080000, CRC(c143b7e4) SHA1(055699a18aa3529bb252dca391cf3f1e19f9ebe8) )
 
 	ROM_REGION( 0x800000, "sprite", 0 )   /* 8x8x8 (Sprites) */
 	ROM_LOAD32_WORD( "obj-o.ic40", 0x000002, 0x400000, CRC(eaa927f1) SHA1(84742aecc1f9e40c289c87319255001cb701949f)  )
 	ROM_LOAD32_WORD( "obj-e.ic41", 0x000000, 0x400000, CRC(a6c1e41b) SHA1(157af81a70604bee194c9b24f5b74774b3e7eff3)  )
 
-	ROM_REGION( 0x400000, "gfx2", 0 )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x400000, "tiles_bg", 0 )   /* 16x16x8 (Background) */
 	ROM_LOAD16_WORD( "bg.ic14", 0x000000, 0x200000, CRC(45f045ed) SHA1(196a41c71f3e579ff5c43ca75f5473a0597333b3) )
 
-	ROM_REGION( 0x400000, "gfx3", 0 )   /* 16x16x8 (Rotation) */
+	ROM_REGION( 0x400000, "tiles_rot", 0 )   /* 16x16x8 (Rotation) */
 	ROM_LOAD( "mr98053-04.ic36", 0x000000, 0x200000, CRC(4c69de30) SHA1(5f758498abb87f86f428193413c8e06bb4024725) )
 
 	ROM_REGION( 0x001000, "gal", ROMREGION_ERASE )  // ICT GAL
@@ -3178,17 +3165,17 @@ ROM_START( vjdash )
 	ROM_LOAD( "mr98053-13.ic11", 0x1800000, 0x400000, CRC(a38af3a1) SHA1(ce7b2d7518f9de050293f3b9a073a1cedbc444fa) )
 	ROM_LOAD( "mr98053-16.ic10", 0x1c00000, 0x400000, CRC(9c7f5964) SHA1(4e8d0a14c2459774204a8b24ea23a65520d3fc29) )
 
-	ROM_REGION( 0x080000, "gfx4", 0 )   /* 8x8x8 (Foreground) */
+	ROM_REGION( 0x080000, "tiles_fg", 0 )   /* 8x8x8 (Foreground) */
 	ROM_LOAD( "vjdash_ver1.0.ic27", 0x000000, 0x080000, CRC(f3cff858) SHA1(9277e5fb3494f7afb7f3911792d1c68b2b1b147e) )
 
 	ROM_REGION( 0x800000, "sprite", 0 )   /* 8x8x8 (Sprites) */
 	ROM_LOAD32_WORD( "vjdash_8.ic40", 0x000002, 0x400000, CRC(798bc4a4) SHA1(5aca6495e48a1d72bf2993ff26f0462d78acc88b) )
 	ROM_LOAD32_WORD( "vjdash_9.ic41", 0x000000, 0x400000, CRC(f2489f68) SHA1(d98f08dd0fa3448e266afaf6971aa5b39686d4f4) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x400000, "tiles_bg", 0 )   /* 16x16x8 (Background) */
 	ROM_LOAD16_WORD( "bg.ic14", 0x000000, 0x200000, CRC(45f045ed) SHA1(196a41c71f3e579ff5c43ca75f5473a0597333b3) )
 
-	ROM_REGION( 0x400000, "gfx3", 0 )   /* 16x16x8 (Rotation) */
+	ROM_REGION( 0x400000, "tiles_rot", 0 )   /* 16x16x8 (Rotation) */
 	ROM_LOAD( "mr98053-04.ic36", 0x000000, 0x200000, CRC(4c69de30) SHA1(5f758498abb87f86f428193413c8e06bb4024725) )
 
 	ROM_REGION( 0x001000, "gal", 0 )  // ICT GAL
@@ -3242,17 +3229,17 @@ ROM_START( vjdasha )
 	ROM_LOAD( "mr98053-13.ic11", 0x1800000, 0x400000, CRC(a38af3a1) SHA1(ce7b2d7518f9de050293f3b9a073a1cedbc444fa) BAD_DUMP )
 	ROM_LOAD( "mr98053-16.ic10", 0x1c00000, 0x400000, CRC(9c7f5964) SHA1(4e8d0a14c2459774204a8b24ea23a65520d3fc29) BAD_DUMP )
 
-	ROM_REGION( 0x080000, "gfx4", 0 )   /* 8x8x8 (Foreground) */
+	ROM_REGION( 0x080000, "tiles_fg", 0 )   /* 8x8x8 (Foreground) */
 	ROM_LOAD( "vjdash_ver1.0.ic27", 0x000000, 0x080000, CRC(f3cff858) SHA1(9277e5fb3494f7afb7f3911792d1c68b2b1b147e) )
 
 	ROM_REGION( 0x800000, "sprite", 0 )   /* 8x8x8 (Sprites) */
 	ROM_LOAD32_WORD( "vjdash_8.ic40", 0x000002, 0x400000, CRC(798bc4a4) SHA1(5aca6495e48a1d72bf2993ff26f0462d78acc88b) BAD_DUMP ) // From vjdash set, may be different on a real Dash Ver 1.2 board
 	ROM_LOAD32_WORD( "vjdash_9.ic41", 0x000000, 0x400000, CRC(f2489f68) SHA1(d98f08dd0fa3448e266afaf6971aa5b39686d4f4) BAD_DUMP )
 
-	ROM_REGION( 0x400000, "gfx2", 0 )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x400000, "tiles_bg", 0 )   /* 16x16x8 (Background) */
 	ROM_LOAD16_WORD( "mr98053-03.ic14", 0x000000, 0x200000, CRC(0bd32084) SHA1(2fcac3019ebedc54b83b08f527aa968ce6d48617) )
 
-	ROM_REGION( 0x400000, "gfx3", 0 )   /* 16x16x8 (Rotation) */
+	ROM_REGION( 0x400000, "tiles_rot", 0 )   /* 16x16x8 (Rotation) */
 	ROM_LOAD( "mr98053-04.ic36", 0x000000, 0x200000, CRC(4c69de30) SHA1(5f758498abb87f86f428193413c8e06bb4024725) )
 
 	ROM_REGION( 0x001000, "gal", 0 )  // ICT GAL
@@ -3300,15 +3287,15 @@ ROM_START( stepstag )
 	ROM_LOAD( "s.s.s._vj-98348_26_pr99021-01", 0x800000, 0x400000, BAD_DUMP CRC(fefb3777) SHA1(df624e105ab1dea52317e318ad29caa02b900788) )  // VERTICAL
 	ROM_LOAD( "s.s.s._vj-98348_3_pr99021-01",  0x800000, 0x400000, CRC(e0fbc6f1) SHA1(7ca4507702f3f81bb9de3f9b5d270d379e439633) )           // VERTICAL
 
-	ROM_REGION( 0x400000, "gfx4", 0 ) // foreground tiles
+	ROM_REGION( 0x400000, "tiles_fg", 0 ) // foreground tiles
 	ROM_LOAD( "vjdash_ver1.0.ic27", 0x000000, 0x080000, BAD_DUMP CRC(f3cff858) SHA1(9277e5fb3494f7afb7f3911792d1c68b2b1b147e) )
 
 	ROM_REGION( 0x400000, "sprite", ROMREGION_ERASE )   /* 8x8x8 (Sprites) */
 
-	ROM_REGION( 0x400000, "gfx2", ROMREGION_ERASE )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x400000, "tiles_bg", ROMREGION_ERASE )   /* 16x16x8 (Background) */
 	ROM_LOAD16_WORD( "stepstag_scroll", 0x000000, 0x400000, NO_DUMP )
 
-	ROM_REGION( 0x400000, "gfx3", ROMREGION_ERASE )   /* 16x16x8 (Rotation) */
+	ROM_REGION( 0x400000, "tiles_rot", ROMREGION_ERASE )   /* 16x16x8 (Rotation) */
 	ROM_LOAD( "stepstag_rott", 0x000000, 0x400000, NO_DUMP )
 
 	DISK_REGION( "jaleco_vj_pc:pci:07.1:ide1:0:hdd" )
@@ -3352,14 +3339,14 @@ ROM_START( step3 )
 	ROM_LOAD( "mr9930-03.ic28",        0x0800000, 0x400000, CRC(9a5d070f) SHA1(b4668b4f299033140a2c56499cc2712ba111cb57) )  // 8x8 VERTICAL
 	ROM_LOAD( "vj98348_step3_25_v1.1", 0x0c00000, 0x400000, CRC(dec612df) SHA1(acb86bb90c1cc61c7db3e022c69a5ff0611ffbae) )  // 8x8 VERTICAL
 
-	ROM_REGION( 0x400000, "gfx4", 0 ) // foreground tiles
+	ROM_REGION( 0x400000, "tiles_fg", 0 ) // foreground tiles
 	ROM_LOAD( "vjdash_ver1.0.ic27", 0x000000, 0x080000, BAD_DUMP CRC(f3cff858) SHA1(9277e5fb3494f7afb7f3911792d1c68b2b1b147e) )
 
 	ROM_REGION( 0x400000, "sprite", ROMREGION_ERASE )   /* 8x8x8 (Sprites) */
 
-	ROM_REGION( 0x400000, "gfx2", ROMREGION_ERASE )   /* 16x16x8 (Background) */
+	ROM_REGION( 0x400000, "tiles_bg", ROMREGION_ERASE )   /* 16x16x8 (Background) */
 
-	ROM_REGION( 0x400000, "gfx3", ROMREGION_ERASE )   /* 16x16x8 (Rotation) */
+	ROM_REGION( 0x400000, "tiles_rot", ROMREGION_ERASE )   /* 16x16x8 (Rotation) */
 
 	DISK_REGION( "jaleco_vj_pc:pci:07.1:ide1:0:hdd" )
 	DISK_IMAGE( "step3", 0, SHA1(926a32998c837f7ba45d07db243c43c1f9d46d6a) )
@@ -3375,31 +3362,31 @@ ROM_END
 ***************************************************************************/
 
 //    YEAR, NAME,      PARENT,   MACHINE,  INPUT,     STATE,          INIT,         MONITOR, COMPANY,                       FULLNAME,                               FLAGS
-GAME( 1997, tetrisp2,  0,        tetrisp2, tetrisp2,  tetrisp2_state, empty_init,   ROT0,    "Jaleco / The Tetris Company", "Tetris Plus 2 (World, V2.8)",          MACHINE_SUPPORTS_SAVE )
-GAME( 1997, tetrisp2a, tetrisp2, tetrisp2, tetrisp2,  tetrisp2_state, empty_init,   ROT0,    "Jaleco / The Tetris Company", "Tetris Plus 2 (World, V2.7)",          MACHINE_SUPPORTS_SAVE )
-GAME( 1997, tetrisp2j, tetrisp2, tetrisp2, tetrisp2j, tetrisp2_state, empty_init,   ROT0,    "Jaleco / The Tetris Company", "Tetris Plus 2 (Japan, V2.2)",          MACHINE_SUPPORTS_SAVE )
-GAME( 1997, tetrisp2ja,tetrisp2, tetrisp2, tetrisp2j, tetrisp2_state, empty_init,   ROT0,    "Jaleco / The Tetris Company", "Tetris Plus 2 (Japan, V2.1)",          MACHINE_SUPPORTS_SAVE )
+GAME( 1997, tetrisp2,  0,        tetrisp2, tetrisp2,  tetrisp2_state, empty_init,   ROT0,                      "Jaleco / The Tetris Company", "Tetris Plus 2 (World, V2.8)",               MACHINE_SUPPORTS_SAVE )
+GAME( 1997, tetrisp2a, tetrisp2, tetrisp2, tetrisp2,  tetrisp2_state, empty_init,   ROT0,                      "Jaleco / The Tetris Company", "Tetris Plus 2 (World, V2.7)",               MACHINE_SUPPORTS_SAVE )
+GAME( 1997, tetrisp2j, tetrisp2, tetrisp2, tetrisp2j, tetrisp2_state, empty_init,   ROT0,                      "Jaleco / The Tetris Company", "Tetris Plus 2 (Japan, V2.2)",               MACHINE_SUPPORTS_SAVE )
+GAME( 1997, tetrisp2ja,tetrisp2, tetrisp2, tetrisp2j, tetrisp2_state, empty_init,   ROT0,                      "Jaleco / The Tetris Company", "Tetris Plus 2 (Japan, V2.1)",               MACHINE_SUPPORTS_SAVE )
 
-GAME( 1997, nndmseal,  0,        nndmseal, nndmseal,  nndmseal_state, init_rockn,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco", "Nandemo Seal Iinkai (ver 1.3)",             MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
-GAME( 1997, nndmseal11,nndmseal, nndmseal, nndmseal,  nndmseal_state, init_rockn,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco", "Nandemo Seal Iinkai (ver 1.1)",             MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
-GAME( 1997, nndmseala, nndmseal, nndmseal, nndmseal,  nndmseal_state, init_rockn,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco", "Nandemo Seal Iinkai (Astro Boy ver. 1.0?)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // version guessed
-GAME( 1997, nndmsealb, nndmseal, nndmseal, nndmseal,  nndmseal_state, init_rockn,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco", "Nandemo Seal Iinkai (Astro Boy ver. 1.1)",  MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // appears to have one more mode than the one above, ver taken from PRG ROM labels
-GAME( 1997, nndmsealc, nndmseal, nndmseal, nndmseal,  nndmseal_state, init_rockn,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco", "Nandemo Seal Iinkai (alternate ver 1.0)",   MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // only shows Jaleco copyright even though I'Max is in strings in ROMs. Ver taken from PRG ROM labels
+GAME( 1997, nndmseal,  0,        nndmseal, nndmseal,  nndmseal_state, empty_init,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco",              "Nandemo Seal Iinkai (ver 1.3)",             MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
+GAME( 1997, nndmseal11,nndmseal, nndmseal, nndmseal,  nndmseal_state, empty_init,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco",              "Nandemo Seal Iinkai (ver 1.1)",             MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
+GAME( 1997, nndmseala, nndmseal, nndmseal, nndmseal,  nndmseal_state, empty_init,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco",              "Nandemo Seal Iinkai (Astro Boy ver. 1.0?)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // version guessed
+GAME( 1997, nndmsealb, nndmseal, nndmseal, nndmseal,  nndmseal_state, empty_init,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco",              "Nandemo Seal Iinkai (Astro Boy ver. 1.1)",  MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // appears to have one more mode than the one above, ver taken from PRG ROM labels
+GAME( 1997, nndmsealc, nndmseal, nndmseal, nndmseal,  nndmseal_state, empty_init,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco",              "Nandemo Seal Iinkai (alternate ver 1.0)",   MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // only shows Jaleco copyright even though I'Max is in strings in ROMs. Ver taken from PRG ROM labels
 
-GAME( 1999, rockn,     0,        rockn,    rockn,     tetrisp2_state, init_rockn,   ROT270, "Jaleco",         "Rock'n Tread (Japan)",            MACHINE_SUPPORTS_SAVE )
-GAME( 1999, rockna,    rockn,    rockn,    rockn,     tetrisp2_state, init_rockn1,  ROT270, "Jaleco",         "Rock'n Tread (Japan, alternate)", MACHINE_SUPPORTS_SAVE )
-GAME( 1999, rockn2,    0,        rockn2,   rockn,     tetrisp2_state, init_rockn2,  ROT270, "Jaleco",         "Rock'n Tread 2 (Japan)",          MACHINE_SUPPORTS_SAVE )
-GAME( 1999, rocknms,   0,        rocknms,  rocknms,   rocknms_state,  init_rocknms, ROT0,   "Jaleco",         "Rock'n MegaSession (Japan)",      MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1999, rockn3,    0,        rockn2,   rockn,     tetrisp2_state, init_rockn3,  ROT270, "Jaleco",         "Rock'n 3 (Japan)",                MACHINE_SUPPORTS_SAVE )
-GAME( 2000, rockn4,    0,        rockn2,   rockn,     tetrisp2_state, init_rockn3,  ROT270, "Jaleco / PCCWJ", "Rock'n 4 (Japan, prototype)",     MACHINE_SUPPORTS_SAVE )
+GAME( 1999, rockn,     0,        rockn,    rockn,     rockn_state,    init_rockn,   ROT270,                    "Jaleco",                      "Rock'n Tread (Japan)",                      MACHINE_SUPPORTS_SAVE )
+GAME( 1999, rockna,    rockn,    rockn,    rockn,     rockn_state,    init_rockn,   ROT270,                    "Jaleco",                      "Rock'n Tread (Japan, alternate)",           MACHINE_SUPPORTS_SAVE )
+GAME( 1999, rockn2,    0,        rockn2,   rockn,     rockn_state,    init_rockn2,  ROT270,                    "Jaleco",                      "Rock'n Tread 2 (Japan)",                    MACHINE_SUPPORTS_SAVE )
+GAME( 1999, rocknms,   0,        rocknms,  rocknms,   rocknms_state,  init_rocknms, ROT0,                      "Jaleco",                      "Rock'n MegaSession (Japan)",                MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1999, rockn3,    0,        rockn2,   rockn,     rockn_state,    init_rockn3,  ROT270,                    "Jaleco",                      "Rock'n 3 (Japan)",                          MACHINE_SUPPORTS_SAVE )
+GAME( 2000, rockn4,    0,        rockn2,   rockn,     rockn_state,    init_rockn3,  ROT270,                    "Jaleco / PCCWJ",              "Rock'n 4 (Japan, prototype)",               MACHINE_SUPPORTS_SAVE )
 
-GAME( 1999, vjslap,    0,        vjdash,   vjdash,    stepstag_state, empty_init,   ROT0,   "Jaleco",         "VJ: Visual & Music Slap",         MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-GAME( 1999, vjdash,    vjslap,   vjdash,   vjdash,    stepstag_state, empty_init,   ROT0,   "Jaleco",         "VJ Dash (ver 1.0)",               MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-GAME( 1999, vjdasha,   vjslap,   vjdash,   vjdash,    stepstag_state, empty_init,   ROT0,   "Jaleco",         "VJ Dash (Ver 1.2)",               MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+GAME( 1999, vjslap,    0,        vjdash,   vjdash,    stepstag_state, empty_init,   ROT0,                      "Jaleco",                      "VJ: Visual & Music Slap",                   MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+GAME( 1999, vjdash,    vjslap,   vjdash,   vjdash,    stepstag_state, empty_init,   ROT0,                      "Jaleco",                      "VJ Dash (ver 1.0)",                         MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+GAME( 1999, vjdasha,   vjslap,   vjdash,   vjdash,    stepstag_state, empty_init,   ROT0,                      "Jaleco",                      "VJ Dash (Ver 1.2)",                         MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 
 // Undumped:
 // - Stepping Stage <- the original Game
 // - Stepping Stage 2 Supreme
 // Dumped (partially):
-GAME( 1999, stepstag,  0,        stepstag, stepstag,  stepstag_state, empty_init,   ROT0,   "Jaleco",         "Stepping Stage Special",         MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-GAME( 1999, step3,     0,        stepstag, stepstag,  stepstag_state, empty_init,   ROT0,   "Jaleco",         "Stepping 3 Superior",            MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+GAME( 1999, stepstag,  0,        stepstag, stepstag,  stepstag_state, empty_init,   ROT0,                      "Jaleco",                      "Stepping Stage Special",                    MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+GAME( 1999, step3,     0,        stepstag, stepstag,  stepstag_state, empty_init,   ROT0,                      "Jaleco",                      "Stepping 3 Superior",                       MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/jaleco/tetrisp2.h
+++ b/src/mame/jaleco/tetrisp2.h
@@ -19,14 +19,13 @@
 class tetrisp2_state : public driver_device
 {
 public:
-	tetrisp2_state(const machine_config &mconfig, device_type type, const char *tag) :
-		driver_device(mconfig, type, tag)
+	tetrisp2_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
 		, m_sysctrl(*this, "sysctrl")
 		, m_sprite(*this, "sprite")
 		, m_screen(*this, "screen")
 		, m_spriteram(*this, "spriteram")
-		, m_spriteram2(*this, "spriteram2")
 		, m_vram_fg(*this, "vram_fg")
 		, m_vram_bg(*this, "vram_bg")
 		, m_vram_rot(*this, "vram_rot")
@@ -35,26 +34,19 @@ public:
 		, m_scroll_bg(*this, "scroll_bg")
 		, m_rotregs(*this, "rotregs")
 		, m_gfxdecode(*this, "gfxdecode")
-		, m_sub_gfxdecode(*this, "sub_gfxdecode")
 		, m_palette(*this, "palette")
 		, m_paletteram(*this, "paletteram")
+		, m_io_system(*this, "SYSTEM")
 		, m_leds(*this, "led%u", 0U)
 	{ }
 
-	void rockn2(machine_config &config);
 	void tetrisp2(machine_config &config);
-	void nndmseal(machine_config &config);
-	void rockn(machine_config &config);
 
-	void init_rockn2();
-	void init_rockn1();
-	void init_rockn();
-	void init_rockn3();
-
-	TILE_GET_INFO_MEMBER(get_tile_info_bg);
-	TILE_GET_INFO_MEMBER(get_tile_info_rot);
 
 protected:
+	virtual void machine_start() override { m_leds.resolve(); }
+	virtual void video_start() override;
+
 	void setup_main_sysctrl(machine_config &config, const XTAL clock);
 	void setup_main_sprite(machine_config &config, const XTAL clock);
 	void flipscreen_w(int state);
@@ -63,41 +55,24 @@ protected:
 	void field_irq_w(int state);
 	void sound_reset_line_w(int state);
 
-	u16 rockn_adpcmbank_r();
-	void rockn_adpcmbank_w(u16 data);
-	void rockn2_adpcmbank_w(u16 data);
-	u16 rockn_soundvolume_r();
-	void rockn_soundvolume_w(u16 data);
-	void nndmseal_sound_bank_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	u16 tetrisp2_ip_1_word_r();
-	u16 rockn_nvram_r(offs_t offset);
 	void tetrisp2_coincounter_w(u16 data);
-	void nndmseal_coincounter_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void nndmseal_b20000_w(u16 data);
 	u16 tetrisp2_nvram_r(offs_t offset);
-	void tetrisp2_nvram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void tetrisp2_palette_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void tetrisp2_priority_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	u16 tetrisp2_priority_r(offs_t offset);
-	void tetrisp2_vram_bg_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void tetrisp2_vram_fg_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void tetrisp2_vram_rot_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void nvram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void palette_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void priority_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 priority_r(offs_t offset);
+	void vram_bg_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void vram_fg_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void vram_rot_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
 	TILE_GET_INFO_MEMBER(get_tile_info_fg);
+	TILE_GET_INFO_MEMBER(get_tile_info_bg);
+	TILE_GET_INFO_MEMBER(get_tile_info_rot);
 
-	DECLARE_VIDEO_START(tetrisp2);
-	DECLARE_VIDEO_START(nndmseal);
-	DECLARE_VIDEO_START(rockntread);
 	u32 screen_update_tetrisp2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	u32 screen_update_rockntread(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void init_rockn_timer();
 
-	void nndmseal_map(address_map &map) ATTR_COLD;
-	void rockn1_map(address_map &map) ATTR_COLD;
-	void rockn2_map(address_map &map) ATTR_COLD;
 	void tetrisp2_map(address_map &map) ATTR_COLD;
-
-	virtual void machine_start() override { m_leds.resolve(); }
 
 	required_device<cpu_device> m_maincpu;
 	required_device<jaleco_ms32_sysctrl_device> m_sysctrl;
@@ -105,7 +80,6 @@ protected:
 	required_device<screen_device> m_screen;
 
 	required_shared_ptr<u16> m_spriteram;
-	optional_shared_ptr<u16> m_spriteram2;
 
 	required_shared_ptr<u16> m_vram_fg;
 	required_shared_ptr<u16> m_vram_bg;
@@ -116,107 +90,177 @@ protected:
 	required_shared_ptr<u16> m_rotregs;
 	std::unique_ptr<u8[]> m_priority;
 	required_device<gfxdecode_device> m_gfxdecode;
-	optional_device<gfxdecode_device> m_sub_gfxdecode;
 	required_device<palette_device> m_palette;
 	required_shared_ptr<u16> m_paletteram;
+
+	optional_ioport m_io_system;
 	output_finder<45> m_leds;
 
-	u16 m_rockn_protectdata = 0;
-	u16 m_rockn_adpcmbank = 0;
-	u16 m_rockn_soundvolume = 0;
-	int m_rot_ofsx = 0, m_rot_ofsy = 0;
-	int m_bank_lo = 0;
-	int m_bank_hi = 0;
+	s32 m_rot_ofsx = 0, m_rot_ofsy = 0;
 
 	tilemap_t *m_tilemap_bg = nullptr;
 	tilemap_t *m_tilemap_fg = nullptr;
 	tilemap_t *m_tilemap_rot = nullptr;
 };
 
+// With camera, printer, OKI MSM6295 sound subsystem
 class nndmseal_state : public tetrisp2_state
 {
 public:
-	using tetrisp2_state::tetrisp2_state;
 	static constexpr feature_type unemulated_features() { return feature::CAMERA | feature::PRINTER; }
+
+	nndmseal_state(const machine_config &mconfig, device_type type, const char *tag)
+		: tetrisp2_state(mconfig, type, tag)
+		, m_okibank(*this, "okibank%u", 0U)
+	{ }
+
+	void nndmseal(machine_config &config);
+
+protected:
+	virtual void machine_start() override;
+	virtual void video_start() override;
+
+private:
+	void nndmseal_sound_bank_w(u8 data);
+	void nndmseal_coincounter_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void nndmseal_b20000_w(u16 data);
+
+	void nndmseal_map(address_map &map) ATTR_COLD;
+	void nndmseal_oki_map(address_map &map) ATTR_COLD;
+
+	required_memory_bank_array<2> m_okibank;
+
+	u8 m_bank_lo;
+	u8 m_bank_hi;
 };
 
-class rocknms_state : public tetrisp2_state
+// with ADPCM bankswitching and alternative layer size
+class rockn_state : public tetrisp2_state
+{
+public:
+	rockn_state(const machine_config &mconfig, device_type type, const char *tag)
+		: tetrisp2_state(mconfig, type, tag)
+		, m_spriteram2(*this, "spriteram2")
+		, m_ymzbank(*this, "ymzbank_%u", 0U)
+	{ }
+
+	void rockn(machine_config &config);
+	void rockn2(machine_config &config);
+
+	void init_rockn();
+	void init_rockn2();
+	void init_rockn3();
+
+protected:
+	virtual void machine_start() override;
+	virtual void video_start() override;
+
+	u16 rockn_adpcmbank_r();
+	void rockn_adpcmbank_w(u16 data);
+	void rockn2_adpcmbank_w(u16 data);
+	u16 rockn_soundvolume_r();
+	void rockn_soundvolume_w(u16 data);
+	u16 rockn_nvram_r(offs_t offset);
+
+	u32 screen_update_rockntread(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+	void rockn1_map(address_map &map) ATTR_COLD;
+	void rockn1_ymz_map(address_map &map) ATTR_COLD;
+	void rockn2_map(address_map &map) ATTR_COLD;
+	void rockn2_ymz_map(address_map &map) ATTR_COLD;
+
+	optional_shared_ptr<u16> m_spriteram2;
+
+	optional_memory_bank_array<3> m_ymzbank;
+
+	u16 m_rockn_protectdata = 0;
+	u16 m_rockn_adpcmbank = 0;
+	u16 m_rockn_soundvolume = 0;
+};
+
+class rocknms_state : public rockn_state
 {
 public:
 	rocknms_state(const machine_config &mconfig, device_type type, const char *tag)
-		: tetrisp2_state(mconfig, type, tag)
+		: rockn_state(mconfig, type, tag)
 		, m_subcpu(*this, "sub")
 		, m_sub_sysctrl(*this, "sub_sysctrl")
 		, m_sub_screen(*this, "sub_screen")
-		, m_rocknms_sub_sprite(*this, "sub_sprite")
-		, m_rocknms_sub_priority(*this, "sub_priority")
-		, m_rocknms_sub_vram_rot(*this, "sub_vram_rot")
-		, m_rocknms_sub_vram_fg(*this, "sub_vram_fg")
-		, m_rocknms_sub_vram_bg(*this, "sub_vram_bg")
-		, m_rocknms_sub_scroll_fg(*this, "sub_scroll_fg")
-		, m_rocknms_sub_scroll_bg(*this, "sub_scroll_bg")
-		, m_rocknms_sub_rotregs(*this, "sub_rotregs")
+		, m_sub_sprite(*this, "sub_sprite")
+		, m_sub_priority(*this, "sub_priority")
+		, m_sub_vram_rot(*this, "sub_vram_rot")
+		, m_sub_vram_fg(*this, "sub_vram_fg")
+		, m_sub_vram_bg(*this, "sub_vram_bg")
+		, m_sub_scroll_fg(*this, "sub_scroll_fg")
+		, m_sub_scroll_bg(*this, "sub_scroll_bg")
+		, m_sub_rotregs(*this, "sub_rotregs")
 		, m_sub_palette(*this, "sub_palette")
 		, m_sub_paletteram(*this, "sub_paletteram")
+		, m_sub_gfxdecode(*this, "sub_gfxdecode")
 	{ }
 
 	void rocknms(machine_config &config);
 	void init_rocknms();
-	ioport_value rocknms_main2sub_status_r();
+	ioport_value main2sub_status_r();
+
+protected:
+	virtual void machine_start() override;
+	virtual void video_start() override;
 
 private:
 	required_device<cpu_device> m_subcpu;
 	required_device<jaleco_ms32_sysctrl_device> m_sub_sysctrl;
 	required_device<screen_device> m_sub_screen;
-	required_device<ms32_sprite_device> m_rocknms_sub_sprite;
-	required_shared_ptr<u16> m_rocknms_sub_priority;
-	required_shared_ptr<u16> m_rocknms_sub_vram_rot;
-	required_shared_ptr<u16> m_rocknms_sub_vram_fg;
-	required_shared_ptr<u16> m_rocknms_sub_vram_bg;
-	required_shared_ptr<u16> m_rocknms_sub_scroll_fg;
-	required_shared_ptr<u16> m_rocknms_sub_scroll_bg;
-	required_shared_ptr<u16> m_rocknms_sub_rotregs;
+	required_device<ms32_sprite_device> m_sub_sprite;
+	required_shared_ptr<u16> m_sub_priority;
+	required_shared_ptr<u16> m_sub_vram_rot;
+	required_shared_ptr<u16> m_sub_vram_fg;
+	required_shared_ptr<u16> m_sub_vram_bg;
+	required_shared_ptr<u16> m_sub_scroll_fg;
+	required_shared_ptr<u16> m_sub_scroll_bg;
+	required_shared_ptr<u16> m_sub_rotregs;
 	required_device<palette_device> m_sub_palette;
 	required_shared_ptr<u16> m_sub_paletteram;
+	required_device<gfxdecode_device> m_sub_gfxdecode;
 
-	u32 screen_update_rocknms_left(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	u32 screen_update_rocknms_right(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	u32 screen_update_top(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	u32 screen_update_bottom(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void rocknms_main_map(address_map &map) ATTR_COLD;
 	void rocknms_sub_map(address_map &map) ATTR_COLD;
 
-	u16 rocknms_main2sub_r();
-	void rocknms_main2sub_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void rocknms_sub2main_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void rocknms_sub_palette_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void rocknms_sub_priority_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void rocknms_sub_vram_bg_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void rocknms_sub_vram_fg_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void rocknms_sub_vram_rot_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	DECLARE_VIDEO_START(rocknms);
+	u16 main2sub_r();
+	void main2sub_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void sub2main_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void sub_palette_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void sub_priority_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void sub_vram_bg_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void sub_vram_fg_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void sub_vram_rot_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
-	TILE_GET_INFO_MEMBER(get_tile_info_rocknms_sub_bg);
-	TILE_GET_INFO_MEMBER(get_tile_info_rocknms_sub_fg);
-	TILE_GET_INFO_MEMBER(get_tile_info_rocknms_sub_rot);
-
-	u16 m_rocknms_main2sub = 0;
-	u16 m_rocknms_sub2main = 0;
-
-	tilemap_t *m_tilemap_sub_bg = nullptr;
-	tilemap_t *m_tilemap_sub_fg = nullptr;
-	tilemap_t *m_tilemap_sub_rot = nullptr;
+	TILE_GET_INFO_MEMBER(get_tile_info_sub_bg);
+	TILE_GET_INFO_MEMBER(get_tile_info_sub_fg);
+	TILE_GET_INFO_MEMBER(get_tile_info_sub_rot);
 
 	void sub_flipscreen_w(int state);
 	void sub_timer_irq_w(int state);
 	void sub_vblank_irq_w(int state);
 	void sub_field_irq_w(int state);
 	void sub_sound_reset_line_w(int state);
+
+	u16 m_main2sub = 0;
+	u16 m_sub2main = 0;
+
+	tilemap_t *m_tilemap_sub_bg = nullptr;
+	tilemap_t *m_tilemap_sub_fg = nullptr;
+	tilemap_t *m_tilemap_sub_rot = nullptr;
+
 };
 
-class stepstag_state : public tetrisp2_state
+class stepstag_state : public rockn_state
 {
 public:
 	stepstag_state(const machine_config &mconfig, device_type type, const char *tag) :
-		tetrisp2_state(mconfig, type, tag)
+		rockn_state(mconfig, type, tag)
 		, m_subcpu(*this, "sub")
 		, m_vj_sprite_l(*this, "sprite_l")
 		, m_vj_sprite_m(*this, "sprite_m")
@@ -233,6 +277,7 @@ public:
 		, m_jaleco_vj_pc(*this, "jaleco_vj_pc")
 		, m_soundvr(*this, "SOUND_VR%u", 1)
 		, m_rscreen(*this, "rscreen")
+		, m_io_coins(*this, "COINS")
 	{ }
 
 	void stepstag(machine_config &config);
@@ -246,8 +291,8 @@ protected:
 
 private:
 	u16 stepstag_coins_r();
-	u16 vj_upload_idx = 0;
-	bool vj_upload_fini = false;
+	u16 m_vj_upload_idx = 0;
+	bool m_vj_upload_fini = false;
 	void stepstag_b00000_w(u16 data);
 	void stepstag_b20000_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	u16 stepstag_sprite_status_status_r();
@@ -256,9 +301,9 @@ private:
 	void stepstag_neon_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void stepstag_step_leds_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void stepstag_button_leds_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void stepstag_palette_left_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void stepstag_palette_mid_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void stepstag_palette_right_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void palette_left_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void palette_mid_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void palette_right_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
 	void stepstag_spriteram1_updated_w(u16 data);
 	void stepstag_spriteram2_updated_w(u16 data);
@@ -303,6 +348,8 @@ private:
 	required_device<jaleco_vj_pc_device> m_jaleco_vj_pc;
 	optional_ioport_array<2> m_soundvr;
 	required_device<screen_device> m_rscreen;
+
+	required_ioport m_io_coins;
 
 	std::unique_ptr<uint16_t[]> m_spriteram1_data;
 	std::unique_ptr<uint16_t[]> m_spriteram2_data;

--- a/src/mame/jaleco/tetrisp2.h
+++ b/src/mame/jaleco/tetrisp2.h
@@ -40,15 +40,15 @@ public:
 		, m_leds(*this, "led%u", 0U)
 	{ }
 
-	void tetrisp2(machine_config &config);
-
+	void tetrisp2(machine_config &config) ATTR_COLD;
 
 protected:
-	virtual void machine_start() override { m_leds.resolve(); }
-	virtual void video_start() override;
+	virtual void machine_start() override ATTR_COLD { m_leds.resolve(); }
+	virtual void video_start() override ATTR_COLD;
 
-	void setup_main_sysctrl(machine_config &config, const XTAL clock);
-	void setup_main_sprite(machine_config &config, const XTAL clock);
+	void setup_main_sysctrl(machine_config &config, const XTAL clock) ATTR_COLD;
+	void setup_main_sprite(machine_config &config, const XTAL clock) ATTR_COLD;
+
 	void flipscreen_w(int state);
 	void timer_irq_w(int state);
 	void vblank_irq_w(int state);
@@ -114,11 +114,11 @@ public:
 		, m_okibank(*this, "okibank%u", 0U)
 	{ }
 
-	void nndmseal(machine_config &config);
+	void nndmseal(machine_config &config) ATTR_COLD;
 
 protected:
-	virtual void machine_start() override;
-	virtual void video_start() override;
+	virtual void machine_start() override ATTR_COLD;
+	virtual void video_start() override ATTR_COLD;
 
 private:
 	void nndmseal_sound_bank_w(u8 data);
@@ -144,16 +144,16 @@ public:
 		, m_ymzbank(*this, "ymzbank_%u", 0U)
 	{ }
 
-	void rockn(machine_config &config);
-	void rockn2(machine_config &config);
+	void rockn(machine_config &config) ATTR_COLD;
+	void rockn2(machine_config &config) ATTR_COLD;
 
-	void init_rockn();
-	void init_rockn2();
-	void init_rockn3();
+	void init_rockn() ATTR_COLD;
+	void init_rockn2() ATTR_COLD;
+	void init_rockn3() ATTR_COLD;
 
 protected:
-	virtual void machine_start() override;
-	virtual void video_start() override;
+	virtual void machine_start() override ATTR_COLD;
+	virtual void video_start() override ATTR_COLD;
 
 	u16 rockn_adpcmbank_r();
 	void rockn_adpcmbank_w(u16 data);
@@ -199,13 +199,15 @@ public:
 		, m_sub_gfxdecode(*this, "sub_gfxdecode")
 	{ }
 
-	void rocknms(machine_config &config);
-	void init_rocknms();
+	void rocknms(machine_config &config) ATTR_COLD;
+
 	ioport_value main2sub_status_r();
 
+	void init_rocknms() ATTR_COLD;
+
 protected:
-	virtual void machine_start() override;
-	virtual void video_start() override;
+	virtual void machine_start() override ATTR_COLD;
+	virtual void video_start() override ATTR_COLD;
 
 private:
 	required_device<cpu_device> m_subcpu;
@@ -225,6 +227,7 @@ private:
 
 	u32 screen_update_top(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	u32 screen_update_bottom(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+
 	void rocknms_main_map(address_map &map) ATTR_COLD;
 	void rocknms_sub_map(address_map &map) ATTR_COLD;
 
@@ -253,14 +256,13 @@ private:
 	tilemap_t *m_tilemap_sub_bg = nullptr;
 	tilemap_t *m_tilemap_sub_fg = nullptr;
 	tilemap_t *m_tilemap_sub_rot = nullptr;
-
 };
 
 class stepstag_state : public rockn_state
 {
 public:
-	stepstag_state(const machine_config &mconfig, device_type type, const char *tag) :
-		rockn_state(mconfig, type, tag)
+	stepstag_state(const machine_config &mconfig, device_type type, const char *tag)
+		: rockn_state(mconfig, type, tag)
 		, m_subcpu(*this, "sub")
 		, m_vj_sprite_l(*this, "sprite_l")
 		, m_vj_sprite_m(*this, "sprite_m")
@@ -280,8 +282,8 @@ public:
 		, m_io_coins(*this, "COINS")
 	{ }
 
-	void stepstag(machine_config &config);
-	void vjdash(machine_config &config);
+	void stepstag(machine_config &config) ATTR_COLD;
+	void vjdash(machine_config &config) ATTR_COLD;
 
 	DECLARE_VIDEO_START(stepstag);
 
@@ -291,8 +293,6 @@ protected:
 
 private:
 	u16 stepstag_coins_r();
-	u16 m_vj_upload_idx = 0;
-	bool m_vj_upload_fini = false;
 	void stepstag_b00000_w(u16 data);
 	void stepstag_b20000_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	u16 stepstag_sprite_status_status_r();
@@ -354,6 +354,9 @@ private:
 	std::unique_ptr<uint16_t[]> m_spriteram1_data;
 	std::unique_ptr<uint16_t[]> m_spriteram2_data;
 	std::unique_ptr<uint16_t[]> m_spriteram3_data;
+
+	u16 m_vj_upload_idx = 0;
+	bool m_vj_upload_fini = false;
 
 	uint8_t m_adv7176a_sclock;
 	uint8_t m_adv7176a_sdata;

--- a/src/mame/jaleco/tetrisp2_v.cpp
+++ b/src/mame/jaleco/tetrisp2_v.cpp
@@ -58,17 +58,17 @@ void rocknms_state::sub_flipscreen_w(int state)
 ***************************************************************************/
 
 /* BBBBBGGGGGRRRRRx xxxxxxxxxxxxxxxx */
-void tetrisp2_state::tetrisp2_palette_w(offs_t offset, u16 data, u16 mem_mask)
+void tetrisp2_state::palette_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	data = COMBINE_DATA(&m_paletteram[offset]);
-	if ((offset & 1) == 0)
+	if (BIT(~offset, 0))
 		m_palette->set_pen_color(offset/2,pal5bit(data >> 1),pal5bit(data >> 6),pal5bit(data >> 11));
 }
 
-void rocknms_state::rocknms_sub_palette_w(offs_t offset, u16 data, u16 mem_mask)
+void rocknms_state::sub_palette_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	data = COMBINE_DATA(&m_sub_paletteram[offset]);
-	if ((offset & 1) == 0)
+	if (BIT(~offset, 0))
 		m_sub_palette->set_pen_color(offset/2,pal5bit(data >> 1),pal5bit(data >> 6),pal5bit(data >> 11));
 }
 
@@ -82,7 +82,7 @@ void rocknms_state::rocknms_sub_palette_w(offs_t offset, u16 data, u16 mem_mask)
 
 ***************************************************************************/
 
-void tetrisp2_state::tetrisp2_priority_w(offs_t offset, u16 data, u16 mem_mask)
+void tetrisp2_state::priority_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (ACCESSING_BITS_0_7)
 		m_priority[offset] = data;
@@ -90,17 +90,17 @@ void tetrisp2_state::tetrisp2_priority_w(offs_t offset, u16 data, u16 mem_mask)
 		m_priority[offset] = data >> 8;
 }
 
-u16 tetrisp2_state::tetrisp2_priority_r(offs_t offset)
+u16 tetrisp2_state::priority_r(offs_t offset)
 {
 	return m_priority[offset] | 0xff00;
 }
 
-void rocknms_state::rocknms_sub_priority_w(offs_t offset, u16 data, u16 mem_mask)
+void rocknms_state::sub_priority_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (ACCESSING_BITS_0_7)
-		m_rocknms_sub_priority[offset] = data;
+		m_sub_priority[offset] = data;
 	else
-		m_rocknms_sub_priority[offset] = data >> 8;
+		m_sub_priority[offset] = data >> 8;
 }
 
 
@@ -133,7 +133,7 @@ TILE_GET_INFO_MEMBER(tetrisp2_state::get_tile_info_bg)
 			0);
 }
 
-void tetrisp2_state::tetrisp2_vram_bg_w(offs_t offset, u16 data, u16 mem_mask)
+void tetrisp2_state::vram_bg_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_vram_bg[offset]);
 	m_tilemap_bg->mark_tile_dirty(offset/2);
@@ -153,7 +153,7 @@ TILE_GET_INFO_MEMBER(tetrisp2_state::get_tile_info_fg)
 			0);
 }
 
-void tetrisp2_state::tetrisp2_vram_fg_w(offs_t offset, u16 data, u16 mem_mask)
+void tetrisp2_state::vram_fg_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	// VJ and Stepping Stage write to the upper byte here to display ASCII text,
 	// other usages in those games outside of ASCII text write a full 16-bit value.
@@ -168,73 +168,73 @@ void tetrisp2_state::tetrisp2_vram_fg_w(offs_t offset, u16 data, u16 mem_mask)
 
 TILE_GET_INFO_MEMBER(tetrisp2_state::get_tile_info_rot)
 {
-	u16 code_hi = m_vram_rot[ 2 * tile_index + 0];
-	u16 code_lo = m_vram_rot[ 2 * tile_index + 1];
+	u16 code_hi = m_vram_rot[2 * tile_index + 0];
+	u16 code_lo = m_vram_rot[2 * tile_index + 1];
 	tileinfo.set(1,
 			code_hi,
 			code_lo & 0xf,
 			0);
 }
 
-void tetrisp2_state::tetrisp2_vram_rot_w(offs_t offset, u16 data, u16 mem_mask)
+void tetrisp2_state::vram_rot_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_vram_rot[offset]);
 	m_tilemap_rot->mark_tile_dirty(offset/2);
 }
 
-TILE_GET_INFO_MEMBER(rocknms_state::get_tile_info_rocknms_sub_bg)
+TILE_GET_INFO_MEMBER(rocknms_state::get_tile_info_sub_bg)
 {
-	u16 code_hi = m_rocknms_sub_vram_bg[ 2 * tile_index + 0];
-	u16 code_lo = m_rocknms_sub_vram_bg[ 2 * tile_index + 1];
+	u16 code_hi = m_sub_vram_bg[2 * tile_index + 0];
+	u16 code_lo = m_sub_vram_bg[2 * tile_index + 1];
 	tileinfo.set(0,
 			code_hi,
 			code_lo & 0xf,
 			0);
 }
 
-void rocknms_state::rocknms_sub_vram_bg_w(offs_t offset, u16 data, u16 mem_mask)
+void rocknms_state::sub_vram_bg_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	COMBINE_DATA(&m_rocknms_sub_vram_bg[offset]);
+	COMBINE_DATA(&m_sub_vram_bg[offset]);
 	m_tilemap_sub_bg->mark_tile_dirty(offset/2);
 }
 
 
-TILE_GET_INFO_MEMBER(rocknms_state::get_tile_info_rocknms_sub_fg)
+TILE_GET_INFO_MEMBER(rocknms_state::get_tile_info_sub_fg)
 {
-	u16 code_hi = m_rocknms_sub_vram_fg[ 2 * tile_index + 0];
-	u16 code_lo = m_rocknms_sub_vram_fg[ 2 * tile_index + 1];
+	u16 code_hi = m_sub_vram_fg[2 * tile_index + 0];
+	u16 code_lo = m_sub_vram_fg[2 * tile_index + 1];
 	tileinfo.set(2,
 			code_hi,
 			code_lo & 0xf,
 			0);
 }
 
-void rocknms_state::rocknms_sub_vram_fg_w(offs_t offset, u16 data, u16 mem_mask)
+void rocknms_state::sub_vram_fg_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	COMBINE_DATA(&m_rocknms_sub_vram_fg[offset]);
+	COMBINE_DATA(&m_sub_vram_fg[offset]);
 	m_tilemap_sub_fg->mark_tile_dirty(offset/2);
 }
 
 
-TILE_GET_INFO_MEMBER(rocknms_state::get_tile_info_rocknms_sub_rot)
+TILE_GET_INFO_MEMBER(rocknms_state::get_tile_info_sub_rot)
 {
-	u16 code_hi = m_rocknms_sub_vram_rot[ 2 * tile_index + 0];
-	u16 code_lo = m_rocknms_sub_vram_rot[ 2 * tile_index + 1];
+	u16 code_hi = m_sub_vram_rot[2 * tile_index + 0];
+	u16 code_lo = m_sub_vram_rot[2 * tile_index + 1];
 	tileinfo.set(1,
 			code_hi,
 			code_lo & 0xf,
 			0);
 }
 
-void rocknms_state::rocknms_sub_vram_rot_w(offs_t offset, u16 data, u16 mem_mask)
+void rocknms_state::sub_vram_rot_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	COMBINE_DATA(&m_rocknms_sub_vram_rot[offset]);
+	COMBINE_DATA(&m_sub_vram_rot[offset]);
 	m_tilemap_sub_rot->mark_tile_dirty(offset/2);
 }
 
 
 
-VIDEO_START_MEMBER(tetrisp2_state,tetrisp2)
+void tetrisp2_state::video_start()
 {
 	m_tilemap_bg = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(tetrisp2_state::get_tile_info_bg)), TILEMAP_SCAN_ROWS, 16,16, NX_0,NY_0);
 	m_tilemap_fg = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(tetrisp2_state::get_tile_info_fg)), TILEMAP_SCAN_ROWS, 8,8, NX_1,NY_1);
@@ -246,23 +246,22 @@ VIDEO_START_MEMBER(tetrisp2_state,tetrisp2)
 	// should be smaller and mirrored like m32 I guess
 	m_priority = std::make_unique<u8[]>(0x40000);
 
+	save_item(NAME(m_rot_ofsx));
+	save_item(NAME(m_rot_ofsy));
 	save_pointer(NAME(m_priority), 0x40000);
 }
 
-VIDEO_START_MEMBER(tetrisp2_state,nndmseal)
+void nndmseal_state::video_start()
 {
-	VIDEO_START_CALL_MEMBER( tetrisp2 );
+	tetrisp2_state::video_start();
 	m_tilemap_bg->set_scrolldx(-4,-4);
-
-	m_bank_hi = 0;
-	m_bank_lo = 0;
 }
 
-VIDEO_START_MEMBER(tetrisp2_state,rockntread)
+void rockn_state::video_start()
 {
-	m_tilemap_bg = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(tetrisp2_state::get_tile_info_bg)), TILEMAP_SCAN_ROWS, 16,16, 256,16);   // rockn ms(main),1,2,3,4
-	m_tilemap_fg = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(tetrisp2_state::get_tile_info_fg)), TILEMAP_SCAN_ROWS, 8,8, 64,64);
-	m_tilemap_rot = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(tetrisp2_state::get_tile_info_rot)), TILEMAP_SCAN_ROWS, 16,16, 128,128);
+	m_tilemap_bg = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(rockn_state::get_tile_info_bg)), TILEMAP_SCAN_ROWS, 16,16, 256,16);   // rockn ms(main),1,2,3,4
+	m_tilemap_fg = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(rockn_state::get_tile_info_fg)), TILEMAP_SCAN_ROWS, 8,8, 64,64);
+	m_tilemap_rot = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(rockn_state::get_tile_info_rot)), TILEMAP_SCAN_ROWS, 16,16, 128,128);
 
 	m_tilemap_bg->set_transparent_pen(0);
 	m_tilemap_fg->set_transparent_pen(0);
@@ -276,14 +275,13 @@ VIDEO_START_MEMBER(tetrisp2_state,rockntread)
 	save_pointer(NAME(m_priority), 0x40000);
 }
 
-
-VIDEO_START_MEMBER(rocknms_state,rocknms)
+void rocknms_state::video_start()
 {
-	VIDEO_START_CALL_MEMBER( rockntread );
+	rockn_state::video_start();
 
-	m_tilemap_sub_bg = &machine().tilemap().create(*m_sub_gfxdecode, tilemap_get_info_delegate(*this, FUNC(rocknms_state::get_tile_info_rocknms_sub_bg)), TILEMAP_SCAN_ROWS, 16,16, 32,256);
-	m_tilemap_sub_fg = &machine().tilemap().create(*m_sub_gfxdecode, tilemap_get_info_delegate(*this, FUNC(rocknms_state::get_tile_info_rocknms_sub_fg)), TILEMAP_SCAN_ROWS, 8,8, 64,64);
-	m_tilemap_sub_rot = &machine().tilemap().create(*m_sub_gfxdecode, tilemap_get_info_delegate(*this, FUNC(rocknms_state::get_tile_info_rocknms_sub_rot)), TILEMAP_SCAN_ROWS, 16,16, 128,128);
+	m_tilemap_sub_bg = &machine().tilemap().create(*m_sub_gfxdecode, tilemap_get_info_delegate(*this, FUNC(rocknms_state::get_tile_info_sub_bg)), TILEMAP_SCAN_ROWS, 16,16, 32,256);
+	m_tilemap_sub_fg = &machine().tilemap().create(*m_sub_gfxdecode, tilemap_get_info_delegate(*this, FUNC(rocknms_state::get_tile_info_sub_fg)), TILEMAP_SCAN_ROWS, 8,8, 64,64);
+	m_tilemap_sub_rot = &machine().tilemap().create(*m_sub_gfxdecode, tilemap_get_info_delegate(*this, FUNC(rocknms_state::get_tile_info_sub_rot)), TILEMAP_SCAN_ROWS, 16,16, 128,128);
 
 	m_tilemap_sub_bg->set_transparent_pen(0);
 	m_tilemap_sub_fg->set_transparent_pen(0);
@@ -390,24 +388,20 @@ static void tetrisp2_draw_sprites(BitmapClass &bitmap, bitmap_ind8 &bitmap_pri, 
 
 u32 tetrisp2_state::screen_update_tetrisp2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	int asc_pri;
-	int scr_pri;
-	int rot_pri;
-
 	/* Black background color */
 	bitmap.fill(0, cliprect);
 	screen.priority().fill(0);
 
-	m_tilemap_bg->set_scrollx(0, (((m_scroll_bg[ 0 ] + 0x0014) + m_scroll_bg[ 2 ] ) & 0xffff));
-	m_tilemap_bg->set_scrolly(0, (((m_scroll_bg[ 3 ] + 0x0000) + m_scroll_bg[ 5 ] ) & 0xffff));
+	m_tilemap_bg->set_scrollx(0, (((m_scroll_bg[0] + 0x0014) + m_scroll_bg[2] ) & 0xffff));
+	m_tilemap_bg->set_scrolly(0, (((m_scroll_bg[3] + 0x0000) + m_scroll_bg[5] ) & 0xffff));
 
-	m_tilemap_fg->set_scrollx(0, m_scroll_fg[ 2 ]);
-	m_tilemap_fg->set_scrolly(0, m_scroll_fg[ 5 ]);
+	m_tilemap_fg->set_scrollx(0, m_scroll_fg[2]);
+	m_tilemap_fg->set_scrolly(0, m_scroll_fg[5]);
 
-	m_tilemap_rot->set_scrollx(0, (m_rotregs[ 0 ] - m_rot_ofsx));
-	m_tilemap_rot->set_scrolly(0, (m_rotregs[ 2 ] - m_rot_ofsy));
+	m_tilemap_rot->set_scrollx(0, (m_rotregs[0] - m_rot_ofsx));
+	m_tilemap_rot->set_scrolly(0, (m_rotregs[2] - m_rot_ofsy));
 
-	asc_pri = scr_pri = rot_pri = 0;
+	int asc_pri = 0, scr_pri = 0, rot_pri = 0;
 
 	if((m_priority[0x2b00 / 2] & 0x00ff) == 0x0034)
 		asc_pri++;
@@ -450,26 +444,22 @@ u32 tetrisp2_state::screen_update_tetrisp2(screen_device &screen, bitmap_ind16 &
 	return 0;
 }
 
-u32 tetrisp2_state::screen_update_rockntread(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 rockn_state::screen_update_rockntread(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	int asc_pri;
-	int scr_pri;
-	int rot_pri;
-
 	/* Black background color */
 	bitmap.fill(0, cliprect);
 	screen.priority().fill(0);
 
-	m_tilemap_bg->set_scrollx(0, (((m_scroll_bg[ 0 ] + 0x0014) + m_scroll_bg[ 2 ] ) & 0xffff));
-	m_tilemap_bg->set_scrolly(0, (((m_scroll_bg[ 3 ] + 0x0000) + m_scroll_bg[ 5 ] ) & 0xffff));
+	m_tilemap_bg->set_scrollx(0, (((m_scroll_bg[0] + 0x0014) + m_scroll_bg[2] ) & 0xffff));
+	m_tilemap_bg->set_scrolly(0, (((m_scroll_bg[3] + 0x0000) + m_scroll_bg[5] ) & 0xffff));
 
-	m_tilemap_fg->set_scrollx(0, m_scroll_fg[ 2 ]);
-	m_tilemap_fg->set_scrolly(0, m_scroll_fg[ 5 ]);
+	m_tilemap_fg->set_scrollx(0, m_scroll_fg[2]);
+	m_tilemap_fg->set_scrolly(0, m_scroll_fg[5]);
 
-	m_tilemap_rot->set_scrollx(0, (m_rotregs[ 0 ] - m_rot_ofsx));
-	m_tilemap_rot->set_scrolly(0, (m_rotregs[ 2 ] - m_rot_ofsy));
+	m_tilemap_rot->set_scrollx(0, (m_rotregs[0] - m_rot_ofsx));
+	m_tilemap_rot->set_scrolly(0, (m_rotregs[2] - m_rot_ofsy));
 
-	asc_pri = scr_pri = rot_pri = 0;
+	int asc_pri = 0, scr_pri = 0, rot_pri = 0;
 
 	if((m_priority[0x2b00 / 2] & 0x00ff) == 0x0034)
 		asc_pri++;
@@ -515,35 +505,31 @@ u32 tetrisp2_state::screen_update_rockntread(screen_device &screen, bitmap_ind16
 
 
 
-u32 rocknms_state::screen_update_rocknms_left(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+u32 rocknms_state::screen_update_top(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	int asc_pri;
-	int scr_pri;
-	int rot_pri;
-
-	m_tilemap_sub_bg->set_scrollx(0, m_rocknms_sub_scroll_bg[ 2 ] + 0x000);
-	m_tilemap_sub_bg->set_scrolly(0, m_rocknms_sub_scroll_bg[ 5 ] + 0x000);
-	m_tilemap_sub_fg->set_scrollx(0, m_rocknms_sub_scroll_fg[ 2 ] + 0x000);
-	m_tilemap_sub_fg->set_scrolly(0, m_rocknms_sub_scroll_fg[ 5 ] + 0x000);
-	m_tilemap_sub_rot->set_scrollx(0, m_rocknms_sub_rotregs[ 0 ] + 0x400);
-	m_tilemap_sub_rot->set_scrolly(0, m_rocknms_sub_rotregs[ 2 ] + 0x400);
+	m_tilemap_sub_bg->set_scrollx(0, m_sub_scroll_bg[2] + 0x000);
+	m_tilemap_sub_bg->set_scrolly(0, m_sub_scroll_bg[5] + 0x000);
+	m_tilemap_sub_fg->set_scrollx(0, m_sub_scroll_fg[2] + 0x000);
+	m_tilemap_sub_fg->set_scrolly(0, m_sub_scroll_fg[5] + 0x000);
+	m_tilemap_sub_rot->set_scrollx(0, m_sub_rotregs[0] + 0x400);
+	m_tilemap_sub_rot->set_scrolly(0, m_sub_rotregs[2] + 0x400);
 
 	bitmap.fill(m_palette->pen(0x0000), cliprect);
 	screen.priority().fill(0, cliprect);
 
-	asc_pri = scr_pri = rot_pri = 0;
+	int asc_pri = 0, scr_pri = 0, rot_pri = 0;
 
-	if((m_rocknms_sub_priority[0x2b00 / 2] & 0x00ff) == 0x0034)
+	if((m_sub_priority[0x2b00 / 2] & 0x00ff) == 0x0034)
 		asc_pri++;
 	else
 		rot_pri++;
 
-	if((m_rocknms_sub_priority[0x2e00 / 2] & 0x00ff) == 0x0034)
+	if((m_sub_priority[0x2e00 / 2] & 0x00ff) == 0x0034)
 		asc_pri++;
 	else
 		scr_pri++;
 
-	if((m_rocknms_sub_priority[0x3a00 / 2] & 0x00ff) == 0x000c)
+	if((m_sub_priority[0x3a00 / 2] & 0x00ff) == 0x000c)
 		scr_pri++;
 	else
 		rot_pri++;
@@ -570,29 +556,25 @@ u32 rocknms_state::screen_update_rocknms_left(screen_device &screen, bitmap_rgb3
 		m_tilemap_sub_fg->draw(screen, bitmap, cliprect, 0, 1 << 2);
 
 	tetrisp2_draw_sprites(bitmap, screen.priority(), cliprect, m_priority.get(),
-							m_spriteram2, m_spriteram2.bytes(), m_rocknms_sub_sprite);
+							m_spriteram2, m_spriteram2.bytes(), m_sub_sprite);
 
 	return 0;
 }
 
-u32 rocknms_state::screen_update_rocknms_right(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+u32 rocknms_state::screen_update_bottom(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	int asc_pri;
-	int scr_pri;
-	int rot_pri;
-
-	m_tilemap_bg->set_scrollx(0, m_scroll_bg[ 2 ] + 0x000);
-	m_tilemap_bg->set_scrolly(0, m_scroll_bg[ 5 ] + 0x000);
-	m_tilemap_fg->set_scrollx(0, m_scroll_fg[ 2 ] + 0x000);
-	m_tilemap_fg->set_scrolly(0, m_scroll_fg[ 5 ] + 0x000);
-	m_tilemap_rot->set_scrollx(0, m_rotregs[ 0 ] + 0x400);
-	m_tilemap_rot->set_scrolly(0, m_rotregs[ 2 ] + 0x400);
+	m_tilemap_bg->set_scrollx(0, m_scroll_bg[2] + 0x000);
+	m_tilemap_bg->set_scrolly(0, m_scroll_bg[5] + 0x000);
+	m_tilemap_fg->set_scrollx(0, m_scroll_fg[2] + 0x000);
+	m_tilemap_fg->set_scrolly(0, m_scroll_fg[5] + 0x000);
+	m_tilemap_rot->set_scrollx(0, m_rotregs[0] + 0x400);
+	m_tilemap_rot->set_scrolly(0, m_rotregs[2] + 0x400);
 
 	/* Black background color */
 	bitmap.fill(m_palette->pen(0x0000), cliprect);
 	screen.priority().fill(0, cliprect);
 
-	asc_pri = scr_pri = rot_pri = 0;
+	int asc_pri = 0, scr_pri = 0, rot_pri = 0;
 
 	if((m_priority[0x2b00 / 2] & 0x00ff) == 0x0034)
 		asc_pri++;
@@ -766,19 +748,19 @@ void stepstag_state::convert_yuv422_to_rgb888(palette_device *paldev, u16 *palra
 	paldev->set_pen_color(offset/4, r, g, b);
 }
 
-void stepstag_state::stepstag_palette_left_w(offs_t offset, u16 data, u16 mem_mask)
+void stepstag_state::palette_left_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_vj_paletteram_l[offset]);
 	convert_yuv422_to_rgb888(m_vj_palette_l,m_vj_paletteram_l,offset);
 }
 
-void stepstag_state::stepstag_palette_mid_w(offs_t offset, u16 data, u16 mem_mask)
+void stepstag_state::palette_mid_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_vj_paletteram_m[offset]);
 	convert_yuv422_to_rgb888(m_vj_palette_m,m_vj_paletteram_m,offset);
 }
 
-void stepstag_state::stepstag_palette_right_w(offs_t offset, u16 data, u16 mem_mask)
+void stepstag_state::palette_right_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_vj_paletteram_r[offset]);
 	convert_yuv422_to_rgb888(m_vj_palette_r,m_vj_paletteram_r,offset);


### PR DESCRIPTION
- Split state via configurations
- Use machine_start(), video_start() overrides for video initialization
- Reduce runtime tag lookups, literal tag usages
- Fix typename value consistency
- Use generic gfx decode layout
- Fix naming