### PR TITLE
Update frontends.rst link to IV/Play + description overhaul

### DIFF
--- a/docs/source/usingmame/frontends.rst
+++ b/docs/source/usingmame/frontends.rst
@@ -28,9 +28,10 @@ starting point.
     tightly and effectively replace MAME’s internal user interface.  It has
     many useful features for home computer emulation.  Written in C++, the
     `source code is on GitHub <https://github.com/npwoods/bletchmame>`__.
-`IV/Play <http://www.mameui.info/>`__ (Microsoft Windows)
-    A simple Windows program for launching systems in MAME.  Written in C#, the
-    `source code is on GitHub <https://github.com/Mataniko/IV-Play>`__.
+`IV/Play <https://john-iv.github.io/iv-play/>`__ (Microsoft Windows)
+    A fast, keyboard-driven, DirectX-accelerated launcher for MAME. IV/Play 
+    features a flexible filtering system, integrated browsing and launching
+    for software lists, and a highly customizable interface. Written in C#.
 `Emu Loader <http://emuloader.mameworld.info/>`__ (Microsoft Windows)
     Emu Loader provides a Windows interface for launching systems in multiple
     emulators, including MAME, Supermodel and DEMUL.  Written in Delphi Pascal,


### PR DESCRIPTION
Remove dead links to prior IV/Play repo and sun setted homepage.  Updated description.