### PR TITLE
cpu/z80/z80.cpp: Get rid of flag LUT tables

### DIFF
--- a/src/devices/cpu/z80/r800.cpp
+++ b/src/devices/cpu/z80/r800.cpp
@@ -74,7 +74,7 @@ u8 r800_device::r800_sll(u8 value)
 {
 	const u8 c = (value & 0x80) ? CF : 0;
 	const u8 res = u8(value << 1);
-	set_f(SZP[res] | c);
+	set_f(flags_szp(res) | c);
 	return res;
 }
 

--- a/src/devices/cpu/z80/z80.cpp
+++ b/src/devices/cpu/z80/z80.cpp
@@ -173,7 +173,7 @@ void z80_device::add_a(u8 value)
  ***************************************************************/
 void z80_device::adc_a(u8 value)
 {
-	const bool c = F & CF;
+	const int c = (F & CF) ? 1 : 0;
 	const u16 res = A + value + c;
 	u8 f = (((A ^ res) & (value ^ res)) >> 5) & VF;
 	f |= flags_szyxc(res);
@@ -202,7 +202,7 @@ void z80_device::sub_a(u8 value)
  ***************************************************************/
 void z80_device::sbc_a(u8 value)
 {
-	const bool c = F & CF;
+	const int c = (F & CF) ? 1 : 0;
 	const u16 res = A - value - c;
 	u8 f = (((A ^ value) & (A ^ res)) >> 5) & VF;
 	f |= NF | flags_szyxc(res);

--- a/src/devices/cpu/z80/z80.cpp
+++ b/src/devices/cpu/z80/z80.cpp
@@ -505,7 +505,10 @@ u8 z80_device::flags_sz_bit(u8 value)
 u8 z80_device::flags_szp(u8 value)
 {
 	u8 f = flags_sz(value);
-	f |= __builtin_parity(value) ? 0 : PF;
+	value ^= value >> 4;
+	value ^= value << 2;
+	value ^= value >> 1;
+	f |= ~value & PF;
 	return f;
 }
 

--- a/src/devices/cpu/z80/z80.cpp
+++ b/src/devices/cpu/z80/z80.cpp
@@ -173,7 +173,7 @@ void z80_device::add_a(u8 value)
  ***************************************************************/
 void z80_device::adc_a(u8 value)
 {
-	const int c = (F & CF) ? 1 : 0;
+	const int c = F & CF;
 	const u16 res = A + value + c;
 	u8 f = (((A ^ res) & (value ^ res)) >> 5) & VF;
 	f |= flags_szyxc(res);
@@ -202,7 +202,7 @@ void z80_device::sub_a(u8 value)
  ***************************************************************/
 void z80_device::sbc_a(u8 value)
 {
-	const int c = (F & CF) ? 1 : 0;
+	const int c = F & CF;
 	const u16 res = A - value - c;
 	u8 f = (((A ^ value) & (A ^ res)) >> 5) & VF;
 	f |= NF | flags_szyxc(res);

--- a/src/devices/cpu/z80/z80.cpp
+++ b/src/devices/cpu/z80/z80.cpp
@@ -34,16 +34,6 @@ TODO:
 #include "logmacro.h"
 
 
-bool z80_device::tables_initialised = false;
-u8 z80_device::SZ[] = {};       // zero and sign flags
-u8 z80_device::SZ_BIT[] = {};   // zero, sign and parity/overflow (=zero) flags for BIT opcode
-u8 z80_device::SZP[] = {};      // zero, sign and parity flags
-u8 z80_device::SZHV_inc[] = {}; // zero, sign, half carry and overflow flags INC r8
-u8 z80_device::SZHV_dec[] = {}; // zero, sign, half carry and overflow flags DEC r8
-u8 z80_device::SZHVC_add[] = {};
-u8 z80_device::SZHVC_sub[] = {};
-
-
 /***************************************************************
  * Enter halt state; write 1 to callback on first execution
  ***************************************************************/
@@ -112,7 +102,7 @@ u8 z80_device::arg_read()
 void z80_device::inc(u8 &r)
 {
 	++r;
-	set_f((F & CF) | SZHV_inc[r]);
+	set_f((F & CF) | flags_szhv_inc(r));
 }
 
 /***************************************************************
@@ -121,7 +111,7 @@ void z80_device::inc(u8 &r)
 void z80_device::dec(u8 &r)
 {
 	--r;
-	set_f((F & CF) | SZHV_dec[r]);
+	set_f((F & CF) | flags_szhv_dec(r));
 }
 
 /***************************************************************
@@ -170,9 +160,11 @@ void z80_device::rra()
  ***************************************************************/
 void z80_device::add_a(u8 value)
 {
-	u32 ah = AF & 0xff00;
-	u32 res = (u8)((ah >> 8) + value);
-	set_f(SZHVC_add[ah | res]);
+	const u16 res = A + value;
+	u8 f = (((A ^ res) & (value ^ res)) >> 5) & VF;
+	f |= flags_szyxc(res);
+	f |= ((A & 0x0f) + (value & 0x0f)) & HF;
+	set_f(f);
 	A = res;
 }
 
@@ -181,20 +173,27 @@ void z80_device::add_a(u8 value)
  ***************************************************************/
 void z80_device::adc_a(u8 value)
 {
-	u32 ah = AF & 0xff00, c = AF & 1;
-	u32 res = (u8)((ah >> 8) + value + c);
-	set_f(SZHVC_add[(c << 16) | ah | res]);
+	const bool c = F & CF;
+	const u16 res = A + value + c;
+	u8 f = (((A ^ res) & (value ^ res)) >> 5) & VF;
+	f |= flags_szyxc(res);
+	f |= ((A & 0x0f) + (value & 0x0f) + c) & HF;
+
+	set_f(f);
 	A = res;
 }
 
 /***************************************************************
- * SUB  n
+ * SUB  A,n
  ***************************************************************/
-void z80_device::sub(u8 value)
+void z80_device::sub_a(u8 value)
 {
-	u32 ah = AF & 0xff00;
-	u32 res = (u8)((ah >> 8) - value);
-	set_f(SZHVC_sub[ah | res]);
+	const u16 res = A - value;
+	u8 f = (((A ^ value) & (A ^ res)) >> 5) & VF;
+	f |= NF | flags_szyxc(res);
+	f |= ((A & 0x0f) - (value & 0x0f)) & HF;
+
+	set_f(f);
 	A = res;
 }
 
@@ -203,9 +202,13 @@ void z80_device::sub(u8 value)
  ***************************************************************/
 void z80_device::sbc_a(u8 value)
 {
-	u32 ah = AF & 0xff00, c = AF & 1;
-	u32 res = (u8)((ah >> 8) - value - c);
-	set_f(SZHVC_sub[(c << 16) | ah | res]);
+	const bool c = F & CF;
+	const u16 res = A - value - c;
+	u8 f = (((A ^ value) & (A ^ res)) >> 5) & VF;
+	f |= NF | flags_szyxc(res);
+	f |= ((A & 0x0f) - (value & 0x0f) - c) & HF;
+
+	set_f(f);
 	A = res;
 }
 
@@ -216,7 +219,7 @@ void z80_device::neg()
 {
 	u8 value = A;
 	A = 0;
-	sub(value);
+	sub_a(value);
 }
 
 /***************************************************************
@@ -236,7 +239,7 @@ void z80_device::daa()
 		if ((F&CF) | (A>0x99)) a+=0x60;
 	}
 
-	set_f((F&(CF|NF)) | (A>0x99) | ((A^a)&HF) | SZP[a]);
+	set_f((F&(CF|NF)) | (A>0x99) | ((A^a)&HF) | flags_szp(a));
 	A = a;
 }
 
@@ -246,7 +249,7 @@ void z80_device::daa()
 void z80_device::and_a(u8 value)
 {
 	A &= value;
-	set_f(SZP[A] | HF);
+	set_f(flags_szp(A) | HF);
 }
 
 /***************************************************************
@@ -255,7 +258,7 @@ void z80_device::and_a(u8 value)
 void z80_device::or_a(u8 value)
 {
 	A |= value;
-	set_f(SZP[A]);
+	set_f(flags_szp(A));
 }
 
 /***************************************************************
@@ -264,7 +267,7 @@ void z80_device::or_a(u8 value)
 void z80_device::xor_a(u8 value)
 {
 	A ^= value;
-	set_f(SZP[A]);
+	set_f(flags_szp(A));
 }
 
 /***************************************************************
@@ -272,10 +275,12 @@ void z80_device::xor_a(u8 value)
  ***************************************************************/
 void z80_device::cp(u8 value)
 {
-	unsigned val = value;
-	u32 ah = AF & 0xff00;
-	u32 res = (u8)((ah >> 8) - val);
-	set_f((SZHVC_sub[ah | res] & ~(YF | XF)) | (val & (YF | XF)));
+	const u16 res = A - value;
+	u8 f = (((A ^ value) & (A ^ res)) >> 5) & VF;
+	f |= NF | flags_szyxc(res);
+	f |= ((A & 0x0f) - (value & 0x0f)) & HF;
+
+	set_f((f & ~(YF | XF)) | (value & (YF | XF)));
 }
 
 /***************************************************************
@@ -297,7 +302,7 @@ u8 z80_device::rlc(u8 value)
 	unsigned res = value;
 	unsigned c = (res & 0x80) ? CF : 0;
 	res = ((res << 1) | (res >> 7)) & 0xff;
-	set_f(SZP[res] | c);
+	set_f(flags_szp(res) | c);
 	return res;
 }
 
@@ -309,7 +314,7 @@ u8 z80_device::rrc(u8 value)
 	unsigned res = value;
 	unsigned c = (res & 0x01) ? CF : 0;
 	res = ((res >> 1) | (res << 7)) & 0xff;
-	set_f(SZP[res] | c);
+	set_f(flags_szp(res) | c);
 	return res;
 }
 
@@ -321,7 +326,7 @@ u8 z80_device::rl(u8 value)
 	unsigned res = value;
 	unsigned c = (res & 0x80) ? CF : 0;
 	res = ((res << 1) | (F & CF)) & 0xff;
-	set_f(SZP[res] | c);
+	set_f(flags_szp(res) | c);
 	return res;
 }
 
@@ -333,7 +338,7 @@ u8 z80_device::rr(u8 value)
 	unsigned res = value;
 	unsigned c = (res & 0x01) ? CF : 0;
 	res = ((res >> 1) | (F << 7)) & 0xff;
-	set_f(SZP[res] | c);
+	set_f(flags_szp(res) | c);
 	return res;
 }
 
@@ -345,7 +350,7 @@ u8 z80_device::sla(u8 value)
 	unsigned res = value;
 	unsigned c = (res & 0x80) ? CF : 0;
 	res = (res << 1) & 0xff;
-	set_f(SZP[res] | c);
+	set_f(flags_szp(res) | c);
 	return res;
 }
 
@@ -357,7 +362,7 @@ u8 z80_device::sra(u8 value)
 	unsigned res = value;
 	unsigned c = (res & 0x01) ? CF : 0;
 	res = ((res >> 1) | (res & 0x80)) & 0xff;
-	set_f(SZP[res] | c);
+	set_f(flags_szp(res) | c);
 	return res;
 }
 
@@ -369,7 +374,7 @@ u8 z80_device::sll(u8 value)
 	unsigned res = value;
 	unsigned c = (res & 0x80) ? CF : 0;
 	res = ((res << 1) | 0x01) & 0xff;
-	set_f(SZP[res] | c);
+	set_f(flags_szp(res) | c);
 	return res;
 }
 
@@ -381,7 +386,7 @@ u8 z80_device::srl(u8 value)
 	unsigned res = value;
 	unsigned c = (res & 0x01) ? CF : 0;
 	res = (res >> 1) & 0xff;
-	set_f(SZP[res] | c);
+	set_f(flags_szp(res) | c);
 	return res;
 }
 
@@ -390,7 +395,7 @@ u8 z80_device::srl(u8 value)
  ***************************************************************/
 void z80_device::bit(int bit, u8 value)
 {
-	set_f((F & CF) | HF | (SZ_BIT[value & (1 << bit)] & ~(YF | XF)) | (value & (YF | XF)));
+	set_f((F & CF) | HF | (flags_sz_bit(value & (1 << bit)) & ~(YF | XF)) | (value & (YF | XF)));
 }
 
 /***************************************************************
@@ -398,7 +403,7 @@ void z80_device::bit(int bit, u8 value)
  ***************************************************************/
 void z80_device::bit_hl(int bit, u8 value)
 {
-	set_f((F & CF) | HF | (SZ_BIT[value & (1 << bit)] & ~(YF | XF)) | (WZ_H & (YF | XF)));
+	set_f((F & CF) | HF | (flags_sz_bit(value & (1 << bit)) & ~(YF | XF)) | (WZ_H & (YF | XF)));
 }
 
 /***************************************************************
@@ -406,7 +411,7 @@ void z80_device::bit_hl(int bit, u8 value)
  ***************************************************************/
 void z80_device::bit_xy(int bit, u8 value)
 {
-	set_f((F & CF) | HF | (SZ_BIT[value & (1 << bit)] & ~(YF | XF)) | ((m_ea >> 8) & (YF | XF)));
+	set_f((F & CF) | HF | (flags_sz_bit(value & (1 << bit)) & ~(YF | XF)) | ((m_ea >> 8) & (YF | XF)));
 }
 
 /***************************************************************
@@ -434,18 +439,18 @@ void z80_device::block_io_interrupted_flags()
 		F &= ~HF;
 		if (TDAT8 & 0x80)
 		{
-			F ^= (SZP[(B - 1) & 0x07] ^ PF) & PF;
+			F ^= (flags_szp((B - 1) & 0x07) ^ PF) & PF;
 			if ((B & 0x0f) == 0x00) F |= HF;
 		}
 		else
 		{
-			F ^= (SZP[(B + 1) & 0x07] ^ PF) & PF;
+			F ^= (flags_szp((B + 1) & 0x07) ^ PF) & PF;
 			if ((B & 0x0f) == 0x0f) F |= HF;
 		}
 	}
 	else
 	{
-		F ^=(SZP[B & 0x07] ^ PF) & PF;
+		F ^=(flags_szp(B & 0x07) ^ PF) & PF;
 	}
 }
 
@@ -476,6 +481,51 @@ void z80_device::illegal_2()
 			m_opcodes.read_byte((PC - 1) & 0xffff));
 }
 
+u8 z80_device::flags_szyxc(u16 value)
+{
+	u8 f = flags_sz(value);
+	f |= (value >> 8) & CF;
+	return f;
+}
+
+u8 z80_device::flags_sz(u8 value)
+{
+	u8 f = value & (SF | YF | XF);  // SF + undocumented flag bits 5+3
+	f |= value ? 0 : ZF;
+	return f;
+}
+
+u8 z80_device::flags_sz_bit(u8 value)
+{
+	u8 f = value & (SF | YF | XF);  // SF + undocumented flag bits 5+3
+	f |= value ? 0 : (ZF | PF);
+	return f;
+}
+
+u8 z80_device::flags_szp(u8 value)
+{
+	u8 f = flags_sz(value);
+	f |= __builtin_parity(value) ? 0 : PF;
+	return f;
+}
+
+u8 z80_device::flags_szhv_inc(u8 value)
+{
+	u8 f = flags_sz(value);
+	f |= (value == 0x80) ? VF : 0;
+	f |= ((value & 0x0f) == 0x00) ? HF : 0;
+	return f;
+}
+
+u8 z80_device::flags_szhv_dec(u8 value)
+{
+	u8 f = NF | flags_sz(value);
+	f |= (value == 0x7f) ? VF : 0;
+	f |= ((value & 0x0f) == 0x0f) ? HF : 0;
+	return f;
+}
+
+
 /****************************************************************************
  * Processor initialization
  ****************************************************************************/
@@ -493,75 +543,6 @@ void z80_device::device_validity_check(validity_checker &valid) const
 
 void z80_device::device_start()
 {
-	if (!tables_initialised)
-	{
-		u8 *padd = &SZHVC_add[  0*256];
-		u8 *padc = &SZHVC_add[256*256];
-		u8 *psub = &SZHVC_sub[  0*256];
-		u8 *psbc = &SZHVC_sub[256*256];
-		for (int oldval = 0; oldval < 256; oldval++)
-		{
-			for (int newval = 0; newval < 256; newval++)
-			{
-				// add or adc w/o carry set
-				int val = newval - oldval;
-				*padd = (newval) ? ((newval & 0x80) ? SF : 0) : ZF;
-				*padd |= (newval & (YF | XF));  // undocumented flag bits 5+3
-				if ((newval & 0x0f) < (oldval & 0x0f)) *padd |= HF;
-				if (newval < oldval) *padd |= CF;
-				if ((val^oldval^0x80) & (val^newval) & 0x80) *padd |= VF;
-				padd++;
-
-				// adc with carry set
-				val = newval - oldval - 1;
-				*padc = (newval) ? ((newval & 0x80) ? SF : 0) : ZF;
-				*padc |= (newval & (YF | XF));  // undocumented flag bits 5+3
-				if ((newval & 0x0f) <= (oldval & 0x0f)) *padc |= HF;
-				if (newval <= oldval) *padc |= CF;
-				if ((val^oldval^0x80) & (val^newval) & 0x80) *padc |= VF;
-				padc++;
-
-				// cp, sub or sbc w/o carry set
-				val = oldval - newval;
-				*psub = NF | ((newval) ? ((newval & 0x80) ? SF : 0) : ZF);
-				*psub |= (newval & (YF | XF));  // undocumented flag bits 5+3
-				if ((newval & 0x0f) > (oldval & 0x0f)) *psub |= HF;
-				if (newval > oldval) *psub |= CF;
-				if ((val^oldval) & (oldval^newval) & 0x80) *psub |= VF;
-				psub++;
-
-				// sbc with carry set
-				val = oldval - newval - 1;
-				*psbc = NF | ((newval) ? ((newval & 0x80) ? SF : 0) : ZF);
-				*psbc |= (newval & (YF | XF));  // undocumented flag bits 5+3
-				if ((newval & 0x0f) >= (oldval & 0x0f)) *psbc |= HF;
-				if (newval >= oldval) *psbc |= CF;
-				if ((val^oldval) & (oldval^newval) & 0x80) *psbc |= VF;
-				psbc++;
-			}
-		}
-
-		for (int i = 0; i < 256; i++)
-		{
-			int p = 0;
-			for (int b = 0; b < 8; b++)
-				p += BIT(i, b);
-			SZ[i] = i ? i & SF : ZF;
-			SZ[i] |= (i & (YF | XF));         // undocumented flag bits 5+3
-			SZ_BIT[i] = i ? i & SF : ZF | PF;
-			SZ_BIT[i] |= (i & (YF | XF));     // undocumented flag bits 5+3
-			SZP[i] = SZ[i] | ((p & 1) ? 0 : PF);
-			SZHV_inc[i] = SZ[i];
-			if (i == 0x80) SZHV_inc[i] |= VF;
-			if ((i & 0x0f) == 0x00) SZHV_inc[i] |= HF;
-			SZHV_dec[i] = SZ[i] | NF;
-			if (i == 0x7f) SZHV_dec[i] |= VF;
-			if ((i & 0x0f) == 0x0f) SZHV_dec[i] |= HF;
-		}
-
-		tables_initialised = true;
-	}
-
 	save_item(NAME(PRVPC));
 	save_item(NAME(PC));
 	save_item(NAME(SP));

--- a/src/devices/cpu/z80/z80.h
+++ b/src/devices/cpu/z80/z80.h
@@ -77,6 +77,12 @@ protected:
 
 	void illegal_1();
 	void illegal_2();
+	u8 flags_szyxc(u16 value);
+	u8 flags_sz(u8 value);
+	u8 flags_sz_bit(u8 value);
+	u8 flags_szp(u8 value);
+	u8 flags_szhv_inc(u8 value);
+	u8 flags_szhv_dec(u8 value);
 
 	void halt();
 	void leave_halt();
@@ -88,7 +94,7 @@ protected:
 	void rra();
 	void add_a(u8 value);
 	void adc_a(u8 value);
-	void sub(u8 value);
+	void sub_a(u8 value);
 	void sbc_a(u8 value);
 	void neg();
 	void daa();
@@ -180,16 +186,6 @@ protected:
 	u8 m_m1_cycles;
 	u8 m_memrq_cycles;
 	u8 m_iorq_cycles;
-
-	static bool tables_initialised;
-	static u8 SZ[0x100];       // zero and sign flags
-	static u8 SZ_BIT[0x100];   // zero, sign and parity/overflow (=zero) flags for BIT opcode
-	static u8 SZP[0x100];      // zero, sign and parity flags
-	static u8 SZHV_inc[0x100]; // zero, sign, half carry and overflow flags INC r8
-	static u8 SZHV_dec[0x100]; // zero, sign, half carry and overflow flags DEC r8
-
-	static u8 SZHVC_add[2 * 0x100 * 0x100];
-	static u8 SZHVC_sub[2 * 0x100 * 0x100];
 };
 
 DECLARE_DEVICE_TYPE(Z80, z80_device)

--- a/src/devices/cpu/z80/z80.lst
+++ b/src/devices/cpu/z80/z80.lst
@@ -206,10 +206,10 @@ macro   r800:ld_r_a
 
 macro   ld_a_r
 	call nomreq_ir 1
-	A = (m_r & 0x7f) | m_r2; set_f((F & CF) | SZ[A] | (m_iff2 << 2)); m_after_ldair = true;
+	A = (m_r & 0x7f) | m_r2; set_f((F & CF) | flags_sz(A) | (m_iff2 << 2)); m_after_ldair = true;
 
 macro   r800:ld_a_r
-	A = (m_r & 0x7f) | m_r2; set_f((F & CF) | SZ[A] | (m_iff2 << 2)); m_after_ldair = true;
+	A = (m_r & 0x7f) | m_r2; set_f((F & CF) | flags_sz(A) | (m_iff2 << 2)); m_after_ldair = true;
 
 macro   ld_i_a
 	call nomreq_ir 1
@@ -220,10 +220,10 @@ macro   r800:ld_i_a
 
 macro   ld_a_i
 	call nomreq_ir 1
-	A = m_i; set_f((F & CF) | SZ[A] | (m_iff2 << 2)); m_after_ldair = true;
+	A = m_i; set_f((F & CF) | flags_sz(A) | (m_iff2 << 2)); m_after_ldair = true;
 
 macro   r800:ld_a_i
-	A = m_i; set_f((F & CF) | SZ[A] | (m_iff2 << 2)); m_after_ldair = true;
+	A = m_i; set_f((F & CF) | flags_sz(A) | (m_iff2 << 2)); m_after_ldair = true;
 
 macro   rst	 addr
 	TDAT = PC;
@@ -237,7 +237,7 @@ macro   rrd
 	4 * call nomreq_addr
 	TDAT_H = TDAT8; TDAT8 = (TDAT8 >> 4) | (A << 4);
 	call wm
-	A = (A & 0xf0) | (TDAT_H & 0x0f); set_f((F & CF) | SZP[A]);
+	A = (A & 0xf0) | (TDAT_H & 0x0f); set_f((F & CF) | flags_szp(A));
 
 macro   rld
 	TADR = HL;
@@ -246,7 +246,7 @@ macro   rld
 	4 * call nomreq_addr
 	TDAT_H = TDAT8; TDAT8 = (TDAT8 << 4) | (A & 0x0f);
 	call wm
-	A = (A & 0xf0) | (TDAT_H >> 4); set_f((F & CF) | SZP[A]);
+	A = (A & 0xf0) | (TDAT_H >> 4); set_f((F & CF) | flags_szp(A));
 
 macro   ex_sp
 	TDAT2 = TDAT;
@@ -300,13 +300,13 @@ macro   cpi
 	TADR = HL;
 	call rm
 	5 * call nomreq_addr
-	{ u8 res = A - TDAT8; WZ++; HL++; BC--; set_f((F & CF) | (SZ[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF); if (F & HF) res -= 1; if (res & 0x02) F |= YF; if (res & 0x08) F |= XF; if (BC) F |= VF; }
+	{ u8 res = A - TDAT8; WZ++; HL++; BC--; set_f((F & CF) | (flags_sz(res)&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF); if (F & HF) res -= 1; if (res & 0x02) F |= YF; if (res & 0x08) F |= XF; if (BC) F |= VF; }
 
 macro   r800:cpi
 	TADR = HL;
 	call rm
 	call nomreq_addr
-	{ u8 res = A - TDAT8; WZ++; HL++; BC--; set_f((F & CF) | (SZ[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF); if (F & HF) res -= 1; if (res & 0x02) F |= YF; if (res & 0x08) F |= XF; if (BC) F |= VF; }
+	{ u8 res = A - TDAT8; WZ++; HL++; BC--; set_f((F & CF) | (flags_sz(res)&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF); if (F & HF) res -= 1; if (res & 0x02) F |= YF; if (res & 0x08) F |= XF; if (BC) F |= VF; }
 
 macro   ini
 	call nomreq_ir 1
@@ -314,14 +314,14 @@ macro   ini
 	call in
 	WZ = BC + 1; B--; TADR = HL;
 	call wm
-	{ HL++; set_f(SZ[B]); unsigned t = (unsigned)((C + 1) & 0xff) + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= SZP[(u8)(t & 0x07) ^ B] & PF; }
+	{ HL++; set_f(flags_sz(B)); unsigned t = (unsigned)((C + 1) & 0xff) + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= flags_szp((u8)(t & 0x07) ^ B) & PF; }
 
 macro   r800:ini
 	TADR = BC;
 	call in
 	WZ = BC + 1; B--; TADR = HL;
 	call wm
-	{ HL++; set_f(SZ[B]); unsigned t = (unsigned)((C + 1) & 0xff) + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= SZP[(u8)(t & 0x07) ^ B] & PF; }
+	{ HL++; set_f(flags_sz(B)); unsigned t = (unsigned)((C + 1) & 0xff) + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= flags_szp((u8)(t & 0x07) ^ B) & PF; }
 
 macro   outi
 	call nomreq_ir 1
@@ -329,14 +329,14 @@ macro   outi
 	call rm
 	B--; WZ = BC + 1; TADR = BC;
 	call out
-	{ HL++; set_f(SZ[B]); unsigned t = (unsigned)L + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= SZP[(u8)(t & 0x07) ^ B] & PF; }
+	{ HL++; set_f(flags_sz(B)); unsigned t = (unsigned)L + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= flags_szp((u8)(t & 0x07) ^ B) & PF; }
 
 macro   r800:outi
 	TADR = HL;
 	call rm
 	B--; WZ = BC + 1; TADR = BC;
 	call out
-	{ HL++; set_f(SZ[B]); unsigned t = (unsigned)L + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= SZP[(u8)(t & 0x07) ^ B] & PF; }
+	{ HL++; set_f(flags_sz(B)); unsigned t = (unsigned)L + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= flags_szp((u8)(t & 0x07) ^ B) & PF; }
 
 macro   ldd
 	TADR = HL;
@@ -359,14 +359,14 @@ macro   cpd
 	call rm
 	TADR = HL;
 	5 * call nomreq_addr
-	{ u8 res = A - TDAT8; WZ--; HL--; BC--; set_f((F & CF) | (SZ[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF); if (F & HF) res -= 1; if (res & 0x02) F |= YF; if (res & 0x08) F |= XF; if (BC) F |= VF; }
+	{ u8 res = A - TDAT8; WZ--; HL--; BC--; set_f((F & CF) | (flags_sz(res)&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF); if (F & HF) res -= 1; if (res & 0x02) F |= YF; if (res & 0x08) F |= XF; if (BC) F |= VF; }
 
 macro   r800:cpd
 	TADR = HL;
 	call rm
 	TADR = HL;
 	call nomreq_addr
-	{ u8 res = A - TDAT8; WZ--; HL--; BC--; set_f((F & CF) | (SZ[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF); if (F & HF) res -= 1; if (res & 0x02) F |= YF; if (res & 0x08) F |= XF; if (BC) F |= VF; }
+	{ u8 res = A - TDAT8; WZ--; HL--; BC--; set_f((F & CF) | (flags_sz(res)&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF); if (F & HF) res -= 1; if (res & 0x02) F |= YF; if (res & 0x08) F |= XF; if (BC) F |= VF; }
 
 macro   ind
 	call nomreq_ir 1
@@ -374,14 +374,14 @@ macro   ind
 	call in
 	WZ = BC - 1; B--; TADR = HL;
 	call wm
-	{ HL--; set_f(SZ[B]); unsigned t = ((unsigned)(C - 1) & 0xff) + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= SZP[(u8)(t & 0x07) ^ B] & PF; }
+	{ HL--; set_f(flags_sz(B)); unsigned t = ((unsigned)(C - 1) & 0xff) + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= flags_szp((u8)(t & 0x07) ^ B) & PF; }
 
 macro   r800:ind
 	TADR = BC;
 	call in
 	WZ = BC - 1; B--; TADR = HL;
 	call wm
-	{ HL--; set_f(SZ[B]); unsigned t = ((unsigned)(C - 1) & 0xff) + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= SZP[(u8)(t & 0x07) ^ B] & PF; }
+	{ HL--; set_f(flags_sz(B)); unsigned t = ((unsigned)(C - 1) & 0xff) + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= flags_szp((u8)(t & 0x07) ^ B) & PF; }
 
 macro   outd
 	call nomreq_ir 1
@@ -389,14 +389,14 @@ macro   outd
 	call rm
 	B--; WZ = BC - 1; TADR = BC;
 	call out
-	{ HL--; set_f(SZ[B]); unsigned t = (unsigned)L + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= SZP[(u8)(t & 0x07) ^ B] & PF; }
+	{ HL--; set_f(flags_sz(B)); unsigned t = (unsigned)L + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= flags_szp((u8)(t & 0x07) ^ B) & PF; }
 
 macro   r800:outd
 	TADR = HL;
 	call rm
 	B--; WZ = BC - 1; TADR = BC;
 	call out
-	{ HL--; set_f(SZ[B]); unsigned t = (unsigned)L + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= SZP[(u8)(t & 0x07) ^ B] & PF; }
+	{ HL--; set_f(flags_sz(B)); unsigned t = (unsigned)L + (unsigned)TDAT8; if (TDAT8 & SF) F |= NF; if (t & 0x100) F |= HF | CF; F |= flags_szp((u8)(t & 0x07) ^ B) & PF; }
 
 macro   ldir
 	call ldi
@@ -3605,10 +3605,10 @@ dd93	# DB   DD
 	call jump 0093
 
 dd94	# SUB  HX
-	sub(HX);
+	sub_a(HX);
 
 dd95	# SUB  LX
-	sub(LX);
+	sub_a(LX);
 
 dd96	# SUB  (IX+o)
 	call eax
@@ -3616,7 +3616,7 @@ dd96	# SUB  (IX+o)
 	5 * call nomreq_addr
 	TADR = m_ea;
 	call rm
-	sub(TDAT8);
+	sub_a(TDAT8);
 
 dd97	# DB   DD
 	illegal_1();
@@ -4693,10 +4693,10 @@ fd93	# DB   FD
 	call jump 0093
 
 fd94	# SUB  HY
-	sub(HY);
+	sub_a(HY);
 
 fd95	# SUB  LY
-	sub(LY);
+	sub_a(LY);
 
 fd96	# SUB  (IY+o)
 	call eay
@@ -4704,7 +4704,7 @@ fd96	# SUB  (IY+o)
 	5 * call nomreq_addr
 	TADR = m_ea;
 	call rm
-	sub(TDAT8);
+	sub_a(TDAT8);
 
 fd97	# DB   FD
 	illegal_1();
@@ -5338,7 +5338,7 @@ ed3f	# DB   ED
 ed40	# IN   B,(C)
 	TADR = BC;
 	call in
-	B = TDAT8; set_f((F & CF) | SZP[B]); WZ = TADR + 1;
+	B = TDAT8; set_f((F & CF) | flags_szp(B)); WZ = TADR + 1;
 
 ed41	# OUT  (C),B
 	TADR = BC; TDAT8 = B;
@@ -5370,7 +5370,7 @@ ed47	# LD   i,A
 ed48	# IN   C,(C)
 	TADR = BC;
 	call in
-	C = TDAT8; set_f((F & CF) | SZP[C]); WZ = TADR + 1;
+	C = TDAT8; set_f((F & CF) | flags_szp(C)); WZ = TADR + 1;
 
 ed49	# OUT  (C),C
 	TADR = BC; TDAT8 = C;
@@ -5402,7 +5402,7 @@ ed4f	# LD   r,A
 ed50	# IN   D,(C)
 	TADR = BC;
 	call in
-	D = TDAT8; set_f((F & CF) | SZP[D]); WZ = TADR + 1;
+	D = TDAT8; set_f((F & CF) | flags_szp(D)); WZ = TADR + 1;
 
 ed51	# OUT  (C),D
 	TADR = BC; TDAT8 = D;
@@ -5434,7 +5434,7 @@ ed57	# LD   A,i
 ed58	# IN   E,(C)
 	TADR = BC;
 	call in
-	E = TDAT8; set_f((F & CF) | SZP[E]); WZ = TADR + 1;
+	E = TDAT8; set_f((F & CF) | flags_szp(E)); WZ = TADR + 1;
 
 ed59	# OUT  (C),E
 	TADR = BC; TDAT8 = E;
@@ -5466,7 +5466,7 @@ ed5f	# LD   A,r
 ed60	# IN   H,(C)
 	TADR = BC;
 	call in
-	H = TDAT8; set_f((F & CF) | SZP[H]); WZ = TADR + 1;
+	H = TDAT8; set_f((F & CF) | flags_szp(H)); WZ = TADR + 1;
 
 ed61	# OUT  (C),H
 	TADR = BC; TDAT8 = H;
@@ -5498,7 +5498,7 @@ ed67	# RRD  (HL)
 ed68	# IN   L,(C)
 	TADR = BC;
 	call in
-	L = TDAT8; set_f((F & CF) | SZP[L]); WZ = TADR + 1;
+	L = TDAT8; set_f((F & CF) | flags_szp(L)); WZ = TADR + 1;
 
 ed69	# OUT  (C),L
 	TADR = BC; TDAT8 = L;
@@ -5530,7 +5530,7 @@ ed6f	# RLD  (HL)
 ed70	# IN   0,(C)
 	TADR = BC;
 	call in
-	set_f((F & CF) | SZP[TDAT8]); WZ = TADR + 1;
+	set_f((F & CF) | flags_szp(TDAT8)); WZ = TADR + 1;
 
 ed71	# OUT  (C),0
 	TADR = BC; TDAT8 = 0;
@@ -5562,7 +5562,7 @@ ed77	# DB   ED,77
 ed78	# IN   A,(C)
 	TADR = BC;
 	call in
-	A = TDAT8; set_f((F & CF) | SZP[A]); WZ = TADR + 1;
+	A = TDAT8; set_f((F & CF) | flags_szp(A)); WZ = TADR + 1;
 
 ed79	# OUT  (C),A
 	TADR = BC; TDAT8 = A;
@@ -6490,30 +6490,30 @@ edff	# DB   ED
 	adc_a(A);
 
 0090	# SUB  B
-	sub(B);
+	sub_a(B);
 
 0091	# SUB  C
-	sub(C);
+	sub_a(C);
 
 0092	# SUB  D
-	sub(D);
+	sub_a(D);
 
 0093	# SUB  E
-	sub(E);
+	sub_a(E);
 
 0094	# SUB  H
-	sub(H);
+	sub_a(H);
 
 0095	# SUB  L
-	sub(L);
+	sub_a(L);
 
 0096	# SUB  (HL)
 	TADR = HL;
 	call rm
-	sub(TDAT8);
+	sub_a(TDAT8);
 
 0097	# SUB  A
-	sub(A);
+	sub_a(A);
 
 0098	# SBC  A,B
 	sbc_a(B);
@@ -6733,7 +6733,7 @@ edff	# DB   ED
 
 00d6	# SUB  n
 	call arg
-	sub(TDAT8);
+	sub_a(TDAT8);
 
 00d7	# RST  2
 	call rst 0x10


### PR DESCRIPTION
Seams like there is no advantage from this look ups.
Potentially opens a room for further optimizations.