### PR TITLE
coreaudio_sound.cpp: fix __MAC_OS_X_VERSION_MIN_REQUIRED version check

### DIFF
--- a/src/osd/modules/sound/coreaudio_sound.cpp
+++ b/src/osd/modules/sound/coreaudio_sound.cpp
@@ -25,7 +25,7 @@
 #include <new>
 #include <cstring>
 
-#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1200
+#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 120000
 #define PROPERTY_ELEMENT_MASTER kAudioObjectPropertyElementMain
 #else
 #define PROPERTY_ELEMENT_MASTER kAudioObjectPropertyElementMaster


### PR DESCRIPTION
AvailabilityVersions.h:
```
#define __MAC_12_0                                      120000
#define  MAC_OS_VERSION_12_0                             __MAC_12_0
```