### PR TITLE
Fixed MT#08942 (some broken minigames in coolmini)

### DIFF
--- a/src/devices/cpu/e132xs/e132xsdrc_ops.hxx
+++ b/src/devices/cpu/e132xs/e132xsdrc_ops.hxx
@@ -665,6 +665,7 @@ void hyperstone_device::generate_divsu(drcuml_block &block, compiler_state &comp
 	{
 		UML_DTEST(block, I1, 0x8000000000000000LL);
 		UML_JMPc(block, uml::COND_NZ, no_result);
+		UML_DSEXT(block, I0, I0, SIZE_DWORD);
 	}
 
 	if (SIGNED)


### PR DESCRIPTION
MAME Testers bugs fixed
-----------------------
- 08942: [Gameplay] (misc/vamphalf.cpp) coolmini: Minigames don't work properly/softlock

-e132xs: Sign-extend the divisor in DIVS instructions. [Ryan Holtz]