### PR TITLE
gt155: avoid possible overflow in filter output

### DIFF
--- a/src/devices/sound/gt155.cpp
+++ b/src/devices/sound/gt155.cpp
@@ -129,10 +129,9 @@ void gt155_device::mix_sample(voice_t &voice, s64 &left, s64 &right)
 
 	// interpolate, apply envelope + channel gain and lowpass, and mix into output
 	s64 sample = voice.m_sample_last + (s64(voice.m_sample - voice.m_sample_last) * voice.m_addr_frac >> 15);
-
 	// TODO: does this produce accurate filter output?
 	sample = sample * voice.m_filter_gain;
-	sample += s32(voice.m_filter_out) * (voice.m_filter ^ 0xffff);
+	sample += voice.m_filter_out * (voice.m_filter ^ 0xffff);
 	sample >>= 16;
 	voice.m_filter_out = sample;
 

--- a/src/devices/sound/gt155.cpp
+++ b/src/devices/sound/gt155.cpp
@@ -131,7 +131,7 @@ void gt155_device::mix_sample(voice_t &voice, s64 &left, s64 &right)
 	s64 sample = voice.m_sample_last + (s64(voice.m_sample - voice.m_sample_last) * voice.m_addr_frac >> 15);
 	// TODO: does this produce accurate filter output?
 	sample = sample * voice.m_filter_gain;
-	sample += voice.m_filter_out * (voice.m_filter ^ 0xffff);
+	sample += s64(voice.m_filter_out) * (voice.m_filter ^ 0xffff);
 	sample >>= 16;
 	voice.m_filter_out = sample;
 

--- a/src/devices/sound/gt155.h
+++ b/src/devices/sound/gt155.h
@@ -60,7 +60,7 @@ private:
 
 		u32 m_filter_gain = 0;
 		u16 m_filter = 0;
-		s16 m_filter_out = 0;
+		s32 m_filter_out = 0;
 		u16 m_filter_unk = 0;
 
 		s16 m_sample_last = 0;


### PR DESCRIPTION
Fixes the issue mentioned here: https://github.com/mamedev/mame/pull/12957#issuecomment-2695904360