### PR TITLE
heathzenith/h8.cpp: Add more cards, change to use address_space_installer

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -5937,6 +5937,12 @@ if (BUSES["H8BUS"]~=null) then
 		MAME_DIR .. "src/devices/bus/heathzenith/h8/h_8_1.h",
 		MAME_DIR .. "src/devices/bus/heathzenith/h8/h_8_5.cpp",
 		MAME_DIR .. "src/devices/bus/heathzenith/h8/h_8_5.h",
+		MAME_DIR .. "src/devices/bus/heathzenith/h8/ha_8_6.cpp",
+		MAME_DIR .. "src/devices/bus/heathzenith/h8/ha_8_6.h",
+		MAME_DIR .. "src/devices/bus/heathzenith/h8/ha_8_8.cpp",
+		MAME_DIR .. "src/devices/bus/heathzenith/h8/ha_8_8.h",
+		MAME_DIR .. "src/devices/bus/heathzenith/h8/wh_8_16.cpp",
+		MAME_DIR .. "src/devices/bus/heathzenith/h8/wh_8_16.h",
 		MAME_DIR .. "src/devices/bus/heathzenith/h8/wh_8_64.cpp",
 		MAME_DIR .. "src/devices/bus/heathzenith/h8/wh_8_64.h",
 	}

--- a/src/devices/bus/heathzenith/h8/cards.cpp
+++ b/src/devices/bus/heathzenith/h8/cards.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:Mark Garlanger
 /***************************************************************************
 
-   Cards for the H8 Benton Harbor Bus
+   Cards for the Heath H8 Benton Harbor Bus
 
 ***************************************************************************/
 
@@ -14,6 +14,9 @@
 #include "h8bus.h"
 #include "h_8_1.h"
 #include "h_8_5.h"
+#include "ha_8_6.h"
+#include "ha_8_8.h"
+#include "wh_8_16.h"
 #include "wh_8_64.h"
 
 // P1 is reserved for the Front Panel
@@ -26,18 +29,22 @@ void h8_p1_cards(device_slot_interface &device)
 void h8_p2_cards(device_slot_interface &device)
 {
 	device.option_add("cpu8080", H8BUS_CPU_8080);
+	device.option_add("ha_8_6",  H8BUS_HA_8_6);
 }
 
 // P10 is reserved for the HA-8-8 Extended Configuration Option card, which is
-// required to run CP/M with the 8080 CPU board.
-// TODO - add the HA-8-8
+// required to run CP/M with the 8080 CPU board. The HA-8-8 should not be used
+// with the HA-8-6 Z80 CPU board since the functionality is built into the Z80
+// board.
 void h8_p10_cards(device_slot_interface &device)
 {
+	device.option_add("ha_8_8", H8BUS_HA_8_8);
 }
 
 void h8_cards(device_slot_interface &device)
 {
 	device.option_add("h_8_1",   H8BUS_H_8_1);
 	device.option_add("h_8_5",   H8BUS_H_8_5);
+	device.option_add("wh_8_16", H8BUS_WH_8_16);
 	device.option_add("wh_8_64", H8BUS_WH_8_64);
 }

--- a/src/devices/bus/heathzenith/h8/cpu8080.cpp
+++ b/src/devices/bus/heathzenith/h8/cpu8080.cpp
@@ -4,8 +4,7 @@
 
   Heathkit 8080A CPU card
 
-  Original 8080A 2.048MHz CPU board from Heath Company.
-
+  Original 8080A 2.048 MHz CPU board from Heath Company.
 
 
   Onboard Jumpers
@@ -44,7 +43,7 @@
   T1-T2     Close     No       -5V to pin 21 of IC204 ROM
   T2-T3     Open      No       +5V to pin 21 of IC204 ROM
 
-  X1-X2     Open      No       Allow /ROM_Disable from BH bus (pin 46) to disable ROM
+  X1-X2     Open      Yes      Allow /ROM_Disable from BH bus (pin 46) to disable ROM
 
   Z1-Z2     Close     No       Tie /A10 to ROM decoder select line
   Z2-Z3     Open      No       Tie +5V to ROM decoder select line
@@ -59,10 +58,25 @@
 #include "bus/heathzenith/intr_cntrl/intr_cntrl.h"
 #include "cpu/i8085/i8085.h"
 
+#define LOG_ORG0 (1U << 1)    // Shows register setup
+
+#define VERBOSE (0)
+
+#include "logmacro.h"
+
+#define LOGORG0(...)        LOGMASKED(LOG_ORG0, __VA_ARGS__)
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
 
 namespace {
 
-class h_8_cpu_8080_device : public device_t, public device_h8bus_card_interface, public device_p201_p2_card_interface
+class h_8_cpu_8080_device : public device_t
+						  , public device_h8bus_card_interface
+						  , public device_p201_p2_card_interface
 {
 public:
 
@@ -75,6 +89,7 @@ public:
 	virtual void int5_w(int state) override;
 	virtual void int6_w(int state) override;
 	virtual void int7_w(int state) override;
+	virtual void rom_disable_w(int state) override;
 
 	virtual void p201_reset_w(int state) override;
 	virtual void p201_int1_w(int state) override;
@@ -91,6 +106,8 @@ protected:
 	void handle_int1();
 	void handle_int2();
 
+	u8 sys_rom_r(offs_t offset);
+
 private:
 	void h8_status_callback(u8 data);
 	void h8_inte_callback(int state);
@@ -98,25 +115,21 @@ private:
 	void mem_map(address_map &map) ATTR_COLD;
 	void io_map(address_map &map) ATTR_COLD;
 
-	void bus_mem_w(offs_t offset, u8 data) { m_mem.write_byte(offset, data); }
-	u8 bus_mem_r(offs_t offset) { return m_mem.read_byte(offset); }
-	void bus_io_w(offs_t offset, u8 data) { m_io.write_byte(offset, data); }
-	u8 bus_io_r(offs_t offset) { return m_io.read_byte(offset); }
-
 	required_device<i8080_cpu_device>  m_maincpu;
 	required_device<heath_intr_socket> m_intr_socket;
+	required_region_ptr<u8>            m_sys_rom;
+	memory_view                        m_mem_view;
 	required_ioport                    m_config;
-
-	memory_access<16, 0, 0, ENDIANNESS_LITTLE>::specific m_mem;
-	memory_access<8, 0, 0, ENDIANNESS_LITTLE>::specific  m_io;
 
 	bool m_m1_state;
 	bool m_allow_bus_int1;
 	bool m_allow_bus_int2;
+	bool m_allow_disable_rom;
 	bool m_p201_int1;
 	bool m_p201_int2;
 	bool m_bus_int1;
 	bool m_bus_int2;
+	bool m_disable_rom;
 };
 
 h_8_cpu_8080_device::h_8_cpu_8080_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
@@ -125,6 +138,8 @@ h_8_cpu_8080_device::h_8_cpu_8080_device(const machine_config &mconfig, const ch
 	, device_p201_p2_card_interface(*this, tag)
 	, m_maincpu(*this, "maincpu")
 	, m_intr_socket(*this, "intr_socket")
+	, m_sys_rom(*this, "maincpu")
+	, m_mem_view(*this, "mem_view")
 	, m_config(*this, "CONFIG")
 {
 }
@@ -136,13 +151,23 @@ void h_8_cpu_8080_device::h8_inte_callback(int state)
 
 void h_8_cpu_8080_device::h8_status_callback(u8 data)
 {
-	int state = (data & i8080_cpu_device::STATUS_M1) ? 1 : 0;
+	int m1_state = (data & i8080_cpu_device::STATUS_M1) ? 1 : 0;
 
-	if (state != m_m1_state)
+	if (m1_state != m_m1_state)
 	{
-		set_slot_m1(state);
+		set_slot_m1(m1_state);
 
-		m_m1_state = state;
+		m_m1_state = m1_state;
+	}
+}
+
+void h_8_cpu_8080_device::rom_disable_w(int state)
+{
+	if (m_allow_disable_rom)
+	{
+		m_disable_rom = bool(state);
+
+		m_mem_view.select(m_disable_rom ? 1 : 0);
 	}
 }
 
@@ -215,6 +240,11 @@ void h_8_cpu_8080_device::p201_int2_w(int state)
 	handle_int2();
 }
 
+u8 h_8_cpu_8080_device::sys_rom_r(offs_t offset)
+{
+	return m_sys_rom[offset & 0xfff];
+}
+
 void h_8_cpu_8080_device::handle_int1()
 {
 	m_intr_socket->set_irq_level(1, (m_p201_int1 || m_bus_int1) ? ASSERT_LINE : CLEAR_LINE);
@@ -225,7 +255,6 @@ void h_8_cpu_8080_device::handle_int2()
 	m_intr_socket->set_irq_level(2, (m_p201_int2 || m_bus_int2) ? ASSERT_LINE : CLEAR_LINE);
 }
 
-
 static void intr_ctrl_options(device_slot_interface &device)
 {
 	device.option_add("original", HEATH_INTR_CNTRL);
@@ -233,22 +262,14 @@ static void intr_ctrl_options(device_slot_interface &device)
 
 void h_8_cpu_8080_device::mem_map(address_map &map)
 {
-	map.unmap_value_high();
-
-	// default mem access to h8bus
-	map(0x0000, 0xffff).rw(FUNC(h_8_cpu_8080_device::bus_mem_r), FUNC(h_8_cpu_8080_device::bus_mem_w));
-
-	// main rom
-	map(0x0000, 0x0fff).rom().region("maincpu", 0).unmapw();
+	map.unmap_value_low();
+	map(0x0000, 0xffff).view(m_mem_view);
 }
 
 void h_8_cpu_8080_device::io_map(address_map &map)
 {
-	map.unmap_value_high();
+	map.unmap_value_low();
 	map.global_mask(0xff);
-
-	// default io access to h8bus
-	map(0x0000, 0xff).rw(FUNC(h_8_cpu_8080_device::bus_io_r), FUNC(h_8_cpu_8080_device::bus_io_w));
 }
 
 
@@ -256,37 +277,35 @@ void h_8_cpu_8080_device::io_map(address_map &map)
 ROM_START( h8 )
 	ROM_REGION( 0x2000, "maincpu", ROMREGION_ERASEFF )
 
-	// H17 fdc bios - needed by bios2&3 this is on a separate card, keeping it documented here until that
-	// card is implemented.
-	//ROM_LOAD( "2716_444-19_h17.rom", 0x1800, 0x0800,     CRC(26e80ae3) SHA1(0c0ee95d7cb1a760f924769e10c0db1678f2435c))
+	// H17 floppy ROM is on a separate card, keeping it documented here until that card is implemented.
+	// ROM_LOAD( "2716_444-19_h17.rom", 0x1800, 0x0800,     CRC(26e80ae3) SHA1(0c0ee95d7cb1a760f924769e10c0db1678f2435c))
 
-	ROM_SYSTEM_BIOS(0, "bios0", "Standard")
+	ROM_SYSTEM_BIOS(0, "pam8", "Standard PAM8")
 	ROMX_LOAD( "2708_444-13_pam8.rom", 0x0000, 0x0400,   CRC(e0745513) SHA1(0e170077b6086be4e5cd10c17e012c0647688c39), ROM_BIOS(0) )
 
-	ROM_SYSTEM_BIOS(1, "bios1", "Alternate")
+	ROM_SYSTEM_BIOS(1, "pam8go", "Alternate PAM8GO")
 	ROMX_LOAD( "2708_444-13_pam8go.rom", 0x0000, 0x0400, CRC(9dbad129) SHA1(72421102b881706877f50537625fc2ab0b507752), ROM_BIOS(1) )
 
-	ROM_SYSTEM_BIOS(2, "bios2", "Disk OS")
+	ROM_SYSTEM_BIOS(2, "pam8at", "Disk OS PAM8AT")
 	ROMX_LOAD( "2716_444-13_pam8at.rom", 0x0000, 0x0800, CRC(fd95ddc1) SHA1(eb1f272439877239f745521139402f654e5403af), ROM_BIOS(2) )
 
-	ROM_SYSTEM_BIOS(3, "bios3", "Disk OS Alt")
+	ROM_SYSTEM_BIOS(3, "xcon8", "Disk OS XCON8")
 	ROMX_LOAD( "2732_444-70_xcon8.rom", 0x0000, 0x1000,  CRC(b04368f4) SHA1(965244277a3a8039a987e4c3593b52196e39b7e7), ROM_BIOS(3) )
 
-	// this one runs off into the weeds, because it is for the HA-8-6 Z-80 replacement CPU card, keeping it documented here, until
-	// that card is implemented.
-	// ROM_SYSTEM_BIOS(4, "bios4", "not working")
-	// ROMX_LOAD( "2732_444-140_pam37.rom", 0x0000, 0x1000, CRC(53a540db) SHA1(90082d02ffb1d27e8172b11fff465bd24343486e), ROM_BIOS(4) )
 ROM_END
 
 static INPUT_PORTS_START( cpu_8080_jumpers )
 
 	PORT_START("CONFIG")
-	PORT_CONFNAME(0x01, 0x00, "Allow INT1 signal on BH Bus - Jumper B1-B2")
+	PORT_CONFNAME(0x01, 0x00, "Allow INT1 signal from BH Bus - Jumper B1-B2")
 	PORT_CONFSETTING(   0x00, DEF_STR( No ))
 	PORT_CONFSETTING(   0x01, DEF_STR( Yes ))
-	PORT_CONFNAME(0x02, 0x00, "Allow INT2 signal on BH Bus - Jumper C1-C2")
+	PORT_CONFNAME(0x02, 0x00, "Allow INT2 signal from BH Bus - Jumper C1-C2")
 	PORT_CONFSETTING(   0x00, DEF_STR( No ))
 	PORT_CONFSETTING(   0x02, DEF_STR( Yes ))
+	PORT_CONFNAME(0x04, 0x04, "Allow /ROM_Disable from BH bus - Jumper X1-X2")
+	PORT_CONFSETTING(   0x00, DEF_STR( No ))
+	PORT_CONFSETTING(   0x04, DEF_STR( Yes ))
 
 INPUT_PORTS_END
 
@@ -307,32 +326,41 @@ void h_8_cpu_8080_device::device_start()
 	save_item(NAME(m_p201_int2));
 	save_item(NAME(m_bus_int1));
 	save_item(NAME(m_bus_int2));
-
-	h8bus().space(AS_PROGRAM).specific(m_mem);
-	h8bus().space(AS_IO).specific(m_io);
+	save_item(NAME(m_disable_rom));
 
 	h8bus().set_clock(m_maincpu->clock());
 }
 
 void h_8_cpu_8080_device::device_reset()
 {
+	ioport_value const config(m_config->read());
+
+	m_allow_bus_int1 = bool(BIT(config, 0));
+	m_allow_bus_int2 = bool(BIT(config, 1));
+	m_allow_disable_rom = bool(BIT(config, 2));
+
+	h8bus().map_mem(m_mem_view[0]);
+	h8bus().map_mem(m_mem_view[1]);
+	m_mem_view[0].install_read_handler(0x0000, 0x0fff, read8sm_delegate(*this, FUNC(h_8_cpu_8080_device::sys_rom_r)));
+
+	m_mem_view.select(0);
+	LOGORG0("%s: mem_view 0\n", FUNCNAME);
+
+	h8bus().map_io(m_maincpu->space(AS_IO));
+
 	m_m1_state  = false;
 	m_p201_int1 = false;
 	m_p201_int2 = false;
 	m_bus_int1  = false;
 	m_bus_int2  = false;
-
-	ioport_value const config(m_config->read());
-
-	m_allow_bus_int1 = bool(BIT(config, 0));
-	m_allow_bus_int2 = bool(BIT(config, 1));
+	m_disable_rom = false;
 }
 
 void h_8_cpu_8080_device::device_add_mconfig(machine_config &config)
 {
 	constexpr XTAL H8_CLOCK = XTAL(18'432'000) / 9;  // 2.048 MHz
 
-	I8080(config, m_maincpu, H8_CLOCK);
+	I8080A(config, m_maincpu, H8_CLOCK);
 	m_maincpu->set_addrmap(AS_PROGRAM, &h_8_cpu_8080_device::mem_map);
 	m_maincpu->set_addrmap(AS_IO, &h_8_cpu_8080_device::io_map);
 	m_maincpu->out_status_func().set(FUNC(h_8_cpu_8080_device::h8_status_callback));

--- a/src/devices/bus/heathzenith/h8/h8bus.cpp
+++ b/src/devices/bus/heathzenith/h8/h8bus.cpp
@@ -83,6 +83,27 @@ h8bus_slot_device::h8bus_slot_device(const machine_config &mconfig, device_type 
 {
 }
 
+void h8bus_slot_device::map_mem(address_space_installer &space)
+{
+	auto dev = get_card_device();
+
+	if(dev)
+	{
+		dev->map_mem(space);
+	}
+}
+
+void h8bus_slot_device::map_io(address_space_installer &space)
+{
+	auto dev = get_card_device();
+
+	if(dev)
+	{
+		dev->map_io(space);
+	}
+}
+
+
 void h8bus_slot_device::device_start()
 {
 }
@@ -139,13 +160,29 @@ void h8bus_device::device_reset()
 
 void h8bus_device::mem_map(address_map &map)
 {
-	map.unmap_value_high();
+	map.unmap_value_low();
 }
 
 void h8bus_device::io_map(address_map &map)
 {
-	map.unmap_value_high();
+	map.unmap_value_low();
 	map.global_mask(0xff);
+}
+
+void h8bus_device::map_mem(address_space_installer &space)
+{
+	for (device_h8bus_card_interface &entry : m_device_list)
+	{
+		entry.map_mem(space);
+	}
+}
+
+void h8bus_device::map_io(address_space_installer &space)
+{
+	for (device_h8bus_card_interface &entry : m_device_list)
+	{
+		entry.map_io(space);
+	}
 }
 
 device_memory_interface::space_config_vector h8bus_device::memory_space_config() const

--- a/src/devices/bus/heathzenith/h8/h8bus.h
+++ b/src/devices/bus/heathzenith/h8/h8bus.h
@@ -150,6 +150,7 @@ class h8bus_device;
 
 class device_h8bus_card_interface : public device_interface
 {
+	friend class h8bus_slot_device;
 	friend class h8bus_device;
 public:
 	virtual ~device_h8bus_card_interface();
@@ -174,6 +175,9 @@ public:
 protected:
 	device_h8bus_card_interface(const machine_config &mconfig, device_t &device);
 	virtual void interface_pre_start() override;
+
+	virtual void map_mem(address_space_installer & space) {};
+	virtual void map_io(address_space_installer & space) {};
 
 	void set_slot_int1(int state);
 	void set_slot_int2(int state);
@@ -256,6 +260,9 @@ public:
 		m_h8bus_slottag = slottag;
 	}
 
+	void map_mem(address_space_installer &space);
+	void map_io(address_space_installer &space);
+
 protected:
 	h8bus_slot_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
@@ -277,6 +284,9 @@ class h8bus_device : public device_t, public device_memory_interface
 public:
 	h8bus_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 	~h8bus_device();
+
+	void map_mem(address_space_installer &space);
+	void map_io(address_space_installer &space);
 
 protected:
 	h8bus_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);

--- a/src/devices/bus/heathzenith/h8/h_8_1.h
+++ b/src/devices/bus/heathzenith/h8/h_8_1.h
@@ -7,6 +7,6 @@
 
 #include "h8bus.h"
 
-DECLARE_DEVICE_TYPE(H8BUS_H_8_1,    device_h8bus_card_interface)
+DECLARE_DEVICE_TYPE(H8BUS_H_8_1, device_h8bus_card_interface)
 
 #endif // MAME_BUS_HEATHZENITH_H8_H_8_1_H

--- a/src/devices/bus/heathzenith/h8/ha_8_6.cpp
+++ b/src/devices/bus/heathzenith/h8/ha_8_6.cpp
@@ -1,0 +1,533 @@
+// license:BSD-3-Clause
+// copyright-holders:Mark Garlanger
+/***************************************************************************
+
+  Heathkit HA-8-6 Z80 CPU board
+
+
+  Onboard Jumpers
+
+  Common   To   Installed  Emulated  Description (if jumper is closed)
+  -------------------------------------------------------------------------
+    E2     E1     Yes       Fixed    On board clock
+           E3     No        No       External clock
+
+    E4     E5     Yes       Fixed    0k to 4k ROM select
+          Open    No        No       0k to 8k ROM select
+
+    E7     E6     Yes       Fixed    Normal bus O2
+           E8     No        No       Offset bus O2
+    E10    E9     Yes       Fixed    Normal bus O2
+           E8     No        No       Offset bus O2
+
+
+    E14    E13    Yes       Fixed    On board reset
+           E12    No        No       External reset
+
+    E15    E16    Yes       No       CS2 to CS1
+           E17    No        No       CS2 to +5V
+
+    E20    E18    No        No       External O2
+           E19    Yes       No       On board
+
+    E23    E21    Yes       No       Reset to bus
+           E22    No        No       Reset from bus
+
+    E24    E25    No        No       CS2 to CS1
+           E26    No        No       CS2 to +5V
+
+    E28    E29    Yes       No       /INTA
+           E27    No        No       /INTA option
+
+    E32    E31    No        No       NMI Option
+           E30    No        No       NMI Option
+
+    E33    E34    No        No       INT 0 Option
+
+    E35     -     No        No       Halt Option
+
+    E36     -     No        No       INTA Option
+
+    E38     -     No        No       Bus Pin 18
+
+    E39     -     No        No       Bus Pin 9
+
+    E40     -     No        No       Refresh Option
+
+    E41     -     No        Yes      Int 20 Option
+
+    E42     -     No        No       External Disable
+
+    E43     -     No        No       Int 0 Option
+
+    E44     -     No        No       Bus Pin 8
+
+    E45     -     No        Yes      Int 10 Option
+
+    E46     -     No        No       Side Select Option
+
+    E47     -     No        No       NMI Option
+
+    E48    E50    No        No       Normal Write
+
+    E49    E51    Yes       No       Early Write
+
+****************************************************************************/
+
+
+#include "emu.h"
+
+#include "ha_8_6.h"
+
+#include "bus/heathzenith/intr_cntrl/intr_cntrl.h"
+#include "cpu/z80/z80.h"
+
+#define LOG_ORG0 (1U << 1)    // Shows register setup
+
+#define VERBOSE (0)
+
+#include "logmacro.h"
+
+#define LOGORG0(...)        LOGMASKED(LOG_ORG0, __VA_ARGS__)
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+
+namespace {
+
+class ha_8_6_device : public device_t
+					, public device_h8bus_card_interface
+					, public device_p201_p2_card_interface
+{
+public:
+
+	ha_8_6_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0);
+
+	virtual void int1_w(int state) override;
+	virtual void int2_w(int state) override;
+	virtual void int3_w(int state) override;
+	virtual void int4_w(int state) override;
+	virtual void int5_w(int state) override;
+	virtual void int6_w(int state) override;
+	virtual void int7_w(int state) override;
+	virtual void rom_disable_w(int state) override;
+
+	virtual void p201_reset_w(int state) override;
+	virtual void p201_int1_w(int state) override;
+	virtual void p201_int2_w(int state) override;
+
+protected:
+
+	virtual const tiny_rom_entry *device_rom_region() const override ATTR_COLD;
+	virtual ioport_constructor device_input_ports() const override ATTR_COLD;
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
+
+	virtual void map_io(address_space_installer & space) override ATTR_COLD;
+
+	void handle_int1();
+	void handle_int2();
+
+	u8 sys_rom_r(offs_t offset);
+
+	u8 portf2_r();
+	void portf2_w(u8 data);
+
+	void update_gpp(u8 data);
+
+	void map_fetch(address_map &map);
+	u8 m1_r(offs_t offset);
+
+	bool m_installed;
+	u8   m_gpp;
+
+	bool m_m1_state;
+	bool m_allow_bus_int1;
+	bool m_allow_bus_int2;
+	bool m_p201_int1;
+	bool m_p201_int2;
+	bool m_bus_int1;
+	bool m_bus_int2;
+
+private:
+	void mem_map(address_map &map) ATTR_COLD;
+	void io_map(address_map &map) ATTR_COLD;
+
+	required_device<z80_device>        m_maincpu;
+	required_device<heath_intr_socket> m_intr_socket;
+	required_region_ptr<u8>            m_sys_rom;
+	memory_view                        m_mem_view;
+	required_ioport                    m_sw1;
+	required_ioport                    m_config;
+
+	memory_access<16, 0, 0, ENDIANNESS_LITTLE>::specific m_mem;
+};
+
+ha_8_6_device::ha_8_6_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, H8BUS_HA_8_6, tag, owner, 0)
+	, device_h8bus_card_interface(mconfig, *this)
+	, device_p201_p2_card_interface(*this, tag)
+	, m_maincpu(*this, "maincpu")
+	, m_intr_socket(*this, "intr_socket")
+	, m_sys_rom(*this, "maincpu")
+	, m_mem_view(*this, "mem")
+	, m_sw1(*this, "SW1")
+	, m_config(*this, "CONFIG")
+{
+}
+
+void ha_8_6_device::int1_w(int state)
+{
+	if (m_allow_bus_int1)
+	{
+		m_bus_int1 = bool(state);
+
+		handle_int1();
+	}
+}
+
+void ha_8_6_device::int2_w(int state)
+{
+	if (m_allow_bus_int2)
+	{
+		m_bus_int2 = bool(state);
+
+		handle_int2();
+	}
+}
+
+void ha_8_6_device::int3_w(int state)
+{
+	m_intr_socket->set_irq_level(3, state);
+}
+
+void ha_8_6_device::int4_w(int state)
+{
+	m_intr_socket->set_irq_level(4, state);
+}
+
+void ha_8_6_device::int5_w(int state)
+{
+	m_intr_socket->set_irq_level(5, state);
+}
+
+void ha_8_6_device::int6_w(int state)
+{
+	m_intr_socket->set_irq_level(6, state);
+}
+
+void ha_8_6_device::int7_w(int state)
+{
+	m_intr_socket->set_irq_level(7, state);
+}
+
+void ha_8_6_device::p201_reset_w(int state)
+{
+	if (state)
+	{
+		m_maincpu->reset();
+	}
+
+	set_slot_reset(state);
+}
+
+void ha_8_6_device::p201_int1_w(int state)
+{
+	m_p201_int1 = bool(state);
+
+	handle_int1();
+}
+
+void ha_8_6_device::p201_int2_w(int state)
+{
+	m_p201_int2 = bool(state);
+
+	handle_int2();
+}
+
+void ha_8_6_device::handle_int1()
+{
+	m_intr_socket->set_irq_level(1, (m_p201_int1 || m_bus_int1) ? ASSERT_LINE : CLEAR_LINE);
+
+}
+
+void ha_8_6_device::handle_int2()
+{
+	m_intr_socket->set_irq_level(2, (m_p201_int2 || m_bus_int2) ? ASSERT_LINE : CLEAR_LINE);
+}
+
+
+static void intr_ctrl_options(device_slot_interface &device)
+{
+	device.option_add("original", HEATH_INTR_CNTRL);
+}
+
+u8 ha_8_6_device::sys_rom_r(offs_t offset)
+{
+	return m_sys_rom[offset & 0xfff];
+}
+
+u8 ha_8_6_device::portf2_r()
+{
+	u8 sw1 = m_sw1->read();
+
+	return sw1;
+}
+
+void ha_8_6_device::portf2_w(u8 data)
+{
+	if (data != m_gpp)
+	{
+		update_gpp(data);
+	}
+}
+
+void ha_8_6_device::update_gpp(u8 data)
+{
+	u8 changed_gpp = data ^ m_gpp;
+
+	m_gpp = data;
+
+	if (BIT(changed_gpp, 5))
+	{
+		int state = BIT(m_gpp, 5);
+
+		LOGORG0("%s: updating gpp: %d\n", FUNCNAME, state);
+
+		set_slot_rom_disable(state);
+	}
+}
+
+void ha_8_6_device::rom_disable_w(int state)
+{
+	LOGORG0("%s: mem_view %d\n", FUNCNAME, (state ? 1 : 0));
+
+	m_mem_view.select(state ? 1 : 0);
+}
+
+void ha_8_6_device::mem_map(address_map &map)
+{
+	map.unmap_value_low();
+
+	map(0x0000, 0xffff).view(m_mem_view);
+}
+
+void ha_8_6_device::io_map(address_map &map)
+{
+	map.unmap_value_low();
+	map.global_mask(0xff);
+}
+
+void ha_8_6_device::map_io(address_space_installer & space)
+{
+	space.install_readwrite_handler(0xf2, 0xf2,
+		read8smo_delegate(*this, FUNC(ha_8_6_device::portf2_r)),
+		write8smo_delegate(*this, FUNC(ha_8_6_device::portf2_w))
+	);
+}
+
+// ROM definition
+ROM_START( ha_8_6 )
+	ROM_REGION( 0x1000, "maincpu", ROMREGION_ERASEFF )
+	ROM_DEFAULT_BIOS("xcon8")
+
+	ROM_SYSTEM_BIOS(0, "xcon8", "ROM supporting ORG0 for H17 and H47")
+	ROMX_LOAD( "2732_444-70_xcon8.rom", 0x0000, 0x1000,  CRC(b04368f4) SHA1(965244277a3a8039a987e4c3593b52196e39b7e7), ROM_BIOS(0) )
+
+	ROM_SYSTEM_BIOS(1, "pam37", "ROM supporting H17, H37, H47, and H67")
+	ROMX_LOAD( "2732_444-140_pam37.rom", 0x0000, 0x1000, CRC(53a540db) SHA1(90082d02ffb1d27e8172b11fff465bd24343486e), ROM_BIOS(1) )
+ROM_END
+
+static INPUT_PORTS_START( ha_8_6_jumpers )
+
+	PORT_START("SW1")
+	// Generic definition
+	PORT_DIPNAME( 0x01, 0x00, "Switch 0" )                        PORT_DIPLOCATION("SW1:1")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x00)
+	PORT_DIPSETTING(    0x00, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x01, DEF_STR( On ) )
+	PORT_DIPNAME( 0x02, 0x00, "Switch 1" )                        PORT_DIPLOCATION("SW1:2")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x00)
+	PORT_DIPSETTING(    0x00, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x02, DEF_STR( On ) )
+	PORT_DIPNAME( 0x04, 0x00, "Switch 2" )                        PORT_DIPLOCATION("SW1:3")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x00)
+	PORT_DIPSETTING(    0x00, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x04, DEF_STR( On ) )
+	PORT_DIPNAME( 0x08, 0x00, "Switch 3" )                        PORT_DIPLOCATION("SW1:4")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x00)
+	PORT_DIPSETTING(    0x00, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x08, DEF_STR( On ) )
+	PORT_DIPNAME( 0x10, 0x00, "Switch 4" )                        PORT_DIPLOCATION("SW1:5")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x00)
+	PORT_DIPSETTING(    0x00, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x10, DEF_STR( On ) )
+	PORT_DIPNAME( 0x20, 0x20, "Switch 5" )                        PORT_DIPLOCATION("SW1:6")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x00)
+	PORT_DIPSETTING(    0x00, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x20, DEF_STR( On ) )
+	PORT_DIPNAME( 0x40, 0x00, "Switch 6" )                        PORT_DIPLOCATION("SW1:7")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x00)
+	PORT_DIPSETTING(    0x00, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x40, DEF_STR( On ) )
+	PORT_DIPNAME( 0x80, 0x00, "Switch 7" )                        PORT_DIPLOCATION("SW1:8")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x00)
+	PORT_DIPSETTING(    0x00, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x80, DEF_STR( On ) )
+
+	PORT_DIPNAME( 0x01, 0x00, "Port 174 device" )                 PORT_DIPLOCATION("SW1:1")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x04)
+	PORT_DIPSETTING(    0x00, "H17" )
+	PORT_DIPSETTING(    0x01, "H47" )
+	PORT_DIPNAME( 0x02, 0x00, "(Set At Zero)" )                   PORT_DIPLOCATION("SW1:2")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x04)
+	PORT_DIPSETTING(    0x00, "Undefined" )
+	PORT_DIPSETTING(    0x02, "Undefined" )
+	PORT_DIPNAME( 0x04, 0x00, "Port 170 device" )                 PORT_DIPLOCATION("SW1:3")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x04)
+	PORT_DIPSETTING(    0x00, "Not in use" )
+	PORT_DIPSETTING(    0x04, "H47" )
+	PORT_DIPNAME( 0x08, 0x00, "(Set At Zero)" )                   PORT_DIPLOCATION("SW1:4")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x04)
+	PORT_DIPSETTING(    0x00, "Undefined" )
+	PORT_DIPSETTING(    0x08, "Undefined" )
+	PORT_DIPNAME( 0x10, 0x10, "Primary Boot from" )               PORT_DIPLOCATION("SW1:5")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x04)
+	PORT_DIPSETTING(    0x00, "Boots from device at port 174" )
+	PORT_DIPSETTING(    0x10, "Boots from device at port 170" )
+	PORT_DIPNAME( 0x20, 0x20, "(Set At Zero)" )                   PORT_DIPLOCATION("SW1:6")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x04)
+	PORT_DIPSETTING(    0x00, "Undefined" )
+	PORT_DIPSETTING(    0x20, "Undefined" )
+	PORT_DIPNAME( 0x40, 0x00, "(Set At Zero)" )                   PORT_DIPLOCATION("SW1:7")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x04)
+	PORT_DIPSETTING(    0x00, "Undefined" )
+	PORT_DIPSETTING(    0x40, "Undefined" )
+	PORT_DIPNAME( 0x80, 0x00, "Boot mode" )                       PORT_DIPLOCATION("SW1:8")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x04)
+	PORT_DIPSETTING(    0x00, DEF_STR( Normal ) )
+	PORT_DIPSETTING(    0x80, "Auto" )
+
+	PORT_DIPNAME( 0x03, 0x00, "Port 174 device" )                 PORT_DIPLOCATION("SW1:1,2")     PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x08)
+	PORT_DIPSETTING(    0x00, "H17" )
+	PORT_DIPSETTING(    0x01, "H47" )
+	PORT_DIPSETTING(    0x02, "H67" )
+	PORT_DIPSETTING(    0x03, "Undefined" )
+	PORT_DIPNAME( 0x0c, 0x00, "Port 170 device" )                 PORT_DIPLOCATION("SW1:3,4")     PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x08)
+	PORT_DIPSETTING(    0x00, "H37" )
+	PORT_DIPSETTING(    0x04, "H47" )
+	PORT_DIPSETTING(    0x08, "H67" )
+	PORT_DIPSETTING(    0x0c, "Undefined" )
+	PORT_DIPNAME( 0x10, 0x10, "Primary Boot from" )               PORT_DIPLOCATION("SW1:5")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x08)
+	PORT_DIPSETTING(    0x00, "Boots from device at port 174" )
+	PORT_DIPSETTING(    0x10, "Boots from device at port 170" )
+	PORT_DIPNAME( 0x20, 0x20, "(Set At Zero)" )                   PORT_DIPLOCATION("SW1:6")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x08)
+	PORT_DIPSETTING(    0x00, "Undefined" )
+	PORT_DIPSETTING(    0x20, "Undefined" )
+	PORT_DIPNAME( 0x40, 0x00, "(Set At Zero)" )                   PORT_DIPLOCATION("SW1:7")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x08)
+	PORT_DIPSETTING(    0x00, "Undefined" )
+	PORT_DIPSETTING(    0x40, "Undefined" )
+	PORT_DIPNAME( 0x80, 0x00, "Boot mode" )                       PORT_DIPLOCATION("SW1:8")       PORT_CONDITION("CONFIG", 0x1c, EQUALS, 0x08)
+	PORT_DIPSETTING(    0x00, DEF_STR( Normal ) )
+	PORT_DIPSETTING(    0x80, "Auto" )
+
+	PORT_START("CONFIG")
+	PORT_CONFNAME(0x01, 0x00, "Allow INT1 signal on BH Bus - Jumper E45" )
+	PORT_CONFSETTING(   0x00, DEF_STR( No ) )
+	PORT_CONFSETTING(   0x01, DEF_STR( Yes ) )
+	PORT_CONFNAME(0x02, 0x00, "Allow INT2 signal on BH Bus - Jumper E41" )
+	PORT_CONFSETTING(   0x00, DEF_STR( No ) )
+	PORT_CONFSETTING(   0x02, DEF_STR( Yes ) )
+
+	PORT_CONFNAME(0x1c, 0x08, "Switch SW1 Definitions" )
+	PORT_CONFSETTING(   0x00, "Generic" )
+	PORT_CONFSETTING(   0x04, "Heath XCON8" )
+	PORT_CONFSETTING(   0x08, "Heath PAM37" )
+
+INPUT_PORTS_END
+
+ioport_constructor ha_8_6_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME(ha_8_6_jumpers);
+}
+
+const tiny_rom_entry *ha_8_6_device::device_rom_region() const
+{
+	return ROM_NAME(ha_8_6);
+}
+
+void ha_8_6_device::map_fetch(address_map &map)
+{
+	map(0x0000, 0xffff).r(FUNC(ha_8_6_device::m1_r));
+}
+
+u8 ha_8_6_device::m1_r(offs_t offset)
+{
+	u8 data = m_mem.read_byte(offset);
+
+	if (!machine().side_effects_disabled())
+	{
+		set_slot_m1(ASSERT_LINE);
+
+		if (data == 0xfb) // Check for EI instruction
+		{
+			m_p201_inte(ASSERT_LINE);
+		}
+		else if (data == 0xf3) // Check for DI instruction
+		{
+			m_p201_inte(CLEAR_LINE);
+		}
+
+		set_slot_m1(CLEAR_LINE);
+	}
+
+	return data;
+}
+
+void ha_8_6_device::device_start()
+{
+	save_item(NAME(m_installed));
+	save_item(NAME(m_gpp));
+	save_item(NAME(m_m1_state));
+	save_item(NAME(m_p201_int1));
+	save_item(NAME(m_p201_int2));
+	save_item(NAME(m_bus_int1));
+	save_item(NAME(m_bus_int2));
+
+	h8bus().set_clock(m_maincpu->clock());
+}
+
+void ha_8_6_device::device_reset()
+{
+	ioport_value const config(m_config->read());
+
+	m_allow_bus_int1 = bool(BIT(config, 0));
+	m_allow_bus_int2 = bool(BIT(config, 1));
+
+	m_maincpu->space(AS_PROGRAM).specific(m_mem);
+
+	h8bus().map_mem(m_mem_view[0]);
+	h8bus().map_mem(m_mem_view[1]);
+	m_mem_view[0].install_read_handler(0x0000, 0x0fff, read8sm_delegate(*this, FUNC(ha_8_6_device::sys_rom_r)));
+
+	m_mem_view.select(0);
+	LOGORG0("%s: mem_view 0\n", FUNCNAME);
+
+	h8bus().map_io(m_maincpu->space(AS_IO));
+
+
+	m_m1_state  = false;
+	m_p201_int1 = false;
+	m_p201_int2 = false;
+	m_bus_int1  = false;
+	m_bus_int2  = false;
+}
+
+void ha_8_6_device::device_add_mconfig(machine_config &config)
+{
+	constexpr XTAL H8_CLOCK = XTAL(18'432'000) / 9;  // 2.048 MHz
+
+	Z80(config, m_maincpu, H8_CLOCK);
+	m_maincpu->set_addrmap(AS_PROGRAM, &ha_8_6_device::mem_map);
+	m_maincpu->set_addrmap(AS_IO, & ha_8_6_device::io_map);
+	m_maincpu->set_m1_map(&ha_8_6_device::map_fetch);
+	m_maincpu->set_irq_acknowledge_callback(m_intr_socket, FUNC(heath_intr_socket::irq_callback));
+
+	HEATH_INTR_SOCKET(config, m_intr_socket, intr_ctrl_options, nullptr);
+	m_intr_socket->irq_line_cb().set_inputline(m_maincpu, INPUT_LINE_IRQ0);
+	m_intr_socket->set_default_option("original");
+	m_intr_socket->set_fixed(true);
+}
+
+} // anonymous namespace
+
+DEFINE_DEVICE_TYPE_PRIVATE(H8BUS_HA_8_6, device_h8bus_card_interface, ha_8_6_device, "h8_ha_8_6", "Heath Z80 CPU board");

--- a/src/devices/bus/heathzenith/h8/ha_8_6.h
+++ b/src/devices/bus/heathzenith/h8/ha_8_6.h
@@ -1,0 +1,12 @@
+// license:BSD-3-Clause
+// copyright-holders:Mark Garlanger
+#ifndef MAME_BUS_HEATHZENITH_H8_HA_8_6_H
+#define MAME_BUS_HEATHZENITH_H8_HA_8_6_H
+
+#pragma once
+
+#include "h8bus.h"
+
+DECLARE_DEVICE_TYPE(H8BUS_HA_8_6, device_h8bus_card_interface)
+
+#endif // MAME_BUS_HEATHZENITH_H8_HA_8_6_H

--- a/src/devices/bus/heathzenith/h8/ha_8_8.cpp
+++ b/src/devices/bus/heathzenith/h8/ha_8_8.cpp
@@ -1,0 +1,157 @@
+// license:BSD-3-Clause
+// copyright-holders:Mark Garlanger
+/***************************************************************************
+
+  Heathkit HA-8-8 Extended Configuration Option board
+
+****************************************************************************/
+
+#include "emu.h"
+
+#include "ha_8_8.h"
+
+#define LOG_REG_R (1U << 1)
+#define LOG_REG_W (1U << 2)
+#define LOG_ORG0 (1U << 3)    // Shows register setup
+
+#define VERBOSE (0)
+
+#include "logmacro.h"
+
+#define LOGREGR(...)        LOGMASKED(LOG_REG_R, __VA_ARGS__)
+#define LOGREGW(...)        LOGMASKED(LOG_REG_W, __VA_ARGS__)
+#define LOGORG0(...)        LOGMASKED(LOG_ORG0, __VA_ARGS__)
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+
+namespace {
+
+class ha_8_8_device : public device_t
+					, public device_h8bus_card_interface
+{
+public:
+
+	ha_8_8_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0);
+
+protected:
+
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+	virtual ioport_constructor device_input_ports() const override ATTR_COLD;
+	virtual void map_io(address_space_installer & space) override ATTR_COLD;
+
+	u8 portf2_r();
+	void portf2_w(u8 data);
+
+	u8 m_gpp;
+	required_ioport m_sw1;
+
+private:
+
+	void update_gpp(u8 data);
+};
+
+
+ha_8_8_device::ha_8_8_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, H8BUS_HA_8_8, tag, owner, 0)
+	, device_h8bus_card_interface(mconfig, *this)
+	, m_sw1(*this, "SW1")
+{
+}
+
+u8 ha_8_8_device::portf2_r()
+{
+	u8 sw1 = m_sw1->read();
+
+	LOGREGR("%s: value: 0x%02x\n", FUNCNAME, sw1);
+
+	return sw1;
+}
+
+void ha_8_8_device::portf2_w(u8 data)
+{
+	LOGREGW("%s: value: 0x%02x\n", FUNCNAME, data);
+
+	if (data != m_gpp)
+	{
+		update_gpp(data);
+	}
+}
+
+void ha_8_8_device::device_start()
+{
+	save_item(NAME(m_gpp));
+}
+
+void ha_8_8_device::device_reset()
+{
+	m_gpp = 0;
+
+	set_slot_rom_disable(BIT(m_gpp, 5));
+}
+
+void ha_8_8_device::update_gpp(u8 data)
+{
+	u8 changed_gpp = data ^ m_gpp;
+
+	m_gpp = data;
+
+	if (BIT(changed_gpp, 5))
+	{
+		int state = BIT(m_gpp, 5);
+
+		LOGORG0("%s: updating gpp: %d\n", FUNCNAME, state);
+
+		set_slot_rom_disable(state);
+	}
+}
+
+void ha_8_8_device::map_io(address_space_installer & space)
+{
+	space.install_readwrite_handler(0xf2, 0xf2,
+		read8smo_delegate(*this, FUNC(ha_8_8_device::portf2_r)),
+		write8smo_delegate(*this, FUNC(ha_8_8_device::portf2_w))
+	);
+}
+
+static INPUT_PORTS_START( sw1 )
+
+	PORT_START("SW1")
+	PORT_DIPNAME( 0x03, 0x00, "Port 174 device" )                 PORT_DIPLOCATION("SW1:1,2")
+	PORT_DIPSETTING(    0x00, "H17" )
+	PORT_DIPSETTING(    0x01, "H47" )
+	PORT_DIPSETTING(    0x02, "Undefined" )
+	PORT_DIPSETTING(    0x03, "Undefined" )
+	PORT_DIPNAME( 0x0c, 0x00, "Port 170 device" )                 PORT_DIPLOCATION("SW1:3,4")
+	PORT_DIPSETTING(    0x00, "Not in use" )
+	PORT_DIPSETTING(    0x04, "H47" )
+	PORT_DIPSETTING(    0x08, "Undefined" )
+	PORT_DIPSETTING(    0x0c, "Undefined" )
+	PORT_DIPNAME( 0x10, 0x00, "Primary Boot from" )               PORT_DIPLOCATION("SW1:5")
+	PORT_DIPSETTING(    0x00, "Boots from device at port 174" )
+	PORT_DIPSETTING(    0x10, "Boots from device at port 170" )
+	PORT_DIPNAME( 0x20, 0x20, "Perform memory test at start" )    PORT_DIPLOCATION("SW1:6")
+	PORT_DIPSETTING(    0x20, DEF_STR( No ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( Yes ) )
+	PORT_DIPNAME( 0x40, 0x00, "Console Baud rate" )               PORT_DIPLOCATION("SW1:7")
+	PORT_DIPSETTING(    0x00, "9600" )
+	PORT_DIPSETTING(    0x40, "19200" )
+	PORT_DIPNAME( 0x80, 0x00, "Boot mode" )                       PORT_DIPLOCATION("SW1:8")
+	PORT_DIPSETTING(    0x00, DEF_STR( Normal ) )
+	PORT_DIPSETTING(    0x80, "Auto" )
+
+INPUT_PORTS_END
+
+ioport_constructor ha_8_8_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME(sw1);
+}
+
+} // anonymous namespace
+
+DEFINE_DEVICE_TYPE_PRIVATE(H8BUS_HA_8_8, device_h8bus_card_interface, ha_8_8_device, "h8_ha_8_8", "Heath HA-8-8 Extended Configuration Option Board");

--- a/src/devices/bus/heathzenith/h8/ha_8_8.h
+++ b/src/devices/bus/heathzenith/h8/ha_8_8.h
@@ -1,0 +1,12 @@
+// license:BSD-3-Clause
+// copyright-holders:Mark Garlanger
+#ifndef MAME_BUS_HEATHZENITH_H8_HA_8_8_H
+#define MAME_BUS_HEATHZENITH_H8_HA_8_8_H
+
+#pragma once
+
+#include "h8bus.h"
+
+DECLARE_DEVICE_TYPE(H8BUS_HA_8_8, device_h8bus_card_interface)
+
+#endif // MAME_BUS_HEATHZENITH_H8_HA_8_8_H

--- a/src/devices/bus/heathzenith/h8/wh_8_16.cpp
+++ b/src/devices/bus/heathzenith/h8/wh_8_16.cpp
@@ -1,0 +1,117 @@
+// license:BSD-3-Clause
+// copyright-holders:Mark Garlanger
+/***************************************************************************
+
+  Heathkit WH-8-16 16k Static RAM board
+
+****************************************************************************/
+
+#include "emu.h"
+
+#include "wh_8_16.h"
+
+#include "machine/ram.h"
+
+#define LOG_INIT (1U << 1)
+
+#define VERBOSE (LOG_INIT)
+
+#include "logmacro.h"
+
+#define LOGINIT(...)        LOGMASKED(LOG_INIT, __VA_ARGS__)
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+
+namespace {
+
+class wh_8_16_device : public device_t
+					 , public device_h8bus_card_interface
+{
+public:
+
+	wh_8_16_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0);
+
+protected:
+
+	virtual void device_start() override ATTR_COLD;
+	virtual ioport_constructor device_input_ports() const override ATTR_COLD;
+	virtual void map_mem(address_space_installer & space) override ATTR_COLD;
+
+	memory_share_creator<u8> m_ram;
+	required_ioport          m_sw1;
+};
+
+
+wh_8_16_device::wh_8_16_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, H8BUS_WH_8_16, tag, owner, 0)
+	, device_h8bus_card_interface(mconfig, *this)
+	, m_ram(*this, "ram", 0x4000U, ENDIANNESS_LITTLE)
+	, m_sw1(*this, "SW1")
+{
+}
+
+void wh_8_16_device::device_start()
+{
+}
+
+void wh_8_16_device::map_mem(address_space_installer & space)
+{
+	ioport_value const sw1(m_sw1->read());
+
+	if (BIT(sw1,0) == 1)
+	{
+		u16 base_addr = (sw1 & 0x1e) << 11;
+		u16 top_addr = base_addr + 0x3fff;
+
+		LOGINIT("%s: base_addr = 0x%04x, top_addr = 0x%04x\n", FUNCNAME, base_addr, top_addr);
+
+		// check for wrap-around
+		if (top_addr < base_addr)
+		{
+			// install wrap around memory
+			u8 mem_offset = 0x3fff - top_addr;
+
+			LOGINIT("%s: wrap around mem_offset = 0x%04x\n", FUNCNAME, mem_offset);
+
+			space.install_ram(0x0000, top_addr, m_ram + mem_offset);
+
+			top_addr = 0xffff;
+		}
+
+		space.install_ram(base_addr, top_addr, m_ram);
+	}
+}
+
+
+static INPUT_PORTS_START( wh_8_16 )
+	PORT_START("SW1")
+	PORT_CONFNAME(0x01, 0x01, "Board Enabled")
+	PORT_CONFSETTING(   0x00, DEF_STR( No ))
+	PORT_CONFSETTING(   0x01, DEF_STR( Yes ))
+	PORT_CONFNAME(0x02, 0x00, "ORG Starting address A12" )
+	PORT_CONFSETTING(   0x00, "0")
+	PORT_CONFSETTING(   0x02, "1")
+	PORT_CONFNAME(0x04, 0x04, "ORG Starting address A13" )
+	PORT_CONFSETTING(   0x00, "0")
+	PORT_CONFSETTING(   0x04, "1")
+	PORT_CONFNAME(0x08, 0x00, "ORG Starting address A14" )
+	PORT_CONFSETTING(   0x00, "0")
+	PORT_CONFSETTING(   0x08, "1")
+	PORT_CONFNAME(0x10, 0x00, "ORG Starting address A15" )
+	PORT_CONFSETTING(   0x00, "0")
+	PORT_CONFSETTING(   0x10, "1")
+INPUT_PORTS_END
+
+ioport_constructor wh_8_16_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME(wh_8_16);
+}
+
+} // anonymous namespace
+
+DEFINE_DEVICE_TYPE_PRIVATE(H8BUS_WH_8_16, device_h8bus_card_interface, wh_8_16_device, "h8_wh_8_16", "Heath WH-8-16 16k Static RAM");

--- a/src/devices/bus/heathzenith/h8/wh_8_16.h
+++ b/src/devices/bus/heathzenith/h8/wh_8_16.h
@@ -1,0 +1,12 @@
+// license:BSD-3-Clause
+// copyright-holders:Mark Garlanger
+#ifndef MAME_BUS_HEATHZENITH_H8_WH_8_16_H
+#define MAME_BUS_HEATHZENITH_H8_WH_8_16_H
+
+#pragma once
+
+#include "h8bus.h"
+
+DECLARE_DEVICE_TYPE(H8BUS_WH_8_16, device_h8bus_card_interface)
+
+#endif // MAME_BUS_HEATHZENITH_H8_WH_8_16_H

--- a/src/devices/bus/heathzenith/h8/wh_8_64.h
+++ b/src/devices/bus/heathzenith/h8/wh_8_64.h
@@ -7,6 +7,6 @@
 
 #include "h8bus.h"
 
-DECLARE_DEVICE_TYPE(H8BUS_WH_8_64,     device_h8bus_card_interface)
+DECLARE_DEVICE_TYPE(H8BUS_WH_8_64, device_h8bus_card_interface)
 
 #endif // MAME_BUS_HEATHZENITH_H8_WH_8_64_H

--- a/src/mame/heathzenith/h8.cpp
+++ b/src/mame/heathzenith/h8.cpp
@@ -114,7 +114,7 @@ void h8_state::h8(machine_config &config)
 	H8BUS_SLOT(config,  "p7", "h8bus", h8_cards,     nullptr);
 	H8BUS_SLOT(config,  "p8", "h8bus", h8_cards,     nullptr);
 	H8BUS_SLOT(config,  "p9", "h8bus", h8_cards,     "h_8_5");
-	H8BUS_SLOT(config, "p10", "h8bus", h8_p10_cards, nullptr);
+	H8BUS_SLOT(config, "p10", "h8bus", h8_p10_cards, "ha_8_8");
 }
 
 // ROM definition


### PR DESCRIPTION
Added cards:

- HA-8-6 - Z80 CPU replacement board
- HA-8-8 - Extended configuration board
- WH-8-16  - 16k Static RAM board

Other changes

- Use `address_space_installer` for the h8 memory mapping
- add support for ROM disable line (to support ORG-0 and CP/M)
- Remove PAM37 ROM as an option for 8080 board (only supported on HA-8-6 Z80 board).
- Update handing of `RUN LED` to match real system.
- Fix value returned for unmapped addresses (memory and IO).

