### PR TITLE
cpu/i960: store IRQ line states, immediately return if unchanged

### DIFF
--- a/src/devices/cpu/i960/i960.cpp
+++ b/src/devices/cpu/i960/i960.cpp
@@ -4,6 +4,8 @@
 #include "i960.h"
 #include "i960dis.h"
 
+#include <algorithm>
+
 #ifdef _MSC_VER
 /* logb prototype is different for MS Visual C */
 #include <cfloat>
@@ -2318,55 +2320,54 @@ void i960_cpu_device::device_start()
 	save_item(NAME(m_stall_state.burst_mode));
 	save_item(NAME(m_irq_line_state));
 
+	state_add(I960_SAT,  "sat", m_SAT).formatstr("%08X");
+	state_add(I960_PRCB, "prcb", m_PRCB).formatstr("%08X");
+	state_add(I960_PC,   "pc", m_PC).formatstr("%08X");
+	state_add(I960_AC,   "ac", m_AC).formatstr("%08X");
+	state_add(I960_IP,   "ip", m_IP).formatstr("%08X");
+	state_add(I960_PIP,  "pip", m_PIP).formatstr("%08X");
+	state_add(I960_R0,   "pfp", m_r[ 0]).formatstr("%08X");
+	state_add(I960_R1,   "sp", m_r[ 1]).formatstr("%08X");
+	state_add(I960_R2,   "rip", m_r[ 2]).formatstr("%08X");
+	state_add(I960_R3,   "r3", m_r[ 3]).formatstr("%08X");
+	state_add(I960_R4,   "r4", m_r[ 4]).formatstr("%08X");
+	state_add(I960_R5,   "r5", m_r[ 5]).formatstr("%08X");
+	state_add(I960_R6,   "r6", m_r[ 6]).formatstr("%08X");
+	state_add(I960_R7,   "r7", m_r[ 7]).formatstr("%08X");
+	state_add(I960_R8,   "r8", m_r[ 8]).formatstr("%08X");
+	state_add(I960_R9,   "r9", m_r[ 9]).formatstr("%08X");
+	state_add(I960_R10,  "r10", m_r[10]).formatstr("%08X");
+	state_add(I960_R11,  "r11", m_r[11]).formatstr("%08X");
+	state_add(I960_R12,  "r12", m_r[12]).formatstr("%08X");
+	state_add(I960_R13,  "r13", m_r[13]).formatstr("%08X");
+	state_add(I960_R14,  "r14", m_r[14]).formatstr("%08X");
+	state_add(I960_R15,  "r15", m_r[15]).formatstr("%08X");
+	state_add(I960_G0,   "g0", m_r[16]).formatstr("%08X");
+	state_add(I960_G1,   "g1", m_r[17]).formatstr("%08X");
+	state_add(I960_G2,   "g2", m_r[18]).formatstr("%08X");
+	state_add(I960_G3,   "g3", m_r[19]).formatstr("%08X");
+	state_add(I960_G4,   "g4", m_r[20]).formatstr("%08X");
+	state_add(I960_G5,   "g5", m_r[21]).formatstr("%08X");
+	state_add(I960_G6,   "g6", m_r[22]).formatstr("%08X");
+	state_add(I960_G7,   "g7", m_r[23]).formatstr("%08X");
+	state_add(I960_G8,   "g8", m_r[24]).formatstr("%08X");
+	state_add(I960_G9,   "g9", m_r[25]).formatstr("%08X");
+	state_add(I960_G10,  "g10", m_r[26]).formatstr("%08X");
+	state_add(I960_G11,  "g11", m_r[27]).formatstr("%08X");
+	state_add(I960_G12,  "g12", m_r[28]).formatstr("%08X");
+	state_add(I960_G13,  "g13", m_r[29]).formatstr("%08X");
+	state_add(I960_G14,  "g14", m_r[30]).formatstr("%08X");
+	state_add(I960_G15,  "fp", m_r[31]).formatstr("%08X");
 
-	state_add( I960_SAT,  "sat", m_SAT).formatstr("%08X");
-	state_add( I960_PRCB, "prcb", m_PRCB).formatstr("%08X");
-	state_add( I960_PC,   "pc", m_PC).formatstr("%08X");
-	state_add( I960_AC,   "ac", m_AC).formatstr("%08X");
-	state_add( I960_IP,   "ip", m_IP).formatstr("%08X");
-	state_add( I960_PIP,  "pip", m_PIP).formatstr("%08X");
-	state_add( I960_R0,   "pfp", m_r[ 0]).formatstr("%08X");
-	state_add( I960_R1,   "sp", m_r[ 1]).formatstr("%08X");
-	state_add( I960_R2,   "rip", m_r[ 2]).formatstr("%08X");
-	state_add( I960_R3,   "r3", m_r[ 3]).formatstr("%08X");
-	state_add( I960_R4,   "r4", m_r[ 4]).formatstr("%08X");
-	state_add( I960_R5,   "r5", m_r[ 5]).formatstr("%08X");
-	state_add( I960_R6,   "r6", m_r[ 6]).formatstr("%08X");
-	state_add( I960_R7,   "r7", m_r[ 7]).formatstr("%08X");
-	state_add( I960_R8,   "r8", m_r[ 8]).formatstr("%08X");
-	state_add( I960_R9,   "r9", m_r[ 9]).formatstr("%08X");
-	state_add( I960_R10,  "r10", m_r[10]).formatstr("%08X");
-	state_add( I960_R11,  "r11", m_r[11]).formatstr("%08X");
-	state_add( I960_R12,  "r12", m_r[12]).formatstr("%08X");
-	state_add( I960_R13,  "r13", m_r[13]).formatstr("%08X");
-	state_add( I960_R14,  "r14", m_r[14]).formatstr("%08X");
-	state_add( I960_R15,  "r15", m_r[15]).formatstr("%08X");
-	state_add( I960_G0,   "g0", m_r[16]).formatstr("%08X");
-	state_add( I960_G1,   "g1", m_r[17]).formatstr("%08X");
-	state_add( I960_G2,   "g2", m_r[18]).formatstr("%08X");
-	state_add( I960_G3,   "g3", m_r[19]).formatstr("%08X");
-	state_add( I960_G4,   "g4", m_r[20]).formatstr("%08X");
-	state_add( I960_G5,   "g5", m_r[21]).formatstr("%08X");
-	state_add( I960_G6,   "g6", m_r[22]).formatstr("%08X");
-	state_add( I960_G7,   "g7", m_r[23]).formatstr("%08X");
-	state_add( I960_G8,   "g8", m_r[24]).formatstr("%08X");
-	state_add( I960_G9,   "g9", m_r[25]).formatstr("%08X");
-	state_add( I960_G10,  "g10", m_r[26]).formatstr("%08X");
-	state_add( I960_G11,  "g11", m_r[27]).formatstr("%08X");
-	state_add( I960_G12,  "g12", m_r[28]).formatstr("%08X");
-	state_add( I960_G13,  "g13", m_r[29]).formatstr("%08X");
-	state_add( I960_G14,  "g14", m_r[30]).formatstr("%08X");
-	state_add( I960_G15,  "fp", m_r[31]).formatstr("%08X");
-
-	state_add( STATE_GENPC, "GENPC", m_IP).noshow();
-	state_add( STATE_GENPCBASE, "CURPC", m_IP).noshow();
-	state_add( STATE_GENFLAGS, "GENFLAGS", m_AC).noshow().formatstr("%2s");
+	state_add(STATE_GENPC, "GENPC", m_IP).noshow();
+	state_add(STATE_GENPCBASE, "CURPC", m_IP).noshow();
+	state_add(STATE_GENFLAGS, "GENFLAGS", m_AC).noshow().formatstr("%2s");
 
 	m_immediate_vector = 0;
 	m_immediate_pri = 0;
-	memset(m_rcache_frame_addr, 0, sizeof(m_rcache_frame_addr));
-	memset(m_fp, 0, sizeof(m_fp));
-	memset(m_irq_line_state, CLEAR_LINE, sizeof(m_irq_line_state));
+	std::fill(std::begin(m_rcache_frame_addr), std::end(m_rcache_frame_addr), 0);
+	std::fill(std::begin(m_fp), std::end(m_fp), 0.0);
+	std::fill(std::begin(m_irq_line_state), std::end(m_irq_line_state), CLEAR_LINE);
 	m_PIP = 0;
 
 	set_icountptr(m_icount);

--- a/src/devices/cpu/i960/i960.cpp
+++ b/src/devices/cpu/i960/i960.cpp
@@ -2218,6 +2218,11 @@ void i960_cpu_device::execute_run()
 
 void i960_cpu_device::execute_set_input(int irqline, int state)
 {
+	if (m_irq_line_state[irqline] == state)
+		return;
+
+	m_irq_line_state[irqline] = state;
+
 	int int_tab =  m_program.read_dword(m_PRCB+20);    // interrupt table
 	int cpu_pri = (m_PC>>16)&0x1f;
 	int vector =0;
@@ -2311,6 +2316,7 @@ void i960_cpu_device::device_start()
 	save_item(NAME(m_stall_state.t1));
 	save_item(NAME(m_stall_state.t2));
 	save_item(NAME(m_stall_state.burst_mode));
+	save_item(NAME(m_irq_line_state));
 
 
 	state_add( I960_SAT,  "sat", m_SAT).formatstr("%08X");
@@ -2396,6 +2402,8 @@ void i960_cpu_device::device_reset()
 	m_r[I960_FP] = m_program.read_dword(m_PRCB+24);
 	m_r[I960_SP] = m_r[I960_FP] + 64;
 	m_rcache_pos = 0;
+
+	std::fill(std::begin(m_irq_line_state), std::end(m_irq_line_state), 0);
 }
 
 std::unique_ptr<util::disasm_interface> i960_cpu_device::create_disassembler()

--- a/src/devices/cpu/i960/i960.cpp
+++ b/src/devices/cpu/i960/i960.cpp
@@ -2366,6 +2366,7 @@ void i960_cpu_device::device_start()
 	m_immediate_pri = 0;
 	memset(m_rcache_frame_addr, 0, sizeof(m_rcache_frame_addr));
 	memset(m_fp, 0, sizeof(m_fp));
+	memset(m_irq_line_state, CLEAR_LINE, sizeof(m_irq_line_state));
 	m_PIP = 0;
 
 	set_icountptr(m_icount);
@@ -2402,8 +2403,6 @@ void i960_cpu_device::device_reset()
 	m_r[I960_FP] = m_program.read_dword(m_PRCB+24);
 	m_r[I960_SP] = m_r[I960_FP] + 64;
 	m_rcache_pos = 0;
-
-	std::fill(std::begin(m_irq_line_state), std::end(m_irq_line_state), 0);
 }
 
 std::unique_ptr<util::disasm_interface> i960_cpu_device::create_disassembler()

--- a/src/devices/cpu/i960/i960.h
+++ b/src/devices/cpu/i960/i960.h
@@ -132,6 +132,8 @@ private:
 	int m_immediate_vector;
 	int  m_immediate_pri;
 
+	int8_t m_irq_line_state[4];
+
 	memory_access<32, 2, 0, ENDIANNESS_LITTLE>::cache m_cache;
 	memory_access<32, 2, 0, ENDIANNESS_LITTLE>::specific m_program;
 

--- a/src/mame/namco/namcofl.cpp
+++ b/src/mame/namco/namcofl.cpp
@@ -353,6 +353,12 @@ void namcofl_state::sysreg_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 		// 1: ROM at 00000000, RAM at 10000000
 		m_mainbank.select(data & 1);
 	}
+	else if (offset >= 0x10 && offset <= 0x13)	// clear i960 IRQ line
+	{
+		// data value doesn't seem to matter
+		const int irq_type[4] = { I960_IRQ0, I960_IRQ1, I960_IRQ2, I960_IRQ3 };
+		m_maincpu->set_input_line(irq_type[offset & 3], CLEAR_LINE);
+	}
 }
 
 // FIXME: remove this trampoline once the IRQ is moved into the actual device

--- a/src/mame/namco/namcofl.cpp
+++ b/src/mame/namco/namcofl.cpp
@@ -656,6 +656,12 @@ void namcofl_state::machine_reset()
 
 	std::fill_n(&m_workram[0], m_workram.bytes() / 4, 0);
 	m_mainbank.select(1);
+
+	const int irq_type[4] = { I960_IRQ0, I960_IRQ1, I960_IRQ2, I960_IRQ3 };
+	for (int i = 0; i < 4; i++)
+	{
+		m_maincpu->set_input_line(irq_type[i], CLEAR_LINE);
+	}
 }
 
 

--- a/src/mame/namco/namcofl.cpp
+++ b/src/mame/namco/namcofl.cpp
@@ -241,6 +241,8 @@ private:
 	uint8_t m_mcu_port6 = 0;
 	uint32_t m_sprbank = 0;
 
+	static constexpr int irq_type[] = { I960_IRQ0, I960_IRQ1, I960_IRQ2, I960_IRQ3 };
+
 	uint32_t unk1_r();
 	uint8_t network_r(offs_t offset);
 	uint32_t sysreg_r();
@@ -356,7 +358,6 @@ void namcofl_state::sysreg_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 	else if (offset >= 0x10 && offset <= 0x13)	// clear i960 IRQ line
 	{
 		// data value doesn't seem to matter
-		const int irq_type[4] = { I960_IRQ0, I960_IRQ1, I960_IRQ2, I960_IRQ3 };
 		m_maincpu->set_input_line(irq_type[offset & 3], CLEAR_LINE);
 	}
 }
@@ -657,7 +658,7 @@ void namcofl_state::machine_reset()
 	std::fill_n(&m_workram[0], m_workram.bytes() / 4, 0);
 	m_mainbank.select(1);
 
-	const int irq_type[] = { I960_IRQ0, I960_IRQ1, I960_IRQ2, I960_IRQ3 };
+	
 	for (auto irq : irq_type)
 	{
 		m_maincpu->set_input_line(irq, CLEAR_LINE);

--- a/src/mame/namco/namcofl.cpp
+++ b/src/mame/namco/namcofl.cpp
@@ -657,10 +657,10 @@ void namcofl_state::machine_reset()
 	std::fill_n(&m_workram[0], m_workram.bytes() / 4, 0);
 	m_mainbank.select(1);
 
-	const int irq_type[4] = { I960_IRQ0, I960_IRQ1, I960_IRQ2, I960_IRQ3 };
-	for (int i = 0; i < 4; i++)
+	const int irq_type[] = { I960_IRQ0, I960_IRQ1, I960_IRQ2, I960_IRQ3 };
+	for (auto irq : irq_type)
 	{
-		m_maincpu->set_input_line(irq_type[i], CLEAR_LINE);
+		m_maincpu->set_input_line(irq, CLEAR_LINE);
 	}
 }
 

--- a/src/mame/sega/model2.cpp
+++ b/src/mame/sega/model2.cpp
@@ -270,10 +270,10 @@ void model2_state::machine_reset()
 	m_geo_write_start_address = 0;
 	m_geo_read_start_address = 0;
 
-	const int irq_type[4] = { I960_IRQ0, I960_IRQ1, I960_IRQ2, I960_IRQ3 };
-	for (int i = 0; i < 4; i++)
+	const int irq_type[] = { I960_IRQ0, I960_IRQ1, I960_IRQ2, I960_IRQ3 };
+	for (auto irq : irq_type)
 	{
-		m_maincpu->set_input_line(irq_type[i], CLEAR_LINE);
+		m_maincpu->set_input_line(irq, CLEAR_LINE);
 	}
 }
 

--- a/src/mame/sega/model2.cpp
+++ b/src/mame/sega/model2.cpp
@@ -269,6 +269,12 @@ void model2_state::machine_reset()
 	m_copro_fifo_out->clear();
 	m_geo_write_start_address = 0;
 	m_geo_read_start_address = 0;
+
+	const int irq_type[4] = { I960_IRQ0, I960_IRQ1, I960_IRQ2, I960_IRQ3 };
+	for (int i = 0; i < 4; i++)
+	{
+		m_maincpu->set_input_line(irq_type[i], CLEAR_LINE);
+	}
 }
 
 void model2_state::reset_model2_scsp()


### PR DESCRIPTION
If a particular IRQ line is already high, trying to assert another IRQ on the same line no longer has any effect; the IRQ line must be cleared/lowered first before another IRQ can be asserted. 

IRQ acknowledgement logic has been implemented for Namco System FL, since it is now required with the i960 update.