### PR TITLE
barcrest\mpu3.cpp: Correct 100hz signal to pia6821 ic3

### DIFF
--- a/src/mame/barcrest/mpu3.cpp
+++ b/src/mame/barcrest/mpu3.cpp
@@ -745,7 +745,7 @@ void mpu3_state::machine_start()
 	m_lamp.resolve();
 }
 
-/* generate a 50 Hz signal (some components rely on this for external sync) */
+/* generate a 100 Hz signal (some components rely on this for external sync) */
 TIMER_DEVICE_CALLBACK_MEMBER(mpu3_state::gen_100hz)
 {
 	/* Although reported as a '50Hz' signal, the fact that both rising and

--- a/src/mame/barcrest/mpu3.cpp
+++ b/src/mame/barcrest/mpu3.cpp
@@ -751,7 +751,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(mpu3_state::gen_100hz)
 	/* Although reported as a '50Hz' signal, the fact that both rising and
 	falling edges of the pulse are used means the timer actually gives a 100Hz
 	oscillating signal.*/
-	m_signal_100hz = m_signal_100hz^=1;
+	m_signal_100hz ^= 1;
 	m_ptm2->set_c1(m_signal_100hz);
 	m_pia3->cb1_w(m_signal_100hz);
 	update_triacs();
@@ -1710,6 +1710,7 @@ GAMEL( 198?, m3ratrce,   0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0
 
 GAME(  198?, m3supasw,   0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "BWB","Supaswop (BWB) (MPU3)",GAME_FLAGS )
 
+// boots and then errors with REEL 'A' FAILURE
 GAMEL( 198?, m3supwin,   0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "BWB","Super Win (BWB) (MPU3, set 1) (W.AG2) ", GAME_FLAGS, layout_m3supwin ) // offset VFD
 GAMEL( 198?, m3supwina,  m3supwin,   mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "BWB","Super Win (BWB) (MPU3, set 2) (S.W.2 1.0)", GAME_FLAGS, layout_m3supwin )
 
@@ -1729,14 +1730,13 @@ GAMEL( 198?, m3spoofa,   m3spoof,    mpu3base, mpu3, mpu3_state, init_mpu3, ROT0
 GAMEL( 198?, m3supspo,   0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Pcp","Super Spoof (Pcp) (MPU3, set 1)", GAME_FLAGS, layout_m3supspo )
 GAMEL( 198?, m3supspoa,  m3supspo,   mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Pcp","Super Spoof (Pcp) (MPU3, set 2)", GAME_FLAGS, layout_m3supspo )
 
-// boots, reel error a
 GAMEL( 198?, m3loony,    0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Pcp","Loonybin (Pcp) (MPU3)", GAME_FLAGS, layout_m3loony )
 
-// does nothing
+// boots, no vfd, then locks
 GAMEL( 198?, m3online,   0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Pcp","On Line (Pcp) (MPU3)", GAME_FLAGS, layout_m3online )
 GAMEL( 198?, m3toplin,   0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Pcp","Top Line (Pcp) (MPU3)", GAME_FLAGS, layout_m3toplin )
 
-// offset VFD, don't boot (act like m3supwin above)
+// REEL 'A' FAILURE
 GAMEL( 198?, m3rockpl,   0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Pcp","Rock Pile (Pcp) (MPU3)", GAME_FLAGS, layout_m3rockpl )
 GAMEL( 198?, m3rollem,   0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Pcp","Roll 'Em (Pcp) (MPU3)", GAME_FLAGS, layout_m3rollem )
 GAME(  198?, m3wigwam,   0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Pcp","Wig Wam (Pcp) (MPU3)",GAME_FLAGS )
@@ -1747,7 +1747,7 @@ GAME(  198?, m3wigwam,   0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0
 // no protection, boots without testing reels?
 GAMEL( 198?, m3gcrown,   0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Mdm","Golden Crowns (Mdm) (MPU3)", GAME_FLAGS, layout_m3gcrown )
 
-// reel A alarm
+// no VFD
 GAMEL( 198?, m3tfair,    0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Mdm","Tuppenny Fair (Mdm) (MPU3)", GAME_FLAGS, layout_m3tfair )
 GAME(  198?, m3wacky,    0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Mdm","Wacky Racer (Mdm) (MPU3)",GAME_FLAGS )
 

--- a/src/mame/barcrest/mpu3.cpp
+++ b/src/mame/barcrest/mpu3.cpp
@@ -751,7 +751,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(mpu3_state::gen_100hz)
 	/* Although reported as a '50Hz' signal, the fact that both rising and
 	falling edges of the pulse are used means the timer actually gives a 100Hz
 	oscillating signal.*/
-	m_signal_100hz = m_signal_100hz?0:1;
+	m_signal_100hz = m_signal_100hz^=1;
 	m_ptm2->set_c1(m_signal_100hz);
 	m_pia3->cb1_w(m_signal_100hz);
 	update_triacs();

--- a/src/mame/barcrest/mpu3.cpp
+++ b/src/mame/barcrest/mpu3.cpp
@@ -4,8 +4,7 @@
 /* Notes 17/07/11 DH
  added most other MPU3 sets
 
- most fail to boot, giving the CPU a 'WAIT' instruction then sitting there
- some complain about Characterizer (protection) and then do the same
+ some complain about Characterizer (protection)
  a few boot to show light displays with no LED text
  some display misaligned LED text
  many run VERY slowly, even when the CPU is inactive (inefficient MAME timer system overhead?)
@@ -227,7 +226,7 @@ private:
 	void pia_ic6_porta_w(uint8_t data);
 	void pia_ic6_portb_w(uint8_t data);
 	TIMER_CALLBACK_MEMBER(ic21_timeout);
-	TIMER_DEVICE_CALLBACK_MEMBER(gen_50hz);
+	TIMER_DEVICE_CALLBACK_MEMBER(gen_100hz);
 	TIMER_DEVICE_CALLBACK_MEMBER(ic10_callback);
 	void update_triacs();
 	void ic11_update();
@@ -258,7 +257,7 @@ private:
 	int m_input_strobe = 0;   /* IC11 74LS138 A = CA2 IC3, B = CA2 IC4, C = CA2 IC5 */
 	uint8_t m_lamp_strobe = 0;
 	uint8_t m_led_strobe = 0;
-	int m_signal_50hz = 0;
+	int m_signal_100hz = 0;
 
 	int m_optic_pattern = 0;
 
@@ -451,7 +450,7 @@ uint8_t mpu3_state::pia_ic3_porta_r()
 			break;
 		}
 	}
-	if (m_signal_50hz)
+	if (m_signal_100hz)
 	{
 		data |= 0x02;
 	}
@@ -747,14 +746,14 @@ void mpu3_state::machine_start()
 }
 
 /* generate a 50 Hz signal (some components rely on this for external sync) */
-TIMER_DEVICE_CALLBACK_MEMBER(mpu3_state::gen_50hz)
+TIMER_DEVICE_CALLBACK_MEMBER(mpu3_state::gen_100hz)
 {
 	/* Although reported as a '50Hz' signal, the fact that both rising and
 	falling edges of the pulse are used means the timer actually gives a 100Hz
 	oscillating signal.*/
-	m_signal_50hz = m_signal_50hz?0:1;
-	m_ptm2->set_c1(m_signal_50hz);
-	m_pia3->cb1_w(~m_signal_50hz);
+	m_signal_100hz = m_signal_100hz?0:1;
+	m_ptm2->set_c1(m_signal_100hz);
+	m_pia3->cb1_w(m_signal_100hz);
 	update_triacs();
 }
 
@@ -810,7 +809,7 @@ void mpu3_state::mpu3base(machine_config &config)
 
 	MSC1937(config, m_vfd);
 
-	TIMER(config, "50hz").configure_periodic(FUNC(mpu3_state::gen_50hz), attotime::from_hz(100));
+	TIMER(config, "100hz").configure_periodic(FUNC(mpu3_state::gen_100hz), attotime::from_hz(200));
 	TIMER(config, "555_ic10").configure_periodic(FUNC(mpu3_state::ic10_callback), PERIOD_OF_555_ASTABLE(10000,1000,0.0000001));
 
 	/* 6840 PTM */
@@ -1689,10 +1688,9 @@ GAME(  198?, m3topsht,   0,          mpu3_chr_c000, mpu3, mpu3_chr_state, init_m
 // doesn't boot, does nothing?
 GAMEL( 198?, m3supnud,   0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Barcrest","Super Nudges Unlimited (Barcrest) (MPU3)", GAME_FLAGS, layout_m3supnud )
 
-// doesn't boot, does nothing?
 GAME(  198?, m3supser,   0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Barcrest","Super Series (Barcrest) (MPU3)",GAME_FLAGS )
 
-// doesn't boot, does nothing?
+// boots without initialising reels
 GAMEL( 198?, m3circle,   0,          mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Barcrest","Special Circle Club (Barcrest) (MPU3, set 1)", GAME_FLAGS, layout_m3circle )
 GAMEL( 198?, m3circlea,  m3circle,   mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Barcrest","Special Circle Club (Barcrest) (MPU3, set 2, bad)", GAME_FLAGS, layout_m3circle )
 GAMEL( 198?, m3circleb,  m3circle,   mpu3base, mpu3, mpu3_state, init_mpu3, ROT0, "Barcrest","Special Circle Club (Barcrest) (MPU3, set 3)", GAME_FLAGS, layout_m3circle )


### PR DESCRIPTION
100hz signal to the pia was previously done with m_pia3->cb1_w(~m_signal_50hz);
As m_signal_50hz was an int with a value of 0 or 1 this meant cb1_w() was always being called with a non-zero value.

In addition to the above, it's supposed to be a 100hz signal, not 50hz.

This fixes software which boots and then locks with TURN-ON-DELAY 30 on the display.
Also, fixes software which use the WAI instruction and then lock.
