### PR TITLE
axc51: Fix destination RAM type in XCHD A, @R0/@R1

### DIFF
--- a/src/devices/cpu/axc51/axc51ops.hxx
+++ b/src/devices/cpu/axc51/axc51ops.hxx
@@ -994,7 +994,7 @@ void axc51base_cpu_device::xchd_a_ir(uint8_t r)
 	ir_data = iram_indirect_read(R_REG(r));                //Grab data pointed to by R0 or R1
 	acc = ACC;                          //Grab ACC value
 	SET_ACC( (acc & 0xf0) | (ir_data & 0x0f) );     //Set ACC to lower nibble of data pointed to by R0 or R1
-	iram_write(R_REG(r), (ir_data & 0xf0) | (acc & 0x0f) ); //Set data pointed to by R0 or R1 to lower nibble of ACC
+	iram_indirect_write(R_REG(r), (ir_data & 0xf0) | (acc & 0x0f) ); //Set data pointed to by R0 or R1 to lower nibble of ACC
 }
 
 //XRL data addr, A                          /* 1: 0110 0010 */


### PR DESCRIPTION
This commit applies the same fix as PR #14289 to axc51 too, as suggested by @mamehaze