### PR TITLE
taito/taitojc.cpp, taito/taitopjc.cpp, taito/tc0780fpa.cpp: Cleanups/Updates:

### DIFF
--- a/src/mame/taito/taitojc.cpp
+++ b/src/mame/taito/taitojc.cpp
@@ -799,9 +799,9 @@ void taitojc_state::dsp_math_viewport_w(offs_t offset, uint16_t data)
 	m_viewport_data[offset] = data;
 }
 
-static inline const uint16_t muldiv(int16_t ma, int16_t mb, int16_t d)
+inline uint16_t muldiv(int16_t ma, int16_t mb, int16_t d)
 {
-	return (d != 0) ? (ma * mb) / d : 0;
+	return (d != 0) ? ((ma * mb) / d) : 0;
 }
 
 uint16_t taitojc_state::dsp_math_projection_y_r()

--- a/src/mame/taito/taitojc.cpp
+++ b/src/mame/taito/taitojc.cpp
@@ -399,7 +399,7 @@ Notes:
 
 
 // lookup tables for densha de go analog controls/meters
-static const int dendego_odometer_table[0x100] =
+static const int odometer_table[0x100] =
 {
 	0,    3,    7,    10,   14,   17,   21,   24,   28,   31,   34,   38,   41,   45,   48,   52,
 	55,   59,   62,   66,   69,   72,   76,   79,   83,   86,   90,   93,   97,   100,  105,  111,
@@ -419,7 +419,7 @@ static const int dendego_odometer_table[0x100] =
 	1253, 1256, 1259, 1262, 1266, 1269, 1272, 1275, 1278, 1281, 1284, 1288, 1291, 1294, 1297, 1300,
 };
 
-static const int dendego_pressure_table[0x100] =
+static const int pressure_table[0x100] =
 {
 	0,    0,    0,    0,    5,    10,   14,   19,   24,   29,   33,   38,   43,   48,   52,   57,
 	62,   67,   71,   76,   81,   86,   90,   95,   100,  106,  112,  119,  125,  131,  138,  144,
@@ -442,18 +442,18 @@ static const int dendego_pressure_table[0x100] =
 
 // hmm, what is the pixel clock? let's assume it's same as the 68040
 // 54MHz(/4) or 16MHz would make HTOTAL unrealistically short
-#define PIXEL_CLOCK         (10000000*2)
+static constexpr XTAL PIXEL_CLOCK = XTAL(10'000'000)*2;
 
 // VSync - 55.6795Hz
 // HSync - 24.639kHz / 24.690kHz (may be inaccurate)
 // TODO: why different HSyncs? 24 kHz assumes medium res monitor, so it can't be interlacing.
-#define HTOTAL              (812)
-#define HBEND               (0)
-#define HBSTART             (512)
+static constexpr unsigned HTOTAL  = 812;
+static constexpr unsigned HBEND   = 0;
+static constexpr unsigned HBSTART = 512;
 
-#define VTOTAL              (443)
-#define VBEND               (0)
-#define VBSTART             (400)
+static constexpr unsigned VTOTAL  = 443;
+static constexpr unsigned VBEND   = 0;
+static constexpr unsigned VBSTART = 400;
 
 
 #define DSP_IDLESKIP        1 /* dsp idle skipping speedup hack */
@@ -461,10 +461,10 @@ static const int dendego_pressure_table[0x100] =
 
 void taitojc_state::coin_control_w(uint8_t data)
 {
-	machine().bookkeeping().coin_lockout_w(0, ~data & 0x01);
-	machine().bookkeeping().coin_lockout_w(1, ~data & 0x02);
-	machine().bookkeeping().coin_counter_w(0, data & 0x04);
-	machine().bookkeeping().coin_counter_w(1, data & 0x08);
+	machine().bookkeeping().coin_lockout_w(0, BIT(~data, 0));
+	machine().bookkeeping().coin_lockout_w(1, BIT(~data, 1));
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 2));
+	machine().bookkeeping().coin_counter_w(1, BIT(data, 3));
 }
 
 
@@ -486,9 +486,11 @@ void taitojc_state::dsp_to_main_7fe_w(offs_t offset, uint16_t data, uint16_t mem
 
 uint16_t taitojc_state::dsp_to_main_7fe_r(offs_t offset, uint16_t mem_mask)
 {
-	if (ACCESSING_BITS_0_7)
-		m_maincpu->set_input_line(6, CLEAR_LINE);
-
+	if (!machine().side_effects_disabled())
+	{
+		if (ACCESSING_BITS_0_7)
+			m_maincpu->set_input_line(6, CLEAR_LINE);
+	}
 	return m_dsp_shared_ram[0x7fe];
 }
 
@@ -500,7 +502,7 @@ void taitojc_state::main_to_dsp_7ff_w(offs_t offset, uint16_t data, uint16_t mem
 	{
 		// shared ram interrupt request from maincpu side
 		// this is hacky, acquiring the internal dsp romdump should allow it to be cleaned up(?)
-		if (data & 0x08)
+		if (BIT(data, 3))
 		{
 			m_dsp->set_input_line(INPUT_LINE_RESET, ASSERT_LINE);
 		}
@@ -521,7 +523,7 @@ void taitojc_state::main_to_dsp_7ff_w(offs_t offset, uint16_t data, uint16_t mem
 			{
 				m_dsp->set_input_line(INPUT_LINE_RESET, CLEAR_LINE);
 			}
-			m_first_dsp_reset = 0;
+			m_first_dsp_reset = false;
 		}
 	}
 }
@@ -532,12 +534,12 @@ void taitojc_state::cpu_space_map(address_map &map)
 	map(0xfffffff4, 0xfffffff5).lr16(NAME([] () -> u16 { return 0x82; }));
 }
 
-INTERRUPT_GEN_MEMBER(taitojc_state::taitojc_vblank)
+INTERRUPT_GEN_MEMBER(taitojc_state::vblank)
 {
 	device.execute().set_input_line(2, HOLD_LINE); // where does it come from?
 }
 
-void taitojc_state::jc_irq_unk_w(uint8_t data)
+void taitojc_state::irq_unk_w(uint8_t data)
 {
 	// gets written to at the end of irq6 routine
 	// writes $02 or $06, depending on a value in DSP RAM, what does it mean?
@@ -599,7 +601,7 @@ void taitojc_state::mcu_comm_w(offs_t offset, uint8_t data)
 }
 
 
-uint8_t taitojc_state::jc_pcbid_r(offs_t offset)
+uint8_t taitojc_state::pcbid_r(offs_t offset)
 {
 	static const char pcb_id[0x40] =
 	{ "DEV=TC0870HVP   SYS=CG  VER=1.0"};
@@ -619,12 +621,12 @@ Not emulated yet...
 
 */
 
-uint8_t taitojc_state::jc_lan_r()
+uint8_t taitojc_state::lan_r()
 {
 	return 0xff;
 }
 
-void taitojc_state::jc_lan_w(uint8_t data)
+void taitojc_state::lan_w(uint8_t data)
 {
 }
 
@@ -633,19 +635,19 @@ void taitojc_state::taitojc_map(address_map &map)
 {
 	map(0x00000000, 0x001fffff).rom().mirror(0x200000);
 	map(0x00400000, 0x01bfffff).rom().region("maingfx", 0);
-	map(0x04000000, 0x040f7fff).ram().share("vram");
-	map(0x040f8000, 0x040fbfff).rw(FUNC(taitojc_state::taitojc_tile_r), FUNC(taitojc_state::taitojc_tile_w));
-	map(0x040fc000, 0x040fefff).rw(FUNC(taitojc_state::taitojc_char_r), FUNC(taitojc_state::taitojc_char_w));
-	map(0x040ff000, 0x040fffff).ram().share("objlist");
-	map(0x05800000, 0x0580003f).r(FUNC(taitojc_state::jc_pcbid_r));
+	map(0x04000000, 0x040f7fff).ram().share(m_vram);
+	map(0x040f8000, 0x040fbfff).ram().w(FUNC(taitojc_state::tile_w)).share(m_tile_ram);
+	map(0x040fc000, 0x040fefff).ram().w(FUNC(taitojc_state::char_w)).share(m_char_ram);
+	map(0x040ff000, 0x040fffff).ram().share(m_objlist);
+	map(0x05800000, 0x0580003f).r(FUNC(taitojc_state::pcbid_r));
 	map(0x05900000, 0x05900007).rw(FUNC(taitojc_state::mcu_comm_r), FUNC(taitojc_state::mcu_comm_w));
-	map(0x06400000, 0x0641ffff).rw(FUNC(taitojc_state::taitojc_palette_r), FUNC(taitojc_state::taitojc_palette_w)).share("palette_ram");
+	map(0x06400000, 0x0641ffff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette");
 	map(0x06600000, 0x0660001f).rw(m_tc0640fio, FUNC(tc0640fio_device::read), FUNC(tc0640fio_device::write)).umask32(0xff000000);
 	map(0x0660004c, 0x0660004f).portw("EEPROMOUT");
-	map(0x06800001, 0x06800001).w(FUNC(taitojc_state::jc_irq_unk_w));
+	map(0x06800001, 0x06800001).w(FUNC(taitojc_state::irq_unk_w));
 	map(0x06a00000, 0x06a01fff).rw("taito_en:dpram", FUNC(mb8421_device::left_r), FUNC(mb8421_device::left_w)).umask32(0xff000000);
-	map(0x06c00000, 0x06c0001f).rw(FUNC(taitojc_state::jc_lan_r), FUNC(taitojc_state::jc_lan_w)).umask32(0x00ff0000);
-	map(0x08000000, 0x080fffff).ram().share("main_ram");
+	map(0x06c00000, 0x06c0001f).rw(FUNC(taitojc_state::lan_r), FUNC(taitojc_state::lan_w)).umask32(0x00ff0000);
+	map(0x08000000, 0x080fffff).ram().share(m_main_ram);
 	map(0x10000000, 0x10001fff).rw(FUNC(taitojc_state::dsp_shared_r), FUNC(taitojc_state::dsp_shared_w)).umask32(0xffff0000);
 	map(0x10001ff8, 0x10001ff9).r(FUNC(taitojc_state::dsp_to_main_7fe_r));
 	map(0x10001ffc, 0x10001ffd).w(FUNC(taitojc_state::main_to_dsp_7ff_w));
@@ -661,30 +663,30 @@ The OKI is used for seat vibration effects.
 
 */
 
-void taitojc_state::dendego_speedmeter_w(uint8_t data)
+void dendego_state::speedmeter_w(uint8_t data)
 {
-	if (m_speed_meter != dendego_odometer_table[data])
+	if (m_speed_meter != odometer_table[data])
 	{
-		m_speed_meter = dendego_odometer_table[data];
+		m_speed_meter = odometer_table[data];
 		m_counters[2] = m_speed_meter / 10;
 		m_counters[3] = m_speed_meter % 10;
 	}
 }
 
-void taitojc_state::dendego_brakemeter_w(uint8_t data)
+void dendego_state::brakemeter_w(uint8_t data)
 {
-	if (m_brake_meter != dendego_pressure_table[data])
+	if (m_brake_meter != pressure_table[data])
 	{
-		m_brake_meter = dendego_pressure_table[data];
+		m_brake_meter = pressure_table[data];
 		m_counters[4] = m_brake_meter;
 	}
 }
 
-void taitojc_state::dendego_map(address_map &map)
+void dendego_state::dendego_map(address_map &map)
 {
 	taitojc_map(map);
-	map(0x06e00001, 0x06e00001).w(FUNC(taitojc_state::dendego_speedmeter_w));
-	map(0x06e00005, 0x06e00005).w(FUNC(taitojc_state::dendego_brakemeter_w));
+	map(0x06e00001, 0x06e00001).w(FUNC(dendego_state::speedmeter_w));
+	map(0x06e00005, 0x06e00005).w(FUNC(dendego_state::brakemeter_w));
 	map(0x06e0000d, 0x06e0000d).rw("oki", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 }
 
@@ -797,14 +799,19 @@ void taitojc_state::dsp_math_viewport_w(offs_t offset, uint16_t data)
 	m_viewport_data[offset] = data;
 }
 
+static inline const uint16_t muldiv(int16_t ma, int16_t mb, int16_t d)
+{
+	return (d != 0) ? (ma * mb) / d : 0;
+}
+
 uint16_t taitojc_state::dsp_math_projection_y_r()
 {
-	return (m_projection_data[2] != 0) ? (m_projection_data[0] * m_viewport_data[0]) / m_projection_data[2] : 0;
+	return muldiv(m_projection_data[0], m_viewport_data[0], m_projection_data[2]);
 }
 
 uint16_t taitojc_state::dsp_math_projection_x_r()
 {
-	return (m_projection_data[2] != 0) ? (m_projection_data[1] * m_viewport_data[1]) / m_projection_data[2] : 0;
+	return muldiv(m_projection_data[1], m_viewport_data[1], m_projection_data[2]);
 }
 
 void taitojc_state::dsp_math_intersection_w(offs_t offset, uint16_t data)
@@ -814,7 +821,7 @@ void taitojc_state::dsp_math_intersection_w(offs_t offset, uint16_t data)
 
 uint16_t taitojc_state::dsp_math_intersection_r()
 {
-	return (m_intersection_data[2] != 0) ? (m_intersection_data[0] * m_intersection_data[1]) / m_intersection_data[2] : 0;
+	return muldiv(m_intersection_data[0], m_intersection_data[1], m_intersection_data[2]);
 }
 
 uint16_t taitojc_state::dsp_math_unk_r()
@@ -827,7 +834,7 @@ uint16_t taitojc_state::dsp_math_unk_r()
 
 uint16_t taitojc_state::dsp_rom_r()
 {
-	assert (m_dsp_rom_pos < 0x800000); // never happens
+	assert(m_dsp_rom_pos < 0x800000); // never happens
 	return m_dspgfx[machine().side_effects_disabled() ? m_dsp_rom_pos : m_dsp_rom_pos++];
 }
 
@@ -866,7 +873,7 @@ void taitojc_state::tms_data_map(address_map &map)
 	map(0x701d, 0x701d).r(FUNC(taitojc_state::dsp_math_projection_y_r));
 	map(0x701f, 0x701f).r(FUNC(taitojc_state::dsp_math_projection_x_r));
 	map(0x7022, 0x7022).r(FUNC(taitojc_state::dsp_math_unk_r));
-	map(0x7800, 0x7fff).ram().share("dsp_shared");
+	map(0x7800, 0x7fff).ram().share(m_dsp_shared_ram);
 	map(0x7ffe, 0x7ffe).w(FUNC(taitojc_state::dsp_to_main_7fe_w));
 	map(0x8000, 0xffff).ram();
 }
@@ -1032,7 +1039,7 @@ INPUT_PORTS_END
 
 void taitojc_state::machine_reset()
 {
-	m_first_dsp_reset = 1;
+	m_first_dsp_reset = true;
 
 	m_mcu_comm_main = 0;
 	m_mcu_comm_hc11 = 0;
@@ -1057,18 +1064,22 @@ void taitojc_state::machine_start()
 	save_item(NAME(m_viewport_data));
 	save_item(NAME(m_projection_data));
 	save_item(NAME(m_intersection_data));
-	save_item(NAME(m_gfx_index));
 
 	save_item(NAME(m_mcu_comm_main));
 	save_item(NAME(m_mcu_comm_hc11));
 	save_item(NAME(m_mcu_data_main));
 	save_item(NAME(m_mcu_data_hc11));
 
-	save_item(NAME(m_speed_meter));
-	save_item(NAME(m_brake_meter));
-
 	m_lamps.resolve();
 	m_counters.resolve();
+}
+
+void dendego_state::machine_start()
+{
+	taitojc_state::machine_start();
+
+	save_item(NAME(m_speed_meter));
+	save_item(NAME(m_brake_meter));
 }
 
 
@@ -1077,7 +1088,7 @@ void taitojc_state::taitojc(machine_config &config)
 	/* basic machine hardware */
 	M68040(config, m_maincpu, XTAL(10'000'000)*2); // 20MHz, clock source = CY7C991
 	m_maincpu->set_addrmap(AS_PROGRAM, &taitojc_state::taitojc_map);
-	m_maincpu->set_vblank_int("screen", FUNC(taitojc_state::taitojc_vblank));
+	m_maincpu->set_vblank_int("screen", FUNC(taitojc_state::vblank));
 	m_maincpu->set_addrmap(m68000_base_device::AS_CPU_SPACE, &taitojc_state::cpu_space_map);
 
 	mc68hc11_cpu_device &sub(MC68HC11M0(config, "sub", XTAL(16'000'000)/2));
@@ -1118,10 +1129,10 @@ void taitojc_state::taitojc(machine_config &config)
 	/* video hardware */
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_raw(PIXEL_CLOCK, HTOTAL, HBEND, HBSTART, VTOTAL, VBEND, VBSTART);
-	m_screen->set_screen_update(FUNC(taitojc_state::screen_update_taitojc));
+	m_screen->set_screen_update(FUNC(taitojc_state::screen_update));
 	m_screen->set_palette(m_palette);
 
-	PALETTE(config, m_palette).set_entries(32768);
+	PALETTE(config, m_palette).set_format(palette_device::xGRB_888, 32768);
 
 	TC0780FPA(config, m_tc0780fpa, 0);
 
@@ -1134,15 +1145,15 @@ void taitojc_state::taitojc(machine_config &config)
 	taito_en.add_route(1, "rspeaker", 1.0);
 }
 
-void taitojc_state::dendego(machine_config &config)
+void dendego_state::dendego(machine_config &config)
 {
 	taitojc(config);
 
 	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &taitojc_state::dendego_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &dendego_state::dendego_map);
 
 	/* video hardware */
-	m_screen->set_screen_update(FUNC(taitojc_state::screen_update_dendego));
+	m_screen->set_screen_update(FUNC(dendego_state::screen_update_dendego));
 
 	/* sound hardware */
 	SPEAKER(config, "vibration").seat();
@@ -1162,42 +1173,46 @@ void taitojc_state::dendego(machine_config &config)
 
 uint16_t taitojc_state::taitojc_dsp_idle_skip_r()
 {
-	if (m_dsp->pc() == 0x404c)
-		m_dsp->spin_until_time(attotime::from_usec(500));
-
+	if (!machine().side_effects_disabled())
+	{
+		if (m_dsp->pc() == 0x404c)
+			m_dsp->spin_until_time(attotime::from_usec(500));
+	}
 	return m_dsp_shared_ram[0x7f0];
 }
 
-uint16_t taitojc_state::dendego2_dsp_idle_skip_r()
+uint16_t dendego_state::dendego2_dsp_idle_skip_r()
 {
-	if (m_dsp->pc() == 0x402e)
-		m_dsp->spin_until_time(attotime::from_usec(500));
-
+	if (!machine().side_effects_disabled())
+	{
+		if (m_dsp->pc() == 0x402e)
+			m_dsp->spin_until_time(attotime::from_usec(500));
+	}
 	return m_dsp_shared_ram[0x7f0];
 }
 
 
 void taitojc_state::init_taitojc()
 {
-	m_has_dsp_hack = 1;
+	m_has_dsp_hack = true;
 
 	if (DSP_IDLESKIP)
 		m_dsp->space(AS_DATA).install_read_handler(0x7ff0, 0x7ff0, read16smo_delegate(*this, FUNC(taitojc_state::taitojc_dsp_idle_skip_r)));
 }
 
-void taitojc_state::init_dendego2()
+void dendego_state::init_dendego2()
 {
 	init_taitojc();
 
 	if (DSP_IDLESKIP)
-		m_dsp->space(AS_DATA).install_read_handler(0x7ff0, 0x7ff0, read16smo_delegate(*this, FUNC(taitojc_state::dendego2_dsp_idle_skip_r)));
+		m_dsp->space(AS_DATA).install_read_handler(0x7ff0, 0x7ff0, read16smo_delegate(*this, FUNC(dendego_state::dendego2_dsp_idle_skip_r)));
 }
 
 void taitojc_state::init_dangcurv()
 {
 	init_taitojc();
 
-	m_has_dsp_hack = 0;
+	m_has_dsp_hack = false;
 }
 
 
@@ -2216,12 +2231,12 @@ GAME( 1996, sidebs,    0,        taitojc, sidebs,   taitojc_state, init_taitojc,
 GAME( 1996, sidebsj,   sidebs,   taitojc, sidebs,   taitojc_state, init_taitojc,  ROT0, "Taito", "Side by Side (Ver 2.7 J)",                             MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING | MACHINE_NODEVICE_LAN )                       // SIDE BY SIDE           VER 2.7 J   1996/10/11   14:54:10
 GAME( 1996, sidebsja,  sidebs,   taitojc, sidebs,   taitojc_state, init_taitojc,  ROT0, "Taito", "Side by Side (Ver 2.6 J)",                             MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING | MACHINE_NODEVICE_LAN )                       // SIDE BY SIDE           VER 2.6 J   1996/ 7/ 1   18:41:51
 GAME( 1996, sidebsjb,  sidebs,   taitojc, sidebs,   taitojc_state, init_taitojc,  ROT0, "Taito", "Side by Side (Ver 2.5 J)",                             MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING | MACHINE_NODEVICE_LAN )                       // SIDE BY SIDE           VER 2.5 J   1996/ 6/20   18:13:14
-GAMEL(1996, dendego,   0,        dendego, dendego,  taitojc_state, init_taitojc,  ROT0, "Taito", "Densha de GO! (Ver 2.3 J)",                            MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING, layout_dendego )                              // DENSYA DE GO           VER 2.3 J   1997/ 3/10   20:49:44
-GAMEL(1996, dendegoa,  dendego,  dendego, dendego,  taitojc_state, init_taitojc,  ROT0, "Taito", "Densha de GO! (Ver 2.2 J)",                            MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING, layout_dendego )                              // DENSYA DE GO           VER 2.2 J   1997/ 2/ 4   12:00:28
-GAMEL(1996, dendegox,  dendego,  dendego, dendego,  taitojc_state, init_taitojc,  ROT0, "Taito", "Densha de GO! EX (Ver 2.4 J)",                         MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING, layout_dendego )                              // DENSYA DE GO           VER 2.4 J   1997/ 4/18   13:38:34
+GAMEL(1996, dendego,   0,        dendego, dendego,  dendego_state, init_taitojc,  ROT0, "Taito", "Densha de GO! (Ver 2.3 J)",                            MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING, layout_dendego )                              // DENSYA DE GO           VER 2.3 J   1997/ 3/10   20:49:44
+GAMEL(1996, dendegoa,  dendego,  dendego, dendego,  dendego_state, init_taitojc,  ROT0, "Taito", "Densha de GO! (Ver 2.2 J)",                            MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING, layout_dendego )                              // DENSYA DE GO           VER 2.2 J   1997/ 2/ 4   12:00:28
+GAMEL(1996, dendegox,  dendego,  dendego, dendego,  dendego_state, init_taitojc,  ROT0, "Taito", "Densha de GO! EX (Ver 2.4 J)",                         MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING, layout_dendego )                              // DENSYA DE GO           VER 2.4 J   1997/ 4/18   13:38:34
 GAME( 1997, sidebs2,   0,        taitojc, sidebs,   taitojc_state, init_taitojc,  ROT0, "Taito", "Side by Side 2 (Ver 2.6 OK)",                          MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING | MACHINE_NODEVICE_LAN )                       // SIDE BY SIDE2          VER 2.6 OK  1997/ 6/ 4   17:27:37
 GAME( 1997, sidebs2u,  sidebs2,  taitojc, sidebs,   taitojc_state, init_taitojc,  ROT0, "Taito", "Side by Side 2 (Ver 2.6 A)",                           MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING | MACHINE_NODEVICE_LAN )                       // SIDE BY SIDE2          VER 2.6 A   1997/ 6/19   09:39:22
 GAME( 1997, sidebs2j,  sidebs2,  taitojc, sidebs,   taitojc_state, init_taitojc,  ROT0, "Taito", "Side by Side 2 Evoluzione RR (Ver 3.1 J)",             MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING | MACHINE_NODEVICE_LAN )                       // SIDE BY SIDE2          VER 3.1 J   1997/10/ 7   13:55:38
 GAME( 1997, sidebs2ja, sidebs2,  taitojc, sidebs,   taitojc_state, init_taitojc,  ROT0, "Taito", "Side by Side 2 Evoluzione (Ver 2.4 J)",                MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING | MACHINE_NODEVICE_LAN )                       // SIDE BY SIDE2          VER 2.4 J   1997/ 5/26   13:06:37
-GAMEL(1998, dendego2,  0,        dendego, dendego,  taitojc_state, init_dendego2, ROT0, "Taito", "Densha de GO! 2 Kousoku-hen (Ver 2.5 J)",              MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING, layout_dendego )                              // DENSYA DE GO2          VER 2.5 J   1998/ 3/ 2   15:30:55
-GAMEL(1998, dendego23k,dendego2, dendego, dendego,  taitojc_state, init_dendego2, ROT0, "Taito", "Densha de GO! 2 Kousoku-hen 3000-bandai (Ver 2.20 J)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING, layout_dendego )                              // DENSYA DE GO! 2 3000   VER 2.20 J  1998/ 7/15   17:42:38
+GAMEL(1998, dendego2,  0,        dendego, dendego,  dendego_state, init_dendego2, ROT0, "Taito", "Densha de GO! 2 Kousoku-hen (Ver 2.5 J)",              MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING, layout_dendego )                              // DENSYA DE GO2          VER 2.5 J   1998/ 3/ 2   15:30:55
+GAMEL(1998, dendego23k,dendego2, dendego, dendego,  dendego_state, init_dendego2, ROT0, "Taito", "Densha de GO! 2 Kousoku-hen 3000-bandai (Ver 2.20 J)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_TIMING, layout_dendego )                              // DENSYA DE GO! 2 3000   VER 2.20 J  1998/ 7/15   17:42:38

--- a/src/mame/taito/taitojc.h
+++ b/src/mame/taito/taitojc.h
@@ -16,69 +16,67 @@ class taitojc_state : public driver_device
 {
 public:
 	taitojc_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_maincpu(*this,"maincpu"),
-		m_dsp(*this,"dsp"),
-		m_tc0640fio(*this, "tc0640fio"),
-		m_dspgfx(*this, "dspgfx"),
-		m_vram(*this, "vram"),
-		m_objlist(*this, "objlist"),
-		m_main_ram(*this, "main_ram"),
-		m_dsp_shared_ram(*this, "dsp_shared"),
-		m_palette_ram(*this, "palette_ram"),
-		m_gfxdecode(*this, "gfxdecode"),
-		m_screen(*this, "screen"),
-		m_palette(*this, "palette"),
-		m_analog_ports(*this, "AN.%u", 0),
-		m_tc0780fpa(*this, "tc0780fpa"),
-		m_lamps(*this, "lamp%u", 0U),
-		m_counters(*this, "counter%u", 0U)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this,"maincpu")
+		, m_dsp(*this,"dsp")
+		, m_tc0640fio(*this, "tc0640fio")
+		, m_tc0780fpa(*this, "tc0780fpa")
+		, m_gfxdecode(*this, "gfxdecode")
+		, m_screen(*this, "screen")
+		, m_palette(*this, "palette")
+		, m_dspgfx(*this, "dspgfx")
+		, m_vram(*this, "vram")
+		, m_objlist(*this, "objlist")
+		, m_main_ram(*this, "main_ram")
+		, m_dsp_shared_ram(*this, "dsp_shared")
+		, m_tile_ram(*this, "tile_ram")
+		, m_char_ram(*this, "char_ram")
+		, m_analog_ports(*this, "AN.%u", 0)
+		, m_lamps(*this, "lamp%u", 0U)
+		, m_counters(*this, "counter%u", 0U)
 	{
-		m_speed_meter = 0;
-		m_brake_meter = 0;
 	}
 
 	void taitojc(machine_config &config);
-	void dendego(machine_config &config);
 
-	void init_dendego2();
 	void init_dangcurv();
 	void init_taitojc();
 
-private:
+protected:
+	virtual void machine_start() override ATTR_COLD;
+	virtual void machine_reset() override ATTR_COLD;
+	virtual void video_start() override ATTR_COLD;
+
 	// device/memory pointers
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_dsp;
 	required_device<tc0640fio_device> m_tc0640fio;
+	required_device<tc0780fpa_device> m_tc0780fpa;
+	required_device<gfxdecode_device> m_gfxdecode;
+	required_device<screen_device> m_screen;
+	required_device<palette_device> m_palette;
+
 	required_region_ptr<uint16_t> m_dspgfx;
 
 	required_shared_ptr<uint32_t> m_vram;
 	required_shared_ptr<uint32_t> m_objlist;
 	required_shared_ptr<uint32_t> m_main_ram;
 	required_shared_ptr<uint16_t> m_dsp_shared_ram;
-	required_shared_ptr<uint32_t> m_palette_ram;
+	required_shared_ptr<uint32_t> m_tile_ram;
+	required_shared_ptr<uint32_t> m_char_ram;
 
-	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<screen_device> m_screen;
-	required_device<palette_device> m_palette;
 	optional_ioport_array<8> m_analog_ports;
-
-	required_device<tc0780fpa_device> m_tc0780fpa;
 
 	output_finder<8> m_lamps;
 	output_finder<5> m_counters;
 
 	uint32_t m_dsp_rom_pos = 0;
 
-	int m_first_dsp_reset = 0;
-	int16_t m_viewport_data[3];
-	int16_t m_projection_data[3];
-	int16_t m_intersection_data[3];
+	bool m_first_dsp_reset = false;
+	int16_t m_viewport_data[3]{};
+	int16_t m_projection_data[3]{};
+	int16_t m_intersection_data[3]{};
 
-	int m_gfx_index = 0;
-
-	std::unique_ptr<uint32_t[]> m_char_ram;
-	std::unique_ptr<uint32_t[]> m_tile_ram;
 	tilemap_t *m_tilemap = nullptr;
 
 	uint8_t m_mcu_comm_main = 0;
@@ -86,21 +84,16 @@ private:
 	uint8_t m_mcu_data_main = 0;
 	uint8_t m_mcu_data_hc11 = 0;
 
-	uint8_t m_has_dsp_hack = 0;
-
-	int m_speed_meter = 0;
-	int m_brake_meter = 0;
+	bool m_has_dsp_hack = false;
 
 	void coin_control_w(uint8_t data);
 
 	uint8_t mcu_comm_r(offs_t offset);
 	void mcu_comm_w(offs_t offset, uint8_t data);
-	uint8_t jc_pcbid_r(offs_t offset);
-	uint8_t jc_lan_r();
-	void jc_lan_w(uint8_t data);
-	void jc_irq_unk_w(uint8_t data);
-	void dendego_speedmeter_w(uint8_t data);
-	void dendego_brakemeter_w(uint8_t data);
+	uint8_t pcbid_r(offs_t offset);
+	uint8_t lan_r();
+	void lan_w(uint8_t data);
+	void irq_unk_w(uint8_t data);
 
 	uint8_t hc11_comm_r();
 	void hc11_comm_w(uint8_t data);
@@ -127,29 +120,52 @@ private:
 	uint16_t dsp_math_unk_r();
 
 	uint16_t taitojc_dsp_idle_skip_r();
-	uint16_t dendego2_dsp_idle_skip_r();
 
-	uint32_t taitojc_palette_r(offs_t offset);
-	void taitojc_palette_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	uint32_t taitojc_tile_r(offs_t offset);
-	uint32_t taitojc_char_r(offs_t offset);
-	void taitojc_tile_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void taitojc_char_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	void tile_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	void char_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 
-	TILE_GET_INFO_MEMBER(taitojc_tile_info);
-	virtual void machine_reset() override ATTR_COLD;
-	virtual void machine_start() override ATTR_COLD;
-	virtual void video_start() override ATTR_COLD;
-	uint32_t screen_update_taitojc(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_dendego(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	INTERRUPT_GEN_MEMBER(taitojc_vblank);
+	TILE_GET_INFO_MEMBER(get_tile_info);
+	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	INTERRUPT_GEN_MEMBER(vblank);
 	void draw_object(bitmap_ind16 &bitmap, const rectangle &cliprect, uint32_t w1, uint32_t w2, uint8_t bank_type);
 	void draw_object_bank(bitmap_ind16 &bitmap, const rectangle &cliprect, uint8_t bank_type, uint8_t pri);
 
-	void dendego_map(address_map &map) ATTR_COLD;
 	void hc11_pgm_map(address_map &map) ATTR_COLD;
 	void taitojc_map(address_map &map) ATTR_COLD;
 	void tms_data_map(address_map &map) ATTR_COLD;
 	void tms_program_map(address_map &map) ATTR_COLD;
 	void cpu_space_map(address_map &map) ATTR_COLD;
+};
+
+// Densha de Go specific, with train controller
+class dendego_state : public taitojc_state
+{
+public:
+	dendego_state(const machine_config &mconfig, device_type type, const char *tag)
+		: taitojc_state(mconfig, type, tag)
+		, m_io_buttons(*this, "BUTTONS")
+	{
+	}
+
+	void dendego(machine_config &config);
+
+	void init_dendego2();
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+
+private:
+	required_ioport m_io_buttons;
+
+	int32_t m_speed_meter = 0;
+	int32_t m_brake_meter = 0;
+
+	void speedmeter_w(uint8_t data);
+	void brakemeter_w(uint8_t data);
+
+	uint16_t dendego2_dsp_idle_skip_r();
+
+	uint32_t screen_update_dendego(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+	void dendego_map(address_map &map) ATTR_COLD;
 };

--- a/src/mame/taito/taitojc.h
+++ b/src/mame/taito/taitojc.h
@@ -5,12 +5,18 @@
   Taito JC System
 
 *************************************************************************/
+#ifndef MAME_TAITO_TAITOJC_H
+#define MAME_TAITO_TAITOJC_H
 
-#include "tc0780fpa.h"
+#pragma once
+
 #include "taitoio.h"
+#include "tc0780fpa.h"
+
 #include "emupal.h"
 #include "screen.h"
 #include "tilemap.h"
+
 
 class taitojc_state : public driver_device
 {
@@ -37,10 +43,10 @@ public:
 	{
 	}
 
-	void taitojc(machine_config &config);
+	void taitojc(machine_config &config) ATTR_COLD;
 
-	void init_dangcurv();
-	void init_taitojc();
+	void init_dangcurv() ATTR_COLD;
+	void init_taitojc() ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
@@ -147,9 +153,9 @@ public:
 	{
 	}
 
-	void dendego(machine_config &config);
+	void dendego(machine_config &config) ATTR_COLD;
 
-	void init_dendego2();
+	void init_dendego2() ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
@@ -169,3 +175,5 @@ private:
 
 	void dendego_map(address_map &map) ATTR_COLD;
 };
+
+#endif // MAME_TAITO_TAITOJC_H

--- a/src/mame/taito/taitojc_v.cpp
+++ b/src/mame/taito/taitojc_v.cpp
@@ -12,7 +12,7 @@
 #include "video/poly.h"
 #include "taitojc.h"
 
-static const gfx_layout taitojc_char_layout =
+static const gfx_layout char_layout =
 {
 	16,16,
 	0x80,
@@ -23,54 +23,24 @@ static const gfx_layout taitojc_char_layout =
 	16*64
 };
 
-TILE_GET_INFO_MEMBER(taitojc_state::taitojc_tile_info)
+TILE_GET_INFO_MEMBER(taitojc_state::get_tile_info)
 {
-	uint32_t val = m_tile_ram[tile_index];
-	int color = (val >> 22) & 0xff;
-	int tile = (val >> 2) & 0x7f;
-	tileinfo.set(m_gfx_index, tile, color, 0);
+	uint32_t const val = m_tile_ram[tile_index];
+	int const color = (val >> 22) & 0xff;
+	int const tile = (val >> 2) & 0x7f;
+	tileinfo.set(0, tile, color, 0);
 }
 
-uint32_t taitojc_state::taitojc_palette_r(offs_t offset)
+void taitojc_state::tile_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	return m_palette_ram[offset];
-}
-
-void taitojc_state::taitojc_palette_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-	int r, g, b;
-	uint32_t color;
-
-	COMBINE_DATA( m_palette_ram + offset );
-
-	color = m_palette_ram[offset];
-	r = (color >>  8) & 0xff;
-	g = (color >> 16) & 0xff;
-	b = (color >>  0) & 0xff;
-
-	m_palette->set_pen_color(offset, rgb_t(r, g, b));
-}
-
-uint32_t taitojc_state::taitojc_tile_r(offs_t offset)
-{
-	return m_tile_ram[offset];
-}
-
-uint32_t taitojc_state::taitojc_char_r(offs_t offset)
-{
-	return m_char_ram[offset];
-}
-
-void taitojc_state::taitojc_tile_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-	COMBINE_DATA(m_tile_ram.get() + offset);
+	COMBINE_DATA(&m_tile_ram[offset]);
 	m_tilemap->mark_tile_dirty(offset);
 }
 
-void taitojc_state::taitojc_char_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+void taitojc_state::char_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	COMBINE_DATA(m_char_ram.get() + offset);
-	m_gfxdecode->gfx(m_gfx_index)->mark_dirty(offset/32);
+	COMBINE_DATA(&m_char_ram[offset]);
+	m_gfxdecode->gfx(0)->mark_dirty(offset/32);
 }
 
 // Object data format:
@@ -122,42 +92,42 @@ void taitojc_state::taitojc_char_w(offs_t offset, uint32_t data, uint32_t mem_ma
 
 void taitojc_state::draw_object(bitmap_ind16 &bitmap, const rectangle &cliprect, uint32_t w1, uint32_t w2, uint8_t bank_type)
 {
-	uint8_t const color_depth = (w2 & 0x10000) >> 16;
-	uint8_t const mask_screen = (w2 & 0x20000) >> 17;
+	uint8_t const color_depth = BIT(w2, 16);
+	uint8_t const mask_screen = BIT(w2, 17);
 
-	uint32_t address = (w2 & 0x7fff) * 0x20;
-	if(w2 & 0x4000)
+	uint32_t address = (w2 & 0x7fff) << 5;
+	if (BIT(w2, 14))
 		address |= 0x40000;
 
 	int x = ((w1 >>  0) & 0x3ff);
-	if(x & 0x200)
+	if (x & 0x200)
 		x |= ~0x1ff;        // sign-extend
 
 	int y = ((w1 >> 16) & 0x3ff);
-	if(y & 0x200)
+	if (y & 0x200)
 		y |= ~0x1ff;        // sign-extend
 
-	int width       = ((w1 >> 10) & 0x3f) * 16;
-	int height      = ((w1 >> 26) & 0x3f) * 16;
-	int palette     = ((w2 >> 22) & 0x7f) << 8;
+	int width         = ((w1 >> 10) & 0x3f) << 4;
+	int height        = ((w1 >> 26) & 0x3f) << 4;
+	int const palette = ((w2 >> 22) & 0x7f) << 8;
 
 	/* TODO: untangle this! */
 	uint32_t const *v;
-	if(address >= 0xff000)
-		v = &m_objlist[(address-0xff000)/4];
-	if(address >= 0xfc000)
-		v = &m_char_ram[(address-0xfc000)/4];
-	else if(address >= 0xf8000)
-		v = &m_tile_ram[(address-0xf8000)/4];
+	if (address >= 0xff000)
+		v = &m_objlist[(address - 0xff000) / 4];
+	if (address >= 0xfc000)
+		v = &m_char_ram[(address - 0xfc000) / 4];
+	else if (address >= 0xf8000)
+		v = &m_tile_ram[(address - 0xf8000) / 4];
 	else
-		v = &m_vram[address/4];
+		v = &m_vram[address / 4];
 	auto const v8 = util::big_endian_cast<u8>(v);
 
 	/* guess, but it's probably doable via a vreg ... */
 	if ((width == 0 || height == 0) && bank_type == 2)
 		width = height = 16;
 
-	if(width == 0 || height == 0)
+	if (width == 0 || height == 0)
 		return;
 
 	int x1 = x;
@@ -197,19 +167,19 @@ void taitojc_state::draw_object(bitmap_ind16 &bitmap, const rectangle &cliprect,
 	}
 
 	/* this bit seems to set up border at left/right of screen (reads at 0xffc00) */
-	if(mask_screen)
+	if (mask_screen)
 	{
-		if(address != 0xffc00)
+		if (address != 0xffc00)
 		{
 			popmessage("mask screen with %08x, contact MAMEdev",address);
 			return;
 		}
 
-		for (int j=y1; j < y2; j++)
+		for (int j = y1; j < y2; j++)
 		{
 			uint16_t *const d = &bitmap.pix(j);
 
-			for (int i=x1; i < x2; i++)
+			for (int i = x1; i < x2; i++)
 			{
 				d[i] = 0x78; //TODO: black
 
@@ -219,14 +189,14 @@ void taitojc_state::draw_object(bitmap_ind16 &bitmap, const rectangle &cliprect,
 			//iy++;
 		}
 	}
-	else if(!color_depth) // Densha de Go 2/2X "credit text", 4bpp
+	else if (!color_depth) // Densha de Go 2/2X "credit text", 4bpp
 	{
-		for (int j=y1; j < y2; j++)
+		for (int j = y1; j < y2; j++)
 		{
 			uint16_t *const d = &bitmap.pix(j);
 			int index = (iy * (width / 2)) + ix;
 
-			for (int i=x1; i < x2; i+=2)
+			for (int i = x1; i < x2; i += 2)
 			{
 				uint8_t pen = (v8[index] & 0xf0) >> 4;
 				if (pen != 0)
@@ -234,7 +204,7 @@ void taitojc_state::draw_object(bitmap_ind16 &bitmap, const rectangle &cliprect,
 
 				pen = v8[index] & 0x0f;
 				if (pen != 0)
-					d[i+1] = palette + pen;
+					d[i + 1] = palette + pen;
 
 				index++;
 			}
@@ -245,14 +215,14 @@ void taitojc_state::draw_object(bitmap_ind16 &bitmap, const rectangle &cliprect,
 	else // 8bpp
 	{
 		{
-			for (int j=y1; j < y2; j++)
+			for (int j = y1; j < y2; j++)
 			{
 				uint16_t *const d = &bitmap.pix(j);
 				int index = (iy * width) + ix;
 
-				for (int i=x1; i < x2; i++)
+				for (int i = x1; i < x2; i++)
 				{
-					uint8_t pen = v8[index];
+					uint8_t const pen = v8[index];
 					if (pen != 0)
 					{
 						d[i] = palette + pen;
@@ -269,23 +239,19 @@ void taitojc_state::draw_object(bitmap_ind16 &bitmap, const rectangle &cliprect,
 
 void taitojc_state::draw_object_bank(bitmap_ind16 &bitmap, const rectangle &cliprect, uint8_t bank_type, uint8_t pri)
 {
-	uint16_t start_offs;
-//  uint8_t double_xy;
-	int i;
-
-	start_offs = ((bank_type+1)*0x400)/4;
-//  double_xy = (m_objlist[(0xd1c+bank_type*0x10)/4] & 0x20000000) >> 29;
+	uint16_t const start_offs = ((bank_type + 1) * 0x400) / 4;
+//  uint8_t const double_xy = BIT(m_objlist[(0xd1c + bank_type * 0x10) / 4], 29);
 
 	/* probably a core bug in there (otherwise objects sticks on screen in Densha de Go) */
-	if(bank_type == 1 && (!(m_objlist[0xfc4/4] & 0x2000)))
+	if ((bank_type == 1) && BIT(~m_objlist[0xfc4/4], 13))
 		return;
 
-	for (i=start_offs-2; i >= (start_offs-0x400/4); i-=2)
+	for (int i = start_offs - 2; i >= (start_offs - 0x400 / 4); i -= 2)
 	{
-		uint32_t w1 = m_objlist[i + 0];
-		uint32_t w2 = m_objlist[i + 1];
+		uint32_t const w1 = m_objlist[i + 0];
+		uint32_t const w2 = m_objlist[i + 1];
 
-		if (((w2 & 0x200000) >> 21) == pri)
+		if (BIT(w2, 21) == pri)
 		{
 			draw_object(bitmap, cliprect, w1, w2, bank_type);
 		}
@@ -295,25 +261,15 @@ void taitojc_state::draw_object_bank(bitmap_ind16 &bitmap, const rectangle &clip
 
 void taitojc_state::video_start()
 {
-	/* find first empty slot to decode gfx */
-	for (m_gfx_index = 0; m_gfx_index < MAX_GFX_ELEMENTS; m_gfx_index++)
-		if (m_gfxdecode->gfx(m_gfx_index) == nullptr)
-			break;
-
-	assert(m_gfx_index != MAX_GFX_ELEMENTS);
-
-	m_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(taitojc_state::taitojc_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
+	m_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(taitojc_state::get_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
 
 	m_tilemap->set_transparent_pen(0);
 
-	m_char_ram = make_unique_clear<uint32_t[]>(0x4000/4);
-	m_tile_ram = make_unique_clear<uint32_t[]>(0x4000/4);
-
 	/* create the char set (gfx will then be updated dynamically from RAM) */
-	m_gfxdecode->set_gfx(m_gfx_index, std::make_unique<gfx_element>(m_palette, taitojc_char_layout, (uint8_t *)m_char_ram.get(), 0, m_palette->entries() / 16, 0));
+	m_gfxdecode->set_gfx(0, std::make_unique<gfx_element>(m_palette, char_layout, (uint8_t *)&m_char_ram[0], 0, m_palette->entries() / 16, 0));
 }
 
-uint32_t taitojc_state::screen_update_taitojc(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t taitojc_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(0, cliprect);
 
@@ -331,32 +287,32 @@ uint32_t taitojc_state::screen_update_taitojc(screen_device &screen, bitmap_ind1
 	draw_object_bank(bitmap, cliprect, 2, 1);
 
 	// text layer
-	if (m_objlist[0xfc4/4] & 0x10000)
+	if (BIT(m_objlist[0xfc4/4], 16))
 		m_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 
 	return 0;
 }
 
-uint32_t taitojc_state::screen_update_dendego(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t dendego_state::screen_update_dendego(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	// update controller state in artwork
-	static const uint8_t dendego_mascon_table[6] = { 0x76, 0x67, 0x75, 0x57, 0x73, 0x37 };
-	static const uint8_t dendego_brake_table[11] = { 0x00, 0x05, 0x1d, 0x35, 0x4d, 0x65, 0x7d, 0x95, 0xad, 0xc5, 0xd4 };
+	static const uint8_t mascon_table[6] = { 0x76, 0x67, 0x75, 0x57, 0x73, 0x37 };
+	static const uint8_t brake_table[11] = { 0x00, 0x05, 0x1d, 0x35, 0x4d, 0x65, 0x7d, 0x95, 0xad, 0xc5, 0xd4 };
 
-	uint8_t btn = (ioport("BUTTONS")->read() & 0x77);
+	uint8_t btn = (m_io_buttons->read() & 0x77);
 	int level;
 	for (level = 5; level > 0; level--)
-		if (btn == dendego_mascon_table[level]) break;
+		if (btn == mascon_table[level]) break;
 
 	if (level != m_counters[0])
 		m_counters[0] = level;
 
 	btn = m_analog_ports[0]->read() & 0xff;
 	for (level = 10; level > 0; level--)
-		if (btn >= dendego_brake_table[level]) break;
+		if (btn >= brake_table[level]) break;
 
 	if (level != m_counters[1])
 		m_counters[1] = level;
 
-	return screen_update_taitojc(screen, bitmap, cliprect);
+	return screen_update(screen, bitmap, cliprect);
 }

--- a/src/mame/taito/taitojc_v.cpp
+++ b/src/mame/taito/taitojc_v.cpp
@@ -99,13 +99,11 @@ void taitojc_state::draw_object(bitmap_ind16 &bitmap, const rectangle &cliprect,
 	if (BIT(w2, 14))
 		address |= 0x40000;
 
-	int x = ((w1 >>  0) & 0x3ff);
-	if (x & 0x200)
-		x |= ~0x1ff;        // sign-extend
+	int x = util((w1 >>  0) & 0x3ff);
+	x = util::sext(x, 10); // sign-extend
 
 	int y = ((w1 >> 16) & 0x3ff);
-	if (y & 0x200)
-		y |= ~0x1ff;        // sign-extend
+	y = util::sext(y, 10); // sign-extend
 
 	int width         = ((w1 >> 10) & 0x3f) << 4;
 	int height        = ((w1 >> 26) & 0x3f) << 4;

--- a/src/mame/taito/taitopjc.cpp
+++ b/src/mame/taito/taitopjc.cpp
@@ -514,8 +514,8 @@ void taitopjc_state::videochip_w(offs_t address, uint32_t data)
 
 		if (address >= 0x1003f000 && address < 0x10040000)
 		{
-			uint32_t const a = (address - 0x1003f000) & 0x7ff;
-			m_tilemap[BIT(address, 11)]->mark_tile_dirty((a * 2));
+			uint32_t const a = address & 0x7ff;
+			m_tilemap[BIT(address, 11)]->mark_tile_dirty((a * 2) + 0);
 			m_tilemap[BIT(address, 11)]->mark_tile_dirty((a * 2) + 1);
 		}
 		m_gfxdecode->gfx(0)->mark_dirty(addr / 64);
@@ -569,17 +569,17 @@ uint64_t taitopjc_state::ppc_common_r(offs_t offset, uint64_t mem_mask)
 {
 	uint64_t r = 0;
 
-	LOGIO("ppc_common_r: %08X, %08X%08X\n", offset, (uint32_t)(mem_mask >> 32), (uint32_t)(mem_mask));
+	LOGIO("ppc_common_r: %08X, %016X\n", offset, mem_mask);
 
 	uint32_t const address = offset * 2;
 
 	if (ACCESSING_BITS_48_63)
 	{
-		r |= (uint64_t)(m_io_share_ram[address]) << 48;
+		r |= uint64_t(m_io_share_ram[address]) << 48;
 	}
 	if (ACCESSING_BITS_16_31)
 	{
-		r |= (uint64_t)(m_io_share_ram[address + 1]) << 16;
+		r |= uint64_t(m_io_share_ram[address + 1]) << 16;
 	}
 
 	return r;

--- a/src/mame/taito/taitopjc.cpp
+++ b/src/mame/taito/taitopjc.cpp
@@ -301,10 +301,18 @@ G)ame Connector, dual row 50 pins
 #define LOG_TLCS_TO_PPC_COMMANDS (1U << 1)
 #define LOG_PPC_TO_TLCS_COMMANDS (1U << 2)
 #define LOG_DISPLAY_LIST         (1U << 3)
+#define LOG_VIDEO                (1U << 4)
+#define LOG_IO                   (1U << 5)
+#define LOG_DSP                  (1U << 6)
+#define LOG_SOUND                (1U << 7)
 
 #define VERBOSE (0)
 #include "logmacro.h"
 
+#define LOGVIDEO(...)  LOGMASKED(LOG_VIDEO, __VA_ARGS__)
+#define LOGIO(...)     LOGMASKED(LOG_IO, __VA_ARGS__)
+#define LOGDSP(...)    LOGMASKED(LOG_DSP, __VA_ARGS__)
+#define LOGSOUND(...)  LOGMASKED(LOG_SOUND, __VA_ARGS__)
 
 namespace {
 
@@ -314,16 +322,20 @@ class taitopjc_state : public driver_device
 {
 public:
 	taitopjc_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_maincpu(*this, "maincpu"),
-		m_iocpu(*this, "iocpu"),
-		m_soundcpu(*this, "mn10200"),
-		m_dsp(*this, "dsp"),
-		m_tc0780fpa(*this, "tc0780fpa"),
-		m_palette(*this, "palette"),
-		m_polyrom(*this, "poly"),
-		m_gfxdecode(*this, "gfxdecode"),
-		m_main_ram(*this, "main_ram")
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_iocpu(*this, "iocpu")
+		, m_soundcpu(*this, "mn10200")
+		, m_dsp(*this, "dsp")
+		, m_tc0780fpa(*this, "tc0780fpa")
+		, m_palette(*this, "palette")
+		, m_polyrom(*this, "poly")
+		, m_gfxdecode(*this, "gfxdecode")
+		, m_main_ram(*this, "main_ram")
+		, m_dsp_ram(*this, "dsp_ram")
+		, m_io_share_ram(*this, "io_share_ram", 0x2000, ENDIANNESS_LITTLE) // or ENDIANNESS_BIG?
+		, m_screen_ram(*this, "screen_ram", 0x40000*4, ENDIANNESS_BIG)
+		, m_paletteram(*this, "paletteram", 0x8000*4, ENDIANNESS_BIG)
 	{ }
 
 	void taitopjc(machine_config &config);
@@ -345,6 +357,10 @@ private:
 	required_memory_region m_polyrom;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_shared_ptr<uint64_t> m_main_ram;
+	required_shared_ptr<uint16_t> m_dsp_ram;
+	memory_share_creator<uint16_t> m_io_share_ram;
+	memory_share_creator<uint32_t> m_screen_ram;
+	memory_share_creator<uint32_t> m_paletteram;
 
 	uint64_t video_r(offs_t offset, uint64_t mem_mask = ~0);
 	void video_w(offs_t offset, uint64_t data, uint64_t mem_mask = ~0);
@@ -357,34 +373,25 @@ private:
 	uint8_t tlcs_sound_r(offs_t offset);
 	void tlcs_sound_w(offs_t offset, uint8_t data);
 	void tlcs_unk_w(offs_t offset, uint16_t data);
-	uint16_t tms_dspshare_r(offs_t offset);
 	void tms_dspshare_w(offs_t offset, uint16_t data);
 	uint16_t dsp_rom_r();
 	void dsp_roml_w(uint16_t data);
 	void dsp_romh_w(uint16_t data);
-	uint32_t screen_update_taitopjc(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	INTERRUPT_GEN_MEMBER(taitopjc_vbi);
+	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	INTERRUPT_GEN_MEMBER(vbi);
 	uint32_t videochip_r(offs_t address);
 	void videochip_w(offs_t address, uint32_t data);
 	void video_exit();
 	[[maybe_unused]] void print_display_list();
-	TILE_GET_INFO_MEMBER(tile_get_info);
-	TILEMAP_MAPPER_MEMBER(tile_scan_layer0);
-	TILEMAP_MAPPER_MEMBER(tile_scan_layer1);
-
-	uint16_t m_dsp_ram[0x1000]{};
-	uint16_t m_io_share_ram[0x2000]{};
-
-	std::unique_ptr<uint32_t[]> m_screen_ram;
-	std::unique_ptr<uint32_t[]> m_pal_ram;
+	template <unsigned Offset> TILE_GET_INFO_MEMBER(get_tile_info);
 
 	tilemap_t *m_tilemap[2]{};
 
 	uint32_t m_video_address = 0;
 
 	uint32_t m_dsp_rom_address = 0;
-	int m_scroll_x = 0;
-	int m_scroll_y = 0;
+	uint16_t m_scroll_x = 0;
+	uint16_t m_scroll_y = 0;
 
 	uint32_t m_tlcs_sound_ptr = 0;
 
@@ -424,30 +431,18 @@ void taitopjc_state::video_exit()
 #endif
 }
 
-TILE_GET_INFO_MEMBER(taitopjc_state::tile_get_info)
+template <unsigned Offset>
+TILE_GET_INFO_MEMBER(taitopjc_state::get_tile_info)
 {
-	uint32_t val = m_screen_ram[0x3f000 + (tile_index/2)];
+	uint32_t val = m_screen_ram[Offset + (tile_index >> 1)];
 
-	if (!(tile_index & 1))
+	if (BIT(~tile_index, 0))
 		val >>= 16;
 
-	int color = (val >> 12) & 0xf;
-	int tile = (val & 0xfff);
-	int flags = 0;
+	int const color = (val >> 12) & 0xf;
+	int const tile = (val & 0xfff);
 
-	tileinfo.set(0, tile, color, flags);
-}
-
-TILEMAP_MAPPER_MEMBER(taitopjc_state::tile_scan_layer0)
-{
-	/* logical (col,row) -> memory offset */
-	return (row * 64) + col;
-}
-
-TILEMAP_MAPPER_MEMBER(taitopjc_state::tile_scan_layer1)
-{
-	/* logical (col,row) -> memory offset */
-	return (row * 64) + col + 4096;
+	tileinfo.set(0, tile, color, 0);
 }
 
 void taitopjc_state::video_start()
@@ -455,7 +450,7 @@ void taitopjc_state::video_start()
 	static const gfx_layout char_layout =
 	{
 		16, 16,
-		4032,
+		4096,
 		8,
 		{ 0,1,2,3,4,5,6,7 },
 		{ 3*8, 2*8, 1*8, 0*8, 7*8, 6*8, 5*8, 4*8, 11*8, 10*8, 9*8, 8*8, 15*8, 14*8, 13*8, 12*8 },
@@ -463,25 +458,25 @@ void taitopjc_state::video_start()
 		8*256
 	};
 
-	m_screen_ram = std::make_unique<uint32_t[]>(0x40000);
-	m_pal_ram = std::make_unique<uint32_t[]>(0x8000);
-
-	m_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(taitopjc_state::tile_get_info)), tilemap_mapper_delegate(*this, FUNC(taitopjc_state::tile_scan_layer0)), 16, 16, 64, 64);
-	m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(taitopjc_state::tile_get_info)), tilemap_mapper_delegate(*this, FUNC(taitopjc_state::tile_scan_layer1)), 16, 16, 64, 64);
+	m_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(taitopjc_state::get_tile_info<0x3f000>)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
+	m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(taitopjc_state::get_tile_info<0x3f800>)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
 	m_tilemap[0]->set_transparent_pen(0);
 	m_tilemap[1]->set_transparent_pen(0);
 
-	m_gfxdecode->set_gfx(0, std::make_unique<gfx_element>(m_palette, char_layout, (uint8_t*)m_screen_ram.get(), 0, m_palette->entries() / 256, 0));
+	m_gfxdecode->set_gfx(0, std::make_unique<gfx_element>(m_palette, char_layout, (uint8_t*)&m_screen_ram[0], 0, m_palette->entries() / 256, 0));
 
-	save_pointer(NAME(m_screen_ram), 0x40000);
-	save_pointer(NAME(m_pal_ram), 0x8000);
+	m_palette->basemem().set(m_paletteram, m_paletteram.bytes(), 32, ENDIANNESS_BIG, 4);
+
+	save_item(NAME(m_video_address));
+	save_item(NAME(m_scroll_x));
+	save_item(NAME(m_scroll_y));
 
 	machine().add_notifier(MACHINE_NOTIFY_EXIT, machine_notify_delegate(&taitopjc_state::video_exit, this));
 }
 
-uint32_t taitopjc_state::screen_update_taitopjc(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t taitopjc_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	bitmap.fill(0x000000, cliprect);
+	bitmap.fill(0, cliprect);
 
 	m_tc0780fpa->draw(bitmap, cliprect);
 
@@ -510,34 +505,20 @@ void taitopjc_state::videochip_w(offs_t address, uint32_t data)
 {
 	if (address >= 0x20000000 && address < 0x20008000)
 	{
-		m_pal_ram[address - 0x20000000] = data;
-
-		int b = (data >> 16) & 0xff;
-		int g = (data >>  8) & 0xff;
-		int r = (data >>  0) & 0xff;
-		m_palette->set_pen_color(address - 0x20000000, rgb_t(r, g, b));
+		m_palette->write32(address - 0x20000000, data);
 	}
 	else if (address >= 0x10000000 && address < 0x10040000)
 	{
-		uint32_t addr = address - 0x10000000;
+		uint32_t const addr = address - 0x10000000;
 		m_screen_ram[addr] = data;
 
-		if (address >= 0x1003f000 && address < 0x1003f800)
+		if (address >= 0x1003f000 && address < 0x10040000)
 		{
-			uint32_t a = address - 0x1003f000;
-			m_tilemap[0]->mark_tile_dirty((a * 2));
-			m_tilemap[0]->mark_tile_dirty((a * 2) + 1);
+			uint32_t const a = (address - 0x1003f000) & 0x7ff;
+			m_tilemap[BIT(address, 11)]->mark_tile_dirty((a * 2));
+			m_tilemap[BIT(address, 11)]->mark_tile_dirty((a * 2) + 1);
 		}
-		else if (address >= 0x1003f800 && address < 0x10040000)
-		{
-			uint32_t a = address - 0x1003f000;
-			m_tilemap[1]->mark_tile_dirty((a * 2));
-			m_tilemap[1]->mark_tile_dirty((a * 2) + 1);
-		}
-		else
-		{
-			m_gfxdecode->gfx(0)->mark_dirty(addr / 64);
-		}
+		m_gfxdecode->gfx(0)->mark_dirty(addr / 64);
 	}
 	else if (address == 0x00000006)
 	{
@@ -546,7 +527,7 @@ void taitopjc_state::videochip_w(offs_t address, uint32_t data)
 	}
 	else
 	{
-		printf("Address %08X = %08X\n", address, data);
+		LOGVIDEO("Video Address %08X = %08X\n", address, data);
 	}
 }
 
@@ -571,7 +552,7 @@ void taitopjc_state::video_w(offs_t offset, uint64_t data, uint64_t mem_mask)
 	{
 		if (ACCESSING_BITS_32_63)
 		{
-			//printf("Address %08X = %08X\n", video_address, (uint32_t)(data >> 32));
+			LOGVIDEO("Video Address %08X = %08X\n", m_video_address, (uint32_t)(data >> 32));
 			videochip_w(m_video_address, (uint32_t)(data >> 32));
 		}
 	}
@@ -587,11 +568,10 @@ void taitopjc_state::video_w(offs_t offset, uint64_t data, uint64_t mem_mask)
 uint64_t taitopjc_state::ppc_common_r(offs_t offset, uint64_t mem_mask)
 {
 	uint64_t r = 0;
-	uint32_t address;
 
-	//logerror("ppc_common_r: %08X, %08X%08X\n", offset, (uint32_t)(mem_mask >> 32), (uint32_t)(mem_mask));
+	LOGIO("ppc_common_r: %08X, %08X%08X\n", offset, (uint32_t)(mem_mask >> 32), (uint32_t)(mem_mask));
 
-	address = offset * 2;
+	uint32_t const address = offset * 2;
 
 	if (ACCESSING_BITS_48_63)
 	{
@@ -599,7 +579,7 @@ uint64_t taitopjc_state::ppc_common_r(offs_t offset, uint64_t mem_mask)
 	}
 	if (ACCESSING_BITS_16_31)
 	{
-		r |= (uint64_t)(m_io_share_ram[address+1]) << 16;
+		r |= (uint64_t)(m_io_share_ram[address + 1]) << 16;
 	}
 
 	return r;
@@ -607,9 +587,9 @@ uint64_t taitopjc_state::ppc_common_r(offs_t offset, uint64_t mem_mask)
 
 void taitopjc_state::ppc_common_w(offs_t offset, uint64_t data, uint64_t mem_mask)
 {
-	uint32_t address = offset * 2;
+	uint32_t const address = offset * 2;
 
-//  logerror("ppc_common_w: %08X, %X, %X\n", offset, data, mem_mask);
+	LOGIO("ppc_common_w: %08X, %X, %X\n", offset, data, mem_mask);
 
 	if (ACCESSING_BITS_48_63)
 	{
@@ -617,7 +597,7 @@ void taitopjc_state::ppc_common_w(offs_t offset, uint64_t data, uint64_t mem_mas
 	}
 	if (ACCESSING_BITS_16_31)
 	{
-		m_io_share_ram[address+1] = (uint16_t)(data >> 16);
+		m_io_share_ram[address + 1] = (uint16_t)(data >> 16);
 	}
 
 	if (offset == 0x7ff && ACCESSING_BITS_48_63)
@@ -640,13 +620,13 @@ uint64_t taitopjc_state::dsp_r(offs_t offset, uint64_t mem_mask)
 
 	if (ACCESSING_BITS_48_63)
 	{
-		int addr = offset * 2;
-		r |= (uint64_t)(m_dsp_ram[addr+0]) << 48;
+		int const addr = offset * 2;
+		r |= (uint64_t)(m_dsp_ram[addr + 0]) << 48;
 	}
 	if (ACCESSING_BITS_16_31)
 	{
-		int addr = offset * 2;
-		r |= (uint64_t)(m_dsp_ram[addr+1]) << 16;
+		int const addr = offset * 2;
+		r |= (uint64_t)(m_dsp_ram[addr + 1]) << 16;
 	}
 
 	return r;
@@ -656,21 +636,21 @@ void taitopjc_state::print_display_list()
 {
 	int ptr = 0;
 
-	uint16_t cmd = m_dsp_ram[0xffe];
+	uint16_t const cmd = m_dsp_ram[0xffe];
 	if (cmd == 0x5245)
 	{
 		logerror("DSP command RE\n");
 		bool end = false;
 		do
 		{
-			uint16_t w = m_dsp_ram[ptr++];
-			if (w & 0x8000)
+			uint16_t const w = m_dsp_ram[ptr++];
+			if (BIT(w, 15))
 			{
-				int count = (w & 0x7fff) + 1;
+				int const count = (w & 0x7fff) + 1;
 				uint16_t d = m_dsp_ram[ptr++];
-				for (int i=0; i < count; i++)
+				for (int i = 0; i < count; i++)
 				{
-					uint16_t s = m_dsp_ram[ptr++];
+					uint16_t const s = m_dsp_ram[ptr++];
 					logerror("   %04X -> [%04X]\n", s, d);
 					d++;
 				}
@@ -706,7 +686,7 @@ void taitopjc_state::print_display_list()
 					default:
 					{
 						logerror("Unknown call %04X\n", w);
-						for (int i=0; i < 10; i++)
+						for (int i = 0; i < 10; i++)
 						{
 							logerror("%04X\n", m_dsp_ram[ptr++]);
 						}
@@ -728,15 +708,14 @@ void taitopjc_state::print_display_list()
 
 void taitopjc_state::dsp_w(offs_t offset, uint64_t data, uint64_t mem_mask)
 {
-	//logerror("dsp_w: %08X, %08X%08X, %08X%08X at %08X\n", offset, (uint32_t)(data >> 32), (uint32_t)(data), (uint32_t)(mem_mask >> 32), (uint32_t)(mem_mask), m_maincpu->pc());
+	LOGDSP("dsp_w: %08X, %08X%08X, %08X%08X at %08X\n", offset, (uint32_t)(data >> 32), (uint32_t)(data), (uint32_t)(mem_mask >> 32), (uint32_t)(mem_mask), m_maincpu->pc());
 
 	if (offset == 0x7fe)
 	{
 		#if 0
 		{
-			int i;
 			FILE *f = fopen("dspram.bin", "wb");
-			for (i=0; i < 0x1000; i++)
+			for (int i = 0; i < 0x1000; i++)
 			{
 				fputc((dsp_ram[i] >> 0) & 0xff, f);
 				fputc((dsp_ram[i] >> 8) & 0xff, f);
@@ -752,13 +731,13 @@ void taitopjc_state::dsp_w(offs_t offset, uint64_t data, uint64_t mem_mask)
 
 	if (ACCESSING_BITS_48_63)
 	{
-		int addr = offset * 2;
-		m_dsp_ram[addr+0] = (data >> 48) & 0xffff;
+		int const addr = offset * 2;
+		m_dsp_ram[addr + 0] = (data >> 48) & 0xffff;
 	}
 	if (ACCESSING_BITS_16_31)
 	{
-		int addr = offset * 2;
-		m_dsp_ram[addr+1] = (data >> 16) & 0xffff;
+		int const addr = offset * 2;
+		m_dsp_ram[addr + 1] = (data >> 16) & 0xffff;
 	}
 }
 
@@ -778,8 +757,8 @@ void taitopjc_state::ppc603e_mem(address_map &map)
 	map(0x40000000, 0x4000000f).rw(FUNC(taitopjc_state::video_r), FUNC(taitopjc_state::video_w));
 	map(0x80000000, 0x80003fff).rw(FUNC(taitopjc_state::dsp_r), FUNC(taitopjc_state::dsp_w));
 	map(0xc0000000, 0xc0003fff).rw(FUNC(taitopjc_state::ppc_common_r), FUNC(taitopjc_state::ppc_common_w));
-	map(0xfe800000, 0xff7fffff).rom().region("gfx1", 0);
-	map(0xffe00000, 0xffffffff).rom().region("user1", 0);
+	map(0xfe800000, 0xff7fffff).rom().region("maingfx", 0);
+	map(0xffe00000, 0xffffffff).rom().region("maindata", 0);
 }
 
 
@@ -787,7 +766,7 @@ void taitopjc_state::ppc603e_mem(address_map &map)
 
 uint8_t taitopjc_state::tlcs_common_r(offs_t offset)
 {
-	if (offset & 1)
+	if (BIT(offset, 0))
 	{
 		return (uint8_t)(m_io_share_ram[offset / 2] >> 8);
 	}
@@ -799,7 +778,7 @@ uint8_t taitopjc_state::tlcs_common_r(offs_t offset)
 
 void taitopjc_state::tlcs_common_w(offs_t offset, uint8_t data)
 {
-	if (offset & 1)
+	if (BIT(offset, 0))
 	{
 		m_io_share_ram[offset / 2] &= 0x00ff;
 		m_io_share_ram[offset / 2] |= (uint16_t)(data) << 8;
@@ -847,7 +826,8 @@ uint8_t taitopjc_state::tlcs_sound_r(offs_t offset)
 	}
 	else if (offset >= 0x80 && offset < 0x100)
 	{
-		m_tlcs_sound_ptr++;
+		if (!machine().side_effects_disabled())
+			m_tlcs_sound_ptr++;
 	}
 
 	return 0;
@@ -855,15 +835,14 @@ uint8_t taitopjc_state::tlcs_sound_r(offs_t offset)
 
 void taitopjc_state::tlcs_sound_w(offs_t offset, uint8_t data)
 {
-//  printf("tlcs_sound_w: %08X, %02X\n", offset, data);
+	LOGSOUND("tlcs_sound_w: %08X, %02X\n", offset, data);
 }
 
 void taitopjc_state::tlcs_unk_w(offs_t offset, uint16_t data)
 {
 	if (offset == 0xc/2)
 	{
-		int reset = (data & 0x4) ? ASSERT_LINE : CLEAR_LINE;
-		m_maincpu->set_input_line(INPUT_LINE_RESET, reset);
+		m_maincpu->set_input_line(INPUT_LINE_RESET, BIT(data, 2));
 	}
 }
 
@@ -901,11 +880,6 @@ void taitopjc_state::mn10200_map(address_map &map)
 
 
 
-uint16_t taitopjc_state::tms_dspshare_r(offs_t offset)
-{
-	return m_dsp_ram[offset];
-}
-
 void taitopjc_state::tms_dspshare_w(offs_t offset, uint16_t data)
 {
 	if (offset == 0xffc)
@@ -919,8 +893,9 @@ uint16_t taitopjc_state::dsp_rom_r()
 {
 	assert(m_dsp_rom_address < 0x800000);
 
-	uint16_t data = ((uint16_t*)m_polyrom->base())[m_dsp_rom_address];
-	m_dsp_rom_address++;
+	uint16_t const data = ((uint16_t*)m_polyrom->base())[m_dsp_rom_address];
+	if (!machine().side_effects_disabled())
+		m_dsp_rom_address++;
 	return data;
 }
 
@@ -947,7 +922,7 @@ void taitopjc_state::tms_data_map(address_map &map)
 {
 	map(0x4000, 0x6fff).rom().region("dspdata", 0x8000);
 	map(0x7000, 0xefff).ram();
-	map(0xf000, 0xffff).rw(FUNC(taitopjc_state::tms_dspshare_r), FUNC(taitopjc_state::tms_dspshare_w));
+	map(0xf000, 0xffff).ram().w(FUNC(taitopjc_state::tms_dspshare_w)).share(m_dsp_ram);
 }
 
 void taitopjc_state::tms_io_map(address_map &map)
@@ -1012,6 +987,9 @@ void taitopjc_state::machine_start()
 	m_maincpu->ppcdrc_set_options(PPCDRC_COMPATIBLE_OPTIONS);
 
 	m_maincpu->ppcdrc_add_fastram(0x00000000, 0x003fffff, false, m_main_ram);
+
+	save_item(NAME(m_dsp_rom_address));
+	save_item(NAME(m_tlcs_sound_ptr));
 }
 
 void taitopjc_state::machine_reset()
@@ -1025,7 +1003,7 @@ void taitopjc_state::machine_reset()
 }
 
 
-INTERRUPT_GEN_MEMBER(taitopjc_state::taitopjc_vbi)
+INTERRUPT_GEN_MEMBER(taitopjc_state::vbi)
 {
 	m_iocpu->set_input_line(TLCS900_INT1, ASSERT_LINE);
 }
@@ -1047,7 +1025,7 @@ void taitopjc_state::taitopjc(machine_config &config)
 	m_iocpu->an_read<2>().set_ioport("ANALOG3");
 	m_iocpu->an_read<3>().set_ioport("ANALOG4");
 	m_iocpu->set_addrmap(AS_PROGRAM, &taitopjc_state::tlcs900h_mem);
-	m_iocpu->set_vblank_int("screen", FUNC(taitopjc_state::taitopjc_vbi));
+	m_iocpu->set_vblank_int("screen", FUNC(taitopjc_state::vbi));
 
 	// TMS320C53 DSP
 	TMS32053(config, m_dsp, 40_MHz_XTAL); // 80MHz rated part, should be 40.0000MHz x 2?
@@ -1068,10 +1046,10 @@ void taitopjc_state::taitopjc(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	screen.set_size(480, 384);
 	screen.set_visarea(0, 479, 0, 383);
-	screen.set_screen_update(FUNC(taitopjc_state::screen_update_taitopjc));
+	screen.set_screen_update(FUNC(taitopjc_state::screen_update));
 	screen.set_palette(m_palette);
 
-	PALETTE(config, m_palette).set_entries(32768);
+	PALETTE(config, m_palette).set_format(palette_device::xBGR_888, 32768);
 	GFXDECODE(config, m_gfxdecode, m_palette, gfxdecode_device::empty);
 
 	TC0780FPA(config, m_tc0780fpa, 0);
@@ -1087,7 +1065,7 @@ void taitopjc_state::init_optiger()
 	rom[BYTE_XOR_LE(0x218)] = 0x00;
 
 #if 0
-	uint32_t *mr = (uint32_t*)memregion("user1")->base();
+	uint32_t *mr = (uint32_t*)memregion("maindata")->base();
 	//mr[(0x23a5c^4)/4] = 0x60000000;
 	mr[((0x513b0-0x40000)^4)/4] = 0x38600001;
 #endif
@@ -1095,7 +1073,7 @@ void taitopjc_state::init_optiger()
 
 
 ROM_START( optiger ) // Ver 2.14 O
-	ROM_REGION64_BE( 0x200000, "user1", 0 )
+	ROM_REGION64_BE( 0x200000, "maindata", 0 )
 	ROM_LOAD32_BYTE( "e63_33-1.ic23", 0x000000, 0x080000, CRC(5ab176e2) SHA1(a0a5b7c0e91928d0a49987f88f6ae647f5cb3e34) ) // PCB silkscreened IC23 (P-HH)
 	ROM_LOAD32_BYTE( "e63_32-1.ic22", 0x000001, 0x080000, CRC(cca8bacc) SHA1(e5a081f5c12a52601745f5b67fe3412033581b00) ) // PCB silkscreened IC22 (P-HL)
 	ROM_LOAD32_BYTE( "e63_31-1.ic8",  0x000002, 0x080000, CRC(ad69e649) SHA1(9fc853d2cb6e7cac87dc06bad91048f191b799c5) ) // PCB silkscreened IC8 (P-LH)
@@ -1116,7 +1094,7 @@ ROM_START( optiger ) // Ver 2.14 O
 	ROM_LOAD16_BYTE( "e63_17-1.ic18", 0x000000, 0x040000, CRC(2a063d5b) SHA1(a2b2fe4d8bad1aef7d9dcc0be607cc4e5bc4f0eb) ) // PCB silkscreened IC18 (S-L)    27C2001
 	ROM_LOAD16_BYTE( "e63_18-1.ic19", 0x000001, 0x040000, CRC(2f590881) SHA1(7fb827a676f45b24380558b0068b76cb858314f6) ) // PCB silkscreened IC19 (S-H)    27C2001
 
-	ROM_REGION64_BE( 0x1000000, "gfx1", 0 ) // mask ROMs
+	ROM_REGION64_BE( 0x1000000, "maingfx", 0 ) // mask ROMs
 	ROM_LOAD32_WORD_SWAP( "e63-21.ic24", 0x000000, 0x400000, CRC(c818b211) SHA1(dce07bfe71a9ba11c3f028a640226c6e59c6aece) ) // PCB silkscreened IC24 (C-H)    23C32000
 	ROM_LOAD32_WORD_SWAP( "e63-15.ic9",  0x000002, 0x400000, CRC(4ec6a2d7) SHA1(2ee6270cff7ea2459121961a29d42e000cee2921) ) // PCB silkscreened IC9 (C-L)    23C32000
 	ROM_LOAD32_WORD_SWAP( "e63-22.ic25", 0x800000, 0x400000, CRC(6d895eb6) SHA1(473795da42fd29841a926f18a93e5992f4feb27c) ) // PCB silkscreened IC25 (M-H)    23C32000
@@ -1144,7 +1122,7 @@ ROM_START( optiger ) // Ver 2.14 O
 ROM_END
 
 ROM_START( optigera ) // Ver 2.10 O
-	ROM_REGION64_BE( 0x200000, "user1", 0 )
+	ROM_REGION64_BE( 0x200000, "maindata", 0 )
 	ROM_LOAD32_BYTE( "e63_33.ic23", 0x000000, 0x080000, CRC(414a7c77) SHA1(d4bbaa13244f1e5f4d418354f40303b9bcc00411) ) // PCB silkscreened IC23 (P-HH)
 	ROM_LOAD32_BYTE( "e63_32.ic22", 0x000001, 0x080000, CRC(8fec33e8) SHA1(1eb0c5613937cd63dc2f54efa33c98920c55f251) ) // PCB silkscreened IC22 (P-HL)
 	ROM_LOAD32_BYTE( "e63_31.ic8",  0x000002, 0x080000, CRC(672f9d4f) SHA1(7eb79963a5d4fb504ffbcf3f51c9bdf659ae053b) ) // PCB silkscreened IC8 (P-LH)
@@ -1165,7 +1143,7 @@ ROM_START( optigera ) // Ver 2.10 O
 	ROM_LOAD16_BYTE( "e63_17.ic18", 0x000000, 0x040000, CRC(daac9e43) SHA1(9ef779a9a5e991ffcfcf30e94ef75329c1030fc2) ) // PCB silkscreened IC18 (S-L)    27C2001
 	ROM_LOAD16_BYTE( "e63_18.ic19", 0x000001, 0x040000, CRC(69c97004) SHA1(65dc3dee0eb7faa1422c38947510abaeb23da7e3) ) // PCB silkscreened IC19 (S-H)    27C2001
 
-	ROM_REGION64_BE( 0x1000000, "gfx1", 0 ) // mask ROMs
+	ROM_REGION64_BE( 0x1000000, "maingfx", 0 ) // mask ROMs
 	ROM_LOAD32_WORD_SWAP( "e63-21.ic24", 0x000000, 0x400000, CRC(c818b211) SHA1(dce07bfe71a9ba11c3f028a640226c6e59c6aece) ) // PCB silkscreened IC24 (C-H)    23C32000
 	ROM_LOAD32_WORD_SWAP( "e63-15.ic9",  0x000002, 0x400000, CRC(4ec6a2d7) SHA1(2ee6270cff7ea2459121961a29d42e000cee2921) ) // PCB silkscreened IC9 (C-L)    23C32000
 	ROM_LOAD32_WORD_SWAP( "e63-22.ic25", 0x800000, 0x400000, CRC(6d895eb6) SHA1(473795da42fd29841a926f18a93e5992f4feb27c) ) // PCB silkscreened IC25 (M-H)    23C32000
@@ -1193,7 +1171,7 @@ ROM_START( optigera ) // Ver 2.10 O
 ROM_END
 
 ROM_START( optigerj ) // ver 2.09 J
-	ROM_REGION64_BE( 0x200000, "user1", 0 )
+	ROM_REGION64_BE( 0x200000, "maindata", 0 )
 	ROM_LOAD32_BYTE( "e63_20.ic23", 0x000000, 0x080000, CRC(04b9820b) SHA1(7a5bd7fd7003948b57d862dc1ecd38ddd25a4ca2) ) // PCB silkscreened IC23 (P-HH)
 	ROM_LOAD32_BYTE( "e63_19.ic22", 0x000001, 0x080000, CRC(a25ff024) SHA1(46e8023a028a384609177d00a47cdfdbbda100be) ) // PCB silkscreened IC22 (P-HL)
 	ROM_LOAD32_BYTE( "e63_14.ic8",  0x000002, 0x080000, CRC(2e68fc12) SHA1(a8ee3e51ad8eb1477db8f67380261cee1dada104) ) // PCB silkscreened IC8 (P-LH)
@@ -1214,7 +1192,7 @@ ROM_START( optigerj ) // ver 2.09 J
 	ROM_LOAD16_BYTE( "e63_17.ic18", 0x000000, 0x040000, CRC(daac9e43) SHA1(9ef779a9a5e991ffcfcf30e94ef75329c1030fc2) ) // PCB silkscreened IC18 (S-L)    27C2001
 	ROM_LOAD16_BYTE( "e63_18.ic19", 0x000001, 0x040000, CRC(69c97004) SHA1(65dc3dee0eb7faa1422c38947510abaeb23da7e3) ) // PCB silkscreened IC19 (S-H)    27C2001
 
-	ROM_REGION64_BE( 0x1000000, "gfx1", 0 ) // mask ROMs
+	ROM_REGION64_BE( 0x1000000, "maingfx", 0 ) // mask ROMs
 	ROM_LOAD32_WORD_SWAP( "e63-21.ic24", 0x000000, 0x400000, CRC(c818b211) SHA1(dce07bfe71a9ba11c3f028a640226c6e59c6aece) ) // PCB silkscreened IC24 (C-H)    23C32000
 	ROM_LOAD32_WORD_SWAP( "e63-15.ic9",  0x000002, 0x400000, CRC(4ec6a2d7) SHA1(2ee6270cff7ea2459121961a29d42e000cee2921) ) // PCB silkscreened IC9 (C-L)    23C32000
 	ROM_LOAD32_WORD_SWAP( "e63-22.ic25", 0x800000, 0x400000, CRC(6d895eb6) SHA1(473795da42fd29841a926f18a93e5992f4feb27c) ) // PCB silkscreened IC25 (M-H)    23C32000
@@ -1242,7 +1220,7 @@ ROM_START( optigerj ) // ver 2.09 J
 ROM_END
 
 ROM_START( optigersm ) // Second Mission ver 2.02 J (build date shows 1999 but still (c) 1998)
-	ROM_REGION64_BE( 0x200000, "user1", 0 )
+	ROM_REGION64_BE( 0x200000, "maindata", 0 )
 	ROM_LOAD32_BYTE( "e63_37.ic23", 0x000000, 0x080000, CRC(16692400) SHA1(0d9d6e90c763de66c2a99790cfe22e11c5d7ec42) ) // PCB silkscreened IC23 (P-HH)
 	ROM_LOAD32_BYTE( "e63_36.ic22", 0x000001, 0x080000, CRC(99d6eed1) SHA1(96d7cff9fe5bedf79d3eaef0f19a4c69d0d233bf) ) // PCB silkscreened IC22 (P-HL)
 	ROM_LOAD32_BYTE( "e63_35.ic8",  0x000002, 0x080000, CRC(85468b85) SHA1(7b24fb6eca29afbfe3ad0e6943145782d8d3b103) ) // PCB silkscreened IC8 (P-LH)
@@ -1263,7 +1241,7 @@ ROM_START( optigersm ) // Second Mission ver 2.02 J (build date shows 1999 but s
 	ROM_LOAD16_BYTE( "e63_17-1.ic18", 0x000000, 0x040000, CRC(2a063d5b) SHA1(a2b2fe4d8bad1aef7d9dcc0be607cc4e5bc4f0eb) ) // PCB silkscreened IC18 (S-L)    27C2001
 	ROM_LOAD16_BYTE( "e63_18-1.ic19", 0x000001, 0x040000, CRC(2f590881) SHA1(7fb827a676f45b24380558b0068b76cb858314f6) ) // PCB silkscreened IC19 (S-H)    27C2001
 
-	ROM_REGION64_BE( 0x1000000, "gfx1", 0 ) // mask ROMs
+	ROM_REGION64_BE( 0x1000000, "maingfx", 0 ) // mask ROMs
 	ROM_LOAD32_WORD_SWAP( "e63-21.ic24", 0x000000, 0x400000, CRC(c818b211) SHA1(dce07bfe71a9ba11c3f028a640226c6e59c6aece) ) // PCB silkscreened IC24 (C-H)    23C32000
 	ROM_LOAD32_WORD_SWAP( "e63-15.ic9",  0x000002, 0x400000, CRC(4ec6a2d7) SHA1(2ee6270cff7ea2459121961a29d42e000cee2921) ) // PCB silkscreened IC9 (C-L)    23C32000
 	ROM_LOAD32_WORD_SWAP( "e63-22.ic25", 0x800000, 0x400000, CRC(6d895eb6) SHA1(473795da42fd29841a926f18a93e5992f4feb27c) ) // PCB silkscreened IC25 (M-H)    23C32000

--- a/src/mame/taito/tc0780fpa.h
+++ b/src/mame/taito/tc0780fpa.h
@@ -32,8 +32,8 @@ public:
 	void swap_buffers();
 
 private:
-	std::unique_ptr<bitmap_ind16> m_fb[2];
-	std::unique_ptr<bitmap_ind16> m_zb;
+	bitmap_ind16 m_fb[2];
+	bitmap_ind16 m_zb;
 	const uint8_t *m_texture;
 
 	rectangle m_cliprect;
@@ -64,14 +64,14 @@ protected:
 private:
 	std::unique_ptr<uint8_t[]> m_texture;
 	std::unique_ptr<uint16_t[]> m_poly_fifo;
-	int m_poly_fifo_ptr = 0;
+	int32_t m_poly_fifo_ptr = 0;
 
 	std::unique_ptr<tc0780fpa_renderer> m_renderer;
 
 	uint16_t m_tex_address = 0;
 	uint16_t m_tex_offset = 0;
-	int m_texbase_x = 0;
-	int m_texbase_y = 0;
+	int32_t m_texbase_x = 0;
+	int32_t m_texbase_y = 0;
 };
 
 DECLARE_DEVICE_TYPE(TC0780FPA, tc0780fpa_device)


### PR DESCRIPTION
Common:
- Reduce preprocessor defines
- Suppress side effects for debugger reads
- Make some arrays to memory_share and shared_ptr
- Fix naming
- Make some variables constant
- Fix typename for fix save state
- Fix spacing
- Use set_format for palette
- Reduce duplicates
- Reduce unnecessary variables

taito/taitojc.cpp:
- Split dendego* driver state class via controller config
- Reduce literal tag usage
- Make some arrays to shared_ptr
- Reduce runtime tag lookups

taito/taitopjc.cpp:
- Fix gfx amount for fix OOB gfx access in tilemap
- Use logmacro for logging
- Add items in save state
- Add notes

taito/tc0780fpa.cpp:
- Use plain type for bitmaps