### PR TITLE
m68kcpu:  for 68010 only, do not throw away buserr on prefetch

### DIFF
--- a/src/devices/cpu/m68000/m68010.cpp
+++ b/src/devices/cpu/m68000/m68010.cpp
@@ -18,6 +18,11 @@ m68010_device::m68010_device(const machine_config &mconfig, const char *tag, dev
 {
 }
 
+m68010_device::m68010_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, address_map_constructor internal_map)
+	: m68000_musashi_device(mconfig, tag, owner, clock, M68010, 16,24, internal_map)
+{
+}
+
 void m68010_device::device_start()
 {
 	m68000_musashi_device::device_start();

--- a/src/devices/cpu/m68000/m68010.h
+++ b/src/devices/cpu/m68000/m68010.h
@@ -12,6 +12,7 @@ class m68010_device : public m68000_musashi_device
 public:
 	// construction/destruction
 	m68010_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+	m68010_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, address_map_constructor internal_map);
 
 	virtual std::unique_ptr<util::disasm_interface> create_disassembler() override;
 

--- a/src/devices/cpu/m68000/m68kcpu.h
+++ b/src/devices/cpu/m68000/m68kcpu.h
@@ -604,11 +604,14 @@ inline u32 m68ki_read_imm_16()
 	result = MASK_OUT_ABOVE_16(m_pref_data);
 	m_pc += 2;
 	if (!m_mmu_tmp_buserror_occurred) {
+
 		// prefetch only if no bus error occurred in opcode fetch
 		m_pref_data = m68ki_ic_readimm16(m_pc);
 		m_pref_addr = m_mmu_tmp_buserror_occurred ? ~0 : m_pc;
-		// ignore bus error on prefetch
-		m_mmu_tmp_buserror_occurred = 0;
+		if (!CPU_TYPE_IS_010())
+		{
+			m_mmu_tmp_buserror_occurred = 0;
+		}
 	}
 
 	return result;


### PR DESCRIPTION
This is required for tek4404 to work.
Added ctor taking internal_map for handling tek4404 custom MMU