### PR TITLE
sdl_sound.cpp: Fall back to 2 channels if 0 channels are detected on a device

### DIFF
--- a/src/osd/modules/sound/sdl_sound.cpp
+++ b/src/osd/modules/sound/sdl_sound.cpp
@@ -106,6 +106,10 @@ int sound_sdl::init(osd_interface &osd, const osd_options &options)
 		const char *const name = SDL_GetAudioDeviceName(i, 0);
 #if SDL_VERSION_ATLEAST(2, 0, 16)
 		const int err = SDL_GetAudioDeviceSpec(i, 0, &spec);
+		// the ALSA backend in SDL2 doesn't return the number of channels, just fall back to a safe value
+		if (spec.channels == 0) {
+			spec.channels = 2;
+		}
 #else
 		// seems to be no way to get the device's native format before SDL 2.0.16, just fall back to 48kHz stereo
 		const int err = 0;


### PR DESCRIPTION
According to SDL2 ALSA backend author, the ALSA backend doesn't return the number of channels in `SDL_GetAudioDeviceSpec()` calls:

https://github.com/libsdl-org/SDL/issues/13315#issuecomment-3032240493

So in the case of  `SDL_GetAudioDeviceSpec()` returning 0 channels, fall back to a safe value of 2 channel for that device.

Maybe  `SDL_GetAudioDeviceSpec()` will return the number of channels on ALSA someday and this can be removed, but for now this is needed to have MAME produce audio when SDL2 uses plain ALSA audio.

This PR fixes issue https://github.com/mamedev/mame/issues/13891