### PR TITLE
Update strings.po

### DIFF
--- a/language/Chinese_Simplified/strings.po
+++ b/language/Chinese_Simplified/strings.po
@@ -1,5 +1,5 @@
 # Chinese Simplified translations for MAME package
-# MAME 套件的简体中文翻译
+# MAME 中文简体语言包
 # Copyright (C) 1997-2025 MAMEdev and contributors
 # This file is distributed under the same license as the MAME package.
 # Automatically generated, 2023.
@@ -10,7 +10,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-02-18 05:29+1100\n"
 "PO-Revision-Date: 2023-02-01 21:24+0800\n"
-"Last-Translator: YuiFAN\n"
+"Last-Translator: YuiFAN\n  \Genlty"
 "Language-Team: MAME Language Team\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
@@ -221,12 +221,12 @@ msgstr "十字准星位移 Y %1$1.3f"
 
 #: src/frontend/mame/ui/ui.cpp:2137
 msgid "**Error saving ui.ini**"
-msgstr "**保存 ui.ini 时错误**"
+msgstr "**保存 ui.ini 时出错**"
 
 #: src/frontend/mame/ui/ui.cpp:2196
 #, c-format
 msgid "**Error saving %s.ini**"
-msgstr "**保存 %s.ini 时错误**"
+msgstr "**保存 %s.ini 时出错**"
 
 #: src/frontend/mame/ui/ui.cpp:2200 src/frontend/mame/ui/miscmenu.cpp:773
 msgid ""
@@ -245,7 +245,7 @@ msgid ""
 " added to favorites list."
 msgstr ""
 "%s\n"
-" 已新增至最爱清单。"
+" 添加到收藏夹。"
 
 #: src/frontend/mame/ui/selsoft.cpp:515 src/frontend/mame/ui/selgame.cpp:323
 #: src/frontend/mame/ui/selgame.cpp:329
@@ -255,7 +255,7 @@ msgid ""
 " removed from favorites list."
 msgstr ""
 "%s\n"
-" 已从最爱清单移除。"
+" 从收藏夹中删除。"
 
 #: src/frontend/mame/ui/selsoft.cpp:576
 msgid "[Start empty]"
@@ -278,12 +278,12 @@ msgstr "%1$s - 选择软件"
 #: src/frontend/mame/ui/selsoft.cpp:762 src/frontend/mame/ui/selgame.cpp:1092
 #, c-format
 msgid "%1$s: %2$s - Search: %3$s_"
-msgstr "%1$s： %2$s - 搜寻： %3$s_"
+msgstr "%1$s： %2$s - 搜索： %3$s_"
 
 #: src/frontend/mame/ui/selsoft.cpp:764 src/frontend/mame/ui/selgame.cpp:1094
 #, c-format
 msgid "Search: %1$s_"
-msgstr "搜寻： %1$s_"
+msgstr "搜索： %1$s_"
 
 #: src/frontend/mame/ui/selsoft.cpp:771
 #, c-format
@@ -312,19 +312,19 @@ msgstr "输入设备"
 
 #: src/frontend/mame/ui/optsmenu.cpp:87
 msgid "Save Settings"
-msgstr "保存设定"
+msgstr "保存修改"
 
 #: src/frontend/mame/ui/optsmenu.cpp:183 src/frontend/mame/ui/optsmenu.cpp:225
 msgid "System Filter"
-msgstr "系統过滤"
+msgstr "系统筛选"
 
 #: src/frontend/mame/ui/optsmenu.cpp:195 src/frontend/mame/ui/custui.cpp:84
 msgid "Customize UI"
-msgstr "自订 UI"
+msgstr "自定义用户界面"
 
 #: src/frontend/mame/ui/optsmenu.cpp:196 src/frontend/mame/ui/dirmenu.cpp:579
 msgid "Configure Folders"
-msgstr "文件夹"
+msgstr "配置文件夹"
 
 #: src/frontend/mame/ui/pluginopt.cpp:35
 msgid "Plugin Options"
@@ -337,11 +337,11 @@ msgstr "[空插槽]"
 
 #: src/frontend/mame/ui/filesel.cpp:238
 msgid "[create]"
-msgstr "[建立]"
+msgstr "[新建]"
 
 #: src/frontend/mame/ui/filesel.cpp:242 src/frontend/mame/ui/swlist.cpp:100
 msgid "[software list]"
-msgstr "[软件清单]"
+msgstr "[软件列表]"
 
 #: src/frontend/mame/ui/filesel.cpp:298
 #, c-format
@@ -354,7 +354,7 @@ msgstr "选择存取模式"
 
 #: src/frontend/mame/ui/filesel.cpp:520
 msgid "Read-only"
-msgstr "唯读"
+msgstr "只读"
 
 #: src/frontend/mame/ui/filesel.cpp:522
 msgid "Read-write"
@@ -382,15 +382,15 @@ msgstr "重新选择上次执行的系统"
 
 #: src/frontend/mame/ui/submenu.cpp:36
 msgid "Enlarge images in the right panel"
-msgstr "放大右侧面版的图片"
+msgstr "放大右侧面板的图片"
 
 #: src/frontend/mame/ui/submenu.cpp:37
 msgid "Cheats"
-msgstr "作弊码文件"
+msgstr "作弊码"
 
 #: src/frontend/mame/ui/submenu.cpp:38
 msgid "Show mouse pointer"
-msgstr "显示鼠标指标"
+msgstr "显示鼠标指针"
 
 #: src/frontend/mame/ui/submenu.cpp:39
 msgid "Confirm quit from emulation"
@@ -402,11 +402,11 @@ msgstr "略过系统信息画面"
 
 #: src/frontend/mame/ui/submenu.cpp:41
 msgid "Force 4:3 aspect for snapshot display"
-msgstr "强制撷图显示比例为 4:3"
+msgstr "强制截图显示比例为 4:3"
 
 #: src/frontend/mame/ui/submenu.cpp:42
 msgid "Use image as background"
-msgstr "使用图片作为背景"
+msgstr "设置为背景"
 
 #: src/frontend/mame/ui/submenu.cpp:43
 msgid "Skip BIOS selection menu"
@@ -422,15 +422,15 @@ msgstr "信息自动校验"
 
 #: src/frontend/mame/ui/submenu.cpp:46
 msgid "Hide romless machine from available list"
-msgstr "在可用清单中隐藏无 ROM 机台"
+msgstr "在可用列表中隐藏无 ROM 机台"
 
 #: src/frontend/mame/ui/submenu.cpp:52
 msgid "Advanced Options"
-msgstr "进阶选项"
+msgstr "高级选项"
 
 #: src/frontend/mame/ui/submenu.cpp:53
 msgid "Performance Options"
-msgstr "效能选项"
+msgstr "性能选项"
 
 #: src/frontend/mame/ui/submenu.cpp:54
 msgid "Auto frame skip"
@@ -474,19 +474,19 @@ msgstr "旋转"
 
 #: src/frontend/mame/ui/submenu.cpp:65
 msgid "Rotate right"
-msgstr "右旋转"
+msgstr "向右旋转"
 
 #: src/frontend/mame/ui/submenu.cpp:66
 msgid "Rotate left"
-msgstr "左旋转"
+msgstr "向左旋转"
 
 #: src/frontend/mame/ui/submenu.cpp:67
 msgid "Auto rotate right"
-msgstr "自动右旋转"
+msgstr "自动向右旋转"
 
 #: src/frontend/mame/ui/submenu.cpp:68
 msgid "Auto rotate left"
-msgstr "自动左旋转"
+msgstr "自动向左旋转"
 
 #: src/frontend/mame/ui/submenu.cpp:69
 msgid "Flip X"
@@ -558,7 +558,7 @@ msgstr "多鼠标"
 
 #: src/frontend/mame/ui/submenu.cpp:89
 msgid "Steadykey"
-msgstr "稳定键"
+msgstr "组合键"
 
 #: src/frontend/mame/ui/submenu.cpp:90
 msgid "UI active"
@@ -582,7 +582,7 @@ msgstr "摇杆阈值"
 
 #: src/frontend/mame/ui/submenu.cpp:95
 msgid "Natural keyboard"
-msgstr "自然键盘"
+msgstr "原始键盘"
 
 #: src/frontend/mame/ui/submenu.cpp:96
 msgid "Allow contradictory joystick inputs"
@@ -811,7 +811,7 @@ msgstr "声音"
 #: src/frontend/mame/ui/info.cpp:46
 msgctxt "emulation-feature"
 msgid "capture hardware"
-msgstr "撷取硬体"
+msgstr "捕获硬件"
 
 #: src/frontend/mame/ui/info.cpp:47
 msgctxt "emulation-feature"
@@ -930,7 +930,7 @@ msgstr "未完美模拟功能: "
 
 #: src/frontend/mame/ui/info.cpp:133
 msgid "Screen flipping in cocktail mode is not supported.\n"
-msgstr "尚未支援台面型筐体模式的画面翻转。\n"
+msgstr "尚未支持台面型筐体模式的画面翻转。\n"
 
 #: src/frontend/mame/ui/info.cpp:135
 msgid "This system requires external artwork files.\n"
@@ -1069,11 +1069,11 @@ msgstr "媒体映像档信息"
 
 #: src/frontend/mame/ui/info.cpp:681
 msgid "Not supported"
-msgstr "不支援"
+msgstr "不支持"
 
 #: src/frontend/mame/ui/info.cpp:684
 msgid "Partially supported"
-msgstr "部分支援"
+msgstr "部分支持"
 
 #: src/frontend/mame/ui/info.cpp:693
 msgid "[empty]"
@@ -1089,15 +1089,15 @@ msgstr "切换项目顺序"
 
 #: src/frontend/mame/ui/swlist.cpp:307
 msgid "Switched Order: entries now ordered by shortname"
-msgstr "切换顺序：当前项目依照短档名排序"
+msgstr "切换顺序：按缩写名排序"
 
 #: src/frontend/mame/ui/swlist.cpp:308
 msgid "Switched Order: entries now ordered by description"
-msgstr "切换顺序：当前项目依照描述排序"
+msgstr "切换顺序：按描述排序"
 
 #: src/frontend/mame/ui/swlist.cpp:409
 msgid "[compatible lists]"
-msgstr "[ 完整清单 ]"
+msgstr "[ 完整列表 ]"
 
 #: src/frontend/mame/ui/filecreate.cpp:79
 msgid "File Already Exists - Override?"
@@ -1121,11 +1121,11 @@ msgstr "映像档格式"
 
 #: src/frontend/mame/ui/filecreate.cpp:202
 msgid "Create"
-msgstr "建立"
+msgstr "新建"
 
 #: src/frontend/mame/ui/filecreate.cpp:230
 msgid "Please enter a file extension too"
-msgstr "请一并输入副档名"
+msgstr "请一并输入扩展名"
 
 #: src/frontend/mame/ui/filecreate.cpp:295
 msgid "Select image format"
@@ -1148,7 +1148,7 @@ msgstr "键盘模式"
 #: src/frontend/mame/ui/keyboard.cpp:47 src/frontend/mame/ui/keyboard.cpp:92
 msgctxt "menu-keyboard"
 msgid "Natural"
-msgstr "自然"
+msgstr "原始"
 
 #: src/frontend/mame/ui/keyboard.cpp:47 src/frontend/mame/ui/keyboard.cpp:92
 msgctxt "menu-keyboard"
@@ -1169,16 +1169,16 @@ msgstr "[root%2$s]"
 
 #: src/frontend/mame/ui/keyboard.cpp:63 src/frontend/mame/ui/keyboard.cpp:110
 msgid "Enabled"
-msgstr "已启用"
+msgstr "启用"
 
 #: src/frontend/mame/ui/keyboard.cpp:63 src/frontend/mame/ui/keyboard.cpp:110
 msgid "Disabled"
-msgstr "已停用"
+msgstr "禁用"
 
 #: src/frontend/mame/ui/utils.cpp:63
 msgctxt "swlist-info"
 msgid "Alternate Title"
-msgstr "别题名"
+msgstr "别名"
 
 #: src/frontend/mame/ui/utils.cpp:64
 msgctxt "swlist-info"
@@ -1228,7 +1228,7 @@ msgstr "配件编号"
 #: src/frontend/mame/ui/utils.cpp:73
 msgctxt "swlist-info"
 msgid "PCB"
-msgstr "PCB"
+msgstr "印刷电路板"
 
 #: src/frontend/mame/ui/utils.cpp:74
 msgctxt "swlist-info"
@@ -1238,7 +1238,7 @@ msgstr "编码"
 #: src/frontend/mame/ui/utils.cpp:75
 msgctxt "swlist-info"
 msgid "Release Date"
-msgstr "发行日"
+msgstr "发行日期"
 
 #: src/frontend/mame/ui/utils.cpp:76
 msgctxt "swlist-info"
@@ -1298,7 +1298,7 @@ msgstr "类别"
 #: src/frontend/mame/ui/utils.cpp:92
 msgctxt "machine-filter"
 msgid "Favorites"
-msgstr "最爱"
+msgstr "收藏夹"
 
 #: src/frontend/mame/ui/utils.cpp:93
 msgctxt "machine-filter"
@@ -1333,12 +1333,12 @@ msgstr "年代"
 #: src/frontend/mame/ui/utils.cpp:99
 msgctxt "machine-filter"
 msgid "Save Supported"
-msgstr "已支援即时存档"
+msgstr "已支持即时存档"
 
 #: src/frontend/mame/ui/utils.cpp:100
 msgctxt "machine-filter"
 msgid "Save Unsupported"
-msgstr "不支援即时存档"
+msgstr "不支持即时存档"
 
 #: src/frontend/mame/ui/utils.cpp:101
 msgctxt "machine-filter"
@@ -1353,17 +1353,17 @@ msgstr "不需要 CHD"
 #: src/frontend/mame/ui/utils.cpp:103
 msgctxt "machine-filter"
 msgid "Vertical Screen"
-msgstr "垂直萤幕"
+msgstr "垂直画面"
 
 #: src/frontend/mame/ui/utils.cpp:104
 msgctxt "machine-filter"
 msgid "Horizontal Screen"
-msgstr "水平萤幕"
+msgstr "水平画面"
 
 #: src/frontend/mame/ui/utils.cpp:105
 msgctxt "machine-filter"
 msgid "Custom Filter"
-msgstr "自订筛选"
+msgstr "自定义筛选"
 
 #: src/frontend/mame/ui/utils.cpp:109
 msgctxt "software-filter"
@@ -1383,7 +1383,7 @@ msgstr "不可用"
 #: src/frontend/mame/ui/utils.cpp:112
 msgctxt "software-filter"
 msgid "Favorites"
-msgstr "最爱"
+msgstr "收藏夹"
 
 #: src/frontend/mame/ui/utils.cpp:113
 msgctxt "software-filter"
@@ -1428,22 +1428,22 @@ msgstr "编码"
 #: src/frontend/mame/ui/utils.cpp:121
 msgctxt "software-filter"
 msgid "Supported"
-msgstr "已支援"
+msgstr "已支持"
 
 #: src/frontend/mame/ui/utils.cpp:122
 msgctxt "software-filter"
 msgid "Partially Supported"
-msgstr "部分支援"
+msgstr "部分支持"
 
 #: src/frontend/mame/ui/utils.cpp:123
 msgctxt "software-filter"
 msgid "Unsupported"
-msgstr "不支援"
+msgstr "不支持"
 
 #: src/frontend/mame/ui/utils.cpp:124
 msgctxt "software-filter"
 msgid "Release Region"
-msgstr "释出区域"
+msgstr "发布区域"
 
 #: src/frontend/mame/ui/utils.cpp:125
 msgctxt "software-filter"
@@ -1453,12 +1453,12 @@ msgstr "设备类别"
 #: src/frontend/mame/ui/utils.cpp:126
 msgctxt "software-filter"
 msgid "Software List"
-msgstr "软件清单"
+msgstr "软件列表"
 
 #: src/frontend/mame/ui/utils.cpp:127
 msgctxt "software-filter"
 msgid "Custom Filter"
-msgstr "自订过滤"
+msgstr "自定义筛选"
 
 #: src/frontend/mame/ui/utils.cpp:213
 msgid "Filter"
@@ -1466,36 +1466,36 @@ msgstr "筛选"
 
 #: src/frontend/mame/ui/utils.cpp:292
 msgid "<set up filters>"
-msgstr "<设定过滤>"
+msgstr "<设定筛选>"
 
 #: src/frontend/mame/ui/utils.cpp:390
 msgid "Select Filters"
-msgstr "选择过滤"
+msgstr "选择筛选"
 
 #: src/frontend/mame/ui/utils.cpp:538
 #, c-format
 msgid "Filter %1$u"
-msgstr "过滤 %1$u"
+msgstr "筛选 %1$u"
 
 #: src/frontend/mame/ui/utils.cpp:552
 msgid "Remove last filter"
-msgstr "移除最后过滤器"
+msgstr "删除最后筛选"
 
 #: src/frontend/mame/ui/utils.cpp:554
 msgid "Add filter"
-msgstr "新增过滤器"
+msgstr "添加到筛选"
 
 #: src/frontend/mame/ui/utils.cpp:1013
 msgid "[no category INI files]"
-msgstr "[没有类别 INI 文件]"
+msgstr "[没有类别初始化文件]"
 
 #: src/frontend/mame/ui/utils.cpp:1021
 msgid "[no groups in INI file]"
-msgstr "[INI 文件中没有群组]"
+msgstr "[初始化文件中没有群组]"
 
 #: src/frontend/mame/ui/utils.cpp:1056
 msgid "No category INI files found"
-msgstr "没有发现群组 INI 文件"
+msgstr "没有发现群组初始化文件"
 
 #: src/frontend/mame/ui/utils.cpp:1061
 msgid "File"
@@ -1541,11 +1541,11 @@ msgstr "系统"
 
 #: src/frontend/mame/ui/miscmenu.cpp:82
 msgid "Reset"
-msgstr "重设"
+msgstr "重置"
 
 #: src/frontend/mame/ui/miscmenu.cpp:150
 msgid "Network Devices"
-msgstr "网路设备"
+msgstr "网络设备"
 
 #: src/frontend/mame/ui/miscmenu.cpp:239
 #, c-format
@@ -1600,7 +1600,7 @@ msgstr "十字准星选项"
 #: src/frontend/mame/ui/miscmenu.cpp:465
 msgctxt "menu-crosshair"
 msgid "Never"
-msgstr "绝不"
+msgstr "从不"
 
 #: src/frontend/mame/ui/miscmenu.cpp:466
 msgctxt "menu-crosshair"
@@ -1637,12 +1637,12 @@ msgstr "%1$d 秒"
 
 #: src/frontend/mame/ui/miscmenu.cpp:593
 msgid "Export Displayed List to File"
-msgstr "汇出显示清单至档案"
+msgstr "导出显示清单至档案"
 
 #: src/frontend/mame/ui/miscmenu.cpp:653
 #, c-format
 msgid "%s.xml saved in UI settings folder."
-msgstr "%s.xml 已保存于 UI 设定文件夹"
+msgstr "%s.xml 已保存于用户界面设置文件夹"
 
 #: src/frontend/mame/ui/miscmenu.cpp:679
 msgid "Name:             Description:\n"
@@ -1651,19 +1651,19 @@ msgstr "名称：            描述：\n"
 #: src/frontend/mame/ui/miscmenu.cpp:690
 #, c-format
 msgid "%s.txt saved in UI settings folder."
-msgstr "%s.txt 已保存于 UI 设定文件夹"
+msgstr "%s.txt 已保存于用户界面设置文件夹"
 
 #: src/frontend/mame/ui/miscmenu.cpp:707
 msgid "Export list in XML format (like -listxml)"
-msgstr "汇出 XML 格式列表 （同 -listxml）"
+msgstr "导出 XML 格式列表 （同 -listxml）"
 
 #: src/frontend/mame/ui/miscmenu.cpp:708
 msgid "Export list in XML format (like -listxml, but exclude devices)"
-msgstr "汇出 XML 格式列表 （同 -listxml，但不包含设备）"
+msgstr "导出 XML 格式列表 （同 -listxml，但不包含设备）"
 
 #: src/frontend/mame/ui/miscmenu.cpp:709
 msgid "Export list in TXT format (like -listfull)"
-msgstr "汇出 TXT 格式列表 （同 -listfull）"
+msgstr "导出 TXT 格式列表 （同 -listfull）"
 
 #: src/frontend/mame/ui/miscmenu.cpp:734
 #, c-format
@@ -1671,7 +1671,7 @@ msgid ""
 "System Settings:\n"
 "%1$s"
 msgstr ""
-"系统设定:\n"
+"系统设置:\n"
 "%1$s"
 
 #: src/frontend/mame/ui/miscmenu.cpp:817
@@ -1684,19 +1684,19 @@ msgstr "[此系统有无 BIOS 设定]"
 
 #: src/frontend/mame/ui/miscmenu.cpp:833
 msgid "Add To Favorites"
-msgstr "新增至最爱"
+msgstr "添加到收藏夹"
 
 #: src/frontend/mame/ui/miscmenu.cpp:835
 msgid "Remove From Favorites"
-msgstr "从最爱移除"
+msgstr "从收藏夹中删除"
 
 #: src/frontend/mame/ui/miscmenu.cpp:838
 msgid "Save System Settings"
-msgstr "保存系统设定"
+msgstr "保存系统设置"
 
 #: src/frontend/mame/ui/miscmenu.cpp:871 src/frontend/mame/ui/selmenu.cpp:2698
 msgid " (default)"
-msgstr " (缺省)"
+msgstr " (默认)"
 
 #: src/frontend/mame/ui/miscmenu.cpp:948
 msgid "No plugins found"
@@ -1749,7 +1749,7 @@ msgstr ""
 #: src/frontend/mame/ui/state.cpp:388
 #, c-format
 msgid "Error removing saved state file %1$s"
-msgstr "移除已保存的状态档 %1$s 时发生错误"
+msgstr "删除已保存的状态档 %1$s 时发生错误"
 
 #: src/frontend/mame/ui/state.cpp:450
 #, c-format
@@ -1795,12 +1795,12 @@ msgstr "输入配置 (一般)"
 
 #: src/frontend/mame/ui/inputmap.cpp:39
 msgid "User Interface"
-msgstr "使用者介面"
+msgstr "用户介面"
 
 #: src/frontend/mame/ui/inputmap.cpp:42
 #, c-format
 msgid "Player %1$d Controls"
-msgstr "玩者 %1$d 控制"
+msgstr "玩家 %1$d 控制"
 
 #: src/frontend/mame/ui/inputmap.cpp:45
 msgid "Other Controls"
@@ -1863,7 +1863,7 @@ msgstr "按下 %1$s 清除\n"
 #: src/frontend/mame/ui/inputmap.cpp:611
 #, c-format
 msgid "Press %1$s to restore default\n"
-msgstr "按下 %1$s 还原缺省值\n"
+msgstr "按下 %1$s 还原默认值\n"
 
 #: src/frontend/mame/ui/inputdevices.cpp:33
 #, c-format
@@ -2014,7 +2014,7 @@ msgstr "设定选项"
 #: src/frontend/mame/ui/simpleselgame.cpp:279
 #: src/frontend/mame/ui/selmenu.cpp:1307
 msgid "Exit"
-msgstr "结束"
+msgstr "退出"
 
 #: src/frontend/mame/ui/simpleselgame.cpp:313
 #, c-format
@@ -2153,7 +2153,7 @@ msgstr "十字准星"
 #: src/frontend/mame/ui/dirmenu.cpp:45
 msgctxt "path-option"
 msgid "Cheat Files"
-msgstr "作弊档"
+msgstr "作弊文件"
 
 #: src/frontend/mame/ui/dirmenu.cpp:46
 msgctxt "path-option"
@@ -2163,47 +2163,47 @@ msgstr "外挂"
 #: src/frontend/mame/ui/dirmenu.cpp:47
 msgctxt "path-option"
 msgid "UI Translations"
-msgstr "UI 翻译"
+msgstr "用户界面翻译"
 
 #: src/frontend/mame/ui/dirmenu.cpp:48
 msgctxt "path-option"
 msgid "Software Lists"
-msgstr "软件清单"
+msgstr "软件列表"
 
 #: src/frontend/mame/ui/dirmenu.cpp:49
 msgctxt "path-option"
-msgid "INIs"
+msgid "初始化"
 msgstr "INI"
 
 #: src/frontend/mame/ui/dirmenu.cpp:50
 msgctxt "path-option"
 msgid "UI Settings"
-msgstr "UI 设定"
+msgstr "用户界面设定"
 
 #: src/frontend/mame/ui/dirmenu.cpp:51
 msgctxt "path-option"
 msgid "Plugin Data"
-msgstr "外挂资料"
+msgstr "外挂数据"
 
 #: src/frontend/mame/ui/dirmenu.cpp:52
 msgctxt "path-option"
 msgid "DATs"
-msgstr "文件"
+msgstr "数据"
 
 #: src/frontend/mame/ui/dirmenu.cpp:53
 msgctxt "path-option"
 msgid "Category INIs"
-msgstr "类别 INI"
+msgstr "类别初始化"
 
 #: src/frontend/mame/ui/dirmenu.cpp:54
 msgctxt "path-option"
 msgid "Snapshots"
-msgstr "快照 (snap)"
+msgstr "快照"
 
 #: src/frontend/mame/ui/dirmenu.cpp:55
 msgctxt "path-option"
 msgid "Icons"
-msgstr "图示"
+msgstr "图标"
 
 #: src/frontend/mame/ui/dirmenu.cpp:56
 msgctxt "path-option"
@@ -2213,22 +2213,22 @@ msgstr "控制面板"
 #: src/frontend/mame/ui/dirmenu.cpp:57
 msgctxt "path-option"
 msgid "Cabinets"
-msgstr "机械图 (cabinets)"
+msgstr "机械图"
 
 #: src/frontend/mame/ui/dirmenu.cpp:58
 msgctxt "path-option"
 msgid "Marquees"
-msgstr "贴画 (marquees)"
+msgstr "贴画"
 
 #: src/frontend/mame/ui/dirmenu.cpp:59
 msgctxt "path-option"
 msgid "PCBs"
-msgstr "PCB 图"
+msgstr "印刷电路板"
 
 #: src/frontend/mame/ui/dirmenu.cpp:60
 msgctxt "path-option"
 msgid "Flyers"
-msgstr "广告图 (flyers)"
+msgstr "广告图"
 
 #: src/frontend/mame/ui/dirmenu.cpp:61
 msgctxt "path-option"
@@ -2253,7 +2253,7 @@ msgstr "装饰图预览"
 #: src/frontend/mame/ui/dirmenu.cpp:65
 msgctxt "path-option"
 msgid "Select"
-msgstr "精选"
+msgstr "选关"
 
 #: src/frontend/mame/ui/dirmenu.cpp:66
 msgctxt "path-option"
@@ -2268,7 +2268,7 @@ msgstr "说明图"
 #: src/frontend/mame/ui/dirmenu.cpp:68
 msgctxt "path-option"
 msgid "Logos"
-msgstr "标题图"
+msgstr "徽标"
 
 #: src/frontend/mame/ui/dirmenu.cpp:69
 msgctxt "path-option"
@@ -2288,17 +2288,17 @@ msgstr "封面"
 #: src/frontend/mame/ui/dirmenu.cpp:101
 #, c-format
 msgid "Remove %1$s Folder"
-msgstr "移除 %1$s 文件夹"
+msgstr "删除 %1$s 文件夹"
 
 #: src/frontend/mame/ui/dirmenu.cpp:357
 #, c-format
 msgid "Add %1$s Folder - Search: %2$s_"
-msgstr "新增 %1$s 文件夹 - 搜寻： %2$s_"
+msgstr "添加 %1$s 文件夹 - 搜索： %2$s_"
 
 #: src/frontend/mame/ui/dirmenu.cpp:357
 #, c-format
 msgid "Change %1$s Folder - Search: %2$s_"
-msgstr "变更 %1$s 文件夹 - 搜寻： %2$s_"
+msgstr "变更 %1$s 文件夹 - 搜索： %2$s_"
 
 #: src/frontend/mame/ui/dirmenu.cpp:368
 msgid "Press TAB to set"
@@ -2316,7 +2316,7 @@ msgstr "%1$s 文件夹"
 
 #: src/frontend/mame/ui/dirmenu.cpp:523
 msgid "Add Folder"
-msgstr "新增文件夹"
+msgstr "新建文件夹"
 
 #: src/frontend/mame/ui/dirmenu.cpp:525
 msgid "Remove Folder"
@@ -2406,19 +2406,19 @@ msgstr " #%1$X:%2$X (%3$d %4$d) = %5$X"
 #, c-format
 msgctxt "gfxview"
 msgid " %1$d×%2$d color %3$X/%4$X"
-msgstr " %1$d×%2$d 色 %3$X/%4$X"
+msgstr " %1$d×%2$d 颜色 %3$X/%4$X"
 
 #: src/frontend/mame/ui/viewgfx.cpp:1306
 #, c-format
 msgctxt "gfxview"
 msgid "Tilemap %1$d/%2$d category %3$u"
-msgstr "砖图 %1$d/%2$d 分类 %3$u"
+msgstr "贴图 %1$d/%2$d 分类 %3$u"
 
 #: src/frontend/mame/ui/viewgfx.cpp:1306
 #, c-format
 msgctxt "gfxview"
 msgid "Tilemap %1$d/%2$d "
-msgstr "砖图 %1$d/%2$d"
+msgstr "贴图 %1$d/%2$d"
 
 #: src/frontend/mame/ui/viewgfx.cpp:1328
 #, c-format
@@ -2434,7 +2434,7 @@ msgstr " %1$d×%2$d 原点 (%3$d %4$d)"
 
 #: src/frontend/mame/ui/selgame.cpp:463
 msgid "System Settings"
-msgstr "系统设定"
+msgstr "系统设置"
 
 #: src/frontend/mame/ui/selgame.cpp:1076
 #, c-format
@@ -2450,7 +2450,7 @@ msgstr "系统： %1$-.100s"
 #, c-format
 msgctxt "menu-selector"
 msgid "%1$s - Search: %2$s_"
-msgstr "%1$s - 搜寻： %2$s_"
+msgstr "%1$s - 搜索： %2$s_"
 
 #: src/frontend/mame/ui/selector.cpp:110
 msgctxt "menu-selector"
@@ -2520,7 +2520,7 @@ msgstr "显示全部"
 
 #: src/frontend/mame/ui/custui.cpp:55
 msgid "Hide Filters"
-msgstr "隐藏过滤器"
+msgstr "隐藏筛选"
 
 #: src/frontend/mame/ui/custui.cpp:56
 msgid "Hide Info/Image"
@@ -2532,7 +2532,7 @@ msgstr "隐藏两者"
 
 #: src/frontend/mame/ui/custui.cpp:144
 msgid "UI Language"
-msgstr "UI 语言"
+msgstr "用户界面语言"
 
 #: src/frontend/mame/ui/custui.cpp:169 src/frontend/mame/ui/custui.cpp:222
 msgid "System Names"
@@ -2540,7 +2540,7 @@ msgstr "系统名称"
 
 #: src/frontend/mame/ui/custui.cpp:195 src/frontend/mame/ui/custui.cpp:225
 msgid "Show Side Panels"
-msgstr "显示侧面版"
+msgstr "显示侧面板"
 
 #: src/frontend/mame/ui/custui.cpp:215
 msgid "Fonts"
@@ -2560,15 +2560,15 @@ msgstr "[内建]"
 
 #: src/frontend/mame/ui/custui.cpp:337
 msgid "UI Fonts"
-msgstr "UI 字体"
+msgstr "用户界面字体"
 
 #: src/frontend/mame/ui/custui.cpp:366
 msgid "default"
-msgstr "缺省"
+msgstr "默认"
 
 #: src/frontend/mame/ui/custui.cpp:465 src/frontend/mame/ui/custui.cpp:507
 msgid "UI Font"
-msgstr "UI 字体"
+msgstr "用户界面字体"
 
 #: src/frontend/mame/ui/custui.cpp:512
 msgid "Bold"
@@ -2592,7 +2592,7 @@ msgstr "采样文字 - Lorem ipsum dolor sit amet, consectetur adipiscing elit."
 
 #: src/frontend/mame/ui/custui.cpp:563
 msgid "UI Colors"
-msgstr "UI 色"
+msgstr "用户界面颜色"
 
 #: src/frontend/mame/ui/custui.cpp:626
 msgctxt "color-option"
@@ -2602,7 +2602,7 @@ msgstr "一般文本"
 #: src/frontend/mame/ui/custui.cpp:627
 msgctxt "color-option"
 msgid "Selected color"
-msgstr "选择色"
+msgstr "选择颜色"
 
 #: src/frontend/mame/ui/custui.cpp:628
 msgctxt "color-option"
@@ -2676,7 +2676,7 @@ msgstr "鼠标按下背景颜色"
 
 #: src/frontend/mame/ui/custui.cpp:645
 msgid "Restore default colors"
-msgstr "还原至缺省颜色"
+msgstr "还原至默认颜色"
 
 #: src/frontend/mame/ui/custui.cpp:666
 #, c-format
@@ -2904,7 +2904,7 @@ msgstr "机器设定"
 #: src/frontend/mame/ui/mainmenu.cpp:122
 msgctxt "menu-main"
 msgid "Bookkeeping Info"
-msgstr "收入资讯"
+msgstr "收入信息"
 
 #: src/frontend/mame/ui/mainmenu.cpp:124
 msgctxt "menu-main"
@@ -2984,17 +2984,17 @@ msgstr "插件选项"
 #: src/frontend/mame/ui/mainmenu.cpp:175
 msgctxt "menu-main"
 msgid "External DAT View"
-msgstr "检视外部文件"
+msgstr "外部文件视图"
 
 #: src/frontend/mame/ui/mainmenu.cpp:181
 msgctxt "menu-main"
 msgid "Add To Favorites"
-msgstr "新增至最爱"
+msgstr "添加到收藏夹"
 
 #: src/frontend/mame/ui/mainmenu.cpp:183
 msgctxt "menu-main"
 msgid "Remove From Favorites"
-msgstr "从最爱移除"
+msgstr "从收藏夹删除"
 
 #: src/frontend/mame/ui/mainmenu.cpp:187
 #, c-format
@@ -3043,7 +3043,7 @@ msgstr "控制面板"
 #: src/frontend/mame/ui/selmenu.cpp:86
 msgctxt "selmenu-artwork"
 msgid "PCB"
-msgstr "PCB 图"
+msgstr "印刷电路板"
 
 #: src/frontend/mame/ui/selmenu.cpp:87
 msgctxt "selmenu-artwork"
@@ -3073,7 +3073,7 @@ msgstr "首领"
 #: src/frontend/mame/ui/selmenu.cpp:92
 msgctxt "selmenu-artwork"
 msgid "Logo"
-msgstr "标题图"
+msgstr "徽标"
 
 #: src/frontend/mame/ui/selmenu.cpp:93
 msgctxt "selmenu-artwork"
@@ -3098,7 +3098,7 @@ msgstr "得分"
 #: src/frontend/mame/ui/selmenu.cpp:97
 msgctxt "selmenu-artwork"
 msgid "Select"
-msgstr "精选"
+msgstr "选关"
 
 #: src/frontend/mame/ui/selmenu.cpp:98
 msgctxt "selmenu-artwork"
@@ -3112,11 +3112,11 @@ msgstr "封面"
 
 #: src/frontend/mame/ui/selmenu.cpp:103
 msgid "Add or remove favorite"
-msgstr "新增或移除最爱项目"
+msgstr "添加到收藏夹"
 
 #: src/frontend/mame/ui/selmenu.cpp:104
 msgid "Export displayed list to file"
-msgstr "汇出显示的清单至文件"
+msgstr "导出显示的列表至文件"
 
 #: src/frontend/mame/ui/selmenu.cpp:105
 msgid "Audit media"
@@ -3124,7 +3124,7 @@ msgstr "校验媒体"
 
 #: src/frontend/mame/ui/selmenu.cpp:106
 msgid "Show DATs view"
-msgstr "显示文件检视"
+msgstr "显示文件预览"
 
 #: src/frontend/mame/ui/selmenu.cpp:268
 msgid "Select Software Package Part"
@@ -3150,15 +3150,15 @@ msgstr "软件为主档"
 
 #: src/frontend/mame/ui/selmenu.cpp:700
 msgid "Supported: No"
-msgstr "已支援： 否"
+msgstr "已支持： 否"
 
 #: src/frontend/mame/ui/selmenu.cpp:705
 msgid "Supported: Partial"
-msgstr "已支援： 部分"
+msgstr "已支持： 部分"
 
 #: src/frontend/mame/ui/selmenu.cpp:710
 msgid "Supported: Yes"
-msgstr "已支援： 是"
+msgstr "已支持： 是"
 
 #: src/frontend/mame/ui/selmenu.cpp:726
 msgid "System is parent"
@@ -3227,7 +3227,7 @@ msgstr "一般信息"
 #: src/frontend/mame/ui/selmenu.cpp:2935
 #, c-format
 msgid "Short Name\t%1$s\n"
-msgstr "短档名\t%1$s\n"
+msgstr "缩写名\t%1$s\n"
 
 #: src/frontend/mame/ui/selmenu.cpp:2936
 #, c-format
@@ -3306,11 +3306,11 @@ msgstr "声音\tOK\n"
 
 #: src/frontend/mame/ui/selmenu.cpp:2985
 msgid "Capture\tUnimplemented\n"
-msgstr "撷取\t无法执行\n"
+msgstr "捕获\t无法执行\n"
 
 #: src/frontend/mame/ui/selmenu.cpp:2987
 msgid "Capture\tImperfect\n"
-msgstr "撷取\t不完美\n"
+msgstr "捕获\t不完美\n"
 
 #: src/frontend/mame/ui/selmenu.cpp:2990
 msgid "Camera\tUnimplemented\n"
@@ -3418,19 +3418,19 @@ msgstr "通讯\t不完美\n"
 
 #: src/frontend/mame/ui/selmenu.cpp:3055
 msgid "LAN\tUnimplemented\n"
-msgstr "区域网路\t无法执行\n"
+msgstr "区域网络\t无法执行\n"
 
 #: src/frontend/mame/ui/selmenu.cpp:3057
 msgid "LAN\tImperfect\n"
-msgstr "区域网路\t不完美\n"
+msgstr "区域网络\t不完美\n"
 
 #: src/frontend/mame/ui/selmenu.cpp:3060
 msgid "WAN\tUnimplemented\n"
-msgstr "外部网路\t无法执行\n"
+msgstr "外部网络\t无法执行\n"
 
 #: src/frontend/mame/ui/selmenu.cpp:3062
 msgid "WAN\tImperfect\n"
-msgstr "外部网路\t不完美\n"
+msgstr "外部网络\t不完美\n"
 
 #: src/frontend/mame/ui/selmenu.cpp:3065
 msgid "Timing\tUnimplemented\n"
@@ -3466,7 +3466,7 @@ msgstr "需要可点击的装饰图\t否\n"
 
 #: src/frontend/mame/ui/selmenu.cpp:3073
 msgid "Support Cocktail\tNo\n"
-msgstr "支援檯面型筐体\t否\n"
+msgstr "支持台面型筐体\t否\n"
 
 #: src/frontend/mame/ui/selmenu.cpp:3074
 msgid "System is BIOS\tYes\n"
@@ -3482,7 +3482,7 @@ msgstr "支援即时存档\t是\n"
 
 #: src/frontend/mame/ui/selmenu.cpp:3075
 msgid "Support Save\tNo\n"
-msgstr "支援即时存档\t否\n"
+msgstr "支持即时存档\t否\n"
 
 #: src/frontend/mame/ui/selmenu.cpp:3076
 msgid "Screen Orientation\tVertical\n"
@@ -3618,7 +3618,7 @@ msgstr ""
 #: src/frontend/mame/ui/devopt.cpp:341
 #, c-format
 msgid "  %1$s    [default: %2$s]\n"
-msgstr "  %1$s    [缺省： %2$s]\n"
+msgstr "  %1$s    [默认： %2$s]\n"
 
 #: src/frontend/mame/ui/devopt.cpp:269 src/frontend/mame/ui/devopt.cpp:285
 #, c-format
@@ -3640,7 +3640,7 @@ msgstr "* 输入设备：\n"
 #: src/frontend/mame/ui/devopt.cpp:302
 #, c-format
 msgid "  User inputs    [%1$d inputs]\n"
-msgstr "  使用者输入    [%1$d 输入]\n"
+msgstr "  用户输入    [%1$d 输入]\n"
 
 #: src/frontend/mame/ui/devopt.cpp:304
 #, c-format
@@ -4592,7 +4592,7 @@ msgstr "机门连锁"
 #: src/emu/inpttype.ipp:609
 msgctxt "input-name"
 msgid "Memory Reset"
-msgstr "记忆体重置"
+msgstr "内存重置"
 
 #: src/emu/inpttype.ipp:610
 msgctxt "input-name"
@@ -5399,7 +5399,7 @@ msgstr "显示/隐藏菜单"
 #: src/emu/inpttype.ipp:875
 msgctxt "input-name"
 msgid "UI Select"
-msgstr "菜单 选定键"
+msgstr "菜单 选择"
 
 #: src/emu/inpttype.ipp:876
 msgctxt "input-name"
@@ -5409,12 +5409,12 @@ msgstr "菜单 返回"
 #: src/emu/inpttype.ipp:877
 msgctxt "input-name"
 msgid "UI Cancel"
-msgstr "菜单 取消键"
+msgstr "菜单 取消"
 
 #: src/emu/inpttype.ipp:878
 msgctxt "input-name"
 msgid "UI Clear"
-msgstr "菜单 清除键"
+msgstr "菜单 清除"
 
 #: src/emu/inpttype.ipp:879
 msgctxt "input-name"
@@ -5424,32 +5424,32 @@ msgstr "菜单 帮助"
 #: src/emu/inpttype.ipp:880
 msgctxt "input-name"
 msgid "UI Up"
-msgstr "菜单 向上键"
+msgstr "菜单 向上"
 
 #: src/emu/inpttype.ipp:881
 msgctxt "input-name"
 msgid "UI Down"
-msgstr "UI 向下键"
+msgstr "UI 向下"
 
 #: src/emu/inpttype.ipp:882
 msgctxt "input-name"
 msgid "UI Left"
-msgstr "菜单 向左键"
+msgstr "菜单 向左"
 
 #: src/emu/inpttype.ipp:883
 msgctxt "input-name"
 msgid "UI Right"
-msgstr "菜单 向右键"
+msgstr "菜单 向右"
 
 #: src/emu/inpttype.ipp:884
 msgctxt "input-name"
 msgid "UI Home"
-msgstr "菜单 最上键"
+msgstr "菜单 最上"
 
 #: src/emu/inpttype.ipp:885
 msgctxt "input-name"
 msgid "UI End"
-msgstr "菜单 最下键"
+msgstr "菜单 最下"
 
 #: src/emu/inpttype.ipp:886
 msgctxt "input-name"
@@ -5484,7 +5484,7 @@ msgstr ""
 #: src/emu/inpttype.ipp:892
 msgctxt "input-name"
 msgid "Break in Debugger"
-msgstr "除错器内中断"
+msgstr "调试器内中断"
 
 #: src/emu/inpttype.ipp:893
 msgctxt "input-name"
@@ -5634,17 +5634,17 @@ msgstr "菜单 上一焦点"
 #: src/emu/inpttype.ipp:922
 msgctxt "input-name"
 msgid "UI External DAT View"
-msgstr "菜单 检视外部 DAT"
+msgstr "菜单 外部文件视图"
 
 #: src/emu/inpttype.ipp:923
 msgctxt "input-name"
 msgid "UI Add/Remove Favorite"
-msgstr "菜单 新增/移除最爱项目"
+msgstr "菜单 添加/删除收藏夹"
 
 #: src/emu/inpttype.ipp:924
 msgctxt "input-name"
 msgid "UI Export List"
-msgstr "菜单 汇出列表"
+msgstr "菜单 导出列表"
 
 #: src/emu/inpttype.ipp:925
 msgctxt "input-name"
@@ -5654,17 +5654,17 @@ msgstr "菜单 校验媒体"
 #: src/osd/modules/input/input_windows.cpp:111 src/osd/sdl/osdsdl.cpp:339
 msgctxt "input-name"
 msgid "Toggle Fullscreen"
-msgstr "切换全萤幕"
+msgstr "切换全画面"
 
 #: src/osd/modules/input/input_windows.cpp:117
 msgctxt "input-name"
 msgid "Take Rendered Snapshot"
-msgstr "拍摄描绘的撷图"
+msgstr "获取截图"
 
 #: src/osd/modules/input/input_windows.cpp:128 src/osd/sdl/osdsdl.cpp:388
 msgctxt "input-name"
 msgid "Record Rendered Video"
-msgstr "拍摄描绘的视频"
+msgstr "获取视频"
 
 #: src/osd/modules/input/input_windows.cpp:144
 msgctxt "input-name"
@@ -5674,7 +5674,7 @@ msgstr "切换后处理"
 #: src/osd/sdl/osdsdl.cpp:365
 msgctxt "input-name"
 msgid "Toggle Filter"
-msgstr "切换过滤"
+msgstr "切换筛选"
 
 #: src/osd/sdl/osdsdl.cpp:371
 msgctxt "input-name"
@@ -5699,7 +5699,7 @@ msgstr "结束时"
 #: plugins/hiscore/init.lua:86
 msgctxt "plugin-hiscore"
 msgid "Hiscore Support Options"
-msgstr "高分档支援选项"
+msgstr "高分档支持选项"
 
 #: plugins/hiscore/init.lua:88
 msgctxt "plugin-hiscore"
@@ -5709,7 +5709,7 @@ msgstr "保存得分"
 #: plugins/hiscore/init.lua:372
 msgctxt "plugin-hiscore"
 msgid "Hiscore Support"
-msgstr "高分档支援"
+msgstr "高分档支持"
 
 #: plugins/cheatfind/init.lua:387
 msgid "Other: "
@@ -5725,7 +5725,7 @@ msgstr "缺省"
 
 #: plugins/cheatfind/init.lua:391
 msgid "Custom"
-msgstr "自订"
+msgstr "自定义"
 
 #: plugins/cheatfind/init.lua:392
 msgid "Cheat Name"
@@ -5734,7 +5734,7 @@ msgstr "作弊码名称"
 #: plugins/cheatfind/init.lua:398 plugins/cheatfind/init.lua:977
 #, lua-format
 msgid "Default name is %s"
-msgstr "缺省名称为 %s"
+msgstr "默认名称为 %s"
 
 #: plugins/cheatfind/init.lua:406
 msgid "Player"
@@ -5783,7 +5783,7 @@ msgstr "CPU 或内存"
 
 #: plugins/cheatfind/init.lua:501
 msgid "Changes to this only take effect when \"Start new search\" is selected"
-msgstr "此变更仅当选定 \"开始新搜寻\" 时生效"
+msgstr "此变更仅当选定 \"开始新搜索\" 时生效"
 
 #: plugins/cheatfind/init.lua:511
 msgid "Automatic"
@@ -5811,17 +5811,17 @@ msgstr "全部插槽已清除且目前状态已保存至插槽 1"
 
 #: plugins/cheatfind/init.lua:555
 msgid "Start new search"
-msgstr "开始新搜寻"
+msgstr "开始新搜索"
 
 #: plugins/cheatfind/init.lua:566
 #, lua-format
 msgid "Memory state saved to Slot %d"
-msgstr "记忆体状态已保存至插槽 %d"
+msgstr "内存状态已保存至插槽 %d"
 
 #: plugins/cheatfind/init.lua:583
 #, lua-format
 msgid "Save current memory state to Slot %d"
-msgstr "保存现有的记忆体状态至插槽 %d"
+msgstr "保存现有的内存状态至插槽 %d"
 
 #: plugins/cheatfind/init.lua:614
 #, lua-format
@@ -5907,7 +5907,7 @@ msgstr "任意"
 
 #: plugins/cheatfind/init.lua:731
 msgid "Data Format"
-msgstr "资料格式"
+msgstr "数据格式"
 
 #: plugins/cheatfind/init.lua:737
 msgid "Slot 1 Value"
@@ -5973,15 +5973,15 @@ msgstr "写入"
 
 #: plugins/cheatfind/init.lua:1003
 msgid "Watch"
-msgstr "监视"
+msgstr "预览"
 
 #: plugins/cheatfind/init.lua:1020
 msgid "Page"
-msgstr "页"
+msgstr "主页"
 
 #: plugins/cheatfind/init.lua:1039
 msgid "Clear Watches"
-msgstr "清除监视"
+msgstr "清除预览"
 
 #: plugins/cheatfind/init.lua:1055
 msgid "Cheat Finder"
@@ -5999,16 +5999,16 @@ msgstr "保存输入名称文件时失败"
 #: plugins/portname/init.lua:167
 #, lua-format
 msgid "Input port name file saved to %s"
-msgstr "输入埠名称文件保存至 %s"
+msgstr "输入端口名称文件保存至 %s"
 
 #: plugins/portname/init.lua:172
 msgid "Input ports"
-msgstr "输入埠"
+msgstr "输入端口"
 
 #: plugins/autofire/init.lua:98
 msgctxt "plugin-autofire"
 msgid "Failed to load autofire menu"
-msgstr "载入连射菜单时失败"
+msgstr "载入连发菜单时失败"
 
 #: plugins/autofire/init.lua:105
 msgctxt "plugin-autofire"
@@ -6103,7 +6103,7 @@ msgstr "完成"
 #: plugins/autofire/autofire_menu.lua:272
 msgctxt "plugin-autofire"
 msgid "Create"
-msgstr "建立"
+msgstr "新建"
 
 #: plugins/autofire/autofire_menu.lua:274
 msgctxt "plugin-autofire"
@@ -6318,7 +6318,7 @@ msgstr "新增输入宏"
 #: plugins/inputmacro/inputmacro_menu.lua:483
 msgctxt "plugin-inputmacro"
 msgid "Create"
-msgstr "建立"
+msgstr "新建"
 
 #: plugins/inputmacro/inputmacro_menu.lua:485
 msgctxt "plugin-inputmacro"


### PR DESCRIPTION
The revision refers to the Windows 11 Chinese Simplified menu buttons and option titles, many places are still not perfect, modify it again and again!Characteristic:
(1) Corrected the traditional and English characters that are currently left in MAME, such as 統 (統), 將 (will), (INI) initialization, etc., Figure 1
(2) Depending on the region, the name will be based on the mainland rather than Hong Kong and Taiwan, such as screen (screen), program (program), export (export), etc., Figure 2
(3) Delete duplicate redundant or unobstructed notes, etc., Figure 3
(4) Added the complete plug-in items that have not yet been integrated, Figure 4.
Left Official Version Right Modified style
![1](https://github.com/user-attachments/assets/e763327c-714b-4348-8bca-8c4e46cc32d1)
![2](https://github.com/user-attachments/assets/3d5d0fbd-0a6c-4c86-be14-1aef132d0df5)
![3](https://github.com/user-attachments/assets/734d822c-75bd-46e6-bd18-2d57c7df244e)
<img width="630" alt="4" src="https://github.com/user-attachments/assets/ed135384-23fd-4a34-871f-1d94a9ef3b42" />
