### PR TITLE
Fix text clipping introduced by https://github.com/mamedev/mame/pull/14550

### DIFF
--- a/src/emu/rendlay.cpp
+++ b/src/emu/rendlay.cpp
@@ -3223,7 +3223,7 @@ protected:
 					float aspect = 1.0;
 					if (width > bounds.width())
 					{
-						aspect = (float) bounds.width() / (float) width;
+						aspect = float(bounds.width()) / float(width);
 						width = bounds.width();
 					}
 
@@ -3369,7 +3369,7 @@ private:
 					float aspect = 1.0;
 					if (width > bounds.width())
 					{
-						aspect = (float) bounds.width() / (float) width;
+						aspect = float(bounds.width()) / float(width);
 						width = bounds.width();
 					}
 
@@ -3715,7 +3715,7 @@ void layout_element::component::draw_text(
 	float aspect = 1.0;
 	if (align == 3 || width > bounds.width())
 	{
-		aspect = (float) bounds.width() / (float) width;
+		aspect = float(bounds.width()) / float(width);
 		width = bounds.width();
 	}
 
@@ -3730,7 +3730,7 @@ void layout_element::component::draw_text(
 
 		// right
 		case 2:
-			curx = bounds.right() - width;
+			curx = bounds.left() + bounds.width() - width;
 			break;
 		
 		// stretch


### PR DESCRIPTION
The width was used to calculate the aspect ration, but was not then updated with the calculated aspect ration
This appears to fix that. The sample simon layout referenced [here](https://github.com/mamedev/mame/pull/14550#issuecomment-3593290805) now looks much better:

<img width="3500" height="1874" alt="Screenshot From 2025-11-30 20-42-24" src="https://github.com/user-attachments/assets/401b2e2c-0214-4f57-95f1-7fd5e1b73206" />
