### PR TITLE
hash/ibm5170{,_cdrom}: PartitionMagic 8.05

### DIFF
--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -8919,6 +8919,101 @@ Missing [modem] features, assume requiring a connection to a Reuters device such
 		</part>
 	</software>
 
+	<software name="pmagic">
+		<description>Norton PartitionMagic 8.05 (English)</description>
+		<year>2004</year>
+		<publisher>Symantec</publisher>
+		<info name="release" value="20040505" />
+		<info name="language" value="English" />
+		<info name="version" value="8.05" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="en partitionmagic 8.05 disk 1.img" size="1474560" crc="209cc49e" sha1="67a3783bb719ad9d57c5fc58b7be454fd0faa07f" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="en partitionmagic 8.05 disk 2.img" size="1474560" crc="bccdbe9d" sha1="fcdc2d0654d16bed4b30ca01462bf367ce781899" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pmagicfr" cloneof="pmagic">
+		<description>Norton PartitionMagic 8.05 (French)</description>
+		<year>2004</year>
+		<publisher>Symantec</publisher>
+		<info name="release" value="20040505" />
+		<info name="language" value="French" />
+		<info name="version" value="8.05" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="fr partitionmagic 8.05 disk 1.img" size="1474560" crc="7599f223" sha1="fa5b78586d716115e17c11379cab7b983c26f62e" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="fr partitionmagic 8.05 disk 2.img" size="1474560" crc="9441481e" sha1="164220d9ddf20fbf63d69514bfaac1707c0b00d8" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pmagicde" cloneof="pmagic">
+		<description>Norton PartitionMagic 8.05 (German)</description>
+		<year>2004</year>
+		<publisher>Symantec</publisher>
+		<info name="release" value="20040505" />
+		<info name="language" value="German" />
+		<info name="version" value="8.05" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="de partitionmagic 8.05 disk 1.img" size="1474560" crc="3f628f48" sha1="4af2afd5cb1f5bc8fd341e3560be8475d2dfed7d" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="de partitionmagic 8.05 disk 2.img" size="1474560" crc="393fcbc5" sha1="395e052239331f608ef74934f5f0a00eb0886e9c" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pmagicit" cloneof="pmagic">
+		<description>Norton PartitionMagic 8.05 (Italian)</description>
+		<year>2004</year>
+		<publisher>Symantec</publisher>
+		<info name="release" value="20040505" />
+		<info name="language" value="Italian" />
+		<info name="version" value="8.05" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="it partitionmagic 8.05 disk 1.img" size="1474560" crc="6188d6b8" sha1="9fe4ced7e9306f04a60b20f43a0e6e21b7cc83bb" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="it partitionmagic 8.05 disk 2.img" size="1474560" crc="88e8db75" sha1="94cec9d7d483e86c7238e7c61e7c7fa8e6a44c08" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pmagices" cloneof="pmagic">
+		<description>Norton PartitionMagic 8.05 (Spanish)</description>
+		<year>2004</year>
+		<publisher>Symantec</publisher>
+		<info name="release" value="20040505" />
+		<info name="language" value="Spanish" />
+		<info name="version" value="8.05" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="es partitionmagic 8.05 disk 1.img" size="1474560" crc="fc9c205a" sha1="928c719d815a71a8d3e00501b99030d7541f5f6c" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="es partitionmagic 8.05 disk 2.img" size="1474560" crc="91ccb6fa" sha1="7b9d7a942ef7fd091a36ac8c8a8b1f2c0f87dd84" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="robotc2d">
 		<description>RobotC2 Demo</description>
 		<year>1989</year>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -8920,7 +8920,7 @@ Missing [modem] features, assume requiring a connection to a Reuters device such
 	</software>
 
 	<software name="pmagic">
-		<description>Norton PartitionMagic 8.05 (English)</description>
+		<description>PartitionMagic 8.05 (English)</description>
 		<year>2004</year>
 		<publisher>Symantec</publisher>
 		<info name="release" value="20040505" />
@@ -8939,7 +8939,7 @@ Missing [modem] features, assume requiring a connection to a Reuters device such
 	</software>
 
 	<software name="pmagicfr" cloneof="pmagic">
-		<description>Norton PartitionMagic 8.05 (French)</description>
+		<description>PartitionMagic 8.05 (French)</description>
 		<year>2004</year>
 		<publisher>Symantec</publisher>
 		<info name="release" value="20040505" />
@@ -8958,7 +8958,7 @@ Missing [modem] features, assume requiring a connection to a Reuters device such
 	</software>
 
 	<software name="pmagicde" cloneof="pmagic">
-		<description>Norton PartitionMagic 8.05 (German)</description>
+		<description>PartitionMagic 8.05 (German)</description>
 		<year>2004</year>
 		<publisher>Symantec</publisher>
 		<info name="release" value="20040505" />
@@ -8977,7 +8977,7 @@ Missing [modem] features, assume requiring a connection to a Reuters device such
 	</software>
 
 	<software name="pmagicit" cloneof="pmagic">
-		<description>Norton PartitionMagic 8.05 (Italian)</description>
+		<description>PartitionMagic 8.05 (Italian)</description>
 		<year>2004</year>
 		<publisher>Symantec</publisher>
 		<info name="release" value="20040505" />
@@ -8996,7 +8996,7 @@ Missing [modem] features, assume requiring a connection to a Reuters device such
 	</software>
 
 	<software name="pmagices" cloneof="pmagic">
-		<description>Norton PartitionMagic 8.05 (Spanish)</description>
+		<description>PartitionMagic 8.05 (Spanish)</description>
 		<year>2004</year>
 		<publisher>Symantec</publisher>
 		<info name="release" value="20040505" />

--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -7469,7 +7469,7 @@ Other stuff untested
 	</software>
 
 	<!-- DOS, Windows 95B, Windows 98, Windows Me, Windows 2000, Windows XP
-	     and bootable. -->
+	     and El Torito bootable. -->
 	<software name="pmagic">
 		<description>Norton PartitionMagic 8.05</description>
 		<year>2004</year>

--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -7468,6 +7468,22 @@ Other stuff untested
 		</part>
 	</software>
 
+	<!-- DOS, Windows 95B, Windows 98, Windows Me, Windows 2000, Windows XP
+	     and bootable. -->
+	<software name="pmagic">
+		<description>Norton PartitionMagic 8.05</description>
+		<year>2004</year>
+		<publisher>Symantec</publisher>
+		<info name="language" value="English/French/German/Italian/Spanish" />
+		<info name="release" value="20040505" />
+		<info name="version" value="8.05" />
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="partitionmagic 8.05" sha1="f783735693288fa20c8d2d7a614a3d0674ede2bf" />
+			</diskarea>
+		</part>
+	</software>
+
 	<!--                                         -->
 	<!--                Multimedia               -->
 	<!--                                         -->

--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -7476,6 +7476,7 @@ Other stuff untested
 		<publisher>Symantec</publisher>
 		<info name="language" value="English/French/German/Italian/Spanish" />
 		<info name="release" value="20040505" />
+		<info name="usage" value="Windows installer accepts any string starting with &quot;PM805EN1-&quot; for a product key." />
 		<info name="version" value="8.05" />
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">

--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -7471,7 +7471,7 @@ Other stuff untested
 	<!-- DOS, Windows 95B, Windows 98, Windows Me, Windows 2000, Windows XP
 	     and El Torito bootable. -->
 	<software name="pmagic">
-		<description>Norton PartitionMagic 8.05</description>
+		<description>PartitionMagic 8.05</description>
 		<year>2004</year>
 		<publisher>Symantec</publisher>
 		<info name="language" value="English/French/German/Italian/Spanish" />


### PR DESCRIPTION
CD-ROM dumped from my own disc.

Floppy images are sort-of unofficial, given that no such floppy disks are shipped in the software’s box.  Even still, the disc has \%LANG%\DOSMAKE\MAKEDISK.BAT files that can be used to create bootable floppy disks.  The utility of the floppy disks for booting systems (especially ct486) without El Torito support is rather high, so I am including them here.

New working software list items (ibm5170.xml)
---------------------------------------------
Norton PartitionMagic 8.05 (English) [chungy]
Norton PartitionMagic 8.05 (French) [chungy]
Norton PartitionMagic 8.05 (German) [chungy]
Norton PartitionMagic 8.05 (Italian) [chungy]
Norton PartitionMagic 8.05 (Spanish) [chungy]

New working software list items (ibm5170_cdrom.xml)
---------------------------------------------------
Norton PartitionMagic 8.05 [chungy]