### PR TITLE
taito/taito_f2.cpp, taito/tc0280grd.cpp: Updates/Cleanups:

### DIFF
--- a/src/mame/taito/taito_f2.cpp
+++ b/src/mame/taito/taito_f2.cpp
@@ -283,33 +283,33 @@ Notes:
 
 void taitof2_state::coin_nibble_w(u8 data)
 {
-	machine().bookkeeping().coin_lockout_w(0, ~data & 0x01);
-	machine().bookkeeping().coin_lockout_w(1, ~data & 0x02);
-	machine().bookkeeping().coin_counter_w(0,  data & 0x04);
-	machine().bookkeeping().coin_counter_w(1,  data & 0x08);
+	machine().bookkeeping().coin_lockout_w(0, BIT(~data, 0));
+	machine().bookkeeping().coin_lockout_w(1, BIT(~data, 1));
+	machine().bookkeeping().coin_counter_w(0, BIT( data, 2));
+	machine().bookkeeping().coin_counter_w(1, BIT( data, 3));
 }
 
 void taitof2_state::growl_coin_word_w(u8 data)/* what about coins 3&4 ?? */
 {
-	machine().bookkeeping().coin_lockout_w(0, ~data & 0x01);
-	machine().bookkeeping().coin_lockout_w(1, ~data & 0x02);
-	machine().bookkeeping().coin_counter_w(0,  data & 0x04);
-	machine().bookkeeping().coin_counter_w(1,  data & 0x08);
+	machine().bookkeeping().coin_lockout_w(0, BIT(~data, 0));
+	machine().bookkeeping().coin_lockout_w(1, BIT(~data, 1));
+	machine().bookkeeping().coin_counter_w(0, BIT( data, 2));
+	machine().bookkeeping().coin_counter_w(1, BIT( data, 3));
 }
 
 void taitof2_state::_4p_coin_word_w(u8 data)
 {
-	machine().bookkeeping().coin_lockout_w(0, ~data & 0x01);
-	machine().bookkeeping().coin_lockout_w(1, ~data & 0x02);
-	machine().bookkeeping().coin_lockout_w(2, ~data & 0x04);
-	machine().bookkeeping().coin_lockout_w(3, ~data & 0x08);
-	machine().bookkeeping().coin_counter_w(0,  data & 0x10);
-	machine().bookkeeping().coin_counter_w(1,  data & 0x20);
-	machine().bookkeeping().coin_counter_w(2,  data & 0x40);
-	machine().bookkeeping().coin_counter_w(3,  data & 0x80);
+	machine().bookkeeping().coin_lockout_w(0, BIT(~data, 0));
+	machine().bookkeeping().coin_lockout_w(1, BIT(~data, 1));
+	machine().bookkeeping().coin_lockout_w(2, BIT(~data, 2));
+	machine().bookkeeping().coin_lockout_w(3, BIT(~data, 3));
+	machine().bookkeeping().coin_counter_w(0, BIT( data, 4));
+	machine().bookkeeping().coin_counter_w(1, BIT( data, 5));
+	machine().bookkeeping().coin_counter_w(2, BIT( data, 6));
+	machine().bookkeeping().coin_counter_w(3, BIT( data, 7));
 }
 
-u16 taitof2_state::cameltry_paddle_r(offs_t offset)
+u16 cameltry_state::paddle_r(offs_t offset)
 {
 	int curr, res = 0xff;
 
@@ -328,58 +328,46 @@ u16 taitof2_state::cameltry_paddle_r(offs_t offset)
 			return res;
 	}
 
-	logerror("CPU #0 PC %06x: warning - read unmapped paddle offset %06x\n", m_maincpu->pc(), offset);
+	if (!machine().side_effects_disabled())
+		logerror("CPU #0 PC %06x: warning - read unmapped paddle offset %06x\n", m_maincpu->pc(), offset);
 
 	return 0;
 }
 
-u16 taitof2_state::mjnquest_dsw_r(offs_t offset)
+u16 mjnquest_state::dsw_r(offs_t offset)
 {
 	switch (offset)
 	{
 		case 0x00:
 		{
-			return (m_io_in[5]->read() << 8) + m_io_dswa->read();   /* DSW A + coin */
+			return (m_io_in[5]->read() << 8) + m_io_dsw[0]->read();   /* DSW A + coin */
 		}
 
 		case 0x01:
 		{
-			return (m_io_in[6]->read() << 8) + m_io_dswb->read();   /* DSW B + coin */
+			return (m_io_in[6]->read() << 8) + m_io_dsw[1]->read();   /* DSW B + coin */
 		}
 	}
 
-	logerror("CPU #0 PC %06x: warning - read unmapped dsw_r offset %06x\n", m_maincpu->pc(), offset);
+	if (!machine().side_effects_disabled())
+		logerror("CPU #0 PC %06x: warning - read unmapped dsw_r offset %06x\n", m_maincpu->pc(), offset);
 
 	return 0xff;
 }
 
-u16 taitof2_state::mjnquest_input_r()
+u16 mjnquest_state::input_r()
 {
-	switch (m_mjnquest_input)
+	u16 ret = 0xffff;
+
+	for (int i = 0; i < 5; i++)
 	{
-		case 0x01:
-			return m_io_in[0]->read();
-
-		case 0x02:
-			return m_io_in[1]->read();
-
-		case 0x04:
-			return m_io_in[2]->read();
-
-		case 0x08:
-			return m_io_in[3]->read();
-
-		case 0x10:
-			return m_io_in[4]->read();
-
+		if (BIT(m_mjnquest_input, i))
+			ret &= m_io_in[i]->read();
 	}
-
-	logerror("CPU #0 mjnquest_input %06x: warning - read unknown input %06x\n", m_maincpu->pc(), m_mjnquest_input);
-
-	return 0xff;
+	return ret;
 }
 
-void taitof2_state::mjnquest_inputselect_w(u16 data)
+void mjnquest_state::inputselect_w(u16 data)
 {
 	m_mjnquest_input = (data >> 6);
 }
@@ -539,14 +527,14 @@ INTERRUPT_GEN_MEMBER(taitof2_state::interrupt)
 	device.execute().set_input_line(5, HOLD_LINE);
 }
 
-INTERRUPT_GEN_MEMBER(taitof2_state::megab_interrupt)
+INTERRUPT_GEN_MEMBER(megablst_state::megab_interrupt)
 {
 	interrupt(device);
 	m_cchip->ext_interrupt(ASSERT_LINE);
 	m_cchip_irq_clear->adjust(attotime::zero);
 }
 
-TIMER_DEVICE_CALLBACK_MEMBER(taitof2_state::cchip_irq_clear_cb)
+TIMER_DEVICE_CALLBACK_MEMBER(megablst_state::cchip_irq_clear_cb)
 {
 	m_cchip->ext_interrupt(CLEAR_LINE);
 }
@@ -567,23 +555,26 @@ void taitof2_state::sound_bankswitch_w(u8 data)
 }
 
 
-u8 taitof2_state::driveout_sound_command_r()
+u8 driveout_state::sound_command_r()
 {
-	m_audiocpu->set_input_line(0, CLEAR_LINE);
-//  logerror("sound IRQ OFF (sound command=%02x)\n", m_driveout_sound_latch);
-	return m_driveout_sound_latch;
+	if (!machine().side_effects_disabled())
+	{
+		m_audiocpu->set_input_line(0, CLEAR_LINE);
+		//logerror("sound IRQ OFF (sound command=%02x)\n", m_sound_latch);
+	}
+	return m_sound_latch;
 }
 
 
-void taitof2_state::oki_bank_w(u8 data)
+void driveout_state::oki_bank_w(u8 data)
 {
-	if (data & 4)
+	if (BIT(data, 2))
 	{
 		m_okibank->set_entry((data & 3));
 	}
 }
 
-void taitof2_state::driveout_sound_command_w(offs_t offset, u8 data)
+void driveout_state::sound_command_w(offs_t offset, u8 data)
 {
 	if (offset == 0)
 	{
@@ -591,13 +582,13 @@ void taitof2_state::driveout_sound_command_w(offs_t offset, u8 data)
 	}
 	else
 	{
-		if (m_nibble == 0)
+		if (!m_nibble)
 		{
-			m_driveout_sound_latch = (data & 0x0f) | (m_driveout_sound_latch & 0xf0);
+			m_sound_latch = (data & 0x0f) | (m_sound_latch & 0xf0);
 		}
 		else
 		{
-			m_driveout_sound_latch = ((data << 4) & 0xf0) | (m_driveout_sound_latch & 0x0f);
+			m_sound_latch = ((data << 4) & 0xf0) | (m_sound_latch & 0x0f);
 			m_audiocpu->set_input_line(0, ASSERT_LINE);
 		}
 	}
@@ -619,11 +610,11 @@ void taitof2_state::finalb_map(address_map &map)
 	map(0x800000, 0x80ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x810000, 0x81ffff).nopw();   /* error in game init code ? */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
 	map(0xb00002, 0xb00003).nopw();   /* ?? */
 }
 
-void taitof2_state::dondokod_map(address_map &map)
+void dondokod_state::dondokod_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
 	map(0x100000, 0x10ffff).ram();
@@ -633,13 +624,13 @@ void taitof2_state::dondokod_map(address_map &map)
 	map(0x320002, 0x320002).rw("tc0140syt", FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0x800000, 0x80ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
-	map(0xa00000, 0xa01fff).rw(m_tc0280grd, FUNC(tc0280grd_device::tc0280grd_word_r), FUNC(tc0280grd_device::tc0280grd_word_w));    /* ROZ tilemap */
-	map(0xa02000, 0xa0200f).w(m_tc0280grd, FUNC(tc0280grd_device::tc0280grd_ctrl_word_w));
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
+	map(0xa00000, 0xa01fff).rw(m_tc0280grd, FUNC(tc0280grd_device::word_r), FUNC(tc0280grd_device::word_w));    /* ROZ tilemap */
+	map(0xa02000, 0xa0200f).w(m_tc0280grd, FUNC(tc0280grd_device::ctrl_word_w));
 	map(0xb00000, 0xb0001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0x00ff);  /* ?? */
 }
 
-void taitof2_state::megab_map(address_map &map)
+void megablst_state::megab_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
 	map(0x100000, 0x100000).w("tc0140syt", FUNC(tc0140syt_device::master_port_w));
@@ -653,7 +644,7 @@ void taitof2_state::megab_map(address_map &map)
 	map(0x600000, 0x60ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x610000, 0x61ffff).ram();   /* unused? */
 	map(0x620000, 0x62000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x800000, 0x80ffff).ram().share("spriteram");
+	map(0x800000, 0x80ffff).ram().share(m_spriteram);
 }
 
 void taitof2_state::thundfox_map(address_map &map)
@@ -668,28 +659,28 @@ void taitof2_state::thundfox_map(address_map &map)
 	map(0x420000, 0x42000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 	map(0x500000, 0x50ffff).rw(m_tc0100scn[1], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));  /* tilemaps */
 	map(0x520000, 0x52000f).rw(m_tc0100scn[1], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x600000, 0x60ffff).ram().share("spriteram");
+	map(0x600000, 0x60ffff).ram().share(m_spriteram);
 	map(0x800000, 0x80001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0xff00);
 }
 
-void taitof2_state::cameltry_map(address_map &map)
+void cameltry_state::cameltry_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();
 	map(0x100000, 0x10ffff).ram();
 	map(0x200000, 0x201fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x300000, 0x30000f).rw(m_tc0220ioc, FUNC(tc0220ioc_device::read), FUNC(tc0220ioc_device::write)).umask16(0x00ff);
-	map(0x300018, 0x30001f).r(FUNC(taitof2_state::cameltry_paddle_r));
+	map(0x300018, 0x30001f).r(FUNC(cameltry_state::paddle_r));
 	map(0x320000, 0x320000).w("tc0140syt", FUNC(tc0140syt_device::master_port_w));
 	map(0x320002, 0x320002).rw("tc0140syt", FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0x800000, 0x813fff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
-	map(0xa00000, 0xa01fff).rw(m_tc0280grd, FUNC(tc0280grd_device::tc0280grd_word_r), FUNC(tc0280grd_device::tc0280grd_word_w));    /* ROZ tilemap */
-	map(0xa02000, 0xa0200f).w(m_tc0280grd, FUNC(tc0280grd_device::tc0280grd_ctrl_word_w));
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
+	map(0xa00000, 0xa01fff).rw(m_tc0280grd, FUNC(tc0280grd_device::word_r), FUNC(tc0280grd_device::word_w));    /* ROZ tilemap */
+	map(0xa02000, 0xa0200f).w(m_tc0280grd, FUNC(tc0280grd_device::ctrl_word_w));
 	map(0xd00000, 0xd0001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0x00ff);  /* ?? */
 }
 
-void taitof2_state::driftoutct_map(address_map &map)
+void cameltry_state::driftoutct_map(address_map &map)
 {
 	cameltry_map(map);
 
@@ -699,20 +690,20 @@ void taitof2_state::driftoutct_map(address_map &map)
 	map(0x30001a, 0x30001b).portr("PADDLE2");
 }
 
-void taitof2_state::cameltrya_map(address_map &map)
+void cameltry_state::cameltrya_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();
 	map(0x100000, 0x10ffff).ram();
 	map(0x200000, 0x201fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x300000, 0x30000f).rw(m_tc0220ioc, FUNC(tc0220ioc_device::read), FUNC(tc0220ioc_device::write)).umask16(0x00ff);
-	map(0x300018, 0x30001f).r(FUNC(taitof2_state::cameltry_paddle_r));
+	map(0x300018, 0x30001f).r(FUNC(cameltry_state::paddle_r));
 	map(0x320000, 0x320000).w("ciu", FUNC(pc060ha_device::master_port_w));
 	map(0x320002, 0x320002).rw("ciu", FUNC(pc060ha_device::master_comm_r), FUNC(pc060ha_device::master_comm_w));
 	map(0x800000, 0x813fff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
-	map(0xa00000, 0xa01fff).rw(m_tc0280grd, FUNC(tc0280grd_device::tc0280grd_word_r), FUNC(tc0280grd_device::tc0280grd_word_w));    /* ROZ tilemap */
-	map(0xa02000, 0xa0200f).w(m_tc0280grd, FUNC(tc0280grd_device::tc0280grd_ctrl_word_w));
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
+	map(0xa00000, 0xa01fff).rw(m_tc0280grd, FUNC(tc0280grd_device::word_r), FUNC(tc0280grd_device::word_w));    /* ROZ tilemap */
+	map(0xa02000, 0xa0200f).w(m_tc0280grd, FUNC(tc0280grd_device::ctrl_word_w));
 	map(0xd00000, 0xd0001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0x00ff);  /* ?? */
 }
 
@@ -726,7 +717,7 @@ void taitof2_state::qtorimon_map(address_map &map)
 	map(0x600002, 0x600002).rw("tc0140syt", FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0x800000, 0x80ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
 	map(0x910000, 0x9120ff).nopw();   /* error in init code ? */
 }
 
@@ -740,7 +731,7 @@ void taitof2_state::liquidk_map(address_map &map)
 	map(0x320003, 0x320003).rw("tc0140syt", FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0x800000, 0x80ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
 	map(0xb00000, 0xb0001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0x00ff);  /* ?? */
 }
 
@@ -763,7 +754,7 @@ void taitof2_state::quizhq_map(address_map &map)
 	map(0x800000, 0x80ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x810000, 0x81ffff).nopw();   /* error in init code ? */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
 }
 
 void taitof2_state::ssi_map(address_map &map)
@@ -777,7 +768,7 @@ void taitof2_state::ssi_map(address_map &map)
 //  map(0x500000, 0x500001).nopw();   /* ?? */
 	map(0x600000, 0x60ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps (not used) */
 	map(0x620000, 0x62000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x800000, 0x80ffff).ram().share("spriteram");   /* sprite ram */
+	map(0x800000, 0x80ffff).ram().share(m_spriteram);   /* sprite ram */
 }
 
 void taitof2_state::gunfront_map(address_map &map)
@@ -790,7 +781,7 @@ void taitof2_state::gunfront_map(address_map &map)
 	map(0x320002, 0x320002).rw("tc0140syt", FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0x800000, 0x80ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
 //  map(0xa00000, 0xa00001).nopw();   /* ?? */
 	map(0xb00000, 0xb0001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0x00ff);  /* ?? */
 }
@@ -815,35 +806,35 @@ void taitof2_state::growl_map(address_map &map)
 	map(0x50c000, 0x50c00f).portr("IN4");
 	map(0x800000, 0x80ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
 	map(0xb00000, 0xb0001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0x00ff);  /* ?? */
 }
 
-void taitof2_state::mjnquest_map(address_map &map)
+void mjnquest_state::mjnquest_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();
 	map(0x110000, 0x11ffff).ram();   /* "sram" */
 	map(0x120000, 0x12ffff).ram();
 	map(0x200000, 0x200007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));    /* palette */
-	map(0x300000, 0x30000f).r(FUNC(taitof2_state::mjnquest_dsw_r));
-	map(0x310000, 0x310001).r(FUNC(taitof2_state::mjnquest_input_r));
-	map(0x320000, 0x320001).w(FUNC(taitof2_state::mjnquest_inputselect_w));
+	map(0x300000, 0x30000f).r(FUNC(mjnquest_state::dsw_r));
+	map(0x310000, 0x310001).r(FUNC(mjnquest_state::input_r));
+	map(0x320000, 0x320001).w(FUNC(mjnquest_state::inputselect_w));
 	map(0x330000, 0x330001).nopw();   /* watchdog ? */
 	map(0x350000, 0x350001).nopw();   /* watchdog ? */
 	map(0x360000, 0x360000).w("tc0140syt", FUNC(tc0140syt_device::master_port_w));
 	map(0x360002, 0x360002).rw("tc0140syt", FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
-	map(0x380001, 0x380001).w(FUNC(taitof2_state::mjnquest_gfxbank_w));   /* scr gfx bank select */
+	map(0x380001, 0x380001).w(FUNC(mjnquest_state::gfxbank_w));   /* scr gfx bank select */
 	map(0x400000, 0x40ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x420000, 0x42000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x500000, 0x50ffff).ram().share("spriteram");
+	map(0x500000, 0x50ffff).ram().share(m_spriteram);
 }
 
-void taitof2_state::footchmp_map(address_map &map)
+void footchmp_state::footchmp_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
 	map(0x100000, 0x10ffff).ram();
-	map(0x200000, 0x20ffff).ram().share("spriteram");
-	map(0x300000, 0x30000f).w(FUNC(taitof2_state::spritebank_w)); /* updated at $a6e, off irq5 */
+	map(0x200000, 0x20ffff).ram().share(m_spriteram);
+	map(0x300000, 0x30000f).w(FUNC(footchmp_state::spritebank_w)); /* updated at $a6e, off irq5 */
 	map(0x400000, 0x40ffff).rw(m_tc0480scp, FUNC(tc0480scp_device::ram_r), FUNC(tc0480scp_device::ram_w));     /* tilemaps */
 	map(0x430000, 0x43002f).rw(m_tc0480scp, FUNC(tc0480scp_device::ctrl_r), FUNC(tc0480scp_device::ctrl_w));
 	map(0x500000, 0x50001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0x00ff);  /* 500002 written like a watchdog?! */
@@ -864,7 +855,7 @@ void taitof2_state::koshien_map(address_map &map)
 	map(0x320002, 0x320002).rw("tc0140syt", FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0x800000, 0x80ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
 	map(0xa20000, 0xa20001).w(FUNC(taitof2_state::koshien_spritebank_w));
 	map(0xb00000, 0xb0001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0xff00);
 }
@@ -877,10 +868,10 @@ void taitof2_state::yuyugogo_map(address_map &map)
 	map(0x400002, 0x400002).rw("tc0140syt", FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0x800000, 0x80ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
 	map(0xa00000, 0xa01fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0xb00000, 0xb10fff).ram();   /* deliberate writes to $b10xxx, I think */
-	map(0xc00000, 0xc01fff).w(FUNC(taitof2_state::sprite_extension_w)).share("sprite_ext");
+	map(0xc00000, 0xc01fff).w(FUNC(taitof2_state::sprite_extension_w)).share(m_sprite_extension);
 	map(0xd00000, 0xdfffff).rom().region("extra", 0);
 }
 
@@ -896,7 +887,7 @@ void taitof2_state::ninjak_map(address_map &map)
 	map(0x600000, 0x60000f).w(FUNC(taitof2_state::spritebank_w));
 	map(0x800000, 0x80ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
 	map(0xb00000, 0xb0001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0x00ff);  /* b00002 written like a watchdog?! */
 }
 
@@ -918,7 +909,7 @@ void taitof2_state::solfigtr_map(address_map &map)
 	map(0x504000, 0x504001).nopw();    /* unknown... various values */
 	map(0x800000, 0x80ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
 	map(0xb00000, 0xb0001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0x00ff);  /* ?? */
 }
 
@@ -930,34 +921,34 @@ void taitof2_state::qzquest_map(address_map &map)
 	map(0x300003, 0x300003).rw("tc0140syt", FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0x400000, 0x401fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x500000, 0x50ffff).ram();
-	map(0x600000, 0x60ffff).ram().share("spriteram");
+	map(0x600000, 0x60ffff).ram().share(m_spriteram);
 	map(0x700000, 0x70ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x720000, 0x72000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 }
 
-void taitof2_state::pulirula_map(address_map &map)
+void dondokod_state::pulirula_map(address_map &map)
 {
 	map(0x000000, 0x0bffff).rom();
 	map(0x200000, 0x200000).w("tc0140syt", FUNC(tc0140syt_device::master_port_w));
 	map(0x200002, 0x200002).rw("tc0140syt", FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0x300000, 0x30ffff).ram();
-	map(0x400000, 0x401fff).rw(m_tc0430grw, FUNC(tc0280grd_device::tc0430grw_word_r), FUNC(tc0280grd_device::tc0430grw_word_w));    /* ROZ tilemap */
-	map(0x402000, 0x40200f).w(m_tc0430grw, FUNC(tc0280grd_device::tc0430grw_ctrl_word_w));
+	map(0x400000, 0x401fff).rw(m_tc0430grw, FUNC(tc0430grw_device::word_r), FUNC(tc0430grw_device::word_w));    /* ROZ tilemap */
+	map(0x402000, 0x40200f).w(m_tc0430grw, FUNC(tc0430grw_device::ctrl_word_w));
 //  map(0x500000, 0x500001).nopw();   /* ??? */
-	map(0x600000, 0x603fff).w(FUNC(taitof2_state::sprite_extension_w)).share("sprite_ext");
+	map(0x600000, 0x603fff).w(FUNC(dondokod_state::sprite_extension_w)).share(m_sprite_extension);
 	map(0x700000, 0x701fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x800000, 0x80ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
 	map(0xa00000, 0xa0001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0xff00);
 	map(0xb00000, 0xb0000f).rw(m_tc0510nio, FUNC(tc0510nio_device::halfword_r), FUNC(tc0510nio_device::halfword_w));
 }
 
-void taitof2_state::metalb_map(address_map &map)
+void footchmp_state::metalb_map(address_map &map)
 {
 	map(0x000000, 0x0bffff).rom();
 	map(0x100000, 0x10ffff).ram();
-	map(0x300000, 0x30ffff).ram().share("spriteram");
+	map(0x300000, 0x30ffff).ram().share(m_spriteram);
 //  map(0x42000c, 0x42000f).nopw();   /* zeroed */
 	map(0x500000, 0x50ffff).rw(m_tc0480scp, FUNC(tc0480scp_device::ram_r), FUNC(tc0480scp_device::ram_w));     /* tilemaps */
 	map(0x530000, 0x53002f).rw(m_tc0480scp, FUNC(tc0480scp_device::ctrl_r), FUNC(tc0480scp_device::ctrl_w));
@@ -977,7 +968,7 @@ void taitof2_state::qzchikyu_map(address_map &map)
 	map(0x300003, 0x300003).rw("tc0140syt", FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0x400000, 0x401fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x500000, 0x50ffff).ram();
-	map(0x600000, 0x60ffff).ram().share("spriteram");
+	map(0x600000, 0x60ffff).ram().share(m_spriteram);
 	map(0x700000, 0x70ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x720000, 0x72000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 }
@@ -986,7 +977,7 @@ void taitof2_state::yesnoj_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
 	map(0x200000, 0x20ffff).ram();
-	map(0x400000, 0x40ffff).ram().share("spriteram");
+	map(0x400000, 0x40ffff).ram().share(m_spriteram);
 	map(0x500000, 0x50ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x520000, 0x52000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 	map(0x600000, 0x601fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
@@ -1002,12 +993,12 @@ void taitof2_state::yesnoj_map(address_map &map)
 	map(0xd00000, 0xd00001).nopw();   /* lots of similar writes */
 }
 
-void taitof2_state::deadconx_map(address_map &map)
+void footchmp_state::deadconx_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();
 	map(0x100000, 0x10ffff).ram();
-	map(0x200000, 0x20ffff).ram().share("spriteram");
-	map(0x300000, 0x30000f).w(FUNC(taitof2_state::spritebank_w));
+	map(0x200000, 0x20ffff).ram().share(m_spriteram);
+	map(0x300000, 0x30000f).w(FUNC(footchmp_state::spritebank_w));
 	map(0x400000, 0x40ffff).rw(m_tc0480scp, FUNC(tc0480scp_device::ram_r), FUNC(tc0480scp_device::ram_w));     /* tilemaps */
 //    map(0x42000c, 0x42000f).nopw();   /* zeroed */
 	map(0x430000, 0x43002f).rw(m_tc0480scp, FUNC(tc0480scp_device::ctrl_r), FUNC(tc0480scp_device::ctrl_w));
@@ -1023,11 +1014,11 @@ void taitof2_state::dinorex_map(address_map &map)
 {
 	map(0x000000, 0x2fffff).rom();
 	map(0x300000, 0x30000f).rw(m_tc0510nio, FUNC(tc0510nio_device::halfword_r), FUNC(tc0510nio_device::halfword_w));
-	map(0x400000, 0x400fff).w(FUNC(taitof2_state::sprite_extension_w)).share("sprite_ext");
+	map(0x400000, 0x400fff).w(FUNC(taitof2_state::sprite_extension_w)).share(m_sprite_extension);
 	map(0x500000, 0x501fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x600000, 0x60ffff).ram();
 	map(0x700000, 0x70001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0x00ff);  /* ?? */
-	map(0x800000, 0x80ffff).ram().share("spriteram");
+	map(0x800000, 0x80ffff).ram().share(m_spriteram);
 	map(0x900000, 0x90ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x920000, 0x92000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 	map(0xa00000, 0xa00000).w("tc0140syt", FUNC(tc0140syt_device::master_port_w));
@@ -1042,11 +1033,11 @@ void taitof2_state::qjinsei_map(address_map &map)
 	map(0x200002, 0x200002).rw("tc0140syt", FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0x300000, 0x30ffff).ram();
 	map(0x500000, 0x500001).nopw();   /* watchdog ? */
-	map(0x600000, 0x603fff).w(FUNC(taitof2_state::sprite_extension_w)).share("sprite_ext");
+	map(0x600000, 0x603fff).w(FUNC(taitof2_state::sprite_extension_w)).share(m_sprite_extension);
 	map(0x700000, 0x701fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x800000, 0x80ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
 	map(0xa00000, 0xa0001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0x00ff);  /* ?? */
 	map(0xb00000, 0xb0000f).rw(m_tc0510nio, FUNC(tc0510nio_device::halfword_r), FUNC(tc0510nio_device::halfword_w));
 }
@@ -1059,9 +1050,9 @@ void taitof2_state::qcrayon_map(address_map &map)
 	map(0x300000, 0x3fffff).rom().region("extra", 0);   /* extra data rom */
 	map(0x500000, 0x500000).w("tc0140syt", FUNC(tc0140syt_device::master_port_w));
 	map(0x500002, 0x500002).rw("tc0140syt", FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
-	map(0x600000, 0x603fff).w(FUNC(taitof2_state::sprite_extension_w)).share("sprite_ext");
+	map(0x600000, 0x603fff).w(FUNC(taitof2_state::sprite_extension_w)).share(m_sprite_extension);
 	map(0x700000, 0x701fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x800000, 0x80ffff).ram().share("spriteram");
+	map(0x800000, 0x80ffff).ram().share(m_spriteram);
 	map(0x900000, 0x90ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x920000, 0x92000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 	map(0xa00000, 0xa0000f).rw(m_tc0510nio, FUNC(tc0510nio_device::halfword_r), FUNC(tc0510nio_device::halfword_w));
@@ -1073,7 +1064,7 @@ void taitof2_state::qcrayon2_map(address_map &map)
 	map(0x000000, 0x07ffff).rom();
 	map(0x200000, 0x20ffff).ram();
 	map(0x300000, 0x301fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x400000, 0x40ffff).ram().share("spriteram");
+	map(0x400000, 0x40ffff).ram().share(m_spriteram);
 	map(0x500000, 0x50ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x520000, 0x52000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 	map(0x600000, 0x67ffff).rom().region("extra", 0);   /* extra data rom */
@@ -1081,21 +1072,21 @@ void taitof2_state::qcrayon2_map(address_map &map)
 	map(0x900000, 0x90001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0x00ff);  /* ?? */
 	map(0xa00000, 0xa00000).w("tc0140syt", FUNC(tc0140syt_device::master_port_w));
 	map(0xa00002, 0xa00002).rw("tc0140syt", FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
-	map(0xb00000, 0xb017ff).w(FUNC(taitof2_state::sprite_extension_w)).share("sprite_ext");
+	map(0xb00000, 0xb017ff).w(FUNC(taitof2_state::sprite_extension_w)).share(m_sprite_extension);
 }
 
-void taitof2_state::driftout_map(address_map &map)
+void dondokod_state::driftout_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();
 	map(0x200000, 0x200000).w("tc0140syt", FUNC(tc0140syt_device::master_port_w));
 	map(0x200002, 0x200002).rw("tc0140syt", FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
 	map(0x300000, 0x30ffff).ram();
-	map(0x400000, 0x401fff).rw(m_tc0430grw, FUNC(tc0280grd_device::tc0430grw_word_r), FUNC(tc0280grd_device::tc0430grw_word_w));    /* ROZ tilemap */
-	map(0x402000, 0x40200f).w(m_tc0430grw, FUNC(tc0280grd_device::tc0430grw_ctrl_word_w));
+	map(0x400000, 0x401fff).rw(m_tc0430grw, FUNC(tc0430grw_device::word_r), FUNC(tc0430grw_device::word_w));    /* ROZ tilemap */
+	map(0x402000, 0x40200f).w(m_tc0430grw, FUNC(tc0430grw_device::ctrl_word_w));
 	map(0x700000, 0x701fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x800000, 0x80ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
 	map(0xa00000, 0xa0001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0xff00);
 	map(0xb00000, 0xb0000f).rw(m_tc0510nio, FUNC(tc0510nio_device::halfword_r), FUNC(tc0510nio_device::halfword_w));
 	map(0xb00018, 0xb00019).portr("PADDLE1");
@@ -1103,17 +1094,17 @@ void taitof2_state::driftout_map(address_map &map)
 }
 
 /* same as driftout, except for sound address 0x200000 */
-void taitof2_state::driveout_map(address_map &map)
+void driveout_state::driveout_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();
-	map(0x200000, 0x200003).nopr().w(FUNC(taitof2_state::driveout_sound_command_w)).umask16(0xff00);
+	map(0x200000, 0x200003).nopr().w(FUNC(driveout_state::sound_command_w)).umask16(0xff00);
 	map(0x300000, 0x30ffff).ram();
-	map(0x400000, 0x401fff).rw(m_tc0430grw, FUNC(tc0280grd_device::tc0430grw_word_r), FUNC(tc0280grd_device::tc0430grw_word_w));    /* ROZ tilemap */
-	map(0x402000, 0x40200f).w(m_tc0430grw, FUNC(tc0280grd_device::tc0430grw_ctrl_word_w));
+	map(0x400000, 0x401fff).rw(m_tc0430grw, FUNC(tc0430grw_device::word_r), FUNC(tc0430grw_device::word_w));    /* ROZ tilemap */
+	map(0x402000, 0x40200f).w(m_tc0430grw, FUNC(tc0430grw_device::ctrl_word_w));
 	map(0x700000, 0x701fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x800000, 0x80ffff).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x820000, 0x82000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x900000, 0x90ffff).ram().share("spriteram");
+	map(0x900000, 0x90ffff).ram().share(m_spriteram);
 	map(0xa00000, 0xa0001f).w(m_tc0360pri, FUNC(tc0360pri_device::write)).umask16(0xff00);
 	map(0xb00000, 0xb0000f).rw(m_tc0510nio, FUNC(tc0510nio_device::halfword_r), FUNC(tc0510nio_device::halfword_w));
 	map(0xb00018, 0xb00019).portr("PADDLE1");
@@ -1126,7 +1117,7 @@ void taitof2_state::driveout_map(address_map &map)
 void taitof2_state::sound_map(address_map &map)
 {
 	map(0x0000, 0x3fff).rom();
-	map(0x4000, 0x7fff).bankr("audiobank");
+	map(0x4000, 0x7fff).bankr(m_audiobank);
 	map(0xc000, 0xdfff).ram();
 	map(0xe000, 0xe003).rw("ymsnd", FUNC(ym2610_device::read), FUNC(ym2610_device::write));
 	map(0xe200, 0xe200).nopr().w("tc0140syt", FUNC(tc0140syt_device::slave_port_w));
@@ -1141,7 +1132,7 @@ void taitof2_state::sound_map(address_map &map)
 
 /* Alt version of Cameltry, YM2203 + M6925 sound */
 
-void taitof2_state::cameltrya_sound_map(address_map &map)
+void cameltry_state::cameltrya_sound_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();     // I can't see a bank control, but there ARE some bytes past 0x8000
 	map(0x8000, 0x8fff).ram();
@@ -1153,19 +1144,19 @@ void taitof2_state::cameltrya_sound_map(address_map &map)
 }
 
 
-void taitof2_state::driveout_sound_map(address_map &map)
+void driveout_state::driveout_sound_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
 	map(0x8000, 0x87ff).ram();
-	map(0x9000, 0x9000).w(FUNC(taitof2_state::oki_bank_w));
+	map(0x9000, 0x9000).w(FUNC(driveout_state::oki_bank_w));
 	map(0x9800, 0x9800).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0xa000, 0xa000).r(FUNC(taitof2_state::driveout_sound_command_r));
+	map(0xa000, 0xa000).r(FUNC(driveout_state::sound_command_r));
 }
 
 
-void taitof2_state::driveout_oki_map(address_map &map)
+void driveout_state::driveout_oki_map(address_map &map)
 {
-	map(0x00000, 0x1ffff).bankr("okibank");
+	map(0x00000, 0x1ffff).bankr(m_okibank);
 	map(0x20000, 0x3ffff).rom().region("oki", 0x80000);
 }
 
@@ -2753,7 +2744,7 @@ static GFXDECODE_START( gfx_footchmpbl )
 GFXDECODE_END
 
 
-void taitof2_state::cameltrya_porta_w(u8 data)
+void cameltry_state::cameltrya_porta_w(u8 data)
 {
 	// Implement //
 }
@@ -2776,6 +2767,38 @@ void taitof2_state::machine_start()
 	}
 
 	m_int6_timer = timer_alloc(FUNC(taitof2_state::trigger_int6), this);
+}
+
+void mjnquest_state::machine_start()
+{
+	taitof2_state::machine_start();
+
+	m_mjnquest_input = 0;
+
+	save_item(NAME(m_mjnquest_input));
+}
+
+void cameltry_state::machine_start()
+{
+	dondokod_state::machine_start();
+
+	m_last[0] = 0;
+	m_last[1] = 0;
+
+	save_item(NAME(m_last));
+}
+
+void driveout_state::machine_start()
+{
+	dondokod_state::machine_start();
+
+	m_okibank->configure_entries(0, 4, memregion("oki")->base(), 0x20000);
+	m_okibank->set_entry(0);
+	m_sound_latch = 0;
+	m_nibble = false;
+
+	save_item(NAME(m_sound_latch));
+	save_item(NAME(m_nibble));
 }
 
 void taitof2_state::taito_f2(machine_config &config)
@@ -2883,7 +2906,7 @@ void taitof2_state::finalb(machine_config &config)
 
 	/* video hardware */
 	m_gfxdecode->set_info(gfx_finalb);
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,finalb)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, finalb)
 	m_screen->screen_vblank().set(FUNC(taitof2_state::screen_vblank_partial_buffer_delayed));
 
 	TC0100SCN(config, m_tc0100scn[0], 0);
@@ -2891,17 +2914,17 @@ void taitof2_state::finalb(machine_config &config)
 	m_tc0100scn[0]->set_palette(m_tc0110pcr);
 }
 
-void taitof2_state::dondokod(machine_config &config)
+void dondokod_state::dondokod(machine_config &config)
 {
 	taito_f2_tc0220ioc(config);
 
 	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::dondokod_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &dondokod_state::dondokod_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,dondokod)
-	m_screen->screen_vblank().set(FUNC(taitof2_state::screen_vblank_partial_buffer_delayed));
-	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri_roz));
+	MCFG_VIDEO_START_OVERRIDE(dondokod_state,dondokod)
+	m_screen->screen_vblank().set(FUNC(dondokod_state::screen_vblank_partial_buffer_delayed));
+	m_screen->set_screen_update(FUNC(dondokod_state::screen_update_pri_roz));
 
 	TC0100SCN(config, m_tc0100scn[0], 0);
 	m_tc0100scn[0]->set_offsets(3, 0);
@@ -2914,23 +2937,23 @@ void taitof2_state::dondokod(machine_config &config)
 	TC0360PRI(config, m_tc0360pri, 0);
 }
 
-void taitof2_state::megab(machine_config &config)
+void megablst_state::megab(machine_config &config)
 {
 	taito_f2_tc0220ioc(config);
 
 	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::megab_map);
-	m_maincpu->set_vblank_int("screen", FUNC(taitof2_state::megab_interrupt));
+	m_maincpu->set_addrmap(AS_PROGRAM, &megablst_state::megab_map);
+	m_maincpu->set_vblank_int("screen", FUNC(megablst_state::megab_interrupt));
 
 	TAITO_CCHIP(config, m_cchip, 24_MHz_XTAL/2); // 12MHz
 	// the ports don't appear to hook up to anything
 
-	TIMER(config, "cchip_irq_clear").configure_generic(FUNC(taitof2_state::cchip_irq_clear_cb));
+	TIMER(config, m_cchip_irq_clear).configure_generic(FUNC(megablst_state::cchip_irq_clear_cb));
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,megab)
-	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri));
-	m_screen->screen_vblank().set(FUNC(taitof2_state::screen_vblank_partial_buffer_delayed));
+	MCFG_VIDEO_START_OVERRIDE(megablst_state,megab)
+	m_screen->set_screen_update(FUNC(megablst_state::screen_update_pri));
+	m_screen->screen_vblank().set(FUNC(megablst_state::screen_vblank_partial_buffer_delayed));
 
 	TC0100SCN(config, m_tc0100scn[0], 0);
 	m_tc0100scn[0]->set_offsets(3, 0);
@@ -2947,7 +2970,7 @@ void taitof2_state::thundfox(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::thundfox_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,thundfox)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, thundfox)
 	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_thundfox));
 	m_screen->screen_vblank().set(FUNC(taitof2_state::screen_vblank_partial_buffer_delayed_thundfox));
 
@@ -2968,16 +2991,16 @@ void taitof2_state::thundfox(machine_config &config)
 	TC0360PRI(config, m_tc0360pri, 0);
 }
 
-void taitof2_state::cameltry(machine_config &config)
+void cameltry_state::cameltry(machine_config &config)
 {
 	taito_f2_tc0220ioc(config);
 
 	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::cameltry_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &cameltry_state::cameltry_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,dondokod)
-	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri_roz));
+	MCFG_VIDEO_START_OVERRIDE(cameltry_state,dondokod)
+	m_screen->set_screen_update(FUNC(cameltry_state::screen_update_pri_roz));
 
 	TC0100SCN(config, m_tc0100scn[0], 0);
 	m_tc0100scn[0]->set_offsets(3, 0);
@@ -2990,11 +3013,11 @@ void taitof2_state::cameltry(machine_config &config)
 	TC0360PRI(config, m_tc0360pri, 0);
 }
 
-void taitof2_state::driftoutct(machine_config &config)
+void cameltry_state::driftoutct(machine_config &config)
 {
 	cameltry(config);
 
-	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::driftoutct_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &cameltry_state::driftoutct_map);
 }
 
 void taitof2_state::qtorimon(machine_config &config)
@@ -3022,7 +3045,7 @@ void taitof2_state::liquidk(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::liquidk_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,megab)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, megab)
 	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri));
 	m_screen->screen_vblank().set(FUNC(taitof2_state::screen_vblank_partial_buffer_delayed));
 
@@ -3060,7 +3083,7 @@ void taitof2_state::ssi(machine_config &config)
 	m_palette->set_format(palette_device::RGBx_444, 4096);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,ssi)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, ssi)
 	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_ssi));
 	m_screen->screen_vblank().set(FUNC(taitof2_state::screen_vblank_partial_buffer_delayed_thundfox));
 
@@ -3079,7 +3102,7 @@ void taitof2_state::gunfront(machine_config &config)
 	m_palette->set_format(palette_device::RGBx_444, 4096);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,gunfront)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, gunfront)
 	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri));
 	m_screen->screen_vblank().set(FUNC(taitof2_state::screen_vblank_partial_buffer_delayed));
 
@@ -3098,7 +3121,7 @@ void taitof2_state::growl(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::growl_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,growl)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, growl)
 	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri));
 
 	m_palette->set_format(palette_device::RRRRGGGGBBBBRGBx, 4096);
@@ -3110,34 +3133,32 @@ void taitof2_state::growl(machine_config &config)
 	TC0360PRI(config, m_tc0360pri, 0);
 }
 
-void taitof2_state::mjnquest(machine_config &config)
+void mjnquest_state::mjnquest(machine_config &config)
 {
 	taito_f2(config);
 	taito_f2_tc0110pcr(config);
 	config.device_remove("palette");
 
 	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::mjnquest_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &mjnquest_state::mjnquest_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,mjnquest)
-
 	TC0100SCN(config, m_tc0100scn[0], 0);
 	m_tc0100scn[0]->set_palette(m_tc0110pcr);
-	m_tc0100scn[0]->set_tile_callback(FUNC(taitof2_state::mjnquest_tmap_cb));
+	m_tc0100scn[0]->set_tile_callback(FUNC(mjnquest_state::tmap_cb));
 }
 
-void taitof2_state::footchmp(machine_config &config)
+void footchmp_state::footchmp(machine_config &config)
 {
 	taito_f2_te7750(config);
 
 	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::footchmp_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &footchmp_state::footchmp_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,footchmp)
-	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_deadconx));
-	m_screen->screen_vblank().set(FUNC(taitof2_state::screen_vblank_full_buffer_delayed));
+	MCFG_VIDEO_START_OVERRIDE(footchmp_state,footchmp)
+	m_screen->set_screen_update(FUNC(footchmp_state::screen_update_deadconx));
+	m_screen->screen_vblank().set(FUNC(footchmp_state::screen_vblank_full_buffer_delayed));
 
 	TC0480SCP(config, m_tc0480scp, 0);
 	m_tc0480scp->set_palette(m_palette);
@@ -3148,7 +3169,7 @@ void taitof2_state::footchmp(machine_config &config)
 	TC0360PRI(config, m_tc0360pri, 0);
 }
 
-void taitof2_state::footchmpbl(machine_config &config)
+void footchmp_state::footchmpbl(machine_config &config)
 {
 	footchmp(config);
 
@@ -3157,25 +3178,10 @@ void taitof2_state::footchmpbl(machine_config &config)
 	m_gfxdecode->set_info(gfx_footchmpbl);
 }
 
-void taitof2_state::hthero(machine_config &config)
+void footchmp_state::hthero(machine_config &config)
 {
-	taito_f2_te7750(config);
-
-	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::footchmp_map);
-
-	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,hthero)
-	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_deadconx));
-	m_screen->screen_vblank().set(FUNC(taitof2_state::screen_vblank_full_buffer_delayed));
-
-	TC0360PRI(config, m_tc0360pri, 0);
-
-	TC0480SCP(config, m_tc0480scp, 0);
-	m_tc0480scp->set_palette(m_palette);
+	footchmp(config);
 	m_tc0480scp->set_offsets(0x33 + 3, -0x04);
-	m_tc0480scp->set_offsets_tx(-1, 0);
-	m_tc0480scp->set_offsets_flip(-1, 0);
 }
 
 void taitof2_state::koshien(machine_config &config)
@@ -3186,7 +3192,7 @@ void taitof2_state::koshien(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::koshien_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,koshien)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, koshien)
 	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri));
 
 	m_palette->set_format(palette_device::RRRRGGGGBBBBRGBx, 4096);
@@ -3209,7 +3215,7 @@ void taitof2_state::yuyugogo(machine_config &config)
 	m_palette->set_format(palette_device::RGBx_444, 4096);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,yuyugogo)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, yuyugogo)
 	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_yesnoj));
 
 	TC0100SCN(config, m_tc0100scn[0], 0);
@@ -3236,7 +3242,7 @@ void taitof2_state::ninjak(machine_config &config)
 	te7750.out_port8_cb().set(FUNC(taitof2_state::_4p_coin_word_w));
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,ninjak)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, ninjak)
 	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri));
 
 	TC0100SCN(config, m_tc0100scn[0], 0);
@@ -3254,7 +3260,7 @@ void taitof2_state::solfigtr(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::solfigtr_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,solfigtr)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, solfigtr)
 	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri));
 
 	TC0100SCN(config, m_tc0100scn[0], 0);
@@ -3280,16 +3286,16 @@ void taitof2_state::qzquest(machine_config &config)
 	m_tc0100scn[0]->set_palette(m_palette);
 }
 
-void taitof2_state::pulirula(machine_config &config)
+void dondokod_state::pulirula(machine_config &config)
 {
 	taito_f2_tc0510nio(config);
 
 	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::pulirula_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &dondokod_state::pulirula_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,pulirula)
-	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri_roz));
+	MCFG_VIDEO_START_OVERRIDE(dondokod_state,pulirula)
+	m_screen->set_screen_update(FUNC(dondokod_state::screen_update_pri_roz));
 
 	TC0100SCN(config, m_tc0100scn[0], 0);
 	m_tc0100scn[0]->set_offsets(3, 0);
@@ -3302,18 +3308,18 @@ void taitof2_state::pulirula(machine_config &config)
 	TC0360PRI(config, m_tc0360pri, 0);
 }
 
-void taitof2_state::metalb(machine_config &config)
+void footchmp_state::metalb(machine_config &config)
 {
 	taito_f2_tc0510nio(config);
 
 	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::metalb_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &footchmp_state::metalb_map);
 
 	/* video hardware */
 	m_palette->set_format(palette_device::RRRRGGGGBBBBRGBx, 8192);
 
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,metalb)
-	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_metalb));
+	MCFG_VIDEO_START_OVERRIDE(footchmp_state,deadconx)
+	m_screen->set_screen_update(FUNC(footchmp_state::screen_update_metalb));
 
 	TC0480SCP(config, m_tc0480scp, 0);
 	m_tc0480scp->set_palette(m_palette);
@@ -3333,7 +3339,7 @@ void taitof2_state::qzchikyu(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::qzchikyu_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,qzchikyu)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, qzchikyu)
 	m_screen->screen_vblank().set(FUNC(taitof2_state::screen_vblank_partial_buffer_delayed_qzchikyu));
 
 	TC0100SCN(config, m_tc0100scn[0], 0);
@@ -3353,7 +3359,7 @@ void taitof2_state::yesnoj(machine_config &config)
 	/* video hardware */
 	m_palette->set_format(palette_device::RRRRGGGGBBBBRGBx, 4096);
 
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,yesnoj)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, yesnoj)
 	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_yesnoj));
 
 	TC0100SCN(config, m_tc0100scn[0], 0);
@@ -3364,18 +3370,18 @@ void taitof2_state::yesnoj(machine_config &config)
 	TC8521(config, "rtc", XTAL(32'768));
 }
 
-void taitof2_state::deadconx(machine_config &config)
+void footchmp_state::deadconx(machine_config &config)
 {
 	taito_f2_te7750(config);
 
 	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::deadconx_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &footchmp_state::deadconx_map);
 
 	/* video hardware */
 	m_palette->set_format(palette_device::RRRRGGGGBBBBRGBx, 4096);
 
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,deadconx)
-	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_deadconx));
+	MCFG_VIDEO_START_OVERRIDE(footchmp_state,deadconx)
+	m_screen->set_screen_update(FUNC(footchmp_state::screen_update_deadconx));
 
 	TC0480SCP(config, m_tc0480scp, 0);
 	m_tc0480scp->set_palette(m_palette);
@@ -3386,24 +3392,10 @@ void taitof2_state::deadconx(machine_config &config)
 	TC0360PRI(config, m_tc0360pri, 0);
 }
 
-void taitof2_state::deadconxj(machine_config &config)
+void footchmp_state::deadconxj(machine_config &config)
 {
-	taito_f2_te7750(config);
-
-	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::deadconx_map);
-
-	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,deadconxj)
-	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_deadconx));
-
-	TC0480SCP(config, m_tc0480scp, 0);
-	m_tc0480scp->set_palette(m_palette);
+	deadconx(config);
 	m_tc0480scp->set_offsets(0x34 + 3, -0x05);
-	m_tc0480scp->set_offsets_tx(-1, 0);
-	m_tc0480scp->set_offsets_flip(-1, 0);
-
-	TC0360PRI(config, m_tc0360pri, 0);
 }
 
 void taitof2_state::dinorex(machine_config &config)
@@ -3414,7 +3406,7 @@ void taitof2_state::dinorex(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::dinorex_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,dinorex)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, dinorex)
 	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri));
 
 	m_palette->set_format(palette_device::RRRRGGGGBBBBRGBx, 4096);
@@ -3434,7 +3426,7 @@ void taitof2_state::qjinsei(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::qjinsei_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,quiz)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, quiz)
 	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri));
 
 	m_palette->set_format(palette_device::RRRRGGGGBBBBRGBx, 4096);
@@ -3454,7 +3446,7 @@ void taitof2_state::qcrayon(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::qcrayon_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,quiz)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, quiz)
 	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri));
 
 	m_palette->set_format(palette_device::RRRRGGGGBBBBRGBx, 4096);
@@ -3474,7 +3466,7 @@ void taitof2_state::qcrayon2(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::qcrayon2_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,quiz)
+	MCFG_VIDEO_START_OVERRIDE(taitof2_state, quiz)
 	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri));
 
 	m_palette->set_format(palette_device::RRRRGGGGBBBBRGBx, 4096);
@@ -3486,16 +3478,16 @@ void taitof2_state::qcrayon2(machine_config &config)
 	TC0360PRI(config, m_tc0360pri, 0);
 }
 
-void taitof2_state::driftout(machine_config &config)
+void dondokod_state::driftout(machine_config &config)
 {
 	taito_f2_tc0510nio(config);
 
 	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::driftout_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &dondokod_state::driftout_map);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,driftout)
-	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri_roz));
+	MCFG_VIDEO_START_OVERRIDE(dondokod_state,driftout)
+	m_screen->set_screen_update(FUNC(dondokod_state::screen_update_pri_roz));
 
 	TC0100SCN(config, m_tc0100scn[0], 0);
 	m_tc0100scn[0]->set_offsets(3, 0);
@@ -3508,22 +3500,22 @@ void taitof2_state::driftout(machine_config &config)
 	TC0360PRI(config, m_tc0360pri, 0);
 }
 
-void taitof2_state::cameltrya(machine_config &config)
+void cameltry_state::cameltrya(machine_config &config)
 {
 	/* basic machine hardware */
-	M68000(config, m_maincpu,24000000/2);  /* verified on pcb  */
-	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::cameltrya_map);
-	m_maincpu->set_vblank_int("screen", FUNC(taitof2_state::interrupt));
+	M68000(config, m_maincpu, 24000000/2);  /* verified on pcb  */
+	m_maincpu->set_addrmap(AS_PROGRAM, &cameltry_state::cameltrya_map);
+	m_maincpu->set_vblank_int("screen", FUNC(cameltry_state::interrupt));
 
 	Z80(config, m_audiocpu, 24000000/4);    /* verifed on pcb */
-	m_audiocpu->set_addrmap(AS_PROGRAM, &taitof2_state::cameltrya_sound_map);
+	m_audiocpu->set_addrmap(AS_PROGRAM, &cameltry_state::cameltrya_sound_map);
 
 	TC0220IOC(config, m_tc0220ioc, 0);
 	m_tc0220ioc->read_0_callback().set_ioport("DSWA");
 	m_tc0220ioc->read_1_callback().set_ioport("DSWB");
 	m_tc0220ioc->read_2_callback().set_ioport("IN0");
 	m_tc0220ioc->read_3_callback().set_ioport("IN1");
-	m_tc0220ioc->write_4_callback().set(FUNC(taitof2_state::coin_nibble_w));
+	m_tc0220ioc->write_4_callback().set(FUNC(cameltry_state::coin_nibble_w));
 	m_tc0220ioc->read_7_callback().set_ioport("IN2");
 
 	/* video hardware */
@@ -3532,14 +3524,14 @@ void taitof2_state::cameltrya(machine_config &config)
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	m_screen->set_size(40*8, 32*8);
 	m_screen->set_visarea(0*8, 40*8-1, 2*8, 30*8-1);
-	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri_roz));
-	m_screen->screen_vblank().set(FUNC(taitof2_state::screen_vblank_no_buffer));
+	m_screen->set_screen_update(FUNC(cameltry_state::screen_update_pri_roz));
+	m_screen->screen_vblank().set(FUNC(cameltry_state::screen_vblank_no_buffer));
 	m_screen->set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_taitof2);
 	PALETTE(config, m_palette).set_format(palette_device::RGBx_444, 4096);
 
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,dondokod)
+	MCFG_VIDEO_START_OVERRIDE(cameltry_state,dondokod)
 
 	TC0100SCN(config, m_tc0100scn[0], 0);
 	m_tc0100scn[0]->set_offsets(3, 0);
@@ -3556,7 +3548,7 @@ void taitof2_state::cameltrya(machine_config &config)
 
 	ym2203_device &ymsnd(YM2203(config, "ymsnd", 24000000/8)); /* verified on pcb  */
 	ymsnd.irq_handler().set_inputline(m_audiocpu, 0);
-	ymsnd.port_a_write_callback().set(FUNC(taitof2_state::cameltrya_porta_w));   /* not implemented */
+	ymsnd.port_a_write_callback().set(FUNC(cameltry_state::cameltrya_porta_w));   /* not implemented */
 	ymsnd.add_route(0, "mono", 0.20);
 	ymsnd.add_route(1, "mono", 0.20);
 	ymsnd.add_route(2, "mono", 0.20);
@@ -3570,22 +3562,22 @@ void taitof2_state::cameltrya(machine_config &config)
 	ciu.reset_callback().set_inputline(m_audiocpu, INPUT_LINE_RESET);
 }
 
-void taitof2_state::driveout(machine_config &config)
+void driveout_state::driveout(machine_config &config)
 {
 	/* basic machine hardware */
 	M68000(config, m_maincpu, 14_MHz_XTAL);  // verified on PCB
-	m_maincpu->set_addrmap(AS_PROGRAM, &taitof2_state::driveout_map);
-	m_maincpu->set_vblank_int("screen", FUNC(taitof2_state::interrupt));
+	m_maincpu->set_addrmap(AS_PROGRAM, &driveout_state::driveout_map);
+	m_maincpu->set_vblank_int("screen", FUNC(driveout_state::interrupt));
 
 	Z80(config, m_audiocpu, 8_MHz_XTAL / 2); // verified on PCB
-	m_audiocpu->set_addrmap(AS_PROGRAM, &taitof2_state::driveout_sound_map);
+	m_audiocpu->set_addrmap(AS_PROGRAM, &driveout_state::driveout_sound_map);
 
 	TC0510NIO(config, m_tc0510nio, 0);
 	m_tc0510nio->read_0_callback().set_ioport("DSWA");
 	m_tc0510nio->read_1_callback().set_ioport("DSWB");
 	m_tc0510nio->read_2_callback().set_ioport("IN0");
 	m_tc0510nio->read_3_callback().set_ioport("IN1");
-	m_tc0510nio->write_4_callback().set(FUNC(taitof2_state::coin_nibble_w));
+	m_tc0510nio->write_4_callback().set(FUNC(driveout_state::coin_nibble_w));
 	m_tc0510nio->read_7_callback().set_ioport("IN2");
 
 	/* video hardware */
@@ -3594,14 +3586,14 @@ void taitof2_state::driveout(machine_config &config)
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	m_screen->set_size(40*8, 32*8);
 	m_screen->set_visarea(0*8, 40*8-1, 2*8, 30*8-1);
-	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri_roz));
-	m_screen->screen_vblank().set(FUNC(taitof2_state::screen_vblank_no_buffer));
+	m_screen->set_screen_update(FUNC(driveout_state::screen_update_pri_roz));
+	m_screen->screen_vblank().set(FUNC(driveout_state::screen_vblank_no_buffer));
 	m_screen->set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_taitof2);
 	PALETTE(config, m_palette).set_format(palette_device::xRGB_555, 4096);
 
-	MCFG_VIDEO_START_OVERRIDE(taitof2_state,driftout)
+	MCFG_VIDEO_START_OVERRIDE(driveout_state,driftout)
 
 	TC0100SCN(config, m_tc0100scn[0], 0);
 	m_tc0100scn[0]->set_offsets(3, 0);
@@ -3614,17 +3606,11 @@ void taitof2_state::driveout(machine_config &config)
 	TC0360PRI(config, m_tc0360pri, 0);
 
 	/* sound hardware */
-	SPEAKER(config, "lspeaker").front_left();   /* does it ? */
-	SPEAKER(config, "rspeaker").front_right();
+	SPEAKER(config, "mono").front_center();
 
 	OKIM6295(config, m_oki, 8_MHz_XTAL / 8, okim6295_device::PIN7_LOW);  // verified on PCB
-	m_oki->set_addrmap(0, &taitof2_state::driveout_oki_map);
-	m_oki->add_route(ALL_OUTPUTS, "lspeaker", 1.0);
-	m_oki->add_route(ALL_OUTPUTS, "rspeaker", 1.0);
-
-	tc0140syt_device &tc0140syt(TC0140SYT(config, "tc0140syt", 0));
-	tc0140syt.nmi_callback().set_inputline(m_audiocpu, INPUT_LINE_NMI);
-	tc0140syt.reset_callback().set_inputline(m_audiocpu, INPUT_LINE_RESET);
+	m_oki->set_addrmap(0, &driveout_state::driveout_oki_map);
+	m_oki->add_route(ALL_OUTPUTS, "mono", 1.0);
 }
 
 
@@ -5559,16 +5545,7 @@ void taitof2_state::init_finalb()
 	m_gfxdecode->set_gfx(1, nullptr);
 }
 
-void taitof2_state::init_cameltry()
-{
-	m_last[0] = 0;
-	m_last[1] = 0;
-
-	save_item(NAME(m_last));
-}
-
-
-void taitof2_state::init_mjnquest()
+void mjnquest_state::init_mjnquest()
 {
 	const u32 len = memregion("sprites")->bytes();
 	u8 *gfx = memregion("sprites")->base();
@@ -5581,121 +5558,105 @@ void taitof2_state::init_mjnquest()
 		gfx[i] = (gfx[i + 1] >> 4) | (gfx[i + 1] << 4);
 		gfx[i + 1] = (t >> 4) | (t << 4);
 	}
-
-	m_mjnquest_input = 0;
-
-	save_item(NAME(m_mjnquest_input));
-}
-
-void taitof2_state::init_driveout()
-{
-	m_okibank->configure_entries(0, 4, memregion("oki")->base(), 0x20000);
-	m_okibank->set_entry(0);
-	m_driveout_sound_latch = 0;
-	m_nibble = 0;
-
-	save_item(NAME(m_driveout_sound_latch));
-	save_item(NAME(m_nibble));
 }
 
 //    YEAR  NAME        PARENT    MACHINE    INPUT       CLASS          INIT           ROT     COMPANY                      FULLNAME
 
-GAME( 1988, finalb,     0,        finalb,    finalb,     taitof2_state, init_finalb,   ROT0,   "Taito Corporation Japan",   "Final Blow (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, finalbu,    finalb,   finalb,    finalbu,    taitof2_state, init_finalb,   ROT0,   "Taito America Corporation", "Final Blow (US, rev 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, finalbj,    finalb,   finalb,    finalbj,    taitof2_state, init_finalb,   ROT0,   "Taito Corporation",         "Final Blow (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, finalb,     0,        finalb,    finalb,     taitof2_state,  init_finalb,   ROT0,   "Taito Corporation Japan",   "Final Blow (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, finalbu,    finalb,   finalb,    finalbu,    taitof2_state,  init_finalb,   ROT0,   "Taito America Corporation", "Final Blow (US, rev 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, finalbj,    finalb,   finalb,    finalbj,    taitof2_state,  init_finalb,   ROT0,   "Taito Corporation",         "Final Blow (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1989, dondokod,   0,        dondokod,  dondokod,   taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Don Doko Don (World, rev 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, dondokodu,  dondokod, dondokod,  dondokodu,  taitof2_state, empty_init,    ROT0,   "Taito America Corporation", "Don Doko Don (US, rev 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, dondokodj,  dondokod, dondokod,  dondokodj,  taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Don Doko Don (Japan, rev 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, dondokod,   0,        dondokod,  dondokod,   dondokod_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Don Doko Don (World, rev 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, dondokodu,  dondokod, dondokod,  dondokodu,  dondokod_state, empty_init,    ROT0,   "Taito America Corporation", "Don Doko Don (US, rev 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, dondokodj,  dondokod, dondokod,  dondokodj,  dondokod_state, empty_init,    ROT0,   "Taito Corporation",         "Don Doko Don (Japan, rev 1)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1989, megablst,   0,        megab,     megab,      taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Mega Blast (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, megablstu,  megablst, megab,     megabu,     taitof2_state, empty_init,    ROT0,   "Taito America Corporation", "Mega Blast (US)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, megablstj,  megablst, megab,     megabj,     taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Mega Blast (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, megablst,   0,        megab,     megab,      megablst_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Mega Blast (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, megablstu,  megablst, megab,     megabu,     megablst_state, empty_init,    ROT0,   "Taito America Corporation", "Mega Blast (US)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, megablstj,  megablst, megab,     megabj,     megablst_state, empty_init,    ROT0,   "Taito Corporation",         "Mega Blast (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1990, thundfox,   0,        thundfox,  thundfox,   taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Thunder Fox (World, rev 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, thundfoxu,  thundfox, thundfox,  thundfoxu,  taitof2_state, empty_init,    ROT0,   "Taito America Corporation", "Thunder Fox (US, rev 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, thundfoxj,  thundfox, thundfox,  thundfoxj,  taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Thunder Fox (Japan, rev 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, thundfox,   0,        thundfox,  thundfox,   taitof2_state,  empty_init,    ROT0,   "Taito Corporation Japan",   "Thunder Fox (World, rev 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, thundfoxu,  thundfox, thundfox,  thundfoxu,  taitof2_state,  empty_init,    ROT0,   "Taito America Corporation", "Thunder Fox (US, rev 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, thundfoxj,  thundfox, thundfox,  thundfoxj,  taitof2_state,  empty_init,    ROT0,   "Taito Corporation",         "Thunder Fox (Japan, rev 1)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1989, cameltry,   0,        cameltry,  cameltry,   taitof2_state, init_cameltry, ROT0,   "Taito America Corporation", "Cameltry (US, YM2610)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, cameltryj,  cameltry, cameltry,  cameltryj,  taitof2_state, init_cameltry, ROT0,   "Taito Corporation",         "Cameltry (Japan, YM2610)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, cameltrya,  cameltry, cameltrya, cameltry,   taitof2_state, init_cameltry, ROT0,   "Taito America Corporation", "Cameltry (World, YM2203 + M6295)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, cameltryau, cameltry, cameltrya, cameltry,   taitof2_state, init_cameltry, ROT0,   "Taito America Corporation", "Cameltry (US, YM2203 + M6295)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, cameltry,   0,        cameltry,  cameltry,   cameltry_state, empty_init,    ROT0,   "Taito America Corporation", "Cameltry (US, YM2610)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, cameltryj,  cameltry, cameltry,  cameltryj,  cameltry_state, empty_init,    ROT0,   "Taito Corporation",         "Cameltry (Japan, YM2610)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, cameltrya,  cameltry, cameltrya, cameltry,   cameltry_state, empty_init,    ROT0,   "Taito America Corporation", "Cameltry (World, YM2203 + M6295)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, cameltryau, cameltry, cameltrya, cameltry,   cameltry_state, empty_init,    ROT0,   "Taito America Corporation", "Cameltry (US, YM2203 + M6295)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1990, qtorimon,   0,        qtorimon,  qtorimon,   taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Quiz Torimonochou (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, qtorimon,   0,        qtorimon,  qtorimon,   taitof2_state,  empty_init,    ROT0,   "Taito Corporation",         "Quiz Torimonochou (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1990, liquidk,    0,        liquidk,   liquidk,    taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Liquid Kids (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, liquidku,   liquidk,  liquidk,   liquidku,   taitof2_state, empty_init,    ROT0,   "Taito America Corporation", "Liquid Kids (US)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, mizubaku,   liquidk,  liquidk,   mizubaku,   taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Mizubaku Daibouken (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, liquidk,    0,        liquidk,   liquidk,    taitof2_state,  empty_init,    ROT0,   "Taito Corporation Japan",   "Liquid Kids (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, liquidku,   liquidk,  liquidk,   liquidku,   taitof2_state,  empty_init,    ROT0,   "Taito America Corporation", "Liquid Kids (US)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, mizubaku,   liquidk,  liquidk,   mizubaku,   taitof2_state,  empty_init,    ROT0,   "Taito Corporation",         "Mizubaku Daibouken (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1990, quizhq,     0,        quizhq,    quizhq,     taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Quiz H.Q. (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, quizhq,     0,        quizhq,    quizhq,     taitof2_state,  empty_init,    ROT0,   "Taito Corporation",         "Quiz H.Q. (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1990, ssi,        0,        ssi,       ssi,        taitof2_state, empty_init,    ROT270, "Taito Corporation Japan",   "Super Space Invaders '91 (World, revised code, Rev 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, ssia,       ssi,      ssi,       ssi,        taitof2_state, empty_init,    ROT270, "Taito Corporation Japan",   "Super Space Invaders '91 (World, revised code)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, ssib,       ssi,      ssi,       ssi,        taitof2_state, empty_init,    ROT270, "Taito Corporation Japan",   "Super Space Invaders '91 (World, earlier code base)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, majest12u,  ssi,      ssi,       majest12u,  taitof2_state, empty_init,    ROT270, "Taito America Corporation", "Majestic Twelve - The Space Invaders Part IV (US, revised code, Rev 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, majest12ua, ssi,      ssi,       majest12u,  taitof2_state, empty_init,    ROT270, "Taito America Corporation", "Majestic Twelve - The Space Invaders Part IV (US, revised code)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, majest12ub, ssi,      ssi,       majest12u,  taitof2_state, empty_init,    ROT270, "Taito America Corporation", "Majestic Twelve - The Space Invaders Part IV (US, earlier code base)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, majest12j,  ssi,      ssi,       majest12j,  taitof2_state, empty_init,    ROT270, "Taito Corporation",         "Majestic Twelve - The Space Invaders Part IV (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, ssi,        0,        ssi,       ssi,        taitof2_state,  empty_init,    ROT270, "Taito Corporation Japan",   "Super Space Invaders '91 (World, revised code, Rev 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, ssia,       ssi,      ssi,       ssi,        taitof2_state,  empty_init,    ROT270, "Taito Corporation Japan",   "Super Space Invaders '91 (World, revised code)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, ssib,       ssi,      ssi,       ssi,        taitof2_state,  empty_init,    ROT270, "Taito Corporation Japan",   "Super Space Invaders '91 (World, earlier code base)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, majest12u,  ssi,      ssi,       majest12u,  taitof2_state,  empty_init,    ROT270, "Taito America Corporation", "Majestic Twelve - The Space Invaders Part IV (US, revised code, Rev 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, majest12ua, ssi,      ssi,       majest12u,  taitof2_state,  empty_init,    ROT270, "Taito America Corporation", "Majestic Twelve - The Space Invaders Part IV (US, revised code)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, majest12ub, ssi,      ssi,       majest12u,  taitof2_state,  empty_init,    ROT270, "Taito America Corporation", "Majestic Twelve - The Space Invaders Part IV (US, earlier code base)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, majest12j,  ssi,      ssi,       majest12j,  taitof2_state,  empty_init,    ROT270, "Taito Corporation",         "Majestic Twelve - The Space Invaders Part IV (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1990, gunfront,   0,        gunfront,  gunfront,   taitof2_state, empty_init,    ROT270, "Taito Corporation Japan",   "Gun & Frontier (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, gunfrontj,  gunfront, gunfront,  gunfrontj,  taitof2_state, empty_init,    ROT270, "Taito Corporation",         "Gun Frontier (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, gunfront,   0,        gunfront,  gunfront,   taitof2_state,  empty_init,    ROT270, "Taito Corporation Japan",   "Gun & Frontier (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, gunfrontj,  gunfront, gunfront,  gunfrontj,  taitof2_state,  empty_init,    ROT270, "Taito Corporation",         "Gun Frontier (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1990, growl,      0,        growl,     growl,      taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Growl (World, Rev 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, growla,     growl,    growl,     growl,      taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Growl (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, growlu,     growl,    growl,     growlu,     taitof2_state, empty_init,    ROT0,   "Taito America Corporation", "Growl (US)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, runark,     growl,    growl,     runark,     taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Runark (Japan)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, growlp,     growl,    growl,     growl,      taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Growl (World, prototype)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, growl,      0,        growl,     growl,      taitof2_state,  empty_init,    ROT0,   "Taito Corporation Japan",   "Growl (World, Rev 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, growla,     growl,    growl,     growl,      taitof2_state,  empty_init,    ROT0,   "Taito Corporation Japan",   "Growl (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, growlu,     growl,    growl,     growlu,     taitof2_state,  empty_init,    ROT0,   "Taito America Corporation", "Growl (US)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, runark,     growl,    growl,     runark,     taitof2_state,  empty_init,    ROT0,   "Taito Corporation",         "Runark (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, growlp,     growl,    growl,     growl,      taitof2_state,  empty_init,    ROT0,   "Taito Corporation Japan",   "Growl (World, prototype)", MACHINE_SUPPORTS_SAVE )
 
+GAME( 1990, mjnquest,   0,        mjnquest,  mjnquest,   mjnquest_state, init_mjnquest, ROT0,   "Taito Corporation",         "Mahjong Quest (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, mjnquestb,  mjnquest, mjnquest,  mjnquest,   mjnquest_state, init_mjnquest, ROT0,   "Taito Corporation",         "Mahjong Quest (Japan, No Nudity)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1990, mjnquest,   0,        mjnquest,  mjnquest,   taitof2_state, init_mjnquest, ROT0,   "Taito Corporation",         "Mahjong Quest (Japan)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, mjnquestb,  mjnquest, mjnquest,  mjnquest,   taitof2_state, init_mjnquest, ROT0,   "Taito Corporation",         "Mahjong Quest (No Nudity)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, footchmp,   0,        footchmp,  footchmp,   footchmp_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Football Champ / Euro Football Champ (World)", MACHINE_SUPPORTS_SAVE ) // title depends on dipswitch
+GAME( 1990, htherou,    footchmp, footchmp,  htherou,    footchmp_state, empty_init,    ROT0,   "Taito Corporation",         "Hat Trick Hero (US)", MACHINE_SUPPORTS_SAVE ) // Single PCB
+GAME( 1990, htheroj,    footchmp, hthero,    htheroj,    footchmp_state, empty_init,    ROT0,   "Taito Corporation",         "Hat Trick Hero (Japan)", MACHINE_SUPPORTS_SAVE ) // Dual PCB
+GAME( 1992, footchmpbl, footchmp, footchmpbl,footchmpbl, footchmp_state, empty_init,    ROT0,   "bootleg",                   "Football Champ / Euro Football Champ (World) (bootleg)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // very different hw register etc.
 
-GAME( 1990, footchmp,   0,        footchmp,  footchmp,   taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Football Champ / Euro Football Champ (World)", MACHINE_SUPPORTS_SAVE ) // title depends on dipswitch
-GAME( 1990, htherou,    footchmp, footchmp,  htherou,    taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Hat Trick Hero (US)", MACHINE_SUPPORTS_SAVE ) // Single PCB
-GAME( 1990, htheroj,    footchmp, hthero,    htheroj,    taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Hat Trick Hero (Japan)", MACHINE_SUPPORTS_SAVE ) // Dual PCB
-GAME( 1992, footchmpbl, footchmp, footchmpbl,footchmpbl, taitof2_state, empty_init,    ROT0,   "bootleg",                   "Football Champ / Euro Football Champ (World) (bootleg)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // very different hw register etc.
+GAME( 1992, euroch92,   0,        footchmp,  footchmp,   footchmp_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Euro Champ '92 (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1992, euroch92j,  euroch92, footchmp,  footchmp,   footchmp_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Euro Champ '92 (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1992, euroch92,   0,        footchmp,  footchmp,   taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Euro Champ '92 (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1992, euroch92j,  euroch92, footchmp,  footchmp,   taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Euro Champ '92 (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, koshien,    0,        koshien,   koshien,    taitof2_state,  empty_init,    ROT0,   "Taito Corporation",         "Ah Eikou no Koshien (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1990, koshien,    0,        koshien,   koshien,    taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Ah Eikou no Koshien (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, yuyugogo,   0,        yuyugogo,  yuyugogo,   taitof2_state,  empty_init,    ROT0,   "Taito Corporation",         "Yuuyu no Quiz de GO!GO! (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1990, yuyugogo,   0,        yuyugogo,  yuyugogo,   taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Yuuyu no Quiz de GO!GO! (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, ninjak,     0,        ninjak,    ninjak,     taitof2_state,  empty_init,    ROT0,   "Taito Corporation Japan",   "The Ninja Kids (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, ninjaku,    ninjak,   ninjak,    ninjaku,    taitof2_state,  empty_init,    ROT0,   "Taito America Corporation", "The Ninja Kids (US)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, ninjakj,    ninjak,   ninjak,    ninjakj,    taitof2_state,  empty_init,    ROT0,   "Taito Corporation",         "The Ninja Kids (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1990, ninjak,     0,        ninjak,    ninjak,     taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "The Ninja Kids (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, ninjaku,    ninjak,   ninjak,    ninjaku,    taitof2_state, empty_init,    ROT0,   "Taito America Corporation", "The Ninja Kids (US)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, ninjakj,    ninjak,   ninjak,    ninjakj,    taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "The Ninja Kids (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1991, solfigtr,   0,        solfigtr,  solfigtr,   taitof2_state,  empty_init,    ROT0,   "Taito Corporation Japan",   "Solitary Fighter (World)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1991, solfigtr,   0,        solfigtr,  solfigtr,   taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Solitary Fighter (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1991, qzquest,    0,        qzquest ,  qzquest,    taitof2_state,  empty_init,    ROT0,   "Taito Corporation",         "Quiz Quest - Hime to Yuusha no Monogatari (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1991, qzquest,    0,        qzquest ,  qzquest,    taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Quiz Quest - Hime to Yuusha no Monogatari (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1991, pulirula,   0,        pulirula,  pulirula,   dondokod_state, empty_init,    ROT0,   "Taito Corporation Japan",   "PuLiRuLa (World, dual PCB)", MACHINE_SUPPORTS_SAVE )
+GAME( 1991, pulirulaa,  pulirula, pulirula,  pulirulaj,  dondokod_state, empty_init,    ROT0,   "Taito Corporation",         "PuLiRuLa (World, single PCB)", MACHINE_SUPPORTS_SAVE )
+GAME( 1991, pulirulaj,  pulirula, pulirula,  pulirulaj,  dondokod_state, empty_init,    ROT0,   "Taito Corporation",         "PuLiRuLa (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1991, pulirula,   0,        pulirula,  pulirula,   taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "PuLiRuLa (World, dual PCB)", MACHINE_SUPPORTS_SAVE )
-GAME( 1991, pulirulaa,  pulirula, pulirula,  pulirulaj,  taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "PuLiRuLa (World, single PCB)", MACHINE_SUPPORTS_SAVE )
-GAME( 1991, pulirulaj,  pulirula, pulirula,  pulirulaj,  taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "PuLiRuLa (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1991, metalb,     0,        metalb,    metalb,     footchmp_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Metal Black (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1991, metalba,    metalb,   metalb,    metalb,     footchmp_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Metal Black (World, single PCB)", MACHINE_SUPPORTS_SAVE )
+GAME( 1991, metalbj,    metalb,   metalb,    metalbj,    footchmp_state, empty_init,    ROT0,   "Taito Corporation",         "Metal Black (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1991, metalb,     0,        metalb,    metalb,     taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Metal Black (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1991, metalba,    metalb,   metalb,    metalb,     taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Metal Black (World, single PCB)", MACHINE_SUPPORTS_SAVE )
-GAME( 1991, metalbj,    metalb,   metalb,    metalbj,    taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Metal Black (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1991, qzchikyu,   0,        qzchikyu,  qzchikyu,   taitof2_state,  empty_init,    ROT0,   "Taito Corporation",         "Quiz Chikyu Bouei Gun (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1991, qzchikyu,   0,        qzchikyu,  qzchikyu,   taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Quiz Chikyu Bouei Gun (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1992, yesnoj,     0,        yesnoj,    yesnoj,     taitof2_state,  empty_init,    ROT0,   "Taito Corporation",         "Yes/No Sinri Tokimeki Chart", MACHINE_SUPPORTS_SAVE | MACHINE_NODEVICE_PRINTER )
 
-GAME( 1992, yesnoj,     0,        yesnoj,    yesnoj,     taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Yes/No Sinri Tokimeki Chart", MACHINE_SUPPORTS_SAVE | MACHINE_NODEVICE_PRINTER )
+GAME( 1992, deadconx,   0,        deadconx,  deadconx,   footchmp_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Dead Connection (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1992, deadconxj,  deadconx, deadconxj, deadconxj,  footchmp_state, empty_init,    ROT0,   "Taito Corporation",         "Dead Connection (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1992, deadconx,   0,        deadconx,  deadconx,   taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Dead Connection (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1992, deadconxj,  deadconx, deadconxj, deadconxj,  taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Dead Connection (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1992, dinorex,    0,        dinorex,   dinorex,    taitof2_state,  empty_init,    ROT0,   "Taito Corporation Japan",   "Dino Rex (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1992, dinorexu,   dinorex,  dinorex,   dinorexu,   taitof2_state,  empty_init,    ROT0,   "Taito America Corporation", "Dino Rex (US)", MACHINE_SUPPORTS_SAVE )
+GAME( 1992, dinorexj,   dinorex,  dinorex,   dinorexj,   taitof2_state,  empty_init,    ROT0,   "Taito Corporation",         "Dino Rex (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1992, dinorex,    0,        dinorex,   dinorex,    taitof2_state, empty_init,    ROT0,   "Taito Corporation Japan",   "Dino Rex (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1992, dinorexu,   dinorex,  dinorex,   dinorexu,   taitof2_state, empty_init,    ROT0,   "Taito America Corporation", "Dino Rex (US)", MACHINE_SUPPORTS_SAVE )
-GAME( 1992, dinorexj,   dinorex,  dinorex,   dinorexj,   taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Dino Rex (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1992, qjinsei,    0,        qjinsei,   qjinsei,    taitof2_state,  empty_init,    ROT0,   "Taito Corporation",         "Quiz Jinsei Gekijoh (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1992, qjinsei,    0,        qjinsei,   qjinsei,    taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Quiz Jinsei Gekijoh (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, qcrayon,    0,        qcrayon,   qcrayon,    taitof2_state,  empty_init,    ROT0,   "Taito Corporation",         "Quiz Crayon Shinchan (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1993, qcrayon,    0,        qcrayon,   qcrayon,    taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Quiz Crayon Shinchan (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, qcrayon2,   0,        qcrayon2,  qcrayon2,   taitof2_state,  empty_init,    ROT0,   "Taito Corporation",         "Crayon Shinchan Orato Asobo (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1993, qcrayon2,   0,        qcrayon2,  qcrayon2,   taitof2_state, empty_init,    ROT0,   "Taito Corporation",         "Crayon Shinchan Orato Asobo (Japan)", MACHINE_SUPPORTS_SAVE )
-
-GAME( 1991, driftout,   0,        driftout,  driftout,   taitof2_state, empty_init,    ROT270, "Visco",                     "Drift Out (Europe)", MACHINE_SUPPORTS_SAVE )
-GAME( 1991, driftoutct, driftout, driftoutct,driftoutct, taitof2_state, empty_init,    ROT270, "Visco",                     "Drift Out (Europe, Cameltry conversion)", MACHINE_SUPPORTS_SAVE )
-GAME( 1991, driftoutj,  driftout, driftout,  driftout,   taitof2_state, empty_init,    ROT270, "Visco",                     "Drift Out (Japan)", MACHINE_SUPPORTS_SAVE )
-GAME( 1991, driveout,   driftout, driveout,  driftout,   taitof2_state, init_driveout, ROT270, "bootleg",                   "Drive Out (bootleg)", MACHINE_SUPPORTS_SAVE )
+GAME( 1991, driftout,   0,        driftout,  driftout,   dondokod_state, empty_init,    ROT270, "Visco",                     "Drift Out (Europe)", MACHINE_SUPPORTS_SAVE )
+GAME( 1991, driftoutct, driftout, driftoutct,driftoutct, cameltry_state, empty_init,    ROT270, "Visco",                     "Drift Out (Europe, Cameltry conversion)", MACHINE_SUPPORTS_SAVE )
+GAME( 1991, driftoutj,  driftout, driftout,  driftout,   dondokod_state, empty_init,    ROT270, "Visco",                     "Drift Out (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1991, driveout,   driftout, driveout,  driftout,   driveout_state, empty_init,    ROT270, "bootleg",                   "Drive Out (bootleg of Drift Out)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/taito/taito_f2.h
+++ b/src/mame/taito/taito_f2.h
@@ -23,32 +23,21 @@ class taitof2_state : public driver_device
 public:
 	taitof2_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
-		, m_sprite_extension(*this, "sprite_ext")
-		, m_spriteram(*this, "spriteram")
 		, m_maincpu(*this, "maincpu")
 		, m_audiocpu(*this, "audiocpu")
-		, m_cchip(*this, "cchip")
-		, m_cchip_irq_clear(*this, "cchip_irq_clear")
 		, m_oki(*this, "oki")
 		, m_tc0100scn(*this, "tc0100scn_%u", 1U)
 		, m_tc0110pcr(*this, "tc0110pcr")
 		, m_tc0360pri(*this, "tc0360pri")
-		, m_tc0280grd(*this, "tc0280grd")
-		, m_tc0430grw(*this, "tc0430grw")
-		, m_tc0480scp(*this, "tc0480scp")
 		, m_tc0220ioc(*this, "tc0220ioc")
 		, m_tc0510nio(*this, "tc0510nio")
 		, m_gfxdecode(*this, "gfxdecode")
 		, m_screen(*this, "screen")
 		, m_palette(*this, "palette")
-		, m_io_paddle(*this, "PADDLE%u", 1U)
-		, m_io_in(*this, "IN%u", 0U)
-		, m_io_dswa(*this, "DSWA")
-		, m_io_dswb(*this, "DSWB")
+		, m_sprite_extension(*this, "sprite_ext")
+		, m_spriteram(*this, "spriteram")
 		, m_audiobank(*this, "audiobank")
-		, m_okibank(*this, "okibank")
 	{ }
-
 
 	void taito_f2_tc0220ioc(machine_config &config);
 	void taito_f2_tc0510nio(machine_config &config);
@@ -57,42 +46,24 @@ public:
 	void taito_f2(machine_config &config);
 	void thundfox(machine_config &config);
 	void dinorex(machine_config &config);
-	void mjnquest(machine_config &config);
-	void cameltrya(machine_config &config);
 	void koshien(machine_config &config);
 	void qzchikyu(machine_config &config);
-	void metalb(machine_config &config);
 	void yesnoj(machine_config &config);
 	void quizhq(machine_config &config);
-	void dondokod(machine_config &config);
 	void qcrayon2(machine_config &config);
 	void qtorimon(machine_config &config);
-	void driftout(machine_config &config);
-	void driftoutct(machine_config &config);
 	void solfigtr(machine_config &config);
 	void qzquest(machine_config &config);
 	void liquidk(machine_config &config);
-	void deadconx(machine_config &config);
 	void ssi(machine_config &config);
-	void pulirula(machine_config &config);
 	void growl(machine_config &config);
 	void ninjak(machine_config &config);
-	void footchmp(machine_config &config);
-	void cameltry(machine_config &config);
 	void finalb(machine_config &config);
-	void hthero(machine_config &config);
-	void driveout(machine_config &config);
 	void gunfront(machine_config &config);
 	void qcrayon(machine_config &config);
-	void megab(machine_config &config);
 	void qjinsei(machine_config &config);
-	void deadconxj(machine_config &config);
-	void footchmpbl(machine_config &config);
 	void yuyugogo(machine_config &config);
 
-	void init_driveout();
-	void init_cameltry();
-	void init_mjnquest();
 	void init_finalb();
 
 protected:
@@ -109,9 +80,25 @@ protected:
 		int zoomx = 0, zoomy = 0;
 		u64 primask = 0;
 	};
+	/* devices */
+	required_device<cpu_device> m_maincpu;
+	required_device<cpu_device> m_audiocpu;
+	optional_device<okim6295_device> m_oki;
+	optional_device_array<tc0100scn_device, 2> m_tc0100scn;
+	optional_device<tc0110pcr_device> m_tc0110pcr;
+	optional_device<tc0360pri_device> m_tc0360pri;
+	optional_device<tc0220ioc_device> m_tc0220ioc;
+	optional_device<tc0510nio_device> m_tc0510nio;
+	required_device<gfxdecode_device> m_gfxdecode;
+	required_device<screen_device> m_screen;
+	optional_device<palette_device> m_palette;
+
 	/* memory pointers */
 	optional_shared_ptr<u16> m_sprite_extension;
 	required_shared_ptr<u16> m_spriteram;
+
+	optional_memory_bank m_audiobank;
+
 	std::unique_ptr<u16[]>   m_spriteram_buffered;
 	std::unique_ptr<u16[]>   m_spriteram_delayed;
 
@@ -138,140 +125,66 @@ protected:
 	s32           m_hide_pixels = 0;
 	s32           m_flip_hide_pixels = 0; /* Different in some games */
 
-	s32           m_pivot_xdisp = 0;  /* Needed in games with a pivot layer */
-	s32           m_pivot_ydisp = 0;
-
 	s32           m_game = 0;
 
 	u8            m_tilepri[6]{}; // todo - move into taitoic.c
 	u8            m_spritepri[6]{}; // todo - move into taitoic.c
 	u8            m_spriteblendmode = 0; // todo - move into taitoic.c
 
-	int           m_prepare_sprites = 0;
-	u8            m_gfxbank = 0;
+	bool          m_prepare_sprites = false;
 
 	/* misc */
-	s32           m_mjnquest_input = 0;
-	int           m_last[2]{};
-	int           m_nibble = 0;
-	s32           m_driveout_sound_latch = 0;
 	emu_timer     *m_int6_timer = nullptr;
 	std::unique_ptr<u8[]> m_decoded_gfx;
-
-	/* devices */
-	required_device<cpu_device> m_maincpu;
-	required_device<cpu_device> m_audiocpu;
-	optional_device<taito_cchip_device> m_cchip;
-	optional_device<timer_device> m_cchip_irq_clear;
-	optional_device<okim6295_device> m_oki;
-	optional_device_array<tc0100scn_device, 2> m_tc0100scn;
-	optional_device<tc0110pcr_device> m_tc0110pcr;
-	optional_device<tc0360pri_device> m_tc0360pri;
-	optional_device<tc0280grd_device> m_tc0280grd;
-	optional_device<tc0280grd_device> m_tc0430grw;
-	optional_device<tc0480scp_device> m_tc0480scp;
-	optional_device<tc0220ioc_device> m_tc0220ioc;
-	optional_device<tc0510nio_device> m_tc0510nio;
-	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<screen_device> m_screen;
-	optional_device<palette_device> m_palette;
-
-	optional_ioport_array<2> m_io_paddle;
-	optional_ioport_array<7> m_io_in;
-	optional_ioport m_io_dswa;
-	optional_ioport m_io_dswb;
-
-	optional_memory_bank m_audiobank;
-	optional_memory_bank m_okibank;
 
 	void coin_nibble_w(u8 data);
 	void growl_coin_word_w(u8 data);
 	void _4p_coin_word_w(u8 data);
-	u16 cameltry_paddle_r(offs_t offset);
-	u16 mjnquest_dsw_r(offs_t offset);
-	u16 mjnquest_input_r();
-	void mjnquest_inputselect_w(u16 data);
 	void sound_bankswitch_w(u8 data);
-	u8 driveout_sound_command_r();
-	void oki_bank_w(u8 data);
-	void driveout_sound_command_w(offs_t offset, u8 data);
 	void sprite_extension_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void spritebank_w(offs_t offset, u16 data);
 	void koshien_spritebank_w(u16 data);
-	void cameltrya_porta_w(u8 data);
-	void mjnquest_gfxbank_w(u8 data);
-	TC0100SCN_CB_MEMBER(mjnquest_tmap_cb);
 
-	DECLARE_VIDEO_START(dondokod);
-	DECLARE_VIDEO_START(driftout);
 	DECLARE_VIDEO_START(finalb);
 	DECLARE_VIDEO_START(megab);
 	DECLARE_VIDEO_START(thundfox);
 	DECLARE_VIDEO_START(ssi);
 	DECLARE_VIDEO_START(gunfront);
 	DECLARE_VIDEO_START(growl);
-	DECLARE_VIDEO_START(mjnquest);
-	DECLARE_VIDEO_START(footchmp);
-	DECLARE_VIDEO_START(hthero);
 	DECLARE_VIDEO_START(koshien);
 	DECLARE_VIDEO_START(yuyugogo);
 	DECLARE_VIDEO_START(ninjak);
 	DECLARE_VIDEO_START(solfigtr);
-	DECLARE_VIDEO_START(pulirula);
-	DECLARE_VIDEO_START(metalb);
 	DECLARE_VIDEO_START(qzchikyu);
 	DECLARE_VIDEO_START(yesnoj);
-	DECLARE_VIDEO_START(deadconx);
-	DECLARE_VIDEO_START(deadconxj);
 	DECLARE_VIDEO_START(dinorex);
 	DECLARE_VIDEO_START(quiz);
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	u32 screen_update_pri_roz(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	u32 screen_update_pri(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	u32 screen_update_thundfox(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	u32 screen_update_ssi(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	u32 screen_update_deadconx(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	u32 screen_update_yesnoj(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	u32 screen_update_metalb(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void screen_vblank_no_buffer(int state);
 	void screen_vblank_partial_buffer_delayed(int state);
 	void screen_vblank_partial_buffer_delayed_thundfox(int state);
 	void screen_vblank_full_buffer_delayed(int state);
 	void screen_vblank_partial_buffer_delayed_qzchikyu(int state);
 	INTERRUPT_GEN_MEMBER(interrupt);
-	INTERRUPT_GEN_MEMBER(megab_interrupt);
-	TIMER_DEVICE_CALLBACK_MEMBER(cchip_irq_clear_cb);
 	void core_vh_start(int sprite_type, int hide, int flip_hide);
 	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u64 *primasks, int uses_tc360_mixer);
 	void update_spritebanks();
 	void handle_sprite_buffering();
 	void update_sprites_active_area();
-	void draw_roz_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u8 priority, u8 priority_mask = 0xff);
 	void taito_f2_tc360_spritemixdraw(screen_device &screen, bitmap_ind16 &dest_bmp, const rectangle &clip, gfx_element *gfx,
 	u32 code, u32 color, int flipx, int flipy, int sx, int sy, int scalex, int scaley, u64 primask = 0, bool use_mixer = false);
 
-	void cameltry_map(address_map &map) ATTR_COLD;
-	void cameltrya_map(address_map &map) ATTR_COLD;
-	void cameltrya_sound_map(address_map &map) ATTR_COLD;
-	void deadconx_map(address_map &map) ATTR_COLD;
 	void dinorex_map(address_map &map) ATTR_COLD;
-	void dondokod_map(address_map &map) ATTR_COLD;
-	void driftout_map(address_map &map) ATTR_COLD;
-	void driftoutct_map(address_map &map) ATTR_COLD;
-	void driveout_map(address_map &map) ATTR_COLD;
-	void driveout_oki_map(address_map &map) ATTR_COLD;
-	void driveout_sound_map(address_map &map) ATTR_COLD;
 	void finalb_map(address_map &map) ATTR_COLD;
-	void footchmp_map(address_map &map) ATTR_COLD;
 	void growl_map(address_map &map) ATTR_COLD;
 	void gunfront_map(address_map &map) ATTR_COLD;
 	void koshien_map(address_map &map) ATTR_COLD;
 	void liquidk_map(address_map &map) ATTR_COLD;
-	void megab_map(address_map &map) ATTR_COLD;
-	void metalb_map(address_map &map) ATTR_COLD;
-	void mjnquest_map(address_map &map) ATTR_COLD;
 	void ninjak_map(address_map &map) ATTR_COLD;
-	void pulirula_map(address_map &map) ATTR_COLD;
 	void qcrayon2_map(address_map &map) ATTR_COLD;
 	void qcrayon_map(address_map &map) ATTR_COLD;
 	void qjinsei_map(address_map &map) ATTR_COLD;
@@ -285,6 +198,184 @@ protected:
 	void thundfox_map(address_map &map) ATTR_COLD;
 	void yesnoj_map(address_map &map) ATTR_COLD;
 	void yuyugogo_map(address_map &map) ATTR_COLD;
+};
+
+// with C-Chip
+class megablst_state : public taitof2_state
+{
+public:
+	megablst_state(const machine_config &mconfig, device_type type, const char *tag)
+		: taitof2_state(mconfig, type, tag)
+		, m_cchip(*this, "cchip")
+		, m_cchip_irq_clear(*this, "cchip_irq_clear")
+	{ }
+
+	void megab(machine_config &config);
+
+private:
+	required_device<taito_cchip_device> m_cchip;
+	required_device<timer_device> m_cchip_irq_clear;
+
+	INTERRUPT_GEN_MEMBER(megab_interrupt);
+	TIMER_DEVICE_CALLBACK_MEMBER(cchip_irq_clear_cb);
+
+	void megab_map(address_map &map) ATTR_COLD;
+};
+
+// with Mahjong inputs and tilemap bank
+class mjnquest_state : public taitof2_state
+{
+public:
+	mjnquest_state(const machine_config &mconfig, device_type type, const char *tag)
+		: taitof2_state(mconfig, type, tag)
+		, m_io_in(*this, "IN%u", 0U)
+		, m_io_dsw(*this, "DSW%c", 'A')
+	{ }
+
+	void mjnquest(machine_config &config);
+
+	void init_mjnquest();
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+	virtual void video_start() override ATTR_COLD;
+
+private:
+	required_ioport_array<7> m_io_in;
+	required_ioport_array<2> m_io_dsw;
+
+	s32 m_mjnquest_input = 0;
+	u8 m_gfxbank = 0;
+
+	u16 dsw_r(offs_t offset);
+	u16 input_r();
+	void inputselect_w(u16 data);
+	void gfxbank_w(u8 data);
+	TC0100SCN_CB_MEMBER(tmap_cb);
+
+	void mjnquest_map(address_map &map) ATTR_COLD;
+};
+
+// with ROZ layer
+class dondokod_state : public taitof2_state
+{
+public:
+	dondokod_state(const machine_config &mconfig, device_type type, const char *tag)
+		: taitof2_state(mconfig, type, tag)
+		, m_tc0280grd(*this, "tc0280grd")
+		, m_tc0430grw(*this, "tc0430grw")
+	{ }
+
+	void dondokod(machine_config &config);
+	void driftout(machine_config &config);
+	void pulirula(machine_config &config);
+
+protected:
+	/* devices */
+	optional_device<tc0280grd_device> m_tc0280grd;
+	optional_device<tc0430grw_device> m_tc0430grw;
+
+	s32 m_pivot_xdisp = 0;  /* Needed in games with a pivot layer */
+	s32 m_pivot_ydisp = 0;
+
+	DECLARE_VIDEO_START(dondokod);
+	DECLARE_VIDEO_START(driftout);
+	DECLARE_VIDEO_START(pulirula);
+	u32 screen_update_pri_roz(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void draw_roz_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u8 priority, u8 priority_mask = 0xff);
+
+	void dondokod_map(address_map &map) ATTR_COLD;
+	void driftout_map(address_map &map) ATTR_COLD;
+	void pulirula_map(address_map &map) ATTR_COLD;
+};
+
+// with Paddle
+class cameltry_state : public dondokod_state
+{
+public:
+	cameltry_state(const machine_config &mconfig, device_type type, const char *tag)
+		: dondokod_state(mconfig, type, tag)
+		, m_io_paddle(*this, "PADDLE%u", 1U)
+	{ }
+
+	void cameltrya(machine_config &config);
+	void cameltry(machine_config &config);
+	void driftoutct(machine_config &config);
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+
+private:
+	required_ioport_array<2> m_io_paddle;
+
+	s32 m_last[2]{};
+
+	u16 paddle_r(offs_t offset);
+	void cameltrya_porta_w(u8 data);
+
+	void cameltry_map(address_map &map) ATTR_COLD;
+	void cameltrya_map(address_map &map) ATTR_COLD;
+	void cameltrya_sound_map(address_map &map) ATTR_COLD;
+	void driftoutct_map(address_map &map) ATTR_COLD;
+};
+
+// Bootleg with different sound system
+class driveout_state : public dondokod_state
+{
+public:
+	driveout_state(const machine_config &mconfig, device_type type, const char *tag)
+		: dondokod_state(mconfig, type, tag)
+		, m_okibank(*this, "okibank")
+	{ }
+
+	void driveout(machine_config &config);
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+
+private:
+	required_memory_bank m_okibank;
+
+	/* misc */
+	bool m_nibble = false;
+	s32  m_sound_latch = 0;
+
+	u8 sound_command_r();
+	void oki_bank_w(u8 data);
+	void sound_command_w(offs_t offset, u8 data);
+
+	void driveout_map(address_map &map) ATTR_COLD;
+	void driveout_oki_map(address_map &map) ATTR_COLD;
+	void driveout_sound_map(address_map &map) ATTR_COLD;
+};
+
+// with TC0480SCP tilemap chip
+class footchmp_state : public taitof2_state
+{
+public:
+	footchmp_state(const machine_config &mconfig, device_type type, const char *tag)
+		: taitof2_state(mconfig, type, tag)
+		, m_tc0480scp(*this, "tc0480scp")
+	{ }
+
+	void deadconx(machine_config &config);
+	void deadconxj(machine_config &config);
+	void footchmp(machine_config &config);
+	void footchmpbl(machine_config &config);
+	void hthero(machine_config &config);
+	void metalb(machine_config &config);
+
+protected:
+	optional_device<tc0480scp_device> m_tc0480scp;
+
+	DECLARE_VIDEO_START(deadconx);
+	DECLARE_VIDEO_START(footchmp);
+	u32 screen_update_deadconx(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_metalb(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+	void deadconx_map(address_map &map) ATTR_COLD;
+	void footchmp_map(address_map &map) ATTR_COLD;
+	void metalb_map(address_map &map) ATTR_COLD;
 };
 
 #endif // MAME_TAITO_TAITO_F2_H

--- a/src/mame/taito/taito_f2.h
+++ b/src/mame/taito/taito_f2.h
@@ -366,7 +366,7 @@ public:
 	void metalb(machine_config &config);
 
 protected:
-	optional_device<tc0480scp_device> m_tc0480scp;
+	required_device<tc0480scp_device> m_tc0480scp;
 
 	DECLARE_VIDEO_START(deadconx);
 	DECLARE_VIDEO_START(footchmp);

--- a/src/mame/taito/taito_f2.h
+++ b/src/mame/taito/taito_f2.h
@@ -7,14 +7,15 @@
 
 #include "taitocchip.h"
 #include "taitoio.h"
-
-#include "sound/okim6295.h"
 #include "tc0100scn.h"
 #include "tc0110pcr.h"
 #include "tc0280grd.h"
 #include "tc0360pri.h"
 #include "tc0480scp.h"
+
 #include "machine/timer.h"
+#include "sound/okim6295.h"
+
 #include "emupal.h"
 #include "screen.h"
 
@@ -39,32 +40,32 @@ public:
 		, m_audiobank(*this, "audiobank")
 	{ }
 
-	void taito_f2_tc0220ioc(machine_config &config);
-	void taito_f2_tc0510nio(machine_config &config);
-	void taito_f2_te7750(machine_config &config);
-	void taito_f2_tc0110pcr(machine_config &config);
-	void taito_f2(machine_config &config);
-	void thundfox(machine_config &config);
-	void dinorex(machine_config &config);
-	void koshien(machine_config &config);
-	void qzchikyu(machine_config &config);
-	void yesnoj(machine_config &config);
-	void quizhq(machine_config &config);
-	void qcrayon2(machine_config &config);
-	void qtorimon(machine_config &config);
-	void solfigtr(machine_config &config);
-	void qzquest(machine_config &config);
-	void liquidk(machine_config &config);
-	void ssi(machine_config &config);
-	void growl(machine_config &config);
-	void ninjak(machine_config &config);
-	void finalb(machine_config &config);
-	void gunfront(machine_config &config);
-	void qcrayon(machine_config &config);
-	void qjinsei(machine_config &config);
-	void yuyugogo(machine_config &config);
+	void taito_f2_tc0220ioc(machine_config &config) ATTR_COLD;
+	void taito_f2_tc0510nio(machine_config &config) ATTR_COLD;
+	void taito_f2_te7750(machine_config &config) ATTR_COLD;
+	void taito_f2_tc0110pcr(machine_config &config) ATTR_COLD;
+	void taito_f2(machine_config &config) ATTR_COLD;
+	void thundfox(machine_config &config) ATTR_COLD;
+	void dinorex(machine_config &config) ATTR_COLD;
+	void koshien(machine_config &config) ATTR_COLD;
+	void qzchikyu(machine_config &config) ATTR_COLD;
+	void yesnoj(machine_config &config) ATTR_COLD;
+	void quizhq(machine_config &config) ATTR_COLD;
+	void qcrayon2(machine_config &config) ATTR_COLD;
+	void qtorimon(machine_config &config) ATTR_COLD;
+	void solfigtr(machine_config &config) ATTR_COLD;
+	void qzquest(machine_config &config) ATTR_COLD;
+	void liquidk(machine_config &config) ATTR_COLD;
+	void ssi(machine_config &config) ATTR_COLD;
+	void growl(machine_config &config) ATTR_COLD;
+	void ninjak(machine_config &config) ATTR_COLD;
+	void finalb(machine_config &config) ATTR_COLD;
+	void gunfront(machine_config &config) ATTR_COLD;
+	void qcrayon(machine_config &config) ATTR_COLD;
+	void qjinsei(machine_config &config) ATTR_COLD;
+	void yuyugogo(machine_config &config) ATTR_COLD;
 
-	void init_finalb();
+	void init_finalb() ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
@@ -80,6 +81,7 @@ protected:
 		int zoomx = 0, zoomy = 0;
 		u64 primask = 0;
 	};
+
 	/* devices */
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_audiocpu;
@@ -210,7 +212,7 @@ public:
 		, m_cchip_irq_clear(*this, "cchip_irq_clear")
 	{ }
 
-	void megab(machine_config &config);
+	void megab(machine_config &config) ATTR_COLD;
 
 private:
 	required_device<taito_cchip_device> m_cchip;
@@ -232,9 +234,9 @@ public:
 		, m_io_dsw(*this, "DSW%c", 'A')
 	{ }
 
-	void mjnquest(machine_config &config);
+	void mjnquest(machine_config &config) ATTR_COLD;
 
-	void init_mjnquest();
+	void init_mjnquest() ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
@@ -266,9 +268,9 @@ public:
 		, m_tc0430grw(*this, "tc0430grw")
 	{ }
 
-	void dondokod(machine_config &config);
-	void driftout(machine_config &config);
-	void pulirula(machine_config &config);
+	void dondokod(machine_config &config) ATTR_COLD;
+	void driftout(machine_config &config) ATTR_COLD;
+	void pulirula(machine_config &config) ATTR_COLD;
 
 protected:
 	/* devices */
@@ -298,9 +300,9 @@ public:
 		, m_io_paddle(*this, "PADDLE%u", 1U)
 	{ }
 
-	void cameltrya(machine_config &config);
-	void cameltry(machine_config &config);
-	void driftoutct(machine_config &config);
+	void cameltrya(machine_config &config) ATTR_COLD;
+	void cameltry(machine_config &config) ATTR_COLD;
+	void driftoutct(machine_config &config) ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
@@ -328,7 +330,7 @@ public:
 		, m_okibank(*this, "okibank")
 	{ }
 
-	void driveout(machine_config &config);
+	void driveout(machine_config &config) ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
@@ -358,12 +360,12 @@ public:
 		, m_tc0480scp(*this, "tc0480scp")
 	{ }
 
-	void deadconx(machine_config &config);
-	void deadconxj(machine_config &config);
-	void footchmp(machine_config &config);
-	void footchmpbl(machine_config &config);
-	void hthero(machine_config &config);
-	void metalb(machine_config &config);
+	void deadconx(machine_config &config) ATTR_COLD;
+	void deadconxj(machine_config &config) ATTR_COLD;
+	void footchmp(machine_config &config) ATTR_COLD;
+	void footchmpbl(machine_config &config) ATTR_COLD;
+	void hthero(machine_config &config) ATTR_COLD;
+	void metalb(machine_config &config) ATTR_COLD;
 
 protected:
 	required_device<tc0480scp_device> m_tc0480scp;

--- a/src/mame/taito/taito_f2_v.cpp
+++ b/src/mame/taito/taito_f2_v.cpp
@@ -28,16 +28,16 @@ enum
 
 /***********************************************************************************/
 
-TC0100SCN_CB_MEMBER(taitof2_state::mjnquest_tmap_cb)
+TC0100SCN_CB_MEMBER(mjnquest_state::tmap_cb)
 {
 	*code = (*code & 0x7fff) | (m_gfxbank << 15);
 }
 
-void taitof2_state::mjnquest_gfxbank_w(u8 data)
+void mjnquest_state::gfxbank_w(u8 data)
 {
-	if ((data ^ m_gfxbank) & 1)
+	if (BIT(data ^ m_gfxbank, 0))
 	{
-		m_gfxbank = data & 1;
+		m_gfxbank = BIT(data, 0);
 		m_tc0100scn[0]->tilemap_set_dirty();
 	}
 }
@@ -66,7 +66,7 @@ void taitof2_state::core_vh_start(int sprite_type, int hide, int flip_hide)
 	m_sprites_master_scrolly = 0;
 
 	m_spriteblendmode = 0;
-	m_prepare_sprites = 0;
+	m_prepare_sprites = false;
 
 	m_game = 0;  /* means NOT footchmp */
 
@@ -149,36 +149,20 @@ VIDEO_START_MEMBER(taitof2_state,thundfox)
 	core_vh_start(0, 3, -3);
 }
 
-VIDEO_START_MEMBER(taitof2_state,mjnquest)
+void mjnquest_state::video_start()
 {
 	core_vh_start(0, 0, 0);
+	save_item(NAME(m_gfxbank));
 }
 
-VIDEO_START_MEMBER(taitof2_state,footchmp)
+VIDEO_START_MEMBER(footchmp_state,footchmp)
 {
 	core_vh_start(0, 3, 3);
 
 	m_game = FOOTCHMP;
 }
 
-VIDEO_START_MEMBER(taitof2_state,hthero)
-{
-	core_vh_start(0, 3, 3);
-
-	m_game = FOOTCHMP;
-}
-
-VIDEO_START_MEMBER(taitof2_state,deadconx)
-{
-	core_vh_start(0, 3, 3);
-}
-
-VIDEO_START_MEMBER(taitof2_state,deadconxj)
-{
-	core_vh_start(0, 3, 3);
-}
-
-VIDEO_START_MEMBER(taitof2_state,metalb)
+VIDEO_START_MEMBER(footchmp_state,deadconx)/* deadconx, metalb */
 {
 	core_vh_start(0, 3, 3);
 }
@@ -198,21 +182,21 @@ VIDEO_START_MEMBER(taitof2_state,dinorex)
 	core_vh_start(3, 3, 3);
 }
 
-VIDEO_START_MEMBER(taitof2_state,dondokod)/* dondokod, cameltry */
+VIDEO_START_MEMBER(dondokod_state,dondokod)/* dondokod, cameltry */
 {
 	m_pivot_xdisp = -16;
 	m_pivot_ydisp = 0;
 	core_vh_start(0, 3, 3);
 }
 
-VIDEO_START_MEMBER(taitof2_state,pulirula)
+VIDEO_START_MEMBER(dondokod_state,pulirula)
 {
 	m_pivot_xdisp = -10;    /* alignment seems correct (see level 2, falling */
 	m_pivot_ydisp = 16; /* block of ice after armour man) */
 	core_vh_start(2, 3, 3);
 }
 
-VIDEO_START_MEMBER(taitof2_state,driftout)
+VIDEO_START_MEMBER(dondokod_state,driftout)
 {
 	m_pivot_xdisp = -16;
 	m_pivot_ydisp = 16;
@@ -365,19 +349,19 @@ void taitof2_state::taito_f2_tc360_spritemixdraw(screen_device &screen, bitmap_i
 					for (int x = sx; x < ex; x++)
 					{
 						const u8 c = source[x_index >> 16];
-						if (c && (pri[x] & 0x80) == 0)
+						if (c && BIT(~pri[x], 7))
 						{
-							u8 tilemap_priority = 0, sprite_priority = 0;
+							u8 tilemap_priority = 0;
 
 							// Get tilemap priority (0 - 0xf) for this destination pixel
-							if (pri[x] & 0x10) tilemap_priority = m_tilepri[4];
-							else if (pri[x] & 0x8) tilemap_priority = m_tilepri[3];
-							else if (pri[x] & 0x4) tilemap_priority = m_tilepri[2];
-							else if (pri[x] & 0x2) tilemap_priority = m_tilepri[1];
-							else if (pri[x] & 0x1) tilemap_priority = m_tilepri[0];
+							if (BIT(pri[x], 4)) tilemap_priority = m_tilepri[4];
+							else if (BIT(pri[x], 3)) tilemap_priority = m_tilepri[3];
+							else if (BIT(pri[x], 2)) tilemap_priority = m_tilepri[2];
+							else if (BIT(pri[x], 1)) tilemap_priority = m_tilepri[1];
+							else if (BIT(pri[x], 0)) tilemap_priority = m_tilepri[0];
 
 							// Get sprite priority (0 - 0xf) for this source pixel
-							sprite_priority = m_spritepri[primask & 0x03];
+							const u8 sprite_priority = m_spritepri[primask & 0x03];
 
 							// Blend mode 1 - Sprite under tilemap, use sprite palette with tilemap data
 							if ((m_spriteblendmode & 0xc0) == 0xc0 && sprite_priority == (tilemap_priority - 1))
@@ -427,7 +411,7 @@ void taitof2_state::taito_f2_tc360_spritemixdraw(screen_device &screen, bitmap_i
 					for (int x = sx; x < ex; x++)
 					{
 						const u8 c = source[x_index >> 16];
-						if (c && (pri[x] & 0x80) == 0)
+						if (c && BIT(~pri[x], 7))
 						{
 							if (((1 << (pri[x] & 0x3f)) & primask) == 0)
 								dest[x] = pal_base + c;
@@ -494,7 +478,7 @@ void taitof2_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, co
 	                           this bit clear is found
 	          --x------------- flip screen
 
-	    000b - 000f : unused
+	    000c - 000f : unused
 
 	DG comment: the sprite zoom code grafted on from Jarek's TaitoB
 	may mean I have pointlessly duplicated x,y latches in the zoom &
@@ -541,10 +525,10 @@ void taitof2_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, co
 		/* sprites_active_area may change during processing */
 		const int offs = off + area;
 
-		if (m_spriteram_buffered[(offs + 6) / 2] & 0x8000)
+		if (BIT(m_spriteram_buffered[(offs + 6) / 2], 15))
 		{
-			disabled = m_spriteram_buffered[(offs + 10) / 2] & 0x1000;
-			m_sprites_flipscreen = m_spriteram_buffered[(offs + 10) / 2] & 0x2000;
+			disabled = BIT(m_spriteram_buffered[(offs + 10) / 2], 12);
+			m_sprites_flipscreen = BIT(m_spriteram_buffered[(offs + 10) / 2], 13);
 
 			/* Get rid of 0-3 unwanted pixels on edge of screen. */
 			f2_x_offset = m_hide_pixels;
@@ -610,7 +594,7 @@ void taitof2_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, co
 		}
 
 
-		if ((spritecont & 0x04) == 0)
+		if (BIT(~spritecont, 2))
 			color = spritedata & 0xff;
 
 
@@ -626,12 +610,12 @@ void taitof2_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, co
 // journey in MjnQuest). You will see they are 1 pixel too far to the right.
 // Where is this extra pixel offset coming from??
 
-			if (x & 0x8000)   /* absolute (koshien) */
+			if (BIT(x, 15))   /* absolute (koshien) */
 			{
 				scrollx = - f2_x_offset - 0x60;
 				scrolly = 0;
 			}
-			else if (x & 0x4000)   /* ignore extra scroll */
+			else if (BIT(x, 14))   /* ignore extra scroll */
 			{
 				scrollx = master_scrollx - f2_x_offset - 0x60;
 				scrolly = master_scrolly;
@@ -649,19 +633,19 @@ void taitof2_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, co
 		}
 		else
 		{
-			if ((spritecont & 0x10) == 0)
+			if (BIT(~spritecont, 4))
 				y = ycurrent;
-			else if ((spritecont & 0x20) != 0)
+			else if (BIT(spritecont, 5))
 			{
 				y += 16;
 				y_no++;   /* keep track of y tile for zooms */
 			}
-			if ((spritecont & 0x40) == 0)
+			if (BIT(~spritecont, 6))
 				x = xcurrent;
-			else if ((spritecont & 0x80) != 0)
+			else if (BIT(spritecont, 7))
 			{
 				x += 16;
-				y_no=0;
+				y_no = 0;
 				x_no++;   /* keep track of x tile for zooms */
 			}
 		}
@@ -703,8 +687,8 @@ void taitof2_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, co
 
 		if (last_continuation_tile)
 		{
-			big_sprite=0;
-			last_continuation_tile=0;
+			big_sprite = 0;
+			last_continuation_tile = 0;
 		}
 
 		u32 code = 0;
@@ -739,8 +723,8 @@ void taitof2_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, co
 
 		if (code == 0) continue;
 
-		int flipx = spritecont & 0x01;
-		int flipy = spritecont & 0x02;
+		int flipx = BIT(spritecont, 0);
+		int flipy = BIT(spritecont, 1);
 
 		int curx = (x + scrollx) & 0xfff;
 		if (curx >= 0x800)  curx -= 0x1000;   /* treat it as signed */
@@ -783,12 +767,13 @@ void taitof2_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, co
 			}
 			else
 			{
-				m_gfxdecode->gfx(0)->zoom_transpen(bitmap,cliprect,
+				m_gfxdecode->gfx(0)->zoom_transpen(bitmap, cliprect,
 						sprite_ptr->code,
 						sprite_ptr->color,
-						sprite_ptr->flipx,sprite_ptr->flipy,
-						sprite_ptr->x,sprite_ptr->y,
-						sprite_ptr->zoomx,sprite_ptr->zoomy,0);
+						sprite_ptr->flipx, sprite_ptr->flipy,
+						sprite_ptr->x, sprite_ptr->y,
+						sprite_ptr->zoomx, sprite_ptr->zoomy,
+						0);
 			}
 		}
 	}
@@ -799,12 +784,15 @@ void taitof2_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, co
 	{
 		sprite_ptr--;
 
-		taito_f2_tc360_spritemixdraw(screen,bitmap,cliprect,m_gfxdecode->gfx(0),
+		taito_f2_tc360_spritemixdraw(screen, bitmap, cliprect,
+				m_gfxdecode->gfx(0),
 				sprite_ptr->code,
 				sprite_ptr->color,
-				sprite_ptr->flipx,sprite_ptr->flipy,
-				sprite_ptr->x,sprite_ptr->y,
-				sprite_ptr->zoomx,sprite_ptr->zoomy,sprite_ptr->primask,uses_tc360_mixer);
+				sprite_ptr->flipx, sprite_ptr->flipy,
+				sprite_ptr->x, sprite_ptr->y,
+				sprite_ptr->zoomx, sprite_ptr->zoomy,
+				sprite_ptr->primask,
+				uses_tc360_mixer);
 	}
 }
 
@@ -831,7 +819,7 @@ void taitof2_state::handle_sprite_buffering()
 	if (m_prepare_sprites)   /* no buffering */
 	{
 		memcpy(m_spriteram_buffered.get(), m_spriteram, m_spriteram.bytes());
-		m_prepare_sprites = 0;
+		m_prepare_sprites = false;
 	}
 }
 
@@ -853,9 +841,9 @@ void taitof2_state::update_sprites_active_area()
 		/* sprites_active_area may change during processing */
 		const int offs = off + m_sprites_active_area;
 
-		if (m_spriteram_buffered[(offs + 6) / 2] & 0x8000)
+		if (BIT(m_spriteram_buffered[(offs + 6) / 2], 15))
 		{
-			m_sprites_disabled = m_spriteram_buffered[(offs + 10) / 2] & 0x1000;
+			m_sprites_disabled = BIT(m_spriteram_buffered[(offs + 10) / 2], 12);
 			if (m_game == FOOTCHMP)
 				m_sprites_active_area = 0x8000 * (m_spriteram_buffered[(offs + 6) / 2] & 0x0001);
 			else
@@ -885,7 +873,7 @@ void taitof2_state::screen_vblank_no_buffer(int state)
 	{
 		update_sprites_active_area();
 
-		m_prepare_sprites = 1;
+		m_prepare_sprites = true;
 	}
 }
 
@@ -896,7 +884,7 @@ void taitof2_state::screen_vblank_full_buffer_delayed(int state)
 	{
 		update_sprites_active_area();
 
-		m_prepare_sprites = 0;
+		m_prepare_sprites = false;
 		memcpy(m_spriteram_buffered.get(), m_spriteram_delayed.get(), m_spriteram.bytes());
 		for (int i = 0; i < m_spriteram.bytes() / 2; i++)
 			m_spriteram_buffered[i] = m_spriteram[i];
@@ -911,7 +899,7 @@ void taitof2_state::screen_vblank_partial_buffer_delayed(int state)
 	{
 		update_sprites_active_area();
 
-		m_prepare_sprites = 0;
+		m_prepare_sprites = false;
 		memcpy(m_spriteram_buffered.get(), m_spriteram_delayed.get(), m_spriteram.bytes());
 		for (int i = 0; i < m_spriteram.bytes() / 2; i += 4)
 			m_spriteram_buffered[i] = m_spriteram[i];
@@ -926,7 +914,7 @@ void taitof2_state::screen_vblank_partial_buffer_delayed_thundfox(int state)
 	{
 		update_sprites_active_area();
 
-		m_prepare_sprites = 0;
+		m_prepare_sprites = false;
 		memcpy(m_spriteram_buffered.get(), m_spriteram_delayed.get(), m_spriteram.bytes());
 		for (int i = 0; i < m_spriteram.bytes() / 2; i += 8)
 		{
@@ -948,7 +936,7 @@ void taitof2_state::screen_vblank_partial_buffer_delayed_qzchikyu(int state)
 
 		update_sprites_active_area();
 
-		m_prepare_sprites = 0;
+		m_prepare_sprites = false;
 		memcpy(m_spriteram_buffered.get(), m_spriteram_delayed.get(), m_spriteram.bytes());
 		for (int i = 0; i < m_spriteram.bytes() / 2; i += 8)
 		{
@@ -1045,16 +1033,16 @@ u32 taitof2_state::screen_update_pri(screen_device &screen, bitmap_ind16 &bitmap
 
 
 
-void taitof2_state::draw_roz_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u8 priority, u8 priority_mask)
+void dondokod_state::draw_roz_layer(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u8 priority, u8 priority_mask)
 {
 	if (m_tc0280grd != nullptr)
-		m_tc0280grd->tc0280grd_zoom_draw(screen, bitmap, cliprect, m_pivot_xdisp, m_pivot_ydisp, priority, priority_mask);
+		m_tc0280grd->zoom_draw(screen, bitmap, cliprect, m_pivot_xdisp, m_pivot_ydisp, priority, priority_mask);
 
 	if (m_tc0430grw != nullptr)
-		m_tc0430grw->tc0430grw_zoom_draw(screen, bitmap, cliprect, m_pivot_xdisp, m_pivot_ydisp, priority, priority_mask);
+		m_tc0430grw->zoom_draw(screen, bitmap, cliprect, m_pivot_xdisp, m_pivot_ydisp, priority, priority_mask);
 }
 
-u32 taitof2_state::screen_update_pri_roz(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 dondokod_state::screen_update_pri_roz(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	int tilepri[3];
 	int layer[3];
@@ -1063,10 +1051,10 @@ u32 taitof2_state::screen_update_pri_roz(screen_device &screen, bitmap_ind16 &bi
 	handle_sprite_buffering();
 
 	if (m_tc0280grd != nullptr)
-		m_tc0280grd->tc0280grd_tilemap_update(roz_base_color);
+		m_tc0280grd->tilemap_update(roz_base_color);
 
 	if (m_tc0430grw != nullptr)
-		m_tc0430grw->tc0430grw_tilemap_update(roz_base_color);
+		m_tc0430grw->tilemap_update(roz_base_color);
 
 	m_tc0100scn[0]->tilemap_update();
 
@@ -1192,7 +1180,7 @@ u32 taitof2_state::screen_update_thundfox(screen_device &screen, bitmap_ind16 &b
 		if (spritepri[i] < tilepri[1][2]) primasks[i] |= 0xffffffff00000000U;
 	}
 
-	draw_sprites(screen, bitmap,cliprect,primasks,0);
+	draw_sprites(screen, bitmap, cliprect, primasks, 0);
 	return 0;
 }
 
@@ -1225,7 +1213,7 @@ and it changes these (and the sprite pri settings) a lot.
 
 ********************************************************************/
 
-u32 taitof2_state::screen_update_metalb(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 footchmp_state::screen_update_metalb(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	u8 layer[5], invlayer[4];
 
@@ -1274,7 +1262,7 @@ u32 taitof2_state::screen_update_metalb(screen_device &screen, bitmap_ind16 &bit
 
 
 /* Deadconx, Footchmp */
-u32 taitof2_state::screen_update_deadconx(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 footchmp_state::screen_update_deadconx(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	u8 layer[5];
 	u8 tilepri[5];

--- a/src/mame/taito/tc0280grd.cpp
+++ b/src/mame/taito/tc0280grd.cpp
@@ -25,18 +25,29 @@ control registers:
 
 #include <algorithm>
 
-#define TC0280GRD_RAM_SIZE 0x2000
+static constexpr unsigned TC0280GRD_RAM_SIZE = 0x2000;
 
-DEFINE_DEVICE_TYPE(TC0280GRD, tc0280grd_device, "tc0280grd", "Taito TC0280GRD / TC0430GRW")
+DEFINE_DEVICE_TYPE(TC0280GRD, tc0280grd_device, "tc0280grd", "Taito TC0280GRD")
+DEFINE_DEVICE_TYPE(TC0430GRW, tc0430grw_device, "tc0430grw", "Taito TC0430GRW")
 
-tc0280grd_device::tc0280grd_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: device_t(mconfig, TC0280GRD, tag, owner, clock)
+tc0280grd_device::tc0280grd_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, type, tag, owner, clock)
 	, device_gfx_interface(mconfig, *this)
 	, m_ram(nullptr)
 	, m_base_color(0)
 	, m_colorbase(0)
 {
 	std::fill(std::begin(m_ctrl), std::end(m_ctrl), 0);
+}
+
+tc0280grd_device::tc0280grd_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: tc0280grd_device(mconfig, TC0280GRD, tag, owner, clock)
+{
+}
+
+tc0430grw_device::tc0430grw_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: tc0280grd_device(mconfig, TC0430GRW, tag, owner, clock)
+{
 }
 
 /*************************************
@@ -66,6 +77,7 @@ void tc0280grd_device::device_start()
 
 	save_pointer(NAME(m_ram), TC0280GRD_RAM_SIZE / 2);
 	save_item(NAME(m_ctrl));
+	save_item(NAME(m_base_color));
 }
 
 //-------------------------------------------------
@@ -83,45 +95,30 @@ void tc0280grd_device::device_reset()
 
 TILE_GET_INFO_MEMBER(tc0280grd_device::get_tile_info)
 {
-	int attr = m_ram[tile_index];
+	int const attr = m_ram[tile_index];
 	tileinfo.set(0,
 			attr & 0x3fff,
 			((attr & 0xc000) >> 14) + m_base_color,
 			0);
 }
 
-u16 tc0280grd_device::tc0280grd_word_r(offs_t offset)
+u16 tc0280grd_device::word_r(offs_t offset)
 {
 	return m_ram[offset];
 }
 
-void tc0280grd_device::tc0280grd_word_w(offs_t offset, u16 data, u16 mem_mask)
+void tc0280grd_device::word_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_ram[offset]);
 	m_tilemap->mark_tile_dirty(offset);
 }
 
-void tc0280grd_device::tc0280grd_ctrl_word_w(offs_t offset, u16 data, u16 mem_mask)
+void tc0280grd_device::ctrl_word_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_ctrl[offset]);
 }
 
-u16 tc0280grd_device::tc0430grw_word_r(offs_t offset)
-{
-	return tc0280grd_word_r(offset);
-}
-
-void tc0280grd_device::tc0430grw_word_w(offs_t offset, u16 data, u16 mem_mask)
-{
-	tc0280grd_word_w(offset, data, mem_mask);
-}
-
-void tc0280grd_device::tc0430grw_ctrl_word_w(offs_t offset, u16 data, u16 mem_mask)
-{
-	tc0280grd_ctrl_word_w(offset, data, mem_mask);
-}
-
-void tc0280grd_device::tc0280grd_tilemap_update(int base_color)
+void tc0280grd_device::tilemap_update(int base_color)
 {
 	if (m_base_color != base_color)
 	{
@@ -130,32 +127,27 @@ void tc0280grd_device::tc0280grd_tilemap_update(int base_color)
 	}
 }
 
-void tc0280grd_device::tc0430grw_tilemap_update(int base_color)
-{
-	tc0280grd_tilemap_update(base_color);
-}
-
-void tc0280grd_device::zoom_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int xoffset, int yoffset, u8 priority, int xmultiply, u8 priority_mask)
+void tc0280grd_device::zoom_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int xoffset, int yoffset, u8 priority, u8 priority_mask)
 {
 	/* 24-bit signed */
 	u32 startx = ((m_ctrl[0] & 0xff) << 16) + m_ctrl[1];
 
-	if (startx & 0x800000)
+	if (BIT(startx, 23))
 		startx -= 0x1000000;
 
 	int incxx = (s16)m_ctrl[2];
-	incxx *= xmultiply;
-	int incyx = (s16)m_ctrl[3];
+	incxx *= get_xmultiply();
+	int const incyx = (s16)m_ctrl[3];
 
 	/* 24-bit signed */
 	u32 starty = ((m_ctrl[4] & 0xff) << 16) + m_ctrl[5];
 
-	if (starty & 0x800000)
+	if (BIT(starty, 23))
 		starty -= 0x1000000;
 
 	int incxy = (s16)m_ctrl[6];
-	incxy *= xmultiply;
-	int incyy = (s16)m_ctrl[7];
+	incxy *= get_xmultiply();
+	int const incyy = (s16)m_ctrl[7];
 
 	startx -= xoffset * incxx + yoffset * incyx;
 	starty -= xoffset * incxy + yoffset * incyy;
@@ -164,14 +156,4 @@ void tc0280grd_device::zoom_draw(screen_device &screen, bitmap_ind16 &bitmap, co
 			incxx << 4, incxy << 4, incyx << 4, incyy << 4,
 			1,  /* copy with wraparound */
 			0, priority, priority_mask);
-}
-
-void tc0280grd_device::tc0280grd_zoom_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int xoffset, int yoffset, u8 priority, u8 priority_mask)
-{
-	zoom_draw(screen, bitmap, cliprect, xoffset, yoffset, priority, 2, priority_mask);
-}
-
-void tc0280grd_device::tc0430grw_zoom_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int xoffset, int yoffset, u8 priority, u8 priority_mask)
-{
-	zoom_draw(screen, bitmap, cliprect, xoffset, yoffset, priority, 1, priority_mask);
 }

--- a/src/mame/taito/tc0280grd.h
+++ b/src/mame/taito/tc0280grd.h
@@ -16,22 +16,20 @@ public:
 	// configuration
 	void set_color_base(u16 base) { m_colorbase = base; }
 
-	u16 tc0280grd_word_r(offs_t offset);
-	void tc0280grd_word_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void tc0280grd_ctrl_word_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void tc0280grd_tilemap_update(int base_color);
-	void tc0280grd_zoom_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int xoffset, int yoffset, u8 priority, u8 priority_mask = 0xff);
-
-	u16 tc0430grw_word_r(offs_t offset);
-	void tc0430grw_word_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void tc0430grw_ctrl_word_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void tc0430grw_tilemap_update(int base_color);
-	void tc0430grw_zoom_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int xoffset, int yoffset, u8 priority, u8 priority_mask = 0xff);
+	u16 word_r(offs_t offset);
+	void word_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void ctrl_word_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void tilemap_update(int base_color);
+	void zoom_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int xoffset, int yoffset, u8 priority, u8 priority_mask = 0xff);
 
 protected:
+	tc0280grd_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
+
 	// device-level overrides
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
+
+	virtual int get_xmultiply() { return 2; }
 
 private:
 	// internal state
@@ -39,19 +37,26 @@ private:
 
 	tilemap_t   *m_tilemap = nullptr;
 
-	u16         m_ctrl[8];
-	int         m_base_color;
+	u16         m_ctrl[8]{};
+	u32         m_base_color;
 
 	// decoding info
 	DECLARE_GFXDECODE_MEMBER(gfxinfo);
 	u16 m_colorbase;
 
 	TILE_GET_INFO_MEMBER(get_tile_info);
-	void zoom_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int xoffset, int yoffset, u8 priority, int xmultiply, u8 priority_mask = 0xff);
+};
+
+class tc0430grw_device : public tc0280grd_device
+{
+public:
+	tc0430grw_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+protected:
+	virtual int get_xmultiply() override { return 1; }
 };
 
 DECLARE_DEVICE_TYPE(TC0280GRD, tc0280grd_device)
-
-#define TC0430GRW TC0280GRD
+DECLARE_DEVICE_TYPE(TC0430GRW, tc0430grw_device)
 
 #endif // MAME_TAITO_TC0280GRD_H

--- a/src/mame/taito/tc0280grd.h
+++ b/src/mame/taito/tc0280grd.h
@@ -23,13 +23,11 @@ public:
 	void zoom_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int xoffset, int yoffset, u8 priority, u8 priority_mask = 0xff);
 
 protected:
-	tc0280grd_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
+	tc0280grd_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, int xmultiply);
 
 	// device-level overrides
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
-
-	virtual int get_xmultiply() { return 2; }
 
 private:
 	// internal state
@@ -40,9 +38,11 @@ private:
 	u16         m_ctrl[8]{};
 	u32         m_base_color;
 
+	u16         m_colorbase;
+	int const   m_xmultiply;
+
 	// decoding info
 	DECLARE_GFXDECODE_MEMBER(gfxinfo);
-	u16 m_colorbase;
 
 	TILE_GET_INFO_MEMBER(get_tile_info);
 };
@@ -51,9 +51,6 @@ class tc0430grw_device : public tc0280grd_device
 {
 public:
 	tc0430grw_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
-
-protected:
-	virtual int get_xmultiply() override { return 1; }
 };
 
 DECLARE_DEVICE_TYPE(TC0280GRD, tc0280grd_device)


### PR DESCRIPTION
Common:
- Fix typenames for fix save state
- Make some variables constant
- Reduce duplicates
- Fix naming

taito/taito_f2.cpp:
- Fix metadata via region and bootlegged game (both mjnquest set have been confirmed to be Japanese version)
- Split driver state class via hardware configuration
- Suppress side effects for debugger reads
- Fix input matrix read behaviour
- Reduce literal tag usage
- Fix docs
- Fix spacings
- Fix driveout sound routing because no sound chip with stereo support

taito/tc0280grd.cpp:
- Split TC0430GRW into separated device
- Reduce preprocessor defines
- Add variables into save state