### PR TITLE
CD-i: Fix Double Width Cursor

### DIFF
--- a/src/mame/philips/mcd212.cpp
+++ b/src/mame/philips/mcd212.cpp
@@ -760,7 +760,7 @@ void mcd212_device::draw_cursor(uint32_t *scanline)
 	if ((0 <= y) && (y < 16))
 	{
 		const uint32_t color = s_4bpp_color[color_index];
-		const uint8_t resolution = (m_cursor_control & CURCNT_CUW) ? 4 : 2;
+		const uint8_t resolution = (m_cursor_control & CURCNT_CUW) ? 1 : 2;
 		for (int x = 0; x < 16; x++)
 		{
 			if (BIT(m_cursor_pattern[y], 15 - x))


### PR DESCRIPTION
This fixes #13968

Originally this flag made the cursor 2x as wide (4 pixels). However the Validation Disc (EU) test GC_Ptn has a clarifying comment that in double-resolution mode, the cursor should be half the width of the normal cursor.

This fixes this oversight.

Here's the comment
<img width="1774" height="939" alt="image" src="https://github.com/user-attachments/assets/32a85609-30c4-4a14-957f-5d82d525c595" />

And with the fix
<img width="1553" height="845" alt="image" src="https://github.com/user-attachments/assets/bce37c78-5151-4591-9f72-67304399c914" />

To validate, you can simply play `The Challenge (UK)` and notice the cursor looks properly sized, instead of 4x too wide.
