### PR TITLE
machine/ncr5385.cpp: delay after XFI_OUT_ACK

### DIFF
--- a/src/devices/machine/ncr5385.cpp
+++ b/src/devices/machine/ncr5385.cpp
@@ -759,7 +759,9 @@ int ncr5385_device::state_step()
 			else
 				m_sbx = false;
 
-			delay = 3'500;		// >=3.5us delay works, < 3.5us fails
+			// tek4404 fails to load without a delay here
+			// >=3.5us delay works, < 3.5us fails
+			delay = 3'500;
 			
 			// clear data and ACK
 			scsi_bus->data_w(scsi_refid, 0);

--- a/src/devices/machine/ncr5385.cpp
+++ b/src/devices/machine/ncr5385.cpp
@@ -759,6 +759,8 @@ int ncr5385_device::state_step()
 			else
 				m_sbx = false;
 
+			delay = 3'500;		// >=3.5us delay works, < 3.5us fails
+			
 			// clear data and ACK
 			scsi_bus->data_w(scsi_refid, 0);
 			scsi_bus->ctrl_w(scsi_refid, 0, S_ACK);


### PR DESCRIPTION
Without a delay after state XFI_OUT_ACK, tek4404 cannot load anything.
Trial and error determined a delay of <3.5us does not work, more than 3.5us does work.
I dont understand exactly why, but tek4404 scsi code just never sees the state change without this.

[I appreciate code changes and not understanding root-cause are not great, but this does resolve all issues with scsi for tek4404.]

