### PR TITLE
sega/model2: implement proper lighting; improve "gamma" table

### DIFF
--- a/src/mame/sega/model2.cpp
+++ b/src/mame/sega/model2.cpp
@@ -10,13 +10,12 @@
     MAME driver by R. Belmont, Olivier Galibert, ElSemi and Angelo Salese.
 
     TODO:
-    - color gamma and Mip Mapping still needs to be properly sorted in the renderer;
+    - Mip Mapping still needs to be properly sorted in the renderer;
     - sound comms still needs some work (sometimes m68k doesn't get some commands or play them with a delay);
     - outputs and artwork (for gearbox indicators);
     - clean-ups;
 
     TODO (per-game issues)
-    - daytona: car glasses doesn't get loaded during gameplay;
     - doa, doaa: corrupted sound, eventually becomes silent;
     - dynamcopc: corrupts palette for 2d;
     - fvipers: enables timers, but then irq register is empty, hence it crashes with an "interrupt halt" at POST (regression);
@@ -26,11 +25,8 @@
                 (compute_fmul_avg, shift operation 0x11, ALU operation 0x89 (compute_favg));
     - manxtt: no escape from "active motion slider" tutorial (needs analog inputs),
               bypass it by entering then exiting service mode;
-    - sgt24h: first turn in easy reverse course has ugly rendered mountain in background;
-    - srallyc: some 3d elements doesn't show up properly (tree models, last hill in course 1 is often black colored);
     - stcc: no collision detection with enemy cars, sometimes enemy cars glitch out and disappear altogether;
     - vcop: sound dies at enter initial screen (i.e. after played the game once) (untested);
-    - vstriker: stadium ads have terrible colors (they uses the wrong color table, @see video/model2rd.hxx)
 
     Notes:
     - some analog games can be calibrated in service mode via volume control item ...

--- a/src/mame/sega/model2.h
+++ b/src/mame/sega/model2.h
@@ -629,6 +629,7 @@ struct m2_poly_extra_data
 	u32      texx, texy;
 	u8       texmirrorx;
 	u8       texmirrory;
+	u8       luma;
 };
 
 

--- a/src/mame/sega/model2rd.ipp
+++ b/src/mame/sega/model2rd.ipp
@@ -61,16 +61,14 @@ void MODEL2_FUNC_NAME(int32_t scanline, const extent_t& extent, const m2_poly_ex
 #if !defined( MODEL2_TRANSLUCENT)
 	model2_state *state = object.state;
 	u32 *const p = &m_destmap.pix(scanline);
-//  u8  *gamma_value = &state->m_gamma_table[0];
+	u8  *gamma_value = &state->m_gamma_table[0];
 
 	/* extract color information */
-//  const u16 *colortable_r = &state->m_colorxlat[0x0000/2];
-//  const u16 *colortable_g = &state->m_colorxlat[0x4000/2];
-//  const u16 *colortable_b = &state->m_colorxlat[0x8000/2];
-//  const u16 *lumaram = &state->m_lumaram[0];
-//  u32  lumabase = object.lumabase;
+	const u16 *colortable_r = &state->m_colorxlat[0x0000/2];
+	const u16 *colortable_g = &state->m_colorxlat[0x4000/2];
+	const u16 *colortable_b = &state->m_colorxlat[0x8000/2];
 	u32  color = object.colorbase;
-//  u8   luma;
+	u8   luma;
 	u32  tr, tg, tb;
 	int     x;
 #endif
@@ -79,27 +77,23 @@ void MODEL2_FUNC_NAME(int32_t scanline, const extent_t& extent, const m2_poly_ex
 	return;
 #else
 
-//  luma = lumaram[(lumabase + (0xf << 3))];
-
-	// fix luma overflow
-//  luma = std::min((int)luma,0x3f);
+	luma = object.luma >> 2;
 
 	color = state->m_palram[(color + 0x1000)] & 0xffff;
 
-//  colortable_r += ((color >>  0) & 0x1f) << 8;
-//  colortable_g += ((color >>  5) & 0x1f) << 8;
-//  colortable_b += ((color >> 10) & 0x1f) << 8;
+	colortable_r += ((color >>  0) & 0x1f) << 8;
+	colortable_g += ((color >>  5) & 0x1f) << 8;
+	colortable_b += ((color >> 10) & 0x1f) << 8;
 
 	/* we have the 6 bits of luma information along with 5 bits per color component */
 	/* now build and index into the master color lookup table and extract the raw RGB values */
 
-	// untextured path doesn't use luma & color table, cfr. Daytona and Motor Raid
-	tr = pal5bit((color >> 0) & 0x1f); //colortable_r[(luma)] & 0xff;
-	tg = pal5bit((color >> 5) & 0x1f); //colortable_g[(luma)] & 0xff;
-	tb = pal5bit((color >> 10) & 0x1f); //colortable_b[(luma)] & 0xff;
-//  tr = gamma_value[tr];
-//  tg = gamma_value[tg];
-//  tb = gamma_value[tb];
+	tr = colortable_r[(luma)] & 0xff;
+	tg = colortable_g[(luma)] & 0xff;
+	tb = colortable_b[(luma)] & 0xff;
+	tr = gamma_value[tr];
+	tg = gamma_value[tg];
+	tb = gamma_value[tb];
 
 	/* build the final color */
 	color = rgb_t(tr, tg, tb);
@@ -184,13 +178,10 @@ void MODEL2_FUNC_NAME(int32_t scanline, const extent_t& extent, const m2_poly_ex
 		if ( t == 0x0f )
 			continue;
 #endif
-		luma = lumaram[(lumabase + (t << 3))];
+		luma = (u32)lumaram[lumabase + (t << 3)] * object.luma / 256;
 
 		// Virtua Striker sets up a luma of 0x40 for national flags on bleachers, fix here.
 		luma = std::min((int)luma,0x3f);
-		// (Again) Virtua Striker seem to lookup colortable with a reversed endianness (stadium ads)
-		// TODO: it breaks Mexican flag colors tho ...
-//      luma^= 1;
 
 		/* we have the 6 bits of luma information along with 5 bits per color component */
 		/* now build and index into the master color lookup table and extract the raw RGB values */


### PR DESCRIPTION
With the implementation of lighting, stadium ads in Virtua Striker now have the correct colors.

Model 2 games set a "gamma curve" by using the color translate RAM. It is most likely that each cabinet has its monitor factory-calibrated to produce a desirable picture for the specific game it was designed to play. Virtua Fighter 2, Fighting Vipers and Sonic the Fighters feature adjustable bias and gain settings, presumably to allow software calibration when installing the game board into an Astro City or similar multi-purpose cabinet.

For now I have settled on the translation `raw_value = std::max(((double)i - 64.0) * 255.0 / 191.0, 0.0)` since this produces decent results for most games without requiring any game-specific adjustments. For the above titles which allow software calibration, setting the bias to 64 and gain to 51 gives optimal results.

The 2D tilemap layers are currently not affected by color translate RAM or the "gamma table"; this is on my to-do list.