### PR TITLE
sdl_sound.cpp: Correct default device selection logic.

### DIFF
--- a/src/osd/modules/sound/sdl_sound.cpp
+++ b/src/osd/modules/sound/sdl_sound.cpp
@@ -208,7 +208,7 @@ uint32_t sound_sdl::stream_sink_open(uint32_t node, std::string name, uint32_t r
 	dspec.callback = sink_callback;
 	dspec.userdata = stream.get();
 
-	stream->m_sdl_id = SDL_OpenAudioDevice(dev.m_def ? nullptr : dev.m_name.c_str(), 0, &dspec, &ospec, 0);
+	stream->m_sdl_id = SDL_OpenAudioDevice(dev.m_def ? dev.m_name.c_str() : nullptr, 0, &dspec, &ospec, 0);
 	if(!stream->m_sdl_id)
 		return 0;
 	SDL_PauseAudioDevice(stream->m_sdl_id, 0);


### PR DESCRIPTION
The logic on the `SDL_OpenAudioDevice()` call was inverted.
This:
`SDL_OpenAudioDevice(dev.m_def ? nullptr : dev.m_name.c_str(), 0, &dspec, &ospec, 0);`
...would mean that if `dev.m_def` has non-zero value, `nullptr` would be used instead of `dev.m_name.c_str()`, which makes no sense: we want to use `dev.m_name.c_str()` when `dev.m_def` is non-zero, and `nullptr` otherwise.

As a side-effect, this works around SDL2's ALSA backend inability to report a default audio device with `SDL_GetDefaultAudioInfo()` and thus is a workaround for issue https://github.com/mamedev/mame/issues/13910
That 's because, when no default device is reported by  `SDL_GetDefaultAudioInfo()`, nullptr is properly passed to `SDL_OpenAudioDevice()` now and the default device is chosen by SDL2 as most SDL2 programs/games do.