### PR TITLE
sound/cem3394.cpp: improved CEM3394 and adapted sente6vb to the changes.

### DIFF
--- a/src/devices/sound/cem3394.h
+++ b/src/devices/sound/cem3394.h
@@ -12,20 +12,29 @@ public:
 	// inputs
 	enum
 	{
-		VCO_FREQUENCY = 0,
+		AUDIO_INPUT = 0,  // not valid for set_voltage()
+		VCO_FREQUENCY,
 		MODULATION_AMOUNT,
 		WAVE_SELECT,
 		PULSE_WIDTH,
 		MIXER_BALANCE,
 		FILTER_RESONANCE,
 		FILTER_FREQENCY,
-		FINAL_GAIN
+		FINAL_GAIN,
+		INPUT_COUNT
 	};
 
-	cem3394_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+	cem3394_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0) ATTR_COLD;
 
-	void set_vco_zero_freq(double freq) { m_vco_zero_freq = freq; }
-	void set_filter_zero_freq(double freq) { m_filter_zero_freq = freq; }
+	// The constructor will initialize components values to those recommended
+	// in the datasheet. configure() can be used to change those.
+	// r_vco: Pin 1 - Resistor to VEE. Sets reference current for the VCO internals.
+	// c_vco: Pin 4 - VCO timing capacitor.
+	// c_vcf: Pin 12 (or 13, or 14, they should be equal) - VCF capacitor.
+	// c_ac: Pin 17 - AC-coupling capacitor on the VCF output.
+	cem3394_device &configure(double r_vco, double c_vco, double c_vcf, double c_ac) ATTR_COLD;
+
+	cem3394_device &configure_limit_pw(bool limit_pw) ATTR_COLD;
 
 protected:
 	// device-level overrides
@@ -38,6 +47,9 @@ public:
 	// Set the voltage going to a particular parameter
 	void set_voltage(int input, double voltage);
 
+	// Requesting a streaming voltage will force a stream update.
+	double get_voltage(int input);
+
 	// Get the translated parameter associated with the given input as follows:
 	//    VCO_FREQUENCY:      frequency in Hz
 	//    MODULATION_AMOUNT:  scale factor, 0.0 to 2.0
@@ -47,20 +59,30 @@ public:
 	//    FILTER_RESONANCE:   resonance, from 0.0 to 1.0
 	//    FILTER_FREQENCY:    frequency, in Hz
 	//    FINAL_GAIN:         gain, in dB
+	// Requesting a parameter associated with a streaming input will force a
+	// stream update.
 	double get_parameter(int input);
 
 private:
 	double compute_db(double voltage);
 	sound_stream::sample_t compute_db_volume(double voltage);
 
-private:
-	double filter(double input, double cutoff);
+	void set_voltage_internal(int input, double voltage);
 
+	double filter(double input, double cutoff);
+	double hpf(double input);
+
+	// device configuration, not needed in save state
 	sound_stream *m_stream;           // our stream
+	double m_inv_sample_rate;         // 1/current sample rate
 	double m_vco_zero_freq;           // frequency of VCO at 0.0V
 	double m_filter_zero_freq;        // frequency of filter at 0.0V
+	double m_hpf_k;                   // RC filter coefficient for AC coupling
+	bool m_limit_pw;                  // whether to clamp the pulse width.
 
-	double m_values[8];               // raw values of registers
+	// device state
+
+	double m_values[INPUT_COUNT];     // raw values of registers
 	u8 m_wave_select;                 // flags which waveforms are enabled
 
 	double m_volume;                  // linear overall volume (0-1)
@@ -78,7 +100,7 @@ private:
 
 	double m_pulse_width;             // fractional pulse width
 
-	double m_inv_sample_rate;         // 1/current sample rate
+	double m_hpf_mem;                 // AC coupling filter memory
 };
 
 DECLARE_DEVICE_TYPE(CEM3394, cem3394_device)

--- a/src/mame/midway/sente6vb.cpp
+++ b/src/mame/midway/sente6vb.cpp
@@ -55,10 +55,12 @@
 ***************************************************************************/
 
 #include "emu.h"
+#include "sound/flt_rc.h"
 #include "sound/mm5837.h"
 #include "sente6vb.h"
 #include "cpu/z80/z80.h"
 #include "machine/clock.h"
+#include "machine/rescap.h"
 #include "speaker.h"
 
 #define LOG_CEM_WRITES (1U << 1)
@@ -131,14 +133,18 @@ void sente6vb_device::device_add_mconfig(machine_config &config)
 	mm5837_stream_device &noise(MM5837_STREAM(config, "noise", 0));
 //  noise.set_vdd(-6.5);   // seems too low -- possible the mapping in mm5837 is wrong
 	noise.set_vdd(-8.0);
+	noise.add_route(ALL_OUTPUTS, "ac_noise", 1.0);
+
+	filter_rc_device &ac_noise(FILTER_RC(config, "ac_noise"));
+	ac_noise.set_rc(filter_rc_device::HIGHPASS, RES_K(68) + RES_K(1), 0, 0, CAP_U(2.2)); // R19, R20, C115
 
 	for (auto &cem_device : m_cem_device)
 	{
 		CEM3394(config, cem_device, 0);
-		cem_device->set_vco_zero_freq(431.894);
-		cem_device->set_filter_zero_freq(1300.0);
-		cem_device->add_route(ALL_OUTPUTS, "mono", 0.90);
-		noise.add_route(0, *cem_device, 0.5);
+		cem_device->configure(RES_K(301), CAP_U(0.002), CAP_U(0.033), CAP_U(10)); // R1, C1, C11, C3 on voice 0 (U1)
+		cem_device->configure_limit_pw(true);
+		cem_device->add_route(ALL_OUTPUTS, "mono", 0.50);
+		ac_noise.add_route(0, *cem_device, 1.0);
 	}
 }
 


### PR DESCRIPTION
Added and improved CEM3394 functionality relevant to the `sixtrak` while working on audio for that driver.

Sending as a separate PR to keep the scope manageable, given there are also changes to `sente6vb`.

Incidental improvements to `sente6vb`:
* Unlocked some sounds. An obvious one is the post-tuning chirp for each voice during boot.
* Centered audio around 0.

`sound/cem3394` changes:
* Made VCO output range [-1, 1], instead of [0, 1].
* Added pulse-width dependent DC level of pulse waveform, as described in the datasheet.
* Waveform selection logic now works for voltages outside the bounds provided in the datasheet.
  * Both the `sixtrak` and `sente6vb` will some times use voltages outside those ranges.
* Added AC coupling between VCF output and VCA input.
* Forcing parameter computation in `device_start()`.
* Added ability to stream voltage inputs. The `sixtrak` needs that for the VCA gain and VCF frequency.
* New configuration interface:
  * New `configure()` method computes VCO and VCF zero frequencies based on the attached passive components.
  * Exposed method for enabling pulse-width limiting for drivers that need it. Now disabled by default.
* Fixed compilation for FILTER_TYPE_ESQ1.

`midway/sente6vb` changes:
* Using new CEM3394 configuration interface.
  * Verified that it produces almost the same VCO and VCF zero frequencies.
* Reduced CEM3394->speaker gain to compensate for increased loudness of CEM3394
  * Old range: [0, 1] nominal. New range: ~[-1, 1] x 0.5 = ~[-0.5, 0.5] nominal (can be exceeded in some cases).
* Added AC coupling to noise output.
  * Also changed the noise->CEM3394 gain from 0.5 to 1.0, to keep relative loudness the same.
  * Old range: [0, 1] x 0.5 = [0, 0.5]. New range: [-0.5, 0.5] x 1