### PR TITLE
cpu/mb86233: sort out register update priority

### DIFF
--- a/src/devices/cpu/mb86233/mb86233.h
+++ b/src/devices/cpu/mb86233/mb86233.h
@@ -113,7 +113,8 @@ private:
 
 	void alu_update_st();
 	void alu_pre(u32 alu);
-	void alu_post(u32 alu);
+	void alu_post_1(u32 alu);
+	void alu_post_2(u32 alu);
 	u16 ea_pre_0(u32 r);
 	void ea_post_0(u32 r);
 	u16 ea_pre_1(u32 r);

--- a/src/mame/sega/model2.cpp
+++ b/src/mame/sega/model2.cpp
@@ -175,7 +175,7 @@ void model2_tgp_state::machine_start()
 {
 	model2_state::machine_start();
 
-	m_copro_fifo_in->setup(16,
+	m_copro_fifo_in->setup(8,
 						   [this]() { m_copro_tgp->stall(); },
 						   [this]() { m_copro_tgp->set_input_line(INPUT_LINE_HALT, ASSERT_LINE); },
 						   [this]() { m_copro_tgp->set_input_line(INPUT_LINE_HALT, CLEAR_LINE); },
@@ -184,7 +184,7 @@ void model2_tgp_state::machine_start()
 						   [    ]() { },
 						   [    ]() { });
 
-	m_copro_fifo_out->setup(16,
+	m_copro_fifo_out->setup(8,
 							[this]() { m_maincpu->i960_stall(); },
 							[this]() { m_maincpu->set_input_line(INPUT_LINE_HALT, ASSERT_LINE); },
 							[this]() { m_maincpu->set_input_line(INPUT_LINE_HALT, CLEAR_LINE); },


### PR DESCRIPTION
The TGP code for Sega Rally and Manx TT have multiple instructions where both the ALU op and the transfer write to the same register D. Here is one of those instructions, from a subroutine that approximates square roots:
`01B3: 1D9DB24E fsmd : mov $0x4e, d`

Since commit 5363907, we emulate it so that the final value assigned to D is the result of the transfer rather than the ALU operation, but this results in the speed of the enemy cars being too slow compared to real hardware (both ElSemi's Model 2 Emulator and the PS2 release of this game bundled with Sega Rally 2006 have the same issue). If we change the register update priority for the above instruction only, the speed of the enemy cars in Sega Rally matches real hardware, without the bug where cars clip into the track and fly into the air that was present before commit 5363907.

It seems that the result of `fsmd` operations take precedence over transfers in the event of both of them writing to the same register, but `subd` and `andd` operations do not. My best guess is that floating point operations take 2 cycles to execute ([MB86232 datasheet](https://ftpmirror.your.org/pub/misc/bitsavers/pdf/fujitsu/_dataSheets/MB86232_DSP_Sep89.pdf), page 33) and so the register is updated after the transfer has completed, whereas integer operations, which execute in a single cycle, update the register before the transfer overwrites the result.

Making the floating point operations take 2 cycles reintroduces the Manx TT course select bug, so I have found another way to fix it: shortening the TGP input/output FIFO buffer length from 16 to 8, which matches the TGPx4.