### PR TITLE
chdman: fix file permissions for verify --fix

### DIFF
--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -1154,11 +1154,10 @@ static void guess_chs(
 
 
 //-------------------------------------------------
-//  parse_input_chd_parameters - parse the
-//  standard set of input CHD parameters
+//  parse_input_parent_chd - parse the parent CHD
 //-------------------------------------------------
 
-static void parse_input_chd_parameters(const parameters_map &params, chd_file &input_chd, chd_file &input_parent_chd, bool writeable = false)
+static void parse_input_parent_chd(const parameters_map &params, chd_file &input_parent_chd)
 {
 	// process input parent file
 	auto input_chd_parent_str = params.find(OPTION_INPUT_PARENT);
@@ -1168,6 +1167,18 @@ static void parse_input_chd_parameters(const parameters_map &params, chd_file &i
 		if (err)
 			report_error(1, "Error opening parent CHD file (%s): %s", *input_chd_parent_str->second, err.message());
 	}
+}
+
+
+//-------------------------------------------------
+//  parse_input_chd_parameters - parse the
+//  standard set of input CHD parameters
+//-------------------------------------------------
+
+static void parse_input_chd_parameters(const parameters_map &params, chd_file &input_chd, chd_file &input_parent_chd, bool writeable = false)
+{
+	// process input parent file
+	parse_input_parent_chd(params, input_parent_chd);
 
 	// process input file
 	auto input_chd_str = params.find(OPTION_INPUT);
@@ -1772,28 +1783,19 @@ static void do_verify(parameters_map &params)
 	// parse out input files
 	chd_file input_parent_chd;
 	chd_file input_chd;
-	{
-		// process input parent file
-		auto input_chd_parent_str = params.find(OPTION_INPUT_PARENT);
-		if (input_chd_parent_str != params.end())
-		{
-			std::error_condition err = input_parent_chd.open(*input_chd_parent_str->second);
-			if (err)
-				report_error(1, "Error opening parent CHD file (%s): %s", *input_chd_parent_str->second, err.message());
-		}
+	parse_input_parent_chd(params, input_parent_chd);
 
-		// process input file
-		auto input_chd_str = params.find(OPTION_INPUT);
-		if (input_chd_str != params.end())
-		{
-			const uint32_t openflags = fix_sha1 ? (OPEN_FLAG_READ | OPEN_FLAG_WRITE) : OPEN_FLAG_READ;
-			util::core_file::ptr file;
-			std::error_condition err = util::core_file::open(*input_chd_str->second, openflags, file);
-			if (!err)
-				err = input_chd.open(std::move(file), false, input_parent_chd.opened() ? &input_parent_chd : nullptr);
-			if (err)
-				report_error(1, "Error opening CHD file (%s): %s", *input_chd_str->second, err.message());
-		}
+	// process input file
+	auto input_chd_str = params.find(OPTION_INPUT);
+	if (input_chd_str != params.end())
+	{
+		const uint32_t openflags = fix_sha1 ? (OPEN_FLAG_READ | OPEN_FLAG_WRITE) : OPEN_FLAG_READ;
+		util::core_file::ptr file;
+		std::error_condition err = util::core_file::open(*input_chd_str->second, openflags, file);
+		if (!err)
+			err = input_chd.open(std::move(file), false, input_parent_chd.opened() ? &input_parent_chd : nullptr);
+		if (err)
+			report_error(1, "Error opening CHD file (%s): %s", *input_chd_str->second, err.message());
 	}
 
 	// only makes sense for compressed CHDs with valid SHA-1's
@@ -1816,7 +1818,7 @@ static void do_verify(parameters_map &params)
 		uint32_t bytes_to_read = (std::min<uint64_t>)(buffer.size(), input_chd.logical_bytes() - offset);
 		std::error_condition err = input_chd.read_bytes(offset, &buffer[0], bytes_to_read);
 		if (err)
-			report_error(1, "Error reading CHD file (%s): %s", *params.find(OPTION_INPUT)->second, err.message());
+			report_error(1, "Error reading CHD file (%s): %s", *input_chd_str->second, err.message());
 
 		// add to the checksum
 		rawsha1.append(&buffer[0], bytes_to_read);


### PR DESCRIPTION
gives EBADF on sha1 write currently due to opening in read-only mode. is the variable `fix_sha1` named ok?
<!-- note i discovered this after accidentally swapping the sha1 endianness oops -->