### PR TITLE
minitel2: fix modem and periinfo default configurations

### DIFF
--- a/src/mame/philips/minitel_2_rpic.cpp
+++ b/src/mame/philips/minitel_2_rpic.cpp
@@ -22,11 +22,7 @@
     - Keyboard
     - 24C02 EPROM
     - Modem serial interface.
-
-    What is implemented but not working :
-
-    - The rear serial port.(Prise péri-informatique)
-     (Internal 8051 serial port emulation missing).
+    - The rear serial port (prise péri-informatique).
 
     What is not yet implemented :
 
@@ -55,6 +51,10 @@
     Example : Command line options to use to create a TCP socket linked to
     the modem port : "-modem null_modem -bitb socket.127.0.0.1:20000"
     Once mame started you can then send vdt files with netcat to this socket.
+
+    Example 2 : Connecting the modem and periinfo ports to different TCP
+    sockets : "-modem null_modem -bitb1 socket.127.0.0.1:20000
+               -periinfo null_modem -bitb2 socket.127.0.0.1:20001"
 
 ****************************************************************************/
 
@@ -511,10 +511,10 @@ static DEVICE_INPUT_DEFAULTS_START( m_modem )
 DEVICE_INPUT_DEFAULTS_END
 
 static DEVICE_INPUT_DEFAULTS_START( m_serport )
-	DEVICE_INPUT_DEFAULTS( "RS232_TXBAUD", 0xff, RS232_BAUD_9600 )
-	DEVICE_INPUT_DEFAULTS( "RS232_RXBAUD", 0xff, RS232_BAUD_9600 )
-	DEVICE_INPUT_DEFAULTS( "RS232_DATABITS", 0xff, RS232_DATABITS_8 )
-	DEVICE_INPUT_DEFAULTS( "RS232_PARITY", 0xff, RS232_PARITY_NONE )
+	DEVICE_INPUT_DEFAULTS( "RS232_TXBAUD", 0xff, RS232_BAUD_1200 )
+	DEVICE_INPUT_DEFAULTS( "RS232_RXBAUD", 0xff, RS232_BAUD_1200 )
+	DEVICE_INPUT_DEFAULTS( "RS232_DATABITS", 0xff, RS232_DATABITS_7 )
+	DEVICE_INPUT_DEFAULTS( "RS232_PARITY", 0xff, RS232_PARITY_EVEN )
 	DEVICE_INPUT_DEFAULTS( "RS232_STOPBITS", 0xff, RS232_STOPBITS_1 )
 DEVICE_INPUT_DEFAULTS_END
 
@@ -538,11 +538,11 @@ void minitel_state::minitel2(machine_config &config)
 
 	RS232_PORT(config, m_modem, default_rs232_devices, nullptr);
 	m_modem->rxd_handler().set_inputline(m_maincpu, MCS51_INT1_LINE).invert();
-	m_modem->set_option_device_input_defaults("terminal", DEVICE_INPUT_DEFAULTS_NAME(m_modem));
+	m_modem->set_option_device_input_defaults("null_modem", DEVICE_INPUT_DEFAULTS_NAME(m_modem));
 
 	RS232_PORT(config, m_serport, default_rs232_devices, nullptr);
 	m_serport->rxd_handler().set(FUNC(minitel_state::serial_rxd));
-	m_serport->set_option_device_input_defaults("terminal", DEVICE_INPUT_DEFAULTS_NAME(m_serport));
+	m_serport->set_option_device_input_defaults("null_modem", DEVICE_INPUT_DEFAULTS_NAME(m_serport));
 
 	lineconnected = 0;
 

--- a/src/mame/philips/minitel_2_rpic.cpp
+++ b/src/mame/philips/minitel_2_rpic.cpp
@@ -539,10 +539,12 @@ void minitel_state::minitel2(machine_config &config)
 	RS232_PORT(config, m_modem, default_rs232_devices, nullptr);
 	m_modem->rxd_handler().set_inputline(m_maincpu, MCS51_INT1_LINE).invert();
 	m_modem->set_option_device_input_defaults("null_modem", DEVICE_INPUT_DEFAULTS_NAME(m_modem));
+	m_modem->set_option_device_input_defaults("terminal", DEVICE_INPUT_DEFAULTS_NAME(m_modem));
 
 	RS232_PORT(config, m_serport, default_rs232_devices, nullptr);
 	m_serport->rxd_handler().set(FUNC(minitel_state::serial_rxd));
 	m_serport->set_option_device_input_defaults("null_modem", DEVICE_INPUT_DEFAULTS_NAME(m_serport));
+	m_serport->set_option_device_input_defaults("terminal", DEVICE_INPUT_DEFAULTS_NAME(m_serport));
 
 	lineconnected = 0;
 


### PR DESCRIPTION
I've tested the command line given at the top of the `minitel_2_rpic.cpp` file (`-modem null_modem -bitb socket.127.0.0.1:20000`) and it didn't work (transferred data was corrupted), because the correct serial parameters are set for `terminal`. This commit makes them apply to `null_modem` instead, so that the documented command line actually works.

While at it, I've also changed the parameters for the second serial port (`periinfo`) to match the Minitel's defaults and verified that it actually works, despite the comment at the top of the file stating the opposite.

These are all the test command lines I've successfully validated, to test that the two Minitel serial ports (`modem` and `periinfo`) work, both in isolation and together. I've used [minipavi.fr](http://minipavi.fr) as the test service to connect to.

### Test n.1: Connecting to a Minitel service through the modem port
Run in two different terminals:
* `socat tcp-listen:20000,fork system:'"set -x; IFS= read -d S; echo -n \"Connecting...\"; exec nc go.minipavi.fr 516"'`
* `./mame -window minitel2 -modem null_modem -bitb socket.127.0.0.1:20000`

Then power on the Minitel (F10) and start the connection (F8).
**Notes:**
* `IFS= read -d S`: waits for the `Connexion ou déconnexion modem` message (`"\x13S"`), emitted when the emulated Minitel modem pretends to start detecting the carrier frequency.

### Test n.2: Connecting to a Minitel service through the serial port
Run in two different terminals:
* `socat tcp-listen:20000,fork system:'"set -x; IFS= read -d r; IFS= read -d r; sleep 3; echo -en \"\\e\\x39\\x68\"; sleep 3; echo -en \"\\e\\x39\\x67\\e\\x3b\\x60\\x58\\x52Connecting...\"; exec nc go.minipavi.fr 516"'`
* `./mame -window minitel2 -periinfo null_modem -bitb socket.127.0.0.1:20000`

Then just power on the Minitel (F10), the socat command above will do the rest to put the Minitel in the right mode and start the connection.
**Notes:**
* `IFS= read -d r` (twice) : wait for the second `Passage en veille ou sortie de veille` message (`"\x13r"`, emitted by the Minitel when powered on)
* `\e\x39\x68` (called `PRO1 CONNEXION` in the manual): tells the Minitel to connect the `modem` port.
* `\e\x39\x67` (called `PRO1 DECONNEXION` in the manual):  tells the Minitel to disconnect the `modem` port.
* We don't actually use the `modem` port at all, we just send `PRO1 CONNEXION` followed by `PRO1 DECONNEXION` to make it leave the initial address book screen and enter the mode that displays incoming data.
* `\e\x3b\x60\x58\x52` -> `PRO3 OFF` to disable local echo

### Test n.3: Both ports at the same time
Run in three different terminals:
* `socat tcp-listen:20000,fork stdio`
* `socat tcp-listen:20001,fork stdio`
* `./mame -window minitel2 -modem null_modem -bitb1 socket.127.0.0.1:20000 -periinfo null_modem -bitb2 socket.127.0.0.1:20001`

Then power on the Minitel (F10), start the connection (F8) and notice how everything typed into one port is echoed on the other one, like on a real Minitel.