### PR TITLE
Faster winhybrid

### DIFF
--- a/scripts/src/osd/windows.lua
+++ b/scripts/src/osd/windows.lua
@@ -36,6 +36,7 @@ function maintargetosdoptions(_target,_subtarget)
 		"psapi",
 		"shlwapi",
 		"uuid",
+		"setupapi"
 	}
 end
 

--- a/src/osd/modules/input/input_winhybrid.cpp
+++ b/src/osd/modules/input/input_winhybrid.cpp
@@ -17,7 +17,6 @@
 #include <oleauto.h>
 
 #include <setupapi.h>
-#pragma comment(lib, "setupapi.lib")
 
 namespace osd {
 

--- a/src/osd/modules/input/input_winhybrid.cpp
+++ b/src/osd/modules/input/input_winhybrid.cpp
@@ -93,6 +93,7 @@ public:
 		
 		HRESULT result = get_xinput_devices(xinput_deviceids);
 		if (result != 0)
+		{
 			xinput_detect_failed = true;
 			xinput_deviceids.clear();
 			osd_printf_warning("XInput device detection failed. XInput won't be used. Error: 0x%X\n", uint32_t(result));

--- a/src/osd/modules/input/input_winhybrid.cpp
+++ b/src/osd/modules/input/input_winhybrid.cpp
@@ -203,7 +203,7 @@ private:
 
 	//-----------------------------------------------------------------------------
 	// Enum each present PNP device in device information set using setupapi 
-	// and check each device ID to see if it contains
+	// and check each device ID  to see if it contains
 	// "IG_" (ex. "VID_045E&PID_028E&IG_00").  If it does, then it's an XInput device
 	// Unfortunately this information can not be found by just using DirectInput.
 	// Checking against a VID/PID of 0x028E/0x045E won't find 3rd party or future
@@ -227,7 +227,7 @@ private:
 			{
 				// Check if the device ID contains "IG_".  If it does, then it's an XInput device
 				// Unfortunately this information can not be found by just using DirectInput
-				// If it does, then get the VID/PID
+				// If it does, then get the VID/PID as DWORD numbers
 				DWORD dwVid = 0;
 				DWORD dwPid = 0;
 				if (wcsstr(strDeviceID, L"IG_") &&

--- a/src/osd/modules/input/input_winhybrid.cpp
+++ b/src/osd/modules/input/input_winhybrid.cpp
@@ -218,7 +218,7 @@ private:
 			osd_printf_error("SetupDiGetClassDevs failed.\n");
 			return HRESULT_FROM_WIN32(GetLastError());
 		}
-		SP_DEVINFO_DATA devInfoData = {sizeof(SP_DEVINFO_DATA), 0, 0};
+		SP_DEVINFO_DATA devInfoData = {sizeof(SP_DEVINFO_DATA)};
 		DWORD devIndex = 0;
 		while (SetupDiEnumDeviceInfo(devInfoSet, devIndex, &devInfoData)) 
 		{


### PR DESCRIPTION
I've observed slow startups of Mame on my Windows machine, and I narrowed it down to the inefficient API use in src/osd/modules/input/input_winhybrid.cpp 

Specifically, it uses WMI which, as configured, starts a new process for a "WMI server", and I concluded it is the cause of multiple seconds delay.

I rewrote that code to use setupapi, which is a supported API, just with much less overhead. I verified that the lists of the iterated devices are identical in both cases (using WMI and my setupapi iteration) on my machine.

The changes are:

1) adding the linkage to the setupapi in `scripts/src/osd/windows.lua`

2) calling the API functions from setupapi which avoid the overheads which made these long "100% CPU, nothing can be done" delays.

The multiple commits are accidental, as I've fixed the build problems. Only two files changed in a single commit describes the changes correctly: it's just **speeding up winhybrid enumeration of the device IDs**.

The speedup of the startup on Windows is more than obvious on my machine (running Windows 8.1 Professional).

The picture shows the CPU usage without the fix and with it. During all the time of high CPU usage (almost 10 seconds without the fix on my machine) the mouse cursor spins and user just waits, seeing nothing and unable to do anything.

<img width="1101" height="479" alt="mame-faster-winhybrid" src="https://github.com/user-attachments/assets/82624dbb-6a4e-4b1f-a321-1b2997bd526c" />
