### PR TITLE
ef9345: fix insert and cursor rendering logic

### DIFF
--- a/src/devices/video/ef9345.h
+++ b/src/devices/video/ef9345.h
@@ -78,9 +78,10 @@ private:
 	uint8_t get_dial(uint8_t x, uint8_t attrib);
 	void zoom(uint8_t *pix, uint16_t n);
 	uint16_t indexblock(uint16_t x, uint16_t y);
-	void bichrome40(uint8_t type, uint16_t address, uint8_t dial, uint16_t iblock, uint16_t x, uint16_t y, uint8_t c0, uint8_t c1, uint8_t insert, uint8_t flash, uint8_t hided, uint8_t negative, uint8_t underline);
+	std::tuple<uint8_t, uint8_t, bool> makecolors(uint8_t c0, uint8_t c1, bool insert, bool flash, bool conceal, bool negative, bool cursor);
+	void bichrome40(uint8_t type, uint16_t address, uint8_t dial, uint16_t iblock, uint16_t x, uint16_t y, uint8_t c0, uint8_t c1, bool insert, bool flash, bool conceal, bool negative, bool underline);
 	void quadrichrome40(uint8_t c, uint8_t b, uint8_t a, uint16_t x, uint16_t y);
-	void bichrome80(uint8_t c, uint8_t a, uint16_t x, uint16_t y, uint8_t cursor);
+	void bichrome80(uint8_t c, uint8_t a, uint16_t x, uint16_t y, bool cursor);
 	void makechar(uint16_t x, uint16_t y);
 	void draw_border(uint16_t line);
 	void makechar_16x40(uint16_t x, uint16_t y);
@@ -103,7 +104,7 @@ private:
 	uint8_t m_border[80];                     //border color
 	uint16_t m_block;                         //current memory block
 	uint16_t m_ram_base[4];                   //index of ram charset
-	uint8_t m_blink;                          //cursor status
+	uint8_t m_blink_phase;                    //flash and cursor blink phase
 	uint8_t m_last_dial[40];                  //last chars dial (for determinate the zoom position)
 	uint8_t m_latchc0;                        //background color latch
 	uint8_t m_latchm;                         //hided attribute latch


### PR DESCRIPTION
Hello, this PR rewrites how the "insert" attribute is processed to solve the issue discussed in https://github.com/jfdelnero/minitel/issues/3#issuecomment-2571487936 and briefly mentioned in #13200.

TL;DR: MAME's current handling of the background color is wrong for the TS9347 video chip variant, and the "insert" attribute is handled wrong on EF9345 too. In addition, the hardware cursor should blink twice as fast as flashing text, instead of the same rate.

Longer recap from that discussion:
- EF9345/TS9347 have a per-character attribute called "insert" that, in conjunction with the PAT register, can be used to force colors to black in some conditions.
- The **minitel2**'s *demov1* bios rendered correctly in MAME, but *ft_bv4* and *ft_bv9* display very noticeable glitches in many Videotex pages, such as those in the [screenshots here](https://github.com/jfdelnero/minitel/issues/3#issue-2768362703):<br/><img src="https://github.com/user-attachments/assets/e36c5a5a-0a32-4de5-8e45-3881aaa3dce5" width="150"/> <img src="https://github.com/user-attachments/assets/6ef0c1ef-4be3-4917-abb7-237ea34d8ae2" width="150"/> <img src="https://github.com/user-attachments/assets/eee2038d-bd77-40dc-9620-7310dd44001f" width="150"/> <img src="https://github.com/user-attachments/assets/015b6802-a5bb-4bb7-ae22-1aa4fa630bc3" width="150"/><br/>instead of<br/><img src="https://github.com/user-attachments/assets/0da48bb9-de68-4f32-a5b7-82d09bbe4d1e" width="150"/> <img src="https://github.com/user-attachments/assets/87de90ca-4314-4c18-8cdf-f13102b03c67" width="150"/> <img src="https://github.com/user-attachments/assets/4903b0e4-f2d4-43ad-8ca4-bea1749d313f" width="150"/> <img src="https://github.com/user-attachments/assets/6e0457bc-2f48-47d1-ac85-1c775ca5862b" width="150"/>
- It turned out that MAME currently contains wrong code that always forces the background of all characters rendered by the **minitel2** machine to black, regardless of insert, PAT or the character's background color.
https://github.com/mamedev/mame/blob/b4d55beeade387baabb6dcca3a58bbfff51fbb6d/src/devices/video/ef9345.cpp#L417-L420
- Just removing those lines made *ft_bv4* and *ft_bv9* render correctly but broke *demov1*, because MAME's current support for "insert" (on which *demov1* relies in order to set black backgrounds) is not feature-complete https://github.com/mamedev/mame/blob/b4d55beeade387baabb6dcca3a58bbfff51fbb6d/src/devices/video/ef9345.cpp#L433-L440

@jfdelnero and I initially made some experiments over the Internet on a real Minitel 2 to better understand how the PAT register works. I've then created a [custom "development" board](https://github.com/fabio-d/minitel-ef9345-testsuite/tree/main/hw_devboard) hosting real EF9345/TS9347 chips I bought on eBay. Thanks to this board I've written automatic tests to exhaustively capture the output of all the combinations of PAT and insert attribute values and, in addition, the interactions with the hardware cursor too.

This PR:
- Removes the wrong "background is always black" code block.
- Properly implements the insert attribute under all the possible PAT values (pixel-perfect validated against the output of the real chip).
- Fixes the timing of the hardware cursor which, when positioned on flashing text, shows that it alternates between 4 phases instead of 2:
  - Old MAME rendering (incorrect):<br/><img src="https://github.com/user-attachments/assets/7bc04cb8-9154-4256-9f21-ef1bf4352509"/>
  - Correct rendering (with this PR), validated with the real chip:<br/><img src="https://github.com/fabio-d/minitel-ef9345-testsuite/blob/main/tests/test_colors_data/test_40columns_cursor_EF9345_pat60mat60a08b00.png?raw=true"/>