### PR TITLE
heathzenith/h89.cpp: Update gpp handling for MMS FDC

### DIFF
--- a/src/devices/bus/heathzenith/h89/h89bus.cpp
+++ b/src/devices/bus/heathzenith/h89/h89bus.cpp
@@ -280,7 +280,7 @@ void h89bus_device::io_dispatch_w(offs_t offset, u8 data)
 
 	if (decode)
 	{
-		if (decode & H89_GPP) m_out_gpp_cb(offset, data);
+		if ((decode & H89_GPP) && ((offset & 7) == 2)) m_out_gpp_cb(offset, data);
 		if (decode & H89_NMI) { m_out_nmi_cb(offset, data); return; }
 		if (decode & H89_TERM) { m_out_tlb_cb(offset & 7, data); return; }
 

--- a/src/mame/heathzenith/h89.cpp
+++ b/src/mame/heathzenith/h89.cpp
@@ -247,9 +247,6 @@ public:
 
 	void h89_mms(machine_config &config);
 
-protected:
-	u8 port_f2_mms_r(offs_t offset);
-	void port_f2_mms_w(offs_t offset, u8 data);
 };
 
 
@@ -885,31 +882,6 @@ void h89_base_state::port_f2_w(offs_t offset, u8 data)
 	m_intr_socket->set_irq_level(1, CLEAR_LINE);
 }
 
-// MMS intercepts the GPIO decoding so the GPIO pin on
-// the right slots can be used as a card select without
-// interfering with normal GPIO port operation.
-u8 h89_mms_state::port_f2_mms_r(offs_t offset)
-{
-	if ((offset & 7) != 2)
-	{
-		return 0;
-	}
-
-	return m_sw501->read();
-}
-
-void h89_mms_state::port_f2_mms_w(offs_t offset, u8 data)
-{
-	if ((offset & 7) != 2)
-	{
-		return;
-	}
-
-	update_gpp(data);
-
-	m_intr_socket->set_irq_level(1, CLEAR_LINE);
-}
-
 static void tlb_options(device_slot_interface &device)
 {
 	device.option_add("heath",        HEATH_TLB);
@@ -1070,9 +1042,6 @@ void h89_mms_state::h89_mms(machine_config &config)
 {
 	h89_base(config);
 	m_h89bus->set_default_bios_tag("444-61c");
-
-	m_h89bus->in_gpp_callback().set(FUNC(h89_mms_state::port_f2_mms_r));
-	m_h89bus->out_gpp_callback().set(FUNC(h89_mms_state::port_f2_mms_w));
 
 	// the card selection is different with the MMS mapping PROM
 	H89BUS_RIGHT_SLOT(config.replace(), "p504", "h89bus", [this](device_slot_interface &device) { h89_right_cards_mms(device); }, "mms77316");


### PR DESCRIPTION
For the existing `h89bus_device::io_dispatch_r()` routine, a check of the offset was occurring that made the check in `h89_mms_state::port_f2_mms_r` redundant. Between the two checks, having it in h89bus_device simplified the logic. 

@rb6502  let me know if you agree with this approach, or if you think the check should removed from `h89bus_device::io_dispatch_r()`. 