### PR TITLE
sinclair/spectrum.cpp: Improved performance by 50% avoiding memregion lookup in a critical path

### DIFF
--- a/src/mame/sinclair/spectrum.cpp
+++ b/src/mame/sinclair/spectrum.cpp
@@ -332,7 +332,7 @@ uint8_t spectrum_state::spectrum_rom_r(offs_t offset)
 {
 	return m_exp->romcs()
 		? m_exp->mreq_r(offset)
-		: memregion("maincpu")->base()[offset];
+		: m_rom[offset];
 }
 
 /*

--- a/src/mame/sinclair/spectrum.h
+++ b/src/mame/sinclair/spectrum.h
@@ -55,6 +55,7 @@ public:
 		m_maincpu(*this, "maincpu"),
 		m_screen(*this, "screen"),
 		m_cassette(*this, "cassette"),
+		m_rom(*this, "maincpu"),
 		m_ram(*this, RAM_TAG),
 		m_specmem(*this, "specmem"),
 		m_speaker(*this, "speaker"),
@@ -155,6 +156,7 @@ protected:
 	void spectrum_data(address_map &map) ATTR_COLD;
 
 	required_device<cassette_image_device> m_cassette;
+	required_region_ptr<u8> m_rom;
 	required_device<ram_device> m_ram;
 	optional_device<address_map_bank_device> m_specmem;
 	required_device<speaker_sound_device> m_speaker;

--- a/src/mame/sinclair/sprinter.cpp
+++ b/src/mame/sinclair/sprinter.cpp
@@ -223,7 +223,6 @@ private:
 	required_device<device_palette_interface> m_palette;
 	required_device<gfxdecode_device> m_gfxdecode;
 	tilemap_t *m_tilemap;
-	memory_region *m_rom;
 	memory_share_creator<u8> m_vram;
 	memory_share_creator<u8> m_fastram;
 	memory_bank_creator m_bank0_fastram;
@@ -1462,8 +1461,8 @@ void sprinter_state::machine_start()
 	m_beta->enable();
 
 	// reconfigure ROMs
-	m_rom = memregion("maincpu");
-	m_bank_rom[0]->configure_entries(0, m_rom->bytes() / 0x4000, m_rom->base(), 0x4000);
+	memory_region *rom = memregion("maincpu");
+	m_bank_rom[0]->configure_entries(0, rom->bytes() / 0x4000, rom->base(), 0x4000);
 	m_bank0_fastram->configure_entries(0, m_fastram.bytes() / 0x4000, m_fastram.target(), 0x4000);
 	for (auto i = 0; i < 4; i++)
 		m_bank_ram[i]->configure_entries(0, m_ram->size() / 0x4000, m_ram->pointer(), 0x4000);


### PR DESCRIPTION
```
~/workspace/mame (spectrum-perf*) » ./mame spectrum -bench 300
Average speed: 2199.09% (299 seconds)
-----------------------------------------------------------------------------------------------
~/workspace/mame (spectrum-perf*) » ./mame spectrum -bench 300
Average speed: 3265.35% (299 seconds)

```