### PR TITLE
Add Windows on ARM build to CI

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -68,3 +68,48 @@ jobs:
           chdman.exe
           unidasm.exe
         if-no-files-found: error
+
+  build-windows-arm64:
+    runs-on: windows-11-arm
+    defaults:
+      run:
+        shell: msys2 {0}
+    strategy:
+      matrix:
+        subtarget: [mame, tiny]
+        include:
+          - subtarget: mame
+            executable: mame
+          - subtarget: tiny
+            executable: mametiny
+    steps:
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: CLANGARM64
+        install: git make mingw-w64-clang-aarch64-cc mingw-w64-clang-aarch64-python mingw-w64-clang-aarch64-libc++ mingw-w64-clang-aarch64-gcc-compat
+    - uses: actions/checkout@main
+      with:
+        fetch-depth: 0
+    - name: Build
+      env:
+        MINGW64: "/clangarm64"
+        OVERRIDE_AR: "llvm-ar"
+        OVERRIDE_CC: clang
+        OVERRIDE_CXX: clang++
+        ARCHOPTS: "-fuse-ld=lld"
+        SUBTARGET: ${{ matrix.subtarget }}
+        ARCHOPTS_C: " -Wno-nontrivial-memcall -march=armv8.2-a"
+        ARCHOPTS_CXX: " -Wno-nontrivial-memcall -march=armv8.2-a"
+        TOOLS: 1
+        PLATFORM: arm64
+      run: make -j3
+    - name: Validate
+      run: ./${{ matrix.executable }}.exe -validate
+    - uses: actions/upload-artifact@main
+      with:
+        name: ${{ matrix.executable }}-windows-clang-arm64-${{ github.sha }}
+        path: |
+          ${{ matrix.executable }}.exe
+          chdman.exe
+          unidasm.exe
+        if-no-files-found: error

--- a/3rdparty/bimg/3rdparty/astc-encoder/source/astcenc_mathlib.h
+++ b/3rdparty/bimg/3rdparty/astc-encoder/source/astcenc_mathlib.h
@@ -70,6 +70,9 @@
 #ifndef ASTCENC_NEON
   #if defined(__aarch64__)
     #define ASTCENC_NEON 1
+    #undef ASTCENC_SSE
+    #undef ASTCENC_AVX
+    #undef ASTCENC_POPCNT
   #else
     #define ASTCENC_NEON 0
   #endif

--- a/makefile
+++ b/makefile
@@ -142,7 +142,7 @@ MAKEPARAMS := -R
 ifeq ($(OS),Windows_NT)
 OS := windows
 GENIEOS := windows
-PLATFORM := x86
+PLATFORM ?= x86
 else
 UNAME := $(shell uname -mps)
 UNAME_M := $(shell uname -m)


### PR DESCRIPTION
Starts addressing https://github.com/orgs/mamedev/discussions/112

Now that Github has Windows on ARM runners, one can use them for native builds under the MSYS2 CLANGARM64 environment. 

The `mingw-w64-clang-aarch64-gcc-compat` package just adds an alias where `gcc` and `g++` are actually `clang` and `clang++`. There is some internal Makefile that is probably not honoring the `OVERRIDE_` variables, so an aliased `gcc` did the trick.

![image](https://github.com/user-attachments/assets/3e365807-2776-4700-b728-c4198b938e8a)
