### PR TITLE
ghostb: there is no ACK for NMIs

### DIFF
--- a/src/mame/dataeast/dec8.h
+++ b/src/mame/dataeast/dec8.h
@@ -250,7 +250,6 @@ private:
 	void garyoret_map(address_map &map) ATTR_COLD;
 
 	bool m_secclr = false;
-	bool m_nmi_enable = false;
 
 	emu_timer *m_6502_timer = nullptr;
 	emu_timer *m_i8751_timer = nullptr;

--- a/src/mame/dataeast/dec8_v.cpp
+++ b/src/mame/dataeast/dec8_v.cpp
@@ -281,9 +281,6 @@ VIDEO_START_MEMBER(ghostb_state,ghostb)
 	m_fix_tilemap->set_transparent_pen(0);
 
 	m_game_uses_priority = 0;
-
-	m_nmi_enable = false;
-	save_item(NAME(m_nmi_enable));
 }
 
 


### PR DESCRIPTION
NMI on the 6309 comes from the 74LS00 @ 13C (dual input NAND gate) where input 1 is vblank and input 2 comes from a latch (74LS273 @ 3A). The latch gets updated with writes to 0x3840, which is what you write to to enable/disable NMI.  So there is no hardware logic to ACK NMIs.