### PR TITLE
imagedev/floppy.cpp: Allow images to be write protected from software list

### DIFF
--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -672,6 +672,11 @@ std::pair<std::error_condition, std::string> floppy_image_device::call_load()
 		m_image.reset();
 		return std::make_pair(image_error::INVALIDIMAGE, "Incompatible image file format or corrupted data");
 	}
+
+	const char *wp = get_feature("write_protected");
+	if(wp && !std::strcmp(wp, "true"))
+		make_readonly();
+
 	m_output_format = is_readonly() ? nullptr : best_format;
 
 	m_image_dirty = false;

--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -656,9 +656,9 @@ std::pair<std::error_condition, std::string> floppy_image_device::call_load()
 	const floppy_image_format_t *best_format = nullptr;
 	for (const floppy_image_format_t *format : m_fif_list) {
 		int score = format->identify(*io, m_form_factor, m_variants);
-		if(score && format->extension_matches(filename()))
+		if (score && format->extension_matches(filename()))
 			score |= floppy_image_format_t::FIFID_EXT;
-		if(score > best) {
+		if (score > best) {
 			best = score;
 			best_format = format;
 		}
@@ -673,8 +673,8 @@ std::pair<std::error_condition, std::string> floppy_image_device::call_load()
 		return std::make_pair(image_error::INVALIDIMAGE, "Incompatible image file format or corrupted data");
 	}
 
-	const char *wp = get_feature("write_protected");
-	if(wp && !std::strcmp(wp, "true"))
+	char const *const wp = get_feature("write_protected");
+	if (wp && !std::strcmp(wp, "true"))
 		make_readonly();
 
 	m_output_format = is_readonly() ? nullptr : best_format;


### PR DESCRIPTION
Since a feature like this seems to be commonly requested, and some of the new software in #14091 demands it, I'm showing how simple it is to implement. The intended usage is:

> `<feature name="write_protected" value="true" />`

to protect one disk image, or

> `<sharedfeat name="write_protected" value="true" />`

to protect all disk images. If other devs want to use a different name or value for this, please comment.