### PR TITLE
Segas32 - Resolution change when zooming

### DIFF
--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -17,9 +17,8 @@
       The theory is that opaque pens should go above background layer and
       behind everything else like System 24.
 
-    - radr uses $1A0 as the X center for zooming; however, this
-      contradicts the theory that bit 9 is a sign bit. For now, the code
-      assumes that the X center has 10 bits of resolution.
+    - Verify that X/Y center has 10 bits of resolution when zooming and
+      9 when not.
 
     - In svf (the field) and radr (on the field), they use tilemap-specific
       flip in conjunction with rowscroll AND rowselect. According to Charles,
@@ -740,8 +739,8 @@ void segas32_state::update_tilemap_zoom(screen_device &screen, segas32_state::la
 	srcy += (m_videoram[0x1ff14/2 + 4 * bgnum] & 0xfe00) << 4;
 
 	/* then account for the destination center coordinates */
-	srcx_start -= util::sext(m_videoram[0x1ff30/2 + 2 * bgnum] & 0x1ff, 10) * srcxstep;
-	srcy -= util::sext(m_videoram[0x1ff32/2 + 2 * bgnum], 9) * srcystep;
+	srcx_start -= util::sext(m_videoram[0x1ff30/2 + 2 * bgnum] & 0x1ff, (dstxstep != 0x200)?10:9) * srcxstep;
+	srcy -= util::sext(m_videoram[0x1ff32/2 + 2 * bgnum], (dstystep != 0x200)?10:9) * srcystep;
 
 	/* finally, account for destination top,left coordinates */
 	srcx_start += cliprect.min_x * srcxstep;

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -742,7 +742,7 @@ void segas32_state::update_tilemap_zoom(screen_device &screen, segas32_state::la
 	/*
 	   Then account for the destination center coordinates - We currently expand the resolution
 	   from 9 bit to 10 bit while zooming which correctly centers the bg in harddunk during attract
-	   mode at the low resolution and the course selection screen in radr at the higher resolution.
+	   mode at the lower resolution and the course selection bg in radr at the higher resolution.
 	   This behavior has not been verified yet on real hardware and might be a hack.
 	*/
 	srcx_start -= util::sext(m_videoram[0x1ff30/2 + 2 * bgnum], (dstxstep != 0x200) ? 10 : 9) * srcxstep;

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -121,14 +121,15 @@
         F44      -wwwwwww --------  Layer 1 upper-right page select
                  -------- -wwwwwww  Layer 1 upper-left page select
         F46      -wwwwwww --------  Layer 1 lower-right page select
-                 -------- -wwwwwww  Layer 2 upper-left page select
-        F48      -wwwwwww --------  Layer 2 upper-right page select
-                 -------- -wwwwwww  Layer 2 lower-left page select
-        F4A      -wwwwwww --------  Layer 2 lower-right page select
-                 -------- -wwwwwww  Layer 3 upper-left page select
-                 -wwwwwww --------  Layer 3 upper-right page select
-        F4E      -------- -wwwwwww  Layer 3 lower-left page select
-                 -wwwwwww --------  Layer 3 lower-right page select
+                 -------- -wwwwwww  Layer 1 lower-left page select
+        F48      -wwwwwww --------  Layer 2 upper-left page select
+                 -------- -wwwwwww  Layer 2 upper-right page select
+        F4A      -wwwwwww --------  Layer 2 lower-left page select
+                 -------- -wwwwwww  Layer 2 lower-right page select
+        F4C      -wwwwwww --------  Layer 3 upper-left page select
+                 -------- -wwwwwww  Layer 3 upper-right page select
+        F4E      -wwwwwww --------  Layer 3 lower-left page select
+                 -------- -wwwwwww  Layer 3 lower-right page select
         F50      xxxxxxxx xxxxxxxx  Layer 0 X step increment (0x200 = 1.0)
         F52      yyyyyyyy yyyyyyyy  Layer 0 Y step increment (0x200 = 1.0)
         F54      xxxxxxxx xxxxxxxx  Layer 1 X step increment (0x200 = 1.0)

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -739,9 +739,14 @@ void segas32_state::update_tilemap_zoom(screen_device &screen, segas32_state::la
 	uint32_t srcy = (m_videoram[0x1ff16/2 + 4 * bgnum] & 0x1ff) << 20;
 	srcy += (m_videoram[0x1ff14/2 + 4 * bgnum] & 0xfe00) << 4;
 
-	/* then account for the destination center coordinates */
-	srcx_start -= util::sext(m_videoram[0x1ff30/2 + 2 * bgnum], (dstxstep != 0x200)?10:9) * srcxstep;
-	srcy -= util::sext(m_videoram[0x1ff32/2 + 2 * bgnum], (dstystep != 0x200)?10:9) * srcystep;
+	/*
+	   then account for the destination center coordinates - we currently expand the resolution
+	   from 9 bit to 10 bit while zooming which correctly centers the bg in harddunk during attract
+	   mode at the low resolution and the course selection screen in radr at the higher resolution.
+	   this behavior has not been verified to real hardware and maybe a hack.
+	*/
+	srcx_start -= util::sext(m_videoram[0x1ff30/2 + 2 * bgnum], (dstxstep != 0x200) ? 10 : 9) * srcxstep;
+	srcy -= util::sext(m_videoram[0x1ff32/2 + 2 * bgnum], (dstystep != 0x200) ? 10 : 9) * srcystep;
 
 	/* finally, account for destination top,left coordinates */
 	srcx_start += cliprect.min_x * srcxstep;

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -739,7 +739,7 @@ void segas32_state::update_tilemap_zoom(screen_device &screen, segas32_state::la
 	srcy += (m_videoram[0x1ff14/2 + 4 * bgnum] & 0xfe00) << 4;
 
 	/* then account for the destination center coordinates */
-	srcx_start -= util::sext(m_videoram[0x1ff30/2 + 2 * bgnum] & 0x1ff, (dstxstep != 0x200)?10:9) * srcxstep;
+	srcx_start -= util::sext(m_videoram[0x1ff30/2 + 2 * bgnum], (dstxstep != 0x200)?10:9) * srcxstep;
 	srcy -= util::sext(m_videoram[0x1ff32/2 + 2 * bgnum], (dstystep != 0x200)?10:9) * srcystep;
 
 	/* finally, account for destination top,left coordinates */

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -741,8 +741,8 @@ void segas32_state::update_tilemap_zoom(screen_device &screen, segas32_state::la
 
 	/*
 	   Then account for the destination center coordinates - We currently expand the resolution
-	   from 9 bit to 10 bit while zooming which correctly centers the bg in harddunk during attract
-	   mode at the lower resolution and the course selection bg in radr at the higher resolution.
+	   from 9 bit to 10 bit while zooming which correctly centers the bg during attract mode in
+	   harddunk at the lower resolution and the course selection bg in radr at the higher resolution.
 	   This behavior has not been verified yet on real hardware and might be a hack.
 	*/
 	srcx_start -= util::sext(m_videoram[0x1ff30/2 + 2 * bgnum], (dstxstep != 0x200) ? 10 : 9) * srcxstep;

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -740,10 +740,10 @@ void segas32_state::update_tilemap_zoom(screen_device &screen, segas32_state::la
 	srcy += (m_videoram[0x1ff14/2 + 4 * bgnum] & 0xfe00) << 4;
 
 	/*
-	   then account for the destination center coordinates - we currently expand the resolution
+	   Then account for the destination center coordinates - We currently expand the resolution
 	   from 9 bit to 10 bit while zooming which correctly centers the bg in harddunk during attract
 	   mode at the low resolution and the course selection screen in radr at the higher resolution.
-	   this behavior has not been verified to real hardware and maybe a hack.
+	   This behavior has not been verified to real hardware and might be a hack.
 	*/
 	srcx_start -= util::sext(m_videoram[0x1ff30/2 + 2 * bgnum], (dstxstep != 0x200) ? 10 : 9) * srcxstep;
 	srcy -= util::sext(m_videoram[0x1ff32/2 + 2 * bgnum], (dstystep != 0x200) ? 10 : 9) * srcystep;

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -33,10 +33,6 @@
       effect to draw the boxing ring over NBG0.
       Same deal for ga2 when in stage 2 cave a wall torch is lit.
 
-    - harddunk draws solid white in attract mode when the players are presented.
-      NBG0 is set with $200 on center X/Y, same as above or perhaps missing
-      tilemap wraparound?
-
     - Wrong priority cases (parenthesis for the level setup):
       dbzvrvs: draws text layer ($e) behind sprite-based gauges ($f).
       dbzvrvs: Sheng-Long speech balloon during Piccoro ending (fixme: check levels).
@@ -744,7 +740,7 @@ void segas32_state::update_tilemap_zoom(screen_device &screen, segas32_state::la
 	srcy += (m_videoram[0x1ff14/2 + 4 * bgnum] & 0xfe00) << 4;
 
 	/* then account for the destination center coordinates */
-	srcx_start -= util::sext(m_videoram[0x1ff30/2 + 2 * bgnum], 10) * srcxstep;
+	srcx_start -= util::sext(m_videoram[0x1ff30/2 + 2 * bgnum] & 0x1ff, 10) * srcxstep;
 	srcy -= util::sext(m_videoram[0x1ff32/2 + 2 * bgnum], 9) * srcystep;
 
 	/* finally, account for destination top,left coordinates */

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -743,7 +743,7 @@ void segas32_state::update_tilemap_zoom(screen_device &screen, segas32_state::la
 	   Then account for the destination center coordinates - We currently expand the resolution
 	   from 9 bit to 10 bit while zooming which correctly centers the bg in harddunk during attract
 	   mode at the low resolution and the course selection screen in radr at the higher resolution.
-	   This behavior has not been verified to real hardware and might be a hack.
+	   This behavior has not been verified yet on real hardware and might be a hack.
 	*/
 	srcx_start -= util::sext(m_videoram[0x1ff30/2 + 2 * bgnum], (dstxstep != 0x200) ? 10 : 9) * srcxstep;
 	srcy -= util::sext(m_videoram[0x1ff32/2 + 2 * bgnum], (dstystep != 0x200) ? 10 : 9) * srcystep;


### PR DESCRIPTION
It seems that zooming requires more resolution but uses 9 bit otherwise.

This should fix the missing background for harddunk in attract mode, while also working with radr map selection, alien3 map between stages and so on. Has not been verified to real hardware but it seems to test correctly with all games. Let me know if there's a specific transition / case you would like tested.