### PR TITLE
osd: remove redundant checks when setting BASE_TARGETOS/SDLOS_TARGETOS

### DIFF
--- a/scripts/src/osd/sdl.lua
+++ b/scripts/src/osd/sdl.lua
@@ -214,12 +214,7 @@ end
 
 BASE_TARGETOS       = "unix"
 SDLOS_TARGETOS      = "unix"
-if _OPTIONS["targetos"]=="linux" then
-elseif _OPTIONS["targetos"]=="openbsd" then
-elseif _OPTIONS["targetos"]=="netbsd" then
-elseif _OPTIONS["targetos"]=="haiku" then
-elseif _OPTIONS["targetos"]=="asmjs" then
-elseif _OPTIONS["targetos"]=="windows" then
+if _OPTIONS["targetos"]=="windows" then
 	BASE_TARGETOS       = "win32"
 	SDLOS_TARGETOS      = "win32"
 elseif _OPTIONS["targetos"]=="macosx" then


### PR DESCRIPTION
The vast majority of the OSes use `BASE_TARGETOS=unix` and `SDLOS_TARGETOS=unix`, which are set as default values; the few exceptions (Windows and macOS) already have their own selections.

Hence drop all the empty if statements for other OSes than Windows and macOS, as actually redundant.