### PR TITLE
apple: fix C06x softswitches

### DIFF
--- a/src/mame/apple/apple2.cpp
+++ b/src/mame/apple/apple2.cpp
@@ -468,8 +468,8 @@ u8 apple2_state::flags_r(offs_t offset)
 	// Y output of 74LS251 at H14 read as D7
 	switch (offset)
 	{
-	case 0: // cassette in (accidentally read at $C068 by ProDOS to attempt IIgs STATE register)
-		return (m_cassette->input() > 0.0 ? 0x80 : 0) | uFloatingBus7;
+	case 0: // cassette in, inverted (accidentally read at $C068 by ProDOS to attempt IIgs STATE register)
+		return (m_cassette->input() > 0.0 ? 0 : 0x80) | uFloatingBus7;
 
 	case 1:  // button 0
 		return (m_gameio->sw0_r() ? 0x80 : 0) | uFloatingBus7;
@@ -477,13 +477,8 @@ u8 apple2_state::flags_r(offs_t offset)
 	case 2:  // button 1
 		return (m_gameio->sw1_r() ? 0x80 : 0) | uFloatingBus7;
 
-	case 3:  // button 2
-		// check if SHIFT key mod configured
-		if (m_sysconfig->read() & 0x04)
-		{
-			return ((m_gameio->sw2_r() || (m_kbspecial->read() & 0x06)) ? 0x80 : 0) | uFloatingBus7;
-		}
-		return (m_gameio->sw2_r() ? 0x80 : 0) | (read_floatingbus() & 0x7f);
+	case 3:  // button 2, inverted (or SHIFT key, with SHIFT key mod)
+		return ((m_gameio->sw2_r() || ((m_sysconfig->read() & 0x04) && (m_kbspecial->read() & 0x06))) ? 0 : 0x80) | uFloatingBus7;
 
 	case 4:  // joy 1 X axis
 		if (!m_gameio->is_device_connected()) return 0x80 | uFloatingBus7;

--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -10,7 +10,7 @@
 
 
     IIe: base of this driver.  64K RAM, slot 0 language card emulation without the double-read requirement,
-         lowercase and SHIFT key on button 2, Open and Solid Apple buttons on joy buttons 0 and 1,
+         lowercase, Open and Solid Apple buttons on joy buttons 0 and 1,
          auxiliary slot, built-in 80 column support if extra RAM added.
 
          Physical slot 0 was eliminated thanks to the built-in language card.
@@ -36,11 +36,12 @@
 
     IIe enhanced: 65C02 CPU with more instructions, MouseText in the character generator.
 
-    IIe platinum: Like enhanced but with added numeric keypad and extended 80-column card
-         included in the box.  Keypad CLEAR generates ESC by default, one hardware mod
-         made it generate CTRL-X instead.  (new keyboard encoder ROM?)
+    IIe Platinum: Like enhanced but with added numeric keypad and extended 80-column card
+         included in the box.  SHIFT key on button 2, keypad CLEAR generates ESC by default,
+         one hardware mod made it generate CTRL-X instead.  (new keyboard encoder ROM?)
 
-    NOTE: On real IIe and IIe enhanced h/w, pressing SHIFT and paddle button 2 will
+    NOTE: On IIe Platinum h/w (or IIe and IIe enhanced, if pad X6 on the motherboard
+    is soldered to enable the SHIFT key mod), pressing SHIFT and paddle button 2 will
     short out the power supply and cause a safety shutdown.  (We don't emulate
     this "feature", and it was relatively rare in real life as Apple joysticks only
     had buttons 0 and 1 normally).
@@ -251,8 +252,6 @@ public:
 		m_printer_conn(*this, "parallel"),
 		m_printer_out(*this, "laserprnout")
 	{
-		m_accel_laser = false;
-		m_has_laser_mouse = false;
 		m_isiic = false;
 		m_isiicplus = false;
 		m_iscec = false;
@@ -262,8 +261,11 @@ public:
 		m_isace2200 = false;
 		m_ace2200_axxx_bank = false;
 		m_pal = false;
+		m_shift_key_mod = false;
 		m_cur_floppy = nullptr;
 		m_devsel = 0;
+		m_has_laser_mouse = false;
+		m_accel_laser = false;
 		m_laser_speed = 0;
 		m_laser_fdc_on = false;
 	}
@@ -459,20 +461,21 @@ private:
 	bool m_intc8rom;
 	bool m_reset_latch;
 
-	bool m_isiic, m_isiicplus, m_iscec, m_iscecm, m_iscec2000, m_pal;
+	bool m_isiic, m_isiicplus, m_iscec, m_iscecm, m_iscec2000;
+	bool m_pal, m_shift_key_mod;
 	u8 m_migram[0x800];
 	u16 m_migpage;
 
 	bool m_isace500, m_isace2200, m_ace_cnxx_bank, m_ace2200_axxx_bank;
 	u16 m_ace500rombank;
 
+	bool m_has_laser_mouse;
+	bool m_laser_fdc_on;
+	bool m_accel_laser;
 	bool m_accel_unlocked;
 	bool m_accel_fast;
 	bool m_accel_present;
 	bool m_accel_temp_slowdown;
-	bool m_accel_laser;
-	bool m_has_laser_mouse;
-	bool m_laser_fdc_on;
 	int m_accel_stage;
 	u32 m_accel_speed;
 	u8 m_accel_slotspk, m_accel_gameio, m_laser_speed;
@@ -2059,11 +2062,11 @@ u8 apple2e_state::c000_r(offs_t offset)
 			}
 			break;
 
-		case 0x60: // cassette in
+		case 0x60: // cassette in, inverted
 		case 0x68:
 			if (m_cassette)
 			{
-				return (m_cassette->input() > 0.0 ? 0x80 : 0) | uFloatingBus7;
+				return (m_cassette->input() > 0.0 ? 0 : 0x80) | uFloatingBus7;
 			}
 			return uFloatingBus7;
 
@@ -2075,9 +2078,9 @@ u8 apple2e_state::c000_r(offs_t offset)
 		case 0x6a:
 			return ((m_gameio->sw1_r() || (m_kbspecial->read() & 0x20)) ? 0x80 : 0) | uFloatingBus7;
 
-		case 0x63:  // button 2 or SHIFT key
+		case 0x63:  // button 2, inverted (or SHIFT key, on IIe Platinum)
 		case 0x6b:
-			return ((m_gameio->sw2_r() || (m_kbspecial->read() & 0x06)) ? 0x80 : 0) | uFloatingBus7;
+			return ((m_gameio->sw2_r() || ((m_shift_key_mod) && (m_kbspecial->read() & 0x06))) ? 0 : 0x80) | uFloatingBus7;
 
 		case 0x64:  // joy 1 X axis
 		case 0x6c:
@@ -2167,7 +2170,7 @@ u8 apple2e_state::c000_iic_r(offs_t offset)
 		case 0x60: // 40/80 column switch (IIc and Franklin ACE 500 only)
 			return ((m_sysconfig.read_safe(0) & 0x40) ? 0x80 : 0) | uFloatingBus7;
 
-		case 0x63:  // mouse button 2 (no other function on IIc)
+		case 0x63:  // mouse button 2, inverted (no other function on IIc)
 		case 0x6b:
 			return (m_mouseb->read() ? 0 : 0x80) | uFloatingBus7;
 
@@ -3767,7 +3770,7 @@ INPUT_PORTS_END
 	*/
 
 	/*
-	  Apple IIe platinum key matrix
+	  Apple IIe Platinum key matrix
 
 	      | Y0  | Y1  | Y2  | Y3  | Y4  | Y5  | Y6  | Y7  | Y8  | Y9  |
 	      |     |     |     |     |     |     |     |     |     |     |
@@ -5005,11 +5008,12 @@ void apple2e_state::tk3000(machine_config &config)
 void apple2e_state::apple2ep(machine_config &config)
 {
 	apple2ee(config);
+	m_shift_key_mod = true; // see Apple IIe Technical Note #9
 }
 
 void apple2e_state::apple2eppal(machine_config &config)
 {
-	apple2ee(config);
+	apple2ep(config);
 	m_maincpu->set_clock(1016966);
 	m_screen->set_raw(1016966 * 14, (65 * 7) * 2, 0, (40 * 7) * 2, 312, 0, 192);
 }

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -1696,8 +1696,8 @@ u8 apple2gs_state::c000_r(offs_t offset)
 		case 0x46:  // INTFLAG
 			return (m_an3 ? INTFLAG_AN3 : 0x00) | m_intflag;
 
-		case 0x60: // button 3 on IIgs
-			return (m_gameio->sw3_r() ? 0x80 : 0x00) | uFloatingBus7;
+		case 0x60: // button 3 on IIgs, inverted
+			return (m_gameio->sw3_r() ? 0 : 0x80) | uFloatingBus7;
 
 		case 0x61: // button 0 or Open Apple
 			// HACK/TODO: the 65816 loses a race to the microcontroller on reset
@@ -1707,8 +1707,8 @@ u8 apple2gs_state::c000_r(offs_t offset)
 		case 0x62: // button 1 or Option
 			return ((m_gameio->sw1_r() || (m_adb_p3_last & 0x10)) ? 0x80 : 0) | uFloatingBus7;
 
-		case 0x63: // button 2 or SHIFT key
-			return (m_gameio->sw2_r() ? 0x80 : 0x00) | uFloatingBus7;
+		case 0x63: // button 2, inverted (no shift key mod)
+			return (m_gameio->sw2_r() ? 0 : 0x80) | uFloatingBus7;
 
 		case 0x64:  // joy 1 X axis
 			if (!m_gameio->is_device_connected()) return 0x80 | uFloatingBus7;


### PR DESCRIPTION
This PR supercedes #14456 and fixes the behavior of C060 and C063 softswitches:

* Apple II/II+ with SHIFT key mod enabled now act as expected ([MT#8917](http://mametesters.org/view.php?id=8917))

* SHIFT key mod is no longer applied to the IIe or IIe Enhanced (pad X6 is a [broken diamond](http://www.applefritter.com/files/styles/95-percent/public/mapetitecollection.com_P.A.L..jpg)) but is [still applied](http://web.archive.org/web/20040130132820/http://web.pdx.edu/~heiss/technotes/aiie/tn.aiie.09.html#:~:text=facilitating%20the%20shift-click%20mouse%20selection) to the IIe Platinum (pad X6 is a [connected bowtie](http://www.applefritter.com/files/styles/95-percent/public/Apple_IIe_platinum.jpg))

* Some cassettes (i.e. "hi" quality WAVs via "Apple Game Server") which previously failed to LOAD with CHKSUM ERROR, now work (and the "lo" WAVs continue to work):
before:
![apple2p_cass_282_before](https://github.com/user-attachments/assets/28ed979e-944b-4ace-8060-d6f50c010e99)
after:
![apple2p_cass_282_after](https://github.com/user-attachments/assets/c365da23-f85f-4c1d-81f1-8ca97e45713d)


Documentation:

* It is unintuitive that PB2 (and SW3 on the IIgs) behaves differently than PB0/PB1.

* Apple's documentation about the gameio pushbuttons says things like "the appropriate game input is connected to bit 7 of the data bus" without specifying if they are high or low. But the //c Tech Ref explicitly mentions [C063 in context of the shift-key mod](http://archive.org/details/AppleIIcTechnicalReference2ndEd/page/n497/mode/2up) and says "0 if it is pressed".

* Sather's [UTA2E Fig 7.2](http://archive.org/details/Understanding_the_Apple_IIe/page/n173/mode/2up) shows pull-down resistors on PB0 and PB1, but not PB2.

* Also, there is good [anecdotal corroboration of what's happening](http://comp.sys.apple2.narkive.com/ibs17S9K/apple-ii-s-paddle-3-button#:~:text=The%20cassette%20input%20is%20inverting) from respected source Michael J. Mahon.

* Sather also describes the LM741 inverting the cassette input, in [UTA2E 7-8.](http://archive.org/details/Understanding_the_Apple_IIe/page/n175/mode/2up)


Testing:

* The [previous SWITCHES test](http://github.com/mamedev/mame/pull/14307) shows that the default state of C06X softswitch reads (with or without a joystick attached) now matches hardware behavior, verified against a ][+ clone, //c, Apple IIe Enhanced and Apple IIgs ROM 3: both C060 and C063 default to high bit ON, except on a //c, C060 depends instead on the 40/80 switch.

* This PR is a [group effort](http://app.slack.com/client/T1J8S1LGH/CABEM8JFK): Shift key behavior was verified across various hardware by folks on Slack; kudos to: SpecLad, Will Scullin, Joshua Bell, and Tom Greene.


Caveats:
* This PR applies to common clones (and the tk3000) but I did not touch the tk2000 or the Apple 1 cassette.
* The shift-key mod could be added back to the IIe and IIe Enhanced via an `m_sysconfig` option bit, if someone wants that.
