### PR TITLE
debugger/qt/debuggerview.cpp: Used DCA_SELECTED color friendly for Light/Dark theme

### DIFF
--- a/src/osd/modules/debugger/qt/debuggerview.cpp
+++ b/src/osd/modules/debugger/qt/debuggerview.cpp
@@ -126,7 +126,7 @@ void DebuggerView::paintEvent(QPaintEvent *event)
 				bgColor.setRgb(palette.color(QPalette::Base).rgb());
 
 			if (textAttr & DCA_SELECTED)
-				bgColor.setRgb(0xff, 0x80, 0x80);
+				bgColor.setRgb(0xcb, 0x4b, 0x16);
 
 			if (textAttr & DCA_CURRENT)
 				bgColor.setRgb(palette.color(QPalette::Highlight).rgb());


### PR DESCRIPTION
Existing color selection doesn't work well when switching from Light to Dark theme

![image](https://github.com/user-attachments/assets/bd760005-42f0-4a14-a6fc-353ffaac3141)
![image](https://github.com/user-attachments/assets/4c7c9ec9-7d66-4bad-a5ca-e0936328f776)

I'm suggesting to use hardcoded colors friendly for both. see: https://ethanschoonover.com/solarized/

![image](https://github.com/user-attachments/assets/5582c8a9-8844-4d2e-9a25-79a080fc4eb5)
![image](https://github.com/user-attachments/assets/cf2c42f8-71ab-466e-b08b-2064c8b80bdc)
