### PR TITLE
ef9345: apply same double-height scaling as the real chip

### DIFF
--- a/src/devices/video/ef9345.cpp
+++ b/src/devices/video/ef9345.cpp
@@ -352,25 +352,25 @@ uint8_t ef9345_device::get_dial(uint8_t x, uint8_t attrib)
 void ef9345_device::zoom(uint8_t *pix, uint16_t n)
 {
 	uint8_t i, j;
-	if ((n & 0x0a) == 0)
-		for(i = 0; i < 80; i += 8) // 1, 4, 5
+	if ((n & 0x0a) == 0) // n = 1, 4, 5 (left side)
+		for(i = 0; i < 80; i += 8)
 			for(j = 7; j > 0; j--)
 				pix[i + j] = pix[i + j / 2];
 
-	if ((n & 0x05) == 0)
-		for(i = 0; i < 80; i += 8) // 2, 8, 10
+	if ((n & 0x05) == 0) // n = 2, 8, 10 (right side)
+		for(i = 0; i < 80; i += 8)
 			for(j =0 ; j < 7; j++)
 				pix[i + j] = pix[i + 4 + j / 2];
 
-	if ((n & 0x0c) == 0)
-		for(i = 0; i < 8; i++) // 1, 2, 3
+	if ((n & 0x0c) == 0) // n = 1, 2, 3 (top side)
+		for(i = 0; i < 8; i++)
 			for(j = 9; j > 0; j--)
-				pix[i + 8 * j] = pix[i + 8 * (j / 2)];
+				pix[i + 8 * j] = pix[i + 8 * ((j-1) / 2)];
 
-	if ((n & 0x03) == 0)
-		for(i = 0; i < 8; i++) // 4, 8, 12
+	if ((n & 0x03) == 0) // n = 4, 8, 12 (bottom side)
+		for(i = 0; i < 8; i++)
 			for(j = 0; j < 9; j++)
-				pix[i + 8 * j] = pix[i + 40 + 8 * (j / 2)];
+				pix[i + 8 * j] = pix[i + 32 + 8 * ((j+1) / 2)];
 }
 
 


### PR DESCRIPTION
Before this commit, characters with the double-height attribute (H) were scaled by equally repeating all their scanlines twice.

In the real chip, the first scanline is repeated three times and the last one only once.

---
Image comparisons (source code [here](https://github.com/fabio-d/minitel-ef9345-testsuite/blob/512d2378df58b25683431e9b077d3fa9b13f88c8/tests/test_size.py#L103)):
 * real output from both EF9345 and TS9347 chips (captured via a [custom board](https://github.com/fabio-d/minitel-ef9345-testsuite/tree/main/hw_devboard)):
![real_chip](https://github.com/user-attachments/assets/94b1d863-d1b1-4eaf-8dbc-13835d59c4e9)
* current MAME output:
![mame](https://github.com/user-attachments/assets/6326b92c-4f06-424a-b049-21c5dce2462c)

The four boxes show the four different scaling modes supported by the chip:
1. Regular size (i.e. no scaling)
1. Double width
1. Double height
1. Double width and height

As you can see, in the last two boxes (those involving double height) the first three lines are different and all the subsequent lines are shifted. This PR makes the output of MAME match the real chips.