### PR TITLE
sega/model2.cpp: when writing to IRQ mask register, wait two cycles before checking for sound IRQ; fixes MT09313

### DIFF
--- a/src/mame/sega/model2.h
+++ b/src/mame/sega/model2.h
@@ -147,6 +147,7 @@ protected:
 	u8 m_driveio_comm_data = 0;
 	int m_iop_write_num = 0;
 	u32 m_iop_data = 0;
+	emu_timer *m_irq_delay_timer;
 
 	u32 m_geo_read_start_address = 0;
 	u32 m_geo_write_start_address = 0;
@@ -227,6 +228,7 @@ protected:
 	void sound_ready_w(int state);
 	template <int TNum> TIMER_DEVICE_CALLBACK_MEMBER(model2_timer_cb);
 	void scsp_irq(offs_t offset, u8 data);
+	TIMER_CALLBACK_MEMBER(check_sound_irq);
 
 	void render_frame_start();
 	void geo_parse();


### PR DESCRIPTION
Virtua Cop 2 runs the following code when playing a music track or some sound effects:

```
0005A524: 90803000 005D05FC ld      0x5d05fc,g0			; load sound buffer queue size
0005A52C: 5CB01E01          mov     1,g6
0005A530: 92B03000 00E80004 st      g6,0xe80004			; mask all IRQs except vblank
0005A538: 92B03000 00E80004 st      g6,0xe80004
0005A540: 3C7C202C          cmpibl  15,g0,0x5a56c
0005A544: 90A03000 005D0600 ld      0x5d0600,g4
0005A54C: 59805010          addo    g0,1,g0				; increment sound buffer queue size
0005A550: 5CA81614          mov     g4,g5
0005A554: 8CA52001          lda     0x1(g4),g4
0005A558: 58A5088F          and     15,g4,g4
0005A55C: 92203915 005D0610 st      r4,0x5d0610[g5*4]
0005A564: 92A03000 005D0600 st      g4,0x5d0600
0005A56C: 8CB00401          lda     0x401,g6
0005A570: 92B03000 00E80004 st      g6,0xe80004			; unmask sound IRQ
0005A578: 92803000 005D05FC st      g0,0x5d05fc			; save sound buffer queue size
0005A580: 92B03000 00E80004 st      g6,0xe80004
```
During the sound interrupt handler, the game checks the sound buffer queue size. If it is greater than zero, it reads the next byte from the sound buffer queue, transmits it to the SCSP and decrements the queue size by one; if it is zero (queue is empty), it bails.

[MT09313](https://mametesters.org/view.php?id=9313) is caused by MAME asserting a sound interrupt the instant it is unmasked, before the game has a chance to save the incremented queue size. The sound interrupt handler reads the queue size, mistakenly thinks that the queue is empty and does not transmit the data to the SCSP, resulting in sound effects and/or music tracks not playing. This occurs since commit 99f8b5e05cc0f983a5d52f3e2bae46358e1ef789 when I rewrote the interrupt logic.

It seems there must be a slight delay between unmasking an interrupt and the same interrupt being fired; the exact delay is unknown, but it only needs to be enough for the following `st g0,0x5d05fc` instruction to be executed before the sound interrupt is asserted.

I have implemented it so that when writing to the IRQ mask register, instead of immediately checking to see if a sound interrupt should be asserted, we use a timer to wait for two cycles before doing so (the `st` instruction requires two cycles to execute).