### PR TITLE
a2gameio: Updated Sirius JoyPort description to mention Atari joysticks being connected to it

### DIFF
--- a/src/devices/bus/a2gameio/joyport.cpp
+++ b/src/devices/bus/a2gameio/joyport.cpp
@@ -127,4 +127,4 @@ void apple2_joyport_device::an1_w(int state)
 //**************************************************************************
 
 // device type definition
-DEFINE_DEVICE_TYPE_PRIVATE(APPLE2_JOYPORT, device_a2gameio_interface, apple2_joyport_device, "a2joyprt", "Sirius JoyPort")
+DEFINE_DEVICE_TYPE_PRIVATE(APPLE2_JOYPORT, device_a2gameio_interface, apple2_joyport_device, "a2joyprt", "Sirius JoyPort with Atari joysticks")


### PR DESCRIPTION
This changes the description of "Sirius JoyPort" to read "Sirius JoyPort with Atari joysticks" instead.

The Sirius JoyPort supports different types of peripherals to be connected to it. 
