### PR TITLE
radikalb: add output start lamp to Gaelco Radikal Bikers

### DIFF
--- a/src/mame/gaelco/gaelco3d.cpp
+++ b/src/mame/gaelco/gaelco3d.cpp
@@ -189,6 +189,8 @@ void gaelco3d_state::machine_start()
 	save_item(NAME(m_fp_state));
 	save_item(NAME(m_fp_analog_ports));
 	save_item(NAME(m_fp_lenght));
+	// Init outputs
+	m_start_lamp.resolve();
 }
 
 
@@ -643,8 +645,8 @@ void gaelco3d_state::adsp_tx_callback(offs_t offset, uint32_t data)
 
 void gaelco3d_state::radikalb_lamp_w(int state)
 {
-	// Arbitrary data written
-	logerror("%06X:unknown_127_w = %d\n", m_maincpu->pc(), state);
+	// Lamp data written directly from latch to output
+	m_start_lamp = m_outlatch->q2_r();
 }
 
 void gaelco3d_state::unknown_137_w(int state)

--- a/src/mame/gaelco/gaelco3d.cpp
+++ b/src/mame/gaelco/gaelco3d.cpp
@@ -189,8 +189,6 @@ void gaelco3d_state::machine_start()
 	save_item(NAME(m_fp_state));
 	save_item(NAME(m_fp_analog_ports));
 	save_item(NAME(m_fp_lenght));
-	// Init outputs
-	m_start_lamp.resolve();
 }
 
 
@@ -642,13 +640,6 @@ void gaelco3d_state::adsp_tx_callback(offs_t offset, uint32_t data)
  *
  *************************************/
 
-
-void gaelco3d_state::radikalb_lamp_w(int state)
-{
-	// Lamp data written directly from latch to output
-	m_start_lamp = m_outlatch->q2_r();
-}
-
 void gaelco3d_state::unknown_137_w(int state)
 {
 	// Only written $00 or $ff
@@ -950,7 +941,7 @@ void gaelco3d_state::gaelco3d(machine_config &config)
 
 	LS259(config, m_outlatch); // IC2 on top board near edge connector
 	m_outlatch->q_out_cb<1>().set(FUNC(gaelco3d_state::tms_control3_w));
-	m_outlatch->q_out_cb<2>().set(FUNC(gaelco3d_state::radikalb_lamp_w));
+	m_outlatch->q_out_cb<2>().set_output("Start_lamp"); // START LAMP
 	m_outlatch->q_out_cb<3>().set(FUNC(gaelco3d_state::unknown_137_w));
 	m_outlatch->q_out_cb<4>().set(m_serial, FUNC(gaelco_serial_device::irq_enable));
 	m_outlatch->q_out_cb<5>().set(FUNC(gaelco3d_state::analog_port_clock_w));

--- a/src/mame/gaelco/gaelco3d.h
+++ b/src/mame/gaelco/gaelco3d.h
@@ -51,7 +51,6 @@ public:
 		, m_paletteram32(*this, "paletteram32")
 		, m_analog(*this, "ANALOG%u", 0U)
 		, m_adsp_bank(*this, "adspbank")
-		, m_start_lamp(*this, "Start_lamp")
 	{ }
 
 	void footbpow(machine_config &config);
@@ -156,7 +155,6 @@ private:
 	void tms_control3_w(int state);
 	void adsp_control_w(offs_t offset, uint16_t data);
 	void adsp_rombank_w(offs_t offset, uint16_t data);
-	void radikalb_lamp_w(int state);
 	void unknown_137_w(int state);
 	void unknown_13a_w(int state);
 	void gaelco3d_render_w(uint32_t data);
@@ -179,8 +177,6 @@ private:
 	void main020_map(address_map &map) ATTR_COLD;
 	void main_map(address_map &map) ATTR_COLD;
 	void tms_map(address_map &map) ATTR_COLD;
-
-	output_finder<> m_start_lamp;
 };
 
 #endif // MAME_GAELCO_GAELCO3D_H

--- a/src/mame/gaelco/gaelco3d.h
+++ b/src/mame/gaelco/gaelco3d.h
@@ -51,6 +51,7 @@ public:
 		, m_paletteram32(*this, "paletteram32")
 		, m_analog(*this, "ANALOG%u", 0U)
 		, m_adsp_bank(*this, "adspbank")
+		, m_start_lamp(*this, "Start_lamp")
 	{ }
 
 	void footbpow(machine_config &config);
@@ -178,6 +179,8 @@ private:
 	void main020_map(address_map &map) ATTR_COLD;
 	void main_map(address_map &map) ATTR_COLD;
 	void tms_map(address_map &map) ATTR_COLD;
+
+	output_finder<> m_start_lamp;
 };
 
 #endif // MAME_GAELCO_GAELCO3D_H


### PR DESCRIPTION
This PR adds the Start Lamp output for Radikal Bikers, now it can be used on external devices to simulate the original European Gaelco cabinet version.