### PR TITLE
Fix 2 Visual Studio Warnings

### DIFF
--- a/3rdparty/lsqlite3/lsqlite3.c
+++ b/3rdparty/lsqlite3/lsqlite3.c
@@ -1317,7 +1317,6 @@ static void db_update_hook_callback(void *user, int op, char const *dbname, char
     sdb *db = (sdb*)user;
     lua_State *L = db->L;
     int top = lua_gettop(L);
-    lua_Number n;
 
     /* setup lua callback call */
     lua_rawgeti(L, LUA_REGISTRYINDEX, db->update_hook_cb);    /* get callback */

--- a/3rdparty/lsqlite3/lsqlite3.c
+++ b/3rdparty/lsqlite3/lsqlite3.c
@@ -1317,6 +1317,7 @@ static void db_update_hook_callback(void *user, int op, char const *dbname, char
     sdb *db = (sdb*)user;
     lua_State *L = db->L;
     int top = lua_gettop(L);
+    lua_Number n;
 
     /* setup lua callback call */
     lua_rawgeti(L, LUA_REGISTRYINDEX, db->update_hook_cb);    /* get callback */

--- a/src/mame/moog/source.cpp
+++ b/src/mame/moog/source.cpp
@@ -408,7 +408,7 @@ float source_state::get_keyboard_v() const
 
 	// *** Convert pressed key to a voltage.
 
-	static constexpr const float KEYBOARD_VREF = 8.24;  // From schematic.
+	static constexpr const float KEYBOARD_VREF = 8.24f;  // From schematic.
 	static constexpr const float RKEY = RES_R(100);
 	static constexpr const float R74 = RES_R(150);
 	static constexpr const float R76 = RES_K(220);

--- a/src/mame/nec/pc88va.cpp
+++ b/src/mame/nec/pc88va.cpp
@@ -256,7 +256,7 @@ void pc88va_state::sys_port5_w(u8 data)
 
 u8 pc88va_state::sys_port5_r()
 {
-	return (u8)m_rstmd | 8;
+	return (m_rstmd ? 1 : 0) | 8;
 }
 
 uint8_t pc88va_state::hdd_status_r()

--- a/src/mame/nec/pc88va.cpp
+++ b/src/mame/nec/pc88va.cpp
@@ -256,7 +256,7 @@ void pc88va_state::sys_port5_w(u8 data)
 
 u8 pc88va_state::sys_port5_r()
 {
-	return m_rstmd | 8;
+	return (u8)m_rstmd | 8;
 }
 
 uint8_t pc88va_state::hdd_status_r()


### PR DESCRIPTION
Two are for implicit casts (which the visual studio build elevates to Errors) and one is for an unused variable.

Since these break compilation from a fresh build in default conditions, and the project is set to elevate warnings to errors, these likely should be fixed.