### PR TITLE
cpu/i960: Split check_irqs() into two separate functions; fixes MT08347

### DIFF
--- a/src/devices/cpu/i960/i960.h
+++ b/src/devices/cpu/i960/i960.h
@@ -176,7 +176,8 @@ private:
 	void execute_op(uint32_t opcode);
 	void execute_burst_stall_op(uint32_t opcode);
 	void take_interrupt(int vector, int lvl);
-	void check_irqs();
+	void check_immediate_irqs();
+	void check_pending_irqs();
 	void do_call(uint32_t adr, int type, uint32_t stack);
 	void do_ret_0();
 	void do_ret();


### PR DESCRIPTION
On the Intel 80960KB, pending interrupts are only checked at the following times ([source](http://bitsavers.informatik.uni-stuttgart.de/components/intel/i960/80960KB_Programmers_Reference_Manual_Mar88.pdf)):

- After returning from an interrupt
- While executing `modpc` if it causes the current priority to be lowered
- After receiving a test pending interrupts IAC message

If pending interrupts are checked during a memory test while it is writing to the same area as the interrupt table, it can result in a spurious IRQ with an invalid vector, ultimately causing MAME to crash when the i960 reads an invalid opcode. This is the cause of [MT08347](https://mametesters.org/view.php?id=8347).

To fix this, `check_irqs()` has been split into two functions: `check_immediate_irqs()` and `check_pending_irqs()`; the latter is now only called at the appropriate times.