### PR TITLE
minitel2: tune palette to differentiate all colors

### DIFF
--- a/src/mame/philips/minitel_2_rpic.cpp
+++ b/src/mame/philips/minitel_2_rpic.cpp
@@ -170,14 +170,14 @@ private:
 
 void minitel_state::machine_start()
 {
-	m_palette->set_pen_color( 0, 0, 0, 0);
-	m_palette->set_pen_color( 1, 86, 86, 86);
-	m_palette->set_pen_color( 2, 172, 172, 172);
-	m_palette->set_pen_color( 3, 255, 255, 255);
-	m_palette->set_pen_color( 4, 44, 44, 44);
-	m_palette->set_pen_color( 5, 86, 86, 86);
-	m_palette->set_pen_color( 6, 172, 172, 172);
-	m_palette->set_pen_color( 7, 255, 255, 255);
+	m_palette->set_pen_color(0, 0, 0, 0);
+	m_palette->set_pen_color(1, 80, 80, 80);
+	m_palette->set_pen_color(2, 160, 160, 160);
+	m_palette->set_pen_color(3, 230, 230, 230);
+	m_palette->set_pen_color(4, 40, 40, 40);
+	m_palette->set_pen_color(5, 120, 120, 120);
+	m_palette->set_pen_color(6, 200, 200, 200);
+	m_palette->set_pen_color(7, 255, 255, 255);
 }
 
 void minitel_state::port1_w(uint8_t data)


### PR DESCRIPTION
Previously, some distinct levels were mapped to the same color, which made them indistinguishable.

The progression of the gray levels is documented both in the Videotex documentation (STUM1B) and in the TS9347 datasheet, by mapping colors to grayscale-equivalent levels.

From STUM1B (page 32):
![stum1b_extract_with_annotated_colors](https://github.com/user-attachments/assets/82886ec8-2da0-41ba-bbeb-6242bb198f9c)

From the TS9347 datasheet (pages 10 and 19):
![progression1_pag19](https://github.com/user-attachments/assets/d5d51b5b-f5da-431a-b33e-cbd99d7673c6) ![progression2_pag10](https://github.com/user-attachments/assets/a818056b-e7a5-4484-81bc-52ba48575b08)

Visually tuned with a test pattern ([colors.vdt.zip](https://github.com/user-attachments/files/18339197/colors.vdt.zip)) using a real Minitel as a reference:
<img src="https://github.com/user-attachments/assets/ff12c080-4aa5-49da-8b2f-329235b38392" width="45%"/> <img src="https://github.com/user-attachments/assets/5abe7702-c269-43b9-ae3d-cd1ccd12ca50" width="45%"/>
Note: The number after # is the index in MAME's minitel2 palette

EDIT: For comparison, with the old palette the above test pattern would have been rendered as:
<img src="https://github.com/user-attachments/assets/d769459e-725f-45ca-93a7-dc8cca944249" width="45%"/>

Important: if you test the new palette, in order to actually see the background colors generated by the test pattern, you currently have to comment out [this line](https://github.com/mamedev/mame/blob/ecc91bf3ff8ca8fe46a83ace9525d1daa374181f/src/devices/video/ef9345.cpp#L403) that makes all backgrounds black. Unlike the real chip, the current code makes all backgrounds black, unconditionally. A proper fix will follow in a different PR (see also the discussion at https://github.com/jfdelnero/minitel/issues/3)

( cc @jfdelnero )