### PR TITLE
current Plug+Play work for 0.276 (1 working, 8 non-working, 2 softlist, minor research)

### DIFF
--- a/hash/tvgogo.xml
+++ b/hash/tvgogo.xml
@@ -7,14 +7,15 @@ license:CC0-1.0
 
 Dumped | Dumped | Name       |Notes
 _(EU)__|__(US)__|____________|_____________________________________
-  Y*   |   Y    | 4 in 1     |No controller
-  Y    |   Y    | Whac-A-Mole|Hammer-shaped IR motion controller
-  Y    |   Y    | Basketball |Ball-shaped motion controller
-  Y    |        | Tennis     |Racquet-shaped IR motion controller
-       |   Y    | Dodgeball  |Motion controller
-       |   Y    | Baseball   |Baseball Bat shaped motion controller
-       |        | Paintball  |Gun controller
-       |        | Skateboard |Skateboard-shaped motion controller
+  Y*   |   Y    | 4 in 1       |No controller
+  Y    |   Y    | Whac-A-Mole  |Hammer-shaped IR motion controller
+  Y    |   Y    | Basketball   |Ball-shaped motion controller
+  Y    |        | Tennis       |Racquet-shaped IR motion controller
+       |   Y    | Dodgeball    |Motion controller
+       |   Y    | Baseball     |Baseball Bat shaped motion controller
+  Y    |        | Paintball    |Gun controller
+  Y    |        | Snowboarding |Snowboard-shaped motion controller	   
+       |        | Skateboard   |Skateboard-shaped motion controller
 
 
     The US carts do not appear to have a language selection screen
@@ -123,6 +124,28 @@ _(EU)__|__(US)__|____________|_____________________________________
 		<part name="cart" interface="tvgogo_cart">
 			<dataarea name="rom" size="0x400000">
 				<rom name="gogobasketball_m5m29gt320_001c0020.bin" size="0x400000" crc="dfdec0c6" sha1="7b3cc68f54b43e839beac8ed0806a005919f61b1"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="snowboar" supported="no">
+		<description>Snowboarding (Europe)</description>
+		<year>2005</year>
+		<publisher>Toyquest</publisher>
+		<part name="cart" interface="tvgogo_cart">
+			<dataarea name="rom" size="0x400000">
+				<rom name="gogotv_snowboarding.bin" size="0x400000" crc="a4472c30" sha1="5f9767cb488fc0627b4b3d1e38114db85ce40c6d"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="paintbal" supported="no">
+		<description>Paintball (Europe)</description>
+		<year>2005</year>
+		<publisher>Toyquest</publisher>
+		<part name="cart" interface="tvgogo_cart">
+			<dataarea name="rom" size="0x400000">
+				<rom name="gogotv_paintball.bin" size="0x400000" crc="b582384a" sha1="aaf793aeac5edef67f885f8e37bef2b431d8538e"/>
 			</dataarea>
 		</part>
 	</software>

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -34972,8 +34972,11 @@ nesm8b
 m82
 
 @source:nintendo/nes_sh6578.cpp
+6578cjz1
+6578cjz2
 bandgpad
 bandggcn
+bb6578
 cpatrolm
 dancmix3
 ts_handy11
@@ -35068,6 +35071,7 @@ cybar120
 dturbogt
 jl2050
 joypad65
+matetsl
 msiwwe
 msiwwea
 msidd
@@ -35093,7 +35097,9 @@ dgun2573a
 dgunl3201
 dgunl3202
 fcpocket
+matet220
 matet300
+myaass
 rminitv
 
 @source:nintendo/nes_vt369_vtunknown.cpp
@@ -35129,6 +35135,7 @@ lxcmcysp
 lxcmcysw
 lxcyber
 matet10
+matet100
 mc_cb280
 mc_hh210
 mog_m320
@@ -46334,6 +46341,7 @@ tvtchspd
 tvtchsb
 
 @source:tvgames/spg2xx_lexibook.cpp
+arcade3d
 lexizeus
 lexiseal
 discpal
@@ -46505,6 +46513,7 @@ gungunad
 gungunrv
 has_wamg
 hikara
+hippofr
 isinger
 jarajal
 jpopira

--- a/src/mame/nintendo/nes_sh6578.cpp
+++ b/src/mame/nintendo/nes_sh6578.cpp
@@ -59,6 +59,7 @@ protected:
 	virtual void video_start() override ATTR_COLD;
 
 	virtual void io_w(uint8_t data);
+	virtual uint8_t extio_r();
 	virtual void extio_w(uint8_t data);
 	bool m_isbanked;
 	required_memory_bank m_bank;
@@ -162,6 +163,18 @@ public:
 protected:
 	virtual void extio_w(uint8_t data) override;
 	virtual void machine_reset() override ATTR_COLD;
+};
+
+class nes_sh6578_cjz_state : public nes_sh6578_state
+{
+public:
+	nes_sh6578_cjz_state(const machine_config& mconfig, device_type type, const char* tag) :
+		nes_sh6578_state(mconfig, type, tag)
+	{ }
+
+protected:
+	// TODO, work out the I/O and anything else specific to this machine
+	virtual uint8_t extio_r() override { return machine().rand(); }
 };
 
 uint8_t nes_sh6578_state::bank_r(int bank, uint16_t offset)
@@ -428,6 +441,12 @@ void nes_sh6578_abl_wikid_state::io_w(uint8_t data)
 	}
 }
 
+uint8_t nes_sh6578_state::extio_r()
+{
+	logerror("%s: extio_r\n", machine().describe_context());
+	return 0x00;
+}
+
 void nes_sh6578_state::extio_w(uint8_t data)
 {
 	logerror("%s: extio_w : %02x\n", machine().describe_context(), data);
@@ -476,7 +495,7 @@ void nes_sh6578_state::nes_sh6578_map(address_map& map)
 	//4023 read/write joystick,mouse control
 	//4024 read - mouse port / write - mouse baud
 	//4025 write - Printer Port
-	map(0x4026, 0x4026).w(FUNC(nes_sh6578_state::extio_w));
+	map(0x4026, 0x4026).rw(FUNC(nes_sh6578_state::extio_r), FUNC(nes_sh6578_state::extio_w));
 	//4027 read/write - DAC data register
 
 	map(0x4031, 0x4031).w(FUNC(nes_sh6578_state::initial_startup_w));
@@ -666,6 +685,21 @@ ROM_START( cpatrolm )
 	ROM_LOAD( "citypatrolman.bin", 0x00000, 0x100000, CRC(4b139c67) SHA1(a5b03f472a94ee879f58bbff201b671fbf4f1ea1) )
 ROM_END
 
+ROM_START( bb6578 )
+	ROM_REGION( 0x80000, "maincpu", 0 )
+	ROM_LOAD( "tv game baseball.bin", 0x00000, 0x80000, CRC(dec862b2) SHA1(fb3d97ccde17ab6ead8eafb4e0aafb72fbb6674c) )
+ROM_END
+
+ROM_START( 6578cjz1 )
+	ROM_REGION( 0x100000, "maincpu", 0 )
+	ROM_LOAD( "tv game1.bin", 0x00000, 0x100000, CRC(161c4119) SHA1(b2ce91b070bcaba73c8a23e7067fe8ba41151a40) )
+ROM_END
+
+ROM_START( 6578cjz2 )
+	ROM_REGION( 0x100000, "maincpu", 0 )
+	ROM_LOAD( "tv game2.bin", 0x00000, 0x100000, CRC(cda1395c) SHA1(b0fdf1d3ebd9b7138ec907a0acdf0ea2d275c990) )
+ROM_END
+
 ROM_START( ablwikid )
 	ROM_REGION( 0x200000, "maincpu", 0 )
 	ROM_LOAD( "mx29f1610atc.u2", 0x00000, 0x200000, CRC(f16abf79) SHA1(aeccbb40d7fdd451ba8e5cca20464da2cf116461) )
@@ -743,6 +777,13 @@ CONS( 1997, bandgpad,    0,  0,  nes_sh6578,     nes_sh6578, nes_sh6578_state, i
 CONS( 1997, bandggcn,    0,  0,  nes_sh6578,     nes_sh6578, nes_sh6578_state, init_nes_sh6578, "Bandai", "Go! Go! Connie-chan! Asobou Mouse", MACHINE_NOT_WORKING )
 
 CONS( 200?, cpatrolm,    0,  0,  nes_sh6578_pal, nes_sh6578, nes_sh6578_state, init_nes_sh6578, "TimeTop", "City Patrolman", MACHINE_NOT_WORKING )
+
+CONS( 200?, bb6578,      0,  0,  nes_sh6578,     nes_sh6578, nes_sh6578_state, init_nes_sh6578, "DaiDaiXing Electronics", "TV Games Baseball (SH6578 hardware)", MACHINE_NOT_WORKING )
+
+// these don't boot much further than the timetop logo and a splash screen
+// "Super Knowledge Monopoly" is an English translation of the title
+CONS( 200?, 6578cjz1,     0,         0,  nes_sh6578,     nes_sh6578, nes_sh6578_cjz_state, init_nes_sh6578, "TimeTop", u8"Chāo Jí Zhī Shi Dà Fù Wēng (vol. 1)", MACHINE_NOT_WORKING )
+CONS( 200?, 6578cjz2,     6578cjz1,  0,  nes_sh6578,     nes_sh6578, nes_sh6578_cjz_state, init_nes_sh6578, "TimeTop", u8"Chāo Jí Zhī Shi Dà Fù Wēng (vol. 2)", MACHINE_NOT_WORKING )
 
 // Super Moto 3 https://youtu.be/DR5Y_r6C_qk - has JungleTac copyrights intact, and appears to have the SH6578 versions of the games
 

--- a/src/mame/nintendo/nes_vt09.cpp
+++ b/src/mame/nintendo/nes_vt09.cpp
@@ -542,6 +542,10 @@ ROM_START( wfmotor )
 	ROM_LOAD( "motorcycle.bin", 0x00000, 0x400000, CRC(978f12f0) SHA1(a0230cfe4398d3971d487ff5d4b7107341799424) )
 ROM_END
 
+ROM_START( matetsl )
+	ROM_REGION( 0x100000, "mainrom", 0 )
+	ROM_LOAD( "slurpeetetris_p25q40sh_856013.bin", 0x00000, 0x80300, CRC(d3b68de8) SHA1(97bcdfcd31bc536b626f9a369afe18de60a399da) )
+ROM_END
 
 } // anonymous namespace
 
@@ -589,6 +593,8 @@ CONS( 2006, vgtablet,  0, 0,  nes_vt09_4mb_rasterhack,  nes_vt09, nes_vt09_state
 CONS( 200?, jl2050,  0,  0,  nes_vt09_16mb,nes_vt09, nes_vt09_state, empty_init, "LexiBook / JungleTac / NiceCode",  "Cyber Console Center 200-in-1 (JL2050)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 
 // might be VT369 based, if so, move
-CONS( 2018, rbbrite,    0,  0,  nes_vt09_1mb, nes_vt09, nes_vt09_state, empty_init, "Coleco", "Rainbow Brite (mini-arcade)", MACHINE_NOT_WORKING )
+CONS( 2018, rbbrite,    0,  0,  nes_vt09_1mb,  nes_vt09, nes_vt09_state,      empty_init, "Coleco", "Rainbow Brite (mini-arcade)", MACHINE_NOT_WORKING )
 
-CONS( 200?, timetp25, 0,  0,  nes_vt09_cart, nes_vt09, nes_vt09_cart_state, empty_init, "Timetop", "Super Game 25-in-1 (GM-228)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
+CONS( 200?, timetp25,   0,  0,  nes_vt09_cart, nes_vt09, nes_vt09_cart_state, empty_init, "Timetop", "Super Game 25-in-1 (GM-228)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
+
+CONS( 2021, matetsl,   0,   0,  nes_vt09_1mb,  nes_vt09, nes_vt09_state,      empty_init, "dreamGEAR", "My Arcade Tetris (Slurpee)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS ) // no bonus games on this model

--- a/src/mame/nintendo/nes_vt32.cpp
+++ b/src/mame/nintendo/nes_vt32.cpp
@@ -361,6 +361,12 @@ ROM_START( dgunl3202 )
 	ROM_IGNORE(0x100)
 ROM_END
 
+ROM_START( myaass )
+	ROM_REGION( 0x2000000, "mainrom", 0 )
+	ROM_LOAD( "s29gl256.u2", 0x00000, 0x2000000, CRC(71a3298d) SHA1(5a2441ae5a8bf3e5efe9f22843ad2b8ef2df0f40) )
+ROM_END
+
+
 ROM_START( fcpocket )
 	ROM_REGION( 0x8000000, "mainrom", 0 )
 	ROM_LOAD( "s29gl01gp.bin", 0x00000, 0x8000000, CRC(8703b18a) SHA1(07943443294e80ca93f83181c8bdbf950b87c52f) ) // 2nd half = 0x00 (so 64MByte of content)
@@ -369,6 +375,12 @@ ROM_END
 ROM_START( matet300 )
 	ROM_REGION( 0x2000000, "mainrom", 0 )
 	ROM_LOAD( "tetris.bin", 0x00000, 0x2000000, CRC(73cbd40a) SHA1(5996c97cebd6cec42a0ba1fba9517adf1af00098) )
+ROM_END
+
+ROM_START( matet220 )
+	ROM_REGION( 0x2000000, "mainrom", 0 )
+	ROM_LOAD( "gamervtetris_s29gl128n10tfi01_0001227e.bin", 0x00000, 0x1000000, CRC(ac244e56) SHA1(89897f5f65f55a46bf0d6b5ca534ca31c79a0658) )
+	ROM_IGNORE(0x100)
 ROM_END
 
 } // anonymous namespace
@@ -387,7 +399,13 @@ CONS( 201?, dgunl3201, 0,  0,  nes_vt32_32mb, nes_vt32, nes_vt32_unk_state, empt
 CONS( 201?, dgunl3202, 0,  0,  nes_vt32_32mb, nes_vt32, nes_vt32_unk_state, empty_init, "dreamGEAR", "My Arcade Data East Classics - Pixel Player (308-in-1) (DGUNL-3202)", MACHINE_NOT_WORKING ) // from a US unit single 32Mbyte bank!
 // There was also a 34-in-1 version of the Data East Classics in a mini-cabinet, NOT running on VT hardware, but using proper arcade ROMs, that one is reportedly running an old MAME build on an ARM SoC (although some sources say FBA)
 
+// many of the games don't work or have scrambled graphics, it writes 0xc0 to vtfp_411e_encryption_state_w in such cases
+CONS( 201?, myaass,    0,  0,  nes_vt32_32mb, nes_vt32, nes_vt32_unk_state, empty_init, "dreamGEAR", "My Arcade All Star Stadium - Pocket Player (307-in-1)", MACHINE_NOT_WORKING )
+
 CONS( 2021, matet300,  0,         0,  nes_vt32_32mb,     nes_vt32, nes_vt32_unk_state, empty_init, "dreamGEAR", "My Arcade Tetris (DGUNL-7029, Go Gamer, with 300 bonus games)", MACHINE_NOT_WORKING )
+
+// some games (eg F22) are scrambled like in myaass
+CONS( 2021, matet220,  0,         0,  nes_vt32_32mb,     nes_vt32, nes_vt32_unk_state, empty_init, "dreamGEAR", "My Arcade Tetris (DGUNL-7030, Gamer V, with 220 bonus games)", MACHINE_NOT_WORKING )
 
 // Use DIP switch to select console or cartridge, as cartridge is fake and just toggles a GPIO
 CONS( 2016, fcpocket,  0,  0,  nes_vt32_4x16mb,   nes_vt32_fp, nes_vt32_unk_state, empty_init, "<unknown>",   "FC Pocket 600 in 1", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )  // has external banking (2x 32mbyte banks)

--- a/src/mame/nintendo/nes_vt32_soc.cpp
+++ b/src/mame/nintendo/nes_vt32_soc.cpp
@@ -46,13 +46,39 @@ uint8_t nes_vt32_soc_device::vtfp_4119_r()
 	return 0x00;
 }
 
-void nes_vt32_soc_device::vtfp_411e_w(uint8_t data)
+void nes_vt32_soc_device::vtfp_411e_encryption_state_w(uint8_t data)
 {
-	logerror("411e_w %02x\n", data);
+	logerror("%s: vtfp_411e_encryption_state_w %02x\n", machine().describe_context(), data);
 	if (data == 0x05)
-		downcast<rp2a03_vtscr &>(*m_maincpu).set_next_scramble(true);
+	{
+		downcast<rp2a03_vtscr&>(*m_maincpu).set_next_scramble(true);
+	}
 	else if (data == 0x00)
-		downcast<rp2a03_vtscr &>(*m_maincpu).set_next_scramble(false);
+	{
+		downcast<rp2a03_vtscr&>(*m_maincpu).set_next_scramble(false);
+	}
+	else if (data == 0xc0)
+	{
+		/* this seems to turn off the code encryption
+		   but turns on some kind of PPU data bitswap? myaass uses it on several games
+
+		in VRAM -> should be in VRAM
+		80 -> 08
+		40 -> 20
+		20- > 40
+		10 -> 01
+		08 -> 80
+		04 -> 02
+		02 -> 04
+		01 -> 10
+
+		it is unclear if this affects reads from ROM, or directly alters reads or
+		writes involving the VRAM
+
+		*/
+
+		downcast<rp2a03_vtscr&>(*m_maincpu).set_next_scramble(false);
+	}
 }
 
 void nes_vt32_soc_device::vtfp_4a00_w(uint8_t data)
@@ -103,7 +129,7 @@ void nes_vt32_soc_device::nes_vt_fp_map(address_map &map)
 	map(0x411d, 0x411d).w(FUNC(nes_vt32_soc_device::vtfp_411d_w));
 
 	map(0x4119, 0x4119).r(FUNC(nes_vt32_soc_device::vtfp_4119_r));
-	map(0x411e, 0x411e).w(FUNC(nes_vt32_soc_device::vtfp_411e_w)); // encryption toggle
+	map(0x411e, 0x411e).w(FUNC(nes_vt32_soc_device::vtfp_411e_encryption_state_w)); // encryption toggle
 
 	map(0x412c, 0x412c).w(FUNC(nes_vt32_soc_device::vtfp_412c_extbank_w)); // GPIO
 	map(0x412d, 0x412d).r(FUNC(nes_vt32_soc_device::vtfp_412d_r)); // GPIO

--- a/src/mame/nintendo/nes_vt32_soc.h
+++ b/src/mame/nintendo/nes_vt32_soc.h
@@ -30,7 +30,7 @@ protected:
 	void nes_vt_fp_map(address_map &map) ATTR_COLD;
 
 	uint8_t vtfp_4119_r();
-	void vtfp_411e_w(uint8_t data);
+	void vtfp_411e_encryption_state_w(uint8_t data);
 	void vtfp_412c_extbank_w(uint8_t data);
 	uint8_t vtfp_412d_r();
 	void vtfp_4242_w(uint8_t data);

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -938,6 +938,12 @@ ROM_START( matet10 )
 	ROM_IGNORE(0x300)
 ROM_END
 
+ROM_START( matet100 )
+	ROM_REGION( 0x2000000, "mainrom", 0 )
+	ROM_LOAD( "picotetris_s29gl064n90tfi04_0001227e.bin", 0x00000, 0x800000, CRC(7d9296f2) SHA1(0db5883028d14783d0abff1f7672e59534b0e513) )
+	ROM_IGNORE(0x100)
+ROM_END
+
 void nes_vt369_vtunknown_state::init_lxcmcypp()
 {
 	int size = memregion("mainrom")->bytes()/2;
@@ -1129,3 +1135,6 @@ CONS( 2021, unk128vt,   0,        0,  nes_vt369_vtunknown_unk_4mb, nes_vt369_vtu
 
 // uses a low res display like the above
 CONS( 2021, matet10,   0,        0,  nes_vt369_vtunknown_unk_2mb, nes_vt369_vtunknown, nes_vt369_vtunknown_unk_state, empty_init, "dreamGEAR", "My Arcade Tetris (DGUNL-7083, Pixel Pocket, with 10 bonus games)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+
+// unknown tech level, scrambled opcodes
+CONS( 2021, matet100,  0,        0,  nes_vt369_vtunknown_hh_8mb,  nes_vt369_vtunknown, nes_vt369_vtunknown_unk_state, empty_init, "dreamGEAR", "My Arcade Tetris (DGUNL-7027, Pico Player, with 100+ bonus games)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS ) // box says 100+ bonus games

--- a/src/mame/tvgames/spg2xx_lexibook.cpp
+++ b/src/mame/tvgames/spg2xx_lexibook.cpp
@@ -343,6 +343,11 @@ ROM_START( lexizeus )
 	ROM_LOAD16_WORD_SWAP( "lexibook1g900us.bin", 0x0000, 0x800000, CRC(c2370806) SHA1(cbb599c29c09b62b6a9951c724cd9fc496309cf9))
 ROM_END
 
+ROM_START( arcade3d )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "arcade3d.u3", 0x0000, 0x800000, CRC(130843a5) SHA1(f6494a34d162e702121cf71d384a4e57e0113498) )
+ROM_END
+
 ROM_START( vsplus )
 	ROM_REGION( 0x1000000, "maincpu", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "vsplus.bin", 0x0000, 0x1000000, CRC(2b13d2cc) SHA1(accae7606d83a313b8ec0232d2d67b63c9c617af) )
@@ -422,6 +427,8 @@ ROM_END
 // these all have the same ROM scrambling
 
 CONS( 200?, lexizeus,    0,     0,        lexizeus,     lexizeus, spg2xx_lexizeus_game_state, init_zeus, "Lexibook / JungleTac", "Zeus IG900 20-in-1 (US?)",          MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // bad sound and some corrupt bg tilemap entries in Tiger Rescue, verify ROM data (same game runs in Zone 60 without issue)
+
+CONS( 200?, arcade3d,    0,     0,        lexizeus,     lexiseal, spg2xx_lexizeus_game_state, init_zeus, "Millennium 2000 GmbH / JungleTac", "Millennium Arcade 3D 15-in-1",          MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // bad sound and some corrupt bg tilemap entries in Tiger Rescue, verify ROM data (same game runs in Zone 60 without issue)
 
 CONS( 200?, vsplus,      0,     0,        vsplus,     vsplus, spg2xx_vsplus_game_state, init_vsplus, "<unknown> / JungleTac", "Vs Power Plus 30-in-1",          MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 

--- a/src/mame/tvgames/xavix.cpp
+++ b/src/mame/tvgames/xavix.cpp
@@ -42,7 +42,7 @@
               Wildest computer robot "Daigander" (Korean version) /TAKARA/Korea                               -           -               -           -               -                   -                       -
     2001      Ping-pong(Chinese version) /Tenpon/China                                                        -           -               -           -               -                   -                       -
               Baseball Korean version /SONOKONG/Korea                                                         -           -               -           -               -                   -                       -
-    1999      ABC Jungle Fun Hippo /VTech/HK, USA, France                                                     -           -               -           -               -                   -                       -
+    1999      ABC Jungle Fun Hippo VTech/HK (USA and UK versions only, FR is dumped)                          -           -               -           -               -                   -                       -
 
     not dumped: no TSOP pads
     2003      Beyblade Arcade Challenge 5-in-1 /Hasbro/USA                                                    -           -               -           -               -                   -                       have
@@ -2795,6 +2795,10 @@ ROM_START( tak_beyb )
 	ROM_LOAD( "beyblade.u2", 0x000000, 0x200000, CRC(bcf6b3a7) SHA1(1c80f1241138b9d7816f1e5285ff8f3c61739c95) )
 ROM_END
 
+ROM_START( hippofr )
+	ROM_REGION( 0x200000, "bios", ROMREGION_ERASE00 )
+	ROM_LOAD( "54-6447-010.u3", 0x000000, 0x200000, CRC(1fb15364) SHA1(ff2bb54f7d6ccd3c83e722599c6f2b213bf35df8) )
+ROM_END
 
 /* XaviX hardware titles (1st Generation)
 
@@ -2807,6 +2811,13 @@ ROM_END
     only new opcodes are callf and retf?
 
 */
+
+// product code 80-32705.
+// Some sites say 1997, but 1999 is what SSD had listed, and seems more fitting.
+// Also exists as
+// 80-32703 Hippo's Alphabet Adventure (UK)
+// 80-32700 ABC Jungle Fun (US?)
+CONS( 1999, hippofr,  0,          0,  xavix_2mb, xavix,xavix_state,      init_xavix,    "VTech",             "Hippo: et la formidable aventure des lettres (France)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND ) // needs keyboard emulating
 
 // Let's!TVプレイCLASSIC タイトーノスタルジア1
 CONS( 2006, taitons1,  0,          0,  xavix_i2c_24lc04_2mb, nostalgia,xavix_i2c_state,      init_xavix,    "Bandai / SSD Company LTD / Taito",             "Let's! TV Play Classic - Taito Nostalgia 1 (Japan)", MACHINE_IMPERFECT_SOUND )

--- a/src/mame/tvgames/xavix_2002.cpp
+++ b/src/mame/tvgames/xavix_2002.cpp
@@ -192,6 +192,17 @@ static INPUT_PORTS_START( xavix_i2c )
 	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER("i2cmem", FUNC(i2cmem_device::read_sda))
 INPUT_PORTS_END
 
+static INPUT_PORTS_START( maxheart )
+	PORT_INCLUDE(xavix_i2c)
+
+	PORT_MODIFY("IN0")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_START1 )
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_START2 )
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_PLAYER(2) PORT_16WAY 
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT ) PORT_PLAYER(2) PORT_16WAY 
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_PLAYER(1) PORT_16WAY 
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT ) PORT_PLAYER(1) PORT_16WAY 
+INPUT_PORTS_END
 
 static INPUT_PORTS_START( epo_tfit )
 	PORT_INCLUDE(xavix)
@@ -912,7 +923,7 @@ CONS( 2004, epo_tfit, 0, 0, superxavix_i2c_24c04_4mb,    epo_tfit,   superxavix_
 CONS( 2010, epo_rgfj, 0, 0, superxavix_i2c_24c08,        xavix_i2c,  superxavix_i2c_state, init_xavix, "Epoch / SSD Company LTD", "Ishikawa Ryou Excite Golf (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 
 // Let's!TVプレイ ふたりはプリキュアMaxHeart マットでダンス MaxHeartにおどっちゃおう
-CONS( 2004, maxheart, 0, 0, superxavix_i2c_24c04_4mb,    xavix_i2c,   superxavix_i2c_state, init_xavix, "Bandai / SSD Company LTD",  "Let's! TV Play Futari wa PreCure MaxHeart Mat de Dance MaxHeart ni Odotchaou (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+CONS( 2004, maxheart, 0, 0, superxavix_i2c_24c04_4mb,    maxheart,   superxavix_i2c_state, init_xavix, "Bandai / SSD Company LTD",  "Let's! TV Play Futari wa PreCure MaxHeart Mat de Dance MaxHeart ni Odotchaou (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // どこでもドラえもん 日本旅行ゲームDX体感！どこドラグランプリ！
 CONS( 2004, epo_doka, 0, 0, xavix2002_4mb,               xavix,      superxavix_state,     init_epo_doka, "Epoch / SSD Company LTD",  "Doko Demo Doraemon Nihon Ryokou Game DX Taikan! Doko Dora Grand Prix! (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )


### PR DESCRIPTION
this is a squashed version of https://github.com/mamedev/mame/pull/13401 without the XaviX sound changes, as more has been discovered since then, which invalidates quite a lot that

- added controls to maxheart (game is playable, but shuts down into power saving after 15 minutes as if no buttons had been pressed) [David Haywood]
- started researching the banking scheme used by atgame40, while several games are now bootable the others appear to use video modes specific to this Genesis clone SoC so fail to display proper gameplay [David Haywood]

new WORKING machines
------------

Millennium Arcade 3D 15-in-1 [TeamEurope, David Haywood]

new NOT WORKING machines
------------

TV Games Baseball (SH6578 hardware) [Ankos, Kryzsiobal]
Chāo Jí Zhī Shi Dà Fù Wēng (vol. 1) [Ankos, Kryzsiobal]
Chāo Jí Zhī Shi Dà Fù Wēng (vol. 2) [Ankos, Kryzsiobal]
My Arcade Tetris (Slurpee) [Sean Riddle]
My Arcade Tetris (DGUNL-7030, Gamer V, with 220 bonus games) [Sean Riddle]
My Arcade Tetris (DGUNL-7027, Pico Player, with 100+ bonus games) [Sean Riddle]
My Arcade All Star Stadium - Pocket Player (307-in-1) [TeamEurope]
Hippo: et la formidable aventure des lettres (France) [TeamEurope, David Haywood]

new NOT WORKING software list entries
--------------

tvgogo.xml:
Snowboarding (Europe) [TeamEurope, David Haywood]
Paintball (Europe) [TeamEurope, David Haywood]
