### PR TITLE
ec1841: support quad density floppies as an option.

### DIFF
--- a/src/devices/bus/isa/fdc.cpp
+++ b/src/devices/bus/isa/fdc.cpp
@@ -29,6 +29,12 @@ static void pc_dd_floppies(device_slot_interface &device)
 	device.option_add("35dd", FLOPPY_35_DD);
 }
 
+static void pc_qd_floppies(device_slot_interface &device)
+{
+	device.option_add("525dd", FLOPPY_525_DD);
+	device.option_add("525qd", FLOPPY_525_QD);
+}
+
 static void pc_hd_floppies(device_slot_interface &device)
 {
 	device.option_add("525hd", FLOPPY_525_HD);
@@ -332,6 +338,8 @@ void isa8_ec1841_0003_device::aux_irq_w(int state)
 void isa8_ec1841_0003_device::device_add_mconfig(machine_config &config)
 {
 	isa8_fdc_xt_device::device_add_mconfig(config);
+	FLOPPY_CONNECTOR(config.replace(), "fdc:0", pc_qd_floppies, "525dd", isa8_fdc_device::floppy_formats).enable_sound(true);
+	FLOPPY_CONNECTOR(config.replace(), "fdc:1", pc_qd_floppies, "525dd", isa8_fdc_device::floppy_formats).enable_sound(true);
 
 	BUS_MOUSE(config, "bus_mouse", 0).extint_callback().set(FUNC(isa8_ec1841_0003_device::aux_irq_w));
 }

--- a/src/devices/bus/isa/hdc.cpp
+++ b/src/devices/bus/isa/hdc.cpp
@@ -145,7 +145,7 @@ static INPUT_PORTS_START( isa_hdc )
 INPUT_PORTS_END
 
 DEFINE_DEVICE_TYPE(XT_HDC,     xt_hdc_device, "xt_hdc", "Generic PC-XT Fixed Disk Controller")
-DEFINE_DEVICE_TYPE(EC1841_HDC, ec1841_device, "ec1481", "EX1841 Fixed Disk Controller")
+DEFINE_DEVICE_TYPE(EC1841_HDC, ec1841_device, "ec1841_hdc", "EC1841 Fixed Disk Controller")
 DEFINE_DEVICE_TYPE(ST11M_HDC,  st11m_device,  "st11m",  "Seagate ST11M Fixed Disk Controller")
 
 xt_hdc_device::xt_hdc_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :

--- a/src/devices/bus/isa/hdc.h
+++ b/src/devices/bus/isa/hdc.h
@@ -179,6 +179,7 @@ public:
 protected:
 	// optional information overrides
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
+	virtual const tiny_rom_entry *device_rom_region() const override ATTR_COLD { return nullptr; }
 
 	required_device<ec1841_device> m_hdc;
 };


### PR DESCRIPTION
Disable option ROM on fixed disk controller (onboard BIOS has built-in support).