### PR TITLE
machine/nmk112.cpp: Convert bank method into memory_bank_creator and address_space finders

### DIFF
--- a/src/devices/machine/nmk112.cpp
+++ b/src/devices/machine/nmk112.cpp
@@ -18,14 +18,11 @@ DEFINE_DEVICE_TYPE(NMK112, nmk112_device, "nmk112", "NMK112")
 
 nmk112_device::nmk112_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, NMK112, tag, owner, clock)
-	, m_samplebank{ {*this, "samplebank_0_%u", 0U}, {*this, "samplebank_1_%u", 0U} }
-	, m_tablebank{ {*this, "tablebank_0_%u", 0U}, {*this, "tablebank_1_%u", 0U} }
+	, m_samplebank{ { *this, "samplebank_0_%u", 0U }, { *this, "samplebank_1_%u", 0U } }
+	, m_tablebank{ { *this, "tablebank_0_%u", 0U }, { *this, "tablebank_1_%u", 0U } }
 	, m_rom(*this, { finder_base::DUMMY_TAG, finder_base::DUMMY_TAG })
-	, m_oki0_space(*this, finder_base::DUMMY_TAG, -1)
-	, m_oki1_space(*this, finder_base::DUMMY_TAG, -1)
 	, m_page_mask(0xff)
-	, m_current_bank{0}
-	, m_size{0}
+	, m_size{ 0, 0 }
 {
 }
 
@@ -35,40 +32,29 @@ nmk112_device::nmk112_device(const machine_config &mconfig, const char *tag, dev
 
 void nmk112_device::device_start()
 {
-	save_item(NAME(m_current_bank));
-
 	for (int c = 0; c < 2; c++)
 	{
 		if (m_rom[c])
 		{
-			const bool paged = is_paged(c);
 			m_size[c] = m_rom[c].bytes();
+
 			// bank slot configurations
 			for (int i = 0; i < 4; i++)
 			{
 				for (int b = 0; b < 256; b++)
 				{
-					m_samplebank[c][i]->configure_entry(b,
-						m_rom[c] + ((page_offset(c, i) + (b << 16)) % m_size[c]));
-					if (paged)
-						m_tablebank[c][i]->configure_entry(b,
-							m_rom[c] + (((i << 8) + (b << 16)) % m_size[c]));
+					if (m_samplebank[c][i])
+						m_samplebank[c][i]->configure_entry(b, &m_rom[c][(b << 16) % m_size[c]]);
+
+					if (m_tablebank[c][i])
+						m_tablebank[c][i]->configure_entry(b, &m_rom[c][((i << 8) + (b << 16)) % m_size[c]]);
 				}
-				m_samplebank[c][i]->set_entry(0);
-				if (paged)
+
+				if (m_samplebank[c][i])
+					m_samplebank[c][i]->set_entry(0);
+
+				if (m_tablebank[c][i])
 					m_tablebank[c][i]->set_entry(0);
-			}
-			// install banks
-			address_space *space = (c == 0) ? m_oki0_space : m_oki1_space;
-			if (space != nullptr)
-			{
-				space->unmap_read(0x00000, 0x3ffff);
-				for (int i = 0; i < 4; i++)
-				{
-					space->install_read_bank((i << 16) | page_offset(c, i), (i << 16) | 0xffff, m_samplebank[c][i]);
-					if (paged)
-						space->install_read_bank(i << 8, (i << 8) | 0xff, m_tablebank[c][i]);
-				}
 			}
 		}
 	}
@@ -80,26 +66,10 @@ void nmk112_device::device_start()
 
 void nmk112_device::device_reset()
 {
-	for (int i = 0; i < 8; i++)
-	{
-		m_current_bank[i] = 0;
-		do_bankswitch(i, m_current_bank[i]);
-	}
+	for (offs_t i = 0; i < 8; i++)
+		okibank_w(i, 0);
 }
 
-void nmk112_device::do_bankswitch(offs_t offset, uint8_t data)
-{
-	const int chip = BIT(offset, 2);
-	const int banknum = offset & 3;
-
-	m_current_bank[offset] = data;
-
-	if (m_size[chip] == 0) return;
-
-	m_samplebank[chip][banknum]->set_entry(data);
-	if (is_paged(chip))
-		m_tablebank[chip][banknum]->set_entry(data);
-}
 
 /*****************************************************************************
     DEVICE HANDLERS
@@ -107,12 +77,47 @@ void nmk112_device::do_bankswitch(offs_t offset, uint8_t data)
 
 void nmk112_device::okibank_w(offs_t offset, u8 data)
 {
-	if (m_current_bank[offset] != data)
-		do_bankswitch(offset, data);
+	const int chip = BIT(offset, 2);
+	const int banknum = offset & 3;
+
+	if (m_size[chip])
+	{
+		if (m_samplebank[chip][banknum])
+			m_samplebank[chip][banknum]->set_entry(data);
+
+		if (m_tablebank[chip][banknum])
+			m_tablebank[chip][banknum]->set_entry(data);
+	}
 }
 
-void nmk112_device::device_post_load()
+
+/*****************************************************************************
+    ADDRESS MAPS
+*****************************************************************************/
+
+void nmk112_device::oki0_map(address_map &map)
 {
-	for (int i = 0; i < 8; i++)
-		do_bankswitch(i, m_current_bank[i]);
+	oki_map(0, map);
+}
+
+void nmk112_device::oki1_map(address_map &map)
+{
+	oki_map(1, map);
+}
+
+void nmk112_device::oki_map(unsigned which, address_map &map)
+{
+	map(0x00000, 0x0ffff).bankr(m_samplebank[which][0]);
+	map(0x10000, 0x1ffff).bankr(m_samplebank[which][1]);
+	map(0x20000, 0x2ffff).bankr(m_samplebank[which][2]);
+	map(0x30000, 0x3ffff).bankr(m_samplebank[which][3]);
+
+	// these get installed over the top of the first bank if present
+	if (is_paged(which))
+	{
+		map(0x00000, 0x000ff).bankr(m_tablebank[which][0]);
+		map(0x00100, 0x001ff).bankr(m_tablebank[which][1]);
+		map(0x00200, 0x002ff).bankr(m_tablebank[which][2]);
+		map(0x00300, 0x003ff).bankr(m_tablebank[which][3]);
+	}
 }

--- a/src/devices/machine/nmk112.h
+++ b/src/devices/machine/nmk112.h
@@ -23,35 +23,31 @@ public:
 	// configuration
 	template <typename T> nmk112_device &set_rom0_tag(T &&tag) { m_rom[0].set_tag(std::forward<T>(tag)); return *this; }
 	template <typename T> nmk112_device &set_rom1_tag(T &&tag) { m_rom[1].set_tag(std::forward<T>(tag)); return *this; }
-	template <typename T> nmk112_device &set_oki0_space_tag(T &&tag) { m_oki0_space.set_tag(std::forward<T>(tag), 0); return *this; }
-	template <typename T> nmk112_device &set_oki1_space_tag(T &&tag) { m_oki1_space.set_tag(std::forward<T>(tag), 0); return *this; }
 	nmk112_device &set_page_mask(uint8_t mask) { m_page_mask = ~mask; return *this; }
 
 	void okibank_w(offs_t offset, u8 data);
 
+	void oki0_map(address_map &map) ATTR_COLD;
+	void oki1_map(address_map &map) ATTR_COLD;
+
 protected:
-	// device-level overrides
+	// device_t implementation
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
-	virtual void device_post_load() override;
 
 private:
-	void do_bankswitch(offs_t offset, uint8_t data);
-	bool is_paged(uint8_t chip) const { return (m_page_mask & (1 << chip)); }
-	uint32_t page_offset(uint8_t chip, uint8_t slot) const { return (is_paged(chip) && (slot == 0)) ? 0x400 : 0; }
+	bool is_paged(uint8_t chip) const { return BIT(m_page_mask, chip); }
 
-	memory_bank_array_creator<4> m_samplebank[2];
-	memory_bank_array_creator<4> m_tablebank[2];
+	void oki_map(unsigned which, address_map &map) ATTR_COLD;
+
+	optional_memory_bank_array<4> m_samplebank[2];
+	optional_memory_bank_array<4> m_tablebank[2];
 	optional_region_ptr_array<uint8_t, 2> m_rom;
-	optional_address_space m_oki0_space;
-	optional_address_space m_oki1_space;
 
 	// internal state
 
 	/* which chips have their sample address table divided into pages */
 	uint8_t m_page_mask;
-
-	uint8_t m_current_bank[8];
 
 	uint32_t m_size[2];
 };

--- a/src/mame/atlus/cave.cpp
+++ b/src/mame/atlus/cave.cpp
@@ -938,6 +938,25 @@ void ppsatan_state::ppsatan_map(address_map &map)
 
 
 /***************************************************************************
+
+
+                            Memory Maps - Oki sound
+
+
+***************************************************************************/
+
+void cave_state::nmk112_oki0_map(address_map &map)
+{
+	map(0x00000, 0x3ffff).m("nmk112", FUNC(nmk112_device::oki0_map));
+}
+
+void cave_state::nmk112_oki1_map(address_map &map)
+{
+	map(0x00000, 0x3ffff).m("nmk112", FUNC(nmk112_device::oki1_map));
+}
+
+
+/***************************************************************************
                                 Power Instinct 2
 ***************************************************************************/
 
@@ -2299,18 +2318,18 @@ void cave_state::donpachi(machine_config &config)
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
 
-	OKIM6295(config, m_oki[0], 4.220_MHz_XTAL/4, okim6295_device::PIN7_HIGH); // pin 7 not verified
-	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 1.60);
-
-	OKIM6295(config, m_oki[1], 4.220_MHz_XTAL/2, okim6295_device::PIN7_HIGH); // pin 7 not verified
-	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 1.0);
-
 	nmk112_device &nmk112(NMK112(config, "nmk112", 0));
 	nmk112.set_rom0_tag("oki1");
 	nmk112.set_rom1_tag("oki2");
-	nmk112.set_oki0_space_tag("oki1");
-	nmk112.set_oki1_space_tag("oki2");
 	nmk112.set_page_mask(1 << 0);    // chip #0 (music) is not paged
+
+	OKIM6295(config, m_oki[0], 4.220_MHz_XTAL/4, okim6295_device::PIN7_HIGH); // pin 7 not verified
+	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 1.60);
+	m_oki[0]->set_addrmap(0, &cave_state::nmk112_oki0_map);
+
+	OKIM6295(config, m_oki[1], 4.220_MHz_XTAL/2, okim6295_device::PIN7_HIGH); // pin 7 not verified
+	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 1.0);
+	m_oki[1]->set_addrmap(0, &cave_state::nmk112_oki1_map);
 }
 
 
@@ -2757,17 +2776,17 @@ void cave_z80_state::pwrinst2(machine_config &config)
 	ym2203.add_route(2, "mono", 0.40);
 	ym2203.add_route(3, "mono", 0.80);
 
-	OKIM6295(config, m_oki[0], 3_MHz_XTAL, okim6295_device::PIN7_LOW);
-	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 0.80);
-
-	OKIM6295(config, m_oki[1], 3_MHz_XTAL, okim6295_device::PIN7_LOW);
-	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 1.00);
-
 	nmk112_device &nmk112(NMK112(config, "nmk112", 0));
 	nmk112.set_rom0_tag("oki1");
 	nmk112.set_rom1_tag("oki2");
-	nmk112.set_oki0_space_tag("oki1");
-	nmk112.set_oki1_space_tag("oki2");
+
+	OKIM6295(config, m_oki[0], 3_MHz_XTAL, okim6295_device::PIN7_LOW);
+	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 0.80);
+	m_oki[0]->set_addrmap(0, &cave_z80_state::nmk112_oki0_map);
+
+	OKIM6295(config, m_oki[1], 3_MHz_XTAL, okim6295_device::PIN7_LOW);
+	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 1.00);
+	m_oki[1]->set_addrmap(0, &cave_z80_state::nmk112_oki1_map);
 }
 
 

--- a/src/mame/atlus/cave.h
+++ b/src/mame/atlus/cave.h
@@ -253,6 +253,9 @@ protected:
 	void tekkencw_map(address_map &map) ATTR_COLD;
 	void tjumpman_map(address_map &map) ATTR_COLD;
 	void uopoko_map(address_map &map) ATTR_COLD;
+
+	void nmk112_oki0_map(address_map &map) ATTR_COLD;
+	void nmk112_oki1_map(address_map &map) ATTR_COLD;
 };
 
 // with sound Z80

--- a/src/mame/atlus/patapata.cpp
+++ b/src/mame/atlus/patapata.cpp
@@ -55,6 +55,9 @@ protected:
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 	void main_map(address_map &map) ATTR_COLD;
+	void nmk112_oki0_map(address_map &map) ATTR_COLD;
+	void nmk112_oki1_map(address_map &map) ATTR_COLD;
+
 	virtual void video_start() override ATTR_COLD;
 
 private:
@@ -204,6 +207,17 @@ void patapata_state::main_map(address_map &map)
 	map(0x180000, 0x18ffff).ram(); // mainram?
 }
 
+void patapata_state::nmk112_oki0_map(address_map &map)
+{
+	map(0x00000, 0x3ffff).m("nmk112", FUNC(nmk112_device::oki0_map));
+}
+
+void patapata_state::nmk112_oki1_map(address_map &map)
+{
+	map(0x00000, 0x3ffff).m("nmk112", FUNC(nmk112_device::oki1_map));
+}
+
+
 static INPUT_PORTS_START( patapata )
 	PORT_START("IN0")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_UNKNOWN )
@@ -296,15 +310,17 @@ void patapata_state::patapata(machine_config &config)
 
 	SPEAKER(config, "mono").front_center();
 
-	OKIM6295(config, "oki1", 16_MHz_XTAL / 4, okim6295_device::PIN7_LOW).add_route(ALL_OUTPUTS, "mono", 0.40); // not verified
-
-	OKIM6295(config, "oki2", 16_MHz_XTAL / 4, okim6295_device::PIN7_LOW).add_route(ALL_OUTPUTS, "mono", 0.40); // not verified
-
 	nmk112_device &nmk112(NMK112(config, "nmk112", 0)); // or 212? difficult to read (maybe 212 is 2* 112?)
 	nmk112.set_rom0_tag("oki1");
 	nmk112.set_rom1_tag("oki2");
-	nmk112.set_oki0_space_tag("oki1");
-	nmk112.set_oki1_space_tag("oki2");
+
+	okim6295_device &oki1(OKIM6295(config, "oki1", 16_MHz_XTAL / 4, okim6295_device::PIN7_LOW)); // not verified
+	oki1.add_route(ALL_OUTPUTS, "mono", 0.40);
+	oki1.set_addrmap(0, &patapata_state::nmk112_oki0_map);
+
+	okim6295_device &oki2(OKIM6295(config, "oki2", 16_MHz_XTAL / 4, okim6295_device::PIN7_LOW)); // not verified
+	oki2.add_route(ALL_OUTPUTS, "mono", 0.40);
+	oki2.set_addrmap(0, &patapata_state::nmk112_oki1_map);
 }
 
 ROM_START( patapata )

--- a/src/mame/nmk/nmk16.cpp
+++ b/src/mame/nmk/nmk16.cpp
@@ -941,18 +941,6 @@ void nmk16_state::ssmissin_sound_map(address_map &map)
 	map(0xa000, 0xa000).r(m_soundlatch, FUNC(generic_latch_8_device::read));
 }
 
-void nmk16_state::oki1_map(address_map &map)
-{
-	map(0x00000, 0x1ffff).rom().region("oki1", 0);
-	map(0x20000, 0x3ffff).bankr(m_okibank[0]);
-}
-
-void nmk16_state::oki2_map(address_map &map)
-{
-	map(0x00000, 0x1ffff).rom().region("oki2", 0);
-	map(0x20000, 0x3ffff).bankr(m_okibank[1]);
-}
-
 void nmk16_state::strahl_map(address_map &map)
 {
 	map(0x00000, 0x3ffff).rom();
@@ -1244,6 +1232,29 @@ void nmk16_state::powerins_bootleg_audio_io_map(address_map &map)
 	map(0x90, 0x97).w("nmk112", FUNC(nmk112_device::okibank_w));
 }
 
+
+void nmk16_state::oki1_map(address_map &map)
+{
+	map(0x00000, 0x1ffff).rom().region("oki1", 0);
+	map(0x20000, 0x3ffff).bankr(m_okibank[0]);
+}
+
+void nmk16_state::oki2_map(address_map &map)
+{
+	map(0x00000, 0x1ffff).rom().region("oki2", 0);
+	map(0x20000, 0x3ffff).bankr(m_okibank[1]);
+}
+
+void nmk16_state::nmk112_oki0_map(address_map &map)
+{
+	map(0x00000, 0x3ffff).m("nmk112", FUNC(nmk112_device::oki0_map));
+}
+
+void nmk16_state::nmk112_oki1_map(address_map &map)
+{
+	map(0x00000, 0x3ffff).m("nmk112", FUNC(nmk112_device::oki1_map));
+}
+
 void nmk16_state::powerinsa_oki_map(address_map &map)
 {
 	map(0x00000, 0x2ffff).rom().region("oki1", 0);
@@ -1255,6 +1266,7 @@ void nmk16_state::tdragonb2_oki_map(address_map &map)
 	map(0x00000, 0x1ffff).rom().region("oki", 0);
 	map(0x20000, 0x3ffff).bankr(m_okibank[0]);
 }
+
 
 static INPUT_PORTS_START( vandyke )
 	PORT_START("IN0")
@@ -5497,17 +5509,17 @@ void nmk16_state::macross2(machine_config &config)
 	ymsnd.add_route(2, "mono", 0.50);
 	ymsnd.add_route(3, "mono", 1.20);
 
-	OKIM6295(config, m_oki[0], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
-	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 0.10);
-
-	OKIM6295(config, m_oki[1], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
-	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 0.10);
-
 	nmk112_device &nmk112(NMK112(config, "nmk112", 0));
 	nmk112.set_rom0_tag("oki1");
 	nmk112.set_rom1_tag("oki2");
-	nmk112.set_oki0_space_tag("oki1");
-	nmk112.set_oki1_space_tag("oki2");
+
+	OKIM6295(config, m_oki[0], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
+	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 0.10);
+	m_oki[0]->set_addrmap(0, &nmk16_state::nmk112_oki0_map);
+
+	OKIM6295(config, m_oki[1], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
+	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 0.10);
+	m_oki[1]->set_addrmap(0, &nmk16_state::nmk112_oki1_map);
 }
 
 void nmk16_state::tdragon2(machine_config &config)
@@ -5543,17 +5555,17 @@ void nmk16_state::tdragon2(machine_config &config)
 	ymsnd.add_route(2, "mono", 0.50);
 	ymsnd.add_route(3, "mono", 1.20);
 
-	OKIM6295(config, m_oki[0], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
-	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 0.10);
-
-	OKIM6295(config, m_oki[1], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
-	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 0.10);
-
 	nmk112_device &nmk112(NMK112(config, "nmk112", 0));
 	nmk112.set_rom0_tag("oki1");
 	nmk112.set_rom1_tag("oki2");
-	nmk112.set_oki0_space_tag("oki1");
-	nmk112.set_oki1_space_tag("oki2");
+
+	OKIM6295(config, m_oki[0], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
+	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 0.10);
+	m_oki[0]->set_addrmap(0, &nmk16_state::nmk112_oki0_map);
+
+	OKIM6295(config, m_oki[1], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
+	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 0.10);
+	m_oki[1]->set_addrmap(0, &nmk16_state::nmk112_oki1_map);
 }
 
 void nmk16_state::tdragon3h(machine_config &config)
@@ -5606,17 +5618,17 @@ void nmk16_state::raphero(machine_config &config)
 	ymsnd.add_route(2, "mono", 0.50);
 	ymsnd.add_route(3, "mono", 1.20);
 
-	OKIM6295(config, m_oki[0], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
-	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 0.10);
-
-	OKIM6295(config, m_oki[1], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
-	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 0.10);
-
 	nmk112_device &nmk112(NMK112(config, "nmk112", 0));
 	nmk112.set_rom0_tag("oki1");
 	nmk112.set_rom1_tag("oki2");
-	nmk112.set_oki0_space_tag("oki1");
-	nmk112.set_oki1_space_tag("oki2");
+
+	OKIM6295(config, m_oki[0], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
+	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 0.10);
+	m_oki[0]->set_addrmap(0, &nmk16_state::nmk112_oki0_map);
+
+	OKIM6295(config, m_oki[1], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
+	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 0.10);
+	m_oki[1]->set_addrmap(0, &nmk16_state::nmk112_oki1_map);
 }
 
 void nmk16_state::bjtwin(machine_config &config)
@@ -5638,17 +5650,17 @@ void nmk16_state::bjtwin(machine_config &config)
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
-	OKIM6295(config, m_oki[0], XTAL(16'000'000)/4, okim6295_device::PIN7_LOW); // verified on PCB
-	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 0.20);
-
-	OKIM6295(config, m_oki[1], XTAL(16'000'000)/4, okim6295_device::PIN7_LOW); // verified on PCB
-	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 0.20);
-
 	nmk112_device &nmk112(NMK112(config, "nmk112", 0));
 	nmk112.set_rom0_tag("oki1");
 	nmk112.set_rom1_tag("oki2");
-	nmk112.set_oki0_space_tag("oki1");
-	nmk112.set_oki1_space_tag("oki2");
+
+	OKIM6295(config, m_oki[0], XTAL(16'000'000)/4, okim6295_device::PIN7_LOW); // verified on PCB
+	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 0.20);
+	m_oki[0]->set_addrmap(0, &nmk16_state::nmk112_oki0_map);
+
+	OKIM6295(config, m_oki[1], XTAL(16'000'000)/4, okim6295_device::PIN7_LOW); // verified on PCB
+	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 0.20);
+	m_oki[1]->set_addrmap(0, &nmk16_state::nmk112_oki1_map);
 }
 
 void nmk16_state::cactus(machine_config &config)
@@ -5782,17 +5794,17 @@ void nmk16_state::powerins(machine_config &config)
 	ymsnd.irq_handler().set_inputline(m_audiocpu, 0);
 	ymsnd.add_route(ALL_OUTPUTS, "mono", 2.0);
 
-	OKIM6295(config, m_oki[0], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW); // verified on PCB
-	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 0.15);
-
-	OKIM6295(config, m_oki[1], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW); // verified on PCB
-	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 0.15);
-
 	nmk112_device &nmk112(NMK112(config, "nmk112", 0));
 	nmk112.set_rom0_tag("oki1");
 	nmk112.set_rom1_tag("oki2");
-	nmk112.set_oki0_space_tag("oki1");
-	nmk112.set_oki1_space_tag("oki2");
+
+	OKIM6295(config, m_oki[0], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW); // verified on PCB
+	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 0.15);
+	m_oki[0]->set_addrmap(0, &nmk16_state::nmk112_oki0_map);
+
+	OKIM6295(config, m_oki[1], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW); // verified on PCB
+	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 0.15);
+	m_oki[1]->set_addrmap(0, &nmk16_state::nmk112_oki1_map);
 }
 
 void nmk16_state::powerinsa(machine_config &config)
@@ -5865,17 +5877,17 @@ void nmk16_state::powerinsb(machine_config &config)
 
 	GENERIC_LATCH_8(config, m_soundlatch);
 
-	OKIM6295(config, m_oki[0], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
-	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 0.15);
-
-	OKIM6295(config, m_oki[1], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
-	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 0.15);
-
 	nmk112_device &nmk112(NMK112(config, "nmk112", 0));
 	nmk112.set_rom0_tag("oki1");
 	nmk112.set_rom1_tag("oki2");
-	nmk112.set_oki0_space_tag("oki1");
-	nmk112.set_oki1_space_tag("oki2");
+
+	OKIM6295(config, m_oki[0], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
+	m_oki[0]->add_route(ALL_OUTPUTS, "mono", 0.15);
+	m_oki[0]->set_addrmap(0, &nmk16_state::nmk112_oki0_map);
+
+	OKIM6295(config, m_oki[1], XTAL(16'000'000) / 4, okim6295_device::PIN7_LOW);
+	m_oki[1]->add_route(ALL_OUTPUTS, "mono", 0.15);
+	m_oki[1]->set_addrmap(0, &nmk16_state::nmk112_oki1_map);
 
 	// Sound code talks to one YM2203, but it's not fitted on the board
 }

--- a/src/mame/nmk/nmk16.h
+++ b/src/mame/nmk/nmk16.h
@@ -247,13 +247,10 @@ protected:
 	void mustangb_map(address_map &map) ATTR_COLD;
 	void mustangb3_map(address_map &map) ATTR_COLD;
 	void mustangb3_sound_map(address_map &map) ATTR_COLD;
-	void oki1_map(address_map &map) ATTR_COLD;
-	void oki2_map(address_map &map) ATTR_COLD;
 	void powerins_map(address_map &map) ATTR_COLD;
 	void powerins_sound_map(address_map &map) ATTR_COLD;
 	void powerins_bootleg_audio_io_map(address_map &map) ATTR_COLD;
 	void powerinsa_map(address_map &map) ATTR_COLD;
-	void powerinsa_oki_map(address_map &map) ATTR_COLD;
 	void raphero_map(address_map &map) ATTR_COLD;
 	void raphero_sound_mem_map(address_map &map) ATTR_COLD;
 	void ssmissin_map(address_map &map) ATTR_COLD;
@@ -266,7 +263,6 @@ protected:
 	void tdragon_map(address_map &map) ATTR_COLD;
 	void tdragonb_map(address_map &map) ATTR_COLD;
 	void tdragonb2_map(address_map &map) ATTR_COLD;
-	void tdragonb2_oki_map(address_map &map) ATTR_COLD;
 	void tdragonb3_map(address_map &map) ATTR_COLD;
 	void tharrier_map(address_map &map) ATTR_COLD;
 	void tharrier_sound_io_map(address_map &map) ATTR_COLD;
@@ -274,6 +270,13 @@ protected:
 	void twinactn_map(address_map &map) ATTR_COLD;
 	void vandyke_map(address_map &map) ATTR_COLD;
 	void vandykeb_map(address_map &map) ATTR_COLD;
+
+	void oki1_map(address_map &map) ATTR_COLD;
+	void oki2_map(address_map &map) ATTR_COLD;
+	void nmk112_oki0_map(address_map &map) ATTR_COLD;
+	void nmk112_oki1_map(address_map &map) ATTR_COLD;
+	void powerinsa_oki_map(address_map &map) ATTR_COLD;
+	void tdragonb2_oki_map(address_map &map) ATTR_COLD;
 };
 
 class tdragon_prot_state : public nmk16_state

--- a/src/mame/nmk/nmkmedal.cpp
+++ b/src/mame/nmk/nmkmedal.cpp
@@ -184,6 +184,9 @@ private:
 	void drail_mem_map(address_map &map) ATTR_COLD;
 	void mem_map(address_map &map) ATTR_COLD;
 	void sweethrt_mem_map(address_map &map) ATTR_COLD;
+
+	void nmk112_oki0_map(address_map &map) ATTR_COLD;
+	void nmk112_oki1_map(address_map &map) ATTR_COLD;
 };
 
 class omatsuri_state : public nmkmedal_state
@@ -262,6 +265,17 @@ void omatsuri_state::mem_map(address_map &map)
 {
 	map(0x0000, 0x9fff).rom().region("maincpu", 0);
 	map(0xd000, 0xefff).ram();
+}
+
+
+void hpierrot_state::nmk112_oki0_map(address_map &map)
+{
+	map(0x00000, 0x3ffff).m("nmk112", FUNC(nmk112_device::oki0_map));
+}
+
+void hpierrot_state::nmk112_oki1_map(address_map &map)
+{
+	map(0x00000, 0x3ffff).m("nmk112", FUNC(nmk112_device::oki1_map));
 }
 
 
@@ -347,10 +361,12 @@ void hpierrot_state::drail(machine_config &config)
 
 	nmk112_device &nmk112(NMK112(config, "nmk112", 0));
 	nmk112.set_rom0_tag("oki");
-	nmk112.set_oki0_space_tag("oki");
 
 	SPEAKER(config, "mono").front_center();
-	OKIM6295(config, "oki", 16_MHz_XTAL / 16, okim6295_device::PIN7_HIGH).add_route(ALL_OUTPUTS, "mono", 1.0); // divider and pin not verified
+
+	okim6295_device &oki(OKIM6295(config, "oki", 16_MHz_XTAL / 16, okim6295_device::PIN7_HIGH)); // divider and pin not verified
+	oki.add_route(ALL_OUTPUTS, "mono", 1.0);
+	oki.set_addrmap(0, &hpierrot_state::nmk112_oki0_map);
 }
 
 void hpierrot_state::sweethrt(machine_config &config)
@@ -361,13 +377,15 @@ void hpierrot_state::sweethrt(machine_config &config)
 	nmk112_device &nmk112(NMK112(config, "nmk112", 0)); // actually thought to be included in the NMK-113 custom
 	nmk112.set_rom0_tag("oki");
 	nmk112.set_rom1_tag("oki2");
-	nmk112.set_oki0_space_tag("oki");
-	nmk112.set_oki1_space_tag("oki2");
 
 	SPEAKER(config, "mono").front_center();
-	OKIM6295(config, "oki", 16_MHz_XTAL / 16, okim6295_device::PIN7_HIGH).add_route(ALL_OUTPUTS, "mono", 1.0); // divider and pin not verified
+	okim6295_device &oki1(OKIM6295(config, "oki", 16_MHz_XTAL / 16, okim6295_device::PIN7_HIGH)); // divider and pin not verified
+	oki1.add_route(ALL_OUTPUTS, "mono", 1.0);
+	oki1.set_addrmap(0, &hpierrot_state::nmk112_oki0_map);
 
-	OKIM6295(config, "oki2", 16_MHz_XTAL / 16, okim6295_device::PIN7_HIGH).add_route(ALL_OUTPUTS, "mono", 1.0); // divider and pin not verified
+	okim6295_device &oki2(OKIM6295(config, "oki2", 16_MHz_XTAL / 16, okim6295_device::PIN7_HIGH)); // divider and pin not verified
+	oki2.add_route(ALL_OUTPUTS, "mono", 1.0);
+	oki2.set_addrmap(0, &hpierrot_state::nmk112_oki1_map);
 }
 
 void omatsuri_state::omatsuri(machine_config &config)

--- a/src/mame/nmk/quizpani.cpp
+++ b/src/mame/nmk/quizpani.cpp
@@ -107,6 +107,7 @@ private:
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 	void program_map(address_map &map) ATTR_COLD;
+	void nmk112_oki0_map(address_map &map) ATTR_COLD;
 };
 
 
@@ -219,6 +220,11 @@ void quizpani_state::program_map(address_map &map)
 	map(0x11c000, 0x11ffff).ram().w(FUNC(quizpani_state::txt_videoram_w)).share(m_txt_videoram);
 	map(0x180000, 0x18ffff).ram();
 	map(0x200000, 0x33ffff).rom();
+}
+
+void quizpani_state::nmk112_oki0_map(address_map &map)
+{
+	map(0x00000, 0x3ffff).m("nmk112", FUNC(nmk112_device::oki0_map));
 }
 
 
@@ -434,11 +440,12 @@ void quizpani_state::quizpani(machine_config &config)
 
 	SPEAKER(config, "mono").front_center();
 
-	OKIM6295(config, "oki", 16'000'000 / 4, okim6295_device::PIN7_LOW).add_route(ALL_OUTPUTS, "mono", 1.0);
-
 	nmk112_device &nmk112(NMK112(config, "nmk112", 0));
 	nmk112.set_rom0_tag("oki");
-	nmk112.set_oki0_space_tag("oki");
+
+	okim6295_device &oki(OKIM6295(config, "oki", 16'000'000 / 4, okim6295_device::PIN7_LOW));
+	oki.add_route(ALL_OUTPUTS, "mono", 1.0);
+	oki.set_addrmap(0, &quizpani_state::nmk112_oki0_map);
 }
 
 ROM_START( quizpani )


### PR DESCRIPTION
- Reduce duplicates
- Fix spacings and argument data type
- atlus/cave.cpp, atlus/patapata.cpp, nmk/nmk16.cpp, nmk/nmkmedal.cpp, nmk/quizpani.cpp: Fix memory region size for NMK112 bankswitched OKI MSM6295 spaces