### PR TITLE
mcs51: Serial output emulation should not clobber P3.1 when IDLE.

### DIFF
--- a/src/devices/cpu/mcs51/mcs51.cpp
+++ b/src/devices/cpu/mcs51/mcs51.cpp
@@ -1128,7 +1128,6 @@ void mcs51_cpu_device::transmit_receive(int source)
 		switch (m_uart.txbit)
 		{
 		case SIO_IDLE:
-			transmit(1);
 			break;
 		case SIO_START:
 			LOGMASKED(LOG_TX, "tx start bit (%s)\n", machine().time().to_string());


### PR DESCRIPTION
This is an improvement, but not a full fix.

Feel free to just consider this a bug report, if the change seems risky. I might take a shot at a proper fix if no one gets to it.

For the following to make sense, see "MCS51 User's Manual" -> "Hardware Description of the 8051, 8052 and 80c51" -> "Port structures and operation" -> "I/O Configurations".

According to the user manual, `P3 output = SFR(P3) & "alternate output"`. Or in the case of P3.1: `P3.1 output = BIT(SFR(P3), 1) & TXD`. However, mcs51.cpp is writing TXD into BIT(SFR(P3), 1) (see `mcs51_cpu_device::transmit()`), clobbering the value written by the firmware. And it is doing so constantly while serial transmission is in the IDLE state.

The proper fix would be to implement the above logic. But it is a bigger change.

This PR will fix drivers that use P3.1 as a general purpose pin. Furthermore, drivers that use P3.1 as TXD should continue working: mcs51.cpp initializes this to 1 (`SET_P3(0xff)` in `device_reset()`) and will set it to 1 after transmitting a stop bit. So the removed `transmit(1)` might have been redundant anyway.

Drivers that use P3.1 as both TXD and a general purpose output will still be affected, but they already are.

I tested this change on drivers that use P3.1 as a GP I/O (Paia synth drivers, not yet submitted). But I don't have a way to test on drivers that use it as TXD.