### PR TITLE
Added 2 verified SEGA SC-3000 BASIC Level 2 definitions.

### DIFF
--- a/hash/sc3000_cart.xml
+++ b/hash/sc3000_cart.xml
@@ -64,6 +64,34 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="basic2pal" cloneof="basic2">
+		<description>BASIC Level 2 (Export, PAL)</description>
+		<year>1985</year>
+		<publisher>Sega</publisher>
+		<part name="cart" interface="sg1000_cart">
+			<feature name="slot" value="othello" />
+			<dataarea name="rom" size="32768">
+				<rom name="basic2pal.bin" size="32768" crc="b7ec1307" sha1="5dc3b029be602d788fdf9d33cb54364e2849aefc" offset="000000" />
+			</dataarea>
+			<dataarea name="ram" size="2048">
+			</dataarea>
+		</part>
+	</software>
+
+    <software name="basic2v10b" cloneof="basic2">
+        <description>BASIC Level 2 (Japan, version 1.0b)</description>
+        <year>1985</year>
+        <publisher>Sega</publisher>
+        <part name="cart" interface="sg1000_cart">
+            <feature name="slot" value="othello" />
+            <dataarea name="rom" size="32768">
+                <rom name="basic2v10b.bin" size="32768" crc="cdf7bdf3" sha1="e8c66630b018ba5fd2ab245c152436934ab44391" offset="000000" />
+            </dataarea>
+            <dataarea name="ram" size="2048">
+            </dataarea>
+        </part>
+    </software>
+
 	<!-- SC-3000 Educational carts -->
 
 	<software name="music">


### PR DESCRIPTION
Added 2 verified SEGA SC-3000 BASIC Level 2 definitions to sc3000_cart.xml.

Six SC-3000 cart dumps supplied by Omar Cornut for analysis and testing, two were previously unknown.
 - basic2pal: basic2pal.bin, BASIC Level 2 (Export, PAL), 32KB, ram 2048
 - basic2v10b: basic2v10b.bin, BASIC Level 2 (Japan, version 1.0b), 32KB, ram 2048