### PR TITLE
[tlcs900 disasm] SFR symbol names for all other TLCS-900 variants:

### DIFF
--- a/src/devices/cpu/tlcs900/dasm900.h
+++ b/src/devices/cpu/tlcs900/dasm900.h
@@ -132,21 +132,33 @@ private:
 class tmp95c061_disassembler : public tlcs900_disassembler
 {
 public:
-	tmp95c061_disassembler() : tlcs900_disassembler() {};
+	tmp95c061_disassembler(std::pair<u16, char const *> const symbols[], std::size_t symbol_count);
+	template<size_t N> tmp95c061_disassembler(std::pair<u16, char const *> const (&symbols)[N]) : tlcs900_disassembler(symbols, N) {}
+
+private:
+	static const char *const s_sfr_names[];
 };
 
 
 class tmp95c063_disassembler : public tlcs900_disassembler
 {
 public:
-	tmp95c063_disassembler() : tlcs900_disassembler() {};
+	tmp95c063_disassembler(std::pair<u16, char const *> const symbols[], std::size_t symbol_count);
+	template<size_t N> tmp95c063_disassembler(std::pair<u16, char const *> const (&symbols)[N]) : tlcs900_disassembler(symbols, N) {}
+
+private:
+	static const char *const s_sfr_names[];
 };
 
 
 class tmp96c141_disassembler : public tlcs900_disassembler
 {
 public:
-	tmp96c141_disassembler() : tlcs900_disassembler() {};
+	tmp96c141_disassembler(std::pair<u16, char const *> const symbols[], std::size_t symbol_count);
+	template<size_t N> tmp96c141_disassembler(std::pair<u16, char const *> const (&symbols)[N]) : tlcs900_disassembler(symbols, N) {}
+
+private:
+	static const char *const s_sfr_names[];
 };
 
 #endif

--- a/src/devices/cpu/tlcs900/tmp94c241.cpp
+++ b/src/devices/cpu/tlcs900/tmp94c241.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:AJR,Felipe Sanches
+// copyright-holders:AJR, Felipe Sanches
 /****************************************************************************
 
     Toshiba TMP94C241 microcontroller

--- a/src/devices/cpu/tlcs900/tmp95c061.cpp
+++ b/src/devices/cpu/tlcs900/tmp95c061.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Wilbert Pol
+// copyright-holders:Wilbert Pol, Felipe Sanches
 /*******************************************************************
 
 Toshiba TMP95C061 emulation
@@ -8,6 +8,7 @@ Toshiba TMP95C061 emulation
 
 #include "emu.h"
 #include "tmp95c061.h"
+#include "dasm900.h"
 
 DEFINE_DEVICE_TYPE(TMP95C061, tmp95c061_device, "tmp95c061", "Toshiba TMP95C061")
 
@@ -1352,4 +1353,39 @@ uint8_t tmp95c061_device::dmemcr_r()
 void tmp95c061_device::dmemcr_w(uint8_t data)
 {
 	m_dram_access = data;
+}
+
+std::pair<u16, char const *> const tmp95c061_syms[] = {
+	{ 0x01, "P1" }, { 0x04, "P1CR" }, { 0x06, "P2" }, { 0x09, "P2FC" },
+	{ 0x0d, "P5" }, { 0x10, "P5CR" }, { 0x11, "P5FC" }, { 0x12, "P6" },
+	{ 0x13, "P7" }, { 0x15, "P6FC" }, { 0x16, "P7CR" }, { 0x17, "P7FC" },
+	{ 0x18, "P8" }, { 0x19, "P9" }, { 0x1a, "P8CR" }, { 0x1b, "P8FC" },
+	{ 0x1e, "PA" }, { 0x1f, "PB" }, { 0x20, "TRUN" }, { 0x22, "TREG0" },
+	{ 0x23, "TREG1" }, { 0x24, "T01MOD" }, { 0x25, "TFFCR" }, { 0x26, "TREG2" },
+	{ 0x27, "TREG3" }, { 0x28, "T23MOD" }, { 0x29, "TRDC" }, { 0x2c, "PACR" },
+	{ 0x2d, "PAFC" }, { 0x2e, "PBCR" }, { 0x2f, "PBFC" }, { 0x30, "TREG4L" },
+	{ 0x31, "TREG4H" }, { 0x32, "TREG5L" }, { 0x33, "TREG5H" }, { 0x34, "CAP1L" },
+	{ 0x35, "CAP1H" }, { 0x36, "CAP2L" }, { 0x37, "CAP2H" }, { 0x38, "T4MOD" },
+	{ 0x39, "T4FFCR" }, { 0x3a, "T45CR" }, { 0x3c, "MSAR0" }, { 0x3d, "MAMR0" },
+	{ 0x3e, "MSAR1" }, { 0x3f, "MAMR1" }, { 0x40, "TREG6L" }, { 0x41, "TREG6H" },
+	{ 0x42, "TREG7L" }, { 0x43, "TREG7H" }, { 0x44, "CAP3L" }, { 0x45, "CAP3H" },
+	{ 0x46, "CAP4L" }, { 0x47, "CAP4H" }, { 0x48, "T5MOD" }, { 0x49, "T5FFCR" },
+	{ 0x4c, "PG0REG" }, { 0x4d, "PG1REG" }, { 0x4e, "PG01CR" }, { 0x50, "SC0BUF" },
+	{ 0x51, "SC0CR" }, { 0x52, "SC0MOD" }, { 0x53, "BR0CR" }, { 0x54, "SC1BUF" },
+	{ 0x55, "SC1CR" }, { 0x56, "SC1MOD" }, { 0x57, "BR1CR" }, { 0x58, "ODE" },
+	{ 0x5a, "DREFCR" }, { 0x5b, "DMEMCR" }, { 0x5c, "MSAR2" }, { 0x5d, "MAMR2" },
+	{ 0x5e, "MSAR3" }, { 0x5f, "MAMR3" }, { 0x60, "ADREG0L" }, { 0x61, "ADREG0H" },
+	{ 0x62, "ADREG1L" }, { 0x63, "ADREG1H" }, { 0x64, "ADREG2L" }, { 0x65, "ADREG2H" },
+	{ 0x66, "ADREG3L" }, { 0x67, "ADREG3H" }, { 0x68, "B0CS" }, { 0x69, "B1CS" },
+	{ 0x6a, "B2CS" }, { 0x6b, "B3CS" }, { 0x6c, "BEXCS" }, { 0x6d, "ADMOD" },
+	{ 0x6e, "WDMOD" }, { 0x6f, "WDCR" }, { 0x70, "INTE0AD" }, { 0x71, "INTE45" },
+	{ 0x72, "INTE67" }, { 0x73, "INTET10" }, { 0x74, "INTET32" }, { 0x75, "INTET54" },
+	{ 0x76, "INTET76" }, { 0x77, "INTES0" }, { 0x78, "INTES1" }, { 0x79, "INTETC01" },
+	{ 0x7a, "INTETC23" }, { 0x7b, "IIMC" }, { 0x7c, "DMA0V" }, { 0x7d, "DMA1V" },
+	{ 0x7e, "DMA2V" }, { 0x7f, "DMA3V" }
+};
+
+std::unique_ptr<util::disasm_interface> tmp95c061_device::create_disassembler()
+{
+	return std::make_unique<tmp95c061_disassembler>(tmp95c061_syms);
 }

--- a/src/devices/cpu/tlcs900/tmp95c061.h
+++ b/src/devices/cpu/tlcs900/tmp95c061.h
@@ -62,6 +62,9 @@ protected:
 	int tlcs900_process_hdma( int channel );
 	void update_porta();
 
+	// device_disasm_interface overrides
+	virtual std::unique_ptr<util::disasm_interface> create_disassembler() override;
+
 private:
 	template <uint8_t> uint8_t port_r();
 	template <uint8_t> void port_w(uint8_t data);

--- a/src/devices/cpu/tlcs900/tmp95c063.cpp
+++ b/src/devices/cpu/tlcs900/tmp95c063.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Wilbert Pol
+// copyright-holders:Wilbert Pol, Felipe Sanches
 /*******************************************************************
 
 Toshiba TMP95C063 emulation
@@ -8,6 +8,7 @@ Toshiba TMP95C063 emulation
 
 #include "emu.h"
 #include "tmp95c063.h"
+#include "dasm900.h"
 
 DEFINE_DEVICE_TYPE(TMP95C063, tmp95c063_device, "tmp95c063", "Toshiba TMP95C063")
 
@@ -1400,4 +1401,32 @@ void tmp95c063_device::execute_set_input(int input, int level)
 		break;
 	}
 	m_check_irqs = 1;
+}
+
+std::pair<u16, char const *> const tmp95c063_syms[] = {
+	{ 0x01, "P1" }, { 0x04, "P1CR" }, { 0x06, "P2" },
+	{ 0x09, "P2FC" }, { 0x0d, "P5" },
+	{ 0x10, "P5CR" }, { 0x11, "P5FC" }, { 0x12, "P6" }, { 0x13, "P7" }, { 0x15, "P6FC" }, { 0x16, "P7CR" }, { 0x17, "P7FC" },
+	{ 0x18, "P8" }, { 0x19, "P9" }, { 0x1a, "P8CR" }, { 0x1b, "P8FC" }, { 0x1c, "P9CR" }, { 0x1d, "P9FC" }, { 0x1e, "PA" }, { 0x1f, "PB" },
+	{ 0x20, "T8RUN" }, { 0x21, "TRDC" }, { 0x22, "TREG0" }, { 0x23, "TREG1" }, { 0x24, "T01MOD" }, { 0x25, "T02FFCR" }, { 0x26, "TREG2" }, { 0x27, "TREG3" },
+	{ 0x28, "T23MOD" }, { 0x29, "TREG4" }, { 0x2a, "TREG5" }, { 0x2b, "T45MOD" }, { 0x2c, "TA46FFCR" }, { 0x2d, "TREG6" }, { 0x2e, "TREG7" }, { 0x2f, "T67MOD" },
+	{ 0x30, "TREG8L" }, { 0x31, "TREG8H" }, { 0x32, "TREG9L" }, { 0x33, "TREG9H" }, { 0x34, "CAP1L" }, { 0x35, "CAP1H" }, { 0x36, "CAP2L" }, { 0x37, "CAP2H" },
+	{ 0x38, "T8MOD" }, { 0x39, "T8FFCR" }, { 0x3a, "T89CR" }, { 0x3b, "T16RUN" },
+	{ 0x40, "TREGAL" }, { 0x41, "TREGAH" }, { 0x42, "TREGBL" }, { 0x43, "TREGBH" }, { 0x44, "CAP3L" }, { 0x45, "CAP3H" }, { 0x46, "CAP4L" }, { 0x47, "CAP4H" },
+	{ 0x48, "T9MOD" }, { 0x49, "T9FFCR" }, { 0x4a, "DAREG0" }, { 0x4b, "DAREG1" }, { 0x4c, "PG0REG" }, { 0x4d, "PG1REG" }, { 0x4e, "PG01CR" }, { 0x4f, "DADRV" },
+	{ 0x50, "SC0BUF" }, { 0x51, "SC0CR" }, { 0x52, "SC0MOD" }, { 0x53, "BR0CR" }, { 0x54, "SC1BUF" }, { 0x55, "SC1CR" }, { 0x56, "SC1MOD" }, { 0x57, "BR1CR" },
+	{ 0x58, "ODE" }, { 0x5a, "DMA0V" }, { 0x5b, "DMA1V" }, { 0x5c, "DMA2V" }, { 0x5d, "DMA3V" }, { 0x5e, "ADMOD1" }, { 0x5f, "ADMOD2" },
+	{ 0x60, "ADREG04L" }, { 0x61, "ADREG04H" }, { 0x62, "ADREG15L" }, { 0x63, "ADREG15H" }, { 0x64, "ADREG26L" }, { 0x65, "ADREG26H" }, { 0x66, "ADREG37L" }, { 0x67, "ADREG37H" },
+	{ 0x6a, "SDMACR0" }, { 0x6b, "SDMACR1" }, { 0x6c, "SDMACR2" }, { 0x6d, "SDMACR3" }, { 0x6e, "WDMOD" }, { 0x6f, "WDCR" },
+	{ 0x70, "INTE_0AD" }, { 0x71, "INTE12" }, { 0x72, "INTE34" }, { 0x73, "INTE56" }, { 0x74, "INT78" }, { 0x75, "INTET01" }, { 0x76, "INTET32" }, { 0x77, "INTET45" },
+	{ 0x78, "INTET67" }, { 0x79, "INTET89" }, { 0x7a, "INTETAB" }, { 0x7b, "INTES0" }, { 0x7c, "INTES1" }, { 0x7d, "INTETC01" }, { 0x7e, "INTETC23" }, { 0x7f, "IIMC" },
+	{ 0x80, "PACR" }, { 0x81, "PAFC" }, { 0x82, "PBCR" }, { 0x83, "PBFC" }, { 0x84, "PC" }, { 0x85, "PD"},
+	{ 0x88, "PDCR" }, { 0x8a, "PE" }, { 0x8c, "PECR" }, { 0x8f, "BEXCS" },
+	{ 0x90, "B0CS" }, { 0x91, "B1CS" }, { 0x92, "B2CS" }, { 0x93, "B3CS" }, { 0x94, "MSAR0" }, { 0x95, "MAMR0" }, { 0x96, "MSAR1" }, { 0x97, "MAMR1" },
+	{ 0x98, "MSAR2" }, { 0x99, "MAMR2" }, { 0x9a, "MSAR3" }, { 0x9b, "MAMR3" }, { 0x9c, "DREFCR1" }, { 0x9d, "DMEMCR1" }, { 0x9e, "DREFCR3" }, { 0x9f, "DMEMCR3" }
+};
+
+std::unique_ptr<util::disasm_interface> tmp95c063_device::create_disassembler()
+{
+	return std::make_unique<tmp95c063_disassembler>(tmp95c063_syms);
 }

--- a/src/devices/cpu/tlcs900/tmp95c063.h
+++ b/src/devices/cpu/tlcs900/tmp95c063.h
@@ -68,6 +68,9 @@ protected:
 	virtual void tlcs900_handle_ad() override;
 	virtual void tlcs900_handle_timers() override;
 
+	// device_disasm_interface overrides
+	virtual std::unique_ptr<util::disasm_interface> create_disassembler() override;
+
 private:
 	template <uint8_t> uint8_t port_r();
 	template <uint8_t> void port_w(uint8_t data);

--- a/src/devices/cpu/tlcs900/tmp96c141.cpp
+++ b/src/devices/cpu/tlcs900/tmp96c141.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:AJR
+// copyright-holders:AJR, Felipe Sanches
 /****************************************************************************
 
     Toshiba TMP96C141 microcontroller
@@ -12,7 +12,7 @@
 
 #include "emu.h"
 #include "tmp96c141.h"
-
+#include "dasm900.h"
 
 //**************************************************************************
 //  GLOBAL VARIABLES
@@ -194,4 +194,29 @@ void tmp96c141_device::tlcs900_handle_timers()
 
 void tmp96c141_device::execute_set_input(int inputnum, int state)
 {
+}
+
+std::pair<u16, char const *> const tmp96c141_syms[] = {
+	{ 0x00, "P0" }, { 0x01, "P1" }, { 0x02, "P0CR" },
+	{ 0x04, "P1CR" }, { 0x05, "P1FC" }, { 0x06, "P2" }, { 0x07, "P3" },
+	{ 0x08, "P2CR" }, { 0x09, "P2FC" }, { 0x0a, "P3CR" }, { 0x0b, "P3FC" }, { 0x0c, "P4" }, { 0x0d, "P5" }, { 0x0e, "P4CR" },
+	{ 0x10, "P4FC" }, { 0x12, "P6" }, { 0x13, "P7" }, { 0x14, "P6CR" }, { 0x15, "P7CR" }, { 0x16, "P6FC" }, { 0x17, "P7FC" },
+	{ 0x18, "P8" }, { 0x19, "P9" }, { 0x1a, "P8CR" }, { 0x1b, "P9CR" }, { 0x1c, "P8FC" }, { 0x1d, "P9FC" },
+	{ 0x20, "TRUN" }, { 0x22, "TREG0" }, { 0x23, "TREG1" }, { 0x24, "TMOD" }, { 0x25, "TFFCR" }, { 0x26, "TREG2" }, { 0x27, "TREG3" },
+	{ 0x28, "P0MOD" }, { 0x29, "P1MOD" }, { 0x2a, "PFFCR" },
+	{ 0x30, "TREG4L" }, { 0x31, "TREG4H" }, { 0x32, "TREG5L" }, { 0x33, "TREG5H" }, { 0x34, "CAP1L" }, { 0x35, "CAP1H" }, { 0x36, "CAP2L" }, { 0x37, "CAP2H" },
+	{ 0x38, "T4MOD" }, { 0x39, "T4FFCR" }, { 0x3a, "T45CR" },
+	{ 0x40, "TREG6L" }, { 0x41, "TREG6H" }, { 0x42, "TREG7L" }, { 0x43, "TREG7H" }, { 0x44, "CAP3L" }, { 0x45, "CAP3H" }, { 0x46, "CAP4L" }, { 0x47, "CAP4H" },
+	{ 0x48, "T5MOD" }, { 0x49, "T5FFCR" }, { 0x4c, "PG0REG" }, { 0x4d, "PG1REG" }, { 0x4e, "PG01CR" },
+	{ 0x50, "SC0BUF" }, { 0x51, "SC0CR" }, { 0x52, "SC0MOD" }, { 0x53, "BR0CR" }, { 0x54, "SC1BUF" }, { 0x55, "SC1CR" }, { 0x56, "SC1MOD" }, { 0x57, "BR1CR" },
+	{ 0x58, "ODE" }, { 0x5c, "WDMOD" }, { 0x5d, "WDCR" }, { 0x5e, "ADMOD" },
+	{ 0x60, "ADREG0L" }, { 0x61, "ADREG0H" }, { 0x62, "ADREG1L" }, { 0x63, "ADREG1H" }, { 0x64, "ADREG2L" }, { 0x65, "ADREG2H" }, { 0x66, "ADREG3L" }, { 0x67, "ADREG3H" },
+	{ 0x68, "B0CS" }, { 0x69, "B1CS" }, { 0x6a, "B2CS" },
+	{ 0x70, "INTE0AD" }, { 0x71, "INTE45" }, { 0x72, "INTE67" }, { 0x73, "INTET10" }, { 0x74, "INTEPW10" }, { 0x75, "INTET54" }, { 0x76, "INTET76" }, { 0x77, "INTES0" },
+	{ 0x78, "INTES1" }, { 0x7b, "IIMC" }, { 0x7c, "DMA0V" }, { 0x7d, "DMA1V" }, { 0x7e, "DMA2V" }, { 0x7f, "DMA3V"}
+};
+
+std::unique_ptr<util::disasm_interface> tmp96c141_device::create_disassembler()
+{
+	return std::make_unique<tmp96c141_disassembler>(tmp96c141_syms);
 }

--- a/src/devices/cpu/tlcs900/tmp96c141.h
+++ b/src/devices/cpu/tlcs900/tmp96c141.h
@@ -88,6 +88,9 @@ protected:
 	virtual void tlcs900_handle_ad() override;
 	virtual void tlcs900_handle_timers() override;
 
+	// device_disasm_interface overrides
+	virtual std::unique_ptr<util::disasm_interface> create_disassembler() override;
+
 private:
 	void internal_mem(address_map &map) ATTR_COLD;
 };


### PR DESCRIPTION
TMP95C061, TMP95C063 and TMP96C141

(follow-up to PR #14181)