### PR TITLE
intel/intellec8.cpp: Add two Intellec 8 MOD80 sets

### DIFF
--- a/src/mame/intel/intellec8.cpp
+++ b/src/mame/intel/intellec8.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Robbbert
+// copyright-holders: Robbbert
 /***************************************************************************
 
 Intellec 8 MCS
@@ -36,8 +36,8 @@ private:
 void intlc8_state::mem_map(address_map &map)
 {
 	map.unmap_value_high();
-	map(0x000, 0x7ff).rom();
-	map(0x800, 0xfff).ram();  // no idea how much ram or where
+	map(0x0000, 0x1fff).rom();  // ROM - 2 KB expandable to 16 KB?
+	map(0x2000, 0x3fff).ram();  // RAM - 8 KB expandable to 16 KB?
 }
 
 void intlc8_state::io_map(address_map &map)
@@ -45,7 +45,7 @@ void intlc8_state::io_map(address_map &map)
 	map.unmap_value_high();
 }
 
-/* Input ports */
+// Input ports
 static INPUT_PORTS_START( intlc8 )
 INPUT_PORTS_END
 
@@ -59,15 +59,15 @@ void intlc8_state::machine_start()
 
 void intlc8_state::intlc8(machine_config &config)
 {
-	/* basic machine hardware */
-	I8008(config, m_maincpu, 800000);   // no idea of clock
+	// basic machine hardware
+	I8008(config, m_maincpu, 800000);   // 750 or 800 kHz clock?
 	m_maincpu->set_addrmap(AS_PROGRAM, &intlc8_state::mem_map);
 	m_maincpu->set_addrmap(AS_IO, &intlc8_state::io_map);
 }
 
-/* ROM definition */
+
 ROM_START( intlc8 )
-	ROM_REGION( 0x0800, "maincpu", ROMREGION_ERASEFF )  // order of roms is a guess and imo some are missing?
+	ROM_REGION( 0x2000, "maincpu", ROMREGION_ERASEFF )  // order of roms is a guess and imo some are missing?
 	ROM_LOAD( "miss0.bin",    0x0000, 0x0100, NO_DUMP )
 	ROM_LOAD( "miss1.bin",    0x0100, 0x0100, NO_DUMP )
 	ROM_LOAD( "rom1.bin",     0x0200, 0x0100, CRC(0ae76bc7) SHA1(374a545cad8406ad862a5f2f1f03c6b6434fd3d8) )
@@ -78,7 +78,47 @@ ROM_START( intlc8 )
 	ROM_LOAD( "miss7.bin",    0x0700, 0x0100, NO_DUMP )
 ROM_END
 
+ROM_START( intlc8m80a )
+	ROM_REGION( 0x2000, "maincpu", ROMREGION_ERASEFF )
+	ROM_LOAD( "3000_1702a.chip_0",                  0x0000, 0x0100, CRC(a72cdab9) SHA1(c9931f1b55558383054a02b40fa716e9658ce3c4) )
+	ROM_LOAD( "3100h_1702a.chip_1",                 0x0100, 0x0100, CRC(62fbc181) SHA1(e704b5b198e43ff0b9c57067e375070a7674f3dd) )
+	ROM_LOAD( "3200_1702a.chip_2",                  0x0200, 0x0100, CRC(65215a39) SHA1(aaaae0f226a0d0f4eeac51e836b1ea674eb0f996) )
+	// Empty sockets from CHIP 3 to CHIP 4
+	ROM_LOAD( "icon_2708-p_mon8_3800_1702a.chip_5", 0x0300, 0x0100, CRC(00445543) SHA1(63ab074ba8c43905e2a43761b5cc5e0618f6e403) )
+	ROM_LOAD( "prog_3600_1702a.chip_6",             0x0400, 0x0100, CRC(61a99002) SHA1(2be84f3191d6de5e184a8c7a40312c663b4c1817) )
+	ROM_LOAD( "1702a.chip_7",                       0x0500, 0x0100, CRC(90d9a76b) SHA1(3d66bc7aa5caa2abb487dfe28ab989b373fe6703) )
+	ROM_LOAD( "3800_mon8_1702a.chip_8",             0x0600, 0x0100, CRC(ee7a08dc) SHA1(f12a690d72f08ef333e65634e0e60aff40746b7a) )
+	ROM_LOAD( "3900h_mon8_1702a.chip_9",            0x0700, 0x0100, CRC(d2795e4d) SHA1(f3ef8e197fcfaf6752da8cee6ee776b7a450cef2) )
+	ROM_LOAD( "3a00h_mon8_1702a.chip_a",            0x0800, 0x0100, CRC(c92f98e3) SHA1(dcb4316c6f037666a2a4b88df7e18ca74e754dd0) )
+	ROM_LOAD( "3b00h_mon8_1702a.chip_b",            0x0900, 0x0100, CRC(23083008) SHA1(57af12b20f160d5faa99ad2bda597f21e52078c9) )
+	ROM_LOAD( "3c00h_mon8_1702a.chip_c",            0x0a00, 0x0100, CRC(32f5c81b) SHA1(2371c0e087486c8bcb909575f158fd5ac9209bc8) )
+	ROM_LOAD( "3d00h_mon8_1702a.chip_d",            0x0b00, 0x0100, CRC(5307307a) SHA1(f38adac5e1a8bb015e23f13be5ab434394e6495f) )
+	ROM_LOAD( "3e00h_mon8_1702a.chip_e",            0x0c00, 0x0100, NO_DUMP )
+	ROM_LOAD( "3f00h_mon8_1702a.chip_f",            0x0d00, 0x0100, CRC(beca9bd7) SHA1(8162306bfbd94a373736b9e8e9f426af104d744e) )
+ROM_END
+
+ROM_START( intlc8m80b )
+	ROM_REGION( 0x2000, "maincpu", ROMREGION_ERASEFF )
+	ROM_LOAD( "1702a.chip_0",      0x0000, 0x0100, CRC(64a1aa3a) SHA1(7158e866eb222b1fbc1f573cdc748f5aedd6d0d4) )
+	ROM_LOAD( "1702a.chip_1",      0x0100, 0x0100, CRC(4583b6c3) SHA1(f9073ecfe0c043756437af595aa87b7224bf370d) )
+	ROM_LOAD( "1702a.chip_2",      0x0200, 0x0100, CRC(5a2951cc) SHA1(d9252365a330cd390ebe029517c83d9e579750a2) )
+	ROM_LOAD( "1702a.chip_3",      0x0300, 0x0100, CRC(37b1b90b) SHA1(b88872d56d03efe6ebc550fc9608e55ca0cae3cd) )
+	ROM_LOAD( "1702a.chip_4",      0x0400, 0x0100, CRC(dcbcc405) SHA1(1dc65e9c73416353e2650158183ff4ff33a9eb0e) )
+	// Empty sockets from CHIP 5 to CHIP 6
+	ROM_LOAD( "3700_1702a.chip_7", 0x0500, 0x0100, CRC(cf5a0f6e) SHA1(13841fe28ac310f00d4c55ed07fee8be556ecc9b) )
+	ROM_LOAD( "1702a.chip_8",      0x0600, 0x0100, CRC(fee2425f) SHA1(0210012153d9e294f46ab3653b4eb439125b6cfe) )
+	ROM_LOAD( "3900_1702a.chip_9", 0x0700, 0x0100, CRC(d2795e4d) SHA1(f3ef8e197fcfaf6752da8cee6ee776b7a450cef2) )
+	ROM_LOAD( "1702a.chip_a",      0x0800, 0x0100, CRC(c92f98e3) SHA1(dcb4316c6f037666a2a4b88df7e18ca74e754dd0) )
+	ROM_LOAD( "1702a.chip_b",      0x0900, 0x0100, CRC(23083008) SHA1(57af12b20f160d5faa99ad2bda597f21e52078c9) )
+	ROM_LOAD( "3c00_1702a.chip_c", 0x0a00, 0x0100, CRC(32f5c81b) SHA1(2371c0e087486c8bcb909575f158fd5ac9209bc8) )
+	ROM_LOAD( "1702a.chip_d",      0x0b00, 0x0100, CRC(5307307a) SHA1(f38adac5e1a8bb015e23f13be5ab434394e6495f) )
+	ROM_LOAD( "3e00_1702a.chip_e", 0x0c00, 0x0100, CRC(a90bd1d4) SHA1(b85a4a3d6515aa4ae298a800192077716a060f85) )
+	ROM_LOAD( "1702a.chip_f",      0x0d00, 0x0100, CRC(ae7c919b) SHA1(ab9e2f70ef19d969ce7238784118ae53a5c7ac85) )
+ROM_END
+
 } // Anonymous namespace
 
-//    YEAR  NAME      PARENT  COMPAT  MACHINE   INPUT     CLASS           INIT        COMPANY     FULLNAME         FLAGS
-COMP( 1973, intlc8,   0,      0,      intlc8, intlc8,     intlc8_state,   empty_init, "Intel", "Intellec 8 MCS", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+//    YEAR  NAME        PARENT      COMPAT  MACHINE  INPUT   CLASS         INIT        COMPANY  FULLNAME                              FLAGS
+COMP( 1973, intlc8,     0,          0,      intlc8,  intlc8, intlc8_state, empty_init, "Intel", "Intellec 8 MCS",                     MACHINE_NO_SOUND | MACHINE_NOT_WORKING ) // MOD8 or MOD80?
+COMP( 1974, intlc8m80a, 0,          0,      intlc8,  intlc8, intlc8_state, empty_init, "Intel", "Intellec 8 MCS MOD80 (set 1, 884A)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+COMP( 1974, intlc8m80b, intlc8m80a, 0,      intlc8,  intlc8, intlc8_state, empty_init, "Intel", "Intellec 8 MCS MOD80 (set 2, 880)",  MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -21517,6 +21517,8 @@ intlc440                        //
 
 @source:intel/intellec8.cpp
 intlc8                          //
+intlc8m80a                      //
+intlc8m80b                      //
 
 @source:intel/ipc.cpp
 ipb                             // intel


### PR DESCRIPTION
New systems marked not working
------------------------------
Intellec 8 MCS MOD80 (set 1, 884A) [ArcadeHacker]

New clones marked not working
------------------------------
Intellec 8 MCS MOD80 (set 2, 880) [ArcadeHacker]