### PR TITLE
machine/rc, paia/fatman: Generalizing RC circuit device.

### DIFF
--- a/scripts/src/machine.lua
+++ b/scripts/src/machine.lua
@@ -3012,6 +3012,18 @@ end
 
 ---------------------------------------------------
 --
+--@src/devices/machine/rescap.h,MACHINES["RC"] = true
+---------------------------------------------------
+
+if (MACHINES["RC"]~=null) then
+	files {
+		MAME_DIR .. "src/devices/machine/rc.cpp",
+		MAME_DIR .. "src/devices/machine/rc.h",
+	}
+end
+
+---------------------------------------------------
+--
 --@src/devices/machine/rf5c296.h,MACHINES["RF5C296"] = true
 ---------------------------------------------------
 

--- a/src/devices/machine/rc.cpp
+++ b/src/devices/machine/rc.cpp
@@ -1,0 +1,85 @@
+// license:BSD-3-Clause
+// copyright-holders:m1macrophage
+
+#include "emu.h"
+#include "rc.h"
+#include "machine/rescap.h"
+
+DEFINE_DEVICE_TYPE(RC_CIRCUIT, rc_circuit_device, "rc_circuit", "DC RC circuit")
+
+rc_circuit_device::rc_circuit_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, RC_CIRCUIT, tag, owner, clock)
+	// Initialize to a valid state.
+	, m_r(RES_M(1))
+	, m_c(CAP_U(1))
+	, m_rc_inv(1.0F / (m_r * m_c))
+	, m_v_start(0)
+	, m_v_end(0)
+{
+}
+
+rc_circuit_device &rc_circuit_device::set_r(float r)
+{
+	assert(r > 0);
+	set_target_v(m_v_end);  // Snapshots voltage, using the old `r` value.
+	m_r = r;
+	m_rc_inv = 1.0F / (m_r * m_c);
+	return *this;
+}
+
+rc_circuit_device &rc_circuit_device::set_c(float c)
+{
+	assert(c > 0);
+	set_target_v(m_v_end);  // Snapshots voltage, using the old `c` value.
+	m_c = c;
+	m_rc_inv = 1.0F / (m_r * m_c);
+	return *this;
+}
+
+rc_circuit_device &rc_circuit_device::set_target_v(float v)
+{
+	if (has_running_machine())
+	{
+		const attotime now = machine().time();
+		m_v_start = get_v(now);
+		m_v_end = v;
+		m_t_start = now;
+	}
+	else
+	{
+		m_v_start = 0;
+		m_v_end = v;
+		m_t_start = attotime::zero;
+	}
+	return *this;
+}
+
+rc_circuit_device &rc_circuit_device::set_instant_v(float v)
+{
+	m_v_start = v;
+	m_v_end = v;
+	m_t_start = has_running_machine() ? machine().time() : attotime::zero;
+	return *this;
+}
+
+float rc_circuit_device::get_v(const attotime &t) const
+{
+	assert(t >= m_t_start);
+	const float delta_t = float((t - m_t_start).as_double());
+	return m_v_start + (m_v_end - m_v_start) * (1.0F - expf(-delta_t * m_rc_inv));
+}
+
+float rc_circuit_device::get_v() const
+{
+	return get_v(machine().time());
+}
+
+void rc_circuit_device::device_start()
+{
+	save_item(NAME(m_r));
+	save_item(NAME(m_c));
+	save_item(NAME(m_rc_inv));
+	save_item(NAME(m_v_start));
+	save_item(NAME(m_v_end));
+	save_item(NAME(m_t_start));
+}

--- a/src/devices/machine/rc.h
+++ b/src/devices/machine/rc.h
@@ -1,0 +1,50 @@
+// license:BSD-3-Clause
+// copyright-holders:m1macrophage
+#ifndef MAME_MACHINE_RC_H
+#define MAME_MACHINE_RC_H
+
+#pragma once
+
+// Emulates a DC RC circuit with an (optionally) variable resistance and
+// capacitance.
+// Can be used to emulate the state of enveloper generators, timing circuits, etc.
+// This is not a simulation. It just uses the standard RC equations to calculate
+// voltage at a specific time.
+// This device is not meant for audio stream processing. See FILTER_RC for that.
+class rc_circuit_device : public device_t
+{
+public:
+	rc_circuit_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0) ATTR_COLD;
+
+	// These setters can be used during both: configuration and normal operation.
+	// `r` and `c` must be > 0. To instantly set the capacitor's voltage to
+	// a specific value, use set_instant_v().
+	rc_circuit_device &set_r(float r);
+	rc_circuit_device &set_c(float c);
+	// Sets target voltage to (dis)charge towards.
+	rc_circuit_device &set_target_v(float v);
+	// Instantly sets voltage to the provided value.
+	rc_circuit_device &set_instant_v(float v);
+
+	float get_r() const { return m_r; }
+	float get_c() const { return m_c; }
+	float get_target_v() const { return m_v_end; }
+
+	float get_v(const attotime &t) const;
+	float get_v() const;
+
+protected:
+	void device_start() override ATTR_COLD;
+
+private:
+	float m_r;
+	float m_c;
+	float m_rc_inv;
+	float m_v_start;
+	float m_v_end;
+	attotime m_t_start;
+};
+
+DECLARE_DEVICE_TYPE(RC_CIRCUIT, rc_circuit_device)
+
+#endif // MAME_MACHINE_RC_H

--- a/src/mame/paia/fatman.cpp
+++ b/src/mame/paia/fatman.cpp
@@ -55,6 +55,7 @@ until a restart or reset (F3).
 #include "cpu/mcs51/mcs51.h"
 #include "bus/midi/midiinport.h"
 #include "bus/midi/midioutport.h"
+#include "machine/rc.h"
 #include "machine/rescap.h"
 #include "video/pwm.h"
 
@@ -70,67 +71,6 @@ until a restart or reset (F3).
 //#define LOG_OUTPUT_FUNC osd_printf_info
 
 #include "logmacro.h"
-
-// Emulates a (DC) RC circuit with a variable resistance. Useful for emulating
-// envelope generators. This is not a simulation, just uses the standard RC
-// equations to return voltage at a specific time.
-class fatman_rc_network_state_device : public device_t
-{
-public:
-	fatman_rc_network_state_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0) ATTR_COLD;
-
-	void set_c(float c);
-	void reset(float v_target, float r, const attotime &t);
-	float get_v(const attotime &t) const;
-
-protected:
-	void device_start() override ATTR_COLD;
-
-private:
-	// Initialize to a slow (large RC) but valid charging state.
-	float m_c = CAP_U(1000);
-	float m_r = RES_M(100);
-	float m_v_start = 0;
-	float m_v_end = 1;
-	attotime m_start_t;
-};
-
-DEFINE_DEVICE_TYPE(FATMAN_RC_NETWORK_STATE, fatman_rc_network_state_device, "fatman_rc_network_state", "Fatman EG RC network");
-
-fatman_rc_network_state_device::fatman_rc_network_state_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: device_t(mconfig, FATMAN_RC_NETWORK_STATE, tag, owner, clock)
-{
-}
-
-void fatman_rc_network_state_device::device_start()
-{
-	save_item(NAME(m_c));
-	save_item(NAME(m_r));
-	save_item(NAME(m_v_start));
-	save_item(NAME(m_v_end));
-	save_item(NAME(m_start_t));
-}
-
-void fatman_rc_network_state_device::set_c(float c)
-{
-	m_c = c;
-}
-
-void fatman_rc_network_state_device::reset(float v_target, float r, const attotime &t)
-{
-	m_v_start = get_v(t);
-	m_v_end = v_target;
-	m_r = r;
-	m_start_t = t;
-}
-
-float fatman_rc_network_state_device::get_v(const attotime &t) const
-{
-	assert(t >= m_start_t);
-	const attotime delta_t = t - m_start_t;
-	return m_v_start + (m_v_end - m_v_start) * (1.0F - expf(-delta_t.as_double() / (m_r * m_c)));
-}
-
 
 namespace {
 
@@ -189,8 +129,8 @@ private:
 	void external_memory_map(address_map &map) ATTR_COLD;
 
 	required_device<mcs51_cpu_device> m_maincpu;
-	required_device<fatman_rc_network_state_device> m_vca_adsr_state;
-	required_device<fatman_rc_network_state_device> m_vcf_ar_state;
+	required_device<rc_circuit_device> m_vca_adsr_state;
+	required_device<rc_circuit_device> m_vcf_ar_state;
 	required_device<pwm_display_device> m_midi_led_pwm;  // D2
 	output_finder<> m_gate_led;  // D13
 	required_ioport m_dsw_io;
@@ -265,8 +205,7 @@ void fatman_state::midi_rxd_w(int state)
 
 int fatman_state::vca_adsr_attack_r() const
 {
-	const float v = m_vca_adsr_state->get_v(machine().time());
-	return (v >= V_EG_COMP) ? 1 : 0;
+	return (m_vca_adsr_state->get_v() >= V_EG_COMP) ? 1 : 0;
 }
 
 void fatman_state::vca_adsr_decay_w(int state)
@@ -303,15 +242,14 @@ void fatman_state::update_vca_adsr_state()
 	if (m_vca_adsr_decay && m_vca_adsr_release)  // Release.
 	{
 		const float r96 = m_vca_release_pot->read() * POT_R96 / 100.0F;
-		m_vca_adsr_state->reset(V_GND, r96 + R95, machine().time());
+		m_vca_adsr_state->set_r(r96 + R95).set_target_v(V_GND);
 	}
 	else if (m_vca_adsr_decay)  // Decay.
 	{
-		const attotime now = machine().time();
 		const float sustain_v = V_PLUS * m_vca_sustain_pot->read() / 100.0F;
-		const float current_v = m_vca_adsr_state->get_v(now);
+		const float current_v = m_vca_adsr_state->get_v();
 		const float r92 = m_vca_decay_pot->read() * POT_R92 / 100.0F;
-		m_vca_adsr_state->reset(std::min(sustain_v, current_v), r92 + R91, now);
+		m_vca_adsr_state->set_r(r92 + R91).set_target_v(std::min(sustain_v, current_v));
 	}
 	else if (m_vca_adsr_release)  // "Invalid" state.
 	{
@@ -324,12 +262,12 @@ void fatman_state::update_vca_adsr_state()
 		const float r_release = r96 + R95;
 		const float target_v = V_PLUS * RES_VOLTAGE_DIVIDER(r_attack, r_release);
 		const float effective_r = RES_2_PARALLEL(r_attack, r_release);
-		m_vca_adsr_state->reset(target_v, effective_r, machine().time());
+		m_vca_adsr_state->set_r(effective_r).set_target_v(target_v);
 	}
 	else // Attack.
 	{
 		const float r94 = m_vca_attack_pot->read() * POT_R94 / 100.0F;
-		m_vca_adsr_state->reset(V_PLUS, POT_R90 + R93 + r94, machine().time());
+		m_vca_adsr_state->set_r(POT_R90 + R93 + r94).set_target_v(V_PLUS);
 	}
 }
 
@@ -343,8 +281,7 @@ int fatman_state::vcf_ar_attack_r() const
 		// completed, and it doesn't start the EG release.
 		return 0;
 	}
-	const float v = m_vcf_ar_state->get_v(machine().time());
-	return (v >= V_EG_COMP) ? 1 : 0;
+	return (m_vcf_ar_state->get_v() >= V_EG_COMP) ? 1 : 0;
 }
 
 void fatman_state::vcf_ar_release_w(int state)
@@ -359,12 +296,12 @@ void fatman_state::vcf_ar_release_w(int state)
 	if (m_vcf_ar_release)  // Start release.
 	{
 		const float r82 = m_vcf_release_pot->read() * POT_R82 / 100.0;
-		m_vcf_ar_state->reset(V_GND, r82 + R81, machine().time());
+		m_vcf_ar_state->set_r(r82 + R81).set_target_v(V_GND);
 	}
 	else // Start attack.
 	{
 		const float r84 = m_vcf_attack_pot->read() * POT_R84 / 100.0;
-		m_vcf_ar_state->reset(V_PLUS, R80 + R83 + r84, machine().time());
+		m_vcf_ar_state->set_r(R80 + R83 + r84).set_target_v(V_PLUS);
 	}
 }
 
@@ -505,8 +442,8 @@ void fatman_state::fatman(machine_config &config)
 	m_maincpu->port_out_cb<3>().set(FUNC(fatman_state::vcf_ar_release_w)).bit(1);
 	m_maincpu->port_out_cb<3>().append(FUNC(fatman_state::cv_mux_w)).mask(0x30);  // Bits 4, 5.
 
-	FATMAN_RC_NETWORK_STATE(config, m_vca_adsr_state).set_c(C19);
-	FATMAN_RC_NETWORK_STATE(config, m_vcf_ar_state).set_c(C22);
+	RC_CIRCUIT(config, m_vca_adsr_state).set_c(C19);
+	RC_CIRCUIT(config, m_vcf_ar_state).set_c(C22);
 
 	midi_port_device &midi_in(MIDI_PORT(config, "mdin", midiin_slot, "midiin"));
 	MIDI_PORT(config, "mdthru", midiout_slot, "midiout");


### PR DESCRIPTION
Generalized and moved the RC circuit device from `paia/fatman.cpp` to `machines/rc.cpp`.

This will be needed in `moog/source.cpp`. It will also be the core building block for the envelope generators in the LinnDrum and DMX.

Filename and class name suggestions welcome. I originally planned to add this in` rescap.h/.cpp` (the device is literally a resistor and a capacitor, after all :)), but `rescap.h` is included in a lot of places. Maybe the new device can move there after it matures? Open to suggestions, of course.
