### PR TITLE
Various neogeo related driver cleanups:

### DIFF
--- a/src/mame/neogeo/neogeo.cpp
+++ b/src/mame/neogeo/neogeo.cpp
@@ -751,11 +751,6 @@ protected:
 // 1146 mclks from the rising edge of /HSYNC.
 #define NEOGEO_VBLANK_RELOAD_HTIM (attotime::from_ticks(1146, NEOGEO_MASTER_CLOCK))
 
-#define IRQ2CTRL_ENABLE             (0x10)
-#define IRQ2CTRL_LOAD_RELATIVE      (0x20)
-#define IRQ2CTRL_AUTOLOAD_VBLANK    (0x40)
-#define IRQ2CTRL_AUTOLOAD_REPEAT    (0x80)
-
 void neogeo_base_state::adjust_display_position_interrupt_timer()
 {
 	attotime period = attotime::from_ticks((uint64_t)m_display_counter + 1, NEOGEO_PIXEL_CLOCK);
@@ -785,7 +780,7 @@ void neogeo_base_state::set_display_counter_lsb(uint16_t data)
 
 	LOGMASKED(LOG_VIDEO_SYSTEM, "PC %06x: set_display_counter %08x\n", m_maincpu->pc(), m_display_counter);
 
-	if (m_display_position_interrupt_control & IRQ2CTRL_LOAD_RELATIVE)
+	if (BIT(m_display_position_interrupt_control, 5))
 	{
 		LOGMASKED(LOG_VIDEO_SYSTEM, "AUTOLOAD_RELATIVE ");
 		adjust_display_position_interrupt_timer();
@@ -803,11 +798,11 @@ void neogeo_base_state::update_interrupts()
 
 void neogeo_base_state::acknowledge_interrupt(uint16_t data)
 {
-	if (data & 0x01)
+	if (BIT(data, 0))
 		m_irq3_pending = 0;
-	if (data & 0x02)
+	if (BIT(data, 1))
 		m_display_position_interrupt_pending = 0;
-	if (data & 0x04)
+	if (BIT(data, 2))
 		m_vblank_interrupt_pending = 0;
 
 	update_interrupts();
@@ -818,7 +813,7 @@ TIMER_CALLBACK_MEMBER(neogeo_base_state::display_position_interrupt_callback)
 {
 	LOGMASKED(LOG_VIDEO_SYSTEM, "--- Scanline @ %d,%d\n", m_screen->vpos(), m_screen->hpos());
 
-	if (m_display_position_interrupt_control & IRQ2CTRL_ENABLE)
+	if (BIT(m_display_position_interrupt_control, 4))
 	{
 		LOGMASKED(LOG_VIDEO_SYSTEM, "*** Scanline interrupt (IRQ2) ***  y: %02x  x: %02x\n", m_screen->vpos(), m_screen->hpos());
 		m_display_position_interrupt_pending = 1;
@@ -826,7 +821,7 @@ TIMER_CALLBACK_MEMBER(neogeo_base_state::display_position_interrupt_callback)
 		update_interrupts();
 	}
 
-	if (m_display_position_interrupt_control & IRQ2CTRL_AUTOLOAD_REPEAT)
+	if (BIT(m_display_position_interrupt_control, 7))
 	{
 		LOGMASKED(LOG_VIDEO_SYSTEM, "AUTOLOAD_REPEAT ");
 		adjust_display_position_interrupt_timer();
@@ -836,7 +831,7 @@ TIMER_CALLBACK_MEMBER(neogeo_base_state::display_position_interrupt_callback)
 
 TIMER_CALLBACK_MEMBER(neogeo_base_state::display_position_vblank_callback)
 {
-	if (m_display_position_interrupt_control & IRQ2CTRL_AUTOLOAD_VBLANK)
+	if (BIT(m_display_position_interrupt_control, 6))
 	{
 		LOGMASKED(LOG_VIDEO_SYSTEM, "AUTOLOAD_VBLANK ");
 		adjust_display_position_interrupt_timer();
@@ -1024,9 +1019,11 @@ uint16_t neogeo_base_state::unmapped_r(address_space &space)
 		ret = 0xffff;
 	else
 	{
-		m_recurse = true;
+		if (!machine().side_effects_disabled())
+			m_recurse = true;
 		ret = space.read_word(m_maincpu->pc());
-		m_recurse = false;
+		if (!machine().side_effects_disabled())
+			m_recurse = false;
 	}
 	return ret;
 }
@@ -1069,7 +1066,8 @@ ioport_value neogeo_base_state::get_memcard_status()
 
 uint16_t neogeo_base_state::memcard_r(offs_t offset, uint16_t mem_mask)
 {
-	m_maincpu->eat_cycles(2); // insert waitstate
+	if (!machine().side_effects_disabled())
+		m_maincpu->eat_cycles(2); // insert waitstate
 
 	// memory card enabled by /UDS
 	if (ACCESSING_BITS_8_15 && m_memcard->present())
@@ -1097,9 +1095,7 @@ void neogeo_base_state::memcard_w(offs_t offset, uint16_t data, uint16_t mem_mas
 
 ioport_value neogeo_base_state::get_audio_result()
 {
-	uint8_t ret = m_soundlatch2->read();
-
-	return ret;
+	return m_soundlatch2->read();
 }
 
 
@@ -1111,7 +1107,8 @@ ioport_value neogeo_base_state::get_audio_result()
 
 uint8_t neogeo_base_state::audio_cpu_bank_select_r(offs_t offset)
 {
-	m_bank_audio_cart[offset & 3]->set_entry(offset >> 8);
+	if (!machine().side_effects_disabled())
+		m_bank_audio_cart[offset & 3]->set_entry(offset >> 8);
 
 	return 0;
 }
@@ -1132,14 +1129,14 @@ void neogeo_base_state::set_use_cart_vectors(int state)
 void neogeo_base_state::set_use_cart_audio(int state)
 {
 	m_use_cart_audio = state;
-	m_sprgen->neogeo_set_fixed_layer_source(state);
+	m_sprgen->set_fixed_layer_source(state);
 	m_bank_audio_main->set_entry(m_use_cart_audio);
 }
 
 
 void neogeo_base_state::write_banksel(uint16_t data)
 {
-	uint32_t len = (!m_slots[m_curr_slot] || m_slots[m_curr_slot]->get_rom_size() == 0) ? m_region_maincpu->bytes() : m_slots[m_curr_slot]->get_rom_size();
+	uint32_t const len = (!m_slots[m_curr_slot] || m_slots[m_curr_slot]->get_rom_size() == 0) ? m_region_maincpu->bytes() : m_slots[m_curr_slot]->get_rom_size();
 
 	if ((len <= 0x100000) && (data & 0x07))
 		logerror("PC %06x: warning: bankswitch to %02x but no banks available\n", m_maincpu->pc(), data);
@@ -1299,7 +1296,7 @@ uint16_t neogeo_base_state::read_lorom_kof10th(offs_t offset)
 void neogeo_base_state::init_cpu()
 {
 	uint8_t *ROM = (!m_slots[m_curr_slot] || m_slots[m_curr_slot]->get_rom_size() == 0) ? m_region_maincpu->base() : (uint8_t *)m_slots[m_curr_slot]->get_rom_base();
-	uint32_t len = (!m_slots[m_curr_slot] || m_slots[m_curr_slot]->get_rom_size() == 0) ? m_region_maincpu->bytes() : m_slots[m_curr_slot]->get_rom_size();
+	uint32_t const len = (!m_slots[m_curr_slot] || m_slots[m_curr_slot]->get_rom_size() == 0) ? m_region_maincpu->bytes() : m_slots[m_curr_slot]->get_rom_size();
 
 	if (len > 0x100000)
 		m_bank_base = 0x100000;
@@ -1312,8 +1309,7 @@ void neogeo_base_state::init_cpu()
 void neogeo_base_state::init_audio()
 {
 	uint8_t *ROM = (!m_slots[m_curr_slot] || m_slots[m_curr_slot]->get_audio_size() == 0) ? m_region_audiocpu->base() : m_slots[m_curr_slot]->get_audio_base();
-	uint32_t len = (!m_slots[m_curr_slot] || m_slots[m_curr_slot]->get_audio_size() == 0) ? m_region_audiocpu->bytes() : m_slots[m_curr_slot]->get_audio_size();
-	uint32_t address_mask;
+	uint32_t const len = (!m_slots[m_curr_slot] || m_slots[m_curr_slot]->get_audio_size() == 0) ? m_region_audiocpu->bytes() : m_slots[m_curr_slot]->get_audio_size();
 
 	/* audio bios/cartridge selection */
 	m_bank_audio_main->configure_entry(0, (m_region_audiobios != nullptr) ? m_region_audiobios->base() : ROM); /* on hardware with no SM1 ROM, the cart ROM is always enabled */
@@ -1326,12 +1322,12 @@ void neogeo_base_state::init_audio()
 	m_bank_audio_cart[2] = membank("audio_c000");
 	m_bank_audio_cart[3] = membank("audio_8000");
 
-	address_mask = (len - 0x10000 - 1) & 0x3ffff;
+	uint32_t const address_mask = (len - 0x10000 - 1) & 0x3ffff;
 	for (int region = 0; region < 4; region++)
 	{
 		for (int bank = 0xff; bank >= 0; bank--)
 		{
-			uint32_t bank_address = 0x10000 + ((bank << (11 + region)) & address_mask);
+			uint32_t const bank_address = 0x10000 + ((bank << (11 + region)) & address_mask);
 			m_bank_audio_cart[region]->configure_entry(bank, &ROM[bank_address]);
 		}
 	}
@@ -1379,7 +1375,7 @@ void neogeo_base_state::init_sprites()
 			m_sprgen->optimize_sprite_data();
 		else
 			m_sprgen->set_optimized_sprite_data(m_slots[m_curr_slot]->get_sprites_opt_base(), m_slots[m_curr_slot]->get_sprites_opt_size() - 1);
-		m_sprgen->m_fixed_layer_bank_type = m_slots[m_curr_slot]->get_fixed_bank_type();
+		m_sprgen->set_fixed_layer_bank_type(m_slots[m_curr_slot]->get_fixed_bank_type());
 	}
 	else
 	{
@@ -1424,7 +1420,7 @@ void neogeo_base_state::set_slot_idx(int slot)
 		if (!m_slots[m_curr_slot]->user_loadable())
 			m_slots[m_curr_slot]->set_cart_type(m_slots[m_curr_slot]->default_option());
 
-		int type = m_slots[m_curr_slot]->get_type();
+		int const type = m_slots[m_curr_slot]->get_type();
 		switch (type)
 		{
 		case NEOGEO_FATFURY2:
@@ -1608,7 +1604,7 @@ void mvs_state::machine_start()
 {
 	ngarcade_base_state::machine_start();
 
-	m_sprgen->m_fixed_layer_bank_type = 0;
+	m_sprgen->set_fixed_layer_bank_type(neosprite_base_device::FIX_BANKTYPE_STD);
 
 	m_curr_slot = -1;
 	set_slot_idx(0);
@@ -1780,7 +1776,7 @@ void aes_state::aes_main_map(address_map &map)
 
 void neogeo_base_state::audio_map(address_map &map)
 {
-	map(0x0000, 0x7fff).bankr("audio_main");
+	map(0x0000, 0x7fff).bankr(m_bank_audio_main);
 	map(0x8000, 0xbfff).bankr("audio_8000");
 	map(0xc000, 0xdfff).bankr("audio_c000");
 	map(0xe000, 0xefff).bankr("audio_e000");
@@ -2130,7 +2126,7 @@ void aes_base_state::machine_start()
 {
 	neogeo_base_state::machine_start();
 
-	m_sprgen->m_fixed_layer_bank_type = 0;
+	m_sprgen->set_fixed_layer_bank_type(neosprite_base_device::FIX_BANKTYPE_STD);
 }
 
 void aes_state::machine_start()
@@ -2141,7 +2137,7 @@ void aes_state::machine_start()
 	set_slot_idx(0);
 
 	// AES has no SFIX ROM and always uses the cartridge's
-	m_sprgen->neogeo_set_fixed_layer_source(1);
+	m_sprgen->set_fixed_layer_source(1);
 }
 
 void aes_state::device_post_load()

--- a/src/mame/neogeo/neogeo.h
+++ b/src/mame/neogeo/neogeo.h
@@ -178,7 +178,7 @@ protected:
 
 	optional_device_array<neogeo_cart_slot_device, 6> m_slots;
 
-	int m_curr_slot = 0;
+	int32_t m_curr_slot = 0;
 
 private:
 	void update_interrupts();
@@ -214,8 +214,8 @@ private:
 	// color/palette related
 	std::vector<uint16_t> m_paletteram;
 	uint8_t      m_palette_lookup[32][4]{};
-	int          m_screen_shadow = 0;
-	int          m_palette_bank = 0;
+	bool         m_screen_shadow = false;
+	uint32_t     m_palette_bank = 0;
 };
 
 

--- a/src/mame/neogeo/neogeo_spr.cpp
+++ b/src/mame/neogeo/neogeo_spr.cpp
@@ -630,7 +630,7 @@ void neosprite_regular_device::set_sprite_region(u8* region_sprites, u32 region_
 
 inline void neosprite_regular_device::draw_pixel(int romaddr, u32* dst, const pen_t *line_pens)
 {
-	const u8* src = m_region_sprites + (((romaddr &~0xff)>>1) | (((romaddr&0x8)^0x8)<<3) | ((romaddr & 0xf0)  >> 2));
+	u8 const *const src = m_region_sprites + (((romaddr &~0xff)>>1) | (((romaddr&0x8)^0x8)<<3) | ((romaddr & 0xf0)  >> 2));
 	const int x = romaddr & 0x7;
 
 	const u8 gfx = (BIT(src[0x3], x) << 3) |
@@ -736,7 +736,7 @@ neosprite_midas_device::neosprite_midas_device(const machine_config &mconfig, co
 
 inline void neosprite_midas_device::draw_pixel(int romaddr, u32* dst, const pen_t *line_pens)
 {
-	const u8* src = m_region_sprites + (((romaddr &~0xff)) | (((romaddr&0x8)^0x8)<<4) | ((romaddr & 0xf0)  >> 1));
+	u8 const *const src = m_region_sprites + (((romaddr &~0xff)) | (((romaddr&0x8)^0x8)<<4) | ((romaddr & 0xf0)  >> 1));
 	const int x = romaddr & 0x7;
 
 	const u8 gfx =   (BIT(src[0x7],  x) << 7) |

--- a/src/mame/neogeo/neogeo_spr.cpp
+++ b/src/mame/neogeo/neogeo_spr.cpp
@@ -16,7 +16,7 @@ neosprite_base_device::neosprite_base_device(
 		device_type type,
 		const char *tag,
 		device_t *owner,
-		uint32_t clock)
+		u32 clock)
 	: device_t(mconfig, type, tag, owner, clock)
 	, device_video_interface(mconfig, *this)
 	, m_bppshift(4)
@@ -26,11 +26,11 @@ neosprite_base_device::neosprite_base_device(
 
 void neosprite_base_device::device_start()
 {
-	m_videoram = std::make_unique<uint16_t[]>(0x8000 + 0x800);
+	m_videoram = std::make_unique<u16[]>(0x8000 + 0x800);
 	m_videoram_drawsource = m_videoram.get();
 
 	/* clear allocated memory */
-	memset(m_videoram.get(), 0x00, (0x8000 + 0x800) * sizeof(uint16_t));
+	memset(m_videoram.get(), 0x00, (0x8000 + 0x800) * sizeof(u16));
 
 	create_sprite_line_timer();
 	create_auto_animation_timer();
@@ -67,14 +67,13 @@ void neosprite_base_device::device_reset()
 }
 
 
-
 /*************************************
  *
  *  Video RAM access
  *
  *************************************/
 
-void neosprite_base_device::set_videoram_offset(uint16_t data)
+void neosprite_base_device::set_videoram_offset(u16 data)
 {
 	m_vram_offset = (data & 0x8000 ? data & 0x87ff : data);
 
@@ -83,13 +82,13 @@ void neosprite_base_device::set_videoram_offset(uint16_t data)
 }
 
 
-uint16_t neosprite_base_device::get_videoram_data()
+u16 neosprite_base_device::get_videoram_data()
 {
 	return m_vram_read_buffer;
 }
 
 
-void neosprite_base_device::set_videoram_data(uint16_t data)
+void neosprite_base_device::set_videoram_data(u16 data)
 {
 	m_videoram[m_vram_offset] = data;
 
@@ -98,17 +97,16 @@ void neosprite_base_device::set_videoram_data(uint16_t data)
 }
 
 
-void neosprite_base_device::set_videoram_modulo(uint16_t data)
+void neosprite_base_device::set_videoram_modulo(u16 data)
 {
 	m_vram_modulo = data;
 }
 
 
-uint16_t neosprite_base_device::get_videoram_modulo()
+u16 neosprite_base_device::get_videoram_modulo()
 {
 	return m_vram_modulo;
 }
-
 
 
 /*************************************
@@ -117,19 +115,19 @@ uint16_t neosprite_base_device::get_videoram_modulo()
  *
  *************************************/
 
-void neosprite_base_device::set_auto_animation_speed(uint8_t data)
+void neosprite_base_device::set_auto_animation_speed(u8 data)
 {
 	m_auto_animation_speed = data;
 }
 
 
-void neosprite_base_device::set_auto_animation_disabled(uint8_t data)
+void neosprite_base_device::set_auto_animation_disabled(u8 data)
 {
 	m_auto_animation_disabled = data;
 }
 
 
-uint8_t neosprite_base_device::neogeo_get_auto_animation_counter()
+u8 neosprite_base_device::get_auto_animation_counter()
 {
 	return m_auto_animation_counter;
 }
@@ -161,16 +159,21 @@ void neosprite_base_device::start_auto_animation_timer()
 }
 
 
-
 /*************************************
  *
  *  Fixed layer
  *
  *************************************/
 
-void neosprite_base_device::neogeo_set_fixed_layer_source(uint8_t data)
+void neosprite_base_device::set_fixed_layer_source(u8 data)
 {
 	m_fixed_layer_source = data;
+}
+
+
+void neosprite_base_device::set_fixed_layer_bank_type(u8 data)
+{
+	m_fixed_layer_bank_type = data;
 }
 
 
@@ -178,17 +181,17 @@ void neosprite_base_device::draw_fixed_layer(bitmap_rgb32 &bitmap, int scanline)
 {
 	assert((m_fixed_layer_source && m_region_fixed != nullptr) || (m_region_fixedbios != nullptr));
 
-	uint8_t* gfx_base = m_fixed_layer_source ? m_region_fixed : m_region_fixedbios->base();
-	uint32_t addr_mask = ( m_fixed_layer_source ? m_region_fixed_size : m_region_fixedbios->bytes() ) - 1;
-	uint16_t *video_data = &m_videoram_drawsource[0x7000 | (scanline >> 3)];
-	uint32_t *pixel_addr = &bitmap.pix(scanline, NEOGEO_HBEND);
+	u8* gfx_base = m_fixed_layer_source ? m_region_fixed : m_region_fixedbios->base();
+	const u32 addr_mask = ( m_fixed_layer_source ? m_region_fixed_size : m_region_fixedbios->bytes() ) - 1;
+	const u16 *video_data = &m_videoram_drawsource[0x7000 | (scanline >> 3)];
+	u32 *pixel_addr = &bitmap.pix(scanline, NEOGEO_HBEND);
 
-	int garouoffsets[34];
-	int banked = m_fixed_layer_source && (addr_mask > 0x1ffff);
+	int garouoffsets[34]{};
+	const bool banked = m_fixed_layer_source && (addr_mask > 0x1ffff);
 
 	/* thanks to Mr K for the garou & kof2000 banking info */
 	/* Build line banking table for Garou & MS3 before starting render */
-	if (banked && m_fixed_layer_bank_type == 1)
+	if (banked && m_fixed_layer_bank_type == FIX_BANKTYPE_GAROU)
 	{
 		int garoubank = 0;
 		int k = 0;
@@ -207,32 +210,30 @@ void neosprite_base_device::draw_fixed_layer(bitmap_rgb32 &bitmap, int scanline)
 
 	for (int x = 0; x < 40; x++)
 	{
-		uint16_t code_and_palette = *video_data;
-		uint16_t code = code_and_palette & 0x0fff;
+		const u16 code_and_palette = *video_data;
+		u16 code = code_and_palette & 0x0fff;
 
 		if (banked)
 		{
 			int y = scanline >> 3;
 			switch (m_fixed_layer_bank_type)
 			{
-			case 1:
+			case FIX_BANKTYPE_GAROU:
 				/* Garou, MSlug 3 */
 				code += 0x1000 * (garouoffsets[(y - 2) & 31] ^ 3);
 				break;
-			case 2:
+			case FIX_BANKTYPE_KOF2000:
 				code += 0x1000 * (((m_videoram_drawsource[0x7500 + ((y - 1) & 31) + 32 * (x / 6)] >> (5 - (x % 6)) * 2) & 3) ^ 3);
 				break;
 			}
 		}
 
 		{
-			int gfx_offset = ((code << 5) | (scanline & 0x07)) & addr_mask;
+			const int gfx_offset = ((code << 5) | (scanline & 0x07)) & addr_mask;
 
-			const pen_t *char_pens;
+			const pen_t *char_pens = &m_pens[code_and_palette >> 12 << m_bppshift];
 
-			char_pens = &m_pens[code_and_palette >> 12 << m_bppshift];
-
-			static const uint32_t pix_offsets[] = { 0x10, 0x18, 0x00, 0x08 };
+			static const u32 pix_offsets[] = { 0x10, 0x18, 0x00, 0x08 };
 
 			for (int i = 0; i < 4; i++)
 			{
@@ -244,9 +245,9 @@ void neosprite_base_device::draw_fixed_layer(bitmap_rgb32 &bitmap, int scanline)
 }
 
 
-inline void neosprite_base_device::draw_fixed_layer_2pixels(uint32_t*&pixel_addr, int offset, uint8_t* gfx_base, const pen_t* char_pens)
+inline void neosprite_base_device::draw_fixed_layer_2pixels(u32*&pixel_addr, int offset, u8* gfx_base, const pen_t* char_pens)
 {
-	uint8_t data = gfx_base[offset];
+	const u8 data = gfx_base[offset];
 
 	if (data & 0x0f)
 		*pixel_addr = char_pens[data & 0x0f];
@@ -264,8 +265,8 @@ inline void neosprite_base_device::draw_fixed_layer_2pixels(uint32_t*&pixel_addr
  *
  *************************************/
 
-#define MAX_SPRITES_PER_SCREEN    (381)
-#define MAX_SPRITES_PER_LINE      (96)
+static constexpr u32 MAX_SPRITES_PER_SCREEN = 381;
+static constexpr u32 MAX_SPRITES_PER_LINE = 96;
 
 
 /* horizontal zoom table - verified on real hardware */
@@ -287,10 +288,10 @@ void neosprite_base_device::draw_sprites(bitmap_rgb32 &bitmap, int scanline)
 	int rows = 0;
 	int zoom_y = 0;
 	int zoom_x = 0;
-	uint16_t *sprite_list;
+	u16 *sprite_list;
 
 	/* select the active list */
-	if (scanline & 0x01)
+	if (BIT(scanline, 0))
 		sprite_list = &m_videoram_drawsource[0x8680];
 	else
 		sprite_list = &m_videoram_drawsource[0x8600];
@@ -310,12 +311,12 @@ void neosprite_base_device::draw_sprites(bitmap_rgb32 &bitmap, int scanline)
 
 	for (int sprite_index = 0; sprite_index <= max_sprite_index; sprite_index++)
 	{
-		uint16_t sprite_number = sprite_list[sprite_index] & 0x01ff;
-		uint16_t y_control = m_videoram_drawsource[0x8200 | sprite_number];
-		uint16_t zoom_control = m_videoram_drawsource[0x8000 | sprite_number];
+		const u16 sprite_number = sprite_list[sprite_index] & 0x01ff;
+		const u16 y_control = m_videoram_drawsource[0x8200 | sprite_number];
+		const u16 zoom_control = m_videoram_drawsource[0x8000 | sprite_number];
 
 		/* if chained, go to next X coordinate and get new X zoom */
-		if (y_control & 0x40)
+		if (BIT(y_control, 6))
 		{
 			x = (x + zoom_x + 1) & 0x01ff;
 			zoom_x = (zoom_control >> 8) & 0x0f;
@@ -340,18 +341,9 @@ void neosprite_base_device::draw_sprites(bitmap_rgb32 &bitmap, int scanline)
 		   since we buffered it */
 		if (sprite_on_scanline(scanline, y, rows))
 		{
-			int sprite_y;
-			int tile;
-			uint8_t sprite_y_and_tile;
-			offs_t attr_and_code_offs;
-			uint16_t attr;
-			uint32_t code;
-			const pen_t *line_pens;
-			int x_inc;
-
-			int sprite_line = (scanline - y) & 0x1ff;
+			const int sprite_line = (scanline - y) & 0x1ff;
 			int zoom_line = sprite_line & 0xff;
-			int invert = sprite_line & 0x100;
+			bool invert = BIT(sprite_line, 8);
 
 			if (invert)
 				zoom_line ^= 0xff;
@@ -367,10 +359,10 @@ void neosprite_base_device::draw_sprites(bitmap_rgb32 &bitmap, int scanline)
 				}
 			}
 
-			sprite_y_and_tile = m_region_zoomy[(zoom_y << 8) | zoom_line];
+			const u8 sprite_y_and_tile = m_region_zoomy[(zoom_y << 8) | zoom_line];
 
-			sprite_y = sprite_y_and_tile & 0x0f;
-			tile = sprite_y_and_tile >> 4;
+			int sprite_y = sprite_y_and_tile & 0x0f;
+			int tile = sprite_y_and_tile >> 4;
 
 			if (invert)
 			{
@@ -378,21 +370,21 @@ void neosprite_base_device::draw_sprites(bitmap_rgb32 &bitmap, int scanline)
 				tile ^= 0x1f;
 			}
 
-			attr_and_code_offs = (sprite_number << 6) | (tile << 1);
-			attr = m_videoram_drawsource[attr_and_code_offs + 1];
-			code = ((attr << 12) & 0xf0000) | m_videoram_drawsource[attr_and_code_offs];
+			const offs_t attr_and_code_offs = (sprite_number << 6) | (tile << 1);
+			const u16 attr = m_videoram_drawsource[attr_and_code_offs + 1];
+			u32 code = ((attr << 12) & 0xf0000) | m_videoram_drawsource[attr_and_code_offs];
 
 			/* substitute auto animation bits */
 			if (!m_auto_animation_disabled)
 			{
-				if (attr & 0x0008)
+				if (BIT(attr, 3))
 					code = (code & ~0x07) | (m_auto_animation_counter & 0x07);
-				else if (attr & 0x0004)
+				else if (BIT(attr, 2))
 					code = (code & ~0x03) | (m_auto_animation_counter & 0x03);
 			}
 
 			/* vertical flip? */
-			if (attr & 0x0002)
+			if (BIT(attr, 1))
 				sprite_y ^= 0x0f;
 
 			u16 zoom_x_table = zoom_x_tables[zoom_x];
@@ -400,10 +392,12 @@ void neosprite_base_device::draw_sprites(bitmap_rgb32 &bitmap, int scanline)
 			/* compute offset in gfx ROM and mask it to the number of bits available */
 			int gfx_base = ((code << 8) | (sprite_y << 4)) & m_sprite_gfx_address_mask;
 
-			line_pens = &m_pens[attr >> 8 << m_bppshift];
+			const pen_t *line_pens = &m_pens[attr >> 8 << m_bppshift];
+
+			int x_inc;
 
 			/* horizontal flip? */
-			if (attr & 0x0001)
+			if (BIT(attr, 0))
 			{
 				gfx_base = gfx_base + 0x0f;
 				x_inc = -1;
@@ -414,11 +408,11 @@ void neosprite_base_device::draw_sprites(bitmap_rgb32 &bitmap, int scanline)
 			/* draw the line - no wrap-around */
 			if (x <= 0x01f0)
 			{
-				uint32_t *pixel_addr = &bitmap.pix(scanline, x + NEOGEO_HBEND);
+				u32 *pixel_addr = &bitmap.pix(scanline, x + NEOGEO_HBEND);
 
 				for (int i = 0; i < 0x10; i++)
 				{
-					if (zoom_x_table & 0x8000)
+					if (BIT(zoom_x_table, 15))
 					{
 						draw_pixel(gfx_base, pixel_addr, line_pens);
 
@@ -435,12 +429,12 @@ void neosprite_base_device::draw_sprites(bitmap_rgb32 &bitmap, int scanline)
 			/* wrap-around */
 			else
 			{
-				int x_save = x;
-				uint32_t *pixel_addr = &bitmap.pix(scanline, NEOGEO_HBEND);
+				const int x_save = x;
+				u32 *pixel_addr = &bitmap.pix(scanline, NEOGEO_HBEND);
 
 				for (int i = 0; i < 0x10; i++)
 				{
-					if (zoom_x_table & 0x8000)
+					if (BIT(zoom_x_table, 15))
 					{
 						if (x >= 0x200)
 						{
@@ -467,26 +461,25 @@ void neosprite_base_device::draw_sprites(bitmap_rgb32 &bitmap, int scanline)
 
 void neosprite_base_device::parse_sprites(int scanline)
 {
-	uint16_t sprite_number;
 	int y = 0;
 	int rows = 0;
-	uint16_t *sprite_list;
+	u16 *sprite_list;
 
 	int active_sprite_count = 0;
 
 	/* select the active list */
-	if (scanline & 0x01)
+	if (BIT(scanline, 0))
 		sprite_list = &m_videoram_drawsource[0x8680];
 	else
 		sprite_list = &m_videoram_drawsource[0x8600];
 
 	/* scan all sprites */
-	for (sprite_number = 0; sprite_number < MAX_SPRITES_PER_SCREEN; sprite_number++)
+	for (u16 sprite_number = 0; sprite_number < MAX_SPRITES_PER_SCREEN; sprite_number++)
 	{
-		uint16_t y_control = m_videoram_drawsource[0x8200 | sprite_number];
+		const u16 y_control = m_videoram_drawsource[0x8200 | sprite_number];
 
 		/* if not chained, get Y position and height, otherwise use previous values */
-		if (~y_control & 0x40)
+		if (BIT(~y_control, 6))
 		{
 			y = 0x200 - (y_control >> 7);
 			rows = y_control & 0x3f;
@@ -546,21 +539,18 @@ void neosprite_base_device::start_sprite_line_timer()
 }
 
 
-uint32_t neosprite_base_device::get_region_mask(uint8_t* rgn, uint32_t rgn_size)
+u32 neosprite_base_device::get_region_mask(u8* rgn, u32 rgn_size)
 {
 	/* convert the sprite graphics data into a format that
 	   allows faster blitting */
-	uint32_t mask;
-	uint32_t len;
-	uint32_t bit;
 
 	/* get mask based on the length rounded up to the nearest
 	   power of 2 */
-	mask = 0xffffffff;
+	u32 mask = 0xffffffff;
 
-	len = rgn_size;
+	const u32 len = rgn_size;
 
-	for (bit = 0x80000000; bit != 0; bit >>= 1)
+	for (u32 bit = 0x80000000; bit != 0; bit >>= 1)
 	{
 		if ((len * 2 - 1) & bit)
 			break;
@@ -578,19 +568,19 @@ void neosprite_base_device::optimize_sprite_data()
 	return;
 }
 
-void neosprite_base_device::set_optimized_sprite_data(uint8_t* sprdata, uint32_t mask)
+void neosprite_base_device::set_optimized_sprite_data(u8* sprdata, u32 mask)
 {
 	return;
 }
 
 // these are for passing in pointers from the main system
-void neosprite_base_device::set_sprite_region(uint8_t* region_sprites, uint32_t region_sprites_size)
+void neosprite_base_device::set_sprite_region(u8* region_sprites, u32 region_sprites_size)
 {
 	m_region_sprites = region_sprites;
 	m_region_sprites_size = region_sprites_size;
 }
 
-void neosprite_base_device::set_fixed_regions(uint8_t* fix_cart, uint32_t fix_cart_size, memory_region* fix_bios)
+void neosprite_base_device::set_fixed_regions(u8* fix_cart, u32 fix_cart_size, memory_region* fix_bios)
 {
 	m_region_fixed = fix_cart;
 	m_region_fixed_size = fix_cart_size;
@@ -615,18 +605,18 @@ void neosprite_base_device::set_pens(const pen_t* pens)
 
 DEFINE_DEVICE_TYPE(NEOGEO_SPRITE_REGULAR, neosprite_regular_device, "neosprite_reg", "Neo-Geo Sprites (regular)")
 
-neosprite_regular_device::neosprite_regular_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+neosprite_regular_device::neosprite_regular_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: neosprite_base_device(mconfig, NEOGEO_SPRITE_REGULAR, tag, owner, clock)
 {
 }
 
-void neosprite_regular_device::set_sprite_region(uint8_t* region_sprites, uint32_t region_sprites_size)
+void neosprite_regular_device::set_sprite_region(u8* region_sprites, u32 region_sprites_size)
 {
 	m_region_sprites = region_sprites;
 	m_region_sprites_size = region_sprites_size;
 
-	uint32_t mask = get_region_mask(m_region_sprites, m_region_sprites_size);
-	uint32_t proper_size = (mask + 1) >>1;
+	const u32 mask = get_region_mask(m_region_sprites, m_region_sprites_size);
+	const u32 proper_size = (mask + 1) >>1;
 
 	printf("lengths %08x %08x m_region_sprites", region_sprites_size, proper_size);
 
@@ -638,15 +628,15 @@ void neosprite_regular_device::set_sprite_region(uint8_t* region_sprites, uint32
 	m_sprite_gfx_address_mask = mask;
 }
 
-inline void neosprite_regular_device::draw_pixel(int romaddr, uint32_t* dst, const pen_t *line_pens)
+inline void neosprite_regular_device::draw_pixel(int romaddr, u32* dst, const pen_t *line_pens)
 {
-	const uint8_t* src = m_region_sprites + (((romaddr &~0xff)>>1) | (((romaddr&0x8)^0x8)<<3) | ((romaddr & 0xf0)  >> 2));
+	const u8* src = m_region_sprites + (((romaddr &~0xff)>>1) | (((romaddr&0x8)^0x8)<<3) | ((romaddr & 0xf0)  >> 2));
 	const int x = romaddr & 0x7;
 
-	const uint8_t gfx = (((src[0x3] >> x) & 0x01) << 3) |
-						(((src[0x1] >> x) & 0x01) << 2) |
-						(((src[0x2] >> x) & 0x01) << 1) |
-						(((src[0x0] >> x) & 0x01) << 0);
+	const u8 gfx = (BIT(src[0x3], x) << 3) |
+						(BIT(src[0x1], x) << 2) |
+						(BIT(src[0x2], x) << 1) |
+						(BIT(src[0x0], x) << 0);
 
 	if (gfx)
 		*dst = line_pens[gfx];
@@ -663,25 +653,22 @@ inline void neosprite_regular_device::draw_pixel(int romaddr, uint32_t* dst, con
 
 DEFINE_DEVICE_TYPE(NEOGEO_SPRITE_OPTIMZIED, neosprite_optimized_device, "neosprite_opt", "Neo-Geo Sprites (optimized)")
 
-neosprite_optimized_device::neosprite_optimized_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+neosprite_optimized_device::neosprite_optimized_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: neosprite_base_device(mconfig, NEOGEO_SPRITE_OPTIMZIED, tag, owner, clock)
 	, m_spritegfx8(nullptr)
 {
 }
 
-uint32_t neosprite_optimized_device::optimize_helper(std::vector<uint8_t> &spritegfx, uint8_t* region_sprites, uint32_t region_sprites_size)
+u32 neosprite_optimized_device::optimize_helper(std::vector<u8> &spritegfx, u8* region_sprites, u32 region_sprites_size)
 {
 	// convert the sprite graphics data into a format that allows faster blitting
-	uint8_t *src;
-	uint8_t *dest;
 
-	uint32_t mask = get_region_mask(region_sprites, region_sprites_size);
+	const u32 mask = get_region_mask(region_sprites, region_sprites_size);
 
 	spritegfx.resize(mask + 1);
-	uint32_t spritegfx_address_mask = mask;
 
-	src = region_sprites;
-	dest = &spritegfx[0];
+	const u8 *src = region_sprites;
+	u8 *dest = &spritegfx[0];
 
 	for (unsigned i = 0; i < region_sprites_size; i += 0x80, src += 0x80)
 	{
@@ -689,23 +676,23 @@ uint32_t neosprite_optimized_device::optimize_helper(std::vector<uint8_t> &sprit
 		{
 			for (unsigned x = 0; x < 8; x++)
 			{
-				*(dest++) = (((src[0x43 | (y << 2)] >> x) & 0x01) << 3) |
-				(((src[0x41 | (y << 2)] >> x) & 0x01) << 2) |
-				(((src[0x42 | (y << 2)] >> x) & 0x01) << 1) |
-				(((src[0x40 | (y << 2)] >> x) & 0x01) << 0);
+				*(dest++) = (BIT(src[0x43 | (y << 2)], x) << 3) |
+				((BIT(src[0x41 | (y << 2)], x)) << 2) |
+				((BIT(src[0x42 | (y << 2)], x)) << 1) |
+				((BIT(src[0x40 | (y << 2)], x)) << 0);
 			}
 
 			for (unsigned x = 0; x < 8; x++)
 			{
-				*(dest++) = (((src[0x03 | (y << 2)] >> x) & 0x01) << 3) |
-				(((src[0x01 | (y << 2)] >> x) & 0x01) << 2) |
-				(((src[0x02 | (y << 2)] >> x) & 0x01) << 1) |
-				(((src[0x00 | (y << 2)] >> x) & 0x01) << 0);
+				*(dest++) = (BIT(src[0x03 | (y << 2)], x) << 3) |
+				(BIT(src[0x01 | (y << 2)], x) << 2) |
+				(BIT(src[0x02 | (y << 2)], x) << 1) |
+				(BIT(src[0x00 | (y << 2)], x) << 0);
 			}
 		}
 	}
 
-	return spritegfx_address_mask;
+	return mask;
 }
 
 
@@ -715,15 +702,15 @@ void neosprite_optimized_device::optimize_sprite_data()
 	m_spritegfx8 = &m_sprite_gfx[0];
 }
 
-void neosprite_optimized_device::set_optimized_sprite_data(uint8_t* sprdata, uint32_t mask)
+void neosprite_optimized_device::set_optimized_sprite_data(u8* sprdata, u32 mask)
 {
 	m_sprite_gfx_address_mask = mask;
 	m_spritegfx8 = &sprdata[0];
 }
 
-inline void neosprite_optimized_device::draw_pixel(int romaddr, uint32_t* dst, const pen_t *line_pens)
+inline void neosprite_optimized_device::draw_pixel(int romaddr, u32* dst, const pen_t *line_pens)
 {
-	const uint8_t gfx = m_spritegfx8[romaddr];
+	const u8 gfx = m_spritegfx8[romaddr];
 
 	if (gfx)
 		*dst = line_pens[gfx];
@@ -733,33 +720,33 @@ inline void neosprite_optimized_device::draw_pixel(int romaddr, uint32_t* dst, c
 /*********************************************************************************************************************************/
 /* MIDAS specific sprite handling                                                                                                */
 /*                                                                                                                               */
-/* this is used by the midas.c hardware which is a reengineered NeoGeo, it has 8bbp tiles instead of 4bpp tiles                  */
+/* this is used by the neogeo/midas.cpp hardware which is a reengineered NeoGeo, it has 8bbp tiles instead of 4bpp tiles         */
 /* and uploads the zoom table.  The additional videoram buffering is a guess because 'hammer' is very glitchy without it         */
 /*********************************************************************************************************************************/
 
 DEFINE_DEVICE_TYPE(NEOGEO_SPRITE_MIDAS, neosprite_midas_device, "midassprite", "MIDAS Sprites")
 
 
-neosprite_midas_device::neosprite_midas_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+neosprite_midas_device::neosprite_midas_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: neosprite_base_device(mconfig, NEOGEO_SPRITE_MIDAS, tag, owner, clock)
 {
 	m_bppshift = 8;
 }
 
 
-inline void neosprite_midas_device::draw_pixel(int romaddr, uint32_t* dst, const pen_t *line_pens)
+inline void neosprite_midas_device::draw_pixel(int romaddr, u32* dst, const pen_t *line_pens)
 {
-	const uint8_t* src = m_region_sprites + (((romaddr &~0xff)) | (((romaddr&0x8)^0x8)<<4) | ((romaddr & 0xf0)  >> 1));
+	const u8* src = m_region_sprites + (((romaddr &~0xff)) | (((romaddr&0x8)^0x8)<<4) | ((romaddr & 0xf0)  >> 1));
 	const int x = romaddr & 0x7;
 
-	const uint8_t gfx =   (((src[0x7] >> x) & 0x01) << 7) |
-						(((src[0x6] >> x) & 0x01) << 6) |
-						(((src[0x5] >> x) & 0x01) << 5) |
-						(((src[0x4] >> x) & 0x01) << 4) |
-						(((src[0x3] >> x) & 0x01) << 3) |
-						(((src[0x2] >> x) & 0x01) << 2) |
-						(((src[0x1] >> x) & 0x01) << 1) |
-						(((src[0x0] >> x) & 0x01) << 0);
+	const u8 gfx =   (BIT(src[0x7],  x) << 7) |
+						(BIT(src[0x6], x) << 6) |
+						(BIT(src[0x5], x) << 5) |
+						(BIT(src[0x4], x) << 4) |
+						(BIT(src[0x3], x) << 3) |
+						(BIT(src[0x2], x) << 2) |
+						(BIT(src[0x1], x) << 1) |
+						(BIT(src[0x0], x) << 0);
 
 	if (gfx)
 		*dst = line_pens[gfx];
@@ -770,37 +757,34 @@ void neosprite_midas_device::device_start()
 {
 	neosprite_base_device::device_start();
 
-	m_videoram_buffer = std::make_unique<uint16_t[]>(0x8000 + 0x800);
+	m_videoram_buffer = std::make_unique<u16[]>(0x8000 + 0x800);
 	m_videoram_drawsource = m_videoram_buffer.get();
 
-	memset(m_videoram_buffer.get(), 0x00, (0x8000 + 0x800) * sizeof(uint16_t));
+	memset(m_videoram_buffer.get(), 0x00, (0x8000 + 0x800) * sizeof(u16));
 
 }
 
 void neosprite_midas_device::buffer_vram()
 {
-	memcpy(m_videoram_buffer.get(), m_videoram.get(), (0x8000 + 0x800) * sizeof(uint16_t));
+	memcpy(m_videoram_buffer.get(), m_videoram.get(), (0x8000 + 0x800) * sizeof(u16));
 }
 
-inline void neosprite_midas_device::draw_fixed_layer_2pixels(uint32_t*&pixel_addr, int offset, uint8_t* gfx_base, const pen_t* char_pens)
+inline void neosprite_midas_device::draw_fixed_layer_2pixels(u32*&pixel_addr, int offset, u8* gfx_base, const pen_t* char_pens)
 {
-	uint8_t data;
-
-	data = ((gfx_base[(offset * 2)+0] & 0x0f)<<0) | ((gfx_base[(offset * 2)+1] & 0x0f)<<4);
+	u8 data = ((gfx_base[(offset * 2) + 0] & 0x0f) << 0) | ((gfx_base[(offset * 2) + 1] & 0x0f) << 4);
 	if (data)
 		*pixel_addr = char_pens[data];
 	pixel_addr++;
 
-	data = ((gfx_base[(offset * 2)+0] & 0xf0)>>4) | ((gfx_base[(offset * 2)+1] & 0xf0)<<0);
+	data = ((gfx_base[(offset * 2) + 0] & 0xf0) >> 4) | ((gfx_base[(offset * 2) + 1] & 0xf0) << 0);
 	if (data)
 		*pixel_addr = char_pens[data];
 	pixel_addr++;
 }
 
-void neosprite_midas_device::set_sprite_region(uint8_t* region_sprites, uint32_t region_sprites_size)
+void neosprite_midas_device::set_sprite_region(u8* region_sprites, u32 region_sprites_size)
 {
 	m_region_sprites = region_sprites;
 	m_region_sprites_size = region_sprites_size;
-	uint32_t mask = get_region_mask(m_region_sprites, m_region_sprites_size);
-	m_sprite_gfx_address_mask = mask;
+	m_sprite_gfx_address_mask = get_region_mask(m_region_sprites, m_region_sprites_size);
 }

--- a/src/mame/neogeo/neogeo_spr.h
+++ b/src/mame/neogeo/neogeo_spr.h
@@ -19,56 +19,36 @@
 class neosprite_base_device : public device_t, public device_video_interface
 {
 public:
+	// fix layer bankswitch type
+	enum
+	{
+		FIX_BANKTYPE_STD = 0,
+		FIX_BANKTYPE_GAROU = 1,
+		FIX_BANKTYPE_KOF2000 = 2
+	};
+
 	virtual void optimize_sprite_data();
-	virtual void set_optimized_sprite_data(uint8_t* sprdata, uint32_t mask);
+	virtual void set_optimized_sprite_data(u8* sprdata, u32 mask);
 
-	virtual void draw_fixed_layer_2pixels(uint32_t*&pixel_addr, int offset, uint8_t* gfx_base, const pen_t* char_pens);
 	void draw_fixed_layer(bitmap_rgb32 &bitmap, int scanline);
-	void set_videoram_offset(uint16_t data);
-	uint16_t get_videoram_data();
-	void set_videoram_data(uint16_t data);
-	void set_videoram_modulo(uint16_t data);
-	uint16_t get_videoram_modulo();
-	void set_auto_animation_speed(uint8_t data);
-	void set_auto_animation_disabled(uint8_t data);
-	uint8_t neogeo_get_auto_animation_counter();
-	void create_auto_animation_timer();
-	void start_auto_animation_timer();
-	void neogeo_set_fixed_layer_source(uint8_t data);
-	inline bool sprite_on_scanline(int scanline, int y, int rows);
-	virtual void draw_pixel(int romaddr, uint32_t* dst, const pen_t *line_pens) = 0;
 	void draw_sprites(bitmap_rgb32 &bitmap, int scanline);
-	void parse_sprites(int scanline);
-	void create_sprite_line_timer();
-	void start_sprite_line_timer();
-	virtual void set_sprite_region(uint8_t* region_sprites, uint32_t region_sprites_size);
-	void set_fixed_regions(uint8_t* fix_cart, uint32_t fix_cart_size, memory_region* fix_bios);
+
+	void set_videoram_offset(u16 data);
+	u16 get_videoram_data();
+	void set_videoram_data(u16 data);
+	void set_videoram_modulo(u16 data);
+	u16 get_videoram_modulo();
+
+	void set_auto_animation_speed(u8 data);
+	void set_auto_animation_disabled(u8 data);
+	u8 get_auto_animation_counter();
+
+	void set_fixed_layer_source(u8 data);
+	void set_fixed_layer_bank_type(u8 data);
+
+	virtual void set_sprite_region(u8* region_sprites, u32 region_sprites_size);
+	void set_fixed_regions(u8* fix_cart, u32 fix_cart_size, memory_region* fix_bios);
 	void set_pens(const pen_t* pens);
-
-	std::unique_ptr<uint16_t[]>     m_videoram;
-	uint16_t     *m_videoram_drawsource = nullptr;
-
-	uint16_t     m_vram_offset = 0;
-	uint16_t     m_vram_read_buffer = 0;
-	uint16_t     m_vram_modulo = 0;
-
-	uint32_t     m_sprite_gfx_address_mask = 0;
-
-	uint8_t      m_auto_animation_speed = 0;
-	uint8_t      m_auto_animation_disabled = 0;
-	uint8_t      m_auto_animation_counter = 0;
-	uint8_t      m_auto_animation_frame_counter = 0;
-
-	uint8_t      m_fixed_layer_source = 0;
-	uint8_t      m_fixed_layer_bank_type = 0;
-
-	emu_timer  *m_auto_animation_timer = nullptr;
-	emu_timer  *m_sprite_line_timer = nullptr;
-
-	TIMER_CALLBACK_MEMBER(auto_animation_timer_callback);
-	TIMER_CALLBACK_MEMBER(sprite_line_timer_callback);
-
-	int m_bppshift; // 4 for 4bpp gfx (NeoGeo) 8 for 8bpp gfx (Midas)
 
 protected:
 	neosprite_base_device(
@@ -76,26 +56,67 @@ protected:
 			device_type type,
 			const char *tag,
 			device_t *owner,
-			uint32_t clock);
+			u32 clock);
 
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
-	uint32_t get_region_mask(uint8_t* rgn, uint32_t rgn_size);
-	uint8_t* m_region_sprites = nullptr; uint32_t m_region_sprites_size = 0;
-	uint8_t* m_region_fixed = nullptr; uint32_t m_region_fixed_size = 0;
+
+	void create_auto_animation_timer();
+	void start_auto_animation_timer();
+
+	void create_sprite_line_timer();
+	void start_sprite_line_timer();
+
+	void parse_sprites(int scanline);
+
+	inline bool sprite_on_scanline(int scanline, int y, int rows);
+
+	virtual void draw_pixel(int romaddr, u32* dst, const pen_t *line_pens) = 0;
+
+	virtual void draw_fixed_layer_2pixels(u32*&pixel_addr, int offset, u8* gfx_base, const pen_t* char_pens);
+
+	TIMER_CALLBACK_MEMBER(auto_animation_timer_callback);
+	TIMER_CALLBACK_MEMBER(sprite_line_timer_callback);
+
+	u32 get_region_mask(u8* rgn, u32 rgn_size);
+
+	u8* m_region_sprites = nullptr; u32 m_region_sprites_size = 0;
+	u8* m_region_fixed = nullptr; u32 m_region_fixed_size = 0;
 	memory_region* m_region_fixedbios = nullptr;
 	const pen_t   *m_pens = nullptr;
 
-	required_region_ptr<uint8_t> m_region_zoomy;
+	std::unique_ptr<u16[]>     m_videoram;
+	u16     *m_videoram_drawsource = nullptr;
+
+	u16     m_vram_offset = 0;
+	u16     m_vram_read_buffer = 0;
+	u16     m_vram_modulo = 0;
+
+	u32     m_sprite_gfx_address_mask = 0;
+
+	u8      m_auto_animation_speed = 0;
+	u8      m_auto_animation_disabled = 0;
+	u8      m_auto_animation_counter = 0;
+	u8      m_auto_animation_frame_counter = 0;
+
+	u8      m_fixed_layer_source = 0;
+	u8      m_fixed_layer_bank_type = 0;
+
+	emu_timer  *m_auto_animation_timer = nullptr;
+	emu_timer  *m_sprite_line_timer = nullptr;
+
+	int m_bppshift; // 4 for 4bpp gfx (NeoGeo) 8 for 8bpp gfx (Midas)
+
+	required_region_ptr<u8> m_region_zoomy;
 };
 
 
 class neosprite_regular_device : public neosprite_base_device
 {
 public:
-	neosprite_regular_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-	virtual void draw_pixel(int romaddr, uint32_t* dst, const pen_t *line_pens) override;
-	virtual void set_sprite_region(uint8_t* region_sprites, uint32_t region_sprites_size) override;
+	neosprite_regular_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+	virtual void draw_pixel(int romaddr, u32* dst, const pen_t *line_pens) override;
+	virtual void set_sprite_region(u8* region_sprites, u32 region_sprites_size) override;
 
 };
 
@@ -105,15 +126,15 @@ DECLARE_DEVICE_TYPE(NEOGEO_SPRITE_REGULAR, neosprite_regular_device)
 class neosprite_optimized_device : public neosprite_base_device
 {
 public:
-	neosprite_optimized_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	neosprite_optimized_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 	virtual void optimize_sprite_data() override;
-	virtual void set_optimized_sprite_data(uint8_t* sprdata, uint32_t mask) override;
-	virtual void draw_pixel(int romaddr, uint32_t* dst, const pen_t *line_pens) override;
-	std::vector<uint8_t> m_sprite_gfx;
-	uint8_t* m_spritegfx8;
+	virtual void set_optimized_sprite_data(u8* sprdata, u32 mask) override;
+	virtual void draw_pixel(int romaddr, u32* dst, const pen_t *line_pens) override;
+	std::vector<u8> m_sprite_gfx;
+	u8* m_spritegfx8;
 
 private:
-	uint32_t optimize_helper(std::vector<uint8_t> &spritegfx, uint8_t* region_sprites, uint32_t region_sprites_size);
+	u32 optimize_helper(std::vector<u8> &spritegfx, u8* region_sprites, u32 region_sprites_size);
 };
 
 DECLARE_DEVICE_TYPE(NEOGEO_SPRITE_OPTIMZIED, neosprite_optimized_device)
@@ -122,14 +143,14 @@ DECLARE_DEVICE_TYPE(NEOGEO_SPRITE_OPTIMZIED, neosprite_optimized_device)
 class neosprite_midas_device : public neosprite_base_device
 {
 public:
-	neosprite_midas_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	neosprite_midas_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void draw_pixel(int romaddr, uint32_t* dst, const pen_t *line_pens) override;
+	virtual void draw_pixel(int romaddr, u32* dst, const pen_t *line_pens) override;
 
-	std::unique_ptr<uint16_t[]> m_videoram_buffer;
+	std::unique_ptr<u16[]> m_videoram_buffer;
 	void buffer_vram();
-	virtual void draw_fixed_layer_2pixels(uint32_t*&pixel_addr, int offset, uint8_t* gfx_base, const pen_t* char_pens) override;
-	virtual void set_sprite_region(uint8_t* region_sprites, uint32_t region_sprites_size) override;
+	virtual void draw_fixed_layer_2pixels(u32*&pixel_addr, int offset, u8* gfx_base, const pen_t* char_pens) override;
+	virtual void set_sprite_region(u8* region_sprites, u32 region_sprites_size) override;
 
 	protected:
 	virtual void device_start() override ATTR_COLD;

--- a/src/mame/neogeo/neogeocd.cpp
+++ b/src/mame/neogeo/neogeocd.cpp
@@ -418,12 +418,7 @@ uint8_t ngcd_state::transfer_r(offs_t offset)
 			uint32_t const address = (m_sprite_transfer_bank + (seek_address & 0x0fffff));
 
 			// address is swizzled a bit due to out sprite decoding
-			if ((address & 3) == 0) return m_sprite_ram[address];
-			if ((address & 3) == 1) return m_sprite_ram[address ^ 3];
-			if ((address & 3) == 2) return m_sprite_ram[address ^ 3];
-			if ((address & 3) == 3) return m_sprite_ram[address];
-
-			return m_sprite_ram[m_sprite_transfer_bank + (seek_address & 0x0fffff)];
+			return m_sprite_ram[address ^ ((BIT(address, 0) == BIT(address, 1)) ? 0 : 3)];
 		}
 		case 1:                         // ADPCM
 			return m_adpcm_ram[m_adpcm_transfer_bank + ((seek_address & 0x0fffff) >> 1)];
@@ -454,11 +449,7 @@ void ngcd_state::transfer_w(offs_t offset, uint8_t data)
 			uint32_t const address = (m_sprite_transfer_bank + (seek_address & 0x0fffff));
 
 			// address is swizzled a bit due to out sprite decoding
-			if ((address & 3) == 0) m_sprite_ram[address] = data;
-			if ((address & 3) == 1) m_sprite_ram[address ^ 3] = data;
-			if ((address & 3) == 2) m_sprite_ram[address ^ 3] = data;
-			if ((address & 3) == 3) m_sprite_ram[address] = data;
-
+			m_sprite_ram[address ^ ((BIT(address, 0) == BIT(address, 1)) ? 0 : 3)] = data;
 			break;
 		}
 		case 1:                         // ADPCM

--- a/src/mame/neogeo/neogeocd.cpp
+++ b/src/mame/neogeo/neogeocd.cpp
@@ -77,24 +77,14 @@ protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
-	int32_t seek_idle(int32_t cycles);
-
 private:
 	optional_device<lc89510_temp_device> m_tempcdc;
 	required_shared_ptr<uint8_t> m_z80_ram;
 	required_shared_ptr<uint8_t> m_adpcm_ram;
 
-	void do_dma(address_space& curr_space);
-	void set_dma_regs(offs_t offset, uint16_t data);
-
-	uint16_t memcard_r(offs_t offset);
-	void memcard_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t control_r(offs_t offset);
-	void control_w(address_space &space, offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint8_t transfer_r(offs_t offset);
-	void transfer_w(offs_t offset, uint8_t data);
-
-	DECLARE_INPUT_CHANGED_MEMBER(aes_jp1);
+	std::unique_ptr<uint8_t[]> m_meminternal_data;
+	std::unique_ptr<uint8_t[]> m_sprite_ram;
+	std::unique_ptr<uint8_t[]> m_fix_ram;
 
 	// neoCD
 	uint8_t m_system_region = 0;
@@ -120,6 +110,20 @@ private:
 
 	bool prohibit_cdc_irq = false; // hack?
 
+	int32_t seek_idle(int32_t cycles);
+
+	void do_dma(address_space& curr_space);
+	void set_dma_regs(offs_t offset, uint16_t data);
+
+	uint16_t memcard_r(offs_t offset);
+	void memcard_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	uint16_t control_r(offs_t offset);
+	void control_w(address_space &space, offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	uint8_t transfer_r(offs_t offset);
+	void transfer_w(offs_t offset, uint8_t data);
+
+	DECLARE_INPUT_CHANGED_MEMBER(aes_jp1);
+
 	int get_irq_vector_ack(void) { return m_irq_vector_ack; }
 	void set_irq_vector_ack(int val) { m_irq_vector_ack = val; }
 	int get_irq_vector(void) { return m_irq_vector; }
@@ -134,16 +138,11 @@ private:
 
 	uint8_t cdc_irq_ack();
 
-	std::unique_ptr<uint8_t[]> m_meminternal_data;
-	std::unique_ptr<uint8_t[]> m_sprite_ram;
-	std::unique_ptr<uint8_t[]> m_fix_ram;
-
 	void neocd_audio_io_map(address_map &map) ATTR_COLD;
 	void neocd_audio_map(address_map &map) ATTR_COLD;
 	void neocd_main_map(address_map &map) ATTR_COLD;
 	void neocd_vector_map(address_map &map) ATTR_COLD;
 	void neocd_ym_map(address_map &map) ATTR_COLD;
-
 };
 
 

--- a/src/mame/neogeo/neogeocd.cpp
+++ b/src/mame/neogeo/neogeocd.cpp
@@ -38,10 +38,10 @@
 namespace {
 
 // was it actually released in eu / asia?
-#define NEOCD_REGION_ASIA 3 // IronClad runs with a darkened screen (MVS has the same issue)
-#define NEOCD_REGION_EUROPE 2 // ^
-#define NEOCD_REGION_US 1
-#define NEOCD_REGION_JAPAN 0
+//static constexpr unsigned NEOCD_REGION_ASIA = 3; // IronClad runs with a darkened screen (MVS has the same issue)
+//static constexpr unsigned NEOCD_REGION_EUROPE = 2; // ^
+static constexpr unsigned NEOCD_REGION_US = 1;
+static constexpr unsigned NEOCD_REGION_JAPAN = 0;
 
 
 class ngcd_state : public aes_base_state
@@ -68,12 +68,24 @@ public:
 		m_has_z80_bus = true;
 	}
 
+	void neocd_ntsc(machine_config &config);
+
+	void init_neocdz();
+	void init_neocdzj();
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+	virtual void machine_reset() override ATTR_COLD;
+
+	int32_t seek_idle(int32_t cycles);
+
+private:
 	optional_device<lc89510_temp_device> m_tempcdc;
 	required_shared_ptr<uint8_t> m_z80_ram;
 	required_shared_ptr<uint8_t> m_adpcm_ram;
 
 	void do_dma(address_space& curr_space);
-	void set_dma_regs(int offset, uint16_t wordValue);
+	void set_dma_regs(offs_t offset, uint16_t data);
 
 	uint16_t memcard_r(offs_t offset);
 	void memcard_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
@@ -96,32 +108,29 @@ public:
 	int32_t m_dma_count;
 	int32_t m_dma_mode;
 	int32_t m_irq_ack;
-	int m_irq_vector_ack;
-	int m_irq_vector;
+	int32_t m_irq_vector_ack;
+	int32_t m_irq_vector;
 
 	bool m_has_sprite_bus;
 	bool m_has_text_bus;
 	bool m_has_ymrom_bus;
 	bool m_has_z80_bus;
 
+	uint8_t m_transfer_write_enable = 0;
+
+	bool prohibit_cdc_irq = false; // hack?
+
 	int get_irq_vector_ack(void) { return m_irq_vector_ack; }
 	void set_irq_vector_ack(int val) { m_irq_vector_ack = val; }
 	int get_irq_vector(void) { return m_irq_vector; }
-	void irq_update(uint8_t byteValue);
+	void irq_update(uint8_t data);
 
 	// from the CDC
 	void interrupt_callback_type1(void);
 	void interrupt_callback_type2(void);
 	void interrupt_callback_type3(void);
 
-	uint8_t m_transfer_write_enable = 0;
-
-	bool prohibit_cdc_irq = false; // hack?
-
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-
-	void init_neocdz();
-	void init_neocdzj();
 
 	uint8_t cdc_irq_ack();
 
@@ -129,18 +138,12 @@ public:
 	std::unique_ptr<uint8_t[]> m_sprite_ram;
 	std::unique_ptr<uint8_t[]> m_fix_ram;
 
-	void neocd_ntsc(machine_config &config);
 	void neocd_audio_io_map(address_map &map) ATTR_COLD;
 	void neocd_audio_map(address_map &map) ATTR_COLD;
 	void neocd_main_map(address_map &map) ATTR_COLD;
 	void neocd_vector_map(address_map &map) ATTR_COLD;
 	void neocd_ym_map(address_map &map) ATTR_COLD;
 
-protected:
-	virtual void machine_start() override ATTR_COLD;
-	virtual void machine_reset() override ATTR_COLD;
-
-	int32_t SekIdle(int32_t nCycles);
 };
 
 
@@ -150,8 +153,6 @@ protected:
  *  Memory card
  *
  *************************************/
-
-#define MEMCARD_SIZE    0x0800
 
 
 /* The NeoCD has an 8kB internal memory card, instead of memcard slots like the MVS and AES */
@@ -178,9 +179,10 @@ void ngcd_state::memcard_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 
 uint16_t ngcd_state::control_r(offs_t offset)
 {
-	uint32_t sekAddress = 0xff0000+ (offset*2);
+	uint32_t const seek_address = 0xff0000 + (offset * 2);
 
-	switch (sekAddress & 0xFFFF) {
+	switch (seek_address & 0xffff)
+	{
 		case 0x0016:
 			return m_tempcdc->nff0016_r();
 
@@ -194,12 +196,12 @@ uint16_t ngcd_state::control_r(offs_t offset)
 		case 0x0160:
 			return m_tempcdc->neocd_cdd_rx_r();
 
-		case 0x011C: // region
+		case 0x011c: // region
 			return ~((0x10 | (m_system_region & 3)) << 8);
 	}
 
 
-//  bprintf(PRINT_NORMAL, _T("  - NGCD port 0x%06X read (word, PC: 0x%06X)\n"), sekAddress, SekGetPC(-1));
+//  bprintf(PRINT_NORMAL, _T("  - NGCD port 0x%06X read (word, PC: 0x%06X)\n"), seek_address, SekGetPC(-1));
 
 	return ~0;
 }
@@ -207,30 +209,29 @@ uint16_t ngcd_state::control_r(offs_t offset)
 
 void ngcd_state::control_w(address_space &space, offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	uint32_t sekAddress = 0xff0000+ (offset*2);
-	uint16_t wordValue = data;
+	uint32_t const seek_address = 0xff0000 + (offset * 2);
 
-//  bprintf(PRINT_NORMAL, _T("  - NGCD port 0x%06X -> 0x%04X (PC: 0x%06X)\n"), sekAddress, wordValue, SekGetPC(-1));
-	int byteValue = wordValue & 0xff;
+//  bprintf(PRINT_NORMAL, _T("  - NGCD port 0x%06X -> 0x%04X (PC: 0x%06X)\n"), seek_address, data, SekGetPC(-1));
+	uint8_t const byte_value = data & 0xff;
 
-	switch (sekAddress & 0xFFFE) {
+	switch (seek_address & 0xfffe)
+	{
 		case 0x0002:
-
-			m_tempcdc->nff0002_set(wordValue);
-
+			m_tempcdc->nff0002_set(data);
 			break;
 
-		case 0x000E:
-			irq_update(wordValue); // irqack
+		case 0x000e:
+			irq_update(data); // irqack
 			break;
 
 		case 0x0016:
-			m_tempcdc->nff0016_set(byteValue);
+			m_tempcdc->nff0016_set(byte_value);
 			break;
 
 			// DMA controller
 		case 0x0060:
-			if (byteValue & 0x40) {
+			if (BIT(byte_value, 6))
+			{
 				do_dma(space);
 			}
 			break;
@@ -238,13 +239,13 @@ void ngcd_state::control_w(address_space &space, offs_t offset, uint16_t data, u
 		case 0x0064:
 		case 0x0066:
 		case 0x0068:
-		case 0x006A:
-		case 0x006C:
-		case 0x006E:
+		case 0x006a:
+		case 0x006c:
+		case 0x006e:
 		case 0x0070:
 		case 0x0072:
-		case 0x007E:
-			set_dma_regs(sekAddress & 0xFFFE, wordValue);
+		case 0x007e:
+			set_dma_regs(seek_address & 0xfffe, data);
 			break;
 
 		// upload DMA controller program
@@ -254,25 +255,25 @@ void ngcd_state::control_w(address_space &space, offs_t offset, uint16_t data, u
 		case 0x0084:
 		case 0x0086:
 		case 0x0088:
-		case 0x008A:
-		case 0x008C:
-		case 0x008E:
-//          bprintf(PRINT_NORMAL, _T("  - DMA controller program[%02i] -> 0x%04X (PC: 0x%06X)\n"), sekAddress & 0x0F, wordValue, SekGetPC(-1));
+		case 0x008a:
+		case 0x008c:
+		case 0x008e:
+//          bprintf(PRINT_NORMAL, _T("  - DMA controller program[%02i] -> 0x%04X (PC: 0x%06X)\n"), seek_address & 0x0F, data, SekGetPC(-1));
 			break;
 
 		// LC8951 registers
 		case 0x0100:
-			m_tempcdc->segacd_cdc_mode_address_w(0, byteValue, 0xffff);
+			m_tempcdc->segacd_cdc_mode_address_w(0, byte_value, 0xffff);
 			break;
 		case 0x0102:
-			m_tempcdc->CDC_Reg_w(byteValue);
+			m_tempcdc->CDC_Reg_w(byte_value);
 			break;
 
 		case 0x0104:
-//          bprintf(PRINT_NORMAL, _T("  - NGCD 0xE00000 area -> 0x%02X (PC: 0x%06X)\n"), byteValue, SekGetPC(-1));
+//          bprintf(PRINT_NORMAL, _T("  - NGCD 0xE00000 area -> 0x%02X (PC: 0x%06X)\n"), byte_value, SekGetPC(-1));
 			if (ACCESSING_BITS_0_7)
 			{
-				m_active_transfer_area = byteValue;
+				m_active_transfer_area = byte_value;
 			}
 			break;
 
@@ -281,7 +282,7 @@ void ngcd_state::control_w(address_space &space, offs_t offset, uint16_t data, u
 			m_has_sprite_bus = false;
 			break;
 		case 0x0122:
-//          bprintf(PRINT_NORMAL, _T("  - NGCD PCM BUSREQ -> 1 (PC: 0x%06X) %x\n"), SekGetPC(-1), byteValue);
+//          bprintf(PRINT_NORMAL, _T("  - NGCD PCM BUSREQ -> 1 (PC: 0x%06X) %x\n"), SekGetPC(-1), byte_value);
 			m_has_ymrom_bus = false;
 			break;
 		case 0x0126:
@@ -316,15 +317,15 @@ void ngcd_state::control_w(address_space &space, offs_t offset, uint16_t data, u
 
 		// CD mechanism communication
 		case 0x0162:
-			m_tempcdc->neocd_cdd_tx_w(byteValue);
+			m_tempcdc->neocd_cdd_tx_w(byte_value);
 			break;
 		case 0x0164:
-			m_tempcdc->NeoCDCommsControl(byteValue & 1, byteValue & 2);
+			m_tempcdc->NeoCDCommsControl(byte_value & 1, byte_value & 2);
 			break;
 
 		case 0x016c:
-//          bprintf(PRINT_ERROR, _T("  - NGCD port 0x%06X -> 0x%02X (PC: 0x%06X)\n"), sekAddress, byteValue, SekGetPC(-1));
-			//MapVectorTable(!(byteValue == 0xFF));
+//          bprintf(PRINT_ERROR, _T("  - NGCD port 0x%06X -> 0x%02X (PC: 0x%06X)\n"), seek_address, byte_value, SekGetPC(-1));
+			//MapVectorTable(!(byte_value == 0xFF));
 			if (ACCESSING_BITS_0_7)
 			{
 				// even like this doubledr ends up mapping vectors in, then erasing them causing the loading to crash??
@@ -342,18 +343,19 @@ void ngcd_state::control_w(address_space &space, offs_t offset, uint16_t data, u
 			break;
 
 		case 0x016e:
-//          bprintf(PRINT_IMPORTANT, _T("  - NGCD 0xE00000 area write access %s (0x%02X, PC: 0x%06X)\n"), byteValue ? _T("enabled") : _T("disabled"), byteValue, SekGetPC(-1));
+//          bprintf(PRINT_IMPORTANT, _T("  - NGCD 0xE00000 area write access %s (0x%02X, PC: 0x%06X)\n"), byte_value ? _T("enabled") : _T("disabled"), byte_value, SekGetPC(-1));
 
-			m_transfer_write_enable = byteValue;
+			m_transfer_write_enable = byte_value;
 			break;
 
-		case 0x0180: {
+		case 0x0180:
+		{
 			// 1 during CD access, 0 otherwise, written frequently
 			//printf("reset cdc %04x %04x\n",data, mem_mask);
 
 			if (ACCESSING_BITS_0_7)
 			{
-				if (data==0x00)
+				if (data == 0x00)
 				{
 				// not a good idea, causes hangs
 				//  m_tempcdc->NeoCDCommsReset();
@@ -369,9 +371,10 @@ void ngcd_state::control_w(address_space &space, offs_t offset, uint16_t data, u
 			}
 			break;
 		}
-		case 0x0182: {
-		//  printf("blah %02x\n", byteValue);
-			if (byteValue == 0x00)
+		case 0x0182:
+		{
+		//  printf("blah %02x\n", byte_value);
+			if (byte_value == 0x00)
 			{
 				m_ym->reset();
 				m_audiocpu->set_input_line(INPUT_LINE_RESET, ASSERT_LINE);
@@ -380,16 +383,17 @@ void ngcd_state::control_w(address_space &space, offs_t offset, uint16_t data, u
 
 			break;
 		}
-		case 0x01A0:
-			m_sprite_transfer_bank = (byteValue & 3) << 20;
+		case 0x01a0:
+			m_sprite_transfer_bank = (byte_value & 3) << 20;
 			break;
-		case 0x01A2:
-			m_adpcm_transfer_bank  = (byteValue & 1) << 19;
+		case 0x01a2:
+			m_adpcm_transfer_bank  = (byte_value & 1) << 19;
 			break;
 
 
-		default: {
-//          bprintf(PRINT_NORMAL, _T("  - NGCD port 0x%06X -> 0x%04X (PC: 0x%06X)\n"), sekAddress, wordValue, SekGetPC(-1));
+		default:
+		{
+//          bprintf(PRINT_NORMAL, _T("  - NGCD port 0x%06X -> 0x%04X (PC: 0x%06X)\n"), seek_address, data, SekGetPC(-1));
 		}
 	}
 
@@ -406,28 +410,29 @@ void ngcd_state::control_w(address_space &space, offs_t offset, uint16_t data, u
 
 uint8_t ngcd_state::transfer_r(offs_t offset)
 {
-	uint32_t sekAddress = 0xe00000+ (offset);
-	int address;
-	sekAddress ^= 1;
+	uint32_t const seek_address = (0xe00000 + offset) ^ 1;
 
-	switch (m_active_transfer_area) {
+	switch (m_active_transfer_area)
+	{
 		case 0: // Sprites
-			address = (m_sprite_transfer_bank + (sekAddress & 0x0FFFFF));
+		{
+			uint32_t const address = (m_sprite_transfer_bank + (seek_address & 0x0fffff));
 
 			// address is swizzled a bit due to out sprite decoding
-			if ((address&3)==0) return m_sprite_ram[address];
-			if ((address&3)==1) return m_sprite_ram[address^3];
-			if ((address&3)==2) return m_sprite_ram[address^3];
-			if ((address&3)==3) return m_sprite_ram[address];
+			if ((address & 3) == 0) return m_sprite_ram[address];
+			if ((address & 3) == 1) return m_sprite_ram[address ^ 3];
+			if ((address & 3) == 2) return m_sprite_ram[address ^ 3];
+			if ((address & 3) == 3) return m_sprite_ram[address];
 
-			return m_sprite_ram[m_sprite_transfer_bank + (sekAddress & 0x0FFFFF)];
+			return m_sprite_ram[m_sprite_transfer_bank + (seek_address & 0x0fffff)];
+		}
 		case 1:                         // ADPCM
-			return m_adpcm_ram[m_adpcm_transfer_bank + ((sekAddress & 0x0FFFFF) >> 1)];
+			return m_adpcm_ram[m_adpcm_transfer_bank + ((seek_address & 0x0fffff) >> 1)];
 		case 4:                         // Z80
-			if ((sekAddress & 0xfffff) >= 0x20000) return ~0;
-			return m_z80_ram[(sekAddress & 0x1FFFF) >> 1];
+			if ((seek_address & 0xfffff) >= 0x20000) return ~0;
+			return m_z80_ram[(seek_address & 0x1ffff) >> 1];
 		case 5:                         // Text
-			return m_fix_ram[(sekAddress & 0x3FFFF) >> 1];
+			return m_fix_ram[(seek_address & 0x3ffff) >> 1];
 	}
 
 	return ~0;
@@ -436,29 +441,29 @@ uint8_t ngcd_state::transfer_r(offs_t offset)
 
 void ngcd_state::transfer_w(offs_t offset, uint8_t data)
 {
-	uint8_t byteValue = data;
-	uint32_t sekAddress = 0xe00000+ (offset);
+	uint32_t const seek_address = (0xe00000 + offset) ^ 1;
 
-	if (!m_transfer_write_enable) {
+	if (!m_transfer_write_enable)
+	{
 //      return;
 	}
-	int address;
 
-	sekAddress ^= 1;
-
-	switch (m_active_transfer_area) {
+	switch (m_active_transfer_area)
+	{
 		case 0:                         // Sprites
-			address = (m_sprite_transfer_bank + (sekAddress & 0x0FFFFF));
+		{
+			uint32_t const address = (m_sprite_transfer_bank + (seek_address & 0x0fffff));
 
 			// address is swizzled a bit due to out sprite decoding
-			if ((address&3)==0) m_sprite_ram[address] = byteValue;
-			if ((address&3)==1) m_sprite_ram[address^3] = byteValue;
-			if ((address&3)==2) m_sprite_ram[address^3] = byteValue;
-			if ((address&3)==3) m_sprite_ram[address] = byteValue;
+			if ((address & 3) == 0) m_sprite_ram[address] = data;
+			if ((address & 3) == 1) m_sprite_ram[address ^ 3] = data;
+			if ((address & 3) == 2) m_sprite_ram[address ^ 3] = data;
+			if ((address & 3) == 3) m_sprite_ram[address] = data;
 
 			break;
+		}
 		case 1:                         // ADPCM
-			m_adpcm_ram[m_adpcm_transfer_bank + ((sekAddress & 0x0FFFFF) >> 1)] = byteValue;
+			m_adpcm_ram[m_adpcm_transfer_bank + ((seek_address & 0x0fffff) >> 1)] = data;
 			break;
 		case 4:                         // Z80
 
@@ -468,71 +473,70 @@ void ngcd_state::transfer_w(offs_t offset, uint8_t data)
 			// transfer area without the bus? - this should really be checked on hw
 			if (m_has_z80_bus)
 			{
-				m_adpcm_ram[m_adpcm_transfer_bank + ((sekAddress & 0x0FFFFF) >> 1)] = byteValue;
+				m_adpcm_ram[m_adpcm_transfer_bank + ((seek_address & 0x0fffff) >> 1)] = data;
 			}
 			else
 			{
-		//  printf("sekAddress %08x %02x\n", sekAddress, data);
-				if ((sekAddress & 0xfffff) >= 0x20000) break;
-				m_z80_ram[(sekAddress & 0x1FFFF) >> 1] = byteValue;
+		//  printf("seek_address %08x %02x\n", seek_address, data);
+				if ((seek_address & 0xfffff) >= 0x20000) break;
+				m_z80_ram[(seek_address & 0x1ffff) >> 1] = data;
 			}
 			break;
 		case 5:                         // Text
-			m_fix_ram[(sekAddress & 0x3FFFF) >> 1] = byteValue;
+			m_fix_ram[(seek_address & 0x3ffff) >> 1] = data;
 			break;
 	}
 }
 
 
 
-void ngcd_state::set_dma_regs(int offset, uint16_t wordValue)
+void ngcd_state::set_dma_regs(offs_t offset, uint16_t data)
 {
 	switch (offset)
 	{
 		case 0x0064:
-			m_dma_address1 &= 0x0000FFFF;
-			m_dma_address1 |= wordValue << 16;
+			m_dma_address1 &= 0x0000ffff;
+			m_dma_address1 |= data << 16;
 			break;
 		case 0x0066:
-			m_dma_address1 &= 0xFFFF0000;
-			m_dma_address1 |= wordValue;
+			m_dma_address1 &= 0xffff0000;
+			m_dma_address1 |= data;
 			break;
 		case 0x0068:
-			m_dma_address2 &= 0x0000FFFF;
-			m_dma_address2 |= wordValue << 16;
+			m_dma_address2 &= 0x0000ffff;
+			m_dma_address2 |= data << 16;
 			break;
-		case 0x006A:
-			m_dma_address2 &= 0xFFFF0000;
-			m_dma_address2 |= wordValue;
+		case 0x006a:
+			m_dma_address2 &= 0xffff0000;
+			m_dma_address2 |= data;
 			break;
-		case 0x006C:
-			m_dma_value1 = wordValue;
+		case 0x006c:
+			m_dma_value1 = data;
 			break;
-		case 0x006E:
-			m_dma_value2 = wordValue;
+		case 0x006e:
+			m_dma_value2 = data;
 			break;
 		case 0x0070:
-			m_dma_count &= 0x0000FFFF;
-			m_dma_count |= wordValue << 16;
+			m_dma_count &= 0x0000ffff;
+			m_dma_count |= data << 16;
 			break;
 		case 0x0072:
-			m_dma_count &= 0xFFFF0000;
-			m_dma_count |= wordValue;
+			m_dma_count &= 0xffff0000;
+			m_dma_count |= data;
 			break;
 
-		case 0x007E:
-			m_dma_mode = wordValue;
-//          bprintf(PRINT_NORMAL, _T("  - DMA controller 0x%2X -> 0x%04X (PC: 0x%06X)\n"), sekAddress & 0xFF, wordValue, SekGetPC(-1));
+		case 0x007e:
+			m_dma_mode = data;
+//          bprintf(PRINT_NORMAL, _T("  - DMA controller 0x%2X -> 0x%04X (PC: 0x%06X)\n"), seek_address & 0xFF, data, SekGetPC(-1));
 			break;
-
 	}
 }
 
 
 
-int32_t ngcd_state::SekIdle(int32_t nCycles)
+int32_t ngcd_state::seek_idle(int32_t cycles)
 {
-	return nCycles;
+	return cycles;
 }
 
 
@@ -595,8 +599,10 @@ void ngcd_state::do_dma(address_space& curr_space)
 
 //  bprintf(PRINT_IMPORTANT, _T("  - DMA controller transfer started (PC: 0x%06X)\n"), SekGetPC(-1));
 
-	switch (m_dma_mode) {
-		case 0xCFFD: {
+	switch (m_dma_mode)
+	{
+		case 0xcffd:
+		{
 //          bprintf(PRINT_NORMAL, _T("    adr : 0x%08X - 0x%08X <- address, skip odd bytes\n"), m_dma_address1, m_dma_address1 + m_dma_count * 8);
 
 			//  - DMA controller 0x7E -> 0xCFFD (PC: 0xC07CE2)
@@ -609,9 +615,10 @@ void ngcd_state::do_dma(address_space& curr_space)
 			//  - DMA controller program[12] -> 0x2E02 (PC: 0xC07D0C)
 			//  - DMA controller program[14] -> 0xFDFF (PC: 0xC07D12)
 
-			SekIdle(m_dma_count * 4);
+			seek_idle(m_dma_count * 4);
 
-			while (m_dma_count--) {
+			while (m_dma_count--)
+			{
 				curr_space.write_word(m_dma_address1 + 0, m_dma_address1 >> 24);
 				curr_space.write_word(m_dma_address1 + 2, m_dma_address1 >> 16);
 				curr_space.write_word(m_dma_address1 + 4, m_dma_address1 >>  8);
@@ -622,7 +629,8 @@ void ngcd_state::do_dma(address_space& curr_space)
 			break;
 		}
 
-		case 0xE2DD: {
+		case 0xe2dd:
+		{
 //          bprintf(PRINT_NORMAL, _T("    copy: 0x%08X - 0x%08X <- 0x%08X - 0x%08X, skip odd bytes\n"), m_dma_address2, m_dma_address2 + m_dma_count * 2, m_dma_address1, m_dma_address1 + m_dma_count * 4);
 
 			//  - DMA controller 0x7E -> 0xE2DD (PC: 0xC0A190)
@@ -635,9 +643,10 @@ void ngcd_state::do_dma(address_space& curr_space)
 			//  - DMA controller program[12] -> 0x02FD (PC: 0xC0A19E)
 			//  - DMA controller program[14] -> 0xFFFF (PC: 0xC0A1A0)
 
-			SekIdle(m_dma_count * 1);
+			seek_idle(m_dma_count * 1);
 
-			while (m_dma_count--) {
+			while (m_dma_count--)
+			{
 				curr_space.write_word(m_dma_address2 + 0, curr_space.read_byte(m_dma_address1 + 0));
 				curr_space.write_word(m_dma_address2 + 2, curr_space.read_byte(m_dma_address1 + 1));
 				m_dma_address1 += 2;
@@ -647,7 +656,8 @@ void ngcd_state::do_dma(address_space& curr_space)
 			break;
 		}
 
-		case 0xFC2D: {
+		case 0xfc2d:
+		{
 //          bprintf(PRINT_NORMAL, _T("    copy: 0x%08X - 0x%08X <- LC8951 external buffer, skip odd bytes\n"), m_dma_address1, m_dma_address1 + m_dma_count * 4);
 
 			//  - DMA controller 0x7E -> 0xFC2D (PC: 0xC0A190)
@@ -661,13 +671,15 @@ void ngcd_state::do_dma(address_space& curr_space)
 			//  - DMA controller program[14] -> 0xFFFE (PC: 0xC0A1A0)
 
 			char* data = m_tempcdc->LC8915InitTransfer(m_dma_count);
-			if (data == nullptr) {
+			if (data == nullptr)
+			{
 				break;
 			}
 
-			SekIdle(m_dma_count * 4);
+			seek_idle(m_dma_count * 4);
 
-			while (m_dma_count--) {
+			while (m_dma_count--)
+			{
 				curr_space.write_byte(m_dma_address1 + 0, data[0]);
 				curr_space.write_byte(m_dma_address1 + 2, data[1]);
 				m_dma_address1 += 4;
@@ -679,7 +691,7 @@ void ngcd_state::do_dma(address_space& curr_space)
 			break;
 		}
 
-		case 0xFE3D:
+		case 0xfe3d:
 
 			//  - DMA controller 0x7E -> 0xFE3D (PC: 0xC0A190)
 			//  - DMA controller program[00] -> 0xFCF5 (PC: 0xC0A192)
@@ -691,7 +703,8 @@ void ngcd_state::do_dma(address_space& curr_space)
 			//  - DMA controller program[12] -> 0xF17D (PC: 0xC0A19E)
 			//  - DMA controller program[14] -> 0xFCF5 (PC: 0xC0A1A0)
 
-		case 0xFE6D: {
+		case 0xfe6d:
+		{
 //          bprintf(PRINT_NORMAL, _T("    copy: 0x%08X - 0x%08X <- 0x%08X - 0x%08X\n"), m_dma_address2, m_dma_address2 + m_dma_count * 2, m_dma_address1, m_dma_address1 + m_dma_count * 2);
 
 			//  - DMA controller 0x7E -> 0xFE6D (PC: 0xC0FD7A)
@@ -704,24 +717,27 @@ void ngcd_state::do_dma(address_space& curr_space)
 			//  - DMA controller program[12] -> 0xC515 (PC: 0xC0FD88)
 			//  - DMA controller program[14] -> 0xFCF5 (PC: 0xC0FD8A)
 
-			SekIdle(m_dma_count * 1);
+			seek_idle(m_dma_count * 1);
 
-			while (m_dma_count--) {
+			while (m_dma_count--)
+			{
 				curr_space.write_word(m_dma_address2, curr_space.read_word(m_dma_address1));
 				m_dma_address1 += 2;
 				m_dma_address2 += 2;
 			}
 
-if (m_dma_address2 == 0x0800)  {
-// MapVectorTable(false);
-//  bprintf(PRINT_ERROR, _T("    RAM vectors mapped (PC = 0x%08X\n"), SekGetPC(0));
-//  extern int32_t bRunPause;
-//  bRunPause = 1;
-}
+			if (m_dma_address2 == 0x0800)
+			{
+			// MapVectorTable(false);
+			//  bprintf(PRINT_ERROR, _T("    RAM vectors mapped (PC = 0x%08X\n"), SekGetPC(0));
+			//  extern int32_t bRunPause;
+			//  bRunPause = 1;
+			}
 			break;
 		}
 
-		case 0xFEF5: {
+		case 0xfef5:
+		{
 //          bprintf(PRINT_NORMAL, _T("    adr : 0x%08X - 0x%08X <- address\n"), m_dma_address1, m_dma_address1 + m_dma_count * 4);
 
 			//  - DMA controller 0x7E -> 0xFEF5 (PC: 0xC07CE2)
@@ -734,9 +750,10 @@ if (m_dma_address2 == 0x0800)  {
 			//  - DMA controller program[12] -> 0xFC3D (PC: 0xC07D0C)
 			//  - DMA controller program[14] -> 0xFCF5 (PC: 0xC07D12)
 
-			SekIdle(m_dma_count * 2);
+			seek_idle(m_dma_count * 2);
 
-			while (m_dma_count--) {
+			while (m_dma_count--)
+			{
 				curr_space.write_word(m_dma_address1 + 0, m_dma_address1 >> 16);
 				curr_space.write_word(m_dma_address1 + 2, m_dma_address1 >>  0);
 				m_dma_address1 += 4;
@@ -745,7 +762,8 @@ if (m_dma_address2 == 0x0800)  {
 			break;
 		}
 
-		case 0xFFC5: {
+		case 0xffc5:
+		{
 //          bprintf(PRINT_NORMAL, _T("    copy: 0x%08X - 0x%08X <- LC8951 external buffer\n"), m_dma_address1, m_dma_address1 + m_dma_count * 2);
 
 			//  - DMA controller 0x7E -> 0xFFC5 (PC: 0xC0A190)
@@ -759,13 +777,15 @@ if (m_dma_address2 == 0x0800)  {
 			//  - DMA controller program[14] -> 0xDA92 (PC: 0xC0A1A0)
 
 			char* data = m_tempcdc->LC8915InitTransfer(m_dma_count);
-			if (data == nullptr) {
+			if (data == nullptr)
+			{
 				break;
 			}
 
-			SekIdle(m_dma_count * 4);
+			seek_idle(m_dma_count * 4);
 
-			while (m_dma_count--) {
+			while (m_dma_count--)
+			{
 				curr_space.write_byte(m_dma_address1 + 0, data[0]);
 				curr_space.write_byte(m_dma_address1 + 1, data[1]);
 				m_dma_address1 += 2;
@@ -777,7 +797,7 @@ if (m_dma_address2 == 0x0800)  {
 			break;
 		}
 
-		case 0xFFCD:
+		case 0xffcd:
 
 			//  - DMA controller 0x7E -> 0xFFCD (PC: 0xC0A190)
 			//  - DMA controller program[00] -> 0xFCF5 (PC: 0xC0A192)
@@ -789,7 +809,8 @@ if (m_dma_address2 == 0x0800)  {
 			//  - DMA controller program[12] -> 0x2412 (PC: 0xC0A19E)
 			//  - DMA controller program[14] -> 0x13FC (PC: 0xC0A1A0)
 
-		case 0xFFDD: {
+		case 0xffdd:
+		{
 //          bprintf(PRINT_NORMAL, _T("    Fill: 0x%08X - 0x%08X <- 0x%04X\n"), m_dma_address1, m_dma_address1 + m_dma_count * 2, m_dma_value1);
 
 			//  - DMA controller 0x7E -> 0xFFDD (PC: 0xC07CE2)
@@ -802,21 +823,23 @@ if (m_dma_address2 == 0x0800)  {
 			//  - DMA controller program[12] -> 0x8AF0 (PC: 0xC07D0C)
 			//  - DMA controller program[14] -> 0x1609 (PC: 0xC07D12)
 
-			SekIdle(m_dma_count * 1);
+			seek_idle(m_dma_count * 1);
 
-			while (m_dma_count--) {
+			while (m_dma_count--)
+			{
 				curr_space.write_word(m_dma_address1, m_dma_value1);
 				m_dma_address1 += 2;
 			}
 
 			break;
 		}
-		default: {
+		default:
+		{
 			//bprintf(PRINT_ERROR, _T("    Unknown transfer type 0x%04X (PC: 0x%06X)\n"), m_dma_mode, SekGetPC(-1));
 			//bprintf(PRINT_NORMAL, _T("    ??? : 0x%08X  0x%08X 0x%04X 0x%04X 0x%08X\n"), m_dma_address1, m_dma_address2, m_dma_value1, m_dma_value2, m_dma_count);
 
-//extern int32_t bRunPause;
-//bRunPause = 1;
+			//extern int32_t bRunPause;
+			//bRunPause = 1;
 
 		}
 	}
@@ -844,7 +867,7 @@ void ngcd_state::machine_start()
 
 	m_sprgen->set_sprite_region(m_sprite_ram.get(), 0x400000);
 	m_sprgen->set_fixed_regions(m_fix_ram.get(), 0x20000, nullptr);
-	m_sprgen->neogeo_set_fixed_layer_source(1);
+	m_sprgen->set_fixed_layer_source(1);
 
 	m_vblank_level = 1;
 	m_raster_level = 3;
@@ -856,6 +879,28 @@ void ngcd_state::machine_start()
 	save_pointer(NAME(m_meminternal_data), 0x2000);
 
 	m_tempcdc->reset_cd();
+
+	save_item(NAME(m_active_transfer_area));
+	save_item(NAME(m_sprite_transfer_bank));
+	save_item(NAME(m_adpcm_transfer_bank));
+	save_item(NAME(m_dma_address1));
+	save_item(NAME(m_dma_address2));
+	save_item(NAME(m_dma_value1));
+	save_item(NAME(m_dma_value2));
+	save_item(NAME(m_dma_count));
+	save_item(NAME(m_dma_mode));
+	save_item(NAME(m_irq_ack));
+	save_item(NAME(m_irq_vector_ack));
+	save_item(NAME(m_irq_vector));
+
+	save_item(NAME(m_has_sprite_bus));
+	save_item(NAME(m_has_text_bus));
+	save_item(NAME(m_has_ymrom_bus));
+	save_item(NAME(m_has_z80_bus));
+
+	save_item(NAME(m_transfer_write_enable));
+
+	save_item(NAME(prohibit_cdc_irq));
 }
 
 
@@ -919,7 +964,7 @@ void ngcd_state::neocd_vector_map(address_map &map)
 
 void ngcd_state::neocd_audio_map(address_map &map)
 {
-	map(0x0000, 0xffff).ram().share("z80_ram");
+	map(0x0000, 0xffff).ram().share(m_z80_ram);
 }
 
 
@@ -940,7 +985,7 @@ void ngcd_state::neocd_audio_io_map(address_map &map)
 
 void ngcd_state::neocd_ym_map(address_map &map)
 {
-	map(0x000000, 0x0fffff).ram().share("adpcm_ram");
+	map(0x000000, 0x0fffff).ram().share(m_adpcm_ram);
 }
 
 
@@ -970,8 +1015,10 @@ INPUT_PORTS_END
 
 uint8_t ngcd_state::cdc_irq_ack()
 {
-	if (get_irq_vector_ack()) {
-		set_irq_vector_ack(0);
+	if (get_irq_vector_ack())
+	{
+		if (!machine().side_effects_disabled())
+			set_irq_vector_ack(0);
 		return get_irq_vector();
 	}
 
@@ -997,27 +1044,30 @@ void ngcd_state::interrupt_callback_type3(void)
 }
 
 
-void ngcd_state::irq_update(uint8_t byteValue)
+void ngcd_state::irq_update(uint8_t data)
 {
 	// do we also need to check the regular interrupts like FBA?
 
-	m_irq_ack |= (byteValue & 0x38);
+	m_irq_ack |= (data & 0x38);
 
 	if (!prohibit_cdc_irq)
 	{
-		if ((m_irq_ack & 0x08) == 0) {
+		if ((m_irq_ack & 0x08) == 0)
+		{
 			m_irq_vector = 0x17;
 			m_irq_vector_ack = 1;
 			m_maincpu->set_input_line(2, HOLD_LINE);
 			return;
 		}
-		if ((m_irq_ack & 0x10) == 0) {
+		if ((m_irq_ack & 0x10) == 0)
+		{
 			m_irq_vector = 0x16;
 			m_irq_vector_ack = 1;
 			m_maincpu->set_input_line(2, HOLD_LINE);
 			return;
 		}
-		if ((m_irq_ack & 0x20) == 0) {
+		if ((m_irq_ack & 0x20) == 0)
+		{
 			m_irq_vector = 0x15;
 			m_irq_vector_ack = 1;
 			m_maincpu->set_input_line(2, HOLD_LINE);

--- a/src/mame/neogeo/neopcb.cpp
+++ b/src/mame/neogeo/neopcb.cpp
@@ -82,9 +82,9 @@ void neopcb_state::neopcb(machine_config &config)
 
 	NEOGEO_CTRL_EDGE_CONNECTOR(config, m_edge, neogeo_arc_edge, "joy", true);
 
-	NG_CMC_PROT(config, "cmc50", 0);
-	NG_PCM2_PROT(config, "pcm2", 0);
-	NG_PVC_PROT(config, "pvc", 0);
+	NG_CMC_PROT(config, m_cmc_prot, 0);
+	NG_PCM2_PROT(config, m_pcm2_prot, 0);
+	NG_PVC_PROT(config, m_pvc_prot, 0);
 }
 
 
@@ -492,7 +492,6 @@ void neopcb_state::install_banked_bios()
 	m_maincpu->space(AS_PROGRAM).install_read_bank(0xc00000, 0xc1ffff, 0x0e0000, m_bios_bank);
 	m_bios_bank->configure_entries(0, 2, memregion("mainbios")->base(), 0x20000);
 	m_bios_bank->set_entry(1);
-
 }
 
 void neopcb_state::init_ms5pcb()
@@ -500,7 +499,7 @@ void neopcb_state::init_ms5pcb()
 	install_common();
 	install_banked_bios();
 
-	m_sprgen->m_fixed_layer_bank_type = 2;
+	m_sprgen->set_fixed_layer_bank_type(neosprite_base_device::FIX_BANKTYPE_KOF2000);
 
 	m_pvc_prot->mslug5_decrypt_68k(cpuregion, cpuregion_size);
 	m_pcm2_prot->swap(ym_region, ym_region_size, 2);
@@ -519,7 +518,7 @@ void neopcb_state::init_svcpcb()
 	install_common();
 	install_banked_bios();
 
-	m_sprgen->m_fixed_layer_bank_type = 2;
+	m_sprgen->set_fixed_layer_bank_type(neosprite_base_device::FIX_BANKTYPE_KOF2000);
 
 	m_pvc_prot->svc_px_decrypt(cpuregion, cpuregion_size);
 	m_pcm2_prot->swap(ym_region, ym_region_size, 3);
@@ -537,7 +536,7 @@ void neopcb_state::init_kf2k3pcb()
 {
 	install_common();
 
-	m_sprgen->m_fixed_layer_bank_type = 2;
+	m_sprgen->set_fixed_layer_bank_type(neosprite_base_device::FIX_BANKTYPE_KOF2000);
 
 	m_pvc_prot->kf2k3pcb_decrypt_68k(cpuregion, cpuregion_size);
 	m_pcm2_prot->swap(ym_region, ym_region_size, 5);
@@ -562,6 +561,6 @@ void neopcb_state::init_kf2k3pcb()
 
 
 GAME( 2003, ms5pcb,     0,        neopcb,   dualbios, neopcb_state, init_ms5pcb,   ROT0, "SNK Playmore", "Metal Slug 5 (JAMMA PCB)", MACHINE_SUPPORTS_SAVE )
-GAME( 2003, svcpcb,     0,        neopcb,   dualbios, neopcb_state, init_svcpcb,   ROT0, "Playmore / Capcom", "SNK vs. Capcom - SVC Chaos (JAMMA PCB, set 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 2003, svcpcba,    svcpcb,   neopcb,   dualbios, neopcb_state, init_svcpcb,   ROT0, "Playmore / Capcom", "SNK vs. Capcom - SVC Chaos (JAMMA PCB, set 2)", MACHINE_SUPPORTS_SAVE ) /* Encrypted Code */
+GAME( 2003, svcpcb,     0,        neopcb,   dualbios, neopcb_state, init_svcpcb,   ROT0, "Playmore / Capcom", "SNK vs. Capcom - SVC Chaos (JAMMA PCB, NEO-MVH MVO PCB)", MACHINE_SUPPORTS_SAVE )
+GAME( 2003, svcpcba,    svcpcb,   neopcb,   dualbios, neopcb_state, init_svcpcb,   ROT0, "Playmore / Capcom", "SNK vs. Capcom - SVC Chaos (JAMMA PCB, NEO-MVH MVOB PCB)", MACHINE_SUPPORTS_SAVE ) /* Encrypted Code */
 GAME( 2003, kf2k3pcb,   0,        neopcb,   neogeo,   neopcb_state, init_kf2k3pcb, ROT0, "SNK Playmore", "The King of Fighters 2003 (Japan, JAMMA PCB)", MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
- neogeo/midas.cpp:
  - Split hammer to derivated class
  - Reduce runtime tag lookups
  - Fix namings
- neogeo/neogeo_spr.cpp:
  - Fix typename consistency
  - Use enum for fix layer bankswitch type
  - Make some variables constant
  - Reduce preprocessor macros
  - Move various functions and variables into protected: section
  - Fix filename comment
  - Fix naming
- neogeo/neogeo.cpp:
  - Suppress side effects for debugger reads
  - Reduce literal tag usages
  - Make some variables constant
- neogeo/neogeocd.cpp:
  - Fix code style consistency, Use lowercase hexadecimal digits and variable names
  - Move various variables and functions into private: section
  - Reduce preprocessor macros
  - Suppress side effects for debugger reads
  - Make some variables constant
  - Fix save states
- neogeo/neopcb.cpp:
  - Reduce literal tag usage
  - Fix metadata related to hardware configuration