### PR TITLE
CD-i: Fix Layering

### DIFF
--- a/src/mame/philips/mcd212.cpp
+++ b/src/mame/philips/mcd212.cpp
@@ -689,12 +689,14 @@ void mcd212_device::mix_lines(uint32_t *plane_a, bool *transparent_a, uint32_t *
 		uint32_t plane_b_cur = MosaicB ? plane_b[x - (x % mosaic_count_b)] : plane_b[x];
 		if (transparent_a[x]) {
 			plane_a_cur = 0;
-		} else if (m_transparency_control & TCR_DISABLE_MX) {
+		} else if (OrderAB && m_transparency_control & TCR_DISABLE_MX) {
 			plane_b_cur = 0;
 		}
 	
 		if (transparent_b[x]) {
 			plane_b_cur = 0;
+		} else if (!OrderAB && m_transparency_control & TCR_DISABLE_MX) {
+			plane_a_cur = 0;
 		}
 
 		const int32_t plane_a_r = 0xff & (plane_a_cur >> 16);
@@ -716,32 +718,6 @@ void mcd212_device::mix_lines(uint32_t *plane_a, bool *transparent_a, uint32_t *
 		const uint8_t out_g = std::clamp(weighted_a_g + weighted_b_g + 16, 0, 255);
 		const uint8_t out_b = std::clamp(weighted_a_b + weighted_b_b + 16, 0, 255);
 		out[x] = 0xff000000 | (out_r << 16) | (out_g << 8) | out_b;
-
-		if (m_transparency_control & TCR_DISABLE_MX)
-		{
-			if (OrderAB)
-			{
-				if (!transparent_a[x])
-				{
-					out[x] = 0xff000000 | (weighted_a_r << 16) | (weighted_a_g << 8) | weighted_a_b;
-				}
-				else if (!transparent_b[x])
-				{
-					out[x] = 0xff000000 | (weighted_b_r << 16) | (weighted_b_g << 8) | weighted_b_b;
-				}
-			}
-			else
-			{
-				if (!transparent_b[x])
-				{
-					out[x] = 0xff000000 | (weighted_b_r << 16) | (weighted_b_g << 8) | weighted_b_b;
-				}
-				else if (!transparent_a[x])
-				{
-					out[x] = 0xff000000 | (weighted_a_r << 16) | (weighted_a_g << 8) | weighted_a_b;
-				}
-			}
-		}
 	}
 
 	if (border_width)


### PR DESCRIPTION
This fixes 2 bugs, and reduces the code by 100 lines.

Bug 1: When Mixing is enabled, but one of the layers is transparent, the transparent layer would still be visible. This is now fixed.

You can validate this by checking "Why CD-i". The menu used to be tinged green, and often had ghost images. Now the ghost images are gone, and the menu correctly shows that the green overlay is only supposed to appear as a highlight on the menu button.
![{86DA21B9-5A9D-4776-8CF2-0936DD525ADF}](https://github.com/user-attachments/assets/6686bf8a-e96b-4d5a-8e80-1e2340ff4e07)


Bug 2: When mixing is enabled and both layers are transparent, previously no background was visible. This is now fixed.

You can validate this by checking the Validation Disc (Europe). The Background test used to appear fully black. Now you can see there is actually a color test on the background layer.
![{87F81EBA-825F-4032-B89D-19F611CAEF68}](https://github.com/user-attachments/assets/c303fcde-d70b-4e98-815b-de8726363ca1)
