### PR TITLE
trs/gime.cpp: fix some legacy video modes

### DIFF
--- a/src/mame/trs/gime.h
+++ b/src/mame/trs/gime.h
@@ -239,6 +239,7 @@ protected:
 	// rendering sampled graphics
 	typedef uint32_t (gime_device::*emit_samples_proc)(const scanline_record *scanline, int sample_start, int sample_count, pixel_t *pixels, const pixel_t *palette);
 	uint32_t emit_dummy_samples(const scanline_record *scanline, int sample_start, int sample_count, pixel_t *pixels, const pixel_t *palette);
+	template<int xscale>
 	uint32_t emit_mc6847_samples(const scanline_record *scanline, int sample_start, int sample_count, pixel_t *pixels, const pixel_t *palette);
 	template<int xscale>
 	uint32_t emit_gime_text_samples(const scanline_record *scanline, int sample_start, int sample_count, pixel_t *pixels, const pixel_t *palette);


### PR DESCRIPTION
The legacy GIME mode lines per row calculation is very different from the MC6847. Also fix a small border color issue when compared with real hardware.