### PR TITLE
nec/pc6001.cpp: Add cassette software lists

### DIFF
--- a/hash/pc6001_cass.xml
+++ b/hash/pc6001_cass.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<!--
+Usage details:
+
+Mode refers to the BASIC version the software requires on Mk II machines:
+Mode 1: N60 BASIC (16K)
+Mode 2: N60 BASIC (32K)
+Mode 3: N60 EXTENDED BASIC (16K)
+Mode 4: N60 EXTENDED BASIC (32K)
+Mode 5: N60m BASIC (64K)
+
+Modes 1 & 2 correspond to the original PC-6001 BASIC versions.
+Modes 3 & 4 correspond to the original PC-6001 running the N60 Extended BASIC cartridge.
+A mode does not need to be selected on the original PC-6001.
+
+The Page value should be entered at the 'How Many Pages?' prompt in all versions of BASIC.
+
+Once in BASIC, enter CLOAD then press ENTER, then RUN then ENTER once loading completes.
+-->
+<softwarelist name="pc6001_cass" description="NEC PC-6001 cassettes">
+
+	<software name="amazon" supported="yes">
+		<description>The Amazon</description>
+		<year>19??</year>
+		<publisher>T. Katayama</publisher>
+        <info name="usage" value="Mode 2, Page 3" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="15260">
+				<rom name="amazon.cas" size="15260" crc="0b154850" sha1="a616b6d8852bea0fae27241ab7a0d5c81014e0e0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="amita" supported="yes">
+		<description>Amita</description>
+		<year>19??</year>
+		<publisher>Unknown</publisher>
+        <info name="usage" value="Mode 1, Page 2" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="2755">
+				<rom name="amita.cas" size="2755" crc="fbb5ec19" sha1="dc49c616fb7822f21ca895bbb5f3b16924d306d8"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="block" supported="yes">
+		<description>Block</description>
+		<year>19??</year>
+		<publisher>Unknown</publisher>
+        <info name="usage" value="Mode 1, Page 2" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="4837">
+				<rom name="block.cas" size="4837" crc="b0bad3d9" sha1="01b2da04a6d8c5766dcd765994d142bd18dcce73"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="brkthru" supported="yes">
+		<description>Break Through</description>
+		<year>19??</year>
+		<publisher>Compac</publisher>
+        <info name="usage" value="Mode 2, Page 2" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="24029">
+				<rom name="break through.cas" size="24029" crc="929dd694" sha1="8e9d3d90a0c506cfcde12139258050cd8608bc5d"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="doordoor" supported="yes">
+		<description>Door Door</description>
+		<year>1984</year>
+		<publisher>Enix</publisher>
+        <info name="usage" value="Mode 2, Page 2" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="32221">
+				<rom name="door door.p6" size="32221" crc="3bc496a3" sha1="f89c8ab94cf0004303714f605739efc0abf2a608"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="earthbnd" supported="yes">
+		<description>Earth Bound</description>
+		<year>1984</year>
+		<publisher>X'tal Soft</publisher>
+        <info name="usage" value="Mode 2, Page 2" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="41241">
+				<rom name="earth bound.cas" size="41241" crc="1c4cafba" sha1="d9d8b4088e1bc2cd3d7df9f238215f41bc4ae065"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="eggy" supported="yes">
+		<description>Eggy</description>
+		<year>19??</year>
+		<publisher>Bothtech</publisher>
+        <info name="usage" value="Mode 2, Page 1" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="22307">
+				<rom name="eggy.cas" size="22307" crc="3c9e47d2" sha1="885c4964480dfcd12164a1ebab0f95aecd06cf2d"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="headon" supported="yes">
+		<description>Head On</description>
+		<year>19??</year>
+		<publisher>ASCII</publisher>
+        <info name="usage" value="Mode 1, Page 1" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="5711">
+				<rom name="head on.cas" size="5711" crc="91f7d594" sha1="e64442f2c32f0a7b6c62e1adcc4555fcc8149b66"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="jintori" supported="yes">
+		<description>Jintori Game</description>
+		<year>19??</year>
+		<publisher>Hudson Soft</publisher>
+        <info name="usage" value="Mode 1, Page 2" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="1766">
+				<rom name="jintori game.cas" size="1766" crc="34f9764d" sha1="2b3e72cb3ac41fb8de50111a9fe78797b1628ae1"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="power" supported="yes">
+		<description>Power Knight</description>
+		<year>19??</year>
+		<publisher>Unknown</publisher>
+        <info name="usage" value="Mode 1, Page 1" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="13612">
+				<rom name="power.cas" size="13612" crc="9252969e" sha1="e0e3b0582c8c17d7f738dd2f61a9933420435283"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="proracer" supported="yes">
+		<description>Pro Racer</description>
+		<year>19??</year>
+		<publisher>Hudson Soft</publisher>
+        <info name="usage" value="Mode 1, Page 2" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="8504">
+				<rom name="pro racer.cas" size="8504" crc="52624dc8" sha1="9e0c8c59f583b4204d52514fc3bbbd2dfb765b8c"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pyramid" supported="yes">
+		<description>Pyramid</description>
+		<year>1983</year>
+		<publisher>Magic Soft</publisher>
+        <info name="usage" value="Mode 2, Page 1" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="15263">
+				<rom name="pyramid.cas" size="15263" crc="7d3b4628" sha1="e1be45b435d599d3f7444f159c538e093ba63f3f"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="spcenemy" supported="yes">
+		<description>Space Enemy</description>
+		<year>1982<year>
+		<publisher>ASCII</publisher>
+        <info name="usage" value="Mode 4, Page 3 - PC-6001 requires N60 Extended BASIC cartridge" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="5579">
+				<rom name="space enemy.cas" size="5579" crc="6601f428" sha1="4d922cef648f9efe001f25920bf1874ca5cbde52"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="suprball" supported="yes">
+		<description>Super Ball</description>
+		<year>19??</year>
+		<publisher>Unknown</publisher>
+        <info name="usage" value="Mode 2, Page 2" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="18114">
+				<rom name="super ball.p6" size="18114" crc="a7923430" sha1="01cb476f5e127176290949ff273cac0c6ffe5c49"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="trickboy" supported="yes">
+		<description>Trick Boy</description>
+		<year>19??</year>
+		<publisher>T&amp;E Soft</publisher>
+        <info name="usage" value="Mode 2, Page 2" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="25800">
+				<rom name="trick boy.cas" size="25800" crc="dfad3c61" sha1="39798e7f7cb2802d977f5124dd053a0d85d4c018"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="txevious" supported="yes">
+		<description>Tiny Xevious</description>
+		<year>19??</year>
+		<publisher>Namco</publisher>
+        <info name="usage" value="Mode 4, Page 2 - PC-6001 requires N60 Extended BASIC cartridge" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="17741">
+				<rom name="tiny xevious.cas" size="17741" crc="5e9e2dbf" sha1="90e2b187f3b042ef1883105a34e83fe69a58e38f"/>
+			</dataarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/hash/pc6001mk2_cass.xml
+++ b/hash/pc6001mk2_cass.xml
@@ -1,0 +1,244 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<!--
+
+Usage details:
+
+Mode refers to the BASIC version the software requires on Mk II machines:
+Mode 1: N60 BASIC (16K)
+Mode 2: N60 BASIC (32K)
+Mode 3: N60 EXTENDED BASIC (16K)
+Mode 4: N60 EXTENDED BASIC (32K)
+Mode 5: N60m BASIC (64K)
+
+The Page value should be entered at the 'How Many Pages?' prompt in all versions of BASIC.
+
+Once in BASIC:
+If usage specifies BASIC: 
+- Enter CLOAD then press ENTER.
+- Then enter RUN then ENTER once loading completes.
+
+If usage specifies MONITOR: 
+- Enter MON then press ENTER to enter the Monitor.
+- Type R-0 (- is entered automatically) then press ENTER.
+
+-->
+<softwarelist name="pc6001mk2_cass" description="NEC PC-6001 Mk II cassettes">
+
+	<software name="bokosuka" supported="yes">
+		<description>Bokosuka</description>
+		<year>1985</year>
+		<publisher>ASCII</publisher>
+        <info name="usage" value="Mode 5, Page 3, BASIC" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="22293">
+				<rom name="bokosuka.cas" size="22293" crc="7690032c" sha1="7928741b1133a1cc87ee6d8ccbf9e7a68278a439"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="cannonbl" supported="yes">
+		<description>Cannon Ball</description>
+		<year>1983</year>
+		<publisher>Hudson Soft</publisher>
+        <info name="usage" value="Mode 5, Page 4, MONITOR" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="10886">
+				<rom name="cannon ball.p6" size="10886" crc="c7eb0282" sha1="d2393ffa00f52fe4f5ce1dd48e3ec8e17ff9559a"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="castleex" supported="yes">
+		<description>Castle Excellent</description>
+		<year>19??</year>
+		<publisher>Unknown</publisher>
+        <info name="usage" value="Mode 5, Page 2, BASIC" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="32980">
+				<rom name="castle excellent.cas" size="32980" crc="dc356757" sha1="2d33d6d3274370aae8052dee29bac993c369b4e5"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="chackpop" supported="yes">
+		<description>Chack 'n Pop</description>
+		<year>1984</year>
+		<publisher>Hidecom-Carry</publisher>
+        <info name="usage" value="Mode 5, Page 1, BASIC" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="46630">
+				<rom name="chack 'n pop.cas" size="46630" crc="de769cca" sha1="3e35398d960442c98035db530c3226dda06ae12f"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="chrith" supported="yes">
+		<description>Chrith</description>
+		<year>19??</year>
+		<publisher>Comix</publisher>
+        <info name="usage" value="Mode 5, Page 3, BASIC" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="26017">
+				<rom name="chrith.cas" size="26017" crc="8e72abd1" sha1="c3e11ec7eb4b89ba6783d4a60336bef3489fcdc2"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="daidasso" supported="yes">
+		<description>Daidasso</description>
+		<year>19??</year>
+		<publisher>Carry Lab</publisher>
+        <info name="usage" value="Mode 5, Page 1, BASIC" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="41712">
+				<rom name="daidasso.cas" size="41712" crc="b0d7af71" sha1="d5cf409aae7c6fbc4332736c16e19850b34d97ef"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="digdug" supported="yes">
+		<description>Dig Dug</description>
+		<year>19??</year>
+		<publisher>Namco</publisher>
+        <info name="usage" value="Mode 4, Page 1, BASIC" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="29546">
+				<rom name="dig dug.cas" size="29546" crc="162c2d86" sha1="084e4e6e01a58eb7bd782fe8c9e925008b5055bc"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dsbubble" supported="yes">
+		<description>Dr. Slump Bubble Daisakusen</description>
+		<year>1984</year>
+		<publisher>Enix</publisher>
+        <info name="usage" value="Mode 5, Page 3, MONITOR" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="28455">
+				<rom name="dr slump bubble daisakusen.cas" size="28455" crc="10529edc" sha1="9fadb778ef869a147956e3d8004cc84574e34bd6"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="doordoor" supported="yes">
+		<description>Door Door Mk. II</description>
+		<year>1984</year>
+		<publisher>Enix</publisher>
+        <info name="usage" value="Mode 5, Page 3, BASIC" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="71593">
+				<rom name="door door.p6" size="71593" crc="567f4190" sha1="4c82a9e4b939962a1fc703a5611f59b3f18118bb"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="flappy" supported="yes">
+		<description>Flappy</description>
+		<year>1984</year>
+		<publisher>dB-SOFT</publisher>
+        <info name="usage" value="Mode 5, Page 2, BASIC" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="71422">
+				<rom name="flappy.cas" size="71422" crc="acaa6d1a" sha1="ace6bf7ae566fa152adc779d37d7476a15b9ab2b"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hisya" supported="yes">
+		<description>Hisya</description>
+		<year>19??</year>
+		<publisher>Carry Lab</publisher>
+        <info name="usage" value="Mode 5, Page 1, BASIC" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="30124">
+				<rom name="hisya.cas" size="30124" crc="c3d88ac6" sha1="c6a857cf88f1205b4dfff00e063739752992a7fc"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="iceblock" supported="yes">
+		<description>Ice Block</description>
+		<year>19??</year>
+		<publisher>dB-SOFT</publisher>
+        <info name="usage" value="Mode 5, Page 2, BASIC" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="28708">
+				<rom name="ice block.cas" size="28708" crc="90b5276e" sha1="422d51cf71113c29e40acf362104602728ed409c"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="nutsmilk" supported="yes">
+		<description>Nuts &amp; Milk</description>
+		<year>1984</year>
+		<publisher>Hudson Soft</publisher>
+        <info name="usage" value="Mode 5, Page 2, MONITOR" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="28846">
+				<rom name="nuts &amp; milk.p6" size="28846" crc="89ab4aa7" sha1="cf8daeab0b07ca04bf178b1df9f8f129e2e41d1a"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pascom" supported="yes">
+		<description>Pascom Tower</description>
+		<year>1984</year>
+		<publisher>MIA</publisher>
+        <info name="usage" value="Mode 5, Page 4, BASIC" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="46657">
+				<rom name="pascom tower.p6" size="46657" crc="22a42558" sha1="6961686d5557cfb9acb66512c8d594599df4c295"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="plazmaln" supported="yes">
+		<description>Plazma</description>
+		<year>19??</year>
+		<publisher>Techno Soft</publisher>
+        <info name="usage" value="Mode 5, Page 3, BASIC" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="35744">
+				<rom name="plazma line.cas" size="35744" crc="972adbaf" sha1="9bf713f6ee0fcb3c8bc1b652b4983a8407769aef"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pbmario" supported="yes">
+		<description>Punchball Mario</description>
+		<year>1983</year>
+		<publisher>Nintendo</publisher>
+        <info name="usage" value="Mode 5, Page 4, MONITOR" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="30669">
+				<rom name="punchball mario.cas" size="30669" crc="a57ba645" sha1="a3852b982638da74e708e0d05c9ef61629495096"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="thunder" supported="yes">
+		<description>Thunder Force</description>
+		<year>1985</year>
+		<publisher>Techno Soft</publisher>
+        <info name="usage" value="Mode 5, Page 3, BASIC" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="35487">
+				<rom name="thunder force.cas" size="35487" crc="bfea6bac" sha1="584cae9a14027eda67b9c24af0186f8096e74d38"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="vegcrash" supported="yes">
+		<description>Vegetable Crash</description>
+		<year>19??</year>
+		<publisher>Hudson Soft</publisher>
+        <info name="usage" value="Mode 5, Page 4, MONITOR" />
+		<part name="cart" interface="pc6001_cass">
+			<dataarea name="rom" size="11027">
+				<rom name="vegetable crash.cas" size="11027" crc="7a0569d1" sha1="932d219a2eae516d57575511a0bdb2a96bd8fa6d"/>
+			</dataarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/src/mame/nec/pc6001.cpp
+++ b/src/mame/nec/pc6001.cpp
@@ -1739,6 +1739,7 @@ void pc6001_state::pc6001(machine_config &config)
 
 	GENERIC_CARTSLOT(config, m_cart, generic_plain_slot, "pc6001_cart");
 	SOFTWARE_LIST(config, "cart_list_pc6001").set_original("pc6001_cart");
+	SOFTWARE_LIST(config, "cass_list_pc6001").set_original("pc6001_cass");
 
 //  CASSETTE(config, m_cassette);
 //  m_cassette->set_formats(pc6001_cassette_formats);
@@ -1776,6 +1777,9 @@ void pc6001mk2_state::pc6001mk2(machine_config &config)
 	subdevice<gfxdecode_device>("gfxdecode")->set_info(gfx_pc6001m2);
 
 	UPD7752(config, "upd7752", PC6001_MAIN_CLOCK / 4).add_route(ALL_OUTPUTS, "mono", 1.00);
+
+	SOFTWARE_LIST(config, "cass_list_pc6001mk2").set_original("pc6001mk2_cass");
+
 }
 
 void pc6601_state::floppy_formats(format_registration &fr)


### PR DESCRIPTION
Enables 2 new software lists:

- pc6001_cass, supporting all PC-6001 models (with 16 initial working software items)
- pc6001mk2_cass, supporting PC-6001mkII, PC-6001mkIISR and PC-6601 (with 18 initial working items)

Approach of separate software lists, with each treated as original is consistent with approach for pc8001 and seems appropriate due to PC-6001 software being fully supported on later versions, and PC-6001 software often having mkII modes.

In line with the current hack to enable cassette based software, items are configured as carts, not cassettes.

All software items sourced from TOSEC repositories.