### PR TITLE
Fix floating value options when the OS is set to certain languages

### DIFF
--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -1378,6 +1378,10 @@ void lua_engine::initialize()
 		[this](core_options::entry &e) -> sol::object {
 			if (e.type() == core_options::option_type::INVALID)
 				return sol::lua_nil;
+			// Save current locale
+			std::string oldLocale = setlocale(LC_NUMERIC, nullptr);
+			// Force "C" locale for parsing
+			setlocale(LC_NUMERIC, "C");
 			switch(e.type())
 			{
 				case core_options::option_type::BOOLEAN:
@@ -1389,6 +1393,8 @@ void lua_engine::initialize()
 				default:
 					return sol::make_object(sol(), e.value());
 			}
+			// Restore old locale
+			setlocale(LC_NUMERIC, oldLocale.c_str());
 		}));
 	core_options_entry_type.set("description", &core_options::entry::description);
 	core_options_entry_type.set("default_value", &core_options::entry::default_value);


### PR DESCRIPTION
As changing the entire locale in MAME to a different option than the OS setting is problematic, I wonder if just changing it temporarily to parse the values is OK.
Interestingly, this problem only occurs with the floating values in the "Advanced Options" menu. The other floating values aren't affected.
As a reminder, these options do not work correctly when the OS is set to those languages where floating values are displayed with a ',' instead of a '.'.