### PR TITLE
plugins/layout: Proposal for sharing slider functionality.

### DIFF
--- a/plugins/layout/init.lua
+++ b/plugins/layout/init.lua
@@ -48,7 +48,8 @@ function layout.startplugin()
 			string = string,
 			tonumber = tonumber,
 			tostring = tostring,
-			table = table }
+			table = table,
+			slider_manager = require("layout/sliders") }
 		local script, err = load(script, script, "t", env)
 		if not script then
 			emu.print_warning("error loading layout script " .. err)

--- a/plugins/layout/sliders.lua
+++ b/plugins/layout/sliders.lua
@@ -1,0 +1,169 @@
+-- license:BSD-3-Clause
+-- copyright-holders:m1macrophage
+
+local slider_manager = {}
+
+-- Creates an instance of a slider_manager.
+-- * view: The layout view that contains the sliders to be managed.
+--         Typically: `file.views["{view layout name}"]`.
+-- * device: Typically `file.device`.
+function slider_manager:new(view, device)
+	local manager = {}
+	setmetatable(manager, self)
+	self.__index = self
+	self.view = view
+	self.device = device
+	self.sliders = {}  -- Stores slider information.
+	self.pointers = {}  -- Tracks pointer state.
+	return manager
+end
+
+-- Adds a vertical slider to the manager.
+-- A slider comprises a click area, a knob and the associated input port.
+-- The knob's Y position must be animated using <animate inputtag="{port_name}">.
+-- The click area's vertical size must exactly span the range of the knob's
+-- movement.
+-- There are no requirements on horizontal dimensions.
+--  _____
+-- | _|_ |
+-- ||___|<-- Slider knob.
+-- |  |  |
+-- |  |  | <-- Slider click area.
+-- |  |  |
+-- |__|__|
+--
+-- * clickarea_id: Element ID of the slider click area.
+-- * knob_id: Element ID of the slider knob.
+-- * port_name: Name of the associated IPT_ADJUSTER port.
+function slider_manager:add_slider(clickarea_id, knob_id, port_name)
+	local slider = {}
+
+	slider.clickarea = self.view.items[clickarea_id]
+	if slider.clickarea == nil then
+		emu.print_error("Slider element: '" .. clickarea_id .. "' not found.")
+		return
+	end
+
+	slider.knob = self.view.items[knob_id]
+	if slider.knob == nil then
+		emu.print_error("Slider knob element: '" .. knob_id .. "' not found.")
+		return
+	end
+
+	local port = self.device:ioport(port_name)
+	if port == nil then
+		emu.print_error("Port: '" .. port_name .. "' not found.")
+		return
+	end
+
+	slider.field = nil
+	for k, val in pairs(port.fields) do
+		slider.field = val
+		break
+	end
+	if slider.field == nil then
+		emu.print_error("Port: '" .. port_name .."' does not seem to be an IPT_ADJUSTER.")
+		return
+	end
+
+	table.insert(self.sliders, slider)
+end
+
+-- Installs all callbacks.
+-- If a layout script needs to install callbacks of its own, then it cannot use
+-- this function. It will need to invoke the slider_manager's callbacks
+-- from within its own callbacks.
+function slider_manager:install_callbacks()
+	self.view:set_pointer_updated_callback(
+		function(type, id, dev, x, y, btn, dn, up, cnt)
+			self:pointer_updated(type, id, dev, x, y, btn, dn, up, cnt)
+		end)
+
+	self.view:set_pointer_left_callback(
+		function(type, id, dev, x, y, up, cnt)
+			self:pointer_left(type, id, dev, x, y, up, cnt)
+		end)
+
+	self.view:set_pointer_aborted_callback(
+		function(type, id, dev, x, y, up, cnt)
+			self:pointer_aborted(type, id, dev, x, y, up, cnt)
+		end)
+
+	self.view:set_forget_pointers_callback(
+		function() self:forget_pointers() end)
+end
+
+-- Pointer device callbacks.
+
+function slider_manager:pointer_updated(type, id, dev, x, y, btn, dn, up, cnt)
+	-- If a button is not pressed, reset the state of the current pointer.
+	if btn & 1 == 0 then
+		self.pointers[id] = nil
+		return
+	end
+
+	-- If a button was just pressed, find the affected slider, if any.
+	if dn & 1 ~= 0 then
+		for i = 1, #self.sliders do
+			if self.sliders[i].knob.bounds:includes(x, y) then
+				self.pointers[id] = {
+					selected_slider = i,
+					relative = true,
+					start_y = y,
+					start_value = self.sliders[i].field.user_value }
+				break
+			elseif self.sliders[i].clickarea.bounds:includes(x, y) then
+				self.pointers[id] = {
+					selected_slider = i,
+					relative = false }
+				break
+			end
+		end
+	end
+
+	-- If there is no slider selected by the current pointer, we are done.
+	if self.pointers[id] == nil then
+		return
+	end
+
+	-- A slider is selected. Update state and, indirectly, slider knob position,
+	-- based on the pointer's Y position. It is assumed the attached IO field is
+	-- an IPT_ADJUSTER with a range of 0-100 (the default).
+
+	local pointer = self.pointers[id]
+	local slider = self.sliders[pointer.selected_slider]
+
+	local knob_half_height = slider.knob.bounds.height / 2
+	local min_y = slider.clickarea.bounds.y0 + knob_half_height
+	local max_y = slider.clickarea.bounds.y1 - knob_half_height
+
+	local new_value = 0
+	if pointer.relative then
+		-- User clicked on the knob. The new value will depend on how much the
+		-- knob was dragged.
+		new_value = pointer.start_value - 100 * (y - pointer.start_y) / (max_y - min_y)
+	else
+		-- User clicked elsewhere on the slider. The new value will depend on
+		-- the absolute position of the click.
+		new_value = 100 - 100 * (y - min_y) / (max_y - min_y)
+	end
+
+	new_value = math.floor(new_value + 0.5)
+	if new_value < 0 then new_value = 0 end
+	if new_value > 100 then new_value = 100 end
+	slider.field.user_value = new_value
+end
+
+function slider_manager:pointer_left(type, id, dev, x, y, up, cnt)
+	self.pointers[id] = nil
+end
+
+function slider_manager:pointer_aborted(type, id, dev, x, y, up, cnt)
+	self.pointers[id] = nil
+end
+
+function slider_manager:forget_pointers()
+	self.pointers = {}
+end
+
+return slider_manager

--- a/src/mame/layout/oberheim_dmx.lay
+++ b/src/mame/layout/oberheim_dmx.lay
@@ -92,13 +92,13 @@ copyright-holders:m1macrophage
 	</element>
 
 	<group name="trimmer">
-		<element ref="invisible-rect" id="slider_pitch_adj_~trimmer_id~">
+		<element ref="invisible-rect" id="trimmer_~trimmer_id~">
 			<bounds x="0" y="0" width="15" height="40"/>
 		</element>
 		<element ref="trimmer-rail">
 			<bounds x="5" y="0" width="5" height="40"/>
 		</element>
-		<element ref="trimmer-knob" id="slider_knob_pitch_adj_~trimmer_id~">
+		<element ref="trimmer-knob" id="trimmer_knob_~trimmer_id~">
 			<animate inputtag="pitch_adj_~trimmer_id~" inputmask="0x7f"/>
 			<bounds state="100" x="0" y="0" width="15" height="5"/>
 			<bounds state="0" x="0" y="35" width="15" height="5"/>
@@ -117,13 +117,13 @@ copyright-holders:m1macrophage
 	</element>
 
 	<group name="fader">
-		<element id="slider_fader_p~fader_id~" ref="invisible-rect">
+		<element id="fader_~fader_id~" ref="invisible-rect">
 			<bounds x="15" y="0" width="35" height="162"/>
 		</element>
 		<element ref="black-rect">  <!-- slider rail -->
 			<bounds x="29" y="9" width="7" height="144"/>
 		</element>
-		<element id="slider_knob_fader_p~fader_id~" ref="fader-knob">
+		<element id="fader_knob_~fader_id~" ref="fader-knob">
 			<animate inputtag="fader_p~fader_id~" inputmask="0x7f"/>
 			<bounds state="100" x="15" y="0" width="35" height="35"/>
 			<bounds state="0" x="15" y="127" width="35" height="35"/>
@@ -355,8 +355,8 @@ copyright-holders:m1macrophage
 			</element>
 		</repeat>
 
-		<!-- Tunning trimmers -->
-		<collection name="tunning">
+		<!-- Tuning trimmers -->
+		<collection name="tuning">
 			<element ref="text-tune">
 				<bounds x="20" y="110" width="30" height="10"/>
 			</element>
@@ -541,120 +541,19 @@ copyright-holders:m1macrophage
 	<script><![CDATA[
 		file:set_resolve_tags_callback(
 			function()
-				local id_port_index <const> = string.len("slider_knob_") + 1
+				sm = slider_manager:new(file.views["Default Layout"], file.device)
 
-				-- State used by pointer handlers.
-				local sliders = {}  -- Info about all sliders (constant after initialization).
-				local pointers = {}  -- Pointer tracking state.
-
-				-- Gather relevant elements and inputs into `sliders`.
-				local view = file.views["Default Layout"]
-				for i = 1, #view.items do
-					local item = view.items:at(i)
-					if item.id ~= nil and string.find(item.id, "slider_knob_") == 1 then
-						local slider_id = string.sub(item.id, id_port_index)
-
-						local port = file.device:ioport(slider_id)
-						local field = nil
-						if port ~= nil then
-							for k, val in pairs(port.fields) do
-								field = val
-								break
-							end
-							if field == nil then
-								print("LAYOUT ERROR - Port does not have a field: " .. slider_id)
-							end
-						else
-							print("LAYOUT ERROR - Port not found: " .. slider_id)
-						end
-
-						local slider = view.items["slider_" .. slider_id]
-						if slider == nil then
-							print("LAYOUT ERROR - Element: 'slider_" .. slider_id .. "' does not exist.")
-						end
-
-						local slider_info = {}
-						slider_info.slider = slider
-						slider_info.knob = item
-						slider_info.field = field
-						table.insert(sliders, slider_info)
-					end
+				-- Configure volume faders.
+				for i = 1, 10 do
+					sm:add_slider("fader_" .. i, "fader_knob_" .. i, "fader_p" .. i)
 				end
 
-				local function forget_pointers()
-					pointers = {}
+				-- Configure tuning trimmers.
+				for i = 1, 8 do
+					sm:add_slider("trimmer_" .. i, "trimmer_knob_" .. i, "pitch_adj_" .. i)
 				end
 
-				local function pointer_lost(type, id, dev, x, y, up, cnt)
-					pointers[id] = nil
-				end
-
-				local function pointer_updated(type, id, dev, x, y, btn, dn, up, cnt)
-					-- Button not pressed? Reset state of current pointer.
-					if btn & 1 == 0 then
-						pointers[id] = nil
-						return
-					end
-
-					-- Button just pressed? Find affected slider, if any.
-					if dn & 1 ~= 0 then
-						for i = 1, #sliders do
-							if sliders[i].knob.bounds:includes(x, y) then
-								local pointer = {}
-								pointer.selected_slider = i
-								pointer.relative = true
-								pointer.start_y = y
-								pointer.start_value = sliders[i].field.user_value
-								pointers[id] = pointer
-								break
-							elseif sliders[i].slider.bounds:includes(x, y) then
-								local pointer = {}
-								pointer.selected_slider = i
-								pointer.relative = false
-								pointers[id] = pointer
-								break
-							end
-						end
-					end
-
-					-- No slider selected by current pointer? Nothing to do.
-					if pointers[id] == nil then
-						return
-					end
-
-					-- A slider is selected. Update state and, indirectly,
-					-- slider knob position, based on the pointer's Y position.
-					-- It is assumed the attached IO field is an IPT_ADJUSTER
-					-- with a range of 0-100 (the default).
-
-					local pointer = pointers[id]
-					local slider_info = sliders[pointer.selected_slider]
-
-					local knob_half_height = slider_info.knob.bounds.height / 2
-					local min_y = slider_info.slider.bounds.y0 + knob_half_height
-					local max_y = slider_info.slider.bounds.y1 - knob_half_height
-
-					local new_value = 0
-					if pointer.relative then
-						-- User clicked on the knob. New value depends on how
-						-- much the knob was dragged.
-						new_value = pointer.start_value - 100 * (y - pointer.start_y) / (max_y - min_y)
-					else
-						-- User clicked elsewhere on the slider. New value
-						-- depends on the absolute position of the click.
-						new_value = 100 - 100 * (y - min_y) / (max_y - min_y)
-					end
-
-					new_value = math.floor(new_value + 0.5)
-					if new_value < 0 then new_value = 0 end
-					if new_value > 100 then new_value = 100 end
-					slider_info.field.user_value = new_value
-				end
-
-				view:set_pointer_updated_callback(pointer_updated)
-				view:set_pointer_left_callback(pointer_lost)
-				view:set_pointer_aborted_callback(pointer_lost)
-				view:set_forget_pointers_callback(forget_pointers)
+				sm:install_callbacks()
 			end)
 	]]></script>
 </mamelayout>


### PR DESCRIPTION
This PR implements one possible way to share slider (and other widget) functionality between layouts.  It also adapts the DMX layout to use the shared library, as a proof of concept.

The `sliders.lua` implementation is basically the implementation in the DMX and LinnDrum layouts, except that scanning the layout for sliders was replaced with `add_slider()` calls from the layout script. I expect that `sliders.lua` will be extended to support horizontal sliders, knobs, etc.

Open to feedback and suggestions from the experts.
