### PR TITLE
CD-i: Add Undefined Matte Behavior

### DIFF
--- a/src/mame/philips/mcd212.cpp
+++ b/src/mame/philips/mcd212.cpp
@@ -54,17 +54,15 @@ inline ATTR_FORCE_INLINE uint8_t mcd212_device::get_matte_op(const uint32_t matt
 
 void mcd212_device::update_matte_arrays()
 {
-	bool latched_mf[2]{ false, false };
-	uint8_t latched_wfa = m_weight_factor[0][0];
-	uint8_t latched_wfb = m_weight_factor[1][0];
 	const int width = get_screen_width();
-
 	const int num_mattes = BIT(m_image_coding_method, ICM_NM_BIT) ? 2 : 1;
-	const bool matte_flag = BIT(m_matte_control[0], MC_MF_BIT); // MF bit must be the same. See 5.10.2 Matte Commands
+	const bool matte_flag = BIT(m_matte_control[0], MC_MF_BIT);
 
+	bool latched_mf[2]{ false, false };
+	uint8_t latched_wf[2] = { m_weight_factor[0][0], m_weight_factor[1][0] };
 	int matte_idx[2] = { 0, 4 };
-	int x = 0;
-	for (; x < width; x++)
+
+	for (int x = 0; x < width; x++)
 	{
 		for (int matte = 0; matte < num_mattes; matte++)
 		{
@@ -74,69 +72,39 @@ void mcd212_device::update_matte_arrays()
 				continue;
 			}
 			const uint32_t matte_ctrl = m_matte_control[matte_idx[matte]];
-			const uint32_t matte_op = get_matte_op(matte_idx[matte]);
-			const int flag = (num_mattes == 2) ? matte : matte_flag;
 
 			if (x == (matte_ctrl & MC_X))
 			{
+				const uint32_t matte_op = get_matte_op(matte_idx[matte]);
+				const int flag = (num_mattes == 2) ? matte : BIT(m_matte_control[matte_idx[matte]], MC_MF_BIT);
+				// See 5.10.2 Matte Commands. Changing the MF-bit inside a line is undefined. Greenbook says don't do it.
+				// Console validation shows the 220 reads and uses this value anyway.
 				switch (matte_op)
 				{
 				case 0: // Disregard all commands in higher registers. See 5.10.2
-					matte_idx[matte] = max_matte_id;
+					matte_idx[matte] = 8;
 					break;
-				case 1:
-				case 2:
-				case 3: // Not used
+				case 1: case 2:	case 3: case 5: case 7: case 10: case 11: // Not used
 					break;
-				case 4: // Change weight of plane A
-					latched_wfa = get_weight_factor(matte_idx[matte]);
+				case 4: case 6: // Change weight of plane (A or B)
+					latched_wf[BIT(matte_op, 1)] = get_weight_factor(matte_idx[matte]);
 					break;
-				case 5: // Not used
+				case 8: case 9: // (Reset or Set) matte flag
+					latched_mf[flag] = BIT(matte_op, 0);
 					break;
-				case 6: // Change weight of plane B
-					latched_wfb = get_weight_factor(matte_idx[matte]);
-					break;
-				case 7: // Not used
-					break;
-				case 8: // Reset matte flag
-					latched_mf[flag] = false;
-					break;
-				case 9: // Set matte flag
-					latched_mf[flag] = true;
-					break;
-				case 10:    // Not used
-				case 11:    // Not used
-					break;
-				case 12: // Reset matte flag and change weight of plane A
-					latched_wfa = get_weight_factor(matte_idx[matte]);
-					latched_mf[flag] = false;
-					break;
-				case 13: // Set matte flag and change weight of plane A
-					latched_wfa = get_weight_factor(matte_idx[matte]);
-					latched_mf[flag] = true;
-					break;
-				case 14: // Reset matte flag and change weight of plane B
-					latched_wfb = get_weight_factor(matte_idx[matte]);
-					latched_mf[flag] = false;
-					break;
-				case 15: // Set matte flag and change weight of plane B
-					latched_wfb = get_weight_factor(matte_idx[matte]);
-					latched_mf[flag] = true;
+				case 12: case 13: case 14: case 15: // Change weight of plane (A or B) and (Reset or Set) matte flag
+					latched_wf[BIT(matte_op, 1)] = get_weight_factor(matte_idx[matte]);
+					latched_mf[flag] = BIT(matte_op, 0);
 					break;
 				}
 				matte_idx[matte]++;
 			}
 		}
-		m_weight_factor[0][x] = latched_wfa;
-		m_weight_factor[1][x] = latched_wfb;
+		m_weight_factor[0][x] = latched_wf[0];
+		m_weight_factor[1][x] = latched_wf[1];
 		m_matte_flag[0][x] = latched_mf[0];
 		m_matte_flag[1][x] = latched_mf[1];
 	}
-	// Fill the remainder.
-	std::fill_n(m_weight_factor[0] + x, std::size(m_weight_factor[0]) - x, latched_wfa);
-	std::fill_n(m_weight_factor[1] + x, std::size(m_weight_factor[1]) - x, latched_wfb);
-	std::fill_n(m_matte_flag[0] + x, std::size(m_matte_flag[0]) - x, latched_mf[0]);
-	std::fill_n(m_matte_flag[1] + x, std::size(m_matte_flag[1]) - x, latched_mf[1]);
 }
 
 template <int Path>


### PR DESCRIPTION
Fixes #13976

Greenbook says not to change the MF flag within a line. However, if you do, the behavior is undefined.

Console verification shows that the real console will use these values. The non-spec behavior is explained in a comment.

Additionally, this tidies up the Matte function.

Previous Behavior
<img width="1357" height="1095" alt="{0C366E68-17F7-4B26-AC48-FB056B3B1381}" src="https://github.com/user-attachments/assets/2841d4dc-c051-4d06-aec9-5fa224e0b193" />

Console Verified Behavior
<img width="1111" height="905" alt="{73492324-2344-4C51-A7E3-2FD111502E4B}" src="https://github.com/user-attachments/assets/7cbea163-e695-47cb-ab58-81eb928967d8" />

New Behavior
<img width="1364" height="1094" alt="{D2F117E2-E375-4B1B-BC33-751EE76493CE}" src="https://github.com/user-attachments/assets/b66915a7-2e59-4f92-8c47-7ec70cbe15cc" />
