### PR TITLE
sequential_sixtrak.lay: Made knobs and wheels interactive.

### DIFF
--- a/src/mame/layout/linn_linndrum.lay
+++ b/src/mame/layout/linn_linndrum.lay
@@ -592,19 +592,19 @@ copyright-holders:m1macrophage
 				local view = file.views["Default Layout"]
 				install_slider_callbacks(view)
 
-				add_simplecounter_knob(view, "knob_pot_tempo", "pot_tempo", 1.5)
-				add_simplecounter_knob(view, "knob_pot_volume", "pot_volume", 1.5)
+				add_knob(view, "knob_pot_tempo", "pot_tempo", 1.5, VERTICAL)
+				add_knob(view, "knob_pot_volume", "pot_volume", 1.5, VERTICAL)
 				for i = 1, 6 do
 					local knob_input = "pot_tuning_" .. i
-					add_simplecounter_knob(view, "knob_" .. knob_input, knob_input, 3.5)
+					add_knob(view, "knob_" .. knob_input, knob_input, 3.5, VERTICAL)
 				end
-				add_simplecounter_knob(view, "knob_pot_hihat_decay", "pot_hihat_decay", 3.5)
+				add_knob(view, "knob_pot_hihat_decay", "pot_hihat_decay", 3.5, VERTICAL)
 
 				for i = 1, 16 do
 					local pan_input = "pot_pan_" .. i
-					add_vertical_slider(view, "slider_" .. pan_input, "slider_knob_" .. pan_input, pan_input)
+					add_slider(view, "slider_" .. pan_input, "slider_knob_" .. pan_input, pan_input)
 					local gain_input = "pot_gain_" .. i
-					add_vertical_slider(view, "slider_" .. gain_input, "slider_knob_" .. gain_input, gain_input)
+					add_slider(view, "slider_" .. gain_input, "slider_knob_" .. gain_input, gain_input)
 				end
 
 				view.items["warning"]:set_state(0)
@@ -614,13 +614,16 @@ copyright-holders:m1macrophage
 		-- Slider and knob library starts.
 		-- Can be copied as-is to other layouts.
 		-----------------------------------------------------------------------
+		VERTICAL = 0
+		HORIZONTAL = 1
+
 		local widgets = {}   -- Stores slider and knob information.
 		local pointers = {}  -- Tracks pointer state.
 
 		-- The knob's Y position must be animated using <animate inputtag="{port_name}">.
 		-- The click area's vertical size must exactly span the range of the
 		-- knob's movement.
-		function add_vertical_slider(view, clickarea_id, knob_id, port_name)
+		function add_slider(view, clickarea_id, knob_id, port_name)
 			table.insert(widgets, {
 				clickarea   = get_layout_item(view, clickarea_id),
 				slider_knob = get_layout_item(view, knob_id),
@@ -630,12 +633,13 @@ copyright-holders:m1macrophage
 
 		-- A sweep between the attached field's min and max values requires
 		-- moving the pointer by `scale * clickarea.height` pixes.
-		function add_simplecounter_knob(view, clickarea_id, port_name, scale)
+		function add_knob(view, clickarea_id, port_name, scale, drag_direction)
 			table.insert(widgets, {
-				clickarea = get_layout_item(view, clickarea_id),
-				field     = get_port_field(port_name),
-				is_knob   = true,
-				scale     = scale })
+				clickarea     = get_layout_item(view, clickarea_id),
+				field         = get_port_field(port_name),
+				is_knob       = true,
+				scale         = scale,
+				is_horizontal = (drag_direction == HORIZONTAL) })
 		end
 
 		function get_layout_item(view, item_id)
@@ -657,17 +661,32 @@ copyright-holders:m1macrophage
 				field = val
 				break
 			end
+			local field_msg = "Needs to either be an IPT_ADJUSTER, or an analog port with auto-center."
 			if field == nil then
-				emu.print_error("Port: '" .. port_name .."' does not seem to be an IPT_ADJUSTER.")
+				emu.print_error("Port '" .. port_name .."' " .. field_msg)
+				return nil
+			end
+			if field.is_analog and (not field.centerdelta or field.centerdelta == 0) then
+				emu.print_error("Port '" .. port_name .."' " .. field_msg)
 				return nil
 			end
 			return field
 		end
 
+		local function release_pointer(pointer_id)
+			if pointers[pointer_id] then
+				local field = widgets[pointers[pointer_id].selected_widget].field
+				if field.is_analog then
+					field:clear_value()
+				end
+			end
+			pointers[pointer_id] = nil
+		end
+
 		local function pointer_updated(type, id, dev, x, y, btn, dn, up, cnt)
 			-- If a button is not pressed, reset the state of the current pointer.
 			if btn & 1 == 0 then
-				pointers[id] = nil
+				release_pointer(id)
 				return
 			end
 
@@ -686,8 +705,9 @@ copyright-holders:m1macrophage
 						pointers[id] = {
 							selected_widget = i,
 							relative = relative,
+							start_x = x,
 							start_y = y,
-							start_value = widgets[i].field.user_value }
+							start_value = widgets[i].field.port:read() }
 						break
 					end
 				end
@@ -698,8 +718,7 @@ copyright-holders:m1macrophage
 				return
 			end
 
-			-- A widget is selected. Update its state based on the pointer's Y
-			-- position. It is assumed the attached IO field is an IPT_ADJUSTER.
+			-- A widget is selected. Update its state based on the pointer's position.
 
 			local pointer = pointers[id]
 			local widget = widgets[pointer.selected_widget]
@@ -710,8 +729,13 @@ copyright-holders:m1macrophage
 
 			local new_value
 			if widget.is_knob then
-				local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
-				new_value = pointer.start_value + (pointer.start_y - y) * step_y
+				if widget.is_horizontal then
+					local step_x = value_range / (widget.scale * widget.clickarea.bounds.width)
+					new_value = pointer.start_value + (x - pointer.start_x) * step_x
+				else
+					local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
+					new_value = pointer.start_value + (pointer.start_y - y) * step_y
+				end
 			else
 				local knob_half_height = widget.slider_knob.bounds.height / 2
 				local min_y = widget.clickarea.bounds.y0 + knob_half_height
@@ -731,18 +755,26 @@ copyright-holders:m1macrophage
 			new_value = math.floor(new_value + 0.5)
 			if new_value < min_value then new_value = min_value end
 			if new_value > max_value then new_value = max_value end
-			widget.field.user_value = new_value
+
+			if widget.field.is_analog then
+				widget.field:set_value(new_value)
+			else
+				widget.field.user_value = new_value
+			end
 		end
 
 		local function pointer_left(type, id, dev, x, y, up, cnt)
-			pointers[id] = nil
+			release_pointer(id)
 		end
 
 		local function pointer_aborted(type, id, dev, x, y, up, cnt)
-			pointers[id] = nil
+			release_pointer(id)
 		end
 
 		local function forget_pointers()
+			for id, pointer in pairs(pointers) do
+				release_pointer(id)
+			end
 			pointers = {}
 		end
 

--- a/src/mame/layout/sequential_sixtrak.lay
+++ b/src/mame/layout/sequential_sixtrak.lay
@@ -5,10 +5,17 @@ copyright-holders:m1macrophage
 -->
 <mamelayout version="2">
 	<!-- case elements -->
+
 	<element name="panel"><rect><color red="0.15" green="0.15" blue="0.15"/></rect></element>
 	<element name="separator"><rect><color red="0.33" green="0.33" blue="0.33"/></rect></element>
 	<element name="wood"><rect><color red="0.43" green="0.20" blue="0.16"/></rect></element>
 	<element name="dark_wood"><rect><color red="0.18" green="0.11" blue="0.11"/></rect></element>
+
+	<element name="script_warning" defstate="1">
+		<text state="1" string="*** to control knobs and wheels with a mouse, enable the layout plugin ***">
+			<color red="0.84" green="0.84" blue="0.84"/>
+		</text>
+	</element>
 
 	<!-- multi-track section elements -->
 
@@ -712,7 +719,9 @@ copyright-holders:m1macrophage
 
 	<group name="knob">
 		<bounds x="0" y="0" width="50" height="50"/>
-		<element ref="knob_background"><bounds x="0" y="0" width="50" height="50"/></element>
+		<element ref="knob_background" id="~input~">
+			<bounds x="0" y="0" width="50" height="50"/>
+		</element>
 		<element ref="knob_value" inputtag="~input~" inputmask="0xffff" inputraw="yes">
 			<bounds x="10" y="20" width="30" height="10"/>
 		</element>
@@ -746,11 +755,13 @@ copyright-holders:m1macrophage
 
 	<group name="wheel">
 		<bounds x="0" y="0" width="30" height="145"/>
-		<element ref="wheel_background"><bounds x="5" y="0" width="20" height="130"/></element>
-		<element ref="wheel_dent">
+		<element ref="wheel_background" id="~input~">
+			<bounds x="3" y="0" width="24" height="130"/>
+		</element>
+		<element ref="wheel_dent" id="~input~_dent">
 			<animate inputtag="~input~" inputmask="0xffff"/>
-			<bounds state="100" x="5" y="0" width="20" height="10"/>
-			<bounds state="0" x="5" y="120" width="20" height="10"/>
+			<bounds state="100" x="3" y="0" width="24" height="10"/>
+			<bounds state="0" x="3" y="120" width="24" height="10"/>
 		</element>
 		<element ref="~label~"><bounds x="0" y="135" width="30" height="10"/></element>
 	</group>
@@ -866,6 +877,10 @@ copyright-holders:m1macrophage
 
 		<!-- case -->
 
+		<collection name="script warning">
+			<element ref="script_warning" id="warning"><bounds x="360" y="0" width="800" height="18"/></element>
+		</collection>
+
 		<element ref="panel"><bounds x="30" y="20" width="1465" height="320"/></element>
 		<element ref="separator"><bounds x="30" y="340" width="1465" height="10"/></element>
 		<element ref="wood"><bounds x="5" y="0" width="25" height="660"/></element>
@@ -889,7 +904,7 @@ copyright-holders:m1macrophage
 		<param name="label" value="volume"/>
 		<group ref="master_knob"><bounds x="1350" y="210" width="70" height="75"/></group>
 
-		<!-- multri-track section -->
+		<!-- multi-track section -->
 
 		<element ref="multitrack_box"><bounds x="218" y="60" width="330" height="250"/></element>
 		<element ref="multitrack_label"><bounds x="291" y="54" width="184" height="14"/></element>
@@ -1022,4 +1037,201 @@ copyright-holders:m1macrophage
 			<bounds x="1424" y="350" width="47" height="300"/>
 		</element>
 	</view>
+
+	<script><![CDATA[
+		file:set_resolve_tags_callback(
+			function()
+				local view = file.views["Default Layout"]
+				install_slider_callbacks(view)
+
+				add_knob(view, "track_volume_knob", "track_volume_knob", 1.2, HORIZONTAL)
+				add_knob(view, "speed_knob", "speed_knob", 1.2, HORIZONTAL)
+				add_knob(view, "value_knob", "value_knob", 2, HORIZONTAL)
+				add_knob(view, "tune_knob", "tune_knob", 2, HORIZONTAL)
+				add_knob(view, "master_volume_knob", "master_volume_knob", 1.2, HORIZONTAL)
+
+				add_slider(view, "pitch_wheel", "pitch_wheel_dent", "pitch_wheel")
+				add_slider(view, "mod_wheel", "mod_wheel_dent", "mod_wheel")
+
+				view.items["warning"]:set_state(0)
+			end)
+
+		-----------------------------------------------------------------------
+		-- Slider and knob library starts.
+		-- Can be copied as-is to other layouts.
+		-----------------------------------------------------------------------
+		VERTICAL = 0
+		HORIZONTAL = 1
+
+		local widgets = {}   -- Stores slider and knob information.
+		local pointers = {}  -- Tracks pointer state.
+
+		-- The knob's Y position must be animated using <animate inputtag="{port_name}">.
+		-- The click area's vertical size must exactly span the range of the
+		-- knob's movement.
+		function add_slider(view, clickarea_id, knob_id, port_name)
+			table.insert(widgets, {
+				clickarea   = get_layout_item(view, clickarea_id),
+				slider_knob = get_layout_item(view, knob_id),
+				field       = get_port_field(port_name),
+				is_knob     = false })
+		end
+
+		-- A sweep between the attached field's min and max values requires
+		-- moving the pointer by `scale * clickarea.height` pixes.
+		function add_knob(view, clickarea_id, port_name, scale, drag_direction)
+			table.insert(widgets, {
+				clickarea     = get_layout_item(view, clickarea_id),
+				field         = get_port_field(port_name),
+				is_knob       = true,
+				scale         = scale,
+				is_horizontal = (drag_direction == HORIZONTAL) })
+		end
+
+		function get_layout_item(view, item_id)
+			local item = view.items[item_id]
+			if item == nil then
+				emu.print_error("Layout element: '" .. item_id .. "' not found.")
+			end
+			return item
+		end
+
+		function get_port_field(port_name)
+			local port = file.device:ioport(port_name)
+			if port == nil then
+				emu.print_error("Port: '" .. port_name .. "' not found.")
+				return nil
+			end
+			local field = nil
+			for k, val in pairs(port.fields) do
+				field = val
+				break
+			end
+			local field_msg = "Needs to either be an IPT_ADJUSTER, or an analog port with auto-center."
+			if field == nil then
+				emu.print_error("Port '" .. port_name .."' " .. field_msg)
+				return nil
+			end
+			if field.is_analog and (not field.centerdelta or field.centerdelta == 0) then
+				emu.print_error("Port '" .. port_name .."' " .. field_msg)
+				return nil
+			end
+			return field
+		end
+
+		local function release_pointer(pointer_id)
+			if pointers[pointer_id] then
+				local field = widgets[pointers[pointer_id].selected_widget].field
+				if field.is_analog then
+					field:clear_value()
+				end
+			end
+			pointers[pointer_id] = nil
+		end
+
+		local function pointer_updated(type, id, dev, x, y, btn, dn, up, cnt)
+			-- If a button is not pressed, reset the state of the current pointer.
+			if btn & 1 == 0 then
+				release_pointer(id)
+				return
+			end
+
+			-- If a button was just pressed, find the affected widget, if any.
+			if dn & 1 ~= 0 then
+				for i = 1, #widgets do
+					local found, relative
+					if widgets[i].slider_knob and widgets[i].slider_knob.bounds:includes(x, y) then
+						found = true
+						relative = true
+					elseif widgets[i].clickarea.bounds:includes(x, y) then
+						found = true
+						relative = false
+					end
+					if found then
+						pointers[id] = {
+							selected_widget = i,
+							relative = relative,
+							start_x = x,
+							start_y = y,
+							start_value = widgets[i].field.port:read() }
+						break
+					end
+				end
+			end
+
+			-- If there is no widget selected by the current pointer, we are done.
+			if pointers[id] == nil then
+				return
+			end
+
+			-- A widget is selected. Update its state based on the pointer's position.
+
+			local pointer = pointers[id]
+			local widget = widgets[pointer.selected_widget]
+
+			local min_value = widget.field.minvalue
+			local max_value = widget.field.maxvalue
+			local value_range = max_value - min_value
+
+			local new_value
+			if widget.is_knob then
+				if widget.is_horizontal then
+					local step_x = value_range / (widget.scale * widget.clickarea.bounds.width)
+					new_value = pointer.start_value + (x - pointer.start_x) * step_x
+				else
+					local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
+					new_value = pointer.start_value + (pointer.start_y - y) * step_y
+				end
+			else
+				local knob_half_height = widget.slider_knob.bounds.height / 2
+				local min_y = widget.clickarea.bounds.y0 + knob_half_height
+				local max_y = widget.clickarea.bounds.y1 - knob_half_height
+
+				if pointer.relative then
+					-- User clicked on the knob. The new value will depend on how
+					--  much the knob was dragged.
+					new_value = pointer.start_value - value_range * (y - pointer.start_y) / (max_y - min_y)
+				else
+					-- User clicked elsewhere on the slider. The new value will depend on
+					-- the absolute position of the click.
+					new_value = max_value - value_range * (y - min_y) / (max_y - min_y)
+				end
+			end
+
+			new_value = math.floor(new_value + 0.5)
+			if new_value < min_value then new_value = min_value end
+			if new_value > max_value then new_value = max_value end
+
+			if widget.field.is_analog then
+				widget.field:set_value(new_value)
+			else
+				widget.field.user_value = new_value
+			end
+		end
+
+		local function pointer_left(type, id, dev, x, y, up, cnt)
+			release_pointer(id)
+		end
+
+		local function pointer_aborted(type, id, dev, x, y, up, cnt)
+			release_pointer(id)
+		end
+
+		local function forget_pointers()
+			for id, pointer in pairs(pointers) do
+				release_pointer(id)
+			end
+			pointers = {}
+		end
+
+		function install_slider_callbacks(view)
+			view:set_pointer_updated_callback(pointer_updated)
+			view:set_pointer_left_callback(pointer_left)
+			view:set_pointer_aborted_callback(pointer_aborted)
+			view:set_forget_pointers_callback(forget_pointers)
+		end
+		-----------------------------------------------------------------------
+		-- Slider and knob library ends.
+		-----------------------------------------------------------------------
+	]]></script>
 </mamelayout>


### PR DESCRIPTION
To review the changes in the Slider script, see `linn_linndrum.lay`.

Updates to reference Slider script in `linn_linndrum.lay`:
* Added support for horizontal control of knobs.
* Added support for auto-center anolog controls. Useful for the pitch wheel.
* Shortened function names.

`sequential_sixtrak.lay`:
* Copied reference Slider script from `linn_linndrum.lay`.
* Adapted layout to make knobs and wheels interactive.