### PR TITLE
ef9345: scanline generation should not assert/deassert the BUSY flag

### DIFF
--- a/src/devices/video/ef9345.cpp
+++ b/src/devices/video/ef9345.cpp
@@ -993,6 +993,7 @@ void ef9345_device::ef9345_exec(uint8_t cmd)
 		case 0x91:  //NOP: no operation
 		case 0x95:  //VRM: vertical sync mask reset
 		case 0x99:  //VSM: vertical sync mask set
+			set_busy_flag(1000);
 			break;
 		case 0xb0:  //INY: increment Y
 			set_busy_flag(2000);
@@ -1074,7 +1075,9 @@ void ef9345_device::update_scanline(uint16_t scanline)
 	if (scanline == 250)
 		m_state &= 0xfb;
 
-	set_busy_flag(104000);
+	// If we are interrupting a running command, delay its completion.
+	if (m_busy_timer->enabled())
+		m_busy_timer->adjust(m_busy_timer->remaining() + attotime::from_nsec(104000));
 
 	if (m_char_mode == MODE12x80 || m_char_mode == MODE8x80)
 	{


### PR DESCRIPTION
The status register's BUSY flag should only be asserted by EF9345 while a user command is pending or being executed. Rendering (i.e. generation of the next line of pixels) is an independent process and it should neither set it nor clear it:

<img width="45%" alt="BUSY is set at the beginning of any command execution. It is reset at completion" src="https://github.com/user-attachments/assets/5fc21d22-5f06-46d6-879c-90de9c69097c" />

The current code, instead, always asserts it at the beginning of the scanline generation periodic task and deasserts it shortly afterwards (after a fixed timeout). This causes the real BUSY value and timer, that were previosly configured as a result of user commands in `ef9345_exec` calling `set_busy_flag`, to be lost.

Figure 10 of the EF9345 datasheet shows that, in real HW, rendering just delays memory accesses due to user commands by 104 us (=40+24+40). As an approximation, this commit delays the completion of the current command, irrespective of whether it involves memory accesses or not.

<img width="45%" src="https://github.com/user-attachments/assets/e80db67d-dec3-4900-b546-908124ee00b5" />
<img width="90%" alt="Figure 10" src="https://github.com/user-attachments/assets/81dcbf80-cd90-4eeb-bc1d-0b39b3f95358" />

cc @jfdelnero 