### PR TITLE
esq5505.cpp and esqpump.cpp: Route es5505 bus 0 to a separate 'aux' stereo output.

### DIFF
--- a/src/mame/ensoniq/esq5505.cpp
+++ b/src/mame/ensoniq/esq5505.cpp
@@ -854,6 +854,10 @@ void esq5505_state::vfxsd(machine_config &config)
 	// but with an updated memory map that includes FDC and sequence RAM
 	m_maincpu->set_addrmap(AS_PROGRAM, &esq5505_state::vfxsd_map);
 
+	SPEAKER(config, "aux", 2).front();
+	m_pump->add_route(2, "aux", 1.0, 0);
+	m_pump->add_route(3, "aux", 1.0, 1);
+
 	// On the VFX-SD, the floppy connector always has exactly one 3.5inch DD floppy drive.
 	WD1772(config, m_fdc, 8000000);
 	FLOPPY_CONNECTOR(config, m_floppy_connector, esq5505_state::floppy_drives, "35dd", esq5505_state::floppy_formats, true).enable_sound(true);
@@ -897,6 +901,10 @@ void esq5505_state::vfx32(machine_config &config)
 	m_pump->set_esp(m_esp);
 	m_pump->add_route(0, "speaker", 1.0, 0);
 	m_pump->add_route(1, "speaker", 1.0, 1);
+
+	SPEAKER(config, "aux", 2).front();
+	m_pump->add_route(2, "aux", 1.0, 0);
+	m_pump->add_route(3, "aux", 1.0, 1);
 
 	ES5505(config, m_otis, 30.47618_MHz_XTAL / 2);
 	m_otis->sample_rate_changed().set(FUNC(esq5505_state::es5505_clock_changed));


### PR DESCRIPTION
The VFX-SD and later keyboards in the family have not only a main stereo output, but also a second 'aux' stereo output that bypasses effects processing and has separate output jacks from the keyboard. 

<img width="1236" height="264" alt="Screenshot From 2025-10-14 14-57-01" src="https://github.com/user-attachments/assets/4d8305c4-4da4-4ac3-92a6-46c0aba2a59c" />

This allows some sound to be routed for separate effects processing or recording.

<img width="1270" height="479" alt="Screenshot From 2025-10-14 14-55-54" src="https://github.com/user-attachments/assets/7ab4f7ed-650a-4096-a118-0d632c89127f" />
