### PR TITLE
macadb: add support for second button of an ADB mouse

### DIFF
--- a/src/mame/apple/macadb.cpp
+++ b/src/mame/apple/macadb.cpp
@@ -82,8 +82,9 @@ enum
 DEFINE_DEVICE_TYPE(MACADB, macadb_device, "macadb", "Mac ADB HLE")
 
 static INPUT_PORTS_START( macadb )
-	PORT_START("MOUSE0") /* Mouse - button */
-	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON1) PORT_NAME("Mouse Button") PORT_CODE(MOUSECODE_BUTTON1)
+	PORT_START("MOUSE0") /* Mouse - buttons */
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON1) PORT_NAME("Mouse Button 0") PORT_CODE(MOUSECODE_BUTTON1)
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_BUTTON2) PORT_NAME("Mouse Button 1") PORT_CODE(MOUSECODE_BUTTON2)
 
 	PORT_START("MOUSE1") /* Mouse - X AXIS */
 	PORT_BIT( 0xff, 0x00, IPT_MOUSE_X) PORT_SENSITIVITY(100) PORT_KEYDELTA(0) PORT_PLAYER(1)
@@ -477,7 +478,7 @@ bool macadb_device::adb_pollmouse()
 {
 	s32 NewX, NewY, NewButton;
 
-	NewButton = m_mouse0->read() & 0x01;
+	NewButton = m_mouse0->read() & 0x03;
 	NewX = m_mouse1->read();
 	NewY = m_mouse2->read();
 
@@ -529,7 +530,7 @@ void macadb_device::adb_accummouse(u8 *MouseX, u8 *MouseY )
 		m_lastmousey = NewY;
 	}
 
-	m_lastbutton = m_mouse0->read() & 0x01;
+	m_lastbutton = m_mouse0->read() & 0x03;
 
 	*MouseX = (u8)MouseCountX;
 	*MouseY = (u8)MouseCountY;
@@ -613,7 +614,8 @@ void macadb_device::adb_talk()
 							//printf("X %x Y %x\n", mouseX, mouseY);
 							m_buffer[0] = (m_lastbutton & 0x01) ? 0x00 : 0x80;
 							m_buffer[0] |= mouseY & 0x7f;
-							m_buffer[1] = (mouseX & 0x7f) | 0x80;
+							m_buffer[1] = (m_lastbutton & 0x02) ? 0x00 : 0x80;
+							m_buffer[1] |= mouseX & 0x7f;
 
 							if ((m_buffer[0] != m_last_mouse[0]) || (m_buffer[1] != m_last_mouse[1]))
 							{


### PR DESCRIPTION
This PR adds support for the second button of an ADB mouse

Testing:
Apple IIGS emulation with MAME 0.273 has the following behavior with regards to the second mouse button:
- The "Shift-Command-Clear" combination enables the ADB mouse keypad.  With a ROM 01, this sequence seems to only work if System Software is running.  With a ROM 03, it also works if ProDOS is running (probably any OS).
- The "Clear" disables the ADB mouse keypad.
- The keypad 5 key emulates the first mouse button.  This works with both apple2gs (ROM 03) and apple2gsr1 (ROM 01)
- The keypad - key emulates the second mouse button.  This only works with the apple2gs (ROM 03)
- There is no means to generate the second mouse button press using the MAME emulated mouse.

Application support (note, with MAME 0.273, the tests below can only be performed with a ROM 03 Apple IIGS):
- System Software 6.0.1 responds to either of the two mouse buttons.
- The 8-bit MousePaint application only responds to the first mouse button.  This is expected since it is not a IIGS specific application.  This test is mostly useful in conjunction with the System Software test to confirm that the two buttons are in distinct.

With this PR's change, the second mouse button can be clicked using the actual mouse.  This works works with the ROM 01 IIGS as well.
