### PR TITLE
apple2gs: fix VBL sync

### DIFF
--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -1559,8 +1559,8 @@ u8 apple2gs_state::c000_r(offs_t offset)
 		case 0x18:  // read 80STORE
 			return (uKeyboardC010 & 0x7f) | (m_video->get_80store() ? 0x80 : 0x00);
 
-		case 0x19:  // read VBLBAR
-			return (uKeyboardC010 & 0x7f) | (m_screen->vblank() ? 0x00 : 0x80);
+		case 0x19:  // read VBL (not VBLBAR, see Apple IIGS Technical Note #40)
+			return (uKeyboardC010 & 0x7f) | (m_screen->vblank() ? 0x80 : 0x00);
 
 		case 0x1a:  // read TEXT
 			return (uKeyboardC010 & 0x7f) | (m_video->get_graphics() ? 0x00 : 0x80);


### PR DESCRIPTION
This PR fixes `$C019` to work correctly on the IIgs: the sense is inverted compared to the //e.
This is documented incorrectly in the [Apple IIgs Hardware Reference](http://archive.org/details/Apple_IIgs_Hardware_Reference_HiRes/page/270/mode/2up), but later corrected in
[Apple IIgs Technical Note #40](http://apple2.gs/technotes/tn/iigs/TN.IIGS.040.txt), and was well-known in [published literature](http://link.springer.com/content/pdf/10.3758/BF03202812.pdf) of that era.

Examples of VBL syncing errors fixed by this PR:
* ACS's ACS_DEMO1.2mg, # 5 GIGA SCROLLING! (tearing top scroller and missing bottom)
* FTA's XMASDEMO.2mg (flickering fill-mode zoom of X-MAS logo) _(but still hangs on WAI after that)_
* Brutal Deluxe's Beauvais1992.2mg (too-fast text scroller at bottom)

I have updated my earlier unit test from #14053 to verify the behavior on real HW:
* added VBL sync in addition to floating bus vaporlock, and sysid detection to use them as appropriate
* added IIgs and Zip speed disabling, so 1MHz cycle counting "just works" _(but not in MAME, yet)_
* added a beam-racing Mousetext mode (yes, this is possible!) _(but not in MAME, yet)_
* added on-screen expected result descriptions
* _(still no 50Hz support)_
![VBLSync_HW_IIe](https://github.com/user-attachments/assets/ffe12b22-420b-4949-a931-d4d257e2784b)
![VBLSync_HW_IIgs](https://github.com/user-attachments/assets/b832d307-dd91-4e20-bd37-6ffa39bf4bb2)
[VidSync_250914.zip](https://github.com/user-attachments/files/22346827/VidSync_250914.zip)

MAME still has several issues with this test, but one step at a time...
