### PR TITLE
namco/namco_cus4xtmap.cpp: Device-fied CUS42 + CUS43 tilemap hardware, Cleanups:

### DIFF
--- a/src/mame/namco/baraduke.cpp
+++ b/src/mame/namco/baraduke.cpp
@@ -107,10 +107,11 @@ DIP locations verified for:
 
 #include "emu.h"
 
+#include "namco_cus4xtmap.h"
+
 #include "cpu/m6800/m6801.h"
 #include "cpu/m6809/m6809.h"
 #include "machine/watchdog.h"
-#include "namco_cus4xtmap.h"
 #include "sound/namco.h"
 #include "video/resnet.h"
 
@@ -141,8 +142,8 @@ public:
 		m_lamps(*this, "lamp%u", 0U)
 	{ }
 
-	void init_baraduke();
-	void baraduke(machine_config &config);
+	void init_baraduke() ATTR_COLD;
+	void baraduke(machine_config &config) ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
@@ -157,8 +158,8 @@ private:
 	void spriteram_w(offs_t offset, uint8_t data);
 	TILEMAP_MAPPER_MEMBER(tx_tilemap_scan);
 	TILE_GET_INFO_MEMBER(tx_get_tile_info);
-	void tile_cb(u8 layer, u8& gfxno, u32& code);
-	void palette(palette_device &palette) const;
+	void tile_cb(u8 layer, u8 &gfxno, u32 &code);
+	void palette(palette_device &palette) const ATTR_COLD;
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void screen_vblank(int state);
 	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);

--- a/src/mame/namco/baraduke.cpp
+++ b/src/mame/namco/baraduke.cpp
@@ -110,7 +110,9 @@ DIP locations verified for:
 #include "cpu/m6800/m6801.h"
 #include "cpu/m6809/m6809.h"
 #include "machine/watchdog.h"
+#include "namco_cus4xtmap.h"
 #include "sound/namco.h"
+#include "video/resnet.h"
 
 #include "emupal.h"
 #include "screen.h"
@@ -126,11 +128,11 @@ public:
 	baraduke_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_spriteram(*this, "spriteram"),
-		m_videoram(*this, "videoram"),
 		m_textram(*this, "textram"),
 		m_maincpu(*this, "maincpu"),
 		m_mcu(*this, "mcu"),
 		m_cus30(*this, "namco"),
+		m_tilegen(*this, "tilegen"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
 		m_in(*this, "IN%u", 0U),
@@ -151,29 +153,25 @@ private:
 	uint8_t inputport_r();
 	void lamps_w(uint8_t data);
 	void irq_ack_w(uint8_t data);
-	void videoram_w(offs_t offset, uint8_t data);
 	void textram_w(offs_t offset, uint8_t data);
-	template <uint8_t Which> void scroll_w(offs_t offset, uint8_t data);
 	void spriteram_w(offs_t offset, uint8_t data);
 	TILEMAP_MAPPER_MEMBER(tx_tilemap_scan);
 	TILE_GET_INFO_MEMBER(tx_get_tile_info);
-	TILE_GET_INFO_MEMBER(get_tile_info0);
-	TILE_GET_INFO_MEMBER(get_tile_info1);
+	void tile_cb(u8 layer, u8& gfxno, u32& code);
 	void palette(palette_device &palette) const;
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void screen_vblank(int state);
 	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void set_scroll(int layer);
 	void main_map(address_map &map) ATTR_COLD;
 	void mcu_map(address_map &map) ATTR_COLD;
 
 	required_shared_ptr<uint8_t> m_spriteram;
-	required_shared_ptr<uint8_t> m_videoram;
 	required_shared_ptr<uint8_t> m_textram;
 
 	required_device<cpu_device> m_maincpu;
 	required_device<hd63701v0_cpu_device> m_mcu;
 	required_device<namco_cus30_device> m_cus30;
+	required_device<namco_cus4xtmap_device> m_tilegen;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
 
@@ -184,9 +182,6 @@ private:
 
 	uint8_t m_inputport_selected = 0;
 	tilemap_t *m_tx_tilemap = nullptr;
-	tilemap_t *m_bg_tilemap[2]{};
-	uint16_t m_xscroll[2]{};
-	uint8_t m_yscroll[2]{};
 	bool m_copy_sprites = false;
 };
 
@@ -197,44 +192,60 @@ private:
 
     The palette PROMs are connected to the RGB output this way:
 
-    bit 3   -- 220 ohm resistor  -- RED/GREEN/BLUE
-            -- 470 ohm resistor  -- RED/GREEN/BLUE
-            -- 1  kohm resistor  -- RED/GREEN/BLUE
-    bit 0   -- 2.2kohm resistor  -- RED/GREEN/BLUE
+    bit 7 -- 220 ohm resistor  -- BLUE
+          -- 470 ohm resistor  -- BLUE
+          -- 1  kohm resistor  -- BLUE
+          -- 2.2kohm resistor  -- BLUE
+          -- 220 ohm resistor  -- GREEN
+          -- 470 ohm resistor  -- GREEN
+          -- 1  kohm resistor  -- GREEN
+    bit 0 -- 2.2kohm resistor  -- GREEN
+
+    bit 3 -- 220 ohm resistor  -- RED
+          -- 470 ohm resistor  -- RED
+          -- 1  kohm resistor  -- RED
+    bit 0 -- 2.2kohm resistor  -- RED
 
 ***************************************************************************/
 
 void baraduke_state::palette(palette_device &palette) const
 {
-	const uint8_t *color_prom = memregion("proms")->base();
+	uint8_t const *const color_prom = memregion("proms")->base();
+	static constexpr int resistances[4] = { 2200, 1000, 470, 220 };
+
+	// compute the color output resistor weights
+	double rweights[4], gweights[4], bweights[4];
+	compute_resistor_weights(0, 255, -1.0,
+			4, &resistances[0], rweights, 0, 0,
+			4, &resistances[0], gweights, 0, 0,
+			4, &resistances[0], bweights, 0, 0);
 
 	for (int i = 0; i < 2048; i++)
 	{
 		int bit0, bit1, bit2, bit3;
 
 		// red component
-		bit0 = BIT(color_prom[2048], 0);
-		bit1 = BIT(color_prom[2048], 1);
-		bit2 = BIT(color_prom[2048], 2);
-		bit3 = BIT(color_prom[2048], 3);
-		int const r = 0x0e * bit0 + 0x1f * bit1 + 0x43 * bit2 + 0x8f * bit3;
+		bit0 = BIT(color_prom[i | 0x800], 0);
+		bit1 = BIT(color_prom[i | 0x800], 1);
+		bit2 = BIT(color_prom[i | 0x800], 2);
+		bit3 = BIT(color_prom[i | 0x800], 3);
+		int const r = combine_weights(rweights, bit0, bit1, bit2, bit3);
 
 		// green component
-		bit0 = BIT(color_prom[0], 0);
-		bit1 = BIT(color_prom[0], 1);
-		bit2 = BIT(color_prom[0], 2);
-		bit3 = BIT(color_prom[0], 3);
-		int const g = 0x0e * bit0 + 0x1f * bit1 + 0x43 * bit2 + 0x8f * bit3;
+		bit0 = BIT(color_prom[i], 0);
+		bit1 = BIT(color_prom[i], 1);
+		bit2 = BIT(color_prom[i], 2);
+		bit3 = BIT(color_prom[i], 3);
+		int const g = combine_weights(gweights, bit0, bit1, bit2, bit3);
 
 		// blue component
-		bit0 = BIT(color_prom[0], 4);
-		bit1 = BIT(color_prom[0], 5);
-		bit2 = BIT(color_prom[0], 6);
-		bit3 = BIT(color_prom[0], 7);
-		int const b = 0x0e * bit0 + 0x1f * bit1 + 0x43 * bit2 + 0x8f * bit3;
+		bit0 = BIT(color_prom[i], 4);
+		bit1 = BIT(color_prom[i], 5);
+		bit2 = BIT(color_prom[i], 6);
+		bit3 = BIT(color_prom[i], 7);
+		int const b = combine_weights(bweights, bit0, bit1, bit2, bit3);
 
 		palette.set_pen_color(i, rgb_t(r, g, b));
-		color_prom++;
 	}
 }
 
@@ -266,28 +277,10 @@ TILE_GET_INFO_MEMBER(baraduke_state::tx_get_tile_info)
 			0);
 }
 
-TILE_GET_INFO_MEMBER(baraduke_state::get_tile_info0)
+void baraduke_state::tile_cb(u8 layer, u8& gfxno, u32& code)
 {
-	int const code = m_videoram[2 * tile_index];
-	int const attr = m_videoram[2 * tile_index + 1];
-
-	tileinfo.set(1,
-			code + ((attr & 0x03) << 8),
-			attr,
-			0);
+	gfxno = layer & 1;
 }
-
-TILE_GET_INFO_MEMBER(baraduke_state::get_tile_info1)
-{
-	int const code = m_videoram[0x1000 + 2 * tile_index];
-	int const attr = m_videoram[0x1000 + 2 * tile_index + 1];
-
-	tileinfo.set(2,
-			code + ((attr & 0x03) << 8),
-			attr,
-			0);
-}
-
 
 
 /***************************************************************************
@@ -299,21 +292,9 @@ TILE_GET_INFO_MEMBER(baraduke_state::get_tile_info1)
 void baraduke_state::video_start()
 {
 	m_tx_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(baraduke_state::tx_get_tile_info)), tilemap_mapper_delegate(*this, FUNC(baraduke_state::tx_tilemap_scan)), 8, 8, 36, 28);
-	m_bg_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(baraduke_state::get_tile_info0)), TILEMAP_SCAN_ROWS, 8, 8, 64, 32);
-	m_bg_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(baraduke_state::get_tile_info1)), TILEMAP_SCAN_ROWS, 8, 8, 64, 32);
-
 	m_tx_tilemap->set_transparent_pen(3);
-	m_bg_tilemap[0]->set_transparent_pen(7);
-	m_bg_tilemap[1]->set_transparent_pen(7);
-
-	m_bg_tilemap[0]->set_scrolldx(-26, -227 + 26);
-	m_bg_tilemap[1]->set_scrolldx(-24, -227 + 24);
-	m_bg_tilemap[0]->set_scrolldy(-9, 9);
-	m_bg_tilemap[1]->set_scrolldy(-9, 9);
 	m_tx_tilemap->set_scrolldy(16, 16);
 
-	save_item(NAME(m_xscroll));
-	save_item(NAME(m_yscroll));
 	save_item(NAME(m_copy_sprites));
 }
 
@@ -325,33 +306,10 @@ void baraduke_state::video_start()
 
 ***************************************************************************/
 
-void baraduke_state::videoram_w(offs_t offset, uint8_t data)
-{
-	m_videoram[offset] = data;
-	m_bg_tilemap[offset / 0x1000]->mark_tile_dirty((offset & 0xfff) / 2);
-}
-
 void baraduke_state::textram_w(offs_t offset, uint8_t data)
 {
 	m_textram[offset] = data;
 	m_tx_tilemap->mark_tile_dirty(offset & 0x3ff);
-}
-
-template <uint8_t Which>
-void baraduke_state::scroll_w(offs_t offset, uint8_t data)
-{
-	switch (offset)
-	{
-		case 0: // high scroll x
-			m_xscroll[Which] = (m_xscroll[Which] & 0xff) | (data << 8);
-			break;
-		case 1: // low scroll x
-			m_xscroll[Which] = (m_xscroll[Which] & 0xff00) | data;
-			break;
-		case 2: // scroll y
-			m_yscroll[Which] = data;
-			break;
-	}
 }
 
 void baraduke_state::spriteram_w(offs_t offset, uint8_t data)
@@ -373,12 +331,11 @@ void baraduke_state::spriteram_w(offs_t offset, uint8_t data)
 
 void baraduke_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint8_t *spriteram = m_spriteram + 0x1800;
-	const uint8_t *source = &spriteram[0x0800 - 32]; // the last is NOT a sprite
-	const uint8_t *finish = &spriteram[0x0000];
+	const uint8_t *source = &m_spriteram[0x2000 - 32]; // the last is NOT a sprite
+	const uint8_t *finish = &m_spriteram[0x1800];
 
-	int const sprite_xoffs = spriteram[0x07f5] - 256 * (spriteram[0x07f4] & 1);
-	int const sprite_yoffs = spriteram[0x07f7];
+	int const sprite_xoffs = m_spriteram[0x1ff5] - 256 * (m_spriteram[0x1ff4] & 1);
+	int const sprite_yoffs = m_spriteram[0x1ff7];
 
 	static constexpr int gfx_offs[2][2] =
 	{
@@ -430,7 +387,7 @@ void baraduke_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, c
 		{
 			for (int x = 0; x <= sizex; x++)
 			{
-				m_gfxdecode->gfx(3)->prio_transpen(bitmap, cliprect,
+				m_gfxdecode->gfx(1)->prio_transpen(bitmap, cliprect,
 					sprite + gfx_offs[y ^ (sizey * flipy)][x ^ (sizex * flipx)],
 					color,
 					flipx, flipy,
@@ -445,40 +402,18 @@ void baraduke_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, c
 }
 
 
-void baraduke_state::set_scroll(int layer)
-{
-	int scrollx = m_xscroll[layer];
-	int scrolly = m_yscroll[layer];
-
-	if (flip_screen())
-	{
-		scrollx = -scrollx;
-		scrolly = -scrolly;
-	}
-
-	m_bg_tilemap[layer]->set_scrollx(0, scrollx);
-	m_bg_tilemap[layer]->set_scrolly(0, scrolly);
-}
-
-
 uint32_t baraduke_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen.priority().fill(0, cliprect);
 
 	// flip screen is embedded in the sprite control registers
-	flip_screen_set(m_spriteram[0x1ff6] & 0x01);
-	set_scroll(0);
-	set_scroll(1);
+	flip_screen_set(BIT(m_spriteram[0x1ff6], 0));
+	m_tilegen->init_scroll(flip_screen());
 
-	int back;
+	int const back = (((m_tilegen->xscroll_r(0) & 0x0e00) >> 9) == 6) ? 1 : 0;
 
-	if (((m_xscroll[0] & 0x0e00) >> 9) == 6)
-		back = 1;
-	else
-		back = 0;
-
-	m_bg_tilemap[back]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-	m_bg_tilemap[back ^ 1]->draw(screen, bitmap, cliprect, 0, 2);
+	m_tilegen->draw(screen, bitmap, cliprect, back, TILEMAP_DRAW_OPAQUE, 1);
+	m_tilegen->draw(screen, bitmap, cliprect, back ^ 1, 0, 2);
 	draw_sprites(screen, bitmap, cliprect);
 
 	m_tx_tilemap->draw(screen, bitmap, cliprect, 0, 0);
@@ -514,9 +449,9 @@ void baraduke_state::inputport_select_w(uint8_t data)
 		m_inputport_selected = data & 0x07;
 	else if ((data & 0xe0) == 0xc0)
 	{
-		machine().bookkeeping().coin_lockout_global_w(~data & 1);
-		machine().bookkeeping().coin_counter_w(0, data & 2);
-		machine().bookkeeping().coin_counter_w(1, data & 4);
+		machine().bookkeeping().coin_lockout_global_w(BIT(~data, 0));
+		machine().bookkeeping().coin_counter_w(0, BIT(data, 1));
+		machine().bookkeeping().coin_counter_w(1, BIT(data, 2));
 	}
 }
 
@@ -559,14 +494,14 @@ void baraduke_state::irq_ack_w(uint8_t data)
 void baraduke_state::main_map(address_map &map)
 {
 	map(0x0000, 0x1fff).ram().w(FUNC(baraduke_state::spriteram_w)).share(m_spriteram);
-	map(0x2000, 0x3fff).ram().w(FUNC(baraduke_state::videoram_w)).share(m_videoram);
+	map(0x2000, 0x3fff).rw(m_tilegen, FUNC(namco_cus4xtmap_device::vram_r), FUNC(namco_cus4xtmap_device::vram_w));
 	map(0x4000, 0x43ff).rw(m_cus30, FUNC(namco_cus30_device::namcos1_cus30_r), FUNC(namco_cus30_device::namcos1_cus30_w)); // PSG device, shared RAM
 	map(0x4800, 0x4fff).ram().w(FUNC(baraduke_state::textram_w)).share(m_textram);
+	map(0x6000, 0xffff).rom();
 	map(0x8000, 0x8000).w("watchdog", FUNC(watchdog_timer_device::reset_w));
 	map(0x8800, 0x8800).w(FUNC(baraduke_state::irq_ack_w));
-	map(0xb000, 0xb002).w(FUNC(baraduke_state::scroll_w<0>));
-	map(0xb004, 0xb006).w(FUNC(baraduke_state::scroll_w<1>));
-	map(0x6000, 0xffff).rom();
+	map(0xb000, 0xb002).w(m_tilegen, FUNC(namco_cus4xtmap_device::scroll_w<0>));
+	map(0xb004, 0xb006).w(m_tilegen, FUNC(namco_cus4xtmap_device::scroll_w<1>));
 }
 
 void baraduke_state::mcu_map(address_map &map)
@@ -702,10 +637,10 @@ static const gfx_layout text_layout =
 	8,8,
 	RGN_FRAC(1,1),
 	2,
-	{ 0, 4 },
-	{ 8*8, 8*8+1, 8*8+2, 8*8+3, 0, 1, 2, 3 },
-	{ 0*8, 1*8, 2*8, 3*8, 4*8, 5*8, 6*8, 7*8 },
-	16*8
+	{ STEP2(0, 4) },
+	{ STEP4(8*8, 1), STEP4(0, 1) },
+	{ STEP8(0, 8) },
+	8*8*2
 };
 
 static const gfx_layout tile_layout =
@@ -713,17 +648,20 @@ static const gfx_layout tile_layout =
 	8,8,
 	1024,
 	3,
-	{ 0x8000*8, 0, 4 },
-	{ 0, 1, 2, 3, 8+0, 8+1, 8+2, 8+3 },
-	{ 0*8, 2*8, 4*8, 6*8, 8*8, 10*8, 12*8, 14*8 },
+	{ 0x8000*8, STEP2(0, 4) },
+	{ STEP4(0, 1), STEP4(8, 1) },
+	{ STEP8(0, 8*2) },
 	16*8
 };
 
 static GFXDECODE_START( gfx_baraduke )
-	GFXDECODE_ENTRY( "chars",   0,      text_layout,            0, 512 )
-	GFXDECODE_ENTRY( "tiles",   0x0000, tile_layout,            0, 256 )
-	GFXDECODE_ENTRY( "tiles",   0x4000, tile_layout,            0, 256 )
-	GFXDECODE_ENTRY( "sprites", 0,      gfx_16x16x4_packed_msb, 0, 128 )
+	GFXDECODE_ENTRY( "chars",   0, text_layout,            0, 512 )
+	GFXDECODE_ENTRY( "sprites", 0, gfx_16x16x4_packed_msb, 0, 128 )
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_baraduke_tile )
+	GFXDECODE_ENTRY( "tiles", 0x0000, tile_layout, 0, 256 )
+	GFXDECODE_ENTRY( "tiles", 0x4000, tile_layout, 0, 256 )
 GFXDECODE_END
 
 
@@ -758,6 +696,10 @@ void baraduke_state::baraduke(machine_config &config)
 	screen.set_screen_update(FUNC(baraduke_state::screen_update));
 	screen.screen_vblank().set(FUNC(baraduke_state::screen_vblank));
 	screen.set_palette(m_palette);
+
+	NAMCO_CUS4XTMAP(config, m_tilegen, 0, m_palette, gfx_baraduke_tile);
+	m_tilegen->set_offset(-26, -227, -9, 9);
+	m_tilegen->set_tile_callback(FUNC(baraduke_state::tile_cb));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_baraduke);
 	PALETTE(config, m_palette, FUNC(baraduke_state::palette), 2048);

--- a/src/mame/namco/namco_cus4xtmap.cpp
+++ b/src/mame/namco/namco_cus4xtmap.cpp
@@ -1,0 +1,121 @@
+// license:BSD-3-Clause
+// copyright-holders:Manuel Abadia, Nicola Salmoria
+
+/*
+    CUS42 + CUS43 Tilemaps
+    used by
+    baraduke.cpp (all games)
+	namcos86.cpp (all games)
+*/
+
+#include "emu.h"
+#include "namco_cus4xtmap.h"
+
+DEFINE_DEVICE_TYPE(NAMCO_CUS4XTMAP, namco_cus4xtmap_device, "namco_cus4xtmap", "Namco CUS42 + CUS43 (2x Tilemaps)")
+
+namco_cus4xtmap_device::namco_cus4xtmap_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, NAMCO_CUS4XTMAP, tag, owner, clock)
+	, device_gfx_interface(mconfig, *this)
+	, m_tile_cb(*this)
+	, m_vram(*this, "videoram", 0x2000, ENDIANNESS_BIG)
+	, m_tilemap{nullptr, nullptr}
+	, m_xscroll{0, 0}
+	, m_yscroll{0, 0}
+	, m_xoffs(0)
+	, m_yoffs(0)
+	, m_flipped_xoffs(0)
+	, m_flipped_yoffs(0)
+{
+}
+
+void namco_cus4xtmap_device::device_start()
+{
+	m_tile_cb.resolve();
+
+	// two scrolling tilemaps
+	m_tilemap[0] = &machine().tilemap().create(*this, tilemap_get_info_delegate(*this, FUNC(namco_cus4xtmap_device::get_tile_info<0>)), TILEMAP_SCAN_ROWS, 8, 8, 64, 32);
+	m_tilemap[1] = &machine().tilemap().create(*this, tilemap_get_info_delegate(*this, FUNC(namco_cus4xtmap_device::get_tile_info<1>)), TILEMAP_SCAN_ROWS, 8, 8, 64, 32);
+
+	// define offsets for scrolling
+	static const int adj[2] = { 0,2 };
+	for (int i = 0; i < 2; i++)
+	{
+		const int dx = m_xoffs + adj[i];
+		m_tilemap[i]->set_scrolldx(dx, m_flipped_xoffs - dx);
+		m_tilemap[i]->set_scrolldy(m_yoffs, m_flipped_yoffs);
+		m_tilemap[i]->set_transparent_pen(7);
+	}
+
+	save_item(NAME(m_xscroll));
+	save_item(NAME(m_yscroll));
+}
+
+/**************************************************************************************/
+
+void namco_cus4xtmap_device::mark_all_dirty(void)
+{
+	for (int i = 0; i < 2; i++)
+	{
+		m_tilemap[i]->mark_all_dirty();
+	}
+}
+
+template <unsigned Layer>
+TILE_GET_INFO_MEMBER(namco_cus4xtmap_device::get_tile_info)
+{
+	u16 const attr = m_vram[(Layer << 12) + (2 * tile_index + 1)];
+	u8 gfxno = 0;
+	u32 code = m_vram[(Layer << 12) + (2 * tile_index)] + ((attr & 0x03) << 8);
+	if (!m_tile_cb.isnull())
+		m_tile_cb(Layer, gfxno, code);
+	tileinfo.set(gfxno, code, attr, 0);
+}
+
+void namco_cus4xtmap_device::init_scroll(bool flip)
+{
+	for (int i = 0; i < 2; i++)
+	{
+		int scrollx = m_xscroll[i];
+		int scrolly = m_yscroll[i];
+		if (flip)
+		{
+			scrollx = -scrollx;
+			scrolly = -scrolly;
+		}
+		m_tilemap[i]->set_scrollx(0, scrollx);
+		m_tilemap[i]->set_scrolly(0, scrolly);
+	}
+}
+
+void namco_cus4xtmap_device::draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u8 layer, u32 flags, u8 prival, u8 primask)
+{
+	m_tilemap[layer]->draw(screen, bitmap, cliprect, flags, prival, primask);
+}
+
+// 8 bit handlers
+void namco_cus4xtmap_device::vram_w(offs_t offset, u8 data, u8 mem_mask)
+{
+	COMBINE_DATA(&m_vram[offset]);
+	m_tilemap[(offset >> 12) & 1]->mark_tile_dirty((offset & 0xfff) >> 1);
+}
+
+u8 namco_cus4xtmap_device::vram_r(offs_t offset)
+{
+	return m_vram[offset];
+}
+
+void namco_cus4xtmap_device::scroll_set(int layer, u8 offset, u8 data)
+{
+	switch (offset)
+	{
+		case 0: // high scroll x
+			m_xscroll[layer] = (m_xscroll[layer] & 0xff) | (data << 8);
+			break;
+		case 1: // low scroll x
+			m_xscroll[layer] = (m_xscroll[layer] & 0xff00) | data;
+			break;
+		case 2: // scroll y
+			m_yscroll[layer] = data;
+			break;
+	}
+}

--- a/src/mame/namco/namco_cus4xtmap.cpp
+++ b/src/mame/namco/namco_cus4xtmap.cpp
@@ -11,7 +11,7 @@
 #include "emu.h"
 #include "namco_cus4xtmap.h"
 
-DEFINE_DEVICE_TYPE(NAMCO_CUS4XTMAP, namco_cus4xtmap_device, "namco_cus4xtmap", "Namco CUS42 + CUS43 (2x Tilemaps)")
+DEFINE_DEVICE_TYPE(NAMCO_CUS4XTMAP, namco_cus4xtmap_device, "namco_cus4xtmap", "Namco CUS42 + CUS43 (dual tilemaps)")
 
 namco_cus4xtmap_device::namco_cus4xtmap_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: device_t(mconfig, NAMCO_CUS4XTMAP, tag, owner, clock)
@@ -54,10 +54,8 @@ void namco_cus4xtmap_device::device_start()
 
 void namco_cus4xtmap_device::mark_all_dirty(void)
 {
-	for (int i = 0; i < 2; i++)
-	{
-		m_tilemap[i]->mark_all_dirty();
-	}
+	for (auto &tilemap : m_tilemaps)
+		tilemap->mark_all_dirty();
 }
 
 template <unsigned Layer>
@@ -96,7 +94,7 @@ void namco_cus4xtmap_device::draw(screen_device &screen, bitmap_ind16 &bitmap, c
 void namco_cus4xtmap_device::vram_w(offs_t offset, u8 data, u8 mem_mask)
 {
 	COMBINE_DATA(&m_vram[offset]);
-	m_tilemap[(offset >> 12) & 1]->mark_tile_dirty((offset & 0xfff) >> 1);
+	m_tilemap[BIT(offset, 12)]->mark_tile_dirty((offset & 0xfff) >> 1);
 }
 
 u8 namco_cus4xtmap_device::vram_r(offs_t offset)

--- a/src/mame/namco/namco_cus4xtmap.cpp
+++ b/src/mame/namco/namco_cus4xtmap.cpp
@@ -5,7 +5,7 @@
     CUS42 + CUS43 Tilemaps
     used by
     baraduke.cpp (all games)
-	namcos86.cpp (all games)
+    namcos86.cpp (all games)
 */
 
 #include "emu.h"

--- a/src/mame/namco/namco_cus4xtmap.h
+++ b/src/mame/namco/namco_cus4xtmap.h
@@ -12,6 +12,8 @@
 class namco_cus4xtmap_device : public device_t, public device_gfx_interface
 {
 public:
+	using tile_delegate = device_delegate<void (u8 layer, u8 &gfxno, u32 &code)>;
+
 	// construction/destruction
 	namco_cus4xtmap_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 	template <typename T> namco_cus4xtmap_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&palette_tag, const gfx_decode_entry *gfxinfo)
@@ -29,7 +31,6 @@ public:
 		m_flipped_yoffs = flipped_yoffs;
 	}
 
-	typedef device_delegate<void(u8 layer, u8& gfxno, u32& code)> tile_delegate;
 	template <typename... T> void set_tile_callback(T &&... args) { m_tile_cb.set(std::forward<T>(args)...); }
 
 	// handlers

--- a/src/mame/namco/namco_cus4xtmap.h
+++ b/src/mame/namco/namco_cus4xtmap.h
@@ -1,0 +1,72 @@
+// license:BSD-3-Clause
+// copyright-holders:Manuel Abadia, Nicola Salmoria
+
+#ifndef MAME_NAMCO_NAMCO_CUS4XTMAP_H
+#define MAME_NAMCO_NAMCO_CUS4XTMAP_H
+
+#pragma once
+
+#include "screen.h"
+#include "tilemap.h"
+
+class namco_cus4xtmap_device : public device_t, public device_gfx_interface
+{
+public:
+	// construction/destruction
+	namco_cus4xtmap_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+	template <typename T> namco_cus4xtmap_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&palette_tag, const gfx_decode_entry *gfxinfo)
+		: namco_cus4xtmap_device(mconfig, tag, owner, clock)
+	{
+		set_info(gfxinfo);
+		set_palette(std::forward<T>(palette_tag));
+	}
+
+	void set_offset(int xoffs, int flipped_xoffs, int yoffs, int flipped_yoffs)
+	{
+		m_xoffs = xoffs;
+		m_yoffs = yoffs;
+		m_flipped_xoffs = flipped_xoffs;
+		m_flipped_yoffs = flipped_yoffs;
+	}
+
+	typedef device_delegate<void(u8 layer, u8& gfxno, u32& code)> tile_delegate;
+	template <typename... T> void set_tile_callback(T &&... args) { m_tile_cb.set(std::forward<T>(args)...); }
+
+	// handlers
+	void vram_w(offs_t offset, u8 data, u8 mem_mask = ~0);
+	u8 vram_r(offs_t offset);
+	template <unsigned Layer> void scroll_w(offs_t offset, u8 data)
+	{
+		scroll_set(Layer, offset, data);
+	}
+	u16 xscroll_r(offs_t layer) { return m_xscroll[layer]; }
+
+	void mark_all_dirty();
+	void init_scroll(bool flip);
+	void draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u8 layer, u32 flags, u8 prival = 0, u8 primask = 0xff);
+
+protected:
+	// device-level overrides
+	virtual void device_start() override ATTR_COLD;
+
+private:
+	template <unsigned Layer> TILE_GET_INFO_MEMBER(get_tile_info);
+	void set_tilemap_videoram(int offset, u16 newword);
+	void scroll_set(int layer, u8 offset, u8 data);
+
+	tile_delegate m_tile_cb;
+	memory_share_creator<u8> m_vram;
+
+	tilemap_t *m_tilemap[2];
+	u16 m_xscroll[2];
+	u8 m_yscroll[2];
+
+	int m_xoffs, m_yoffs;
+	int m_flipped_xoffs, m_flipped_yoffs;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(NAMCO_CUS4XTMAP, namco_cus4xtmap_device)
+
+#endif // MAME_NAMCO_NAMCO_CUS4XTMAP_H
+

--- a/src/mame/namco/namcos86.h
+++ b/src/mame/namco/namcos86.h
@@ -5,11 +5,13 @@
 
 #pragma once
 
+#include "namco_cus4xtmap.h"
+
 #include "cpu/m6800/m6801.h"
 #include "machine/watchdog.h"
-#include "namco_cus4xtmap.h"
 #include "sound/n63701x.h"
 #include "sound/namco.h"
+
 #include "emupal.h"
 #include "tilemap.h"
 
@@ -35,13 +37,13 @@ public:
 		, m_leds(*this, "led%u", 0U)
 	{ }
 
-	void genpeitd(machine_config &config);
-	void wndrmomo(machine_config &config);
-	void roishtar(machine_config &config);
-	void rthunder(machine_config &config);
-	void hopmappy(machine_config &config);
+	void genpeitd(machine_config &config) ATTR_COLD;
+	void wndrmomo(machine_config &config) ATTR_COLD;
+	void roishtar(machine_config &config) ATTR_COLD;
+	void rthunder(machine_config &config) ATTR_COLD;
+	void hopmappy(machine_config &config) ATTR_COLD;
 
-	void init_namco86();
+	void init_namco86() ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
@@ -63,8 +65,8 @@ private:
 	void backcolor_w(uint8_t data);
 	void spriteram_w(offs_t offset, uint8_t data);
 
-	void tile_cb_0(u8 layer, u8& gfxno, u32& code);
-	void tile_cb_1(u8 layer, u8& gfxno, u32& code);
+	void tile_cb_0(u8 layer, u8 &gfxno, u32 &code);
+	void tile_cb_1(u8 layer, u8 &gfxno, u32 &code);
 
 	void namcos86_palette(palette_device &palette);
 

--- a/src/mame/namco/namcos86.h
+++ b/src/mame/namco/namcos86.h
@@ -7,6 +7,7 @@
 
 #include "cpu/m6800/m6801.h"
 #include "machine/watchdog.h"
+#include "namco_cus4xtmap.h"
 #include "sound/n63701x.h"
 #include "sound/namco.h"
 #include "emupal.h"
@@ -24,11 +25,13 @@ public:
 		, m_cus30(*this, "namco")
 		, m_gfxdecode(*this, "gfxdecode")
 		, m_palette(*this, "palette")
+		, m_tilegen(*this, "tilegen_%u", 0U)
 		, m_63701x(*this, "namco2")
-		, m_rthunder_videoram1(*this, "videoram1")
-		, m_rthunder_videoram2(*this, "videoram2")
-		, m_rthunder_spriteram(*this, "spriteram")
-		, m_user1_ptr(*this, "user1")
+		, m_spriteram(*this, "spriteram")
+		, m_bankeddata_ptr(*this, "bankeddata")
+		, m_mainbank(*this, "mainbank")
+		, m_subbank(*this, "subbank")
+		, m_io_dsw(*this, "DSW%c", 'A')
 		, m_leds(*this, "led%u", 0U)
 	{ }
 
@@ -52,32 +55,22 @@ private:
 	uint8_t dsw1_r();
 	void int_ack1_w(uint8_t data);
 	void int_ack2_w(uint8_t data);
-	void watchdog1_w(uint8_t data);
-	void watchdog2_w(uint8_t data);
+	template <unsigned Bit> void watchdog_w(uint8_t data);
 	void coin_w(uint8_t data);
 	void led_w(uint8_t data);
 	void cus115_w(offs_t offset, uint8_t data);
-	void videoram1_w(offs_t offset, uint8_t data);
-	void videoram2_w(offs_t offset, uint8_t data);
 	void tilebank_select_w(offs_t offset, uint8_t data);
-	void scroll0_w(offs_t offset, uint8_t data);
-	void scroll1_w(offs_t offset, uint8_t data);
-	void scroll2_w(offs_t offset, uint8_t data);
-	void scroll3_w(offs_t offset, uint8_t data);
 	void backcolor_w(uint8_t data);
 	void spriteram_w(offs_t offset, uint8_t data);
 
-	TILE_GET_INFO_MEMBER(get_tile_info0);
-	TILE_GET_INFO_MEMBER(get_tile_info1);
-	TILE_GET_INFO_MEMBER(get_tile_info2);
-	TILE_GET_INFO_MEMBER(get_tile_info3);
+	void tile_cb_0(u8 layer, u8& gfxno, u32& code);
+	void tile_cb_1(u8 layer, u8& gfxno, u32& code);
 
 	void namcos86_palette(palette_device &palette);
 
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void screen_vblank(int state);
 	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void scroll_w(offs_t offset, int data, int layer);
 
 	void common_mcu_map(address_map &map) ATTR_COLD;
 	void cpu1_map(address_map &map) ATTR_COLD;
@@ -99,25 +92,20 @@ private:
 	required_device<namco_cus30_device> m_cus30;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
+	required_device_array<namco_cus4xtmap_device, 2> m_tilegen;
 	optional_device<namco_63701x_device> m_63701x;
-	required_shared_ptr<uint8_t> m_rthunder_videoram1;
-	required_shared_ptr<uint8_t> m_rthunder_videoram2;
-	required_shared_ptr<uint8_t> m_rthunder_spriteram;
-	optional_region_ptr<uint8_t> m_user1_ptr;
+	required_shared_ptr<uint8_t> m_spriteram;
+	optional_region_ptr<uint8_t> m_bankeddata_ptr;
+	required_memory_bank m_mainbank;
+	optional_memory_bank m_subbank;
+	optional_ioport_array<2> m_io_dsw;
 	output_finder<2> m_leds;
 
-	uint8_t *m_spriteram = nullptr;
-	int m_wdog = 0;
-	int m_tilebank = 0;
-	int m_xscroll[4];
-	int m_yscroll[4];
-	tilemap_t *m_bg_tilemap[4]{};
-	int m_backcolor = 0;
+	uint8_t m_wdog = 0;
+	uint32_t m_tilebank = 0;
+	uint16_t m_backcolor = 0;
 	const uint8_t *m_tile_address_prom = nullptr;
-	int m_copy_sprites = 0;
-
-	inline void get_tile_info(tile_data &tileinfo,int tile_index,int layer,uint8_t *vram);
-	void set_scroll(int layer);
+	bool m_copy_sprites = false;
 };
 
 #endif // MAME_NAMCO_NAMCOS86_H

--- a/src/mame/namco/namcos86_v.cpp
+++ b/src/mame/namco/namcos86_v.cpp
@@ -101,12 +101,12 @@ void namcos86_state::namcos86_palette(palette_device &palette)
 
 ***************************************************************************/
 
-void namcos86_state::tile_cb_0(u8 layer, u8& gfxno, u32& code)
+void namcos86_state::tile_cb_0(u8 layer, u8 &gfxno, u32 &code)
 {
 	code = (code & 0xff) | ((((m_tile_address_prom[((layer & 1) << 4) + (((code >> 8) & 0x03) << 2)] & 0x0e) >> 1) << 8) | (m_tilebank << 11));
 }
 
-void namcos86_state::tile_cb_1(u8 layer, u8& gfxno, u32& code)
+void namcos86_state::tile_cb_1(u8 layer, u8 &gfxno, u32 &code)
 {
 	code = (code & 0xff) | (((m_tile_address_prom[((layer & 1) << 4) + ((code >> 8) & 0x03)] & 0xe0) >> 5) << 8);
 }

--- a/src/mame/namco/namcos86_v.cpp
+++ b/src/mame/namco/namcos86_v.cpp
@@ -8,6 +8,8 @@ Namco System 86 Video Hardware
 
 #include "emu.h"
 #include "namcos86.h"
+
+#include "video/resnet.h"
 #include "screen.h"
 
 
@@ -38,49 +40,59 @@ Namco System 86 Video Hardware
 void namcos86_state::namcos86_palette(palette_device &palette)
 {
 	const uint8_t *color_prom = memregion("proms")->base();
+	static constexpr int resistances[4] = { 2200, 1000, 470, 220 };
 
-	rgb_t palette_val[512];
+	// compute the color output resistor weights
+	double rweights[4], gweights[4], bweights[4];
+	compute_resistor_weights(0, 255, -1.0,
+			4, &resistances[0], rweights, 0, 0,
+			4, &resistances[0], gweights, 0, 0,
+			4, &resistances[0], bweights, 0, 0);
+
+	// create a lookup table for the palette
 	for (int i = 0; i < 512; i++)
 	{
 		int bit0, bit1, bit2, bit3;
 
-		bit0 = BIT(color_prom[0], 0);
-		bit1 = BIT(color_prom[0], 1);
-		bit2 = BIT(color_prom[0], 2);
-		bit3 = BIT(color_prom[0], 3);
-		int const r = 0x0e * bit0 + 0x1f * bit1 + 0x43 * bit2 + 0x8f * bit3;
-		bit0 = BIT(color_prom[0], 4);
-		bit1 = BIT(color_prom[0], 5);
-		bit2 = BIT(color_prom[0], 6);
-		bit3 = BIT(color_prom[0], 7);
-		int const g = 0x0e * bit0 + 0x1f * bit1 + 0x43 * bit2 + 0x8f * bit3;
-		bit0 = BIT(color_prom[512], 0);
-		bit1 = BIT(color_prom[512], 1);
-		bit2 = BIT(color_prom[512], 2);
-		bit3 = BIT(color_prom[512], 3);
-		int const b = 0x0e * bit0 + 0x1f * bit1 + 0x43 * bit2 + 0x8f * bit3;
+		// red component
+		bit0 = BIT(color_prom[i], 0);
+		bit1 = BIT(color_prom[i], 1);
+		bit2 = BIT(color_prom[i], 2);
+		bit3 = BIT(color_prom[i], 3);
+		int const r = combine_weights(rweights, bit0, bit1, bit2, bit3);
+		
+		// green component
+		bit0 = BIT(color_prom[i], 4);
+		bit1 = BIT(color_prom[i], 5);
+		bit2 = BIT(color_prom[i], 6);
+		bit3 = BIT(color_prom[i], 7);
+		int const g = combine_weights(gweights, bit0, bit1, bit2, bit3);
+		
+		// blue component
+		bit0 = BIT(color_prom[i | 0x200], 0);
+		bit1 = BIT(color_prom[i | 0x200], 1);
+		bit2 = BIT(color_prom[i | 0x200], 2);
+		bit3 = BIT(color_prom[i | 0x200], 3);
+		int const b = combine_weights(bweights, bit0, bit1, bit2, bit3);
 
-		palette_val[i] = rgb_t(r, g, b);
-		color_prom++;
+		palette.set_indirect_color(i, rgb_t(r, g, b));
 	}
 
-	color_prom += 512;
 	// color_prom now points to the beginning of the lookup table
+	color_prom += 0x400;
 
 	// tiles lookup table
 	for (int i = 0; i < 2048; i++)
-		palette.set_pen_color(i, palette_val[*color_prom++]);
+		palette.set_pen_indirect(i, *color_prom++);
 
 	// sprites lookup table
 	for (int i = 0; i < 2048; i++)
-		palette.set_pen_color(2048 + i, palette_val[256 + *color_prom++]);
+		palette.set_pen_indirect(2048 + i, 256 + *color_prom++);
 
 	// color_prom now points to the beginning of the tile address decode PROM
 
 	m_tile_address_prom = color_prom; // we'll need this at run time
 }
-
-
 
 
 /***************************************************************************
@@ -89,39 +101,14 @@ void namcos86_state::namcos86_palette(palette_device &palette)
 
 ***************************************************************************/
 
-inline void namcos86_state::get_tile_info(tile_data &tileinfo,int tile_index,int layer,uint8_t *vram)
+void namcos86_state::tile_cb_0(u8 layer, u8& gfxno, u32& code)
 {
-	int attr = vram[2*tile_index + 1];
-	int tile_offs;
-	if (layer & 2)
-		tile_offs = ((m_tile_address_prom[((layer & 1) << 4) + (attr & 0x03)] & 0xe0) >> 5) * 0x100;
-	else
-		tile_offs = ((m_tile_address_prom[((layer & 1) << 4) + ((attr & 0x03) << 2)] & 0x0e) >> 1) * 0x100 + m_tilebank * 0x800;
-
-	tileinfo.set((layer & 2) ? 1 : 0,
-			vram[2*tile_index] + tile_offs,
-			attr,
-			0);
+	code = (code & 0xff) | ((((m_tile_address_prom[((layer & 1) << 4) + (((code >> 8) & 0x03) << 2)] & 0x0e) >> 1) << 8) | (m_tilebank << 11));
 }
 
-TILE_GET_INFO_MEMBER(namcos86_state::get_tile_info0)
+void namcos86_state::tile_cb_1(u8 layer, u8& gfxno, u32& code)
 {
-	get_tile_info(tileinfo,tile_index,0,&m_rthunder_videoram1[0x0000]);
-}
-
-TILE_GET_INFO_MEMBER(namcos86_state::get_tile_info1)
-{
-	get_tile_info(tileinfo,tile_index,1,&m_rthunder_videoram1[0x1000]);
-}
-
-TILE_GET_INFO_MEMBER(namcos86_state::get_tile_info2)
-{
-	get_tile_info(tileinfo,tile_index,2,&m_rthunder_videoram2[0x0000]);
-}
-
-TILE_GET_INFO_MEMBER(namcos86_state::get_tile_info3)
-{
-	get_tile_info(tileinfo,tile_index,3,&m_rthunder_videoram2[0x1000]);
+	code = (code & 0xff) | (((m_tile_address_prom[((layer & 1) << 4) + ((code >> 8) & 0x03)] & 0xe0) >> 5) << 8);
 }
 
 
@@ -133,31 +120,10 @@ TILE_GET_INFO_MEMBER(namcos86_state::get_tile_info3)
 
 void namcos86_state::video_start()
 {
-	m_bg_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(namcos86_state::get_tile_info0)), TILEMAP_SCAN_ROWS, 8,8, 64,32);
-	m_bg_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(namcos86_state::get_tile_info1)), TILEMAP_SCAN_ROWS, 8,8, 64,32);
-	m_bg_tilemap[2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(namcos86_state::get_tile_info2)), TILEMAP_SCAN_ROWS, 8,8, 64,32);
-	m_bg_tilemap[3] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(namcos86_state::get_tile_info3)), TILEMAP_SCAN_ROWS, 8,8, 64,32);
-
-	for (int i = 0; i < 4; i++)
-	{
-		static constexpr int xdisp[] = { 47, 49, 46, 48 };
-
-		m_bg_tilemap[i]->set_scrolldx(xdisp[i], 422 - xdisp[i]);
-		m_bg_tilemap[i]->set_scrolldy(-9, 9);
-		m_bg_tilemap[i]->set_transparent_pen(7);
-	}
-
-	m_spriteram = m_rthunder_spriteram + 0x1800;
-
 	save_item(NAME(m_tilebank));
-	save_item(NAME(m_xscroll));
-	save_item(NAME(m_yscroll));
 	save_item(NAME(m_backcolor));
 	save_item(NAME(m_copy_sprites));
-
-	m_backcolor = 0;
 }
-
 
 
 /***************************************************************************
@@ -166,60 +132,14 @@ void namcos86_state::video_start()
 
 ***************************************************************************/
 
-void namcos86_state::videoram1_w(offs_t offset, uint8_t data)
-{
-	m_rthunder_videoram1[offset] = data;
-	m_bg_tilemap[offset/0x1000]->mark_tile_dirty((offset & 0xfff)/2);
-}
-
-void namcos86_state::videoram2_w(offs_t offset, uint8_t data)
-{
-	m_rthunder_videoram2[offset] = data;
-	m_bg_tilemap[2+offset/0x1000]->mark_tile_dirty((offset & 0xfff)/2);
-}
-
 void namcos86_state::tilebank_select_w(offs_t offset, uint8_t data)
 {
-	int bit = BIT(offset,10);
+	uint32_t const bit = BIT(offset, 10);
 	if (m_tilebank != bit)
 	{
 		m_tilebank = bit;
-		m_bg_tilemap[0]->mark_all_dirty();
-		m_bg_tilemap[1]->mark_all_dirty();
+		m_tilegen[0]->mark_all_dirty();
 	}
-}
-
-void namcos86_state::scroll_w(offs_t offset, int data, int layer)
-{
-	switch (offset)
-	{
-		case 0:
-			m_xscroll[layer] = (m_xscroll[layer]&0xff)|(data<<8);
-			break;
-		case 1:
-			m_xscroll[layer] = (m_xscroll[layer]&0xff00)|data;
-			break;
-		case 2:
-			m_yscroll[layer] = data;
-			break;
-	}
-}
-
-void namcos86_state::scroll0_w(offs_t offset, uint8_t data)
-{
-	scroll_w(offset,data,0);
-}
-void namcos86_state::scroll1_w(offs_t offset, uint8_t data)
-{
-	scroll_w(offset,data,1);
-}
-void namcos86_state::scroll2_w(offs_t offset, uint8_t data)
-{
-	scroll_w(offset,data,2);
-}
-void namcos86_state::scroll3_w(offs_t offset, uint8_t data)
-{
-	scroll_w(offset,data,3);
 }
 
 void namcos86_state::backcolor_w(uint8_t data)
@@ -230,11 +150,11 @@ void namcos86_state::backcolor_w(uint8_t data)
 
 void namcos86_state::spriteram_w(offs_t offset, uint8_t data)
 {
-	m_rthunder_spriteram[offset] = data;
+	m_spriteram[offset] = data;
 
-	/* a write to this offset tells the sprite chip to buffer the sprite list */
+	// a write to this offset tells the sprite chip to buffer the sprite list
 	if (offset == 0x1ff2)
-		m_copy_sprites = 1;
+		m_copy_sprites = true;
 }
 
 
@@ -266,35 +186,36 @@ sprite format:
 
 void namcos86_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	const uint8_t *source = &m_spriteram[0x0800-0x20]; /* the last is NOT a sprite */
-	const uint8_t *finish = &m_spriteram[0];
-	gfx_element *gfx = m_gfxdecode->gfx(2);
+	const uint8_t *source = &m_spriteram[0x2000-0x20]; // the last is NOT a sprite
+	const uint8_t *finish = &m_spriteram[0x1800];
+	gfx_element *gfx = m_gfxdecode->gfx(0);
 
-	int sprite_xoffs = m_spriteram[0x07f5] + ((m_spriteram[0x07f4] & 1) << 8);
-	int sprite_yoffs = m_spriteram[0x07f7];
+	int const sprite_xoffs = m_spriteram[0x1ff5] + ((m_spriteram[0x1ff4] & 1) << 8);
+	int const sprite_yoffs = m_spriteram[0x1ff7];
 
-	int bank_sprites = m_gfxdecode->gfx(2)->elements() / 8;
+	int const bank_sprites = m_gfxdecode->gfx(0)->elements() / 8;
+
+	static const int sprite_size[4] = { 16, 8, 32, 4 };
 
 	while (source >= finish)
 	{
-		static const int sprite_size[4] = { 16, 8, 32, 4 };
-		int attr1 = source[10];
-		int attr2 = source[14];
+		int const attr1 = source[10];
+		int const attr2 = source[14];
 		int color = source[12];
-		int flipx = (attr1 & 0x20) >> 5;
-		int flipy = (attr2 & 0x01);
-		int sizex = sprite_size[(attr1 & 0xc0) >> 6];
-		int sizey = sprite_size[(attr2 & 0x06) >> 1];
-		int tx = (attr1 & 0x18) & (~(sizex-1));
-		int ty = (attr2 & 0x18) & (~(sizey-1));
+		bool flipx = BIT(attr1, 5);
+		bool flipy = BIT(attr2, 0);
+		int const sizex = sprite_size[(attr1 & 0xc0) >> 6];
+		int const sizey = sprite_size[(attr2 & 0x06) >> 1];
+		int const tx = (attr1 & 0x18) & (~(sizex - 1));
+		int const ty = (attr2 & 0x18) & (~(sizey - 1));
 		int sx = source[13] + ((color & 0x01) << 8);
 		int sy = -source[15] - sizey;
 		int sprite = source[11];
-		int sprite_bank = attr1 & 7;
-		int priority = (source[14] & 0xe0) >> 5;
-		int pri_mask = (0xff << (priority + 1)) & 0xff;
+		int const sprite_bank = attr1 & 7;
+		int const priority = (source[14] & 0xe0) >> 5;
+		uint32_t const pri_mask = (0xff << (priority + 1)) & 0xff;
 
-		sprite &= bank_sprites-1;
+		sprite &= bank_sprites - 1;
 		sprite += sprite_bank * bank_sprites;
 		color = color >> 1;
 
@@ -305,59 +226,43 @@ void namcos86_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, c
 		{
 			sx = -sx - sizex;
 			sy = -sy - sizey;
-			flipx ^= 1;
-			flipy ^= 1;
+			flipx = !flipx;
+			flipy = !flipy;
 		}
 
-		sy++;   /* sprites are buffered and delayed by one scanline */
+		sy++;   // sprites are buffered and delayed by one scanline
 
 		gfx->set_source_clip(tx, sizex, ty, sizey);
-		gfx->prio_transpen(bitmap,cliprect,
+		gfx->prio_transpen(bitmap, cliprect,
 				sprite,
 				color,
-				flipx,flipy,
+				flipx, flipy,
 				sx & 0x1ff,
 				((sy + 16) & 0xff) - 16,
-				screen.priority(), pri_mask,0xf);
+				screen.priority(), pri_mask, 0xf);
 
 		source -= 0x10;
 	}
 }
 
 
-void namcos86_state::set_scroll(int layer)
-{
-	int scrollx = m_xscroll[layer];
-	int scrolly = m_yscroll[layer];
-	if (flip_screen())
-	{
-		scrollx = -scrollx;
-		scrolly = -scrolly;
-	}
-	m_bg_tilemap[layer]->set_scrollx(0, scrollx);
-	m_bg_tilemap[layer]->set_scrolly(0, scrolly);
-}
-
-
 uint32_t namcos86_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	/* flip screen is embedded in the sprite control registers */
-	flip_screen_set(m_spriteram[0x07f6] & 1);
-	set_scroll(0);
-	set_scroll(1);
-	set_scroll(2);
-	set_scroll(3);
+	// flip screen is embedded in the sprite control registers
+	flip_screen_set(BIT(m_spriteram[0x1ff6], 0));
+	m_tilegen[0]->init_scroll(flip_screen());
+	m_tilegen[1]->init_scroll(flip_screen());
 
 	screen.priority().fill(0, cliprect);
 
-	bitmap.fill(m_gfxdecode->gfx(0)->colorbase() + 8*m_backcolor+7, cliprect);
+	bitmap.fill(m_tilegen[0]->gfx(0)->colorbase() + 8*m_backcolor+7, cliprect);
 
-	for (int layer = 0;layer < 8;layer++)
+	for (int layer = 0; layer < 8; layer++)
 	{
-		for (int i = 3;i >= 0;i--)
+		for (int i = 3; i >= 0; i--)
 		{
-			if (((m_xscroll[i] & 0x0e00) >> 9) == layer)
-				m_bg_tilemap[i]->draw(screen, bitmap, cliprect, 0,layer,0);
+			if (((m_tilegen[i >> 1]->xscroll_r(i & 1) & 0x0e00) >> 9) == layer)
+				m_tilegen[i >> 1]->draw(screen, bitmap, cliprect, i & 1, 0, layer, 0);
 		}
 	}
 
@@ -373,13 +278,13 @@ void namcos86_state::screen_vblank(int state)
 	{
 		if (m_copy_sprites)
 		{
-			for (int i = 0;i < 0x800;i += 16)
+			for (int i = 0x1800; i < 0x2000; i += 16)
 			{
-				for (int j = 10;j < 16;j++)
-					m_spriteram[i+j] = m_spriteram[i+j - 6];
+				for (int j = 10; j < 16; j++)
+					m_spriteram[i + j] = m_spriteram[i + j - 6];
 			}
 
-			m_copy_sprites = 0;
+			m_copy_sprites = false;
 		}
 	}
 }


### PR DESCRIPTION
namco/baraduke.cpp:
- Use video/resnet.h for palette initialization
- Make some variables constant
- Simplify gfx decode layout
- Fix address map order

namco/namcos86.cpp:
- Use video/resnet.h for palette initialization
- Use set_pen_indirect and set_indirect_color for indirect color palette beheviour
- Make some variables constant
- Simplify gfx decode layout
- Reduce unnecessary pointer
- Reduce runtime tag lookups
- Reduce duplicates
- Fix type value for some variables
- Fix address map order
- Fix spacing
- Fix naming
- Use C++ style single line comments