### PR TITLE
hash/pc8801_flop.xml: babylon updates

### DIFF
--- a/hash/pc8801_flop.xml
+++ b/hash/pc8801_flop.xml
@@ -4070,7 +4070,8 @@ A few kanji drawings in gameplay are odd to look at (cfr. signs, sports as full 
 		<!-- PC8801mk2SR -->
 		<info name="release" value="198612xx"/>
 		<info name="alt_title" value="バビロン"/>
-		<info name="usage" value="Needs BASIC V2, check Crimson usage information's to create user disk"/>
+		<info name="usage" value="Needs BASIC V2"/>
+		<!-- check Crimson usage information for instructions on how to create user disk -->
 		<!--combined image-->
 		<!--rom name="babylon.d88" size="1067728" crc="117d7783" sha1="31bf30823e223c63f9b71c92c024904416da9294"/-->
 

--- a/hash/pc8801_flop.xml
+++ b/hash/pc8801_flop.xml
@@ -4067,14 +4067,10 @@ A few kanji drawings in gameplay are odd to look at (cfr. signs, sports as full 
 		<description>Babylon</description>
 		<year>1986</year>
 		<publisher>クリスタルソフト (Xtal Soft)</publisher>
-		<notes><![CDATA[
-The scenario disk is a user disk for this set so make user is not possible.
-Check the floppy name on XM8.
-]]></notes>
 		<!-- PC8801mk2SR -->
 		<info name="release" value="198612xx"/>
 		<info name="alt_title" value="バビロン"/>
-		<info name="usage" value="Needs BASIC V2"/>
+		<info name="usage" value="Needs BASIC V2, check Crimson usage information's to create user disk"/>
 		<!--combined image-->
 		<!--rom name="babylon.d88" size="1067728" crc="117d7783" sha1="31bf30823e223c63f9b71c92c024904416da9294"/-->
 

--- a/hash/pc8801_flop.xml
+++ b/hash/pc8801_flop.xml
@@ -4067,7 +4067,11 @@ A few kanji drawings in gameplay are odd to look at (cfr. signs, sports as full 
 		<description>Babylon</description>
 		<year>1986</year>
 		<publisher>クリスタルソフト (Xtal Soft)</publisher>
-		<!-- PC8801 -->
+		<notes><![CDATA[
+The scenario disk is a user disk for this set so make user is not possible.
+Check the floppy name on XM8.
+]]></notes>
+		<!-- PC8801mk2SR -->
 		<info name="release" value="198612xx"/>
 		<info name="alt_title" value="バビロン"/>
 		<info name="usage" value="Needs BASIC V2"/>
@@ -4100,7 +4104,7 @@ A few kanji drawings in gameplay are odd to look at (cfr. signs, sports as full 
 		<description>Babylon (alt)</description>
 		<year>1986</year>
 		<publisher>クリスタルソフト (Xtal Soft)</publisher>
-		<!-- PC8801 -->
+		<!-- PC8801mk2SR -->
 		<info name="release" value="198612xx"/>
 		<info name="alt_title" value="バビロン"/>
 		<info name="usage" value="Needs BASIC V2"/>


### PR DESCRIPTION
- Required V2 Mode set so change PC8801 to PC8801mk2SR
- Parent set the scenario disk is user disk so make user is not possible (add a note)

If I set the scenario disk on XM8, the message indicate the disk is not the correct one.
![image](https://github.com/user-attachments/assets/b74d409c-20ff-458d-bbdc-3167b287089e)

If I set Mode n88v1h
![image](https://github.com/user-attachments/assets/d1f7c556-2461-4413-936f-1f571a189831)

The user disk of this set seems a blank disk.

Thanks,