### PR TITLE
phc25: fix cursor blinking too fast

### DIFF
--- a/src/mame/sanyo/phc25.cpp
+++ b/src/mame/sanyo/phc25.cpp
@@ -23,7 +23,6 @@
     - colours and graphics are different to those shown at
       http://www.phc25.com/collection.htm - who is correct?
     - screen attribute bit 7 is unknown in alphanumeric/semigraphics mode (0x6800-0x6BFF)
-    - cursor flashes too rapidly, maybe VDG FSYNC issue?
     - Japanese keyboard labels for phc25j.
 
     TODO: MAP-1010
@@ -67,7 +66,7 @@ public:
 		, m_vram(*this, "videoram")
 		, m_maincpu(*this, "maincpu")
 		, m_chargen(*this, "chargen")
-		, m_vdg(*this, "mc6847")
+		, m_vdg(*this, "m5c6847p1")
 		, m_centronics(*this, "centronics")
 		, m_cent_data_out(*this, "cent_data_out")
 		, m_cassette(*this, "cassette")
@@ -87,7 +86,7 @@ protected:
 	required_shared_ptr<uint8_t> m_vram;
 	required_device<cpu_device> m_maincpu;
 	required_region_ptr<uint8_t> m_chargen;
-	required_device<mc6847_base_device> m_vdg;
+	required_device<m5c6847p1_device> m_vdg;
 	required_device<centronics_device> m_centronics;
 	required_device<output_latch_device> m_cent_data_out;
 	required_device<cassette_image_device> m_cassette;
@@ -98,6 +97,7 @@ private:
 
 	uint8_t video_ram_r(offs_t offset);
 	MC6847_GET_CHARROM_MEMBER(char_rom_r);
+	void fsync_irq_w(int state);
 
 	uint8_t m_port40 = 0U;
 	int m_centronics_busy = 0;
@@ -603,6 +603,14 @@ MC6847_GET_CHARROM_MEMBER(phc25_state::char_rom_r)
 	return m_chargen[(ch * 16 + line) & 0xfff];
 }
 
+void phc25_state::fsync_irq_w(int state)
+{
+    if (state == 0)
+    {
+		m_maincpu->pulse_input_line(INPUT_LINE_IRQ0, attotime::from_usec(100));
+    }
+}
+
 void phc25_state::machine_reset()
 {
 	m_port40 = 0;
@@ -634,9 +642,9 @@ void phc25_state::phc25(machine_config &config)
 	/* video hardware */
 	SCREEN(config, "screen", SCREEN_TYPE_RASTER);
 
-	MC6847_PAL(config, m_vdg, XTAL(4'433'619));
+	M5C6847P1(config, m_vdg, XTAL(4'433'619));
 	m_vdg->set_screen("screen");
-	m_vdg->fsync_wr_callback().set_inputline(m_maincpu, INPUT_LINE_IRQ0).invert();
+	m_vdg->fsync_wr_callback().set(FUNC(phc25_state::fsync_irq_w));
 	m_vdg->input_callback().set(FUNC(phc25_state::video_ram_r));
 	m_vdg->set_get_char_rom(FUNC(phc25_state::char_rom_r));
 	m_vdg->set_get_fixed_mode(mc6847_pal_device::MODE_GM2 | mc6847_pal_device::MODE_GM1 | mc6847_pal_device::MODE_INTEXT);
@@ -670,7 +678,7 @@ void phc25_state::phc25j(machine_config &config)
 {
 	phc25(config);
 
-	MC6847_NTSC(config.replace(), m_vdg, XTAL(3'579'545));
+	M5C6847P1(config.replace(), m_vdg, XTAL(3'579'545));
 	m_vdg->set_screen("screen");
 	m_vdg->fsync_wr_callback().set_inputline(m_maincpu, INPUT_LINE_IRQ0).invert();
 	m_vdg->input_callback().set(FUNC(phc25_state::video_ram_r));


### PR DESCRIPTION
Two changes:
- change VDG to m5c6847p1 which is the processor used by PHC-25
- IRQ gets a pulse from fsync. The reason of fast blinking was that IRQ was asserted during whole fsync and ISR restarted four times during the time of assertion