### PR TITLE
scripts/build: add a python script for checking style rules

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -20,11 +20,15 @@ jobs:
       - name: Install reviewdog
         uses: reviewdog/action-setup@v1.3.2
 
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v46.0.5
+
       - name: Run style check
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          files=$(git diff --name-only --diff-filter=d "${{ github.event.base_ref }}~1" "${{ github.event.head_ref }}" | grep -E '\.(c|cpp|h|hpp)$' || true)
+          files=$(echo ${{ steps.changed-files.outputs.all_changed_files }} | grep -E '\.(cpp|h)$' || true)
           if [ -n "$files" ]; then
             python3 scripts/build/style.py $files \
               | reviewdog -efm="%f:%l: %m" \

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -28,12 +28,9 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          files=$(echo ${{ steps.changed-files.outputs.all_changed_files }} | grep -E '\.(cpp|h)$' || true)
-          if [ -n "$files" ]; then
-            python3 scripts/build/style.py $files \
+          python3 scripts/build/style.py ${{ steps.changed-files.outputs.all_changed_files }} \
               | reviewdog -efm="%f:%l: %m" \
                 -name="cpp-style" \
                 -reporter=github-pr-review \
                 -filter-mode=diff_context \
                 -fail-on-error=false
-          fi

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Install reviewdog
         uses: reviewdog/action-setup@v1
@@ -22,7 +24,7 @@ jobs:
 
       - name: Run style check
         run: |
-          files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '\.(c|cpp|h|hpp)$' || true)
+          files=$(git diff --name-only HEAD^1 HEAD | grep -E '\.(c|cpp|h|hpp)$' || true)
           if [ -n "$files" ]; then
             scripts/build/style.py $files \
               | reviewdog -efm="%f:%l: %m" \

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python3 scripts/build/style.py ${{ steps.changed-files.outputs.all_changed_files }} \
+          python3 scripts/build/style.py -f ${{ steps.changed-files.outputs.all_changed_files }} \
               | reviewdog -efm="%f:%l: %m" \
                 -name="stylecheck" \
                 -reporter=github-pr-review \
@@ -35,5 +35,3 @@ jobs:
 
       - name: Make suggestions
         uses: reviewdog/action-suggester@v1.22
-        with:
-          tool_name: python3 scripts/build/style.py python3 scripts/build/style.py -f ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -32,7 +32,7 @@ jobs:
               | reviewdog -efm="%f:%l: %m" \
                 -name="stylecheck" \
                 -reporter=github-pr-review \
-                -filter-mode=diff_context \
+                -filter-mode=nofilter \
                 -fail-on-error=false
 
       - name: Make suggestions

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Install reviewdog
         uses: reviewdog/action-setup@v1.3.2
@@ -24,7 +24,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          files=$(git diff --name-only HEAD^1 HEAD | grep -E '\.(c|cpp|h|hpp)$' || true)
+          files=$(git diff --name-only --diff-filter=d "${{ github.event.base_ref }}~1" "${{ github.event.head_ref }}" | grep -E '\.(c|cpp|h|hpp)$' || true)
           if [ -n "$files" ]; then
             python3 scripts/build/style.py $files \
               | reviewdog -efm="%f:%l: %m" \

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -28,12 +28,10 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python3 scripts/build/style.py -f ${{ steps.changed-files.outputs.all_changed_files }} \
+          python3 scripts/build/style.py ${{ steps.changed-files.outputs.all_changed_files }} \
               | reviewdog -efm="%f:%l: %m" \
                 -name="stylecheck" \
                 -reporter=github-pr-review \
                 -filter-mode=nofilter \
                 -fail-on-error=false
 
-      - name: Make suggestions
-        uses: reviewdog/action-suggester@v1.22

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Install reviewdog
         uses: reviewdog/action-setup@v1.3.2
+        with:
+          reviewdog_version: nightly
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -18,15 +18,15 @@ jobs:
           fetch-depth: 2
 
       - name: Install reviewdog
-        uses: reviewdog/action-setup@v1
-        with:
-          reviewdog_version: latest
+        uses: reviewdog/action-setup@v1.3.2
 
       - name: Run style check
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           files=$(git diff --name-only HEAD^1 HEAD | grep -E '\.(c|cpp|h|hpp)$' || true)
           if [ -n "$files" ]; then
-            scripts/build/style.py $files \
+            python3 scripts/build/style.py $files \
               | reviewdog -efm="%f:%l: %m" \
                 -name="cpp-style" \
                 -reporter=github-pr-review \

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,7 +1,8 @@
 name: Style Check
 
 on:
-    pull_request:
+  pull_request:
+    paths:
     - '.github/workflows/**'
     - 'src/**.cpp'
     - 'src/**.h'

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,28 @@
+name: Style Check
+
+on:
+    pull_request:
+    - '.github/workflows/**'
+    - 'src/**.cpp'
+    - 'src/**.h'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install reviewdog
+        uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
+
+      - name: Run linter
+        run: |
+          # Get changed files in the PR
+          files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '\.(c|cpp|h|hpp)$' || true)
+          if [ -n "$files" ]; then
+            scripts/build/style.py $files | reviewdog -efm="%f:%l: %m" -name="pr-linter" -reporter=github-pr-review -level=error
+          fi

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,14 +8,12 @@ on:
     - 'src/**.h'
 
 jobs:
-  lint:
+  stylecheck:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Install reviewdog
         uses: reviewdog/action-setup@v1.3.2
@@ -30,7 +28,12 @@ jobs:
         run: |
           python3 scripts/build/style.py ${{ steps.changed-files.outputs.all_changed_files }} \
               | reviewdog -efm="%f:%l: %m" \
-                -name="cpp-style" \
+                -name="stylecheck" \
                 -reporter=github-pr-review \
                 -filter-mode=diff_context \
                 -fail-on-error=false
+
+      - name: Make suggestions
+        uses: reviewdog/action-suggester@v1.22
+        with:
+          tool_name: python3 scripts/build/style.py python3 scripts/build/style.py -f ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -19,10 +19,14 @@ jobs:
         with:
           reviewdog_version: latest
 
-      - name: Run linter
+      - name: Run style check
         run: |
-          # Get changed files in the PR
           files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '\.(c|cpp|h|hpp)$' || true)
           if [ -n "$files" ]; then
-            scripts/build/style.py $files | reviewdog -efm="%f:%l: %m" -name="pr-linter" -reporter=github-pr-review -level=error
+            scripts/build/style.py $files \
+              | reviewdog -efm="%f:%l: %m" \
+                -name="cpp-style" \
+                -reporter=github-pr-review \
+                -filter-mode=diff_context \
+                -fail-on-error=false
           fi

--- a/scripts/build/style.py
+++ b/scripts/build/style.py
@@ -32,7 +32,7 @@ def check_cpp_file(path: Path):
 
         comment_pattern = re.compile(r"/\*.*\*/")
         if comment_pattern.search(line.strip()):
-            errors.append((i, "/* Single-line block comments */ are not allowed, use // instead"))
+            errors.append((i, "/* Single-line block comments */ should use // instead"))
 
         macro_pattern = re.compile(r"^\s*#define\s+([A-Za-z0-9_]+)")
         m = macro_pattern.match(line)

--- a/scripts/build/style.py
+++ b/scripts/build/style.py
@@ -45,7 +45,7 @@ def check_file(path: Path, fix: bool = False):
     return errors
 
 def check_cpp_file(path: Path, fix: bool = False):
-    errors = []
+    errors = check_file(path, fix)
     try:
         text = path.read_text()
     except Exception:

--- a/scripts/build/style.py
+++ b/scripts/build/style.py
@@ -40,8 +40,6 @@ def check_file(path: Path, fix: bool = False):
 
     for i, line in enumerate(lines, 1):
         if line.rstrip() != line:
-            if fix:
-                lines[i - 1] = line.rstrip()
             errors.append((i, "Trailing whitespace detected"))
 
     return errors
@@ -137,7 +135,8 @@ def main():
     args = [f for f in sys.argv[1:] if f != "-f"]
 
     cpp_files = {f for f in args if f.endswith(".c") or f.endswith(".cpp")}
-    h_files = {f for f in args if f.endswith(".h") or f.endswith(".hpp") or f.endswith(".hxx")}
+    h_files = {f for f in args if f.endswith(".h") or f.endswith(".hpp") or f.endswith(".hxx") or f.endswith(".ipp")}
+    other_files = {f for f in args if f.endswith(".py") or f.endswith(".lua") or f.endswith(".mm") or f.endswith(".lay") or f.endswith(".lst")}
 
     for file in cpp_files:
         path = Path(file)
@@ -149,6 +148,13 @@ def main():
     for file in h_files:
         path = Path(file)
         errors = check_cpp_file(path, fix=fix)
+
+        for lineno, msg in errors:
+            print(f"{path}:{lineno}: {msg}")
+
+    for file in other_files:
+        path = Path(file)
+        errors = check_file(path, fix=fix)
 
         for lineno, msg in errors:
             print(f"{path}:{lineno}: {msg}")

--- a/scripts/build/style.py
+++ b/scripts/build/style.py
@@ -13,7 +13,7 @@ def is_screaming_snake(name: str):
 def is_snake_case(name: str):
     return re.fullmatch(r"[a-z][a-z0-9_]*(_[a-z0-9]+)*", name) is not None
 
-def check_cpp_file(path: Path, fix: bool = False):
+def check_file(path: Path, fix: bool = False):
     errors = []
     try:
         text = path.read_text()
@@ -26,6 +26,17 @@ def check_cpp_file(path: Path, fix: bool = False):
         if fix:
             path.write_text(text + "\n")
         errors.append((len(lines) or 1, "File should end with a newline"))
+
+    return errors
+
+def check_cpp_file(path: Path, fix: bool = False):
+    errors = []
+    try:
+        text = path.read_text()
+    except Exception:
+        return errors
+
+    lines = text.splitlines()
 
     for i, line in enumerate(lines, 1):
         hex_pattern = re.compile(r"0x[A-F]+")
@@ -63,29 +74,30 @@ def check_cpp_file(path: Path, fix: bool = False):
 
     return errors
 
+def check_block(block, start_line, src_file):
+    if not src_file or src_file not in changed_cpp_files:
+        return []
+    sorted_block = sorted(block, key=lambda s: s.lower())
+    errors_local = []
+    for offset, (expected, actual) in enumerate(zip(sorted_block, block)):
+        if expected != actual:
+            line_no = start_line + offset + 1
+            errors_local.append(
+                (line_no, f"Entry '{actual}' is out of order, expected '{expected}'")
+            )
+    return errors_local
+
 def check_mame_lst(changed_cpp_files: set[str]):
-    errors = []
+    path = Path("src/mame/mame.lst")
+    errors = check_file(path, False)
     try:
-        lines = Path("src/mame/mame.lst").read_text().splitlines()
+        lines = path.read_text().splitlines()
     except Exception:
         return errors
 
     current_block = []
     block_start_line = 0
     current_source = None
-
-    def check_block(block, start_line, src_file):
-        if not src_file or src_file not in changed_cpp_files:
-            return []
-        sorted_block = sorted(block, key=lambda s: s.lower())
-        errors_local = []
-        for offset, (expected, actual) in enumerate(zip(sorted_block, block)):
-            if expected != actual:
-                line_no = start_line + offset + 1
-                errors_local.append(
-                    (line_no, f"Entry '{actual}' is out of order, expected '{expected}'")
-                )
-        return errors_local
 
     for i, line in enumerate(lines):
         if line.startswith("@source:"):
@@ -107,8 +119,8 @@ def main():
     fix = "-f" in sys.argv
     args = [f for f in sys.argv[1:] if f != "-f"]
 
-    cpp_files = {f for f in args if f.endswith(".cpp")}
-    h_files = {f for f in args if f.endswith(".h")}
+    cpp_files = {f for f in args if f.endswith(".c") or f.endswith(".cpp")}
+    h_files = {f for f in args if f.endswith(".h") or f.endswith(".hpp") or f.endswith(".hxx")}
 
     for file in cpp_files:
         path = Path(file)

--- a/scripts/build/style.py
+++ b/scripts/build/style.py
@@ -14,7 +14,7 @@ def check_cpp_file(path: Path):
     try:
         text = path.read_text()
     except Exception:
-        return errors # skip non-text files
+        return errors
 
     lines = text.splitlines()
 
@@ -83,10 +83,8 @@ def check_mame_lst(changed_cpp_files: set[str]):
 
     for i, line in enumerate(lines):
         if line.startswith("@source:"):
-            # clear previous block
             if current_block:
                 errors.extend(check_block(current_block, block_start_line, current_source))
-            # new block
             current_source = "src/mame/" + line[len("@source:"):].strip()
             
             current_block = []
@@ -113,7 +111,7 @@ def main():
     for lineno, msg in errors:
             print(f"src/mame/mame.lst:{lineno}: {msg}")
 
-    sys.exit(0) # needed so workflow doesn't fail
+    sys.exit(0)
 
 if __name__ == "__main__":
     main()

--- a/scripts/build/style.py
+++ b/scripts/build/style.py
@@ -74,7 +74,7 @@ def check_cpp_file(path: Path, fix: bool = False):
 
     return errors
 
-def check_block(block, start_line, src_file):
+def check_block(block, changed_cpp_files, start_line, src_file):
     if not src_file or src_file not in changed_cpp_files:
         return []
     sorted_block = sorted(block, key=lambda s: s.lower())
@@ -102,7 +102,7 @@ def check_mame_lst(changed_cpp_files: set[str]):
     for i, line in enumerate(lines):
         if line.startswith("@source:"):
             if current_block:
-                errors.extend(check_block(current_block, block_start_line, current_source))
+                errors.extend(check_block(current_block, changed_cpp_files, block_start_line, current_source))
             current_source = "src/mame/" + line[len("@source:"):].strip()
             
             current_block = []
@@ -111,7 +111,7 @@ def check_mame_lst(changed_cpp_files: set[str]):
             current_block.append(line.strip())
 
     if current_block:
-        errors.extend(check_block(current_block, block_start_line, current_source))
+        errors.extend(check_block(current_block, changed_cpp_files, block_start_line, current_source))
 
     return errors
 

--- a/scripts/build/style.py
+++ b/scripts/build/style.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import re
+import sys
+from pathlib import Path
+
+def check_file(path: Path):
+    errors = []
+    try:
+        text = path.read_text()
+    except Exception:
+        return errors  # skip non-text files
+
+    # Must end with newline
+    if not text.endswith("\n"):
+        errors.append((len(text.splitlines()) or 1, "File must end with a newline"))
+
+    # Hex literals lowercase
+    hex_pattern = re.compile(r"0x[A-F]+")
+    for i, line in enumerate(text.splitlines(), 1):
+        if hex_pattern.search(line):
+            errors.append((i, "Hex literals must be lowercase"))
+
+    # No single-line C-style comments
+    comment_pattern = re.compile(r"/\*.*\*/")
+    for i, line in enumerate(text.splitlines(), 1):
+        if comment_pattern.search(line):
+            errors.append((i, "Single-line block comments (/* ... */) are not allowed"))
+
+    return errors
+
+def main():
+    failed = False
+    for file in sys.argv[1:]:
+        path = Path(file)
+        for lineno, msg in check_file(path):
+            print(f"{path}:{lineno}: {msg}")
+            failed = True
+    sys.exit(1 if failed else 0)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build/style.py
+++ b/scripts/build/style.py
@@ -3,39 +3,117 @@ import re
 import sys
 from pathlib import Path
 
-def check_file(path: Path):
+def is_screaming_snake(name: str):
+    return re.fullmatch(r"[A-Z][A-Z0-9_]*", name) is not None
+
+def is_snake_case(name: str):
+    return re.fullmatch(r"[a-z][a-z0-9_]*(_[a-z0-9]+)*", name) is not None
+
+def check_cpp_file(path: Path):
     errors = []
     try:
         text = path.read_text()
     except Exception:
         return errors  # skip non-text files
 
-    # Must end with newline
+    lines = text.splitlines()
+
     if not text.endswith("\n"):
-        errors.append((len(text.splitlines()) or 1, "File must end with a newline"))
+        errors.append((len(lines) or 1, "File should end with a newline"))
 
-    # Hex literals lowercase
-    hex_pattern = re.compile(r"0x[A-F]+")
-    for i, line in enumerate(text.splitlines(), 1):
+    for i, line in enumerate(lines, 1):
+        hex_pattern = re.compile(r"0x[A-F]+")
         if hex_pattern.search(line):
-            errors.append((i, "Hex literals must be lowercase"))
+            errors.append((i, "Hex literals should be lowercase (0x1a not 0x1A)"))
 
-    # No single-line C-style comments
-    comment_pattern = re.compile(r"/\*.*\*/")
-    for i, line in enumerate(text.splitlines(), 1):
-        if comment_pattern.search(line):
-            errors.append((i, "Single-line block comments (/* ... */) are not allowed"))
+        comment_pattern = re.compile(r"/\*.*\*/")
+        if comment_pattern.search(line.strip()):
+            errors.append((i, "/* Single-line block comments */ are not allowed, use // instead"))
+
+        macro_pattern = re.compile(r"^\s*#define\s+([A-Za-z0-9_]+)")
+        m = macro_pattern.match(line)
+        if m and not is_screaming_snake(m.group(1)):
+            errors.append((i, f"Macro '{m.group(1)}' should use SCREAMING_SNAKE_CASE"))
+
+        const_pattern = re.compile(r"\bconst\b[^;=()]*\b([A-Za-z_][A-Za-z0-9_]*)\b\s*(?:=|;)")
+        c = const_pattern.search(line)
+        if c and not is_screaming_snake(c.group(1)):
+            errors.append((i, f"Constant '{c.group(1)}' should use SCREAMING_SNAKE_CASE"))
+
+        function_pattern = re.compile(r"\b([a-z][a-z0-9_]*)\s*\(")
+        f = function_pattern.search(line)
+        if f and not is_snake_case(f.group(1)):
+            errors.append((i, f"Function '{f.group(1)}' should use snake_case"))
+
+        class_pattern = re.compile(r"\bclass\s+([A-Za-z0-9_]+)")
+        cl = class_pattern.search(line)
+        if cl and not is_snake_case(cl.group(1)):
+            errors.append((i, f"Class '{cl.group(1)}' should use snake_case"))
+
+        enum_pattern = re.compile(r"\benum\s+(class\s+)?([A-Za-z0-9_]+)")
+        en = enum_pattern.search(line)
+        if en and not is_snake_case(en.group(2)):
+            errors.append((i, f"Enum '{en.group(2)}' should use snake_case"))
+
+    return errors
+
+def check_mame_lst(changed_cpp_files: set[str]):
+    errors = []
+    try:
+        lines = Path("src/mame/mame.lst").read_text().splitlines()
+    except Exception:
+        return errors
+
+    current_block = []
+    block_start_line = 0
+    current_source = None
+
+    def check_block(block, start_line, src_file):
+        if not src_file or src_file not in changed_cpp_files:
+            return []
+        sorted_block = sorted(block, key=lambda s: s.lower())
+        errors_local = []
+        for offset, (expected, actual) in enumerate(zip(sorted_block, block)):
+            if expected != actual:
+                line_no = start_line + offset + 1
+                errors_local.append(
+                    (line_no, f"Entry '{actual}' is out of order, expected '{expected}'")
+                )
+        return errors_local
+
+    for i, line in enumerate(lines):
+        if line.startswith("@source:"):
+            # clear previous block
+            if current_block:
+                errors.extend(check_block(current_block, block_start_line, current_source))
+            # new block
+            current_source = "src/mame/" + line[len("@source:"):].strip()
+            
+            current_block = []
+            block_start_line = i + 1
+        elif line.strip():
+            current_block.append(line.strip())
+
+    if current_block:
+        errors.extend(check_block(current_block, block_start_line, current_source))
 
     return errors
 
 def main():
-    failed = False
+    cpp_files = {f for f in sys.argv[1:] if f.endswith(".cpp")}
+
     for file in sys.argv[1:]:
         path = Path(file)
-        for lineno, msg in check_file(path):
+        errors = check_cpp_file(path)
+
+        for lineno, msg in errors:
             print(f"{path}:{lineno}: {msg}")
-            failed = True
-    sys.exit(1 if failed else 0)
+
+    errors = check_mame_lst(cpp_files)
+    for lineno, msg in errors:
+            print(f"src/mame/mame.lst:{lineno}: {msg}")
+
+    sys.exit(0) # needed so workflow doesn't fail
 
 if __name__ == "__main__":
     main()

--- a/scripts/build/style.py
+++ b/scripts/build/style.py
@@ -13,7 +13,7 @@ def is_screaming_snake(name: str):
 def is_snake_case(name: str):
     return re.fullmatch(r"[a-z][a-z0-9_]*(_[a-z0-9]+)*", name) is not None
 
-def check_cpp_file(path: Path):
+def check_cpp_file(path: Path, fix: bool = False):
     errors = []
     try:
         text = path.read_text()
@@ -23,6 +23,8 @@ def check_cpp_file(path: Path):
     lines = text.splitlines()
 
     if not text.endswith("\n"):
+        if fix:
+            path.write_text(text + "\n")
         errors.append((len(lines) or 1, "File should end with a newline"))
 
     for i, line in enumerate(lines, 1):
@@ -102,19 +104,22 @@ def check_mame_lst(changed_cpp_files: set[str]):
     return errors
 
 def main():
-    cpp_files = {f for f in sys.argv[1:] if f.endswith(".cpp")}
-    h_files = {f for f in sys.argv[1:] if f.endswith(".h")}
+    fix = "-f" in sys.argv
+    args = [f for f in sys.argv[1:] if f != "-f"]
+
+    cpp_files = {f for f in args if f.endswith(".cpp")}
+    h_files = {f for f in args if f.endswith(".h")}
 
     for file in cpp_files:
         path = Path(file)
-        errors = check_cpp_file(path)
+        errors = check_cpp_file(path, fix=fix)
 
         for lineno, msg in errors:
             print(f"{path}:{lineno}: {msg}")
 
     for file in h_files:
         path = Path(file)
-        errors = check_cpp_file(path)
+        errors = check_cpp_file(path, fix=fix)
 
         for lineno, msg in errors:
             print(f"{path}:{lineno}: {msg}")

--- a/scripts/build/style.py
+++ b/scripts/build/style.py
@@ -16,9 +16,20 @@ def is_snake_case(name: str):
 def check_file(path: Path, fix: bool = False):
     errors = []
     try:
-        text = path.read_text()
+        raw_bytes = path.read_bytes()
+        try:
+            text = raw_bytes.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as e:
+            errors.append((1, f"Invalid UTF-8 sequence at byte {e.start}-{e.end}"))
+            return errors
     except Exception:
         return errors
+
+    # Detect non-native line endings
+    if sys.platform != "win32" and b"\r\n" in raw_bytes:
+        errors.append((1, "File contains Windows (CRLF) line endings on a non-Windows system"))
+    elif sys.platform == "win32" and b"\n" in raw_bytes and b"\r\n" not in raw_bytes:
+        errors.append((1, "File contains Unix (LF) line endings on Windows"))
 
     lines = text.splitlines()
 
@@ -26,6 +37,12 @@ def check_file(path: Path, fix: bool = False):
         if fix:
             path.write_text(text + "\n")
         errors.append((len(lines) or 1, "File should end with a newline"))
+
+    for i, line in enumerate(lines, 1):
+        if line.rstrip() != line:
+            if fix:
+                lines[i - 1] = line.rstrip()
+            errors.append((i, "Trailing whitespace detected"))
 
     return errors
 

--- a/scripts/build/style.py
+++ b/scripts/build/style.py
@@ -74,7 +74,7 @@ def check_cpp_file(path: Path, fix: bool = False):
 
     return errors
 
-def check_block(block, changed_cpp_files, start_line, src_file):
+def check_lst_block(block, changed_cpp_files, start_line, src_file):
     if not src_file or src_file not in changed_cpp_files:
         return []
     sorted_block = sorted(block, key=lambda s: s.lower())
@@ -102,7 +102,7 @@ def check_mame_lst(changed_cpp_files: set[str]):
     for i, line in enumerate(lines):
         if line.startswith("@source:"):
             if current_block:
-                errors.extend(check_block(current_block, changed_cpp_files, block_start_line, current_source))
+                errors.extend(check_lst_block(current_block, changed_cpp_files, block_start_line, current_source))
             current_source = "src/mame/" + line[len("@source:"):].strip()
             
             current_block = []
@@ -111,7 +111,7 @@ def check_mame_lst(changed_cpp_files: set[str]):
             current_block.append(line.strip())
 
     if current_block:
-        errors.extend(check_block(current_block, changed_cpp_files, block_start_line, current_source))
+        errors.extend(check_lst_block(current_block, changed_cpp_files, block_start_line, current_source))
 
     return errors
 

--- a/scripts/build/style.py
+++ b/scripts/build/style.py
@@ -103,8 +103,16 @@ def check_mame_lst(changed_cpp_files: set[str]):
 
 def main():
     cpp_files = {f for f in sys.argv[1:] if f.endswith(".cpp")}
+    h_files = {f for f in sys.argv[1:] if f.endswith(".h")}
 
-    for file in sys.argv[1:]:
+    for file in cpp_files:
+        path = Path(file)
+        errors = check_cpp_file(path)
+
+        for lineno, msg in errors:
+            print(f"{path}:{lineno}: {msg}")
+
+    for file in h_files:
         path = Path(file)
         errors = check_cpp_file(path)
 

--- a/scripts/build/style.py
+++ b/scripts/build/style.py
@@ -14,7 +14,7 @@ def check_cpp_file(path: Path):
     try:
         text = path.read_text()
     except Exception:
-        return errors  # skip non-text files
+        return errors # skip non-text files
 
     lines = text.splitlines()
 

--- a/scripts/build/style.py
+++ b/scripts/build/style.py
@@ -25,7 +25,6 @@ def check_file(path: Path, fix: bool = False):
     except Exception:
         return errors
 
-    # Detect non-native line endings
     if sys.platform != "win32" and b"\r\n" in raw_bytes:
         errors.append((1, "File contains Windows (CRLF) line endings on a non-Windows system"))
     elif sys.platform == "win32" and b"\n" in raw_bytes and b"\r\n" not in raw_bytes:
@@ -40,7 +39,7 @@ def check_file(path: Path, fix: bool = False):
 
     for i, line in enumerate(lines, 1):
         if line.rstrip() != line:
-            errors.append((i, "Trailing whitespace detected"))
+            errors.append((i, "Lines should not have trailing whitespaces"))
 
     return errors
 

--- a/scripts/build/style.py
+++ b/scripts/build/style.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+##
+## license:BSD-3-Clause
+## copyright-holders:stonedDiscord
+
 import re
 import sys
 from pathlib import Path


### PR DESCRIPTION
I realize this is in direct competition with #14107, I started work on this on saturday when I posted the question if this could be automated in the Discord server.

The action will post code reviews, much like a human reviwer would.
An example can be seen here: https://github.com/stonedDiscord/mame/pull/5

I went through https://docs.mamedev.org/contributing/cxx.html to come up with these rules.
It will detect
- Missing newline at EOF
- Invalid UTF-8
- Wrong type of line ending
- Trailing whitespaces
- Uppercase hex literals
- Single line block comments
- Lowercase constants
- Uppercase functions
- Uppercase class names
- Uppercase Enum names

It mostly uses regex to detect those, I haven't run into any false positives yet, but I'm on the fence about dropping the constants check because it will complain about variables that someone has marked const.