### PR TITLE
cpu/sharc.cpp: stall if looping until a flag input changes

### DIFF
--- a/src/devices/cpu/sharc/sharc.cpp
+++ b/src/devices/cpu/sharc/sharc.cpp
@@ -1076,6 +1076,8 @@ void adsp21062_device::execute_run()
 
 			m_core->opcode = m_program->read_qword(m_core->pc);
 
+			m_core->flag_stalled = false;
+
 			// handle looping
 			if (m_core->pc == m_core->laddr.addr)
 			{
@@ -1101,6 +1103,10 @@ void adsp21062_device::execute_run()
 					else
 					{
 						CHANGE_PC(TOP_PC());
+
+						// if a flag is causing us to loop, stall
+						if ((condition & 0xf) >= 0x9 && (condition & 0xf) <= 0xc)
+							m_core->flag_stalled = true;
 					}
 
 					m_core->astat = m_core->astat_old;

--- a/src/devices/cpu/sharc/sharc.h
+++ b/src/devices/cpu/sharc/sharc.h
@@ -378,6 +378,7 @@ private:
 		SHARC_DMA_OP dma_op[12];
 		uint32_t dma_status;
 		bool write_stalled;
+		bool flag_stalled;
 
 		int32_t interrupt_active;
 

--- a/src/devices/cpu/sharc/sharcops.hxx
+++ b/src/devices/cpu/sharc/sharcops.hxx
@@ -1850,6 +1850,10 @@ void adsp21062_device::sharcop_relative_jump()
 		else
 		{
 			CHANGE_PC(m_core->pc + util::sext(address, 24));
+
+			// if a flag is causing the instruction to jump to itself, eat the remaining cycles
+			if (address == 0 && (cond & 0xf) >= 0x9 && (cond & 0xf) <= 0xc)
+				eat_cycles(m_core->icount);
 		}
 	}
 }
@@ -2704,6 +2708,8 @@ void adsp21062_device::sharcop_push_pop_stacks()
 
 void adsp21062_device::sharcop_nop()
 {
+	if (m_core->flag_stalled)
+		eat_cycles(m_core->icount);
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
When emulating Sega Model 2, 2A and 2C, if the TGP or TGPx4 DSP tries to read data from the input FIFO buffer but it is empty, the Model 2 driver will halt the DSP, improving emulation performance since the DSP is no longer running cycles while waiting for data.

This is not quite as simple for the SHARC DSP on Model 2B since it uses input flags to report the status of the FIFO buffers; it does not try to read the input FIFO buffer until it has confirmed that it is not empty by setting up an infinite loop that runs until flag #0 is clear.

Most Model 2B games set up a loop that repeatedly executes a NOP with the condition that flag #0 must be clear before exiting the loop, for example:

```
02013E  DO (0x0002013F) UNTIL NOT FLAG0_IN
02013F  NOP
```

Virtua Striker instead has an instruction that jumps to itself if flag #0 is set:

```
020119  IF FLAG0_IN, JUMP (0x00020119)
```

For both cases I have made it so that the emulated SHARC eats the remaining cycles in its timeslice if a flag is causing a loop, since the flag state cannot change until the i960 is run which can only happen after the SHARC has finished its timeslice. For the former case, it only eats the remaining cycles if the looping instruction is a NOP to ensure that there can be no difference in results compared to letting the remaining cycles run.