### PR TITLE
apple2gs: fix inconsistent clocks

### DIFF
--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -93,7 +93,8 @@ namespace {
 #define A2GS_MASTER_CLOCK (XTAL(28'636'363))
 #define A2GS_14M    (A2GS_MASTER_CLOCK/2)
 #define A2GS_7M     (A2GS_MASTER_CLOCK/4)
-#define A2GS_1M     (A2GS_MASTER_CLOCK/28)
+#define A2GS_2_8M   (A2GS_MASTER_CLOCK/10)
+#define A2GS_1M     (XTAL(1021800))
 
 #define A2GS_UPPERBANK_TAG "inhbank"
 #define A2GS_AUXUPPER_TAG "inhaux"
@@ -519,7 +520,7 @@ private:
 		}
 		else
 		{
-			m_maincpu->set_unscaled_clock(1021800);
+			m_maincpu->set_unscaled_clock(A2GS_1M);
 		}
 	}
 
@@ -539,11 +540,11 @@ private:
 
 		if (isfast)
 		{
-			m_maincpu->set_unscaled_clock(A2GS_14M/5);
+			m_maincpu->set_unscaled_clock(A2GS_2_8M);
 		}
 		else
 		{
-			m_maincpu->set_unscaled_clock(1021800);
+			m_maincpu->set_unscaled_clock(A2GS_1M);
 		}
 	}
 
@@ -847,7 +848,7 @@ void apple2gs_state::machine_reset()
 	m_slow_counter = 0;
 
 	// always assert full speed on reset
-	m_maincpu->set_unscaled_clock(A2GS_14M/5);
+	m_maincpu->set_unscaled_clock(A2GS_2_8M);
 	m_last_speed = true;
 
 	m_sndglu_ctrl = 0;
@@ -971,7 +972,7 @@ void apple2gs_state::update_speed()
 		}
 		else
 		{
-			m_maincpu->set_unscaled_clock(isfast ? A2GS_14M / 5 : A2GS_1M);
+			m_maincpu->set_unscaled_clock(isfast ? A2GS_2_8M : A2GS_1M);
 		}
 		m_last_speed = isfast;
 	}
@@ -3743,7 +3744,7 @@ INPUT_PORTS_END
 void apple2gs_state::apple2gs(machine_config &config)
 {
 	/* basic machine hardware */
-	G65816(config, m_maincpu, A2GS_MASTER_CLOCK/10);
+	G65816(config, m_maincpu, A2GS_2_8M);
 	m_maincpu->set_addrmap(AS_PROGRAM, &apple2gs_state::apple2gs_map);
 	m_maincpu->set_addrmap(g65816_device::AS_VECTORS, &apple2gs_state::vectors_map);
 	m_maincpu->set_dasm_override(FUNC(apple2gs_state::dasm_trampoline));
@@ -3811,7 +3812,7 @@ void apple2gs_state::apple2gs(machine_config &config)
 	ADDRESS_MAP_BANK(config, A2GS_C300_TAG).set_map(&apple2gs_state::c300bank_map).set_options(ENDIANNESS_LITTLE, 8, 32, 0x100);
 
 	/* serial */
-	SCC85C30(config, m_scc, A2GS_14M / 2);
+	SCC85C30(config, m_scc, A2GS_7M);
 	m_scc->configure_channels(3'686'400, 3'686'400, 3'686'400, 3'686'400);
 	m_scc->out_int_callback().set(FUNC(apple2gs_state::scc_irq_w));
 	m_scc->out_txda_callback().set("printer", FUNC(rs232_port_device::write_txd));
@@ -3842,7 +3843,7 @@ void apple2gs_state::apple2gs(machine_config &config)
 	A2BUS_SLOT(config, "sl6", A2GS_7M, m_a2bus, apple2gs_cards, nullptr);
 	A2BUS_SLOT(config, "sl7", A2GS_7M, m_a2bus, apple2gs_cards, nullptr);
 
-	IWM(config, m_iwm, A2GS_7M, A2GS_MASTER_CLOCK/14);
+	IWM(config, m_iwm, A2GS_7M, A2GS_1M*2);
 	m_iwm->phases_cb().set(FUNC(apple2gs_state::phases_w));
 	m_iwm->sel35_cb().set(FUNC(apple2gs_state::sel35_w));
 	m_iwm->devsel_cb().set(FUNC(apple2gs_state::devsel_w));


### PR DESCRIPTION
This commit fixes apple2gs to stop using two slightly different 1 MHz clocks:
* `1022727` used in [update_speed()](https://github.com/mamedev/mame/blob/dc9501e19c3626695253d6f16e993857d0893bf6/src/mame/apple/apple2gs.cpp#L974) and [IWM()](https://github.com/mamedev/mame/blob/dc9501e19c3626695253d6f16e993857d0893bf6/src/mame/apple/apple2gs.cpp#L3845)
* `1021800` used when [toggling the ZipGS](https://github.com/mamedev/mame/blob/dc9501e19c3626695253d6f16e993857d0893bf6/src/mame/apple/apple2gs.cpp#L546), and expected by the 262-line [video @ 60Hz](https://github.com/mamedev/mame/blob/dc9501e19c3626695253d6f16e993857d0893bf6/src/mame/apple/apple2gs.cpp#L3785)

Making the clocks consistent fixes the out-of-sync flickering/slowing rolling drift visible in some beam-racing demos, such as French Touch [CC65C02](http://fr3nch.t0uch.free.fr/CC/CC.html) or deater's [double](http://deater.net/weave/vmwprod/mode_switch/) (first part, the second part syncs to C019 instead) or [fancy lores](http://www.deater.net/weave/vmwprod/fancy_lores/).

More complicated intra-scanline beam racing (as used in the first two of those demos) still doesn't work (the 16 MHz screen timing has [no HBL](https://github.com/mamedev/mame/blob/dc9501e19c3626695253d6f16e993857d0893bf6/src/mame/apple/apple2gs.cpp#L3786) and 14 MHz cliprects are scaled weird and also [not honored](https://github.com/mamedev/mame/blob/dc9501e19c3626695253d6f16e993857d0893bf6/src/mame/apple/apple2video.cpp#L911)) but this is enough to make simple whole-scanline timing stable.


This change undoes part of 623e248 which [changed the IWM() Q3 clock](https://github.com/mamedev/mame/commit/623e248524a0ae8330606bbef108aa416b5cf85c#diff-15e0351827a2a52d6a094733f34a2e9600a495c56cd7fe87e6396052af857ec2L4811).  That change made it consistent with the old A2GS_1M; now it becomes consistent with the rest of the apple2 1021800 clocks.

Due to the ongoing disk corruption #14474, I ran a bunch of before/after testing on the IWM, with and without the ZipGS enabled:
```
                                                        Before 2.8 7 16 After 2.8 7 16
* Apple IIgs Diagnostic v3.1: Disk Port Test, 100 iterations     √ √ √          √ √ √
* Disk Muncher 2.0: copy DOS3.3 35-track disk to blank, boot it  √ √ √          √ √ √
* Apple II System Utilities 3.2: FastCopy & Compare ProDOS disk  √ √ √          √ √ √
* GSOS 6.0.4 Finder: initialize ProDOS blank, drag-copy disk     √ √ √          √ √ √
* XPS Diagnostic IIe 1.0.5: E) CPU G) DISK L) MEDIA              1 2 2          1 1 1

1: XPS shows the same errors before and after:
G) DISK SYSTEM shows SEEK errors
L) MEDIA VERIFY shows errors reading the last track
These errors don't occur in apple2ee with diskiing.  I don't have functional floppy disks to verify this against my IIgs hardware...

2: XPS shows disk corruption with the ZipGS:
G) READ errors in addition to SEEK
L) MEDIA VERIFY shows error with tracks 0, 33 and 34 (and then the disk was corrupt)
(corruption was intermittent but repeatable, running E) G) L) on fresh copies of the XPS disk.)
```
<img width="704" height="460" alt="apple2gs_Zip7_XPS_media" src="https://github.com/user-attachments/assets/5770d341-87fa-40f0-b4cc-b02362abbc09" />

Note that all of the typical user-facing tasks appear to succeed before this PR, including the long-running Disk Port Test! So whatever the timing problem is that causes corruption in XPS, it is subtle and intermittent.   Making the IWM Q3 clock consistent with the ZipGS 1 MHz temporary delay clock appears to fix (or at least, avoid) the problem.
