### PR TITLE
Adding IBM System/23 Datamaster

### DIFF
--- a/hash/amiga_cd.xml
+++ b/hash/amiga_cd.xml
@@ -5,7 +5,7 @@ license:CC0-1.0
 
 http://redump.org/discs/system/acd
 -->
-<softwarelist name="amigacd" description="Commodore AmigaCD images">
+<softwarelist name="amiga_cd" description="Commodore AmigaCD images">
 
 <!-- !Games -->
 

--- a/src/devices/video/i8275.cpp
+++ b/src/devices/video/i8275.cpp
@@ -27,7 +27,6 @@
     TODO:
 
     - double spaced rows
-    - preset counters - how it affects DMA and HRTC?
 
 */
 
@@ -418,6 +417,7 @@ std::pair<uint8_t, uint8_t> i8275_device::char_from_buffer(int n, int sx, int rc
 		{
 			// simply blank the attribute character itself
 			attr = FAC_B;
+			attr |= (data & FAC_GG); // add the GG attributes
 		}
 	}
 	else if (data >= 0xf0 || BIT(end_of_row, n))

--- a/src/devices/video/i8275.cpp
+++ b/src/devices/video/i8275.cpp
@@ -36,7 +36,7 @@
 
 #include "screen.h"
 
-//#define VERBOSE 1
+#define VERBOSE 1
 #include "logmacro.h"
 
 
@@ -144,6 +144,13 @@ void i8275_device::device_start()
 		m_drq_on_timer = timer_alloc(FUNC(i8275_device::drq_on), this);
 		m_scanline_timer = timer_alloc(FUNC(i8275_device::scanline_tick), this);
 	}
+
+	//preinitialize the device with valid data (in real hardware parameters initialize to random)
+	m_param[REG_SCN1] = 0x4f;
+	m_param[REG_SCN2] = 0x58;
+	m_param[REG_SCN3] = 0x89;
+	m_param[REG_SCN4] = 0xd9;
+	recompute_parameters();
 
 	// state saving
 	save_item(NAME(m_status));
@@ -300,6 +307,7 @@ TIMER_CALLBACK_MEMBER(i8275_device::scanline_tick)
 		{
 			if ((crtc->m_status & ST_IE) && !(crtc->m_status & ST_IR))
 			{
+				LOG("I8275 IRQ Set\n");
 				crtc->m_status |= ST_IR;
 				crtc->m_write_irq(ASSERT_LINE);
 			}

--- a/src/devices/video/i8275.cpp
+++ b/src/devices/video/i8275.cpp
@@ -36,7 +36,7 @@
 
 #include "screen.h"
 
-#define VERBOSE 1
+//#define VERBOSE 1
 #include "logmacro.h"
 
 

--- a/src/mame/ibm/system23.cpp
+++ b/src/mame/ibm/system23.cpp
@@ -2,6 +2,8 @@
 #include "cpu/i8085/i8085.h"
 #include "machine/i8255.h"
 
+#include "ibmsystem23.lh"
+
 namespace system23
 {
 	class system23_state: public driver_device
@@ -29,12 +31,12 @@ namespace system23
 
 			void system23_io(address_map &map) ATTR_COLD;
 			void system23_mem(address_map &map) ATTR_COLD;
-	}
+	};
 
 	void system23_state::diag_digits_w(uint8_t data)
 	{
-		m_diag_digits[0] = val & 0x0f;
-		m_diag_digits[1] = (val >> 4) & 0x0f;
+		m_diag_digits[0] = data & 0x0f;
+		m_diag_digits[1] = (data >> 4) & 0x0f;
 	}
 
 	void system23_state::system23_io(address_map &map)
@@ -46,16 +48,28 @@ namespace system23
 	void system23_state::system23_mem(address_map &map)
 	{
 		map.unmap_value_high();
-		map(0x0000, 0x3fff).rom.region("ros_unpaged");
+		map(0x0000, 0x3fff).rom().region("ros_unpaged",0);
+	}
+
+	void system23_state::system23(machine_config &config)
+	{
+		i8085a_cpu_device &maincpu(I8085A(config, "maincpu", 6_MHz_XTAL)); //frequency needs to be adjusted
+		maincpu.set_addrmap(AS_PROGRAM, &system23_state::system23_mem);
+		maincpu.set_addrmap(AS_IO, &system23_state::system23_io);
+
+		config.set_perfect_quantum("maincpu");
+		config.set_default_layout(layout_ibmsystem23);
+
+
 	}
 
 	ROM_START( system23 )
-		ROM_REGION(0x1800, "ros_unpaged", 0)
+		ROM_REGION(0x4000, "ros_unpaged", 0)
 		ROM_LOAD("02_61c9866a_4481186.bin", 0x0000, 0x2000, CRC(61c9866a) SHA1(3b51a6b72d2ccae2459ddb2e16fbd21b19dfa2b8) )
 		ROM_LOAD("09_07843020_8493747.bin", 0x2000, 0x2000, CRC(07843020) SHA1(078405ad202e26b7bac7132b06682fb01270af63) )
 	ROM_END
 
 
-	COMP( 1981, system23, 0,      0,      system23, 0,     system23_state, empty_init, "IBM",   "IBM System/23 Datamaster", MACHINE_SKELETON | MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+	COMP( 1981, system23, 0,      0,      system23, 0,     system23_state, empty_init, "IBM",   "IBM System/23 Datamaster", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
 
 }

--- a/src/mame/ibm/system23.cpp
+++ b/src/mame/ibm/system23.cpp
@@ -1,0 +1,61 @@
+#include "emu.h"
+#include "cpu/i8085/i8085.h"
+#include "machine/i8255.h"
+
+namespace system23
+{
+	class system23_state: public driver_device
+	{
+		public:
+			system23_state(const machine_config &mconfig, device_type type, const char *tag)
+				: driver_device(mconfig, type, tag),
+				m_ppi8255(*this,"ppi8255"),
+				m_diag_digits(*this, "digit%u", 0U)
+			{
+
+			}
+
+			void system23(machine_config &config);
+
+		protected:
+			virtual void machine_start() override ATTR_COLD;
+			virtual void machine_reset() override ATTR_COLD;
+
+		private:
+			required_device<i8255_device> m_ppi8255;
+			output_finder<2> m_diag_digits;
+
+			void diag_digits_w(uint8_t data);
+
+			void system23_io(address_map &map) ATTR_COLD;
+			void system23_mem(address_map &map) ATTR_COLD;
+	}
+
+	void system23_state::diag_digits_w(uint8_t data)
+	{
+		m_diag_digits[0] = val & 0x0f;
+		m_diag_digits[1] = (val >> 4) & 0x0f;
+	}
+
+	void system23_state::system23_io(address_map &map)
+	{
+		map.unmap_value_high();
+		map(0x43, 0x43).w(FUNC(diag_digits_w));
+	}
+
+	void system23_state::system23_mem(address_map &map)
+	{
+		map.unmap_value_high();
+		map(0x0000, 0x3fff).rom.region("ros_unpaged");
+	}
+
+	ROM_START( system23 )
+		ROM_REGION(0x1800, "ros_unpaged", 0)
+		ROM_LOAD("02_61c9866a_4481186.bin", 0x0000, 0x2000, CRC(61c9866a) SHA1(3b51a6b72d2ccae2459ddb2e16fbd21b19dfa2b8) )
+		ROM_LOAD("09_07843020_8493747.bin", 0x2000, 0x2000, CRC(07843020) SHA1(078405ad202e26b7bac7132b06682fb01270af63) )
+	ROM_END
+
+
+	COMP( 1981, system23, 0,      0,      system23, 0,     system23_state, empty_init, "IBM",   "IBM System/23 Datamaster", MACHINE_SKELETON | MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+
+}

--- a/src/mame/ibm/system23.cpp
+++ b/src/mame/ibm/system23.cpp
@@ -7,6 +7,8 @@
 #include "machine/i8257.h"
 #include "video/i8275.h"
 #include "machine/ram.h"
+#include "screen.h"
+#include "emupal.h"
 
 #include "ibmsystem23.lh"
 
@@ -21,9 +23,12 @@ namespace
 				m_ppi_kbd(*this, "ppi_kbd"),
 				m_ppi_diag(*this, "ppi_diag"),
 				m_ppi_settings(*this, "ppi_settings"),
-				m_dma(*this,"dma"),
-				m_crtc(*this,"crtc"),
+				m_dmac(*this,"dma"),
+				m_crtc(*this, "crtc"),
+				m_palette(*this, "palette"),
+				m_chargen(*this, "chargen"),
 				m_ram(*this, RAM_TAG),
+				m_screen(*this, "screen"),
 				m_diag_digits(*this, "digit%u", 0U)
 
 			{
@@ -41,9 +46,13 @@ namespace
 			required_device<i8255_device> m_ppi_kbd;
 			required_device<i8255_device> m_ppi_diag;
 			required_device<i8255_device> m_ppi_settings;
-			required_device<i8257_device> m_dma;
+			required_device<i8257_device> m_dmac;
 			required_device<i8275_device> m_crtc;
+			required_device<palette_device> m_palette;
+			required_region_ptr<uint8_t> m_chargen;
 			required_device<ram_device> m_ram;
+			required_device<screen_device> m_screen;
+
 			output_finder<2> m_diag_digits;
 
 			uint8_t m_bus_test_register = 0;
@@ -59,6 +68,14 @@ namespace
 			uint8_t sid_sod_connection;
 			void sod_w(int state);
 			int sid_r();
+
+			uint8_t dmac_mem_r(offs_t offset);
+			void dmac_mem_w(offs_t offset, uint8_t data);
+
+			void dmac_hrq_w(int state);
+
+			void crtc_dack_w(offs_t offset, uint8_t data);
+			I8275_DRAW_CHARACTER_MEMBER(display_pixels);
 
 			void system23_io(address_map &map) ATTR_COLD;
 			void system23_mem(address_map &map) ATTR_COLD;
@@ -95,10 +112,52 @@ namespace
 		sid_sod_connection = state;
 	}
 
+	uint8_t system23_state::dmac_mem_r(offs_t offset)
+	{
+		return m_maincpu->space(AS_PROGRAM).read_byte(offset);
+	}
+
+	void system23_state::dmac_mem_w(offs_t offset, uint8_t data)
+	{
+		m_maincpu->space(AS_PROGRAM).write_byte(offset, data);
+	}
+
+	void system23_state::dmac_hrq_w(int state)
+	{
+		m_maincpu->set_input_line(INPUT_LINE_HALT, state ? ASSERT_LINE : CLEAR_LINE);
+		m_dmac->hlda_w(state);
+	}
+
+	I8275_DRAW_CHARACTER_MEMBER( system23_state::display_pixels )
+	{
+		const rgb_t *palette = m_palette->palette()->entry_list_raw();
+		uint8_t gfx = 0;
+
+		using namespace i8275_attributes;
+
+		if (!BIT(attrcode, VSP))
+			gfx = m_chargen[(linecount & 15) | (charcode << 4)];
+
+		if (BIT(attrcode, LTEN))
+			gfx = 0xff;
+
+		if (BIT(attrcode, RVV))
+			gfx ^= 0xff;
+
+		// Highlight not used
+		bitmap.pix(y, x++) = BIT(gfx, 1) ? palette[1] : palette[0];
+		bitmap.pix(y, x++) = BIT(gfx, 2) ? palette[1] : palette[0];
+		bitmap.pix(y, x++) = BIT(gfx, 3) ? palette[1] : palette[0];
+		bitmap.pix(y, x++) = BIT(gfx, 4) ? palette[1] : palette[0];
+		bitmap.pix(y, x++) = BIT(gfx, 5) ? palette[1] : palette[0];
+		bitmap.pix(y, x++) = BIT(gfx, 6) ? palette[1] : palette[0];
+		bitmap.pix(y, x++) = BIT(gfx, 7) ? palette[1] : palette[0];
+	}
+
 	void system23_state::system23_io(address_map &map)
 	{
 		map.unmap_value_high();
-		map(0x00, 0x0f).rw(m_dma, FUNC(i8257_device::read), FUNC(i8257_device::write));
+		map(0x00, 0x08).rw(m_dmac, FUNC(i8257_device::read), FUNC(i8257_device::write));
 		map(0x2c, 0x2f).rw(m_ppi_settings, FUNC(i8255_device::read), FUNC(i8255_device::write));
 		map(0x40, 0x43).rw(m_ppi_diag, FUNC(i8255_device::read), FUNC(i8255_device::write));
 		map(0x44, 0x47).rw(m_crtc, FUNC(i8275_device::read), FUNC(i8275_device::write));
@@ -115,7 +174,7 @@ namespace
 
 	void system23_state::system23(machine_config &config)
 	{
-		i8085a_cpu_device &maincpu(I8085A(config, "maincpu", 6.144_MHz_XTAL)); //frequency needs to be adjusted
+		i8085a_cpu_device &maincpu(I8085A(config, "maincpu", (18'432'000 / 3))); //frequency needs to be adjusted
 		maincpu.set_addrmap(AS_PROGRAM, &system23_state::system23_mem);
 		maincpu.set_addrmap(AS_IO, &system23_state::system23_io);
 		maincpu.in_sid_func().set(FUNC(system23_state::sid_r));
@@ -131,9 +190,23 @@ namespace
 		I8255(config, m_ppi_settings);
 		m_ppi_settings->in_pc_callback().set(FUNC(system23_state::memory_settings_r));
 
-		I8257(config, m_dma, 6.144_MHz_XTAL / 2); //frequency needs to be adjusted
+		I8257(config, m_dmac, (18'432'000 / 6)); //frequency needs to be adjusted
+		m_dmac->out_memw_cb().set(FUNC(system23_state::dmac_mem_w));
+		m_dmac->in_memr_cb().set(FUNC(system23_state::dmac_mem_r));
+		m_dmac->out_iow_cb<2>().set(m_crtc, FUNC(i8275_device::dack_w));
+		m_dmac->out_hrq_cb().set(FUNC(dmac_hrq_w));
+
+		PALETTE(config, m_palette, palette_device::MONOCHROME_HIGHLIGHT);
+
+		SCREEN(config, m_screen, SCREEN_TYPE_RASTER, rgb_t::green());
+		m_screen->set_raw(18'432'000, 800, 0, 640, 324, 0, 300);
+		m_screen->set_screen_update(m_crtc, FUNC(i8275_device::screen_update));
+		m_screen->set_palette(m_palette);
 
 		I8275(config, m_crtc, (18'432'000 / 8));
+		m_crtc->set_character_width(8);
+		m_crtc->set_screen(m_screen);
+		m_crtc->set_display_callback(FUNC(system23_state::display_pixels));
 
 		RAM(config, m_ram).set_default_size("16k");
 
@@ -151,10 +224,14 @@ namespace
 
 	}
 
+
 	ROM_START( system23 )
 		ROM_REGION(0x4000, "ros_unpaged", 0)
 		ROM_LOAD("02_61c9866a_4481186.bin", 0x0000, 0x2000, CRC(61c9866a) SHA1(43f2bed5cc2374c7fde4632948329062e57e994b) )
 		ROM_LOAD("09_07843020_8493747.bin", 0x2000, 0x2000, CRC(07843020) SHA1(828ca0199af1246f6caf58bcb785f791c3a7e34e) )
+
+		ROM_REGION(0x2000, "chargen", 0)
+		ROM_LOAD("chr_73783bc7_8519412.bin", 0x0000, 0x2000, CRC(73783bc7) SHA1(45ee2a9acbb577b281ad8181b7ec0c5ef05c346a))
 	ROM_END
 
 }

--- a/src/mame/ibm/system23.cpp
+++ b/src/mame/ibm/system23.cpp
@@ -5,6 +5,7 @@
 #include "cpu/i8085/i8085.h"
 #include "machine/i8255.h"
 #include "machine/i8257.h"
+#include "video/i8275.h"
 #include "machine/ram.h"
 
 #include "ibmsystem23.lh"
@@ -21,6 +22,7 @@ namespace
 				m_ppi_diag(*this, "ppi_diag"),
 				m_ppi_settings(*this, "ppi_settings"),
 				m_dma(*this,"dma"),
+				m_crtc(*this,"crtc"),
 				m_ram(*this, RAM_TAG),
 				m_diag_digits(*this, "digit%u", 0U)
 
@@ -40,6 +42,7 @@ namespace
 			required_device<i8255_device> m_ppi_diag;
 			required_device<i8255_device> m_ppi_settings;
 			required_device<i8257_device> m_dma;
+			required_device<i8275_device> m_crtc;
 			required_device<ram_device> m_ram;
 			output_finder<2> m_diag_digits;
 
@@ -98,6 +101,7 @@ namespace
 		map(0x00, 0x0f).rw(m_dma, FUNC(i8257_device::read), FUNC(i8257_device::write));
 		map(0x2c, 0x2f).rw(m_ppi_settings, FUNC(i8255_device::read), FUNC(i8255_device::write));
 		map(0x40, 0x43).rw(m_ppi_diag, FUNC(i8255_device::read), FUNC(i8255_device::write));
+		map(0x44, 0x47).rw(m_crtc, FUNC(i8275_device::read), FUNC(i8275_device::write));
 		map(0x4c, 0x4f).rw(m_ppi_kbd, FUNC(i8255_device::read), FUNC(i8255_device::write));
 	}
 
@@ -106,7 +110,7 @@ namespace
 		map.unmap_value_high();
 		map(0x0000, 0x3fff).rom().region("ros_unpaged",0);
 		map(0x8000, 0xbfff).ram();
-		//map(0xC000, 0xffff).ram();
+
 	}
 
 	void system23_state::system23(machine_config &config)
@@ -128,6 +132,8 @@ namespace
 		m_ppi_settings->in_pc_callback().set(FUNC(system23_state::memory_settings_r));
 
 		I8257(config, m_dma, 6.144_MHz_XTAL / 2); //frequency needs to be adjusted
+
+		I8275(config, m_crtc, (18'432'000 / 8));
 
 		RAM(config, m_ram).set_default_size("16k");
 

--- a/src/mame/ibm/system23.cpp
+++ b/src/mame/ibm/system23.cpp
@@ -9,6 +9,7 @@
 #include "machine/ram.h"
 #include "screen.h"
 #include "emupal.h"
+#include "logmacro.h"
 
 #include "ibmsystem23.lh"
 
@@ -68,7 +69,6 @@ namespace
 
 			uint8_t memory_settings_r();
 
-			uint8_t sid_sod_connection;
 			void sod_w(int state);
 			int sid_r();
 
@@ -122,7 +122,7 @@ namespace
 
 	void system23_state::sod_w(int state)
 	{
-		sid_sod_connection = state;
+		// At this point, it is unknown what SOD is attached to
 	}
 
 	//Those routines deal with the DMA controller accesses to memory and I/O devices
@@ -160,6 +160,16 @@ namespace
 
 		if (BIT(attrcode, RVV))
 			gfx ^= 0xff;
+
+		if (BIT(attrcode, GPA0) && BIT(attrcode, GPA1))
+		{
+			m_crtc->lpen_w(ASSERT_LINE);				//hack to test the light pen at test 05
+			LOG("Sytem/23: Light pen asserted\n");
+		}
+		else
+		{
+			m_crtc->lpen_w(CLEAR_LINE);
+		}
 
 		// Highlight not used
 		bitmap.pix(y, x++) = BIT(gfx, 1) ? 1 : 0;
@@ -235,6 +245,7 @@ namespace
 		m_crtc->drq_wr_callback().set(m_dmac, FUNC(i8257_device::dreq2_w));
 		//m_crtc->irq_wr_callback().set_inputline(m_maincpu, I8085_RST55_LINE); // Only when jumper J1 is bridged
 
+
 		RAM(config, m_ram).set_default_size("16k");
 
 		config.set_perfect_quantum(m_maincpu);
@@ -283,8 +294,8 @@ namespace
 
 
 	ROM_START( system23 )
-		ROM_SYSTEM_BIOS(0, "r_set", "1982?")
-		ROM_SYSTEM_BIOS(1, "tm_set", "1981?")
+		ROM_SYSTEM_BIOS(0, "r_set", "\"R\" Set - 1982?")
+		ROM_SYSTEM_BIOS(1, "tm_set", "\"TM\" Set - 1981?")
 
 		ROM_REGION(0x4000, "maincpu", 0)
 		ROMX_LOAD("02_61c9866a_4481186.bin", 0x0000, 0x2000, CRC(61c9866a) SHA1(43f2bed5cc2374c7fde4632948329062e57e994b),ROM_BIOS(0))
@@ -294,7 +305,8 @@ namespace
 		ROMX_LOAD("09_07843020_8493747.bin", 0x2000, 0x2000, CRC(07843020) SHA1(828ca0199af1246f6caf58bcb785f791c3a7e34e),ROM_BIOS(1))
 
 		ROM_REGION(0x2000, "chargen", 0)
-		ROM_LOAD("chr_73783bc7_8519412.bin", 0x0000, 0x2000, CRC(73783bc7) SHA1(45ee2a9acbb577b281ad8181b7ec0c5ef05c346a) )
+		ROMX_LOAD("chr_73783bc7_8519412.bin", 0x0000, 0x2000, CRC(73783bc7) SHA1(45ee2a9acbb577b281ad8181b7ec0c5ef05c346a),ROM_BIOS(0))
+		ROMX_LOAD("chr_73783bc7_6842372.bin", 0x0000, 0x2000, CRC(73783bc7) SHA1(45ee2a9acbb577b281ad8181b7ec0c5ef05c346a),ROM_BIOS(1))
 	ROM_END
 
 }

--- a/src/mame/ibm/system23.cpp
+++ b/src/mame/ibm/system23.cpp
@@ -4,13 +4,14 @@
 
 #include "ibmsystem23.lh"
 
-namespace system23
+namespace
 {
 	class system23_state: public driver_device
 	{
 		public:
 			system23_state(const machine_config &mconfig, device_type type, const char *tag)
 				: driver_device(mconfig, type, tag),
+				m_maincpu(*this, "maincpu"),
 				m_ppi8255(*this,"ppi8255"),
 				m_diag_digits(*this, "digit%u", 0U)
 			{
@@ -24,6 +25,7 @@ namespace system23
 			virtual void machine_reset() override ATTR_COLD;
 
 		private:
+			required_device<i8085a_cpu_device> m_maincpu;
 			required_device<i8255_device> m_ppi8255;
 			output_finder<2> m_diag_digits;
 
@@ -59,17 +61,25 @@ namespace system23
 
 		config.set_perfect_quantum("maincpu");
 		config.set_default_layout(layout_ibmsystem23);
+	}
 
+	void system23_state::machine_start()
+	{
+
+	}
+
+	void system23_state::machine_reset()
+	{
 
 	}
 
 	ROM_START( system23 )
 		ROM_REGION(0x4000, "ros_unpaged", 0)
-		ROM_LOAD("02_61c9866a_4481186.bin", 0x0000, 0x2000, CRC(61c9866a) SHA1(3b51a6b72d2ccae2459ddb2e16fbd21b19dfa2b8) )
-		ROM_LOAD("09_07843020_8493747.bin", 0x2000, 0x2000, CRC(07843020) SHA1(078405ad202e26b7bac7132b06682fb01270af63) )
+		ROM_LOAD("02_61c9866a_4481186.bin", 0x0000, 0x2000, CRC(61c9866a) SHA1(43f2bed5cc2374c7fde4632948329062e57e994b) )
+		ROM_LOAD("09_07843020_8493747.bin", 0x2000, 0x2000, CRC(07843020) SHA1(828ca0199af1246f6caf58bcb785f791c3a7e34e) )
 	ROM_END
 
+}
 
 	COMP( 1981, system23, 0,      0,      system23, 0,     system23_state, empty_init, "IBM",   "IBM System/23 Datamaster", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
 
-}

--- a/src/mame/ibm/system23.cpp
+++ b/src/mame/ibm/system23.cpp
@@ -4,6 +4,8 @@
 #include "emu.h"
 #include "cpu/i8085/i8085.h"
 #include "machine/i8255.h"
+#include "machine/i8257.h"
+#include "machine/ram.h"
 
 #include "ibmsystem23.lh"
 
@@ -17,8 +19,9 @@ namespace
 				m_maincpu(*this, "maincpu"),
 				m_ppi_kbd(*this, "ppi_kbd"),
 				m_ppi_diag(*this, "ppi_diag"),
-				m_ram(*this, "ram"),
-				m_paged_ram(*this, "paged_ram"),
+				m_ppi_settings(*this, "ppi_settings"),
+				m_dma(*this,"dma"),
+				m_ram(*this, RAM_TAG),
 				m_diag_digits(*this, "digit%u", 0U)
 
 			{
@@ -35,8 +38,9 @@ namespace
 			required_device<i8085a_cpu_device> m_maincpu;
 			required_device<i8255_device> m_ppi_kbd;
 			required_device<i8255_device> m_ppi_diag;
-			required_shared_ptr<u8> m_ram;
-			required_shared_ptr<u8> m_paged_ram;
+			required_device<i8255_device> m_ppi_settings;
+			required_device<i8257_device> m_dma;
+			required_device<ram_device> m_ram;
 			output_finder<2> m_diag_digits;
 
 			uint8_t m_bus_test_register = 0;
@@ -46,6 +50,8 @@ namespace
 
 			void cpu_test_register_w(uint8_t data);
 			uint8_t cpu_test_register_r();
+
+			uint8_t memory_settings_r();
 
 			uint8_t sid_sod_connection;
 			void sod_w(int state);
@@ -71,9 +77,14 @@ namespace
 		return m_bus_test_register;
 	}
 
+	uint8_t system23_state::memory_settings_r()
+	{
+		return 0;	//Patch to make the memory test work while port 2e is being studied
+	}
+
 	int system23_state::sid_r()
 	{
-		return ASSERT_LINE; // patch to bypass the test
+		return ASSERT_LINE; // Actually, SID is tied to VCC at the motherboard
 	}
 
 	void system23_state::sod_w(int state)
@@ -84,6 +95,8 @@ namespace
 	void system23_state::system23_io(address_map &map)
 	{
 		map.unmap_value_high();
+		map(0x00, 0x0f).rw(m_dma, FUNC(i8257_device::read), FUNC(i8257_device::write));
+		map(0x2c, 0x2f).rw(m_ppi_settings, FUNC(i8255_device::read), FUNC(i8255_device::write));
 		map(0x40, 0x43).rw(m_ppi_diag, FUNC(i8255_device::read), FUNC(i8255_device::write));
 		map(0x4c, 0x4f).rw(m_ppi_kbd, FUNC(i8255_device::read), FUNC(i8255_device::write));
 	}
@@ -92,13 +105,13 @@ namespace
 	{
 		map.unmap_value_high();
 		map(0x0000, 0x3fff).rom().region("ros_unpaged",0);
-		map(0x8000, 0xbfff).ram().share("ram");
-		map(0xC000, 0xffff).ram().share("paged_ram");
+		map(0x8000, 0xbfff).ram();
+		//map(0xC000, 0xffff).ram();
 	}
 
 	void system23_state::system23(machine_config &config)
 	{
-		i8085a_cpu_device &maincpu(I8085A(config, "maincpu", 6_MHz_XTAL)); //frequency needs to be adjusted
+		i8085a_cpu_device &maincpu(I8085A(config, "maincpu", 6.144_MHz_XTAL)); //frequency needs to be adjusted
 		maincpu.set_addrmap(AS_PROGRAM, &system23_state::system23_mem);
 		maincpu.set_addrmap(AS_IO, &system23_state::system23_io);
 		maincpu.in_sid_func().set(FUNC(system23_state::sid_r));
@@ -110,6 +123,13 @@ namespace
 
 		I8255(config, m_ppi_diag);
 		m_ppi_diag->out_pb_callback().set(FUNC(system23_state::diag_digits_w));
+
+		I8255(config, m_ppi_settings);
+		m_ppi_settings->in_pc_callback().set(FUNC(system23_state::memory_settings_r));
+
+		I8257(config, m_dma);
+
+		RAM(config, m_ram).set_default_size("16k");
 
 		config.set_perfect_quantum("maincpu");
 		config.set_default_layout(layout_ibmsystem23);

--- a/src/mame/ibm/system23.cpp
+++ b/src/mame/ibm/system23.cpp
@@ -127,7 +127,7 @@ namespace
 		I8255(config, m_ppi_settings);
 		m_ppi_settings->in_pc_callback().set(FUNC(system23_state::memory_settings_r));
 
-		I8257(config, m_dma);
+		I8257(config, m_dma, 6.144_MHz_XTAL / 2); //frequency needs to be adjusted
 
 		RAM(config, m_ram).set_default_size("16k");
 

--- a/src/mame/ibm/system23.cpp
+++ b/src/mame/ibm/system23.cpp
@@ -29,6 +29,7 @@ namespace
 				m_chargen(*this, "chargen"),
 				m_ram(*this, RAM_TAG),
 				m_screen(*this, "screen"),
+				m_language(*this,"lang"),
 				m_diag_digits(*this, "digit%u", 0U)
 
 			{
@@ -52,7 +53,7 @@ namespace
 			required_region_ptr<uint8_t> m_chargen;
 			required_device<ram_device> m_ram;
 			required_device<screen_device> m_screen;
-
+			required_ioport m_language;
 			output_finder<2> m_diag_digits;
 
 			uint8_t m_bus_test_register = 0;
@@ -73,8 +74,6 @@ namespace
 			void dmac_mem_w(offs_t offset, uint8_t data);
 
 			void dmac_hrq_w(int state);
-
-			uint8_t language_r();
 
 			void crtc_dack_w(offs_t offset, uint8_t data);
 			I8275_DRAW_CHARACTER_MEMBER(display_pixels);
@@ -170,11 +169,6 @@ namespace
 		bitmap.pix(y, x++) = BIT(gfx, 7) ? palette[1] : palette[0];
 	}
 
-	uint8_t system23_state::language_r()
-	{
-		return 3;	//hack to set region to Spain
-	}
-
 	//This routine describes the computer's I/O map
 
 	void system23_state::system23_io(address_map &map)
@@ -216,7 +210,8 @@ namespace
 
 		I8255(config, m_ppi_settings);
 		m_ppi_settings->in_pc_callback().set(FUNC(system23_state::memory_settings_r));
-		m_ppi_settings->in_pa_callback().set(FUNC(system23_state::language_r));
+		//m_ppi_settings->in_pa_callback().set(FUNC(system23_state::language_r));
+		m_ppi_settings->in_pa_callback().set_ioport(m_language);
 
 		I8257(config, m_dmac, (18'432'000 / 6)); //frequency needs to be adjusted
 		m_dmac->out_memw_cb().set(FUNC(system23_state::dmac_mem_w));
@@ -254,16 +249,48 @@ namespace
 
 	}
 
+	static INPUT_PORTS_START(system23)
+		PORT_START("ce")
+			PORT_DIPNAME( 0x01, 0x00, "A1")
+			PORT_DIPSETTING(    0x01, DEF_STR( Off ))
+			PORT_DIPSETTING(    0x00, DEF_STR( On ))
+			PORT_DIPNAME( 0x02, 0x00, "A2")
+			PORT_DIPSETTING(    0x02, DEF_STR( Off ))
+			PORT_DIPSETTING(    0x00, DEF_STR( On ))
+			PORT_DIPNAME( 0x04, 0x00, "A3")
+			PORT_DIPSETTING(    0x04, DEF_STR( Off ))
+			PORT_DIPSETTING(    0x00, DEF_STR( On ))
+
+		PORT_START("lang")
+			PORT_DIPNAME( 0x01, 0x00, "B1")
+			PORT_DIPSETTING(    0x01, DEF_STR( Off ))
+			PORT_DIPSETTING(    0x00, DEF_STR( On ))
+			PORT_DIPNAME( 0x02, 0x00, "B2")
+			PORT_DIPSETTING(    0x02, DEF_STR( Off ))
+			PORT_DIPSETTING(    0x00, DEF_STR( On ))
+			PORT_DIPNAME( 0x04, 0x00, "B3")
+			PORT_DIPSETTING(    0x04, DEF_STR( Off ))
+			PORT_DIPSETTING(    0x00, DEF_STR( On ))
+			PORT_DIPNAME( 0x08, 0x00, "B4")
+			PORT_DIPSETTING(    0x08, DEF_STR( Off ))
+			PORT_DIPSETTING(    0x00, DEF_STR( On ))
+			PORT_DIPNAME( 0x10, 0x00, "B5")
+			PORT_DIPSETTING(    0x10, DEF_STR( Off ))
+			PORT_DIPSETTING(    0x00, DEF_STR( On ))
+
+
+	INPUT_PORTS_END
+
 
 	ROM_START( system23 )
-		ROM_SYSTEM_BIOS(0, "R Set", "1982?")
-		ROM_SYSTEM_BIOS(1, "TM Set", "1981?")
+		ROM_SYSTEM_BIOS(0, "r set", "1982?")
+		ROM_SYSTEM_BIOS(1, "tm set", "1981?")
 
 		ROM_REGION(0x4000, "ros_unpaged", 0)
 		ROMX_LOAD("02_61c9866a_4481186.bin", 0x0000, 0x2000, CRC(61c9866a) SHA1(43f2bed5cc2374c7fde4632948329062e57e994b),ROM_BIOS(0))
 		ROMX_LOAD("09_07843020_8493747.bin", 0x2000, 0x2000, CRC(07843020) SHA1(828ca0199af1246f6caf58bcb785f791c3a7e34e),ROM_BIOS(0))
 
-		ROMX_LOAD("02_081AE664_8493746.bin", 0x0000, 0x2000, CRC(081AE664) SHA1(82561e33012f21918927c85527531f21d66deba8),ROM_BIOS(1))
+		ROMX_LOAD("02_081ae664_8493746.bin", 0x0000, 0x2000, CRC(081ae664) SHA1(82561e33012f21918927c85527531f21d66deba8),ROM_BIOS(1))
 		ROMX_LOAD("09_07843020_8493747.bin", 0x2000, 0x2000, CRC(07843020) SHA1(828ca0199af1246f6caf58bcb785f791c3a7e34e),ROM_BIOS(1))
 
 		ROM_REGION(0x2000, "chargen", 0)

--- a/src/mame/layout/ibmsystem23.lay
+++ b/src/mame/layout/ibmsystem23.lay
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+license:CC0-1.0
+-->
+<mamelayout version="2">
+	<element name="digit" defstate="10">
+		<led7seg>
+			<color red="1.0" green="0.1" blue="0.15" />
+		</led7seg>
+	</element>
+
+	<view name="Diagnostics Port">
+		<element name="digit0" ref="digit">
+			<bounds x="2.070" y="3.1" width="0.145" height="0.2" />
+		</element>
+		<element name="digit1" ref="digit">
+			<bounds x="1.925" y="3.1" width="0.145" height="0.2" />
+		</element>
+	</view>
+</mamelayout>

--- a/src/mame/layout/ibmsystem23.lay
+++ b/src/mame/layout/ibmsystem23.lay
@@ -9,7 +9,10 @@ license:CC0-1.0
 		</led7seg>
 	</element>
 
-	<view name="Diagnostics Port">
+	<view name="Default Layout">
+		<screen index="0">
+			<bounds x="0" y="0" width="~scr0width~" height="~scr0height~" />
+		</screen>
 		<element name="digit0" ref="digit">
 			<bounds x="2.070" y="3.1" width="0.145" height="0.2" />
 		</element>

--- a/src/mame/layout/ibmsystem23.lay
+++ b/src/mame/layout/ibmsystem23.lay
@@ -14,10 +14,10 @@ license:CC0-1.0
 			<bounds x="0" y="0" width="~scr0width~" height="~scr0height~" />
 		</screen>
 		<element name="digit0" ref="digit">
-			<bounds x="2.070" y="3.1" width="0.145" height="0.2" />
+			<bounds x="14" y="0" width="14" height="20" />
 		</element>
 		<element name="digit1" ref="digit">
-			<bounds x="1.925" y="3.1" width="0.145" height="0.2" />
+			<bounds x="0" y="0" width="14" height="20" />
 		</element>
 	</view>
 </mamelayout>

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -20069,7 +20069,8 @@ rtpc020                         // IBM RT PC Model 020
 rtpc025                         // IBM RT PC Model 025
 rtpca25                         // IBM RT PC Model A25
 
-@source:ibm/system23.cpp		//IBM System/23 Datamaster
+@source:ibm/system23.cpp		// IBM System/23 Datamaster
+system23
 
 @source:ibm/thinkpad600.cpp
 thinkpad600                     // IBM Thinkpad 600

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -20069,6 +20069,8 @@ rtpc020                         // IBM RT PC Model 020
 rtpc025                         // IBM RT PC Model 025
 rtpca25                         // IBM RT PC Model A25
 
+@source:ibm/system23.cpp		//IBM System/23 Datamaster
+
 @source:ibm/thinkpad600.cpp
 thinkpad600                     // IBM Thinkpad 600
 thinkpad600e                    // IBM Thinkpad 600E


### PR DESCRIPTION
I have written this driver to emulate the System/23 Datamaster. It halts at test 05, so it is still not working, unfortunately. The cause of this is the implementation of the Intel 8275 (i8275.cpp), which does not implement the behaviour of the IC when not initialized. This computer relies on this behaviour in order to perform tests so it stalls. Some components and memory regions haven't still been added as the current ones were added as needed in order to keep the code clean. Basically this pull request is for allowing MAME testers to test the 8275 with the example that made it fail. Whenever the issue with such component is resolved, programation of this driver will resume.

Thank you for your time and patience.