### PR TITLE
phc25: Invert cassette polarity.

### DIFF
--- a/src/lib/formats/phc25_cas.cpp
+++ b/src/lib/formats/phc25_cas.cpp
@@ -57,15 +57,15 @@ static int phc25_output_bit(int16_t *buffer, int sample_pos, bool bit)
 
 	if (bit)
 	{
-		samples += phc25_put_samples(buffer, sample_pos + samples, 2, WAVEENTRY_LOW);
 		samples += phc25_put_samples(buffer, sample_pos + samples, 2, WAVEENTRY_HIGH);
 		samples += phc25_put_samples(buffer, sample_pos + samples, 2, WAVEENTRY_LOW);
 		samples += phc25_put_samples(buffer, sample_pos + samples, 2, WAVEENTRY_HIGH);
+		samples += phc25_put_samples(buffer, sample_pos + samples, 2, WAVEENTRY_LOW);
 	}
 	else
 	{
-		samples += phc25_put_samples(buffer, sample_pos + samples, 4, WAVEENTRY_LOW);
 		samples += phc25_put_samples(buffer, sample_pos + samples, 4, WAVEENTRY_HIGH);
+		samples += phc25_put_samples(buffer, sample_pos + samples, 4, WAVEENTRY_LOW);
 	}
 
 	return samples;

--- a/src/mame/sanyo/phc25.cpp
+++ b/src/mame/sanyo/phc25.cpp
@@ -190,7 +190,7 @@ uint8_t phc25_state::port40_r()
 	data |= !m_vdg->fs_r() << 4;
 
 	/* cassette read */
-	data |= (m_cassette->input() < +0.3) << 5;
+	data |= (m_cassette->input() > +0.3) << 5;
 
 	/* centronics busy */
 	data |= m_centronics_busy << 6;
@@ -229,7 +229,7 @@ void phc25_state::port40_w(uint8_t data)
 	*/
 
 	/* cassette output */
-	m_cassette->output( BIT(data, 0) ? -1.0 : +1.0);
+	m_cassette->output( BIT(data, 0) ? +1.0 : -1.0);
 
 	/* cassette motor */
 	m_cassette->change_state(BIT(data, 1) ? CASSETTE_MOTOR_DISABLED : CASSETTE_MOTOR_ENABLED, CASSETTE_MASK_MOTOR);


### PR DESCRIPTION
### Description

When trying to load the WAV file produced by castool on a real phc-25, we noticed that the program is not detected and the loading fails.

We compared with a working WAV file and noticed that the baud polarity is inverted. If we invert the polarity in the WAV file produced by castool, then it loads correctly on real hardware.

### Change

This PR proposes to invert the cassette polarity both in the machine and in the format ; this is a noop for people loading a .phc file in MAME, but should fix using castool for the real target.

- [ ] ~~Tested the castool binary from CI with real hardware~~ Can't do because castool is not bundled in artifacts.