### PR TITLE
cpu/sharc: correctly align 32-bit data transfers using PM bus

### DIFF
--- a/src/devices/cpu/sharc/sharcmem.hxx
+++ b/src/devices/cpu/sharc/sharcmem.hxx
@@ -10,8 +10,7 @@ uint32_t adsp21062_device::pm_read32(uint32_t address)
 
 void adsp21062_device::pm_write32(uint32_t address, uint32_t data)
 {
-	u64 res = ((u64)data << 16) | (m_program->read_qword(address) & 0xffff);
-	m_program->write_qword(address, res);
+	m_program->write_qword(address, (u64)data << 16, 0xffffffff0000);
 }
 
 uint64_t adsp21062_device::pm_read48(uint32_t address)


### PR DESCRIPTION
Both Fighting Vipers and Sonic the Fighters will occasionally write values to internal memory using the DM (data memory) bus, and then try to read them back using the PM (program memory) bus; these were not being aligned correctly, resulting in corrupted values and ultimately leading to the "glitchy polygons" bug for certain characters.

According to the [ADSP-21062 manual](https://www.analog.com/media/en/dsp-documentation/processor-manuals/50836807228561adsp2106xsharcprocessorusersmanual_revision2_1.pdf) (page 5-5), 32-bit memory transfers using the PM bus are aligned to the upper 32 bits of the bus, whereas the existing code aligns it to the lower 32 bits; my fix correctly aligns data to the upper 32-bits of the PM bus for both 32-bit reads and writes by performing a QWORD access, as is used for 48-bit transfers, and shifting left or right by 16 bits accordingly.

Without having intricate knowledge of MAME's memory mapping code, I am uncertain if there is a way to set up the memory map so that 32-bit transfers automatically align to the upper 32 bits of the PM bus rather than having to do it manually as my implementation does; if there is, I welcome an alternative implementation.