### PR TITLE
g65816: fix status flag display in emulation mode

### DIFF
--- a/src/devices/cpu/g65816/g65816.cpp
+++ b/src/devices/cpu/g65816/g65816.cpp
@@ -1063,10 +1063,9 @@ void g65816_device::state_string_export(const device_state_entry &entry, std::st
 			str = string_format("%c%c%c%c%c%c%c%c",
 				m_flag_n & NFLAG_SET ? 'N':'.',
 				m_flag_v & VFLAG_SET ? 'V':'.',
-				m_flag_m & MFLAG_SET ? 'M':'.',
-				m_flag_x & XFLAG_SET ? 'X':'.',
+				m_flag_m & MFLAG_SET ? (m_flag_e ? ' ':'M'):'.',
+				m_flag_x & XFLAG_SET ? (m_flag_e ? 'B':'X'):'.',
 				m_flag_d & DFLAG_SET ? 'D':'.',
-
 				m_flag_i & IFLAG_SET ? 'I':'.',
 				m_flag_z == 0        ? 'Z':'.',
 				m_flag_c & CFLAG_SET ? 'C':'.');


### PR DESCRIPTION
Cosmetic-only change to slightly improve the register display in MAME's debugger.

I also considered changing all of the P flags and E flag to lowercase.  This matches the convention used in "[Programming the 65816](https://archive.org/details/0893037893ProgrammingThe65816/page/51/mode/2up)" (Eyes/Lichty), [Apple's documentation](https://archive.org/details/Apple_IIgs_Hardware_Reference_HiRes/page/210/mode/2up), and the Apple IIgs [Monitor firmware](https://archive.org/details/Apple_IIgs_Firmware_Reference_HiRes/page/n57/mode/2up).  Lowercase eliminates some ambiguity (b != B, c != C), however the 'E' flag is exposed via MAME's Lua scripting interface, which is case-sensitive, so changing it might break existing scripts?
