### PR TITLE
Disable assembly including DRC on unsupported platforms

### DIFF
--- a/makefile
+++ b/makefile
@@ -396,6 +396,18 @@ ifeq ($(findstring aarch64,$(UNAME)),aarch64)
 ARCHITECTURE :=
 endif
 
+ifneq (,$(findstring ppc,$(UNAME)))
+ifndef FORCE_DRC_C_BACKEND
+	FORCE_DRC_C_BACKEND := 1
+endif
+endif
+
+ifneq (,$(findstring s390x,$(UNAME)))
+ifndef NOASM
+	NOASM := 1
+endif
+endif
+
 # Autodetect BIGENDIAN
 # MacOSX
 ifndef BIGENDIAN


### PR DESCRIPTION
Disable all assembly on s390x and DRC assembly on ppc.

This should fix #13649.

I am waiting for the test build to complete hence the draft status.