### PR TITLE
taitotz.cpp: mark raizpinj HDD as BAD_DUMP

### DIFF
--- a/src/mame/taito/taitotz.cpp
+++ b/src/mame/taito/taitotz.cpp
@@ -2870,7 +2870,7 @@ ROM_START( raizpinj )
 	ROM_LOAD( "e68-01.ic7", 0x000000, 0x010000, NO_DUMP )
 
 	DISK_REGION( "ata:0:hdd" )
-	DISK_IMAGE( "raizin ping pong ver 2.01j", 0, SHA1(eddc803c2507d19f0a3e3cc217bb22a565c04f3e) )
+	DISK_IMAGE( "raizin ping pong ver 2.01j", BAD_DUMP, SHA1(eddc803c2507d19f0a3e3cc217bb22a565c04f3e) )
 ROM_END
 
 ROM_START( styphp )


### PR DESCRIPTION
According to [mokonaXVI:](https://www.youtube.com/watch?v=hdL0qHdppng)
>TATIO Type-Zero HDD for MAMEemu.
>of raizin ping pong ver 2.01j.chd (CRC32: 29BD7716)
>seems to be a bad dump.
>The SYSROM (v1.52 BIOS on HDD) did not match the files shipped 
>with other Type-Zero games.
>Other files seem to be worm-eaten as well.

Mokona also informed Guru about the issue, and I mentioned it in the batlgr2a PR (#13691), but I forgot to include that before that got merged.