### PR TITLE
dinetwork: packet logging helper

### DIFF
--- a/src/devices/machine/am79c90.cpp
+++ b/src/devices/machine/am79c90.cpp
@@ -190,7 +190,8 @@ int am7990_device_base::receive(u8 *buf, int length)
 		return -1;
 
 	LOGMASKED(LOG_RXTX, "receive packet length %d\n", length);
-	dump_bytes(buf, length);
+	if (VERBOSE & LOG_PACKETS)
+		log_bytes(buf, length);
 
 	// check we have a buffer
 	u32 ring_address = (m_rx_ring_base + (m_rx_ring_pos << 3)) & RING_ADDR_MASK;
@@ -452,7 +453,8 @@ void am7990_device_base::transmit()
 	}
 
 	LOGMASKED(LOG_RXTX, "transmit sending packet length %d\n", length);
-	dump_bytes(buf, length);
+	if (VERBOSE & LOG_PACKETS)
+		log_bytes(buf, length);
 
 	// handle loopback
 	if (m_mode & MODE_LOOP)
@@ -822,22 +824,6 @@ void am7990_device_base::dma_out(u32 address, u8 *buf, int length)
 		buf++;
 		address++;
 		length--;
-	}
-}
-
-void am7990_device_base::dump_bytes(u8 *buf, int length)
-{
-	if (VERBOSE & LOG_PACKETS)
-	{
-		// pad with zeros to 8-byte boundary
-		for (int i = 0; i < 8 - (length % 8); i++)
-			buf[length + i] = 0;
-
-		// dump length / 8 (rounded up) groups of 8 bytes
-		for (int i = 0; i < (length + 7) / 8; i++)
-			LOGMASKED(LOG_PACKETS, "%02x %02x %02x %02x %02x %02x %02x %02x\n",
-				buf[i * 8 + 0], buf[i * 8 + 1], buf[i * 8 + 2], buf[i * 8 + 3],
-				buf[i * 8 + 4], buf[i * 8 + 5], buf[i * 8 + 6], buf[i * 8 + 7]);
 	}
 }
 

--- a/src/devices/machine/am79c90.h
+++ b/src/devices/machine/am79c90.h
@@ -43,7 +43,6 @@ protected:
 
 	void dma_in(u32 address, u8 *buf, int length);
 	void dma_out(u32 address, u8 *buf, int length);
-	void dump_bytes(u8 *buf, int length);
 
 	virtual int get_buf_length(u16 data) const = 0;
 

--- a/src/devices/machine/dp83932c.cpp
+++ b/src/devices/machine/dp83932c.cpp
@@ -149,7 +149,8 @@ int dp83932c_device::recv_start_cb(u8 *buf, int length)
 	if (m_reg[RCR] & RCR_LB)
 		m_reg[RCR] |= RCR_LBK;
 
-	dump_bytes(buf, length);
+	if (VERBOSE & LOG_PACKETS)
+		log_bytes(buf, length);
 
 	// save rba pointer registers
 	m_reg[TRBA0] = m_reg[CRBA0];
@@ -411,7 +412,8 @@ void dp83932c_device::transmit()
 	LOG("transmit length %d word %d tda 0x%08x\n", length, word, EA(m_reg[UTDA], m_reg[CTDA]));
 
 	// transmit data
-	dump_bytes(buf, length);
+	if (VERBOSE & LOG_PACKETS)
+		log_bytes(buf, length);
 	send(buf, length, 4);
 }
 
@@ -573,22 +575,6 @@ bool dp83932c_device::address_filter(u8 *buf)
 	}
 
 	return false;
-}
-
-void dp83932c_device::dump_bytes(u8 *buf, int length)
-{
-	if (VERBOSE & LOG_PACKETS)
-	{
-		// pad with zeros to 8-byte boundary
-		for (int i = 0; i < 8 - (length % 8); i++)
-			buf[length + i] = 0;
-
-		// dump length / 8 (rounded up) groups of 8 bytes
-		for (int i = 0; i < (length + 7) / 8; i++)
-			LOGMASKED(LOG_PACKETS, "%02x %02x %02x %02x %02x %02x %02x %02x\n",
-				buf[i * 8 + 0], buf[i * 8 + 1], buf[i * 8 + 2], buf[i * 8 + 3],
-				buf[i * 8 + 4], buf[i * 8 + 5], buf[i * 8 + 6], buf[i * 8 + 7]);
-	}
 }
 
 u16 dp83932c_device::read_bus_word(offs_t address)

--- a/src/devices/machine/dp83932c.h
+++ b/src/devices/machine/dp83932c.h
@@ -42,9 +42,6 @@ protected:
 	void update_interrupts();
 	bool address_filter(u8 *buf);
 
-	// diagnostic helper
-	void dump_bytes(u8 *buf, int length);
-
 	enum registers : unsigned
 	{
 		CR    = 0x00, // command

--- a/src/devices/machine/edlc.cpp
+++ b/src/devices/machine/edlc.cpp
@@ -97,7 +97,8 @@ int seeq8003_device::recv_start_cb(u8 *buf, int length)
 	if (address_filter(buf))
 	{
 		LOG("receiving frame length %d\n", length);
-		dump_bytes(buf, length);
+		if (VERBOSE & LOG_FRAMES)
+			log_bytes(buf, length);
 
 		return receive(buf, length);
 	}
@@ -280,7 +281,8 @@ void seeq8003_device::transmit(s32 param)
 		}
 
 		LOG("transmitting frame length %d\n", length);
-		dump_bytes(buf, length);
+		if (VERBOSE & LOG_FRAMES)
+			log_bytes(buf, length);
 
 		// transmit the frame
 		send(buf, length, 4);
@@ -618,20 +620,4 @@ bool seeq80c03_device::address_filter(u8 *address)
 	}
 
 	return false;
-}
-
-void seeq8003_device::dump_bytes(u8 *buf, int length)
-{
-	if (VERBOSE & LOG_FRAMES)
-	{
-		// pad frame with zeros to 8-byte boundary
-		for (int i = 0; i < 8 - (length % 8); i++)
-			buf[length + i] = 0;
-
-		// dump length / 8 (rounded up) groups of 8 bytes
-		for (int i = 0; i < (length + 7) / 8; i++)
-			LOGMASKED(LOG_FRAMES, "%02x %02x %02x %02x %02x %02x %02x %02x\n",
-				buf[i * 8 + 0], buf[i * 8 + 1], buf[i * 8 + 2], buf[i * 8 + 3],
-				buf[i * 8 + 4], buf[i * 8 + 5], buf[i * 8 + 6], buf[i * 8 + 7]);
-	}
 }

--- a/src/devices/machine/edlc.h
+++ b/src/devices/machine/edlc.h
@@ -60,7 +60,6 @@ protected:
 	int receive(u8 *buf, int length);
 	void interrupt(s32 param = 0);
 	virtual bool address_filter(u8 *address);
-	void dump_bytes(u8 *buf, int length);
 
 	// 80c03 option helpers
 	virtual bool mode_tx_pad() const { return false; }

--- a/src/devices/machine/i82586.cpp
+++ b/src/devices/machine/i82586.cpp
@@ -268,7 +268,8 @@ int i82586_base_device::recv_start(u8 *buf, int length)
 	if (address_filter(buf))
 	{
 		LOG("recv_start receiving frame length %d\n", length);
-		dump_bytes(buf, length);
+		if (VERBOSE & LOG_FRAMES)
+			log_bytes(buf, length);
 
 		return ru_execute(buf, length);
 	}
@@ -754,22 +755,6 @@ int i82586_base_device::store_bytes(u32 dst, u8 *buf, int length)
 	return offset;
 }
 
-void i82586_base_device::dump_bytes(u8 *buf, int length)
-{
-	if (VERBOSE & LOG_FRAMES)
-	{
-		// pad frame with zeros to 8-byte boundary
-		for (int i = 0; i < 8 - (length % 8); i++)
-			buf[length + i] = 0;
-
-		// dump length / 8 (rounded up) groups of 8 bytes
-		for (int i = 0; i < (length + 7) / 8; i++)
-			LOGMASKED(LOG_FRAMES, "%02x %02x %02x %02x %02x %02x %02x %02x\n",
-				buf[i * 8 + 0], buf[i * 8 + 1], buf[i * 8 + 2], buf[i * 8 + 3],
-				buf[i * 8 + 4], buf[i * 8 + 5], buf[i * 8 + 6], buf[i * 8 + 7]);
-	}
-}
-
 // 82586 implementation
 void i82586_device::device_start()
 {
@@ -1020,7 +1005,8 @@ bool i82586_device::cu_transmit(u32 command)
 	else
 	{
 		LOG("cu_transmit sending frame length %d\n", length);
-		dump_bytes(buf, length);
+		if (VERBOSE & LOG_FRAMES)
+			log_bytes(buf, length);
 
 		return send(buf, length, 4) == length;
 	}
@@ -1680,7 +1666,8 @@ bool i82596_device::cu_transmit(u32 command)
 	else
 	{
 		LOG("cu_transmit sending frame length %d\n", length);
-		dump_bytes(buf, length);
+		if (VERBOSE & LOG_FRAMES)
+			log_bytes(buf, length);
 
 		return send(buf, length) == length;
 	}

--- a/src/devices/machine/i82586.h
+++ b/src/devices/machine/i82586.h
@@ -205,7 +205,6 @@ protected:
 	static u64 address_hash(u8 *buf, int length);
 	int fetch_bytes(u8 *buf, u32 src, int length);
 	int store_bytes(u32 dst, u8 *buf, int length);
-	void dump_bytes(u8 *buf, int length);
 
 	// device_* members
 	const address_space_config m_space_config;

--- a/src/emu/dinetwork.cpp
+++ b/src/emu/dinetwork.cpp
@@ -172,3 +172,18 @@ void device_network_interface::set_loopback(bool loopback)
 			start_net_device();
 	}
 }
+
+void device_network_interface::log_bytes(u8 *buf, int len)
+{
+	static const char *const frame_fmt = "%02x %02x %02x %02x %02x %02x %02x %02x\n";
+
+	for (int i = 0; i < len / 8; i++)
+		device().logerror(frame_fmt,
+			buf[i * 8 + 0], buf[i * 8 + 1], buf[i * 8 + 2], buf[i * 8 + 3],
+			buf[i * 8 + 4], buf[i * 8 + 5], buf[i * 8 + 6], buf[i * 8 + 7]);
+
+	if (int const tail = len % 8)
+		device().logerror(&frame_fmt[tail * 5],
+			buf[len - tail + 0], buf[len - tail + 1], buf[len - tail + 2], buf[len - tail + 3],
+			buf[len - tail + 4], buf[len - tail + 5], buf[len - tail + 6], buf[len - tail + 7]);
+}

--- a/src/emu/dinetwork.h
+++ b/src/emu/dinetwork.h
@@ -33,6 +33,7 @@ public:
 
 protected:
 	bool has_net_device() const noexcept { return bool(m_dev); }
+	void log_bytes(u8 *buf, int len);
 
 	// bandwidth in bytes per second
 	u32 m_bandwidth;


### PR DESCRIPTION
I propose adding a logging helper function to `device_network_interface` which is useful for tracing received and transmitted packet data. The implementation could be enhanced (e.g., allowing different numbers of bytes logged per line), but I think this is a reasonable start.

I've included the changes to various network devices which currently have their own implementations of this code, showing how it could easily produce some reuse benefits.