### PR TITLE
CD-i: Add RGB Decoding

### DIFF
--- a/src/mame/philips/mcd212.cpp
+++ b/src/mame/philips/mcd212.cpp
@@ -640,13 +640,13 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 	const uint8_t *data = reinterpret_cast<uint8_t *>(Path ? m_planeb.target() : m_planea.target());
 	const uint8_t *data2 = reinterpret_cast<uint8_t*>(!Path ? m_planeb.target() : m_planea.target());
 	const uint8_t icm = get_icm<Path>();
-	const uint8_t transp_ctrl = get_transparency_control<Path>();
+	const uint8_t tp_ctrl = get_transparency_control<Path>();
 	const int width = get_screen_width();
 
 	uint32_t vsr = get_vsr<Path>();
 	uint32_t vsr2 = get_vsr<!Path>();
 
-	if (transp_ctrl == TCR_COND_1 || !icm || !vsr)
+	if (tp_ctrl == TCR_ALWAYS || !icm || !vsr)
 	{
 		std::fill_n(pixels, get_screen_width(), s_4bpp_color[0]);
 		std::fill_n(transparent, get_screen_width(), true);
@@ -664,16 +664,17 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 	uint8_t v = (dyuv_abs_start >>  0) & 0x000000ff;
 
 	const uint32_t mask_bits = (~m_mask_color[Path]) & 0x00fcfcfc;
-	const uint32_t transp_match = m_transparent_color[Path] & mask_bits;
-	const uint8_t transp_ctrl_masked = transp_ctrl & 0x07;
+	const uint32_t tp_color_match = m_transparent_color[Path] & mask_bits;
+	const uint8_t tp_ctrl_type = tp_ctrl & 0x07;
 
-	const bool use_transparent_bit = (transp_ctrl_masked == TCR_COND_XLU_1);
-	const bool transp_always = (transp_ctrl_masked == TCR_COND_1);
-	const bool invert_transp_condition = BIT(transp_ctrl, 3);
-	const int region_flag_index = 1 - (transp_ctrl_masked & 1);
+	const bool use_rgb_tp_bit = (tp_ctrl_type == TCR_RGB);
+	const bool tp_check_parity = !BIT(tp_ctrl, 3);
+	const bool tp_always = ((tp_ctrl_type == TCR_ALWAYS) && tp_check_parity);
+	const int region_flag_index = 1 - (tp_ctrl_type & 1);
 	const bool *region_flags = m_region_flag[region_flag_index];
-	const bool use_region_flag = (transp_ctrl_masked >= TCR_COND_RF0_1 && transp_ctrl_masked <= TCR_COND_RF1KEY_1);
-	bool use_color_key = (icm != ICM_DYUV && !(icm == ICM_RGB555 && Path == 1)) && (transp_ctrl_masked == TCR_COND_KEY_1 || transp_ctrl_masked == TCR_COND_RF0KEY_1 || transp_ctrl_masked == TCR_COND_RF1KEY_1);
+	const bool use_region_flag = (tp_ctrl_type >= TCR_RF0 && tp_ctrl_type <= TCR_RF1_KEY1);
+	bool use_color_key = (tp_ctrl_type == TCR_KEY || tp_ctrl_type == TCR_RF0_KEY1 || tp_ctrl_type == TCR_RF1_KEY1);
+	use_color_key &= (icm != ICM_DYUV && !(icm == ICM_RGB555 && Path == 1)); // DYUV and RGB do not have access to color key.
 
 	LOGMASKED(LOG_VSR, "Scanline %d: VSR Path %d, ICM (%02x), VSR (%08x)\n", screen().vpos(), Path, icm, vsr);
 
@@ -682,7 +683,7 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 		const uint8_t byte = data[(vsr++ & 0x0007ffff) ^ 1];
 		uint32_t color0 = 0;
 		uint32_t color1 = 0;
-		bool transparent_bit = false;
+		bool rgb_tp_bit = false;
 		if (icm == ICM_DYUV)
 		{
 			const uint8_t byte1 = data[(vsr++ & 0x0007ffff) ^ 1];
@@ -707,22 +708,24 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 			pixels[x + 1] = color0;
 			pixels[x + 2] = color1;
 			pixels[x + 3] = color1;
-			transparent[x] = (transp_always || (use_region_flag && region_flags[x])) != invert_transp_condition;
-			transparent[x + 1] = (transp_always || (use_region_flag && region_flags[x + 1])) != invert_transp_condition;
-			transparent[x + 2] = (transp_always || (use_region_flag && region_flags[x + 2])) != invert_transp_condition;
-			transparent[x + 3] = (transp_always || (use_region_flag && region_flags[x + 3])) != invert_transp_condition;
+			transparent[x    ] = tp_always || (use_region_flag && (region_flags[x    ] == tp_check_parity));
+			transparent[x + 1] = tp_always || (use_region_flag && (region_flags[x + 1] == tp_check_parity));
+			transparent[x + 2] = tp_always || (use_region_flag && (region_flags[x + 2] == tp_check_parity));
+			transparent[x + 3] = tp_always || (use_region_flag && (region_flags[x + 3] == tp_check_parity));
 			x += 4;
 		}
 		else
 		{
-			if (icm == ICM_RGB555 && Path == 1) {
+			if (icm == ICM_RGB555 && Path == 1)
+			{
 				const uint8_t byte1 = data2[(vsr2++ & 0x0007ffff) ^ 1];
 				const uint8_t blue = (byte & 0b11111) << 3;
 				const uint8_t green = ((byte & 0b11100000) >> 2) + ((byte1 & 0b11) << 6);
 				const uint8_t red = (byte1 & 0b01111100) << 1;
-				transparent_bit = (use_transparent_bit && (byte1 & 0x80));
+				rgb_tp_bit = (use_rgb_tp_bit && ((byte1 & 0x80) == tp_check_parity));
 				color1 = color0 = (red << 16) + (green << 8) + blue;
-			} else if (icm == ICM_CLUT4)
+			}
+			else if (icm == ICM_CLUT4)
 			{
 				const uint8_t mask = (decodingMode == DDR_FT_RLE) ? 0x7 : 0xf;
 				color0 = m_clut[BYTE_TO_CLUT<Path>(icm, mask & (byte >> 4))];
@@ -740,15 +743,15 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 				length_m = length ? (length * 2) : width;
 			}
 
-			const bool color_match0 = (mask_bits & color0) == transp_match;
-			const bool color_match1 = (mask_bits & color1) == transp_match;
+			const bool color_match0 = (((mask_bits & color0) == tp_color_match) == tp_check_parity);
+			const bool color_match1 = (((mask_bits & color1) == tp_color_match) == tp_check_parity);
 			const int end = std::min<int>(width, x + length_m);
 			for (int rl_index = x; rl_index < end; rl_index += 2)
 			{
-				pixels[rl_index] = color0;
-				transparent[rl_index] = (transp_always || transparent_bit || (use_color_key && color_match0) || (use_region_flag && region_flags[rl_index])) != invert_transp_condition;
+				pixels[rl_index    ] = color0;
 				pixels[rl_index + 1] = color1;
-				transparent[rl_index + 1] = (transp_always || transparent_bit || (use_color_key && color_match1) || (use_region_flag && region_flags[rl_index + 1])) != invert_transp_condition;
+				transparent[rl_index    ] = tp_always || rgb_tp_bit || (use_color_key && color_match0) || (use_region_flag && (region_flags[rl_index    ] == tp_check_parity));
+				transparent[rl_index + 1] = tp_always || rgb_tp_bit || (use_color_key && color_match1) || (use_region_flag && (region_flags[rl_index + 1] == tp_check_parity));
 			}
 			x = end;
 		}

--- a/src/mame/philips/mcd212.h
+++ b/src/mame/philips/mcd212.h
@@ -107,21 +107,21 @@ protected:
 		TCR_TA               = 0x00000f,    // Plane A
 		TCR_TB               = 0x000f00,    // Plane B
 		TCR_TB_SHIFT         = 8,
-		TCR_COND_1           = 0x0,         // Transparent if: Always (Plane Disabled)
-		TCR_COND_KEY_1       = 0x1,         // Transparent if: Color Key = True
-		TCR_COND_XLU_1       = 0x2,         // Transparent if: Transparency Bit = 1
-		TCR_COND_RF0_1       = 0x3,         // Transparent if: Region Flag 0 = True
-		TCR_COND_RF1_1       = 0x4,         // Transparent if: Region Flag 1 = True
-		TCR_COND_RF0KEY_1    = 0x5,         // Transparent if: Region Flag 0 = True || Color Key = True
-		TCR_COND_RF1KEY_1    = 0x6,         // Transparent if: Region Flag 1 = True || Color Key = True
+		TCR_ALWAYS           = 0x0,         // Transparent if: Always (Plane Disabled)
+		TCR_KEY              = 0x1,         // Transparent if: Color Key = True
+		TCR_RGB              = 0x2,         // Transparent if: Transparency Bit = 1 (RGB Only)
+		TCR_RF0              = 0x3,         // Transparent if: Region Flag 0 = True
+		TCR_RF1              = 0x4,         // Transparent if: Region Flag 1 = True
+		TCR_RF0_KEY1         = 0x5,         // Transparent if: Region Flag 0 = True || Color Key = True
+		TCR_RF1_KEY1         = 0x6,         // Transparent if: Region Flag 1 = True || Color Key = True
 		TCR_COND_UNUSED0     = 0x7,         // Unused
-		TCR_COND_0           = 0x8,         // Transparent if: Never (No Transparent Area)
-		TCR_COND_KEY_0       = 0x9,         // Transparent if: Color Key = False
-		TCR_COND_XLU_0       = 0xa,         // Transparent if: Transparency Bit = 0
-		TCR_COND_RF0_0       = 0xb,         // Transparent if: Region Flag 0 = False
-		TCR_COND_RF1_0       = 0xc,         // Transparent if: Region Flag 1 = False
-		TCR_COND_RF0KEY_0    = 0xd,         // Transparent if: Region Flag 0 = False && Color Key = False
-		TCR_COND_RF1KEY_0    = 0xe,         // Transparent if: Region Flag 1 = False && Color Key = False
+		TCR_NEVER            = 0x8,         // Transparent if: Never (No Transparent Area)
+		TCR_NOT_KEY          = 0x9,         // Transparent if: Color Key = False
+		TCR_NOT_RGB          = 0xa,         // Transparent if: Transparency Bit = 0 (RGB Only)
+		TCR_NOT_RF0          = 0xb,         // Transparent if: Region Flag 0 = False
+		TCR_NOT_RF1          = 0xc,         // Transparent if: Region Flag 1 = False
+		TCR_NOT_RF0_KEY      = 0xd,         // Transparent if: Region Flag 0 = False || Color Key = False
+		TCR_NOT_RF1_KEY      = 0xe,         // Transparent if: Region Flag 1 = False || Color Key = False
 		TCR_COND_UNUSED1     = 0xf,         // Unused
 		TCR_DISABLE_MX       = 0x800000,    // Mix disable
 

--- a/src/mame/philips/mcd212.h
+++ b/src/mame/philips/mcd212.h
@@ -171,7 +171,7 @@ protected:
 
 		ICM_OFF              = 0x0,
 		ICM_CLUT8            = 0x1,
-		ICM_RGB555           = 0x2,
+		ICM_RGB555           = 0x1,
 		ICM_CLUT7            = 0x3,
 		ICM_CLUT77           = 0x4,
 		ICM_DYUV             = 0x5,


### PR DESCRIPTION
1. This fix adds RGB decoding and RGB Transparency bit. It disables transparency color keying for RGB.
2. It fixes an incorrect enum that was foreshadowed in previous revisions.

As with previous pulls, you can validate this using the Validation Disc (Europe) for the CD-i.

### RGB Scroll Test
Due to the enum for CLUT8 and RGB being the same, this previously decoded as a CLUT8 image. When ICM flag 1 is used on path 1, it is instead decoded as RGB.
![{24B08B2F-8C6C-4F60-B01C-57E3D8EA26F2}](https://github.com/user-attachments/assets/82bbee49-12bb-4710-9317-cc249ac1d20b)

### RGB Draw Test
The house is now the right color
![{07289C62-1273-4C22-8A7D-13D5680C3CE2}](https://github.com/user-attachments/assets/a9ca776f-184a-4a74-a181-5040b8626b96)

### Color Keying Test
RGB is now decoded correctly. Additionally, RGB does not match color key. Even when matching "red" colors, notice that the line of RGB still shows red. This is correct behavior, as RGB is not allowed to match color keys.
![{827BF19D-391A-4880-9AC2-BD8BA927D76E}](https://github.com/user-attachments/assets/9b1c89b2-e764-4a5f-94df-0f0f8c3f5bc5)

### Transparency Control (Uncertain Issue)
The implementation of RGB color keying is to always be false. However the spec says that "RGB cannot use color key tests". Since this would be a misconfiguration in practice... I am not sure what a true console would produce. The Transparency Control shows a different behavior. It's not clear from looking at it whether the change is expected or unexpected.
![{9EA9127F-762D-4546-9183-4BC508D6BAFB}](https://github.com/user-attachments/assets/ac3da1b4-e273-4863-827f-a12c1548f312)

Despite the last image, this change is much closer to correct spec behavior and it's recommended to pull. Someone with a real console should at some point run through all visual tests to get proper reference images.