### PR TITLE
sega/model2.cpp: TGP math lookup table logic, fixes MT09265

### DIFF
--- a/src/mame/sega/model2.cpp
+++ b/src/mame/sega/model2.cpp
@@ -519,9 +519,9 @@ u32 model2_tgp_state::copro_inv_r(offs_t offset)
 	u32 result = m_copro_tgp_tables[index | 0x8000];
 	u8 bexp = (m_copro_inv_base >> 23) & 0xff;
 	u8 exp = (result >> 23) + (0x7f - bexp);
-	result = (result & 0x807fffff) | (exp << 23);
-	if(m_copro_inv_base & 0x80000000)
-		result ^= 0x80000000;
+	result = (result & 0x007fffff) | (exp << 23);
+	if (m_copro_inv_base & 0x80000000 && offset)
+		result |= 0x80000000;
 	return result;
 }
 
@@ -607,9 +607,6 @@ void model2_tgp_state::copro_fifo_w(u32 data)
 	}
 	else
 		m_copro_fifo_in->push(u32(data));
-
-	// 1 wait state for i960; prevents Manx TT course select rotation bug
-	m_maincpu->spin_until_time(attotime::from_nsec(40));
 }
 
 


### PR DESCRIPTION
Testing is required to determine whether Model 1 requires the same adjustment.

Also remove wait state when writing to copro FIFO, since this no longer needed since commit 7d06354.