### PR TITLE
bug: gcc-12.3.0 identifies these as uninitialized/maybe-uninitialized

### DIFF
--- a/src/lib/netlist/plib/parray.h
+++ b/src/lib/netlist/plib/parray.h
@@ -163,7 +163,7 @@ namespace plib {
 			if (SIZE2 <= 0)
 			{
 				for (size_type i=0; i < this->size(); i++)
-					(*this)[i] = parray<FT, SIZE2>(size2);
+					(*this)[i] = parray<FT, SIZE2>(size2, static_cast<FT>(0));
 			}
 		}
 

--- a/src/lib/netlist/plib/prandom.h
+++ b/src/lib/netlist/plib/prandom.h
@@ -157,6 +157,7 @@ namespace plib
 	template<typename FT>
 	class normal_distribution_t
 	{
+		std::array<FT, 256> m_buf {};
 	public:
 		normal_distribution_t(FT dev)
 		: m_p(m_buf.size()), m_stddev(dev) { }
@@ -213,7 +214,6 @@ namespace plib
 			m_p = 0;
 		}
 
-		std::array<FT, 256> m_buf;
 		std::size_t m_p;
 		FT m_stddev;
 	};

--- a/src/lib/util/server_http_impl.hpp
+++ b/src/lib/util/server_http_impl.hpp
@@ -94,6 +94,7 @@ namespace webpp {
 		};
 
 		class Request : public webpp::Request {
+			asio::streambuf streambuf;
 			friend class ServerBase<socket_type>;
 			friend class Server<socket_type>;
 		public:
@@ -108,7 +109,6 @@ namespace webpp {
 				}
 				catch(...) {}
 			}
-			asio::streambuf streambuf;
 		};
 
 		class Config {


### PR DESCRIPTION
Three lines to make it compile with g++ 12.3.0 with -Werror=uninitialized and -Werror=maybe-uninitialized (default flags).

