### PR TITLE
ef9345: Make 80-col mode add margin similarly to 40-col mode

### DIFF
--- a/src/devices/video/ef9345.h
+++ b/src/devices/video/ef9345.h
@@ -70,8 +70,6 @@ protected:
 
 private:
 	void set_busy_flag(int period);
-	void draw_char_40(uint8_t *c, uint16_t x, uint16_t y);
-	void draw_char_80(uint8_t *c, uint16_t x, uint16_t y);
 	void set_video_mode(void);
 	void init_accented_chars(void);
 	uint8_t read_char(uint8_t index, uint16_t addr);
@@ -79,14 +77,26 @@ private:
 	void zoom(uint8_t *pix, uint16_t n);
 	uint16_t indexblock(uint16_t x, uint16_t y);
 	std::tuple<uint8_t, uint8_t, bool> makecolors(uint8_t c0, uint8_t c1, bool insert, bool flash, bool conceal, bool negative, bool cursor);
-	void bichrome40(uint8_t type, uint16_t address, uint8_t dial, uint16_t iblock, uint16_t x, uint16_t y, uint8_t c0, uint8_t c1, bool insert, bool flash, bool conceal, bool negative, bool underline);
-	void quadrichrome40(uint8_t c, uint8_t b, uint8_t a, uint16_t x, uint16_t y);
-	void bichrome80(uint8_t c, uint8_t a, uint16_t x, uint16_t y, bool cursor);
+
+	// Dispatch rendering of character (x, y) to one of the specialized
+	// drawing functions (bichrome40/quadrichrome40/bichrome80).
 	void makechar(uint16_t x, uint16_t y);
-	void draw_border(uint16_t line);
 	void makechar_16x40(uint16_t x, uint16_t y);
 	void makechar_24x40(uint16_t x, uint16_t y);
 	void makechar_12x80(uint16_t x, uint16_t y);
+
+	// Call draw_char_40/80 to draw the given character ** at (x + 1, y + 1) **.
+	// Why at (x + 1, y + 1) and not just at (x, y)? Because we need to leave
+	// some blank space at the top and at the left of the text area for the
+	// margin.
+	void bichrome40(uint8_t type, uint16_t address, uint8_t dial, uint16_t iblock, uint16_t x, uint16_t y, uint8_t c0, uint8_t c1, bool insert, bool flash, bool conceal, bool negative, bool underline);
+	void quadrichrome40(uint8_t c, uint8_t b, uint8_t a, uint16_t x, uint16_t y);
+	void bichrome80(uint8_t c, uint8_t a, uint16_t x, uint16_t y, bool cursor);
+
+	void draw_char_40(uint8_t *c, uint16_t x, uint16_t y);
+	void draw_char_80(uint8_t *c, uint16_t x, uint16_t y);
+	void draw_border(uint16_t line);
+
 	void ef9345_exec(uint8_t cmd);
 
 	void ef9345(address_map &map) ATTR_COLD;


### PR DESCRIPTION
This commit consists of comments explaining a very subtle detail about a change of coordinates, plus the one minor change described below. In the light of this subtle detail, it is apparent that `update_scanline()` has a number of off-by-one issues. I will refactor and fix this logic in a separate commit.

The chain of calls that lead to rendering a character is:
- A timer calls `update_scanline` once every 10 lines of pixels. Conveniently, the EF9345 fonts have height = 10 pixels. Therefore, each `update_scanline()` call takes care of a full row of text.
- For each character in the row, `update_scanline()` calls `makechar(x, y)`.
- `makechar(x, y)` calls one of the specialized `makechar_NxM(x, y)` functions, depending of the current video mode.
- `makechar_NxM(x, y)` calls one of the even more specialized `bichrome40`/`quadrichrome40`/`bichrome80` (depending on both the video mode and the attributes the character).
- `bichrome40`/`quadrichrome40`/`bichrome80` bottom out to either `draw_char_40` or `draw_char_80`.

When `makechar(x, y)` is called, `x` and `y` refer to text coordinates. In other words, `(0, 0)` is the top-left text character.

However, as we go down in the call stack, at some point both coordinates are incremented. In other words, the top-left text character is going to be rendered at cell `(1, 1)`. This is so that the left column and the top row stay empty (in fact, they are filled with the configured margin color).

Before this commit, the incrementation happened at different stack levels for 40 columns and 80 columns mode: in 40-col mode it happened just before calling `draw_char_40`; in 80-col mode it happened just before calling `bichrome80`.

This commit moves the incrementation in 80-col mode so that, coherently to 40-col mode, it happens just before calling
`draw_char_80`.

The rest of the commit simply adds some explanatory comments.

The off-by-one calls to `draw_border` will be fixed in a separate commit.

cc @jfdelnero