### PR TITLE
nes.xml: Added two new working entries (Galaga)

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -13848,7 +13848,7 @@ Entirely different from Namco's port. The CHR ROM to this prototype is lost.
 				<rom size="16384" offset="0x4000" loadflag="reload" />
 			</dataarea>
 			<dataarea name="chr" size="8192">
-				<rom name="chr" size="8192" crc="" sha1="" status="nodump" />	<!-- CHR ROM missing -->
+				<rom name="chr" size="8192" status="nodump" />	<!-- CHR ROM missing -->
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
Added two new working entries:

- Galaga (prototype) [VGHF]
- Galaga (prototype, with recreated graphics) [VGHF, Frank Cifaldi, Rushifell, ndiddy]

Context for these two entries with their historical significance, from the Hidden Palace website:
> Atari contracted Nintendo to develop ports of 4 titles that Atari owned the home rights to (Galaga, Joust, Millipede, and Stargate) as launch titles for Atari's version of the Famicom. Nintendo then subcontracted development on these titles to HAL Laboratory. After the deal fell through, HAL eventually released Joust, Millipede, and Stargate themselves, but Galaga never saw a release as Namco had already put out their own Famicom port of Galaga. Namco's port is entirely different from HAL's port.
> The CHR ROM to this prototype is lost, and had to be recreated to make the game fully playable. The graphics for the recreated CHR ROM were mostly sourced from HAL's port of Stargate and from the arcade version of Galaga.