### PR TITLE
kchqflag: Increase white svg background to avoid black border

### DIFF
--- a/src/mame/handheld/hh_sm510.cpp
+++ b/src/mame/handheld/hh_sm510.cpp
@@ -5637,7 +5637,7 @@ ROM_START( knascar )
 	ROM_LOAD( "783.program", 0x0000, 0x1000, CRC(0a08536a) SHA1(199203fad96e0d2b173b876b9746064b0c30dc7b) )
 
 	ROM_REGION( 0x100, "maincpu:melody", 0 )
-	ROM_LOAD( "783.melody", 0x000, 0x100, CRC(ffeef4bc) SHA1(a3b21eefb170aa54eb53cf56f88b0c00dd29703f))
+	ROM_LOAD( "783.melody", 0x000, 0x100, CRC(ffeef4bc) SHA1(a3b21eefb170aa54eb53cf56f88b0c00dd29703f) )
 
 	ROM_REGION( 474061, "screen", 0)
 	ROM_LOAD( "knascar.svg", 0, 474061, CRC(d30f639a) SHA1(6fd061eda61f925a9f85cf5fb4b7024f15e1e1fe) )
@@ -5648,7 +5648,7 @@ ROM_START( kchqflag )
 	ROM_LOAD( "783.program", 0x0000, 0x1000, CRC(0a08536a) SHA1(199203fad96e0d2b173b876b9746064b0c30dc7b) )
 
 	ROM_REGION( 0x100, "maincpu:melody", 0 )
-	ROM_LOAD( "783.melody", 0x000, 0x100, CRC(ffeef4bc) SHA1(a3b21eefb170aa54eb53cf56f88b0c00dd29703f))
+	ROM_LOAD( "783.melody", 0x000, 0x100, CRC(ffeef4bc) SHA1(a3b21eefb170aa54eb53cf56f88b0c00dd29703f) )
 
 	ROM_REGION( 439251, "screen", 0)
 	ROM_LOAD( "kchqflag.svg", 0, 439251, CRC(8d477ab1) SHA1(eb0fe02a4f285081f0fd422df17bca48498112de) )

--- a/src/mame/handheld/hh_sm510.cpp
+++ b/src/mame/handheld/hh_sm510.cpp
@@ -5650,8 +5650,8 @@ ROM_START( kchqflag )
 	ROM_REGION( 0x100, "maincpu:melody", 0 )
 	ROM_LOAD( "783.melody", 0x000, 0x100, CRC(ffeef4bc) SHA1(a3b21eefb170aa54eb53cf56f88b0c00dd29703f))
 
-	ROM_REGION( 439248, "screen", 0)
-	ROM_LOAD( "kchqflag.svg", 0, 439248, CRC(bb490885) SHA1(8cf3db765517c3532c04dce5e7f88a6d66d3f7c4) )
+	ROM_REGION( 439251, "screen", 0)
+	ROM_LOAD( "kchqflag.svg", 0, 439251, CRC(8d477ab1) SHA1(eb0fe02a4f285081f0fd422df17bca48498112de) )
 ROM_END
 
 


### PR DESCRIPTION
The white background of the SVG for kchqflag has been increased to avoid a black border from being shown.