### PR TITLE
Move switching of screen's current bitmap to after layout updates

### DIFF
--- a/src/emu/screen.cpp
+++ b/src/emu/screen.cpp
@@ -1779,7 +1779,6 @@ bool screen_device::update_quads()
 				}
 				m_texture[m_curbitmap]->set_bitmap(m_bitmap[m_curbitmap], m_visarea, m_bitmap[m_curbitmap].texformat());
 				m_curtexture = m_curbitmap;
-				m_curbitmap = 1 - m_curbitmap;
 			}
 
 			// brightness adjusted render color
@@ -1791,10 +1790,30 @@ bool screen_device::update_quads()
 		}
 	}
 
+	return m_changed;
+}
+
+
+//-------------------------------------------------
+//  switch current bitmap
+//-------------------------------------------------
+
+void screen_device::switch_current_bitmap()
+{
+	// only updated if live
+	if (machine().render().is_live(*this))
+	{
+		// only updated if empty and not a vector game; otherwise assume the driver did it directly
+		if (m_type != SCREEN_TYPE_VECTOR && (m_video_attributes & VIDEO_SELF_RENDER) == 0)
+		{
+			// if we're not skipping the frame and if the screen actually changed, then switch the bitmap
+			if (!machine().video().skip_this_frame() && m_changed)
+				m_curbitmap = 1 - m_curbitmap;
+		}
+	}
+
 	// reset the screen changed flags
-	bool result = m_changed;
 	m_changed = false;
-	return result;
 }
 
 

--- a/src/emu/screen.h
+++ b/src/emu/screen.h
@@ -415,6 +415,7 @@ public:
 
 	// internal to the video system
 	bool update_quads();
+	void switch_current_bitmap();
 	void update_burnin();
 
 	// globally accessible constants

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -244,6 +244,10 @@ void video_manager::frame_update(bool from_debugger)
 		machine().osd().update(!from_debugger && skipped_it);
 	}
 
+	// prepare screens for next frame
+	if (update_screens)
+		post_screen_updates();
+
 	// we synchronize after rendering instead of before, if low latency mode is enabled
 	if (!from_debugger && phase > machine_phase::INIT && m_low_latency && effective_throttle())
 		update_throttle(current_time);
@@ -654,6 +658,19 @@ bool video_manager::finish_screen_updates()
 	return anything_changed;
 }
 
+
+//-------------------------------------------------
+//  post_screen_updates - prepare screens for next
+//  frame
+//-------------------------------------------------
+
+void video_manager::post_screen_updates()
+{
+	screen_device_enumerator iter(machine().root_device());
+
+	for (screen_device &screen : iter)
+		screen.switch_current_bitmap();
+}
 
 
 //-------------------------------------------------

--- a/src/emu/video.h
+++ b/src/emu/video.h
@@ -101,6 +101,7 @@ private:
 	// speed and throttling helpers
 	int original_speed_setting() const;
 	bool finish_screen_updates();
+	void post_screen_updates();
 	void update_throttle(attotime emutime);
 	osd_ticks_t throttle_until_ticks(osd_ticks_t target_ticks);
 	void update_frameskip();


### PR DESCRIPTION
Currently video_manager::frame_update() updates the screen object by calling finish_screen_updates(), that calls screen.update_quads(), where the current m_curbitmap is set as the bitmap to be used by the frame texture. The code then switches the m_curbitmap pointer to the other bitmap available to blit the next frame. The execution returns to after the last call was made in video_manager::frame_update() and continues through the code. One of the remaining calls is machine().osd().update(), where the layout is rendered. If the layout contains a script that calls screen:pixels() to obtain the data of pixels in the frame, it won't get the data of the last frame. To make this work, these changes move switching of screen's current bitmap to after the layout is updated.