### PR TITLE
taito/tc0110pcr.cpp: Use callback and configuration for color format and address shift, Minor cleanups

### DIFF
--- a/src/mame/taito/galastrm.cpp
+++ b/src/mame/taito/galastrm.cpp
@@ -150,6 +150,7 @@ private:
 	INTERRUPT_GEN_MEMBER(interrupt);
 	void draw_sprites_pre(int x_offs, int y_offs);
 	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, const u32 *primasks, int priority);
+	rgb_t color_xrgb555(u16 data);
 
 	void main_map(address_map &map) ATTR_COLD;
 };
@@ -584,6 +585,11 @@ void galastrm_renderer::tc0610_rotate_draw(bitmap_ind16 &srcbitmap, const rectan
                 SCREEN REFRESH
 **************************************************************/
 
+rgb_t galastrm_state::color_xrgb555(u16 data)
+{
+	return rgb_t(pal5bit(data >> 10), pal5bit(data >> 5), pal5bit(data >> 0));
+}
+
 u32 galastrm_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	u8 layer[5];
@@ -750,7 +756,7 @@ void galastrm_state::main_map(address_map &map)
 	map(0x600000, 0x6007ff).rw("taito_en:dpram", FUNC(mb8421_device::left_r), FUNC(mb8421_device::left_w)); // Sound shared RAM
 	map(0x800000, 0x80ffff).rw(m_tc0480scp, FUNC(tc0480scp_device::ram_r), FUNC(tc0480scp_device::ram_w));        // tilemaps
 	map(0x830000, 0x83002f).rw(m_tc0480scp, FUNC(tc0480scp_device::ctrl_r), FUNC(tc0480scp_device::ctrl_w));
-	map(0x900000, 0x900003).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_rbswap_word_w));
+	map(0x900000, 0x900003).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));
 	map(0xb00000, 0xb00003).w(FUNC(galastrm_state::tc0610_w<0>));
 	map(0xc00000, 0xc00003).w(FUNC(galastrm_state::tc0610_w<1>));
 	map(0xd00000, 0xd0ffff).rw(m_tc0100scn, FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));        // piv tilemaps
@@ -868,6 +874,8 @@ void galastrm_state::galastrm(machine_config &config)
 	m_tc0480scp->set_offsets(-40, -3);
 
 	TC0110PCR(config, m_tc0110pcr, 0);
+	m_tc0110pcr->set_shift(0);
+	m_tc0110pcr->set_color_callback(FUNC(galastrm_state::color_xrgb555));
 
 	// sound hardware
 	SPEAKER(config, "speaker", 2).front();

--- a/src/mame/taito/ninjaw.cpp
+++ b/src/mame/taito/ninjaw.cpp
@@ -395,6 +395,8 @@ private:
 	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int x_offs, int y_offs, int chip);
 	void parse_control();
 	u32 update_screen(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int xoffs, int chip);
+	rgb_t color_xbgr555(u16 data);
+
 	void darius2_master_map(address_map &map) ATTR_COLD;
 	void darius2_slave_map(address_map &map) ATTR_COLD;
 	void ninjaw_master_map(address_map &map) ATTR_COLD;
@@ -546,6 +548,11 @@ void ninjaw_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, con
         SCREEN REFRESH
 *******************************************************************************/
 
+rgb_t ninjaw_state::color_xbgr555(u16 data)
+{
+	return rgb_t(pal5bit(data >> 0), pal5bit(data >> 5), pal5bit(data >> 10));
+}
+
 u32 ninjaw_state::update_screen(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int xoffs, int chip)
 {
 	tc0100scn_device *tc0100scn = m_tc0100scn[chip];
@@ -673,9 +680,9 @@ void ninjaw_state::ninjaw_master_map(address_map &map)
 	map(0x2e0000, 0x2e000f).rw(m_tc0100scn[1], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 	map(0x300000, 0x313fff).rw(m_tc0100scn[2], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));      /* tilemaps (3rd screen) */
 	map(0x320000, 0x32000f).rw(m_tc0100scn[2], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x340000, 0x340007).rw(m_tc0110pcr[0], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));        /* palette (1st screen) */
-	map(0x350000, 0x350007).rw(m_tc0110pcr[1], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));        /* palette (2nd screen) */
-	map(0x360000, 0x360007).rw(m_tc0110pcr[2], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));        /* palette (3rd screen) */
+	map(0x340000, 0x340007).rw(m_tc0110pcr[0], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));        /* palette (1st screen) */
+	map(0x350000, 0x350007).rw(m_tc0110pcr[1], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));        /* palette (2nd screen) */
+	map(0x360000, 0x360007).rw(m_tc0110pcr[2], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));        /* palette (3rd screen) */
 }
 
 // NB there could be conflicts between which cpu writes what to the
@@ -689,9 +696,9 @@ void ninjaw_state::ninjaw_slave_map(address_map &map)
 	map(0x240000, 0x24ffff).ram().share("share1");
 	map(0x260000, 0x263fff).ram().share("spriteram");
 	map(0x280000, 0x293fff).r(m_tc0100scn[0], FUNC(tc0100scn_device::ram_r)).w(FUNC(ninjaw_state::tc0100scn_triple_screen_w)); /* tilemaps (1st screen/all screens) */
-	map(0x340000, 0x340007).rw(m_tc0110pcr[0], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));        /* palette (1st screen) */
-	map(0x350000, 0x350007).rw(m_tc0110pcr[1], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));        /* palette (2nd screen) */
-	map(0x360000, 0x360007).rw(m_tc0110pcr[2], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));        /* palette (3rd screen) */
+	map(0x340000, 0x340007).rw(m_tc0110pcr[0], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));        /* palette (1st screen) */
+	map(0x350000, 0x350007).rw(m_tc0110pcr[1], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));        /* palette (2nd screen) */
+	map(0x360000, 0x360007).rw(m_tc0110pcr[2], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));        /* palette (3rd screen) */
 }
 
 void ninjaw_state::darius2_master_map(address_map &map)
@@ -710,9 +717,9 @@ void ninjaw_state::darius2_master_map(address_map &map)
 	map(0x2e0000, 0x2e000f).rw(m_tc0100scn[1], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 	map(0x300000, 0x313fff).rw(m_tc0100scn[2], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));      /* tilemaps (3rd screen) */
 	map(0x320000, 0x32000f).rw(m_tc0100scn[2], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x340000, 0x340007).rw(m_tc0110pcr[0], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));        /* palette (1st screen) */
-	map(0x350000, 0x350007).rw(m_tc0110pcr[1], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));        /* palette (2nd screen) */
-	map(0x360000, 0x360007).rw(m_tc0110pcr[2], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));        /* palette (3rd screen) */
+	map(0x340000, 0x340007).rw(m_tc0110pcr[0], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));        /* palette (1st screen) */
+	map(0x350000, 0x350007).rw(m_tc0110pcr[1], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));        /* palette (2nd screen) */
+	map(0x360000, 0x360007).rw(m_tc0110pcr[2], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));        /* palette (3rd screen) */
 }
 
 void ninjaw_state::darius2_slave_map(address_map &map)
@@ -955,6 +962,8 @@ void ninjaw_state::ninjaw(machine_config &config)
 	m_tc0100scn[0]->set_palette(m_tc0110pcr[0]);
 
 	TC0110PCR(config, m_tc0110pcr[0], 0);
+	m_tc0110pcr[0]->set_shift(0);
+	m_tc0110pcr[0]->set_color_callback(FUNC(ninjaw_state::color_xbgr555));
 
 	TC0100SCN(config, m_tc0100scn[1], 0);
 	m_tc0100scn[1]->set_offsets(22, 0);
@@ -963,6 +972,8 @@ void ninjaw_state::ninjaw(machine_config &config)
 	m_tc0100scn[1]->set_palette(m_tc0110pcr[1]);
 
 	TC0110PCR(config, m_tc0110pcr[1], 0);
+	m_tc0110pcr[1]->set_shift(0);
+	m_tc0110pcr[1]->set_color_callback(FUNC(ninjaw_state::color_xbgr555));
 
 	TC0100SCN(config, m_tc0100scn[2], 0);
 	m_tc0100scn[2]->set_offsets(22, 0);
@@ -971,6 +982,8 @@ void ninjaw_state::ninjaw(machine_config &config)
 	m_tc0100scn[2]->set_palette(m_tc0110pcr[2]);
 
 	TC0110PCR(config, m_tc0110pcr[2], 0);
+	m_tc0110pcr[2]->set_shift(0);
+	m_tc0110pcr[2]->set_color_callback(FUNC(ninjaw_state::color_xbgr555));
 
 	/* sound hardware */
 	SPEAKER(config, "speaker", 2).front();
@@ -1060,6 +1073,8 @@ void ninjaw_state::darius2(machine_config &config)
 	m_tc0100scn[0]->set_palette(m_tc0110pcr[0]);
 
 	TC0110PCR(config, m_tc0110pcr[0], 0);
+	m_tc0110pcr[0]->set_shift(0);
+	m_tc0110pcr[0]->set_color_callback(FUNC(ninjaw_state::color_xbgr555));
 
 	TC0100SCN(config, m_tc0100scn[1], 0);
 	m_tc0100scn[1]->set_offsets(22, 0);
@@ -1068,6 +1083,8 @@ void ninjaw_state::darius2(machine_config &config)
 	m_tc0100scn[1]->set_palette(m_tc0110pcr[1]);
 
 	TC0110PCR(config, m_tc0110pcr[1], 0);
+	m_tc0110pcr[1]->set_shift(0);
+	m_tc0110pcr[1]->set_color_callback(FUNC(ninjaw_state::color_xbgr555));
 
 	TC0100SCN(config, m_tc0100scn[2], 0);
 	m_tc0100scn[2]->set_offsets(22, 0);
@@ -1076,6 +1093,8 @@ void ninjaw_state::darius2(machine_config &config)
 	m_tc0100scn[2]->set_palette(m_tc0110pcr[2]);
 
 	TC0110PCR(config, m_tc0110pcr[2], 0);
+	m_tc0110pcr[2]->set_shift(0);
+	m_tc0110pcr[2]->set_color_callback(FUNC(ninjaw_state::color_xbgr555));
 
 	/* sound hardware */
 	SPEAKER(config, "speaker", 2).front();

--- a/src/mame/taito/othunder.cpp
+++ b/src/mame/taito/othunder.cpp
@@ -410,7 +410,7 @@ void othunder_state::othunder_map(address_map &map)
 	map(0x080000, 0x08ffff).ram();
 	map(0x090000, 0x09000f).rw(m_tc0220ioc, FUNC(tc0220ioc_device::read), FUNC(tc0220ioc_device::write)).umask16(0x00ff);
 //  map(0x09000c, 0x09000d).nopw();   /* ?? (keeps writing 0x77) */
-	map(0x100000, 0x100007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_rbswap_word_w));   /* palette */
+	map(0x100000, 0x100007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));   /* palette */
 	map(0x200000, 0x20ffff).rw(m_tc0100scn, FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x220000, 0x22000f).rw(m_tc0100scn, FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 	map(0x300001, 0x300001).w(m_tc0140syt, FUNC(tc0140syt_device::master_port_w));
@@ -625,6 +625,8 @@ void othunder_state::othunder(machine_config &config)
 	m_tc0100scn->set_palette(m_tc0110pcr);
 
 	TC0110PCR(config, m_tc0110pcr, 0);
+	m_tc0110pcr->set_shift(0);
+	m_tc0110pcr->set_color_callback(FUNC(othunder_state::color_xrgb555));
 
 	/* sound hardware */
 	SPEAKER(config, "speaker", 2).front();

--- a/src/mame/taito/othunder.h
+++ b/src/mame/taito/othunder.h
@@ -61,6 +61,7 @@ private:
 	void tc0310fam_w(offs_t offset, u8 data);
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void vblank_w(int state);
+	rgb_t color_xrgb555(u16 data);
 
 	void othunder_map(address_map &map) ATTR_COLD;
 	void z80_sound_map(address_map &map) ATTR_COLD;

--- a/src/mame/taito/othunder_v.cpp
+++ b/src/mame/taito/othunder_v.cpp
@@ -193,6 +193,11 @@ logerror("Sprite number %04x had %02x invalid chunks\n",tilenum,bad_chunks);
                 SCREEN REFRESH
 **************************************************************/
 
+rgb_t othunder_state::color_xrgb555(u16 data)
+{
+	return rgb_t(pal5bit(data >> 10), pal5bit(data >> 5), pal5bit(data >> 0));
+}
+
 u32 othunder_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	int layer[3];

--- a/src/mame/taito/taito_f2.cpp
+++ b/src/mame/taito/taito_f2.cpp
@@ -2911,6 +2911,9 @@ void taitof2_state::finalb(machine_config &config)
 	TC0100SCN(config, m_tc0100scn[0], 0);
 	m_tc0100scn[0]->set_offsets(1, 0);
 	m_tc0100scn[0]->set_palette(m_tc0110pcr);
+
+	m_tc0110pcr->set_shift(1);
+	m_tc0110pcr->set_color_callback(FUNC(taitof2_state::color_xbgr555));
 }
 
 void dondokod_state::dondokod(machine_config &config)
@@ -3034,6 +3037,9 @@ void taitof2_state::qtorimon(machine_config &config)
 	TC0100SCN(config, m_tc0100scn[0], 0);
 	m_tc0100scn[0]->set_gfxlayout(TC0100SCN_LAYOUT_1BPP);
 	m_tc0100scn[0]->set_palette(m_tc0110pcr);
+
+	m_tc0110pcr->set_shift(1);
+	m_tc0110pcr->set_color_callback(FUNC(taitof2_state::color_xbgr555));
 }
 
 void taitof2_state::liquidk(machine_config &config)
@@ -3070,6 +3076,9 @@ void taitof2_state::quizhq(machine_config &config)
 	TC0100SCN(config, m_tc0100scn[0], 0);
 	m_tc0100scn[0]->set_gfxlayout(TC0100SCN_LAYOUT_1BPP);
 	m_tc0100scn[0]->set_palette(m_tc0110pcr);
+
+	m_tc0110pcr->set_shift(1);
+	m_tc0110pcr->set_color_callback(FUNC(taitof2_state::color_xbgr555));
 }
 
 void taitof2_state::ssi(machine_config &config)
@@ -3145,6 +3154,9 @@ void mjnquest_state::mjnquest(machine_config &config)
 	TC0100SCN(config, m_tc0100scn[0], 0);
 	m_tc0100scn[0]->set_palette(m_tc0110pcr);
 	m_tc0100scn[0]->set_tile_callback(FUNC(mjnquest_state::tmap_cb));
+
+	m_tc0110pcr->set_shift(1);
+	m_tc0110pcr->set_color_callback(FUNC(mjnquest_state::color_xbgr555));
 }
 
 void footchmp_state::footchmp(machine_config &config)

--- a/src/mame/taito/taito_f2.h
+++ b/src/mame/taito/taito_f2.h
@@ -179,6 +179,7 @@ protected:
 	void update_sprites_active_area();
 	void taito_f2_tc360_spritemixdraw(screen_device &screen, bitmap_ind16 &dest_bmp, const rectangle &clip, gfx_element *gfx,
 	u32 code, u32 color, int flipx, int flipy, int sx, int sy, int scalex, int scaley, u64 primask = 0, bool use_mixer = false);
+	rgb_t color_xbgr555(u16 data);
 
 	void dinorex_map(address_map &map) ATTR_COLD;
 	void finalb_map(address_map &map) ATTR_COLD;

--- a/src/mame/taito/taito_f2_v.cpp
+++ b/src/mame/taito/taito_f2_v.cpp
@@ -28,6 +28,11 @@ enum
 
 /***********************************************************************************/
 
+rgb_t taitof2_state::color_xbgr555(u16 data)
+{
+	return rgb_t(pal5bit(data >> 0), pal5bit(data >> 5), pal5bit(data >> 10));
+}
+
 TC0100SCN_CB_MEMBER(mjnquest_state::tmap_cb)
 {
 	*code = (*code & 0x7fff) | (m_gfxbank << 15);

--- a/src/mame/taito/taito_z.cpp
+++ b/src/mame/taito/taito_z.cpp
@@ -1599,7 +1599,7 @@ void contcirc_state::contcirc_map(address_map &map)
 	map(0x080000, 0x083fff).ram();
 	map(0x084000, 0x087fff).ram().share("share1");
 	map(0x090001, 0x090001).w(FUNC(contcirc_state::contcirc_out_w));    /* road palette bank, sub CPU reset, 3d glasses control */
-	map(0x100000, 0x100007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_rbswap_word_w));   /* palette */
+	map(0x100000, 0x100007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));   /* palette */
 	map(0x200000, 0x20ffff).rw(m_tc0100scn, FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x220000, 0x22000f).rw(m_tc0100scn, FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 	map(0x300000, 0x301fff).rw(m_tc0150rod, FUNC(tc0150rod_device::word_r), FUNC(tc0150rod_device::word_w));    /* "root ram" */
@@ -1629,7 +1629,7 @@ void chasehq_state::chasehq_map(address_map &map)
 	map(0x800000, 0x800001).w(FUNC(chasehq_state::cpua_ctrl_w));
 	map(0x820001, 0x820001).w(m_tc0140syt, FUNC(tc0140syt_device::master_port_w));
 	map(0x820003, 0x820003).rw(m_tc0140syt, FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
-	map(0xa00000, 0xa00007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));  /* palette */
+	map(0xa00000, 0xa00007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));  /* palette */
 	map(0xc00000, 0xc0ffff).rw(m_tc0100scn, FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0xc20000, 0xc2000f).rw(m_tc0100scn, FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 	map(0xd00000, 0xd007ff).ram().share("spriteram");
@@ -1653,7 +1653,7 @@ void contcirc_state::enforce_map(address_map &map)
 	map(0x200001, 0x200001).w(FUNC(contcirc_state::contcirc_out_w));
 	map(0x300000, 0x3006ff).ram().share("spriteram");
 	map(0x400000, 0x401fff).rw(m_tc0150rod, FUNC(tc0150rod_device::word_r), FUNC(tc0150rod_device::word_w));    /* "root ram" ??? */
-	map(0x500000, 0x500007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_rbswap_word_w));   /* palette */
+	map(0x500000, 0x500007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));   /* palette */
 	map(0x600000, 0x60ffff).rw(m_tc0100scn, FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x620000, 0x62000f).rw(m_tc0100scn, FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 }
@@ -1747,7 +1747,7 @@ void nightstr_state::nightstr_map(address_map &map)
 	map(0x800000, 0x800001).w(FUNC(nightstr_state::cpua_ctrl_w));
 	map(0x820001, 0x820001).w(m_tc0140syt, FUNC(tc0140syt_device::master_port_w));
 	map(0x820003, 0x820003).rw(m_tc0140syt, FUNC(tc0140syt_device::master_comm_r), FUNC(tc0140syt_device::master_comm_w));
-	map(0xa00000, 0xa00007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));  /* palette */
+	map(0xa00000, 0xa00007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));  /* palette */
 	map(0xc00000, 0xc0ffff).rw(m_tc0100scn, FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0xc20000, 0xc2000f).rw(m_tc0100scn, FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 	map(0xd00000, 0xd007ff).ram().share("spriteram");
@@ -1770,7 +1770,7 @@ void taitoz_z80_sound_state::aquajack_map(address_map &map)
 	map(0x100000, 0x103fff).ram();
 	map(0x104000, 0x107fff).ram().share("share1");
 	map(0x200000, 0x200001).w(FUNC(taitoz_z80_sound_state::cpua_ctrl_w));  // not needed, but it's probably like the others
-	map(0x300000, 0x300007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));  /* palette */
+	map(0x300000, 0x300007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));  /* palette */
 	map(0x800000, 0x801fff).rw(m_tc0150rod, FUNC(tc0150rod_device::word_r), FUNC(tc0150rod_device::word_w));
 	map(0xa00000, 0xa0ffff).rw(m_tc0100scn, FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0xa20000, 0xa2000f).rw(m_tc0100scn, FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
@@ -1799,7 +1799,7 @@ void spacegun_state::spacegun_map(address_map &map)
 	map(0x500000, 0x5005ff).ram().share("spriteram");
 	map(0x900000, 0x90ffff).rw(m_tc0100scn, FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));    /* tilemaps */
 	map(0x920000, 0x92000f).rw(m_tc0100scn, FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0xb00000, 0xb00007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_rbswap_word_w));   /* palette */
+	map(0xb00000, 0xb00007).rw(m_tc0110pcr, FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));   /* palette */
 }
 
 void spacegun_state::spacegun_cpub_map(address_map &map)
@@ -3217,6 +3217,8 @@ void contcirc_state::contcirc(machine_config &config) //OSC: 26.686, 24.000, 16.
 	TC0150ROD(config, m_tc0150rod, 0);
 
 	TC0110PCR(config, m_tc0110pcr, 0);
+	m_tc0110pcr->set_shift(0);
+	m_tc0110pcr->set_color_callback(FUNC(contcirc_state::color_xrgb555));
 
 	/* sound hardware */
 	SPEAKER(config, "front").front_center();
@@ -3276,6 +3278,8 @@ void chasehq_state::chasehq(machine_config &config) //OSC: 26.686, 24.000, 16.00
 	TC0150ROD(config, m_tc0150rod, 0);
 
 	TC0110PCR(config, m_tc0110pcr, 0);
+	m_tc0110pcr->set_shift(0);
+	m_tc0110pcr->set_color_callback(FUNC(chasehq_state::color_xbgr555));
 
 	/* sound hardware */
 	SPEAKER(config, "front").front_center();
@@ -3338,6 +3342,8 @@ void contcirc_state::enforce(machine_config &config)
 	TC0150ROD(config, m_tc0150rod, 0);
 
 	TC0110PCR(config, m_tc0110pcr, 0);
+	m_tc0110pcr->set_shift(0);
+	m_tc0110pcr->set_color_callback(FUNC(contcirc_state::color_xrgb555));
 
 	/* sound hardware */
 	SPEAKER(config, "speaker", 2).front();
@@ -3535,6 +3541,8 @@ void nightstr_state::nightstr(machine_config &config) //OSC: 26.686, 24.000, 16.
 	TC0150ROD(config, m_tc0150rod, 0);
 
 	TC0110PCR(config, m_tc0110pcr, 0);
+	m_tc0110pcr->set_shift(0);
+	m_tc0110pcr->set_color_callback(FUNC(nightstr_state::color_xbgr555));
 
 	/* sound hardware */
 	SPEAKER(config, "front").front_center();
@@ -3596,6 +3604,8 @@ void taitoz_z80_sound_state::aquajack(machine_config &config) //OSC: 26.686, 24.
 	TC0150ROD(config, m_tc0150rod, 0);
 
 	TC0110PCR(config, m_tc0110pcr, 0);
+	m_tc0110pcr->set_shift(0);
+	m_tc0110pcr->set_color_callback(FUNC(taitoz_z80_sound_state::color_xbgr555));
 
 	/* sound hardware */
 	SPEAKER(config, "speaker", 2).front();
@@ -3662,6 +3672,8 @@ void spacegun_state::spacegun(machine_config &config) //OSC: 26.686, 24.000, 16.
 	m_tc0100scn->set_palette(m_tc0110pcr);
 
 	TC0110PCR(config, m_tc0110pcr, 0);
+	m_tc0110pcr->set_shift(0);
+	m_tc0110pcr->set_color_callback(FUNC(spacegun_state::color_xrgb555));
 
 	/* sound hardware */
 	SPEAKER(config, "speaker", 2).front();

--- a/src/mame/taito/taito_z.h
+++ b/src/mame/taito/taito_z.h
@@ -69,6 +69,7 @@ protected:
 	void pancontrol_w(offs_t offset, u8 data);
 
 	void bshark_draw_sprites_16x8(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int y_offs);
+	rgb_t color_xrgb555(u16 data);
 
 	/* memory pointers */
 	required_shared_ptr<u16> m_spriteram;
@@ -127,6 +128,8 @@ protected:
 	u16 dblaxle_steer_input_r(offs_t offset);
 
 	u32 screen_update_chasehq(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+	rgb_t color_xbgr555(u16 data);
 
 	void z80_sound_map(address_map &map) ATTR_COLD;
 

--- a/src/mame/taito/taito_z_v.cpp
+++ b/src/mame/taito/taito_z_v.cpp
@@ -782,6 +782,16 @@ void spacegun_state::spacegun_draw_sprites_16x8(screen_device &screen, bitmap_in
                         SCREEN REFRESH
 **************************************************************/
 
+rgb_t taitoz_z80_sound_state::color_xbgr555(u16 data)
+{
+	return rgb_t(pal5bit(data >> 0), pal5bit(data >> 5), pal5bit(data >> 10));
+}
+
+rgb_t taitoz_state::color_xrgb555(u16 data)
+{
+	return rgb_t(pal5bit(data >> 10), pal5bit(data >> 5), pal5bit(data >> 0));
+}
+
 void contcirc_state::contcirc_out_w(u8 data)
 {
 	/* bit 0 = reset sub CPU */

--- a/src/mame/taito/tc0110pcr.h
+++ b/src/mame/taito/tc0110pcr.h
@@ -9,13 +9,15 @@
 class tc0110pcr_device : public device_t, public device_palette_interface
 {
 public:
+	using color_delegate = device_delegate<rgb_t (uint16_t data)>;
 	tc0110pcr_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
+	// configurations
+	void set_shift(uint8_t shift) { m_shift = shift; }
+	template <typename... T> void set_color_callback(T &&... args) { m_color_cb.set(std::forward<T>(args)...); }
+
 	u16 word_r(offs_t offset);
-	void word_w(offs_t offset, u16 data); /* color index goes up in step of 2 */
-	void step1_word_w(offs_t offset, u16 data);   /* color index goes up in step of 1 */
-	void step1_rbswap_word_w(offs_t offset, u16 data);    /* swaps red and blue components */
-	void step1_4bpg_word_w(offs_t offset, u16 data);  /* only 4 bits per color gun */
+	void word_w(offs_t offset, u16 data);
 
 	void restore_colors();
 
@@ -31,9 +33,13 @@ protected:
 private:
 	static const unsigned TC0110PCR_RAM_SIZE = 0x2000 / 2;
 
-	std::unique_ptr<uint16_t[]>     m_ram;
-	int          m_type;
-	int          m_addr;
+	// internal states
+	std::unique_ptr<uint16_t[]> m_ram;
+	uint16_t m_addr;
+
+	// configurations
+	uint8_t m_shift;
+	color_delegate m_color_cb;
 };
 
 DECLARE_DEVICE_TYPE(TC0110PCR, tc0110pcr_device)

--- a/src/mame/taito/warriorb.cpp
+++ b/src/mame/taito/warriorb.cpp
@@ -228,6 +228,7 @@ private:
 
 	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int x_offs, int y_offs, int chip);
 	template <u8 Which> u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	rgb_t color_xbgr555(u16 data);
 
 	void darius2d_main_map(address_map &map) ATTR_COLD;
 	void warriorb_main_map(address_map &map) ATTR_COLD;
@@ -301,6 +302,11 @@ void warriorb_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, c
 /**************************************************************
                 SCREEN REFRESH
 **************************************************************/
+
+rgb_t warriorb_state::color_xbgr555(u16 data)
+{
+	return rgb_t(pal5bit(data >> 0), pal5bit(data >> 5), pal5bit(data >> 10));
+}
 
 template <u8 Which>
 u32 warriorb_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
@@ -394,8 +400,8 @@ void warriorb_state::darius2d_main_map(address_map &map)
 	map(0x220000, 0x22000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 	map(0x240000, 0x253fff).rw(m_tc0100scn[1], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));      // tilemaps (2nd screen)
 	map(0x260000, 0x26000f).rw(m_tc0100scn[1], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x400000, 0x400007).rw(m_tc0110pcr[0], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));    // palette (1st screen)
-	map(0x420000, 0x420007).rw(m_tc0110pcr[1], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));    // palette (2nd screen)
+	map(0x400000, 0x400007).rw(m_tc0110pcr[0], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));    // palette (1st screen)
+	map(0x420000, 0x420007).rw(m_tc0110pcr[1], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));    // palette (2nd screen)
 	map(0x600000, 0x6013ff).ram().share(m_spriteram);
 	map(0x800000, 0x80000f).rw("tc0220ioc", FUNC(tc0220ioc_device::read), FUNC(tc0220ioc_device::write)).umask16(0x00ff);
 //  map(0x820000, 0x820001).nopw();    // ???
@@ -411,8 +417,8 @@ void warriorb_state::warriorb_main_map(address_map &map)
 	map(0x320000, 0x32000f).rw(m_tc0100scn[0], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
 	map(0x340000, 0x353fff).rw(m_tc0100scn[1], FUNC(tc0100scn_device::ram_r), FUNC(tc0100scn_device::ram_w));      // tilemaps (2nd screen)
 	map(0x360000, 0x36000f).rw(m_tc0100scn[1], FUNC(tc0100scn_device::ctrl_r), FUNC(tc0100scn_device::ctrl_w));
-	map(0x400000, 0x400007).rw(m_tc0110pcr[0], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));    // palette (1st screen)
-	map(0x420000, 0x420007).rw(m_tc0110pcr[1], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::step1_word_w));    // palette (2nd screen)
+	map(0x400000, 0x400007).rw(m_tc0110pcr[0], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));    // palette (1st screen)
+	map(0x420000, 0x420007).rw(m_tc0110pcr[1], FUNC(tc0110pcr_device::word_r), FUNC(tc0110pcr_device::word_w));    // palette (2nd screen)
 	map(0x600000, 0x6013ff).ram().share(m_spriteram);
 	map(0x800000, 0x80000f).rw("tc0510nio", FUNC(tc0510nio_device::read), FUNC(tc0510nio_device::write)).umask16(0x00ff);
 //  map(0x820000, 0x820001).nopw();    // ? uses bits 0,2,3
@@ -612,6 +618,8 @@ void warriorb_state::darius2d(machine_config &config)
 	m_tc0100scn[0]->set_palette(m_tc0110pcr[0]);
 
 	TC0110PCR(config, m_tc0110pcr[0], 0);
+	m_tc0110pcr[0]->set_shift(0);
+	m_tc0110pcr[0]->set_color_callback(FUNC(warriorb_state::color_xbgr555));
 
 	screen_device &rscreen(SCREEN(config, "rscreen", SCREEN_TYPE_RASTER));
 	rscreen.set_refresh_hz(60);
@@ -627,6 +635,8 @@ void warriorb_state::darius2d(machine_config &config)
 	m_tc0100scn[1]->set_palette(m_tc0110pcr[1]);
 
 	TC0110PCR(config, m_tc0110pcr[1], 0);
+	m_tc0110pcr[1]->set_shift(0);
+	m_tc0110pcr[1]->set_color_callback(FUNC(warriorb_state::color_xbgr555));
 
 	// sound hardware
 	SPEAKER(config, "speaker", 2).front();
@@ -687,6 +697,8 @@ void warriorb_state::warriorb(machine_config &config)
 	m_tc0100scn[0]->set_palette(m_tc0110pcr[0]);
 
 	TC0110PCR(config, m_tc0110pcr[0], 0);
+	m_tc0110pcr[0]->set_shift(0);
+	m_tc0110pcr[0]->set_color_callback(FUNC(warriorb_state::color_xbgr555));
 
 	screen_device &rscreen(SCREEN(config, "rscreen", SCREEN_TYPE_RASTER));
 	rscreen.set_refresh_hz(60);
@@ -703,6 +715,8 @@ void warriorb_state::warriorb(machine_config &config)
 	m_tc0100scn[1]->set_palette(m_tc0110pcr[1]);
 
 	TC0110PCR(config, m_tc0110pcr[1], 0);
+	m_tc0110pcr[1]->set_shift(0);
+	m_tc0110pcr[1]->set_color_callback(FUNC(warriorb_state::color_xbgr555));
 
 	// sound hardware
 	SPEAKER(config, "speaker", 2).front();


### PR DESCRIPTION
- Use logmacro.h for logging
- Suppress side effects for debugger
- Remove unnecessary comments
- Fix spacings