### PR TITLE
Add documentation comments about the effects of the CVS sound registers observed by poking values on a real PCB.

### DIFF
--- a/src/mame/misc/cvs.cpp
+++ b/src/mame/misc/cvs.cpp
@@ -682,6 +682,25 @@ void cvs_state::sh_trigger_w(offs_t offset, u8 data)
 	// offset 2 is used in darkwar, spacefrt, 8ball, dazzler, superbik, raiders
 	// offset 3 is used in cosmos, darkwar, superbik, raiders
 
+	/**********
+	Additional notes from poking the CVS sound hardware with an
+	In Circuit Emulator from PrSwan (Paul Swan).
+	I have recordings available.
+
+	- 0x1884 - Enables an XP8038 frequency generator IC
+		Reflected on pin 10 of a 4016.
+		The frequency is set by 0x1840, the 8 bit DAC register.
+		Not all 0x1840 values were tested, but:
+			0x00 - off, 0x1884 enable has no sound.
+			0x55,0xAA,0xFF - increasing value has higher frequency
+	- 0x1885 - A scope showed this halving the XP8038 amplitude with a little decay.
+		Causes 4016 pin 11 to rise (on) and decay-fall (off)
+	- 0x1886 - Mikes comment above about a high pitched whistle didn't match my PCBs. His was faulty?
+		Outputs a complete Galaxia-style ship fire sound, with attack-to-on and decay-to-off.
+	- 0x1887 - Reflected on an LM380.
+		Causes an envelope-like operation on the XP8038 tone with attack (on) and decay (off).
+	***********/
+
 	data &= 1;
 
 	if (data != m_sh_trigger[offset])


### PR DESCRIPTION
Comment update to add notes about the four sound registers 0x1884 -> 0x1887 as observed on a real PCB.