### PR TITLE
mz700_cass, mz800_cass: 43 additions and other updates to software lists

### DIFF
--- a/hash/mz700_cass.xml
+++ b/hash/mz700_cass.xml
@@ -1052,7 +1052,7 @@ Easidata (English Version)
 	<software name="blizzard" supported="yes">
 		<description>Blizzard</description>
 		<year>19??</year>
-		<publisher>Unknown</publisher>
+		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cass" interface="mz_cass">
 			<dataarea name="cass" size="23681">
 				<rom name="blizzard.mzt" size="23681" crc="bf76135c" sha1="d29d5299e70e5a07ee32155750623b0dc8ec6053"/>
@@ -1153,7 +1153,7 @@ Easidata (English Version)
 	</software>
 	
 	<software name="carrier2a" cloneof="carrier2" supported="yes">
-		<description>Carrier ][ (Joystick version)</description>
+		<description>Carrier ][ (joystick version)</description>
 		<year>1984</year>
 		<publisher>BBG Software</publisher>
 		<part name="cass" interface="mz_cass">
@@ -1415,7 +1415,7 @@ Easidata (English Version)
 	<software name="drop" supported="yes">
 		<description>The Drop</description>
 		<year>19??</year>
-		<publisher>Unknown</publisher>
+		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cass" interface="mz_cass">
 			<dataarea name="cass" size="25089">
 				<rom name="drop.mzt" size="25089" crc="793f3b50" sha1="ff8cff42ec94762cd897851232daf4187c8287bc"/>
@@ -1532,7 +1532,7 @@ Easidata (English Version)
 	<software name="galaxoid" supported="yes">
 		<description>Galaxoids</description>
 		<year>19??</year>
-		<publisher>Unknown</publisher>
+		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cass" interface="mz_cass">
 			<dataarea name="cass" size="9602">
 				<rom name="galaxoids.mzt" size="9602" crc="43116eb6" sha1="45c6ce35bdbe117d9a9039f29c9eb9ee0d038c99"/>
@@ -2066,6 +2066,7 @@ Easidata (English Version)
 		</part>
 	</software>
 
+	<!-- Requires PCG to display correctly -->
 	<software name="moty" supported="partial">
 		<description>Moty</description>
 		<year>1985</year>
@@ -2080,7 +2081,7 @@ Easidata (English Version)
 	<software name="mrfixit" supported="yes">
 		<description>Mr Fixit</description>
 		<year>19??</year>
-		<publisher>Unknown</publisher>
+		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cass" interface="mz_cass">
 			<dataarea name="cass" size="38124">
 				<rom name="mr fixit.mzt" size="38124" crc="83a56cb6" sha1="d04663bd37f60763e8619886f52299934b7576a0"/>
@@ -2142,6 +2143,7 @@ Easidata (English Version)
 		</part>
 	</software>
 
+	<!-- Requires PCG to display correctly -->
 	<software name="nakamoto" supported="partial">
 		<description>Nakamoto</description>
 		<year>19??</year>
@@ -2708,7 +2710,7 @@ Easidata (English Version)
 	<software name="tetris" supported="yes">
 		<description>Tetris!</description>
 		<year>19??</year>
-		<publisher>Unknown</publisher>
+		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cass" interface="mz_cass">
 			<dataarea name="cass" size="17013">
 				<rom name="tetris.mzt" size="17013" crc="e0a4ae3c" sha1="2bc76126f45b44ee70d6f809e76adf4fcc0b3fa7"/>
@@ -2837,6 +2839,7 @@ Easidata (English Version)
 		</part>
 	</software>
 
+	<!-- Requires PCG to display correctly -->
 	<software name="wooky" supported="partial">
 		<description>Wooky</description>
 		<year>19??</year>

--- a/hash/mz800_cass.xml
+++ b/hash/mz800_cass.xml
@@ -30,7 +30,7 @@ MZ-821 Sharp BASIC Trainer (Germany):   Account Manager: Einnahmen/Ausgaben-Verw
 	<software name="appleman" supported="yes">
 		<description>Appleman</description>
 		<year>19??</year>
-		<publisher>Unknown</publisher>
+		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cass" interface="mz_cass">
 			<dataarea name="cass" size="20749">
 				<rom name="appleman.mzt" size="20749" crc="a10f4777" sha1="87edaf080ceffb3d5316bd83361fe95d2a8ae87b"/>
@@ -81,7 +81,7 @@ MZ-821 Sharp BASIC Trainer (Germany):   Account Manager: Einnahmen/Ausgaben-Verw
 	<software name="building" supported="yes">
 		<description>Building Hopper</description>
 		<year>1983</year>
-		<publisher>Unknown</publisher>
+		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cass" interface="mz_cass">
 			<dataarea name="cass" size="42368">
 				<rom name="building.mzf" size="42368" crc="fa79fff0" sha1="4d3c845519f3acf2f062da0888d564e468453408"/>
@@ -148,7 +148,7 @@ MZ-821 Sharp BASIC Trainer (Germany):   Account Manager: Einnahmen/Ausgaben-Verw
 	<software name="galao" supported="yes">
 		<description>Galao</description>
 		<year>19??</year>
-		<publisher>Unknown</publisher>
+		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cass" interface="mz_cass">
 			<dataarea name="cass" size="20177">
 				<rom name="galao.mzt" size="20177" crc="fad2a016" sha1="d3e334f7155fbe031a859128bd3b7fb3d08f92a4"/>
@@ -157,9 +157,9 @@ MZ-821 Sharp BASIC Trainer (Germany):   Account Manager: Einnahmen/Ausgaben-Verw
 	</software>
 
 	<software name="galaoa" cloneof="galao" supported="yes">
-		<description>Galao (Joystick version)</description>
+		<description>Galao (joystick version)</description>
 		<year>19??</year>
-		<publisher>Unknown</publisher>
+		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cass" interface="mz_cass">
 			<dataarea name="cass" size="20177">
 				<rom name="galao joy.mzt" size="20177" crc="85bedb36" sha1="ee6c57736274aadb56d97b371901e360c5601956"/>
@@ -348,7 +348,7 @@ MZ-821 Sharp BASIC Trainer (Germany):   Account Manager: Einnahmen/Ausgaben-Verw
 	<software name="penguin" supported="yes">
 		<description>Penguin</description>
 		<year>19??</year>
-		<publisher>Unknown</publisher>
+		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cass" interface="mz_cass">
 			<dataarea name="cass" size="13697">
 				<rom name="penguin.mzt" size="13697" crc="a2b50de3" sha1="571d5d626b97aec039766c422e4256e6579fef8d"/>
@@ -370,7 +370,7 @@ MZ-821 Sharp BASIC Trainer (Germany):   Account Manager: Einnahmen/Ausgaben-Verw
 	<software name="pinball" supported="yes">
 		<description>Pinball</description>
 		<year>19??</year>
-		<publisher>Unknown</publisher>
+		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cass" interface="mz_cass">
 			<dataarea name="cass" size="24856">
 				<rom name="pinball.mzt" size="24856" crc="ddac61c9" sha1="90976ddbdec6759f42db791f14484dcd112bac70"/>


### PR DESCRIPTION
22 additions to mz800_cass software list, including 1 clone and 4 items already included in mz700_cass which are not/partially supported on MZ-700 but fully supported on MZ-800.

21 additions to mz700_cass software list, including 1 clone.

4 items in mz800_cass previously marked not working updated to working.

The 4 items in mz700_cass replicated in mz800_cass updated in mz700_cass to partially (3) or not (1) working (previously no supported status set).

Virtually everything here will load on MZ-700 as very little truly MZ-800 specific software is supported by the current state of MZ-800 emulation. MZ-800 will however support PCG, which is not supported by the current state of MZ-700 emulation.

As emulation of both matures, these software lists probably need a re-think, but right now items added to MZ-800 (and any tidy up of supported statuses) reflects the current state of emulation of both systems and feels consistent with existing decisions on which software list to add items to. Largely therefore that means additions to the MZ-800 list are:
- The handful of software which will run on MZ-800 right now but is not supported on MZ-700.
- Software supported by both but which relies heavily on PCG, so is significantly more playable on MZ-800.
- Software which explicitly states it is for MZ-800 (even if it actually runs on MZ-700).

Additions sourced from http://www.mz-800.scav.cz/.
