### PR TITLE
SN76489 / SN76489A / SN76496: Corrected chip type

### DIFF
--- a/src/mame/capcom/exedexes.cpp
+++ b/src/mame/capcom/exedexes.cpp
@@ -345,8 +345,8 @@ void exedexes_state::sound_map(address_map &map)
 	map(0x4000, 0x47ff).ram();
 	map(0x6000, 0x6000).r("soundlatch", FUNC(generic_latch_8_device::read));
 	map(0x8000, 0x8001).w("aysnd", FUNC(ay8910_device::address_data_w));
-	map(0x8002, 0x8002).w("sn1", FUNC(sn76489_device::write));
-	map(0x8003, 0x8003).w("sn2", FUNC(sn76489_device::write));
+	map(0x8002, 0x8002).w("sn1", FUNC(sn76489a_device::write));
+	map(0x8003, 0x8003).w("sn2", FUNC(sn76489a_device::write));
 }
 
 
@@ -524,8 +524,8 @@ void exedexes_state::exedexes(machine_config &config)
 
 	AY8910(config, "aysnd", 12_MHz_XTAL / 8).add_route(ALL_OUTPUTS, "mono", 0.10); // 1.5 MHz, verified on PCB
 
-	SN76489(config, "sn1", 12_MHz_XTAL / 4).add_route(ALL_OUTPUTS, "mono", 0.36); // 3 MHz, verified on PCB
-	SN76489(config, "sn2", 12_MHz_XTAL / 4).add_route(ALL_OUTPUTS, "mono", 0.36); // 3 MHz, verified on PCB
+	SN76489A(config, "sn1", 12_MHz_XTAL / 4).add_route(ALL_OUTPUTS, "mono", 0.36); // 3 MHz, verified on PCB
+	SN76489A(config, "sn2", 12_MHz_XTAL / 4).add_route(ALL_OUTPUTS, "mono", 0.36); // 3 MHz, verified on PCB
 }
 
 

--- a/src/mame/kiwako/mrjong.cpp
+++ b/src/mame/kiwako/mrjong.cpp
@@ -25,8 +25,8 @@ C2-00154C
 |          4H  5H           PROM7J        |
 |                           PAL    DSW1(8)|
 |              PROM5G                     |
-|                           76489         |
-|                           76489         |
+|                           76489AN       |
+|                           76489AN       |
 |               Z80                       |
 |                                PAL      |
 |15.468MHz PAL              6116     555  |
@@ -257,8 +257,8 @@ void mrjong_state::io_map(address_map &map)
 {
 	map.global_mask(0xff);
 	map(0x00, 0x00).portr("P2").w(FUNC(mrjong_state::flipscreen_w));
-	map(0x01, 0x01).portr("P1").w("sn1", FUNC(sn76489_device::write));
-	map(0x02, 0x02).portr("DSW").w("sn2", FUNC(sn76489_device::write));
+	map(0x01, 0x01).portr("P1").w("sn1", FUNC(sn76489a_device::write));
+	map(0x02, 0x02).portr("DSW").w("sn2", FUNC(sn76489a_device::write));
 	map(0x03, 0x03).r(FUNC(mrjong_state::io_0x03_r));     // Unknown
 }
 
@@ -379,8 +379,8 @@ void mrjong_state::mrjong(machine_config &config)
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
-	SN76489(config, "sn1", 15'468'000 / 6).add_route(ALL_OUTPUTS, "mono", 1.0);
-	SN76489(config, "sn2", 15'468'000 / 6).add_route(ALL_OUTPUTS, "mono", 1.0);
+	SN76489A(config, "sn1", 15'468'000 / 6).add_route(ALL_OUTPUTS, "mono", 1.0);
+	SN76489A(config, "sn2", 15'468'000 / 6).add_route(ALL_OUTPUTS, "mono", 1.0);
 }
 
 

--- a/src/mame/konami/circusc.cpp
+++ b/src/mame/konami/circusc.cpp
@@ -104,7 +104,7 @@ private:
 	// devices
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_audiocpu;
-	required_device_array<sn76496_device, 2> m_sn;
+	required_device_array<sn76489a_device, 2> m_sn;
 	required_device<dac_byte_interface> m_dac;
 	required_device<discrete_device> m_discrete;
 	required_device<gfxdecode_device> m_gfxdecode;
@@ -645,8 +645,9 @@ void circusc_state::circusc(machine_config &config)
 
 	GENERIC_LATCH_8(config, "soundlatch");
 
-	SN76496(config, m_sn[0], 14.318181_MHz_XTAL / 8).add_route(0, "fltdisc", 1.0, 0);
-	SN76496(config, m_sn[1], 14.318181_MHz_XTAL / 8).add_route(0, "fltdisc", 1.0, 1);
+	// According to the schematics, part numbers scratched off
+	SN76489A(config, m_sn[0], 14.318181_MHz_XTAL / 8).add_route(0, "fltdisc", 1.0, 0);
+	SN76489A(config, m_sn[1], 14.318181_MHz_XTAL / 8).add_route(0, "fltdisc", 1.0, 1);
 
 	// ls374.7g + r44+r45+r47+r48+r50+r56+r57+r58+r59 (20k) + r46+r49+r51+r52+r53+r54+r55 (10k) + upc324.3h
 	DAC_8BIT_R2R(config, "dac", 0).set_output_range(0, 1).add_route(0, "fltdisc", 1.0, 2);

--- a/src/mame/konami/hyperspt.cpp
+++ b/src/mame/konami/hyperspt.cpp
@@ -78,7 +78,7 @@ protected:
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_audiocpu;
 	required_device<dac_8bit_r2r_device> m_dac;
-	required_device<sn76496_device> m_sn;
+	required_device<sn76489a_device> m_sn;
 	required_device<trackfld_audio_device> m_soundbrd;
 	required_device<screen_device> m_screen;
 	required_device<gfxdecode_device> m_gfxdecode;
@@ -88,10 +88,10 @@ protected:
 	tilemap_t *m_bg_tilemap = nullptr;
 
 private:
-	uint8_t m_sn76496_latch = 0U;
+	uint8_t m_sn76489a_latch = 0U;
 
-	void konami_sn76496_latch_w(uint8_t data) { m_sn76496_latch = data; }
-	void konami_sn76496_w(uint8_t data) { m_sn->write(m_sn76496_latch); }
+	void konami_sn76489a_latch_w(uint8_t data) { m_sn76489a_latch = data; }
+	void konami_sn76489a_w(uint8_t data) { m_sn->write(m_sn76489a_latch); }
 
 	uint8_t m_irq_mask = 0U;
 	template <uint8_t Which> void coin_counter_w(int state);
@@ -328,7 +328,7 @@ void roadf_state::video_start()
 void base_state::machine_start()
 {
 	save_item(NAME(m_irq_mask));
-	save_item(NAME(m_sn76496_latch));
+	save_item(NAME(m_sn76489a_latch));
 }
 
 template <uint8_t Which>
@@ -382,8 +382,8 @@ void base_state::common_sound_map(address_map &map)
 	map(0x6000, 0x6000).r("soundlatch", FUNC(generic_latch_8_device::read));
 	map(0x8000, 0x8000).r(m_soundbrd, FUNC(trackfld_audio_device::hyperspt_sh_timer_r));
 	map(0xe000, 0xe000).w(m_dac, FUNC(dac_byte_interface::data_w));
-	map(0xe001, 0xe001).w(FUNC(hyperspt_state::konami_sn76496_latch_w));  // Loads the snd command into the snd latch
-	map(0xe002, 0xe002).w(FUNC(hyperspt_state::konami_sn76496_w));  // This address triggers the SN chip to read the data port.
+	map(0xe001, 0xe001).w(FUNC(hyperspt_state::konami_sn76489a_latch_w));  // Loads the snd command into the snd latch
+	map(0xe002, 0xe002).w(FUNC(hyperspt_state::konami_sn76489a_w));  // This address triggers the SN chip to read the data port.
 }
 
 void hyperspt_state::sound_map(address_map &map)
@@ -651,8 +651,8 @@ void base_state::base(machine_config &config)
 
 	DAC_8BIT_R2R(config, m_dac, 0).add_route(ALL_OUTPUTS, "speaker", 0.4); // unknown DAC
 
-	SN76496(config, m_sn, XTAL(14'318'181)/8);  // verified on PCB
-	m_sn->add_route(ALL_OUTPUTS, "speaker", 1.0);
+	// According to the schematics, part number scratched off
+	SN76489A(config, m_sn, XTAL(14'318'181)/8).add_route(ALL_OUTPUTS, "speaker", 1.0);  // clock verified on PCB
 }
 
 void hyperspt_state::hyperspt(machine_config &config)

--- a/src/mame/konami/pingpong.cpp
+++ b/src/mame/konami/pingpong.cpp
@@ -317,8 +317,8 @@ void pingpong_state::pingpong_map(address_map &map)
 	map(0x9003, 0x9052).ram().share(m_spriteram);
 	map(0x9053, 0x97ff).ram();
 	map(0xa000, 0xa000).w(FUNC(pingpong_state::coin_w));   // coin counters + irq enables
-	map(0xa200, 0xa200).nopw();        // SN76496 data latch
-	map(0xa400, 0xa400).w("snsnd", FUNC(sn76496_device::write));    // trigger read
+	map(0xa200, 0xa200).nopw();        // SN76489A data latch
+	map(0xa400, 0xa400).w("snsnd", FUNC(sn76489a_device::write));    // trigger read
 	map(0xa600, 0xa600).w("watchdog", FUNC(watchdog_timer_device::reset_w));
 	map(0xa800, 0xa800).portr("SYSTEM");
 	map(0xa880, 0xa880).portr("INPUTS");
@@ -343,8 +343,8 @@ void pingpong_state::merlinmm_map(address_map &map)
 	map(0xa080, 0xa080).portr("IN1");
 	map(0xa100, 0xa100).portr("IN2");
 	map(0xa180, 0xa180).portr("IN3");
-	map(0xa200, 0xa200).nopw();        // SN76496 data latch
-	map(0xa400, 0xa400).w("snsnd", FUNC(sn76496_device::write));    // trigger read
+	map(0xa200, 0xa200).nopw();        // SN76489A data latch
+	map(0xa400, 0xa400).w("snsnd", FUNC(sn76489a_device::write));    // trigger read
 	map(0xa600, 0xa600).w("watchdog", FUNC(watchdog_timer_device::reset_w));
 }
 
@@ -707,7 +707,7 @@ void pingpong_state::pingpong(machine_config &config)
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
-	SN76496(config, "snsnd", 18'432'000 / 8).add_route(ALL_OUTPUTS, "mono", 1.0);
+	SN76489A(config, "snsnd", 18'432'000 / 8).add_route(ALL_OUTPUTS, "mono", 1.0);
 }
 
 // too fast!

--- a/src/mame/konami/sbasketb.cpp
+++ b/src/mame/konami/sbasketb.cpp
@@ -101,7 +101,7 @@ private:
 	// devices
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_audiocpu;
-	required_device<sn76489_device> m_sn;
+	required_device<sn76489a_device> m_sn;
 	required_device<vlm5030_device> m_vlm;
 	required_device<screen_device> m_screen;
 	required_device<gfxdecode_device> m_gfxdecode;
@@ -112,7 +112,7 @@ private:
 	bool m_spriteram_select = false;
 
 	bool m_irq_mask = false;
-	uint8_t m_sn76496_latch = 0;
+	uint8_t m_sn76489a_latch = 0;
 
 	void sh_irqtrigger_w(uint8_t data);
 	template <uint8_t Which> void coin_counter_w(int state);
@@ -120,8 +120,8 @@ private:
 	void videoram_w(offs_t offset, uint8_t data);
 	void colorram_w(offs_t offset, uint8_t data);
 	void spriteram_select_w(int state);
-	void konami_sn76496_latch_w(uint8_t data) { m_sn76496_latch = data; }
-	void konami_sn76496_w(uint8_t data) { m_sn->write(m_sn76496_latch); }
+	void konami_sn76489a_latch_w(uint8_t data) { m_sn76489a_latch = data; }
+	void konami_sn76489a_w(uint8_t data) { m_sn->write(m_sn76489a_latch); }
 	TILE_GET_INFO_MEMBER(get_bg_tile_info);
 	void palette(palette_device &palette) const;
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
@@ -244,7 +244,7 @@ void sbasketb_state::video_start()
 
 	save_item(NAME(m_spriteram_select));
 	save_item(NAME(m_irq_mask));
-	save_item(NAME(m_sn76496_latch));
+	save_item(NAME(m_sn76489a_latch));
 }
 
 void sbasketb_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect)
@@ -340,8 +340,8 @@ void sbasketb_state::sound_map(address_map &map)
 	map(0xa000, 0xa000).w(m_vlm, FUNC(vlm5030_device::data_w)); // speech
 	map(0xc000, 0xdfff).w("soundbrd", FUNC(trackfld_audio_device::hyperspt_sound_w));     // speech and output control
 	map(0xe000, 0xe000).w("dac", FUNC(dac_byte_interface::data_w));
-	map(0xe001, 0xe001).w(FUNC(sbasketb_state::konami_sn76496_latch_w));  // Loads the snd command into the snd latch
-	map(0xe002, 0xe002).w(FUNC(sbasketb_state::konami_sn76496_w));      // This address triggers the SN chip to read the data port.
+	map(0xe001, 0xe001).w(FUNC(sbasketb_state::konami_sn76489a_latch_w));  // Loads the snd command into the snd latch
+	map(0xe002, 0xe002).w(FUNC(sbasketb_state::konami_sn76489a_w));      // This address triggers the SN chip to read the data port.
 }
 
 
@@ -439,7 +439,7 @@ void sbasketb_state::sbasketb(machine_config &config)
 
 	DAC_8BIT_R2R(config, "dac", 0).add_route(ALL_OUTPUTS, "speaker", 0.4); // unknown DAC
 
-	SN76489(config, m_sn, 14.318181_MHz_XTAL / 8).add_route(ALL_OUTPUTS, "speaker", 1.0);
+	SN76489A(config, m_sn, 14.318181_MHz_XTAL / 8).add_route(ALL_OUTPUTS, "speaker", 1.0);
 
 	VLM5030(config, m_vlm, 3.579545_MHz_XTAL); // Schematics say 3.58MHz, but board uses 3.579545MHz xtal
 	m_vlm->add_route(ALL_OUTPUTS, "speaker", 1.0);

--- a/src/mame/konami/tp84.cpp
+++ b/src/mame/konami/tp84.cpp
@@ -56,11 +56,11 @@ There are 3 or 4 76489AN chips driven by the Z80
 6000-7fff Sound data in
 8000-9fff Timer
 A000-Bfff Filters
-C000      Store Data that will go to one of the 76489AN
-C001      76489 #1 trigger
-C002      76489 #2 (optional) trigger
-C003      76489 #3 trigger
-C004      76489 #4 trigger
+C000      Store Data that will go to one of the 76489A
+C001      76489A #1 trigger
+C002      76489A #2 (optional) trigger
+C003      76489A #3 trigger
+C004      76489A #4 trigger
 
 ***************************************************************************/
 
@@ -405,24 +405,24 @@ uint8_t tp84_state::sh_timer_r()
 
 void tp84_state::filter_w(offs_t offset, uint8_t data)
 {
-	// 76489 #0
+	// 76489A #0
 	int C = 0;
 	if (BIT(offset, 3)) C +=  47000;    //  47000pF = 0.047uF
 	if (BIT(offset, 4)) C += 470000;    // 470000pF = 0.47uF
 	m_filter[0]->filter_rc_set_RC(filter_rc_device::LOWPASS_3R, 1000, 2200, 1000, CAP_P(C));
 
-	// 76489 #1 (optional)
+	// 76489A #1 (optional)
 	C = 0;
 	if (BIT(offset, 5)) C +=  47000;    //  47000pF = 0.047uF
 	if (BIT(offset, 6)) C += 470000;    // 470000pF = 0.47uF
 	//m_filter[1]->filter_rc_set_RC(filter_rc_device::LOWPASS_3R, 1000, 2200, 1000, CAP_P(C));
 
-	// 76489 #2
+	// 76489A #2
 	C = 0;
 	if (BIT(offset, 7)) C += 470000;    // 470000pF = 0.47uF
 	m_filter[1]->filter_rc_set_RC(filter_rc_device::LOWPASS_3R, 1000, 2200, 1000, CAP_P(C));
 
-	// 76489 #3
+	// 76489A #3
 	C = 0;
 	if (BIT(offset, 8)) C += 470000;    // 470000pF = 0.47uF
 	m_filter[2]->filter_rc_set_RC(filter_rc_device::LOWPASS_3R, 1000, 2200, 1000, CAP_P(C));
@@ -506,9 +506,9 @@ void tp84_state::audio_map(address_map &map)
 	map(0x8000, 0x8000).r(FUNC(tp84_state::sh_timer_r));
 	map(0xa000, 0xa1ff).w(FUNC(tp84_state::filter_w));
 	map(0xc000, 0xc000).nopw();
-	map(0xc001, 0xc001).w("y2404_1", FUNC(y2404_device::write));
-	map(0xc003, 0xc003).w("y2404_2", FUNC(y2404_device::write));
-	map(0xc004, 0xc004).w("y2404_3", FUNC(y2404_device::write));
+	map(0xc001, 0xc001).w("sn1", FUNC(sn76489a_device::write));
+	map(0xc003, 0xc003).w("sn2", FUNC(sn76489a_device::write));
+	map(0xc004, 0xc004).w("sn3", FUNC(sn76489a_device::write));
 }
 
 
@@ -633,11 +633,10 @@ void tp84_state::tp84(machine_config &config)
 
 	GENERIC_LATCH_8(config, "soundlatch");
 
-	Y2404(config, "y2404_1", XTAL(14'318'181) / 8).add_route(ALL_OUTPUTS, "filter1", 0.75); // verified on PCB
-
-	Y2404(config, "y2404_2", XTAL(14'318'181) / 8).add_route(ALL_OUTPUTS, "filter2", 0.75); // verified on PCB
-
-	Y2404(config, "y2404_3", XTAL(14'318'181) / 8).add_route(ALL_OUTPUTS, "filter3", 0.75); // verified on PCB
+	// According to the schematics, part numbers scratched off
+	SN76489A(config, "sn1", XTAL(14'318'181) / 8).add_route(ALL_OUTPUTS, "filter1", 0.75); // clock verified on PCB
+	SN76489A(config, "sn2", XTAL(14'318'181) / 8).add_route(ALL_OUTPUTS, "filter2", 0.75); // clock verified on PCB
+	SN76489A(config, "sn3", XTAL(14'318'181) / 8).add_route(ALL_OUTPUTS, "filter3", 0.75); // clock verified on PCB
 
 	for (auto &filter : m_filter)
 		FILTER_RC(config, filter).add_route(ALL_OUTPUTS, "mono", 1.0);

--- a/src/mame/konami/trackfld.cpp
+++ b/src/mame/konami/trackfld.cpp
@@ -14,7 +14,7 @@ GX361 PWB(B)3000151A
 |----------------------------------------|
 |     Z80A                    3.579545MHz|
 |              14.31818MHz        VLM5030|
-|CN1                            SN76489  |
+|CN1                            SN76489AN|
 |                                        |
 |   361D13.2C                            |
 |                               361D15.9C|
@@ -30,18 +30,18 @@ GX361 PWB(B)3000151A
 |CN2         DSW1 DSW2            LM358  |
 |----------------------------------------|
 Notes:
-      Z80A    - Clock input 3.579545MHz [14.31818/4]
-      VLM5030 - Clock input 3.579545MHz
-      SN76489 - Texas Instruments Digital Complex Sound Generator, clock input 1.7897725MHz [3.579545/2]
-      361*    - 2764 EPROMs
-      2114    - 1k x4 SRAM with multiplexed I/O
-      M5224   - Mitsubishi M5224 Quad Operational Amplifier (compatible with LM324)
-      LM358   - Dual Operational Amplifier
-      CN1     - Flat cable joining to main board
-      CN2     - 2-pin power connector for +5V/GND
-      DSW1/2  - 8-position DIP switches
-      Note: On most original boards the Z80, VLM and 76489 have their part numbers scratched off. The
-            76489 might be a 76496? The schematics say '76489'
+      Z80A      - Clock input 3.579545MHz [14.31818/4]
+      VLM5030   - Clock input 3.579545MHz
+      SN76489AN - Texas Instruments Digital Complex Sound Generator, clock input 1.7897725MHz [3.579545/2]
+      361*      - 2764 EPROMs
+      2114      - 1k x4 SRAM with multiplexed I/O
+      M5224     - Mitsubishi M5224 Quad Operational Amplifier (compatible with LM324)
+      LM358     - Dual Operational Amplifier
+      CN1       - Flat cable joining to main board
+      CN2       - 2-pin power connector for +5V/GND
+      DSW1/2    - 8-position DIP switches
+      Note: On most original boards the Z80, VLM and 76489AN have their part numbers scratched off. 
+	        The schematics say '76489AN'
 
       Measurements
       ------------
@@ -276,8 +276,8 @@ void trackfld_state::trackfld_VLM5030_control_w(uint8_t data)
 
 void trackfld_state::yieartf_map(address_map &map)
 {
-	map(0x0000, 0x0000).r(FUNC(trackfld_state::trackfld_speech_r)).w(FUNC(trackfld_state::konami_SN76496_latch_w));
-	map(0x0001, 0x0001).w(FUNC(trackfld_state::konami_SN76496_w));
+	map(0x0000, 0x0000).r(FUNC(trackfld_state::trackfld_speech_r)).w(FUNC(trackfld_state::konami_SN76489a_latch_w));
+	map(0x0001, 0x0001).w(FUNC(trackfld_state::konami_SN76489a_w));
 	map(0x0002, 0x0002).w(FUNC(trackfld_state::trackfld_VLM5030_control_w));
 	map(0x0003, 0x0003).w(m_vlm, FUNC(vlm5030_device::data_w));
 	map(0x1000, 0x1000).mirror(0x007f).w("watchdog", FUNC(watchdog_timer_device::reset_w));       /* AFE */
@@ -386,9 +386,9 @@ void trackfld_state::wizzquiz_map(address_map &map)
 }
 
 
-uint8_t trackfld_state::trackfld_SN76496_r()
+uint8_t trackfld_state::trackfld_SN76489a_r()
 {
-	konami_SN76496_w(0);
+	konami_SN76489a_w(0);
 	return 0xff; // ?
 }
 
@@ -398,8 +398,8 @@ void trackfld_state::sound_map(address_map &map)
 	map(0x4000, 0x43ff).mirror(0x1c00).ram();
 	map(0x6000, 0x6000).mirror(0x1fff).r("soundlatch", FUNC(generic_latch_8_device::read));
 	map(0x8000, 0x8000).mirror(0x1fff).r(m_soundbrd, FUNC(trackfld_audio_device::trackfld_sh_timer_r));
-	map(0xa000, 0xa000).mirror(0x1fff).w(FUNC(trackfld_state::konami_SN76496_latch_w));
-	map(0xc000, 0xc000).mirror(0x1fff).r(FUNC(trackfld_state::trackfld_SN76496_r)).w(FUNC(trackfld_state::konami_SN76496_w));
+	map(0xa000, 0xa000).mirror(0x1fff).w(FUNC(trackfld_state::konami_SN76489a_latch_w));
+	map(0xc000, 0xc000).mirror(0x1fff).r(FUNC(trackfld_state::trackfld_SN76489a_r)).w(FUNC(trackfld_state::konami_SN76489a_w));
 	map(0xe000, 0xe000).mirror(0x1ff8).w(m_dac, FUNC(dac_byte_interface::data_w));
 	map(0xe001, 0xe001).mirror(0x1ff8).noprw();           /* watch dog ?; reaktor reads here */
 	map(0xe002, 0xe002).mirror(0x1ff8).r(m_soundbrd, FUNC(trackfld_audio_device::trackfld_speech_r));
@@ -413,8 +413,8 @@ void trackfld_state::hyprolyb_sound_map(address_map &map)
 	map(0x4000, 0x43ff).mirror(0x1c00).ram();
 	map(0x6000, 0x6000).mirror(0x1fff).r("soundlatch", FUNC(generic_latch_8_device::read));
 	map(0x8000, 0x8000).mirror(0x1fff).r(m_soundbrd, FUNC(trackfld_audio_device::trackfld_sh_timer_r));
-	map(0xa000, 0xa000).mirror(0x1fff).w(FUNC(trackfld_state::konami_SN76496_latch_w));
-	map(0xc000, 0xc000).mirror(0x1fff).r(FUNC(trackfld_state::trackfld_SN76496_r)).w(FUNC(trackfld_state::konami_SN76496_w));
+	map(0xa000, 0xa000).mirror(0x1fff).w(FUNC(trackfld_state::konami_SN76489a_latch_w));
+	map(0xc000, 0xc000).mirror(0x1fff).r(FUNC(trackfld_state::trackfld_SN76489a_r)).w(FUNC(trackfld_state::konami_SN76489a_w));
 	map(0xe000, 0xe000).mirror(0x1ff8).w(m_dac, FUNC(dac_byte_interface::data_w));
 	map(0xe001, 0xe001).mirror(0x1ff8).noprw();           /* watch dog ?; reaktor reads here */
 	map(0xe002, 0xe002).mirror(0x1ff8).r("hyprolyb_adpcm", FUNC(hyprolyb_adpcm_device::busy_r));
@@ -932,7 +932,7 @@ void trackfld_state::trackfld(machine_config &config)
 
 	DAC_8BIT_R2R(config, m_dac, 0).add_route(ALL_OUTPUTS, "speaker", 0.4); // ls374.8e + r34-r47(20k) + r35-r53(10k) + r54(20k) + upc324.8f
 
-	SN76496(config, m_sn, SOUND_CLOCK/8);
+	SN76489A(config, m_sn, SOUND_CLOCK/8);
 	m_sn->add_route(ALL_OUTPUTS, "speaker", 1.0);
 
 	VLM5030(config, m_vlm, VLM_CLOCK);
@@ -1004,7 +1004,7 @@ void trackfld_state::yieartf(machine_config &config)
 
 	DAC_8BIT_R2R(config, m_dac, 0).add_route(ALL_OUTPUTS, "speaker", 0.4); // ls374.8e + r34-r47(20k) + r35-r53(10k) + r54(20k) + upc324.8f
 
-	SN76496(config, m_sn, MASTER_CLOCK/6/2);
+	SN76489A(config, m_sn, MASTER_CLOCK/6/2);
 	m_sn->add_route(ALL_OUTPUTS, "speaker", 1.0);
 
 	VLM5030(config, m_vlm, VLM_CLOCK);

--- a/src/mame/konami/trackfld.h
+++ b/src/mame/konami/trackfld.h
@@ -63,11 +63,11 @@ private:
 	void trackfld_videoram_w(offs_t offset, uint8_t data);
 	void trackfld_colorram_w(offs_t offset, uint8_t data);
 	void atlantol_gfxbank_w(uint8_t data);
-	uint8_t trackfld_SN76496_r();
+	uint8_t trackfld_SN76489a_r();
 	uint8_t trackfld_speech_r();
 	void trackfld_VLM5030_control_w(uint8_t data);
-	void konami_SN76496_latch_w(uint8_t data) { m_SN76496_latch = data; }
-	void konami_SN76496_w(uint8_t data) { m_sn->write(m_SN76496_latch); }
+	void konami_SN76489a_latch_w(uint8_t data) { m_SN76489a_latch = data; }
+	void konami_SN76489a_w(uint8_t data) { m_sn->write(m_SN76489a_latch); }
 
 	void hyprolyb_sound_map(address_map &map) ATTR_COLD;
 	void main_map(address_map &map) ATTR_COLD;
@@ -93,7 +93,7 @@ private:
 	optional_device<ls259_device> m_mainlatch;
 	optional_device<cpu_device> m_audiocpu;
 	optional_device<trackfld_audio_device> m_soundbrd;
-	optional_device<sn76496_device> m_sn;
+	optional_device<sn76489a_device> m_sn;
 	optional_device<vlm5030_device> m_vlm;
 	required_device<dac_8bit_r2r_device> m_dac;
 	required_device<screen_device> m_screen;
@@ -111,7 +111,7 @@ private:
 	bool     m_irq_mask = false;
 	bool     m_nmi_mask = false;
 
-	uint8_t m_SN76496_latch = 0;
+	uint8_t m_SN76489a_latch = 0;
 
 	void coin_counter_1_w(int state);
 	void coin_counter_2_w(int state);

--- a/src/mame/konami/trackfld_a.cpp
+++ b/src/mame/konami/trackfld_a.cpp
@@ -104,7 +104,7 @@ void trackfld_audio_device::hyperspt_sound_w(offs_t offset, uint8_t data)
 	/* A5 = RST pin 1=reset                                */
 	/* A6 = VLM5030    output disable (don't care ) */
 	/* A7 = kONAMI DAC output disable (don't care ) */
-	/* A8 = SN76489    output disable (don't care ) */
+	/* A8 = SN76489AN  output disable (don't care ) */
 
 	/* A4 VLM5030 ST pin */
 	if (changes & 0x10)

--- a/src/mame/konami/yiear.cpp
+++ b/src/mame/konami/yiear.cpp
@@ -20,7 +20,7 @@ The 6809 NMI is used for sound timing.
                     bit 3 - coin counter A
                     bit 4 - coin counter B
 4800         W  sound latch write
-4900         W  copy sound latch to SN76496
+4900         W  copy sound latch to SN76489A
 4a00         W  VLM5030 control
 4b00         W  VLM5030 data
 4c00        R   DSW #0
@@ -158,14 +158,14 @@ private:
 	uint8_t m_nmi_enable = 0;
 	uint8_t m_irq_enable = 0;
 
-	uint8_t m_sn76496_latch = 0;
+	uint8_t m_sn76489a_latch = 0;
 
 	void videoram_w(offs_t offset, uint8_t data);
 	void control_w(uint8_t data);
 	uint8_t speech_r();
 	void vlm5030_control_w(uint8_t data);
-	void konami_sn76496_latch_w(uint8_t data) { m_sn76496_latch = data; }
-	void konami_sn76496_w(uint8_t data) { m_sn->write(m_sn76496_latch); }
+	void konami_sn76489a_latch_w(uint8_t data) { m_sn76489a_latch = data; }
+	void konami_sn76489a_w(uint8_t data) { m_sn->write(m_sn76489a_latch); }
 	TILE_GET_INFO_MEMBER(get_bg_tile_info);
 	void palette(palette_device &palette) const;
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
@@ -341,8 +341,8 @@ void yiear_state::main_map(address_map &map)
 {
 	map(0x0000, 0x0000).r(FUNC(yiear_state::speech_r));
 	map(0x4000, 0x4000).w(FUNC(yiear_state::control_w));
-	map(0x4800, 0x4800).w(FUNC(yiear_state::konami_sn76496_latch_w));
-	map(0x4900, 0x4900).w(FUNC(yiear_state::konami_sn76496_w));
+	map(0x4800, 0x4800).w(FUNC(yiear_state::konami_sn76489a_latch_w));
+	map(0x4900, 0x4900).w(FUNC(yiear_state::konami_sn76489a_w));
 	map(0x4a00, 0x4a00).w(FUNC(yiear_state::vlm5030_control_w));
 	map(0x4b00, 0x4b00).w(m_vlm, FUNC(vlm5030_device::data_w));
 	map(0x4c00, 0x4c00).portr("DSW2");
@@ -507,7 +507,7 @@ void yiear_state::yiear(machine_config &config)
 
 	TRACKFLD_AUDIO(config, m_audio, 0, finder_base::DUMMY_TAG, m_vlm);
 
-	SN76489A(config, m_sn, XTAL(18'432'000)/12).add_route(ALL_OUTPUTS, "mono", 1.0);   // verified on PCB
+	SN76489A(config, m_sn, XTAL(18'432'000)/12).add_route(ALL_OUTPUTS, "mono", 1.0); // clock verified on PCB
 
 	VLM5030(config, m_vlm, XTAL(3'579'545));   // verified on PCB
 	m_vlm->set_addrmap(0, &yiear_state::vlm_map);

--- a/src/mame/sanritsu/appoooh.cpp
+++ b/src/mame/sanritsu/appoooh.cpp
@@ -30,9 +30,9 @@
     04  IN2
 
     write:
-    00  SN76496 #1
-    01  SN76496 #2
-    02  SN76496 #3
+    00  SN76489A #1
+    01  SN76489A #2
+    02  SN76489A #3
     03  MSM5205 address write
     04  bit 0   = NMI enable
         bit 1   = flipscreen
@@ -50,13 +50,13 @@
 ****************************************************************************
 
     Robo Wres 2001
-    Sega, (198x, possibly 1986?)
+    Sega, 1986
 
     Top Board
     =========
     PCB No: 834-5990 SEGA 1986
     CPU   : NEC D315-5179 (Z80?)
-    SOUND : OKI MSM5205 + Resonator 384kHz, SN76489 (x3)
+    SOUND : OKI MSM5205 + Resonator 384kHz, SN76489AN (x3)
     RAM   : MB8128 (x1)
     OTHER : Volume Pot (x2, labelled VOICE and SOUND)
     PALs  : (x1, near EPR-7542.15D, labelled 315-5056)
@@ -558,9 +558,9 @@ void robowres_state::decrypted_opcodes_map(address_map &map)
 void base_state::main_portmap(address_map &map)
 {
 	map.global_mask(0xff);
-	map(0x00, 0x00).portr("P1").w("sn1", FUNC(sn76489_device::write));
-	map(0x01, 0x01).portr("P2").w("sn2", FUNC(sn76489_device::write));
-	map(0x02, 0x02).w("sn3", FUNC(sn76489_device::write));
+	map(0x00, 0x00).portr("P1").w("sn1", FUNC(sn76489a_device::write));
+	map(0x01, 0x01).portr("P2").w("sn2", FUNC(sn76489a_device::write));
+	map(0x02, 0x02).w("sn3", FUNC(sn76489a_device::write));
 	map(0x03, 0x03).portr("DSW1").w(FUNC(base_state::adpcm_w));
 	map(0x04, 0x04).portr("BUTTON3").w(FUNC(base_state::out_w));
 	map(0x05, 0x05).w(FUNC(base_state::scroll_w)); // unknown
@@ -716,9 +716,9 @@ void base_state::common(machine_config &config)
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
-	SN76489(config, "sn1", 18.432_MHz_XTAL / 6).add_route(ALL_OUTPUTS, "mono", 0.30); // divider unknown
-	SN76489(config, "sn2", 18.432_MHz_XTAL / 6).add_route(ALL_OUTPUTS, "mono", 0.30); // divider unknown
-	SN76489(config, "sn3", 18.432_MHz_XTAL / 6).add_route(ALL_OUTPUTS, "mono", 0.30); // divider unknown
+	SN76489A(config, "sn1", 18.432_MHz_XTAL / 6).add_route(ALL_OUTPUTS, "mono", 0.30); // divider unknown
+	SN76489A(config, "sn2", 18.432_MHz_XTAL / 6).add_route(ALL_OUTPUTS, "mono", 0.30); // divider unknown
+	SN76489A(config, "sn3", 18.432_MHz_XTAL / 6).add_route(ALL_OUTPUTS, "mono", 0.30); // divider unknown
 
 	MSM5205(config, m_msm, 384000);
 	m_msm->vck_callback().set(FUNC(base_state::adpcm_int));

--- a/src/mame/sanritsu/bankp.cpp
+++ b/src/mame/sanritsu/bankp.cpp
@@ -29,23 +29,23 @@
 |                             EPR-10910  PR-10901  EPR-10905   SW1      W|
 |                                                                       A|
 |                                                                       Y|
-|                             EPR-10911  2016      EPR-10906   SN76489   |
+|                             EPR-10911  2016      EPR-10906   SN76489AN |
 |                                                                        |
-|                                                              SN76489   |
+|                                                              SN76489AN |
 |                             EPR-10912                                  |
-|                                                              SN76489   |
+|                                                              SN76489AN |
 |             2016            EPR-10913             Z80                  |
 |                                                               VOL      |
 |15.468MHz                    EPR-10914             555   358     HA1377A|
 |------------------------------------------------------------------------|
 
     Notes:
-          2016          - 2kx8 SRAM
-          Z80 clock     - 2.578MHz [15.468/6]
-          SN76489 clock - 2.578MHz [15.468/6]
-          VSync         - 60Hz
-          HSync         - 15.36kHz
-          SW1           - 8-position DIP switch
+          2016            - 2kx8 SRAM
+          Z80 clock       - 2.578MHz [15.468/6]
+          SN76489AN clock - 2.578MHz [15.468/6]
+          VSync           - 60Hz
+          HSync           - 15.36kHz
+          SW1             - 8-position DIP switch
 
           ROMs
           ----
@@ -78,9 +78,9 @@
     04  DSW
 
     write:
-    00  SN76496 #1
-    01  SN76496 #2
-    02  SN76496 #3
+    00  SN76489A #1
+    01  SN76489A #2
+    02  SN76489A #3
     05  horizontal scroll
     07  video control
 
@@ -374,9 +374,9 @@ void bankp_state::prg_map(address_map &map)
 void bankp_state::io_map(address_map &map)
 {
 	map.global_mask(0xff);
-	map(0x00, 0x00).portr("IN0").w("sn1", FUNC(sn76489_device::write));
-	map(0x01, 0x01).portr("IN1").w("sn2", FUNC(sn76489_device::write));
-	map(0x02, 0x02).portr("IN2").w("sn3", FUNC(sn76489_device::write));
+	map(0x00, 0x00).portr("IN0").w("sn1", FUNC(sn76489a_device::write));
+	map(0x01, 0x01).portr("IN1").w("sn2", FUNC(sn76489a_device::write));
+	map(0x02, 0x02).portr("IN2").w("sn3", FUNC(sn76489a_device::write));
 	map(0x04, 0x04).portr("DSW1");
 	map(0x05, 0x05).w(FUNC(bankp_state::scroll_w));
 	map(0x07, 0x07).w(FUNC(bankp_state::video_control_w));
@@ -526,12 +526,10 @@ INTERRUPT_GEN_MEMBER(bankp_state::vblank_interrupt)
 
 void bankp_state::bankp(machine_config &config)
 {
-	static constexpr XTAL MASTER_CLOCK = XTAL(15'468'480);
-
 	// Video timing
 	// PCB measured: H = 15.61khz V = 60.99hz, +/- 0.01hz
 	// --> VTOTAL should be OK, HTOTAL not 100% certain
-	static constexpr XTAL PIXEL_CLOCK = MASTER_CLOCK / 3;
+	static constexpr XTAL PIXEL_CLOCK = 15.46848_MHz_XTAL / 3;
 
 	static constexpr int HTOTAL  = 330;
 	static constexpr int HBEND   = 0 + 3 * 8;
@@ -542,7 +540,7 @@ void bankp_state::bankp(machine_config &config)
 	static constexpr int VBSTART = 224 + 2 * 8;
 
 	// basic machine hardware
-	Z80(config, m_maincpu, MASTER_CLOCK / 6);
+	Z80(config, m_maincpu, 15.46848_MHz_XTAL / 6);
 	m_maincpu->set_addrmap(AS_PROGRAM, &bankp_state::prg_map);
 	m_maincpu->set_addrmap(AS_IO, &bankp_state::io_map);
 	m_maincpu->set_vblank_int("screen", FUNC(bankp_state::vblank_interrupt));
@@ -559,9 +557,9 @@ void bankp_state::bankp(machine_config &config)
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
-	SN76489(config, "sn1", MASTER_CLOCK / 6).add_route(ALL_OUTPUTS, "mono", 1.0);
-	SN76489(config, "sn2", MASTER_CLOCK / 6).add_route(ALL_OUTPUTS, "mono", 1.0);
-	SN76489(config, "sn3", MASTER_CLOCK / 6).add_route(ALL_OUTPUTS, "mono", 1.0);
+	SN76489A(config, "sn1", 15.46848_MHz_XTAL / 6).add_route(ALL_OUTPUTS, "mono", 1.0);
+	SN76489A(config, "sn2", 15.46848_MHz_XTAL / 6).add_route(ALL_OUTPUTS, "mono", 1.0);
+	SN76489A(config, "sn3", 15.46848_MHz_XTAL / 6).add_route(ALL_OUTPUTS, "mono", 1.0);
 }
 
 

--- a/src/mame/sega/suprloco.cpp
+++ b/src/mame/sega/suprloco.cpp
@@ -360,8 +360,8 @@ void suprloco_state::sound_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
 	map(0x8000, 0x87ff).ram();
-	map(0xa000, 0xa003).w("sn1", FUNC(sn76496_device::write));
-	map(0xc000, 0xc003).w("sn2", FUNC(sn76496_device::write));
+	map(0xa000, 0xa003).w("sn1", FUNC(sn76489a_device::write));
+	map(0xc000, 0xc003).w("sn2", FUNC(sn76489a_device::write));
 	map(0xe000, 0xe000).r("ppi", FUNC(i8255_device::acka_r));
 }
 
@@ -499,9 +499,8 @@ void suprloco_state::suprloco(machine_config &config)
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
-	SN76496(config, "sn1", 4'000'000).add_route(ALL_OUTPUTS, "mono", 1.0);
-
-	SN76496(config, "sn2", 2'000'000).add_route(ALL_OUTPUTS, "mono", 1.0);
+	SN76489A(config, "sn1", 4'000'000).add_route(ALL_OUTPUTS, "mono", 1.0);
+	SN76489A(config, "sn2", 2'000'000).add_route(ALL_OUTPUTS, "mono", 1.0);
 }
 
 

--- a/src/mame/sunelectronics/ikki.cpp
+++ b/src/mame/sunelectronics/ikki.cpp
@@ -318,8 +318,8 @@ void ikki_state::sub_map(address_map &map)
 	map(0x0000, 0x1fff).rom();
 	map(0xc000, 0xc7ff).ram().share(m_spriteram);
 	map(0xc800, 0xcfff).ram().share("shared_ram");
-	map(0xd801, 0xd801).w("sn1", FUNC(sn76496_device::write));
-	map(0xd802, 0xd802).w("sn2", FUNC(sn76496_device::write));
+	map(0xd801, 0xd801).w("sn1", FUNC(sn76489a_device::write));
+	map(0xd802, 0xd802).w("sn2", FUNC(sn76489a_device::write));
 }
 
 
@@ -525,9 +525,8 @@ void ikki_state::ikki(machine_config &config)
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
-	SN76496(config, "sn1", CPU_CLOCK / 4).add_route(ALL_OUTPUTS, "mono", 0.75);
-
-	SN76496(config, "sn2", CPU_CLOCK / 2).add_route(ALL_OUTPUTS, "mono", 0.75);
+	SN76489A(config, "sn1", CPU_CLOCK / 4).add_route(ALL_OUTPUTS, "mono", 0.75);
+	SN76489A(config, "sn2", CPU_CLOCK / 2).add_route(ALL_OUTPUTS, "mono", 0.75);
 }
 
 

--- a/src/mame/tecmo/senjyo.cpp
+++ b/src/mame/tecmo/senjyo.cpp
@@ -171,9 +171,9 @@ void senjyo_state::senjyo_sound_map(address_map &map)
 {
 	map(0x0000, 0x1fff).rom();
 	map(0x4000, 0x43ff).ram();
-	map(0x8000, 0x8000).w("sn1", FUNC(sn76496_device::write));
-	map(0x9000, 0x9000).w("sn2", FUNC(sn76496_device::write));
-	map(0xa000, 0xa000).w("sn3", FUNC(sn76496_device::write));
+	map(0x8000, 0x8000).w("sn1", FUNC(sn76489a_device::write));
+	map(0x9000, 0x9000).w("sn2", FUNC(sn76489a_device::write));
+	map(0xa000, 0xa000).w("sn3", FUNC(sn76489a_device::write));
 	map(0xd000, 0xd000).w(FUNC(senjyo_state::dac_volume_w));
 	map(0xe000, 0xe000).w(FUNC(senjyo_state::dac_enable_w));
 }
@@ -238,9 +238,9 @@ void senjyo_state::starforb_sound_map(address_map &map)
 {
 	map(0x0000, 0x1fff).rom();
 	map(0x4000, 0x43ff).ram();
-	map(0x8000, 0x8000).w("sn1", FUNC(sn76496_device::write));
-	map(0x9000, 0x9000).w("sn2", FUNC(sn76496_device::write));
-	map(0xa000, 0xa000).w("sn3", FUNC(sn76496_device::write));
+	map(0x8000, 0x8000).w("sn1", FUNC(sn76489a_device::write));
+	map(0x9000, 0x9000).w("sn2", FUNC(sn76489a_device::write));
+	map(0xa000, 0xa000).w("sn3", FUNC(sn76489a_device::write));
 	map(0xd000, 0xd000).w(FUNC(senjyo_state::dac_volume_w));
 	map(0xe000, 0xe000).w(FUNC(senjyo_state::dac_enable_w));
 	map(0xf000, 0xffff).ram();
@@ -601,9 +601,9 @@ void senjyo_state::senjyo(machine_config &config)
 	/* sound hardware */
 	SPEAKER(config, "speaker").front_center();
 
-	SN76496(config, "sn1", 2000000).add_route(ALL_OUTPUTS, "speaker", 0.5);
-	SN76496(config, "sn2", 2000000).add_route(ALL_OUTPUTS, "speaker", 0.5);
-	SN76496(config, "sn3", 2000000).add_route(ALL_OUTPUTS, "speaker", 0.5);
+	SN76489A(config, "sn1", 2000000).add_route(ALL_OUTPUTS, "speaker", 0.5);
+	SN76489A(config, "sn2", 2000000).add_route(ALL_OUTPUTS, "speaker", 0.5);
+	SN76489A(config, "sn3", 2000000).add_route(ALL_OUTPUTS, "speaker", 0.5);
 
 	GENERIC_LATCH_8(config, m_soundlatch);
 	m_soundlatch->data_pending_callback().set(m_pio, FUNC(z80pio_device::strobe_a)).invert();


### PR DESCRIPTION
Corrected chip type based from PCB photos if it's not surface-scratched, otherwise schematics.

- Exed Exes
[PCB photo](https://i.ebayimg.com/images/g/6OQAAOSwfENkDlHk/s-l1600.webp) (taken from [ebay](https://www.ebay.com/itm/175648488300))

- Mr. Jong
[PCB photo](https://auctions.c.yimg.jp/images.auctions.yahoo.co.jp/image/dr000/auc0106/user/000696f3254c78fbbda1f60d0452f0d39da18c8be849aaac63ed7c464486683d/i-img1200x890-17500334907288amxjv6134917.jpg) (taken from [yahoo auction](https://auctions.yahoo.co.jp/jp/auction/p1188946995))

- Circus Charlie
[PCB photo](https://pbs.twimg.com/media/GZMrDcgasAAkADe?format=jpg&name=large) (taken from [X](https://x.com/BEEP_akihabara/status/1842864014352892315/photo/3), Surface scratched)
[schematic](https://www.arcade-museum.com/manuals-videogames/C/CircusCharlie.pdf)

- Hyper Sports
[PCB photo](https://i.ebayimg.com/images/g/O7QAAOSwS3hng16E/s-l1600.jpg) (taken from [ebay](https://www.ebay.com/itm/356459789866), Surface scratched)
[schematic](https://arcarc.xmission.com/PDF_Arcade_Manuals_and_Schematics/Hyper_Sports_Schematics.pdf)

- Konami's Ping Pong
[PCB photo](https://img.ricardostatic.ch/images/22d01ddf-7893-4eec-8f1d-41d90f81adc4/t_1800x1350/ping-pong-arcade-pcb-orig-konami) (taken from [ricardo.ch](https://www.ricardo.ch/de/a/ping-pong-arcade-pcb-orig-konami-1139289540/))

- Super Basketball
[PCB photo](https://i.ebayimg.com/00/s/MTYwMFgxNjAw/z/N8wAAOSwNnlkh6Ab/$_59.JPG) (taken from [sekaimon](https://www.sekaimon.com/itemdetail/155605506771/), Surface scratched)
[schematic](https://arcarc.xmission.com/PDF_Arcade_Manuals_and_Schematics/Super%20Basketball%20Schematics.pdf)

- Time Pilot '84
[PCB photo](https://i.ebayimg.com/images/g/MrMAAOSwRVBmBEN0/s-l1600.jpg) (taken from [ebay](https://www.ebay.com/itm/156779003368?_trksid=p2332490.c101224.m-1), Surface scratched)
[schematic](https://arcarc.xmission.com/PDF_Arcade_Manuals_and_Schematics/Time_Pilot_84_Schematics.pdf)

- Track & Field
[PCB photo](https://blog.jamesgamecenter.com/public/RL_TRACKFIELD/.TF_01_b.jpg) (taken from [blog.jamesgamecenter](https://blog.jamesgamecenter.com/index.php?post/2022/08/07/Repair-Log-2.17%3A-Hyper-Olympic-/-Track-Field-%28Nintendo%2C-1983%29), Surface scratched)
[schematic](https://arcarc.xmission.com/PDF_Arcade_Manuals_and_Schematics/Track_and_Field_Schematics_Complete.pdf)

- Appoooh
[PCB photo](https://livedoor.blogimg.jp/gotochin_5g/imgs/9/a/9a7794bf.jpg) (taken from [blog.livedoor](http://blog.livedoor.jp/gotochin_5g/archives/1060782107.html))

- Bank Panic
[PCB photo](https://www.ukvac.com/forum/data/uploads/3725/20220223_161359_copy_4000x3000_copy_2000x1500.jpg) (taken from [ukvac](https://www.ukvac.com/forum/threads/bank-panic-prom.69270/))

- Super Locomotive
[PCB photo](https://auctions.afimg.jp/e1102720712/ya/image/e1102720712.4.jpg) (taken from [yahoo auction](https://aucview.com/yahoo/e1102720712/))

- Ikki
[PCB photo](https://img.aucfree.com/p719465977.3.jpg) (taken from [aucfree](https://aucfree.com/items/p719465977))

- Star Force
[PCB photo](https://pbs.twimg.com/media/GtjinmLaAAA0ttz?format=jpg&name=large) (taken from [X](https://x.com/smf_uf/status/1934545284329246979))