### PR TITLE
apple2e: fix -ramsize crash

### DIFF
--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -868,7 +868,7 @@ void apple2e_state::memexp_w(offs_t offset, u8 data)
 			break;
 
 		case 3:
-//            printf("Write %02x to RAM[%x]\n", data, m_liveptr);
+//			printf("Write %02x to RAM[%x]\n", data, m_exp_liveptr);
 			if (m_exp_liveptr <= m_exp_addrmask)
 			{
 				m_exp_ram[m_exp_liveptr] = data;
@@ -912,7 +912,7 @@ void apple2e_state::machine_start()
 	m_inh_bank = 0;
 
 	m_migpage = 0;
-	memset(m_migram, 0, 0x200);
+	memset(m_migram, 0, sizeof(m_migram));
 
 	// expansion RAM size
 	if (m_ram_size > (128*1024))
@@ -1278,6 +1278,8 @@ void apple2e_state::machine_reset()
 	}
 
 	m_exp_bankhior = 0xf0;
+	memset(m_exp_regs, 0, sizeof(m_exp_regs));
+	m_exp_wptr = m_exp_liveptr = 0;
 
 	// sync up the banking with the variables.
 	lcrom_update();


### PR DESCRIPTION
This PR fixes apple2c* crashing when using -ramsize.

To reproduce:
1. launch MAME with: apple2c3 [or apple2c4, apple2cp] -ramsize 1152K -flop1 A2eDiagnostics_v2.1.dsk

On arm64 macos Sonoma 14.8.1, MAME 0.282 crashes while booting ProDOS:
`zsh: segmentation fault  ./appulatord apple2c3 -ramsize 1152K -flop1`
(this is an uninitialized memory bug, so the results may vary run-to-run or depend on OS-specific allocator behavior.)

After rebuilding with Asan (ARCHOPTS="-fsanitize=address") we can see:
`SUMMARY: AddressSanitizer: BUS apple2e.cpp:874 in (anonymous namespace)::apple2e_state::memexp_w(unsigned int, unsigned char)`
[mame_282_asan.txt](https://github.com/user-attachments/files/23384199/mame_282_asan.txt)

...and logging `m_exp_liveptr` shows that the high byte is non-zero, i.e. beyond any possible apple2 allocation.
The code updating `m_exp_wptr` [masks out each of the low three bytes](https://github.com/mamedev/mame/blob/ca3c4b269ef8063fb6de08b63b3dfbe1a8f666ce/src/mame/apple/apple2e.cpp#L844), but notice: the highest byte was never initialized...

This commit adds initialization, mimicking the `device_reset()` [from a2bus_memexp_device](https://github.com/mamedev/mame/blob/ca3c4b269ef8063fb6de08b63b3dfbe1a8f666ce/src/devices/bus/a2bus/a2memexp.cpp#L156) (which works fine in apple2ee.)
