### PR TITLE
midway/omegrace.cpp: Enable cocktail mode

### DIFF
--- a/src/mame/layout/omegrace.lay
+++ b/src/mame/layout/omegrace.lay
@@ -3,10 +3,14 @@
 license:CC0-1.0
 -->
 <mamelayout version="2">
-	<element name="overlay">
-		<rect>
+	<element name="overlay" defstate="0">
+		<rect state="0">
 			<bounds left="0" top="0" right="1" bottom="1" />
 			<color red="1.0" green="0.894" blue="0.341" />
+		</rect>
+		<rect state="1">
+			<bounds left="0" top="0" right="1" bottom="1" />
+			<color red="0" green="0.586" blue="1.0" />
 		</rect>
 	</element>
 
@@ -14,7 +18,7 @@ license:CC0-1.0
 		<screen index="0">
 			<bounds left="0" top="0" right="4" bottom="3" />
 		</screen>
-		<element ref="overlay" blend="multiply">
+		<element ref="overlay" blend="multiply" inputtag="DSW2" inputmask="0x80">
 			<bounds left="0" top="0" right="4" bottom="3" />
 		</element>
 	</view>

--- a/src/mame/midway/omegrace.cpp
+++ b/src/mame/midway/omegrace.cpp
@@ -362,7 +362,10 @@ void omegrace_state::outputs_w(uint8_t data)
 	m_leds[2] = BIT(~data, 4);
 	m_leds[3] = BIT(~data, 5);
 
-	/* bit 6 flips screen (not supported) */
+	/* bit 6 flips screen */
+	int flip = BIT(~data, 6);
+	m_dvg->set_flip_x(flip);
+	m_dvg->set_flip_y(flip);
 }
 
 
@@ -677,7 +680,7 @@ void omegrace_state::init_omegrace()
  *
  *************************************/
 
-GAMEL(1981, omegrace,  0,        omegrace, omegrace, omegrace_state, init_omegrace, ROT0, "Midway", "Omega Race (set 1)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE, layout_omegrace )
-GAMEL(1981, omegrace2, omegrace, omegrace, omegrace, omegrace_state, init_omegrace, ROT0, "Midway", "Omega Race (set 2)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE, layout_omegrace )
-GAMEL(1981, omegrace3, omegrace, omegrace, omegrace, omegrace_state, init_omegrace, ROT0, "Midway", "Omega Race (set 3, 7/27)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE, layout_omegrace )
-GAMEL(1981, deltrace,  omegrace, omegrace, omegrace, omegrace_state, init_omegrace, ROT0, "bootleg (Allied Leisure)", "Delta Race", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE, layout_omegrace )
+GAMEL(1981, omegrace,  0,        omegrace, omegrace, omegrace_state, init_omegrace, ROT0, "Midway", "Omega Race (set 1)", MACHINE_SUPPORTS_SAVE, layout_omegrace )
+GAMEL(1981, omegrace2, omegrace, omegrace, omegrace, omegrace_state, init_omegrace, ROT0, "Midway", "Omega Race (set 2)", MACHINE_SUPPORTS_SAVE, layout_omegrace )
+GAMEL(1981, omegrace3, omegrace, omegrace, omegrace, omegrace_state, init_omegrace, ROT0, "Midway", "Omega Race (set 3, 7/27)", MACHINE_SUPPORTS_SAVE, layout_omegrace )
+GAMEL(1981, deltrace,  omegrace, omegrace, omegrace, omegrace_state, init_omegrace, ROT0, "bootleg (Allied Leisure)", "Delta Race", MACHINE_SUPPORTS_SAVE, layout_omegrace )


### PR DESCRIPTION
This enables screen flipping when the Omega Race dip switch is set to cocktail.

Also updates layout file as the cocktail has a blue overlay instead of the yellow one the upright has.