### PR TITLE
minitel2: Improved ROM list

### DIFF
--- a/src/mame/philips/minitel_2_rpic.cpp
+++ b/src/mame/philips/minitel_2_rpic.cpp
@@ -2,7 +2,7 @@
 // copyright-holders: Jean-Francois DEL NERO
 /***************************************************************************
 
-    Minitel 2
+    Minitel 2 by Philips
 
     The Minitel is a small, on-line computer/Videotex terminal with multi-services that
     can be connected to any French telephone line. This terminal was widely used in France
@@ -11,7 +11,9 @@
     There are several models and versions. Most of them are based on 8051 compatible MCUs
     and EF9345 semi graphic video chip.
 
-    The current implementation is a Minitel 2 from "La RADIOTECHNIQUE PORTENSEIGNE" / RPIC (Philips)
+    The current implementation is a Minitel 2 (NFZ 400) from "La RADIOTECHNIQUE
+    PORTENSEIGNE" (RPIC, later acquired by Philips).
+
     More Minitel hardware related informations are available on this page :
     http://hxc2001.free.fr/minitel
 
@@ -60,6 +62,8 @@
 
 #include "emu.h"
 
+#include "bus/generic/carts.h"
+#include "bus/generic/slot.h"
 #include "bus/rs232/rs232.h"
 #include "cpu/mcs51/mcs51.h"
 #include "machine/clock.h"
@@ -113,6 +117,7 @@ public:
 	minitel_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
+		, m_romslot(*this, "romslot")
 		, m_ts9347(*this, "ts9347")
 		, m_palette(*this, "palette")
 		, m_i2cmem(*this, "i2cmem")
@@ -129,6 +134,7 @@ protected:
 
 private:
 	required_device<i80c32_device> m_maincpu;
+	required_device<generic_slot_device> m_romslot;
 	required_device<ts9347_device> m_ts9347;
 	required_device<palette_device> m_palette;
 	required_device<i2cmem_device> m_i2cmem;
@@ -178,6 +184,9 @@ void minitel_state::machine_start()
 	m_palette->set_pen_color(5, 120, 120, 120);
 	m_palette->set_pen_color(6, 200, 200, 200);
 	m_palette->set_pen_color(7, 255, 255, 255);
+
+	if (m_romslot->exists())
+		m_maincpu->space(AS_PROGRAM).install_read_handler(0x0000, 0xffff, emu::rw_delegate(*m_romslot, FUNC(generic_slot_device::read_rom)));
 }
 
 void minitel_state::port1_w(uint8_t data)
@@ -529,6 +538,9 @@ void minitel_state::minitel2(machine_config &config)
 	m_maincpu->port_in_cb<3>().set(FUNC(minitel_state::port3_r));
 	m_maincpu->port_out_cb<3>().set(FUNC(minitel_state::port3_w));
 
+	/* if populated, this ROM slot replaces the main ROM */
+	GENERIC_SOCKET(config, m_romslot, generic_linear_slot, "minitel_rom", "bin,rom");
+
 	I2C_24C02(config, m_i2cmem);
 
 	TS9347(config, m_ts9347, 0);
@@ -564,18 +576,23 @@ void minitel_state::minitel2(machine_config &config)
 }
 
 ROM_START( minitel2 )
-
 	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_DEFAULT_BIOS("ft_bv4")
 
-	ROM_SYSTEM_BIOS(0, "ft_bv4", "Minitel 2 ROM BV4")
+	ROM_SYSTEM_BIOS(0, "ft_bv4", "France Telecom Bv4")
 	ROMX_LOAD( "minitel2_bv4.bin",   0x0000, 0x8000, CRC(8844a0a7) SHA1(d3e9079b080dbcee27ad870ec6c39ac42e7deacf), ROM_BIOS(0) )
 
-	ROM_SYSTEM_BIOS(1, "demov1", "Minitel 2 Demo")
-	ROMX_LOAD( "demo_minitel.bin",   0x0000, 0x8000, CRC(607f2482) SHA1(7965edbef68e45d09dc67a4684da56003eff6328), ROM_BIOS(1) )
+	ROM_SYSTEM_BIOS(1, "ft_bv6", "France Telecom Bv6")
+	ROMX_LOAD( "bv6.bin",            0x0000, 0x8000, CRC(9e162977) SHA1(e66a0951d14be4f9da693c478319d1c620878347), ROM_BIOS(1) )
 
-	ROM_SYSTEM_BIOS(2, "ft_bv9", "Minitel 2 ROM Bv9")
-	ROMX_LOAD( "bv9.1402",           0x0000, 0x8000, CRC(ace5d65e) SHA1(c8d589f8af6bd7d339964fdece937a76db972115), ROM_BIOS(2) )
+	ROM_SYSTEM_BIOS(2, "ft_bv7", "France Telecom Bv7")
+	ROMX_LOAD( "bv7.bin",            0x0000, 0x8000, CRC(2dde1628) SHA1(85500c06b93efb6e925dcb156248425fa3366ce6), ROM_BIOS(2) )
+
+	ROM_SYSTEM_BIOS(3, "ft_bv9", "France Telecom Bv9")
+	ROMX_LOAD( "bv9.1402",           0x0000, 0x8000, CRC(ace5d65e) SHA1(c8d589f8af6bd7d339964fdece937a76db972115), ROM_BIOS(3) )
+
+	ROM_SYSTEM_BIOS(4, "demov1", "The Minitel Demo (jfdelnero)")
+	ROMX_LOAD( "demo_minitel.bin",   0x0000, 0x8000, CRC(607f2482) SHA1(7965edbef68e45d09dc67a4684da56003eff6328), ROM_BIOS(4) )
 
 	ROM_REGION( 0x4000, "ts9347", 0 )
 	ROM_LOAD( "charset.rom", 0x0000, 0x2000, BAD_DUMP CRC(b2f49eb3) SHA1(d0ef530be33bfc296314e7152302d95fdf9520fc) )            // from dcvg5k
@@ -583,4 +600,4 @@ ROM_END
 
 } // anonymous namespace
 
-COMP( 1989, minitel2, 0, 0, minitel2, minitel2, minitel_state, empty_init, "Philips", "Minitel 2", MACHINE_NO_SOUND )
+COMP( 1989, minitel2, 0, 0, minitel2, minitel2, minitel_state, empty_init, "Philips", "Minitel 2 NFZ 400", MACHINE_NO_SOUND )


### PR DESCRIPTION
Different revisions of the Minitel 2 came with slightly different ROMs. In addition to the ones already listed (Bv4 and Bv9), this commits adds references to Bv6 and Bv7 too.

The descriptions of the ROMs were updated to mention "France Telecom" (the "ft_" in their names), who commissioned this Minitel model.

A placeholder "Custom ROM (for homebrew development)" was added too, with the maximum possible size (64 KiB). This makes it easy use precompiled MAME binaries to test/debug an homebrew ROM too, by simply copying it into the roms directory under the name "devel.bin" and then booting with "-bios devel".

cc @jfdelnero 