### PR TITLE
fix risc-v build error casued by cast-align warnings

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -1087,6 +1087,13 @@ if (_OPTIONS["PLATFORM"]=="arm64") then
 	}
 end
 
+if (_OPTIONS["PLATFORM"]=="riscv64") then
+	buildoptions {
+		"-Wno-cast-align",
+	}
+end
+
+
 local subdir
 if (_OPTIONS["target"] == _OPTIONS["subtarget"]) then
 	subdir = _OPTIONS["osd"] .. "/" .. _OPTIONS["target"]


### PR DESCRIPTION
RISC-V, like Arm/Arm64, is stricker on the memory alignment. Disable Wcast-align to make the code buildable for RISC-V.