### PR TITLE
heathzenith/h19/tlb.cpp: Make the page 2 memory option configurable for UltraROM

### DIFF
--- a/src/devices/bus/heathzenith/h19/tlb.h
+++ b/src/devices/bus/heathzenith/h19/tlb.h
@@ -220,9 +220,14 @@ public:
 protected:
 	virtual const tiny_rom_entry *device_rom_region() const override ATTR_COLD;
 	virtual ioport_constructor device_input_ports() const override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 
 	void mem_map(address_map &map) ATTR_COLD;
+
+	required_memory_region m_maincpu_region;
+	required_shared_ptr<u8> m_page_2_ram;
+	memory_view m_mem_view;
 };
 
 /**
@@ -374,9 +379,14 @@ public:
 protected:
 	virtual const tiny_rom_entry *device_rom_region() const override ATTR_COLD;
 	virtual ioport_constructor device_input_ports() const override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 
 	void mem_map(address_map &map) ATTR_COLD;
+
+	required_memory_region m_maincpu_region;
+	required_shared_ptr<u8> m_page_2_ram;
+	memory_view m_mem_view;
 };
 
 /**

--- a/src/mame/heathzenith/h89.cpp
+++ b/src/mame/heathzenith/h89.cpp
@@ -296,16 +296,16 @@ void h89_base_state::h89_mem(address_map &map)
 	// View 0 - ROM / Floppy RAM R/O
 	// View 1 - ROM / Floppy RAM R/W
 	// monitor ROM
-	m_mem_view[0](0x0000, 0x0fff).rom().region("maincpu", 0).unmapw();
-	m_mem_view[1](0x0000, 0x0fff).rom().region("maincpu", 0).unmapw();
+	m_mem_view[0](0x0000, 0x0fff).rom().region(m_maincpu_region, 0).unmapw();
+	m_mem_view[1](0x0000, 0x0fff).rom().region(m_maincpu_region, 0).unmapw();
 
 	// Floppy RAM
 	m_mem_view[0](0x1400, 0x17ff).readonly().share(m_floppy_ram);
 	m_mem_view[1](0x1400, 0x17ff).ram().share(m_floppy_ram);
 
 	// Floppy ROM
-	m_mem_view[0](0x1800, 0x1fff).rom().region("maincpu", 0x1800).unmapw();
-	m_mem_view[1](0x1800, 0x1fff).rom().region("maincpu", 0x1800).unmapw();
+	m_mem_view[0](0x1800, 0x1fff).rom().region(m_maincpu_region, 0x1800).unmapw();
+	m_mem_view[1](0x1800, 0x1fff).rom().region(m_maincpu_region, 0x1800).unmapw();
 }
 
 void h89_base_state::map_fetch(address_map &map)


### PR DESCRIPTION
tlb.cpp: 

- Add machine configuration option to install/remove the optional page 2 memory for the UltraROM.

h89.cpp:

- Use class variable instead of tag for memory_view region routine.
