### PR TITLE
cpu/z80: Handled flags lazyly

### DIFF
--- a/src/devices/cpu/z80/r800.cpp
+++ b/src/devices/cpu/z80/r800.cpp
@@ -69,7 +69,7 @@ u8 r800_device::r800_sll(u8 value)
 {
 	const u8 c = (value & 0x80) ? CF : 0;
 	const u8 res = u8(value << 1);
-	set_f(SZP[res] | c);
+	set_f(SZYXP[res] | c);
 	return res;
 }
 

--- a/src/devices/cpu/z80/z80.h
+++ b/src/devices/cpu/z80/z80.h
@@ -191,11 +191,11 @@ protected:
 	u8 m_iorq_cycles;
 
 	static bool tables_initialised;
-	static u8 SZ[0x100];       // zero and sign flags
-	static u8 SZ_BIT[0x100];   // zero, sign and parity/overflow (=zero) flags for BIT opcode
-	static u8 SZP[0x100];      // zero, sign and parity flags
-	static u8 SZHV_inc[0x100]; // zero, sign, half carry and overflow flags INC r8
-	static u8 SZHV_dec[0x100]; // zero, sign, half carry and overflow flags DEC r8
+	static u8 SZYX[0x100];        // zero and sign flags
+	static u8 SZYXP_BIT[0x100];   // zero, sign and parity/overflow (=zero) flags for BIT opcode
+	static u8 SZYXP[0x100];       // zero, sign and parity flags
+	static u8 SZYHXPN_inc[0x100]; // zero, sign, half carry and overflow flags INC r8
+	static u8 SZYHXPN_dec[0x100]; // zero, sign, half carry and overflow flags DEC r8
 };
 
 DECLARE_DEVICE_TYPE(Z80, z80_device)

--- a/src/devices/cpu/z80/z80.h
+++ b/src/devices/cpu/z80/z80.h
@@ -77,7 +77,6 @@ protected:
 
 	void illegal_1();
 	void illegal_2();
-	u8 flags_szyxc(u16 value);
 	template <u8 Bit, bool State> void set_service_attention() { static_assert(Bit < 8, "out of range bit index"); if (State) m_service_attention |= (1 << Bit); else m_service_attention &= ~(1 << Bit); };
 	template <u8 Bit> bool get_service_attention() { static_assert(Bit < 8, "out of range bit index"); return m_service_attention & (1 << Bit); };
 
@@ -114,7 +113,6 @@ protected:
 	u8 res(int bit, u8 value);
 	u8 set(int bit, u8 value);
 	void ei();
-	void set_f(u8 f);
 	void block_io_interrupted_flags();
 
 	virtual u8 data_read(u16 addr);
@@ -163,12 +161,10 @@ protected:
 	PAIR16       m_bc2;
 	PAIR16       m_de2;
 	PAIR16       m_hl2;
-	u8           m_qtemp;
-	u8           m_q;
 	u8           m_r;
 	u8           m_r2;
-	u8           m_iff1;
-	u8           m_iff2;
+	bool         m_iff1;
+	bool         m_iff2;
 	u8           m_halt;
 	u8           m_im;
 	u8           m_i;
@@ -178,6 +174,25 @@ protected:
 	int          m_busrq_state;        // bus request pin state
 	u8           m_busack_state;       // bus acknowledge pin state
 	u16          m_ea;
+
+	struct
+	{
+		bool sign;
+		bool zero;
+		u8 yx;
+		bool half_carry;
+		bool parity_overflow;
+		bool subtract;
+		bool carry;
+
+		u8 q;
+		u8 qtemp;
+	} m_f;
+	u8 get_f(u8 flagsMask = 0xff);
+	void set_f(u8 f, u8  flagsMask = 0xff);
+	void set_0_f(u8  flagsMask = 0xff) { set_f(0x00, flagsMask); };
+	void set_1_f(u8 flagsMask = 0xff) { set_f(0xff, flagsMask); };
+	void set_f_szc(u16 value);
 
 	int          m_icount;
 	int          m_tmp_irq_vector;

--- a/src/devices/cpu/z80/z80.inc
+++ b/src/devices/cpu/z80/z80.inc
@@ -12,9 +12,8 @@
 #define NF      0x02
 #define PF      0x04
 #define VF      PF
-#define XF      0x08
 #define HF      0x10
-#define YF      0x20
+#define YXF     0x28
 #define ZF      0x40
 #define SF      0x80
 
@@ -26,11 +25,9 @@
 
 #define SP      m_sp.w
 
-#define AF      m_af.w
 #define A       m_af.b.h
-#define F       m_af.b.l
-#define Q       m_q
-#define QT      m_qtemp
+#define Q       m_f.q
+#define QT      m_f.qtemp
 #define I       m_i
 #define R       m_r
 #define R2      m_r2

--- a/src/devices/cpu/z80/z80.lst
+++ b/src/devices/cpu/z80/z80.lst
@@ -219,13 +219,13 @@ macro   r800:ld_r_a
 macro   ld_a_r
 	@nomreq_ir 1
 	A = (m_r & 0x7f) | m_r2;
-	set_f((F & CF) | SZ[A] | (m_iff2 << 2));
+	set_f((F & CF) | SZYX[A] | (m_iff2 << 2));
 	if (HAS_LDAIR_QUIRK)
 		set_service_attention<SA_AFTER_LDAIR, 1>();
 
 macro   r800:ld_a_r
 	A = (m_r & 0x7f) | m_r2;
-	set_f((F & CF) | SZ[A] | (m_iff2 << 2));
+	set_f((F & CF) | SZYX[A] | (m_iff2 << 2));
 	if (HAS_LDAIR_QUIRK)
 		set_service_attention<SA_AFTER_LDAIR, 1>();
 
@@ -239,13 +239,13 @@ macro   r800:ld_i_a
 macro   ld_a_i
 	@nomreq_ir 1
 	A = m_i;
-	set_f((F & CF) | SZ[A] | (m_iff2 << 2));
+	set_f((F & CF) | SZYX[A] | (m_iff2 << 2));
 	if (HAS_LDAIR_QUIRK)
 		set_service_attention<SA_AFTER_LDAIR, 1>();
 
 macro   r800:ld_a_i
 	A = m_i;
-	set_f((F & CF) | SZ[A] | (m_iff2 << 2));
+	set_f((F & CF) | SZYX[A] | (m_iff2 << 2));
 	if (HAS_LDAIR_QUIRK)
 		set_service_attention<SA_AFTER_LDAIR, 1>();
 
@@ -262,7 +262,7 @@ macro   rrd
 	TDAT8 = (TDAT8 >> 4) | (A << 4);
 	@wm HL
 	A = (A & 0xf0) | (TDAT_H & 0x0f);
-	set_f((F & CF) | SZP[A]);
+	set_f((F & CF) | SZYXP[A]);
 
 macro   rld
 	@rm HL
@@ -272,7 +272,7 @@ macro   rld
 	TDAT8 = (TDAT8 << 4) | (A & 0x0f);
 	@wm HL
 	A = (A & 0xf0) | (TDAT_H >> 4);
-	set_f((F & CF) | SZP[A]);
+	set_f((F & CF) | SZYXP[A]);
 
 macro   ex_sp   %dd
 	@pop
@@ -371,7 +371,7 @@ macro   cpi
 	WZ++;
 	HL++;
 	BC--;
-	set_f((F & CF) | (SZ[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF);
+	set_f((F & CF) | (SZYX[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF);
 	if (F & HF)
 		res -= 1;
 	if (res & 0x02)
@@ -390,7 +390,7 @@ macro   r800:cpi
 	WZ++;
 	HL++;
 	BC--;
-	set_f((F & CF) | (SZ[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF);
+	set_f((F & CF) | (SZYX[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF);
 	if (F & HF)
 		res -= 1;
 	if (res & 0x02)
@@ -409,13 +409,13 @@ macro   ini
 	B--;
 	@wm HL
 	HL++;
-	set_f(SZ[B]);
+	set_f(SZYX[B]);
 	unsigned t = (unsigned)((C + 1) & 0xff) + (unsigned)TDAT8;
 	if (TDAT8 & SF)
 		F |= NF;
 	if (t & 0x100)
 		F |= HF | CF;
-	F |= SZP[(u8)(t & 0x07) ^ B] & PF;
+	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
 }
 
 macro   r800:ini
@@ -425,13 +425,13 @@ macro   r800:ini
 	B--;
 	@wm HL
 	HL++;
-	set_f(SZ[B]);
+	set_f(SZYX[B]);
 	unsigned t = (unsigned)((C + 1) & 0xff) + (unsigned)TDAT8;
 	if (TDAT8 & SF)
 		F |= NF;
 	if (t & 0x100)
 		F |= HF | CF;
-	F |= SZP[(u8)(t & 0x07) ^ B] & PF;
+	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
 }
 
 macro   outi
@@ -442,13 +442,13 @@ macro   outi
 	WZ = BC + 1;
 	@out BC
 	HL++;
-	set_f(SZ[B]);
+	set_f(SZYX[B]);
 	unsigned t = (unsigned)L + (unsigned)TDAT8;
 	if (TDAT8 & SF)
 		F |= NF;
 	if (t & 0x100)
 		F |= HF | CF;
-	F |= SZP[(u8)(t & 0x07) ^ B] & PF;
+	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
 }
 
 macro   r800:outi
@@ -458,13 +458,13 @@ macro   r800:outi
 	WZ = BC + 1;
 	@out BC
 	HL++;
-	set_f(SZ[B]);
+	set_f(SZYX[B]);
 	unsigned t = (unsigned)L + (unsigned)TDAT8;
 	if (TDAT8 & SF)
 		F |= NF;
 	if (t & 0x100)
 		F |= HF | CF;
-	F |= SZP[(u8)(t & 0x07) ^ B] & PF;
+	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
 }
 
 macro   ldd
@@ -509,7 +509,7 @@ macro   cpd
 	WZ--;
 	HL--;
 	BC--;
-	set_f((F & CF) | (SZ[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF);
+	set_f((F & CF) | (SZYX[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF);
 	if (F & HF)
 		res -= 1;
 	if (res & 0x02)
@@ -528,7 +528,7 @@ macro   r800:cpd
 	WZ--;
 	HL--;
 	BC--;
-	set_f((F & CF) | (SZ[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF);
+	set_f((F & CF) | (SZYX[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF);
 	if (F & HF)
 		res -= 1;
 	if (res & 0x02)
@@ -547,13 +547,13 @@ macro   ind
 	B--;
 	@wm HL
 	HL--;
-	set_f(SZ[B]);
+	set_f(SZYX[B]);
 	unsigned t = ((unsigned)(C - 1) & 0xff) + (unsigned)TDAT8;
 	if (TDAT8 & SF)
 		F |= NF;
 	if (t & 0x100)
 		F |= HF | CF;
-	F |= SZP[(u8)(t & 0x07) ^ B] & PF;
+	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
 }
 
 macro   r800:ind
@@ -563,13 +563,13 @@ macro   r800:ind
 	B--;
 	@wm HL
 	HL--;
-	set_f(SZ[B]);
+	set_f(SZYX[B]);
 	unsigned t = ((unsigned)(C - 1) & 0xff) + (unsigned)TDAT8;
 	if (TDAT8 & SF)
 		F |= NF;
 	if (t & 0x100)
 		F |= HF | CF;
-	F |= SZP[(u8)(t & 0x07) ^ B] & PF;
+	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
 }
 
 macro   outd
@@ -580,13 +580,13 @@ macro   outd
 	WZ = BC - 1;
 	@out BC
 	HL--;
-	set_f(SZ[B]);
+	set_f(SZYX[B]);
 	unsigned t = (unsigned)L + (unsigned)TDAT8;
 	if (TDAT8 & SF)
 		F |= NF;
 	if (t & 0x100)
 		F |= HF | CF;
-	F |= SZP[(u8)(t & 0x07) ^ B] & PF;
+	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
 }
 
 macro   r800:outd
@@ -596,13 +596,13 @@ macro   r800:outd
 	WZ = BC - 1;
 	@out BC
 	HL--;
-	set_f(SZ[B]);
+	set_f(SZYX[B]);
 	unsigned t = (unsigned)L + (unsigned)TDAT8;
 	if (TDAT8 & SF)
 		F |= NF;
 	if (t & 0x100)
 		F |= HF | CF;
-	F |= SZP[(u8)(t & 0x07) ^ B] & PF;
+	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
 }
 
 macro   ldir
@@ -5388,7 +5388,7 @@ ed3f	# DB   ED
 ed40	# IN   B,(C)
 	@in BC
 	B = TDAT8;
-	set_f((F & CF) | SZP[B]);
+	set_f((F & CF) | SZYXP[B]);
 	WZ = BC + 1;
 
 ed41	# OUT  (C),B
@@ -5421,7 +5421,7 @@ ed47	# LD   i,A
 ed48	# IN   C,(C)
 	@in BC
 	C = TDAT8;
-	set_f((F & CF) | SZP[C]);
+	set_f((F & CF) | SZYXP[C]);
 	WZ = BC + 1;
 
 ed49	# OUT  (C),C
@@ -5454,7 +5454,7 @@ ed4f	# LD   r,A
 ed50	# IN   D,(C)
 	@in BC
 	D = TDAT8;
-	set_f((F & CF) | SZP[D]);
+	set_f((F & CF) | SZYXP[D]);
 	WZ = BC + 1;
 
 ed51	# OUT  (C),D
@@ -5487,7 +5487,7 @@ ed57	# LD   A,i
 ed58	# IN   E,(C)
 	@in BC
 	E = TDAT8;
-	set_f((F & CF) | SZP[E]);
+	set_f((F & CF) | SZYXP[E]);
 	WZ = BC + 1;
 
 ed59	# OUT  (C),E
@@ -5520,7 +5520,7 @@ ed5f	# LD   A,r
 ed60	# IN   H,(C)
 	@in BC
 	H = TDAT8;
-	set_f((F & CF) | SZP[H]);
+	set_f((F & CF) | SZYXP[H]);
 	WZ = BC + 1;
 
 ed61	# OUT  (C),H
@@ -5553,7 +5553,7 @@ ed67	# RRD  (HL)
 ed68	# IN   L,(C)
 	@in BC
 	L = TDAT8;
-	set_f((F & CF) | SZP[L]);
+	set_f((F & CF) | SZYXP[L]);
 	WZ = BC + 1;
 
 ed69	# OUT  (C),L
@@ -5585,7 +5585,7 @@ ed6f	# RLD  (HL)
 
 ed70	# IN   0,(C)
 	@in BC
-	set_f((F & CF) | SZP[TDAT8]);
+	set_f((F & CF) | SZYXP[TDAT8]);
 	WZ = BC + 1;
 
 ed71	# OUT  (C),0
@@ -5618,7 +5618,7 @@ ed77	# DB   ED,77
 ed78	# IN   A,(C)
 	@in BC
 	A = TDAT8;
-	set_f((F & CF) | SZP[A]);
+	set_f((F & CF) | SZYXP[A]);
 	WZ = BC + 1;
 
 ed79	# OUT  (C),A

--- a/src/devices/cpu/z80/z80.lst
+++ b/src/devices/cpu/z80/z80.lst
@@ -35,11 +35,14 @@ macro   wm16   %addr
 	m_memrq_cycles !! data_write(%addr, TDAT_L);
 	m_memrq_cycles !! data_write(%addr+1, TDAT_H);
 
-macro   wm16_sp %d16
+macro   wm_sp %d
 	SP--;
-	m_memrq_cycles !! stack_write(SP, (%d16) >> 8);
-	SP--;
-	m_memrq_cycles !! stack_write(SP, %d16);
+	m_memrq_cycles !! stack_write(SP, %d);
+
+
+macro   wm16_sp %dd
+	@wm_sp %dd >> 8
+	@wm_sp %dd
 
 macro   rop
 	m_m1_cycles-2 !! TDAT8 = opcode_read();
@@ -49,14 +52,14 @@ macro   rop
 	PC++;
 	R++;
 	Q = QT;
-	QT = YF | XF;
+	QT = YXF;
 
 macro   r800:rop
 	m_m1_cycles !! TDAT8 = opcode_read();
 	PC++;
 	R++;
 	Q = QT;
-	QT = YF | XF;
+	QT = YXF;
 
 macro   arg
 	m_memrq_cycles !! TDAT8 = arg_read();
@@ -98,8 +101,8 @@ macro   t6a84:jp
 	WZ = PC;
 	paged_jump();
 
-macro   jp_cond
-	if (TDAT8) {
+macro   jp_cond   %cond
+	if (%cond) {
 		@arg16 PC
 		WZ = PC;
 	} else {
@@ -107,8 +110,8 @@ macro   jp_cond
 		@arg16 WZ
 	}
 
-macro   t6a84:jp_cond
-	if (TDAT8) {
+macro   t6a84:jp_cond   %cond
+	if (%cond) {
 		@arg16 PC
 		WZ = PC;
 		paged_jump();
@@ -136,8 +139,8 @@ macro   r800:jr
 	PC += (s8)TDAT8;
 	WZ = PC;
 
-macro   jr_cond
-	if (TDAT8) {
+macro   jr_cond   %cond
+	if (%cond) {
 		@jr
 	} else {
 		@arg
@@ -157,16 +160,16 @@ macro   r800:arg16_call
 	@wm16_sp PC
 	PC = m_ea;
 
-macro   call_cond
-	if (TDAT8) {
+macro   call_cond   %cond
+	if (%cond) {
 		@arg16_call
 	} else {
 		@arg16 WZ
 	}
 
-macro   ret_cond
+macro   ret_cond   %cond
 	@nomreq_ir 1
-	if (TDAT8) {
+	if (%cond) {
 		@pop
 		PC = TDAT;
 		WZ = PC;
@@ -219,13 +222,23 @@ macro   r800:ld_r_a
 macro   ld_a_r
 	@nomreq_ir 1
 	A = (m_r & 0x7f) | m_r2;
-	set_f((F & CF) | SZYX[A] | (m_iff2 << 2));
+	{
+		// keep C
+		set_f(SZYX[A], SF | ZF | YXF);
+		set_0_f(HF | NF);
+		m_f.parity_overflow = m_iff2;
+	}
 	if (HAS_LDAIR_QUIRK)
 		set_service_attention<SA_AFTER_LDAIR, 1>();
 
 macro   r800:ld_a_r
 	A = (m_r & 0x7f) | m_r2;
-	set_f((F & CF) | SZYX[A] | (m_iff2 << 2));
+	{
+		// keep C
+		set_f(SZYX[A], SF | ZF | YXF);
+		set_0_f(HF | NF);
+		m_f.parity_overflow = m_iff2;
+	}
 	if (HAS_LDAIR_QUIRK)
 		set_service_attention<SA_AFTER_LDAIR, 1>();
 
@@ -239,13 +252,23 @@ macro   r800:ld_i_a
 macro   ld_a_i
 	@nomreq_ir 1
 	A = m_i;
-	set_f((F & CF) | SZYX[A] | (m_iff2 << 2));
+	{
+		// keep C
+		set_f(SZYX[A], SF | ZF | YXF);
+		set_0_f(HF | NF);
+		m_f.parity_overflow = m_iff2;
+	}
 	if (HAS_LDAIR_QUIRK)
 		set_service_attention<SA_AFTER_LDAIR, 1>();
 
 macro   r800:ld_a_i
 	A = m_i;
-	set_f((F & CF) | SZYX[A] | (m_iff2 << 2));
+	{
+		// keep C
+		set_f(SZYX[A], SF | ZF | YXF);
+		set_0_f(HF | NF);
+		m_f.parity_overflow = m_iff2;
+	}
 	if (HAS_LDAIR_QUIRK)
 		set_service_attention<SA_AFTER_LDAIR, 1>();
 
@@ -262,7 +285,11 @@ macro   rrd
 	TDAT8 = (TDAT8 >> 4) | (A << 4);
 	@wm HL
 	A = (A & 0xf0) | (TDAT_H & 0x0f);
-	set_f((F & CF) | SZYXP[A]);
+	{
+		// keep C
+		set_f(SZYXP[A], SF | ZF | YXF | PF);
+		set_0_f(HF | NF);
+	}
 
 macro   rld
 	@rm HL
@@ -272,7 +299,11 @@ macro   rld
 	TDAT8 = (TDAT8 << 4) | (A & 0x0f);
 	@wm HL
 	A = (A & 0xf0) | (TDAT_H >> 4);
-	set_f((F & CF) | SZYXP[A]);
+	{
+		// keep C
+		set_f(SZYXP[A], SF | ZF | YXF | PF);
+		set_0_f(HF | NF);
+	}
 
 macro   ex_sp   %dd
 	@pop
@@ -285,51 +316,101 @@ macro   ex_sp   %dd
 macro   add16   %dd1 %dd2
 {
 	@nomreq_ir 7
-	u32 res = %dd1 + %dd2;
+	const u32 res = %dd1 + %dd2;
 	WZ = %dd1 + 1;
-	set_f((F & (SF | ZF | VF)) | (((%dd1 ^ res ^ %dd2) >> 8) & HF) | ((res >> 16) & CF) | ((res >> 8) & (YF | XF)));
+	{
+		QT = 0;
+		// keep szv
+		m_f.yx = res >> 8;
+		m_f.half_carry = ((%dd1 ^ res ^ %dd2) >> 8) & HF;
+		m_f.subtract = 0;
+		m_f.carry = res & 0x10000;
+	}
 	%dd1 = (u16)res;
 }
 
 macro   r800:add16   %dd1 %dd2
 {
-	u32 res = %dd1 + %dd2;
+	const u32 res = %dd1 + %dd2;
 	WZ = %dd1 + 1;
-	set_f((F & (SF | ZF | VF)) | (((%dd1 ^ res ^ %dd2) >> 8) & HF) | ((res >> 16) & CF) | ((res >> 8) & (YF | XF)));
+	{
+		QT = 0;
+		// keep szv
+		m_f.yx = res >> 8;
+		m_f.half_carry = ((%dd1 ^ res ^ %dd2) >> 8) & HF;
+		m_f.subtract = 0;
+		m_f.carry = res & 0x10000;
+	}
 	%dd1 = (u16)res;
 }
 
-macro   adc_hl
+macro   adc_hl   %dd
 {
 	@nomreq_ir 7
-	u32 res = HL + TDAT + (F & CF);
+	const u32 res = HL + %dd + m_f.carry;
 	WZ = HL + 1;
-	set_f((((HL ^ res ^ TDAT) >> 8) & HF) | ((res >> 16) & CF) | ((res >> 8) & (SF | YF | XF)) | ((res & 0xffff) ? 0 : ZF) | (((TDAT ^ HL ^ 0x8000) & (TDAT ^ res) & 0x8000) >> 13));
+	{
+		QT = 0;
+		m_f.sign = res & 0x8000;
+		m_f.zero = u16(res) == 0;
+		m_f.yx = res >> 8;
+		m_f.half_carry = ((HL ^ res ^ %dd) >> 8) & HF;
+		m_f.parity_overflow = (%dd ^ HL ^ 0x8000) & (%dd ^ res) & 0x8000;
+		m_f.subtract = 0;
+		m_f.carry = res & 0x10000;
+	}
 	HL = (u16)res;
 }
 
-macro   r800:adc_hl
+macro   r800:adc_hl   %dd
 {
-	u32 res = HL + TDAT + (F & CF);
+	u32 res = HL + %dd + m_f.carry;
 	WZ = HL + 1;
-	set_f((((HL ^ res ^ TDAT) >> 8) & HF) | ((res >> 16) & CF) | ((res >> 8) & (SF | YF | XF)) | ((res & 0xffff) ? 0 : ZF) | (((TDAT ^ HL ^ 0x8000) & (TDAT ^ res) & 0x8000) >> 13));
+	{
+		QT = 0;
+		m_f.sign = res & 0x8000;
+		m_f.zero = u16(res) == 0;
+		m_f.yx = res >> 8;
+		m_f.half_carry = ((HL ^ res ^ %dd) >> 8) & HF;
+		m_f.parity_overflow = (%dd ^ HL ^ 0x8000) & (%dd ^ res) & 0x8000;
+		m_f.subtract = 0;
+		m_f.carry = res & 0x10000;
+	}
 	HL = (u16)res;
 }
 
-macro   sbc_hl
+macro   sbc_hl   %dd
 {
 	@nomreq_ir 7
-	u32 res = HL - TDAT - (F & CF);
+	u32 res = HL - %dd - m_f.carry;
 	WZ = HL + 1;
-	set_f((((HL ^ res ^ TDAT) >> 8) & HF) | NF | ((res >> 16) & CF) | ((res >> 8) & (SF | YF | XF)) | ((res & 0xffff) ? 0 : ZF) | (((TDAT ^ HL) & (HL ^ res) & 0x8000) >> 13));
+	{
+		QT = 0;
+		m_f.sign = res & 0x8000;
+		m_f.zero = u16(res) == 0;
+		m_f.yx = res >> 8;
+		m_f.half_carry = ((HL ^ res ^ %dd) >> 8) & HF;
+		m_f.parity_overflow = (%dd ^ HL) & (HL ^ res) & 0x8000;
+		m_f.subtract = 1;
+		m_f.carry = res & 0x10000;
+	}
 	HL = (u16)res;
 }
 
-macro   r800:sbc_hl
+macro   r800:sbc_hl   %dd
 {
-	u32 res = HL - TDAT - (F & CF);
+	u32 res = HL - %dd - m_f.carry;
 	WZ = HL + 1;
-	set_f((((HL ^ res ^ TDAT) >> 8) & HF) | NF | ((res >> 16) & CF) | ((res >> 8) & (SF | YF | XF)) | ((res & 0xffff) ? 0 : ZF) | (((TDAT ^ HL) & (HL ^ res) & 0x8000) >> 13));
+	{
+		QT = 0;
+		m_f.sign = res & 0x8000;
+		m_f.zero = u16(res) == 0;
+		m_f.yx = res >> 8;
+		m_f.half_carry = ((HL ^ res ^ %dd) >> 8) & HF;
+		m_f.parity_overflow = (%dd ^ HL) & (HL ^ res) & 0x8000;
+		m_f.subtract = 1;
+		m_f.carry = res & 0x10000;
+	}
 	HL = (u16)res;
 }
 
@@ -337,68 +418,72 @@ macro   ldi
 	@rm HL
 	@wm DE
 	2 * @nomreq_addr DE
-	set_f(F & (SF | ZF | CF));
-	if ((A + TDAT8) & 0x02)
-		F |= YF;
-	if ((A + TDAT8) & 0x08)
-		F |= XF;
 	HL++;
 	DE++;
 	BC--;
-	if (BC)
-		F |= VF;
+	{
+		// keep SZC
+		m_f.yx = ((A + TDAT8) << 4) | ((A + TDAT8) & 0x0f);
+		set_0_f(HF | NF);
+		m_f.parity_overflow = BC;
+	}
 
 macro   r800:ldi
 	@rm HL
 	@wm DE
 	@nomreq_addr DE
-	set_f(F & (SF | ZF | CF));
-	if ((A + TDAT8) & 0x02)
-		F |= YF;
-	if ((A + TDAT8) & 0x08)
-		F |= XF;
 	HL++;
 	DE++;
 	BC--;
-	if (BC)
-		F |= VF;
+	{
+		// keep SZC
+		m_f.yx = ((A + TDAT8) << 4) | ((A + TDAT8) & 0x0f);
+		set_0_f(HF | NF);
+		m_f.parity_overflow = BC;
+	}
 
 macro   cpi
 {
 	@rm HL
 	5 * @nomreq_addr HL
-	u8 res = A - TDAT8;
 	WZ++;
 	HL++;
 	BC--;
-	set_f((F & CF) | (SZYX[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF);
-	if (F & HF)
-		res -= 1;
-	if (res & 0x02)
-		F |= YF;
-	if (res & 0x08)
-		F |= XF;
-	if (BC)
-		F |= VF;
+	u8 res = A - TDAT8;
+	{
+		QT = 0;
+		// keep C
+		m_f.sign = res & SF;
+		m_f.zero = res == 0;
+		m_f.half_carry = (A ^ TDAT8 ^ res) & HF;
+		if (m_f.half_carry)
+			res -= 1;
+		m_f.yx = (res << 4) | (res & 0x0f);
+		m_f.parity_overflow = BC;
+		m_f.subtract = 1;
+	}
 }
 
 macro   r800:cpi
 {
 	@rm HL
 	@nomreq_addr HL
-	u8 res = A - TDAT8;
 	WZ++;
 	HL++;
 	BC--;
-	set_f((F & CF) | (SZYX[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF);
-	if (F & HF)
-		res -= 1;
-	if (res & 0x02)
-		F |= YF;
-	if (res & 0x08)
-		F |= XF;
-	if (BC)
-		F |= VF;
+	u8 res = A - TDAT8;
+	{
+		QT = 0;
+		// keep C
+		m_f.sign = res & SF;
+		m_f.zero = res == 0;
+		m_f.half_carry = (A ^ TDAT8 ^ res) & HF;
+		if (m_f.half_carry)
+			res -= 1;
+		m_f.yx = (res << 4) | (res & 0x0f);
+		m_f.parity_overflow = BC;
+		m_f.subtract = 1;
+	}
 }
 
 macro   ini
@@ -409,13 +494,14 @@ macro   ini
 	B--;
 	@wm HL
 	HL++;
-	set_f(SZYX[B]);
-	unsigned t = (unsigned)((C + 1) & 0xff) + (unsigned)TDAT8;
-	if (TDAT8 & SF)
-		F |= NF;
-	if (t & 0x100)
-		F |= HF | CF;
-	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
+	const u16 t = ((C + 1) & 0xff) + TDAT8;
+	{
+		set_f(SZYX[B], SF | ZF | YXF);
+		m_f.half_carry = t & 0x100;
+		m_f.parity_overflow = SZYXP[(u8)(t & 0x07) ^ B] & PF;
+		m_f.subtract = TDAT8 & SF;
+		m_f.carry = t & 0x100;
+	}
 }
 
 macro   r800:ini
@@ -425,13 +511,14 @@ macro   r800:ini
 	B--;
 	@wm HL
 	HL++;
-	set_f(SZYX[B]);
-	unsigned t = (unsigned)((C + 1) & 0xff) + (unsigned)TDAT8;
-	if (TDAT8 & SF)
-		F |= NF;
-	if (t & 0x100)
-		F |= HF | CF;
-	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
+	const u16 t = ((C + 1) & 0xff) + TDAT8;
+	{
+		set_f(SZYX[B], SF | ZF | YXF);
+		m_f.half_carry = t & 0x100;
+		m_f.parity_overflow = SZYXP[(u8)(t & 0x07) ^ B] & PF;
+		m_f.subtract = TDAT8 & SF;
+		m_f.carry = t & 0x100;
+	}
 }
 
 macro   outi
@@ -442,13 +529,14 @@ macro   outi
 	WZ = BC + 1;
 	@out BC
 	HL++;
-	set_f(SZYX[B]);
-	unsigned t = (unsigned)L + (unsigned)TDAT8;
-	if (TDAT8 & SF)
-		F |= NF;
-	if (t & 0x100)
-		F |= HF | CF;
-	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
+	const u16 t = L + TDAT8;
+	{
+		set_f(SZYX[B], SF | ZF | YXF);
+		m_f.half_carry = t & 0x100;
+		m_f.parity_overflow = SZYXP[(u8)(t & 0x07) ^ B] & PF;
+		m_f.subtract = TDAT8 & SF;
+		m_f.carry = t & 0x100;
+	}
 }
 
 macro   r800:outi
@@ -458,13 +546,14 @@ macro   r800:outi
 	WZ = BC + 1;
 	@out BC
 	HL++;
-	set_f(SZYX[B]);
-	unsigned t = (unsigned)L + (unsigned)TDAT8;
-	if (TDAT8 & SF)
-		F |= NF;
-	if (t & 0x100)
-		F |= HF | CF;
-	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
+	const u16 t = L + TDAT8;
+	{
+		set_f(SZYX[B], SF | ZF | YXF);
+		m_f.half_carry = t & 0x100;
+		m_f.parity_overflow = SZYXP[(u8)(t & 0x07) ^ B] & PF;
+		m_f.subtract = TDAT8 & SF;
+		m_f.carry = t & 0x100;
+	}
 }
 
 macro   ldd
@@ -472,16 +561,15 @@ macro   ldd
 	@rm HL
 	@wm DE
 	2 * @nomreq_addr DE
-	set_f(F & (SF | ZF | CF));
-	if ((A + TDAT8) & 0x02)
-		F |= YF;
-	if ((A + TDAT8) & 0x08)
-		F |= XF;
 	HL--;
 	DE--;
 	BC--;
-	if (BC)
-		F |= VF;
+	{
+		// keep SZC
+		m_f.yx = ((A + TDAT8) << 4) | ((A + TDAT8) & 0x0f);
+		set_0_f(HF | NF);
+		m_f.parity_overflow = BC;
+	}
 }
 
 macro   r800:ldd
@@ -489,54 +577,59 @@ macro   r800:ldd
 	@rm HL
 	@wm DE
 	@nomreq_addr DE
-	set_f(F & (SF | ZF | CF));
-	if ((A + TDAT8) & 0x02)
-		F |= YF;
-	if ((A + TDAT8) & 0x08)
-		F |= XF;
 	HL--;
 	DE--;
 	BC--;
-	if (BC)
-		F |= VF;
+	{
+		// keep SZC
+		m_f.yx = ((A + TDAT8) << 4) | ((A + TDAT8) & 0x0f);
+		set_0_f(HF | NF);
+		m_f.parity_overflow = BC;
+	}
 }
 
 macro   cpd
 {
 	@rm HL
 	5 * @nomreq_addr HL
-	u8 res = A - TDAT8;
 	WZ--;
 	HL--;
 	BC--;
-	set_f((F & CF) | (SZYX[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF);
-	if (F & HF)
-		res -= 1;
-	if (res & 0x02)
-		F |= YF;
-	if (res & 0x08)
-		F |= XF;
-	if (BC)
-		F |= VF;
+	u8 res = A - TDAT8;
+	{
+		QT = 0;
+		// keep C
+		m_f.sign = res & SF;
+		m_f.zero = res == 0;
+		m_f.half_carry = (A ^ TDAT8 ^ res) & HF;
+		if (m_f.half_carry)
+			res -= 1;
+		m_f.yx = (res << 4) | (res & 0x0f);
+		m_f.parity_overflow = BC;
+		m_f.subtract = 1;
+	}
 }
 
 macro   r800:cpd
 {
 	@rm HL
 	@nomreq_addr HL
-	u8 res = A - TDAT8;
 	WZ--;
 	HL--;
 	BC--;
-	set_f((F & CF) | (SZYX[res]&~(YF|XF)) | ((A^TDAT8^res)&HF) | NF);
-	if (F & HF)
-		res -= 1;
-	if (res & 0x02)
-		F |= YF;
-	if (res & 0x08)
-		F |= XF;
-	if (BC)
-		F |= VF;
+	u8 res = A - TDAT8;
+	{
+		QT = 0;
+		// keep C
+		m_f.sign = res & SF;
+		m_f.zero = res == 0;
+		m_f.half_carry = (A ^ TDAT8 ^ res) & HF;
+		if (m_f.half_carry)
+			res -= 1;
+		m_f.yx = (res << 4) | (res & 0x0f);
+		m_f.parity_overflow = BC;
+		m_f.subtract = 1;
+	}
 }
 
 macro   ind
@@ -547,13 +640,14 @@ macro   ind
 	B--;
 	@wm HL
 	HL--;
-	set_f(SZYX[B]);
-	unsigned t = ((unsigned)(C - 1) & 0xff) + (unsigned)TDAT8;
-	if (TDAT8 & SF)
-		F |= NF;
-	if (t & 0x100)
-		F |= HF | CF;
-	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
+	const u16 t = ((C - 1) & 0xff) + TDAT8;
+	{
+		set_f(SZYX[B], SF | ZF | YXF);
+		m_f.half_carry = t & 0x100;
+		m_f.parity_overflow = SZYXP[(u8)(t & 0x07) ^ B] & PF;
+		m_f.subtract = TDAT8 & SF;
+		m_f.carry = t & 0x100;
+	}
 }
 
 macro   r800:ind
@@ -563,13 +657,14 @@ macro   r800:ind
 	B--;
 	@wm HL
 	HL--;
-	set_f(SZYX[B]);
-	unsigned t = ((unsigned)(C - 1) & 0xff) + (unsigned)TDAT8;
-	if (TDAT8 & SF)
-		F |= NF;
-	if (t & 0x100)
-		F |= HF | CF;
-	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
+	const u16 t = ((C - 1) & 0xff) + TDAT8;
+	{
+		set_f(SZYX[B], SF | ZF | YXF);
+		m_f.half_carry = t & 0x100;
+		m_f.parity_overflow = SZYXP[(u8)(t & 0x07) ^ B] & PF;
+		m_f.subtract = TDAT8 & SF;
+		m_f.carry = t & 0x100;
+	}
 }
 
 macro   outd
@@ -580,13 +675,14 @@ macro   outd
 	WZ = BC - 1;
 	@out BC
 	HL--;
-	set_f(SZYX[B]);
-	unsigned t = (unsigned)L + (unsigned)TDAT8;
-	if (TDAT8 & SF)
-		F |= NF;
-	if (t & 0x100)
-		F |= HF | CF;
-	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
+	const u16 t = L + TDAT8;
+	{
+		set_f(SZYX[B], SF | ZF | YXF);
+		m_f.half_carry = t & 0x100;
+		m_f.parity_overflow = SZYXP[(u8)(t & 0x07) ^ B] & PF;
+		m_f.subtract = TDAT8 & SF;
+		m_f.carry = t & 0x100;
+	}
 }
 
 macro   r800:outd
@@ -596,13 +692,14 @@ macro   r800:outd
 	WZ = BC - 1;
 	@out BC
 	HL--;
-	set_f(SZYX[B]);
-	unsigned t = (unsigned)L + (unsigned)TDAT8;
-	if (TDAT8 & SF)
-		F |= NF;
-	if (t & 0x100)
-		F |= HF | CF;
-	F |= SZYXP[(u8)(t & 0x07) ^ B] & PF;
+	const u16 t = L + TDAT8;
+	{
+		set_f(SZYX[B], SF | ZF | YXF);
+		m_f.half_carry = t & 0x100;
+		m_f.parity_overflow = SZYXP[(u8)(t & 0x07) ^ B] & PF;
+		m_f.subtract = TDAT8 & SF;
+		m_f.carry = t & 0x100;
+	}
 }
 
 macro   ldir
@@ -611,8 +708,7 @@ macro   ldir
 		5 * @nomreq_addr DE
 		PC -= 2;
 		WZ = PC + 1;
-		F &= ~(YF | XF);
-		F |= (PC >> 8) & (YF | XF);
+		m_f.yx = PC >> 8;
 	}
 
 macro   r800:ldir
@@ -621,28 +717,25 @@ macro   r800:ldir
 		@nomreq_addr DE
 		PC -= 2;
 		WZ = PC + 1;
-		F &= ~(YF | XF);
-		F |= (PC >> 8) & (YF | XF);
+		m_f.yx = PC >> 8;
 	}
 
 macro   cpir
 	@cpi
-	if (BC != 0 && !(F & ZF)) {
+	if (BC != 0 && !m_f.zero) {
 		5 * @nomreq_addr HL
 		PC -= 2;
 		WZ = PC + 1;
-		F &= ~(YF | XF);
-		F |= (PC >> 8) & (YF | XF);
+		m_f.yx = PC >> 8;
 	}
 
 macro   r800:cpir
 	@cpi
 	@nomreq_addr HL
-	if (BC != 0 && !(F & ZF)) {
+	if (BC != 0 && !m_f.zero) {
 		PC -= 2;
 		WZ = PC + 1;
-		F &= ~(YF | XF);
-		F |= (PC >> 8) & (YF | XF);
+		m_f.yx = PC >> 8;
 	}
 
 macro   inir
@@ -690,8 +783,7 @@ macro   lddr
 		5 * @nomreq_addr DE
 		PC -= 2;
 		WZ = PC + 1;
-		F &= ~(YF | XF);
-		F |= (PC >> 8) & (YF | XF);
+		m_f.yx = PC >> 8;
 	}
 
 macro   r800:lddr
@@ -700,28 +792,25 @@ macro   r800:lddr
 		@nomreq_addr DE
 		PC -= 2;
 		WZ = PC + 1;
-		F &= ~(YF | XF);
-		F |= (PC >> 8) & (YF | XF);
+		m_f.yx = PC >> 8;
 	}
 
 macro   cpdr
 	@cpd
-	if (BC != 0 && !(F & ZF)) {
+	if (BC != 0 && !m_f.zero) {
 		5 * @nomreq_addr HL
 		PC -= 2;
 		WZ = PC + 1;
-		F &= ~(YF | XF);
-		F |= (PC >> 8) & (YF | XF);
+		m_f.yx = PC >> 8;
 	}
 
 macro   r800:cpdr
 	@cpd
 	@nomreq_addr HL /* suspected wrong. must be inside if? */
-	if (BC != 0 && !(F & ZF)) {
+	if (BC != 0 && !m_f.zero) {
 		PC -= 2;
 		WZ = PC + 1;
-		F &= ~(YF | XF);
-		F |= (PC >> 8) & (YF | XF);
+		m_f.yx = PC >> 8;
 	}
 
 macro   indr
@@ -775,7 +864,7 @@ macro   take_nmi
 	leave_halt();
 	if (HAS_LDAIR_QUIRK)
 		// reset parity flag after LD A,I or LD A,R
-		if (get_service_attention<SA_AFTER_LDAIR>()) F &= ~PF;
+		if (get_service_attention<SA_AFTER_LDAIR>()) m_f.parity_overflow = 0;;
 	m_iff1 = 0;
 	m_r++;
 	+ 5
@@ -866,7 +955,7 @@ macro   take_interrupt
 	WZ = PC;
 	if (HAS_LDAIR_QUIRK)
 		// reset parity flag after LD A,I or LD A,R
-		if (get_service_attention<SA_AFTER_LDAIR>()) F &= ~PF;
+		if (get_service_attention<SA_AFTER_LDAIR>()) m_f.parity_overflow = 0;
 
 macro   check_interrupts
 	if (get_service_attention<SA_NMI_PENDING>()) {
@@ -910,7 +999,7 @@ macro   nsc800_take_interrupt
 	WZ = PC;
 	if (HAS_LDAIR_QUIRK)
 		// reset parity flag after LD A,I or LD A,R
-		if (get_service_attention<SA_AFTER_LDAIR>()) F &= ~PF;
+		if (get_service_attention<SA_AFTER_LDAIR>()) m_f.parity_overflow = 0;
 
 macro   nsc800:check_interrupts
 	if (get_service_attention<SA_NMI_PENDING>()) {
@@ -5387,8 +5476,12 @@ ed3f	# DB   ED
 
 ed40	# IN   B,(C)
 	@in BC
+	{
+		// keep C
+		set_f(SZYXP[TDAT8], SF | ZF | YXF | PF);
+		set_0_f(HF | NF);
+	}
 	B = TDAT8;
-	set_f((F & CF) | SZYXP[B]);
 	WZ = BC + 1;
 
 ed41	# OUT  (C),B
@@ -5397,8 +5490,7 @@ ed41	# OUT  (C),B
 	WZ = BC + 1;
 
 ed42	# SBC  HL,BC
-	TDAT = BC;
-	@sbc_hl
+	@sbc_hl BC
 
 ed43	# LD   (w),BC
 	@arg16 m_ea
@@ -5420,8 +5512,12 @@ ed47	# LD   i,A
 
 ed48	# IN   C,(C)
 	@in BC
+	{
+		// keep C
+		set_f(SZYXP[TDAT8], SF | ZF | YXF | PF);
+		set_0_f(HF | NF);
+	}
 	C = TDAT8;
-	set_f((F & CF) | SZYXP[C]);
 	WZ = BC + 1;
 
 ed49	# OUT  (C),C
@@ -5430,8 +5526,7 @@ ed49	# OUT  (C),C
 	WZ = BC + 1;
 
 ed4a	# ADC  HL,BC
-	TDAT = BC;
-	@adc_hl
+	@adc_hl BC
 
 ed4b	# LD   BC,(w)
 	@arg16 m_ea
@@ -5453,8 +5548,12 @@ ed4f	# LD   r,A
 
 ed50	# IN   D,(C)
 	@in BC
+	{
+		// keep C
+		set_f(SZYXP[TDAT8], SF | ZF | YXF | PF);
+		set_0_f(HF | NF);
+	}
 	D = TDAT8;
-	set_f((F & CF) | SZYXP[D]);
 	WZ = BC + 1;
 
 ed51	# OUT  (C),D
@@ -5463,8 +5562,7 @@ ed51	# OUT  (C),D
 	WZ = BC + 1;
 
 ed52	# SBC  HL,DE
-	TDAT = DE;
-	@sbc_hl
+	@sbc_hl DE
 
 ed53	# LD   (w),DE
 	@arg16 m_ea
@@ -5486,8 +5584,12 @@ ed57	# LD   A,i
 
 ed58	# IN   E,(C)
 	@in BC
+	{
+		// keep C
+		set_f(SZYXP[TDAT8], SF | ZF | YXF | PF);
+		set_0_f(HF | NF);
+	}
 	E = TDAT8;
-	set_f((F & CF) | SZYXP[E]);
 	WZ = BC + 1;
 
 ed59	# OUT  (C),E
@@ -5496,8 +5598,7 @@ ed59	# OUT  (C),E
 	WZ = BC + 1;
 
 ed5a	# ADC  HL,DE
-	TDAT = DE;
-	@adc_hl
+	@adc_hl DE
 
 ed5b	# LD   DE,(w)
 	@arg16 m_ea
@@ -5519,8 +5620,12 @@ ed5f	# LD   A,r
 
 ed60	# IN   H,(C)
 	@in BC
+	{
+		// keep C
+		set_f(SZYXP[TDAT8], SF | ZF | YXF | PF);
+		set_0_f(HF | NF);
+	}
 	H = TDAT8;
-	set_f((F & CF) | SZYXP[H]);
 	WZ = BC + 1;
 
 ed61	# OUT  (C),H
@@ -5529,8 +5634,7 @@ ed61	# OUT  (C),H
 	WZ = BC + 1;
 
 ed62	# SBC  HL,HL
-	TDAT = HL;
-	@sbc_hl
+	@sbc_hl HL
 
 ed63	# LD   (w),HL
 	@arg16 m_ea
@@ -5552,8 +5656,12 @@ ed67	# RRD  (HL)
 
 ed68	# IN   L,(C)
 	@in BC
+	{
+		// keep C
+		set_f(SZYXP[TDAT8], SF | ZF | YXF | PF);
+		set_0_f(HF | NF);
+	}
 	L = TDAT8;
-	set_f((F & CF) | SZYXP[L]);
 	WZ = BC + 1;
 
 ed69	# OUT  (C),L
@@ -5562,8 +5670,7 @@ ed69	# OUT  (C),L
 	WZ = BC + 1;
 
 ed6a	# ADC  HL,HL
-	TDAT = HL;
-	@adc_hl
+	@adc_hl HL
 
 ed6b	# LD   HL,(w)
 	@arg16 m_ea
@@ -5585,7 +5692,11 @@ ed6f	# RLD  (HL)
 
 ed70	# IN   0,(C)
 	@in BC
-	set_f((F & CF) | SZYXP[TDAT8]);
+	{
+		// keep C
+		set_f(SZYXP[TDAT8], SF | ZF | YXF | PF);
+		set_0_f(HF | NF);
+	}
 	WZ = BC + 1;
 
 ed71	# OUT  (C),0
@@ -5594,8 +5705,7 @@ ed71	# OUT  (C),0
 	WZ = BC + 1;
 
 ed72	# SBC  HL,SP
-	TDAT = SP;
-	@sbc_hl
+	@sbc_hl SP
 
 ed73	# LD   (w),SP
 	@arg16 m_ea
@@ -5617,8 +5727,12 @@ ed77	# DB   ED,77
 
 ed78	# IN   A,(C)
 	@in BC
+	{
+		// keep C
+		set_f(SZYXP[TDAT8], SF | ZF | YXF | PF);
+		set_0_f(HF | NF);
+	}
 	A = TDAT8;
-	set_f((F & CF) | SZYXP[A]);
 	WZ = BC + 1;
 
 ed79	# OUT  (C),A
@@ -5627,8 +5741,7 @@ ed79	# OUT  (C),A
 	WZ = BC + 1;
 
 ed7a	# ADC  HL,SP
-	TDAT = SP;
-	@adc_hl
+	@adc_hl SP
 
 ed7b	# LD   SP,(w)
 	@arg16 m_ea
@@ -6065,8 +6178,10 @@ edff	# DB   ED
 	rlca();
 
 0008	# EX   AF,AF'
+	m_af.b.l = get_f();
 	using std::swap;
 	swap(m_af, m_af2);
+	set_f(m_af.b.l);
 
 0009	# ADD  HL,BC
 	@add16 HL, BC
@@ -6095,8 +6210,7 @@ edff	# DB   ED
 
 0010	# DJNZ o
 	@nomreq_ir 1
-	TDAT8 = --B;
-	@jr_cond
+	@jr_cond --B
 
 0011	# LD   DE,w
 	@arg16 DE
@@ -6153,8 +6267,7 @@ edff	# DB   ED
 	rra();
 
 0020	# JR   NZ,o
-	TDAT8 = !(F & ZF);
-	@jr_cond
+	@jr_cond !m_f.zero
 
 0021	# LD   HL,w
 	@arg16 HL
@@ -6183,8 +6296,7 @@ edff	# DB   ED
 	daa();
 
 0028	# JR   Z,o
-	TDAT8 = F & ZF;
-	@jr_cond
+	@jr_cond m_f.zero
 
 0029	# ADD  HL,HL
 	@add16 HL, HL
@@ -6211,11 +6323,14 @@ edff	# DB   ED
 
 002f	# CPL
 	A ^= 0xff;
-	set_f((F & (SF | ZF | PF | CF)) | HF | NF | (A & (YF | XF)));
+	{
+		// keep SZPC
+		m_f.yx = A;
+		set_1_f(HF | NF);
+	}
 
 0030	# JR   NC,o
-	TDAT8 = !(F & CF);
-	@jr_cond
+	@jr_cond !m_f.carry
 
 0031	# LD   SP,w
 	@arg16 SP
@@ -6246,11 +6361,15 @@ edff	# DB   ED
 	@wm HL
 
 0037	# SCF
-	set_f((F & (SF | ZF | PF)) | CF | (((F & Q) | A) & (YF | XF)));
+	{
+		// keep SZP
+		m_f.yx = (m_f.yx & Q) | A;
+		set_0_f(HF | NF);
+		m_f.carry = 1;
+	}
 
 0038	# JR   C,o
-	TDAT8 = F & CF;
-	@jr_cond
+	@jr_cond m_f.carry
 
 0039	# ADD  HL,SP
 	@add16 HL, SP
@@ -6276,7 +6395,18 @@ edff	# DB   ED
 	A = TDAT8;
 
 003f	# CCF
-	set_f(((F & (SF | ZF | PF | CF)) ^ CF) | ((F & CF) << 4) | (((F & Q) | A) & (YF | XF)));
+{
+	u8 f = get_f();
+	f = ((f & (SF | ZF | PF | CF)) ^ CF) | ((f & CF) << 4) | (((f & Q) | A) & (YXF));
+	{
+		QT = 0;
+		// keep SZP
+		m_f.yx = (m_f.yx & Q) | A;
+		m_f.half_carry = m_f.carry;
+		m_f.subtract = 0;
+		m_f.carry = !m_f.carry;
+	}
+}
 
 0040	# LD   B,B
 
@@ -6678,23 +6808,20 @@ edff	# DB   ED
 	cp(A);
 
 00c0	# RET  NZ
-	TDAT8 = !(F & ZF);
-	@ret_cond
+	@ret_cond !m_f.zero
 
 00c1	# POP  BC
 	@pop
 	BC = TDAT;
 
 00c2	# JP   NZ,a
-	TDAT8 = !(F & ZF);
-	@jp_cond
+	@jp_cond !m_f.zero
 
 00c3	# JP   a
 	@jp
 
 00c4	# CALL NZ,a
-	TDAT8 = !(F & ZF);
-	@call_cond
+	@call_cond !m_f.zero
 
 00c5	# PUSH BC
 	@push BC
@@ -6707,8 +6834,7 @@ edff	# DB   ED
 	@rst 0x00
 
 00c8	# RET  Z
-	TDAT8 = (F & ZF);
-	@ret_cond
+	@ret_cond m_f.zero
 
 00c9	# RET
 	@pop
@@ -6716,16 +6842,14 @@ edff	# DB   ED
 	WZ = PC;
 
 00ca	# JP   Z,a
-	TDAT8 = F & ZF;
-	@jp_cond
+	@jp_cond m_f.zero
 
 00cb	# **** CB xx
 	@rop
 	@jump_prefixed 0xcb
 
 00cc	# CALL Z,a
-	TDAT8 = F & ZF;
-	@call_cond
+	@call_cond m_f.zero
 
 00cd	# CALL a
 	@arg16_call
@@ -6738,16 +6862,14 @@ edff	# DB   ED
 	@rst 0x08
 
 00d0	# RET  NC
-	TDAT8 = !(F & CF);
-	@ret_cond
+	@ret_cond !m_f.carry
 
 00d1	# POP  DE
 	@pop
 	DE = TDAT;
 
 00d2	# JP   NC,a
-	TDAT8 = !(F & CF);
-	@jp_cond
+	@jp_cond !m_f.carry
 
 00d3	# OUT  (n),A
 	@arg
@@ -6758,8 +6880,7 @@ edff	# DB   ED
 	WZ_H = A;
 
 00d4	# CALL NC,a
-	TDAT8 = !(F & CF);
-	@call_cond
+	@call_cond !m_f.carry
 
 00d5	# PUSH DE
 	@push DE
@@ -6772,15 +6893,13 @@ edff	# DB   ED
 	@rst 0x10
 
 00d8	# RET  C
-	TDAT8 = (F & CF);
-	@ret_cond
+	@ret_cond m_f.carry
 
 00d9	# EXX
 	exx();
 
 00da	# JP   C,a
-	TDAT8 = F & CF;
-	@jp_cond
+	@jp_cond m_f.carry
 
 00db	# IN   A,(n)
 	@arg
@@ -6790,8 +6909,7 @@ edff	# DB   ED
 	WZ = TDAT2 + 1;
 
 00dc	# CALL C,a
-	TDAT8 = F & CF;
-	@call_cond
+	@call_cond m_f.carry
 
 00dd	# **** DD xx
 	@rop
@@ -6805,23 +6923,20 @@ edff	# DB   ED
 	@rst 0x18
 
 00e0	# RET  PO
-	TDAT8 = !(F & PF);
-	@ret_cond
+	@ret_cond !m_f.parity_overflow
 
 00e1	# POP  HL
 	@pop
 	HL = TDAT;
 
 00e2	# JP   PO,a
-	TDAT8 = !(F & PF);
-	@jp_cond
+	@jp_cond !m_f.parity_overflow
 
 00e3	# EX   HL,(SP)
 	@ex_sp HL
 
 00e4	# CALL PO,a
-	TDAT8 = !(F & PF);
-	@call_cond
+	@call_cond !m_f.parity_overflow
 
 00e5	# PUSH HL
 	@push HL
@@ -6834,23 +6949,20 @@ edff	# DB   ED
 	@rst 0x20
 
 00e8	# RET  PE
-	TDAT8 = (F & PF);
-	@ret_cond
+	@ret_cond m_f.parity_overflow
 
 00e9	# JP   (HL)
 	PC = HL;
 
 00ea	# JP   PE,a
-	TDAT8 = F & PF;
-	@jp_cond
+	@jp_cond m_f.parity_overflow
 
 00eb	# EX   DE,HL
 	using std::swap;
 	swap(DE, HL);
 
 00ec	# CALL PE,a
-	TDAT8 = F & PF;
-	@call_cond
+	@call_cond m_f.parity_overflow
 
 00ed	# **** ED xx
 	@rop
@@ -6864,26 +6976,26 @@ edff	# DB   ED
 	@rst 0x28
 
 00f0	# RET  P
-	TDAT8 = !(F & SF);
-	@ret_cond
+	@ret_cond !m_f.sign
 
 00f1	# POP  AF
 	@pop
-	AF = TDAT;
+	A = TDAT_H;
+	set_f(TDAT_L);
 
 00f2	# JP   P,a
-	TDAT8 = !(F & SF);
-	@jp_cond
+	@jp_cond !m_f.sign
 
 00f3	# DI
 	m_iff1 = m_iff2 = 0;
 
 00f4	# CALL P,a
-	TDAT8 = !(F & SF);
-	@call_cond
+	@call_cond !m_f.sign
 
 00f5	# PUSH AF
-	@push AF
+	@nomreq_ir 1
+	@wm_sp A
+	@wm_sp get_f()
 
 00f6	# OR   n
 	@arg
@@ -6893,23 +7005,20 @@ edff	# DB   ED
 	@rst 0x30
 
 00f8	# RET  M
-	TDAT8 = (F & SF);
-	@ret_cond
+	@ret_cond m_f.sign
 
 00f9	# LD   SP,HL
 	@nomreq_ir 2
 	SP = HL;
 
 00fa	# JP   M,a
-	TDAT8 = F & SF;
-	@jp_cond
+	@jp_cond m_f.sign
 
 00fb	# EI
 	ei();
 
 00fc	# CALL M,a
-	TDAT8 = F & SF;
-	@call_cond
+	@call_cond m_f.sign
 
 00fd	# **** FD xx
 	@rop

--- a/src/mame/sinclair/sprinter.cpp
+++ b/src/mame/sinclair/sprinter.cpp
@@ -907,7 +907,7 @@ void sprinter_state::accel_control_r(u8 data)
 				case 1: m_acc_dir = 0b00100101; break; // LD C,C % % fill by constant
 				case 2: m_acc_dir = 0b00001001; break; // LD D,D % % load count accelerator
 				case 3: m_acc_dir = 0b00010101; break; // LD E,E % % fill by constant VERTICAL
-				case 4: m_acc_dir = 0b01000001; break; // LD H,H % % duble byte fn
+				case 4: m_acc_dir = 0b01000001; break; // LD H,H % % double byte fn
 				case 5: m_acc_dir = 0b00100111; break; // LD L,L % % copy line
 				case 6: m_acc_dir = 0b00000000; break; // HALT
 				case 7: m_acc_dir = 0b00010111; break; // LD A,A % % copy line VERTICAL


### PR DESCRIPTION
Credits to @smf- for the idea!

Before:
```
» repeat 3 ./mame zexall -bench 100 && sleep 1
Average speed: 9008.28% (99 seconds)
Average speed: 9315.16% (99 seconds)
Average speed: 9412.46% (99 seconds)
-------------------------------------------------------------------------
» repeat 3 ./mame docastle -bench 100 && sleep 1
Average speed: 1529.40% (99 seconds)
Average speed: 1539.67% (99 seconds)
Average speed: 1538.97% (99 seconds)
-------------------------------------------------------------------------
» repeat 3 ./mame pacman -bench 100 && sleep 1
Average speed: 14265.06% (99 seconds)
Average speed: 13265.54% (99 seconds)
Average speed: 13061.40% (99 seconds)
```
After:
```
» repeat 3 ./mame zexall -bench 100 && sleep 1
Average speed: 10282.77% (99 seconds)
Average speed: 10319.55% (99 seconds)
Average speed: 9790.69% (99 seconds)
-------------------------------------------------------------------------
» repeat 3 ./mame docastle -bench 100 && sleep 1
Average speed: 1556.15% (99 seconds)
Average speed: 1537.15% (99 seconds)
Average speed: 1557.02% (99 seconds)
-------------------------------------------------------------------------
» repeat 3 ./mame pacman -bench 100 && sleep 1
Average speed: 14055.56% (99 seconds)
Average speed: 13918.92% (99 seconds)
Average speed: 14550.54% (99 seconds)
```

_P.S. I feel I'm getting blind while trying to review it visually. Will do couple more attempts later myself.
Main flags tests are passing `Timing_Tests-48k_v1.0` and Raxsoft's `z80full`_