### PR TITLE
apple2e: fix IIc mouse regression

### DIFF
--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -2176,14 +2176,10 @@ u8 apple2e_state::c000_iic_r(offs_t offset)
 
 		case 0x66: // mouse X1 (IIc only)
 		case 0x6e:
-			if (!m_gameio->is_device_connected())
-				return 0x80 | uFloatingBus7;
 			return (m_x1 ? 0x80 : 0) | uFloatingBus7;
 
 		case 0x67: // mouse Y1 (IIc only)
 		case 0x6f:
-			if (!m_gameio->is_device_connected())
-				return 0x80 | uFloatingBus7;
 			return (m_y1 ? 0x80 : 0) | uFloatingBus7;
 
 		case 0x78: case 0x7a: case 0x7c: case 0x7e:  // read IOUDIS


### PR DESCRIPTION
This PR fixes #14463, which is a regression introduced by 92aa47f.

The "unconnected joysticks now read properly" portion of that commit fixed joystick 1 as advertised, however it incorrectly propagated similar logic to the IIc-specific mouse handling for C066/67.  The result is that the mouse stops functioning if no joystick is plugged in.

For folks affected by this in 0.282, a workaround is to launch with `-gameio joy`, which will restore mouse functionality.
