### PR TITLE
Multiple synth layouts: slider scripts use adjuster's min and max instead of assuming the range is 0-100.

### DIFF
--- a/src/mame/ensoniq/esq1.cpp
+++ b/src/mame/ensoniq/esq1.cpp
@@ -709,16 +709,16 @@ void esq1_state::sq80(machine_config &config)
 
 static INPUT_PORTS_START( esq1 )
 	PORT_START("volume_slider")
-	PORT_ADJUSTER(255, "Volume")
+	PORT_ADJUSTER(100, "Volume")
 
 	PORT_START("data_entry_slider")
-	PORT_ADJUSTER(255, "Data Entry")
+	PORT_ADJUSTER(100, "Data Entry")
 
 	PORT_START("pitch_wheel")
-	PORT_ADJUSTER(255, "Pitch Wheel")
+	PORT_ADJUSTER(50, "Pitch Wheel")
 
 	PORT_START("mod_wheel")
-	PORT_ADJUSTER(255, "Mod Wheel")
+	PORT_ADJUSTER(0, "Mod Wheel")
 
 	PORT_START("COL0")
 	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_CODE(KEYCODE_Q) PORT_CHAR('q') PORT_CHAR('Q') PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(esq1_state::key_stroke), 0x84) PORT_NAME("SEQ")

--- a/src/mame/layout/esq1.lay
+++ b/src/mame/layout/esq1.lay
@@ -156,7 +156,7 @@ license:CC0-1.0
 		</element>
 		<element ref="slider_ticks"><bounds x="0" y="0" width="46" height="94"/></element>
 		<element id="slider_knob_~slider_id~" ref="slider-knob">
-			<animate inputtag="~port_name~" inputmask="0x7f"/>
+			<animate inputtag="~port_name~" inputmask="0xffff"/>
 			<bounds state="100" x="9" y="11" width="29" height="16"/>
 			<bounds state="0" x="9" y="66" width="29" height="16"/>
 		</element>
@@ -170,7 +170,7 @@ license:CC0-1.0
 			<bounds x="12" y="10" width="23" height="77"/>
 		</element>
 		<element id="slider_knob_~slider_id~" ref="wheel-knob">
-			<animate inputtag="~port_name~" inputmask="0x7f"/>
+			<animate inputtag="~port_name~" inputmask="0xffff"/>
 			<bounds state="100" x="12" y="11" width="23" height="16"/>
 			<bounds state="0" x="12" y="66" width="23" height="16"/>
 		</element>
@@ -673,47 +673,57 @@ license:CC0-1.0
 			end)
 
 		-----------------------------------------------------------------------
-		-- Slider library starts.
+		-- Slider and knob library starts.
 		-- Can be copied as-is to other layouts.
 		-----------------------------------------------------------------------
-		local sliders = {}   -- Stores slider information.
+		local widgets = {}   -- Stores slider and knob information.
 		local pointers = {}  -- Tracks pointer state.
 
 		-- The knob's Y position must be animated using <animate inputtag="{port_name}">.
 		-- The click area's vertical size must exactly span the range of the
 		-- knob's movement.
 		function add_vertical_slider(view, clickarea_id, knob_id, port_name)
-			local slider = {}
+			table.insert(widgets, {
+				clickarea   = get_layout_item(view, clickarea_id),
+				slider_knob = get_layout_item(view, knob_id),
+				field       = get_port_field(port_name),
+				is_knob     = false })
+		end
 
-			slider.clickarea = view.items[clickarea_id]
-			if slider.clickarea == nil then
-				emu.print_error("Slider element: '" .. clickarea_id .. "' not found.")
-				return
+		-- A sweep between the attached field's min and max values requires
+		-- moving the pointer by `scale * clickarea.height` pixes.
+		function add_simplecounter_knob(view, clickarea_id, port_name, scale)
+			table.insert(widgets, {
+				clickarea = get_layout_item(view, clickarea_id),
+				field     = get_port_field(port_name),
+				is_knob   = true,
+				scale     = scale })
+		end
+
+		function get_layout_item(view, item_id)
+			local item = view.items[item_id]
+			if item == nil then
+				emu.print_error("Layout element: '" .. item_id .. "' not found.")
 			end
+			return item
+		end
 
-			slider.knob = view.items[knob_id]
-			if slider.knob == nil then
-				emu.print_error("Slider knob element: '" .. knob_id .. "' not found.")
-				return
-			end
-
+		function get_port_field(port_name)
 			local port = file.device:ioport(port_name)
 			if port == nil then
 				emu.print_error("Port: '" .. port_name .. "' not found.")
-				return
+				return nil
 			end
-
-			slider.field = nil
+			local field = nil
 			for k, val in pairs(port.fields) do
-				slider.field = val
+				field = val
 				break
 			end
-			if slider.field == nil then
+			if field == nil then
 				emu.print_error("Port: '" .. port_name .."' does not seem to be an IPT_ADJUSTER.")
-				return
+				return nil
 			end
-
-			table.insert(sliders, slider)
+			return field
 		end
 
 		local function pointer_updated(type, id, dev, x, y, btn, dn, up, cnt)
@@ -723,56 +733,67 @@ license:CC0-1.0
 				return
 			end
 
-			-- If a button was just pressed, find the affected slider, if any.
+			-- If a button was just pressed, find the affected widget, if any.
 			if dn & 1 ~= 0 then
-				for i = 1, #sliders do
-					if sliders[i].knob.bounds:includes(x, y) then
+				for i = 1, #widgets do
+					local found, relative
+					if widgets[i].slider_knob and widgets[i].slider_knob.bounds:includes(x, y) then
+						found = true
+						relative = true
+					elseif widgets[i].clickarea.bounds:includes(x, y) then
+						found = true
+						relative = false
+					end
+					if found then
 						pointers[id] = {
-							selected_slider = i,
-							relative = true,
+							selected_widget = i,
+							relative = relative,
 							start_y = y,
-							start_value = sliders[i].field.user_value }
-						break
-					elseif sliders[i].clickarea.bounds:includes(x, y) then
-						pointers[id] = {
-							selected_slider = i,
-							relative = false }
+							start_value = widgets[i].field.user_value }
 						break
 					end
 				end
 			end
 
-			-- If there is no slider selected by the current pointer, we are done.
+			-- If there is no widget selected by the current pointer, we are done.
 			if pointers[id] == nil then
 				return
 			end
 
-			-- A slider is selected. Update state and, indirectly, slider knob position,
-			-- based on the pointer's Y position. It is assumed the attached IO field is
-			-- an IPT_ADJUSTER with a range of 0-100 (the default).
+			-- A widget is selected. Update its state based on the pointer's Y
+			-- position. It is assumed the attached IO field is an IPT_ADJUSTER.
 
 			local pointer = pointers[id]
-			local slider = sliders[pointer.selected_slider]
+			local widget = widgets[pointer.selected_widget]
 
-			local knob_half_height = slider.knob.bounds.height / 2
-			local min_y = slider.clickarea.bounds.y0 + knob_half_height
-			local max_y = slider.clickarea.bounds.y1 - knob_half_height
+			local min_value = widget.field.minvalue
+			local max_value = widget.field.maxvalue
+			local value_range = max_value - min_value
 
-			local new_value = 0
-			if pointer.relative then
-				-- User clicked on the knob. The new value will depend on how much the
-				-- knob was dragged.
-				new_value = pointer.start_value - 100 * (y - pointer.start_y) / (max_y - min_y)
+			local new_value
+			if widget.is_knob then
+				local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
+				new_value = pointer.start_value + (pointer.start_y - y) * step_y
 			else
-				-- User clicked elsewhere on the slider. The new value will depend on
-				-- the absolute position of the click.
-				new_value = 100 - 100 * (y - min_y) / (max_y - min_y)
+				local knob_half_height = widget.slider_knob.bounds.height / 2
+				local min_y = widget.clickarea.bounds.y0 + knob_half_height
+				local max_y = widget.clickarea.bounds.y1 - knob_half_height
+
+				if pointer.relative then
+					-- User clicked on the knob. The new value will depend on how
+					--  much the knob was dragged.
+					new_value = pointer.start_value - value_range * (y - pointer.start_y) / (max_y - min_y)
+				else
+					-- User clicked elsewhere on the slider. The new value will depend on
+					-- the absolute position of the click.
+					new_value = max_value - value_range * (y - min_y) / (max_y - min_y)
+				end
 			end
 
 			new_value = math.floor(new_value + 0.5)
-			if new_value < 0 then new_value = 0 end
-			if new_value > 100 then new_value = 100 end
-			slider.field.user_value = new_value
+			if new_value < min_value then new_value = min_value end
+			if new_value > max_value then new_value = max_value end
+			widget.field.user_value = new_value
 		end
 
 		local function pointer_left(type, id, dev, x, y, up, cnt)
@@ -794,7 +815,7 @@ license:CC0-1.0
 			view:set_forget_pointers_callback(forget_pointers)
 		end
 		-----------------------------------------------------------------------
-		-- Slider library ends.
+		-- Slider and knob library ends.
 		-----------------------------------------------------------------------
 	]]></script>
 

--- a/src/mame/layout/linn_linndrum.lay
+++ b/src/mame/layout/linn_linndrum.lay
@@ -221,7 +221,7 @@ copyright-holders:m1macrophage
 	<group name="knob">
 		<element ref="knob_outer" id="knob_~knob_input~"><bounds x="0" y="0" width="68" height="68"/></element>
 		<element ref="knob_inner"><bounds x="9" y="9" width="50" height="50"/></element>
-		<element ref="knob_value" inputtag="~knob_input~" inputmask="0x7f" inputraw="yes">
+		<element ref="knob_value" inputtag="~knob_input~" inputmask="0xffff" inputraw="yes">
 			<bounds x="17" y="22" width="34" height="24"/>
 		</element>
 		<element ref="transparent" clickthrough="no"><bounds x="17" y="22" width="34" height="24"/></element>
@@ -236,7 +236,7 @@ copyright-holders:m1macrophage
 		</element>
 		<element ref="slider_well"><bounds x="8" y="0" width="16" height="~slider_height~"/></element>
 		<element ref="slider_knob" id="slider_knob_~slider_input~">>
-			<animate inputtag="~slider_input~" inputmask="0x7f"/>
+			<animate inputtag="~slider_input~" inputmask="0xffff"/>
 			<bounds state="100" x="10" y="0" width="12" height="28"/>
 			<bounds state="0" x="10" y="~slider_knob_max_y~" width="12" height="28"/>
 		</element>
@@ -628,8 +628,8 @@ copyright-holders:m1macrophage
 				is_knob     = false })
 		end
 
-		-- A sweep between 0 and 100 requires moving the pointer by
-		-- `scale * clickarea.height` pixes.
+		-- A sweep between the attached field's min and max values requires
+		-- moving the pointer by `scale * clickarea.height` pixes.
 		function add_simplecounter_knob(view, clickarea_id, port_name, scale)
 			table.insert(widgets, {
 				clickarea = get_layout_item(view, clickarea_id),
@@ -699,15 +699,18 @@ copyright-holders:m1macrophage
 			end
 
 			-- A widget is selected. Update its state based on the pointer's Y
-			-- position. It is assumed the attached IO field is an
-			-- IPT_ADJUSTER with a range of 0-100 (the default).
+			-- position. It is assumed the attached IO field is an IPT_ADJUSTER.
 
 			local pointer = pointers[id]
 			local widget = widgets[pointer.selected_widget]
 
+			local min_value = widget.field.minvalue
+			local max_value = widget.field.maxvalue
+			local value_range = max_value - min_value
+
 			local new_value
 			if widget.is_knob then
-				local step_y = 100.0 / (widget.scale * widget.clickarea.bounds.height)
+				local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
 				new_value = pointer.start_value + (pointer.start_y - y) * step_y
 			else
 				local knob_half_height = widget.slider_knob.bounds.height / 2
@@ -717,17 +720,17 @@ copyright-holders:m1macrophage
 				if pointer.relative then
 					-- User clicked on the knob. The new value will depend on how
 					--  much the knob was dragged.
-					new_value = pointer.start_value - 100 * (y - pointer.start_y) / (max_y - min_y)
+					new_value = pointer.start_value - value_range * (y - pointer.start_y) / (max_y - min_y)
 				else
 					-- User clicked elsewhere on the slider. The new value will depend on
 					-- the absolute position of the click.
-					new_value = 100 - 100 * (y - min_y) / (max_y - min_y)
+					new_value = max_value - value_range * (y - min_y) / (max_y - min_y)
 				end
 			end
 
 			new_value = math.floor(new_value + 0.5)
-			if new_value < 0 then new_value = 0 end
-			if new_value > 100 then new_value = 100 end
+			if new_value < min_value then new_value = min_value end
+			if new_value > max_value then new_value = max_value end
 			widget.field.user_value = new_value
 		end
 

--- a/src/mame/layout/oberheim_dmx.lay
+++ b/src/mame/layout/oberheim_dmx.lay
@@ -99,7 +99,7 @@ copyright-holders:m1macrophage
 			<bounds x="5" y="0" width="5" height="40"/>
 		</element>
 		<element ref="trimmer-knob" id="trimmer_knob_~trimmer_id~">
-			<animate inputtag="pitch_adj_~trimmer_id~" inputmask="0x7f"/>
+			<animate inputtag="pitch_adj_~trimmer_id~" inputmask="0xffff"/>
 			<bounds state="100" x="0" y="0" width="15" height="5"/>
 			<bounds state="0" x="0" y="35" width="15" height="5"/>
 		</element>
@@ -124,7 +124,7 @@ copyright-holders:m1macrophage
 			<bounds x="29" y="9" width="7" height="144"/>
 		</element>
 		<element id="fader_knob_~fader_id~" ref="fader-knob">
-			<animate inputtag="fader_p~fader_id~" inputmask="0x7f"/>
+			<animate inputtag="fader_p~fader_id~" inputmask="0xffff"/>
 			<bounds state="100" x="15" y="0" width="35" height="35"/>
 			<bounds state="0" x="15" y="127" width="35" height="35"/>
 		</element>
@@ -569,47 +569,57 @@ copyright-holders:m1macrophage
 			end)
 
 		-----------------------------------------------------------------------
-		-- Slider library starts.
+		-- Slider and knob library starts.
 		-- Can be copied as-is to other layouts.
 		-----------------------------------------------------------------------
-		local sliders = {}   -- Stores slider information.
+		local widgets = {}   -- Stores slider and knob information.
 		local pointers = {}  -- Tracks pointer state.
 
 		-- The knob's Y position must be animated using <animate inputtag="{port_name}">.
 		-- The click area's vertical size must exactly span the range of the
 		-- knob's movement.
 		function add_vertical_slider(view, clickarea_id, knob_id, port_name)
-			local slider = {}
+			table.insert(widgets, {
+				clickarea   = get_layout_item(view, clickarea_id),
+				slider_knob = get_layout_item(view, knob_id),
+				field       = get_port_field(port_name),
+				is_knob     = false })
+		end
 
-			slider.clickarea = view.items[clickarea_id]
-			if slider.clickarea == nil then
-				emu.print_error("Slider element: '" .. clickarea_id .. "' not found.")
-				return
+		-- A sweep between the attached field's min and max values requires
+		-- moving the pointer by `scale * clickarea.height` pixes.
+		function add_simplecounter_knob(view, clickarea_id, port_name, scale)
+			table.insert(widgets, {
+				clickarea = get_layout_item(view, clickarea_id),
+				field     = get_port_field(port_name),
+				is_knob   = true,
+				scale     = scale })
+		end
+
+		function get_layout_item(view, item_id)
+			local item = view.items[item_id]
+			if item == nil then
+				emu.print_error("Layout element: '" .. item_id .. "' not found.")
 			end
+			return item
+		end
 
-			slider.knob = view.items[knob_id]
-			if slider.knob == nil then
-				emu.print_error("Slider knob element: '" .. knob_id .. "' not found.")
-				return
-			end
-
+		function get_port_field(port_name)
 			local port = file.device:ioport(port_name)
 			if port == nil then
 				emu.print_error("Port: '" .. port_name .. "' not found.")
-				return
+				return nil
 			end
-
-			slider.field = nil
+			local field = nil
 			for k, val in pairs(port.fields) do
-				slider.field = val
+				field = val
 				break
 			end
-			if slider.field == nil then
+			if field == nil then
 				emu.print_error("Port: '" .. port_name .."' does not seem to be an IPT_ADJUSTER.")
-				return
+				return nil
 			end
-
-			table.insert(sliders, slider)
+			return field
 		end
 
 		local function pointer_updated(type, id, dev, x, y, btn, dn, up, cnt)
@@ -619,56 +629,67 @@ copyright-holders:m1macrophage
 				return
 			end
 
-			-- If a button was just pressed, find the affected slider, if any.
+			-- If a button was just pressed, find the affected widget, if any.
 			if dn & 1 ~= 0 then
-				for i = 1, #sliders do
-					if sliders[i].knob.bounds:includes(x, y) then
+				for i = 1, #widgets do
+					local found, relative
+					if widgets[i].slider_knob and widgets[i].slider_knob.bounds:includes(x, y) then
+						found = true
+						relative = true
+					elseif widgets[i].clickarea.bounds:includes(x, y) then
+						found = true
+						relative = false
+					end
+					if found then
 						pointers[id] = {
-							selected_slider = i,
-							relative = true,
+							selected_widget = i,
+							relative = relative,
 							start_y = y,
-							start_value = sliders[i].field.user_value }
-						break
-					elseif sliders[i].clickarea.bounds:includes(x, y) then
-						pointers[id] = {
-							selected_slider = i,
-							relative = false }
+							start_value = widgets[i].field.user_value }
 						break
 					end
 				end
 			end
 
-			-- If there is no slider selected by the current pointer, we are done.
+			-- If there is no widget selected by the current pointer, we are done.
 			if pointers[id] == nil then
 				return
 			end
 
-			-- A slider is selected. Update state and, indirectly, slider knob position,
-			-- based on the pointer's Y position. It is assumed the attached IO field is
-			-- an IPT_ADJUSTER with a range of 0-100 (the default).
+			-- A widget is selected. Update its state based on the pointer's Y
+			-- position. It is assumed the attached IO field is an IPT_ADJUSTER.
 
 			local pointer = pointers[id]
-			local slider = sliders[pointer.selected_slider]
+			local widget = widgets[pointer.selected_widget]
 
-			local knob_half_height = slider.knob.bounds.height / 2
-			local min_y = slider.clickarea.bounds.y0 + knob_half_height
-			local max_y = slider.clickarea.bounds.y1 - knob_half_height
+			local min_value = widget.field.minvalue
+			local max_value = widget.field.maxvalue
+			local value_range = max_value - min_value
 
-			local new_value = 0
-			if pointer.relative then
-				-- User clicked on the knob. The new value will depend on how much the
-				-- knob was dragged.
-				new_value = pointer.start_value - 100 * (y - pointer.start_y) / (max_y - min_y)
+			local new_value
+			if widget.is_knob then
+				local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
+				new_value = pointer.start_value + (pointer.start_y - y) * step_y
 			else
-				-- User clicked elsewhere on the slider. The new value will depend on
-				-- the absolute position of the click.
-				new_value = 100 - 100 * (y - min_y) / (max_y - min_y)
+				local knob_half_height = widget.slider_knob.bounds.height / 2
+				local min_y = widget.clickarea.bounds.y0 + knob_half_height
+				local max_y = widget.clickarea.bounds.y1 - knob_half_height
+
+				if pointer.relative then
+					-- User clicked on the knob. The new value will depend on how
+					--  much the knob was dragged.
+					new_value = pointer.start_value - value_range * (y - pointer.start_y) / (max_y - min_y)
+				else
+					-- User clicked elsewhere on the slider. The new value will depend on
+					-- the absolute position of the click.
+					new_value = max_value - value_range * (y - min_y) / (max_y - min_y)
+				end
 			end
 
 			new_value = math.floor(new_value + 0.5)
-			if new_value < 0 then new_value = 0 end
-			if new_value > 100 then new_value = 100 end
-			slider.field.user_value = new_value
+			if new_value < min_value then new_value = min_value end
+			if new_value > max_value then new_value = max_value end
+			widget.field.user_value = new_value
 		end
 
 		local function pointer_left(type, id, dev, x, y, up, cnt)
@@ -690,7 +711,7 @@ copyright-holders:m1macrophage
 			view:set_forget_pointers_callback(forget_pointers)
 		end
 		-----------------------------------------------------------------------
-		-- Slider library ends.
+		-- Slider and knob library ends.
 		-----------------------------------------------------------------------
 	]]></script>
 </mamelayout>

--- a/src/mame/layout/paia_fatman.lay
+++ b/src/mame/layout/paia_fatman.lay
@@ -228,7 +228,7 @@ copyright-holders:m1macrophage
 		<element ref="text-slow">
 			<bounds x="138" y="94" width="40" height="15"/>
 		</element>
-		<element ref="knob-value" inputraw="yes" inputtag="~knob_id~" inputmask="0x7f">
+		<element ref="knob-value" inputraw="yes" inputtag="~knob_id~" inputmask="0xffff">
 			<bounds x="68" y="52" width="40" height="16"/>
 		</element>
 		<element ref="transparent-rect" clickthrough="no" id="~knob_id~">
@@ -428,18 +428,29 @@ copyright-holders:m1macrophage
 
 		-----------------------------------------------------------------------
 		-- Slider and knob library starts.
-		-- This is a *trimmed down* version of the reference implementation in
-		-- linn_linndrum.lay.
+		-- Can be copied as-is to other layouts.
 		-----------------------------------------------------------------------
 		local widgets = {}   -- Stores slider and knob information.
 		local pointers = {}  -- Tracks pointer state.
 
-		-- A sweep between 0 and 100 requires moving the pointer by
-		-- `scale * clickarea.height` pixes.
+		-- The knob's Y position must be animated using <animate inputtag="{port_name}">.
+		-- The click area's vertical size must exactly span the range of the
+		-- knob's movement.
+		function add_vertical_slider(view, clickarea_id, knob_id, port_name)
+			table.insert(widgets, {
+				clickarea   = get_layout_item(view, clickarea_id),
+				slider_knob = get_layout_item(view, knob_id),
+				field       = get_port_field(port_name),
+				is_knob     = false })
+		end
+
+		-- A sweep between the attached field's min and max values requires
+		-- moving the pointer by `scale * clickarea.height` pixes.
 		function add_simplecounter_knob(view, clickarea_id, port_name, scale)
 			table.insert(widgets, {
 				clickarea = get_layout_item(view, clickarea_id),
 				field     = get_port_field(port_name),
+				is_knob   = true,
 				scale     = scale })
 		end
 
@@ -479,9 +490,18 @@ copyright-holders:m1macrophage
 			-- If a button was just pressed, find the affected widget, if any.
 			if dn & 1 ~= 0 then
 				for i = 1, #widgets do
-					if widgets[i].clickarea.bounds:includes(x, y) then
+					local found, relative
+					if widgets[i].slider_knob and widgets[i].slider_knob.bounds:includes(x, y) then
+						found = true
+						relative = true
+					elseif widgets[i].clickarea.bounds:includes(x, y) then
+						found = true
+						relative = false
+					end
+					if found then
 						pointers[id] = {
 							selected_widget = i,
+							relative = relative,
 							start_y = y,
 							start_value = widgets[i].field.user_value }
 						break
@@ -495,17 +515,38 @@ copyright-holders:m1macrophage
 			end
 
 			-- A widget is selected. Update its state based on the pointer's Y
-			-- position. It is assumed the attached IO field is an
-			-- IPT_ADJUSTER with a range of 0-100 (the default).
+			-- position. It is assumed the attached IO field is an IPT_ADJUSTER.
 
 			local pointer = pointers[id]
 			local widget = widgets[pointer.selected_widget]
-			local step_y = 100.0 / (widget.scale * widget.clickarea.bounds.height)
-			local new_value = pointer.start_value + (pointer.start_y - y) * step_y
+
+			local min_value = widget.field.minvalue
+			local max_value = widget.field.maxvalue
+			local value_range = max_value - min_value
+
+			local new_value
+			if widget.is_knob then
+				local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
+				new_value = pointer.start_value + (pointer.start_y - y) * step_y
+			else
+				local knob_half_height = widget.slider_knob.bounds.height / 2
+				local min_y = widget.clickarea.bounds.y0 + knob_half_height
+				local max_y = widget.clickarea.bounds.y1 - knob_half_height
+
+				if pointer.relative then
+					-- User clicked on the knob. The new value will depend on how
+					--  much the knob was dragged.
+					new_value = pointer.start_value - value_range * (y - pointer.start_y) / (max_y - min_y)
+				else
+					-- User clicked elsewhere on the slider. The new value will depend on
+					-- the absolute position of the click.
+					new_value = max_value - value_range * (y - min_y) / (max_y - min_y)
+				end
+			end
 
 			new_value = math.floor(new_value + 0.5)
-			if new_value < 0 then new_value = 0 end
-			if new_value > 100 then new_value = 100 end
+			if new_value < min_value then new_value = min_value end
+			if new_value > max_value then new_value = max_value end
 			widget.field.user_value = new_value
 		end
 

--- a/src/mame/layout/pg1000.lay
+++ b/src/mame/layout/pg1000.lay
@@ -140,7 +140,7 @@ license:CC0-1.0
 			<bounds x="0" y="8" width="29" height="112"/>
 		</element>
 		<element id="knob_~slider_id~" ref="slider_knob">
-			<animate inputtag="~port_name~" inputmask="0x7f"/>
+			<animate inputtag="~port_name~" inputmask="0xffff"/>
 			<bounds state="255" x="2" y="7" width="25" height="20"/>
 			<bounds state="0" x="2" y="100" width="25" height="20"/>
 		</element>
@@ -863,10 +863,14 @@ license:CC0-1.0
 
 			-- A slider is selected. Update state and, indirectly, slider knob position,
 			-- based on the pointer's Y position. It is assumed the attached IO field is
-			-- an IPT_ADJUSTER with a range of 0-255.
+			-- an IPT_ADJUSTER.
 
 			local pointer = pointers[id]
 			local slider = sliders[pointer.selected_slider]
+
+			local min_value = slider.field.minvalue
+			local max_value = slider.field.maxvalue
+			local value_range = max_value - min_value
 
 			local knob_half_height = slider.knob.bounds.height / 2
 			local min_y = slider.clickarea.bounds.y0 + knob_half_height
@@ -876,16 +880,16 @@ license:CC0-1.0
 			if pointer.relative then
 				-- User clicked on the knob. The new value will depend on how much the
 				-- knob was dragged.
-				new_value = pointer.start_value - 255 * (y - pointer.start_y) / (max_y - min_y)
+				new_value = pointer.start_value - value_range * (y - pointer.start_y) / (max_y - min_y)
 			else
 				-- User clicked elsewhere on the slider. The new value will depend on
 				-- the absolute position of the click.
-				new_value = 255 - 255 * (y - min_y) / (max_y - min_y)
+				new_value = max_value - value_range * (y - min_y) / (max_y - min_y)
 			end
 
 			new_value = math.floor(new_value + 0.5)
-			if new_value < 0 then new_value = 0 end
-			if new_value > 255 then new_value = 255 end
+			if new_value < min_value then new_value = min_value end
+			if new_value > max_value then new_value = max_value end
 			slider.field.user_value = new_value
 		end
 

--- a/src/mame/layout/roland_d70.lay
+++ b/src/mame/layout/roland_d70.lay
@@ -249,7 +249,7 @@ copyright-holders:Felipe Sanches, m1macrophage
 		<element ref="slider-wider-well" id="SLIDER4"><bounds x="200" y="349" width="43" height="97"/></element>
 		<element ref="slider-well"><bounds x="217" y="357" width="10" height="82"/></element>
 		<element ref="slider-knob" id="SLIDER-KNOB4">
-			<animate inputtag="SLIDER4" inputmask="0x7f"/>
+			<animate inputtag="SLIDER4" inputmask="0xffff"/>
 			<bounds state="100" x="203" y="352" width="37" height="24"/>
 			<bounds state="0"  x="203" y="417" width="37" height="24"/>
 		</element>
@@ -257,7 +257,7 @@ copyright-holders:Felipe Sanches, m1macrophage
 		<element ref="slider-wider-well" id="SLIDER5"><bounds x="269" y="349" width="43" height="97"/></element>
 		<element ref="slider-well"><bounds x="286" y="357" width="10" height="82"/></element>
 		<element ref="slider-knob" id="SLIDER-KNOB5">
-			<animate inputtag="SLIDER5" inputmask="0x7f"/>
+			<animate inputtag="SLIDER5" inputmask="0xffff"/>
 			<bounds state="100" x="272" y="352" width="37" height="24"/>
 			<bounds state="0" x="272" y="417" width="37" height="24"/>
 		</element>
@@ -265,7 +265,7 @@ copyright-holders:Felipe Sanches, m1macrophage
 		<element ref="slider-wider-well" id="SLIDER6"><bounds x="337" y="349" width="43" height="97"/></element>
 		<element ref="slider-well"><bounds x="354" y="357" width="10" height="82"/></element>
 		<element ref="slider-knob" id="SLIDER-KNOB6">
-			<animate inputtag="SLIDER6" inputmask="0x7f"/>
+			<animate inputtag="SLIDER6" inputmask="0xffff"/>
 			<bounds state="100" x="340" y="352" width="37" height="24"/>
 			<bounds state="0"  x="340" y="417" width="37" height="24"/>
 		</element>
@@ -273,7 +273,7 @@ copyright-holders:Felipe Sanches, m1macrophage
 		<element ref="slider-wider-well" id="SLIDER7"><bounds x="405" y="349" width="43" height="97"/></element>
 		<element ref="slider-well"><bounds x="422" y="357" width="10" height="82"/></element>
 		<element ref="slider-knob" id="SLIDER-KNOB7">
-			<animate inputtag="SLIDER7" inputmask="0x7f"/>
+			<animate inputtag="SLIDER7" inputmask="0xffff"/>
 			<bounds state="100" x="408" y="352" width="37" height="24"/>
 			<bounds state="0"  x="408" y="417" width="37" height="24"/>
 		</element>
@@ -557,48 +557,59 @@ copyright-holders:Felipe Sanches, m1macrophage
 					add_vertical_slider(view, "SLIDER" .. i, "SLIDER-KNOB" .. i, "SLIDER" .. i)
 				end
 			end)
+
 		-----------------------------------------------------------------------
-		-- Slider library starts.
+		-- Slider and knob library starts.
 		-- Can be copied as-is to other layouts.
 		-----------------------------------------------------------------------
-		local sliders = {}   -- Stores slider information.
+		local widgets = {}   -- Stores slider and knob information.
 		local pointers = {}  -- Tracks pointer state.
 
 		-- The knob's Y position must be animated using <animate inputtag="{port_name}">.
 		-- The click area's vertical size must exactly span the range of the
 		-- knob's movement.
 		function add_vertical_slider(view, clickarea_id, knob_id, port_name)
-			local slider = {}
+			table.insert(widgets, {
+				clickarea   = get_layout_item(view, clickarea_id),
+				slider_knob = get_layout_item(view, knob_id),
+				field       = get_port_field(port_name),
+				is_knob     = false })
+		end
 
-			slider.clickarea = view.items[clickarea_id]
-			if slider.clickarea == nil then
-				emu.print_error("Slider element: '" .. clickarea_id .. "' not found.")
-				return
+		-- A sweep between the attached field's min and max values requires
+		-- moving the pointer by `scale * clickarea.height` pixes.
+		function add_simplecounter_knob(view, clickarea_id, port_name, scale)
+			table.insert(widgets, {
+				clickarea = get_layout_item(view, clickarea_id),
+				field     = get_port_field(port_name),
+				is_knob   = true,
+				scale     = scale })
+		end
+
+		function get_layout_item(view, item_id)
+			local item = view.items[item_id]
+			if item == nil then
+				emu.print_error("Layout element: '" .. item_id .. "' not found.")
 			end
+			return item
+		end
 
-			slider.knob = view.items[knob_id]
-			if slider.knob == nil then
-				emu.print_error("Slider knob element: '" .. knob_id .. "' not found.")
-				return
-			end
-
+		function get_port_field(port_name)
 			local port = file.device:ioport(port_name)
 			if port == nil then
 				emu.print_error("Port: '" .. port_name .. "' not found.")
-				return
+				return nil
 			end
-
-			slider.field = nil
+			local field = nil
 			for k, val in pairs(port.fields) do
-				slider.field = val
+				field = val
 				break
 			end
-			if slider.field == nil then
+			if field == nil then
 				emu.print_error("Port: '" .. port_name .."' does not seem to be an IPT_ADJUSTER.")
-				return
+				return nil
 			end
-
-			table.insert(sliders, slider)
+			return field
 		end
 
 		local function pointer_updated(type, id, dev, x, y, btn, dn, up, cnt)
@@ -608,56 +619,67 @@ copyright-holders:Felipe Sanches, m1macrophage
 				return
 			end
 
-			-- If a button was just pressed, find the affected slider, if any.
+			-- If a button was just pressed, find the affected widget, if any.
 			if dn & 1 ~= 0 then
-				for i = 1, #sliders do
-					if sliders[i].knob.bounds:includes(x, y) then
+				for i = 1, #widgets do
+					local found, relative
+					if widgets[i].slider_knob and widgets[i].slider_knob.bounds:includes(x, y) then
+						found = true
+						relative = true
+					elseif widgets[i].clickarea.bounds:includes(x, y) then
+						found = true
+						relative = false
+					end
+					if found then
 						pointers[id] = {
-							selected_slider = i,
-							relative = true,
+							selected_widget = i,
+							relative = relative,
 							start_y = y,
-							start_value = sliders[i].field.user_value }
-						break
-					elseif sliders[i].clickarea.bounds:includes(x, y) then
-						pointers[id] = {
-							selected_slider = i,
-							relative = false }
+							start_value = widgets[i].field.user_value }
 						break
 					end
 				end
 			end
 
-			-- If there is no slider selected by the current pointer, we are done.
+			-- If there is no widget selected by the current pointer, we are done.
 			if pointers[id] == nil then
 				return
 			end
 
-			-- A slider is selected. Update state and, indirectly, slider knob position,
-			-- based on the pointer's Y position. It is assumed the attached IO field is
-			-- an IPT_ADJUSTER with a range of 0-100 (the default).
+			-- A widget is selected. Update its state based on the pointer's Y
+			-- position. It is assumed the attached IO field is an IPT_ADJUSTER.
 
 			local pointer = pointers[id]
-			local slider = sliders[pointer.selected_slider]
+			local widget = widgets[pointer.selected_widget]
 
-			local knob_half_height = slider.knob.bounds.height / 2
-			local min_y = slider.clickarea.bounds.y0 + knob_half_height
-			local max_y = slider.clickarea.bounds.y1 - knob_half_height
+			local min_value = widget.field.minvalue
+			local max_value = widget.field.maxvalue
+			local value_range = max_value - min_value
 
-			local new_value = 0
-			if pointer.relative then
-				-- User clicked on the knob. The new value will depend on how much the
-				-- knob was dragged.
-				new_value = pointer.start_value - 100 * (y - pointer.start_y) / (max_y - min_y)
+			local new_value
+			if widget.is_knob then
+				local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
+				new_value = pointer.start_value + (pointer.start_y - y) * step_y
 			else
-				-- User clicked elsewhere on the slider. The new value will depend on
-				-- the absolute position of the click.
-				new_value = 100 - 100 * (y - min_y) / (max_y - min_y)
+				local knob_half_height = widget.slider_knob.bounds.height / 2
+				local min_y = widget.clickarea.bounds.y0 + knob_half_height
+				local max_y = widget.clickarea.bounds.y1 - knob_half_height
+
+				if pointer.relative then
+					-- User clicked on the knob. The new value will depend on how
+					--  much the knob was dragged.
+					new_value = pointer.start_value - value_range * (y - pointer.start_y) / (max_y - min_y)
+				else
+					-- User clicked elsewhere on the slider. The new value will depend on
+					-- the absolute position of the click.
+					new_value = max_value - value_range * (y - min_y) / (max_y - min_y)
+				end
 			end
 
 			new_value = math.floor(new_value + 0.5)
-			if new_value < 0 then new_value = 0 end
-			if new_value > 100 then new_value = 100 end
-			slider.field.user_value = new_value
+			if new_value < min_value then new_value = min_value end
+			if new_value > max_value then new_value = max_value end
+			widget.field.user_value = new_value
 		end
 
 		local function pointer_left(type, id, dev, x, y, up, cnt)
@@ -679,8 +701,9 @@ copyright-holders:Felipe Sanches, m1macrophage
 			view:set_forget_pointers_callback(forget_pointers)
 		end
 		-----------------------------------------------------------------------
-		-- Slider library ends.
+		-- Slider and knob library ends.
 		-----------------------------------------------------------------------
+
 	]]></script>
 
 </mamelayout>

--- a/src/mame/layout/roland_tr707.lay
+++ b/src/mame/layout/roland_tr707.lay
@@ -268,10 +268,10 @@ the visibility and style of elements that differ between the two.
 		<element ref="sunken"><bounds x="0" y="0" width="38" height="216"/></element>
 		<element ref="sliderwell"><bounds x="11" y="53" width="16" height="116"/></element>
 		<element ref="transparent" id="slider_area_~slider_i~">
-			<bounds x="0" y="38" width="38" height="184"/>
+			<bounds x="0" y="38" width="38" height="146"/>
 		</element>
 		<element ref="sliderknob" id="slider_knob_~slider_i~">
-			<animate inputtag="SLIDER_~slider_i~" inputmask="0x7f"/>
+			<animate inputtag="SLIDER_~slider_i~" inputmask="0xffff"/>
 			<bounds state="100" x="7" y="38" width="24" height="50"/>
 			<bounds state="0" x="7" y="134" width="24" height="50"/>
 		</element>
@@ -289,7 +289,7 @@ the visibility and style of elements that differ between the two.
 			<bounds x="0" y="16" width="38" height="189"/>
 		</element>
 		<element ref="mastersliderknob" id="master_volume_knob">
-			<animate inputtag="VOLUME" inputmask="07f"/>
+			<animate inputtag="VOLUME" inputmask="0xffff"/>
 			<bounds state="100" x="7" y="16" width="24" height="50"/>
 			<bounds state="0" x="7" y="155" width="24" height="50"/>
 		</element>
@@ -762,7 +762,7 @@ the visibility and style of elements that differ between the two.
 		<element ref="txt_fast"><bounds x="1477" y="612" width="42" height="15"/></element>
 		<element ref="tempo_well"><bounds x="1366" y="480" width="130" height="130"/></element>
 		<element ref="tempo_knob" id="tempo_knob"><bounds x="1381" y="495" width="100" height="100"/></element>
-		<element ref="tempo_value" inputtag="TEMPO" inputmask="0x7f" inputraw="yes">
+		<element ref="tempo_value" inputtag="TEMPO" inputmask="0xffff" inputraw="yes">
 			<bounds x="1386" y="533" width="90" height="24"/>
 		</element>
 		<element ref="transparent" clickthrough="no"><bounds x="1381" y="495" width="100" height="100"/></element>
@@ -960,8 +960,8 @@ the visibility and style of elements that differ between the two.
 				is_knob     = false })
 		end
 
-		-- A sweep between 0 and 100 requires moving the pointer by
-		-- `scale * clickarea.height` pixes.
+		-- A sweep between the attached field's min and max values requires
+		-- moving the pointer by `scale * clickarea.height` pixes.
 		function add_simplecounter_knob(view, clickarea_id, port_name, scale)
 			table.insert(widgets, {
 				clickarea = get_layout_item(view, clickarea_id),
@@ -1031,15 +1031,18 @@ the visibility and style of elements that differ between the two.
 			end
 
 			-- A widget is selected. Update its state based on the pointer's Y
-			-- position. It is assumed the attached IO field is an
-			-- IPT_ADJUSTER with a range of 0-100 (the default).
+			-- position. It is assumed the attached IO field is an IPT_ADJUSTER.
 
 			local pointer = pointers[id]
 			local widget = widgets[pointer.selected_widget]
 
+			local min_value = widget.field.minvalue
+			local max_value = widget.field.maxvalue
+			local value_range = max_value - min_value
+
 			local new_value
 			if widget.is_knob then
-				local step_y = 100.0 / (widget.scale * widget.clickarea.bounds.height)
+				local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
 				new_value = pointer.start_value + (pointer.start_y - y) * step_y
 			else
 				local knob_half_height = widget.slider_knob.bounds.height / 2
@@ -1049,17 +1052,17 @@ the visibility and style of elements that differ between the two.
 				if pointer.relative then
 					-- User clicked on the knob. The new value will depend on how
 					--  much the knob was dragged.
-					new_value = pointer.start_value - 100 * (y - pointer.start_y) / (max_y - min_y)
+					new_value = pointer.start_value - value_range * (y - pointer.start_y) / (max_y - min_y)
 				else
 					-- User clicked elsewhere on the slider. The new value will depend on
 					-- the absolute position of the click.
-					new_value = 100 - 100 * (y - min_y) / (max_y - min_y)
+					new_value = max_value - value_range * (y - min_y) / (max_y - min_y)
 				end
 			end
 
 			new_value = math.floor(new_value + 0.5)
-			if new_value < 0 then new_value = 0 end
-			if new_value > 100 then new_value = 100 end
+			if new_value < min_value then new_value = min_value end
+			if new_value > max_value then new_value = max_value end
 			widget.field.user_value = new_value
 		end
 


### PR DESCRIPTION
* **Review can focus on this**: Script in `linn_linndrum.lay` updated to take advantage of #14317.
* The linndrum script was copied to `esq1.lay`, `oberheim_dmx.lay`, `paia_fatman.lay`, `roland_d70.lay` and `roland_tr707.lay`. Note that the diffs for some of these look large. That's because they were using older versions of the "reference" script in `linn_linndrum.lay`.
* Script in `pg1000.lay` updated accordingly. This had local changes, so didn't just copy the reference.
* Broadened the `inputmask` for sliders and knobs in all layouts, so they can accommodate ranges beyond 0-127.

Related minor fixes:
* `esq1.cpp`: Fixed adjuster defaults to be within range. Defaults were being set to 255, but the adjuster's range was 100, and the driver and layout assumed that too.
* `roland_tr707.lay`: Corrected volume slider click area. Also fixes the knob sliding below the cursor when dragged.