### PR TITLE
casio_rompack.xml: Added 33 entries

### DIFF
--- a/hash/casio_rompack.xml
+++ b/hash/casio_rompack.xml
@@ -945,6 +945,7 @@ license:CC0-1.0
 		5. サザエさん一家 「サザエさん」より
 		6. Dang Dang 気になる 「美味しんぼ」より
 		7. キッチンから愛をこめて 「ハーイ あっこです」より
+	-->
 	<software name="ro189a">
 		<description>Animation Themes 7 (RO-189A)</description>
 		<year>19??</year>


### PR DESCRIPTION
Added new Japanese Rom Pack dumps:

- The Hit Parade (RO-101) [Edward d-tech]
- Hit Kayou (RO-102) [kosei_515]
- New Music (RO-103) [kosei_515]
- Enka Vol.2 Karaoke Hit Shuu (RO-106) [kosei_515]
- Enka 3 (RO-108) [kosei_515]
- Easy Listening 3 (RO-110) [kosei_515]
- Enka 4 (RO-111) [kosei_515]
- Young Best Hits (RO-113) [kosei_515]
- Enka 5 (RO-114) [Edward d-tech]
- Screen Themes 3 (RO-118) [kosei_515]
- Kodomo no Uta 3 (RO-119) [kosei_515]
- Enka 9 (RO-125E) [Edward d-tech]
- Paul Mauriat (RO-151) [kosei_515]
- Young Hits (RO-153) [kosei_515]
- Animation (RO-155) [kosei_515]
- Kodomo no Uta 1 (RO-158) [kosei_515]
- Animation 2 (RO-162) [kosei_515]
- Animation Themes 3 (RO-166) [kosei_515]
- Animation Themes 4 (RO-169A) [kosei_515]
- Animation Themes 5 (RO-170A) [kosei_515]
- Event Songs (RO-171I) [kosei_515]
- Game Music: Dragon Quest III Yori (RO-172G) [kosei_515]
- Animation Themes 6 (RO-178A) [kosei_515]
- Christmas Songs 2 (RO-180X) [whc2001 (Ian Wang)]
- Standards 2 (RO-181S) [kosei_515]
- Beatles 2 (RO-182B) [kosei_515]
- Comic Songs (RO-183C) [kosei_515]
- Shougakusei no Ongaku 1 (RO-184T) [kosei_515]
- Shougakusei no Ongaku 2 (RO-185T) [kosei_515]
- Shougakusei no Ongaku 3 (RO-186T) [kosei_515]
- Animation Themes 7 (RO-189A) [kosei_515]
- Young Best Hits 8 (RO-191Y) [Edward d-tech]
- Young Best Hits 9 (RO-192Y) [Edward d-tech]