### PR TITLE
cpu/z80/t6a84: Fix emscripten compile issue

### DIFF
--- a/src/devices/cpu/z80/t6a84.cpp
+++ b/src/devices/cpu/z80/t6a84.cpp
@@ -139,7 +139,7 @@ bool t6a84_device::memory_translate(int spacenum, int intention, offs_t &address
 
 uint32_t t6a84_device::code_address(uint16_t address)
 {
-	const uint32_t page_address = PAGE_SIZE * m_code_page + address;
+	const uint32_t page_address = DEVICE_PAGE_SIZE * m_code_page + address;
 	LOGMASKED(LOG_MEM, "CODE @ %06x => %06x\n", address, page_address);
 
 	return page_address;
@@ -147,7 +147,7 @@ uint32_t t6a84_device::code_address(uint16_t address)
 
 uint32_t t6a84_device::data_address(uint16_t address)
 {
-	const uint32_t page_address = PAGE_SIZE * m_data_page + address;
+	const uint32_t page_address = DEVICE_PAGE_SIZE * m_data_page + address;
 	LOGMASKED(LOG_MEM, "DATA @ %06x => %06x\n", address, page_address);
 
 	return page_address;
@@ -155,7 +155,7 @@ uint32_t t6a84_device::data_address(uint16_t address)
 
 uint32_t t6a84_device::stack_address(uint16_t address)
 {
-	const uint32_t page_address = PAGE_SIZE * m_stack_page + address;
+	const uint32_t page_address = DEVICE_PAGE_SIZE * m_stack_page + address;
 	LOGMASKED(LOG_MEM, "STACK @ %06x => %06x\n", address, page_address);
 
 	return page_address;

--- a/src/devices/cpu/z80/t6a84.h
+++ b/src/devices/cpu/z80/t6a84.h
@@ -41,7 +41,7 @@ public:
 	uint32_t stack_address(uint16_t address);
 
 protected:
-	static inline constexpr uint32_t PAGE_SIZE = 0x10000;
+	static inline constexpr uint32_t DEVICE_PAGE_SIZE = 0x10000;
 
 	t6a84_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, address_map_constructor io_map);
 


### PR DESCRIPTION
This PR changes fixes a emscripten compile issue described in #13041.