### PR TITLE
[Model 2] Unoptimized preliminary support for mipmaps and trilinear filtering

### DIFF
--- a/src/devices/video/poly.h
+++ b/src/devices/video/poly.h
@@ -279,6 +279,7 @@ public:
 		{
 			BaseType start;                     // parameter value at start
 			BaseType dpdx;                      // dp/dx relative to start
+			BaseType dpdy;                      // dp/dy relative to start
 		};
 		int16_t startx, stopx;                  // starting (inclusive)/ending (exclusive) endpoints
 		std::array<param_t, MaxParams> param;   // array of parameter start/delays
@@ -786,6 +787,7 @@ uint32_t poly_manager<BaseType, ObjectType, MaxParams, Flags>::render_tile(recta
 				{
 					extent.param[paramnum].start = v1->p[paramnum] + fullstartx * param_dpdx[paramnum] + fully * param_dpdy[paramnum];
 					extent.param[paramnum].dpdx = param_dpdx[paramnum];
+					extent.param[paramnum].dpdy = param_dpdy[paramnum];
 				}
 			}
 		}
@@ -950,6 +952,7 @@ uint32_t poly_manager<BaseType, ObjectType, MaxParams, Flags>::render_triangle(c
 			{
 				extent.param[paramnum].start = param_start[paramnum] + fullstartx * param_dpdx[paramnum] + fully * param_dpdy[paramnum];
 				extent.param[paramnum].dpdx = param_dpdx[paramnum];
+				extent.param[paramnum].dpdy = param_dpdy[paramnum];
 			}
 		}
 	}
@@ -1066,6 +1069,7 @@ uint32_t poly_manager<BaseType, ObjectType, MaxParams, Flags>::render_extents(re
 			{
 				extent.param[paramnum].start = srcextent.param[paramnum].start;
 				extent.param[paramnum].dpdx = srcextent.param[paramnum].dpdx;
+				extent.param[paramnum].dpdy = srcextent.param[paramnum].dpdy;
 			}
 			extent.userdata = srcextent.userdata;
 
@@ -1248,6 +1252,7 @@ uint32_t poly_manager<BaseType, ObjectType, MaxParams, Flags>::render_polygon(re
 
 					extent.param[paramnum].start = lparam;// - (BaseType(istartx) + 0.5f) * dpdx;
 					extent.param[paramnum].dpdx = dpdx;
+					extent.param[paramnum].dpdy = ledge->dpdy[paramnum];
 				}
 			}
 

--- a/src/mame/sega/model2.h
+++ b/src/mame/sega/model2.h
@@ -621,15 +621,15 @@ struct m2_poly_extra_data
 	model2_state *  state;
 	u32      lumabase;
 	u32      colorbase;
-	u32 *    texsheet;
-	u32      texwidth;
-	u32      texheight;
-	u32      texx, texy;
+	u32 *    texsheet[6];
+	u32      texwidth[6];
+	u32      texheight[6];
+	u32      texx[6];
+	u32		 texy[6];
 	u8       texmirrorx;
 	u8       texmirrory;
 	u8       luma;
 };
-
 
 static inline u16 get_texel( u32 base_x, u32 base_y, int x, int y, u32 *sheet )
 {

--- a/src/mame/sega/model2_v.cpp
+++ b/src/mame/sega/model2_v.cpp
@@ -807,13 +807,40 @@ void model2_renderer::model2_3d_render(triangle *tri, const rectangle &cliprect)
 
 	if (renderer & 2)
 	{
-		extra.texwidth = 32 << ((tri->texheader[0] >> 0) & 0x7);
-		extra.texheight = 32 << ((tri->texheader[0] >> 3) & 0x7);
-		extra.texx = 32 * ((tri->texheader[2] >> 0) & 0x3f);
-		extra.texy = 32 * ((tri->texheader[2] >> 6) & 0x1f);
 		extra.texmirrorx = (tri->texheader[0] >> 8) & 1;
 		extra.texmirrory = (tri->texheader[0] >> 9) & 1;
-		extra.texsheet = (tri->texheader[2] & 0x1000) ? m_state.m_textureram1 : m_state.m_textureram0;
+
+		u32* sheet = (tri->texheader[2] & 0x1000) ? m_state.m_textureram1 : m_state.m_textureram0;
+		u32 width = 32 << ((tri->texheader[0] >> 0) & 0x7);
+		u32 height = 32 << ((tri->texheader[0] >> 3) & 0x7);
+		u32 posx = 32 * ( (tri->texheader[2] >> 0) & 0x3f );
+		u32 posy = 32 * ( (tri->texheader[2] >> 6) & 0x1f );
+
+		// 6 MIPS LEVELS
+		// EACH MIP LEVEL HAS HALF WIDTH AND HALF HEIGHT
+		// LOCATED RECURSIVELY IN THE BOTTOM RIGHT CORNER OF 2048x1024
+		// EACH LEVEL HAS FLIPPED RAM BANKS
+		for (u32 mip = 0; mip < 6; mip++)
+		{
+			extra.texsheet[mip] = sheet;
+			extra.texwidth[mip] = width;
+			extra.texheight[mip] = height;
+			extra.texx[mip] = posx;
+			extra.texy[mip] = posy;
+
+			width /= 2;
+			height /= 2;
+			posx = 2048 - (2048 - posx) / 2;
+			posy = 1024 - (1024 - posy) / 2;
+			if (sheet == m_state.m_textureram0)
+			{
+				sheet = m_state.m_textureram1;
+			}
+			else
+			{
+				sheet = m_state.m_textureram0;
+			}
+		}
 
 		tri->v[0].pz = 1.0f / (tri->v[0].pz + std::numeric_limits<float>::min());
 		tri->v[0].pu = tri->v[0].pu * tri->v[0].pz * (1.0f / 8.0f);
@@ -2667,8 +2694,7 @@ u32 model2_state::screen_update_model2(screen_device &screen, bitmap_rgb32 &bitm
 // TODO: fix forward declaration mess and move this function there instead
 void model2_state::tri_list_dump(FILE *dst)
 {
-	u32  i;
-
+	u32 i;
 	for( i = 0; i < m_raster->tri_list_index; i++ )
 	{
 		fprintf( dst, "index: %d\n", i );

--- a/src/mame/sega/model2rd.ipp
+++ b/src/mame/sega/model2rd.ipp
@@ -108,14 +108,96 @@ void MODEL2_FUNC_NAME(int32_t scanline, const extent_t& extent, const m2_poly_ex
 }
 
 #else
+#define MODEL2_CONCAT(x, y) x##y
+#define MODEL2_XCONCAT(x, y) MODEL2_CONCAT(x, y)
+#define MODEL2_BILINEAR_FUNC_NAME MODEL2_XCONCAT(MODEL2_FUNC_NAME,_BilinearSample)
+
+u32 MODEL2_BILINEAR_FUNC_NAME(const m2_poly_extra_data& object, const u32 miplevel, const float fu, const float fv )
+{
+	float lodfactor[6] = { 256.0f, 128.0f, 64.0f, 32.0f, 16.0f, 8.0f };
+	u32  tex_mirr_x = object.texmirrorx;
+	u32  tex_mirr_y = object.texmirrory;
+	u32  tex_width = object.texwidth[miplevel];
+	u32  tex_height = object.texheight[miplevel];
+	u32* sheet = object.texsheet[miplevel];
+	u32  tex_x = object.texx[miplevel];
+	u32  tex_y = object.texy[miplevel];
+	u32  tex_x_mask = tex_width - 1;
+	u32  tex_y_mask = tex_height - 1;
+	int32_t u = fu * lodfactor[miplevel];
+	int32_t v = fv * lodfactor[miplevel];
+	u32  t, tex1, tex2, tex3, tex4, frac1, frac2, frac3, frac4;
+#if defined(MODEL2_TRANSLUCENT)
+	u32  alp, alp1, alp2, alp3, alp4;
+#endif
+	int u2, u2n;
+	int v2, v2n;
+
+	u2 = u >> 8;
+	v2 = v >> 8;
+
+	if (tex_mirr_x && ((u2 & tex_width) != 0)) // Only flip if even number of tilings
+	{
+		u2 = (u2 ^ tex_x_mask) & tex_x_mask;
+		u2n = std::max(0, u2 - 1); // Ensure sample is inside texture
+	}
+	else
+	{
+		u2 &= tex_x_mask;
+		u2n = std::min(u2 + 1, (int)tex_x_mask); // Ensure sample is inside texture
+	}
+	if (tex_mirr_y && ((v2 & tex_height) != 0)) // Only flip if even number of tilings
+	{
+		v2 = (v2 ^ tex_y_mask) & tex_y_mask;
+		v2n = std::max(0, v2 - 1); // Ensure sample is inside texture
+	}
+	else
+	{
+		v2 &= tex_y_mask;
+		v2n = std::min(v2 + 1, (int)tex_y_mask);  // Ensure sample is inside texture
+	}
+
+	frac1 = u & 0xFF;
+	frac2 = 0x100 - frac1;
+	frac3 = v & 0xFF;
+	frac4 = 0x100 - frac3;
+	tex1 = get_texel(tex_x, tex_y, u2, v2, sheet);
+	tex2 = get_texel(tex_x, tex_y, u2n, v2, sheet);
+	tex3 = get_texel(tex_x, tex_y, u2, v2n, sheet);
+	tex4 = get_texel(tex_x, tex_y, u2n, v2n, sheet);
+#if defined(MODEL2_TRANSLUCENT)
+	alp1 = (tex1 + 1) >> 4;
+	alp2 = (tex2 + 1) >> 4;
+	alp3 = (tex3 + 1) >> 4;
+	alp4 = (tex4 + 1) >> 4;
+	alp = alp1 * frac2 * frac4 + alp2 * frac1 * frac4 + alp3 * frac2 * frac3 + alp4 * frac1 * frac3;
+	if (alp >= 0x8000)
+		return 0xFFFFFFFF;
+
+	// Anti Alpha Highlighted Edges
+	tex1 &= alp1 - 1;
+	tex2 &= alp2 - 1;
+	tex3 &= alp3 - 1;
+	tex4 &= alp4 - 1;
+	u32 maxValidTex = std::max(std::max(std::max(tex1, tex2), tex3), tex4);
+	if (alp1)
+		tex1 = maxValidTex;
+	if (alp2)
+		tex2 = maxValidTex;
+	if (alp3)
+		tex3 = maxValidTex;
+	if (alp4)
+		tex4 = maxValidTex;
+#endif
+	t = tex1 * frac2 * frac4 + tex2 * frac1 * frac4 + tex3 * frac2 * frac3 + tex4 * frac1 * frac3;
+	return t >> 8;
+}
+
 /* textured render path */
 void MODEL2_FUNC_NAME(int32_t scanline, const extent_t& extent, const m2_poly_extra_data& object, int threadid)
 {
 	model2_state *state = object.state;
 	u32 *const p = &m_destmap.pix(scanline);
-
-	u32  tex_width = object.texwidth;
-	u32  tex_height = object.texheight;
 
 	/* extract color information */
 	const u16 *colortable_r = &state->m_colorxlat[0x0000/2];
@@ -124,23 +206,20 @@ void MODEL2_FUNC_NAME(int32_t scanline, const extent_t& extent, const m2_poly_ex
 	const u16 *lumaram = &state->m_lumaram[0];
 	u32  colorbase = object.colorbase;
 	u32  lumabase = object.lumabase;
-	u32  tex_x = object.texx;
-	u32  tex_y = object.texy;
-	u32  tex_x_mask, tex_y_mask;
-	u32  tex_mirr_x = object.texmirrorx;
-	u32  tex_mirr_y = object.texmirrory;
-	u32 *sheet = object.texsheet;
 	u8  *gamma_value = &state->m_gamma_table[0];
 	float ooz = extent.param[0].start;
 	float uoz = extent.param[1].start;
 	float voz = extent.param[2].start;
 	float dooz = extent.param[0].dpdx;
-	float duoz = extent.param[1].dpdx;
-	float dvoz = extent.param[2].dpdx;
+	float dudxoz = extent.param[1].dpdx;
+	float dvdxoz = extent.param[2].dpdx;
+	float dudyoz = extent.param[1].dpdy;
+	float dvdyoz = extent.param[2].dpdy;
+	float norm = sqrtf( std::max(dudxoz * dudxoz + dvdxoz * dvdxoz, dudyoz * dudyoz + dvdyoz * dvdyoz) );
+	int  tr, tg, tb;
+	u32	t, t2;
+	u8 luma;
 	int     x;
-
-	tex_x_mask = tex_width - 1;
-	tex_y_mask = tex_height - 1;
 
 	colorbase = state->m_palram[(colorbase + 0x1000)] & 0x7fff;
 
@@ -148,83 +227,34 @@ void MODEL2_FUNC_NAME(int32_t scanline, const extent_t& extent, const m2_poly_ex
 	colortable_g += ((colorbase >>  5) & 0x1f) << 8;
 	colortable_b += ((colorbase >> 10) & 0x1f) << 8;
 
-	for (x = extent.startx; x < extent.stopx; x++, uoz += duoz, voz += dvoz, ooz += dooz)
+	for (x = extent.startx; x < extent.stopx; x++, uoz += dudxoz, voz += dvdxoz, ooz += dooz)
 	{
-		float z = recip_approx(ooz) * 256.0f;
-		int32_t u = uoz * z;
-		int32_t v = voz * z;
-		int  tr, tg, tb;
-		u32  t, tex1, tex2, tex3, tex4, frac1, frac2, frac3, frac4;
-#if defined(MODEL2_TRANSLUCENT)
-		u32  alp, alp1, alp2, alp3, alp4;
-#endif
-		u8 luma;
-		int u2, u2n;
-		int v2, v2n;
-
 #if defined(MODEL2_CHECKER)
 		if (((x ^ scanline) & 1) == 0)
 			continue;
 #endif
-		u2 = u >> 8;
-		v2 = v >> 8;
 
-		if (tex_mirr_x && ((u2 & tex_width) != 0)) // Only flip if even number of tilings
-		{
-			u2 = (u2 ^ tex_x_mask) & tex_x_mask;
-			u2n = std::max(0, u2 - 1); // Ensure sample is inside texture
-		}
-		else
-		{
-			u2 &= tex_x_mask;
-			u2n = std::min(u2 + 1, (int) tex_x_mask); // Ensure sample is inside texture
-		}
-		if (tex_mirr_y && ((v2 & tex_height) != 0)) // Only flip if even number of tilings
-		{
-			v2 = (v2 ^ tex_y_mask) & tex_y_mask;
-			v2n = std::max(0, v2 - 1); // Ensure sample is inside texture
-		}
-		else 
-		{
-			v2 &= tex_y_mask;
-			v2n = std::min(v2 + 1, (int) tex_y_mask);  // Ensure sample is inside texture
-		}
+		float z = recip_approx(ooz);
+		float mml = log2(norm * z) - 2.0f; // No parts are squared so no need for the usual 0.5 factor
+		u32 level = std::min(std::max(0, (int)mml), 4); // We need room for one more level for trilinear
+		float fu = uoz * z;
+		float fv = voz * z;
 
-		frac1 = u & 0xFF;
-		frac2 = 0x100 - frac1;
-		frac3 = v & 0xFF;
-		frac4 = 0x100 - frac3;
-		tex1 = get_texel(tex_x, tex_y, u2, v2, sheet);
-		tex2 = get_texel(tex_x, tex_y, u2n, v2, sheet);
-		tex3 = get_texel(tex_x, tex_y, u2, v2n, sheet);
-		tex4 = get_texel(tex_x, tex_y, u2n, v2n, sheet);
-#if defined(MODEL2_TRANSLUCENT)
-		alp1 = (tex1 + 1) >> 4;
-		alp2 = (tex2 + 1) >> 4;
-		alp3 = (tex3 + 1) >> 4;
-		alp4 = (tex4 + 1) >> 4;
-		alp = alp1 * frac2 * frac4 + alp2 * frac1 * frac4 + alp3 * frac2 * frac3 + alp4 * frac1 * frac3;
-		if ( alp >= 0x8000 )
+		t = MODEL2_BILINEAR_FUNC_NAME(object, level, fu, fv);
+		if (t == 0xFFFFFFFF)
 			continue;
-		// Anti Alpha Highlighted Edges
-		tex1 &= alp1 - 1;
-		tex2 &= alp2 - 1;
-		tex3 &= alp3 - 1;
-		tex4 &= alp4 - 1;
-		u32 maxValidTex = std::max(std::max(std::max(tex1, tex2), tex3), tex4);
-		if (alp1)
-			tex1 = maxValidTex;
-		if (alp2)
-			tex2 = maxValidTex;
-		if (alp3)
-			tex3 = maxValidTex;
-		if (alp4)
-			tex4 = maxValidTex;
-#endif
-		t = tex1 * frac2 * frac4 + tex2 * frac1 * frac4 + tex3 * frac2 * frac3 + tex4 * frac1 * frac3;
 
-		// Bilinear combination has 16 bits of precision, and the table needs t to be shifted by 3 on the left
-		luma = (u32)lumaram[lumabase + (t >> 13)] * object.luma / 256;
+		t2 = MODEL2_BILINEAR_FUNC_NAME(object, level + 1, fu, fv);
+		if (t2 != 0xFFFFFFFF)
+		{
+			// Trilinear combination
+			int frac = (int)((mml - level) * 256.0f);
+			frac = std::min(std::max(frac, 0), 256);
+			t = (256 - frac) * t + frac * t2;
+		}
+
+		// Trilinear combination has 16 bits of precision, and the table needs t to be shifted by 3 on the left
+		luma = (u32)lumaram[lumabase + (t >> (16-3))] * object.luma / 256;
 
 		// Virtua Striker sets up a luma of 0x40 for national flags on bleachers, fix here.
 		luma = std::min((int)luma,0x3f);


### PR DESCRIPTION
[poly.h] Added dpdy information to extents to be able to compute mipmap lod index per pixel
[model2.h and model2_v.cpp] Added all mipmap information to m2_poly_extra_data structure
[model2rd.ipp] Added preliminary unoptimized support for mipmaps and trilinear filtering