### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/3rdparty/libjpeg/rdtarga.c
+++ b/3rdparty/libjpeg/rdtarga.c
@@ -365,7 +365,8 @@ start_input_tga (j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
       width <= 0 || height <= 0 ||
       source->pixel_size < 1 || source->pixel_size > 4 ||
       (UCH(targaheader[16]) & 7) != 0 || /* bits/pixel must be multiple of 8 */
-      interlace_type != 0)	/* currently don't allow interlaced image */
+      interlace_type != 0 ||      /* currently don't allow interlaced image */
+      width == 0 || height == 0)  /* image width/height must be non-zero */
     ERREXIT(cinfo, JERR_TGA_BADPARMS);
 
   if (subtype > 8) {


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in start_input_tga() that was cloned from libjpeg-turbo but did not receive the security patch. The original issue was reported and fixed under https://github.com/libjpeg-turbo/libjpeg-turbo/commit/82923eb93a2eacf4a593e00e3e672bbb86a8a3a0.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2018-11212
https://github.com/libjpeg-turbo/libjpeg-turbo/commit/82923eb93a2eacf4a593e00e3e672bbb86a8a3a0
