### PR TITLE
hash/ibm51*.xml: New FreeDOS 1.3 hard disk image, FreeDOS 1.4 images

### DIFF
--- a/hash/ibm5150.xml
+++ b/hash/ibm5150.xml
@@ -6043,6 +6043,85 @@ Stalls or throws either "Bad command or file name", "disk read error" or "divide
 		</part>
 	</software>
 
+	<software name="freedos14_720">
+		<description>FreeDOS 1.4 (Floppy-Only Edition, 3.5" 720k)</description>
+		<year>2025</year>
+		<publisher>The FreeDOS Project</publisher>
+		<info name="version" value="1.4" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installer" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86BOOT.img" size="737280" crc="0d52c73c" sha1="8a8e8d43ad11817661ae9cbbff6a0fa372ea76fa" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK01.img" size="737280" crc="3f879626" sha1="1a9eed17c9f9f708fddecb31c764786a80c9ebce" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK02.img" size="737280" crc="5cb6a495" sha1="cf401c8280598e388d6a988c51fd6c17cd6b9ab4" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK03.img" size="737280" crc="6252dc59" sha1="8b0e4acc9efcecae78e922c35fb0f8dc6830baee" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 4" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK04.img" size="737280" crc="1197a133" sha1="4bf43573e3fe73d58071d680bbbb00fc32237f15" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 5" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK05.img" size="737280" crc="fcdcfe15" sha1="5ff2e3ec4d68802bc59c8f95713a24775d86f745" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 6" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK06.img" size="737280" crc="c3246fa2" sha1="2ef78ec8c42b64aaf55273b76cbf3610db0c2885" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 7" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK07.img" size="737280" crc="62545372" sha1="e8be09b41a2f07e183fc5284a3a5b3b76d0c04f5" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 8" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK08.img" size="737280" crc="42845f50" sha1="e6ef0bb133dfa86fffe48d1c75162f1f17c8642e" />
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 9" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK09.img" size="737280" crc="b48f740c" sha1="4d995317845a88e5e310a632acaa07cdecd83358" />
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 10" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK10.img" size="737280" crc="7747ce58" sha1="41620723781d8379cb60125cc643d4690667f636" />
+			</dataarea>
+		</part>
+		<part name="flop12" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 11" />
+			<dataarea name="flop" size="737280">
+				<rom name="x86DSK11.img" size="737280" crc="09e61f03" sha1="05b019c750f8fa0b0f59dd42760300576edc1b5e" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="k16auto">
 		<description>Kaypro 16 Autoload</description>
 		<year>1984</year>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -658,6 +658,110 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="freedos14_120" cloneof="freedos14_144">
+		<description>FreeDOS 1.4 (Floppy-Only Edition, 5.25" 1.2MB)</description>
+		<year>2025</year>
+		<publisher>The FreeDOS Project</publisher>
+		<info name="version" value="1.4" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Installer" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86BOOT.img" size="1228800" crc="23ce30f4" sha1="d29345d413cfed8a27cef1f17a12220ec0bdad84" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK01.img" size="1228800" crc="ac6cb8f2" sha1="465cdaaba287fe42cd5f452d7c8cce80c81074a2" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK02.img" size="1228800" crc="73ccbaaf" sha1="717c8a5e226280cd867f7a776b0e9c5efb432733" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK03.img" size="1228800" crc="226d3a99" sha1="24bf874f604ce76e8c74bd55edef2ef0c5191114" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 4" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK04.img" size="1228800" crc="43dc6593" sha1="b5ba6d9b17800389deeb3551fbba2e05bb8ab415" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 5" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK05.img" size="1228800" crc="f61c24ca" sha1="d19f63b25bb0829b8d3034fe119603ed745bf7e7" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 6" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK06.img" size="1228800" crc="c23d16c4" sha1="5ff7fb1f64d314b420e458696bd0b47f78e1d948" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_5_25">
+			<feature name="part_id" value="Disk 7" />
+			<dataarea name="flop" size="1228800">
+				<rom name="x86DSK07.img" size="1228800" crc="77f14264" sha1="a8b0e86d11ef7230e5714f5585ee67c23d2e58a6" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="freedos14_144">
+		<description>FreeDOS 1.4 (Floppy-Only Edition, 3.5" 1.44MB)</description>
+		<year>2025</year>
+		<publisher>The FreeDOS Project</publisher>
+		<info name="version" value="1.4" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installer" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86BOOT.img" size="1474560" crc="96f2cbaf" sha1="58627e80e30598f806a11342af4d6b0c36400a3f" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK01.img" size="1474560" crc="58e308b8" sha1="5d2379cbe8ddacf9619098d801df8e9ea70bed10" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK02.img" size="1474560" crc="6c02d6d8" sha1="23d276e84549c2d6dadf96a3b870a868de35c73f" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK03.img" size="1474560" crc="6627dc0c" sha1="50c6962128d23b4c0729dfe7d8ece02b623ae29a" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK04.img" size="1474560" crc="0892e7a4" sha1="5c7b4345cde968aa502e4dedf2bd1e31d153fcde" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK05.img" size="1474560" crc="c1a96bd7" sha1="eec0d289a14db3c3c43c9b630bf53480d0fc2a2a" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 6" />
+			<dataarea name="flop" size="1474560">
+				<rom name="x86DSK06.img" size="1474560" crc="c2094b10" sha1="b155ee091752fac2b2ae219343c51d58359ea036" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="gem11">
 		<description>GEM Desktop 1.1</description>
 		<year>1985</year>

--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -7254,6 +7254,37 @@ Installation and Open Circulation CDs are bootable.
 		</part>
 	</software>
 
+	<software name="freedos14">
+		<description>FreeDOS 1.4</description>
+		<year>2025</year>
+		<publisher>The FreeDOS Project</publisher>
+		<info name="version" value="1.4" />
+		<part name="cdrom1" interface="cdrom">
+			<feature name="part_id" value="LiveCD" />
+			<diskarea name="cdrom">
+				<disk name="fd14live" sha1="05d928a57c1197a78f0503f8c56d3b63e5334a5e" />
+			</diskarea>
+		</part>
+		<part name="cdrom2" interface="cdrom">
+			<feature name="part_id" value="Legacy CD" />
+			<diskarea name="cdrom">
+				<disk name="fd14lgcy" sha1="e0c4ccec6b798811df2849f2d7112f95e29cd4e3" />
+			</diskarea>
+		</part>
+		<part name="cdrom3" interface="cdrom">
+			<feature name="part_id" value="Bonus CD" />
+			<diskarea name="cdrom">
+				<disk name="fd14bns" sha1="12b6f445a75d4b1bc236626631396efd638f2381" />
+			</diskarea>
+		</part>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot Floppy" />
+			<dataarea name="flop" size="1474560">
+				<rom name="FD14BOOT.img" size="1474560" crc="930a7c56" sha1="67581ee9c6b20d44599626c2a68939de85b5b4a9" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="nasfdu12">
 		<description>NASLite NAS Server Operating System (v1.x)</description>
 		<year>2004</year>

--- a/hash/ibm5170_hdd.xml
+++ b/hash/ibm5170_hdd.xml
@@ -55,7 +55,7 @@ license:CC0-1.0
 		<info name="version" value="1.4" />
 		<part name="hdd" interface="ide_hdd">
 			<diskarea name="harddriv">
-				<disk name="freedos14" sha1="c1ffb2c1cbf3f9c8f6193d5ba9c5c01ce74d3d4e" writable="yes" />
+				<disk name="freedos14" sha1="c1ffb2c1cbf3f9c8f6193d5ba9c5c01ce74d3d4e" writeable="yes" />
 			</diskarea>
 		</part>
 	</software>

--- a/hash/ibm5170_hdd.xml
+++ b/hash/ibm5170_hdd.xml
@@ -47,6 +47,19 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="freedos14">
+		<description>FreeDOS (version 1.4)</description>
+		<year>2025</year>
+		<publisher>The FreeDOS Project</publisher>
+		<info name="language" value="English" />
+		<info name="version" value="1.4" />
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="freedos14" sha1="c1ffb2c1cbf3f9c8f6193d5ba9c5c01ce74d3d4e" writable="yes" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="msdos331">
 		<description>MS-DOS (Version 3.31)</description>
 		<year>1987</year>

--- a/hash/ibm5170_hdd.xml
+++ b/hash/ibm5170_hdd.xml
@@ -42,7 +42,7 @@ license:CC0-1.0
 		<info name="usage" value="FreeDOS contains a CPU detection bug in VINFO.COM, always reporting a 80186.  Edit C:\FDAUTO.BAT to remove calls to VINFO and always run Support286 or Support386 routines to work around the problem." />
 		<part name="hdd" interface="ide_hdd">
 			<diskarea name="harddriv">
-				<disk name="freedos13" sha1="72eef7bf0ad53b8a240ce05244173df54db923f0" writeable="yes"/>
+				<disk name="freedos13" sha1="756df2d38608588678c670a17cfc3c098c127df6" writeable="yes"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/ibm5170_hdd.xml
+++ b/hash/ibm5170_hdd.xml
@@ -48,7 +48,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="freedos14">
-		<description>FreeDOS (version 1.4)</description>
+		<description>FreeDOS 1.4</description>
 		<year>2025</year>
 		<publisher>The FreeDOS Project</publisher>
 		<info name="language" value="English" />


### PR DESCRIPTION
This one is installed with the CD-ROM version of the operating system, and the “Full” installation option selected.  It is much more representative of what FreeDOS is supposed to be than using the floppy disk set as in the previous image.

I've also made a repository to preserve and document the INP files used to create the FreeDOS disk images: https://github.com/chungy/mame-reprod-chd/tree/master/freedos13