### PR TITLE
sega/model2_v.cpp: shift texture parameters index right by 2

### DIFF
--- a/src/mame/sega/model2_v.cpp
+++ b/src/mame/sega/model2_v.cpp
@@ -2116,7 +2116,7 @@ u32 *model2_state::geo_texture_parameters( geo_state *geo, u32 opcode, u32 *inpu
 	(void)opcode;
 
 	/* read in the index */
-	index = *input++;
+	index = (*input++) >> 2;
 
 	/* read in the conut */
 	count = *input++;


### PR DESCRIPTION
Fixes glitchy polygons and motion blur effect in vf2 ending