### PR TITLE
Konami (GX) blending - additive sprite blending, improved tile blending

### DIFF
--- a/src/mame/konami/k053246_k053247_k055673.cpp
+++ b/src/mame/konami/k053246_k053247_k055673.cpp
@@ -439,12 +439,11 @@ void k053247_device::k053247_sprites_draw(bitmap_rgb32 &bitmap, const rectangle 
 void k053247_device::zdrawgfxzoom32GP(
 		bitmap_rgb32 &bitmap, const rectangle &cliprect,
 		u32 code, u32 color, bool flipx, bool flipy, int sx, int sy,
-		int scalex, int scaley, int alpha, int drawmode, int zcode, int pri, u8* gx_objzbuf, u8* gx_shdzbuf)
+		int scalex, int scaley, int alpha, int drawmode, int zcode, u8 pri, u8* gx_objzbuf, u8* gx_shdzbuf)
 {
-	constexpr int FP    = 19;
-	constexpr int FPENT = 0;
+	constexpr u8 FP = 19; // 13.19 fixed point
 
-	// cull illegal and transparent objects
+	// cull objects with invalid scale
 	if (!scalex || !scaley) return;
 
 	// find shadow pens and cull invisible shadows
@@ -453,267 +452,119 @@ void k053247_device::zdrawgfxzoom32GP(
 
 	if (zcode >= 0)
 	{
-		if (drawmode == 5) { drawmode = 4; shdpen = 1; }
+		if (drawmode == 5)
+		{
+			drawmode = 4;
+			shdpen = 1;
+		}
 	}
-	else
-		if (drawmode >= 4) return;
+	else if (drawmode >= 4) return;
 
-	// alpha blend necessary?
+	// alpha blend check: cull if 0% opaque, or skip alpha blending if 100% opaque
 	if (drawmode & 2)
 	{
 		if (alpha <= 0) return;
 		if (alpha >= 255) drawmode &= ~2;
 	}
 
-	// cull off-screen objects
-	if (sx > cliprect.max_x || sy > cliprect.max_y) return;
+	rectangle dst_rect = rectangle {sx, 0, sy, 0};
+	dst_rect.set_size(((scalex << 4) + 0x8000) >> 16, ((scaley << 4) + 0x8000) >> 16);
 
-	// fill internal data structure with default values
-	u8 *ozbuf_ptr = gx_objzbuf;
-	u8 *szbuf_ptr = gx_shdzbuf;
+	// cull off-screen and zero height/width objects
+	if (dst_rect.left() > cliprect.right() || dst_rect.right() < cliprect.left()) return;
+	if (dst_rect.top() > cliprect.bottom() || dst_rect.bottom() < cliprect.top()) return;
+	if (!dst_rect.width() || !dst_rect.height()) return;
+
+	constexpr u8 src_size = 16;
+	const int src_stride_x = (src_size << FP) / dst_rect.width();
+	const int src_stride_y = (src_size << FP) / dst_rect.height();
+
+	const int src_offset_x = std::max(cliprect.left() - dst_rect.left(), 0);
+	const int src_offset_y = std::max(cliprect.top() - dst_rect.top(), 0);
+
+	const int src_base_x = src_offset_x * src_stride_x;
+	const int src_base_y = src_offset_y * src_stride_y;
+
+	// exclude dst_rect area outside cliprect
+	dst_rect &= cliprect;
+
+	// invert src x/y offsets if flip enabled
+	u8 flip_mask = 0;
+	if (flipx) flip_mask |= src_size - 1;
+	if (flipy) flip_mask |= (src_size - 1) << 4;
+
+	const int dst_pitch = bitmap.rowpixels();
+	u32 *dst_ptr = &bitmap.pix(0) + dst_rect.left() + dst_rect.top() * dst_pitch;
 
 	const u8 *src_base = m_gfx->get_data(code % m_gfx->elements());
-
 	const pen_t *pal_base = palette().pens() + m_gfx->colorbase() + (color % m_gfx->colors()) * granularity;
-	const pen_t *shd_base = palette().shadow_table();
 
-	u32 *dst_ptr = &bitmap.pix(0);
-	const int dst_pitch = bitmap.rowpixels();
-	int dst_x = sx;
-	int dst_y = sy;
+	const int z_buffer_offset = (dst_rect.top() - cliprect.top()) * GX_ZBUFW + (dst_rect.left() - cliprect.left());
+	u8 *ozbuf_ptr = gx_objzbuf + z_buffer_offset;
 
-	int dst_w, dst_h;
-	int src_fdx, src_fdy;
-	int src_pitch = 16, src_fw = 16, src_fh = 16;
-
-	const bool nozoom = (scalex == 0x10000 && scaley == 0x10000);
-	if (nozoom)
-	{
-		dst_h = dst_w = 16;
-		src_fdy = src_fdx = 1;
-	}
-	else
-	{
-		dst_w = ((scalex<<4)+0x8000)>>16;
-		dst_h = ((scaley<<4)+0x8000)>>16;
-		if (!dst_w || !dst_h) return;
-
-		src_fw <<= FP;
-		src_fh <<= FP;
-		src_fdx = src_fw / dst_w;
-		src_fdy = src_fh / dst_h;
-	}
-
-	const int dst_lastx = dst_x + dst_w - 1;
-	const int dst_lasty = dst_y + dst_h - 1;
-	if (dst_lastx < cliprect.min_x || dst_lasty < cliprect.min_y) return;
-
-	// clip destination
-	int dst_skipx = 0;
-	if (int delta_min_x = cliprect.min_x - dst_x; delta_min_x > 0)
-	{
-		dst_skipx = delta_min_x;
-		dst_w -= delta_min_x;
-		dst_x = cliprect.min_x;
-	}
-	if (int delta_max_x = dst_lastx - cliprect.max_x; delta_max_x > 0) dst_w -= delta_max_x;
-
-	int dst_skipy = 0;
-	if (int delta_min_y = cliprect.min_y - dst_y; delta_min_y > 0)
-	{
-		dst_skipy = delta_min_y;
-		dst_h -= delta_min_y;
-		dst_y = cliprect.min_y;
-	}
-	if (int delta_max_y = dst_lasty - cliprect.max_y; delta_max_y > 0) dst_h -= delta_max_y;
-
-	int src_fby, src_fbx;
-
-	// calculate zoom factors and clip source
-	if (nozoom)
-	{
-		if (!flipx) src_fbx = 0; else { src_fbx = src_fw - 1; src_fdx = -src_fdx; }
-		if (!flipy) src_fby = 0; else { src_fby = src_fh - 1; src_fdy = -src_fdy; src_pitch = -src_pitch; }
-	}
-	else
-	{
-		if (!flipx) src_fbx = FPENT; else { src_fbx = src_fw - FPENT - 1; src_fdx = -src_fdx; }
-		if (!flipy) src_fby = FPENT; else { src_fby = src_fh - FPENT - 1; src_fdy = -src_fdy; }
-	}
-	src_fbx += dst_skipx * src_fdx;
-	src_fby += dst_skipy * src_fdy;
-
-	// adjust insertion points and pre-entry constants
-	const int offset = (dst_y - cliprect.min_y) * GX_ZBUFW + (dst_x - cliprect.min_x) + dst_w;
-	ozbuf_ptr += offset;
-	szbuf_ptr += offset << 1;
 	const u8 z8 = (u8)zcode;
-	const u8 p8 = (u8)pri;
-	dst_ptr += dst_y * dst_pitch + dst_x + dst_w;
-	dst_w = -dst_w;
 
-	int src_fx, src_x, ecx;
-	const u8 *src_ptr;
-
-	if (!nozoom)
+	if (zcode < 0)
 	{
-		ecx = src_fby;   src_fby += src_fdy;
-		ecx >>= FP;      src_fx = src_fbx;
-		src_x = src_fbx; src_fx += src_fdx;
-		ecx <<= 4;       src_ptr = src_base;
-		src_x >>= FP;    src_ptr += ecx;
-		ecx = dst_w;
+		// no shadow and z-buffering
 
-		if (zcode < 0) // no shadow and z-buffering
+		for (int y = 0; y < dst_rect.height(); ++y)
 		{
-			do {
-				do {
-					const u8 pal_idx = src_ptr[src_x];
-					src_x = src_fx >> FP;
-					src_fx += src_fdx;
-					if (!pal_idx || pal_idx >= shdpen) continue;
-					dst_ptr[ecx] = pal_base[pal_idx];
-				}
-				while (++ecx);
-
-				ecx = src_fby;   src_fby += src_fdy;
-				dst_ptr += dst_pitch;
-				ecx >>= FP;      src_fx = src_fbx;
-				src_x = src_fbx; src_fx += src_fdx;
-				ecx <<= 4;       src_ptr = src_base;
-				src_x >>= FP;    src_ptr += ecx;
-				ecx = dst_w;
+			for (int x = 0; x < dst_rect.width(); ++x)
+			{
+				const int x_off = (src_base_x + x * src_stride_x) >> FP;
+				const int y_off = (src_base_y + y * src_stride_y) >> FP;
+				const u8 pal_idx = src_base[(x_off + y_off * 16) ^ flip_mask];
+				if (!pal_idx || pal_idx >= shdpen) continue;
+				ozbuf_ptr[x + y * GX_ZBUFW] = z8;
+				dst_ptr[x + y * dst_pitch] = pal_base[pal_idx];
 			}
-			while (--dst_h);
 		}
-		else if (drawmode < 4)
+	}
+	else if (drawmode < 4)
+	{
+		// 0: all pens solid
+		// 1: solid pens only
+		// 2: all pens solid with alpha blending
+		// 3: solid pens only with alpha blending
+
+		for (int y = 0; y < dst_rect.height(); ++y)
 		{
-			// 0: all pens solid
-			// 1: solid pens only
-			// 2: all pens solid with alpha blending
-			// 3: solid pens only with alpha blending
-			do {
-				do {
-					const u8 pal_idx = src_ptr[src_x];
-					src_x = src_fx >> FP;
-					src_fx += src_fdx;
-					if (!pal_idx || (drawmode & 0b01 && pal_idx >= shdpen) || ozbuf_ptr[ecx] < z8) continue;
-					ozbuf_ptr[ecx] = z8;
-					dst_ptr[ecx] = (drawmode & 0b10) ? alpha_blend_r32(dst_ptr[ecx], pal_base[pal_idx], alpha) : pal_base[pal_idx];
-				}
-				while (++ecx);
-
-				ecx = src_fby;   src_fby += src_fdy;
-				ozbuf_ptr += GX_ZBUFW;
-				dst_ptr += dst_pitch;
-				ecx >>= FP;      src_fx = src_fbx;
-				src_x = src_fbx; src_fx += src_fdx;
-				ecx <<= 4;       src_ptr = src_base;
-				src_x >>= FP;    src_ptr += ecx;
-				ecx = dst_w;
+			for (int x = 0; x < dst_rect.width(); ++x)
+			{
+				const int x_off = (src_base_x + x * src_stride_x) >> FP;
+				const int y_off = (src_base_y + y * src_stride_y) >> FP;
+				const u8 pal_idx = src_base[(x_off + y_off * 16) ^ flip_mask];
+				if (!pal_idx || (drawmode & 0b01 && pal_idx >= shdpen) || ozbuf_ptr[x + y * GX_ZBUFW] < z8) continue;
+				ozbuf_ptr[x + y * GX_ZBUFW] = z8;
+				dst_ptr[x + y * dst_pitch] = (drawmode & 0b10) ? alpha_blend_r32(dst_ptr[x + y * dst_pitch], pal_base[pal_idx], alpha) : pal_base[pal_idx];
 			}
-			while (--dst_h);
 		}
-		else
-		{
-			// 4: shadow pens only
-			do {
-				do {
-					const u8 pal_idx = src_ptr[src_x];
-					src_x = src_fx >> FP;
-					src_fx += src_fdx;
-					if (pal_idx < shdpen || szbuf_ptr[ecx*2] < z8 || szbuf_ptr[ecx*2+1] <= p8) continue;
-					rgb_t pix = dst_ptr[ecx];
-					szbuf_ptr[ecx*2] = z8;
-					szbuf_ptr[ecx*2+1] = p8;
-
-					// the shadow tables are 15-bit lookup tables which accept RGB15... lossy, nasty, yuck!
-					dst_ptr[ecx] = shd_base[pix.as_rgb15()];
-					//dst_ptr[ecx] =(eax>>3&0x001f);lend_r32(eax, 0x00000000, 128);
-				}
-				while (++ecx);
-
-				ecx = src_fby;   src_fby += src_fdy;
-				szbuf_ptr += (GX_ZBUFW<<1);
-				dst_ptr += dst_pitch;
-				ecx >>= FP;      src_fx = src_fbx;
-				src_x = src_fbx; src_fx += src_fdx;
-				ecx <<= 4;       src_ptr = src_base;
-				src_x >>= FP;    src_ptr += ecx;
-				ecx = dst_w;
-			}
-			while (--dst_h);
-		}
-	} // if (!nozoom)
+	}
 	else
 	{
-		src_ptr = src_base + (src_fby<<4) + src_fbx;
-		src_fdy = src_fdx * dst_w + src_pitch;
-		ecx = dst_w;
+		// 4: shadow pens only
 
-		if (zcode < 0) // no shadow and z-buffering
+		const pen_t *shd_base = palette().shadow_table();
+		u8 *szbuf_ptr = gx_shdzbuf + z_buffer_offset * 2;
+
+		for (int y = 0; y < dst_rect.height(); ++y)
 		{
-			do {
-				do {
-					const u8 pal_idx = *src_ptr;
-					src_ptr += src_fdx;
-					if (!pal_idx || pal_idx >= shdpen) continue;
-					dst_ptr[ecx] = pal_base[pal_idx];
-				}
-				while (++ecx);
+			for (int x = 0; x < dst_rect.width(); ++x)
+			{
+				const int x_off = (src_base_x + x * src_stride_x) >> FP;
+				const int y_off = (src_base_y + y * src_stride_y) >> FP;
+				const u8 pal_idx = src_base[(x_off + y_off * 16) ^ flip_mask];
+				const int szbuf_offset = x * 2 + y * GX_ZBUFW * 2;
+				if (pal_idx < shdpen || szbuf_ptr[szbuf_offset] < z8 || szbuf_ptr[szbuf_offset + 1] <= pri) continue;
+				szbuf_ptr[szbuf_offset] = z8;
+				szbuf_ptr[szbuf_offset + 1] = pri;
 
-				src_ptr += src_fdy;
-				dst_ptr += dst_pitch;
-				ecx = dst_w;
+				rgb_t pix = dst_ptr[x + y * dst_pitch];
+				// the shadow tables are 15-bit lookup tables which accept RGB15... lossy, nasty, yuck!
+				dst_ptr[x + y * dst_pitch] = shd_base[pix.as_rgb15()];
+				//dst_ptr[ecx] =(eax>>3&0x001f);lend_r32(eax, 0x00000000, 128);
 			}
-			while (--dst_h);
-		}
-		else if (drawmode < 4)
-		{
-			// 0: all pens solid
-			// 1: solid pens only
-			// 2: all pens solid with alpha blending
-			// 3: solid pens only with alpha blending
-			do {
-				do {
-					const u8 pal_idx = *src_ptr;
-					src_ptr += src_fdx;
-					if (!pal_idx || (drawmode & 0b01 && pal_idx >= shdpen) || ozbuf_ptr[ecx] < z8) continue;
-					ozbuf_ptr[ecx] = z8;
-					dst_ptr[ecx] = (drawmode & 0b10) ? alpha_blend_r32(dst_ptr[ecx], pal_base[pal_idx], alpha) : pal_base[pal_idx];
-				}
-				while (++ecx);
-
-				src_ptr += src_fdy;
-				ozbuf_ptr += GX_ZBUFW;
-				dst_ptr += dst_pitch;
-				ecx = dst_w;
-			}
-			while (--dst_h);
-		}
-		else
-		{
-			// 4: shadow pens only
-			do {
-				do {
-					const u8 pal_idx = *src_ptr;
-					src_ptr += src_fdx;
-					if (pal_idx < shdpen || szbuf_ptr[ecx*2] < z8 || szbuf_ptr[ecx*2+1] <= p8) continue;
-					rgb_t pix = dst_ptr[ecx];
-					szbuf_ptr[ecx*2] = z8;
-					szbuf_ptr[ecx*2+1] = p8;
-
-					// the shadow tables are 15-bit lookup tables which accept RGB15... lossy, nasty, yuck!
-					dst_ptr[ecx] = shd_base[pix.as_rgb15()];
-				}
-				while (++ecx);
-
-				src_ptr += src_fdy;
-				szbuf_ptr += (GX_ZBUFW<<1);
-				dst_ptr += dst_pitch;
-				ecx = dst_w;
-			}
-			while (--dst_h);
 		}
 	}
 }

--- a/src/mame/konami/k053246_k053247_k055673.cpp
+++ b/src/mame/konami/k053246_k053247_k055673.cpp
@@ -555,6 +555,7 @@ void k053247_device::zdrawgfxzoom32GP(
 
 					if (additive_mode)
 					{
+						// todo: improve additive blend calculation
 						const u32 temp = alpha_blend_r32(src, 0, alpha_level);
 						dst_ptr[x + y * dst_pitch] = add_blend_r32(dst, temp);
 					}

--- a/src/mame/konami/k053246_k053247_k055673.cpp
+++ b/src/mame/konami/k053246_k053247_k055673.cpp
@@ -546,7 +546,8 @@ void k053247_device::zdrawgfxzoom32GP(
 				{
 					const u8 alpha_level = alpha;
 					const bool additive_mode = alpha & (1 << 8);
-					// todo: use mix_pri to flip src & dst
+					// mix_pri flips src & dst
+					// todo: find a game that exhibits this behavior
 					// const bool mix_pri = alpha & (1 << 9);
 
 					const u32 src = pal_base[pal_idx];

--- a/src/mame/konami/k053246_k053247_k055673.h
+++ b/src/mame/konami/k053246_k053247_k055673.h
@@ -112,7 +112,7 @@ public:
 	void zdrawgfxzoom32GP(
 			bitmap_rgb32 &bitmap, const rectangle &cliprect,
 			u32 code, u32 color, bool flipx, bool flipy, int sx, int sy,
-			int scalex, int scaley, int alpha, int drawmode, int zcode, int pri, u8* gx_objzbuf, u8* gx_shdzbuf);
+			int scalex, int scaley, int alpha, int drawmode, int zcode, u8 pri, u8* gx_objzbuf, u8* gx_shdzbuf);
 
 	void zdrawgfxzoom32GP(
 			bitmap_ind16 &bitmap, const rectangle &cliprect,

--- a/src/mame/konami/k054156_k054157_k056832.cpp
+++ b/src/mame/konami/k054156_k054157_k056832.cpp
@@ -506,9 +506,7 @@ void k056832_device::get_tile_info(  tile_data &tileinfo, int tile_index, int pa
 	color = (attr & smptr->palm1) | (attr >> smptr->pals2 & smptr->palm2);
 	flags = TILE_FLIPYX(flip);
 
-	flags |= attr << 8;
-
-	m_k056832_cb(layer, &code, &color, &flags, &priority);
+	m_k056832_cb(layer, &code, &color, &flags, &priority, attr);
 
 	tileinfo.set(m_gfx_num,
 			code,

--- a/src/mame/konami/k054156_k054157_k056832.cpp
+++ b/src/mame/konami/k054156_k054157_k056832.cpp
@@ -1878,6 +1878,51 @@ u16 k056832_device::b_word_r(offs_t offset)
 	return (m_regsb[offset]);
 }   // VSCCS (board dependent)
 
+u8 k056832_device::get_mix_bits(u8 layer) {
+	// there can be several pages associated with a layer
+	// check all of them? unless there's a way to tell which specific page to check
+	std::vector<u8> pages;
+
+	for (int page = 0; page < 16; ++page) {
+		if (layer == m_layer_assoc_with_page[page]) {
+			pages.push_back(page);
+		}
+	}
+
+	// first visible pixels on screen
+	const u8 visible_x = 24;
+	const u8 visible_y = 16;
+
+	const u8 x_tile_scroll_offset = ((m_regs[0x14 + layer] + visible_x) & 0x1FF) / 8;
+	const u8 y_tile_scroll_offset = ((m_regs[0x10 + layer] + visible_y) & 0xFF) / 8;
+
+	for (auto page : pages) {
+		// 36 * 32 tiles = 288 * 256 pixels = visible area
+		const u8 scan_range_x = 36;
+		const u8 scan_range_y = 32;
+
+		for (int y = 0; y < scan_range_y; ++y) {
+			for (int x = 0; x < scan_range_x; ++x) {
+				const u8 page_tile_width = 64;
+				const u8 page_tile_height = 32;
+
+				const u8 x_tile_offset = (x + x_tile_scroll_offset) & page_tile_width - 1;
+				const u8 y_tile_offset = (y + y_tile_scroll_offset) & page_tile_height - 1;
+
+				const u32 offset = ((x_tile_offset * 2) + (y_tile_offset * 0x80)) | (page << 12);
+				const u8 bits = (m_videoram[offset] >> 2) & 0b11; // mystwarr
+				// const u8 bits = (m_videoram[offset] >> 6) & 0b11; // sexyparo
+
+				if (bits) {
+					return bits;
+				}
+			}
+		}
+	}
+
+	return 0;
+}
+
 /*
 
   some drivers still rely on this non-device implementation, this should be collapsed into the device.

--- a/src/mame/konami/k054156_k054157_k056832.h
+++ b/src/mame/konami/k054156_k054157_k056832.h
@@ -8,7 +8,7 @@
 #include "k055555.h" // still needs k055555_get_palette_index
 #include "tilemap.h"
 
-#define K056832_CB_MEMBER(_name)   void _name(int layer, int *code, int *color, int *flags, int *priority)
+#define K056832_CB_MEMBER(_name)   void _name(int layer, int *code, int *color, int *flags, int *priority, u16 attr)
 
 #define K056832_PAGE_COUNT 16
 
@@ -31,7 +31,7 @@ class k055555_device;
 class k056832_device : public device_t, public device_gfx_interface
 {
 public:
-	using tile_delegate = device_delegate<void (int layer, int *code, int *color, int *flags, int *priority)>;
+	using tile_delegate = device_delegate<void (int layer, int *code, int *color, int *flags, int *priority, u16 attr)>;
 
 	template <typename T> k056832_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&mixer_tag)
 		: k056832_device(mconfig, tag, owner, clock)

--- a/src/mame/konami/k054156_k054157_k056832.h
+++ b/src/mame/konami/k054156_k054157_k056832.h
@@ -103,6 +103,8 @@ public:
 	u16 word_r(offs_t offset);        // VACSET
 	u16 b_word_r(offs_t offset);      // VSCCS  (board dependent)
 
+	u8 get_mix_bits(u8 layer);
+
 
 protected:
 	// device-level overrides

--- a/src/mame/konami/k054156_k054157_k056832.h
+++ b/src/mame/konami/k054156_k054157_k056832.h
@@ -103,8 +103,6 @@ public:
 	u16 word_r(offs_t offset);        // VACSET
 	u16 b_word_r(offs_t offset);      // VSCCS  (board dependent)
 
-	u8 get_mix_bits(u8 layer);
-
 
 protected:
 	// device-level overrides

--- a/src/mame/konami/k054338.cpp
+++ b/src/mame/konami/k054338.cpp
@@ -65,7 +65,7 @@ u16 k054338_device::register_r(offs_t offset)
 	return m_regs[offset];
 }
 
-void k054338_device::update_all_shadows( int rushingheroes_hack, palette_device &palette )
+void k054338_device::update_all_shadows(int rushingheroes_hack, palette_device &palette)
 {
 	int i, d;
 	int noclip = m_regs[K338_REG_CONTROL] & K338_CTL_CLIPSL;
@@ -73,8 +73,7 @@ void k054338_device::update_all_shadows( int rushingheroes_hack, palette_device 
 	for (i = 0; i < 9; i++)
 	{
 		d = m_regs[K338_REG_SHAD1R + i] & 0x1ff;
-		if (d >= 0x100)
-			d -= 0x200;
+		if (d >= 0x100) d -= 0x200;
 		m_shd_rgb[i] = d;
 	}
 
@@ -93,7 +92,7 @@ void k054338_device::update_all_shadows( int rushingheroes_hack, palette_device 
 }
 
 // k054338 BG color fill
-void k054338_device::fill_solid_bg( bitmap_rgb32 &bitmap, const rectangle &cliprect )
+void k054338_device::fill_solid_bg(bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	uint32_t bgcolor = (register_r(K338_REG_BGC_R) & 0xff) << 16;
 	bgcolor |= register_r(K338_REG_BGC_GB);
@@ -142,60 +141,43 @@ void k054338_device::fill_backcolor(bitmap_rgb32 &bitmap, const rectangle &clipr
 }
 
 // addition blending unimplemented (requires major changes to drawgfx and tilemap.cpp)
-int k054338_device::set_alpha_level( int pblend )
+int k054338_device::set_alpha_level(int pblend)
 {
-	uint16_t *regs;
-	int ctrl, mixpri, mixset, mixlv;
+	if (pblend > 3) logerror("mixing mode index out of range: %d (valid range: 0-3)", pblend);
 
-	if (pblend <= 0 || pblend > 3)
-	{
-		return (255);
-	}
+	if (!pblend) return 255;
 
-	regs   = m_regs;
-	ctrl   = m_regs[K338_REG_CONTROL];
-	mixpri = ctrl & K338_CTL_MIXPRI;
-	mixset = regs[K338_REG_PBLEND + (pblend >> 1 & 1)] >> (~pblend << 3 & 8);
-	mixlv  = mixset & 0x1f;
+	// sanitize input
+	pblend &= 0b11;
 
-	if (m_alpha_inv)
-		mixlv = 0x1f - mixlv;
+	const u8 mixset = m_regs[K338_REG_PBLEND + (pblend >> 1 & 1)] >> (~pblend << 3 & 8);
+	u8 mixlv  = mixset & 0x1f;
 
-	if (!(mixset & 0x20))
-	{
-		mixlv = (mixlv << 3) | (mixlv >> 2);
-	}
-	else
-	{
-		if (!mixpri)
-		{
-			// source x alpha  +  target (clipped at 255)
-		}
-		else
-		{
-			// source  +  target x alpha (clipped at 255)
-		}
+	if (m_alpha_inv) mixlv = 0x1f - mixlv;
 
-		// DUMMY
-		if (mixlv && mixlv < 0x1f)
-			mixlv = 0x10;
+	// expand mix level (5 bits -> 8)
+	mixlv = (mixlv << 3) | (mixlv >> 2);
 
-		mixlv = (mixlv << 3) | (mixlv >> 2);
+	const bool additive_mode = mixset & 0x20;
+	const bool mixpri = m_regs[K338_REG_CONTROL] & K338_CTL_MIXPRI;
 
-		if (VERBOSE)
-			popmessage("MIXSET%1d %s addition mode: %02x", pblend, (mixpri) ? "dst" : "src", mixset & 0x1f);
-	}
+	mixlv |= additive_mode << 8;
+	mixlv |= mixpri << 9;
 
+	// returns 10 bits: pa llll llll
+	// p: MI (mixpri)
+	// a: additive mode
+	// l: alpha level (expanded)
 	return mixlv;
 }
 
-void k054338_device::invert_alpha( int invert )
+void k054338_device::invert_alpha(int invert)
 {
 	m_alpha_inv = invert;
 }
 
 
-void k054338_device::export_config( int **shd_rgb )
+void k054338_device::export_config(int **shd_rgb)
 {
 	*shd_rgb = m_shd_rgb;
 }

--- a/src/mame/konami/k054338.cpp
+++ b/src/mame/konami/k054338.cpp
@@ -151,7 +151,7 @@ int k054338_device::set_alpha_level(int pblend)
 	pblend &= 0b11;
 
 	const u8 mixset = m_regs[K338_REG_PBLEND + (pblend >> 1 & 1)] >> (~pblend << 3 & 8);
-	u8 mixlv  = mixset & 0x1f;
+	int mixlv  = mixset & 0x1f;
 
 	if (m_alpha_inv) mixlv = 0x1f - mixlv;
 

--- a/src/mame/konami/konamigx.cpp
+++ b/src/mame/konami/konamigx.cpp
@@ -1831,6 +1831,8 @@ void konamigx_state::salmndr2(machine_config &config)
 	konamigx(config);
 	m_k056832->set_config(K056832_BPP_6, 1, 0);
 
+	m_k056832->set_tile_callback(FUNC(konamigx_state::salmndr2_tile_callback));
+
 	m_k055673->set_sprite_callback(FUNC(konamigx_state::salmndr2_sprite_callback));
 	m_k055673->set_config(K055673_LAYOUT_GX6, -48, -23);
 }

--- a/src/mame/konami/konamigx.h
+++ b/src/mame/konami/konamigx.h
@@ -134,8 +134,7 @@ public:
 						tilemap_t *sub1, int sub1flags,
 						tilemap_t *sub2, int sub2flags,
 						int mixerflags, bitmap_ind16 *extra_bitmap, int rushingheroes_hack,
-						GX_OBJ *objpool,
-						u16 nobj
+						const std::vector<GX_OBJ> &objpool
 						);
 
 
@@ -303,8 +302,6 @@ protected:
 	std::unique_ptr<bitmap_ind16> m_gxtype1_roz_dstbitmap;
 	std::unique_ptr<bitmap_ind16> m_gxtype1_roz_dstbitmap2;
 	rectangle m_gxtype1_roz_dstbitmapclip;
-
-	std::unique_ptr<GX_OBJ[]> m_gx_objpool;
 
 	u8 m_type3_psac2_bank = 0;
 	u8 m_type3_spriteram_bank = 0;

--- a/src/mame/konami/konamigx.h
+++ b/src/mame/konami/konamigx.h
@@ -138,7 +138,7 @@ public:
 						);
 
 
-	void gx_draw_basic_tilemaps(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int mixerflags, int code);
+	void gx_draw_basic_tilemaps(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int mixerflags, u8 layer);
 	void gx_draw_basic_extended_tilemaps_1(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int mixerflags, int code, tilemap_t *sub1, int sub1flags, int rushingheroes_hack, int offs);
 	void gx_draw_basic_extended_tilemaps_2(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int mixerflags, int code, tilemap_t *sub2, int sub2flags, bitmap_ind16 *extra_bitmap, int offs);
 

--- a/src/mame/konami/konamigx.h
+++ b/src/mame/konami/konamigx.h
@@ -135,8 +135,7 @@ public:
 						tilemap_t *sub2, int sub2flags,
 						int mixerflags, bitmap_ind16 *extra_bitmap, int rushingheroes_hack,
 						GX_OBJ *objpool,
-						u16 *objbuf,
-						int nobj
+						u16 nobj
 						);
 
 

--- a/src/mame/konami/konamigx.h
+++ b/src/mame/konami/konamigx.h
@@ -121,7 +121,11 @@ public:
 	K055673_CB_MEMBER(salmndr2_sprite_callback);
 	K055673_CB_MEMBER(le2_sprite_callback);
 
-	struct GX_OBJ { int order = 0, offs = 0, code = 0, color = 0; };
+	struct GX_OBJ
+	{
+		u32 order = 0;
+		int offs = 0, code = 0, color = 0;
+	};
 
 	void common_init();
 	uint32_t k_6bpp_rom_long_r(offs_t offset, uint32_t mem_mask = ~0);
@@ -131,7 +135,7 @@ public:
 						tilemap_t *sub2, int sub2flags,
 						int mixerflags, bitmap_ind16 *extra_bitmap, int rushingheroes_hack,
 						GX_OBJ *objpool,
-						int *objbuf,
+						u16 *objbuf,
 						int nobj
 						);
 

--- a/src/mame/konami/konamigx.h
+++ b/src/mame/konami/konamigx.h
@@ -139,7 +139,7 @@ public:
 						);
 
 
-	void gx_draw_basic_tilemaps(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int mixerflags, u8 layer);
+	void gx_draw_basic_tilemaps(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int mixerflags, uint8_t layer);
 	void gx_draw_basic_extended_tilemaps_1(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int mixerflags, int code, tilemap_t *sub1, int sub1flags, int rushingheroes_hack, int offs);
 	void gx_draw_basic_extended_tilemaps_2(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int mixerflags, int code, tilemap_t *sub2, int sub2flags, bitmap_ind16 *extra_bitmap, int offs);
 

--- a/src/mame/konami/konamigx.h
+++ b/src/mame/konami/konamigx.h
@@ -340,6 +340,7 @@ protected:
     ----FFEEDDCCBBAA---------------- (layer A-F mix codes in forced blending)
     ---x---------------------------- (disable shadows)
     --x----------------------------- (disable z-buffering)
+	yy------------------------------ (last encountered tile mix code)
 */
 #define GXMIX_BLEND_AUTO    0           // emulate all blend effects
 #define GXMIX_BLEND_NONE    1           // disable all blend effects

--- a/src/mame/konami/konamigx.h
+++ b/src/mame/konami/konamigx.h
@@ -253,6 +253,8 @@ protected:
 	u8 m_current_brightness = 0xff;
 	u8 m_brightness[3]{};
 
+	u8 m_last_alpha_tile_mix_code = 0;
+
 	// mirrored K054338 settings
 	int *m_K054338_shdRGB = nullptr;
 

--- a/src/mame/konami/konamigx.h
+++ b/src/mame/konami/konamigx.h
@@ -115,6 +115,7 @@ public:
 	TIMER_CALLBACK_MEMBER(boothack_callback);
 	double adc0834_callback(uint8_t input);
 	K056832_CB_MEMBER(type2_tile_callback);
+	K056832_CB_MEMBER(salmndr2_tile_callback);
 	K056832_CB_MEMBER(alpha_tile_callback);
 	K055673_CB_MEMBER(type2_sprite_callback);
 	K055673_CB_MEMBER(dragoonj_sprite_callback);

--- a/src/mame/konami/konamigx_v.cpp
+++ b/src/mame/konami/konamigx_v.cpp
@@ -733,8 +733,13 @@ void konamigx_state::gx_draw_basic_tilemaps(screen_device &screen, bitmap_rgb32 
 			flags2 |= K056382_DRAW_FLAG_FORCE_XYSCROLL;
 		}
 
-		const int alpha = m_k054338->set_alpha_level(mix_mode_internal) & 0xFF;
-		const int alpha2 = m_k054338->set_alpha_level(mix_mode_external) & 0xFF;
+		// hack: mask out mixpri bit. if additive bit set, mask it out and invert alpha.
+		// this makes additive alpha effects look OK until they are properly handled.
+		int alpha = m_k054338->set_alpha_level(mix_mode_internal) & 0x1FF;
+		if (alpha & 0x100) alpha = ~alpha & 0xFF;
+
+		int alpha2 = m_k054338->set_alpha_level(mix_mode_external) & 0x1FF;
+		if (alpha2 & 0x100) alpha2 = ~alpha2 & 0xFF;
 
 		if (alpha < 255) flags |= TILEMAP_DRAW_ALPHA(alpha);
 

--- a/src/mame/konami/konamigx_v.cpp
+++ b/src/mame/konami/konamigx_v.cpp
@@ -739,7 +739,8 @@ void konamigx_state::gx_draw_basic_tilemaps(screen_device &screen, bitmap_rgb32 
 			}
 		}
 
-		int flags = 0, flags2 = 0;
+		int flags = TILEMAP_DRAW_CATEGORY(0);
+		int flags2 = TILEMAP_DRAW_CATEGORY(1);
 
 		if (const int alpha = m_k054338->set_alpha_level(mix_mode_bits) & 0xFF; alpha < 255)
 		{
@@ -1459,8 +1460,6 @@ uint32_t konamigx_state::screen_update_konamigx(screen_device &screen, bitmap_rg
 	}
 	else
 	{
-		konamigx_mixer(screen, bitmap, cliprect, nullptr, 0, nullptr, 0, 0, nullptr, m_gx_rushingheroes_hack);
-
 		int mixerflags = m_last_alpha_tile_mix_code << 30;
 		konamigx_mixer(screen, bitmap, cliprect, nullptr, 0, nullptr, 0, mixerflags, nullptr, m_gx_rushingheroes_hack);
 	}

--- a/src/mame/konami/konamigx_v.cpp
+++ b/src/mame/konami/konamigx_v.cpp
@@ -758,11 +758,13 @@ void konamigx_state::gx_draw_basic_tilemaps(screen_device &screen, bitmap_rgb32 
 
 		if (alpha2 < 255)
 		{
+			// tiles with mix codes are put into category 1.
+			// draw them in a separate pass for per-tile blending if necessary.
 			m_k056832->m_tilemap_draw(screen, bitmap, cliprect, layer, flags2, 0);
 		}
 		else
 		{
-			// if no alpha is being used for category 1 (tile mix code) tiles,
+			// if no alpha is being applied to category 1 (tile mix code) tiles,
 			// draw all tiles with one m_tilemap_draw call
 			flags |= TILEMAP_DRAW_ALL_CATEGORIES;
 		}
@@ -1069,23 +1071,10 @@ K056832_CB_MEMBER(konamigx_state::salmndr2_tile_callback)
 
 K056832_CB_MEMBER(konamigx_state::alpha_tile_callback)
 {
-	int mixcode;
 	int d = *code;
 
-	mixcode = K055555GX_decode_vmixcolor(layer, color);
-
-	if (mixcode < 0)
-		*code = (m_gx_tilebanks[(d & 0xe000)>>13]<<13) + (d & 0x1fff);
-	else
-	{
-		/* save mixcode and mark tile alpha (unimplemented) */
-		// Daisu-Kiss stage presentation
-		// Sexy Parodius level 3b
-		*code =  (m_gx_tilebanks[(d & 0xe000)>>13]<<13) + (d & 0x1fff);
-
-		if (VERBOSE)
-			popmessage("skipped alpha tile(layer=%d mix=%d)", layer, mixcode);
-	}
+	*code = (m_gx_tilebanks[(d & 0xe000)>>13]<<13) + (d & 0x1fff);
+	K055555GX_decode_vmixcolor(layer, color);
 
 	const u8 mix_code = (*flags >> (8 + 6)) & 0b11;
 	if (mix_code) {

--- a/src/mame/konami/konamigx_v.cpp
+++ b/src/mame/konami/konamigx_v.cpp
@@ -749,17 +749,12 @@ void konamigx_state::gx_draw_basic_tilemaps(screen_device &screen, bitmap_rgb32 
 			flags |= TILEMAP_DRAW_ALPHA(alpha);
 		}
 
-		if (alpha2 < 255)
-		{
-			flags2 |= TILEMAP_DRAW_ALPHA(alpha2);
-		}
-
-
-
-		if (alpha2 < 255)
+		if (alpha2 < 255 && mix_mode_bits != 0b11)
 		{
 			// tiles with mix codes are put into category 1.
 			// draw them in a separate pass for per-tile blending if necessary.
+
+			flags2 |= TILEMAP_DRAW_ALPHA(alpha2);
 			m_k056832->m_tilemap_draw(screen, bitmap, cliprect, layer, flags2, 0);
 		}
 		else

--- a/src/mame/konami/konamigx_v.cpp
+++ b/src/mame/konami/konamigx_v.cpp
@@ -867,7 +867,7 @@ void konamigx_state::konamigx_mixer_draw(screen_device &screen, bitmap_rgb32 &bi
 			if (drawmode & 2)
 			{
 				alpha = color>>K055555_MIXSHIFT & 3;
-				if (alpha) alpha = m_k054338->set_alpha_level(alpha) & 0xFF;
+				if (alpha) alpha = m_k054338->set_alpha_level(alpha);
 				if (alpha <= 0) continue;
 			}
 			color &= K055555_COLORMASK;

--- a/src/mame/konami/konamigx_v.cpp
+++ b/src/mame/konami/konamigx_v.cpp
@@ -703,7 +703,7 @@ void konamigx_state::gx_draw_basic_tilemaps(screen_device &screen, bitmap_rgb32 
 		*/
 		if (temp1!=0xff && temp2 /*&& temp3==3*/)
 		{
-			temp4 = m_k054338->set_alpha_level(temp2);
+			temp4 = m_k054338->set_alpha_level(temp2) & 0xFF;
 
 			if (temp4 <= 0) return;
 			if (temp4 < 255) k = TILEMAP_DRAW_ALPHA(temp4);
@@ -738,7 +738,7 @@ void konamigx_state::gx_draw_basic_extended_tilemaps_1(screen_device &screen, bi
 
 		if (temp1!=0xff && temp2 /*&& temp3==3*/)
 		{
-			alpha = temp4 = m_k054338->set_alpha_level(temp2);
+			alpha = temp4 = m_k054338->set_alpha_level(temp2) & 0xFF;
 
 			if (temp4 <= 0) return;
 			if (temp4 < 255) k = 1;
@@ -786,7 +786,7 @@ void konamigx_state::gx_draw_basic_extended_tilemaps_2(screen_device &screen, bi
 		if (temp1!=0xff && temp2 /*&& temp3==3*/)
 		{
 			//alpha =
-			temp4 = m_k054338->set_alpha_level(temp2);
+			temp4 = m_k054338->set_alpha_level(temp2) & 0xFF;
 
 			if (temp4 <= 0) return;
 			//if (temp4 < 255) k = 1;
@@ -867,7 +867,7 @@ void konamigx_state::konamigx_mixer_draw(screen_device &screen, bitmap_rgb32 &bi
 			if (drawmode & 2)
 			{
 				alpha = color>>K055555_MIXSHIFT & 3;
-				if (alpha) alpha = m_k054338->set_alpha_level(alpha);
+				if (alpha) alpha = m_k054338->set_alpha_level(alpha) & 0xFF;
 				if (alpha <= 0) continue;
 			}
 			color &= K055555_COLORMASK;

--- a/src/mame/konami/konamigx_v.cpp
+++ b/src/mame/konami/konamigx_v.cpp
@@ -721,36 +721,34 @@ void konamigx_state::gx_draw_basic_tilemaps(screen_device &screen, bitmap_rgb32 
 		}
 		else
 		{
-			const u8 v_inmix_layer = m_vinmix >> layer2 & 0b11;
 			const u8 v_inmix_on_layer = m_vmixon >> layer2 & 0b11;
+			const u8 v_inmix_layer = m_vinmix >> layer2 & 0b11;
 
 			if (!v_inmix_on_layer)
 			{
+				// if v_inmix_on_layer == 0, the mix mode bits are are taken from the tiles.
+				// this probably needs to be done if v_inmix_on_layer != 0b11, not just v_inmix_on_layer == 0b00?
+				// todo: find a game that sets v_inmix_on to 0b01 or 0b10. 
 				mix_mode_bits2 = u32(mixerflags) >> 30;
 			}
 			else
 			{
+				// v_inmix_on_layer == 0b11 (also 0b01, 0b10 currently)
+				// get mix mode bits from v_inmix
 				mix_mode_bits = v_inmix_layer;
 			}
 		}
-
-		/* blend layer only when:
-		    1) m_vinmix != 0xff
-		    2) its internal mix code is set
-		    3) all mix code bits are internal(overridden until tile blending has been implemented)
-		    4) 0 > alpha < 255;
-		*/
 
 		int flags = 0, flags2 = 0;
 
 		if (const int alpha = m_k054338->set_alpha_level(mix_mode_bits) & 0xFF; alpha < 255)
 		{
-			flags = TILEMAP_DRAW_ALPHA(alpha);
+			flags |= TILEMAP_DRAW_ALPHA(alpha);
 		}
 
 		if (const int alpha = m_k054338->set_alpha_level(mix_mode_bits2) & 0xFF; alpha < 255)
 		{
-			flags2 = TILEMAP_DRAW_ALPHA(alpha);
+			flags2 |= TILEMAP_DRAW_ALPHA(alpha);
 		}
 
 		if (mixerflags & 1 << (layer + 12))
@@ -761,8 +759,8 @@ void konamigx_state::gx_draw_basic_tilemaps(screen_device &screen, bitmap_rgb32 
 
 		m_k056832->m_tilemap_draw(screen, bitmap, cliprect, layer, flags, 0);
 
-		// category 1 contains tiles with a mix code
-		m_k056832->m_tilemap_draw(screen, bitmap, cliprect, layer, flags2 | 1, 0);
+		// category 1 is tiles with a mix code
+		m_k056832->m_tilemap_draw(screen, bitmap, cliprect, layer, flags2, 0);
 	}
 }
 

--- a/src/mame/konami/konamigx_v.cpp
+++ b/src/mame/konami/konamigx_v.cpp
@@ -1057,30 +1057,29 @@ K056832_CB_MEMBER(konamigx_state::type2_tile_callback)
 
 K056832_CB_MEMBER(konamigx_state::salmndr2_tile_callback)
 {
-	int d = *code;
-
-	*code = (m_gx_tilebanks[(d & 0xe000)>>13]<<13) + (d & 0x1fff);
-	K055555GX_decode_vmixcolor(layer, color);
-
-	const u8 mix_code = (*flags >> (8 + 4)) & 0b11;
+	const u8 mix_code = attr >> 4 & 0b11;
 	if (mix_code) {
 		*priority = 1;
 		m_last_alpha_tile_mix_code = mix_code;
 	}
+
+	int d = *code;
+
+	*code = (m_gx_tilebanks[(d & 0xe000)>>13]<<13) + (d & 0x1fff);
+	K055555GX_decode_vmixcolor(layer, color);
 }
 
 K056832_CB_MEMBER(konamigx_state::alpha_tile_callback)
 {
-	int d = *code;
-
-	*code = (m_gx_tilebanks[(d & 0xe000)>>13]<<13) + (d & 0x1fff);
-	K055555GX_decode_vmixcolor(layer, color);
-
-	const u8 mix_code = (*flags >> (8 + 6)) & 0b11;
+	const u8 mix_code = attr >> 6 & 0b11;
 	if (mix_code) {
 		*priority = 1;
 		m_last_alpha_tile_mix_code = mix_code;
 	}
+	int d = *code;
+
+	*code = (m_gx_tilebanks[(d & 0xe000)>>13]<<13) + (d & 0x1fff);
+	K055555GX_decode_vmixcolor(layer, color);
 }
 
 /*

--- a/src/mame/konami/konamigx_v.cpp
+++ b/src/mame/konami/konamigx_v.cpp
@@ -533,7 +533,7 @@ void konamigx_state::konamigx_mixer(screen_device &screen, bitmap_rgb32 &bitmap,
 				if (shadow != 1 || k053246_objset1 & 0x20)
 				{
 					shadow--;
-					add_solid = 1; // add solid
+					add_solid = 1;
 					solid_draw_mode = 1; // draw partial solid
 					if (shadowon[shadow])
 					{
@@ -552,7 +552,7 @@ void konamigx_state::konamigx_mixer(screen_device &screen, bitmap_rgb32 &bitmap,
 			}
 			else
 			{
-				add_solid = 1; // add solid
+				add_solid = 1;
 				solid_draw_mode = 0; // draw full solid
 			}
 
@@ -637,10 +637,10 @@ void konamigx_state::konamigx_mixer_draw(screen_device &screen, bitmap_rgb32 &bi
 
 	for (int count=0; count<objpool.size(); count++)
 	{
-		const u32 order  = objpool[count].order;
-		const int offs   = objpool[count].offs;
-		const int code   = objpool[count].code;
-		int color        = objpool[count].color;
+		const u32 order = objpool[count].order;
+		const int offs  = objpool[count].offs;
+		const int code  = objpool[count].code;
+		int color       = objpool[count].color;
 
 		/* entries >=0 in our list are sprites */
 		if (offs >= 0)

--- a/src/mame/konami/konamigx_v.cpp
+++ b/src/mame/konami/konamigx_v.cpp
@@ -735,11 +735,15 @@ void konamigx_state::gx_draw_basic_tilemaps(screen_device &screen, bitmap_rgb32 
 
 		// hack: mask out mixpri bit. if additive bit set, mask it out and invert alpha.
 		// this makes additive alpha effects look OK until they are properly handled.
-		int alpha = m_k054338->set_alpha_level(mix_mode_internal) & 0x1FF;
-		if (alpha & 0x100) alpha = ~alpha & 0xFF;
+		int alpha = m_k054338->set_alpha_level(mix_mode_internal) & 0x1ff;
+		if (alpha & 0x100)
+		{
+			alpha &= 0xff;
+			if (alpha) alpha = ~alpha & 0xff;
+		}
 
-		int alpha2 = m_k054338->set_alpha_level(mix_mode_external) & 0x1FF;
-		if (alpha2 & 0x100) alpha2 = ~alpha2 & 0xFF;
+		int alpha2 = m_k054338->set_alpha_level(mix_mode_external) & 0x1ff;
+		if (alpha2 & 0x100) alpha2 = ~alpha2 & 0xff;
 
 		if (alpha < 255) flags |= TILEMAP_DRAW_ALPHA(alpha);
 

--- a/src/mame/konami/konamigx_v.cpp
+++ b/src/mame/konami/konamigx_v.cpp
@@ -55,9 +55,9 @@ void konamigx_state::konamigx_precache_registers(void)
 	m_osinmix  = m_k055555->K055555_read_register(K55_OSBLEND_ENABLES);
 	m_osmixon  = m_k055555->K055555_read_register(K55_OSBLEND_ON);
 
-	m_brightness[0] = u8(m_k054338->register_r(K338_REG_BRI3));
-	m_brightness[1] = u8(m_k054338->register_r(K338_REG_BRI3 + 1) >> 8);
-	m_brightness[2] = u8(m_k054338->register_r(K338_REG_BRI3 + 1));
+	m_brightness[0] = uint8_t(m_k054338->register_r(K338_REG_BRI3));
+	m_brightness[1] = uint8_t(m_k054338->register_r(K338_REG_BRI3 + 1) >> 8);
+	m_brightness[2] = uint8_t(m_k054338->register_r(K338_REG_BRI3 + 1));
 }
 
 inline int konamigx_state::K053247GX_combine_c18(int attrib) // (see p.46)
@@ -249,9 +249,9 @@ void konamigx_state::wipezbuf(int noshadow)
 
 void konamigx_state::set_brightness(int layer)
 {
-	const u8 bri_mode = (m_k055555->K055555_read_register(K55_VBRI) >> layer * 2) & 0b11;
+	const uint8_t bri_mode = (m_k055555->K055555_read_register(K55_VBRI) >> layer * 2) & 0b11;
 
-	const u8 new_brightness = bri_mode ? m_brightness[bri_mode - 1] : 0xff;
+	const uint8_t new_brightness = bri_mode ? m_brightness[bri_mode - 1] : 0xff;
 
 	if (m_current_brightness != new_brightness)
 	{
@@ -351,9 +351,9 @@ void konamigx_state::konamigx_mixer(screen_device &screen, bitmap_rgb32 &bitmap,
 		m_k054338->fill_solid_bg(bitmap, cliprect);
 
 	// abort if video has been disabled
-	const u8 disp = m_k055555->K055555_read_register(K55_INPUT_ENABLES);
+	const uint8_t disp = m_k055555->K055555_read_register(K55_INPUT_ENABLES);
 	if (!disp) return;
-	u16 cltc_shdpri = m_k054338->register_r(K338_REG_CONTROL);
+	uint16_t cltc_shdpri = m_k054338->register_r(K338_REG_CONTROL);
 
 
 	if (!rushingheroes_hack) // Slam Dunk 2 never sets this.  It's either part of the protection, or type4 doesn't use it
@@ -375,13 +375,13 @@ void konamigx_state::konamigx_mixer(screen_device &screen, bitmap_rgb32 &bitmap,
 	konamigx_precache_registers();
 
 	// init OBJSET2 and mixer parameters (see p.51 and chapter 7)
-	u8 layerid[6] = {0, 1, 2, 3, 4, 5};
+	uint8_t layerid[6] = {0, 1, 2, 3, 4, 5};
 
 
 	// invert layer priority when this flag is set (not used by any GX game?)
 	//prflp = K055555_read_register(K55_CONTROL) & K55_CTL_FLIPPRI;
 
-	u8 layerpri[6];
+	uint8_t layerpri[6];
 	layerpri[0] = m_k055555->K055555_read_register(K55_PRIINP_0);
 	layerpri[1] = m_k055555->K055555_read_register(K55_PRIINP_3);
 	layerpri[3] = m_k055555->K055555_read_register(K55_PRIINP_7);
@@ -408,7 +408,7 @@ void konamigx_state::konamigx_mixer(screen_device &screen, bitmap_rgb32 &bitmap,
 	if (!(shdprisel & 0x0c)) shadowon[1] = 0;
 	if (!(shdprisel & 0x30)) shadowon[2] = 0;
 
-	u8 shdpri[3];
+	uint8_t shdpri[3];
 	shdpri[0]   = m_k055555->K055555_read_register(K55_SHAD1_PRI);
 	shdpri[1]   = m_k055555->K055555_read_register(K55_SHAD2_PRI);
 	shdpri[2]   = m_k055555->K055555_read_register(K55_SHAD3_PRI);
@@ -457,7 +457,7 @@ void konamigx_state::konamigx_mixer(screen_device &screen, bitmap_rgb32 &bitmap,
 	{
 		int offs;
 
-		const u8 code = layerid[i];
+		const uint8_t code = layerid[i];
 		switch (code)
 		{
 			/*
@@ -484,22 +484,22 @@ void konamigx_state::konamigx_mixer(screen_device &screen, bitmap_rgb32 &bitmap,
 
 		if (offs != -128)
 		{
-			const u32 order = layerpri[i] << 24;
+			const uint32_t order = layerpri[i] << 24;
 			const int color = 0;
 			objpool.push_back(GX_OBJ{order, offs, code, color});
 		}
 	}
 
-	const u32 start_addr = m_type3_spriteram_bank ? 0x800 : 0;
+	const uint32_t start_addr = m_type3_spriteram_bank ? 0x800 : 0;
 
 	for (int x = 0; x < 256; ++x)
 	{
-		const u16 offs = start_addr + x * 8;
+		const uint16_t offs = start_addr + x * 8;
 		int pri = 0;
 
 		if (!(m_gx_spriteram[offs] & 0x8000)) continue;
 
-		u8 zcode = m_gx_spriteram[offs] & 0xff;
+		uint8_t zcode = m_gx_spriteram[offs] & 0xff;
 
 		// invert z-order when opset_pri is set (see p.51 OPSET PRI)
 		if (m_k053247_opset & 0x10) zcode = 0xff - zcode;
@@ -510,12 +510,12 @@ void konamigx_state::konamigx_mixer(screen_device &screen, bitmap_rgb32 &bitmap,
 
 		m_k055673->m_k053247_cb(&code, &color, &pri);
 
-		u8 shadow_draw_mode = 0; // shadow pens draw mode (4-5)
-		bool add_shadow = 0;     // add shadow object
-		u8 solid_draw_mode = 0;  // solid pens draw mode (0-3)
-		bool add_solid = 0;      // add solid object
-		u8 spri = 0;             // shadow priority
-		u8 shadow = 0;           // shadow code
+		uint8_t shadow_draw_mode = 0; // shadow pens draw mode (4-5)
+		bool add_shadow = 0;          // add shadow object
+		uint8_t solid_draw_mode = 0;  // solid pens draw mode (0-3)
+		bool add_solid = 0;           // add solid object
+		uint8_t spri = 0;             // shadow priority
+		uint8_t shadow = 0;           // shadow code
 
 		if (color & K055555_FULLSHADOW)
 		{
@@ -599,14 +599,14 @@ void konamigx_state::konamigx_mixer(screen_device &screen, bitmap_rgb32 &bitmap,
 		if (add_solid)
 		{
 			// add objects with solid or alpha pens
-			u32 order = pri<<24 | zcode<<16 | offs<<(8-3) | solid_draw_mode<<4;
+			uint32_t order = pri<<24 | zcode<<16 | offs<<(8-3) | solid_draw_mode<<4;
 			objpool.push_back(GX_OBJ{order, offs, code, color});
 		}
 
 		if (add_shadow && !(color & K055555_SKIPSHADOW) && !(mixerflags & GXMIX_NOSHADOW))
 		{
 			// add objects with shadows if enabled
-			u32 order = spri<<24 | zcode<<16 | offs<<(8-3) | shadow_draw_mode<<4 | shadow;
+			uint32_t order = spri<<24 | zcode<<16 | offs<<(8-3) | shadow_draw_mode<<4 | shadow;
 			objpool.push_back(GX_OBJ{ order, offs, code, color});
 		}
 	}
@@ -633,14 +633,14 @@ void konamigx_state::konamigx_mixer_draw(screen_device &screen, bitmap_rgb32 &bi
 					)
 {
 	// traverse draw list
-	const u8 disp = m_k055555->K055555_read_register(K55_INPUT_ENABLES);
+	const uint8_t disp = m_k055555->K055555_read_register(K55_INPUT_ENABLES);
 
 	for (int count=0; count<objpool.size(); count++)
 	{
-		const u32 order = objpool[count].order;
-		const int offs  = objpool[count].offs;
-		const int code  = objpool[count].code;
-		int color       = objpool[count].color;
+		const uint32_t order = objpool[count].order;
+		const int offs = objpool[count].offs;
+		const int code = objpool[count].code;
+		int color = objpool[count].color;
 
 		/* entries >=0 in our list are sprites */
 		if (offs >= 0)
@@ -698,27 +698,27 @@ void konamigx_state::konamigx_mixer_draw(screen_device &screen, bitmap_rgb32 &bi
 	}
 }
 
-void konamigx_state::gx_draw_basic_tilemaps(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int mixerflags, u8 layer)
+void konamigx_state::gx_draw_basic_tilemaps(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int mixerflags, uint8_t layer)
 {
-	const u8 disp = m_k055555->K055555_read_register(K55_INPUT_ENABLES);
+	const uint8_t disp = m_k055555->K055555_read_register(K55_INPUT_ENABLES);
 
 	if (disp & (1 << layer))
 	{
 		set_brightness(layer);
 
-		const u8 layer2 = layer << 1;
-		const u8 j = mixerflags >> layer2 & 0b11;
+		const uint8_t layer2 = layer << 1;
+		const uint8_t j = mixerflags >> layer2 & 0b11;
 
 		// keep internal and external mix codes separated, so the external mix code can be applied to category 1 tiles
-		u8 mix_mode_internal = 0;
-		u8 mix_mode_external = 0;
+		uint8_t mix_mode_internal = 0;
+		uint8_t mix_mode_external = 0;
 
 		if (j == GXMIX_BLEND_FORCE) mix_mode_internal = mixerflags >> (layer2 + 16) & 0b11; // hack
 		else
 		{
-			const u8 v_inmix_on_layer = m_vmixon >> layer2 & 0b11;
-			const u8 v_inmix_layer = m_vinmix >> layer2 & 0b11;
-			const u8 tile_mix_code = u32(mixerflags) >> 30;
+			const uint8_t v_inmix_on_layer = m_vmixon >> layer2 & 0b11;
+			const uint8_t v_inmix_layer = m_vinmix >> layer2 & 0b11;
+			const uint8_t tile_mix_code = uint32_t(mixerflags) >> 30;
 
 			mix_mode_internal = v_inmix_layer & v_inmix_on_layer;
 			mix_mode_external = tile_mix_code & ~v_inmix_on_layer;
@@ -787,7 +787,7 @@ void konamigx_state::gx_draw_basic_extended_tilemaps_1(screen_device &screen, bi
 
 		if (temp1!=0xff && temp2 /*&& temp3==3*/)
 		{
-			alpha = temp4 = m_k054338->set_alpha_level(temp2) & 0xFF;
+			alpha = temp4 = m_k054338->set_alpha_level(temp2) & 0xff;
 
 			if (temp4 <= 0) return;
 			if (temp4 < 255) k = 1;
@@ -835,7 +835,7 @@ void konamigx_state::gx_draw_basic_extended_tilemaps_2(screen_device &screen, bi
 		if (temp1!=0xff && temp2 /*&& temp3==3*/)
 		{
 			//alpha =
-			temp4 = m_k054338->set_alpha_level(temp2) & 0xFF;
+			temp4 = m_k054338->set_alpha_level(temp2) & 0xff;
 
 			if (temp4 <= 0) return;
 			//if (temp4 < 255) k = 1;
@@ -1049,7 +1049,7 @@ K056832_CB_MEMBER(konamigx_state::type2_tile_callback)
 
 K056832_CB_MEMBER(konamigx_state::salmndr2_tile_callback)
 {
-	const u8 mix_code = attr >> 4 & 0b11;
+	const uint8_t mix_code = attr >> 4 & 0b11;
 	if (mix_code) {
 		*priority = 1;
 		m_last_alpha_tile_mix_code = mix_code;
@@ -1063,7 +1063,7 @@ K056832_CB_MEMBER(konamigx_state::salmndr2_tile_callback)
 
 K056832_CB_MEMBER(konamigx_state::alpha_tile_callback)
 {
-	const u8 mix_code = attr >> 6 & 0b11;
+	const uint8_t mix_code = attr >> 6 & 0b11;
 	if (mix_code) {
 		*priority = 1;
 		m_last_alpha_tile_mix_code = mix_code;

--- a/src/mame/konami/konamigx_v.cpp
+++ b/src/mame/konami/konamigx_v.cpp
@@ -728,7 +728,7 @@ void konamigx_state::gx_draw_basic_tilemaps(screen_device &screen, bitmap_rgb32 
 			{
 				// if v_inmix_on_layer == 0, the mix mode bits are are taken from the tiles.
 				// this probably needs to be done if v_inmix_on_layer != 0b11, not just v_inmix_on_layer == 0b00?
-				// todo: find a game that sets v_inmix_on to 0b01 or 0b10. 
+				// todo: find a game that sets v_inmix_on to 0b01 or 0b10.
 				mix_mode_bits2 = u32(mixerflags) >> 30;
 			}
 			else

--- a/src/mame/konami/moo.cpp
+++ b/src/mame/konami/moo.cpp
@@ -333,7 +333,7 @@ uint32_t moo_state::screen_update_moo(screen_device &screen, bitmap_rgb32 &bitma
 	// There is probably a control bit somewhere to turn off alpha blending.
 	m_alpha_enabled = m_k054338->register_r(K338_REG_CONTROL) & K338_CTL_MIXPRI; // DUMMY
 
-	alpha = (m_alpha_enabled) ? m_k054338->set_alpha_level(1) & 0xFF : 255;
+	alpha = (m_alpha_enabled) ? m_k054338->set_alpha_level(1) & 0xff : 255;
 
 	if (alpha > 0)
 		m_k056832->tilemap_draw(screen, bitmap, cliprect, layers[2], TILEMAP_DRAW_ALPHA(alpha), 4);

--- a/src/mame/konami/moo.cpp
+++ b/src/mame/konami/moo.cpp
@@ -333,7 +333,7 @@ uint32_t moo_state::screen_update_moo(screen_device &screen, bitmap_rgb32 &bitma
 	// There is probably a control bit somewhere to turn off alpha blending.
 	m_alpha_enabled = m_k054338->register_r(K338_REG_CONTROL) & K338_CTL_MIXPRI; // DUMMY
 
-	alpha = (m_alpha_enabled) ? m_k054338->set_alpha_level(1) : 255;
+	alpha = (m_alpha_enabled) ? m_k054338->set_alpha_level(1) & 0xFF : 255;
 
 	if (alpha > 0)
 		m_k056832->tilemap_draw(screen, bitmap, cliprect, layers[2], TILEMAP_DRAW_ALPHA(alpha), 4);

--- a/src/mame/konami/mystwarr.cpp
+++ b/src/mame/konami/mystwarr.cpp
@@ -1034,7 +1034,7 @@ void mystwarr_state::viostorm(machine_config &config)
 	m_screen->set_size(64*8, 32*8);
 	m_screen->set_visarea(40, 40+384-1, 16, 16+224-1);
 
-	m_k056832->set_tile_callback(FUNC(mystwarr_state::game4bpp_tile_callback));
+	m_k056832->set_tile_callback(FUNC(mystwarr_state::viostorm_tile_callback));
 
 	m_k055673->set_sprite_callback(FUNC(mystwarr_state::metamrph_sprite_callback));
 	m_k055673->set_config(K055673_LAYOUT_RNG, -62, -23);
@@ -1082,7 +1082,7 @@ void mystwarr_state::metamrph(machine_config &config)
 	m_screen->set_size(64*8, 32*8);
 	m_screen->set_visarea(24, 24+288-1, 15, 15+224-1);
 
-	m_k056832->set_tile_callback(FUNC(mystwarr_state::game4bpp_tile_callback));
+	m_k056832->set_tile_callback(FUNC(mystwarr_state::viostorm_tile_callback));
 
 	m_k055673->set_sprite_callback(FUNC(mystwarr_state::metamrph_sprite_callback));
 	m_k055673->set_config(K055673_LAYOUT_RNG, -51, -24);

--- a/src/mame/konami/mystwarr.h
+++ b/src/mame/konami/mystwarr.h
@@ -55,6 +55,8 @@ private:
 	uint8_t m_sound_ctrl = 0;
 	uint8_t m_sound_nmi_clk = 0;
 
+	u8 m_last_alpha_tile_mix_code = 0;
+
 	uint16_t eeprom_r(offs_t offset, uint16_t mem_mask = ~0);
 	void mweeprom_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	uint16_t dddeeprom_r(offs_t offset, uint16_t mem_mask = ~0);

--- a/src/mame/konami/mystwarr.h
+++ b/src/mame/konami/mystwarr.h
@@ -105,6 +105,7 @@ private:
 	TIMER_DEVICE_CALLBACK_MEMBER(metamrph_interrupt);
 	TIMER_DEVICE_CALLBACK_MEMBER(mchamp_interrupt);
 	K056832_CB_MEMBER(mystwarr_tile_callback);
+	K056832_CB_MEMBER(viostorm_tile_callback);
 	K056832_CB_MEMBER(game5bpp_tile_callback);
 	K056832_CB_MEMBER(game4bpp_tile_callback);
 	K055673_CB_MEMBER(mystwarr_sprite_callback);

--- a/src/mame/konami/mystwarr.h
+++ b/src/mame/konami/mystwarr.h
@@ -55,7 +55,7 @@ private:
 	uint8_t m_sound_ctrl = 0;
 	uint8_t m_sound_nmi_clk = 0;
 
-	u8 m_last_alpha_tile_mix_code = 0;
+	uint8_t m_last_alpha_tile_mix_code = 0;
 
 	uint16_t eeprom_r(offs_t offset, uint16_t mem_mask = ~0);
 	void mweeprom_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);

--- a/src/mame/konami/mystwarr_v.cpp
+++ b/src/mame/konami/mystwarr_v.cpp
@@ -59,7 +59,7 @@ void mystwarr_state::decode_tiles()
 // Mystic Warriors requires tile based blending.
 K056832_CB_MEMBER(mystwarr_state::mystwarr_tile_callback)
 {
-	const u8 mix_code = (*flags >> (8 + 2)) & 0b11;
+	const u8 mix_code = attr >> 2 & 0b11;
 	if (mix_code) {
 		*priority = 1;
 		m_last_alpha_tile_mix_code = mix_code;
@@ -70,7 +70,7 @@ K056832_CB_MEMBER(mystwarr_state::mystwarr_tile_callback)
 
 K056832_CB_MEMBER(mystwarr_state::viostorm_tile_callback)
 {
-	const u8 mix_code = (*flags >> 8) & 0b11;
+	const u8 mix_code = attr & 0b11;
 	if (mix_code) {
 		*priority = 1;
 		m_last_alpha_tile_mix_code = mix_code;

--- a/src/mame/konami/mystwarr_v.cpp
+++ b/src/mame/konami/mystwarr_v.cpp
@@ -68,6 +68,17 @@ K056832_CB_MEMBER(mystwarr_state::mystwarr_tile_callback)
 	*color = m_layer_colorbase[layer] | (*color >> 1 & 0x1e);
 }
 
+K056832_CB_MEMBER(mystwarr_state::viostorm_tile_callback)
+{
+	const u8 mix_code = (*flags >> 8) & 0b11;
+	if (mix_code) {
+		*priority = 1;
+		m_last_alpha_tile_mix_code = mix_code;
+	}
+
+	*color = m_layer_colorbase[layer] | (*color >> 2 & 0x0f);
+}
+
 // for games with 5bpp tile data
 K056832_CB_MEMBER(mystwarr_state::game5bpp_tile_callback)
 {
@@ -282,7 +293,8 @@ uint32_t mystwarr_state::screen_update_metamrph(screen_device &screen, bitmap_rg
 
 	m_sprite_colorbase = m_k055555->K055555_get_palette_index(4) << 4;
 
-	konamigx_mixer(screen, bitmap, cliprect, nullptr, GXSUB_K053250 | GXSUB_4BPP, nullptr, 0, 0, nullptr, 0);
+	int mixerflags = m_last_alpha_tile_mix_code << 30;
+	konamigx_mixer(screen, bitmap, cliprect, nullptr, GXSUB_K053250 | GXSUB_4BPP, nullptr, 0, mixerflags, nullptr, 0);
 	return 0;
 }
 

--- a/src/mame/konami/mystwarr_v.cpp
+++ b/src/mame/konami/mystwarr_v.cpp
@@ -65,7 +65,7 @@ K056832_CB_MEMBER(mystwarr_state::mystwarr_tile_callback)
 		m_last_alpha_tile_mix_code = mix_code;
 	}
 
-	*color = m_layer_colorbase[layer] | (*color >> 1 & 0x1e);
+	*color = m_layer_colorbase[layer] | (*color >> 1 & 0x0f);
 }
 
 K056832_CB_MEMBER(mystwarr_state::viostorm_tile_callback)

--- a/src/mame/konami/mystwarr_v.cpp
+++ b/src/mame/konami/mystwarr_v.cpp
@@ -70,6 +70,7 @@ K056832_CB_MEMBER(mystwarr_state::mystwarr_tile_callback)
 
 K056832_CB_MEMBER(mystwarr_state::viostorm_tile_callback)
 {
+	// metamrph either uses bits 0-1 or 4-5, not sure which
 	const u8 mix_code = attr & 0b11;
 	if (mix_code) {
 		*priority = 1;

--- a/src/mame/konami/mystwarr_v.cpp
+++ b/src/mame/konami/mystwarr_v.cpp
@@ -206,8 +206,6 @@ VIDEO_START_MEMBER(mystwarr_state, mystwarr)
 	m_k056832->set_layer_offs(1,  0-3, 0);
 	m_k056832->set_layer_offs(2,  2-3, 0);
 	m_k056832->set_layer_offs(3,  3-3, 0);
-
-	m_cbparam = 0;
 }
 
 VIDEO_START_MEMBER(mystwarr_state, metamrph)

--- a/src/mame/konami/mystwarr_v.cpp
+++ b/src/mame/konami/mystwarr_v.cpp
@@ -59,6 +59,12 @@ void mystwarr_state::decode_tiles()
 // Mystic Warriors requires tile based blending.
 K056832_CB_MEMBER(mystwarr_state::mystwarr_tile_callback)
 {
+	const u8 mix_code = (*flags >> (8 + 2)) & 0b11;
+	if (mix_code) {
+		*priority = 1;
+		m_last_alpha_tile_mix_code = mix_code;
+	}
+
 	*color = m_layer_colorbase[layer] | (*color >> 1 & 0x1e);
 }
 
@@ -262,7 +268,8 @@ uint32_t mystwarr_state::screen_update_mystwarr(screen_device &screen, bitmap_rg
 
 	m_sprite_colorbase = m_k055555->K055555_get_palette_index(4) << 5;
 
-	konamigx_mixer(screen, bitmap, cliprect, nullptr, 0, nullptr, 0, 0, nullptr, 0);
+	int mixerflags = m_last_alpha_tile_mix_code << 30;
+	konamigx_mixer(screen, bitmap, cliprect, nullptr, 0, nullptr, 0, mixerflags, nullptr, 0);
 	return 0;
 }
 

--- a/src/mame/konami/mystwarr_v.cpp
+++ b/src/mame/konami/mystwarr_v.cpp
@@ -59,8 +59,9 @@ void mystwarr_state::decode_tiles()
 // Mystic Warriors requires tile based blending.
 K056832_CB_MEMBER(mystwarr_state::mystwarr_tile_callback)
 {
-	const u8 mix_code = attr >> 2 & 0b11;
-	if (mix_code) {
+	const uint8_t mix_code = attr >> 2 & 0b11;
+	if (mix_code)
+	{
 		*priority = 1;
 		m_last_alpha_tile_mix_code = mix_code;
 	}
@@ -71,8 +72,9 @@ K056832_CB_MEMBER(mystwarr_state::mystwarr_tile_callback)
 K056832_CB_MEMBER(mystwarr_state::viostorm_tile_callback)
 {
 	// metamrph either uses bits 0-1 or 4-5, not sure which
-	const u8 mix_code = attr & 0b11;
-	if (mix_code) {
+	const uint8_t mix_code = attr & 0b11;
+	if (mix_code)
+	{
 		*priority = 1;
 		m_last_alpha_tile_mix_code = mix_code;
 	}

--- a/src/mame/konami/mystwarr_v.cpp
+++ b/src/mame/konami/mystwarr_v.cpp
@@ -59,15 +59,6 @@ void mystwarr_state::decode_tiles()
 // Mystic Warriors requires tile based blending.
 K056832_CB_MEMBER(mystwarr_state::mystwarr_tile_callback)
 {
-	if (layer == 1)
-	{
-		//* water hack (TEMPORARY)
-		if ((*code & 0xff00) + (*color) == 0x4101)
-			m_cbparam++;
-		else
-			m_cbparam--;
-	}
-
 	*color = m_layer_colorbase[layer] | (*color >> 1 & 0x1e);
 }
 
@@ -262,14 +253,6 @@ VIDEO_START_MEMBER(mystwarr_state, martchmp)
 
 uint32_t mystwarr_state::screen_update_mystwarr(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	int blendmode = 0;
-
-	//* water hack (TEMPORARY)
-	if (m_cbparam < 0)
-		m_cbparam = 0;
-	else if (m_cbparam >= 32)
-		blendmode = (1 << 16 | GXMIX_BLEND_FORCE) << 2;
-
 	for (int i = 0; i < 4; i++)
 	{
 		int old = m_layer_colorbase[i];
@@ -279,7 +262,7 @@ uint32_t mystwarr_state::screen_update_mystwarr(screen_device &screen, bitmap_rg
 
 	m_sprite_colorbase = m_k055555->K055555_get_palette_index(4) << 5;
 
-	konamigx_mixer(screen, bitmap, cliprect, nullptr, 0, nullptr, 0, blendmode, nullptr, 0);
+	konamigx_mixer(screen, bitmap, cliprect, nullptr, 0, nullptr, 0, 0, nullptr, 0);
 	return 0;
 }
 

--- a/src/mame/konami/xexex.cpp
+++ b/src/mame/konami/xexex.cpp
@@ -364,7 +364,7 @@ uint32_t xexex_state::screen_update_xexex(screen_device &screen, bitmap_rgb32 &b
 
 	if (m_cur_alpha)
 	{
-		alpha = m_k054338->set_alpha_level(1);
+		alpha = m_k054338->set_alpha_level(1) & 0xFF;
 
 		if (alpha > 0)
 		{

--- a/src/mame/konami/xexex.cpp
+++ b/src/mame/konami/xexex.cpp
@@ -364,7 +364,7 @@ uint32_t xexex_state::screen_update_xexex(screen_device &screen, bitmap_rgb32 &b
 
 	if (m_cur_alpha)
 	{
-		alpha = m_k054338->set_alpha_level(1) & 0xFF;
+		alpha = m_k054338->set_alpha_level(1) & 0xff;
 
 		if (alpha > 0)
 		{


### PR DESCRIPTION
I feel like I'm starting to amass a lot of changes so I'm opening a PR now. That, and the current changes are starting to reach a stable state! ...I hope!

The TL;DR version, games I know to be affected in parentheses:
**Additive sprite blending** (mmaulers)
**Improved tile blending** (mystwarr, viostorm, metamrph, sexyparo)

---

10 months ago, master Galibert sent down His [holy](https://github.com/orgs/mamedev/discussions/109#discussioncomment-9355919) [scriptures](https://github.com/orgs/mamedev/discussions/109#discussioncomment-9429978) to a certain inquisitive peasant. Since then I've spent some time on and off trying to interpret His writings, and well, I can confidently say that *some* of it has definitely sunk in!

---

File by file commentary:

**k053246_k053247_k055673.cpp, k053246_k053247_k055673.h:**
I went back to update zdrawgfxzoom32GP(), now down to a third of its original size before I started changing it. As a thinly veiled excuse for reworking the whole function, I went ahead and added additive sprite blending (to the now singular alpha call site).

Remarks: the mix priority setting is not yet handled. It seems simple enough (flip dst and src), but I would like to find an example of this before I implement it.

**k054156_k054157_k056832.cpp:**
The `attr` variable holds what appear to be the elusive tile (external) mix codes. Attach it to the `flags` variable so these bits can be accessed in the tile callback functions. Tiles with mix codes gets their own tilemap category.

Remarks: ~~this is kind of a hacky way to get `attr` into the callbacks. This should at minimum be documented, or be changed.~~ I've now changed the callback to include an attr param.

**k054338.cpp:**
Update set_alpha_level. This function now returns a level, an additive blend bool and a mixpri bool. Minor style changes to the overall file.

Remarks: set_alpha_level doesn't actually *set* anything. Maybe rename to get_alpha_level?

**moo.cpp, xexex.cpp:**
Mask out the new additive & mixpri bits from set_alpha_level calls for now, until it's known if / how they should be used over there.

**mystwarr_v.cpp, mystwarr.h:**
Remove mystwarr water hack.
Update mystwarr_tile_callback (and add viostorm_tile_callback) to read tile mix codes, store last read mix code in a new m_last_alpha_tile_mix_code variable.
Attach m_last_alpha_tile_mix_code to `mixerflags`, which happens to have two unused bits.

Remarks: ~~I should document that the two last bits of `mixerflags` is carrying a tile mix code now.~~ I updated the mixerflags documentation to mention the usage of the last two bits.

**konamigx_v.cpp, konamigx.cpp, konamigx.h:**
Shrink GX_MAX_SPRITES, which to the best of my ability seems to be oversized. There does seem to be several oversized arrays / defs in these files, so I think this is one of them.
The usual *FredYeye* updates to konamigx_mixer - move declarations closer to use, more suited types, rename `temp` vars, etc.
Change objpool to a vector, simplifying usage (push_back, size).
Replace sorting loop with reverse + stable_sort.
Improve gx_draw_basic_tilemaps - read internal / external alpha mix codes based on vinmix_on. Tiles with mixcodes get drawn in a separate pass for per-tile blending.
Update alpha_tile_callback and add salmndr2_tile_callback, same as the mystwarr_v callbacks.

Remarks: ~~There are still some things that should be done here - alpha_tile_callback needs to be cleaned up, for example.~~ Mostly done here now.

---

What started out as trying to sort out konamigx_mixer() to look at shadow/priority issues instead ended up with me finally getting a foot into the figurative tile blending door. The mystwarr water hack is gone, and sexyparo gets transparent windows. This might affect many GX and related games. Alpha blending might be broken in some games now, and needs to get their mix codes attached in their respective callbacks. salmndr2 got tagged in my automatic video comparison for differing from earlier versions, that's why I managed to fix it already.

Known problems:
metamrph: stained glass windows are near-transparent at the moment. I think additive tile blending will fix it...
viostorm: character names fade in in reverse. This also uses additive blending, so this might also get fixed once that's in.
fantjour: the top & bottom flames at the captain kebab ship go missing. Uses additive blending.

---

I'll mark this as a draft and go ahead and try to improve on some of the current things that are left. Thanks for coming to my ted talk.