### PR TITLE
mz2000_cass: New additions to software list and items promoted to fully/partially working (69 changes)

### DIFF
--- a/hash/mz2000_cass.xml
+++ b/hash/mz2000_cass.xml
@@ -937,7 +937,7 @@ CHECK SUM ERROR, boots with Z80 clock set at 3.2 MHz (80%)
 	</software>
 
 	<software name="sstreama" cloneof="sstream" supported="yes">
-		<description>Star Stream</description>
+		<description>Star Stream (Alt)</description>
 		<year>1983</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="usage" value="IPL" />


### PR DESCRIPTION
65 initial changes @ 11.11.2025:
- 9 non-working Hudson Soft games in WAV format now working. New working WAV files converted from MZT files (which do not work) on Gaming Alexandria, using DumpListEditor.
- 1 non-working game modified to partial support. No change to the file itself, just amended guidance notes on using it in line with other new partially working software added (see below).
- All 20 MZ-2000/MZ-2200 versions of Inufuto games, all working. MZT versions do not work but Inufuto site provides both MZT and WAV originals. WAV versions all work so used here.
- 35 new additions, all fully or partially working sourced from TOSEC repositories (largely from UnRenamed Files - Japanese Systems I). The vast majority of these are in the original format on TOSEC. A handful of MZTs are unconverted where these work. Most had MTI extensions but are WAV files. A small minority of non-working MZTs have been converted to WAV using DumpListEditor.

Any items marked partially supported have the same issue - software does not automatically run (Monitor) or show Ready prompt (BASIC) when tape loading completes, but removing the tape image triggers this, allowing the software to run. It is not clear if this is an issue with the emulation, an issue with these dumps or an issue with the original tapes or indeed a bug in the original machine. But this replication of ejecting the tape triggers the automatic end of loading process.

Much of this software requires MZ-1Z001 or MZ-1Z002 operating system loading first. The current tape dumps do not work but as these are in MZT format I have not replaced them with working conversions to WAV, to preserve the preferred format where already present in the software list.

I have however proposed a new mz2000_snap software list of dumps of software that does not work in original format (pull request 14429) and have included dumps of these there.

4 additional changes @ 12.11.2025:
- 3 additional clones - add working WAV versions of Star Stream, Vosque 2000 and Harvest (Color) ensuring non-working MZT versions are preserved.
- Change to compatability for Amateur Tennis - this is a mono only version (there is a separate colour only version on one of the games compilation disks in the proposed additions to mz2000_flop in pull request 14428).