### PR TITLE
3rdparty.lua: Fix compilation of Lzma for arm64 architecture

### DIFF
--- a/scripts/src/3rdparty.lua
+++ b/scripts/src/3rdparty.lua
@@ -866,6 +866,7 @@ project "7z"
 	configuration { "gmake or ninja" }
 		buildoptions_c {
 			"-Wno-error=undef",
+			"-Wno-error=strict-prototypes"
 		}
 if _OPTIONS["gcc"]~=nil then
 	if string.find(_OPTIONS["gcc"], "clang") then

--- a/scripts/src/3rdparty.lua
+++ b/scripts/src/3rdparty.lua
@@ -866,7 +866,7 @@ project "7z"
 	configuration { "gmake or ninja" }
 		buildoptions_c {
 			"-Wno-error=undef",
-			"-Wno-error=strict-prototypes"
+			"-Wno-error=strict-prototypes",
 		}
 if _OPTIONS["gcc"]~=nil then
 	if string.find(_OPTIONS["gcc"], "clang") then


### PR DESCRIPTION
The builder was failing in compiling the Lzma source code due to the global compiler flag `-Werror -Wstrict-prototype` triggering errors when compiling code specific to arm64 architecture.

This PR sets the  `-Wno-error=strict-prototypes` flag when building the Lzma library