### PR TITLE
Fix floating value options when Windows is set to certain languages

### DIFF
--- a/src/osd/windows/winmain.cpp
+++ b/src/osd/windows/winmain.cpp
@@ -172,7 +172,7 @@ static int is_double_click_start(int argc);
 
 int main(int argc, char *argv[])
 {
-	std::setlocale(LC_ALL, "");
+	std::setlocale(LC_ALL, "en_US.UTF-8");
 	std::vector<std::string> args = osd_get_command_line(argc, argv);
 
 	// use small output buffers on non-TTYs (i.e. pipes)


### PR DESCRIPTION
If Windows is set to those languages where floating values are displayed with a ',' instead of a '.' (such as Italian and German), the options in General Settings->Advanced Options with a floating value do not work correctly and they can only display either 1 or 0, with the latter value not allowing any changes, so those values can only be changed by modifying them in the mame.ini file.

This is a fix for that.