### PR TITLE
toaplan/*.cpp: Merge common text layer emulation in GP9001 based drivers into toaplan/toaplan_txtilemap.cpp

### DIFF
--- a/src/mame/toaplan/batsugun.cpp
+++ b/src/mame/toaplan/batsugun.cpp
@@ -15,7 +15,6 @@
 #include "emupal.h"
 #include "screen.h"
 #include "speaker.h"
-#include "tilemap.h"
 
 /*
 Name        Board No      Maker         Game name

--- a/src/mame/toaplan/dt7.cpp
+++ b/src/mame/toaplan/dt7.cpp
@@ -15,6 +15,7 @@
     - service mode doesn't display properly
     - currently only coins up with service button
     - sound dies after one stage?
+	- merge tilemap emulation into toaplan/toaplan_txtilemap.cpp?
 */
 
 
@@ -585,7 +586,7 @@ ROM_START( dt7 )
 
 	/* Secondary CPU is a Toaplan marked chip, (TS-007-Spy  TOA PLAN) */
 	/* It's a NEC V25 (PLCC94) (encrypted program uploaded by main CPU) */
-	/* Note, same markings as other games found in toaplan2.cpp, but table is different! */
+	/* Note, same markings as other games found in toaplan/toaplan2.cpp, but table is different! */
 
 	ROM_REGION( 0x400000, "gp9001_0", 0 )
 	ROM_LOAD( "3a.49", 0x000000, 0x080000, CRC(ba8e378c) SHA1(d5eb4a839d6b3c2b9bf0bd87f06859a01a2c0cbf) )

--- a/src/mame/toaplan/enmadaio.cpp
+++ b/src/mame/toaplan/enmadaio.cpp
@@ -13,7 +13,6 @@
 #include "emupal.h"
 #include "screen.h"
 #include "speaker.h"
-#include "tilemap.h"
 
 /*
 Name        Board No      Maker         Game name

--- a/src/mame/toaplan/ghox.cpp
+++ b/src/mame/toaplan/ghox.cpp
@@ -14,7 +14,6 @@
 #include "emupal.h"
 #include "screen.h"
 #include "speaker.h"
-#include "tilemap.h"
 
 /*
 Name        Board No      Maker         Game name

--- a/src/mame/toaplan/kbash.cpp
+++ b/src/mame/toaplan/kbash.cpp
@@ -16,7 +16,6 @@
 #include "emupal.h"
 #include "screen.h"
 #include "speaker.h"
-#include "tilemap.h"
 
 /*
 Name        Board No      Maker         Game name

--- a/src/mame/toaplan/pipibibi.cpp
+++ b/src/mame/toaplan/pipibibi.cpp
@@ -15,7 +15,6 @@
 #include "emupal.h"
 #include "screen.h"
 #include "speaker.h"
-#include "tilemap.h"
 
 /*
 * Name        Board No      Maker         Game name
@@ -477,10 +476,10 @@ ROM_END
 
 } // anonymous namespace
 
-GAME( 1991, pipibibs,    0,        pipibibs,     pipibibs,   pipibibi_state, empty_init,    ROT0,   "Toaplan",         "Pipi & Bibis / Whoopee!! (Z80 sound cpu, set 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1991, pipibibsa,   pipibibs, pipibibs,     pipibibs,   pipibibi_state, empty_init,    ROT0,   "Toaplan",         "Pipi & Bibis / Whoopee!! (Z80 sound cpu, set 2)", MACHINE_SUPPORTS_SAVE )
-GAME( 1991, pipibibsp,   pipibibs, pipibibs,     pipibibsp,  pipibibi_state, empty_init,    ROT0,   "Toaplan",         "Pipi & Bibis / Whoopee!! (prototype)",            MACHINE_SUPPORTS_SAVE )
+GAME( 1991, pipibibs,    0,        pipibibs,     pipibibs,   pipibibi_state        , empty_init,      ROT0, "Toaplan", "Pipi & Bibis / Whoopee!! (Z80 sound cpu, set 1)",     MACHINE_SUPPORTS_SAVE )
+GAME( 1991, pipibibsa,   pipibibs, pipibibs,     pipibibs,   pipibibi_state,         empty_init,      ROT0, "Toaplan", "Pipi & Bibis / Whoopee!! (Z80 sound cpu, set 2)",     MACHINE_SUPPORTS_SAVE )
+GAME( 1991, pipibibsp,   pipibibs, pipibibs,     pipibibsp,  pipibibi_state,         empty_init,      ROT0, "Toaplan", "Pipi & Bibis / Whoopee!! (prototype)",                MACHINE_SUPPORTS_SAVE )
 
-GAME( 1991, pipibibsbl,  pipibibs, pipibibsbl,   pipibibsbl, pipibibi_bootleg_state, init_pipibibsbl, ROT0, "bootleg (Ryouta Kikaku)", "Pipi & Bibis / Whoopee!! (Ryouta Kikaku bootleg, encrypted)", MACHINE_SUPPORTS_SAVE )
-GAME( 1991, pipibibsbl2, pipibibs, pipibibsbl,   pipibibsbl, pipibibi_bootleg_state, empty_init,    ROT0,   "bootleg",                 "Pipi & Bibis / Whoopee!! (bootleg, decrypted)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // different memory map, not scrambled
-GAME( 1991, pipibibsbl3, pipibibs, pipibibsbl,   pipibibsbl, pipibibi_bootleg_state, empty_init,    ROT0,   "bootleg (Ryouta Kikaku)", "Pipi & Bibis / Whoopee!! (Ryouta Kikaku bootleg, decrypted)", MACHINE_SUPPORTS_SAVE )
+GAME( 1991, pipibibsbl,  pipibibs, pipibibsbl,   pipibibsbl, pipibibi_bootleg_state, init_pipibibsbl, ROT0, "bootleg", "Pipi & Bibis / Whoopee!! (bootleg, encrypted)",       MACHINE_SUPPORTS_SAVE )
+GAME( 1991, pipibibsbl2, pipibibs, pipibibsbl,   pipibibsbl, pipibibi_bootleg_state, empty_init,      ROT0, "bootleg", "Pipi & Bibis / Whoopee!! (bootleg, decrypted set 1)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // different memory map, not scrambled
+GAME( 1991, pipibibsbl3, pipibibs, pipibibsbl,   pipibibsbl, pipibibi_bootleg_state, empty_init,      ROT0, "bootleg", "Pipi & Bibis / Whoopee!! (bootleg, decrypted set 2)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/toaplan/raizing.h
+++ b/src/mame/toaplan/raizing.h
@@ -7,6 +7,7 @@
 
 #include "gp9001.h"
 #include "toaplan_coincounter.h"
+#include "toaplan_txtilemap.h"
 #include "toaplipt.h"
 
 #include "cpu/m68000/m68000.h"
@@ -21,7 +22,6 @@
 #include "emupal.h"
 #include "screen.h"
 #include "speaker.h"
-#include "tilemap.h"
 
 
 class raizing_base_state : public driver_device
@@ -29,9 +29,6 @@ class raizing_base_state : public driver_device
 public:
 	raizing_base_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
-		, m_tx_videoram(*this, "tx_videoram")
-		, m_tx_lineselect(*this, "tx_lineselect")
-		, m_tx_linescroll(*this, "tx_linescroll")
 		, m_tx_gfxram(*this, "tx_gfxram")
 		, m_audiobank(*this, "audiobank")
 		, m_raizing_okibank{
@@ -42,7 +39,7 @@ public:
 		, m_audiocpu(*this, "audiocpu")
 		, m_vdp(*this, "gp9001")
 		, m_oki(*this, "oki%u", 1U)
-		, m_gfxdecode(*this, "gfxdecode")
+		, m_tx_tilemap(*this, "tx_tilemap")
 		, m_screen(*this, "screen")
 		, m_palette(*this, "palette")
 		, m_soundlatch(*this, "soundlatch%u", 1U)
@@ -53,8 +50,6 @@ public:
 protected:
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
-	// used by everything
-	void create_tx_tilemap(int dx = 0, int dx_flipped = 0);
 	// used by bgaregga + batrider etc.
 	void bgaregga_common_video_start();
 	void raizing_z80_bankswitch_w(u8 data);
@@ -84,26 +79,19 @@ protected:
 	u32 screen_update_base(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void screen_vblank(int state);
 
-	void tx_videoram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void tx_linescroll_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	TILE_GET_INFO_MEMBER(get_text_tile_info);
-
 	void coin_w(u8 data);
 	void reset_audiocpu(int state);
 
-	tilemap_t *m_tx_tilemap = nullptr;    /* Tilemap for extra-text-layer */
-	required_shared_ptr<u16> m_tx_videoram;
-	optional_shared_ptr<u16> m_tx_lineselect;
-	optional_shared_ptr<u16> m_tx_linescroll;
 	optional_shared_ptr<u16> m_tx_gfxram;
 	optional_memory_bank m_audiobank; // batrider and bgaregga
 	optional_memory_bank_array<8> m_raizing_okibank[2];
 	optional_shared_ptr<u8> m_shared_ram; // 8 bit RAM shared between 68K and sound CPU
+
 	required_device<m68000_base_device> m_maincpu;
 	optional_device<z80_device> m_audiocpu;
 	required_device<gp9001vdp_device> m_vdp;
 	optional_device_array<okim6295_device, 2> m_oki;
-	optional_device<gfxdecode_device> m_gfxdecode;
+	required_device<toaplan_txtilemap_device> m_tx_tilemap;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 	optional_device_array<generic_latch_8_device, 4> m_soundlatch; // tekipaki, batrider, bgaregga, batsugun

--- a/src/mame/toaplan/raizing_batrider.cpp
+++ b/src/mame/toaplan/raizing_batrider.cpp
@@ -239,7 +239,7 @@ void batrider_state::batrider_tx_gfxram_w(offs_t offset, u16 data, u16 mem_mask)
 	if (oldword != data)
 	{
 		COMBINE_DATA(&m_tx_gfxram[offset]);
-		m_gfxdecode->gfx(0)->mark_dirty(offset/16);
+		m_tx_tilemap->gfx(0)->mark_dirty(offset/16);
 	}
 }
 
@@ -292,9 +292,7 @@ void batrider_state::video_start()
 	m_vdp->disable_sprite_buffer(); // disable buffering on this game
 
 	// Create the Text tilemap for this game
-	m_gfxdecode->gfx(0)->set_source(reinterpret_cast<u8 *>(m_tx_gfxram.target()));
-
-	create_tx_tilemap(0x1d4, 0x16b);
+	m_tx_tilemap->gfx(0)->set_source(reinterpret_cast<u8 *>(m_tx_gfxram.target()));
 
 	// Has special banking
 	save_item(NAME(m_gfxrom_bank));
@@ -620,10 +618,10 @@ INPUT_PORTS_END
 
 void batrider_state::batrider_dma_mem(address_map &map)
 {
-	map(0x0000, 0x1fff).ram().w(FUNC(batrider_state::tx_videoram_w)).share(m_tx_videoram);
+	map(0x0000, 0x1fff).rw(m_tx_tilemap, FUNC(toaplan_txtilemap_device::videoram_r), FUNC(toaplan_txtilemap_device::videoram_w));
 	map(0x2000, 0x2fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x3000, 0x31ff).ram().share(m_tx_lineselect);
-	map(0x3200, 0x33ff).ram().w(FUNC(batrider_state::tx_linescroll_w)).share(m_tx_linescroll);
+	map(0x3000, 0x31ff).rw(m_tx_tilemap, FUNC(toaplan_txtilemap_device::lineselect_r), FUNC(toaplan_txtilemap_device::lineselect_w));
+	map(0x3200, 0x33ff).rw(m_tx_tilemap, FUNC(toaplan_txtilemap_device::linescroll_r), FUNC(toaplan_txtilemap_device::linescroll_w));
 	map(0x3400, 0x7fff).ram();
 	map(0x8000, 0xffff).ram().w(FUNC(batrider_state::batrider_tx_gfxram_w)).share(m_tx_gfxram);
 }
@@ -802,13 +800,15 @@ void batrider_state::batrider(machine_config &config)
 	m_screen->screen_vblank().set(FUNC(batrider_state::screen_vblank));
 	m_screen->set_palette(m_palette);
 
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_batrider);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, gp9001vdp_device::VDP_PALETTE_LENGTH);
 
 	GP9001_VDP(config, m_vdp, 27_MHz_XTAL);
 	m_vdp->set_palette(m_palette);
 	m_vdp->set_tile_callback(FUNC(batrider_state::batrider_bank_cb));
 	m_vdp->vint_out_cb().set_inputline(m_maincpu, M68K_IRQ_2);
+
+	TOAPLAN_TXTILEMAP(config, m_tx_tilemap, 27_MHz_XTAL, m_palette, gfx_batrider);
+	m_tx_tilemap->set_offset(0x1d4, 0, 0x16b, 0);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
@@ -866,13 +866,15 @@ void bbakraid_state::bbakraid(machine_config &config)
 	m_screen->screen_vblank().set(FUNC(bbakraid_state::screen_vblank));
 	m_screen->set_palette(m_palette);
 
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_batrider);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, gp9001vdp_device::VDP_PALETTE_LENGTH);
 
 	GP9001_VDP(config, m_vdp, 27_MHz_XTAL);
 	m_vdp->set_palette(m_palette);
 	m_vdp->set_tile_callback(FUNC(bbakraid_state::batrider_bank_cb));
 	m_vdp->vint_out_cb().set_inputline(m_maincpu, M68K_IRQ_1);
+
+	TOAPLAN_TXTILEMAP(config, m_tx_tilemap, 27_MHz_XTAL, m_palette, gfx_batrider);
+	m_tx_tilemap->set_offset(0x1d4, 0, 0x16b, 0);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
@@ -912,12 +914,14 @@ void nprobowl_state::nprobowl(machine_config &config)
 	m_screen->screen_vblank().set(FUNC(nprobowl_state::screen_vblank));
 	m_screen->set_palette(m_palette);
 
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_batrider);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, gp9001vdp_device::VDP_PALETTE_LENGTH);
 
 	GP9001_VDP(config, m_vdp, 27_MHz_XTAL);
 	m_vdp->set_palette(m_palette);
 	m_vdp->vint_out_cb().set_inputline(m_maincpu, M68K_IRQ_2);
+
+	TOAPLAN_TXTILEMAP(config, m_tx_tilemap, 27_MHz_XTAL, m_palette, gfx_batrider);
+	m_tx_tilemap->set_offset(0x1d4, 0, 0x16b, 0);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/toaplan/snowbro2.cpp
+++ b/src/mame/toaplan/snowbro2.cpp
@@ -14,7 +14,6 @@
 #include "emupal.h"
 #include "screen.h"
 #include "speaker.h"
-#include "tilemap.h"
 
 /*
 Name        Board No      Maker         Game name

--- a/src/mame/toaplan/sunwise.cpp
+++ b/src/mame/toaplan/sunwise.cpp
@@ -16,7 +16,6 @@
 #include "emupal.h"
 #include "screen.h"
 #include "speaker.h"
-#include "tilemap.h"
 
 /*****************************************************************************
 

--- a/src/mame/toaplan/tekipaki.cpp
+++ b/src/mame/toaplan/tekipaki.cpp
@@ -15,7 +15,6 @@
 #include "emupal.h"
 #include "screen.h"
 #include "speaker.h"
-#include "tilemap.h"
 
 /*
 
@@ -335,7 +334,7 @@ ROM_START( whoopee )
 	ROM_LOAD16_BYTE( "whoopee.1", 0x000000, 0x020000, CRC(28882e7e) SHA1(8fcd278a7d005eb81cd9e461139c0c0f756a4fa4) )
 	ROM_LOAD16_BYTE( "whoopee.2", 0x000001, 0x020000, CRC(6796f133) SHA1(d4e657be260ba3fd3f0556ade617882513b52685) )
 
-	ROM_REGION( 0x10000, "audiocpu", 0 )            /* Sound HD647180 code */
+	ROM_REGION( 0x8000, "audiocpu", 0 )            /* Sound HD647180 code */
 	ROM_LOAD( "hd647180.025", 0x00000, 0x08000, CRC(c02436f6) SHA1(385343f88991646ec23b385eaea82718f1251ea6) )
 
 	ROM_REGION( 0x200000, "gp9001", 0 )

--- a/src/mame/toaplan/toaplan_txtilemap.cpp
+++ b/src/mame/toaplan/toaplan_txtilemap.cpp
@@ -1,0 +1,157 @@
+// license:BSD-3-Clause
+// copyright-holders:Quench, Yochizo, David Haywood
+/***************************************************************************
+
+Common Toaplan text tilemap generator usally paired with GP9001
+
+Tilemap: Single 64x32 tilemap (tile size: 8x8) with Per-line scroll
+
+RAM format (original docs from toaplan/truxton2.cpp)
+
+Text RAM format      $0000-1FFF (actually its probably $0000-0FFF)
+---- --xx xxxx xxxx = Tile number
+xxxx xx-- ---- ---- = Color (0 - 3Fh) + 40h
+
+Line select / flip   $0000-01EF (some games go to $01FF (excess?))
+---x xxxx xxxx xxxx = Line select for each line
+x--- ---- ---- ---- = X flip for each line ???
+
+Line scroll          $0000-01EF (some games go to $01FF (excess?))
+---- ---x xxxx xxxx = X scroll for each line
+
+Used in:
+- toaplan/fixeight.cpp
+- toaplan/raizing_batrider.cpp
+- toaplan/raizing.cpp
+- toaplan/truxton2.cpp
+
+***************************************************************************/
+
+
+#include "emu.h"
+#include "toaplan_txtilemap.h"
+#include "screen.h"
+
+DEFINE_DEVICE_TYPE(TOAPLAN_TXTILEMAP, toaplan_txtilemap_device, "toaplan_txtilemap", "Toaplan Text tilemap generator")
+
+toaplan_txtilemap_device::toaplan_txtilemap_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, TOAPLAN_TXTILEMAP, tag, owner, clock)
+	, device_gfx_interface(mconfig, *this)
+	, m_videoram(*this, "videoram", 0x2000U, ENDIANNESS_BIG)
+	, m_linescroll(*this, "linescroll", 0x200U, ENDIANNESS_BIG)
+	, m_lineselect(*this, "lineselect", 0x1000U, ENDIANNESS_BIG) // some hardware has 4KB line select RAM
+	, m_tilemap(nullptr)
+	, m_dx(0)
+	, m_dy(0)
+	, m_dx_flipped(0)
+	, m_dy_flipped(0)
+{
+}
+
+TILE_GET_INFO_MEMBER(toaplan_txtilemap_device::get_tile_info)
+{
+	const u16 attrib = m_videoram[tile_index];
+	const u32 tile_number = attrib & 0x3ff;
+	const u32 color = (attrib >> 10) & 0x3f;
+	tileinfo.set(0, tile_number, color, 0);
+}
+
+
+void toaplan_txtilemap_device::device_start()
+{
+	m_tilemap = &machine().tilemap().create(*this, tilemap_get_info_delegate(*this, FUNC(toaplan_txtilemap_device::get_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 64, 32);
+
+	m_tilemap->set_scroll_rows(8*32); /* line scrolling */
+	m_tilemap->set_scroll_cols(1);
+	m_tilemap->set_scrolldx(m_dx, m_dx_flipped);
+	m_tilemap->set_scrolldy(m_dy, m_dy_flipped);
+	m_tilemap->set_transparent_pen(0);
+}
+
+void toaplan_txtilemap_device::device_reset()
+{
+}
+
+// read/write handlers
+
+u16 toaplan_txtilemap_device::videoram_r(offs_t offset)
+{
+	return m_videoram[offset];
+}
+
+u16 toaplan_txtilemap_device::linescroll_r(offs_t offset)
+{
+	return m_linescroll[offset];
+}
+
+u16 toaplan_txtilemap_device::lineselect_r(offs_t offset)
+{
+	return m_lineselect[offset];
+}
+
+void toaplan_txtilemap_device::videoram_w(offs_t offset, u16 data, u16 mem_mask)
+{
+	COMBINE_DATA(&m_videoram[offset]);
+	if (offset < 64*32)
+		m_tilemap->mark_tile_dirty(offset);
+}
+
+void toaplan_txtilemap_device::linescroll_w(offs_t offset, u16 data, u16 mem_mask)
+{
+	/*** Line-Scroll RAM for Text Layer ***/
+	COMBINE_DATA(&m_linescroll[offset]);
+	m_tilemap->set_scrollx(offset, m_linescroll[offset]);
+}
+
+void toaplan_txtilemap_device::lineselect_w(offs_t offset, u16 data, u16 mem_mask)
+{
+	COMBINE_DATA(&m_lineselect[offset]);
+}
+
+// draw routine
+
+template <class BitmapClass>
+void toaplan_txtilemap_device::draw_tilemap_base(screen_device &screen, BitmapClass &bitmap, const rectangle &cliprect)
+{
+	rectangle clip = cliprect;
+
+	/* it seems likely that flipx can be set per line! */
+	/* however, none of the games does it, and emulating it in the */
+	/* MAME tilemap system without being ultra slow would be tricky */
+	m_tilemap->set_flip(m_lineselect[0] & 0x8000 ? 0 : TILEMAP_FLIPX);
+
+	/* line select is used for 'for use in' and '8ing' screen on bbakraid, 'Raizing' logo on batrider */
+	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
+	{
+		clip.min_y = clip.max_y = y;
+		m_tilemap->set_scrolly(0, m_lineselect[y] - y);
+		m_tilemap->draw(screen, bitmap, clip, 0);
+	}
+}
+
+template <class BitmapClass>
+void toaplan_txtilemap_device::draw_tilemap_bootleg_base(screen_device &screen, BitmapClass &bitmap, const rectangle &cliprect)
+{
+	// bootleg hardware has no scroll RAM
+	m_tilemap->draw(screen, bitmap, cliprect, 0, 0);
+}
+
+void toaplan_txtilemap_device::draw_tilemap(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+{
+	draw_tilemap_base(screen, bitmap, cliprect);
+}
+
+void toaplan_txtilemap_device::draw_tilemap(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	draw_tilemap_base(screen, bitmap, cliprect);
+}
+
+void toaplan_txtilemap_device::draw_tilemap_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+{
+	draw_tilemap_bootleg_base(screen, bitmap, cliprect);
+}
+
+void toaplan_txtilemap_device::draw_tilemap_bootleg(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	draw_tilemap_bootleg_base(screen, bitmap, cliprect);
+}

--- a/src/mame/toaplan/toaplan_txtilemap.h
+++ b/src/mame/toaplan/toaplan_txtilemap.h
@@ -1,0 +1,71 @@
+// license:BSD-3-Clause
+// copyright-holders:Quench, David Haywood
+/***************************************************************************
+
+Common Toaplan text tilemap generator usally paired with GP9001
+
+***************************************************************************/
+#ifndef MAME_TOAPLAN_TOAPLAN_TXTILEMAP_H
+#define MAME_TOAPLAN_TOAPLAN_TXTILEMAP_H
+
+#pragma once
+
+#include "tilemap.h"
+
+class toaplan_txtilemap_device : public device_t, public device_gfx_interface
+{
+public:
+	toaplan_txtilemap_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+	template <typename T> toaplan_txtilemap_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, T &&palette_tag, const gfx_decode_entry *gfxinfo)
+		: toaplan_txtilemap_device(mconfig, tag, owner, clock)
+	{
+		set_info(gfxinfo);
+		set_palette(std::forward<T>(palette_tag));
+	}
+
+	// configurations
+	void set_offset(int dx, int dy, int dx_flipped, int dy_flipped)
+	{
+		m_dx = dx;
+		m_dy = dy;
+		m_dx_flipped = dx_flipped;
+		m_dy_flipped = dy_flipped;
+	}
+
+	// read/write handlers
+	u16 videoram_r(offs_t offset);
+	u16 linescroll_r(offs_t offset);
+	u16 lineselect_r(offs_t offset);
+	void videoram_w(offs_t offset, u16 data, u16 mem_mask);
+	void linescroll_w(offs_t offset, u16 data, u16 mem_mask);
+	void lineselect_w(offs_t offset, u16 data, u16 mem_mask);
+
+	// renderer
+	void draw_tilemap(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void draw_tilemap(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	void draw_tilemap_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void draw_tilemap_bootleg(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+private:
+	template <class BitmapClass> void draw_tilemap_base(screen_device &screen, BitmapClass &bitmap, const rectangle &cliprect);
+	template <class BitmapClass> void draw_tilemap_bootleg_base(screen_device &screen, BitmapClass &bitmap, const rectangle &cliprect);
+
+	TILE_GET_INFO_MEMBER(get_tile_info);
+
+	memory_share_creator<u16> m_videoram;
+	memory_share_creator<u16> m_linescroll;
+	memory_share_creator<u16> m_lineselect;
+
+	tilemap_t *m_tilemap = nullptr;
+
+	int m_dx, m_dy;
+	int m_dx_flipped, m_dy_flipped;
+};
+
+DECLARE_DEVICE_TYPE(TOAPLAN_TXTILEMAP, toaplan_txtilemap_device)
+
+#endif // MAME_TOAPLAN_TOAPLAN_TXTILEMAP_H

--- a/src/mame/toaplan/vfive.cpp
+++ b/src/mame/toaplan/vfive.cpp
@@ -15,7 +15,6 @@
 #include "emupal.h"
 #include "screen.h"
 #include "speaker.h"
-#include "tilemap.h"
 
 /*
 Name        Board No      Maker         Game name


### PR DESCRIPTION
Various Toaplan GP9001 based drivers: Remove unnecessary include and variables
toaplan/pipibibi.cpp: Fix metadata (Ryouta Kikaku is (planned?) distributor of prototype in Japan/World, not of bootlegger nor distributor of bootleg sets - just bootlegger has retains 'Ryouta Kikaku' in title screen)
toaplan/dt7.cpp: Fix filename and add notes
toaplan/dogyuun.cpp: Reduce duplicates