### PR TITLE
diserial.cpp: Avoid updating data frame if nothing changed

### DIFF
--- a/src/emu/diserial.cpp
+++ b/src/emu/diserial.cpp
@@ -154,6 +154,10 @@ void device_serial_interface::set_data_frame(int start_bit_count, int data_bit_c
 {
 	LOGMASKED(LOG_SETUP, "Start bits: %d; Data bits: %d; Parity: %s; Stop bits: %s\n", start_bit_count, data_bit_count, parity_tostring(parity), stop_bits_tostring(stop_bits));
 
+	bool df_changed = (start_bit_count != m_df_start_bit_count) || (data_bit_count != m_df_word_length) || (parity != m_df_parity);
+	u8 orig_stop_bit_count = m_df_stop_bit_count;
+	u8 orig_min_rx_stop_bit_count = m_df_min_rx_stop_bit_count;
+
 	m_df_word_length = data_bit_count;
 
 	switch (stop_bits)
@@ -178,6 +182,15 @@ void device_serial_interface::set_data_frame(int start_bit_count, int data_bit_c
 		m_df_stop_bit_count = 2;
 		m_df_min_rx_stop_bit_count = 1;
 		break;
+	}
+
+	df_changed |= (m_df_stop_bit_count != orig_stop_bit_count) || (m_df_min_rx_stop_bit_count != orig_min_rx_stop_bit_count);
+
+	if (!df_changed)
+	{
+		LOGMASKED(LOG_SETUP, "No change to data frame, skipping\n");
+
+		return;
 	}
 
 	m_df_parity = parity;


### PR DESCRIPTION
Avoid updating the data frame and resetting the receive register. The original change adding the reset of the receive register - https://github.com/mamedev/mame/commit/9070579622081991a899ba5d4fb1b6bb61084f6e cause a regression in the Heathkit H89 emulation, and the CPU and terminal boards (connected by 8250s) were not properly syncing. This caused garbled text.

<img width="905" height="378" alt="Screenshot 2025-08-31 at 3 02 49 PM" src="https://github.com/user-attachments/assets/571e70b1-b81b-4d40-8c8a-b94a13b24d7e" />

Instead of the correct monitor prompt.
<img width="900" height="253" alt="Screenshot 2025-08-31 at 3 03 53 PM" src="https://github.com/user-attachments/assets/63fb18c1-107d-4d5b-a51a-f94f6cd3837e" />

