### PR TITLE
Fedora 42 build fixes

### DIFF
--- a/src/lib/util/corestr.cpp
+++ b/src/lib/util/corestr.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 
 #include <cctype>
+#include <cstdint>
 #include <cstdlib>
 
 

--- a/src/osd/modules/sound/sdl_sound.cpp
+++ b/src/osd/modules/sound/sdl_sound.cpp
@@ -21,6 +21,7 @@
 #include <SDL2/SDL.h>
 
 #include <algorithm>
+#include <cmath>
 #include <fstream>
 #include <memory>
 


### PR DESCRIPTION
Fedora 42 plans to ship gcc-15 and to replace native SDL2 with sdl2-compat. These changes have exposed minor header issues which this PR addresses.