### PR TITLE
Add skeleton driver for Sun E250

### DIFF
--- a/hash/sun_sparc.xml
+++ b/hash/sun_sparc.xml
@@ -6,7 +6,7 @@ license:CC0-1.0
 <softwarelist name="sun_sparc" description="Sun Microsystems SPARC software">
 
 	<!-- Dumped from original Sun CDs with a Plextor and without any reading or C2 error -->
-	<software name="sol8_10-10_sparc" supported="no">
+	<software name="sol8_10_10_sparc" supported="no">
 		<description>Solaris 8 10-00 Media - SPARC Platform Edition for Sun Computer Systems</description>
 		<year>2000</year>
 		<publisher>Sun Microsystems</publisher>

--- a/hash/sun_sparc.xml
+++ b/hash/sun_sparc.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<!--
+license:CC0-1.0
+-->
+<softwarelist name="sun_sparc" description="Sun Microsystems SPARC software">
+
+	<!-- Dumped from original Sun CDs with a Plextor and without any reading or C2 error -->
+	<software name="sol8_10-10_sparc" supported="no">
+		<description>Solaris 8 10-00 Media - SPARC Platform Edition for Sun Computer Systems</description>
+		<year>2000</year>
+		<publisher>Sun Microsystems</publisher>
+		<part name="cdrom1" interface="cdrom">
+			<feature name="part_id" value="Solaris 8 Installation - SPARC Platform Edition for Sun Computer Systems 10-00 Revision A"/>
+			<diskarea name="cdrom">
+				<disk name="solaris_8_installation_10-00.chd" sha1="c2a783c4a90928eb5e75f031058b15d2516ad609" />
+			</diskarea>
+		</part>
+		<part name="cdrom2" interface="cdrom">
+			<feature name="part_id" value="Solaris 8 Software - SPARC Platform Edition 10-00 Revision A - 1 of 2"/>
+			<diskarea name="cdrom">
+				<disk name="solaris_8_software_10-00_1_of_2.chd" sha1="dabf63ce5b91873da57590d781eb2d33f3f90749" />
+			</diskarea>
+		</part>
+		<part name="cdrom3" interface="cdrom">
+			<feature name="part_id" value="Solaris 8 Software - SPARC Platform Edition 10-00 Revision A - 2 of 2"/>
+			<diskarea name="cdrom">
+				<disk name="solaris_8_software_10-00_2_of_2.chd" sha1="984c8a2d2896fce5f54d735b01d3e0ef7da7c6db" />
+			</diskarea>
+		</part>
+		<part name="cdrom4" interface="cdrom">
+			<feature name="part_id" value="Solaris 8 Maintenance Update 2 And Installation Guide - SPARC Platform Edition 10-00 Revision A"/>
+			<diskarea name="cdrom">
+				<disk name="solaris_8_maintenance_update_2_and_installation_guide_10-00.chd" sha1="4d6ed28882a02579384bb63850539e77c1283030" />
+			</diskarea>
+		</part>
+		<part name="cdrom5" interface="cdrom">
+			<feature name="part_id" value="Solaris 8 Software Supplement - SPARC Platform Edition for Sun Computer Systems 10-00 Revision A"/>
+			<diskarea name="cdrom">
+				<disk name="solaris_8_software_supplement_10-00.chd" sha1="75d8645b7b6840587d37bb1fb7b50085f46d1491" />
+			</diskarea>
+		</part>
+		<part name="cdrom6" interface="cdrom">
+			<feature name="part_id" value="Solaris 8 Documentation - SPARC / Intel PLatform Edition 10-00 Revision A"/>
+			<diskarea name="cdrom">
+				<disk name="solaris_8_documentation_10-00.chd" sha1="56010878650de07a6a844b7ffe2d7b02dd0dcc1a" />
+			</diskarea>
+		</part>
+		<part name="cdrom7" interface="cdrom">
+			<feature name="part_id" value="Flash PROM Update Multimedia Answerbook - SPARC Platform Edition for Sun Computer Systems 10-00 Revision A"/>
+			<diskarea name="cdrom">
+				<disk name="flash_prom_update_multimedia_answerbook_10-00.chd" sha1="2190acf740279dec20be16a5703adc1b6915854f" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Dumped from original Sun CD with a Plextor and without any reading or C2 error -->
+	<software name="smc_2_1_2" supported="no">
+		<description>Sun Management Center 2.1.1 - February 2000 Revision A</description>
+		<year>2000</year>
+		<publisher>Sun Microsystems</publisher>
+		<part name="cdrom1" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="sun_management_center_2_1_1.chd" sha1="1a204a0f0ad3d7b34cf577e3d5242eb4f036fb2e" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Dumped from original Sun CD with a Plextor and without any reading or C2 error -->
+	<software name="sunsol_vol1_2000" supported="no">
+		<description>SunSolutions CD Volume 1 2000</description>
+		<year>2000</year>
+		<publisher>Sun Microsystems</publisher>
+		<part name="cdrom1" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="sunsolutions_2000_vol_1.chd" sha1="b3b529ba4bc7aa63e58bf99daf1efdfef28762c8" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Dumped from original CD with a Plextor and without any reading or C2 error -->
+	<software name="raptorgfx_2_1" supported="no">
+		<description>Raptor GFX Open Windows for Solaris - Version 2.1</description>
+		<year>1999</year>
+		<publisher>Tech Source Inc.</publisher>
+		<part name="cdrom1" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="raptor_gfx_openwindows_for_solaris.chd" sha1="c6e79c454561eb1735bae77058651fcb2a242a05" />
+			</diskarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -44625,6 +44625,9 @@ sothello
 @source:success/tonton.cpp
 tonton
 
+@source:sun/e250.cpp
+e250
+
 @source:sun/sun1.cpp
 sun1
 

--- a/src/mame/sun/e250.cpp
+++ b/src/mame/sun/e250.cpp
@@ -1,0 +1,94 @@
+// license:BSD-3-Clause
+// copyright-holders:
+
+/***********************************************************************************************************
+Skeleton driver for Sun Microsystems Enterprise 250 Server.
+
+Hardware info about Enterprise 250 Server:
+ -Dual 250, 300 or 400 MHz UltraSPARC II with onboard e-cache.
+ -1-MB external cache per processor with 250-MHz CPU or 2-MB per processor with 300 or 400 MHz CPU.
+ -16 DIMM slots, four banks of four slots. 128 MB to 2 GB total memory capacity.
+ -Four full-size slots compliant with PCI specification version 2.1:
+    One slot operating at 33- or 66-MHz, 32- or 64-bit data bus width, 3.3 volt
+    Three slots operating at 33 MHz, 32- or 64-bit data bus width, 5 volt
+ -One 40MB/sec, 68-pin, Ultra SCSI (SCSI-3), 2 channels (synchronous).
+ -Two RS-232D/RS423 serial ports (DB25).
+
+Main components found on its main PCB:
+ -LSI LSA0009 LSI53C876 PCI to Dual Channel SCSI Multifunction Controller.
+ -Sun Microsystems STP2223BGA (PN 100-4611-05) UPA to PCI Interface.
+ -Motorola XPC823ZT66B2 RISC Microprocessor, 32-Bit, 66MHz.
+ -SMSC LAN91C96 Non-PCI Single-Chip Ethernet Controller.
+ -Synergy SY100E11LEJC.
+ -Infineon SAB82532N 10 multiprotocol data communication controller with two symmetrical serial channels.
+ -Sun Microsystems STP2210QFP (PN 100-3988-01) Uniprocessor System Controller (USC).
+ -National Semiconductor ES0012BG DP83840AVCE-1.
+ -National Semiconductor NS0052AJ PC87332VLJ SuperI/O III.
+ -Sun Microsystems STP2003QFP (PN 100-4183-05) LAN Node Controller.
+ -Sun Microsystems STP2202ABGA (ON 100-4671-02).
+ -National Semiconductor ES00116AD DP83223V.
+ -Analog Devices ADM5180JP.
+ -Motorola MC12439.
+
+***********************************************************************************************************/
+
+#include "emu.h"
+
+#include "cpu/powerpc/ppc.h"
+#include "cpu/sparc/sparc.h"
+
+#include "softlist_dev.h"
+
+
+namespace {
+
+class e250_state : public driver_device
+{
+public:
+	e250_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_subcpu(*this, "subcpu")
+
+	{ }
+
+	void e250(machine_config &config);
+
+private:
+	required_device<cpu_device> m_maincpu;
+	required_device<cpu_device> m_subcpu;
+};
+
+
+static INPUT_PORTS_START(e250)
+INPUT_PORTS_END
+
+void e250_state::e250(machine_config &config)
+{
+	SPARCV8(config, m_maincpu, 20'000'000); // Actually a UltraSPARC II 250, 300 or 400 MHz
+	//SPARCV8(config, m_maincpu, 20'000'000); // Actually a UltraSPARC II 250, 300 or 400 MHz (optional 2nd CPU)
+
+	// For management console
+	MPC8240(config, m_subcpu, XTAL(66'000'000)); // Actually a Motorola XPC823ZT66B2
+
+	SOFTWARE_LIST(config, "sun_sparc").set_original("sun_sparc");
+}
+
+
+ROM_START(e250)
+	ROM_REGION(0x400000, "maincpu", 0)
+	ROM_LOAD( "525-1718-15_a30250_e28f008sa.u2703", 0x000000, 0x100000, CRC(293ac969) SHA1(88fa0c2607bd68bbb209fc8242efeaba60956daa) )
+
+	ROM_REGION(0x400000, "subcpu", 0)
+	ROM_LOAD( "525-1724-08_a29898_e28f008sa.u4401", 0x000000, 0x100000, CRC(567fcc56) SHA1(c6a26b34f61559ec49119eed258666318d551378) ) // VxWorks for management console
+
+	ROM_REGION(0x021000, "nvram", 0)
+	ROM_LOAD( "525-1726-02_stm48t59y-70p10.u2706",  0x000000, 0x002000, CRC(adc6696f) SHA1(97e4d4709ba739e8adbe5298175d38e826c0321f) ) // Seems to contain passwords
+
+	ROM_REGION(0x008000, "seeprom", 0)
+	ROM_LOAD( "24c02n.u4402",                       0x000000, 0x000100, CRC(e98dd85c) SHA1(014e89081945a6c16e1498a2f10604ce64048ae6) )
+ROM_END
+
+} // anonymous namespace
+
+COMP( 1998, e250, 0, 0, e250, e250, e250_state, empty_init, "Sun Microsystems", "Enterprise 250", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/sun/e250.cpp
+++ b/src/mame/sun/e250.cpp
@@ -83,10 +83,10 @@ ROM_START(e250)
 	ROM_LOAD( "525-1724-08_a29898_e28f008sa.u4401", 0x000000, 0x100000, CRC(567fcc56) SHA1(c6a26b34f61559ec49119eed258666318d551378) ) // VxWorks for management console
 
 	ROM_REGION(0x021000, "nvram", 0)
-	ROM_LOAD( "525-1726-02_stm48t59y-70p10.u2706",  0x000000, 0x002000, CRC(adc6696f) SHA1(97e4d4709ba739e8adbe5298175d38e826c0321f) ) // Seems to contain passwords
+	ROM_LOAD( "525-1726-02_stm48t59y-70p10.u2706",  0x000000, 0x002000, CRC(adc6696f) SHA1(97e4d4709ba739e8adbe5298175d38e826c0321f) )
 
 	ROM_REGION(0x008000, "seeprom", 0)
-	ROM_LOAD( "24c02n.u4402",                       0x000000, 0x000100, CRC(e98dd85c) SHA1(014e89081945a6c16e1498a2f10604ce64048ae6) )
+	ROM_LOAD( "24c02n.u4402",                       0x000000, 0x000100, CRC(e98dd85c) SHA1(014e89081945a6c16e1498a2f10604ce64048ae6) ) // Seems to contain passwords
 ROM_END
 
 } // anonymous namespace


### PR DESCRIPTION
New systems marked not working
------------------------------
Enterprise 250 [ClawGrip, ArcadeHacker]

New software list items marked not working
------------------------------------------
Solaris 8 10-00 Media - SPARC Platform Edition for Sun Computer Systems [ClawGrip]
Sun Management Center 2.1.1 - February 2000 Revision A [ClawGrip]
SunSolutions CD Volume 1 2000 [ClawGrip]
Raptor GFX Open Windows for Solaris - Version 2.1 [ClawGrip]
