### PR TITLE
fixing cpu for missing opcode

### DIFF
--- a/src/devices/cpu/sc61860/scdasm.cpp
+++ b/src/devices/cpu/sc61860/scdasm.cpp
@@ -66,40 +66,47 @@
 */
 
 const sc61860_disassembler::opcode sc61860_disassembler::table[]={
+//    00-0F / 0-3 4-7 8-B C-F
 	{ "LII",    Imm }, { "LIJ",     Imm }, { "LIA",     Imm }, { "LIB",     Imm },
 	{ "IX",     Imp }, { "DX",      Imp }, { "IY",      Imp }, { "DY",      Imp },
 	{ "MVW",    Imp }, { "EXW",     Imp }, { "MVB",     Imp }, { "EXB",     Imp },
 	{ "ADN",    Imp }, { "SBN",     Imp }, { "ADW",     Imp }, { "SBW",     Imp },
 
+//    10-1F / 0-3 4-7 8-B C-F
 	{ "LIDP",   ImmW}, { "LIDL",    Imm }, { "LIP",     Imm }, { "LIQ",     Imm },
 	{ "ADB",    Imp }, { "SBB",     Imp }, { "LIDP",    ImmW}, { "LIDL",    Imm },
 	{ "MVWD",   Imp }, { "EXWD",    Imp }, { "MVBD",    Imp }, { "EXBD",    Imp },
 	{ "SRW",    Imp }, { "SLW",     Imp }, { "FILM",    Imp }, { "FILD",    Imp },
 
-	{ "LDP",    Imp }, { "LPQ",     Imp }, { "LPR",     Imp }, { nullptr,         Ill },
+//    20-2F / 0-3 4-7 8-B C-F
+	{ "LDP",    Imp }, { "LPQ",     Imp }, { "LPR",     Imp }, { "CLRA", /* =RA undocumented  */   Imp },
 	{ "IXL",    Imp }, { "DXL",     Imp }, { "IYS",     Imp }, { "DYS",     Imp },
 	{ "JRNZP",  RelP}, { "JRNZM",   RelM}, { "JRNCP",   RelP}, { "JRNCM",   RelM},
 	{ "JRP",    RelP}, { "JRM",     RelM}, { nullptr,         Ill }, { "LOOP",    RelM},
 
+//    30-3F / 0-3 4-7 8-B C-F
 	{ "STP",    Imp }, { "STQ",     Imp }, { "STR",     Imp }, { nullptr,         Ill },
 	{ "PUSH",   Imp }, { "DATA",    Imp }, { nullptr,         Ill }, { "RTN",     Imp },
 	{ "JRZP",   RelP}, { "JRZM",    RelM}, { "JRCP",    RelP}, { "JRCM",    RelM},
 	{ nullptr,        Ill }, { nullptr,         Ill }, { nullptr,         Ill }, { nullptr,         Ill },
 
+//    40-4F / 0-3 4-7 8-B C-F
 	{ "INCI",   Imp }, { "DECI",    Imp }, { "INCA",    Imp }, { "DECA",    Imp },
 	{ "ADM",    Imp }, { "SBM",     Imp }, { "ANMA",    Imp }, { "ORMA",    Imp },
 	{ "INCK",   Imp }, { "DECK",    Imp }, { "INCV",    Imp }, { "DECV",    Imp },
-	{ "INA",    Imp }, { "NOPW",    Imp }, { "WAIT",    Imm }, { "IPXL"/*CDN, lxn*/,            Imp },
+	{ "INA",    Imp }, { "NOPW",    Imp }, { "WAIT",    Imm }, { "IPXL"/* =CDN, lxn*/,            Imp },
 
+//    50-5F / 0-3 4-7 8-B C-F
 	{ "INCP",   Imp }, { "DECP",    Imp }, { "STD",     Imp }, { "MVDM",    Imp },
 	{ "READM",/*mvmp*/  Imp }, { "MVMD",    Imp }, { "READ"/*ldpc*/,    Imp }, { "LDD",     Imp },
 	{ "SWP",    Imp }, { "LDM",     Imp }, { "SL",      Imp }, { "POP",     Imp },
 	{ nullptr,        Ill }, { "OUTA",    Imp }, { nullptr,         Ill }, { "OUTF",    Imp },
 
+//    60-5F / 0-3 4-7 8-B C-F
 	{ "ANIM",   Imm }, { "ORIM",    Imm }, { "TSIM",    Imm }, { "CPIM",    Imm },
 	{ "ANIA",   Imm }, { "ORIA",    Imm }, { "TSIA",    Imm }, { "CPIA",    Imm },
 	{ nullptr,        Ill }, { "ETC",     Etc }, { nullptr,         Ill }, { "TEST",    Imm },
-	{ nullptr,        Ill }, { nullptr,         Ill }, { nullptr,         Ill }, { "IPXH"/*CDN,lxp*/, Imp },
+	{ nullptr,        Ill }, { nullptr,         Ill }, { nullptr,         Ill }, { "IPXH"/* =CUP,lxp*/, Imp },
 
 	{ "ADIM",   Imm }, { "SBIM",    Imm }, { nullptr,         Ill }, { nullptr,         Ill },
 	{ "ADIA",   Imm }, { "SBIA",    Imm }, { nullptr,         Ill }, { nullptr,         Ill },
@@ -172,11 +179,11 @@ offs_t sc61860_disassembler::disassemble(std::ostream &stream, offs_t pc, const 
 				util::stream_format(stream,"%-6s%04x",table[oper].mnemonic, adr);
 				break;
 			case RelM:
-				adr=pc-opcodes.r8(pos++);
+				adr=pc-opcodes.r8(pos++)+1;
 				util::stream_format(stream,"%-6s%04x",table[oper].mnemonic, adr&0xffff);
 				break;
 			case RelP:
-				adr=pc+opcodes.r8(pos++);
+				adr=pc+opcodes.r8(pos++)+1;
 				util::stream_format(stream,"%-6s%04x",table[oper].mnemonic, adr&0xffff);
 				break;
 			case Ptc:

--- a/src/devices/cpu/sc61860/scops.hxx
+++ b/src/devices/cpu/sc61860/scops.hxx
@@ -740,9 +740,8 @@ void sc61860_device::sc61860_exchange_ext(int count)
 	}
 }
 
-// undocumented
-// only 1 opcode working in pc1403
-// both opcodes working in pc1350
+// Documented in PC1350_MachineLanguage: IPXL = CDN, IPXH = CUP
+// only 1 opcode working in pc1403 (IPXL, or IPXH?)
 void sc61860_device::sc61860_wait_x(int level)
 {
 	int c;

--- a/src/devices/cpu/sc61860/sctable.hxx
+++ b/src/devices/cpu/sc61860/sctable.hxx
@@ -42,6 +42,7 @@ void sc61860_device::sc61860_instruction()
 		case 32: sc61860_store_p();m_icount-=2;break;
 		case 33: sc61860_store_q();m_icount-=2;break;
 		case 34: sc61860_store_r();m_icount-=2;break;
+		case 35: sc61860_load_imm(A, 0);m_icount-=2/*?*/;break; // undocumented
 		case 36: sc61860_inc_load_dp_load();m_icount-=7;break;
 		case 37: sc61860_dec_load_dp_load();m_icount-=7;break;
 		case 38: sc61860_inc_load_dp_store();m_icount-=7;break;
@@ -78,14 +79,14 @@ void sc61860_device::sc61860_instruction()
 		case 76: sc61860_in_a();m_icount-=2;break;
 		case 77: /*nopw*/;m_icount-=2;break;
 		case 78: sc61860_wait();m_icount-=6;break;
-		case 79: sc61860_wait_x(false);m_icount-=1;break;
+		case 79: sc61860_wait_x(false);m_icount-=1;break; 
 		case 80: sc61860_inc_p();m_icount-=2;break;
 		case 81: sc61860_dec_p();m_icount-=2;break;
 		case 82: sc61860_store_ext(A);m_icount-=2;break;
 		case 83: sc61860_store_ext(m_p);m_icount-=2;break;
-		case 84: sc61860_load_imm(m_p, READ_OP());m_icount-=3/*?*/;break; // undocumented
+		case 84: sc61860_load_imm(m_p, READ_OP());m_icount-=3/*?*/;break; // PC1350: 0x54 READM undocumented
 		case 85: sc61860_load_ext(m_p);m_icount-=3;break;
-		case 86: sc61860_load_imm(m_p, READ_OP());m_icount-=3/*?*/;break; // undocumented
+		case 86: sc61860_load_imm(m_p, READ_OP());m_icount-=3/*?*/;break; // PC1350: 0x56 READ undocumented
 		case 87: sc61860_load_ext(A);m_icount-=3;break;
 		case 88: sc61860_swap();m_icount-=2;break;
 		case 89: sc61860_load();m_icount-=2;break;


### PR DESCRIPTION
Working on the Sharp PC-series emulaton, I noticed a bug in the SC61860 cpu, which was missing an opcode implementation.
It is a pointlike fix, and it has been tested by me locally for correctness.
See also https://www.youtube.com/watch?v=qsQMiYbir20, for an example of my activity on this device.