### PR TITLE
i960: don't preserve sign bit when shifting integer left

### DIFF
--- a/src/devices/cpu/i960/i960.cpp
+++ b/src/devices/cpu/i960/i960.cpp
@@ -1157,7 +1157,7 @@ void i960_cpu_device::execute_op(uint32_t opcode)
 				m_icount--;
 				t1 = get_1_ri(opcode);
 				t2 = get_2_ri(opcode);
-				set_ri(opcode, t1 >= 32 ? 0 : ((int32_t)t2) << t1);	// sign is not preserved
+				set_ri(opcode, t1 >= 32 ? 0 : ((int32_t)t2) << t1);
 				break;
 
 			default:

--- a/src/devices/cpu/i960/i960.cpp
+++ b/src/devices/cpu/i960/i960.cpp
@@ -1157,7 +1157,7 @@ void i960_cpu_device::execute_op(uint32_t opcode)
 				m_icount--;
 				t1 = get_1_ri(opcode);
 				t2 = get_2_ri(opcode);
-				set_ri(opcode, (t2 & 0x80000000) | (t1 >= 32 ? 0 : (t2<<t1) & 0x7fffffff)); // sign is preserved
+				set_ri(opcode, t1 >= 32 ? 0 : ((int32_t)t2) << t1);	// sign is not preserved
 				break;
 
 			default:


### PR DESCRIPTION
Commit 4cce14e changed the behavior of the shli instruction to preserve the sign bit, but I don't know of any other CPUs that do this nor is there any evidence in the [programmers reference manual](http://bitsavers.informatik.uni-stuttgart.de/components/intel/i960/80960KB_Programmers_Reference_Manual_Mar88.pdf) to suggest the i960 actually does this.

The i960 manual says that shifting left is supposed to be equivalent to multiplying by a power of 2, but if you multiply the signed integer 2,000,000,000 by 2 it overflows to negative, so the sign bit is not being preserved in this case.

If there is actual evidence that the i960 preserves the sign bit when shifting integers left I would be interested to see it, but until then I can only assume that commit 4cce14e is a regression; the opponent cars in Daytona USA have weird orientation issues that did not occur before this commit.