### PR TITLE
ibm5170_cdrom: new working software list title: BSD on Windows

### DIFF
--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -7634,6 +7634,31 @@ Shows Phantagram logo with bottom red strip (DOS 6.22)
 	<!--               Applications              -->
 	<!--                                         -->
 
+	<!-- Windows 3.1/95 -->
+	<!-- From: https://archive.org/details/bsd-on-windows -->
+	<!-- Some documentation is in Japanese, most is in English -->
+	<software name="bow">
+		<description>BSD on Windows (1.5)</description>
+		<year>1996</year>
+		<publisher>ASCII</publisher>
+		<info name="developer" value="Hiroshi Oota" />
+		<info name="language" value="English" />
+		<info name="language" value="Japanese" />
+		<info name="usage" value="Start installation from the floppy disk \SETUP.EXE" />
+		<part name="cdrom1" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="bsd on windows 1.5" sha1="1ccddf4e9eec446d51a1b9e9a15060d9ffd57ec3" />
+			</diskarea>
+		</part>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Setup Disk" />
+			<!-- baddump: Files were accessed in 2023 and two deleted files from 2023 -->
+			<dataarea name="flop" size="1474560">
+				<rom name="bsd on windows 1.5.img" size="1474560" crc="0d44812e" sha1="83fd924a58b6e21bccc76117bdc13d5f9273f3d3" status="baddump" />
+			</dataarea>
+		</part>
+	</software>
+
 	<!-- Windows 95 -->
 	<software name="cdraw6" supported="no">
 		<description>Corel DRAW! 6</description>


### PR DESCRIPTION
Disk images were uploaded to archive.org.  The dumper did not put the floppy disk in write protect mode before dumping and thus several files have 2023 access times, as well as two 2023 files being deleted in the FAT structure.

See also, this blog: https://virtuallyfun.com/2023/12/08/bsd-on-windows-things-i-wish-i-knew-existed/