### PR TITLE
Reset the transmit register when requested by witing CR with bit 3 set.

### DIFF
--- a/src/devices/machine/mc68681.cpp
+++ b/src/devices/machine/mc68681.cpp
@@ -1809,6 +1809,7 @@ void duart_channel::write_CR(uint8_t data)
 			m_uart->clear_ISR_bits(INT_TXRDYA);
 		else
 			m_uart->clear_ISR_bits(INT_TXRDYB);
+		transmit_register_reset();
 	}
 
 	update_interrupts();


### PR DESCRIPTION
This fixes https://github.com/mamedev/mame/issues/14030 .