### PR TITLE
formats/all.cpp: Include IPF, 86F disk formats in floptool

### DIFF
--- a/src/lib/formats/all.cpp
+++ b/src/lib/formats/all.cpp
@@ -9,6 +9,7 @@
 
 #include "cqm_dsk.h"
 #include "dsk_dsk.h"
+#include "ipf_dsk.h"
 #include "td0_dsk.h"
 #include "hxchfe_dsk.h"
 #include "hxcmfm_dsk.h"
@@ -18,6 +19,7 @@
 #include "pc_dsk.h"
 #include "d88_dsk.h"
 #include "dfi_dsk.h"
+#include "86f_dsk.h"
 #include "fs_unformatted.h"
 
 #ifdef HAS_FORMATS_2D_DSK
@@ -532,10 +534,6 @@
 #include "pc98_dsk.h"
 #endif
 
-#ifdef HAS_FORMATS_IPF_DSK
-#include "ipf_dsk.h"
-#endif
-
 #ifdef HAS_FORMATS_PHC25_CAS
 #include "phc25_cas.h"
 #endif
@@ -783,6 +781,7 @@ void mame_formats_full_list(mame_formats_enumerator &en)
 	en.add(FLOPPY_MFM_FORMAT); // hxcmfm_dsk.h
 	en.add(FLOPPY_TD0_FORMAT); // td0_dsk.h
 	en.add(FLOPPY_IMD_FORMAT); // imd_dsk.h
+	en.add(FLOPPY_86F_FORMAT); // 86f_dsk.h
 
 	en.category("Container MFM");
 	en.add(FLOPPY_D88_FORMAT); // d88_dsk.h
@@ -822,6 +821,7 @@ void mame_formats_full_list(mame_formats_enumerator &en)
 
 	en.category("PC");
 	en.add(FLOPPY_PC_FORMAT); // pc_dsk.h
+	en.add(FLOPPY_IPF_FORMAT); // ipf_dsk.h
 #ifdef HAS_FORMATS_IBMXDF_DSK
 	en.add(FLOPPY_IBMXDF_FORMAT); // ibmxdf_dsk.h
 #endif
@@ -898,9 +898,6 @@ void mame_formats_full_list(mame_formats_enumerator &en)
 #ifdef HAS_FORMATS_AMI_DSK
 	en.add(FLOPPY_ADF_FORMAT); // ami_dsk.h
 #endif
-#ifdef HAS_FORMATS_IPF_DSK
-	en.add(FLOPPY_IPF_FORMAT); // ipf_dsk.h
-#endif
 
 	en.category("Archimedes");
 #ifdef HAS_FORMATS_APD_DSK
@@ -921,7 +918,7 @@ void mame_formats_full_list(mame_formats_enumerator &en)
 	en.add(FLOPPY_HPI_FORMAT); // hpi_dsk.h
 #endif
 #ifdef HAS_FORMATS_FS_HPLIF
-	en.add(fs::HPLIF); // fs_lif.h
+	en.add(fs::HPLIF); // fs_hplif.h
 #endif
 #ifdef HAS_FORMATS_FS_HP98X5
 	en.add(fs::HP9825);


### PR DESCRIPTION
IPF is included unconditionally by scripts/formats.lua, so the HAS_FORMATS condition was always false.

86F is also included unconditionally but simply wasn't added to formats/all.cpp when it was introduced.

I added 86F to the "Container FM/MFM" category for consistency with the grouping in devices/imagedev/floppy.cpp and moved IPF to the "PC" category for the same reason.

cf. 3b13ae6d7121b3e1de8e5aa48918f9f9b6567f7a, add6b4515206d5973ec7e3e30012a469fecc49bb