### PR TITLE
fix: apple2/apple2e shift mod io value

### DIFF
--- a/src/mame/apple/apple2.cpp
+++ b/src/mame/apple/apple2.cpp
@@ -481,7 +481,7 @@ u8 apple2_state::flags_r(offs_t offset)
 		// check if SHIFT key mod configured
 		if (m_sysconfig->read() & 0x04)
 		{
-			return ((m_gameio->sw2_r() || (m_kbspecial->read() & 0x06)) ? 0 : 0x80) | uFloatingBus7;
+			return ((m_gameio->sw2_r() || !(m_kbspecial->read() & 0x06)) ? 0x80 : 0) | uFloatingBus7;
 		}
 		return (m_gameio->sw2_r() ? 0x80 : 0) | (read_floatingbus() & 0x7f);
 

--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -2077,7 +2077,7 @@ u8 apple2e_state::c000_r(offs_t offset)
 
 		case 0x63:  // button 2 or SHIFT key
 		case 0x6b:
-			return ((m_gameio->sw2_r() || (m_kbspecial->read() & 0x06)) ? 0 : 0x80) | uFloatingBus7;
+			return ((m_gameio->sw2_r() || !(m_kbspecial->read() & 0x06)) ? 0x80 : 0) | uFloatingBus7;
 
 		case 0x64:  // joy 1 X axis
 		case 0x6c:


### PR DESCRIPTION
Shift mod I/O value was inverted:

Real hardware:
Platinum //e
![IMG_2400](https://github.com/user-attachments/assets/1f8dba6d-f0bf-46d7-8c60-7feb901e3a2e)

Apple II with shift mod
![IMG_2402](https://github.com/user-attachments/assets/074686b5-b620-4150-975a-5a16f2c9159b)

Before:
<img width="1116" height="833" alt="Screenshot 2025-11-02 at 7 21 35 AM" src="https://github.com/user-attachments/assets/4e01d7d8-1320-4ca3-8194-2dc2f187c29a" />

After:
<img width="1110" height="826" alt="Screenshot 2025-11-02 at 8 01 32 AM" src="https://github.com/user-attachments/assets/50ff393f-eccf-40e8-9da6-b2bbc8b6b2d8" />
