### PR TITLE
TMS32031 ABSF was mistakenly using ~mantissa instead of -mantissa

### DIFF
--- a/src/devices/cpu/tms32031/32031ops.hxx
+++ b/src/devices/cpu/tms32031/32031ops.hxx
@@ -1409,16 +1409,36 @@ uint32_t tms3203x_device::modillegal_def(uint32_t op, uint8_t ar, uint32_t *&def
 
 #define ABSF(dreg, sreg)                                                \
 {                                                                       \
-	int32_t man = FREGMAN(sreg);                                          \
+	int32_t man = FREGMAN(sreg);                                        \
+	int8_t fexp = FREGEXP(sreg);									    \
 	CLR_NZVUF();                                                        \
-	m_r[dreg] = m_r[sreg];                              \
+	m_r[dreg] = m_r[sreg];                                              \
+	if (fexp == -128)													\
+	{	/* if sreg was misformed, it should come out 80:00000000 */     \
+		m_r[dreg].set_mantissa(0);										\
+	}																	\
+	else																\
 	if (man < 0)                                                        \
 	{                                                                   \
-		m_r[dreg].set_mantissa(~man);                           \
-		if (man == (int32_t)0x80000000 && FREGEXP(sreg) == 127)           \
-			IREG(TMR_ST) |= VFLAG | LVFLAG;                             \
+		if (man == (int32_t)0x80000000)                                 \
+		{                                                               \
+			if (fexp == 127)									        \
+			{ /* total overflow result: 7F:7FFFFFFFF */                 \
+			    IREG(TMR_ST) |= VFLAG | LVFLAG;                         \
+				m_r[dreg].set_mantissa(0x7fffffff);						\
+			}															\
+			else														\
+			{ /* man overflow -80000000 to +80000000 : increment exp */ \
+				m_r[dreg].set_exponent(fexp + 1);						\
+				m_r[dreg].set_mantissa(0);								\
+			}															\
+        }																\
+		else															\
+		{ /* normal case */                                             \
+			m_r[dreg].set_mantissa(-man); /* aka (~man)+1 */            \
+		}																\
 	}                                                                   \
-	OR_NZF(m_r[dreg]);                                          \
+	OR_NZF(m_r[dreg]);                                                  \
 }
 
 void tms3203x_device::absf_reg(uint32_t op)


### PR DESCRIPTION
This caused an easily reproducible bug in MK4. Start a 2 player game and walk both players toward each other. Instead of pushing each other back, they would pass cleanly through each other.

The game logic determines examines whether |A|+|B| == |A + B| to decide what collision case to check.
The incorrect ABSF results, off by the smallest possible floating point amount, resulted in a non-equal floating-point comparison.

The relevant block of mk4 code:
```
01f3ad:07020000:				ldf		R0,R2
01f3ae:07030001:				ldf		R1,R3
01f3af:00020002:				absf	R2,R2
01f3b0:00030003:				absf	R3,R3
01f3b1:01830002:				addf	R2,R3
01f3b2:01810000:				addf	R0,R1
01f3b3:00010001:				absf	R1,R1
01f3b4:04010003:				cmpf	R3,R1
01f3b5:42e40000:				ldfeq	#1,R4
01f3b6:43e4f800:				ldflt	#-1,R4
```