### PR TITLE
qbus: add bus error and BEVENT (periodic timer) callbacks.

### DIFF
--- a/src/devices/bus/qbus/dvk_kgd.h
+++ b/src/devices/bus/qbus/dvk_kgd.h
@@ -46,6 +46,8 @@ protected:
 	virtual void device_reset() override ATTR_COLD;
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 
+	bool m_installed;
+
 	required_device<screen_device> m_screen;
 
 private:

--- a/src/devices/bus/qbus/dvk_mx.h
+++ b/src/devices/bus/qbus/dvk_mx.h
@@ -126,6 +126,8 @@ private:
 
 	required_device_array<floppy_connector, 4> m_connectors;
 
+	bool m_installed;
+
 	uint16_t m_mxcs;
 	uint16_t m_rbuf;
 	uint16_t m_wbuf;

--- a/src/devices/bus/qbus/pc11.h
+++ b/src/devices/bus/qbus/pc11.h
@@ -59,6 +59,7 @@ protected:
 	TIMER_CALLBACK_MEMBER(read_tick);
 
 private:
+	bool m_installed;
 	int m_rxvec;
 	int m_txvec;
 

--- a/src/devices/bus/qbus/qbus.cpp
+++ b/src/devices/bus/qbus/qbus.cpp
@@ -98,6 +98,8 @@ qbus_device::qbus_device(const machine_config &mconfig, const char *tag, device_
 	device_z80daisy_interface(mconfig, *this),
 	m_program_config("a18", ENDIANNESS_BIG, 16, 16, 0, address_map_constructor()),
 	m_space(*this, finder_base::DUMMY_TAG, -1),
+	m_out_bus_error_cb(*this),
+	m_out_bevnt_cb(*this),
 	m_out_birq4_cb(*this),
 	m_out_birq5_cb(*this),
 	m_out_birq6_cb(*this),
@@ -124,6 +126,7 @@ device_memory_interface::space_config_vector qbus_device::memory_space_config() 
 
 void qbus_device::device_start()
 {
+	m_view = nullptr;
 }
 
 
@@ -156,7 +159,10 @@ void qbus_device::add_card(device_qbus_card_interface &card)
 
 void qbus_device::install_device(offs_t start, offs_t end, read16sm_delegate rhandler, write16sm_delegate whandler, uint32_t mask)
 {
-	m_space->install_readwrite_handler(start, end, rhandler, whandler, mask);
+	if (m_view)
+		m_view->install_readwrite_handler(start, end, rhandler, whandler, mask);
+	else
+		m_space->install_readwrite_handler(start, end, rhandler, whandler, mask);
 }
 
 

--- a/src/devices/bus/qbus/qbus.h
+++ b/src/devices/bus/qbus/qbus.h
@@ -71,10 +71,14 @@ public:
 
 	// inline configuration
 	template <typename T> void set_space(T &&tag, int spacenum) { m_space.set_tag(std::forward<T>(tag), spacenum); }
+	void set_view(memory_view::memory_view_entry &view) { m_view = &view; };
 
 	virtual space_config_vector memory_space_config() const override;
 	address_space &program_space() const { return *m_space; }
 
+	auto bus_error_callback() { return m_out_bus_error_cb.bind(); }
+
+	auto bevnt() { return m_out_bevnt_cb.bind(); }
 	auto birq4() { return m_out_birq4_cb.bind(); }
 	auto birq5() { return m_out_birq6_cb.bind(); }
 	auto birq6() { return m_out_birq6_cb.bind(); }
@@ -84,7 +88,9 @@ public:
 	void install_device(offs_t start, offs_t end, read16sm_delegate rhandler, write16sm_delegate whandler, uint32_t mask=0xffffffff);
 
 	void init_w();
+	void bus_error_w(int state) { m_out_bus_error_cb(state); }
 
+	void bevnt_w(int state) { m_out_bevnt_cb(state); }
 	void birq4_w(int state) { m_out_birq4_cb(state); }
 	void birq5_w(int state) { m_out_birq5_cb(state); }
 	void birq6_w(int state) { m_out_birq6_cb(state); }
@@ -106,10 +112,14 @@ protected:
 
 	// internal state
 	required_address_space m_space;
+	memory_view::memory_view_entry *m_view;
 
 private:
 	using card_vector = std::vector<std::reference_wrapper<device_qbus_card_interface> >;
 
+	devcb_write_line m_out_bus_error_cb;
+
+	devcb_write_line m_out_bevnt_cb;
 	devcb_write_line m_out_birq4_cb;
 	devcb_write_line m_out_birq5_cb;
 	devcb_write_line m_out_birq6_cb;


### PR DESCRIPTION
Support systems with entire memory space covered by a view (uknc) -- views are not initialized at device_start() time.

Correct initial state of PC11 device.