### PR TITLE
Adjust PV-1000 screen stretch to show full game area by default

### DIFF
--- a/src/mame/casio/pv1000.cpp
+++ b/src/mame/casio/pv1000.cpp
@@ -554,10 +554,11 @@ void pv1000_state::pv1000(machine_config &config)
 	// Display aspect is MAME's 4:3 default.
 
 	// Note that this value is overridden by the user's pv1000.cfg, if present.
-	// 206px x 48/35(PAR) / 4/3(DAR) = 212sl
+	// To allow full game display by default while preserving pixel aspect and display aspect, setting Screen Horizontal Stretch to 1.0, Screen Vertical Display to 1.097659
+	// This matches previous ratio established by lidnariq based on 206px x 48/35(PAR) / 4/3(DAR) = 212sl, or m_screen->set_default_position(216/206.0, 0, 244/212.0, 0)
 	m_screen->set_default_position(
-			216/206.0, 0, //216 px in storage aspect; cropped to 206 px
-			244/212.0, 0); //244 sl in storage aspect; cropped to 212 sl
+			1.0, 0,
+			6283.0/5724.0, 0); 
 	m_screen->set_screen_update(FUNC(pv1000_state::screen_update_pv1000));
 	m_screen->set_palette(m_palette);
 


### PR DESCRIPTION
Set the PV-1000 default screen scaling to:

    set_default_position(1.0, 0, 6283.0/5724.0, 0)

Previously, the default scaling caused games to appear cropped on both the left and right edges, requiring users to manually adjust stretch settings to see the full image. I understand that the change was done this way to simulate how it would look on an old CRT TV. With modern displays and monitors, real hardware can, and most of the time will show the full game area.

This change ensures the entire game area is visible by default, resulting in a much better out-of-the-box user experience while preserving visual accuracy.

The vertical stretch of ~1.097659 matches the original PAR/DAR correction derived from:
    (216 / 206.0) / (244 / 212.0) = 6283 / 5724

This maintains a 4:3 display shape with a pixel aspect ratio of 48:35, per lidnariq's analysis.

Attached are visuals of a couple games with current settings and with fixed default settings.
![Guntus_MAME0277](https://github.com/user-attachments/assets/aea067f3-9cf5-4c1c-8330-ae20807eaac7)
![Guntus_withFix](https://github.com/user-attachments/assets/6149565b-7cb3-4116-9087-9fd4040776f2)
![Turpin_MAME0277](https://github.com/user-attachments/assets/5a52a743-2920-4da4-94d6-b3a6be164990)
![Turpin_withFix](https://github.com/user-attachments/assets/b7848071-944a-4728-9d7b-4b960de8dab0)
        
As noted earlier, this fix not only preserves emulation accuracy 100%, but also provides everyone trying the Casio PV-1000 in MAME the best out-of-the-box experience in the modern TVs and monitors today, with absolutely no changes to sliders or configuration files.