### PR TITLE
sinclair/specnext.cpp: various fixes

### DIFF
--- a/src/mame/sinclair/screen_ula.cpp
+++ b/src/mame/sinclair/screen_ula.cpp
@@ -226,16 +226,8 @@ std::pair<rgb_t, rgb_t> screen_ula_device::parse_attribute(u8 attr)
 	}
 	else if (m_ulap_en)
 	{
-		if (m_ula_type == ULA_TYPE_NEXT)
-		{
-			ink = 0xc0 | ((attr & 0xc0) >> 3) | BIT(attr, 0, 3);
-			pap = 0xe0 | ((attr & 0xc0) >> 3) | BIT(attr, 3, 3);
-		}
-		else
-		{
-			ink = 0xc0 | ((attr & 0xc0) >> 2) | BIT(attr, 0, 3);
-			pap = 0xc8 | ((attr & 0xc0) >> 2) | BIT(attr, 3, 3);
-		}
+		ink = 0xc0 | ((attr & 0xc0) >> 2) | BIT(attr, 0, 3);
+		pap = 0xc8 | ((attr & 0xc0) >> 2) | BIT(attr, 3, 3);
 	}
 	else
 	{

--- a/src/mame/sinclair/specnext_layer2.cpp
+++ b/src/mame/sinclair/specnext_layer2.cpp
@@ -24,27 +24,48 @@ specnext_layer2_device &specnext_layer2_device::set_palette(const char *tag, u16
 	return *this;
 }
 
-rgb_t specnext_layer2_device::blend(u32 &target, const rgb_t pen, u8 mixer)
+void specnext_layer2_device::blend(u8 &prio, u32 &target, const rgb_t pen, bool is_transparent, bool is_prio_color, u8 pcode, u8 priority_mask, u8 mixer)
 {
-	switch (mixer)
-	{
-	case 0:
-		target = pen;
-		break;
-	case 1:
-		target = rgb_t(target) + pen;
-		break;
-	default:
-	{
-		const u8 five = pal3bit(5);
-		const rgb_t t = rgb_t(target);
-		target = rgb_t(0, rgb_t::clamp(t.r() + pen.r() - five)
-			, rgb_t::clamp(t.g() + pen.g() - five)
-			, rgb_t::clamp(t.b() + pen.b() - five));
-	}
-	}
+	if (is_transparent && !mixer)
+		return;
 
-	return target;
+	if (mixer)
+	{
+		if (!prio)
+			mixer = 0;
+		else if (!(prio & priority_mask) || (prio & ~priority_mask))
+			return;
+
+		if (is_transparent)
+			mixer = 3;
+
+		switch (mixer)
+		{
+		case 0:
+			target = pen;
+			break;
+		case 1:
+			target = rgb_t(target) + pen;
+			break;
+		case 2:
+		{
+			const u8 five = pal3bit(5);
+			const rgb_t t = rgb_t(target);
+			target = rgb_t(0, rgb_t::clamp(t.r() + pen.r() - five)
+				, rgb_t::clamp(t.g() + pen.g() - five)
+				, rgb_t::clamp(t.b() + pen.b() - five));
+		}
+			break;
+		default:
+			target = palette().pen_color(0x800);
+			break;
+		}
+	}
+	else if (is_prio_color || !(prio & priority_mask))
+	{
+		target = pen;
+		prio |= is_prio_color ? 8 : pcode;
+	}
 }
 
 void specnext_layer2_device::draw_mix(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, u8 mixer)
@@ -68,7 +89,7 @@ void specnext_layer2_device::draw_256(screen_device &screen, bitmap_rgb32 &bitma
 	const u8 res = m_resolution + 1;
 	const u16 (&info)[5] = LAYER2_INFO[m_resolution];
 
-	rectangle clip = rectangle{ ((m_clip_x1 + 1) << res) - 1, (std::min<u16>(m_clip_x2 + 1, info[0]) << res) - 1, m_clip_y1, std::min<u8>(m_clip_y2, info[1] - 1) };
+	rectangle clip = rectangle{ m_clip_x1 << res, (std::min<u16>(m_clip_x2 + 1, info[0]) << res) - 1, m_clip_y1, std::min<u8>(m_clip_y2, info[1] - 1) };
 	u16 offset_h = m_offset_h - (info[2] << 1);
 	u16 offset_v = m_offset_v - info[2];
 	clip.offset(offset_h, offset_v);
@@ -80,7 +101,6 @@ void specnext_layer2_device::draw_256(screen_device &screen, bitmap_rgb32 &bitma
 
 	const rgb_t gt0 = rgbexpand<3,3,3>((m_global_transparent << 1) | 0, 6, 3, 0);
 	const rgb_t gt1 = rgbexpand<3,3,3>((m_global_transparent << 1) | 1, 6, 3, 0);
-	const rgb_t fallback_color = palette().pen_color(0x800);
 	const u16 pen_base = (m_layer2_palette_select ? m_palette_alt_offset : m_palette_base_offset) | (m_palette_offset << 4);
 	const u16 x_min = (((clip.left() - offset_h) >> 1) + m_scroll_x) % info[0];
 	const bool x_overscan = m_scroll_x >= info[0] && info[3] == 256;
@@ -95,25 +115,10 @@ void specnext_layer2_device::draw_256(screen_device &screen, bitmap_rgb32 &bitma
 		{
 			const u16 idx = pen_base + (*scr);
 			const rgb_t pen = palette().pen_color(idx);
-			if ((pen != gt0) && (pen != gt1))
-			{
-				const bool prio_color = m_pen_priority[idx];
-				if (prio_color || mixer || ((*(prio) & priority_mask) == 0))
-				{
-					blend(*pix, pen, (*(prio) == priority_mask) ? mixer : 0);
-					*(prio) |= prio_color ? 8 : pcode;
-				}
-				if (prio_color || mixer || ((*(prio + 1) & priority_mask) == 0))
-				{
-					blend(*(pix + 1), pen, (*(prio + 1) == priority_mask) ? mixer : 0);
-					*(prio + 1) |= prio_color ? 8 : pcode;
-				}
-			}
-			else if (mixer)
-			{
-				*pix = fallback_color;
-				*(pix + 1) = fallback_color;
-			}
+			const bool is_transparent = (pen == gt0) || (pen == gt1);
+			const bool is_prio_color = m_pen_priority[idx];
+			blend(*(prio), *(pix), pen, is_transparent, is_prio_color, pcode, priority_mask, mixer);
+			blend(*(prio + 1), *(pix + 1), pen, is_transparent, is_prio_color, pcode, priority_mask, mixer);
 
 			++x %= info[0];
 			if (x == 0 && !x_overscan)
@@ -128,7 +133,7 @@ void specnext_layer2_device::draw_16(screen_device &screen, bitmap_rgb32 &bitmap
 {
 	const u16 (&info)[5] = LAYER2_INFO[1];
 
-	rectangle clip = rectangle{ m_clip_x1 << 2, (std::min<u16>(m_clip_x2, info[0] - 1) << 2) | 1, m_clip_y1, std::min<u8>(m_clip_y2, info[1] - 1) };
+	rectangle clip = rectangle{ m_clip_x1 << 2, (std::min<u16>(m_clip_x2 + 1, info[0]) << 2) - 1, m_clip_y1, std::min<u8>(m_clip_y2, info[1] - 1) };
 
 	u16 offset_h = m_offset_h - (info[2] << 1);
 	u16 offset_v = m_offset_v - info[2];
@@ -156,31 +161,19 @@ void specnext_layer2_device::draw_16(screen_device &screen, bitmap_rgb32 &bitmap
 				hpos ^= 1;
 			else
 			{
-				u16 idx = pen_base + (*scr >> 4);
-				rgb_t pen = palette().pen_color(idx);
-				if ((pen != gt0) && (pen != gt1))
-				{
-					const bool prio_color = m_pen_priority[idx];
-					if (prio_color || mixer || ((*(prio) & priority_mask) == 0))
-					{
-						blend(*pix, pen, (*(prio) == priority_mask) ? mixer : 0);
-						*(prio) |= prio_color ? 8 : pcode;
-					}
-				}
+				const u16 idx = pen_base + (*scr >> 4);
+				const rgb_t pen = palette().pen_color(idx);
+				const bool is_transparent = (pen == gt0) || (pen == gt1);
+				const bool is_prio_color = m_pen_priority[idx];
+				blend(*(prio), *(pix), pen, is_transparent, is_prio_color, pcode, priority_mask, mixer);
 			}
 
 			{
-				u16 idx = pen_base + (*scr & 0x0f);
-				rgb_t pen = palette().pen_color(idx);
-				if ((pen != gt0) && (pen != gt1))
-				{
-					const bool prio_color = m_pen_priority[idx];
-					if (prio_color || mixer || ((*(prio + 1) & priority_mask) == 0))
-					{
-						blend(*(pix + 1), pen, (*(prio + 1) == priority_mask) ? mixer : 0);
-						*(prio + 1) |= prio_color ? 8 : pcode;
-					}
-				}
+				const u16 idx = pen_base + (*scr & 0x0f);
+				const rgb_t pen = palette().pen_color(idx);
+				const bool is_transparent = (pen == gt0) || (pen == gt1);
+				const bool is_prio_color = m_pen_priority[idx];
+				blend(*(prio + 1), *(pix + 1), pen, is_transparent, is_prio_color, pcode, priority_mask, mixer);
 			}
 
 			++x %= info[0];

--- a/src/mame/sinclair/specnext_layer2.h
+++ b/src/mame/sinclair/specnext_layer2.h
@@ -49,7 +49,7 @@ protected:
 private:
 	void draw_256(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, u8 pcode, u8 priority_mask, u8 mixer);
 	void draw_16(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, u8 pcode, u8 priority_mask, u8 mixer);
-	static rgb_t blend(u32 &target, const rgb_t pen, u8 mixer);
+	void blend(u8 &prio, u32 &target, const rgb_t pen, bool is_transparent, bool is_prio_color, u8 pcode, u8 priority_mask, u8 mixer);
 
 	u16 m_offset_h, m_offset_v;
 	const u8 *m_host_ram_ptr;

--- a/src/mame/sinclair/specnext_lores.cpp
+++ b/src/mame/sinclair/specnext_lores.cpp
@@ -46,7 +46,9 @@ void specnext_lores_device::draw(screen_device &screen, bitmap_rgb32 &bitmap, co
 
 	const rgb_t gt0 = rgbexpand<3,3,3>((m_global_transparent << 1) | 0, 6, 3, 0);
 	const rgb_t gt1 = rgbexpand<3,3,3>((m_global_transparent << 1) | 1, 6, 3, 0);
-	const u16 pen_base = (m_lores_palette_select ? m_palette_alt_offset : m_palette_base_offset) | (m_lores_palette_offset << 4);
+	u16 pen_base = (m_lores_palette_select ? m_palette_alt_offset : m_palette_base_offset);
+	if (m_mode) pen_base |= (((m_ulap_en ? 0b1100 : 0) | m_lores_palette_offset) << 4);
+
 	const u8 *screen_location = m_host_ram_ptr + (5 << 14);
 
 	const u16 x4_min = (clip.left() - m_offset_h + (m_scroll_x << 1) + (SCREEN_AREA.width() << 1)) % (SCREEN_AREA.width() << 1);
@@ -55,13 +57,25 @@ void specnext_lores_device::draw(screen_device &screen, bitmap_rgb32 &bitmap, co
 		const u16 y = ((vpos - m_offset_v + m_scroll_y) % SCREEN_AREA.height()) >> 1;
 		u16 x4 = x4_min;
 		u8 off4 = x4 & 3;
-		const u8 *scr = &screen_location[(x4 >> 2) + ((y < 48) ?  128 * y : (128 * (y - 48) + 0x2000))];
+		u16 addr = m_mode
+			? (x4 >> 3) + 64 * y + (m_dfile ? 0x2000 : 0) // Radastan (4bpp)
+			: (x4 >> 2) + ((y < 48) ?  128 * y : (128 * (y - 48) + 0x2000)); // Lores/Jimastan (8bpp)
+		const u8 *scr = &screen_location[addr];
 
 		u32 *pix = &(bitmap.pix(vpos, clip.left()));
 		u8 *prio = &(screen.priority().pix(vpos, clip.left()));
 		for (u16 hpos = clip.left(); hpos <= clip.right(); hpos += 4, pix += 4, prio += 4)
 		{
-			const rgb_t pen = palette().pen_color(pen_base + *scr);
+			u8 attr = *scr;
+			if (m_mode)
+			{
+				if (x4 & 4)
+					attr &= 0x0f;
+				else
+					attr >>= 4;
+			}
+
+			const rgb_t pen = palette().pen_color(pen_base + attr);
 			if ((pen != gt0) && (pen != gt1))
 			{
 				for (u8 i = 0; (i < 4 - off4) && ((hpos + i) <= clip.right()); ++i)
@@ -80,8 +94,13 @@ void specnext_lores_device::draw(screen_device &screen, bitmap_rgb32 &bitmap, co
 			}
 			x4 = (x4 + 4) % (SCREEN_AREA.width() << 1);
 			if (x4 == 0)
-				scr = &screen_location[(y < 48) ?  128 * y : (128 * (y - 48) + 0x2000)];
-			else
+			{
+				addr = m_mode
+					? 64 * y + (m_dfile ? 0x2000 : 0)
+					: (y < 48) ?  128 * y : (128 * (y - 48) + 0x2000);
+				scr = &screen_location[addr];
+			}
+			else if (!m_mode || !(x4 & 4))
 				++scr;
 		}
 	}

--- a/src/mame/sinclair/specnext_sprites.cpp
+++ b/src/mame/sinclair/specnext_sprites.cpp
@@ -81,10 +81,15 @@ void specnext_sprites_device::draw(screen_device &screen, bitmap_rgb32 &bitmap, 
 		const u8 n = m_zero_on_top ? i : (m_sprites_cache.size() - 1) - i;
 		const sprite_data &spr = m_sprites_cache[n];
 
+		s32 destx = m_offset_h + ((spr.x & 0x1ff) << 1);
+		if (destx > (m_offset_h + ((SCREEN_AREA.right() << 1) | 1))) destx -= 512 << 1;
+		s32 desty = m_offset_v + (spr.y & 0x1ff);
+		if (desty > (m_offset_v + SCREEN_AREA.bottom())) desty -= 512;
+
 		gfx((spr.rotate << 1) | spr.h)->prio_zoom_transpen(bitmap, clipped
 			, spr.pattern >> (1 - spr.h), spr.paloff
 			, spr.xmirror, spr.ymirror
-			, ((spr.x & 0x1ff) << 1) + m_offset_h, (spr.y & 0x1ff) + m_offset_v
+			, destx, desty
 			, 0x20000 << spr.xscale, 0x10000 << spr.yscale
 			, screen.priority(), pmask
 			, m_transp_colour & (spr.h ? 0x0f : 0xff));

--- a/src/mame/sinclair/specnext_tiles.h
+++ b/src/mame/sinclair/specnext_tiles.h
@@ -24,7 +24,7 @@ public:
 	void default_flags_w(u8 default_flags) { m_default_flags = default_flags; m_tilemap[0]->mark_all_dirty(); m_tilemap[1]->mark_all_dirty(); }
 	void transp_colour_w(u8 transp_colour) { m_transp_colour = transp_colour; tilemap_update(); }
 
-	void tm_map_base_w(u8 tm_map_base) { m_tm_map_base = tm_map_base; m_tilemap[0]->mark_all_dirty(); m_tilemap[1]->mark_all_dirty(); }
+	void tm_map_base_w(u8 tm_map_base) { m_tm_map_base = tm_map_base; tilemap_update(); }
 	void tm_tile_base_w(u8 tm_tile_base) { m_tm_tile_base = tm_tile_base; tilemap_update(); }
 
 	void tm_scroll_x_w(u16 tm_scroll_x) { m_tm_scroll_x = tm_scroll_x; tilemap_update(); }
@@ -35,7 +35,7 @@ public:
 	void clip_y1_w(u8 clip_y1) { m_clip_y1 = clip_y1; }
 	void clip_y2_w(u8 clip_y2) { m_clip_y2 = clip_y2; }
 
-	void draw(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, u32 flags, u8 pcode = 0xff, u8 priority_mask = 0xff);
+	void draw(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, u32 flags, u8 pcode = 0, u8 priority_mask = 0xff);
 
 protected:
 	static constexpr u8 OVER_BORDER = 32;


### PR DESCRIPTION
sinclair/specnext.cpp:
  * Enabled timer-based steps for SPI
  * Fixed visarea clipping
  * Refactored video modes with blending
  * Fixed ULA+ pen parser - GGGRRRBB instead of RRRGGGBB
  * Renamed "Video" Machine Configuration option to less confusing "Captured Video Resolution"

screen_ula.cpp:
  * ULA+ palette matches original ULA+

specnext_layer2.cpp:
  * Revisited blending layers processing
  * Fixed the layer clipping

specnext_lores.cpp:
  * Added support of Radastan (4bpp) variant
  * Fixed palette configured with offset parameter

specnext_sprites.cpp:
  * Fixed drawing of sprites from negative offset position

specnext_tiles.cpp:
  * Fixed "always on top" option
  * Fixed priority in all variants of textmode