### PR TITLE
taito/qix.cpp: Cleanups/Updates

### DIFF
--- a/src/mame/taito/qix.cpp
+++ b/src/mame/taito/qix.cpp
@@ -240,52 +240,84 @@ Interrupts:
 
 /*************************************
  *
+ *  Slither SN76489 I/O
+ *
+ *************************************/
+
+template <unsigned Which>
+void slither_state::sn76489_ctrl_w(int state)
+{
+	// write to the sound chip
+	if (!state && m_sn76489_ctrl[Which])
+		m_sn[Which]->write(m_pia[Which + 1]->b_output());
+
+	m_sn76489_ctrl[Which] = bool(state);
+}
+
+
+
+/*************************************
+ *
+ *  Slither trackball I/O
+ *
+ *************************************/
+
+template <unsigned Which>
+uint8_t slither_state::trak_r()
+{
+	return m_trak[Which + (m_flip ? 2 : 0)]->read();
+}
+
+
+
+/*************************************
+ *
  *  Data CPU memory handlers
  *
  *************************************/
 
 void qix_state::main_map(address_map &map)
 {
-	map(0x8000, 0x83ff).ram().share("share1");
+	map(0x8000, 0x83ff).ram().share("sharedram");
 	map(0x8400, 0x87ff).ram();
 	map(0x8800, 0x8bff).nopr();   /* 6850 ACIA */
-	map(0x8c00, 0x8c00).mirror(0x3fe).rw(FUNC(qix_state::qix_video_firq_r), FUNC(qix_state::qix_video_firq_w));
-	map(0x8c01, 0x8c01).mirror(0x3fe).rw(FUNC(qix_state::qix_data_firq_ack_r), FUNC(qix_state::qix_data_firq_ack_w));
-	map(0x9000, 0x93ff).rw(m_sndpia0, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0x9400, 0x97ff).r(m_pia0, FUNC(pia6821_device::read)).w(FUNC(qix_state::qix_pia_w));
-	map(0x9800, 0x9bff).rw(m_pia1, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0x9c00, 0x9fff).rw(m_pia2, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x8c00, 0x8c00).mirror(0x3fe).rw(FUNC(qix_state::video_firq_r), FUNC(qix_state::video_firq_w));
+	map(0x8c01, 0x8c01).mirror(0x3fe).rw(FUNC(qix_state::data_firq_ack_r), FUNC(qix_state::data_firq_ack_w));
+	map(0x9000, 0x93ff).rw(m_sndpia[0], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x9400, 0x97ff).r(m_pia[0], FUNC(pia6821_device::read)).w(FUNC(qix_state::pia_w));
+	map(0x9800, 0x9bff).rw(m_pia[1], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x9c00, 0x9fff).rw(m_pia[2], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0xa000, 0xffff).rom();
 }
 
 
-void qix_state::kram3_main_map(address_map &map)
+void kram3_state::main_map(address_map &map)
 {
-	map(0x8000, 0x83ff).ram().share("share1");
+	map(0x8000, 0x83ff).ram().share("sharedram");
 	map(0x8400, 0x87ff).ram();
 	map(0x8800, 0x8bff).nopr();   /* 6850 ACIA */
-	map(0x8c00, 0x8c00).mirror(0x3fe).rw(FUNC(qix_state::qix_video_firq_r), FUNC(qix_state::qix_video_firq_w));
-	map(0x8c01, 0x8c01).mirror(0x3fe).rw(FUNC(qix_state::qix_data_firq_ack_r), FUNC(qix_state::qix_data_firq_ack_w));
-	map(0x9000, 0x93ff).rw(m_sndpia0, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0x9400, 0x97ff).r(m_pia0, FUNC(pia6821_device::read)).w(FUNC(qix_state::qix_pia_w));
-	map(0x9800, 0x9bff).rw(m_pia1, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0x9c00, 0x9fff).rw(m_pia2, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0xa000, 0xffff).bankr("bank0");
+	map(0x8c00, 0x8c00).mirror(0x3fe).rw(FUNC(kram3_state::video_firq_r), FUNC(kram3_state::video_firq_w));
+	map(0x8c01, 0x8c01).mirror(0x3fe).rw(FUNC(kram3_state::data_firq_ack_r), FUNC(kram3_state::data_firq_ack_w));
+	map(0x9000, 0x93ff).rw(m_sndpia[0], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x9400, 0x97ff).r(m_pia[0], FUNC(pia6821_device::read)).w(FUNC(kram3_state::pia_w));
+	map(0x9800, 0x9bff).rw(m_pia[1], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x9c00, 0x9fff).rw(m_pia[2], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0xa000, 0xffff).bankr(m_mainbank);
 }
 
 
 
 void zookeep_state::main_map(address_map &map)
 {
-	map(0x0000, 0x03ff).ram().share("share1");
+	map(0x0000, 0x03ff).ram().share("sharedram");
 	map(0x0400, 0x07ff).ram();
 	map(0x0800, 0x0bff).nopr();   /* ACIA */
-	map(0x0c00, 0x0c00).mirror(0x3fe).rw(FUNC(zookeep_state::qix_video_firq_r), FUNC(zookeep_state::qix_video_firq_w));
-	map(0x0c01, 0x0c01).mirror(0x3fe).rw(FUNC(zookeep_state::qix_data_firq_ack_r), FUNC(zookeep_state::qix_data_firq_ack_w));
-	map(0x1000, 0x13ff).rw(m_sndpia0, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0x1400, 0x17ff).r(m_pia0, FUNC(pia6821_device::read)).w(FUNC(zookeep_state::qix_pia_w));
-	map(0x1800, 0x1bff).rw(m_pia1, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0x1c00, 0x1fff).rw(m_pia2, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x0c00, 0x0c00).mirror(0x3fe).rw(FUNC(zookeep_state::video_firq_r), FUNC(zookeep_state::video_firq_w));
+	map(0x0c01, 0x0c01).mirror(0x3fe).rw(FUNC(zookeep_state::data_firq_ack_r), FUNC(zookeep_state::data_firq_ack_w));
+	map(0x1000, 0x13ff).rw(m_sndpia[0], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x1400, 0x17ff).r(m_pia[0], FUNC(pia6821_device::read)).w(FUNC(zookeep_state::pia_w));
+	map(0x1800, 0x1bff).rw(m_pia[1], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x1c00, 0x1fff).rw(m_pia[2], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0x8000, 0xffff).rom();
 }
 
@@ -612,21 +644,21 @@ void qix_state::qix_base(machine_config &config)
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
-	PIA6821(config, m_pia0);
-	m_pia0->readpa_handler().set_ioport("P1");
-	m_pia0->set_port_a_input_overrides_output_mask(0xff);
-	m_pia0->readpb_handler().set_ioport("COIN");
+	PIA6821(config, m_pia[0]);
+	m_pia[0]->readpa_handler().set_ioport("P1");
+	m_pia[0]->set_port_a_input_overrides_output_mask(0xff);
+	m_pia[0]->readpb_handler().set_ioport("COIN");
 
-	PIA6821(config, m_pia1);
-	m_pia1->readpa_handler().set_ioport("SPARE");
-	m_pia1->set_port_a_input_overrides_output_mask(0xff);
-	m_pia1->readpb_handler().set_ioport("IN0");
+	PIA6821(config, m_pia[1]);
+	m_pia[1]->readpa_handler().set_ioport("SPARE");
+	m_pia[1]->set_port_a_input_overrides_output_mask(0xff);
+	m_pia[1]->readpb_handler().set_ioport("IN0");
 
-	PIA6821(config, m_pia2);
-	m_pia2->readpa_handler().set_ioport("P2");
-	m_pia2->set_port_a_input_overrides_output_mask(0xff);
-	m_pia2->writepb_handler().set(FUNC(qix_state::qix_coinctl_w));
-	m_pia2->tspb_handler().set_constant(0);
+	PIA6821(config, m_pia[2]);
+	m_pia[2]->readpa_handler().set_ioport("P2");
+	m_pia[2]->set_port_a_input_overrides_output_mask(0xff);
+	m_pia[2]->writepb_handler().set(FUNC(qix_state::coinctr_w));
+	m_pia[2]->tspb_handler().set_constant(0);
 
 	/* video hardware */
 	qix_video(config);
@@ -639,13 +671,13 @@ void qix_state::qix(machine_config &config)
 	qix_audio(config);
 }
 
-void qix_state::kram3(machine_config &config)
+void kram3_state::kram3(machine_config &config)
 {
 	qix(config);
-	m_maincpu->set_addrmap(AS_PROGRAM, &qix_state::kram3_main_map);
-	m_maincpu->lic().set(FUNC(qix_state::kram3_lic_maincpu_changed));
+	m_maincpu->set_addrmap(AS_PROGRAM, &kram3_state::main_map);
+	m_maincpu->lic().set(FUNC(kram3_state::lic_maincpu_changed));
 
-	kram3_video(config);
+	video(config);
 }
 
 /***************************************************************************
@@ -660,6 +692,7 @@ void qixmcu_state::mcu(machine_config &config)
 	qix(config);
 
 	/* basic machine hardware */
+	constexpr XTAL COIN_CLOCK_OSC = XTAL(4'000'000);     /* 4 MHz */
 
 	M68705P3(config, m_mcu, COIN_CLOCK_OSC); /* 1.00 MHz */
 	m_mcu->portb_r().set(FUNC(qixmcu_state::mcu_portb_r));
@@ -667,10 +700,10 @@ void qixmcu_state::mcu(machine_config &config)
 	m_mcu->porta_w().set(FUNC(qixmcu_state::mcu_porta_w));
 	m_mcu->portb_w().set(FUNC(qixmcu_state::mcu_portb_w));
 
-	m_pia0->readpb_handler().set(FUNC(qixmcu_state::coin_r));
-	m_pia0->writepb_handler().set(FUNC(qixmcu_state::coin_w));
+	m_pia[0]->readpb_handler().set(FUNC(qixmcu_state::coin_r));
+	m_pia[0]->writepb_handler().set(FUNC(qixmcu_state::coin_w));
 
-	m_pia2->writepb_handler().set(FUNC(qixmcu_state::coinctrl_w));
+	m_pia[2]->writepb_handler().set(FUNC(qixmcu_state::coinctrl_w));
 }
 
 
@@ -703,20 +736,20 @@ void slither_state::slither(machine_config &config)
 
 	m_maincpu->set_clock(SLITHER_CLOCK_OSC/4/4);   /* 1.34 MHz */
 
-	m_pia1->readpa_handler().set(FUNC(slither_state::trak_lr_r));
-	m_pia1->cb2_handler().set(FUNC(slither_state::sn76489_0_ctrl_w));
-	m_pia1->readpb_handler().set_constant(0);
+	m_pia[1]->readpa_handler().set(FUNC(slither_state::trak_r<1>));
+	m_pia[1]->cb2_handler().set(FUNC(slither_state::sn76489_ctrl_w<0>));
+	m_pia[1]->readpb_handler().set_constant(0);
 
-	m_pia2->readpa_handler().set(FUNC(slither_state::trak_ud_r));
-	m_pia2->writepb_handler().set_nop();
-	m_pia2->cb2_handler().set(FUNC(slither_state::sn76489_1_ctrl_w));
-	m_pia2->readpb_handler().set_constant(0);
+	m_pia[2]->readpa_handler().set(FUNC(slither_state::trak_r<0>));
+	m_pia[2]->writepb_handler().set_nop();
+	m_pia[2]->cb2_handler().set(FUNC(slither_state::sn76489_ctrl_w<1>));
+	m_pia[2]->readpb_handler().set_constant(0);
 
 	/* video hardware */
-	slither_video(config);
+	video(config);
 
 	/* audio hardware */
-	slither_audio(config);
+	audio(config);
 }
 
 
@@ -1337,7 +1370,7 @@ static const uint8_t xor2_table[] =
 	99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,11, 6,99,
 };
 
-int qix_state::kram3_permut1(int idx, int value)
+static inline int permut1(int idx, int value)
 {
 	switch (idx)
 	{
@@ -1349,7 +1382,7 @@ int qix_state::kram3_permut1(int idx, int value)
 	}
 }
 
-int qix_state::kram3_permut2(int tbl_index, int idx, const uint8_t *xor_table)
+static inline int permut2(int tbl_index, int idx, const uint8_t *xor_table)
 {
 	int xorval = 0;
 
@@ -1370,7 +1403,7 @@ int qix_state::kram3_permut2(int tbl_index, int idx, const uint8_t *xor_table)
 	return xorval;
 }
 
-int qix_state::kram3_decrypt(int address, int value)
+static inline int decrypt(int address, int value)
 {
 	int indx1 = (BIT(address,1) << 1) | BIT(address,5);
 	int indx2 = (BIT(address,7) << 1) | BIT(address,3);
@@ -1380,15 +1413,15 @@ int qix_state::kram3_decrypt(int address, int value)
 
 	int tbl_index = ((address & 0x7f00) >> 4) | (BIT(address,6) << 3) | (BIT(address,4) << 2) | (BIT(address,2) << 1) | (BIT(address,0) << 0);
 
-	int xor1 = kram3_permut2(tbl_index, indx1, xor1_table);
-	int xor2 = kram3_permut2(tbl_index, indx2, xor2_table);
+	int xor1 = permut2(tbl_index, indx1, xor1_table);
+	int xor2 = permut2(tbl_index, indx2, xor2_table);
 
 	// handle missing values in table
 	if (xor1 == 99 || xor2 == 99)
 		return 99;
 
-	bits1 = kram3_permut1(indx1, bits1);
-	bits2 = kram3_permut1(indx2, bits2);
+	bits1 = permut1(indx1, bits1);
+	bits2 = permut1(indx2, bits2);
 
 	bits1 ^= xor1;
 	bits2 ^= xor2;
@@ -1396,11 +1429,11 @@ int qix_state::kram3_decrypt(int address, int value)
 	return ((bits2 & 0xe) << 4) | ((bits1 & 0x8) << 1) | ((bits2 & 0x1) << 3) | ((bits1 & 0x7) << 0);
 }
 
-void qix_state::init_kram3()
+void kram3_state::init_kram3()
 {
 	//const uint8_t *patch;
-	assert(m_bank0);
-	assert(m_bank1);
+	assert(m_mainbank);
+	assert(m_videobank);
 
 	/********************************
 
@@ -1418,41 +1451,41 @@ void qix_state::init_kram3()
 
 	//patch = memregion("user1")->base();
 	uint8_t *rom = memregion("maincpu")->base();
-	m_decrypted = std::make_unique<uint8_t[]>(0x6000);
+	m_main_decrypted = std::make_unique<uint8_t[]>(0x6000);
 
-	memcpy(m_decrypted.get(),&rom[0xa000],0x6000);
+	memcpy(m_main_decrypted.get(),&rom[0xa000],0x6000);
 	for (int i = 0xa000; i < 0x10000; ++i)
 	{
-		m_decrypted[i-0xa000] = kram3_decrypt(i, rom[i]);
+		m_main_decrypted[i - 0xa000] = decrypt(i, rom[i]);
 	}
 
-	m_bank0->configure_entry(0, memregion("maincpu")->base() + 0xa000);
-	m_bank0->configure_entry(1, m_decrypted.get());
-	m_bank0->set_entry(0);
+	m_mainbank->configure_entry(0, memregion("maincpu")->base() + 0xa000);
+	m_mainbank->configure_entry(1, m_main_decrypted.get());
+	m_mainbank->set_entry(0);
 
 	//patch = memregion("user2")->base();
 	rom = memregion("videocpu")->base();
-	m_decrypted2 = std::make_unique<uint8_t[]>(0x6000);
+	m_video_decrypted = std::make_unique<uint8_t[]>(0x6000);
 
-	memcpy(m_decrypted2.get(),&rom[0xa000],0x6000);
+	memcpy(m_video_decrypted.get(),&rom[0xa000],0x6000);
 	for (int i = 0xa000; i < 0x10000; ++i)
 	{
-		m_decrypted2[i-0xa000] = kram3_decrypt(i, rom[i]);
+		m_video_decrypted[i - 0xa000] = decrypt(i, rom[i]);
 	}
 
-	m_bank1->configure_entry(0, memregion("videocpu")->base() + 0xa000);
-	m_bank1->configure_entry(1, m_decrypted2.get());
-	m_bank1->set_entry(0);
+	m_videobank->configure_entry(0, memregion("videocpu")->base() + 0xa000);
+	m_videobank->configure_entry(1, m_video_decrypted.get());
+	m_videobank->set_entry(0);
 }
 
-void qix_state::kram3_lic_maincpu_changed(int state)
+void kram3_state::lic_maincpu_changed(int state)
 {
-	m_bank0->set_entry( state ? 1 : 0 );
+	m_mainbank->set_entry(state ? 1 : 0);
 }
 
-void qix_state::kram3_lic_videocpu_changed(int state)
+void kram3_state::lic_videocpu_changed(int state)
 {
-	m_bank1->set_entry( state ? 1 : 0 );
+	m_videobank->set_entry(state ? 1 : 0);
 }
 
 /*************************************
@@ -1476,7 +1509,7 @@ GAMEL(1982, elecyoyoa, elecyoyo, mcu,       elecyoyo, qixmcu_state,  empty_init,
 
 GAME( 1982, kram,      0,        mcu,       kram,     qixmcu_state,  empty_init,   ROT0,   "Taito America Corporation", "Kram (rev 1)", MACHINE_SUPPORTS_SAVE )
 GAME( 1982, krama,     kram,     mcu,       kram,     qixmcu_state,  empty_init,   ROT0,   "Taito America Corporation", "Kram", MACHINE_SUPPORTS_SAVE )
-GAME( 1982, krame,     kram,     kram3,     kram,     qix_state,     init_kram3,   ROT0,   "Taito America Corporation", "Kram (encrypted)", MACHINE_UNEMULATED_PROTECTION | MACHINE_SUPPORTS_SAVE )
+GAME( 1982, krame,     kram,     kram3,     kram,     kram3_state,   init_kram3,   ROT0,   "Taito America Corporation", "Kram (encrypted)", MACHINE_UNEMULATED_PROTECTION | MACHINE_SUPPORTS_SAVE )
 
 GAME( 1982, zookeep,   0,        zookeep,   zookeep,  zookeep_state, empty_init,   ROT0,   "Taito America Corporation", "Zoo Keeper (set 1)", MACHINE_SUPPORTS_SAVE )
 GAME( 1982, zookeep2,  zookeep,  zookeep,   zookeep,  zookeep_state, empty_init,   ROT0,   "Taito America Corporation", "Zoo Keeper (set 2)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/taito/qix.h
+++ b/src/mame/taito/qix.h
@@ -134,7 +134,6 @@ private:
 	void lic_maincpu_changed(int state);
 	void lic_videocpu_changed(int state);
 
-
 	std::unique_ptr<uint8_t[]> m_main_decrypted;
 	std::unique_ptr<uint8_t[]> m_video_decrypted;
 

--- a/src/mame/taito/qix.h
+++ b/src/mame/taito/qix.h
@@ -123,11 +123,12 @@ public:
 	{ }
 
 	void kram3(machine_config &config) ATTR_COLD;
-	void video(machine_config &config) ATTR_COLD;
 
 	void init_kram3();
 
 protected:
+	void video(machine_config &config) ATTR_COLD;
+
 	void main_map(address_map &map) ATTR_COLD;
 	void video_map(address_map &map) ATTR_COLD;
 
@@ -153,11 +154,12 @@ public:
 	{ }
 
 	void slither(machine_config &config) ATTR_COLD;
-	void video(machine_config &config) ATTR_COLD;
-	void audio(machine_config &config) ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
+
+	void video(machine_config &config) ATTR_COLD;
+	void audio(machine_config &config) ATTR_COLD;
 
 	void video_map(address_map &map) ATTR_COLD;
 
@@ -220,10 +222,11 @@ public:
 
 	void zookeep(machine_config &config) ATTR_COLD;
 	void zookeepbl(machine_config &config) ATTR_COLD;
-	void video(machine_config &config) ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
+
+	void video(machine_config &config) ATTR_COLD;
 
 	void main_map(address_map &map) ATTR_COLD;
 	void video_map(address_map &map) ATTR_COLD;

--- a/src/mame/taito/qix.h
+++ b/src/mame/taito/qix.h
@@ -45,10 +45,7 @@ public:
 		m_videobank(*this, "videobank")
 	{ }
 
-	void qix_base(machine_config &config);
-	void qix(machine_config &config);
-	void qix_video(machine_config &config);
-	void qix_audio(machine_config &config);
+	void qix(machine_config &config) ATTR_COLD;
 
 protected:
 	static constexpr XTAL MAIN_CLOCK_OSC  = XTAL(20'000'000);    /* 20 MHz */
@@ -107,9 +104,13 @@ protected:
 	MC6845_BEGIN_UPDATE(crtc_begin_update);
 	MC6845_UPDATE_ROW(crtc_update_row);
 
+	void qix_base(machine_config &config) ATTR_COLD;
+	void qix_video(machine_config &config) ATTR_COLD;
+	void qix_audio(machine_config &config) ATTR_COLD;
+
 	void audio_map(address_map &map) ATTR_COLD;
-	virtual void main_map(address_map &map) ATTR_COLD;
-	virtual void video_map(address_map &map) ATTR_COLD;
+	void qix_main_map(address_map &map) ATTR_COLD;
+	void qix_video_map(address_map &map) ATTR_COLD;
 };
 
 // with encrypted CPU opcode
@@ -121,14 +122,14 @@ public:
 		m_mainbank(*this, "mainbank")
 	{ }
 
-	void kram3(machine_config &config);
-	void video(machine_config &config);
+	void kram3(machine_config &config) ATTR_COLD;
+	void video(machine_config &config) ATTR_COLD;
 
 	void init_kram3();
 
 protected:
-	virtual void main_map(address_map &map) override ATTR_COLD;
-	virtual void video_map(address_map &map) override ATTR_COLD;
+	void main_map(address_map &map) ATTR_COLD;
+	void video_map(address_map &map) ATTR_COLD;
 
 private:
 	void lic_maincpu_changed(int state);
@@ -151,14 +152,14 @@ public:
 		m_trak(*this, "AN%u", 0U)
 	{ }
 
-	void slither(machine_config &config);
-	void video(machine_config &config);
-	void audio(machine_config &config);
+	void slither(machine_config &config) ATTR_COLD;
+	void video(machine_config &config) ATTR_COLD;
+	void audio(machine_config &config) ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
 
-	virtual void video_map(address_map &map) override ATTR_COLD;
+	void video_map(address_map &map) ATTR_COLD;
 
 private:
 	static constexpr XTAL SLITHER_CLOCK_OSC = XTAL(21'300'000);    /* 21.3 MHz */
@@ -186,7 +187,7 @@ public:
 		m_coin(*this, "COIN")
 	{ }
 
-	void mcu(machine_config &config);
+	void mcu(machine_config &config) ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
@@ -217,15 +218,15 @@ public:
 		qixmcu_state(mconfig, type, tag)
 	{ }
 
-	void zookeep(machine_config &config);
-	void zookeepbl(machine_config &config);
-	void video(machine_config &config);
+	void zookeep(machine_config &config) ATTR_COLD;
+	void zookeepbl(machine_config &config) ATTR_COLD;
+	void video(machine_config &config) ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
 
-	virtual void main_map(address_map &map) override ATTR_COLD;
-	virtual void video_map(address_map &map) override ATTR_COLD;
+	void main_map(address_map &map) ATTR_COLD;
+	void video_map(address_map &map) ATTR_COLD;
 
 private:
 	void bankswitch_w(uint8_t data);

--- a/src/mame/taito/qix.h
+++ b/src/mame/taito/qix.h
@@ -21,14 +21,9 @@
 
 #include "video/mc6845.h"
 
+#include "emupal.h"
 #include "screen.h"
 
-
-#define MAIN_CLOCK_OSC          20000000    /* 20 MHz */
-#define SLITHER_CLOCK_OSC       21300000    /* 21.3 MHz */
-#define SOUND_CLOCK_OSC         7372800     /* 7.3728 MHz */
-#define COIN_CLOCK_OSC          4000000     /* 4 MHz */
-#define QIX_CHARACTER_CLOCK     (20000000/2/16)
 
 class qix_state : public driver_device
 {
@@ -39,33 +34,25 @@ public:
 		m_audiocpu(*this, "audiocpu"),
 		m_videocpu(*this, "videocpu"),
 		m_crtc(*this, "vid_u18"),
-		m_pia0(*this, "pia0"),
-		m_pia1(*this, "pia1"),
-		m_pia2(*this, "pia2"),
-		m_sndpia0(*this, "sndpia0"),
-		m_sndpia1(*this, "sndpia1"),
-		m_sndpia2(*this, "sndpia2"),
+		m_pia(*this, "pia%u", 0U),
+		m_sndpia(*this, "sndpia%u", 0U),
 		m_discrete(*this, "discrete"),
-		m_paletteram(*this, "paletteram"),
+		m_screen(*this, "screen"),
+		m_palette(*this, "palette"),
 		m_videoram(*this, "videoram", 0x10000, ENDIANNESS_BIG),
 		m_videoram_address(*this, "videoram_addr"),
-		m_videoram_mask(*this, "videoram_mask"),
 		m_scanline_latch(*this, "scanline_latch"),
-		m_bank0(*this, "bank0"),
-		m_bank1(*this, "bank1"),
-		m_screen(*this, "screen")
+		m_videobank(*this, "videobank")
 	{ }
 
 	void qix_base(machine_config &config);
 	void qix(machine_config &config);
 	void qix_video(machine_config &config);
 	void qix_audio(machine_config &config);
-	void kram3(machine_config &config);
-	void kram3_video(machine_config &config);
-
-	void init_kram3();
 
 protected:
+	static constexpr XTAL MAIN_CLOCK_OSC  = XTAL(20'000'000);    /* 20 MHz */
+
 	virtual void video_start() override ATTR_COLD;
 
 	/* devices */
@@ -73,106 +60,122 @@ protected:
 	optional_device<cpu_device> m_audiocpu;
 	required_device<mc6809e_device> m_videocpu;
 	required_device<mc6845_device> m_crtc;
-	required_device<pia6821_device> m_pia0;
-	required_device<pia6821_device> m_pia1;
-	required_device<pia6821_device> m_pia2;
-	required_device<pia6821_device> m_sndpia0;
-	optional_device<pia6821_device> m_sndpia1;
-	optional_device<pia6821_device> m_sndpia2;
+	required_device_array<pia6821_device, 3> m_pia;
+	optional_device_array<pia6821_device, 3> m_sndpia;
 	optional_device<discrete_sound_device> m_discrete;
+	required_device<screen_device> m_screen;
+	required_device<palette_device> m_palette;
 
 	/* video state */
-	required_shared_ptr<uint8_t> m_paletteram;
 	memory_share_creator<uint8_t> m_videoram;
 	required_shared_ptr<uint8_t> m_videoram_address;
-	optional_shared_ptr<uint8_t> m_videoram_mask;
 	required_shared_ptr<uint8_t> m_scanline_latch;
-	uint8_t  m_flip = 0U;
+
+	optional_memory_bank m_videobank;
+
+	bool     m_flip = false;
 	uint8_t  m_palette_bank = 0U;
 	uint8_t  m_leds = 0U;
 
-	optional_memory_bank m_bank0;
-	optional_memory_bank m_bank1;
-	required_device<screen_device> m_screen;
-	std::unique_ptr<uint8_t[]> m_decrypted;
-	std::unique_ptr<uint8_t[]> m_decrypted2;
-
-	pen_t m_pens[0x400]{};
-	void qix_data_firq_w(uint8_t data);
-	void qix_data_firq_ack_w(uint8_t data);
-	uint8_t qix_data_firq_r(address_space &space);
-	uint8_t qix_data_firq_ack_r(address_space &space);
-	void qix_video_firq_w(uint8_t data);
-	void qix_video_firq_ack_w(uint8_t data);
-	uint8_t qix_video_firq_r(address_space &space);
-	uint8_t qix_video_firq_ack_r(address_space &space);
-	uint8_t qix_videoram_r(offs_t offset);
-	void qix_videoram_w(offs_t offset, uint8_t data);
-	uint8_t qix_addresslatch_r(offs_t offset);
-	void qix_addresslatch_w(offs_t offset, uint8_t data);
-	void qix_paletteram_w(offs_t offset, uint8_t data);
-	void qix_palettebank_w(uint8_t data);
+	static rgb_t qix_R2G2B2I2(uint32_t raw);
+	void data_firq_w(uint8_t data);
+	void data_firq_ack_w(uint8_t data);
+	uint8_t data_firq_r(address_space &space);
+	uint8_t data_firq_ack_r(address_space &space);
+	void video_firq_w(uint8_t data);
+	void video_firq_ack_w(uint8_t data);
+	uint8_t video_firq_r(address_space &space);
+	uint8_t video_firq_ack_r(address_space &space);
+	uint8_t videoram_r(offs_t offset);
+	void videoram_w(offs_t offset, uint8_t data);
+	uint8_t addresslatch_r();
+	void addresslatch_w(uint8_t data);
+	void paletteram_w(offs_t offset, uint8_t data);
+	void palettebank_w(uint8_t data);
 
 	TIMER_CALLBACK_MEMBER(pia_w_callback);
 	TIMER_CALLBACK_MEMBER(deferred_sndpia1_porta_w);
-	void qix_vsync_changed(int state);
-	void qix_pia_w(offs_t offset, uint8_t data);
-	void qix_coinctl_w(uint8_t data);
+	void vsync_changed(int state);
+	void pia_w(offs_t offset, uint8_t data);
+	void coinctr_w(uint8_t data);
 	void display_enable_changed(int state);
-	void qix_flip_screen_w(int state);
-	void qix_dac_w(uint8_t data);
-	void qix_vol_w(uint8_t data);
+	void flip_screen_w(int state);
+	void dac_w(uint8_t data);
+	void vol_w(uint8_t data);
 	void sndpia_2_warning_w(uint8_t data);
 	void sync_sndpia1_porta_w(uint8_t data);
 	MC6845_BEGIN_UPDATE(crtc_begin_update);
 	MC6845_UPDATE_ROW(crtc_update_row);
-	void set_pen(int offs);
-	int kram3_permut1(int idx, int value);
-	int kram3_permut2(int tbl_index, int idx, const uint8_t *xor_table);
-	int kram3_decrypt(int address, int value);
-	void kram3_lic_maincpu_changed(int state);
-	void kram3_lic_videocpu_changed(int state);
 
 	void audio_map(address_map &map) ATTR_COLD;
-	void kram3_main_map(address_map &map) ATTR_COLD;
-	void kram3_video_map(address_map &map) ATTR_COLD;
 	void main_map(address_map &map) ATTR_COLD;
 	void qix_video_map(address_map &map) ATTR_COLD;
 };
 
+// with encrypted CPU opcode
+class kram3_state : public qix_state
+{
+public:
+	kram3_state(const machine_config &mconfig, device_type type, const char *tag) :
+		qix_state(mconfig, type, tag),
+		m_mainbank(*this, "mainbank")
+	{ }
+
+	void kram3(machine_config &config);
+	void video(machine_config &config);
+
+	void init_kram3();
+
+private:
+	void lic_maincpu_changed(int state);
+	void lic_videocpu_changed(int state);
+
+	void main_map(address_map &map) ATTR_COLD;
+	void video_map(address_map &map) ATTR_COLD;
+
+	std::unique_ptr<uint8_t[]> m_main_decrypted;
+	std::unique_ptr<uint8_t[]> m_video_decrypted;
+
+	required_memory_bank m_mainbank;
+};
+
+// with different sound system, video RAM write masking feature
 class slither_state : public qix_state
 {
 public:
 	slither_state(const machine_config &mconfig, device_type type, const char *tag) :
 		qix_state(mconfig, type, tag),
 		m_sn(*this, "sn%u", 1U),
+		m_videoram_mask(*this, "videoram_mask"),
 		m_trak(*this, "AN%u", 0U)
 	{ }
 
 	void slither(machine_config &config);
-	void slither_video(machine_config &config);
-	void slither_audio(machine_config &config);
+	void video(machine_config &config);
+	void audio(machine_config &config);
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
 
 private:
-	uint8_t trak_lr_r();
-	uint8_t trak_ud_r();
-	void sn76489_0_ctrl_w(int state);
-	void sn76489_1_ctrl_w(int state);
-	void slither_coinctl_w(uint8_t data);
-	void slither_videoram_w(offs_t offset, uint8_t data);
-	void slither_addresslatch_w(offs_t offset, uint8_t data);
+	static constexpr XTAL SLITHER_CLOCK_OSC = XTAL(21'300'000);    /* 21.3 MHz */
 
-	void slither_video_map(address_map &map) ATTR_COLD;
+	template <unsigned Which> uint8_t trak_r();
+	template <unsigned Which> void sn76489_ctrl_w(int state);
+	void slither_coinctr_w(uint8_t data);
+	void slither_videoram_w(offs_t offset, uint8_t data);
+	void slither_addresslatch_w(uint8_t data);
+
+	void video_map(address_map &map) ATTR_COLD;
 
 	required_device_array<sn76489_device, 2> m_sn;
+	required_shared_ptr<uint8_t> m_videoram_mask;
 	required_ioport_array<4> m_trak;
 
 	bool m_sn76489_ctrl[2] = { false, false };
 };
 
+// with MCU
 class qixmcu_state : public qix_state
 {
 public:
@@ -205,12 +208,12 @@ private:
 	uint8_t  m_coinctrl = 0;
 };
 
+// with video CPU bankswitching
 class zookeep_state : public qixmcu_state
 {
 public:
 	zookeep_state(const machine_config &mconfig, device_type type, const char *tag) :
-		qixmcu_state(mconfig, type, tag),
-		m_vidbank(*this, "bank1")
+		qixmcu_state(mconfig, type, tag)
 	{ }
 
 	void zookeep(machine_config &config);
@@ -225,8 +228,6 @@ private:
 
 	void main_map(address_map &map) ATTR_COLD;
 	void video_map(address_map &map) ATTR_COLD;
-
-	required_memory_bank m_vidbank;
 };
 
 #endif // MAME_TAITO_QIX_H

--- a/src/mame/taito/qix.h
+++ b/src/mame/taito/qix.h
@@ -108,8 +108,8 @@ protected:
 	MC6845_UPDATE_ROW(crtc_update_row);
 
 	void audio_map(address_map &map) ATTR_COLD;
-	void main_map(address_map &map) ATTR_COLD;
-	void qix_video_map(address_map &map) ATTR_COLD;
+	virtual void main_map(address_map &map) ATTR_COLD;
+	virtual void video_map(address_map &map) ATTR_COLD;
 };
 
 // with encrypted CPU opcode
@@ -126,12 +126,14 @@ public:
 
 	void init_kram3();
 
+protected:
+	virtual void main_map(address_map &map) override ATTR_COLD;
+	virtual void video_map(address_map &map) override ATTR_COLD;
+
 private:
 	void lic_maincpu_changed(int state);
 	void lic_videocpu_changed(int state);
 
-	void main_map(address_map &map) ATTR_COLD;
-	void video_map(address_map &map) ATTR_COLD;
 
 	std::unique_ptr<uint8_t[]> m_main_decrypted;
 	std::unique_ptr<uint8_t[]> m_video_decrypted;
@@ -157,6 +159,8 @@ public:
 protected:
 	virtual void machine_start() override ATTR_COLD;
 
+	virtual void video_map(address_map &map) override ATTR_COLD;
+
 private:
 	static constexpr XTAL SLITHER_CLOCK_OSC = XTAL(21'300'000);    /* 21.3 MHz */
 
@@ -165,8 +169,6 @@ private:
 	void slither_coinctr_w(uint8_t data);
 	void slither_videoram_w(offs_t offset, uint8_t data);
 	void slither_addresslatch_w(uint8_t data);
-
-	void video_map(address_map &map) ATTR_COLD;
 
 	required_device_array<sn76489_device, 2> m_sn;
 	required_shared_ptr<uint8_t> m_videoram_mask;
@@ -223,11 +225,11 @@ public:
 protected:
 	virtual void machine_start() override ATTR_COLD;
 
+	virtual void main_map(address_map &map) override ATTR_COLD;
+	virtual void video_map(address_map &map) override ATTR_COLD;
+
 private:
 	void bankswitch_w(uint8_t data);
-
-	void main_map(address_map &map) ATTR_COLD;
-	void video_map(address_map &map) ATTR_COLD;
 };
 
 #endif // MAME_TAITO_QIX_H

--- a/src/mame/taito/qix_a.cpp
+++ b/src/mame/taito/qix_a.cpp
@@ -134,7 +134,6 @@ void qix_state::audio_map(address_map &map)
 
 
 
-
 /*************************************
  *
  *  Machine drivers

--- a/src/mame/taito/qix_a.cpp
+++ b/src/mame/taito/qix_a.cpp
@@ -10,17 +10,19 @@
 #include "qix.h"
 
 #include "cpu/m6800/m6800.h"
+
 #include "machine/input_merger.h"
+
 #include "sound/discrete.h"
+
 #include "speaker.h"
 
 
-
 /* Discrete Sound Input Nodes */
-#define QIX_DAC_DATA        NODE_01
-#define QIX_VOL_DATA        NODE_02
-#define QIX_VOL_DATA_L      NODE_03
-#define QIX_VOL_DATA_R      NODE_04
+static constexpr uint32_t QIX_DAC_DATA   = NODE_01;
+static constexpr uint32_t QIX_VOL_DATA   = NODE_02;
+static constexpr uint32_t QIX_VOL_DATA_L = NODE_03;
+static constexpr uint32_t QIX_VOL_DATA_R = NODE_04;
 
 
 
@@ -28,12 +30,12 @@
 Audio handlers
 ***************************************************************************/
 
-void qix_state::qix_dac_w(uint8_t data)
+void qix_state::dac_w(uint8_t data)
 {
 	m_discrete->write(QIX_DAC_DATA, data);
 }
 
-void qix_state::qix_vol_w(uint8_t data)
+void qix_state::vol_w(uint8_t data)
 {
 	m_discrete->write(QIX_VOL_DATA, data);
 }
@@ -105,7 +107,7 @@ void qix_state::sndpia_2_warning_w(uint8_t data)
 
 TIMER_CALLBACK_MEMBER(qix_state::deferred_sndpia1_porta_w)
 {
-	m_sndpia1->porta_w(param);
+	m_sndpia[1]->porta_w(param);
 }
 
 
@@ -125,8 +127,8 @@ void qix_state::sync_sndpia1_porta_w(uint8_t data)
 
 void qix_state::audio_map(address_map &map)
 {
-	map(0x2000, 0x2003).mirror(0x5ffc).rw(m_sndpia2, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0x4000, 0x4003).mirror(0x3ffc).rw(m_sndpia1, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x2000, 0x2003).mirror(0x5ffc).rw(m_sndpia[2], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0x4000, 0x4003).mirror(0x3ffc).rw(m_sndpia[1], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
 	map(0xd000, 0xffff).rom();
 }
 
@@ -141,6 +143,8 @@ void qix_state::audio_map(address_map &map)
 
 void qix_state::qix_audio(machine_config &config)
 {
+	constexpr XTAL SOUND_CLOCK_OSC = XTAL(7'372'800);     /* 7.3728 MHz */
+
 	M6802(config, m_audiocpu, SOUND_CLOCK_OSC/2); /* 0.92 MHz */
 	m_audiocpu->set_addrmap(AS_PROGRAM, &qix_state::audio_map);
 
@@ -150,28 +154,28 @@ void qix_state::qix_audio(machine_config &config)
 	// SINT is connected to the sound CPU's IRQ line
 	INPUT_MERGER_ANY_HIGH(config, "sint").output_handler().set_inputline(m_audiocpu, M6802_IRQ_LINE);
 
-	PIA6821(config, m_sndpia0);
-	m_sndpia0->writepa_handler().set(FUNC(qix_state::sync_sndpia1_porta_w));
-	m_sndpia0->writepb_handler().set(FUNC(qix_state::qix_vol_w));
-	m_sndpia0->tspb_handler().set_constant(0xff);
-	m_sndpia0->ca2_handler().set("sndpia1", FUNC(pia6821_device::ca1_w));
-	m_sndpia0->cb2_handler().set(FUNC(qix_state::qix_flip_screen_w));
-	m_sndpia0->irqa_handler().set("dint", FUNC(input_merger_device::in_w<0>));
-	m_sndpia0->irqb_handler().set("dint", FUNC(input_merger_device::in_w<1>));
+	PIA6821(config, m_sndpia[0]);
+	m_sndpia[0]->writepa_handler().set(FUNC(qix_state::sync_sndpia1_porta_w));
+	m_sndpia[0]->writepb_handler().set(FUNC(qix_state::vol_w));
+	m_sndpia[0]->tspb_handler().set_constant(0xff);
+	m_sndpia[0]->ca2_handler().set(m_sndpia[1], FUNC(pia6821_device::ca1_w));
+	m_sndpia[0]->cb2_handler().set(FUNC(qix_state::flip_screen_w));
+	m_sndpia[0]->irqa_handler().set("dint", FUNC(input_merger_device::in_w<0>));
+	m_sndpia[0]->irqb_handler().set("dint", FUNC(input_merger_device::in_w<1>));
 
-	PIA6821(config, m_sndpia1);
-	m_sndpia1->writepa_handler().set("sndpia0", FUNC(pia6821_device::porta_w));
-	m_sndpia1->writepb_handler().set(FUNC(qix_state::qix_dac_w));
-	m_sndpia1->tspb_handler().set_constant(0);
-	m_sndpia1->ca2_handler().set("sndpia0", FUNC(pia6821_device::ca1_w));
-	m_sndpia1->irqa_handler().set("sint", FUNC(input_merger_device::in_w<0>));
-	m_sndpia1->irqb_handler().set("sint", FUNC(input_merger_device::in_w<1>));
+	PIA6821(config, m_sndpia[1]);
+	m_sndpia[1]->writepa_handler().set(m_sndpia[0], FUNC(pia6821_device::porta_w));
+	m_sndpia[1]->writepb_handler().set(FUNC(qix_state::dac_w));
+	m_sndpia[1]->tspb_handler().set_constant(0);
+	m_sndpia[1]->ca2_handler().set(m_sndpia[0], FUNC(pia6821_device::ca1_w));
+	m_sndpia[1]->irqa_handler().set("sint", FUNC(input_merger_device::in_w<0>));
+	m_sndpia[1]->irqb_handler().set("sint", FUNC(input_merger_device::in_w<1>));
 
-	PIA6821(config, m_sndpia2);
-	m_sndpia2->writepa_handler().set(FUNC(qix_state::sndpia_2_warning_w));
-	m_sndpia2->writepb_handler().set(FUNC(qix_state::sndpia_2_warning_w));
-	m_sndpia2->ca2_handler().set(FUNC(qix_state::sndpia_2_warning_w));
-	m_sndpia2->cb2_handler().set(FUNC(qix_state::sndpia_2_warning_w));
+	PIA6821(config, m_sndpia[2]);
+	m_sndpia[2]->writepa_handler().set(FUNC(qix_state::sndpia_2_warning_w));
+	m_sndpia[2]->writepb_handler().set(FUNC(qix_state::sndpia_2_warning_w));
+	m_sndpia[2]->ca2_handler().set(FUNC(qix_state::sndpia_2_warning_w));
+	m_sndpia[2]->cb2_handler().set(FUNC(qix_state::sndpia_2_warning_w));
 
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
@@ -181,26 +185,26 @@ void qix_state::qix_audio(machine_config &config)
 	m_discrete->add_route(1, "rspeaker", 1.0);
 }
 
-void slither_state::slither_audio(machine_config &config)
+void slither_state::audio(machine_config &config)
 {
 	// DINT is connected to the data CPU's IRQ line
 	INPUT_MERGER_ANY_HIGH(config, "dint").output_handler().set_inputline(m_maincpu, M6809_IRQ_LINE);
 
-	PIA6821(config, m_sndpia0);
-	m_sndpia0->readpa_handler().set_ioport("P2");
-	m_sndpia0->writepb_handler().set(FUNC(slither_state::slither_coinctl_w));
-	m_sndpia0->tspb_handler().set_constant(0x0f);
-	m_sndpia0->cb2_handler().set(FUNC(slither_state::qix_flip_screen_w));
-	m_sndpia0->irqa_handler().set("dint", FUNC(input_merger_device::in_w<0>));
-	m_sndpia0->irqb_handler().set("dint", FUNC(input_merger_device::in_w<1>));
+	PIA6821(config, m_sndpia[0]);
+	m_sndpia[0]->readpa_handler().set_ioport("P2");
+	m_sndpia[0]->writepb_handler().set(FUNC(slither_state::slither_coinctr_w));
+	m_sndpia[0]->tspb_handler().set_constant(0x0f);
+	m_sndpia[0]->cb2_handler().set(FUNC(slither_state::flip_screen_w));
+	m_sndpia[0]->irqa_handler().set("dint", FUNC(input_merger_device::in_w<0>));
+	m_sndpia[0]->irqb_handler().set("dint", FUNC(input_merger_device::in_w<1>));
 
 	SPEAKER(config, "mono").front_center();
 
 	SN76489(config, m_sn[0], SLITHER_CLOCK_OSC/4/4);
 	m_sn[0]->add_route(ALL_OUTPUTS, "mono", 0.50);
-	m_sn[0]->ready_cb().set(m_pia1, FUNC(pia6821_device::cb1_w));
+	m_sn[0]->ready_cb().set(m_pia[1], FUNC(pia6821_device::cb1_w));
 
 	SN76489(config, m_sn[1], SLITHER_CLOCK_OSC/4/4);
 	m_sn[1]->add_route(ALL_OUTPUTS, "mono", 0.50);
-	m_sn[1]->ready_cb().set(m_pia2, FUNC(pia6821_device::cb1_w));
+	m_sn[1]->ready_cb().set(m_pia[2], FUNC(pia6821_device::cb1_w));
 }

--- a/src/mame/taito/qix_v.cpp
+++ b/src/mame/taito/qix_v.cpp
@@ -282,7 +282,7 @@ MC6845_UPDATE_ROW(qix_state::crtc_update_row)
  *
  *************************************/
 
-void qix_state::video_map(address_map &map)
+void qix_state::qix_video_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rw(FUNC(qix_state::videoram_r), FUNC(qix_state::videoram_w));
 	map(0x8000, 0x83ff).ram().share("sharedram");
@@ -369,7 +369,7 @@ void qix_state::qix_video(machine_config &config)
 	constexpr XTAL QIX_CHARACTER_CLOCK = (XTAL(20'000'000)/2/16);
 
 	MC6809E(config, m_videocpu, MAIN_CLOCK_OSC/4/4); /* 1.25 MHz */
-	m_videocpu->set_addrmap(AS_PROGRAM, &qix_state::video_map);
+	m_videocpu->set_addrmap(AS_PROGRAM, &qix_state::qix_video_map);
 
 	MC6845(config, m_crtc, QIX_CHARACTER_CLOCK);
 	m_crtc->set_screen(m_screen);

--- a/src/mame/taito/qix_v.cpp
+++ b/src/mame/taito/qix_v.cpp
@@ -282,7 +282,7 @@ MC6845_UPDATE_ROW(qix_state::crtc_update_row)
  *
  *************************************/
 
-void qix_state::qix_video_map(address_map &map)
+void qix_state::video_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rw(FUNC(qix_state::videoram_r), FUNC(qix_state::videoram_w));
 	map(0x8000, 0x83ff).ram().share("sharedram");
@@ -369,7 +369,7 @@ void qix_state::qix_video(machine_config &config)
 	constexpr XTAL QIX_CHARACTER_CLOCK = (XTAL(20'000'000)/2/16);
 
 	MC6809E(config, m_videocpu, MAIN_CLOCK_OSC/4/4); /* 1.25 MHz */
-	m_videocpu->set_addrmap(AS_PROGRAM, &qix_state::qix_video_map);
+	m_videocpu->set_addrmap(AS_PROGRAM, &qix_state::video_map);
 
 	MC6845(config, m_crtc, QIX_CHARACTER_CLOCK);
 	m_crtc->set_screen(m_screen);


### PR DESCRIPTION
- Use palette_device for palette feature
- Separate driver state class for kram3 due to encryption
- Use logmacro.h for MCU logging
- Suppress side effects for debugger read
- Make some variables constant
- Reduce preprocessor defines
- Reduce literal tag usage
- Reduce duplicates
- Fix spacings
- Fix namings
- Add notes