### PR TITLE
scsp: improve handling of MIDI interrupts

### DIFF
--- a/src/devices/sound/scsp.h
+++ b/src/devices/sound/scsp.h
@@ -37,6 +37,7 @@ public:
 	// MIDI I/O access (used for comms on Model 2/3)
 	void midi_in(u8 data);
 	u16 midi_out_r();
+	void midi_out_w(u8 data);
 
 protected:
 	// device-level overrides
@@ -118,6 +119,7 @@ private:
 	u32 m_IrqTimBC;
 	u32 m_IrqMidi;
 
+	u8 m_MidiOutStack[32];
 	u8 m_MidiOutW, m_MidiOutR;
 	u8 m_MidiStack[32];
 	u8 m_MidiW, m_MidiR;


### PR DESCRIPTION
The previous code would immediately clear the SCIPD register (m_udata.data[0x20/2]) when firing a MIDI interrupt, which would cause issues if a timer interrupt fired before reading from the MIDI input FIFO buffer; the SCIPD register would be set up to fire another MIDI interrupt and the SCSP would end up reading garbage from the "empty" input FIFO. The new code clears the SCIPD register only when clearing the interrupt, preventing it from firing again if the input FIFO is empty.

Also the MIDI output FIFO buffer is separate from the MIDI input FIFO buffer; the former is currently not hooked up to either the Model 2 or Model 3 drivers.