### PR TITLE
philips/mcd212.cpp: Rename matte flag constants and refactor matte handling code

### DIFF
--- a/src/mame/philips/mcd212.cpp
+++ b/src/mame/philips/mcd212.cpp
@@ -62,8 +62,9 @@ void mcd212_device::update_matte_arrays()
 	const int num_mattes = BIT(m_image_coding_method, ICM_NM_BIT) ? 2 : 1;
 	const bool matte_flag = BIT(m_matte_control[0], MC_MF_BIT); // MF bit must be the same. See 5.10.2 Matte Commands
 	
+	int x = 0;
 	int matte_idx = 0;
-	for (int x = 0; x < width; x++)
+	for (; x < width; x++)
 	{
 		for (int f1 = 0; f1 < num_mattes; f1++)
 		{

--- a/src/mame/philips/mcd212.cpp
+++ b/src/mame/philips/mcd212.cpp
@@ -42,31 +42,31 @@ TODO:
 // device type definition
 DEFINE_DEVICE_TYPE(MCD212, mcd212_device, "mcd212", "MCD212 VDSC")
 
-inline ATTR_FORCE_INLINE uint8_t mcd212_device::get_weight_factor(const uint32_t region_idx)
+inline ATTR_FORCE_INLINE uint8_t mcd212_device::get_weight_factor(const uint32_t matte_idx)
 {
-	return (uint8_t)((m_region_control[region_idx] & RC_WF) >> RC_WF_SHIFT);
+	return (uint8_t)((m_matte_control[matte_idx] & MC_WF) >> MC_WF_SHIFT);
 }
 
-inline ATTR_FORCE_INLINE uint8_t mcd212_device::get_region_op(const uint32_t region_idx)
+inline ATTR_FORCE_INLINE uint8_t mcd212_device::get_matte_op(const uint32_t matte_idx)
 {
-	return (m_region_control[region_idx] & RC_OP) >> RC_OP_SHIFT;
+	return (m_matte_control[matte_idx] & MC_OP) >> MC_OP_SHIFT;
 }
 
-void mcd212_device::update_region_arrays()
+void mcd212_device::update_matte_arrays()
 {
-	bool latched_rf[2]{ false, false };
+	bool latched_mf[2]{ false, false };
 	uint8_t latched_wfa = m_weight_factor[0][0];
 	uint8_t latched_wfb = m_weight_factor[1][0];
 	const int width = get_screen_width();
 
-	if (BIT(m_image_coding_method, ICM_NR_BIT))
+	if (BIT(m_image_coding_method, ICM_NM_BIT))
 	{
-		if (get_region_op(0) == 0 && get_region_op(4) == 0)
+		if (get_matte_op(0) == 0 && get_matte_op(4) == 0)
 		{
 			std::fill_n(m_weight_factor[0], std::size(m_weight_factor[0]), latched_wfa);
 			std::fill_n(m_weight_factor[1], std::size(m_weight_factor[1]), latched_wfb);
-			std::fill_n(m_region_flag[0], std::size(m_region_flag[0]), false);
-			std::fill_n(m_region_flag[1], std::size(m_region_flag[1]), false);
+			std::fill_n(m_matte_flag[0], std::size(m_matte_flag[0]), false);
+			std::fill_n(m_matte_flag[1], std::size(m_matte_flag[1]), false);
 			return;
 		}
 
@@ -74,59 +74,59 @@ void mcd212_device::update_region_arrays()
 		{
 			for (int flag = 0; flag < 2; flag++)
 			{
-				for (int region = 0; region < 4; region++)
+				for (int matte = 0; matte < 4; matte++)
 				{
-					const int region_idx = (flag << 2) + region;
-					const uint32_t region_ctrl = m_region_control[region_idx];
-					const uint32_t region_op = get_region_op(region_idx);
-					if (region_op == 0)
+					const int matte_idx = (flag << 2) + matte;
+					const uint32_t matte_ctrl = m_matte_control[matte_idx];
+					const uint32_t matte_op = get_matte_op(matte_idx);
+					if (matte_op == 0)
 					{
 						break;
 					}
-					if (x == (region_ctrl & RC_X))
+					if (x == (matte_ctrl & MC_X))
 					{
-						switch (region_op)
+						switch (matte_op)
 						{
-							case 0: // End of region control for line
+							case 0: // End of matte control for line
 								break;
 							case 1:
 							case 2:
 							case 3: // Not used
 								break;
 							case 4: // Change weight of plane A
-								latched_wfa = get_weight_factor(region_idx);
+								latched_wfa = get_weight_factor(matte_idx);
 								break;
 							case 5: // Not used
 								break;
 							case 6: // Change weight of plane B
-								latched_wfb = get_weight_factor(region_idx);
+								latched_wfb = get_weight_factor(matte_idx);
 								break;
 							case 7: // Not used
 								break;
-							case 8: // Reset region flag
-								latched_rf[flag] = false;
+							case 8: // Reset matte flag
+								latched_mf[flag] = false;
 								break;
-							case 9: // Set region flag
-								latched_rf[flag] = true;
+							case 9: // Set matte flag
+								latched_mf[flag] = true;
 								break;
 							case 10:    // Not used
 							case 11:    // Not used
 								break;
-							case 12: // Reset region flag and change weight of plane A
-								latched_wfa = get_weight_factor(region_idx);
-								latched_rf[flag] = false;
+							case 12: // Reset matte flag and change weight of plane A
+								latched_wfa = get_weight_factor(matte_idx);
+								latched_mf[flag] = false;
 								break;
-							case 13: // Set region flag and change weight of plane A
-								latched_wfa = get_weight_factor(region_idx);
-								latched_rf[flag] = true;
+							case 13: // Set matte flag and change weight of plane A
+								latched_wfa = get_weight_factor(matte_idx);
+								latched_mf[flag] = true;
 								break;
-							case 14: // Reset region flag and change weight of plane B
-								latched_wfb = get_weight_factor(region_idx);
-								latched_rf[flag] = false;
+							case 14: // Reset matte flag and change weight of plane B
+								latched_wfb = get_weight_factor(matte_idx);
+								latched_mf[flag] = false;
 								break;
-							case 15: // Set region flag and change weight of plane B
-								latched_wfb = get_weight_factor(region_idx);
-								latched_rf[flag] = true;
+							case 15: // Set matte flag and change weight of plane B
+								latched_wfb = get_weight_factor(matte_idx);
+								latched_mf[flag] = true;
 								break;
 						}
 					}
@@ -134,81 +134,81 @@ void mcd212_device::update_region_arrays()
 			}
 			m_weight_factor[0][x] = latched_wfa;
 			m_weight_factor[1][x] = latched_wfb;
-			m_region_flag[0][x] = latched_rf[0];
-			m_region_flag[1][x] = latched_rf[1];
+			m_matte_flag[0][x] = latched_mf[0];
+			m_matte_flag[1][x] = latched_mf[1];
 		}
 	}
 	else
 	{
-		int region_idx = 0;
+		int matte_idx = 0;
 		for (int x = 0; x < width; x++)
 		{
-			if (region_idx < 8)
+			if (matte_idx < 8)
 			{
-				const int flag = BIT(m_region_control[region_idx], RC_RF_BIT);
-				const uint32_t region_ctrl = m_region_control[region_idx];
-				const uint32_t region_op = get_region_op(region_idx);
-				if (region_op == 0)
+				const int flag = BIT(m_matte_control[matte_idx], MC_MF_BIT);
+				const uint32_t matte_ctrl = m_matte_control[matte_idx];
+				const uint32_t matte_op = get_matte_op(matte_idx);
+				if (matte_op == 0)
 				{
 					std::fill_n(m_weight_factor[0] + x, std::size(m_weight_factor[0]) - x, latched_wfa);
 					std::fill_n(m_weight_factor[1] + x, std::size(m_weight_factor[1]) - x, latched_wfb);
-					std::fill_n(m_region_flag[0] + x, std::size(m_region_flag[0]) - x, latched_rf[0]);
-					std::fill_n(m_region_flag[1] + x, std::size(m_region_flag[1]) - x, latched_rf[1]);
+					std::fill_n(m_matte_flag[0] + x, std::size(m_matte_flag[0]) - x, latched_mf[0]);
+					std::fill_n(m_matte_flag[1] + x, std::size(m_matte_flag[1]) - x, latched_mf[1]);
 					return;
 				}
-				if (x == (region_ctrl & RC_X))
+				if (x == (matte_ctrl & MC_X))
 				{
-					switch (region_op)
+					switch (matte_op)
 					{
-						case 0: // End of region control for line
+						case 0: // End of matte control for line
 							break;
 						case 1:
 						case 2:
 						case 3: // Not used
 							break;
 						case 4: // Change weight of plane A
-							latched_wfa = get_weight_factor(region_idx);
+							latched_wfa = get_weight_factor(matte_idx);
 							break;
 						case 5: // Not used
 							break;
 						case 6: // Change weight of plane B
-							latched_wfb = get_weight_factor(region_idx);
+							latched_wfb = get_weight_factor(matte_idx);
 							break;
 						case 7: // Not used
 							break;
-						case 8: // Reset region flag
-							latched_rf[flag] = false;
+						case 8: // Reset matte flag
+							latched_mf[flag] = false;
 							break;
-						case 9: // Set region flag
-							latched_rf[flag] = true;
+						case 9: // Set matte flag
+							latched_mf[flag] = true;
 							break;
 						case 10:    // Not used
 						case 11:    // Not used
 							break;
-						case 12: // Reset region flag and change weight of plane A
-							latched_wfa = get_weight_factor(region_idx);
-							latched_rf[flag] = false;
+						case 12: // Reset matte flag and change weight of plane A
+							latched_wfa = get_weight_factor(matte_idx);
+							latched_mf[flag] = false;
 							break;
-						case 13: // Set region flag and change weight of plane A
-							latched_wfa = get_weight_factor(region_idx);
-							latched_rf[flag] = true;
+						case 13: // Set matte flag and change weight of plane A
+							latched_wfa = get_weight_factor(matte_idx);
+							latched_mf[flag] = true;
 							break;
-						case 14: // Reset region flag and change weight of plane B
-							latched_wfb = get_weight_factor(region_idx);
-							latched_rf[flag] = false;
+						case 14: // Reset matte flag and change weight of plane B
+							latched_wfb = get_weight_factor(matte_idx);
+							latched_mf[flag] = false;
 							break;
-						case 15: // Set region flag and change weight of plane B
-							latched_wfb = get_weight_factor(region_idx);
-							latched_rf[flag] = true;
+						case 15: // Set matte flag and change weight of plane B
+							latched_wfb = get_weight_factor(matte_idx);
+							latched_mf[flag] = true;
 							break;
 					}
-					region_idx++;
+					matte_idx++;
 				}
 			}
 			m_weight_factor[0][x] = latched_wfa;
 			m_weight_factor[1][x] = latched_wfb;
-			m_region_flag[0][x] = latched_rf[0];
-			m_region_flag[1][x] = latched_rf[1];
+			m_matte_flag[0][x] = latched_mf[0];
+			m_matte_flag[1][x] = latched_mf[1];
 		}
 	}
 }
@@ -320,7 +320,7 @@ void mcd212_device::set_register(uint8_t reg, uint32_t value)
 				m_cursor_pattern[(value >> 16) & 0x000f] = value & 0x0000ffff;
 			}
 			break;
-		case 0xd0: // Region Control 0-7
+		case 0xd0: // matte Control 0-7
 		case 0xd1:
 		case 0xd2:
 		case 0xd3:
@@ -328,9 +328,9 @@ void mcd212_device::set_register(uint8_t reg, uint32_t value)
 		case 0xd5:
 		case 0xd6:
 		case 0xd7:
-			LOGMASKED(LOG_REGISTERS, "%s: Scanline %d, Path %d: Region Control %d = %08x\n", machine().describe_context(), screen().vpos(), Path, reg & 7, value);
-			m_region_control[reg & 7] = value;
-			update_region_arrays();
+			LOGMASKED(LOG_REGISTERS, "%s: Scanline %d, Path %d: matte Control %d = %08x\n", machine().describe_context(), screen().vpos(), Path, reg & 7, value);
+			m_matte_control[reg & 7] = value;
+			update_matte_arrays();
 			break;
 		case 0xd8: // Backdrop Color
 			if (Path == 0)
@@ -358,7 +358,7 @@ void mcd212_device::set_register(uint8_t reg, uint32_t value)
 			{
 				LOGMASKED(LOG_REGISTERS, "%s: Scanline %d, Path 0: Weight Factor A = %08x\n", machine().describe_context(), screen().vpos(), value);
 				m_weight_factor[0][0] = (uint8_t)value;
-				update_region_arrays();
+				update_matte_arrays();
 			}
 			break;
 		case 0xdc: // Weight Factor B
@@ -366,7 +366,7 @@ void mcd212_device::set_register(uint8_t reg, uint32_t value)
 			{
 				LOGMASKED(LOG_REGISTERS, "%s: Scanline %d, Path 1: Weight Factor B = %08x\n", machine().describe_context(), screen().vpos(), value);
 				m_weight_factor[1][0] = (uint8_t)value;
-				update_region_arrays();
+				update_matte_arrays();
 			}
 			break;
 	}
@@ -569,14 +569,7 @@ static inline uint8_t BYTE_TO_CLUT(int icm, uint8_t byte)
 		case 1:
 			return byte;
 		case 3:
-			if (Path == 1)
-			{
-				return 0x80 + (byte & 0x7f);
-			}
-			else
-			{
-				return byte & 0x7f;
-			}
+			return (Path ? 0x80 : 0) | (byte & 0x7f);
 		case 4:
 			if (Path == 0)
 			{
@@ -584,14 +577,7 @@ static inline uint8_t BYTE_TO_CLUT(int icm, uint8_t byte)
 			}
 			break;
 		case 11:
-			if (Path == 1)
-			{
-				return 0x80 + (byte & 0x0f);
-			}
-			else
-			{
-				return byte & 0x0f;
-			}
+			return (Path ? 0x80 : 0) | (byte & 0x0f);
 		default:
 			break;
 	}
@@ -622,16 +608,6 @@ template <int Path>
 inline ATTR_FORCE_INLINE uint8_t mcd212_device::get_mosaic_factor()
 {
 	return 1 << (((m_ddr[Path] & DDR_MT) >> DDR_MT_SHIFT) + 1);
-}
-
-template <int Path>
-int mcd212_device::get_plane_width()
-{
-	const int width = get_screen_width();
-	const uint8_t icm = get_icm<Path>();
-	if (icm == ICM_CLUT4)
-		return width;
-	return width >> 1;
 }
 
 template <int Path>
@@ -670,11 +646,11 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 	const bool use_rgb_tp_bit = (tp_ctrl_type == TCR_RGB);
 	const bool tp_check_parity = !BIT(tp_ctrl, 3);
 	const bool tp_always = ((tp_ctrl_type == TCR_ALWAYS) && tp_check_parity);
-	const int region_flag_index = BIT(~tp_ctrl_type, 0);
-	const bool *const region_flags = m_region_flag[region_flag_index];
-	const bool use_region_flag = (tp_ctrl_type >= TCR_RF0 && tp_ctrl_type <= TCR_RF1_KEY1);
+	const int matte_flag_index = BIT(~tp_ctrl_type, 0);
+	const bool *const matte_flags = m_matte_flag[matte_flag_index];
+	const bool use_matte_flag = (tp_ctrl_type >= TCR_MF0 && tp_ctrl_type <= TCR_MF1_KEY1);
 	const bool is_dyuv_rgb = (icm == ICM_DYUV) || ((icm == ICM_RGB555) && (Path == 1)); // DYUV and RGB do not have access to color key.
-	const bool use_color_key = !is_dyuv_rgb && ((tp_ctrl_type == TCR_KEY) || (tp_ctrl_type == TCR_RF0_KEY1) || (tp_ctrl_type == TCR_RF1_KEY1));
+	const bool use_color_key = !is_dyuv_rgb && ((tp_ctrl_type == TCR_KEY) || (tp_ctrl_type == TCR_MF0_KEY1) || (tp_ctrl_type == TCR_MF1_KEY1));
 
 	LOGMASKED(LOG_VSR, "Scanline %d: VSR Path %d, ICM (%02x), VSR (%08x)\n", screen().vpos(), Path, icm, vsr);
 
@@ -708,10 +684,10 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 			pixels[x + 1] = color0;
 			pixels[x + 2] = color1;
 			pixels[x + 3] = color1;
-			transparent[x    ] = tp_always || (use_region_flag && (region_flags[x    ] == tp_check_parity));
-			transparent[x + 1] = tp_always || (use_region_flag && (region_flags[x + 1] == tp_check_parity));
-			transparent[x + 2] = tp_always || (use_region_flag && (region_flags[x + 2] == tp_check_parity));
-			transparent[x + 3] = tp_always || (use_region_flag && (region_flags[x + 3] == tp_check_parity));
+			transparent[x    ] = tp_always || (use_matte_flag && (matte_flags[x    ] == tp_check_parity));
+			transparent[x + 1] = tp_always || (use_matte_flag && (matte_flags[x + 1] == tp_check_parity));
+			transparent[x + 2] = tp_always || (use_matte_flag && (matte_flags[x + 2] == tp_check_parity));
+			transparent[x + 3] = tp_always || (use_matte_flag && (matte_flags[x + 3] == tp_check_parity));
 			x += 4;
 		}
 		else
@@ -750,8 +726,8 @@ void mcd212_device::process_vsr(uint32_t *pixels, bool *transparent)
 			{
 				pixels[rl_index    ] = color0;
 				pixels[rl_index + 1] = color1;
-				transparent[rl_index    ] = tp_always || rgb_tp_bit || (use_color_key && color_match0) || (use_region_flag && (region_flags[rl_index    ] == tp_check_parity));
-				transparent[rl_index + 1] = tp_always || rgb_tp_bit || (use_color_key && color_match1) || (use_region_flag && (region_flags[rl_index + 1] == tp_check_parity));
+				transparent[rl_index    ] = tp_always || rgb_tp_bit || (use_color_key && color_match0) || (use_matte_flag && (matte_flags[rl_index    ] == tp_check_parity));
+				transparent[rl_index + 1] = tp_always || rgb_tp_bit || (use_color_key && color_match1) || (use_matte_flag && (matte_flags[rl_index + 1] == tp_check_parity));
 			}
 			x = end;
 		}
@@ -778,98 +754,73 @@ void mcd212_device::mix_lines(uint32_t *plane_a, bool *transparent_a, uint32_t *
 	uint8_t *weight_a = &m_weight_factor[0][0];
 	uint8_t *weight_b = &m_weight_factor[1][0];
 
-	if (!(m_transparency_control & TCR_DISABLE_MX))
+	for (int x = 0; x < width; x++)
 	{
-		for (int x = 0; x < width; x++, weight_a++, transparent_a++, weight_b++, transparent_b++)
+		const uint32_t plane_a_cur = MosaicA ? plane_a[x - (x % mosaic_count_a)] : plane_a[x];
+		const uint32_t plane_b_cur = MosaicB ? plane_b[x - (x % mosaic_count_b)] : plane_b[x];
+		if (!(m_transparency_control & TCR_DISABLE_MX))
 		{
-			const uint8_t weight_a_cur = *weight_a;
-			const uint8_t weight_b_cur = *weight_b;
-
-			const uint32_t plane_a_cur = plane_a[x];
-			const uint32_t plane_b_cur = plane_b[x];
-
-			const int32_t plane_a_r = (int32_t)(uint8_t)(plane_a_cur >> 16);
-			const int32_t plane_b_r = (int32_t)(uint8_t)(plane_b_cur >> 16);
-			const int32_t plane_a_g = (int32_t)(uint8_t)(plane_a_cur >> 8);
-			const int32_t plane_b_g = (int32_t)(uint8_t)(plane_b_cur >> 8);
-			const int32_t plane_a_b = (int32_t)(uint8_t)plane_a_cur;
-			const int32_t plane_b_b = (int32_t)(uint8_t)plane_b_cur;
-			const int32_t weighted_a_r = (plane_a_r > 16) ? (((plane_a_r - 16) * weight_a_cur) >> 6) : 0;
-			const int32_t weighted_a_g = (plane_a_g > 16) ? (((plane_a_g - 16) * weight_a_cur) >> 6) : 0;
-			const int32_t weighted_a_b = (plane_a_b > 16) ? (((plane_a_b - 16) * weight_a_cur) >> 6) : 0;
-			const int32_t weighted_b_r = ((plane_b_r > 16) ? (((plane_b_r - 16) * weight_b_cur) >> 6) : 0) + weighted_a_r;
-			const int32_t weighted_b_g = ((plane_b_g > 16) ? (((plane_b_g - 16) * weight_b_cur) >> 6) : 0) + weighted_a_g;
-			const int32_t weighted_b_b = ((plane_b_b > 16) ? (((plane_b_b - 16) * weight_b_cur) >> 6) : 0) + weighted_a_b;
+			const int32_t plane_a_r = 0xff & (plane_a[x] >> 16);
+			const int32_t plane_b_r = 0xff & (plane_b[x] >> 16);
+			const int32_t plane_a_g = 0xff & (plane_a[x] >> 8);
+			const int32_t plane_b_g = 0xff & (plane_b[x] >> 8);
+			const int32_t plane_a_b = 0xff &  plane_a[x];
+			const int32_t plane_b_b = 0xff &  plane_b[x];
+			const int32_t weighted_a_r =  (plane_a_r > 16) ? (((plane_a_r - 16) * weight_a[x]) >> 6) : 0;
+			const int32_t weighted_a_g =  (plane_a_g > 16) ? (((plane_a_g - 16) * weight_a[x]) >> 6) : 0;
+			const int32_t weighted_a_b =  (plane_a_b > 16) ? (((plane_a_b - 16) * weight_a[x]) >> 6) : 0;
+			const int32_t weighted_b_r = ((plane_b_r > 16) ? (((plane_b_r - 16) * weight_b[x]) >> 6) : 0) + weighted_a_r;
+			const int32_t weighted_b_g = ((plane_b_g > 16) ? (((plane_b_g - 16) * weight_b[x]) >> 6) : 0) + weighted_a_g;
+			const int32_t weighted_b_b = ((plane_b_b > 16) ? (((plane_b_b - 16) * weight_b[x]) >> 6) : 0) + weighted_a_b;
 			const uint8_t out_r = (weighted_b_r > 255) ? 255 : (uint8_t)weighted_b_r;
 			const uint8_t out_g = (weighted_b_g > 255) ? 255 : (uint8_t)weighted_b_g;
 			const uint8_t out_b = (weighted_b_b > 255) ? 255 : (uint8_t)weighted_b_b;
-			*out++ = 0xff000000 | (out_r << 16) | (out_g << 8) | out_b;
+			out[x] = 0xff000000 | (out_r << 16) | (out_g << 8) | out_b;
 		}
-	}
-	else
-	{
-		for (int x = 0; x < width; x++, weight_a++, transparent_a++, weight_b++, transparent_b++)
+		else
 		{
+			const int32_t plane_a_r = 0xff & (plane_a_cur >> 16);
+			const int32_t plane_a_g = 0xff & (plane_a_cur >> 8);
+			const int32_t plane_a_b = 0xff &  plane_a_cur;
+			const int32_t plane_b_r = 0xff & (plane_b_cur >> 16);
+			const int32_t plane_b_g = 0xff & (plane_b_cur >> 8);
+			const int32_t plane_b_b = 0xff &  plane_b_cur;
+
+			const uint8_t weighted_a_r = std::clamp(((plane_a_r > 16) ? (((plane_a_r - 16) * weight_a[x]) >> 6) : 0) + 16, 0, 255);
+			const uint8_t weighted_a_g = std::clamp(((plane_a_g > 16) ? (((plane_a_g - 16) * weight_a[x]) >> 6) : 0) + 16, 0, 255);
+			const uint8_t weighted_a_b = std::clamp(((plane_a_b > 16) ? (((plane_a_b - 16) * weight_a[x]) >> 6) : 0) + 16, 0, 255);
+			const uint8_t weighted_b_r = std::clamp(((plane_b_r > 16) ? (((plane_b_r - 16) * weight_b[x]) >> 6) : 0) + 16, 0, 255);
+			const uint8_t weighted_b_g = std::clamp(((plane_b_g > 16) ? (((plane_b_g - 16) * weight_b[x]) >> 6) : 0) + 16, 0, 255);
+			const uint8_t weighted_b_b = std::clamp(((plane_b_b > 16) ? (((plane_b_b - 16) * weight_b[x]) >> 6) : 0) + 16, 0, 255);
+
 			if (OrderAB)
 			{
-				if (!(*transparent_a))
+				if (!transparent_a[x])
 				{
-					const uint32_t plane_a_cur = MosaicA ? plane_a[x - (x % mosaic_count_a)] : plane_a[x];
-					const uint8_t weight_a_cur = *weight_a;
-					const int32_t plane_a_r = (int32_t)(uint8_t)(plane_a_cur >> 16);
-					const int32_t plane_a_g = (int32_t)(uint8_t)(plane_a_cur >> 8);
-					const int32_t plane_a_b = (int32_t)(uint8_t)plane_a_cur;
-					const uint8_t weighted_a_r = std::clamp(((plane_a_r > 16) ? (((plane_a_r - 16) * weight_a_cur) >> 6) : 0) + 16, 0, 255);
-					const uint8_t weighted_a_g = std::clamp(((plane_a_g > 16) ? (((plane_a_g - 16) * weight_a_cur) >> 6) : 0) + 16, 0, 255);
-					const uint8_t weighted_a_b = std::clamp(((plane_a_b > 16) ? (((plane_a_b - 16) * weight_a_cur) >> 6) : 0) + 16, 0, 255);
-					*out++ = 0xff000000 | (weighted_a_r << 16) | (weighted_a_g << 8) | weighted_a_b;
+					out[x] = 0xff000000 | (weighted_a_r << 16) | (weighted_a_g << 8) | weighted_a_b;
 				}
-				else if (!(*transparent_b))
+				else if (!transparent_b[x])
 				{
-					const uint32_t plane_b_cur = MosaicB ? plane_b[x - (x % mosaic_count_b)] : plane_b[x];
-					const uint8_t weight_b_cur = *weight_b;
-					const int32_t plane_b_r = (int32_t)(uint8_t)(plane_b_cur >> 16);
-					const int32_t plane_b_g = (int32_t)(uint8_t)(plane_b_cur >> 8);
-					const int32_t plane_b_b = (int32_t)(uint8_t)plane_b_cur;
-					const uint8_t weighted_b_r = std::clamp(((plane_b_r > 16) ? (((plane_b_r - 16) * weight_b_cur) >> 6) : 0) + 16, 0, 255);
-					const uint8_t weighted_b_g = std::clamp(((plane_b_g > 16) ? (((plane_b_g - 16) * weight_b_cur) >> 6) : 0) + 16, 0, 255);
-					const uint8_t weighted_b_b = std::clamp(((plane_b_b > 16) ? (((plane_b_b - 16) * weight_b_cur) >> 6) : 0) + 16, 0, 255);
-					*out++ = 0xff000000 | (weighted_b_r << 16) | (weighted_b_g << 8) | weighted_b_b;
+					out[x] = 0xff000000 | (weighted_b_r << 16) | (weighted_b_g << 8) | weighted_b_b;
 				}
 				else
 				{
-					*out++ = backdrop;
+					out[x] = backdrop;
 				}
 			}
 			else
 			{
-				if (!(*transparent_b))
+				if (!transparent_b[x])
 				{
-					const uint32_t plane_b_cur = MosaicB ? plane_b[x - (x % mosaic_count_b)] : plane_b[x];
-					const uint8_t weight_b_cur = *weight_b;
-					const int32_t plane_b_r = (int32_t)(uint8_t)(plane_b_cur >> 16);
-					const int32_t plane_b_g = (int32_t)(uint8_t)(plane_b_cur >> 8);
-					const int32_t plane_b_b = (int32_t)(uint8_t)plane_b_cur;
-					const uint8_t weighted_b_r = std::clamp(((plane_b_r > 16) ? (((plane_b_r - 16) * weight_b_cur) >> 6) : 0) + 16, 0, 255);
-					const uint8_t weighted_b_g = std::clamp(((plane_b_g > 16) ? (((plane_b_g - 16) * weight_b_cur) >> 6) : 0) + 16, 0, 255);
-					const uint8_t weighted_b_b = std::clamp(((plane_b_b > 16) ? (((plane_b_b - 16) * weight_b_cur) >> 6) : 0) + 16, 0, 255);
-					*out++ = 0xff000000 | (weighted_b_r << 16) | (weighted_b_g << 8) | weighted_b_b;
+					out[x] = 0xff000000 | (weighted_b_r << 16) | (weighted_b_g << 8) | weighted_b_b;
 				}
-				else if (!(*transparent_a))
+				else if (!transparent_a[x])
 				{
-					const uint32_t plane_a_cur = MosaicA ? plane_a[x - (x % mosaic_count_a)] : plane_a[x];
-					const uint8_t weight_a_cur = *weight_a;
-					const int32_t plane_a_r = (int32_t)(uint8_t)(plane_a_cur >> 16);
-					const int32_t plane_a_g = (int32_t)(uint8_t)(plane_a_cur >> 8);
-					const int32_t plane_a_b = (int32_t)(uint8_t)plane_a_cur;
-					const uint8_t weighted_a_r = std::clamp(((plane_a_r > 16) ? (((plane_a_r - 16) * weight_a_cur) >> 6) : 0) + 16, 0, 255);
-					const uint8_t weighted_a_g = std::clamp(((plane_a_g > 16) ? (((plane_a_g - 16) * weight_a_cur) >> 6) : 0) + 16, 0, 255);
-					const uint8_t weighted_a_b = std::clamp(((plane_a_b > 16) ? (((plane_a_b - 16) * weight_a_cur) >> 6) : 0) + 16, 0, 255);
-					*out++ = 0xff000000 | (weighted_a_r << 16) | (weighted_a_g << 8) | weighted_a_b;
+					out[x] = 0xff000000 | (weighted_a_r << 16) | (weighted_a_g << 8) | weighted_a_b;
 				}
 				else
 				{
-					*out++ = backdrop;
+					out[x] = backdrop;
 				}
 			}
 		}
@@ -877,44 +828,46 @@ void mcd212_device::mix_lines(uint32_t *plane_a, bool *transparent_a, uint32_t *
 
 	if (border_width)
 	{
-		std::fill_n(out, border_width, 0xff101010);
+		std::fill_n(&out[width], border_width, s_4bpp_color[0]);
 	}
 }
 
 void mcd212_device::draw_cursor(uint32_t *scanline)
 {
-	if (m_cursor_control & CURCNT_EN)
+	if (!(m_cursor_control & CURCNT_EN))
 	{
-		uint16_t y = (uint16_t)screen().vpos();
-		const uint16_t cursor_x =  m_cursor_position & 0x3ff;
-		const uint16_t cursor_y = ((m_cursor_position >> 12) & 0x3ff) + m_ica_height;
-		if (y >= cursor_y && y < (cursor_y + 16))
+		return;
+	}
+
+	uint16_t y = (uint16_t)screen().vpos();
+	const uint16_t cursor_x =  m_cursor_position & 0x3ff;
+	const uint16_t cursor_y = ((m_cursor_position >> 12) & 0x3ff) + m_ica_height;
+	if (y >= cursor_y && y < (cursor_y + 16))
+	{
+		const int width = get_screen_width();
+		uint32_t color = s_4bpp_color[m_cursor_control & CURCNT_COLOR];
+		y -= cursor_y;
+		if (m_cursor_control & CURCNT_CUW)
 		{
-			const int width = get_screen_width();
-			uint32_t color = s_4bpp_color[m_cursor_control & CURCNT_COLOR];
-			y -= cursor_y;
-			if (m_cursor_control & CURCNT_CUW)
+			for (int x = cursor_x; x < cursor_x + 64 && x < width; x++)
 			{
-				for (int x = cursor_x; x < cursor_x + 64 && x < width; x++)
+				if (m_cursor_pattern[y] & (1 << (15 - ((x - cursor_x) >> 2))))
 				{
-					if (m_cursor_pattern[y] & (1 << (15 - ((x - cursor_x) >> 2))))
-					{
-						scanline[x++] = color;
-						scanline[x++] = color;
-						scanline[x++] = color;
-						scanline[x] = color;
-					}
+					scanline[x++] = color;
+					scanline[x++] = color;
+					scanline[x++] = color;
+					scanline[x] = color;
 				}
 			}
-			else
+		}
+		else
+		{
+			for (int x = cursor_x; x < cursor_x + 32 && x < width; x++)
 			{
-				for (int x = cursor_x; x < cursor_x + 32 && x < width; x++)
+				if (m_cursor_pattern[y] & (1 << (15 - ((x - cursor_x) >> 1))))
 				{
-					if (m_cursor_pattern[y] & (1 << (15 - ((x - cursor_x) >> 1))))
-					{
-						scanline[x++] = color;
-						scanline[x] = color;
-					}
+					scanline[x++] = color;
+					scanline[x] = color;
 				}
 			}
 		}
@@ -1253,13 +1206,13 @@ void mcd212_device::device_reset()
 	m_cursor_position = 0;
 	m_cursor_control = 0;
 	std::fill_n(m_cursor_pattern, std::size(m_cursor_pattern), 0);
-	std::fill_n(m_region_control, 8, 0);
+	std::fill_n(m_matte_control, 8, 0);
 	m_backdrop_color = 0;
 	std::fill_n(m_mosaic_hold, 2, 0);
 	std::fill_n(m_weight_factor[0], std::size(m_weight_factor[0]), 0);
 	std::fill_n(m_weight_factor[1], std::size(m_weight_factor[1]), 0);
-	std::fill_n(m_region_flag[0], std::size(m_region_flag[0]), false);
-	std::fill_n(m_region_flag[1], std::size(m_region_flag[1]), false);
+	std::fill_n(m_matte_flag[0], std::size(m_matte_flag[0]), false);
+	std::fill_n(m_matte_flag[1], std::size(m_matte_flag[1]), false);
 
 	m_ica_height = 32;
 	m_total_height = 312;
@@ -1311,8 +1264,8 @@ void mcd212_device::device_start()
 		m_dyuv_v_to_r[sw] = (351 * (sw - 128)) / 256;
 	}
 
-	save_item(NAME(m_region_flag[0]));
-	save_item(NAME(m_region_flag[1]));
+	save_item(NAME(m_matte_flag[0]));
+	save_item(NAME(m_matte_flag[1]));
 	save_item(NAME(m_ica_height));
 	save_item(NAME(m_total_height));
 	save_item(NAME(m_csrr));
@@ -1333,7 +1286,7 @@ void mcd212_device::device_start()
 	save_item(NAME(m_cursor_position));
 	save_item(NAME(m_cursor_control));
 	save_item(NAME(m_cursor_pattern));
-	save_item(NAME(m_region_control));
+	save_item(NAME(m_matte_control));
 	save_item(NAME(m_backdrop_color));
 	save_item(NAME(m_mosaic_hold));
 	save_item(NAME(m_weight_factor[0]));

--- a/src/mame/philips/mcd212.cpp
+++ b/src/mame/philips/mcd212.cpp
@@ -59,12 +59,11 @@ void mcd212_device::update_matte_arrays()
 	uint8_t latched_wfb = m_weight_factor[1][0];
 	const int width = get_screen_width();
 
-	int x = 0;
 	const int num_mattes = BIT(m_image_coding_method, ICM_NM_BIT) ? 2 : 1;
 	const bool matte_flag = BIT(m_matte_control[0], MC_MF_BIT); // MF bit must be the same. See 5.10.2 Matte Commands
 	
 	int matte_idx = 0;
-	for (; x < width; x++)
+	for (int x = 0; x < width; x++)
 	{
 		for (int f1 = 0; f1 < num_mattes; f1++)
 		{

--- a/src/mame/philips/mcd212.h
+++ b/src/mame/philips/mcd212.h
@@ -100,8 +100,8 @@ protected:
 		ICM_MODE2            = 0x000f00,    // Plane 2
 		ICM_MODE2_SHIFT      = 8,
 		ICM_EV               = 0x040000,    // External video
-		ICM_NR               = 0x080000,    // Number of region flags
-		ICM_NR_BIT           = 19,
+		ICM_NM               = 0x080000,    // Number of Matte flags
+		ICM_NM_BIT           = 19,
 		ICM_CS               = 0x400000,    // CLUT select
 
 		TCR_TA               = 0x00000f,    // Plane A
@@ -110,30 +110,30 @@ protected:
 		TCR_ALWAYS           = 0x0,         // Transparent if: Always (Plane Disabled)
 		TCR_KEY              = 0x1,         // Transparent if: Color Key = True
 		TCR_RGB              = 0x2,         // Transparent if: Transparency Bit = 1 (RGB Only)
-		TCR_RF0              = 0x3,         // Transparent if: Region Flag 0 = True
-		TCR_RF1              = 0x4,         // Transparent if: Region Flag 1 = True
-		TCR_RF0_KEY1         = 0x5,         // Transparent if: Region Flag 0 = True || Color Key = True
-		TCR_RF1_KEY1         = 0x6,         // Transparent if: Region Flag 1 = True || Color Key = True
+		TCR_MF0              = 0x3,         // Transparent if: Matte Flag 0 = True
+		TCR_MF1              = 0x4,         // Transparent if: Matte Flag 1 = True
+		TCR_MF0_KEY1         = 0x5,         // Transparent if: Matte Flag 0 = True || Color Key = True
+		TCR_MF1_KEY1         = 0x6,         // Transparent if: Matte Flag 1 = True || Color Key = True
 		TCR_COND_UNUSED0     = 0x7,         // Unused
 		TCR_NEVER            = 0x8,         // Transparent if: Never (No Transparent Area)
 		TCR_NOT_KEY          = 0x9,         // Transparent if: Color Key = False
 		TCR_NOT_RGB          = 0xa,         // Transparent if: Transparency Bit = 0 (RGB Only)
-		TCR_NOT_RF0          = 0xb,         // Transparent if: Region Flag 0 = False
-		TCR_NOT_RF1          = 0xc,         // Transparent if: Region Flag 1 = False
-		TCR_NOT_RF0_KEY      = 0xd,         // Transparent if: Region Flag 0 = False || Color Key = False
-		TCR_NOT_RF1_KEY      = 0xe,         // Transparent if: Region Flag 1 = False || Color Key = False
+		TCR_NOT_MF0          = 0xb,         // Transparent if: Matte Flag 0 = False
+		TCR_NOT_MF1          = 0xc,         // Transparent if: Matte Flag 1 = False
+		TCR_NOT_MF0_KEY      = 0xd,         // Transparent if: Matte Flag 0 = False || Color Key = False
+		TCR_NOT_MF1_KEY      = 0xe,         // Transparent if: Matte Flag 1 = False || Color Key = False
 		TCR_COND_UNUSED1     = 0xf,         // Unused
 		TCR_DISABLE_MX       = 0x800000,    // Mix disable
 
 		POR_AB               = 0,           // Plane A in front of Plane B
 		POR_BA               = 1,           // Plane B in front of Plane A
 
-		RC_X                 = 0x0003ff,    // X position
-		RC_WF                = 0x00fc00,    // Weight position
-		RC_WF_SHIFT          = 10,
-		RC_RF_BIT            = 16,          // Region flag bit
-		RC_OP                = 0xf00000,    // Operation
-		RC_OP_SHIFT          = 20,
+		MC_X                 = 0x0003ff,    // X position
+		MC_WF                = 0x00fc00,    // Weight position
+		MC_WF_SHIFT          = 10,
+		MC_MF_BIT            = 16,          // Matte flag bit
+		MC_OP                = 0xf00000,    // Operation
+		MC_OP_SHIFT          = 20,
 
 		CSR1R_PA             = 0x20,        // Parity
 		CSR1R_DA             = 0x80,        // Display Active
@@ -196,7 +196,7 @@ protected:
 	uint32_t m_cursor_position = 0;
 	uint32_t m_cursor_control = 0;
 	uint32_t m_cursor_pattern[16]{};
-	uint32_t m_region_control[8]{};
+	uint32_t m_matte_control[8]{};
 	uint32_t m_backdrop_color = 0;
 	uint32_t m_mosaic_hold[2]{};
 	uint8_t m_weight_factor[2][768]{};
@@ -229,7 +229,7 @@ protected:
 	required_shared_ptr<uint16_t> m_planeb;
 
 	// internal state
-	bool m_region_flag[2][768]{};
+	bool m_matte_flag[2][768]{};
 	int m_ica_height = 0;
 	int m_total_height = 0;
 	emu_timer *m_ica_timer = nullptr;
@@ -237,13 +237,12 @@ protected:
 
 	static const uint32_t s_4bpp_color[16];
 
-	uint8_t get_weight_factor(const uint32_t region_idx);
-	uint8_t get_region_op(const uint32_t region_idx);
-	void update_region_arrays();
+	uint8_t get_weight_factor(const uint32_t Matte_idx);
+	uint8_t get_matte_op(const uint32_t Matte_idx);
+	void update_matte_arrays();
 
 	int get_screen_width();
 	int get_border_width();
-	template <int Path> int get_plane_width();
 
 	template <int Path> void set_vsr(uint32_t value);
 	template <int Path> uint32_t get_vsr();


### PR DESCRIPTION
This intentionally has no visible effects. The purpose is to make the code easier to understand and maintain.

1. The non-canonical name "Regions" was changed to the official name "Mattes". Corresponding abbreviation "R" is changed to "M".
2. Deprecated function get_plane_width is deleted.
3. mix_lines is refactored.
4. Minor changes.