### PR TITLE
cpu/drcbearm64.cpp: Optimised conditional operations using carry flag

### DIFF
--- a/src/devices/cpu/drcbearm64.cpp
+++ b/src/devices/cpu/drcbearm64.cpp
@@ -379,16 +379,6 @@ inline void get_unordered(a64::Assembler &a, const a64::Gp &reg)
 	a.ubfx(reg.x(), FLAGS_REG, FLAG_BIT_U, 1);
 }
 
-inline void check_unordered_condition(a64::Assembler &a, uml::condition_t cond, const Label &condition_met, bool not_equal)
-{
-	assert((cond == uml::COND_U) || (cond == uml::COND_NU));
-
-	const a64::Inst::Id opcode = ((uml::COND_U == cond) == not_equal) ? a64::Inst::kIdCbz : a64::Inst::kIdCbnz;
-
-	get_unordered(a, SCRATCH_REG1);
-	a.emit(opcode, SCRATCH_REG1, condition_met);
-}
-
 inline void store_carry_reg(a64::Assembler &a, const a64::Gp &reg)
 {
 	a.bfi(FLAGS_REG, reg.x(), FLAG_BIT_C, 1);
@@ -417,6 +407,13 @@ public:
 	virtual bool logging() const noexcept override { return false; }
 
 private:
+	enum class carry_state
+	{
+		POISON,     // does not correspond to UML carry flag
+		CANONICAL,  // corresponds directly to UML carry flag
+		LOGICAL     // logical borrow state
+	};
+
 	class be_parameter
 	{
 		static inline constexpr int REG_MAX = 30;
@@ -593,18 +590,20 @@ private:
 	void emit_float_ldr_mem(asmjit::a64::Assembler &a, const asmjit::a64::Vec &reg, const void *ptr) const;
 	void emit_float_str_mem(asmjit::a64::Assembler &a, const asmjit::a64::Vec &reg, const void *ptr) const;
 
+	void emit_skip(a64::Assembler &a, uml::condition_t cond, Label &skip);
+
 	void emit_memaccess_setup(asmjit::a64::Assembler &a, const be_parameter &addrp, const memory_accessors &accessors, const address_space::specific_access_info::side &side) const;
 	void emit_narrow_memwrite(asmjit::a64::Assembler &a, const be_parameter &addrp, const parameter &spacesizep, const memory_accessors &accessors) const;
 
-	void store_carry(asmjit::a64::Assembler &a, bool inverted = false) const;
-	void load_carry(asmjit::a64::Assembler &a, bool inverted = false) const;
-	void set_flags(asmjit::a64::Assembler &a) const;
+	void store_carry(asmjit::a64::Assembler &a, bool inverted = false);
+	void load_carry(asmjit::a64::Assembler &a, bool inverted = false);
+	void set_flags(asmjit::a64::Assembler &a);
 
-	void calculate_carry_shift_left(asmjit::a64::Assembler &a, const asmjit::a64::Gp &reg, const asmjit::a64::Gp &shift, int maxBits) const;
-	void calculate_carry_shift_left_imm(asmjit::a64::Assembler &a, const asmjit::a64::Gp &reg, const int shift, int maxBits) const;
+	void calculate_carry_shift_left(asmjit::a64::Assembler &a, const asmjit::a64::Gp &reg, const asmjit::a64::Gp &shift, int maxBits);
+	void calculate_carry_shift_left_imm(asmjit::a64::Assembler &a, const asmjit::a64::Gp &reg, const int shift, int maxBits);
 
-	void calculate_carry_shift_right(asmjit::a64::Assembler &a, const asmjit::a64::Gp &reg, const asmjit::a64::Gp &shift) const;
-	void calculate_carry_shift_right_imm(asmjit::a64::Assembler &a, const asmjit::a64::Gp &reg, const int shift) const;
+	void calculate_carry_shift_right(asmjit::a64::Assembler &a, const asmjit::a64::Gp &reg, const asmjit::a64::Gp &shift);
+	void calculate_carry_shift_right_imm(asmjit::a64::Assembler &a, const asmjit::a64::Gp &reg, const int shift);
 
 	void mov_float_reg_param(asmjit::a64::Assembler &a, uint32_t regsize, asmjit::a64::Vec const &dst, const be_parameter &src) const;
 	void mov_float_param_param(asmjit::a64::Assembler &a, uint32_t regsize, const be_parameter &dst, const be_parameter &src) const;
@@ -623,6 +622,7 @@ private:
 	drc_hash_table m_hash;
 	drc_map_variables m_map;
 	FILE *m_log_asmjit;
+	carry_state m_carry_state;
 
 	arm64_entry_point_func m_entry;
 	drccodeptr m_exit;
@@ -955,6 +955,45 @@ void drcbe_arm64::emit_strh_mem(a64::Assembler &a, const a64::Gp &reg, const voi
 void drcbe_arm64::emit_float_ldr_mem(a64::Assembler &a, const a64::Vec &reg, const void *ptr) const { emit_ldr_str_base_mem(a, a64::Inst::kIdLdr_v, reg, reg.isVecS() ? 2 : 3, ptr); }
 void drcbe_arm64::emit_float_str_mem(a64::Assembler &a, const a64::Vec &reg, const void *ptr) const { emit_ldr_str_base_mem(a, a64::Inst::kIdStr_v, reg, reg.isVecS() ? 2 : 3, ptr); }
 
+void drcbe_arm64::emit_skip(a64::Assembler &a, uml::condition_t cond, Label &skip)
+{
+	// Nothing to do if the instruction is unconditional
+	if (cond == uml::COND_ALWAYS)
+		return;
+
+	// Branch to the skip point if the condition is not met
+	skip = a.newLabel();
+	switch (cond)
+	{
+		case uml::COND_U:
+			a.tbz(FLAGS_REG, FLAG_BIT_U, skip);
+			break;
+		case uml::COND_NU:
+			a.tbnz(FLAGS_REG, FLAG_BIT_U, skip);
+			break;
+		case uml::COND_C:
+		case uml::COND_NC:
+			switch (m_carry_state)
+			{
+				case carry_state::CANONICAL:
+					a.b(ARM_CONDITION(cond), skip);
+					break;
+				case carry_state::LOGICAL:
+					a.b(ARM_NOT_CONDITION(cond), skip);
+					break;
+				default:
+					a.emit((cond == uml::COND_C) ? a64::Inst::kIdTbz : a64::Inst::kIdTbnz, FLAGS_REG, FLAG_BIT_C, skip);
+			}
+			break;
+		case uml::COND_A:
+		case uml::COND_BE:
+			load_carry(a, true);
+			[[fallthrough]];
+		default:
+			a.b(ARM_NOT_CONDITION(cond), skip);
+	}
+}
+
 void drcbe_arm64::emit_memaccess_setup(asmjit::a64::Assembler &a, const be_parameter &addrp, const memory_accessors &accessors, const address_space::specific_access_info::side &side) const
 {
 	auto const addrreg = (accessors.no_mask || accessors.mask_simple) ? REG_PARAM2 : a64::x6;
@@ -1255,8 +1294,10 @@ void drcbe_arm64::call_arm_addr(a64::Assembler &a, const void *offs) const
 	}
 }
 
-void drcbe_arm64::store_carry(a64::Assembler &a, bool inverted) const
+void drcbe_arm64::store_carry(a64::Assembler &a, bool inverted)
 {
+	m_carry_state = inverted ? carry_state::LOGICAL : carry_state::CANONICAL;
+
 	if (inverted)
 		a.cset(SCRATCH_REG1, a64::CondCode::kCC);
 	else
@@ -1265,20 +1306,28 @@ void drcbe_arm64::store_carry(a64::Assembler &a, bool inverted) const
 	store_carry_reg(a, SCRATCH_REG1);
 }
 
-void drcbe_arm64::load_carry(a64::Assembler &a, bool inverted) const
+void drcbe_arm64::load_carry(a64::Assembler &a, bool inverted)
 {
-	a.mrs(SCRATCH_REG1, a64::Predicate::SysReg::kNZCV);
-	a.bfi(SCRATCH_REG1, FLAGS_REG, 29, 1);
+	const carry_state desired = inverted ? carry_state::LOGICAL : carry_state::CANONICAL;
+	if (desired != m_carry_state)
+	{
+		m_carry_state = desired;
 
-	if (inverted)
-		a.eor(SCRATCH_REG1, SCRATCH_REG1, 1 << 29);
+		a.mrs(SCRATCH_REG1, a64::Predicate::SysReg::kNZCV);
+		a.bfi(SCRATCH_REG1, FLAGS_REG, 29, 1);
 
-	a.msr(a64::Predicate::SysReg::kNZCV, SCRATCH_REG1);
+		if (inverted)
+			a.eor(SCRATCH_REG1, SCRATCH_REG1, 1 << 29);
+
+		a.msr(a64::Predicate::SysReg::kNZCV, SCRATCH_REG1);
+	}
 }
 
-void drcbe_arm64::set_flags(asmjit::a64::Assembler &a) const
+void drcbe_arm64::set_flags(asmjit::a64::Assembler &a)
 {
 	// Set native condition codes after loading flags register
+	m_carry_state = carry_state::POISON; // TODO: take a bet they'll try a conditional branch and set the C flag?
+
 	a.mrs(TEMP_REG1, a64::Predicate::SysReg::kNZCV);
 
 	a.and_(TEMP_REG2, FLAGS_REG, 0b1100); // zero + sign
@@ -1292,8 +1341,10 @@ void drcbe_arm64::set_flags(asmjit::a64::Assembler &a) const
 	a.and_(FLAGS_REG, FLAGS_REG, TEMP_REG2);
 }
 
-void drcbe_arm64::calculate_carry_shift_left(a64::Assembler &a, const a64::Gp &reg, const a64::Gp &shift, int maxBits) const
+void drcbe_arm64::calculate_carry_shift_left(a64::Assembler &a, const a64::Gp &reg, const a64::Gp &shift, int maxBits)
 {
+	m_carry_state = carry_state::POISON;
+
 	Label calc = a.newLabel();
 	Label end = a.newLabel();
 
@@ -1313,8 +1364,10 @@ void drcbe_arm64::calculate_carry_shift_left(a64::Assembler &a, const a64::Gp &r
 	a.bind(end);
 }
 
-void drcbe_arm64::calculate_carry_shift_left_imm(a64::Assembler &a, const a64::Gp &reg, const int shift, int maxBits) const
+void drcbe_arm64::calculate_carry_shift_left_imm(a64::Assembler &a, const a64::Gp &reg, const int shift, int maxBits)
 {
+	m_carry_state = carry_state::POISON;
+
 	if (shift == 0)
 	{
 		store_carry_reg(a, a64::xzr);
@@ -1328,8 +1381,10 @@ void drcbe_arm64::calculate_carry_shift_left_imm(a64::Assembler &a, const a64::G
 	store_carry_reg(a, scratch);
 }
 
-void drcbe_arm64::calculate_carry_shift_right(a64::Assembler &a, const a64::Gp &reg, const a64::Gp &shift) const
+void drcbe_arm64::calculate_carry_shift_right(a64::Assembler &a, const a64::Gp &reg, const a64::Gp &shift)
 {
+	m_carry_state = carry_state::POISON;
+
 	Label calc = a.newLabel();
 	Label end = a.newLabel();
 
@@ -1348,8 +1403,10 @@ void drcbe_arm64::calculate_carry_shift_right(a64::Assembler &a, const a64::Gp &
 	a.bind(end);
 }
 
-void drcbe_arm64::calculate_carry_shift_right_imm(a64::Assembler &a, const a64::Gp &reg, const int shift) const
+void drcbe_arm64::calculate_carry_shift_right_imm(a64::Assembler &a, const a64::Gp &reg, const int shift)
 {
+	m_carry_state = carry_state::POISON;
+
 	if (shift == 0)
 	{
 		store_carry_reg(a, a64::xzr);
@@ -1368,6 +1425,7 @@ drcbe_arm64::drcbe_arm64(drcuml_state &drcuml, device_t &device, drc_cache &cach
 	, m_hash(cache, modes, addrbits, ignorebits)
 	, m_map(cache, 0xaaaaaaaa5555)
 	, m_log_asmjit(nullptr)
+	, m_carry_state(carry_state::POISON)
 	, m_entry(nullptr)
 	, m_exit(nullptr)
 	, m_nocode(nullptr)
@@ -1503,8 +1561,9 @@ void drcbe_arm64::reset()
 
 	// reset our hash tables
 	m_hash.reset();
-
 	m_hash.set_default_codeptr(m_nocode);
+
+	m_carry_state = carry_state::POISON;
 }
 
 int drcbe_arm64::execute(code_handle &entry)
@@ -1526,6 +1585,7 @@ void drcbe_arm64::generate(drcuml_block &block, const instruction *instlist, uin
 	// tell all of our utility objects that a block is beginning
 	m_hash.block_begin(block, instlist, numinst);
 	m_map.block_begin(block);
+	m_carry_state = carry_state::POISON;
 
 	// compute the base by aligning the cache top to a cache line
 	auto [err, linesize] = osd_get_cache_line_size();
@@ -1618,6 +1678,8 @@ void drcbe_arm64::op_handle(a64::Assembler &a, const uml::instruction &inst)
 	assert(inst.numparams() == 1);
 	assert(inst.param(0).is_code_handle());
 
+	m_carry_state = carry_state::POISON;
+
 	// make a label for documentation
 	Label handle = a.newNamedLabel(inst.param(0).handle().string());
 	a.bind(handle);
@@ -1642,6 +1704,8 @@ void drcbe_arm64::op_hash(a64::Assembler &a, const uml::instruction &inst)
 	assert(inst.param(0).is_immediate());
 	assert(inst.param(1).is_immediate());
 
+	m_carry_state = carry_state::POISON;
+
 	const uint64_t mode = inst.param(0).immediate();
 	const uint64_t pc = inst.param(1).immediate();
 
@@ -1654,6 +1718,8 @@ void drcbe_arm64::op_label(a64::Assembler &a, const uml::instruction &inst)
 	assert_no_flags(inst);
 	assert(inst.numparams() == 1);
 	assert(inst.param(0).is_code_label());
+
+	m_carry_state = carry_state::POISON;
 
 	std::string labelName = util::string_format("PC$%x", inst.param(0).label());
 	Label label = a.labelByName(labelName.c_str());
@@ -1696,6 +1762,8 @@ void drcbe_arm64::op_break(a64::Assembler &a, const uml::instruction &inst)
 	assert_no_condition(inst);
 	assert_no_flags(inst);
 
+	m_carry_state = carry_state::POISON;
+
 	static const char *const message = "break from drc";
 	get_imm_relative(a, REG_PARAM1, (uintptr_t)message);
 	call_arm_addr(a, (const void *)&osd_break_into_debugger);
@@ -1709,6 +1777,8 @@ void drcbe_arm64::op_debug(a64::Assembler &a, const uml::instruction &inst)
 
 	if (m_device.machine().debug_flags & DEBUG_FLAG_ENABLED)
 	{
+		m_carry_state = carry_state::POISON;
+
 		const a64::Gp temp = TEMP_REG1.w();
 
 		be_parameter pcp(*this, inst.param(0), PTYPE_MRI);
@@ -1735,23 +1805,14 @@ void drcbe_arm64::op_exit(a64::Assembler &a, const uml::instruction &inst)
 
 	be_parameter retp(*this, inst.param(0), PTYPE_MRI);
 
-	mov_reg_param(a, 4, REG_PARAM1, retp);
+	Label skip;
+	emit_skip(a, inst.condition(), skip);
 
-	if (inst.condition() == uml::COND_ALWAYS)
-	{
-		a.b(m_exit);
-	}
-	else if (inst.condition() == uml::COND_U || inst.condition() == uml::COND_NU)
-	{
-		Label skip = a.newLabel();
-		check_unordered_condition(a, inst.condition(), skip, false);
-		a.b(m_exit);
+	mov_reg_param(a, 4, REG_PARAM1, retp);
+	a.b(m_exit);
+
+	if (inst.condition() != uml::COND_ALWAYS)
 		a.bind(skip);
-	}
-	else
-	{
-		a.b(ARM_CONDITION(inst.condition()), m_exit);
-	}
 }
 
 void drcbe_arm64::op_hashjmp(a64::Assembler &a, const uml::instruction &inst)
@@ -1859,6 +1920,8 @@ void drcbe_arm64::op_hashjmp(a64::Assembler &a, const uml::instruction &inst)
 		emit_ldr_mem(a, SCRATCH_REG1, targetptr);
 		a.blr(SCRATCH_REG1);
 	}
+
+	m_carry_state = carry_state::POISON;
 }
 
 void drcbe_arm64::op_jmp(a64::Assembler &a, const uml::instruction &inst)
@@ -1878,17 +1941,60 @@ void drcbe_arm64::op_jmp(a64::Assembler &a, const uml::instruction &inst)
 	if (inst.condition() == uml::COND_ALWAYS)
 	{
 		a.b(jmptarget);
+		return;
 	}
-	else if (inst.condition() == uml::COND_U || inst.condition() == uml::COND_NU)
-	{
-		check_unordered_condition(a, inst.condition(), jmptarget, false);
-	}
-	else
-	{
-		if (inst.condition() == COND_C || inst.condition() == COND_NC || inst.condition() == COND_A || inst.condition() == COND_BE)
-			load_carry(a, true);
 
-		a.b(ARM_CONDITION(inst.condition()), jmptarget);
+	const bool bound = a.code()->isLabelBound(jmptarget);
+	const uint64_t targetoffs = a.code()->baseAddress() + a.code()->labelOffset(jmptarget);
+	const uint64_t codeoffs = a.code()->baseAddress() + a.offset();
+	const bool tbnzrange = bound && is_valid_immediate_signed(int64_t(targetoffs) - codeoffs, 14 + 2);
+
+	switch (inst.condition())
+	{
+		case uml::COND_U:
+		case uml::COND_NU:
+			if (tbnzrange)
+			{
+				const a64::Inst::Id opcode = (inst.condition() == uml::COND_U) ? a64::Inst::kIdTbnz : a64::Inst::kIdTbz;
+				a.emit(opcode, FLAGS_REG, FLAG_BIT_U, jmptarget);
+			}
+			else
+			{
+				const a64::Inst::Id opcode = (inst.condition() == uml::COND_U) ? a64::Inst::kIdCbnz : a64::Inst::kIdCbz;
+				get_unordered(a, SCRATCH_REG1);
+				a.emit(opcode, SCRATCH_REG1, jmptarget);
+			}
+			break;
+		case uml::COND_C:
+		case uml::COND_NC:
+			switch (m_carry_state)
+			{
+				case carry_state::CANONICAL:
+					a.b(ARM_NOT_CONDITION(inst.condition()), jmptarget);
+					break;
+				case carry_state::LOGICAL:
+					a.b(ARM_CONDITION(inst.condition()), jmptarget);
+					break;
+				default:
+					if (tbnzrange)
+					{
+						const a64::Inst::Id opcode = (inst.condition() == uml::COND_C) ? a64::Inst::kIdTbnz : a64::Inst::kIdTbz;
+						a.emit(opcode, FLAGS_REG, FLAG_BIT_C, jmptarget);
+					}
+					else
+					{
+						const a64::Inst::Id opcode = (inst.condition() == uml::COND_C) ? a64::Inst::kIdCbnz : a64::Inst::kIdCbz;
+						get_carry(a, SCRATCH_REG1);
+						a.emit(opcode, SCRATCH_REG1, jmptarget);
+					}
+			}
+			break;
+		case uml::COND_A:
+		case uml::COND_BE:
+			load_carry(a, true);
+			[[fallthrough]];
+		default:
+			a.b(ARM_CONDITION(inst.condition()), jmptarget);
 	}
 }
 
@@ -1903,22 +2009,7 @@ void drcbe_arm64::op_exh(a64::Assembler &a, const uml::instruction &inst)
 
 	// perform the exception processing
 	Label no_exception;
-	if (inst.condition() != uml::COND_ALWAYS)
-	{
-		no_exception = a.newLabel();
-
-		if (inst.condition() == uml::COND_U || inst.condition() == uml::COND_NU)
-		{
-			check_unordered_condition(a, inst.condition(), no_exception, true);
-		}
-		else
-		{
-			if (inst.condition() == COND_C || inst.condition() == COND_NC || inst.condition() == COND_A || inst.condition() == COND_BE)
-				load_carry(a, true);
-
-			a.b(ARM_NOT_CONDITION(inst.condition()), no_exception);
-		}
-	}
+	emit_skip(a, inst.condition(), no_exception);
 
 	mov_mem_param(a, 4, &m_state.exp, exp);
 
@@ -1935,6 +2026,8 @@ void drcbe_arm64::op_exh(a64::Assembler &a, const uml::instruction &inst)
 
 	if (inst.condition() != uml::COND_ALWAYS)
 		a.bind(no_exception);
+
+	m_carry_state = carry_state::POISON;
 }
 
 void drcbe_arm64::op_callh(a64::Assembler &a, const uml::instruction &inst)
@@ -1947,22 +2040,7 @@ void drcbe_arm64::op_callh(a64::Assembler &a, const uml::instruction &inst)
 	assert(handp.is_code_handle());
 
 	Label skip;
-	if (inst.condition() != uml::COND_ALWAYS)
-	{
-		skip = a.newLabel();
-
-		if (inst.condition() == uml::COND_U || inst.condition() == uml::COND_NU)
-		{
-			check_unordered_condition(a, inst.condition(), skip, true);
-		}
-		else
-		{
-			if (inst.condition() == COND_C || inst.condition() == COND_NC || inst.condition() == COND_A || inst.condition() == COND_BE)
-				load_carry(a, true);
-
-			a.b(ARM_NOT_CONDITION(inst.condition()), skip);
-		}
-	}
+	emit_skip(a, inst.condition(), skip);
 
 	drccodeptr *const targetptr = handp.handle().codeptr_addr();
 	if (*targetptr != nullptr)
@@ -1977,6 +2055,8 @@ void drcbe_arm64::op_callh(a64::Assembler &a, const uml::instruction &inst)
 
 	if (inst.condition() != uml::COND_ALWAYS)
 		a.bind(skip);
+
+	m_carry_state = carry_state::POISON;
 }
 
 void drcbe_arm64::op_ret(a64::Assembler &a, const uml::instruction &inst)
@@ -1987,22 +2067,7 @@ void drcbe_arm64::op_ret(a64::Assembler &a, const uml::instruction &inst)
 	assert(inst.numparams() == 0);
 
 	Label skip;
-	if (inst.condition() != uml::COND_ALWAYS)
-	{
-		skip = a.newLabel();
-
-		if (inst.condition() == uml::COND_U || inst.condition() == uml::COND_NU)
-		{
-			check_unordered_condition(a, inst.condition(), skip, true);
-		}
-		else
-		{
-			if (inst.condition() == COND_C || inst.condition() == COND_NC || inst.condition() == COND_A || inst.condition() == COND_BE)
-				load_carry(a, true);
-
-			a.b(ARM_NOT_CONDITION(inst.condition()), skip);
-		}
-	}
+	emit_skip(a, inst.condition(), skip);
 
 	a.ldp(a64::x29, a64::x30, arm::Mem(a64::sp).post(16));
 	a.ret(a64::x30);
@@ -2022,22 +2087,7 @@ void drcbe_arm64::op_callc(a64::Assembler &a, const uml::instruction &inst)
 	be_parameter paramp(*this, inst.param(1), PTYPE_M);
 
 	Label skip;
-	if (inst.condition() != uml::COND_ALWAYS)
-	{
-		skip = a.newLabel();
-
-		if (inst.condition() == uml::COND_U || inst.condition() == uml::COND_NU)
-		{
-			check_unordered_condition(a, inst.condition(), skip, true);
-		}
-		else
-		{
-			if (inst.condition() == COND_C || inst.condition() == COND_NC || inst.condition() == COND_A || inst.condition() == COND_BE)
-				load_carry(a, true);
-
-			a.b(ARM_NOT_CONDITION(inst.condition()), skip);
-		}
-	}
+	emit_skip(a, inst.condition(), skip);
 
 	emit_str_mem(a, FLAGS_REG.w(), &m_near.emulated_flags);
 
@@ -2049,6 +2099,8 @@ void drcbe_arm64::op_callc(a64::Assembler &a, const uml::instruction &inst)
 
 	if (inst.condition() != uml::COND_ALWAYS)
 		a.bind(skip);
+
+	m_carry_state = carry_state::POISON;
 }
 
 void drcbe_arm64::op_recover(a64::Assembler &a, const uml::instruction &inst)
@@ -2056,6 +2108,8 @@ void drcbe_arm64::op_recover(a64::Assembler &a, const uml::instruction &inst)
 	assert(inst.size() == 4);
 	assert_no_condition(inst);
 	assert_no_flags(inst);
+
+	m_carry_state = carry_state::POISON;
 
 	be_parameter dstp(*this, inst.param(0), PTYPE_MR);
 
@@ -2523,6 +2577,8 @@ void drcbe_arm64::op_read(a64::Assembler &a, const uml::instruction &inst)
 	assert_no_condition(inst);
 	assert_no_flags(inst);
 
+	m_carry_state = carry_state::POISON;
+
 	be_parameter dstp(*this, inst.param(0), PTYPE_MR);
 	be_parameter addrp(*this, inst.param(1), PTYPE_MRI);
 	const parameter &spacesizep = inst.param(2);
@@ -2579,6 +2635,8 @@ void drcbe_arm64::op_readm(a64::Assembler &a, const uml::instruction &inst)
 	assert(inst.size() == 4 || inst.size() == 8);
 	assert_no_condition(inst);
 	assert_no_flags(inst);
+
+	m_carry_state = carry_state::POISON;
 
 	be_parameter dstp(*this, inst.param(0), PTYPE_MR);
 	be_parameter addrp(*this, inst.param(1), PTYPE_MRI);
@@ -2639,6 +2697,8 @@ void drcbe_arm64::op_write(a64::Assembler &a, const uml::instruction &inst)
 	assert(inst.size() == 4 || inst.size() == 8);
 	assert_no_condition(inst);
 	assert_no_flags(inst);
+
+	m_carry_state = carry_state::POISON;
 
 	be_parameter addrp(*this, inst.param(0), PTYPE_MRI);
 	be_parameter srcp(*this, inst.param(1), PTYPE_MRI);
@@ -2702,6 +2762,8 @@ void drcbe_arm64::op_writem(a64::Assembler &a, const uml::instruction &inst)
 	assert(inst.size() == 4 || inst.size() == 8);
 	assert_no_condition(inst);
 	assert_no_flags(inst);
+
+	m_carry_state = carry_state::POISON;
 
 	be_parameter addrp(*this, inst.param(0), PTYPE_MRI);
 	be_parameter srcp(*this, inst.param(1), PTYPE_MRI);
@@ -2769,6 +2831,8 @@ void drcbe_arm64::op_carry(a64::Assembler &a, const uml::instruction &inst)
 	assert_no_condition(inst);
 	assert_flags(inst, FLAG_C);
 
+	m_carry_state = carry_state::POISON;
+
 	be_parameter srcp(*this, inst.param(0), PTYPE_MRI);
 	be_parameter bitp(*this, inst.param(1), PTYPE_MRI);
 
@@ -2831,18 +2895,37 @@ void drcbe_arm64::op_set(a64::Assembler &a, const uml::instruction &inst)
 
 	const a64::Gp dst = dstp.select_register(TEMP_REG1, inst.size());
 
-	if (inst.condition() == COND_C || inst.condition() == COND_NC || inst.condition() == COND_A || inst.condition() == COND_BE)
-		load_carry(a, true);
-
-	if (inst.condition() == uml::COND_U || inst.condition() == uml::COND_NU)
+	switch (inst.condition())
 	{
-		get_unordered(a, dst);
-
-		if (inst.condition() == uml::COND_NU)
-			a.eor(dst, dst, 1);
+		case uml::COND_U:
+		case uml::COND_NU:
+			get_unordered(a, dst);
+			if (inst.condition() == uml::COND_NU)
+				a.eor(dst, dst, 1);
+			break;
+		case uml::COND_C:
+		case uml::COND_NC:
+			switch (m_carry_state)
+			{
+				case carry_state::CANONICAL:
+					a.cset(dst, ARM_NOT_CONDITION(inst.condition()));
+					break;
+				case carry_state::LOGICAL:
+					a.cset(dst, ARM_CONDITION(inst.condition()));
+					break;
+				default:
+					get_carry(a, dst);
+					if (inst.condition() == uml::COND_NC)
+						a.eor(dst, dst, 1);
+			}
+			break;
+		case uml::COND_A:
+		case uml::COND_BE:
+			load_carry(a, true);
+			[[fallthrough]];
+		default:
+			a.cset(dst, ARM_CONDITION(inst.condition()));
 	}
-	else
-		a.cset(dst, ARM_CONDITION(inst.condition()));
 
 	mov_param_reg(a, inst.size(), dstp, dst);
 }
@@ -2859,19 +2942,7 @@ void drcbe_arm64::op_mov(a64::Assembler &a, const uml::instruction &inst)
 	// add a conditional branch unless a conditional move is possible
 	// TODO: optimise to use csel if the source and destination are both kept in host registers
 	Label skip;
-
-	if (inst.condition() != uml::COND_ALWAYS)
-	{
-		skip = a.newLabel();
-
-		if (inst.condition() == COND_C || inst.condition() == COND_NC || inst.condition() == COND_A || inst.condition() == COND_BE)
-			load_carry(a, true);
-
-		if (inst.condition() == uml::COND_U || inst.condition() == uml::COND_NU)
-			check_unordered_condition(a, inst.condition(), skip, true);
-		else
-			a.b(ARM_NOT_CONDITION(inst.condition()), skip);
-	}
+	emit_skip(a, inst.condition(), skip);
 
 	mov_param_param(a, inst.size(), dstp, srcp);
 
@@ -2927,7 +2998,10 @@ void drcbe_arm64::op_sext(a64::Assembler &a, const uml::instruction &inst)
 	}
 
 	if (inst.flags())
+	{
 		a.tst(dstreg, dstreg);
+		m_carry_state = carry_state::POISON;
+	}
 }
 
 void drcbe_arm64::op_roland(a64::Assembler &a, const uml::instruction &inst)
@@ -2954,7 +3028,10 @@ void drcbe_arm64::op_roland(a64::Assembler &a, const uml::instruction &inst)
 		mov_param_reg(a, inst.size(), dstp, zero);
 
 		if (inst.flags())
+		{
 			a.tst(zero, zero);
+			m_carry_state = carry_state::POISON;
+		}
 
 		return;
 	}
@@ -3070,6 +3147,8 @@ void drcbe_arm64::op_roland(a64::Assembler &a, const uml::instruction &inst)
 	{
 		if (optimized)
 			a.tst(output, output);
+
+		m_carry_state = carry_state::POISON;
 	}
 }
 
@@ -3095,6 +3174,7 @@ void drcbe_arm64::op_rolins(a64::Assembler &a, const uml::instruction &inst)
 			dst = dstp.select_register(TEMP_REG2, inst.size());
 			mov_reg_param(a, inst.size(), dst, dstp);
 			a.tst(dst, dst);
+			m_carry_state = carry_state::POISON;
 		}
 
 		return;
@@ -3274,7 +3354,10 @@ void drcbe_arm64::op_rolins(a64::Assembler &a, const uml::instruction &inst)
 	mov_param_reg(a, inst.size(), dstp, dst);
 
 	if (inst.flags())
+	{
 		a.tst(dst, dst);
+		m_carry_state = carry_state::POISON;
+	}
 }
 
 template <bool CarryIn> void drcbe_arm64::op_add(a64::Assembler &a, const uml::instruction &inst)
@@ -3578,6 +3661,8 @@ void drcbe_arm64::op_mulu(a64::Assembler &a, const uml::instruction &inst)
 		a.bfi(SCRATCH_REG1, TEMP_REG3, 31, 1); // sign flag
 
 		a.msr(a64::Predicate::SysReg::kNZCV, SCRATCH_REG1);
+
+		m_carry_state = carry_state::POISON;
 	}
 }
 
@@ -3636,6 +3721,8 @@ void drcbe_arm64::op_mululw(a64::Assembler &a, const uml::instruction &inst)
 		a.bfi(TEMP_REG1, SCRATCH_REG1, 31, 1); // sign flag
 
 		a.msr(a64::Predicate::SysReg::kNZCV, TEMP_REG1);
+
+		m_carry_state = carry_state::POISON;
 	}
 }
 
@@ -3711,6 +3798,8 @@ void drcbe_arm64::op_muls(a64::Assembler &a, const uml::instruction &inst)
 		a.bfi(SCRATCH_REG1, TEMP_REG1, 31, 1); // sign flag
 
 		a.msr(a64::Predicate::SysReg::kNZCV, SCRATCH_REG1);
+
+		m_carry_state = carry_state::POISON;
 	}
 }
 
@@ -3782,6 +3871,8 @@ void drcbe_arm64::op_mulslw(a64::Assembler &a, const uml::instruction &inst)
 		a.bfi(SCRATCH_REG1, TEMP_REG1, 31, 1); // sign flag
 
 		a.msr(a64::Predicate::SysReg::kNZCV, SCRATCH_REG1);
+
+		m_carry_state = carry_state::POISON;
 	}
 }
 
@@ -3837,6 +3928,7 @@ template <a64::Inst::Id Opcode> void drcbe_arm64::op_div(a64::Assembler &a, cons
 		a.mov(SCRATCH_REG1, 1 << 28); // set overflow flag
 		a.msr(a64::Predicate::SysReg::kNZCV, SCRATCH_REG1);
 	}
+	m_carry_state = carry_state::POISON;
 }
 
 void drcbe_arm64::op_and(a64::Assembler &a, const uml::instruction &inst)
@@ -3892,6 +3984,9 @@ void drcbe_arm64::op_and(a64::Assembler &a, const uml::instruction &inst)
 	}
 
 	mov_param_reg(a, inst.size(), dstp, dst);
+
+	if (inst.flags())
+		m_carry_state = carry_state::POISON;
 }
 
 void drcbe_arm64::op_test(a64::Assembler &a, const uml::instruction &inst)
@@ -3938,6 +4033,8 @@ void drcbe_arm64::op_test(a64::Assembler &a, const uml::instruction &inst)
 		mov_reg_param(a, inst.size(), src2, src2p);
 		a.tst(src1, src2);
 	}
+
+	m_carry_state = carry_state::POISON;
 }
 
 void drcbe_arm64::op_or(a64::Assembler &a, const uml::instruction &inst)
@@ -3988,7 +4085,10 @@ void drcbe_arm64::op_or(a64::Assembler &a, const uml::instruction &inst)
 	mov_param_reg(a, inst.size(), dstp, dst);
 
 	if (inst.flags())
+	{
 		a.tst(dst, dst);
+		m_carry_state = carry_state::POISON;
+	}
 }
 
 void drcbe_arm64::op_xor(a64::Assembler &a, const uml::instruction &inst)
@@ -4034,7 +4134,10 @@ void drcbe_arm64::op_xor(a64::Assembler &a, const uml::instruction &inst)
 	mov_param_reg(a, inst.size(), dstp, dst);
 
 	if (inst.flags())
+	{
 		a.tst(dst, dst);
+		m_carry_state = carry_state::POISON;
+	}
 }
 
 void drcbe_arm64::op_lzcnt(a64::Assembler &a, const uml::instruction &inst)
@@ -4056,7 +4159,10 @@ void drcbe_arm64::op_lzcnt(a64::Assembler &a, const uml::instruction &inst)
 	mov_param_reg(a, inst.size(), dstp, dst);
 
 	if (inst.flags())
+	{
 		a.tst(dst, dst);
+		m_carry_state = carry_state::POISON;
+	}
 }
 
 void drcbe_arm64::op_tzcnt(a64::Assembler &a, const uml::instruction &inst)
@@ -4083,6 +4189,7 @@ void drcbe_arm64::op_tzcnt(a64::Assembler &a, const uml::instruction &inst)
 	{
 		a.eor(temp, dst, inst.size() * 8);
 		a.tst(temp, temp);
+		m_carry_state = carry_state::POISON;
 	}
 }
 
@@ -4108,7 +4215,10 @@ void drcbe_arm64::op_bswap(a64::Assembler &a, const uml::instruction &inst)
 	mov_param_reg(a, inst.size(), dstp, dst);
 
 	if (inst.flags())
+	{
 		a.tst(dst, dst);
+		m_carry_state = carry_state::POISON;
+	}
 }
 
 
@@ -4165,7 +4275,10 @@ template <a64::Inst::Id Opcode> void drcbe_arm64::op_shift(a64::Assembler &a, co
 	}
 
 	if (inst.flags())
+	{
 		a.tst(dst, dst);
+		m_carry_state = carry_state::POISON;
+	}
 
 	// save dst after using inputs for calculations so the registers have no chance of being overwritten
 	mov_param_reg(a, inst.size(), dstp, dst);
@@ -4227,7 +4340,10 @@ void drcbe_arm64::op_rol(a64::Assembler &a, const uml::instruction &inst)
 	}
 
 	if (inst.flags())
+	{
 		a.tst(output, output);
+		m_carry_state = carry_state::POISON;
+	}
 
 	mov_param_reg(a, inst.size(), dstp, output);
 }
@@ -4321,6 +4437,8 @@ void drcbe_arm64::op_rolc(a64::Assembler &a, const uml::instruction &inst)
 		a.tst(output, output);
 
 	mov_param_reg(a, inst.size(), dstp, output);
+
+	m_carry_state = carry_state::POISON;
 }
 
 void drcbe_arm64::op_rorc(a64::Assembler &a, const uml::instruction &inst)
@@ -4415,6 +4533,8 @@ void drcbe_arm64::op_rorc(a64::Assembler &a, const uml::instruction &inst)
 		a.tst(output, output);
 
 	mov_param_reg(a, inst.size(), dstp, output);
+
+	m_carry_state = carry_state::POISON;
 }
 
 void drcbe_arm64::op_fload(a64::Assembler &a, const uml::instruction &inst)
@@ -4485,6 +4605,8 @@ void drcbe_arm64::op_fread(a64::Assembler &a, const uml::instruction &inst)
 	assert_no_condition(inst);
 	assert_no_flags(inst);
 
+	m_carry_state = carry_state::POISON;
+
 	be_parameter dstp(*this, inst.param(0), PTYPE_MR);
 	be_parameter addrp(*this, inst.param(1), PTYPE_MRI);
 	const parameter &spacesizep = inst.param(2);
@@ -4516,6 +4638,8 @@ void drcbe_arm64::op_fwrite(a64::Assembler &a, const uml::instruction &inst)
 	assert(inst.size() == 4 || inst.size() == 8);
 	assert_no_condition(inst);
 	assert_no_flags(inst);
+
+	m_carry_state = carry_state::POISON;
 
 	be_parameter addrp(*this, inst.param(0), PTYPE_MRI);
 	be_parameter srcp(*this, inst.param(1), PTYPE_MF);
@@ -4553,18 +4677,7 @@ void drcbe_arm64::op_fmov(a64::Assembler &a, const uml::instruction &inst)
 
 	// TODO: optimise to use fcsel if the source and destination are both kept in host registers
 	Label skip;
-	if (inst.condition() != uml::COND_ALWAYS)
-	{
-		skip = a.newLabel();
-
-		if (inst.condition() == COND_C || inst.condition() == COND_NC || inst.condition() == COND_A || inst.condition() == COND_BE)
-			load_carry(a, true);
-
-		if (inst.condition() == uml::COND_U || inst.condition() == uml::COND_NU)
-			check_unordered_condition(a, inst.condition(), skip, true);
-		else
-			a.b(ARM_NOT_CONDITION(inst.condition()), skip);
-	}
+	emit_skip(a, inst.condition(), skip);
 
 	mov_float_param_param(a, inst.size(), dstp, srcp);
 

--- a/src/devices/cpu/drcbearm64.h
+++ b/src/devices/cpu/drcbearm64.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:windyfairy
+// copyright-holders:windyfairy, Vas Crabb
 #ifndef MAME_CPU_DRCBEARM64_H
 #define MAME_CPU_DRCBEARM64_H
 


### PR DESCRIPTION
If you look at the current code generated by the AArch64 recompiler back-end, you see stuff like this (example is the “fastram” checks for a 32-bit read in `fiveside`):

```
    ands w19, w19, 0x7FFFFFFF               ; 737A0072
    nop                                     ; 1F2003D5
    mov w9, w19                             ; E903132A
    mov w10, 0xFF01FFFF                     ; CA1FA012
    cmp w9, w10                             ; 3F010A6B
    cset x12, 5                             ; EC279F9A
    bfi x28, x12, 0, 1                      ; 9C0140B3
    mrs x12, 0xDA10                         ; 0C423BD5
    bfi x12, x28, 0x1D, 1                   ; 8C0363B3
    eor x12, x12, 0x20000000                ; 8C0163D2
    msr 0xDA10, x12                         ; 0C421BD5
    b.hi PC$1                               ; 08000054
    mov w9, w19                             ; E903132A
    mov w10, 0xFF000000                     ; 0AE0BF52
    cmp w9, w10                             ; 3F010A6B
    cset x12, 5                             ; EC279F9A
    bfi x28, x12, 0, 1                      ; 9C0140B3
    mrs x12, 0xDA10                         ; 0C423BD5
    bfi x12, x28, 0x1D, 1                   ; 8C0363B3
    eor x12, x12, 0x20000000                ; 8C0163D2
    msr 0xDA10, x12                         ; 0C421BD5
    b.lo PC$1                               ; 03000054
    nop                                     ; 1F2003D5
    mov x9, 0x555515FA7750                  ; 09EA8ED249BFA2F2A9AACAF2
    ldr w19, [x9, w19]                      ; 336973B8
    ldp x29, x30, [sp], 0x10                ; FD7BC1A8
    ret x30                                 ; C0035FD6
PC$1:
```

Notice that it:
* Does a comparison
* Stashes the complement of the carry flag in x28 bit zero (it does this because it needs to emulate Intel/Motorola-style “arithmetic borrow” to satisfy UML)
* Loads the NZCV system register into a GPR
* Inserts the complement of the UML carry flag from x28 bit zero into it
* Stores the updated value (actually unchanged) into the NZCV system register
* Does a conditional branch
* Then does the same thing again

Now this is pretty bad for performance.  The `msr` is likely to cause a pipeline stall on the next conditional branch that depends on the condition codes (as opposed to conditional branches that depend on GPRs).  Even if it doesn’t cause a pipeline stall, the only thing between the `cset` and the `msr` can be reordered or parallelised is executing/retiring the `mrs` early.  That means the branch will be liable for a five-cycle penalty on misprediction.  This really takes the “fast” out of “fastram”.

You see similar patterns in other places, for example here’s code generated by the Hyperstone E1 CPU core for setting a global register where it’s checking whether it needs to deal with an extended register or the status register:

```
    cmp w9, 0x10                            ; 3F410071
    cset x12, 5                             ; EC279F9A
    bfi x28, x12, 0, 1                      ; 9C0140B3
    mrs x12, 0xDA10                         ; 0C423BD5
    bfi x12, x28, 0x1D, 1                   ; 8C0363B3
    eor x12, x12, 0x20000000                ; 8C0163D2
    msr 0xDA10, x12                         ; 0C421BD5
    b.hs PC$4                               ; 02000054
    mov w9, w23                             ; E903172A
    cmp w9, 1                               ; 3F050071
    cset x12, 5                             ; EC279F9A
    bfi x28, x12, 0, 1                      ; 9C0140B3
    mrs x12, 0xDA10                         ; 0C423BD5
    bfi x12, x28, 0x1D, 1                   ; 8C0363B3
    eor x12, x12, 0x20000000                ; 8C0163D2
    msr 0xDA10, x12                         ; 0C421BD5
    b.hi PC$5                               ; 08000054
    b.eq PC$6                               ; 00000054
    mov w10, 0xFFFFFFFFFFFFFFFE             ; 2A008012
    ands w11, w24, w10                      ; 0B030A6A
    stur w11, [x27, 0xFFFFFFFFFFFFFF00]     ; 6B0310B8
    b PC$7                                  ; 00000014
```

So this pattern is happening pretty frequently, and often multiple times in succession.

Now it should be possible to avoid this:
* Most of the time, conditional branches that depend on the carry flag immediately follow a `CMP`.  If they follow a `CMP` (or `SUB`/`SUBB`) with no intervening operations that affect flags or labels, the native carry flag will already be in the desired state, so there’s no need to mess with it.
* If a branch with the `C` or `NC` condition follows an `ADD`/`ADDC` with no intervening operations that affect flags or labels, it’s still possible to translate to a native conditional branch just by inverting the condition.
* Even if the state of the native carry flag doesn’t correspond to the UML `C` flag, you can implement the `C` and `NC` conditions in terms of the UML `C` flag stored in x28 and avoid the expensive system register modification.

This PR adds basic inter-instruction optimisation to deal with this.  The state of the native carry flag as it corresponds (or doesn’t correspond) to the UML `C` flag is tracked, and the strategy for conditional operations is chosen accordingly.

There are also some other fixes, optimisations an adjustments:
* Code for emitting conditional skip setup has been refactored into a single function to simplify maintenance.  The code generated for `U`/`NU` conditions has been slightly optimised.
* Using conditional select instructions (`csel`/`csinc`/`csinv`/`fcssel`) to implement conditional forms of `MOV` and `FMOV` when advantageous.
* Some situations where a conditional `EXIT` would misbehave have been fixed (we never hit these because no CPU front-end uses conditional `EXIT` anyway).
* Range for conditional `EXIT` has been extended to ±128 MiB (it was ±1 MiB for most conditions, which is a bit short).  It would be possible to make it a bit more efficient by checking the actual distance to the `EXIT` landing pad, that would mean it couldn’t use the common skip setup function, and I really doubt it would be worthwhile, even if front-ends actually did use conditional `EXIT`.
* Slight optimisation saving one instruction for some short backward conditional jumps.
* Some more simplification for the `ADD`/`ADDC`/`SUB`/`SUBB` code generation, avoiding an unnecessary move in some cases and reducing the number of temporary registers used in others.

It’s entirely possible I’ve missed something.

Can someone with some kind of ARM Cortex-A system set up for testing MAME (maybe @danmons or @grant2258 if you have some time) please check some things for me?

* Check that `fiveside` (PowerPC 403), `coolmini` (E1-16) and `soldivid` (SH-2) are still working.
* Get before/after scores for:
  * `-bench 90 fiveside`
  * `-bench 90 coolmini`
  * `-bench 90 soldivid`
* Get me a copy of the logged generated code for:
  * `-drc_log_native -bench 1 fiveside`
  * `-drc_log_native -bench 1 coolmini`
  * `-drc_log_native -bench 1 soldivid`

If stuff’s broken, I’ll do my best to work with people to get it sorted out.  I really don’t like leaving performance on the table.