### PR TITLE
cocoa debugger: debug view scroll workarounds

### DIFF
--- a/src/osd/modules/debugger/osx/debugview.mm
+++ b/src/osd/modules/debugger/osx/debugview.mm
@@ -49,6 +49,11 @@ static void debugwin_view_update(debug_view &view, void *osdprivate)
 
 
 @implementation MAMEDebugView
+{
+	// workaround for the bug that prevents the console view from scrolling
+	// to the bottom when the console window is not full yet
+	BOOL ignoreNextFrameUpdate;
+}
 
 + (void)initialize {
 	// 10.15 and better get full adaptive Dark Mode support
@@ -311,6 +316,7 @@ static void debugwin_view_update(debug_view &view, void *osdprivate)
 				content.height += (fontHeight * 2) - 1;
 			[self setFrameSize:NSMakeSize(ceil(std::max(clip.width, content.width)),
 										  ceil(std::max(clip.height, content.height)))];
+			ignoreNextFrameUpdate = YES;
 			[scroller reflectScrolledClipView:[scroller contentView]];
 		}
 		totalWidth = newSize.x;
@@ -476,6 +482,12 @@ static void debugwin_view_update(debug_view &view, void *osdprivate)
 
 
 - (void)viewFrameDidChange:(NSNotification *)notification {
+	if (ignoreNextFrameUpdate) {
+		ignoreNextFrameUpdate = NO;
+		return;
+	}
+	ignoreNextFrameUpdate = NO;
+
 	NSView *const changed = [notification object];
 	if (changed == [[self enclosingScrollView] contentView])
 		[self adjustSizeAndRecomputeVisible];

--- a/src/osd/modules/debugger/osx/debugview.mm
+++ b/src/osd/modules/debugger/osx/debugview.mm
@@ -303,25 +303,21 @@ static void debugwin_view_update(debug_view &view, void *osdprivate)
 - (void)update {
 	// resize our frame if the total size has changed
 	debug_view_xy const newSize = view->total_size();
-	BOOL const resized = (newSize.x != totalWidth) || (newSize.y != totalHeight);
-	if (resized)
+	NSScrollView *const scroller = [self enclosingScrollView];
+	if (scroller)
 	{
-		NSScrollView *const scroller = [self enclosingScrollView];
-		if (scroller)
-		{
-			NSSize const clip = [[scroller contentView] bounds].size;
-			NSSize content = NSMakeSize((fontWidth * newSize.x) + (2 * [textContainer lineFragmentPadding]),
-										fontHeight * newSize.y);
-			if (wholeLineScroll)
-				content.height += (fontHeight * 2) - 1;
-			[self setFrameSize:NSMakeSize(ceil(std::max(clip.width, content.width)),
-										  ceil(std::max(clip.height, content.height)))];
-			ignoreNextFrameUpdate = YES;
-			[scroller reflectScrolledClipView:[scroller contentView]];
-		}
-		totalWidth = newSize.x;
-		totalHeight = newSize.y;
+		NSSize const clip = [[scroller contentView] bounds].size;
+		NSSize content = NSMakeSize((fontWidth * newSize.x) + (2 * [textContainer lineFragmentPadding]),
+									fontHeight * newSize.y);
+		if (wholeLineScroll)
+			content.height += (fontHeight * 2) - 1;
+		[self setFrameSize:NSMakeSize(ceil(std::max(clip.width, content.width)),
+									  ceil(std::max(clip.height, content.height)))];
+		ignoreNextFrameUpdate = YES;
+		[scroller reflectScrolledClipView:[scroller contentView]];
 	}
+	totalWidth = newSize.x;
+	totalHeight = newSize.y;
 
 	// scroll the view if we're being told to
 	debug_view_xy const newOrigin = view->visible_position();


### PR DESCRIPTION
The Cocoa debugger has an annoying bug where the first time the console "overflows" the bottom, the view will not scroll.

This patch includes a workaround to skip frame size notifications in the middle of the text update, and this seems to fix the issue.


### Before
https://github.com/user-attachments/assets/13edad06-76cc-4f65-bcbb-98f936225fb9 

### After
https://github.com/user-attachments/assets/b3a9a118-748b-4984-a2da-5d82f40237db 

