### PR TITLE
pasopia7_cass: 25 additions to software list (19 working)

### DIFF
--- a/hash/pasopia7_cass.xml
+++ b/hash/pasopia7_cass.xml
@@ -161,7 +161,7 @@ Freezes at loading screen.
 		<publisher>Hudson Soft</publisher>
 		<part name="cass1" interface="pasopia7_cass">
 			<dataarea name="cass" size="3837482">
-				<rom name="hitsuji ya-i!.wav" size="3837482" crc="219bf296" sha1="74f28e21e6f075830913d278c8a7ba1abe76d783"/>
+				<rom name="hitsuji yai.wav" size="3837482" crc="219bf296" sha1="74f28e21e6f075830913d278c8a7ba1abe76d783"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
25 additions to Pasopia 7 cassette software list, 19 working.

Also added notes to software list with standard loading instructions.

Dumps from retro-rock, either provided here: https://forums.bannister.org/ubbthreads.php?ubb=showflat&Number=123072 or in rocks preserved games TOSEC repository.

WAVs redumped from original files above using DumpListEditor as the majority of originals did not work, majority of the redumps do.