### PR TITLE
apple: slightly improve Zip Chip emulation

### DIFF
--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -2105,18 +2105,18 @@ u8 apple2e_state::c000_r(offs_t offset)
 
 			if (m_accel_unlocked)
 			{
-				if (offset == 0x5b)
+				if (offset == 0x5b) // Zip status flags
 				{
+					// bits 0-1 are cache size; [8, 16, 32, 64]kB
+					u8 b01 = 0x03;
+					// bit 3 is set if a temporary delay is active due to slot or softswitch access
+					u8 b3 = m_accel_temp_slowdown ? 0x08 : 0x00;
+					// bit 4 is set if the Zip is disabled
+					u8 b4 = m_accel_fast ? 0x00 : 0x10;
 					// bit 7 is a 1.0035 millisecond clock; the value changes every 0.50175 milliseconds
 					const int time = machine().time().as_ticks(1.0f / 0.00050175f);
-					if (time & 1)
-					{
-						return 0x03;
-					}
-					else
-					{
-						return 0x83;
-					}
+					u8 b7 = time & 1 ? 0x80 : 0x00;
+					return b7 | b4 | b3 | b01;
 				}
 				else if (offset == 0x5c)
 				{

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -1754,18 +1754,18 @@ u8 apple2gs_state::c000_r(offs_t offset)
 				{
 					return m_accel_percent | 0x0f;
 				}
-				else if (offset == 0x5b)
+				else if (offset == 0x5b) // Zip status flags
 				{
+					// bits 0-1 are cache size: [8, 16, 32, 64]kB
+					u8 b01 = 0x03;
+					// bit 3 is set if a temporary delay is active due to slot or softswitch access
+					u8 b3 = m_accel_temp_slowdown ? 0x08 : 0x00;
+					// bit 4 is set if the Zip is disabled
+					u8 b4 = m_accel_fast ? 0x00 : 0x10;
 					// bit 7 is a 1.0035 millisecond clock; the value changes every 0.50175 milliseconds
 					const int time = machine().time().as_ticks(1.0f / 0.00050175f);
-					if (time & 1)
-					{
-						return 0x03;
-					}
-					else
-					{
-						return 0x83;
-					}
+					u8 b7 = time & 1 ? 0x80 : 0x00;
+					return b7 | b4 | b3 | b01;
 				}
 				else if (offset == 0x5c)
 				{


### PR DESCRIPTION
I'm going to split my Zip Chip changes into two PRs. This first smaller one fixes problems in the existing implementation, and implements two useful status bits:

* apple2gs: fix Zip Chip inconsistencies
The [previous PR](http://github.com/mamedev/mame/pull/14388) made the IIc consistent with the IIe, now we do the same for the IIgs.  The IIgs had the same problem as #9503, and it was also erroneously re-locking the Zip when disabling via C05A. 

* apple: improve Zip Chip C05B
The disable bit allows querying the current state; this is very useful when writing vaporlock beam-racing tests ^\_^;
The delay bit allows measuring delays, which may only be useful to folks trying to write Zip Chip unit tests ^\_^;

These changes have been verified against a ZipGSX in an Apple IIgs ROM3.
The C05B status bit behaviors are described in the [1987 Zip manual](http://mirrors.apple2.org.za/ftp.apple.asimov.net/documentation/hardware/accelerators/zip_instruction_manual.pdf#page=12) (but due to inconsistent documentation I am not implementing bit 5 in this PR.)
The real annunciator side-effect behavior is more complex, and is handled in a WIP PR.


Testing:
* Total Replay continues to work, enabling the Zip Chip for decompression and disabling for play (or relying on CPS Follow on the IIgs.)
* Zip Chip Utilities are unchanged (System Check passes, Cache Diagnostics fail.)
* The ZipGS CDA and CDEV are improved: the initial "Sorry, no ZipGS present"/"No ZipGS detected" error is fixed, and the Misc Settings now display accurately.

I also have a WIP test suite verifying all of the remaining softswitches and side-effects, which identifies many failures in 0.281 _before_ this PR:
<img width="704" height="460" alt="ZIPTEST_apple2gs_before" src="https://github.com/user-attachments/assets/11526127-645c-4ab0-943a-a26327858cce" />

And a little better _after_ (disabling no longer locks, disable & delay status works, delays can be measured): 
<img width="704" height="460" alt="ZIPTEST_apple2gs_after" src="https://github.com/user-attachments/assets/bd662d3d-5e4c-4084-b2ff-ec8dc74be78a" />

Hardware looks like this:
![ZIPTEST_apple2gs_HW](https://github.com/user-attachments/assets/a568877c-ad11-41e1-ad95-d999aea8c5e2)
and with my WIP PR, ZipGS emulation passes all of this. However, I am holding off on that PR until I can [locate a volunteer](http://apple2infinitum.slack.com/archives/CABEM8JFK/p1760827313370039) to verify the behavior of the the 8-bit Zip Chip in a IIe or IIc+.  (There is enough difference between the Zip Chip and ZipGS that I can't just guess at the behavior.)
