### PR TITLE
Adjust macOS CI to use three simultaneous jobs

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -34,7 +34,7 @@ jobs:
       env:
         USE_LIBSDL: 1
         TOOLS: 1
-      run: make -j2
+      run: make -j3
     - name: Validate
       run: ./mame -validate
     - uses: actions/upload-artifact@main


### PR DESCRIPTION
As of December 2024, all the used gitlab hosted runners have 7 GB of RAM and 14 GB of storage. macOS runner has 3 CPUs whereas Linux and Windows runners have 2. Since Windows and Linux jobs already use 3 jobs, it should also work for macOS.