### PR TITLE
cpu/mb86235: Use separate memory spaces for data A and external

### DIFF
--- a/src/devices/cpu/mb86235/mb86235.cpp
+++ b/src/devices/cpu/mb86235/mb86235.cpp
@@ -9,7 +9,6 @@
  * - rewrite fifo hookups, remove them from the actual opcodes.
  * - illegal delay slots unsupported, and no idea about what is supposed to happen;
  * - externalize PDR (error LED flags on Model 2);
- * - perform external memory access if AALU-A is 0x400 or higher
  *
  ********************************************************************************/
 
@@ -86,8 +85,9 @@ void mb86235_device::device_start()
 {
 	space(AS_PROGRAM).cache(m_pcache);
 	space(AS_PROGRAM).specific(m_program);
-	space(AS_DATA).specific(m_dataa);
-	space(AS_IO).specific(m_datab);
+	space(AS_DATA).specific(m_external);
+	space(AS_BUSA).specific(m_dataa);
+	space(AS_BUSB).specific(m_datab);
 
 	m_core = (mb86235_internal_state *)m_cache.alloc_near(sizeof(mb86235_internal_state));
 	memset(m_core, 0, sizeof(mb86235_internal_state));
@@ -255,8 +255,9 @@ void mb86235_cpu_device::execute_set_input(int irqline, int state)
 
 mb86235_device::mb86235_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: cpu_device(mconfig, MB86235, tag, owner, clock)
-	, m_program_config("program", ENDIANNESS_LITTLE, 64, 32, -3)
-	, m_dataa_config("data_a", ENDIANNESS_LITTLE, 32, 24, -2, address_map_constructor(FUNC(mb86235_device::internal_abus), this))
+	, m_program_config("program", ENDIANNESS_LITTLE, 64, 12, -3)
+	, m_external_config("external", ENDIANNESS_LITTLE, 32, 24, -2)
+	, m_dataa_config("data_a", ENDIANNESS_LITTLE, 32, 10, -2, address_map_constructor(FUNC(mb86235_device::internal_abus), this))
 	, m_datab_config("data_b", ENDIANNESS_LITTLE, 32, 10, -2, address_map_constructor(FUNC(mb86235_device::internal_bbus), this))
 	, m_fifoin(*this, finder_base::DUMMY_TAG)
 	, m_fifoout(*this, finder_base::DUMMY_TAG)
@@ -274,8 +275,9 @@ device_memory_interface::space_config_vector mb86235_device::memory_space_config
 {
 	return space_config_vector {
 		std::make_pair(AS_PROGRAM, &m_program_config),
-		std::make_pair(AS_DATA,    &m_dataa_config),
-		std::make_pair(AS_IO,      &m_datab_config)
+		std::make_pair(AS_DATA,    &m_external_config),
+		std::make_pair(AS_BUSA,    &m_dataa_config),
+		std::make_pair(AS_BUSB,    &m_datab_config)
 	};
 }
 

--- a/src/devices/cpu/mb86235/mb86235.h
+++ b/src/devices/cpu/mb86235/mb86235.h
@@ -39,6 +39,12 @@ public:
 	void pcs_overflow();
 	void pcs_underflow();
 
+	enum address_spaces
+	{
+		AS_BUSA = AS_OPCODES + 1,
+		AS_BUSB
+	};
+
 	enum
 	{
 		MB86235_PC = 1,
@@ -162,6 +168,7 @@ private:
 	uml::code_handle *m_write_abus;
 
 	address_space_config m_program_config;
+	address_space_config m_external_config;
 	address_space_config m_dataa_config;
 	address_space_config m_datab_config;
 	optional_device<generic_fifo_u32_device> m_fifoin;
@@ -171,10 +178,11 @@ private:
 	std::unique_ptr<drcuml_state> m_drcuml;
 	std::unique_ptr<mb86235_frontend> m_drcfe;
 
-	memory_access<32, 3, -3, ENDIANNESS_LITTLE>::cache m_pcache;
-	memory_access<32, 3, -3, ENDIANNESS_LITTLE>::specific m_program;
-	memory_access<24, 2, -2, ENDIANNESS_LITTLE>::specific m_dataa;
+	memory_access<12, 3, -3, ENDIANNESS_LITTLE>::cache m_pcache;
+	memory_access<12, 3, -3, ENDIANNESS_LITTLE>::specific m_program;
+	memory_access<10, 2, -2, ENDIANNESS_LITTLE>::specific m_dataa;
 	memory_access<10, 2, -2, ENDIANNESS_LITTLE>::specific m_datab;
+	memory_access<24, 2, -2, ENDIANNESS_LITTLE>::specific m_external;
 
 	/* internal compiler state */
 	struct compiler_state
@@ -258,8 +266,10 @@ private:
 	inline uint32_t get_transfer_reg(uint8_t which);
 	inline void set_transfer_reg(uint8_t which, uint32_t value);
 	inline uint32_t decode_ea(uint8_t mode, uint8_t rx, uint8_t ry, uint16_t disp, bool isbbus);
-	inline uint32_t read_bus(bool isbbus, uint32_t addr);
-	inline void write_bus(bool isbbus, uint32_t addr, uint32_t data);
+	inline uint32_t read_abus(uint32_t addr);
+	inline uint32_t read_bbus(uint32_t addr);
+	inline void write_abus(uint32_t addr, uint32_t data);
+	inline void write_bbus(uint32_t addr, uint32_t data);
 	inline void increment_pwp();
 	inline void increment_prp();
 	inline void decrement_prp();

--- a/src/devices/cpu/mb86235/mb86235ops.cpp
+++ b/src/devices/cpu/mb86235/mb86235ops.cpp
@@ -179,19 +179,31 @@ inline uint32_t mb86235_device::decode_ea(uint8_t mode, uint8_t rx, uint8_t ry, 
 	return 0;
 }
 
-inline uint32_t mb86235_device::read_bus(bool isbbus, uint32_t addr)
+inline uint32_t mb86235_device::read_abus(uint32_t addr)
 {
-	return isbbus == true ? m_datab.read_dword(addr & 0x3ff) : m_dataa.read_dword(addr & 0x3ff);
-}
-
-inline void mb86235_device::write_bus(bool isbbus, uint32_t addr, uint32_t data)
-{
-	if(isbbus == true)
-		m_datab.write_dword(addr & 0x3ff,data);
+	if ((addr & 0x3fff) >= 0x400)
+		return m_external.read_dword(addr & 0x3fff);
 	else
-		m_dataa.write_dword(addr & 0x3ff,data);
+		return m_dataa.read_dword(addr & 0x3ff);
 }
 
+inline uint32_t mb86235_device::read_bbus(uint32_t addr)
+{
+	return m_datab.read_dword(addr & 0x3ff);
+}
+
+inline void mb86235_device::write_abus(uint32_t addr, uint32_t data)
+{
+	if ((addr & 0x3fff) >= 0x400)
+		m_external.write_dword(addr & 0x3fff, data);
+	else
+		m_dataa.write_dword(addr & 0x3ff, data);
+}
+
+inline void mb86235_device::write_bbus(uint32_t addr, uint32_t data)
+{
+	m_datab.write_dword(addr & 0x3ff, data);
+}
 
 /*********************
  *
@@ -894,9 +906,9 @@ void mb86235_device::do_alu2_trans2_1(uint64_t op)
 	case 2:
 	{
 		uint32_t addr = decode_ea(op & 0xf, (op >> 17) & 7, (op >> 14) & 7, 0, false);
-		ares = read_bus(false, addr);
+		ares = read_abus(addr);
 		addr = decode_ea(op & 0xf, (op >> 7) & 7, (op >> 4) & 7, 0, true);
-		bres = read_bus(true, addr);
+		bres = read_bbus(addr);
 		break;
 	}
 	default:
@@ -921,9 +933,9 @@ void mb86235_device::do_alu2_trans2_1(uint64_t op)
 	case 1:
 	{
 		uint32_t addr = decode_ea(op & 0xf, (op >> 17) & 7, (op >> 14) & 7, 0, false);
-		write_bus(false, addr, ares);
+		write_abus(addr, ares);
 		addr = decode_ea(op & 0xf, (op >> 7) & 7, (op >> 4) & 7, 0, true);
-		write_bus(true, addr, bres);
+		write_bbus(addr, bres);
 		break;
 	}
 	}
@@ -940,7 +952,7 @@ void mb86235_device::do_alu2_trans1_1(uint64_t op)
 		if(BIT(op, 25)) // ext -> int
 		{
 			uint32_t addr = m_core->eb+m_core->eo;
-			res = m_dataa.read_dword(addr);
+			res = m_external.read_dword(addr);
 
 			// do alu
 			do_alu2(op);
@@ -949,8 +961,11 @@ void mb86235_device::do_alu2_trans1_1(uint64_t op)
 			if(dr & 0x40)
 			{
 				bool isbbus = (dr & 0x20) == 0x20;
-				addr = decode_ea(op & 0xf,dr & 7,(op >> 4) & 7, (op >> 7) & 0x1f,isbbus);
-				write_bus(isbbus,addr,res);
+				addr = decode_ea(op & 0xf,dr & 7,(op >> 4) & 7, (op >> 7) & 0x1f,isbbus) & 0x3ff;
+				if (isbbus)
+					write_bbus(addr, res);
+				else
+					write_abus(addr, res);
 			}
 			else
 				set_transfer_reg(dr,res);
@@ -966,8 +981,8 @@ void mb86235_device::do_alu2_trans1_1(uint64_t op)
 			if (sr & 0x40)
 			{
 				bool isbbus = (sr & 0x20) == 0x20;
-				uint32_t addr = decode_ea(op & 0xf, sr & 7, (op >> 4) & 7, (op >> 7) & 0x1f, isbbus);
-				res = read_bus(isbbus, addr);
+				uint32_t addr = decode_ea(op & 0xf, sr & 7, (op >> 4) & 7, (op >> 7) & 0x1f, isbbus) & 0x3ff;
+				res = isbbus ? read_bbus(addr) : read_abus(addr);
 			}
 			else
 				res = get_transfer_reg(sr);
@@ -976,7 +991,7 @@ void mb86235_device::do_alu2_trans1_1(uint64_t op)
 			do_alu2(op);
 
 			uint32_t addr = m_core->eb + m_core->eo;
-			m_dataa.write_dword(addr, res);
+			m_external.write_dword(addr, res);
 
 			int8_t disp_offs = (op >> 19) & 0x3f;
 			if (disp_offs & 0x20)
@@ -995,7 +1010,7 @@ void mb86235_device::do_alu2_trans1_1(uint64_t op)
 			{
 				bool isbbus = (sr & 0x20) == 0x20;
 				uint32_t addr = decode_ea(op & 0xf,sr & 7,(op >> 4) & 7, (op >> 7) & 0x1f,isbbus);
-				res = read_bus(isbbus,addr);
+				res = isbbus ? read_bbus(addr) : read_abus(addr);
 			}
 		}
 		else
@@ -1012,7 +1027,10 @@ void mb86235_device::do_alu2_trans1_1(uint64_t op)
 
 			bool isbbus = (dr & 0x20) == 0x20;
 			uint32_t addr = decode_ea(op & 0xf,dr & 7,(op >> 4) & 7, (op >> 7) & 0x1f,isbbus);
-			write_bus(isbbus,addr,res);
+			if (isbbus)
+				write_bbus(addr, res);
+			else
+				write_abus(addr, res);
 		}
 		else
 			set_transfer_reg(dr,res);
@@ -1039,7 +1057,7 @@ void mb86235_device::do_alu1_trans2_2(uint64_t op)
 	case 2:
 	{
 		uint32_t addr = decode_ea((op >> 20) & 0xf, (op >> 30) & 7, (op >> 27) & 7, (op >> 24) & 7, false);
-		ares = read_bus(false, addr);
+		ares = read_abus(addr);
 		break;
 	}
 	default:
@@ -1060,7 +1078,7 @@ void mb86235_device::do_alu1_trans2_2(uint64_t op)
 	case 2:
 	{
 		uint32_t addr = decode_ea(op & 0xf, (op >> 10) & 7, (op >> 7) & 7, (op >> 4) & 7, true);
-		bres = read_bus(true, addr);
+		bres = read_bbus(addr);
 		break;
 	}
 	default:
@@ -1084,7 +1102,7 @@ void mb86235_device::do_alu1_trans2_2(uint64_t op)
 	case 1:
 	{
 		uint32_t addr = decode_ea((op >> 20) & 0xf, (op >> 30) & 7, (op >> 27) & 7, (op >> 24) & 7, false);
-		write_bus(false, addr, ares);
+		write_abus(addr, ares);
 		break;
 	}
 	}
@@ -1102,7 +1120,7 @@ void mb86235_device::do_alu1_trans2_2(uint64_t op)
 	case 1:
 	{
 		uint32_t addr = decode_ea(op & 0xf, (op >> 10) & 7, (op >> 7) & 7, (op >> 4) & 7, true);
-		write_bus(true, addr, bres);
+		write_bbus(addr, bres);
 		break;
 	}
 	}
@@ -1119,7 +1137,7 @@ void mb86235_device::do_alu1_trans1_2(uint64_t op)
 		if(BIT(op, 37)) // ext->int
 		{
 			uint32_t addr = m_core->eb+m_core->eo;
-			uint32_t res = m_dataa.read_dword(addr);
+			uint32_t res = m_external.read_dword(addr);
 
 			// do alu
 			do_alu1(op);
@@ -1128,8 +1146,11 @@ void mb86235_device::do_alu1_trans1_2(uint64_t op)
 			if(dr & 0x40)
 			{
 				bool isbbus = (dr & 0x20) == 0x20;
-				addr = decode_ea(op & 0xf, dr & 7, (op >> 4) & 7, (op >> 7) & 0x3fff, isbbus);
-				write_bus(isbbus, addr, res);
+				addr = decode_ea(op & 0xf, dr & 7, (op >> 4) & 7, (op >> 7) & 0x3fff, isbbus) & 0x3ff;
+				if (isbbus)
+					write_bbus(addr, res);
+				else
+					write_abus(addr, res);
 			}
 			else
 				set_transfer_reg(dr,res);
@@ -1149,8 +1170,8 @@ void mb86235_device::do_alu1_trans1_2(uint64_t op)
 				else
 				{
 					bool isbbus = (sr & 0x20) == 0x20;
-					uint32_t addr = decode_ea(op & 0xf, sr & 7, (op >> 4) & 7, (op >> 7) & 0x3fff, isbbus);
-					res = read_bus(isbbus, addr);
+					uint32_t addr = decode_ea(op & 0xf, sr & 7, (op >> 4) & 7, (op >> 7) & 0x3fff, isbbus) & 0x3ff;
+					res = isbbus ? read_bbus(addr) : read_abus(addr);
 				}
 			}
 			else
@@ -1160,7 +1181,7 @@ void mb86235_device::do_alu1_trans1_2(uint64_t op)
 			do_alu1(op);
 
 			uint32_t addr = m_core->eb + m_core->eo;
-			m_dataa.write_dword(addr,res);
+			m_external.write_dword(addr, res);
 
 			int8_t disp_offs = (op >> 31) & 0x3f;
 			if (disp_offs & 0x20)
@@ -1179,7 +1200,7 @@ void mb86235_device::do_alu1_trans1_2(uint64_t op)
 			{
 				bool isbbus = (sr & 0x20) == 0x20;
 				uint32_t addr = decode_ea(op & 0xf,sr & 7,(op >> 4) & 7, (op >> 7) & 0x3fff,isbbus);
-				res = read_bus(isbbus,addr);
+				res = isbbus ? read_bbus(addr) : read_abus(addr);
 			}
 		}
 		else
@@ -1196,7 +1217,10 @@ void mb86235_device::do_alu1_trans1_2(uint64_t op)
 
 			bool isbbus = (dr & 0x20) == 0x20;
 			uint32_t addr = decode_ea(op & 0xf,dr & 7,(op >> 4) & 7, (op >> 7) & 0x3fff,isbbus);
-			write_bus(isbbus,addr,res);
+			if (isbbus)
+				write_bbus(addr, res);
+			else
+				write_abus(addr, res);
 		}
 		else
 			set_transfer_reg(dr,res);
@@ -1213,7 +1237,10 @@ void mb86235_device::do_trans1_3(uint64_t op)
 	{
 		bool isbbus = (dr & 0x20) == 0x20;
 		uint32_t addr = decode_ea(op & 0xf,dr & 7,(op >> 4) & 7, (op >> 7) & 0xfff,isbbus);
-		write_bus(isbbus,addr,imm);
+		if (isbbus)
+			write_bbus(addr, imm);
+		else
+			write_abus(addr, imm);
 	}
 	else // direct imm reg
 		set_transfer_reg(dr,imm);
@@ -1262,16 +1289,16 @@ inline uint32_t mb86235_device::do_control_dst(uint64_t op)
 		addr = BIT(op, 11) ? m_core->mb[(op >> 6) & 7] : m_core->ma[(op >> 6) & 7];
 		break;
 	case 4:
-		addr = read_bus(false, op & 0x3ff);
+		addr = read_abus(op & 0x3ff);
 		break;
 	case 5:
-		addr = read_bus(true, op & 0x3ff);
+		addr = read_bbus(op & 0x3ff);
 		break;
 	case 6:
-		addr = read_bus(false, m_core->ar[(op >> 6) & 7]);
+		addr = read_abus(m_core->ar[(op >> 6) & 7]);
 		break;
 	case 7:
-		addr = read_bus(true, m_core->ar[(op >> 6) & 7]);
+		addr = read_bbus(m_core->ar[(op >> 6) & 7]);
 		break;
 	}
 

--- a/src/devices/cpu/mb86235/mb86235ops.cpp
+++ b/src/devices/cpu/mb86235/mb86235ops.cpp
@@ -182,7 +182,7 @@ inline uint32_t mb86235_device::decode_ea(uint8_t mode, uint8_t rx, uint8_t ry, 
 inline uint32_t mb86235_device::read_abus(uint32_t addr)
 {
 	if ((addr & 0x3fff) >= 0x400)
-		return m_external.read_dword(addr & 0x3fff);
+		return m_external.read_dword((addr & 0x3fff) + (m_core->eb & 0xffc000));
 	else
 		return m_dataa.read_dword(addr & 0x3ff);
 }
@@ -195,7 +195,7 @@ inline uint32_t mb86235_device::read_bbus(uint32_t addr)
 inline void mb86235_device::write_abus(uint32_t addr, uint32_t data)
 {
 	if ((addr & 0x3fff) >= 0x400)
-		m_external.write_dword(addr & 0x3fff, data);
+		m_external.write_dword((addr & 0x3fff) + (m_core->eb & 0xffc000), data);
 	else
 		m_dataa.write_dword(addr & 0x3ff, data);
 }

--- a/src/mame/sega/model2.cpp
+++ b/src/mame/sega/model2.cpp
@@ -29,7 +29,6 @@
               bypass it by entering then exiting service mode;
     - sgt24h: has input analog issues, steering doesn't center when neutral,
       gas and brake pedals pulses instead of being fixed;
-    - stcc: no collision detection with enemy cars, sometimes enemy cars glitch out and disappear altogether;
     - vcop: sound dies at enter initial screen (i.e. after played the game once) (untested);
 
     Notes:
@@ -758,12 +757,11 @@ void model2c_state::copro_function_port_w(offs_t offset, u32 data)
 
 void model2c_state::copro_tgpx4_map(address_map &map)
 {
-	map(0x00000000, 0x00007fff).ram().share("copro_tgpx4_program");
+	map(0x00000000, 0x00000fff).ram().share("copro_tgpx4_program");
 }
 
 void model2c_state::copro_tgpx4_data_map(address_map &map)
 {
-//  map(0x00000000, 0x000003ff) internal RAM
 	map(0x00400000, 0x00407fff).ram().share("bufferram").mirror(0x003f8000);
 	map(0x00800000, 0x009fffff).rom().region("copro_data",0); // ROM data
 }


### PR DESCRIPTION
For each Model 2C game the copro TGPx4 initialization procedure writes a list of function addresses to data A and afterwards writes 0 to external address 0x2C, which in the current code is mapped to data A so it ends up corrupting the address of copro function 0x2C. This commit separates data A and external memory so this no longer occurs.

Fixes enemy car collision detection in stcc, probably other bugs in Model 2C games we hadn't discovered