### PR TITLE
model1/model 2: TGP sin/cos lookup tables

### DIFF
--- a/src/mame/sega/model1_m.cpp
+++ b/src/mame/sega/model1_m.cpp
@@ -183,8 +183,8 @@ u32 model1_state::copro_sincos_r(offs_t offset)
 {
 	offs_t ang = m_copro_sincos_base + offset * 0x4000;
 	offs_t index = ang & 0x3fff;
-	if(ang & 0x4000)
-		index ^= 0x3fff;
+	if (ang & 0x4000)
+		index = std::min(0x4000 - (int)index, 0x3fff);
 	u32 result = m_copro_tables[index];
 	if(ang & 0x8000)
 		result ^= 0x80000000;

--- a/src/mame/sega/model2.cpp
+++ b/src/mame/sega/model2.cpp
@@ -494,8 +494,8 @@ u32 model2_tgp_state::copro_sincos_r(offs_t offset)
 {
 	offs_t ang = m_copro_sincos_base + offset * 0x4000;
 	offs_t index = ang & 0x3fff;
-	if(ang & 0x4000)
-		index ^= 0x3fff;
+	if (ang & 0x4000)
+		index = std::min(0x4000 - (int)index, 0x3fff);
 	u32 result = m_copro_tgp_tables[index];
 	if(ang & 0x8000)
 		result ^= 0x80000000;


### PR DESCRIPTION
Calculating `index ^= 0x3fff` when `ang & 0x4000` was leading to results that were not always completely accurate; for example, calculating sin when ang = 0x2000 (equivalent to 45 degrees) gives a result of 0.70710677 which is accurate to single precision, but ang = 0x6000 (equivalent to 135 degrees) gives a result of 0.707039 which is very slightly off. This tiny error wasn't making any discernible difference in most games, but for some reason it was messing up Daytona; at very specific angles the player car would move sideways during a frame instead of forwards, and the camera would rotate to follow the car moving sideways:

![image](https://github.com/user-attachments/assets/31b302e2-16d9-4866-aa67-0aa37857b673)

Changing the calculation to `index = std::min(0x4000 - (int)index, 0x3fff)` makes it so the results are always accurate, and the above bug no longer occurs. Clamping the index to 0x3fff is required because 0x4000 would end up reading from the atan2 lookup table.

I have made the change for both Model 1 and Model 2, since I presume the logic on each is the same.