### PR TITLE
rare/kinst.cpp: Fix metadata

### DIFF
--- a/src/mame/rare/kinst.cpp
+++ b/src/mame/rare/kinst.cpp
@@ -862,6 +862,6 @@ void kinst_state::init_kinst2()
 // versions selectable by changing bioses
 
 //    YEAR  NAME      PARENT  MACHINE   INPUT   CLASS           INIT         SCREEN  COMPANY                  FULLNAME           FLAGS
-GAME( 1994, kinst,    0,      kinst,    kinst,  kinst_state,    init_kinst,  ROT0,   "Nintendo / Rare (Midway license)", "Killer Instinct", MACHINE_SUPPORTS_SAVE )
-GAME( 1996, kinst2,   0,      kinst2,   kinst2, kinst_state,    init_kinst2, ROT0,   "Nintendo / Rare (Midway license)", "Killer Instinct 2", MACHINE_SUPPORTS_SAVE )
-GAME( 1996, kinst2uk, kinst2, kinst2uk, kinst2, kinst2uk_state, init_kinst2, ROT0,   "Nintendo / Rare (Midway license)", "Killer Instinct 2 (upgrade kit)", MACHINE_SUPPORTS_SAVE )
+GAME( 1994, kinst,    0,      kinst,    kinst,  kinst_state,    init_kinst,  ROT0,   "Rare / Nintendo (Midway license)", "Killer Instinct", MACHINE_SUPPORTS_SAVE )
+GAME( 1996, kinst2,   0,      kinst2,   kinst2, kinst_state,    init_kinst2, ROT0,   "Rare / Nintendo (Midway license)", "Killer Instinct 2", MACHINE_SUPPORTS_SAVE )
+GAME( 1996, kinst2uk, kinst2, kinst2uk, kinst2, kinst2uk_state, init_kinst2, ROT0,   "Rare / Nintendo (Midway license)", "Killer Instinct 2 (upgrade kit)", MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
Nintendo has co-copyright of games in these drivers, until Rare get copyright alone.
reference: https://flyers.arcade-museum.com/videogames/show/525