### PR TITLE
Add Mieyen and Mazy2 homebrew games to PV-1000 software list

### DIFF
--- a/hash/pv1000.xml
+++ b/hash/pv1000.xml
@@ -359,4 +359,26 @@ Undumped carts:
 		</part>
 	</software>
 
+	<software name="mieyen">
+		<description>Mieyen</description>
+		<year>2025</year>
+		<publisher>Inufuto</publisher>
+		<part name="cart" interface="pv1000_cart">
+			<dataarea name="rom" size = "0x4000">
+				<rom name="mieyen.rom" size="0x4000" crc="c5fbd695" sha1="96f41e9c5447f78b3003dd6a92088ea02d9ef7fe"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mazy2">
+		<description>Mazy2</description>
+		<year>2025</year>
+		<publisher>Inufuto</publisher>
+		<part name="cart" interface="pv1000_cart">
+			<dataarea name="rom" size = "0x4000">
+				<rom name="mazy2.rom" size="0x4000" crc="6e6f9694" sha1="c8c678aec84c181ca7f2dfa155fc211f51832e15"/>
+			</dataarea>
+		</part>
+	</software>	
+
 </softwarelist>


### PR DESCRIPTION
Inufuto has released two additional homebrew games since last addition. The new games are:

New working software list items
-------------------------------
pv1000: Mieyen, Mazy2 [inufuto]

This PR adds both games to Inufuto's 16 homebrew games already in the list. Both Mieyen and Mazy2 tested in a fresh MAME 0277 install + updated pv1000.xml file.

![Screenshot (16)](https://github.com/user-attachments/assets/ab34edf8-244a-4764-b1bc-59e3f4c6a15c)
![Screenshot (17)](https://github.com/user-attachments/assets/a105e65a-53fb-4d86-a427-bf75213cd6b1)

