### PR TITLE
gaelco/gaelco_wrally_sprites.cpp: Use device_video_interface for screen, Minor cleanups

### DIFF
--- a/src/mame/gaelco/blmbycar.cpp
+++ b/src/mame/gaelco/blmbycar.cpp
@@ -206,7 +206,7 @@ TILE_GET_INFO_MEMBER(base_state::get_tile_info)
 			attr & 0x1f,
 			TILE_FLIPYX((attr >> 6) & 3));
 
-	tileinfo.category = (attr >> 5) & 1;
+	tileinfo.category = BIT(attr, 5);
 }
 
 /***************************************************************************
@@ -292,14 +292,14 @@ void blmbycar_state::pot_wheel_reset_w(uint8_t data)
 
 void blmbycar_state::pot_wheel_shift_w(uint8_t data)
 {
-	if ( ((m_old_val) == 0xff) && ((data) == 0) )
+	if ((m_old_val == 0xff) && (data == 0))
 		m_pot_wheel <<= 1;
 	m_old_val = data;
 }
 
 uint16_t blmbycar_state::pot_wheel_r()
 {
-	return ((m_pot_wheel & 0x80) ? 0x04 : 0) | (machine().rand() & 0x08);
+	return (BIT(m_pot_wheel, 7) ? 0x04 : 0) | (machine().rand() & 0x08);
 }
 
 
@@ -370,7 +370,8 @@ void blmbycar_state::prg_map(address_map &map)
 
 uint16_t watrball_state::unk_r()
 {
-	m_retvalue ^= 0x0008; // must toggle.. but not vblank?
+	if (!machine().side_effects_disabled())
+		m_retvalue ^= 0x0008; // must toggle.. but not vblank?
 	return m_retvalue;
 }
 
@@ -608,7 +609,7 @@ void base_state::base(machine_config &config)
 
 	BLMBYCAR_SPRITES(config, m_sprites, 0);
 	m_sprites->set_gfxdecode_tag("gfxdecode");
-	m_sprites->set_screen_tag("screen");
+	m_sprites->set_screen("screen");
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
@@ -688,7 +689,7 @@ ROM_START( blmbycar )
 	ROM_LOAD( "bc_rom9",   0x100000, 0x080000, CRC(0337ab3d) SHA1(18c72cd640c7b599390dffaeb670f5832202bf06) )
 	ROM_LOAD( "bc_rom10",  0x180000, 0x080000, CRC(5458917e) SHA1(c8dd5a391cc20a573e27a140b185893a8c04859e) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // 8 bit ADPCM (banked)
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM (banked)
 	ROM_LOAD( "bc_rom1",     0x000000, 0x080000, CRC(ac6f8ba1) SHA1(69d2d47cdd331bde5a8973d29659b3f8520452e7) )
 	ROM_LOAD( "bc_rom2",     0x080000, 0x080000, CRC(a4bc31bf) SHA1(f3d60141a91449a73f6cec9f4bc5d95ca7911e19) )
 ROM_END
@@ -704,7 +705,7 @@ ROM_START( blmbycaru )
 	ROM_LOAD( "bc_rom9",   0x100000, 0x080000, CRC(0337ab3d) SHA1(18c72cd640c7b599390dffaeb670f5832202bf06) )
 	ROM_LOAD( "bc_rom10",  0x180000, 0x080000, CRC(5458917e) SHA1(c8dd5a391cc20a573e27a140b185893a8c04859e) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // 8 bit ADPCM (banked)
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM (banked)
 	ROM_LOAD( "bc_rom1",     0x000000, 0x080000, CRC(ac6f8ba1) SHA1(69d2d47cdd331bde5a8973d29659b3f8520452e7) )
 	ROM_LOAD( "bc_rom2",     0x080000, 0x080000, CRC(a4bc31bf) SHA1(f3d60141a91449a73f6cec9f4bc5d95ca7911e19) )
 ROM_END
@@ -736,7 +737,7 @@ ROM_START( watrball )
 	ROM_LOAD( "rom9.bin",   0x100000, 0x080000, CRC(122cc0ad) SHA1(27cdb19fa082089e47c5cdb44742cfd93aa23a00) )
 	ROM_LOAD( "rom10.bin",  0x180000, 0x080000, CRC(22a2a706) SHA1(c7350a94a857e0007d7fc0076b44a3d62693cb6c) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // 8 bit ADPCM (banked)
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM (banked)
 	ROM_LOAD( "rom1.bin",     0x000000, 0x080000, CRC(7f88dee7) SHA1(d493b961fa4631185a33faee7f61786430707209))
 //  ROM_LOAD( "rom2.bin",     0x080000, 0x080000, // not populated for this game
 ROM_END

--- a/src/mame/gaelco/gaelco_wrally_sprites.h
+++ b/src/mame/gaelco/gaelco_wrally_sprites.h
@@ -7,13 +7,12 @@
 
 #include "screen.h"
 
-class gaelco_wrally_sprites_device : public device_t
+class gaelco_wrally_sprites_device : public device_t, public device_video_interface
 {
 public:
 	gaelco_wrally_sprites_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	template <typename T> void set_gfxdecode_tag(T &&tag) { m_gfxdecode.set_tag(std::forward<T>(tag)); }
-	template <typename T> void set_screen_tag(T &&tag) { m_screen.set_tag(std::forward<T>(tag)); }
 
 	void draw_sprites(const rectangle &cliprect, uint16_t* spriteram, int flip_screen);
 	void mix_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, int priority);
@@ -28,7 +27,6 @@ protected:
 
 private:
 	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<screen_device> m_screen;
 
 	bitmap_ind16 m_temp_bitmap_sprites;
 };

--- a/src/mame/gaelco/wrally.cpp
+++ b/src/mame/gaelco/wrally.cpp
@@ -239,11 +239,11 @@ private:
 template <int Layer>
 TILE_GET_INFO_MEMBER(wrally_state::get_tile_info)
 {
-	int const data = m_videoram[(Layer * 0x2000 / 2) + (tile_index << 1)];
-	int const data2 = m_videoram[(Layer * 0x2000 / 2) + (tile_index << 1) + 1];
+	int const data = m_videoram[(Layer << 12) + (tile_index << 1)];
+	int const data2 = m_videoram[(Layer << 12) + (tile_index << 1) + 1];
 	int const code = data & 0x3fff;
 
-	tileinfo.category = (data2 >> 5) & 0x01;
+	tileinfo.category = BIT(data2, 5);
 
 	tileinfo.set(0, code, data2 & 0x1f, TILE_FLIPYX((data2 >> 6) & 0x03));
 }
@@ -274,12 +274,15 @@ uint32_t wrally_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap
 	m_sprites->draw_sprites(cliprect, m_spriteram, flip_screen());
 
 	// set scroll registers
-	if (!flip_screen()) {
+	if (!flip_screen())
+	{
 		m_tilemap[0]->set_scrolly(0, m_vregs[0]);
 		m_tilemap[0]->set_scrollx(0, m_vregs[1] + 4);
 		m_tilemap[1]->set_scrolly(0, m_vregs[2]);
 		m_tilemap[1]->set_scrollx(0, m_vregs[3]);
-	} else {
+	}
+	else
+	{
 		m_tilemap[0]->set_scrolly(0, 248 - m_vregs[0]);
 		m_tilemap[0]->set_scrollx(0, 1024 - m_vregs[1] - 4);
 		m_tilemap[1]->set_scrolly(0, 248 - m_vregs[2]);
@@ -288,15 +291,15 @@ uint32_t wrally_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap
 
 	// draw tilemaps + sprites
 	m_tilemap[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_CATEGORY(0) | TILEMAP_DRAW_LAYER0,0);
-	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_CATEGORY(0) | TILEMAP_DRAW_LAYER1,0);
+	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_CATEGORY(0) | TILEMAP_DRAW_LAYER0, 0);
+	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_CATEGORY(0) | TILEMAP_DRAW_LAYER1, 0);
 
 	m_tilemap[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_CATEGORY(1), 0);
-	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_CATEGORY(1) | TILEMAP_DRAW_LAYER0,0);
+	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_CATEGORY(1) | TILEMAP_DRAW_LAYER0, 0);
 
 	m_sprites->mix_sprites(bitmap, cliprect, 0);
 
-	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_CATEGORY(1) | TILEMAP_DRAW_LAYER1,0);
+	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_CATEGORY(1) | TILEMAP_DRAW_LAYER1, 0);
 
 	m_sprites->mix_sprites(bitmap, cliprect, 1);
 
@@ -358,7 +361,7 @@ void wrally_state::coin_lockout_w(int state)
 template <int N>
 int wrally_state::analog_bit_r()
 {
-	return (m_analog_ports[N] >> 7) & 0x01;
+	return BIT(m_analog_ports[N], 7);
 }
 
 void wrally_state::adc_clk(int state)
@@ -512,7 +515,7 @@ static const gfx_layout wrally_tilelayout16 =
 };
 
 static GFXDECODE_START( gfx_wrally )
-	GFXDECODE_ENTRY( "gfx", 0x000000, wrally_tilelayout16, 0, 64*8 )
+	GFXDECODE_ENTRY( "gfx", 0, wrally_tilelayout16, 0, 64*8 )
 GFXDECODE_END
 
 
@@ -544,7 +547,7 @@ void wrally_state::wrally(machine_config &config)
 
 	GAELCO_WRALLY_SPRITES(config, m_sprites, 0);
 	m_sprites->set_gfxdecode_tag("gfxdecode");
-	m_sprites->set_screen_tag("screen");
+	m_sprites->set_screen("screen");
 
 	LS259(config, m_outlatch);
 	m_outlatch->q_out_cb<0>().set(FUNC(wrally_state::coin_lockout_w<0>));
@@ -585,7 +588,7 @@ ROM_START( wrally )
 	ROM_LOAD16_BYTE( "worldr19.i09", 0x100000, 0x080000, CRC(018b35bb) SHA1(ca789e23d18cc7d7e48b6858e6b61e03bf88b475) )
 	ROM_LOAD16_BYTE( "worldr18.i07", 0x100001, 0x080000, CRC(b37c807e) SHA1(9e6155a2b5206c0d4dca669d24d9fe9830027651) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples - sound chip is OKIM6295
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "worldr14.c01",   0x000000, 0x080000, CRC(e931c2ee) SHA1(ea1cf8ad52713e5136a370e289567eea9e6403d6) )
 	// 0x00000-0x2ffff is fixed, 0x30000-0x3ffff is bank switched from all the ROMs
 	ROM_LOAD( "worldr15.c03",   0x080000, 0x080000, CRC(11f0fe2c) SHA1(96c2a04874fa036576b7cfc5559bb0e33582ffd2) )
@@ -618,7 +621,7 @@ ROM_START( wrallya )
 	ROM_LOAD16_BYTE( "rally i9.i9",   0x100000, 0x080000, CRC(018b35bb) SHA1(ca789e23d18cc7d7e48b6858e6b61e03bf88b475) )
 	ROM_LOAD16_BYTE( "rally i7.i7",   0x100001, 0x080000, CRC(b37c807e) SHA1(9e6155a2b5206c0d4dca669d24d9fe9830027651) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples - sound chip is OKIM6295
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "rally c1.c1",   0x000000, 0x080000, CRC(e931c2ee) SHA1(ea1cf8ad52713e5136a370e289567eea9e6403d6) )
 	// 0x00000-0x2ffff is fixed, 0x30000-0x3ffff is bank switched from all the ROMs
 	ROM_LOAD( "rally c3.c3",   0x080000, 0x080000, CRC(11f0fe2c) SHA1(96c2a04874fa036576b7cfc5559bb0e33582ffd2) )
@@ -650,7 +653,7 @@ ROM_START( wrallyb )
 	ROM_LOAD( "rally h-12.h12", 0x000000, 0x100000, CRC(3353dc00) SHA1(db3b1686751dcaa231d66c08b5be81fcfe299ad9) ) // Same data, different layout
 	ROM_LOAD( "rally h-8.h8",   0x100000, 0x100000, CRC(58dcd024) SHA1(384ff296d3c7c8e0c4469231d1940de3cea89fc2) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples - sound chip is OKIM6295
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "sound c-1.c1", 0x000000, 0x100000, CRC(2d69c9b8) SHA1(328cb3c928dc6921c0c3f0277f59bca6c747c504) ) // Same data in a single ROM
 
 	ROM_REGION( 0x0514, "plds", 0 ) // PALs and GALs
@@ -681,7 +684,7 @@ ROM_START( wrallyc )
 	ROM_LOAD16_BYTE( "worldr19.i09", 0x100000, 0x080000, CRC(018b35bb) SHA1(ca789e23d18cc7d7e48b6858e6b61e03bf88b475) )
 	ROM_LOAD16_BYTE( "worldr18.i07", 0x100001, 0x080000, CRC(b37c807e) SHA1(9e6155a2b5206c0d4dca669d24d9fe9830027651) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples - sound chip is OKIM6295
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "worldr14.c01",   0x000000, 0x080000, CRC(e931c2ee) SHA1(ea1cf8ad52713e5136a370e289567eea9e6403d6) )
 	// 0x00000-0x2ffff is fixed, 0x30000-0x3ffff is bank switched from all the ROMs
 	ROM_LOAD( "worldr15.c03",   0x080000, 0x080000, CRC(11f0fe2c) SHA1(96c2a04874fa036576b7cfc5559bb0e33582ffd2) )
@@ -714,7 +717,7 @@ ROM_START( wrallyd )
 	ROM_LOAD16_BYTE( "worldr19.i09", 0x100000, 0x080000, CRC(018b35bb) SHA1(ca789e23d18cc7d7e48b6858e6b61e03bf88b475) )
 	ROM_LOAD16_BYTE( "worldr18.i07", 0x100001, 0x080000, CRC(b37c807e) SHA1(9e6155a2b5206c0d4dca669d24d9fe9830027651) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples - sound chip is OKIM6295
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "worldr14.c01",   0x000000, 0x080000, CRC(e931c2ee) SHA1(ea1cf8ad52713e5136a370e289567eea9e6403d6) )
 	// 0x00000-0x2ffff is fixed, 0x30000-0x3ffff is bank switched from all the ROMs
 	ROM_LOAD( "worldr15.c03",   0x080000, 0x080000, CRC(11f0fe2c) SHA1(96c2a04874fa036576b7cfc5559bb0e33582ffd2) )
@@ -747,7 +750,7 @@ ROM_START( wrallye )
 	ROM_LOAD16_BYTE( "worldr19.i09", 0x100000, 0x080000, CRC(018b35bb) SHA1(ca789e23d18cc7d7e48b6858e6b61e03bf88b475) )
 	ROM_LOAD16_BYTE( "worldr18.i07", 0x100001, 0x080000, CRC(b37c807e) SHA1(9e6155a2b5206c0d4dca669d24d9fe9830027651) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples - sound chip is OKIM6295
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "worldr14.c01",   0x000000, 0x080000, CRC(e931c2ee) SHA1(ea1cf8ad52713e5136a370e289567eea9e6403d6) )
 	// 0x00000-0x2ffff is fixed, 0x30000-0x3ffff is bank switched from all the ROMs
 	ROM_LOAD( "worldr15.c03",   0x080000, 0x080000, CRC(11f0fe2c) SHA1(96c2a04874fa036576b7cfc5559bb0e33582ffd2) )
@@ -780,7 +783,7 @@ ROM_START( wrallyac )
 	ROM_LOAD16_BYTE( "worldr19.i09", 0x100000, 0x080000, CRC(018b35bb) SHA1(ca789e23d18cc7d7e48b6858e6b61e03bf88b475) )
 	ROM_LOAD16_BYTE( "worldr18.i07", 0x100001, 0x080000, CRC(b37c807e) SHA1(9e6155a2b5206c0d4dca669d24d9fe9830027651) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples - sound chip is OKIM6295
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "worldr14.c01",   0x000000, 0x080000, CRC(e931c2ee) SHA1(ea1cf8ad52713e5136a370e289567eea9e6403d6) )
 	// 0x00000-0x2ffff is fixed, 0x30000-0x3ffff is bank switched from all the ROMs
 	ROM_LOAD( "worldr15.c03",   0x080000, 0x080000, CRC(11f0fe2c) SHA1(96c2a04874fa036576b7cfc5559bb0e33582ffd2) )
@@ -811,7 +814,7 @@ ROM_START( wrallyat ) // Board marked 930217, Atari license
 	ROM_LOAD( "rally h-12.h12", 0x000000, 0x100000, CRC(3353dc00) SHA1(db3b1686751dcaa231d66c08b5be81fcfe299ad9) ) // Same data, different layout
 	ROM_LOAD( "rally h-8.h8",   0x100000, 0x100000, CRC(58dcd024) SHA1(384ff296d3c7c8e0c4469231d1940de3cea89fc2) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples - sound chip is OKIM6295
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "sound c-1.c1", 0x000000, 0x100000, CRC(2d69c9b8) SHA1(328cb3c928dc6921c0c3f0277f59bca6c747c504) ) // Same data in a single ROM
 
 	ROM_REGION( 0x0514, "plds", 0 ) // PALs and GALs
@@ -840,7 +843,7 @@ ROM_START( wrallyata ) // Board marked REF. 930217, Atari license
 	ROM_LOAD( "rally h-12.h12", 0x000000, 0x100000, CRC(3353dc00) SHA1(db3b1686751dcaa231d66c08b5be81fcfe299ad9) ) // Same data, different layout
 	ROM_LOAD( "rally h-8.h8",   0x100000, 0x100000, CRC(58dcd024) SHA1(384ff296d3c7c8e0c4469231d1940de3cea89fc2) )
 
-	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples - sound chip is OKIM6295
+	ROM_REGION( 0x100000, "oki", 0 )    // ADPCM samples
 	ROM_LOAD( "sound c-1.c1", 0x000000, 0x100000, CRC(2d69c9b8) SHA1(328cb3c928dc6921c0c3f0277f59bca6c747c504) ) // Same data in a single ROM
 
 	ROM_REGION( 0x0514, "plds", 0 ) // PALs and GALs


### PR DESCRIPTION
- Minor optimization in sprite draw routine
- Fix spacings
- Use BIT macro for single bit values
- Make some variables constant

gaelco/blmbycar.cpp: Minor cleanups
- Suppress side effects for debugger reads
- Fix comments
- Use BIT macro for single bit values

gaelco/wrally.cpp: Minor cleanups
- Fix some code style consistency
- Use shift for per-tilemap RAM offset
- Fix spacings
- Fix comments
- Use BIT macro for single bit values