### PR TITLE
sharp/mz700.cpp: Enable mz700_cass software list for Sharp MZ-800

### DIFF
--- a/src/mame/sharp/mz700.cpp
+++ b/src/mame/sharp/mz700.cpp
@@ -428,7 +428,7 @@ void mz800_state::mz800(machine_config &config)
 
 	config.device_remove("cass_list");
 	SOFTWARE_LIST(config, "cass_list").set_original("mz800_cass");
-	SOFTWARE_LIST(config, "cass_list_700").set_original("mz700_cass");
+	SOFTWARE_LIST(config, "cass_list_700").set_compatible("mz700_cass");
 
 	/* devices */
 	m_pit->set_clk<0>(XTAL(17'734'470)/16);


### PR DESCRIPTION
As Sharp MZ-800 is fully backwards compatible with MZ-700, change enables mz700_cass as a compatible software list for MZ-800.

This avoids duplication in the mz800_cass software list, particularly of software that functions better on MZ-800 but is also MZ-700 compatible (and may over time, with fuller emulation of MZ-700 capabilities such as PCG run consistency on both machines).