### PR TITLE
sd132_flop.xml, sd1_flop.xml, vfxsd_flop.xml, ibm5170_cdrom-xml: Metadata cleanings

### DIFF
--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -257,7 +257,7 @@ Black colored OEM CD with no id whatsoever
 
 	<!-- Windows 95/98 -->
 	<software name="acatari2">
-		<description>Aracde's Greatest Hits: The Atari Collection 2</description>
+		<description>Arcade's Greatest Hits: The Atari Collection 2</description>
 		<year>1998</year>
 		<publisher>GT Interactive</publisher>
 		<info name="developer" value="Atari" />
@@ -9784,9 +9784,9 @@ Video editing software for [ZR36067]-based PCI card, can also detect [DC30] and 
 Has an HW tester, DirectDraw fails to enable overlay with [ViRGE] Scenic Highway interface
 ]]></notes>
 		<!-- Serial number: 3920519554 -->
-		<info name="language" value="Deutsch" />
 		<info name="language" value="Dutch" />
 		<info name="language" value="English" />
+		<info name="language" value="German" />
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
 				<disk name="pinnacle-studio-dc10-plus" sha1="1530776b913e21774ade2b160960f2fe70bf4c6b"/>

--- a/hash/sd132_flop.xml
+++ b/hash/sd132_flop.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="sd132_flop" description="Ensoniq SD-1 32 Voice Disk Images">
+<softwarelist name="sd132_flop" description="Ensoniq SD-1 32 Voice disk images">
 
 	<software name="os400" cloneof="os410" supported="yes">
 		<description>SD-1 Sequencer OS version 4.00</description>

--- a/hash/sd1_flop.xml
+++ b/hash/sd1_flop.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="sd1_flop" description="Ensoniq SD-1 Disk Images">
+<softwarelist name="sd1_flop" description="Ensoniq SD-1 disk images">
 
 	<software name="os3" supported="yes">
 		<description>SD-1 Sequencer OS version 3.0</description>

--- a/hash/vfxsd_flop.xml
+++ b/hash/vfxsd_flop.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="vfxsd_flop" description="Ensoniq VFX-SD Disk Images">
+<softwarelist name="vfxsd_flop" description="Ensoniq VFX-SD disk images">
 
 	<software name="os137" cloneof="os210" supported="yes">
 		<description>VFX-SD Sequencer OS version 1.37</description>


### PR DESCRIPTION
sd132_flop: Lowercase letters in words associated with storage media (in software list description).
sd1_flop: Lowercase letters in words associated with storage media (in software list description).
vfxsd_flop: Lowercase letters in words associated with storage media (in software list description).
ibm5170_cdrom-xml: Fixed typo on [acatari2] set description.