### PR TITLE
zvt/pp01.cpp: Updates/Cleanups

### DIFF
--- a/src/mame/zvt/pp01.cpp
+++ b/src/mame/zvt/pp01.cpp
@@ -32,29 +32,15 @@ ToDo:
 /* Address maps */
 void pp01_state::mem_map(address_map &map)
 {
-	map(0x0000, 0x0fff).bankrw("bank0");
-	map(0x1000, 0x1fff).bankrw("bank1");
-	map(0x2000, 0x2fff).bankrw("bank2");
-	map(0x3000, 0x3fff).bankrw("bank3");
-	map(0x4000, 0x4fff).bankrw("bank4");
-	map(0x5000, 0x5fff).bankrw("bank5");
-	map(0x6000, 0x6fff).bankrw("bank6");
-	map(0x7000, 0x7fff).bankrw("bank7");
-	map(0x8000, 0x8fff).bankrw("bank8");
-	map(0x9000, 0x9fff).bankrw("bank9");
-	map(0xa000, 0xafff).bankrw("bank10");
-	map(0xb000, 0xbfff).bankrw("bank11");
-	map(0xc000, 0xcfff).bankrw("bank12");
-	map(0xd000, 0xdfff).bankrw("bank13");
-	map(0xe000, 0xefff).bankrw("bank14");
-	map(0xf000, 0xffff).bankrw("bank15");
+	for (int i = 0; i < 16; i++)
+		map(i << 12, (i << 12) | 0xfff).bankrw(m_bank[i]);
 }
 
 void pp01_state::io_map(address_map &map)
 {
-	map(0xc0, 0xc3).rw("ppi1", FUNC(i8255_device::read), FUNC(i8255_device::write)); // system
-	map(0xc4, 0xc7).rw("ppi2", FUNC(i8255_device::read), FUNC(i8255_device::write)); // user
-	map(0xc8, 0xc9).mirror(2).rw("uart", FUNC(i8251_device::read), FUNC(i8251_device::write));
+	map(0xc0, 0xc3).rw(m_ppi[0], FUNC(i8255_device::read), FUNC(i8255_device::write)); // system
+	map(0xc4, 0xc7).rw(m_ppi[1], FUNC(i8255_device::read), FUNC(i8255_device::write)); // user
+	map(0xc8, 0xc9).mirror(2).rw(m_uart, FUNC(i8251_device::read), FUNC(i8251_device::write));
 	map(0xcc, 0xcf).w(FUNC(pp01_state::video_write_mode_w));
 	map(0xd0, 0xd3).rw(m_pit, FUNC(pit8253_device::read), FUNC(pit8253_device::write));
 	//map(0xd4, 0xd7). MH3214 interrupt controller
@@ -195,7 +181,7 @@ void pp01_state::pp01(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	screen.set_size(256, 256);
 	screen.set_visarea(0, 256-1, 0, 256-1);
-	screen.set_screen_update(FUNC(pp01_state::screen_update_pp01));
+	screen.set_screen_update(FUNC(pp01_state::screen_update));
 	screen.set_palette("palette");
 
 	PALETTE(config, "palette", FUNC(pp01_state::pp01_palette), 8);
@@ -214,15 +200,15 @@ void pp01_state::pp01(machine_config &config)
 	m_pit->set_clk<2>(2000000);
 	m_pit->out_handler<2>().set(FUNC(pp01_state::z2_w));
 
-	I8255A(config, m_ppi1);
-	m_ppi1->in_pa_callback().set(FUNC(pp01_state::ppi1_porta_r));
-	m_ppi1->out_pa_callback().set(FUNC(pp01_state::ppi1_porta_w));
-	m_ppi1->in_pb_callback().set(FUNC(pp01_state::ppi1_portb_r));
-	m_ppi1->out_pb_callback().set(FUNC(pp01_state::ppi1_portb_w));
-	m_ppi1->in_pc_callback().set(FUNC(pp01_state::ppi1_portc_r));
-	m_ppi1->out_pc_callback().set(FUNC(pp01_state::ppi1_portc_w));
+	I8255A(config, m_ppi[0]);
+	m_ppi[0]->in_pa_callback().set(FUNC(pp01_state::ppi1_porta_r));
+	m_ppi[0]->out_pa_callback().set(FUNC(pp01_state::ppi1_porta_w));
+	m_ppi[0]->in_pb_callback().set(FUNC(pp01_state::ppi1_portb_r));
+	m_ppi[0]->out_pb_callback().set(FUNC(pp01_state::ppi1_portb_w));
+	m_ppi[0]->in_pc_callback().set(FUNC(pp01_state::ppi1_portc_r));
+	m_ppi[0]->out_pc_callback().set(FUNC(pp01_state::ppi1_portc_w));
 
-	I8255A(config, m_ppi2);
+	I8255A(config, m_ppi[1]);
 
 	/* internal ram */
 	RAM(config, RAM_TAG).set_default_size("64K").set_default_value(0x00);

--- a/src/mame/zvt/pp01.h
+++ b/src/mame/zvt/pp01.h
@@ -28,12 +28,12 @@ public:
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
 		, m_pit(*this, "pit")
-		, m_ppi1(*this, "ppi1")
-		, m_ppi2(*this, "ppi2")
+		, m_ppi(*this, "ppi%u", 1U)
 		, m_speaker(*this, "speaker")
 		, m_ram(*this, RAM_TAG)
 		, m_uart(*this, "uart")
 		, m_cass(*this, "cassette")
+		, m_mainrom(*this, "maincpu")
 		, m_bank(*this, "bank%d", 0U)
 		, m_io_keyboard(*this, "LINE%d", 0U)
 	{ }
@@ -41,50 +41,53 @@ public:
 	void pp01(machine_config &config);
 
 protected:
+	virtual void device_post_load() override ATTR_COLD;
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
 private:
-	uint8_t m_video_scroll = 0;
-	uint8_t m_memory_block[16]{};
-	uint8_t m_video_write_mode = 0;
-	uint8_t m_key_line = 0;
-	bool m_txe = false, m_txd = false, m_rts = false, m_casspol = false;
-	u8 m_cass_data[4]{};
-
-	void video_write_mode_w(uint8_t data);
-	void video_r_1_w(offs_t offset, uint8_t data);
-	void video_g_1_w(offs_t offset, uint8_t data);
-	void video_b_1_w(offs_t offset, uint8_t data);
-	void video_r_2_w(offs_t offset, uint8_t data);
-	void video_g_2_w(offs_t offset, uint8_t data);
-	void video_b_2_w(offs_t offset, uint8_t data);
-	void mem_block_w(offs_t offset, uint8_t data);
-	uint8_t mem_block_r(offs_t offset);
+	void video_write_mode_w(u8 data);
+	void video_r_1_w(offs_t offset, u8 data);
+	void video_g_1_w(offs_t offset, u8 data);
+	void video_b_1_w(offs_t offset, u8 data);
+	void video_r_2_w(offs_t offset, u8 data);
+	void video_g_2_w(offs_t offset, u8 data);
+	void video_b_2_w(offs_t offset, u8 data);
+	void mem_block_w(offs_t offset, u8 data);
+	u8 mem_block_r(offs_t offset);
 	TIMER_DEVICE_CALLBACK_MEMBER(kansas_r);
 	void pp01_palette(palette_device &palette) const;
-	uint32_t screen_update_pp01(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void z2_w(int state);
-	uint8_t ppi1_porta_r();
-	void ppi1_porta_w(uint8_t data);
-	uint8_t ppi1_portb_r();
-	void ppi1_portb_w(uint8_t data);
-	void ppi1_portc_w(uint8_t data);
-	uint8_t ppi1_portc_r();
-	void video_w(uint8_t block,uint16_t offset,uint8_t data,uint8_t part);
-	void set_memory(uint8_t block, uint8_t data);
+	u8 ppi1_porta_r();
+	void ppi1_porta_w(u8 data);
+	u8 ppi1_portb_r();
+	void ppi1_portb_w(u8 data);
+	void ppi1_portc_w(u8 data);
+	u8 ppi1_portc_r();
+	void video_w(u8 block, uint16_t offset, u8 data, bool part);
+	void set_memory(u8 block, u8 data);
 	void io_map(address_map &map) ATTR_COLD;
 	void mem_map(address_map &map) ATTR_COLD;
 
+	u8 m_video_scroll = 0;
+	u8 m_memory_block[16]{};
+	u8 m_video_write_mode = 0;
+	u8 m_key_line = 0;
+	bool m_txe = false, m_txd = false, m_rts = false, m_casspol = false;
+	u8 m_cass_data[4]{};
+
 	required_device<cpu_device> m_maincpu;
 	required_device<pit8253_device> m_pit;
-	required_device<i8255_device> m_ppi1;
-	required_device<i8255_device> m_ppi2;
+	required_device_array<i8255_device, 2> m_ppi;
 	required_device<speaker_sound_device> m_speaker;
 	required_device<ram_device> m_ram;
 	required_device<i8251_device> m_uart;
 	required_device<cassette_image_device> m_cass;
+
+	required_region_ptr<u8> m_mainrom;
 	required_memory_bank_array<16> m_bank;
+
 	required_ioport_array<17> m_io_keyboard;
 };
 

--- a/src/mame/zvt/pp01_m.cpp
+++ b/src/mame/zvt/pp01_m.cpp
@@ -34,7 +34,6 @@ void pp01_state::video_w(u8 block, u16 offset, u8 data, bool part)
 			else
 				ram[rgb_offset[i] + offset] = 0;
 		}
-
 	}
 	else
 	{
@@ -79,7 +78,7 @@ void pp01_state::set_memory(u8 block, u8 data)
 	{
 		// This is RAM
 		space.install_read_bank(startaddr, endaddr, m_bank[block]);
-		switch(data)
+		switch (data)
 		{
 		case 0xe6:
 			space.install_write_handler(startaddr, endaddr, write8sm_delegate(*this, FUNC(pp01_state::video_r_1_w)));
@@ -103,7 +102,6 @@ void pp01_state::set_memory(u8 block, u8 data)
 			space.install_write_bank(startaddr, endaddr, m_bank[block]);
 			break;
 		}
-
 		m_bank[block]->set_base(m_ram->pointer() + (data & 0x0f) * 0x1000);
 	}
 	else if (data >= 0xfc)

--- a/src/mame/zvt/pp01_m.cpp
+++ b/src/mame/zvt/pp01_m.cpp
@@ -13,89 +13,75 @@
 #include "pp01.h"
 
 
-void pp01_state::video_write_mode_w(uint8_t data)
+void pp01_state::video_write_mode_w(u8 data)
 {
 	m_video_write_mode = data & 0x0f;
 }
 
-void pp01_state::video_w(uint8_t block,uint16_t offset,uint8_t data,uint8_t part)
+void pp01_state::video_w(u8 block, u16 offset, u8 data, bool part)
 {
-	uint16_t addroffset = part ? 0x1000  : 0x0000;
-	uint8_t *ram = m_ram->pointer();
+	u16 const rgb_offset[3] = { 0x6000, 0xa000, 0xe000 };
+	offset += part ? 0x1000 : 0x0000;
+	u8 *const ram = m_ram->pointer();
 
-	if (BIT(m_video_write_mode,3))
+	if (BIT(m_video_write_mode, 3))
 	{
 		// Copy mode
-		if(BIT(m_video_write_mode,0))
-			ram[0x6000+offset+addroffset] = data;
-		else
-			ram[0x6000+offset+addroffset] = 0;
-
-		if(BIT(m_video_write_mode,1))
-			ram[0xa000+offset+addroffset] = data;
-		else
-			ram[0xa000+offset+addroffset] = 0;
-
-		if(BIT(m_video_write_mode,2))
-			ram[0xe000+offset+addroffset] = data;
-		else
-			ram[0xe000+offset+addroffset] = 0;
+		for (int i = 0; i < 3; i++)
+		{
+			if (BIT(m_video_write_mode, i))
+				ram[rgb_offset[i] + offset] = data;
+			else
+				ram[rgb_offset[i] + offset] = 0;
+		}
 
 	}
 	else
 	{
-		if (block==0)
-			ram[0x6000+offset+addroffset] = data;
-		else
-		if (block==1)
-			ram[0xa000+offset+addroffset] = data;
-		else
-		if (block==2)
-			ram[0xe000+offset+addroffset] = data;
+		ram[rgb_offset[block] + offset] = data;
 	}
 }
 
-void pp01_state::video_r_1_w(offs_t offset, uint8_t data)
+void pp01_state::video_r_1_w(offs_t offset, u8 data)
 {
-	video_w(0,offset,data,0);
+	video_w(0, offset, data, false);
 }
-void pp01_state::video_g_1_w(offs_t offset, uint8_t data)
+void pp01_state::video_g_1_w(offs_t offset, u8 data)
 {
-	video_w(1,offset,data,0);
+	video_w(1, offset, data, false);
 }
-void pp01_state::video_b_1_w(offs_t offset, uint8_t data)
+void pp01_state::video_b_1_w(offs_t offset, u8 data)
 {
-	video_w(2,offset,data,0);
-}
-
-void pp01_state::video_r_2_w(offs_t offset, uint8_t data)
-{
-	video_w(0,offset,data,1);
-}
-void pp01_state::video_g_2_w(offs_t offset, uint8_t data)
-{
-	video_w(1,offset,data,1);
-}
-void pp01_state::video_b_2_w(offs_t offset, uint8_t data)
-{
-	video_w(2,offset,data,1);
+	video_w(2, offset, data, false);
 }
 
-
-void pp01_state::set_memory(uint8_t block, uint8_t data)
+void pp01_state::video_r_2_w(offs_t offset, u8 data)
 {
-	uint8_t *mem = memregion("maincpu")->base();
+	video_w(0, offset, data, true);
+}
+void pp01_state::video_g_2_w(offs_t offset, u8 data)
+{
+	video_w(1, offset, data, true);
+}
+void pp01_state::video_b_2_w(offs_t offset, u8 data)
+{
+	video_w(2, offset, data, true);
+}
+
+
+void pp01_state::set_memory(u8 block, u8 data)
+{
 	address_space &space = m_maincpu->space(AS_PROGRAM);
-	uint16_t startaddr = block*0x1000;
-	uint16_t endaddr   = startaddr+0xfff;
+	u16 const startaddr = block * 0x1000;
+	u16 const endaddr   = startaddr + 0xfff;
 
-	if (data>=0xE0 && data<=0xEF)
+	if (data >= 0xe0 && data <= 0xef)
 	{
 		// This is RAM
-		space.install_read_bank (startaddr, endaddr, m_bank[block]);
+		space.install_read_bank(startaddr, endaddr, m_bank[block]);
 		switch(data)
 		{
-		case 0xe6 :
+		case 0xe6:
 			space.install_write_handler(startaddr, endaddr, write8sm_delegate(*this, FUNC(pp01_state::video_r_1_w)));
 			break;
 		case 0xe7:
@@ -118,43 +104,38 @@ void pp01_state::set_memory(uint8_t block, uint8_t data)
 			break;
 		}
 
-		m_bank[block]->set_base(m_ram->pointer() + (data & 0x0F)* 0x1000);
+		m_bank[block]->set_base(m_ram->pointer() + (data & 0x0f) * 0x1000);
 	}
-	else
-	if (data>=0xFC)
+	else if (data >= 0xfc)
 	{
-		space.install_read_bank (startaddr, endaddr, m_bank[block]);
+		space.install_read_bank(startaddr, endaddr, m_bank[block]);
 		space.unmap_write(startaddr, endaddr);
-		m_bank[block]->set_base(mem + (data & 0x03)* 0x1000);
+		m_bank[block]->set_base(&m_mainrom[(data & 0x03) * 0x1000]);
 	}
 	else
 	{
-		logerror("%02x %02x\n",block,data);
-		space.unmap_readwrite (startaddr, endaddr);
+		logerror("set_memory %02x = %02x\n", block, data);
+		space.unmap_readwrite(startaddr, endaddr);
 	}
 }
 
-void pp01_state::machine_reset()
-{
-	int i;
-	memset(m_memory_block,0xff,16);
-	for(i=0;i<16;i++)
-	{
-		m_memory_block[i] = 0xff;
-		set_memory(i, 0xff);
-	}
-	m_uart->write_cts(0);
-}
-
-void pp01_state::mem_block_w(offs_t offset, uint8_t data)
+void pp01_state::mem_block_w(offs_t offset, u8 data)
 {
 	m_memory_block[offset] = data;
 	set_memory(offset, data);
 }
 
-uint8_t pp01_state::mem_block_r(offs_t offset)
+u8 pp01_state::mem_block_r(offs_t offset)
 {
 	return m_memory_block[offset];
+}
+
+void pp01_state::device_post_load()
+{
+	for (int i = 0; i < 16; i++)
+	{
+		set_memory(i, m_memory_block[i]);
+	}
 }
 
 void pp01_state::machine_start()
@@ -170,7 +151,17 @@ void pp01_state::machine_start()
 	save_item(NAME(m_cass_data));
 }
 
-TIMER_DEVICE_CALLBACK_MEMBER( pp01_state::kansas_r )
+void pp01_state::machine_reset()
+{
+	for (int i = 0; i < 16; i++)
+	{
+		m_memory_block[i] = 0xff;
+		set_memory(i, 0xff);
+	}
+	m_uart->write_cts(0);
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER(pp01_state::kansas_r)
 {
 	if (m_rts)
 	{
@@ -182,7 +173,7 @@ TIMER_DEVICE_CALLBACK_MEMBER( pp01_state::kansas_r )
 	m_cass_data[1]++;
 	m_cass_data[2]++;
 
-	uint8_t cass_ws = (m_cass->input() > +0.04) ? 1 : 0;
+	u8 const cass_ws = (m_cass->input() > +0.04) ? 1 : 0;
 
 	if (cass_ws != m_cass_data[0])
 	{
@@ -193,7 +184,7 @@ TIMER_DEVICE_CALLBACK_MEMBER( pp01_state::kansas_r )
 		m_cass_data[2] = 0;
 		m_uart->write_rxd(m_casspol);
 	}
-	if ((m_cass_data[2] & 7)==2)
+	if ((m_cass_data[2] & 7) == 2)
 	{
 		m_cass_data[3]++;
 		m_uart->write_rxc(BIT(m_cass_data[3], 0));
@@ -208,26 +199,26 @@ void pp01_state::z2_w(int state)
 		m_cass->output((m_txd ^ state) ? -1.0 : 1.0);
 }
 
-uint8_t pp01_state::ppi1_porta_r()
+u8 pp01_state::ppi1_porta_r()
 {
 	return m_video_scroll;
 }
-void pp01_state::ppi1_porta_w(uint8_t data)
+void pp01_state::ppi1_porta_w(u8 data)
 {
 	m_video_scroll = data;
 }
 
-uint8_t pp01_state::ppi1_portb_r()
+u8 pp01_state::ppi1_portb_r()
 {
 	return m_io_keyboard[m_key_line]->read() | m_io_keyboard[16]->read();
 }
-void pp01_state::ppi1_portb_w(uint8_t data)
+void pp01_state::ppi1_portb_w(u8 data)
 {
-	//logerror("pp01_8255_portb_w %02x\n",data);
+	//logerror("pp01_8255_portb_w %02x\n", data);
 
 }
 
-void pp01_state::ppi1_portc_w(uint8_t data)
+void pp01_state::ppi1_portc_w(u8 data)
 {
 	if (BIT(data, 4))
 		m_key_line = data & 0x0f;
@@ -235,7 +226,7 @@ void pp01_state::ppi1_portc_w(uint8_t data)
 		m_speaker->level_w(BIT(data, 0));
 }
 
-uint8_t pp01_state::ppi1_portc_r()
+u8 pp01_state::ppi1_portc_r()
 {
 	return 0xff;
 }

--- a/src/mame/zvt/pp01_v.cpp
+++ b/src/mame/zvt/pp01_v.cpp
@@ -12,22 +12,22 @@
 #include "emu.h"
 #include "pp01.h"
 
-uint32_t pp01_state::screen_update_pp01(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 pp01_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint8_t const *const ram = m_ram->pointer();
+	u8 const *const ram = m_ram->pointer();
 
-	for (int y = 0; y < 256; y++)
+	for (int y = cliprect.top(); y <= cliprect.bottom(); y++)
 	{
-		for (int x = 0; x < 32; x++)
+		for (int x = cliprect.left() & ~7; x <= cliprect.right(); x += 8)
 		{
-			u16 t = ((y+m_video_scroll)&0xff)*32 + x;
-			uint8_t const code_r = ram[0x6000 + t];
-			uint8_t const code_g = ram[0xa000 + t];
-			uint8_t const code_b = ram[0xe000 + t];
+			u16 const t = ((y + m_video_scroll) & 0xff) * 32 + (x >> 3);
+			u8 const code_r = ram[0x6000 + t];
+			u8 const code_g = ram[0xa000 + t];
+			u8 const code_b = ram[0xe000 + t];
 			for (int b = 0; b < 8; b++)
 			{
-				uint8_t const col = (BIT(code_r, b) << 2) | (BIT(code_g, b) << 1) | (BIT(code_b, b) << 0);
-				bitmap.pix(y, x*8+(7-b)) = col;
+				u8 const col = (BIT(code_r, b) << 2) | (BIT(code_g, b) << 1) | (BIT(code_b, b) << 0);
+				bitmap.pix(y, x + (7 - b)) = col;
 			}
 		}
 	}


### PR DESCRIPTION
- Restrict screen update function to cliprect
- Add device_post_load for memory bankswitching
- Reduce duplicates
- Reduce runtime tag lookups
- Reduce literal tag usages
- Fix logging
- Fix typename for boolean flags
- Make some variables constant
- Fix typename consistency
- Fix spacings
- Fix namings