### PR TITLE
sound/s_dsp.cpp: Updates/Cleanups

### DIFF
--- a/src/devices/sound/s_dsp.cpp
+++ b/src/devices/sound/s_dsp.cpp
@@ -687,7 +687,7 @@ void s_dsp_device::dsp_update( s16 *sound_ptr )
 		else
 		{
 			if (outl > 32767)
-					*sound_ptr = 32767;
+				*sound_ptr = 32767;
 			else if (outl < -32768)
 				*sound_ptr = -32768;
 			else
@@ -696,7 +696,7 @@ void s_dsp_device::dsp_update( s16 *sound_ptr )
 			sound_ptr++;
 
 			if (outr > 32767)
-					*sound_ptr = 32767;
+				*sound_ptr = 32767;
 			else if (outr < -32768)
 				*sound_ptr = -32768;
 			else

--- a/src/devices/sound/s_dsp.h
+++ b/src/devices/sound/s_dsp.h
@@ -92,20 +92,20 @@ private:
 	u8                    m_dsp_addr;
 	u8                    m_dsp_regs[256];      /* DSP registers */
 
-	int                   m_keyed_on;
-	int                   m_keys;               /* 8-bits for 8 voices */
+	u8                    m_keyed_on;
+	u8                    m_keys;               /* 8-bits for 8 voices */
 	voice_state_type      m_voice_state[8];
 
 	/* Noise stuff */
-	int                   m_noise_cnt;
-	int                   m_noise_lev;
+	u32                   m_noise_cnt;
+	u32                   m_noise_lev;
 
 	/* These are for the FIR echo filter */
 #ifndef NO_ECHO
 	s16                   m_fir_lbuf[8];
 	s16                   m_fir_rbuf[8];
-	int                   m_fir_ptr;
-	int                   m_echo_ptr;
+	u8                    m_fir_ptr;
+	u16                   m_echo_ptr;
 #endif
 
 };

--- a/src/devices/sound/s_dsp.h
+++ b/src/devices/sound/s_dsp.h
@@ -56,19 +56,19 @@ private:
 	struct voice_state_type                      /* Voice state type             */
 	{
 		u16             mem_ptr;        /* Sample data memory pointer   */
-		int             end;            /* End or loop after block      */
-		int             envcnt;         /* Counts to envelope update    */
+		u8              end;            /* End or loop after block      */
+		s32             envcnt;         /* Counts to envelope update    */
 		env_state_t32   envstate;       /* Current envelope state       */
-		int             envx;           /* Last env height (0-0x7FFF)   */
-		int             filter;         /* Last header's filter         */
-		int             half;           /* Active nybble of BRR         */
-		int             header_cnt;     /* Bytes before new header (0-8)*/
-		int             mixfrac;        /* Fractional part of smpl pstn */
-		int             on_cnt;         /* Is it time to turn on yet?   */
-		int             pitch;          /* Sample pitch (4096->32000Hz) */
-		int             range;          /* Last header's range          */
+		s32             envx;           /* Last env height (0-0x7FFF)   */
+		u8              filter;         /* Last header's filter         */
+		bool            half;           /* Active nybble of BRR         */
+		s8              header_cnt;     /* Bytes before new header (0-8)*/
+		s32             mixfrac;        /* Fractional part of smpl pstn */
+		s32             on_cnt;         /* Is it time to turn on yet?   */
+		s32             pitch;          /* Sample pitch (4096->32000Hz) */
+		u8              range;          /* Last header's range          */
 		u32             samp_id;        /* Sample ID#                   */
-		int             sampptr;        /* Where in sampbuf we are      */
+		s8              sampptr;        /* Where in sampbuf we are      */
 		s32             smp1;           /* Last sample (for BRR filter) */
 		s32             smp2;           /* Second-to-last sample decoded*/
 		s16             sampbuf[4];     /* Buffer for Gaussian interp   */

--- a/src/mame/nintendo/nss.cpp
+++ b/src/mame/nintendo/nss.cpp
@@ -851,7 +851,7 @@ void nss_state::nss(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	S_DSP(config, m_s_dsp, XTAL(24'576'000) / 12);
+	S_DSP(config, m_s_dsp, XTAL(24'576'000));
 	m_s_dsp->set_addrmap(0, &nss_state::spc_map);
 	m_s_dsp->add_route(0, "lspeaker", 1.00);
 	m_s_dsp->add_route(1, "rspeaker", 1.00);

--- a/src/mame/nintendo/sfcbox.cpp
+++ b/src/mame/nintendo/sfcbox.cpp
@@ -471,7 +471,7 @@ void sfcbox_state::sfcbox(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	S_DSP(config, m_s_dsp, XTAL(24'576'000) / 12);
+	S_DSP(config, m_s_dsp, XTAL(24'576'000));
 	m_s_dsp->set_addrmap(0, &sfcbox_state::spc_map);
 	m_s_dsp->add_route(0, "lspeaker", 1.00);
 	m_s_dsp->add_route(1, "rspeaker", 1.00);

--- a/src/mame/nintendo/snes.cpp
+++ b/src/mame/nintendo/snes.cpp
@@ -1365,7 +1365,7 @@ void snes_console_state::snes(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	S_DSP(config, m_s_dsp, XTAL(24'576'000) / 12);
+	S_DSP(config, m_s_dsp, XTAL(24'576'000));
 	m_s_dsp->set_addrmap(0, &snes_console_state::spc_map);
 	m_s_dsp->add_route(0, "lspeaker", 1.00);
 	m_s_dsp->add_route(1, "rspeaker", 1.00);

--- a/src/mame/nintendo/snesb.cpp
+++ b/src/mame/nintendo/snesb.cpp
@@ -1019,7 +1019,7 @@ void snesb_state::base(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	S_DSP(config, m_s_dsp, XTAL(24'576'000) / 12);
+	S_DSP(config, m_s_dsp, XTAL(24'576'000));
 	m_s_dsp->set_addrmap(0, &snesb_state::spc_map);
 	m_s_dsp->add_route(0, "lspeaker", 1.00);
 	m_s_dsp->add_route(1, "rspeaker", 1.00);

--- a/src/mame/nintendo/snesb51.cpp
+++ b/src/mame/nintendo/snesb51.cpp
@@ -274,7 +274,7 @@ void snesb51_state::base(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	S_DSP(config, m_s_dsp, XTAL(24'576'000) / 12);
+	S_DSP(config, m_s_dsp, XTAL(24'576'000));
 	m_s_dsp->set_addrmap(0, &snesb51_state::spc_map);
 	m_s_dsp->add_route(0, "lspeaker", 1.00);
 	m_s_dsp->add_route(1, "rspeaker", 1.00);


### PR DESCRIPTION
- Fix pitch modulation emulation
- Fix input clock
- Fix save state support
- Fix indent inconsistency
- Use std::clamp for clamping functions
- Use reference for voice state
- Use lowercase hexadecimal values
- Use logmacro.h for logging

reference: https://snes.nesdev.org/wiki/SNESdev_Wiki