### PR TITLE
flopimg.cpp: add a default implementation for `supports_save`

### DIFF
--- a/src/lib/formats/86f_dsk.cpp
+++ b/src/lib/formats/86f_dsk.cpp
@@ -74,11 +74,6 @@ const char *_86f_format::extensions() const noexcept
 	return "86f";
 }
 
-bool _86f_format::supports_save() const noexcept
-{
-	return false;
-}
-
 int _86f_format::identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const
 {
 	uint8_t header[4];

--- a/src/lib/formats/86f_dsk.h
+++ b/src/lib/formats/86f_dsk.h
@@ -21,12 +21,10 @@ public:
 
 	virtual int identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const override;
 	virtual bool load(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants, floppy_image &image) const override;
-	//virtual bool save(util::random_read_write &io, const std::vector<uint32_t> &variants, const floppy_image &image) const override;
 
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 
 private:
 	void generate_track_from_bitstream_with_weak(int track, int head, const uint8_t *trackbuf, const uint8_t *weak, int index_cell, int track_size, floppy_image &image) const;

--- a/src/lib/formats/acorn_dsk.cpp
+++ b/src/lib/formats/acorn_dsk.cpp
@@ -650,11 +650,6 @@ const char *opus_ddcpm_format::extensions() const noexcept
 	return "ssd";
 }
 
-bool opus_ddcpm_format::supports_save() const noexcept
-{
-	return false;
-}
-
 int opus_ddcpm_format::identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const
 {
 	uint8_t h[8];
@@ -718,11 +713,6 @@ bool opus_ddcpm_format::load(util::random_read &io, uint32_t form_factor, const 
 	}
 
 	return true;
-}
-
-bool opus_ddcpm_format::save(util::random_read_write &io, const std::vector<uint32_t> &variants, const floppy_image &image) const
-{
-	return false;
 }
 
 

--- a/src/lib/formats/acorn_dsk.h
+++ b/src/lib/formats/acorn_dsk.h
@@ -125,12 +125,10 @@ public:
 
 	virtual int identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const override;
 	virtual bool load(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants, floppy_image &image) const override;
-	virtual bool save(util::random_read_write &io, const std::vector<uint32_t> &variants, const floppy_image &image) const override;
 
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 };
 
 

--- a/src/lib/formats/ap2_dsk.cpp
+++ b/src/lib/formats/ap2_dsk.cpp
@@ -133,11 +133,6 @@ const char *a2_13sect_format::extensions() const noexcept
 	return "d13";
 }
 
-bool a2_13sect_format::supports_save() const noexcept
-{
-	return false;
-}
-
 const a2_13sect_format FLOPPY_A213S_FORMAT;
 
 static const uint8_t translate6[0x40] =
@@ -1154,11 +1149,6 @@ const char *a2_edd_format::extensions() const noexcept
 	return "edd";
 }
 
-bool a2_edd_format::supports_save() const noexcept
-{
-	return false;
-}
-
 int a2_edd_format::identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const
 {
 	uint64_t size;
@@ -1274,11 +1264,6 @@ const char *a2_nib_format::description() const noexcept
 const char *a2_nib_format::extensions() const noexcept
 {
 	return "nib";
-}
-
-bool a2_nib_format::supports_save() const noexcept
-{
-	return false;
 }
 
 int a2_nib_format::identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const

--- a/src/lib/formats/ap2_dsk.h
+++ b/src/lib/formats/ap2_dsk.h
@@ -37,7 +37,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 
 private:
 	static uint8_t gb(const std::vector<bool> &buf, int &pos, int &wrap);
@@ -113,7 +112,6 @@ public:
 
 	virtual int identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const override;
 	virtual bool load(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants, floppy_image &image) const override;
-	virtual bool supports_save() const noexcept override;
 
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
@@ -132,7 +130,6 @@ public:
 
 	virtual int identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const override;
 	virtual bool load(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants, floppy_image &image) const override;
-	virtual bool supports_save() const noexcept override;
 
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;

--- a/src/lib/formats/apd_dsk.cpp
+++ b/src/lib/formats/apd_dsk.cpp
@@ -208,9 +208,4 @@ bool apd_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	return true;
 }
 
-bool apd_format::supports_save() const noexcept
-{
-	return false;
-}
-
 const apd_format FLOPPY_APD_FORMAT;

--- a/src/lib/formats/apd_dsk.h
+++ b/src/lib/formats/apd_dsk.h
@@ -25,7 +25,6 @@ public:
 
 	virtual int identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const override;
 	virtual bool load(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants, floppy_image &image) const override;
-	virtual bool supports_save() const noexcept override;
 };
 
 extern const apd_format FLOPPY_APD_FORMAT;

--- a/src/lib/formats/apridisk.cpp
+++ b/src/lib/formats/apridisk.cpp
@@ -148,9 +148,4 @@ bool apridisk_format::load(util::random_read &io, uint32_t form_factor, const st
 	return true;
 }
 
-bool apridisk_format::supports_save() const noexcept
-{
-	return false;
-}
-
 const apridisk_format FLOPPY_APRIDISK_FORMAT;

--- a/src/lib/formats/apridisk.h
+++ b/src/lib/formats/apridisk.h
@@ -25,7 +25,6 @@ public:
 
 	virtual int identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const override;
 	virtual bool load(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants, floppy_image &image) const override;
-	virtual bool supports_save() const noexcept override;
 
 private:
 	static const int APR_HEADER_SIZE = 128;

--- a/src/lib/formats/ccvf_dsk.cpp
+++ b/src/lib/formats/ccvf_dsk.cpp
@@ -153,9 +153,4 @@ bool ccvf_format::load(util::random_read &io, uint32_t form_factor, const std::v
 	return true;
 }
 
-bool ccvf_format::supports_save() const noexcept
-{
-	return false;
-}
-
 const ccvf_format FLOPPY_CCVF_FORMAT;

--- a/src/lib/formats/ccvf_dsk.h
+++ b/src/lib/formats/ccvf_dsk.h
@@ -41,7 +41,6 @@ public:
 
 	virtual int identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const override;
 	virtual bool load(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants, floppy_image &image) const override;
-	virtual bool supports_save() const noexcept override;
 
 protected:
 	const format *formats;

--- a/src/lib/formats/cqm_dsk.cpp
+++ b/src/lib/formats/cqm_dsk.cpp
@@ -368,14 +368,4 @@ bool cqm_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	return true;
 }
 
-bool cqm_format::save(util::random_read_write &io, const std::vector<uint32_t> &variants, const floppy_image &image) const
-{
-	return false;
-}
-
-bool cqm_format::supports_save() const noexcept
-{
-	return false;
-}
-
 const cqm_format FLOPPY_CQM_FORMAT;

--- a/src/lib/formats/cqm_dsk.h
+++ b/src/lib/formats/cqm_dsk.h
@@ -21,12 +21,10 @@ public:
 
 	virtual int identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const override;
 	virtual bool load(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants, floppy_image &image) const override;
-	virtual bool save(util::random_read_write &io, const std::vector<uint32_t> &variants, const floppy_image &image) const override;
 
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 };
 
 extern const cqm_format FLOPPY_CQM_FORMAT;

--- a/src/lib/formats/d88_dsk.cpp
+++ b/src/lib/formats/d88_dsk.cpp
@@ -554,9 +554,4 @@ bool d88_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	return true;
 }
 
-bool d88_format::supports_save() const noexcept
-{
-	return false;
-}
-
 const d88_format FLOPPY_D88_FORMAT;

--- a/src/lib/formats/d88_dsk.h
+++ b/src/lib/formats/d88_dsk.h
@@ -26,7 +26,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 };
 
 extern const d88_format FLOPPY_D88_FORMAT;

--- a/src/lib/formats/dcp_dsk.cpp
+++ b/src/lib/formats/dcp_dsk.cpp
@@ -298,9 +298,4 @@ bool dcp_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	return true;
 }
 
-bool dcp_format::supports_save() const noexcept
-{
-	return false;
-}
-
 const dcp_format FLOPPY_DCP_FORMAT;

--- a/src/lib/formats/dcp_dsk.h
+++ b/src/lib/formats/dcp_dsk.h
@@ -26,7 +26,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 };
 
 extern const dcp_format FLOPPY_DCP_FORMAT;

--- a/src/lib/formats/dfi_dsk.cpp
+++ b/src/lib/formats/dfi_dsk.cpp
@@ -57,11 +57,6 @@ const char *dfi_format::extensions() const noexcept
 	return "dfi";
 }
 
-bool dfi_format::supports_save() const noexcept
-{
-	return false;
-}
-
 int dfi_format::identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const
 {
 	char sign[4];

--- a/src/lib/formats/dfi_dsk.h
+++ b/src/lib/formats/dfi_dsk.h
@@ -18,7 +18,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 };
 
 extern const dfi_format FLOPPY_DFI_FORMAT;

--- a/src/lib/formats/dim_dsk.cpp
+++ b/src/lib/formats/dim_dsk.cpp
@@ -131,9 +131,4 @@ bool dim_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 }
 
 
-bool dim_format::supports_save() const noexcept
-{
-	return false;
-}
-
 const dim_format FLOPPY_DIM_FORMAT;

--- a/src/lib/formats/dim_dsk.h
+++ b/src/lib/formats/dim_dsk.h
@@ -27,7 +27,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 };
 
 extern const dim_format FLOPPY_DIM_FORMAT;

--- a/src/lib/formats/dip_dsk.cpp
+++ b/src/lib/formats/dip_dsk.cpp
@@ -92,9 +92,4 @@ bool dip_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	return true;
 }
 
-bool dip_format::supports_save() const noexcept
-{
-	return false;
-}
-
 const dip_format FLOPPY_DIP_FORMAT;

--- a/src/lib/formats/dip_dsk.h
+++ b/src/lib/formats/dip_dsk.h
@@ -26,7 +26,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 };
 
 extern const dip_format FLOPPY_DIP_FORMAT;

--- a/src/lib/formats/dmk_dsk.cpp
+++ b/src/lib/formats/dmk_dsk.cpp
@@ -346,10 +346,4 @@ bool dmk_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	return true;
 }
 
-bool dmk_format::supports_save() const noexcept
-{
-	return false;
-}
-
-
 const dmk_format FLOPPY_DMK_FORMAT;

--- a/src/lib/formats/dmk_dsk.h
+++ b/src/lib/formats/dmk_dsk.h
@@ -27,7 +27,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 };
 
 extern const dmk_format FLOPPY_DMK_FORMAT;

--- a/src/lib/formats/dsk_dsk.cpp
+++ b/src/lib/formats/dsk_dsk.cpp
@@ -303,11 +303,6 @@ const char *dsk_format::extensions() const noexcept
 	return "dsk";
 }
 
-bool dsk_format::supports_save() const noexcept
-{
-	return false;
-}
-
 int dsk_format::identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const
 {
 	uint8_t header[16];

--- a/src/lib/formats/dsk_dsk.h
+++ b/src/lib/formats/dsk_dsk.h
@@ -25,7 +25,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 };
 
 extern const dsk_format FLOPPY_DSK_FORMAT;

--- a/src/lib/formats/fdd_dsk.cpp
+++ b/src/lib/formats/fdd_dsk.cpp
@@ -147,9 +147,4 @@ bool fdd_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	return true;
 }
 
-bool fdd_format::supports_save() const noexcept
-{
-	return false;
-}
-
 const fdd_format FLOPPY_FDD_FORMAT;

--- a/src/lib/formats/fdd_dsk.h
+++ b/src/lib/formats/fdd_dsk.h
@@ -26,7 +26,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 };
 
 extern const fdd_format FLOPPY_FDD_FORMAT;

--- a/src/lib/formats/flopimg.cpp
+++ b/src/lib/formats/flopimg.cpp
@@ -178,6 +178,11 @@ bool floppy_image_format_t::save(util::random_read_write &io, const std::vector<
 	return false;
 }
 
+bool floppy_image_format_t::supports_save() const noexcept
+{
+	return false;
+}
+
 bool floppy_image_format_t::extension_matches(const char *file_name) const
 {
 	const char *ext = strrchr(file_name, '.');

--- a/src/lib/formats/flopimg.h
+++ b/src/lib/formats/flopimg.h
@@ -88,7 +88,7 @@ public:
 	//! extensions the format may use.
 	virtual const char *extensions() const noexcept = 0;
 	//! @returns true if format supports saving.
-	virtual bool supports_save() const noexcept = 0;
+	virtual bool supports_save() const noexcept;
 
 	//! This checks if the file has the proper extension for this format.
 	//! @param file_name

--- a/src/lib/formats/fsd_dsk.cpp
+++ b/src/lib/formats/fsd_dsk.cpp
@@ -83,11 +83,6 @@ const char *fsd_format::extensions() const noexcept
 	return "fsd";
 }
 
-bool fsd_format::supports_save() const noexcept
-{
-	return false;
-}
-
 int fsd_format::identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const
 {
 	uint8_t h[3];

--- a/src/lib/formats/fsd_dsk.h
+++ b/src/lib/formats/fsd_dsk.h
@@ -31,7 +31,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 
 	virtual int identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const override;
 	virtual bool load(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants, floppy_image &image) const override;

--- a/src/lib/formats/imd_dsk.cpp
+++ b/src/lib/formats/imd_dsk.cpp
@@ -649,9 +649,4 @@ bool imd_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	return true;
 }
 
-bool imd_format::supports_save() const noexcept
-{
-	return false;
-}
-
 const imd_format FLOPPY_IMD_FORMAT;

--- a/src/lib/formats/imd_dsk.h
+++ b/src/lib/formats/imd_dsk.h
@@ -23,7 +23,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 
 private:
 	void fixnum(char *start, char *end) const;

--- a/src/lib/formats/ipf_dsk.cpp
+++ b/src/lib/formats/ipf_dsk.cpp
@@ -91,11 +91,6 @@ const char *ipf_format::extensions() const noexcept
 	return "ipf";
 }
 
-bool ipf_format::supports_save() const noexcept
-{
-	return false;
-}
-
 int ipf_format::identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const
 {
 	static const uint8_t refh[12] = { 0x43, 0x41, 0x50, 0x53, 0x00, 0x00, 0x00, 0x0c, 0x1c, 0xd5, 0x73, 0xba };

--- a/src/lib/formats/ipf_dsk.h
+++ b/src/lib/formats/ipf_dsk.h
@@ -18,7 +18,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 
 private:
 	struct ipf_decode;

--- a/src/lib/formats/jfd_dsk.cpp
+++ b/src/lib/formats/jfd_dsk.cpp
@@ -374,9 +374,4 @@ bool jfd_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	return true;
 }
 
-bool jfd_format::supports_save() const noexcept
-{
-	return false;
-}
-
 const jfd_format FLOPPY_JFD_FORMAT;

--- a/src/lib/formats/jfd_dsk.h
+++ b/src/lib/formats/jfd_dsk.h
@@ -25,7 +25,6 @@ public:
 
 	virtual int identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const override;
 	virtual bool load(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants, floppy_image &image) const override;
-	virtual bool supports_save() const noexcept override;
 };
 
 extern const jfd_format FLOPPY_JFD_FORMAT;

--- a/src/lib/formats/lw30_dsk.cpp
+++ b/src/lib/formats/lw30_dsk.cpp
@@ -204,10 +204,4 @@ const char *lw30_format::extensions() const noexcept
 	return "img";
 }
 
-bool lw30_format::supports_save() const noexcept
-{
-	// TODO
-	return false;
-}
-
 const lw30_format FLOPPY_LW30_FORMAT;

--- a/src/lib/formats/lw30_dsk.h
+++ b/src/lib/formats/lw30_dsk.h
@@ -21,7 +21,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 };
 
 extern const lw30_format FLOPPY_LW30_FORMAT;

--- a/src/lib/formats/nfd_dsk.cpp
+++ b/src/lib/formats/nfd_dsk.cpp
@@ -283,9 +283,4 @@ bool nfd_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	return true;
 }
 
-bool nfd_format::supports_save() const noexcept
-{
-	return false;
-}
-
 const nfd_format FLOPPY_NFD_FORMAT;

--- a/src/lib/formats/nfd_dsk.h
+++ b/src/lib/formats/nfd_dsk.h
@@ -26,7 +26,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 };
 
 extern const nfd_format FLOPPY_NFD_FORMAT;

--- a/src/lib/formats/pasti_dsk.cpp
+++ b/src/lib/formats/pasti_dsk.cpp
@@ -37,11 +37,6 @@ const char *pasti_format::extensions() const noexcept
 	return "stx";
 }
 
-bool pasti_format::supports_save() const noexcept
-{
-	return false;
-}
-
 int pasti_format::identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const
 {
 	uint8_t h[16];

--- a/src/lib/formats/pasti_dsk.h
+++ b/src/lib/formats/pasti_dsk.h
@@ -18,7 +18,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 
 	static const desc_e xdesc[];
 

--- a/src/lib/formats/pc98fdi_dsk.cpp
+++ b/src/lib/formats/pc98fdi_dsk.cpp
@@ -105,9 +105,4 @@ bool pc98fdi_format::load(util::random_read &io, uint32_t form_factor, const std
 	return true;
 }
 
-bool pc98fdi_format::supports_save() const noexcept
-{
-	return false;
-}
-
 const pc98fdi_format FLOPPY_PC98FDI_FORMAT;

--- a/src/lib/formats/pc98fdi_dsk.h
+++ b/src/lib/formats/pc98fdi_dsk.h
@@ -26,7 +26,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 };
 
 extern const pc98fdi_format FLOPPY_PC98FDI_FORMAT;

--- a/src/lib/formats/sap_dsk.cpp
+++ b/src/lib/formats/sap_dsk.cpp
@@ -34,11 +34,6 @@ const char *sap_dsk_format::extensions() const noexcept
 	return "sap";
 }
 
-bool sap_dsk_format::supports_save() const noexcept
-{
-	return false;
-}
-
 int sap_dsk_format::identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const
 {
 	uint8_t buffer[HEADER_LENGTH];

--- a/src/lib/formats/sap_dsk.h
+++ b/src/lib/formats/sap_dsk.h
@@ -16,7 +16,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 
 	virtual int identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const override;
 	virtual bool load(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants, floppy_image &image) const override;

--- a/src/lib/formats/sdf_dsk.cpp
+++ b/src/lib/formats/sdf_dsk.cpp
@@ -187,10 +187,4 @@ bool sdf_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 }
 
 
-bool sdf_format::supports_save() const noexcept
-{
-	return false;
-}
-
-
 const sdf_format FLOPPY_SDF_FORMAT;

--- a/src/lib/formats/sdf_dsk.h
+++ b/src/lib/formats/sdf_dsk.h
@@ -28,7 +28,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 
 protected:
 	static constexpr int HEADER_SIZE  = 512;

--- a/src/lib/formats/td0_dsk.cpp
+++ b/src/lib/formats/td0_dsk.cpp
@@ -1052,9 +1052,4 @@ bool td0_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 }
 
 
-bool td0_format::supports_save() const noexcept
-{
-	return false;
-}
-
 const td0_format FLOPPY_TD0_FORMAT;

--- a/src/lib/formats/td0_dsk.h
+++ b/src/lib/formats/td0_dsk.h
@@ -19,7 +19,6 @@ public:
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
-	virtual bool supports_save() const noexcept override;
 };
 
 extern const td0_format FLOPPY_TD0_FORMAT;


### PR DESCRIPTION
Since the default implementation of `save` is a stub that always fails, it makes sense to also add a default implementation of `supports_save` that returns `false`. That way, there's one fewer method that needs to be implemented for read-only image formats.

Remove the now-redundant implementations in concrete format classes.