### PR TITLE
luaengine_input.cpp: Export minvalue and maxvalue for IPT_ADJUSTER.

### DIFF
--- a/src/frontend/mame/luaengine_input.cpp
+++ b/src/frontend/mame/luaengine_input.cpp
@@ -395,12 +395,14 @@ void lua_engine::initialize_input(sol::table &emu)
 	ioport_field_type["minvalue"] = sol::property(
 			[] (ioport_field const &f)
 			{
-				return f.is_analog() ? std::make_optional(f.minval()) : std::nullopt;
+				const bool has_minmax = f.is_analog() || f.type() == IPT_ADJUSTER;
+				return has_minmax ? std::make_optional(f.minval()) : std::nullopt;
 			});
 	ioport_field_type["maxvalue"] = sol::property(
 			[] (ioport_field const &f)
 			{
-				return f.is_analog() ? std::make_optional(f.maxval()) : std::nullopt;
+				const bool has_minmax = f.is_analog() || f.type() == IPT_ADJUSTER;
+				return has_minmax ? std::make_optional(f.maxval()) : std::nullopt;
 			});
 	ioport_field_type["sensitivity"] = sol::property(
 			[] (ioport_field const &f)


### PR DESCRIPTION
IPT_ADJUSTERs have a min and max value, but those are not being exported to Lua scripts because IPT_ADJUSTER is not within IPT_ANALOG_FIRST and IPT_ANALOG_LAST (`is_analog()` returns false):
https://github.com/mamedev/mame/blob/71e7563495b2c58ede3a0c357110ad2e9a529f0f/src/emu/inpttype.h#L241-L244

This PR exposes ADJUSTER min and max to Lua scripts. This will allow scripts not to make assumptions about the range of adjusters. For example, this sort of thing is common in synth layouts: 
https://github.com/mamedev/mame/blob/71e7563495b2c58ede3a0c357110ad2e9a529f0f/src/mame/layout/linn_linndrum.lay#L702-L703, and it could be fixed if min and max were exposed.

If this PR looks OK, I can update the layout scripts to take advantage of it.
