### PR TITLE
namco/turrett*.cpp: Minor cleanups

### DIFF
--- a/src/mame/namco/turrett.cpp
+++ b/src/mame/namco/turrett.cpp
@@ -16,16 +16,6 @@
 
 /*************************************
  *
- *  Definitions
- *
- *************************************/
-
-#define R3041_CLOCK         XTAL(25'000'000)
-
-
-
-/*************************************
- *
  *  Machine initialization
  *
  *************************************/
@@ -100,8 +90,8 @@ void turrett_state::cpu_map(address_map &map)
 
 void turrett_state::turrett_sound_map(address_map &map)
 {
-	map(0x0000000, 0x7ffffff).ram().share("bank_a");
-	map(0x8000000, 0xfffffff).ram().share("bank_b");
+	map(0x0000000, 0x7ffffff).ram().share(m_ram_bank[0]);
+	map(0x8000000, 0xfffffff).ram().share(m_ram_bank[1]);
 }
 
 
@@ -178,11 +168,11 @@ uint32_t turrett_state::int_r()
 void turrett_state::int_w(uint32_t data)
 {
 	// TODO
-	logerror("Output write: %08x\n", data);
+	logerror("%s: Output write: %08x\n", machine().describe_context(), data);
 }
 
 
-uint32_t turrett_state::update_inputs(void)
+uint32_t turrett_state::update_inputs()
 {
 	uint32_t val = 0;
 
@@ -191,64 +181,71 @@ uint32_t turrett_state::update_inputs(void)
 	{
 		if (m_inputs_active & 0x00000001)
 		{
-			val = 0x00 | (ioport("PORT.0X")->read() & 0x3f);
-			m_inputs_active &= ~1;
+			val = 0x00 | (m_input_port[0]->read() & 0x3f);
+			if (!machine().side_effects_disabled())
+				m_inputs_active &= ~1;
 		}
 		else if (m_inputs_active & 0x00000002)
 		{
-			val = 0x40 | (ioport("PORT.4X")->read() & 0x3f);
-			m_inputs_active &= ~2;
+			val = 0x40 | (m_input_port[1]->read() & 0x3f);
+			if (!machine().side_effects_disabled())
+				m_inputs_active &= ~2;
 		}
 		else if (m_inputs_active & 0x0000ff00)
 		{
-			uint32_t data = ioport("PORT.CX")->read();
-			uint32_t bits = m_inputs_active >> 8;
+			const uint32_t data = m_input_port[2]->read();
+			const uint32_t bits = m_inputs_active >> 8;
 
 			val = 0xc0;
 
 			for (int i = 0; i < 8; ++i)
 			{
-				if (bits & (1 << i))
+				if (BIT(bits, i))
 				{
 					val |= i << 1;
-					val |= (data >> i) & 1;
-					m_inputs_active &= ~(1 << (i + 8));
+					val |= BIT(data, i);
+					if (!machine().side_effects_disabled())
+						m_inputs_active &= ~(1 << (i + 8));
 					break;
 				}
 			}
 		}
 		else if (m_inputs_active & 0x00ff0000)
 		{
-			uint32_t data = ioport("PORT.DX")->read();
-			uint32_t bits = m_inputs_active >> 16;
+			const uint32_t data = m_input_port[3]->read();
+			const uint32_t bits = m_inputs_active >> 16;
 
 			val = 0xd0;
 
 			for (int i = 0; i < 8; ++i)
 			{
-				if (bits & (1 << i))
+				if (BIT(bits, i))
 				{
 					val |= i << 1;
-					val |= (data >> i) & 1;
-					m_inputs_active &= ~(1 << (i + 16));
+					val |= BIT(data, i);
+					if (!machine().side_effects_disabled())
+						m_inputs_active &= ~(1 << (i + 16));
 					break;
 				}
 			}
 		}
 		else if (m_inputs_active & 0x01000000)
 		{
-			val = 0xe0 | ioport("PORT.EX")->read();
-			m_inputs_active &= ~0x01000000;
+			val = 0xe0 | m_input_port[4]->read();
+			if (!machine().side_effects_disabled())
+				m_inputs_active &= ~0x01000000;
 		}
 		else if (m_inputs_active & 0x02000000)
 		{
-			val = 0xf0 | ioport("PORT.FX")->read();
-			m_inputs_active &= ~0x02000000;
+			val = 0xf0 | m_input_port[5]->read();
+			if (!machine().side_effects_disabled())
+				m_inputs_active &= ~0x02000000;
 		}
 	}
 
 	// Update IRQ state
-	m_maincpu->set_input_line(INPUT_LINE_IRQ1, m_inputs_active ? ASSERT_LINE : CLEAR_LINE);
+	if (!machine().side_effects_disabled())
+		m_maincpu->set_input_line(INPUT_LINE_IRQ1, m_inputs_active ? ASSERT_LINE : CLEAR_LINE);
 	return val;
 }
 
@@ -350,6 +347,8 @@ void turrett_devices(device_slot_interface &device)
 
 void turrett_state::turrett(machine_config &config)
 {
+	constexpr XTAL R3041_CLOCK = XTAL(25'000'000);
+
 	/* basic machine hardware */
 	R3041(config, m_maincpu, R3041_CLOCK);
 	m_maincpu->set_endianness(ENDIANNESS_BIG);
@@ -376,8 +375,8 @@ void turrett_state::turrett(machine_config &config)
 
 	turrett_device &ttsound(TURRETT(config, "ttsound", R3041_CLOCK)); // ?
 	ttsound.set_addrmap(0, &turrett_state::turrett_sound_map);
-	ttsound.add_route(ALL_OUTPUTS, "speaker", 1.0, 0);
-	ttsound.add_route(ALL_OUTPUTS, "speaker", 1.0, 1);
+	ttsound.add_route(0, "speaker", 1.0, 1);
+	ttsound.add_route(1, "speaker", 1.0, 0);
 }
 
 
@@ -411,4 +410,4 @@ ROM_END
  *
  *************************************/
 
-GAME( 2001, turrett, 0, turrett, turrett, turrett_state, empty_init, ROT0, "Dell Electronics (Namco license)", "Turret Tower", 0 )
+GAME( 2001, turrett, 0, turrett, turrett, turrett_state, empty_init, ROT0, "Dell Electronics (Namco license)", "Turret Tower - The Enemy Has Arrived", 0 )

--- a/src/mame/namco/turrett.h
+++ b/src/mame/namco/turrett.h
@@ -24,9 +24,13 @@ public:
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
 		, m_ata(*this, "ata")
-		, m_bank_a(*this, "bank_a")
-		, m_bank_b(*this, "bank_b")
+		, m_ram_bank(*this, "ram_bank_%u", 0U)
 		, m_screen(*this, "screen")
+		, m_input_port(*this,
+			{
+				"PORT.0X", "PORT.4X", "PORT.CX",
+				"PORT.DX", "PORT.EX", "PORT.FX"
+			})
 	{
 	}
 
@@ -45,9 +49,9 @@ private:
 	// devices
 	required_device<r3041_device> m_maincpu;
 	required_device<ata_interface_device> m_ata;
-	required_shared_ptr<uint16_t> m_bank_a;
-	required_shared_ptr<uint16_t> m_bank_b;
+	required_shared_ptr_array<uint16_t, 2> m_ram_bank;
 	required_device<screen_device> m_screen;
+	required_ioport_array<6> m_input_port;
 
 	// handlers
 	void dma_w(offs_t offset, uint32_t data);
@@ -65,8 +69,8 @@ private:
 	// functions
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t write_video_ram(uint16_t data);
-	void update_video_addr(void);
-	uint32_t update_inputs(void);
+	void update_video_addr();
+	uint32_t update_inputs();
 
 	// members
 	emu_timer *m_dma_timer = nullptr;

--- a/src/mame/namco/turrett_a.cpp
+++ b/src/mame/namco/turrett_a.cpp
@@ -57,12 +57,9 @@ void turrett_device::device_start()
 	m_volume_table[0x4f] = 0;
 
 	// Register state for saving
-	for (int ch = 0; ch < SOUND_CHANNELS; ++ch)
-	{
-		save_item(NAME(m_channels[ch].m_address), ch);
-		save_item(NAME(m_channels[ch].m_volume), ch);
-		save_item(NAME(m_channels[ch].m_playing), ch);
-	}
+	save_item(STRUCT_MEMBER(m_channels, m_address));
+	save_item(STRUCT_MEMBER(m_channels, m_volume));
+	save_item(STRUCT_MEMBER(m_channels, m_playing));
 }
 
 
@@ -95,11 +92,11 @@ void turrett_device::sound_stream_update(sound_stream &stream)
 			rvol = m_volume_table[rvol];
 
 			// Channels 30 and 31 expect interleaved stereo samples
-			uint32_t incr = (ch >= 30) ? 2 : 1;
+			const uint32_t incr = (ch >= 30) ? 2 : 1;
 
 			for (int s = 0; s < stream.samples(); ++s)
 			{
-				int16_t sample = m_cache.read_word(addr << 1);
+				const int16_t sample = m_cache.read_word(addr << 1);
 
 				if ((uint16_t)sample == 0x8000)
 				{
@@ -125,7 +122,7 @@ uint32_t turrett_device::read(offs_t offset)
 {
 	m_stream->update();
 
-	int ch = offset & 0x3f;
+	const int ch = offset & 0x3f;
 
 	return m_channels[ch].m_playing << 31;
 }
@@ -139,7 +136,7 @@ void turrett_device::write(offs_t offset, uint32_t data)
 {
 	m_stream->update();
 
-	int ch = offset & 0x3f;
+	const int ch = offset & 0x3f;
 
 	if (offset < 0x100/4)
 	{


### PR DESCRIPTION
- Add subtitles in metadata
- Fix sound output routing (Inverted stereo)
- Use std::clamp for clamp function
- Make some variables constant
- Use BIT macro for single bit values
- Use STRUCT_MEMBER for saving struct variables
- Reduce runtime tag lookups
- Use finder array for RAM bank array