### PR TITLE
wing/pinkiri8.cpp: Updates/Cleanups:

### DIFF
--- a/src/mame/wing/pinkiri8.cpp
+++ b/src/mame/wing/pinkiri8.cpp
@@ -39,11 +39,15 @@ Dumped by Chackn
 ***************************************************************************/
 
 #include "emu.h"
+
 #include "cpu/z180/hd647180x.h"
+
 #include "sound/okim6295.h"
+
 #include "emupal.h"
 #include "screen.h"
 #include "speaker.h"
+#include "tilemap.h"
 
 #define LOG_VRAM (1U << 1)
 
@@ -53,21 +57,47 @@ Dumped by Chackn
 
 
 /* VDP device to give us our own memory map */
-class janshi_vdp_device : public device_t, public device_memory_interface
+class janshi_vdp_device : public device_t, public device_memory_interface, public device_gfx_interface
 {
 public:
 	janshi_vdp_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	void map(address_map &map) ATTR_COLD;
+	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+	void write(offs_t offset, uint8_t data);
 
 protected:
+	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 	virtual void device_validity_check(validity_checker &valid) const override;
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 	virtual space_config_vector memory_space_config() const override;
 
 private:
-	address_space_config        m_space_config;
+	address_space_config m_space_config;
+
+	required_device<palette_device> m_palette;
+
+	required_shared_ptr<uint8_t> m_back_vram;
+	required_shared_ptr<uint8_t> m_vram1;
+	required_shared_ptr<uint8_t> m_unk1;
+	required_shared_ptr<uint8_t> m_widthflags;
+	required_shared_ptr<uint8_t> m_unk2;
+	required_shared_ptr<uint8_t> m_vram2;
+	required_shared_ptr<uint8_t> m_crtc_regs;
+
+	uint32_t m_vram_addr;
+	int32_t m_prev_writes;
+
+	tilemap_t *m_tilemap;
+
+	void back_vram_w(offs_t offset, uint8_t data);
+	DECLARE_GFXDECODE_MEMBER(gfxinfo);
+	TILE_GET_INFO_MEMBER(get_tile_info);
+
+	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+	void map(address_map &map) ATTR_COLD;
 };
 
 class pinkiri8_state : public driver_device
@@ -75,86 +105,58 @@ class pinkiri8_state : public driver_device
 public:
 	pinkiri8_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
-		m_janshi_back_vram(*this, "janshivdp:back_vram"),
-		m_janshi_vram1(*this, "janshivdp:vram1"),
-		m_janshi_unk1(*this, "janshivdp:unk1"),
-		m_janshi_widthflags(*this, "janshivdp:widthflags"),
-		m_janshi_unk2(*this, "janshivdp:unk2"),
-		m_janshi_vram2(*this, "janshivdp:vram2"),
-		m_janshi_paletteram(*this, "janshivdp:paletteram"),
-		m_janshi_paletteram2(*this, "janshivdp:paletteram2"),
-		m_janshi_crtc_regs(*this, "janshivdp:crtc_regs"),
 		m_maincpu(*this, "maincpu"),
 		m_vdp(*this, "janshivdp"),
-		m_gfxdecode(*this, "gfxdecode"),
-		m_palette(*this, "palette")
+		m_io_pl{{*this, "PL1_%u", 1U}, {*this, "PL2_%u", 1U}}
 	{ }
 
 	void pinkiri8(machine_config &config);
 	void ronjan(machine_config &config);
 
 protected:
+	virtual void machine_start() override ATTR_COLD;
+
+private:
 	void output_regs_w(uint8_t data);
-	void pinkiri8_vram_w(offs_t offset, uint8_t data);
-	void mux_w(uint8_t data);
-	uint8_t mux_p2_r();
-	uint8_t mux_p1_r();
+	void io_matrix_w(uint8_t data);
+	template <unsigned Player> uint8_t io_matrix_r();
 	uint8_t ronjan_prot_r();
 	void ronjan_prot_w(uint8_t data);
 	uint8_t ronjan_prot_status_r();
 	uint8_t ronjan_patched_prot_r();
-	virtual void video_start() override ATTR_COLD;
-	uint32_t screen_update_pinkiri8(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-
-	void draw_background(bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 	void pinkiri8_io(address_map &map) ATTR_COLD;
-	void pinkiri8_map(address_map &map) ATTR_COLD;
+	void prg_map(address_map &map) ATTR_COLD;
 	void ronjan_io(address_map &map) ATTR_COLD;
-
-private:
-	required_shared_ptr<uint8_t> m_janshi_back_vram;
-	required_shared_ptr<uint8_t> m_janshi_vram1;
-	required_shared_ptr<uint8_t> m_janshi_unk1;
-	required_shared_ptr<uint8_t> m_janshi_widthflags;
-	required_shared_ptr<uint8_t> m_janshi_unk2;
-	required_shared_ptr<uint8_t> m_janshi_vram2;
-	required_shared_ptr<uint8_t> m_janshi_paletteram;
-	required_shared_ptr<uint8_t> m_janshi_paletteram2;
-	required_shared_ptr<uint8_t> m_janshi_crtc_regs;
-	uint32_t m_vram_addr = 0;
-	int m_prev_writes = 0;
-	uint8_t m_mux_data = 0;
-	uint8_t m_prot_read_index = 0;
-	uint8_t m_prot_char[5]{};
-	uint8_t m_prot_index = 0;
 
 	required_device<hd647180x_device> m_maincpu;
 	required_device<janshi_vdp_device> m_vdp;
-	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<palette_device> m_palette;
+
+	required_ioport_array<5> m_io_pl[2];
+
+	uint8_t m_io_matrix = 0;
+	uint8_t m_prot_read_index = 0;
+	uint8_t m_prot_char[5]{};
+	uint8_t m_prot_index = 0;
 };
-
-
 
 
 
 void janshi_vdp_device::map(address_map &map)
 {
-	map(0xfc0000, 0xfc1fff).ram().share("back_vram"); // bg tilemap?
-	map(0xfc2000, 0xfc2fff).ram().share("vram1"); // xpos, colour, tile number etc.
+	map(0xfc0000, 0xfc1fff).ram().w(FUNC(janshi_vdp_device::back_vram_w)).share(m_back_vram); // bg tilemap?
+	map(0xfc2000, 0xfc2fff).ram().share(m_vram1); // xpos, colour, tile number etc.
 
-	map(0xfc3700, 0xfc377f).ram().share("unk1"); // ?? height related?
-	map(0xfc3780, 0xfc37bf).ram().share("widthflags");
-	map(0xfc37c0, 0xfc37ff).ram().share("unk2"); // 2x increasing tables 00 10 20 30 etc.
+	map(0xfc3700, 0xfc377f).ram().share(m_unk1); // ?? height related?
+	map(0xfc3780, 0xfc37bf).ram().share(m_widthflags);
+	map(0xfc37c0, 0xfc37ff).ram().share(m_unk2); // 2x increasing tables 00 10 20 30 etc.
 
-	map(0xfc3800, 0xfc3fff).ram().share("vram2"); // y pos + unknown
+	map(0xfc3800, 0xfc3fff).ram().share(m_vram2); // y pos + unknown
 
-	map(0xff0000, 0xff07ff).ram().share("paletteram"); //ram().w(FUNC(janshi_vdp_device::paletteram_xBBBBBGGGGGRRRRR_byte_split_lo_w));
-	map(0xff2000, 0xff27ff).ram().share("paletteram2"); //ram().w(FUNC(janshi_vdp_device::paletteram_xBBBBBGGGGGRRRRR_byte_split_hi_w));
+	map(0xff0000, 0xff07ff).ram().w(m_palette, FUNC(palette_device::write8)).share("palette"); //ram().w(FUNC(janshi_vdp_device::paletteram_xBBBBBGGGGGRRRRR_byte_split_lo_w));
+	map(0xff2000, 0xff27ff).ram().w(m_palette, FUNC(palette_device::write8_ext)).share("palette_ext"); //ram().w(FUNC(janshi_vdp_device::paletteram_xBBBBBGGGGGRRRRR_byte_split_hi_w));
 
-	map(0xff6000, 0xff601f).ram().share("crtc_regs");
+	map(0xff6000, 0xff601f).ram().share(m_crtc_regs);
 }
 
 DEFINE_DEVICE_TYPE(JANSHIVDP, janshi_vdp_device, "janshi_vdp", "Janshi VDP")
@@ -162,12 +164,51 @@ DEFINE_DEVICE_TYPE(JANSHIVDP, janshi_vdp_device, "janshi_vdp", "Janshi VDP")
 janshi_vdp_device::janshi_vdp_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, JANSHIVDP, tag, owner, clock)
 	, device_memory_interface(mconfig, *this)
+	, device_gfx_interface(mconfig, *this, gfxinfo, "palette")
 	, m_space_config("janshi_vdp", ENDIANNESS_LITTLE, 8,24, 0, address_map_constructor(FUNC(janshi_vdp_device::map), this))
+	, m_palette(*this, "palette")
+	, m_back_vram(*this, "back_vram")
+	, m_vram1(*this, "vram1")
+	, m_unk1(*this, "unk1")
+	, m_widthflags(*this, "widthflags")
+	, m_unk2(*this, "unk2")
+	, m_vram2(*this, "vram2")
+	, m_crtc_regs(*this, "crtc_regs")
+	, m_vram_addr(0)
+	, m_prev_writes(0)
 {
 }
 
+static const gfx_layout charlayout =
+{
+	16,8,
+	RGN_FRAC(1,5),
+	5,
+	{ RGN_FRAC(4,5),RGN_FRAC(3,5),RGN_FRAC(2,5),RGN_FRAC(1,5),RGN_FRAC(0,5) },
+	{ STEP8(0,1), STEP8(8*8,1) },
+	{ STEP8(0,8) },
+	8*16
+};
+
+GFXDECODE_MEMBER(janshi_vdp_device::gfxinfo)
+	GFXDECODE_DEVICE(DEVICE_SELF, 0, charlayout, 0, 0x40 )
+GFXDECODE_END
+
+void janshi_vdp_device::device_add_mconfig(machine_config &config)
+{
+	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, 0x800);
+}
+
 void janshi_vdp_device::device_validity_check(validity_checker &valid) const {}
-void janshi_vdp_device::device_start() {}
+
+void janshi_vdp_device::device_start()
+{
+	m_tilemap = &machine().tilemap().create(*this, tilemap_get_info_delegate(*this, FUNC(janshi_vdp_device::get_tile_info)), TILEMAP_SCAN_ROWS, 16, 8, 32, 64);
+
+	save_item(NAME(m_vram_addr));
+	save_item(NAME(m_prev_writes));
+}
+
 void janshi_vdp_device::device_reset() {}
 
 device_memory_interface::space_config_vector janshi_vdp_device::memory_space_config() const
@@ -177,249 +218,18 @@ device_memory_interface::space_config_vector janshi_vdp_device::memory_space_con
 	};
 }
 
-void pinkiri8_state::video_start() {}
-
-
-void pinkiri8_state::draw_background(bitmap_ind16 &bitmap, const rectangle &cliprect)
+void janshi_vdp_device::back_vram_w(offs_t offset, uint8_t data)
 {
-	gfx_element *gfx = m_gfxdecode->gfx(0);
-
-	/* FIXME: color is a bit of a mystery */
-	{
-		int x, y, col, tile, count, attr;
-
-		count = 0;
-
-		for (y = 0; y < 64; y++)
-		{
-			for (x = 0; x < 32; x++)
-			{
-				tile = m_janshi_back_vram[count + 1] << 8 | m_janshi_back_vram[count + 0];
-				attr = m_janshi_back_vram[count + 2] ^ 0xf0;
-				col = (attr >> 4) | 0x10;
-
-					gfx->transpen(bitmap,cliprect, tile, col, 0, 0, x * 16, y * 8, 0);
-
-				count += 4;
-			}
-		}
-	}
+	m_back_vram[offset] = data;
+	m_tilemap->mark_tile_dirty(offset >> 2);
 }
 
-void pinkiri8_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect)
+void janshi_vdp_device::write(offs_t offset, uint8_t data)
 {
-	int MACHINE_TYPE_hack = 0;
-	int col_bank;
-	gfx_element *gfx = m_gfxdecode->gfx(0);
-
-	if (!strcmp(machine().system().name,"janshi")) MACHINE_TYPE_hack = 1;
-
-	//popmessage("%02x",m_janshi_crtc_regs[0x0a]);
-	col_bank = (m_janshi_crtc_regs[0x0a] & 0x40) >> 6;
-
-
-	int x,y; //,unk2;
-	int col;
-
-	int spr_offs,i;
-
-	int width, height;
-
-
-
-	for(i=(0x1000/4)-4;i>=0;i--)
-	{
-	/*  "vram1" (video map 0xfc2000)
-
-	    tttt tttt | 00tt tttt | cccc c000 | xxxx xxxx |
-
-	    "vram2" (video map 0xfc3800)
-
-	    yyyy yyyy | ???? ???? |
-
-
-	    widths come from "widthflags" (0xfc3780)
-	    "unk1" (0xfc3700) and "unk2" (0xfc37c0) are a mystery
-
-	    */
-
-		spr_offs = ((m_janshi_vram1[(i*4)+0] & 0xff) | (m_janshi_vram1[(i*4)+1]<<8)) & 0xffff;
-		col = (m_janshi_vram1[(i*4)+2] & 0xf8) >> 3;
-		x =   m_janshi_vram1[(i*4)+3] * 2;
-
-//          unk2 = m_janshi_vram2[(i*2)+1];
-		y = (m_janshi_vram2[(i*2)+0]);
-
-		y = 0x100-y;
-
-		col|= col_bank<<5;
-
-	//  width = 0; height = 0;
-
-		width = 2;
-		height = 2;
-
-
-		// this bit determines the sprite width, one bit is used in each word, each bit is used for a range of sprites
-		int bit = m_janshi_widthflags[(i/0x20)*2 + 1];
-
-		if (bit)
-		{
-			//col = machine().rand();
-			width = 2;
-		}
-		else
-		{
-			width = 1;
-			height = 2;
-		}
-
-		// hacks!
-		if (MACHINE_TYPE_hack==1) // janshi
-		{
-			if (spr_offs<0x400)
-			{
-				height = 4;
-			}
-			else if (spr_offs<0x580)
-			{
-			//  height = 2;
-			}
-			else if (spr_offs<0x880)
-			{
-				height = 4;
-			}
-			else if (spr_offs<0x1000)
-			{
-			//  height = 2;
-			}
-			else if (spr_offs<0x1080)
-			{
-			//  height = 2;
-			}
-			else if (spr_offs<0x1700)
-			{
-				height = 4;
-			}
-			else if (spr_offs<0x1730)
-			{
-			//  height = 2;
-			}
-			else if (spr_offs<0x1930)
-			{
-				height = 4;
-			}
-			else if (spr_offs<0x19c0)
-			{
-				height = 1;
-			}
-			else
-			{
-				height = 4;
-			}
-
-
-		}
-
-
-
-
-
-
-		if (height==1)
-			y+=16;
-
-
-		// hmm...
-		if (height==2)
-			y+=16;
-
-
-
-		{
-			int count = 0;
-
-
-			for (int yy=0;yy<height;yy++)
-			{
-				for (int xx=0;xx<width;xx++)
-				{
-					gfx->transpen(bitmap,cliprect,spr_offs+count,col,0,0,(x+xx*16) -7 ,(y+yy*8)-33,0);
-					count++;
-				}
-			}
-		}
-	}
-}
-
-uint32_t pinkiri8_state::screen_update_pinkiri8(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
-{
-	/* update palette */
-	for (int pen = 0; pen < 0x800 ; pen++)
-	{
-		uint16_t val = (m_janshi_paletteram[pen]) | (m_janshi_paletteram2[pen]<<8);
-		int r = (val & 0x001f) >> 0;
-		int g = (val & 0x03e0) >> 5;
-		int b = (val & 0x7c00) >> 10;
-		m_palette->set_pen_color(pen, pal5bit(r), pal5bit(g), pal5bit(b));
-	}
-
-
-
-#if 0
-	if ( machine().input().code_pressed_once(KEYCODE_W) )
-	{
-		int i;
-		int count2;
-		printf("-------------------------------\n");
-		count2=0;
-		for (i=0x00;i<0x40;i+=2)
-		{
-			printf("%02x, ", m_janshi_widthflags[i+1]);
-
-			count2++;
-
-			if (count2==0x10)
-			{
-				printf("\n");
-				count2 = 0;
-			}
-		}
-	}
-#endif
-
-
-	bitmap.fill(m_palette->black_pen(), cliprect);
-
-	draw_background(bitmap, cliprect);
-
-	draw_sprites(bitmap, cliprect);
-
-	return 0;
-}
-
-void pinkiri8_state::pinkiri8_map(address_map &map)
-{
-	map(0x00000, 0x0bfff).rom();
-	map(0x0c000, 0x0dfff).ram();
-	map(0x0e000, 0x0ffff).rom();
-	map(0x10000, 0x1ffff).rom();
-}
-
-void pinkiri8_state::output_regs_w(uint8_t data)
-{
-	if(data & 0x40)
-		m_maincpu->set_input_line(INPUT_LINE_NMI, CLEAR_LINE);
-	//data & 0x80 is probably NMI mask
-}
-
-
-void pinkiri8_state::pinkiri8_vram_w(offs_t offset, uint8_t data)
-{
-	switch(offset)
+	switch (offset)
 	{
 		case 0:
-			m_vram_addr = (data << 0)  | (m_vram_addr&0xffff00);
+			m_vram_addr = (data << 0)  | (m_vram_addr & 0xffff00);
 			LOGMASKED(LOG_VRAM, "\n prev writes was %04x\n\naddress set to %04x -\n", m_prev_writes, m_vram_addr);
 			m_prev_writes = 0;
 			break;
@@ -436,50 +246,212 @@ void pinkiri8_state::pinkiri8_vram_w(offs_t offset, uint8_t data)
 
 		case 3:
 		{
-			address_space &vdp_space = m_vdp->space();
-
 			LOGMASKED(LOG_VRAM, "%02x ", data);
 			m_prev_writes++;
 			m_vram_addr++;
 
-			vdp_space.write_byte(m_vram_addr, data);
+			space(0).write_byte(m_vram_addr, data);
 			break;
 		}
 	}
 }
 
-
-void pinkiri8_state::mux_w(uint8_t data)
+TILE_GET_INFO_MEMBER(janshi_vdp_device::get_tile_info)
 {
-	m_mux_data = data;
+	/* FIXME: color is a bit of a mystery */
+	tile_index <<= 2;
+	int const tile = m_back_vram[tile_index + 1] << 8 | m_back_vram[tile_index + 0];
+	int const attr = m_back_vram[tile_index + 2] ^ 0xf0;
+	int const col = (attr >> 4) | 0x10;
+
+	tileinfo.set(0, tile, col, 0);
 }
 
-uint8_t pinkiri8_state::mux_p2_r()
+void janshi_vdp_device::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	switch(m_mux_data)
-	{
-		case 0x01: return ioport("PL2_01")->read();
-		case 0x02: return ioport("PL2_02")->read();
-		case 0x04: return ioport("PL2_03")->read();
-		case 0x08: return ioport("PL2_04")->read();
-		case 0x10: return ioport("PL2_05")->read();
-	}
+	bool MACHINE_TYPE_hack = false;
 
-	return 0xff;
+	if (!strcmp(machine().system().name,"janshi")) MACHINE_TYPE_hack = true;
+
+	//popmessage("%02x", m_crtc_regs[0x0a]);
+	int const col_bank = (m_crtc_regs[0x0a] & 0x40) >> 6;
+
+	for (int i = (0x1000 / 4) - 4; i >= 0; i--)
+	{
+		/*
+		"vram1" (video map 0xfc2000)
+
+		tttt tttt | 00tt tttt | cccc c000 | xxxx xxxx |
+
+		"vram2" (video map 0xfc3800)
+
+		yyyy yyyy | ???? ???? |
+
+
+		widths come from "widthflags" (0xfc3780)
+		"unk1" (0xfc3700) and "unk2" (0xfc37c0) are a mystery
+	    */
+
+		int spr_offs = (m_vram1[(i * 4) + 0] | (m_vram1[(i * 4) + 1] << 8)) & 0xffff;
+		int col = (m_vram1[(i * 4) + 2] & 0xf8) >> 3;
+		int x =   m_vram1[(i * 4) + 3] * 2;
+
+		//int unk2 = m_vram2[(i * 2) + 1];
+		int y = (m_vram2[(i * 2) + 0]);
+		y = 0x100 - y;
+
+		col |= col_bank << 5;
+
+		//int width = 0, height = 0;
+
+		int width = 2;
+		int height = 2;
+
+		// this bit determines the sprite width, one bit is used in each word, each bit is used for a range of sprites
+		int const bit = m_widthflags[(i / 0x20) * 2 + 1];
+
+		if (bit)
+		{
+			//col = machine().rand();
+			width = 2;
+		}
+		else
+		{
+			width = 1;
+			height = 2;
+		}
+
+		// hacks!
+		if (MACHINE_TYPE_hack) // janshi
+		{
+			if (spr_offs < 0x400)
+			{
+				height = 4;
+			}
+			else if (spr_offs < 0x580)
+			{
+			//  height = 2;
+			}
+			else if (spr_offs < 0x880)
+			{
+				height = 4;
+			}
+			else if (spr_offs < 0x1000)
+			{
+			//  height = 2;
+			}
+			else if (spr_offs < 0x1080)
+			{
+			//  height = 2;
+			}
+			else if (spr_offs < 0x1700)
+			{
+				height = 4;
+			}
+			else if (spr_offs < 0x1730)
+			{
+			//  height = 2;
+			}
+			else if (spr_offs < 0x1930)
+			{
+				height = 4;
+			}
+			else if (spr_offs < 0x19c0)
+			{
+				height = 1;
+			}
+			else
+			{
+				height = 4;
+			}
+		}
+
+		if (height == 1)
+			y += 16;
+
+		// hmm...
+		if (height == 2)
+			y += 16;
+
+		int count = 0;
+
+		for (int yy = 0; yy < height; yy++)
+		{
+			for (int xx = 0; xx < width; xx++)
+			{
+				gfx(0)->transpen(bitmap, cliprect,
+						spr_offs + count, col,
+						0, 0,
+						(x + xx * 16) - 7, (y + yy * 8) - 33,
+						0);
+				count++;
+			}
+		}
+	}
 }
 
-uint8_t pinkiri8_state::mux_p1_r()
+uint32_t janshi_vdp_device::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	switch(m_mux_data)
+#if 0
+	if (machine().input().code_pressed_once(KEYCODE_W))
 	{
-		case 0x01: return ioport("PL1_01")->read();
-		case 0x02: return ioport("PL1_02")->read();
-		case 0x04: return ioport("PL1_03")->read();
-		case 0x08: return ioport("PL1_04")->read();
-		case 0x10: return ioport("PL1_05")->read();
+		printf("-------------------------------\n");
+		int count2 = 0;
+		for (int i = 0x00; i < 0x40; i += 2)
+		{
+			printf("%02x, ", m_widthflags[i+1]);
+
+			count2++;
+
+			if (count2 == 0x10)
+			{
+				printf("\n");
+				count2 = 0;
+			}
+		}
+	}
+#endif
+
+	bitmap.fill(m_palette->black_pen(), cliprect);
+
+	m_tilemap->draw(screen, bitmap, cliprect, 0, 0);
+
+	draw_sprites(bitmap, cliprect);
+
+	return 0;
+}
+
+void pinkiri8_state::prg_map(address_map &map)
+{
+	map(0x00000, 0x0bfff).rom();
+	map(0x0c000, 0x0dfff).ram();
+	map(0x0e000, 0x0ffff).rom();
+	map(0x10000, 0x1ffff).rom();
+}
+
+void pinkiri8_state::output_regs_w(uint8_t data)
+{
+	if (BIT(data, 6))
+		m_maincpu->set_input_line(INPUT_LINE_NMI, CLEAR_LINE);
+	//BIT(data, 7) is probably NMI mask
+}
+
+void pinkiri8_state::io_matrix_w(uint8_t data)
+{
+	m_io_matrix = data;
+}
+
+template <unsigned Player>
+uint8_t pinkiri8_state::io_matrix_r()
+{
+	uint8_t ret = 0xff;
+	for (int i = 0; i < 5; i++)
+	{
+		if (BIT(m_io_matrix, i))
+			ret &= m_io_pl[Player][i]->read();
 	}
 
-	return 0xff;
+	return ret;
 }
 
 void pinkiri8_state::pinkiri8_io(address_map &map)
@@ -487,12 +459,12 @@ void pinkiri8_state::pinkiri8_io(address_map &map)
 	map.global_mask(0xff);
 	map(0x00, 0x3f).ram(); //Z180 internal I/O
 	map(0x60, 0x60).nopw();
-	map(0x80, 0x83).w(FUNC(pinkiri8_state::pinkiri8_vram_w));
+	map(0x80, 0x83).w(m_vdp, FUNC(janshi_vdp_device::write));
 
 	map(0xa0, 0xa0).rw("oki", FUNC(okim6295_device::read), FUNC(okim6295_device::write)); //correct?
-	map(0xb0, 0xb0).w(FUNC(pinkiri8_state::mux_w)); //mux
-	map(0xb0, 0xb0).r(FUNC(pinkiri8_state::mux_p2_r)); // mux inputs
-	map(0xb1, 0xb1).r(FUNC(pinkiri8_state::mux_p1_r)); // mux inputs
+	map(0xb0, 0xb0).w(FUNC(pinkiri8_state::io_matrix_w)); //mux
+	map(0xb0, 0xb0).r(FUNC(pinkiri8_state::io_matrix_r<1>)); // mux inputs
+	map(0xb1, 0xb1).r(FUNC(pinkiri8_state::io_matrix_r<0>)); // mux inputs
 	map(0xb2, 0xb2).portr("SYSTEM");
 	map(0xf8, 0xf8).portr("DSW1");
 	map(0xf9, 0xf9).portr("DSW2");
@@ -536,7 +508,7 @@ static INPUT_PORTS_START( base_inputs )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_GAMBLE_KEYIN )
 	PORT_BIT( 0xc0, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("PL1_01")
+	PORT_START("PL1_1")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_MAHJONG_A )
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_MAHJONG_E )
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_MAHJONG_I )
@@ -544,7 +516,7 @@ static INPUT_PORTS_START( base_inputs )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_MAHJONG_KAN )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_START1 )
 
-	PORT_START("PL1_02")
+	PORT_START("PL1_2")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_MAHJONG_B )
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_MAHJONG_F )
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_MAHJONG_J )
@@ -552,7 +524,7 @@ static INPUT_PORTS_START( base_inputs )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_MAHJONG_REACH )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_MAHJONG_BET )
 
-	PORT_START("PL1_03")
+	PORT_START("PL1_3")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_MAHJONG_C )
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_MAHJONG_G )
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_MAHJONG_K )
@@ -560,7 +532,7 @@ static INPUT_PORTS_START( base_inputs )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_MAHJONG_RON )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("PL1_04")
+	PORT_START("PL1_4")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_MAHJONG_D )
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_MAHJONG_H )
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_MAHJONG_L )
@@ -568,7 +540,7 @@ static INPUT_PORTS_START( base_inputs )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("PL1_05")
+	PORT_START("PL1_5")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_MAHJONG_LAST_CHANCE )
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_MAHJONG_SCORE )
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_MAHJONG_DOUBLE_UP )
@@ -576,7 +548,7 @@ static INPUT_PORTS_START( base_inputs )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_MAHJONG_BIG )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_MAHJONG_SMALL )
 
-	PORT_START("PL2_01")
+	PORT_START("PL2_1")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_MAHJONG_A ) PORT_PLAYER(2)
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_MAHJONG_E ) PORT_PLAYER(2)
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_MAHJONG_I ) PORT_PLAYER(2)
@@ -584,7 +556,7 @@ static INPUT_PORTS_START( base_inputs )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_MAHJONG_KAN ) PORT_PLAYER(2)
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_START2 )
 
-	PORT_START("PL2_02")
+	PORT_START("PL2_2")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_MAHJONG_B ) PORT_PLAYER(2)
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_MAHJONG_F ) PORT_PLAYER(2)
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_MAHJONG_J ) PORT_PLAYER(2)
@@ -592,7 +564,7 @@ static INPUT_PORTS_START( base_inputs )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_MAHJONG_REACH ) PORT_PLAYER(2)
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_MAHJONG_BET ) PORT_PLAYER(2)
 
-	PORT_START("PL2_03")
+	PORT_START("PL2_3")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_MAHJONG_C ) PORT_PLAYER(2)
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_MAHJONG_G ) PORT_PLAYER(2)
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_MAHJONG_K ) PORT_PLAYER(2)
@@ -600,7 +572,7 @@ static INPUT_PORTS_START( base_inputs )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_MAHJONG_RON ) PORT_PLAYER(2)
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("PL2_04")
+	PORT_START("PL2_4")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_MAHJONG_D ) PORT_PLAYER(2)
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_MAHJONG_H ) PORT_PLAYER(2)
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_MAHJONG_L ) PORT_PLAYER(2)
@@ -608,7 +580,7 @@ static INPUT_PORTS_START( base_inputs )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("PL2_05")
+	PORT_START("PL2_5")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_MAHJONG_LAST_CHANCE ) PORT_PLAYER(2)
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_MAHJONG_SCORE ) PORT_PLAYER(2)
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_MAHJONG_DOUBLE_UP ) PORT_PLAYER(2)
@@ -913,7 +885,7 @@ static INPUT_PORTS_START( pinkiri8 )
 	PORT_INCLUDE( base_inputs )
 
 	/* standard mahjong panel converted to a hanafuda one */
-	PORT_MODIFY("PL1_01")
+	PORT_MODIFY("PL1_1")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_HANAFUDA_A )
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_HANAFUDA_E )
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -921,7 +893,7 @@ static INPUT_PORTS_START( pinkiri8 )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_START1 )
 
-	PORT_MODIFY("PL1_02")
+	PORT_MODIFY("PL1_2")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_HANAFUDA_B )
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_HANAFUDA_F )
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -929,7 +901,7 @@ static INPUT_PORTS_START( pinkiri8 )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_MAHJONG_BET )
 
-	PORT_MODIFY("PL1_03")
+	PORT_MODIFY("PL1_3")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_HANAFUDA_C )
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_HANAFUDA_G )
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -937,7 +909,7 @@ static INPUT_PORTS_START( pinkiri8 )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_MODIFY("PL1_04")
+	PORT_MODIFY("PL1_4")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_HANAFUDA_D )
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_HANAFUDA_H )
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -945,7 +917,7 @@ static INPUT_PORTS_START( pinkiri8 )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_MODIFY("PL1_05")
+	PORT_MODIFY("PL1_5")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -953,7 +925,7 @@ static INPUT_PORTS_START( pinkiri8 )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_MODIFY("PL2_01")
+	PORT_MODIFY("PL2_1")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_HANAFUDA_A ) PORT_PLAYER(2)
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_HANAFUDA_E ) PORT_PLAYER(2)
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -961,7 +933,7 @@ static INPUT_PORTS_START( pinkiri8 )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_START2 )
 
-	PORT_MODIFY("PL2_02")
+	PORT_MODIFY("PL2_2")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_HANAFUDA_B ) PORT_PLAYER(2)
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_HANAFUDA_F ) PORT_PLAYER(2)
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -969,7 +941,7 @@ static INPUT_PORTS_START( pinkiri8 )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_MAHJONG_BET ) PORT_PLAYER(2)
 
-	PORT_MODIFY("PL2_03")
+	PORT_MODIFY("PL2_3")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_HANAFUDA_C ) PORT_PLAYER(2)
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_HANAFUDA_G ) PORT_PLAYER(2)
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -977,7 +949,7 @@ static INPUT_PORTS_START( pinkiri8 )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_MODIFY("PL2_04")
+	PORT_MODIFY("PL2_4")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_HANAFUDA_D ) PORT_PLAYER(2)
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_HANAFUDA_H ) PORT_PLAYER(2)
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -985,7 +957,7 @@ static INPUT_PORTS_START( pinkiri8 )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_MODIFY("PL2_05")
+	PORT_MODIFY("PL2_5")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_UNUSED )
@@ -1103,25 +1075,19 @@ static INPUT_PORTS_START( pinkiri8 )
 	PORT_DIPUNUSED_DIPLOC( 0x80, 0x80, "SW4:8" )
 INPUT_PORTS_END
 
-static const gfx_layout charlayout =
+void pinkiri8_state::machine_start()
 {
-	16,8,
-	RGN_FRAC(1,5),
-	5,
-	{ RGN_FRAC(4,5),RGN_FRAC(3,5),RGN_FRAC(2,5),RGN_FRAC(1,5),RGN_FRAC(0,5) },
-	{ 0, 1, 2, 3, 4, 5, 6, 7, 8*8+0, 8*8+1, 8*8+2, 8*8+3, 8*8+4, 8*8+5, 8*8+6, 8*8+7 },
-	{ 0*8, 1*8, 2*8, 3*8, 4*8, 5*8, 6*8, 7*8 },
-	8*16
-};
-
-static GFXDECODE_START( gfx_pinkiri8 )
-	GFXDECODE_ENTRY( "gfx1", 0, charlayout,     0, 0x100 )
-GFXDECODE_END
+	save_item(NAME(m_io_matrix));
+	
+	save_item(NAME(m_prot_read_index));
+	save_item(NAME(m_prot_char));
+	save_item(NAME(m_prot_index));
+}
 
 void pinkiri8_state::pinkiri8(machine_config &config)
 {
 	HD647180X(config, m_maincpu, XTAL(32'000'000)/2);
-	m_maincpu->set_addrmap(AS_PROGRAM, &pinkiri8_state::pinkiri8_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &pinkiri8_state::prg_map);
 	m_maincpu->set_addrmap(AS_IO, &pinkiri8_state::pinkiri8_io);
 	m_maincpu->set_vblank_int("screen", FUNC(pinkiri8_state::nmi_line_assert));
 	m_maincpu->out_pa_callback().set(FUNC(pinkiri8_state::output_regs_w));
@@ -1131,11 +1097,8 @@ void pinkiri8_state::pinkiri8(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	screen.set_size(64*8, 64*8);
 	screen.set_visarea(0*8, 62*8-1, 0*8, 32*8-1);
-	screen.set_screen_update(FUNC(pinkiri8_state::screen_update_pinkiri8));
-	screen.set_palette(m_palette);
-
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_pinkiri8);
-	PALETTE(config, m_palette).set_entries(0x2000);
+	screen.set_screen_update(m_vdp, FUNC(janshi_vdp_device::screen_update));
+	screen.set_palette("janshivdp:palette");
 
 	JANSHIVDP(config, m_vdp, 0);
 
@@ -1164,7 +1127,7 @@ ROM_START( pinkiri8 )
 	ROM_LOAD( "pinkiri8-ver.1.02.l1",   0x0000, 0x20000, CRC(f2df5b12) SHA1(e374e184a6a1e932550516011ec09a5accec9b03) )
 	ROM_LOAD( "bios.rom", 0x0000, 0x4000, CRC(399df1ee) SHA1(8251f3aa7da4c7899c8e739c10b61260f4471311) ) //overlapped internal ROM
 
-	ROM_REGION( 0x20000*5, "gfx1", 0 )
+	ROM_REGION( 0x20000*5, "janshivdp", 0 )
 	ROM_LOAD( "pinkiri8-chr-01.a1",  0x00000, 0x20000, CRC(8ec73662) SHA1(9098348e519ce753dd7f38f0d855181bfc65aa42) )
 	ROM_LOAD( "pinkiri8-chr-02.bc1", 0x20000, 0x20000, CRC(8dc20a65) SHA1(4062510fe06e8844a732754b7915a3b67ba2a3c5) )
 	ROM_LOAD( "pinkiri8-chr-03.d1",  0x40000, 0x20000, CRC(bd5f269a) SHA1(7dfd039227551f0f0ed4afaafc76ca64a39a9b83) )
@@ -1180,7 +1143,7 @@ ROM_START( janshi )
 	ROM_LOAD( "11.1l",    0x00000, 0x20000, CRC(a7692ddf) SHA1(5e7f43d8337583977baf22a28bbcd9b2182c0cde) )
 	ROM_LOAD( "=3= 9009 1992.1 new jansh.bin", 0x0000, 0x4000, CRC(63cd3f12) SHA1(aebac739bffaf043e6acffa978e935f73ee1385f) ) //overlapped internal ROM
 
-	ROM_REGION( 0x140000, "gfx1", 0 )
+	ROM_REGION( 0x140000, "janshivdp", 0 )
 	ROM_LOAD( "1.1a", 0x000000, 0x40000, CRC(92b140a5) SHA1(f3b38563f74650604ed0faaf84460e0b04b386b7) )
 	ROM_LOAD( "2.1b", 0x040000, 0x40000, CRC(6de7e086) SHA1(e87426264f0181c17383ffe0f7ec7ff5fce3d809) )
 	ROM_LOAD( "3.1d", 0x080000, 0x40000, CRC(4e94d8f2) SHA1(a25f542943d74915fc82910baafb9ff9db1ffd70) )
@@ -1196,7 +1159,7 @@ ROM_START( ronjans )
 	ROM_LOAD( "ver201.bin",    0x00000, 0x20000, CRC(caa98c79) SHA1(e18f52fc910e3a77142ad2a3167805cfd664f0f4) )
 	ROM_LOAD( "9009 1996.08 ron jan.bin", 0x00000, 0x4000, CRC(4eb74322) SHA1(84f864c0da3fb69948f6eb7ffecf0e722a882efc) ) //overlapped internal ROM
 
-	ROM_REGION( 0x140000, "gfx1", 0 )
+	ROM_REGION( 0x140000, "janshivdp", 0 )
 	ROM_LOAD( "eagle.1", 0x000000, 0x40000, CRC(11cef2c4) SHA1(fcd46bfa123cd91053f8d49892778e02a275ffdd) )
 	ROM_LOAD( "eagle.2", 0x040000, 0x40000, CRC(177c444c) SHA1(5af0f6040ba121c90b3480ce636885cce535d3ea) )
 	ROM_LOAD( "eagle.3", 0x080000, 0x40000, CRC(5b15b99f) SHA1(b99e2fa4cde7c8661d1a81ce5045f5df4f1de9f2) )
@@ -1212,7 +1175,7 @@ ROM_START( ronjansa ) // the Z180 internal ROM wasn't extracted from this PCB. I
 	ROM_LOAD( "eagle_18.i1",              0x00000, 0x20000, CRC(b5cc6d84) SHA1(e76ec529a7cd788a9ca0119d2f2dc00b29181289) )
 	ROM_LOAD( "9009 1992.04 ron jan.bin", 0x00000, 0x04000, NO_DUMP ) //overlapped internal ROM
 
-	ROM_REGION( 0x140000, "gfx1", 0 )
+	ROM_REGION( 0x140000, "janshivdp", 0 )
 	ROM_LOAD( "eagle_1.a1", 0x000000, 0x40000, CRC(11cef2c4) SHA1(fcd46bfa123cd91053f8d49892778e02a275ffdd) )
 	ROM_LOAD( "eagle_2.b1", 0x040000, 0x40000, CRC(177c444c) SHA1(5af0f6040ba121c90b3480ce636885cce535d3ea) )
 	ROM_LOAD( "eagle_3.d1", 0x080000, 0x40000, CRC(5b15b99f) SHA1(b99e2fa4cde7c8661d1a81ce5045f5df4f1de9f2) )
@@ -1228,7 +1191,7 @@ ROM_START( ronjansb ) // the Z180 internal ROM wasn't extracted from this PCB. I
 	ROM_LOAD( "eagle_19.i1",              0x00000, 0x20000, CRC(348fa965) SHA1(082395c51478c1cc053425d30fc94871fdc244ea) )
 	ROM_LOAD( "9009 1992.09 ron jan.bin", 0x00000, 0x04000, NO_DUMP ) //overlapped internal ROM
 
-	ROM_REGION( 0x140000, "gfx1", 0 )
+	ROM_REGION( 0x140000, "janshivdp", 0 )
 	ROM_LOAD( "eagle_1.a1", 0x000000, 0x40000, CRC(11cef2c4) SHA1(fcd46bfa123cd91053f8d49892778e02a275ffdd) )
 	ROM_LOAD( "eagle_2.b1", 0x040000, 0x40000, CRC(177c444c) SHA1(5af0f6040ba121c90b3480ce636885cce535d3ea) )
 	ROM_LOAD( "eagle_3.d1", 0x080000, 0x40000, CRC(5b15b99f) SHA1(b99e2fa4cde7c8661d1a81ce5045f5df4f1de9f2) )
@@ -1244,7 +1207,7 @@ ROM_START( ronjan ) // the Z180 internal ROM wasn't extracted from this PCB. Usi
 	ROM_LOAD( "9.l1",    0x00000, 0x20000, CRC(1bc4468e) SHA1(5b317c922d9a6f533958526e676f95af0ee6a19f) )
 	ROM_LOAD( "9009 1991.11 ron jan.bin", 0x00000, 0x4000, BAD_DUMP CRC(4eb74322) SHA1(84f864c0da3fb69948f6eb7ffecf0e722a882efc) ) //overlapped internal ROM
 
-	ROM_REGION( 0x140000, "gfx1", 0 )
+	ROM_REGION( 0x140000, "janshivdp", 0 )
 	ROM_LOAD( "1.a1", 0x000000, 0x20000, CRC(8242a791) SHA1(bb753e81293685499513e83b7a103396b3a32ad8) )
 	ROM_LOAD( "2.c1", 0x040000, 0x20000, CRC(4b25c09a) SHA1(edbe1907c300f12bf65c81b2d9e034d6f5545bd0) )
 	ROM_LOAD( "3.d1", 0x080000, 0x20000, CRC(7b956af6) SHA1(4a661d5cc5b06658804c8d377d5a266f5bd9ce85) )
@@ -1260,7 +1223,7 @@ ROM_START( ronjana ) // the Z180 internal ROM wasn't extracted from this PCB. Us
 	ROM_LOAD( "eagle_16.i1",              0x00000, 0x20000, CRC(9b7bf916) SHA1(d8a732bb53926e8127bc3638c8719f3c43c7881d) )
 	ROM_LOAD( "9009 1991.11 ron jan.bin", 0x00000, 0x04000, BAD_DUMP CRC(4eb74322) SHA1(84f864c0da3fb69948f6eb7ffecf0e722a882efc) ) //overlapped internal ROM
 
-	ROM_REGION( 0x140000, "gfx1", 0 )
+	ROM_REGION( 0x140000, "janshivdp", 0 )
 	ROM_LOAD( "eagle_1.a1", 0x000000, 0x40000, CRC(11cef2c4) SHA1(fcd46bfa123cd91053f8d49892778e02a275ffdd) )
 	ROM_LOAD( "eagle_2.b1", 0x040000, 0x40000, CRC(177c444c) SHA1(5af0f6040ba121c90b3480ce636885cce535d3ea) )
 	ROM_LOAD( "eagle_3.d1", 0x080000, 0x40000, CRC(5b15b99f) SHA1(b99e2fa4cde7c8661d1a81ce5045f5df4f1de9f2) )
@@ -1275,28 +1238,30 @@ uint8_t pinkiri8_state::ronjan_prot_r()
 {
 	static const char wing_str[6] = { 'W', 'I', 'N', 'G', '8', '9' };
 
-	m_prot_read_index++;
+	uint8_t prot_read_index = m_prot_read_index + 1;
+	if (!machine().side_effects_disabled())
+		m_prot_read_index++;
 
-	if(m_prot_read_index & 1)
+	if (BIT(prot_read_index, 0))
 		return 0xff; //value is discarded
 
-	return wing_str[(m_prot_read_index >> 1)-1];
+	return wing_str[(prot_read_index >> 1)-1];
 }
 
 void pinkiri8_state::ronjan_prot_w(uint8_t data)
 {
-	if(data == 0)
+	if (data == 0)
 	{
 		m_prot_index = 0;
 	}
 	else
 	{
-		if(m_prot_index == 5)
+		if (m_prot_index == 5)
 			return;
 
 		m_prot_char[m_prot_index++] = data;
 
-		if(m_prot_char[0] == 'E' && m_prot_char[1] == 'R' && m_prot_char[2] == 'R' && m_prot_char[3] == 'O' && m_prot_char[4] == 'R')
+		if (m_prot_char[0] == 'E' && m_prot_char[1] == 'R' && m_prot_char[2] == 'R' && m_prot_char[3] == 'O' && m_prot_char[4] == 'R')
 			m_prot_read_index = 0;
 	}
 }
@@ -1317,4 +1282,4 @@ GAME( 1994,  ronjana,  ronjans, ronjan,   ronjan,   pinkiri8_state, empty_init, 
 GAME( 1994,  ronjans,  0,       ronjan,   ronjan,   pinkiri8_state, empty_init, ROT0, "Wing Co., Ltd", "Ron Jan Super (set 1)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NOT_WORKING ) // 'SUPER' flashes in the middle of the screen
 GAME( 1994,  ronjansa, ronjans, ronjan,   ronjan,   pinkiri8_state, empty_init, ROT0, "Wing Co., Ltd", "Ron Jan Super (set 2)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NOT_WORKING ) // possibly Super or not, needs internal ROM dump
 GAME( 1994,  ronjansb, ronjans, ronjan,   ronjan,   pinkiri8_state, empty_init, ROT0, "Wing Co., Ltd", "Ron Jan Super (set 3)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NOT_WORKING ) // "
-GAME( 1994,  pinkiri8, 0,       pinkiri8, pinkiri8, pinkiri8_state, empty_init, ROT0, "Alta",          "Pinkiri 8",             MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NOT_WORKING )
+GAME( 1994,  pinkiri8, 0,       pinkiri8, pinkiri8, pinkiri8_state, empty_init, ROT0, "Alta",          "Pinkiri 8",             MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NOT_WORKING )


### PR DESCRIPTION
- Move video function into janshi_vdp_device
- Use device_gfx_interface for janshi_vdp_device gfx decoding feature
- Demote pinkiri8 to MACHINE_NO_SOUND because sound ROM not dumped (or not exists in real hardware?)
- Use set_format for palette format, Fix palette entry matches to palette RAM size(*2 for 16(15 actually) bit color)
- Add items into save state
- Suppress side effects for debugger reads
- Fix input matrix reading behavior
- Reduce duplicates
- Reduce unnecessary lines
- Reduce literal tag usages and runtime tag lookups
- Convert background tilemap to tilemap_t
- Fix namings
- Fix spacings