### PR TITLE
Battle Gear 3 Tuned has a Hong Kong (server?) version

### DIFF
--- a/src/mame/namco/namcops2.cpp
+++ b/src/mame/namco/namcops2.cpp
@@ -30,7 +30,8 @@ Battle Gear 3 (Japan)........................... XX34XXX  M9005793A VER.2.04J  H
 Battle Gear 3 (Export).......................... XX34XXX  M9005793A VER.2.04J  HDD (20GB)   NM00010  *B3900068A(?)           Taito 2002                     | All require Taito JVS Universal I/O board K91X0951A otherwise no boot-up; dongle selects region using same HDDs
 Battle Gear 3 (US).............................. ------X  M9005951A VER.2.00A  HDD (30GB)   NM00010?  B3900068A              Taito 2002                     | 2004 Betson release; contrary to flyer, does *not* remove Honda cars (contrast sidebs2u/batlgear)
 Battle Gear 3 Tuned (Japan)..................... XX34XXX  M9006066A VER.2.03J  HDD (30GB)   NM00015  *B3900074B              Taito 2003                     | HDD: Maxtor Fireball 3 30GB 2F030L0
-Battle Gear 3 Tuned (Export).................... XX34XXX  M9006066A VER.2.03J  HDD (30GB)   NM00015   B3900074C              Taito 2003                    /
+Battle Gear 3 Tuned (Export).................... XX34XXX  M9006066A VER.2.03J  HDD (30GB)   NM00015   B3900074C              Taito 2003                     |
+Battle Gear 3 Tuned (Hong Kong)................. ------X  M9006543A VER.2.00C  HDD (40GB)   NM00015   B3900077A              Taito 2003                    /  HDD: Western Digital WD400EB; different online server (also the case for US version of BG3 on top of Honda issue)
 Bloody Roar 3................................... 1234XXX  BRT1-A               CD           NM00002   BRT1 Ver.A             Namco/8ing/Raizing 2000
 Capcom Fighting Jam/Capcom Fighting Evolution... XXXX56X  JAM1 DVD0            DVD          NM00018   JAM1 Ver.A             Capcom 2004
 Cobra The Arcade................................ XXXX56X  CBR1-HA              HDD (40GB)   NM00021   CBR1 Ver.B             Namco 2004                    Requires RAYS I/O PCB and IR guns and IR sensors. HDD: Maxtor DiamondMax Plus 8 40GB 6E040L0


### PR DESCRIPTION
[As pointed out here](https://twitter.com/mokonaXVI/status/1900725071817437407) [through this auction listing.](https://www.ebay.com/itm/176916947204?_skw=battle+gear&itmmeta=01JPBNH27KRKX070HV7FBPVV1G&hash=item2931126104:g:gSYAAOSwN7Bn0cAu&itmprp=enc%3AAQAKAAAA0FkggFvd1GGDu0w3yXCmi1eMCW8qh8Fjk0L%2BPMGruHGD0en6CV0gCfcQrx5Bbcqw02ilz5%2FuiuX35%2BxQvIenFZL5g5EH8SgloiebZ3Remt0emqSteGDsV9kXcfZjgsz55t5GP6bCzY9lMGRDesklNo%2Bcoj915edv35VKdBkAFE0riQ9PnMbJ9X4YXtfwWl2c7ebBA05MUN8MZeibpIsTrVZfVtoGBYYzpgLFJne45vfK03X3AxjvqdUFH7tOQcjc2b24dE3ATm1YHrrdqfxQdb4%3D%7Ctkp%3ABk9SR4CkxPWyZQ)

>DONGLE NM00015  B3900077A  
>HDD 40.0GB WD WD400EB
>(BG3 TUNED)-(HK) M9006543A VER.2.00C

Other references of the alternate server intended to be used with this revision (vs. the "O" export/English version, which has media ID of M9006066A VER.2.03J/dongle ID of B3900074C):
- https://lamkiuwai.blogspot.com/2006/08/blog-post_15.html -- has poster for the HK BG3 server, but no waybacks of the URL mentioned
- https://idforums.net/lofiversion/index.php?t388-1725.html -- "If your a [BG3T] UK player then your playing on the HK servers"

Worth noting that this version is otherwise in English.

---

Also requesting I be credited as "FMecha" should this be added to the whatsnew.txt - I noticed my old MAMEWorld/MAMETesters name that I no longer used was used in the whatsnew.txt when I documented the US version of BG3.