### PR TITLE
sega/model2: prevent infinite loop in geo_parse()

### DIFF
--- a/src/mame/sega/model2_v.cpp
+++ b/src/mame/sega/model2_v.cpp
@@ -2563,9 +2563,10 @@ void model2_state::geo_parse( void )
 	u32  address = (m_geo_read_start_address & 0x1ffff)/4;
 	u32 *input = &m_bufferram[address];
 	u32  opcode;
+	u32  op_count = 0;
 	bool end_code = false;
 
-	while( end_code == false && (input - m_bufferram) < 0x20000/4  )
+	while( end_code == false && (input - m_bufferram) < 0x20000/4 && op_count++ < 0x8000 )
 	{
 		/* read in the opcode */
 		opcode = *input++;


### PR DESCRIPTION
MAME no longer hangs when exiting Sonic the Fighters service menu