### PR TITLE
misc/changyu.cpp: change year 19?? to 1991 for changyu2, pinpoint voice roms

### DIFF
--- a/src/mame/misc/changyu.cpp
+++ b/src/mame/misc/changyu.cpp
@@ -532,7 +532,7 @@ ROM_START( changyu2 ) // 999 ROM999 II BY HUANGYEH string
 	ROM_LOAD( "93.bin",  0x10000, 0x08000, CRC(1d2b75de) SHA1(89b201b75691ee6ac3fc71fb8a998dbf05a1b0b2) ) // 27256
 	ROM_LOAD( "94.bin",  0x18000, 0x08000, CRC(f61a8410) SHA1(3c4df3e973322200aa72cf1d1df827c2ba69671b) ) // 27256
 
-	ROM_REGION(0x30000, "unsorted", 0)
+	ROM_REGION(0x30000, "voice", 0)
 	ROM_LOAD( "96c.bin", 0x00000, 0x10000, CRC(06d11350) SHA1(3c65d1d71010a3f10b00c799ede2debc96f6f3cf) ) // 27C512
 	ROM_LOAD( "97c.bin", 0x10000, 0x10000, CRC(e242ab79) SHA1(a7b14692556605eb039d1ef98fb3b8b007717c12) ) // 27C512
 	ROM_LOAD( "98c.bin", 0x20000, 0x10000, CRC(c8879f76) SHA1(6bcc686720dc63f50509f3f003b1f62ff43fc6b1) ) // 27C512
@@ -553,4 +553,4 @@ ROM_END
 
 // No copyright for both, are these really bootlegs?
 GAME( 1989, changyu,  0, changyu,  changyu, changyu_state,  empty_init, ROT0, "Chang Yu Electronic", "Mayo no 21", MACHINE_NOT_WORKING | MACHINE_NO_SOUND ) // Wing Co. in GFX1, year taken from start of maincpu ROM
-GAME( 19??, changyu2, 0, changyu2, changyu2,changyu2_state, empty_init, ROT0, "Chang Yu Electronic", "999", MACHINE_NOT_WORKING ) // Wing Co. in GFX1
+GAME( 1991, changyu2, 0, changyu2, changyu2,changyu2_state, empty_init, ROT0, "Chang Yu Electronic", "999", MACHINE_NOT_WORKING ) // Wing Co. in GFX1


### PR DESCRIPTION
at the driver note
marked 9101
1991 january?
in the maganize 317 of Sep. 91 Replay
fun nine look similar to 999.
96c 97c 98c are just voice rom cvsd.