### PR TITLE
sequential/sixtrak.cpp: Added Rev A as a clone.

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -42742,6 +42742,7 @@ prpht600
 
 @source:sequential/sixtrak.cpp
 sixtrak
+sixtraka
 
 @source:seta/albazc.cpp
 hanaroku


### PR DESCRIPTION
The same firmware is also compatible with the Rev A tuning circuit.

New working clones
------------------
Sequential Circuits Six-Trak (Model 610) Rev A