### PR TITLE
cpu/se3208/se3208dis.cpp, */vrender0.cpp: Additional update after https://github.com/mamedev/mame/pull/14453

### DIFF
--- a/src/devices/cpu/se3208/se3208dis.cpp
+++ b/src/devices/cpu/se3208/se3208dis.cpp
@@ -1125,7 +1125,7 @@ INST(MVFC)
 	return 0;
 }
 
-se3208_disassembler::_OP se3208_disassembler::decode_op(u16 opcode)
+se3208_disassembler::OP se3208_disassembler::decode_op(u16 opcode)
 {
 	switch (EXTRACT(opcode, 14, 15))
 	{

--- a/src/devices/cpu/se3208/se3208dis.h
+++ b/src/devices/cpu/se3208/se3208dis.h
@@ -16,7 +16,7 @@ public:
 	virtual offs_t disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params) override;
 
 private:
-	typedef u32 (se3208_disassembler::*_OP)(u16 opcode, std::ostream &stream);
+	typedef u32 (se3208_disassembler::*OP)(u16 opcode, std::ostream &stream);
 
 	u32 INVALIDOP(u16 opcode, std::ostream &stream);
 	u32 LDB(u16 opcode, std::ostream &stream);
@@ -93,7 +93,7 @@ private:
 	u32 MVTC(u16 opcode, std::ostream &stream);
 	u32 MVFC(u16 opcode, std::ostream &stream);
 
-	_OP decode_op(u16 opcode);
+	OP decode_op(u16 opcode);
 
 	u32 PC;
 	u32 SR;

--- a/src/devices/sound/vrender0.cpp
+++ b/src/devices/sound/vrender0.cpp
@@ -532,7 +532,7 @@ void vr0sound_device::render_audio(sound_stream &stream)
 				if (channel.modes & MODE_8BIT)   //8bit
 				{
 					sample = channel.cache->read_byte(channel.cur_saddr >> 9);
-					sample = s16(s8(sample & 0xff) << 8);
+					sample = s16((sample & 0xff) << 8);
 				}
 				else                //16bit
 				{

--- a/src/devices/video/vrender0.cpp
+++ b/src/devices/video/vrender0.cpp
@@ -263,9 +263,9 @@ constexpr u16 RGB32TO16(u32 rgb)
 	return (((rgb >> (16 + 3)) & 0x1f) << 11) | (((rgb >> (8 + 2)) & 0x3f) << 5) | (((rgb >> (3)) & 0x1f) << 0);
 }
 
-constexpr u8 EXTRACTR8(u16 src) { return ((src >> 11) << 3) & 0xff; }
-constexpr u8 EXTRACTG8(u16 src) { return ((src >>  5) << 2) & 0xff; }
-constexpr u8 EXTRACTB8(u16 src) { return ((src >>  0) << 3) & 0xff; }
+constexpr u8 EXTRACTR8(u16 src) { return pal5bit(src >> 11); }
+constexpr u8 EXTRACTG8(u16 src) { return pal6bit(src >>  5); }
+constexpr u8 EXTRACTB8(u16 src) { return pal5bit(src >>  0); }
 
 static inline u16 do_shade(u16 src, u32 shade)
 {


### PR DESCRIPTION
- cpu/se3208/se3208dis.cpp: Fix typename for avoid reserved naming convention

- sound/vrender0.cpp: Simplify casting

- video/vrender0.cpp: Use pal*bit function for color extraction