### PR TITLE
hash/ibm51?0.xml: MS-DOS 6.22 variants

### DIFF
--- a/hash/ibm5150.xml
+++ b/hash/ibm5150.xml
@@ -6829,6 +6829,106 @@ Throws "Null sized DOS image ! Invalid disk !" from HxC Disk Browser
 		</part>
 	</software>
 
+	<software name="msdos622">
+		<!-- If a non-upgrade version exists and is found, this should become msdos622u -->
+		<description>MS-DOS (Version 6.22, 360K 5.25", Upgrade)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="English" />
+		<info name="version" value="6.22" />
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="disk01.img" size="368640" crc="941919da" sha1="d5943abd7245237759235da92350dc9926ad0cdd"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="disk02.img" size="368640" crc="0c4efbdb" sha1="49b7e75c82f64e85e67c4f04c15f591947c0435f"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="disk03.img" size="368640" crc="bc45d263" sha1="e5c30533f50dea1f1ba6111e84b203334333d853"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="disk04.img" size="368640" crc="abf5c052" sha1="8de9f574505149c4f5123f3905e9b27805b4b1b7"/>
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="disk05.img" size="368640" crc="b199f525" sha1="139dc0ce531701a068fabe48b554de90b31cd3e6"/>
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="disk06.img" size="368640" crc="d4fff0a8" sha1="7f3b20e25d36b4f44af09e681557be1813979ee6"/>
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="disk07.img" size="368640" crc="da97587e" sha1="544b53abddf5247eb51e8289f2a710f61a8fe945"/>
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="disk08.img" size="368640" crc="11ac146d" sha1="8b3bbea86975200af53d8a505101512429fd0f47"/>
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="disk09.img" size="368640" crc="7c27cf02" sha1="dc5a5c990f192a15567e50b5db63c04df2824e73"/>
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="disk10.img" size="368640" crc="ac4520e6" sha1="a6836c62c4f24cc24451d86751845a00c54c5652"/>
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="disk11.img" size="368640" crc="7ed47c77" sha1="7d81474bfa306505a6c2832f7e49a53ff766e73c"/>
+			</dataarea>
+		</part>
+		<part name="flop12" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="disk12.img" size="368640" crc="3745c46f" sha1="0453a1ed0c0f56bb4806780b6d71c195b056363d"/>
+			</dataarea>
+		</part>
+		<part name="flop13" interface="floppy_5_25">
+			<dataarea name="flop" size="368640">
+				<rom name="disk13.img" size="368640" crc="bf9045d3" sha1="b567e8b04e34d312cd9b49073481ae1f602f852b"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="msdos622sup">
+		<description>MS-DOS 6.22 Supplemental Kit</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="English" />
+		<info name="version" value="6.22" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Supplemental Disk 1" />
+			<dataarea name="flop" size="368640">
+				<rom name="disk01.img" size="368640" crc="acd4a768" sha1="aecb6c64d22241a8af2d0f9227884f431ef72e39"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Supplemental Disk 2" />
+			<dataarea name="flop" size="368640">
+				<rom name="disk02.img" size="368640" crc="0af2d03a" sha1="10ae513c0ff170b51d1c96541647aef36a00f7b2"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Supplemental Disk 3" />
+			<dataarea name="flop" size="368640">
+				<rom name="disk03.img" size="368640" crc="bac65dfe" sha1="68c0b930f02f174d2cd370b21385b24fb272512b"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="mmsdos4">
 		<description>Multitasking MS-DOS (Version 4.00)</description>
 		<year>1985</year>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -3529,6 +3529,28 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="msdos622b" cloneof="msdos622">
+		<description>MS-DOS (Version 6.22, 1994-05-09 beta)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="version" value="6.22"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk1b.img" size="1474560" crc="9ac544b1" sha1="b213b7d9b597d8f64d9507d32e5518426f331086"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk2b.img" size="1474560" crc="ad24247c" sha1="98e6352d337fcafca1aa9ac8018a8983b69e898b"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="disk3b.img" size="1474560" crc="12052bf6" sha1="97bd560965ac5bcc000f999ddfa7bed74d513f7c"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="msdos622u" cloneof="msdos622">
 		<description>MS-DOS (Version 6.22, Upgrade, 3.5")</description>
 		<year>1994</year>
@@ -3600,11 +3622,76 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="msdos622es" cloneof="msdos622">
+		<description>MS-DOS (Version 6.22, Spanish)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="Spanish" />
+		<info name="version" value="6.22" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot / Installation Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk1es.img" size="1474560" crc="4fc5957e" sha1="17a7e800228af53c8868010a85d94007cbe17c76" status="baddump"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Installation Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk2es.img" size="1474560" crc="735fa49e" sha1="f5a4292046d69d3aaeb459afab30a217d6bc869b" status="baddump"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Installation Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk3es.img" size="1474560" crc="95520d61" sha1="e0390f40de740cd580f41ec20bc119114c0fce09" status="baddump"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Supplemental Disk" />
+			<dataarea name="flop" size="1474560">
+				<rom name="supplement-es.img" size="1474560" crc="645dfb68" sha1="3723e292431c6fa93746d5f2461e6b112c564bcd" status="baddump"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="msdos622fr" cloneof="msdos622">
+		<description>MS-DOS (Version 6.22, French)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="French" />
+		<info name="version" value="6.22" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot / Installation Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk1fr.img" size="1474560" crc="5697e0dc" sha1="2563599c6b1574a7e27d8b150b13c681db13bbd7"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Installation Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk2fr.img" size="1474560" crc="507f780d" sha1="caa2c16eeda98f5c68f24826a067152764abb495"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Installation Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk3fr.img" size="1474560" crc="1033f40f" sha1="5c88b00f449055fcc88f363d5bcd2632e07f1fb9"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Supplemental Disk" />
+			<dataarea name="flop" size="1474560">
+				<rom name="supplement-fr.img" size="1474560" crc="ae02bc3e" sha1="f4054aa95b951df9dde0d4db49091eec22ec503c"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="msdos622de" cloneof="msdos622">
 		<!-- KryoFlux dump from original disks, shows as unmodified -->
 		<description>MS-DOS (Version 6.22, German)</description>
 		<year>1994</year>
 		<publisher>Microsoft</publisher>
+		<info name="language" value="German" />
 		<info name="version" value="6.22" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1474560">
@@ -3619,6 +3706,70 @@ license:CC0-1.0
 		<part name="flop3" interface="floppy_3_5">
 			<dataarea name="flop" size="1474560">
 				<rom name="MS_DOS_6.22_German_disk3.img" size="1474560" crc="95f32c5d" sha1="ed1358083d1c56105356e4b029e2beca6d6211da"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Supplemental Disk" />
+			<dataarea name="flop" size="1474560">
+				<rom name="MS_DOS_6.22_German_Supplemental.img" size="1474560" crc="fa16918f" sha1="9e360df52f57c1595d66889502929fd18ebb61d7"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="msdos622it" cloneof="msdos622">
+		<description>MS-DOS (Version 6.22, Italian)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="Italian" />
+		<info name="version" value="6.22" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot / Installation Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk1it.img" size="1474560" crc="e8961cb9" sha1="0760046471a25547ad003cc2b371779383f0baef"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Boot / Installation Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk2it.img" size="1474560" crc="a2b4513f" sha1="ca5bca4a1d593e175e7b71e27b54b9a4e58ab697"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Boot / Installation Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk3it.img" size="1474560" crc="3b2937a8" sha1="1b774a0de129345fcd6440399a1ef0112c829927"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Supplemental Disk" />
+			<dataarea name="flop" size="1474560">
+				<rom name="supplement-it.img" size="1474560" crc="94be47c6" sha1="1a47996abc36b7053d19ab144daf93481ad5ce35"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="msdos622nl" cloneof="msdos622">
+		<description>MS-DOS (Version 6.22, Dutch)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="Dutch" />
+		<info name="version" value="6.22" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot / Installation Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk1nl.img" size="1474560" crc="1e2caca7" sha1="3003d435415a04879f36b24a9f8000c7c5402312"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Installation Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk2nl.img" size="1474560" crc="c834b954" sha1="045aa044528611e14f41e115b3e4af74f7b37963"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Installation Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk3nl.img" size="1474560" crc="86b86531" sha1="eba8a7afc8305b0a2e2fab762e35e79aec0fbeb1"/>
 			</dataarea>
 		</part>
 	</software>
@@ -3650,6 +3801,59 @@ license:CC0-1.0
 			<feature name="part_id" value="Supplemental Disk" />
 			<dataarea name="flop" size = "1474560">
 				<rom name="MS-DOS 6.22 [BR] - Disk 4 of 4 - Supplemental Disk.img" size="1474560" crc="491b3f2c" sha1="1b288096d3d59af039c591d68bf1490fbe1929e0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="msdos622ru" cloneof="msdos622">
+		<!-- Contains disk identifier files dated 1995 -->
+		<description>MS-DOS (Version 6.22, Russian)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="Russian" />
+		<info name="version" value="6.22" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot / Installation Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk1ru.img" size="1474560" crc="a5a28e90" sha1="e7e842ae68c385cf18a1a99bcb454dc10b5bcd2a" status="baddump"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Installation Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk2ru.img" size="1474560" crc="ac5109d8" sha1="ff62e1a52c734b0e2f5624d5aa6a6293abb6a8cb" status="baddump"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Installation Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk3ru.img" size="1474560" crc="543cf6c6" sha1="4c8560551a0e828617bc9c280aa5bdab4acc9c19" status="baddump"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="msdos622sv" cloneof="msdos622">
+		<description>MS-DOS (Version 6.22, Swedish)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<info name="language" value="Swedish" />
+		<info name="version" value="6.22" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot / Installation Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk1sv.img" size="1474560" crc="edcec394" sha1="8ca3a2b0209f47e587bbebf773dd301b73609398" status="baddump"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Installation Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk2sv.img" size="1474560" crc="5fdabb47" sha1="6a699745d2d4994ce271f5799890572de68ede40" status="baddump"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Installation Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk3sv.img" size="1474560" crc="ae13becf" sha1="9fd60a7377236578e00d2f7a8f2fe669fddf8be1" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
A beta build of MS-DOS floats around as an alternative set.  Added the German supplemental disk to msdos622de (most of the disk is still in English, but notably DOS Shell is translated into German).

Most of the sets on WinWorld appear to be genuine, albeit the Russian translation has obvious signs of likely unintentional tampering, so that's the singular entry being marked as bad dumps here.

New working software list items (ibm5150.xml)
---------------------------------------------
MS-DOS (Version 6.22, 360K 5.25", Upgrade) [winworldpc.com]
MS-DOS 6.22 Supplemental Kit [winworldpc.com]

New working software list items (ibm5170.xml)
---------------------------------------------
MS-DOS (Version 6.22, 1994-05-09 beta) [winworldpc.com]
MS-DOS (Version 6.22, Dutch) [winworldpc.com]
MS-DOS (Version 6.22, French) [winworldpc.com]
MS-DOS (Version 6.22, Italian) [winworldpc.com]
MS-DOS (Version 6.22, Russian) [winworldpc.com]
MS-DOS (Version 6.22, Spanish) [winworldpc.com]
MS-DOS (Version 6.22, Swedish) [winworldpc.com]