### PR TITLE
cpu/drccache.cpp: Defer allocating to start, allow forcing W^X mode

### DIFF
--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -3923,7 +3923,9 @@ Core Misc Options
 
 **-[no]drc**
 
-    Enable DRC (dynamic recompiler) CPU core if available for maximum speed.
+    Enable DRC (dynamic recompiler) CPU cores if available.  Turn this option
+    off to use interpreter CPU cores if available.  This option does not affect
+    CPUs that only support one core type.
 
     The default is ON (**-drc**).
 
@@ -3932,18 +3934,37 @@ Core Misc Options
 
             mame ironfort -nodrc
 
+.. _mame-commandline-drcrwx:
+
+**\-[no]drc_rwx**
+
+    Allow DRC CPU cores to use memory that is simultaneously writable and
+    executable if supported.  Turning this option off may decrease performance.
+    This option only affects DRC CPU cores, and has no effect in configurations
+    that do not allow memory to be simultaneously writable and executable (e.g.
+    recent versions of macOS and NetBSD).
+
+    The default is ON (**-drc_rwx**).
+
+    Example:
+        .. code-block:: bash
+
+            mame fiveside -nodrc_rwx
+
 .. _mame-commandline-drcusec:
 
 **\-[no]drc_use_c**
 
-    Force DRC to use the C code backend.
+    Force DRC CPU cores to use the portable C code back-end when a native
+    back-end is available.  This option only affects DRC CPU cores, and has no
+    effect if a native DRC back-end is not available.
 
     The default is OFF (**-nodrc_use_c**).
 
     Example:
         .. code-block:: bash
 
-            mame ironfort -drc_use_c
+            mame vamphalf -drc_use_c
 
 .. _mame-commandline-drcloguml:
 

--- a/docs/source/commandline/commandline-index.rst
+++ b/docs/source/commandline/commandline-index.rst
@@ -318,6 +318,7 @@ Core Misc Options
 ~~~~~~~~~~~~~~~~~
 
 | :ref:`[no]drc <mame-commandline-drc>`
+| :ref:`[no]drc_rwx <mame-commandline-drcrwx>`
 | :ref:`[no]drc_use_c <mame-commandline-drcusec>`
 | :ref:`[no]drc_log_uml <mame-commandline-drcloguml>`
 | :ref:`[no]drc_log_native <mame-commandline-drclognative>`

--- a/src/devices/cpu/drcbearm64.cpp
+++ b/src/devices/cpu/drcbearm64.cpp
@@ -1549,7 +1549,7 @@ drcbe_arm64::drcbe_arm64(drcuml_state &drcuml, device_t &device, drc_cache &cach
 	, m_nocode(nullptr)
 	, m_endofblock(nullptr)
 	, m_baseptr(cache.near() + 0x100)
-	, m_near(*(near_state *)cache.alloc_near(sizeof(m_near)))
+	, m_near(*cache.alloc_near<near_state>())
 {
 	// create the log
 	if (device.machine().options().drc_log_native())

--- a/src/devices/cpu/drcbex64.cpp
+++ b/src/devices/cpu/drcbex64.cpp
@@ -1014,14 +1014,14 @@ drcbe_x64::drcbe_x64(drcuml_state &drcuml, device_t &device, drc_cache &cache, u
 	, m_log_asmjit(nullptr)
 	, m_lzcnt(false)
 	, m_bmi(false)
-	, m_absmask32((u32 *)cache.alloc_near(16*2 + 15))
+	, m_absmask32((u32 *)cache.alloc_near(16*2 + 15, std::align_val_t(alignof(u32))))
 	, m_absmask64(nullptr)
 	, m_rbpvalue(cache.near() + 0x80)
 	, m_entry(nullptr)
 	, m_exit(nullptr)
 	, m_nocode(nullptr)
 	, m_endofblock(nullptr)
-	, m_near(*(near_state *)cache.alloc_near(sizeof(m_near)))
+	, m_near(*cache.alloc_near<near_state>())
 {
 	// check for optional CPU features
 	const auto &x86_features = CpuInfo::host().features().x86();

--- a/src/devices/cpu/drcuml.cpp
+++ b/src/devices/cpu/drcuml.cpp
@@ -89,7 +89,7 @@ drcbe_interface::drcbe_interface(drcuml_state &drcuml, drc_cache &cache, device_
 	, m_cache(cache)
 	, m_device(device)
 	, m_space()
-	, m_state(*reinterpret_cast<drcuml_machine_state *>(cache.alloc_near(sizeof(m_state))))
+	, m_state(*cache.alloc_near<drcuml_machine_state>())
 {
 	// reset the machine state
 	memset(&m_state, 0, sizeof(m_state));

--- a/src/devices/cpu/drcuml.h
+++ b/src/devices/cpu/drcuml.h
@@ -247,7 +247,7 @@ inline void drcuml_block::append_comment(Format &&fmt, Params &&... args)
 	std::string const temp(util::string_format(std::forward<Format>(fmt), std::forward<Params>(args)...));
 
 	// allocate space in the cache to hold the comment
-	char *const comment = reinterpret_cast<char *>(m_drcuml.cache().alloc_temporary(temp.length() + 1));
+	char *const comment = reinterpret_cast<char *>(m_drcuml.cache().alloc_temporary(temp.length() + 1, std::align_val_t(alignof(char))));
 	if (comment)
 	{
 		strcpy(comment, temp.c_str());

--- a/src/devices/cpu/dsp16/dsp16.cpp
+++ b/src/devices/cpu/dsp16/dsp16.cpp
@@ -77,8 +77,11 @@
 
 #include "emu.h"
 #include "dsp16.h"
+
 #include "dsp16core.ipp"
 #include "dsp16rc.h"
+
+#include "emuopts.h"
 
 #include <functional>
 #include <limits>
@@ -184,7 +187,7 @@ dsp16_device_base::dsp16_device_base(
 			{ "exm", ENDIANNESS_BIG, 16, 16, -1 } }
 	, m_yaau_bits(yaau_bits)
 	, m_workram(*this, "workram"), m_spaces{ nullptr, nullptr, nullptr }, m_workram_mask(0U)
-	, m_drc_cache(CACHE_SIZE), m_core(nullptr, [] (core_state *core) { core->~core_state(); }), m_recompiler()
+	, m_drc_cache(CACHE_SIZE), m_core(), m_recompiler()
 	, m_cache_mode(cache::NONE), m_phase(phase::PURGE), m_int_enable{ 0U, 0U }, m_flags(FLAGS_NONE), m_cache_ptr(0U), m_cache_limit(0U), m_cache_iterations(0U)
 	, m_exm_in(1U), m_int_in(CLEAR_LINE), m_iack_out(1U)
 	, m_ick_in(1U), m_ild_in(CLEAR_LINE), m_do_out(1U), m_ock_in(1U), m_old_in(CLEAR_LINE), m_ose_out(1U)
@@ -202,8 +205,8 @@ dsp16_device_base::dsp16_device_base(
 
 void dsp16_device_base::device_start()
 {
-	m_core.reset(reinterpret_cast<core_state *>(m_drc_cache.alloc_near(sizeof(core_state))));
-	new (m_core.get()) core_state(m_yaau_bits);
+	m_drc_cache.allocate_cache(mconfig().options().drc_rwx());
+	m_core.reset(m_drc_cache.alloc_near<core_state>(m_yaau_bits));
 	set_icountptr(m_core->icount);
 
 	m_spaces[AS_PROGRAM] = &space(AS_PROGRAM);

--- a/src/devices/cpu/dsp16/dsp16.h
+++ b/src/devices/cpu/dsp16/dsp16.h
@@ -175,7 +175,8 @@ private:
 	class core_state;
 	class frontend;
 	class recompiler;
-	using core_state_ptr = std::unique_ptr<core_state, void (*)(core_state *)>;
+	struct core_destructer { void operator()(core_state *obj) const noexcept; };
+	using core_state_ptr = std::unique_ptr<core_state, core_destructer>;
 	using recompiler_ptr = std::unique_ptr<recompiler>;
 
 	// internal address maps

--- a/src/devices/cpu/dsp16/dsp16core.h
+++ b/src/devices/cpu/dsp16/dsp16core.h
@@ -114,4 +114,11 @@ private:
 	u64 dau_set_psw_flags(s64 d);
 };
 
+
+inline void dsp16_device::core_destructer::operator()(core_state *obj) const noexcept
+{
+	if (obj)
+		obj->~core_state();
+}
+
 #endif // MAME_CPU_DSP16_DSP16CORE_H

--- a/src/devices/cpu/dspp/dspp.h
+++ b/src/devices/cpu/dspp/dspp.h
@@ -15,7 +15,6 @@
 
 #include "cpu/drcfe.h"
 #include "cpu/drcuml.h"
-#include "cpu/drcumlsh.h"
 
 
 //**************************************************************************
@@ -243,7 +242,9 @@ private:
 
 		// External control registers
 		uint32_t    m_dspx_control;
-	} * m_core;
+	};
+	dspp_internal_state* m_core;
+	dspp_internal_state m_local_core; // for non-DRC mode
 
 	// DMA
 	struct fifo_dma
@@ -319,7 +320,7 @@ private:
 	};
 
 public: // TODO
-	void alloc_handle(drcuml_state *drcuml, uml::code_handle **handleptr, const char *name);
+	void alloc_handle(uml::code_handle **handleptr, const char *name);
 	void load_fast_iregs(drcuml_block &block);
 	void save_fast_iregs(drcuml_block &block);
 //  void arm7_drc_init();

--- a/src/devices/cpu/e132xs/e132xs.h
+++ b/src/devices/cpu/e132xs/e132xs.h
@@ -467,6 +467,8 @@ private:
 	uml::code_handle *m_io_write32;
 	uml::code_handle *m_exception;
 
+	internal_hyperstone_state m_local_core; // for non-DRC mode
+
 	uint32_t m_debug_local_regs[16];
 
 	bool m_enable_drc;

--- a/src/devices/cpu/mb86235/mb86235.cpp
+++ b/src/devices/cpu/mb86235/mb86235.cpp
@@ -14,8 +14,11 @@
 
 #include "emu.h"
 #include "mb86235.h"
-#include "mb86235fe.h"
+
 #include "mb86235d.h"
+#include "mb86235fe.h"
+
+#include "emuopts.h"
 
 
 #define ENABLE_DRC      0
@@ -89,7 +92,8 @@ void mb86235_device::device_start()
 	space(AS_BUSA).specific(m_dataa);
 	space(AS_BUSB).specific(m_datab);
 
-	m_core = (mb86235_internal_state *)m_cache.alloc_near(sizeof(mb86235_internal_state));
+	m_cache.allocate_cache(mconfig().options().drc_rwx());
+	m_core = m_cache.alloc_near<mb86235_internal_state>();
 	memset(m_core, 0, sizeof(mb86235_internal_state));
 
 

--- a/src/devices/cpu/mb86235/mb86235.h
+++ b/src/devices/cpu/mb86235/mb86235.h
@@ -13,7 +13,9 @@
 
 #include "cpu/drcfe.h"
 #include "cpu/drcuml.h"
+
 #include "machine/gen_fifo.h"
+
 
 class mb86235_frontend;
 

--- a/src/devices/cpu/mips/mips3com.h
+++ b/src/devices/cpu/mips/mips3com.h
@@ -200,4 +200,30 @@
 #define CACHE_TYPE      ((op >> 16) & 3)
 #define CACHE_OP        ((op >> 18) & 7)
 
+
+/***************************************************************************
+    INLINE FUNCTIONS
+***************************************************************************/
+
+/*-------------------------------------------------
+    tlb_entry_matches_asid - true if the given
+    TLB entry matches the provided ASID
+-------------------------------------------------*/
+
+inline bool mips3_device::mips3_tlb_entry::matches_asid(uint8_t asid) const noexcept
+{
+	return (entry_hi & 0xff) == asid;
+}
+
+
+/*-------------------------------------------------
+    tlb_entry_is_global - true if the given
+    TLB entry is global
+-------------------------------------------------*/
+
+inline bool mips3_device::mips3_tlb_entry::is_global() const noexcept
+{
+	return (entry_lo[0] & entry_lo[1] & TLB_GLOBAL);
+}
+
 #endif // MAME_CPU_MIPS_MIPS3COM_H

--- a/src/devices/cpu/powerpc/ppc.h
+++ b/src/devices/cpu/powerpc/ppc.h
@@ -229,6 +229,7 @@ public:
 
 	void ppc_set_dcstore_callback(write32sm_delegate callback);
 
+	void set_drc_cache_size(size_t bytes) { m_cache.set_size(bytes); }
 	void ppcdrc_set_options(uint32_t options);
 	void ppcdrc_add_fastram(offs_t start, offs_t end, uint8_t readonly, void *base);
 	void ppcdrc_add_hotspot(offs_t pc, uint32_t opcode, uint32_t cycles);
@@ -259,7 +260,7 @@ public:
 	void ppccom_get_dsisr();
 
 protected:
-	// device-level overrides
+	// device_t implementation
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 	virtual void device_stop() override ATTR_COLD;

--- a/src/devices/cpu/powerpc/ppccom.cpp
+++ b/src/devices/cpu/powerpc/ppccom.cpp
@@ -10,8 +10,12 @@
 
 #include "emu.h"
 #include "ppccom.h"
+
 #include "ppcfe.h"
 #include "ppc_dasm.h"
+
+#include "emuopts.h"
+
 
 /***************************************************************************
     DEBUGGING
@@ -596,7 +600,8 @@ static inline int sign_double(double x)
 void ppc_device::device_start()
 {
 	/* allocate the core from the near cache */
-	m_core = (internal_ppc_state *)m_cache.alloc_near(sizeof(internal_ppc_state));
+	m_cache.allocate_cache(mconfig().options().drc_rwx());
+	m_core = m_cache.alloc_near<internal_ppc_state>();
 	memset(m_core, 0, sizeof(internal_ppc_state));
 
 	m_entry = nullptr;

--- a/src/devices/cpu/sh/sh.cpp
+++ b/src/devices/cpu/sh/sh.cpp
@@ -3,13 +3,38 @@
 
 #include "emu.h"
 #include "sh.h"
+
 #include "sh_dasm.h"
+
 #include "cpu/drcumlsh.h"
+
+#include "emuopts.h"
+
+
+sh_common_execution::sh_common_execution(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, endianness_t endianness, address_map_constructor internal)
+	: cpu_device(mconfig, type, tag, owner, clock)
+	, m_sh2_state(nullptr)
+	, m_cache(CACHE_SIZE + sizeof(internal_sh2_state))
+	, m_drcuml(nullptr)
+	, m_drcoptions(0)
+	, m_entry(nullptr)
+	, m_read8(nullptr)
+	, m_write8(nullptr)
+	, m_read16(nullptr)
+	, m_write16(nullptr)
+	, m_read32(nullptr)
+	, m_write32(nullptr)
+	, m_interrupt(nullptr)
+	, m_nocode(nullptr)
+	, m_out_of_cycles(nullptr)
+{
+}
 
 void sh_common_execution::device_start()
 {
 	/* allocate the implementation-specific state from the full cache */
-	m_sh2_state = (internal_sh2_state *)m_cache.alloc_near(sizeof(internal_sh2_state));
+	m_cache.allocate_cache(mconfig().options().drc_rwx());
+	m_sh2_state = m_cache.alloc_near<internal_sh2_state>();
 
 	save_item(NAME(m_sh2_state->pc));
 	save_item(NAME(m_sh2_state->sr));

--- a/src/devices/cpu/sh/sh.h
+++ b/src/devices/cpu/sh/sh.h
@@ -101,24 +101,6 @@ class sh_common_execution : public cpu_device
 {
 
 public:
-	sh_common_execution(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, endianness_t endianness, address_map_constructor internal)
-		: cpu_device(mconfig, type, tag, owner, clock)
-		, m_sh2_state(nullptr)
-		, m_cache(CACHE_SIZE + sizeof(internal_sh2_state))
-		, m_drcuml(nullptr)
-		, m_drcoptions(0)
-		, m_entry(nullptr)
-		, m_read8(nullptr)
-		, m_write8(nullptr)
-		, m_read16(nullptr)
-		, m_write16(nullptr)
-		, m_read32(nullptr)
-		, m_write32(nullptr)
-		, m_interrupt(nullptr)
-		, m_nocode(nullptr)
-		, m_out_of_cycles(nullptr)
-	{ }
-
 	// Data that needs to be stored close to the generated DRC code
 	struct internal_sh2_state
 	{
@@ -203,6 +185,8 @@ protected:
 		EXECUTE_UNMAPPED_CODE       = 2,
 		EXECUTE_RESET_CACHE         = 3
 	};
+
+	sh_common_execution(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, endianness_t endianness, address_map_constructor internal);
 
 	void ADD(uint32_t m, uint32_t n);
 	void ADDI(uint32_t i, uint32_t n);

--- a/src/devices/cpu/sharc/sharc.cpp
+++ b/src/devices/cpu/sharc/sharc.cpp
@@ -7,8 +7,11 @@
 
 #include "emu.h"
 #include "sharc.h"
-#include "sharcfe.h"
+
 #include "sharcdsm.h"
+#include "sharcfe.h"
+
+#include "emuopts.h"
 
 
 #define DISABLE_FAST_REGISTERS      1
@@ -474,7 +477,8 @@ void adsp21062_device::external_dma_write(uint32_t address, uint64_t data)
 
 void adsp21062_device::device_start()
 {
-	m_core = (sharc_internal_state *)m_cache.alloc_near(sizeof(sharc_internal_state));
+	m_cache.allocate_cache(mconfig().options().drc_rwx());
+	m_core = m_cache.alloc_near<sharc_internal_state>();
 	memset(m_core, 0, sizeof(sharc_internal_state));
 
 	m_program = &space(AS_PROGRAM);

--- a/src/devices/cpu/uml.cpp
+++ b/src/devices/cpu/uml.cpp
@@ -236,7 +236,7 @@ opcode_info const instruction::s_opcode_info_table[OP_MAX] =
 //-------------------------------------------------
 
 uml::code_handle::code_handle(drcuml_state &drcuml, const char *name)
-	: m_code(reinterpret_cast<drccodeptr *>(drcuml.cache().alloc_near(sizeof(drccodeptr))))
+	: m_code(drcuml.cache().alloc_near<drccodeptr>())
 	, m_string(name)
 	, m_drcuml(drcuml)
 {

--- a/src/devices/sound/swp30.cpp
+++ b/src/devices/sound/swp30.cpp
@@ -9,6 +9,7 @@
 #include "cpu/drcumlsh.h"
 
 #include "debugger.h"
+#include "emuopts.h"
 
 #include <algorithm>
 #include <sstream>
@@ -1718,7 +1719,8 @@ void swp30_device::device_start()
 	m_wave->cache(m_wave_cache);
 	m_reverb->cache(m_reverb_cache);
 
-	m_meg = static_cast<meg_state *>(m_drccache.alloc_near(sizeof(meg_state)));
+	m_drccache.allocate_cache(mconfig().options().drc_rwx());
+	m_meg = m_drccache.alloc_near<meg_state>();
 	m_meg->m_swp = this;
 	m_meg->reset();
 

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -197,7 +197,8 @@ const options_entry emu_options::s_option_entries[] =
 
 	// misc options
 	{ nullptr,                                           nullptr,     core_options::option_type::HEADER,     "CORE MISC OPTIONS" },
-	{ OPTION_DRC,                                        "1",         core_options::option_type::BOOLEAN,    "enable DRC CPU core if available" },
+	{ OPTION_DRC,                                        "1",         core_options::option_type::BOOLEAN,    "enable DRC CPU cores if available" },
+	{ OPTION_DRC_RWX,                                    "1",         core_options::option_type::BOOLEAN,    "allow DRC to use writable executable pages if supported" },
 	{ OPTION_DRC_USE_C,                                  "0",         core_options::option_type::BOOLEAN,    "force DRC to use C backend" },
 	{ OPTION_DRC_LOG_UML,                                "0",         core_options::option_type::BOOLEAN,    "write DRC UML disassembly log" },
 	{ OPTION_DRC_LOG_NATIVE,                             "0",         core_options::option_type::BOOLEAN,    "write DRC native disassembly log" },

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -161,6 +161,7 @@
 
 // core misc options
 #define OPTION_DRC                  "drc"
+#define OPTION_DRC_RWX              "drc_rwx"
 #define OPTION_DRC_USE_C            "drc_use_c"
 #define OPTION_DRC_LOG_UML          "drc_log_uml"
 #define OPTION_DRC_LOG_NATIVE       "drc_log_native"
@@ -444,6 +445,7 @@ public:
 
 	// core misc options
 	bool drc() const { return bool_value(OPTION_DRC); }
+	bool drc_rwx() const { return bool_value(OPTION_DRC_RWX); }
 	bool drc_use_c() const { return bool_value(OPTION_DRC_USE_C); }
 	bool drc_log_uml() const { return bool_value(OPTION_DRC_LOG_UML); }
 	bool drc_log_native() const { return bool_value(OPTION_DRC_LOG_NATIVE); }


### PR DESCRIPTION
This makes a few changes to the DRC cache.  I expect this won't be contentious, but @galibert or @MooglyGuy might have something to say about it.

This adds a user-facing option to disable use of read/write/execute pages even if they're permitted on the host system (-[no]drc_rwx).  This is useful for debugging or profiling W^X mode on Windows/Linux/whatever when RWX pages are permitted.  People may also want to use it if they want to make MAME marginally less insecure or something (it might prevent certain classes of VM escape bug).

This defers DRC cache allocation from construction to start time.  This has two main benefits right now:
* It improves the performance of `-validate`, `-listxml`, the internal UI, etc. because it's no longer asking the virtual memory system for megabytes of memory it has no need for and messing with page tables.
* It means systems/devices can override the cache size for CPUs at configuration time, which may improve performance if they have a large working set.  To this end, MIPS III and PowerPC get `set_drc_cache_size(size_t)` configuration member functions to set the desired cache size.

This adds helpers for allocating structures or objects in the DRC cache.  This makes syntax a bit prettier in CPU cores.  It prints an error message if the structure/object could possibly be misaligned (changing the heap management approach to correctly align things that aren't satisfied with `max_align_t` alignment is too intrusive to do in this PR).

This adds some DRC cache stats to verbose output on destruction.  Debug builds have more counters than release builds.  This can give you an idea of whether the cache is big enough.  Note that cache use will be higher with `-drc_log_uml`, and a lot higher with `-drc_log_native`, especially on i686 and x86-64.

There's also some general cleanup in some of the CPU cores, but nothing major.