### PR TITLE
mz2000_flop: Add 7 working items

### DIFF
--- a/hash/mz2000_flop.xml
+++ b/hash/mz2000_flop.xml
@@ -191,4 +191,134 @@ Requires Disk BASIC
 		</part>
 	</software>
 
+	<software name="games01" supported="yes">
+		<description>Games Vol. 01</description>
+		<year>200?</year>
+		<publisher>Unknown</publisher>
+		<notes><![CDATA[
+Compilation of (mostly) Carry Soft games.
+SEAFARI: works
+POLARIS: works
+JELDA I: works
+BACTERIA: works
+KICK OFF: works
+DOG FIGHT: works
+SPACE BEE: works
+CHACK N'POP: works
+ULTRA 7BRIDGE: works
+CRAZY DANGO: works
+PUCKMAN: works
+FLIGHT SIMULATOR: works
+]]></notes>
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="305328">
+				<rom name="games01.d88" size="305328" crc="f70ef985" sha1="d7321e0e8dc3f892e48779730780019fe33b4b99"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="games02" supported="yes">
+		<description>Games Vol. 02</description>
+		<year>200?</year>
+		<publisher>Unknown</publisher>
+		<notes><![CDATA[
+Compilation of (mostly) Carry Soft games.
+HIROTON WARS: works
+SPACE CRUISER: works
+LOVE ANT LOVE: works
+FIGHTER 2000: works
+HP OHSHO 2200: works
+BUG FIRE 2200: works
+PETTER.B 2200: works
+POLAR STAR II: works
+AMA TENNIS 2200: works
+SPECIAL 3D-MAZE: works
+]]>
+</notes>
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="305328">
+				<rom name="games02.d88" size="305328" crc="4693cabb" sha1="7254718b2490be8d0e9737ae3223f1a717525208"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="games03" supported="yes">
+		<description>Games Vol. 03</description>
+		<year>200?</year>
+		<publisher>Unknown</publisher>
+		<notes><![CDATA[
+Compilation of (mostly) Carry Soft games/utilities.
+STARLIGHT ADV 1: works
+STARLIGHT ADV 2: works
+SPC INV: works
+GALAXIAN: works
+DCOPY: works
+MISSILE DEFENDER: works
+]]>
+</notes>
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="305328">
+				<rom name="games03.d88" size="305328" crc="6657065a" sha1="6e07333ebef702229a85973b6862559a817298f5"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="games04" supported="yes">
+		<description>Games Vol. 04</description>
+		<year>200?</year>
+		<publisher>Unknown</publisher>
+		<notes><![CDATA[
+Compilation of (mostly)  Carry Soft games.
+JELDA II: works
+PLAZMA LINE: works
+]]>
+</notes>
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="305328">
+				<rom name="games04.d88" size="305328" crc="afc9fa03" sha1="0baf83732ab7f46a3374574a76c8128981a20910"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="games05" supported="yes">
+		<description>Games Vol. 05</description>
+		<year>200?</year>
+		<publisher>Unknown</publisher>
+		<notes><![CDATA[
+Compilation of (mostly)  Carry Soft games.
+MILKY WAY: works
+FRONT LINE: works
+]]>
+</notes>
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="305328">
+				<rom name="games05.d88" size="305328" crc="1ed8e173" sha1="fb4ca3973f8b8903c83a67a660c1e1c9b6ebbb2a"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="miranda" supported="yes">
+		<description>Miranda</description>
+		<year>200?</year>
+		<publisher>Unknown</publisher>
+		<usage>In DISK MONITOR, type l 1,"MIRANDA"</usage>
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="305328">
+				<rom name="miranda.d88" size="305328" crc="c5cad887" sha1="ed092e7752c04ab0842c68195b00b98b09ebf388"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="uootoy" supported="yes">
+		<description>Uootoy</description>
+		<year>1986</year>
+		<publisher>Denjin</publisher>
+		<usage>In DISK MONITOR, type l 1,"UOOTOY RUN"</usage>
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="305328">
+				<rom name="uootoy.d88" size="305328" crc="cd8d08a2" sha1="f0500bdba64fdfc068897c818220dd24a6933f89"/>
+			</dataarea>
+		</part>
+	</software>
+
 </softwarelist>


### PR DESCRIPTION
Add 7 working items to mz2000_flop.

These are existing disk images from https://www.dropbox.com/scl/fo/sxfhjwvpvi5c1nz4lazcc/ABaWp8TGtqwohP4JgrlDHgA?rlkey=1f173gm8qugys7jqxeal9bvx1&e=2&dl=0. 

These were not working but fixed using MZDiskExplorer.

5 compilations of mostly Carry Lab games and 2 disks of individual games, Miranda and Uootoy.