### PR TITLE
sound/cem3394.cpp: implement self-oscillation when no waveforms are enabled

### DIFF
--- a/src/devices/sound/cem3394.cpp
+++ b/src/devices/sound/cem3394.cpp
@@ -259,7 +259,6 @@ double cem3394_device::filter(double input, double cutoff)
 		m_filter_out[0] *= scale;
 		m_filter_out[1] *= scale;
 	}
-
 	return output;
 }
 


### PR DESCRIPTION
Detecting the special case of a filter with high resonance and no input waveforms, and generating a sine wave to implement self-oscillation.

Fixes the regression reporter [here](https://github.com/mamedev/mame/pull/14531#issuecomment-3653253168). Also fixes patches 98 and 99 on the `sixtrak`, and enables ever more sounds in `sente6vb` .

Finally, corrected the value of `m_pulse_width` when PW is at 100%.  Though this does not make a difference, since `m_pulse_width` is not used when the PW is 100%.