### PR TITLE
mz80b_cass: 12 additions to software list

### DIFF
--- a/hash/mz80b_cass.xml
+++ b/hash/mz80b_cass.xml
@@ -51,7 +51,7 @@ CHECK SUM ERROR, boots with Z80 clock set at 3.2 MHz (80%)
 	</software>
 
 	<software name="sb5520a" cloneof="sb5520" supported="yes">
-		<description>BASIC SB-5520 (Alt)</description>
+		<description>BASIC SB-5520 (alt)</description>
 		<year>1981</year>
 		<publisher>Sharp</publisher>
 		<info name="usage" value="IPL" />
@@ -187,7 +187,7 @@ CHECK SUM ERROR, boots with Z80 clock set at 3.2 MHz (80%)
 	</software>
 
 	<software name="puckpucka" cloneof="puckpuck" supported="yes">
-		<description>Puck &amp; Puck (Alt)</description>
+		<description>Puck &amp; Puck (alt)</description>
 		<year>19??</year>
 		<publisher>K. Kuromusha</publisher>
 		<info name="usage" value="IPL" />
@@ -254,7 +254,7 @@ CHECK SUM ERROR, boots with Z80 clock set at 3.2 MHz (80%)
 	</software>
 
 	<software name="vosquea" cloneof="vosque" supported="yes">
-		<description>Vosque (Alt)</description>
+		<description>Vosque (alt)</description>
 		<year>19??</year>
 		<!-- TODO: from title, check spelling on tape cover -->
 		<publisher>d.B Soft</publisher>


### PR DESCRIPTION
12 additions to software list. This includes 3 working clones in WAV format of non-working MZT files (Vosque is already included in the software list, MZT and WAV versions of SB-5520 BASIC and Puck & Puck game are added). Working WAVs converted from MZT using DumpListEditor

All other additions originally in WAV format.

Any software items which require BASIC loading first require the cassette image to be removed before they will run. This issue occurs with some MZ-2000/MZ-2200 software too, so unclear if this is an emulation issue, issue with the dumps or an issue with the original tapes or hardware. These items are playable but marked partially supported due to this issue.

Notes added to the software list to provide guidance on loading methods (in line with similar notes in the mz2000_cass software list).

All files sourced from TOSEC repositories, either UnRenamed Japanese Systems I or Rocks Preserved Games. 