### PR TITLE
mb86233: write the results of an ALU operation before writing to register/memory, and only test the d register after ALU operations

### DIFF
--- a/src/devices/cpu/mb86233/mb86233.cpp
+++ b/src/devices/cpu/mb86233/mb86233.cpp
@@ -256,18 +256,6 @@ void mb86233_device::pcs_pop()
 		m_pcs[i] = m_pcs[i+1];
 }
 
-void mb86233_device::testdz()
-{
-	if(m_d)
-		m_st &= ~F_ZRD;
-	else
-		m_st |= F_ZRD;
-	if(m_d & 0x80000000)
-		m_st |= F_SGD;
-	else
-		m_st &= ~F_SGD;
-}
-
 void mb86233_device::stset_set_sz_int(u32 val)
 {
 	m_alu_stset = val ? (val & 0x80000000 ? F_SGD : 0) : F_ZRD;
@@ -324,7 +312,7 @@ void mb86233_device::alu_pre(u32 alu)
 	}
 
 	case 0x06: {
-		// fmad
+		// fadd
 		m_alu_stmask = F_ZRD|F_SGD|F_CPD|F_OVD|F_DVZD;
 		m_alu_r1 = f2u(u2f(m_d) + u2f(m_a));
 		stset_set_sz_fp(m_alu_r1);
@@ -676,9 +664,9 @@ void mb86233_device::write_reg(u32 r, u32 v)
 	case 0x14: m_b = set_exp(m_b, v); break;
 	case 0x15: m_b = set_mant(m_b, v); break;
 		/* c */
-	case 0x19: m_d = v; testdz(); break;
-	case 0x1a: m_d = set_exp(m_d, v); testdz(); break;
-	case 0x1b: m_d = set_mant(m_d, v); testdz(); break;
+	case 0x19: m_d = v; break;
+	case 0x1a: m_d = set_exp(m_d, v); break;
+	case 0x1b: m_d = set_mant(m_d, v); break;
 	case 0x1c: m_p = v; break;
 	case 0x1d: m_p = set_exp(m_p, v); break;
 	case 0x1e: m_p = set_mant(m_p, v); break;
@@ -812,6 +800,7 @@ void mb86233_device::execute_run()
 				u32 v = m_data.read_dword(ea);
 				if(m_stall) goto do_stall;
 				ea_post_0(r1);
+				alu_post(alu);
 				write_mem_io_1(r2, v);
 				break;
 			}
@@ -822,6 +811,7 @@ void mb86233_device::execute_run()
 				u32 v = m_data.read_dword(ea);
 				if(m_stall) goto do_stall;
 				ea_post_0(r1);
+				alu_post(alu);
 				write_mem_io_1(r2, v);
 				break;
 			}
@@ -832,6 +822,7 @@ void mb86233_device::execute_run()
 				u32 v = m_io.read_dword(ea);
 				if(m_stall) goto do_stall;
 				ea_post_0(r1);
+				alu_post(alu);
 				write_mem_internal_1(r2, v, false);
 				break;
 			}
@@ -842,6 +833,7 @@ void mb86233_device::execute_run()
 				u32 v = m_data.read_dword(ea);
 				if(m_stall) goto do_stall;
 				ea_post_0(r1);
+				alu_post(alu);
 				write_mem_internal_1(r2, v, true);
 				break;
 			}
@@ -852,6 +844,7 @@ void mb86233_device::execute_run()
 				u32 v = m_data.read_dword(ea);
 				if(m_stall) goto do_stall;
 				ea_post_0(r1);
+				alu_post(alu);
 				write_mem_internal_1(r2, v, false);
 				break;
 			}
@@ -862,6 +855,7 @@ void mb86233_device::execute_run()
 				u32 v = m_program.read_dword(ea);
 				if(m_stall) goto do_stall;
 				ea_post_0(r1);
+				alu_post(alu);
 				write_mem_internal_1(r2, v, false);
 				break;
 			}
@@ -872,6 +866,7 @@ void mb86233_device::execute_run()
 					// mov reg, mem
 					u32 v = read_reg(r2);
 					if(m_stall) goto do_stall;
+					alu_post(alu);
 					write_mem_internal_1(r1, v, false);
 					break;
 				}
@@ -880,6 +875,7 @@ void mb86233_device::execute_run()
 					// mov reg, mem (e)
 					u32 v = read_reg(r2);
 					if(m_stall) goto do_stall;
+					alu_post(alu);
 					write_mem_io_1(r1, v);
 					break;
 				}
@@ -890,6 +886,7 @@ void mb86233_device::execute_run()
 					u32 v = m_data.read_dword(ea);
 					if(m_stall) goto do_stall;
 					ea_post_1(r1);
+					alu_post(alu);
 					write_reg(r2, v);
 					break;
 				}
@@ -900,6 +897,7 @@ void mb86233_device::execute_run()
 					u32 v = m_data.read_dword(ea);
 					if(m_stall) goto do_stall;
 					ea_post_1(r1);
+					alu_post(alu);
 					write_reg(r2, v);
 					break;
 				}
@@ -910,6 +908,7 @@ void mb86233_device::execute_run()
 					u32 v = m_io.read_dword(ea);
 					if(m_stall) goto do_stall;
 					ea_post_1(r1);
+					alu_post(alu);
 					write_reg(r2, v);
 					break;
 				}
@@ -920,6 +919,7 @@ void mb86233_device::execute_run()
 					u32 v = m_program.read_dword(ea);
 					if(m_stall) goto do_stall;
 					ea_post_0(r1);
+					alu_post(alu);
 					write_reg(r2, v);
 					break;
 				}
@@ -928,11 +928,13 @@ void mb86233_device::execute_run()
 					// mov reg, reg
 					u32 v = read_reg(r1);
 					if(m_stall) goto do_stall;
+					alu_post(alu);
 					write_reg(r2, v);
 					break;
 				}
 
 				default:
+					alu_post(alu);
 					logerror("unhandled ld/mov subop 7/%x (%x)\n", r2 >> 6, m_ppc);
 					break;
 				}
@@ -940,11 +942,11 @@ void mb86233_device::execute_run()
 			}
 
 			default:
+				alu_post(alu);
 				logerror("unhandled ld/mov subop %x (%x)\n", op, m_ppc);
 				break;
 			}
 
-			alu_post(alu);
 			break;
 		}
 
@@ -983,7 +985,6 @@ void mb86233_device::execute_run()
 				break;
 			case 3:
 				m_d = util::sext(opcode, 24);
-				testdz();
 				break;
 			}
 			break;

--- a/src/devices/cpu/mb86233/mb86233.h
+++ b/src/devices/cpu/mb86233/mb86233.h
@@ -109,7 +109,6 @@ private:
 	static u32 get_exp(u32 val);
 	static u32 get_mant(u32 val);
 
-	void testdz();
 	void alu_update_st();
 	void alu_pre(u32 alu);
 	void alu_post(u32 alu);


### PR DESCRIPTION
Sega Rally currently has a bug where the cars will glitch into certain parts of the track and fly into the air:

https://youtu.be/-QdM_98HiYA?t=170

I've discovered that the cause of this bug is a particular TGP instruction in a subroutine that calculates square roots, which tries to add the result of a multiplication to the D accumulator register at the same time as loading a value into the same register:

`01B3: 1D9DB24E fsmd : mov $0x4e, d`

Before the TGP emulation rewrite in MAME 0.197, the ALU operation would be performed first and the result in the D register would be overwritten by the MOV operation. Since the rewrite the ALU operation is split into two parts: the calculation is performed first and the result stored in an intermediate register, and the D register is updated at the end overwriting the value loaded by the MOV operation.

With the ALU operation result overwritten by the MOV operation the maximum error of the square root result is 0.17%, while vice versa the maximum error is a whopping 21.1%, which is enough to cause the above bug.

With this edit I've moved the alu_post() call to before write_mem_internal_1(), write_mem_io_1() and write_reg() when performing a MOV operation; I haven't bothered for LAB operations since these never affect the D register. I've also removed testdz() since it seems that loading a value into the D register does not overwrite the flags set by an ALU operation.

The result is that the bug no longer occurs, however the opponent cars are now slower than they are on real hardware (similar to MAME 0.196 and earlier). Their increased speed after the TGP rewrite was a side effect of this emulation bug; the game commonly calls a TGP function that calculates the distance between two vectors, and the result was inflated by the incorrect square root calculation; larger values lead to the opponent cars moving faster.

I suspect the real reason why the opponent cars move faster on real hardware is because the fdvd operation is only an approximation (possibly using an internal lookup table?), and that it tends to approximate slightly too high. Fudging the calculation by multiplying the result of a divide by 1.01 leads to the cars being much closer to real hardware, though obviously this would not be an acceptable solution for MAME. To actually make the speed of opponent cars match that of real hardware, we would need to figure out exactly how the TGP performs the fdvd operation.

I wonder if it would be a good idea to merge the alu_pre() and alu_post() functions into a single alu() function which is called after reading from registers/memory (and also checking that we don't need to stall) and before writing to registers/memory; there is no longer any real need to separate the two functions.