### PR TITLE
Windows:  Do not drop into debugger when no MAME window has focus

### DIFF
--- a/src/osd/modules/debugger/debugwin.cpp
+++ b/src/osd/modules/debugger/debugwin.cpp
@@ -235,16 +235,20 @@ void debugger_windows::debugger_update()
 	// if we're running live, do some checks
 	if (!winwindow_has_focus() && m_machine && !m_machine->debugger().cpu().is_stopped() && (m_machine->phase() == machine_phase::RUNNING))
 	{
-		// see if the interrupt key is pressed and break if it is
-		if (seq_pressed())
+		// check to see if a debugger window has focus
+		if (std::any_of(m_window_list.begin(), m_window_list.end(), [](auto const& window) { return window->has_focus(); }))
 		{
-			HWND const focuswnd = GetFocus();
+			// see if the interrupt key is pressed and break if it is
+			if (seq_pressed())
+			{
+				HWND const focuswnd = GetFocus();
 
-			m_machine->debugger().debug_break();
+				m_machine->debugger().debug_break();
 
-			// if we were focused on some window's edit box, reset it to default
-			for (auto &info : m_window_list)
-				info->restore_field(focuswnd);
+				// if we were focused on some window's edit box, reset it to default
+				for (auto& info : m_window_list)
+					info->restore_field(focuswnd);
+			}
 		}
 	}
 }

--- a/src/osd/modules/debugger/win/debugwininfo.cpp
+++ b/src/osd/modules/debugger/win/debugwininfo.cpp
@@ -81,6 +81,14 @@ void debugwin_info::destroy()
 	DestroyWindow(m_wnd);
 }
 
+
+bool debugwin_info::has_focus() const
+{
+	HWND focus_hwnd = GetFocus();
+	return m_wnd == focus_hwnd || IsChild(m_wnd, focus_hwnd);
+}
+
+
 bool debugwin_info::set_default_focus()
 {
 	return false;

--- a/src/osd/modules/debugger/win/debugwininfo.h
+++ b/src/osd/modules/debugger/win/debugwininfo.h
@@ -43,6 +43,7 @@ public:
 	void set_foreground() const { SetForegroundWindow(m_wnd); }
 	void redraw();
 	void destroy();
+	bool has_focus() const;
 
 	virtual bool set_default_focus();
 	void prev_view(debugview_info *curview);


### PR DESCRIPTION
On Windows, the debugger has a special Windows-specific feature that drops the user into the debugger if the key sequence is pressed.  This seems to be present so that the key sequence triggers dropping into the debugger not just from the main window, but also from debugger windows.

This has also created an oddity where pressing the debugger key sequence from a MAME window will cause a "User-initiated break" but pressing it from a debugger window will cause "Internal breakpoint" to be displayed.

However, while this logic has a check to not apply when to a MAME window, it seems to also activate even if MAME itself is not in focus.  This change ensures that a stray debugger sequence in a completely unrelated application won't cause the user to be dropped in the debugger.