### PR TITLE
Miscellaneous code cleanups:

### DIFF
--- a/src/devices/bus/isa/fdc.cpp
+++ b/src/devices/bus/isa/fdc.cpp
@@ -330,18 +330,13 @@ void isa8_ec1841_0003_device::device_start()
 	m_isa->install_device(0x023c, 0x023f, *m_bus_mouse, &bus_mouse_device::map);
 }
 
-void isa8_ec1841_0003_device::aux_irq_w(int state)
-{
-	m_isa->irq4_w(state ? ASSERT_LINE : CLEAR_LINE);
-}
-
 void isa8_ec1841_0003_device::device_add_mconfig(machine_config &config)
 {
 	isa8_fdc_xt_device::device_add_mconfig(config);
 	FLOPPY_CONNECTOR(config.replace(), "fdc:0", pc_qd_floppies, "525dd", isa8_fdc_device::floppy_formats).enable_sound(true);
 	FLOPPY_CONNECTOR(config.replace(), "fdc:1", pc_qd_floppies, "525dd", isa8_fdc_device::floppy_formats).enable_sound(true);
 
-	BUS_MOUSE(config, "bus_mouse", 0).extint_callback().set(FUNC(isa8_ec1841_0003_device::aux_irq_w));
+	BUS_MOUSE(config, "bus_mouse", 0).extint_callback().set([this] (int state) { m_isa->irq4_w(state); });
 }
 
 

--- a/src/devices/bus/isa/fdc.h
+++ b/src/devices/bus/isa/fdc.h
@@ -135,8 +135,6 @@ protected:
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 
-	void aux_irq_w(int state);
-
 	required_device<bus_mouse_device> m_bus_mouse;
 };
 

--- a/src/devices/bus/isbx/isbc_218a.cpp
+++ b/src/devices/bus/isbx/isbc_218a.cpp
@@ -165,7 +165,7 @@ void isbc_218a_device::mcs1_w(offs_t offset, uint8_t data)
 	case 4:
 		m_motor = data & 1;
 		if(!m_fd8)
-			m_floppy0->get_device()->mon_w(!(data & 1));
+			m_floppy0->get_device()->mon_w(!m_motor);
 		break;
 	case 6: m_fdc->tc_w(data & 1); break;
 	}

--- a/src/devices/machine/pic8259.cpp
+++ b/src/devices/machine/pic8259.cpp
@@ -195,13 +195,16 @@ uint8_t pic8259_device::read(offs_t offset)
 				{
 					data = 0x80 | m_current_level;
 
-					if (!m_level_trig_mode && (!m_master || !BIT(m_slave, m_current_level)))
-						m_irr &= ~(1 << m_current_level);
+					if (!machine().side_effects_disabled())
+					{
+						if (!m_level_trig_mode && (!m_master || !BIT(m_slave, m_current_level)))
+							m_irr &= ~(1 << m_current_level);
 
-					if (!m_auto_eoi)
-						m_isr |= 1 << m_current_level;
+						if (!m_auto_eoi)
+							m_isr |= 1 << m_current_level;
 
-					m_irq_timer->adjust(attotime::zero);
+						m_irq_timer->adjust(attotime::zero);
+					}
 				}
 			}
 			else

--- a/src/mame/gridcomp/gridcomp.cpp
+++ b/src/mame/gridcomp/gridcomp.cpp
@@ -444,7 +444,7 @@ void gridcomp_state::grid1131(machine_config &config)
 {
 	grid1121(config);
 	subdevice<screen_device>("screen")->set_screen_update(FUNC(gridcomp_state::screen_update_113x));
-	subdevice<screen_device>("screen")->set_raw(XTAL(15'000'000)/2, 720, 0, 512, 262, 0, 240); // XXX
+	subdevice<screen_device>("screen")->set_raw(XTAL(15'000'000)/2, 720, 0, 512, 262, 0, 256);
 }
 
 void gridcomp_state::grid1139(machine_config &config)


### PR DESCRIPTION
- gridcomp: correct vertical resolution for Compass II
- isa/fdc: use a lambda instead of short function
- pic8259: side effect protection