### PR TITLE
cpu/i960: Reduce padding area size when servicing interrupt

### DIFF
--- a/src/devices/cpu/i960/i960.cpp
+++ b/src/devices/cpu/i960/i960.cpp
@@ -469,7 +469,7 @@ void i960_cpu_device::take_interrupt(int vector, int lvl)
 	}
 
 	SP = (SP + 63) & ~63;
-	SP += 128;  // emulate ElSemi's core, this fixes the crash in sonic the fighters
+	SP += 64;	// add padding to prevent buffer underflow when saving processor state
 
 	do_call(IRQV, 7, SP);
 


### PR DESCRIPTION
128 bytes of padding was resulting in stack overflow during the Virtual-On ranking screen, crashing MAME. Reducing the padding to 64 bytes prevents the stack overflow while still ensuring that saved local registers are not overwritten by the processor state.

It should be noted that the actual i960 behavior is to save the processor state before performing the call operation ([source](http://bitsavers.informatik.uni-stuttgart.de/components/intel/i960/80960KB_Programmers_Reference_Manual_Mar88.pdf), 8-5), though this is unlikely to result in any difference in operation.