### PR TITLE
hash/megadriv.xml: add Fix-It Felix Jr.

### DIFF
--- a/hash/a2600.xml
+++ b/hash/a2600.xml
@@ -6186,6 +6186,47 @@ MOS Atari-made game NTSC ROMs had a CO16xxx number and PAL ROMs had CO17xxx numb
 		</part>
 	</software>
 
+	<!-- https://forums.atariage.com/topic/210515-new-2600-homebrews-heartbreak-fix-it-felix-sr-joy-ride/ -->
+	<software name="felixsr">
+		<description>Fix-It Felix Sr.</description>
+		<year>2013</year>
+		<publisher>Cybearg</publisher>
+		<info name="release" value="20130327"/>
+		<sharedfeat name="compatibility" value="NTSC"/>
+		<part name="cart" interface="a2600_cart">
+			<dataarea name="rom" size="4096">
+				<rom name="fix-it felix sr. (pal50).bin" size="4096" crc="4f066bc9" sha1="296d9c1ef7b214b863516822c7a38009559f3a2a"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="felixsre" cloneof="felixsr">
+		<description>Fix-It Felix Sr. (PAL)</description>
+		<year>2013</year>
+		<publisher>Cybearg</publisher>
+		<info name="release" value="20130327"/>
+		<sharedfeat name="compatibility" value="PAL" />
+		<part name="cart" interface="a2600_cart">
+			<dataarea name="rom" size="4096">
+				<rom name="fix-it felix sr. (pal50).bin" size="4096" crc="a0a88a0c" sha1="8942868cead351fffd1914fd52b523bdc774dace"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Is this meant for a console mod? -->
+	<software name="felixsrea" cloneof="felixsr" supported="no">
+		<description>Fix-It Felix Sr. (PAL60)</description>
+		<year>2013</year>
+		<publisher>Cybearg</publisher>
+		<info name="release" value="20130327"/>
+		<sharedfeat name="compatibility" value="PAL" />
+		<part name="cart" interface="a2600_cart">
+			<dataarea name="rom" size="4096">
+				<rom name="fix-it felix sr. (pal60).bin" size="4096" crc="b0677067" sha1="5a258bdfdf1c72c7b74d1a90f7fb8f7a4d3f7cc7"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="festival">
 		<description>Festival (PAL)</description>
 		<year>1983</year>

--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -3006,6 +3006,58 @@ Crashes after EA logo, requires better [VDP] irq handling
 	</software>
 
 
+	<software name="felixjr">
+		<description>Fix-it Felix Jr.</description>
+		<year>2014</year>
+		<publisher>Airwalk Studios</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="601870">
+				<rom name="fix-it felix jr (final)" size="601870" crc="424ff451" sha1="2bad4a0db0f95a7588e75f344c25427a6e83522b" />
+			</dataarea>
+		</part>
+	</software>
+
+
+	<!-- Another, 1.12, version is known to have existed between this and the final version
+		 See: https://www.youtube.com/watch?v=_1uGkfw5ky8 -->
+	<software name="felixjro" cloneof="felixjr">
+		<description>Fix-it Felix Jr. (v1.0)</description>
+		<year>2013</year>
+		<publisher>Airwalk Studios</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="131072">
+				<rom name="fix-it felix jr (1.0)" size="131072" crc="0b3ab7e9" sha1="c097b6dda7c0014e269884602bacd0eaff02d005" />
+			</dataarea>
+		</part>
+	</software>
+
+
+	<software name="wreckit" cloneof="felixjr">
+		<description>Wreck It Ralph (Russian translation bootleg)</description>
+		<year>2022</year>
+		<publisher>T+Rus Pirates</publisher>
+		<info name="language" value="Russian" />
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="601870">
+				<rom name="wreck it ralph (trus bootleg)" size="601870" crc="6eec9f12" sha1="72eb534155a846327f2081566d7fa5ff12952ffa" />
+			</dataarea>
+		</part>
+	</software>
+
+
+	<software name="wreckita" cloneof="felixjr">
+		<description>Wreck It Ralph (Russian translation bootleg, alt)</description>
+		<year>2022</year>
+		<publisher>T+Rus Pirates</publisher>
+		<info name="language" value="Russian" />
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="601870">
+				<rom name="wreck it ralph (trus bootleg alt)" size="601870" crc="ac8e0de5" sha1="68d1908926c39c336340300742086d5e17bf9806" />
+			</dataarea>
+		</part>
+	</software>
+
+
 	<software name="feverpit">
 		<description>Fever Pitch (Europe)</description>
 		<year>1995</year>

--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -3012,7 +3012,7 @@ Crashes after EA logo, requires better [VDP] irq handling
 		<publisher>Airwalk Studios</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="601870">
-				<rom name="fix-it felix jr (final)" size="601870" crc="424ff451" sha1="2bad4a0db0f95a7588e75f344c25427a6e83522b" />
+				<rom name="fix-it felix jr (final).bin" size="601870" crc="424ff451" sha1="2bad4a0db0f95a7588e75f344c25427a6e83522b" />
 			</dataarea>
 		</part>
 	</software>
@@ -3026,7 +3026,7 @@ Crashes after EA logo, requires better [VDP] irq handling
 		<publisher>Airwalk Studios</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="131072">
-				<rom name="fix-it felix jr (1.0)" size="131072" crc="0b3ab7e9" sha1="c097b6dda7c0014e269884602bacd0eaff02d005" />
+				<rom name="fix-it felix jr (1.0).bin" size="131072" crc="0b3ab7e9" sha1="c097b6dda7c0014e269884602bacd0eaff02d005" />
 			</dataarea>
 		</part>
 	</software>
@@ -3039,7 +3039,7 @@ Crashes after EA logo, requires better [VDP] irq handling
 		<info name="language" value="Russian" />
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="601870">
-				<rom name="wreck it ralph (trus bootleg)" size="601870" crc="6eec9f12" sha1="72eb534155a846327f2081566d7fa5ff12952ffa" />
+				<rom name="wreck it ralph (trus bootleg).bin" size="601870" crc="6eec9f12" sha1="72eb534155a846327f2081566d7fa5ff12952ffa" />
 			</dataarea>
 		</part>
 	</software>
@@ -3052,7 +3052,7 @@ Crashes after EA logo, requires better [VDP] irq handling
 		<info name="language" value="Russian" />
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="601870">
-				<rom name="wreck it ralph (trus bootleg alt)" size="601870" crc="ac8e0de5" sha1="68d1908926c39c336340300742086d5e17bf9806" />
+				<rom name="wreck it ralph (trus bootleg alt).bin" size="601870" crc="ac8e0de5" sha1="68d1908926c39c336340300742086d5e17bf9806" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -3020,7 +3020,7 @@ Crashes after EA logo, requires better [VDP] irq handling
 
 	<!-- Another, 1.12, version is known to have existed between this and the final version
 		 See: https://www.youtube.com/watch?v=_1uGkfw5ky8 -->
-	<software name="felixjro" cloneof="felixjr">
+	<software name="felixjrv10" cloneof="felixjr">
 		<description>Fix-it Felix Jr. (v1.0)</description>
 		<year>2013</year>
 		<publisher>Airwalk Studios</publisher>


### PR DESCRIPTION
I had 1.0 on my hard disk, never knew it was updated until now.  Found the final release easily, there's a "1.12" referenced in a YouTube video between 1.0 and final, but I was unable to find a copy.

Archive.org has the Russian translation hacks, too.

New working software list items (megadriv.xml)
----------------------------------------------
Fix-it Felix Jr.
Fix-it Felix Jr. (v1.0) [chungy]
Wreck It Ralph (Russian translation bootleg) [unknown]
Wreck It Ralph (Russian translation bootleg, alt) [unknown]