### PR TITLE
debugger: fix symlist default CPU

### DIFF
--- a/src/emu/debug/debugcmd.cpp
+++ b/src/emu/debug/debugcmd.cpp
@@ -3912,8 +3912,8 @@ void debugger_commands::execute_symlist(const std::vector<std::string_view> &par
 	device_t *cpu = nullptr;
 	symbol_table *symtable;
 
-	// default to CPU "0" if none specified
-	if (!m_console.validate_cpu_parameter(params.empty() ? "0" : params[0], cpu))
+	// default to visible CPU if none specified
+	if (!m_console.validate_cpu_parameter(params.empty() ? std::string_view() : params[0], cpu))
 	{
 		if (!params.empty())
 			return; // explicitly specified CPU is invalid


### PR DESCRIPTION
When executed with no parameters, symlist was displaying the symbol tables for the first CPU and the debugger built-in globals.  Defaulting to the first CPU like that didn't make sense.  It now displays the symbol tables for the VISIBLE cpu and the debugger built-in globals.