### PR TITLE
debugger: more granular naming for symbol table types

### DIFF
--- a/src/emu/debug/debugcmd.cpp
+++ b/src/emu/debug/debugcmd.cpp
@@ -3930,7 +3930,7 @@ void debugger_commands::execute_symlist(const std::vector<std::string_view> &par
 	for (; symtable != nullptr; symtable = symtable->parent())
 	{
 		// Skip globals if user explicitly requested CPU
-		if (symtable->type() == symbol_table::BUILTIN_GLOBALS && !params.empty())
+		if (symtable->type() == symbol_table::DEBUGGER_GLOBALS && !params.empty())
 			continue;
 
 		if (symtable->entries().size() == 0)
@@ -3944,7 +3944,7 @@ void debugger_commands::execute_symlist(const std::vector<std::string_view> &par
 		case symbol_table::CPU_STATE:
 			m_console.printf("\n**** CPU '%s' symbols ****\n", cpu->tag());
 			break;
-		case symbol_table::BUILTIN_GLOBALS:
+		case symbol_table::DEBUGGER_GLOBALS:
 			m_console.printf("\n**** Global symbols ****\n");
 			break;
 		default:

--- a/src/emu/debug/debugcpu.cpp
+++ b/src/emu/debug/debugcpu.cpp
@@ -57,7 +57,7 @@ debugger_cpu::debugger_cpu(running_machine &machine)
 	m_tempvar = make_unique_clear<u64[]>(NUM_TEMP_VARIABLES);
 
 	/* create a global symbol table */
-	m_symtable = std::make_unique<symbol_table>(machine, symbol_table::BUILTIN_GLOBALS);
+	m_symtable = std::make_unique<symbol_table>(machine, symbol_table::DEBUGGER_GLOBALS);
 	m_symtable->set_memory_modified_func([this]() { set_memory_modified(true); });
 
 	/* add "wpaddr", "wpdata", "wpsize" to the global symbol table */

--- a/src/emu/debug/express.h
+++ b/src/emu/debug/express.h
@@ -176,8 +176,10 @@ public:
 	enum table_type
 	{
 		CPU_STATE,         // CPU registers, etc.
-		BUILTIN_GLOBALS,   // Built-in MAME global symbols (e.g., beamx, beamy, frame, etc.)
-						   // (also used for tables outside debugger: lua scripts, cheat engine)
+		DEBUGGER_GLOBALS,  // Debugger global symbol table (e.g., beamx, beamy, frame, etc.)
+		CHEAT_ENTRY,       // symbols used in cheat entry actions (argindex, temp variables)
+		CHEAT_MANAGER,     // symbols from the cheat manager (frame value, from/tobcd functions)
+		LUA_SCRIPT,        // custom symbols added by a LUA script for use from the LUA script
 	};
 
 	// construction/destruction

--- a/src/frontend/mame/cheat.cpp
+++ b/src/frontend/mame/cheat.cpp
@@ -683,7 +683,7 @@ void cheat_script::script_entry::output_argument::save(util::core_file &cheatfil
 
 cheat_entry::cheat_entry(cheat_manager &manager, symbol_table &globaltable, std::string const &filename, util::xml::data_node const &cheatnode)
 	: m_manager(manager)
-	, m_symbols(manager.machine(), symbol_table::BUILTIN_GLOBALS, &globaltable)
+	, m_symbols(manager.machine(), symbol_table::CHEAT_ENTRY, &globaltable)
 	, m_state(SCRIPT_STATE_OFF)
 	, m_numtemp(DEFAULT_TEMP_VARIABLES)
 	, m_argindex(0)
@@ -1065,7 +1065,7 @@ cheat_manager::cheat_manager(running_machine &machine)
 	, m_numlines(0)
 	, m_lastline(0)
 	, m_disabled(true)
-	, m_symtable(machine, symbol_table::BUILTIN_GLOBALS)
+	, m_symtable(machine, symbol_table::CHEAT_MANAGER)
 {
 	// if the cheat engine is disabled, we're done
 	if (!machine.options().cheat())

--- a/src/frontend/mame/luaengine_debug.cpp
+++ b/src/frontend/mame/luaengine_debug.cpp
@@ -91,7 +91,7 @@ public:
 
 	symbol_table_wrapper(lua_engine &host, running_machine &machine, std::shared_ptr<symbol_table_wrapper> const &parent, device_t *device)
 		: m_host(host)
-		, m_table(machine, symbol_table::BUILTIN_GLOBALS, parent ? &parent->table() : nullptr, device)
+		, m_table(machine, symbol_table::LUA_SCRIPT, parent ? &parent->table() : nullptr, device)
 		, m_parent(parent)
 	{
 	}


### PR DESCRIPTION
This is to address the naming feedback from https://github.com/mamedev/mame/commit/b39e6846221f958ef10d02cb16f5c35221f0fb2b.  That commit added an enum to identify the type of each symbol table.  This PR adds a few enum values so that symbol tables can be more granularly typed.  With the PR, the list is:

```
        CPU_STATE,         // CPU registers, etc.
        DEBUGGER_GLOBALS,  // Debugger global symbol table (e.g., beamx, beamy, frame, etc.)
        CHEAT_ENTRY,       // symbols used in cheat entry actions (argindex, temp variables)
        CHEAT_MANAGER,     // symbols from the cheat manager (frame value, from/tobcd functions)
        LUA_SCRIPT,        // custom symbols added by a LUA script for use from the LUA script
```

This reduces the set of symbols confusingly identified as global.  But the debugger's global symbol table is still named as such (for now) because that’s how the public symlist docs, preexisting function names, and code comments have been referring to it.  If you’d like those changed, that’s totally fine, let me know what you’d like.  A few candidates: DEBUGGER_GENERAL, DEBUGGER_COMMON, DEBUGGER_BUILTIN.
