### PR TITLE
cpu/avr8/avr8.cpp: Updates:

### DIFF
--- a/src/devices/cpu/avr8/avr8.cpp
+++ b/src/devices/cpu/avr8/avr8.cpp
@@ -731,7 +731,7 @@ atmega168_device::atmega168_device(const machine_config &mconfig, const char *ta
 //-------------------------------------------------
 
 atmega328_device::atmega328_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device<3>(mconfig, tag, owner, clock, ATMEGA328, 0x7fff, address_map_constructor(FUNC(atmega328_device::atmega328_internal_map), this))
+	: avr8_device<3>(mconfig, tag, owner, clock, ATMEGA328, 0x3fff, address_map_constructor(FUNC(atmega328_device::atmega328_internal_map), this))
 {
 }
 
@@ -740,7 +740,7 @@ atmega328_device::atmega328_device(const machine_config &mconfig, const char *ta
 //-------------------------------------------------
 
 atmega644_device::atmega644_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device<3>(mconfig, tag, owner, clock, ATMEGA644, 0xffff, address_map_constructor(FUNC(atmega644_device::atmega644_internal_map), this))
+	: avr8_device<3>(mconfig, tag, owner, clock, ATMEGA644, 0x7fff, address_map_constructor(FUNC(atmega644_device::atmega644_internal_map), this))
 {
 }
 
@@ -749,7 +749,7 @@ atmega644_device::atmega644_device(const machine_config &mconfig, const char *ta
 //-------------------------------------------------
 
 atmega1280_device::atmega1280_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device<6>(mconfig, tag, owner, clock, ATMEGA1280, 0x1ffff, address_map_constructor(FUNC(atmega1280_device::atmega1280_internal_map), this))
+	: avr8_device<6>(mconfig, tag, owner, clock, ATMEGA1280, 0xffff, address_map_constructor(FUNC(atmega1280_device::atmega1280_internal_map), this))
 {
 }
 
@@ -767,7 +767,7 @@ atmega2560_device::atmega2560_device(const machine_config &mconfig, const char *
 //-------------------------------------------------
 
 attiny15_device::attiny15_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device<2>(mconfig, tag, owner, clock, ATTINY15, 0x03ff, address_map_constructor(FUNC(attiny15_device::attiny15_internal_map), this))
+	: avr8_device<2>(mconfig, tag, owner, clock, ATTINY15, 0x01ff, address_map_constructor(FUNC(attiny15_device::attiny15_internal_map), this))
 {
 }
 
@@ -1126,23 +1126,23 @@ void avr8_base_device::device_reset()
 	switch ((m_hfuses & (BOOTSZ1 | BOOTSZ0)) >> 1)
 	{
 	case 0:
-		if (m_addr_mask <= 0x1fff) { m_boot_size = 1024; }
-		else if (m_addr_mask <= 0xffff) { m_boot_size = 2048; }
+		if (m_addr_mask <= 0x3fff) { m_boot_size = 1024; }
+		else if (m_addr_mask <= 0x7fff) { m_boot_size = 2048; }
 		else { m_boot_size = 4096; }
 		break;
 	case 1:
-		if (m_addr_mask <= 0x1fff) { m_boot_size = 512; }
-		else if (m_addr_mask <= 0xffff) { m_boot_size = 1024; }
+		if (m_addr_mask <= 0x3fff) { m_boot_size = 512; }
+		else if (m_addr_mask <= 0x7fff) { m_boot_size = 1024; }
 		else { m_boot_size = 2048; }
 		break;
 	case 2:
-		if (m_addr_mask <= 0x1fff) { m_boot_size = 256; }
-		else if (m_addr_mask <= 0xffff) { m_boot_size = 512; }
+		if (m_addr_mask <= 0x3fff) { m_boot_size = 256; }
+		else if (m_addr_mask <= 0x7fff) { m_boot_size = 512; }
 		else { m_boot_size = 1024; }
 		break;
 	case 3:
-		if (m_addr_mask <= 0x1fff) { m_boot_size = 128; }
-		else if (m_addr_mask <= 0xffff) { m_boot_size = 256; }
+		if (m_addr_mask <= 0x3fff) { m_boot_size = 128; }
+		else if (m_addr_mask <= 0x7fff) { m_boot_size = 256; }
 		else { m_boot_size = 512; }
 		break;
 	default:
@@ -1220,7 +1220,7 @@ void avr8_base_device::state_string_export(const device_state_entry &entry, std:
 	case STATE_GENPC:
 	case STATE_GENPCBASE:
 	case AVR8_PC:
-		str = string_format("%05x", m_pc << 1);
+		str = string_format("%05x", m_pc >> 1);
 		break;
 	case STATE_GENFLAGS:
 		str = string_format("%c%c%c%c%c%c%c%c",

--- a/src/mame/handheld/pensebem.cpp
+++ b/src/mame/handheld/pensebem.cpp
@@ -301,7 +301,7 @@ void pensebem2017_state::pensebem2017(machine_config &config)
 }
 
 ROM_START( pbem2017 )
-	ROM_REGION(0x20000, "maincpu", 0)
+	ROM_REGION(0x4000, "maincpu", 0)
 	ROM_DEFAULT_BIOS("sept2017")
 
 	/* September 2017 release */

--- a/src/mame/makerbot/replicator.cpp
+++ b/src/mame/makerbot/replicator.cpp
@@ -605,12 +605,12 @@ void replicator_state::port_l_w(uint8_t data)
 
 void replicator_state::prg_map(address_map &map)
 {
-	map(0x0000, 0x1FFFF).rom();
+	map(0x00000, 0x1ffff).rom();
 }
 
 void replicator_state::data_map(address_map &map)
 {
-	map(0x0200, 0x21FF).ram();  /* ATMEGA1280 Internal SRAM */
+	map(0x0200, 0x21ff).ram();  /* ATMEGA1280 Internal SRAM */
 }
 
 /****************************************************\

--- a/src/mame/skeleton/venteta.cpp
+++ b/src/mame/skeleton/venteta.cpp
@@ -105,7 +105,7 @@ void venteta_state::venteta(machine_config &config)
 {
 	ATMEGA1280(config, m_maincpu, 24_MHz_XTAL); // TODO: actually ATMEGA103
 	m_maincpu->set_addrmap(AS_PROGRAM, &venteta_state::program_map);
-	m_maincpu->set_addrmap(AS_PROGRAM, &venteta_state::data_map);
+	m_maincpu->set_addrmap(AS_DATA, &venteta_state::data_map);
 	m_maincpu->set_eeprom_tag("eeprom");
 
 	// TODO: everything

--- a/src/mame/skeleton/venteta.cpp
+++ b/src/mame/skeleton/venteta.cpp
@@ -42,12 +42,13 @@ public:
 	void venteta(machine_config &config);
 
 private:
-	required_device<atmega168_device> m_maincpu;
+	required_device<atmega1280_device> m_maincpu;
 	required_device<gfxdecode_device> m_gfxdecode;
 
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
 	void program_map(address_map &map) ATTR_COLD;
+	void data_map(address_map &map) ATTR_COLD;
 };
 
 
@@ -61,7 +62,13 @@ uint32_t venteta_state::screen_update(screen_device &screen, bitmap_rgb32 &bitma
 
 void venteta_state::program_map(address_map &map)
 {
-	map(0x0000, 0xffff).rom();
+	map(0x00000, 0x1ffff).rom();
+}
+
+void venteta_state::data_map(address_map &map)
+{
+	//map(0x0020, 0x005f) Internal I/O registers - incorrect
+	map(0x0060, 0x0fff).ram(); // 4000 bytes internal RAM
 }
 
 
@@ -96,8 +103,9 @@ GFXDECODE_END
 
 void venteta_state::venteta(machine_config &config)
 {
-	ATMEGA168(config, m_maincpu, 24_MHz_XTAL); // TODO: actually ATMEGA103
+	ATMEGA1280(config, m_maincpu, 24_MHz_XTAL); // TODO: actually ATMEGA103
 	m_maincpu->set_addrmap(AS_PROGRAM, &venteta_state::program_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &venteta_state::data_map);
 	m_maincpu->set_eeprom_tag("eeprom");
 
 	// TODO: everything

--- a/src/mame/skeleton/venteta.cpp
+++ b/src/mame/skeleton/venteta.cpp
@@ -67,7 +67,7 @@ void venteta_state::program_map(address_map &map)
 
 void venteta_state::data_map(address_map &map)
 {
-	//map(0x0020, 0x005f) Internal I/O registers - incorrect
+	//map(0x0020, 0x005f) Internal I/O registers
 	map(0x0060, 0x0fff).ram(); // 4000 bytes internal RAM
 }
 

--- a/src/mame/ultimachine/rambo.cpp
+++ b/src/mame/ultimachine/rambo.cpp
@@ -57,7 +57,7 @@ private:
 
 void rambo_state::rambo_prg_map(address_map &map)
 {
-	map(0x0000, 0x1FFFF).rom();
+	map(0x00000, 0x3ffff).rom();
 }
 
 void rambo_state::rambo_data_map(address_map &map)
@@ -101,7 +101,7 @@ void rambo_state::rambo(machine_config &config)
 }
 
 ROM_START( metamaq2 )
-	ROM_REGION( 0x20000, "maincpu", 0 )
+	ROM_REGION( 0x40000, "maincpu", 0 )
 	ROM_DEFAULT_BIOS("20131015")
 
 	ROM_SYSTEM_BIOS( 0, "20130619", "June 19th, 2013" )
@@ -158,7 +158,7 @@ ROM_START( metamaq2 )
 	   A proper dump would be good.
 	   Also, it is not clear whether there's any difference in the bootloader
 	   between the ATMEGA1280 and the ATMEGA2560 MCUs */
-	ROM_LOAD( "atmegaboot_168_atmega1280.bin", 0x1f000, 0x0f16, BAD_DUMP CRC(c041f8db) SHA1(d995ebf360a264cccacec65f6dc0c2257a3a9224) )
+	ROM_LOAD( "atmegaboot_168_atmega1280.bin", 0x3f000, 0x0f16, BAD_DUMP CRC(c041f8db) SHA1(d995ebf360a264cccacec65f6dc0c2257a3a9224) )
 
 	/* on-die 4kbyte eeprom */
 	ROM_REGION( 0x1000, "eeprom", ROMREGION_ERASEFF )


### PR DESCRIPTION
- Fix address mask (word(2 byte) unit)
- Fix boot size
- Fix PC shifting in state_string_export
- verified from their datasheets

handheld/pensebem.cpp: Fix internal ROM region size

makerbot/replicator.cpp: Use lowercase hexadecimal values

skeleton/venteta.cpp: Fix CPU type for fix PC size (16 bits - also word unit) and internal RAM size (4000 bytes)

ultimachine/rambo.cpp: Fix internal ROM region size, Use lowercase hexadecimal values