### PR TITLE
cpu/mb86235: Improve TGPx4 interpreter

### DIFF
--- a/src/devices/cpu/mb86235/mb86235.cpp
+++ b/src/devices/cpu/mb86235/mb86235.cpp
@@ -1,22 +1,17 @@
 // license:BSD-3-Clause
-// copyright-holders:Angelo Salese, ElSemi, Ville Linde
+// copyright-holders:Angelo Salese, ElSemi, Ville Linde, Matthew Daniels
 /********************************************************************************
  *
  * MB86235 "TGPx4" (c) Fujitsu
  *
- * Written by Angelo Salese & ElSemi
+ * Written by Angelo Salese, ElSemi & Matthew Daniels
  *
  * TODO:
  * - rewrite ALU integer/floating point functions, use templates etc;
- * - move post-opcodes outside of the execute_op() function, like increment_prp()
- *    (needed if opcode uses fifo in/out);
  * - rewrite fifo hookups, remove them from the actual opcodes.
- * - use a phase system for the execution, like do_alu() being separated
- *    from control();
  * - illegal delay slots unsupported, and no idea about what is supposed to happen;
- * - externalize PDR / DDR (error LED flags on Model 2);
- * - instruction cycles;
- * - pipeline (four instruction executed per cycle!)
+ * - externalize PDR (error LED flags on Model 2);
+ * - perform external memory access if AALU-A is 0x400 or higher
  *
  ********************************************************************************/
 
@@ -78,7 +73,9 @@ void mb86235_device::execute_run()
 		else
 			handle_single_step_execution();
 
-		execute_op(opcode >> 32, opcode & 0xffffffff);
+		m_core->cur_fifo_state.has_stalled = false;
+
+		execute_op(opcode);
 
 		m_core->icount--;
 	}
@@ -264,8 +261,7 @@ mb86235_device::mb86235_device(const machine_config &mconfig, const char *tag, d
 	, m_dataa_config("data_a", ENDIANNESS_LITTLE, 32, 24, -2, address_map_constructor(FUNC(mb86235_device::internal_abus), this))
 	, m_datab_config("data_b", ENDIANNESS_LITTLE, 32, 10, -2, address_map_constructor(FUNC(mb86235_device::internal_bbus), this))
 	, m_fifoin(*this, finder_base::DUMMY_TAG)
-	, m_fifoout0(*this, finder_base::DUMMY_TAG)
-	, m_fifoout1(*this, finder_base::DUMMY_TAG)
+	, m_fifoout(*this, finder_base::DUMMY_TAG)
 	, m_cache(CACHE_SIZE + sizeof(mb86235_internal_state))
 	, m_drcuml(nullptr)
 	, m_drcfe(nullptr)

--- a/src/devices/cpu/mb86235/mb86235.h
+++ b/src/devices/cpu/mb86235/mb86235.h
@@ -27,8 +27,9 @@ public:
 	virtual ~mb86235_device() override;
 
 	template <typename T> void set_fifoin_tag(T &&fifo_tag) { m_fifoin.set_tag(std::forward<T>(fifo_tag)); }
-	template <typename T> void set_fifoout0_tag(T &&fifo_tag) { m_fifoout0.set_tag(std::forward<T>(fifo_tag)); }
-	template <typename T> void set_fifoout1_tag(T &&fifo_tag) { m_fifoout1.set_tag(std::forward<T>(fifo_tag)); }
+	template <typename T> void set_fifoout_tag(T &&fifo_tag) { m_fifoout.set_tag(std::forward<T>(fifo_tag)); }
+
+	void stall() { m_core->cur_fifo_state.has_stalled = true; }
 
 	void unimplemented_op();
 	void unimplemented_alu();
@@ -164,8 +165,7 @@ private:
 	address_space_config m_dataa_config;
 	address_space_config m_datab_config;
 	optional_device<generic_fifo_u32_device> m_fifoin;
-	optional_device<generic_fifo_u32_device> m_fifoout0;
-	optional_device<generic_fifo_u32_device> m_fifoout1;
+	optional_device<generic_fifo_u32_device> m_fifoout;
 
 	drc_cache m_cache;
 	std::unique_ptr<drcuml_state> m_drcuml;
@@ -226,25 +226,22 @@ private:
 	u32 m_cur_value;
 
 	static void clear_fifoin(void *param);
-	static void clear_fifoout0(void *param);
-	static void clear_fifoout1(void *param);
+	static void clear_fifoout(void *param);
 	static void read_fifoin(void *param);
-	static void write_fifoout0(void *param);
-	static void write_fifoout1(void *param);
+	static void write_fifoout(void *param);
 	static void empty_fifoin(void *param);
-	static void full_fifoout0(void *param);
-	static void full_fifoout1(void *param);
+	static void full_fifoout(void *param);
 
 	// interpreter
-	void execute_op(uint32_t h, uint32_t l);
-	void do_alu1(uint32_t h, uint32_t l);
-	void do_alu2(uint32_t h, uint32_t l);
-	void do_trans2_1(uint32_t h, uint32_t l);
-	void do_trans1_1(uint32_t h, uint32_t l);
-	void do_trans2_2(uint32_t h, uint32_t l);
-	void do_trans1_2(uint32_t h, uint32_t l);
-	void do_trans1_3(uint32_t h, uint32_t l);
-	void do_control(uint32_t h, uint32_t l);
+	void execute_op(uint64_t op);
+	void do_alu1(uint64_t op);
+	void do_alu2(uint64_t op);
+	void do_alu2_trans2_1(uint64_t op);
+	void do_alu2_trans1_1(uint64_t op);
+	void do_alu1_trans2_2(uint64_t op);
+	void do_alu1_trans1_2(uint64_t op);
+	void do_trans1_3(uint64_t op);
+	void do_alu_control(uint64_t op);
 	inline uint32_t get_prx(uint8_t which);
 	inline uint32_t get_constfloat(uint8_t which);
 	inline uint32_t get_constint(uint8_t which);
@@ -254,7 +251,7 @@ private:
 	inline void decode_aluop(uint8_t opcode, uint32_t src1, uint32_t src2, uint8_t imm, uint8_t dst_which);
 	inline void decode_mulop(bool isfmul, uint32_t src1, uint32_t src2, uint8_t dst_which);
 	inline bool decode_branch_jump(uint8_t which);
-	inline uint32_t do_control_dst(uint32_t l);
+	inline uint32_t do_control_dst(uint64_t op);
 	inline void push_pc(uint32_t pcval);
 	inline uint32_t pop_pc();
 	inline void set_mod(uint16_t mod1, uint16_t mod2);
@@ -268,7 +265,7 @@ private:
 	inline void decrement_prp();
 	inline void zero_prp();
 	inline void set_alu_flagsd(uint32_t val);
-	inline void set_alu_flagsf(double val);
+	inline void set_alu_flagsf(float val);
 	inline void set_alu_flagsi(int val);
 	inline bool get_alu_second_src(uint8_t which);
 	void handle_single_step_execution();

--- a/src/devices/cpu/mb86235/mb86235d.cpp
+++ b/src/devices/cpu/mb86235/mb86235d.cpp
@@ -98,19 +98,19 @@ void mb86235_disassembler::dasm_ea(std::ostream &stream, int md, int arx, int ar
 		case 0x0: util::stream_format(stream, "@AR%d", arx); break;
 		case 0x1: util::stream_format(stream, "@AR%d++", arx); break;
 		case 0x2: util::stream_format(stream, "@AR%d--", arx); break;
-		case 0x3: util::stream_format(stream, "@AR%d++%04X", arx, disp); break;
+		case 0x3: util::stream_format(stream, "@AR%d++%XH", arx, disp); break;
 		case 0x4: util::stream_format(stream, "@AR%d+AR%d", arx, ary); break;
 		case 0x5: util::stream_format(stream, "@AR%d+AR%d++", arx, ary); break;
 		case 0x6: util::stream_format(stream, "@AR%d+AR%d--", arx, ary); break;
-		case 0x7: util::stream_format(stream, "@AR%d+AR%d++%04X", arx, ary, disp); break;
+		case 0x7: util::stream_format(stream, "@AR%d+AR%d++%XH", arx, ary, disp); break;
 		case 0x8: util::stream_format(stream, "@AR%d+AR%dU", arx, ary); break;
 		case 0x9: util::stream_format(stream, "@AR%d+AR%dL", arx, ary); break;
-		case 0xa: util::stream_format(stream, "@AR%d+%04X", arx, disp); break;
-		case 0xb: util::stream_format(stream, "@AR%d+AR%d+%04X", arx, ary, disp); break;
-		case 0xc: util::stream_format(stream, "%04X", disp); break;
+		case 0xa: util::stream_format(stream, "@AR%d+%XH", arx, disp); break;
+		case 0xb: util::stream_format(stream, "@AR%d+AR%d+%XH", arx, ary, disp); break;
+		case 0xc: util::stream_format(stream, "%XH", disp); break;
 		case 0xd: util::stream_format(stream, "@AR%d+[AR%d++]", arx, ary); break;
 		case 0xe: util::stream_format(stream, "@AR%d+[AR%d--]", arx, ary); break;
-		case 0xf: util::stream_format(stream, "@AR%d+[AR%d++%04X]", arx, ary, disp); break;
+		case 0xf: util::stream_format(stream, "@AR%d+[AR%d++%XH]", arx, ary, disp); break;
 	}
 
 	stream << ')';
@@ -145,9 +145,9 @@ void mb86235_disassembler::dasm_alu_mul(std::ostream &stream, uint64_t opcode, b
 				break;
 			case 0x07: stream << "NOP";
 				break;
-			case 0x08: util::stream_format(stream, "FEA %s, #%02X, %s", ai1_field[i1], i2, mo_field[o]);
+			case 0x08: util::stream_format(stream, "FEA %s, #%XH, %s", ai1_field[i1], i2, mo_field[o]);
 				break;
-			case 0x09: util::stream_format(stream, "FES %s, #%02X, %s", ai1_field[i1], i2, mo_field[o]);
+			case 0x09: util::stream_format(stream, "FES %s, #%XH, %s", ai1_field[i1], i2, mo_field[o]);
 				break;
 			case 0x0a: util::stream_format(stream, "FRCP %s, %s", ai1_field[i1], mo_field[o]);
 				break;
@@ -185,13 +185,13 @@ void mb86235_disassembler::dasm_alu_mul(std::ostream &stream, uint64_t opcode, b
 				break;
 			case 0x1b: util::stream_format(stream, "NOT %s, %s", ai1_field[i1], mo_field[o]);
 				break;
-			case 0x1c: util::stream_format(stream, "LSR %s, #%02X, %s", ai1_field[i1], i2, mo_field[o]);
+			case 0x1c: util::stream_format(stream, "LSR %s, #%XH, %s", ai1_field[i1], i2, mo_field[o]);
 				break;
-			case 0x1d: util::stream_format(stream, "LSL %s, #%02X, %s", ai1_field[i1], i2, mo_field[o]);
+			case 0x1d: util::stream_format(stream, "LSL %s, #%XH, %s", ai1_field[i1], i2, mo_field[o]);
 				break;
-			case 0x1e: util::stream_format(stream, "ASR %s, #%02X, %s", ai1_field[i1], i2, mo_field[o]);
+			case 0x1e: util::stream_format(stream, "ASR %s, #%XH, %s", ai1_field[i1], i2, mo_field[o]);
 				break;
-			case 0x1f: util::stream_format(stream, "ASL %s, #%02X, %s", ai1_field[i1], i2, mo_field[o]);
+			case 0x1f: util::stream_format(stream, "ASL %s, #%XH, %s", ai1_field[i1], i2, mo_field[o]);
 				break;
 		}
 	}
@@ -236,13 +236,13 @@ offs_t mb86235_disassembler::dasm_control(std::ostream &stream, uint32_t pc, uin
 			break;
 		case 0x01:
 			if (ef1 == 0)
-				util::stream_format(stream, "REP #%04X", ef2);
+				util::stream_format(stream, "REP #%04XH", ef2);
 			else
 				util::stream_format(stream, "REP AR%d", (ef2 >> 12) & 7);
 			break;
 		case 0x02:
 			if (ef1 == 0)
-				util::stream_format(stream, "SETL #%04X", ef2);
+				util::stream_format(stream, "SETL #%04XH", ef2);
 			else
 				util::stream_format(stream, "SETL AR%d", (ef2 >> 12) & 7);
 			break;
@@ -261,32 +261,32 @@ offs_t mb86235_disassembler::dasm_control(std::ostream &stream, uint32_t pc, uin
 			util::stream_format(stream, "POP %s", regname[(ef2 >> 6) & 0x3f]);
 			break;
 		case 0x08:
-			util::stream_format(stream, "SETM #%04X", ef2);
+			util::stream_format(stream, "SETM #%04XH", ef2);
 			break;
 		case 0x09:
-			util::stream_format(stream, "SETM #%01X, CBSA", (ef2 >> 12) & 7);
+			util::stream_format(stream, "SETM #%Xh, CBSA", (ef2 >> 12) & 7);
 			break;
 		case 0x0a:
-			util::stream_format(stream, "SETM #%01X, CBSB", (ef2 >> 8) & 7);
+			util::stream_format(stream, "SETM #%Xh, CBSB", (ef2 >> 8) & 7);
 			break;
 		case 0x0b:
-			util::stream_format(stream, "SETM #%d, RF", (ef2 >> 7) & 1);
+			util::stream_format(stream, "SETM #%Xh, RF", (ef2 >> 7) & 1);
 			break;
 		case 0x0c:
-			util::stream_format(stream, "SETM #%d, RDY", (ef2 >> 4) & 1);
+			util::stream_format(stream, "SETM #%Xh, RDY", (ef2 >> 4) & 1);
 			break;
 		case 0x0d:
-			util::stream_format(stream, "SETM #%01X, WAIT", ef2 & 7);
+			util::stream_format(stream, "SETM #%Xh, WAIT", ef2 & 7);
 			break;
 		case 0x13:
-			util::stream_format(stream, "DBLP %04X", pc + rel12);
+			util::stream_format(stream, "DBLP %03X", pc + rel12);
 			break;
 		case 0x14:
-			util::stream_format(stream, "DBBC AR%d:%d, %04X", (uint32_t)((opcode >> 13) & 7), (uint32_t)((opcode >> 16) & 0xf), pc + rel12);
+			util::stream_format(stream, "DBBC AR%d:%d, %03X", (uint32_t)((opcode >> 13) & 7), (uint32_t)((opcode >> 16) & 0xf), pc + rel12);
 			flags = STEP_COND | step_over_extra(1);
 			break;
 		case 0x15:
-			util::stream_format(stream, "DBBS AR%d:%d, %04X", (uint32_t)((opcode >> 13) & 7), (uint32_t)((opcode >> 16) & 0xf), pc + rel12);
+			util::stream_format(stream, "DBBS AR%d:%d, %03X", (uint32_t)((opcode >> 13) & 7), (uint32_t)((opcode >> 16) & 0xf), pc + rel12);
 			flags = STEP_COND | step_over_extra(1);
 			break;
 		case 0x1b:
@@ -332,7 +332,7 @@ offs_t mb86235_disassembler::dasm_control(std::ostream &stream, uint32_t pc, uin
 			switch ((opcode >> 12) & 0xf)
 			{
 				case 0x0: util::stream_format(stream, "%03X", ef2 & 0xfff); break;
-				case 0x1: util::stream_format(stream, "%04X", pc + rel12); break;
+				case 0x1: util::stream_format(stream, "%03X", pc + rel12); break;
 				case 0x2: util::stream_format(stream, "%s", regname[(ef2 >> 6) & 0x3f]); break;
 				case 0x3: util::stream_format(stream, "+%s", regname[(ef2 >> 6) & 0x3f]); break;
 				case 0x4: util::stream_format(stream, "%s", regname[(ef2 >> 6) & 0x3f]); break;
@@ -450,7 +450,7 @@ void mb86235_disassembler::dasm_xfer1(std::ostream &stream, uint64_t opcode)
 	{
 		if (sr == 0x58)
 		{
-			util::stream_format(stream, "#%03X, %s", (uint32_t)(opcode & 0xfff), regname[dr]);
+			util::stream_format(stream, "#%XH, %s", (uint32_t)(opcode & 0xfff), regname[dr]);
 		}
 		else
 		{
@@ -476,11 +476,17 @@ void mb86235_disassembler::dasm_xfer1(std::ostream &stream, uint64_t opcode)
 			else
 				dasm_ea(stream, md, dr, ary, disp5);
 
-			util::stream_format(stream, "E(@EB+EO++%02X)", sr);
+			if (sr & 0x20)
+				util::stream_format(stream, "E(@EB+EO++-%XH)", 0x40 - (sr & 0x3f));
+			else
+				util::stream_format(stream, "E(@EB+EO++%XH)", sr & 0x3f);
 		}
 		else
 		{
-			util::stream_format(stream, "E(@EB+EO++%02X), ", sr);
+			if (sr & 0x20)
+				util::stream_format(stream, "E(@EB+EO++-%XH), ", 0x40 - (sr & 0x3f));
+			else
+				util::stream_format(stream, "E(@EB+EO++%XH), ", sr & 0x3f);
 
 			if ((dr & 0x40) == 0)
 				stream << regname[dr];
@@ -580,22 +586,22 @@ void mb86235_disassembler::dasm_double_xfer2(std::ostream &stream, uint64_t opco
 
 		switch (bmd)
 		{
-			case 0x0: util::stream_format(stream, "B(@BAR%d)", barx); break;
-			case 0x1: util::stream_format(stream, "B(@BAR%d++)", barx); break;
-			case 0x2: util::stream_format(stream, "B(@BAR%d--)", barx); break;
-			case 0x3: util::stream_format(stream, "B(@BAR%d++%02X)", barx, disp3); break;
-			case 0x4: util::stream_format(stream, "B(@BAR%d+BAR%d)", barx, bary); break;
-			case 0x5: util::stream_format(stream, "B(@BAR%d+BAR%d++)", barx, bary); break;
-			case 0x6: util::stream_format(stream, "B(@BAR%d+BAR%d--)", barx, bary); break;
-			case 0x7: util::stream_format(stream, "B(@BAR%d+BAR%d++%02X)", barx, bary, disp3); break;
-			case 0x8: util::stream_format(stream, "B(@BAR%d+BAR%dU)", barx, bary); break;
-			case 0x9: util::stream_format(stream, "B(@BAR%d+BAR%dL)", barx, bary); break;
-			case 0xa: util::stream_format(stream, "B(@BAR%d+%02X)", barx, disp3); break;
-			case 0xb: util::stream_format(stream, "B(@BAR%d+BAR%d+%02X)", barx, bary, disp3); break;
+			case 0x0: util::stream_format(stream, "B(@AR%d)", barx); break;
+			case 0x1: util::stream_format(stream, "B(@AR%d++)", barx); break;
+			case 0x2: util::stream_format(stream, "B(@AR%d--)", barx); break;
+			case 0x3: util::stream_format(stream, "B(@AR%d++%XH)", barx, disp3); break;
+			case 0x4: util::stream_format(stream, "B(@AR%d+AR%d)", barx, bary); break;
+			case 0x5: util::stream_format(stream, "B(@AR%d+AR%d++)", barx, bary); break;
+			case 0x6: util::stream_format(stream, "B(@AR%d+AR%d--)", barx, bary); break;
+			case 0x7: util::stream_format(stream, "B(@AR%d+AR%d++%XH)", barx, bary, disp3); break;
+			case 0x8: util::stream_format(stream, "B(@AR%d+AR%dU)", barx, bary); break;
+			case 0x9: util::stream_format(stream, "B(@AR%d+AR%dL)", barx, bary); break;
+			case 0xa: util::stream_format(stream, "B(@AR%d+%XH)", barx, disp3); break;
+			case 0xb: util::stream_format(stream, "B(@AR%d+AR%d+%XH)", barx, bary, disp3); break;
 			case 0xc: stream << "???"; break;
-			case 0xd: util::stream_format(stream, "B(@BAR%d+[BAR%d++])", barx, bary); break;
-			case 0xe: util::stream_format(stream, "B(@BAR%d+[BAR%d--])", barx, bary); break;
-			case 0xf: util::stream_format(stream, "B(@BAR%d+[BAR%d++%02X])", barx, bary, disp3); break;
+			case 0xd: util::stream_format(stream, "B(@AR%d+[AR%d++])", barx, bary); break;
+			case 0xe: util::stream_format(stream, "B(@AR%d+[AR%d--])", barx, bary); break;
+			case 0xf: util::stream_format(stream, "B(@AR%d+[AR%d++%XH])", barx, bary, disp3); break;
 		}
 
 		util::stream_format(stream, ", I(@AR%d++)", arx);
@@ -628,7 +634,7 @@ void mb86235_disassembler::dasm_xfer2(std::ostream &stream, uint64_t opcode)
 		{
 			if (sr == 0x58)
 			{
-				util::stream_format(stream, "#%06X, %s", (uint32_t)(opcode & 0xffffff), regname[dr]);
+				util::stream_format(stream, "#%06XH, %s", (uint32_t)(opcode & 0xffffff), regname[dr]);
 			}
 			else
 			{
@@ -648,9 +654,29 @@ void mb86235_disassembler::dasm_xfer2(std::ostream &stream, uint64_t opcode)
 		else
 		{
 			if (dir == 0)
-				util::stream_format(stream, "%s, E(@EB+EO++%02X)", regname[dr], sr);
+			{
+				if (dr & 0x40)
+					dasm_ea(stream, md, dr, ary, disp14);
+				else
+					stream << regname[dr];
+
+				if (sr & 0x20)
+					util::stream_format(stream, ", E(@EB+EO++-%XH)", 0x40 - (sr & 0x3f));
+				else
+					util::stream_format(stream, ", E(@EB+EO++%XH)", sr & 0x3f);
+			}
 			else
-				util::stream_format(stream, "E(@EB+EO++%02X), %s", sr, regname[dr]);
+			{
+				if (sr & 0x20)
+					util::stream_format(stream, "E(@EB+EO++-%XH), ", 0x40 - (sr & 0x3f));
+				else
+					util::stream_format(stream, "E(@EB+EO++%XH), ", sr & 0x3f);
+
+				if (dr & 0x40)
+					dasm_ea(stream, md, dr, ary, disp14);
+				else
+					stream << regname[dr];
+			}
 		}
 	}
 	else if (op == 2)
@@ -662,7 +688,7 @@ void mb86235_disassembler::dasm_xfer2(std::ostream &stream, uint64_t opcode)
 			if ((sr & 0x40) == 0)
 				stream << regname[sr];
 			else if (sr == 0x58)
-				util::stream_format(stream, "#%06X", (uint32_t)(opcode & 0xffffff));
+				util::stream_format(stream, "#%06XH", (uint32_t)(opcode & 0xffffff));
 			else
 				dasm_ea(stream, md, sr, ary, disp14);
 
@@ -671,9 +697,19 @@ void mb86235_disassembler::dasm_xfer2(std::ostream &stream, uint64_t opcode)
 		else
 		{
 			if (dir == 0)
-				util::stream_format(stream, "ICDTR%d, E(@EB+EO++%02X)", dr & 7, sr);
+			{
+				if (sr & 0x20)
+					util::stream_format(stream, "ICDTR%d, E(@EB+EO++-%XH)", dr & 7, 0x40 - (sr & 0x3f));
+				else
+					util::stream_format(stream, "ICDTR%d, E(@EB+EO++%XH)", dr & 7, sr & 0x3f);
+			}
 			else
-				util::stream_format(stream, "E(@EB+EO++%02X), ICDTR%d", sr, dr & 7);
+			{
+				if (sr & 0x20)
+					util::stream_format(stream, "E(@EB+EO++-%XH), ICDTR%d", 0x40 - (sr & 0x3f), dr & 7);
+				else
+					util::stream_format(stream, "E(@EB+EO++%XH), ICDTR%d", sr & 0x3f, dr & 7);
+			}
 		}
 	}
 }
@@ -704,7 +740,7 @@ offs_t mb86235_disassembler::disassemble(std::ostream &stream, offs_t pc, const 
 			stream << " : ";
 			dasm_double_xfer1(stream, opcode);
 			break;
-		case 1:     // ALU / MYL / transfer (type 1)
+		case 1:     // ALU / MUL / transfer (type 1)
 			dasm_alu_mul(stream, opcode, true);
 			stream << " : ";
 			dasm_xfer1(stream, opcode);

--- a/src/devices/cpu/mb86235/mb86235defs.h
+++ b/src/devices/cpu/mb86235/mb86235defs.h
@@ -5,8 +5,7 @@
 
 
 #define OP_USERFLAG_FIFOIN              0x1
-#define OP_USERFLAG_FIFOOUT0            0x2
-#define OP_USERFLAG_FIFOOUT1            0x4
+#define OP_USERFLAG_FIFOOUT             0x2
 #define OP_USERFLAG_REPEAT              0x8
 #define OP_USERFLAG_REPEATED_OP         0x10
 #define OP_USERFLAG_PR_MASK             0x300

--- a/src/devices/cpu/mb86235/mb86235fe.cpp
+++ b/src/devices/cpu/mb86235/mb86235fe.cpp
@@ -256,7 +256,6 @@ void mb86235_frontend::describe_reg_read(opcode_desc &desc, int reg)
 			break;
 
 		case 0x32:      // FO0
-			break;
 		case 0x33:      // FO1
 			break;
 
@@ -311,11 +310,8 @@ void mb86235_frontend::describe_reg_write(opcode_desc &desc, int reg)
 			break;
 
 		case 0x32:      // FO0
-			desc.userflags |= OP_USERFLAG_FIFOOUT0;
-			desc.flags |= OPFLAG_IS_BRANCH_TARGET;      // fifo check makes this a branch target
-			break;
 		case 0x33:      // FO1
-			desc.userflags |= OP_USERFLAG_FIFOOUT1;
+			desc.userflags |= OP_USERFLAG_FIFOOUT;
 			desc.flags |= OPFLAG_IS_BRANCH_TARGET;      // fifo check makes this a branch target
 			break;
 

--- a/src/devices/cpu/mb86235/mb86235ops.cpp
+++ b/src/devices/cpu/mb86235/mb86235ops.cpp
@@ -145,9 +145,9 @@ inline uint32_t mb86235_device::decode_ea(uint8_t mode, uint8_t rx, uint8_t ry, 
 			m_core->ar[ry] &= 0x3fff;
 			return m_core->ar[rx] + res;
 		case 0x08: // ARx + ARyU/ARyL (A bus/B bus)
-			return m_core->ar[rx] + isbbus ? (m_core->ar[ry] & 0x7f) : (m_core->ar[ry] >> 7);
+			return m_core->ar[rx] + (isbbus ? (m_core->ar[ry] & 0x7f) : (m_core->ar[ry] >> 7));
 		case 0x09: // ARx + ARyL/ARyU (A bus/B bus)
-			return m_core->ar[rx] + isbbus ? (m_core->ar[ry] >> 7) : (m_core->ar[ry] & 0x7f);
+			return m_core->ar[rx] + (isbbus ? (m_core->ar[ry] >> 7) : (m_core->ar[ry] & 0x7f));
 		case 0x0a: // ARx + disp14
 			return m_core->ar[rx] + disp;
 		case 0x0b: // ARx + ARy + disp14

--- a/src/devices/cpu/mb86235/mb86235ops.cpp
+++ b/src/devices/cpu/mb86235/mb86235ops.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Angelo Salese, ElSemi
+// copyright-holders:Angelo Salese, ElSemi, Matthew Daniels
 /*****************************************************************************
  *
  * MB86235 "TGPx4" (c) Fujitsu
@@ -41,23 +41,23 @@
 #define F1  0x20000000
 #define F2  0x40000000
 
-#define FSET(f) m_core->st|=(f)
-#define FCLR(f) m_core->st&=~(f)
+#define FSET(f) m_core->st |= (f)
+#define FCLR(f) m_core->st &= ~(f)
 
 void mb86235_device::handle_single_step_execution()
 {
-	if(m_core->cur_fifo_state.has_stalled == true)
+	if (m_core->cur_fifo_state.has_stalled == true)
 		return;
 
 	// repeat opcode
-	if(m_core->st & RP)
+	if (m_core->st & RP)
 	{
 		--m_core->rpc;
-		if(m_core->rpc == 1)
+		if (m_core->rpc == 1)
 			FCLR(RP);
 	}
 	else // normal operation
-		m_core->pc ++;
+		m_core->pc++;
 }
 
 bool mb86235_device::check_previous_op_stall()
@@ -68,23 +68,23 @@ bool mb86235_device::check_previous_op_stall()
 inline void mb86235_device::increment_pwp()
 {
 	m_core->pwp++;
-	if(m_core->pwp >= 24)
+	if (m_core->pwp >= 24)
 		m_core->pwp = 0;
 }
 
 void mb86235_device::increment_prp()
 {
-	m_core->prp ++;
-	if(m_core->prp >= 24)
+	m_core->prp++;
+	if (m_core->prp >= 24)
 		m_core->prp = 0;
 }
 
 void mb86235_device::decrement_prp()
 {
-	if(m_core->prp == 0)
+	if (m_core->prp == 0)
 		m_core->prp = 24;
 
-	m_core->prp --;
+	m_core->prp--;
 }
 
 void mb86235_device::zero_prp()
@@ -100,44 +100,82 @@ inline uint32_t mb86235_device::decode_ea(uint8_t mode, uint8_t rx, uint8_t ry, 
 	{
 		case 0x00: // ARx
 			return m_core->ar[rx];
-		case 0x01: // ARx ++
+		case 0x01: // ARx++
 			res = m_core->ar[rx];
-			if(m_core->cur_fifo_state.has_stalled == true)
+			if (m_core->cur_fifo_state.has_stalled == true)
 				return res;
 			m_core->ar[rx]++;
-			m_core->ar[rx]&=0x3fff;
+			m_core->ar[rx] &= 0x3fff;
 			return res;
-		case 0x03: // ARx + disp12
+		case 0x02: // ARx--
 			res = m_core->ar[rx];
-			if(m_core->cur_fifo_state.has_stalled == true)
+			if (m_core->cur_fifo_state.has_stalled == true)
 				return res;
-			m_core->ar[rx]+=disp;
-			m_core->ar[rx]&=0x3fff;
+			m_core->ar[rx]--;
+			m_core->ar[rx] &= 0x3fff;
+			return res;
+		case 0x03: // ARx++ disp14
+			res = m_core->ar[rx];
+			if (m_core->cur_fifo_state.has_stalled == true)
+				return res;
+			m_core->ar[rx] += disp;
+			m_core->ar[rx] &= 0x3fff;
 			return res;
 		case 0x04: // ARx + ARy
-			return m_core->ar[rx]+m_core->ar[ry];
+			return m_core->ar[rx] + m_core->ar[ry];
 		case 0x05: // ARx + ARy++
 			res = m_core->ar[ry];
-			if(m_core->cur_fifo_state.has_stalled == true)
-				return res;
+			if (m_core->cur_fifo_state.has_stalled == true)
+				return m_core->ar[rx] + res;
 			m_core->ar[ry]++;
-			m_core->ar[ry]&=0x3fff;
-			return m_core->ar[rx]+res;
-		case 0x07: // ARx + (ARy + disp12)
+			m_core->ar[ry] &= 0x3fff;
+			return m_core->ar[rx] + res;
+		case 0x06: // ARx + ARy--
 			res = m_core->ar[ry];
-			if(m_core->cur_fifo_state.has_stalled == true)
-				return res;
-			m_core->ar[ry]+=disp;
-			m_core->ar[ry]&=0x3fff;
-			return m_core->ar[rx]+res;
-		case 0x0a: // ARx + disp12
-			return m_core->ar[rx]+disp;
-		case 0x0b: // ARx + ARy + disp12
-			return m_core->ar[rx]+m_core->ar[ry]+disp;
+			if (m_core->cur_fifo_state.has_stalled == true)
+				return m_core->ar[rx] + res;
+			m_core->ar[ry]--;
+			m_core->ar[ry] &= 0x3fff;
+			return m_core->ar[rx] + res;
+		case 0x07: // ARx + (ARy++ disp14)
+			res = m_core->ar[ry];
+			if (m_core->cur_fifo_state.has_stalled == true)
+				return m_core->ar[rx] + res;
+			m_core->ar[ry] += disp;
+			m_core->ar[ry] &= 0x3fff;
+			return m_core->ar[rx] + res;
+		case 0x08: // ARx + ARyU/ARyL (A bus/B bus)
+			return m_core->ar[rx] + isbbus ? (m_core->ar[ry] & 0x7f) : (m_core->ar[ry] >> 7);
+		case 0x09: // ARx + ARyL/ARyU (A bus/B bus)
+			return m_core->ar[rx] + isbbus ? (m_core->ar[ry] >> 7) : (m_core->ar[ry] & 0x7f);
+		case 0x0a: // ARx + disp14
+			return m_core->ar[rx] + disp;
+		case 0x0b: // ARx + ARy + disp14
+			return m_core->ar[rx] + m_core->ar[ry] + disp;
+		case 0x0d: // ARx + [ARy++]
+			res = m_core->ar[ry] & (0x1ff >> (7 - (isbbus ? ((m_core->mod >> 8) & 7) : ((m_core->mod >> 12) & 7))));
+			if (m_core->cur_fifo_state.has_stalled == true)
+				return m_core->ar[rx] + res;
+			m_core->ar[ry]++;
+			m_core->ar[ry] &= 0x3fff;
+			return m_core->ar[rx] + res;
+		case 0x0e: // ARx + [ARy--]
+			res = m_core->ar[ry] & (0x1ff >> (7 - (isbbus ? ((m_core->mod >> 8) & 7) : ((m_core->mod >> 12) & 7))));
+			if (m_core->cur_fifo_state.has_stalled == true)
+				return m_core->ar[rx] + res;
+			m_core->ar[ry]--;
+			m_core->ar[ry] &= 0x3fff;
+			return m_core->ar[rx] + res;
+		case 0x0f: // ARx + [ARy++ disp14]
+			res = m_core->ar[ry] & (0x1ff >> (7 - (isbbus ? ((m_core->mod >> 8) & 7) : ((m_core->mod >> 12) & 7))));
+			if (m_core->cur_fifo_state.has_stalled == true)
+				return m_core->ar[rx] + res;
+			m_core->ar[ry] += disp;
+			m_core->ar[ry] &= 0x3fff;
+			return m_core->ar[rx] + res;
 	}
 
-
-	fatalerror("TGPx4: unemulated decode_ea type %02x executed at pc=%08x\n",mode,m_core->ppc);
+	fatalerror("TGPx4: illegal decode_ea type %02x executed at pc=%03x\n",mode,m_core->ppc);
 	return 0;
 }
 
@@ -161,39 +199,31 @@ inline void mb86235_device::write_bus(bool isbbus, uint32_t addr, uint32_t data)
  *
  ********************/
 
-void mb86235_device::execute_op(uint32_t h, uint32_t l)
+void mb86235_device::execute_op(uint64_t op)
 {
-	switch((h >> 29) & 7)
+	switch((op >> 61) & 7)
 	{
 		case 0:
-			do_alu2(h,l);
-			do_trans2_1(h,l);
+			do_alu2_trans2_1(op);
 			break;
 		case 1:
-			do_alu2(h,l);
-			do_trans1_1(h,l);
-			break;
-		case 2:
-			do_alu2(h,l);
-			do_control(h,l);
+			do_alu2_trans1_1(op);
 			break;
 		case 4:
-			do_alu1(h,l);
-			do_trans2_2(h,l);
+			do_alu1_trans2_2(op);
 			break;
 		case 5:
-			do_alu1(h,l);
-			do_trans1_2(h,l);
+			do_alu1_trans1_2(op);
 			break;
+		case 2:
 		case 6:
-			do_alu1(h,l);
-			do_control(h,l);
+			do_alu_control(op);
 			break;
 		case 7:
-			do_trans1_3(h,l);
+			do_trans1_3(op);
 			break;
 		default:
-			fatalerror("TGPx4: illegal opcode type %02x executed at pc=%08x\n",(h >> 29) & 7,m_core->ppc);
+			fatalerror("TGPx4: illegal opcode type %02x executed at pc=%03x\n",(op >> 61) & 7,m_core->ppc);
 	}
 }
 
@@ -206,34 +236,34 @@ void mb86235_device::execute_op(uint32_t h, uint32_t l)
 inline void mb86235_device::set_alu_flagsd(uint32_t val)
 {
 	FCLR(AN|AZ);
-	if(val&0x80000000) FSET(AN);
-	if(val==0) FSET(AZ);
+	if (val & 0x80000000) FSET(AN);
+	if (val == 0) FSET(AZ);
 }
 
-inline void mb86235_device::set_alu_flagsf(double val)
+inline void mb86235_device::set_alu_flagsf(float val)
 {
 	FCLR(AN|AZ);
-	if(val<0.0) FSET(AN);
-	if(val==0.0) FSET(AZ);
+	if (val < 0.0f) FSET(AN);
+	if (val == 0.0f) FSET(AZ);
 }
 
 inline void mb86235_device::set_alu_flagsi(int val)
 {
 	FCLR(AN|AZ);
-	if(val<0) FSET(AN);
-	if(val==0) FSET(AZ);
+	if (val < 0) FSET(AN);
+	if (val == 0) FSET(AZ);
 }
 
 inline uint32_t mb86235_device::get_prx(uint8_t which)
 {
 	uint32_t res = m_core->pr[m_core->prp];
-	switch(which & 7)
+	switch (which & 7)
 	{
 		case 0: break;
 		case 1: increment_prp(); break;
 		case 2: decrement_prp(); break;
 		case 3: zero_prp(); break;
-		default: fatalerror("TGPx4: unimplemented get_prx %02x at pc=%08x\n",which & 7,m_core->ppc); break;
+		default: fatalerror("TGPx4: illegal get_prx %02x at pc=%03x\n",which & 7,m_core->ppc); break;
 	}
 
 	return res;
@@ -241,13 +271,13 @@ inline uint32_t mb86235_device::get_prx(uint8_t which)
 
 inline uint32_t mb86235_device::get_constfloat(uint8_t which)
 {
-	const double float_table[8] = { -1.0, 0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 5.0 };
+	const float float_table[8] = { -1.0f, 0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 5.0f };
 	return f2u(float_table[which & 7]);
 }
 
 inline uint32_t mb86235_device::get_constint(uint8_t which)
 {
-	switch(which & 7)
+	switch (which & 7)
 	{
 		case 0: // A0
 			return 0;
@@ -257,13 +287,13 @@ inline uint32_t mb86235_device::get_constint(uint8_t which)
 			return 0xffffffff; // -1
 	}
 
-	fatalerror("TGPx4: illegal get_constint %02x at pc=%08x\n",which,m_core->ppc);
+	fatalerror("TGPx4: illegal get_constint %02x at pc=%03x\n",which,m_core->ppc);
 	return 0;
 }
 
 inline uint32_t mb86235_device::get_alureg(uint8_t which, bool isfloatop)
 {
-	switch(which >> 3)
+	switch (which >> 3)
 	{
 		case 0: // AAx
 			return m_core->aa[which & 7];
@@ -275,13 +305,13 @@ inline uint32_t mb86235_device::get_alureg(uint8_t which, bool isfloatop)
 			return (isfloatop == true) ? get_constfloat(which & 7) : get_constint(which & 7);
 	}
 
-	fatalerror("TGPx4: unimplemented get_alureg %02x at pc=%08x\n",which,m_core->ppc);
+	fatalerror("TGPx4: illegal get_alureg %02x at pc=%03x\n",which,m_core->ppc);
 	return 0;
 }
 
 inline uint32_t mb86235_device::get_mulreg(uint8_t which, bool isfloatop)
 {
-	switch(which >> 3)
+	switch (which >> 3)
 	{
 		case 0: // MAx
 			return m_core->ma[which & 7];
@@ -293,13 +323,13 @@ inline uint32_t mb86235_device::get_mulreg(uint8_t which, bool isfloatop)
 			return (isfloatop == true) ? get_constfloat(which & 7) : get_constint(which & 7);
 	}
 
-	fatalerror("TGPx4: unimplemented get_mulreg %02x at pc=%08x\n",which,m_core->ppc);
+	fatalerror("TGPx4: illegal get_mulreg %02x at pc=%03x\n",which,m_core->ppc);
 	return 0;
 }
 
 inline void mb86235_device::set_alureg(uint8_t which, uint32_t value)
 {
-	switch(which >> 3)
+	switch (which >> 3)
 	{
 		case 0: // MAx
 			m_core->ma[which & 7] = value;
@@ -326,41 +356,41 @@ inline void mb86235_device::decode_aluop(uint8_t opcode, uint32_t src1, uint32_t
 		case 0x02: // FSUB
 		case 0x03: // FSUBZ
 		{
-			double f1 = u2f(src1);
-			double f2 = u2f(src2);
-			double d;
+			float f1 = u2f(src1);
+			float f2 = u2f(src2);
+			float d;
 
-			if(opcode & 2)
+			if (opcode & 2)
 				d = f2-f1;
 			else
 				d = f1+f2;
 
-			if(opcode & 1)
+			if (opcode & 1)
 			{
 				FCLR(ZC);
-				if(d < 0.0)
+				if(d < 0.0f)
 				{
 					FSET(ZC);
-					d = 0.0;
+					d = 0.0f;
 				}
 			}
 
 			set_alu_flagsf(d);
-			set_alureg(dst_which,f2u(d));
+			set_alureg(dst_which, f2u(d));
 			break;
 		}
 
 		case 0x04: // FCMP
 		case 0x06: // FABC
 		{
-			double f1 = u2f(src1);
-			double f2 = u2f(src2);
-			double d;
+			float f1 = u2f(src1);
+			float f2 = u2f(src2);
+			float d;
 
 			if(opcode & 2)
-				d = fabs(f2)-fabs(f1);
+				d = fabs(f2) - fabs(f1);
 			else
-				d = f2-f1;
+				d = f2 - f1;
 
 			set_alu_flagsf(d);
 			break;
@@ -368,10 +398,10 @@ inline void mb86235_device::decode_aluop(uint8_t opcode, uint32_t src1, uint32_t
 
 		case 0x05: // FABS
 		{
-			double d = u2f(src1);
+			float d = u2f(src1);
 			d = fabs(d);
 			set_alu_flagsf(d);
-			set_alureg(dst_which,f2u(d));
+			set_alureg(dst_which, f2u(d));
 			break;
 		}
 
@@ -381,59 +411,59 @@ inline void mb86235_device::decode_aluop(uint8_t opcode, uint32_t src1, uint32_t
 		case 0x08: // FEA
 		case 0x09: // FES
 		{
-			uint32_t exp = (src1>>23)&0xff;
+			uint32_t exp = (src1 >> 23) & 0xff;
 			src1 &= 0x7f800000;
 			if(opcode & 1)
 				exp -= imm;
 			else
 				exp += imm;
 			exp &= 0xff;
-			src1 |= exp<<23;
+			src1 |= exp << 23;
 			set_alu_flagsd(src1);
-			set_alureg(dst_which,src1);
+			set_alureg(dst_which, src1);
 			break;
 		}
 
 		case 0x0a: // FRCP
 		{
-			double f = u2f(src1);
+			float f = u2f(src1);
 			FCLR(ZD);
-			if(f == 0.0f)
+			if (f == 0.0f)
 				FSET(ZD);
-			f = 1.0/f;
+			f = 1.0f / f;
 			set_alu_flagsf(f);
-			set_alureg(dst_which,f2u(f));
+			set_alureg(dst_which, f2u(f));
 			break;
 		}
 
 		case 0x0b: // FRSQ
 		{
-			double f = u2f(src1);
+			float f = u2f(src1);
 			FCLR(NR);
-			if(f <= 0.0f)
+			if (f <= 0.0f)
 				FSET(NR);
-			f = 1.0/sqrtf(f);
+			f = 1.0f / sqrtf(f);
 			set_alu_flagsf(f);
-			set_alureg(dst_which,f2u(f));
+			set_alureg(dst_which, f2u(f));
 			break;
 		}
 
 		case 0x0c: // FLOG
 		{
-			double f = u2f(src1);
+			float f = u2f(src1);
 			FCLR(IL);
 			if(f <= 0.0f)
 				FSET(IL);
-			f = log(f)/0.301030; // log2
+			f = log(f) / 0.301030f; // log2
 			set_alu_flagsf(f);
-			set_alureg(dst_which,f2u(f));
+			set_alureg(dst_which, f2u(f));
 			break;
 		}
 
 		case 0x0d: // CIF
 		{
 			int v = (int)src1;
-			double f = u2f(v);
+			float f = (float)v;
 			set_alu_flagsf(f);
 			set_alureg(dst_which,f2u(f));
 			break;
@@ -441,29 +471,26 @@ inline void mb86235_device::decode_aluop(uint8_t opcode, uint32_t src1, uint32_t
 
 		case 0x0e: // CFI
 		{
-			double f = u2f(src1);
+			float f = u2f(src1);
 			int v = (int)f;
 			set_alu_flagsi(v);
-			set_alureg(dst_which,f2u(v));
+			set_alureg(dst_which, (uint32_t)v);
 			break;
 		}
 
 		case 0x0f: // CFIB
 		{
-			double f = u2f(src1);
-			uint32_t res;
-			FCLR(AU);
-			res = f2u(f);
-			if(f<0)
+			float f = u2f(src1);
+			uint32_t res = (uint32_t)f;
+			if (f < 0.0f)
 			{
 				FSET(AU);
 				res=0;
 			};
 			FCLR(AZ);
-			if(res==0)
+			if (res == 0)
 				FSET(AZ);
-			FCLR(AV);
-			if(res>0xff)
+			if (res > 0xff)
 			{
 				FSET(AV);
 				res=0xff;
@@ -497,7 +524,7 @@ inline void mb86235_device::decode_aluop(uint8_t opcode, uint32_t src1, uint32_t
 				}
 			}
 			set_alu_flagsi(res);
-			set_alureg(dst_which,(uint32_t)res);
+			set_alureg(dst_which, (uint32_t)res);
 			break;
 		}
 
@@ -505,7 +532,7 @@ inline void mb86235_device::decode_aluop(uint8_t opcode, uint32_t src1, uint32_t
 		{
 			int v1 = (((int)src1) << 0) >> 0;
 			int v2 = (((int)src2) << 0) >> 0;
-			int res = v2-v1;
+			int res = v2 - v1;
 			set_alu_flagsi(res);
 			break;
 		}
@@ -514,23 +541,23 @@ inline void mb86235_device::decode_aluop(uint8_t opcode, uint32_t src1, uint32_t
 		{
 			src1 &= 0x7fffffff;
 			set_alu_flagsd(src1);
-			set_alureg(dst_which,src1);
+			set_alureg(dst_which, src1);
 			break;
 		}
 
 		case 0x16: // ATR
 		case 0x17: // ATRZ
 		{
-			if(opcode & 1)
+			if (opcode & 1)
 			{
 				FCLR(ZC);
-				if(src1&0x80000000)
+				if (src1 & 0x80000000)
 				{
 					FSET(ZC);
-					src1=0;
+					src1 = 0;
 				}
 			}
-			set_alureg(dst_which,src1);
+			set_alureg(dst_which, src1);
 			break;
 		}
 
@@ -539,7 +566,7 @@ inline void mb86235_device::decode_aluop(uint8_t opcode, uint32_t src1, uint32_t
 		{
 			uint32_t res = src1 & src2;
 			set_alu_flagsd(res);
-			set_alureg(dst_which,res);
+			set_alureg(dst_which, res);
 			break;
 		}
 
@@ -547,7 +574,7 @@ inline void mb86235_device::decode_aluop(uint8_t opcode, uint32_t src1, uint32_t
 		{
 			uint32_t res = src1 | src2;
 			set_alu_flagsd(res);
-			set_alureg(dst_which,res);
+			set_alureg(dst_which, res);
 			break;
 		}
 
@@ -555,7 +582,7 @@ inline void mb86235_device::decode_aluop(uint8_t opcode, uint32_t src1, uint32_t
 		{
 			uint32_t res = src1 ^ src2;
 			set_alu_flagsd(res);
-			set_alureg(dst_which,res);
+			set_alureg(dst_which, res);
 			break;
 		}
 
@@ -563,7 +590,7 @@ inline void mb86235_device::decode_aluop(uint8_t opcode, uint32_t src1, uint32_t
 		{
 			uint32_t res = ~src1;
 			set_alu_flagsd(res);
-			set_alureg(dst_which,res);
+			set_alureg(dst_which, res);
 			break;
 		}
 
@@ -571,7 +598,7 @@ inline void mb86235_device::decode_aluop(uint8_t opcode, uint32_t src1, uint32_t
 		{
 			uint32_t res = src1 >> imm;
 			set_alu_flagsd(res);
-			set_alureg(dst_which,res);
+			set_alureg(dst_which, res);
 			break;
 		}
 
@@ -579,7 +606,7 @@ inline void mb86235_device::decode_aluop(uint8_t opcode, uint32_t src1, uint32_t
 		{
 			uint32_t res = src1 << imm;
 			set_alu_flagsd(res);
-			set_alureg(dst_which,res);
+			set_alureg(dst_which, res);
 			break;
 		}
 
@@ -587,20 +614,20 @@ inline void mb86235_device::decode_aluop(uint8_t opcode, uint32_t src1, uint32_t
 		{
 			int res = ((((int)src1) << 0) >> 0) >> imm;
 			set_alu_flagsi(res);
-			set_alureg(dst_which,(uint32_t)res);
+			set_alureg(dst_which, (uint32_t)res);
 			break;
 		}
 
 		case 0x1f: // ASL
 		{
 			int res = ((((int)src1) << 0) >> 0) << imm;
-			set_alu_flagsd(res);
-			set_alureg(dst_which,(uint32_t)res);
+			set_alu_flagsi(res);
+			set_alureg(dst_which, (uint32_t)res);
 			break;
 		}
 
 		default:
-			fatalerror("TGPx4: unimplemented decode_aluop %02x at pc=%08x\n",opcode,m_core->ppc);
+			fatalerror("TGPx4: illegal decode_aluop %02x at pc=%03x\n",opcode,m_core->ppc);
 	}
 }
 
@@ -608,100 +635,102 @@ void mb86235_device::decode_mulop(bool isfmul, uint32_t src1, uint32_t src2, uin
 {
 	if(isfmul == true) // FMUL
 	{
-		double f1 = u2f(src1);
-		double f2 = u2f(src2);
-		double res = f1*f2;
-		FCLR(MD|MU|MV);
-		// TODO: MD MU MV flags
-		FCLR(MN|MZ);
-		if(res<0.0) FSET(MN);
-		if(res==0.0) FSET(MZ);
-		set_alureg(dst_which,f2u(res));
+		float f1 = u2f(src1);
+		float f2 = u2f(src2);
+		float res = f1 * f2;
+		FCLR(MN|MZ|MD);	// MV and MU are not reset
+		if (res < 0.0f) FSET(MN);
+		if (res == 0.0f) FSET(MZ);
+		if (std::isinf(res)) FSET(MV);
+		if (std::abs(res) < std::numeric_limits<float>::min()) FSET(MU);
+		if (std::isnan(res)) FSET(MD);
+		set_alureg(dst_which, f2u(res));
 	}
 	else // MUL
 	{
 		int v1 = (int)src1;
 		int v2 = (int)src2;
-		int res = v1*v2;
+		int res = v1 * v2;
 		FCLR(MN|MZ);
-		if(res<0) FSET(MN);
-		if(res==0) FSET(MZ);
-		set_alureg(dst_which,(uint32_t)res);
+		if (res < 0) FSET(MN);
+		if (res == 0) FSET(MZ);
+		set_alureg(dst_which, (uint32_t)res);
 	}
 }
 
-#define GETAOP(x)  ((x>>24)&0x1f)
-#define GETAI1(x)  ((x>>20)&0xf)
-#define GETAI2(x)  ((x>>15)&0x1f)
-#define GETAO(x)   ((x>>10)&0x1f)
+#define GETAOP(x)  ((x >> 56) & 0x1f)
+#define GETAI1(x)  ((x >> 52) & 0x0f)
+#define GETAI2(x)  ((x >> 47) & 0x1f)
+#define GETAO(x)   ((x >> 42) & 0x1f)
 
-#define GETMOP(x)   ((x>>9)&0x1)
-#define GETMI1(x)   ((x>>5)&0x0f)
-#define GETMI2(x)   ((x>>0)&0x1f)
-#define GETMO(x)    ((x>>27)&0x1f)
+#define GETMOP(x)   ((x >> 41) & 0x01)
+#define GETMI1(x)   ((x >> 37) & 0x0f)
+#define GETMI2(x)   ((x >> 32) & 0x1f)
+#define GETMO(x)    ((x >> 27) & 0x1f)
 
 inline bool mb86235_device::get_alu_second_src(uint8_t which)
 {
-	if((which & 0x1c) == 0x1c) // logical ops
+	if ((which & 0x1c) == 0x1c) // logical ops
 		return false;
 
-	if((which & 0x1e) == 0x16) // ATRx
+	if ((which & 0x1e) == 0x16) // ATRx
 		return false;
 
-	if((which & 0x0f) == 0x05) // ABS/FABS
+	if ((which & 0x0f) == 0x05) // ABS/FABS
 		return false;
 
-	if((which & 0x18) == 0x08) // floating point ops
+	if ((which & 0x18) == 0x08) // floating point ops
 		return false;
 
 	return true;
 }
 
-void mb86235_device::do_alu1(uint32_t h, uint32_t l)
+void mb86235_device::do_alu1(uint64_t op)
 {
-	if(m_core->cur_fifo_state.has_stalled == true)
+	if (m_core->cur_fifo_state.has_stalled == true)
 		return;
 
-	if(h&(1<<9)) // ALU
+	if (op & (1ll << 41)) // ALU
 	{
-		uint8_t opcode = GETAOP(h);
-		uint32_t alusrc1 = get_alureg(GETAI1(h),false);
+		uint8_t aluop = GETAOP(op);
+		uint32_t alusrc1 = get_alureg(GETAI1(op),false);
 		uint32_t alusrc2;
-		if(get_alu_second_src(opcode) == true)
-			alusrc2 = get_alureg(GETAI2(h),(opcode & 0x10) == 0);
+		if(get_alu_second_src(aluop) == true)
+			alusrc2 = get_alureg(GETAI2(op),(aluop & 0x10) == 0);
 		else
 			alusrc2 = 0;
-		decode_aluop(opcode, alusrc1, alusrc2, GETAI2(h), GETAO(h));
+		decode_aluop(aluop, alusrc1, alusrc2, GETAI2(op), GETAO(op));
 	}
 	else // MUL
 	{
-		bool opcode = GETAOP(h) != 0;
-		uint32_t mulsrc1 = get_mulreg(GETAI1(h),false);
-		uint32_t mulsrc2 = get_mulreg(GETAI2(h),opcode);
-		decode_mulop(opcode, mulsrc1, mulsrc2, GETAO(h));
+		bool isfmul = GETAOP(op) != 0;
+		uint32_t mulsrc1 = get_mulreg(GETAI1(op),false);
+		uint32_t mulsrc2 = get_mulreg(GETAI2(op),isfmul);
+		decode_mulop(isfmul, mulsrc1, mulsrc2, GETAO(op));
 	}
 }
 
-void mb86235_device::do_alu2(uint32_t h, uint32_t l)
+void mb86235_device::do_alu2(uint64_t op)
 {
-	if(m_core->cur_fifo_state.has_stalled == true)
+	if (m_core->cur_fifo_state.has_stalled == true)
 		return;
 
 	// ALU
-	uint8_t opcode = GETAOP(h);
-	uint32_t alusrc1 = get_alureg(GETAI1(h),false);
+	uint8_t aluop = GETAOP(op);
+	uint32_t alusrc1 = get_alureg(GETAI1(op), false);
 	uint32_t alusrc2;
-	if(get_alu_second_src(opcode) == true)
-		alusrc2 = get_alureg(GETAI2(h),(opcode & 0x10) == 0);
+	if (get_alu_second_src(aluop) == true)
+		alusrc2 = get_alureg(GETAI2(op), (aluop & 0x10) == 0);
 	else
 		alusrc2 = 0;
-	decode_aluop(opcode, alusrc1, alusrc2, GETAI2(h), GETAO(h));
 
 	// MUL
-	opcode = GETMOP(h);
-	alusrc1 = get_mulreg(GETMI1(h),false);
-	alusrc2 = get_mulreg(GETMI2(h),opcode != 0);
-	decode_mulop(opcode != 0, alusrc1, alusrc2, GETMO(l));
+	bool isfmul = GETMOP(op) != 0;
+	uint32_t mulsrc1 = get_mulreg(GETMI1(op), false);
+	uint32_t mulsrc2 = get_mulreg(GETMI2(op), isfmul);
+
+	decode_aluop(aluop, alusrc1, alusrc2, GETAI2(op), GETAO(op));
+	decode_mulop(isfmul, mulsrc1, mulsrc2, GETMO(op));
 }
 
 /*********************
@@ -712,26 +741,23 @@ void mb86235_device::do_alu2(uint32_t h, uint32_t l)
 
 inline uint32_t mb86235_device::get_transfer_reg(uint8_t which)
 {
-	switch(which >> 3)
+	switch (which >> 3)
 	{
 		case 0: // MAx
 			return m_core->ma[which & 7];
 		case 1: // AAx
 			return m_core->aa[which & 7];
 		case 2:
-			switch(which & 7)
+			switch (which & 7)
 			{
 				case 0: return m_core->eb;
-				//case 1: m_core->ebu = value; break;
-				//case 2: m_core->ebl = value; break;
+				case 1: return m_core->eb >> 14;
+				case 2: return m_core->eb & 0x3fff;
 				case 3: return m_core->eo;
 				case 4: return m_core->sp;
 				case 5: return m_core->st;
 				case 6: return m_core->mod;
 				case 7: return m_core->lpc;
-				default:
-					fatalerror("TGPx4: unimplemented set_transfer_reg %02x at pc=%08x\n",which,m_core->ppc);
-					break;
 			}
 
 			break;
@@ -750,27 +776,30 @@ inline uint32_t mb86235_device::get_transfer_reg(uint8_t which)
 
 				case 1: // FI
 				{
-					FCLR(IFE);
-					if(m_fifoin->is_empty())
+					uint32_t res = m_fifoin->pop();
+					if (m_core->cur_fifo_state.has_stalled == true)
 					{
-						FSET(IFE);
-						m_core->cur_fifo_state.has_stalled = true;
 						if((m_core->st & RP) == 0)
 							m_core->cur_fifo_state.pc = m_core->ppc;
 						//else
-						//  fatalerror("check me %08x\n",m_core->ppc);
-
-						return 0;
+						//  fatalerror("check me %03x\n",m_core->ppc);
 					}
 
-					m_core->cur_fifo_state.has_stalled = false;
-					return m_fifoin->pop();
+					return res;
 				}
+				case 4: // PDR
+					return m_core->pdr;
+				case 5: // DDR
+					return m_core->ddr;
+				case 6: // PRP
+					return m_core->prp;
+				case 7: // PWP
+					return m_core->pwp;
 			}
 		}
 	}
 
-	fatalerror("TGPx4: unimplemented get_transfer_reg %02x at pc=%08x\n",which,m_core->ppc);
+	fatalerror("TGPx4: illegal get_transfer_reg %02x at pc=%03x\n",which,m_core->ppc);
 	return 0;
 }
 
@@ -788,18 +817,14 @@ inline void mb86235_device::set_transfer_reg(uint8_t which, uint32_t value)
 			switch(which & 7)
 			{
 				case 0: m_core->eb = value; break;
-				//case 1: m_core->ebu = value; break;
-				//case 2: m_core->ebl = value; break;
+				case 1: m_core->eb = (m_core->eb & 0x3fff) | (value << 14); break;
+				case 2: m_core->eb = (m_core->eb & 0xffc000) | (value << 14); break;
 				case 3: m_core->eo = value; break;
 				case 4: m_core->sp = value; break;
 				case 5: m_core->st = value; break;
 				case 6: m_core->mod = value; break;
 				case 7: m_core->lpc = value; break;
-				default:
-					fatalerror("TGPx4: unimplemented set_transfer_reg %02x at pc=%08x\n",which,m_core->ppc);
-					break;
 			}
-
 			break;
 		case 3: // ARx
 			m_core->ar[which & 7] = value & 0x3fff;
@@ -819,117 +844,174 @@ inline void mb86235_device::set_transfer_reg(uint8_t which, uint32_t value)
 						increment_pwp();
 					break;
 				case 2: // FO0
-					FCLR(OFF);
-					if(m_fifoout0)
-					{
-						if(m_fifoout0->is_full())
-						{
-							FSET(OFF);
-							m_core->cur_fifo_state.has_stalled = true;
-							if((m_core->st & RP) == 0)
-								m_core->cur_fifo_state.pc = m_core->ppc;
-
-							//else
-							//  fatalerror("check me (writes)");
-							return;
-						}
-
-						m_core->cur_fifo_state.has_stalled = false;
-						m_fifoout0->push(u32(value));
-					}
+				case 3: // FO1 (same FIFO output buffer but sets the 33rd bit; not used by Model 2)
+					if(m_fifoout)
+						m_fifoout->push(u32(value));
 					break;
 				case 4: m_core->pdr = value; break;
 				case 5: m_core->ddr = value; break;
 				case 6:
 					if(value >= 24)
-						fatalerror("TGPx4: attempting to set prp with a %02x at pc=%08x\n",value,m_core->ppc);
+						fatalerror("TGPx4: attempting to set prp with a %02x at pc=%03x\n",value,m_core->ppc);
 
 					m_core->prp = value;
 					break;
 				case 7:
 					if(value >= 24)
-						fatalerror("TGPx4: attempting to set pwp with a %02x at pc=%08x\n",value,m_core->ppc);
+						fatalerror("TGPx4: attempting to set pwp with a %02x at pc=%03x\n",value,m_core->ppc);
 
 					m_core->pwp = value;
 					break;
 				default:
-					fatalerror("TGPx4: unimplemented set_transfer_reg %02x at pc=%08x\n",which,m_core->ppc);
+					fatalerror("TGPx4: illegal set_transfer_reg %02x at pc=%03x\n",which,m_core->ppc);
 					break;
 			}
 
 			break;
 		default:
-			fatalerror("TGPx4: unimplemented set_transfer_reg dst %02x at pc=%08x\n",which,m_core->ppc);
+			fatalerror("TGPx4: illegal set_transfer_reg dst %02x at pc=%03x\n",which,m_core->ppc);
 			break;
 	}
 }
 
 // double transfer type 1
-void mb86235_device::do_trans2_1(uint32_t h, uint32_t l)
+void mb86235_device::do_alu2_trans2_1(uint64_t op)
 {
-	fatalerror("TGPx4: unimplemented trans2_1 op %08x %08x at pc=%08x\n",h,l,m_core->ppc);
+	uint8_t sd = (op >> 25) & 3;
+	uint32_t ares, bres;
+
+	switch (sd)
+	{
+	case 0:
+	case 1:
+	{
+		uint8_t as = (op >> 20) & 0x1f;
+		uint8_t bs = (op >> 10) & 0xf;
+		ares = get_transfer_reg(as);
+		bres = get_transfer_reg(bs | 0x20);
+		break;
+	}
+	case 2:
+	{
+		uint32_t addr = decode_ea(op & 0xf, (op >> 17) & 7, (op >> 14) & 7, 0, false);
+		ares = read_bus(false, addr);
+		addr = decode_ea(op & 0xf, (op >> 7) & 7, (op >> 4) & 7, 0, true);
+		bres = read_bus(true, addr);
+		break;
+	}
+	default:
+		fatalerror("TGPx4: illegal trans2_1 SD %02x at pc=%03x\n", sd, m_core->ppc);
+		break;
+	}
+
+	// do alu
+	do_alu2(op);
+
+	switch (sd)
+	{
+	case 0:
+	case 2:
+	{
+		uint8_t ad = (op >> 20) & 0x1f;
+		uint8_t bd = (op >> 10) & 0xf;
+		set_transfer_reg(ad, ares);
+		set_transfer_reg(bd | 0x20, bres);
+		break;
+	}
+	case 1:
+	{
+		uint32_t addr = decode_ea(op & 0xf, (op >> 17) & 7, (op >> 14) & 7, 0, false);
+		write_bus(false, addr, ares);
+		addr = decode_ea(op & 0xf, (op >> 7) & 7, (op >> 4) & 7, 0, true);
+		write_bus(true, addr, bres);
+		break;
+	}
+	}
 }
 
 // transfer type 1
-void mb86235_device::do_trans1_1(uint32_t h, uint32_t l)
+void mb86235_device::do_alu2_trans1_1(uint64_t op)
 {
 	uint8_t sr,dr;
 	uint32_t res;
 
-	if(l & (1<<26)) //External transfer
+	if(op & (1ll<<26)) //External transfer
 	{
-		if(l & (1<<25)) // ext -> int
+		if(op & (1ll<<25)) // ext -> int
 		{
-			dr = (l >> 12) & 0x7f;
 			uint32_t addr = m_core->eb+m_core->eo;
-			uint8_t disp_offs = (l >> 19) & 0x3f;
-
 			res = m_dataa.read_dword(addr);
+
+			// do alu
+			do_alu2(op);
+
+			dr = (op >> 12) & 0x7f;
 			if(dr & 0x40)
 			{
 				bool isbbus = (dr & 0x20) == 0x20;
-				addr = decode_ea(l & 0xf,dr & 7,(l >> 4) & 7, (l >> 7) & 0x1f,isbbus);
+				addr = decode_ea(op & 0xf,dr & 7,(op >> 4) & 7, (op >> 7) & 0x1f,isbbus);
 				write_bus(isbbus,addr,res);
 			}
 			else
 				set_transfer_reg(dr,res);
 
-			if(disp_offs & 0x20)
-				m_core->eo -= disp_offs & 0x1f;
-			else
-				m_core->eo += disp_offs & 0x1f;
+			int8_t disp_offs = (op >> 19) & 0x3f;
+			if (disp_offs & 0x20)
+				disp_offs -= 0x40;
+			m_core->eo += disp_offs;
 		}
 		else // int -> ext
 		{
-			fatalerror("TGPx4: unimplemented trans1_1 int->ext %08x %08x at pc=%08x\n",h,l,m_core->ppc);
+			sr = (op >> 12) & 0x7f;
+			if (sr & 0x40)
+			{
+				bool isbbus = (sr & 0x20) == 0x20;
+				uint32_t addr = decode_ea(op & 0xf, sr & 7, (op >> 4) & 7, (op >> 7) & 0x1f, isbbus);
+				res = read_bus(isbbus, addr);
+			}
+			else
+				res = get_transfer_reg(sr);
+
+			// do alu
+			do_alu2(op);
+
+			uint32_t addr = m_core->eb + m_core->eo;
+			m_dataa.write_dword(addr, res);
+
+			int8_t disp_offs = (op >> 19) & 0x3f;
+			if (disp_offs & 0x20)
+				disp_offs -= 0x40;
+			m_core->eo += disp_offs;
 		}
 	}
 	else
 	{
-		sr = (l>>19) & 0x7f;
-		dr = (l>>12) & 0x7f;
-
+		sr = (op>>19) & 0x7f;
 		if(sr & 0x40)
 		{
-			if(sr == 0x58)
-				fatalerror("TGPx4: unimplemented trans1_1 sr %08x dr %08x at pc=%08x\n",sr,dr,m_core->ppc);
+			if (sr == 0x58)
+				res = op & 0xfff;
 			else
 			{
 				bool isbbus = (sr & 0x20) == 0x20;
-				uint32_t addr = decode_ea(l & 0xf,sr & 7,(l >> 4) & 7, (l >> 7) & 0x1f,isbbus);
+				uint32_t addr = decode_ea(op & 0xf,sr & 7,(op >> 4) & 7, (op >> 7) & 0x1f,isbbus);
 				res = read_bus(isbbus,addr);
 			}
 		}
 		else
 			res = get_transfer_reg(sr);
 
+		// do alu
+		do_alu2(op);
+
+		dr = (op >> 12) & 0x7f;
 		if(dr & 0x40)
 		{
 			if(dr == 0x58)
-				fatalerror("TGPx4: illegal do_trans1_1 dr == 0x58 at pc=%08x\n",m_core->ppc);
+				fatalerror("TGPx4: illegal do_alu2_trans1_1 dr == 0x58 at pc=%03x\n",m_core->ppc);
 
 			bool isbbus = (dr & 0x20) == 0x20;
-			uint32_t addr = decode_ea(l & 0xf,dr & 7,(l >> 4) & 7, (l >> 7) & 0x1f,isbbus);
+			uint32_t addr = decode_ea(op & 0xf,dr & 7,(op >> 4) & 7, (op >> 7) & 0x1f,isbbus);
 			write_bus(isbbus,addr,res);
 		}
 		else
@@ -938,137 +1020,182 @@ void mb86235_device::do_trans1_1(uint32_t h, uint32_t l)
 }
 
 // double transfer type 2
-void mb86235_device::do_trans2_2(uint32_t h, uint32_t l)
+void mb86235_device::do_alu1_trans2_2(uint64_t op)
 {
-	uint8_t sda = (h >> 6) & 3;
-	uint8_t sdb = (l >> 18) & 3;
+	uint8_t sda = (op >> 38) & 3;
+	uint8_t sdb = (op >> 18) & 3;
+	uint32_t ares, bres;
 
-	// A bus
+	// A bus read
 	switch(sda)
 	{
-		// reg -> reg
-		case 0:
-		{
-			uint8_t as = (h >> 1) & 0x1f;
-			uint8_t ada= (l >> 28) & 0xf;
-			if(h&1)
-				ada|=0x10;
-
-			set_transfer_reg(ada,get_transfer_reg(as));
-			break;
-		}
-		default:
-			fatalerror("TGPx4: unimplemented trans2_2 SDA %08x at pc=%08x\n",sda,m_core->ppc);
-			break;
+	case 0:
+	case 1:
+	{
+		uint8_t as = (op >> 33) & 0x1f;
+		ares = get_transfer_reg(as);
+		break;
+	}
+	case 2:
+	{
+		uint32_t addr = decode_ea((op >> 20) & 0xf, (op >> 30) & 7, (op >> 27) & 7, (op >> 24) & 7, false);
+		ares = read_bus(false, addr);
+		break;
+	}
+	default:
+		fatalerror("TGPx4: illegal trans2_2 SDA %02x at pc=%03x\n", sda, m_core->ppc);
+		break;
 	}
 
-	// B bus
+	// B bus read
 	switch(sdb)
 	{
-		// reg -> reg
-		case 0:
-		{
-			uint8_t bs = (l >> 13) & 0x1f;
-			uint8_t bd = (l >>  8) & 0xf;
-			set_transfer_reg(bd|0x20,get_transfer_reg(bs|0x20));
-			break;
-		}
+	case 0:
+	case 1:
+	{
+		uint8_t bs = (op >> 13) & 0x1f;
+		bres = get_transfer_reg(bs | 0x20);
+		break;
+	}
+	case 2:
+	{
+		uint32_t addr = decode_ea(op & 0xf, (op >> 10) & 7, (op >> 7) & 7, (op >> 4) & 7, true);
+		bres = read_bus(true, addr);
+		break;
+	}
+	default:
+		fatalerror("TGPx4: illegal trans2_2 SDB %02x at pc=%03x\n", sdb, m_core->ppc);
+		break;
+	}
 
-		default:
-			fatalerror("TGPx4: unimplemented trans2_2 SDB %08x at pc=%08x\n",sdb,m_core->ppc);
-			break;
+	// do alu
+	do_alu1(op);
+
+	// A bus write
+	switch (sda)
+	{
+	case 0:
+	case 2:
+	{
+		uint8_t ad = (op >> 28) & 0x1f;
+		set_transfer_reg(ad, ares);
+		break;
+	}
+	case 1:
+	{
+		uint32_t addr = decode_ea((op >> 20) & 0xf, (op >> 30) & 7, (op >> 27) & 7, (op >> 24) & 7, false);
+		write_bus(false, addr, ares);
+		break;
+	}
+	}
+
+	// B bus write
+	switch (sdb)
+	{
+	case 0:
+	case 2:
+	{
+		uint8_t bd = (op >> 8) & 0x1f;
+		set_transfer_reg(bd | 0x20, bres);
+		break;
+	}
+	case 1:
+	{
+		uint32_t addr = decode_ea(op & 0xf, (op >> 10) & 7, (op >> 7) & 7, (op >> 4) & 7, true);
+		write_bus(true, addr, bres);
+		break;
+	}
 	}
 }
 
 // transfer type 2
-void mb86235_device::do_trans1_2(uint32_t h, uint32_t l)
+void mb86235_device::do_alu1_trans1_2(uint64_t op)
 {
 	uint8_t sr, dr;
 	uint32_t res;
 
-	if(h & 1<<6) // external transfer
+	if(op & 1ll<<38) // external transfer
 	{
-		if(h & 1<<5) // ext->int
+		if(op & 1ll<<37) // ext->int
 		{
-			dr = (l >> 24) & 0x7f;
 			uint32_t addr = m_core->eb+m_core->eo;
-			uint8_t disp_offs = (h << 1) & 0x3e;
-			uint32_t res;
-			if(l&0x80000000)
-				disp_offs |= 1;
+			uint32_t res = m_dataa.read_dword(addr);
 
-			res = m_dataa.read_dword(addr);
+			// do alu
+			do_alu1(op);
+
+			dr = (op >> 24) & 0x7f;
 			if(dr & 0x40)
 			{
 				bool isbbus = (dr & 0x20) == 0x20;
-				addr = decode_ea(l & 0xf,dr & 7,(l >> 4) & 7, (l >> 7) & 0xfff,isbbus);
-				write_bus(isbbus,addr,res);
+				addr = decode_ea(op & 0xf, dr & 7, (op >> 4) & 7, (op >> 7) & 0x3fff, isbbus);
+				write_bus(isbbus, addr, res);
 			}
 			else
 				set_transfer_reg(dr,res);
 
-			if(disp_offs & 0x20)
-				m_core->eo -= disp_offs & 0x1f;
-			else
-				m_core->eo += disp_offs & 0x1f;
+			int8_t disp_offs = (op >> 31) & 0x3f;
+			if (disp_offs & 0x20)
+				disp_offs -= 0x40;
+			m_core->eo += disp_offs;
 		}
 		else // int->ext
 		{
-			sr = (l >> 24) & 0x7f;
-			uint32_t addr = m_core->eb+m_core->eo;
-			uint8_t disp_offs = (h << 1) & 0x3e;
-			if(l&0x80000000)
-				disp_offs |= 1;
-
+			sr = (op >> 24) & 0x7f;
 			if(sr & 0x40)
 			{
 				if(sr == 0x58)
-					res = l & 0xffffff;
+					res = op & 0xffffff;
 				else
 				{
 					bool isbbus = (sr & 0x20) == 0x20;
-					uint32_t addr = decode_ea(l & 0xf,sr & 7,(l >> 4) & 7, (l >> 7) & 0x3fff,isbbus);
-					res = read_bus(isbbus,addr);
+					uint32_t addr = decode_ea(op & 0xf, sr & 7, (op >> 4) & 7, (op >> 7) & 0x3fff, isbbus);
+					res = read_bus(isbbus, addr);
 				}
 			}
 			else
 				res = get_transfer_reg(sr);
 
+			// do alu
+			do_alu1(op);
+
+			uint32_t addr = m_core->eb + m_core->eo;
 			m_dataa.write_dword(addr,res);
-			if(disp_offs & 0x20)
-				m_core->eo -= disp_offs & 0x1f;
-			else
-				m_core->eo += disp_offs & 0x1f;
+
+			int8_t disp_offs = (op >> 31) & 0x3f;
+			if (disp_offs & 0x20)
+				disp_offs -= 0x40;
+			m_core->eo += disp_offs;
 		}
 	}
 	else
 	{
-		sr = (h << 1) &0x7e;
-		dr = (l >> 24) &0x7f;
-		if(l & 0x80000000)
-			sr|=1;
-
+		sr = (op >> 31) & 0x7f;
 		if(sr & 0x40)
 		{
 			if(sr == 0x58)
-				res = l & 0xffffff;
+				res = op & 0xffffff;
 			else
 			{
 				bool isbbus = (sr & 0x20) == 0x20;
-				uint32_t addr = decode_ea(l & 0xf,sr & 7,(l >> 4) & 7, (l >> 7) & 0x3fff,isbbus);
+				uint32_t addr = decode_ea(op & 0xf,sr & 7,(op >> 4) & 7, (op >> 7) & 0x3fff,isbbus);
 				res = read_bus(isbbus,addr);
 			}
 		}
 		else
 			res = get_transfer_reg(sr);
 
+		// do alu
+		do_alu1(op);
+
+		dr = (op >> 24) & 0x7f;
 		if(dr & 0x40)
 		{
 			if(dr == 0x58)
-				fatalerror("TGPx4: illegal do_trans1_2 dr == 0x58 at pc=%08x\n",m_core->ppc);
+				fatalerror("TGPx4: illegal do_alu1_trans1_2 dr == 0x58 at pc=%03x\n",m_core->ppc);
 
 			bool isbbus = (dr & 0x20) == 0x20;
-			uint32_t addr = decode_ea(l & 0xf,dr & 7,(l >> 4) & 7, (l >> 7) & 0x3fff,isbbus);
+			uint32_t addr = decode_ea(op & 0xf,dr & 7,(op >> 4) & 7, (op >> 7) & 0x3fff,isbbus);
 			write_bus(isbbus,addr,res);
 		}
 		else
@@ -1077,16 +1204,15 @@ void mb86235_device::do_trans1_2(uint32_t h, uint32_t l)
 }
 
 // transfer type 3
-void mb86235_device::do_trans1_3(uint32_t h, uint32_t l)
+void mb86235_device::do_trans1_3(uint64_t op)
 {
-	uint8_t dr   = (l >> 19) & 0x7f;
-	uint32_t imm = (l >> 27) & 0x1f;
-	imm|= (h & 0x7ffffff)<<5;
+	uint8_t dr   = (op >> 19) & 0x7f;
+	uint32_t imm = (op >> 27) & 0xffffffff;
 
 	if(dr & 0x40)
 	{
 		bool isbbus = (dr & 0x20) == 0x20;
-		uint32_t addr = decode_ea(l & 0xf,dr & 7,(l >> 4) & 7, (l >> 7) & 0xfff,isbbus);
+		uint32_t addr = decode_ea(op & 0xf,dr & 7,(op >> 4) & 7, (op >> 7) & 0xfff,isbbus);
 		write_bus(isbbus,addr,imm);
 	}
 	else // direct imm reg
@@ -1104,7 +1230,7 @@ inline void mb86235_device::push_pc(uint32_t pcval)
 	m_core->pcs[m_core->pcp++] = pcval;
 	m_core->pcp &= 3;
 //  if(m_core->pcp & ~3)
-//      fatalerror("TGPx4: push_pc overflow PCP=%08x PC=%08x\n",m_core->pcp,m_core->ppc);
+//      fatalerror("TGPx4: push_pc overflow PCP=%08x PC=%03x\n",m_core->pcp,m_core->ppc);
 }
 
 inline uint32_t mb86235_device::pop_pc()
@@ -1112,26 +1238,50 @@ inline uint32_t mb86235_device::pop_pc()
 	m_core->pcp--;
 	m_core->pcp &= 3;
 //  if(m_core->pcp & ~3)
-//      fatalerror("TGPx4: pop_pc underflow PCP=%08x PC=%08x\n",m_core->pcp,m_core->ppc);
+//      fatalerror("TGPx4: pop_pc underflow PCP=%08x PC=%03x\n",m_core->pcp,m_core->ppc);
 
 	return m_core->pcs[m_core->pcp];
 }
 
-inline uint32_t mb86235_device::do_control_dst(uint32_t l)
+inline uint32_t mb86235_device::do_control_dst(uint64_t op)
 {
-	switch((l>>12)&0xf)
+	uint32_t addr = 0;
+
+	switch ((op >> 13) & 7)
 	{
-		case 0: // absolute immediate
-			return l & 0xfff;
-		case 2: // absolute register AR
-			return m_core->ar[(l >> 6) & 7];
-		case 4: // absolute register AAx / ABx
-			return (l & 1 << 11) ? m_core->ab[(l >> 6) & 7] : m_core->aa[(l >> 6) & 7];
-		default:
-			fatalerror("TGPx4: unimplemented do_control_dst op mode %08x at pc=%08x\n",(l>>12) & 0xf,m_core->ppc);
+	case 0: // immediate
+		addr = op & 0xfff;
+		break;
+	case 1: // register ARx
+		addr = m_core->ar[(op >> 6) & 7];
+		break;
+	case 2:
+		addr = (op & 1ll << 11) ? m_core->ab[(op >> 6) & 7] : m_core->aa[(op >> 6) & 7];
+		break;
+	case 3:
+		addr = (op & 1ll << 11) ? m_core->mb[(op >> 6) & 7] : m_core->ma[(op >> 6) & 7];
+		break;
+	case 4:
+		addr = read_bus(false, op & 0x3ff);
+		break;
+	case 5:
+		addr = read_bus(true, op & 0x3ff);
+		break;
+	case 6:
+		addr = read_bus(false, m_core->ar[(op >> 6) & 7]);
+		break;
+	case 7:
+		addr = read_bus(true, m_core->ar[(op >> 6) & 7]);
+		break;
 	}
 
-	return 0;
+	if (op & 1ll << 12)
+	{
+		m_core->icount--;
+		return (m_core->pc + addr) & 0xfff;
+	}
+	else
+		return addr & 0xfff;
 }
 
 inline void mb86235_device::set_mod(uint16_t mod1, uint16_t mod2)
@@ -1142,25 +1292,38 @@ inline void mb86235_device::set_mod(uint16_t mod1, uint16_t mod2)
 
 inline bool mb86235_device::decode_branch_jump(uint8_t which)
 {
-	// test, should be 22
-	if(which < 14)
+	if (which < 19)
 	{
-		const uint32_t condition_table[22] = {MN, MZ, MV, MU, ZD, NR, IL, ZC,
-											  AN, AZ, AV, AU, MD, AD, F0, F1,
-											  F2,IFF,IFE,OFF,OFE, 0};
+		const uint32_t condition_table[19] = { MN, MZ, MV, MU, ZD, NR, IL, ZC, AN, AZ,
+											   AV, AU, MD, AD, 0, 0, F0, F1, F2 };
 
 		return (m_core->st & condition_table[which]) != 0;
 	}
+	else switch (which)
+	{
+	case 20: // IFF
+		return m_fifoin->is_full();
+	case 21: // IFE
+		return m_fifoin->is_empty();
+	case 22: // OFF
+		return m_fifoout->is_full();
+	case 23: // OFE
+		return m_fifoout->is_empty();
+	case 24: // IF
+		return false;	// bit 33 of input FIFO; not used by Model 2
+	default:
+		fatalerror("TGPx4: illegal decode_branch_jump mode %02x at pc=%03x\n", which, m_core->ppc);
+	}
 
-	fatalerror("TGPx4: unimplemented decode_branch_jump mode %08x at pc=%08x\n",which,m_core->ppc);
+	
 	return false;
 }
 
-void mb86235_device::do_control(uint32_t h, uint32_t l)
+void mb86235_device::do_alu_control(uint64_t op)
 {
-	uint32_t cop = (l >> 22) & 0x1f;
-	uint32_t ef1 = (l >> 16) & 0x3f;
-	uint16_t ef2 = l & 0xffff;
+	uint32_t cop = (op >> 22) & 0x1f;
+	uint32_t ef1 = (op >> 16) & 0x3f;
+	uint16_t ef2 = op & 0xffff;
 
 	switch(cop)
 	{
@@ -1187,48 +1350,38 @@ void mb86235_device::do_control(uint32_t h, uint32_t l)
 			{
 				if(m_fifoin)
 					m_fifoin->clear();
-				FSET(IFE);
-				FCLR(IFF);
-				m_core->cur_fifo_state.has_stalled = false;
 			}
-			if(ef1 & 2) // clear fifo0/1 out (CLRFO)
+			if(ef1 & 2) // clear fifo out (CLRFO)
 			{
-				if(m_fifoout0)
-					m_fifoout0->clear();
-				if(m_fifoout1)
-					m_fifoout1->clear();
-				FSET(OFE);
-				FCLR(OFF);
-				m_core->cur_fifo_state.has_stalled = false;
+				if(m_fifoout)
+					m_fifoout->clear();
 			}
 			break;
 		case 0x04: // PUSH
-			m_core->sp --;
+			m_core->sp--;
 			m_core->sp &= 0x3ff;
-			m_datab.write_dword(m_core->sp,get_transfer_reg((ef2>>6) & 0x3f));
+			m_datab.write_dword(m_core->sp, get_transfer_reg((ef2>>6) & 0x3f));
 			break;
 		case 0x05: // POP
-			set_transfer_reg((ef2>>6) & 0x3f, m_datab.read_dword(m_core->sp));
-			m_core->sp ++;
-			m_core->sp &= 0x3ff;
+			// wait until ALU operation(s) have finished before popping
 			break;
 		case 0x08: // SETM
-			set_mod(0xffff,ef2);
+			set_mod(0xffff, ef2);
 			break;
 		case 0x09: // SETMCBSA
-			set_mod(0x7000,ef2);
+			set_mod(0x7000, ef2);
 			break;
 		case 0x0a: // SETMCBSB
-			set_mod(0x0e00,ef2);
+			set_mod(0x0e00, ef2);
 			break;
 		case 0x0b: // SETMRF
-			set_mod(0x0080,ef2);
+			set_mod(0x0080, ef2);
 			break;
 		case 0x0c: // SETMRDY
-			set_mod(0x0010,ef2);
+			set_mod(0x0010, ef2);
 			break;
 		case 0x0d: // SETMWAIT
-			set_mod(0x0007,ef2);
+			set_mod(0x0007, ef2);
 			break;
 
 		// control flow
@@ -1238,9 +1391,9 @@ void mb86235_device::do_control(uint32_t h, uint32_t l)
 			if(result == true)
 			{
 				m_core->delay_slot = true;
-				m_core->delay_pc = do_control_dst(l);
-				m_core->icount--;
+				m_core->delay_pc = do_control_dst(op);
 			}
+			m_core->icount--;
 			break;
 		}
 		case 0x11: // DBNcc
@@ -1249,15 +1402,16 @@ void mb86235_device::do_control(uint32_t h, uint32_t l)
 			if(result == false)
 			{
 				m_core->delay_slot = true;
-				m_core->delay_pc = do_control_dst(l);
-				m_core->icount--;
+				m_core->delay_pc = do_control_dst(op);
 			}
+			m_core->icount--;
 			break;
 		}
 		case 0x12: // DJMP
 		{
 			m_core->delay_slot = true;
-			m_core->delay_pc = do_control_dst(l);
+			m_core->delay_pc = do_control_dst(op);
+			m_core->icount--;
 			break;
 		}
 		case 0x13: // DBLP
@@ -1266,7 +1420,7 @@ void mb86235_device::do_control(uint32_t h, uint32_t l)
 			{
 				m_core->delay_slot = true;
 				// relative addressing only
-				m_core->delay_pc = m_core->pc + (l & 0xfff);
+				m_core->delay_pc = m_core->pc + (op & 0xfff);
 				m_core->delay_pc&= 0xfff;
 			}
 
@@ -1275,15 +1429,40 @@ void mb86235_device::do_control(uint32_t h, uint32_t l)
 				FCLR(LP);
 			break;
 		}
+		case 0x14: // DBBC
+		{
+			bool result = m_core->ar[(op >> 13) & 7] & (1 << ((op >> 16) & 0xf));
+			if (result == false)
+			{
+				m_core->delay_slot = true;
+				m_core->delay_pc = m_core->pc + (op & 0xfff);
+				m_core->delay_pc &= 0xfff;
+			}
+			m_core->icount -= 2;
+			break;
+		}
+		case 0x15: // DBBS
+		{
+			bool result = m_core->ar[(op >> 13) & 7] & (1 << ((op >> 16) & 0xf));
+			if (result == true)
+			{
+				m_core->delay_slot = true;
+				m_core->delay_pc = m_core->pc + (op & 0xfff);
+				m_core->delay_pc &= 0xfff;
+			}
+			m_core->icount -= 2;
+			break;
+		}
 		case 0x18: // DCcc
 		{
 			bool result = decode_branch_jump(ef1);
 			if(result == true)
 			{
 				m_core->delay_slot = true;
-				m_core->delay_pc = do_control_dst(l);
+				m_core->delay_pc = do_control_dst(op);
 				push_pc(m_core->pc+1);
 			}
+			m_core->icount--;
 			break;
 		}
 		case 0x19: // DCNcc
@@ -1292,14 +1471,15 @@ void mb86235_device::do_control(uint32_t h, uint32_t l)
 			if(result == false)
 			{
 				m_core->delay_slot = true;
-				m_core->delay_pc = do_control_dst(l);
+				m_core->delay_pc = do_control_dst(op);
 				push_pc(m_core->pc+1);
 			}
+			m_core->icount--;
 			break;
 		}
 		case 0x1a: // DCALL
 			m_core->delay_slot = true;
-			m_core->delay_pc = do_control_dst(l);
+			m_core->delay_pc = do_control_dst(op);
 			push_pc(m_core->pc+1);
 			break;
 		case 0x1b: // DRET
@@ -1307,7 +1487,21 @@ void mb86235_device::do_control(uint32_t h, uint32_t l)
 			m_core->delay_pc = pop_pc();
 			break;
 		default:
-			fatalerror("TGPx4: unimplemented control op %08x at pc=%08x\n",cop,m_core->ppc);
+			fatalerror("TGPx4: illegal control op %02x at pc=%03x\n", cop, m_core->ppc);
+	}
+
+	// do alu
+	if (op & (1ll << 63))
+		do_alu1(op);
+	else
+		do_alu2(op);
+
+	// now we can safely pop if needed
+	if (cop == 0x05)
+	{
+		set_transfer_reg((ef2 >> 6) & 0x3f, m_datab.read_dword(m_core->sp));
+		m_core->sp++;
+		m_core->sp &= 0x3ff;
 	}
 }
 

--- a/src/mame/sega/model2.cpp
+++ b/src/mame/sega/model2.cpp
@@ -12,7 +12,6 @@
     TODO:
     - color gamma and Mip Mapping still needs to be properly sorted in the renderer;
     - sound comms still needs some work (sometimes m68k doesn't get some commands or play them with a delay);
-    - 2C games needs TGPx4 emulation;
     - outputs and artwork (for gearbox indicators);
     - clean-ups;
 
@@ -30,6 +29,7 @@
               bypass it by entering then exiting service mode;
     - sgt24h: first turn in easy reverse course has ugly rendered mountain in background;
     - srallyc: some 3d elements doesn't show up properly (tree models, last hill in course 1 is often black colored);
+	- stcc: no collision detection with enemy cars, sometimes enemy cars glitch out and disappear altogether;
     - vcop: sound dies at enter initial screen (i.e. after played the game once) (untested);
     - vstriker: stadium ads have terrible colors (they uses the wrong color table, @see video/model2rd.hxx)
 
@@ -221,20 +221,20 @@ void model2c_state::machine_start()
 {
 	model2_state::machine_start();
 
-	m_copro_fifo_in->setup(16,
-						   [    ]() { },
-						   [    ]() { },
-						   [    ]() { },
+	m_copro_fifo_in->setup(8,
+						   [this]() { m_copro_tgpx4->stall(); },
+						   [this]() { m_copro_tgpx4->set_input_line(INPUT_LINE_HALT, ASSERT_LINE); },
+						   [this]() { m_copro_tgpx4->set_input_line(INPUT_LINE_HALT, CLEAR_LINE); },
 						   [this]() { m_maincpu->set_input_line(INPUT_LINE_HALT, ASSERT_LINE); },
 						   [this]() { m_maincpu->set_input_line(INPUT_LINE_HALT, CLEAR_LINE); },
 						   [    ]() { },
 						   [    ]() { });
-	m_copro_fifo_out->setup(16,
+	m_copro_fifo_out->setup(8,
 							[this]() { m_maincpu->i960_stall(); },
 							[this]() { m_maincpu->set_input_line(INPUT_LINE_HALT, ASSERT_LINE); },
 							[this]() { m_maincpu->set_input_line(INPUT_LINE_HALT, CLEAR_LINE); },
-							[    ]() { },
-							[    ]() { },
+							[this]() { m_copro_tgpx4->set_input_line(INPUT_LINE_HALT, ASSERT_LINE); },
+							[this]() { m_copro_tgpx4->set_input_line(INPUT_LINE_HALT, CLEAR_LINE); },
 							[    ]() { },
 							[    ]() { });
 }
@@ -763,7 +763,7 @@ void model2c_state::copro_tgpx4_data_map(address_map &map)
 {
 //  map(0x00000000, 0x000003ff) internal RAM
 	map(0x00400000, 0x00407fff).ram().share("bufferram").mirror(0x003f8000);
-	map(0x00800000, 0x008fffff).rom().region("copro_data",0); // ROM data
+	map(0x00800000, 0x009fffff).rom().region("copro_data",0); // ROM data
 }
 
 
@@ -2804,7 +2804,7 @@ void model2b_state::model2b(machine_config &config)
 
 	TIMER(config, "scantimer", 0).configure_scanline(FUNC(model2_state::model2_interrupt), "screen", 0, 1);
 
-	ADSP21062(config, m_copro_adsp, 40000000);
+	ADSP21062(config, m_copro_adsp, 32_MHz_XTAL);
 	m_copro_adsp->set_boot_mode(adsp21062_device::BOOT_MODE_HOST);
 	m_copro_adsp->set_addrmap(AS_DATA, &model2b_state::copro_sharc_map);
 
@@ -2958,11 +2958,11 @@ void model2c_state::model2c(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &model2c_state::model2c_crx_mem);
 	TIMER(config, "scantimer").configure_scanline(FUNC(model2c_state::model2c_interrupt), "screen", 0, 1);
 
-	MB86235(config, m_copro_tgpx4, 40000000);
+	MB86235(config, m_copro_tgpx4, 20_MHz_XTAL);
 	m_copro_tgpx4->set_addrmap(AS_PROGRAM, &model2c_state::copro_tgpx4_map);
 	m_copro_tgpx4->set_addrmap(AS_DATA, &model2c_state::copro_tgpx4_data_map);
 	m_copro_tgpx4->set_fifoin_tag(m_copro_fifo_in);
-	m_copro_tgpx4->set_fifoout0_tag(m_copro_fifo_out);
+	m_copro_tgpx4->set_fifoout_tag(m_copro_fifo_out);
 
 	GENERIC_FIFO_U32(config, m_copro_fifo_in, 0);
 	GENERIC_FIFO_U32(config, m_copro_fifo_out, 0);
@@ -4549,6 +4549,9 @@ ROM_START( stcc ) /* Sega Touring Car Championship, Model 2C - Defaults to Japan
 	ROM_LOAD32_WORD("mpr-19252.21", 0x000002, 0x400000, CRC(68509993) SHA1(654d5cdf44e7e1e788b26593f418ce76a5c1165a) )
 	ROM_LOAD32_WORD("epr-19266.18", 0x800000, 0x080000, CRC(41464ee2) SHA1(afbbc0328bd36c34c69f0f54404dfd6a64036417) )
 	ROM_LOAD32_WORD("epr-19267.22", 0x800002, 0x080000, CRC(780f994d) SHA1(f134482ed0fcfc7b3eea39947da47081301a111a) )
+	ROM_COPY("polygons", 0x800000, 0x900000, 0x100000)
+	ROM_COPY("polygons", 0x800000, 0xa00000, 0x200000)
+	ROM_COPY("polygons", 0x800000, 0xc00000, 0x400000)
 
 	ROM_REGION( 0x1000000, "textures", 0 ) // Textures
 	ROM_LOAD32_WORD("mpr-19254.27", 0x000000, 0x200000, CRC(1ec49c02) SHA1(a9bdbab7b4b265c9118cf27fd45ca94f4516d5c6) )
@@ -4614,6 +4617,9 @@ ROM_START( stccb ) /* Sega Touring Car Championship Revision B, Model 2C - Defau
 	ROM_LOAD32_WORD("mpr-19252.21", 0x000002, 0x400000, CRC(68509993) SHA1(654d5cdf44e7e1e788b26593f418ce76a5c1165a) )
 	ROM_LOAD32_WORD("epr-19266.18", 0x800000, 0x080000, CRC(41464ee2) SHA1(afbbc0328bd36c34c69f0f54404dfd6a64036417) )
 	ROM_LOAD32_WORD("epr-19267.22", 0x800002, 0x080000, CRC(780f994d) SHA1(f134482ed0fcfc7b3eea39947da47081301a111a) )
+	ROM_COPY("polygons", 0x800000, 0x900000, 0x100000)
+	ROM_COPY("polygons", 0x800000, 0xa00000, 0x200000)
+	ROM_COPY("polygons", 0x800000, 0xc00000, 0x400000)
 
 	ROM_REGION( 0x1000000, "textures", 0 ) // Textures
 	ROM_LOAD32_WORD("mpr-19254.27", 0x000000, 0x200000, CRC(1ec49c02) SHA1(a9bdbab7b4b265c9118cf27fd45ca94f4516d5c6) )
@@ -4679,6 +4685,9 @@ ROM_START( stcca ) /* Sega Touring Car Championship Revision A, Model 2C - Defau
 	ROM_LOAD32_WORD("mpr-19252.21", 0x000002, 0x400000, CRC(68509993) SHA1(654d5cdf44e7e1e788b26593f418ce76a5c1165a) )
 	ROM_LOAD32_WORD("epr-19266.18", 0x800000, 0x080000, CRC(41464ee2) SHA1(afbbc0328bd36c34c69f0f54404dfd6a64036417) )
 	ROM_LOAD32_WORD("epr-19267.22", 0x800002, 0x080000, CRC(780f994d) SHA1(f134482ed0fcfc7b3eea39947da47081301a111a) )
+	ROM_COPY("polygons", 0x800000, 0x900000, 0x100000)
+	ROM_COPY("polygons", 0x800000, 0xa00000, 0x200000)
+	ROM_COPY("polygons", 0x800000, 0xc00000, 0x400000)
 
 	ROM_REGION( 0x1000000, "textures", 0 ) // Textures
 	ROM_LOAD32_WORD("mpr-19254.27", 0x000000, 0x200000, CRC(1ec49c02) SHA1(a9bdbab7b4b265c9118cf27fd45ca94f4516d5c6) )
@@ -4744,6 +4753,9 @@ ROM_START( stcco ) /* Sega Touring Car Championship, Model 2C - Defaults to Japa
 	ROM_LOAD32_WORD("mpr-19252.21", 0x000002, 0x400000, CRC(68509993) SHA1(654d5cdf44e7e1e788b26593f418ce76a5c1165a) )
 	ROM_LOAD32_WORD("epr-19266.18", 0x800000, 0x080000, CRC(41464ee2) SHA1(afbbc0328bd36c34c69f0f54404dfd6a64036417) )
 	ROM_LOAD32_WORD("epr-19267.22", 0x800002, 0x080000, CRC(780f994d) SHA1(f134482ed0fcfc7b3eea39947da47081301a111a) )
+	ROM_COPY("polygons", 0x800000, 0x900000, 0x100000)
+	ROM_COPY("polygons", 0x800000, 0xa00000, 0x200000)
+	ROM_COPY("polygons", 0x800000, 0xc00000, 0x400000)
 
 	ROM_REGION( 0x1000000, "textures", 0 ) // Textures
 	ROM_LOAD32_WORD("mpr-19254.27", 0x000000, 0x200000, CRC(1ec49c02) SHA1(a9bdbab7b4b265c9118cf27fd45ca94f4516d5c6) )


### PR DESCRIPTION
Most Sega Model 2C-CRX games are now working with 3D graphics. Top Skater still doesn't display properly because it uses a secondary transformation matrix which is not implemented in the HLE geometry engine; proper emulation of the geometry DSP is required.