### PR TITLE
sound/k053260.cpp: Add notes for pan LUT

### DIFF
--- a/src/devices/sound/k053260.cpp
+++ b/src/devices/sound/k053260.cpp
@@ -68,6 +68,7 @@ DEFINE_DEVICE_TYPE(K053260, k053260_device, "k053260", "Konami 053260 KDSC")
 // Pan multipliers.  Set according to integer angles in degrees, amusingly.
 // Exact precision hard to know, the floating point-ish output format makes
 // comparisons iffy.  So we used a 1.16 format.
+// TODO: actually LUT based, mentioned from RE'd schematics.
 const int k053260_device::pan_mul[8][2] =
 {
 	{     0,     0 }, // No sound for pan 0


### PR DESCRIPTION
reference: https://github.com/furrtek/SiliconRE/blob/master/Konami/053260/k053260_schematics.PDF (Schematics from RE work by furrtek)