### PR TITLE
Fix infinite looping on reading corrupted OSD files.

### DIFF
--- a/src/lib/util/corefile.cpp
+++ b/src/lib/util/corefile.cpp
@@ -313,7 +313,10 @@ int core_text_file::getc()
 				if (readlen > 0)
 				{
 					auto const charlen = osd_uchar_from_osdchar(&uchar, default_buffer, readlen / sizeof(default_buffer[0]));
-					seek(std::int64_t(charlen * sizeof(default_buffer[0])) - readlen, SEEK_CUR);
+					if( charlen == 0 ) // terminating null character ('\0') has been read. Corrupted file.
+						uchar = ~char32_t(0);
+					else
+						seek(std::int64_t(charlen * sizeof(default_buffer[0])) - readlen, SEEK_CUR);
 				}
 			}
 			break;


### PR DESCRIPTION
On Linux, if an OSD file contains a 0x0. It is interpreted as a terminating null character by mbstowcs. So osd_uchar_from_osdchar returns 0. This seems legit.

core_text_file::getc is calculating a seek value from this return value (charlen) like this:

seek(std::int64_t(charlen * sizeof(default_buffer[0])) - readlen, SEEK_CUR);

Since charlen is 0, we end up having seek(-readlen) which create an infinite loop preventing MAME from starting.

It happens to me with a corrupted .ini file in the "folders" directory.

