### PR TITLE
Add point-ROM auto-increment to Namco System 23

### DIFF
--- a/src/mame/namco/namcos23.cpp
+++ b/src/mame/namco/namcos23.cpp
@@ -4810,9 +4810,8 @@ u16 namcos23_state::c417_ptrom_lsw_r()
 		LOGMASKED(LOG_C417_REG, "%s: c417 point rom (over-limit) lsw read: %04x\n", machine().describe_context(), 0xffff);
 		return 0xffff;
 	}
-	// TODO: rapid river wants auto-inc in some way here (NGs point ROM self test otherwise)
 	LOGMASKED(LOG_C417_REG, "%s: c417 point rom[%06x] lsw read: %04x\n", machine().describe_context(), m_c417.pointrom_adr, (u16)m_ptrom[m_c417.pointrom_adr]);
-	return m_ptrom[m_c417.pointrom_adr];
+	return m_ptrom[m_c417.pointrom_adr++];
 }
 
 void namcos23_state::c417_irq_ack_w(offs_t offset, u16 data)


### PR DESCRIPTION
This fixes point-ROM verification in Final Furlong's service menu.

In addition, it significantly improves graphics in Downhill Bikers and Race On!, as both games look for the expected walking-bit patterns from offset 0x100 to 0x1FF in the point-ROM data, with the expectation of the current point-ROM peephole address to auto-increment after each LSW read. If the walking-bit patterns aren't found, it zeroes out a global model-index offset, otherwise it sets that offset to 0x80.

Downhill Bikers won't fail to POST if these bit patterns aren't present, so this might be some sort of development leftover where the first 512 bytes of data were only added to the point-ROM data as part of the retail build process.