### PR TITLE
ef9345: Fix TS9347 font rendering and IND ROM command

### DIFF
--- a/src/devices/video/ef9345.cpp
+++ b/src/devices/video/ef9345.cpp
@@ -65,16 +65,6 @@ inline uint16_t ef9345_device::indexram(uint8_t r)
 	return ((x&0x3f) | ((x & 0x40) << 6) | ((x & 0x80) << 4) | ((y & 0x1f) << 6) | ((y & 0x20) << 8));
 }
 
-// calculate the internal ROM offset
-inline uint16_t ef9345_device::indexrom(uint8_t r)
-{
-	uint8_t x = m_registers[r];
-	uint8_t y = m_registers[r - 1];
-	if (y < 8)
-		y &= 1;
-	return((x&0x3f)|((x&0x40)<<6)|((x&0x80)<<4)|((y&0x1f)<<6));
-}
-
 // increment x
 inline void ef9345_device::inc_x(uint8_t r)
 {
@@ -602,10 +592,11 @@ void ef9345_device::bichrome80(uint8_t c, uint8_t a, uint16_t x, uint16_t y, boo
 	c1 = (a & 1) ? (m_dor >> 4) & 7 : m_dor & 7;    //foreground color = DOR
 	c0 =  m_mat & 7;                                //background color = MAT
 
-	switch(c & 0x80)
+	if (m_variant == EF9345_MODE::TYPE_TS9347 || (c & 0x80) == 0) //alphanumeric G0 set
 	{
-	case 0: //alphanumeric G0 set
-	{
+		// On the TS9347, G11 comes right after G0 starting from char 128.
+		uint8_t index = (c & 0x80) ? 3 : 0;
+
 		//A0: D = color set
 		//A1: U = underline
 		//A2: F = flash
@@ -623,7 +614,7 @@ void ef9345_device::bichrome80(uint8_t c, uint8_t a, uint16_t x, uint16_t y, boo
 
 		for (i=0, j=0; i < 10; i++)
 		{
-			uint8_t ch = read_char(0, d + 4 * i);
+			uint8_t ch = read_char(index, d + 4 * i);
 			for (uint8_t b=0; b<6; b++)
 				pix[j++] = (ch & (1<<b)) ? c1 : c0;
 		}
@@ -631,9 +622,8 @@ void ef9345_device::bichrome80(uint8_t c, uint8_t a, uint16_t x, uint16_t y, boo
 		//draw the underline
 		if (underline)
 			memset(&pix[54], c1, 6);
-		break;
 	}
-	default: //dedicated mosaic set
+	else //dedicated mosaic set (EF9345 only)
 	{
 		//A0: D = color set
 		//A1-3: 3 blocks de 6 pixels
@@ -665,8 +655,6 @@ void ef9345_device::bichrome80(uint8_t c, uint8_t a, uint16_t x, uint16_t y, boo
 		//draw the underline
 		if (cursor_underline)
 			memset(&pix[54], c1, 6);
-		break;
-	}
 	}
 
 	draw_char_80(pix, x, y);
@@ -744,6 +732,8 @@ void ef9345_device::makechar_24x40(uint16_t x, uint16_t y)
 	//type and address of the char
 	address = ((c & 0x7f) >> 2) * 0x40 + (c & 0x03);
 	type = (b & 0xf0) >> 4;
+	if (m_variant == EF9345_MODE::TYPE_TS9347 && !(type & 0x8))
+		type &= 0x3; // drop the i2 bit, which is not part of the type
 
 	//char attributes
 	c0 = a & 0x07;                  //background
@@ -998,7 +988,16 @@ void ef9345_device::ef9345_exec(uint8_t cmd)
 			set_busy_flag(3500);
 			switch(cmd&7)
 			{
-				case 0:     m_registers[1] = m_charset[indexrom(7) & 0x1fff]; break;
+				case 0:
+				{
+					uint8_t type = ((m_registers[6]&0x20)>>3) | ((m_registers[7]&0x40)>>5) | ((m_registers[7]&0x80)>>7);
+					if (m_variant == EF9345_MODE::TYPE_TS9347)
+						type &= 0x3; // 4-7 are aliases of 0-3 on the TS9347
+
+					uint16_t addr = ((m_registers[6]&0x1f)<<6) | (m_registers[7]&0x3f);
+					m_registers[1] = read_char(type, addr); // read slice from ROM
+					break;
+				}
 				case 1:     m_registers[1] = m_tgs; break;
 				case 2:     m_registers[1] = m_mat; break;
 				case 3:     m_registers[1] = m_pat; break;

--- a/src/devices/video/ef9345.h
+++ b/src/devices/video/ef9345.h
@@ -61,7 +61,6 @@ protected:
 
 	// inline helpers
 	inline uint16_t indexram(uint8_t r);
-	inline uint16_t indexrom(uint8_t r);
 	inline void inc_x(uint8_t r);
 	inline void inc_y(uint8_t r);
 

--- a/src/mame/philips/minitel_2_rpic.cpp
+++ b/src/mame/philips/minitel_2_rpic.cpp
@@ -577,8 +577,8 @@ ROM_START( minitel2 )
 	ROM_SYSTEM_BIOS(2, "ft_bv9", "Minitel 2 ROM Bv9")
 	ROMX_LOAD( "bv9.1402",           0x0000, 0x8000, CRC(ace5d65e) SHA1(c8d589f8af6bd7d339964fdece937a76db972115), ROM_BIOS(2) )
 
-	ROM_REGION( 0x4000, "ts9347", 0 )
-	ROM_LOAD( "charset.rom", 0x0000, 0x2000, BAD_DUMP CRC(b2f49eb3) SHA1(d0ef530be33bfc296314e7152302d95fdf9520fc) )            // from dcvg5k
+	ROM_REGION( 0x2000, "ts9347", 0 )
+	ROM_LOAD( "ts9347.bin", 0x0000, 0x2000, CRC(acff72e7) SHA1(54c8b6f5b6407f13a933a40b5b7742ca06cdc1a3) )
 ROM_END
 
 } // anonymous namespace


### PR DESCRIPTION
`src/devices/video/ef9345.cpp` supports both the EF9345 and the TS9347 video chips.

- In 40-column mode, unlike the EF9345, the TS9347 does not have dedicated fonts for accented characters. Instead, the bit that on the EF9345 would select those fonts is reused for a different purpose (the _i2_ flag, currently unimplemented). Before this commit, we were still interpreting this bit as if on the EF9345 and selecting the accented fonts. This commit ensures that the bit is ignored both while rendering and in the ROM access command (`IND ROM`).

- In 80-column mode, the TS9347 maps the ranges that the EF9345 would interpret as mosaic characters to a different set of regular characters and symbols. This commit ensures we render them correctly.

The new font ROM referenced by the `minitel2` machine (TS9347-based) has been checked with the real hardware.

Links:
- The new [`ts9347.bin`](https://gist.github.com/fabio-d/ca65f94be841a5e480da1a0786a33b99/raw/9bf0f6fa576ec3dff2207f5a2f9cecb8f7ae3d08/ts9347.bin) font file.
- [Tests](https://github.com/fabio-d/minitel-ef9345-testsuite/blob/main/tests/test_font.py) that were used to validate the rendering and the result of `IND ROM`.
- [Script](https://gist.github.com/fabio-d/ca65f94be841a5e480da1a0786a33b99) used to generate it, initially from the datasheet and then tweaked until everything matched the output of the chip.

cc @jfdelnero