### PR TITLE
CD-i: Fix Pixel Hold Clut4

### DIFF
--- a/src/mame/philips/mcd212.cpp
+++ b/src/mame/philips/mcd212.cpp
@@ -674,13 +674,23 @@ const uint32_t mcd212_device::s_4bpp_color[16] =
 template <bool MosaicA, bool MosaicB, bool OrderAB>
 void mcd212_device::mix_lines(uint32_t *plane_a, bool *transparent_a, uint32_t *plane_b, bool *transparent_b, uint32_t *out)
 {
-	const uint8_t mosaic_count_a = (m_mosaic_hold[0] & 0x0000ff) << 1;
-	const uint8_t mosaic_count_b = (m_mosaic_hold[1] & 0x0000ff) << 1;
+	const uint8_t icmA = get_icm<0>();
+	const uint8_t icmB = get_icm<1>();
+	uint16_t mosaic_count_a = (m_mosaic_hold[0] & 0x0000ff) << 1;
+	uint16_t mosaic_count_b = (m_mosaic_hold[1] & 0x0000ff) << 1;
 	const int width = get_screen_width();
 	const int border_width = get_border_width();
 
 	uint8_t *weight_a = &m_weight_factor[0][0];
 	uint8_t *weight_b = &m_weight_factor[1][0];
+
+	// Console Verified. CLUT4 pixels are drawn in pairs during VSR. So the mosaic here is halved.
+	if (icmA == ICM_CLUT4) {
+		mosaic_count_a >>= 1;
+	}
+	if (icmB == ICM_CLUT4) {
+		mosaic_count_b >>= 1;
+	}
 
 	for (int x = 0; x < width; x++)
 	{


### PR DESCRIPTION
Console verification identified a dependency in CLUT4 pixel hold behavior.

This corrects a factor of 2 error in the width for CLUT4.

This fixes #13513

Previous Behavior:
<img width="2560" height="1600" alt="425791586-989b6115-31cc-4621-98b4-eb9be119ef16" src="https://github.com/user-attachments/assets/2a61b61a-1f29-4444-85fe-b982984f6780" />

Correct Console behavior:
<img width="1098" height="694" alt="425791517-5a2979d9-73d8-48bf-b79d-bd9a181e9f6e" src="https://github.com/user-attachments/assets/d17e96fc-fb37-4f68-9d10-a077b4cc4982" />

New behavior after fix
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/197c0138-5636-4a29-aa0a-87b7214989c0" />

