### PR TITLE
namcos21: clear screen to palette index 0 instead of 0xff

### DIFF
--- a/src/mame/namco/namcos21.cpp
+++ b/src/mame/namco/namcos21.cpp
@@ -486,7 +486,7 @@ void namcos21_state::winrun_bitmap_draw(bitmap_ind16 &bitmap, const rectangle &c
 
 uint32_t namcos21_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	bitmap.fill(0xff, cliprect );
+	bitmap.fill(0, cliprect);
 
 	m_namcos21_3d->copy_visible_poly_framebuffer(bitmap, cliprect, 0x7fc0, 0x7ffe);
 	m_namcos21_3d->copy_visible_poly_framebuffer(bitmap, cliprect, 0, 0x7fbf);


### PR DESCRIPTION
This makes the sky background from Winning Run games to blend more seamless with the fading horizon (specially winrungp and winrun91), this is just a duct-tape fix and the actual clear screen behavior from the hardware needs to be studied.