### PR TITLE
further XaviX sound improvements and code cleanups [ramacat]

### DIFF
--- a/src/mame/tvgames/xavix.h
+++ b/src/mame/tvgames/xavix.h
@@ -66,7 +66,6 @@ public:
 	double tempo_frequency(uint8_t tempo) const;
 	double tempo_tick_hz(uint8_t tempo) const;
 	uint32_t  phase_step_per_tick(uint32_t rate) const;
-	uint8_t   current_page() const;
 	uint32_t envelope_period_ticks(uint8_t tp) const;
 
 
@@ -81,8 +80,6 @@ protected:
 private:
 	// stream
 	sound_stream* m_stream = nullptr;
-	//uint32_t m_output_rate = 167791;
-	xavix_state* m_owner_state = nullptr;
 
 	// global timing
 	uint8_t m_tempo_div[4] = { 0, 0, 0, 0 };
@@ -127,7 +124,6 @@ private:
 		bool      log_env_stopped = false;
 		bool      log_env_paused = false;
 
-		uint8_t ram_page = 0;
 		uint16_t noise_state = 0;
 	};
 
@@ -229,7 +225,6 @@ public:
 	void init_xavix();
 	void init_no_timer() { init_xavix(); m_disable_timer_irq_hack = true; }
 
-	uint8_t sound_wave_ram_read(uint8_t page, uint16_t offset) const;
 	uint8_t sound_current_page() const;
 
 	void ioevent_trg01(int state);


### PR DESCRIPTION
Further XaviX sound improvements and code cleanups [ramacat]
- Last remaining stuck notes bugs fixed.
 - IRQ handling for audio engine rewritten to remove 10.3 magic number and to derive from the sequencer rate only:
   - Balls now line up perfectly on popira towards the end of the song.
   - No more re-syncs between CPU and audio engine in hikara, which caused a lumbering feel to the music on each resync.
 - Sequencer rate calculated from hardware behaviours.
 - WM1 (Noise Generator) corrected to better reflect hardware.
 - Various envelope logic bugs fixed.
 - Implement capacity limit for mixer with hardware accurate voice clipping.
 - Implement DAC broadcast and multiplex mixer modes.
 - Simplified pitch-bend stepping logic.
 - WM0 waves are now read from RAM, as they are CPU modifiable.
 - Gain calculations adjusted to avoid clipping on worst case titles.
 - Lots of clean-up, de-duplication, better naming, and correctness fixes.
 - Detailed logging put in place.
 - Annotations added.
 - Use BIT helpers.