### PR TITLE
alphatpx.cpp: Honor 'cliprect' in screen_update()

### DIFF
--- a/src/mame/ta/alphatpx.cpp
+++ b/src/mame/ta/alphatpx.cpp
@@ -909,28 +909,27 @@ u32 alphatp_12_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap,
 	int const start = m_crtc->upscroll_offset();
 	rectangle cursor;
 	m_crtc->cursor_bounds(cursor);
-	for (int y = 0; y < 24; y++)
+	int left = cliprect.left() / 8;
+	int right = cliprect.right() / 8;
+	for (int y = cliprect.top(); y <= cliprect.bottom(); y++)
 	{
-		int const vramy = (start + y) % 24;
-		for (int x = 0; x < 80; x++)
+		int const vramy = (start + y/12) % 24;
+		int const line = y % 12;
+		for (int x = left; x <= right; x++)
 		{
 			u8 code = m_vram[(vramy * 128) + x];   // helwie44 must be 128d is 080h physical display-ram step line
-			// draw 12 lines of the character
-			bool const cursoren = cursor.contains(x * 8, y * 12);
-			for (int line = 0; line < 12; line++)
-			{
-				u8 data = m_gfx[((code & 0x7f) * 16) + line];
-				if (cursoren)
-					data ^= 0xff;
-				bitmap.pix(y * 12 + line, x * 8 + 0) = pen[BIT(data, 0) ^ BIT(code, 7)];
-				bitmap.pix(y * 12 + line, x * 8 + 1) = pen[BIT(data, 1) ^ BIT(code, 7)];
-				bitmap.pix(y * 12 + line, x * 8 + 2) = pen[BIT(data, 2) ^ BIT(code, 7)];
-				bitmap.pix(y * 12 + line, x * 8 + 3) = pen[BIT(data, 3) ^ BIT(code, 7)];
-				bitmap.pix(y * 12 + line, x * 8 + 4) = pen[BIT(data, 4) ^ BIT(code, 7)];
-				bitmap.pix(y * 12 + line, x * 8 + 5) = pen[BIT(data, 5) ^ BIT(code, 7)];
-				bitmap.pix(y * 12 + line, x * 8 + 6) = pen[BIT(data, 6) ^ BIT(code, 7)];
-				bitmap.pix(y * 12 + line, x * 8 + 7) = pen[BIT(data, 7) ^ BIT(code, 7)];
-			}
+			bool const cursoren = cursor.contains(x * 8, y);
+			u8 data = m_gfx[((code & 0x7f) * 16) + line];
+			if (cursoren)
+				data ^= 0xff;
+			bitmap.pix(y, x * 8 + 0) = pen[BIT(data, 0) ^ BIT(code, 7)];
+			bitmap.pix(y, x * 8 + 1) = pen[BIT(data, 1) ^ BIT(code, 7)];
+			bitmap.pix(y, x * 8 + 2) = pen[BIT(data, 2) ^ BIT(code, 7)];
+			bitmap.pix(y, x * 8 + 3) = pen[BIT(data, 3) ^ BIT(code, 7)];
+			bitmap.pix(y, x * 8 + 4) = pen[BIT(data, 4) ^ BIT(code, 7)];
+			bitmap.pix(y, x * 8 + 5) = pen[BIT(data, 5) ^ BIT(code, 7)];
+			bitmap.pix(y, x * 8 + 6) = pen[BIT(data, 6) ^ BIT(code, 7)];
+			bitmap.pix(y, x * 8 + 7) = pen[BIT(data, 7) ^ BIT(code, 7)];
 		}
 	}
 
@@ -951,40 +950,39 @@ u32 alphatp_34_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap,
 	int const start = m_crtc->upscroll_offset();
 	rectangle cursor;
 	m_crtc->cursor_bounds(cursor);
+	int left = cliprect.left() / 8;
+	int right = cliprect.right() / 8;
 	bool const scrext = m_scncfg->read() ? true : false;
-	for (int y = 0; y < 24; y++)
+	for (int y = cliprect.top(); y <= cliprect.bottom(); y++)
 	{
-		int const vramy = (start + y) % 24;
-		for (int x = 0; x < 80; x++)
+		int const vramy = (start + y/12) % 24;
+		int const line = y % 12;
+		for (int x = left; x <= right; x++)
 		{
 			u8 code = m_vram[(vramy * 128) + x];   // helwie44 must be 128d is 080h physical display-ram step line
-			// draw 12 lines of the character
-			bool const cursoren = cursor.contains(x * 8, y * 12);
-			for (int line = 0; line < 12; line++)
+			bool const cursoren = cursor.contains(x * 8, y);
+			u8 data = 0;
+			if (scrext)
 			{
-				u8 data = 0;
-				if (scrext)
-				{
-					offs_t offset = (((vramy * 12) + line) * 80) + x;
-					if(offset < (371 * 80))
-						data = m_vramext[offset];
-					code = 0;
-				}
-				else
-				{
-					data = m_gfx[((code & 0x7f) * 16) + line];
-					if (cursoren)
-						data ^= 0xff;
-				}
-				bitmap.pix(y * 12 + line, x * 8 + 0) = pen[BIT(data, 0) ^ BIT(code, 7)];
-				bitmap.pix(y * 12 + line, x * 8 + 1) = pen[BIT(data, 1) ^ BIT(code, 7)];
-				bitmap.pix(y * 12 + line, x * 8 + 2) = pen[BIT(data, 2) ^ BIT(code, 7)];
-				bitmap.pix(y * 12 + line, x * 8 + 3) = pen[BIT(data, 3) ^ BIT(code, 7)];
-				bitmap.pix(y * 12 + line, x * 8 + 4) = pen[BIT(data, 4) ^ BIT(code, 7)];
-				bitmap.pix(y * 12 + line, x * 8 + 5) = pen[BIT(data, 5) ^ BIT(code, 7)];
-				bitmap.pix(y * 12 + line, x * 8 + 6) = pen[BIT(data, 6) ^ BIT(code, 7)];
-				bitmap.pix(y * 12 + line, x * 8 + 7) = pen[BIT(data, 7) ^ BIT(code, 7)];
+				offs_t offset = (((vramy * 12) + line) * 80) + x;
+				if(offset < (371 * 80))
+					data = m_vramext[offset];
+				code = 0;
 			}
+			else
+			{
+				data = m_gfx[((code & 0x7f) * 16) + line];
+				if (cursoren)
+					data ^= 0xff;
+			}
+			bitmap.pix(y, x * 8 + 0) = pen[BIT(data, 0) ^ BIT(code, 7)];
+			bitmap.pix(y, x * 8 + 1) = pen[BIT(data, 1) ^ BIT(code, 7)];
+			bitmap.pix(y, x * 8 + 2) = pen[BIT(data, 2) ^ BIT(code, 7)];
+			bitmap.pix(y, x * 8 + 3) = pen[BIT(data, 3) ^ BIT(code, 7)];
+			bitmap.pix(y, x * 8 + 4) = pen[BIT(data, 4) ^ BIT(code, 7)];
+			bitmap.pix(y, x * 8 + 5) = pen[BIT(data, 5) ^ BIT(code, 7)];
+			bitmap.pix(y, x * 8 + 6) = pen[BIT(data, 6) ^ BIT(code, 7)];
+			bitmap.pix(y, x * 8 + 7) = pen[BIT(data, 7) ^ BIT(code, 7)];
 		}
 	}
 


### PR DESCRIPTION
Performance issue: the entire screen was being updated when only a single scanline needed to be updated, causing 100% host CPU usage and non-realtime emulation.