### PR TITLE
as_dsk.cpp: Fix size of FLUX chunk in MOOF files

### DIFF
--- a/src/lib/formats/as_dsk.cpp
+++ b/src/lib/formats/as_dsk.cpp
@@ -423,7 +423,7 @@ bool woz_format::save(util::random_read_write &io, const std::vector<uint32_t> &
 	auto [total_blocks, max_blocks] = count_blocks(tracks);
 	bool has_flux = test_flux(tracks);
 
-	std::vector<uint8_t> data(1536 + total_blocks*512 + (has_flux ? 512 : 0), 0);
+	std::vector<uint8_t> data(1536 + total_blocks*512 + (has_flux ? 168 : 0), 0);
 
 	memcpy(&data[0], signature2, 8);
 


### PR DESCRIPTION
The previous code allocated 512 bytes to accomodate a FLUX chunk if the resulting file has flux tracks, but the actual size of a FLUX chunk is 168 bytes (8 bytes header + 160 bytes chunk).

When MAME allocated 512 bytes, this left 344 zero-bytes padding in the file that other tools would interpret as invalid chunks.

See file format reference: https://applesaucefdc.com/moof-reference/