### PR TITLE
atari/atarig1.cpp, atarig42.cpp, atarigt.cpp, atarigx2.cpp, atarirle.cpp: Cleanups:

### DIFF
--- a/src/mame/atari/atarig1.cpp
+++ b/src/mame/atari/atarig1.cpp
@@ -51,7 +51,7 @@ void atarig1_state::video_int_ack_w(uint16_t data)
 void atarig1_state::mo_command_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	COMBINE_DATA(m_mo_command);
-	m_rle->command_write((data == 0 && m_is_pitfight) ? ATARIRLE_COMMAND_CHECKSUM : ATARIRLE_COMMAND_DRAW);
+	m_rle->command_write((data == 0 && m_is_pitfight) ? atari_rle_objects_device::COMMAND_CHECKSUM : atari_rle_objects_device::COMMAND_DRAW);
 }
 
 
@@ -291,9 +291,9 @@ static const gfx_layout pftoplayout =
 
 
 static GFXDECODE_START( gfx_atarig1 )
-	GFXDECODE_ENTRY( "gfx1", 0, pflayout, 0x300, 8 )
-	GFXDECODE_ENTRY( "gfx2", 0, gfx_8x8x4_packed_msb, 0x100, 16 )
-	GFXDECODE_ENTRY( "gfx1", 0, pftoplayout, 0x300, 8 )
+	GFXDECODE_ENTRY( "tiles", 0, pflayout, 0x300, 8 )
+	GFXDECODE_ENTRY( "chars", 0, gfx_8x8x4_packed_msb, 0x100, 16 )
+	GFXDECODE_ENTRY( "tiles", 0, pftoplayout, 0x300, 8 )
 GFXDECODE_END
 
 
@@ -361,7 +361,7 @@ void atarig1_state::atarig1(machine_config &config)
 	m_screen->set_video_attributes(VIDEO_UPDATE_BEFORE_VBLANK);
 	/* note: these parameters are from published specs, not derived */
 	m_screen->set_raw(14.318181_MHz_XTAL/2, 456, 0, 336, 262, 0, 240);
-	m_screen->set_screen_update(FUNC(atarig1_state::screen_update_atarig1));
+	m_screen->set_screen_update(FUNC(atarig1_state::screen_update));
 	m_screen->set_palette("palette");
 	m_screen->screen_vblank().set_inputline(m_maincpu, M68K_IRQ_1, ASSERT_LINE);
 
@@ -476,7 +476,7 @@ ROM_START( hydra )
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 64k for 6502 code */
 	ROM_LOAD( "hydraa0.bin", 0x00000, 0x10000, CRC(619d7319) SHA1(3c58f18ca5c93ae049bfca91043718fff43e674c) )
 
-	ROM_REGION( 0x0a0000, "gfx1", 0 )
+	ROM_REGION( 0x0a0000, "tiles", 0 )
 	ROM_LOAD( "136079-1017.bin",  0x000000, 0x10000, CRC(bd77b747) SHA1(da57e305468c159ca3d2cfae807a85e643bbf053) ) /* playfield, planes 0-3 odd */
 	ROM_LOAD( "136079-1018.bin",  0x010000, 0x10000, CRC(7c24e637) SHA1(dd9fa8a59cbd692b0d8c0e452df4fa18d770c602) )
 	ROM_LOAD( "136079-1019.bin",  0x020000, 0x10000, CRC(aa2fb07b) SHA1(ed5aa82d5bac112f0507be3e4e2a5bad184eceeb) )
@@ -488,7 +488,7 @@ ROM_START( hydra )
 	ROM_LOAD( "136079-1025.bin",  0x080000, 0x10000, CRC(98b5b1a1) SHA1(dfee7d334c4541eb13ee96b43d4d3e1a3c8deb72) ) /* playfield plane 4 */
 	ROM_LOAD( "136079-1026.bin",  0x090000, 0x10000, CRC(d68d44aa) SHA1(8fc8b82f4f90515f2af93d3f2d6903a74aac0cc9) )
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136079-1027.bin",  0x000000, 0x20000, CRC(f9135b9b) SHA1(48c0ad0d3e592d191d1385e30530bdb69a095452) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x100000, "rle", 0 )
@@ -535,7 +535,7 @@ ROM_START( hydrap )
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 64k for 6502 code */
 	ROM_LOAD( "hydraa0.bin", 0x00000, 0x10000, BAD_DUMP CRC(619d7319) SHA1(3c58f18ca5c93ae049bfca91043718fff43e674c)  )
 
-	ROM_REGION( 0x0a0000, "gfx1", 0 )
+	ROM_REGION( 0x0a0000, "tiles", 0 )
 	ROM_LOAD( "136079-1017.bin",  0x000000, 0x10000, CRC(bd77b747) SHA1(da57e305468c159ca3d2cfae807a85e643bbf053) ) /* playfield, planes 0-3 odd */
 	ROM_LOAD( "136079-1018.bin",  0x010000, 0x10000, CRC(7c24e637) SHA1(dd9fa8a59cbd692b0d8c0e452df4fa18d770c602) )
 	ROM_LOAD( "136079-1019.bin",  0x020000, 0x10000, CRC(aa2fb07b) SHA1(ed5aa82d5bac112f0507be3e4e2a5bad184eceeb) )
@@ -547,7 +547,7 @@ ROM_START( hydrap )
 	ROM_LOAD( "136079-1025.bin",  0x080000, 0x10000, CRC(98b5b1a1) SHA1(dfee7d334c4541eb13ee96b43d4d3e1a3c8deb72) ) /* playfield plane 4 */
 	ROM_LOAD( "hydpl41.bin",   0x090000, 0x10000, CRC(85f9afa6) SHA1(01d8e07ff249bfab83791fc8916542f38133fadf) )
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "hydalph.bin",   0x000000, 0x20000, CRC(7dd2b062) SHA1(789b35b1e8cce73e2314d1b6688b5066df91b604) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x100000, "rle", 0 )
@@ -594,7 +594,7 @@ ROM_START( hydrap2 )
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 64k for 6502 code */
 	ROM_LOAD( "aud.1b",      0x00000, 0x10000, CRC(e1b5188a) SHA1(e9f2a78df49fa085a9363ca194e2ceb5fa5409c4) )
 
-	ROM_REGION( 0x0a0000, "gfx1", 0 )
+	ROM_REGION( 0x0a0000, "tiles", 0 )
 	ROM_LOAD( "136079-1017.bin",  0x000000, 0x10000, CRC(bd77b747) SHA1(da57e305468c159ca3d2cfae807a85e643bbf053) ) /* playfield, planes 0-3 odd */
 	ROM_LOAD( "136079-1018.bin",  0x010000, 0x10000, CRC(7c24e637) SHA1(dd9fa8a59cbd692b0d8c0e452df4fa18d770c602) )
 	ROM_LOAD( "136079-1019.bin",  0x020000, 0x10000, CRC(aa2fb07b) SHA1(ed5aa82d5bac112f0507be3e4e2a5bad184eceeb) )
@@ -606,7 +606,7 @@ ROM_START( hydrap2 )
 	ROM_LOAD( "136079-1025.bin",  0x080000, 0x10000, CRC(98b5b1a1) SHA1(dfee7d334c4541eb13ee96b43d4d3e1a3c8deb72) ) /* playfield plane 4 */
 	ROM_LOAD( "136079-1026.bin",  0x090000, 0x10000, CRC(d68d44aa) SHA1(8fc8b82f4f90515f2af93d3f2d6903a74aac0cc9) )
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136079-1027.bin",  0x000000, 0x20000, CRC(f9135b9b) SHA1(48c0ad0d3e592d191d1385e30530bdb69a095452) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x100000, "rle", 0 )
@@ -682,14 +682,14 @@ ROM_START( pitfight )
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 64k for 6502 code */
 	ROM_LOAD( "136081-1060.1b", 0x00000, 0x10000, CRC(231d71d7) SHA1(24622eee5fe873ef81e1df2691bd7a1d3ea7ef6b) )
 
-	ROM_REGION( 0x0a0000, "gfx1", 0 )
+	ROM_REGION( 0x0a0000, "tiles", 0 )
 	ROM_LOAD( "136081-1017.130m", 0x000000, 0x10000, CRC(ad3cfea5) SHA1(7b6fec131230e84ab87b7fc95f08989916f30e02) ) /* playfield, planes 0-3 odd */
 	ROM_LOAD( "136081-1018.120m", 0x010000, 0x10000, CRC(1a0f8bcf) SHA1(b965e73246db9507d2ad42dfcb033692b43b9b7a) )
 	ROM_LOAD( "136081-1021.90m",  0x040000, 0x10000, CRC(777efee3) SHA1(07591f11685c4c75c24c55fd242878253d32481b) ) /* playfield, planes 0-3 even */
 	ROM_LOAD( "136081-1022.75m",  0x050000, 0x10000, CRC(524319d0) SHA1(6f47a69d7d4e2a8f79b7470138e8b4edd6d0b2bb) )
 	ROM_LOAD( "136081-1025.45m",  0x080000, 0x10000, CRC(fc41691a) SHA1(4ef2f9093f20d27e1ba7d218b90ff6abb1f33646) ) /* playfield plane 4 */
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136081-1027.15l",  0x000000, 0x10000, CRC(a59f381d) SHA1(b14e878340ad2adbf4f6d4fc331c58f62037c7c7) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x200000, "rle", 0 )
@@ -777,14 +777,14 @@ ROM_START( pitfight7 )
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 64k for 6502 code */
 	ROM_LOAD( "136081-1060.1b", 0x00000, 0x10000, CRC(231d71d7) SHA1(24622eee5fe873ef81e1df2691bd7a1d3ea7ef6b) )
 
-	ROM_REGION( 0x0a0000, "gfx1", 0 )
+	ROM_REGION( 0x0a0000, "tiles", 0 )
 	ROM_LOAD( "136081-1017.130m", 0x000000, 0x10000, CRC(ad3cfea5) SHA1(7b6fec131230e84ab87b7fc95f08989916f30e02) ) /* playfield, planes 0-3 odd */
 	ROM_LOAD( "136081-1018.120m", 0x010000, 0x10000, CRC(1a0f8bcf) SHA1(b965e73246db9507d2ad42dfcb033692b43b9b7a) )
 	ROM_LOAD( "136081-1021.90m",  0x040000, 0x10000, CRC(777efee3) SHA1(07591f11685c4c75c24c55fd242878253d32481b) ) /* playfield, planes 0-3 even */
 	ROM_LOAD( "136081-1022.75m",  0x050000, 0x10000, CRC(524319d0) SHA1(6f47a69d7d4e2a8f79b7470138e8b4edd6d0b2bb) )
 	ROM_LOAD( "136081-1025.45m",  0x080000, 0x10000, CRC(fc41691a) SHA1(4ef2f9093f20d27e1ba7d218b90ff6abb1f33646) ) /* playfield plane 4 */
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136081-1027.15l",  0x000000, 0x10000, CRC(a59f381d) SHA1(b14e878340ad2adbf4f6d4fc331c58f62037c7c7) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x200000, "rle", 0 )
@@ -839,14 +839,14 @@ ROM_START( pitfight6 )
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 64k for 6502 code */
 	ROM_LOAD( "136081-1060.1b", 0x00000, 0x10000, CRC(231d71d7) SHA1(24622eee5fe873ef81e1df2691bd7a1d3ea7ef6b) )
 
-	ROM_REGION( 0x0a0000, "gfx1", 0 )
+	ROM_REGION( 0x0a0000, "tiles", 0 )
 	ROM_LOAD( "136081-1017.130m", 0x000000, 0x10000, CRC(ad3cfea5) SHA1(7b6fec131230e84ab87b7fc95f08989916f30e02) ) /* playfield, planes 0-3 odd */
 	ROM_LOAD( "136081-1018.120m", 0x010000, 0x10000, CRC(1a0f8bcf) SHA1(b965e73246db9507d2ad42dfcb033692b43b9b7a) )
 	ROM_LOAD( "136081-1021.90m",  0x040000, 0x10000, CRC(777efee3) SHA1(07591f11685c4c75c24c55fd242878253d32481b) ) /* playfield, planes 0-3 even */
 	ROM_LOAD( "136081-1022.75m",  0x050000, 0x10000, CRC(524319d0) SHA1(6f47a69d7d4e2a8f79b7470138e8b4edd6d0b2bb) )
 	ROM_LOAD( "136081-1025.45m",  0x080000, 0x10000, CRC(fc41691a) SHA1(4ef2f9093f20d27e1ba7d218b90ff6abb1f33646) ) /* playfield plane 4 */
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136081-1027.15l",  0x000000, 0x10000, CRC(a59f381d) SHA1(b14e878340ad2adbf4f6d4fc331c58f62037c7c7) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x200000, "rle", 0 )
@@ -889,14 +889,14 @@ ROM_START( pitfight5 )
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 64k for 6502 code */
 	ROM_LOAD( "136081-1060.1b", 0x00000, 0x10000, CRC(231d71d7) SHA1(24622eee5fe873ef81e1df2691bd7a1d3ea7ef6b) )
 
-	ROM_REGION( 0x0a0000, "gfx1", 0 )
+	ROM_REGION( 0x0a0000, "tiles", 0 )
 	ROM_LOAD( "136081-1017.130m", 0x000000, 0x10000, CRC(ad3cfea5) SHA1(7b6fec131230e84ab87b7fc95f08989916f30e02) ) /* playfield, planes 0-3 odd */
 	ROM_LOAD( "136081-1018.120m", 0x010000, 0x10000, CRC(1a0f8bcf) SHA1(b965e73246db9507d2ad42dfcb033692b43b9b7a) )
 	ROM_LOAD( "136081-1021.90m",  0x040000, 0x10000, CRC(777efee3) SHA1(07591f11685c4c75c24c55fd242878253d32481b) ) /* playfield, planes 0-3 even */
 	ROM_LOAD( "136081-1022.75m",  0x050000, 0x10000, CRC(524319d0) SHA1(6f47a69d7d4e2a8f79b7470138e8b4edd6d0b2bb) )
 	ROM_LOAD( "136081-1025.45m",  0x080000, 0x10000, CRC(fc41691a) SHA1(4ef2f9093f20d27e1ba7d218b90ff6abb1f33646) ) /* playfield plane 4 */
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136081-1027.15l",  0x000000, 0x10000, CRC(a59f381d) SHA1(b14e878340ad2adbf4f6d4fc331c58f62037c7c7) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x200000, "rle", 0 )
@@ -939,14 +939,14 @@ ROM_START( pitfight4 )
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 64k for 6502 code */
 	ROM_LOAD( "136081-1060.1b", 0x00000, 0x10000, CRC(231d71d7) SHA1(24622eee5fe873ef81e1df2691bd7a1d3ea7ef6b) )
 
-	ROM_REGION( 0x0a0000, "gfx1", 0 )
+	ROM_REGION( 0x0a0000, "tiles", 0 )
 	ROM_LOAD( "136081-1017.130m", 0x000000, 0x10000, CRC(ad3cfea5) SHA1(7b6fec131230e84ab87b7fc95f08989916f30e02) ) /* playfield, planes 0-3 odd */
 	ROM_LOAD( "136081-1018.120m", 0x010000, 0x10000, CRC(1a0f8bcf) SHA1(b965e73246db9507d2ad42dfcb033692b43b9b7a) )
 	ROM_LOAD( "136081-1021.90m",  0x040000, 0x10000, CRC(777efee3) SHA1(07591f11685c4c75c24c55fd242878253d32481b) ) /* playfield, planes 0-3 even */
 	ROM_LOAD( "136081-1022.75m",  0x050000, 0x10000, CRC(524319d0) SHA1(6f47a69d7d4e2a8f79b7470138e8b4edd6d0b2bb) )
 	ROM_LOAD( "136081-1025.45m",  0x080000, 0x10000, CRC(fc41691a) SHA1(4ef2f9093f20d27e1ba7d218b90ff6abb1f33646) ) /* playfield plane 4 */
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136081-1027.15l",  0x000000, 0x10000, CRC(a59f381d) SHA1(b14e878340ad2adbf4f6d4fc331c58f62037c7c7) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x200000, "rle", 0 )
@@ -1001,14 +1001,14 @@ ROM_START( pitfight3 )
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 64k for 6502 code */
 	ROM_LOAD( "136081-1060.1b", 0x00000, 0x10000, CRC(231d71d7) SHA1(24622eee5fe873ef81e1df2691bd7a1d3ea7ef6b) )
 
-	ROM_REGION( 0x0a0000, "gfx1", 0 )
+	ROM_REGION( 0x0a0000, "tiles", 0 )
 	ROM_LOAD( "136081-1017.130m", 0x000000, 0x10000, CRC(ad3cfea5) SHA1(7b6fec131230e84ab87b7fc95f08989916f30e02) ) /* playfield, planes 0-3 odd */
 	ROM_LOAD( "136081-1018.120m", 0x010000, 0x10000, CRC(1a0f8bcf) SHA1(b965e73246db9507d2ad42dfcb033692b43b9b7a) )
 	ROM_LOAD( "136081-1021.90m",  0x040000, 0x10000, CRC(777efee3) SHA1(07591f11685c4c75c24c55fd242878253d32481b) ) /* playfield, planes 0-3 even */
 	ROM_LOAD( "136081-1022.75m",  0x050000, 0x10000, CRC(524319d0) SHA1(6f47a69d7d4e2a8f79b7470138e8b4edd6d0b2bb) )
 	ROM_LOAD( "136081-1025.45m",  0x080000, 0x10000, CRC(fc41691a) SHA1(4ef2f9093f20d27e1ba7d218b90ff6abb1f33646) ) /* playfield plane 4 */
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136081-1027.15l",  0x000000, 0x10000, CRC(a59f381d) SHA1(b14e878340ad2adbf4f6d4fc331c58f62037c7c7) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x200000, "rle", 0 )
@@ -1063,14 +1063,14 @@ ROM_START( pitfight2 )
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 64k for 6502 code */
 	ROM_LOAD( "136081-1060.1b", 0x00000, 0x10000, CRC(231d71d7) SHA1(24622eee5fe873ef81e1df2691bd7a1d3ea7ef6b) )
 
-	ROM_REGION( 0x0a0000, "gfx1", 0 )
+	ROM_REGION( 0x0a0000, "tiles", 0 )
 	ROM_LOAD( "136081-1017.130m", 0x000000, 0x10000, CRC(ad3cfea5) SHA1(7b6fec131230e84ab87b7fc95f08989916f30e02) ) /* playfield, planes 0-3 odd */
 	ROM_LOAD( "136081-1018.120m", 0x010000, 0x10000, CRC(1a0f8bcf) SHA1(b965e73246db9507d2ad42dfcb033692b43b9b7a) )
 	ROM_LOAD( "136081-1021.90m",  0x040000, 0x10000, CRC(777efee3) SHA1(07591f11685c4c75c24c55fd242878253d32481b) ) /* playfield, planes 0-3 even */
 	ROM_LOAD( "136081-1022.75m",  0x050000, 0x10000, CRC(524319d0) SHA1(6f47a69d7d4e2a8f79b7470138e8b4edd6d0b2bb) )
 	ROM_LOAD( "136081-1025.45m",  0x080000, 0x10000, CRC(fc41691a) SHA1(4ef2f9093f20d27e1ba7d218b90ff6abb1f33646) ) /* playfield plane 4 */
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136081-1027.15l",  0x000000, 0x10000, CRC(a59f381d) SHA1(b14e878340ad2adbf4f6d4fc331c58f62037c7c7) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x200000, "rle", 0 )
@@ -1125,14 +1125,14 @@ ROM_START( pitfight1p2 )
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 64k for 6502 code */
 	ROM_LOAD( "136081-1060.1b", 0x00000, 0x10000, CRC(231d71d7) SHA1(24622eee5fe873ef81e1df2691bd7a1d3ea7ef6b) )
 
-	ROM_REGION( 0x0a0000, "gfx1", 0 )
+	ROM_REGION( 0x0a0000, "tiles", 0 )
 	ROM_LOAD( "136081-1017.130m", 0x000000, 0x10000, CRC(ad3cfea5) SHA1(7b6fec131230e84ab87b7fc95f08989916f30e02) ) /* playfield, planes 0-3 odd */
 	ROM_LOAD( "136081-1018.120m", 0x010000, 0x10000, CRC(1a0f8bcf) SHA1(b965e73246db9507d2ad42dfcb033692b43b9b7a) )
 	ROM_LOAD( "136081-1021.90m",  0x040000, 0x10000, CRC(777efee3) SHA1(07591f11685c4c75c24c55fd242878253d32481b) ) /* playfield, planes 0-3 even */
 	ROM_LOAD( "136081-1022.75m",  0x050000, 0x10000, CRC(524319d0) SHA1(6f47a69d7d4e2a8f79b7470138e8b4edd6d0b2bb) )
 	ROM_LOAD( "136081-1025.45m",  0x080000, 0x10000, CRC(fc41691a) SHA1(4ef2f9093f20d27e1ba7d218b90ff6abb1f33646) ) /* playfield plane 4 */
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136081-1027.15l",  0x000000, 0x10000, CRC(a59f381d) SHA1(b14e878340ad2adbf4f6d4fc331c58f62037c7c7) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x200000, "rle", 0 )
@@ -1187,14 +1187,14 @@ ROM_START( pitfightj )
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 64k for 6502 code */
 	ROM_LOAD( "136081-2060.1b", 0x00000, 0x10000, CRC(4317a9f3) SHA1(310154be47fd16b417699338e04e08f3ed973198) )
 
-	ROM_REGION( 0x0a0000, "gfx1", 0 )
+	ROM_REGION( 0x0a0000, "tiles", 0 )
 	ROM_LOAD( "136081-1017.130m", 0x000000, 0x10000, CRC(ad3cfea5) SHA1(7b6fec131230e84ab87b7fc95f08989916f30e02) ) /* playfield, planes 0-3 odd */
 	ROM_LOAD( "136081-1018.120m", 0x010000, 0x10000, CRC(1a0f8bcf) SHA1(b965e73246db9507d2ad42dfcb033692b43b9b7a) )
 	ROM_LOAD( "136081-1021.90m",  0x040000, 0x10000, CRC(777efee3) SHA1(07591f11685c4c75c24c55fd242878253d32481b) ) /* playfield, planes 0-3 even */
 	ROM_LOAD( "136081-1022.75m",  0x050000, 0x10000, CRC(524319d0) SHA1(6f47a69d7d4e2a8f79b7470138e8b4edd6d0b2bb) )
 	ROM_LOAD( "136081-1025.45m",  0x080000, 0x10000, CRC(fc41691a) SHA1(4ef2f9093f20d27e1ba7d218b90ff6abb1f33646) ) /* playfield plane 4 */
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136081-1427.dat",  0x000000, 0x20000, CRC(b2c51dff) SHA1(7ad82a6a55d3a68e39d113c92f9e89a43408b5b2) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x200000, "rle", 0 )
@@ -1249,14 +1249,14 @@ ROM_START( pitfightb )
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 64k for 6502 code */
 	ROM_LOAD( "136081-1060.1b", 0x00000, 0x10000, CRC(231d71d7) SHA1(24622eee5fe873ef81e1df2691bd7a1d3ea7ef6b) )
 
-	ROM_REGION( 0x0a0000, "gfx1", 0 )
+	ROM_REGION( 0x0a0000, "tiles", 0 )
 	ROM_LOAD( "136081-1017.130m", 0x000000, 0x10000, CRC(ad3cfea5) SHA1(7b6fec131230e84ab87b7fc95f08989916f30e02) ) /* playfield, planes 0-3 odd */
 	ROM_LOAD( "136081-1018.120m", 0x010000, 0x10000, CRC(1a0f8bcf) SHA1(b965e73246db9507d2ad42dfcb033692b43b9b7a) )
 	ROM_LOAD( "136081-1021.90m",  0x040000, 0x10000, CRC(777efee3) SHA1(07591f11685c4c75c24c55fd242878253d32481b) ) /* playfield, planes 0-3 even */
 	ROM_LOAD( "136081-1022.75m",  0x050000, 0x10000, CRC(524319d0) SHA1(6f47a69d7d4e2a8f79b7470138e8b4edd6d0b2bb) )
 	ROM_LOAD( "136081-1025.45m",  0x080000, 0x10000, CRC(fc41691a) SHA1(4ef2f9093f20d27e1ba7d218b90ff6abb1f33646) ) /* playfield plane 4 */
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136081-1027.15l",  0x000000, 0x10000, CRC(a59f381d) SHA1(b14e878340ad2adbf4f6d4fc331c58f62037c7c7) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x200000, "rle", 0 )

--- a/src/mame/atari/atarig1.h
+++ b/src/mame/atari/atarig1.h
@@ -27,8 +27,8 @@ public:
 		m_alpha_tilemap(*this, "alpha"),
 		m_rle(*this, "rle"),
 		m_adc(*this, "adc"),
-		m_in1(*this, "IN1"),
-		m_mo_command(*this, "mo_command")
+		m_mo_command(*this, "mo_command"),
+		m_in1(*this, "IN1")
 	{ }
 
 	void atarig1(machine_config &config);
@@ -57,11 +57,12 @@ private:
 	required_device<atari_rle_objects_device> m_rle;
 
 	optional_device<adc0808_device> m_adc;
+
+	required_shared_ptr<uint16_t> m_mo_command;
+
 	optional_ioport m_in1;
 
 	bool            m_is_pitfight = false;
-
-	required_shared_ptr<uint16_t> m_mo_command;
 
 	bool            m_bslapstic_primed = false;
 
@@ -80,7 +81,7 @@ private:
 	void update_bank(int bank);
 	TILE_GET_INFO_MEMBER(get_alpha_tile_info);
 	TILE_GET_INFO_MEMBER(get_playfield_tile_info);
-	uint32_t screen_update_atarig1(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void main_map(address_map &map) ATTR_COLD;
 	void pitfight_map(address_map &map) ATTR_COLD;
 	void hydra_map(address_map &map) ATTR_COLD;

--- a/src/mame/atari/atarig1_v.cpp
+++ b/src/mame/atari/atarig1_v.cpp
@@ -20,20 +20,20 @@
 
 TILE_GET_INFO_MEMBER(atarig1_state::get_alpha_tile_info)
 {
-	uint16_t data = m_alpha_tilemap->basemem_read(tile_index);
-	int code = data & 0xfff;
-	int color = (data >> 12) & 0x0f;
-	int opaque = data & 0x8000;
+	uint16_t const data = m_alpha_tilemap->basemem_read(tile_index);
+	int const code = data & 0xfff;
+	int const color = (data >> 12) & 0x0f;
+	bool const opaque = BIT(data, 15);
 	tileinfo.set(1, code, color, opaque ? TILE_FORCE_LAYER0 : 0);
 }
 
 
 TILE_GET_INFO_MEMBER(atarig1_state::get_playfield_tile_info)
 {
-	uint16_t data = m_playfield_tilemap->basemem_read(tile_index);
-	int code = (m_playfield_tile_bank << 12) | (data & 0xfff);
-	int color = (data >> 12) & 7;
-	tileinfo.set(0, code, color, (data >> 15) & 1);
+	uint16_t const data = m_playfield_tilemap->basemem_read(tile_index);
+	int const code = (m_playfield_tile_bank << 12) | (data & 0xfff);
+	int const color = (data >> 12) & 7;
+	tileinfo.set(0, code, color, BIT(data, 15));
 }
 
 
@@ -69,7 +69,7 @@ void atarig1_state::video_start()
 
 TIMER_DEVICE_CALLBACK_MEMBER(atarig1_state::scanline_update)
 {
-	int scanline = param;
+	int const scanline = param;
 
 	//if (scanline == 0) logerror("-------\n");
 
@@ -82,13 +82,11 @@ TIMER_DEVICE_CALLBACK_MEMBER(atarig1_state::scanline_update)
 	/* update the playfield scrolls */
 	for (int i = 0; i < 8; i++)
 	{
-		uint16_t word;
-
 		/* first word controls horizontal scroll */
-		word = m_alpha_tilemap->basemem_read(offset++);
-		if (word & 0x8000)
+		uint16_t word = m_alpha_tilemap->basemem_read(offset++);
+		if (BIT(word, 15))
 		{
-			int newscroll = ((word >> 6) + m_pfscroll_xoffset) & 0x1ff;
+			int const newscroll = ((word >> 6) + m_pfscroll_xoffset) & 0x1ff;
 			if (newscroll != m_playfield_xscroll)
 			{
 				m_screen->update_partial(std::max(scanline + i - 1, 0));
@@ -99,10 +97,10 @@ TIMER_DEVICE_CALLBACK_MEMBER(atarig1_state::scanline_update)
 
 		/* second word controls vertical scroll and tile bank */
 		word = m_alpha_tilemap->basemem_read(offset++);
-		if (word & 0x8000)
+		if (BIT(word, 15))
 		{
-			int newscroll = ((word >> 6) - (scanline + i)) & 0x1ff;
-			int newbank = word & 7;
+			int const newscroll = ((word >> 6) - (scanline + i)) & 0x1ff;
+			int const newbank = word & 7;
 			if (newscroll != m_playfield_yscroll)
 			{
 				m_screen->update_partial(std::max(scanline + i - 1, 0));
@@ -127,7 +125,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(atarig1_state::scanline_update)
  *
  *************************************/
 
-uint32_t atarig1_state::screen_update_atarig1(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t atarig1_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	/* draw the playfield */
 	m_playfield_tilemap->draw(screen, bitmap, cliprect, 0, 0);

--- a/src/mame/atari/atarig42.cpp
+++ b/src/mame/atari/atarig42.cpp
@@ -77,7 +77,7 @@ uint8_t atarig42_state::a2d_data_r(offs_t offset)
 	if (!m_adc.found())
 		return 0xff;
 
-	uint8_t result = m_adc->data_r();
+	uint8_t const result = m_adc->data_r();
 	if (!machine().side_effects_disabled())
 		m_adc->address_offset_start_w(offset, 0);
 	return result;
@@ -90,7 +90,7 @@ void atarig42_state::io_latch_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 	if (ACCESSING_BITS_8_15)
 	{
 		/* bit 14 controls the ASIC65 reset line */
-		m_asic65->reset_line((~data >> 14) & 1);
+		m_asic65->reset_line(BIT(~data, 14));
 
 		/* bits 13-11 are the MO control bits */
 		m_rle->control_write((data >> 11) & 7);
@@ -100,8 +100,8 @@ void atarig42_state::io_latch_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 	if (ACCESSING_BITS_0_7)
 	{
 		/* bit 4 resets the sound CPU */
-		m_jsa->soundcpu().set_input_line(INPUT_LINE_RESET, (data & 0x10) ? CLEAR_LINE : ASSERT_LINE);
-		if (!(data & 0x10))
+		m_jsa->soundcpu().set_input_line(INPUT_LINE_RESET, BIT(data, 4) ? CLEAR_LINE : ASSERT_LINE);
+		if (BIT(~data, 4))
 			m_jsa->reset();
 
 		/* bit 5 is /XRESET, probably related to the ASIC */
@@ -114,7 +114,7 @@ void atarig42_state::io_latch_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 void atarig42_state::mo_command_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	COMBINE_DATA(m_mo_command);
-	m_rle->command_write((data == 0) ? ATARIRLE_COMMAND_CHECKSUM : ATARIRLE_COMMAND_DRAW);
+	m_rle->command_write((data == 0) ? atari_rle_objects_device::COMMAND_CHECKSUM : atari_rle_objects_device::COMMAND_DRAW);
 }
 
 
@@ -239,7 +239,8 @@ void atarig42_0x200_state::roadriot_sloop_tweak(int offset)
 
 uint16_t atarig42_0x200_state::roadriot_sloop_data_r(offs_t offset)
 {
-	roadriot_sloop_tweak(offset);
+	if (!machine().side_effects_disabled())
+		roadriot_sloop_tweak(offset);
 	if (offset < 0x78000/2)
 		return m_sloop_base[offset];
 	else
@@ -296,7 +297,8 @@ void atarig42_0x400_state::guardians_sloop_tweak(int offset)
 
 uint16_t atarig42_0x400_state::guardians_sloop_data_r(offs_t offset)
 {
-	guardians_sloop_tweak(offset);
+	if (!machine().side_effects_disabled())
+		guardians_sloop_tweak(offset);
 	if (offset < 0x78000/2)
 		return m_sloop_base[offset];
 	else
@@ -341,7 +343,7 @@ void atarig42_state::main_map(address_map &map)
 	map(0xff1000, 0xff1fff).ram();
 	map(0xff2000, 0xff5fff).ram().w(m_playfield_tilemap, FUNC(tilemap_device::write16)).share("playfield");
 	map(0xff6000, 0xff6fff).ram().w(m_alpha_tilemap, FUNC(tilemap_device::write16)).share("alpha");
-	map(0xff7000, 0xff7001).ram().w(FUNC(atarig42_state::mo_command_w)).share("mo_command");
+	map(0xff7000, 0xff7001).ram().w(FUNC(atarig42_state::mo_command_w)).share(m_mo_command);
 	map(0xff7002, 0xffffff).ram();
 }
 
@@ -503,9 +505,9 @@ static const gfx_layout pftoplayout =
 };
 
 static GFXDECODE_START( gfx_atarig42 )
-	GFXDECODE_ENTRY( "gfx1", 0, pflayout, 0x000, 64 )
-	GFXDECODE_ENTRY( "gfx2", 0, gfx_8x8x4_packed_msb, 0x000, 16 )
-	GFXDECODE_ENTRY( "gfx1", 0, pftoplayout, 0x000, 64 )
+	GFXDECODE_ENTRY( "tiles", 0, pflayout, 0x000, 64 )
+	GFXDECODE_ENTRY( "chars", 0, gfx_8x8x4_packed_msb, 0x000, 16 )
+	GFXDECODE_ENTRY( "tiles", 0, pftoplayout, 0x000, 64 )
 GFXDECODE_END
 
 
@@ -578,7 +580,7 @@ void atarig42_state::atarig42(machine_config &config)
 	/* note: these parameters are from published specs, not derived */
 	/* the board uses an SOS chip to generate video signals */
 	m_screen->set_raw(14.318181_MHz_XTAL/2, 456, 0, 336, 262, 0, 240);
-	m_screen->set_screen_update(FUNC(atarig42_state::screen_update_atarig42));
+	m_screen->set_screen_update(FUNC(atarig42_state::screen_update));
 	m_screen->set_palette("palette");
 	m_screen->screen_vblank().set_inputline(m_maincpu, M68K_IRQ_4, ASSERT_LINE);
 
@@ -634,7 +636,7 @@ ROM_START( roadriot ) // Test mode shows DSP COMM and DSP LINK tests; This is a 
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 6502 code */
 	ROM_LOAD( "136089-1047.12c", 0x00000, 0x10000, CRC(849dd26c) SHA1(05a0b2a5f7ee4437448b5f076d3066d96dec2320) )
 
-	ROM_REGION( 0xc0000, "gfx1", 0 )
+	ROM_REGION( 0xc0000, "tiles", 0 )
 	ROM_LOAD( "136089-1041.22d",    0x000000, 0x20000, CRC(b7451f92) SHA1(9fd17913630e457e406e596f2d86afff98787750) ) /* playfield, planes 0-1 */
 	ROM_LOAD( "136089-1038.22c",    0x020000, 0x20000, CRC(90f3c6ee) SHA1(7607509e2d3b2080a918cfaf2879dbed6b79d029) )
 	ROM_LOAD( "136089-1037.2021d",  0x040000, 0x20000, CRC(d40de62b) SHA1(fa6dfd20bdad7874ae33a1027a9bb0ea200f86ca) ) /* playfield, planes 2-3 */
@@ -642,7 +644,7 @@ ROM_START( roadriot ) // Test mode shows DSP COMM and DSP LINK tests; This is a 
 	ROM_LOAD( "136089-1040.20d",    0x080000, 0x20000, CRC(a81ae93f) SHA1(b694ba5fab35f8fa505a02039ae62f7af3c7ae1d) ) /* playfield, planes 4-5 */
 	ROM_LOAD( "136089-1042.20c",    0x0a0000, 0x20000, CRC(b8a6d15a) SHA1(43d2be9d40a84b2c01d80bbcac737eda04d55999) )
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136089-1046.22j",    0x000000, 0x20000, CRC(0005bab0) SHA1(257e1b23eea117fe6701a67134b96d9d9fe10caf) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x200000, "rle", 0 )
@@ -694,7 +696,7 @@ ROM_START( roadriota ) // Test mode shows DSP COMM and DSP LINK tests; This is a
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 6502 code */
 	ROM_LOAD( "136089-1047.12c", 0x00000, 0x10000, CRC(849dd26c) SHA1(05a0b2a5f7ee4437448b5f076d3066d96dec2320) )
 
-	ROM_REGION( 0xc0000, "gfx1", 0 )
+	ROM_REGION( 0xc0000, "tiles", 0 )
 	ROM_LOAD( "136089-1041.22d",    0x000000, 0x20000, CRC(b7451f92) SHA1(9fd17913630e457e406e596f2d86afff98787750) ) /* playfield, planes 0-1 */
 	ROM_LOAD( "136089-1038.22c",    0x020000, 0x20000, CRC(90f3c6ee) SHA1(7607509e2d3b2080a918cfaf2879dbed6b79d029) )
 	ROM_LOAD( "136089-1037.2021d",  0x040000, 0x20000, CRC(d40de62b) SHA1(fa6dfd20bdad7874ae33a1027a9bb0ea200f86ca) ) /* playfield, planes 2-3 */
@@ -702,7 +704,7 @@ ROM_START( roadriota ) // Test mode shows DSP COMM and DSP LINK tests; This is a
 	ROM_LOAD( "136089-1040.20d",    0x080000, 0x20000, CRC(a81ae93f) SHA1(b694ba5fab35f8fa505a02039ae62f7af3c7ae1d) ) /* playfield, planes 4-5 */
 	ROM_LOAD( "136089-1042.20c",    0x0a0000, 0x20000, CRC(b8a6d15a) SHA1(43d2be9d40a84b2c01d80bbcac737eda04d55999) )
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136089-1046.22j",    0x000000, 0x20000, CRC(0005bab0) SHA1(257e1b23eea117fe6701a67134b96d9d9fe10caf) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x200000, "rle", 0 )
@@ -754,7 +756,7 @@ ROM_START( roadriotb ) // Test mode shows only COMM RAM test; This is a dedicate
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 6502 code */
 	ROM_LOAD( "136089-1047.12c", 0x00000, 0x10000, CRC(849dd26c) SHA1(05a0b2a5f7ee4437448b5f076d3066d96dec2320) )
 
-	ROM_REGION( 0xc0000, "gfx1", 0 )
+	ROM_REGION( 0xc0000, "tiles", 0 )
 	ROM_LOAD( "136089-1041.22d",    0x000000, 0x20000, CRC(b7451f92) SHA1(9fd17913630e457e406e596f2d86afff98787750) ) /* playfield, planes 0-1 */
 	ROM_LOAD( "136089-1038.22c",    0x020000, 0x20000, CRC(90f3c6ee) SHA1(7607509e2d3b2080a918cfaf2879dbed6b79d029) )
 	ROM_LOAD( "136089-1037.2021d",  0x040000, 0x20000, CRC(d40de62b) SHA1(fa6dfd20bdad7874ae33a1027a9bb0ea200f86ca) ) /* playfield, planes 2-3 */
@@ -762,7 +764,7 @@ ROM_START( roadriotb ) // Test mode shows only COMM RAM test; This is a dedicate
 	ROM_LOAD( "136089-1040.20d",    0x080000, 0x20000, CRC(a81ae93f) SHA1(b694ba5fab35f8fa505a02039ae62f7af3c7ae1d) ) /* playfield, planes 4-5 */
 	ROM_LOAD( "136089-1042.20c",    0x0a0000, 0x20000, CRC(b8a6d15a) SHA1(43d2be9d40a84b2c01d80bbcac737eda04d55999) )
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136089-1046.22j",    0x000000, 0x20000, CRC(0005bab0) SHA1(257e1b23eea117fe6701a67134b96d9d9fe10caf) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x200000, "rle", 0 )
@@ -813,7 +815,7 @@ ROM_START( dangerex )
 	ROM_LOAD( "dx12c-5.12c", 0x10000, 0x4000, CRC(d72621f7) SHA1(4bf5c98dd2434cc6ed1bddb6baf42f41cf138e1a) )
 	ROM_CONTINUE(            0x04000, 0xc000 )
 
-	ROM_REGION( 0xc0000, "gfx1", 0 )
+	ROM_REGION( 0xc0000, "tiles", 0 )
 	ROM_LOAD( "dxc117-22d.22d",    0x000000, 0x20000, CRC(5532995a) SHA1(21e001c911adb91dbe43e895ae8582df65f2995d) ) /* playfield, planes 0-1 */
 	ROM_LOAD( "dx82-22c.22c",      0x020000, 0x20000, CRC(9548599b) SHA1(d08bae8dabce0175f956631ddfbf091653af035e) )
 	ROM_LOAD( "dxc116-20-21d.21d", 0x040000, 0x20000, CRC(ebbf0fd8) SHA1(4ceb026c4231b675215110c16c8f75551cdfa461) ) /* playfield, planes 2-3 */
@@ -821,7 +823,7 @@ ROM_START( dangerex )
 	ROM_LOAD( "dxc115-20d.20d",    0x080000, 0x20000, CRC(2819ce54) SHA1(9a3c041d9046af41997dc1d9f41bf0e1be9489f9) ) /* playfield, planes 4-5 */
 	ROM_LOAD( "dxc80-20c.20c",     0x0a0000, 0x20000, CRC(a8ffe459) SHA1(92a10694c38a4fbe3022662f4e8e4e214aab31c9) )
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "dxc187-22j.22j",   0x000000, 0x20000, CRC(7231ecc2) SHA1(8b1b0aed3a0d907630e120395b0a97fd9a1ef8cc) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x800000, "rle", 0 )
@@ -871,12 +873,12 @@ ROM_START( guardian )
 	ROM_REGION( 0x10000, "jsa:cpu", 0 ) /* 6502 code */
 	ROM_LOAD( "136092-0080-snd.12c", 0x00000, 0x10000, CRC(0388f805) SHA1(49c11313bc4192dbe294cf68b652cb19047889fd) )
 
-	ROM_REGION( 0x180000, "gfx1", 0 )
+	ROM_REGION( 0x180000, "tiles", 0 )
 	ROM_LOAD( "136092-0037a.23e",  0x000000, 0x80000, CRC(ca10b63e) SHA1(243a2a440e1bc9135d3dbe6553d39c54b9bdcd13) ) /* playfield, planes 0-1 */
 	ROM_LOAD( "136092-0038a.22e",  0x080000, 0x80000, CRC(cb1431a1) SHA1(d7b8f49a1e794ca2083e4bf0fa3870ce08caa53a) ) /* playfield, planes 2-3 */
 	ROM_LOAD( "136092-0039a.20e",  0x100000, 0x80000, CRC(2eee7188) SHA1(d3adbd7b20bc898fee35b6ba781e7775f82acd19) ) /* playfield, planes 4-5 */
 
-	ROM_REGION( 0x020000, "gfx2", 0 )
+	ROM_REGION( 0x020000, "chars", 0 )
 	ROM_LOAD( "136092-0030.23k",   0x000000, 0x20000, CRC(0fd7baa1) SHA1(7802d732e5173291628ed498ad0fab71aeef4688) ) /* alphanumerics */
 
 	ROM_REGION16_BE( 0x600000, "rle", 0 )

--- a/src/mame/atari/atarig42.h
+++ b/src/mame/atari/atarig42.h
@@ -45,7 +45,7 @@ protected:
 	TILE_GET_INFO_MEMBER(get_alpha_tile_info);
 	TILE_GET_INFO_MEMBER(get_playfield_tile_info);
 	TILEMAP_MAPPER_MEMBER(atarig42_playfield_scan);
-	uint32_t screen_update_atarig42(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void atarig42(machine_config &config);
 	void main_map(address_map &map) ATTR_COLD;
 
@@ -57,6 +57,8 @@ protected:
 	required_device<asic65_device> m_asic65;
 	optional_device<adc0808_device> m_adc;
 
+	required_shared_ptr<uint16_t> m_mo_command;
+
 	uint16_t          m_playfield_base = 0;
 
 	uint16_t          m_current_control = 0;
@@ -65,12 +67,10 @@ protected:
 	uint16_t          m_playfield_xscroll = 0;
 	uint16_t          m_playfield_yscroll = 0;
 
-	required_shared_ptr<uint16_t> m_mo_command;
-
-	int             m_sloop_bank = 0;
-	int             m_sloop_next_bank = 0;
-	int             m_sloop_offset = 0;
-	int             m_sloop_state = 0;
+	int32_t           m_sloop_bank = 0;
+	int32_t           m_sloop_next_bank = 0;
+	int32_t           m_sloop_offset = 0;
+	int32_t           m_sloop_state = 0;
 	uint16_t *        m_sloop_base = nullptr;
 
 	uint32_t          m_last_accesses[8]{};

--- a/src/mame/atari/atarig42_v.cpp
+++ b/src/mame/atari/atarig42_v.cpp
@@ -35,27 +35,27 @@
 
 TILE_GET_INFO_MEMBER(atarig42_state::get_alpha_tile_info)
 {
-	uint16_t data = m_alpha_tilemap->basemem_read(tile_index);
-	int code = data & 0xfff;
-	int color = (data >> 12) & 0x0f;
-	int opaque = data & 0x8000;
+	uint16_t const data = m_alpha_tilemap->basemem_read(tile_index);
+	int const code = data & 0xfff;
+	int const color = (data >> 12) & 0x0f;
+	bool const opaque = BIT(data, 15);
 	tileinfo.set(1, code, color, opaque ? TILE_FORCE_LAYER0 : 0);
 }
 
 
 TILE_GET_INFO_MEMBER(atarig42_state::get_playfield_tile_info)
 {
-	uint16_t data = m_playfield_tilemap->basemem_read(tile_index);
-	int code = (m_playfield_tile_bank << 12) | (data & 0xfff);
-	int color = (m_playfield_base >> 5) + ((m_playfield_color_bank << 3) & 0x18) + ((data >> 12) & 7);
-	tileinfo.set(0, code, color, (data >> 15) & 1);
+	uint16_t const data = m_playfield_tilemap->basemem_read(tile_index);
+	int const code = (m_playfield_tile_bank << 12) | (data & 0xfff);
+	int const color = (m_playfield_base >> 5) + ((m_playfield_color_bank << 3) & 0x18) + ((data >> 12) & 7);
+	tileinfo.set(0, code, color, BIT(data, 15));
 	tileinfo.category = (m_playfield_color_bank >> 2) & 7;
 }
 
 
 TILEMAP_MAPPER_MEMBER(atarig42_state::atarig42_playfield_scan)
 {
-	int bank = 1 - (col / (num_cols / 2));
+	int const bank = 1 - (col / (num_cols / 2));
 	return bank * (num_rows * num_cols / 2) + row * (num_cols / 2) + (col % (num_cols / 2));
 }
 
@@ -90,7 +90,7 @@ void atarig42_state::video_start()
 
 TIMER_DEVICE_CALLBACK_MEMBER(atarig42_state::scanline_update)
 {
-	int scanline = param;
+	int const scanline = param;
 
 	/* keep in range */
 	int offset = (scanline / 8) * 64 + 48;
@@ -100,13 +100,11 @@ TIMER_DEVICE_CALLBACK_MEMBER(atarig42_state::scanline_update)
 	/* update the playfield scrolls */
 	for (int i = 0; i < 8; i++)
 	{
-		uint16_t word;
-
-		word = m_alpha_tilemap->basemem_read(offset++);
-		if (word & 0x8000)
+		uint16_t word = m_alpha_tilemap->basemem_read(offset++);
+		if (BIT(word, 15))
 		{
-			int newscroll = (word >> 5) & 0x3ff;
-			int newbank = word & 0x1f;
+			int const newscroll = (word >> 5) & 0x3ff;
+			int const newbank = word & 0x1f;
 			if (newscroll != m_playfield_xscroll)
 			{
 				if (scanline + i > 0)
@@ -124,10 +122,10 @@ TIMER_DEVICE_CALLBACK_MEMBER(atarig42_state::scanline_update)
 		}
 
 		word = m_alpha_tilemap->basemem_read(offset++);
-		if (word & 0x8000)
+		if (BIT(word, 15))
 		{
-			int newscroll = ((word >> 6) - (scanline + i)) & 0x1ff;
-			int newbank = word & 7;
+			int const newscroll = ((word >> 6) - (scanline + i)) & 0x1ff;
+			int const newbank = word & 7;
 			if (newscroll != m_playfield_yscroll)
 			{
 				if (scanline + i > 0)
@@ -154,7 +152,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(atarig42_state::scanline_update)
  *
  *************************************/
 
-uint32_t atarig42_state::screen_update_atarig42(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t atarig42_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap_ind8 &priority_bitmap = screen.priority();
 
@@ -187,9 +185,9 @@ uint32_t atarig42_state::screen_update_atarig42(screen_device &screen, bitmap_in
 				if (mo[x])
 				{
 					int const pfpri = pri[x];
-					int const mopri = mo[x] >> ATARIRLE_PRIORITY_SHIFT;
+					int const mopri = mo[x] >> atari_rle_objects_device::PRIORITY_SHIFT;
 					if (mopri >= pfpri)
-						pf[x] = mo[x] & ATARIRLE_DATA_MASK;
+						pf[x] = mo[x] & atari_rle_objects_device::DATA_MASK;
 				}
 		}
 	}

--- a/src/mame/atari/atarigt.h
+++ b/src/mame/atari/atarigt.h
@@ -14,11 +14,6 @@
 #include "emupal.h"
 #include "tilemap.h"
 
-#define CRAM_ENTRIES        0x4000
-#define TRAM_ENTRIES        0x4000
-#define MRAM_ENTRIES        0x8000
-
-#define ADDRSEQ_COUNT   4
 
 class atarigt_state : public atarigen_state
 {
@@ -31,11 +26,11 @@ public:
 		m_playfield_tilemap(*this, "playfield"),
 		m_alpha_tilemap(*this, "alpha"),
 		m_rle(*this, "rle"),
+		m_mo_command(*this, "mo_command"),
+		m_cage(*this, "cage"),
 		m_service_io(*this, "SERVICE"),
 		m_coin_io(*this, "COIN"),
-		m_fake_io(*this, "FAKE"),
-		m_mo_command(*this, "mo_command"),
-		m_cage(*this, "cage")
+		m_fake_io(*this, "FAKE")
 	{ }
 
 	void atarigt(machine_config &config);
@@ -52,8 +47,8 @@ protected:
 	virtual void video_start() override ATTR_COLD;
 
 private:
+	static const unsigned ADDRSEQ_COUNT = 4;
 
-	bool           m_is_primrage = false;
 	required_device<palette_device> m_palette;
 	memory_share_creator<uint16_t> m_colorram;
 
@@ -63,9 +58,14 @@ private:
 	required_device<tilemap_device> m_alpha_tilemap;
 	required_device<atari_rle_objects_device> m_rle;
 
+	required_shared_ptr<uint32_t> m_mo_command;
+	required_device<atari_cage_device> m_cage;
+
 	optional_ioport m_service_io;
 	optional_ioport m_coin_io;
 	optional_ioport m_fake_io;
+
+	bool            m_is_primrage = false;
 
 	bool            m_scanline_int_state = false;
 	bool            m_video_int_state = false;
@@ -79,9 +79,6 @@ private:
 	uint16_t          m_playfield_yscroll = 0;
 
 	uint32_t          m_tram_checksum = 0;
-
-	required_shared_ptr<uint32_t> m_mo_command;
-	required_device<atari_cage_device> m_cage;
 
 	void            (atarigt_state::*m_protection_w)(address_space &space, offs_t offset, uint16_t data);
 	void            (atarigt_state::*m_protection_r)(address_space &space, offs_t offset, uint16_t *data);
@@ -117,7 +114,7 @@ private:
 	TILE_GET_INFO_MEMBER(get_alpha_tile_info);
 	TILE_GET_INFO_MEMBER(get_playfield_tile_info);
 	TILEMAP_MAPPER_MEMBER(playfield_scan);
-	uint32_t screen_update_atarigt(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void main_map(address_map &map) ATTR_COLD;
 
 	void tmek_update_mode(offs_t offset);

--- a/src/mame/atari/atarigt.h
+++ b/src/mame/atari/atarigt.h
@@ -33,21 +33,21 @@ public:
 		m_fake_io(*this, "FAKE")
 	{ }
 
-	void atarigt(machine_config &config);
-	void atarigt_stereo(machine_config &config);
-	void tmek(machine_config &config);
-	void primrage20(machine_config &config);
-	void primrage(machine_config &config);
+	void atarigt(machine_config &config) ATTR_COLD;
+	void atarigt_stereo(machine_config &config) ATTR_COLD;
+	void tmek(machine_config &config) ATTR_COLD;
+	void primrage20(machine_config &config) ATTR_COLD;
+	void primrage(machine_config &config) ATTR_COLD;
 
-	void init_primrage();
-	void init_tmek();
+	void init_primrage() ATTR_COLD;
+	void init_tmek() ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void video_start() override ATTR_COLD;
 
 private:
-	static const unsigned ADDRSEQ_COUNT = 4;
+	static inline constexpr unsigned ADDRSEQ_COUNT = 4;
 
 	required_device<palette_device> m_palette;
 	memory_share_creator<uint16_t> m_colorram;
@@ -73,21 +73,21 @@ private:
 	bitmap_ind16    m_pf_bitmap;
 	bitmap_ind16    m_an_bitmap;
 
-	uint8_t           m_playfield_tile_bank = 0;
-	uint8_t           m_playfield_color_bank = 0;
-	uint16_t          m_playfield_xscroll = 0;
-	uint16_t          m_playfield_yscroll = 0;
+	uint8_t         m_playfield_tile_bank = 0;
+	uint8_t         m_playfield_color_bank = 0;
+	uint16_t        m_playfield_xscroll = 0;
+	uint16_t        m_playfield_yscroll = 0;
 
-	uint32_t          m_tram_checksum = 0;
+	uint32_t        m_tram_checksum = 0;
 
 	void            (atarigt_state::*m_protection_w)(address_space &space, offs_t offset, uint16_t data);
 	void            (atarigt_state::*m_protection_r)(address_space &space, offs_t offset, uint16_t *data);
 
 	bool            m_ignore_writes = false;
 	offs_t          m_protaddr[ADDRSEQ_COUNT]{};
-	uint8_t           m_protmode = 0;
-	uint16_t          m_protresult = 0;
-	std::unique_ptr<uint8_t[]> m_protdata;
+	uint8_t         m_protmode = 0;
+	uint16_t        m_protresult = 0;
+	std::unique_ptr<uint8_t []> m_protdata;
 
 	INTERRUPT_GEN_MEMBER(scanline_int_gen);
 	void video_int_write_line(int state);

--- a/src/mame/atari/atarigx2.h
+++ b/src/mame/atari/atarigx2.h
@@ -31,6 +31,8 @@ public:
 		, m_alpha_tilemap(*this, "alpha")
 		, m_rle(*this, "rle")
 		, m_adc(*this, "adc")
+		, m_io_service(*this, "SERVICE")
+		, m_io_special(*this, "SPECIAL")
 	{ }
 
 	void init_spclords();
@@ -54,15 +56,13 @@ protected:
 	TILE_GET_INFO_MEMBER(get_alpha_tile_info);
 	TILE_GET_INFO_MEMBER(get_playfield_tile_info);
 	TILEMAP_MAPPER_MEMBER(atarigx2_playfield_scan);
-	uint32_t screen_update_atarigx2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void atarigx2_mo_control_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 
 	void atarigx2(machine_config &config);
 	void main_map(address_map &map) ATTR_COLD;
 
 private:
-	uint16_t          m_playfield_base = 0U;
-
 	required_device<atari_jsa_iiis_device> m_jsa;
 	optional_device<atari_xga_device> m_xga;
 
@@ -73,6 +73,11 @@ private:
 	required_device<atari_rle_objects_device> m_rle;
 
 	required_device<adc0808_device> m_adc;
+
+	optional_ioport m_io_service;
+	optional_ioport m_io_special;
+
+	uint16_t          m_playfield_base = 0U;
 
 	uint16_t          m_current_control = 0U;
 	uint8_t           m_playfield_tile_bank = 0U;

--- a/src/mame/atari/atarirle.h
+++ b/src/mame/atari/atarirle.h
@@ -51,18 +51,18 @@ class atari_rle_objects_device : public device_t,
 {
 public:
 	// constants
-	static const int PRIORITY_SHIFT     = 12;
-	//static const int BANK_SHIFT         = 15;
-	static const uint16_t PRIORITY_MASK = ((0xffff << PRIORITY_SHIFT) & 0xffff);
-	static const uint16_t DATA_MASK     = (PRIORITY_MASK ^ 0xffff);
+	static inline constexpr int PRIORITY_SHIFT     = 12;
+	//static inline constexpr int BANK_SHIFT         = 15;
+	static inline constexpr uint16_t PRIORITY_MASK = ((0xffff << PRIORITY_SHIFT) & 0xffff);
+	static inline constexpr uint16_t DATA_MASK     = (PRIORITY_MASK ^ 0xffff);
 
-	static const int CONTROL_MOGO       = 1;
-	static const int CONTROL_ERASE      = 2;
-	static const int CONTROL_FRAME      = 4;
+	static inline constexpr int CONTROL_MOGO       = 1;
+	static inline constexpr int CONTROL_ERASE      = 2;
+	static inline constexpr int CONTROL_FRAME      = 4;
 
-	static const int COMMAND_NOP        = 0;
-	static const int COMMAND_DRAW       = 1;
-	static const int COMMAND_CHECKSUM   = 2;
+	static inline constexpr int COMMAND_NOP        = 0;
+	static inline constexpr int COMMAND_DRAW       = 1;
+	static inline constexpr int COMMAND_CHECKSUM   = 2;
 
 	// construction/destruction
 	atari_rle_objects_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, const atari_rle_objects_config &config)
@@ -87,7 +87,7 @@ public:
 	bitmap_ind16 &vram(int idx) { return m_vram[idx][(m_control_bits & CONTROL_FRAME) >> 2]; }
 
 protected:
-	// device-level overrides
+	// device_t implementation
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 

--- a/src/mame/atari/atarirle.h
+++ b/src/mame/atari/atarirle.h
@@ -16,25 +16,6 @@
 
 
 //**************************************************************************
-//  CONSTANTS
-//**************************************************************************
-
-#define ATARIRLE_PRIORITY_SHIFT     12
-#define ATARIRLE_BANK_SHIFT         15
-#define ATARIRLE_PRIORITY_MASK      ((0xffff << ATARIRLE_PRIORITY_SHIFT) & 0xffff)
-#define ATARIRLE_DATA_MASK          (ATARIRLE_PRIORITY_MASK ^ 0xffff)
-
-#define ATARIRLE_CONTROL_MOGO       1
-#define ATARIRLE_CONTROL_ERASE      2
-#define ATARIRLE_CONTROL_FRAME      4
-
-#define ATARIRLE_COMMAND_NOP        0
-#define ATARIRLE_COMMAND_DRAW       1
-#define ATARIRLE_COMMAND_CHECKSUM   2
-
-
-
-//**************************************************************************
 //  TYPES & STRUCTURES
 //**************************************************************************
 
@@ -69,6 +50,20 @@ class atari_rle_objects_device : public device_t,
 									public atari_rle_objects_config
 {
 public:
+	// constants
+	static const int PRIORITY_SHIFT     = 12;
+	//static const int BANK_SHIFT         = 15;
+	static const uint16_t PRIORITY_MASK = ((0xffff << PRIORITY_SHIFT) & 0xffff);
+	static const uint16_t DATA_MASK     = (PRIORITY_MASK ^ 0xffff);
+
+	static const int CONTROL_MOGO       = 1;
+	static const int CONTROL_ERASE      = 2;
+	static const int CONTROL_FRAME      = 4;
+
+	static const int COMMAND_NOP        = 0;
+	static const int COMMAND_DRAW       = 1;
+	static const int COMMAND_CHECKSUM   = 2;
+
 	// construction/destruction
 	atari_rle_objects_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, const atari_rle_objects_config &config)
 		: atari_rle_objects_device(mconfig, tag, owner, clock)
@@ -89,7 +84,7 @@ public:
 	void vblank_callback(screen_device &screen, bool state);
 
 	// getters
-	bitmap_ind16 &vram(int idx) { return m_vram[idx][(m_control_bits & ATARIRLE_CONTROL_FRAME) >> 2]; }
+	bitmap_ind16 &vram(int idx) { return m_vram[idx][(m_control_bits & CONTROL_FRAME) >> 2]; }
 
 protected:
 	// device-level overrides
@@ -138,6 +133,9 @@ private:
 	void draw_rle_zoom_hflip(bitmap_ind16 &bitmap, const rectangle &clip, const object_info &info, u32 palette, int sx, int sy, int scalex, int scaley);
 	void hilite_object(bitmap_ind16 &bitmap, int hilite);
 
+	required_region_ptr<u16> m_rombase;    // pointer to the base of the GFX ROM
+	memory_array     m_ram;
+
 	// derived state
 	int             m_bitmapwidth = 0;        // width of the full playfield bitmap
 	int             m_bitmapheight = 0;       // height of the full playfield bitmap
@@ -157,19 +155,17 @@ private:
 	sprite_parameter    m_vrammask;           // mask for the VRAM target
 
 	// ROM information
-	required_region_ptr<u16> m_rombase;    // pointer to the base of the GFX ROM
 	int                 m_objectcount = 0;        // number of objects in the ROM
 	std::vector<object_info> m_info;               // list of info records
 
 	// rendering state
 	bitmap_ind16     m_vram[2][2];         // pointers to VRAM bitmaps and backbuffers
-	int              m_partial_scanline = 0;   // partial update scanline
+	s32              m_partial_scanline = 0;   // partial update scanline
 
 	// control state
 	u8               m_control_bits = 0;       // current control bits
 	u8               m_command = 0;            // current command
 	u16              m_checksums[256];     // checksums for each 0x40000 bytes
-	memory_array     m_ram;
 
 	// tables
 	u8               m_rle_bpp[8];


### PR DESCRIPTION
- Reduce preprocessor defines
- Make some variables constant
- Fix save states
- Fix naming
- Fix spacing
- Reduce literal tag usages
- Suppress side effects for debugger read
atari/atarigx2.cpp:
- Reduce runtime tag lookups