### PR TITLE
formats/tzx_cas.cpp: Cut data size in case header requesting more than available (MT8952)

### DIFF
--- a/src/lib/formats/a26_cas.cpp
+++ b/src/lib/formats/a26_cas.cpp
@@ -120,7 +120,7 @@ static int a26_cas_do_work( int16_t **buffer, const uint8_t *bytes ) {
 	return size;
 }
 
-static int a26_cas_fill_wave( int16_t *buffer, int length, uint8_t *bytes ) {
+static int a26_cas_fill_wave( int16_t *buffer, int length, const uint8_t *bytes ) {
 	int16_t   *p = buffer;
 
 	return a26_cas_do_work( &p, (const uint8_t *)bytes );

--- a/src/lib/formats/ace_tap.cpp
+++ b/src/lib/formats/ace_tap.cpp
@@ -135,7 +135,7 @@ static int ace_handle_tap(int16_t *buffer, const uint8_t *casdata)
 /*******************************************************************
    Generate samples for the tape image
 ********************************************************************/
-static int ace_tap_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+static int ace_tap_fill_wave(int16_t *buffer, int sample_count, const uint8_t *bytes)
 {
 	return ace_handle_tap( buffer, bytes );
 }

--- a/src/lib/formats/apf_apt.cpp
+++ b/src/lib/formats/apf_apt.cpp
@@ -152,12 +152,12 @@ static int apf_cpf_handle_cassette(int16_t *buffer, const uint8_t *bytes)
    Generate samples for the tape image
 ********************************************************************/
 
-static int apf_apt_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int apf_apt_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	return apf_apt_handle_cassette(buffer, bytes);
 }
 
-static int apf_cpf_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int apf_cpf_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	return apf_cpf_handle_cassette(buffer, bytes);
 }

--- a/src/lib/formats/camplynx_cas.cpp
+++ b/src/lib/formats/camplynx_cas.cpp
@@ -179,7 +179,7 @@ static int camplynx_handle_cassette(int16_t *buffer, const uint8_t *bytes)
    Generate samples for the tape image
 ********************************************************************/
 
-static int camplynx_cassette_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int camplynx_cassette_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	return camplynx_handle_cassette(buffer, bytes);
 }

--- a/src/lib/formats/cassimg.h
+++ b/src/lib/formats/cassimg.h
@@ -120,7 +120,7 @@ public:
 	/* code to adapt existing legacy fill_wave functions */
 	struct LegacyWaveFiller
 	{
-		int (*fill_wave)(int16_t *, int, uint8_t *) = nullptr;
+		int (*fill_wave)(int16_t *, int, const uint8_t *) = nullptr;
 		int chunk_size = 0;
 		int chunk_samples = 0;
 		int (*chunk_sample_calc)(const uint8_t *bytes, int length) = nullptr;

--- a/src/lib/formats/cbm_tap.cpp
+++ b/src/lib/formats/cbm_tap.cpp
@@ -330,7 +330,7 @@ static int cbm_tap_to_wav_size( const uint8_t *tapdata, int taplen )
 	return size;
 }
 
-static int cbm_tap_fill_wave( int16_t *buffer, int length, uint8_t *bytes )
+static int cbm_tap_fill_wave( int16_t *buffer, int length, const uint8_t *bytes )
 {
 	int16_t *p = buffer;
 

--- a/src/lib/formats/cgen_cas.cpp
+++ b/src/lib/formats/cgen_cas.cpp
@@ -108,7 +108,7 @@ static int cgenie_handle_cas(int16_t *buffer, const uint8_t *casdata)
 /*******************************************************************
    Generate samples for the tape image
 ********************************************************************/
-static int cgenie_cas_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+static int cgenie_cas_fill_wave(int16_t *buffer, int sample_count, const uint8_t *bytes)
 {
 	return cgenie_handle_cas(buffer, bytes);
 }

--- a/src/lib/formats/fc100_cas.cpp
+++ b/src/lib/formats/fc100_cas.cpp
@@ -104,7 +104,7 @@ static int fc100_handle_cassette(int16_t *buffer, const uint8_t *bytes)
    Generate samples for the tape image
 ********************************************************************/
 
-static int fc100_cassette_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int fc100_cassette_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	return fc100_handle_cassette(buffer, bytes);
 }

--- a/src/lib/formats/fm7_cas.cpp
+++ b/src/lib/formats/fm7_cas.cpp
@@ -72,7 +72,7 @@ static int fm7_cas_to_wav_size (const uint8_t *casdata, int caslen)
 /*******************************************************************
    Generate samples for the tape image
 ********************************************************************/
-static int fm7_cas_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+static int fm7_cas_fill_wave(int16_t *buffer, int sample_count, const uint8_t *bytes)
 {
 	return fm7_handle_t77(buffer,bytes);
 }

--- a/src/lib/formats/fmsx_cas.cpp
+++ b/src/lib/formats/fmsx_cas.cpp
@@ -49,7 +49,7 @@ static int fmsx_cas_to_wav_size (const uint8_t *casdata, int caslen)
 /*******************************************************************
    Generate samples for the tape image
 ********************************************************************/
-static int fmsx_cas_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+static int fmsx_cas_fill_wave(int16_t *buffer, int sample_count, const uint8_t *bytes)
 {
 	int cas_pos, bit, state = 1, samples_pos, size, n, i, p;
 

--- a/src/lib/formats/gtp_cas.cpp
+++ b/src/lib/formats/gtp_cas.cpp
@@ -127,7 +127,7 @@ static int gtp_cas_to_wav_size( const uint8_t *casdata, int caslen ) {
 	return size;
 }
 
-static int gtp_cas_fill_wave( int16_t *buffer, int length, uint8_t *bytes ) {
+static int gtp_cas_fill_wave( int16_t *buffer, int length, const uint8_t *bytes ) {
 	int i,size,n;
 	size = 0;
 	n = 0;

--- a/src/lib/formats/h8_cas.cpp
+++ b/src/lib/formats/h8_cas.cpp
@@ -102,7 +102,7 @@ static int h8_handle_cassette(int16_t *buffer, const uint8_t *bytes)
    Generate samples for the tape image
 ********************************************************************/
 
-static int h8_cassette_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int h8_cassette_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	return h8_handle_cassette(buffer, bytes);
 }

--- a/src/lib/formats/hect_tap.cpp
+++ b/src/lib/formats/hect_tap.cpp
@@ -203,7 +203,7 @@ static int hector_handle_forth_tap(int16_t *buffer, const uint8_t *casdata)
 /*******************************************************************
    Generate samples for the tape image
 ********************************************************************/
-static int hector_tap_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+static int hector_tap_fill_wave(int16_t *buffer, int sample_count, const uint8_t *bytes)
 {
 	return hector_handle_tap( buffer, bytes );
 }
@@ -222,7 +222,7 @@ static int hector_tap_forth_to_wav_size(const uint8_t *casdata, int caslen)
 /*******************************************************************
    Generate samples for the tape image FORTH
 ********************************************************************/
-static int hector_tap_forth_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+static int hector_tap_forth_fill_wave(int16_t *buffer, int sample_count, const uint8_t *bytes)
 {
 	return hector_handle_forth_tap( buffer, bytes ); //forth removed here !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 }

--- a/src/lib/formats/kc_cas.cpp
+++ b/src/lib/formats/kc_cas.cpp
@@ -232,7 +232,7 @@ static int kc_handle_sss(int16_t *buffer, const uint8_t *casdata)
 /*******************************************************************
    Generate samples for the tape image
 ********************************************************************/
-static int kc_kcc_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+static int kc_kcc_fill_wave(int16_t *buffer, int sample_count, const uint8_t *bytes)
 {
 	return kc_handle_kcc(buffer, bytes);
 }
@@ -284,7 +284,7 @@ static const cassette_image::Format kc_kcc_format =
 /*******************************************************************
    Generate samples for the tape image
 ********************************************************************/
-static int kc_tap_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+static int kc_tap_fill_wave(int16_t *buffer, int sample_count, const uint8_t *bytes)
 {
 	return kc_handle_tap(buffer, bytes);
 }
@@ -336,7 +336,7 @@ static const cassette_image::Format kc_tap_format =
 /*******************************************************************
    Generate samples for the tape image
 ********************************************************************/
-static int kc_sss_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+static int kc_sss_fill_wave(int16_t *buffer, int sample_count, const uint8_t *bytes)
 {
 	return kc_handle_sss(buffer, bytes);
 }

--- a/src/lib/formats/kim1_cas.cpp
+++ b/src/lib/formats/kim1_cas.cpp
@@ -145,7 +145,7 @@ static int kim1_handle_kim(int16_t *buffer, const uint8_t *casdata)
 /*******************************************************************
    Generate samples for the tape image
 ********************************************************************/
-static int kim1_kim_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+static int kim1_kim_fill_wave(int16_t *buffer, int sample_count, const uint8_t *bytes)
 {
 	return kim1_handle_kim( buffer, bytes );
 }

--- a/src/lib/formats/lviv_lvt.cpp
+++ b/src/lib/formats/lviv_lvt.cpp
@@ -71,7 +71,7 @@ static int lviv_cassette_calculate_size_in_samples(const uint8_t *bytes, int len
 
 /*************************************************************************************/
 
-static int lviv_cassette_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int lviv_cassette_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	int16_t * p = buffer;
 

--- a/src/lib/formats/mbee_cas.cpp
+++ b/src/lib/formats/mbee_cas.cpp
@@ -209,7 +209,7 @@ static int mbee_handle_tap(int16_t *buffer, const uint8_t *bytes)
    Generate samples for the tape image
 ********************************************************************/
 
-static int mbee_tap_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int mbee_tap_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	return mbee_handle_tap(buffer, bytes);
 }

--- a/src/lib/formats/mz_cas.cpp
+++ b/src/lib/formats/mz_cas.cpp
@@ -69,7 +69,7 @@ static int fill_wave_b(int16_t *buffer, int offs, int byte)
 	return count;
 }
 
-static int fill_wave(int16_t *buffer, int length, uint8_t *code)
+static int fill_wave(int16_t *buffer, int length, const uint8_t *code)
 {
 	static int16_t *beg;
 	static uint16_t csum = 0;

--- a/src/lib/formats/orao_cas.cpp
+++ b/src/lib/formats/orao_cas.cpp
@@ -62,7 +62,7 @@ static int orao_cas_to_wav_size( const uint8_t *casdata, int caslen ) {
 	return size;
 }
 
-static int orao_cas_fill_wave( int16_t *buffer, int length, uint8_t *bytes ) {
+static int orao_cas_fill_wave( int16_t *buffer, int length, const uint8_t *bytes ) {
 	int i,j,size,k;
 	uint8_t b;
 	size = 0;

--- a/src/lib/formats/oric_tap.cpp
+++ b/src/lib/formats/oric_tap.cpp
@@ -345,7 +345,7 @@ static int oric_cassette_calculate_size_in_samples(const uint8_t *bytes, int len
 }
 
 /* length is length of sample buffer to fill! */
-static int oric_cassette_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int oric_cassette_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	unsigned char header[9];
 	uint8_t *data_ptr;

--- a/src/lib/formats/p6001_cas.cpp
+++ b/src/lib/formats/p6001_cas.cpp
@@ -53,7 +53,7 @@ static int pc6001_cas_to_wav_size (const uint8_t *casdata, int caslen)
 /*******************************************************************
    Generate samples for the tape image
 ********************************************************************/
-static int pc6001_cas_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+static int pc6001_cas_fill_wave(int16_t *buffer, int sample_count, const uint8_t *bytes)
 {
 	return pc6001_handle_cas(buffer,bytes);
 }

--- a/src/lib/formats/phc25_cas.cpp
+++ b/src/lib/formats/phc25_cas.cpp
@@ -129,7 +129,7 @@ static int phc25_handle_cassette(int16_t *buffer, const uint8_t *bytes)
    Generate samples for the tape image
 ********************************************************************/
 
-static int phc25_cassette_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int phc25_cassette_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	return phc25_handle_cassette(buffer, bytes);
 }

--- a/src/lib/formats/pmd_cas.cpp
+++ b/src/lib/formats/pmd_cas.cpp
@@ -168,7 +168,7 @@ static int pmd85_handle_cassette(int16_t *buffer, const uint8_t *bytes)
    Generate samples for the tape image
 ********************************************************************/
 
-static int pmd85_cassette_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int pmd85_cassette_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	return pmd85_handle_cassette(buffer, bytes);
 }

--- a/src/lib/formats/primoptp.cpp
+++ b/src/lib/formats/primoptp.cpp
@@ -138,7 +138,7 @@ static int primo_cassette_calculate_size_in_samples(const uint8_t *bytes, int le
 	return size_in_samples;
 }
 
-static int primo_cassette_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int primo_cassette_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	int i = 0, j = 0, k;
 

--- a/src/lib/formats/rk_cas.cpp
+++ b/src/lib/formats/rk_cas.cpp
@@ -77,7 +77,7 @@ static int gam_cas_to_wav_size( const uint8_t *casdata, int caslen ) {
 	return  (RK_HEADER_LEN  * 8 * 2 +  caslen * 8 * 2) * RK_SIZE_20;
 }
 
-static int rk20_cas_fill_wave( int16_t *buffer, int length, uint8_t *bytes ) {
+static int rk20_cas_fill_wave( int16_t *buffer, int length, const uint8_t *bytes ) {
 	int i;
 	int16_t * p = buffer;
 
@@ -93,7 +93,7 @@ static int rk20_cas_fill_wave( int16_t *buffer, int length, uint8_t *bytes ) {
 	return p - buffer;
 }
 
-static int rk22_cas_fill_wave( int16_t *buffer, int length, uint8_t *bytes ) {
+static int rk22_cas_fill_wave( int16_t *buffer, int length, const uint8_t *bytes ) {
 	int i;
 	int16_t * p = buffer;
 
@@ -109,7 +109,7 @@ static int rk22_cas_fill_wave( int16_t *buffer, int length, uint8_t *bytes ) {
 	return p - buffer;
 }
 
-static int rk60_cas_fill_wave( int16_t *buffer, int length, uint8_t *bytes ) {
+static int rk60_cas_fill_wave( int16_t *buffer, int length, const uint8_t *bytes ) {
 	int i;
 	int16_t * p = buffer;
 
@@ -125,7 +125,7 @@ static int rk60_cas_fill_wave( int16_t *buffer, int length, uint8_t *bytes ) {
 	return p - buffer;
 }
 
-static int gam_cas_fill_wave( int16_t *buffer, int length, uint8_t *bytes ) {
+static int gam_cas_fill_wave( int16_t *buffer, int length, const uint8_t *bytes ) {
 	int i;
 	int16_t * p = buffer;
 

--- a/src/lib/formats/sol_cas.cpp
+++ b/src/lib/formats/sol_cas.cpp
@@ -335,7 +335,7 @@ static int sol20_handle_cassette(int16_t *buffer, const uint8_t *bytes)
    Generate samples for the tape image
 ********************************************************************/
 
-static int sol20_cassette_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int sol20_cassette_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	return sol20_handle_cassette(buffer, bytes);
 }

--- a/src/lib/formats/sorc_cas.cpp
+++ b/src/lib/formats/sorc_cas.cpp
@@ -107,7 +107,7 @@ static int sorcerer_handle_cassette(int16_t *buffer, const uint8_t *bytes)
    Generate samples for the tape image
 ********************************************************************/
 
-static int sorcerer_cassette_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int sorcerer_cassette_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	return sorcerer_handle_cassette(buffer, bytes);
 }

--- a/src/lib/formats/spc1000_cas.cpp
+++ b/src/lib/formats/spc1000_cas.cpp
@@ -89,12 +89,12 @@ static int spc1000_handle_cas(int16_t *buffer, const uint8_t *bytes)
    Generate samples for the tape image
 ********************************************************************/
 
-static int spc1000_tap_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int spc1000_tap_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	return spc1000_handle_tap(buffer, bytes);
 }
 
-static int spc1000_cas_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int spc1000_cas_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	return spc1000_handle_cas(buffer, bytes);
 }

--- a/src/lib/formats/svi_cas.cpp
+++ b/src/lib/formats/svi_cas.cpp
@@ -24,7 +24,7 @@ static int cas_size; // FIXME: global variable prevents multiple instances
 /*******************************************************************
    Generate samples for the tape image
 ********************************************************************/
-static int svi_cas_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+static int svi_cas_fill_wave(int16_t *buffer, int sample_count, const uint8_t *bytes)
 {
 	int cas_pos, samples_pos, n, i;
 

--- a/src/lib/formats/trs_cas.cpp
+++ b/src/lib/formats/trs_cas.cpp
@@ -174,7 +174,7 @@ static int trs80m3_handle_cas(int16_t *buffer, const uint8_t *casdata)
 /*******************************************************************
    Generate samples for the tape image
 ********************************************************************/
-static int trs80_cas_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+static int trs80_cas_fill_wave(int16_t *buffer, int sample_count, const uint8_t *bytes)
 {
 	if (cas_size && (bytes[0] == 0x55))
 		return trs80m3_handle_cas( buffer, bytes );

--- a/src/lib/formats/tzx_cas.cpp
+++ b/src/lib/formats/tzx_cas.cpp
@@ -72,7 +72,7 @@ static void toggle_wave_data(void)
 
 static void tzx_cas_get_blocks( const uint8_t *casdata, int caslen )
 {
-	int pos = sizeof(TZX_HEADER) + 2;
+	uint32_t pos = sizeof(TZX_HEADER) + 2;
 	int max_block_count = INITIAL_MAX_BLOCK_COUNT;
 	int loopcount = 0, loopoffset = 0;
 	blocks = (uint8_t**)malloc(max_block_count * sizeof(uint8_t*));
@@ -192,7 +192,14 @@ static void tzx_cas_get_blocks( const uint8_t *casdata, int caslen )
 			break;
 		}
 
-		block_count++;
+		if (pos > caslen)
+		{
+			LOG_FORMATS("Block %d(ID=%d) with wrong lenght discarded\n", block_count, blocktype);
+		}
+		else
+		{
+			block_count++;
+		}
 	}
 }
 
@@ -779,7 +786,7 @@ cleanup:
 	return -1;
 }
 
-static int tzx_cas_fill_wave( int16_t *buffer, int length, uint8_t *bytes )
+static int tzx_cas_fill_wave( int16_t *buffer, int length, const uint8_t *bytes )
 {
 	int16_t *p = buffer;
 	int size = 0;
@@ -788,7 +795,7 @@ static int tzx_cas_fill_wave( int16_t *buffer, int length, uint8_t *bytes )
 	return size;
 }
 
-static int cdt_cas_fill_wave( int16_t *buffer, int length, uint8_t *bytes )
+static int cdt_cas_fill_wave( int16_t *buffer, int length, const uint8_t *bytes )
 {
 	int16_t *p = buffer;
 	int size = 0;
@@ -802,10 +809,16 @@ static int tap_cas_to_wav_size( const uint8_t *casdata, int caslen )
 	int size = 0;
 	const uint8_t *p = casdata;
 
-	while (p < casdata + caslen)
+	while (caslen > 0)
 	{
 		int data_size = get_u16le(&p[0]);
 		int pilot_length = (p[2] == 0x00) ? 8063 : 3223;
+		caslen -= data_size;
+		if (caslen < 0)
+		{
+			LOG_FORMATS("tap_cas_to_wav_size: Requested 0x%X byte but only 0x%X available.\n", data_size, data_size + caslen);
+			data_size += caslen;
+		}
 		LOG_FORMATS("tap_cas_to_wav_size: Handling TAP block containing 0x%X bytes", data_size);
 		p += 2;
 		size += tzx_cas_handle_block(nullptr, p, 1000, data_size, 2168, pilot_length, 667, 735, 855, 1710, 8);
@@ -815,16 +828,21 @@ static int tap_cas_to_wav_size( const uint8_t *casdata, int caslen )
 	return size;
 }
 
-static int tap_cas_fill_wave( int16_t *buffer, int length, uint8_t *bytes )
+static int tap_cas_fill_wave( int16_t *buffer, int length, const uint8_t *bytes )
 {
 	int16_t *p = buffer;
 	int size = 0;
 
-	while (size < length)
+	while (length > 0)
 	{
 		int data_size = get_u16le(&bytes[0]);
 		int pilot_length = (bytes[2] == 0x00) ? 8063 : 3223;
 		LOG_FORMATS("tap_cas_fill_wave: Handling TAP block containing 0x%X bytes\n", data_size);
+		length -= data_size;
+		if (length < 0)
+		{
+			data_size += length; // Take as much as we can.
+		}
 		bytes += 2;
 		size += tzx_cas_handle_block(&p, bytes, 1000, data_size, 2168, pilot_length, 667, 735, 855, 1710, 8);
 		bytes += data_size;

--- a/src/lib/formats/uef_cas.cpp
+++ b/src/lib/formats/uef_cas.cpp
@@ -247,7 +247,7 @@ static int16_t* uef_cas_fill_bit( uint8_t loops, int16_t *buffer, bool bit )
 	return buffer;
 }
 
-static int uef_cas_fill_wave( int16_t *buffer, int length, uint8_t *bytes )
+static int uef_cas_fill_wave( int16_t *buffer, int length, const uint8_t *bytes )
 {
 	if ( bytes[0] == 0x1f && bytes[1] == 0x8b ) {
 		if ( gz_ptr == nullptr ) {

--- a/src/lib/formats/vg5k_cas.cpp
+++ b/src/lib/formats/vg5k_cas.cpp
@@ -184,7 +184,7 @@ static int vg5k_handle_tap(int16_t *buffer, const uint8_t *casdata)
 /*******************************************************************
    Generate samples for the tape image
 ********************************************************************/
-static int vg5k_k7_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+static int vg5k_k7_fill_wave(int16_t *buffer, int sample_count, const uint8_t *bytes)
 {
 	return vg5k_handle_tap(buffer, bytes);
 }

--- a/src/lib/formats/vt_cas.cpp
+++ b/src/lib/formats/vt_cas.cpp
@@ -90,7 +90,7 @@ static int16_t *vtech1_fill_wave_byte(int16_t *buffer, int byte)
 	return buffer;
 }
 
-static int vtech1_cassette_fill_wave(int16_t *buffer, int length, uint8_t *code)
+static int vtech1_cassette_fill_wave(int16_t *buffer, int length, const uint8_t *code)
 {
 	return generic_fill_wave(buffer, length, code, V1_BITSAMPLES, V1_BYTESAMPLES, V1_LO, vtech1_fill_wave_byte);
 }
@@ -185,7 +185,7 @@ static int16_t *vtech2_fill_wave_byte(int16_t *buffer, int byte)
 	return buffer;
 }
 
-static int vtech2_cassette_fill_wave(int16_t *buffer, int length, uint8_t *code)
+static int vtech2_cassette_fill_wave(int16_t *buffer, int length, const uint8_t *code)
 {
 	return generic_fill_wave(buffer, length, code, VT2_BITSAMPLES, VT2_BYTESAMPLES, VT2_LO, vtech2_fill_wave_byte);
 }

--- a/src/lib/formats/x07_cas.cpp
+++ b/src/lib/formats/x07_cas.cpp
@@ -122,7 +122,7 @@ static int x07_handle_cassette(int16_t *buffer, const uint8_t *bytes)
    Generate samples for the tape image
 ********************************************************************/
 
-static int x07_cassette_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int x07_cassette_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	return x07_handle_cassette(buffer, bytes);
 }

--- a/src/lib/formats/x1_tap.cpp
+++ b/src/lib/formats/x1_tap.cpp
@@ -101,7 +101,7 @@ static int x1_cas_to_wav_size (const uint8_t *casdata, int caslen)
 /*******************************************************************
    Generate samples for the tape image
 ********************************************************************/
-static int x1_cas_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+static int x1_cas_fill_wave(int16_t *buffer, int sample_count, const uint8_t *bytes)
 {
 	return x1_handle_tap(buffer,bytes);
 }

--- a/src/lib/formats/zx81_p.cpp
+++ b/src/lib/formats/zx81_p.cpp
@@ -173,7 +173,7 @@ static int zx81_cassette_calculate_size_in_samples(const uint8_t *bytes, int len
 	return (number_of_0_data+number_of_0_name)*ZX81_LOW_BIT_LENGTH + (number_of_1_data+number_of_1_name)*ZX81_HIGH_BIT_LENGTH + ZX81_PILOT_LENGTH;
 }
 
-static int zx81_cassette_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int zx81_cassette_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	int16_t * p = buffer;
 	int i;
@@ -250,7 +250,7 @@ static int zx80_cassette_calculate_size_in_samples(const uint8_t *bytes, int len
 	return number_of_0_data*ZX81_LOW_BIT_LENGTH + number_of_1_data*ZX81_HIGH_BIT_LENGTH + ZX81_PILOT_LENGTH;
 }
 
-static int zx80_cassette_fill_wave(int16_t *buffer, int length, uint8_t *bytes)
+static int zx80_cassette_fill_wave(int16_t *buffer, int length, const uint8_t *bytes)
 {
 	int16_t * p = buffer;
 	int i;


### PR DESCRIPTION
Images reported in MT8952 have wrong headers and requesting more than available. Added guards for segfault prevention.