### PR TITLE
Remove redundant children device reset for most drivers

### DIFF
--- a/src/mame/act/victor9k.cpp
+++ b/src/mame/act/victor9k.cpp
@@ -149,7 +149,6 @@ private:
 	required_shared_ptr<uint8_t> m_video_ram;
 
 	virtual void machine_start() override ATTR_COLD;
-	virtual void machine_reset() override ATTR_COLD;
 
 	void via1_pa_w(uint8_t data);
 	void write_nfrd(int state);
@@ -683,17 +682,6 @@ void victor9k_state::machine_start()
 	}
 }
 
-void victor9k_state::machine_reset()
-{
-	m_maincpu->reset();
-	m_upd7201->reset();
-	m_ssda->reset();
-	m_via1->reset();
-	m_via2->reset();
-	m_via3->reset();
-	m_crtc->reset();
-	m_fdc->reset();
-}
 
 
 

--- a/src/mame/atari/mediagx.cpp
+++ b/src/mame/atari/mediagx.cpp
@@ -861,7 +861,6 @@ void mediagx_state::machine_reset()
 {
 	uint8_t *rom = memregion("bios")->base();
 	memcpy(m_bios_ram, rom, 0x40000);
-	m_maincpu->reset();
 
 	timer_device *sound_timer = subdevice<timer_device>("sound_timer");
 	sound_timer->adjust(attotime::from_msec(10));

--- a/src/mame/ausnz/applix.cpp
+++ b/src/mame/ausnz/applix.cpp
@@ -708,7 +708,6 @@ void applix_state::machine_reset()
 	membank("bank1")->set_entry(0);
 	m_p3 = 0xff;
 	m_last_write_addr = 0;
-	m_maincpu->reset();
 }
 
 void applix_state::floppy_formats(format_registration &fr)

--- a/src/mame/ausnz/eti660.cpp
+++ b/src/mame/ausnz/eti660.cpp
@@ -301,7 +301,6 @@ void eti660_state::pia_pa_w(u8 data)
 void eti660_state::machine_reset()
 {
 	m_resetcnt = 0;
-	m_maincpu->reset();  // needed
 }
 
 void eti660_state::machine_start()

--- a/src/mame/ausnz/excali64.cpp
+++ b/src/mame/ausnz/excali64.cpp
@@ -433,8 +433,6 @@ void excali64_state::machine_reset()
 	m_bankw[1]->set_entry(2); // write to videoram
 	m_bankw[2]->set_entry(2); // write to videoram hires pointers
 	m_bankw[3]->set_entry(0); // write to RAM
-
-	m_maincpu->reset();
 }
 
 void excali64_state::machine_start()

--- a/src/mame/barcrest/mpu3.cpp
+++ b/src/mame/barcrest/mpu3.cpp
@@ -314,8 +314,6 @@ void mpu3_state::update_triacs()
 /* called if board is reset */
 void mpu3_state::machine_reset()
 {
-	m_vfd->reset();
-
 	m_lamp_strobe   = 0;
 	m_led_strobe    = 0;
 

--- a/src/mame/barcrest/mpu4vid.cpp
+++ b/src/mame/barcrest/mpu4vid.cpp
@@ -1891,8 +1891,6 @@ void mpu4vid_state::machine_start()
 
 void mpu4vid_state::machine_reset()
 {
-	m_vfd->reset(); //for debug ports only
-
 	m_lamp_strobe    = 0;
 	m_lamp_strobe2   = 0;
 	m_led_strobe     = 0;

--- a/src/mame/bfm/bfm_sc1.cpp
+++ b/src/mame/bfm/bfm_sc1.cpp
@@ -653,8 +653,6 @@ void bfm_sc1_state::machine_reset()
 	m_mux2_datahi         = 0;
 	m_mux2_input        = 0;
 
-	m_vfd0->reset();
-
 	m_acia_status   = 0x02; // MC6850 transmit buffer empty !!!
 	m_locked          = 0x07; // hardware is locked
 

--- a/src/mame/bfm/bfm_sc2.cpp
+++ b/src/mame/bfm/bfm_sc2.cpp
@@ -490,9 +490,6 @@ void bfm_sc2_state::on_scorpion2_reset()
 
 	e2ram_reset();
 
-	if (m_ym2413)
-		m_ym2413->reset();
-
 	// make sure no inputs are overidden ////////////////////////////////////
 	memset(m_input_override, 0, sizeof(m_input_override));
 
@@ -1458,10 +1455,7 @@ int bfm_sc2_state::read_e2ram()
 void bfm_sc2_vid_state::machine_reset()
 {
 	// reset the board //////////////////////////////////////////////////////
-
 	on_scorpion2_reset();
-	m_vfd0->reset();
-	m_vfd1->reset();
 }
 
 
@@ -2822,8 +2816,6 @@ void bfm_sc2_state::bfmdm01_busy(int state)
 void bfm_sc2_awp_state::machine_reset()
 {
 	on_scorpion2_reset();
-	m_vfd0->reset();
-	m_vfd1->reset();
 }
 
 

--- a/src/mame/bfm/bfmsys85.cpp
+++ b/src/mame/bfm/bfmsys85.cpp
@@ -180,8 +180,6 @@ void bfmsys85_state::machine_reset()
 	m_mux_input_strobe  = 0;
 	m_mux_input         = 0;
 
-	m_vfd->reset(); // reset display1
-
 	m_locked          = 0x00; // hardware is open
 }
 

--- a/src/mame/brother/lw350.cpp
+++ b/src/mame/brother/lw350.cpp
@@ -417,7 +417,6 @@ void lw350_state::machine_start()
 void lw350_state::machine_reset()
 {
 	io_90 = 0x00;
-	fdc->reset();
 	fdc_drq = 0;
 }
 

--- a/src/mame/camputers/camplynx.cpp
+++ b/src/mame/camputers/camplynx.cpp
@@ -745,7 +745,6 @@ void camplynx_state::machine_reset()
 		port82_w( 0 );
 	else
 		port7f_w( 0 );
-	m_maincpu->reset();
 }
 
 MC6845_UPDATE_ROW( camplynx_state::lynx48k_update_row )

--- a/src/mame/cave/cv1k.cpp
+++ b/src/mame/cave/cv1k.cpp
@@ -460,7 +460,6 @@ void cv1k_state::machine_reset()
 {
 	m_blitter->set_rambase(reinterpret_cast<uint16_t *>(m_ram.target()));
 	m_blitter->install_handlers( 0x18000000, 0x18000057 );
-	m_blitter->reset();
 }
 
 void cv1k_state::cv1k(machine_config &config)

--- a/src/mame/commodore/plus4.cpp
+++ b/src/mame/commodore/plus4.cpp
@@ -812,17 +812,6 @@ void plus4_state::machine_start()
 
 void plus4_state::machine_reset()
 {
-	m_maincpu->reset();
-
-	m_iec->reset();
-
-	if (m_acia)
-	{
-		m_acia->reset();
-	}
-
-	m_exp->reset();
-
 	if (m_user)
 	{
 		m_user->write_3(0);

--- a/src/mame/enterprise/ep64.cpp
+++ b/src/mame/enterprise/ep64.cpp
@@ -557,9 +557,6 @@ void ep64_state::machine_start()
 
 void ep64_state::machine_reset()
 {
-	m_dave->reset();
-	m_nick->reset();
-
 	wr0_w(0);
 	subdevice<output_latch_device>("cent_data_out")->write(0);
 	wr2_w(0);

--- a/src/mame/grundy/newbrain.cpp
+++ b/src/mame/grundy/newbrain.cpp
@@ -767,9 +767,6 @@ void newbrain_state::machine_start()
 
 void newbrain_state::machine_reset()
 {
-	m_maincpu->reset();
-	m_cop->reset();
-
 	m_maincpu->set_input_line(INPUT_LINE_HALT, ASSERT_LINE);
 	m_cop->set_input_line(INPUT_LINE_HALT, ASSERT_LINE);
 

--- a/src/mame/hitachi/bmjr.cpp
+++ b/src/mame/hitachi/bmjr.cpp
@@ -460,7 +460,6 @@ void bmjr_state::machine_reset()
 	m_basic_view.select(0);
 	m_printer_view.select(0);
 	m_monitor_view.select(0);
-	m_maincpu->reset();
 }
 
 void bmjr_state::bmjr(machine_config &config)

--- a/src/mame/hp/hp49gp.cpp
+++ b/src/mame/hp/hp49gp.cpp
@@ -47,8 +47,6 @@ private:
 	required_device<s3c2410_device> m_s3c2410;
 	required_shared_ptr<uint32_t> m_steppingstone;
 	lcd_spi_t m_lcd_spi;
-	virtual void machine_start() override ATTR_COLD;
-	virtual void machine_reset() override ATTR_COLD;
 	uint32_t s3c2410_gpio_port_r(offs_t offset);
 	void s3c2410_gpio_port_w(offs_t offset, uint32_t data);
 	inline void verboselog(int n_level, const char *s_fmt, ...) ATTR_PRINTF(3,4);
@@ -251,17 +249,6 @@ void hp49gp_state::s3c2410_gpio_port_w(offs_t offset, uint32_t data)
 INPUT_CHANGED_MEMBER(hp49gp_state::port_changed)
 {
 	m_s3c2410->s3c2410_request_eint(param + 8);
-}
-
-// ...
-
-void hp49gp_state::machine_start()
-{
-}
-
-void hp49gp_state::machine_reset()
-{
-	m_maincpu->reset();
 }
 
 /***************************************************************************

--- a/src/mame/itech/itech8.cpp
+++ b/src/mame/itech/itech8.cpp
@@ -675,7 +675,6 @@ void itech8_state::machine_reset()
 	if (m_mainbank)
 	{
 		m_mainbank->set_entry(0 ^ m_bankxor);
-		m_maincpu->reset();
 	}
 
 	// set the visible area

--- a/src/mame/jpm/jpmimpct.cpp
+++ b/src/mame/jpm/jpmimpct.cpp
@@ -265,9 +265,6 @@ void jpmimpct_state::machine_start()
 void jpmimpct_state::machine_reset()
 {
 	/* Reset states */
-	if (m_vfd)
-		m_vfd->reset();
-
 	m_coinstate = 0xffff;
 }
 

--- a/src/mame/jpm/jpmsys5.cpp
+++ b/src/mame/jpm/jpmsys5.cpp
@@ -1105,7 +1105,6 @@ void jpmsys5_state::machine_reset()
 {
 	m_acia6850[2]->write_rxd(1);
 	m_acia6850[2]->write_dcd(0);
-	m_vfd->reset();
 }
 
 

--- a/src/mame/kaypro/kaypro_m.cpp
+++ b/src/mame/kaypro/kaypro_m.cpp
@@ -276,7 +276,6 @@ void kaypro_state::machine_reset()
 	m_bank3->set_entry(1); // point at video ram
 	m_system_port = 0x80;
 	m_fdc_rq = 0;
-	m_maincpu->reset();
 	m_floppy_timer->adjust(attotime::from_hz(1));   /* kick-start the nmi timer */
 }
 

--- a/src/mame/luxor/ds90.cpp
+++ b/src/mame/luxor/ds90.cpp
@@ -69,8 +69,6 @@ private:
 	required_device_array<floppy_connector, 3> m_floppy;
 	required_device<nscsi_callback_device> m_sasi;
 
-	virtual void machine_reset() override ATTR_COLD;
-
 	static void floppy_formats(format_registration &fr);
 
 	void program_map(address_map &map) ATTR_COLD;
@@ -89,11 +87,6 @@ void x37_state::cpu_space_map(address_map &map)
 
 static INPUT_PORTS_START( x37 )
 INPUT_PORTS_END
-
-void x37_state::machine_reset()
-{
-	m_fpu->reset();
-}
 
 static void x37_floppies(device_slot_interface &device)
 {

--- a/src/mame/mattel/juicebox.cpp
+++ b/src/mame/mattel/juicebox.cpp
@@ -294,7 +294,6 @@ void juicebox_state::machine_start()
 
 void juicebox_state::machine_reset()
 {
-	m_maincpu->reset();
 	smc_reset();
 }
 

--- a/src/mame/maygay/maygay1b.cpp
+++ b/src/mame/maygay/maygay1b.cpp
@@ -101,8 +101,7 @@
 
 void maygay1b_state::machine_reset()
 {
-	m_vfd->reset(); // reset display1
-	m_Vmm=false;
+	m_Vmm = false;
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/mame/midway/balsente_m.cpp
+++ b/src/mame/midway/balsente_m.cpp
@@ -99,7 +99,6 @@ void balsente_state::machine_reset()
 	m_bankab->set_entry(0);
 	m_bankcd->set_entry(0);
 	m_bankef->set_entry(0);
-	m_maincpu->reset();
 
 	/* start a timer to generate interrupts */
 	m_scanline_timer->adjust(m_screen->time_until_pos(0));

--- a/src/mame/midway/midvunit.cpp
+++ b/src/mame/midway/midvunit.cpp
@@ -110,15 +110,6 @@ void midvunit_base_state::machine_reset()
 	m_dcs->reset_w(1);
 
 	memcpy(m_ram_base, memregion("maindata")->base(), 0x20000*4);
-	m_maincpu->reset();
-}
-
-
-void midvplus_state::machine_reset()
-{
-	midvunit_base_state::machine_reset();
-
-	m_ata->reset();
 }
 
 

--- a/src/mame/midway/midvunit.h
+++ b/src/mame/midway/midvunit.h
@@ -261,7 +261,6 @@ public:
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
-	virtual void machine_reset() override ATTR_COLD;
 
 private:
 	uint32_t midvplus_misc_r(offs_t offset);

--- a/src/mame/midway/midzeus.cpp
+++ b/src/mame/midway/midzeus.cpp
@@ -238,7 +238,6 @@ void midzeus_state::machine_reset()
 {
 	memcpy(m_ram_base, memregion("maindata")->base(), 0x40000*4);
 	*m_ram_base <<= 1;
-	m_maincpu->reset();
 
 	m_cmos_protected = true;
 	memset(m_disk_asic_jr, 0x0, 0x10 * 4);

--- a/src/mame/midway/pinball2k.cpp
+++ b/src/mame/midway/pinball2k.cpp
@@ -606,9 +606,7 @@ void pinball2k_state::machine_start()
 void pinball2k_state::machine_reset()
 {
 	uint8_t *rom = memregion("bios")->base();
-
 	memcpy(m_bios_ram, rom, 0x40000);
-	m_maincpu->reset();
 }
 
 void pinball2k_state::ramdac_map(address_map &map)

--- a/src/mame/midway/wmg.cpp
+++ b/src/mame/midway/wmg.cpp
@@ -427,7 +427,6 @@ void wmg_state::machine_reset()
 	m_wmg_d000 = 0xff;
 	m_port_select = 0;
 	wmg_c400_w(0);
-	m_maincpu->reset();
 }
 
 /*************************************

--- a/src/mame/misc/hapyfish.cpp
+++ b/src/mame/misc/hapyfish.cpp
@@ -476,7 +476,6 @@ void hapyfish_state::machine_start()
 
 void hapyfish_state::machine_reset()
 {
-	m_maincpu->reset();
 	std::fill(std::begin(m_port), std::end(m_port), 0);
 	m_nand_select = true; // select NAND #1
 	m_i2c_sda_in = 1;

--- a/src/mame/misc/proconn.cpp
+++ b/src/mame/misc/proconn.cpp
@@ -61,8 +61,6 @@ public:
 
 	void init_proconn();
 
-protected:
-	virtual void machine_reset() override ATTR_COLD;
 
 private:
 	template <unsigned N> void ay_w(uint8_t data) { m_ay->address_data_w(N, data); }
@@ -264,10 +262,6 @@ static const z80_daisy_config z80_daisy_chain[] =
 	{ nullptr }
 };
 
-void proconn_state::machine_reset()
-{
-	m_vfd->reset(); // reset display1
-}
 
 void proconn_state::proconn(machine_config &config)
 {

--- a/src/mame/morrow/tricep.cpp
+++ b/src/mame/morrow/tricep.cpp
@@ -88,8 +88,6 @@ void tricep_state::machine_reset()
 
 	memcpy((uint8_t*)m_ram.target(),bios,0x2000);
 
-	m_maincpu->reset();
-
 	m_mux = 0;
 }
 

--- a/src/mame/motorola/mekd1.cpp
+++ b/src/mame/motorola/mekd1.cpp
@@ -369,8 +369,6 @@ void mekd1_state::write_f13_clock(int state)
 
 void mekd1_state::machine_reset()
 {
-	m_pia0->reset();
-	m_pia1->reset();
 	m_brg->rsa_w(CLEAR_LINE);
 	m_brg->rsb_w(ASSERT_LINE);
 	m_bit_rate_timer->reset();

--- a/src/mame/motorola/uchroma68.cpp
+++ b/src/mame/motorola/uchroma68.cpp
@@ -403,8 +403,6 @@ void uchroma68_state::machine_start()
 
 void uchroma68_state::machine_reset()
 {
-	m_mc6846->reset();
-	m_pia->reset();
 	m_kbd_strobe_timer->reset();
 	m_kbd_strobe = 1;
 	m_kbd_data = 0;

--- a/src/mame/nichibutsu/galivan.cpp
+++ b/src/mame/nichibutsu/galivan.cpp
@@ -1132,8 +1132,6 @@ void youmab_state::machine_start()
 
 void galivan_state::machine_reset()
 {
-	m_maincpu->reset();
-
 	m_layers = 0;
 	m_scrollx[0] = m_scrollx[1] = 0;
 	m_scrolly[0] = m_scrolly[1] = 0;
@@ -1141,8 +1139,6 @@ void galivan_state::machine_reset()
 
 void ninjemak_state::machine_reset()
 {
-	m_maincpu->reset();
-
 	m_scrollx = 0;
 	m_scrolly = 0;
 	m_dispdisable = 0;

--- a/src/mame/nintendo/nes_m.cpp
+++ b/src/mame/nintendo/nes_m.cpp
@@ -31,8 +31,6 @@ void nes_state::machine_reset()
 	// Reset the mapper variables. Will also mark the char-gen ram as dirty
 	if (m_cartslot)
 		m_cartslot->pcb_reset();
-
-	m_maincpu->reset();
 }
 
 //-------------------------------------------------

--- a/src/mame/olivetti/m20.cpp
+++ b/src/mame/olivetti/m20.cpp
@@ -719,8 +719,6 @@ void m20_state::machine_reset()
 	if(system_bios() > 0)  // bits have different meanings?
 		m_port21 &= ~8;
 
-	m_fd1797->reset();
-
 	memcpy(RAM, ROM, 8);  // we need only the reset vector
 	m_kbdi8251->write_cts(0);
 	if (m_apb)

--- a/src/mame/osborne/vixen.cpp
+++ b/src/mame/osborne/vixen.cpp
@@ -799,9 +799,6 @@ void vixen_state::machine_reset()
 	m_cmd_d1 = 0;
 	update_interrupt();
 
-	m_fdc->reset();
-	m_io_i8155->reset();
-	m_usart->reset();
 	m_maincpu->set_state_int(Z80_PC, 0xf000);
 }
 

--- a/src/mame/palm/palmz22.cpp
+++ b/src/mame/palm/palmz22.cpp
@@ -270,7 +270,6 @@ void palmz22_state::machine_start()
 
 void palmz22_state::machine_reset()
 {
-	m_maincpu->reset();
 	memset( m_port, 0, sizeof( m_port));
 }
 

--- a/src/mame/rca/microkit.cpp
+++ b/src/mame/rca/microkit.cpp
@@ -136,7 +136,6 @@ void microkit_state::ram_w(offs_t offset, uint8_t data)
 void microkit_state::machine_reset()
 {
 	m_resetcnt = 0;
-	m_maincpu->reset();
 }
 
 void microkit_state::machine_start()

--- a/src/mame/rca/studio2.cpp
+++ b/src/mame/rca/studio2.cpp
@@ -265,7 +265,6 @@ protected:
 	required_device<screen_device> m_screen;
 
 	virtual void machine_start() override ATTR_COLD;
-	virtual void machine_reset() override ATTR_COLD;
 
 	uint8_t dispon_r();
 	void keylatch_w(uint8_t data);
@@ -322,7 +321,6 @@ private:
 	required_device<cdp1864_device> m_cti;
 
 	virtual void machine_start() override ATTR_COLD;
-	virtual void machine_reset() override ATTR_COLD;
 
 	void dma_w(offs_t offset, uint8_t data);
 	int rdata_r();
@@ -419,7 +417,7 @@ INPUT_CHANGED_MEMBER( studio2_state::reset_w )
 {
 	if (oldval && !newval)
 	{
-		machine_reset();
+		m_vdc->reset();
 	}
 }
 
@@ -577,16 +575,6 @@ void mpt02_state::machine_start()
 
 	// register for state saving
 	save_item(NAME(m_keylatch));
-}
-
-void studio2_state::machine_reset()
-{
-	m_vdc->reset();
-}
-
-void mpt02_state::machine_reset()
-{
-	m_cti->reset();
 }
 
 DEVICE_IMAGE_LOAD_MEMBER( studio2_state::cart_load )

--- a/src/mame/regnecentralen/rc702.cpp
+++ b/src/mame/regnecentralen/rc702.cpp
@@ -170,7 +170,6 @@ void rc702_state::machine_reset()
 	m_7474->preset_w(1);
 	m_fdc->set_ready_line_connected(1); // always ready for minifloppy; controlled by fdc for 20cm
 	m_fdc->set_unscaled_clock(4000000); // 4MHz for minifloppy; 8MHz for 20cm
-	m_maincpu->reset();
 }
 
 void rc702_state::machine_start()

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -339,7 +339,6 @@ void rm380z_state::machine_reset()
 	m_fbfe = 0x00;
 
 	config_memory_map();
-	m_fdc->reset();
 }
 
 void rm380z_state_cos34::machine_reset()

--- a/src/mame/skeleton/bitgraph.cpp
+++ b/src/mame/skeleton/bitgraph.cpp
@@ -458,7 +458,6 @@ void bitgraph_state::machine_start()
 
 void bitgraph_state::machine_reset()
 {
-	m_maincpu->reset();
 	m_misccr = 0;
 	m_pia_a = 0;
 	m_pia_b = 0;

--- a/src/mame/skeleton/didact.cpp
+++ b/src/mame/skeleton/didact.cpp
@@ -276,7 +276,6 @@ void md6802_state::machine_start()
 void md6802_state::machine_reset()
 {
 	LOG("--->%s()\n", FUNCNAME);
-	m_maincpu->reset();
 }
 
 // This address map is traced from schema
@@ -467,7 +466,6 @@ int mp68a_state::pia2_cb1_r()
 void mp68a_state::machine_reset()
 {
 	LOG("--->%s()\n", FUNCNAME);
-	m_maincpu->reset();
 }
 
 void mp68a_state::machine_start()
@@ -633,8 +631,6 @@ void modulab_state::io_w(offs_t offset, u8 data)
 void modulab_state::machine_reset()
 {
 	LOG("--->%s()\n", FUNCNAME);
-
-	m_maincpu->reset();
 }
 
 void modulab_state::machine_start()
@@ -774,7 +770,7 @@ INPUT_CHANGED_MEMBER(didact_state::trigger_reset)
 	if (newval == CLEAR_LINE)
 	{
 		LOGKBD("RESET is released, resetting the CPU\n");
-		machine_reset();
+		m_maincpu->reset();
 		m_shift = 0;
 		m_led = 0;
 	}

--- a/src/mame/skeleton/didact.cpp
+++ b/src/mame/skeleton/didact.cpp
@@ -770,7 +770,7 @@ INPUT_CHANGED_MEMBER(didact_state::trigger_reset)
 	if (newval == CLEAR_LINE)
 	{
 		LOGKBD("RESET is released, resetting the CPU\n");
-		m_maincpu->reset();
+		machine_reset();
 		m_shift = 0;
 		m_led = 0;
 	}

--- a/src/mame/skeleton/digel804.cpp
+++ b/src/mame/skeleton/digel804.cpp
@@ -94,7 +94,6 @@ public:
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
-	virtual void machine_reset() override ATTR_COLD;
 
 	void op00(uint8_t data);
 	uint8_t ip40();
@@ -209,11 +208,6 @@ void digel804_state::machine_start()
 	m_keyen_state = 1; // /KEYEN
 
 	m_rambank->set_base(m_ram->pointer());
-}
-
-void digel804_state::machine_reset()
-{
-	m_vfd->reset();
 }
 
 uint8_t digel804_state::ip40() // eprom data bus read

--- a/src/mame/skeleton/ht68k.cpp
+++ b/src/mame/skeleton/ht68k.cpp
@@ -88,7 +88,6 @@ void ht68k_state::machine_reset()
 
 	memcpy((uint8_t*)m_ram.target(),bios,0x8000);
 
-	m_fdc->reset();
 	m_fdc->set_floppy(nullptr);
 	m_fdc->dden_w(0);
 }

--- a/src/mame/skeleton/micro20.cpp
+++ b/src/mame/skeleton/micro20.cpp
@@ -52,7 +52,6 @@ private:
 	required_device<pit68230_device> m_pit;
 	required_device<msm58321_device> m_rtc;
 
-	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
 	void m68k_reset_callback(int state);
@@ -74,9 +73,6 @@ private:
 	u8 m_h4;
 };
 
-void micro20_state::machine_start()
-{
-}
 
 void micro20_state::machine_reset()
 {
@@ -85,7 +81,6 @@ void micro20_state::machine_reset()
 
 	pRAM[0] = pROM[2];
 	pRAM[1] = pROM[3];
-	m_maincpu->reset();
 
 	m_tin = 0;
 }

--- a/src/mame/skeleton/mini2440.cpp
+++ b/src/mame/skeleton/mini2440.cpp
@@ -50,7 +50,6 @@ private:
 	required_ioport m_peny;
 
 	uint32_t m_port[9] = { };
-	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 	inline void verboselog(int n_level, const char *s_fmt, ...) ATTR_PRINTF(3,4);
 	uint32_t s3c2440_gpio_port_r(offs_t offset);
@@ -198,13 +197,8 @@ INPUT_CHANGED_MEMBER(mini2440_state::mini2440_input_changed)
 
 // ...
 
-void mini2440_state::machine_start()
-{
-}
-
 void mini2440_state::machine_reset()
 {
-	m_maincpu->reset();
 	memset( m_port, 0, sizeof( m_port));
 }
 

--- a/src/mame/skeleton/pes.cpp
+++ b/src/mame/skeleton/pes.cpp
@@ -141,7 +141,6 @@ void pes_state::rx_w(int state)
 void pes_state::machine_reset()
 {
 	m_port3 = 0; // reset the openbus state of port 3
-	m_speech->reset(); // reset the 5220
 }
 
 

--- a/src/mame/skeleton/zorba.cpp
+++ b/src/mame/skeleton/zorba.cpp
@@ -414,8 +414,6 @@ void zorba_state::machine_reset()
 	m_pia0->cb1_w(m_printer_prowriter ? m_printer_select : m_printer_fault);
 
 	m_bank1->set_entry(1);
-
-	m_maincpu->reset();
 }
 
 

--- a/src/mame/taito/gladiatr.cpp
+++ b/src/mame/taito/gladiatr.cpp
@@ -207,7 +207,6 @@ void gladiatr_state::machine_reset()
 {
 	// 6809 bank memory set
 	m_adpcmbank->set_entry(0);
-	m_audiocpu->reset();
 }
 
 /* YM2203 port B handler (output) */

--- a/src/mame/taito/missb2.cpp
+++ b/src/mame/taito/missb2.cpp
@@ -462,7 +462,6 @@ void missb2_state::machine_reset()
 {
 	MACHINE_RESET_CALL_MEMBER(common);
 
-	m_oki->reset();
 	bublbobl_bankswitch_w(0x00); // force a bankswitch write of all zeroes, as /RESET clears the latch
 }
 

--- a/src/mame/telenova/compis.cpp
+++ b/src/mame/telenova/compis.cpp
@@ -122,7 +122,6 @@ public:
 	required_ioport m_s8;
 
 	virtual void machine_start() override ATTR_COLD;
-	virtual void machine_reset() override ATTR_COLD;
 
 	uint16_t pcs6_0_1_r(offs_t offset, uint16_t mem_mask = ~0);
 	void pcs6_0_1_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
@@ -714,21 +713,6 @@ void compis_state::machine_start()
 	save_item(NAME(m_centronics_busy));
 	save_item(NAME(m_centronics_select));
 	save_item(NAME(m_tmr0));
-}
-
-
-//-------------------------------------------------
-//  machine_reset
-//-------------------------------------------------
-
-void compis_state::machine_reset()
-{
-	m_uart->reset();
-	m_mpsc->reset();
-	m_ppi->reset();
-	m_graphics->reset();
-	m_isbx0->reset();
-	m_isbx1->reset();
 }
 
 

--- a/src/mame/telercas/tmc1800.cpp
+++ b/src/mame/telercas/tmc1800.cpp
@@ -697,10 +697,6 @@ void osc1000b_state::machine_start()
 	save_item(NAME(m_keylatch));
 }
 
-void osc1000b_state::machine_reset()
-{
-}
-
 // Telmac 2000
 
 void tmc2000_state::machine_start()

--- a/src/mame/telercas/tmc1800.h
+++ b/src/mame/telercas/tmc1800.h
@@ -99,7 +99,6 @@ public:
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
-	virtual void machine_reset() override ATTR_COLD;
 
 	/* keyboard state */
 	int m_keylatch = 0;

--- a/src/mame/telercas/tmc2000e.cpp
+++ b/src/mame/telercas/tmc2000e.cpp
@@ -272,12 +272,6 @@ void tmc2000e_state::machine_start()
 	save_item(NAME(m_keylatch));
 }
 
-void tmc2000e_state::machine_reset()
-{
-	m_cti->reset();
-
-	// reset program counter to 0xc000
-}
 
 /* Machine Drivers */
 

--- a/src/mame/telercas/tmc2000e.h
+++ b/src/mame/telercas/tmc2000e.h
@@ -63,7 +63,6 @@ private:
 	void tmc2000e_map(address_map &map) ATTR_COLD;
 
 	virtual void machine_start() override ATTR_COLD;
-	virtual void machine_reset() override ATTR_COLD;
 
 	required_device<cosmac_device> m_maincpu;
 	required_device<cdp1864_device> m_cti;

--- a/src/mame/televideo/ts816.cpp
+++ b/src/mame/televideo/ts816.cpp
@@ -224,7 +224,6 @@ void ts816_state::machine_reset()
 	m_term_data = 0;
 	m_status = 1;
 	set_banks();
-	m_maincpu->reset();
 }
 
 // correct order yet to be determined

--- a/src/mame/tigertel/gizmondo.cpp
+++ b/src/mame/tigertel/gizmondo.cpp
@@ -61,7 +61,6 @@ private:
 	uint32_t m_port[9];
 	required_device<s3c2440_device> m_s3c2440;
 	virtual void machine_start() override ATTR_COLD;
-	virtual void machine_reset() override ATTR_COLD;
 	required_device<cpu_device> m_maincpu;
 	required_device<gf4500_device> m_gf4500;
 	uint32_t s3c2440_gpio_port_r(offs_t offset);
@@ -147,10 +146,6 @@ void gizmondo_state::machine_start()
 	m_port[S3C2440_GPIO_PORT_D] = 0x4F60;
 }
 
-void gizmondo_state::machine_reset()
-{
-	m_maincpu->reset();
-}
 
 /*******************************************************************************
     ADDRESS MAPS

--- a/src/mame/trainer/selz80.cpp
+++ b/src/mame/trainer/selz80.cpp
@@ -210,7 +210,6 @@ void dagz80_state::machine_reset()
 	uint8_t* rom = memregion("user1")->base();
 	uint16_t size = memregion("user1")->bytes();
 	memcpy(m_p_ram, rom, size);
-	m_maincpu->reset();
 }
 
 void selz80_state::scanlines_w(uint8_t data)

--- a/src/mame/trs/dgn_beta_m.cpp
+++ b/src/mame/trs/dgn_beta_m.cpp
@@ -793,9 +793,7 @@ void dgn_beta_state::machine_reset()
 	m_DMA_NMI_LAST = 0x80;       /* start with DMA NMI inactive, as pulled up */
 //  DMA_NMI = CLEAR_LINE;       /* start with DMA NMI inactive */
 
-	m_wd2797_written=0;
-
-	m_maincpu->reset();
+	m_wd2797_written = 0;
 }
 
 void dgn_beta_state::machine_start()

--- a/src/mame/tvgames/generalplus_gpl16250.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250.cpp
@@ -164,17 +164,10 @@ void gcm394_game_state::base(machine_config &config)
 
 
 
-
-void gcm394_game_state::machine_start()
-{
-}
-
 void gcm394_game_state::machine_reset()
 {
 	cs_callback(0x00, 0x00, 0x00, 0x00, 0x00);
 	m_maincpu->set_cs_space(m_memory->get_program());
-
-	m_maincpu->reset(); // reset CPU so vector gets read etc.
 
 	//m_maincpu->set_paldisplaybank_high_hack(1);
 	m_maincpu->set_alt_tile_addressing_hack(0);

--- a/src/mame/tvgames/generalplus_gpl16250.h
+++ b/src/mame/tvgames/generalplus_gpl16250.h
@@ -47,7 +47,6 @@ public:
 	void cs_callback(uint16_t cs0, uint16_t cs1, uint16_t cs2, uint16_t cs3, uint16_t cs4);
 
 protected:
-	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
 

--- a/src/mame/tvgames/generalplus_gpl16250_romram.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_romram.cpp
@@ -314,7 +314,6 @@ void wrlshunt_game_state::machine_reset()
 {
 	cs_callback(0x00, 0x00, 0x00, 0x00, 0x00);
 	m_maincpu->set_cs_space(m_memory->get_program());
-	m_maincpu->reset(); // reset CPU so vector gets read etc.
 
 	//m_maincpu->set_paldisplaybank_high_hack(1);
 	m_maincpu->set_alt_tile_addressing_hack(1);
@@ -389,7 +388,6 @@ void jak_s500_game_state::machine_reset()
 {
 	cs_callback(0x00, 0x00, 0x00, 0x00, 0x00);
 	m_maincpu->set_cs_space(m_memory->get_program());
-	m_maincpu->reset(); // reset CPU so vector gets read etc.
 
 	//m_maincpu->set_paldisplaybank_high_hack(0);
 	m_maincpu->set_alt_tile_addressing_hack(1);

--- a/src/mame/tvgames/generalplus_gpl16250_spi.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_spi.cpp
@@ -60,8 +60,6 @@ void generalplus_gpspispi_game_state::machine_start()
 
 void generalplus_gpspispi_game_state::machine_reset()
 {
-	m_maincpu->reset(); // reset CPU so vector gets read etc.
-
 	//m_maincpu->set_paldisplaybank_high_hack(0);
 	m_maincpu->set_alt_tile_addressing_hack(1);
 }

--- a/src/mame/tvgames/generalplus_gpl16250_spi_direct.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_spi_direct.cpp
@@ -30,7 +30,6 @@ public:
 	void generalplus_gpspi_direct(machine_config &config);
 
 protected:
-	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
 	virtual uint16_t cs0_r(offs_t offset) override;
@@ -38,17 +37,10 @@ protected:
 private:
 };
 
-void generalplus_gpspi_direct_game_state::machine_start()
-{
-}
-
 void generalplus_gpspi_direct_game_state::machine_reset()
 {
 	cs_callback(0x00, 0x00, 0x00, 0x00, 0x00);
 	m_maincpu->set_cs_space(m_memory->get_program());
-
-	m_maincpu->reset(); // reset CPU so vector gets read etc.
-
 	m_maincpu->set_alt_tile_addressing_hack(1);
 }
 

--- a/src/mame/tvgames/spg2xx.cpp
+++ b/src/mame/tvgames/spg2xx.cpp
@@ -1394,7 +1394,6 @@ void spg2xx_game_state::machine_reset()
 {
 	m_current_bank = -1;
 	switch_bank(0);
-	m_maincpu->reset();
 }
 
 void spg2xx_game_state::spg2xx_base(machine_config &config)

--- a/src/mame/tvgames/spg2xx_mysprtch.cpp
+++ b/src/mame/tvgames/spg2xx_mysprtch.cpp
@@ -94,7 +94,6 @@ void spg2xx_game_mysprt_plus_state::machine_reset()
 	m_bank_enabled = 0;
 
 	m_maincpu->invalidate_cache();
-	m_maincpu->reset();
 }
 
 void spg2xx_game_mysprt_orig_state::machine_reset()
@@ -106,7 +105,6 @@ void spg2xx_game_mysprt_orig_state::machine_reset()
 	m_bank_enabled = 0;
 
 	m_maincpu->invalidate_cache();
-	m_maincpu->reset();
 }
 
 static INPUT_PORTS_START( mysprtch ) // Down + Button 1 and Button 2 for service mode

--- a/src/mame/tvgames/spg2xx_pdc.cpp
+++ b/src/mame/tvgames/spg2xx_pdc.cpp
@@ -157,7 +157,6 @@ void spg2xx_pdc_game_state::machine_reset()
 {
 	m_current_bank = -1;
 	switch_bank(m_numbanks - 1); // pdc100 must boot from upper bank
-	m_maincpu->reset();
 }
 
 // pdc100 simply writes 0000 at times during bootup while initializing stuff, which causes an invalid bankswitch mid-code execution

--- a/src/mame/tvgames/spg2xx_wiwi.cpp
+++ b/src/mame/tvgames/spg2xx_wiwi.cpp
@@ -164,7 +164,6 @@ void spg2xx_game_marc250_state::machine_reset()
 {
 	spg2xx_game_marc101_state::machine_reset();
 	switch_bank(31);
-	m_maincpu->reset();
 
 	m_pulse_timer2->adjust(attotime::never);
 	m_toggle2 = false;

--- a/src/mame/tvgames/spg2xx_zone.cpp
+++ b/src/mame/tvgames/spg2xx_zone.cpp
@@ -183,7 +183,6 @@ void zone40_state::machine_reset()
 	wireless60_state::machine_reset();
 	m_z40_rombase = 0x1e0;
 	m_maincpu->invalidate_cache();
-	m_maincpu->reset();
 }
 
 static INPUT_PORTS_START( wirels60 )

--- a/src/mame/ussr/pyl601.cpp
+++ b/src/mame/ussr/pyl601.cpp
@@ -400,8 +400,6 @@ void pyl601_state::machine_reset()
 	membank("bank3")->set_base(ram + 0xe000);
 	membank("bank4")->set_base(ram + 0xe700);
 	membank("bank6")->set_base(ram + 0xf000);
-
-	m_maincpu->reset();
 }
 
 void pyl601_state::machine_start()

--- a/src/mame/visual/v1050.cpp
+++ b/src/mame/visual/v1050.cpp
@@ -1019,8 +1019,6 @@ void v1050_state::machine_reset()
 	bankswitch();
 
 	set_baud_sel(0);
-
-	m_fdc->reset();
 }
 
 // Machine Driver


### PR DESCRIPTION
This removes the manual children device reset that was happening under ``machine_reset()`` for most drivers, it's redundant since all the children devices are automatically resetted when the user invokes the reset command before the call to``machine_reset()``

There were some drivers I didn't debilatery touch such as the commodore machines because they reuse the machine_reset function to manually reset [selected] children devices when the RESET input port is changed and I didn't want to break functionality.