### PR TITLE
vt369 - allow rtvgc300/rtvgc300fz to display menus / select games, vt32 - preliminary support for new video mode used by lxpcsp 

### DIFF
--- a/src/devices/video/ppu2c0x.h
+++ b/src/devices/video/ppu2c0x.h
@@ -78,6 +78,8 @@ public:
 	auto int_callback() { return m_int_callback.bind(); }
 
 	void spriteram_dma(address_space &space, const u8 page);
+	void set_spriteram_value(offs_t offset, u8 data) { m_spriteram[offset] = data; }
+
 	void render(bitmap_rgb32 &bitmap, bool flipx, bool flipy, int sx, int sy, const rectangle &cliprect);
 	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 

--- a/src/devices/video/ppu2c0x.h
+++ b/src/devices/video/ppu2c0x.h
@@ -198,7 +198,7 @@ protected:
 	int                         m_vblank_first_scanline;  /* the very first scanline where VBLANK occurs */
 
 	// used in rendering
-	u8 m_planebuf[8]; // temp buffer used for fetching tile data
+	u8 m_planebuf[16]; // temp buffer used for fetching tile data
 	s32                    m_scanline;         /* scanline count */
 	std::unique_ptr<u8[]>  m_spriteram;           /* sprite ram */
 

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -631,24 +631,18 @@ void ppu_vt32_device::draw_background(u8* line_priority)
 		{
 			const int index1 = tile_index + (x * 2);
 			int page2 = readbyte(index1);
-	
+			// index+1 is colour data? maybe extra tile bits?
+
 			if (start_x < VISIBLE_SCREEN_WIDTH)
 			{
 				int gfx_address = page2 * 0x100;
 				gfx_address += 0x68000;
 				gfx_address += scroll_y_fine * 16;
 				gfx_address += ((m_refresh_data & 0x0020) >> 5) * 0x80;
-				m_whichpixel = 0;
-
-				for (int i = 0; i < 16; i++)
-					m_planebuf[i] = m_read_onespace(gfx_address + i);
 
 				for (int i = 0; i < 16; i++)
 				{
-					u8 pix = m_planebuf[m_whichpixel];
-
-					m_whichpixel++;
-
+					u8 pix = m_read_onespace(gfx_address + i);
 					if ((start_x + i) >= 0 && (start_x + i) < VISIBLE_SCREEN_WIDTH)
 					{
 						u16 palval = (m_palette_ram[pix & 0x7f] & 0x3f);

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -633,7 +633,7 @@ void ppu_vt32_device::draw_background(u8* line_priority)
 		{
 			const int index1 = tile_index + (x * 2);
 			int page2 = readbyte(index1);
-			// index+1 is colour data? maybe extra tile bits?
+			page2 |= (readbyte(index1+1) & 0x01) << 8; // index+1 is colour data? maybe extra tile bits?
 
 			if (start_x < VISIBLE_SCREEN_WIDTH)
 			{

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -758,6 +758,7 @@ void ppu_vt3xx_device::read_tile_plane_data(int address, int color)
 		m_read_bg4_bg3 = color;
 		m_whichpixel = 0;
 
+		// used by the rtvgc300 / rtvgc300fz menus, and also 'image match' in lxcmcysp
 		if (m_newvid_1c & 0x04) // high resolution mode
 		{
 			m_planebuf[0] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 0) & 0x1fff, 0));

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -732,6 +732,21 @@ offs_t ppu_vt3xx_device::recalculate_offsets_8x8x8packed_tile(int address, int v
 	return finaladdr + finaloffset;
 }
 
+offs_t ppu_vt3xx_device::recalculate_offsets_16x16x8packed_hires_tile(int address, int va34)
+{
+	int finaladdr = get_newmode_tilebase() * 0x2000;
+	int colorbits = get_m_read_bg4_bg3();
+	int tileline = address & 0x0007;
+	int tileplane = address & 0x0008;
+	int tilenum = (address & 0x0ff0) >> 4;
+	int finaloffset = tilenum * 0x100;
+	finaloffset += tileline * 0x20; // 0x10 are the odd lines, we currently only fetch even as we're pretending these are 8x8
+	finaloffset += va34; // 3 bits
+	finaloffset += tileplane; // 1 bit
+	finaloffset += colorbits * 0x10000;
+	return finaladdr + finaloffset;
+}
+
 void ppu_vt3xx_device::read_tile_plane_data(int address, int color)
 {
 	if (!m_newvid_1e)
@@ -741,26 +756,47 @@ void ppu_vt3xx_device::read_tile_plane_data(int address, int color)
 	else
 	{
 		m_read_bg4_bg3 = color;
-
 		m_whichpixel = 0;
 
-		if ((m_newvid_1c & 0x03) == 0x02)
+		if (m_newvid_1c & 0x04) // high resolution mode
 		{
-			m_planebuf[0] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 0) & 0x1fff, 0));
-			m_planebuf[1] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 8) & 0x1fff, 0));
-			m_planebuf[2] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 0) & 0x1fff, 1));
-			m_planebuf[3] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 8) & 0x1fff, 1));
-			m_planebuf[4] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 0) & 0x1fff, 2));
-			m_planebuf[5] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 8) & 0x1fff, 2));
-			m_planebuf[6] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 0) & 0x1fff, 3));
-			m_planebuf[7] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 8) & 0x1fff, 3));
+			m_planebuf[0] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 0) & 0x1fff, 0));
+			m_planebuf[1] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 8) & 0x1fff, 0));
+			m_planebuf[2] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 0) & 0x1fff, 1));
+			m_planebuf[3] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 8) & 0x1fff, 1));
+			m_planebuf[4] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 0) & 0x1fff, 2));
+			m_planebuf[5] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 8) & 0x1fff, 2));
+			m_planebuf[6] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 0) & 0x1fff, 3));
+			m_planebuf[7] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 8) & 0x1fff, 3));
+			m_planebuf[8] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 0) & 0x1fff, 4));
+			m_planebuf[9] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 8) & 0x1fff, 4));
+			m_planebuf[10] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 0) & 0x1fff, 5));
+			m_planebuf[11] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 8) & 0x1fff, 5));
+			m_planebuf[12] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 0) & 0x1fff, 6));
+			m_planebuf[13] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 8) & 0x1fff, 6));
+			m_planebuf[14] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 0) & 0x1fff, 7));
+			m_planebuf[15] = m_read_onespace_with_relative(recalculate_offsets_16x16x8packed_hires_tile((address + 8) & 0x1fff, 7));
 		}
 		else
 		{
-			m_planebuf[0] = m_read_onespace_with_relative(recalculate_offsets_8x8x4packed_tile((address + 0) & 0x1fff, 0));
-			m_planebuf[1] = m_read_onespace_with_relative(recalculate_offsets_8x8x4packed_tile((address + 8) & 0x1fff, 0));
-			m_planebuf[2] = m_read_onespace_with_relative(recalculate_offsets_8x8x4packed_tile((address + 0) & 0x1fff, 1));
-			m_planebuf[3] = m_read_onespace_with_relative(recalculate_offsets_8x8x4packed_tile((address + 8) & 0x1fff, 1));
+			if ((m_newvid_1c & 0x03) == 0x02)
+			{
+				m_planebuf[0] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 0) & 0x1fff, 0));
+				m_planebuf[1] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 8) & 0x1fff, 0));
+				m_planebuf[2] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 0) & 0x1fff, 1));
+				m_planebuf[3] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 8) & 0x1fff, 1));
+				m_planebuf[4] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 0) & 0x1fff, 2));
+				m_planebuf[5] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 8) & 0x1fff, 2));
+				m_planebuf[6] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 0) & 0x1fff, 3));
+				m_planebuf[7] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 8) & 0x1fff, 3));
+			}
+			else
+			{
+				m_planebuf[0] = m_read_onespace_with_relative(recalculate_offsets_8x8x4packed_tile((address + 0) & 0x1fff, 0));
+				m_planebuf[1] = m_read_onespace_with_relative(recalculate_offsets_8x8x4packed_tile((address + 8) & 0x1fff, 0));
+				m_planebuf[2] = m_read_onespace_with_relative(recalculate_offsets_8x8x4packed_tile((address + 0) & 0x1fff, 1));
+				m_planebuf[3] = m_read_onespace_with_relative(recalculate_offsets_8x8x4packed_tile((address + 8) & 0x1fff, 1));
+			}
 		}
 	}
 }
@@ -773,38 +809,55 @@ void ppu_vt3xx_device::shift_tile_plane_data(u8& pix)
 	}
 	else
 	{
-		if ((m_newvid_1c & 0x03) == 0x02)
+		if (m_newvid_1c & 0x04) // high resolution mode
 		{
-			// 8x8x8 non-planar mode
+			// we currently pretend this is 8x8, not 16x16
 			switch (m_whichpixel)
 			{
-			case 0: pix = m_planebuf[0]; break;
-			case 1: pix = m_planebuf[2]; break;
-			case 2: pix = m_planebuf[4]; break;
-			case 3: pix = m_planebuf[6]; break;
-			case 4: pix = m_planebuf[1]; break;
-			case 5: pix = m_planebuf[3]; break;
-			case 6: pix = m_planebuf[5]; break;
-			case 7: pix = m_planebuf[7]; break;
+				case 0: pix = m_planebuf[0]; break;
+				case 1: pix = m_planebuf[4]; break;
+				case 2: pix = m_planebuf[8]; break;
+				case 3: pix = m_planebuf[12]; break;
+				case 4: pix = m_planebuf[1]; break;
+				case 5: pix = m_planebuf[5]; break;
+				case 6: pix = m_planebuf[9]; break;
+				case 7: pix = m_planebuf[13]; break;
 			}
 		}
 		else
 		{
-			// extended modes
-			// 8x8x4 non-planar mode
-			switch (m_whichpixel)
+			if ((m_newvid_1c & 0x03) == 0x02)
 			{
-			case 0: pix = (m_planebuf[0] >> 0) & 0xf; break;
-			case 1: pix = (m_planebuf[0] >> 4) & 0xf; break;
-			case 2: pix = (m_planebuf[2] >> 0) & 0xf; break;
-			case 3: pix = (m_planebuf[2] >> 4) & 0xf; break;
-			case 4: pix = (m_planebuf[1] >> 0) & 0xf; break;
-			case 5: pix = (m_planebuf[1] >> 4) & 0xf; break;
-			case 6: pix = (m_planebuf[3] >> 0) & 0xf; break;
-			case 7: pix = (m_planebuf[3] >> 4) & 0xf; break;
+				// 8x8x8 non-planar mode
+				switch (m_whichpixel)
+				{
+				case 0: pix = m_planebuf[0]; break;
+				case 1: pix = m_planebuf[2]; break;
+				case 2: pix = m_planebuf[4]; break;
+				case 3: pix = m_planebuf[6]; break;
+				case 4: pix = m_planebuf[1]; break;
+				case 5: pix = m_planebuf[3]; break;
+				case 6: pix = m_planebuf[5]; break;
+				case 7: pix = m_planebuf[7]; break;
+				}
+			}
+			else
+			{
+				// extended modes
+				// 8x8x4 non-planar mode
+				switch (m_whichpixel)
+				{
+				case 0: pix = (m_planebuf[0] >> 0) & 0xf; break;
+				case 1: pix = (m_planebuf[0] >> 4) & 0xf; break;
+				case 2: pix = (m_planebuf[2] >> 0) & 0xf; break;
+				case 3: pix = (m_planebuf[2] >> 4) & 0xf; break;
+				case 4: pix = (m_planebuf[1] >> 0) & 0xf; break;
+				case 5: pix = (m_planebuf[1] >> 4) & 0xf; break;
+				case 6: pix = (m_planebuf[3] >> 0) & 0xf; break;
+				case 7: pix = (m_planebuf[3] >> 4) & 0xf; break;
+				}
 			}
 		}
-
 		m_whichpixel++;
 	}
 }

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -660,7 +660,7 @@ void ppu_vt32_device::draw_background(u8* line_priority)
 						if (pix & 0x80)
 							palval = (m_vt3xx_palette[pix & 0x7f] & 0x3f) | ((m_vt3xx_palette[(pix & 0x7f) + 0x80] & 0x3f) << 6);
 						else
-							palval = (m_palette_ram[pix & 0x7f] & 0x3f) | ((m_palette_ram[(pix & 0x7f) + 0x80] & 0x3f) << 6);
+							palval = (m_vt3xx_palette[(pix & 0x7f) + 0x100] & 0x3f) | ((m_vt3xx_palette[(pix & 0x7f) + 0x180] & 0x3f) << 6);
 
 						// does grayscale mode exist here? (we haven't calculated any colours for it)
 						//if (m_regs[PPU_CONTROL1] & PPU_CONTROL1_DISPLAY_MONO)

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -616,7 +616,7 @@ void ppu_vt32_device::draw_background(u8* line_priority)
 		const u8  scroll_y_coarse = (m_refresh_data & 0x03c0) >> 5;
 		// m_refresh_data & 0x0020 in this case would be the top/bottom of the tile
 
-		const u16 nametable = m_refresh_data & 0x0c00;
+		const u16 nametable = (m_refresh_data & 0x0c00) >> 1;
 		const u8  scroll_y_fine = (m_refresh_data & 0x7000) >> 12;
 
 		int x = scroll_x_coarse >> 1;// &~1;
@@ -633,7 +633,7 @@ void ppu_vt32_device::draw_background(u8* line_priority)
 		{
 			const int index1 = tile_index + (x * 2);
 			int page2 = readbyte(index1);
-			page2 |= (readbyte(index1+1) & 0x03) << 8; // index+1 is colour data? and extra tile bits
+			page2 |= (readbyte(index1 + 1) & 0x03) << 8; // index+1 is colour data? and extra tile bits
 
 			if (start_x < VISIBLE_SCREEN_WIDTH)
 			{

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -21,6 +21,9 @@
 DEFINE_DEVICE_TYPE(PPU_VT03, ppu_vt03_device, "ppu_vt03", "VT03 PPU (NTSC)")
 DEFINE_DEVICE_TYPE(PPU_VT03PAL, ppu_vt03pal_device, "ppu_vt03pal", "VT03 PPU (PAL)")
 
+DEFINE_DEVICE_TYPE(PPU_VT32, ppu_vt32_device, "ppu_vt32", "VT32 PPU (NTSC)")
+DEFINE_DEVICE_TYPE(PPU_VT32PAL, ppu_vt32pal_device, "ppu_vt32pal", "VT32 PPU (PAL)")
+
 DEFINE_DEVICE_TYPE(PPU_VT3XX, ppu_vt3xx_device, "ppu_vt3xx", "VT3XX PPU (NTSC)")
 
 ppu_vt03_device::ppu_vt03_device(const machine_config& mconfig, device_type type, const char* tag, device_t* owner, u32 clock) :
@@ -48,6 +51,24 @@ ppu_vt03pal_device::ppu_vt03pal_device(const machine_config& mconfig, const char
 	m_is_50hz = true;
 }
 
+ppu_vt32_device::ppu_vt32_device(const machine_config& mconfig, device_type type, const char* tag, device_t* owner, u32 clock) :
+	ppu_vt03_device(mconfig, type, tag, owner, clock)
+{
+}
+
+ppu_vt32_device::ppu_vt32_device(const machine_config& mconfig, const char* tag, device_t* owner, u32 clock) :
+	ppu_vt32_device(mconfig, PPU_VT32, tag, owner, clock)
+{
+}
+
+ppu_vt32pal_device::ppu_vt32pal_device(const machine_config& mconfig, const char* tag, device_t* owner, u32 clock) :
+	ppu_vt32_device(mconfig, PPU_VT32PAL, tag, owner, clock)
+{
+	m_scanlines_per_frame = PAL_SCANLINES_PER_FRAME;
+	m_vblank_first_scanline = VBLANK_FIRST_SCANLINE_PALC;
+	m_is_pal = true;
+	m_is_50hz = true;
+}
 
 u8 ppu_vt03_device::palette_read(offs_t offset)
 {
@@ -574,6 +595,19 @@ void ppu_vt03_device::videobank0_extra_w(offs_t offset, u8 data) { m_videobank0_
 /* 201d read gun read y (older VT chipsets) */
 /* 201e read gun 2 read x (older VT chipsets) */
 /* 201f read gun 2 read y (older VT chipsets) */
+
+void ppu_vt32_device::draw_background(u8* line_priority)
+{
+	if (TEST_VT32_NEW_BGMODE)
+	{
+		popmessage("TEST_VT32_NEW_BGMODE");
+	}
+	else
+	{
+		ppu2c0x_device::draw_background(line_priority);
+	}
+}
+
 
 ppu_vt3xx_device::ppu_vt3xx_device(const machine_config& mconfig, const char* tag, device_t* owner, u32 clock) :
 	ppu_vt03_device(mconfig, PPU_VT3XX, tag, owner, clock)

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -977,13 +977,13 @@ void ppu_vt3xx_device::draw_sprites_high_res(u8* line_priority)
 		int pattern_offset;
 		if (bpp == 4)
 		{
-			pattern_offset = tilenum * (0x20 * width);
-			pattern_offset += sprite_line * (0x2 * width);
+			pattern_offset = tilenum * (2 * height * width);
+			pattern_offset += sprite_line * (2 * width);
 		}
 		else
 		{
-			pattern_offset = tilenum * (0x40 * width);
-			pattern_offset += sprite_line * (0x4 * width);
+			pattern_offset = tilenum * (4 * height * width);
+			pattern_offset += sprite_line * (4 * width);
 		}
 
 		pattern_offset += get_newmode_spritebase() * 0x2000;

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -609,11 +609,6 @@ void ppu_vt32_device::draw_background(u8* line_priority)
 	{
 		// strange custom mode, feels more like a vt369 mode
 		// tiles use 16x16x8 packed data
-		// if ROM is decoded as this they're at
-		// tile 0x680 in matet220 (0x68000 in ROM)
-		// tile 0x800 in matet300 (0x80000 in ROM)
-
-		// palette data seems to be written to 3c00? (usually VT32 would be 3e00+ for palette)
 
 		// determine where in the nametable to start drawing from
 		// based on the current scanline and scroll regs

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -154,12 +154,20 @@ public:
 	ppu_vt32_device(const machine_config& mconfig, const char* tag, device_t* owner, u32 clock);
 	ppu_vt32_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
 
+	void vt32_extvid_201b_w(u8 data);
+	void vt32_extvid_201c_w(u8 data);
+	void vt32_extvid_201d_w(u8 data);
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
 private:
 	virtual void draw_background(u8 *line_priority) override;
 
-	// see notes in .cpp file, there's an extra mode
-	// but we don't know how to enable it for now
-	static constexpr bool TEST_VT32_NEW_BGMODE = false;
+	u8 vt32_extvid_201b;
+	u8 vt32_extvid_201c;
+	u8 vt32_extvid_201d;
 };
 
 class ppu_vt32pal_device : public ppu_vt32_device {

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -181,6 +181,7 @@ private:
 
 	offs_t recalculate_offsets_8x8x4packed_tile(int address, int va34);
 	offs_t recalculate_offsets_8x8x8packed_tile(int address, int va34);
+	offs_t recalculate_offsets_16x16x8packed_hires_tile(int address, int va34);
 
 	void draw_extended_sprite_pixel_low(bitmap_rgb32& bitmap, int pixel_data, int pixel, int xpos, int pal, int bpp, u8* line_priority);
 	void draw_extended_sprite_pixel_high(bitmap_rgb32& bitmap, int pixel_data, int pixel, int xpos, int pal, int bpp, u8* line_priority);

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -73,8 +73,9 @@ public:
 	u8 get_extended_modes_enable() { return m_extended_modes_enable; }
 	u8 get_extended_modes2_enable() { return m_extended_modes2_enable; }
 
+	u8 get_newvid_1c() { return m_newvid_1c; }
+	u8 get_newvid_1d() { return m_newvid_1d; }
 	bool is_v3xx_extended_mode() { return (m_newvid_1e == 0x00) ? false : true; }
-	bool get_newvid_1d() { return m_newvid_1d; }
 
 	u16 get_newmode_tilebase() { return m_tilebases_2x[0] | (m_tilebases_2x[1] << 8); }
 	u16 get_newmode_spritebase() { return m_tilebases_2x[2] | (m_tilebases_2x[3] << 8); }
@@ -125,12 +126,15 @@ protected:
 
 	int m_whichpixel;
 
+	u8 m_newvid_1b;
 	u8 m_newvid_1c;
 	u8 m_newvid_1d;
 	u8 m_newvid_1e;
 	u8 m_tilebases_2x[4];
 
 	u8 m_vt3xx_palette[0x400];
+
+	static constexpr unsigned YUV444_COLOR = (0x40 * 8);
 private:
 
 	u8 m_extra_sprite_bits;
@@ -141,7 +145,6 @@ private:
 	void init_vtxx_rgb555_palette_tables();
 	void init_vtxx_rgb444_palette_tables();
 
-	static constexpr unsigned YUV444_COLOR = (0x40 * 8);
 };
 
 class ppu_vt03pal_device : public ppu_vt03_device {
@@ -154,20 +157,12 @@ public:
 	ppu_vt32_device(const machine_config& mconfig, const char* tag, device_t* owner, u32 clock);
 	ppu_vt32_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
 
-	void vt32_extvid_201b_w(u8 data);
-	void vt32_extvid_201c_w(u8 data);
-	void vt32_extvid_201d_w(u8 data);
-
-protected:
-	virtual void device_start() override ATTR_COLD;
-	virtual void device_reset() override ATTR_COLD;
+	void m_newvid_1b_w(u8 data);
+	void m_newvid_1c_w(u8 data);
+	void m_newvid_1d_w(u8 data);
 
 private:
 	virtual void draw_background(u8 *line_priority) override;
-
-	u8 vt32_extvid_201b;
-	u8 vt32_extvid_201c;
-	u8 vt32_extvid_201d;
 };
 
 class ppu_vt32pal_device : public ppu_vt32_device {

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -29,6 +29,7 @@ public:
 
 	auto read_bg() { return m_read_bg.bind(); }
 	auto read_sp() { return m_read_sp.bind(); }
+	auto read_onespace() { return m_read_onespace.bind(); }
 	auto read_onespace_with_relative() { return m_read_onespace_with_relative.bind(); }
 
 	void set_palette_mode(vtxx_pal_mode pmode) { m_pal_mode = pmode; }
@@ -117,6 +118,7 @@ protected:
 
 	devcb_read8 m_read_bg;
 	devcb_read8 m_read_sp;
+	devcb_read8 m_read_onespace;
 	devcb_read8 m_read_onespace_with_relative;
 
 	int32_t m_read_bg4_bg3;
@@ -155,11 +157,8 @@ public:
 private:
 	virtual void draw_background(u8 *line_priority) override;
 
-	// This is used by matet220 and matet300 for the menus
-	// it seems a lot more like a VT369 mode, and even uses packed
-	// format tiles, but those sets use VT32 style encryption
-	// and don't touch the usual VT369 registers.
-	// maybe a revision of the VT32?
+	// see notes in .cpp file, there's an extra mode
+	// but we don't know how to enable it for now
 	static constexpr bool TEST_VT32_NEW_BGMODE = false;
 };
 

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -183,6 +183,9 @@ private:
 	offs_t recalculate_offsets_8x8x8packed_tile(int address, int va34);
 	offs_t recalculate_offsets_16x16x8packed_hires_tile(int address, int va34);
 
+	void draw_sprites_standard_res(u8* line_priority);
+	void draw_sprites_high_res(u8* line_priority);
+
 	void draw_extended_sprite_pixel_low(bitmap_rgb32& bitmap, int pixel_data, int pixel, int xpos, int pal, int bpp, u8* line_priority);
 	void draw_extended_sprite_pixel_high(bitmap_rgb32& bitmap, int pixel_data, int pixel, int xpos, int pal, int bpp, u8* line_priority);
 

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -147,6 +147,28 @@ public:
 	ppu_vt03pal_device(const machine_config& mconfig, const char* tag, device_t* owner, u32 clock);
 };
 
+class ppu_vt32_device : public ppu_vt03_device {
+public:
+	ppu_vt32_device(const machine_config& mconfig, const char* tag, device_t* owner, u32 clock);
+	ppu_vt32_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
+
+private:
+	virtual void draw_background(u8 *line_priority) override;
+
+	// This is used by matet220 and matet300 for the menus
+	// it seems a lot more like a VT369 mode, and even uses packed
+	// format tiles, but those sets use VT32 style encryption
+	// and don't touch the usual VT369 registers.
+	// maybe a revision of the VT32?
+	static constexpr bool TEST_VT32_NEW_BGMODE = false;
+};
+
+class ppu_vt32pal_device : public ppu_vt32_device {
+public:
+	ppu_vt32pal_device(const machine_config& mconfig, const char* tag, device_t* owner, u32 clock);
+};
+
+
 class ppu_vt3xx_device : public ppu_vt03_device {
 public:
 	ppu_vt3xx_device(const machine_config& mconfig, const char* tag, device_t* owner, u32 clock);
@@ -196,6 +218,9 @@ private:
 
 DECLARE_DEVICE_TYPE(PPU_VT03,    ppu_vt03_device)
 DECLARE_DEVICE_TYPE(PPU_VT03PAL, ppu_vt03pal_device)
+
+DECLARE_DEVICE_TYPE(PPU_VT32, ppu_vt32_device)
+DECLARE_DEVICE_TYPE(PPU_VT32PAL, ppu_vt32pal_device)
 
 DECLARE_DEVICE_TYPE(PPU_VT3XX,    ppu_vt3xx_device)
 

--- a/src/mame/nintendo/nes_vt32_soc.cpp
+++ b/src/mame/nintendo/nes_vt32_soc.cpp
@@ -118,6 +118,45 @@ u8 nes_vt32_soc_device::vthh_414a_r()
 	return machine().rand();
 }
 
+
+void nes_vt32_soc_device::scrambled_8000_w(u16 offset, u8 data)
+{
+	offset &= 0x7fff;
+
+	u16 addr = offset+0x8000;
+	if ((m_411d & 0x03) == 0x03) // (VT32 only, not VT03/09)
+	{
+		//CNROM compat
+		logerror("%s: vtxx_cnrom_8000_w real address: (%04x) translated address: (%04x) %02x\n", machine().describe_context(), addr, offset + 0x8000, data);
+		m_ppu->set_videobank0_reg(0x4, data * 8);
+		m_ppu->set_videobank0_reg(0x5, data * 8 + 2);
+		m_ppu->set_videobank0_reg(0x0, data * 8 + 4);
+		m_ppu->set_videobank0_reg(0x1, data * 8 + 5);
+		m_ppu->set_videobank0_reg(0x2, data * 8 + 6);
+		m_ppu->set_videobank0_reg(0x3, data * 8 + 7);
+
+	}
+	else if ((m_411d & 0x03) == 0x01) // (VT32 only, not VT03/09)
+	{
+		//MMC1 compat, TODO
+		logerror("%s: vtxx_mmc1_8000_w real address: (%04x) translated address: (%04x) %02x\n", machine().describe_context(), addr, offset + 0x8000, data);
+	}
+	else if ((m_411d & 0x03) == 0x02) // (VT32 only, not VT03/09)
+	{
+		//UNROM compat
+		logerror("%s: vtxx_unrom_8000_w real address: (%04x) translated address: (%04x) %02x\n", machine().describe_context(), addr, offset + 0x8000, data);
+
+		m_410x[0x7] = ((data & 0x0F) << 1);
+		m_410x[0x8] = ((data & 0x0F) << 1) + 1;
+		update_banks();
+	}
+	else // standard mode (VT03/09)
+	{
+		nes_vt02_vt03_soc_device::scrambled_8000_w(offset, data);
+	}
+}
+
+
 void nes_vt32_soc_device::nes_vt32_soc_map(address_map &map)
 {
 	map(0x0000, 0x1fff).ram(); // .mask(0x0fff).ram();

--- a/src/mame/nintendo/nes_vt32_soc.cpp
+++ b/src/mame/nintendo/nes_vt32_soc.cpp
@@ -35,7 +35,7 @@ u8 nes_vt32_soc_device::read_onespace_bus(offs_t offset)
 
 u8 nes_vt32_soc_device::spr_r(offs_t offset)
 {
-	if (m_4242 & 0x1 || m_411d & 0x04)
+	if (m_4242 & 0x1 || m_411d & 0x04) // VT32 only?
 	{
 		return m_chrram[offset & 0x1fff];
 	}
@@ -52,7 +52,7 @@ u8 nes_vt32_soc_device::spr_r(offs_t offset)
 
 u8 nes_vt32_soc_device::chr_r(offs_t offset)
 {
-	if (m_4242 & 0x1 || m_411d & 0x04) // newer VT platforms only (not VT03/09), split out
+	if (m_4242 & 0x1 || m_411d & 0x04) // VT32 only?
 	{
 		return m_chrram[offset & 0x1fff];
 	}

--- a/src/mame/nintendo/nes_vt32_soc.cpp
+++ b/src/mame/nintendo/nes_vt32_soc.cpp
@@ -149,14 +149,14 @@ u8 nes_vt32_soc_device::vtfp_412d_r()
 
 void nes_vt32_soc_device::vtfp_4242_w(u8 data)
 {
-	logerror("vtfp_4242_w %02x\n", data);
+	logerror("%s: vtfp_4242_w %02x\n", machine().describe_context(), data);
 	m_4242 = data;
 }
 
 void nes_vt32_soc_device::vtfp_411d_w(u8 data)
 {
 	// controls chram access and mapper emulation modes in later models
-	logerror("vtfp_411d_w  %02x\n", data);
+	logerror("%s: vtfp_411d_w  %02x\n", machine().describe_context(), data);
 	m_411d = data;
 	update_banks();
 }
@@ -212,22 +212,24 @@ void nes_vt32_soc_device::nes_vt32_soc_map(address_map &map)
 	map(0x2000, 0x2007).rw(m_ppu, FUNC(ppu2c0x_device::read), FUNC(ppu2c0x_device::write)); // standard PPU registers
 
 	// 2010 - 201f are extended regs, and can differ between VT models
-	map(0x2010, 0x2010).rw(m_ppu, FUNC(ppu_vt03_device::extended_modes_enable_r), FUNC(ppu_vt03_device::extended_modes_enable_w));
-	map(0x2011, 0x2011).rw(m_ppu, FUNC(ppu_vt03_device::extended_modes2_enable_r), FUNC(ppu_vt03_device::extended_modes2_enable_w));
-	map(0x2012, 0x2012).rw(m_ppu, FUNC(ppu_vt03_device::videobank0_0_r), FUNC(ppu_vt03_device::videobank0_0_w));
-	map(0x2013, 0x2013).rw(m_ppu, FUNC(ppu_vt03_device::videobank0_1_r), FUNC(ppu_vt03_device::videobank0_1_w));
-	map(0x2014, 0x2014).rw(m_ppu, FUNC(ppu_vt03_device::videobank0_2_r), FUNC(ppu_vt03_device::videobank0_2_w));
-	map(0x2015, 0x2015).rw(m_ppu, FUNC(ppu_vt03_device::videobank0_3_r), FUNC(ppu_vt03_device::videobank0_3_w));
-	map(0x2016, 0x2016).rw(m_ppu, FUNC(ppu_vt03_device::videobank0_4_r), FUNC(ppu_vt03_device::videobank0_4_w));
-	map(0x2017, 0x2017).rw(m_ppu, FUNC(ppu_vt03_device::videobank0_5_r), FUNC(ppu_vt03_device::videobank0_5_w));
-	map(0x2018, 0x2018).rw(m_ppu, FUNC(ppu_vt03_device::videobank1_r), FUNC(ppu_vt03_device::videobank1_w));
-	map(0x2019, 0x2019).rw(m_ppu, FUNC(ppu_vt03_device::unk_2019_r), FUNC(ppu_vt03_device::gun_reset_w));
-	map(0x201a, 0x201a).rw(m_ppu, FUNC(ppu_vt03_device::videobank0_extra_r), FUNC(ppu_vt03_device::videobank0_extra_w));
-	map(0x201b, 0x201b).r(m_ppu, FUNC(ppu_vt03_device::unk_201b_r));
-	map(0x201c, 0x201c).r(m_ppu, FUNC(ppu_vt03_device::gun_x_r));
-	map(0x201d, 0x201d).r(m_ppu, FUNC(ppu_vt03_device::gun_y_r));
-	map(0x201e, 0x201e).r(m_ppu, FUNC(ppu_vt03_device::gun2_x_r));
-	map(0x201f, 0x201f).r(m_ppu, FUNC(ppu_vt03_device::gun2_y_r));
+	map(0x2010, 0x2010).rw(m_ppu, FUNC(ppu_vt32_device::extended_modes_enable_r), FUNC(ppu_vt32_device::extended_modes_enable_w));
+	map(0x2011, 0x2011).rw(m_ppu, FUNC(ppu_vt32_device::extended_modes2_enable_r), FUNC(ppu_vt32_device::extended_modes2_enable_w));
+	map(0x2012, 0x2012).rw(m_ppu, FUNC(ppu_vt32_device::videobank0_0_r), FUNC(ppu_vt32_device::videobank0_0_w));
+	map(0x2013, 0x2013).rw(m_ppu, FUNC(ppu_vt32_device::videobank0_1_r), FUNC(ppu_vt32_device::videobank0_1_w));
+	map(0x2014, 0x2014).rw(m_ppu, FUNC(ppu_vt32_device::videobank0_2_r), FUNC(ppu_vt32_device::videobank0_2_w));
+	map(0x2015, 0x2015).rw(m_ppu, FUNC(ppu_vt32_device::videobank0_3_r), FUNC(ppu_vt32_device::videobank0_3_w));
+	map(0x2016, 0x2016).rw(m_ppu, FUNC(ppu_vt32_device::videobank0_4_r), FUNC(ppu_vt32_device::videobank0_4_w));
+	map(0x2017, 0x2017).rw(m_ppu, FUNC(ppu_vt32_device::videobank0_5_r), FUNC(ppu_vt32_device::videobank0_5_w));
+	map(0x2018, 0x2018).rw(m_ppu, FUNC(ppu_vt32_device::videobank1_r), FUNC(ppu_vt32_device::videobank1_w));
+	map(0x2019, 0x2019).rw(m_ppu, FUNC(ppu_vt32_device::unk_2019_r), FUNC(ppu_vt32_device::gun_reset_w));
+	map(0x201a, 0x201a).rw(m_ppu, FUNC(ppu_vt32_device::videobank0_extra_r), FUNC(ppu_vt32_device::videobank0_extra_w));
+	map(0x201b, 0x201b).rw(m_ppu, FUNC(ppu_vt32_device::unk_201b_r), FUNC(ppu_vt32_device::vt32_extvid_201b_w));
+	map(0x201c, 0x201c).rw(m_ppu, FUNC(ppu_vt32_device::gun_x_r), FUNC(ppu_vt32_device::vt32_extvid_201c_w));
+	map(0x201d, 0x201d).rw(m_ppu, FUNC(ppu_vt32_device::gun_y_r), FUNC(ppu_vt32_device::vt32_extvid_201d_w));
+	map(0x201e, 0x201e).r(m_ppu, FUNC(ppu_vt32_device::gun2_x_r));
+	map(0x201f, 0x201f).r(m_ppu, FUNC(ppu_vt32_device::gun2_y_r));
+
+	map(0x2040, 0x2049).nopw();// w(m_ppu, FUNC(ppu_vt3xx_device::lcdc_regs_w)); // LCD control like on VT369?
 
 	map(0x4000, 0x4017).w(m_apu, FUNC(nes_apu_vt_device::write));
 	map(0x4014, 0x4014).w(FUNC(nes_vt32_soc_device::vt_dma_w));
@@ -256,7 +258,10 @@ void nes_vt32_soc_device::nes_vt32_soc_map(address_map &map)
 	map(0x414a, 0x414a).r(FUNC(nes_vt32_soc_device::vthh_414a_r));
 
 	map(0x412c, 0x412c).w(FUNC(nes_vt32_soc_device::vtfp_412c_extbank_w)); // GPIO
-	map(0x412d, 0x412d).r(FUNC(nes_vt32_soc_device::vtfp_412d_r)); // GPIO
+	map(0x412d, 0x412d).r(FUNC(nes_vt32_soc_device::vtfp_412d_r)).nopw(); // GPIO
+
+	map(0x4141, 0x4141).nopw(); // ??
+	map(0x4142, 0x4142).nopw(); // ??
 
 	map(0x4242, 0x4242).w(FUNC(nes_vt32_soc_device::vtfp_4242_w));
 

--- a/src/mame/nintendo/nes_vt32_soc.cpp
+++ b/src/mame/nintendo/nes_vt32_soc.cpp
@@ -25,6 +25,13 @@ nes_vt32_soc_pal_device::nes_vt32_soc_pal_device(const machine_config& mconfig, 
 {
 }
 
+
+u8 nes_vt32_soc_device::read_onespace_bus(offs_t offset)
+{
+	address_space& spc = this->space(AS_PROGRAM);
+	return spc.read_byte(offset);
+}
+
 void nes_vt32_soc_device::device_add_mconfig(machine_config& config)
 {
 	RP2A03_VTSCR(config, m_maincpu, NTSC_APU_CLOCK);
@@ -44,6 +51,8 @@ void nes_vt32_soc_device::device_add_mconfig(machine_config& config)
 	m_ppu->read_bg().set(FUNC(nes_vt32_soc_device::chr_r));
 	m_ppu->read_sp().set(FUNC(nes_vt32_soc_device::spr_r));
 	m_ppu->set_screen(m_screen);
+	m_ppu->read_onespace().set(FUNC(nes_vt32_soc_device::read_onespace_bus));
+
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/nintendo/nes_vt32_soc.cpp
+++ b/src/mame/nintendo/nes_vt32_soc.cpp
@@ -205,6 +205,41 @@ void nes_vt32_soc_device::scrambled_8000_w(u16 offset, u8 data)
 }
 
 
+u8 nes_vt32_soc_device::vt32_palette_r(offs_t offset)
+{
+	if (offset < 0x100)
+	{
+		// can the usual nametable mirroring be enabled?
+		//return nt_r(offset + 0x3e00);
+		return m_ppu->vt3xx_extended_palette_r(offset);
+	}
+	else
+	{
+		return m_ppu->palette_read(offset - 0x100);
+	}
+}
+
+void nes_vt32_soc_device::vt32_palette_w(offs_t offset, u8 data)
+{
+	if (offset < 0x100)
+	{
+		// can the usual nametable mirroring be enabled?
+		//nt_w(offset + 0x3e00, data);
+		m_ppu->vt3xx_extended_palette_w(offset, data);
+	}
+	else
+	{
+		m_ppu->palette_write(offset - 0x100, data);
+	}	
+}
+
+void nes_vt32_soc_device::device_start()
+{
+	nes_vt09_soc_device::device_start();
+	m_ppu->space(AS_PROGRAM).install_readwrite_handler(0x3e00, 0x3fff, read8sm_delegate(*this, FUNC(nes_vt32_soc_device::vt32_palette_r)), write8sm_delegate(*this, FUNC(nes_vt32_soc_device::vt32_palette_w)));
+}
+
+
 void nes_vt32_soc_device::nes_vt32_soc_map(address_map &map)
 {
 	map(0x0000, 0x1fff).ram(); // .mask(0x0fff).ram();
@@ -223,9 +258,9 @@ void nes_vt32_soc_device::nes_vt32_soc_map(address_map &map)
 	map(0x2018, 0x2018).rw(m_ppu, FUNC(ppu_vt32_device::videobank1_r), FUNC(ppu_vt32_device::videobank1_w));
 	map(0x2019, 0x2019).rw(m_ppu, FUNC(ppu_vt32_device::unk_2019_r), FUNC(ppu_vt32_device::gun_reset_w));
 	map(0x201a, 0x201a).rw(m_ppu, FUNC(ppu_vt32_device::videobank0_extra_r), FUNC(ppu_vt32_device::videobank0_extra_w));
-	map(0x201b, 0x201b).rw(m_ppu, FUNC(ppu_vt32_device::unk_201b_r), FUNC(ppu_vt32_device::vt32_extvid_201b_w));
-	map(0x201c, 0x201c).rw(m_ppu, FUNC(ppu_vt32_device::gun_x_r), FUNC(ppu_vt32_device::vt32_extvid_201c_w));
-	map(0x201d, 0x201d).rw(m_ppu, FUNC(ppu_vt32_device::gun_y_r), FUNC(ppu_vt32_device::vt32_extvid_201d_w));
+	map(0x201b, 0x201b).rw(m_ppu, FUNC(ppu_vt32_device::unk_201b_r), FUNC(ppu_vt32_device::m_newvid_1b_w));
+	map(0x201c, 0x201c).rw(m_ppu, FUNC(ppu_vt32_device::gun_x_r), FUNC(ppu_vt32_device::m_newvid_1c_w));
+	map(0x201d, 0x201d).rw(m_ppu, FUNC(ppu_vt32_device::gun_y_r), FUNC(ppu_vt32_device::m_newvid_1d_w));
 	map(0x201e, 0x201e).r(m_ppu, FUNC(ppu_vt32_device::gun2_x_r));
 	map(0x201f, 0x201f).r(m_ppu, FUNC(ppu_vt32_device::gun2_y_r));
 

--- a/src/mame/nintendo/nes_vt32_soc.cpp
+++ b/src/mame/nintendo/nes_vt32_soc.cpp
@@ -230,6 +230,9 @@ void nes_vt32_soc_device::vt32_palette_w(offs_t offset, u8 data)
 	else
 	{
 		m_ppu->palette_write(offset - 0x100, data);
+		// also store an unmodified copy of the data written (no mirroring etc.) for rendering use
+		// it isn't clear how the hardware does this
+		m_ppu->vt3xx_extended_palette_w(offset, data);
 	}	
 }
 

--- a/src/mame/nintendo/nes_vt32_soc.h
+++ b/src/mame/nintendo/nes_vt32_soc.h
@@ -24,6 +24,7 @@ public:
 
 protected:
 	virtual void device_start() override;
+	virtual void device_reset() override;
 
 	nes_vt32_soc_device(const machine_config& mconfig, device_type type, const char* tag, device_t* owner, u32 clock);
 
@@ -43,10 +44,14 @@ protected:
 	void vtfp_4a00_w(u8 data);
 	void vtfp_411d_w(u8 data);
 	u8 vthh_414a_r();
+	virtual u8 spr_r(offs_t offset) override;
+	virtual u8 chr_r(offs_t offset) override;
 
 private:
 	u8 vt32_palette_r(offs_t offset);
 	void vt32_palette_w(offs_t offset, u8 data);
+
+	int m_ppu_chr_data_scramble;
 };
 
 class nes_vt32_soc_pal_device : public nes_vt32_soc_device

--- a/src/mame/nintendo/nes_vt32_soc.h
+++ b/src/mame/nintendo/nes_vt32_soc.h
@@ -48,6 +48,8 @@ public:
 
 protected:
 	virtual void device_add_mconfig(machine_config& config) override ATTR_COLD;
+
+	virtual void do_pal_timings_and_ppu_replacement(machine_config& config) override;
 };
 
 

--- a/src/mame/nintendo/nes_vt32_soc.h
+++ b/src/mame/nintendo/nes_vt32_soc.h
@@ -23,6 +23,8 @@ public:
 	nes_vt32_soc_device(const machine_config& mconfig, const char* tag, device_t* owner, u32 clock);
 
 protected:
+	virtual void device_start() override;
+
 	nes_vt32_soc_device(const machine_config& mconfig, device_type type, const char* tag, device_t* owner, u32 clock);
 
 	virtual void device_add_mconfig(machine_config& config) override ATTR_COLD;
@@ -41,6 +43,10 @@ protected:
 	void vtfp_4a00_w(u8 data);
 	void vtfp_411d_w(u8 data);
 	u8 vthh_414a_r();
+
+private:
+	u8 vt32_palette_r(offs_t offset);
+	void vt32_palette_w(offs_t offset, u8 data);
 };
 
 class nes_vt32_soc_pal_device : public nes_vt32_soc_device

--- a/src/mame/nintendo/nes_vt32_soc.h
+++ b/src/mame/nintendo/nes_vt32_soc.h
@@ -29,6 +29,8 @@ protected:
 
 	void nes_vt32_soc_map(address_map &map) ATTR_COLD;
 
+	virtual void scrambled_8000_w(u16 offset, u8 data) override;
+
 	u8 vtfp_4119_r();
 	void vtfp_411e_encryption_state_w(u8 data);
 	void vtfp_412c_extbank_w(u8 data);

--- a/src/mame/nintendo/nes_vt32_soc.h
+++ b/src/mame/nintendo/nes_vt32_soc.h
@@ -31,6 +31,8 @@ protected:
 
 	virtual void scrambled_8000_w(u16 offset, u8 data) override;
 
+	u8 read_onespace_bus(offs_t offset);
+
 	u8 vtfp_4119_r();
 	void vtfp_411e_encryption_state_w(u8 data);
 	void vtfp_412c_extbank_w(u8 data);

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -179,7 +179,6 @@ public:
 
 	void vt369_unk(machine_config& config);
 	void vt369_unk_1mb(machine_config& config);
-	void vt369_unk_4mb(machine_config& config);
 	void vt369_unk_16mb(machine_config& config);
 
 };
@@ -479,13 +478,6 @@ void vt36x_state::vt369_unk_1mb(machine_config& config)
 	vt369_unk(config);
 	m_soc->set_addrmap(AS_PROGRAM, &vt36x_state::vt_external_space_map_1mbyte);
 }
-
-void vt36x_state::vt369_unk_4mb(machine_config& config)
-{
-	vt369_unk(config);
-	m_soc->set_addrmap(AS_PROGRAM, &vt36x_state::vt_external_space_map_4mbyte);
-}
-
 
 
 // New mystery handheld architecture, VTxx derived
@@ -1316,7 +1308,7 @@ CONS( 201?, rd5_240,    0,        0,  vt36x_8mb, vt369, vt36x_state, empty_init,
 CONS( 201?, hkb502,   0,      0,  vt36x_4mb, vt369, vt36x_state, empty_init, "<unknown>", "HKB-502 268-in-1 (set 1)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 CONS( 201?, hkb502a,  hkb502, 0,  vt36x_4mb, vt369, vt36x_state, empty_init, "<unknown>", "HKB-502 268-in-1 (set 2)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 // similar to above, fewer games in menu
-CONS( 2021, unk128vt, 0,      0,  vt369_unk_4mb, vt369, vt36x_state, empty_init, "<unknown>", "unknown VT369 based 128-in-1 (GC31-369-20210702-V2)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+CONS( 2021, unk128vt, 0,      0,  vt36x_4mb, vt369, vt36x_state, empty_init, "<unknown>", "unknown VT369 based 128-in-1 (GC31-369-20210702-V2)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 
 // uses a LCD with resolution of 160x128 (image scaled to fit for some games, others run natively at 160x128)
 // contains a protection chip, command 80 XX returns a byte
@@ -1332,7 +1324,7 @@ CONS( 201?, myarccn,   0, 0,  vt36x_1mb, vt369, vt36x_state, empty_init, "DreamG
 CONS( 201?, denv150,   0,        0,  vt36x_8mb, vt369, vt36x_state, empty_init, "Denver", "Denver Game Console GMP-240C 150-in-1", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 CONS( 201?, egame150,  denv150,  0,  vt36x_8mb, vt369, vt36x_state, empty_init, "<unknown>", "E-Game! 150-in-1", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 
-// uncertain, uses SPI ROM so probably VT369, has extra protection?
+// uncertain, uses SPI ROM so probably VT369, has extra protection? (but RAM test goes up to 0x2000, over the internal ROM area?)
 CONS( 2017, otrail,     0,        0,  vt369_unk_1mb, vt369, vt36x_state, empty_init, "Basic Fun", "The Oregon Trail", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 
 // has extra protection?

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -163,6 +163,7 @@ public:
 	void vt36x_16mb(machine_config& config);
 	void vt36x_32mb(machine_config& config);
 	void vt36x_32mb_2banks_lexi(machine_config& config);
+	void vt36x_32mb_2banks_lexi300(machine_config& config);
 
 	void vt36x_swap(machine_config& config);
 	void vt36x_swap_2mb(machine_config& config);
@@ -615,6 +616,13 @@ void vt36x_state::vt36x_32mb_2banks_lexi(machine_config& config)
 	m_soc->set_4150_write_cb().set(FUNC(vt36x_state::extbank_w));
 }
 
+void vt36x_state::vt36x_32mb_2banks_lexi300(machine_config& config)
+{
+	vt36x_32mb(config);
+	m_soc->set_addrmap(AS_PROGRAM, &vt36x_state::vt_external_space_map_32mbyte_bank);
+	m_soc->set_411e_write_cb().set(FUNC(vt36x_state::extbank_w)); // could be on 411d
+}
+
 static INPUT_PORTS_START( vt369 )
 	PORT_START("IO0")
 	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER(1) PORT_NAME("A")
@@ -729,7 +737,14 @@ ROM_END
 ROM_START( rtvgc300 )
 	ROM_REGION( 0x8000000, "mainrom", 0 )
 	// some of the higher address lines might be swapped
-	ROM_LOAD( "lexibook300.bin", 0x00000, 0x4000000, CRC(015c4067) SHA1(a12986c4a366a23c4c7ca7b3d33e421a8dfdffc0) )
+	ROM_LOAD( "lexibook300.bin", 0x00000, 0x0800000, CRC(015c4067) SHA1(a12986c4a366a23c4c7ca7b3d33e421a8dfdffc0) )
+	ROM_CONTINUE(0x1000000, 0x0800000)
+	ROM_CONTINUE(0x0800000, 0x0800000)
+	ROM_CONTINUE(0x1800000, 0x0800000)
+	ROM_CONTINUE(0x2000000, 0x0800000)
+	ROM_CONTINUE(0x3000000, 0x0800000)
+	ROM_CONTINUE(0x2800000, 0x0800000)
+	ROM_CONTINUE(0x3800000, 0x0800000)
 
 	VT3XX_INTERNAL_NO_SWAP // not verified for this set, used for testing
 ROM_END
@@ -774,6 +789,7 @@ ROM_START( lxcmcysw ) // all games selectable
 	ROM_CONTINUE(0x3000000, 0x0800000)
 	ROM_CONTINUE(0x2800000, 0x0800000)
 	ROM_CONTINUE(0x3800000, 0x0800000)
+
 	VT3XX_INTERNAL_NO_SWAP // not verified for this set, used for testing
 ROM_END
 
@@ -1196,8 +1212,8 @@ CONS( 200?, lxcmcy,    0,  0,  vt36x_32mb_2banks_lexi, vt369, vt36x_state, empty
 CONS( 2012, dgun2561,  0,  0,  vt36x_32mb_2banks_lexi, vt369, vt36x_state, empty_init, "dreamGEAR", "My Arcade Portable Gaming System with 140 Games (DGUN-2561)", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
 
 // GB-NO13-Main-VT389-2 on PCBs - uses higher resolution mode (twice usual h-res?)
-CONS( 2016, rtvgc300,  0,  0,  vt36x_32mb_2banks_lexi, vt369, vt36x_state, empty_init,    "Lexibook", "Retro TV Game Console - 300 Games", MACHINE_NOT_WORKING )
-CONS( 2017, rtvgc300fz,0,  0,  vt36x_32mb_2banks_lexi, vt369, vt36x_state, empty_init,    "Lexibook", "Retro TV Game Console - Frozen - 300 Games", MACHINE_NOT_WORKING )
+CONS( 2016, rtvgc300,  0,  0,  vt36x_32mb_2banks_lexi300, vt369, vt36x_state, empty_init,    "Lexibook", "Retro TV Game Console - 300 Games", MACHINE_NOT_WORKING )
+CONS( 2017, rtvgc300fz,0,  0,  vt36x_32mb_2banks_lexi300, vt369, vt36x_state, empty_init,    "Lexibook", "Retro TV Game Console - Frozen - 300 Games", MACHINE_NOT_WORKING )
 
 
 /* The following are also confirmed to be NES/VT derived units, most having a standard set of games with a handful of lazy graphic mods thrown in to fit the unit theme

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -730,12 +730,16 @@ ROM_START( rtvgc300 )
 	ROM_REGION( 0x8000000, "mainrom", 0 )
 	// some of the higher address lines might be swapped
 	ROM_LOAD( "lexibook300.bin", 0x00000, 0x4000000, CRC(015c4067) SHA1(a12986c4a366a23c4c7ca7b3d33e421a8dfdffc0) )
+
+	VT3XX_INTERNAL_NO_SWAP // not verified for this set, used for testing
 ROM_END
 
 ROM_START( rtvgc300fz )
 	ROM_REGION( 0x8000000, "mainrom", 0 )
 	// some of the higher address lines might be swapped
 	ROM_LOAD( "jg7800fz.bin", 0x00000, 0x4000000, CRC(c9d319d2) SHA1(9d0d1435b802f63ce11b94ce54d11f4065b324cc) )
+
+	VT3XX_INTERNAL_NO_SWAP // not verified for this set, used for testing
 ROM_END
 
 
@@ -1192,8 +1196,8 @@ CONS( 200?, lxcmcy,    0,  0,  vt36x_32mb_2banks_lexi, vt369, vt36x_state, empty
 CONS( 2012, dgun2561,  0,  0,  vt36x_32mb_2banks_lexi, vt369, vt36x_state, empty_init, "dreamGEAR", "My Arcade Portable Gaming System with 140 Games (DGUN-2561)", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
 
 // GB-NO13-Main-VT389-2 on PCBs - uses higher resolution mode (twice usual h-res?)
-CONS( 2016, rtvgc300,  0,  0,  vt36x_16mb, vt369, vt36x_state, empty_init,    "Lexibook", "Retro TV Game Console - 300 Games", MACHINE_NOT_WORKING )
-CONS( 2017, rtvgc300fz,0,  0,  vt36x_16mb, vt369, vt36x_state, empty_init,    "Lexibook", "Retro TV Game Console - Frozen - 300 Games", MACHINE_NOT_WORKING )
+CONS( 2016, rtvgc300,  0,  0,  vt36x_32mb_2banks_lexi, vt369, vt36x_state, empty_init,    "Lexibook", "Retro TV Game Console - 300 Games", MACHINE_NOT_WORKING )
+CONS( 2017, rtvgc300fz,0,  0,  vt36x_32mb_2banks_lexi, vt369, vt36x_state, empty_init,    "Lexibook", "Retro TV Game Console - Frozen - 300 Games", MACHINE_NOT_WORKING )
 
 
 /* The following are also confirmed to be NES/VT derived units, most having a standard set of games with a handful of lazy graphic mods thrown in to fit the unit theme

--- a/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
@@ -272,6 +272,8 @@ void vt3xx_soc_base_device::vt369_map(address_map &map)
 	// 0x411a RS232 TX data
 	// 0x411b RS232 RX data
 	map(0x411c, 0x411c).w(FUNC(vt3xx_soc_base_device::vt369_411c_bank6000_enable_w));
+	map(0x411d, 0x411d).w(FUNC(vt3xx_soc_base_device::vt369_411d_w));
+	map(0x411e, 0x411e).w(FUNC(vt3xx_soc_base_device::vt369_411e_w));
 
 	// 412d
 
@@ -565,6 +567,22 @@ void vt3xx_soc_base_device::vt369_411c_bank6000_enable_w(offs_t offset, u8 data)
 	m_bank6000_enable = data;
 }
 
+void vt3xx_soc_base_device::vt369_411d_w(offs_t offset, u8 data)
+{
+	// controls chram access and mapper emulation modes in later models
+	// also written by rtvgc300 and rtvgc300fz (with the same value as 411e)
+	// when external banking is needed?
+	logerror("%s: vt369_411d_w  %02x\n", machine().describe_context(), data);
+	m_411d = data;
+	update_banks();
+}
+
+void vt3xx_soc_base_device::vt369_411e_w(offs_t offset, u8 data)
+{
+	logerror("%s: vt369_411e_w (%02x) (external bankswitch + more?)\n", machine().describe_context(), data);
+	m_411e_write_cb(data); 
+}
+
 
 void vt3xx_soc_base_device::vt369_4112_bank6000_select_w(offs_t offset, u8 data)
 {
@@ -761,13 +779,6 @@ void vt369_soc_introm_noswap_device::device_start()
 	m_encryption_allowed = false;
 }
 
-void vt369_soc_introm_noswap_device::vtfp_411d_w(u8 data)
-{
-	// controls chram access and mapper emulation modes in later models
-	logerror("vtfp_411d_w  %02x\n", data);
-	m_411d = data;
-	update_banks();
-}
 
 u8 vt369_soc_introm_noswap_device::vthh_414a_r()
 {
@@ -783,7 +794,6 @@ void vt369_soc_introm_noswap_device::vt369_introm_map(address_map &map)
 	map(0x1000, 0x1fff).r(FUNC(vt369_soc_introm_noswap_device::read_internal));
 
 	map(0x414a, 0x414a).r(FUNC(vt369_soc_introm_noswap_device::vthh_414a_r));
-	map(0x411d, 0x411d).w(FUNC(vt369_soc_introm_noswap_device::vtfp_411d_w));
 
 	map(0x4169, 0x4169).w(FUNC(vt369_soc_introm_noswap_device::encryption_4169_w));
 }

--- a/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
@@ -199,6 +199,21 @@ void vt3xx_soc_base_device::alu_w(offs_t offset, u8 data)
 	}
 }
 
+void vt3xx_soc_base_device::highres_sprite_dma_w(u8 data)
+{
+	// is this correct? the rtvgc300 / rtvgc300fz don't appear to transfer the
+	// sprite data from main RAM to sprite RAM in any other way.
+	//
+	// do the high res sprites use their own spriteram, or does this go to the
+	// standard PPU spriteram?
+
+	for (int i = 0; i < 0x200; i++)
+	{
+		u8 read_data = m_maincpu->space(AS_PROGRAM).read_byte((data << 8) + i);
+		m_ppu->set_spriteram_value(i, read_data);
+	}
+}
+
 void vt3xx_soc_base_device::vt369_map(address_map &map)
 {
 	map(0x0000, 0x1fff).ram(); // 8k RAM?
@@ -288,6 +303,8 @@ void vt3xx_soc_base_device::vt369_map(address_map &map)
 	map(0x41b0, 0x41bf).r(FUNC(vt3xx_soc_base_device::vt369_41bx_r)).w(FUNC(vt3xx_soc_base_device::vt369_41bx_w));
 
 	map(0x41e6, 0x41e6).w(FUNC(vt3xx_soc_base_device::extra_io_41e6_w)); // banking on red5mam
+
+	map(0x4201, 0x4201).w(FUNC(vt3xx_soc_base_device::highres_sprite_dma_w));
 
 	// 4304
 

--- a/src/mame/nintendo/nes_vt369_vtunknown_soc.h
+++ b/src/mame/nintendo/nes_vt369_vtunknown_soc.h
@@ -52,6 +52,8 @@ protected:
 	u8 vt369_6000_r(offs_t offset);
 	void vt369_6000_w(offs_t offset, u8 data);
 
+	void highres_sprite_dma_w(u8 data);
+
 	void vt369_soundcpu_control_w(offs_t offset, u8 data);
 	void vt369_4112_bank6000_select_w(offs_t offset, u8 data);
 	void vt369_411c_bank6000_enable_w(offs_t offset, u8 data);

--- a/src/mame/nintendo/nes_vt369_vtunknown_soc.h
+++ b/src/mame/nintendo/nes_vt369_vtunknown_soc.h
@@ -57,6 +57,8 @@ protected:
 	void vt369_soundcpu_control_w(offs_t offset, u8 data);
 	void vt369_4112_bank6000_select_w(offs_t offset, u8 data);
 	void vt369_411c_bank6000_enable_w(offs_t offset, u8 data);
+	void vt369_411d_w(offs_t offset, u8 data);
+	void vt369_411e_w(offs_t offset, u8 data);
 	void vt369_relative_w(offs_t offset, u8 data);
 
 	u8 read_internal(offs_t offset);
@@ -145,7 +147,6 @@ protected:
 	void vt369_introm_map(address_map &map) ATTR_COLD;
 
 	u8 vthh_414a_r();
-	void vtfp_411d_w(u8 data);
 	void encryption_4169_w(u8 data);
 
 	bool m_encryption_allowed;

--- a/src/mame/nintendo/nes_vt_soc.cpp
+++ b/src/mame/nintendo/nes_vt_soc.cpp
@@ -425,32 +425,18 @@ void nes_vt02_vt03_soc_device::scrambled_410x_w(u16 offset, u8 data)
 
 u8 nes_vt02_vt03_soc_device::spr_r(offs_t offset)
 {
-	if (m_4242 & 0x1 || m_411d & 0x04)
-	{
-		return m_chrram[offset & 0x1fff];
-	}
-	else
-	{
-		int realaddr = calculate_real_video_address(offset, 1);
+	int realaddr = calculate_real_video_address(offset, 1);
 
-		address_space& spc = this->space(AS_PROGRAM);
-		return spc.read_byte(get_relative() + realaddr);
-	}
+	address_space& spc = this->space(AS_PROGRAM);
+	return spc.read_byte(get_relative() + realaddr);
 }
 
 u8 nes_vt02_vt03_soc_device::chr_r(offs_t offset)
 {
-	if (m_4242 & 0x1 || m_411d & 0x04) // newer VT platforms only (not VT03/09), split out
-	{
-		return m_chrram[offset & 0x1fff];
-	}
-	else
-	{
-		int realaddr = calculate_real_video_address(offset, 0);
+	int realaddr = calculate_real_video_address(offset, 0);
 
-		address_space& spc = this->space(AS_PROGRAM);
-		return spc.read_byte(get_relative() + realaddr);
-	}
+	address_space& spc = this->space(AS_PROGRAM);
+	return spc.read_byte(get_relative() + realaddr);
 }
 
 

--- a/src/mame/nintendo/nes_vt_soc.cpp
+++ b/src/mame/nintendo/nes_vt_soc.cpp
@@ -511,22 +511,8 @@ void nes_vt02_vt03_soc_device::nt_w(offs_t offset, u8 data)
 }
 
 
-
-
-
-
-int nes_vt02_vt03_soc_device::calculate_real_video_address(int addr, int readtype)
+int nes_vt02_vt03_soc_device::calculate_va17_va10(int addr)
 {
-	// this is what gets passed in
-	//      00Pb bbtt tttt plll
-	//  P = plane3/4 select (4bpp modes)
-	//  p = plane0/1 select
-	//  l = tile line
-	//  b = tile number bits passed into banking
-	//  t = tile number (0x1ff tile number bits total)
-	int va34 = (addr & 0x6000) >> 13;
-	addr &= 0x1fff;
-
 	/*
 	Calculating TVA17 - TVA10
 
@@ -550,7 +536,6 @@ int nes_vt02_vt03_soc_device::calculate_real_video_address(int addr, int readtyp
 	m_r2017 = rv5x
 
 	*/
-	int finaladdr = 0;
 
 	int sel = (addr & 0x1c00) | ((m_410x[0x5] & 0x80) ? 0x2000 : 0x000);
 
@@ -631,6 +616,24 @@ int nes_vt02_vt03_soc_device::calculate_real_video_address(int addr, int readtyp
 	case 0x7: return -1;
 	}
 
+	return va17_va10;
+}
+
+
+int nes_vt02_vt03_soc_device::calculate_real_video_address(int addr, int readtype)
+{
+	// this is what gets passed in
+	//      00Pb bbtt tttt plll
+	//  P = plane3/4 select (4bpp modes)
+	//  p = plane0/1 select
+	//  l = tile line
+	//  b = tile number bits passed into banking
+	//  t = tile number (0x1ff tile number bits total)
+	int va34 = (addr & 0x6000) >> 13;
+	addr &= 0x1fff;
+
+	int va17_va10 = calculate_va17_va10(addr);
+
 	// Adjust where we actually read from for special modes
 
 	// might be a VT09 only feature (alt 4bpp mode?)
@@ -650,6 +653,8 @@ int nes_vt02_vt03_soc_device::calculate_real_video_address(int addr, int readtyp
 			extended = 1;
 		}
 	}
+
+	int finaladdr = 0;
 
 	if (!extended)
 	{

--- a/src/mame/nintendo/nes_vt_soc.cpp
+++ b/src/mame/nintendo/nes_vt_soc.cpp
@@ -86,6 +86,7 @@ nes_vt02_vt03_soc_device::nes_vt02_vt03_soc_device(const machine_config& mconfig
 	m_ntram(nullptr),
 	m_chrram(nullptr),
 	m_4150_write_cb(*this),
+	m_411e_write_cb(*this),
 	m_41e6_write_cb(*this),
 	m_space_config("program", ENDIANNESS_LITTLE, 8, 25, 0, address_map_constructor(FUNC(nes_vt02_vt03_soc_device::program_map), this)),
 	m_write_0_callback(*this),

--- a/src/mame/nintendo/nes_vt_soc.cpp
+++ b/src/mame/nintendo/nes_vt_soc.cpp
@@ -807,7 +807,7 @@ void nes_vt02_vt03_soc_device::scrambled_8000_w(u16 offset, u8 data)
 	else if ((addr >= 0xa000) && (addr < 0xc000) && !(addr & 0x01))
 	{
 		// Mirroring
-		m_410x[0x6] &= 0xFE;
+		m_410x[0x6] &= 0xfe;
 		m_410x[0x6] |= data & 0x01;
 	}
 	else if ((addr >= 0xa000) && (addr < 0xc000) && (addr & 0x01))

--- a/src/mame/nintendo/nes_vt_soc.h
+++ b/src/mame/nintendo/nes_vt_soc.h
@@ -22,6 +22,7 @@ public:
 	void vt03_8000_mapper_w(offs_t offset, u8 data);
 
 	auto set_4150_write_cb() { return m_4150_write_cb.bind(); }
+	auto set_411e_write_cb() { return m_411e_write_cb.bind(); }
 	auto set_41e6_write_cb() { return m_41e6_write_cb.bind(); }
 
 	// 8-bit ports
@@ -139,6 +140,7 @@ protected:
 
 
 	devcb_write8 m_4150_write_cb;
+	devcb_write8 m_411e_write_cb;
 	devcb_write8 m_41e6_write_cb;
 
 private:

--- a/src/mame/nintendo/nes_vt_soc.h
+++ b/src/mame/nintendo/nes_vt_soc.h
@@ -69,8 +69,8 @@ protected:
 	void vt03_410x_w(offs_t offset, u8 data);
 	u8 vt03_410x_r(offs_t offset);
 	void scrambled_410x_w(u16 offset, u8 data);
-	u8 spr_r(offs_t offset);
-	u8 chr_r(offs_t offset);
+	virtual u8 spr_r(offs_t offset);
+	virtual u8 chr_r(offs_t offset);
 	void chr_w(offs_t offset, u8 data);
 	void scanline_irq(int scanline, bool vblank, bool blanked);
 	void hblank_irq(int scanline, bool vblank, bool blanked);

--- a/src/mame/nintendo/nes_vt_soc.h
+++ b/src/mame/nintendo/nes_vt_soc.h
@@ -77,6 +77,7 @@ protected:
 	void video_irq(bool hblank, int scanline, bool vblank, bool blanked);
 	u8 nt_r(offs_t offset);
 	void nt_w(offs_t offset, u8 data);
+	int calculate_va17_va10(int addr);
 	int calculate_real_video_address(int addr, int readtype);
 	virtual void scrambled_8000_w(u16 offset, u8 data);
 	virtual void vt_dma_w(u8 data);

--- a/src/mame/nintendo/nes_vt_soc.h
+++ b/src/mame/nintendo/nes_vt_soc.h
@@ -103,7 +103,7 @@ protected:
 	// additional relative offset for everything on vt3xx sets (seems to address up to 32mbytes only still?)
 	int get_relative() { return (m_relative[0] + ((m_relative[1] & 0x0f) << 8)) * 0x2000; }
 
-	void do_pal_timings_and_ppu_replacement(machine_config& config);
+	virtual void do_pal_timings_and_ppu_replacement(machine_config& config);
 
 	u32 screen_update(screen_device& screen, bitmap_rgb32& bitmap, const rectangle& cliprect);
 

--- a/src/mame/nintendo/nes_vt_soc.h
+++ b/src/mame/nintendo/nes_vt_soc.h
@@ -78,7 +78,7 @@ protected:
 	u8 nt_r(offs_t offset);
 	void nt_w(offs_t offset, u8 data);
 	int calculate_real_video_address(int addr, int readtype);
-	void scrambled_8000_w(u16 offset, u8 data);
+	virtual void scrambled_8000_w(u16 offset, u8 data);
 	virtual void vt_dma_w(u8 data);
 	void do_dma(u8 data, bool has_ntsc_bug);
 	void vt03_4034_w(u8 data);


### PR DESCRIPTION
- added basic support for 'high resolution' mode on VT369 (currently renders at standard resolution, but the tiles used are now correct)
- added another new sprite mode, used in high res mode
- menus are now visible in rtvgc300, rtvgc300fz, background is visible on image match in lxcmcysp is visible
- moved some VT32 specific code to the VT32 device as it was preventing aero engine in the rtvgc300 sets from working
- split VT32 PPU into its own derived device
- added preliminary support for a new VT32 (or maybe a newer variant of it) specific(?) video mode used by lxpcsp and maybe a few others
- added VT32 specific support for a bitswap on PPU character data pulls used by some titles (some of the bonus games in myaasa etc.)
- improved a few notes