### PR TITLE
model2 driveio_comm_out

### DIFF
--- a/src/mame/sega/model2.cpp
+++ b/src/mame/sega/model2.cpp
@@ -144,6 +144,7 @@ void model2_state::machine_start()
 	debug_init();
 
 	m_lamps.resolve();
+	m_driveio_comm_out.resolve();
 	
 	save_item(NAME(m_intreq));
 	save_item(NAME(m_intena));
@@ -1577,6 +1578,7 @@ void model2_state::rchase2_drive_board_w(u8 data)
 
 void model2_state::drive_board_w(u8 data)
 {
+	m_driveio_comm_out = data;
 	m_driveio_comm_data = data;
 	if (m_drivecpu)
 		m_drivecpu->set_input_line(0, HOLD_LINE);

--- a/src/mame/sega/model2.h
+++ b/src/mame/sega/model2.h
@@ -73,7 +73,8 @@ public:
 		m_in0(*this, "IN0"),
 		m_gears(*this, "GEARS"),
 		m_lightgun_ports(*this, {"P1_Y", "P1_X", "P2_Y", "P2_X"}),
-		m_lamps(*this, "lamp%u", 0U)		
+		m_lamps(*this, "lamp%u", 0U),
+		m_driveio_comm_out(*this, "driveio_comm")
 	{ }
 
 	/* Public for access by the rendering functions */
@@ -138,6 +139,7 @@ protected:
 	optional_ioport m_gears;
 	optional_ioport_array<4> m_lightgun_ports;
 	output_finder<6> m_lamps;
+	output_finder<> m_driveio_comm_out;
 	
 	u32 m_timervals[4]{};
 	u32 m_timerorig[4]{};


### PR DESCRIPTION
This does not implement force feedback.
It only exposes the raw 8-bit value that the game writes to the Model 2 Drive I/O register.

This byte is real machine state and part of the communication protocol with the external motor driver PCB on original hardware. No interpretation or scaling is performed.

Providing this raw value is useful for debugging, hardware research, and future emulation of the actual motor-driver board. Other MAME drivers expose similar raw protocol bytes even when the downstream hardware is not yet emulated.

A consideration for the merge would be highly appreciated.