### PR TITLE
For discussion: es550[56] devices generate 20bit samples, not 16-bit ones.

### DIFF
--- a/src/devices/sound/es5506.cpp
+++ b/src/devices/sound/es5506.cpp
@@ -1039,7 +1039,8 @@ void es5506_device::generate_samples(sound_stream &stream)
 		}
 
 		for (int c = 0; c < stream.output_count(); c++)
-			stream.put_int(c, sampindex, cursample[c], 32768);
+			// generated samples are 20-bit signed, range is [-2^19 .. 2^19-1]
+			stream.put_int_clamp(c, sampindex, cursample[c], (1 << 19));
 	}
 }
 
@@ -1077,7 +1078,8 @@ void es5505_device::generate_samples(sound_stream &stream)
 		}
 
 		for (int c = 0; c < stream.output_count(); c++)
-			stream.put_int(c, sampindex, cursample[c], 32768);
+			// generated samples are 20-bit signed, range is [-2^19 .. 2^19-1]
+			stream.put_int_clamp(c, sampindex, cursample[c], (1 << 19));
 	}
 }
 

--- a/src/devices/sound/esqpump.cpp
+++ b/src/devices/sound/esqpump.cpp
@@ -63,12 +63,12 @@ void esq_5505_5510_pump_device::device_clock_changed()
 
 void esq_5505_5510_pump_device::sound_stream_update(sound_stream &stream)
 {
-#define SAMPLE_SHIFT 4
-	constexpr sound_stream::sample_t input_scale = 32768.0 / (1 << SAMPLE_SHIFT);
+	constexpr sound_stream::sample_t input_scale = 32768.0;
+	constexpr sound_stream::sample_t output_scale = 1.0 / input_scale;
 
 	// Push the 'Aux' output samples directly into the output stream
-	stream.put(2, 0, stream.get(0, 0) * (1.0 / (1 << SAMPLE_SHIFT)));
-	stream.put(3, 0, stream.get(1, 0) * (1.0 / (1 << SAMPLE_SHIFT)));
+	stream.put(2, 0, stream.get(0, 0));
+	stream.put(3, 0, stream.get(1, 0));
 
 	// Push the 'FX1', 'FX2' and 'DRY' samples into the ESP
 	m_esp->ser_w(0, s32(stream.get(2, 0) * input_scale));
@@ -92,8 +92,8 @@ void esq_5505_5510_pump_device::sound_stream_update(sound_stream &stream)
 #endif
 
 	// Read the processed result from the ESP.
-	sound_stream::sample_t l = sound_stream::sample_t(m_esp->ser_r(6)) * (1.0 / 32768.0);
-	sound_stream::sample_t r = sound_stream::sample_t(m_esp->ser_r(7)) * (1.0 / 32768.0);
+	sound_stream::sample_t l = sound_stream::sample_t(m_esp->ser_r(6)) * output_scale;
+	sound_stream::sample_t r = sound_stream::sample_t(m_esp->ser_r(7)) * output_scale;
 
 #if !PUMP_FAKE_ESP_PROCESSING && PUMP_REPLACE_ESP_PROGRAM
 	// if we're processing the fake program through the ESP, the result should just be that of adding the inputs

--- a/src/mame/itech/itech32.cpp
+++ b/src/mame/itech/itech32.cpp
@@ -1797,8 +1797,8 @@ void itech32_state::base_devices(machine_config &config)
 	m_ensoniq->set_region2("ensoniq.2");
 	m_ensoniq->set_region3("ensoniq.3");
 	m_ensoniq->set_channels(1);               // channels
-	m_ensoniq->add_route(0, "speaker", 0.1, 1); // swapped stereo
-	m_ensoniq->add_route(1, "speaker", 0.1, 0);
+	m_ensoniq->add_route(0, "speaker", 1.6, 1); // swapped stereo
+	m_ensoniq->add_route(1, "speaker", 1.6, 0);
 }
 
 void itech32_state::via(machine_config &config)
@@ -1872,8 +1872,8 @@ void drivedge_state::drivedge(machine_config &config)
 	SPEAKER(config, "back", 2).rear();
 
 	m_ensoniq->set_channels(2);
-	m_ensoniq->add_route(2, "back", 0.1, 1);  // swapped stereo
-	m_ensoniq->add_route(3, "back", 0.1, 0);
+	m_ensoniq->add_route(2, "back", 1.6, 1);  // swapped stereo
+	m_ensoniq->add_route(3, "back", 1.6, 0);
 }
 
 void shoottv_state::shoottv(machine_config &config)

--- a/src/mame/nmk/macrossp.cpp
+++ b/src/mame/nmk/macrossp.cpp
@@ -1025,8 +1025,8 @@ void macrossp_state::macrossp(machine_config &config)
 	ensoniq.set_addrmap(1, &macrossp_state::es5506_bank1_map);
 	ensoniq.set_channels(1);
 	ensoniq.irq_cb().set(FUNC(macrossp_state::irqhandler));
-	ensoniq.add_route(0, "speaker", 0.1, 0);
-	ensoniq.add_route(1, "speaker", 0.1, 1);
+	ensoniq.add_route(0, "speaker", 1.6, 0);
+	ensoniq.add_route(1, "speaker", 1.6, 1);
 }
 
 void macrossp_state::quizmoon(machine_config &config)

--- a/src/mame/seta/ssv.cpp
+++ b/src/mame/seta/ssv.cpp
@@ -2453,8 +2453,8 @@ void ssv_state::ssv(machine_config &config)
 	m_ensoniq->set_region2("ensoniq.2");
 	m_ensoniq->set_region3("ensoniq.3");
 	m_ensoniq->set_channels(1);
-	m_ensoniq->add_route(0, "speaker", 0.075, 0);
-	m_ensoniq->add_route(1, "speaker", 0.075, 1);
+	m_ensoniq->add_route(0, "speaker", 1.2, 0);
+	m_ensoniq->add_route(1, "speaker", 1.2, 1);
 }
 
 void drifto94_state::drifto94(machine_config &config)

--- a/src/mame/virtual/vgmplay.cpp
+++ b/src/mame/virtual/vgmplay.cpp
@@ -4050,15 +4050,15 @@ void vgmplay_state::vgmplay(machine_config &config)
 	// TODO m_es5505[0]->set_addrmap(0, &vgmplay_state::es5505_map<0>);
 	// TODO m_es5505[0]->set_addrmap(1, &vgmplay_state::es5505_map<0>);
 	m_es5505[0]->set_channels(1);
-	m_es5505[0]->add_route(0, m_viz, 0.5, 0);
-	m_es5505[0]->add_route(1, m_viz, 0.5, 1);
+	m_es5505[0]->add_route(0, m_viz, 8.0, 0);
+	m_es5505[0]->add_route(1, m_viz, 8.0, 1);
 
 	ES5505(config, m_es5505[1], 0);
 	// TODO m_es5505[1]->set_addrmap(0, &vgmplay_state::es5505_map<1>);
 	// TODO m_es5505[1]->set_addrmap(1, &vgmplay_state::es5505_map<1>);
 	m_es5505[1]->set_channels(1);
-	m_es5505[1]->add_route(0, m_viz, 0.5, 0);
-	m_es5505[1]->add_route(1, m_viz, 0.5, 1);
+	m_es5505[1]->add_route(0, m_viz, 8.0, 0);
+	m_es5505[1]->add_route(1, m_viz, 8.0, 1);
 
 	X1_010(config, m_x1_010[0], 0);
 	m_x1_010[0]->set_addrmap(0, &vgmplay_state::x1_010_map<0>);


### PR DESCRIPTION
This is intended as much for discussion as for potentially merging into MAME.

The Ensoniq [ES5506 (OTTO)](https://drive.google.com/open?id=1wurPv72pYo0anJti0PuvurUGI51-IfxK) sound synthesis chip generates 20-bit samples.

See "[ENSONIQ OTTO Specification Rev. 2.3](https://drive.google.com/open?id=1wurPv72pYo0anJti0PuvurUGI51-IfxK)" page 14, section "6 THE CHANNEL REGISTERS - page 40hex":

> All the Channel register are 23 bits right justified. The upper three bits are three overflow guard bits.
> The lower 20 data bits are transferred to the serial output register.

See also Figure 16.6 on page 48, "SERIAL INTERFACE TIMING", which shows that the data shifted out on the serial audio data lines are the most significant 16 or 18 of the 20 bits in the channel register

The es5506_device code in [es5506.cpp](https://github.com/mamedev/mame/blob/master/src/devices/sound/es5506.cpp) correctly generates 20-bit samples, but they are [currently added to the audio stream as if they were 16-bit samples](https://github.com/mamedev/mame/blob/master/src/devices/sound/es5506.cpp#L1042):

```c++
stream.put_int(c, sampindex, cursample[c], 32768);
```

This results in samples in a range of ±16 rather than ±1. 

While the Ensoniq [ES5505 (OTIS)](https://drive.google.com/open?id=1O-qBbXW9oKCTsWpCb22k8ClBph7wQIql) chip does generate 16-bit samples, the es5505_device uses the same code as es5506_device, and thus also generates 20-bit samples, again added to the audio stream as if they were 16-bit ones.

The esq_5505_5510_pump_device in [esqpump.cpp](https://github.com/mamedev/mame/blob/master/src/devices/sound/esqpump.cpp) has always compensated for this by shifting the incoming 20-bit samples from the es5505_device right by `SAMPLE_SHIFT` = 4 bits, ever since this was added back when samples were still integers. 

I have verified, by logging the incoming samples to the esq_5505_5501_pump_device while playing music on an sd132 (in esq5505.cpp), that the samples it receives from the es5505_device are generally in the ±16 range, so this is not just theoretical.

None of this prevents anything from working, but it does mean that the es550[56]_device generated samples are outside of the [documented tech specs](https://docs.mamedev.org/techspecs/device_sound_interface.html#generalities):

> Samples in streams are encoded as sample_t. In the current implementation, this is a float. Nominal values are between -1 and 1 [...]

Anyone who reads the documentation and then tries to use an es550[56] device would likely be surprised by the sample range they would actually encounter. To me, it seems better if the es550[56]_device classes follow the [principle of least astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment) and add their samples to their output streams in the documented ±1 range.

Another issue is that the current code even generates samples outside the ±16 range - samples which both ES550[56] chips would have clamped, see the [ES5505 (OTIS) datasheet](https://drive.google.com/open?id=1O-qBbXW9oKCTsWpCb22k8ClBph7wQIql)" page 7, under "Serial Mode Register (SERMODE) -8",

> MSB[4:0] 
> The channel registers are 16 bits with 5 guard bits to prevent overflow during accumulation.
> Since the bus interface is 16 bits, these 5 bits are prevented and are written to the 5 MSB's when a
> channel register is written. If these bits are not either all 0's or all 1's, then overflow has occurred
> and the output will be saturated at either most positive or most negative depending on the state of MSB[4].

and the "[ENSONIQ OTTO Specification Rev. 2.3](https://drive.google.com/open?id=1wurPv72pYo0anJti0PuvurUGI51-IfxK)" on page 14, section "6 THE CHANNEL REGISTERS - page 40hex"

> If an overflow or underflow condition is present at the time of transfer to the output, the data is
> saturated to the appropriate rail so that data "wrapping" does not occur.

While the [tech specs](https://docs.mamedev.org/techspecs/device_sound_interface.html#generalities) say that

> clamping at the device level is not recommended (unless that's what happens in hardware of course)

the clamping here does happen in the real hardware, so should be simulated.

That actually also fixes some real observed audio glitches when playing back a demo sequence (`$SD-PALETTE` from the SD-1 Sequencer OS 4.10 disk).

Without this PR, so without clamping: [without_clamping.wav](https://github.com/user-attachments/files/22932852/without_clamping.wav)

With this PR, so including clamping: [with_clamping.wav](https://github.com/user-attachments/files/22932882/with_clamping.wav)


This PR proposes to address both of these by updating es5506.cpp to add generated samples to the output stream by

```c++
stream.put_int_clamp(c, sampindex, cursample[c], (1 << 19));
```

which not only brings the generated samples from 20-bit integers into the ±1 float range, but also clamps them.

Once the samples are generated in the correct ±1 range, the `SAMPLE_SHIFT` in `esqpump.cpp` can be removed, which this PR also does.

This PR also updates all routes that I was able to find in the codebase of audio from an es550[56]_device  to anything that is _not_ an esq_5505_5510_pump_device (that one is also being updated to handle the change in sample range), multiplying the route gain by 16 to compensate for the fact that the generated samples are now a factor of 16 smaller. 

This _should_ leave all audio sounding as before. 

I have verified that the VFX family of keyboards (vfx, vfxsd, sd1 and sd132) do in fact sound the same after as before, which makes sense, as they use the esq_5505_5510_pump_device and the reduction in the incoming sample range from ±16 is exactly compensated for by removing the 4-bit SAMPLE_SHIFT.

However, as I am not familiar with any of the other devices, they should probably be tested by someone who is, to verify that they still behave as expected. I may also have missed something, so more and more knowledgeable pairs of eyes would be a great help.

So I hope that this PR can be a starting point for discussion and finding the correct solution, which may of course be something completely different than this - or simply accepting the status quo, since it does after all work.
