### PR TITLE
apple2e: fix FLASH timing

### DIFF
--- a/src/mame/apple/apple2video.cpp
+++ b/src/mame/apple/apple2video.cpp
@@ -955,7 +955,16 @@ uint32_t a2_video_device::screen_update(screen_device &screen, bitmap_ind16 &bit
 	}
 
 	// always update the flash timer here so it's smooth regardless of mode switches
-	m_flash = ((machine().time() * 4).seconds() & 1) ? true : false;
+	if (Model == model::IIE || Model == model::IIGS)
+	{
+		// video scanner overflow flash timer every 16 frames, ~1.87 Hz (NTSC)
+		m_flash = screen.frame_number() & 0x10;
+	}
+	else
+	{
+		// approximate 555 flash timer, ~2 Hz cycle
+		m_flash = (machine().time() * 4).seconds() & 1;
+	}
 
 	int text_start_row = 0;
 


### PR DESCRIPTION
This commit fixes the FLASH timing for IIe, IIc, IIgs.

apple2 uses a 555 timer @ ~2.182 Hz ([Sather UTA2 8.6, 8.7](https://archive.org/details/understanding_the_apple_ii/page/n207/mode/2up)) which alternates every ~15 frames.
apple2e and later do not have this 555 timer on the motherboard. Sather postulates that they instead use IOU video counter overflow ([UTA2E fig 3.8](https://archive.org/details/Understanding_the_Apple_IIe/page/n55/mode/2up)), which alternates exactly every 16 frames (regardless of NTSC/PAL.)


Testing:
New FLASHHZ unit test, which shows a (_possibly seizure-inducing_) pattern of columns blinking at decreasing rates, to align with real FLASH text:
<img width="560" height="384" alt="FLASHHZ_apple2p" src="https://github.com/user-attachments/assets/3a1ad672-3f05-447b-ae09-b75170246ff1" />
[FLASHHZ_251119.zip](https://github.com/user-attachments/files/23638852/FLASHHZ_251119.zip)

The test is beam-racing the flashing columns via vaporlock (or VBL on the IIgs) and is NTSC/PAL compatible.  The (D) key delays the blinking one frame, so you can manually align the phase of column G (or column F on the ][+).

After this PR, MAME now matches the behavior of a real Apple IIe:
(_blinky video, photosensitive epilepsy warning_)
https://github.com/user-attachments/assets/74eda815-0188-4730-a140-55bed6d2bb2b

A real IIgs also matches this.  The IIgs can dynamically toggle between 60/50Hz, where we can see that the 50Hz display also flashes exactly every 16 frames:
(_even more blinky video_)
https://github.com/user-attachments/assets/1e2791b0-69bd-4abc-b3c8-d7a88af3733b


TODO:
After #14495, apple2gs now has stable beam-racing in this test, however LANGSEL doesn't implement 50Hz in MAME yet.  I have that working in another WIP PR, but there are entanglements with C02E and floating bus readback which need more testing.
