### PR TITLE
ef9345: implement service row for the TS9347 variant

### DIFF
--- a/src/devices/video/ef9345.cpp
+++ b/src/devices/video/ef9345.cpp
@@ -378,7 +378,23 @@ void ef9345_device::zoom(uint8_t *pix, uint16_t n)
 uint16_t ef9345_device::indexblock(uint16_t x, uint16_t y)
 {
 	uint16_t i = x, j;
-	j = (y == 0) ? ((m_tgs & 0x20) >> 5) : ((m_ror & 0x1f) + y - 1);
+
+	if (m_variant == EF9345_MODE::TYPE_EF9345)
+	{
+		// On the EF9345 the service row is always displayed at the top, and
+		// it can be fetched from either Y=0 or Y=1.
+		j = (y == 0) ? ((m_tgs & 0x20) >> 5) : ((m_ror & 0x1f) + y - 1);
+	}
+	else
+	{
+		// On the TS9347 the service row is displayed either at the top or at
+		// the bottom, and it is always fetched from Y=0.
+		if (m_tgs & 1)
+			j = (y == 24) ? 0 : ((m_ror & 0x1f) + y);
+		else
+			j = (y == 0) ? 0 : ((m_ror & 0x1f) + y - 1);
+	}
+
 	j = (j > 31) ? (j - 24) : j;
 
 	//right side of a double width character


### PR DESCRIPTION
With this change, the minitel2 can correctly display its status row at the top of the screen.

Screenshots before:
<img src="https://github.com/user-attachments/assets/0a8eb54f-5ec5-4784-ad1b-5a6149884ecc" width="45%"/> <img src="https://github.com/user-attachments/assets/b71a847c-39c0-4a22-98fe-6462517ae7c4" width="45%"/>

Screenshots after:
<img src="https://github.com/user-attachments/assets/210daf29-2dac-40bc-b4ca-e33c5f0771bb" width="45%"/> <img src="https://github.com/user-attachments/assets/ed132000-d7d4-4c15-aa48-61d9944d962f" width="45%"/>

Corresponding picture from a real Minitel 2: http://hxc2001.free.fr/minitel/minitel2.jpg (from @jfdelnero's website).

### Explanation

The ef9345.cpp file provides support for both the EF9345 and the TS9347 video chips. Compared to the EF9345, the TS9347 has a slightly different logic for the "service row" (i.e. a text line that is conceptually separate from the main contents of the screen). In particular:
- the EF9345 lets one select the memory location for fetching data for the service row, but not where to display it (it's always displayed at the top of the screen)
- the TS9347 lets one select where to display (either at the top or at the bottom), but not where to fetch it from (it's always fetched from the beginning of the video memory block)

Before this change, the TS9347 peculiarities were not implemented. The EF9345 code path is not affected by this change.

Relevant extract from the **EF9345** datasheet (i.e. the one that is already implemented):
<img src="https://github.com/user-attachments/assets/3a9033d3-c6dc-4c0d-ab58-c640f416a279" width="45%"/>


Relevant extract from the **TS9347** datasheet (i.e. the variant implemented by this change):
<img src="https://github.com/user-attachments/assets/eafbe027-40ed-4737-8b99-46e2b23466e1" width="45%"/> <img src="https://github.com/user-attachments/assets/921e5bce-5a74-4289-812d-73861cfab456" width="45%"/>

