### PR TITLE
(Proposal) emu/sound.cpp: Have update() also compute the sample spanning the current time.

### DIFF
--- a/docs/source/techspecs/device_sound_interface.rst
+++ b/docs/source/techspecs/device_sound_interface.rst
@@ -272,7 +272,7 @@ multiplies the current gain by the given value.
 The method ``set_sample_rate`` allows to change the sample rate of the
 stream.  The method ``update`` triggers a call of
 ``sound_stream_update`` on the stream and the ones it depends on to
-compute all samples up to and including the one spanning the current time.
+compute all samples whose ``sample_time()`` is smaller than the update time.
 
 
 4. Devices using device_mixer_interface

--- a/docs/source/techspecs/device_sound_interface.rst
+++ b/docs/source/techspecs/device_sound_interface.rst
@@ -272,7 +272,7 @@ multiplies the current gain by the given value.
 The method ``set_sample_rate`` allows to change the sample rate of the
 stream.  The method ``update`` triggers a call of
 ``sound_stream_update`` on the stream and the ones it depends on to
-reach the current time in terms of samples.
+compute all samples up to and including the one spanning the current time.
 
 
 4. Devices using device_mixer_interface

--- a/docs/source/techspecs/device_sound_interface.rst
+++ b/docs/source/techspecs/device_sound_interface.rst
@@ -272,7 +272,8 @@ multiplies the current gain by the given value.
 The method ``set_sample_rate`` allows to change the sample rate of the
 stream.  The method ``update`` triggers a call of
 ``sound_stream_update`` on the stream and the ones it depends on to
-compute all samples whose ``sample_time()`` is smaller than the update time.
+compute all samples whose ``sample_time()`` is smaller or equal to the update
+time.
 
 
 4. Devices using device_mixer_interface

--- a/src/emu/sound.cpp
+++ b/src/emu/sound.cpp
@@ -491,7 +491,8 @@ void sound_stream::init()
 u64 sound_stream::get_current_sample_index() const
 {
 	attotime now = m_device.machine().time();
-	return now.m_seconds * m_sample_rate + ((now.m_attoseconds / 1'000'000'000) * m_sample_rate) / 1'000'000'000;
+	// The "+ 500'000'000" ensures the result of the integer divisions is rounded up.
+	return now.m_seconds * m_sample_rate + ((((now.m_attoseconds + 500'000'000) / 1'000'000'000) * m_sample_rate) + 500'000'000) / 1'000'000'000;
 }
 
 void sound_stream::update()
@@ -501,7 +502,7 @@ void sound_stream::update()
 
 	// Find out where we are and how much we have to do
 	u64 idx = get_current_sample_index();
-	m_samples_to_update = idx - m_output_buffer.write_sample();
+	m_samples_to_update = idx - m_output_buffer.write_sample() + 1;
 
 	if(m_samples_to_update > 0) {
 		m_in_update = true;
@@ -523,7 +524,7 @@ void sound_stream::update_nodeps()
 
 	// Find out where we are and how much we have to do
 	u64 idx = get_current_sample_index();
-	m_samples_to_update = idx - m_output_buffer.write_sample();
+	m_samples_to_update = idx - m_output_buffer.write_sample() + 1;
 
 	if(m_samples_to_update > 0) {
 		m_in_update = true;


### PR DESCRIPTION
Guarantees that: if update() is called at time `t`, any subsequent call to `sound_stream_update()` will receive a stream with `.start_time() > t`.
<br>

This is a followup to the discussion in #13637.  It is a proposal for what the semantics of `update()` could be. This seems to also match the old behavior, and fixes the assertion failure (in debug builds) in `va_eg.cpp`.

The `+ 1` change ensures that `update()` will also process the sample at `idx` , instead of stopping right before that.

The `+ 500'000'000` change ensures the result of the division rounds up, instead of down.

