### PR TITLE
victor9k: Add hard drive support

### DIFF
--- a/src/mame/act/v9kdmaib.cpp
+++ b/src/mame/act/v9kdmaib.cpp
@@ -1,0 +1,292 @@
+// license:BSD-3-Clause
+
+#include "emu.h"
+#include "v9kdmaib.h"
+
+#include "logmacro.h"
+
+/*
+ * Emulation of the Victor 9000 DMA Interface Board, which interfaces to the
+ * Xebec S1410 Hard Disk controller.
+ *
+ * Source: https://bitsavers.org/pdf/victor/victor9000/Victor_9000_Sirius_1_Hard_Disk_Subsystem.pdf
+ *
+ * Compared to the typical SCSI/SASI controller device, the DMA Interface Board
+ * acts more like a passthrough, and the usual state machine is primarily
+ * implemented on the main CPU.
+ */
+
+DEFINE_DEVICE_TYPE(V9KDMAIB, v9kdmaib_device, "v9kdmaib", "Victor 9000 DMA Interface Board")
+
+v9kdmaib_device::v9kdmaib_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	v9kdmaib_device(mconfig, V9KDMAIB, tag, owner, clock)
+{
+}
+
+v9kdmaib_device::v9kdmaib_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	nscsi_device(mconfig, type, tag, owner, clock),
+	nscsi_slot_card_interface(mconfig, *this, DEVICE_SELF),
+	m_dma_r(*this, 0xff),
+	m_dma_w(*this),
+	m_irq_handler(*this),
+	m_dma_on(false),
+	m_dma_write(false),
+	m_dma_addr(0),
+	m_asserting_ack(false),
+	m_non_dma_req(false),
+	m_ctrl(0),
+	m_data(0),
+	m_bus_ctrl(0),
+	m_irq_state(false)
+{
+}
+
+uint8_t v9kdmaib_device::read(offs_t offset)
+{
+	// Lower address bits are ignored
+	if (offset >= 0x80)
+	{
+		offset &= ~0x1f;
+	}
+	else
+	{
+		offset &= ~0xf;
+	}
+
+	uint8_t data = 0xff;
+
+	switch (offset) {
+		case R_CONTROL:
+			// Write only
+			break;
+		case R_DATA:
+			if (m_non_dma_req)
+			{
+				m_non_dma_req = false;
+				scsi_bus->data_w(scsi_refid, 0);
+				m_data = scsi_bus->data_r();
+				m_asserting_ack = true;
+				scsi_bus->ctrl_w(scsi_refid, S_ACK, S_ACK);
+			}
+			data = m_data;
+			break;
+		case R_STATUS:
+			// Reading status register clears interrupt
+			update_ints(false);
+
+			data = ((m_bus_ctrl & S_INP) ? R_S_INP : 0) |
+				   ((m_bus_ctrl & S_CTL) ? R_S_CMD : 0) |
+				   ((m_bus_ctrl & S_BSY) ? R_S_BSY : 0) |
+				   ((m_bus_ctrl & S_REQ) ? R_S_REQ : 0) |
+				   ((m_bus_ctrl & S_MSG) ? R_S_MSG : 0);
+			break;
+		case R_ADDR_L:
+			data = m_dma_addr & 0xff;
+			break;
+		case R_ADDR_M:
+			data = (m_dma_addr >> 8) & 0xff;
+			break;
+		case R_ADDR_H:
+			// Full DMA address is 20 bits
+			data = (m_dma_addr >> 16) & 0x0f;
+			break;
+		default:
+			logerror("Read from unknown register offset (0x%x)\n", offset);
+			break;
+	}
+
+	return data;
+}
+
+void v9kdmaib_device::write(offs_t offset, uint8_t data)
+{
+	// Lower address bits are ignored
+	if (offset >= 0x80)
+	{
+		offset &= ~0x1f;
+	}
+	else
+	{
+		offset &= ~0xf;
+	}
+
+	switch (offset) {
+		case R_CONTROL:
+			m_ctrl = data;
+			if (data & R_C_RESET)
+			{
+				device_reset();
+			}
+			else
+			{
+				if (data & R_C_DMAON_LATCH)
+				{
+					m_dma_on = (data & R_C_DMAON_VALUE);
+				}
+
+				m_dma_write = (data & R_C_WMODE);
+
+				uint32_t sel = ((data & R_C_SELECT) ? S_SEL : 0);
+				scsi_bus->ctrl_w(scsi_refid, sel, S_SEL);
+			}
+			break;
+		case R_DATA:
+			m_data = data;
+
+			if (m_ctrl & R_C_SELECT)
+			{
+				// Later versions of HDSETUP.EXE don't always clear the select
+				// bit before asserting a new target ID on the data bus during
+				// selection.  This is in violation of the SCSI spec (the data
+				// lines are supposed to be asserted first, then SEL should be
+				// asserted after a delay).  nscsi_bus doesn't react if the
+				// data lines change without a change in the SEL control line.
+				// Workaround is to ensure SEL isn't asserted whenever the data
+				// bus is written.
+				scsi_bus->ctrl_w(scsi_refid, 0, S_SEL);
+				m_ctrl &= ~R_C_SELECT;
+			}
+
+			scsi_bus->data_w(scsi_refid, data);
+			if (m_non_dma_req)
+			{
+				m_non_dma_req = false;
+				m_asserting_ack = true;
+				scsi_bus->ctrl_w(scsi_refid, S_ACK, S_ACK);
+			}
+			break;
+		case R_STATUS:
+			// Read only
+			break;
+		case R_ADDR_L:
+			m_dma_addr = (m_dma_addr & ~0xff) | data;
+			break;
+		case R_ADDR_M:
+			m_dma_addr = (m_dma_addr & ~0xff00) | data << 8;
+			break;
+		case R_ADDR_H:
+			m_dma_addr = (m_dma_addr & ~0x0f0000) | (data & 0x0f) << 16;
+			break;
+		default:
+			logerror("Write to unknown register offset (0x%x)\n", offset);
+			break;
+	}
+}
+
+void v9kdmaib_device::device_reset()
+{
+	m_dma_on = false;
+	m_dma_write = false;
+	m_dma_addr = 0;
+	m_asserting_ack = false;
+	m_non_dma_req = false;
+	m_data = 0;
+	m_bus_ctrl = 0;
+
+	scsi_bus->ctrl_wait(scsi_refid, S_SEL|S_BSY|S_REQ|S_RST, S_ALL);
+	scsi_bus->ctrl_w(scsi_refid, 0, S_ALL);
+	scsi_bus->data_w(scsi_refid, 0);
+
+	update_ints(false);
+	m_irq_handler(false);
+}
+
+void v9kdmaib_device::device_start()
+{
+	m_ctrl_timer = timer_alloc(FUNC(v9kdmaib_device::ctrl_change_handler), this);
+
+	save_item(NAME(m_dma_on));
+	save_item(NAME(m_dma_write));
+	save_item(NAME(m_dma_addr));
+	save_item(NAME(m_asserting_ack));
+	save_item(NAME(m_non_dma_req));
+	save_item(NAME(m_ctrl));
+	save_item(NAME(m_data));
+	save_item(NAME(m_bus_ctrl));
+	save_item(NAME(m_irq_state));
+}
+
+TIMER_CALLBACK_MEMBER(v9kdmaib_device::ctrl_change_handler)
+{
+	m_ctrl_timer->reset();
+
+	if (m_bus_ctrl & S_REQ)
+	{
+		// Only data (not control or status) transfers can use DMA
+		if (m_dma_on && !(m_bus_ctrl & S_CTL))
+		{
+			if (m_dma_write)
+			{
+				// Write to system memory
+				scsi_bus->data_w(scsi_refid, 0);
+				m_data = scsi_bus->data_r();
+				m_dma_w(m_dma_addr, m_data);
+			}
+			else
+			{
+				// Read from system memory
+				m_data = m_dma_r(m_dma_addr);
+				scsi_bus->data_w(scsi_refid, m_data);
+			}
+			m_dma_addr++;
+
+			m_asserting_ack = true;
+			scsi_bus->ctrl_w(scsi_refid, S_ACK, S_ACK);
+		}
+		else
+		{
+			// ACK will be generated upon direct data register access
+			m_non_dma_req = true;
+		}
+	} else if (m_asserting_ack) {
+		scsi_bus->ctrl_w(scsi_refid, 0, S_ACK);
+		m_asserting_ack = false;
+	}
+
+	if ((m_bus_ctrl & (S_REQ|S_CTL)) == (S_REQ|S_CTL))
+	{
+		// Command or status request from controller generates interrupt
+		update_ints(true);
+	}
+}
+
+void v9kdmaib_device::scsi_ctrl_changed()
+{
+	m_bus_ctrl = scsi_bus->ctrl_r();
+	attotime delay;
+
+	if (m_bus_ctrl & S_REQ)
+	{
+		if (m_dma_on && !(m_bus_ctrl & S_CTL))
+		{
+			// How long a DMA transaction takes to complete depends on what
+			// the 8088 is doing.  The right thing to do here is to assert
+			// HOLD, then wait for HLDA, but the 8088 emulation doesn't
+			// seem to implement these signals currently.
+			delay = clocks_to_attotime(2);
+		}
+		else
+		{
+			delay = clocks_to_attotime(0);
+		}
+	}
+	else if (m_asserting_ack)
+	{
+		delay = clocks_to_attotime(1);
+	}
+	else
+	{
+		delay = attotime::never;
+	}
+
+	m_ctrl_timer->adjust(delay);
+}
+
+void v9kdmaib_device::update_ints(bool irq_state)
+{
+	if (irq_state != m_irq_state)
+	{
+		m_irq_state = irq_state;
+		m_irq_handler(m_irq_state);
+	}
+}

--- a/src/mame/act/v9kdmaib.h
+++ b/src/mame/act/v9kdmaib.h
@@ -1,0 +1,110 @@
+// license:BSD-3-Clause
+#ifndef MAME_MACHINE_V9KDMAIB_H
+#define MAME_MACHINE_V9KDMAIB_H
+
+#pragma once
+
+#include "machine/nscsi_bus.h"
+
+class v9kdmaib_device : public nscsi_device, public nscsi_slot_card_interface
+{
+public:
+	v9kdmaib_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// Memory mapped registers
+	uint8_t read(offs_t offset);
+	void write(offs_t offset, uint8_t data);
+
+	auto irq_handler() { return m_irq_handler.bind(); }
+
+	auto dma_read() { return m_dma_r.bind(); }
+	auto dma_write() { return m_dma_w.bind(); }
+
+	virtual void scsi_ctrl_changed() override;
+
+protected:
+	v9kdmaib_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+private:
+	/*
+	 * Register Definitions
+	 *
+	 * 0x00: Control
+	 *
+	 *     0: DMA-ON Value (0: DMA Off, 1: DMA On)
+	 *     1: Lockout Mode
+	 *     2: DMA-ON Latch: if set, latch DMA-ON state from bit 0.
+	 *     3: Write Mode: if set, DMA direction is controller -> memory
+	 *     4: Target Selection
+	 *     5: Controller Reset
+	 *
+	 * 0x10: Data read/write (non-DMA accesses)
+	 *
+	 * 0x20: Status
+	 *
+	 *     0: I(/O)     0: Host -> Controller, 1: Controller -> Host
+	 *     1: C(/D)     0: Data, 1: Command
+	 *     2: BSY       1 = Busy
+	 *     3: REQ       1 = Request
+	 *     4: MSG       1 = Message
+	 *
+	 * 0x80: DMA address Low Byte
+	 * 0xa0: DMA address Middle Byte
+	 * 0xc0: DMA address High Byte
+	 */
+	enum {
+		// Register address offsets
+		R_CONTROL		= 0x00,
+		R_DATA			= 0x10,
+		R_STATUS		= 0x20,
+		R_ADDR_L		= 0x80,
+		R_ADDR_M		= 0xa0,
+		R_ADDR_H		= 0xc0,
+
+		// Control register bit fields
+		R_C_DMAON_VALUE	= 0x01,
+		R_C_LOCKOUT		= 0x02,
+		R_C_DMAON_LATCH	= 0x04,
+		R_C_WMODE		= 0x08,
+		R_C_SELECT		= 0x10,
+		R_C_RESET		= 0x20,
+
+		// Status register bit fields
+		R_S_INP			= 0x01,
+		R_S_CMD			= 0x02,
+		R_S_BSY			= 0x04,
+		R_S_REQ			= 0x08,
+		R_S_MSG			= 0x10,
+	};
+
+	emu_timer *m_ctrl_timer;
+	TIMER_CALLBACK_MEMBER(ctrl_change_handler);
+
+	void update_ints(bool status);
+
+	devcb_read8 m_dma_r;
+	devcb_write8 m_dma_w;
+
+	devcb_write_line m_irq_handler;
+
+	bool m_dma_on;
+	bool m_dma_write;
+
+	uint32_t m_dma_addr;
+
+	bool m_asserting_ack;
+	bool m_non_dma_req;
+
+	uint8_t m_ctrl;
+	uint8_t m_data;
+
+	uint32_t m_bus_ctrl;
+
+	bool m_irq_state;
+};
+
+DECLARE_DEVICE_TYPE(V9KDMAIB, v9kdmaib_device)
+
+#endif // MAME_MACHINE_V9KDMAIB_H

--- a/src/mame/act/victor9k.cpp
+++ b/src/mame/act/victor9k.cpp
@@ -15,7 +15,6 @@
     - codec sound
     - expansion bus
         - Z80 card
-        - Winchester DMA card (Xebec S1410 + Tandon TM502/TM603SE)
         - RAM cards
         - clock cards
     - floppy 8048
@@ -38,6 +37,8 @@
 #include "machine/pit8253.h"
 #include "machine/ram.h"
 #include "machine/rescap.h"
+#include "bus/nscsi/s1410.h"
+#include "v9kdmaib.h"
 #include "machine/z80sio.h"
 #include "sound/flt_biquad.h"
 #include "sound/hc55516.h"
@@ -115,6 +116,8 @@ public:
 		m_cvsd_filter2(*this, "cvsd_filter2"),
 		m_kb(*this, KB_TAG),
 		m_fdc(*this, "fdc"),
+		m_scsibus(*this, "scsi"),
+		m_v9kdmaib(*this, "scsi:7:v9kdmaib"),
 		m_centronics(*this, "centronics"),
 		m_rs232a(*this, RS232_A_TAG),
 		m_rs232b(*this, RS232_B_TAG),
@@ -152,6 +155,8 @@ private:
 	optional_device<filter_biquad_device> m_cvsd_filter2;
 	required_device<victor_9000_keyboard_device> m_kb;
 	required_device<victor_9000_fdc_device> m_fdc;
+	required_device<nscsi_bus_device> m_scsibus;
+	required_device<v9kdmaib_device> m_v9kdmaib;
 	required_device<centronics_device> m_centronics;
 	required_device<rs232_port_device> m_rs232a;
 	required_device<rs232_port_device> m_rs232b;
@@ -186,6 +191,8 @@ private:
 	void kbdata_w(int state);
 	void vert_w(int state);
 
+	uint8_t hd_dma_r(offs_t offset);
+	void hd_dma_w(offs_t offset, uint8_t data);
 
 	MC6845_UPDATE_ROW( crtc_update_row );
 	MC6845_BEGIN_UPDATE( crtc_begin_update );
@@ -209,6 +216,8 @@ private:
 	int m_kbackctl;
 
 	void update_kback();
+
+	static void scsi_devices(device_slot_interface &device);
 
 	void victor9k_mem(address_map &map) ATTR_COLD;
 };
@@ -238,6 +247,7 @@ void victor9k_state::victor9k_mem(address_map &map)
 	map(0xe80a0, 0xe80af).mirror(0x7f00).rw(m_fdc, FUNC(victor_9000_fdc_device::cs5_r), FUNC(victor_9000_fdc_device::cs5_w));
 	map(0xe80c0, 0xe80cf).mirror(0x7f00).rw(m_fdc, FUNC(victor_9000_fdc_device::cs6_r), FUNC(victor_9000_fdc_device::cs6_w));
 	map(0xe80e0, 0xe80ef).mirror(0x7f00).rw(m_fdc, FUNC(victor_9000_fdc_device::cs7_r), FUNC(victor_9000_fdc_device::cs7_w));
+	map(0xef300, 0xef3ff).rw(m_v9kdmaib, FUNC(v9kdmaib_device::read), FUNC(v9kdmaib_device::write));
 	map(0xf0000, 0xf0fff).mirror(0x1000).ram().share("video_ram");
 	map(0xf8000, 0xf9fff).mirror(0x6000).rom().region(I8088_TAG, 0);
 }
@@ -621,6 +631,18 @@ void victor9k_state::fdc_irq_w(int state)
 	m_pic->ir3_w(m_ssda_irq || m_via1_irq || m_via3_irq || m_fdc_irq);
 }
 
+uint8_t victor9k_state::hd_dma_r(offs_t offset)
+{
+	address_space &program = m_maincpu->space(AS_PROGRAM);
+	return program.read_byte(offset);
+}
+
+void victor9k_state::hd_dma_w(offs_t offset, uint8_t data)
+{
+	address_space &program = m_maincpu->space(AS_PROGRAM);
+	program.write_byte(offset, data);
+}
+
 //**************************************************************************
 //  MACHINE INITIALIZATION
 //**************************************************************************
@@ -710,6 +732,11 @@ void victor9k_state::machine_reset()
 //-------------------------------------------------
 //  machine_config( victor9k )
 //-------------------------------------------------
+
+void victor9k_state::scsi_devices(device_slot_interface &device)
+{
+	device.option_add("harddisk", NSCSI_S1410);
+}
 
 void victor9k_state::victor9k(machine_config &config)
 {
@@ -828,6 +855,19 @@ void victor9k_state::victor9k(machine_config &config)
 	m_fdc->irq_wr_callback().set(FUNC(victor9k_state::fdc_irq_w));
 	m_fdc->syn_wr_callback().set(I8259A_TAG, FUNC(pic8259_device::ir0_w)).invert();
 	m_fdc->lbrdy_wr_callback().set_inputline(I8088_TAG, INPUT_LINE_TEST).invert();
+
+	NSCSI_BUS(config, m_scsibus);
+	NSCSI_CONNECTOR(config, "scsi:0", scsi_devices, "harddisk", false);
+	NSCSI_CONNECTOR(config, "scsi:7").option_set("v9kdmaib", V9KDMAIB).machine_config(
+		[this](device_t *device)
+		{
+			v9kdmaib_device &v9kdmaib(downcast<v9kdmaib_device &>(*device));
+
+			device->set_clock(15_MHz_XTAL / 3);
+			v9kdmaib.irq_handler().append(m_pic, FUNC(pic8259_device::ir4_w));
+			v9kdmaib.dma_read().set(*this, FUNC(victor9k_state::hd_dma_r));
+			v9kdmaib.dma_write().set(*this, FUNC(victor9k_state::hd_dma_w));
+		});
 
 	RAM(config, m_ram).set_default_size("128K").set_extra_options("128K,256K,512K,640K,768K,896K");
 


### PR DESCRIPTION
Adds support for expansion bus card which interfaces to the Xebec s1410 via SASI.  Adds support for a single controller + hard drive, although a second controller plus hard drive should be possible.  Using FACTORYF and HDSETUP, I was able to create a new hard drive image, create partitions, and get working c: etc. to appear.  HDTEST utility is passing.
