### PR TITLE
nmk/nmk004.cpp, nmk/nmk16.cpp: Cleanups/Updates

### DIFF
--- a/src/mame/nmk/nmk004.cpp
+++ b/src/mame/nmk/nmk004.cpp
@@ -33,16 +33,33 @@ void nmk004_device::port4_w(uint8_t data)
 	m_reset_cb(BIT(data, 0) ? ASSERT_LINE : CLEAR_LINE);
 }
 
-void nmk004_device::oki0_bankswitch_w(uint8_t data)
+uint8_t nmk004_device::ym_r(offs_t offset)
 {
-	data &= 3;
-	membank(":okibank1")->set_entry(data);
+	return m_ym_read_cb(offset);
 }
 
-void nmk004_device::oki1_bankswitch_w(uint8_t data)
+void nmk004_device::ym_w(offs_t offset, uint8_t data)
+{
+	m_ym_write_cb(offset, data);
+}
+
+template <unsigned Which>
+uint8_t nmk004_device::oki_r()
+{
+	return m_oki_read_cb[Which]();
+}
+
+template <unsigned Which>
+void nmk004_device::oki_w(uint8_t data)
+{
+	m_oki_write_cb[Which](data);
+}
+
+template <unsigned Which>
+void nmk004_device::oki_bankswitch_w(uint8_t data)
 {
 	data &= 3;
-	membank(":okibank2")->set_entry(data);
+	m_okibank[Which]->set_entry(data);
 }
 
 uint8_t nmk004_device::tonmk004_r()
@@ -63,18 +80,18 @@ void nmk004_device::ym2203_irq_handler(int irq)
 	m_cpu->set_input_line(0, irq ? ASSERT_LINE : CLEAR_LINE);
 }
 
-void nmk004_device::nmk004_sound_mem_map(address_map &map)
+void nmk004_device::mem_map(address_map &map)
 {
 	//map(0x0000, 0x1fff).rom(); /* 0x0000 - 0x1fff = internal ROM */
-	map(0x2000, 0xefff).rom().region(":audiocpu", 0x2000);
+	map(0x2000, 0xefff).rom().region(DEVICE_SELF, 0x2000);
 	map(0xf000, 0xf7ff).ram();
-	map(0xf800, 0xf801).rw(":ymsnd", FUNC(ym2203_device::read), FUNC(ym2203_device::write));
-	map(0xf900, 0xf900).rw(":oki1", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0xfa00, 0xfa00).rw(":oki2", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
+	map(0xf800, 0xf801).rw(FUNC(nmk004_device::ym_r), FUNC(nmk004_device::ym_w));
+	map(0xf900, 0xf900).rw(FUNC(nmk004_device::oki_r<0>), FUNC(nmk004_device::oki_w<0>));
+	map(0xfa00, 0xfa00).rw(FUNC(nmk004_device::oki_r<1>), FUNC(nmk004_device::oki_w<1>));
 	map(0xfb00, 0xfb00).r(FUNC(nmk004_device::tonmk004_r));    // from main cpu
 	map(0xfc00, 0xfc00).w(FUNC(nmk004_device::tomain_w));  // to main cpu
-	map(0xfc01, 0xfc01).w(FUNC(nmk004_device::oki0_bankswitch_w));
-	map(0xfc02, 0xfc02).w(FUNC(nmk004_device::oki1_bankswitch_w));
+	map(0xfc01, 0xfc01).w(FUNC(nmk004_device::oki_bankswitch_w<0>));
+	map(0xfc02, 0xfc02).w(FUNC(nmk004_device::oki_bankswitch_w<1>));
 }
 
 
@@ -87,11 +104,17 @@ ROM_END
 DEFINE_DEVICE_TYPE(NMK004, nmk004_device, "nmk004", "NMK004")
 
 nmk004_device::nmk004_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: device_t(mconfig, NMK004, tag, owner, clock),
-	m_cpu(*this, "mcu"),
-	m_reset_cb(*this),
-	to_nmk004(0xff),
-	to_main(0xff)
+	: device_t(mconfig, NMK004, tag, owner, clock)
+	, m_cpu(*this, "mcu")
+	, m_okirom(*this, {finder_base::DUMMY_TAG, finder_base::DUMMY_TAG})
+	, m_okibank(*this, {finder_base::DUMMY_TAG, finder_base::DUMMY_TAG})
+	, m_reset_cb(*this)
+	, m_ym_read_cb(*this, 0)
+	, m_ym_write_cb(*this)
+	, m_oki_read_cb{{*this, 0}, {*this, 0}}
+	, m_oki_write_cb{{*this}, {*this}}
+	, to_nmk004(0xff)
+	, to_main(0xff)
 {
 }
 
@@ -104,8 +127,10 @@ void nmk004_device::device_start()
 	save_item(NAME(to_main));
 	save_item(NAME(to_nmk004));
 
-	membank(":okibank1")->configure_entries(0, 4, memregion(":oki1")->base() + 0x20000, 0x20000);
-	membank(":okibank2")->configure_entries(0, 4, memregion(":oki2")->base() + 0x20000, 0x20000);
+	for (int i = 0; i < 2; i++)
+	{
+		m_okibank[i]->configure_entries(0, 4, m_okirom[i] + 0x20000, 0x20000);
+	}
 }
 
 //-------------------------------------------------
@@ -114,7 +139,7 @@ void nmk004_device::device_start()
 void nmk004_device::device_add_mconfig(machine_config &config)
 {
 	TMP90840(config, m_cpu, DERIVED_CLOCK(1,1)); // Toshiba TMP90C840AF in QFP64 package with 8Kbyte internal ROM
-	m_cpu->set_addrmap(AS_PROGRAM, &nmk004_device::nmk004_sound_mem_map);
+	m_cpu->set_addrmap(AS_PROGRAM, &nmk004_device::mem_map);
 	m_cpu->port_write<4>().set(FUNC(nmk004_device::port4_w));
 }
 
@@ -124,5 +149,5 @@ void nmk004_device::device_add_mconfig(machine_config &config)
 //-------------------------------------------------
 const tiny_rom_entry *nmk004_device::device_rom_region() const
 {
-	return ROM_NAME(nmk004 );
+	return ROM_NAME(nmk004);
 }

--- a/src/mame/nmk/nmk004.h
+++ b/src/mame/nmk/nmk004.h
@@ -18,17 +18,30 @@ class nmk004_device : public device_t
 public:
 	nmk004_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
+	// configuration
 	auto reset_cb() { return m_reset_cb.bind(); }
+	template <typename T, typename U> void set_rom_tag(T &&tag1, U &&tag2)
+	{
+		m_okirom[0].set_tag(std::forward<T>(tag1));
+		m_okirom[1].set_tag(std::forward<U>(tag2));
+	}
+	template <typename T, typename U> void set_rombank_tag(T &&tag1, U &&tag2)
+	{
+		m_okibank[0].set_tag(std::forward<T>(tag1));
+		m_okibank[1].set_tag(std::forward<U>(tag2));
+	}
+	auto ym_read_callback() { return m_ym_read_cb.bind(); }
+	auto ym_write_callback() { return m_ym_write_cb.bind(); }
+	template <unsigned Which> auto oki_read_callback() { return m_oki_read_cb[Which].bind(); }
+	template <unsigned Which> auto oki_write_callback() { return m_oki_write_cb[Which].bind(); }
 
 	// host interface
 	void write(uint8_t data);
 	uint8_t read();
 	void nmi_w(int state) { m_cpu->set_input_line(INPUT_LINE_NMI, state); }
 
-	void port4_w(uint8_t data);
 	void ym2203_irq_handler(int irq);
 
-	void nmk004_sound_mem_map(address_map &map) ATTR_COLD;
 protected:
 	// device-level overrides
 	virtual void device_start() override ATTR_COLD;
@@ -37,16 +50,29 @@ protected:
 
 private:
 	// internal state
-	required_device<tlcs90_device>  m_cpu;
-	devcb_write_line                m_reset_cb;
+	required_device<tlcs90_device> m_cpu;
+	required_region_ptr_array<uint8_t, 2> m_okirom;
+	required_memory_bank_array<2> m_okibank;
+	devcb_write_line m_reset_cb;
+	devcb_read8 m_ym_read_cb;
+	devcb_write8 m_ym_write_cb;
+	devcb_read8 m_oki_read_cb[2];
+	devcb_write8 m_oki_write_cb[2];
 
 	uint8_t to_nmk004;
 	uint8_t to_main;
 
-	void oki0_bankswitch_w(uint8_t data);
-	void oki1_bankswitch_w(uint8_t data);
+	template <unsigned Which> void oki_bankswitch_w(uint8_t data);
+	uint8_t ym_r(offs_t offset);
+	void ym_w(offs_t offset, uint8_t data);
+	template <unsigned Which> uint8_t oki_r();
+	template <unsigned Which> void oki_w(uint8_t data);
 	uint8_t tonmk004_r();
 	void tomain_w(uint8_t data);
+
+	void port4_w(uint8_t data);
+
+	void mem_map(address_map &map) ATTR_COLD;
 };
 
 DECLARE_DEVICE_TYPE(NMK004, nmk004_device)

--- a/src/mame/nmk/nmk16.cpp
+++ b/src/mame/nmk/nmk16.cpp
@@ -331,7 +331,7 @@ u8 nmk16_state::powerins_bootleg_fake_ym2203_r()
 ***************************************************************************/
 void nmk16_state::tharrier_mcu_control_w(u16 data)
 {
-//  LOG("%04x: mcu_control_w %02x\n",m_maincpu->pc(),data);
+//  LOG("%06x: mcu_control_w %02x\n", m_maincpu->pc(), data);
 }
 
 u16 nmk16_state::tharrier_mcu_r(offs_t offset, u16 mem_mask)
@@ -347,13 +347,17 @@ u16 nmk16_state::tharrier_mcu_r(offs_t offset, u16 mem_mask)
 
 		int res;
 
-		if (m_maincpu->pc()==0x8aa) res = (m_mainram[0x9064/2])|0x20; // Task Force Harrier
-		else if (m_maincpu->pc()==0x8ce) res = (m_mainram[0x9064/2])|0x60; // Task Force Harrier
+		if (m_maincpu->pc() == 0x8aa) res = (m_mainram[0x9064/2]) | 0x20; // Task Force Harrier
+		else if (m_maincpu->pc() == 0x8ce) res = (m_mainram[0x9064/2]) | 0x60; // Task Force Harrier
 		else
 		{
-			res = to_main[m_prot_count++];
-			if (m_prot_count == sizeof(to_main))
-				m_prot_count = 0;
+			res = to_main[m_prot_count];
+			if (!machine().side_effects_disabled())
+			{
+				m_prot_count++;
+				if (m_prot_count == sizeof(to_main))
+					m_prot_count = 0;
+			}
 		}
 
 		return res << 8;
@@ -440,7 +444,7 @@ void tharrierb_state::mcu_portc_w(u8 data)
 
 u8 tharrierb_state::mcu_portd_r()
 {
-	u8 select = m_mcu_portc & 0x07;
+	const u8 select = m_mcu_portc & 0x07;
 
 	if (select < 5)
 		return m_inputs[select]->read();
@@ -474,15 +478,15 @@ void nmk16_state::scroll_w(offs_t offset, u8 data)
 {
 	m_scroll[Layer][offset] = data;
 
-	if (offset & 2)
+	if (BIT(offset, 1))
 	{
-		m_bg_tilemap[Layer]->set_scrolly(0,((m_scroll[Layer][2] << 8) | m_scroll[Layer][3]));
+		m_bg_tilemap[Layer]->set_scrolly(0, ((m_scroll[Layer][2] << 8) | m_scroll[Layer][3]));
 	}
 	else
 	{
 		if ((m_bgvideoram[Layer].bytes() > 0x4000) && (offset == 0))
 		{
-			int newbank = (m_scroll[Layer][0] >> 4) & ((m_bgvideoram[Layer].bytes() >> 14) - 1);
+			const int newbank = (m_scroll[Layer][0] >> 4) & ((m_bgvideoram[Layer].bytes() >> 14) - 1);
 			if (m_tilerambank != newbank)
 			{
 				m_tilerambank = newbank;
@@ -491,7 +495,7 @@ void nmk16_state::scroll_w(offs_t offset, u8 data)
 
 			}
 		}
-		m_bg_tilemap[Layer]->set_scrollx(0,(m_scroll[Layer][0] << 8) | m_scroll[Layer][1]);
+		m_bg_tilemap[Layer]->set_scrollx(0, (m_scroll[Layer][0] << 8) | m_scroll[Layer][1]);
 	}
 }
 
@@ -512,10 +516,10 @@ void nmk16_state::vandyke_map(address_map &map)
 	map(0x08001f, 0x08001f).w(m_nmk004, FUNC(nmk004_device::write));
 	map(0x088000, 0x0887ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x08c000, 0x08c007).w(FUNC(nmk16_state::vandyke_scroll_w));
-	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
+	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
 	map(0x094000, 0x097fff).ram(); // what is this?
-	map(0x09d000, 0x09d7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share("mainram");
+	map(0x09d000, 0x09d7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share(m_mainram);
 }
 
 void nmk16_state::vandykeb_map(address_map &map)
@@ -533,10 +537,10 @@ void nmk16_state::vandykeb_map(address_map &map)
 //  map(0x08001f, 0x08001f).w(m_nmk004, FUNC(nmk004_device::write));
 	map(0x088000, 0x0887ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x08c000, 0x08c007).nopw();    // just in case...
-	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
+	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
 	map(0x094000, 0x097fff).ram(); // what is this?
-	map(0x09d000, 0x09d7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share("mainram");
+	map(0x09d000, 0x09d7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share(m_mainram);
 }
 
 void nmk16_state::manybloc_map(address_map &map)
@@ -551,10 +555,10 @@ void nmk16_state::manybloc_map(address_map &map)
 	map(0x08001c, 0x08001d).nopw();            // See notes at the top of the driver
 	map(0x08001f, 0x08001f).r("soundlatch2", FUNC(generic_latch_8_device::read)).w(m_soundlatch, FUNC(generic_latch_8_device::write)).umask16(0x00ff);
 	map(0x088000, 0x0883ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x09c000, 0x09cfff).ram().w(FUNC(nmk16_state::manybloc_scroll_w)).share("scrollram");
-	map(0x09d000, 0x09d7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0x0f0000, 0x0fffff).ram().share("mainram");
+	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x09c000, 0x09cfff).ram().w(FUNC(nmk16_state::manybloc_scroll_w)).share(m_gunnail_scrollram);
+	map(0x09d000, 0x09d7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0x0f0000, 0x0fffff).ram().share(m_mainram);
 }
 
 void nmk16_tomagic_state::tomagic_map(address_map &map)
@@ -568,19 +572,19 @@ void nmk16_tomagic_state::tomagic_map(address_map &map)
 	map(0x080018, 0x080019).w(FUNC(nmk16_tomagic_state::tilebank_w));
 	map(0x08001f, 0x08001f).w(m_soundlatch, FUNC(generic_latch_8_device::write));
 	map(0x088000, 0x0887ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x08c000, 0x08c1ff).writeonly().share("scrollram");
-	map(0x08c200, 0x08c3ff).writeonly().share("scrollramy");
-	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_tomagic_state::bgvideoram_w<0>)).share("bgvideoram0");
+	map(0x08c000, 0x08c1ff).writeonly().share(m_gunnail_scrollram);
+	map(0x08c200, 0x08c3ff).writeonly().share(m_gunnail_scrollramy);
+	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_tomagic_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
 	map(0x094001, 0x094001).w(m_oki[0], FUNC(okim6295_device::write));
 	map(0x094003, 0x094003).r(m_oki[0], FUNC(okim6295_device::read));
-	map(0x09c000, 0x09cfff).mirror(0x001000).ram().w(FUNC(nmk16_tomagic_state::txvideoram_w)).share("txvideoram");
-	map(0x0f0000, 0x0fffff).ram().share("mainram");
+	map(0x09c000, 0x09cfff).mirror(0x001000).ram().w(FUNC(nmk16_tomagic_state::txvideoram_w)).share(m_txvideoram);
+	map(0x0f0000, 0x0fffff).ram().share(m_mainram);
 }
 
 void nmk16_tomagic_state::tomagic_sound_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom().region("audiocpu", 0);
-	map(0x8000, 0xbfff).bankr("audiobank");
+	map(0x8000, 0xbfff).bankr(m_audiobank);
 	map(0xc000, 0xdfff).ram();
 }
 
@@ -603,14 +607,15 @@ void nmk16_state::tharrier_map(address_map &map)
 	map(0x080012, 0x080013).nopw();
 //  map(0x080015, 0x080015).w(FUNC(nmk16_state::flipscreen_w));
 //  map(0x080019, 0x080019).w(FUNC(nmk16_state::tilebank_w));
+//  map(0x08001c, 0x08001d) sound reset
 	map(0x08001f, 0x08001f).w(m_soundlatch, FUNC(generic_latch_8_device::write));
 	map(0x080202, 0x080203).portr("IN2");
 	map(0x088000, 0x0883ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 //  map(0x08c000, 0x08c007).w(FUNC(nmk16_state::scroll_w<0>)).umask16(0x00ff);
-	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
+	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
 	map(0x09c000, 0x09c7ff).ram(); // Unused txvideoram area?
-	map(0x09d000, 0x09d7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share("mainram");
+	map(0x09d000, 0x09d7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share(m_mainram);
 }
 
 void tharrierb_state::tharrierb_map(address_map &map)
@@ -625,11 +630,11 @@ void tharrierb_state::tharrierb_map(address_map &map)
 	map(0x08001c, 0x08001d).unmaprw(); // sound cpu reset
 	map(0x08001f, 0x08001f).w(m_soundlatch, FUNC(generic_latch_8_device::write));
 	map(0x088000, 0x0883ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x090000, 0x093fff).ram().w(FUNC(tharrierb_state::bgvideoram_w<0>)).share("bgvideoram0");
+	map(0x090000, 0x093fff).ram().w(FUNC(tharrierb_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
 	map(0x09c000, 0x09cfff).ram(); // verified in test mode
-	map(0x09d000, 0x09d7ff).ram().w(FUNC(tharrierb_state::txvideoram_w)).share("txvideoram");
+	map(0x09d000, 0x09d7ff).ram().w(FUNC(tharrierb_state::txvideoram_w)).share(m_txvideoram);
 	map(0x09d800, 0x09dfff).ram(); // verified in test mode
-	map(0x0f0000, 0x0fffff).ram().w(FUNC(tharrierb_state::mainram_strange_w)).share("mainram");
+	map(0x0f0000, 0x0fffff).ram().w(FUNC(tharrierb_state::mainram_strange_w)).share(m_mainram);
 }
 
 void nmk16_state::tharrier_sound_map(address_map &map)
@@ -666,9 +671,9 @@ void nmk16_state::mustang_map(address_map &map)
 	map(0x088000, 0x0887ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x08c000, 0x08c001).w(FUNC(nmk16_state::mustang_scroll_w));
 	map(0x08c002, 0x08c087).nopw();    // ??
-	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x09c000, 0x09c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share("mainram");
+	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x09c000, 0x09c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share(m_mainram);
 }
 
 void nmk16_state::mustangb_map(address_map &map)
@@ -684,9 +689,9 @@ void nmk16_state::mustangb_map(address_map &map)
 	map(0x088000, 0x0887ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x08c000, 0x08c001).w(FUNC(nmk16_state::mustang_scroll_w));
 	map(0x08c002, 0x08c087).nopw();    // ??
-	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x09c000, 0x09c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share("mainram");
+	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x09c000, 0x09c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share(m_mainram);
 }
 
 void nmk16_state::mustangb3_map(address_map &map)
@@ -704,9 +709,9 @@ void nmk16_state::mustangb3_map(address_map &map)
 	map(0x088000, 0x0887ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x08c000, 0x08c001).w(FUNC(nmk16_state::mustang_scroll_w));
 	map(0x08c002, 0x08c087).nopw();
-	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x09c000, 0x09c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share("mainram");
+	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x09c000, 0x09c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share(m_mainram);
 }
 
 void nmk16_state::mustangb3_sound_map(address_map &map)
@@ -731,15 +736,15 @@ void nmk16_state::twinactn_map(address_map &map)
 	map(0x088000, 0x0887ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x08c000, 0x08c001).w(FUNC(nmk16_state::mustang_scroll_w));
 	map(0x08c002, 0x08c087).nopw();    // ??
-	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x09c000, 0x09c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share("mainram");
+	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x09c000, 0x09c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share(m_mainram);
 }
 
 void nmk16_state::acrobatm_map(address_map &map)
 {
 	map(0x00000, 0x3ffff).rom();
-	map(0x80000, 0x8ffff).ram().share("mainram");
+	map(0x80000, 0x8ffff).ram().share(m_mainram);
 	map(0xc0000, 0xc0001).portr("IN0");
 	map(0xc0002, 0xc0003).portr("IN1");
 	map(0xc0008, 0xc0009).portr("DSW1");
@@ -751,14 +756,14 @@ void nmk16_state::acrobatm_map(address_map &map)
 	map(0xc001f, 0xc001f).w(m_nmk004, FUNC(nmk004_device::write));
 	map(0xc4000, 0xc45ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0xc8000, 0xc8007).ram().w(FUNC(nmk16_state::scroll_w<0>)).umask16(0x00ff);
-	map(0xcc000, 0xcffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0xd4000, 0xd47ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
+	map(0xcc000, 0xcffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0xd4000, 0xd47ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
 }
 
 void nmk16_state::acrobatmbl_map(address_map &map)
 {
 	map(0x00000, 0x3ffff).rom();
-	map(0x80000, 0x8ffff).ram().share("mainram");
+	map(0x80000, 0x8ffff).ram().share(m_mainram);
 	map(0xc0000, 0xc0001).portr("IN0");
 	map(0xc0002, 0xc0003).portr("IN1");
 	map(0xc0008, 0xc0009).portr("DSW1");
@@ -768,8 +773,8 @@ void nmk16_state::acrobatmbl_map(address_map &map)
 	map(0xc001e, 0xc001f).w("seibu_sound", FUNC(seibu_sound_device::main_mustb_w));
 	map(0xc4000, 0xc45ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0xc8000, 0xc8007).ram().w(FUNC(nmk16_state::scroll_w<0>)).umask16(0x00ff);
-	map(0xcc000, 0xcffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0xd4000, 0xd47ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
+	map(0xcc000, 0xcffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0xd4000, 0xd47ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
 }
 
 void nmk16_state::bioship_map(address_map &map)
@@ -788,8 +793,8 @@ void nmk16_state::bioship_map(address_map &map)
 	map(0x08c000, 0x08c007).ram().w(FUNC(nmk16_state::scroll_w<1>)).umask16(0xff00);
 	map(0x08c010, 0x08c017).ram().w(FUNC(nmk16_state::scroll_w<0>)).umask16(0xff00);
 	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<1>)).share("bgvideoram1");
-	map(0x09c000, 0x09c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share("mainram");
+	map(0x09c000, 0x09c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share(m_mainram);
 }
 
 void nmk16_state::hachamf_map(address_map &map)
@@ -808,9 +813,9 @@ void nmk16_state::hachamf_map(address_map &map)
 
 	map(0x088000, 0x0887ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x08c000, 0x08c007).w(FUNC(nmk16_state::scroll_w<0>)).umask16(0x00ff);
-	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x09c000, 0x09c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0x0f0000, 0x0fffff).ram().share("mainram"); // Main RAM, inc sprites, shared with MCU
+	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x09c000, 0x09c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0x0f0000, 0x0fffff).ram().share(m_mainram); // Main RAM, inc sprites, shared with MCU
 }
 
 void nmk16_state::tdragon_map(address_map &map)
@@ -818,7 +823,7 @@ void nmk16_state::tdragon_map(address_map &map)
 	map(0x000000, 0x03ffff).rom();
 	map(0x044022, 0x044023).nopr();  // No Idea (ROM mirror? - does this even exist on originals?)
 
-	map(0x080000, 0x08ffff).mirror(0x030000).ram().share("mainram");
+	map(0x080000, 0x08ffff).mirror(0x030000).ram().share(m_mainram);
 
 	map(0x0c0000, 0x0c0001).mirror(0x020000).portr("IN0");
 	map(0x0c0002, 0x0c0003).mirror(0x020000).portr("IN1");
@@ -832,8 +837,8 @@ void nmk16_state::tdragon_map(address_map &map)
 
 	map(0x0c4000, 0x0c4007).ram().w(FUNC(nmk16_state::scroll_w<0>)).umask16(0x00ff);
 	map(0x0c8000, 0x0c87ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x0cc000, 0x0cffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x0d0000, 0x0d07ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
+	map(0x0cc000, 0x0cffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x0d0000, 0x0d07ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
 }
 
 // No sprites without this. Is it actually protection?
@@ -846,7 +851,7 @@ void nmk16_state::tdragonb_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();
 	map(0x044022, 0x044023).r(FUNC(nmk16_state::tdragonb_prot_r));
-	map(0x0b0000, 0x0bffff).ram().share("mainram");
+	map(0x0b0000, 0x0bffff).ram().share(m_mainram);
 	map(0x0c0000, 0x0c0001).portr("IN0");
 	map(0x0c0002, 0x0c0003).portr("IN1");
 	map(0x0c0008, 0x0c0009).portr("DSW1");
@@ -856,8 +861,8 @@ void nmk16_state::tdragonb_map(address_map &map)
 	map(0x0c001e, 0x0c001f).w("seibu_sound", FUNC(seibu_sound_device::main_mustb_w));
 	map(0x0c4000, 0x0c4007).ram().w(FUNC(nmk16_state::scroll_w<0>)).umask16(0x00ff);
 	map(0x0c8000, 0x0c87ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x0cc000, 0x0cffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x0d0000, 0x0d07ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
+	map(0x0cc000, 0x0cffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x0d0000, 0x0d07ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
 }
 
 void nmk16_state::tdragonb3_map(address_map &map)
@@ -871,7 +876,7 @@ void nmk16_state::tdragonb3_map(address_map &map)
 void nmk16_state::tdragonb2_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();
-	map(0x0b0000, 0x0bffff).ram().share("mainram");
+	map(0x0b0000, 0x0bffff).ram().share(m_mainram);
 	map(0x08e294, 0x08e925).portr("IN1");
 	map(0x0c0000, 0x0c0001).portr("IN0");
 	map(0x0c0002, 0x0c0003).nopr(); // leftover from the original?
@@ -889,14 +894,14 @@ void nmk16_state::tdragonb2_map(address_map &map)
 	map(0x0c4006, 0x0c4007).nopw(); // duplicate value of the above
 	map(0x0c4018, 0x0c4019).nopr(); // ??
 	map(0x0c8000, 0x0c87ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x0cc000, 0x0cffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x0d0000, 0x0d07ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
+	map(0x0cc000, 0x0cffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x0d0000, 0x0d07ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
 }
 
 void nmk16_state::ssmissin_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();
-	map(0x0b0000, 0x0bffff).ram().share("mainram");
+	map(0x0b0000, 0x0bffff).ram().share(m_mainram);
 	map(0x0c0000, 0x0c0001).portr("IN0");
 	map(0x0c0004, 0x0c0005).portr("IN1");
 	map(0x0c0006, 0x0c0007).portr("DSW1");
@@ -906,8 +911,8 @@ void nmk16_state::ssmissin_map(address_map &map)
 	map(0x0c001f, 0x0c001f).w(m_soundlatch, FUNC(generic_latch_8_device::write));
 	map(0x0c4000, 0x0c4007).ram().w(FUNC(nmk16_state::scroll_w<0>)).umask16(0x00ff);
 	map(0x0c8000, 0x0c87ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x0cc000, 0x0cffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x0d0000, 0x0d07ff).mirror(0x1800).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram"); //mirror for airattck
+	map(0x0cc000, 0x0cffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x0d0000, 0x0d07ff).mirror(0x1800).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram); //mirror for airattck
 }
 
 void nmk16_state::ssmissin_sound_map(address_map &map)
@@ -922,13 +927,13 @@ void nmk16_state::ssmissin_sound_map(address_map &map)
 void nmk16_state::oki1_map(address_map &map)
 {
 	map(0x00000, 0x1ffff).rom().region("oki1", 0);
-	map(0x20000, 0x3ffff).bankr("okibank1");
+	map(0x20000, 0x3ffff).bankr(m_okibank[0]);
 }
 
 void nmk16_state::oki2_map(address_map &map)
 {
 	map(0x00000, 0x1ffff).rom().region("oki2", 0);
-	map(0x20000, 0x3ffff).bankr("okibank2");
+	map(0x20000, 0x3ffff).bankr(m_okibank[1]);
 }
 
 void nmk16_state::strahl_map(address_map &map)
@@ -945,10 +950,10 @@ void nmk16_state::strahl_map(address_map &map)
 	map(0x84000, 0x84007).ram().w(FUNC(nmk16_state::scroll_w<0>)).umask16(0x00ff);
 	map(0x88000, 0x88007).ram().w(FUNC(nmk16_state::scroll_w<1>)).umask16(0x00ff);
 	map(0x8c000, 0x8c7ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x90000, 0x93fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
+	map(0x90000, 0x93fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
 	map(0x94000, 0x97fff).ram().w(FUNC(nmk16_state::bgvideoram_w<1>)).share("bgvideoram1");
-	map(0x9c000, 0x9c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0xf0000, 0xfffff).ram().share("mainram");
+	map(0x9c000, 0x9c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0xf0000, 0xfffff).ram().share(m_mainram);
 }
 
 void nmk16_state::strahljbl_map(address_map &map)
@@ -963,10 +968,10 @@ void nmk16_state::strahljbl_map(address_map &map)
 	map(0x84000, 0x84007).ram().w(FUNC(nmk16_state::scroll_w<0>)).umask16(0x00ff);
 	map(0x88000, 0x88007).ram().w(FUNC(nmk16_state::scroll_w<1>)).umask16(0x00ff);
 	map(0x8c000, 0x8c7ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x90000, 0x93fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
+	map(0x90000, 0x93fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
 	map(0x94000, 0x97fff).ram().w(FUNC(nmk16_state::bgvideoram_w<1>)).share("bgvideoram1");
-	map(0x9c000, 0x9c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0xf0000, 0xfffff).ram().share("mainram");
+	map(0x9c000, 0x9c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0xf0000, 0xfffff).ram().share(m_mainram);
 }
 
 void nmk16_state::macross_map(address_map &map)
@@ -983,9 +988,9 @@ void nmk16_state::macross_map(address_map &map)
 	map(0x08001f, 0x08001f).w(m_nmk004, FUNC(nmk004_device::write));
 	map(0x088000, 0x0887ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x08c000, 0x08c007).ram().w(FUNC(nmk16_state::scroll_w<0>)).umask16(0x00ff);
-	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x09c000, 0x09c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share("mainram");
+	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x09c000, 0x09c7ff).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0x0f0000, 0x0fffff).ram().w(FUNC(nmk16_state::mainram_strange_w)).share(m_mainram);
 }
 
 void nmk16_state::gunnail_map(address_map &map)
@@ -1001,12 +1006,12 @@ void nmk16_state::gunnail_map(address_map &map)
 	map(0x080019, 0x080019).w(FUNC(nmk16_state::tilebank_w));
 	map(0x08001f, 0x08001f).w(m_nmk004, FUNC(nmk004_device::write));
 	map(0x088000, 0x0887ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x08c000, 0x08c1ff).writeonly().share("scrollram");
-	map(0x08c200, 0x08c3ff).writeonly().share("scrollramy");
+	map(0x08c000, 0x08c1ff).writeonly().share(m_gunnail_scrollram);
+	map(0x08c200, 0x08c3ff).writeonly().share(m_gunnail_scrollramy);
 	map(0x08c400, 0x08c7ff).nopw();   // unknown
-	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x09c000, 0x09cfff).mirror(0x001000).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0x0f0000, 0x0fffff).ram().share("mainram");
+	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x09c000, 0x09cfff).mirror(0x001000).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0x0f0000, 0x0fffff).ram().share(m_mainram);
 }
 
 void nmk16_state::gunnailb_map(address_map &map)
@@ -1022,19 +1027,19 @@ void nmk16_state::gunnailb_map(address_map &map)
 	map(0x080019, 0x080019).w(FUNC(nmk16_state::tilebank_w));
 	map(0x08001f, 0x08001f).w(m_soundlatch, FUNC(generic_latch_8_device::write));
 	map(0x088000, 0x0887ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x08c000, 0x08c1ff).writeonly().share("scrollram");
-	map(0x08c200, 0x08c3ff).writeonly().share("scrollramy");
+	map(0x08c000, 0x08c1ff).writeonly().share(m_gunnail_scrollram);
+	map(0x08c200, 0x08c3ff).writeonly().share(m_gunnail_scrollramy);
 	map(0x08c400, 0x08c7ff).nopw();   // unknown
-	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x09c000, 0x09cfff).mirror(0x001000).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0x0f0000, 0x0fffff).ram().share("mainram");
+	map(0x090000, 0x093fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x09c000, 0x09cfff).mirror(0x001000).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0x0f0000, 0x0fffff).ram().share(m_mainram);
 	map(0x194001, 0x194001).w(m_oki[0], FUNC(okim6295_device::write));
 }
 
 void nmk16_state::gunnailb_sound_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
-	map(0x8000, 0xbfff).bankr("audiobank");
+	map(0x8000, 0xbfff).bankr(m_audiobank);
 	map(0xc000, 0xdfff).ram();
 }
 
@@ -1061,15 +1066,15 @@ void nmk16_state::macross2_map(address_map &map)
 	map(0x10001f, 0x10001f).w(m_soundlatch, FUNC(generic_latch_8_device::write)); // to Z80
 	map(0x120000, 0x1207ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x130000, 0x130007).ram().w(FUNC(nmk16_state::scroll_w<0>)).umask16(0x00ff);
-	map(0x140000, 0x14ffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x170000, 0x170fff).mirror(0x1000).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0x1f0000, 0x1fffff).ram().share("mainram");
+	map(0x140000, 0x14ffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x170000, 0x170fff).mirror(0x1000).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0x1f0000, 0x1fffff).ram().share(m_mainram);
 }
 
 void nmk16_state::tdragon2_map(address_map &map)
 { // mainram address scrambled
 	macross2_map(map);
-	map(0x1f0000, 0x1fffff).rw(FUNC(nmk16_state::mainram_swapped_r), FUNC(nmk16_state::mainram_swapped_w)).share("mainram");
+	map(0x1f0000, 0x1fffff).rw(FUNC(nmk16_state::mainram_swapped_r), FUNC(nmk16_state::mainram_swapped_w)).share(m_mainram);
 }
 
 void nmk16_state::tdragon3h_map(address_map &map)
@@ -1092,18 +1097,18 @@ void nmk16_state::raphero_map(address_map &map)
 	map(0x100019, 0x100019).w(FUNC(nmk16_state::tilebank_w));
 	map(0x10001f, 0x10001f).w(m_soundlatch, FUNC(generic_latch_8_device::write)); // to Z80
 	map(0x120000, 0x1207ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x130000, 0x1301ff).ram().w(FUNC(nmk16_state::raphero_scroll_w)).share("scrollram");
-	map(0x130200, 0x1303ff).ram().share("scrollramy");
+	map(0x130000, 0x1301ff).ram().w(FUNC(nmk16_state::raphero_scroll_w)).share(m_gunnail_scrollram);
+	map(0x130200, 0x1303ff).ram().share(m_gunnail_scrollramy);
 	map(0x130400, 0x1307ff).ram();
-	map(0x140000, 0x14ffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x170000, 0x170fff).mirror(0x1000).ram().w(FUNC(nmk16_state::txvideoram_w)).share("txvideoram");
-	map(0x1f0000, 0x1fffff).rw(FUNC(nmk16_state::mainram_swapped_r), FUNC(nmk16_state::mainram_swapped_w)).share("mainram");
+	map(0x140000, 0x14ffff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x170000, 0x170fff).mirror(0x1000).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
+	map(0x1f0000, 0x1fffff).rw(FUNC(nmk16_state::mainram_swapped_r), FUNC(nmk16_state::mainram_swapped_w)).share(m_mainram);
 }
 
 void nmk16_state::raphero_sound_mem_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
-	map(0x8000, 0xbfff).bankr("audiobank");
+	map(0x8000, 0xbfff).bankr(m_audiobank);
 	map(0xc000, 0xc001).rw("ymsnd", FUNC(ym2203_device::read), FUNC(ym2203_device::write));
 	map(0xc800, 0xc800).rw(m_oki[0], FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0xc808, 0xc808).rw(m_oki[1], FUNC(okim6295_device::read), FUNC(okim6295_device::write));
@@ -1116,7 +1121,7 @@ void nmk16_state::raphero_sound_mem_map(address_map &map)
 void nmk16_state::macross2_sound_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
-	map(0x8000, 0xbfff).bankr("audiobank");    // banked ROM
+	map(0x8000, 0xbfff).bankr(m_audiobank);    // banked ROM
 	map(0xa000, 0xa000).nopr(); // IRQ ack? watchdog?
 	map(0xc000, 0xdfff).ram();
 	map(0xe001, 0xe001).w(FUNC(nmk16_state::macross2_audiobank_w));
@@ -1155,8 +1160,8 @@ void nmk16_state::bjtwin_map(address_map &map)
 	map(0x088000, 0x0887ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x094001, 0x094001).w(FUNC(nmk16_state::tilebank_w));
 	map(0x094003, 0x094003).w(FUNC(nmk16_state::bjtwin_scroll_w));    // sabotenb specific?
-	map(0x09c000, 0x09cfff).mirror(0x1000).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share("bgvideoram0");
-	map(0x0f0000, 0x0fffff).ram().share("mainram");
+	map(0x09c000, 0x09cfff).mirror(0x1000).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
+	map(0x0f0000, 0x0fffff).ram().share(m_mainram);
 }
 
 void nmk16_state::powerins_map(address_map &map)
@@ -1174,7 +1179,7 @@ void nmk16_state::powerins_map(address_map &map)
 	map(0x130000, 0x130007).ram().w(FUNC(nmk16_state::scroll_w<0>)).umask16(0x00ff);
 	map(0x140000, 0x143fff).ram().w(FUNC(nmk16_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);
 	map(0x170000, 0x170fff).mirror(0x1000).ram().w(FUNC(nmk16_state::txvideoram_w)).share(m_txvideoram);
-	map(0x180000, 0x18ffff).ram().share("mainram");
+	map(0x180000, 0x18ffff).ram().share(m_mainram);
 }
 
 // powerinsa: same as the original one but without the sound CPU (and inferior sound HW)
@@ -4168,14 +4173,14 @@ static GFXDECODE_START( gfx_bioship )
 	GFXDECODE_ENTRY( "fgtile",  0, gfx_8x8x4_packed_msb,               0x300, 16 ) // color 0x300-0x3ff
 	GFXDECODE_ENTRY( "bgtile",  0, gfx_8x8x4_col_2x2_group_packed_msb, 0x100, 16 ) // color 0x100-0x1ff
 	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x200, 16 ) // color 0x200-0x2ff
-	GFXDECODE_ENTRY( "gfx4",    0, gfx_8x8x4_col_2x2_group_packed_msb, 0x000, 16 ) // color 0x000-0x0ff
+	GFXDECODE_ENTRY( "bg2tile", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x000, 16 ) // color 0x000-0x0ff
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_strahl )
 	GFXDECODE_ENTRY( "fgtile",  0, gfx_8x8x4_packed_msb,               0x000, 16 ) // color 0x000-0x0ff
 	GFXDECODE_ENTRY( "bgtile",  0, gfx_8x8x4_col_2x2_group_packed_msb, 0x300, 16 ) // color 0x300-0x3ff
 	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x100, 16 ) // color 0x100-0x1ff
-	GFXDECODE_ENTRY( "gfx4",    0, gfx_8x8x4_col_2x2_group_packed_msb, 0x200, 16 ) // color 0x200-0x2ff
+	GFXDECODE_ENTRY( "bg2tile", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x200, 16 ) // color 0x200-0x2ff
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_powerins )
@@ -4407,24 +4412,24 @@ TIMER_DEVICE_CALLBACK_MEMBER(nmk16_state::nmk16_scanline)
 	constexpr int PROM_START_OFFSET = 0x75; // previous entries are never addressed
 	constexpr int PROM_FRAME_OFFSET = 0x0b; // first 11 "used" entries (from 0x75 to 0x7f: 0xb entries) are prior to start of frame, which occurs on 0x80 address (128 entry)
 
-	u8 *prom = m_vtiming_prom->base();
-	int len = m_vtiming_prom->bytes();
+	u8 const *const prom = m_vtiming_prom->base();
+	const int len = m_vtiming_prom->bytes();
 
-	int scanline = param;
+	const int scanline = param;
 
 	// every PROM entry is addressed each 2 scanlines, so only even lines are actually addressing it:
 	if ((scanline & 0x1) == 0x0)
 	{
-		u8 address = ((((scanline / 2) + PROM_FRAME_OFFSET) % (0x100 - PROM_START_OFFSET)) + PROM_START_OFFSET) % len;
+		const u8 address = ((((scanline / 2) + PROM_FRAME_OFFSET) % (0x100 - PROM_START_OFFSET)) + PROM_START_OFFSET) % len;
 
 		LOG("nmk16_scanline: Scanline: %03d - Current PROM entry: %03d\n", scanline, address);
 
-		u8 val = prom[address];
+		const u8 val = prom[address];
 
 		// Interrupt requests are triggered at rising edge of bit 7:
 		if (BIT(val & ~m_vtiming_val, TRIGG_INDEX))
 		{
-			u8 int_level = bitswap<3>(val, IPL2_INDEX, IPL1_INDEX, IPL0_INDEX);
+			const u8 int_level = bitswap<3>(val, IPL2_INDEX, IPL1_INDEX, IPL0_INDEX);
 			if (int_level > 0)
 			{
 				LOG("nmk16_scanline: Triggered interrupt: IRQ%d at scanline: %03d\n", int_level, scanline);
@@ -4486,7 +4491,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(nmk16_state::nmk16_hacky_scanline)
 	const int IRQ1_SCANLINE_1 = VBIN_SCANLINE + 52;    // 52 lines after VBIN and 68 from the start of frame
 	const int IRQ1_SCANLINE_2 = IRQ1_SCANLINE_1 + 128; // 128 lines after IRQ1_SCANLINE_1
 
-	int scanline = param;
+	const int scanline = param;
 
 	if (scanline == VBOUT_SCANLINE) // vblank-out irq
 		m_maincpu->set_input_line(4, HOLD_LINE);
@@ -4517,9 +4522,22 @@ void nmk16_state::set_hacky_interrupt_timing(machine_config &config)
 void nmk16_state::sprite_dma()
 {
 	// 2 buffers confirmed on PCB, 1 on sabotenb
-	memcpy(m_spriteram_old2.get(),m_spriteram_old.get(), 0x1000);
+	memcpy(m_spriteram_old2.get(), m_spriteram_old.get(), 0x1000);
 	memcpy(m_spriteram_old.get(), m_mainram + m_sprdma_base / 2, 0x1000);
 	//m_maincpu->spin_until_time(attotime::from_usec(694)); // stop cpu during DMA?
+}
+
+void nmk16_state::configure_nmk004(machine_config &config)
+{
+	m_nmk004->reset_cb().set_inputline(m_maincpu, INPUT_LINE_RESET);
+	m_nmk004->set_rom_tag("oki1", "oki2");
+	m_nmk004->set_rombank_tag(m_okibank[0], m_okibank[1]);
+	m_nmk004->ym_read_callback().set("ymsnd", FUNC(ym2203_device::read));
+	m_nmk004->ym_write_callback().set("ymsnd", FUNC(ym2203_device::write));
+	m_nmk004->oki_read_callback<0>().set(m_oki[0], FUNC(okim6295_device::read));
+	m_nmk004->oki_write_callback<0>().set(m_oki[0], FUNC(okim6295_device::write));
+	m_nmk004->oki_read_callback<1>().set(m_oki[1], FUNC(okim6295_device::read));
+	m_nmk004->oki_write_callback<1>().set(m_oki[1], FUNC(okim6295_device::write));
 }
 
 // OSC : 10MHz, 12MHz, 4MHz, 4.9152MHz
@@ -4602,7 +4620,7 @@ void nmk16_state::mustang(machine_config &config)
 	SPEAKER(config, "mono").front_center();
 
 	NMK004(config, m_nmk004, 8000000);
-	m_nmk004->reset_cb().set_inputline(m_maincpu, INPUT_LINE_RESET);
+	configure_nmk004(config);
 
 	ym2203_device &ymsnd(YM2203(config, "ymsnd", 1500000));
 	ymsnd.irq_handler().set("nmk004", FUNC(nmk004_device::ym2203_irq_handler));
@@ -4717,7 +4735,7 @@ void nmk16_state::bioship(machine_config &config)
 	SPEAKER(config, "mono").front_center();
 
 	NMK004(config, m_nmk004, XTAL(8'000'000));
-	m_nmk004->reset_cb().set_inputline(m_maincpu, INPUT_LINE_RESET);
+	configure_nmk004(config);
 
 	ym2203_device &ymsnd(YM2203(config, "ymsnd", XTAL(12'000'000) / 8)); // 1.5 Mhz (verified)
 	ymsnd.irq_handler().set("nmk004", FUNC(nmk004_device::ym2203_irq_handler));
@@ -4755,7 +4773,7 @@ void nmk16_state::vandyke(machine_config &config)
 	SPEAKER(config, "mono").front_center();
 
 	NMK004(config, m_nmk004, 8000000);
-	m_nmk004->reset_cb().set_inputline(m_maincpu, INPUT_LINE_RESET);
+	configure_nmk004(config);
 
 	ym2203_device &ymsnd(YM2203(config, "ymsnd", XTAL(12'000'000)/8)); // verified on PCB
 	ymsnd.irq_handler().set("nmk004", FUNC(nmk004_device::ym2203_irq_handler));
@@ -4819,7 +4837,7 @@ void nmk16_state::acrobatm(machine_config &config)
 	SPEAKER(config, "mono").front_center();
 
 	NMK004(config, m_nmk004, XTAL(16'000'000)/2);
-	m_nmk004->reset_cb().set_inputline(m_maincpu, INPUT_LINE_RESET);
+	configure_nmk004(config);
 
 	ym2203_device &ymsnd(YM2203(config, "ymsnd", XTAL(12'000'000)/8)); // verified on PCB
 	ymsnd.irq_handler().set("nmk004", FUNC(nmk004_device::ym2203_irq_handler));
@@ -4964,7 +4982,7 @@ void nmk16_state::tdragon(machine_config &config)
 	SPEAKER(config, "mono").front_center();
 
 	NMK004(config, m_nmk004, 8000000);
-	m_nmk004->reset_cb().set_inputline(m_maincpu, INPUT_LINE_RESET);
+	configure_nmk004(config);
 
 	ym2203_device &ymsnd(YM2203(config, "ymsnd", XTAL(12'000'000)/8)); // verified on PCB
 	ymsnd.irq_handler().set("nmk004", FUNC(nmk004_device::ym2203_irq_handler));
@@ -5062,8 +5080,9 @@ void tdragon_prot_state::mcu_side_shared_w(offs_t offset, u8 data)
 
 u8 tdragon_prot_state::mcu_side_shared_r(offs_t offset)
 {
-	u8 retval = m_maincpu->space(AS_PROGRAM).read_byte((offset));
-	LOG("%s: mcu_side_shared_r offset %08x (retval %02x)\n", machine().describe_context(), offset, retval);
+	const u8 retval = m_maincpu->space(AS_PROGRAM).read_byte(offset);
+	if (!machine().side_effects_disabled())
+		LOG("%s: mcu_side_shared_r offset %08x (retval %02x)\n", machine().describe_context(), offset, retval);
 	return retval;
 }
 
@@ -5136,7 +5155,7 @@ void nmk16_state::strahl(machine_config &config)
 	SPEAKER(config, "mono").front_center();
 
 	NMK004(config, m_nmk004, 8000000);
-	m_nmk004->reset_cb().set_inputline(m_maincpu, INPUT_LINE_RESET);
+	configure_nmk004(config);
 
 	ym2203_device &ymsnd(YM2203(config, "ymsnd", 1500000));
 	ymsnd.irq_handler().set("nmk004", FUNC(nmk004_device::ym2203_irq_handler));
@@ -5209,7 +5228,7 @@ void nmk16_state::hachamf(machine_config &config)
 	SPEAKER(config, "mono").front_center();
 
 	NMK004(config, m_nmk004, 8000000);
-	m_nmk004->reset_cb().set_inputline(m_maincpu, INPUT_LINE_RESET);
+	configure_nmk004(config);
 
 	ym2203_device &ymsnd(YM2203(config, "ymsnd", 1500000));
 	ymsnd.irq_handler().set("nmk004", FUNC(nmk004_device::ym2203_irq_handler));
@@ -5286,7 +5305,7 @@ void nmk16_state::macross(machine_config &config)
 	SPEAKER(config, "mono").front_center();
 
 	NMK004(config, m_nmk004, XTAL(16'000'000)/2); // verified on PCB
-	m_nmk004->reset_cb().set_inputline(m_maincpu, INPUT_LINE_RESET);
+	configure_nmk004(config);
 
 	ym2203_device &ymsnd(YM2203(config, "ymsnd", XTAL(12'000'000)/8)); // verified on PCB
 	ymsnd.irq_handler().set("nmk004", FUNC(nmk004_device::ym2203_irq_handler));
@@ -5324,7 +5343,7 @@ void nmk16_state::blkheart(machine_config &config)
 	SPEAKER(config, "mono").front_center();
 
 	NMK004(config, m_nmk004, 8000000);
-	m_nmk004->reset_cb().set_inputline(m_maincpu, INPUT_LINE_RESET);
+	configure_nmk004(config);
 
 	ym2203_device &ymsnd(YM2203(config, "ymsnd", XTAL(12'000'000)/8)); // verified on PCB
 	ymsnd.irq_handler().set("nmk004", FUNC(nmk004_device::ym2203_irq_handler));
@@ -5361,7 +5380,7 @@ void nmk16_state::gunnail(machine_config &config)
 	SPEAKER(config, "mono").front_center();
 
 	NMK004(config, m_nmk004, XTAL(16'000'000)/2); // verified on PCB
-	m_nmk004->reset_cb().set_inputline(m_maincpu, INPUT_LINE_RESET);
+	configure_nmk004(config);
 
 	ym2203_device &ymsnd(YM2203(config, "ymsnd", XTAL(12'000'000)/8)); // verified on PCB
 	ymsnd.irq_handler().set("nmk004", FUNC(nmk004_device::ym2203_irq_handler));
@@ -6272,13 +6291,13 @@ void afega_state::afega_map(address_map &map)
 	map(0x084000, 0x084003).ram().w(FUNC(afega_state::afega_scroll_w<0>));  // Scroll on redhawkb (mirror or changed?..)
 	map(0x084004, 0x084007).ram().w(FUNC(afega_state::afega_scroll_w<1>));  // Scroll on redhawkb (mirror or changed?..)
 	map(0x088000, 0x0885ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette"); // Palette
-	map(0x08c000, 0x08c003).ram().w(FUNC(afega_state::afega_scroll_w<0>)).share("afega_scroll_0");   // Scroll
-	map(0x08c004, 0x08c007).ram().w(FUNC(afega_state::afega_scroll_w<1>)).share("afega_scroll_1");   //
-	map(0x090000, 0x093fff).ram().w(FUNC(afega_state::bgvideoram_w<0>)).share("bgvideoram0");    // Layer 0                  // ?
-	map(0x09c000, 0x09c7ff).ram().w(FUNC(afega_state::txvideoram_w)).share("txvideoram");  // Layer 1
+	map(0x08c000, 0x08c003).ram().w(FUNC(afega_state::afega_scroll_w<0>)).share(m_afega_scroll[0]);   // Scroll
+	map(0x08c004, 0x08c007).ram().w(FUNC(afega_state::afega_scroll_w<1>)).share(m_afega_scroll[1]);   //
+	map(0x090000, 0x093fff).ram().w(FUNC(afega_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);    // Layer 0                  // ?
+	map(0x09c000, 0x09c7ff).ram().w(FUNC(afega_state::txvideoram_w)).share(m_txvideoram);  // Layer 1
 
-	map(0x0c0000, 0x0cffff).ram().w(FUNC(afega_state::mainram_strange_w)).share("mainram");
-	map(0x0f0000, 0x0fffff).ram().w(FUNC(afega_state::mainram_strange_w)).share("mainram");
+	map(0x0c0000, 0x0cffff).ram().w(FUNC(afega_state::mainram_strange_w)).share(m_mainram);
+	map(0x0f0000, 0x0fffff).ram().w(FUNC(afega_state::mainram_strange_w)).share(m_mainram);
 }
 
 // firehawk has 0x100000 bytes of program ROM (at least the switchable version) so the above can't work.
@@ -6294,13 +6313,13 @@ void afega_state::firehawk_map(address_map &map)
 	map(0x284000, 0x284003).ram().w(FUNC(afega_state::afega_scroll_w<0>));  // Scroll on redhawkb (mirror or changed?..)
 	map(0x284004, 0x284007).ram().w(FUNC(afega_state::afega_scroll_w<1>));  // Scroll on redhawkb (mirror or changed?..)
 	map(0x288000, 0x2885ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette"); // Palette
-	map(0x28c000, 0x28c003).ram().w(FUNC(afega_state::afega_scroll_w<0>)).share("afega_scroll_0");   // Scroll
-	map(0x28c004, 0x28c007).ram().w(FUNC(afega_state::afega_scroll_w<1>)).share("afega_scroll_1");   //
-	map(0x290000, 0x293fff).ram().w(FUNC(afega_state::bgvideoram_w<0>)).share("bgvideoram0");    // Layer 0                  // ?
-	map(0x29c000, 0x29c7ff).ram().w(FUNC(afega_state::txvideoram_w)).share("txvideoram");  // Layer 1
+	map(0x28c000, 0x28c003).ram().w(FUNC(afega_state::afega_scroll_w<0>)).share(m_afega_scroll[0]);   // Scroll
+	map(0x28c004, 0x28c007).ram().w(FUNC(afega_state::afega_scroll_w<1>)).share(m_afega_scroll[1]);   //
+	map(0x290000, 0x293fff).ram().w(FUNC(afega_state::bgvideoram_w<0>)).share(m_bgvideoram[0]);    // Layer 0                  // ?
+	map(0x29c000, 0x29c7ff).ram().w(FUNC(afega_state::txvideoram_w)).share(m_txvideoram);  // Layer 1
 
-	map(0x3c0000, 0x3cffff).ram().w(FUNC(afega_state::mainram_strange_w)).share("mainram");
-	map(0x3f0000, 0x3fffff).ram().w(FUNC(afega_state::mainram_strange_w)).share("mainram");
+	map(0x3c0000, 0x3cffff).ram().w(FUNC(afega_state::mainram_strange_w)).share(m_mainram);
+	map(0x3f0000, 0x3fffff).ram().w(FUNC(afega_state::mainram_strange_w)).share(m_mainram);
 }
 
 
@@ -6319,7 +6338,7 @@ void afega_state::spec2k_oki1_banking_w(u8 data)
 		m_oki[1]->set_rom_bank(1);
 }
 
-void afega_state::afega_sound_cpu(address_map &map)
+void afega_state::afega_sound_map(address_map &map)
 {
 	map(0x0003, 0x0003).nopw(); // bug in sound prg?
 	map(0x0004, 0x0004).nopw(); // bug in sound prg?
@@ -6330,7 +6349,7 @@ void afega_state::afega_sound_cpu(address_map &map)
 	map(0xf80a, 0xf80a).rw(m_oki[0], FUNC(okim6295_device::read), FUNC(okim6295_device::write));      // M6295
 }
 
-void afega_state::firehawk_sound_cpu(address_map &map)
+void afega_state::firehawk_sound_map(address_map &map)
 {
 	map(0x0000, 0xefff).rom();
 	map(0xf000, 0xf7ff).ram();
@@ -6391,7 +6410,7 @@ void afega_state::stagger1(machine_config &config)
 	set_hacky_interrupt_timing(config);
 
 	Z80(config, m_audiocpu, XTAL(4'000'000)); // verified on PCB
-	m_audiocpu->set_addrmap(AS_PROGRAM, &afega_state::afega_sound_cpu);
+	m_audiocpu->set_addrmap(AS_PROGRAM, &afega_state::afega_sound_map);
 
 	// video hardware
 	set_screen_lowres(config);
@@ -6474,7 +6493,7 @@ void afega_state::firehawk(machine_config &config)
 	set_hacky_interrupt_timing(config);
 
 	Z80(config, m_audiocpu, 4000000);
-	m_audiocpu->set_addrmap(AS_PROGRAM, &afega_state::firehawk_sound_cpu);
+	m_audiocpu->set_addrmap(AS_PROGRAM, &afega_state::firehawk_sound_map);
 
 	// video hardware
 	set_screen_lowres(config);
@@ -6569,7 +6588,7 @@ ROM_START( vandyke )
 	ROM_LOAD16_BYTE( "vdk-1.16",  0x00000, 0x20000, CRC(c1d01c59) SHA1(04a7fd31ca4d87d078070390660edf08bf1d96b5) )
 	ROM_LOAD16_BYTE( "vdk-2.15",  0x00001, 0x20000, CRC(9d741cc2) SHA1(2d101044fba5fc5b7d63869a0a053c42fdc2598b) )
 
-	ROM_REGION(0x10000, "audiocpu", 0 ) // 64k for sound CPU code
+	ROM_REGION(0x10000, "nmk004", 0 ) // 64k for sound CPU code
 	ROM_LOAD( "vdk-4.127",    0x00000, 0x10000, CRC(eba544f0) SHA1(36f6d048d15a392542a9220a244d8a7049aaff8b) )
 
 	ROM_REGION( 0x010000, "fgtile", 0 )
@@ -6602,7 +6621,7 @@ ROM_START( vandykejal )
 	ROM_LOAD16_BYTE( "vdk-1.16",   0x00000, 0x20000, CRC(c1d01c59) SHA1(04a7fd31ca4d87d078070390660edf08bf1d96b5) )
 	ROM_LOAD16_BYTE( "jaleco2.15", 0x00001, 0x20000, CRC(170e4d2e) SHA1(6009d19d30e345fea93e039d165061e2b20ff058) )
 
-	ROM_REGION(0x10000, "audiocpu", 0 ) // 64k for sound CPU code
+	ROM_REGION(0x10000, "nmk004", 0 ) // 64k for sound CPU code
 	ROM_LOAD( "vdk-4.127",    0x00000, 0x10000, CRC(eba544f0) SHA1(36f6d048d15a392542a9220a244d8a7049aaff8b) )
 
 	ROM_REGION( 0x010000, "fgtile", 0 )
@@ -6635,7 +6654,7 @@ ROM_START( vandykejal2 )
 	ROM_LOAD16_BYTE( "vdk-even.16",  0x00000, 0x20000, CRC(cde05a84) SHA1(dab5981d7dad9abe86cfe011da8ca0b11d484a3f) ) // Hand written labels, dated 2/12
 	ROM_LOAD16_BYTE( "vdk-odd.15",   0x00001, 0x20000, CRC(0f6fea40) SHA1(3acbe72c251d51b028d8c66274263a2b39b042ea) )
 
-	ROM_REGION(0x10000, "audiocpu", 0 ) // 64k for sound CPU code
+	ROM_REGION(0x10000, "nmk004", 0 ) // 64k for sound CPU code
 	ROM_LOAD( "vdk-4.127",    0x00000, 0x10000, CRC(eba544f0) SHA1(36f6d048d15a392542a9220a244d8a7049aaff8b) )
 
 	ROM_REGION( 0x010000, "fgtile", 0 )
@@ -6918,7 +6937,7 @@ ROM_START( mustang )
 	ROM_LOAD16_BYTE( "2.bin",    0x00000, 0x20000, CRC(bd9f7c89) SHA1(a0af46a8ff82b90bece2515e1bd74e7a7ddf5379) )
 	ROM_LOAD16_BYTE( "3.bin",    0x00001, 0x20000, CRC(0eec36a5) SHA1(c549fbcd3e2741a6d0f2633ded6a85909d37f633) )
 
-	ROM_REGION(0x10000, "audiocpu", 0 ) // 64k for sound CPU code
+	ROM_REGION(0x10000, "nmk004", 0 ) // 64k for sound CPU code
 	ROM_LOAD( "90058-7",    0x00000, 0x10000, CRC(920a93c8) SHA1(7660ca419e2fd98848ae7f5994994eaed023151e) )
 
 	ROM_REGION( 0x020000, "fgtile", 0 )
@@ -6949,7 +6968,7 @@ ROM_START( mustangs )
 	ROM_LOAD16_BYTE( "90058-2",    0x00000, 0x20000, CRC(833aa458) SHA1(a9924f7044397e3a36c674b064173ffae80a79ec) )
 	ROM_LOAD16_BYTE( "90058-3",    0x00001, 0x20000, CRC(e4b80f06) SHA1(ce589cebb5ea85c89eb44796b821a4bd0c44b9a8) )
 
-	ROM_REGION(0x10000, "audiocpu", 0 ) // 64k for sound CPU code
+	ROM_REGION(0x10000, "nmk004", 0 ) // 64k for sound CPU code
 	ROM_LOAD( "90058-7",    0x00000, 0x10000, CRC(920a93c8) SHA1(7660ca419e2fd98848ae7f5994994eaed023151e) )
 
 	ROM_REGION( 0x020000, "fgtile", 0 )
@@ -7151,7 +7170,7 @@ ROM_START( acrobatm )
 	ROM_LOAD( "am-01.ic42",  0x000000, 0x100000, CRC(5672bdaa) SHA1(5401a104d72904de19b73125451767bc63d36809) ) // Sprites
 	ROM_LOAD( "am-02.ic29",  0x100000, 0x080000, CRC(b4c0ace3) SHA1(5d638781d588cfbf4025d002d5a2309049fe1ee5) )
 
-	ROM_REGION( 0x10000, "audiocpu", 0 )
+	ROM_REGION( 0x10000, "nmk004", 0 )
 	ROM_LOAD( "4.ic74",    0x00000, 0x10000, CRC(176905fb) SHA1(135a184f44bedd93b293b9124fa0bd725e0ee93b) )
 
 	ROM_REGION( 0x80000, "oki1", 0 )    // OKIM6295 samples
@@ -7197,7 +7216,7 @@ ROM_END
 
 /*
 
-S.B.S. Gomorrah / Bio-ship Paladin (UPL, 1993)
+S.B.S. Gomorrah / Bio-ship Paladin (UPL, 1990)
 Hardware info by Guru
 
 PCB Layout
@@ -7256,14 +7275,14 @@ ROM_START( bioship )
 	ROM_REGION( 0x80000, "sprites", 0 )
 	ROM_LOAD( "sbs-g_03.ic194",  0x000000, 0x80000, CRC(60e00d7b) SHA1(36fd02a7842ce1e79b8c4cfbe9c97052bef4aa62) ) // Sprites
 
-	ROM_REGION( 0x80000, "gfx4", 0 )
+	ROM_REGION( 0x80000, "bg2tile", 0 )
 	ROM_LOAD( "sbs-g_02.ic4",  0x000000, 0x80000, CRC(f31eb668) SHA1(67d6d56ea203edfbae4db658399bf61f14134206) ) // Background
 
 	ROM_REGION16_BE(0x20000, "tilerom", 0 )    // Background tilemaps (used at runtime)
 	ROM_LOAD16_BYTE( "8.ic27",    0x00000, 0x10000, CRC(75a46fea) SHA1(3d78cfc482b42779bb5aedb722c4a39cbc71bd10) )
 	ROM_LOAD16_BYTE( "9.ic26",    0x00001, 0x10000, CRC(d91448ee) SHA1(7f84ca3605edcab4bf226dab8dd7218cd5c3e5a4) )
 
-	ROM_REGION( 0x10000, "audiocpu", 0 )
+	ROM_REGION( 0x10000, "nmk004", 0 )
 	ROM_LOAD( "6.ic120",    0x00000, 0x10000, CRC(5f39a980) SHA1(2a440f86685249f9c317634cad8cdedc8a8f1491) )
 
 	ROM_REGION(0x80000, "oki1", 0 ) // Oki sample data
@@ -7296,14 +7315,14 @@ ROM_START( sbsgomo )
 	ROM_REGION( 0x80000, "sprites", 0 )
 	ROM_LOAD( "sbs-g_03.ic194",  0x000000, 0x80000, CRC(60e00d7b) SHA1(36fd02a7842ce1e79b8c4cfbe9c97052bef4aa62) ) // Sprites
 
-	ROM_REGION( 0x80000, "gfx4", 0 )
+	ROM_REGION( 0x80000, "bg2tile", 0 )
 	ROM_LOAD( "sbs-g_02.ic4",  0x000000, 0x80000, CRC(f31eb668) SHA1(67d6d56ea203edfbae4db658399bf61f14134206) ) // Background
 
 	ROM_REGION16_BE(0x20000, "tilerom", 0 )    // Background tilemaps (used at runtime)
 	ROM_LOAD16_BYTE( "8.ic27",    0x00000, 0x10000, CRC(75a46fea) SHA1(3d78cfc482b42779bb5aedb722c4a39cbc71bd10) )
 	ROM_LOAD16_BYTE( "9.ic26",    0x00001, 0x10000, CRC(d91448ee) SHA1(7f84ca3605edcab4bf226dab8dd7218cd5c3e5a4) )
 
-	ROM_REGION( 0x10000, "audiocpu", 0 )
+	ROM_REGION( 0x10000, "nmk004", 0 )
 	ROM_LOAD( "6.ic120",    0x00000, 0x10000, CRC(5f39a980) SHA1(2a440f86685249f9c317634cad8cdedc8a8f1491) )
 
 	ROM_REGION(0x80000, "oki1", 0 ) // Oki sample data
@@ -7327,7 +7346,7 @@ ROM_START( blkheart )
 	ROM_LOAD16_BYTE( "blkhrt.7",  0x00000, 0x20000, CRC(5bd248c0) SHA1(0649f4f8682404aeb3fc80643fcabc2d7836bb23) )
 	ROM_LOAD16_BYTE( "blkhrt.6",  0x00001, 0x20000, CRC(6449e50d) SHA1(d8cd126d921c95478346da96c20da01212395d77) )
 
-	ROM_REGION( 0x10000, "audiocpu", 0 )        // Code for (unknown?) CPU
+	ROM_REGION( 0x10000, "nmk004", 0 )        // Code for NMK004 CPU
 	ROM_LOAD( "4.bin",      0x00000, 0x10000, CRC(7cefa295) SHA1(408f46613b3620cee31dec43281688d231b47ddd) )
 
 	ROM_REGION( 0x020000, "fgtile", 0 )
@@ -7357,7 +7376,7 @@ ROM_START( blkheartj )
 	ROM_LOAD16_BYTE( "7.bin",  0x00000, 0x20000, CRC(e0a5c667) SHA1(3ef39b2dc1f7ffdddf586f0b3080ecd1f362ec37) )
 	ROM_LOAD16_BYTE( "6.bin",  0x00001, 0x20000, CRC(7cce45e8) SHA1(72491e30d1f9be2eede21fdde5a7484d4f65cfbf) )
 
-	ROM_REGION( 0x10000, "audiocpu", 0 )        // Code for (unknown?) CPU
+	ROM_REGION( 0x10000, "nmk004", 0 )        // Code for NMK004 CPU
 	ROM_LOAD( "4.bin",      0x00000, 0x10000, CRC(7cefa295) SHA1(408f46613b3620cee31dec43281688d231b47ddd) )
 
 	ROM_REGION( 0x020000, "fgtile", 0 )
@@ -7396,7 +7415,7 @@ ROM_START( tdragon )
 	ROM_REGION( 0x100000, "sprites", 0 )
 	ROM_LOAD16_WORD_SWAP( "91070.4",    0x000000, 0x100000, CRC(3eedc2fe) SHA1(9f48986c231a8fbc07f2b39b2017d1e967b2ed3c) )  // Sprites
 
-	ROM_REGION( 0x010000, "audiocpu", 0 ) // NMK004 sound data
+	ROM_REGION( 0x010000, "nmk004", 0 ) // NMK004 sound data
 	ROM_LOAD( "91070.1",      0x00000, 0x10000, CRC(bf493d74) SHA1(6f8f5eff4b71fb6cabda10075cfa88a3f607859e) )
 
 	ROM_REGION( 0x080000, "oki1", 0 )   // OKIM6295 samples
@@ -7429,7 +7448,7 @@ ROM_START( tdragon1 )
 	ROM_REGION( 0x100000, "sprites", 0 )
 	ROM_LOAD16_WORD_SWAP( "91070.4",    0x000000, 0x100000, CRC(3eedc2fe) SHA1(9f48986c231a8fbc07f2b39b2017d1e967b2ed3c) )  // Sprites
 
-	ROM_REGION( 0x010000, "audiocpu", 0 ) // NMK004 sound data
+	ROM_REGION( 0x010000, "nmk004", 0 ) // NMK004 sound data
 	ROM_LOAD( "91070.1",      0x00000, 0x10000, CRC(bf493d74) SHA1(6f8f5eff4b71fb6cabda10075cfa88a3f607859e) )
 
 	ROM_REGION( 0x080000, "oki1", 0 )   // OKIM6295 samples
@@ -7648,10 +7667,10 @@ ROM_START( strahl )
 	ROM_LOAD( "strl4-02.57",  0x080000, 0x80000, CRC(2a38552b) SHA1(82335fc6aa3de9145dd84952e5ed423493bf7141) )
 	ROM_LOAD( "strl5-03.58",  0x100000, 0x80000, CRC(a0e7d210) SHA1(96a762a3a1cdeaa91bde50429e0ac665fb81190b) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 )
+	ROM_REGION( 0x80000, "bg2tile", 0 )
 	ROM_LOAD( "str6b1w1.776", 0x000000, 0x80000, CRC(bb1bb155) SHA1(83a02e89180e15f0e7817e0e92b4bf4e209bb69a) ) // Tiles
 
-	ROM_REGION( 0x10000, "audiocpu", 0 )
+	ROM_REGION( 0x10000, "nmk004", 0 )
 	ROM_LOAD( "strahl-4.66",    0x00000, 0x10000, CRC(60a799c4) SHA1(8ade3cf827a389f7cb4080957dc4d67077ea4166) )
 
 	ROM_REGION( 0xa0000, "oki1", 0 )    // Oki sample data
@@ -7685,10 +7704,10 @@ ROM_START( strahlj )
 	ROM_LOAD( "strl4-02.57",  0x080000, 0x80000, CRC(2a38552b) SHA1(82335fc6aa3de9145dd84952e5ed423493bf7141) )
 	ROM_LOAD( "strl5-03.58",  0x100000, 0x80000, CRC(a0e7d210) SHA1(96a762a3a1cdeaa91bde50429e0ac665fb81190b) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 )
+	ROM_REGION( 0x80000, "bg2tile", 0 )
 	ROM_LOAD( "str6b1w1.776", 0x000000, 0x80000, CRC(bb1bb155) SHA1(83a02e89180e15f0e7817e0e92b4bf4e209bb69a) ) // Tiles
 
-	ROM_REGION( 0x10000, "audiocpu", 0 )
+	ROM_REGION( 0x10000, "nmk004", 0 )
 	ROM_LOAD( "strahl-4.66",    0x00000, 0x10000, CRC(60a799c4) SHA1(8ade3cf827a389f7cb4080957dc4d67077ea4166) )
 
 	ROM_REGION( 0xa0000, "oki1", 0 )    // Oki sample data
@@ -7722,10 +7741,10 @@ ROM_START( strahlja )
 	ROM_LOAD( "strl4-02.57",  0x080000, 0x80000, CRC(2a38552b) SHA1(82335fc6aa3de9145dd84952e5ed423493bf7141) )
 	ROM_LOAD( "strl5-03.58",  0x100000, 0x80000, CRC(a0e7d210) SHA1(96a762a3a1cdeaa91bde50429e0ac665fb81190b) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 )
+	ROM_REGION( 0x80000, "bg2tile", 0 )
 	ROM_LOAD( "str6b1w1.776", 0x000000, 0x80000, CRC(bb1bb155) SHA1(83a02e89180e15f0e7817e0e92b4bf4e209bb69a) ) // Tiles
 
-	ROM_REGION( 0x10000, "audiocpu", 0 )
+	ROM_REGION( 0x10000, "nmk004", 0 )
 	ROM_LOAD( "strahl-4.66",    0x00000, 0x10000, CRC(60a799c4) SHA1(8ade3cf827a389f7cb4080957dc4d67077ea4166) )
 
 	ROM_REGION( 0xa0000, "oki1", 0 )    // Oki sample data
@@ -7758,7 +7777,7 @@ ROM_START( strahljbl ) // N0 892 PCB, this bootleg uses SEIBU sound system
 	ROM_LOAD( "d.8m",  0x000000, 0x100000, CRC(09ede4d4) SHA1(5c5dcc57f78145b9c6e711a32afc0aab7a5a0450) )
 	ROM_LOAD( "5.4m",  0x100000, 0x080000, CRC(a0e7d210) SHA1(96a762a3a1cdeaa91bde50429e0ac665fb81190b) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) // same as original
+	ROM_REGION( 0x80000, "bg2tile", 0 ) // same as original
 	ROM_LOAD( "4.4m", 0x000000, 0x80000, CRC(bb1bb155) SHA1(83a02e89180e15f0e7817e0e92b4bf4e209bb69a) ) // Tiles
 
 	ROM_REGION(0x20000, "audiocpu", 0 )
@@ -7782,7 +7801,7 @@ ROM_START( hachamf )
 	// has 'WAKAUS' for the game name string, and appears to have programs for multiple games, depending on port 7 reads
 	ROM_LOAD( "nmk-113.bin", 0x00000, 0x04000, CRC(f3072715) SHA1(cee6534de6645c41cbbb1450ad3e5207e44460c7) )
 
-	ROM_REGION( 0x10000, "audiocpu", 0 ) // NMK004 sound data
+	ROM_REGION( 0x10000, "nmk004", 0 ) // NMK004 sound data
 	ROM_LOAD( "1.70",  0x00000, 0x10000, CRC(9e6f48fc) SHA1(aeb5bfecc025b5478f6de874792fc0f7f54932be) )
 
 	ROM_REGION( 0x020000, "fgtile", 0 )
@@ -7818,7 +7837,7 @@ ROM_START( hachamfa) // reportedly a Korean PCB / version
 	// has 'WAKAUS' for the game name string, and appears to have programs for multiple games, depending on port 7 reads
 	ROM_LOAD( "nmk-113.bin", 0x00000, 0x04000, CRC(f3072715) SHA1(cee6534de6645c41cbbb1450ad3e5207e44460c7) )
 
-	ROM_REGION( 0x10000, "audiocpu", 0 ) // NMK004 sound data
+	ROM_REGION( 0x10000, "nmk004", 0 ) // NMK004 sound data
 	ROM_LOAD( "1.70",  0x00000, 0x10000, CRC(9e6f48fc) SHA1(aeb5bfecc025b5478f6de874792fc0f7f54932be) )
 
 	ROM_REGION( 0x020000, "fgtile", 0 ) // Smaller NMK logo plus alternate  Distributed by UPL  Company Limited  starting at tile 0xF80
@@ -7850,7 +7869,7 @@ ROM_START( hachamfb ) // Thunder Dragon conversion - unprotected prototype or bo
 	ROM_LOAD16_BYTE( "8.bin",  0x00000, 0x20000, CRC(14845b65) SHA1(5cafd07a8a6f5ccbb36de7a90571f8b33ecf273e) ) // internally reports as 19th Sep. 1991
 	ROM_LOAD16_BYTE( "7.bin",  0x00001, 0x20000, CRC(069ca579) SHA1(0db4c3c41e17fca613d11de89b388a4af206ec6b) )
 
-	ROM_REGION( 0x10000, "audiocpu", 0 ) // NMK004 sound data
+	ROM_REGION( 0x10000, "nmk004", 0 ) // NMK004 sound data
 	ROM_LOAD( "1.70",  0x00000, 0x10000, CRC(9e6f48fc) SHA1(aeb5bfecc025b5478f6de874792fc0f7f54932be) )
 
 	ROM_REGION( 0x020000, "fgtile", 0 )
@@ -7882,7 +7901,7 @@ ROM_START( hachamfp ) // Protoype Location Test Release; Hand-written labels wit
 	ROM_LOAD16_BYTE( "kf-68-pe-b.ic7",  0x00000, 0x20000, CRC(b98a525e) SHA1(161c3b3360068e606e4d4104cc172b9736a52eeb) ) // Label says "KF 9/25 II 68 PE B"
 	ROM_LOAD16_BYTE( "kf-68-po-b.ic6",  0x00001, 0x20000, CRC(b62ad179) SHA1(60a66fb9eb3fc792d172e1f4507a806ac2ad4217) ) // Label says "KF 9/25 II 68 PO B"
 
-	ROM_REGION( 0x10000, "audiocpu", 0 ) // NMK004 sound data
+	ROM_REGION( 0x10000, "nmk004", 0 ) // NMK004 sound data
 	ROM_LOAD( "kf-snd.ic4",  0x00000, 0x10000, CRC(f7cace47) SHA1(599f6406f5bea69d77f39847d5d5fa361cdb7d00) ) // Label says "KF 9/20 SND"
 
 	ROM_REGION( 0x020000, "fgtile", 0 )
@@ -7913,7 +7932,7 @@ ROM_START( macross )
 	ROM_REGION( 0x80000, "maincpu", 0 )     // 68000 code
 	ROM_LOAD16_WORD_SWAP( "921a03",        0x00000, 0x80000, CRC(33318d55) SHA1(c99f85e09bd334dc8ce138b08cbed2331b0d67dd) )
 
-	ROM_REGION( 0x10000, "audiocpu", 0 )        // sound program (unknown CPU)
+	ROM_REGION( 0x10000, "nmk004", 0 )        // sound program (NMK004)
 	ROM_LOAD( "921a02",      0x00000, 0x10000, CRC(77c082c7) SHA1(be07aa14d0116f830f98e11a19f1debb48a5230e) )
 
 	ROM_REGION( 0x020000, "fgtile", 0 )
@@ -8018,7 +8037,7 @@ ROM_START( gunnail )
 	ROM_LOAD16_BYTE( "3e.u131",  0x00000, 0x40000, CRC(61d985b2) SHA1(96daca603f18accb47f98a3e584b2c84fc5a2ca4) )
 	ROM_LOAD16_BYTE( "3o.u133",  0x00001, 0x40000, CRC(f114e89c) SHA1(a12f5278167f446bb5277e87289c41b5aa365c86) )
 
-	ROM_REGION( 0x10000, "audiocpu", 0 )     // Code for NMK004 CPU
+	ROM_REGION( 0x10000, "nmk004", 0 )     // Code for NMK004 CPU
 	ROM_LOAD( "92077_2.u101",      0x00000, 0x10000, CRC(cd4e55f8) SHA1(92182767ca0ec37ec4949bd1a88c2efdcdcb60ed) )
 
 	ROM_REGION( 0x020000, "fgtile", 0 )
@@ -8055,7 +8074,7 @@ ROM_START( gunnailp )
 	ROM_REGION( 0x80000, "maincpu", 0 )     // 68000 code
 	ROM_LOAD16_WORD_SWAP( "3.u132",  0x00000, 0x80000, CRC(93570f03) SHA1(54fb203b5bfceb0ac86627bff3e67863f460fe73) )
 
-	ROM_REGION( 0x10000, "audiocpu", 0 )     // Code for NMK004 CPU
+	ROM_REGION( 0x10000, "nmk004", 0 )     // Code for NMK004 CPU
 	ROM_LOAD( "92077_2.u101",      0x00000, 0x10000, CRC(cd4e55f8) SHA1(92182767ca0ec37ec4949bd1a88c2efdcdcb60ed) )
 
 	ROM_REGION( 0x020000, "fgtile", 0 )

--- a/src/mame/nmk/nmk16.h
+++ b/src/mame/nmk/nmk16.h
@@ -105,22 +105,6 @@ protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
-	TIMER_DEVICE_CALLBACK_MEMBER(nmk16_scanline);
-	TIMER_DEVICE_CALLBACK_MEMBER(nmk16_hacky_scanline);
-	u32 screen_update_macross(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-
-	void txvideoram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void flipscreen_w(u8 data);
-	void vandyke_flipscreen_w(u8 data);
-	void tilebank_w(u8 data);
-
-	void macross2_sound_reset_w(u16 data);
-	void macross2_audiobank_w(u8 data);
-	void ssmissin_okibank_w(u8 data);
-	void powerinsa_okibank_w(u8 data);
-	template<unsigned Chip> void tharrier_okibank_w(u8 data);
-	u8 powerins_bootleg_fake_ym2203_r();
-
 	required_device<cpu_device> m_maincpu;
 	optional_device<cpu_device> m_audiocpu;
 	optional_device_array<okim6295_device, 2> m_oki;
@@ -146,19 +130,18 @@ protected:
 	optional_ioport_array<2> m_dsw_io;
 	optional_ioport_array<3> m_in_io;
 
-	int m_tilerambank = 0;
+	u32 m_tilerambank = 0;
 	int m_sprdma_base = 0;
-	int mask[4*2]{};
 	std::unique_ptr<u16[]> m_spriteram_old;
 	std::unique_ptr<u16[]> m_spriteram_old2;
-	int m_bgbank = 0;
-	int m_bioship_background_bank = 0;
+	u8 m_bgbank = 0;
+	u8 m_bioship_background_bank = 0;
 	tilemap_t *m_bg_tilemap[2]{};
 	tilemap_t *m_tx_tilemap = nullptr;
-	int m_mustang_bg_xscroll = 0;
+	s32 m_mustang_bg_xscroll = 0;
 	u8 m_scroll[2][4]{};
 	u16 m_vscroll[4]{};
-	int m_prot_count = 0;
+	u8 m_prot_count = 0;
 	u8 m_vtiming_val = 0;
 
 	void mainram_strange_w(offs_t offset, u16 data/*, u16 mem_mask = ~0*/);
@@ -168,6 +151,11 @@ protected:
 	u16 tharrier_mcu_r(offs_t offset, u16 mem_mask = ~0);
 	u16 vandykeb_r();
 	u16 tdragonb_prot_r();
+
+	void flipscreen_w(u8 data);
+	void vandyke_flipscreen_w(u8 data);
+
+	void txvideoram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	template<unsigned Layer> void bgvideoram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void mustang_scroll_w(u16 data);
 	void raphero_scroll_w(offs_t offset, u16 data, u16 mem_mask = ~0);
@@ -176,15 +164,28 @@ protected:
 	void vandyke_scroll_w(offs_t offset, u16 data);
 	void vandykeb_scroll_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void manybloc_scroll_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void tilebank_w(u8 data);
 	void bioship_bank_w(u8 data);
 	void nmk004_x0016_w(u16 data);
 	void nmk004_bioship_x0016_w(u16 data);
+
+	void macross2_sound_reset_w(u16 data);
+	void macross2_audiobank_w(u8 data);
+	void ssmissin_okibank_w(u8 data);
+	void powerinsa_okibank_w(u8 data);
+	template<unsigned Chip> void tharrier_okibank_w(u8 data);
+	u8 powerins_bootleg_fake_ym2203_r();
 
 	void set_interrupt_timing(machine_config &config);
 	void set_hacky_interrupt_timing(machine_config &config);
 	void set_screen_lowres(machine_config &config);
 	void set_screen_midres(machine_config &config);
 	void set_screen_hires(machine_config &config);
+
+	void configure_nmk004(machine_config &config);
+
+	TIMER_DEVICE_CALLBACK_MEMBER(nmk16_scanline);
+	TIMER_DEVICE_CALLBACK_MEMBER(nmk16_hacky_scanline);
 
 	TILEMAP_MAPPER_MEMBER(tilemap_scan_pages);
 	template<unsigned Layer, unsigned Gfx> TILE_GET_INFO_MEMBER(common_get_bg_tile_info);
@@ -204,6 +205,7 @@ protected:
 	void get_colour_6bit(u32 &colour, u32 &pri_mask);
 	void get_sprite_flip(u16 attr, int &flipx, int &flipy, int &code);
 	void get_flip_extcode_powerins(u16 attr, int &flipx, int &flipy, int &code);
+	u32 screen_update_macross(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	u32 screen_update_tharrier(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	u32 screen_update_strahl(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	u32 screen_update_bjtwin(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
@@ -381,9 +383,9 @@ private:
 	void redhawki_video_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 	void afega_map(address_map &map) ATTR_COLD;
-	void afega_sound_cpu(address_map &map) ATTR_COLD;
+	void afega_sound_map(address_map &map) ATTR_COLD;
 	void firehawk_map(address_map &map) ATTR_COLD;
-	void firehawk_sound_cpu(address_map &map) ATTR_COLD;
+	void firehawk_sound_map(address_map &map) ATTR_COLD;
 };
 
 class nmk16_tomagic_state : public nmk16_state

--- a/src/mame/nmk/nmk16_v.cpp
+++ b/src/mame/nmk/nmk16_v.cpp
@@ -94,8 +94,7 @@ void nmk16_state::video_init()
 	save_pointer(NAME(m_spriteram_old2), 0x1000/2);
 	save_item(NAME(m_bgbank));
 	save_item(NAME(m_mustang_bg_xscroll));
-	save_item(NAME(m_scroll[0]));
-	save_item(NAME(m_scroll[1]));
+	save_item(NAME(m_scroll));
 	save_item(NAME(m_vscroll));
 	save_item(NAME(m_tilerambank));
 }
@@ -112,7 +111,7 @@ VIDEO_START_MEMBER(nmk16_state, bioship)
 	m_tx_tilemap->set_transparent_pen(15);
 
 	video_init();
-	m_bioship_background_bank=0;
+	m_bioship_background_bank = 0;
 	save_item(NAME(m_bioship_background_bank));
 	m_bg_tilemap[0]->set_scrolldx(92, 92);
 	m_bg_tilemap[1]->set_scrolldx(92, 92);
@@ -209,7 +208,7 @@ void nmk16_state::mustang_scroll_w(u16 data)
 	switch (data & 0xff00)
 	{
 		case 0x0000:
-			m_mustang_bg_xscroll = (m_mustang_bg_xscroll & 0x00ff) | ((data & 0x00ff)<<8);
+			m_mustang_bg_xscroll = (m_mustang_bg_xscroll & 0x00ff) | ((data & 0x00ff) << 8);
 			break;
 
 		case 0x0100:
@@ -226,20 +225,20 @@ void nmk16_state::mustang_scroll_w(u16 data)
 			break;
 	}
 
-	m_bg_tilemap[0]->set_scrollx(0,m_mustang_bg_xscroll);
+	m_bg_tilemap[0]->set_scrollx(0, m_mustang_bg_xscroll);
 }
 
 void nmk16_state::bjtwin_scroll_w(offs_t offset, u8 data)
 {
-	m_bg_tilemap[0]->set_scrolly(0,-data);
+	m_bg_tilemap[0]->set_scrolly(0, -data);
 }
 
 void nmk16_state::vandyke_scroll_w(offs_t offset, u16 data)
 {
 	m_vscroll[offset] = data;
 
-	m_bg_tilemap[0]->set_scrollx(0,m_vscroll[0] * 256 + (m_vscroll[1] >> 8));
-	m_bg_tilemap[0]->set_scrolly(0,m_vscroll[2] * 256 + (m_vscroll[3] >> 8));
+	m_bg_tilemap[0]->set_scrollx(0, m_vscroll[0] * 256 + (m_vscroll[1] >> 8));
+	m_bg_tilemap[0]->set_scrolly(0, m_vscroll[2] * 256 + (m_vscroll[3] >> 8));
 }
 
 void nmk16_state::vandykeb_scroll_w(offs_t offset, u16 data, u16 mem_mask)
@@ -252,21 +251,21 @@ void nmk16_state::vandykeb_scroll_w(offs_t offset, u16 data, u16 mem_mask)
 	case 6: COMBINE_DATA(&m_vscroll[0]); break;
 	}
 
-	m_bg_tilemap[0]->set_scrollx(0,m_vscroll[0] * 256 + (m_vscroll[1] >> 8));
-	m_bg_tilemap[0]->set_scrolly(0,m_vscroll[2] * 256 + (m_vscroll[3] >> 8));
+	m_bg_tilemap[0]->set_scrollx(0, m_vscroll[0] * 256 + (m_vscroll[1] >> 8));
+	m_bg_tilemap[0]->set_scrolly(0, m_vscroll[2] * 256 + (m_vscroll[3] >> 8));
 }
 
 void nmk16_state::manybloc_scroll_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_gunnail_scrollram[offset]);
 
-	m_bg_tilemap[0]->set_scrollx(0,m_gunnail_scrollram[0x82/2]);
-	m_bg_tilemap[0]->set_scrolly(0,m_gunnail_scrollram[0xc2/2]);
+	m_bg_tilemap[0]->set_scrollx(0, m_gunnail_scrollram[0x82/2]);
+	m_bg_tilemap[0]->set_scrolly(0, m_gunnail_scrollram[0xc2/2]);
 }
 
 void nmk16_state::flipscreen_w(u8 data)
 {
-	flip_screen_set(data & 0x01);
+	flip_screen_set(BIT(data, 0));
 	m_spritegen->set_flip_screen(flip_screen());
 }
 
@@ -292,7 +291,7 @@ void nmk16_state::raphero_scroll_w(offs_t offset, u16 data, u16 mem_mask)
 	COMBINE_DATA(&m_gunnail_scrollram[offset]);
 	if ((m_bgvideoram[0].bytes() > 0x4000) && (offset == 0))
 	{
-		int newbank = (m_gunnail_scrollram[0] >> 12) & ((m_bgvideoram[0].bytes() >> 14) - 1);
+		const int newbank = (m_gunnail_scrollram[0] >> 12) & ((m_bgvideoram[0].bytes() >> 14) - 1);
 		if (m_tilerambank != newbank)
 		{
 			m_tilerambank = newbank;
@@ -343,13 +342,13 @@ void nmk16_state::get_colour_6bit(u32 &colour, u32 &pri_mask)
 
 void nmk16_state::get_sprite_flip(u16 attr, int &flipx, int &flipy, int &code)
 {
-	flipy = (attr & 0x200) >> 9;
-	flipx = (attr & 0x100) >> 8;
+	flipy = BIT(attr, 9);
+	flipx = BIT(attr, 8);
 }
 
 void nmk16_state::get_flip_extcode_powerins(u16 attr, int &flipx, int &flipy, int &code)
 {
-	flipx = (attr & 0x1000) >> 12;
+	flipx = BIT(attr, 12);
 	code = (code & 0x7fff) | ((attr & 0x100) << 7);
 }
 
@@ -425,7 +424,7 @@ u32 nmk16_state::screen_update_tharrier(screen_device &screen, bitmap_ind16 &bit
 {
 	screen.priority().fill(0, cliprect);
 	/* I think the protection device probably copies this to the regs... */
-	u16 tharrier_scroll = m_mainram[0x9f00/2];
+	const u16 tharrier_scroll = m_mainram[0x9f00/2];
 
 	m_bg_tilemap[0]->set_scrollx(0, tharrier_scroll);
 
@@ -459,7 +458,7 @@ void nmk16_state::screen_vblank_powerins_bootleg(int state)
 	{
 		m_maincpu->set_input_line(4, HOLD_LINE);
 		// bootlegs don't have DMA?
-		memcpy(m_spriteram_old2.get(),m_spriteram_old.get(), 0x1000);
+		memcpy(m_spriteram_old2.get(), m_spriteram_old.get(), 0x1000);
 		memcpy(m_spriteram_old.get(), m_mainram + m_sprdma_base / 2, 0x1000);
 	}
 }
@@ -511,8 +510,8 @@ void afega_state::video_update(screen_device &screen, bitmap_ind16 &bitmap, cons
 	screen.priority().fill(0, cliprect);
 	if (dsw_flipscreen)
 	{
-		flip_screen_x_set(~m_dsw_io[0]->read() & 0x0100);
-		flip_screen_y_set(~m_dsw_io[0]->read() & 0x0200);
+		flip_screen_x_set(BIT(~m_dsw_io[0]->read(), 8));
+		flip_screen_y_set(BIT(~m_dsw_io[0]->read(), 9));
 	}
 
 	m_bg_tilemap[0]->set_scrollx(0, m_afega_scroll[0][1] + xoffset);
@@ -531,8 +530,8 @@ void afega_state::video_update(screen_device &screen, bitmap_ind16 &bitmap, cons
 void afega_state::redhawki_video_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen.priority().fill(0, cliprect);
-	m_bg_tilemap[0]->set_scrollx(0, m_afega_scroll[1][0]&0xff);
-	m_bg_tilemap[0]->set_scrolly(0, m_afega_scroll[1][1]&0xff);
+	m_bg_tilemap[0]->set_scrollx(0, m_afega_scroll[1][0] & 0xff);
+	m_bg_tilemap[0]->set_scrolly(0, m_afega_scroll[1][1] & 0xff);
 
 	m_bg_tilemap[0]->draw(screen, bitmap, cliprect, 0, 1);
 


### PR DESCRIPTION
nmk/nmk004.cpp Cleanups:
- Remove hardcoded tags
- Reduce duplicates
- Fix naming

nmk/nmk16.cpp: Cleanups:
- Suppress side effects for debugger reads
- Reduce literal tag usage
- Make some variables constant
- Fix save states
- Remove unused variables
- Fix spacings
- Fix namings
- Add notes