### PR TITLE
Lift address-bus width limit to 64 bits.

### DIFF
--- a/src/devices/bus/coco/coco_dwsock.cpp
+++ b/src/devices/bus/coco/coco_dwsock.cpp
@@ -162,7 +162,7 @@ u8 beckerport_device::read(offs_t offset)
 			//logerror("beckerport_device: data read 1 byte (0x%02x).  %i bytes remaining.\n", data&0xff, m_rx_pending);
 			break;
 		default:
-			fprintf(stderr, "%s: read from bad offset %d\n", __FILE__, offset);
+			fprintf(stderr, "%s: read from bad offset %04x\n", __FILE__, (uint16_t)offset);
 	}
 
 	return data;
@@ -193,7 +193,7 @@ void beckerport_device::write(offs_t offset, u8 data)
 			//logerror("beckerport_write: data write one byte (0x%02x)\n", d & 0xff);
 			break;
 		default:
-			fprintf(stderr, "%s: write to bad offset %d\n", __FILE__, offset);
+			fprintf(stderr, "%s: write to bad offset %04x\n", __FILE__, (uint16_t)offset);
 	}
 }
 

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -556,7 +556,7 @@ static std::error_condition read_coco_rpk(std::unique_ptr<util::random_read> &&s
 			return err;
 
 		// copy the bytes
-		offs_t size = (offs_t) std::min(contents.size(), (size_t)cart_length - pos);
+		offs_t size = std::min((offs_t)contents.size(), cart_length - pos);
 		memcpy(&mem[pos], &contents[0], size);
 		pos += size;
 	}

--- a/src/devices/bus/isa/ex1280.cpp
+++ b/src/devices/bus/isa/ex1280.cpp
@@ -167,7 +167,7 @@ TMS340X0_SCANLINE_RGB32_CB_MEMBER(isa16_ex1280_device::scanline_update)
 
 TMS340X0_TO_SHIFTREG_CB_MEMBER(isa16_ex1280_device::to_shiftreg)
 {
-	printf("address to shiftreg: %08x\n", address);
+	printf("address to shiftreg: %08x\n", (uint32_t)address);
 	if (address < 0xa00000)
 	{
 		memcpy(shiftreg, &m_vram[address >> 4], 0x400);
@@ -181,7 +181,7 @@ TMS340X0_TO_SHIFTREG_CB_MEMBER(isa16_ex1280_device::to_shiftreg)
 
 TMS340X0_FROM_SHIFTREG_CB_MEMBER(isa16_ex1280_device::from_shiftreg)
 {
-	printf("address from shiftreg: %08x\n", address);
+	printf("address from shiftreg: %08x\n", (uint32_t)address);
 	if (address < 0xa00000)
 	{
 		memcpy(&m_vram[address >> 4], shiftreg, 0x400);

--- a/src/devices/bus/pet/superpet.cpp
+++ b/src/devices/bus/pet/superpet.cpp
@@ -312,7 +312,7 @@ void superpet_device::pet_bd_w(offs_t offset, uint8_t data, int &sel)
 	case 0xefe2:
 	case 0xefe3:
 		m_dongle->write(offset & 0x03, data);
-		printf("6702 %u %02x\n", offset & 0x03, data);
+		printf("6702 %u %02x\n", (uint8_t)offset & 0x03, data);
 		break;
 
 	case 0xeff0:

--- a/src/devices/cpu/arm7/arm7.cpp
+++ b/src/devices/cpu/arm7/arm7.cpp
@@ -2104,7 +2104,7 @@ void arm946es_cpu_device::RefreshITCM()
 	}
 }
 
-void arm946es_cpu_device::arm7_cpu_write32(uint32_t addr, uint32_t data)
+void arm946es_cpu_device::arm7_cpu_write32(offs_t addr, uint32_t data)
 {
 	addr &= ~3;
 
@@ -2125,7 +2125,7 @@ void arm946es_cpu_device::arm7_cpu_write32(uint32_t addr, uint32_t data)
 }
 
 
-void arm946es_cpu_device::arm7_cpu_write16(uint32_t addr, uint16_t data)
+void arm946es_cpu_device::arm7_cpu_write16(offs_t addr, uint16_t data)
 {
 	addr &= ~1;
 	if ((addr >= cp15_itcm_base) && (addr <= cp15_itcm_end))
@@ -2144,7 +2144,7 @@ void arm946es_cpu_device::arm7_cpu_write16(uint32_t addr, uint16_t data)
 	m_program->write_word(addr, data);
 }
 
-void arm946es_cpu_device::arm7_cpu_write8(uint32_t addr, uint8_t data)
+void arm946es_cpu_device::arm7_cpu_write8(offs_t addr, uint8_t data)
 {
 	if ((addr >= cp15_itcm_base) && (addr <= cp15_itcm_end))
 	{
@@ -2160,7 +2160,7 @@ void arm946es_cpu_device::arm7_cpu_write8(uint32_t addr, uint8_t data)
 	m_program->write_byte(addr, data);
 }
 
-uint32_t arm946es_cpu_device::arm7_cpu_read32(uint32_t addr)
+uint32_t arm946es_cpu_device::arm7_cpu_read32(offs_t addr)
 {
 	uint32_t result;
 
@@ -2204,7 +2204,7 @@ uint32_t arm946es_cpu_device::arm7_cpu_read32(uint32_t addr)
 	return result;
 }
 
-uint32_t arm946es_cpu_device::arm7_cpu_read16(uint32_t addr)
+uint32_t arm946es_cpu_device::arm7_cpu_read16(offs_t addr)
 {
 	addr &= ~1;
 
@@ -2222,7 +2222,7 @@ uint32_t arm946es_cpu_device::arm7_cpu_read16(uint32_t addr)
 	return m_program->read_word(addr);
 }
 
-uint8_t arm946es_cpu_device::arm7_cpu_read8(uint32_t addr)
+uint8_t arm946es_cpu_device::arm7_cpu_read8(offs_t addr)
 {
 	if ((addr >= cp15_itcm_base) && (addr <= cp15_itcm_end))
 	{
@@ -2308,7 +2308,7 @@ void arm1176jzf_s_cpu_device::arm7_rt_w_callback(offs_t offset, uint32_t data)
 /***************************************************************************
  * Default Memory Handlers
  ***************************************************************************/
-void arm7_cpu_device::arm7_cpu_write32(uint32_t addr, uint32_t data)
+void arm7_cpu_device::arm7_cpu_write32(offs_t addr, uint32_t data)
 {
 	if( COPRO_CTRL & COPRO_CTRL_MMU_EN )
 	{
@@ -2323,7 +2323,7 @@ void arm7_cpu_device::arm7_cpu_write32(uint32_t addr, uint32_t data)
 }
 
 
-void arm7_cpu_device::arm7_cpu_write16(uint32_t addr, uint16_t data)
+void arm7_cpu_device::arm7_cpu_write16(offs_t addr, uint16_t data)
 {
 	if( COPRO_CTRL & COPRO_CTRL_MMU_EN )
 	{
@@ -2337,7 +2337,7 @@ void arm7_cpu_device::arm7_cpu_write16(uint32_t addr, uint16_t data)
 	m_program->write_word(addr, data);
 }
 
-void arm7_cpu_device::arm7_cpu_write8(uint32_t addr, uint8_t data)
+void arm7_cpu_device::arm7_cpu_write8(offs_t addr, uint8_t data)
 {
 	if( COPRO_CTRL & COPRO_CTRL_MMU_EN )
 	{
@@ -2350,7 +2350,7 @@ void arm7_cpu_device::arm7_cpu_write8(uint32_t addr, uint8_t data)
 	m_program->write_byte(addr, data);
 }
 
-uint32_t arm7_cpu_device::arm7_cpu_read32(uint32_t addr)
+uint32_t arm7_cpu_device::arm7_cpu_read32(offs_t addr)
 {
 	uint32_t result;
 
@@ -2374,7 +2374,7 @@ uint32_t arm7_cpu_device::arm7_cpu_read32(uint32_t addr)
 	return result;
 }
 
-uint32_t arm7_cpu_device::arm7_cpu_read16(uint32_t addr)
+uint32_t arm7_cpu_device::arm7_cpu_read16(offs_t addr)
 {
 	uint32_t result;
 
@@ -2396,7 +2396,7 @@ uint32_t arm7_cpu_device::arm7_cpu_read16(uint32_t addr)
 	return result;
 }
 
-uint8_t arm7_cpu_device::arm7_cpu_read8(uint32_t addr)
+uint8_t arm7_cpu_device::arm7_cpu_read8(offs_t addr)
 {
 	if( COPRO_CTRL & COPRO_CTRL_MMU_EN )
 	{

--- a/src/devices/cpu/arm7/arm7.h
+++ b/src/devices/cpu/arm7/arm7.h
@@ -233,12 +233,12 @@ protected:
 	int detect_fault(int desc_lvl1, int ap, int flags);
 	void arm7_check_irq_state();
 	void update_irq_state();
-	virtual void arm7_cpu_write32(uint32_t addr, uint32_t data);
-	virtual void arm7_cpu_write16(uint32_t addr, uint16_t data);
-	virtual void arm7_cpu_write8(uint32_t addr, uint8_t data);
-	virtual uint32_t arm7_cpu_read32(uint32_t addr);
-	virtual uint32_t arm7_cpu_read16(uint32_t addr);
-	virtual uint8_t arm7_cpu_read8(uint32_t addr);
+	virtual void arm7_cpu_write32(offs_t addr, uint32_t data);
+	virtual void arm7_cpu_write16(offs_t addr, uint16_t data);
+	virtual void arm7_cpu_write8(offs_t addr, uint8_t data);
+	virtual uint32_t arm7_cpu_read32(offs_t addr);
+	virtual uint32_t arm7_cpu_read16(offs_t addr);
+	virtual uint8_t arm7_cpu_read8(offs_t addr);
 
 	// Coprocessor support
 	void arm7_do_callback(uint32_t data);
@@ -417,12 +417,12 @@ public:
 	virtual uint32_t arm7_rt_r_callback(offs_t offset) override;
 	virtual void arm7_rt_w_callback(offs_t offset, uint32_t data) override;
 
-	virtual void arm7_cpu_write32(uint32_t addr, uint32_t data) override;
-	virtual void arm7_cpu_write16(uint32_t addr, uint16_t data) override;
-	virtual void arm7_cpu_write8(uint32_t addr, uint8_t data) override;
-	virtual uint32_t arm7_cpu_read32(uint32_t addr) override;
-	virtual uint32_t arm7_cpu_read16(uint32_t addr) override;
-	virtual uint8_t arm7_cpu_read8(uint32_t addr) override;
+	virtual void arm7_cpu_write32(offs_t addr, uint32_t data) override;
+	virtual void arm7_cpu_write16(offs_t addr, uint16_t data) override;
+	virtual void arm7_cpu_write8(offs_t addr, uint8_t data) override;
+	virtual uint32_t arm7_cpu_read32(offs_t addr) override;
+	virtual uint32_t arm7_cpu_read16(offs_t addr) override;
+	virtual uint8_t arm7_cpu_read8(offs_t addr) override;
 
 protected:
 	arm946es_cpu_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);

--- a/src/devices/cpu/drcbex64.cpp
+++ b/src/devices/cpu/drcbex64.cpp
@@ -1816,7 +1816,7 @@ void drcbe_x64::movsd_p64_r128(Assembler &a, be_parameter const &param, Vec cons
 
 void drcbe_x64::debug_log_hashjmp(offs_t pc, int mode)
 {
-	std::printf("mode=%d PC=%16llX\n", mode, pc);
+	std::printf("mode=%d PC=%s\n", mode, util::string_format("%x", pc).c_str());
 }
 
 

--- a/src/devices/cpu/drcbex64.cpp
+++ b/src/devices/cpu/drcbex64.cpp
@@ -1816,7 +1816,7 @@ void drcbe_x64::movsd_p64_r128(Assembler &a, be_parameter const &param, Vec cons
 
 void drcbe_x64::debug_log_hashjmp(offs_t pc, int mode)
 {
-	std::printf("mode=%d PC=%08X\n", mode, pc);
+	std::printf("mode=%d PC=%16llX\n", mode, pc);
 }
 
 

--- a/src/devices/cpu/drcbex86.cpp
+++ b/src/devices/cpu/drcbex86.cpp
@@ -2860,7 +2860,7 @@ void drcbe_x86::emit_fstp_p(Assembler &a, int size, be_parameter const &param)
 
 void drcbe_x86::debug_log_hashjmp(int mode, offs_t pc)
 {
-	std::printf("mode=%d PC=%16llX\n", mode, pc);
+	std::printf("mode=%d PC=%s\n", mode, util::string_format("%x", pc).c_str());
 }
 
 

--- a/src/devices/cpu/drcbex86.cpp
+++ b/src/devices/cpu/drcbex86.cpp
@@ -2860,7 +2860,7 @@ void drcbe_x86::emit_fstp_p(Assembler &a, int size, be_parameter const &param)
 
 void drcbe_x86::debug_log_hashjmp(int mode, offs_t pc)
 {
-	std::printf("mode=%d PC=%08X\n", mode, pc);
+	std::printf("mode=%d PC=%16llX\n", mode, pc);
 }
 
 

--- a/src/devices/cpu/drcfe.cpp
+++ b/src/devices/cpu/drcfe.cpp
@@ -52,7 +52,7 @@ struct pc_stack_entry
 //  drc_frontend - constructor
 //-------------------------------------------------
 
-drc_frontend::drc_frontend(device_t &cpu, u32 window_start, u32 window_end, u32 max_sequence)
+drc_frontend::drc_frontend(device_t &cpu, offs_t window_start, offs_t window_end, u32 max_sequence)
 	: m_window_start(window_start)
 	, m_window_end(window_end)
 	, m_max_sequence(max_sequence)

--- a/src/devices/cpu/drcfe.h
+++ b/src/devices/cpu/drcfe.h
@@ -128,7 +128,7 @@ class drc_frontend
 {
 public:
 	// construction/destruction
-	drc_frontend(device_t &cpu, u32 window_start, u32 window_end, u32 max_sequence);
+	drc_frontend(device_t &cpu, offs_t window_start, offs_t window_end, u32 max_sequence);
 	virtual ~drc_frontend();
 
 	// describe a block
@@ -148,8 +148,8 @@ private:
 	void release_descriptions();
 
 	// configuration parameters
-	u32                 m_window_start;             // code window start offset = startpc - window_start
-	u32                 m_window_end;               // code window end offset = startpc + window_end
+	offs_t              m_window_start;             // code window start offset = startpc - window_start
+	offs_t              m_window_end;               // code window end offset = startpc + window_end
 	u32                 m_max_sequence;             // maximum instructions to include in a sequence
 
 	// CPU parameters

--- a/src/devices/cpu/dspp/dspp.cpp
+++ b/src/devices/cpu/dspp/dspp.cpp
@@ -2046,7 +2046,7 @@ uint32_t dspp_device::read_ext_control(offs_t offset)
 		}
 		default:
 		{
-			printf("DSPP: Unhandled external control read (%.4x)\n", offset << 2);
+			printf("DSPP: Unhandled external control read (%.4x)\n", (uint16_t)offset << 2);
 			break;
 		}
 	}
@@ -2281,7 +2281,7 @@ void dspp_device::write_ext_control(offs_t offset, uint32_t data)
 		}
 		default:
 		{
-			printf("DSPP: Unhandled external control write (%.4x with %.8x)\n", offset << 2, data);
+			printf("DSPP: Unhandled external control write (%.4x with %.8x)\n", (uint16_t)offset << 2, data);
 			break;
 		}
 	}

--- a/src/devices/cpu/f2mc16/f2mc16d.cpp
+++ b/src/devices/cpu/f2mc16/f2mc16d.cpp
@@ -66,7 +66,7 @@ const std::string_view f2mc16_disassembler::s_bcc_ops[16] =
 	"BLS", "BHI"
 };
 
-offs_t f2mc16_disassembler::opcode_alignment() const
+u32 f2mc16_disassembler::opcode_alignment() const
 {
 	return 1;
 }

--- a/src/devices/cpu/f2mc16/f2mc16d.h
+++ b/src/devices/cpu/f2mc16/f2mc16d.h
@@ -13,7 +13,7 @@ public:
 
 protected:
 	// disasm_interface overrides
-	virtual offs_t opcode_alignment() const override;
+	virtual u32 opcode_alignment() const override;
 	virtual u32 interface_flags() const override;
 	virtual u32 page_address_bits() const override;
 	virtual offs_t disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params) override;

--- a/src/devices/cpu/h8500/h8500dasm.cpp
+++ b/src/devices/cpu/h8500/h8500dasm.cpp
@@ -63,7 +63,7 @@ const char *const h8500_disassembler::s_branches[0x10] =
 	"BGT", "BLE"
 };
 
-offs_t h8500_disassembler::opcode_alignment() const
+u32 h8500_disassembler::opcode_alignment() const
 {
 	return 1;
 }

--- a/src/devices/cpu/h8500/h8500dasm.h
+++ b/src/devices/cpu/h8500/h8500dasm.h
@@ -13,7 +13,7 @@ public:
 
 protected:
 	// disasm_interface overrides
-	virtual offs_t opcode_alignment() const override;
+	virtual u32 opcode_alignment() const override;
 	virtual u32 interface_flags() const override;
 	virtual u32 page_address_bits() const override;
 	virtual offs_t disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params) override;

--- a/src/devices/cpu/i386/athlon.cpp
+++ b/src/devices/cpu/i386/athlon.cpp
@@ -407,7 +407,8 @@ void athlonxp_device::cache_clean()
 
 uint8_t athlonxp_device::READ8PL(uint32_t ea, uint8_t privilege)
 {
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	if(!translate_address(privilege,TR_READ,&address,&error))
 		PF_THROW(error);
@@ -421,7 +422,8 @@ uint8_t athlonxp_device::READ8PL(uint32_t ea, uint8_t privilege)
 uint16_t athlonxp_device::READ16PL(uint32_t ea, uint8_t privilege)
 {
 	uint16_t value;
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	switch (ea & 3)
 	{
@@ -462,7 +464,8 @@ uint16_t athlonxp_device::READ16PL(uint32_t ea, uint8_t privilege)
 uint32_t athlonxp_device::READ32PL(uint32_t ea, uint8_t privilege)
 {
 	uint32_t value;
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	switch (ea & 3)
 	{
@@ -507,7 +510,8 @@ uint32_t athlonxp_device::READ32PL(uint32_t ea, uint8_t privilege)
 uint64_t athlonxp_device::READ64PL(uint32_t ea, uint8_t privilege)
 {
 	uint64_t value;
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	switch (ea & 3)
 	{
@@ -551,7 +555,8 @@ uint64_t athlonxp_device::READ64PL(uint32_t ea, uint8_t privilege)
 
 void athlonxp_device::WRITE8PL(uint32_t ea, uint8_t privilege, uint8_t value)
 {
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 	if(!translate_address(privilege,TR_WRITE,&address,&error))
 		PF_THROW(error);
 
@@ -563,7 +568,8 @@ void athlonxp_device::WRITE8PL(uint32_t ea, uint8_t privilege, uint8_t value)
 
 void athlonxp_device::WRITE16PL(uint32_t ea, uint8_t privilege, uint16_t value)
 {
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	switch(ea & 3)
 	{
@@ -600,7 +606,8 @@ void athlonxp_device::WRITE16PL(uint32_t ea, uint8_t privilege, uint16_t value)
 
 void athlonxp_device::WRITE32PL(uint32_t ea, uint8_t privilege, uint32_t value)
 {
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	switch(ea & 3)
 	{
@@ -641,7 +648,8 @@ void athlonxp_device::WRITE32PL(uint32_t ea, uint8_t privilege, uint32_t value)
 
 void athlonxp_device::WRITE64PL(uint32_t ea, uint8_t privilege, uint64_t value)
 {
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	switch(ea & 3)
 	{

--- a/src/devices/cpu/i386/i386.cpp
+++ b/src/devices/cpu/i386/i386.cpp
@@ -194,10 +194,10 @@ device_vtlb_interface::vtlb_entry i386_device::get_permissions(uint32_t pte, int
 
 bool i386_device::i386_translate_address(int intention, bool debug, offs_t *address, vtlb_entry *entry)
 {
-	uint32_t a = *address;
-	uint32_t pdbr = m_cr[3] & 0xfffff000;
-	uint32_t directory = (a >> 22) & 0x3ff;
-	uint32_t table = (a >> 12) & 0x3ff;
+	offs_t a = *address;
+	offs_t pdbr = m_cr[3] & 0xfffff000;
+	offs_t directory = (a >> 22) & 0x3ff;
+	offs_t table = (a >> 12) & 0x3ff;
 	vtlb_entry perm = 0;
 	bool ret;
 	bool user = (intention & TR_USER) ? true : false;
@@ -281,20 +281,20 @@ bool i386_device::i386_translate_address(int intention, bool debug, offs_t *addr
 
 //#define TEST_TLB
 
-bool i386_device::translate_address(int pl, int type, uint32_t *address, uint32_t *error)
+bool i386_device::translate_address(int pl, int type, offs_t *address, uint32_t *error)
 {
 	if (!(m_cr[0] & CR0_PG)) // Some (very few) old OS's won't work with this
 		return true;
 
 	const vtlb_entry *table = vtlb_table();
-	uint32_t index = *address >> 12;
+	offs_t index = *address >> 12;
 	vtlb_entry entry = table[index];
 	if (type == TR_FETCH)
 		type = TR_READ;
 	if (pl == 3)
 		type |= TR_USER;
 #ifdef TEST_TLB
-	uint32_t test_addr = *address;
+	offs_t test_addr = *address;
 #endif
 
 	if (!(entry & FLAG_VALID) || ((type & TR_WRITE) && !(entry & FLAG_DIRTY)))
@@ -340,7 +340,8 @@ void i386_device::NEAR_BRANCH(int32_t offs)
 uint8_t i386_device::FETCH()
 {
 	uint8_t value;
-	uint32_t address = m_pc, error;
+	offs_t address = m_pc;
+	uint32_t error;
 
 	if(!translate_address(m_CPL,TR_FETCH,&address,&error))
 		PF_THROW(error);
@@ -357,7 +358,8 @@ uint8_t i386_device::FETCH()
 uint16_t i386_device::FETCH16()
 {
 	uint16_t value;
-	uint32_t address = m_pc, error;
+	offs_t address = m_pc;
+	uint32_t error;
 
 	if( !WORD_ALIGNED(address) ) {       /* Unaligned read */
 		value = (FETCH() << 0);
@@ -375,7 +377,8 @@ uint16_t i386_device::FETCH16()
 uint32_t i386_device::FETCH32()
 {
 	uint32_t value;
-	uint32_t address = m_pc, error;
+	offs_t address = m_pc;
+	uint32_t error;
 
 	if( !DWORD_ALIGNED(m_pc) ) {      /* Unaligned read */
 		value = (FETCH() << 0);
@@ -396,7 +399,8 @@ uint32_t i386_device::FETCH32()
 
 uint8_t i386_device::READ8PL(uint32_t ea, uint8_t privilege)
 {
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	if(!translate_address(privilege,TR_READ,&address,&error))
 		PF_THROW(error);
@@ -408,7 +412,8 @@ uint8_t i386_device::READ8PL(uint32_t ea, uint8_t privilege)
 uint16_t i386_device::READ16PL(uint32_t ea, uint8_t privilege)
 {
 	uint16_t value;
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	switch (ea & 3)
 	{
@@ -442,7 +447,8 @@ uint16_t i386_device::READ16PL(uint32_t ea, uint8_t privilege)
 uint32_t i386_device::READ32PL(uint32_t ea, uint8_t privilege)
 {
 	uint32_t value;
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	switch (ea & 3)
 	{
@@ -487,7 +493,8 @@ uint32_t i386_device::READ32PL(uint32_t ea, uint8_t privilege)
 uint64_t i386_device::READ64PL(uint32_t ea, uint8_t privilege)
 {
 	uint64_t value;
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	switch (ea & 3)
 	{
@@ -532,7 +539,8 @@ uint64_t i386_device::READ64PL(uint32_t ea, uint8_t privilege)
 uint16_t i386sx_device::READ16PL(uint32_t ea, uint8_t privilege)
 {
 	uint16_t value;
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	if (WORD_ALIGNED(ea))
 	{
@@ -595,14 +603,16 @@ uint64_t i386sx_device::READ64PL(uint32_t ea, uint8_t privilege)
 
 void i386_device::WRITE_TEST(uint32_t ea)
 {
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 	if(!translate_address(m_CPL,TR_WRITE,&address,&error))
 		PF_THROW(error);
 }
 
 void i386_device::WRITE8PL(uint32_t ea, uint8_t privilege, uint8_t value)
 {
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 	if(!translate_address(privilege,TR_WRITE,&address,&error))
 		PF_THROW(error);
 
@@ -612,7 +622,8 @@ void i386_device::WRITE8PL(uint32_t ea, uint8_t privilege, uint8_t value)
 
 void i386_device::WRITE16PL(uint32_t ea, uint8_t privilege, uint16_t value)
 {
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	switch(ea & 3)
 	{
@@ -642,7 +653,8 @@ void i386_device::WRITE16PL(uint32_t ea, uint8_t privilege, uint16_t value)
 
 void i386_device::WRITE32PL(uint32_t ea, uint8_t privilege, uint32_t value)
 {
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	switch(ea & 3)
 	{
@@ -683,7 +695,8 @@ void i386_device::WRITE32PL(uint32_t ea, uint8_t privilege, uint32_t value)
 
 void i386_device::WRITE64PL(uint32_t ea, uint8_t privilege, uint64_t value)
 {
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	switch(ea & 3)
 	{
@@ -724,7 +737,8 @@ void i386_device::WRITE64PL(uint32_t ea, uint8_t privilege, uint64_t value)
 
 void i386sx_device::WRITE16PL(uint32_t ea, uint8_t privilege, uint16_t value)
 {
-	uint32_t address = ea, error;
+	offs_t address = ea;
+	uint32_t error;
 
 	if (WORD_ALIGNED(ea))
 	{
@@ -1740,9 +1754,9 @@ void i386_device::i386_decode_four_byte38f3()
 
 uint8_t i386_device::read8_debug(uint32_t ea, uint8_t *data)
 {
-	uint32_t address = ea;
+	offs_t address = ea;
 
-	if(!i386_translate_address(TR_READ, true, &address,nullptr))
+	if(!i386_translate_address(TR_READ, true, &address, nullptr))
 		return 0;
 
 	address &= m_a20_mask;
@@ -1875,9 +1889,9 @@ uint64_t i386_device::debug_segofftovirt(int params, const uint64_t *param)
 
 uint64_t i386_device::debug_virttophys(int params, const uint64_t *param)
 {
-	uint32_t result = param[0];
+	offs_t result = param[0];
 
-	if(!i386_translate_address(TR_READ,true,&result,nullptr))
+	if(!i386_translate_address(TR_READ, true, &result, nullptr))
 		return 0;
 	return result;
 }
@@ -2760,11 +2774,11 @@ void i386_device::i386_set_a20_line(int state)
 {
 	if (state)
 	{
-		m_a20_mask = ~0;
+		m_a20_mask = ~0ULL;
 	}
 	else
 	{
-		m_a20_mask = ~(1 << 20);
+		m_a20_mask = ~(1ULL << 20);
 	}
 	// TODO: how does A20M and the tlb interact
 	vtlb_flush_dynamic();
@@ -2801,7 +2815,16 @@ void i386_device::execute_run()
 				{
 					uint32_t phys_addr = 0;
 					uint32_t error;
-					phys_addr = (m_cr[0] & CR0_PG) ? translate_address(m_CPL, TR_FETCH, &m_dr[i], &error) : m_dr[i];
+					if(m_cr[0] & CR0_PG)
+					{
+						offs_t addr = m_dr[i];
+						phys_addr = translate_address(m_CPL, TR_FETCH, &addr, &error);
+						m_dr[i] = (uint32_t)addr;
+					}
+					else
+					{
+						phys_addr = m_dr[i];
+					}
 					if(breakpoint_length != 0) // Not one byte in length? logerror it, I have no idea how this works on real processors.
 					{
 						LOGMASKED(LOG_INVALID_OPCODE, "i386: Breakpoint length not 1 byte on an instruction breakpoint\n");

--- a/src/devices/cpu/i386/i386.h
+++ b/src/devices/cpu/i386/i386.h
@@ -347,7 +347,7 @@ protected:
 	uint8_t m_irq_state;
 	address_space *m_program;
 	address_space *m_io;
-	uint32_t m_a20_mask;
+	offs_t m_a20_mask;
 	memory_access<32, 1, 0, ENDIANNESS_LITTLE>::cache macache16;
 	memory_access<32, 2, 0, ENDIANNESS_LITTLE>::cache macache32;
 
@@ -438,7 +438,7 @@ protected:
 	uint32_t i386_translate(int segment, uint32_t ip, int rwn, int size = 1);
 	inline vtlb_entry get_permissions(uint32_t pte, int wp);
 	bool i386_translate_address(int intention, bool debug, offs_t *address, vtlb_entry *entry);
-	bool translate_address(int pl, int type, uint32_t *address, uint32_t *error);
+	bool translate_address(int pl, int type, offs_t *address, uint32_t *error);
 	void CHANGE_PC(uint32_t pc);
 	inline void NEAR_BRANCH(int32_t offs);
 	inline uint8_t FETCH();

--- a/src/devices/cpu/i386/i386op16.hxx
+++ b/src/devices/cpu/i386/i386op16.hxx
@@ -3215,7 +3215,7 @@ void i386_device::i386_group0F00_16()          // Opcode 0x0f 00
 				seg.selector = m_task.segment;
 				i386_load_protected_mode_segment(&seg,nullptr);
 
-				uint32_t addr = ((seg.selector & 4) ? m_ldtr.base : m_gdtr.base) + (seg.selector & ~7) + 5;
+				offs_t addr = ((seg.selector & 4) ? m_ldtr.base : m_gdtr.base) + (seg.selector & ~7) + 5;
 				i386_translate_address(TR_READ, false, &addr, nullptr);
 				m_program->write_byte(addr, (seg.flags & 0xff) | 2);
 

--- a/src/devices/cpu/i386/i386op32.hxx
+++ b/src/devices/cpu/i386/i386op32.hxx
@@ -3017,7 +3017,7 @@ void i386_device::i386_group0F00_32()          // Opcode 0x0f 00
 				seg.selector = m_task.segment;
 				i386_load_protected_mode_segment(&seg,nullptr);
 
-				uint32_t addr = ((seg.selector & 4) ? m_ldtr.base : m_gdtr.base) + (seg.selector & ~7) + 5;
+				offs_t addr = ((seg.selector & 4) ? m_ldtr.base : m_gdtr.base) + (seg.selector & ~7) + 5;
 				i386_translate_address(TR_READ, false, &addr, nullptr);
 				m_program->write_byte(addr, (seg.flags & 0xff) | 2);
 

--- a/src/devices/cpu/i386/i386segs.hxx
+++ b/src/devices/cpu/i386/i386segs.hxx
@@ -80,7 +80,7 @@ void i386_device::i386_load_call_gate(I386_CALL_GATE *gate)
 void i386_device::i386_set_descriptor_accessed(uint16_t selector)
 {
 	// assume the selector is valid, we don't need to check it again
-	uint32_t base, addr;
+	offs_t base, addr;
 	uint8_t rights;
 	if(!(selector & ~3))
 		return;
@@ -2500,7 +2500,7 @@ inline void i386_device::dri_changed()
 		{
 			int breakpoint_type = (m_dr[7] >> ((dr << 2) + 16)) & 3;
 			int breakpoint_length = (m_dr[7] >> ((dr << 2) + 16 + 2)) & 3;
-			uint32_t phys_addr = m_dr[dr];
+			offs_t phys_addr = m_dr[dr];
 			uint32_t error;
 			if(translate_address(m_CPL, TR_READ, &phys_addr, &error))
 			{

--- a/src/devices/cpu/lc8670/lc8670dsm.cpp
+++ b/src/devices/cpu/lc8670/lc8670dsm.cpp
@@ -109,18 +109,18 @@ void lc8670_disassembler::dasm_arg(uint8_t op, char *buffer, offs_t pc, int arg,
 			pc++;
 			[[fallthrough]];
 		case OP_R8RI:
-			buffer += sprintf(buffer, "%04x", (pc + 1 + opcodes.r8(pos) - (opcodes.r8(pos)&0x80 ? 0x100 : 0)) & 0xffff);
+			buffer += sprintf(buffer, "%04x", ((u32)pc + 1 + opcodes.r8(pos) - (opcodes.r8(pos)&0x80 ? 0x100 : 0)) & 0xffff);
 			pos++;
 			break;
 		case OP_R16:
-			buffer += sprintf(buffer, "%04x", (pc + 2 + ((opcodes.r8(pos+1)<<8) | opcodes.r8(pos))) & 0xffff);
+			buffer += sprintf(buffer, "%04x", ((u32)pc + 2 + ((opcodes.r8(pos+1)<<8) | opcodes.r8(pos))) & 0xffff);
 			pos += 2;
 			break;
 		case OP_RI:
 			buffer += sprintf(buffer, "@%x", op & 0x03);
 			break;
 		case OP_A12:
-			buffer += sprintf(buffer, "%04x", ((pc + 2) & 0xf000) | ((op & 0x10)<<7) | ((op & 0x07)<<8) | opcodes.r8(pos));
+			buffer += sprintf(buffer, "%04x", (((u32)pc + 2) & 0xf000) | ((op & 0x10)<<7) | ((op & 0x07)<<8) | opcodes.r8(pos));
 			pos++;
 			break;
 		case OP_A16:

--- a/src/devices/cpu/mips/mips1.cpp
+++ b/src/devices/cpu/mips/mips1.cpp
@@ -1127,7 +1127,7 @@ template <typename T> unsigned mips1core_device_base::shift_factor(u32 address) 
 		return 0;
 }
 
-template <typename T, bool Aligned, typename U> std::enable_if_t<std::is_convertible<U, std::function<void(T)>>::value, void> mips1core_device_base::load(u32 address, U &&apply)
+template <typename T, bool Aligned, typename U> std::enable_if_t<std::is_convertible<U, std::function<void(T)>>::value, void> mips1core_device_base::load(offs_t address, U &&apply)
 {
 	// alignment error
 	if (Aligned && (address & (sizeof(T) - 1)))
@@ -1204,7 +1204,7 @@ template <typename T, bool Aligned, typename U> std::enable_if_t<std::is_convert
 	apply(data);
 }
 
-template <typename T, bool Aligned> void mips1core_device_base::store(u32 address, T data, T mem_mask)
+template <typename T, bool Aligned> void mips1core_device_base::store(offs_t address, T data, T mem_mask)
 {
 	// alignment error
 	if (Aligned && (address & (sizeof(T) - 1)))
@@ -1274,7 +1274,7 @@ template <typename T, bool Aligned> void mips1core_device_base::store(u32 addres
 	}
 }
 
-void mips1core_device_base::fetch(u32 address, std::function<void(u32)> &&apply)
+void mips1core_device_base::fetch(offs_t address, std::function<void(u32)> &&apply)
 {
 	// alignment error
 	if (address & 3)

--- a/src/devices/cpu/mips/mips1.h
+++ b/src/devices/cpu/mips/mips1.h
@@ -59,9 +59,9 @@ protected:
 	// memory
 	enum translate_result : unsigned { ERROR, UNCACHED, CACHED };
 	virtual translate_result translate(int intention, offs_t &address, bool debug);
-	template <typename T, bool Aligned = true, typename U> std::enable_if_t<std::is_convertible<U, std::function<void(T)>>::value, void> load(u32 address, U &&apply);
-	template <typename T, bool Aligned = true> void store(u32 address, T data, T mem_mask = ~T(0));
-	void fetch(u32 address, std::function<void(u32)> &&apply);
+	template <typename T, bool Aligned = true, typename U> std::enable_if_t<std::is_convertible<U, std::function<void(T)>>::value, void> load(offs_t address, U &&apply);
+	template <typename T, bool Aligned = true> void store(offs_t address, T data, T mem_mask = ~T(0));
+	void fetch(offs_t address, std::function<void(u32)> &&apply);
 
 	// cache
 	template <typename T> unsigned shift_factor(u32 address) const;

--- a/src/devices/cpu/ns32000/common.h
+++ b/src/devices/cpu/ns32000/common.h
@@ -87,7 +87,7 @@ class ns32000_mmu_interface : public ns32000_slave_interface
 {
 public:
 	enum translate_result : unsigned { COMPLETE, CANCEL, ABORT };
-	virtual translate_result translate(address_space &space, unsigned st, u32 &address, bool user, bool write, bool flag = false, bool suppress = false) = 0;
+	virtual translate_result translate(address_space &space, unsigned st, offs_t &address, bool user, bool write, bool flag = false, bool suppress = false) = 0;
 
 protected:
 	ns32000_mmu_interface(machine_config const &mconfig, device_t &device)

--- a/src/devices/cpu/ns32000/ns32000.cpp
+++ b/src/devices/cpu/ns32000/ns32000.cpp
@@ -263,9 +263,9 @@ template <int HighBits, int Width> void ns32000_device<HighBits, Width>::state_s
  *
  * Underlying handlers further subdivide accesses by device bus width.
  */
-template <int HighBits, int Width> template<typename T> T ns32000_device<HighBits, Width>::mem_read(unsigned st, u32 address, bool user, bool pfs)
+template <int HighBits, int Width> template<typename T> T ns32000_device<HighBits, Width>::mem_read(unsigned st, offs_t address, bool user, bool pfs)
 {
-	u32 physical = address;
+	offs_t physical = address;
 	ns32000_mmu_interface::translate_result tr = m_mmu ?
 		m_mmu->translate(m_bus[st].space(), st, physical, (m_psr & PSR_U) || user, false, pfs) : ns32000_mmu_interface::COMPLETE;
 
@@ -348,9 +348,9 @@ template <int HighBits, int Width> template<typename T> T ns32000_device<HighBit
 	return 0;
 }
 
-template <int HighBits, int Width> template<typename T> void ns32000_device<HighBits, Width>::mem_write(unsigned st, u32 address, u64 data, bool user)
+template <int HighBits, int Width> template<typename T> void ns32000_device<HighBits, Width>::mem_write(unsigned st, offs_t address, u64 data, bool user)
 {
-	u32 physical = address;
+	offs_t physical = address;
 	ns32000_mmu_interface::translate_result tr = m_mmu ?
 		m_mmu->translate(m_bus[st].space(), st, physical, (m_psr & PSR_U) || user, true) : ns32000_mmu_interface::COMPLETE;
 
@@ -739,7 +739,7 @@ template <int HighBits, int Width> void ns32000_device<HighBits, Width>::gen_wri
 	if (mode.type == TOS && mode.access == WRITE)
 		SP() -= mode.size + 1;
 
-	u32 const address = (mode.type == TOS) ? SP() : ea(mode);
+	offs_t const address = (mode.type == TOS) ? SP() : ea(mode);
 
 	switch (mode.size)
 	{
@@ -3947,7 +3947,7 @@ static constexpr u32 MSR(unsigned st, bool user, bool write, unsigned tex)
 	return u32(((st << 4) & MSR_STT) | (user ? MSR_UST : 0) | (write ? MSR_DDT : 0) | (tex & MSR_TEX));
 }
 
-ns32000_mmu_interface::translate_result ns32532_device::translate(address_space &space, unsigned st, u32 &address, bool user, bool write, bool rdwrval, bool suppress)
+ns32000_mmu_interface::translate_result ns32532_device::translate(address_space &space, unsigned st, offs_t &address, bool user, bool write, bool rdwrval, bool suppress)
 {
 	enum mcr_mask : u32
 	{
@@ -4188,7 +4188,7 @@ u16 ns32532_device::slave(u8 opbyte, u16 opword, addr_mode op1, addr_mode op2)
 		case 0: // rdval
 		case 1: // wrval
 			{
-				u32 address = ea(op1);
+				offs_t address = ea(op1);
 
 				switch (translate(space(AS_PROGRAM), ns32000::ST_ODT, address, true, BIT(opword, 2), true, true))
 				{

--- a/src/devices/cpu/ns32000/ns32000.h
+++ b/src/devices/cpu/ns32000/ns32000.h
@@ -117,8 +117,8 @@ protected:
 	};
 
 	// memory accessors
-	template <typename T> T mem_read(unsigned st, u32 address, bool user = false, bool pfs = false);
-	template <typename T> void mem_write(unsigned st, u32 address, u64 data, bool user = false);
+	template <typename T> T mem_read(unsigned st, offs_t address, bool user = false, bool pfs = false);
+	template <typename T> void mem_write(unsigned st, offs_t address, u64 data, bool user = false);
 
 	// instruction fetch/decode helpers
 	template <typename T> T fetch(unsigned &bytes);
@@ -227,7 +227,7 @@ public:
 
 	// ns32000_mmu_interface implementation
 	virtual void state_add(device_state_interface &parent, int &index) override;
-	virtual translate_result translate(address_space &space, unsigned st, u32 &address, bool user, bool write, bool rdwrval = false, bool suppress = false) override;
+	virtual translate_result translate(address_space &space, unsigned st, offs_t &address, bool user, bool write, bool rdwrval = false, bool suppress = false) override;
 
 protected:
 	// device_t implementation

--- a/src/devices/cpu/olms66k/nx8dasm.cpp
+++ b/src/devices/cpu/olms66k/nx8dasm.cpp
@@ -190,7 +190,7 @@ nx8_500s_disassembler::nx8_500s_disassembler(const u16 &psw)
 {
 }
 
-offs_t nx8_500s_disassembler::opcode_alignment() const
+u32 nx8_500s_disassembler::opcode_alignment() const
 {
 	return 1;
 }

--- a/src/devices/cpu/olms66k/nx8dasm.h
+++ b/src/devices/cpu/olms66k/nx8dasm.h
@@ -14,7 +14,7 @@ public:
 
 protected:
 	// disasm_interface overrides
-	virtual offs_t opcode_alignment() const override;
+	virtual u32 opcode_alignment() const override;
 	virtual u32 interface_flags() const override;
 	virtual u32 page_address_bits() const override;
 	virtual offs_t disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params) override;

--- a/src/devices/cpu/powerpc/ppccom.cpp
+++ b/src/devices/cpu/powerpc/ppccom.cpp
@@ -1522,7 +1522,8 @@ void ppc_device::ppccom_get_dsisr()
 		intent = TR_READ;
 	}
 
-	m_core->param1 = ppccom_translate_address_internal(intent, false, m_core->param0);
+	offs_t address = m_core->param0;
+	m_core->param1 = ppccom_translate_address_internal(intent, false, address);
 }
 
 /*-------------------------------------------------
@@ -2860,7 +2861,7 @@ uint8_t ppc4xx_device::ppc4xx_spu_r(offs_t offset)
 			break;
 	}
 	if (PRINTF_SPU)
-		printf("spu_r(%d) = %02X\n", offset, result);
+		printf("spu_r(%d) = %02X\n", (uint32_t)offset, result);
 	return result;
 }
 
@@ -2874,7 +2875,7 @@ void ppc4xx_device::ppc4xx_spu_w(offs_t offset, uint8_t data)
 	uint8_t oldstate, newstate;
 
 	if (PRINTF_SPU)
-		printf("spu_w(%d) = %02X\n", offset, data);
+		printf("spu_w(%d) = %02X\n", (uint32_t)offset, data);
 	switch (offset)
 	{
 		/* clear error bits */

--- a/src/devices/cpu/rii/riidasm.cpp
+++ b/src/devices/cpu/rii/riidasm.cpp
@@ -14,7 +14,7 @@
 
 using osd::u32;
 using util::BIT;
-using offs_t = u32;
+using offs_t = u64;
 
 // TODO: add register sets for other models
 const char *const epg3231_disassembler::s_regs[0x60] =

--- a/src/devices/cpu/romp/rsc.h
+++ b/src/devices/cpu/romp/rsc.h
@@ -37,29 +37,29 @@ public:
 		RSC_PUT = 7,
 	};
 
-	virtual bool mem_load(u32 address, u8 &data, rsc_mode const mode = RSC_N, bool sp = false) = 0;
-	virtual bool mem_load(u32 address, u16 &data, rsc_mode const mode = RSC_N, bool sp = false) = 0;
-	virtual bool mem_load(u32 address, u32 &data, rsc_mode const mode = RSC_N, bool sp = false) = 0;
+	virtual bool mem_load(offs_t address, u8 &data, rsc_mode const mode = RSC_N, bool sp = false) = 0;
+	virtual bool mem_load(offs_t address, u16 &data, rsc_mode const mode = RSC_N, bool sp = false) = 0;
+	virtual bool mem_load(offs_t address, u32 &data, rsc_mode const mode = RSC_N, bool sp = false) = 0;
 
-	virtual bool mem_store(u32 address, u8 data, rsc_mode const mode = RSC_N, bool sp = false) = 0;
-	virtual bool mem_store(u32 address, u16 data, rsc_mode const mode = RSC_N, bool sp = false) = 0;
-	virtual bool mem_store(u32 address, u32 data, rsc_mode const mode = RSC_N, bool sp = false) = 0;
+	virtual bool mem_store(offs_t address, u8 data, rsc_mode const mode = RSC_N, bool sp = false) = 0;
+	virtual bool mem_store(offs_t address, u16 data, rsc_mode const mode = RSC_N, bool sp = false) = 0;
+	virtual bool mem_store(offs_t address, u32 data, rsc_mode const mode = RSC_N, bool sp = false) = 0;
 
-	virtual bool mem_modify(u32 address, std::function<u8(u8)> f, rsc_mode const mode = RSC_N) = 0;
-	virtual bool mem_modify(u32 address, std::function<u16(u16)> f, rsc_mode const mode = RSC_N) = 0;
-	virtual bool mem_modify(u32 address, std::function<u32(u32)> f, rsc_mode const mode = RSC_N) = 0;
+	virtual bool mem_modify(offs_t address, std::function<u8(u8)> f, rsc_mode const mode = RSC_N) = 0;
+	virtual bool mem_modify(offs_t address, std::function<u16(u16)> f, rsc_mode const mode = RSC_N) = 0;
+	virtual bool mem_modify(offs_t address, std::function<u32(u32)> f, rsc_mode const mode = RSC_N) = 0;
 
-	virtual bool pio_load(u32 address, u8 &data, rsc_mode const mode = RSC_N) = 0;
-	virtual bool pio_load(u32 address, u16 &data, rsc_mode const mode = RSC_N) = 0;
-	virtual bool pio_load(u32 address, u32 &data, rsc_mode const mode = RSC_N) = 0;
+	virtual bool pio_load(offs_t address, u8 &data, rsc_mode const mode = RSC_N) = 0;
+	virtual bool pio_load(offs_t address, u16 &data, rsc_mode const mode = RSC_N) = 0;
+	virtual bool pio_load(offs_t address, u32 &data, rsc_mode const mode = RSC_N) = 0;
 
-	virtual bool pio_store(u32 address, u8 data, rsc_mode const mode = RSC_N) = 0;
-	virtual bool pio_store(u32 address, u16 data, rsc_mode const mode = RSC_N) = 0;
-	virtual bool pio_store(u32 address, u32 data, rsc_mode const mode = RSC_N) = 0;
+	virtual bool pio_store(offs_t address, u8 data, rsc_mode const mode = RSC_N) = 0;
+	virtual bool pio_store(offs_t address, u16 data, rsc_mode const mode = RSC_N) = 0;
+	virtual bool pio_store(offs_t address, u32 data, rsc_mode const mode = RSC_N) = 0;
 
-	virtual bool pio_modify(u32 address, std::function<u8(u8)> f, rsc_mode const mode = RSC_N) = 0;
-	virtual bool pio_modify(u32 address, std::function<u16(u16)> f, rsc_mode const mode = RSC_N) = 0;
-	virtual bool pio_modify(u32 address, std::function<u32(u32)> f, rsc_mode const mode = RSC_N) = 0;
+	virtual bool pio_modify(offs_t address, std::function<u8(u8)> f, rsc_mode const mode = RSC_N) = 0;
+	virtual bool pio_modify(offs_t address, std::function<u16(u16)> f, rsc_mode const mode = RSC_N) = 0;
+	virtual bool pio_modify(offs_t address, std::function<u32(u32)> f, rsc_mode const mode = RSC_N) = 0;
 
 protected:
 	rsc_bus_interface(machine_config const &mconfig, device_t &device, char const *type)
@@ -79,17 +79,17 @@ public:
 	virtual ~rsc_cpu_interface() = default;
 
 	// cpu interface
-	virtual bool fetch(u32 address, u16 &data, rsc_mode const mode = RSC_N) = 0;
-	virtual bool translate(u32 &address) const = 0;
+	virtual bool fetch(offs_t address, u16 &data, rsc_mode const mode = RSC_N) = 0;
+	virtual bool translate(offs_t &address) const = 0;
 
 	// rsc_bus_interface overrides
-	virtual bool mem_load(u32 address, u8 &data, rsc_mode const mode = RSC_N, bool sp = true) override = 0;
-	virtual bool mem_load(u32 address, u16 &data, rsc_mode const mode = RSC_N, bool sp = true) override = 0;
-	virtual bool mem_load(u32 address, u32 &data, rsc_mode const mode = RSC_N, bool sp = true) override = 0;
+	virtual bool mem_load(offs_t address, u8 &data, rsc_mode const mode = RSC_N, bool sp = true) override = 0;
+	virtual bool mem_load(offs_t address, u16 &data, rsc_mode const mode = RSC_N, bool sp = true) override = 0;
+	virtual bool mem_load(offs_t address, u32 &data, rsc_mode const mode = RSC_N, bool sp = true) override = 0;
 
-	virtual bool mem_store(u32 address, u8 data, rsc_mode const mode = RSC_N, bool sp = true) override = 0;
-	virtual bool mem_store(u32 address, u16 data, rsc_mode const mode = RSC_N, bool sp = true) override = 0;
-	virtual bool mem_store(u32 address, u32 data, rsc_mode const mode = RSC_N, bool sp = true) override = 0;
+	virtual bool mem_store(offs_t address, u8 data, rsc_mode const mode = RSC_N, bool sp = true) override = 0;
+	virtual bool mem_store(offs_t address, u16 data, rsc_mode const mode = RSC_N, bool sp = true) override = 0;
+	virtual bool mem_store(offs_t address, u32 data, rsc_mode const mode = RSC_N, bool sp = true) override = 0;
 };
 
 #endif // MAME_CPU_ROMP_RSC_H

--- a/src/devices/cpu/sparc/sparc_intf.h
+++ b/src/devices/cpu/sparc/sparc_intf.h
@@ -22,7 +22,7 @@ class sparc_mmu_interface
 {
 public:
 	virtual ~sparc_mmu_interface() { }
-	virtual uint32_t fetch_insn(const bool supervisor, const uint32_t offset) = 0;
+	virtual uint32_t fetch_insn(const bool supervisor, const offs_t offset) = 0;
 	virtual void set_host(sparc_mmu_host_interface *host) = 0;
 };
 

--- a/src/devices/machine/68340ser.cpp
+++ b/src/devices/machine/68340ser.cpp
@@ -41,7 +41,7 @@ uint8_t mc68340_serial_module_device::read(offs_t offset)
 	LOG("%s\n", FUNCNAME);
 	int val = 0;
 
-	LOGR("%08x %s %08x\n", m_cpu->pcbase(), FUNCNAME, offset);
+	LOGR("%08x %s %08x\n", (uint32_t)m_cpu->pcbase(), FUNCNAME, (uint32_t)offset);
 
 	/*Setting the STP bit stops all clocks within the serial module (including the crystal
 	  or external clock and SCLK), except for the clock from the IMB. The clock from the IMB
@@ -58,24 +58,24 @@ uint8_t mc68340_serial_module_device::read(offs_t offset)
 	{
 	case REG_MCRH:
 		val = m_mcrh;
-		LOGSERIAL("- %08x %s %04x, %04x (MCRH - Module Configuration Register High byte)\n", m_cpu->pcbase(), FUNCNAME, offset, val);
+		LOGSERIAL("- %08x %s %04x, %04x (MCRH - Module Configuration Register High byte)\n", (uint32_t)m_cpu->pcbase(), FUNCNAME, (uint32_t)offset, val);
 		break;
 	case REG_MCRL:
 		val = m_mcrl;
-		LOGSERIAL("- %08x %s %04x, %04x (MCRL - Module Configuration Register Low byte)\n", m_cpu->pcbase(), FUNCNAME, offset, val);
+		LOGSERIAL("- %08x %s %04x, %04x (MCRL - Module Configuration Register Low byte)\n", (uint32_t)m_cpu->pcbase(), FUNCNAME, (uint32_t)offset, val);
 		break;
 	case REG_ILR:
 		val = m_ilr;
-		LOGSERIAL("- %08x %s %04x, %04x (ILR - Interrupt Level Register)\n", m_cpu->pcbase(), FUNCNAME, offset, val);
+		LOGSERIAL("- %08x %s %04x, %04x (ILR - Interrupt Level Register)\n", (uint32_t)m_cpu->pcbase(), FUNCNAME, (uint32_t)offset, val);
 		break;
 	case REG_IVR:
 		val = m_ivr;
-		LOGSERIAL("- %08x %s %04x, %04x (IVR - Interrupt Vector Register)\n", m_cpu->pcbase(), FUNCNAME, offset, val);
+		LOGSERIAL("- %08x %s %04x, %04x (IVR - Interrupt Vector Register)\n", (uint32_t)m_cpu->pcbase(), FUNCNAME, (uint32_t)offset, val);
 		break;
 	}
 
 
-	LOGR(" * Reg %02x -> %02x - %s\n", offset, val,
+	LOGR(" * Reg %02x -> %02x - %s\n", (uint32_t)offset, val,
 		(offset > 0x21) ? "Error - should not happen" :
 		 std::array<char const *, 0x22>
 		 {{
@@ -91,7 +91,7 @@ uint8_t mc68340_serial_module_device::read(offs_t offset)
 void mc68340_serial_module_device::write(offs_t offset, uint8_t data)
 {
 	LOG("\n%s\n", FUNCNAME);
-	LOGSETUP(" * Reg %02x <- %02x - %s\n", offset, data,
+	LOGSETUP(" * Reg %02x <- %02x - %s\n", (uint32_t)offset, data,
 		 (offset > 0x21) ? "Error - should not happen" :
 		 std::array<char const *, 0x22>
 		 {{
@@ -116,26 +116,26 @@ void mc68340_serial_module_device::write(offs_t offset, uint8_t data)
 	{
 	case REG_MCRH:
 		m_mcrh = data;
-		LOGSERIAL("PC: %08x %s %04x, %04x (MCRH - Module Configuration Register High byte)\n", m_cpu->pcbase(), FUNCNAME, offset, data);
+		LOGSERIAL("PC: %08x %s %04x, %04x (MCRH - Module Configuration Register High byte)\n", (uint32_t)m_cpu->pcbase(), FUNCNAME, (uint32_t)offset, data);
 		LOGSERIAL("- Clocks are %s\n", data & REG_MCRH_STP ? "stopped" : "running");
 		LOGSERIAL("- Freeze signal %s - not implemented\n", data & REG_MCRH_FRZ1 ? "stops at character boundary" : "is ignored");
 		LOGSERIAL("- CTS capture clock: %s - not implemented\n", data & REG_MCRH_ICCS ? "SCLK" : "Crystal");
 		break;
 	case REG_MCRL:
 		m_mcrl = data;
-		LOGSERIAL("PC: %08x %s %04x, %04x (MCRL - Module Configuration Register Low byte)\n", m_cpu->pcbase(), FUNCNAME, offset, data);
+		LOGSERIAL("PC: %08x %s %04x, %04x (MCRL - Module Configuration Register Low byte)\n", (uint32_t)m_cpu->pcbase(), FUNCNAME, (uint32_t)offset, data);
 		LOGSERIAL("- Supervisor registers %s - not implemented\n", data & REG_MCRL_SUPV ? "requries supervisor privileges" : "can be accessed by user privileged software");
 		LOGSERIAL("- Interrupt Arbitration level: %02x\n", data & REG_MCRL_ARBLV);
 		break;
 	case REG_ILR:
 		m_ilr = data;
-		LOGSERIAL("PC: %08x %s %04x, %04x (ILR - Interrupt Level Register)\n", m_cpu->pcbase(), FUNCNAME, offset, data);
+		LOGSERIAL("PC: %08x %s %04x, %04x (ILR - Interrupt Level Register)\n", (uint32_t)m_cpu->pcbase(), FUNCNAME, (uint32_t)offset, data);
 		LOGSERIAL("- Interrupt Level: %02x\n", data & REG_ILR_MASK);
 		m_cpu->update_ipl();
 		break;
 	case REG_IVR:
 		m_ivr = data;
-		LOGSERIAL("PC: %08x %s %04x, %04x (IVR - Interrupt Vector Register)\n", m_cpu->pcbase(), FUNCNAME, offset, data);
+		LOGSERIAL("PC: %08x %s %04x, %04x (IVR - Interrupt Vector Register)\n", (uint32_t)m_cpu->pcbase(), FUNCNAME, (uint32_t)offset, data);
 		LOGSERIAL("- Interrupt Vector: %02x\n", data);
 		break;
 	default:

--- a/src/devices/machine/68340sim.cpp
+++ b/src/devices/machine/68340sim.cpp
@@ -50,46 +50,46 @@ uint16_t m68340_cpu_device::m68340_internal_sim_r(offs_t offset, uint16_t mem_ma
 	switch (offset * 2)
 	{
 		case m68340_sim::REG_MCR:
-			LOGSIM("- %08x %s %04x, (%04x) (MCR - Module Configuration Register) - not implemented\n", m_ppc, FUNCNAME, offset * 2, mem_mask);
+			LOGSIM("- %08x %s %04x, (%04x) (MCR - Module Configuration Register) - not implemented\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, mem_mask);
 			val = sim.m_mcr;
 			break;
 
 		case m68340_sim::REG_SYNCR:
-			LOGSIM("- %08x %s %04x, (%04x) (SYNCR - Clock Synthesizer Register) - not implemented\n", m_ppc, FUNCNAME, offset*2,mem_mask);
+			LOGSIM("- %08x %s %04x, (%04x) (SYNCR - Clock Synthesizer Register) - not implemented\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, mem_mask);
 			val = sim.m_syncr;
 			break;
 
 		case m68340_sim::REG_AVR_RSR: // Manual seems to say that AVR only autovectors externally triggered interrupts (INT1-INT7)
-			LOGSIM("- %08x %s %04x, (%04x) (AVR, RSR - Auto Vector Register, Reset Status Register) - not implemented\n", m_ppc, FUNCNAME, offset*2,mem_mask);
+			LOGSIM("- %08x %s %04x, (%04x) (AVR, RSR - Auto Vector Register, Reset Status Register) - not implemented\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, mem_mask);
 			val = sim.m_avr_rsr;
 			break;
 
 		case m68340_sim::REG_SWIV_SYPCR:
-			LOGSIM("- %08x %s %04x, (%04x) (SWIV_SYPCR - Software Interrupt Vector, System Protection Control Register) - not implemented\n", m_ppc, FUNCNAME, offset*2,mem_mask);
+			LOGSIM("- %08x %s %04x, (%04x) (SWIV_SYPCR - Software Interrupt Vector, System Protection Control Register) - not implemented\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, mem_mask);
 			val = sim.m_swiv_sypcr;
 			break;
 
 		case m68340_sim::REG_PICR:
-			LOGPIT("- %08x %s %04x, (%04x) (PICR - Periodic Interrupt Control Register) - not implemented\n", m_ppc, FUNCNAME, offset*2,mem_mask);
+			LOGPIT("- %08x %s %04x, (%04x) (PICR - Periodic Interrupt Control Register) - not implemented\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, mem_mask);
 			val = sim.m_picr;
 			break;
 
 		case m68340_sim::REG_PITR:
-			LOGPIT("- %08x %s %04x, (%04x) (PITR - Periodic Interrupt Timer Register) - not implemented\n", m_ppc, FUNCNAME, offset*2,mem_mask);
+			LOGPIT("- %08x %s %04x, (%04x) (PITR - Periodic Interrupt Timer Register) - not implemented\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, mem_mask);
 			val = sim.m_pitr;
 			break;
 
 		case m68340_sim::REG_SWSR:
-			LOGSIM("- %08x %s %04x, (%04x) (SWSR - Software Service) - not implemented\n", m_ppc, FUNCNAME, offset*2,mem_mask);
+			LOGSIM("- %08x %s %04x, (%04x) (SWSR - Software Service) - not implemented\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, mem_mask);
 			val = sim.m_swsr;
 			break;
 
 		default:
-			logerror("- %08x %s %04x, (%04x) (unsupported register)\n", m_ppc, FUNCNAME, offset * 2, mem_mask);
-			LOGSIM("- %08x %s %04x, (%04x) (unsupported register)\n", m_ppc, FUNCNAME, offset * 2, mem_mask);
+			logerror("- %08x %s %04x, (%04x) (unsupported register)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, mem_mask);
+			LOGSIM("- %08x %s %04x, (%04x) (unsupported register)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, mem_mask);
 	}
 
-	LOGR(" * Reg %02x -> %02x - %s\n", offset * 2, val,
+	LOGR(" * Reg %02x -> %02x - %s\n", (uint32_t)offset * 2, val,
 		 ((offset * 2) >= 0x10 && (offset * 2) < 0x20) || (offset * 2) >= 0x60 ? "Error - should not happen" :
 		 std::array<char const *, 8> {{"MCR", "reserved", "SYNCR", "AVR/RSR", "SWIV/SYPCR", "PICR", "PITR", "SWSR"}}[(offset * 2) <= m68340_sim::REG_AVR_RSR ? offset : offset - 0x10 + 0x04]);
 
@@ -99,7 +99,7 @@ uint16_t m68340_cpu_device::m68340_internal_sim_r(offs_t offset, uint16_t mem_ma
 void m68340_cpu_device::m68340_internal_sim_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	LOG("\n%s\n", FUNCNAME);
-	LOGSETUP(" * Reg %02x <- %02x - %s\n", offset * 2, data,
+	LOGSETUP(" * Reg %02x <- %02x - %s\n", (uint32_t)offset * 2, data,
 		 ((offset * 2) >= 0x10 && (offset * 2) < 0x20) || (offset * 2) >= 0x60 ? "Error - should not happen" :
 		 std::array<char const *, 8> {{"MCR", "reserved", "SYNCR", "AVR/RSR", "SWIV/SYPCR", "PICR", "PITR", "SWSR"}}[(offset * 2) <= m68340_sim::REG_AVR_RSR ? offset : offset - 0x10 + 0x04]);
 
@@ -110,7 +110,7 @@ void m68340_cpu_device::m68340_internal_sim_w(offs_t offset, uint16_t data, uint
 	{
 		case m68340_sim::REG_MCR:
 			COMBINE_DATA(&sim.m_mcr);
-			LOGSIM("PC: %08x %s %04x, %04x (%04x) (MCR - Module Configuration Register)\n", m_ppc, FUNCNAME, offset * 2, data, mem_mask);
+			LOGSIM("PC: %08x %s %04x, %04x (%04x) (MCR - Module Configuration Register)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, data, mem_mask);
 			LOGPIT("- FRZ1: Watchdog and PIT timer are %s\n", (data & m68340_sim::REG_MCR_FRZ1) == 0 ? "enabled" : "disabled");
 			LOGSIM("- FRZ0: The BUS monitor is %s\n", (data & m68340_sim::REG_MCR_FRZ0) == 0 ? "enabled" : "disabled");
 			LOGSIM("- FIRQ: Full Interrupt Request Mode %s\n", data & m68340_sim::REG_MCR_FIRQ ? "used on port B" : "suppressed, adding 4 chip select lines on Port B");
@@ -120,7 +120,7 @@ void m68340_cpu_device::m68340_internal_sim_w(offs_t offset, uint16_t data, uint
 			break;
 
 		case m68340_sim::REG_SYNCR:
-			LOGSIM("PC: %08x %s %04x, %04x (%04x) (SYNCR - Clock Synthesizer Register) - not implemented\n", m_ppc, FUNCNAME, offset * 2, data, mem_mask);
+			LOGSIM("PC: %08x %s %04x, %04x (%04x) (SYNCR - Clock Synthesizer Register) - not implemented\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, data, mem_mask);
 			COMBINE_DATA(&sim.m_syncr);
 			LOGSIM("- W    : VCO x %d\n", data & m68340_sim::REG_SYNCR_W ? 4 : 1);
 			LOGSIM("- X    : System clock / %d\n", data & m68340_sim::REG_SYNCR_X ? 1 : 2);
@@ -142,14 +142,14 @@ void m68340_cpu_device::m68340_internal_sim_w(offs_t offset, uint16_t data, uint
 			break;
 
 		case m68340_sim::REG_AVR_RSR:
-			LOGSIM("PC: %08x %s %04x, %04x (%04x) (AVR, RSR - Auto Vector Register, Reset Status Register)\n", m_ppc, FUNCNAME, offset * 2, data, mem_mask);
+			LOGSIM("PC: %08x %s %04x, %04x (%04x) (AVR, RSR - Auto Vector Register, Reset Status Register)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, data, mem_mask);
 			COMBINE_DATA(&sim.m_avr_rsr);
 			LOGSIM("- AVR: AV7-AV1 autovector bits:  %02x\n", ((data & m68340_sim::REG_AVR_VEC) >> 8) & 0xff);
 			LOGSIM("- RSR: Last reset type:  %02x - not implemented\n", (data & m68340_sim::REG_RSR_RESBITS) & 0xff);
 			break;
 
 		case m68340_sim::REG_SWIV_SYPCR:
-			LOGSIM("PC: %08x %s %04x, %04x (%04x) (SWIV_SYPCR - Software Interrupt Vector, System Protection Control Register) - not implemented\n", m_ppc, FUNCNAME, offset * 2, data, mem_mask);
+			LOGSIM("PC: %08x %s %04x, %04x (%04x) (SWIV_SYPCR - Software Interrupt Vector, System Protection Control Register) - not implemented\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, data, mem_mask);
 			COMBINE_DATA(&sim.m_swiv_sypcr);
 			LOGSIM("- SWIV: Software watchdog Interrupt Vector: %02x\n", ((data & m68340_sim::REG_SWIV_VEC) >> 8) & 0xff);
 			LOGSIM("- SWE : Software watchdog %s\n", (data & m68340_sim::REG_SYPCR_SWE) ? "enabled" : "disabled");
@@ -159,7 +159,7 @@ void m68340_cpu_device::m68340_internal_sim_w(offs_t offset, uint16_t data, uint
 			break;
 
 		case m68340_sim::REG_PICR:
-			LOGPIT("PC: %08x %s %04x, %04x (%04x) (PICR - Periodic Interrupt Control Register)\n", m_ppc, FUNCNAME, offset*2,data,mem_mask);
+			LOGPIT("PC: %08x %s %04x, %04x (%04x) (PICR - Periodic Interrupt Control Register)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, data, mem_mask);
 			COMBINE_DATA(&sim.m_picr);
 			LOGPIT("- PIRQL: Periodic Interrupt Level  %d%s\n", (data & m68340_sim::REG_PICR_PIRQL) >> 8, (data & m68340_sim::REG_PICR_PIRQL) == 0 ? " (disabled)" : "");
 			LOGPIT("- PIV  : Periodic Interrupt Vector %02x\n", (data & m68340_sim::REG_PICR_PIVEC));
@@ -167,7 +167,7 @@ void m68340_cpu_device::m68340_internal_sim_w(offs_t offset, uint16_t data, uint
 			break;
 
 		case m68340_sim::REG_PITR:
-			LOGPIT("PC: %08x %s %04x, %04x (%04x) (PITR - Periodic Interrupt Timer Register)\n", m_ppc, FUNCNAME, offset*2,data,mem_mask);
+			LOGPIT("PC: %08x %s %04x, %04x (%04x) (PITR - Periodic Interrupt Timer Register)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, data, mem_mask);
 			COMBINE_DATA(&sim.m_pitr);
 			LOGSIM("- SWP  : Software watchdog prescale factor is %d\n", (data & m68340_sim::REG_PITR_SWP) ? 512 : 1);
 			LOGPIT("- PTP  : Periodic timer prescale factor is %d\n", (data & m68340_sim::REG_PITR_PTP) ? 512 : 1);
@@ -183,11 +183,11 @@ void m68340_cpu_device::m68340_internal_sim_w(offs_t offset, uint16_t data, uint
 
 		case m68340_sim::REG_SWSR:
 			// basically watchdog, you must write an alternating pattern of 0x55 / 0xaa to keep the watchdog from resetting the system
-			//LOGSIM("- %08x %s %04x, %04x (%04x) (SWSR - Software Service)\n", m_ppc, FUNCNAME, offset*2,data,mem_mask);
+			//LOGSIM("- %08x %s %04x, %04x (%04x) (SWSR - Software Service)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, data, mem_mask);
 			break;
 
 		default:
-			LOGSIM("- %08x %s %04x, %04x (%04x) - not implemented\n", m_ppc, FUNCNAME, offset*2,data,mem_mask);
+			LOGSIM("- %08x %s %04x, %04x (%04x) - not implemented\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset * 2, data, mem_mask);
 
 	}
 }
@@ -204,7 +204,7 @@ uint8_t m68340_cpu_device::m68340_internal_sim_ports_r(offs_t offset)
 	switch (offset)
 	{
 		case m68340_sim::REG_PORTA:
-			LOGR("- %08x %s %04x (PORTA - Port A Data)\n", m_ppc, FUNCNAME, offset);
+			LOGR("- %08x %s %04x (PORTA - Port A Data)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset);
 			sim.m_porta &= sim.m_ddra;
 			// TODO: call callback
 
@@ -222,26 +222,26 @@ uint8_t m68340_cpu_device::m68340_internal_sim_ports_r(offs_t offset)
 			break;
 
 		case m68340_sim::REG_DDRA:
-			LOGR("- %08x %s %04x (DDRA - Port A Data Direction)\n", m_ppc, FUNCNAME, offset);
+			LOGR("- %08x %s %04x (DDRA - Port A Data Direction)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset);
 			val = sim.m_ddra;
 			break;
 
 		case m68340_sim::REG_PPARA1:
-			LOGR("- %08x %s %04x (PPRA1 - Port A Pin Assignment 1)\n", m_ppc, FUNCNAME, offset);
+			LOGR("- %08x %s %04x (PPRA1 - Port A Pin Assignment 1)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset);
 			val = sim.m_ppara1;
 			break;
 
 		case m68340_sim::REG_PPARA2:
-			LOGR("- %08x %s %04x (PPRA2 - Port A Pin Assignment 2) - not implemented\n", m_ppc, FUNCNAME, offset);
+			LOGR("- %08x %s %04x (PPRA2 - Port A Pin Assignment 2) - not implemented\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset);
 			val = sim.m_ppara2;
 			break;
 
 		case m68340_sim::REG_PORTB1:
-			LOGR("- %08x %s %04x (PORTB1 - Port B Data 1)\n", m_ppc, FUNCNAME, offset);
+			LOGR("- %08x %s %04x (PORTB1 - Port B Data 1)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset);
 			// Fallthrough to mirror register
 			[[fallthrough]];
 		case m68340_sim::REG_PORTB:
-			LOGR("- %08x %s %04x (PORTB - Port B Data 0)\n", m_ppc, FUNCNAME, offset);
+			LOGR("- %08x %s %04x (PORTB - Port B Data 0)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset);
 			sim.m_portb &= sim.m_ddrb;
 			// TODO: call callback
 
@@ -259,21 +259,21 @@ uint8_t m68340_cpu_device::m68340_internal_sim_ports_r(offs_t offset)
 			break;
 
 		case m68340_sim::REG_DDRB:
-			LOGR("- %08x %s %04x (DDR - Port B Data Direction)\n", m_ppc, FUNCNAME, offset);
+			LOGR("- %08x %s %04x (DDR - Port B Data Direction)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset);
 			val = sim.m_ddrb;
 			break;
 
 		case m68340_sim::REG_PPARB:
-			LOGR("- %08x %s %04x (PPARB - Port B Pin Assignment)\n", m_ppc, FUNCNAME, offset);
+			LOGR("- %08x %s %04x (PPARB - Port B Pin Assignment)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset);
 			val = sim.m_pparb;
 			break;
 
 		default:
-			LOGR("- %08x %s %04x (ILLEGAL?)\n", m_ppc, FUNCNAME, offset);
-			logerror("%08x m68340_internal_sim_r %04x (ILLEGAL?)\n", m_ppc, FUNCNAME, offset);
+			LOGR("- %08x %s %04x (ILLEGAL?)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset);
+			logerror("%08x m68340_internal_sim_r %04x (ILLEGAL?)\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset);
 			break;
 	}
-	LOGR(" * Reg %02x -> %02x - %s\n", offset, val, std::array<char const *, 16>
+	LOGR(" * Reg %02x -> %02x - %s\n", (uint32_t)offset, val, std::array<char const *, 16>
 		 {{"", "PORTA", "", "DDRA", "", "PPARA1", "", "PPARA2", "", "PORTB","", "PORTB1", "", "DDRB", "", "PPARB"}}[offset - 0x10]);
 
 	return val;
@@ -286,12 +286,12 @@ void m68340_cpu_device::m68340_internal_sim_ports_w(offs_t offset, uint8_t data)
 	assert(m_m68340SIM);
 	m68340_sim &sim = *m_m68340SIM;
 
-	LOGSETUP(" * Reg %02x <- %02x - %s\n", offset, data, std::array<char const *, 8>
+	LOGSETUP(" * Reg %02x <- %02x - %s\n", (uint32_t)offset, data, std::array<char const *, 8>
 			 {{"PORTA", "DDRA", "PPRA1", "PPRA2", "PORTB", "PORTB1", "DDRB", "PPARB"}}[(offset - 0x10) / 2]);
 	switch (offset)
 	{
 		case m68340_sim::REG_PORTA:
-			LOGDATA("- %08x %04x, %02x (PORTA - Port A Data)\n", m_ppc, offset,data);
+			LOGDATA("- %08x %04x, %02x (PORTA - Port A Data)\n", (uint32_t)m_ppc, (uint32_t)offset, data);
 			sim.m_porta = (data & sim.m_ddra & sim.m_ppara1);
 
 			// callback
@@ -299,26 +299,26 @@ void m68340_cpu_device::m68340_internal_sim_ports_w(offs_t offset, uint8_t data)
 			break;
 
 		case m68340_sim::REG_DDRA:
-			LOGPORTS("- %08x %04x, %02x (DDRA - Port A Data Direction)\n", m_ppc, offset,data);
+			LOGPORTS("- %08x %04x, %02x (DDRA - Port A Data Direction)\n", (uint32_t)m_ppc, (uint32_t)offset, data);
 			sim.m_ddra = data;
 			break;
 
 		case m68340_sim::REG_PPARA1:
-			LOGPORTS("- %08x %04x, %02x (PPARA1 - Port A Pin Assignment 1)\n", m_ppc, offset,data);
+			LOGPORTS("- %08x %04x, %02x (PPARA1 - Port A Pin Assignment 1)\n", (uint32_t)m_ppc, (uint32_t)offset, data);
 			sim.m_ppara1 = data;
 			break;
 
 		case m68340_sim::REG_PPARA2:
-			LOGPORTS("- %08x %04x, %02x (PPARA2 - Port A Pin Assignment 2)\n", m_ppc, offset,data);
+			LOGPORTS("- %08x %04x, %02x (PPARA2 - Port A Pin Assignment 2)\n", (uint32_t)m_ppc, (uint32_t)offset, data);
 			sim.m_ppara2 = data;
 			break;
 
 		case m68340_sim::REG_PORTB1:
-			LOGDATA("- %08x %04x, %02x (PORTB1 - Port B Data - mirror)\n", m_ppc, offset,data);
+			LOGDATA("- %08x %04x, %02x (PORTB1 - Port B Data - mirror)\n", (uint32_t)m_ppc, (uint32_t)offset, data);
 			// Falling through to mirrored register portb
 			[[fallthrough]];
 		case m68340_sim::REG_PORTB:
-			LOGDATA("- %08x %04x, %02x (PORTB - Port B Data)\n", m_ppc, offset,data);
+			LOGDATA("- %08x %04x, %02x (PORTB - Port B Data)\n", (uint32_t)m_ppc, (uint32_t)offset, data);
 			sim.m_portb = (data & sim.m_ddrb & sim.m_pparb);
 
 			// callback
@@ -326,18 +326,18 @@ void m68340_cpu_device::m68340_internal_sim_ports_w(offs_t offset, uint8_t data)
 			break;
 
 		case m68340_sim::REG_DDRB:
-			LOGPORTS("- %08x %04x, %02x (DDR - Port B Data Direction)\n", m_ppc, offset,data);
+			LOGPORTS("- %08x %04x, %02x (DDR - Port B Data Direction)\n", (uint32_t)m_ppc, (uint32_t)offset, data);
 			sim.m_ddrb = data;
 			break;
 
 		case m68340_sim::REG_PPARB:
-			LOGPORTS("- %08x %04x, %02x (PPARB - Port B Pin Assignment)\n", m_ppc, offset,data);
+			LOGPORTS("- %08x %04x, %02x (PPARB - Port B Pin Assignment)\n", (uint32_t)m_ppc, (uint32_t)offset, data);
 			sim.m_pparb = data;
 			break;
 
 		default:
-			LOGPORTS("- %08x %s %04x, %02x (ILLEGAL?) - not implemented\n", m_ppc, FUNCNAME, offset,data);
-			logerror("%08x m68340_internal_sim_ports_w %04x, %02x (ILLEGAL?)\n", m_ppc, offset,data);
+			LOGPORTS("- %08x %s %04x, %02x (ILLEGAL?) - not implemented\n", (uint32_t)m_ppc, FUNCNAME, (uint32_t)offset, data);
+			logerror("%08x m68340_internal_sim_ports_w %04x, %02x (ILLEGAL?)\n", (uint32_t)m_ppc, (uint32_t)offset, data);
 			break;
 	}
 }
@@ -363,7 +363,7 @@ uint16_t m68340_cpu_device::m68340_internal_sim_cs_r(offs_t offset, uint16_t mem
 		case m68340_sim::REG_BA_CS3:  data = sim.m_ba[3];  break;
 
 		default:
-			logerror("%08x m68340_internal_sim_r %08x, (%08x)\n", m_ppc, offset*2,mem_mask);
+			logerror("%08x m68340_internal_sim_r %08x, (%08x)\n", (uint32_t)m_ppc, (uint32_t)offset * 2, mem_mask);
 	}
 
 	return (BIT(offset,0) ? data : (data >> 16)) & 0xffff;
@@ -379,12 +379,12 @@ void m68340_cpu_device::m68340_internal_sim_cs_w(offs_t offset, uint16_t data, u
 	{
 		if (BIT(offset, 0))
 		{
-			LOGCS("%08x (LSWORD) Base address CS%d %08x, %04x (%04x) ", m_ppc, (offset - 0x20) / 2, offset * 2, data, mem_mask);
+			LOGCS("%08x (LSWORD) Base address CS%d %08x, %04x (%04x) ", (uint32_t)m_ppc, ((uint32_t)offset - 0x20) / 2, (uint32_t)offset * 2, data, mem_mask);
 			LOGCS("- Base: %04x BFC:%02x WP:%d FTE:%d NCS:%d Valid: %s\n", data & 0xff00, (data & 0xf0) >> 4, data & 0x08 ? 1 : 0, data & 0x04 ? 1 : 0, data & 0x02 ? 1 : 0, data & 0x01 ? "Yes" : "No");
 		}
 		else
 		{
-			LOGCS("%08x (MSWORD) Base address CS%d %08x, %04x (%04x) ", m_ppc, (offset - 0x20) / 2, offset * 2, data, mem_mask);
+			LOGCS("%08x (MSWORD) Base address CS%d %08x, %04x (%04x) ", (uint32_t)m_ppc, ((uint32_t)offset - 0x20) / 2, (uint32_t)offset * 2, data, mem_mask);
 			LOGCS("- Base: %04x\n", data);
 		}
 	}
@@ -392,12 +392,12 @@ void m68340_cpu_device::m68340_internal_sim_cs_w(offs_t offset, uint16_t data, u
 	{
 		if (BIT(offset, 0))
 		{
-			LOGCS("%08x Address mask CS%d %08x, %04x (%04x) ", m_ppc, (offset - 0x20) / 2, offset * 2, data, mem_mask);
+			LOGCS("%08x Address mask CS%d %08x, %04x (%04x) ", (uint32_t)m_ppc, ((uint32_t)offset - 0x20) / 2, (uint32_t)offset * 2, data, mem_mask);
 			LOGCS("- FCM:%02x DD:%d PS: %s\n", (data & 0xf0) >> 4, (data >> 2) & 0x03, std::array<char const *, 4>{{"Reserved", "16-Bit", "8-bit", "External DSACK response"}}[data & 0x03]);
 		}
 		else
 		{
-			LOGCS("%08x Address mask CS%d %08x, %04x (%04x) ", m_ppc, (offset - 0x20) / 2, offset * 2, data, mem_mask);
+			LOGCS("%08x Address mask CS%d %08x, %04x (%04x) ", (uint32_t)m_ppc, ((uint32_t)offset - 0x20) / 2, (uint32_t)offset * 2, data, mem_mask);
 			LOGCS("- Mask: %04x\n", data & 0xff00);
 		}
 	}
@@ -455,7 +455,7 @@ void m68340_cpu_device::m68340_internal_sim_cs_w(offs_t offset, uint16_t data, u
 			break;
 
 		default:
-			logerror("%08x m68340_internal_sim_cs_w %08x, %08x (%08x)\n", m_ppc, offset*2,data,mem_mask);
+			logerror("%08x m68340_internal_sim_cs_w %08x, %08x (%08x)\n", (uint32_t)m_ppc, (uint32_t)offset * 2, data, mem_mask);
 			break;
 	}
 }

--- a/src/devices/machine/generalplus_gpl162xx_soc.cpp
+++ b/src/devices/machine/generalplus_gpl162xx_soc.cpp
@@ -1710,7 +1710,7 @@ void sunplus_gcm394_base_device::videoirq_w(int state)
 	set_state_unsynced(UNSP_IRQ5_LINE, state);
 }
 
-uint16_t sunplus_gcm394_base_device::read_space(uint32_t offset)
+uint16_t sunplus_gcm394_base_device::read_space(offs_t offset)
 {
 	address_space& space = this->space(AS_PROGRAM);
 	uint16_t val;
@@ -1720,7 +1720,7 @@ uint16_t sunplus_gcm394_base_device::read_space(uint32_t offset)
 	}
 	else
 	{
-		val = m_cs_space->read_word(offset-m_csbase);
+		val = m_cs_space->read_word(offset - m_csbase);
 	}
 
 	return val;
@@ -1728,7 +1728,7 @@ uint16_t sunplus_gcm394_base_device::read_space(uint32_t offset)
 
 
 
-void sunplus_gcm394_base_device::write_space(uint32_t offset, uint16_t data)
+void sunplus_gcm394_base_device::write_space(offs_t offset, uint16_t data)
 {
 	address_space& space = this->space(AS_PROGRAM);
 	if (offset < m_csbase)

--- a/src/devices/machine/generalplus_gpl162xx_soc.h
+++ b/src/devices/machine/generalplus_gpl162xx_soc.h
@@ -339,8 +339,8 @@ private:
 
 	TIMER_CALLBACK_MEMBER(unknown_tick);
 
-	inline uint16_t read_space(uint32_t offset);
-	inline void write_space(uint32_t offset, uint16_t data);
+	inline uint16_t read_space(offs_t offset);
+	inline void write_space(offs_t offset, uint16_t data);
 
 	bool m_alt_periodic_irq; // might be multiple timers, might be a register to configure, currently a config option.
 

--- a/src/devices/machine/gt64xxx.cpp
+++ b/src/devices/machine/gt64xxx.cpp
@@ -945,7 +945,7 @@ TIMER_CALLBACK_MEMBER(gt64xxx_device::timer_callback)
  *  Galileo DMA handler
  *
  *************************************/
-address_space* gt64xxx_device::dma_decode_address(uint32_t &addr)
+address_space* gt64xxx_device::dma_decode_address(offs_t &addr)
 {
 	for (size_t index = 0; index < proc_addr_bank::ADDR_NUM; ++index)
 	{

--- a/src/devices/machine/gt64xxx.h
+++ b/src/devices/machine/gt64xxx.h
@@ -148,7 +148,7 @@ private:
 	galileo_addr_map dma_addr_map[proc_addr_bank::ADDR_NUM];
 	int dma_fetch_next(address_space &space, int which);
 	TIMER_CALLBACK_MEMBER(perform_dma);
-	address_space* dma_decode_address(uint32_t &addr);
+	address_space* dma_decode_address(offs_t &addr);
 };
 
 // Supports R4600/4650/4700/R5000 CPUs

--- a/src/devices/machine/mc88200.h
+++ b/src/devices/machine/mc88200.h
@@ -14,10 +14,10 @@ public:
 
 	template <typename T> void set_mbus(T &&tag, int spacenum) { m_mbus.set_tag(std::forward<T>(tag), spacenum); }
 
-	bool translate(int intention, u32 &address, bool supervisor);
+	bool translate(int intention, offs_t &address, bool supervisor);
 
-	template <typename T> std::optional<T> read(u32 virtual_address, bool supervisor);
-	template <typename T> bool write(u32 virtual_address, T data, bool supervisor);
+	template <typename T> std::optional<T> read(offs_t virtual_address, bool supervisor);
+	template <typename T> bool write(offs_t virtual_address, T data, bool supervisor);
 	void bus_error_w(int state) { if (!machine().side_effects_disabled()) m_bus_error = true; }
 
 protected:
@@ -59,19 +59,19 @@ protected:
 
 	struct translate_result
 	{
-		translate_result(u32 address, bool ci, bool g, bool wt)
+		translate_result(offs_t address, bool ci, bool g, bool wt)
 			: address(address)
 			, ci(ci)
 			, g(g)
 			, wt(wt)
 		{}
 
-		u32 const address;
+		offs_t const address;
 		bool const ci; // cache inhibit
 		bool const g;  // global
 		bool const wt; // writethrough
 	};
-	std::optional<translate_result> translate(u32 virtual_address, bool supervisor, bool write);
+	std::optional<translate_result> translate(offs_t virtual_address, bool supervisor, bool write);
 
 	struct cache_set
 	{
@@ -92,24 +92,24 @@ protected:
 
 		struct cache_line
 		{
-			bool match_segment(u32 const address) const;
-			bool match_page(u32 const address) const;
+			bool match_segment(offs_t const address) const;
+			bool match_page(offs_t const address) const;
 
-			bool load_line(mc88200_device &cmmu, u32 const address);
-			bool copy_back(mc88200_device &cmmu, u32 const address, bool const flush = false);
+			bool load_line(mc88200_device &cmmu, offs_t const address);
+			bool copy_back(mc88200_device &cmmu, offs_t const address, bool const flush = false);
 
 			u32 tag;
 			u32 data[4];
 		}
 		line[4];
 	};
-	typedef bool (mc88200_device::cache_set::cache_line::* match_function)(u32 const) const;
+	typedef bool (mc88200_device::cache_set::cache_line::* match_function)(offs_t const) const;
 
 	std::optional<unsigned> cache_replace(cache_set const &cs);
 	void cache_flush(unsigned const start, unsigned const limit, match_function match, bool const copyback, bool const invalidate);
 
-	template <typename T> std::optional<T> mbus_read(u32 address);
-	template <typename T> bool mbus_write(u32 address, T data, bool flush = false);
+	template <typename T> std::optional<T> mbus_read(offs_t address);
+	template <typename T> bool mbus_write(offs_t address, T data, bool flush = false);
 
 private:
 	required_address_space m_mbus;

--- a/src/devices/machine/ns32082.cpp
+++ b/src/devices/machine/ns32082.cpp
@@ -374,7 +374,7 @@ void ns32082_device::set_msr(u32 data)
 	m_msr = (m_msr & ~MSR_WM) | (data & MSR_WM);
 }
 
-ns32082_device::translate_result ns32082_device::translate(address_space &space, unsigned st, u32 &address, bool user, bool write, bool pfs, bool suppress)
+ns32082_device::translate_result ns32082_device::translate(address_space &space, unsigned st, offs_t &address, bool user, bool write, bool pfs, bool suppress)
 {
 	// update program flow trace state
 	if (pfs && (m_msr & MSR_FT))
@@ -406,7 +406,7 @@ ns32082_device::translate_result ns32082_device::translate(address_space &space,
 	LOGMASKED(LOG_TRANSLATE, "translate address_space %d access_level %d page table 0x%08x address 0x%08x\n", address_space, access_level, ptb, address);
 
 	// read level 1 page table entry
-	u32 const pte1_address = ptb | ((address & VA_INDEX1) >> 14);
+	offs_t const pte1_address = ptb | ((address & VA_INDEX1) >> 14);
 	u32 const pte1 = space.read_dword(pte1_address);
 	LOGMASKED(LOG_TRANSLATE, "translate level 1 page table address 0x%06x entry 0x%08x\n", pte1_address, pte1);
 
@@ -448,7 +448,7 @@ ns32082_device::translate_result ns32082_device::translate(address_space &space,
 		space.write_word(pte1_address, u16(pte1 | PTE_R));
 
 	// read level 2 page table entry
-	u32 const pte2_address = ((pte1 & PTE_MS) >> 7) | (pte1 & PTE_PFN) | ((address & VA_INDEX2) >> 7);
+	offs_t const pte2_address = ((pte1 & PTE_MS) >> 7) | (pte1 & PTE_PFN) | ((address & VA_INDEX2) >> 7);
 	u32 const pte2 = space.read_dword(pte2_address);
 	LOGMASKED(LOG_TRANSLATE, "translate level 2 page table address 0x%06x entry 0x%08x\n", pte2_address, pte2);
 

--- a/src/devices/machine/ns32082.h
+++ b/src/devices/machine/ns32082.h
@@ -25,7 +25,7 @@ public:
 	virtual void slow_write(u16 data) override;
 
 	// ns32000_mmu_interface implementation
-	virtual translate_result translate(address_space &space, unsigned st, u32 &address, bool user, bool write, bool pfs = false, bool suppress = false) override;
+	virtual translate_result translate(address_space &space, unsigned st, offs_t &address, bool user, bool write, bool pfs = false, bool suppress = false) override;
 
 protected:
 	// device_t implementation

--- a/src/devices/machine/ns32382.cpp
+++ b/src/devices/machine/ns32382.cpp
@@ -330,7 +330,7 @@ void ns32382_device::execute()
 		m_state = STATUS;
 }
 
-ns32382_device::translate_result ns32382_device::translate(address_space &space, unsigned st, u32 &address, bool user, bool write, bool pfs, bool debug)
+ns32382_device::translate_result ns32382_device::translate(address_space &space, unsigned st, offs_t &address, bool user, bool write, bool pfs, bool debug)
 {
 	// check translation required
 	if ((!(m_mcr & MCR_TU) && user) || (!(m_mcr & MCR_TS) && !user))
@@ -347,7 +347,7 @@ ns32382_device::translate_result ns32382_device::translate(address_space &space,
 		m_msr &= ~(MSR_STT | MSR_UST | MSR_DDT | MSR_TEX);
 
 	// read level 1 page table entry
-	u32 const pte1_address = m_ptb[address_space] | ((address & VA_INDEX1) >> 20);
+	offs_t const pte1_address = m_ptb[address_space] | ((address & VA_INDEX1) >> 20);
 	u32 const pte1 = space.read_dword(pte1_address);
 	LOGMASKED(LOG_TRANSLATE, "translate level 1 page table address 0x%06x entry 0x%08x\n", pte1_address, pte1);
 
@@ -386,7 +386,7 @@ ns32382_device::translate_result ns32382_device::translate(address_space &space,
 		space.write_dword(pte1_address, pte1 | PTE_R);
 
 	// read level 2 page table entry
-	u32 const pte2_address = (pte1 & PTE_PFN) | ((address & VA_INDEX2) >> 10);
+	offs_t const pte2_address = (pte1 & PTE_PFN) | ((address & VA_INDEX2) >> 10);
 	u32 const pte2 = space.read_dword(pte2_address);
 	LOGMASKED(LOG_TRANSLATE, "translate level 2 page table address 0x%06x entry 0x%08x\n", pte2_address, pte2);
 

--- a/src/devices/machine/ns32382.h
+++ b/src/devices/machine/ns32382.h
@@ -25,7 +25,7 @@ public:
 	virtual void fast_write(u32 data) override;
 
 	// ns32000_mmu_interface implementation
-	virtual translate_result translate(address_space &space, unsigned st, u32 &address, bool user, bool write, bool pfs = false, bool debug = false) override;
+	virtual translate_result translate(address_space &space, unsigned st, offs_t &address, bool user, bool write, bool pfs = false, bool debug = false) override;
 
 protected:
 	// device_t implementation

--- a/src/devices/machine/rtc4513.cpp
+++ b/src/devices/machine/rtc4513.cpp
@@ -1,0 +1,369 @@
+// license:BSD-3-Clause
+// copyright-holders:Ryan Holtz
+/***************************************************************************
+
+    rtc4513.cpp - Epson RTC-4513 real-time clock emulation
+
+***************************************************************************/
+
+#include "emu.h"
+#include "rtc4513.h"
+
+#include "machine/timehelp.h"
+
+#define VERBOSE (1)
+#include "logmacro.h"
+
+
+DEFINE_DEVICE_TYPE(RTC4513,  rtc4513_device,  "rtc4513",  "RTC-4513 Real Time Clock Module")
+
+rtc4513_device::rtc4513_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, RTC4513, tag, owner, clock)
+	, device_nvram_interface(mconfig, *this)
+	, device_rtc_interface(mconfig, *this)
+	, m_irq_cb(*this)
+	, m_default_data(*this, DEVICE_SELF)
+	, m_periodic_timer(nullptr)
+	, m_mode(MODE_IDLE)
+	, m_index(0)
+	, m_shifter(0)
+	, m_shift_count(0)
+	, m_data(false)
+	, m_clk(false)
+	, m_ce(false)
+	, m_tick_held(false)
+{
+}
+
+void rtc4513_device::device_start()
+{
+	save_item(NAME(m_r));
+	save_item(NAME(m_mode));
+	save_item(NAME(m_index));
+	save_item(NAME(m_shifter));
+	save_item(NAME(m_shift_count));
+	save_item(NAME(m_data));
+	save_item(NAME(m_clk));
+	save_item(NAME(m_ce));
+	save_item(NAME(m_tick_held));
+
+	set_defaults();
+
+	emu_timer *timer = timer_alloc(FUNC(rtc4513_device::second_tick), this);
+	timer->adjust(attotime::from_seconds(1), 0, attotime::from_seconds(1));
+
+	m_periodic_timer = timer_alloc(FUNC(rtc4513_device::periodic_tick), this);
+	m_periodic_timer->adjust(attotime::never);
+}
+
+void rtc4513_device::device_reset()
+{
+}
+
+void rtc4513_device::set_defaults()
+{
+	memset(&m_r[0], 0, 16);
+	m_r[REG_DAY_L] = 1;
+	m_r[REG_MONTH_L] = 1;
+	m_r[REG_CD] = HOLD_MASK;
+	m_r[REG_CE] = (INT_MODE_HOUR << INT_MODE_BIT) | INT_STND_MASK | INT_MASK_MASK;
+	m_r[REG_CF] = HOUR24_MASK | STOP_MASK;
+}
+
+void rtc4513_device::rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second)
+{
+}
+
+void rtc4513_device::increment_minutes()
+{
+	u8 minutes = ((m_r[REG_MINUTES_H] & MINUTES_H_MASK) << 4) | m_r[REG_MINUTES_L];
+	bool carry = time_helper::inc_bcd(&minutes, MINUTES_MASK, 0x00, 0x59);
+	m_r[REG_MINUTES_L] = minutes & 0x0f;
+	m_r[REG_MINUTES_H] = (m_r[REG_MINUTES_H] & ~MINUTES_H_MASK) | ((minutes >> 4) & MINUTES_H_MASK);
+	if (!carry)
+		return;
+
+	u8 hours = ((m_r[REG_HOURS_H] & HOURS_H_MASK) << 4) | m_r[REG_HOURS_L];
+	const bool hour24_mode = BIT(m_r[REG_CF], HOUR24_BIT);
+	const u8 max_hours = hour24_mode ? 0x23 : 0x11;
+	carry = time_helper::inc_bcd(&hours, HOURS_MASK, 0x00, max_hours);
+	m_r[REG_HOURS_L] = hours & 0x0f;
+	m_r[REG_HOURS_H] = (m_r[REG_HOURS_H] & ~HOURS_H_MASK) | ((hours >> 4) & HOURS_H_MASK);
+	if (!carry)
+		return;
+
+	if (hour24_mode && !BIT(m_r[REG_CF], HOUR24_BIT))
+	{
+		m_r[REG_HOURS_H] ^= AM_PM_MASK;
+		if (BIT(m_r[REG_HOURS_H], AM_PM_BIT))
+			return;
+	}
+
+	u8 weekday = m_r[REG_WEEKDAY] & WEEKDAY_MASK;
+	u8 day = ((m_r[REG_DAY_H] & DAY_H_MASK) << 4) | m_r[REG_DAY_L];
+	u8 month = ((m_r[REG_MONTH_H] & MONTH_H_MASK) << 4) | m_r[REG_MONTH_L];
+	u8 year = (m_r[REG_YEAR_H] << 4) | m_r[REG_YEAR_L];
+
+	weekday = (weekday + 1) % 7;
+	m_r[REG_WEEKDAY] = (m_r[REG_WEEKDAY] & ~WEEKDAY_MASK) | weekday;
+
+	u8 maxdays;
+	static const u8 daysinmonth[] = { 0x31, 0x28, 0x31, 0x30, 0x31, 0x30, 0x31, 0x31, 0x30, 0x31, 0x30, 0x31 };
+	maxdays = (month < 0 || month >= 12) ? 0x31 : daysinmonth[month];
+	if (month == 2 && (year % 4) == 0)
+		maxdays++;
+	carry = time_helper::inc_bcd(&day, DAY_MASK, 0x01, maxdays);
+	m_r[REG_DAY_L] = day & 0x0f;
+	m_r[REG_DAY_H] = (m_r[REG_DAY_H] & ~DAY_H_MASK) | ((day >> 4) & DAY_H_MASK);
+
+	carry = time_helper::inc_bcd(&month, MONTH_MASK, 0x01, 0x12);
+	m_r[REG_MONTH_L] = month & 0x0f;
+	m_r[REG_MONTH_H] = (m_r[REG_MONTH_H] & ~MONTH_H_MASK) | ((month >> 4) & MONTH_H_MASK);
+	if (!carry)
+		return;
+
+	time_helper::inc_bcd(&year, 0xff, 0x00, 0x99);
+	m_r[REG_YEAR_L] = year & 0x0f;
+	m_r[REG_YEAR_H] = (m_r[REG_YEAR_H] >> 4) & 0x0f;
+}
+
+TIMER_CALLBACK_MEMBER(rtc4513_device::second_tick)
+{
+	if (BIT(m_r[REG_CF], STOP_BIT))
+		return;
+
+	if (BIT(m_r[REG_CD], HOLD_BIT))
+	{
+		m_tick_held = true;
+		return;
+	}
+
+	u8 seconds = ((m_r[REG_SECONDS_H] & SECONDS_H_MASK) << 4) | m_r[REG_SECONDS_L];
+	bool carry = time_helper::inc_bcd(&seconds, SECONDS_MASK, 0x00, 0x59);
+	m_r[REG_SECONDS_L] = seconds & 0x0f;
+	m_r[REG_SECONDS_H] = (m_r[REG_SECONDS_H] & ~SECONDS_H_MASK) | ((seconds >> 4) & SECONDS_H_MASK);
+
+	if (!carry)
+		return;
+
+	if (m_ce)
+	{
+		m_r[REG_MINUTES_H] |= READ_FLAG_MASK;
+		m_r[REG_HOURS_H] |= READ_FLAG_MASK;
+		m_r[REG_DAY_H] |= READ_FLAG_MASK;
+		m_r[REG_MONTH_H] |= READ_FLAG_MASK;
+		m_r[REG_WEEKDAY] |= READ_FLAG_MASK;
+	}
+
+	increment_minutes();
+}
+
+TIMER_CALLBACK_MEMBER(rtc4513_device::periodic_tick)
+{
+	// If we're in standard IRQ mode, raise the flag.
+	if (BIT(m_r[REG_CE], INT_STND_BIT))
+	{
+		m_r[REG_CD] |= IRQ_FLAG_MASK;
+		m_irq_cb(ASSERT_LINE);
+		return;
+	}
+
+	// If we're not in standard IRQ mode, clear it if we're supposed to, otherwise set it.
+	if (param)
+	{
+		m_r[REG_CD] &= ~IRQ_FLAG_BIT;
+		m_irq_cb(CLEAR_LINE);
+		switch (BIT(m_r[REG_CE], INT_MODE_BIT, INT_MODE_WIDTH))
+		{
+		case INT_MODE_64HZ:
+			m_periodic_timer->adjust(attotime::from_ticks(1, 128));
+			break;
+		case INT_MODE_SEC:
+			m_periodic_timer->adjust(attotime::from_ticks(1, 1) - attotime::from_ticks(1, 128));
+			break;
+		case INT_MODE_MIN:
+			m_periodic_timer->adjust(attotime::from_ticks(60, 1) - attotime::from_ticks(1, 128));
+			break;
+		case INT_MODE_HOUR:
+			m_periodic_timer->adjust(attotime::from_ticks(3600, 1) - attotime::from_ticks(1, 128));
+			break;
+		}
+	}
+	else
+	{
+		m_r[REG_CD] |= IRQ_FLAG_BIT;
+		m_irq_cb(ASSERT_LINE);
+		m_periodic_timer->adjust(attotime::from_ticks(1, 128), 1);
+	}
+}
+
+void rtc4513_device::clk_w(int state)
+{
+	if (m_clk == state)
+		return;
+	m_clk = state;
+
+	if (!m_clk)
+		return;
+
+	if (m_mode == MODE_READ_DATA)
+	{
+		m_shifter >>= 1;
+		m_shift_count++;
+		if (m_shift_count == 4)
+		{
+			m_shift_count = 0;
+			m_shifter = read_register(m_index);
+			m_index = (m_index + 1) & 0x0f;
+		}
+		m_data = BIT(m_shifter, 0);
+		return;
+	}
+
+	m_shifter >>= 1;
+	m_shifter |= (u8)m_data << 3;
+	m_shift_count++;
+
+	if (m_shift_count == 4)
+	{
+		switch (m_mode)
+		{
+		case MODE_CMD:
+			if (m_shifter == CMD_READ)
+			{
+				LOG("Entering read-address mode\n");
+				m_mode = MODE_READ_ADDR;
+			}
+			else
+			{
+				LOG("Entering write-address mode\n");
+				m_mode = MODE_WRITE_ADDR;
+			}
+			m_shifter = 0;
+			break;
+		case MODE_READ_ADDR:
+			m_mode = MODE_READ_DATA;
+			m_index = m_shifter;
+			LOG("Entering read-data mode for index %d\n", m_index);
+			m_shift_count = 0;
+			m_shifter = read_register(m_index);
+			m_index = (m_index + 1) & 0xf;
+			m_data = BIT(m_shifter, 0);
+			break;
+		case MODE_WRITE_ADDR:
+			m_index = m_shifter;
+			m_shifter = 0;
+			LOG("Entering write-data mode for index %d\n", m_index);
+			m_mode = MODE_WRITE_DATA;
+			break;
+		case MODE_WRITE_DATA:
+			LOG("Writing %x to register %d\n", m_shifter, m_index);
+			write_register(m_index, m_shifter & 0x0f);
+			m_shifter = 0;
+			m_index = (m_index + 1) & 0x0f;
+			break;
+		}
+		m_shift_count = 0;
+	}
+}
+
+void rtc4513_device::ce_w(int state)
+{
+	m_ce = state;
+	m_shifter = 0;
+	m_shift_count = 0;
+
+	if (m_ce)
+	{
+		// Raising chip select
+		m_mode = MODE_CMD;
+		return;
+	}
+
+	// Lowering chip select
+	m_mode = MODE_IDLE;
+	m_r[REG_MINUTES_H] &= ~READ_FLAG_MASK;
+	m_r[REG_HOURS_H] &= ~READ_FLAG_MASK;
+	m_r[REG_DAY_H] &= ~READ_FLAG_MASK;
+	m_r[REG_MONTH_H] &= ~READ_FLAG_MASK;
+	m_r[REG_WEEKDAY] &= ~READ_FLAG_MASK;
+
+	if (BIT(m_r[REG_CF], RESET_BIT))
+	{
+		m_r[REG_CF] &= ~RESET_MASK;
+		m_r[REG_SECONDS_L] = 0;
+		m_r[REG_SECONDS_H] &= ~SECONDS_H_MASK;
+	}
+}
+
+u8 rtc4513_device::read_register(offs_t offset)
+{
+	const u8 data = m_r[offset];
+	LOG("read_register %d: %x\n", offset, data);
+	if (offset == REG_CD)
+	{
+		m_r[REG_CD] &= ~IRQ_FLAG_MASK;
+	}
+	return data;
+}
+
+void rtc4513_device::write_register(offs_t offset, u8 data)
+{
+	const u8 old_data = m_r[offset];
+	m_r[offset] = data;
+	LOG("m_r[%d] is now %02x\n", offset, m_r[offset]);
+	if (offset == REG_CD)
+	{
+		if (!BIT(old_data, ADJ30_BIT) && BIT(data, ADJ30_BIT))
+		{
+			m_r[REG_CD] &= ~ADJ30_MASK;
+			if ((m_r[REG_SECONDS_H] & SECONDS_H_MASK) >= 3)
+				increment_minutes();
+			m_r[REG_SECONDS_L] = 0;
+			m_r[REG_SECONDS_H] &= ~SECONDS_H_MASK;
+		}
+
+		if (BIT(old_data, HOLD_BIT) && !BIT(data, HOLD_BIT) && m_tick_held)
+		{
+			m_tick_held = false;
+			second_tick(0);
+		}
+	}
+}
+
+//-------------------------------------------------
+//  nvram_default - called to initialize NVRAM to
+//  its default state
+//-------------------------------------------------
+
+void rtc4513_device::nvram_default()
+{
+	if (m_default_data.found())
+		memcpy(&m_r[0], m_default_data, 16);
+	else
+		set_defaults();
+}
+
+
+//-------------------------------------------------
+//  nvram_read - called to read NVRAM from the
+//  .nv file
+//-------------------------------------------------
+
+bool rtc4513_device::nvram_read(util::read_stream &file)
+{
+	auto const [err, actual] = util::read(file, &m_r[0], 16);
+	return !err && actual == 16;
+}
+
+
+//-------------------------------------------------
+//  nvram_write - called to write NVRAM to the
+//  .nv file
+//-------------------------------------------------
+
+bool rtc4513_device::nvram_write(util::write_stream &file)
+{
+	auto const [err, actual] = util::write(file, &m_r[0], 16);
+	return !err;
+}

--- a/src/devices/machine/rtc4513.h
+++ b/src/devices/machine/rtc4513.h
@@ -1,0 +1,180 @@
+// license:BSD-3-Clause
+// copyright-holders:Ryan Holtz
+/***************************************************************************
+
+    rtc4513.h - Epson RTC-4513 real-time clock emulation
+
+***************************************************************************/
+
+#ifndef MAME_MACHINE_RTC4513_H
+#define MAME_MACHINE_RTC4513_H
+
+#pragma once
+
+#include "dirtc.h"
+
+
+class rtc4513_device : public device_t,
+                       public device_nvram_interface,
+                       public device_rtc_interface
+{
+public:
+	// construction/destruction
+	rtc4513_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	int data_r() { return m_data; }
+	void data_w(int state) { m_data = state; }
+	void clk_w(int state);
+	void ce_w(int state);
+
+	auto irq_cb() { return m_irq_cb.bind(); }
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// device_nvram_interface overrides
+	virtual void nvram_default() override;
+	virtual bool nvram_read(util::read_stream &file) override;
+	virtual bool nvram_write(util::write_stream &file) override;
+
+	// device_rtc_interface overrides
+	virtual bool rtc_feature_y2k() const override { return false; }
+	virtual bool rtc_feature_leap_year() const override { return true; }
+	virtual void rtc_clock_updated(int year, int month, int day, int day_of_week, int hour, int minute, int second) override;
+
+	TIMER_CALLBACK_MEMBER(second_tick);
+	TIMER_CALLBACK_MEMBER(periodic_tick);
+
+	devcb_write_line m_irq_cb;
+
+private:
+	enum reg_t : u8
+	{
+		REG_SECONDS_L,
+		REG_SECONDS_H,
+		REG_MINUTES_L,
+		REG_MINUTES_H,
+		REG_HOURS_L,
+		REG_HOURS_H,
+		REG_DAY_L,
+		REG_DAY_H,
+		REG_MONTH_L,
+		REG_MONTH_H,
+		REG_YEAR_L,
+		REG_YEAR_H,
+		REG_WEEKDAY,
+		REG_CD,
+		REG_CE,
+		REG_CF
+	};
+
+	enum regbit_t : u8
+	{
+		SECONDS_MASK = 0x7f,
+		SECONDS_H_MASK = 0x07,
+
+		MINUTES_MASK = 0x7f,
+		MINUTES_H_MASK = 0x07,
+
+		HOURS_MASK = 0x3f,
+		HOURS_H_MASK = 0x03,
+
+		DAY_MASK = 0x3f,
+		DAY_H_MASK = 0x03,
+
+		MONTH_MASK = 0x1f,
+		MONTH_H_MASK = 0x01,
+
+		WEEKDAY_MASK = 0x07,
+
+		OSC_FLAG_BIT = 3,
+		OSC_FLAG_MASK = 0x08,
+
+		READ_FLAG_BIT = 3,
+		READ_FLAG_MASK = 0x08,
+
+		AM_PM_BIT = 2,
+		AM_PM_MASK = 0x04,
+
+		DAY_RAM_MASK = 0x04,
+		MONTH_RAM_MASK = 0x06,
+
+		ADJ30_BIT = 3,
+		ADJ30_MASK = 0x08,
+
+		IRQ_FLAG_BIT = 2,
+		IRQ_FLAG_MASK = 0x04,
+
+		CAL_HW_BIT = 1,
+		CAL_HW_MASK = 0x02,
+
+		HOLD_BIT = 0,
+		HOLD_MASK = 0x01,
+
+		INT_MODE_BIT = 2,
+		INT_MODE_WIDTH = 2,
+		INT_MODE_64HZ = 0,
+		INT_MODE_SEC = 1,
+		INT_MODE_MIN = 2,
+		INT_MODE_HOUR = 3,
+
+		INT_STND_BIT = 1,
+		INT_STND_MASK = 0x02,
+
+		INT_MASK_BIT = 0,
+		INT_MASK_MASK = 0x01,
+
+		TEST_BIT = 3,
+		TEST_MASK = 0x08,
+
+		HOUR24_BIT = 2,
+		HOUR24_MASK = 0x04,
+
+		STOP_BIT = 1,
+		STOP_MASK = 0x02,
+
+		RESET_BIT = 0,
+		RESET_MASK = 0x01
+	};
+
+	enum mode_t : u8
+	{
+		MODE_IDLE,
+		MODE_CMD,
+		MODE_WRITE_ADDR,
+		MODE_WRITE_DATA,
+		MODE_READ_ADDR,
+		MODE_READ_DATA,
+	};
+
+	enum cmd_t : u8
+	{
+		CMD_READ = 0x0c,
+		CMD_WRITE = 0x03
+	};
+
+	void set_defaults();
+	void increment_minutes();
+	u8 read_register(offs_t offset);
+	void write_register(offs_t offset, u8 data);
+
+	optional_region_ptr<u8> m_default_data;
+
+	emu_timer *m_periodic_timer;
+
+	u8 m_r[16];
+	u8 m_mode;
+	u8 m_index;
+	u8 m_shifter;
+	u8 m_shift_count;
+	bool m_data;
+	bool m_clk;
+	bool m_ce;
+	bool m_tick_held;
+};
+
+DECLARE_DEVICE_TYPE(RTC4513,  rtc4513_device)
+
+#endif // MAME_MACHINE_RTC4513_H

--- a/src/devices/machine/s3c44b0.cpp
+++ b/src/devices/machine/s3c44b0.cpp
@@ -844,13 +844,13 @@ uint32_t s3c44b0_device::get_mclk()
 uint32_t s3c44b0_device::clkpow_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t data = ((uint32_t*)&m_clkpow.regs)[offset];
-	verboselog( *this, 9, "(CLKPOW) %08X -> %08X\n", S3C44B0_BASE_CLKPOW + (offset << 2), data);
+	verboselog( *this, 9, "(CLKPOW) %08X -> %08X\n", S3C44B0_BASE_CLKPOW + ((uint32_t)offset << 2), data);
 	return data;
 }
 
 void s3c44b0_device::clkpow_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	verboselog( *this, 9, "(CLKPOW) %08X <- %08X\n", S3C44B0_BASE_CLKPOW + (offset << 2), data);
+	verboselog( *this, 9, "(CLKPOW) %08X <- %08X\n", S3C44B0_BASE_CLKPOW + ((uint32_t)offset << 2), data);
 	COMBINE_DATA(&((uint32_t*)&m_clkpow.regs)[offset]);
 	switch (offset)
 	{
@@ -951,13 +951,13 @@ void s3c44b0_device::request_eint(uint32_t number)
 uint32_t s3c44b0_device::irq_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t data = ((uint32_t*)&m_irq.regs)[offset];
-	verboselog( *this, 9, "(IRQ) %08X -> %08X\n", S3C44B0_BASE_INT + (offset << 2), data);
+	verboselog( *this, 9, "(IRQ) %08X -> %08X\n", S3C44B0_BASE_INT + ((uint32_t)offset << 2), data);
 	return data;
 }
 
 void s3c44b0_device::irq_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	verboselog( *this, 9, "(IRQ) %08X <- %08X\n", S3C44B0_BASE_INT + (offset << 2), data);
+	verboselog( *this, 9, "(IRQ) %08X <- %08X\n", S3C44B0_BASE_INT + ((uint32_t)offset << 2), data);
 	COMBINE_DATA(&((uint32_t*)&m_irq.regs)[offset]);
 	switch (offset)
 	{
@@ -1034,7 +1034,7 @@ uint32_t s3c44b0_device::pwm_r(offs_t offset, uint32_t mem_mask)
 		}
 		break;
 	}
-	verboselog( *this, 9, "(PWM) %08X -> %08X\n", S3C44B0_BASE_PWM + (offset << 2), data);
+	verboselog( *this, 9, "(PWM) %08X -> %08X\n", S3C44B0_BASE_PWM + ((uint32_t)offset << 2), data);
 	return data;
 }
 
@@ -1155,7 +1155,7 @@ void s3c44b0_device::pwm_recalc(int timer)
 void s3c44b0_device::pwm_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	uint32_t old_value = ((uint32_t*)&m_pwm.regs)[offset];
-	verboselog( *this, 9, "(PWM) %08X <- %08X\n", S3C44B0_BASE_PWM + (offset << 2), data);
+	verboselog( *this, 9, "(PWM) %08X <- %08X\n", S3C44B0_BASE_PWM + ((uint32_t)offset << 2), data);
 	COMBINE_DATA(&((uint32_t*)&m_pwm.regs)[offset]);
 	switch (offset)
 	{
@@ -1324,14 +1324,14 @@ uint32_t s3c44b0_device::iic_r(offs_t offset, uint32_t mem_mask)
 		}
 		break;
 	}
-	verboselog( *this, 9, "(IIC) %08X -> %08X\n", S3C44B0_BASE_IIC + (offset << 2), data);
+	verboselog( *this, 9, "(IIC) %08X -> %08X\n", S3C44B0_BASE_IIC + ((uint32_t)offset << 2), data);
 	return data;
 }
 
 void s3c44b0_device::iic_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	uint32_t old_value = ((uint32_t*)&m_iic.regs)[offset];
-	verboselog( *this, 9, "(IIC) %08X <- %08X\n", S3C44B0_BASE_IIC + (offset << 2), data);
+	verboselog( *this, 9, "(IIC) %08X <- %08X\n", S3C44B0_BASE_IIC + ((uint32_t)offset << 2), data);
 	COMBINE_DATA(&((uint32_t*)&m_iic.regs)[offset]);
 	switch (offset)
 	{
@@ -1475,14 +1475,14 @@ uint32_t s3c44b0_device::gpio_r(offs_t offset, uint32_t mem_mask)
 		}
 		break;
 	}
-	verboselog( *this, 9, "(GPIO) %08X -> %08X\n", S3C44B0_BASE_GPIO + (offset << 2), data);
+	verboselog( *this, 9, "(GPIO) %08X -> %08X\n", S3C44B0_BASE_GPIO + ((uint32_t)offset << 2), data);
 	return data;
 }
 
 void s3c44b0_device::gpio_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	uint32_t old_value = ((uint32_t*)&m_gpio.regs)[offset];
-	verboselog( *this, 9, "(GPIO) %08X <- %08X\n", S3C44B0_BASE_GPIO + (offset << 2), data);
+	verboselog( *this, 9, "(GPIO) %08X <- %08X\n", S3C44B0_BASE_GPIO + ((uint32_t)offset << 2), data);
 	COMBINE_DATA(&((uint32_t*)&m_gpio.regs)[offset]);
 	switch (offset)
 	{
@@ -1582,26 +1582,26 @@ void s3c44b0_device::uart_w(int ch, uint32_t offset, uint32_t data, uint32_t mem
 uint32_t s3c44b0_device::uart_0_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t data = uart_r(0, offset);
-//  verboselog( *this, 9, "(UART 0) %08X -> %08X\n", S3C44B0_BASE_UART_0 + (offset << 2), data);
+//  verboselog( *this, 9, "(UART 0) %08X -> %08X\n", S3C44B0_BASE_UART_0 + ((uint32_t)offset << 2), data);
 	return data;
 }
 
 uint32_t s3c44b0_device::uart_1_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t data = uart_r(1, offset);
-//  verboselog( *this, 9, "(UART 1) %08X -> %08X\n", S3C44B0_BASE_UART_1 + (offset << 2), data);
+//  verboselog( *this, 9, "(UART 1) %08X -> %08X\n", S3C44B0_BASE_UART_1 + ((uint32_t)offset << 2), data);
 	return data;
 }
 
 void s3c44b0_device::uart_0_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	verboselog( *this, 9, "(UART 0) %08X <- %08X (%08X)\n", S3C44B0_BASE_UART_0 + (offset << 2), data, mem_mask);
+	verboselog( *this, 9, "(UART 0) %08X <- %08X (%08X)\n", S3C44B0_BASE_UART_0 + ((uint32_t)offset << 2), data, mem_mask);
 	uart_w(0, offset, data, mem_mask);
 }
 
 void s3c44b0_device::uart_1_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	verboselog( *this, 9, "(UART 1) %08X <- %08X (%08X)\n", S3C44B0_BASE_UART_1 + (offset << 2), data, mem_mask);
+	verboselog( *this, 9, "(UART 1) %08X <- %08X (%08X)\n", S3C44B0_BASE_UART_1 + ((uint32_t)offset << 2), data, mem_mask);
 	uart_w(1, offset, data, mem_mask);
 }
 
@@ -1645,7 +1645,7 @@ uint32_t s3c44b0_device::wdt_r(offs_t offset, uint32_t mem_mask)
 		}
 		break;
 	}
-	verboselog( *this, 9, "(WDT) %08X -> %08X\n", S3C44B0_BASE_WDT + (offset << 2), data);
+	verboselog( *this, 9, "(WDT) %08X -> %08X\n", S3C44B0_BASE_WDT + ((uint32_t)offset << 2), data);
 	return data;
 }
 
@@ -1681,7 +1681,7 @@ void s3c44b0_device::wdt_recalc()
 void s3c44b0_device::wdt_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	uint32_t old_value = ((uint32_t*)&m_wdt.regs)[offset];
-	verboselog( *this, 9, "(WDT) %08X <- %08X\n", S3C44B0_BASE_WDT + (offset << 2), data);
+	verboselog( *this, 9, "(WDT) %08X <- %08X\n", S3C44B0_BASE_WDT + ((uint32_t)offset << 2), data);
 	COMBINE_DATA(&((uint32_t*)&m_wdt.regs)[offset]);
 	switch (offset)
 	{
@@ -1715,13 +1715,13 @@ TIMER_CALLBACK_MEMBER( s3c44b0_device::wdt_timer_exp )
 uint32_t s3c44b0_device::cpuwrap_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t data = ((uint32_t*)&m_cpuwrap.regs)[offset];
-	verboselog( *this, 9, "(CPUWRAP) %08X -> %08X\n", S3C44B0_BASE_CPU_WRAPPER + (offset << 2), data);
+	verboselog( *this, 9, "(CPUWRAP) %08X -> %08X\n", S3C44B0_BASE_CPU_WRAPPER + ((uint32_t)offset << 2), data);
 	return data;
 }
 
 void s3c44b0_device::cpuwrap_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	verboselog( *this, 9, "(CPUWRAP) %08X <- %08X\n", S3C44B0_BASE_CPU_WRAPPER + (offset << 2), data);
+	verboselog( *this, 9, "(CPUWRAP) %08X <- %08X\n", S3C44B0_BASE_CPU_WRAPPER + ((uint32_t)offset << 2), data);
 	COMBINE_DATA(&((uint32_t*)&m_cpuwrap.regs)[offset]);
 }
 
@@ -1730,7 +1730,7 @@ void s3c44b0_device::cpuwrap_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 uint32_t s3c44b0_device::adc_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t data = ((uint32_t*)&m_adc.regs)[offset];
-	verboselog( *this, 9, "(ADC) %08X -> %08X\n", S3C44B0_BASE_ADC + (offset << 2), data);
+	verboselog( *this, 9, "(ADC) %08X -> %08X\n", S3C44B0_BASE_ADC + ((uint32_t)offset << 2), data);
 	return data;
 }
 
@@ -1764,7 +1764,7 @@ void s3c44b0_device::adc_recalc()
 void s3c44b0_device::adc_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	uint32_t old_value = ((uint32_t*)&m_wdt.regs)[offset];
-	verboselog( *this, 9, "(ADC) %08X <- %08X\n", S3C44B0_BASE_ADC + (offset << 2), data);
+	verboselog( *this, 9, "(ADC) %08X <- %08X\n", S3C44B0_BASE_ADC + ((uint32_t)offset << 2), data);
 	COMBINE_DATA(&((uint32_t*)&m_adc.regs)[offset]);
 	switch (offset)
 	{
@@ -1792,7 +1792,7 @@ TIMER_CALLBACK_MEMBER( s3c44b0_device::adc_timer_exp )
 uint32_t s3c44b0_device::sio_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t data = ((uint32_t*)&m_sio.regs)[offset];
-	verboselog( *this, 9, "(SIO) %08X -> %08X\n", S3C44B0_BASE_SIO + (offset << 2), data);
+	verboselog( *this, 9, "(SIO) %08X -> %08X\n", S3C44B0_BASE_SIO + ((uint32_t)offset << 2), data);
 	return data;
 }
 
@@ -1828,7 +1828,7 @@ void s3c44b0_device::sio_recalc()
 void s3c44b0_device::sio_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	uint32_t old_value = ((uint32_t*)&m_sio.regs)[offset];
-	verboselog( *this, 9, "(SIO) %08X <- %08X\n", S3C44B0_BASE_SIO + (offset << 2), data);
+	verboselog( *this, 9, "(SIO) %08X <- %08X\n", S3C44B0_BASE_SIO + ((uint32_t)offset << 2), data);
 	COMBINE_DATA(&((uint32_t*)&m_sio.regs)[offset]);
 	switch (offset)
 	{
@@ -1887,14 +1887,14 @@ void s3c44b0_device::iis_stop()
 uint32_t s3c44b0_device::iis_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t data = ((uint32_t*)&m_iis.regs)[offset];
-	verboselog( *this, 9, "(IIS) %08X -> %08X\n", S3C44B0_BASE_IIS + (offset << 2), data);
+	verboselog( *this, 9, "(IIS) %08X -> %08X\n", S3C44B0_BASE_IIS + ((uint32_t)offset << 2), data);
 	return data;
 }
 
 void s3c44b0_device::iis_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	uint32_t old_value = ((uint32_t*)&m_iis.regs)[offset];
-	verboselog( *this, 9, "(IIS) %08X <- %08X\n", S3C44B0_BASE_IIS + (offset << 2), data);
+	verboselog( *this, 9, "(IIS) %08X <- %08X\n", S3C44B0_BASE_IIS + ((uint32_t)offset << 2), data);
 	COMBINE_DATA(&((uint32_t*)&m_iis.regs)[offset]);
 	switch (offset)
 	{
@@ -2034,26 +2034,26 @@ void s3c44b0_device::zdma_w(int ch, uint32_t offset, uint32_t data, uint32_t mem
 uint32_t s3c44b0_device::zdma_0_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t data = zdma_r(0, offset);
-	verboselog( *this, 9, "(ZDMA 0) %08X -> %08X\n", S3C44B0_BASE_ZDMA_0 + (offset << 2), data);
+	verboselog( *this, 9, "(ZDMA 0) %08X -> %08X\n", S3C44B0_BASE_ZDMA_0 + ((uint32_t)offset << 2), data);
 	return data;
 }
 
 uint32_t s3c44b0_device::zdma_1_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t data = zdma_r(1, offset);
-	verboselog( *this, 9, "(ZDMA 1) %08X -> %08X\n", S3C44B0_BASE_ZDMA_1 + (offset << 2), data);
+	verboselog( *this, 9, "(ZDMA 1) %08X -> %08X\n", S3C44B0_BASE_ZDMA_1 + ((uint32_t)offset << 2), data);
 	return data;
 }
 
 void s3c44b0_device::zdma_0_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	verboselog( *this, 9, "(ZDMA 0) %08X <- %08X (%08X)\n", S3C44B0_BASE_ZDMA_0 + (offset << 2), data, mem_mask);
+	verboselog( *this, 9, "(ZDMA 0) %08X <- %08X (%08X)\n", S3C44B0_BASE_ZDMA_0 + ((uint32_t)offset << 2), data, mem_mask);
 	zdma_w(0, offset, data, mem_mask);
 }
 
 void s3c44b0_device::zdma_1_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	verboselog( *this, 9, "(ZDMA 1) %08X <- %08X (%08X)\n", S3C44B0_BASE_ZDMA_1 + (offset << 2), data, mem_mask);
+	verboselog( *this, 9, "(ZDMA 1) %08X <- %08X (%08X)\n", S3C44B0_BASE_ZDMA_1 + ((uint32_t)offset << 2), data, mem_mask);
 	zdma_w(1, offset, data, mem_mask);
 }
 
@@ -2174,26 +2174,26 @@ void s3c44b0_device::bdma_w(int ch, uint32_t offset, uint32_t data, uint32_t mem
 uint32_t s3c44b0_device::bdma_0_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t data = bdma_r(0, offset);
-	verboselog( *this, 9, "(BDMA 0) %08X -> %08X\n", S3C44B0_BASE_BDMA_0 + (offset << 2), data);
+	verboselog( *this, 9, "(BDMA 0) %08X -> %08X\n", S3C44B0_BASE_BDMA_0 + ((uint32_t)offset << 2), data);
 	return data;
 }
 
 uint32_t s3c44b0_device::bdma_1_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t data = bdma_r(1, offset);
-	verboselog( *this, 9, "(BDMA 1) %08X -> %08X\n", S3C44B0_BASE_BDMA_1 + (offset << 2), data);
+	verboselog( *this, 9, "(BDMA 1) %08X -> %08X\n", S3C44B0_BASE_BDMA_1 + ((uint32_t)offset << 2), data);
 	return data;
 }
 
 void s3c44b0_device::bdma_0_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	verboselog( *this, 9, "(BDMA 0) %08X <- %08X (%08X)\n", S3C44B0_BASE_BDMA_0 + (offset << 2), data, mem_mask);
+	verboselog( *this, 9, "(BDMA 0) %08X <- %08X (%08X)\n", S3C44B0_BASE_BDMA_0 + ((uint32_t)offset << 2), data, mem_mask);
 	bdma_w(0, offset, data, mem_mask);
 }
 
 void s3c44b0_device::bdma_1_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	verboselog( *this, 9, "(BDMA 1) %08X <- %08X (%08X)\n", S3C44B0_BASE_BDMA_1 + (offset << 2), data, mem_mask);
+	verboselog( *this, 9, "(BDMA 1) %08X <- %08X (%08X)\n", S3C44B0_BASE_BDMA_1 + ((uint32_t)offset << 2), data, mem_mask);
 	bdma_w(1, offset, data, mem_mask);
 }
 

--- a/src/devices/machine/sis630_host.cpp
+++ b/src/devices/machine/sis630_host.cpp
@@ -159,9 +159,9 @@ void sis630_host_device::memory_map(address_map &map)
 {
 }
 
-void sis630_host_device::map_shadowram(address_space *memory_space, uint32_t start_offs, uint32_t end_offs, bool read_enable, bool write_enable)
+void sis630_host_device::map_shadowram(address_space *memory_space, offs_t start_offs, offs_t end_offs, bool read_enable, bool write_enable)
 {
-	LOGMAP("- 0x%08x-0x%08x ", start_offs, end_offs);
+	LOGMAP("- 0x%08x-0x%08x ", (uint32_t)start_offs, (uint32_t)end_offs);
 
 	switch(write_enable << 1 | read_enable)
 	{

--- a/src/devices/machine/sun4c_mmu.cpp
+++ b/src/devices/machine/sun4c_mmu.cpp
@@ -194,7 +194,7 @@ TIMER_CALLBACK_MEMBER(sun4_mmu_base_device::reset_off_tick)
 	m_cpu->set_input_line(SPARC_RESET, CLEAR_LINE);
 }
 
-uint32_t sun4_mmu_base_device::fetch_insn(const bool supervisor, const uint32_t offset)
+uint32_t sun4_mmu_base_device::fetch_insn(const bool supervisor, const offs_t offset)
 {
 	if (supervisor)
 		return insn_data_r<SUPER_INSN>(offset, 0xffffffff);
@@ -202,56 +202,56 @@ uint32_t sun4_mmu_base_device::fetch_insn(const bool supervisor, const uint32_t 
 		return insn_data_r<USER_INSN>(offset, 0xffffffff);
 }
 
-void sun4_mmu_base_device::segment_flush_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::segment_flush_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	// Do nothing for now
 	LOGMASKED(LOG_SEGMENT_FLUSH, "%s: segment_flush_w %08x & %08x: %08x\n", machine().describe_context(), offset << 2, data, mem_mask);
 }
 
-void sun4_mmu_base_device::page_flush_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::page_flush_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	// Do nothing for now
 	LOGMASKED(LOG_PAGE_FLUSH, "%s: page_flush_w %08x & %08x: %08x\n", machine().describe_context(), offset << 2, data, mem_mask);
 }
 
-void sun4_mmu_base_device::context_flush_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::context_flush_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	// Do nothing for now
 	LOGMASKED(LOG_CONTEXT_FLUSH, "%s: context_flush_w %08x & %08x: %08x\n", machine().describe_context(), offset << 2, data, mem_mask);
 }
 
-void sun4_mmu_base_device::hw_segment_flush_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::hw_segment_flush_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	// Do nothing for now
 	LOGMASKED(LOG_SEGMENT_FLUSH, "%s: segment_flush_w %08x & %08x: %08x\n", machine().describe_context(), offset << 2, data, mem_mask);
 }
 
-void sun4_mmu_base_device::hw_page_flush_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::hw_page_flush_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	// Do nothing for now
 	LOGMASKED(LOG_PAGE_FLUSH, "%s: page_flush_w %08x & %08x: %08x\n", machine().describe_context(), offset << 2, data, mem_mask);
 }
 
-void sun4_mmu_base_device::hw_context_flush_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::hw_context_flush_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	// Do nothing for now
 	LOGMASKED(LOG_CONTEXT_FLUSH, "%s: context_flush_w %08x & %08x: %08x\n", machine().describe_context(), offset << 2, data, mem_mask);
 }
 
-void sun4_mmu_base_device::hw_flush_all_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::hw_flush_all_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	// Do nothing for now
 	LOGMASKED(LOG_ALL_FLUSH, "%s: hw_flush_all_w %08x = %08x: %08x\n", machine().describe_context(), offset << 2, data, mem_mask);
 }
 
-uint32_t sun4_mmu_base_device::context_reg_r(uint32_t offset, uint32_t mem_mask)
+uint32_t sun4_mmu_base_device::context_reg_r(offs_t offset, uint32_t mem_mask)
 {
 	const uint32_t data = m_context << (mem_mask == 0x00ff0000 ? 16 : 24);
 	LOGMASKED(LOG_CONTEXT, "%s: context_reg_r %08x & %08x: %08x\n", machine().describe_context(), offset << 2, mem_mask, data);
 	return data;
 }
 
-void sun4_mmu_base_device::context_reg_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::context_reg_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	LOGMASKED(LOG_CONTEXT, "%s: context_reg_w: %08x = %08x & %08x\n", machine().describe_context(), offset << 2, data, mem_mask);
 	m_context = data >> 24;
@@ -261,14 +261,14 @@ void sun4_mmu_base_device::context_reg_w(uint32_t offset, uint32_t data, uint32_
 	m_curr_segmap_masked = &m_segmap_masked[m_context_masked][0];
 }
 
-uint32_t sun4_mmu_base_device::system_enable_r(uint32_t offset, uint32_t mem_mask)
+uint32_t sun4_mmu_base_device::system_enable_r(offs_t offset, uint32_t mem_mask)
 {
 	const uint32_t data = m_system_enable << 24;
 	LOGMASKED(LOG_SYSTEM_ENABLE, "%s: system_enable_r %08x & %08x: %08x\n", machine().describe_context(), offset << 2, mem_mask, data);
 	return data;
 }
 
-void sun4_mmu_base_device::system_enable_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::system_enable_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	LOGMASKED(LOG_SYSTEM_ENABLE, "%s: system_enable_w: %08x = %08x & %08x\n", machine().describe_context(), offset << 2, data, mem_mask);
 	m_system_enable = data >> 24;
@@ -287,7 +287,7 @@ void sun4_mmu_base_device::system_enable_w(uint32_t offset, uint32_t data, uint3
 	}
 }
 
-uint32_t sun4_mmu_base_device::bus_error_r(uint32_t offset, uint32_t mem_mask)
+uint32_t sun4_mmu_base_device::bus_error_r(offs_t offset, uint32_t mem_mask)
 {
 	const uint32_t data = m_buserr[offset & 0xf];
 	LOGMASKED(LOG_BUSERROR, "%s: bus_error_r %08x & %08x: %08x\n", machine().describe_context(), 0x60000000 | (offset << 2), mem_mask, data);
@@ -295,7 +295,7 @@ uint32_t sun4_mmu_base_device::bus_error_r(uint32_t offset, uint32_t mem_mask)
 	return data;
 }
 
-void sun4_mmu_base_device::bus_error_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::bus_error_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	const uint32_t masked_offset = offset & 0xf;
 	LOGMASKED(LOG_BUSERROR, "%s: bus_error_w: %08x = %08x & %08x\n", machine().describe_context(), 0x60000000 | (offset << 2), data, mem_mask);
@@ -309,33 +309,33 @@ void sun4_mmu_base_device::bus_error_w(uint32_t offset, uint32_t data, uint32_t 
 		m_buserr[3] = (data & 0x3fffffff) | ((data & 0x20000000) << 1) | ((data & 0x20000000) << 2);
 }
 
-uint32_t sun4_mmu_base_device::cache_tag_r(uint32_t offset, uint32_t mem_mask)
+uint32_t sun4_mmu_base_device::cache_tag_r(offs_t offset, uint32_t mem_mask)
 {
 	const uint32_t data = m_cachetags[offset & m_cache_mask];
 	LOGMASKED(LOG_CACHE_TAGS, "%s: cache_tag_r %08x & %08x: %08x\n", machine().describe_context(), offset, mem_mask, data);
 	return data;
 }
 
-void sun4_mmu_base_device::cache_tag_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::cache_tag_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	LOGMASKED(LOG_CACHE_TAGS, "%s: cache_tag_w: %08x = %08x & %08x\n", machine().describe_context(), offset, data, mem_mask);
 	m_cachetags[offset & m_cache_mask] = data & 0x03f8fffc;
 }
 
-uint32_t sun4_mmu_base_device::cache_data_r(uint32_t offset, uint32_t mem_mask)
+uint32_t sun4_mmu_base_device::cache_data_r(offs_t offset, uint32_t mem_mask)
 {
 	const uint32_t data = m_cachedata[offset & m_cache_mask];
 	LOGMASKED(LOG_CACHE_DATA, "%s: cache_data_r %08x & %08x: %08x\n", machine().describe_context(), offset, mem_mask, data);
 	return data;
 }
 
-void sun4_mmu_base_device::cache_data_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::cache_data_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	LOGMASKED(LOG_CACHE_DATA, "%s: cache_data_w: %08x = %08x & %08x\n", machine().describe_context(), offset, data, mem_mask);
 	m_cachedata[offset & m_cache_mask] = data | (1 << 19);
 }
 
-uint32_t sun4_mmu_base_device::uart_r(uint32_t offset, uint32_t mem_mask)
+uint32_t sun4_mmu_base_device::uart_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t data = 0xffffffff;
 	switch (offset & 3)
@@ -357,7 +357,7 @@ uint32_t sun4_mmu_base_device::uart_r(uint32_t offset, uint32_t mem_mask)
 	return data;
 }
 
-void sun4_mmu_base_device::uart_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::uart_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	LOGMASKED(LOG_UART, "%s: uart_w: %08x = %08x & %08x\n", machine().describe_context(), offset, data, mem_mask);
 	switch (offset & 3)
@@ -383,7 +383,7 @@ void sun4_mmu_base_device::uart_w(uint32_t offset, uint32_t data, uint32_t mem_m
 	}
 }
 
-uint32_t sun4_mmu_base_device::segment_map_r(uint32_t offset, uint32_t mem_mask)
+uint32_t sun4_mmu_base_device::segment_map_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t data = 0;
 	if (mem_mask == 0xffff0000)
@@ -398,7 +398,7 @@ uint32_t sun4_mmu_base_device::segment_map_r(uint32_t offset, uint32_t mem_mask)
 	return data;
 }
 
-void sun4_mmu_base_device::segment_map_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::segment_map_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	LOGMASKED(LOG_SEGMENT_MAP, "%s: segment_map_w: %08x = %08x & %08x\n", machine().describe_context(), offset << 2, data, mem_mask);
 
@@ -417,7 +417,7 @@ void sun4_mmu_base_device::segment_map_w(uint32_t offset, uint32_t data, uint32_
 	m_curr_segmap_masked[seg] = (segdata & m_pmeg_mask) << 6;
 }
 
-uint32_t sun4_mmu_base_device::page_map_r(uint32_t offset, uint32_t mem_mask)
+uint32_t sun4_mmu_base_device::page_map_r(offs_t offset, uint32_t mem_mask)
 {
 	const uint32_t page = m_curr_segmap_masked[(offset >> 16) & 0xfff] | ((offset >> m_seg_entry_shift) & m_seg_entry_mask);
 	const uint32_t data = page_entry_to_uint(page);
@@ -425,7 +425,7 @@ uint32_t sun4_mmu_base_device::page_map_r(uint32_t offset, uint32_t mem_mask)
 	return data;
 }
 
-void sun4_mmu_base_device::page_map_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::page_map_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	const uint32_t page = m_curr_segmap_masked[(offset >> 16) & 0xfff] | ((offset >> m_seg_entry_shift) & m_seg_entry_mask);
 	LOGMASKED(LOG_PAGE_MAP, "%s: page_map_w: %08x (%x) = %08x & %08x\n", machine().describe_context(), offset << 2, page, data, mem_mask);
@@ -433,7 +433,7 @@ void sun4_mmu_base_device::page_map_w(uint32_t offset, uint32_t data, uint32_t m
 	m_page_valid[page] = m_pagemap[page].valid;
 }
 
-void sun4_mmu_base_device::type0_timeout_r(const uint32_t offset)
+void sun4_mmu_base_device::type0_timeout_r(const offs_t offset)
 {
 	LOGMASKED(LOG_TYPE0_TIMEOUT, "%s: type0_timeout_r (%08x)\n", machine().describe_context(), offset << 2);
 	m_buserr[0] = 0x20; // read timeout
@@ -441,7 +441,7 @@ void sun4_mmu_base_device::type0_timeout_r(const uint32_t offset)
 	m_host->set_mae();
 }
 
-void sun4_mmu_base_device::type0_timeout_w(const uint32_t offset)
+void sun4_mmu_base_device::type0_timeout_w(const offs_t offset)
 {
 	LOGMASKED(LOG_TYPE0_TIMEOUT, "%s: type0_timeout_w (%08x)\n", machine().describe_context(), offset << 2);
 	m_buserr[0] = 0x8020; // write timeout
@@ -449,7 +449,7 @@ void sun4_mmu_base_device::type0_timeout_w(const uint32_t offset)
 	m_host->set_mae();
 }
 
-uint32_t sun4_mmu_base_device::type1_timeout_r(uint32_t offset)
+uint32_t sun4_mmu_base_device::type1_timeout_r(offs_t offset)
 {
 	LOGMASKED(LOG_TYPE1_TIMEOUT, "%s: type1_timeout_r (%08x)\n", machine().describe_context(), offset << 2);
 	m_buserr[2] = 0x20; // read timeout
@@ -457,14 +457,14 @@ uint32_t sun4_mmu_base_device::type1_timeout_r(uint32_t offset)
 	return 0;
 }
 
-void sun4_mmu_base_device::type1_timeout_w(uint32_t offset, uint32_t data)
+void sun4_mmu_base_device::type1_timeout_w(offs_t offset, uint32_t data)
 {
 	LOGMASKED(LOG_TYPE1_TIMEOUT, "%s: type1_timeout_w (%08x)\n", machine().describe_context(), offset << 2);
 	m_buserr[2] = 0x120; // write timeout
 	m_buserr[3] = m_type1_offset << 2;
 }
 
-uint32_t sun4_mmu_base_device::parity_r(uint32_t offset, uint32_t mem_mask)
+uint32_t sun4_mmu_base_device::parity_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t data = 0;
 	if (offset == 0)
@@ -481,7 +481,7 @@ uint32_t sun4_mmu_base_device::parity_r(uint32_t offset, uint32_t mem_mask)
 	return data;
 }
 
-void sun4_mmu_base_device::parity_w(uint32_t offset, uint32_t data, uint32_t mem_mask)
+void sun4_mmu_base_device::parity_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	if (offset == 0)
 	{
@@ -515,13 +515,13 @@ void sun4_mmu_base_device::merge_page_entry(uint32_t index, uint32_t data, uint3
 	pe.page = (new_value & m_page_entry_mask) << m_seg_entry_shift;
 }
 
-template uint32_t sun4_mmu_base_device::insn_data_r<sun4_mmu_base_device::USER_INSN>(const uint32_t, const uint32_t);
-template uint32_t sun4_mmu_base_device::insn_data_r<sun4_mmu_base_device::SUPER_INSN>(const uint32_t, const uint32_t);
-template uint32_t sun4_mmu_base_device::insn_data_r<sun4_mmu_base_device::USER_DATA>(const uint32_t, const uint32_t);
-template uint32_t sun4_mmu_base_device::insn_data_r<sun4_mmu_base_device::SUPER_DATA>(const uint32_t, const uint32_t);
+template uint32_t sun4_mmu_base_device::insn_data_r<sun4_mmu_base_device::USER_INSN>(const offs_t, const uint32_t);
+template uint32_t sun4_mmu_base_device::insn_data_r<sun4_mmu_base_device::SUPER_INSN>(const offs_t, const uint32_t);
+template uint32_t sun4_mmu_base_device::insn_data_r<sun4_mmu_base_device::USER_DATA>(const offs_t, const uint32_t);
+template uint32_t sun4_mmu_base_device::insn_data_r<sun4_mmu_base_device::SUPER_DATA>(const offs_t, const uint32_t);
 
 template <sun4_mmu_base_device::insn_data_mode MODE>
-uint32_t sun4_mmu_base_device::insn_data_r(const uint32_t offset, const uint32_t mem_mask)
+uint32_t sun4_mmu_base_device::insn_data_r(const offs_t offset, const uint32_t mem_mask)
 {
 	// supervisor program fetches in boot state are special
 	if (MODE == SUPER_INSN && m_fetch_bootrom)
@@ -597,13 +597,13 @@ uint32_t sun4_mmu_base_device::insn_data_r(const uint32_t offset, const uint32_t
 	}
 }
 
-template void sun4_mmu_base_device::insn_data_w<sun4_mmu_base_device::USER_INSN>(const uint32_t, const uint32_t, const uint32_t);
-template void sun4_mmu_base_device::insn_data_w<sun4_mmu_base_device::SUPER_INSN>(const uint32_t, const uint32_t, const uint32_t);
-template void sun4_mmu_base_device::insn_data_w<sun4_mmu_base_device::USER_DATA>(const uint32_t, const uint32_t, const uint32_t);
-template void sun4_mmu_base_device::insn_data_w<sun4_mmu_base_device::SUPER_DATA>(const uint32_t, const uint32_t, const uint32_t);
+template void sun4_mmu_base_device::insn_data_w<sun4_mmu_base_device::USER_INSN>(const offs_t, const uint32_t, const uint32_t);
+template void sun4_mmu_base_device::insn_data_w<sun4_mmu_base_device::SUPER_INSN>(const offs_t, const uint32_t, const uint32_t);
+template void sun4_mmu_base_device::insn_data_w<sun4_mmu_base_device::USER_DATA>(const offs_t, const uint32_t, const uint32_t);
+template void sun4_mmu_base_device::insn_data_w<sun4_mmu_base_device::SUPER_DATA>(const offs_t, const uint32_t, const uint32_t);
 
 template <sun4_mmu_base_device::insn_data_mode MODE>
-void sun4_mmu_base_device::insn_data_w(const uint32_t offset, const uint32_t data, const uint32_t mem_mask)
+void sun4_mmu_base_device::insn_data_w(const offs_t offset, const uint32_t data, const uint32_t mem_mask)
 {
 	// it's translation time
 	const uint32_t pmeg = m_curr_segmap_masked[(offset >> 16) & 0xfff];// & m_pmeg_mask;

--- a/src/devices/machine/sun4c_mmu.h
+++ b/src/devices/machine/sun4c_mmu.h
@@ -58,43 +58,43 @@ public:
 		SUPER_DATA
 	};
 
-	template <insn_data_mode MODE> uint32_t insn_data_r(const uint32_t offset, const uint32_t mem_mask);
-	template <insn_data_mode MODE> void insn_data_w(const uint32_t offset, const uint32_t data, const uint32_t mem_mask);
+	template <insn_data_mode MODE> uint32_t insn_data_r(const offs_t offset, const uint32_t mem_mask);
+	template <insn_data_mode MODE> void insn_data_w(const offs_t offset, const uint32_t data, const uint32_t mem_mask);
 
-	uint32_t type1_timeout_r(uint32_t offset);
-	void type1_timeout_w(uint32_t offset, uint32_t data);
-	uint32_t parity_r(uint32_t offset, uint32_t mem_mask);
-	void parity_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
+	uint32_t type1_timeout_r(offs_t offset);
+	void type1_timeout_w(offs_t offset, uint32_t data);
+	uint32_t parity_r(offs_t offset, uint32_t mem_mask);
+	void parity_w(offs_t offset, uint32_t data, uint32_t mem_mask);
 
 	// sparc_mmu_interface overrides
-	uint32_t fetch_insn(const bool supervisor, const uint32_t offset) override;
+	uint32_t fetch_insn(const bool supervisor, const offs_t offset) override;
 	void set_host(sparc_mmu_host_interface *host) override { m_host = host; }
 
-	uint32_t context_reg_r(uint32_t offset, uint32_t mem_mask);
-	void context_reg_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
-	uint32_t system_enable_r(uint32_t offset, uint32_t mem_mask);
-	void system_enable_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
-	uint32_t bus_error_r(uint32_t offset, uint32_t mem_mask);
-	void bus_error_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
-	uint32_t cache_tag_r(uint32_t offset, uint32_t mem_mask);
-	void cache_tag_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
-	uint32_t cache_data_r(uint32_t offset, uint32_t mem_mask);
-	void cache_data_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
-	uint32_t uart_r(uint32_t offset, uint32_t mem_mask);
-	void uart_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
-	uint32_t segment_map_r(uint32_t offset, uint32_t mem_mask);
-	void segment_map_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
-	uint32_t page_map_r(uint32_t offset, uint32_t mem_mask);
-	void page_map_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
+	uint32_t context_reg_r(offs_t offset, uint32_t mem_mask);
+	void context_reg_w(offs_t offset, uint32_t data, uint32_t mem_mask);
+	uint32_t system_enable_r(offs_t offset, uint32_t mem_mask);
+	void system_enable_w(offs_t offset, uint32_t data, uint32_t mem_mask);
+	uint32_t bus_error_r(offs_t offset, uint32_t mem_mask);
+	void bus_error_w(offs_t offset, uint32_t data, uint32_t mem_mask);
+	uint32_t cache_tag_r(offs_t offset, uint32_t mem_mask);
+	void cache_tag_w(offs_t offset, uint32_t data, uint32_t mem_mask);
+	uint32_t cache_data_r(offs_t offset, uint32_t mem_mask);
+	void cache_data_w(offs_t offset, uint32_t data, uint32_t mem_mask);
+	uint32_t uart_r(offs_t offset, uint32_t mem_mask);
+	void uart_w(offs_t offset, uint32_t data, uint32_t mem_mask);
+	uint32_t segment_map_r(offs_t offset, uint32_t mem_mask);
+	void segment_map_w(offs_t offset, uint32_t data, uint32_t mem_mask);
+	uint32_t page_map_r(offs_t offset, uint32_t mem_mask);
+	void page_map_w(offs_t offset, uint32_t data, uint32_t mem_mask);
 
-	void segment_flush_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
-	void page_flush_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
-	void context_flush_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
+	void segment_flush_w(offs_t offset, uint32_t data, uint32_t mem_mask);
+	void page_flush_w(offs_t offset, uint32_t data, uint32_t mem_mask);
+	void context_flush_w(offs_t offset, uint32_t data, uint32_t mem_mask);
 
-	void hw_segment_flush_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
-	void hw_page_flush_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
-	void hw_context_flush_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
-	void hw_flush_all_w(uint32_t offset, uint32_t data, uint32_t mem_mask);
+	void hw_segment_flush_w(offs_t offset, uint32_t data, uint32_t mem_mask);
+	void hw_page_flush_w(offs_t offset, uint32_t data, uint32_t mem_mask);
+	void hw_context_flush_w(offs_t offset, uint32_t data, uint32_t mem_mask);
+	void hw_flush_all_w(offs_t offset, uint32_t data, uint32_t mem_mask);
 
 protected:
 	sun4_mmu_base_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
@@ -107,8 +107,8 @@ protected:
 	uint32_t page_entry_to_uint(uint32_t index);
 	void merge_page_entry(uint32_t index, uint32_t data, uint32_t mem_mask);
 
-	void type0_timeout_r(const uint32_t offset);
-	void type0_timeout_w(const uint32_t offset);
+	void type0_timeout_r(const offs_t offset);
+	void type0_timeout_w(const offs_t offset);
 	void l2p_command(const std::vector<std::string_view> &params);
 
 	enum

--- a/src/devices/sound/discrete.cpp
+++ b/src/devices/sound/discrete.cpp
@@ -1108,10 +1108,10 @@ void discrete_device::write(offs_t offset, uint8_t data)
 		if (node->interface(intf))
 				intf->input_write(0, data);
 		else
-			discrete_log("discrete_sound_w write to non-input NODE_%02d\n", offset-NODE_00);
+			discrete_log("discrete_sound_w write to non-input NODE_%02d\n", (uint8_t)offset-NODE_00);
 	}
 	else
 	{
-		discrete_log("discrete_sound_w write to non-existent NODE_%02d\n", offset-NODE_00);
+		discrete_log("discrete_sound_w write to non-existent NODE_%02d\n", (uint8_t)offset-NODE_00);
 	}
 }

--- a/src/devices/sound/qs1000.cpp
+++ b/src/devices/sound/qs1000.cpp
@@ -358,7 +358,7 @@ void qs1000_device::wave_w(offs_t offset, uint8_t data)
 	m_stream->update();
 
 	if (LOGGING_ENABLED)
-		printf("QS1000 W[%x] %x\n", 0x200 + offset, data);
+		printf("QS1000 W[%x] %x\n", 0x200 + (uint16_t)offset, data);
 
 	switch (offset)
 	{

--- a/src/devices/video/ym7101.cpp
+++ b/src/devices/video/ym7101.cpp
@@ -439,7 +439,7 @@ void ym7101_device::vram_w(offs_t offset, u16 data, u16 mem_mask)
 	COMBINE_DATA(&m_vram[offset]);
 	gfx(0)->mark_dirty(offset >> 4);
 
-	const u32 sprite_table = m_sprite_attribute_table >> 1;
+	const offs_t sprite_table = m_sprite_attribute_table >> 1;
 
 	// TODO: check akumajo Stage 6-3
 	// TODO: check segacd:snatcheru (H32, puts sprite_table at $fe00)

--- a/src/emu/addrmap.cpp
+++ b/src/emu/addrmap.cpp
@@ -1067,7 +1067,7 @@ void address_map::map_validity_check(validity_checker &valid, int spacenum) cons
 	if (m_spacenum != spacenum)
 		osd_printf_error("Space %d has address space %d handlers!\n", spacenum, m_spacenum);
 
-	offs_t globalmask = (~0ULL) >> (64 - spaceconfig.m_addr_width);
+	offs_t globalmask = (~offs_t(0)) >> (8 * sizeof(offs_t) - spaceconfig.m_addr_width);
 	if (m_globalmask != 0)
 		globalmask = m_globalmask;
 

--- a/src/emu/addrmap.cpp
+++ b/src/emu/addrmap.cpp
@@ -1067,7 +1067,7 @@ void address_map::map_validity_check(validity_checker &valid, int spacenum) cons
 	if (m_spacenum != spacenum)
 		osd_printf_error("Space %d has address space %d handlers!\n", spacenum, m_spacenum);
 
-	offs_t globalmask = 0xffffffffUL >> (32 - spaceconfig.m_addr_width);
+	offs_t globalmask = (~0ULL) >> (64 - spaceconfig.m_addr_width);
 	if (m_globalmask != 0)
 		globalmask = m_globalmask;
 

--- a/src/emu/debug/debugcmd.cpp
+++ b/src/emu/debug/debugcmd.cpp
@@ -4561,9 +4561,9 @@ void debugger_commands::execute_memdump(const std::vector<std::string_view> &par
 						for (memory_entry &entry : entries[mode])
 						{
 							if (octal)
-								fprintf(file, "%0*llo - %0*llo:", nc, entry.start, nc, entry.end);
+								fprintf(file, "%s", string_format("%0*o - %0*o:", nc, entry.start, nc, entry.end).c_str());
 							else
-								fprintf(file, "%0*llx - %0*llx:", nc, entry.start, nc, entry.end);
+								fprintf(file, "%s", string_format("%0*x - %0*x:", nc, entry.start, nc, entry.end).c_str());
 							for (const auto &c : entry.context)
 								if (c.disabled)
 									fprintf(file, " %s[off]", c.view->name().c_str());

--- a/src/emu/debug/debugcmd.cpp
+++ b/src/emu/debug/debugcmd.cpp
@@ -612,7 +612,7 @@ bool debugger_commands::mini_printf(std::ostream &stream, const std::vector<std:
 							address_space *tspace;
 							std::string s;
 
-							for (u32 address = u32(number), taddress; space->device().memory().translate(space->spacenum(), device_memory_interface::TR_READ, taddress = address, tspace); address++)
+							for (offs_t address = offs_t(number), taddress; space->device().memory().translate(space->spacenum(), device_memory_interface::TR_READ, taddress = address, tspace); address++)
 							{
 								u8 const data = tspace->read_byte(taddress);
 
@@ -4561,9 +4561,9 @@ void debugger_commands::execute_memdump(const std::vector<std::string_view> &par
 						for (memory_entry &entry : entries[mode])
 						{
 							if (octal)
-								fprintf(file, "%0*o - %0*o:", nc, entry.start, nc, entry.end);
+								fprintf(file, "%0*llo - %0*llo:", nc, entry.start, nc, entry.end);
 							else
-								fprintf(file, "%0*x - %0*x:", nc, entry.start, nc, entry.end);
+								fprintf(file, "%0*llx - %0*llx:", nc, entry.start, nc, entry.end);
 							for (const auto &c : entry.context)
 								if (c.disabled)
 									fprintf(file, " %s[off]", c.view->name().c_str());

--- a/src/emu/debug/express.h
+++ b/src/emu/debug/express.h
@@ -51,7 +51,7 @@ enum expression_space
 //  TYPE DEFINITIONS
 //**************************************************************************
 
-using offs_t = u32;
+using offs_t = u64;
 
 // ======================> expression_error
 

--- a/src/emu/emumem.h
+++ b/src/emu/emumem.h
@@ -66,8 +66,8 @@ template<int Width, int AddrShift> class handler_entry_write_passthrough;
 //  TYPE DEFINITIONS
 //**************************************************************************
 
-// offsets and addresses are 32-bit (for now...)
-using offs_t = u32;
+// offsets and addresses are 64-bit
+using offs_t = u64;
 
 // address map constructors are delegates that build up an address_map
 using address_map_constructor = named_delegate<void (address_map &)>;

--- a/src/lib/util/disasmintf.h
+++ b/src/lib/util/disasmintf.h
@@ -33,7 +33,7 @@ public:
 	using s16 = osd::s16;
 	using s32 = osd::s32;
 	using s64 = osd::s64;
-	using offs_t = u32;
+	using offs_t = u64;
 
 	// Disassembler constants for the return value
 	static constexpr u32 SUPPORTED       = 0x80000000;   // are disassembly flags supported?

--- a/src/mame/apple/dbdma.cpp
+++ b/src/mame/apple/dbdma.cpp
@@ -162,13 +162,13 @@ void dbdma_device::waitselect_w(u32 data)
 	m_waitselect = data;
 }
 
-u32 dbdma_device::dma_read(u32 offset)
+u32 dbdma_device::dma_read(offs_t offset)
 {
 	step_program();
 	return m_xfer_word;
 }
 
-void dbdma_device::dma_write(u32 offset, u32 data)
+void dbdma_device::dma_write(offs_t offset, u32 data)
 {
 	m_xfer_word = data;
 	step_program();

--- a/src/mame/apple/dbdma.h
+++ b/src/mame/apple/dbdma.h
@@ -21,8 +21,8 @@ public:
 
 	dbdma_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	u32 dma_read(u32 offset);
-	void dma_write(u32 offset, u32 data);
+	u32 dma_read(offs_t offset);
+	void dma_write(offs_t offset, u32 data);
 
 	auto irq_callback() { return write_irq.bind(); }
 

--- a/src/mame/apple/heathrow.cpp
+++ b/src/mame/apple/heathrow.cpp
@@ -700,12 +700,12 @@ void macio_device::codec_w(offs_t offset, uint32_t data)
 	write_codec(offset, data);
 }
 
-u32 macio_device::codec_dma_read(u32 offset)
+u32 macio_device::codec_dma_read(offs_t offset)
 {
 	return m_dma_audio_out->dma_read(offset);
 }
 
-void macio_device::codec_dma_write(u32 offset, u32 data)
+void macio_device::codec_dma_write(offs_t offset, u32 data)
 {
 	m_dma_audio_in->dma_write(offset, data);
 }

--- a/src/mame/apple/heathrow.h
+++ b/src/mame/apple/heathrow.h
@@ -39,8 +39,8 @@ public:
 
 	template <int bit> void set_irq_line(int state);
 
-	u32 codec_dma_read(u32 offset);
-	void codec_dma_write(u32 offset, u32 data);
+	u32 codec_dma_read(offs_t offset);
+	void codec_dma_write(offs_t offset, u32 data);
 
 	u32 codec_r(offs_t offset);
 	void codec_w(offs_t offset, u32 data);

--- a/src/mame/capcom/cps1bl_5205.cpp
+++ b/src/mame/capcom/cps1bl_5205.cpp
@@ -271,7 +271,7 @@ void cps1bl_5205_state::sf2b_layer_w(offs_t offset, uint16_t data)
 		m_cps_b_regs[m_layer_enable_reg / 2] = data;
 		break;
 	default:
-		printf("%X:%X ",offset,data);
+		logerror("%X:%X ", offset, data);
 	}
 }
 

--- a/src/mame/exidy/exidy440_a.cpp
+++ b/src/mame/exidy/exidy440_a.cpp
@@ -262,7 +262,7 @@ uint8_t exidy440_sound_device::sound_volume_r(offs_t offset)
 void exidy440_sound_device::sound_volume_w(offs_t offset, uint8_t data)
 {
 	if (SOUND_LOG && m_debuglog)
-		fprintf(m_debuglog, "Volume %02X=%02X\n", offset, data);
+		fprintf(m_debuglog, "Volume %02llX=%02X\n", offset, data);
 
 	/* update the stream */
 	m_stream->update();

--- a/src/mame/exidy/exidy440_a.cpp
+++ b/src/mame/exidy/exidy440_a.cpp
@@ -262,7 +262,7 @@ uint8_t exidy440_sound_device::sound_volume_r(offs_t offset)
 void exidy440_sound_device::sound_volume_w(offs_t offset, uint8_t data)
 {
 	if (SOUND_LOG && m_debuglog)
-		fprintf(m_debuglog, "Volume %02llX=%02X\n", offset, data);
+		fprintf(m_debuglog, "Volume %X=%02X\n", (uint8_t)offset, data);
 
 	/* update the stream */
 	m_stream->update();

--- a/src/mame/funworld/funworld.cpp
+++ b/src/mame/funworld/funworld.cpp
@@ -3562,7 +3562,7 @@ uint8_t royalcrdf_state::royalcrdf_opcode_r(offs_t offset)
 	if(offset < 0x800)
 		data = bitswap<8>(data ^ 0x22, 2, 6, 7, 4, 3, 1, 5, 0);
 
-	unsigned idx {bitswap<4>(offset, 8, 5, 2, 1)};
+	uint64_t idx {bitswap<4>(offset, 8, 5, 2, 1)};
 
 	return bitswap<8>(data, bs[idx][3], 6, bs[idx][2], 4, 3, bs[idx][1], bs[idx][0], 0) ^ xm[idx];
 }
@@ -3623,7 +3623,7 @@ uint8_t multiwin_state::multiwin_opcode_r(offs_t offset)
 	};
 
 	uint8_t data {m_maincpu->space(AS_PROGRAM).read_byte(offset)};
-	unsigned idx {bitswap<4>(offset, 6,9,5,3)};
+	uint64_t idx {bitswap<4>(offset, 6,9,5,3)};
 
 	return bitswap<8>(data, bs[idx&7][4],6,bs[idx&7][3],bs[idx&7][2],3,bs[idx&7][1],1,bs[idx&7][0]) ^ xm[idx];
 }

--- a/src/mame/gaelco/atvtrack.cpp
+++ b/src/mame/gaelco/atvtrack.cpp
@@ -208,9 +208,7 @@ inline u32 atvtrack_state::decode64_32(offs_t offset64, u64 data, u64 mem_mask, 
 
 u64 atvtrack_state::control_r(offs_t offset, u64 mem_mask)
 {
-	u32 addr;
-
-	addr = 0;
+	offs_t addr = 0;
 	decode64_32(offset, 0, mem_mask, addr);
 	if (addr == (0x00020000-0x00020000)/4)
 		return -1;
@@ -221,11 +219,9 @@ u64 atvtrack_state::control_r(offs_t offset, u64 mem_mask)
 
 void atvtrack_state::control_w(offs_t offset, u64 data, u64 mem_mask)
 {
-	u32 addr, dat; //, old;
-
-	addr = 0;
-	dat = decode64_32(offset, data, mem_mask, addr);
-//  old = m_area1_data[addr];
+	offs_t addr = 0;
+	u32 dat = decode64_32(offset, data, mem_mask, addr);
+//  u32 old = m_area1_data[addr];
 	m_area1_data[addr] = dat;
 	if (addr == (0x00020000-0x00020000)/4) {
 		if ((data & 4) && m_slaverun)

--- a/src/mame/hp/hp9845_optrom.cpp
+++ b/src/mame/hp/hp9845_optrom.cpp
@@ -46,8 +46,8 @@ std::pair<std::error_condition, std::string> hp9845_optrom_device::call_load()
 		return std::make_pair(image_error::BADSOFTWARE, "Software item is missing 'base' feature");
 	}
 
-	offs_t base_addr;
-	if (base_feature[ 0 ] != '0' || base_feature[ 1 ] != 'x' || sscanf(&base_feature[ 2 ] , "%llx" , &base_addr) != 1) {
+	u32 base_addr;
+	if (base_feature[ 0 ] != '0' || base_feature[ 1 ] != 'x' || sscanf(&base_feature[ 2 ] , "%x" , &base_addr) != 1) {
 		return std::make_pair(image_error::BADSOFTWARE, "Can't parse software item 'base' feature");
 	}
 

--- a/src/mame/hp/hp9845_optrom.cpp
+++ b/src/mame/hp/hp9845_optrom.cpp
@@ -47,7 +47,7 @@ std::pair<std::error_condition, std::string> hp9845_optrom_device::call_load()
 	}
 
 	offs_t base_addr;
-	if (base_feature[ 0 ] != '0' || base_feature[ 1 ] != 'x' || sscanf(&base_feature[ 2 ] , "%x" , &base_addr) != 1) {
+	if (base_feature[ 0 ] != '0' || base_feature[ 1 ] != 'x' || sscanf(&base_feature[ 2 ] , "%llx" , &base_addr) != 1) {
 		return std::make_pair(image_error::BADSOFTWARE, "Can't parse software item 'base' feature");
 	}
 

--- a/src/mame/hp/hp_ipc_optrom.cpp
+++ b/src/mame/hp/hp_ipc_optrom.cpp
@@ -61,7 +61,7 @@ std::pair<std::error_condition, std::string> hp_ipc_optrom_device::call_load()
 		return std::make_pair(image_error::BADSOFTWARE, "Software item is missing 'base' feature");
 	}
 
-	if (base_feature[ 0 ] != '0' || base_feature[ 1 ] != 'x' || sscanf(&base_feature[ 2 ] , "%llx" , &m_base) != 1) {
+	if (base_feature[ 0 ] != '0' || base_feature[ 1 ] != 'x' || sscanf(&base_feature[ 2 ] , "%x" , &m_base) != 1) {
 		return std::make_pair(image_error::BADSOFTWARE, "Can't parse software item 'base' feature");
 	}
 

--- a/src/mame/hp/hp_ipc_optrom.cpp
+++ b/src/mame/hp/hp_ipc_optrom.cpp
@@ -61,7 +61,7 @@ std::pair<std::error_condition, std::string> hp_ipc_optrom_device::call_load()
 		return std::make_pair(image_error::BADSOFTWARE, "Software item is missing 'base' feature");
 	}
 
-	if (base_feature[ 0 ] != '0' || base_feature[ 1 ] != 'x' || sscanf(&base_feature[ 2 ] , "%x" , &m_base) != 1) {
+	if (base_feature[ 0 ] != '0' || base_feature[ 1 ] != 'x' || sscanf(&base_feature[ 2 ] , "%llx" , &m_base) != 1) {
 		return std::make_pair(image_error::BADSOFTWARE, "Can't parse software item 'base' feature");
 	}
 

--- a/src/mame/hp/hp_ipc_optrom.h
+++ b/src/mame/hp/hp_ipc_optrom.h
@@ -43,7 +43,7 @@ protected:
 	virtual const char *file_extensions() const noexcept override { return "bin"; }
 
 private:
-	offs_t m_base;
+	u32 m_base;
 };
 
 // device type definition

--- a/src/mame/ibm/rosetta.cpp
+++ b/src/mame/ibm/rosetta.cpp
@@ -245,7 +245,7 @@ void rosetta_device::device_post_load()
 	config_tlb();
 }
 
-bool rosetta_device::ior(u32 address, u32 &data)
+bool rosetta_device::ior(offs_t address, u32 &data)
 {
 	if ((address >> 16) == u8(m_control[IOBA]))
 	{
@@ -299,7 +299,7 @@ bool rosetta_device::ior(u32 address, u32 &data)
 	return false;
 }
 
-bool rosetta_device::iow(u32 address, u32 data)
+bool rosetta_device::iow(offs_t address, u32 data)
 {
 	if ((address >> 16) == u8(m_control[IOBA]))
 	{
@@ -360,9 +360,9 @@ bool rosetta_device::iow(u32 address, u32 data)
 }
 
 // translate logical to physical address ignoring protection and without side effects
-bool rosetta_device::translate(u32 &address) const
+bool rosetta_device::translate(offs_t &address) const
 {
-	unsigned const segment = address >> 28;
+	offs_t const segment = address >> 28;
 
 	// segment present
 	if (!(m_segment[segment] & SEGMENT_P))
@@ -376,7 +376,7 @@ bool rosetta_device::translate(u32 &address) const
 		return true;
 	}
 
-	u64 const virtual_address = (u64(m_segment[segment] & SEGMENT_ID) << 26) | (address & 0x0fff'ffffU);
+	offs_t const virtual_address = (u64(m_segment[segment] & SEGMENT_ID) << 26) | (address & 0x0fff'ffffU);
 
 	// ignore tlb and directly search inverted page table
 	u32 page_address = 0;
@@ -431,9 +431,9 @@ bool rosetta_device::translate(u32 &address) const
 	return true;
 }
 
-bool rosetta_device::translate(u32 &address, bool system_processor, bool store)
+bool rosetta_device::translate(offs_t &address, bool system_processor, bool store)
 {
-	unsigned const segment = address >> 28;
+	offs_t const segment = address >> 28;
 
 	// segment present
 	if (!(m_segment[segment] & SEGMENT_P))
@@ -457,7 +457,7 @@ bool rosetta_device::translate(u32 &address, bool system_processor, bool store)
 		return true;
 	}
 
-	u64 const virtual_address = (u64(m_segment[segment] & SEGMENT_ID) << 26) | (address & 0x0fff'ffffU);
+	offs_t const virtual_address = (offs_t(m_segment[segment] & SEGMENT_ID) << 26) | (address & 0x0fff'ffffU);
 
 	tlb_entry const te = tlb_search(virtual_address, m_segment[segment] & SEGMENT_S);
 	if (!(te.field1 & TLB_V))
@@ -611,7 +611,7 @@ rosetta_device::tlb_entry rosetta_device::tlb_search(u64 const virtual_address, 
 	return te;
 }
 
-u32 rosetta_device::tlb_reload(rosetta_device::tlb_entry &tlb_entry, u64 const virtual_address, bool special)
+u32 rosetta_device::tlb_reload(rosetta_device::tlb_entry &tlb_entry, offs_t const virtual_address, bool special)
 {
 	// compute hat index
 	u16 hat_offset = (((virtual_address >> 26) & SEGMENT_ID) ^ (virtual_address >> (m_page_shift - 2))) & m_hat_mask;
@@ -1103,7 +1103,7 @@ void rosetta_device::compute_address(u32 data)
 			: ((t.field1 & TLB_RPN2K) << 8) | (data & 0x07ffU);
 }
 
-bool rosetta_device::fetch(u32 address, u16 &data, rsc_mode const mode)
+bool rosetta_device::fetch(offs_t address, u16 &data, rsc_mode const mode)
 {
 	if (mode & rsc_mode::RSC_T)
 	{
@@ -1143,7 +1143,7 @@ bool rosetta_device::fetch(u32 address, u16 &data, rsc_mode const mode)
 	return true;
 }
 
-template <typename T> bool rosetta_device::load(u32 address, T &data, rsc_mode const mode, bool sp)
+template <typename T> bool rosetta_device::load(offs_t address, T &data, rsc_mode const mode, bool sp)
 {
 	if (mode & rsc_mode::RSC_T)
 	{
@@ -1193,7 +1193,7 @@ template <typename T> bool rosetta_device::load(u32 address, T &data, rsc_mode c
 	return true;
 }
 
-template <typename T> bool rosetta_device::store(u32 address, T data, rsc_mode const mode, bool sp)
+template <typename T> bool rosetta_device::store(offs_t address, T data, rsc_mode const mode, bool sp)
 {
 	if (mode & rsc_mode::RSC_T)
 	{
@@ -1237,7 +1237,7 @@ template <typename T> bool rosetta_device::store(u32 address, T data, rsc_mode c
 	return true;
 }
 
-template <typename T> bool rosetta_device::modify(u32 address, std::function<T(T)> f, rsc_mode const mode)
+template <typename T> bool rosetta_device::modify(offs_t address, std::function<T(T)> f, rsc_mode const mode)
 {
 	if (mode & rsc_mode::RSC_T)
 	{

--- a/src/mame/ibm/rosetta.h
+++ b/src/mame/ibm/rosetta.h
@@ -35,29 +35,29 @@ public:
 	using rsc_mode = rsc_bus_interface::rsc_mode;
 
 	// rsc_cpu_interface overrides
-	virtual bool fetch(u32 address, u16 &data, rsc_mode const mode) override;
-	virtual bool translate(u32 &address) const override;
+	virtual bool fetch(offs_t address, u16 &data, rsc_mode const mode) override;
+	virtual bool translate(offs_t &address) const override;
 
 	// rsc_bus_interface overrides
-	virtual bool mem_load(u32 address, u8 &data, rsc_mode const mode, bool sp) override { return load<u8>(address, data, mode, sp); }
-	virtual bool mem_load(u32 address, u16 &data, rsc_mode const mode, bool sp) override { return load<u16>(address, data, mode, sp); }
-	virtual bool mem_load(u32 address, u32 &data, rsc_mode const mode, bool sp) override { return load<u32>(address, data, mode, sp); }
-	virtual bool mem_store(u32 address, u8 data, rsc_mode const mode, bool sp) override { return store<u8>(address, data, mode, sp); }
-	virtual bool mem_store(u32 address, u16 data, rsc_mode const mode, bool sp) override { return store<u16>(address, data, mode, sp); }
-	virtual bool mem_store(u32 address, u32 data, rsc_mode const mode, bool sp) override { return store<u32>(address, data, mode, sp); }
-	virtual bool mem_modify(u32 address, std::function<u8(u8)> f, rsc_mode const mode) override { return modify<u8>(address, f, mode); }
-	virtual bool mem_modify(u32 address, std::function<u16(u16)> f, rsc_mode const mode) override { return modify<u16>(address, f, mode); }
-	virtual bool mem_modify(u32 address, std::function<u32(u32)> f, rsc_mode const mode) override { return modify<u32>(address, f, mode); }
+	virtual bool mem_load(offs_t address, u8 &data, rsc_mode const mode, bool sp) override { return load<u8>(address, data, mode, sp); }
+	virtual bool mem_load(offs_t address, u16 &data, rsc_mode const mode, bool sp) override { return load<u16>(address, data, mode, sp); }
+	virtual bool mem_load(offs_t address, u32 &data, rsc_mode const mode, bool sp) override { return load<u32>(address, data, mode, sp); }
+	virtual bool mem_store(offs_t address, u8 data, rsc_mode const mode, bool sp) override { return store<u8>(address, data, mode, sp); }
+	virtual bool mem_store(offs_t address, u16 data, rsc_mode const mode, bool sp) override { return store<u16>(address, data, mode, sp); }
+	virtual bool mem_store(offs_t address, u32 data, rsc_mode const mode, bool sp) override { return store<u32>(address, data, mode, sp); }
+	virtual bool mem_modify(offs_t address, std::function<u8(u8)> f, rsc_mode const mode) override { return modify<u8>(address, f, mode); }
+	virtual bool mem_modify(offs_t address, std::function<u16(u16)> f, rsc_mode const mode) override { return modify<u16>(address, f, mode); }
+	virtual bool mem_modify(offs_t address, std::function<u32(u32)> f, rsc_mode const mode) override { return modify<u32>(address, f, mode); }
 
-	virtual bool pio_load(u32 address, u8 &data, rsc_mode const mode) override { return false; }
-	virtual bool pio_load(u32 address, u16 &data, rsc_mode const mode) override { return false; }
-	virtual bool pio_load(u32 address, u32 &data, rsc_mode const mode) override { return ior(address, data); }
-	virtual bool pio_store(u32 address, u8 data, rsc_mode const mode) override { return false; }
-	virtual bool pio_store(u32 address, u16 data, rsc_mode const mode) override { return false; }
-	virtual bool pio_store(u32 address, u32 data, rsc_mode const mode) override { return iow(address, data); }
-	virtual bool pio_modify(u32 address, std::function<u8(u8)> f, rsc_mode const mode) override { return false; }
-	virtual bool pio_modify(u32 address, std::function<u16(u16)> f, rsc_mode const mode) override { return false; }
-	virtual bool pio_modify(u32 address, std::function<u32(u32)> f, rsc_mode const mode) override { return false; }
+	virtual bool pio_load(offs_t address, u8 &data, rsc_mode const mode) override { return false; }
+	virtual bool pio_load(offs_t address, u16 &data, rsc_mode const mode) override { return false; }
+	virtual bool pio_load(offs_t address, u32 &data, rsc_mode const mode) override { return ior(address, data); }
+	virtual bool pio_store(offs_t address, u8 data, rsc_mode const mode) override { return false; }
+	virtual bool pio_store(offs_t address, u16 data, rsc_mode const mode) override { return false; }
+	virtual bool pio_store(offs_t address, u32 data, rsc_mode const mode) override { return iow(address, data); }
+	virtual bool pio_modify(offs_t address, std::function<u8(u8)> f, rsc_mode const mode) override { return false; }
+	virtual bool pio_modify(offs_t address, std::function<u16(u16)> f, rsc_mode const mode) override { return false; }
+	virtual bool pio_modify(offs_t address, std::function<u32(u32)> f, rsc_mode const mode) override { return false; }
 
 protected:
 	// device_t overrides
@@ -67,14 +67,14 @@ protected:
 	virtual void device_post_load() override;
 
 	// virtual address translation
-	bool translate(u32 &address, bool system_processor, bool store);
+	bool translate(offs_t &address, bool system_processor, bool store);
 
 	// rsc_bus_interface implementation
-	template <typename T> bool load(u32 address, T &data, rsc_mode const mode, bool sp);
-	template <typename T> bool store(u32 address, T data, rsc_mode const mode, bool sp);
-	template <typename T> bool modify(u32 address, std::function<T(T)> f, rsc_mode const mode);
-	bool ior(u32 address, u32 &data);
-	bool iow(u32 address, u32 data);
+	template <typename T> bool load(offs_t address, T &data, rsc_mode const mode, bool sp);
+	template <typename T> bool store(offs_t address, T data, rsc_mode const mode, bool sp);
+	template <typename T> bool modify(offs_t address, std::function<T(T)> f, rsc_mode const mode);
+	bool ior(offs_t address, u32 &data);
+	bool iow(offs_t address, u32 data);
 
 	// register read handlers
 	u32 segment_r(offs_t offset);
@@ -105,8 +105,8 @@ protected:
 		u32 field1 = 0; // real page, valid, key
 		u32 field2 = 0; // write, transaction identifier, lockbits
 	};
-	tlb_entry tlb_search(u64 const virtual_address, bool const special);
-	u32 tlb_reload(tlb_entry &tlb_entry, u64 const virtual_address, bool special = false);
+	tlb_entry tlb_search(offs_t const virtual_address, bool const special);
+	u32 tlb_reload(tlb_entry &tlb_entry, offs_t const virtual_address, bool special = false);
 
 	void tlb_inv_all(u32 data);
 	void tlb_inv_segment(u32 data);

--- a/src/mame/ibm/rtpc_iocc.cpp
+++ b/src/mame/ibm/rtpc_iocc.cpp
@@ -78,7 +78,7 @@ u8 rtpc_iocc_device::dma_b_r(offs_t offset)
 	if (!BIT(m_dmr, 7 - m_adc))
 	{
 		u16 const tcw = m_tcw[(m_adc << 6) | (offset >> 11)];
-		u32 const real = ((tcw & TCW_PFX) << 11) | (offset & 0x7ff);
+		offs_t const real = ((tcw & TCW_PFX) << 11) | (offset & 0x7ff);
 
 		LOGMASKED(LOG_DMA, "dma0 tcw 0x%04x real 0x%08x\n", tcw, real);
 		if (tcw & TCW_IOC)
@@ -131,7 +131,7 @@ u8 rtpc_iocc_device::dma_w_r(offs_t offset)
 	if (!BIT(m_dmr, 7 - m_adc))
 	{
 		u16 const tcw = m_tcw[(m_adc << 6) | (offset >> 10)];
-		u32 const real = ((tcw & TCW_PFX) << 11) | (offset & 0x7ff);
+		offs_t const real = ((tcw & TCW_PFX) << 11) | (offset & 0x7ff);
 
 		LOGMASKED(LOG_DMA, "dma1 tcw 0x%04x real 0x%08x\n", tcw, real);
 		if (tcw & TCW_IOC)
@@ -170,7 +170,7 @@ void rtpc_iocc_device::dma_w_w(offs_t offset, u8 data)
 #pragma warning(disable:4333)
 #endif
 
-template <typename T> bool rtpc_iocc_device::mem_load(u32 address, T &data, rsc_mode const mode)
+template <typename T> bool rtpc_iocc_device::mem_load(offs_t address, T &data, rsc_mode const mode)
 {
 	if ((mode & RSC_U) && !(m_ccr & CCR_MMP))
 	{
@@ -193,7 +193,7 @@ template <typename T> bool rtpc_iocc_device::mem_load(u32 address, T &data, rsc_
 	return true;
 }
 
-template <typename T> bool rtpc_iocc_device::mem_store(u32 address, T data, rsc_mode const mode)
+template <typename T> bool rtpc_iocc_device::mem_store(offs_t address, T data, rsc_mode const mode)
 {
 	int const spacenum = (address >> 24) & 15 ? AS_PROGRAM : AS_IO;
 
@@ -225,7 +225,7 @@ template <typename T> bool rtpc_iocc_device::mem_store(u32 address, T data, rsc_
 	return true;
 }
 
-template <typename T> bool rtpc_iocc_device::mem_modify(u32 address, std::function<T(T)> f, rsc_mode const mode)
+template <typename T> bool rtpc_iocc_device::mem_modify(offs_t address, std::function<T(T)> f, rsc_mode const mode)
 {
 	if ((mode & RSC_U) && !(m_ccr & CCR_MMP))
 	{
@@ -262,7 +262,7 @@ template <typename T> bool rtpc_iocc_device::mem_modify(u32 address, std::functi
 	return true;
 }
 
-template <typename T> bool rtpc_iocc_device::pio_load(u32 address, T &data, rsc_mode const mode)
+template <typename T> bool rtpc_iocc_device::pio_load(offs_t address, T &data, rsc_mode const mode)
 {
 	if ((mode & RSC_U) && (address == CSR_ADDR || !(m_ccr & CCR_IMP)))
 	{
@@ -323,7 +323,7 @@ template <typename T> bool rtpc_iocc_device::pio_load(u32 address, T &data, rsc_
 	return true;
 }
 
-template <typename T> bool rtpc_iocc_device::pio_store(u32 address, T data, rsc_mode const mode)
+template <typename T> bool rtpc_iocc_device::pio_store(offs_t address, T data, rsc_mode const mode)
 {
 	if ((mode & RSC_U) && (address == CSR_ADDR || !(m_ccr & CCR_IMP)))
 	{
@@ -393,7 +393,7 @@ template <typename T> bool rtpc_iocc_device::pio_store(u32 address, T data, rsc_
 	return true;
 }
 
-template <typename T> bool rtpc_iocc_device::pio_modify(u32 address, std::function<T(T)> f, rsc_mode const mode)
+template <typename T> bool rtpc_iocc_device::pio_modify(offs_t address, std::function<T(T)> f, rsc_mode const mode)
 {
 	LOG("modify pio space invalid operation (%s)\n", machine().describe_context());
 	m_csr |= CSR_EXR | CSR_PER | CSR_PD | CSR_INVOP;

--- a/src/mame/ibm/rtpc_iocc.h
+++ b/src/mame/ibm/rtpc_iocc.h
@@ -76,25 +76,25 @@ public:
 	using rsc_mode = rsc_bus_interface::rsc_mode;
 
 	// rsc_bus_interface overrides
-	virtual bool mem_load(u32 address, u8 &data, rsc_mode const mode, bool sp) override { return mem_load<u8>(address, data, mode); }
-	virtual bool mem_load(u32 address, u16 &data, rsc_mode const mode, bool sp) override { return mem_load<u16>(address, data, mode); }
-	virtual bool mem_load(u32 address, u32 &data, rsc_mode const mode, bool sp) override { return mem_load<u32>(address, data, mode); }
-	virtual bool mem_store(u32 address, u8 data, rsc_mode const mode, bool sp) override { return mem_store<u8>(address, data, mode); }
-	virtual bool mem_store(u32 address, u16 data, rsc_mode const mode, bool sp) override { return mem_store<u16>(address, data, mode); }
-	virtual bool mem_store(u32 address, u32 data, rsc_mode const mode, bool sp) override { return mem_store<u32>(address, data, mode); }
-	virtual bool mem_modify(u32 address, std::function<u8(u8)> f, rsc_mode const mode) override { return mem_modify<u8>(address, f, mode); }
-	virtual bool mem_modify(u32 address, std::function<u16(u16)> f, rsc_mode const mode) override { return mem_modify<u16>(address, f, mode); }
-	virtual bool mem_modify(u32 address, std::function<u32(u32)> f, rsc_mode const mode) override { return mem_modify<u32>(address, f, mode); }
+	virtual bool mem_load(offs_t address, u8 &data, rsc_mode const mode, bool sp) override { return mem_load<u8>(address, data, mode); }
+	virtual bool mem_load(offs_t address, u16 &data, rsc_mode const mode, bool sp) override { return mem_load<u16>(address, data, mode); }
+	virtual bool mem_load(offs_t address, u32 &data, rsc_mode const mode, bool sp) override { return mem_load<u32>(address, data, mode); }
+	virtual bool mem_store(offs_t address, u8 data, rsc_mode const mode, bool sp) override { return mem_store<u8>(address, data, mode); }
+	virtual bool mem_store(offs_t address, u16 data, rsc_mode const mode, bool sp) override { return mem_store<u16>(address, data, mode); }
+	virtual bool mem_store(offs_t address, u32 data, rsc_mode const mode, bool sp) override { return mem_store<u32>(address, data, mode); }
+	virtual bool mem_modify(offs_t address, std::function<u8(u8)> f, rsc_mode const mode) override { return mem_modify<u8>(address, f, mode); }
+	virtual bool mem_modify(offs_t address, std::function<u16(u16)> f, rsc_mode const mode) override { return mem_modify<u16>(address, f, mode); }
+	virtual bool mem_modify(offs_t address, std::function<u32(u32)> f, rsc_mode const mode) override { return mem_modify<u32>(address, f, mode); }
 
-	virtual bool pio_load(u32 address, u8 &data, rsc_mode const mode) override { return pio_load<u8>(address, data, mode); }
-	virtual bool pio_load(u32 address, u16 &data, rsc_mode const mode) override { return pio_load<u16>(address, data, mode); }
-	virtual bool pio_load(u32 address, u32 &data, rsc_mode const mode) override { return pio_load<u32>(address, data, mode); }
-	virtual bool pio_store(u32 address, u8 data, rsc_mode const mode) override { return pio_store<u8>(address, data, mode); }
-	virtual bool pio_store(u32 address, u16 data, rsc_mode const mode) override { return pio_store<u16>(address, data, mode); }
-	virtual bool pio_store(u32 address, u32 data, rsc_mode const mode) override { return pio_store<u32>(address, data, mode); }
-	virtual bool pio_modify(u32 address, std::function<u8(u8)> f, rsc_mode const mode) override { return pio_modify<u8>(address, f, mode); }
-	virtual bool pio_modify(u32 address, std::function<u16(u16)> f, rsc_mode const mode) override { return pio_modify<u16>(address, f, mode); }
-	virtual bool pio_modify(u32 address, std::function<u32(u32)> f, rsc_mode const mode) override { return pio_modify<u32>(address, f, mode); }
+	virtual bool pio_load(offs_t address, u8 &data, rsc_mode const mode) override { return pio_load<u8>(address, data, mode); }
+	virtual bool pio_load(offs_t address, u16 &data, rsc_mode const mode) override { return pio_load<u16>(address, data, mode); }
+	virtual bool pio_load(offs_t address, u32 &data, rsc_mode const mode) override { return pio_load<u32>(address, data, mode); }
+	virtual bool pio_store(offs_t address, u8 data, rsc_mode const mode) override { return pio_store<u8>(address, data, mode); }
+	virtual bool pio_store(offs_t address, u16 data, rsc_mode const mode) override { return pio_store<u16>(address, data, mode); }
+	virtual bool pio_store(offs_t address, u32 data, rsc_mode const mode) override { return pio_store<u32>(address, data, mode); }
+	virtual bool pio_modify(offs_t address, std::function<u8(u8)> f, rsc_mode const mode) override { return pio_modify<u8>(address, f, mode); }
+	virtual bool pio_modify(offs_t address, std::function<u16(u16)> f, rsc_mode const mode) override { return pio_modify<u16>(address, f, mode); }
+	virtual bool pio_modify(offs_t address, std::function<u32(u32)> f, rsc_mode const mode) override { return pio_modify<u32>(address, f, mode); }
 
 	u8 ccr_r() { return m_ccr; }
 	void ccr_w(u8 data) { m_ccr = data; }
@@ -123,12 +123,12 @@ protected:
 	virtual space_config_vector memory_space_config() const override;
 	//virtual bool memory_translate(int spacenum, int intention, offs_t &address, address_space *&target_space) override;
 
-	template <typename T> bool mem_load(u32 address, T &data, rsc_mode const mode);
-	template <typename T> bool mem_store(u32 address, T data, rsc_mode const mode);
-	template <typename T> bool mem_modify(u32 address, std::function<T(T)> f, rsc_mode const mode);
-	template <typename T> bool pio_load(u32 address, T &data, rsc_mode const mode);
-	template <typename T> bool pio_store(u32 address, T data, rsc_mode const mode);
-	template <typename T> bool pio_modify(u32 address, std::function<T(T)> f, rsc_mode const mode);
+	template <typename T> bool mem_load(offs_t address, T &data, rsc_mode const mode);
+	template <typename T> bool mem_store(offs_t address, T data, rsc_mode const mode);
+	template <typename T> bool mem_modify(offs_t address, std::function<T(T)> f, rsc_mode const mode);
+	template <typename T> bool pio_load(offs_t address, T &data, rsc_mode const mode);
+	template <typename T> bool pio_store(offs_t address, T data, rsc_mode const mode);
+	template <typename T> bool pio_modify(offs_t address, std::function<T(T)> f, rsc_mode const mode);
 
 	void set_int(bool state)
 	{

--- a/src/mame/konami/tasman.cpp
+++ b/src/mame/konami/tasman.cpp
@@ -192,12 +192,12 @@ void kongambl_state::eeprom_w(offs_t offset, uint8_t data)
 	{
 		ioport("EEPROMOUT")->write(data&0x7, 0xff);
 		if(data & 0xf8)
-			printf("Unused EEPROM bits %02x %02x\n",offset,data);
+			printf("Unused EEPROM bits %02x %02x\n", (uint8_t)offset, data);
 	}
 	else
-		printf("%02x %02x\n",offset,data);
+		printf("%02x %02x\n", (uint8_t)offset, data);
 
-	if(offset == 0)
+	if (offset == 0)
 		m_irq_mask = data;
 }
 

--- a/src/mame/konami/viper.cpp
+++ b/src/mame/konami/viper.cpp
@@ -1329,13 +1329,13 @@ uint64_t viper_state::cf_card_r(offs_t offset, uint64_t mem_mask)
 
 				default:
 				{
-					printf("%s:compact_flash_r: IDE reg %02X\n", machine().describe_context().c_str(), offset & 0xf);
+					printf("%s:compact_flash_r: IDE reg %02X\n", machine().describe_context().c_str(), (uint32_t)offset & 0xf);
 				}
 			}
 		}
 		else
 		{
-			int reg = offset;
+			uint32_t reg = (uint32_t)offset;
 
 			logerror("cf_r: %04X\n", reg);
 

--- a/src/mame/mattel/juicebox.cpp
+++ b/src/mame/mattel/juicebox.cpp
@@ -245,13 +245,13 @@ uint32_t juicebox_state::juicebox_nand_r(offs_t offset, uint32_t mem_mask)
 	if (ACCESSING_BITS_8_15) data = data | (smc_read() <<  8);
 	if (ACCESSING_BITS_16_23) data = data | (smc_read() << 16);
 	if (ACCESSING_BITS_24_31) data = data | (smc_read() << 24);
-	verboselog( 5, "juicebox_nand_r %08X %08X %08X\n", offset, mem_mask, data);
+	verboselog( 5, "juicebox_nand_r %08X %08X %08X\n", (uint32_t)offset, mem_mask, data);
 	return data;
 }
 
 void juicebox_state::juicebox_nand_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	verboselog( 5, "juicebox_nand_w %08X %08X %08X\n", offset, mem_mask, data);
+	verboselog( 5, "juicebox_nand_w %08X %08X %08X\n", (uint32_t)offset, mem_mask, data);
 	if (ACCESSING_BITS_0_7) smc_write((data >>  0) & 0xFF);
 	if (ACCESSING_BITS_8_15) smc_write((data >>  8) & 0xFF);
 	if (ACCESSING_BITS_16_23) smc_write((data >> 16) & 0xFF);

--- a/src/mame/mattel/stic.h
+++ b/src/mame/mattel/stic.h
@@ -66,7 +66,7 @@ public:
 
 	uint16_t read(offs_t offset);
 	uint16_t gram_read(offs_t offset);
-	uint16_t grom_read(offs_t offset) { if (offset > 0x800) printf("help! %llX\n", offset); return (0xff00 | m_grom[offset]); }
+	uint16_t grom_read(offs_t offset) { if (offset > 0x800) printf("help! %x\n", (uint16_t)offset); return (0xff00 | m_grom[offset]); }
 	void write(offs_t offset, uint16_t data);
 	void gram_write(offs_t offset, uint16_t data);
 

--- a/src/mame/mattel/stic.h
+++ b/src/mame/mattel/stic.h
@@ -66,7 +66,7 @@ public:
 
 	uint16_t read(offs_t offset);
 	uint16_t gram_read(offs_t offset);
-	uint16_t grom_read(offs_t offset) { if (offset > 0x800) printf("help! %X\n", offset); return (0xff00 | m_grom[offset]); }
+	uint16_t grom_read(offs_t offset) { if (offset > 0x800) printf("help! %llX\n", offset); return (0xff00 | m_grom[offset]); }
 	void write(offs_t offset, uint16_t data);
 	void gram_write(offs_t offset, uint16_t data);
 

--- a/src/mame/misc/39in1.cpp
+++ b/src/mame/misc/39in1.cpp
@@ -161,7 +161,7 @@ u32 _39in1_state::cpld_r(offs_t offset)
 				case 0x4001a: return 0x75;
 				case 0x4001c: return 0x97;
 				case 0x4001e: return 0xb1;
-				default: printf("State 1 unknown offset %x\n", offset); break;
+				default: printf("State 1 unknown offset %x\n", (u32)offset); break;
 			}
 		}
 		else if (m_state == 2)                      // 29c0: 53 ac 0c 2b a2 07 e6 be 31

--- a/src/mame/misc/3do_m.cpp
+++ b/src/mame/misc/3do_m.cpp
@@ -621,8 +621,8 @@ void _3do_state::madam_w(offs_t offset, uint32_t data, uint32_t mem_mask){
 	case 0x05d0/4: case 0x05d4/4: case 0x05d8/4: case 0x05dc/4:
 	case 0x05e0/4: case 0x05e4/4: case 0x05e8/4: case 0x05ec/4:
 	case 0x05f0/4: case 0x05f4/4: case 0x05f8/4: case 0x05fc/4:
-		printf("%08x %08x\n",offset*4,data);
-		m_madam.dma[(offset/4) & 0x1f][offset & 0x03] = data;
+		printf("%08x %08x\n", (uint32_t)offset * 4, data);
+		m_madam.dma[(offset / 4) & 0x1f][offset & 0x03] = data;
 		return;
 
 	/* Hardware multiplier */

--- a/src/mame/misc/ttchamp.cpp
+++ b/src/mame/misc/ttchamp.cpp
@@ -438,7 +438,7 @@ void ttchamp_state::mem_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 		{
 			if(m_spritesinit != 3)
 			{
-				printf("blitter bus write but blitter unselected? %08x %04x\n",offset*2,data);
+				printf("blitter bus write but blitter unselected? %08x %04x\n", (uint32_t)offset * 2,data);
 				return;
 			}
 
@@ -496,7 +496,7 @@ void ttchamp_state::mem_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 		else
 		{
 			// sometimes happens, why? special meanings? wrong interpretation of something else?
-			printf("%06x: spider_blitter_w unhandled RAM access %08x %04x %04x\n", m_maincpu->pc(), offset * 2, data, mem_mask);
+			printf("%06x: spider_blitter_w unhandled RAM access %08x %04x %04x\n", (uint32_t)m_maincpu->pc(), (uint32_t)offset * 2, data, mem_mask);
 		}
 	}
 }

--- a/src/mame/namco/namcos11.cpp
+++ b/src/mame/namco/namcos11.cpp
@@ -549,14 +549,14 @@ void namcos11_state::rom8_w(offs_t offset, uint16_t data)
 
 void namcos11_state::rom8_64_upper_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	verboselog(2, "rom8_64_upper_w( %08x, %08x, %08x )\n", offset, data, mem_mask );
+	verboselog(2, "rom8_64_upper_w( %08x, %08x, %08x )\n", (uint32_t)offset, data, mem_mask );
 
 	m_n_bankoffset = offset * 16;
 }
 
 void namcos11_state::rom8_64_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	verboselog(2, "rom8_64_w( %08x, %08x, %08x )\n", offset, data, mem_mask );
+	verboselog(2, "rom8_64_w( %08x, %08x, %08x )\n", (uint32_t)offset, data, mem_mask );
 
 	// TODO: verify behaviour
 	m_bank[ offset ]->set_entry( ( ( ( ( data & 0xc0 ) >> 3 ) + ( data & 0x07 ) ) ^ m_n_bankoffset ) );
@@ -611,7 +611,7 @@ uint16_t namcos11_state::lightgun_r(offs_t offset, uint16_t mem_mask)
 		data = m_lightgun_io[3]->read() + 1;
 		break;
 	}
-	verboselog(2, "lightgun_r( %08x, %08x ) %08x\n", offset, mem_mask, data );
+	verboselog(2, "lightgun_r( %08x, %08x ) %08x\n", (uint32_t)offset, mem_mask, data );
 	return data;
 }
 

--- a/src/mame/next/next.cpp
+++ b/src/mame/next/next.cpp
@@ -84,14 +84,14 @@ uint32_t next_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, 
 uint32_t next_state::rom_map_r()
 {
 	if(0 && !machine().side_effects_disabled())
-		printf("%08x ROM MAP?\n",maincpu->pc());
+		printf("%08x ROM MAP?\n", (uint32_t)maincpu->pc());
 	return 0x01000000;
 }
 
 uint32_t next_state::scr2_r()
 {
 	if(0 && !machine().side_effects_disabled())
-		printf("%08x\n",maincpu->pc());
+		printf("%08x\n", (uint32_t)maincpu->pc());
 	/*
 	x--- ---- ---- ---- ---- ---- ---- ---- dsp reset
 	-x-- ---- ---- ---- ---- ---- ---- ---- dsp block end
@@ -128,7 +128,7 @@ uint32_t next_state::scr2_r()
 void next_state::scr2_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	if(0 && !machine().side_effects_disabled())
-		printf("scr2_w %08x (%08x)\n", data, maincpu->pc());
+		printf("scr2_w %08x (%08x)\n", data, (uint32_t)maincpu->pc());
 	COMBINE_DATA(&scr2);
 
 	rtc->ce_w(BIT(scr2, 8));

--- a/src/mame/nintendo/nds.cpp
+++ b/src/mame/nintendo/nds.cpp
@@ -86,7 +86,7 @@ uint32_t nds_state::arm7_io_r(offs_t offset, uint32_t mem_mask)
 				double time, ticks;
 				int timer = (offset - TIMER_OFFSET) + 4;
 
-				printf("Read timer reg %x (PC=%x)\n", timer, m_arm7->pc());
+				printf("Read timer reg %x (PC=%x)\n", timer, (uint32_t)m_arm7->pc());
 
 				// update times for
 				if (m_timer_regs[timer] & 0x800000)
@@ -190,7 +190,7 @@ uint32_t nds_state::arm7_io_r(offs_t offset, uint32_t mem_mask)
 			return (m_wramcnt << 8) | temp1 | temp2;
 
 		default:
-			verboselog(*this, 0, "[ARM7] [IO] Unknown read: %08x (%08x)\n", offset*4, mem_mask);
+			verboselog(*this, 0, "[ARM7] [IO] Unknown read: %08x (%08x)\n", (uint32_t)offset * 4, mem_mask);
 			break;
 	}
 
@@ -215,7 +215,7 @@ void nds_state::arm7_io_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 
 				m_timer_regs[timer] = (m_timer_regs[timer] & ~(mem_mask & 0xFFFF0000)) | (data & (mem_mask & 0xFFFF0000));
 
-				printf("%08x to timer %d (mask %08x PC %x)\n", data, timer, ~mem_mask, m_arm7->pc());
+				printf("%08x to timer %d (mask %08x PC %x)\n", data, timer, ~mem_mask, (uint32_t)m_arm7->pc());
 
 				if (ACCESSING_BITS_0_15)
 				{
@@ -355,7 +355,7 @@ void nds_state::arm7_io_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 			}
 			break;
 		default:
-			verboselog(*this, 0, "[ARM7] [IO] Unknown write: %08x = %08x (%08x)\n", offset*4, data, mem_mask);
+			verboselog(*this, 0, "[ARM7] [IO] Unknown write: %08x = %08x (%08x)\n", (uint32_t)offset * 4, data, mem_mask);
 			break;
 	}
 }
@@ -427,7 +427,7 @@ uint32_t nds_state::arm9_io_r(offs_t offset, uint32_t mem_mask)
 			*/
 			return m_arm9_postflg;
 		default:
-			verboselog(*this, 0, "[ARM9] [IO] Unknown read: %08x (%08x)\n", offset*4, mem_mask);
+			verboselog(*this, 0, "[ARM9] [IO] Unknown read: %08x (%08x)\n", (uint32_t)offset * 4, mem_mask);
 			break;
 	}
 
@@ -452,7 +452,7 @@ void nds_state::arm9_io_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 
 				m_timer_regs[timer] = (m_timer_regs[timer] & ~(mem_mask & 0xFFFF0000)) | (data & (mem_mask & 0xFFFF0000));
 
-				printf("%x to timer %d (mask %x PC %x)\n", data, timer, ~mem_mask, m_arm9->pc());
+				printf("%x to timer %d (mask %x PC %x)\n", data, timer, ~mem_mask, (uint32_t)m_arm9->pc());
 
 				if (ACCESSING_BITS_0_15)
 				{
@@ -579,7 +579,7 @@ void nds_state::arm9_io_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 			m_arm9_postflg |= data & POSTFLG_RAM_MASK;
 			break;
 		default:
-			verboselog(*this, 0, "[ARM7] [IO] Unknown write: %08x = %08x (%08x)\n", offset*4, data, mem_mask);
+			verboselog(*this, 0, "[ARM7] [IO] Unknown write: %08x = %08x (%08x)\n", (uint32_t)offset * 4, data, mem_mask);
 			break;
 	}
 }

--- a/src/mame/nintendo/vboy.cpp
+++ b/src/mame/nintendo/vboy.cpp
@@ -703,12 +703,10 @@ void vboy_state::vip_map(address_map &map)
 // - vfishing draws selection accents in main menu with BRTA signal (currently almost invisible);
 void vboy_state::set_brightness()
 {
-	int a,b,c;
-
-	//d = (m_vip_io.BRTA + m_vip_io.BRTB + m_vip_io.BRTC + m_vip_io.REST);
-	a = (0xff * (m_vip_io.BRTA)) / 0x80;
-	b = (0xff * (m_vip_io.BRTA + m_vip_io.BRTB)) / 0x80;
-	c = (0xff * (m_vip_io.BRTA + m_vip_io.BRTB + m_vip_io.BRTC)) / 0x80;
+	//int d = (m_vip_io.BRTA + m_vip_io.BRTB + m_vip_io.BRTC + m_vip_io.REST);
+	int a = (0xff * (m_vip_io.BRTA)) / 0x80;
+	int b = (0xff * (m_vip_io.BRTA + m_vip_io.BRTB)) / 0x80;
+	int c = (0xff * (m_vip_io.BRTA + m_vip_io.BRTB + m_vip_io.BRTC)) / 0x80;
 
 	if(a < 0) { a = 0; }
 	if(b < 0) { b = 0; }
@@ -811,7 +809,7 @@ uint16_t vboy_state::vip_io_r(offs_t offset)
 		case 0x42:  //XPCTRL
 					return m_vip_io.XPCTRL;
 		case 0x44:  //VER
-					printf("%08x read VER\n",m_maincpu->pc());
+					printf("%08x read VER\n", (uint32_t)m_maincpu->pc());
 					return m_vip_io.VER;
 		case 0x48:  //SPT0
 					return m_vip_io.SPT[0];

--- a/src/mame/olympia/monzagp.cpp
+++ b/src/mame/olympia/monzagp.cpp
@@ -295,42 +295,42 @@ uint8_t monzagp_state::port_r(offs_t offset)
 	uint8_t data = 0xff;
 	if (!(m_p1 & 0x01))             // 8350 videoram
 	{
-		//printf("ext 0 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, offset);
+		//printf("ext 0 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, (uint8_t)offset);
 		int const addr = ((m_p2 & 0x3f) << 5) | (offset & 0x1f);
 		data = m_vram[addr];
 	}
 	if (!(m_p1 & 0x02))
 	{
-		printf("ext 1 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, offset);
+		printf("ext 1 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, (uint8_t)offset);
 	}
 	if (!(m_p1 & 0x04))             // GFX
 	{
-		//printf("ext 2 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, offset);
-		int const addr = ((m_p2 & 0x7f) << 5) | (offset & 0x1f);
+		//printf("ext 2 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, (uint8_t)offset);
+		uint64_t const addr = ((m_p2 & 0x7f) << 5) | (offset & 0x1f);
 		data = m_gfx[0][addr];
 	}
 	if (!(m_p1 & 0x08))
 	{
-		//printf("ext 3 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, offset);
+		//printf("ext 3 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, (uint8_t)offset);
 		data = m_in[1]->read();
 	}
 	if (!(m_p1 & 0x10))
 	{
-		//printf("ext 4 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, offset);
+		//printf("ext 4 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, (uint8_t)offset);
 		data = (m_dsw->read() & 0x1f) | (m_in[0]->read() & 0xe0);
 	}
 	if (!(m_p1 & 0x20))
 	{
-		printf("ext 5 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, offset);
+		printf("ext 5 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, (uint8_t)offset);
 	}
 	if (!(m_p1 & 0x40))             // digits
 	{
 		data = m_score_ram[bitswap<8>(offset, 3, 2, 1, 0, 7, 6, 5, 4)];
-		//printf("ext 6 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, offset);
+		//printf("ext 6 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, (uint8_t)offset);
 	}
 	if (!(m_p1 & 0x80))
 	{
-		//printf("ext 7 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, offset);
+		//printf("ext 7 r P1:%02x P2:%02x %02x\n", m_p1, m_p2, (uint8_t)offset);
 		data = m_collisions_ff | (m_time_tick ? 0x10 : 0);
 	}
 
@@ -341,19 +341,19 @@ void monzagp_state::port_w(offs_t offset, uint8_t data)
 {
 	if (!(m_p1 & 0x01))     // 8350 videoram
 	{
-		//printf("ext 0 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, offset, data);
+		//printf("ext 0 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, (uint8_t)offset, data);
 
 		int const addr = ((m_p2 & 0x3f) << 5) | (offset & 0x1f);
 		m_vram[addr] = data;
 	}
 	if (!(m_p1 & 0x02))
 	{
-		printf("ext 1 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, offset, data);
+		printf("ext 1 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, (uint8_t)offset, data);
 	}
 	if (!(m_p1 & 0x04))    // GFX
 	{
-		//printf("ext 2 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, offset, data);
-		int const addr = ((m_p2 & 0x7f) << 5) | (offset & 0x1f);
+		//printf("ext 2 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, (uint8_t)offset, data);
+		uint64_t const addr = ((m_p2 & 0x7f) << 5) | (offset & 0x1f);
 		if (addr < 0x400)
 		{
 			static int pt[] = { 0x0e, 0x0c, 0x0d, 0x08, 0x09, 0x0a, 0x0b, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x0f };
@@ -363,19 +363,19 @@ void monzagp_state::port_w(offs_t offset, uint8_t data)
 	}
 	if (!(m_p1 & 0x08))
 	{
-		//printf("ext 3 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, offset, data);
+		//printf("ext 3 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, (uint8_t)offset, data);
 	}
 	if (!(m_p1 & 0x10))
 	{
-		printf("ext 4 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, offset, data);
+		printf("ext 4 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, (uint8_t)offset, data);
 	}
 	if (!(m_p1 & 0x20))
 	{
-		//printf("ext 5 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, offset, data);
+		//printf("ext 5 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, (uint8_t)offset, data);
 	}
 	if (!(m_p1 & 0x40))    // digits
 	{
-		//printf("ext 6 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, offset, data);
+		//printf("ext 6 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, (uint8_t)offset, data);
 		offs_t const ram_offset = bitswap<8>(offset, 3, 2, 1, 0, 7, 6, 5, 4);
 		m_score_ram[ram_offset] = data & 0x0f;
 
@@ -388,7 +388,7 @@ void monzagp_state::port_w(offs_t offset, uint8_t data)
 	}
 	if (!(m_p1 & 0x80))
 	{
-		//printf("ext 7 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, offset, data);
+		//printf("ext 7 w P1:%02x P2:%02x, %02x = %02x\n", m_p1, m_p2, (uint8_t)offset, data);
 		m_video_ctrl[0][(offset >> 0) & 0x07] = data;
 		m_video_ctrl[1][(offset >> 3) & 0x07] = data;
 

--- a/src/mame/sega/315_5195.cpp
+++ b/src/mame/sega/315_5195.cpp
@@ -479,7 +479,7 @@ void sega_315_5195_mapper_device::compute_region(region_info &info, u8 index, u3
 	info.base = (m_regs[0x11 + 2 * index] << 16) & ~info.size_mask;
 	info.mirror = mirror & info.size_mask;
 	info.start = info.base + (offset & info.size_mask);
-	info.end = info.start + std::min(length - 1, info.size_mask);
+	info.end = info.start + std::min(length - 1, (u32)info.size_mask);
 }
 
 

--- a/src/mame/sega/coolridr.cpp
+++ b/src/mame/sega/coolridr.cpp
@@ -2632,7 +2632,7 @@ void coolridr_state::unk_blit_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 	{
 		default:
 		{
-			printf("sysh1_unk_blit_w unhandled offset %04x %08x %08x\n", offset, data, mem_mask);
+			printf("sysh1_unk_blit_w unhandled offset %04x %08x %08x\n", (uint16_t)offset, data, mem_mask);
 		}
 		break;
 
@@ -2859,7 +2859,7 @@ uint32_t coolridr_state::sound_dma_r(offs_t offset)
 	if(offset == 2 || offset == 6) // DMA status
 		return 0;
 
-	printf("%08x\n",offset);
+	printf("%08x\n", (uint32_t)offset);
 
 	return m_sound_dma[offset];
 }

--- a/src/mame/sega/saturn_v.cpp
+++ b/src/mame/sega/saturn_v.cpp
@@ -428,7 +428,7 @@ void saturn_state::vdp1_regs_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 			if ( VDP1_LOG ) logerror( "VDP1: Draw forced termination register write: %08X %08X\n", offset*2, data );
 			break;
 		default:
-			printf("Warning: write to unknown VDP1 reg %08x %08x\n",offset*2,data);
+			printf("Warning: write to unknown VDP1 reg %08x %08x\n", (uint32_t)offset * 2,data);
 			break;
 	}
 

--- a/src/mame/shared/xbox.cpp
+++ b/src/mame/shared/xbox.cpp
@@ -310,15 +310,15 @@ void xbox_base_state::threadlist_command(const std::vector<std::string_view> &pa
 	con.printf("-------------------------------\n");
 	for (int pri = 0; pri < 16; pri++)
 	{
-		uint32_t curr = debugc_bios->parameter[1 - 1] + pri * 8;
-		uint32_t addr = curr;
+		offs_t curr = debugc_bios->parameter[1 - 1] + pri * 8;
+		offs_t addr = curr;
 		if (!m_maincpu->translate(AS_PROGRAM, device_memory_interface::TR_READ, addr, tspace))
 			continue;
-		uint32_t next = tspace->read_dword_unaligned(addr);
+		offs_t next = tspace->read_dword_unaligned(addr);
 
 		while ((next != curr) && (next != 0))
 		{
-			uint32_t kthrd = next - debugc_bios->parameter[2 - 1];
+			offs_t kthrd = next - debugc_bios->parameter[2 - 1];
 			if (!m_maincpu->translate(AS_PROGRAM, device_memory_interface::TR_READ, kthrd, tspace))
 				break;
 			uint32_t topstack = tspace->read_dword_unaligned(kthrd + debugc_bios->parameter[3 - 1]);

--- a/src/mame/skeleton/dm7000.cpp
+++ b/src/mame/skeleton/dm7000.cpp
@@ -355,7 +355,7 @@ uint32_t dm7000_state::screen_update_dm7000(screen_device &screen, bitmap_rgb32 
 uint32_t dm7000_state::dcr_r(offs_t offset)
 {
 	osd_printf_debug("DCR %03X read\n", offset);
-	if(offset>=1024) {printf("get %04X\n", offset); return 0;} else
+	if(offset>=1024) {printf("get %04X\n", (uint16_t)offset); return 0;} else
 	switch(offset) {
 		case DCRSTB045_CMD_STAT:
 			return 0; // assume that video dev is always ready
@@ -368,7 +368,7 @@ uint32_t dm7000_state::dcr_r(offs_t offset)
 void dm7000_state::dcr_w(offs_t offset, uint32_t data)
 {
 	osd_printf_debug("DCR %03X write = %08X\n", offset, data);
-	if(offset>=1024) {printf("get %04X\n", offset); } else
+	if(offset>=1024) {printf("get %04X\n", (uint16_t)offset); } else
 	dcr[offset] = data;
 }
 

--- a/src/mame/skeleton/molecular.cpp
+++ b/src/mame/skeleton/molecular.cpp
@@ -155,7 +155,7 @@ void molecula_state::file_output_w(offs_t offset, uint8_t data)
 		file_ram_enable = (data & 0x80) >> 7;
 
 	if(data & 0x7f || offset)
-		printf("FILE output -> %02x %02x\n",data,offset);
+		printf("FILE output -> %02x %02x\n", data, (uint8_t)offset);
 }
 
 
@@ -164,7 +164,7 @@ void molecula_state::app_output_w(uint8_t data)
 	app_ram_enable = (data & 0x80) >> 7;
 
 	if(data & 0x7f)
-		printf("APP 0x10 -> %02x\n",data);
+		printf("APP 0x10 -> %02x\n", data);
 }
 
 uint8_t molecula_state::sio_r(offs_t offset)

--- a/src/mame/sun/sun2.cpp
+++ b/src/mame/sun/sun2.cpp
@@ -358,7 +358,7 @@ uint16_t sun2_state::tl_mmu_r(uint8_t fc, offs_t offset, uint16_t mem_mask)
 		if (!machine().side_effects_disabled()) printf("sun2: pagemap entry not valid!\n");
 	}
 
-	if (!machine().side_effects_disabled()) printf("sun2: Unmapped read @ %08x (FC %d, mask %04x, PC=%x, seg %x)\n", offset<<1, fc, mem_mask, m_maincpu->pc(), offset>>15);
+	if (!machine().side_effects_disabled()) printf("sun2: Unmapped read @ %08x (FC %d, mask %04x, PC=%x, seg %x)\n", (uint32_t)offset << 1, fc, mem_mask, (uint32_t)m_maincpu->pc(), (uint32_t)offset >> 15);
 
 	return 0xffff;
 }
@@ -384,7 +384,7 @@ void sun2_state::tl_mmu_w(uint8_t fc, offs_t offset, uint16_t data, uint16_t mem
 
 				case 5:
 					// XOR to match Table 2-1 in the 2/50 Field Service Manual
-					printf("sun2: CPU LEDs to %02x (PC=%x) => ", (data & 0xff) ^ 0xff, m_maincpu->pc());
+					printf("sun2: CPU LEDs to %02x (PC=%x) => ", (data & 0xff) ^ 0xff, (uint32_t)m_maincpu->pc());
 					m_diagreg = data & 0xff;
 					for (int i = 0; i < 8; i++)
 					{
@@ -488,7 +488,7 @@ void sun2_state::tl_mmu_w(uint8_t fc, offs_t offset, uint16_t data, uint16_t mem
 		if (!machine().side_effects_disabled()) printf("sun2: pagemap entry not valid!\n");
 	}
 
-	printf("sun2: Unmapped write %04x (FC %d, mask %04x, PC=%x) to %08x\n", data, fc, mem_mask, m_maincpu->pc(), offset<<1);
+	printf("sun2: Unmapped write %04x (FC %d, mask %04x, PC=%x) to %08x\n", data, fc, mem_mask, (uint32_t)m_maincpu->pc(), (uint32_t)offset << 1);
 }
 
 // BW2 video control

--- a/src/mame/sun/sun3.cpp
+++ b/src/mame/sun/sun3.cpp
@@ -346,7 +346,7 @@ uint32_t sun3_state::ram_r(offs_t offset)
 {
 	if (m_ecc[0] == 0x10c00000)
 	{
-		//printf("ECC testing, RAM read ofs %x\n", offset);
+		//printf("ECC testing, RAM read ofs %x\n", (uint32_t)offset);
 		m_ecc[1] &= 0x00ffffff;
 
 		if (m_ecc[2] == 0x01000000) // single-bit error test
@@ -368,7 +368,7 @@ uint32_t sun3_state::ram_r(offs_t offset)
 
 	if (!m_bInBusErr)
 	{
-		//printf("ram_r: bus error on timeout, access to invalid addr %08x, PC=%x\n", offset<<2, m_maincpu->pc());
+		//printf("ram_r: bus error on timeout, access to invalid addr %08x, PC=%x\n", (uint32_t)offset << 2, (uint32_t)m_maincpu->pc());
 		//fflush(stdout);
 		m_buserr = BE_TIMEOUT;
 		m_maincpu->set_input_line(M68K_LINE_BUSERROR, ASSERT_LINE);
@@ -441,7 +441,7 @@ void sun3_state::ram_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 
 	if (!m_bInBusErr)
 	{
-		//printf("ram_w: bus error on timeout, access to invalid addr %08x, PC=%x\n", offset<<2, m_maincpu->pc());
+		//printf("ram_w: bus error on timeout, access to invalid addr %08x, PC=%x\n", (uint32_t)offset << 2, (uint32_t)m_maincpu->pc());
 		fflush(stdout);
 		m_buserr = BE_TIMEOUT;
 		m_maincpu->set_input_line(M68K_LINE_BUSERROR, ASSERT_LINE);
@@ -460,17 +460,17 @@ uint32_t sun3_state::tl_mmu_r(offs_t offset, uint32_t mem_mask)
 		switch (offset >> 26)
 		{
 			case 0: // IDPROM
-				//printf("sun3: Read IDPROM at %x (mask %08x)\n", offset, mem_mask);
+				//printf("sun3: Read IDPROM at %x (mask %08x)\n", (uint32_t)offset, mem_mask);
 				return m_idprom_ptr[(offset*4)] << 24 | m_idprom_ptr[(offset*4)+1]<<16 | m_idprom_ptr[(offset*4)+2]<<8 | m_idprom_ptr[(offset*4)+3];
 
 			case 1: // page map
 				page = m_segmap[m_context & 7][(offset >> 15) & 0x7ff] << 4;
 				page += (offset >> 11) & 0xf;
-				//printf("sun3: Read page map at %x (entry %d)\n", offset<<1, page);
+				//printf("sun3: Read page map at %x (entry %d)\n", (uint32_t)offset << 1, page);
 				return m_pagemap[page];
 
 			case 2: // segment map
-				//printf("sun3: Read segment map at %x (entry %d, user ctx %d mask %x)\n", offset<<2, (offset & ~0x3c000000) >> 15, m_context & 7, mem_mask);
+				//printf("sun3: Read segment map at %x (entry %d, user ctx %d mask %x)\n", (uint32_t)offset << 2, (uint32_t)(offset & ~0x3c000000) >> 15, m_context & 7, mem_mask);
 				return m_segmap[m_context & 7][(offset >> 15) & 0x7ff]<<24;
 
 			case 3: // context reg
@@ -492,22 +492,22 @@ uint32_t sun3_state::tl_mmu_r(offs_t offset, uint32_t mem_mask)
 				return 0;
 
 			case 8: // cache tags
-				//printf("sun3: read cache tags @ %x, PC = %x\n", offset, m_maincpu->pc());
+				//printf("sun3: read cache tags @ %x, PC = %x\n", (uint32_t)offset, (uint32_t)m_maincpu->pc());
 				return m_cache_tags[(offset & 0x3fff) >> 2];
 
 			case 9: // cache data
-				//printf("sun3: read cache data @ %x, PC = %x\n", offset, m_maincpu->pc());
+				//printf("sun3: read cache data @ %x, PC = %x\n", (uint32_t)offset, (uint32_t)m_maincpu->pc());
 				return m_cache_data[(offset & 0x3fff)];
 
 			case 10: // flush cache
 				return 0xffffffff;
 
 			case 11: // block copy
-				printf("sun3: read block copy @ %x, PC = %x\n", offset, m_maincpu->pc());
+				printf("sun3: read block copy @ %x, PC = %x\n", (uint32_t)offset, (uint32_t)m_maincpu->pc());
 				return 0xffffffff;
 
 			case 15: // UART bypass
-				//printf("sun3: read UART bypass @ %x, PC = %x, mask = %08x\n", offset, m_maincpu->pc(), mem_mask);
+				//printf("sun3: read UART bypass @ %x, PC = %x, mask = %08x\n", (uint32_t)offset, (uint32_t)m_maincpu->pc(), mem_mask);
 				return 0xffffffff;
 		}
 	}
@@ -590,7 +590,7 @@ void sun3_state::tl_mmu_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	uint8_t fc = m_maincpu->get_fc();
 
-	//printf("sun3: Write %08x (FC %d, mask %08x, PC=%x) to %08x\n", data, fc, mem_mask, m_maincpu->pc(), offset<<1);
+	//printf("sun3: Write %08x (FC %d, mask %08x, PC=%x) to %08x\n", data, fc, mem_mask, (uint32_t)m_maincpu->pc(), (uint32_t)offset << 1);
 
 	if (fc == 3)    // control space
 	{
@@ -603,17 +603,17 @@ void sun3_state::tl_mmu_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 
 			case 1: // page map  fefaf32
 				page = m_segmap[m_context & 7][(offset >> 15) & 0x7ff] << 4;
-				//printf("context = %d, segment = %d, PMEG = %d, add = %d\n", m_context & 7, (offset >> 15) & 0x7ff, page, (offset >> 11) & 0xf);
+				//printf("context = %d, segment = %d, PMEG = %d, add = %d\n", m_context & 7, (uint32_t)(offset >> 15) & 0x7ff, page, (uint32_t)(offset >> 11) & 0xf);
 				page += (offset >> 11) & 0xf;
 
-				//printf("sun3: Write %04x to page map at %x (entry %d), ", data, offset<<2, page);
+				//printf("sun3: Write %04x to page map at %x (entry %d), ", data, (uint32_t)offset << 2, page);
 				COMBINE_DATA(&m_pagemap[page]);
 
-				//printf("entry now %08x (adr %08x  PC=%x mask %x)\n", m_pagemap[page], (m_pagemap[page] & 0xfffff) << 13, m_maincpu->pc(), mem_mask);
+				//printf("entry now %08x (adr %08x  PC=%x mask %x)\n", m_pagemap[page], (m_pagemap[page] & 0xfffff) << 13, (uint32_t)m_maincpu->pc(), mem_mask);
 				return;
 
 			case 2: // segment map
-				//printf("sun3: Write %02x to segment map at %x (entry %d, user ctx %d PC=%x mask %x)\n", (data>>24) & 0xff, offset<<2, (offset & ~0x3c000000)>>15, m_context & 7, m_maincpu->pc(), mem_mask);
+				//printf("sun3: Write %02x to segment map at %x (entry %d, user ctx %d PC=%x mask %x)\n", (data>>24) & 0xff, (uint32_t)offset << 2, (uint32_t)(offset & ~0x3c000000) >> 15, m_context & 7, (uint32_t)m_maincpu->pc(), mem_mask);
 				m_segmap[m_context & 7][(offset >> 15) & 0x7ff] = (data>>24) & 0xff;
 				//printf("segment map[%d][%d] now %x\n", m_context & 7, (offset & ~0x3c000000) >> 15, m_segmap[m_context & 7][(offset & ~0x3c000000) >> 15] = (data>>24) & 0xff);
 				return;
@@ -624,7 +624,7 @@ void sun3_state::tl_mmu_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 				return;
 
 			case 4: // enable reg
-				//printf("sun3: Write %x to enable, PC=%x\n", data, m_maincpu->pc());
+				//printf("sun3: Write %x to enable, PC=%x\n", data, (uint32_t)m_maincpu->pc());
 				COMBINE_DATA(&m_enable);
 				return;
 
@@ -638,7 +638,7 @@ void sun3_state::tl_mmu_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 			case 7: // diagnostic reg
 				m_diag = data >> 24;
 				#if 0
-				printf("sun3: CPU LEDs to %02x (PC=%x) => ", ((data>>24) & 0xff) ^ 0xff, m_maincpu->pc());
+				printf("sun3: CPU LEDs to %02x (PC=%x) => ", ((data>>24) & 0xff) ^ 0xff, (uint32_t)m_maincpu->pc());
 				for (int i = 0; i < 8; i++)
 				{
 					if (m_diag & (1<<i))
@@ -655,12 +655,12 @@ void sun3_state::tl_mmu_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 				return;
 
 			case 8: // cache tags
-				//printf("sun3: %08x to cache tags @ %x, PC = %x, mask = %08x\n", data, offset, m_maincpu->pc(), mem_mask);
+				//printf("sun3: %08x to cache tags @ %x, PC = %x, mask = %08x\n", data, (uint32_t)offset, (uint32_t)m_maincpu->pc(), mem_mask);
 				m_cache_tags[(offset & 0x3fff) >> 2] = data;
 				return;
 
 			case 9: // cache data
-				//printf("sun3: %08x to cache data @ %x, PC = %x, mask = %08x\n", data, offset, m_maincpu->pc(), mem_mask);
+				//printf("sun3: %08x to cache data @ %x, PC = %x, mask = %08x\n", data, (uint32_t)offset, (uint32_t)m_maincpu->pc(), mem_mask);
 				m_cache_data[(offset & 0x3fff)] = data;
 				return;
 
@@ -668,11 +668,11 @@ void sun3_state::tl_mmu_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 				return;
 
 			case 11: // block copy
-				printf("sun3: %08x to block copy @ %x, PC = %x\n", data, offset, m_maincpu->pc());
+				printf("sun3: %08x to block copy @ %x, PC = %x\n", data, (uint32_t)offset, (uint32_t)m_maincpu->pc());
 				return;
 
 			case 15: // UART bypass
-				//printf("sun3: %08x to UART bypass @ %x, PC = %x\n", data, offset, m_maincpu->pc());
+				//printf("sun3: %08x to UART bypass @ %x, PC = %x\n", data, (uint32_t)offset, (uint32_t)m_maincpu->pc());
 				return;
 			}
 	}
@@ -699,7 +699,7 @@ void sun3_state::tl_mmu_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 		uint32_t tmp = (m_pagemap[entry] & 0x7ffff) << 11;
 		tmp |= (offset & 0x7ff);
 
-		//if (!machine().side_effects_disabled()) printf("sun3: Translated addr: %08x, type %d (page entry %08x, orig virt %08x)\n", tmp << 2, (m_pagemap[entry] >> 26) & 3, m_pagemap[entry], offset<<2);
+		//if (!machine().side_effects_disabled()) printf("sun3: Translated addr: %08x, type %d (page entry %08x, orig virt %08x)\n", tmp << 2, (m_pagemap[entry] >> 26) & 3, m_pagemap[entry], (uint32_t)offset << 2);
 
 		switch ((m_pagemap[entry] >> 26) & 3)
 		{

--- a/src/mame/taito/gladiatr.cpp
+++ b/src/mame/taito/gladiatr.cpp
@@ -536,7 +536,7 @@ void ppking_state::ppking_qx0_w(offs_t offset, u8 data)
 				break;
 
 			default:
-				printf("%02x %02x\n",offset,data);
+				printf("%02x %02x\n", (uint8_t)offset, data);
 				break;
 		}
 	}

--- a/src/mame/taito/taitoair.cpp
+++ b/src/mame/taito/taitoair.cpp
@@ -346,7 +346,7 @@ void taitoair_state::sound_bankswitch_w(u8 data)
 */
 void taitoair_state::dma_regs_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	printf("%08x %04x\n",offset,data);
+	printf("%08x %04x\n", (u32)offset, data);
 
 	if (offset == 0 && ACCESSING_BITS_8_15)
 	{

--- a/src/mame/televideo/ts803.cpp
+++ b/src/mame/televideo/ts803.cpp
@@ -278,7 +278,7 @@ void ts803_state::porta0_w(offs_t offset, uint8_t data)
 uint8_t ts803_state::port10_r(offs_t offset)
 {
 	offset += 0x10;
-	printf("Port read [%x]\n",offset);
+	printf("Port read [%x]\n", (uint8_t)offset);
 
 	return 0xff;
 }
@@ -316,7 +316,7 @@ void ts803_state::port10_w(offs_t offset, uint8_t data)
 			break;
 
 		default:
-			printf("unknown port [%2.2x] write of [%2.2x]\n",offset,data);
+			printf("unknown port [%2.2x] write of [%2.2x]\n", (uint16_t)offset, data);
 			break;
 	}
 }

--- a/src/mame/tigertel/docg3.cpp
+++ b/src/mame/tigertel/docg3.cpp
@@ -117,7 +117,7 @@ uint16_t diskonchip_g3_device::sec_1_r(offs_t offset)
 	{
 		data = (g3_read_data() << 0) | (g3_read_data() << 8);
 	}
-	verboselog(*this, 9, "(DOC) %08X -> %04X\n", 0x0800 + (offset << 1), data);
+	verboselog(*this, 9, "(DOC) %08X -> %04X\n", 0x0800 + ((uint32_t)offset << 1), data);
 	return data;
 }
 
@@ -146,7 +146,7 @@ void diskonchip_g3_device::g3_write_data(uint8_t data)
 
 void diskonchip_g3_device::sec_1_w(offs_t offset, uint16_t data)
 {
-	verboselog(*this, 9, "(DOC) %08X <- %04X\n", 0x0800 + (offset << 1), data);
+	verboselog(*this, 9, "(DOC) %08X <- %04X\n", 0x0800 + ((uint32_t)offset << 1), data);
 	if (m_sec_2[0x1B] & 0x40)
 	{
 		g3_write_data(data);
@@ -737,13 +737,13 @@ void diskonchip_g3_device::sec_2_w(offs_t offset, uint16_t data, uint16_t mem_ma
 uint16_t diskonchip_g3_device::sec_3_r(offs_t offset)
 {
 	uint16_t data = 0;
-	verboselog(*this, 9, "(DOC) %08X -> %04X\n", 0x1800 + (offset << 1), data);
+	verboselog(*this, 9, "(DOC) %08X -> %04X\n", 0x1800 + ((uint32_t)offset << 1), data);
 	return data;
 }
 
 void diskonchip_g3_device::sec_3_w(offs_t offset, uint16_t data)
 {
-	verboselog(*this, 9, "(DOC) %08X <- %02X\n", 0x1800 + (offset << 1), data);
+	verboselog(*this, 9, "(DOC) %08X <- %02X\n", 0x1800 + ((uint32_t)offset << 1), data);
 }
 
 //-------------------------------------------------

--- a/src/mame/tomy/tutor.cpp
+++ b/src/mame/tomy/tutor.cpp
@@ -304,13 +304,13 @@ uint8_t tutor_state::key_r(offs_t offset)
 	char port[12];
 	uint8_t value;
 
-	snprintf(port, std::size(port), "LINE%d", (offset & 0x007e) >> 3);
+	snprintf(port, std::size(port), "LINE%d", ((uint32_t)offset & 0x007e) >> 3);
 	value = ioport(port)->read();
 
 	/* hack for ports overlapping with joystick */
 	if (offset >= 32 && offset < 48)
 	{
-		snprintf(port, std::size(port), "LINE%d_alt", (offset & 0x007e) >> 3);
+		snprintf(port, std::size(port), "LINE%d_alt", ((uint32_t)offset & 0x007e) >> 3);
 		value |= ioport(port)->read();
 	}
 

--- a/src/tools/unidasm.cpp
+++ b/src/tools/unidasm.cpp
@@ -1233,9 +1233,11 @@ static int parse_options(int argc, char *argv[], options *opts)
 				goto usage;
 
 		} else if(pending_base) {
-		// base PC
+			// base PC
+			u32 basepc_dword = 0;
 			if(parse_number(curarg, "%x", &opts->basepc) != 1)
 				goto usage;
+			opts->basepc = basepc_dword;
 			pending_base = false;
 
 		} else if(pending_arch) {

--- a/src/tools/unidasm.cpp
+++ b/src/tools/unidasm.cpp
@@ -10,7 +10,7 @@
 #include "coretmpl.h"
 #include "disasmintf.h"
 
-using offs_t = osd::u32;
+using offs_t = osd::u64;
 using util::BIT;
 
 #include "cpu/8x300/8x300dasm.h"

--- a/src/tools/unidasm.cpp
+++ b/src/tools/unidasm.cpp
@@ -1235,7 +1235,7 @@ static int parse_options(int argc, char *argv[], options *opts)
 		} else if(pending_base) {
 			// base PC
 			u32 basepc_dword = 0;
-			if(parse_number(curarg, "%x", &opts->basepc) != 1)
+			if(parse_number(curarg, "%x", &basepc_dword) != 1)
 				goto usage;
 			opts->basepc = basepc_dword;
 			pending_base = false;


### PR DESCRIPTION
This switches the `offs_t` declaration from `u32` to `u64`, updates the global mask in `address_map::map_validity_check`, and fixes the compile errors that fell out of the change.

Most of it was associated with logging, so I added explicitly-narrowing casts where most applicable, and switched other situations over from using `u32` for addresses to using `offs_t`.

It would be nice if @pmackinlay would have a look, as ROMP, NS32xxx, and M88x00 had more changes than most.