### PR TITLE
nwk-tr.cpp: Revert back to one K001604 to properly show graphics during POST

### DIFF
--- a/src/mame/konami/nwk-tr.cpp
+++ b/src/mame/konami/nwk-tr.cpp
@@ -416,12 +416,12 @@ void nwktr_state::sysreg_w(offs_t offset, uint8_t data)
 			m_konppc->set_cgboard_id((data >> 4) & 0x3);
 
 			/* 
-			Racing Jam sets both EXID bits when writing to the tilemap chip before POST. This means 
+			Racing Jam enables both EXID bits when writing to the tilemap chip before POST. This means 
 			writing to both CG boards at the tilemap chip simultaneously. However, broadcasting
-			read/write handlers currently isn't supported and likely will never be for preventing
-			possible race conditions. Due to the way Konami configured this hardware in such an
-			illegal manner, we'll cheat by only using one K001604 instead to show all the tilemap
-			graphics can properly display during POST (and pass "both" tilemap IC tests).
+			read/write handlers in this kind of manner wouldn't be very ideal and could cause undefined
+			values and/or race conditions. Due to the way Konami configured this hardware in such an
+			unorthodox way, we'll cheat by only using one K001604 instead so POST can properly display
+   			its tilemap graphics (and pass "both" tilemap IC tests in the process).
 			*/
 
 //			cg_view_select((data >> 4) & 0x3);  This normally selects which CG board to read/write to (see above note)

--- a/src/mame/konami/nwk-tr.cpp
+++ b/src/mame/konami/nwk-tr.cpp
@@ -314,7 +314,6 @@ private:
 
 	uint8_t sysreg_r(offs_t offset);
 	void sysreg_w(offs_t offset, uint8_t data);
-	void cg_view_select(int view);
 	void soundtimer_en_w(uint16_t data);
 	void soundtimer_count_w(uint16_t data);
 	double adc12138_input_callback(uint8_t input);


### PR DESCRIPTION
racingj and racingj2 had a problem where some portions of POST wouldn't properly show with two k001604 tilemap ICs. This is because of the hardware configured in a way so that each CG board had its own separate bit (EXID0 and EXID1) to set for a read/write. This means the main board could set both bits on for a broadcast read/write to both boards simultaneously which is exactly what racingj does before POST to initialize both k001604 registers at once.

I myself have no clue if this kind of broadcasting is supported when it comes to address maps as it would be nice to convert k001604's register area to use a memory map instead of switch case mess. Regardless, it makes more sense to revert to one k001604 as the registers initialized to both are the same by default.