### PR TITLE
CD-i: Fix DYUV Format

### DIFF
--- a/src/mame/philips/mcd212.cpp
+++ b/src/mame/philips/mcd212.cpp
@@ -724,7 +724,7 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 
 						uint32_t entry = (limit_rgb[m_dyuv_v_to_r[v0]] << 16) | (limit_rgb[m_dyuv_u_to_g[u0] + m_dyuv_v_to_g[v0]] << 8) | limit_rgb[m_dyuv_u_to_b[u0]];
 						pixels[x] = entry;
-						transparent[x] = (transp_always || (use_region_flag && region_flags[x])) != invert_transp_condition;
+						transparent[x] = (transp_always || (use_region_flag && region_flags[x<<1])) != invert_transp_condition;
 
 						x++;
 
@@ -732,7 +732,7 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 
 						entry = (limit_rgb[m_dyuv_v_to_r[v1]] << 16) | (limit_rgb[m_dyuv_u_to_g[u1] + m_dyuv_v_to_g[v1]] << 8) | limit_rgb[m_dyuv_u_to_b[u1]];
 						pixels[x] = entry;
-						transparent[x] = (transp_always || (use_region_flag && region_flags[x])) != invert_transp_condition;
+						transparent[x] = (transp_always || (use_region_flag && region_flags[x<<1])) != invert_transp_condition;
 
 						byte = data[(vsr++ & 0x0007ffff) ^ 1];
 

--- a/src/mame/philips/mcd212.cpp
+++ b/src/mame/philips/mcd212.cpp
@@ -724,7 +724,7 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 
 						uint32_t entry = (limit_rgb[m_dyuv_v_to_r[v0]] << 16) | (limit_rgb[m_dyuv_u_to_g[u0] + m_dyuv_v_to_g[v0]] << 8) | limit_rgb[m_dyuv_u_to_b[u0]];
 						pixels[x] = entry;
-						transparent[x] = (transp_always || (use_region_flag && region_flags[x<<1])) != invert_transp_condition;
+						transparent[x] = (transp_always || (use_region_flag && region_flags[x << 1])) != invert_transp_condition;
 
 						x++;
 
@@ -732,7 +732,7 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 
 						entry = (limit_rgb[m_dyuv_v_to_r[v1]] << 16) | (limit_rgb[m_dyuv_u_to_g[u1] + m_dyuv_v_to_g[v1]] << 8) | limit_rgb[m_dyuv_u_to_b[u1]];
 						pixels[x] = entry;
-						transparent[x] = (transp_always || (use_region_flag && region_flags[x<<1])) != invert_transp_condition;
+						transparent[x] = (transp_always || (use_region_flag && region_flags[x << 1])) != invert_transp_condition;
 
 						byte = data[(vsr++ & 0x0007ffff) ^ 1];
 
@@ -1408,7 +1408,7 @@ void mcd212_device::device_start()
 
 	for (uint16_t w = 0; w < 0x300; w++)
 	{
-		const uint8_t limit = (w < 0x100) ? 0 : w < 0x200 ? w - 0x100 : 0xff;
+		const uint8_t limit = (w < 0x100) ? 0 : (w < 0x200) ? (w - 0x100) : 0xff;
 		m_dyuv_limit_rgb_lut[w] = limit;
 	}
 

--- a/src/mame/philips/mcd212.cpp
+++ b/src/mame/philips/mcd212.cpp
@@ -661,9 +661,9 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 	const uint8_t mosaic_factor = get_mosaic_factor<Channel>();
 
 	const uint32_t dyuv_abs_start = m_dyuv_abs_start[Channel];
-	const uint8_t start_y = (dyuv_abs_start >> 16) & 0x000000ff;
-	const uint8_t start_u = (dyuv_abs_start >>  8) & 0x000000ff;
-	const uint8_t start_v = (dyuv_abs_start >>  0) & 0x000000ff;
+	uint8_t y = (dyuv_abs_start >> 16) & 0x000000ff;
+	uint8_t u = (dyuv_abs_start >>  8) & 0x000000ff;
+	uint8_t v = (dyuv_abs_start >>  0) & 0x000000ff;
 
 	const uint32_t transparent_color = m_transparent_color[Channel];
 	const uint8_t transp_ctrl_masked = transp_ctrl & 0x07;
@@ -707,9 +707,6 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 					use_color_key = false;
 
 					LOGMASKED(LOG_VSR, "Scanline %d: Chan %d: DYUV\n", screen().vpos(), Channel);
-					uint8_t y = start_y;
-					uint8_t u = start_u;
-					uint8_t v = start_v;
 					for (; x < width; x++)
 					{
 						const uint8_t byte1 = data[(vsr++ & 0x0007ffff) ^ 1];
@@ -719,48 +716,23 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 						const uint8_t v1 = v + m_delta_uv_lut[byte1];
 						const uint8_t y1 = y0 + m_delta_y_lut[byte1];
 
-						const uint8_t u0 = (u + u1) >> 1;
-						const uint8_t v0 = (v + v1) >> 1;
+						// Midpoint Interpolation prevents rollover, against spec.
+						const uint8_t u0 = (u >> 1) + (u1 >> 1) + (u & u1 & 1); 
+						const uint8_t v0 = (v >> 1) + (v1 >> 1) + (v & v1 & 1);
 
-						uint32_t *limit_r = m_dyuv_limit_r_lut + y0 + 0xff;
-						uint32_t *limit_g = m_dyuv_limit_g_lut + y0 + 0xff;
-						uint32_t *limit_b = m_dyuv_limit_b_lut + y0 + 0xff;
+						uint32_t* limit_rgb = m_dyuv_limit_rgb_lut + y0 + 0x100;
 
-						uint32_t entry = limit_r[m_dyuv_v_to_r[v0]] | limit_g[m_dyuv_u_to_g[u0] + m_dyuv_v_to_g[v0]] | limit_b[m_dyuv_u_to_b[u0]];
+						uint32_t entry = (limit_rgb[m_dyuv_v_to_r[v0]] << 16) | (limit_rgb[m_dyuv_u_to_g[u0] + m_dyuv_v_to_g[v0]] << 8) | limit_rgb[m_dyuv_u_to_b[u0]];
 						pixels[x] = entry;
-						transparent[x] = (transp_always || (use_region_flag && region_flags[x << 1])) != invert_transp_condition;
+						transparent[x] = (transp_always || (use_region_flag && region_flags[x])) != invert_transp_condition;
 
-						if (mosaic_enable)
-						{
-							for (int mosaic_index = 1; mosaic_index < mosaic_factor && (x + mosaic_index) < width; mosaic_index++)
-							{
-								pixels[x + mosaic_index] = pixels[x];
-								transparent[x + mosaic_index] = transparent[x << 1];
-							}
-							x += mosaic_factor;
-						}
-						else
-						{
-							x++;
-						}
+						x++;
 
-						limit_r = m_dyuv_limit_r_lut + y1 + 0xff;
-						limit_g = m_dyuv_limit_g_lut + y1 + 0xff;
-						limit_b = m_dyuv_limit_b_lut + y1 + 0xff;
+						limit_rgb = m_dyuv_limit_rgb_lut + y1 + 0x100;
 
-						entry = limit_r[m_dyuv_v_to_r[v1]] | limit_g[m_dyuv_u_to_g[u1] + m_dyuv_v_to_g[v1]] | limit_b[m_dyuv_u_to_b[u1]];
+						entry = (limit_rgb[m_dyuv_v_to_r[v1]] << 16) | (limit_rgb[m_dyuv_u_to_g[u1] + m_dyuv_v_to_g[v1]] << 8) | limit_rgb[m_dyuv_u_to_b[u1]];
 						pixels[x] = entry;
-						transparent[x] = (transp_always || (use_region_flag && region_flags[x << 1])) != invert_transp_condition;
-
-						if (mosaic_enable)
-						{
-							for (int mosaic_index = 1; mosaic_index < mosaic_factor && (x + mosaic_index) < width; mosaic_index++)
-							{
-								pixels[x + mosaic_index] = pixels[x];
-								transparent[x + mosaic_index] = transparent[x];
-							}
-							x += mosaic_factor - 1;
-						}
+						transparent[x] = (transp_always || (use_region_flag && region_flags[x])) != invert_transp_condition;
 
 						byte = data[(vsr++ & 0x0007ffff) ^ 1];
 
@@ -1434,12 +1406,10 @@ void mcd212_device::device_start()
 		m_delta_uv_lut[d] = s_dyuv_deltas[d >> 4];
 	}
 
-	for (uint16_t w = 0; w < 3 * 0xff; w++)
+	for (uint16_t w = 0; w < 0x300; w++)
 	{
-		const uint8_t limit = (w < 0xff + 16) ?  0 : w <= 16 + 2 * 0xff ? w - 0x10f : 0xff;
-		m_dyuv_limit_r_lut[w] = limit << 16;
-		m_dyuv_limit_g_lut[w] = limit << 8;
-		m_dyuv_limit_b_lut[w] = limit;
+		const uint8_t limit = (w < 0x100) ? 0 : w < 0x200 ? w - 0x100 : 0xff;
+		m_dyuv_limit_rgb_lut[w] = limit;
 	}
 
 	for (int16_t sw = 0; sw < 0x100; sw++)

--- a/src/mame/philips/mcd212.h
+++ b/src/mame/philips/mcd212.h
@@ -171,7 +171,7 @@ protected:
 
 		ICM_OFF              = 0x0,
 		ICM_CLUT8            = 0x1,
-		ICM_RGB555           = 0x1,
+		ICM_RGB555           = 0x2,
 		ICM_CLUT7            = 0x3,
 		ICM_CLUT77           = 0x4,
 		ICM_DYUV             = 0x5,

--- a/src/mame/philips/mcd212.h
+++ b/src/mame/philips/mcd212.h
@@ -171,7 +171,7 @@ protected:
 
 		ICM_OFF              = 0x0,
 		ICM_CLUT8            = 0x1,
-		ICM_RGB555           = 0x2,
+		ICM_RGB555           = 0x1,
 		ICM_CLUT7            = 0x3,
 		ICM_CLUT77           = 0x4,
 		ICM_DYUV             = 0x5,
@@ -202,9 +202,7 @@ protected:
 	uint8_t m_weight_factor[2][768]{};
 
 	// DYUV color limit arrays.
-	uint32_t m_dyuv_limit_r_lut[3 * 0xff];
-	uint32_t m_dyuv_limit_g_lut[3 * 0xff];
-	uint32_t m_dyuv_limit_b_lut[3 * 0xff];
+	uint32_t m_dyuv_limit_rgb_lut[0x300];
 
 	// DYUV delta-Y decoding array
 	uint8_t m_delta_y_lut[0x100];


### PR DESCRIPTION
This change fixes the following issues with the DYUV format:

1. The DYUV format incorrectly was too dark by 16/256. This fix corrects a previously incorrect attempt to fix that issue.
2. The DYUV format does not allow Mosaic features.

To Validate this change:
1. Use the Validation CD (Europe).
2. Click "Philips Tests"
3. Click "Video Representations"
4. Click "DYUV Decoder"

Result:
The DYUV format is slightly brighter. Mosaic effects will work more correctly. Unfortunately I don't know of a good example of how to see the mosaic behavior difference, however the spec makes it clear this configuration is not allowed.

Uncertain Issues:
The previous midpoint interpolation of 129+129 would be 1. The spec agrees with that formula. As the expected behavior is not yet well understood, a modified algorithm is used to produce more sensible midpoints that do not have this rollover artifact.

Known Issues:
There are further transparency issues that are out of scope for this update.

RGB format fix is not included in this update. Previous discussion about color/noise can be safely ignored for now, and discussed in the RGB update later.

There are further format issues.

Updated Test Images:
![image](https://github.com/user-attachments/assets/145828b1-1036-44eb-95ae-60de99d5cd76)
![image](https://github.com/user-attachments/assets/5f2b42b4-cc6f-4886-b730-e2851e4e9e61)

Compare to previous broken decoder:
![image](https://github.com/user-attachments/assets/fb6f8ae5-6e76-4a25-8f06-b15f692eca7c)
![image](https://github.com/user-attachments/assets/b75f2a79-c45d-421b-899b-ba5ab096710d)

