### PR TITLE
Fix missing declarations of altivec variant of bilinear filter functions

### DIFF
--- a/src/emu/video/rgbutil.h
+++ b/src/emu/video/rgbutil.h
@@ -426,8 +426,13 @@ public:
 		return *this;
 	}
 
+#ifdef __ALTIVEC__
+	static u32 bilinear_filter(const u32 &rgb00, const u32 &rgb01, const u32 &rgb10, const u32 &rgb11, u8 u, u8 v);
+	void bilinear_filter_rgbaint(const u32 &rgb00, const u32 &rgb01, const u32 &rgb10, const u32 &rgb11, u8 u, u8 v);
+#else
 	static u32 bilinear_filter(u32 rgb00, u32 rgb01, u32 rgb10, u32 rgb11, u8 u, u8 v) noexcept;
 	void bilinear_filter_rgbaint(u32 rgb00, u32 rgb01, u32 rgb10, u32 rgb11, u8 u, u8 v) noexcept;
+#endif
 
 protected:
 	s32 m_a;


### PR DESCRIPTION
This "fixes" #14473 in that it mame compiles. Unfortunately, the validation fails with 7967 errors like:
```
   Error testing rgbaint_t::bilinear_filter_rgbaint get_a32() = 5799936 (expected 78)
   Error testing rgbaint_t::bilinear_filter_rgbaint get_r32() = 5963776 (expected 236)
   Error testing rgbaint_t::bilinear_filter_rgbaint get_g32() = 6127616 (expected 109)
   Error testing rgbaint_t::bilinear_filter_rgbaint get_b32() = 3801088 (expected 40)
   Error testing rgbaint_t::bilinear_filter get_a32() = 231 (expected 169)
   Error testing rgbaint_t::bilinear_filter get_r32() = 227 (expected 174)
   Error testing rgbaint_t::bilinear_filter get_g32() = 1 (expected 96)
   Error testing rgbaint_t::bilinear_filter get_b32() = 144 (expected 136)
   Error testing rgbaint_t::bilinear_filter_rgbaint get_a32() = 7569408 (expected 169)
   Error testing rgbaint_t::bilinear_filter_rgbaint get_r32() = 7438336 (expected 174)
   Error testing rgbaint_t::bilinear_filter_rgbaint get_g32() = 32768 (expected 96)
   Error testing rgbaint_t::bilinear_filter_rgbaint get_b32() = 4718592 (expected 136)
   Error testing rgbaint_t::bilinear_filter get_a32() = 85 (expected 198)
   Error testing rgbaint_t::bilinear_filter get_r32() = 115 (expected 52)
   Error testing rgbaint_t::bilinear_filter get_g32() = 7 (expected 32)
   Error testing rgbaint_t::bilinear_filter get_b32() = 114 (expected 49)
   Error testing rgbaint_t::bilinear_filter_rgbaint get_a32() = 2785280 (expected 198)
   Error testing rgbaint_t::bilinear_filter_rgbaint get_r32() = 3768320 (expected 52)
   Error testing rgbaint_t::bilinear_filter_rgbaint get_g32() = 229376 (expected 32)
   Error testing rgbaint_t::bilinear_filter_rgbaint get_b32() = 3735552 (expected 49)
   Error testing rgbaint_t::bilinear_filter get_a32() = 45 (expected 91)
   Error testing rgbaint_t::bilinear_filter get_r32() = 186 (expected 177)
   Error testing rgbaint_t::bilinear_filter get_g32() = 98 (expected 139)
   Error testing rgbaint_t::bilinear_filter get_b32() = 8 (expected 64)
   Error testing rgbaint_t::bilinear_filter_rgbaint get_a32() = 1474560 (expected 91)
   Error testing rgbaint_t::bilinear_filter_rgbaint get_r32() = 6094848 (expected 177)
   Error testing rgbaint_t::bilinear_filter_rgbaint get_g32() = 3211264 (expected 139)
   Error testing rgbaint_t::bilinear_filter_rgbaint get_b32() = 262144 (expected 64)
```
I do not know whether this is an issue with the fix or with changes from 6d4ccfd.