### PR TITLE
sound/va_vca.cpp: Defined a CEM3360_VCA specialization and used in on the linndrum.

### DIFF
--- a/src/devices/sound/va_vca.h
+++ b/src/devices/sound/va_vca.h
@@ -1,55 +1,90 @@
 // license:BSD-3-Clause
 // copyright-holders:m1macrophage
 
+/*
+Virtual analog amplifiers (VCAs).
+
+The gain CV ("control value") can either be provided via a class method, or in
+an input stream.
+
+The meaning of "gain CV" depends on the (sub)class being instantiated. It will
+typically match the type of gain control input in the emulated hardware.
+
+Summary of devices. See class comments for more details.
+
+* VA_VCA: An ideal, linear amplifier. The gain CV is just the gain (
+  output = gain_cv * input).
+
+* CEM3360_VCA: A CEM3360 OTA configured as a VCA. The gain CV is the voltage
+  applied to certain pins, depending on configuration (see class documentation).
+*/
+
 #ifndef MAME_SOUND_VA_VCA_H
 #define MAME_SOUND_VA_VCA_H
 
 #pragma once
 
-// Emulates a voltage-controled amplifier (VCA). The control value (CV) can
-// be set directly (set_fixed_cv()), or it can be provided in a sound stream
+DECLARE_DEVICE_TYPE(VA_VCA, va_vca_device)
+DECLARE_DEVICE_TYPE(CEM3360_VCA, cem3360_vca_device)
+
+// Emulates a voltage-controlled amplifier (VCA). The control value (CV) can
+// be set directly (set_fixed_gain_cv()), or it can be provided in a sound stream
 // (input 1), by a device in va_eg.h, for example. When the cv is provided via a
 // stream, this is also a ring modulator.
 //
-// The behavior of specific VCAs can be emulated by using the respective
-// configure_* functions.
-// Note that "CV" ("control value") could either refer to a control voltage, or
-// a control current, depending on the device.
+// The CV for this device is simply the gain (output = gain * input).
 class va_vca_device : public device_t, public device_sound_interface
 {
 public:
+	enum input_streams
+	{
+		INPUT_AUDIO = 0,
+		INPUT_GAIN,
+	};
+
 	va_vca_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0) ATTR_COLD;
 
-	// By default, the CV will be treated as a typical gain (output = cv * input)
-	// The configure_*() functions below might change this.
-
-	// CEM3360 (or AS3360) VCA in linear CV configuration: CV connected to pin
-	// Vc, and pins Vo and Ve connected to each other. The CV input (fixed or
-	// streaming) should be the voltage at the Vc pin.
-	va_vca_device &configure_cem3360_linear_cv();
-
-	// Fixed control value.
-	// Ignored when a second input is connected. CV will be obtained from
-	// input stream 1 in this case.
-	void set_fixed_cv(float cv);
+	// The meaning of "gain CV" depends on the class being instantiated. See
+	// each (sub)class documentation.
+	void set_fixed_gain_cv(float gain_cv);
 
 protected:
+	va_vca_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) ATTR_COLD;
+
+	virtual float cv_to_gain(float cv) const;
+
 	void device_start() override ATTR_COLD;
 	void sound_stream_update(sound_stream &stream) override;
 
 private:
-	float cv_to_gain(float cv) const;
-
-	// Configuration. No need to include in save state.
 	sound_stream *m_stream;
-	float m_min_cv;
-	float m_max_cv;
-	float m_cv_scale;
-
-	// State.
 	float m_fixed_gain;
 };
 
-DECLARE_DEVICE_TYPE(VA_VCA, va_vca_device)
+
+// Emulates a CEM3360-based VCA. Each CEM3360 has two OTAs that can be
+// configured as VCAs.
+//
+// The CEM3360 can be configured for linear or exponential gain control.
+// In linear control mode, pin Vo (4, 11) is connected to pin Ve (3, 12), and
+// the CV is applied to pin Vc (5, 10).
+// In exponential mode, pins Vo and Vc do not connect to anything, and the CV
+// is applied to pin Ve, which is also connected to pin Vref (8) via a resistor.
+//
+// Currently, only the linear control mode is implemented. The provided CV is
+// the voltage applied to pin Vc (5, 10).
+//
+// Known inaccuracies:
+// - Linear response. The real device likely has a tanh response, given it is
+//   OTA-based.
+// - Exponential gain control is not implemented.
+class cem3360_vca_device : public va_vca_device
+{
+public:
+	cem3360_vca_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0) ATTR_COLD;
+
+protected:
+	float cv_to_gain(float cv) const override;
+};
 
 #endif  // MAME_SOUND_VA_VCA_H

--- a/src/mame/linn/linndrum.cpp
+++ b/src/mame/linn/linndrum.cpp
@@ -402,7 +402,7 @@ private:
 	required_device<linndrum_vcf_eg_device> m_bass_eg;
 	required_device<timer_device> m_hat_trigger_timer;  // U37B (LM556).
 	required_device<va_rc_eg_device> m_hat_eg;
-	required_device<va_vca_device> m_hat_vca;  // CEM3360 (U91B).
+	required_device<cem3360_vca_device> m_hat_vca;  // U91B.
 	bool m_hat_open = false;
 	bool m_hat_triggered = false;
 	std::array<bool, NUM_MUX_VOICES> m_mux_counting = { false, false, false, false, false, false, false, false };
@@ -764,9 +764,9 @@ void linndrum_audio_device::device_add_mconfig(machine_config &config)
 
 	TIMER(config, m_hat_trigger_timer).configure_generic(FUNC(linndrum_audio_device::hat_trigger_timer_tick));  // LM556 (U37B).
 	VA_RC_EG(config, m_hat_eg).set_c(HAT_C22);
-	VA_VCA(config, m_hat_vca).configure_cem3360_linear_cv();
-	m_mux_volume[MV_HAT]->add_route(0, m_hat_vca, 1.0, 0);
-	m_hat_eg->add_route(0, m_hat_vca, HAT_EG2CV_SCALER, 1);
+	CEM3360_VCA(config, m_hat_vca);
+	m_mux_volume[MV_HAT]->add_route(0, m_hat_vca, 1.0, cem3360_vca_device::INPUT_AUDIO);
+	m_hat_eg->add_route(0, m_hat_vca, HAT_EG2CV_SCALER, cem3360_vca_device::INPUT_GAIN);
 
 	// *** Snare / sidestick section.
 

--- a/src/mame/roland/roland_tr707.cpp
+++ b/src/mame/roland/roland_tr707.cpp
@@ -550,8 +550,8 @@ void tr707_audio_device::device_add_mconfig(machine_config &config)
 		VA_RC_EG(config, m_mux_eg[i]).set_c(MUX_EG_C[i]);
 		DAC08(config, m_mux_dac[i]);
 		VA_VCA(config, m_mux_vca[i]);
-		m_mux_dac[i]->add_route(0, m_mux_vca[i], 1.0, 0);
-		m_mux_eg[i]->add_route(0, m_mux_vca[i], mux_dac_scale, 1);
+		m_mux_dac[i]->add_route(0, m_mux_vca[i], 1.0, va_vca_device::INPUT_AUDIO);
+		m_mux_eg[i]->add_route(0, m_mux_vca[i], mux_dac_scale, va_vca_device::INPUT_GAIN);
 	}
 
 
@@ -573,8 +573,8 @@ void tr707_audio_device::device_add_mconfig(machine_config &config)
 
 	VA_RC_EG(config, m_hat_eg).set_c(CAP_U(1));  // C71
 	auto &hat_vca = VA_VCA(config, "hat_vca");  // 2SD1469R, Q32
-	hat_hpf.add_route(0, hat_vca, HAT_VCA_SCALE, 0);
-	m_hat_eg->add_route(0, hat_vca, 1.0 / VCC, 1);
+	hat_hpf.add_route(0, hat_vca, HAT_VCA_SCALE, va_vca_device::INPUT_AUDIO);
+	m_hat_eg->add_route(0, hat_vca, 1.0 / VCC, va_vca_device::INPUT_GAIN);
 
 
 	// *** Single sound section ***
@@ -596,8 +596,8 @@ void tr707_audio_device::device_add_mconfig(machine_config &config)
 
 		VA_RC_EG(config, m_cymbal_eg[i]).set_c(CYMBAL_EG_C[i]);
 		VA_VCA(config, m_cymbal_vca[i]);  // 2SD1469R [Q14, Q15]
-		m_cymbal_hpf[i]->add_route(0, m_cymbal_vca[i], CYMBAL_VCA_SCALE, 0);
-		m_cymbal_eg[i]->add_route(0, m_cymbal_vca[i], 1.0 / VCC, 1);
+		m_cymbal_hpf[i]->add_route(0, m_cymbal_vca[i], CYMBAL_VCA_SCALE, va_vca_device::INPUT_AUDIO);
+		m_cymbal_eg[i]->add_route(0, m_cymbal_vca[i], 1.0 / VCC, va_vca_device::INPUT_GAIN);
 	}
 
 


### PR DESCRIPTION
Also, improved input handling: defined enums and added validation.

This should be a functional no-op. Just turned `CEM3360_VCA` into a device, instead of using VA_VCA with `.configure_cem3360()`.
