### PR TITLE
sound/dac76.h: Documenting equivalence to AM6070. Fixing pin locations.

### DIFF
--- a/src/devices/sound/dac76.h
+++ b/src/devices/sound/dac76.h
@@ -6,16 +6,19 @@
 
     Companding D/A Converter
 
+    Equivalent to the AM6070, which is an "improved pin-for-pin replacement for
+    DAC-76" (according to the AM6070 datasheet).
+
               ___ ___
-      E/D  1 |*  u   | 10  VLC
-       SB  2 |       | 11  VR+
-       B1  3 |       | 12  VR-
-       B2  4 |       | 13  V-
+      E/D  1 |*  u   | 18  V+
+       SB  2 |       | 17  IOD-
+       B1  3 |       | 16  IOD+
+       B2  4 |       | 15  IOE-
        B3  5 |       | 14  IOE+
-       B4  6 |       | 15  IOE-
-       B5  7 |       | 16  IOD+
-       B6  8 |       | 17  IOD-
-       B7  9 |_______| 18  V+
+       B4  6 |       | 13  V-
+       B5  7 |       | 12  VR-
+       B6  8 |       | 11  VR+
+       B7  9 |_______| 10  VLC
 
 ***************************************************************************/
 


### PR DESCRIPTION
AM6070 is the DAC being used in the DMX.

**Questions**

1) Is documentation of the component compatibility enough? Or is the preference to add a `class am6070_device` and `DECLARE_DEVICE_TYPE(AM6070, am6070_device)` ?

2) @startaq, just out of curiosity, is the `* 8` below done to improve or avoid aliasing? Or is there some other reason?
https://github.com/mamedev/mame/blob/82466846f81f93244ee2188c06bae8f45a2e6dd0/src/devices/sound/dac76.cpp#L51-L54