### PR TITLE
demote to imperfectly sound whtm68k.cpp

### DIFF
--- a/src/mame/skeleton/whtm68k.cpp
+++ b/src/mame/skeleton/whtm68k.cpp
@@ -350,4 +350,4 @@ ROM_END
 } // anonymous namespace
 
 
-GAME( 1996, yizhix,  0, yizhix, yizhix,  whtm68k_state, empty_init, ROT0, "WHT", "Yizhi Xiangqi", MACHINE_NO_SOUND | MACHINE_NOT_WORKING ) // 1996 WHT copyright in GFX
+GAME( 1996, yizhix,  0, yizhix, yizhix,  whtm68k_state, empty_init, ROT0, "WHT", "Yizhi Xiangqi", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING ) // 1996 WHT copyright in GFX


### PR DESCRIPTION
since required rom banking at 8000-FFFF so demoted to imperfectly sound
Bank 1 music 1-4
at 8000-FFFF
Bank 2 music 1-3
at 10000-17FFF
Bank 3 music 1-3
at 18000-1FFFF
at dip switch 2 seem to be input?
sw2 3 left
sw2 4 right
sw2 5 bet
sw2 6 start
sw2 8 pay out