### PR TITLE
hash/pc8801_flop.xml: update QA

### DIFF
--- a/hash/pc8801_flop.xml
+++ b/hash/pc8801_flop.xml
@@ -29122,29 +29122,29 @@ Start and Program Disks OK, the remaining part is damaged (missing d88 headers?)
 	</software>
 
 	<software name="sf3dthxg">
-		<description>S.F.3.D Point X Senryou Sakusen - Original Operation Thanksgiving</description>
+		<description>S.F.3.D - Original Operation Thanksgiving</description>
 		<year>1986</year>
 		<publisher>クロスメディアソフト (Cross Media Soft)</publisher>
 		<!-- PC8801 -->
 		<info name="release" value="198609xx"/>
-		<info name="alt_title" value="ポイントX占領作戦 (Box)"/>
+		<info name="alt_title" value="ポイントX占領作戦 S.F.3.D - Original Operation Thanksgiving (Box)"/>
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="365168">
-				<rom name="s.f.3.d. point x senryou sakusen - original operation thanksgiving.d88" size="365168" crc="4985b37a" sha1="d13efd4b247b0e6ec702e769e51a5963fa007411"/>
+				<rom name="s.f.3.d. - original operation thanksgiving.d88" size="365168" crc="4985b37a" sha1="d13efd4b247b0e6ec702e769e51a5963fa007411"/>
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="sf3dthxga">
-		<description>S.F.3.D Point X Senryou Sakusen - Original Operation Thanksgiving (alt)</description>
+		<description>S.F.3.D - Original Operation Thanksgiving (alt)</description>
 		<year>1986</year>
 		<publisher>クロスメディアソフト (Cross Media Soft)</publisher>
 		<!-- PC8801 -->
 		<info name="release" value="198609xx"/>
-		<info name="alt_title" value="ポイントX占領作戦 (Box)"/>
+		<info name="alt_title" value="ポイントX占領作戦 S.F.3.D - Original Operation Thanksgiving (Box)"/>
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="365168">
-				<rom name="s.f.3.d. point x senryou sakusen - original operation thanksgiving (a).d88" size="365168" crc="ffb66bfb" sha1="8524f776b1a0730086ebc78ae6dc20b4483fff57"/>
+				<rom name="s.f.3.d. - original operation thanksgiving (a).d88" size="365168" crc="ffb66bfb" sha1="8524f776b1a0730086ebc78ae6dc20b4483fff57"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/pc8801_flop.xml
+++ b/hash/pc8801_flop.xml
@@ -29122,7 +29122,7 @@ Start and Program Disks OK, the remaining part is damaged (missing d88 headers?)
 	</software>
 
 	<software name="sf3dthxg">
-		<description>S.F.3.D Point X Senryou Sakusen - Operation Thanksgiving</description>
+		<description>S.F.3.D Point X Senryou Sakusen - Original Operation Thanksgiving</description>
 		<year>1986</year>
 		<publisher>クロスメディアソフト (Cross Media Soft)</publisher>
 		<!-- PC8801 -->
@@ -29130,13 +29130,13 @@ Start and Program Disks OK, the remaining part is damaged (missing d88 headers?)
 		<info name="alt_title" value="ポイントX占領作戦 (Box)"/>
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="365168">
-				<rom name="s.f.3.d. point x senryou sakusen - operation thanksgiving.d88" size="365168" crc="4985b37a" sha1="d13efd4b247b0e6ec702e769e51a5963fa007411"/>
+				<rom name="s.f.3.d. point x senryou sakusen - original operation thanksgiving.d88" size="365168" crc="4985b37a" sha1="d13efd4b247b0e6ec702e769e51a5963fa007411"/>
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="sf3dthxga">
-		<description>S.F.3.D Point X Senryou Sakusen - Operation Thanksgiving (alt)</description>
+		<description>S.F.3.D Point X Senryou Sakusen - Original Operation Thanksgiving (alt)</description>
 		<year>1986</year>
 		<publisher>クロスメディアソフト (Cross Media Soft)</publisher>
 		<!-- PC8801 -->
@@ -29144,7 +29144,7 @@ Start and Program Disks OK, the remaining part is damaged (missing d88 headers?)
 		<info name="alt_title" value="ポイントX占領作戦 (Box)"/>
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="365168">
-				<rom name="s.f.3.d. point x senryou sakusen - operation thanksgiving (a).d88" size="365168" crc="ffb66bfb" sha1="8524f776b1a0730086ebc78ae6dc20b4483fff57"/>
+				<rom name="s.f.3.d. point x senryou sakusen - original operation thanksgiving (a).d88" size="365168" crc="ffb66bfb" sha1="8524f776b1a0730086ebc78ae6dc20b4483fff57"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/pc8801_flop.xml
+++ b/hash/pc8801_flop.xml
@@ -240,6 +240,7 @@ Are the following undumped or mistranslated (check also if available in TOSEC)?
  - ゴルゴ13 狼の巣 (198410xx) by Pony Canyon
  - Breakfast3号 (1984xxxx) by Kominiketo
  - Blue Blood disks (at least Vol. 1-6 and CG set Vol. 1 according to gradiusm)
+ - S.F.3.D Original Operation V by Cross Media Soft
 
 Not included:
  - ミラーズ (19901210) by Studio Wing, uses CDROM (>PC8801MC)
@@ -5898,12 +5899,13 @@ Not extensively tested
 	</software>
 
 	<software name="carmine">
-		<description>Carmine</description>
+		<description>Carmine 88</description>
 		<year>1987</year>
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
-		<!-- PC8801 -->
+		<!-- PC8801mk2SR -->
 		<info name="release" value="198702xx"/>
-		<info name="alt_title" value="カーマイン"/>
+		<info name="alt_title" value="カーマイン88"/>
+		<info name="usage" value="Needs BASIC V2"/>
 		<!--combined image-->
 		<!--rom name="carmine.d88" size="770496" crc="ade94761" sha1="220ee916091ece8176e56867e3923529a8c49591"/-->
 
@@ -5923,12 +5925,13 @@ Not extensively tested
 	</software>
 
 	<software name="carminea" cloneof="carmine">
-		<description>Carmine (alt?)</description>
+		<description>Carmine 88 (alt?)</description>
 		<year>1987</year>
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
-		<!-- PC8801 -->
+		<!-- PC8801mk2SR -->
 		<info name="release" value="198702xx"/>
-		<info name="alt_title" value="カーマイン"/>
+		<info name="alt_title" value="カーマイン88"/>
+		<info name="usage" value="Needs BASIC V2"/>
 		<!--combined image-->
 		<!--rom name="carmine.d88" size="1140944" crc="62aeef7e" sha1="18a952b782b71177fa0000652422d0ed23d7d6a5"/-->
 
@@ -29118,21 +29121,8 @@ Start and Program Disks OK, the remaining part is damaged (missing d88 headers?)
 		</part>
 	</software>
 
-	<software name="sf3dopv">
-		<description>S.F.3.D Original Operation V</description>
-		<year>1985</year>
-		<publisher>クロスメディアソフト (Cross Media Soft)</publisher>
-		<!-- PC8801 -->
-		<info name="release" value="198512xx"/>
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="365168">
-				<rom name="s.f.3.d original operation v (1985)(cross media).d88" size="365168" crc="ffb66bfb" sha1="8524f776b1a0730086ebc78ae6dc20b4483fff57"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="sf3dthxg">
-		<description>S.F.3.D. - Original Operation Thanksgiving</description>
+		<description>S.F.3.D Point X Senryou Sakusen - Operation Thanksgiving</description>
 		<year>1986</year>
 		<publisher>クロスメディアソフト (Cross Media Soft)</publisher>
 		<!-- PC8801 -->
@@ -29140,7 +29130,21 @@ Start and Program Disks OK, the remaining part is damaged (missing d88 headers?)
 		<info name="alt_title" value="ポイントX占領作戦 (Box)"/>
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="365168">
-				<rom name="s.f.3.d. - original operation thanksgiving.d88" size="365168" crc="4985b37a" sha1="d13efd4b247b0e6ec702e769e51a5963fa007411"/>
+				<rom name="s.f.3.d. point x senryou sakusen - operation thanksgiving.d88" size="365168" crc="4985b37a" sha1="d13efd4b247b0e6ec702e769e51a5963fa007411"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sf3dthxga">
+		<description>S.F.3.D Point X Senryou Sakusen - Operation Thanksgiving (alt)</description>
+		<year>1986</year>
+		<publisher>クロスメディアソフト (Cross Media Soft)</publisher>
+		<!-- PC8801 -->
+		<info name="release" value="198609xx"/>
+		<info name="alt_title" value="ポイントX占領作戦 (Box)"/>
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="365168">
+				<rom name="s.f.3.d. point x senryou sakusen - operation thanksgiving (a).d88" size="365168" crc="ffb66bfb" sha1="8524f776b1a0730086ebc78ae6dc20b4483fff57"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
- sf3dopv is the same game as sf3dthxg. So I make it a alternative. Add sf3dopv to undumped list. Fix the name to reflect the box name.

I put S.F.3.D Original Operation V on the undumped list.
TOSEC listed S.F.3.D Original Operation V but it is S.F.3.D Point X Senryou Sakusen - Operation Thanksgiving. (check with TOSEC (2024-05-17))

Both games existed as mentioned of this website
https://www.zimmerit.moe/kow-yokoyama-sf3d-original/

Box art of S.F.3.D Point X Senryou Sakusen - Operation Thanksgiving
https://gamesdb.launchbox-app.com/games/images/147053-sf3d-original-operation-thanksgiving
Box art of S.F.3.D Original Operation V
https://www.ebay.com/itm/375902905939
Name for S.F.3.D Point X Senryou Sakusen - Operation Thanksgiving
https://www.8-bits.info/gamelist/PC88/info/info_QI7pTNS9F8yuPygb.php

- Carmine fix name to reflect the box and set V2 Mode required.
![Carmine 88 (Cover)  Photomerge + Descreen 300dpi](https://github.com/user-attachments/assets/db09b017-162a-4b90-a60b-6dfcf3851da7)


Thanks,