### PR TITLE
segaic24: draw bottom tilemap layer as opaque

### DIFF
--- a/src/mame/sega/model1_v.cpp
+++ b/src/mame/sega/model1_v.cpp
@@ -1649,8 +1649,9 @@ uint32_t model1_state::screen_update_model1(screen_device &screen, bitmap_rgb32 
 	screen.priority().fill(0);
 	bitmap.fill(m_palette->pen(0x400), cliprect);
 
-	m_tiles->draw(screen, bitmap, cliprect, 6, 0, 0);
-	m_tiles->draw(screen, bitmap, cliprect, 4, 0, 0);
+	// draw tilemap B as opaque
+	m_tiles->draw(screen, bitmap, cliprect, 6, 0, TILEMAP_DRAW_OPAQUE);
+	m_tiles->draw(screen, bitmap, cliprect, 4, 0, TILEMAP_DRAW_OPAQUE);
 	m_tiles->draw(screen, bitmap, cliprect, 2, 0, 0);
 	m_tiles->draw(screen, bitmap, cliprect, 0, 0, 0);
 

--- a/src/mame/sega/segas24.cpp
+++ b/src/mame/sega/segas24.cpp
@@ -2573,7 +2573,7 @@ void segas24_state::init_roughrac()
 /* 06 */GAME( 1990, roughrac,  0,        system24_floppy_fd_upd, roughrac, segas24_state, init_roughrac, ROT0,   "Sega", "Rough Racer (Japan, Floppy Based, FD1094 317-0058-06b)", 0 )
 /* 07 */GAME( 1990, bnzabros,  0,        system24_floppy_rom,    bnzabros, segas24_state, init_bnzabros, ROT0,   "Sega", "Bonanza Bros (US, Floppy DS3-5000-07d? Based)", 0 )
 /* 07 */GAME( 1990, bnzabrosj, bnzabros, system24_floppy_rom,    bnzabros, segas24_state, init_bnzabros, ROT0,   "Sega", "Bonanza Bros (Japan, Floppy DS3-5000-07b Based)", 0 )
-/* 08 */GAME( 1991, qsww,      0,        system24_floppy_fd1094, qsww,     segas24_state, init_qsww,     ROT0,   "Sega", "Quiz Syukudai wo Wasuremashita (Japan, Floppy Based, FD1094 317-0058-08b)", MACHINE_IMPERFECT_GRAPHICS ) // wrong bg colour on title
+/* 08 */GAME( 1991, qsww,      0,        system24_floppy_fd1094, qsww,     segas24_state, init_qsww,     ROT0,   "Sega", "Quiz Syukudai wo Wasuremashita (Japan, Floppy Based, FD1094 317-0058-08b)", 0 )
 /* 09 */GAME( 1991, dcclubfd,  dcclub,   system24_floppy_dcclub, dcclub,   segas24_state, init_dcclubfd, ROT0,   "Sega", "Dynamic Country Club (US, Floppy Based, FD1094 317-0058-09d)", 0 )
 
 //    YEAR  NAME      PARENT    MACHINE       INPUT     CLASS          INIT           MONITOR COMPANY FULLNAME FLAGS

--- a/src/mame/sega/segas24_v.cpp
+++ b/src/mame/sega/segas24_v.cpp
@@ -46,6 +46,12 @@ uint32_t segas24_state::screen_update(screen_device &screen, bitmap_ind16 &bitma
 
 	std::sort(order.begin(), order.end(), layer_sort(*m_vmixer));
 
+	// zero value pixels from the bottommost layer show color 0 of the specified palette
+	// to do this we draw the tilemap layers in reverse order as opaque
+	for (int i = 11; i >= 0; i--)
+		if (order[i] < 8 && (order[i] & 1) == 0)
+			m_vtile->draw(screen, bitmap, cliprect, order[i], 0, TILEMAP_DRAW_OPAQUE);
+
 	int spri[4]{};
 	int level = 0;
 	for(int i=0; i<12; i++)


### PR DESCRIPTION
Applying my recent Model 2 tilemap fixes to System 24 and Model 1 as well; fixes the title screen of `qsww` and most of the issues in [MT06379](https://mametesters.org/view.php?id=6379).

The one remaining tilemap bug in Crack Down is the description of the time bomb not scrolling into view during attract mode; this is due to the scrolling of tall playfields not being implemented properly and I am working on a separate fix for this.

I noted that the System 24 tilegen issues could also be fixed by simply always drawing tilemap B as opaque before drawing the tilemap layers as normal, rather than drawing all the tilemap layers in reverse order:

`m_vtile->draw(screen, bitmap, cliprect, 6, 0, TILEMAP_DRAW_OPAQUE);`
`m_vtile->draw(screen, bitmap, cliprect, 4, 0, TILEMAP_DRAW_OPAQUE);`

However, since the [System 24 Hardware Notes](https://segaretro.org/Sega_System_24_Hardware_Notes_(2013-06-16)) specify that "zero value pixels from the _bottommost_ layer show color 0 of the specified palette", I have implemented the behavior as described.