### PR TITLE
nmk/nmk16spr.cpp: Use device_gfx_interface for gfx layout

### DIFF
--- a/src/mame/nmk/nmk16.cpp
+++ b/src/mame/nmk/nmk16.cpp
@@ -4145,54 +4145,66 @@ static INPUT_PORTS_START( dolmenk )
 	PORT_BIT(  0x8000, IP_ACTIVE_HIGH, IPT_UNKNOWN ) // Tested at boot
 INPUT_PORTS_END
 
-static GFXDECODE_START( gfx_tharrier )
-	GFXDECODE_ENTRY( "fgtile",  0, gfx_8x8x4_packed_msb,               0x000, 16 ) // color 0x000-0x0ff
-	GFXDECODE_ENTRY( "bgtile",  0, gfx_8x8x4_col_2x2_group_packed_msb, 0x000, 16 ) // color 0x000-0x0ff
+static GFXDECODE_START( gfx_macross_spr )
 	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x100, 16 ) // color 0x100-0x1ff
 GFXDECODE_END
 
-static GFXDECODE_START( gfx_macross )
-	GFXDECODE_ENTRY( "fgtile",  0, gfx_8x8x4_packed_msb,               0x200, 16 ) // color 0x200-0x2ff
-	GFXDECODE_ENTRY( "bgtile",  0, gfx_8x8x4_col_2x2_group_packed_msb, 0x000, 16 ) // color 0x000-0x0ff
-	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x100, 16 ) // color 0x100-0x1ff
-GFXDECODE_END
-
-static GFXDECODE_START( gfx_macross2 )
-	GFXDECODE_ENTRY( "fgtile",  0, gfx_8x8x4_packed_msb,               0x300, 16 ) // color 0x300-0x3ff
-	GFXDECODE_ENTRY( "bgtile",  0, gfx_8x8x4_col_2x2_group_packed_msb, 0x000, 16 ) // color 0x000-0x0ff
+static GFXDECODE_START( gfx_macross2_spr )
 	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x100, 32 ) // color 0x100-0x2ff
 GFXDECODE_END
 
+static GFXDECODE_START( gfx_bioship_spr )
+	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x200, 16 ) // color 0x200-0x2ff
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_powerins_spr )
+	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x400, 0x40 )
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_powerinsc_spr )
+	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_lsb, 0x400, 0x40 ) // TODO: wrong decode and ROM loading
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_tharrier )
+	GFXDECODE_ENTRY( "fgtile", 0, gfx_8x8x4_packed_msb,               0x000, 16 ) // color 0x000-0x0ff
+	GFXDECODE_ENTRY( "bgtile", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x000, 16 ) // color 0x000-0x0ff
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_macross )
+	GFXDECODE_ENTRY( "fgtile", 0, gfx_8x8x4_packed_msb,               0x200, 16 ) // color 0x200-0x2ff
+	GFXDECODE_ENTRY( "bgtile", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x000, 16 ) // color 0x000-0x0ff
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_macross2 )
+	GFXDECODE_ENTRY( "fgtile", 0, gfx_8x8x4_packed_msb,               0x300, 16 ) // color 0x300-0x3ff
+	GFXDECODE_ENTRY( "bgtile", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x000, 16 ) // color 0x000-0x0ff
+GFXDECODE_END
+
 static GFXDECODE_START( gfx_bjtwin )
-	GFXDECODE_ENTRY( "fgtile",  0, gfx_8x8x4_packed_msb,               0x000, 16 ) // color 0x000-0x0ff
-	GFXDECODE_ENTRY( "bgtile",  0, gfx_8x8x4_packed_msb,               0x000, 16 ) // color 0x000-0x0ff
-	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x100, 16 ) // color 0x100-0x1ff
+	GFXDECODE_ENTRY( "fgtile", 0, gfx_8x8x4_packed_msb, 0x000, 16 ) // color 0x000-0x0ff
+	GFXDECODE_ENTRY( "bgtile", 0, gfx_8x8x4_packed_msb, 0x000, 16 ) // color 0x000-0x0ff
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_bioship )
 	GFXDECODE_ENTRY( "fgtile",  0, gfx_8x8x4_packed_msb,               0x300, 16 ) // color 0x300-0x3ff
 	GFXDECODE_ENTRY( "bgtile",  0, gfx_8x8x4_col_2x2_group_packed_msb, 0x100, 16 ) // color 0x100-0x1ff
-	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x200, 16 ) // color 0x200-0x2ff
 	GFXDECODE_ENTRY( "bg2tile", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x000, 16 ) // color 0x000-0x0ff
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_strahl )
 	GFXDECODE_ENTRY( "fgtile",  0, gfx_8x8x4_packed_msb,               0x000, 16 ) // color 0x000-0x0ff
 	GFXDECODE_ENTRY( "bgtile",  0, gfx_8x8x4_col_2x2_group_packed_msb, 0x300, 16 ) // color 0x300-0x3ff
-	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x100, 16 ) // color 0x100-0x1ff
 	GFXDECODE_ENTRY( "bg2tile", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x200, 16 ) // color 0x200-0x2ff
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_powerins )
-	GFXDECODE_ENTRY( "fgtile",  0, gfx_8x8x4_packed_msb,               0x200, 0x10 )  // TODO: confirm values (is it same that macross2 one?)
-	GFXDECODE_ENTRY( "bgtile",  0, gfx_8x8x4_col_2x2_group_packed_msb, 0x000, 0x20 )
-	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x400, 0x40 )
+	GFXDECODE_ENTRY( "fgtile", 0, gfx_8x8x4_packed_msb,               0x200, 0x10 )  // TODO: confirm values (is it same that macross2 one?)
+	GFXDECODE_ENTRY( "bgtile", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x000, 0x20 )
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_powerinsc )
-	GFXDECODE_ENTRY( "bgtile",  0x280000, gfx_8x8x4_packed_lsb,               0x200, 0x10 )
-	GFXDECODE_ENTRY( "bgtile",  0,        gfx_8x8x4_col_2x2_group_packed_lsb, 0x000, 0x20 )
-	GFXDECODE_ENTRY( "sprites", 0,        gfx_8x8x4_col_2x2_group_packed_lsb, 0x400, 0x40 ) // TODO: wrong decode and ROM loading
+	GFXDECODE_ENTRY( "bgtile", 0x280000, gfx_8x8x4_packed_lsb,               0x200, 0x10 )
+	GFXDECODE_ENTRY( "bgtile", 0,        gfx_8x8x4_col_2x2_group_packed_lsb, 0x000, 0x20 )
 GFXDECODE_END
 
 
@@ -4334,6 +4346,7 @@ void nmk16_state::set_screen_lowres(machine_config &config)
 	m_screen->set_palette(m_palette);
 
 	NMK_16BIT_SPRITE(config, m_spritegen, XTAL(12'000'000)/2);
+	m_spritegen->set_palette(m_palette);
 	m_spritegen->set_screen_size(92+348, 16+240);
 	m_spritegen->set_max_sprite_clock(384 * 263); // from hardware manual
 	m_spritegen->set_videoshift(92);
@@ -4347,6 +4360,7 @@ void nmk16_state::set_screen_midres(machine_config &config)
 	m_screen->set_palette(m_palette);
 
 	NMK_16BIT_SPRITE(config, m_spritegen, XTAL(14'000'000)/2);
+	m_spritegen->set_palette(m_palette);
 	m_spritegen->set_mask(0x3ff, 0x3ff);
 	m_spritegen->set_screen_size(60+380, 16+240);
 	m_spritegen->set_max_sprite_clock(448 * 263); // not verified?
@@ -4360,6 +4374,7 @@ void nmk16_state::set_screen_hires(machine_config &config)
 	m_screen->set_palette(m_palette);
 
 	NMK_16BIT_SPRITE(config, m_spritegen, XTAL(16'000'000)/2);
+	m_spritegen->set_palette(m_palette);
 	m_spritegen->set_screen_size(28+412, 16+240);
 	m_spritegen->set_max_sprite_clock(512 * 263); // not verified?
 	m_spritegen->set_videoshift(28+64);
@@ -4554,6 +4569,7 @@ void nmk16_state::tharrier(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_spritegen->set_ext_callback(FUNC(nmk16_state::get_sprite_flip));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_tharrier));
@@ -4609,6 +4625,7 @@ void nmk16_state::mustang(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -4651,6 +4668,7 @@ void nmk16_state::mustangb(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -4688,6 +4706,7 @@ void nmk16_state::mustangb3(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -4724,6 +4743,7 @@ void nmk16_state::bioship(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_bioship_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_strahl));
 
@@ -4762,6 +4782,7 @@ void nmk16_state::vandyke(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -4802,6 +4823,7 @@ void nmk16_state::vandykeb(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -4826,11 +4848,12 @@ void nmk16_state::acrobatm(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);
-	PALETTE(config, m_palette).set_format(palette_device::RGBx_444, 768);
+	PALETTE(config, m_palette).set_format(palette_device::RRRRGGGGBBBBRGBx, 768);
 	MCFG_VIDEO_START_OVERRIDE(nmk16_state,macross)
 
 	// sound hardware
@@ -4870,11 +4893,12 @@ void nmk16_state::acrobatmbl(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config); // TODO: video XTAL is 12 MHz
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_macross);
-	PALETTE(config, m_palette).set_format(palette_device::RGBx_444, 768);
+	PALETTE(config, m_palette).set_format(palette_device::RRRRGGGGBBBBRGBx, 768);
 	MCFG_VIDEO_START_OVERRIDE(nmk16_state, macross)
 
 	// sound hardware
@@ -4907,6 +4931,7 @@ void nmk16_state::tdragonb(machine_config &config)    // bootleg using Raiden so
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -4947,6 +4972,7 @@ void nmk16_state::tdragonb2(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -4971,6 +4997,7 @@ void nmk16_state::tdragon(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -5057,7 +5084,7 @@ void macross_prot_state::device_post_load()
 		// Force graphics unscrambling now
 		decode_nmk214();
 		m_gfxdecode->gfx(1)->mark_all_dirty(); // background tiles
-		m_gfxdecode->gfx(2)->mark_all_dirty(); // sprites
+		m_spritegen->gfx(0)->mark_all_dirty(); // sprites
 		m_bg_tilemap[0]->mark_all_dirty();
 		m_gfx_decoded = true;
 	}
@@ -5117,6 +5144,7 @@ void nmk16_state::ssmissin(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -5144,11 +5172,12 @@ void nmk16_state::strahl(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_strahl));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_strahl);
-	PALETTE(config, m_palette).set_format(palette_device::RGBx_444, 1024);
+	PALETTE(config, m_palette).set_format(palette_device::RRRRGGGGBBBBRGBx, 1024);
 	MCFG_VIDEO_START_OVERRIDE(nmk16_state,strahl)
 
 	// sound hardware
@@ -5184,11 +5213,12 @@ void nmk16_state::strahljbl(machine_config &config)
 	m_audiocpu->set_irq_acknowledge_callback("seibu_sound", FUNC(seibu_sound_device::im0_vector_cb));
 
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_strahl));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_strahl);
-	PALETTE(config, m_palette).set_format(palette_device::RGBx_444, 1024);
+	PALETTE(config, m_palette).set_format(palette_device::RRRRGGGGBBBBRGBx, 1024);
 	MCFG_VIDEO_START_OVERRIDE(nmk16_state,strahl)
 
 	SPEAKER(config, "mono").front_center();
@@ -5217,6 +5247,7 @@ void nmk16_state::hachamf(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -5294,6 +5325,7 @@ void nmk16_state::macross(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -5332,6 +5364,7 @@ void nmk16_state::blkheart(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -5369,6 +5402,7 @@ void nmk16_state::gunnail(machine_config &config)
 
 	// video hardware
 	set_screen_hires(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -5436,6 +5470,7 @@ void nmk16_state::macross2(machine_config &config)
 
 	// video hardware
 	set_screen_hires(config);
+	m_spritegen->set_info(gfx_macross2_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_5bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -5480,6 +5515,7 @@ void nmk16_state::tdragon2(machine_config &config)
 
 	// video hardware
 	set_screen_hires(config);
+	m_spritegen->set_info(gfx_macross2_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_5bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -5541,6 +5577,7 @@ void nmk16_state::raphero(machine_config &config)
 
 	// video hardware
 	set_screen_hires(config);
+	m_spritegen->set_info(gfx_macross2_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_5bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 
@@ -5581,6 +5618,7 @@ void nmk16_state::bjtwin(machine_config &config)
 
 	// video hardware
 	set_screen_hires(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_bjtwin));
 
@@ -5633,7 +5671,7 @@ void macross_prot_state::mcu_port3_to_214_w(u8 data)
 			{
 				decode_nmk214();
 				m_gfxdecode->gfx(1)->mark_all_dirty(); // background tiles
-				m_gfxdecode->gfx(2)->mark_all_dirty(); // sprites
+				m_spritegen->gfx(0)->mark_all_dirty(); // sprites
 				m_bg_tilemap[0]->mark_all_dirty();
 				m_gfx_decoded = true;
 			}
@@ -5716,6 +5754,7 @@ void nmk16_state::powerins(machine_config &config)
 
 	// video hardware
 	set_screen_midres(config);
+	m_spritegen->set_info(gfx_powerins_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_6bit));
 	m_spritegen->set_ext_callback(FUNC(nmk16_state::get_flip_extcode_powerins));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
@@ -5757,7 +5796,7 @@ void nmk16_state::powerinsa(machine_config &config)
 	m_screen->screen_vblank().set(FUNC(nmk16_state::screen_vblank_powerins_bootleg));
 	m_screen->set_palette(m_palette);
 
-	NMK_16BIT_SPRITE(config, m_spritegen, XTAL(14'000'000) / 2);
+	NMK_16BIT_SPRITE(config, m_spritegen, XTAL(14'000'000) / 2, m_palette, gfx_powerins_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_6bit));
 	m_spritegen->set_ext_callback(FUNC(nmk16_state::get_flip_extcode_powerins));
 	m_spritegen->set_mask(0x3ff, 0x3ff);
@@ -5797,7 +5836,7 @@ void nmk16_state::powerinsb(machine_config &config)
 	m_screen->screen_vblank().set(FUNC(nmk16_state::screen_vblank_powerins_bootleg));
 	m_screen->set_palette(m_palette);
 
-	NMK_16BIT_SPRITE(config, m_spritegen, XTAL(14'000'000) / 2);
+	NMK_16BIT_SPRITE(config, m_spritegen, XTAL(14'000'000) / 2, m_palette, gfx_powerins_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_6bit));
 	m_spritegen->set_ext_callback(FUNC(nmk16_state::get_flip_extcode_powerins));
 	m_spritegen->set_mask(0x3ff, 0x3ff);
@@ -5831,6 +5870,7 @@ void nmk16_state::powerinsc(machine_config &config)
 {
 	powerinsb(config);
 
+	m_spritegen->set_info(gfx_powerinsc_spr);
 	m_gfxdecode->set_info(gfx_powerinsc);
 }
 
@@ -5872,7 +5912,7 @@ void nmk16_state::manybloc(machine_config &config)
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 	m_screen->set_palette(m_palette);
 
-	NMK_16BIT_SPRITE(config, m_spritegen, XTAL(12'000'000)/2);
+	NMK_16BIT_SPRITE(config, m_spritegen, XTAL(12'000'000)/2, m_palette, gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_spritegen->set_ext_callback(FUNC(nmk16_state::get_sprite_flip));
 	m_spritegen->set_screen_size(256, 256);
@@ -5880,7 +5920,7 @@ void nmk16_state::manybloc(machine_config &config)
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_tharrier);
 	PALETTE(config, m_palette).set_format(palette_device::RRRRGGGGBBBBRGBx, 512);
-	MCFG_VIDEO_START_OVERRIDE(nmk16_state,macross)
+	MCFG_VIDEO_START_OVERRIDE(nmk16_state,manybloc)
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
@@ -5919,6 +5959,7 @@ void nmk16_tomagic_state::tomagic(machine_config &config)
 
 	// video hardware
 	set_screen_hires(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_tomagic_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_tomagic_state::screen_update_macross));
 
@@ -6382,15 +6423,17 @@ static const gfx_layout tilelayout_8bpp =
 
 
 static GFXDECODE_START( gfx_grdnstrm )
-	GFXDECODE_ENTRY( "fgtile",  0, gfx_8x8x4_packed_msb,               0x200, 16 ) // [2] Layer 1
-	GFXDECODE_ENTRY( "bgtile",  0, tilelayout_8bpp,                    0x000,  1 ) // [1] Layer 0
-	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_msb, 0x100, 16 ) // [0] Sprites
+	GFXDECODE_ENTRY( "fgtile", 0, gfx_8x8x4_packed_msb, 0x200, 16 ) // [0] Layer 1
+	GFXDECODE_ENTRY( "bgtile", 0, tilelayout_8bpp,      0x000,  1 ) // [1] Layer 0
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_redhawkb_spr )
+	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_lsb, 0x100, 16 ) // [0] Sprites
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_redhawkb )
-	GFXDECODE_ENTRY( "fgtile",  0, gfx_8x8x4_packed_msb,               0x200, 16 ) // [2] Layer 1
-	GFXDECODE_ENTRY( "bgtile",  0, gfx_8x8x4_col_2x2_group_packed_lsb, 0x000, 16 ) // [1] Layer 0
-	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_col_2x2_group_packed_lsb, 0x100, 16 ) // [0] Sprites
+	GFXDECODE_ENTRY( "fgtile", 0, gfx_8x8x4_packed_msb,               0x200, 16 ) // [0] Layer 1
+	GFXDECODE_ENTRY( "bgtile", 0, gfx_8x8x4_col_2x2_group_packed_lsb, 0x000, 16 ) // [1] Layer 0
 GFXDECODE_END
 
 
@@ -6414,6 +6457,7 @@ void afega_state::stagger1(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(afega_state::get_colour_4bit));
 	m_spritegen->set_ext_callback(FUNC(afega_state::get_sprite_flip));
 	m_screen->set_screen_update(FUNC(afega_state::screen_update_afega));
@@ -6451,6 +6495,7 @@ void afega_state::redhawkb(machine_config &config)
 
 	// basic machine hardware
 	// video hardware
+	m_spritegen->set_info(gfx_redhawkb_spr);
 	m_gfxdecode->set_info(gfx_redhawkb);
 	m_screen->set_screen_update(FUNC(afega_state::screen_update_redhawkb));
 }
@@ -6497,6 +6542,7 @@ void afega_state::firehawk(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(afega_state::get_colour_4bit));
 	m_spritegen->set_ext_callback(FUNC(afega_state::get_sprite_flip));
 	m_screen->set_screen_update(FUNC(afega_state::screen_update_firehawk));
@@ -6537,6 +6583,7 @@ void nmk16_state::twinactn(machine_config &config)
 
 	// video hardware
 	set_screen_lowres(config);
+	m_spritegen->set_info(gfx_macross_spr);
 	m_spritegen->set_colpri_callback(FUNC(nmk16_state::get_colour_4bit));
 	m_screen->set_screen_update(FUNC(nmk16_state::screen_update_macross));
 

--- a/src/mame/nmk/nmk16.h
+++ b/src/mame/nmk/nmk16.h
@@ -194,6 +194,7 @@ protected:
 	TILE_GET_INFO_MEMBER(bjtwin_get_bg_tile_info);
 	TILE_GET_INFO_MEMBER(powerins_get_bg_tile_info);
 	DECLARE_VIDEO_START(macross);
+	DECLARE_VIDEO_START(manybloc);
 	DECLARE_VIDEO_START(bioship);
 	DECLARE_VIDEO_START(strahl);
 	DECLARE_VIDEO_START(macross2);

--- a/src/mame/nmk/nmk16_v.cpp
+++ b/src/mame/nmk/nmk16_v.cpp
@@ -52,7 +52,7 @@ TILE_GET_INFO_MEMBER(nmk16_state::common_get_tx_tile_info)
 TILE_GET_INFO_MEMBER(nmk16_state::bioship_get_bg_tile_info)
 {
 	const u16 code = m_tilemap_rom[(m_bioship_background_bank << 13) | tile_index]; // ROM Based
-	tileinfo.set(3, code & 0xfff, code >> 12, 0);
+	tileinfo.set(2, code & 0xfff, code >> 12, 0);
 }
 
 TILE_GET_INFO_MEMBER(nmk16_state::bjtwin_get_bg_tile_info)
@@ -131,10 +131,18 @@ VIDEO_START_MEMBER(nmk16_state,macross)
 	m_tx_tilemap->set_scrolldx(92, 92);
 }
 
+VIDEO_START_MEMBER(nmk16_state,manybloc)
+{
+	VIDEO_START_CALL_MEMBER(macross);
+	// no video shift in this hardware
+	m_bg_tilemap[0]->set_scrolldx(0, 0);
+	m_tx_tilemap->set_scrolldx(0, 0);
+}
+
 VIDEO_START_MEMBER(nmk16_state,strahl)
 {
 	VIDEO_START_CALL_MEMBER(macross);
-	m_bg_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&nmk16_state::common_get_bg_tile_info<1, 3>))), tilemap_mapper_delegate(*this, FUNC(nmk16_state::tilemap_scan_pages)), 16, 16, 256, 32);
+	m_bg_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&nmk16_state::common_get_bg_tile_info<1, 2>))), tilemap_mapper_delegate(*this, FUNC(nmk16_state::tilemap_scan_pages)), 16, 16, 256, 32);
 	m_bg_tilemap[1]->set_transparent_pen(15);
 
 	m_sprdma_base = 0xf000;
@@ -354,7 +362,7 @@ void nmk16_state::get_flip_extcode_powerins(u16 attr, int &flipx, int &flipy, in
 
 void nmk16_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u16 *src)
 {
-	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(2), src, 0x1000 / 2);
+	m_spritegen->draw_sprites(screen, bitmap, cliprect, src, 0x1000 / 2);
 }
 
 /***************************************************************************

--- a/src/mame/nmk/nmk16spr.cpp
+++ b/src/mame/nmk/nmk16spr.cpp
@@ -16,7 +16,7 @@
 
     Offset Bits              Description
            fedcba98 76543210
-    00     -------- -------s Visible
+    00     -------- -------x Visible
     02     ---x---- -------- Flip X (powerins)
            ------x- -------- Flip Y (manybloc)
            -------x -------- Flip X (manybloc) or Code hi bits (powerins)
@@ -39,6 +39,7 @@ DEFINE_DEVICE_TYPE(NMK_16BIT_SPRITE, nmk_16bit_sprite_device, "nmk16spr", "NMK 1
 
 nmk_16bit_sprite_device::nmk_16bit_sprite_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, NMK_16BIT_SPRITE, tag, owner, clock)
+	, device_gfx_interface(mconfig, *this)
 	, m_colpri_cb(*this)
 	, m_ext_cb(*this)
 	, m_flip_screen(false)
@@ -50,7 +51,7 @@ nmk_16bit_sprite_device::nmk_16bit_sprite_device(const machine_config &mconfig, 
 }
 
 // this implementation was originally from nmk16.cpp
-void nmk_16bit_sprite_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, u16* spriteram, int size)
+void nmk_16bit_sprite_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u16* spriteram, int size)
 {
 	const bool priority = !m_colpri_cb.isnull();
 	sprite_t *sprite_ptr = m_spritelist.get();
@@ -64,7 +65,7 @@ void nmk_16bit_sprite_device::draw_sprites(screen_device &screen, bitmap_ind16 &
 		if (clk >= m_max_sprite_clock)
 			break;
 
-		if (!(spriteram[offs + 0] & 0x0001))
+		if (BIT(~spriteram[offs + 0], 0))
 			continue;
 
 		// extract parameters
@@ -226,7 +227,7 @@ void nmk_16bit_sprite_device::draw_sprites(screen_device &screen, bitmap_ind16 &
 				}
 				else
 				{
-					gfx->transpen(bitmap, cliprect,
+					gfx(0)->transpen(bitmap, cliprect,
 						codecol,
 						colour,
 						flipx_global, flipy_global,
@@ -246,7 +247,7 @@ void nmk_16bit_sprite_device::draw_sprites(screen_device &screen, bitmap_ind16 &
 		{
 			sprite_ptr--;
 
-			gfx->prio_transpen(bitmap, cliprect,
+			gfx(0)->prio_transpen(bitmap, cliprect,
 					sprite_ptr->code,
 					sprite_ptr->colour,
 					sprite_ptr->flipx, sprite_ptr->flipy,

--- a/src/mame/nmk/nmk16spr.h
+++ b/src/mame/nmk/nmk16spr.h
@@ -8,13 +8,19 @@
 
 #include "screen.h"
 
-class nmk_16bit_sprite_device : public device_t
+class nmk_16bit_sprite_device : public device_t, public device_gfx_interface
 {
 public:
 	typedef device_delegate<void (u32 &colour, u32 &pri_mask)> colpri_cb_delegate;
 	typedef device_delegate<void (u16 attr, int &flipx, int &flipy, int &code)> ext_cb_delegate;
 
 	nmk_16bit_sprite_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	template <typename T> nmk_16bit_sprite_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&palette_tag, const gfx_decode_entry *gfxinfo)
+		: nmk_16bit_sprite_device(mconfig, tag, owner, clock)
+	{
+		set_info(gfxinfo);
+		set_palette(std::forward<T>(palette_tag));
+	}
 
 	// configuration
 	template <typename... T> void set_colpri_callback(T &&... args) { m_colpri_cb.set(std::forward<T>(args)...); }
@@ -24,7 +30,7 @@ public:
 	void set_screen_size(int width, int height) { m_screen_width = width, m_screen_height = height; }
 	void set_max_sprite_clock(u32 max) { m_max_sprite_clock = max; }
 
-	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, u16* spriteram, int size);
+	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u16* spriteram, int size);
 	void set_flip_screen(bool flip) { m_flip_screen = flip; }
 
 protected:


### PR DESCRIPTION
nmk/nmk16.cpp: Fix acrobatm, strahl palette format (LSBs are used at color fading), Fix manybloc offset regression, Fix spacings