### PR TITLE
Various PC Engine related fixes/Cleanups/Updates:

### DIFF
--- a/src/devices/sound/c6280.cpp
+++ b/src/devices/sound/c6280.cpp
@@ -44,123 +44,128 @@
 
 void c6280_device::sound_stream_update(sound_stream &stream, std::vector<read_stream_view> const &inputs, std::vector<write_stream_view> &outputs)
 {
-	const u8 lmal = (m_balance >> 4) & 0x0f;
-	const u8 rmal = (m_balance >> 0) & 0x0f;
+	static const u8 scale_tab[16] =
+	{
+		0x00, 0x03, 0x05, 0x07, 0x09, 0x0b, 0x0d, 0x0f,
+		0x10, 0x13, 0x15, 0x17, 0x19, 0x1b, 0x1d, 0x1f
+	};
+
+	const u8 lmal = scale_tab[(m_balance >> 4) & 0x0f];
+	const u8 rmal = scale_tab[(m_balance >> 0) & 0x0f];
 
 	/* Clear buffer */
 	outputs[0].fill(0);
 	outputs[1].fill(0);
 
-	for (int ch = 0; ch < 6; ch++)
+	for (int i = 0; i < outputs[0].samples(); i++)
 	{
-		channel *chan = &m_channel[ch];
-		/* Only look at enabled channels */
-		if (chan->control & 0x80)
+		s32 lout = 0, rout = 0;
+		for (int ch = 0; ch < 6; ch++)
 		{
-			const u8 lal = (chan->balance >> 4) & 0x0f;
-			const u8 ral = (chan->balance >> 0) & 0x0f;
-			const u8 al  = (chan->control >> 1) & 0x0f; // only high 4 bit is affected to calculating volume, low 1 bit is independent
-
-			// verified from both patent and manual
-			int vll = (0xf - lmal) + (0xf - al) + (0xf - lal);
-			if (vll > 0xf) vll = 0xf;
-
-			int vlr = (0xf - rmal) + (0xf - al) + (0xf - ral);
-			if (vlr > 0xf) vlr = 0xf;
-
-			vll = m_volume_table[(vll << 1) | (~chan->control & 1)];
-			vlr = m_volume_table[(vlr << 1) | (~chan->control & 1)];
-
-			/* Check channel mode */
-			if ((ch >= 4) && (chan->noise_control & 0x80))
+			channel &chan = m_channel[ch];
+			/* Only look at enabled channels */
+			if (BIT(chan.control, 7))
 			{
-				/* Noise mode */
-				const u32 step = (chan->noise_control & 0x1f) ^ 0x1f;
-				for (int i = 0; i < outputs[0].samples(); i += 1)
+				const u8 lal = scale_tab[(chan.balance >> 4) & 0x0f];
+				const u8 ral = scale_tab[(chan.balance >> 0) & 0x0f];
+				const u8 al  = chan.control & 0x1f;
+
+				// verified from both patent and manual
+				int vll = (0x1f - lmal) + (0x1f - al) + (0x1f - lal);
+				if (vll > 0x1f) vll = 0x1f;
+
+				int vlr = (0x1f - rmal) + (0x1f - al) + (0x1f - ral);
+				if (vlr > 0x1f) vlr = 0x1f;
+
+				vll = m_volume_table[vll];
+				vlr = m_volume_table[vlr];
+
+				/* Check channel mode */
+				if ((ch >= 4) && BIT(chan.noise_control, 7))
 				{
-					s16 data = BIT(chan->noise_seed, 0) ? 0x1f : 0;
-					chan->noise_counter--;
-					if (chan->noise_counter <= 0)
+					/* Noise mode */
+					const u32 step = (chan.noise_control & 0x1f) ^ 0x1f;
+					const s16 data = BIT(chan.noise_seed, 0) ? 0x1f : 0;
+					chan.noise_counter--;
+					if (chan.noise_counter <= 0)
 					{
-						chan->noise_counter = step << 6; // 32 * 2
-						const u32 seed = chan->noise_seed;
+						chan.noise_counter = step << 6; // 32 * 2
+						const u32 seed = chan.noise_seed;
 						// based on Charles MacDonald's research
-						chan->noise_seed = (seed >> 1) | ((BIT(seed, 0) ^ BIT(seed, 1) ^ BIT(seed, 11) ^ BIT(seed, 12) ^ BIT(seed, 17)) << 17);
+						chan.noise_seed = (seed >> 1) | ((BIT(seed, 0) ^ BIT(seed, 1) ^ BIT(seed, 11) ^ BIT(seed, 12) ^ BIT(seed, 17)) << 17);
 					}
-					outputs[0].add_int(i, s16(vll * (data - 16)), 32768);
-					outputs[1].add_int(i, s16(vlr * (data - 16)), 32768);
+					lout += vll * (data - 16);
+					rout += vlr * (data - 16);
 				}
-			}
-			else
-			if (chan->control & 0x40)
-			{
-				/* DDA mode */
-				for (int i = 0; i < outputs[0].samples(); i++)
+				else if (BIT(chan.control, 6))
 				{
-					outputs[0].add_int(i, s16(vll * (chan->dda - 16)), 32768);
-					outputs[1].add_int(i, s16(vlr * (chan->dda - 16)), 32768);
-				}
-			}
-			else
-			{
-				if ((m_lfo_control & 3) && (ch < 2))
-				{
-					if (ch == 0) // CH 0 only, CH 1 is muted
-					{
-						/* Waveform mode with LFO */
-						channel *lfo_srcchan = &m_channel[1];
-						channel *lfo_dstchan = &m_channel[0];
-						const u16 lfo_step = lfo_srcchan->frequency ? lfo_srcchan->frequency : 0x1000;
-						for (int i = 0; i < outputs[0].samples(); i += 1)
-						{
-							s32 step = lfo_dstchan->frequency ? lfo_dstchan->frequency : 0x1000;
-							if (m_lfo_control & 0x80) // reset LFO
-							{
-								lfo_srcchan->tick = lfo_step * m_lfo_frequency;
-								lfo_srcchan->index = 0;
-							}
-							else
-							{
-								const s16 lfo_data = lfo_srcchan->waveform[lfo_srcchan->index];
-								lfo_srcchan->tick--;
-								if (lfo_srcchan->tick <= 0)
-								{
-									lfo_srcchan->tick = lfo_step * m_lfo_frequency; // verified from manual
-									lfo_srcchan->index = (lfo_srcchan->index + 1) & 0x1f;
-								}
-								step += ((lfo_data - 16) << (((m_lfo_control & 3)-1)<<1)); // verified from manual
-							}
-							const s16 data = lfo_dstchan->waveform[lfo_dstchan->index];
-							lfo_dstchan->tick--;
-							if (lfo_dstchan->tick <= 0)
-							{
-								lfo_dstchan->tick = step;
-								lfo_dstchan->index = (lfo_dstchan->index + 1) & 0x1f;
-							}
-							outputs[0].add_int(i, s16(vll * (data - 16)), 32768);
-							outputs[1].add_int(i, s16(vlr * (data - 16)), 32768);
-						}
-					}
+					/* DDA mode */
+					lout += vll * (chan.dda - 16);
+					rout += vlr * (chan.dda - 16);
 				}
 				else
 				{
-					/* Waveform mode */
-					const u32 step = chan->frequency ? chan->frequency : 0x1000;
-					for (int i = 0; i < outputs[0].samples(); i += 1)
+					if ((m_lfo_control & 3) && (ch < 2))
 					{
-						const s16 data = chan->waveform[chan->index];
-						chan->tick--;
-						if (chan->tick <= 0)
+						if (ch == 0)
 						{
-							chan->tick = step;
-							chan->index = (chan->index + 1) & 0x1f;
+							/* Waveform mode with LFO */
+							channel &lfo_srcchan = m_channel[1];
+							channel &lfo_dstchan = m_channel[0];
+							const u16 lfo_step = lfo_srcchan.frequency ? lfo_srcchan.frequency : 0x1000;
+							s32 step = lfo_dstchan.frequency ? lfo_dstchan.frequency : 0x1000;
+							if (BIT(m_lfo_control, 7)) // reset LFO
+							{
+								lfo_srcchan.tick = lfo_step * m_lfo_frequency;
+								lfo_srcchan.index = 0;
+							}
+							else
+							{
+								const s16 lfo_data = lfo_srcchan.waveform[lfo_srcchan.index];
+								lfo_srcchan.tick--;
+								if (lfo_srcchan.tick <= 0)
+								{
+									lfo_srcchan.tick = lfo_step * m_lfo_frequency; // verified from manual
+									lfo_srcchan.index = (lfo_srcchan.index + 1) & 0x1f;
+								}
+								step += ((lfo_data - 16) << (((m_lfo_control & 3) - 1) << 1)); // verified from manual
+							}
+							const s16 data = lfo_dstchan.waveform[lfo_dstchan.index];
+							lfo_dstchan.tick--;
+							if (lfo_dstchan.tick <= 0)
+							{
+								lfo_dstchan.tick = step;
+								lfo_dstchan.index = (lfo_dstchan.index + 1) & 0x1f;
+							}
+							lout += vll * (data - 16);
+							rout += vlr * (data - 16);
 						}
-						outputs[0].add_int(i, s16(vll * (data - 16)), 32768);
-						outputs[1].add_int(i, s16(vlr * (data - 16)), 32768);
+						else if (ch == 1) // NOT muted even when LFO is on
+						{
+							const s16 data = chan.waveform[chan.index];
+							lout += vll * (data - 16);
+							rout += vlr * (data - 16);
+						}
+					}
+					else
+					{
+						/* Waveform mode */
+						const u32 step = chan.frequency ? chan.frequency : 0x1000;
+						const s16 data = chan.waveform[chan.index];
+						chan.tick--;
+						if (chan.tick <= 0)
+						{
+							chan.tick = step;
+							chan.index = (chan.index + 1) & 0x1f;
+						}
+						lout += vll * (data - 16);
+						rout += vlr * (data - 16);
 					}
 				}
 			}
 		}
+		outputs[0].put_int(i, lout, 32768);
+		outputs[1].put_int(i, rout, 32768);
 	}
 }
 
@@ -215,7 +220,7 @@ void c6280_device::sound_stream_update(sound_stream &stream, std::vector<read_st
 
 void c6280_device::c6280_w(offs_t offset, uint8_t data)
 {
-	channel *chan = &m_channel[m_select];
+	channel &chan = m_channel[m_select];
 
 	/* Update stream */
 	m_stream->update();
@@ -231,50 +236,50 @@ void c6280_device::c6280_w(offs_t offset, uint8_t data)
 			break;
 
 		case 0x02: /* Channel frequency (LSB) */
-			chan->frequency = (chan->frequency & 0x0f00) | data;
+			chan.frequency = (chan.frequency & 0x0f00) | data;
 			break;
 
 		case 0x03: /* Channel frequency (MSB) */
-			chan->frequency = (chan->frequency & 0x00ff) | ((data << 8) & 0x0f00);
+			chan.frequency = (chan.frequency & 0x00ff) | ((data << 8) & 0x0f00);
 			break;
 
 		case 0x04: /* Channel control (key-on, DDA mode, volume) */
 
 			/* 1-to-0 transition of DDA bit resets waveform index */
-			if ((chan->control & 0x40) && ((data & 0x40) == 0))
+			if (BIT(chan.control, 6) && BIT(~data, 6))
 			{
-				chan->index = 0;
+				chan.index = 0;
 			}
-			if (((chan->control & 0x80) == 0) && (data & 0x80))
+			if (BIT(~chan.control, 7) && BIT(data, 7))
 			{
-				chan->tick = chan->frequency;
+				chan.tick = chan.frequency;
 			}
-			chan->control = data;
+			chan.control = data;
 			break;
 
 		case 0x05: /* Channel balance */
-			chan->balance = data;
+			chan.balance = data;
 			break;
 
 		case 0x06: /* Channel waveform data */
 
-			switch (chan->control & 0x40)
+			switch (chan.control & 0x40)
 			{
 				case 0x00: // Waveform
-					chan->waveform[chan->index & 0x1f] = data & 0x1f;
-					if (!(chan->control & 0x80)) // TODO : wave pointer is increased at writing data when sound playback is off??
-						chan->index = (chan->index + 1) & 0x1f;
+					chan.waveform[chan.index & 0x1f] = data & 0x1f;
+					if (BIT(~chan.control, 7)) // TODO : wave pointer is increased at writing data when sound playback is off??
+						chan.index = (chan.index + 1) & 0x1f;
 					break;
 
 				case 0x40: // Direct D/A
-					chan->dda = data & 0x1f;
+					chan.dda = data & 0x1f;
 					break;
 			}
 
 			break;
 
 		case 0x07: /* Noise control (enable, frequency) */
-			chan->noise_control = data;
+			chan.noise_control = data;
 			break;
 
 		case 0x08: /* LFO frequency */
@@ -324,12 +329,12 @@ void c6280_device::device_start()
 	/* Make volume table */
 	/* PSG has 48dB volume range spread over 32 steps */
 	double step = 48.0 / 32.0;
-	for (int i = 0; i < 30; i++)
+	for (int i = 0; i < 31; i++)
 	{
 		m_volume_table[i] = (u16)level;
 		level /= pow(10.0, step / 20.0);
 	}
-	m_volume_table[30] = m_volume_table[31] = 0;
+	m_volume_table[31] = 0;
 
 	save_item(NAME(m_select));
 	save_item(NAME(m_balance));
@@ -352,9 +357,9 @@ void c6280_device::device_reset()
 {
 	for (int ch = 0; ch < 6; ch++)
 	{
-		channel *chan = &m_channel[ch];
-		chan->index = 0;
+		channel &chan = m_channel[ch];
+		chan.index = 0;
 		if (ch >= 4)
-			chan->noise_seed = 1;
+			chan.noise_seed = 1;
 	}
 }

--- a/src/devices/video/huc6202.cpp
+++ b/src/devices/video/huc6202.cpp
@@ -239,22 +239,22 @@ void huc6202_device::write(offs_t offset, u8 data)
 			break;
 
 		case 0x02:  /* Window 1 LSB */
-			m_window1 = (m_window1 & 0xFF00) | data;
+			m_window1 = (m_window1 & 0xff00) | data;
 			m_map_dirty = true;
 			break;
 
 		case 0x03:  /* Window 1 MSB */
-			m_window1 = ((m_window1 & 0x00FF) | (data << 8)) & 0x3FF;
+			m_window1 = ((m_window1 & 0x00ff) | (data << 8)) & 0x3ff;
 			m_map_dirty = true;
 			break;
 
 		case 0x04:  /* Window 2 LSB */
-			m_window2 = (m_window2 & 0xFF00) | data;
+			m_window2 = (m_window2 & 0xff00) | data;
 			m_map_dirty = true;
 			break;
 
 		case 0x05:  /* Window 2 MSB */
-			m_window2 = ((m_window2 & 0x00FF) | (data << 8)) & 0x3FF;
+			m_window2 = ((m_window2 & 0x00ff) | (data << 8)) & 0x3ff;
 			m_map_dirty = true;
 			break;
 

--- a/src/devices/video/huc6202.cpp
+++ b/src/devices/video/huc6202.cpp
@@ -15,7 +15,7 @@
 DEFINE_DEVICE_TYPE(HUC6202, huc6202_device, "huc6202", "Hudson HuC6202 VPC")
 
 
-huc6202_device::huc6202_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+huc6202_device::huc6202_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: device_t(mconfig, HUC6202, tag, owner, clock)
 	, m_next_pixel_0_cb(*this, 0)
 	, m_time_til_next_event_0_cb(*this, 1)
@@ -29,61 +29,60 @@ huc6202_device::huc6202_device(const machine_config &mconfig, const char *tag, d
 	, m_hsync_changed_1_cb(*this)
 	, m_read_1_cb(*this, 0)
 	, m_write_1_cb(*this)
-	, m_window1(0), m_window2(0), m_io_device(0), m_map_index(0), m_map_dirty(0)
+	, m_window1(0), m_window2(0), m_io_device(false), m_map_index(0), m_map_dirty(false)
 {
 }
 
 
 u16 huc6202_device::next_pixel()
 {
-	uint16_t data = huc6270_device::HUC6270_BACKGROUND;
+	u16 data = huc6270_device::HUC6270_BACKGROUND;
 
-	uint16_t data_0 = m_next_pixel_0_cb();
-	uint16_t data_1 = m_next_pixel_1_cb();
+	u16 const data_0 = m_next_pixel_0_cb();
+	u16 const data_1 = m_next_pixel_1_cb();
 
-	if ( data_0 == huc6270_device::HUC6270_SPRITE && data_1 == huc6270_device::HUC6270_SPRITE )
+	if (data_0 == huc6270_device::HUC6270_SPRITE && data_1 == huc6270_device::HUC6270_SPRITE)
 	{
 		m_map_index = 0;
-		if ( m_map_dirty )
+		if (m_map_dirty)
 		{
-			int i;
-
-			for ( i = 0; i < 512; i++ )
+			for (int i = 0; i < 512; i++)
 			{
-				m_prio_map[ i ] = 0;
-				if ( m_window1 < 0x40 || i > m_window1 )
+				m_prio_map[i] = 0;
+				if (m_window1 < 0x40 || i > m_window1)
 				{
-					m_prio_map [ i ] |= 1;
+					m_prio_map[i] |= 1;
 				}
-				if ( m_window2 < 0x40 || i > m_window2 )
+				if (m_window2 < 0x40 || i > m_window2)
 				{
-					m_prio_map[ i ] |= 2;
+					m_prio_map[i] |= 2;
 				}
 			}
-			m_map_dirty = 0;
+			m_map_dirty = false;
 		}
 	}
 	else
 	{
-		uint8_t   prio_index = m_prio_map[ m_map_index ];
+		u8 const prio_index = m_prio_map[m_map_index];
 
-		if ( m_prio[ prio_index ].dev0_enabled && data_0 != huc6270_device::HUC6270_SPRITE )
+		if (m_prio[prio_index].dev0_enabled && data_0 != huc6270_device::HUC6270_SPRITE)
 		{
-			if ( m_prio[ prio_index ].dev1_enabled && data_1 != huc6270_device::HUC6270_SPRITE )
+			if (m_prio[prio_index].dev1_enabled && data_1 != huc6270_device::HUC6270_SPRITE)
 			{
-				switch ( m_prio[ prio_index ].prio_type )
+				switch (m_prio[prio_index].prio_type)
 				{
+				default:
 				case 0:     /* Back - BG1 SP1 BG0 SP0 - Front */
-					data = ( data_0 & 0x0F ) ? data_0 : data_1;
+					data = (data_0 & 0x0f) ? data_0 : data_1;
 					break;
 
 				case 1:     /* Back - BG1 BG0 SP1 SP0 - Front */
-					if ( data_0 > huc6270_device::HUC6270_SPRITE )
+					if (data_0 > huc6270_device::HUC6270_SPRITE)
 					{
 						/* Device 0 sprite */
 						data = data_0;
 					}
-					else if ( data_1 > huc6270_device::HUC6270_SPRITE )
+					else if (data_1 > huc6270_device::HUC6270_SPRITE)
 					{
 						/* Device 1 sprite */
 						data = data_1;
@@ -91,7 +90,7 @@ u16 huc6202_device::next_pixel()
 					else
 					{
 						/* Device 0 and 1 backgrounds */
-						data = ( data_0 & 0x0F ) ? data_0 : data_1;
+						data = (data_0 & 0x0f) ? data_0 : data_1;
 					}
 					break;
 
@@ -100,9 +99,9 @@ u16 huc6202_device::next_pixel()
 				                      BG1 + SP0 => BG1
 				                      SP0 + SP1 => SP0
 				            */
-					if ( data_1 > huc6270_device::HUC6270_SPRITE )
+					if (data_1 > huc6270_device::HUC6270_SPRITE)
 					{
-						if ( data_0 > huc6270_device::HUC6270_SPRITE )
+						if (data_0 > huc6270_device::HUC6270_SPRITE)
 						{
 							/* Device 1 sprite, device 0 sprite */
 							data = data_0;
@@ -110,12 +109,12 @@ u16 huc6202_device::next_pixel()
 						else
 						{
 							/* Device 1 sprite, device 0 background */
-							data = ( data_0 & 0x0F ) ? data_0 : data_1;
+							data = (data_0 & 0x0f) ? data_0 : data_1;
 						}
 					}
 					else
 					{
-						if ( data_0 > huc6270_device::HUC6270_SPRITE )
+						if (data_0 > huc6270_device::HUC6270_SPRITE)
 						{
 							/* Device 1 background, device 0 sprite */
 							data = data_1;
@@ -123,12 +122,9 @@ u16 huc6202_device::next_pixel()
 						else
 						{
 							/* Device 1 background, device 0 background */
-							data = ( data_0 & 0x0F ) ? data_0 : data_1;
+							data = (data_0 & 0x0f) ? data_0 : data_1;
 						}
 					}
-					break;
-
-				case 3:     /* ?? */
 					break;
 				}
 			}
@@ -141,7 +137,7 @@ u16 huc6202_device::next_pixel()
 		else
 		{
 			/* Only device 1 is enabled */
-			if ( m_prio[ prio_index ].dev1_enabled && data_1 != huc6270_device::HUC6270_SPRITE )
+			if (m_prio[prio_index].dev1_enabled && data_1 != huc6270_device::HUC6270_SPRITE)
 			{
 				data = data_1;
 			}
@@ -154,65 +150,65 @@ u16 huc6202_device::next_pixel()
 
 u16 huc6202_device::time_until_next_event()
 {
-	uint16_t next_event_clocks_0 = m_time_til_next_event_0_cb();
-	uint16_t next_event_clocks_1 = m_time_til_next_event_1_cb();
+	u16 const next_event_clocks_0 = m_time_til_next_event_0_cb();
+	u16 const next_event_clocks_1 = m_time_til_next_event_1_cb();
 
-	return std::min( next_event_clocks_0, next_event_clocks_1 );
+	return std::min(next_event_clocks_0, next_event_clocks_1);
 }
 
 
 void huc6202_device::vsync_changed(int state)
 {
-	m_vsync_changed_0_cb( state );
-	m_vsync_changed_1_cb( state );
+	m_vsync_changed_0_cb(state);
+	m_vsync_changed_1_cb(state);
 }
 
 
 void huc6202_device::hsync_changed(int state)
 {
-	m_hsync_changed_0_cb( state );
-	m_hsync_changed_1_cb( state );
+	m_hsync_changed_0_cb(state);
+	m_hsync_changed_1_cb(state);
 }
 
 
 u8 huc6202_device::read(offs_t offset)
 {
-	uint8_t data = 0xFF;
+	u8 data = 0xff;
 
-	switch ( offset & 7 )
+	switch (offset & 7)
 	{
 		case 0x00:  /* Priority register #0 */
-			data = ( m_prio[0].prio_type << 2 ) |
-				( m_prio[0].dev0_enabled ? 0x01 : 0 ) |
-				( m_prio[0].dev1_enabled ? 0x02 : 0 ) |
-				( m_prio[1].prio_type << 6 ) |
-				( m_prio[1].dev0_enabled ? 0x10 : 0 ) |
-				( m_prio[1].dev1_enabled ? 0x20 : 0 );
+			data = (m_prio[0].prio_type << 2) |
+				(m_prio[0].dev0_enabled ? 0x01 : 0) |
+				(m_prio[0].dev1_enabled ? 0x02 : 0) |
+				(m_prio[1].prio_type << 6) |
+				(m_prio[1].dev0_enabled ? 0x10 : 0) |
+				(m_prio[1].dev1_enabled ? 0x20 : 0);
 			break;
 
 		case 0x01:  /* Priority register #1 */
-			data = ( m_prio[2].prio_type << 2 ) |
-				( m_prio[2].dev0_enabled ? 0x01 : 0 ) |
-				( m_prio[2].dev1_enabled ? 0x02 : 0 ) |
-				( m_prio[3].prio_type << 6 ) |
-				( m_prio[3].dev0_enabled ? 0x10 : 0 ) |
-				( m_prio[3].dev1_enabled ? 0x20 : 0 );
+			data = (m_prio[2].prio_type << 2) |
+				(m_prio[2].dev0_enabled ? 0x01 : 0) |
+				(m_prio[2].dev1_enabled ? 0x02 : 0) |
+				(m_prio[3].prio_type << 6) |
+				(m_prio[3].dev0_enabled ? 0x10 : 0) |
+				(m_prio[3].dev1_enabled ? 0x20 : 0);
 			break;
 
 		case 0x02:  /* Window 1 LSB */
-			data = m_window1 & 0xFF;
+			data = m_window1 & 0xff;
 			break;
 
 		case 0x03:  /* Window 1 MSB */
-			data = ( m_window1 >> 8 ) & 0xFF;
+			data = (m_window1 >> 8) & 0xff;
 			break;
 
 		case 0x04:  /* Window 2 LSB */
-			data = m_window2 & 0xFF;
+			data = m_window2 & 0xff;
 			break;
 
 		case 0x05:  /* Window 2 MSB */
-			data = ( m_window2 >> 8 ) & 0xFF;
+			data = (m_window2 >> 8) & 0xff;
 			break;
 	}
 
@@ -222,48 +218,48 @@ u8 huc6202_device::read(offs_t offset)
 
 void huc6202_device::write(offs_t offset, u8 data)
 {
-	switch ( offset & 7 )
+	switch (offset & 7)
 	{
 		case 0x00:  /* Priority register #0 */
-			m_prio[0].dev0_enabled = data & 0x01;
-			m_prio[0].dev1_enabled = data & 0x02;
-			m_prio[0].prio_type = ( data >> 2 ) & 0x03;
-			m_prio[1].dev0_enabled = data & 0x10;
-			m_prio[1].dev1_enabled = data & 0x20;
-			m_prio[1].prio_type = ( data >> 6 ) & 0x03;
+			m_prio[0].dev0_enabled = BIT(data, 0);
+			m_prio[0].dev1_enabled = BIT(data, 1);
+			m_prio[0].prio_type = (data >> 2) & 0x03;
+			m_prio[1].dev0_enabled = BIT(data, 4);
+			m_prio[1].dev1_enabled = BIT(data, 5);
+			m_prio[1].prio_type = (data >> 6) & 0x03;
 			break;
 
 		case 0x01:  /* Priority register #1 */
-			m_prio[2].dev0_enabled = data & 0x01;
-			m_prio[2].dev1_enabled = data & 0x02;
-			m_prio[2].prio_type = ( data >> 2 ) & 0x03;
-			m_prio[3].dev0_enabled = data & 0x10;
-			m_prio[3].dev1_enabled = data & 0x20;
-			m_prio[3].prio_type = ( data >> 6 ) & 0x03;
+			m_prio[2].dev0_enabled = BIT(data, 0);
+			m_prio[2].dev1_enabled = BIT(data, 1);
+			m_prio[2].prio_type = (data >> 2) & 0x03;
+			m_prio[3].dev0_enabled = BIT(data, 4);
+			m_prio[3].dev1_enabled = BIT(data, 5);
+			m_prio[3].prio_type = (data >> 6) & 0x03;
 			break;
 
 		case 0x02:  /* Window 1 LSB */
-			m_window1 = ( m_window1 & 0xFF00 ) | data;
-			m_map_dirty = 1;
+			m_window1 = (m_window1 & 0xFF00) | data;
+			m_map_dirty = true;
 			break;
 
 		case 0x03:  /* Window 1 MSB */
-			m_window1 = ( ( m_window1 & 0x00FF ) | ( data << 8 ) ) & 0x3FF;
-			m_map_dirty = 1;
+			m_window1 = ((m_window1 & 0x00FF) | (data << 8)) & 0x3FF;
+			m_map_dirty = true;
 			break;
 
 		case 0x04:  /* Window 2 LSB */
-			m_window2 = ( m_window2 & 0xFF00 ) | data;
-			m_map_dirty = 1;
+			m_window2 = (m_window2 & 0xFF00) | data;
+			m_map_dirty = true;
 			break;
 
 		case 0x05:  /* Window 2 MSB */
-			m_window2 = ( ( m_window2 & 0x00FF ) | ( data << 8 ) ) & 0x3FF;
-			m_map_dirty = 1;
+			m_window2 = ((m_window2 & 0x00FF) | (data << 8)) & 0x3FF;
+			m_map_dirty = true;
 			break;
 
 		case 0x06:  /* I/O select */
-			m_io_device = data & 0x01;
+			m_io_device = BIT(data, 0);
 			break;
 	}
 }
@@ -271,26 +267,26 @@ void huc6202_device::write(offs_t offset, u8 data)
 
 u8 huc6202_device::io_read(offs_t offset)
 {
-	if ( m_io_device )
+	if (m_io_device)
 	{
-		return m_read_1_cb( offset );
+		return m_read_1_cb(offset);
 	}
 	else
 	{
-		return m_read_0_cb( offset );
+		return m_read_0_cb(offset);
 	}
 }
 
 
 void huc6202_device::io_write(offs_t offset, u8 data)
 {
-	if ( m_io_device )
+	if (m_io_device)
 	{
-		m_write_1_cb( offset, data );
+		m_write_1_cb(offset, data);
 	}
 	else
 	{
-		m_write_0_cb( offset, data );
+		m_write_0_cb(offset, data);
 	}
 }
 
@@ -308,18 +304,9 @@ void huc6202_device::device_start()
 	assert(!m_write_1_cb.isunset());
 
 	/* Register save items */
-	save_item(NAME(m_prio[0].prio_type));
-	save_item(NAME(m_prio[0].dev0_enabled));
-	save_item(NAME(m_prio[0].dev1_enabled));
-	save_item(NAME(m_prio[1].prio_type));
-	save_item(NAME(m_prio[1].dev0_enabled));
-	save_item(NAME(m_prio[1].dev1_enabled));
-	save_item(NAME(m_prio[2].prio_type));
-	save_item(NAME(m_prio[2].dev0_enabled));
-	save_item(NAME(m_prio[2].dev1_enabled));
-	save_item(NAME(m_prio[3].prio_type));
-	save_item(NAME(m_prio[3].dev0_enabled));
-	save_item(NAME(m_prio[3].dev1_enabled));
+	save_item(STRUCT_MEMBER(m_prio, prio_type));
+	save_item(STRUCT_MEMBER(m_prio, dev0_enabled));
+	save_item(STRUCT_MEMBER(m_prio, dev1_enabled));
 	save_item(NAME(m_window1));
 	save_item(NAME(m_window2));
 	save_item(NAME(m_io_device));
@@ -332,19 +319,19 @@ void huc6202_device::device_start()
 void huc6202_device::device_reset()
 {
 	m_prio[0].prio_type = 0;
-	m_prio[0].dev0_enabled = 1;
-	m_prio[0].dev1_enabled = 0;
+	m_prio[0].dev0_enabled = true;
+	m_prio[0].dev1_enabled = false;
 	m_prio[1].prio_type = 0;
-	m_prio[1].dev0_enabled = 1;
-	m_prio[1].dev1_enabled = 0;
+	m_prio[1].dev0_enabled = true;
+	m_prio[1].dev1_enabled = false;
 	m_prio[2].prio_type = 0;
-	m_prio[2].dev0_enabled = 1;
-	m_prio[2].dev1_enabled = 0;
+	m_prio[2].dev0_enabled = true;
+	m_prio[2].dev1_enabled = false;
 	m_prio[3].prio_type = 0;
-	m_prio[3].dev0_enabled = 1;
-	m_prio[3].dev1_enabled = 0;
-	m_map_dirty = 1;
+	m_prio[3].dev0_enabled = true;
+	m_prio[3].dev1_enabled = false;
+	m_map_dirty = true;
 	m_window1 = 0;
 	m_window2 = 0;
-	m_io_device = 0;
+	m_io_device = false;
 }

--- a/src/devices/video/huc6202.h
+++ b/src/devices/video/huc6202.h
@@ -16,7 +16,7 @@ class huc6202_device : public device_t
 {
 public:
 	// construction/destruction
-	huc6202_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	huc6202_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	auto next_pixel_0_callback() { return m_next_pixel_0_cb.bind(); }
 	auto time_til_next_event_0_callback() { return m_time_til_next_event_0_cb.bind(); }
@@ -73,16 +73,16 @@ private:
 	devcb_write8                m_write_1_cb;
 
 	struct {
-		uint8_t   prio_type;
-		uint8_t   dev0_enabled;
-		uint8_t   dev1_enabled;
+		u8   prio_type;
+		bool dev0_enabled;
+		bool dev1_enabled;
 	} m_prio[4];
-	uint16_t  m_window1;
-	uint16_t  m_window2;
-	int     m_io_device;
-	int     m_map_index;
-	int     m_map_dirty;
-	uint8_t   m_prio_map[512];
+	u16  m_window1;
+	u16  m_window2;
+	bool m_io_device;
+	u32  m_map_index;
+	bool m_map_dirty;
+	u8   m_prio_map[512];
 
 };
 

--- a/src/devices/video/huc6260.h
+++ b/src/devices/video/huc6260.h
@@ -23,7 +23,6 @@ public:
 	static constexpr unsigned WPF = 1365;   // width of a line in frame including blanking areas
 	static constexpr unsigned LPF = 263;    // max number of lines in a single frame
 
-
 	// construction/destruction
 	huc6260_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
@@ -71,13 +70,13 @@ private:
 	uint16_t  m_palette[512];
 	uint16_t  m_address;
 	uint16_t  m_greyscales;       /* Should the HuC6260 output grey or color graphics */
-	uint8_t   m_blur;             /* Should the edges of graphics be blurred/Select screen height 0=262, 1=263 */
+	bool      m_blur;             /* Should the edges of graphics be blurred/Select screen height 0=262, 1=263 */
 	uint8_t   m_pixels_per_clock; /* Number of pixels to output per colour clock */
 	uint16_t  m_pixel_data;
 	uint8_t   m_pixel_clock;
 
 	emu_timer   *m_timer;
-	std::unique_ptr<bitmap_ind16>   m_bmp;
+	bitmap_ind16 m_bmp;
 };
 
 

--- a/src/devices/video/huc6270.cpp
+++ b/src/devices/video/huc6270.cpp
@@ -68,12 +68,12 @@ enum {
 	BXR = 0x07,
 	BYR = 0x08,
 	MWR = 0x09,
-	HSR = 0x0A,
-	HDR = 0x0B,
-	VPR = 0x0C,
-	VDW = 0x0D,
-	VCR = 0x0E,
-	DCR = 0x0F,
+	HSR = 0x0a,
+	HDR = 0x0b,
+	VPR = 0x0c,
+	VDW = 0x0d,
+	VCR = 0x0e,
+	DCR = 0x0f,
 	SOUR = 0x10,
 	DESR = 0x11,
 	LENR = 0x12,
@@ -112,20 +112,20 @@ huc6270_device::huc6270_device(const machine_config &mconfig, const char *tag, d
 */
 inline void huc6270_device::fetch_bat_tile_row()
 {
-	const uint16_t bat_data = m_vram[ m_bat_address & m_vram_mask ];
-	const uint16_t tile_palette = ( bat_data >> 8 ) & 0xF0;
-	uint16_t data1 = m_vram[ ( ( ( bat_data & 0x0FFF ) << 4 ) + m_bat_row + 0 ) & m_vram_mask ];
-	uint16_t data2 = ( data1 >> 7 ) & 0x1FE;
-	uint16_t data3 = m_vram[ ( ( ( bat_data & 0x0FFF ) << 4 ) + m_bat_row + 8 ) & m_vram_mask ];
-	uint16_t data4 = ( data3 >> 5 ) & 0x7F8;
+	const uint16_t bat_data = m_vram[m_bat_address & m_vram_mask];
+	const uint16_t tile_palette = (bat_data >> 8) & 0xf0;
+	uint16_t data1 = m_vram[(((bat_data & 0x0fff) << 4) + m_bat_row + 0) & m_vram_mask];
+	uint16_t data2 = (data1 >> 7) & 0x1fe;
+	uint16_t data3 = m_vram[(((bat_data & 0x0fff) << 4) + m_bat_row + 8) & m_vram_mask];
+	uint16_t data4 = (data3 >> 5) & 0x7f8;
 	data3 <<= 2;
 
-	for ( int i = 7; i >= 0; i-- )
+	for (int i = 7; i >= 0; i--)
 	{
-		uint16_t c = ( data1 & 0x01 ) | ( data2 & 0x02 ) | ( data3 & 0x04 ) | ( data4 & 0x08 );
+		uint16_t c = (data1 & 0x01) | (data2 & 0x02) | (data3 & 0x04) | (data4 & 0x08);
 
 		/* Colour 0 for background tiles is always taken from palette 0 */
-		if ( c )
+		if (c)
 			c |= tile_palette;
 
 		m_bat_tile_row[i] = c;
@@ -138,63 +138,62 @@ inline void huc6270_device::fetch_bat_tile_row()
 }
 
 
-void huc6270_device::add_sprite( int index, int x, int pattern, int line, int flip_x, int palette, int priority, int sat_lsb )
+void huc6270_device::add_sprite(int index, int x, int pattern, int line, int flip_x, int palette, int priority, int sat_lsb)
 {
-	int i = m_sprites_this_line;
+	const int i = m_sprites_this_line;
 
-	if ( i < 16 )
+	if (i < 16)
 	{
 		uint32_t b0, b1, b2, b3;
-		int j;
 
-		if ( flip_x )
-			flip_x = 0x0F;
+		if (flip_x)
+			flip_x = 0x0f;
 
-		pattern += ( ( line >> 4 ) << 1 );
+		pattern += ((line >> 4) << 1);
 
-		if ( ( m_mwr & 0x0c ) == 0x04 )
+		if ((m_mwr & 0x0c) == 0x04)
 		{
-			if ( ! sat_lsb )
+			if (!sat_lsb)
 			{
-				b0 = m_vram[ ( ( pattern * 0x40 ) + ( line & 0x0F ) + 0x00 ) & m_vram_mask ];
-				b1 = m_vram[ ( ( pattern * 0x40 ) + ( line & 0x0F ) + 0x10 ) & m_vram_mask ] << 1;
+				b0 = m_vram[((pattern * 0x40) + (line & 0x0f) + 0x00) & m_vram_mask];
+				b1 = m_vram[((pattern * 0x40) + (line & 0x0f) + 0x10) & m_vram_mask] << 1;
 			}
 			else
 			{
-				b0 = m_vram[ ( ( pattern * 0x40 ) + ( line & 0x0F ) + 0x20 ) & m_vram_mask ];
-				b1 = m_vram[ ( ( pattern * 0x40 ) + ( line & 0x0F ) + 0x30 ) & m_vram_mask ] << 1;
+				b0 = m_vram[((pattern * 0x40) + (line & 0x0f) + 0x20) & m_vram_mask];
+				b1 = m_vram[((pattern * 0x40) + (line & 0x0f) + 0x30) & m_vram_mask] << 1;
 			}
 			b2 = 0;
 			b3 = 0;
 		}
 		else
 		{
-			b0 = m_vram[ ( ( pattern * 0x40 ) + ( line & 0x0F ) + 0x00 ) & m_vram_mask ];
-			b1 = m_vram[ ( ( pattern * 0x40 ) + ( line & 0x0F ) + 0x10 ) & m_vram_mask ] << 1;
-			b2 = m_vram[ ( ( pattern * 0x40 ) + ( line & 0x0F ) + 0x20 ) & m_vram_mask ] << 2;
-			b3 = m_vram[ ( ( pattern * 0x40 ) + ( line & 0x0F ) + 0x30 ) & m_vram_mask ] << 3;
+			b0 = m_vram[((pattern * 0x40) + (line & 0x0f) + 0x00) & m_vram_mask];
+			b1 = m_vram[((pattern * 0x40) + (line & 0x0f) + 0x10) & m_vram_mask] << 1;
+			b2 = m_vram[((pattern * 0x40) + (line & 0x0f) + 0x20) & m_vram_mask] << 2;
+			b3 = m_vram[((pattern * 0x40) + (line & 0x0f) + 0x30) & m_vram_mask] << 3;
 		}
 
-		for ( j = 15; j >= 0; j-- )
+		for (int j = 15; j >= 0; j--)
 		{
-			uint8_t data = ( b3 & 0x08 ) | ( b2 & 0x04 ) | ( b1 & 0x02 ) | ( b0 & 0x01 );
+			uint8_t data = (b3 & 0x08) | (b2 & 0x04) | (b1 & 0x02) | (b0 & 0x01);
 
-			if ( data )
+			if (data)
 			{
 				data |= palette << 4;
 
-				if ( x + ( j ^ flip_x ) < 1024 )
+				if (x + (j ^ flip_x) < 1024)
 				{
-					if (! m_sprite_row[ x + ( j ^ flip_x ) ] )
+					if (!m_sprite_row[x + (j ^ flip_x)])
 					{
-						m_sprite_row[ x + ( j ^ flip_x ) ] = ( priority ? 0x4000 : 0x0000 ) | ( index << 8 ) | data;
+						m_sprite_row[x + (j ^ flip_x)] = (priority ? 0x4000 : 0x0000) | (index << 8) | data;
 					}
 					else
 					{
-						if ( ! ( m_sprite_row[ x + ( j ^ flip_x ) ] & 0xFF00 ) )
+						if (!(m_sprite_row[x + (j ^ flip_x)] & 0xff00))
 						{
 							/* Sprite 0 collission */
-							m_sprite_row[ x + ( j ^ flip_x ) ] |= 0x8000;
+							m_sprite_row[x + (j ^ flip_x)] |= 0x8000;
 						}
 					}
 				}
@@ -213,78 +212,76 @@ void huc6270_device::add_sprite( int index, int x, int pattern, int line, int fl
 
 void huc6270_device::select_sprites()
 {
-	int i;
-
 	m_sprites_this_line = 0;
-	memset( m_sprite_row, 0, sizeof( m_sprite_row ) );
+	memset(m_sprite_row, 0, sizeof(m_sprite_row));
 	m_sprite_row_index = 0x20;
 
-	for ( i = 0; i < 4 * 64; i += 4 )
+	for (int i = 0; i < 4 * 64; i += 4)
 	{
 		static const int cgy_table[4] = { 16, 32, 64, 64 };
-		int cgy = ( m_sat[i+3] >> 12 ) & 0x03;
-		int height = cgy_table[ cgy ];
+		const int cgy = (m_sat[i + 3] >> 12) & 0x03;
+		const int height = cgy_table[cgy];
 		// TODO: we are one line off in alignment, is following compensation right?
 		// cfr. rennybla & draculax (at least), they are otherwise offset by 1
 		// compared to background.
 		int sprite_line = m_raster_count - 1 - m_sat[i];
 
-		if ( sprite_line >= 0 && sprite_line < height )
+		if (sprite_line >= 0 && sprite_line < height)
 		{
-			int pattern = m_sat[i+2] >> 1;
-			int sat_lsb = m_sat[i+2] & 0x01;
-			int palette = m_sat[i+3] & 0x0F;
-			int priority = m_sat[i+3] & 0x80;
-			int cgx = m_sat[i+3] & 0x0100;
+			int pattern = m_sat[i + 2] >> 1;
+			const bool sat_lsb = BIT(m_sat[i + 2], 0);
+			const int palette = m_sat[i + 3] & 0x0f;
+			const bool priority = BIT(m_sat[i + 3], 7);
+			const bool cgx = BIT(m_sat[i + 3], 8);
 
 			/* If CGY is set to 1, bit 1 of the sprite pattern index is forced to 0 */
-			if ( cgy & 1 )
+			if (BIT(cgy, 0))
 				pattern &= ~0x0002;
 
 			/* If CGY is set to 2 or 3, bits 1 and 2 of the sprite pattern index are forced to 0 */
-			if ( cgy & 2 )
+			if (BIT(cgy, 1))
 				pattern &= ~0x0006;
 
 			/* Recalculate line index when sprite is flipped vertically */
-			if ( m_sat[i+3] & 0x8000 )
-				sprite_line = ( height - 1 ) - sprite_line;
+			if (BIT(m_sat[i + 3], 15))
+				sprite_line = (height - 1) - sprite_line;
 
 			/* Is the sprite 32 pixels wide */
-			if ( cgx )
+			if (cgx)
 			{
 				/* If CGX is set, bit 0 of the sprite pattern index is forced to 0 */
 				pattern &= ~0x0001;
 
 				/* Check for horizontal flip */
-				if ( m_sat[i+3] & 0x0800 )
+				if (BIT(m_sat[i + 3], 11))
 				{
 					/* Add to our list of sprites for this line */
-					add_sprite( i/4, m_sat[i+1], pattern + 1, sprite_line, 1, palette, priority, sat_lsb );
-					add_sprite( i/4, m_sat[i+1] + 16, pattern, sprite_line, 1, palette, priority, sat_lsb );
+					add_sprite(i / 4, m_sat[i + 1], pattern + 1, sprite_line, 1, palette, priority, sat_lsb);
+					add_sprite(i / 4, m_sat[i + 1] + 16, pattern, sprite_line, 1, palette, priority, sat_lsb);
 				}
 				else
 				{
 					/* Add to our list of sprites for this line */
-					add_sprite( i/4, m_sat[i+1], pattern, sprite_line, 0, palette, priority, sat_lsb );
-					add_sprite( i/4, m_sat[i+1] + 16, pattern + 1, sprite_line, 0, palette, priority, sat_lsb );
+					add_sprite(i / 4, m_sat[i + 1], pattern, sprite_line, 0, palette, priority, sat_lsb);
+					add_sprite(i / 4, m_sat[i + 1] + 16, pattern + 1, sprite_line, 0, palette, priority, sat_lsb);
 				}
 			}
 			else
 			{
 				/* Add to our list of sprites for this line */
-				add_sprite( i/4, m_sat[i+1], pattern, sprite_line, m_sat[i+3] & 0x0800, palette, priority, sat_lsb );
+				add_sprite(i / 4, m_sat[i + 1], pattern, sprite_line, BIT(m_sat[i + 3], 11), palette, priority, sat_lsb);
 			}
 		}
 	}
 
 	/* Check for sprite overflow */
-	if ( m_sprites_this_line >= 16 )
+	if (m_sprites_this_line >= 16)
 	{
 		/* note: flag is set only if irq is taken, Mizubaku Daibouken relies on this behaviour */
-		if ( m_cr & 0x02 )
+		if (BIT(m_cr, 1))
 		{
 			m_status |= HUC6270_OR;
-			m_irq_changed_cb( ASSERT_LINE );
+			m_irq_changed_cb(ASSERT_LINE);
 		}
 	}
 }
@@ -292,70 +289,68 @@ void huc6270_device::select_sprites()
 
 inline void huc6270_device::handle_vblank()
 {
-	if ( ! m_vd_triggered )
+	if (!m_vd_triggered)
 	{
-		if ( m_cr & 0x08 )
+		if (BIT(m_cr, 3))
 		{
 			m_status |= HUC6270_VD;
-			m_irq_changed_cb( ASSERT_LINE );
+			m_irq_changed_cb(ASSERT_LINE);
 		}
 
 		/* Should we initiate a VRAM->SATB DMA transfer.
 		   The timing for this is incorrect.
 		 */
-		if ( m_dvssr_written || ( m_dcr & 0x10 ) )
+		if (m_dvssr_written || BIT(m_dcr, 4))
 		{
-			int i;
-
-			LOG("SATB transfer from %05x\n", m_dvssr << 1 );
-			for ( i = 0; i < 4 * 64; i += 4 )
+			LOG("SATB transfer from %05x\n", m_dvssr << 1);
+			for (int i = 0; i < 4 * 64; i += 4)
 			{
-				m_sat[i + 0] = m_vram[ ( m_dvssr + i + 0 ) & m_vram_mask ] & 0x03FF;
-				m_sat[i + 1] = m_vram[ ( m_dvssr + i + 1 ) & m_vram_mask ] & 0x03FF;
-				m_sat[i + 2] = m_vram[ ( m_dvssr + i + 2 ) & m_vram_mask ] & 0x07FF;
-				m_sat[i + 3] = m_vram[ ( m_dvssr + i + 3 ) & m_vram_mask ];
+				m_sat[i + 0] = m_vram[(m_dvssr + i + 0) & m_vram_mask] & 0x03ff;
+				m_sat[i + 1] = m_vram[(m_dvssr + i + 1) & m_vram_mask] & 0x03ff;
+				m_sat[i + 2] = m_vram[(m_dvssr + i + 2) & m_vram_mask] & 0x07ff;
+				m_sat[i + 3] = m_vram[(m_dvssr + i + 3) & m_vram_mask];
 			}
-			m_dvssr_written = 0;
+			m_dvssr_written = false;
 
 			/* Generate SATB interrupt if requested */
-			if ( m_dcr & 0x01 )
+			if (BIT(m_dcr, 0))
 			{
 				m_satb_countdown = 4;
-//                  m_status |= HUC6270_DS;
-//                  m_irq_changed_cb( ASSERT_LINE );
+//              m_status |= HUC6270_DS;
+//              m_irq_changed_cb(ASSERT_LINE);
 			}
 		}
 
-		m_vd_triggered = 1;
+		m_vd_triggered = true;
 	}
 }
 
 
 inline void huc6270_device::next_vert_state()
 {
-	switch ( m_vert_state )
+	switch (m_vert_state)
 	{
 	case v_state::VSW:
 		m_vert_state = v_state::VDS;
-		m_vert_to_go = ( ( m_vpr >> 8 ) & 0xFF ) + 2;
+		m_vert_to_go = ((m_vpr >> 8) & 0xff) + 2;
 		break;
 
 	case v_state::VDS:
 		m_vert_state = v_state::VDW;
-		m_vert_to_go = ( m_vdw & 0x1FF ) + 1;
+		m_vert_to_go = (m_vdw & 0x1ff) + 1;
 		m_byr_latched = m_byr;
-		m_vd_triggered = 0;
+		m_vd_triggered = false;
 		break;
 
 	case v_state::VDW:
 		m_vert_state = v_state::VCR;
-		m_vert_to_go = ( m_vcr & 0xFF );
+		m_vert_to_go = (m_vcr & 0xff);
 		handle_vblank();
 		break;
 
 	case v_state::VCR:
 		m_vert_state = v_state::VSW;
-		m_vert_to_go = ( m_vpr & 0x1F ) + 1;
+		m_vert_to_go = (m_vpr & 0x1f) + 1;
 		break;
 	}
 }
@@ -363,21 +358,20 @@ inline void huc6270_device::next_vert_state()
 
 inline void huc6270_device::next_horz_state()
 {
-	switch ( m_horz_state )
+	switch (m_horz_state)
 	{
 	case h_state::HDS:
 		m_bxr_latched = m_bxr;
 		m_horz_state = h_state::HDW;
-		m_horz_to_go = ( m_hdr & 0x7F ) + 1;
+		m_horz_to_go = (m_hdr & 0x7f) + 1;
 		{
 			static const int width_shift[4] = { 5, 6, 7, 7 };
-			uint16_t v;
 
-			v = ( m_byr_latched ) & ( ( m_mwr & 0x40 ) ? 0x1FF : 0xFF );
+			const uint16_t v = (m_byr_latched) & (BIT(m_mwr, 6) ? 0x1ff : 0xff);
 			m_bat_row = v & 7;
-			m_bat_address_mask = ( 1 << width_shift[ ( m_mwr >> 4 ) & 0x03 ] ) - 1;
-			m_bat_address = ( ( v >> 3 ) << ( width_shift[ ( m_mwr >> 4 ) & 0x03 ] ) )
-				| ( ( m_bxr_latched >> 3 ) & m_bat_address_mask );
+			m_bat_address_mask = (1 << width_shift[(m_mwr >> 4) & 0x03]) - 1;
+			m_bat_address = ((v >> 3) << (width_shift[(m_mwr >> 4) & 0x03]))
+				| ((m_bxr_latched >> 3) & m_bat_address_mask);
 			m_bat_column = m_bxr & 7;
 			fetch_bat_tile_row();
 		}
@@ -385,20 +379,20 @@ inline void huc6270_device::next_horz_state()
 
 	case h_state::HDW:
 		m_horz_state = h_state::HDE;
-		m_horz_to_go = ( ( m_hdr >> 8 ) & 0x7F ) + 1;
+		m_horz_to_go = ((m_hdr >> 8) & 0x7f) + 1;
 		break;
 
 	case h_state::HDE:
 		m_horz_state = h_state::HSW;
-		m_horz_to_go = ( m_hsr & 0x1F ) + 1;
+		m_horz_to_go = (m_hsr & 0x1f) + 1;
 		break;
 
 	case h_state::HSW:
 		m_horz_state = h_state::HDS;
-		m_horz_to_go = std::max( ( ( m_hsr >> 8 ) & 0x7F ), 2 ) + 1;
+		m_horz_to_go = std::max(((m_hsr >> 8) & 0x7f), 2) + 1;
 
 		/* If section has ended, advance to next vertical state */
-		while ( m_vert_to_go == 0 )
+		while (m_vert_to_go == 0)
 			next_vert_state();
 
 		/* Select sprites for the coming line */
@@ -414,26 +408,26 @@ u16 huc6270_device::next_pixel()
 	uint16_t data = HUC6270_SPRITE;
 
 	/* Check if we're on an active display line */
-	if ( m_vert_state == v_state::VDW )
+	if (m_vert_state == v_state::VDW)
 	{
 		/* Check if we're in active display area */
-		if ( m_horz_state == h_state::HDW )
+		if (m_horz_state == h_state::HDW)
 		{
-			uint8_t sprite_data = m_sprite_row[ m_sprite_row_index ] & 0x00FF;
-			int collission = ( m_sprite_row[ m_sprite_row_index ] & 0x8000 ) ? 1 : 0;
+			const uint8_t sprite_data = m_sprite_row[m_sprite_row_index] & 0x00ff;
+			const bool collission = BIT(m_sprite_row[m_sprite_row_index], 15);
 
-			if ( m_cr & 0x80 )
+			if (BIT(m_cr, 7))
 			{
-				data = HUC6270_BACKGROUND | m_bat_tile_row[ m_bat_column ];
-				if ( sprite_data && ( m_cr & 0x40 ) )
+				data = HUC6270_BACKGROUND | m_bat_tile_row[m_bat_column];
+				if (sprite_data && BIT(m_cr, 6))
 				{
-					if ( m_sprite_row[ m_sprite_row_index ] & 0x4000 )
+					if (BIT(m_sprite_row[m_sprite_row_index], 14))
 					{
 						data = HUC6270_SPRITE | sprite_data;
 					}
 					else
 					{
-						if ( data == HUC6270_BACKGROUND )
+						if (data == HUC6270_BACKGROUND)
 						{
 							data = HUC6270_SPRITE | sprite_data;
 						}
@@ -442,7 +436,7 @@ u16 huc6270_device::next_pixel()
 			}
 			else
 			{
-				if ( m_cr & 0x40 )
+				if (BIT(m_cr, 6))
 				{
 					data = HUC6270_SPRITE | sprite_data;
 				}
@@ -450,28 +444,28 @@ u16 huc6270_device::next_pixel()
 
 			m_sprite_row_index = m_sprite_row_index + 1;
 			m_bat_column += 1;
-			if ( m_bat_column >= 8 )
+			if (m_bat_column >= 8)
 			{
-				m_bat_address = ( m_bat_address & ~m_bat_address_mask )
-					| ( ( m_bat_address + 1 ) & m_bat_address_mask );
+				m_bat_address = (m_bat_address & ~m_bat_address_mask)
+					| ((m_bat_address + 1) & m_bat_address_mask);
 				m_bat_column = 0;
 				fetch_bat_tile_row();
 			}
 
-			if ( collission && ( m_cr & 0x01 ) )
+			if (collission && BIT(m_cr, 0))
 			{
 				m_status |= HUC6270_CR;
-				m_irq_changed_cb( ASSERT_LINE );
+				m_irq_changed_cb(ASSERT_LINE);
 			}
 		}
 	}
 
 	m_horz_steps++;
-	if ( m_horz_steps == 8 )
+	if (m_horz_steps == 8)
 	{
 		m_horz_to_go -= 1;
 		m_horz_steps = 0;
-		while ( m_horz_to_go == 0 )
+		while (m_horz_to_go == 0)
 			next_horz_state();
 	}
 	return data;
@@ -487,15 +481,15 @@ u16 huc6270_device::next_pixel()
 void huc6270_device::vsync_changed(int state)
 {
 	state &= 0x01;
-	if ( m_vsync != state )
+	if (m_vsync != state)
 	{
 		/* Check for high->low VSYNC transition */
-		if ( !state )
+		if (!state)
 		{
 			m_vert_state = v_state::VCR;
 			m_vert_to_go = 0;
 
-			while ( m_vert_to_go == 0 )
+			while (m_vert_to_go == 0)
 				next_vert_state();
 		}
 		else
@@ -519,14 +513,14 @@ void huc6270_device::hsync_changed(int state)
 		/* Check for low->high HSYNC transition */
 		if(state)
 		{
-			if ( m_satb_countdown )
+			if (m_satb_countdown)
 			{
 				m_satb_countdown--;
 
-				if ( m_satb_countdown == 0 )
+				if (m_satb_countdown == 0)
 				{
 					m_status |= HUC6270_DS;
-					m_irq_changed_cb( ASSERT_LINE );
+					m_irq_changed_cb(ASSERT_LINE);
 				}
 			}
 
@@ -542,14 +536,14 @@ void huc6270_device::hsync_changed(int state)
 			// - draculax Stage 4' "all blue" Richter;
 			// - faussete Stage 2 excessive slowdown;
 			// - xwiber Stage 2 boss never spawning (MT#07384)
-			if ( m_vert_to_go == 2 && m_vert_state == v_state::VDS )
+			if (m_vert_to_go == 2 && m_vert_state == v_state::VDS)
 			{
 				m_raster_count = 0x40;
 			}
 
 			m_vert_to_go -= 1;
 
-			while ( m_horz_to_go == 0 )
+			while (m_horz_to_go == 0)
 				next_horz_state();
 
 			handle_dma();
@@ -558,10 +552,10 @@ void huc6270_device::hsync_changed(int state)
 		{
 			/* Check for high->low HSYNC transition */
 			// RCR IRQ happens near the end of the HDW period
-			if ( m_raster_count == m_rcr && ( m_cr & 0x04 ) )
+			if (m_raster_count == m_rcr && BIT(m_cr, 2))
 			{
 				m_status |= HUC6270_RR;
-				m_irq_changed_cb( ASSERT_LINE );
+				m_irq_changed_cb(ASSERT_LINE);
 			}
 		}
 	}
@@ -574,35 +568,35 @@ inline void huc6270_device::handle_dma()
 	/* Should we perform VRAM-VRAM dma.
 	   The timing for this is incorrect.
 	 */
-	if ( m_dma_enabled )
+	if (m_dma_enabled)
 	{
-		int desr_inc = ( m_dcr & 0x0008 ) ? -1 : +1;
-		int sour_inc = ( m_dcr & 0x0004 ) ? -1 : +1;
+		const int desr_inc = (m_dcr & 0x0008) ? -1 : +1;
+		const int sour_inc = (m_dcr & 0x0004) ? -1 : +1;
 
-		LOG("doing dma sour = %04x, desr = %04x, lenr = %04x\n", m_sour, m_desr, m_lenr );
+		LOG("doing dma sour = %04x, desr = %04x, lenr = %04x\n", m_sour, m_desr, m_lenr);
 
 		do {
 			uint16_t data;
 
 			// area 0x8000-0xffff cannot be r/w (open bus)
 			if(m_sour <= m_vram_mask)
-				data = m_vram[ m_sour ];
+				data = m_vram[m_sour];
 			else
 				data = 0;
 
 			if(m_desr <= m_vram_mask)
-				m_vram[ m_desr ] = data;
+				m_vram[m_desr] = data;
 			m_sour += sour_inc;
 			m_desr += desr_inc;
 			m_lenr -= 1;
-		} while ( m_lenr != 0xFFFF );
+		} while (m_lenr != 0xffff);
 
-		if ( m_dcr & 0x0002 )
+		if (BIT(m_dcr, 1))
 		{
 			m_status |= HUC6270_DV;
-			m_irq_changed_cb( ASSERT_LINE );
+			m_irq_changed_cb(ASSERT_LINE);
 		}
-		m_dma_enabled = 0;
+		m_dma_enabled = false;
 	}
 }
 
@@ -610,31 +604,34 @@ u8 huc6270_device::read(offs_t offset)
 {
 	uint8_t data = 0x00;
 
-	switch ( offset & 3 )
+	switch (offset & 3)
 	{
 		case 0x00:  /* status */
 			data = m_status;
-			m_status &= ~( HUC6270_VD | HUC6270_DV | HUC6270_RR | HUC6270_CR | HUC6270_OR | HUC6270_DS );
-			m_irq_changed_cb( CLEAR_LINE );
+			m_status &= ~(HUC6270_VD | HUC6270_DV | HUC6270_RR | HUC6270_CR | HUC6270_OR | HUC6270_DS);
+			m_irq_changed_cb(CLEAR_LINE);
 			break;
 
 		case 0x02:
-			data = m_vrr & 0xFF;
+			data = m_vrr & 0xff;
 			break;
 
 		case 0x03:
 			data = m_vrr >> 8;
-			if ( m_register_index == VxR )
+			if (!machine().side_effects_disabled())
 			{
-				m_marr += vram_increments[ ( m_cr >> 11 ) & 3 ];
-
-				if(m_marr <= m_vram_mask)
-					m_vrr = m_vram[ m_marr ];
-				else
+				if (m_register_index == VxR)
 				{
-					// TODO: test with real HW
-					m_vrr = 0;
-					logerror("%s Open Bus VRAM read (register read) %04x\n",this->tag(),m_marr);
+					m_marr += vram_increments[(m_cr >> 11) & 3];
+
+					if(m_marr <= m_vram_mask)
+						m_vrr = m_vram[m_marr];
+					else
+					{
+						// TODO: test with real HW
+						m_vrr = 0;
+						logerror("%s Open Bus VRAM read (register read) %04x\n",this->tag(),m_marr);
+					}
 				}
 			}
 			break;
@@ -647,23 +644,23 @@ void huc6270_device::write(offs_t offset, u8 data)
 {
 	LOG("%s: huc6270 write %02x <- %02x ", machine().describe_context(), offset, data);
 
-	switch ( offset & 3 )
+	switch (offset & 3)
 	{
 		case 0x00:  /* VDC register select */
 			m_register_index = data & 0x1F;
 			break;
 
 		case 0x02:  /* VDC data LSB */
-			switch ( m_register_index )
+			switch (m_register_index)
 			{
 				case MAWR:      /* memory address write register LSB */
-					m_mawr = ( m_mawr & 0xFF00 ) | data;
+					m_mawr = (m_mawr & 0xff00) | data;
 					break;
 
 				case MARR:      /* memory address read register LSB */
-					m_marr = ( m_marr & 0xFF00 ) | data;
+					m_marr = (m_marr & 0xff00) | data;
 					if(m_marr <= m_vram_mask)
-						m_vrr = m_vram[ m_marr ];
+						m_vrr = m_vram[m_marr];
 					else
 					{
 						// TODO: test with real HW
@@ -673,169 +670,169 @@ void huc6270_device::write(offs_t offset, u8 data)
 					break;
 
 				case VxR:       /* vram write data LSB */
-					m_vwr = ( m_vwr & 0xFF00 ) | data;
+					m_vwr = (m_vwr & 0xff00) | data;
 					break;
 
 				case CR:        /* control register LSB */
-					m_cr = ( m_cr & 0xFF00 ) | data;
+					m_cr = (m_cr & 0xff00) | data;
 					break;
 
 				case RCR:       /* raster compare register LSB */
-					m_rcr = ( m_rcr & 0x0300 ) | data;
-//                  if ( m_raster_count == m_rcr && m_cr & 0x04 )
+					m_rcr = (m_rcr & 0x0300) | data;
+//                  if (m_raster_count == m_rcr && m_cr & 0x04)
 //                  {
 //                      m_status |= HUC6270_RR;
-//                      m_irq_changed_cb( ASSERT_LINE );
+//                      m_irq_changed_cb(ASSERT_LINE);
 //                  }
 					break;
 
 				case BXR:       /* background x-scroll register LSB */
-					m_bxr = ( m_bxr & 0x0300 ) | data;
+					m_bxr = (m_bxr & 0x0300) | data;
 					break;
 
 				case BYR:       /* background y-scroll register LSB */
-					m_byr = ( m_byr & 0x0100 ) | data;
+					m_byr = (m_byr & 0x0100) | data;
 					m_byr_latched = m_byr;
 					break;
 
 				case MWR:       /* memory width register LSB */
-					m_mwr = ( m_mwr & 0xFF00 ) | data;
+					m_mwr = (m_mwr & 0xff00) | data;
 					break;
 
 				case HSR:       /* horizontal sync register LSB */
-					m_hsr = ( m_hsr & 0xFF00 ) | data;
+					m_hsr = (m_hsr & 0xff00) | data;
 					break;
 
 				case HDR:       /* horizontal display register LSB */
-					m_hdr = ( m_hdr & 0xFF00 ) | data;
+					m_hdr = (m_hdr & 0xff00) | data;
 					break;
 
 				case VPR:       /* vertical sync register LSB */
-					m_vpr = ( m_vpr & 0xFF00 ) | data;
+					m_vpr = (m_vpr & 0xff00) | data;
 					break;
 
 				case VDW:       /* vertical display register LSB */
-					m_vdw = ( m_vdw & 0xFF00 ) | data;
+					m_vdw = (m_vdw & 0xff00) | data;
 					break;
 
 				case VCR:       /* vertical display end position register LSB */
-					m_vcr = ( m_vcr & 0xFF00 ) | data;
+					m_vcr = (m_vcr & 0xff00) | data;
 					break;
 
 				case DCR:       /* DMA control register LSB */
-					m_dcr = ( m_dcr & 0xFF00 ) | data;
+					m_dcr = (m_dcr & 0xff00) | data;
 					break;
 
 				case SOUR:      /* DMA source address register LSB */
-					m_sour = ( m_sour & 0xFF00 ) | data;
+					m_sour = (m_sour & 0xff00) | data;
 					break;
 
 				case DESR:      /* DMA destination address register LSB */
-					m_desr = ( m_desr & 0xFF00 ) | data;
+					m_desr = (m_desr & 0xff00) | data;
 					break;
 
 				case LENR:      /* DMA length register LSB */
-					m_lenr = ( m_lenr & 0xFF00 ) | data;
+					m_lenr = (m_lenr & 0xff00) | data;
 					break;
 
 				case DVSSR:     /* Sprite attribute table LSB */
-					m_dvssr = ( m_dvssr & 0xFF00 ) | data;
-					m_dvssr_written = 1;
+					m_dvssr = (m_dvssr & 0xff00) | data;
+					m_dvssr_written = true;
 					break;
 			}
 			break;
 
 		case 0x03:  /* VDC data MSB */
-			switch ( m_register_index )
+			switch (m_register_index)
 			{
 				case MAWR:      /* memory address write register MSB */
-					m_mawr = ( m_mawr & 0x00FF ) | ( data << 8 );
+					m_mawr = (m_mawr & 0x00ff) | (data << 8);
 					break;
 
 				case MARR:      /* memory address read register MSB */
-					m_marr = ( m_marr & 0x00FF ) | ( data << 8 );
+					m_marr = (m_marr & 0x00ff) | (data << 8);
 					if(m_marr <= m_vram_mask)
-						m_vrr = m_vram[ m_marr ];
+						m_vrr = m_vram[m_marr];
 					else
 						m_vrr = 0;
 					break;
 
 				case VxR:       /* vram write data MSB */
-					m_vwr = ( m_vwr & 0x00FF ) | ( data << 8 );
+					m_vwr = (m_vwr & 0x00ff) | (data << 8);
 					// area 0x8000-0xffff is NOP and cannot be written to.
 					if(m_mawr <= m_vram_mask)
-						m_vram[ m_mawr ] = m_vwr;
-					m_mawr += vram_increments[ ( m_cr >> 11 ) & 3 ];
+						m_vram[m_mawr] = m_vwr;
+					m_mawr += vram_increments[(m_cr >> 11) & 3];
 					break;
 
 				case CR:        /* control register MSB */
-					m_cr = ( m_cr & 0x00FF ) | ( data << 8 );
+					m_cr = (m_cr & 0x00ff) | (data << 8);
 					break;
 
 				case RCR:       /* raster compare register MSB */
-					m_rcr = ( m_rcr & 0x00FF ) | ( ( data & 0x03 ) << 8 );
+					m_rcr = (m_rcr & 0x00ff) | ((data & 0x03) << 8);
 //printf("%s: RCR set to %03x\n", machine().describe_context().c_str(), m_rcr);
-//                  if ( m_raster_count == m_rcr && m_cr & 0x04 )
+//                  if (m_raster_count == m_rcr && m_cr & 0x04)
 //                  {
 //                      m_status |= HUC6270_RR;
-//                      m_irq_changed_cb( ASSERT_LINE );
+//                      m_irq_changed_cb(ASSERT_LINE);
 //                  }
 					break;
 
 				case BXR:       /* background x-scroll register MSB */
-					m_bxr = ( m_bxr & 0x00FF ) | ( ( data & 0x03 ) << 8 );
+					m_bxr = (m_bxr & 0x00ff) | ((data & 0x03) << 8);
 					break;
 
 				case BYR:       /* background y-scroll register MSB */
-					m_byr = ( m_byr & 0x00FF ) | ( ( data & 0x01 ) << 8 );
+					m_byr = (m_byr & 0x00ff) | ((data & 0x01) << 8);
 					m_byr_latched = m_byr;
 					break;
 
 				case MWR:       /* memory width register MSB */
-					m_mwr = ( m_mwr & 0x00FF ) | ( data << 8 );
+					m_mwr = (m_mwr & 0x00ff) | (data << 8);
 					break;
 
 				case HSR:       /* horizontal sync register MSB */
-					m_hsr = ( m_hsr & 0x00FF ) | ( data << 8 );
+					m_hsr = (m_hsr & 0x00ff) | (data << 8);
 					break;
 
 				case HDR:       /* horizontal display register MSB */
-					m_hdr = ( m_hdr & 0x00FF ) | ( data << 8 );
+					m_hdr = (m_hdr & 0x00ff) | (data << 8);
 					break;
 
 				case VPR:       /* vertical sync register MSB */
-					m_vpr = ( m_vpr & 0x00FF ) | ( data << 8 );
+					m_vpr = (m_vpr & 0x00ff) | (data << 8);
 					break;
 
 				case VDW:       /* vertical display register MSB */
-					m_vdw = ( m_vdw & 0x00FF ) | ( data << 8 );
+					m_vdw = (m_vdw & 0x00ff) | (data << 8);
 					break;
 
 				case VCR:       /* vertical display end position register MSB */
-					m_vcr = ( m_vcr & 0x00FF ) | ( data << 8 );
+					m_vcr = (m_vcr & 0x00ff) | (data << 8);
 					break;
 
 				case DCR:       /* DMA control register MSB */
-					m_dcr = ( m_dcr & 0x00FF ) | ( data << 8 );
+					m_dcr = (m_dcr & 0x00ff) | (data << 8);
 					break;
 
 				case SOUR:      /* DMA source address register MSB */
-					m_sour = ( m_sour & 0x00FF ) | ( data << 8 );
+					m_sour = (m_sour & 0x00ff) | (data << 8);
 					break;
 
 				case DESR:      /* DMA destination address register MSB */
-					m_desr = ( m_desr & 0x00FF ) | ( data << 8 );
+					m_desr = (m_desr & 0x00ff) | (data << 8);
 					break;
 
 				case LENR:      /* DMA length register MSB */
-					m_lenr = ( m_lenr & 0x00FF ) | ( data << 8 );
-					m_dma_enabled = 1;
+					m_lenr = (m_lenr & 0x00ff) | (data << 8);
+					m_dma_enabled = true;
 //logerror("DMA is not supported yet.\n");
 					break;
 
 				case DVSSR:     /* Sprite attribute table MSB */
-					m_dvssr = ( m_dvssr & 0x00FF ) | ( data << 8 );
-					m_dvssr_written = 1;
+					m_dvssr = (m_dvssr & 0x00ff) | (data << 8);
+					m_dvssr_written = true;
 					break;
 			}
 			break;
@@ -919,8 +916,8 @@ void huc6270_device::device_reset()
 	m_lenr = 0;
 	m_dvssr = 0;
 	m_status = 0;
-	m_vd_triggered = 0;
-	m_dvssr_written = 0;
+	m_vd_triggered = false;
+	m_dvssr_written = false;
 	m_satb_countdown = 0;
 	m_raster_count = 0x4000;
 	m_vert_to_go = 0;
@@ -928,9 +925,9 @@ void huc6270_device::device_reset()
 	m_horz_steps = 0;
 	m_horz_to_go = 0;
 	m_horz_state = h_state::HDS;
-	m_hsync = 0;
-	m_vsync = 0;
-	m_dma_enabled = 0;
+	m_hsync = false;
+	m_vsync = false;
+	m_dma_enabled = false;
 	m_byr_latched = 0;
 
 	memset(m_sat, 0, sizeof(m_sat));

--- a/src/devices/video/huc6270.h
+++ b/src/devices/video/huc6270.h
@@ -95,20 +95,20 @@ private:
 	uint8_t   m_status;
 
 	/* To keep track of external hsync and vsync signals */
-	int m_hsync;
-	int m_vsync;
+	bool m_hsync;
+	bool m_vsync;
 
 	/* internal variables */
 	v_state m_vert_state;
 	h_state m_horz_state;
-	int m_vd_triggered;
-	int m_vert_to_go;
-	int m_horz_to_go;
-	int m_horz_steps;
-	int m_raster_count;
-	int m_dvssr_written;
-	int m_satb_countdown;
-	int m_dma_enabled;
+	bool m_vd_triggered;
+	int32_t m_vert_to_go;
+	int32_t m_horz_to_go;
+	int32_t m_horz_steps;
+	int32_t m_raster_count;
+	bool m_dvssr_written;
+	int32_t m_satb_countdown;
+	bool m_dma_enabled;
 	uint16_t m_byr_latched;
 	uint16_t m_bxr_latched;
 	uint16_t m_bat_address;
@@ -120,8 +120,8 @@ private:
 	   from VRAM to this internal table.
 	*/
 	uint16_t m_sat[4*64];
-	int m_sprites_this_line;
-	int m_sprite_row_index;
+	int32_t m_sprites_this_line;
+	uint16_t m_sprite_row_index;
 	uint16_t  m_sprite_row[1024];
 	std::unique_ptr<uint16_t[]>  m_vram;
 	uint16_t  m_vram_mask;


### PR DESCRIPTION
Common:
- Fix typename for fix save state support
- Use lowercase hexadecimal values
- Make some variables constant
- Fix spacings

sound/c6280.cpp:
- Minor volume/LFO accuracy fixes
- Use reference instead pointer

video/huc6202.cpp:
- Fix typename inconsistency

video/huc6260.cpp:
- Suppress side effects for debugger reads
- Fix save state

video/huc6270.cpp:
- Suppress side effects for debugger reads

reference: https://github.com/tildearrow/furnace/issues/88#issuecomment-1052483501