### PR TITLE
Ensure error.log is flushed on Windows OSD

### DIFF
--- a/src/osd/modules/file/winfile.cpp
+++ b/src/osd/modules/file/winfile.cpp
@@ -107,8 +107,10 @@ public:
 
 	virtual std::error_condition flush() noexcept override
 	{
-		// shouldn't be any userspace buffers on the file handle
-		return std::error_condition();
+		if (!FlushFileBuffers(m_handle))
+			return win_error_to_error_condition(GetLastError());
+		else
+			return std::error_condition();
 	}
 
 private:


### PR DESCRIPTION
The comment in `win_osd_file::flush`:
`// shouldn't be any userspace buffers on the file handle`
is not accurate.

Per Microsoft's documentation for Fileapi.h and the `FlushFileBuffers` function:
> Typically the [WriteFile](https://learn.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-writefile) and [WriteFileEx](https://learn.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-writefileex) functions write data to an internal buffer that the operating system writes to a disk or communication pipe on a regular basis. The FlushFileBuffers function writes all the buffered information for a specified file to the device or pipe.

This tracks with the behavior observed when MAME crashes while running with `-log`: The log file is often truncated.

The buffered amount can be significant; when debugging a crash in a Taito Type-Zero game, MAME could run for upwards of a minute prior to crashing, with nothing written to error.log due to even several kilobytes of text data being insufficient to result in an automatic flush to disk.

While this has a performance cost when hitting the error log with extreme frequency, being able to have a complete view of what was written to the log in the event of a crash can, itself, be useful in diagnosing said crash.