### PR TITLE
sound/dac76.cpp: Emulating multiplying capability and using it in dmx and linndrum.

### DIFF
--- a/src/devices/sound/dac76.cpp
+++ b/src/devices/sound/dac76.cpp
@@ -38,10 +38,36 @@ dac76_device::dac76_device(const machine_config &mconfig, const char *tag, devic
 	device_t(mconfig, DAC76, tag, owner, clock),
 	device_sound_interface(mconfig, *this),
 	m_stream(nullptr),
+	m_streaming_iref(false),
+	m_voltage_output(false),
+	m_r_pos(1.0F),
+	m_r_neg(1.0F),
 	m_chord(0),
 	m_step(0),
-	m_sb(false)
+	m_sb(false),
+	m_fixed_iref(1.0F)
 {
+}
+
+void dac76_device::configure_streaming_iref(bool streaming_iref)
+{
+	m_streaming_iref = streaming_iref;
+}
+
+void dac76_device::configure_voltage_output(float i2v_r_pos, float i2v_r_neg)
+{
+	m_voltage_output = true;
+	m_r_pos = i2v_r_pos;
+	m_r_neg = i2v_r_neg;
+}
+
+void dac76_device::set_fixed_iref(float iref)
+{
+	if (m_fixed_iref == iref)
+		return;
+	if (m_stream != nullptr)
+		m_stream->update();
+	m_fixed_iref = iref;
 }
 
 //-------------------------------------------------
@@ -51,12 +77,14 @@ dac76_device::dac76_device(const machine_config &mconfig, const char *tag, devic
 void dac76_device::device_start()
 {
 	// create sound stream
-	m_stream = stream_alloc(0, 1, machine().sample_rate() * 8);
+	const int input_count = m_streaming_iref ? 1 : 0;
+	m_stream = stream_alloc(input_count, 1, machine().sample_rate() * 8);
 
 	// register for save states
 	save_item(NAME(m_chord));
 	save_item(NAME(m_step));
 	save_item(NAME(m_sb));
+	save_item(NAME(m_fixed_iref));
 }
 
 //-------------------------------------------------
@@ -85,5 +113,24 @@ void dac76_device::sound_stream_update(sound_stream &stream, std::vector<read_st
 	vout *= (m_sb ? +1 : -1);
 
 	// range is 0-8031, normalize to 0-1 range
-	outputs[0].fill(stream_buffer::sample_t(vout) * (1.0 / 8031.0));
+	stream_buffer::sample_t y = stream_buffer::sample_t(vout) * (1.0 / 8031.0);
+
+	if (m_voltage_output)
+	{
+		static constexpr const float FULL_SCALE_MULT = 3.8F;  // From datasheet.
+		y *= ((y >= 0) ? m_r_pos : m_r_neg) * FULL_SCALE_MULT;
+	}
+
+	write_stream_view &out = outputs[0];
+	if (m_streaming_iref)
+	{
+		const read_stream_view &iref = inputs[0];
+		const int n = out.samples();
+		for (int i = 0; i < n; ++i)
+			out.put(i, iref.get(i) * y);
+	}
+	else
+	{
+		out.fill(m_fixed_iref * y);
+	}
 }

--- a/src/devices/sound/dac76.h
+++ b/src/devices/sound/dac76.h
@@ -4,7 +4,7 @@
 
     PMI DAC-76 COMDAC
 
-    Companding D/A Converter
+    Companding Multiplying D/A Converter
 
     Equivalent to the AM6070, which is an "improved pin-for-pin replacement for
     DAC-76" (according to the AM6070 datasheet).
@@ -19,6 +19,19 @@
        B5  7 |       | 12  VR-
        B6  8 |       | 11  VR+
        B7  9 |_______| 10  VLC
+
+    Given:
+    - Iref = current flowing into VR+
+    - X = DAC value, normalized to [-1, 1]
+    - E/D (pin 1) is low
+
+    The output will be:
+    - IOD+ = (X > 0) ? (3.8 * Iref * abs(X)) : 0
+    - IOD- = (X < 0) ? (3.8 * Iref * abs(X)) : 0
+
+    The outputs are typically converted to voltages and summed into a single
+    signal by a current-to-voltage converter (I2V) consisting of an op-amp and
+    two resistors.
 
 ***************************************************************************/
 
@@ -38,6 +51,25 @@ class dac76_device : public device_t, public device_sound_interface
 public:
 	// construction/destruction
 	dac76_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// When streaming is enabled, the Iref will be obtained from the input sound
+	// stream. Otherwise, the value set with `set_fixed_iref` will be used.
+	void configure_streaming_iref(bool streaming_iref);
+
+	// By default, the control current (Iref) is treated as normalized ([0, 1],
+	// defaults to 1), and the sound output is normalized to [-1, 1].
+	//
+	// When in "voltage output" mode, Iref (fixed or streaming) should be the
+	// current flowing into pin 11, and the output will be a voltage stream.
+	// `r_pos` is the feedback resistor of the I2V, which is also connected to
+	// IOD+ (pin 16).
+	// `r_neg` is the resistor to ground connected to IOD- (pin 17).
+	// Note that r_pos connects to the "-" input of the I2V op-amp, and r_neg to
+	// the "+" input.
+	void configure_voltage_output(float i2v_r_pos, float i2v_r_neg);
+
+	// Reference current. Ignored when streaming Iref mode is enabled.
+	void set_fixed_iref(float iref);
 
 	// chord
 	void b1_w(int state) { m_chord &= ~(1 << 2); m_chord |= (state << 2); }
@@ -67,9 +99,17 @@ private:
 
 	sound_stream *m_stream;
 
+	// configuration
+	bool m_streaming_iref;
+	bool m_voltage_output;
+	float m_r_pos;
+	float m_r_neg;
+
+	// state
 	uint8_t m_chord; // 3-bit
 	uint8_t m_step; // 4-bit
 	bool m_sb;
+	float m_fixed_iref;
 };
 
 // device type definition


### PR DESCRIPTION
* Added support for reference current (multiplying capability).
* Added support for voltage output.
* Added support for streaming reference current.
* Used those capabilities in `oberheim/dmx.cpp` and `linn/linndrum.cpp`.

I went with this approach because it better matches the real device. The DAC76 is a multiplying DAC. But I can think of some alternative implementations. @galibert or others, let me know if one of those is preferable:
1. Add a `configure_dac76_voltage_output()` in `sound/va_vca`, and have drivers that need multiplying capability always follow the `dac76_device` with a `va_vca_device`. This is similar to the implementation before this PR, but the dac76-specific logic will move from individual drivers to `va_vca`.
1. Add an `mdac76_device` subclass in `sound/dac76`, so as not to clutter the `dac76_device` interface.


