### PR TITLE
MOS6551: correctly transfer data from RSR to RDR

### DIFF
--- a/src/devices/machine/mos6551.cpp
+++ b/src/devices/machine/mos6551.cpp
@@ -39,7 +39,7 @@ mos6551_device::mos6551_device(const machine_config &mconfig, const char *tag, d
 	m_dcd(1),
 	m_rxd(1), m_wordlength(0), m_extrastop(0), m_brk(0), m_echo_mode(0), m_parity(0),
 	m_rx_state(STATE_START),
-	m_rx_clock(0), m_rx_bits(0), m_rx_shift(0), m_rx_parity(0),
+	m_rx_clock(0), m_rx_bits(0), m_rx_shift(0), m_rx_shifted_bits(0), m_rx_parity(0),
 	m_rx_counter(0), m_rx_irq_enable(0),
 	m_rx_internal_clock(0),
 	m_tx_state(STATE_START),
@@ -112,6 +112,7 @@ void mos6551_device::device_start()
 	save_item(NAME(m_rx_clock));
 	save_item(NAME(m_rx_bits));
 	save_item(NAME(m_rx_shift));
+	save_item(NAME(m_rx_shifted_bits));
 	save_item(NAME(m_rx_parity));
 	save_item(NAME(m_rx_counter));
 	save_item(NAME(m_rx_irq_enable));
@@ -580,6 +581,7 @@ void mos6551_device::receiver_clock(int state)
 						m_rx_shift = 0;
 						m_rx_parity = 0;
 						m_rx_bits = 0;
+						m_rx_shifted_bits = 0;
 					}
 					else
 					{
@@ -622,38 +624,58 @@ void mos6551_device::receiver_clock(int state)
 				break;
 
 			case STATE_STOP:
-				if (m_rx_counter >= stoplength())
+				if (m_rx_counter * 2 > (stoplength() * 2) - m_wordlength)
 				{
+					/* Copy Receive Shift Register into data register, bit-by-bit
+					 * Do two bits each iteration as shifting happens on both
+					 * clock phases.
+					 */
+					for (int i = 0; i < 2 && m_rx_shifted_bits < m_wordlength; i++) {
+						if (m_rx_shift & (1 << m_rx_shifted_bits))
+						{
+							m_rdr |= (1 << m_rx_shifted_bits);
+						}
+						else
+						{
+							m_rdr &= ~(1 << m_rx_shifted_bits);
+						}
+						m_rx_shifted_bits++;
+					}
+
+					if (m_rx_counter < stoplength())
+					{
+						break;
+					}
+
+					/* Very last cycle of this byte: update status register,
+					 * trigger IRQ, etc.
+					 */
 					m_rx_counter = 0;
 
 					LOG("MOS6551: RX STOP BIT\n");
 
-					if (!(m_status & SR_RDRF))
-					{
-						if (!m_rxd)
-						{
-							m_status |= SR_FRAMING_ERROR;
-						}
-
-						if ((m_parity == PARITY_ODD && !m_rx_parity) ||
-							(m_parity == PARITY_EVEN && m_rx_parity))
-						{
-							m_status |= SR_PARITY_ERROR;
-						}
-
-						m_rdr = m_rx_shift;
-
-						if (m_wordlength == 7 && m_parity != PARITY_NONE)
-						{
-							m_rdr &= 0x7f;
-						}
-
-						m_status |= SR_RDRF;
-					}
-					else
+					if ((m_status & SR_RDRF))
 					{
 						m_status |= SR_OVERRUN;
 					}
+
+					if (!m_rxd)
+					{
+						m_status |= SR_FRAMING_ERROR;
+					}
+
+					if ((m_parity == PARITY_ODD && !m_rx_parity) ||
+						(m_parity == PARITY_EVEN && m_rx_parity))
+					{
+						m_status |= SR_PARITY_ERROR;
+					}
+
+					if (m_wordlength == 7 && m_parity != PARITY_NONE)
+					{
+						m_rdr &= 0x7f;
+					}
+
+					m_status |= SR_RDRF;
 
 					if (m_rx_irq_enable)
 					{

--- a/src/devices/machine/mos6551.h
+++ b/src/devices/machine/mos6551.h
@@ -172,6 +172,7 @@ private:
 	int m_rx_clock;
 	int m_rx_bits;
 	int m_rx_shift;
+	int m_rx_shifted_bits;
 	int m_rx_parity;
 	int m_rx_counter;
 	int m_rx_irq_enable;


### PR DESCRIPTION
**Context:**
This pull request aims to fix a discrepancy between MAME emulation of the 6551 and real life. I have written in the last monthes an Apple II audio/video streamer, which works over two 6551 serial ports at 115200 bps, getting data from a serial proxy. In this project, there are not enough cycles available to handle the Status register read before reading the Data register on both ports, so I chose to check Status before reading Data on the video stream, and blindly read Data on the audio stream. The rationale being that it is not a problem to misread an audio sample, whereas it would be a problem to misread a video byte.
The audio bytes are used to update a JMP target and branch to the next duty cycle. Each duty cycle does PWM for sound check if a video byte if present, updates the jump target to the next audio duty cycle without checking if it's a new one, etc.

I made this project work on MAME emulation, and then tested on real hardware, only to quickly JMP at random places out of my duty cycles range, and crashing. I figured that it was because my program read wrong values on the audio stream.

Debugging on real hardware showed that when reading the ACIA’s Data register without first waiting on Status register’s “Receive Data Register Full” bit, one can read the Data register in the middle of the transfer from the Receive Shift Register to the Data register, leading to “half-fresh, half-old” bytes. For example, if the data register contained 0x82 (10000010) and the new byte transferred is 0x6F (01101111), I could read 10001111.

I solved this on my project by having sample values that can’t fall out of range even on half-reads (31 levels, bit-aligned so that the high bits never change and there is a valid jump target at every value from 00000 to 11111), but I think it would be good for programmers to be able to experience this side-effect in MAME, where it is much easier to debug than on an Apple II.

**The change:**
This pull request changes the way the RSR is transferred to the RDR. So far, it was atomically copied to RDR on the last cycle of the stop bit. With this change, the RSR is copied into the RDR bit-by-bit during the last cycles instead.
To be precise, in the implementation, it’s done two-bits by two-bits, as it seems that this copy, on real hardware, is done on both clock transitions. (When testing this change, I noticed that doing it bit-by-bit lead to wrong data read on MAME whereas there is very consistently no issue on real hardware).

This pull request also fixes another discrepancy, where the new byte would not be put into the read register if an overrun occurred: this doesn’t reflect reality, where every new byte overwrites the previous one.

Hope this helps!