### PR TITLE
taitotz.cpp: landhigh doesn't use the sub monitor, landhigha does

### DIFF
--- a/src/mame/taito/taitotz.cpp
+++ b/src/mame/taito/taitotz.cpp
@@ -3013,8 +3013,8 @@ ROM_END
 
 GAME( 1999, taitotz,   0,        taitotz,  taitotz,  taitotz_state, empty_init,    ROT0, "Taito", "Type Zero BIOS", MACHINE_NO_SOUND | MACHINE_NOT_WORKING | MACHINE_IS_BIOS_ROOT )
 GAME( 1999, batlgear,  taitotz,  taitotz,  batlgr2,  taitotz_state, init_batlgear, ROT0, "Taito", "Battle Gear (VER.2.40A)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_NODEVICE_LAN )
-GAME( 1999, landhigh,  taitotz,  landhigh, landhigh, taitotz_state, init_landhigh, ROT0, "Taito", "Landing High Japan (VER.2.01OK)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-GAME( 1999, landhigha, landhigh, landhigh, landhigh, taitotz_state, init_landhigha,ROT0, "Taito", "Landing High Japan (VER.2.02O)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+GAME( 1999, landhigh,  taitotz,  landhigh, landhigh, taitotz_state, init_landhigh, ROT0, "Taito", "Landing High Japan (VER.2.01OK, no sub monitor)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND ) // pitch/roll indicator on main screen
+GAME( 1999, landhigha, landhigh, landhigh, landhigh, taitotz_state, init_landhigha,ROT0, "Taito", "Landing High Japan (VER.2.02O)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND ) // pitch/roll indicator on sub monitor, requires sub monitor-compatible board
 GAME( 1999, pwrshovl,  taitotz,  taitotz,  pwrshovl, taitotz_state, init_pwrshovl, ROT0, "Taito", "Power Shovel ni Norou!! - Power Shovel Simulator (VER.2.07J)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND ) // 1999/8/5 19:13:35
 GAME( 2000, batlgr2,   taitotz,  taitotz,  batlgr2,  taitotz_state, init_batlgr2,  ROT0, "Taito", "Battle Gear 2 (VER.2.04J)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_NODEVICE_LAN )
 GAME( 2000, batlgr2a,  batlgr2,  taitotz,  batlgr2,  taitotz_state, init_batlgr2a, ROT0, "Taito", "Battle Gear 2 (VER.2.01J, Side by Side conversion)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_NODEVICE_LAN ) // "BATTLE GEAR2(S)" on test menu


### PR DESCRIPTION
According to [mokonaXVI:](https://www.youtube.com/watch?v=scE5jnXo6QY&lc=UgzBosVelc_9YYWKln54AaABAg.AJGjeHgd4aIAJGpQcfFpS_)
>The "VER 2.01 OK" does not have a sub-monitor, all information is displayed on the main monitor.
>"VER 2.01 O" and "VER 2.06 J" is equipped with a sub-monitor.

[Additional info on mokona's website:](https://mokonaxvi.sakura.ne.jp/typezero/lhj.htm)
>　基板の特徴:
　　フィルターボードも変わっているが、
　　サブモニタ搭載版はドーターボード(IDE付いてる方の板)が専用設計になっている。
　　サブモニタ搭載版HDD(J地域用とVER2.02O)は普通のType-Zero基板に載せても遊べない。
　　サブモニタ未搭載版は筐体にサブモニタが無く、
　　ドーターPCBがBG2基板と同等の汎用品を使用している為、BG2マザーで動作する。
　　国内版は稼働後にイージーVER.へのコンバートがあった模様。
　　変更された筐体の少なさからすると、有償アップデートかTAITOのロケ限定？
---
> Board Features:
The filter board has also changed, but the version equipped with sub-monitor has a specially designed daughter board (with the IDE port).
The two-screen version's HDD (for region J and VER2.02O) will not boot if placed on a normal Type-Zero board.
The non-two-screen version has no sub-monitor in the cabinet, and the daughterboard is equivalent to those used in Battle Gear 2, so it will work on a BG2 motherboard.
It appears that the Japanese version was converted to the Easy Ver. [an undumped revision update] after installation.
Given the small number of upgraded cabinets, was [Easy Ver.] a paid update or only available at Taito's own arcades?