### PR TITLE
wozfdc.cpp: improve timing of data register reads

### DIFF
--- a/src/devices/machine/wozfdc.h
+++ b/src/devices/machine/wozfdc.h
@@ -49,7 +49,7 @@ protected:
 	void a3_update_drive_sel();
 
 	void lss_start();
-	void lss_sync();
+	void lss_sync(uint64_t extra_cycles = 0);
 
 	enum {
 		MODE_IDLE, MODE_ACTIVE, MODE_DELAY


### PR DESCRIPTION
When one of the even-numbered c08x locations is read, the FDC returns the value of its data register. However, its LSS (logic state sequencer) runs fast enough that between when the CPU puts the address on the bus and when it reads the result, it manages to complete one cycle. This is explained in _Understanding the Apple II_, page 9-22.

This patch emulates this behavior. Its effect can be seen with the INIT command in DOS 3.2 and earlier. Without the patch, the command fails with an I/O error; with the patch, it succeeds. The reason is that it checks if the disk is write-protected after formatting every track, so it executes the following instructions while the FDC is in write mode:

    lda $c08d,x
    lda $c08e,x
    bmi error

The way it's supposed to work is:

1. The second LDA instruction switches the FDC to "check write protect" mode.
2. The LSS runs for 1 cycle, which loads the write-protect status into the data register.
3. The data register is copied into A, which puts the write-protect status into the N flag.
4. The BMI instruction tests the status.

Without step 2, the N flag is loaded with whatever was in the high bit of the data register, which seems to be 1 more often than not, so DOS thinks the disk is write-protected, and aborts.