### PR TITLE
[win] debugger crash: Add fallback to "0" if address evaluation fails

### DIFF
--- a/src/emu/debug/debugvw.cpp
+++ b/src/emu/debug/debugvw.cpp
@@ -511,7 +511,19 @@ bool debug_view_expression::recompute()
 		}
 		catch (expression_error &)
 		{
-			m_parsed.parse(oldstring);
+			try
+			{
+				// If we got here because the user typed in a new expression,
+				// then going back to the previous expression should work
+				m_parsed.parse(oldstring);
+			}
+			catch (expression_error &)
+			{
+				// If that didn't work, perhaps the user switched sources
+				// and the previous expression doesn't evaluate with the
+				// new symbol table.  Try "0" as last resort
+				m_parsed.parse("0");
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes issue #13685

If the memory window address string evaluation fails, we have been falling back to the last-known-working string.  This works great if the failure is due to the user changing the string.  But if the user changes the source, that also can cause failures (different symbol table used for evaluation), and this fallback does not help.

The fix is to add a second fallback: Use "0" as the address string when all else fails.