### PR TITLE
Fix dark color of CD-i DYUV format

### DIFF
--- a/src/mame/philips/mcd212.cpp
+++ b/src/mame/philips/mcd212.cpp
@@ -1434,9 +1434,9 @@ void mcd212_device::device_start()
 		m_delta_uv_lut[d] = s_dyuv_deltas[d >> 4];
 	}
 
-	for (uint16_t w = 0; w < 3 * 0xff; w++)
+	for (uint16_t w = 0; w < 0x300; w++)
 	{
-		const uint8_t limit = (w < 0xff + 16) ?  0 : w <= 16 + 2 * 0xff ? w - 0x10f : 0xff;
+		const uint8_t limit = (w < 0x110) ?  0 : w > 0x1e0 ? 0xff : (uint8_t)((w-0x110)*1.16438f); // Renormalize to the range 16-235
 		m_dyuv_limit_r_lut[w] = limit << 16;
 		m_dyuv_limit_g_lut[w] = limit << 8;
 		m_dyuv_limit_b_lut[w] = limit;

--- a/src/mame/philips/mcd212.cpp
+++ b/src/mame/philips/mcd212.cpp
@@ -722,9 +722,9 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 						const uint8_t u0 = (u + u1) >> 1;
 						const uint8_t v0 = (v + v1) >> 1;
 
-						uint32_t *limit_r = m_dyuv_limit_r_lut + y0 + 0xff;
-						uint32_t *limit_g = m_dyuv_limit_g_lut + y0 + 0xff;
-						uint32_t *limit_b = m_dyuv_limit_b_lut + y0 + 0xff;
+						uint32_t *limit_r = m_dyuv_limit_r_lut + y0 + 0x100;
+						uint32_t *limit_g = m_dyuv_limit_g_lut + y0 + 0x100;
+						uint32_t *limit_b = m_dyuv_limit_b_lut + y0 + 0x100;
 
 						uint32_t entry = limit_r[m_dyuv_v_to_r[v0]] | limit_g[m_dyuv_u_to_g[u0] + m_dyuv_v_to_g[v0]] | limit_b[m_dyuv_u_to_b[u0]];
 						pixels[x] = entry;
@@ -744,9 +744,9 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 							x++;
 						}
 
-						limit_r = m_dyuv_limit_r_lut + y1 + 0xff;
-						limit_g = m_dyuv_limit_g_lut + y1 + 0xff;
-						limit_b = m_dyuv_limit_b_lut + y1 + 0xff;
+						limit_r = m_dyuv_limit_r_lut + y1 + 0x100;
+						limit_g = m_dyuv_limit_g_lut + y1 + 0x100;
+						limit_b = m_dyuv_limit_b_lut + y1 + 0x100;
 
 						entry = limit_r[m_dyuv_v_to_r[v1]] | limit_g[m_dyuv_u_to_g[u1] + m_dyuv_v_to_g[v1]] | limit_b[m_dyuv_u_to_b[u1]];
 						pixels[x] = entry;

--- a/src/mame/philips/mcd212.h
+++ b/src/mame/philips/mcd212.h
@@ -202,9 +202,9 @@ protected:
 	uint8_t m_weight_factor[2][768]{};
 
 	// DYUV color limit arrays.
-	uint32_t m_dyuv_limit_r_lut[3 * 0xff];
-	uint32_t m_dyuv_limit_g_lut[3 * 0xff];
-	uint32_t m_dyuv_limit_b_lut[3 * 0xff];
+	uint32_t m_dyuv_limit_r_lut[0x300];
+	uint32_t m_dyuv_limit_g_lut[0x300];
+	uint32_t m_dyuv_limit_b_lut[0x300];
 
 	// DYUV delta-Y decoding array
 	uint8_t m_delta_y_lut[0x100];


### PR DESCRIPTION
Full color images were 16% too dark. See page V-20 of the Green Book. The original had the scale from [16..255]. This corrects the scale to [16..235].

Use of 0x100 instead of 0xff makes the arithmetic easier to read. This simultaneously fixes an off by one error on the low end.