### PR TITLE
Service periodic callbacks on Windows while MAME debugger is active

### DIFF
--- a/src/osd/modules/debugger/debugwin.cpp
+++ b/src/osd/modules/debugger/debugwin.cpp
@@ -206,23 +206,28 @@ void debugger_windows::wait_for_debugger(device_t &device, bool firststop)
 
 	// get and process messages
 	MSG message;
-	GetMessage(&message, nullptr, 0, 0);
 
-	switch (message.message)
+	// Crude implementation of GetMessage with timeout
+	if (MsgWaitForMultipleObjects(0, nullptr, false, 16, QS_ALLINPUT) == WAIT_OBJECT_0)
 	{
-	// check for F10 -- we need to capture that ourselves
-	case WM_SYSKEYDOWN:
-	case WM_SYSKEYUP:
-		if (message.wParam == VK_F4 && message.message == WM_SYSKEYDOWN)
-			SendMessage(GetAncestor(GetFocus(), GA_ROOT), WM_CLOSE, 0, 0);
-		if (message.wParam == VK_F10)
-			SendMessage(GetAncestor(GetFocus(), GA_ROOT), (message.message == WM_SYSKEYDOWN) ? WM_KEYDOWN : WM_KEYUP, message.wParam, message.lParam);
-		break;
+		if (PeekMessage(&message, nullptr, 0, 0, PM_REMOVE)) {
+			switch (message.message)
+			{
+				// check for F10 -- we need to capture that ourselves
+				case WM_SYSKEYDOWN:
+				case WM_SYSKEYUP:
+					if (message.wParam == VK_F4 && message.message == WM_SYSKEYDOWN)
+						SendMessage(GetAncestor(GetFocus(), GA_ROOT), WM_CLOSE, 0, 0);
+					if (message.wParam == VK_F10)
+						SendMessage(GetAncestor(GetFocus(), GA_ROOT), (message.message == WM_SYSKEYDOWN) ? WM_KEYDOWN : WM_KEYUP, message.wParam, message.lParam);
+					break;
 
-	// process everything else
-	default:
-		winwindow_dispatch_message(*m_machine, message);
-		break;
+					// process everything else
+				default:
+					winwindow_dispatch_message(*m_machine, message);
+					break;
+			}
+		}
 	}
 
 	// mark the debugger as active


### PR DESCRIPTION
Ensure that LUA periodic callbacks continue to be regularly serviced on Windows builds while the MAME debugger is in a `stop` state.