### PR TITLE
mcs51: fix destination RAM type in XCHD A, @R0/@R1

### DIFF
--- a/src/devices/cpu/mcs51/mcs51ops.hxx
+++ b/src/devices/cpu/mcs51/mcs51ops.hxx
@@ -930,7 +930,7 @@ OPHANDLER( xchd_a_ir )
 	ir_data = IRAM_IR(R_REG(r));            //Grab data pointed to by R0 or R1
 	acc = ACC;                              //Grab ACC value
 	SET_ACC((acc & 0xf0) | (ir_data & 0x0f)); //Set ACC to lower nibble of data pointed to by R0 or R1
-	IRAM_W(R_REG(r), (ir_data & 0xf0) | (acc & 0x0f)); //Set data pointed to by R0 or R1 to lower nibble of ACC
+	IRAM_IW(R_REG(r), (ir_data & 0xf0) | (acc & 0x0f)); //Set data pointed to by R0 or R1 to lower nibble of ACC
 }
 
 //XRL data addr, A                          /* 1: 0110 0010 */


### PR DESCRIPTION
- The initial value is read from internal RAM (IRAM_IR).
- The final value must be written to the internal RAM too (IRAM_IW instead of IRAM_W).

----

I and @jyaif have found an issue in the mcs51's implementation of the `XCHD` ("Exchange Digit") instruction: it reads the old value with `IRAM_IR` but writes the new value with `IRAM_W`.

Instead, it should have written the new value symmetrically with `IRAM_IW`:
<img width="60%" alt="XCHD documentation" src="https://github.com/user-attachments/assets/9c4e72de-05ad-446b-a25a-46e3ba3e2ad8" />

We found the issue while investigating a bad Dynamical Redefinable Character Set (DRCS) rendering on the minitel2 (`src/mame/philips/minitel_2_rpic.cpp`).

Before this patch:
<img width="40%" alt="before" src="https://github.com/user-attachments/assets/5035aa93-0103-45ce-aaee-8eff1c8907a1" />

After this patch:
<img width="40%" alt="after" src="https://github.com/user-attachments/assets/4c44b993-24ae-4eea-9ee1-519fab4e35d2" />

(from [MiniPavi](https://www.minipavi.fr/) service -> code `6212*DRCS` -> image 1)

cc @jfdelnero
