### PR TITLE
ins8250.cpp: Avoid setting data frame when bit encoding doesn't change

### DIFF
--- a/src/devices/machine/ins8250.cpp
+++ b/src/devices/machine/ins8250.cpp
@@ -301,6 +301,7 @@ void ins8250_uart_device::ins8250_w(offs_t offset, u8 data)
 		case 3:
 			{
 			bool break_state_changed = bool((m_regs.lcr ^ data) & INS8250_LCR_BREAK);
+			bool data_frame_changed = bool((m_regs.lcr ^ data) & 0x3f);
 
 			m_regs.lcr = data;
 
@@ -351,7 +352,10 @@ void ins8250_uart_device::ins8250_w(offs_t offset, u8 data)
 					m_out_tx_cb(new_out_val);
 				}
 			}
-			set_data_frame(1, data_bit_count, parity, stop_bits);
+			if (data_frame_changed)
+			{
+				set_data_frame(1, data_bit_count, parity, stop_bits);
+			}
 			}
 			break;
 		case 4:


### PR DESCRIPTION
Avoid making a call to set the data frame when there is no changes to the number of data bits, stop bits, or parity. This is a followup to https://github.com/mamedev/mame/pull/14105 based on comments from @galibert and @pmackinlay. 