### PR TITLE
konami/tutankhm.cpp, konami/junofrst.cpp: Cleanups:

### DIFF
--- a/src/mame/konami/junofrst.cpp
+++ b/src/mame/konami/junofrst.cpp
@@ -106,9 +106,7 @@ public:
 		: tutankhm_state(mconfig, type, tag)
 		, m_audiocpu(*this, "audiocpu")
 		, m_i8039(*this, "mcu")
-		, m_filter_0_0(*this, "filter.0.0")
-		, m_filter_0_1(*this, "filter.0.1")
-		, m_filter_0_2(*this, "filter.0.2")
+		, m_filter(*this, "filter.0.%u", 0U)
 		, m_blitrom(*this, "blitrom")
 	{
 	}
@@ -121,7 +119,6 @@ protected:
 
 private:
 	void blitter_w(offs_t offset, uint8_t data);
-	void bankselect_w(uint8_t data);
 	void sh_irqtrigger_w(uint8_t data);
 	void i8039_irq_w(uint8_t data);
 	void i8039_irqen_and_status_w(uint8_t data);
@@ -136,9 +133,7 @@ private:
 
 	required_device<cpu_device> m_audiocpu;
 	required_device<i8039_device> m_i8039;
-	required_device<filter_rc_device> m_filter_0_0;
-	required_device<filter_rc_device> m_filter_0_1;
-	required_device<filter_rc_device> m_filter_0_2;
+	required_device_array<filter_rc_device, 3> m_filter;
 	required_region_ptr<uint8_t> m_blitrom;
 
 	uint8_t  m_blitterdata[4]{};
@@ -175,7 +170,7 @@ void junofrst_state::blitter_w(offs_t offset, uint8_t data)
 		offs_t src = ((m_blitterdata[2] << 8) | m_blitterdata[3]) & 0xfffc;
 		offs_t dest = (m_blitterdata[0] << 8) | m_blitterdata[1];
 
-		int copy = m_blitterdata[3] & 0x01;
+		bool const copy = BIT(m_blitterdata[3], 0);
 
 		/* 16x16 graphics */
 		for (int i = 0; i < 16; i++)
@@ -184,50 +179,40 @@ void junofrst_state::blitter_w(offs_t offset, uint8_t data)
 			{
 				uint8_t data;
 
-				if (src & 1)
+				if (BIT(src, 0))
 					data = m_blitrom[src >> 1] & 0x0f;
 				else
 					data = m_blitrom[src >> 1] >> 4;
 
-				src += 1;
+				src++;
 
 				/* if there is a source pixel either copy the pixel or clear the pixel depending on the copy flag */
 
 				if (data)
 				{
-					if (copy == 0)
+					if (!copy)
 						data = 0;
 
-					if (dest & 1)
+					if (BIT(dest, 0))
 						m_videoram[dest >> 1] = (m_videoram[dest >> 1] & 0x0f) | (data << 4);
 					else
 						m_videoram[dest >> 1] = (m_videoram[dest >> 1] & 0xf0) | data;
 				}
-
-				dest += 1;
+				dest++;
 			}
-
 			dest += 240;
 		}
 	}
 }
 
 
-void junofrst_state::bankselect_w(uint8_t data)
-{
-	m_mainbank->set_entry(data & 0x0f);
-}
-
-
 uint8_t junofrst_state::portA_r()
 {
-	int timer;
-
 	/* main xtal 14.318MHz, divided by 8 to get the CPU clock, further */
 	/* divided by 1024 to get this timer */
 	/* (divide by (1024/2), and not 1024, because the CPU cycle counter is */
 	/* incremented every other state change of the clock) */
-	timer = (m_audiocpu->total_cycles() / (1024 / 2)) & 0x0f;
+	int const timer = (m_audiocpu->total_cycles() / (1024 / 2)) & 0x0f;
 
 	/* low three bits come from the 8039 */
 
@@ -237,20 +222,17 @@ uint8_t junofrst_state::portA_r()
 
 void junofrst_state::portB_w(uint8_t data)
 {
-	filter_rc_device *filter[3] = { m_filter_0_0, m_filter_0_1, m_filter_0_2 };
-	int i;
-
-	for (i = 0; i < 3; i++)
+	for (int i = 0; i < 3; i++)
 	{
 		int C = 0;
 
-		if (data & 1)
+		if (BIT(data, 0))
 			C += 47000; /* 47000pF = 0.047uF */
-		if (data & 2)
+		if (BIT(data, 1))
 			C += 220000;    /* 220000pF = 0.22uF */
 
 		data >>= 2;
-		filter[i]->filter_rc_set_RC(filter_rc_device::LOWPASS_3R, 1000, 2200, 200, CAP_P(C));
+		m_filter[i]->filter_rc_set_RC(filter_rc_device::LOWPASS_3R, 1000, 2200, 200, CAP_P(C));
 	}
 }
 
@@ -262,7 +244,6 @@ void junofrst_state::sh_irqtrigger_w(uint8_t data)
 		/* setting bit 0 low then high triggers IRQ on the sound CPU */
 		m_audiocpu->set_input_line_and_vector(0, HOLD_LINE, 0xff); // Z80
 	}
-
 	m_last_irq = data;
 }
 
@@ -275,7 +256,7 @@ void junofrst_state::i8039_irq_w(uint8_t data)
 
 void junofrst_state::i8039_irqen_and_status_w(uint8_t data)
 {
-	if ((data & 0x80) == 0)
+	if (BIT(~data, 7))
 		m_i8039->set_input_line(0, CLEAR_LINE);
 	m_i8039_status = (data & 0x70) >> 4;
 }
@@ -283,7 +264,7 @@ void junofrst_state::i8039_irqen_and_status_w(uint8_t data)
 
 void junofrst_state::main_map(address_map &map)
 {
-	map(0x0000, 0x7fff).ram().share("videoram");
+	map(0x0000, 0x7fff).ram().share(m_videoram);
 	map(0x8000, 0x800f).ram().w(m_palette, FUNC(palette_device::write8)).share("palette");
 	map(0x8010, 0x8010).portr("DSW2");
 	map(0x801c, 0x801c).r("watchdog", FUNC(watchdog_timer_device::reset_r));
@@ -434,9 +415,8 @@ void junofrst_state::junofrst(machine_config &config)
 	m_screen->set_raw(GALAXIAN_PIXEL_CLOCK, GALAXIAN_HTOTAL, GALAXIAN_HBEND, GALAXIAN_HBSTART, GALAXIAN_VTOTAL, GALAXIAN_VBEND, GALAXIAN_VBSTART);
 	PALETTE(config, m_palette).set_format(1, tutankhm_state::raw_to_rgb_func, 16);
 
-	m_screen->set_screen_update(FUNC(junofrst_state::screen_update_tutankhm_scramble));
+	m_screen->set_screen_update(FUNC(junofrst_state::screen_update_scramble));
 	m_screen->screen_vblank().set(FUNC(junofrst_state::_30hz_irq));
-
 
 	/* sound hardware */
 	SPEAKER(config, "speaker").front_center();
@@ -453,14 +433,14 @@ void junofrst_state::junofrst(machine_config &config)
 
 	DAC_8BIT_R2R(config, "dac", 0).add_route(ALL_OUTPUTS, "speaker", 0.25); // 100K (R56-63)/200K (R64-71) ladder network
 
-	FILTER_RC(config, m_filter_0_0).add_route(ALL_OUTPUTS, "speaker", 1.0);
-	FILTER_RC(config, m_filter_0_1).add_route(ALL_OUTPUTS, "speaker", 1.0);
-	FILTER_RC(config, m_filter_0_2).add_route(ALL_OUTPUTS, "speaker", 1.0);
+	FILTER_RC(config, m_filter[0]).add_route(ALL_OUTPUTS, "speaker", 1.0);
+	FILTER_RC(config, m_filter[1]).add_route(ALL_OUTPUTS, "speaker", 1.0);
+	FILTER_RC(config, m_filter[2]).add_route(ALL_OUTPUTS, "speaker", 1.0);
 }
 
 
 ROM_START( junofrst )
-	ROM_REGION( 0x1c000, "maincpu", 0 ) /* code + space for decrypted opcodes */
+	ROM_REGION( 0x20000, "maincpu", ROMREGION_ERASE00 ) /* code + space for decrypted opcodes */
 	ROM_LOAD( "jfa_b9.bin",   0x0a000, 0x2000, CRC(f5a7ab9d) SHA1(9603e797839290f8e1f93ccff9cc820604cc49ab) ) /* program ROMs */
 	ROM_LOAD( "jfb_b10.bin",  0x0c000, 0x2000, CRC(f20626e0) SHA1(46f58bdc1a613124e2c148b61f774fcc6c232868) )
 	ROM_LOAD( "jfc_a10.bin",  0x0e000, 0x2000, CRC(1e7744a7) SHA1(bee69833af886436016560295cddf0c8b4c5e771) )
@@ -472,7 +452,7 @@ ROM_START( junofrst )
 	ROM_LOAD( "jfc5_a8.bin",  0x18000, 0x2000, CRC(0539f328) SHA1(c532aaed7f9e6f564e3df0dc6d8fdbee6ed721a2) )
 	ROM_LOAD( "jfc6_a9.bin",  0x1a000, 0x2000, CRC(1da2ad6e) SHA1(de997d1b2ff6671088b57192bc9f1279359fad5d) )
 
-	ROM_REGION(  0x10000 , "audiocpu", 0 ) /* 64k for Z80 sound CPU code */
+	ROM_REGION(  0x1000, "audiocpu", 0 ) /* 64k for Z80 sound CPU code */
 	ROM_LOAD( "jfs1_j3.bin",  0x0000, 0x1000, CRC(235a2893) SHA1(b90251c4971f7ba12e407f86c32723d513d6b4a0) )
 
 	ROM_REGION( 0x1000, "mcu", 0 )  /* 8039 */
@@ -485,7 +465,7 @@ ROM_START( junofrst )
 ROM_END
 
 ROM_START( junofrstg )
-	ROM_REGION( 0x1c000, "maincpu", 0 ) /* code + space for decrypted opcodes */
+	ROM_REGION( 0x20000, "maincpu", ROMREGION_ERASE00 ) /* code + space for decrypted opcodes */
 	ROM_LOAD( "jfg_a.9b",     0x0a000, 0x2000, CRC(8f77d1c5) SHA1(d47fcdbc47673c228661a3528fff0c691c76df9e) ) /* program ROMs */
 	ROM_LOAD( "jfg_b.10b",    0x0c000, 0x2000, CRC(cd645673) SHA1(25994210a8a424bdf2eca3efa19e7eeffc097cec) )
 	ROM_LOAD( "jfg_c.10a",    0x0e000, 0x2000, CRC(47852761) SHA1(eeef814b6ad681d4c2274f0a69d1ed9c5c1b9118) )
@@ -497,7 +477,7 @@ ROM_START( junofrstg )
 	ROM_LOAD( "jfc5_a8.bin",  0x18000, 0x2000, CRC(0539f328) SHA1(c532aaed7f9e6f564e3df0dc6d8fdbee6ed721a2) )
 	ROM_LOAD( "jfc6_a9.bin",  0x1a000, 0x2000, CRC(1da2ad6e) SHA1(de997d1b2ff6671088b57192bc9f1279359fad5d) )
 
-	ROM_REGION(  0x10000 , "audiocpu", 0 ) /* 64k for Z80 sound CPU code */
+	ROM_REGION(  0x1000, "audiocpu", 0 ) /* 64k for Z80 sound CPU code */
 	ROM_LOAD( "jfs1_j3.bin",  0x0000, 0x1000, CRC(235a2893) SHA1(b90251c4971f7ba12e407f86c32723d513d6b4a0) )
 
 	ROM_REGION( 0x1000, "mcu", 0 )  /* 8039 */

--- a/src/mame/konami/tutankhm.cpp
+++ b/src/mame/konami/tutankhm.cpp
@@ -398,7 +398,7 @@ ROM_START( tutankhms )
 	/* the other banks (1900-1fff) are empty */
 
 	/* ROMS located on the KT-5112-2B board. */
-	ROM_REGION(  0x10000, "timeplt_audio:tpsound", ROMREGION_ERASE00 ) /* 64k for Z80 sound CPU code */
+	ROM_REGION(  0x3000, "timeplt_audio:tpsound", ROMREGION_ERASE00 ) /* 64k for Z80 sound CPU code */
 	ROM_LOAD( "s1.7a", 0x0000, 0x1000, CRC(b52d01fa) SHA1(9b6cf9ea51d3a87c174f34d42a4b1b5f38b48723) )
 	ROM_LOAD( "s2.8a", 0x1000, 0x1000, CRC(9db5c0ce) SHA1(b5bc1d89a7f7d7a0baae64390c37ee11f69a0e76) )
 ROM_END

--- a/src/mame/konami/tutankhm.cpp
+++ b/src/mame/konami/tutankhm.cpp
@@ -126,7 +126,7 @@ void tutankhm_state::irq_enable_w(int state)
  *
  *************************************/
 
-void tutankhm_state::tutankhm_bankselect_w(uint8_t data)
+void tutankhm_state::bankselect_w(uint8_t data)
 {
 	m_mainbank->set_entry(data & 0x0f);
 }
@@ -165,10 +165,10 @@ void tutankhm_state::sound_on_w(uint8_t data)
 
 void tutankhm_state::main_map(address_map &map)
 {
-	map(0x0000, 0x7fff).ram().share("videoram");
+	map(0x0000, 0x7fff).ram().share(m_videoram);
 	map(0x8000, 0x800f).mirror(0x00f0).ram().w(m_palette, FUNC(palette_device::write8)).share("palette");
 	//0x8100 -> Custom 089 D9 Pin 15
-	map(0x8100, 0x8100).mirror(0x000f).ram().share("scroll");
+	map(0x8100, 0x8100).mirror(0x000f).ram().share(m_scroll);
 
 	/* a read here produces a 1-0-1 write to line 420 (084).
 	 * This most likely resets some sort of timer implemented by the 084 custom chip
@@ -183,7 +183,7 @@ void tutankhm_state::main_map(address_map &map)
 	map(0x81c0, 0x81c0).mirror(0x000f).portr("IN2");  /* IN2: Player 2 I/O */
 	map(0x81e0, 0x81e0).mirror(0x000f).portr("DSW1"); /* DSW1 (inverted bits) */
 	map(0x8200, 0x8207).mirror(0x00f8).nopr().w("mainlatch", FUNC(ls259_device::write_d0));
-	map(0x8300, 0x8300).mirror(0x00ff).w(FUNC(tutankhm_state::tutankhm_bankselect_w));
+	map(0x8300, 0x8300).mirror(0x00ff).w(FUNC(tutankhm_state::bankselect_w));
 	map(0x8600, 0x8600).mirror(0x00ff).w(FUNC(tutankhm_state::sound_on_w));
 	map(0x8700, 0x8700).mirror(0x00ff).w(m_timeplt_audio, FUNC(timeplt_audio_device::sound_data_w));
 
@@ -291,8 +291,8 @@ void tutankhm_state::tutankhm(machine_config &config)
 	mainlatch.q_out_cb<1>().set_nop(); // PAY OUT - not used
 	mainlatch.q_out_cb<2>().set(FUNC(tutankhm_state::coin_counter_2_w));
 	mainlatch.q_out_cb<3>().set(FUNC(tutankhm_state::coin_counter_1_w));
-	mainlatch.q_out_cb<4>().set(FUNC(tutankhm_state::galaxian_stars_enable_w));
-	mainlatch.q_out_cb<5>().set("timeplt_audio", FUNC(timeplt_audio_device::mute_w));
+	mainlatch.q_out_cb<4>().set(FUNC(tutankhm_state::stars_enable_w));
+	mainlatch.q_out_cb<5>().set(m_timeplt_audio, FUNC(timeplt_audio_device::mute_w));
 	mainlatch.q_out_cb<6>().set(FUNC(tutankhm_state::flip_screen_x_w));
 	mainlatch.q_out_cb<7>().set(FUNC(tutankhm_state::flip_screen_y_w));
 
@@ -303,11 +303,11 @@ void tutankhm_state::tutankhm(machine_config &config)
 	m_screen->set_raw(GALAXIAN_PIXEL_CLOCK, GALAXIAN_HTOTAL, GALAXIAN_HBEND, GALAXIAN_HBSTART, GALAXIAN_VTOTAL, GALAXIAN_VBEND, GALAXIAN_VBSTART);
 	PALETTE(config, m_palette).set_format(1, tutankhm_state::raw_to_rgb_func, 16);
 
-	m_screen->set_screen_update(FUNC(tutankhm_state::screen_update_tutankhm));
+	m_screen->set_screen_update(FUNC(tutankhm_state::screen_update));
 	m_screen->screen_vblank().set(FUNC(tutankhm_state::vblank_irq));
 
 	/* sound hardware */
-	TIMEPLT_AUDIO(config, "timeplt_audio");
+	TIMEPLT_AUDIO(config, m_timeplt_audio);
 
 	/* blinking frequency is determined by 555 counter with Ra=100k, Rb=10k, C=10uF */
 	TIMER(config, "stars").configure_periodic(FUNC(tutankhm_state::scramble_stars_blink_timer), PERIOD_OF_555_ASTABLE(100000, 10000, 0.00001));
@@ -329,7 +329,7 @@ void tutankhm_state::tutankhm(machine_config &config)
 
 ROM_START( tutankhm )
 	/* ROMS located on the  KT-3203-1B board. */
-	ROM_REGION( 0x20000, "maincpu", 0 )      /* 64k for M6809 CPU code + 64k for ROM banks */
+	ROM_REGION( 0x20000, "maincpu", ROMREGION_ERASE00 )      /* 64k for M6809 CPU code + 64k for ROM banks */
 	ROM_LOAD( "m1.1h", 0x0a000, 0x1000, CRC(da18679f) SHA1(8d2a3665db937d0e1d19300ae22277d9db61fcbc) ) /* program ROMs */
 	ROM_LOAD( "m2.2h", 0x0b000, 0x1000, CRC(a0f02c85) SHA1(29a78b3ffd6b597772953543b02dd59acf5af38c) )
 	ROM_LOAD( "3j.3h", 0x0c000, 0x1000, CRC(ea03a1ab) SHA1(27a3cca0595bac642caaf9ee2f276814442c8721) ) /* Name guessed */
@@ -348,7 +348,7 @@ ROM_START( tutankhm )
 	/* the other banks (1900-1fff) are empty */
 
 	/* ROMS located on the KT-5112-2B board. */
-	ROM_REGION(  0x10000 , "timeplt_audio:tpsound", 0 ) /* 64k for Z80 sound CPU code */
+	ROM_REGION(  0x3000, "timeplt_audio:tpsound", ROMREGION_ERASE00 ) /* 64k for Z80 sound CPU code */
 	ROM_LOAD( "s1.7a", 0x0000, 0x1000, CRC(b52d01fa) SHA1(9b6cf9ea51d3a87c174f34d42a4b1b5f38b48723) )
 	ROM_LOAD( "s2.8a", 0x1000, 0x1000, CRC(9db5c0ce) SHA1(b5bc1d89a7f7d7a0baae64390c37ee11f69a0e76) )
 ROM_END
@@ -379,7 +379,7 @@ TUTANKHAM   RA1 10E (25)  1982   STERN    (in socket 8A)
 */
 ROM_START( tutankhms )
 	/* ROMS located on the KT-3203-1B board. */
-	ROM_REGION( 0x20000, "maincpu", 0 )      /* 64k for M6809 CPU code + 64k for ROM banks */
+	ROM_REGION( 0x20000, "maincpu", ROMREGION_ERASE00 )      /* 64k for M6809 CPU code + 64k for ROM banks */
 	ROM_LOAD( "m1.1h", 0x0a000, 0x1000, CRC(da18679f) SHA1(8d2a3665db937d0e1d19300ae22277d9db61fcbc) ) /* program ROMs */
 	ROM_LOAD( "m2.2h", 0x0b000, 0x1000, CRC(a0f02c85) SHA1(29a78b3ffd6b597772953543b02dd59acf5af38c) )
 	ROM_LOAD( "3a.3h", 0x0c000, 0x1000, CRC(2d62d7b1) SHA1(910718f36735f2614cda0c3a1abdfa995d82dbd2) )
@@ -398,7 +398,7 @@ ROM_START( tutankhms )
 	/* the other banks (1900-1fff) are empty */
 
 	/* ROMS located on the KT-5112-2B board. */
-	ROM_REGION(  0x10000, "timeplt_audio:tpsound", 0 ) /* 64k for Z80 sound CPU code */
+	ROM_REGION(  0x10000, "timeplt_audio:tpsound", ROMREGION_ERASE00 ) /* 64k for Z80 sound CPU code */
 	ROM_LOAD( "s1.7a", 0x0000, 0x1000, CRC(b52d01fa) SHA1(9b6cf9ea51d3a87c174f34d42a4b1b5f38b48723) )
 	ROM_LOAD( "s2.8a", 0x1000, 0x1000, CRC(9db5c0ce) SHA1(b5bc1d89a7f7d7a0baae64390c37ee11f69a0e76) )
 ROM_END

--- a/src/mame/konami/tutankhm.h
+++ b/src/mame/konami/tutankhm.h
@@ -29,37 +29,30 @@ class tutankhm_state : public driver_device
 public:
 	tutankhm_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
-		m_videoram(*this, "videoram"),
-		m_scroll(*this, "scroll"),
-		m_mainbank(*this, "mainbank"),
 		m_maincpu(*this, "maincpu"),
 		m_palette(*this, "palette"),
 		m_screen(*this, "screen"),
 		m_timeplt_audio(*this, "timeplt_audio"),
-		m_stars_config(*this, "STARS")
+		m_stars_config(*this, "STARS"),
+		m_videoram(*this, "videoram"),
+		m_scroll(*this, "scroll"),
+		m_mainbank(*this, "mainbank")
 	{
 	}
 
 	void tutankhm(machine_config &config);
 
 protected:
-	void irq_enable_w(int state);
-	void tutankhm_bankselect_w(uint8_t data);
-	void coin_counter_1_w(int state);
-	void coin_counter_2_w(int state);
-	void sound_on_w(uint8_t data);
-	void flip_screen_x_w(int state);
-	void flip_screen_y_w(int state);
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
-	uint32_t screen_update_tutankhm_bootleg(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_tutankhm_scramble(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_tutankhm(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	void vblank_irq(int state);
-	void main_map(address_map &map) ATTR_COLD;
 	virtual void video_start() override ATTR_COLD;
-	void galaxian_palette(palette_device &palette);
-	static rgb_t raw_to_rgb_func(u32 raw);
+
+	/* devices */
+	required_device<cpu_device> m_maincpu;
+	required_device<palette_device> m_palette;
+	required_device<screen_device> m_screen;
+	optional_device<timeplt_audio_device> m_timeplt_audio;
+	optional_ioport m_stars_config;
 
 	/* memory pointers */
 	required_shared_ptr<uint8_t> m_videoram;
@@ -75,15 +68,28 @@ protected:
 	uint8_t    m_irq_toggle = 0;
 	uint8_t    m_irq_enable = 0;
 
-	/* devices */
-	required_device<cpu_device> m_maincpu;
-	required_device<palette_device> m_palette;
-	required_device<screen_device> m_screen;
-	optional_device<timeplt_audio_device> m_timeplt_audio;
-	optional_ioport m_stars_config;
+	uint8_t m_star_mode = 0;
+	rgb_t m_star_color[64];
+	std::unique_ptr<uint8_t[]> m_stars;
+	uint8_t m_stars_enabled = 0;
+	uint8_t m_stars_blink_state = 0;
+
+	void irq_enable_w(int state);
+	void bankselect_w(uint8_t data);
+	void coin_counter_1_w(int state);
+	void coin_counter_2_w(int state);
+	void sound_on_w(uint8_t data);
+	void flip_screen_x_w(int state);
+	void flip_screen_y_w(int state);
+	uint32_t screen_update_bootleg(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update_scramble(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	void vblank_irq(int state);
+	void galaxian_palette(palette_device &palette);
+	static rgb_t raw_to_rgb_func(u32 raw);
 
 	TIMER_DEVICE_CALLBACK_MEMBER(scramble_stars_blink_timer);
-	void galaxian_stars_enable_w(uint8_t data);
+	void stars_enable_w(uint8_t data);
 	void stars_init();
 	void stars_init_scramble();
 	void stars_init_bootleg();
@@ -91,11 +97,7 @@ protected:
 	void scramble_draw_stars(bitmap_rgb32 &bitmap, const rectangle &cliprect, int maxx);
 	void scramble_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
-	uint8_t m_star_mode = 0;
-	rgb_t m_star_color[64];
-	std::unique_ptr<uint8_t[]> m_stars;
-	uint8_t m_stars_enabled = 0;
-	uint8_t m_stars_blink_state = 0;
+	void main_map(address_map &map) ATTR_COLD;
 };
 
 #endif // MAME_KONAMI_TUTANKHM_H

--- a/src/mame/shared/timeplt_a.h
+++ b/src/mame/shared/timeplt_a.h
@@ -36,12 +36,11 @@ protected:
 private:
 	// internal state
 	required_device<generic_latch_8_device> m_soundlatch;
-	required_device_array<filter_rc_device, 3> m_filter_0;
-	required_device_array<filter_rc_device, 3> m_filter_1;
+	required_device_array<filter_rc_device, 3> m_filter[2];
 
 	uint8_t    m_last_irq_state;
 
-	void set_filter(filter_rc_device &device, int data);
+	void set_filter(int no, int ch, int data);
 };
 
 class locomotn_audio_device : public timeplt_audio_device


### PR DESCRIPTION
- Reduce unnecessary lines
- Make some variables constant
- Reduce duplicates
- Reduce preprocessor defines
- Fix namings
- Fix main CPU ROM region size (for fix OOB error in main CPU ROM bankswitching)
- Match audio CPU ROM region size into mapped size in CPU

konami/junofrst.cpp, konami/timeplt_a.cpp: Use array for filter