### PR TITLE
rendlay.cpp: Improve accuracy and performance calculating text aspect ratio.

### DIFF
--- a/docs/source/techspecs/layout_files.rst
+++ b/docs/source/techspecs/layout_files.rst
@@ -512,9 +512,10 @@ text
     Draws text in using the UI font in the specified colour.  The text to draw
     must be supplied using a ``string`` attribute.  An ``align`` attribute may
     be supplied to set text alignment.  If present, the ``align`` attribute must
-    be an integer, where 0 (zero) means centred, 1 (one) means left-aligned, and
-    2 (two) means right-aligned.  If the ``align`` attribute is absent, the text
-    will be centred.
+    be an integer, where 0 (zero) means centred, 1 (one) means left-aligned,
+    2 (two) means right-aligned, and 3 (three) means that the text will be
+    stretched horizontally to fill its bounds. If the ``align`` attribute is
+    absent, the text will be centred.
 led7seg
     Draws a standard seven-segment (plus decimal point) digital LED/fluorescent
     display in the specified colour.  The low eight bits of the element’s state

--- a/scripts/build/complay.py
+++ b/scripts/build/complay.py
@@ -452,7 +452,7 @@ class LayoutChecker(Minifyer):
             if 'string' not in attrs:
                 self.handle_error('Element text missing attribute string')
             align = self.check_int_attribute(name, attrs, 'align', None)
-            if (align is not None) and ((0 > align) or (2 < align)):
+            if (align is not None) and ((0 > align) or (3 < align)):
                 self.handle_error('Element text attribute align "%s" not in valid range 0-2' % (attrs['align'], ))
             self.check_component(name, attrs)
         elif 'simplecounter' == name:

--- a/src/emu/rendlay.cpp
+++ b/src/emu/rendlay.cpp
@@ -3219,16 +3219,8 @@ protected:
 					bitmap_argb32 tempbitmap(dest.width(), dest.height());
 
 					// get the width of the string
-					float aspect = 1.0f;
-					s32 width;
-
-					while (1)
-					{
-						width = font->string_width(ourheight / num_shown, aspect, m_stopnames[fruit]);
-						if (width < bounds.width())
-							break;
-						aspect *= 0.95f;
-					}
+					s32 width = font->string_width(ourheight / num_shown, 1.0f, m_stopnames[fruit]);
+					float aspect = width > bounds.width() ? (float) bounds.width() / (float) width : 1.0f;
 
 					float curx = bounds.left() + (bounds.width() - width) / 2.0f;
 
@@ -3368,15 +3360,8 @@ private:
 				else // render text (fallback)
 				{
 					// get the width of the string
-					float aspect = 1.0f;
-					s32 width;
-					while (1)
-					{
-						width = font->string_width(dest.height(), aspect, m_stopnames[fruit]);
-						if (width < bounds.width())
-							break;
-						aspect *= 0.95f;
-					}
+					s32 width = font->string_width(dest.height(), 1.0f, m_stopnames[fruit]);
+					float aspect = width > bounds.width() ? (float) bounds.width() / (float) width : 1.0f;
 
 					float curx = bounds.left();
 
@@ -3716,16 +3701,8 @@ void layout_element::component::draw_text(
 		const render_color &color)
 {
 	// get the width of the string
-	float aspect = 1.0f;
-	s32 width;
-
-	while (1)
-	{
-		width = font.string_width(bounds.height(), aspect, str);
-		if (width < bounds.width())
-			break;
-		aspect *= 0.95f;
-	}
+	s32 width = font.string_width(bounds.height(), 1.0f, str);
+	float aspect = (align == 3 || width > bounds.width()) ? (float) bounds.width() / (float) width : 1.0f;
 
 	// get alignment
 	float curx;
@@ -3739,6 +3716,11 @@ void layout_element::component::draw_text(
 		// right
 		case 2:
 			curx = bounds.right() - width;
+			break;
+		
+		// stretch
+		case 3:
+			curx = bounds.left();
 			break;
 
 		// default to center

--- a/src/mame/layout/sd1.lay
+++ b/src/mame/layout/sd1.lay
@@ -468,23 +468,21 @@
 	<element name="text_L_phones">
 		<text string="Phones" align="1" />
 	</element>
-	<element name="text_L_music_production_synthesizer">
-		<text string="MUSIC PRODUCTION SYNTHESIZER" align="1" />
+	<element name="text_S_music_production_synthesizer">
+		<text string="MUSIC PRODUCTION SYNTHESIZER" align="3" />
 	</element>
-	<element name="text_ensoniq">
-		<text string="ensoniq" />
+	<element name="text_S_ensoniq">
+		<text string="ensoniq" align="3" />
 	</element>
-	<element name="text_L_sd_1">
-		<text string="SD-1" align="1" />
+	<element name="text_S_sd_1">
+		<text string="SD-1" align="3" />
 	</element>
 	<element name="text_L_patch_select">
 		<text string="Patch Select" align="1" />
 	</element>
 
 	<element name="plugin_warning" defstate="1">
-		<rect state="1">
-			<color red="0.69804" green="0.69804" blue="0.69804" />
-		</rect>
+		<rect name="Color(name='plugin_warning_background', _hex='#b2b2b2', _rgb=[0.6980392156862745, 0.6980392156862745, 0.6980392156862745])" state="1" />
 		<text string="This view requires the layout plugin." align="0" state="1">
 			<color red="0.73333" green="0.17255" blue="0.17255" />
 		</text>
@@ -2523,13 +2521,13 @@
 		<element ref="text_L_cartridge">
 			<bounds x="720" y="17.7" width="56" height="4.3" />
 		</element>
-		<element ref="text_L_music_production_synthesizer">
-			<bounds x="13" y="7" width="200" height="4.3" />
+		<element ref="text_S_music_production_synthesizer">
+			<bounds x="13" y="7" width="88" height="4.3" />
 		</element>
-		<element ref="text_ensoniq">
-			<bounds x="765" y="92" width="62" height="9" />
+		<element ref="text_S_ensoniq">
+			<bounds x="762" y="92" width="68" height="9" />
 		</element>
-		<element ref="text_L_sd_1">
+		<element ref="text_S_sd_1">
 			<bounds x="13" y="77.5" width="67" height="27" />
 		</element>
 		<element name="lights" ref="light_16">

--- a/src/mame/layout/sd132.lay
+++ b/src/mame/layout/sd132.lay
@@ -468,26 +468,24 @@
 	<element name="text_L_phones">
 		<text string="Phones" align="1" />
 	</element>
-	<element name="text_L_music_production_synthesizer">
-		<text string="MUSIC PRODUCTION SYNTHESIZER" align="1" />
+	<element name="text_S_music_production_synthesizer">
+		<text string="MUSIC PRODUCTION SYNTHESIZER" align="3" />
 	</element>
-	<element name="text_ensoniq">
-		<text string="ensoniq" />
+	<element name="text_S_ensoniq">
+		<text string="ensoniq" align="3" />
 	</element>
-	<element name="text_3__2__v__o__i__c__e">
-		<text string="3  2  V  O  I  C  E" />
+	<element name="text_S_3__2__v__o__i__c__e">
+		<text string="3  2  V  O  I  C  E" align="3" />
 	</element>
-	<element name="text_L_sd_1">
-		<text string="SD-1" align="1" />
+	<element name="text_S_sd_1">
+		<text string="SD-1" align="3" />
 	</element>
 	<element name="text_L_patch_select">
 		<text string="Patch Select" align="1" />
 	</element>
 
 	<element name="plugin_warning" defstate="1">
-		<rect state="1">
-			<color red="0.69804" green="0.69804" blue="0.69804" />
-		</rect>
+		<rect name="Color(name='plugin_warning_background', _hex='#b2b2b2', _rgb=[0.6980392156862745, 0.6980392156862745, 0.6980392156862745])" state="1" />
 		<text string="This view requires the layout plugin." align="0" state="1">
 			<color red="0.73333" green="0.17255" blue="0.17255" />
 		</text>
@@ -2529,17 +2527,17 @@
 		<element ref="text_L_cartridge">
 			<bounds x="720" y="17.7" width="56" height="4.3" />
 		</element>
-		<element ref="text_L_music_production_synthesizer">
-			<bounds x="13" y="7" width="200" height="4.3" />
+		<element ref="text_S_music_production_synthesizer">
+			<bounds x="13" y="7" width="88" height="4.3" />
 		</element>
-		<element ref="text_ensoniq">
-			<bounds x="765" y="92" width="62" height="9" />
+		<element ref="text_S_ensoniq">
+			<bounds x="762" y="92" width="68" height="9" />
 		</element>
-		<element ref="text_3__2__v__o__i__c__e">
+		<element ref="text_S_3__2__v__o__i__c__e">
 			<bounds x="14" y="98.5" width="65" height="5" />
 			<color red="0.2" green="0.2" blue="0.2" />
 		</element>
-		<element ref="text_L_sd_1">
+		<element ref="text_S_sd_1">
 			<bounds x="13" y="67.5" width="67" height="27" />
 		</element>
 		<element name="lights" ref="light_16">

--- a/src/mame/layout/vfx.lay
+++ b/src/mame/layout/vfx.lay
@@ -412,23 +412,21 @@
 	<element name="text_L_phones">
 		<text string="Phones" align="1" />
 	</element>
-	<element name="text_L_dynamic_component_synthesizer">
-		<text string="DYNAMIC COMPONENT SYNTHESIZER" align="1" />
+	<element name="text_S_dynamic_component_synthesizer">
+		<text string="DYNAMIC COMPONENT SYNTHESIZER" align="3" />
 	</element>
-	<element name="text_ensoniq">
-		<text string="ensoniq" />
+	<element name="text_S_ensoniq">
+		<text string="ensoniq" align="3" />
 	</element>
-	<element name="text_L_vfx">
-		<text string="VFX" align="1" />
+	<element name="text_S_vfx">
+		<text string="VFX" align="3" />
 	</element>
 	<element name="text_L_patch_select">
 		<text string="Patch Select" align="1" />
 	</element>
 
 	<element name="plugin_warning" defstate="1">
-		<rect state="1">
-			<color red="0.69804" green="0.69804" blue="0.69804" />
-		</rect>
+		<rect name="Color(name='plugin_warning_background', _hex='#b2b2b2', _rgb=[0.6980392156862745, 0.6980392156862745, 0.6980392156862745])" state="1" />
 		<text string="This view requires the layout plugin." align="0" state="1">
 			<color red="0.73333" green="0.17255" blue="0.17255" />
 		</text>
@@ -2344,13 +2342,13 @@
 		<element ref="text_L_cartridge">
 			<bounds x="720" y="17.7" width="56" height="4.3" />
 		</element>
-		<element ref="text_L_dynamic_component_synthesizer">
-			<bounds x="13" y="7" width="200" height="4.3" />
+		<element ref="text_S_dynamic_component_synthesizer">
+			<bounds x="13" y="7" width="88" height="4.3" />
 		</element>
-		<element ref="text_ensoniq">
-			<bounds x="765" y="92" width="62" height="9" />
+		<element ref="text_S_ensoniq">
+			<bounds x="762" y="92" width="68" height="9" />
 		</element>
-		<element ref="text_L_vfx">
+		<element ref="text_S_vfx">
 			<bounds x="13" y="70.5" width="92" height="43" />
 		</element>
 		<group ref="Sliders">

--- a/src/mame/layout/vfxsd.lay
+++ b/src/mame/layout/vfxsd.lay
@@ -468,23 +468,21 @@
 	<element name="text_L_phones">
 		<text string="Phones" align="1" />
 	</element>
-	<element name="text_L_music_production_synthesizer">
-		<text string="MUSIC PRODUCTION SYNTHESIZER" align="1" />
+	<element name="text_S_music_production_synthesizer">
+		<text string="MUSIC PRODUCTION SYNTHESIZER" align="3" />
 	</element>
-	<element name="text_ensoniq">
-		<text string="ensoniq" />
+	<element name="text_S_ensoniq">
+		<text string="ensoniq" align="3" />
 	</element>
-	<element name="text_L_vfx_sd">
-		<text string="VFX-SD" align="1" />
+	<element name="text_S_vfx_sd">
+		<text string="VFX-SD" align="3" />
 	</element>
 	<element name="text_L_patch_select">
 		<text string="Patch Select" align="1" />
 	</element>
 
 	<element name="plugin_warning" defstate="1">
-		<rect state="1">
-			<color red="0.69804" green="0.69804" blue="0.69804" />
-		</rect>
+		<rect name="Color(name='plugin_warning_background', _hex='#b2b2b2', _rgb=[0.6980392156862745, 0.6980392156862745, 0.6980392156862745])" state="1" />
 		<text string="This view requires the layout plugin." align="0" state="1">
 			<color red="0.73333" green="0.17255" blue="0.17255" />
 		</text>
@@ -2523,13 +2521,13 @@
 		<element ref="text_L_cartridge">
 			<bounds x="720" y="17.7" width="56" height="4.3" />
 		</element>
-		<element ref="text_L_music_production_synthesizer">
-			<bounds x="13" y="7" width="200" height="4.3" />
+		<element ref="text_S_music_production_synthesizer">
+			<bounds x="13" y="7" width="88" height="4.3" />
 		</element>
-		<element ref="text_ensoniq">
-			<bounds x="765" y="92" width="62" height="9" />
+		<element ref="text_S_ensoniq">
+			<bounds x="762" y="92" width="68" height="9" />
 		</element>
-		<element ref="text_L_vfx_sd">
+		<element ref="text_S_vfx_sd">
 			<bounds x="13" y="77.5" width="67" height="27" />
 		</element>
 		<element name="lights" ref="light_16">


### PR DESCRIPTION
Also adds another text alignment option to stretch the text to fill its bounds horizontally.

The current code calculating the aspect ratio for text involves looping, calculating the width of text for a variety of decreasing aspect ratios until the text's width is less than the available bounds. However, this string width calculation performs the same loop over the text each time, finally multiplying by the candidate aspect ratio. That text width calculation thus really only needs to be done once. Further, instead of trying different aspect ratios, the ratio can simply be calculated directly by dividing the width of the bounds by the string's width. This also calculates a more accurate aspect ratio, rather than always resulting in an aspect ratio of (0.95)^n.

For example, when trying to fit a 101-pixel wide text into a 100-pixel wide space, the current code would result in an aspect ratio of 0.95, making the text 96 pixels wide,  leaving 4 pixels unused;  the new code will instead calculate the aspect ratio as 100/101 == 0.9900990099... , making the text use the full 100 available pixels.

This in turn allows us to easily calculate the ratio also if we want to not just schrink but also stretch the text to fill the available space, so we add that as another text alignment option, number 3 (three).

This PR also demonstrates this in the VFX family of layouts, where on the default Full view, the text "MUSIC PRODUCTION SYNTHESIZER" ("DYNAMIC COMPONENT SYNTHESIZER" on the VFX), the logo-like text "ensoniq", and the keyboard-specific markers "VFX", "VFX-SD", "SD-1" and "3 2 V O I C E" can now be made to fill their available space horizontally as they should, making it all look that much more like the real thing. One example from the sd132, before:

<img width="282" height="292" alt="Screenshot From 2025-11-19 16-34-01" src="https://github.com/user-attachments/assets/995d262b-2f1f-405a-b385-29b4aa495c75" />

after:

<img width="282" height="292" alt="Screenshot From 2025-11-19 16-33-18" src="https://github.com/user-attachments/assets/8cddfc0e-8267-4025-ba6b-d4e959e1b500" />
 
and the real thing:

<img width="282" height="292" alt="image" src="https://github.com/user-attachments/assets/da00308d-b356-4bfd-85b0-7be99e7f8b9a" />

While still not perfect, the "after" at least has the corrects widths and horizontal alignments.
