### PR TITLE
ibm5170: Mark Crystal Caves as a baddump; fix grdchessdx media type

### DIFF
--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -12123,9 +12123,9 @@ Differences between clone/parent:
 		<publisher>Apogee Software</publisher>
 		<info name="developer" value="Apogee Software" />
 		<info name="version" value="1.0a" />
+		<!-- baddump: file dates are in 2005, this is unlikely to be unmodified original media -->
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size = "1474560">
-				<!-- File dates are in 2005; this is unlikely to be unmodified original media -->
 				<rom name="Crystal Caves [Apogee Software] [1991] [3.5HD] [Disk 1 of 1].img" size="1474560" crc="f4360e24" sha1="93a63c8bb0764ba83829b30263ce8870d1902c9f" status="baddump"/>
 			</dataarea>
 		</part>


### PR DESCRIPTION
The file dates for Crystal Caves show as 2005.  I believe this is unlikely to be original media, unless the guy mastering the disks in 1991 had his clock set forward by 14 years by accident.  (Not impossible, but I doubt it.)

Grandmaster Chess Deluxe has its entries set for a 5¼″ floppy drive. The images should be for a 3½″ drive instead.