### PR TITLE
Add toggle hotkey to autofire plugin

### DIFF
--- a/docs/source/plugins/autofire.rst
+++ b/docs/source/plugins/autofire.rst
@@ -62,6 +62,16 @@ may need higher numbers than 1 for the system to recognise the button being
 released and pressed again (e.g. 2 on frames and 2 off frames works for Alcon).
 Experiment with different values to get the best effect.
 
+Select **Toggle hotkey** to set a control to enable/disable autofire on the
+button.  This is optional, and may be skipped if not needed.  Press the UI Clear
+key or select the **Unset toggle hotkey** menu item (which appears when the
+toggle hotkey is set) to remove the hotkey.  When the toggle hotkey is set,
+pressing it turns off autofire on the button, making it behave like a
+non-autofire button (holding the hotkey keeps the button pressed).  Pressing the
+toggle hotkey again turns autofire back on.  This is useful if you want to
+switch between autofire and non-autofire behavior without having separate
+buttons for the two.
+
 When adding a new autofire button, there is a **Cancel** option that changes to
 **Create** after you set the input and hotkey.  Select **Create** to finish
 creating the autofire button and return to the list of autofire buttons.  The
@@ -112,4 +122,5 @@ levels will only produce a single beam, greatly reducing the weapon’s
 effectiveness.  The fire button must be held down to produce all beams.  Some
 shooting games (e.g. Raiden Fighters) require the primary fire button to be held
 down for a charged special attack.  This means it’s often necessary to have a
-non-autofire input for the primary fire button assigned to play effectively.
+non-autofire input for the primary fire button assigned to play effectively, or
+a toggle hotkey assigned to switch between autofire and non-autofire.

--- a/plugins/autofire/autofire_save.lua
+++ b/plugins/autofire/autofire_save.lua
@@ -19,7 +19,10 @@ local function initialize_button(settings)
 			key_cfg = settings.key,
 			on_frames = settings.on_frames,
 			off_frames = settings.off_frames,
-			counter = 0
+			counter = 0,
+			enabled = true,
+			toggle_key = settings.toggle_key and manager.machine.input:seq_from_tokens(settings.toggle_key),
+			toggle_key_cfg = settings.toggle_key
 		}
 		local port = ioport.ports[settings.port]
 		if port then
@@ -42,7 +45,8 @@ local function serialize_settings(button_list)
 			type = manager.machine.ioport:input_type_to_token(button.type),
 			key = button.key_cfg,
 			on_frames = button.on_frames,
-			off_frames = button.off_frames
+			off_frames = button.off_frames,
+			toggle_key = button.toggle_key_cfg
 		}
 		table.insert(settings, setting)
 	end

--- a/plugins/autofire/plugin.json
+++ b/plugins/autofire/plugin.json
@@ -2,7 +2,7 @@
 	"plugin": {
 		"name": "autofire",
 		"description": "Autofire plugin",
-		"version": "0.0.4",
+		"version": "0.0.5",
 		"author": "Jack Li",
 		"type": "plugin",
 		"start": "false"


### PR DESCRIPTION
I added an optional toggle hotkey for the autofire plugin that turns autofire on/off for a button. This is useful for games where you want to have both autofire and non-autofire but don't want different buttons for the two. For example, in Fire Shark the blue and green weapons benefit from autofire, but the red weapon breaks with autofire. The toggle hotkey lets you turn off autofire when using the red weapon without having to switch to a different fire button.