### PR TITLE
Expose device properties to debugger -- taylorza

### DIFF
--- a/src/emu/debug/debugcpu.cpp
+++ b/src/emu/debug/debugcpu.cpp
@@ -65,6 +65,12 @@ debugger_cpu::debugger_cpu(running_machine &machine)
 	m_symtable->add("wpdata", symbol_table::READ_ONLY, &m_wpdata);
 	m_symtable->add("wpsize", symbol_table::READ_ONLY, &m_wpsize);
 
+	/* add device symbols to the global symbol table */
+	for(auto &symbol : machine.root_device().get_device_symbols())
+	{
+		m_symtable->add(symbol.name(), symbol.getter(), symbol.setter());
+	}
+
 	screen_device_enumerator screen_enumerator = screen_device_enumerator(m_machine.root_device());
 	screen_device_enumerator::iterator iter = screen_enumerator.begin();
 	const uint32_t count = (uint32_t)screen_enumerator.count();

--- a/src/emu/device.h
+++ b/src/emu/device.h
@@ -451,6 +451,28 @@ extern emu::detail::device_registrar const registered_device_types;
 /// \sa device_t::device_start device_interface::interface_pre_start
 class device_missing_dependencies : public emu_exception { };
 
+/// \brief Symbol exposed by a device for debugging
+///
+/// Represents a named symbol exposed by a device for use by the
+/// debugger system.
+class device_symbol {
+public:
+	typedef std::function<u64()> getter_func;
+	typedef std::function<void(u64 value)> setter_func;
+
+	// construction/destruction
+	device_symbol(const char *name, getter_func getter, setter_func setter = nullptr)
+		: m_name(name), m_getter(getter), m_setter(setter) { }
+	
+	const char *name() const { return m_name; }
+	getter_func getter() const { return m_getter; }
+	setter_func setter() const { return m_setter; }
+
+private:
+    const char *m_name;
+	getter_func m_getter;
+	setter_func m_setter;
+};
 
 /// \brief Base class for devices
 ///
@@ -619,6 +641,8 @@ public:
 	virtual ~device_t();
 
 	// getters
+	virtual std::vector<device_symbol> get_device_symbols() const { return {}; }
+	
 	bool has_running_machine() const { return m_machine != nullptr; }
 	running_machine &machine() const { /*assert(m_machine != nullptr);*/ return *m_machine; }
 	const char *tag() const { return m_tag.c_str(); }

--- a/src/mame/sinclair/specnext.cpp
+++ b/src/mame/sinclair/specnext.cpp
@@ -138,6 +138,19 @@ public:
 	INPUT_CHANGED_MEMBER(on_mf_nmi);
 	INPUT_CHANGED_MEMBER(on_divmmc_nmi);
 
+	virtual std::vector<device_symbol> get_device_symbols() const override { 
+		return {
+			device_symbol("mmu0", [this]() { return m_mmu[0]; }),
+			device_symbol("mmu1", [this]() { return m_mmu[1]; }),
+			device_symbol("mmu2", [this]() { return m_mmu[2]; }),
+			device_symbol("mmu3", [this]() { return m_mmu[3]; }),
+			device_symbol("mmu4", [this]() { return m_mmu[4]; }),
+			device_symbol("mmu5", [this]() { return m_mmu[5]; }),
+			device_symbol("mmu6", [this]() { return m_mmu[6]; }),
+			device_symbol("mmu7", [this]() { return m_mmu[7]; }),
+		};
+	}
+
 protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;


### PR DESCRIPTION
This allows to share more internal states with debugger.
<img width="308" height="515" alt="image" src="https://github.com/user-attachments/assets/b1399b96-c552-431d-9b47-e8bcaa8980c5" />
... and makes possible do something like: `bp c000, mmu6==2a`

Brought by taylorza