### PR TITLE
posixfile.cpp: remove redundant realpath() call

### DIFF
--- a/src/osd/modules/file/posixfile.cpp
+++ b/src/osd/modules/file/posixfile.cpp
@@ -425,13 +425,6 @@ std::error_condition osd_get_full_path(std::string &dst, std::string const &path
 			dst = canonical.get();
 			return std::error_condition();
 		}
-
-		std::vector<char> path_buffer(PATH_MAX);
-		if (::realpath(path.c_str(), &path_buffer[0]))
-		{
-			dst = &path_buffer[0];
-			return std::error_condition();
-		}
 		else if (path[0] == PATHSEPCH)
 		{
 			dst = path;
@@ -439,6 +432,7 @@ std::error_condition osd_get_full_path(std::string &dst, std::string const &path
 		}
 		else
 		{
+			std::vector<char> path_buffer(128);
 			while (!::getcwd(&path_buffer[0], path_buffer.size()))
 			{
 				if (errno != ERANGE)


### PR DESCRIPTION
Commit 1bd116c5c8f8f3d28e4db7925efcb87279ba860b makes use of the allocating mode of `realpath()` by duplicating the `realpath()` invocation already done (i.e. with the same input path). In practice, if the `realpath()` invocation with `nullptr` fails, the `realpath()` invocation with a destination buffer is very likely to fail in the same way.

Hence drop the `realpath()` invocation with a destination buffer, and move the `realpath()` invocation with `nullptr` in the existing `if`/`else if` chain to maintain the existing `behaviour`.

Since `path_buffer` now is needed only for the fallback `getcwd()` invocation, move it in the inner scope where it is used. Since the usage of `getcwd()` already has a growing buffer logic, make the initial buffer size shorter, which should be enough to get current working directory already at the first attempt in most of the cases.