### PR TITLE
No longer require wayland-egl-backend at compile-time

### DIFF
--- a/scripts/src/3rdparty.lua
+++ b/scripts/src/3rdparty.lua
@@ -1636,9 +1636,6 @@ end
 			defines {
 				"WL_EGL_PLATFORM=1",
 			}
-			buildoptions {
-				backtick(pkgconfigcmd() .. " --cflags wayland-egl-backend"),
-			}
 		end
 	end
 


### PR DESCRIPTION
Since ba6f5853e9382a959af8ff81980c0f06a6ffe80e wayland is dynamically loaded at run-time.