### PR TITLE
sgx.xml: Changed media description

### DIFF
--- a/hash/sgx.xml
+++ b/hash/sgx.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="sgx" description="NEC Supergrafx cartridges">
+<softwarelist name="sgx" description="NEC Supergrafx HuCards">
 	<software name="1941">
 		<description>1941 - Counter Attack</description>
 		<year>1991</year>


### PR DESCRIPTION
Replaced "cartridges" to "HuCards" on the software list description.