### PR TITLE
t11: handle unaligned accesses to I/O page.

### DIFF
--- a/src/devices/cpu/t11/t11.cpp
+++ b/src/devices/cpu/t11/t11.cpp
@@ -138,13 +138,39 @@ void t11_device::WBYTE(int addr, int data)
 
 int t11_device::RWORD(int addr)
 {
-	return m_program.read_word(addr & 0xfffe);
+	if (addr < 0160000)
+		return m_program.read_word(addr & 0xfffe);
+	else // accessing I/O page
+	{
+		auto flags = m_program.lookup_read_word_flags(addr);
+		if (!flags)
+			return m_program.read_word(addr & 0xfffe);
+		else if (flags & UNALIGNED_WORD)
+			return m_program.read_word_unaligned(addr);
+		else if (flags & UNALIGNED_BYTE)
+			return m_program.read_byte(addr);
+		else
+			return m_program.read_word(addr & 0xfffe);
+	}
 }
 
 
 void t11_device::WWORD(int addr, int data)
 {
-	m_program.write_word(addr & 0xfffe, data);
+	if (addr < 0160000)
+		m_program.write_word(addr & 0xfffe, data);
+	else // accessing I/O page
+	{
+		auto flags = m_program.lookup_write_word_flags(addr);
+		if (!flags)
+			m_program.write_word(addr & 0xfffe, data);
+		else if (flags & UNALIGNED_WORD)
+			m_program.write_word_unaligned(addr, data);
+		else if (flags & UNALIGNED_BYTE)
+			m_program.write_byte(addr, data);
+		else
+			m_program.write_word(addr & 0xfffe, data);
+	}
 }
 
 

--- a/src/devices/cpu/t11/t11.h
+++ b/src/devices/cpu/t11/t11.h
@@ -35,6 +35,10 @@ public:
 	static constexpr uint8_t POWER_FAIL = PF_LINE;
 	static constexpr uint8_t BUS_ERROR = 8;
 
+	// memory flags
+	static constexpr uint16_t UNALIGNED_BYTE = 1;
+	static constexpr uint16_t UNALIGNED_WORD = 2;
+
 	// construction/destruction
 	t11_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 


### PR DESCRIPTION
Certain devices on bk, uknc require this, as they do not handle the WTBT bus signal and always decode full address.