### PR TITLE
mz2000_flop: 11 additions to software list

### DIFF
--- a/hash/mz2000_flop.xml
+++ b/hash/mz2000_flop.xml
@@ -309,7 +309,7 @@ FRONT LINE: works
 		</part>
 	</software>
 
-	<software name="ipls2d01" supported="yes">
+	<software name="ipls2d01" supported="partial">
 		<description>Compilation Disk IPLS2D-001</description>
 		<year>200?</year>
 		<publisher>Unknown</publisher>
@@ -343,7 +343,7 @@ PLAZMA LINE: works
 		</part>
 	</software>
 
-	<software name="mz1z001" supported="yes">
+	<software name="mz1z001" supported="partial">
 		<description>BASIC MZ-1Z001 DISK</description>
 		<year>2023</year>
 		<publisher>Sharp</publisher>


### PR DESCRIPTION
Add 11 items to mz2000_flop, 8 working,  2 partially working, 1 not working.

These were not working but fixed using MZDiskExplorer.

Additions include:
- 5 compilations of mostly Carry Lab games.
- 2 disks of individual games, Miranda and Uootoy.
- A compilation with a mix of BASIC versions and games.
- A disk based version of MZ-1Z001 BASIC (not MZ-2Z001 disk BASIC).
- A data disk of MZ-1Z002 samples which is not working (or at least unable to test it is) as it requires disk BASIC (presumably MZ-2Z002).