### PR TITLE
esq5505 Ensoniq VFX family layouts: Specify the bounds for each group.

### DIFF
--- a/src/mame/layout/sd1.lay
+++ b/src/mame/layout/sd1.lay
@@ -931,6 +931,7 @@
 
 	<!-- Group definitions -->
 	<group name="Sliders">
+		<bounds x="0" y="15" width="90" height="88.2" />
 		<element ref="triangle_down">
 			<bounds x="52.5" y="55" width="5" height="2.5" />
 		</element>
@@ -964,6 +965,7 @@
 		</group>
 	</group>
 	<group name="DisplayAndButtons">
+		<bounds x="0" y="8" width="245" height="95.2" />
 		<element ref="rect_glass">
 			<bounds x="0" y="8" width="245" height="67.5" />
 		</element>
@@ -1116,6 +1118,7 @@
 		</element>
 	</group>
 	<group name="Buttons">
+		<bounds x="0" y="8.2" width="180" height="95.0" />
 		<element ref="rect_white">
 			<bounds x="15" y="75.5" width="7.5" height="0.25" />
 		</element>
@@ -1442,6 +1445,7 @@
 		</element>
 	</group>
 	<group name="BackPanel">
+		<bounds x="0" y="0" width="845" height="32" />
 		<element ref="rect_body">
 			<bounds x="0" y="0" width="845" height="32" />
 		</element>
@@ -1516,6 +1520,7 @@
 		</element>
 	</group>
 	<group name="WheelArea">
+		<bounds x="0" y="0" width="108" height="122" />
 		<element ref="rect_panel">
 			<bounds x="0" y="0" width="108" height="122" />
 		</element>
@@ -1564,6 +1569,7 @@
 		</group>
 	</group>
 	<group name="full_keyboard">
+		<bounds x="0.0" y="0" width="845.0" height="138" />
 		<element ref="full_keyboard_background" id="full_keyboard_background">
 			<bounds x="0" y="0" width="845" height="138" />
 			<color red="0.33333" green="0.33333" blue="0.33333" />
@@ -2058,6 +2064,7 @@
 		</element>
 	</group>
 	<group name="NarrowWheelArea">
+		<bounds x="0" y="0" width="86" height="122" />
 		<element ref="rect_panel">
 			<bounds x="0" y="0" width="86" height="122" />
 		</element>
@@ -2106,6 +2113,7 @@
 		</group>
 	</group>
 	<group name="playable_keyboard">
+		<bounds x="0.0" y="0" width="516.0" height="138" />
 		<element ref="playable_keyboard_background" id="playable_keyboard_background">
 			<bounds x="0" y="0" width="516" height="138" />
 			<color red="0.33333" green="0.33333" blue="0.33333" />
@@ -2408,6 +2416,7 @@
 		</element>
 	</group>
 	<group name="CompactVolumeSlider">
+		<bounds x="0" y="15" width="35" height="88.2" />
 		<element ref="rect_sd1">
 			<bounds x="0" y="102" width="30" height="1.2" />
 		</element>
@@ -2421,6 +2430,7 @@
 		</group>
 	</group>
 	<group name="PatchSelects">
+		<bounds x="0" y="55" width="40" height="48.2" />
 		<element ref="rect_sd1">
 			<bounds x="0" y="102" width="40" height="1.2" />
 		</element>
@@ -2435,6 +2445,7 @@
 		</element>
 	</group>
 	<group name="CompactValueSlider">
+		<bounds x="0" y="15" width="63.0" height="88.2" />
 		<element ref="triangle_down">
 			<bounds x="5" y="55" width="5" height="2.5" />
 		</element>

--- a/src/mame/layout/sd132.lay
+++ b/src/mame/layout/sd132.lay
@@ -934,6 +934,7 @@
 
 	<!-- Group definitions -->
 	<group name="Sliders">
+		<bounds x="0" y="15" width="90" height="88.2" />
 		<element ref="triangle_down">
 			<bounds x="52.5" y="55" width="5" height="2.5" />
 		</element>
@@ -967,6 +968,7 @@
 		</group>
 	</group>
 	<group name="DisplayAndButtons">
+		<bounds x="0" y="8" width="245" height="95.2" />
 		<element ref="rect_glass">
 			<bounds x="0" y="8" width="245" height="67.5" />
 		</element>
@@ -1119,6 +1121,7 @@
 		</element>
 	</group>
 	<group name="Buttons">
+		<bounds x="0" y="8.2" width="180" height="95.0" />
 		<element ref="rect_white">
 			<bounds x="15" y="75.5" width="7.5" height="0.25" />
 		</element>
@@ -1445,6 +1448,7 @@
 		</element>
 	</group>
 	<group name="BackPanel">
+		<bounds x="0" y="0" width="845" height="32" />
 		<element ref="rect_body">
 			<bounds x="0" y="0" width="845" height="32" />
 		</element>
@@ -1519,6 +1523,7 @@
 		</element>
 	</group>
 	<group name="WheelArea">
+		<bounds x="0" y="0" width="108" height="122" />
 		<element ref="rect_panel">
 			<bounds x="0" y="0" width="108" height="122" />
 		</element>
@@ -1567,6 +1572,7 @@
 		</group>
 	</group>
 	<group name="full_keyboard">
+		<bounds x="0.0" y="0" width="845.0" height="138" />
 		<element ref="full_keyboard_background" id="full_keyboard_background">
 			<bounds x="0" y="0" width="845" height="138" />
 			<color red="0.33333" green="0.33333" blue="0.33333" />
@@ -2061,6 +2067,7 @@
 		</element>
 	</group>
 	<group name="NarrowWheelArea">
+		<bounds x="0" y="0" width="86" height="122" />
 		<element ref="rect_panel">
 			<bounds x="0" y="0" width="86" height="122" />
 		</element>
@@ -2109,6 +2116,7 @@
 		</group>
 	</group>
 	<group name="playable_keyboard">
+		<bounds x="0.0" y="0" width="516.0" height="138" />
 		<element ref="playable_keyboard_background" id="playable_keyboard_background">
 			<bounds x="0" y="0" width="516" height="138" />
 			<color red="0.33333" green="0.33333" blue="0.33333" />
@@ -2411,6 +2419,7 @@
 		</element>
 	</group>
 	<group name="CompactVolumeSlider">
+		<bounds x="0" y="15" width="35" height="88.2" />
 		<element ref="rect_sd1">
 			<bounds x="0" y="102" width="30" height="1.2" />
 		</element>
@@ -2424,6 +2433,7 @@
 		</group>
 	</group>
 	<group name="PatchSelects">
+		<bounds x="0" y="55" width="40" height="48.2" />
 		<element ref="rect_sd1">
 			<bounds x="0" y="102" width="40" height="1.2" />
 		</element>
@@ -2438,6 +2448,7 @@
 		</element>
 	</group>
 	<group name="CompactValueSlider">
+		<bounds x="0" y="15" width="63.0" height="88.2" />
 		<element ref="triangle_down">
 			<bounds x="5" y="55" width="5" height="2.5" />
 		</element>

--- a/src/mame/layout/vfx.lay
+++ b/src/mame/layout/vfx.lay
@@ -851,6 +851,7 @@
 
 	<!-- Group definitions -->
 	<group name="Sliders">
+		<bounds x="0" y="15" width="90" height="88.2" />
 		<element ref="triangle_down">
 			<bounds x="52.5" y="55" width="5" height="2.5" />
 		</element>
@@ -884,6 +885,7 @@
 		</group>
 	</group>
 	<group name="DisplayAndButtons">
+		<bounds x="0" y="8" width="245" height="95.2" />
 		<element ref="rect_glass">
 			<bounds x="0" y="8" width="245" height="67.5" />
 		</element>
@@ -1030,6 +1032,7 @@
 		</element>
 	</group>
 	<group name="Buttons">
+		<bounds x="0" y="8.2" width="180" height="95.0" />
 		<element ref="rect_white">
 			<bounds x="15" y="75.5" width="10" height="0.1" />
 		</element>
@@ -1281,6 +1284,7 @@
 		</element>
 	</group>
 	<group name="BackPanel">
+		<bounds x="0" y="0" width="845" height="32" />
 		<element ref="rect_body">
 			<bounds x="0" y="0" width="845" height="32" />
 		</element>
@@ -1340,6 +1344,7 @@
 		</element>
 	</group>
 	<group name="WheelArea">
+		<bounds x="0" y="0" width="108" height="122" />
 		<element ref="rect_panel">
 			<bounds x="0" y="0" width="108" height="122" />
 		</element>
@@ -1388,6 +1393,7 @@
 		</group>
 	</group>
 	<group name="full_keyboard">
+		<bounds x="0.0" y="0" width="845.0" height="138" />
 		<element ref="full_keyboard_background" id="full_keyboard_background">
 			<bounds x="0" y="0" width="845" height="138" />
 			<color red="0.33333" green="0.33333" blue="0.33333" />
@@ -1882,6 +1888,7 @@
 		</element>
 	</group>
 	<group name="NarrowWheelArea">
+		<bounds x="0" y="0" width="86" height="122" />
 		<element ref="rect_panel">
 			<bounds x="0" y="0" width="86" height="122" />
 		</element>
@@ -1930,6 +1937,7 @@
 		</group>
 	</group>
 	<group name="playable_keyboard">
+		<bounds x="0.0" y="0" width="516.0" height="138" />
 		<element ref="playable_keyboard_background" id="playable_keyboard_background">
 			<bounds x="0" y="0" width="516" height="138" />
 			<color red="0.33333" green="0.33333" blue="0.33333" />
@@ -2232,6 +2240,7 @@
 		</element>
 	</group>
 	<group name="CompactVolumeSlider">
+		<bounds x="0" y="15" width="35" height="88.2" />
 		<element ref="rect_vfx">
 			<bounds x="0" y="102" width="30" height="1.2" />
 		</element>
@@ -2245,6 +2254,7 @@
 		</group>
 	</group>
 	<group name="PatchSelects">
+		<bounds x="0" y="55" width="40" height="48.2" />
 		<element ref="rect_vfx">
 			<bounds x="0" y="102" width="40" height="1.2" />
 		</element>
@@ -2259,6 +2269,7 @@
 		</element>
 	</group>
 	<group name="CompactValueSlider">
+		<bounds x="0" y="15" width="63.0" height="88.2" />
 		<element ref="triangle_down">
 			<bounds x="5" y="55" width="5" height="2.5" />
 		</element>

--- a/src/mame/layout/vfxsd.lay
+++ b/src/mame/layout/vfxsd.lay
@@ -931,6 +931,7 @@
 
 	<!-- Group definitions -->
 	<group name="Sliders">
+		<bounds x="0" y="15" width="90" height="88.2" />
 		<element ref="triangle_down">
 			<bounds x="52.5" y="55" width="5" height="2.5" />
 		</element>
@@ -964,6 +965,7 @@
 		</group>
 	</group>
 	<group name="DisplayAndButtons">
+		<bounds x="0" y="8" width="245" height="95.2" />
 		<element ref="rect_glass">
 			<bounds x="0" y="8" width="245" height="67.5" />
 		</element>
@@ -1116,6 +1118,7 @@
 		</element>
 	</group>
 	<group name="Buttons">
+		<bounds x="0" y="8.2" width="180" height="95.0" />
 		<element ref="rect_white">
 			<bounds x="15" y="75.5" width="7.5" height="0.25" />
 		</element>
@@ -1442,6 +1445,7 @@
 		</element>
 	</group>
 	<group name="BackPanel">
+		<bounds x="0" y="0" width="845" height="32" />
 		<element ref="rect_body">
 			<bounds x="0" y="0" width="845" height="32" />
 		</element>
@@ -1516,6 +1520,7 @@
 		</element>
 	</group>
 	<group name="WheelArea">
+		<bounds x="0" y="0" width="108" height="122" />
 		<element ref="rect_panel">
 			<bounds x="0" y="0" width="108" height="122" />
 		</element>
@@ -1564,6 +1569,7 @@
 		</group>
 	</group>
 	<group name="full_keyboard">
+		<bounds x="0.0" y="0" width="845.0" height="138" />
 		<element ref="full_keyboard_background" id="full_keyboard_background">
 			<bounds x="0" y="0" width="845" height="138" />
 			<color red="0.33333" green="0.33333" blue="0.33333" />
@@ -2058,6 +2064,7 @@
 		</element>
 	</group>
 	<group name="NarrowWheelArea">
+		<bounds x="0" y="0" width="86" height="122" />
 		<element ref="rect_panel">
 			<bounds x="0" y="0" width="86" height="122" />
 		</element>
@@ -2106,6 +2113,7 @@
 		</group>
 	</group>
 	<group name="playable_keyboard">
+		<bounds x="0.0" y="0" width="516.0" height="138" />
 		<element ref="playable_keyboard_background" id="playable_keyboard_background">
 			<bounds x="0" y="0" width="516" height="138" />
 			<color red="0.33333" green="0.33333" blue="0.33333" />
@@ -2408,6 +2416,7 @@
 		</element>
 	</group>
 	<group name="CompactVolumeSlider">
+		<bounds x="0" y="15" width="35" height="88.2" />
 		<element ref="rect_vfx">
 			<bounds x="0" y="102" width="30" height="1.2" />
 		</element>
@@ -2421,6 +2430,7 @@
 		</group>
 	</group>
 	<group name="PatchSelects">
+		<bounds x="0" y="55" width="40" height="48.2" />
 		<element ref="rect_vfx">
 			<bounds x="0" y="102" width="40" height="1.2" />
 		</element>
@@ -2435,6 +2445,7 @@
 		</element>
 	</group>
 	<group name="CompactValueSlider">
+		<bounds x="0" y="15" width="63.0" height="88.2" />
 		<element ref="triangle_down">
 			<bounds x="5" y="55" width="5" height="2.5" />
 		</element>


### PR DESCRIPTION
Specify the bounds for each group in the Ensoniq VFX family layouts.

This fixes an issue where the VFX (non-SD)'s button area is stretched vertically, because it does not have the "System" label at the top, leaving an empty space that was not included in the bounds calculation. This resulted in the button area being stretched vertically to fill the space, and the buttons being taller than they should.

Before:
<img width="3500" height="1286" alt="Screenshot From 2025-11-13 16-12-58" src="https://github.com/user-attachments/assets/bc7d7934-0193-4bdc-a1b9-07c66148a9eb" />
<img width="3500" height="796" alt="Screenshot From 2025-11-13 16-16-22" src="https://github.com/user-attachments/assets/26bfce92-c034-4dc7-a630-44048c4c8caf" />

After:
<img width="3500" height="1286" alt="Screenshot From 2025-11-13 16-12-22" src="https://github.com/user-attachments/assets/ab78f4d8-36d4-4d4d-8257-0321681198be" />
<img width="3500" height="796" alt="Screenshot From 2025-11-13 16-16-00" src="https://github.com/user-attachments/assets/4acd8b01-7cc3-477d-bbab-a5e24ef5692f" />
