### PR TITLE
glfgreat: uses k053260's TIM2 output as interrupt source.

### DIFF
--- a/src/devices/sound/k053260.cpp
+++ b/src/devices/sound/k053260.cpp
@@ -184,7 +184,8 @@ TIMER_CALLBACK_MEMBER(k053260_device::update_state_outputs)
 // least. These counters together produce a count that is 112 times slower than
 // the SH1 pin, taking it down from 56kHz to 500Hz. The period of 500Hz is 2ms,
 // hence the pin name TIM2 and also the signal name 2MS seen in glfgreat schematics.
-void k053260_device::tim2_count() {
+void k053260_device::tim2_count()
+{
 	bool over = m_tim2 >= 111;
 	if (over)
 	{

--- a/src/devices/sound/k053260.cpp
+++ b/src/devices/sound/k053260.cpp
@@ -179,8 +179,13 @@ TIMER_CALLBACK_MEMBER(k053260_device::update_state_outputs)
 	m_timer_state = (m_timer_state+1) & 3;
 }
 
+// TIM2 is implemented on the original chip as two counters in series, where the
+// first one may be bypassed with a test bit, which is not used by glfgreat at
+// least. These counters together produce a count that is 112 times slower than
+// the SH1 pin, taking it down from 56kHz to 500Hz. The period of 500Hz is 2ms,
+// hence the pin name TIM2 and also the signal name 2MS seen in glfgreat schematics.
 void k053260_device::tim2_count() {
-	bool over = m_tim2>=111;
+	bool over = m_tim2 >= 111;
 	if (over)
 	{
 		m_tim2 = 0;

--- a/src/devices/sound/k053260.cpp
+++ b/src/devices/sound/k053260.cpp
@@ -95,11 +95,13 @@ k053260_device::k053260_device(const machine_config &mconfig, const char *tag, d
 	, device_rom_interface(mconfig, *this)
 	, m_sh1_cb(*this)
 	, m_sh2_cb(*this)
+	, m_tim2_cb(*this)
 	, m_stream(nullptr)
 	, m_timer(nullptr)
 	, m_keyon(0)
 	, m_mode(0)
 	, m_timer_state(0)
+	, m_tim2(0)
 	, m_voice{ { *this }, { *this }, { *this }, { *this } }
 {
 	std::fill(std::begin(m_portdata), std::end(m_portdata), 0);
@@ -119,6 +121,7 @@ void k053260_device::device_start()
 	save_item(NAME(m_keyon));
 	save_item(NAME(m_mode));
 	save_item(NAME(m_timer_state));
+	save_item(NAME(m_tim2));
 
 	for (int i = 0; i < 4; i++)
 		m_voice[i].voice_start(i);
@@ -169,11 +172,21 @@ TIMER_CALLBACK_MEMBER(k053260_device::update_state_outputs)
 	switch (m_timer_state)
 	{
 		case 0: m_sh1_cb(ASSERT_LINE); break;
-		case 1: m_sh1_cb(CLEAR_LINE); break;
+		case 1: m_sh1_cb(CLEAR_LINE); tim2_count(); break;
 		case 2: m_sh2_cb(ASSERT_LINE); break;
 		case 3: m_sh2_cb(CLEAR_LINE); break;
 	}
 	m_timer_state = (m_timer_state+1) & 3;
+}
+
+void k053260_device::tim2_count() {
+	bool over = m_tim2>=111;
+	m_tim2 = over ? 0 : m_tim2+1;
+	if(over) {
+		m_tim2_cb(ASSERT_LINE);
+	} else {
+		m_tim2_cb(CLEAR_LINE);
+	}
 }
 
 u8 k053260_device::main_read(offs_t offset)

--- a/src/devices/sound/k053260.cpp
+++ b/src/devices/sound/k053260.cpp
@@ -181,10 +181,11 @@ TIMER_CALLBACK_MEMBER(k053260_device::update_state_outputs)
 
 void k053260_device::tim2_count() {
 	bool over = m_tim2>=111;
-	m_tim2 = over ? 0 : m_tim2+1;
 	if(over) {
+		m_tim2 = 0;
 		m_tim2_cb(ASSERT_LINE);
 	} else {
+		m_tim2++;
 		m_tim2_cb(CLEAR_LINE);
 	}
 }

--- a/src/devices/sound/k053260.cpp
+++ b/src/devices/sound/k053260.cpp
@@ -181,10 +181,13 @@ TIMER_CALLBACK_MEMBER(k053260_device::update_state_outputs)
 
 void k053260_device::tim2_count() {
 	bool over = m_tim2>=111;
-	if(over) {
+	if (over)
+	{
 		m_tim2 = 0;
 		m_tim2_cb(ASSERT_LINE);
-	} else {
+	}
+	else
+	{
 		m_tim2++;
 		m_tim2_cb(CLEAR_LINE);
 	}

--- a/src/devices/sound/k053260.h
+++ b/src/devices/sound/k053260.h
@@ -48,6 +48,7 @@ protected:
 	virtual void rom_bank_pre_change() override;
 
 	TIMER_CALLBACK_MEMBER(update_state_outputs);
+
 private:
 	// Pan multipliers
 	static const int pan_mul[8][2];
@@ -66,8 +67,8 @@ private:
 	u8           m_portdata[4];
 	u8           m_keyon;
 	u8           m_mode;
-	int          m_timer_state;
-	int          m_tim2;
+	u32          m_timer_state;
+	u32          m_tim2;
 
 	// per voice state
 	class KDSC_Voice

--- a/src/devices/sound/k053260.h
+++ b/src/devices/sound/k053260.h
@@ -31,8 +31,9 @@ public:
 	u8 read(offs_t offset);
 	void write(offs_t offset, u8 data);
 
-	auto sh1_cb() { return m_sh1_cb.bind(); }
-	auto sh2_cb() { return m_sh2_cb.bind(); }
+	auto sh1_cb()  { return m_sh1_cb.bind();  }
+	auto sh2_cb()  { return m_sh2_cb.bind();  }
+	auto tim2_cb() { return m_tim2_cb.bind(); }
 
 protected:
 	// device-level overrides
@@ -47,7 +48,6 @@ protected:
 	virtual void rom_bank_pre_change() override;
 
 	TIMER_CALLBACK_MEMBER(update_state_outputs);
-
 private:
 	// Pan multipliers
 	static const int pan_mul[8][2];
@@ -55,6 +55,8 @@ private:
 	// Sample hold lines callbacks (often used for interrupts)
 	devcb_write_line m_sh1_cb;
 	devcb_write_line m_sh2_cb;
+	devcb_write_line m_tim2_cb; // tim2 output (2ms period)
+	void tim2_count();
 
 	// configuration
 	sound_stream *m_stream;
@@ -65,6 +67,7 @@ private:
 	u8           m_keyon;
 	u8           m_mode;
 	int          m_timer_state;
+	int          m_tim2;
 
 	// per voice state
 	class KDSC_Voice

--- a/src/mame/konami/tmnt2.cpp
+++ b/src/mame/konami/tmnt2.cpp
@@ -176,6 +176,7 @@ protected:
 	void k053244_word_noA1_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void sound_arm_nmi_w(uint8_t data);
 	void z80_nmi_w(int state);
+	void z80_int_w(int state);
 	uint16_t punkshot_kludge_r();
 	uint16_t ssriders_protection_r(address_space &space);
 	void ssriders_protection_w(address_space &space, offs_t offset, uint16_t data);
@@ -391,9 +392,6 @@ void tmnt2_state::k053244_word_noA1_w(offs_t offset, uint16_t data, uint16_t mem
 void glfgreat_state::glfgreat_sound_w(offs_t offset, uint8_t data)
 {
 	m_k053260->main_write(offset, data);
-
-	if (offset)
-		m_audiocpu->set_input_line_and_vector(0, HOLD_LINE, 0xff); // Z80
 }
 
 
@@ -421,6 +419,10 @@ void tmnt2_state::z80_nmi_w(int state)
 		m_audiocpu->set_input_line(INPUT_LINE_NMI, ASSERT_LINE);
 }
 
+void tmnt2_state::z80_int_w(int state)
+{
+	m_audiocpu->set_input_line(0, ASSERT_LINE);
+}
 
 uint16_t tmnt2_state::punkshot_kludge_r()
 {
@@ -2499,6 +2501,7 @@ void glfgreat_state::glfgreat(machine_config &config)
 	m_k053260->add_route(0, "speaker", 1.0, 1);
 	m_k053260->add_route(1, "speaker", 1.0, 0);
 	m_k053260->sh1_cb().set(FUNC(glfgreat_state::z80_nmi_w));
+	m_k053260->tim2_cb().set(FUNC(glfgreat_state::z80_int_w));
 }
 
 void prmrsocr_state::machine_start()

--- a/src/mame/konami/tmnt2.cpp
+++ b/src/mame/konami/tmnt2.cpp
@@ -176,7 +176,6 @@ protected:
 	void k053244_word_noA1_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void sound_arm_nmi_w(uint8_t data);
 	void z80_nmi_w(int state);
-	void z80_int_w(int state);
 	uint16_t punkshot_kludge_r();
 	uint16_t ssriders_protection_r(address_space &space);
 	void ssriders_protection_w(address_space &space, offs_t offset, uint16_t data);
@@ -417,11 +416,6 @@ void tmnt2_state::z80_nmi_w(int state)
 {
 	if (state && !m_nmi_blocked->enabled())
 		m_audiocpu->set_input_line(INPUT_LINE_NMI, ASSERT_LINE);
-}
-
-void tmnt2_state::z80_int_w(int state)
-{
-	m_audiocpu->set_input_line(0, ASSERT_LINE);
 }
 
 uint16_t tmnt2_state::punkshot_kludge_r()
@@ -2501,7 +2495,7 @@ void glfgreat_state::glfgreat(machine_config &config)
 	m_k053260->add_route(0, "speaker", 1.0, 1);
 	m_k053260->add_route(1, "speaker", 1.0, 0);
 	m_k053260->sh1_cb().set(FUNC(glfgreat_state::z80_nmi_w));
-	m_k053260->tim2_cb().set(FUNC(glfgreat_state::z80_int_w));
+	m_k053260->tim2_cb().set_inputline(m_audiocpu, 0, HOLD_LINE);
 }
 
 void prmrsocr_state::machine_start()

--- a/src/mame/konami/tmnt2.cpp
+++ b/src/mame/konami/tmnt2.cpp
@@ -231,7 +231,6 @@ private:
 	uint16_t glfgreat_rom_r(offs_t offset);
 	void glfgreat_122000_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	uint16_t glfgreat_ball_r();
-	void glfgreat_sound_w(offs_t offset, uint8_t data);
 
 	TILE_GET_INFO_MEMBER(glfgreat_get_roz_tile_info);
 	DECLARE_VIDEO_START(glfgreat);
@@ -383,13 +382,6 @@ void tmnt2_state::k053244_word_noA1_w(offs_t offset, uint16_t data, uint16_t mem
 		m_k053245->k053244_w(offset, (data >> 8) & 0xff);
 	if (ACCESSING_BITS_0_7)
 		m_k053245->k053244_w(offset + 1, data & 0xff);
-}
-
-
-
-void glfgreat_state::glfgreat_sound_w(offs_t offset, uint8_t data)
-{
-	m_k053260->main_write(offset, data);
 }
 
 
@@ -1272,7 +1264,7 @@ void glfgreat_state::glfgreat_main_map(address_map &map)
 	map(0x122000, 0x122001).w(FUNC(glfgreat_state::glfgreat_122000_w));
 	map(0x123000, 0x123000).rw("adc", FUNC(adc0804_device::read), FUNC(adc0804_device::write));
 	map(0x124000, 0x124001).w("watchdog", FUNC(watchdog_timer_device::reset16_w));
-	map(0x125000, 0x125003).r(m_k053260, FUNC(k053260_device::main_read)).umask16(0xff00).w(FUNC(glfgreat_state::glfgreat_sound_w)).umask16(0xff00);
+	map(0x125000, 0x125003).rw(m_k053260, FUNC(k053260_device::main_read), FUNC(k053260_device::main_write)).umask16(0xff00);
 	map(0x200000, 0x207fff).rw(FUNC(glfgreat_state::k052109_word_noA12_r), FUNC(glfgreat_state::k052109_word_noA12_w));
 	map(0x300000, 0x3fffff).r(FUNC(glfgreat_state::glfgreat_rom_r));
 }

--- a/src/mame/konami/tmnt2.cpp
+++ b/src/mame/konami/tmnt2.cpp
@@ -26,7 +26,6 @@ TODO:
   1. putting to MAX power on green causes the game to return an incorrect
      value a.k.a. it detects a bunker/rough/water hazard;
   2. top/back spins doesn't have any effect in-game;
-- glfgreat: serious sound cut off -> "it's in the" ... "water"
 - prmrsocr: when the field rotates before the penalty kicks, parts of the
   053936 tilemap that shouldn't be seen are visible. Maybe the tilemap ROM is
   banked, or there are controls to clip the visible region (registers 0x06 and
@@ -3870,9 +3869,9 @@ GAME( 1991, blswhstl,    0,        blswhstl, blswhstl,  tmnt2_state,    empty_in
 GAME( 1991, blswhstla,   blswhstl, blswhstl, blswhstl,  tmnt2_state,    empty_init, ROT90,  "Konami",  "Bells & Whistles (Asia, version M)",   MACHINE_SUPPORTS_SAVE )
 GAME( 1991, detatwin,    blswhstl, blswhstl, blswhstl,  tmnt2_state,    empty_init, ROT90,  "Konami",  "Detana!! Twin Bee (Japan, version J)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1991, glfgreat,    0,        glfgreat, glfgreat,  glfgreat_state, empty_init, ROT0,   "Konami",  "Golfing Greats (World, version L)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
-GAME( 1991, glfgreatu,   glfgreat, glfgreat, glfgreatu, glfgreat_state, empty_init, ROT0,   "Konami",  "Golfing Greats (US, version K)",    MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
-GAME( 1991, glfgreatj,   glfgreat, glfgreat, glfgreatj, glfgreat_state, empty_init, ROT0,   "Konami",  "Golfing Greats (Japan, version J)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
+GAME( 1991, glfgreat,    0,        glfgreat, glfgreat,  glfgreat_state, empty_init, ROT0,   "Konami",  "Golfing Greats (World, version L)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
+GAME( 1991, glfgreatu,   glfgreat, glfgreat, glfgreatu, glfgreat_state, empty_init, ROT0,   "Konami",  "Golfing Greats (US, version K)",    MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
+GAME( 1991, glfgreatj,   glfgreat, glfgreat, glfgreatj, glfgreat_state, empty_init, ROT0,   "Konami",  "Golfing Greats (Japan, version J)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
 
 GAME( 1991, tmnt2,       0,        tmnt2,    ssridr4p,  tmnt2_state,    empty_init, ROT0,   "Konami",  "Teenage Mutant Ninja Turtles: Turtles in Time (4 Players ver UAA)", MACHINE_SUPPORTS_SAVE )
 GAME( 1991, tmnt2a,      tmnt2,    tmnt2,    ssrid4ps,  tmnt2_state,    empty_init, ROT0,   "Konami",  "Teenage Mutant Ninja Turtles: Turtles in Time (4 Players ver ADA)", MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
The sound interrupt for the Z80 is wrong on glfgreat. It should be the TIM2 output of the K053260. This output produces a pulse with a 2ms period, hence the pin name. Furrtek's schematics for this chip show the function.

The M68000 does not produce an interrupt on the Z80 on this board.

I have modified the files to implement this, but given my poor understanding of the MAME framework, something might be wrong. Particularly, the K053260 should set the interrupt request and it should not be cleared until the Z80 starts the interrupt execution. I do not know if my changes implement that correctly.

There is a note about wrong audio before but I have not really listened to the audio from the old driver as it must be wrong if a 500Hz interrupt becomes a random interrupt from the M68000. 

This is a picture from the original schematics. I have a board and I have measured these pins and the schematic is accurate.

Please push to the same branch on my repo or ask me if you need further changes on this. I am not sure whether this is enough to remove the "BAD SOUND" warning from the driver.

![glfgreat](https://github.com/user-attachments/assets/be74f87e-4220-4fb4-98e3-a43d8a3f087b)
