### PR TITLE
oberheim/dmx.cpp: Adapting to new sound interface.

### DIFF
--- a/src/mame/oberheim/dmx.cpp
+++ b/src/mame/oberheim/dmx.cpp
@@ -1222,8 +1222,8 @@ void dmx_state::update_mix_level(int voice)
 	const float rc_c = (voice == METRONOME_INDEX) ? PB_C24 : VC_C10;
 
 	m_voice_rc[voice]->filter_rc_set_RC(filter_rc_device::HIGHPASS, rc_r, 0, 0, rc_c);
-	m_left_mixer->set_input_gain(voice, gain_left);
-	m_right_mixer->set_input_gain(voice, gain_right);
+	m_voice_rc[voice]->set_route_gain(0, m_left_mixer, 0, gain_left);
+	m_voice_rc[voice]->set_route_gain(0, m_right_mixer, 0, gain_right);
 
 	LOGMASKED(LOG_FADERS, "Voice %d volume changed to: %d (gain L:%f, R:%f), HPF cutoff: %.2f Hz\n",
 			voice, pot_percent, gain_left, gain_right, 1.0F / (2 * float(M_PI) * r_gnd * rc_c));


### PR DESCRIPTION
This fixes a `Fatal error: Requested input 3 on sound device :left_mixer which only has 1.`

If this is the right fix (it does work), I will also incorporate it in the linndrum. It requires some rearrangement there, so I first wanted to verify this is an expected change in behavior for `set_input_gain`.
 <br/><br/>
 
I also noticed another difference. Say we do the following:
```
    m_stream->update(); 
    attotime t = machine().time();
```

In the past, `sound_stream_update()` invocations that happened after the snippet above executed satisfied: `inputs[0].start_time() >= t`.  This does not seem to be the case now, where we can get `stream.start_time() < t`. Is this expected? Or maybe I was just lucky in the past, and there was no such guarantee? :)

This is reproducible on the `obdmx`. Either in a debug build, or by changing the following `assert` to a hard failure: https://github.com/mamedev/mame/blob/099e3a6a8574e919d9b7b472dc73691cfc119cfb/src/devices/sound/va_eg.cpp#L78-L82