### PR TITLE
ef9345: Fix underline condition for ts9345 variant

### DIFF
--- a/src/devices/video/ef9345.cpp
+++ b/src/devices/video/ef9345.cpp
@@ -732,7 +732,7 @@ void ef9345_device::makechar_24x40(uint16_t x, uint16_t y)
 	const uint8_t f = BIT(a, 3);        //flash
 	const uint8_t m = BIT(b, 2);        //conceal
 	const uint8_t n = BIT(a, 7);        //negative
-	const uint8_t u = (((b & 0x60) == 0) || ((b & 0xc0) == 0x40)) ? BIT(b, 4) : 0; //underline
+	const uint8_t u = (((type & 0x6) == 0) || ((type & 0xc) == 0x4)) ? BIT(b, 4) : 0; //underline
 
 	bichrome40(type, address, dial, iblock, x, y, c0, c1, i, f, m, n, u);
 }


### PR DESCRIPTION
The check should be done on the `type`, already extracted and masked a few lines above, rather than on the raw value of `b`.

Tested with https://github.com/fabio-d/minitel-ef9345-testsuite/blob/f82aa4b14094affd49d9b237aa856b8e8690ef50/tests/test_font.py#L63

Current wrong rendering:
<img width="324" height="254" alt="wrong rendering" src="https://github.com/user-attachments/assets/86ceaddf-2fbe-4a65-9a70-6c8f8881d253" />

Correct new rendering:
<img width="324" height="254" alt="correct rendering" src="https://github.com/user-attachments/assets/26ed2fc2-7201-4204-8cf5-e69be476374b" />

Relevant table from the TS9345 datasheet:
<img width="1699" height="541" alt="image" src="https://github.com/user-attachments/assets/81d16861-afec-47e9-8d15-ced30424da4a" />

