### PR TITLE
toaplan/twincobr.cpp, toaplan/wardner.cpp: Cleanups

### DIFF
--- a/src/mame/toaplan/twincobr.cpp
+++ b/src/mame/toaplan/twincobr.cpp
@@ -235,7 +235,7 @@ Stephh's notes (based on the games M68000 and Z80 code and some tests) :
 
   - This bootleg is heavily based on 'skyshark', so they share the same infos.
     However, the values written to the DSP (0x030004) are the same as in 'hishouza'
-    and the chars ROMS (gfx1) are the same as in 'fshark' !
+    and the chars ROMS (chars) are the same as in 'fshark' !
 
 **************************** Memory & I/O Maps *****************************
 68000: Main CPU
@@ -425,7 +425,7 @@ void twincobr_state::main_program_map(address_map &map)
 void twincobr_state::sound_program_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
-	map(0x8000, 0x87ff).ram().share("sharedram");
+	map(0x8000, 0x87ff).ram().share(m_sharedram);
 }
 
 void twincobr_state::sound_io_map(address_map &map)
@@ -661,9 +661,9 @@ static const gfx_layout tilelayout =
 };
 
 static GFXDECODE_START( gfx_twincobr )
-	GFXDECODE_ENTRY( "gfx1", 0x00000, charlayout,   1536, 32 )  // Colors 1536-1791
-	GFXDECODE_ENTRY( "gfx2", 0x00000, tilelayout,   1280, 16 )  // Colors 1280-1535
-	GFXDECODE_ENTRY( "gfx3", 0x00000, tilelayout,   1024, 16 )  // Colors 1024-1079
+	GFXDECODE_ENTRY( "chars",    0x00000, charlayout, 1536, 32 )  // Colors 1536-1791
+	GFXDECODE_ENTRY( "fg_tiles", 0x00000, tilelayout, 1280, 16 )  // Colors 1280-1535
+	GFXDECODE_ENTRY( "bg_tiles", 0x00000, tilelayout, 1024, 16 )  // Colors 1024-1079
 GFXDECODE_END
 
 
@@ -673,11 +673,11 @@ void twincobr_state::twincobr(machine_config &config)
 	M68000(config, m_maincpu, XTAL(28'000'000) / 4);    // 7MHz - Main board Crystal is 28MHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &twincobr_state::main_program_map);
 
-	z80_device &audiocpu(Z80(config, "audiocpu", XTAL(28'000'000)/8));  // 3.5MHz
+	z80_device &audiocpu(Z80(config, "audiocpu", XTAL(28'000'000) / 8));  // 3.5MHz
 	audiocpu.set_addrmap(AS_PROGRAM, &twincobr_state::sound_program_map);
 	audiocpu.set_addrmap(AS_IO, &twincobr_state::sound_io_map);
 
-	TMS32010(config, m_dsp, XTAL(28'000'000)/2);         // 14MHz CLKin
+	TMS32010(config, m_dsp, XTAL(28'000'000) / 2);         // 14MHz CLKin
 	m_dsp->set_addrmap(AS_PROGRAM, &twincobr_state::dsp_program_map);
 	// Data Map is internal to the CPU
 	m_dsp->set_addrmap(AS_IO, &twincobr_state::dsp_io_map);
@@ -761,7 +761,7 @@ void twincobr_state::fsharkbt(machine_config &config)
 {
 	fshark(config);
 
-	I8741A(config, "mcu", XTAL(28'000'000)/16).set_disable();  // Internal program code is not dumped
+	I8741A(config, "mcu", XTAL(28'000'000) / 16).set_disable();  // Internal program code is not dumped
 	// Program Map is internal to the CPU
 }
 
@@ -791,18 +791,18 @@ ROM_START( twincobr )
     ROM_LOAD16_BYTE( "tc2a",        0x0001, 0x0800, CRC(d6d878c9) SHA1(fb2dd8dba0b1ce1959e1b6e62840fdd7a97ceb92) )
 */
 
-	ROM_REGION( 0x0c000, "gfx1", 0 )    // Chars
+	ROM_REGION( 0x0c000, "chars", 0 )    // Chars
 	ROM_LOAD( "b30_08.8c",  0x00000, 0x04000, CRC(0a254133) SHA1(17e9cc5e36fb4696012d0f9229fa172034cd843a) )
 	ROM_LOAD( "b30_07.10b", 0x04000, 0x04000, CRC(e9e2d4b1) SHA1(e0a19dd46a9ba85d95bba7fbf81d8dc36dbfeabd) )
 	ROM_LOAD( "b30_06.8b",  0x08000, 0x04000, CRC(a599d845) SHA1(732001f2d378d890f148e6b616c287d71fae832a) )
 
-	ROM_REGION( 0x40000, "gfx2", 0 )    // fg tiles
+	ROM_REGION( 0x40000, "fg_tiles", 0 )    // fg tiles
 	ROM_LOAD( "b30_16.20b", 0x00000, 0x10000, CRC(15b3991d) SHA1(f5e7ed7a7721ed7e6dfd440634160390b7a294e4) )
 	ROM_LOAD( "b30_15.18b", 0x10000, 0x10000, CRC(d9e2e55d) SHA1(0409e6df836d1d5198b64b21b42192631aa6d096) )
 	ROM_LOAD( "b30_13.18c", 0x20000, 0x10000, CRC(13daeac8) SHA1(1cb103f434e2ecf193fa936ca7ea9194064c5b39) )
 	ROM_LOAD( "b30_14.20c", 0x30000, 0x10000, CRC(8cc79357) SHA1(31064df2b796ca85ad3caccf626b684dff1104a1) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 )    // bg tiles
+	ROM_REGION( 0x20000, "bg_tiles", 0 )    // bg tiles
 	ROM_LOAD( "b30_12.16c", 0x00000, 0x08000, CRC(b5d48389) SHA1(a00c5b9c231d3d580fa20c7ad3f8b6fd990e6594) )
 	ROM_LOAD( "b30_11.14c", 0x08000, 0x08000, CRC(97f20fdc) SHA1(7cb3cd0637b0db889a3d552fd7c1a916eee5ca27) )
 	ROM_LOAD( "b30_10.12c", 0x10000, 0x08000, CRC(170c01db) SHA1(f4c5a1600f6cbb48abbace66c6f7514f79138e8b) )
@@ -836,18 +836,18 @@ ROM_START( twincobru )
 	ROM_LOAD16_BYTE( "dsp_22.bin", 0x0001, 0x0800, CRC(79389a71) SHA1(14ec4c1c9b06702319e89a7a250d0038393437f4) )
 	ROM_LOAD16_BYTE( "dsp_21.bin", 0x0000, 0x0800, CRC(2d135376) SHA1(67a2cc774d272ee1cd6e6bc1c5fc33fc6968837e) )
 
-	ROM_REGION( 0x0c000, "gfx1", 0 )    // Chars
+	ROM_REGION( 0x0c000, "chars", 0 )    // Chars
 	ROM_LOAD( "b30_08.8c",  0x00000, 0x04000, CRC(0a254133) SHA1(17e9cc5e36fb4696012d0f9229fa172034cd843a) )
 	ROM_LOAD( "b30_07.10b", 0x04000, 0x04000, CRC(e9e2d4b1) SHA1(e0a19dd46a9ba85d95bba7fbf81d8dc36dbfeabd) )
 	ROM_LOAD( "b30_06.8b",  0x08000, 0x04000, CRC(a599d845) SHA1(732001f2d378d890f148e6b616c287d71fae832a) )
 
-	ROM_REGION( 0x40000, "gfx2", 0 )    // fg tiles
+	ROM_REGION( 0x40000, "fg_tiles", 0 )    // fg tiles
 	ROM_LOAD( "b30_16.20b", 0x00000, 0x10000, CRC(15b3991d) SHA1(f5e7ed7a7721ed7e6dfd440634160390b7a294e4) )
 	ROM_LOAD( "b30_15.18b", 0x10000, 0x10000, CRC(d9e2e55d) SHA1(0409e6df836d1d5198b64b21b42192631aa6d096) )
 	ROM_LOAD( "b30_13.18c", 0x20000, 0x10000, CRC(13daeac8) SHA1(1cb103f434e2ecf193fa936ca7ea9194064c5b39) )
 	ROM_LOAD( "b30_14.20c", 0x30000, 0x10000, CRC(8cc79357) SHA1(31064df2b796ca85ad3caccf626b684dff1104a1) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 )    // bg tiles
+	ROM_REGION( 0x20000, "bg_tiles", 0 )    // bg tiles
 	ROM_LOAD( "b30_12.16c", 0x00000, 0x08000, CRC(b5d48389) SHA1(a00c5b9c231d3d580fa20c7ad3f8b6fd990e6594) )
 	ROM_LOAD( "b30_11.14c", 0x08000, 0x08000, CRC(97f20fdc) SHA1(7cb3cd0637b0db889a3d552fd7c1a916eee5ca27) )
 	ROM_LOAD( "b30_10.12c", 0x10000, 0x08000, CRC(170c01db) SHA1(f4c5a1600f6cbb48abbace66c6f7514f79138e8b) )
@@ -880,18 +880,18 @@ ROM_START( ktiger )
 	ROM_REGION( 0x2000, "dsp", 0 )  // Co-Processor TMS320C10 MCU code
 	ROM_LOAD( "d70015u_gxc-03_mcu_74002", 0x0000, 0x0c00, CRC(265b6f32) SHA1(1b548edeada4144baf732aba7e7013281c8e9608) ) // decapped, real label D70015U GXC-03 MCU ^ 74002
 
-	ROM_REGION( 0x0c000, "gfx1", 0 )    // Chars
+	ROM_REGION( 0x0c000, "chars", 0 )    // Chars
 	ROM_LOAD( "b30_08.8c",  0x00000, 0x04000, CRC(0a254133) SHA1(17e9cc5e36fb4696012d0f9229fa172034cd843a) )
 	ROM_LOAD( "b30_07.10b", 0x04000, 0x04000, CRC(e9e2d4b1) SHA1(e0a19dd46a9ba85d95bba7fbf81d8dc36dbfeabd) )
 	ROM_LOAD( "b30_06.8b",  0x08000, 0x04000, CRC(a599d845) SHA1(732001f2d378d890f148e6b616c287d71fae832a) )
 
-	ROM_REGION( 0x40000, "gfx2", 0 )    // fg tiles
+	ROM_REGION( 0x40000, "fg_tiles", 0 )    // fg tiles
 	ROM_LOAD( "b30_16.20b", 0x00000, 0x10000, CRC(15b3991d) SHA1(f5e7ed7a7721ed7e6dfd440634160390b7a294e4) )
 	ROM_LOAD( "b30_15.18b", 0x10000, 0x10000, CRC(d9e2e55d) SHA1(0409e6df836d1d5198b64b21b42192631aa6d096) )
 	ROM_LOAD( "b30_13.18c", 0x20000, 0x10000, CRC(13daeac8) SHA1(1cb103f434e2ecf193fa936ca7ea9194064c5b39) )
 	ROM_LOAD( "b30_14.20c", 0x30000, 0x10000, CRC(8cc79357) SHA1(31064df2b796ca85ad3caccf626b684dff1104a1) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 )    // bg tiles
+	ROM_REGION( 0x20000, "bg_tiles", 0 )    // bg tiles
 	ROM_LOAD( "b30_12.16c", 0x00000, 0x08000, CRC(b5d48389) SHA1(a00c5b9c231d3d580fa20c7ad3f8b6fd990e6594) )
 	ROM_LOAD( "b30_11.14c", 0x08000, 0x08000, CRC(97f20fdc) SHA1(7cb3cd0637b0db889a3d552fd7c1a916eee5ca27) )
 	ROM_LOAD( "b30_10.12c", 0x10000, 0x08000, CRC(170c01db) SHA1(f4c5a1600f6cbb48abbace66c6f7514f79138e8b) )
@@ -924,18 +924,18 @@ ROM_START( ktigera )
 	ROM_REGION( 0x2000, "dsp", 0 )  // Co-Processor TMS320C10 MCU code
 	ROM_LOAD( "d70015u_gxc-03_mcu_74002", 0x0000, 0x0c00, CRC(265b6f32) SHA1(1b548edeada4144baf732aba7e7013281c8e9608) ) // decapped, real label D70015U GXC-03 MCU ^ 74002
 
-	ROM_REGION( 0x0c000, "gfx1", 0 )    // Chars
+	ROM_REGION( 0x0c000, "chars", 0 )    // Chars
 	ROM_LOAD( "b30_08.8c", 0x00000, 0x04000, CRC(0a254133) SHA1(17e9cc5e36fb4696012d0f9229fa172034cd843a) )
 	ROM_LOAD( "b30_07.10b", 0x04000, 0x04000, CRC(e9e2d4b1) SHA1(e0a19dd46a9ba85d95bba7fbf81d8dc36dbfeabd) )
 	ROM_LOAD( "b30_06.8b", 0x08000, 0x04000, CRC(a599d845) SHA1(732001f2d378d890f148e6b616c287d71fae832a) )
 
-	ROM_REGION( 0x40000, "gfx2", 0 )    // fg tiles
+	ROM_REGION( 0x40000, "fg_tiles", 0 )    // fg tiles
 	ROM_LOAD( "b30_16.20b", 0x00000, 0x10000, CRC(15b3991d) SHA1(f5e7ed7a7721ed7e6dfd440634160390b7a294e4) )
 	ROM_LOAD( "b30_15.18b", 0x10000, 0x10000, CRC(d9e2e55d) SHA1(0409e6df836d1d5198b64b21b42192631aa6d096) )
 	ROM_LOAD( "b30_13.18c", 0x20000, 0x10000, CRC(13daeac8) SHA1(1cb103f434e2ecf193fa936ca7ea9194064c5b39) )
 	ROM_LOAD( "b30_14.20c", 0x30000, 0x10000, CRC(8cc79357) SHA1(31064df2b796ca85ad3caccf626b684dff1104a1) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 )    // bg tiles
+	ROM_REGION( 0x20000, "bg_tiles", 0 )    // bg tiles
 	ROM_LOAD( "b30_12.16c", 0x00000, 0x08000, CRC(b5d48389) SHA1(a00c5b9c231d3d580fa20c7ad3f8b6fd990e6594) )
 	ROM_LOAD( "b30_11.14c", 0x08000, 0x08000, CRC(97f20fdc) SHA1(7cb3cd0637b0db889a3d552fd7c1a916eee5ca27) )
 	ROM_LOAD( "b30_10.12c", 0x10000, 0x08000, CRC(170c01db) SHA1(f4c5a1600f6cbb48abbace66c6f7514f79138e8b) )
@@ -966,18 +966,18 @@ ROM_START( fshark )
 	ROM_REGION( 0x2000, "dsp", 0 )  // Co-Processor TMS320C10 MCU code
 	ROM_LOAD( "d70012u_gxc-02_mcu_71001",  0x0000, 0x0c00, CRC(eee0ff59) SHA1(dad4570815ec444e34cc73f7cd90f9ca8f7b3eb8) ) // decapped, real label D70012U GXC-02 MCU ^ 71001
 
-	ROM_REGION( 0x0c000, "gfx1", 0 )    // Chars
+	ROM_REGION( 0x0c000, "chars", 0 )    // Chars
 	ROM_LOAD( "b02_07-1.h11", 0x00000, 0x04000, CRC(e669f80e) SHA1(05c1a4ff9adaa6c8035f38a76c5ee333fafba2bf) )
 	ROM_LOAD( "b02_06-1.h10", 0x04000, 0x04000, CRC(5e53ae47) SHA1(55bde4133deebb59a87d9b96c6d0fd7b4bbc0e02) )
 	ROM_LOAD( "b02_05-1.h8",  0x08000, 0x04000, CRC(a8b05bd0) SHA1(37317838ea57cb98cf9599cedf8e72bcae913d29) )
 
-	ROM_REGION( 0x20000, "gfx2", 0 )    // fg tiles
+	ROM_REGION( 0x20000, "fg_tiles", 0 )    // fg tiles
 	ROM_LOAD( "b02_12.h20", 0x00000, 0x08000, CRC(733b9997) SHA1(75e874a1d148fcc8fa09bb724ce8346565ace4e5) )
 	ROM_LOAD( "b02_15.h24", 0x08000, 0x08000, CRC(8b70ef32) SHA1(e1f988d650dce17e3bfbea12e5fddbb671df18d4) )
 	ROM_LOAD( "b02_14.h23", 0x10000, 0x08000, CRC(f711ba7d) SHA1(49644a264c09fc2d743e4f801b8b82e980f2def9) )
 	ROM_LOAD( "b02_13.h21", 0x18000, 0x08000, CRC(62532cd3) SHA1(df483db7604c0135130f92b08bad3fbffb4f5c47) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 )    // bg tiles
+	ROM_REGION( 0x20000, "bg_tiles", 0 )    // bg tiles
 	ROM_LOAD( "b02_08.h13", 0x00000, 0x08000, CRC(ef0cf49c) SHA1(6fd5727462cd6c5dab4c5d780bd7504e48583894) )
 	ROM_LOAD( "b02_11.h18", 0x08000, 0x08000, CRC(f5799422) SHA1(3f79dd849db787695a587f0db19a6782153b5955) )
 	ROM_LOAD( "b02_10.h16", 0x10000, 0x08000, CRC(4bd099ff) SHA1(9326075f83549b0a9656f69bd4436fb1be2ac805) )
@@ -1016,18 +1016,18 @@ ROM_START( fsharkb )
 	ROMX_LOAD( "82s137-7.mcu",  0x0801, 0x0400, CRC(cbf3184b) SHA1(a3eafadc319183ed688dc081c4dfcbe8d476abea), ROM_NIBBLE | ROM_SHIFT_NIBBLE_HI | ROM_SKIP(1) )
 	ROMX_LOAD( "82s137-8.mcu",  0x0801, 0x0400, CRC(8246a05c) SHA1(2511fa99fbdd6c75281fa85ecca2a617d36eb360), ROM_NIBBLE | ROM_SHIFT_NIBBLE_LO | ROM_SKIP(1) )
 
-	ROM_REGION( 0x0c000, "gfx1", 0 )    // Chars
+	ROM_REGION( 0x0c000, "chars", 0 )    // Chars
 	ROM_LOAD( "b02_07-1.h11", 0x00000, 0x04000, CRC(e669f80e) SHA1(05c1a4ff9adaa6c8035f38a76c5ee333fafba2bf) )
 	ROM_LOAD( "b02_06-1.h10", 0x04000, 0x04000, CRC(5e53ae47) SHA1(55bde4133deebb59a87d9b96c6d0fd7b4bbc0e02) )
 	ROM_LOAD( "b02_05-1.h8",  0x08000, 0x04000, CRC(a8b05bd0) SHA1(37317838ea57cb98cf9599cedf8e72bcae913d29) )
 
-	ROM_REGION( 0x20000, "gfx2", 0 )    // fg tiles
+	ROM_REGION( 0x20000, "fg_tiles", 0 )    // fg tiles
 	ROM_LOAD( "b02_12.h20", 0x00000, 0x08000, CRC(733b9997) SHA1(75e874a1d148fcc8fa09bb724ce8346565ace4e5) )
 	ROM_LOAD( "b02_15.h24", 0x08000, 0x08000, CRC(8b70ef32) SHA1(e1f988d650dce17e3bfbea12e5fddbb671df18d4) )
 	ROM_LOAD( "b02_14.h23", 0x10000, 0x08000, CRC(f711ba7d) SHA1(49644a264c09fc2d743e4f801b8b82e980f2def9) )
 	ROM_LOAD( "b02_13.h21", 0x18000, 0x08000, CRC(62532cd3) SHA1(df483db7604c0135130f92b08bad3fbffb4f5c47) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 )    // bg tiles
+	ROM_REGION( 0x20000, "bg_tiles", 0 )    // bg tiles
 	ROM_LOAD( "b02_08.h13", 0x00000, 0x08000, CRC(ef0cf49c) SHA1(6fd5727462cd6c5dab4c5d780bd7504e48583894) )
 	ROM_LOAD( "b02_11.h18", 0x08000, 0x08000, CRC(f5799422) SHA1(3f79dd849db787695a587f0db19a6782153b5955) )
 	ROM_LOAD( "b02_10.h16", 0x10000, 0x08000, CRC(4bd099ff) SHA1(9326075f83549b0a9656f69bd4436fb1be2ac805) )
@@ -1058,18 +1058,18 @@ ROM_START( skyshark )
 	ROM_REGION( 0x2000, "dsp", 0 )  // Co-Processor TMS320C10 MCU code
 	ROM_LOAD( "d70012u_gxc-02_mcu_71001",  0x0000, 0x0c00, BAD_DUMP CRC(eee0ff59) SHA1(dad4570815ec444e34cc73f7cd90f9ca8f7b3eb8) ) // it should use undumped MCU 71400, but they are interchangeable
 
-	ROM_REGION( 0x0c000, "gfx1", 0 )    // Chars
+	ROM_REGION( 0x0c000, "chars", 0 )    // Chars
 	ROM_LOAD( "b02_7-2.h11", 0x00000, 0x04000, CRC(af48c4e6) SHA1(07e8bb6cb92f812990112063f87073df9a346ff4) )
 	ROM_LOAD( "b02_6-2.h10", 0x04000, 0x04000, CRC(9a29a862) SHA1(5742f1f5a9c8d644d2a48496466039d18f192929) )
 	ROM_LOAD( "b02_5-2.h8",  0x08000, 0x04000, CRC(fb7cad55) SHA1(91815a717511cc97477f08f0fed568247c7fd143) )
 
-	ROM_REGION( 0x20000, "gfx2", 0 )    // fg tiles
+	ROM_REGION( 0x20000, "fg_tiles", 0 )    // fg tiles
 	ROM_LOAD( "b02_12.h20", 0x00000, 0x08000, CRC(733b9997) SHA1(75e874a1d148fcc8fa09bb724ce8346565ace4e5) )
 	ROM_LOAD( "b02_15.h24", 0x08000, 0x08000, CRC(8b70ef32) SHA1(e1f988d650dce17e3bfbea12e5fddbb671df18d4) )
 	ROM_LOAD( "b02_14.h23", 0x10000, 0x08000, CRC(f711ba7d) SHA1(49644a264c09fc2d743e4f801b8b82e980f2def9) )
 	ROM_LOAD( "b02_13.h21", 0x18000, 0x08000, CRC(62532cd3) SHA1(df483db7604c0135130f92b08bad3fbffb4f5c47) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 )    // bg tiles
+	ROM_REGION( 0x20000, "bg_tiles", 0 )    // bg tiles
 	ROM_LOAD( "b02_08.h13", 0x00000, 0x08000, CRC(ef0cf49c) SHA1(6fd5727462cd6c5dab4c5d780bd7504e48583894) )
 	ROM_LOAD( "b02_11.h18", 0x08000, 0x08000, CRC(f5799422) SHA1(3f79dd849db787695a587f0db19a6782153b5955) )
 	ROM_LOAD( "b02_10.h16", 0x10000, 0x08000, CRC(4bd099ff) SHA1(9326075f83549b0a9656f69bd4436fb1be2ac805) )
@@ -1100,18 +1100,18 @@ ROM_START( skysharka )
 	ROM_REGION( 0x2000, "dsp", 0 )  // Co-Processor TMS320C10 MCU code
 	ROM_LOAD( "d70012u_gxc-02_mcu_71001",  0x0000, 0x0c00, BAD_DUMP CRC(eee0ff59) SHA1(dad4570815ec444e34cc73f7cd90f9ca8f7b3eb8) )  // it should use undumped MCU 71400, but they are interchangeable
 
-	ROM_REGION( 0x0c000, "gfx1", 0 )    // Chars
+	ROM_REGION( 0x0c000, "chars", 0 )    // Chars
 	ROM_LOAD( "b02_7-2.h11", 0x00000, 0x04000, CRC(af48c4e6) SHA1(07e8bb6cb92f812990112063f87073df9a346ff4) )
 	ROM_LOAD( "b02_6-2.h10", 0x04000, 0x04000, CRC(9a29a862) SHA1(5742f1f5a9c8d644d2a48496466039d18f192929) )
 	ROM_LOAD( "b02_5-2.h8",  0x08000, 0x04000, CRC(fb7cad55) SHA1(91815a717511cc97477f08f0fed568247c7fd143) )
 
-	ROM_REGION( 0x20000, "gfx2", 0 )    // fg tiles
+	ROM_REGION( 0x20000, "fg_tiles", 0 )    // fg tiles
 	ROM_LOAD( "b02_12.h20", 0x00000, 0x08000, CRC(733b9997) SHA1(75e874a1d148fcc8fa09bb724ce8346565ace4e5) )
 	ROM_LOAD( "b02_15.h24", 0x08000, 0x08000, CRC(8b70ef32) SHA1(e1f988d650dce17e3bfbea12e5fddbb671df18d4) )
 	ROM_LOAD( "b02_14.h23", 0x10000, 0x08000, CRC(f711ba7d) SHA1(49644a264c09fc2d743e4f801b8b82e980f2def9) )
 	ROM_LOAD( "b02_13.h21", 0x18000, 0x08000, CRC(62532cd3) SHA1(df483db7604c0135130f92b08bad3fbffb4f5c47) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 )    // bg tiles
+	ROM_REGION( 0x20000, "bg_tiles", 0 )    // bg tiles
 	ROM_LOAD( "b02_08.h13", 0x00000, 0x08000, CRC(ef0cf49c) SHA1(6fd5727462cd6c5dab4c5d780bd7504e48583894) )
 	ROM_LOAD( "b02_11.h18", 0x08000, 0x08000, CRC(f5799422) SHA1(3f79dd849db787695a587f0db19a6782153b5955) )
 	ROM_LOAD( "b02_10.h16", 0x10000, 0x08000, CRC(4bd099ff) SHA1(9326075f83549b0a9656f69bd4436fb1be2ac805) )
@@ -1142,18 +1142,18 @@ ROM_START( hishouza )
 	ROM_REGION( 0x2000, "dsp", 0 )  // Co-Processor TMS320C10 MCU code
 	ROM_LOAD( "d70011u_gxc-01_mcu_64000",  0x0000, 0x0c00, CRC(1ca63774) SHA1(e534325af9433fb0e9ccdf82ee3a192d2459b18f) ) // decapped, real label D70011U GXC-01 MCU 64000
 
-	ROM_REGION( 0x0c000, "gfx1", 0 )    // Chars
+	ROM_REGION( 0x0c000, "chars", 0 )    // Chars
 	ROM_LOAD( "b02-07.h11", 0x00000, 0x04000, CRC(c13a775e) SHA1(b60d26126ec6ebc24a7ca87dd0234e4d9d3e78fc) )
 	ROM_LOAD( "b02-06.h10", 0x04000, 0x04000, CRC(ad5f1371) SHA1(feae9d7bb75bfab5353be4c5931d78a530bd9bcd) )
 	ROM_LOAD( "b02-05.h8",  0x08000, 0x04000, CRC(85a7bff6) SHA1(38cd89aa0800e3796f7ecac657d14119543057c2) )
 
-	ROM_REGION( 0x20000, "gfx2", 0 )    // fg tiles
+	ROM_REGION( 0x20000, "fg_tiles", 0 )    // fg tiles
 	ROM_LOAD( "b02_12.h20", 0x00000, 0x08000, CRC(733b9997) SHA1(75e874a1d148fcc8fa09bb724ce8346565ace4e5) )
 	ROM_LOAD( "b02_15.h24", 0x08000, 0x08000, CRC(8b70ef32) SHA1(e1f988d650dce17e3bfbea12e5fddbb671df18d4) )
 	ROM_LOAD( "b02_14.h23", 0x10000, 0x08000, CRC(f711ba7d) SHA1(49644a264c09fc2d743e4f801b8b82e980f2def9) )
 	ROM_LOAD( "b02_13.h21", 0x18000, 0x08000, CRC(62532cd3) SHA1(df483db7604c0135130f92b08bad3fbffb4f5c47) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 )    // bg tiles
+	ROM_REGION( 0x20000, "bg_tiles", 0 )    // bg tiles
 	ROM_LOAD( "b02_08.h13", 0x00000, 0x08000, CRC(ef0cf49c) SHA1(6fd5727462cd6c5dab4c5d780bd7504e48583894) )
 	ROM_LOAD( "b02_11.h18", 0x08000, 0x08000, CRC(f5799422) SHA1(3f79dd849db787695a587f0db19a6782153b5955) )
 	ROM_LOAD( "b02_10.h16", 0x10000, 0x08000, CRC(4bd099ff) SHA1(9326075f83549b0a9656f69bd4436fb1be2ac805) )
@@ -1192,18 +1192,18 @@ ROM_START( hishouzab )
 	ROMX_LOAD( "dsp-b7.bpr", 0x0801, 0x0400, CRC(e87540cd) SHA1(bb6e98c47ed46abbbfa06571806cb2d663880419), ROM_NIBBLE | ROM_SHIFT_NIBBLE_HI | ROM_SKIP(1) )
 	ROMX_LOAD( "dsp-b8.bpr", 0x0801, 0x0400, CRC(d3c16c5c) SHA1(a24d9536914734c1875c8a39938a346ff4418dd0), ROM_NIBBLE | ROM_SHIFT_NIBBLE_LO | ROM_SKIP(1) )
 
-	ROM_REGION( 0x0c000, "gfx1", 0 )    // Chars
+	ROM_REGION( 0x0c000, "chars", 0 )    // Chars
 	ROM_LOAD( "b02-07.h11", 0x00000, 0x04000, CRC(c13a775e) SHA1(b60d26126ec6ebc24a7ca87dd0234e4d9d3e78fc) )
 	ROM_LOAD( "b02-06.h10", 0x04000, 0x04000, CRC(ad5f1371) SHA1(feae9d7bb75bfab5353be4c5931d78a530bd9bcd) )
 	ROM_LOAD( "b02-05.h8",  0x08000, 0x04000, CRC(85a7bff6) SHA1(38cd89aa0800e3796f7ecac657d14119543057c2) )
 
-	ROM_REGION( 0x20000, "gfx2", 0 )    // fg tiles
+	ROM_REGION( 0x20000, "fg_tiles", 0 )    // fg tiles
 	ROM_LOAD( "b02_12.h20", 0x00000, 0x08000, CRC(733b9997) SHA1(75e874a1d148fcc8fa09bb724ce8346565ace4e5) )
 	ROM_LOAD( "b02_15.h24", 0x08000, 0x08000, CRC(8b70ef32) SHA1(e1f988d650dce17e3bfbea12e5fddbb671df18d4) )
 	ROM_LOAD( "b02_14.h23", 0x10000, 0x08000, CRC(f711ba7d) SHA1(49644a264c09fc2d743e4f801b8b82e980f2def9) )
 	ROM_LOAD( "b02_13.h21", 0x18000, 0x08000, CRC(62532cd3) SHA1(df483db7604c0135130f92b08bad3fbffb4f5c47) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 )    // bg tiles
+	ROM_REGION( 0x20000, "bg_tiles", 0 )    // bg tiles
 	ROM_LOAD( "b02_08.h13", 0x00000, 0x08000, CRC(ef0cf49c) SHA1(6fd5727462cd6c5dab4c5d780bd7504e48583894) )
 	ROM_LOAD( "b02_11.h18", 0x08000, 0x08000, CRC(f5799422) SHA1(3f79dd849db787695a587f0db19a6782153b5955) )
 	ROM_LOAD( "b02_10.h16", 0x10000, 0x08000, CRC(4bd099ff) SHA1(9326075f83549b0a9656f69bd4436fb1be2ac805) )
@@ -1244,18 +1244,18 @@ ROM_START( fsharkbt )
 	ROM_REGION( 0x0400, "mcu", 0 )  // i8741a MCU
 	ROM_LOAD( "fsb_8741.mcu", 0x0000, 0x0400, NO_DUMP )
 
-	ROM_REGION( 0x0c000, "gfx1", 0 )    // Chars
+	ROM_REGION( 0x0c000, "chars", 0 )    // Chars
 	ROM_LOAD( "b02_07-1.h11", 0x00000, 0x04000, CRC(e669f80e) SHA1(05c1a4ff9adaa6c8035f38a76c5ee333fafba2bf) )
 	ROM_LOAD( "b02_06-1.h10", 0x04000, 0x04000, CRC(5e53ae47) SHA1(55bde4133deebb59a87d9b96c6d0fd7b4bbc0e02) )
 	ROM_LOAD( "b02_05-1.h8",  0x08000, 0x04000, CRC(a8b05bd0) SHA1(37317838ea57cb98cf9599cedf8e72bcae913d29) )
 
-	ROM_REGION( 0x20000, "gfx2", 0 )    // fg tiles
+	ROM_REGION( 0x20000, "fg_tiles", 0 )    // fg tiles
 	ROM_LOAD( "b02_12.h20", 0x00000, 0x08000, CRC(733b9997) SHA1(75e874a1d148fcc8fa09bb724ce8346565ace4e5) )
 	ROM_LOAD( "b02_15.h24", 0x08000, 0x08000, CRC(8b70ef32) SHA1(e1f988d650dce17e3bfbea12e5fddbb671df18d4) )
 	ROM_LOAD( "b02_14.h23", 0x10000, 0x08000, CRC(f711ba7d) SHA1(49644a264c09fc2d743e4f801b8b82e980f2def9) )
 	ROM_LOAD( "b02_13.h21", 0x18000, 0x08000, CRC(62532cd3) SHA1(df483db7604c0135130f92b08bad3fbffb4f5c47) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 )    // bg tiles
+	ROM_REGION( 0x20000, "bg_tiles", 0 )    // bg tiles
 	ROM_LOAD( "b02_08.h13", 0x00000, 0x08000, CRC(ef0cf49c) SHA1(6fd5727462cd6c5dab4c5d780bd7504e48583894) )
 	ROM_LOAD( "b02_11.h18", 0x08000, 0x08000, CRC(f5799422) SHA1(3f79dd849db787695a587f0db19a6782153b5955) )
 	ROM_LOAD( "b02_10.h16", 0x10000, 0x08000, CRC(4bd099ff) SHA1(9326075f83549b0a9656f69bd4436fb1be2ac805) )
@@ -1299,7 +1299,7 @@ ROM_START( fnshark ) // Based on a different version of the game code? (only a ~
 	ROM_LOAD( "f.ic170", 0x0000, 0x8000, CRC(cdd1a153) SHA1(de9827a959039cf753ecac6756fb1925c37466d8) )
 
 	// ugly bootleg logo (and corrupt 0 text)
-	ROM_REGION( 0x0c000, "gfx1", 0 )    // Chars
+	ROM_REGION( 0x0c000, "chars", 0 )    // Chars
 	// same data on larger EPROMs with first half empty, verified on 2 different PCBs
 	ROM_LOAD( "7.bin", 0x00000, 0x04000, CRC(d2b05463) SHA1(25131b64e63cd3791bc84d525b7e4b2a398be6ca) )
 	ROM_CONTINUE(0x00000,0x04000)
@@ -1308,13 +1308,13 @@ ROM_START( fnshark ) // Based on a different version of the game code? (only a ~
 	ROM_LOAD( "5.bin", 0x08000, 0x04000, CRC(ca8badd2) SHA1(e81863ac03c9219a8de01b03dbac522022212b14) )
 	ROM_CONTINUE(0x08000,0x04000)
 
-	ROM_REGION( 0x20000, "gfx2", 0 )    // fg tiles
+	ROM_REGION( 0x20000, "fg_tiles", 0 )    // fg tiles
 	ROM_LOAD( "b.ic114", 0x00000, 0x08000, CRC(733b9997) SHA1(75e874a1d148fcc8fa09bb724ce8346565ace4e5) )
 	ROM_LOAD( "e.ic111", 0x08000, 0x08000, CRC(8b70ef32) SHA1(e1f988d650dce17e3bfbea12e5fddbb671df18d4) )
 	ROM_LOAD( "d.ic112", 0x10000, 0x08000, CRC(f711ba7d) SHA1(49644a264c09fc2d743e4f801b8b82e980f2def9) )
 	ROM_LOAD( "c.ic113", 0x18000, 0x08000, CRC(62532cd3) SHA1(df483db7604c0135130f92b08bad3fbffb4f5c47) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 )    // bg tiles
+	ROM_REGION( 0x20000, "bg_tiles", 0 )    // bg tiles
 	ROM_LOAD( "8.ic118",  0x00000, 0x08000, CRC(ef0cf49c) SHA1(6fd5727462cd6c5dab4c5d780bd7504e48583894) )
 	ROM_LOAD( "a.ic115",  0x08000, 0x08000, CRC(f5799422) SHA1(3f79dd849db787695a587f0db19a6782153b5955) )
 	ROM_LOAD( "10.ic116", 0x10000, 0x08000, CRC(4bd099ff) SHA1(9326075f83549b0a9656f69bd4436fb1be2ac805) )
@@ -1346,18 +1346,18 @@ ROM_START( skysharkb )
 	ROM_REGION( 0x8000, "audiocpu", 0 ) // Sound Z80 code
 	ROM_LOAD( "1p.ic16", 0x0000, 0x8000, CRC(f0b98af2) SHA1(7054029b1955c510a6b693d278dd4d8a384112df) )
 
-	ROM_REGION( 0x0c000, "gfx1", 0 )    // Chars
+	ROM_REGION( 0x0c000, "chars", 0 )    // Chars
 	ROM_LOAD( "1g.ic7", 0x00000, 0x04000, CRC(9d3f698d) SHA1(8e5497929663ec3bd27e9a84fe068d12c53de5c5) ) // 1xxxxxxxxxxxxx = 0xFF
 	ROM_LOAD( "1e.ic5", 0x04000, 0x04000, CRC(543bbb81) SHA1(8aabc3d4f14b6531af000008b50cf09bb6cd003f) ) // 1xxxxxxxxxxxxx = 0xFF
 	ROM_LOAD( "1f.ic6", 0x08000, 0x04000, CRC(d357f494) SHA1(e83560e551ea15cac903e9a8c5ce57d51af175c7) ) // 1xxxxxxxxxxxxx = 0xFF
 
-	ROM_REGION( 0x20000, "gfx2", 0 ) // fg tiles
+	ROM_REGION( 0x20000, "fg_tiles", 0 ) // fg tiles
 	ROM_LOAD( "1l.ic12", 0x00000, 0x08000, CRC(733b9997) SHA1(75e874a1d148fcc8fa09bb724ce8346565ace4e5) )
 	ROM_LOAD( "1o.ic15", 0x08000, 0x08000, CRC(8b70ef32) SHA1(e1f988d650dce17e3bfbea12e5fddbb671df18d4) )
 	ROM_LOAD( "1n.ic14", 0x10000, 0x08000, CRC(f711ba7d) SHA1(49644a264c09fc2d743e4f801b8b82e980f2def9) )
 	ROM_LOAD( "1m.ic13", 0x18000, 0x08000, CRC(62532cd3) SHA1(df483db7604c0135130f92b08bad3fbffb4f5c47) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) // bg tiles
+	ROM_REGION( 0x20000, "bg_tiles", 0 ) // bg tiles
 	ROM_LOAD( "1h.ic8",  0x00000, 0x08000, CRC(ef0cf49c) SHA1(6fd5727462cd6c5dab4c5d780bd7504e48583894) )
 	ROM_LOAD( "1k.ic11", 0x08000, 0x08000, CRC(f5799422) SHA1(3f79dd849db787695a587f0db19a6782153b5955) )
 	ROM_LOAD( "1j.ic10", 0x10000, 0x08000, CRC(4bd099ff) SHA1(9326075f83549b0a9656f69bd4436fb1be2ac805) )
@@ -1402,18 +1402,18 @@ ROM_START( gulfwar2 )
 	ROM_CONTINUE(                 0x001, 0x800 )
 	ROM_CONTINUE(                 0x001, 0x800 )
 
-	ROM_REGION( 0x0c000, "gfx1", 0 )    // Chars
+	ROM_REGION( 0x0c000, "chars", 0 )    // Chars
 	ROM_LOAD( "03-u9.bin",  0x00000, 0x04000, CRC(1b7934b3) SHA1(c7f5ac364dec4c7843c30e098fd02e0901bdf4b7) )
 	ROM_LOAD( "04-u10.bin", 0x04000, 0x04000, CRC(6f7bfb58) SHA1(4c5602668938a52321b70cd971326fe1a4930889) )
 	ROM_LOAD( "05-u11.bin", 0x08000, 0x04000, CRC(31814724) SHA1(bdcf270e6219555a7f776167f6bf971c6ff18a83) )
 
-	ROM_REGION( 0x40000, "gfx2", 0 )    // fg tiles
+	ROM_REGION( 0x40000, "fg_tiles", 0 )    // fg tiles
 	ROM_LOAD( "16-u202.bin", 0x00000, 0x10000, CRC(d815d175) SHA1(917043d0731226d18bcc22dfe27e5a5a18b03c06) )
 	ROM_LOAD( "13-u199.bin", 0x10000, 0x10000, CRC(d949b0d9) SHA1(1974d3b54e082baa9084dd619c8a879d954644cd) )
 	ROM_LOAD( "14-u200.bin", 0x20000, 0x10000, CRC(c109a6ac) SHA1(3a13ec802e5bafcf599c273a0bb0fd078e01e171) )
 	ROM_LOAD( "15-u201.bin", 0x30000, 0x10000, CRC(ad21f2ab) SHA1(0ab6eeb4dc9c2531c6f19479e7f9bc54fc1c1fdf) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 )    // bg tiles
+	ROM_REGION( 0x20000, "bg_tiles", 0 )    // bg tiles
 	ROM_LOAD( "09-u195.bin", 0x00000, 0x08000, CRC(b7be3a6d) SHA1(68b9223fd07e81d443a1ae3ff04b2af105b27548) )
 	ROM_LOAD( "12-u198.bin", 0x08000, 0x08000, CRC(fd7032a6) SHA1(8be6315d732b154163a3573e2017fdfc77c92e54) )
 	ROM_LOAD( "11-u197.bin", 0x10000, 0x08000, CRC(7b721ed3) SHA1(afd10229414c65a56e184d56a69460ca3a502a27) )
@@ -1448,18 +1448,18 @@ ROM_START( gulfwar2a )
 	ROM_LOAD16_BYTE( "gw2_22.udsp1", 0x001, 0x800, CRC(3a97b0db) SHA1(4f4e2e432aa05fddce8bb7c8a6c7e222bdd50c16) ) // Same code as Twin Cobra
 	ROM_IGNORE( 0x800 ) // 2nd half is no good (1 bit error)
 
-	ROM_REGION( 0x18000, "gfx1", 0 )    // Chars
+	ROM_REGION( 0x18000, "chars", 0 )    // Chars
 	ROM_LOAD( "gw2_23.u9",  0x00000, 0x08000, CRC(a2aee4c8) SHA1(dd6267f6ffbca0621790b76114d7c303a93b18e1) )
 	ROM_LOAD( "gw2_24.u10", 0x08000, 0x08000, CRC(fb3f71cd) SHA1(1594ab7a2700617dfcd73b091d4b94fb21e06c0d) )
 	ROM_LOAD( "gw2_25.u11", 0x10000, 0x08000, CRC(90eeb0a0) SHA1(126877900ce6bb9b2bf6420f588174f010f9bb6c) )
 
-	ROM_REGION( 0x40000, "gfx2", 0 )    // fg tiles
+	ROM_REGION( 0x40000, "fg_tiles", 0 )    // fg tiles
 	ROM_LOAD( "16-u202.bin", 0x00000, 0x10000, CRC(d815d175) SHA1(917043d0731226d18bcc22dfe27e5a5a18b03c06) )
 	ROM_LOAD( "13-u199.bin", 0x10000, 0x10000, CRC(d949b0d9) SHA1(1974d3b54e082baa9084dd619c8a879d954644cd) )
 	ROM_LOAD( "14-u200.bin", 0x20000, 0x10000, CRC(c109a6ac) SHA1(3a13ec802e5bafcf599c273a0bb0fd078e01e171) )
 	ROM_LOAD( "15-u201.bin", 0x30000, 0x10000, CRC(ad21f2ab) SHA1(0ab6eeb4dc9c2531c6f19479e7f9bc54fc1c1fdf) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 )    // bg tiles
+	ROM_REGION( 0x20000, "bg_tiles", 0 )    // bg tiles
 	ROM_LOAD( "09-u195.bin", 0x00000, 0x08000, CRC(b7be3a6d) SHA1(68b9223fd07e81d443a1ae3ff04b2af105b27548) )
 	ROM_LOAD( "12-u198.bin", 0x08000, 0x08000, CRC(fd7032a6) SHA1(8be6315d732b154163a3573e2017fdfc77c92e54) )
 	ROM_LOAD( "11-u197.bin", 0x10000, 0x08000, CRC(7b721ed3) SHA1(afd10229414c65a56e184d56a69460ca3a502a27) )
@@ -1479,24 +1479,19 @@ ROM_START( gulfwar2a )
 	ROM_LOAD( "82s123.b24", 0x240, 0x020, CRC(4fb5df2a) SHA1(506ef2c8e4cf45c256d6831a0a5760732f2de422) )    // Tile to sprite priority ??
 ROM_END
 
-void twincobr_state::init_twincobr()
-{
-	driver_savestate();
-}
 
-
-GAME( 1987, fshark,    0,        fshark,    fshark,    twincobr_state, init_twincobr, ROT270, "Toaplan / Taito Corporation",                           "Flying Shark (World)",                         0 )
-GAME( 1987, skyshark,  fshark,   fshark,    skyshark,  twincobr_state, init_twincobr, ROT270, "Toaplan / Taito America Corporation (Romstar license)", "Sky Shark (US, set 1)",                        0 )
-GAME( 1987, skysharka, fshark,   fshark,    skyshark,  twincobr_state, init_twincobr, ROT270, "Toaplan / Taito America Corporation (Romstar license)", "Sky Shark (US, set 2)",                        0 )
-GAME( 1987, hishouza,  fshark,   fshark,    hishouza,  twincobr_state, init_twincobr, ROT270, "Toaplan / Taito Corporation",                           "Hishou Zame (Japan)",                          0 )
-GAME( 1987, fsharkb,   fshark,   fshark,    fshark,    twincobr_state, init_twincobr, ROT270, "bootleg",                                               "Flying Shark (World, bootleg)",                0 )
-GAME( 1987, hishouzab, fshark,   fshark,    hishouza,  twincobr_state, init_twincobr, ROT270, "bootleg",                                               "Hishou Zame (Japan, bootleg)",                 0 )
-GAME( 1987, fsharkbt,  fshark,   fsharkbt,  skyshark,  twincobr_state, init_twincobr, ROT270, "bootleg",                                               "Flying Shark (bootleg with 8741)",             0 )
-GAME( 1987, fnshark,   fshark,   fnshark,   hishouza,  twincobr_state, init_twincobr, ROT270, "bootleg",                                               "Flyin' Shark (bootleg of Hishou Zame)",        0 )
-GAME( 1987, skysharkb, fshark,   fshark,    hishouza,  twincobr_state, init_twincobr, ROT270, "bootleg",                                               "Sky Shark (bootleg)",                          0 )
-GAME( 1987, twincobr,  0,        twincobrw, twincobr,  twincobr_state, init_twincobr, ROT270, "Toaplan / Taito Corporation",                           "Twin Cobra (World)",                           0 )
-GAME( 1987, twincobru, twincobr, twincobrw, twincobru, twincobr_state, init_twincobr, ROT270, "Toaplan / Taito America Corporation (Romstar license)", "Twin Cobra (US)",                              0 )
-GAME( 1989, ktiger,    twincobr, twincobr,  ktiger,    twincobr_state, init_twincobr, ROT270, "Toaplan / Taito Corporation",                           "Kyukyoku Tiger (Japan, 2 player cooperative)", 0 )
-GAME( 1987, ktigera,   twincobr, twincobr,  ktigera,   twincobr_state, init_twincobr, ROT270, "Toaplan / Taito Corporation",                           "Kyukyoku Tiger (Japan, 2 player alternate)",   0 )
-GAME( 1991, gulfwar2,  0,        twincobr,  gulfwar2,  twincobr_state, init_twincobr, ROT270, "Comad",                                                 "Gulf War II (set 1)",                          0 )
-GAME( 1991, gulfwar2a, gulfwar2, twincobr,  gulfwar2,  twincobr_state, init_twincobr, ROT270, "Comad",                                                 "Gulf War II (set 2)",                          0 )
+GAME( 1987, fshark,    0,        fshark,    fshark,    twincobr_state, empty_init, ROT270, "Toaplan / Taito Corporation",                           "Flying Shark (World)",                         0 )
+GAME( 1987, skyshark,  fshark,   fshark,    skyshark,  twincobr_state, empty_init, ROT270, "Toaplan / Taito America Corporation (Romstar license)", "Sky Shark (US, set 1)",                        0 )
+GAME( 1987, skysharka, fshark,   fshark,    skyshark,  twincobr_state, empty_init, ROT270, "Toaplan / Taito America Corporation (Romstar license)", "Sky Shark (US, set 2)",                        0 )
+GAME( 1987, hishouza,  fshark,   fshark,    hishouza,  twincobr_state, empty_init, ROT270, "Toaplan / Taito Corporation",                           "Hishou Zame (Japan)",                          0 )
+GAME( 1987, fsharkb,   fshark,   fshark,    fshark,    twincobr_state, empty_init, ROT270, "bootleg",                                               "Flying Shark (World, bootleg)",                0 )
+GAME( 1987, hishouzab, fshark,   fshark,    hishouza,  twincobr_state, empty_init, ROT270, "bootleg",                                               "Hishou Zame (Japan, bootleg)",                 0 )
+GAME( 1987, fsharkbt,  fshark,   fsharkbt,  skyshark,  twincobr_state, empty_init, ROT270, "bootleg",                                               "Flying Shark (bootleg with 8741)",             0 )
+GAME( 1987, fnshark,   fshark,   fnshark,   hishouza,  twincobr_state, empty_init, ROT270, "bootleg",                                               "Flyin' Shark (bootleg of Hishou Zame)",        0 )
+GAME( 1987, skysharkb, fshark,   fshark,    hishouza,  twincobr_state, empty_init, ROT270, "bootleg",                                               "Sky Shark (bootleg)",                          0 )
+GAME( 1987, twincobr,  0,        twincobrw, twincobr,  twincobr_state, empty_init, ROT270, "Toaplan / Taito Corporation",                           "Twin Cobra (World)",                           0 )
+GAME( 1987, twincobru, twincobr, twincobrw, twincobru, twincobr_state, empty_init, ROT270, "Toaplan / Taito America Corporation (Romstar license)", "Twin Cobra (US)",                              0 )
+GAME( 1989, ktiger,    twincobr, twincobr,  ktiger,    twincobr_state, empty_init, ROT270, "Toaplan / Taito Corporation",                           "Kyukyoku Tiger (Japan, 2 player cooperative)", 0 )
+GAME( 1987, ktigera,   twincobr, twincobr,  ktigera,   twincobr_state, empty_init, ROT270, "Toaplan / Taito Corporation",                           "Kyukyoku Tiger (Japan, 2 player alternate)",   0 )
+GAME( 1991, gulfwar2,  0,        twincobr,  gulfwar2,  twincobr_state, empty_init, ROT270, "Comad",                                                 "Gulf War II (set 1)",                          0 )
+GAME( 1991, gulfwar2a, gulfwar2, twincobr,  gulfwar2,  twincobr_state, empty_init, ROT270, "Comad",                                                 "Gulf War II (set 2)",                          0 )

--- a/src/mame/toaplan/twincobr.h
+++ b/src/mame/toaplan/twincobr.h
@@ -77,7 +77,7 @@ protected:
 	s32 m_txoffs = 0;
 	s32 m_fgoffs = 0;
 	s32 m_bgoffs = 0;
-	s32 m_display_on = false;
+	bool m_display_on = false;
 	tilemap_t *m_bg_tilemap = nullptr;
 	tilemap_t *m_fg_tilemap = nullptr;
 	tilemap_t *m_tx_tilemap = nullptr;

--- a/src/mame/toaplan/twincobr.h
+++ b/src/mame/toaplan/twincobr.h
@@ -23,9 +23,6 @@ class twincobr_state : public driver_device
 public:
 	twincobr_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
-		m_sharedram(*this, "sharedram"),
-		m_spriteram8(*this, "spriteram8"),
-		m_spriteram16(*this, "spriteram16"),
 		m_maincpu(*this, "maincpu"),
 		m_dsp(*this, "dsp"),
 		m_spritegen(*this, "scu"),
@@ -33,7 +30,10 @@ public:
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
 		m_mainlatch(*this, "mainlatch"),
-		m_coinlatch(*this, "coinlatch")
+		m_coinlatch(*this, "coinlatch"),
+		m_sharedram(*this, "sharedram"),
+		m_spriteram8(*this, "spriteram8"),
+		m_spriteram16(*this, "spriteram16")
 	{ }
 
 	void twincobr(machine_config &config);
@@ -42,11 +42,19 @@ public:
 	void fshark(machine_config &config);
 	void fnshark(machine_config &config);
 
-	void init_twincobr();
-
 protected:
+	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 	virtual void video_start() override ATTR_COLD;
+
+	required_device<cpu_device> m_maincpu;
+	required_device<tms32010_device> m_dsp;
+	required_device<toaplan_scu_device> m_spritegen;
+	required_device<gfxdecode_device> m_gfxdecode;
+	required_device<screen_device> m_screen;
+	required_device<palette_device> m_palette;
+	required_device<ls259_device> m_mainlatch;
+	required_device<ls259_device> m_coinlatch;
 
 	optional_shared_ptr<u8> m_sharedram;
 	optional_device<buffered_spriteram8_device> m_spriteram8;
@@ -54,12 +62,6 @@ protected:
 
 	u32 m_fg_rom_bank = 0;
 	u32 m_bg_ram_bank = 0;
-	int m_intenable = 0;
-	int m_dsp_bio = 0;
-	int m_fsharkbt_8741 = 0;
-	int m_dsp_execute = 0;
-	u32 m_dsp_addr_w = 0;
-	u32 m_main_ram_seg = 0;
 	std::unique_ptr<u16[]> m_bgvideoram16;
 	std::unique_ptr<u16[]> m_fgvideoram16;
 	std::unique_ptr<u16[]> m_txvideoram16;
@@ -75,10 +77,17 @@ protected:
 	s32 m_txoffs = 0;
 	s32 m_fgoffs = 0;
 	s32 m_bgoffs = 0;
-	s32 m_display_on = 0;
+	s32 m_display_on = false;
 	tilemap_t *m_bg_tilemap = nullptr;
 	tilemap_t *m_fg_tilemap = nullptr;
 	tilemap_t *m_tx_tilemap = nullptr;
+
+	bool m_intenable = false;
+	s32 m_dsp_bio = 0;
+	s32 m_fsharkbt_8741 = 0;
+	bool m_dsp_execute = false;
+	u32 m_dsp_addr_w = 0;
+	u32 m_main_ram_seg = 0;
 
 	void twincobr_dsp_addrsel_w(u16 data);
 	u16 twincobr_dsp_r();
@@ -134,15 +143,6 @@ protected:
 	void bg_ram_bank_w(int state);
 	void fg_rom_bank_w(int state);
 	void log_vram();
-	void driver_savestate();
-	required_device<cpu_device> m_maincpu;
-	required_device<tms32010_device> m_dsp;
-	required_device<toaplan_scu_device> m_spritegen;
-	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<screen_device> m_screen;
-	required_device<palette_device> m_palette;
-	required_device<ls259_device> m_mainlatch;
-	required_device<ls259_device> m_coinlatch;
 
 	void dsp_io_map(address_map &map) ATTR_COLD;
 	void dsp_program_map(address_map &map) ATTR_COLD;

--- a/src/mame/toaplan/twincobr_m.cpp
+++ b/src/mame/toaplan/twincobr_m.cpp
@@ -34,7 +34,7 @@ void twincobr_state::twincobr_dsp_addrsel_w(u16 data)
 	m_main_ram_seg = ((data & 0xe000) << 3);
 	m_dsp_addr_w   = ((data & 0x1fff) << 1);
 
-	LOG("DSP PC:%04x IO write %04x (%08x) at port 0\n",m_dsp->pcbase(),data,m_main_ram_seg + m_dsp_addr_w);
+	LOG("DSP PC:%04x IO write %04x (%08x) at port 0\n", m_dsp->pcbase(), data, m_main_ram_seg + m_dsp_addr_w);
 }
 
 u16 twincobr_state::twincobr_dsp_r()
@@ -46,30 +46,43 @@ u16 twincobr_state::twincobr_dsp_r()
 	{
 	case 0x30000:
 	case 0x40000:
-	case 0x50000:  {address_space &mainspace = m_maincpu->space(AS_PROGRAM);
-					input_data = mainspace.read_word(m_main_ram_seg + m_dsp_addr_w);
-					break;}
-	default:        logerror("DSP PC:%04x Warning !!! IO reading from %08x (port 1)\n",m_dsp->pcbase(),m_main_ram_seg + m_dsp_addr_w); break;
+	case 0x50000:
+		{
+			address_space &mainspace = m_maincpu->space(AS_PROGRAM);
+			input_data = mainspace.read_word(m_main_ram_seg + m_dsp_addr_w);
+			break;
+		}
+	default:
+		if (!machine().side_effects_disabled())
+			logerror("DSP PC:%04x Warning !!! IO reading from %08x (port 1)\n", m_dsp->pcbase(), m_main_ram_seg + m_dsp_addr_w);
+		break;
 	}
-	LOG("DSP PC:%04x IO read %04x at %08x (port 1)\n",m_dsp->pcbase(),input_data,m_main_ram_seg + m_dsp_addr_w);
+	if (!machine().side_effects_disabled())
+		LOG("DSP PC:%04x IO read %04x at %08x (port 1)\n", m_dsp->pcbase(), input_data, m_main_ram_seg + m_dsp_addr_w);
 	return input_data;
 }
 
 void twincobr_state::twincobr_dsp_w(u16 data)
 {
 	/* Data written to main CPU RAM via DSP IO port 1 */
-	m_dsp_execute = 0;
+	m_dsp_execute = false;
 	switch (m_main_ram_seg)
 	{
-	case 0x30000:   if ((m_dsp_addr_w < 3) && (data == 0)) m_dsp_execute = 1;
+	case 0x30000:
+		if ((m_dsp_addr_w < 3) && (data == 0)) m_dsp_execute = true;
 		[[fallthrough]];
 	case 0x40000:
-	case 0x50000:  {address_space &mainspace = m_maincpu->space(AS_PROGRAM);
-					mainspace.write_word(m_main_ram_seg + m_dsp_addr_w, data);
-					break;}
-	default:        logerror("DSP PC:%04x Warning !!! IO writing to %08x (port 1)\n",m_dsp->pcbase(),m_main_ram_seg + m_dsp_addr_w); break;
+	case 0x50000:
+		{
+			address_space &mainspace = m_maincpu->space(AS_PROGRAM);
+			mainspace.write_word(m_main_ram_seg + m_dsp_addr_w, data);
+			break;
+		}
+	default:
+		logerror("DSP PC:%04x Warning !!! IO writing to %08x (port 1)\n", m_dsp->pcbase(), m_main_ram_seg + m_dsp_addr_w);
+		break;
 	}
-	LOG("DSP PC:%04x IO write %04x at %08x (port 1)\n",m_dsp->pcbase(),data,m_main_ram_seg + m_dsp_addr_w);
+	LOG("DSP PC:%04x IO write %04x at %08x (port 1)\n", m_dsp->pcbase(), data, m_main_ram_seg + m_dsp_addr_w);
 }
 
 void twincobr_state::wardner_dsp_addrsel_w(u16 data)
@@ -84,7 +97,7 @@ void twincobr_state::wardner_dsp_addrsel_w(u16 data)
 
 	if (m_main_ram_seg == 0x6000) m_main_ram_seg = 0x7000;
 
-	LOG("DSP PC:%04x IO write %04x (%08x) at port 0\n",m_dsp->pcbase(),data,m_main_ram_seg + m_dsp_addr_w);
+	LOG("DSP PC:%04x IO write %04x (%08x) at port 0\n", m_dsp->pcbase(), data, m_main_ram_seg + m_dsp_addr_w);
 }
 
 u16 twincobr_state::wardner_dsp_r()
@@ -96,32 +109,45 @@ u16 twincobr_state::wardner_dsp_r()
 	{
 	case 0x7000:
 	case 0x8000:
-	case 0xa000:   {address_space &mainspace = m_maincpu->space(AS_PROGRAM);
-					input_data =  mainspace.read_byte(m_main_ram_seg + (m_dsp_addr_w + 0))
-								| (mainspace.read_byte(m_main_ram_seg + (m_dsp_addr_w + 1)) << 8);
-					break;}
-	default:        logerror("DSP PC:%04x Warning !!! IO reading from %08x (port 1)\n",m_dsp->pcbase(),m_main_ram_seg + m_dsp_addr_w); break;
+	case 0xa000:
+		{
+			address_space &mainspace = m_maincpu->space(AS_PROGRAM);
+			input_data =  mainspace.read_byte(m_main_ram_seg + (m_dsp_addr_w + 0))
+						| (mainspace.read_byte(m_main_ram_seg + (m_dsp_addr_w + 1)) << 8);
+			break;
+		}
+	default:
+		if (!machine().side_effects_disabled())
+			logerror("DSP PC:%04x Warning !!! IO reading from %08x (port 1)\n", m_dsp->pcbase(), m_main_ram_seg + m_dsp_addr_w);
+		break;
 	}
-	LOG("DSP PC:%04x IO read %04x at %08x (port 1)\n",m_dsp->pcbase(),input_data,m_main_ram_seg + m_dsp_addr_w);
+	if (!machine().side_effects_disabled())
+		LOG("DSP PC:%04x IO read %04x at %08x (port 1)\n", m_dsp->pcbase(), input_data, m_main_ram_seg + m_dsp_addr_w);
 	return input_data;
 }
 
 void twincobr_state::wardner_dsp_w(u16 data)
 {
 	/* Data written to main CPU RAM via DSP IO port 1 */
-	m_dsp_execute = 0;
+	m_dsp_execute = false;
 	switch (m_main_ram_seg)
 	{
-	case 0x7000:    if ((m_dsp_addr_w < 3) && (data == 0)) m_dsp_execute = 1;
+	case 0x7000:
+		if ((m_dsp_addr_w < 3) && (data == 0)) m_dsp_execute = true;
 		[[fallthrough]];
 	case 0x8000:
-	case 0xa000:   {address_space &mainspace = m_maincpu->space(AS_PROGRAM);
-					mainspace.write_byte(m_main_ram_seg + (m_dsp_addr_w + 0), (data & 0xff));
-					mainspace.write_byte(m_main_ram_seg + (m_dsp_addr_w + 1), ((data >> 8) & 0xff));
-					break;}
-	default:        logerror("DSP PC:%04x Warning !!! IO writing to %08x (port 1)\n",m_dsp->pcbase(),m_main_ram_seg + m_dsp_addr_w); break;
+	case 0xa000:
+		{
+			address_space &mainspace = m_maincpu->space(AS_PROGRAM);
+			mainspace.write_byte(m_main_ram_seg + (m_dsp_addr_w + 0), (data & 0xff));
+			mainspace.write_byte(m_main_ram_seg + (m_dsp_addr_w + 1), ((data >> 8) & 0xff));
+			break;
+		}
+	default:
+		logerror("DSP PC:%04x Warning !!! IO writing to %08x (port 1)\n", m_dsp->pcbase(), m_main_ram_seg + m_dsp_addr_w);
+		break;
 	}
-	LOG("DSP PC:%04x IO write %04x at %08x (port 1)\n",m_dsp->pcbase(),data,m_main_ram_seg + m_dsp_addr_w);
+	LOG("DSP PC:%04x IO write %04x at %08x (port 1)\n", m_dsp->pcbase(), data, m_main_ram_seg + m_dsp_addr_w);
 }
 
 void twincobr_state::twincobr_dsp_bio_w(u16 data)
@@ -131,8 +157,8 @@ void twincobr_state::twincobr_dsp_bio_w(u16 data)
 	/*              Actually only DSP data bit 15 controls this */
 	/* data 0x0000  means set DSP BIO line active and disable */
 	/*              communication to main processor*/
-	LOG("DSP PC:%04x IO write %04x at port 3\n",m_dsp->pcbase(),data);
-	if (data & 0x8000)
+	LOG("DSP PC:%04x IO write %04x at port 3\n", m_dsp->pcbase(), data);
+	if (BIT(data, 15))
 	{
 		m_dsp_bio = CLEAR_LINE;
 	}
@@ -142,7 +168,7 @@ void twincobr_state::twincobr_dsp_bio_w(u16 data)
 		{
 			LOG("Turning the main CPU on\n");
 			m_maincpu->set_input_line(INPUT_LINE_HALT, CLEAR_LINE);
-			m_dsp_execute = 0;
+			m_dsp_execute = false;
 		}
 		m_dsp_bio = ASSERT_LINE;
 	}
@@ -155,15 +181,15 @@ u16 twincobr_state::fsharkbt_dsp_r()
 	/* Port is read three times during startup. First and last data */
 	/*   read must equal, but second data read must be different */
 	m_fsharkbt_8741 += 1;
-	LOG("DSP PC:%04x IO read %04x from 8741 MCU (port 2)\n",m_dsp->pcbase(),(m_fsharkbt_8741 & 0x08));
-	return (m_fsharkbt_8741 & 1);
+	LOG("DSP PC:%04x IO read %04x from 8741 MCU (port 2)\n", m_dsp->pcbase(), BIT(m_fsharkbt_8741, 3));
+	return BIT(m_fsharkbt_8741, 0);
 }
 
 void twincobr_state::fsharkbt_dsp_w(u16 data)
 {
 	/* Flying Shark bootleg DSP writes data to an extra MCU (8741) at IO port 2 */
 #if 0
-	logerror("DSP PC:%04x IO write from DSP RAM:%04x to 8741 MCU (port 2)\n",m_dsp->pcbase(),m_fsharkbt_8741);
+	logerror("DSP PC:%04x IO write from DSP RAM:%04x to 8741 MCU (port 2)\n", m_dsp->pcbase(), m_fsharkbt_8741);
 #endif
 }
 
@@ -231,17 +257,7 @@ void twincobr_state::twincobr_sharedram_w(offs_t offset, u8 data)
 	m_sharedram[offset] = data;
 }
 
-
-void twincobr_state::machine_reset()
-{
-	m_dsp_addr_w = 0;
-	m_main_ram_seg = 0;
-	m_dsp_execute = 0;
-	m_dsp_bio = CLEAR_LINE;
-	m_fsharkbt_8741 = -1;
-}
-
-void twincobr_state::driver_savestate()
+void twincobr_state::machine_start()
 {
 	save_item(NAME(m_intenable));
 	save_item(NAME(m_dsp_addr_w));
@@ -249,4 +265,13 @@ void twincobr_state::driver_savestate()
 	save_item(NAME(m_dsp_bio));
 	save_item(NAME(m_dsp_execute));
 	save_item(NAME(m_fsharkbt_8741));
+}
+
+void twincobr_state::machine_reset()
+{
+	m_dsp_addr_w = 0;
+	m_main_ram_seg = 0;
+	m_dsp_execute = false;
+	m_dsp_bio = CLEAR_LINE;
+	m_fsharkbt_8741 = -1;
 }

--- a/src/mame/toaplan/twincobr_v.cpp
+++ b/src/mame/toaplan/twincobr_v.cpp
@@ -234,37 +234,37 @@ void twincobr_state::twincobr_exscroll_w(offs_t offset, u16 data)/* Extra unused
 /******************** Wardner interface to this hardware ********************/
 void twincobr_state::wardner_txlayer_w(offs_t offset, u8 data)
 {
-	const int shift = 8 * (offset & 1);
+	const int shift = 8 * BIT(offset, 0);
 	twincobr_txoffs_w(offset / 2, data << shift, 0xff << shift);
 }
 
 void twincobr_state::wardner_bglayer_w(offs_t offset, u8 data)
 {
-	const int shift = 8 * (offset & 1);
+	const int shift = 8 * BIT(offset, 0);
 	twincobr_bgoffs_w(offset / 2, data << shift, 0xff << shift);
 }
 
 void twincobr_state::wardner_fglayer_w(offs_t offset, u8 data)
 {
-	const int shift = 8 * (offset & 1);
+	const int shift = 8 * BIT(offset, 0);
 	twincobr_fgoffs_w(offset / 2, data << shift, 0xff << shift);
 }
 
 void twincobr_state::wardner_txscroll_w(offs_t offset, u8 data)
 {
-	const int shift = 8 * (offset & 1);
+	const int shift = 8 * BIT(offset, 0);
 	twincobr_txscroll_w(offset / 2, data << shift, 0xff << shift);
 }
 
 void twincobr_state::wardner_bgscroll_w(offs_t offset, u8 data)
 {
-	const int shift = 8 * (offset & 1);
+	const int shift = 8 * BIT(offset, 0);
 	twincobr_bgscroll_w(offset / 2, data << shift, 0xff << shift);
 }
 
 void twincobr_state::wardner_fgscroll_w(offs_t offset, u8 data)
 {
-	const int shift = 8 * (offset & 1);
+	const int shift = 8 * BIT(offset, 0);
 	twincobr_fgscroll_w(offset / 2, data << shift, 0xff << shift);
 }
 
@@ -281,7 +281,7 @@ void twincobr_state::wardner_exscroll_w(offs_t offset, u8 data)/* Extra unused v
 
 u8 twincobr_state::wardner_videoram_r(offs_t offset)
 {
-	const int shift = 8 * (offset & 1);
+	const int shift = 8 * BIT(offset, 0);
 	switch (offset / 2)
 	{
 		case 0: return twincobr_txram_r() >> shift;
@@ -293,7 +293,7 @@ u8 twincobr_state::wardner_videoram_r(offs_t offset)
 
 void twincobr_state::wardner_videoram_w(offs_t offset, u8 data)
 {
-	const int shift = 8 * (offset & 1);
+	const int shift = 8 * BIT(offset, 0);
 	switch (offset / 2)
 	{
 		case 0: twincobr_txram_w(0, data << shift, 0xff << shift); break;
@@ -305,7 +305,7 @@ void twincobr_state::wardner_videoram_w(offs_t offset, u8 data)
 u8 twincobr_state::wardner_sprite_r(offs_t offset)
 {
 	u16 const *const spriteram16 = reinterpret_cast<u16 *>(m_spriteram8->live());
-	const int shift = (offset & 1) * 8;
+	const int shift = BIT(offset, 0) * 8;
 	return spriteram16[offset / 2] >> shift;
 }
 

--- a/src/mame/toaplan/twincobr_v.cpp
+++ b/src/mame/toaplan/twincobr_v.cpp
@@ -89,7 +89,7 @@ void twincobr_state::video_start()
 	m_fgvideoram16 = make_unique_clear<u16[]>(m_fgvideoram_size);
 	m_bgvideoram16 = make_unique_clear<u16[]>(m_bgvideoram_size);
 
-	m_display_on = 0;
+	m_display_on = false;
 
 	save_pointer(NAME(m_txvideoram16), m_txvideoram_size);
 	save_pointer(NAME(m_fgvideoram16), m_fgvideoram_size);
@@ -234,37 +234,37 @@ void twincobr_state::twincobr_exscroll_w(offs_t offset, u16 data)/* Extra unused
 /******************** Wardner interface to this hardware ********************/
 void twincobr_state::wardner_txlayer_w(offs_t offset, u8 data)
 {
-	int shift = 8 * (offset & 1);
+	const int shift = 8 * (offset & 1);
 	twincobr_txoffs_w(offset / 2, data << shift, 0xff << shift);
 }
 
 void twincobr_state::wardner_bglayer_w(offs_t offset, u8 data)
 {
-	int shift = 8 * (offset & 1);
+	const int shift = 8 * (offset & 1);
 	twincobr_bgoffs_w(offset / 2, data << shift, 0xff << shift);
 }
 
 void twincobr_state::wardner_fglayer_w(offs_t offset, u8 data)
 {
-	int shift = 8 * (offset & 1);
+	const int shift = 8 * (offset & 1);
 	twincobr_fgoffs_w(offset / 2, data << shift, 0xff << shift);
 }
 
 void twincobr_state::wardner_txscroll_w(offs_t offset, u8 data)
 {
-	int shift = 8 * (offset & 1);
+	const int shift = 8 * (offset & 1);
 	twincobr_txscroll_w(offset / 2, data << shift, 0xff << shift);
 }
 
 void twincobr_state::wardner_bgscroll_w(offs_t offset, u8 data)
 {
-	int shift = 8 * (offset & 1);
+	const int shift = 8 * (offset & 1);
 	twincobr_bgscroll_w(offset / 2, data << shift, 0xff << shift);
 }
 
 void twincobr_state::wardner_fgscroll_w(offs_t offset, u8 data)
 {
-	int shift = 8 * (offset & 1);
+	const int shift = 8 * (offset & 1);
 	twincobr_fgscroll_w(offset / 2, data << shift, 0xff << shift);
 }
 
@@ -281,7 +281,7 @@ void twincobr_state::wardner_exscroll_w(offs_t offset, u8 data)/* Extra unused v
 
 u8 twincobr_state::wardner_videoram_r(offs_t offset)
 {
-	int shift = 8 * (offset & 1);
+	const int shift = 8 * (offset & 1);
 	switch (offset / 2)
 	{
 		case 0: return twincobr_txram_r() >> shift;
@@ -293,29 +293,29 @@ u8 twincobr_state::wardner_videoram_r(offs_t offset)
 
 void twincobr_state::wardner_videoram_w(offs_t offset, u8 data)
 {
-	int shift = 8 * (offset & 1);
+	const int shift = 8 * (offset & 1);
 	switch (offset / 2)
 	{
-		case 0: twincobr_txram_w(0,data << shift, 0xff << shift); break;
-		case 1: twincobr_bgram_w(0,data << shift, 0xff << shift); break;
-		case 2: twincobr_fgram_w(0,data << shift, 0xff << shift); break;
+		case 0: twincobr_txram_w(0, data << shift, 0xff << shift); break;
+		case 1: twincobr_bgram_w(0, data << shift, 0xff << shift); break;
+		case 2: twincobr_fgram_w(0, data << shift, 0xff << shift); break;
 	}
 }
 
 u8 twincobr_state::wardner_sprite_r(offs_t offset)
 {
-	u16 *spriteram16 = reinterpret_cast<u16 *>(m_spriteram8->live());
-	int shift = (offset & 1) * 8;
-	return spriteram16[offset/2] >> shift;
+	u16 const *const spriteram16 = reinterpret_cast<u16 *>(m_spriteram8->live());
+	const int shift = (offset & 1) * 8;
+	return spriteram16[offset / 2] >> shift;
 }
 
 void twincobr_state::wardner_sprite_w(offs_t offset, u8 data)
 {
-	u16 *spriteram16 = reinterpret_cast<u16 *>(m_spriteram8->live());
-	if (offset & 1)
-		spriteram16[offset/2] = (spriteram16[offset/2] & 0x00ff) | (data << 8);
+	u16 *const spriteram16 = reinterpret_cast<u16 *>(m_spriteram8->live());
+	if (BIT(offset, 0))
+		spriteram16[offset / 2] = (spriteram16[offset/2] & 0x00ff) | (data << 8);
 	else
-		spriteram16[offset/2] = (spriteram16[offset/2] & 0xff00) | data;
+		spriteram16[offset / 2] = (spriteram16[offset/2] & 0xff00) | data;
 }
 
 
@@ -326,14 +326,13 @@ void twincobr_state::log_vram()
 {
 #ifdef MAME_DEBUG
 
-	if ( machine().input().code_pressed(KEYCODE_M) )
+	if (machine().input().code_pressed(KEYCODE_M))
 	{
-		offs_t tile_voffs;
-		int tcode[4];
+		int tcode[4]{};
 		while (machine().input().code_pressed(KEYCODE_M)) ;
 		logerror("Scrolls             BG-X BG-Y  FG-X FG-Y  TX-X  TX-Y\n");
 		logerror("------>             %04x %04x  %04x %04x  %04x  %04x\n",m_bgscrollx,m_bgscrolly,m_fgscrollx,m_fgscrolly,m_txscrollx,m_txscrolly);
-		for ( tile_voffs = 0; tile_voffs < (m_txvideoram_size/2); tile_voffs++ )
+		for (offs_t tile_voffs = 0; tile_voffs < (m_txvideoram_size / 2); tile_voffs++)
 		{
 			tcode[1] = m_bgvideoram16[tile_voffs];
 			tcode[2] = m_fgvideoram16[tile_voffs];
@@ -343,7 +342,7 @@ void twincobr_state::log_vram()
 							tcode[2] & 0xf000 >> 12, tcode[2] & 0x0fff,
 							tcode[3] & 0xf800 >> 11, tcode[3] & 0x07ff);
 		}
-		for ( tile_voffs = (m_txvideoram_size/2); tile_voffs < (m_fgvideoram_size/2); tile_voffs++ )
+		for (offs_t tile_voffs = (m_txvideoram_size / 2); tile_voffs < (m_fgvideoram_size / 2); tile_voffs++)
 		{
 			tcode[1] = m_bgvideoram16[tile_voffs];
 			tcode[2] = m_fgvideoram16[tile_voffs];
@@ -351,7 +350,7 @@ void twincobr_state::log_vram()
 							tcode[1] & 0xf000 >> 12, tcode[1] & 0x0fff,
 							tcode[2] & 0xf000 >> 12, tcode[2] & 0x0fff);
 		}
-		for ( tile_voffs = (m_fgvideoram_size/2); tile_voffs < (m_bgvideoram_size/2); tile_voffs++ )
+		for (offs_t tile_voffs = (m_fgvideoram_size / 2); tile_voffs < (m_bgvideoram_size / 2); tile_voffs++)
 		{
 			tcode[1] = m_bgvideoram16[tile_voffs];
 			logerror("$(%04x)  (Col-Tile) BG1:%01x-%03x\n", tile_voffs,

--- a/src/mame/toaplan/wardner.cpp
+++ b/src/mame/toaplan/wardner.cpp
@@ -18,7 +18,7 @@ Supported games:
 Notes:
         Basically the same video and machine hardware as Flying Shark,
           except for the Main CPU which is a Z80 here.
-        See twincobr.cpp machine and video drivers to complete the
+        See toaplan/twincobr*.cpp machine and video drivers to complete the
           hardware setup.
         To enter the "test mode", press START1 when the grid is displayed.
         Press 0 (actually P1 button 3) on startup to skip some video RAM tests
@@ -153,8 +153,7 @@ public:
 	void init_wardner();
 
 protected:
-	virtual void driver_start() override;
-	virtual void machine_reset() override ATTR_COLD;
+	virtual void machine_start() override ATTR_COLD;
 
 private:
 	memory_view m_rom_ram_view;
@@ -381,23 +380,18 @@ static const gfx_layout tilelayout =
 
 
 static GFXDECODE_START( gfx_wardner )
-	GFXDECODE_ENTRY( "chars", 0x00000, charlayout,   1536, 32 )  // colors 1536-1791
+	GFXDECODE_ENTRY( "chars",    0x00000, charlayout,   1536, 32 )  // colors 1536-1791
 	GFXDECODE_ENTRY( "fg_tiles", 0x00000, tilelayout,   1280, 16 )  // colors 1280-1535
 	GFXDECODE_ENTRY( "bg_tiles", 0x00000, tilelayout,   1024, 16 )  // colors 1024-1079
 GFXDECODE_END
 
 
-void wardner_state::driver_start()
+void wardner_state::machine_start()
 {
-	// Save-State stuff in src/machine/twincobr.cpp
-	driver_savestate();
+	// Save-State stuff in toaplan/twincobr_m.cpp
+	twincobr_state::machine_start();
 
 	m_rombank->configure_entries(0, 8, memregion("maincpu")->base(), 0x8000);
-}
-
-void wardner_state::machine_reset()
-{
-	twincobr_state::machine_reset();
 }
 
 void wardner_state::wardner(machine_config &config)
@@ -433,7 +427,7 @@ void wardner_state::wardner(machine_config &config)
 	m_coinlatch->q_out_cb<7>().set(FUNC(wardner_state::coin_lockout_2_w));
 
 	// video hardware
-	hd6845s_device &crtc(HD6845S(config, "crtc", XTAL(14'000'000)/4)); // 3.5MHz measured on CLKin
+	hd6845s_device &crtc(HD6845S(config, "crtc", XTAL(14'000'000) / 4)); // 3.5MHz measured on CLKin
 	crtc.set_screen(m_screen);
 	crtc.set_show_border_area(false);
 	crtc.set_char_width(2);
@@ -454,7 +448,7 @@ void wardner_state::wardner(machine_config &config)
 	m_screen->screen_vblank().append(FUNC(wardner_state::wardner_vblank_irq));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_wardner);
-	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, 4096);
+	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, 0x1000 / 2);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();


### PR DESCRIPTION
- Suppress side effects for debugger read
- Fix typename for boolean flags and member variables
- Use machine_start() for save states
- Reduce literal tag usages
- Make some variables constant
- Fix palette entries for wardner
- Fix filename
- Fix spacings
- Fix namings