### PR TITLE
lgtnfght: removed NMI connection as it does not exist on schematics.

### DIFF
--- a/src/mame/konami/tmnt2.cpp
+++ b/src/mame/konami/tmnt2.cpp
@@ -2468,7 +2468,6 @@ void tmnt2_state::lgtnfght(machine_config &config)
 	K053260(config, m_k053260, XTAL(3'579'545));
 	m_k053260->add_route(0, "speaker", 0.70, 0);
 	m_k053260->add_route(1, "speaker", 0.70, 1);
-	m_k053260->sh1_cb().set(FUNC(tmnt2_state::z80_nmi_w));
 }
 
 void tmnt2_state::blswhstl(machine_config &config)


### PR DESCRIPTION
Trigon schematics show a pull-up resistor at the NMI pin. However, the driver connects that signal.

![image](https://github.com/user-attachments/assets/354a68e4-293e-46d5-9710-3754568a2f8f)

This PR removes the connection in the driver. The sound is not affected after the change.

I created a separate branch in my fork for this, so feel free to push other changes to it.