### PR TITLE
debugger: symlist usability + symbol table extensibility

### DIFF
--- a/src/emu/debug/debugcpu.cpp
+++ b/src/emu/debug/debugcpu.cpp
@@ -57,7 +57,7 @@ debugger_cpu::debugger_cpu(running_machine &machine)
 	m_tempvar = make_unique_clear<u64[]>(NUM_TEMP_VARIABLES);
 
 	/* create a global symbol table */
-	m_symtable = std::make_unique<symbol_table>(machine);
+	m_symtable = std::make_unique<symbol_table>(machine, symbol_table::BUILTIN_GLOBALS);
 	m_symtable->set_memory_modified_func([this]() { set_memory_modified(true); });
 
 	/* add "wpaddr", "wpdata", "wpsize" to the global symbol table */
@@ -488,7 +488,7 @@ device_debug::device_debug(device_t &device)
 	, m_state(nullptr)
 	, m_disasm(nullptr)
 	, m_flags(0)
-	, m_symtable(std::make_unique<symbol_table>(device.machine(), &device.machine().debugger().cpu().global_symtable(), &device))
+	, m_symtable(std::make_unique<symbol_table>(device.machine(), symbol_table::CPU_STATE, &device.machine().debugger().cpu().global_symtable(), &device))
 	, m_stepaddr(0)
 	, m_stepsleft(0)
 	, m_delay_steps(0)

--- a/src/emu/debug/express.cpp
+++ b/src/emu/debug/express.cpp
@@ -363,8 +363,9 @@ symbol_entry::~symbol_entry()
 //  symbol_table - constructor
 //-------------------------------------------------
 
-symbol_table::symbol_table(running_machine &machine, symbol_table *parent, device_t *device)
+symbol_table::symbol_table(running_machine &machine, table_type type, symbol_table *parent, device_t *device)
 	: m_machine(machine)
+	, m_type(type)
 	, m_parent(parent)
 	, m_memintf(dynamic_cast<device_memory_interface *>(device))
 	, m_memory_modified(nullptr)

--- a/src/emu/debug/express.h
+++ b/src/emu/debug/express.h
@@ -171,11 +171,21 @@ public:
 		READ_WRITE
 	};
 
+	// Identifies the type of symbols stored in this table.  These help symlist create
+	// useful output
+	enum table_type
+	{
+		CPU_STATE,         // CPU registers, etc.
+		BUILTIN_GLOBALS,   // Built-in MAME global symbols (e.g., beamx, beamy, frame, etc.)
+						   // (also used for tables outside debugger: lua scripts, cheat engine)
+	};
+
 	// construction/destruction
-	symbol_table(running_machine &machine, symbol_table *parent = nullptr, device_t *device = nullptr);
+	symbol_table(running_machine &machine, table_type type, symbol_table *parent = nullptr, device_t *device = nullptr);
 
 	// getters
 	const std::unordered_map<std::string, std::unique_ptr<symbol_entry>> &entries() const { return m_symlist; }
+	table_type type() const { return m_type; }
 	symbol_table *parent() const { return m_parent; }
 	running_machine &machine() { return m_machine; }
 
@@ -212,6 +222,7 @@ private:
 
 	// internal state
 	running_machine &       m_machine;          // reference to the machine
+	table_type              m_type;             // kind of symbols stored in this table
 	symbol_table *          m_parent;           // pointer to the parent symbol table
 	std::unordered_map<std::string,std::unique_ptr<symbol_entry>> m_symlist;        // list of symbols
 	device_memory_interface *const m_memintf;   // pointer to the local memory interface (if any)

--- a/src/frontend/mame/cheat.cpp
+++ b/src/frontend/mame/cheat.cpp
@@ -683,7 +683,7 @@ void cheat_script::script_entry::output_argument::save(util::core_file &cheatfil
 
 cheat_entry::cheat_entry(cheat_manager &manager, symbol_table &globaltable, std::string const &filename, util::xml::data_node const &cheatnode)
 	: m_manager(manager)
-	, m_symbols(manager.machine(), &globaltable)
+	, m_symbols(manager.machine(), symbol_table::BUILTIN_GLOBALS, &globaltable)
 	, m_state(SCRIPT_STATE_OFF)
 	, m_numtemp(DEFAULT_TEMP_VARIABLES)
 	, m_argindex(0)
@@ -1065,7 +1065,7 @@ cheat_manager::cheat_manager(running_machine &machine)
 	, m_numlines(0)
 	, m_lastline(0)
 	, m_disabled(true)
-	, m_symtable(machine)
+	, m_symtable(machine, symbol_table::BUILTIN_GLOBALS)
 {
 	// if the cheat engine is disabled, we're done
 	if (!machine.options().cheat())

--- a/src/frontend/mame/luaengine_debug.cpp
+++ b/src/frontend/mame/luaengine_debug.cpp
@@ -91,7 +91,7 @@ public:
 
 	symbol_table_wrapper(lua_engine &host, running_machine &machine, std::shared_ptr<symbol_table_wrapper> const &parent, device_t *device)
 		: m_host(host)
-		, m_table(machine, parent ? &parent->table() : nullptr, device)
+		, m_table(machine, symbol_table::BUILTIN_GLOBALS, parent ? &parent->table() : nullptr, device)
 		, m_parent(parent)
 	{
 	}


### PR DESCRIPTION
This addresses issue #6655 (symlist command usability), plus adds a bit of plumbing for future extensibility.

### Symlist command usability

The distinction between global and CPU symbols is unclear to most who don't read the source, so this makes `symlist` more natural:
- `symlist` with no arguments displays all global *and* :maincpu symbols, with clear header text for each list.  At the bottom, prints helper text to make user aware of the cpu form
- `symlist <cpu>` works as it has before, only displays symbols for specified CPU

### Symbol table extensibility

This pr includes some changes in anticipation of features that add new kinds of symbol tables.  Example: the source-level debugging pr (#13444) adds symbol tables for local and global variables that appear in the debugged source code.  The following were originally part of the source-level debugging PR, so merging this will shrink that PR somewhat.
- Add an enum field to symbol table for its 'type', for prettier printing from symlist.
- symlist now traverses symbol table chain completely.  No noticeable difference from before, but this will make extensions to the chain work automatically
- Eliminate hard-coded limit (1000) on number of symbols to print per symbol table

### Sample session

A CoCo with Speech-Sound cartridge (thus, two valid CPUs).

```
>symlist

**** CPU ':maincpu' symbols ****
a = 0
b = B
cc = 90
curflags = 90
curpc = 10C
cycles = 24  (read-only)
d = B
dp = 0
lastinstructioncycles = 18  (read-only)
logunmap = 1
pc = 10C
s = 7F1E
totalcycles = 24E077  (read-only)
u = ABEE
x = 402
y = A00E

**** Global symbols ****
beamx = 85  (read-only)
beamy = D9  (read-only)
cpunum = 0  (read-only)
frame = A1  (read-only)
temp0 = 0
temp1 = 0
temp2 = 0
temp3 = 0
temp4 = 0
temp5 = 0
temp6 = 0
temp7 = 0
temp8 = 0
temp9 = 0
wpaddr = 0  (read-only)
wpdata = 0  (read-only)
wpsize = 0  (read-only)

To view the symbols for a particular CPU, try symlist <cpu>,
where <cpu> is the ID number or tag for a CPU.


>symlist :maincpu

**** CPU ':maincpu' symbols ****
a = 0
b = B
cc = 90
curflags = 90
curpc = 10C
cycles = 24  (read-only)
d = B
dp = 0
lastinstructioncycles = 18  (read-only)
logunmap = 1
pc = 10C
s = 7F1E
totalcycles = 24E077  (read-only)
u = ABEE
x = 402
y = A00E


>symlist 0

**** CPU ':maincpu' symbols ****
a = 0
b = B
cc = 90
curflags = 90
curpc = 10C
cycles = 24  (read-only)
d = B
dp = 0
lastinstructioncycles = 18  (read-only)
logunmap = 1
pc = 10C
s = 7F1E
totalcycles = 24E077  (read-only)
u = ABEE
x = 402
y = A00E


>symlist 1

**** CPU ':ext:multi:slot3:ssc:pic7040' symbols ****
a = FF
b = 0
curflags = D0
curpc = F2D1
cycles = 0  (read-only)
genpc = F2D1
lastinstructioncycles = 9  (read-only)
logunmap = 1
pc = F2D1
sp = 4C
st = D0
totalcycles = 24E062  (read-only)


>symlist 2
Invalid CPU index 2
```