### PR TITLE
sega/model2: limit microtexture blend factor to 127/256

### DIFF
--- a/src/mame/sega/model2_v.cpp
+++ b/src/mame/sega/model2_v.cpp
@@ -845,15 +845,7 @@ void model2_renderer::model2_3d_render(triangle *tri, const rectangle &cliprect)
 		tri->v[2].pv = tri->v[2].pv * tri->v[2].pz * (1.0f / 8.0f);
 	}
 
-	switch (renderer)
-	{
-	case 0:
-	case 1:
-	case 2:
-	case 3:
-		render_triangle<3>(vp, m_render_callbacks[renderer], tri->v[0], tri->v[1], tri->v[2]);
-		break;
-	}
+	render_triangle<3>(vp, m_render_callbacks[renderer], tri->v[0], tri->v[1], tri->v[2]);
 }
 
 /*

--- a/src/mame/sega/model2rd.ipp
+++ b/src/mame/sega/model2rd.ipp
@@ -224,7 +224,7 @@ void model2_renderer::draw_scanline_tex(int32_t scanline, const extent_t &extent
 	float dvoz = extent.param[2].dpdx;
 
 	// calculate maximum mipmap level from texture dimensions; we go down to 2x2
-	s32 max_level = (f2u(float(std::min(object.texwidth, object.texheight))) >> 23) - 128;
+	s32 max_level = 30 - count_leading_zeros_32(std::min(object.texwidth, object.texheight));
 
 	colorbase = state->m_palram[(colorbase + 0x1000)] & 0x7fff;
 
@@ -265,9 +265,9 @@ void model2_renderer::draw_scanline_tex(int32_t scanline, const extent_t &extent
 		}
 		else if (object.utex && mml < 0)
 		{
-			// microtexture; blend up to 50%
+			// microtexture; blend up to almost 50%
 			u32 t2 = fetch_bilinear_texel<Translucent>(object, -1, u, v);
-			s32 frac = std::min(-mml >> object.utexminlod, 128);
+			s32 frac = std::min(-mml >> object.utexminlod, 127);
 			t = LERP(t, t2, frac);
 		}
 


### PR DESCRIPTION
Prevents microtextures being drawn when the base texture is transparent; fixes wallpaper in hotd