### PR TITLE
Add 16:9 support to Sega Touring Car Championship

### DIFF
--- a/src/mame/layout/stcc.lay
+++ b/src/mame/layout/stcc.lay
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 license:CC0-1.0
-authors:hap
+authors:AnthonyRyuki
 -->
 <mamelayout version="2">
 
@@ -13,3 +13,4 @@ authors:hap
 		</screen>
 	</view>
 </mamelayout>
+


### PR DESCRIPTION
When the cabinet option in the Test Menu is set to Deluxe, the screen's aspect ratio is set to 16:9.