### PR TITLE
commandline-all.rst: typo fix, local_commport and remote_commport default values 15122 -> 15112

### DIFF
--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -3847,7 +3847,7 @@ Core Communication Options
     Local port to bind to. This can be any traditional communications port as
     an unsigned 16-bit integer (0-65535).
 
-    The default value is ``15122``.
+    The default value is ``15112``.
 
     Example:
         .. code-block:: bash
@@ -3876,7 +3876,7 @@ Core Communication Options
     Remote port to connect to. This can be any traditional communications port
     as an unsigned 16-bit integer (0-65535).
 
-    The default value is "``15122``".
+    The default value is "``15112``".
 
     Example:
         .. code-block:: bash


### PR DESCRIPTION
This fixes a typo in the documentation for the `local_localport` and `comm_remoteport` flags.

The default value in [the code](https://github.com/mamedev/mame/blob/master/src/emu/emuopts.cpp#L192) is 15112.
