### PR TITLE
sound/[va_eg, va_vca, dac76]: Automatically adapt to the  input and output connections.

### DIFF
--- a/src/devices/sound/dac76.cpp
+++ b/src/devices/sound/dac76.cpp
@@ -38,7 +38,6 @@ dac76_device::dac76_device(const machine_config &mconfig, const char *tag, devic
 	device_t(mconfig, DAC76, tag, owner, clock),
 	device_sound_interface(mconfig, *this),
 	m_stream(nullptr),
-	m_streaming_iref(false),
 	m_voltage_output(false),
 	m_r_pos(1.0F),
 	m_r_neg(1.0F),
@@ -47,11 +46,6 @@ dac76_device::dac76_device(const machine_config &mconfig, const char *tag, devic
 	m_sb(false),
 	m_fixed_iref(1.0F)
 {
-}
-
-void dac76_device::configure_streaming_iref(bool streaming_iref)
-{
-	m_streaming_iref = streaming_iref;
 }
 
 void dac76_device::configure_voltage_output(float i2v_r_pos, float i2v_r_neg)
@@ -77,8 +71,8 @@ void dac76_device::set_fixed_iref(float iref)
 void dac76_device::device_start()
 {
 	// create sound stream
-	const int input_count = m_streaming_iref ? 1 : 0;
-	m_stream = stream_alloc(input_count, 1, machine().sample_rate() * 8);
+	assert(get_sound_requested_inputs_mask() == 0x00 || get_sound_requested_inputs_mask() == 0x01);
+	m_stream = stream_alloc(get_sound_requested_inputs(), 1, machine().sample_rate() * 8);
 
 	// register for save states
 	save_item(NAME(m_chord));
@@ -121,7 +115,7 @@ void dac76_device::sound_stream_update(sound_stream &stream)
 		y *= ((y >= 0) ? m_r_pos : m_r_neg) * FULL_SCALE_MULT;
 	}
 
-	if (m_streaming_iref)
+	if (get_sound_requested_inputs() > 0)
 	{
 		const int n = stream.samples();
 		for (int i = 0; i < n; ++i)

--- a/src/devices/sound/dac76.h
+++ b/src/devices/sound/dac76.h
@@ -33,6 +33,9 @@
     signal by a current-to-voltage converter (I2V) consisting of an op-amp and
     two resistors.
 
+	Iref can either be provided as a stream by connecting a second input, or
+	as a fixed value by using `set_fixed_iref()`.
+
 ***************************************************************************/
 
 #ifndef MAME_SOUND_DAC76_H
@@ -52,13 +55,8 @@ public:
 	// construction/destruction
 	dac76_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	// When streaming is enabled, the Iref will be obtained from the input sound
-	// stream. Otherwise, the value set with `set_fixed_iref` will be used.
-	void configure_streaming_iref(bool streaming_iref);
-
 	// By default, the control current (Iref) is treated as normalized ([0, 1],
 	// defaults to 1), and the sound output is normalized to [-1, 1].
-	//
 	// When in "voltage output" mode, Iref (fixed or streaming) should be the
 	// current flowing into pin 11, and the output will be a voltage stream.
 	// `r_pos` is the feedback resistor of the I2V, which is also connected to
@@ -68,7 +66,9 @@ public:
 	// the "+" input.
 	void configure_voltage_output(float i2v_r_pos, float i2v_r_neg);
 
-	// Reference current. Ignored when streaming Iref mode is enabled.
+	// Fixed reference current.
+	// Ignored when a second input is connected. Iref will be obtained from
+	// input stream 1 in this case.
 	void set_fixed_iref(float iref);
 
 	// chord

--- a/src/devices/sound/dac76.h
+++ b/src/devices/sound/dac76.h
@@ -33,8 +33,8 @@
     signal by a current-to-voltage converter (I2V) consisting of an op-amp and
     two resistors.
 
-	Iref can either be provided as a stream by connecting a second input, or
-	as a fixed value by using `set_fixed_iref()`.
+	Iref can either be provided as a stream by connecting an input, or as a
+	fixed value by using `set_fixed_iref()`.
 
 ***************************************************************************/
 
@@ -67,8 +67,8 @@ public:
 	void configure_voltage_output(float i2v_r_pos, float i2v_r_neg);
 
 	// Fixed reference current.
-	// Ignored when a second input is connected. Iref will be obtained from
-	// input stream 1 in this case.
+	// Ignored when an input is connected. Iref will be obtained from input
+	// stream 0 in this case.
 	void set_fixed_iref(float iref);
 
 	// chord

--- a/src/devices/sound/dac76.h
+++ b/src/devices/sound/dac76.h
@@ -100,7 +100,6 @@ private:
 	sound_stream *m_stream;
 
 	// configuration
-	bool m_streaming_iref;
 	bool m_voltage_output;
 	float m_r_pos;
 	float m_r_neg;

--- a/src/devices/sound/va_eg.cpp
+++ b/src/devices/sound/va_eg.cpp
@@ -14,7 +14,6 @@ va_rc_eg_device::va_rc_eg_device(const machine_config &mconfig, const char *tag,
 	: device_t(mconfig, VA_RC_EG, tag, owner, clock)
 	, device_sound_interface(mconfig, *this)
 	, m_stream(nullptr)
-	, m_streaming(true)
 	// Initialize to a valid state.
 	, m_r(RES_M(1))
 	, m_c(CAP_U(1))
@@ -22,12 +21,6 @@ va_rc_eg_device::va_rc_eg_device(const machine_config &mconfig, const char *tag,
 	, m_v_start(0)
 	, m_v_end(0)
 {
-}
-
-va_rc_eg_device &va_rc_eg_device::disable_streaming()
-{
-	m_streaming = false;
-	return *this;
 }
 
 va_rc_eg_device &va_rc_eg_device::set_r(float r)
@@ -118,8 +111,11 @@ attotime va_rc_eg_device::get_dt(float v) const
 
 void va_rc_eg_device::device_start()
 {
-	if (m_streaming)
+	if (get_sound_requested_outputs() > 0)
 		m_stream = stream_alloc(0, 1, SAMPLE_RATE_OUTPUT_ADAPTIVE);
+	else
+		m_stream = nullptr;
+
 	save_item(NAME(m_r));
 	save_item(NAME(m_c));
 	save_item(NAME(m_rc_inv));
@@ -131,7 +127,6 @@ void va_rc_eg_device::device_start()
 
 void va_rc_eg_device::sound_stream_update(sound_stream &stream)
 {
-	assert(m_streaming);
 	assert(stream.input_count() == 0 && stream.output_count() == 1);
 	attotime t = stream.start_time();
 

--- a/src/devices/sound/va_eg.h
+++ b/src/devices/sound/va_eg.h
@@ -32,10 +32,6 @@ class va_rc_eg_device : public device_t, public device_sound_interface
 public:
 	va_rc_eg_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0) ATTR_COLD;
 
-	// Skip creating a sound stream. Useful when using this device for RC
-	// emulation other than sound.
-	va_rc_eg_device &disable_streaming();
-
 	// These setters can be used during both: configuration and normal operation.
 	// `r` and `c` must be > 0. To instantly set the capacitor's voltage to
 	// a specific value, use set_instant_v().
@@ -65,7 +61,6 @@ private:
 	void snapshot();
 
 	sound_stream *m_stream;
-	bool m_streaming;
 
 	float m_r;
 	float m_c;

--- a/src/devices/sound/va_vca.h
+++ b/src/devices/sound/va_vca.h
@@ -20,10 +20,6 @@ class va_vca_device : public device_t, public device_sound_interface
 public:
 	va_vca_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0) ATTR_COLD;
 
-	// When streaming is enabled, the CV will be obtained from input 1 of the
-	// sound stream. Otherwise, the value set with `set_fixed_cv` will be used.
-	va_vca_device &configure_streaming_cv(bool use_streaming_cv);
-
 	// By default, the CV will be treated as a typical gain (output = cv * input)
 	// The configure_*() functions below might change this.
 
@@ -32,7 +28,9 @@ public:
 	// streaming) should be the voltage at the Vc pin.
 	va_vca_device &configure_cem3360_linear_cv();
 
-	// Ignored when streaming CVs are enabled.
+	// Fixed control value.
+	// Ignored when a second input is connected. CV will be obtained from
+	// input stream 1 in this case.
 	void set_fixed_cv(float cv);
 
 protected:
@@ -44,7 +42,6 @@ private:
 
 	// Configuration. No need to include in save state.
 	sound_stream *m_stream;
-	bool m_has_cv_stream;
 	float m_min_cv;
 	float m_max_cv;
 	float m_cv_scale;

--- a/src/mame/casio/cps2000.cpp
+++ b/src/mame/casio/cps2000.cpp
@@ -317,11 +317,11 @@ void cps2000_state::cps2000(machine_config &config)
 	// UPD932(config, "upd932a", 4.9468_MHz_XTAL);
 	// UPD932(config, "upd932b", 4.9468_MHz_XTAL);
 
-	DAC_1BIT(config, "bass").add_route(0, "bass_vca", 1.0);
+	DAC_1BIT(config, "bass").add_route(0, "bass_vca", 1.0, 0);
 	m_maincpu->co0_func().set("bass", FUNC(dac_1bit_device::write));
 
-	VA_RC_EG(config, m_bass_env).set_c(CAP_U(3.3)).add_route(0, "bass_vca", 1.0 / 5);
-	VA_VCA(config, "bass_vca").configure_streaming_cv(true).add_route(0, "bass_rc1", 1.0);
+	VA_RC_EG(config, m_bass_env).set_c(CAP_U(3.3)).add_route(0, "bass_vca", 1.0 / 5, 1);
+	VA_VCA(config, "bass_vca").add_route(0, "bass_rc1", 1.0);
 
 	FILTER_RC(config, "bass_rc1").set_lowpass(RES_K(47), CAP_N(47)).add_route(0, "bass_rc2", 1.0);
 	FILTER_RC(config, "bass_rc2").set_lowpass(RES_K(22), CAP_N(47))

--- a/src/mame/linn/linndrum.cpp
+++ b/src/mame/linn/linndrum.cpp
@@ -576,7 +576,7 @@ void linndrum_audio_device::device_add_mconfig(machine_config &config)
 
 	TIMER(config, m_hat_trigger_timer).configure_generic(FUNC(linndrum_audio_device::hat_trigger_timer_tick));  // LM556 (U37B).
 	VA_RC_EG(config, m_hat_eg).set_c(HAT_C22);
-	VA_VCA(config, m_hat_vca).configure_streaming_cv(true).configure_cem3360_linear_cv();
+	VA_VCA(config, m_hat_vca).configure_cem3360_linear_cv();
 	m_mux_volume[MV_HAT]->add_route(0, m_hat_vca, 1.0, 0);
 	m_hat_eg->add_route(0, m_hat_vca, HAT_EG2CV_SCALER, 1);
 

--- a/src/mame/moog/source.cpp
+++ b/src/mame/moog/source.cpp
@@ -864,8 +864,8 @@ void source_state::source(machine_config &config)
 
 	NVRAM(config, NVRAM_TAG, nvram_device::DEFAULT_ALL_0);  // 2x6514: U27, U28.
 
-	VA_RC_EG(config, m_contour[FILTER_CONTOUR]).disable_streaming().set_c(CONTOUR_C);  // C57 (Board 2).
-	VA_RC_EG(config, m_contour[LOUDNESS_CONTOUR]).disable_streaming().set_c(CONTOUR_C);  // C56 (Board 2).
+	VA_RC_EG(config, m_contour[FILTER_CONTOUR]).set_c(CONTOUR_C);  // C57 (Board 2).
+	VA_RC_EG(config, m_contour[LOUDNESS_CONTOUR]).set_c(CONTOUR_C);  // C56 (Board 2).
 	TIMER(config, m_lfo_timer).configure_generic(FUNC(source_state::lfo_timer_tick));
 
 	config.set_default_layout(layout_moog_source);

--- a/src/mame/oberheim/dmx.cpp
+++ b/src/mame/oberheim/dmx.cpp
@@ -299,7 +299,6 @@ void dmx_voice_card_device::device_add_mconfig(machine_config &config)
 	if (has_decay())
 	{
 		VA_RC_EG(config, m_eg).set_c(m_config.c3);
-		m_dac->configure_streaming_iref(true);
 		m_eg->add_route(0, m_dac, 1.0);
 	}
 

--- a/src/mame/paia/fatman.cpp
+++ b/src/mame/paia/fatman.cpp
@@ -442,8 +442,8 @@ void fatman_state::fatman(machine_config &config)
 	m_maincpu->port_out_cb<3>().set(FUNC(fatman_state::vcf_ar_release_w)).bit(1);
 	m_maincpu->port_out_cb<3>().append(FUNC(fatman_state::cv_mux_w)).mask(0x30);  // Bits 4, 5.
 
-	VA_RC_EG(config, m_vca_adsr).disable_streaming().set_c(C19);
-	VA_RC_EG(config, m_vcf_ar).disable_streaming().set_c(C22);
+	VA_RC_EG(config, m_vca_adsr).set_c(C19);
+	VA_RC_EG(config, m_vcf_ar).set_c(C22);
 
 	midi_port_device &midi_in(MIDI_PORT(config, "mdin", midiin_slot, "midiin"));
 	MIDI_PORT(config, "mdthru", midiout_slot, "midiout");

--- a/src/mame/roland/roland_tr707.cpp
+++ b/src/mame/roland/roland_tr707.cpp
@@ -1631,7 +1631,7 @@ void roland_tr707_state::tr_707_727_common(machine_config &config)
 	TTL7474(config, m_tempo_ff, 0);  // 4013, IC4a.
 	m_tempo_ff->comp_output_cb().set(FUNC(roland_tr707_state::internal_tempo_clock_cb));
 
-	VA_RC_EG(config, m_accent_adc_rc).disable_streaming().set_c(CAP_U(0.27));  // C15.
+	VA_RC_EG(config, m_accent_adc_rc).set_c(CAP_U(0.27));  // C15.
 	TIMER(config, m_accent_adc_timer).configure_generic(FUNC(roland_tr707_state::accent_adc_timer_tick));
 	TTL7474(config, m_accent_adc_ff, 0);  // 4013, IC4b.
 	m_accent_adc_ff->d_w(1);  // D tied to VCC.

--- a/src/mame/roland/roland_tr707.cpp
+++ b/src/mame/roland/roland_tr707.cpp
@@ -455,7 +455,7 @@ void tr707_audio_device::device_add_mconfig(machine_config &config)
 	{
 		VA_RC_EG(config, m_mux_eg[i]).set_r(MUX_EG_R[i]).set_c(CAP_U(0.047));  // [C48, C52-55, C57-58]
 		DAC08(config, m_mux_dac[i]);
-		VA_VCA(config, m_mux_vca[i]).configure_streaming_cv(true);
+		VA_VCA(config, m_mux_vca[i]);
 		m_mux_dac[i]->add_route(0, m_mux_vca[i], 1.0, 0);
 		m_mux_eg[i]->add_route(0, m_mux_vca[i], mux_dac_scale, 1);
 	}
@@ -479,7 +479,7 @@ void tr707_audio_device::device_add_mconfig(machine_config &config)
 	m_mux_vca[MV_HI_HAT]->add_route(0, hat_hpf, HAT_HPF_SCALE, 0);
 
 	VA_RC_EG(config, m_hat_eg).set_c(CAP_U(1));  // C71
-	auto &hat_vca = VA_VCA(config, "hat_vca").configure_streaming_cv(true);  // 2SD1469R, Q32
+	auto &hat_vca = VA_VCA(config, "hat_vca");  // 2SD1469R, Q32
 	hat_hpf.add_route(0, hat_vca, HAT_VCA_SCALE, 0);
 	m_hat_eg->add_route(0, hat_vca, 1.0 / VCC, 1);
 
@@ -509,7 +509,7 @@ void tr707_audio_device::device_add_mconfig(machine_config &config)
 		m_cymbal_dac[i]->add_route(0, m_cymbal_hpf[i], CYMBAL_HPF_SCALE);
 
 		VA_RC_EG(config, m_cymbal_eg[i]).set_r(CYMBAL_EG_R[i]).set_c(CAP_U(1));  // [C50, C49]
-		VA_VCA(config, m_cymbal_vca[i]).configure_streaming_cv(true);   // 2SD1469R [Q14, Q15]
+		VA_VCA(config, m_cymbal_vca[i]);  // 2SD1469R [Q14, Q15]
 		// V2I converter is based on an op-amp in inverting configuration.
 		m_cymbal_hpf[i]->add_route(0, m_cymbal_vca[i], CYMBAL_VCA_SCALE, 0);
 		m_cymbal_eg[i]->add_route(0, m_cymbal_vca[i], 1.0 / VCC, 1);


### PR DESCRIPTION
Implemented the suggestion in #13860, for `va_eg` (first commit in this PR).

I also noticed there is a `get_sound_requested_inputs()`, which `sound/dac` uses to automatically switch to streaming ranges. So I did something similar for `va_vca` and `dac76`, and got rid of the `configure_streaming_*` functions. @galibert, I am assuming this is preferable, given the suggestion in  #13860, but let me know if I should just stick to the `va_eg` changes.

This change also required adapting `cps2000` to the new sound engine. Other than that, this PR is a behavioral no-op.