### PR TITLE
cpu/drcbearm64.cpp: Emit optimised memory access code

### DIFF
--- a/src/devices/cpu/drcbearm64.cpp
+++ b/src/devices/cpu/drcbearm64.cpp
@@ -540,6 +540,8 @@ private:
 	void emit_float_ldr_mem(asmjit::a64::Assembler &a, const asmjit::a64::Vec &reg, const void *ptr) const;
 	void emit_float_str_mem(asmjit::a64::Assembler &a, const asmjit::a64::Vec &reg, const void *ptr) const;
 
+	void emit_memaccess_setup(asmjit::a64::Assembler &a, const be_parameter &addrp, const memory_accessors &accessors, const address_space::specific_access_info::side &side) const;
+
 	void get_carry(asmjit::a64::Assembler &a, const asmjit::a64::Gp &reg, bool inverted = false) const;
 	void load_carry(asmjit::a64::Assembler &a, bool inverted = false) const;
 	void store_carry(asmjit::a64::Assembler &a, bool inverted = false) const;
@@ -905,6 +907,47 @@ void drcbe_arm64::emit_strh_mem(a64::Assembler &a, const a64::Gp &reg, const voi
 
 void drcbe_arm64::emit_float_ldr_mem(a64::Assembler &a, const a64::Vec &reg, const void *ptr) const { emit_ldr_str_base_mem(a, a64::Inst::kIdLdr_v, reg, reg.isVecS() ? 2 : 3, ptr); }
 void drcbe_arm64::emit_float_str_mem(a64::Assembler &a, const a64::Vec &reg, const void *ptr) const { emit_ldr_str_base_mem(a, a64::Inst::kIdStr_v, reg, reg.isVecS() ? 2 : 3, ptr); }
+
+void drcbe_arm64::emit_memaccess_setup(asmjit::a64::Assembler &a, const be_parameter &addrp, const memory_accessors &accessors, const address_space::specific_access_info::side &side) const
+{
+	auto const addrreg = (accessors.no_mask || accessors.mask_simple) ? REG_PARAM2 : a64::x6;
+	mov_reg_param(a, 4, addrreg, addrp);
+	get_imm_relative(a, a64::x8, uintptr_t(side.dispatch));
+
+	// if the high bits aren't affected by the global mask, extract them early
+	if (accessors.high_bits && !accessors.mask_high_bits)
+		a.ubfx(a64::w7, addrreg.w(), accessors.specific.low_bits, accessors.high_bits);
+
+	if (accessors.mask_simple)
+		a.and_(REG_PARAM2.w(), addrreg.w(), accessors.address_mask);
+	else if (!accessors.no_mask)
+		a.mov(REG_PARAM2.w(), accessors.address_mask); // 32-bit value, no more than two instructions
+
+	// if the high address bits aren't affected by the global mask, load the dispatch table entry now
+	if (!accessors.high_bits)
+		a.ldr(REG_PARAM1, a64::Mem(a64::x8));
+	else if (!accessors.mask_high_bits)
+		a.ldr(REG_PARAM1, a64::Mem(a64::x8, a64::x7, arm::Shift(arm::ShiftOp::kLSL, 3)));
+
+	// apply non-trivial global mask if necessary
+	if (!accessors.no_mask && !accessors.mask_simple)
+		a.and_(REG_PARAM2.w(), REG_PARAM2.w(), addrreg.w());
+
+	// if the high address bits are affected by the global mask, load the dispatch table entry now
+	if (accessors.mask_high_bits)
+	{
+		a.lsr(a64::w7, REG_PARAM2.w(), accessors.specific.low_bits);
+		a.ldr(REG_PARAM1, a64::Mem(a64::x8, a64::x7, arm::Shift(arm::ShiftOp::kLSL, 3)));
+	}
+
+	// apply this pointer displacement if necessary
+	if (side.displacement)
+		a.add(REG_PARAM1, REG_PARAM1, side.displacement); // assume less than 4K
+
+	// adjusted dispatch table entry pointer in REG_PARAM1
+	// masked address in REG_PARAM2
+	// x8, x7 and potentially x6 clobbered
+}
 
 void drcbe_arm64::mov_reg_param(a64::Assembler &a, uint32_t regsize, const a64::Gp &dst, const be_parameter &src) const
 {
@@ -2332,28 +2375,46 @@ void drcbe_arm64::op_read(a64::Assembler &a, const uml::instruction &inst)
 	assert(spacesizep.is_size_space());
 
 	auto const &accessors = m_memory_accessors[spacesizep.space()];
+	bool const have_specific = (uintptr_t(nullptr) != accessors.specific.read.function) || accessors.specific.read.is_virtual;
 
-	mov_reg_param(a, 4, REG_PARAM2, addrp);
+	if (have_specific && ((1 << spacesizep.size()) == accessors.specific.native_bytes))
+	{
+		emit_memaccess_setup(a, addrp, accessors, accessors.specific.read);
+		if (accessors.specific.read.is_virtual)
+		{
+			a.ldr(a64::x8, a64::Mem(REG_PARAM1));
+			a.ldr(a64::x8, a64::Mem(a64::x8, accessors.specific.read.function)); // assume no more than 4096 vtable entries
+		}
+		a.mov(REG_PARAM3, make_bitmask<uint64_t>(accessors.specific.native_bytes << 3));
+		if (accessors.specific.read.is_virtual)
+			a.blr(a64::x8);
+		else
+			call_arm_addr(a, (const void *)accessors.specific.read.function);
+	}
+	else
+	{
+		mov_reg_param(a, 4, REG_PARAM2, addrp);
 
-	if (spacesizep.size() == SIZE_BYTE)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.read_byte.obj);
-		call_arm_addr(a, accessors.resolved.read_byte.func);
-	}
-	else if (spacesizep.size() == SIZE_WORD)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.read_word.obj);
-		call_arm_addr(a, accessors.resolved.read_word.func);
-	}
-	else if (spacesizep.size() == SIZE_DWORD)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.read_dword.obj);
-		call_arm_addr(a, accessors.resolved.read_dword.func);
-	}
-	else if (spacesizep.size() == SIZE_QWORD)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.read_qword.obj);
-		call_arm_addr(a, accessors.resolved.read_qword.func);
+		if (spacesizep.size() == SIZE_BYTE)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.read_byte.obj);
+			call_arm_addr(a, accessors.resolved.read_byte.func);
+		}
+		else if (spacesizep.size() == SIZE_WORD)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.read_word.obj);
+			call_arm_addr(a, accessors.resolved.read_word.func);
+		}
+		else if (spacesizep.size() == SIZE_DWORD)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.read_dword.obj);
+			call_arm_addr(a, accessors.resolved.read_dword.func);
+		}
+		else if (spacesizep.size() == SIZE_QWORD)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.read_qword.obj);
+			call_arm_addr(a, accessors.resolved.read_qword.func);
+		}
 	}
 
 	mov_param_reg(a, inst.size(), dstp, REG_PARAM1);
@@ -2372,29 +2433,48 @@ void drcbe_arm64::op_readm(a64::Assembler &a, const uml::instruction &inst)
 	assert(spacesizep.is_size_space());
 
 	auto const &accessors = m_memory_accessors[spacesizep.space()];
+	bool const have_specific = (uintptr_t(nullptr) != accessors.specific.read.function) || accessors.specific.read.is_virtual;
 
-	mov_reg_param(a, 4, REG_PARAM2, addrp);
-	mov_reg_param(a, inst.size(), REG_PARAM3, maskp);
+	if (have_specific && ((1 << spacesizep.size()) == accessors.specific.native_bytes))
+	{
+		emit_memaccess_setup(a, addrp, accessors, accessors.specific.read);
+		mov_reg_param(a, inst.size(), REG_PARAM3, maskp);
+		if (accessors.specific.read.is_virtual)
+		{
+			a.ldr(a64::x8, a64::Mem(REG_PARAM1));
+			a.ldr(a64::x8, a64::Mem(a64::x8, accessors.specific.read.function)); // assume no more than 4096 vtable entries
+			a.blr(a64::x8);
+		}
+		else
+		{
+			call_arm_addr(a, (const void *)accessors.specific.read.function);
+		}
+	}
+	else
+	{
+		mov_reg_param(a, 4, REG_PARAM2, addrp);
+		mov_reg_param(a, inst.size(), REG_PARAM3, maskp);
 
-	if (spacesizep.size() == SIZE_BYTE)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.read_byte_masked.obj);
-		call_arm_addr(a, accessors.resolved.read_byte_masked.func);
-	}
-	else if (spacesizep.size() == SIZE_WORD)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.read_word_masked.obj);
-		call_arm_addr(a, accessors.resolved.read_word_masked.func);
-	}
-	else if (spacesizep.size() == SIZE_DWORD)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.read_dword_masked.obj);
-		call_arm_addr(a, accessors.resolved.read_dword_masked.func);
-	}
-	else if (spacesizep.size() == SIZE_QWORD)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.read_qword_masked.obj);
-		call_arm_addr(a, accessors.resolved.read_qword_masked.func);
+		if (spacesizep.size() == SIZE_BYTE)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.read_byte_masked.obj);
+			call_arm_addr(a, accessors.resolved.read_byte_masked.func);
+		}
+		else if (spacesizep.size() == SIZE_WORD)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.read_word_masked.obj);
+			call_arm_addr(a, accessors.resolved.read_word_masked.func);
+		}
+		else if (spacesizep.size() == SIZE_DWORD)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.read_dword_masked.obj);
+			call_arm_addr(a, accessors.resolved.read_dword_masked.func);
+		}
+		else if (spacesizep.size() == SIZE_QWORD)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.read_qword_masked.obj);
+			call_arm_addr(a, accessors.resolved.read_qword_masked.func);
+		}
 	}
 
 	mov_param_reg(a, inst.size(), dstp, REG_PARAM1);
@@ -2412,29 +2492,48 @@ void drcbe_arm64::op_write(a64::Assembler &a, const uml::instruction &inst)
 	assert(spacesizep.is_size_space());
 
 	auto const &accessors = m_memory_accessors[spacesizep.space()];
+	bool const have_specific = (uintptr_t(nullptr) != accessors.specific.write.function) || accessors.specific.write.is_virtual;
 
-	mov_reg_param(a, 4, REG_PARAM2, addrp);
-	mov_reg_param(a, inst.size(), REG_PARAM3, srcp);
+	if (have_specific && ((1 << spacesizep.size()) == accessors.specific.native_bytes))
+	{
+		emit_memaccess_setup(a, addrp, accessors, accessors.specific.write);
+		mov_reg_param(a, inst.size(), REG_PARAM3, srcp);
+		if (accessors.specific.write.is_virtual)
+		{
+			a.ldr(a64::x8, a64::Mem(REG_PARAM1));
+			a.ldr(a64::x8, a64::Mem(a64::x8, accessors.specific.write.function)); // assume no more than 4096 vtable entries
+		}
+		a.mov(REG_PARAM4, make_bitmask<uint64_t>(accessors.specific.native_bytes << 3));
+		if (accessors.specific.write.is_virtual)
+			a.blr(a64::x8);
+		else
+			call_arm_addr(a, (const void *)accessors.specific.write.function);
+	}
+	else
+	{
+		mov_reg_param(a, 4, REG_PARAM2, addrp);
+		mov_reg_param(a, inst.size(), REG_PARAM3, srcp);
 
-	if (spacesizep.size() == SIZE_BYTE)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.write_byte.obj);
-		call_arm_addr(a, accessors.resolved.write_byte.func);
-	}
-	else if (spacesizep.size() == SIZE_WORD)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.write_word.obj);
-		call_arm_addr(a, accessors.resolved.write_word.func);
-	}
-	else if (spacesizep.size() == SIZE_DWORD)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.write_dword.obj);
-		call_arm_addr(a, accessors.resolved.write_dword.func);
-	}
-	else if (spacesizep.size() == SIZE_QWORD)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.write_qword.obj);
-		call_arm_addr(a, accessors.resolved.write_qword.func);
+		if (spacesizep.size() == SIZE_BYTE)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.write_byte.obj);
+			call_arm_addr(a, accessors.resolved.write_byte.func);
+		}
+		else if (spacesizep.size() == SIZE_WORD)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.write_word.obj);
+			call_arm_addr(a, accessors.resolved.write_word.func);
+		}
+		else if (spacesizep.size() == SIZE_DWORD)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.write_dword.obj);
+			call_arm_addr(a, accessors.resolved.write_dword.func);
+		}
+		else if (spacesizep.size() == SIZE_QWORD)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.write_qword.obj);
+			call_arm_addr(a, accessors.resolved.write_qword.func);
+		}
 	}
 }
 
@@ -2452,30 +2551,49 @@ void drcbe_arm64::op_writem(a64::Assembler &a, const uml::instruction &inst)
 
 	// set up a call to the write handler
 	auto const &accessors = m_memory_accessors[spacesizep.space()];
+	bool const have_specific = (uintptr_t(nullptr) != accessors.specific.write.function) || accessors.specific.write.is_virtual;
 
-	mov_reg_param(a, 4, REG_PARAM2, addrp);
-	mov_reg_param(a, inst.size(), REG_PARAM3, srcp);
-	mov_reg_param(a, inst.size(), REG_PARAM4, maskp);
+	if (have_specific && ((1 << spacesizep.size()) == accessors.specific.native_bytes))
+	{
+		emit_memaccess_setup(a, addrp, accessors, accessors.specific.write);
+		mov_reg_param(a, inst.size(), REG_PARAM3, srcp);
+		if (accessors.specific.write.is_virtual)
+		{
+			a.ldr(a64::x8, a64::Mem(REG_PARAM1));
+			a.ldr(a64::x8, a64::Mem(a64::x8, accessors.specific.write.function)); // assume no more than 4096 vtable entries
+		}
+		mov_reg_param(a, inst.size(), REG_PARAM4, maskp);
+		if (accessors.specific.write.is_virtual)
+			a.blr(a64::x8);
+		else
+			call_arm_addr(a, (const void *)accessors.specific.write.function);
+	}
+	else
+	{
+		mov_reg_param(a, 4, REG_PARAM2, addrp);
+		mov_reg_param(a, inst.size(), REG_PARAM3, srcp);
+		mov_reg_param(a, inst.size(), REG_PARAM4, maskp);
 
-	if (spacesizep.size() == SIZE_BYTE)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.write_byte_masked.obj);
-		call_arm_addr(a, accessors.resolved.write_byte_masked.func);
-	}
-	else if (spacesizep.size() == SIZE_WORD)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.write_word_masked.obj);
-		call_arm_addr(a, accessors.resolved.write_word_masked.func);
-	}
-	else if (spacesizep.size() == SIZE_DWORD)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.write_dword_masked.obj);
-		call_arm_addr(a, accessors.resolved.write_dword_masked.func);
-	}
-	else if (spacesizep.size() == SIZE_QWORD)
-	{
-		get_imm_relative(a, REG_PARAM1, accessors.resolved.write_qword_masked.obj);
-		call_arm_addr(a, accessors.resolved.write_qword_masked.func);
+		if (spacesizep.size() == SIZE_BYTE)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.write_byte_masked.obj);
+			call_arm_addr(a, accessors.resolved.write_byte_masked.func);
+		}
+		else if (spacesizep.size() == SIZE_WORD)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.write_word_masked.obj);
+			call_arm_addr(a, accessors.resolved.write_word_masked.func);
+		}
+		else if (spacesizep.size() == SIZE_DWORD)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.write_dword_masked.obj);
+			call_arm_addr(a, accessors.resolved.write_dword_masked.func);
+		}
+		else if (spacesizep.size() == SIZE_QWORD)
+		{
+			get_imm_relative(a, REG_PARAM1, accessors.resolved.write_qword_masked.obj);
+			call_arm_addr(a, accessors.resolved.write_qword_masked.func);
+		}
 	}
 }
 


### PR DESCRIPTION
This is more of the stuff recommended by @galibert – I need help testing this on a 64-bit ARMv8 system.

The basic premise is that:
* The address line count, global address mask and dispatch table pointers for an address space don’t change after setup.  This means you can treat them as immediate constants/PC-relative addresses and avoid accessing the address space object altogether.
* In practice, the global address mask is always a contiguous sequence of set bits.  This means the address can be masked with an AND immediate instruction.  The dispatch table index can also be extracted with a UBFX instruction before the mask is applied for slightly better pipeline utilisation.

I’ve used some functions to reduce repetition, and I’ve commented to code to explain what it’s doing (not just the instructions it emits).  I’ve read the code multiple times and hand-simulated it, but I may well have missed something.  Use of functions should also make fixing potential screw-ups simpler.

* If I’ve screwed up native width reads or writes, basically everything using the DRC should break.
* If I’ve screwed up writes narrower than native width for little Endian CPUs, `sf2049` should fail to boot.
* If I’ve screwed up writes narrower than native width for big Endian CPUs, `pmac6100 mac750` should show graphical corruption during the boot process.

Some good things to test:
* `sf2049` boots to attract mode (little Endian CPU, 32-bit data bus)
* `pmac6100 mac750` boots to the desktop without graphical corruption during the boot process (big Endian CPU, 64-bit data bus)
* `finfurl` boots to attract mode (tests that global address mask is being applied correctly)
* `coolmini` boots to attract mode (16-bit data bus)
* `fiveside` boots to attract mode (less than 32 address lines)

Also, I’d appreciate it if someone could get me the logged generated code from `-bench 1 -drc_log_native` for the following so I can sanity check it:
* `-bench 1 -drc_log_native sf2049`
* `-bench 1 -drc_log_native pmac6100`
* `-bench 1 -drc_log_native finfurl`
* `-bench 1 -drc_log_native coolmini`
* `-bench 1 -drc_log_native fiveside`

These changes are more likely to improve performance on systems with weaker memory interfaces and/or narrower decode/issue stages (e.g. ARM Cortex CPUs are more likely to benefit than Apple M series CPUs).  If anything’s going to show a pronounced improvement it’s probably `fiveside`.