### PR TITLE
sega/model2.cpp: make hpyagu98 playable

### DIFF
--- a/src/mame/sega/model2.cpp
+++ b/src/mame/sega/model2.cpp
@@ -7435,10 +7435,10 @@ ROM_START( hpyagu98 ) /* Hanguk Pro Yagu 98, Model 2A, ROM board# 834-11342 REV.
 	ROM_LOAD16_WORD_SWAP( "bb-sn-4.37", 0x600000, 0x200000, CRC(8692fbf3) SHA1(d8e854bba7b54fba85e182d761a9fd02fd13646f) )
 
 	ROM_REGION16_LE(0x80, "eeprom", 0) // EEPROM (required to prevent error #0 on boot)
-	ROM_LOAD("hpyagu98_nvram", 0x00, 0x80, CRC(3634c60f) SHA1(1ab7b74fd05b2d21496af9b2a477c0d197847c55)) // same settings as dynabb97 default
+	ROM_LOAD("hpyagu98_nvram", 0x00, 0x80, CRC(3634c60f) SHA1(1ab7b74fd05b2d21496af9b2a477c0d197847c55)) // partly handcrafted, same settings as dynabb97 default
 
 	ROM_REGION(0x4000, "backup1", 0) // Backup RAM (required to prevent error #0 on boot)
-	ROM_LOAD("hpyagu98_backup", 0x0000, 0x4000, CRC(979751d5) SHA1(2f6c6d12b77d7fbd3e44b05f4c21ca479fae782c))
+	ROM_LOAD("hpyagu98_backup", 0x0000, 0x4000, CRC(979751d5) SHA1(2f6c6d12b77d7fbd3e44b05f4c21ca479fae782c)) // partly handcrafted
 
 	MODEL2_CPU_BOARD
 	MODEL2A_VID_BOARD


### PR DESCRIPTION
`hpyagu98` requires certain values to be set in EEPROM and backup RAM, otherwise it fails to boot with "Error 1":

- The values `0xfa`, `0xe3`, `0xa6` and `0x29` at addresses `0x08`, `0x09`, `0x0a` and `0x0b` respectively in the EEPROM
- The string `"98KOREA PRO B.B."` at the start of backup RAM
- The 32-bit magic number `0x5042c660` at address `0x398` in backup RAM
- A 16-bit checksum at address `0x1d4` in backup RAM; with backup RAM set to default and only the above values modified, this checksum is `0xf92f`

With the above values set the game successfully boots, but the game/coin options are invalid; in my testing I was able to play through a full game, but the game crashed shortly after returning to attract mode.

The game/coin options can easily be set to valid options in the service menu; my current commit uses an EEPROM and backup RAM from just after setting the game/coin options to match the defaults for `dynabb97` and clearing the backup RAM data in the service menu. After doing this, the game appears to be stable.

I shall send the EEPROM and backup RAM used in this commit to the email address listed in [this page](https://wiki.mamedev.org/index.php?title=Submitting_Source_Code). If there is anywhere else I should send these, let me know.

I have swapped the texture ROMs as they were the wrong way round; for now I have left their names intact, but we may want to rename them to `bb-tx-1.25` and `bb-tx-0.24` to reflect their actual IC numbers.