### PR TITLE
fix LZMA PPMD support

### DIFF
--- a/scripts/src/3rdparty.lua
+++ b/scripts/src/3rdparty.lua
@@ -917,7 +917,7 @@ elseif _OPTIONS["vs"]=="intel-15" then
 end
 	configuration { }
 		defines {
-			"Z7_PPMD_SUPPPORT",
+			"Z7_PPMD_SUPPORT",
 			"Z7_ST",
 		}
 


### PR DESCRIPTION
was broken in 79bef1e23049fdac25f1fefd132e0b6c7d2cc3a1 by leaving a typo in 3rdparty.lua that had been fixed in LZMA source

not in this PR, but LZMA 25.00 is out btw