### PR TITLE
nes.xml: Added two new working entries (Popils)

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -29406,19 +29406,19 @@ The EEPROM chip that contained the sequence data for the music and sound effects
 			<feature name="slot" value="namcot_3433" />
 			<feature name="pcb" value="TENGEN-800030" />
 			<feature name="mirroring" value="vertical" />
-			<dataarea name="chr" size="65536">
-				<rom name="popil chr0.bin" size="32768" crc="18fa74c0" sha1="64672be98a4745ceca3863759e586a6778e3958a" offset="00000" />
-				<rom name="popil chr1.bin" size="32768" crc="5980514c" sha1="8f793c1a9d587a2f60eaa22c14eca2fea53fe71b" offset="0x08000" />
+			<dataarea name="chr" size="0x10000">
+				<rom name="popil chr0.bin" size="0x8000" crc="18fa74c0" sha1="64672be98a4745ceca3863759e586a6778e3958a" offset="0x00000" />
+				<rom name="popil chr1.bin" size="0x8000" crc="5980514c" sha1="8f793c1a9d587a2f60eaa22c14eca2fea53fe71b" offset="0x08000" />
 			</dataarea>
-			<dataarea name="prg" size="131072">
-				<rom name="popil prg0.bin" size="32768" crc="" sha1="" status="nodump" />	<!-- EEPROM chip for the sound data, not found with the others -->
-				<rom name="popil prg1.bin" size="32768" crc="2ce83498" sha1="d3fc1b7cadb9be9de1a6028ef59df700a6e8588a" offset="0x08000" />
-				<rom name="popil prg2.bin" size="32768" crc="d0a719a8" sha1="bef214d4670df0b5eb44b1760b58a3b1f87f8fb5" offset="0x10000" />
-				<rom name="popil prg3.bin" size="32768" crc="b7b8b773" sha1="cb90b4ddfe0e5b7213905301292882be97f5a852" offset="0x18000" />
+			<dataarea name="prg" size="0x20000">
+				<rom name="popil prg0.bin" size="0x8000" status="nodump" />	<!-- EEPROM chip for the sound data, not found with the others -->
+				<rom name="popil prg1.bin" size="0x8000" crc="2ce83498" sha1="d3fc1b7cadb9be9de1a6028ef59df700a6e8588a" offset="0x08000" />
+				<rom name="popil prg2.bin" size="0x8000" crc="d0a719a8" sha1="bef214d4670df0b5eb44b1760b58a3b1f87f8fb5" offset="0x10000" />
+				<rom name="popil prg3.bin" size="0x8000" crc="b7b8b773" sha1="cb90b4ddfe0e5b7213905301292882be97f5a852" offset="0x18000" />
 			</dataarea>
 			<!-- 8k WRAM on cartridge, battery backed up -->
-			<dataarea name="bwram" size="8192">
-				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
+			<dataarea name="bwram" size="0x2000">
+				<rom value="0x00" size="0x2000" offset="0" loadflag="fill" />
 			</dataarea>
 		</part>
 	</software>
@@ -29434,19 +29434,19 @@ This mod inserts recreations of the music tracks and sound effects into the prot
 			<feature name="slot" value="namcot_3433" />
 			<feature name="pcb" value="TENGEN-800030" />
 			<feature name="mirroring" value="vertical" />
-			<dataarea name="chr" size="65536">
-				<rom name="popil chr0.bin" size="32768" crc="18fa74c0" sha1="64672be98a4745ceca3863759e586a6778e3958a" offset="00000" />
-				<rom name="popil chr1.bin" size="32768" crc="5980514c" sha1="8f793c1a9d587a2f60eaa22c14eca2fea53fe71b" offset="0x08000" />
+			<dataarea name="chr" size="0x10000">
+				<rom name="popil chr0.bin" size="0x8000" crc="18fa74c0" sha1="64672be98a4745ceca3863759e586a6778e3958a" offset="0x00000" />
+				<rom name="popil chr1.bin" size="0x8000" crc="5980514c" sha1="8f793c1a9d587a2f60eaa22c14eca2fea53fe71b" offset="0x08000" />
 			</dataarea>
-			<dataarea name="prg" size="131072">
-				<rom name="prg0" size="32768" crc="90da0dd3" sha1="7db3ea71db43d4df7d75851f485d57620d3d57f3" offset="0" status="baddump" /> <!-- EEPROM chip for the sound data, recreated using the Game Gear version's sound data -->
-				<rom name="popil prg1.bin" size="32768" crc="2ce83498" sha1="d3fc1b7cadb9be9de1a6028ef59df700a6e8588a" offset="0x08000" />
-				<rom name="popil prg2.bin" size="32768" crc="d0a719a8" sha1="bef214d4670df0b5eb44b1760b58a3b1f87f8fb5" offset="0x10000" />
-				<rom name="popil prg3.bin" size="32768" crc="b7b8b773" sha1="cb90b4ddfe0e5b7213905301292882be97f5a852" offset="0x18000" />
+			<dataarea name="prg" size="0x20000">
+				<rom name="prg0" size="0x8000" crc="90da0dd3" sha1="7db3ea71db43d4df7d75851f485d57620d3d57f3" offset="0" status="baddump" /> <!-- EEPROM chip for the sound data, recreated using the Game Gear version's sound data -->
+				<rom name="popil prg1.bin" size="0x8000" crc="2ce83498" sha1="d3fc1b7cadb9be9de1a6028ef59df700a6e8588a" offset="0x08000" />
+				<rom name="popil prg2.bin" size="0x8000" crc="d0a719a8" sha1="bef214d4670df0b5eb44b1760b58a3b1f87f8fb5" offset="0x10000" />
+				<rom name="popil prg3.bin" size="0x8000" crc="b7b8b773" sha1="cb90b4ddfe0e5b7213905301292882be97f5a852" offset="0x18000" />
 			</dataarea>
 			<!-- 8k WRAM on cartridge, battery backed up -->
-			<dataarea name="bwram" size="8192">
-				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
+			<dataarea name="bwram" size="0x2000">
+				<rom value="0x00" size="0x2000" offset="0" loadflag="fill" />
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
Added two new working entries:

- Magical Puzzle Popils (prototype) [VGHF]
- Magical Puzzle Popils (prototype, with recreated sound) [VGHF, Mister Man, ndiddy]

All the context for these two entries can be found here (there's no ROM links in the page, only the patch): [https://romhackplaza.org/romhacks/magical-puzzle-popils-prototype-audio-recreation-nes/](url)

> Magical Puzzle Popils is a puzzle platformer game developed for the NES, with ports for the Turbografx-16 and the Game Gear also being developed around the same time. In the end, however, only the Game Gear port was released, with the other two versions becoming lost media aside of gameplay footage shared by Jun Amanai (the game’s programmer for all versions) through his YouTube channel.
> 
> On December 17 2025, the Video Game History Foundation preserved and released a late prototype of the NES version of Magical Puzzle Popils. While this prototype is fully playable from start to end, unfortunately the EEPROM chip that contained the sequence data for the music and sound effects could not be found, which means that the game no longer has any audio to play at all. Despite this, however, a lot of important sound-related data (sound driver, ADSR envelopes, ROM pointers, channel assignations) is still present in the other EEPROM chips.
> 
> This hack inserts recreations of all publicly available music tracks and sound effects into the prototype. This was done by porting the sequence data of all sounds found in the Game Gear version, along with doing many adjustments (ASDR, vibrato and note transposing edits) to match the audio heard in Jun Amanai’s gameplay videos as closely as possible.