### PR TITLE
bus/megadrive/titan.cpp, bus/megadrive/rom.cpp: Add notes for mapper chip

### DIFF
--- a/src/devices/bus/megadrive/rom.cpp
+++ b/src/devices/bus/megadrive/rom.cpp
@@ -546,7 +546,7 @@ uint16_t md_rom_fram_device::read_a13(offs_t offset)
 }
 
 /*-------------------------------------------------
- SUPER STREET FIGHTER 2
+ SUPER STREET FIGHTER 2 (with 315-5709/315-5779)
  -------------------------------------------------*/
 
 uint16_t md_rom_ssf2_device::read(offs_t offset)
@@ -573,6 +573,14 @@ void md_rom_ssf2_device::write_a13(offs_t offset, uint16_t data)
 				m_bank[offset] = data & 0xf;
 				memcpy(ROM + offset * 0x080000/2, ROM + 0x400000/2 + (m_bank[offset] * 0x080000)/2, 0x080000);
 			}
+			/*
+			else
+			{
+				D0: Determine upper half (0x200000 onward) of ROM space: Backup RAM(1) or ROM(0)
+				D1: Backup RAM Write protect
+				(No official licensed software used these features)
+			}
+			*/
 		}
 	}
 }

--- a/src/devices/bus/megadrive/titan.cpp
+++ b/src/devices/bus/megadrive/titan.cpp
@@ -6,6 +6,8 @@ Titan Overdrive 2 mapper
 
 https://plutiedev.com/beyond-4mb
 
+- Bankswitching controlled by SEGA 315-5709/315-5779 mapper or compatible hardwares
+
 TODO:
 - This is same as SSF2 mapper, merge at cart slot rewrite;
 
@@ -62,6 +64,14 @@ void md_rom_titan_device::write_a13(offs_t offset, uint16_t data)
 			// D7-D6 unconnected, sgdk_bap (and likely others) cares about D4
 			m_bank[offset] = data & 0x3f;
 		}
+		/*
+		else
+		{
+			D0: Determine upper half (0x200000 onward) of ROM space: Backup RAM(1) or ROM(0)
+			D1: Backup RAM Write protect
+			(No official licensed software used these features)
+		}
+		*/
 	}
 }
 


### PR DESCRIPTION
In Mega drive/Genesis Super Street Fighter 2 Cartridge, Sega 315-5709/315-5779 controls bankswitching and determines upper half of ROM space (Backup RAM or ROM).

Titan Overdrive 2 requires compatible mapper hardware as above, but ROM space is forced to ROM?

Reference (for mapper chip): https://segaretro.org/images/7/78/IC_BD_16M_42PIN_x_4_EPROM_32X_RD_User%27s_Manual.pdf