### PR TITLE
dataeast/brkthru.cpp: Remove brkthrubl

### DIFF
--- a/src/mame/dataeast/brkthru.cpp
+++ b/src/mame/dataeast/brkthru.cpp
@@ -977,43 +977,6 @@ ROM_START( brkthrut )
 	ROM_LOAD( "4_de-0230-2_27256.d6", 0x8000, 0x8000, CRC(c309435f) SHA1(82914004c2b169a7c31aa49af83a699ebbc7b33f) ) // Same as parent
 ROM_END
 
-ROM_START( brkthrubl ) // 3002A + 3002B PCBs. Everything's the same as the original but the main CPU ROMs, which differ quite a lot (possibly bootlegged from a different revision?)
-	ROM_REGION( 0x20000, "maincpu", 0 )
-	ROM_LOAD( "4",    0x04000, 0x4000, CRC(0f21b4c5) SHA1(e5ef67006394d475571196dcdc181d28a0831bdf) )
-	ROM_LOAD( "3",    0x08000, 0x8000, CRC(51c7c378) SHA1(b779df719b89bb41e342c472b38e20d8fc71ca6d) )
-	ROM_LOAD( "1",    0x10000, 0x8000, CRC(209484c2) SHA1(da7311768b675b833066a7403fd507969d74699e) )
-	ROM_LOAD( "2",    0x18000, 0x8000, CRC(2f2c40c2) SHA1(fcb78941453520a3a07f272127dae7c2cc1999ea) )
-
-	ROM_REGION( 0x02000, "chars", 0 )
-	ROM_LOAD( "12",   0x00000, 0x2000, CRC(58c0b29b) SHA1(9dc075f8afae7e8fe164a9fe325e9948cdc7e4bb) )
-
-	ROM_REGION( 0x20000, "tiles", 0 ) // background
-	ROM_LOAD( "7",    0x00000, 0x4000, CRC(920cc56a) SHA1(c75806691073f1f3bd54dcaca4c14155ecf4471d) )   // bitplanes 1,2 for bank 1,2
-	ROM_CONTINUE(             0x08000, 0x4000 )             // bitplanes 1,2 for bank 3,4
-	ROM_LOAD( "6",    0x10000, 0x4000, CRC(fd3cee40) SHA1(3308b96bb69e0fa6dffbdff296273fafa16d5e70) )   // bitplanes 1,2 for bank 5,6
-	ROM_CONTINUE(             0x18000, 0x4000 )             // bitplanes 1,2 for bank 7,8
-	ROM_LOAD( "8",    0x04000, 0x1000, CRC(f67ee64e) SHA1(75634bd481ae44b8aa02acb4f9b4d7ff973a4c71) )   // bitplane 3 for bank 1,2
-	ROM_CONTINUE(             0x06000, 0x1000 )
-	ROM_CONTINUE(             0x0c000, 0x1000 )             // bitplane 3 for bank 3,4
-	ROM_CONTINUE(             0x0e000, 0x1000 )
-	ROM_CONTINUE(             0x14000, 0x1000 )             // bitplane 3 for bank 5,6
-	ROM_CONTINUE(             0x16000, 0x1000 )
-	ROM_CONTINUE(             0x1c000, 0x1000 )             // bitplane 3 for bank 7,8
-	ROM_CONTINUE(             0x1e000, 0x1000 )
-
-	ROM_REGION( 0x18000, "sprites", 0 )
-	ROM_LOAD( "9",    0x00000, 0x8000, CRC(f54e50a7) SHA1(eccf4d859c26944271ec6586644b4730a72851fd) )
-	ROM_LOAD( "10",   0x08000, 0x8000, CRC(fd156945) SHA1(a0575a4164217e63317886176ab7e59d255fc771) )
-	ROM_LOAD( "11",   0x10000, 0x8000, CRC(c152a99b) SHA1(f96133aa01219eda357b9e906bd9577dbfe359c0) )
-
-	ROM_REGION( 0x0200, "proms", 0 )
-	ROM_LOAD( "brkthru.13",   0x0000, 0x0100, CRC(aae44269) SHA1(7c66aeb93577104109d264ee8b848254256c81eb) ) // red and green component
-	ROM_LOAD( "brkthru.14",   0x0100, 0x0100, CRC(f2d4822a) SHA1(f535e91b87ff01f2a73662856fd3f72907ca62e9) ) // blue component
-
-	ROM_REGION( 0x10000, "audiocpu", 0 )
-	ROM_LOAD( "5",    0x8000, 0x8000, CRC(c309435f) SHA1(82914004c2b169a7c31aa49af83a699ebbc7b33f) )
-ROM_END
-
 // bootleg, changed prg ROM fails test, probably just the Japanese version modified to have English title
 ROM_START( forcebrk )
 	ROM_REGION( 0x20000, "maincpu", 0 )
@@ -1113,5 +1076,4 @@ GAME( 1986, brkthruu,  brkthru, brkthru, brkthru,  brkthru_state, empty_init, RO
 GAME( 1986, brkthruj,  brkthru, brkthru, brkthruj, brkthru_state, empty_init, ROT0,   "Data East Corporation",                  "Kyohkoh-Toppa (Japan)",       MACHINE_SUPPORTS_SAVE )
 GAME( 1986, brkthrut,  brkthru, brkthru, brkthruj, brkthru_state, empty_init, ROT0,   "Data East Corporation (Tecfri license)", "Break Thru (Tecfri license)", MACHINE_SUPPORTS_SAVE )
 GAME( 1986, forcebrk,  brkthru, brkthru, brkthruj, brkthru_state, empty_init, ROT0,   "bootleg",                                "Force Break (bootleg)",       MACHINE_SUPPORTS_SAVE )
-GAME( 1986, brkthrubl, brkthru, brkthru, brkthruj, brkthru_state, empty_init, ROT0,   "bootleg",                                "Break Thru (bootleg)",        MACHINE_SUPPORTS_SAVE )
 GAME( 1986, darwin,    0,       darwin,  darwin,   brkthru_state, empty_init, ROT270, "Data East Corporation",                  "Darwin 4078 (Japan)",         MACHINE_SUPPORTS_SAVE )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -16856,7 +16856,6 @@ ragtimea
 
 @source:dataeast/brkthru.cpp
 brkthru
-brkthrubl
 brkthruj
 brkthrut
 brkthruu


### PR DESCRIPTION
Has the same ROMs as the original World version