### PR TITLE
z80/z80dasm.cpp: Switched *R (LDIR, OTIR, etc) debugger flag to STEP_OVER

### DIFF
--- a/src/devices/cpu/z80/z80dasm.cpp
+++ b/src/devices/cpu/z80/z80dasm.cpp
@@ -33,10 +33,10 @@ static const char *const s_mnemonic[] =
 const u32 z80_disassembler::s_flags[] =
 {
 	0        ,0        ,0        ,0        ,STEP_OVER,0    ,0        ,0        ,
-	STEP_COND,0        ,STEP_COND,0        ,0        ,0    ,0        ,0        ,
+	STEP_OVER,0        ,STEP_OVER,0        ,0        ,0    ,0        ,0        ,
 	STEP_COND,0        ,0        ,0        ,STEP_OVER,0    ,0        ,0        ,
-	0        ,STEP_COND,0        ,STEP_COND,0        ,0    ,0        ,0        ,
-	STEP_COND,0        ,STEP_COND,0        ,0        ,0    ,STEP_COND,STEP_COND,
+	0        ,STEP_OVER,0        ,STEP_OVER,0        ,0    ,0        ,0        ,
+	STEP_OVER,0        ,STEP_OVER,0        ,0        ,0    ,STEP_OVER,STEP_OVER,
 	0        ,0        ,0        ,0        ,0        ,0    ,STEP_OUT ,STEP_OUT ,
 	STEP_OUT ,0        ,0        ,0        ,0        ,0    ,0        ,0        ,
 	0        ,0        ,0        ,STEP_OVER,0        ,0    ,0        ,0        ,


### PR DESCRIPTION
STEP_COND on repeatable instructions doesn't allow to skip execution with F10
STEP_OVER is more reasonable for this instructions as allowed to take advantage from F10/F11

Per my understanding that should close match expectation:
`static constexpr u32 STEP_OVER       = 0x20000000;   // this instruction should be stepped over by setting a breakpoint afterwards`