### PR TITLE
hash/pc8801_cass.xml: Added 1 not-working item

### DIFF
--- a/hash/pc8801_cass.xml
+++ b/hash/pc8801_cass.xml
@@ -257,6 +257,20 @@ kanji name, romaji name, manufacturer, release date in %MMM %YY format, notes
 		</part>
 	</software>
 
+	<software name="ctgolf" supported="no">
+		<description>Computer the Golf</description>
+		<year>1983</year>
+		<publisher>日本ファルコム (Nihon Falcom)</publisher>
+		<!-- PC8801 -->
+		<info name="release" value="198310xx"/>
+		<info name="alt_title" value="コンピュータ ザ ゴルフ"/>
+		<part name="cass" interface="pc8801_cass">
+			<dataarea name="cass" size="23624">
+				<rom name="computer the golf.t88" size="23624" crc="a149466d" sha1="176a97e426d4b0a9fca206db249bdcb07870d24c"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="cosmox">
 		<description>Cosmo Cross</description>
 		<year>19??</year>


### PR DESCRIPTION
New software list items marked not working (pc8801_cass.xml) 
-------------------------------------------------------------------------------------------
Computer the Golf (1983)(Nihon Falcom) [shawnji on archive.org]
It is available on shawnji profile on archive.org.

![ctg_tape](https://github.com/user-attachments/assets/fa7e3f6c-c73f-482f-8ed4-87ebde2ad7d3)

Information of the game:
https://www.giantbomb.com/computer-the-golf/3030-70864/releases/
Thanks,