### PR TITLE
cpu/m6800/m6801.cpp: Corrected the ICR read handlers.

### DIFF
--- a/src/devices/cpu/m6800/m6801.cpp
+++ b/src/devices/cpu/m6800/m6801.cpp
@@ -2217,12 +2217,12 @@ u8 m6801_cpu_device::icrh_r()
 	{
 		m_tcsr &= ~TCSR_ICF;
 	}
-	return (m_input_capture >> 0) & 0xff;
+	return (m_input_capture >> 8) & 0xff;
 }
 
 u8 m6801_cpu_device::icrl_r()
 {
-	return (m_input_capture >> 8) & 0xff;
+	return (m_input_capture >> 0) & 0xff;
 }
 
 


### PR DESCRIPTION
Noticed this because the tr707 uses the ICR to compute the displayed tempo. The issue can be reproduced in #13798: the tempo display is erratic. Applying this PR fixes it.

Sending as a separate PR because the modified code is used more broadly.

I verified that `icrh_r` and `icrl_r` are mapped to the correct addresses for the high and low bytes of the ICR respectively. But they were returning the low and high bytes instead.