### PR TITLE
sega/model2: tilemap fixes

### DIFF
--- a/src/mame/sega/model2_v.cpp
+++ b/src/mame/sega/model2_v.cpp
@@ -2599,11 +2599,9 @@ u32 model2_state::screen_update_model2(screen_device &screen, bitmap_rgb32 &bitm
 	bitmap.fill(m_palette->pen(0), cliprect);
 	m_sys24_bitmap.fill(0, cliprect);
 
+	// draw tilemap B as opaque
 	for (int layer = 3; layer >= 2; layer--)
-	{
-		m_tiles->draw(screen, m_sys24_bitmap, cliprect, layer << 1, 0, 1);
-		m_tiles->draw(screen, m_sys24_bitmap, cliprect, (layer << 1) | 1, 0, 1);
-	}
+		m_tiles->draw(screen, m_sys24_bitmap, cliprect, layer << 1, 0, TILEMAP_DRAW_OPAQUE);
 
 	for (int layer = 1; layer >= 0; layer--)
 		m_tiles->draw(screen, m_sys24_bitmap, cliprect, layer << 1, 0, 0);

--- a/src/mame/sega/segaic24.cpp
+++ b/src/mame/sega/segaic24.cpp
@@ -102,7 +102,7 @@ void segas24_tile_device::device_start()
 }
 
 void segas24_tile_device::draw_rect(screen_device &screen, bitmap_ind16 &bm, bitmap_ind8 &tm, bitmap_ind16 &dm, const uint16_t *mask,
-								uint16_t tpri, uint8_t lpri, int win, int sx, int sy, int xx1, int yy1, int xx2, int yy2)
+								uint16_t tpri, uint8_t lpri, int flags, int win, int sx, int sy, int xx1, int yy1, int xx2, int yy2)
 {
 	const uint16_t *source = &bm.pix(sy, sx);
 	const uint8_t  *trans = &tm.pix(sy, sx);
@@ -141,7 +141,7 @@ void segas24_tile_device::draw_rect(screen_device &screen, bitmap_ind16 &bm, bit
 				if(!m) {
 					// 1- 128 pixels from this layer
 					for(int x=0; x<128; x++) {
-						if(*srct++ == tpri) {
+						if(*srct++ == tpri || flags & TILEMAP_DRAW_OPAQUE) {
 							*dst = *src;
 							*pr |= lpri;
 						}
@@ -163,7 +163,7 @@ void segas24_tile_device::draw_rect(screen_device &screen, bitmap_ind16 &bm, bit
 						if(!(m & 0x8000)) {
 							int xx;
 							for(xx=0; xx<8; xx++)
-								if(srct[xx] == tpri) {
+								if(srct[xx] == tpri || flags & TILEMAP_DRAW_OPAQUE) {
 									dst[xx] = src[xx];
 									pr[xx] |= lpri;
 								}
@@ -182,7 +182,7 @@ void segas24_tile_device::draw_rect(screen_device &screen, bitmap_ind16 &bm, bit
 				if(!m) {
 					// 1- 128 pixels from this layer
 					for(int x = cur_x; x<llx1; x++) {
-						if(*srct++ == tpri) {
+						if(*srct++ == tpri || flags & TILEMAP_DRAW_OPAQUE) {
 							*dst = *src;
 							*pr |= lpri;
 						}
@@ -201,7 +201,7 @@ void segas24_tile_device::draw_rect(screen_device &screen, bitmap_ind16 &bm, bit
 				} else {
 					// 3- 128 pixels from both layers
 					for(int x=cur_x; x<llx1; x++) {
-						if(*srct++ == tpri && !(m & (0x8000 >> (x >> 3)))) {
+						if((*srct++ == tpri || flags & TILEMAP_DRAW_OPAQUE) && !(m & (0x8000 >> (x >> 3)))) {
 							*dst = *src;
 							*pr |= lpri;
 						}
@@ -229,7 +229,7 @@ void segas24_tile_device::draw_rect(screen_device &screen, bitmap_ind16 &bm, bit
 // priority_bitmap
 
 void segas24_tile_device::draw_rect(screen_device &screen, bitmap_ind16 &bm, bitmap_ind8 &tm, bitmap_rgb32 &dm, const uint16_t *mask,
-								uint16_t tpri, uint8_t lpri, int win, int sx, int sy, int xx1, int yy1, int xx2, int yy2)
+								uint16_t tpri, uint8_t lpri, int flags, int win, int sx, int sy, int xx1, int yy1, int xx2, int yy2)
 {
 	const uint16_t *source = &bm.pix(sy, sx);
 	const uint8_t  *trans = &tm.pix(sy, sx);
@@ -267,7 +267,7 @@ void segas24_tile_device::draw_rect(screen_device &screen, bitmap_ind16 &bm, bit
 				if(!m) {
 					// 1- 128 pixels from this layer
 					for(int x=0; x<128; x++) {
-						if(*srct++ == tpri)
+						if(*srct++ == tpri || flags & TILEMAP_DRAW_OPAQUE)
 							*dst = pens[*src];
 						src++;
 						dst++;
@@ -284,7 +284,7 @@ void segas24_tile_device::draw_rect(screen_device &screen, bitmap_ind16 &bm, bit
 					for(int x=0; x<128; x+=8) {
 						if(!(m & 0x8000)) {
 							for(int xx=0; xx<8; xx++)
-								if(srct[xx] == tpri)
+								if(srct[xx] == tpri || flags & TILEMAP_DRAW_OPAQUE)
 									dst[xx] = pens[src[xx]];
 						}
 						src += 8;
@@ -300,7 +300,7 @@ void segas24_tile_device::draw_rect(screen_device &screen, bitmap_ind16 &bm, bit
 				if(!m) {
 					// 1- 128 pixels from this layer
 					for(int x = cur_x; x<llx1; x++) {
-						if(*srct++ == tpri)
+						if(*srct++ == tpri || flags & TILEMAP_DRAW_OPAQUE)
 							*dst = pens[*src];
 						src++;
 						dst++;
@@ -316,7 +316,7 @@ void segas24_tile_device::draw_rect(screen_device &screen, bitmap_ind16 &bm, bit
 					// 3- 128 pixels from both layers
 					int x;
 					for(x=cur_x; x<llx1; x++) {
-						if(*srct++ == tpri && !(m & (0x8000 >> (x >> 3))))
+						if((*srct++ == tpri || flags & TILEMAP_DRAW_OPAQUE) && !(m & (0x8000 >> (x >> 3))))
 							*dst = pens[*src];
 
 						src++;
@@ -350,11 +350,6 @@ void segas24_tile_device::draw_common(screen_device &screen, BitmapClass &bitmap
 	if(vscr & 0x8000)
 		return;
 
-	if (flags & 1)
-		tile_layer[layer]->map_pen_to_layer(0, 0, TILEMAP_PIXEL_LAYER0);
-	else
-		tile_layer[layer]->map_pen_to_layer(0, 0, TILEMAP_PIXEL_TRANSPARENT);
-
 	if(ctrl & 0x6000) {
 		// Special window/scroll modes
 		if(layer & 1)
@@ -385,7 +380,7 @@ void segas24_tile_device::draw_common(screen_device &screen, BitmapClass &bitmap
 
 					h = hscr & 0x1ff;
 					tile_layer[l1]->set_scrollx(0, -h);
-					tile_layer[l1]->draw(screen, bitmap, c, tpri, lpri);
+					tile_layer[l1]->draw(screen, bitmap, c, tpri | flags, lpri);
 				}
 				break;
 			}
@@ -412,8 +407,8 @@ void segas24_tile_device::draw_common(screen_device &screen, BitmapClass &bitmap
 
 					c1.min_y = c1.max_y = c2.min_y = c2.max_y = y;
 
-					tile_layer[l1]->draw(screen, bitmap, c1, tpri, lpri);
-					tile_layer[l1^1]->draw(screen, bitmap, c2, tpri, lpri);
+					tile_layer[l1]->draw(screen, bitmap, c1, tpri | flags, lpri);
+					tile_layer[l1^1]->draw(screen, bitmap, c2, tpri | flags, lpri);
 				}
 				break;
 			}
@@ -436,8 +431,8 @@ void segas24_tile_device::draw_common(screen_device &screen, BitmapClass &bitmap
 				if(!((-vscr) & 0x200))
 					layer ^= 1;
 
-				tile_layer[layer]->draw(screen, bitmap, c1, tpri, lpri);
-				tile_layer[layer^1]->draw(screen, bitmap, c2, tpri, lpri);
+				tile_layer[layer]->draw(screen, bitmap, c1, tpri | flags, lpri);
+				tile_layer[layer^1]->draw(screen, bitmap, c2, tpri | flags, lpri);
 				break;
 			}
 			case 2: case 3: {
@@ -452,8 +447,8 @@ void segas24_tile_device::draw_common(screen_device &screen, BitmapClass &bitmap
 				if(!((+hscr) & 0x200))
 					layer ^= 1;
 
-				tile_layer[layer]->draw(screen, bitmap, c1, tpri, lpri);
-				tile_layer[layer^1]->draw(screen, bitmap, c2, tpri, lpri);
+				tile_layer[layer]->draw(screen, bitmap, c1, tpri | flags, lpri);
+				tile_layer[layer^1]->draw(screen, bitmap, c2, tpri | flags, lpri);
 				break;
 			}
 			}
@@ -474,11 +469,11 @@ void segas24_tile_device::draw_common(screen_device &screen, BitmapClass &bitmap
 				hscr = (-hscrtb[y]) & 0x1ff;
 				if(hscr + 496 <= 512) {
 					// Horizontal split unnecessary
-					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, win, hscr, vscr,        0,        y,      496,      y+1);
+					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, flags, win, hscr, vscr,        0,        y,      496,      y+1);
 				} else {
 					// Horizontal split necessary
-					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, win, hscr, vscr,        0,        y, 512-hscr,      y+1);
-					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, win,    0, vscr, 512-hscr,        y,      496,      y+1);
+					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, flags, win, hscr, vscr,        0,        y, 512-hscr,      y+1);
+					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, flags, win,    0, vscr, 512-hscr,        y,      496,      y+1);
 				}
 				vscr = (vscr + 1) & 0x1ff;
 			}
@@ -490,25 +485,25 @@ void segas24_tile_device::draw_common(screen_device &screen, BitmapClass &bitmap
 				// Horizontal split unnecessary
 				if(vscr + 384 <= 512) {
 					// Vertical split unnecessary
-					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, win, hscr, vscr,        0,        0,      496,      384);
+					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, flags, win, hscr, vscr,        0,        0,      496,      384);
 				} else {
 					// Vertical split necessary
-					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, win, hscr, vscr,        0,        0,      496, 512-vscr);
-					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, win, hscr,    0,        0, 512-vscr,      496,      384);
+					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, flags, win, hscr, vscr,        0,        0,      496, 512-vscr);
+					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, flags, win, hscr,    0,        0, 512-vscr,      496,      384);
 
 				}
 			} else {
 				// Horizontal split necessary
 				if(vscr + 384 <= 512) {
 					// Vertical split unnecessary
-					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, win, hscr, vscr,        0,        0, 512-hscr,      384);
-					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, win,    0, vscr, 512-hscr,        0,      496,      384);
+					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, flags, win, hscr, vscr,        0,        0, 512-hscr,      384);
+					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, flags, win,    0, vscr, 512-hscr,        0,      496,      384);
 				} else {
 					// Vertical split necessary
-					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, win, hscr, vscr,        0,        0, 512-hscr, 512-vscr);
-					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, win,    0, vscr, 512-hscr,        0,      496, 512-vscr);
-					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, win, hscr,    0,        0, 512-vscr, 512-hscr,      384);
-					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, win,    0,    0, 512-hscr, 512-vscr,      496,      384);
+					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, flags, win, hscr, vscr,        0,        0, 512-hscr, 512-vscr);
+					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, flags, win,    0, vscr, 512-hscr,        0,      496, 512-vscr);
+					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, flags, win, hscr,    0,        0, 512-vscr, 512-hscr,      384);
+					draw_rect(screen, bm, tm, bitmap, mask, tpri, lpri, flags, win,    0,    0, 512-hscr, 512-vscr,      496,      384);
 				}
 			}
 		}

--- a/src/mame/sega/segaic24.h
+++ b/src/mame/sega/segaic24.h
@@ -65,9 +65,9 @@ private:
 	TILE_GET_INFO_MEMBER(tile_info_1w);
 
 	void draw_rect(screen_device &screen, bitmap_ind16 &bm, bitmap_ind8 &tm, bitmap_ind16 &dm, const uint16_t *mask,
-					uint16_t tpri, uint8_t lpri, int win, int sx, int sy, int xx1, int yy1, int xx2, int yy2);
+					uint16_t tpri, uint8_t lpri, int flags, int win, int sx, int sy, int xx1, int yy1, int xx2, int yy2);
 	void draw_rect(screen_device &screen, bitmap_ind16 &bm, bitmap_ind8 &tm, bitmap_rgb32 &dm, const uint16_t *mask,
-					uint16_t tpri, uint8_t lpri, int win, int sx, int sy, int xx1, int yy1, int xx2, int yy2);
+					uint16_t tpri, uint8_t lpri, int flags, int win, int sx, int sy, int xx1, int yy1, int xx2, int yy2);
 
 	template<class BitmapClass>
 	void draw_common(screen_device &screen, BitmapClass &bitmap, const rectangle &cliprect, int layer, int pri, int flags);


### PR DESCRIPTION
When emulating System 24 tilemaps (which Model 2 uses) MAME currently treats color 0 of any palette as transparent, but some Model 2 games use color 0 to encode tile-specific colors. Here is a screenshot of Behind Enemy Lines demonstrating the problem:

<img width="496" height="384" alt="image" src="https://github.com/user-attachments/assets/a5573bb2-ca76-4a3b-8f64-fe2b61a0c9ec" />

Here is what that screenshot is supposed to look like:

<img width="496" height="384" alt="image" src="https://github.com/user-attachments/assets/eb1b02c6-fcd8-4231-82be-f94ae81e5a48" />

The [Sega System 24 Hardware Notes](https://segaretro.org/Sega_System_24_Hardware_Notes_(2013-06-16)) specifies the following when ABSEL=0:

> Zero value pixels from the topmost layer are considered transparent.
> Zero value pixels from the bottommost layer show color 0 of the specified
> palette.
> 
> If the topmost layer is blanked, it is considered transparent.
> If the bottommost layer is blanked, it is filled with color 0 of palette 0.

On Model 2, tilemap B is usually the bottommost layer unless it has the priority flag set, in which case either tilemap A or the framebuffer is the bottommost layer depending on whether tilemap A also has the priority flag set. However, I have observed that the polygon layer is never displayed if it is empty even if both tilemaps A and B have priority (Virtual On title screen). It is unknown whether tilemap A would instead be chosen if tilemap B has priority set and tilemap A does not, making tilemap A the bottommost layer; I have not observed any games that depend on this.

The easiest solution I have found is to display color 0 from the tile-specific palette of tilemap B if all three would otherwise be transparent; this seems to fix all tilegen issues. My current solution works by drawing the layers in this order:

- tilemap B without priority as opaque
- tilemap B with priority as opaque
- tilemap A without priority
- frame buffer
- tilemap B with priority
- tilemap A with priority

The solution is not quite as neat as I'd like it to be so I'm submitting this commit as a draft for now; any ideas to make the solution more elegant are welcome.