### PR TITLE
Prevent NTSC/PAL NES from loading Basic carts

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -11837,7 +11837,8 @@ license:CC0-1.0
 		<info name="serial" value="HVC-BS"/>
 		<info name="release" value="19840621"/>
 		<info name="alt_title" value="ファミリーベーシック"/>
-		<sharedfeat name="exp_default" value="fc_keyboard"/>
+		<sharedfeat name="compatibility" value="fbasic" />
+		<sharedfeat name="exp_default" value="fc_keyboard" />
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="hvc_basic" />
 			<feature name="pcb_model" value="FB-R-128-01" />
@@ -11863,7 +11864,8 @@ license:CC0-1.0
 		<info name="serial" value="HVC-BS"/>
 		<info name="release" value="19840621"/>
 		<info name="alt_title" value="ファミリーベーシック"/>
-		<sharedfeat name="exp_default" value="fc_keyboard"/>
+		<sharedfeat name="compatibility" value="fbasic" />
+		<sharedfeat name="exp_default" value="fc_keyboard" />
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="hvc_basic" />
 			<feature name="pcb_model" value="FB-N-128-02" />
@@ -11889,7 +11891,8 @@ license:CC0-1.0
 		<info name="serial" value="HVC-VT"/>
 		<info name="release" value="19850221"/>
 		<info name="alt_title" value="ファミリーベーシックV3"/>
-		<sharedfeat name="exp_default" value="fc_keyboard"/>
+		<sharedfeat name="compatibility" value="fbasic" />
+		<sharedfeat name="exp_default" value="fc_keyboard" />
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="hvc_basic" />
 			<feature name="pcb_model" value="VT-N-256-41" />
@@ -44345,7 +44348,8 @@ We should eventually add it to MAME as a separate driver with a NES CPU and a GB
 		<description>Playbox BASIC (Japan, V1.0)</description>
 		<year>198?</year>
 		<publisher>Nintendo / Hudson Soft / Sharp</publisher>
-		<sharedfeat name="exp_default" value="fc_keyboard"/>
+		<sharedfeat name="compatibility" value="fbasic" />
+		<sharedfeat name="exp_default" value="fc_keyboard" />
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="hvc_basic" />
 			<feature name="mirroring" value="vertical" />
@@ -44366,7 +44370,8 @@ We should eventually add it to MAME as a separate driver with a NES CPU and a GB
 		<description>Playbox BASIC (Japan, V0.0)</description>
 		<year>198?</year>
 		<publisher>Nintendo / Hudson Soft / Sharp</publisher>
-		<sharedfeat name="exp_default" value="fc_keyboard"/>
+		<sharedfeat name="compatibility" value="fbasic" />
+		<sharedfeat name="exp_default" value="fc_keyboard" />
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="hvc_basic" />
 			<feature name="pcb" value="HVC-FAMILYBASIC" />
@@ -46849,7 +46854,8 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<info name="serial" value="HVC-BS"/>
 		<info name="release" value="19840621"/>
 		<info name="alt_title" value="ファミリーベーシック"/>
-		<sharedfeat name="exp_default" value="fc_keyboard"/>
+		<sharedfeat name="compatibility" value="fbasic" />
+		<sharedfeat name="exp_default" value="fc_keyboard" />
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="hvc_basic" />
 			<feature name="pcb_model" value="FB-R-128-01" />

--- a/src/mame/nintendo/nes.cpp
+++ b/src/mame/nintendo/nes.cpp
@@ -436,7 +436,7 @@ void nes_state::nes(machine_config &config)
 	NES_CONTROL_PORT(config, m_special, nes_control_special_devices, nullptr).set_screen_tag(m_screen);
 
 	NES_CART_SLOT(config, m_cartslot, NTSC_APU_CLOCK, nes_cart, nullptr).set_must_be_loaded(true);
-	SOFTWARE_LIST(config, "cart_list").set_original("nes");
+	SOFTWARE_LIST(config, "cart_list").set_original("nes").set_filter("!fbasic");
 	SOFTWARE_LIST(config, "ade_list").set_original("nes_ade");         // Camerica/Codemasters Aladdin Deck Enhancer mini-carts
 	SOFTWARE_LIST(config, "ntb_list").set_original("nes_ntbrom");      // Sunsoft Nantettate! Baseball mini-carts
 	SOFTWARE_LIST(config, "kstudio_list").set_original("nes_kstudio"); // Bandai Karaoke Studio expansion carts
@@ -473,6 +473,7 @@ void nes_state::famicom(machine_config &config)
 	NES_CONTROL_PORT(config.replace(), m_ctrl2, fc_control_port2_devices, "joypad").set_screen_tag(m_screen);
 	NES_CONTROL_PORT(config, m_exp, fc_expansion_devices, nullptr).set_screen_tag(m_screen);
 
+	SOFTWARE_LIST(config.replace(), "cart_list").set_original("nes");
 	SOFTWARE_LIST(config, "flop_list").set_original("famicom_flop");
 	SOFTWARE_LIST(config, "cass_list").set_original("famicom_cass");
 }


### PR DESCRIPTION
This change prevents loading all variants of Family Basic carts on non-Japanese hardware. Since stock systems lack the expansion port to use the keyboard (and consequentially, the audio port for the tape deck), this renders them unusable and causes the same issues that were mentioned in MAMETesters bug 8443.