### PR TITLE
misc/amaticmg: Add V.Int version of Multi Game III

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -29414,7 +29414,8 @@ am_mg31i
 am_mg33i
 am_mg34i
 am_mg35i
-am_mg3a
+am_mg3g
+am_mg3ga
 am_mg4sk
 am_mg4v
 am_mg5hu

--- a/src/mame/misc/amaticmg.cpp
+++ b/src/mame/misc/amaticmg.cpp
@@ -319,6 +319,100 @@
   |___________________|
 
 
+  ------------------------------------------------
+	 Multi Game III v3.63 (AMA-8000-2)
+  ------------------------------------------------
+
+  PCB Layout:
+			  ________________________________________________________________________
+			 | |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | |
+   __________| |  |  |  |  |  |  |  |  |36x2 edge connector |  |  |  |  |  |  |  |  | |__________
+  |  _______________________                                                                     |
+  | |   :::::::::::::::::   |                                                                    |
+  | |___________ ___________|                                                                    |
+  |  __________   __________                                                         __________  |
+  | |TD62083AP | |TD62083AP |                                                       |TD62083AP | |
+  | |__________| |__________|                                                       |__________| |
+  |                                                                                              |
+  |    __________________________    __________________________    __________________________    |
+  |   |        NEC JAPAN         |  |        NEC JAPAN         |  |        NEC JAPAN         |   |
+  |   |        D71055C           |  |        D71055C           |  |        D71055C           |   |
+  |   |        9750LDW38         |  |        9750LDW38         |  |        9750LDW38         |   |
+  |   |                          |  |                          |  |                          |   |
+  |   |__________________________|  |__________________________|  |__________________________|   |
+  |                                                                                              |
+  |      DIP1                                     __________                                     |
+  |   __________                                 |   XTAL   |    _______________                 |
+  |  | 12345678 |                                |  16 Mhz  |   | YAMAHA JAPAN  |                |
+  |  |__________|                                |__________|   | YM3812        |                |
+  |                                                             | 9212 EACB     |                |
+  |                                                             |_______________|                |
+  |   _________________________            __________________                                    |
+  |  |AMATIC                   |          |                  |             ___   __              |
+  |  |Lfnd. Nr. 98.1500306     |          |      ALTERA      |            | A | |B |             |
+  |  |Type: 80-I               |          |                  |            |___| |__|             |
+  |  |Datum: 19.06.01          |          |    CY7C346B-     |                                   |
+  |  |_________________________|          |      35JC        |      ____                         |
+  |                                       |    B  02 0104    |     /    \                        |
+  |   ___________________                 |     602779       |    |  ?   |     ____              |
+  |  |MG III  VInt       |                |                  |    |      |    /    \             |
+  |  |3.63/I/8206        |  __________    |                  |     \____/    | Pot  |            |
+  |  |                   | |HY62256A  |   |                  |               |      |            |
+  |  |___________________| |__________|   |__________________|                \____/             |
+  |                                                                                              |
+  |                                                      __   __   __________                    |
+  |   ___        ____     __________              ___   |D | |E | |HC573A    |                   |
+  |  |SW |      /    \   |DS1236    |            | C |  |  | |  | |__________|     __      __    |
+  |  |   |     | Batt |  |__________|            |   |  |__| |__|                 |  |    |  |   |
+  |  |___|     | ery  |                          |___|                            |H |    |H |   |
+  |             \____/                       __   __   __   __   __   __          |  |    |  |   |
+  |   _______________________               |G | |G | |G | |G | |G | |G |         |  |    |  |   |
+  |  |   :::::::::::::::::   |              |  | |  | |  | |  | |  | |  |         |__|    |__|   |
+  |  |___________ ___________|              |__| |__| |__| |__| |__| |__|                        |
+  |     _______                  __      __                                                      |
+  |    |       |                |  |    |  |                                         _______     |
+  |    |MC68B  |                |J |    |F |                                        |       |    |
+  |    |    45P|   ________     |  |    |  |                                        |       |    |
+  |    |       |  |LS157   |    |  |    |  |    _______    _______    _______       |       |    |
+  |    | 2JR5  |  |________|    |__|    |__|   |       |  |       |  |       |      |       |    |
+  |    |       |              _______          |MG III |  |MG III |  |MG III |      |  IV   |    |
+  |    |       |   ________  |       |   __    |     51|  |     51|  |     51|      |       |    |
+  |    |CTCTAB |  |LS157   | |HY6264A|  |  |   |       |  |       |  |       |      |    AM |    |
+  |    |  9735 |  |________| | LP-70 |  |F |   |  ZG3  |  |  ZG2  |  |  ZG1  |      |27C1024|    |
+  |    |       |             |       |  |  |   |       |  |       |  |       |      |       |    |
+  |    |       |   ________  | 9750B |  |  |   |       |  |       |  |       |      |       |    |
+  |    |       |  |LS157   | | KOREA |  |__|   |       |  |       |  |       |      |       |    |
+  |    |       |  |________| |       |         |       |  |       |  |       |      |       |    |
+  |    |       |             |       |   __    |       |  |       |  |       |      |       |    |
+  |    |       |   ________  |       |  |I |   |_______|  |_______|  |_______|      |       |    |
+  |    |       |  |LS157   | |       |  |  |                              ______    |       |    |
+  |    |_______|  |________| |_______|  |__|                             |ALS174|   |       |    |
+  |                                                                      |______|   |_______|    |
+  |                                              AMA 8000 - 2 REV. 3                             |
+  |______________________________________________________________________________________________|
+
+  A = Y3014B
+  B = LM358
+  C = 14538B
+  D = HC133
+  E = HC04A
+  F = HC374
+  G = LS194A
+  H = HCT273
+  I = HC174A
+  J = 74HC244A
+
+  DIP1:
+   ___________________
+  | ON                |
+  |  _______________  |
+  | |_|_|_|_|_|_|_|_| |
+  | |#|#|#|#|#|#|#|#| |
+  | |_______________| |
+  |  1 2 3 4 5 6 7 8  |
+  |___________________|
+
+
 ***********************************************************************************
 
 
@@ -457,6 +551,10 @@
 
 ***********************************************************************************
 
+
+  [2025/08/16]
+
+  - Added dump for Multi Game III (V.Int 1.63) (AMA-8000-2).
 
   [2025/08/08]
 
@@ -1156,7 +1254,32 @@ ROM_END
 
 //******** MG III ********
 
+/*
+  1x 40-pin custom CPU labeled:
+
+     Amatic
+     Lfnd. Nr. 98.1500306
+     Type:     80-I
+     Datum:    19.06.01
+*/
 ROM_START( am_mg3 )
+	ROM_REGION( 0x40000, "maincpu", ROMREGION_ERASE00 )
+
+	ROM_REGION( 0x40000, "mainprg", 0 ) // encrypted program ROM
+	ROM_LOAD( "mg_iii_vint_3.63-i-8206.i6", 0x00000, 0x40000, CRC(f62190c1) SHA1(5c37b228f683657136f3dbc1de6448df3f68beca) )
+
+	ROM_REGION( 0x180000, "chars", 0 )
+	ROM_LOAD( "mg_iii_51_zg1.i17", 0x100000, 0x80000, CRC(84f86874) SHA1(c483a50df6a9a71ddfdf8530a894135f9b852b89) )
+	ROM_LOAD( "mg_iii_51_zg2.i18", 0x080000, 0x80000, CRC(4425e535) SHA1(726c322c5d0b391b82e49dd1797ebf0abfa4a65a) )
+	ROM_LOAD( "mg_iii_51_zg3.i33", 0x000000, 0x80000, CRC(36d4c0fa) SHA1(20352dbbb2ce2233be0f4f694ddf49b8f5d6a64f) )
+
+	ROM_REGION( 0x20000, "proms", 0 )
+	ROM_LOAD( "iv.i35", 0x00000, 0x20000, CRC(937e6668) SHA1(396e69317f82b1b9e5ac81ee5a59d24c3c2e95c8) )
+ROM_END
+
+// German sets...
+
+ROM_START( am_mg3g )
 	ROM_REGION( 0x40000, "maincpu", ROMREGION_ERASE00 )
 
 	ROM_REGION( 0x40000, "mainprg", 0 ) // encrypted program ROM
@@ -1171,7 +1294,7 @@ ROM_START( am_mg3 )
 	ROM_LOAD( "v.bin", 0x00000, 0x20000, CRC(524767e2) SHA1(03a108494f42365c820fdfbcba9496bda86f3081) )
 ROM_END
 
-ROM_START( am_mg3a )
+ROM_START( am_mg3ga )
 	ROM_REGION( 0x40000, "maincpu", ROMREGION_ERASE00 )
 
 	ROM_REGION( 0x40000, "mainprg", 0 ) // encrypted program ROM
@@ -1460,8 +1583,9 @@ GAMEL( 1996, suprstar, 0,        amaticmg,  amaticmg, amaticmg_state, init_ama80
 GAME(  2004, fpoker,   0,        amaticmg4, amaticmg, amaticmg_state, init_ama8000_3_o, ROT0,  "Amatic Trading GmbH", "Fruit Poker (V.Swe 1.74)",     MACHINE_IMPERFECT_GRAPHICS | MACHINE_WRONG_COLORS | MACHINE_UNEMULATED_PROTECTION | MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 GAME(  2000, am_mg24,  0,        amaticmg2, amaticmg, amaticmg_state, init_ama8000_2_i, ROT0,  "Amatic Trading GmbH", "Multi Game I (V.Ger 2.4)",     MACHINE_IMPERFECT_GRAPHICS | MACHINE_WRONG_COLORS | MACHINE_UNEMULATED_PROTECTION | MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 GAME(  2000, am_mg24a, 0,        amaticmg2, amaticmg, amaticmg_state, init_ama8000_1_x, ROT0,  "Amatic Trading GmbH", "Multi Game I (V.Stm 2.7)",     MACHINE_IMPERFECT_GRAPHICS | MACHINE_WRONG_COLORS | MACHINE_UNEMULATED_PROTECTION | MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-GAME(  2000, am_mg3,   0,        amaticmg2, amaticmg, amaticmg_state, init_ama8000_2_i, ROT0,  "Amatic Trading GmbH", "Multi Game III (V.Ger 3.5)",   MACHINE_IMPERFECT_GRAPHICS | MACHINE_WRONG_COLORS | MACHINE_UNEMULATED_PROTECTION | MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-GAME(  2000, am_mg3a,  0,        amaticmg4, amaticmg, amaticmg_state, init_ama8000_2_v, ROT0,  "Amatic Trading GmbH", "Multi Game III (V.Ger 3.64)",  MACHINE_IMPERFECT_GRAPHICS | MACHINE_WRONG_COLORS | MACHINE_UNEMULATED_PROTECTION | MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+GAME(  2000, am_mg3,   0,        amaticmg2, amaticmg, amaticmg_state, init_ama8000_2_i, ROT0,  "Amatic Trading GmbH", "Multi Game III (V.Int 3.63)",  MACHINE_IMPERFECT_GRAPHICS | MACHINE_WRONG_COLORS | MACHINE_UNEMULATED_PROTECTION | MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+GAME(  2000, am_mg3g,  0,        amaticmg2, amaticmg, amaticmg_state, init_ama8000_2_i, ROT0,  "Amatic Trading GmbH", "Multi Game III (V.Ger 3.5)",   MACHINE_IMPERFECT_GRAPHICS | MACHINE_WRONG_COLORS | MACHINE_UNEMULATED_PROTECTION | MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+GAME(  2000, am_mg3ga, 0,        amaticmg4, amaticmg, amaticmg_state, init_ama8000_2_v, ROT0,  "Amatic Trading GmbH", "Multi Game III (V.Ger 3.64)",  MACHINE_IMPERFECT_GRAPHICS | MACHINE_WRONG_COLORS | MACHINE_UNEMULATED_PROTECTION | MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 GAME(  2000, am_mg35i, 0,        amaticmg2, amaticmg, amaticmg_state, init_ama8000_3_o, ROT0,  "Amatic Trading GmbH", "Multi Game III (S.Ita 3.5)",   MACHINE_IMPERFECT_GRAPHICS | MACHINE_WRONG_COLORS | MACHINE_UNEMULATED_PROTECTION | MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 GAME(  2000, am_mg34i, am_mg35i, amaticmg2, amaticmg, amaticmg_state, init_ama8000_3_o, ROT0,  "Amatic Trading GmbH", "Multi Game III (S.Ita 3.4)",   MACHINE_IMPERFECT_GRAPHICS | MACHINE_WRONG_COLORS | MACHINE_UNEMULATED_PROTECTION | MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 GAME(  2000, am_mg33i, am_mg35i, amaticmg2, amaticmg, amaticmg_state, init_ama8000_3_o, ROT0,  "Amatic Trading GmbH", "Multi Game III (S.Ita 3.3)",   MACHINE_IMPERFECT_GRAPHICS | MACHINE_WRONG_COLORS | MACHINE_UNEMULATED_PROTECTION | MACHINE_NO_SOUND | MACHINE_NOT_WORKING )


### PR DESCRIPTION
## New systems marked not working
Multi Game III  (V.Int 3.63) [FakeShemp]

---

I changed this to be `am_mg3` and renamed the German versions to be `am_mg3g*`. As far as I understand, English versions should be "parents" if available. 

![MG III - PCB](https://github.com/user-attachments/assets/dd95c6f2-eb7f-4835-8336-98b4effed6de)
