### PR TITLE
emscripten: fixes to get bgfx working

### DIFF
--- a/docs/source/initialsetup/compilingmame.rst
+++ b/docs/source/initialsetup/compilingmame.rst
@@ -353,7 +353,7 @@ above in All Platforms.
 Emscripten Javascript and HTML
 ------------------------------
 
-First, download and install Emscripten 2.0.25 or later by following the
+First, download and install Emscripten 3.1.35 or later by following the
 instructions at the `official site <https://emscripten.org/docs/getting_started/downloads.html>`_.
 
 Once Emscripten has been installed, it should be possible to compile MAME

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -1196,7 +1196,6 @@ configuration { "asmjs" }
 	if _OPTIONS["SYMBOLS"]~=nil and _OPTIONS["SYMBOLS"]~="0" then
 		linkoptions {
 			"-g" .. _OPTIONS["SYMLEVEL"],
-			"-s DEMANGLE_SUPPORT=1",
 		}
 	end
 	if _OPTIONS["WEBASSEMBLY"] then

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -1178,20 +1178,19 @@ configuration { "asmjs" }
 		"-O" .. _OPTIONS["OPTIMIZE"],
 		"-s USE_SDL=2",
 		"-s USE_SDL_TTF=2",
-		"--memory-init-file 0",
 		"-s DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=\"['\\$$ERRNO_CODES']\"",
 		"-s EXPORTED_FUNCTIONS=\"['_main', '_malloc', '__ZN15running_machine30emscripten_get_running_machineEv', '__ZN15running_machine17emscripten_get_uiEv', '__ZN15running_machine20emscripten_get_soundEv', '__ZN15mame_ui_manager12set_show_fpsEb', '__ZNK15mame_ui_manager8show_fpsEv', '__ZN13sound_manager4muteEbh', '_SDL_PauseAudio', '_SDL_SendKeyboardKey', '__ZN15running_machine15emscripten_saveEPKc', '__ZN15running_machine15emscripten_loadEPKc', '__ZN15running_machine21emscripten_hard_resetEv', '__ZN15running_machine21emscripten_soft_resetEv', '__ZN15running_machine15emscripten_exitEv']\"",
 		"-s EXPORTED_RUNTIME_METHODS=\"['cwrap']\"",
 		"-s ERROR_ON_UNDEFINED_SYMBOLS=0",
-		"-s USE_WEBGL2=1",
-		"-s LEGACY_GL_EMULATION=1",
-		"-s GL_UNSAFE_OPTS=0",
+		"-s STACK_SIZE=5MB",
+		"-s MAX_WEBGL_VERSION=2",
 		"--pre-js " .. _MAKE.esc(MAME_DIR) .. "src/osd/modules/sound/js_sound.js",
 		"--post-js " .. _MAKE.esc(MAME_DIR) .. "scripts/resources/emscripten/emscripten_post.js",
 		"--embed-file " .. _MAKE.esc(MAME_DIR) .. "bgfx/chains@bgfx/chains",
 		"--embed-file " .. _MAKE.esc(MAME_DIR) .. "bgfx/effects@bgfx/effects",
 		"--embed-file " .. _MAKE.esc(MAME_DIR) .. "bgfx/shaders/essl@bgfx/shaders/essl",
 		"--embed-file " .. _MAKE.esc(MAME_DIR) .. "artwork/bgfx@artwork/bgfx",
+		"--embed-file " .. _MAKE.esc(MAME_DIR) .. "artwork/lut-default.png@artwork/lut-default.png",
 		"--embed-file " .. _MAKE.esc(MAME_DIR) .. "artwork/slot-mask.png@artwork/slot-mask.png",
 	}
 	if _OPTIONS["SYMBOLS"]~=nil and _OPTIONS["SYMBOLS"]~="0" then
@@ -1213,11 +1212,12 @@ configuration { "asmjs" }
 		-- define a fixed memory size because allowing memory growth disables asm.js optimizations
 		linkoptions {
 			"-s ALLOW_MEMORY_GROWTH=0",
-			"-s TOTAL_MEMORY=268435456",
+			"-s INITIAL_MEMORY=256MB",
 		}
 	else
 		linkoptions {
 			"-s ALLOW_MEMORY_GROWTH=1",
+			"-s INITIAL_MEMORY=24MB"
 		}
 	end
 	archivesplit_size "20"

--- a/src/osd/modules/font/font_sdl.cpp
+++ b/src/osd/modules/font/font_sdl.cpp
@@ -15,11 +15,8 @@
 #include "unicode.h"
 #include "osdcore.h"
 
-#ifdef SDLMAME_EMSCRIPTEN
-#include <SDL_ttf.h>
-#else
 #include <SDL2/SDL_ttf.h>
-#endif
+
 #if !defined(SDLMAME_HAIKU) && !defined(SDLMAME_EMSCRIPTEN)
 #include <fontconfig/fontconfig.h>
 #endif

--- a/src/osd/modules/render/bgfx/shadermanager.cpp
+++ b/src/osd/modules/render/bgfx/shadermanager.cpp
@@ -83,6 +83,15 @@ std::string shader_manager::make_path_string(const osd_options &options, const s
 {
 	std::string shader_path(options.bgfx_path());
 	shader_path += PATH_SEPARATOR "shaders" PATH_SEPARATOR;
+
+#if defined(SDLMAME_EMSCRIPTEN)
+	// Hard-code renderer type to OpenGL ES for emscripten builds since the
+	// bgfx::getRendererType() is called here before BGFX has been
+	// initialized and therefore gives the wrong renderer type (Noop).
+	shader_path += "essl" PATH_SEPARATOR;
+	return shader_path;
+#endif
+
 	switch (bgfx::getRendererType())
 	{
 		case bgfx::RendererType::Noop:

--- a/src/osd/modules/render/drawbgfx.cpp
+++ b/src/osd/modules/render/drawbgfx.cpp
@@ -395,6 +395,17 @@ bool video_bgfx::set_platform_data(bgfx::PlatformData &platform_data, osd_window
 	platform_data.ndt = nullptr;
 	platform_data.nwh = GetOSWindow(dynamic_cast<mac_window_info const &>(window).platform_window());
 #else // defined(OSD_*)
+
+#if defined(SDLMAME_EMSCRIPTEN)
+	platform_data.ndt = nullptr;
+	platform_data.nwh = (void *)"#canvas"; // HTML5 target selector
+	platform_data.context = nullptr;
+	platform_data.backBuffer = nullptr;
+	platform_data.backBufferDS = nullptr;
+	bgfx::setPlatformData(platform_data);
+	return true;
+#endif
+
 	SDL_SysWMinfo wmi;
 	SDL_VERSION(&wmi.version);
 	if (!SDL_GetWindowWMInfo(dynamic_cast<sdl_window_info const &>(window).platform_window(), &wmi))

--- a/src/osd/modules/render/drawbgfx.cpp
+++ b/src/osd/modules/render/drawbgfx.cpp
@@ -396,7 +396,7 @@ bool video_bgfx::set_platform_data(bgfx::PlatformData &platform_data, osd_window
 	platform_data.nwh = GetOSWindow(dynamic_cast<mac_window_info const &>(window).platform_window());
 #elif defined(SDLMAME_EMSCRIPTEN)
 	platform_data.ndt = nullptr;
-        platform_data.nwh = (void *)"#canvas"; // HTML5 target selector
+	platform_data.nwh = (void *)"#canvas"; // HTML5 target selector
 #else // defined(OSD_*)
 	SDL_SysWMinfo wmi;
 	SDL_VERSION(&wmi.version);

--- a/src/osd/modules/render/drawbgfx.cpp
+++ b/src/osd/modules/render/drawbgfx.cpp
@@ -394,18 +394,10 @@ bool video_bgfx::set_platform_data(bgfx::PlatformData &platform_data, osd_window
 #elif defined(OSD_MAC)
 	platform_data.ndt = nullptr;
 	platform_data.nwh = GetOSWindow(dynamic_cast<mac_window_info const &>(window).platform_window());
-#else // defined(OSD_*)
-
-#if defined(SDLMAME_EMSCRIPTEN)
+#elif defined(SDLMAME_EMSCRIPTEN)
 	platform_data.ndt = nullptr;
-	platform_data.nwh = (void *)"#canvas"; // HTML5 target selector
-	platform_data.context = nullptr;
-	platform_data.backBuffer = nullptr;
-	platform_data.backBufferDS = nullptr;
-	bgfx::setPlatformData(platform_data);
-	return true;
-#endif
-
+        platform_data.nwh = (void *)"#canvas"; // HTML5 target selector
+#else // defined(OSD_*)
 	SDL_SysWMinfo wmi;
 	SDL_VERSION(&wmi.version);
 	if (!SDL_GetWindowWMInfo(dynamic_cast<sdl_window_info const &>(window).platform_window(), &wmi))


### PR DESCRIPTION
This PR adds support for the bgfx video backend when building for emscripten.

In order to get bgfx build and run with mame, the following changes has been done:
* `src/osd/modules/render/bgfx/shadermanager.cpp`: Change `make_path_string(...)` to always return the path to the `essl` shaders. This wasn't working properly since the call to the function is done before bgfx has been initialised and therefore returned the renderer type `Noop` instead (see https://bkaradzic.github.io/bgfx/bgfx.html#_CPPv4N4bgfx15getRendererTypeEv).
* `src/osd/modules/render/drawbgfx.cpp`: Change `set_platform_data(...)` to return platform data with a window handle that includes a HTML target selector for the canvas element to use (currently set to `#canvas`).
* `scripts/genie.lua`: Update emscripten compiler flags to match recent emscripten versions and set memory allocation to work with the drivers I've been testing with. Also embedded a file, `artwork/lut-default.png`, which is required for the lut and hlsl chains.

Additional changes:
* `src/osd/modules/font/font_sdl.cpp`: Change SDL_ttf include to use SDL2 since recent emscripten supports this.
* `docs/source/initialsetup/compilingmame.rst`: Update emscripten version to use.

The change has been tested by me and works well with the drivers I've tested. The performance is greatly improved when using bgfx compared to the soft renderer and many drivers that struggled to maintain a decent framerate are now running smoothly at 100%.

![image](https://github.com/user-attachments/assets/b9b9aa31-ffb3-4a7f-858e-0463083c8781)

All builds has been done using emscripten 3.1.35. When trying later versions various other issues has been encountered which I haven't addressed or investigated further.

Setting this as a draft and ask kindly for other Mame developers with more insight into the OSD and build system to please take a look at this PR and suggest how these changes can be improved.