### PR TITLE
Add translations for the Quit menu

### DIFF
--- a/language/Afrikaans/strings.po
+++ b/language/Afrikaans/strings.po
@@ -1658,13 +1658,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Albanian/strings.po
+++ b/language/Albanian/strings.po
@@ -1658,13 +1658,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Arabic/strings.po
+++ b/language/Arabic/strings.po
@@ -1658,13 +1658,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Basque/strings.po
+++ b/language/Basque/strings.po
@@ -1659,13 +1659,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Belarusian/strings.po
+++ b/language/Belarusian/strings.po
@@ -1714,18 +1714,23 @@ msgstr " (па змаўчанні)"
 msgid "No plugins found"
 msgstr "Плагіны не знойдзены"
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Вы сапраўды жадаеце выйсці?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Вы сапраўды жадаеце выйсці?\n"
-"\n"
-"Націсніце %1$s, каб выйсці\n"
-"Націсніце %2$s, каб вярнуцца да эмуляцыі"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Bosnian/strings.po
+++ b/language/Bosnian/strings.po
@@ -1658,13 +1658,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Bulgarian/strings.po
+++ b/language/Bulgarian/strings.po
@@ -1660,13 +1660,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Burmese/strings.po
+++ b/language/Burmese/strings.po
@@ -1658,13 +1658,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Catalan/strings.po
+++ b/language/Catalan/strings.po
@@ -1688,13 +1688,22 @@ msgstr " (per defecte)"
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Chinese_Simplified/strings.po
+++ b/language/Chinese_Simplified/strings.po
@@ -1702,18 +1702,23 @@ msgstr " (默认)"
 msgid "No plugins found"
 msgstr "未找到插件"
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "确定要退出吗？"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"确定要退出吗？\n"
-"\n"
-"按 %1$s 退出\n"
-"按 %2$s 继续模拟"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Chinese_Traditional/strings.po
+++ b/language/Chinese_Traditional/strings.po
@@ -1702,18 +1702,23 @@ msgstr " (預設)"
 msgid "No plugins found"
 msgstr "未找到外掛"
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "確定要退出嗎？"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"確定要退出嗎？\n"
-"\n"
-"按 %1$s 退出 \n"
-"按 %2$s 繼續模擬"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Croatian/strings.po
+++ b/language/Croatian/strings.po
@@ -1660,13 +1660,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Czech/strings.po
+++ b/language/Czech/strings.po
@@ -1713,18 +1713,23 @@ msgstr " (původní)"
 msgid "No plugins found"
 msgstr "Nenalezeny žádné pluginy"
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Jste si jistý, že chcete skončit?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Jste si jistý, že chcete skončit?\n"
-"\n"
-"Stiskněte %1$s pro ukončení\n"
-"Nebo %2$s pro návrat do emulace"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Danish/strings.po
+++ b/language/Danish/strings.po
@@ -1660,13 +1660,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Dutch/strings.po
+++ b/language/Dutch/strings.po
@@ -1698,18 +1698,23 @@ msgstr " (standaard)"
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Weet u zeker dat u wilt stoppen?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Weet u zeker dat u wilt stoppen?\n"
-"\n"
-"Druk op %1$s om te stoppen\n"
-"druk op %2$s om terug te keren naar de emulatie"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1659,13 +1659,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Estonian/strings.po
+++ b/language/Estonian/strings.po
@@ -1659,13 +1659,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Finnish/strings.po
+++ b/language/Finnish/strings.po
@@ -1660,13 +1660,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/French/strings.po
+++ b/language/French/strings.po
@@ -1701,18 +1701,23 @@ msgstr " (par défaut)"
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Êtes-vous certain de vouloir quitter ?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Êtes-vous certain de vouloir quitter ?\n"
-"\n"
-"Appuyez sur %1$s pour quitter\n"
-"Appuyez sur %2$s pour retourner à l'émulation"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/French_Belgium/strings.po
+++ b/language/French_Belgium/strings.po
@@ -1700,18 +1700,23 @@ msgstr " (par défaut)"
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Êtes-vous certain de vouloir quitter ?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Êtes-vous certain de vouloir quitter ?\n"
-"\n"
-"Appuyez sur %1$s pour quitter\n"
-"Appuyez sur %2$s pour retourner à l'émulation"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/French_Canada/strings.po
+++ b/language/French_Canada/strings.po
@@ -1660,13 +1660,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Georgian/strings.po
+++ b/language/Georgian/strings.po
@@ -1658,13 +1658,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -1716,18 +1716,23 @@ msgstr " (Standard)"
 msgid "No plugins found"
 msgstr "Keine Erweiterungen gefunden"
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Sind Sie sicher, dass Sie die Emulation verlassen wollen?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Sind Sie sicher, dass Sie die Emulation verlassen wollen?\n"
-"\n"
-"Zum Beenden drücken Sie %1$s\n"
-"Um zur Emulation zurückzukehren drücken Sie %2$s"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Greek/strings.po
+++ b/language/Greek/strings.po
@@ -1715,18 +1715,23 @@ msgstr " (προεπιλογή)"
 msgid "No plugins found"
 msgstr "Δε βρέθηκαν πρόσθετα"
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Είστε βέβαιοι ότι θέλετε να εγκαταλείψετε;"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Είστε βέβαιοι ότι θέλετε να εγκαταλείψετε;\n"
-"\n"
-"Πατήστε %1$s για να εγκαταλείψετε\n"
-"Πατήστε %2$s για να επιστρέψετε στην εξομοίωση"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Hebrew/strings.po
+++ b/language/Hebrew/strings.po
@@ -1659,13 +1659,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Hindi/strings.po
+++ b/language/Hindi/strings.po
@@ -1658,13 +1658,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Hungarian/strings.po
+++ b/language/Hungarian/strings.po
@@ -1684,13 +1684,22 @@ msgstr " (alap)"
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Indonesian/strings.po
+++ b/language/Indonesian/strings.po
@@ -1659,13 +1659,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Italian/strings.po
+++ b/language/Italian/strings.po
@@ -1693,18 +1693,23 @@ msgstr " (predefinito)"
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Sei sicuro di voler uscire?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Sei sicuro di voler uscire?\n"
-"\n"
-"Premi %1$s per uscire\n"
-"Premi %2$s per contrinuare l'emulazione"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Korean/strings.po
+++ b/language/Korean/strings.po
@@ -1682,18 +1682,23 @@ msgstr " (기본)"
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "정말로 종료하겠습니까?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"정말로 종료하겠습니까?\n"
-"\n"
-"%1$s를 누르면 종료\n"
-"%2$s를 누르면 원래 화면으로 복귀"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Latvian/strings.po
+++ b/language/Latvian/strings.po
@@ -1660,13 +1660,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Lithuanian/strings.po
+++ b/language/Lithuanian/strings.po
@@ -1660,13 +1660,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Macedonian/strings.po
+++ b/language/Macedonian/strings.po
@@ -1658,13 +1658,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Norwegian/strings.po
+++ b/language/Norwegian/strings.po
@@ -1682,18 +1682,23 @@ msgstr " (standard)"
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Er du sikker på at du vil avslutte?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Er du sikker på at du vil avslutte?\n"
-"\n"
-"Trykk %1$s for å avslutte\n"
-"Trykk %2$s for å gå tilbake til emuleringen"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Persian/strings.po
+++ b/language/Persian/strings.po
@@ -1658,13 +1658,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Polish/strings.po
+++ b/language/Polish/strings.po
@@ -1714,18 +1714,23 @@ msgstr " (domyślny)"
 msgid "No plugins found"
 msgstr "Nie znaleziono wtyczek"
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Czy na pewno chcesz wyjść?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Czy na pewno chcesz wyjść?\n"
-"\n"
-"Naciśnij %1$s, aby wyjść\n"
-"Naciśnij %2$s, aby wrócić do emulacji"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Portuguese/strings.po
+++ b/language/Portuguese/strings.po
@@ -1694,18 +1694,23 @@ msgstr "(padrão)"
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Tem a certeza que deseja sair?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Tem a certeza que deseja sair?\n"
-"\n"
-"Pressione %1$s para sair\n"
-"Pressione %2$s para voltar à emulação"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Portuguese_Brazil/strings.po
+++ b/language/Portuguese_Brazil/strings.po
@@ -1718,18 +1718,23 @@ msgstr " (padrão)"
 msgid "No plugins found"
 msgstr "Não foram achados plugins"
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Você tem certeza que você quer sair?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Você tem certeza que você quer sair?\n"
-"\n"
-"Pressione '%1$s' pra sair,\n"
-"Pressione '%2$s' pra retornar pra emulação"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Romanian/strings.po
+++ b/language/Romanian/strings.po
@@ -1661,13 +1661,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Russian/strings.po
+++ b/language/Russian/strings.po
@@ -1714,18 +1714,23 @@ msgstr " (по-умолчанию)"
 msgid "No plugins found"
 msgstr "Плагины не найдены"
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Вы действительно хотите выйти?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Вы действительно хотите выйти?\n"
-"\n"
-"Нажмите %1$s для выхода\n"
-"Нажмите %2$s для возврата к эмуляции"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Serbian/strings.po
+++ b/language/Serbian/strings.po
@@ -1685,18 +1685,23 @@ msgstr " (uobičajeno)"
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Da li ste sigurni da želite da napustite program?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Da li ste sigurni da želite da napustite program?\n"
-"\n"
-"Pritisnite %1$s za napuštaǌe programa\n"
-"Pritisnite %2$s za nastavak emulacije"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Serbian_Cyrillic/strings.po
+++ b/language/Serbian_Cyrillic/strings.po
@@ -1685,18 +1685,23 @@ msgstr " (уобичајено)"
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Да ли сте сигурни да желите да напустите програм?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Да ли сте сигурни да желите да напустите програм?\n"
-"\n"
-"Притисните %1$s за напуштање програма\n"
-"Притисните %2$s за наставак емулације"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Slovak/strings.po
+++ b/language/Slovak/strings.po
@@ -1714,18 +1714,23 @@ msgstr " (pôvodné)"
 msgid "No plugins found"
 msgstr "Neboli nájdené žiadne pluginy"
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Ste si istý, že chcete skončiť?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Ste si istý, že chcete skončiť?\n"
-"\n"
-"Stlačte %1$s pre ukončenie\n"
-"Alebo %2$s pre návrat do emulácie"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Slovenian/strings.po
+++ b/language/Slovenian/strings.po
@@ -1661,13 +1661,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Spanish/strings.po
+++ b/language/Spanish/strings.po
@@ -1699,18 +1699,23 @@ msgstr " (predeterminado)"
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "¿Seguro que quieres salir?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"¿Seguro que quieres salir?\n"
-"\n"
-"Presiona %1$s para salir\n"
-"Presiona %2$s para volver al emulador"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Spanish_Mexico/strings.po
+++ b/language/Spanish_Mexico/strings.po
@@ -1660,13 +1660,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Thai/strings.po
+++ b/language/Thai/strings.po
@@ -1658,13 +1658,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22

--- a/language/Turkish/strings.po
+++ b/language/Turkish/strings.po
@@ -1709,18 +1709,23 @@ msgstr " (varsayılan)"
 msgid "No plugins found"
 msgstr "Eklenti bulunamadı"
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Çıkmak istediğinize emin misiniz?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Çıkmak istediğinize emin misiniz?\n"
-"\n"
-"Çıkmak için %1$s'e basın\n"
-"Dönmek için %2$s'e basın"
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Ukrainian/strings.po
+++ b/language/Ukrainian/strings.po
@@ -1706,18 +1706,23 @@ msgstr " (типово)"
 msgid "No plugins found"
 msgstr "Не знайдено плаґінів."
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr "Вийти?"
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
 msgstr ""
-"Вийти?\n"
-"\n"
-"%1$s - вихід.\n"
-"%2$s - повернення до емуляції."
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
+msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22
 msgid "Pseudo Terminals"

--- a/language/Vietnamese/strings.po
+++ b/language/Vietnamese/strings.po
@@ -1659,13 +1659,22 @@ msgstr ""
 msgid "No plugins found"
 msgstr ""
 
-#: src/frontend/mame/ui/quitmenu.cpp:37
+#: src/frontend/mame/ui/quitmenu.cpp:24
 #, c-format
-msgid ""
-"Are you sure you want to quit?\n"
-"\n"
-"Press %1$s to quit\n"
-"Press %2$s to return to emulation"
+msgctxt "menu-quit"
+msgid "Are you sure you want to quit?"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:35
+#, c-format
+msgctxt "menu-quit"
+msgid "Quit"
+msgstr ""
+
+#: src/frontend/mame/ui/quitmenu.cpp:36
+#, c-format
+msgctxt "menu-quit"
+msgid "Return to emulation"
 msgstr ""
 
 #: src/frontend/mame/ui/info_pty.cpp:22


### PR DESCRIPTION
Previous translations for "Are you sure you want to quit?" were moved over.  Text for "Press X to quit" and "Press Y to return to emulation" were removed, since the new wording is simply "Quit" and "Return to emulation" and wouldn't translate exactly.  Swedish and Japanese had already been converted, hence not included in this commit.