### PR TITLE
apple2: cleanup IOUDIS

### DIFF
--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -1786,11 +1786,11 @@ void apple2e_state::do_io(int offset, bool is_iic)
 			switch (offset)
 			{
 				case 0x5e:  // SETDHIRES
-					m_video->dhires_w(0);
+					m_video->an3_w(0);
 					break;
 
 				case 0x5f:  // CLRDHIRES
-					m_video->dhires_w(1);
+					m_video->an3_w(1);
 					break;
 			}
 		}

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -1416,13 +1416,13 @@ void apple2gs_state::do_io(int offset)
 		case 0x5e: // AN3 off, DHIRESON
 			m_an3 = false;
 			m_gameio->an3_w(0);
-			m_video->dhires_w(0);
+			m_video->an3_w(0);
 			break;
 
 		case 0x5f: // AN3 on, DHIRESOFF
 			m_an3 = true;
 			m_gameio->an3_w(1);
-			m_video->dhires_w(1);
+			m_video->an3_w(1);
 			break;
 
 		case 0x69:  // 16-bit access to STATEREG

--- a/src/mame/apple/apple2video.cpp
+++ b/src/mame/apple/apple2video.cpp
@@ -133,7 +133,12 @@ void a2_video_device::res_w(int state)
 	m_hires = state;
 }
 
-void a2_video_device::dhires_w(int state)
+void a2_video_device::an2_w(int state)
+{
+	m_an2 = state;
+}
+
+void a2_video_device::an3_w(int state)
 {
 	// select double hi-res
 	screen().update_now();
@@ -146,11 +151,6 @@ void a2_video_device::dhires_w(int state)
 	}
 
 	m_dhires = !state;
-}
-
-void a2_video_device::an2_w(int state)
-{
-	m_an2 = state;
 }
 
 void a2_video_device::a80col_w(bool b80Col)

--- a/src/mame/apple/apple2video.h
+++ b/src/mame/apple/apple2video.h
@@ -31,8 +31,8 @@ public:
 	void mix_w(int state);
 	void scr_w(int state);
 	void res_w(int state);
-	void dhires_w(int state);
 	void an2_w(int state);
+	void an3_w(int state);
 
 	bool get_graphics() const   { return m_graphics; }
 	bool get_hires() const      { return m_hires; }


### PR DESCRIPTION
This PR fixes a recent regression, and cleans up IOUDIS:

* apple2e: fix regression in 85e73ca reintroducing #12468
In 0.281, apple2c0 fails the GLU self-test again.  Reverting the RDIOUDIS polarity fixes it, and DGR still works, using examples [one](http://devonhubner.org/Applesoft_BASIC_Double_Low_Resolution_Graphics/) or [two](http://github.com/ibrumby/Crossrunner-Issues/issues/49).

* apple2e: IOUDIS and RDDHIRES only exist on the IIc
I did some [archeology](http://forums.bannister.org/ubbthreads.php?ubb=showflat&Number=115202#Post115202) here, and the TLDR is that Apple copy-pasted [wrong information](http://archive.org/details/apple-iie-technical-reference-manual-1987-edition/page/30/mode/2up) into the IIe Technical References, so everyone [was confused](http://github.com/mamedev/mame/commit/6a4854bbc0905281ff29c58457b2d7723a23373e).  AppleWin has a [similar issue](http://github.com/AppleWin/AppleWin/issues/636#issuecomment-480530115) open, which I've verified on a physical Apple IIe Enhanced.  But why stop there, when we can visualize the entire softswitch range at once:

![Switches_apple2ee_HW](https://github.com/user-attachments/assets/42e4d186-c91a-4104-81b2-d7bfe4b4f3ef)
[Switches_251013.zip](https://github.com/user-attachments/files/22894536/Switches_251013.zip) (updated [per thread](http://www.applefritter.com/content/help-wanted-testing-softswitches#comment-113310))

This uses carefully controlled floating bus readback to indicate which softswitches (or the low 7 bits) are floating, which on the IIe is C020-C08F.  We can see that C07E/7F (and mirrors) are entirely floating, which definitively tells us that RDIOUDIS and RDDHIRES don't exist.

Here's 0.281 before this PR (via `apple2ee -gameio ""`, to match my hardware)
<img width="560" height="384" alt="Switches_apple2ee_281_before" src="https://github.com/user-attachments/assets/d2b15908-3d85-4764-b46a-2965aa4e9bd7" />
C078-7F clearly show that only the low 7 bits are floating, which was wrong.

* apple2video: rename dhires_w to reduce confusion
This is merely naming clarification.  I'm not sure if the IIc's RDDHIRES polarity is actually correct, I'm [looking for someone to test it](http://www.applefritter.com/content/help-wanted-testing-softswitches).



TODO:
* apple2c* allows -gameio compeyes (and it continues to function after this PR), but in reality this is [physically impossible to connect](http://www.digital-vision-inc.com/products/CE-AppleII/CE_Apple_pic.jpg).
* The SWITCHES test also shows errors with the C05x video softswitches. This happens because the (page2/mixed/lores etc) video mode is changed prior to the floating bus read, and gets random data (instead of the controlled HGR black/white.)  On real IIe hardware, the video switches are latched with a ~2 cycle delay, after the floating bus readback, and the test is completely deterministic (assuming you don't press a key while it is running.)

