### PR TITLE
Implemented VA EG (Envelope Generator) and VCA (Voltage Controlled Amplifier) sound devices.

### DIFF
--- a/scripts/src/sound.lua
+++ b/scripts/src/sound.lua
@@ -1166,6 +1166,29 @@ if (SOUNDS["UPD7752"]~=null) then
 	}
 end
 
+--------------------------------------------------
+-- Virtual analog envelope generators (EGs)
+--@src/devices/sound/va_eg.h,SOUNDS["VA_EG"] = true
+--------------------------------------------------
+
+if (SOUNDS["VA_EG"]~=null) then
+	files {
+		MAME_DIR .. "src/devices/sound/va_eg.cpp",
+		MAME_DIR .. "src/devices/sound/va_eg.h",
+	}
+end
+
+--------------------------------------------------
+-- Virtual analog voltage-controlled amplifiers (VCAs)
+--@src/devices/sound/va_vca.h,SOUNDS["VA_VCA"] = true
+--------------------------------------------------
+
+if (SOUNDS["VA_VCA"]~=null) then
+	files {
+		MAME_DIR .. "src/devices/sound/va_vca.cpp",
+		MAME_DIR .. "src/devices/sound/va_vca.h",
+	}
+end
 
 ---------------------------------------------------
 -- VLM5030 speech synthesizer

--- a/src/devices/sound/va_eg.cpp
+++ b/src/devices/sound/va_eg.cpp
@@ -1,0 +1,129 @@
+// license:BSD-3-Clause
+// copyright-holders:m1macrophage
+
+#include "emu.h"
+#include "va_eg.h"
+#include "machine/rescap.h"
+
+DEFINE_DEVICE_TYPE(VA_RC_EG, va_rc_eg_device, "va_rc_eg", "RC-based Envelope Generator")
+
+va_rc_eg_device::va_rc_eg_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, VA_RC_EG, tag, owner, clock)
+	, device_sound_interface(mconfig, *this)
+	, m_stream(nullptr)
+	// Initialize to a valid state.
+	, m_r(RES_M(1))
+	, m_c(CAP_U(1))
+	, m_rc_inv(1.0F / (m_r * m_c))
+	, m_v_start(0)
+	, m_v_end(0)
+{
+}
+
+va_rc_eg_device &va_rc_eg_device::set_r(float r)
+{
+	assert(r > 0);
+	if (r == m_r)
+		return *this;
+	if (m_stream != nullptr)
+		m_stream->update();
+
+	set_target_v(m_v_end);  // Snapshots voltage, using the old `r` value.
+	m_r = r;
+	m_rc_inv = 1.0F / (m_r * m_c);
+	return *this;
+}
+
+va_rc_eg_device &va_rc_eg_device::set_c(float c)
+{
+	assert(c > 0);
+	if (c == m_c)
+		return *this;
+	if (m_stream != nullptr)
+		m_stream->update();
+
+	set_target_v(m_v_end);  // Snapshots voltage, using the old `c` value.
+	m_c = c;
+	m_rc_inv = 1.0F / (m_r * m_c);
+	return *this;
+}
+
+va_rc_eg_device &va_rc_eg_device::set_target_v(float v)
+{
+	if (v == m_v_end)
+		return *this;
+	if (m_stream != nullptr)
+		m_stream->update();
+
+	if (has_running_machine())
+	{
+		const attotime now = machine().time();
+		m_v_start = get_v(now);
+		m_v_end = v;
+		m_t_start = now;
+	}
+	else
+	{
+		m_v_start = 0;
+		m_v_end = v;
+		m_t_start = attotime::zero;
+	}
+	return *this;
+}
+
+va_rc_eg_device &va_rc_eg_device::set_instant_v(float v)
+{
+	if (m_stream != nullptr)
+		m_stream->update();
+
+	m_v_start = v;
+	m_v_end = v;
+	m_t_start = has_running_machine() ? machine().time() : attotime::zero;
+	return *this;
+}
+
+float va_rc_eg_device::get_v(const attotime &t) const
+{
+	assert(t >= m_t_start);
+	const float delta_t = float((t - m_t_start).as_double());
+	return m_v_start + (m_v_end - m_v_start) * (1.0F - expf(-delta_t * m_rc_inv));
+}
+
+float va_rc_eg_device::get_v() const
+{
+	return get_v(machine().time());
+}
+
+void va_rc_eg_device::device_start()
+{
+	m_stream = stream_alloc(0, 1, SAMPLE_RATE_OUTPUT_ADAPTIVE);
+	save_item(NAME(m_r));
+	save_item(NAME(m_c));
+	save_item(NAME(m_rc_inv));
+	save_item(NAME(m_v_start));
+	save_item(NAME(m_v_end));
+	save_item(NAME(m_t_start));
+}
+
+void va_rc_eg_device::sound_stream_update(sound_stream &stream, const std::vector<read_stream_view> &inputs, std::vector<write_stream_view> &outputs)
+{
+	// The envelope stage will be considered done once the voltage reaches
+	// within MIN_DELTA of the target.
+	static constexpr const float MIN_DELTA = 0.0001F;
+
+	assert(inputs.size() == 0 && outputs.size() == 1);
+	write_stream_view &out = outputs[0];
+	attotime t = out.start_time();
+
+	if (fabsf(get_v(t) - m_v_end) < MIN_DELTA)
+	{
+		// Avoid expensive get_v() calls if the envelope stage has completed.
+		out.fill(m_v_end);
+		return;
+	}
+
+	const int n = out.samples();
+	const attotime dt = out.sample_period();
+	for (int i = 0; i < n; ++i, t += dt)
+		out.put(i, get_v(t));
+}

--- a/src/devices/sound/va_eg.h
+++ b/src/devices/sound/va_eg.h
@@ -15,7 +15,7 @@
 // - Machine configuration: rc_eg.set_c(C);
 // - Start attack:          rc_eg.set_r(attack_r).set_target_v(max_v);
 // - Start decay:           rc_eg.set_r(decay_r).set_target_v(sustain_v);
-// - Start release:         rc_eg.set_r(realse_r).set_target_v(0);
+// - Start release:         rc_eg.set_r(release_r).set_target_v(0);
 //
 class va_rc_eg_device : public device_t, public device_sound_interface
 {

--- a/src/devices/sound/va_eg.h
+++ b/src/devices/sound/va_eg.h
@@ -1,0 +1,47 @@
+// license:BSD-3-Clause
+// copyright-holders:m1macrophage
+
+#ifndef MAME_SOUND_VA_EG_H
+#define MAME_SOUND_VA_EG_H
+
+#pragma once
+
+// Building block for emulating envelope generators (EGs) based on RC circuits.
+// The voltage is published to as a sound stream, and is also available by
+// calling `get_v()`.
+class va_rc_eg_device : public device_t, public device_sound_interface
+{
+public:
+	va_rc_eg_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0) ATTR_COLD;
+
+	// These setters can be used during both: configuration and normal operation.
+	// `r` and `c` must be > 0. To instantly set the capacitor's voltage to
+	// a specific value, use set_instant_v().
+	va_rc_eg_device &set_r(float r);
+	va_rc_eg_device &set_c(float v);
+	// Sets target voltage to (dis)charge towards.
+	va_rc_eg_device &set_target_v(float v);
+	// Sets the voltage to the given value, instantly.
+	va_rc_eg_device &set_instant_v(float v);
+
+	float get_v(const attotime &t) const;
+	float get_v() const;  // Get voltage at the machine's current time.
+
+protected:
+	void device_start() override ATTR_COLD;
+	void sound_stream_update(sound_stream &stream, const std::vector<read_stream_view> &inputs, std::vector<write_stream_view> &outputs) override;
+
+private:
+	sound_stream *m_stream;
+
+	float m_r;
+	float m_c;
+	float m_rc_inv;
+	float m_v_start;
+	float m_v_end;
+	attotime m_t_start;
+};
+
+DECLARE_DEVICE_TYPE(VA_RC_EG, va_rc_eg_device)
+
+#endif  // MAME_SOUND_VA_EG_H

--- a/src/devices/sound/va_eg.h
+++ b/src/devices/sound/va_eg.h
@@ -7,7 +7,7 @@
 #pragma once
 
 // Building block for emulating envelope generators (EGs) based on RC circuits.
-// The voltage is published to as a sound stream, and is also available by
+// The voltage is published as a sound stream, and is also available by
 // calling `get_v()`.
 class va_rc_eg_device : public device_t, public device_sound_interface
 {

--- a/src/devices/sound/va_eg.h
+++ b/src/devices/sound/va_eg.h
@@ -6,9 +6,17 @@
 
 #pragma once
 
-// Building block for emulating envelope generators (EGs) based on RC circuits.
-// The voltage is published as a sound stream, and is also available by
-// calling `get_v()`.
+// Building block for emulating envelope generators (EGs) based on a single RC
+// circuit. The controlling source sets a target voltage and the device
+// interpolates up or down to it through a RC circuit. The voltage is published
+// as a sound stream and also available from `get_v()`.
+//
+// For example, emulating a CPU-controlled ADSR EG will look something like:
+// - Machine configuration: rc_eg.set_c(C);
+// - Start attack:          rc_eg.set_r(attack_r).set_target_v(max_v);
+// - Start decay:           rc_eg.set_r(decay_r).set_target_v(sustain_v);
+// - Start release:         rc_eg.set_r(realse_r).set_target_v(0);
+//
 class va_rc_eg_device : public device_t, public device_sound_interface
 {
 public:
@@ -19,8 +27,10 @@ public:
 	// a specific value, use set_instant_v().
 	va_rc_eg_device &set_r(float r);
 	va_rc_eg_device &set_c(float v);
+
 	// Sets target voltage to (dis)charge towards.
 	va_rc_eg_device &set_target_v(float v);
+
 	// Sets the voltage to the given value, instantly.
 	va_rc_eg_device &set_instant_v(float v);
 

--- a/src/devices/sound/va_vca.cpp
+++ b/src/devices/sound/va_vca.cpp
@@ -6,6 +6,9 @@
 
 #include <cfloat>
 
+// Default max peak-to-peak voltage for the CV input.
+static constexpr const float DEFAULT_MAX_VPP = 100;
+
 DEFINE_DEVICE_TYPE(VA_VCA, va_vca_device, "va_vca", "Voltage Controlled Amplifier")
 
 va_vca_device::va_vca_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
@@ -13,8 +16,8 @@ va_vca_device::va_vca_device(const machine_config &mconfig, const char *tag, dev
 	, device_sound_interface(mconfig, *this)
 	, m_stream(nullptr)
 	, m_has_cv_stream(false)
-	, m_min_cv(-FLT_MAX)
-	, m_max_cv(FLT_MAX)
+	, m_min_cv(-DEFAULT_MAX_VPP)
+	, m_max_cv(DEFAULT_MAX_VPP)
 	, m_cv_scale(1.0F)
 	, m_fixed_gain(1.0F)
 {

--- a/src/devices/sound/va_vca.cpp
+++ b/src/devices/sound/va_vca.cpp
@@ -1,0 +1,73 @@
+// license:BSD-3-Clause
+// copyright-holders:m1macrophage
+
+#include "emu.h"
+#include "va_vca.h"
+
+#include <cfloat>
+
+DEFINE_DEVICE_TYPE(VA_VCA, va_vca_device, "va_vca", "Voltage Controlled Amplifier")
+
+va_vca_device::va_vca_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, VA_VCA, tag, owner, clock)
+	, device_sound_interface(mconfig, *this)
+	, m_stream(nullptr)
+	, m_has_cv_stream(false)
+	, m_min_cv(-FLT_MAX)
+	, m_max_cv(FLT_MAX)
+	, m_cv_scale(1.0F)
+	, m_fixed_gain(1.0F)
+{
+}
+
+va_vca_device &va_vca_device::configure_streaming_cv(bool use_streaming_cv)
+{
+	m_has_cv_stream = use_streaming_cv;
+	return *this;
+}
+
+va_vca_device &va_vca_device::configure_cem3360_linear_cv()
+{
+	// TODO: For now, the CEM3360 is treated as a linear device. But since it
+	// is OTA-based, it likely has a tanh response. This requires more research.
+
+	// Typical linear CV for max gain, as reported on the CEM3360 datasheet.
+	static constexpr const float CEM3360_MAX_GAIN_CV = 1.93F;
+	m_min_cv = 0;
+	m_max_cv = CEM3360_MAX_GAIN_CV;
+	m_cv_scale = 1.0F / CEM3360_MAX_GAIN_CV;
+	return *this;
+}
+
+void va_vca_device::set_fixed_cv(float cv)
+{
+	m_stream->update();
+	m_fixed_gain = cv_to_gain(cv);
+}
+
+void va_vca_device::device_start()
+{
+	const int input_count = m_has_cv_stream ? 2 : 1;
+	m_stream = stream_alloc(input_count, 1, SAMPLE_RATE_OUTPUT_ADAPTIVE);
+	save_item(NAME(m_fixed_gain));
+}
+
+void va_vca_device::sound_stream_update(sound_stream &stream, const std::vector<read_stream_view> &inputs, std::vector<write_stream_view> &outputs)
+{
+	if (m_has_cv_stream)
+	{
+		for (int i = 0; i < outputs[0].samples(); i++)
+			outputs[0].put(i, inputs[0].get(i) * cv_to_gain(inputs[1].get(i)));
+	}
+	else
+	{
+		for (int i = 0; i < outputs[0].samples(); i++)
+			outputs[0].put(i, inputs[0].get(i) * m_fixed_gain);
+	}
+}
+
+float va_vca_device::cv_to_gain(float cv) const
+{
+	return std::clamp(cv, m_min_cv, m_max_cv) * m_cv_scale;
+}
+

--- a/src/devices/sound/va_vca.h
+++ b/src/devices/sound/va_vca.h
@@ -6,12 +6,12 @@
 
 #pragma once
 
-// Emulates a voltage-controled amplifier (VCA). The control voltage (CV) can
+// Emulates a voltage-controled amplifier (VCA). The control value (CV) can
 // be set directly (set_fixed_cv()), or it can be provided in a sound stream
-// (input 1), by using a device in va_eg.h for example. The behavior of
-// specific VCAs can be emulated by using the respective configure_* functions.
-// Note that, depending on the device, CV could refer to a control voltage or
-// a control current.
+// (input 1), by a device in va_eg.h, for example. The behavior of specific VCAs
+// can be emulated by using the respective configure_* functions. Note that "CV"
+// ("control value") could either refer to a control voltage, or a control
+// current, depending on the device.
 class va_vca_device : public device_t, public device_sound_interface
 {
 public:

--- a/src/devices/sound/va_vca.h
+++ b/src/devices/sound/va_vca.h
@@ -1,0 +1,54 @@
+// license:BSD-3-Clause
+// copyright-holders:m1macrophage
+
+#ifndef MAME_SOUND_VA_VCA_H
+#define MAME_SOUND_VA_VCA_H
+
+#pragma once
+
+// Emulates a voltage-controled amplifier (VCA). The control voltage (CV) can
+// be set directly (set_fixed_cv()), or it can be provided in a sound stream
+// (input 1), by using a device in va_eg.h for example. The behavior of
+// specific VCAs can be emulated by using the respective configure_* functions.
+// Note that, depending on the device, CV could refer to a control voltage or
+// a control current.
+class va_vca_device : public device_t, public device_sound_interface
+{
+public:
+	va_vca_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0) ATTR_COLD;
+
+	// When streaming is enabled, the CV will be obtained from input 1 of the
+	// sound stream. Otherwise, the value set with `set_fixed_cv` will be used.
+	va_vca_device &configure_streaming_cv(bool use_streaming_cv);
+
+	// By default, the CV will be treated as a typical gain (output = gain * input)
+	// The configure_*() functions below might change this.
+
+	// CEM3360 (or AS3360) VCA in linear CV configuration: CV connected to pin
+	// Vc, and pins Vo and Ve connected to each other.
+	va_vca_device &configure_cem3360_linear_cv();
+
+	// Ignored when streaming CVs are enabled.
+	void set_fixed_cv(float cv);
+
+protected:
+	void device_start() override ATTR_COLD;
+	void sound_stream_update(sound_stream &stream, const std::vector<read_stream_view> &inputs, std::vector<write_stream_view> &outputs) override;
+
+private:
+	float cv_to_gain(float cv) const;
+
+	// Configuration. No need to include in save state.
+	sound_stream *m_stream;
+	bool m_has_cv_stream;
+	float m_min_cv;
+	float m_max_cv;
+	float m_cv_scale;
+
+	// State.
+	float m_fixed_gain;
+};
+
+DECLARE_DEVICE_TYPE(VA_VCA, va_vca_device)
+
+#endif  // MAME_SOUND_VA_VCA_H

--- a/src/devices/sound/va_vca.h
+++ b/src/devices/sound/va_vca.h
@@ -8,10 +8,13 @@
 
 // Emulates a voltage-controled amplifier (VCA). The control value (CV) can
 // be set directly (set_fixed_cv()), or it can be provided in a sound stream
-// (input 1), by a device in va_eg.h, for example. The behavior of specific VCAs
-// can be emulated by using the respective configure_* functions. Note that "CV"
-// ("control value") could either refer to a control voltage, or a control
-// current, depending on the device.
+// (input 1), by a device in va_eg.h, for example. When the cv is provided via a
+// stream, this is also a ring modulator.
+//
+// The behavior of specific VCAs can be emulated by using the respective
+// configure_* functions.
+// Note that "CV" ("control value") could either refer to a control voltage, or
+// a control current, depending on the device.
 class va_vca_device : public device_t, public device_sound_interface
 {
 public:
@@ -25,7 +28,8 @@ public:
 	// The configure_*() functions below might change this.
 
 	// CEM3360 (or AS3360) VCA in linear CV configuration: CV connected to pin
-	// Vc, and pins Vo and Ve connected to each other.
+	// Vc, and pins Vo and Ve connected to each other. The CV input (fixed or
+	// streaming) should be the voltage at the Vc pin.
 	va_vca_device &configure_cem3360_linear_cv();
 
 	// Ignored when streaming CVs are enabled.

--- a/src/devices/sound/va_vca.h
+++ b/src/devices/sound/va_vca.h
@@ -21,7 +21,7 @@ public:
 	// sound stream. Otherwise, the value set with `set_fixed_cv` will be used.
 	va_vca_device &configure_streaming_cv(bool use_streaming_cv);
 
-	// By default, the CV will be treated as a typical gain (output = gain * input)
+	// By default, the CV will be treated as a typical gain (output = cv * input)
 	// The configure_*() functions below might change this.
 
 	// CEM3360 (or AS3360) VCA in linear CV configuration: CV connected to pin

--- a/src/mame/linn/linndrum.cpp
+++ b/src/mame/linn/linndrum.cpp
@@ -101,6 +101,8 @@ Example:
 #include "sound/flt_vol.h"
 #include "sound/mixer.h"
 #include "sound/spkrdev.h"
+#include "sound/va_eg.h"
+#include "sound/va_vca.h"
 #include "speaker.h"
 
 #include "linn_linndrum.lh"
@@ -113,7 +115,7 @@ Example:
 #define LOG_TAPE_SYNC_ENABLE (1U << 6)
 #define LOG_MIX              (1U << 7)
 #define LOG_PITCH            (1U << 8)
-#define LOG_HAT_VCA          (1U << 9)
+#define LOG_HAT_EG           (1U << 9)
 
 #define VERBOSE (LOG_GENERAL)
 //#define LOG_OUTPUT_FUNC osd_printf_info
@@ -182,156 +184,6 @@ enum mixer_channels
 
 }  // anonymous namespace
 
-// This device combines the CEM3360 and its envelope generator (EG) that process
-// the hi-hat voice.
-// TODO: Look into implementing the CEM3360 and a generic EG as devices under
-// src/devices/sound.
-class linndrum_hat_vca_device : public device_t, public device_sound_interface
-{
-public:
-	linndrum_hat_vca_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0) ATTR_COLD;
-
-	void trigger();
-	void set_open(bool open_hat);
-
-protected:
-	void device_add_mconfig(machine_config &config) override ATTR_COLD;
-	void device_start() override ATTR_COLD;
-	void device_reset() override ATTR_COLD;
-	void sound_stream_update(sound_stream &stream, std::vector<read_stream_view> const &inputs, std::vector<write_stream_view> &outputs) override;
-
-private:
-	static float get_cem3360_gain(float cv);
-
-	TIMER_DEVICE_CALLBACK_MEMBER(trigger_timer_tick);
-
-	static constexpr const float C22 = CAP_U(1);
-	static constexpr const float R33 = RES_M(1);
-	static constexpr const float R34 = RES_K(10);
-	static constexpr const float DECAY_POT_R_MAX = RES_K(100);
-
-	sound_stream *m_stream = nullptr;
-
-	required_ioport m_decay_pot;
-	required_device<timer_device> m_trigger_timer;  // U37B (LM556).
-
-	float m_rc_inv = 1.0F / (R33 * C22);
-	bool m_decaying = true;
-	bool m_decay_done = true;
-	attotime m_decay_start_time;
-};
-
-DEFINE_DEVICE_TYPE(LINNDRUM_HAT_VCA, linndrum_hat_vca_device, "linndrum_hat_vca", "LinnDrum CEM3360 VCA and EG");
-
-linndrum_hat_vca_device::linndrum_hat_vca_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: device_t(mconfig, LINNDRUM_HAT_VCA, tag, owner, clock)
-	, device_sound_interface(mconfig, *this)
-	, m_decay_pot(*this, ":pot_tuning_7")
-	, m_trigger_timer(*this, "hat_trigger_timer")
-{
-}
-
-void linndrum_hat_vca_device::trigger()
-{
-	m_stream->update();
-	m_decaying = false;
-	m_decay_done = false;
-	m_trigger_timer->adjust(PERIOD_OF_555_MONOSTABLE(RES_K(510), CAP_U(0.01)));  // R8, C4.
-	LOGMASKED(LOG_HAT_VCA, "Hat VCA trigerred.\n");
-}
-
-void linndrum_hat_vca_device::set_open(bool open_hat)
-{
-	// The envelope generator can run in two different modes.
-	// - Open hat: the capacitor is discharged through a 1M resistor.
-	// - Closed hat: U90 (CD4053 MUX) adds a parallel discharge path through the
-	//   "hihat decay" knob.
-	m_stream->update();
-	float r = R33;
-	if (!open_hat)
-	{
-		const float r_decay = DECAY_POT_R_MAX * m_decay_pot->read() / 100.0F;
-		r = RES_2_PARALLEL(R33, R34 + r_decay);
-	}
-	m_rc_inv = 1.0F / (r * C22);
-	LOGMASKED(LOG_HAT_VCA, "Hat decay. Open: %d, r: %g\n", open_hat, r);
-}
-
-void linndrum_hat_vca_device::device_add_mconfig(machine_config &config)
-{
-	TIMER(config, m_trigger_timer).configure_generic(FUNC(linndrum_hat_vca_device::trigger_timer_tick));
-}
-
-void linndrum_hat_vca_device::device_start()
-{
-	m_stream = stream_alloc(1, 1, machine().sample_rate());
-	save_item(NAME(m_rc_inv));
-	save_item(NAME(m_decaying));
-	save_item(NAME(m_decay_done));
-	save_item(NAME(m_decay_start_time));
-}
-
-void linndrum_hat_vca_device::device_reset()
-{
-	set_open(false);
-}
-
-void linndrum_hat_vca_device::sound_stream_update(sound_stream &stream, std::vector<read_stream_view> const &inputs, std::vector<write_stream_view> &outputs)
-{
-	static constexpr const float MIN_GAIN = 0.0001F; // A gain lower than this will be treated as 0.
-	static constexpr const float MAX_EG_CV = 5;
-	static constexpr const float CV_SCALE = RES_VOLTAGE_DIVIDER(RES_K(8.2), RES_K(10));  // R67, R66.
-
-	assert(inputs.size() == 1 && outputs.size() == 1);
-	const read_stream_view &in = inputs[0];
-	write_stream_view &out = outputs[0];
-
-	if (m_decay_done)
-	{
-		out.fill(0);
-		return;
-	}
-
-	const int n = in.samples();
-	if (!m_decaying)
-	{
-		const float gain = get_cem3360_gain(MAX_EG_CV * CV_SCALE);
-		for (int i = 0; i < n; ++i)
-			out.put(i, gain * in.get(i));
-		return;
-	}
-
-	attotime t = in.start_time() - m_decay_start_time;
-	assert(t >= attotime::from_double(0));
-	float gain = 0;
-	for (int i = 0; i < n; ++i, t += in.sample_period())
-	{
-		// TODO: The CEM3360 is based on an OTA, which means it likely has a
-		// tanh, rather than a linear response. But this needs more research.
-		const float decay = expf(-t.as_double() * m_rc_inv);
-		gain = get_cem3360_gain(decay * MAX_EG_CV * CV_SCALE);
-		out.put(i, gain * in.get(i));
-	}
-
-	if (gain < MIN_GAIN)
-		m_decay_done = true;
-}
-
-float linndrum_hat_vca_device::get_cem3360_gain(float cv)
-{
-	// Typical linear CV for max gain, as reported on the CEM3360 datasheet.
-	static constexpr const float MAX_GAIN_CV = 1.93F;
-	return std::clamp<float>(cv / MAX_GAIN_CV, 0, 1);
-}
-
-TIMER_DEVICE_CALLBACK_MEMBER(linndrum_hat_vca_device::trigger_timer_tick)
-{
-	m_stream->update();
-	m_decaying = true;
-	m_decay_done = false;
-	m_decay_start_time = machine().time();
-	LOGMASKED(LOG_HAT_VCA, "Hat VCA started decay.\n");
-}
 
 class linndrum_audio_device : public device_t
 {
@@ -361,6 +213,7 @@ private:
 	static s32 get_ls267_freq(const std::array<s32, 2>& freq_range_hz, float cv);
 	static float get_snare_tom_pitch_cv(float v);
 
+	TIMER_DEVICE_CALLBACK_MEMBER(hat_trigger_timer_tick);
 	TIMER_DEVICE_CALLBACK_MEMBER(mux_timer_tick);
 	TIMER_DEVICE_CALLBACK_MEMBER(snare_timer_tick);
 	TIMER_DEVICE_CALLBACK_MEMBER(click_timer_tick);
@@ -374,11 +227,14 @@ private:
 
 	// Mux drums.
 	required_ioport m_mux_tuning_trimmer;
+	required_ioport m_hat_decay_pot;
 	required_memory_region_array<NUM_MUX_VOICES> m_mux_samples;
 	required_device<timer_device> m_mux_timer;  // 74LS627 (U77A).
 	required_device_array<dac76_device, NUM_MUX_VOICES> m_mux_dac;  // AM6070 (U88).
 	required_device_array<filter_volume_device, NUM_MUX_VOICES> m_mux_volume;  // CD4053 (U90), R60, R62.
-	required_device<linndrum_hat_vca_device> m_hat_vca;
+	required_device<timer_device> m_hat_trigger_timer;  // U37B (LM556).
+	required_device<va_rc_eg_device> m_hat_eg;
+	required_device<va_vca_device> m_hat_vca;  // CEM3360 (U91B).
 	std::array<bool, NUM_MUX_VOICES> m_mux_counting = { false, false, false, false, false, false, false, false };
 	std::array<u16, NUM_MUX_VOICES> m_mux_counters = { 0, 0, 0, 0, 0, 0, 0, 0 };
 
@@ -450,6 +306,13 @@ private:
 	static constexpr const float MUX_DAC_IREF = VPLUS / (RES_K(15) + RES_K(15));  // R55 + R57.
 	static constexpr const float TOM_DAC_IREF = MUX_DAC_IREF;  // Configured in the same way.
 
+	// Constants for hi hat envelope generator circuit.
+	static constexpr const float HAT_C22 = CAP_U(1);
+	static constexpr const float HAT_R33 = RES_M(1);
+	static constexpr const float HAT_R34 = RES_K(10);
+	static constexpr const float HAT_DECAY_POT_R_MAX = RES_K(100);
+	static constexpr const float HAT_MAX_CV = VCC * RES_VOLTAGE_DIVIDER(RES_K(8.2), RES_K(10));  // R67, R66.
+
 	// The audio pipeline operates on voltage magnitudes. This scaler normalizes
 	// the final output's range to approximately: -1 - 1.
 	static constexpr const float VOLTAGE_TO_SOUND_SCALER = 0.2F;
@@ -486,10 +349,13 @@ DEFINE_DEVICE_TYPE(LINNDRUM_AUDIO, linndrum_audio_device, "linndrum_audio_device
 linndrum_audio_device::linndrum_audio_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: device_t(mconfig, LINNDRUM_AUDIO, tag, owner, clock)
 	, m_mux_tuning_trimmer(*this, ":pot_mux_tuning")
+	, m_hat_decay_pot(*this, ":pot_tuning_7")
 	, m_mux_samples(*this, ":sample_mux_drum_%u", 0)
 	, m_mux_timer(*this, "mux_drum_timer")
 	, m_mux_dac(*this, "mux_drums_virtual_dac_%u", 1)
 	, m_mux_volume(*this, "mux_drums_volume_control_%u", 1)
+	, m_hat_trigger_timer(*this, "hat_trigger_timer")
+	, m_hat_eg(*this, "hat_eg")
 	, m_hat_vca(*this, "hat_vca")
 	, m_snare_samples(*this, ":sample_snare")
 	, m_sidestick_samples(*this, ":sample_sidestick")
@@ -538,9 +404,22 @@ void linndrum_audio_device::mux_drum_w(int voice, u8 data, bool is_strobe)
 
 	if (voice == MV_HAT)
 	{
-		m_hat_vca->set_open(BIT(data, 2));
+		float r = HAT_R33;
+		const bool is_open_hat = BIT(data, 2);
+		if (!is_open_hat)
+		{
+			const float r_decay = HAT_DECAY_POT_R_MAX * m_hat_decay_pot->read() / 100.0F;
+			r = RES_2_PARALLEL(HAT_R33, HAT_R34 + r_decay);
+		}
+		m_hat_eg->set_r(r);
+		LOGMASKED(LOG_HAT_EG, "Hat decay. Open: %d, r: %g\n", is_open_hat, r);
+
 		if (is_strobe)
-			m_hat_vca->trigger();
+		{
+			m_hat_eg->set_instant_v(HAT_MAX_CV);
+			m_hat_trigger_timer->adjust(PERIOD_OF_555_MONOSTABLE(RES_K(510), CAP_U(0.01)));  // R8, C4.
+			LOGMASKED(LOG_HAT_EG, "Hat EG triggered.\n");
+		}
 	}
 
 	LOGMASKED(LOG_STROBES, "Strobed mux drum %s: %02x (gain: %f)\n",
@@ -697,8 +576,11 @@ void linndrum_audio_device::device_add_mconfig(machine_config &config)
 		m_mux_dac[voice]->add_route(0, m_mux_volume[voice], get_dac_scaler(MUX_DAC_IREF));
 	}
 
-	LINNDRUM_HAT_VCA(config, m_hat_vca);
+	TIMER(config, m_hat_trigger_timer).configure_generic(FUNC(linndrum_audio_device::hat_trigger_timer_tick));  // LM556 (U37B).
+	VA_RC_EG(config, m_hat_eg).set_c(HAT_C22);
+	VA_VCA(config, m_hat_vca).configure_streaming_cv(true).configure_cem3360_linear_cv();
 	m_mux_volume[MV_HAT]->add_route(0, m_hat_vca, 1.0);
+	m_hat_eg->add_route(0, m_hat_vca, 1.0);
 
 	// *** Snare / sidestick section.
 
@@ -877,6 +759,12 @@ float linndrum_audio_device::get_snare_tom_pitch_cv(float v_tune)
 
 	// There are clamping diodes attached to the CV input.
 	return std::clamp<float>(cv, 0, VCC);
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER(linndrum_audio_device::hat_trigger_timer_tick)
+{
+	m_hat_eg->set_target_v(0);
+	LOGMASKED(LOG_HAT_EG, "Hat EG started decay.\n");
 }
 
 TIMER_DEVICE_CALLBACK_MEMBER(linndrum_audio_device::mux_timer_tick)


### PR DESCRIPTION
* Implemented VA_RC_EG (in `sound/va_eg`). Emulates an RC-circuit-based envelope generator. Values are published to a sound stream and can also be accessed directly.
* Implemented VA_VCA (in `sound/va_vca`). Emulates a voltage-controlled amplifier. 
* Replaced the custom EG and VCA implementations in `paia/fatman`, `linn/linndrum` and `oberheim/dmx` with the ones above.

This also required moving initialization and triggering code from the custom VCA devices in the `linndrum` and `dmx` into the core audio device in each driver.

Followed the naming and EG structure suggestions in  #13531. Open to additional suggestions of course.
