### PR TITLE
hyperscan.xml, hyperscan_card.xml, x68k_flop.xml, orina_stylish_plus_cart.xml: Normalize descriptions

### DIFF
--- a/hash/hyperscan.xml
+++ b/hash/hyperscan.xml
@@ -4,7 +4,7 @@
 license:CC0-1.0
 -->
 
-<softwarelist name="hyperscan" description="HyperScan CD-ROMs">
+<softwarelist name="hyperscan" description="Mattel HyperScan CD-ROMs">
 
 	<software name="ben101">
 		<description>Ben 10 (USE1)</description>

--- a/hash/hyperscan_card.xml
+++ b/hash/hyperscan_card.xml
@@ -23,7 +23,7 @@ license:CC0-1.0
     NOTE: all cards marked baddump are not real dumps, but manually generated.
 -->
 
-<softwarelist name="hyperscan_card" description="Mattel Hyperscan RFID cards">
+<softwarelist name="hyperscan_card" description="Mattel HyperScan RFID cards">
 	<software name="ben001">
 		<description>Ben 10: Ben Tennyson (Character)</description>
 		<year>2006</year>

--- a/hash/orina_stylish_plus_cart.xml
+++ b/hash/orina_stylish_plus_cart.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="orina_stylish_plus_cart" description="Takara Tomy Orina Stylish+ Cartridges">
+<softwarelist name="orina_stylish_plus_cart" description="Takara Tomy Orina Stylish+ cartridges">
 
 	<!-- "Demon Slayer" and "Sanrio Characters" cartridges also exist -->
 

--- a/hash/x68k_flop.xml
+++ b/hash/x68k_flop.xml
@@ -385,7 +385,7 @@ Most info on release dates and Jpn titles come from the following (wonderful) re
  * http://mercenaryforce.web.fc2.com/x68k/x68000.html
 -->
 
-<softwarelist name="x68k_flop" description="Sharp X68k disk images">
+<softwarelist name="x68k_flop" description="Sharp X68000 disk images">
 
 
 	<software name="2069ad">


### PR DESCRIPTION
hyperscan.xml; Added manufacturer's name.
hyperscan_card.xml: Fixed HyperScan word.
x68k_flop.xml: Replaced "X68k" by the correct system name X68000. 
orina_stylish_plus_cart.xml: Lower case on the media's description.