### PR TITLE
sega/model2.cpp: improve interrupt logic

### DIFF
--- a/src/mame/sega/model2.h
+++ b/src/mame/sega/model2.h
@@ -103,6 +103,8 @@ public:
 	void init_srallyc();
 	void init_powsledm();
 
+	void sound_ready_w(int state);
+
 protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
@@ -151,9 +153,7 @@ protected:
 	std::unique_ptr<raster_state> m_raster;
 	std::unique_ptr<geo_state> m_geo;
 	bitmap_rgb32 m_sys24_bitmap;
-//  u32 m_soundack;
-	void model2_check_irq_state();
-	void model2_check_irqack_state(u32 data);
+	bool m_sound_irq_pending = false;
 	u8 m_gearsel = 0;
 	u8 m_lightgun_mux = 0;
 
@@ -193,6 +193,7 @@ protected:
 	void irq_ack_w(u32 data);
 	u32 irq_enable_r();
 	void irq_enable_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	void irq_update();
 	u8 model2_serial_r(offs_t offset);
 	void model2_serial_w(offs_t offset, u8 data);
 	void horizontal_sync_w(u16 data);
@@ -224,7 +225,6 @@ protected:
 	void reset_model2_scsp();
 	u32 screen_update_model2(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 //  void screen_vblank_model2(int state);
-//  void sound_ready_w(int state);
 	template <int TNum> TIMER_DEVICE_CALLBACK_MEMBER(model2_timer_cb);
 	void scsp_irq(offs_t offset, u8 data);
 
@@ -598,8 +598,6 @@ protected:
 	void copro_function_port_w(offs_t offset, u32 data);
 	u32 copro_fifo_r();
 	void copro_fifo_w(u32 data);
-
-	TIMER_DEVICE_CALLBACK_MEMBER(model2c_interrupt);
 
 	void model2c_crx_mem(address_map &map) ATTR_COLD;
 	void model2c_5881_mem(address_map &map) ATTR_COLD;


### PR DESCRIPTION
- Interrupt control register only returns interrupts actively signalled to the i960; masked interrupts are not returned
- Sound IRQs are triggered when either TxRDY or RxRDY from the USART is active (Model 2B manual, section 6.2)
- Remove model2c_interrupt callback; no evidence that Model 2C behaves any differently to earlier board revisions
- Remove vcop issue from TODO list since it no longer occurs (tested)