### PR TITLE
[win] debugger cleanup: use enums for m_views indices

### DIFF
--- a/src/osd/modules/debugger/win/debugwininfo.cpp
+++ b/src/osd/modules/debugger/win/debugwininfo.cpp
@@ -353,7 +353,10 @@ void debugwin_info::restore_configuration_from_node(util::xml::data_node const &
 	recompute_children();
 }
 
-
+// Set the bounds for the corresponding debug_viewinfo.  This implementation
+// is only intended for use with win_infos that appear solely as an
+// independent free-floating window.  win_infos that can appear as a frame
+// within the main consolewin_info should override this.
 void debugwin_info::recompute_children()
 {
 	if (m_views[0] != nullptr)

--- a/src/osd/modules/debugger/win/debugwininfo.h
+++ b/src/osd/modules/debugger/win/debugwininfo.h
@@ -58,7 +58,6 @@ protected:
 	static DWORD const  DEBUG_WINDOW_STYLE = (WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN) & (~WS_MINIMIZEBOX & ~WS_MAXIMIZEBOX);
 	static DWORD const  DEBUG_WINDOW_STYLE_EX = 0;
 
-	static int const    MAX_VIEWS = 4;
 	static int const    EDGE_WIDTH = 3;
 
 	enum
@@ -120,6 +119,19 @@ protected:
 		ID_DARK_BACKGROUND,
 
 		ID_DEVICE_OPTIONS   // always keep this at the end
+	};
+
+	// Indices for use with m_views.  Each *win_info class that can appear
+	// as a frame within the main consolewin_info should use these
+	// indices to find its *view_info class, even when it's currently
+	// shown as an independent free-floating window.  All other *win_info
+	// classes (e.g., logwin_info, pointswin_info, etc.) just use m_views[0]
+	enum
+	{
+		VIEW_IDX_DISASM,
+		VIEW_IDX_STATE,
+		VIEW_IDX_CONSOLE,
+		MAX_VIEWS
 	};
 
 	debugwin_info(debugger_windows_interface &debugger, bool is_main_console, LPCSTR title, WNDPROC handler);

--- a/src/osd/modules/debugger/win/disasmbasewininfo.cpp
+++ b/src/osd/modules/debugger/win/disasmbasewininfo.cpp
@@ -23,15 +23,15 @@
 namespace osd::debugger::win {
 
 disasmbasewin_info::disasmbasewin_info(debugger_windows_interface &debugger, bool is_main_console, LPCSTR title, WNDPROC handler) :
-	editwin_info(debugger, is_main_console, title, handler)
+	editwin_info(debugger, is_main_console, VIEW_IDX_DISASM, title, handler)
 {
 	if (!window())
 		return;
 
-	m_views[0].reset(new disasmview_info(debugger, *this, window()));
-	if (!m_views[0] || !m_views[0]->is_valid())
+	m_views[VIEW_IDX_DISASM].reset(new disasmview_info(debugger, *this, window()));
+	if (!m_views[VIEW_IDX_DISASM] || !m_views[VIEW_IDX_DISASM]->is_valid())
 	{
-		m_views[0].reset();
+		m_views[VIEW_IDX_DISASM].reset();
 		return;
 	}
 
@@ -47,8 +47,8 @@ disasmbasewin_info::disasmbasewin_info(debugger_windows_interface &debugger, boo
 	AppendMenu(GetMenu(window()), MF_ENABLED | MF_POPUP, (UINT_PTR)optionsmenu, TEXT("Options"));
 
 	// set up the view to track the initial expression
-	downcast<disasmview_info *>(m_views[0].get())->set_expression("curpc");
-	m_views[0]->set_source_for_visible_cpu();
+	downcast<disasmview_info *>(m_views[VIEW_IDX_DISASM].get())->set_expression("curpc");
+	m_views[VIEW_IDX_DISASM]->set_source_for_visible_cpu();
 }
 
 
@@ -92,7 +92,7 @@ bool disasmbasewin_info::handle_key(WPARAM wparam, LPARAM lparam)
 		return true;
 
 	case VK_RETURN:
-		if (m_views[0]->cursor_visible() && m_views[0]->source_is_visible_cpu())
+		if (m_views[VIEW_IDX_DISASM]->cursor_visible() && m_views[VIEW_IDX_DISASM]->source_is_visible_cpu())
 		{
 			SendMessage(window(), WM_COMMAND, ID_STEP, 0);
 			return true;
@@ -108,7 +108,7 @@ void disasmbasewin_info::update_menu()
 {
 	editwin_info::update_menu();
 
-	auto *const dasmview = downcast<disasmview_info *>(m_views[0].get());
+	auto *const dasmview = downcast<disasmview_info *>(m_views[VIEW_IDX_DISASM].get());
 	HMENU const menu = GetMenu(window());
 
 	bool const disasm_cursor_visible = dasmview->cursor_visible();
@@ -154,7 +154,7 @@ void disasmbasewin_info::update_menu()
 
 bool disasmbasewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 {
-	auto *const dasmview = downcast<disasmview_info *>(m_views[0].get());
+	auto *const dasmview = downcast<disasmview_info *>(m_views[VIEW_IDX_DISASM].get());
 
 	switch (HIWORD(wparam))
 	{
@@ -270,14 +270,14 @@ bool disasmbasewin_info::handle_command(WPARAM wparam, LPARAM lparam)
 void disasmbasewin_info::restore_configuration_from_node(util::xml::data_node const &node)
 {
 	editwin_info::restore_configuration_from_node(node);
-	m_views[0]->restore_configuration_from_node(node);
+	m_views[VIEW_IDX_DISASM]->restore_configuration_from_node(node);
 }
 
 
 void disasmbasewin_info::save_configuration_to_node(util::xml::data_node &node)
 {
 	editwin_info::save_configuration_to_node(node);
-	m_views[0]->save_configuration_to_node(node);
+	m_views[VIEW_IDX_DISASM]->save_configuration_to_node(node);
 }
 
 } // namespace osd::debugger::win

--- a/src/osd/modules/debugger/win/disasmwininfo.cpp
+++ b/src/osd/modules/debugger/win/disasmwininfo.cpp
@@ -24,7 +24,7 @@ disasmwin_info::disasmwin_info(debugger_windows_interface &debugger) :
 	disasmbasewin_info(debugger, false, "Disassembly", nullptr),
 	m_combownd(nullptr)
 {
-	if ((window() == nullptr) || (m_views[0] == nullptr))
+	if ((window() == nullptr) || (m_views[VIEW_IDX_DISASM] == nullptr))
 		return;
 
 	// set up the view to track the initial expression
@@ -33,7 +33,7 @@ disasmwin_info::disasmwin_info(debugger_windows_interface &debugger) :
 	editwnd_select_all();
 
 	// create a combo box
-	m_combownd = m_views[0]->create_source_combobox(window(), (LONG_PTR)this);
+	m_combownd = m_views[VIEW_IDX_DISASM]->create_source_combobox(window(), (LONG_PTR)this);
 
 	// set the caption
 	update_caption();
@@ -60,7 +60,7 @@ void disasmwin_info::recompute_children()
 	// compute a client rect
 	RECT bounds;
 	bounds.top = bounds.left = 0;
-	bounds.right = m_views[0]->prefwidth() + (2 * EDGE_WIDTH);
+	bounds.right = m_views[VIEW_IDX_DISASM]->prefwidth() + (2 * EDGE_WIDTH);
 	bounds.bottom = 200;
 	AdjustWindowRectEx(&bounds, DEBUG_WINDOW_STYLE, FALSE, DEBUG_WINDOW_STYLE_EX);
 
@@ -93,7 +93,7 @@ void disasmwin_info::recompute_children()
 	dasmrect.right = parent.right - EDGE_WIDTH;
 
 	// set the bounds of things
-	m_views[0]->set_bounds(dasmrect);
+	m_views[VIEW_IDX_DISASM]->set_bounds(dasmrect);
 	set_editwnd_bounds(editrect);
 	smart_set_window_bounds(m_combownd, window(), comborect);
 }
@@ -109,7 +109,7 @@ bool disasmwin_info::handle_command(WPARAM wparam, LPARAM lparam)
 			int const sel = SendMessage((HWND)lparam, CB_GETCURSEL, 0, 0);
 			if (sel != CB_ERR)
 			{
-				m_views[0]->set_source_index(sel);
+				m_views[VIEW_IDX_DISASM]->set_source_index(sel);
 				update_caption();
 
 				// reset the focus
@@ -134,7 +134,7 @@ void disasmwin_info::draw_contents(HDC dc)
 void disasmwin_info::process_string(const std::string &string)
 {
 	// set the string to the disasm view
-	downcast<disasmview_info *>(m_views[0].get())->set_expression(string);
+	downcast<disasmview_info *>(m_views[VIEW_IDX_DISASM].get())->set_expression(string);
 
 	// select everything in the edit text box
 	editwnd_select_all();
@@ -146,14 +146,15 @@ void disasmwin_info::process_string(const std::string &string)
 
 void disasmwin_info::update_caption()
 {
-	win_set_window_text_utf8(window(), std::string("Disassembly: ").append(m_views[0]->source_name()).c_str());
+	win_set_window_text_utf8(window(), std::string("Disassembly: ").append(m_views[VIEW_IDX_DISASM]->source_name()).c_str());
 }
 
 
 void disasmwin_info::restore_configuration_from_node(util::xml::data_node const &node)
 {
-	m_views[0]->set_source_index(node.get_attribute_int(ATTR_WINDOW_DISASSEMBLY_CPU, m_views[0]->source_index()));
-	int const cursource = m_views[0]->source_index();
+	m_views[VIEW_IDX_DISASM]->set_source_index(
+		node.get_attribute_int(ATTR_WINDOW_DISASSEMBLY_CPU, m_views[VIEW_IDX_DISASM]->source_index()));
+	int const cursource = m_views[VIEW_IDX_DISASM]->source_index();
 	if (0 <= cursource)
 		SendMessage(m_combownd, CB_SETCURSEL, cursource, 0);
 	update_caption();
@@ -174,8 +175,10 @@ void disasmwin_info::save_configuration_to_node(util::xml::data_node &node)
 	disasmbasewin_info::save_configuration_to_node(node);
 
 	node.set_attribute_int(ATTR_WINDOW_TYPE, WINDOW_TYPE_DISASSEMBLY_VIEWER);
-	node.set_attribute_int(ATTR_WINDOW_DISASSEMBLY_CPU, m_views[0]->source_index());
-	node.add_child(NODE_WINDOW_EXPRESSION, downcast<disasmview_info *>(m_views[0].get())->expression());
+	node.set_attribute_int(ATTR_WINDOW_DISASSEMBLY_CPU, m_views[VIEW_IDX_DISASM]->source_index());
+	node.add_child(
+		NODE_WINDOW_EXPRESSION,
+		downcast<disasmview_info *>(m_views[VIEW_IDX_DISASM].get())->expression());
 }
 
 } // namespace osd::debugger::win

--- a/src/osd/modules/debugger/win/editwininfo.cpp
+++ b/src/osd/modules/debugger/win/editwininfo.cpp
@@ -32,9 +32,10 @@ constexpr int   HISTORY_LENGTH      = 100;
 } // anonymous namespace
 
 
-editwin_info::editwin_info(debugger_windows_interface &debugger, bool is_main_console, LPCSTR title, WNDPROC handler) :
+editwin_info::editwin_info(debugger_windows_interface &debugger, bool is_main_console, int viewidx, LPCSTR title, WNDPROC handler) :
 	debugwin_info(debugger, is_main_console, title, handler),
 	m_editwnd(nullptr),
+	m_viewidx(viewidx),
 	m_edit_defstr(),
 	m_original_editproc(nullptr),
 	m_history(),
@@ -185,13 +186,13 @@ LRESULT editwin_info::edit_proc(UINT message, WPARAM wparam, LPARAM lparam)
 			break;
 
 		case VK_PRIOR:
-			if (m_views[0] != nullptr)
-				m_views[0]->send_pageup();
+			if (m_views[m_viewidx] != nullptr)
+				m_views[m_viewidx]->send_pageup();
 			break;
 
 		case VK_NEXT:
-			if (m_views[0] != nullptr)
-				m_views[0]->send_pagedown();
+			if (m_views[m_viewidx] != nullptr)
+				m_views[m_viewidx]->send_pagedown();
 			break;
 
 		case VK_TAB:

--- a/src/osd/modules/debugger/win/editwininfo.h
+++ b/src/osd/modules/debugger/win/editwininfo.h
@@ -23,7 +23,7 @@ namespace osd::debugger::win {
 class editwin_info : public debugwin_info
 {
 public:
-	editwin_info(debugger_windows_interface &debugger, bool is_main_console, LPCSTR title, WNDPROC handler);
+	editwin_info(debugger_windows_interface &debugger, bool is_main_console, int viewidx, LPCSTR title, WNDPROC handler);
 	virtual ~editwin_info();
 
 	virtual bool restore_field(HWND wnd) override;
@@ -55,6 +55,7 @@ private:
 	static LRESULT CALLBACK static_edit_proc(HWND wnd, UINT message, WPARAM wparam, LPARAM lparam);
 
 	HWND                    m_editwnd;
+	int                     m_viewidx;
 	std::string             m_edit_defstr;
 	WNDPROC                 m_original_editproc;
 	history_deque           m_history;

--- a/src/osd/modules/debugger/win/memorywininfo.cpp
+++ b/src/osd/modules/debugger/win/memorywininfo.cpp
@@ -21,7 +21,7 @@
 namespace osd::debugger::win {
 
 memorywin_info::memorywin_info(debugger_windows_interface &debugger) :
-	editwin_info(debugger, false, "Memory", nullptr),
+	editwin_info(debugger, false, 0 /* view index */, "Memory", nullptr),
 	m_combownd(nullptr)
 {
 	if (!window())


### PR DESCRIPTION
For the wininfos that participate as individual panes in the main console window, their viewinfos are referenced via the m_views[] array with hard-coded indices of 0, 1, and 2.

- Define & use enums for those indices (VIEW_IDX_DISASM, VIEW_IDX_STATE, VIEW_IDX_CONSOLE)
- Change MAX_VIEWS from a hard-coded constant of 4 to the last enum in that list, which changes it to 3.  (I don't think it should have been 4 in the first place.)
- wininfos that NEVER appear as panes in the main console window (e.g., logwin_info, pointswin_info, etc.) continue to use m_views[0]

This cleanup was originally written as part of my large source-level debugging PR (#13444), so merging this will shrink that somewhat.