### PR TITLE
apple2gs_flop_clcracked.xml: New Apple IIgs software list additions

### DIFF
--- a/hash/apple2gs_flop_clcracked.xml
+++ b/hash/apple2gs_flop_clcracked.xml
@@ -1,3618 +1,3682 @@
-<?xml version="1.0"?>
-<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 <!--
 license:CC0-1.0
 -->
-
 <softwarelist name="apple2gs_flop_clcracked" description="Apple IIgs cleanly cracked disks">
-
-	<software name="4thinchs">
-		<description>4th &amp; Inches (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Accolade</publisher>
-		<info name="programmer" value="Tony Manso" />
-		<info name="programmer" value="Ed Bogas" />
-		<info name="programmer" value="Les Pardew" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs -->
-		<!-- The Team Construction Set was sold separately, but only works with 4th & Inches so it's included as "Disk 2" -->
-		<!-- The Team Construction Set disk doesn't check itself for being an original, but runs a nibble count on the 4th & Inches disk -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="4th &amp; inches iigs (trex crack).2mg" size="819264" crc="63566084" sha1="2f2780317b64acfee335f14df333f2e6d275632a"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Team Construction disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="4th &amp; inches team construction disk iigs (trex crack).2mg" size="819264" crc="85a18133" sha1="3a45fb29a5b0b4ecebd99c396a6c1d2859087e50"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="aesopfbl">
-		<description>Aesop's Fables (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Unicorn Software</publisher>
-		<info name="programmer" value="William Demas" />
-		<info name="programmer" value="Joseph Hewitt IV" />
-		<info name="programmer" value="June Stark" />
-		<info name="usage" value="Requires a 768K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "Aesop's Fables" is a 1988 educational program developed by William Demas, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="aesop's fables iigs - disk 1 (trex crack).2mg" size="819264" crc="45eceb6d" sha1="82fa0b3d9e303b576ac4e469708860c1cbd88e5b"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="aesop's fables iigs - disk 2 (trex crack).2mg" size="819264" crc="87c1d3ae" sha1="44531b8c40a966d7999397a2f41fbcbff47b4ceb"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="allabamr">
-		<description>All About America (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Unicorn Software</publisher>
-		<info name="programmer" value="Stanley Brewster" />
-		<info name="programmer" value="June Stark" />
-		<info name="programmer" value="Joseph B. Hewitt IV" />
-		<info name="usage" value="Requires a 768K Apple IIgs ROM 03." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K ROM3 Apple IIgs. (crashes on ROM01 Apple IIgs?) -->
-		<!-- "All About America" is a 1988 educational program developed by Stanley Brewster, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="all about america iigs - disk 1 (trex crack).2mg" size="819264" crc="0ffc52de" sha1="147395c621f0c1075995da84c11980df3add6403"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="all about america iigs - disk 2 (trex crack).2mg" size="819264" crc="dbc50936" sha1="faf94b81dfe45af084ceb82dcc2a08e750aa24f3"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="alandofys">
-		<description>Ancient Land of Ys (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Kyodai</publisher>
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Ancient Land of Ys" is a 1989 fantasy role playing game developed by Kyodai and distributed by Brøderbund. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="ancient land of ys iigs - disk 1 - program disk (trex crack).2mg" size="819264" crc="1770d1a8" sha1="f298033c84a26f8835a7c29327dffee09ddefcf6"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Data disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="ancient land of ys iigs - disk 2 - data disk (trex crack).2mg" size="819264" crc="b4056419" sha1="2a6141344cbaa09b01aae468a86c40c8f9cce1e6"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="arkanoid">
-		<description>Arkanoid (version 12-Jan-89) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Taito</publisher>
-		<info name="programmer" value="Ryan Ridges" />
-		<info name="programmer" value="John Lund" />
-		<info name="version" value="12-Jan-89 - ROM 03 compatible" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs -->
-		<!-- "Arkanoid" is a 1988 action game developed by Ryan Ridges and John Lund, and distributed by Taito America. -->
-		<!-- The copy protection routines are not compatible with the ROM03, however the cracked version runs on any 512K Apple IIgs -->
-		<!-- ark.s16 dated 12-Jan-89 -->
-		<!-- Protection: Excessive zero bits after D5 CC AA header. Then 4 bytes are read through 4 loops with matches recorded. Read matches must equal less then 12 out of 16 reads -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="arkanoid iigs (12-jan-89) (trex crack).2mg" size="819264" crc="1cd0cc32" sha1="0c8fda06f1ddd7a53d7a0e36276f1fb45e993c42"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="arknoid2">
-		<description>Arkanoid II: Revenge of Doh (version 29-Aug-89) (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Taito</publisher>
-		<info name="programmer" value="Ryan Ridges" />
-		<info name="programmer" value="John Lund" />
-		<info name="version" value="29-Aug-89" />
-		<info name="usage" value="Requires a 512K Apple IIgs ROM01 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs ROM01 or later. -->
-		<!-- "Arkanoid II" is a 1989 action game developed by Ryan Ridges and John Lund, and distributed by Taito America. -->
-		<!-- ark.s16 dated 29-Aug-89 -->
-		<!-- Protection: Excessive zero bits after D5 CC AA header. Then 4 bytes are read through 4 loops with matches recorded. Read matches must equal less then 12 out of 16 reads -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="arkanoid ii - revenge of doh iigs (29-aug-89) (trex crack).2mg" size="819264" crc="d9207384" sha1="b04253e088b65df6189268c6e5eade67fb155827"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="arknoid2a" cloneof="arknoid2">
-		<description>Arkanoid II: Revenge of Doh (version 18-Jul-89) (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Taito</publisher>
-		<info name="programmer" value="Ryan Ridges" />
-		<info name="programmer" value="John Lund" />
-		<info name="version" value="18-Jul-89" />
-		<info name="usage" value="Requires a 512K Apple IIgs ROM01 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs ROM01 or later. -->
-		<!-- "Arkanoid II" is a 1989 action game developed by Ryan Ridges and John Lund, and distributed by Taito America. -->
-		<!-- ark.s16 dated 18-Jul-89 -->
-		<!-- Protection: Excessive zero bits after D5 CC AA header. Then 4 bytes are read through 4 loops with matches recorded. Read matches must equal less then 12 out of 16 reads -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="arkanoid ii - revenge of doh iigs (18-jul-89) (trex crack).2mg" size="819264" crc="b3b4cd5b" sha1="4d302c876001cf638afa0c58d8254b7f2d138c51"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="btlchess">
-		<description>Battle Chess (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Interplay Productions</publisher>
-		<info name="programmer" value="Jim Sproul" />
-		<info name="programmer" value="Todd J. Camasta" />
-		<info name="programmer" value="Bruce Schlickbernd" />
-		<info name="programmer" value="Kurt Heiden" />
-		<info name="programmer" value="Bill (Weez) Dugan" />
-		<info name="programmer" value="Thomas R. Decker" />
-		<info name="programmer" value="Troy P. Worrell" />
-		<info name="programmer" value="Michael Quarles" />
-		<info name="programmer" value="Rebecca Heineman" />
-		<info name="programmer" value="Alan Pavlish" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- board game -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="battle chess iigs (trex crack).2mg" size="819264" crc="f40de0f7" sha1="8cd2fc36064fe531172d532db948865bce36307a"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="blockout">
-		<description>Block Out (version 1.0) (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>California Dreams</publisher>
-		<info name="programmer" value="Alexander Ustaszewski" />
-		<info name="programmer" value="Marek Jackiewicz" />
-		<info name="programmer" value="Adam Skorupinski" />
-		<info name="programmer" value="Marcin Szostakowski" />
-		<info name="programmer" value="Marcin Grzegorzewski" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Block Out" is a 1989 action game developed by Alexander Ustaszewski, Marek Jackiewicz, Adam Skorupinski, Marcin Szostakowski, and Marcin Grzegorzewski, and distributed by California Dreams. -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="block out v1.0 iigs (trex crack).2mg" size="819264" crc="c15e712f" sha1="fe037f0ac74aea08a82bb7ee748fba77b563d58a"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bghost">
-		<description>Bubble Ghost (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Accolade</publisher>
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Bubble Ghost" is a 1988 action game developed by Infogrames and distributed by Accolade. -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="bubble ghost iigs (trex crack).2mg" size="819264" crc="cba0efd6" sha1="e6ac73d5415aab87d4206d49bd1aa5cbc2d558f5"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bghosthd" cloneof="bghost">
-		<description>Bubble Ghost - Hard Drive compatible (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Accolade</publisher>
-		<info name="version" value="Hard Drive compatible" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Bubble Ghost" is a 1988 action game developed by Infogrames and distributed by Accolade. -->
-		<!-- Hard coded path names were replaced with names to use current volume / directory -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="bubble ghost iigs (hard drive mod) (trex crack).2mg" size="819264" crc="6a612172" sha1="02b32bee6e79055f0436f693a6e12563f2d4c1a1"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="calcraft">
-		<description>Calendar Crafter (A-194 version 1.2) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>MECC</publisher>
-		<info name="partno" value="A-194" />
-		<info name="programmer" value="Gene Breault" />
-		<info name="programmer" value="Charolyn Kapplinger" />
-		<info name="programmer" value="Diane Portner" />
-		<info name="programmer" value="Steven D. Splinter" />
-		<info name="programmer" value="Paul R. Wenker" />
-		<info name="usage" value="Requires a 768K Apple IIgs ROM 01 or later." />
-		<info name="version" value="1.2" />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs ROM 01 or later. -->
-		<!-- productivity program -->
-		<!-- Protection: Bad block check for block $8 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="calendar crafter v1.2 iigs(trex crack).2mg" size="819264" crc="65717231" sha1="2f2415385a699fc78a68a3a73ff8470a5fc8df6f"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="calgames">
-		<description>California Games (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Epyx</publisher>
-		<info name="programmer" value="Jimmy Huey" />
-		<info name="programmer" value="Dan Chang" />
-		<info name="programmer" value="Jenny Martin" />
-		<info name="programmer" value="Sheryl Knowles" />
-		<info name="programmer" value="Bill Bogenreif" />
-		<info name="programmer" value="Matt Householder" />
-		<info name="programmer" value="Ron Fortier" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-		<!-- sports game -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="california games iigs (trex crack).2mg" size="819264" crc="908b7825" sha1="d276969f7e11b493d10fb2d7b2943c3e668864aa"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="captbld">
-		<description>Captain Blood (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Mindscape</publisher>
-		<info name="programmer" value="Philippe Ulrich" />
-		<info name="programmer" value="Didier Bouchon" />
-		<info name="programmer" value="Jean-Michel Jarre" />
-		<info name="programmer" value="Alexis Martial" />
-		<info name="programmer" value="Michael Rho" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- simulation game -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="captain blood iigs (trex crack).2mg" size="819264" crc="7b2dede6" sha1="6ead26e7e2c4d3bb65b3d91e13df784503c9e643"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cavcobra">
-		<description>Cavern Cobra (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>PBI Software</publisher>
-		<info name="programmer" value="Greg Hale" />
-		<info name="programmer" value="Richard L. Seaborne" />
-		<info name="usage" value="Requires a 768K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "Cavern Cobra" is a 1987 action game developed by Greg Hale and Richard L. Seaborne, and distributed by PBI Software. -->
-		<!-- Protection: Bad block check for block $7 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="cavern cobra iigs (trex crack).2mg" size="819264" crc="8345e4a2" sha1="8a3c05ce714b5f3bbbc5bc1d6649530e21c093b3"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="clbbgmn">
-		<description>Club Backgammon (version 2.0 12-Dec-88) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>California Dreams</publisher>
-		<info name="programmer" value="Staszek Bartkowski" />
-		<info name="programmer" value="Jarek Olszewski" />
-		<info name="programmer" value="Dorota B&#x142;aszczak" />
-		<info name="programmer" value="Maciej Markuszewski" />
-		<info name="programmer" value="Marcin Szostakowski" />
-		<info name="version" value="2.0 12-Dec-88" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Club Backgammon" is a 1988 board game developed by Staszek Bartkowski, Jarek Olszewski, Dorota Błaszczak, Maciej Markuszewski, and Marcin Szostakowski, and distributed by California Dreams. -->
-		<!-- gammon.sys16 dated 12-Dec-88 -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="club backgammon v2.0 iigs (trex crack).2mg" size="819264" crc="94bc57d4" sha1="bd32dd7098ddbbeaf89620e1faf32b66df91a4f7"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="clbbgmna" cloneof="clbbgmn">
-		<description>Club Backgammon (version 1.0 09-May-88) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>California Dreams</publisher>
-		<info name="programmer" value="Staszek Bartkowski" />
-		<info name="programmer" value="Jarek Olszewski" />
-		<info name="programmer" value="Dorota B&#x142;aszczak" />
-		<info name="programmer" value="Maciej Markuszewski" />
-		<info name="programmer" value="Marcin Szostakowski" />
-		<info name="version" value="1.0 09-May-88" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Club Backgammon" is a 1988 board game developed by Staszek Bartkowski, Jarek Olszewski, Dorota Błaszczak, Maciej Markuszewski, and Marcin Szostakowski, and distributed by California Dreams. -->
-		<!-- gammon.sys16 dated 09-May-88 -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="club backgammon v1.0 iigs (trex crack).2mg" size="819264" crc="b511a503" sha1="e0dbfb6311329ca50b88fe4c94b618f360988d88"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cribgin">
-		<description>Cribbage King / Gin King (version 1.01) (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>The Software Toolworks</publisher>
-		<info name="programmer" value="Mark Manyen" />
-		<info name="programmer" value="Don Laabs" />
-		<info name="programmer" value="David M. Linnehan" />
-		<info name="programmer" value="Elizabeth Scafati" />
-		<info name="version" value="1.01" />
-		<info name="usage" value="Requires a 1MB Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 1MB Apple IIgs. -->
-		<!-- "Cribbage King / Gin King" is a 1989 board game developed by Mark Manyen, Don Laabs, David M. Linnehan, and Elizabeth Scafati, and distributed by The Software Toolworks. -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - System disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="cribbage king - gin king v1.01 iigs - disk 1 - system.2mg" size="819264" crc="13734d39" sha1="5c501b2e3d17eb8dbc518a7be038953b5eef6f86"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="cribbage king - gin king v1.01 iigs - disk 2 - program (trex crack).2mg" size="819264" crc="a94cd6a5" sha1="50f215f226f14effcb1c29974b94e34a11e66783"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="defcrown">
-		<description>Defender of the Crown (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Cinemaware</publisher>
-		<info name="programmer" value="Kellyn Beeck" />
-		<info name="programmer" value="James Sachs" />
-		<info name="programmer" value="Ivan Manley" />
-		<info name="programmer" value="Robert Jacob" />
-		<info name="programmer" value="Phyllis Jacob" />
-		<info name="programmer" value="Pat Cook" />
-		<info name="programmer" value="Jim Cuomo" />
-		<info name="programmer" value="Tom Warner" />
-		<info name="programmer" value="Jeff Hilbers" />
-		<info name="programmer" value="Steve Quinn" />
-		<info name="programmer" value="Richard La Barre" />
-		<info name="programmer" value="John Cutter" />
-		<info name="programmer" value="Rob Landeros" />
-		<info name="programmer" value="Doug Smith" />
-		<info name="programmer" value="Betsy Scafati" />
-		<info name="programmer" value="Wayne Brockman" />
-		<info name="usage" value="Requires a 768K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "Defender of the Crown" is a 1988 adventure game developed by Kellyn Beeck, James Sachs, Ivan Manley, Robert Jacob, Phyllis Jacob, Pat Cook, Jim Cuomo, Tom Warner, Jeff Hilbers, Steve Quinn, Richard La Barre, John Cutter, Rob Landeros, Doug Smith, Betsy Scafati, and Wayne Brockman, and distributed by Cinemaware Corporation. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Reel 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="defender of the crown iigs - reel 1 (trex crack).2mg" size="819264" crc="c6e42ad9" sha1="798e460a036cd089e714fa4c42477c807942b55d"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Reel 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="defender of the crown iigs - reel 2 (trex crack).2mg" size="819264" crc="cecd1d4c" sha1="9a25fc96e8ed25cc5afeab36396e8f376268258b"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dejavu">
-		<description>Déjà Vu (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>ICOM Simulations</publisher>
-		<info name="programmer" value="Fred Allen" />
-		<info name="programmer" value="David Marsh" />
-		<info name="programmer" value="Karl Roelofs" />
-		<info name="programmer" value="Todd Squires" />
-		<info name="programmer" value="Craig Erickson" />
-		<info name="programmer" value="Kurt Nelson" />
-		<info name="programmer" value="Steven Hays" />
-		<info name="programmer" value="Terry Schulenburg" />
-		<info name="programmer" value="Darin Adler" />
-		<info name="programmer" value="Jay Zipnick" />
-		<info name="programmer" value="Waldermar Horwat" />
-		<info name="programmer" value="Mark Waterman" />
-		<info name="programmer" value="Tod Zipnick" />
-		<info name="usage" value="Requires a 768K Apple IIgs ROM01 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs ROM01 or later. -->
-		<!-- "Deja Vu" is a 1988 adventure game developed by Fred Allen, David Marsh, Karl Roelofs, Todd Squires, Craig Erickson, Kurt Nelson, Steven Hays, Terry Schulenburg, Darin Adler, Jay Zipnick, Waldermar Horwat, Mark Waterman, and Tod Zipnick, and distributed by ICOM Simulations. -->
-		<!-- Protection: Bad block check for block $7 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - System disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="deja vu iigs - disk 1 - system disk (trex crack).2mg" size="819264" crc="cc772518" sha1="dc2426407b1177a717d93d09416875228b971ce0"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="deja vu iigs - disk 2 - program disk (trex crack).2mg" size="819264" crc="6d60c03b" sha1="f99fee8c3870bfdf4f2483f7801f3c7f9a11a3ff"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dejavu2">
-		<description>Déjà Vu II: Lost in Las Vegas (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Mindscape</publisher>
-		<info name="programmer" value="Fred Allen" />
-		<info name="programmer" value="David Marsh" />
-		<info name="programmer" value="Michael Manning" />
-		<info name="programmer" value="Todd Squires" />
-		<info name="programmer" value="David Feldman" />
-		<info name="programmer" value="Paul Snively" />
-		<info name="programmer" value="Brian Baker" />
-		<info name="programmer" value="Karl Roelofs" />
-		<info name="programmer" value="Ed Dluzen" />
-		<info name="programmer" value="Darin Adler" />
-		<info name="programmer" value="Jay Zipnick" />
-		<info name="programmer" value="Waldemar Horwat" />
-		<info name="programmer" value="Julia Ulano" />
-		<info name="programmer" value="Tod Zipnick" />
-		<info name="programmer" value="Mitch Adler" />
-		<info name="usage" value="Requires a 768K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "Déjà Vu II: Lost in Las Vegas" is a 1989 adventure game developed by Fred Allen, David Marsh, Michael Manning, Todd Squires, David Feldman, Paul Snively, Brian Baker, Karl Roelofs, Ed Dluzen, Darin Adler, Jay Zipnick, Waldemar Horwat, Julia Ulano, Tod Zipnick, and Mitch Adler, and distributed by Mindscape. -->
-		<!-- Protection: Bad block check for block $7 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - System disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="deja vu ii lost in las vegas - disk 1 - system disk (trex crack).2mg" size="819264" crc="9dd61c1e" sha1="ef2237b9d2a8af21f991ee611fc6be16fa370399"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="deja vu ii lost in las vegas iigs - disk 2 - program disk (trex crack).2mg" size="819264" crc="c0361def" sha1="420226429cfb3cf015d7540251863b8445aaa0d7"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dsgnprnt">
-		<description>Designer Prints (A-252 version 1.0) (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>MECC</publisher>
-		<info name="partno" value="A-252" />
-		<info name="programmer" value="Diane Portner" />
-		<info name="programmer" value="Michael Stein" />
-		<info name="programmer" value="Brian Walker" />
-		<info name="programmer" value="Paul Wenker" />
-		<info name="usage" value="Requires a 768K Apple IIgs ROM 01 or later." />
-		<info name="version" value="1.0" />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs ROM 01 or later. -->
-		<!-- desktop publishing program -->
-		<!-- Protection: Bad block check for block $8 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - System disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="designer prints v1.0 iigs - disk 1 - system (trex crack).2mg" size="819264" crc="40720257" sha1="91cde62b8b6a1d8420af13580f707cb910ad1e22"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="designer prints v1.0 iigs - disk 2 - program (trex crack).2mg" size="819264" crc="aa1887a9" sha1="2727f3bb37d8cfaae85af20562e0d9f080fa1857"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dsgnpuzl">
-		<description>Designer Puzzles (A-223 version 1.0) (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>MECC</publisher>
-		<info name="partno" value="A-223" />
-		<info name="programmer" value="Susan Gabrys" />
-		<info name="programmer" value="John J. Krenz" />
-		<info name="programmer" value="Diane Portner" />
-		<info name="programmer" value="Steve Splinter" />
-		<info name="usage" value="Requires a 768K Apple IIgs ROM 01 or later." />
-		<info name="version" value="1.0" />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2021-08-13 -->
-		<!-- desktop publishing program -->
-		<!-- Protection: Bad block check for block $8 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - System disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="designer puzzles v1.0 iigs - disk 1 - system (trex crack).2mg" size="819264" crc="e1c43cca" sha1="e81f5fb94098806ea04f1d911b21ba46dc4ff4ef"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="designer puzzles v1.0 iigs - disk 2 - program (trex crack).2mg" size="819264" crc="3ac9cb9a" sha1="a48e900f2699fcc85a505a6486fb7635c0d1e1de"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="destryr">
-		<description>Destroyer (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Epyx</publisher>
-		<info name="programmer" value="Michael Kosaka" />
-		<info name="programmer" value="Chuck Sommerville" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 - 10 separate occurrences (Yes 10!) -->
-		<!-- simulation game -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="destroyer iigs (trex crack).2mg" size="819264" crc="a6943b6d" sha1="2160a034da86a894a0615490d55b8c585f0e1fcc"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dhilchl">
-		<description>Downhill Challenge (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Brøderbund Software</publisher>
-		<info name="author" value="Christian Bertrand" />
-		<info name="programmer" value="Jean Claude Levy" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Downhill Challenge" is a 1989 sports game designed by Christian Bertrand, ported to the Apple IIgs by Jean Claude Levy, and distributed by Brøderbund Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - System disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="downhill challenge iigs - disk 1 - system disk (trex crack).2mg" size="819264" crc="0168462f" sha1="bd7dba9c84634a93360b9a1615debf7908603e95"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Game disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="downhill challenge iigs - disk 2 - game disk (trex crack).2mg" size="819264" crc="01d4dd29" sha1="3ae9ec0b5eb5893327eef32167ae3c95fb7c89e3"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="drawplus10">
-		<description>Draw Plus (version 1.0) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Activision</publisher>
-		<info name="programmer" value="H. Lamiraux" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2025-01-25 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Draw Plus" is full-color precision drawing program with text and graphics intergraion. -->
-		<!-- Protection: Bad block check for block $7, later versions dropped the copy protection -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="draw plus v1.0 iigs (trex crack).2mg" size="819264" crc="efddd532" sha1="518ccb81ca6c20686e18c5a88b3d54708c62aba1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fantavsn">
-		<description>Fantavision (version 2.1) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Brøderbund Software</publisher>
-		<info name="programmer" value="Scott Anderson" />
-		<info name="programmer" value="Ken Rosen" />
-		<info name="version" value="2.1" />
-		<info name="usage" value="Requires a 256K Apple IIgs ROM 01 or earlier." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 256K Apple IIgs ROM 01 or earlier. -->
-		<!-- NOT Compatible with the Apple IIgs ROM03. -->
-		<!-- "Fantavision IIgs" is a 1987 graphics program developed by Scott Anderson and Ken Rosen, and distributed by Brøderbund Software. -->
-		<!-- About screen shows "BrøderbundS NEW FANTAVISION GS" -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="fantavision v2.1 iigs (trex crack).2mg" size="819264" crc="e0430e48" sha1="cb7762e193296cb3648687424b5911ea4c8d3902"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fantavsna" cloneof="fantavsn">
-		<description>Fantavision (version 1.0) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Brøderbund Software</publisher>
-		<info name="programmer" value="Scott Anderson" />
-		<info name="programmer" value="Ken Rosen" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 256K Apple IIgs ROM 01 or earlier." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 256K Apple IIgs ROM 01 or earlier. -->
-		<!-- NOT Compatible with the Apple IIgs ROM03. -->
-		<!-- "Fantavision IIgs" is a 1987 graphics program developed by Scott Anderson and Ken Rosen, and distributed by Brøderbund Software. -->
-		<!-- About screen shows "Brøderbund presents FANTAVISION" -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="fantavision v1.0 iigs (trex crack).2mg" size="819264" crc="0a94d284" sha1="09ee33786fef5f1d1eaadeb85ba275c9a451f003"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fastbrk">
-		<description>Fast Break (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Accolade</publisher>
-		<info name="programmer" value="Steve Cartwright" />
-		<info name="programmer" value="Greg Hospelhorn" />
-		<info name="programmer" value="George Wong" />
-		<info name="programmer" value="Pam Levins" />
-		<info name="programmer" value="Roseann Mitchell" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Fast Break" is a 1989 sports game developed by Steve Cartwright, Greg Hospelhorn, George Wong, Pam Levins, and Roseann Mitchell, and distributed by Accolade. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="fast break iigs (trex crack).2mg" size="819264" crc="b112c95f" sha1="f145e9973b4849f7cd1759a461832b34d2bf6df4"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="finalass">
-		<description>Final Assault (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Epyx</publisher>
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Final Assault" is a 1988 sports game developed by Infogrames and distributed by Epyx. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="final assault iigs (trex crack).2mg" size="819264" crc="1de1fae5" sha1="ae7329a9614f2be55232d2f7584b885b3ee3ed61"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gauntlet">
-		<description>Gauntlet (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Mindscape</publisher>
-		<info name="developer" value="Atari Games" />
-		<info name="usage" value="Requires a 256K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 256K Apple IIgs. -->
-		<!-- Protection: Bad block check for block $7 -->
-		<!-- arcade game -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="gauntlet iigs (trex crack).2mg" size="819264" crc="9350598a" sha1="e594829ae86956a4e86a5e7243e82bf7d3606c17"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gbabsktb">
-		<description>GBA Championship Basketball: Two-on-Two (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Activision</publisher>
-		<info name="programmer" value="Paul Terry" />
-		<info name="programmer" value="Jack Thornton" />
-		<info name="programmer" value="Scott Orr" />
-		<info name="programmer" value="John Cutter" />
-		<info name="programmer" value="Troy Lyndon" />
-		<info name="programmer" value="Russell Lieblich" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2023-04-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "GBA Championship Basketball" is a 1987 sports game developed by Paul Terry, Jack Thornton, Scott Orr, John Cutter, Troy Lyndon, and Russell Lieblich, and distributed by Activision. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="gba championship basketball two-on-two iigs (trex crack).2mg" size="819264" crc="2a5318f2" sha1="7220908177bea5ac84c0a17064589549edaeb904"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="geometry">
-		<description>Geometry (version 1.0) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Brøderbund</publisher>
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 768K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "Geometry v1.0" is a educational program teaching the concepts of geometry by Sensei Software, and publised by Brøderbund Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - System disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="geometry v1.0 iigs - disk 1 - System disk (trex crack).2mg" size="819264" crc="8f090d9b" sha1="c0620fd5df319357f830e109600da3cab2d1f0d4"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="geometry v1.0 iigs - disk 2 (trex crack).2mg" size="819264" crc="e01d0b28" sha1="545c72635f0cc2ff5498ae457fea07c11e09840e"/>
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 3"/>
-			<dataarea name="flop" size="819264">
-				<rom name="geometry v1.0 iigs - disk 3 (trex crack).2mg" size="819264" crc="6b68ee23" sha1="c5ff132dbdb9deed4a791ab07659563378ed2dee"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gnrlgolf">
-		<description>Gnarly Golf (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Fanfare by Britannica</publisher>
-		<info name="programmer" value="Jim Coliz, Jr." />
-		<info name="programmer" value="Darren Bartlett" />
-		<info name="programmer" value="Andy Hildebrand" />
-		<info name="programmer" value="Greg Thomas" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Gnarly Golf" is a 1989 miniture golf / putt game by Jim Coliz Jr & Darren Bartlett of Visual Concepts, Ltd., and distributed by Britannica Software. -->
-		<!-- Protection: Read block $63F with data markers AD AA D5 and compare read data against self generated data -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="gnarly golf iigs disk 1 - program (trex crack).2mg" size="819264" crc="b1a3cc99" sha1="6823ceb096d707670168af9e97549fc8787004a1"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Course disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="gnarly golf iigs disk 2 - course (trex crack).2mg" size="819264" crc="92373f7e" sha1="a14134e2cf97f11c540c3c2a3016db1bab490b5b"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gpcirc">
-		<description>Grand Prix Circuit (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Accolade</publisher>
-		<info name="programmer" value="Don Mattrick" />
-		<info name="programmer" value="Brad Gour" />
-		<info name="programmer" value="Allan Johanson" />
-		<info name="programmer" value="Erik Kiss" />
-		<info name="programmer" value="Amory Wong" />
-		<info name="programmer" value="Rick Friesen" />
-		<info name="programmer" value="Kris Hatlelid" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Grand Prix Circuit" is a 1989 racing simulation game developed by Don Mattrick, Brad Gour, Allan Johanson, Erik Kiss, Amory Wong, Rick Friesen, and Kris Hatlelid, and distributed by Accolade. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="grand prix circuit iigs (trex crack).2mg" size="819264" crc="a8877cb5" sha1="27b4c207a0bcda52c45bffd26302c2e5739e1152"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gwshoot">
-		<description>Great Western Shootout (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Britannica Software</publisher>
-		<info name="programmer" value="Scott Patterson" />
-		<info name="programmer" value="Matt Crysdale" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Great Western Shootout" is a 1989 action game developed by Scott Patterson and Matt Crysdale, and distributed by Britannica Software. -->
-		<!-- Disk 2 was a copy / back-up of the original Game Disk -->
-		<!-- Protection: Read block $63F with data markers AD AA D5 and compare read data against self generated data -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Game disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="great western shootout iigs - game disk (trex crack).2mg" size="819264" crc="1a4d1dd5" sha1="fe023cce106c4dfac512a215277de15a4eb6992e"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Back-up game disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="great western shootout iigs - back-up game disk (trex crack).2mg" size="819264" crc="1a4d1dd5" sha1="fe023cce106c4dfac512a215277de15a4eb6992e"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hacker2">
-		<description>Hacker II: The Doomsday Papers (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Activision</publisher>
-		<info name="programmer" value="Steve Cartwright" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Hacker II: The Doomsday Papers" is a 1987 simulation game developed by Steve Cartwright and distributed by Activision. -->
-		<!-- Protection: Bad block check for block $7 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="hacker ii - the doomsday papers iigs (trex crack).2mg" size="819264" crc="89341016" sha1="e4a4a4cf5e4a723de531cf90825bbe8b97115109"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hardball">
-		<description>Hardball! (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Accolade</publisher>
-		<info name="programmer" value="Dan Thompson" />
-		<info name="programmer" value="Ed Bogas" />
-		<info name="programmer" value="John Boechler" />
-		<info name="programmer" value="Mike Benna" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Hardball!" is a 1987 sports game developed by Dan Thompson, Ed Bogas, John Boechler, and Mike Benna, and distributed by Accolade. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="hardball iigs (trex crack).2mg" size="819264" crc="5dac9206" sha1="55ffa3a5931449ae6c6de43f52f288f7ef3258e5"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hostage">
-		<description>Hostage: Rescue Mission (cleanly cracked)</description>
-		<year>1990</year>
-		<publisher>Mindscape</publisher>
-		<info name="developer" value="Infogrames" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- simulation game -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="hostage - rescue mission iigs (trex crack).2mg" size="819264" crc="96b1c5b2" sha1="8c541ef7455a4cd5f9cb90093b158b618cdb131c"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="impmiss2">
-		<description>Impossible Mission II (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Epyx</publisher>
-		<info name="programmer" value="Istvan Cseri" />
-		<info name="programmer" value="Gyula Horvath" />
-		<info name="programmer" value="Pal Komondi" />
-		<info name="programmer" value="Sultan" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- action game -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="impossible mission ii iigs (trex crack).2mg" size="819264" crc="74ff8279" sha1="53daf3ca16a5f2bee0104e1d6688ce45ead599bc"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="instmus">
-		<description>Instant Music</description>
-		<year>1987</year>
-		<publisher>Electronic Arts</publisher>
-		<info name="programmer" value="Bob Campbell" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2026-01-05 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- audio program -->
-		<!-- Protection: Bad block check for block $63F -->
-		<!-- This archive includes the two add-on disks that were available separately. -->
-		<!-- Electronic Arts' It's Only Rock 'N' Roll -->
-		<!-- Electronic Arts' Hot & Cool Jazz Deluxe Library -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="instant music iigs (trex crack).2mg" size="819264" crc="df085767" sha1="6fea4620b343385de318963a8882f171b7dd9c51" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - It's Only Rock 'N' Roll Music disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="it's only rock'n'roll music disk.2mg" size="819264" crc="24e05c46" sha1="beadb4dd288cf1bd4d3532f344318a0a7de889db" />
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 3 - Hot &amp; Cool Jazz Deluxe Library disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="hot&amp;cool jazz deluxe library disk.2mg" size="819264" crc="89cc7d25" sha1="0e53bc7cb770a5512b874dbcac1be5db2afd4891" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="nicklaus">
-		<description>Jack Nicklaus' Greatest 18 Holes of Major Championship Golf (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Accolade</publisher>
-		<info name="programmer" value="Tony Manso" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Jack Nicklaus' Greatest 18 Holes of Major Championship Golf" is a 1989 sports game developed by Tony Manso and distributed by Accolade. -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-		<!-- This archive includes the four add-on disks that were available separately. -->
-		<!-- Jack Nicklaus Presents The Major Championship Courses Of 1989 (Includes: Oak Hill - U.S. Open, Royal Troon - British Open & Kemper Lakes - PGA courses) -->
-		<!-- Jack Nicklaus Presents The Major Championship Courses Of 1990 (Includes: Medinah Country Club, Shoal Creek Golf Club & St. Andrews (Old Course) courses) -->
-		<!-- Jack Nicklaus Presents The International Course Disk (Includes: St. Mellion Golf Club, St. Creek Golf Club & Australian Golf Club (Sydney) courses) -->
-		<!-- Jack Nicklaus Presents The Great Courses Of The U.S. Open (Includes: Baltusrol Golf Club, Oakmont Country Club & Pebble Beach courses) -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="jack nicklaus' greatest 18 holes of major championship golf iigs - disk 1 - program disk (trex crack).2mg" size="819264" crc="fe61da3c" sha1="534a006bc861f17340df146e7735c0c566862b34"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Course disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="jack nicklaus' greatest 18 holes of major championship golf iigs - disk 2 - course disk (trex crack).2mg" size="819264" crc="600ed4ff" sha1="42dbe44b840c9512455184c64e1fc0f9b29706d4"/>
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 3 - Championship Courses of 1989"/>
-			<dataarea name="flop" size="819264">
-				<rom name="jack nicklaus presents the major championship courses of 1989.2mg" size="819264" crc="a307775b" sha1="d7fe58a4c7111c738214fcb250568aa88b475557"/>
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 4 - Championship Courses of 1990"/>
-			<dataarea name="flop" size="819264">
-				<rom name="jack nicklaus presents the major championship courses of 1990.2mg" size="819264" crc="188c5562" sha1="fd40796422d7233e8d5f4ea607afadae737e69a3"/>
-			</dataarea>
-		</part>
-		<part name="flop5" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 5 - U.S. Open Course disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="jack nicklaus presents the greatest courses of the u.s. open.2mg" size="819264" crc="1474fa5b" sha1="8686611bdf391237540301bd5ec475e96194e453"/>
-			</dataarea>
-		</part>
-		<part name="flop6" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 6 - International Courses"/>
-			<dataarea name="flop" size="819264">
-				<rom name="jack nicklaus presents the international course Disk.2mg" size="819264" crc="6e19dc44" sha1="e8a393b2d17d98c6a63c4c38c16fb9b921ff1e92"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jigsaw">
-		<description>Jigsaw (version 1.4 - 022988) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Britannica Software</publisher>
-		<info name="programmer" value="Javier Rullan Ruano" />
-		<info name="programmer" value="Huibert Aalbers" />
-		<info name="version" value="1.4" />
-		<info name="usage" value="Requires a 768K Apple IIgs ROM01 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs ROM01 or later. -->
-		<!-- "Jigsaw" is a 1988 board game developed by Javier Rullan Ruano and Huibert Aalbers, and distributed by Britannica Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="jigsaw v1.4 (022988) iigs - disk 1 - program disk (trex crack).2mg" size="819264" crc="24002d06" sha1="b901d7064f5cd65b36f6b9d3767d9692142c8a6b"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Picture library"/>
-			<dataarea name="flop" size="819264">
-				<rom name="jigsaw v1.4 (022988) iigs - disk 2 - picture library (trex crack).2mg" size="819264" crc="a513c0cb" sha1="d62c330b6e2b1debe2b1b1e5b9d70c6295335658"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kquest">
-		<description>King's Quest - Quest for the Crown (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Sierra On-Line</publisher>
-		<info name="author" value="Roberta Williams, Al Lowe, Charles Tingley, Ken MacNeill, Chris Iden, Doug MacNeill, Greg Rowland, and Chris Iden" />
-		<info name="programmer" value="Carlos Escobar" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- Protection: Bad block check for block $634 -->
-		<!-- adventure game -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="king's quest - quest for the crown iigs - disk 1 (trex crack).2mg" size="819264" crc="fd8ec559" sha1="ecd22526d022247393e7eb69b76c2ef7e48bee5f"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="king's quest - quest for the crown iigs - disk 2 (trex crack).2mg" size="819264" crc="3f71d689" sha1="d961c10eba23a15f1df851e3d7150c0615d5b78d"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kquest2">
-		<description>King's Quest II - Romancing The Throne (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Sierra On-Line</publisher>
-		<info name="programmer" value="Roberta Williams" />
-		<info name="programmer" value="Jeff Stephenson" />
-		<info name="programmer" value="Chris Iden" />
-		<info name="programmer" value="Robert Heitman" />
-		<info name="programmer" value="Ken Williams" />
-		<info name="programmer" value="Sol Ackerman" />
-		<info name="programmer" value="Scott Murphy" />
-		<info name="programmer" value="Doug MacNeill" />
-		<info name="programmer" value="Mark Crowe" />
-		<info name="programmer" value="Al Lowe" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- Protection: Bad block check for block $634 -->
-		<!-- adventure game -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="king's quest ii - romancing the throne iigs - disk 1 (trex crack).2mg" size="819264" crc="b9471715" sha1="c5030ccde3bd9bbb7d4f2735733269ebcb0fc7b4"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="king's quest ii - romancing the throne iigs - disk 2 (trex crack).2mg" size="819264" crc="ca9f6588" sha1="d8f755e80185b6e6e7af43fcb23b72e497941da3"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kquest3">
-		<description>King's Quest III - To Hier is Human (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Sierra On-Line</publisher>
-		<info name="programmer" value="Roberta Williams" />
-		<info name="programmer" value="Al Lowe" />
-		<info name="programmer" value="Bob Kernaghan" />
-		<info name="programmer" value="Robert E. Heitman" />
-		<info name="programmer" value="Jeff Stephenson" />
-		<info name="programmer" value="Chris Iden" />
-		<info name="programmer" value="Doug MacNeill" />
-		<info name="programmer" value="Margaret Lowe" />
-		<info name="programmer" value="Dale Carlson" />
-		<info name="programmer" value="Jennifer Cobb" />
-		<info name="programmer" value="Chad Bye" />
-		<info name="programmer" value="Jeremy T. Cromwell" />
-		<info name="programmer" value="Carlos Escobar" />
-		<info name="programmer" value="Annette Childs" />
-		<info name="programmer" value="Greg Steffen" />
-		<info name="programmer" value="Ken Williams" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- Protection: Bad block check for block $634 -->
-		<!-- adventure game -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="king's quest iii - to hier is human iigs - disk 1 (trex crack).2mg" size="819264" crc="01929d52" sha1="1861372f15165e7e65c011a721f6488d576ad465"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="king's quest iii - to hier is human iigs - disk 2 (trex crack).2mg" size="819264" crc="55741036" sha1="5a57837dbd0a1dedb054b661fd2527edbc936011"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lasrforc">
-		<description>LaserForce (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Fanfare</publisher>
-		<info name="programmer" value="Javier Rullan" />
-		<info name="programmer" value="Huibert Aalbers" />
-		<info name="programmer" value="Thierry Méchain" />
-		<info name="programmer" value="Stéphane Renaudin" />
-		<info name="programmer" value="J-C. Doré" />
-		<info name="programmer" value="Olivier Guichaoua" />
-		<info name="usage" value="Requires a 1.25MB Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 1.25MB Apple IIgs. -->
-		<!-- "LaserForce" is a 1989 action game developed by Javier Rullan, Huibert Aalbers, Thierry Méchain, Stéphane Renaudin, J-C. Doré, and Olivier Guichaoua, and distributed by Fanfare. -->
-		<!-- Protection: Read block $63F with data markers AD AA D5 and compare read data against self generated data -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="laserforce iigs - disk 1 (trex crack).2mg" size="819264" crc="1d6599e8" sha1="631a55cd0efba1fec91674112b7a945f5e29b6b5"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="laserforce iigs - disk 2 (trex crack).2mg" size="819264" crc="fb6e89bb" sha1="660199a65ec7328fd0757f0581c07014d55f0c1a"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lsl1">
-		<description>Leisure Suit Larry in The Land of the Lounge Lizards (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Sierra On-Line</publisher>
-		<info name="programmer" value="Al Lowe" />
-		<info name="programmer" value="Chuck Benton" />
-		<info name="programmer" value="Mark Crowe" />
-		<info name="programmer" value="Jeff Stephenson" />
-		<info name="programmer" value="Chris Iden" />
-		<info name="programmer" value="Bob Heitman" />
-		<info name="programmer" value="Ken Williams" />
-		<info name="programmer" value="Carlos Escobar" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- Protection: Bad block check for block $634 -->
-		<!-- adventure game -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="leisure suit larry in the land of the lounge lizards iigs - disk 1 (trex crack).2mg" size="819264" crc="9d33056d" sha1="425395bdda7c2a80969d91e950edeb03a1b212c6"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="leisure suit larry in the land of the lounge lizards iigs - disk 2 (trex crack).2mg" size="819264" crc="e1fa7b20" sha1="cc16b8f8e06f6d22febe375a2ac1372ef81989dd"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="magicmth">
-		<description>Magical Myths (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Unicorn Software</publisher>
-		<info name="programmer" value="Stan Brewster" />
-		<info name="programmer" value="Joseph B. Hewitt IV" />
-		<info name="programmer" value="June Stark" />
-		<info name="usage" value="Requires a 768K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "Magical Myths" is a 1988 educational program developed by Stanley Brewster, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="magical myths iigs - disk 1 (trex crack).2mg" size="819264" crc="5857246f" sha1="2107f5fd5341414c1fd8e85474b0ca2a98f01748"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="magical myths iigs - disk 2 (trex crack).2mg" size="819264" crc="bf41ab59" sha1="1077a37340c212ff9e875a6c2deac4a3142770a0"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mancala">
-		<description>Mancala (version 1.0) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>California Dreams</publisher>
-		<info name="programmer" value="Jarek Olszewski" />
-		<info name="programmer" value="Maciej Markuszewski" />
-		<info name="programmer" value="Marcin Szostakowski" />
-		<info name="programmer" value="Dorota Błaszczak" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Macala" is a 1988 board game developed by Jarek Olszewski, Maciej Markuszewski, Marcin Szostakowski, and Dorota Błaszczak, and distributed by California Dreams. -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="mancala v1.0 iigs (trex crack).2mg" size="819264" crc="027b7cfb" sha1="e7772d01109045cb4f036a8a799fa18a01e2508e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="marble">
-		<description>Marble Madness (cleanly cracked)</description>
-		<year>1986</year>
-		<publisher>Electronic Arts</publisher>
-		<info name="programmer" value="Will Harvey" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<info name="programmer" value="Will Harvey"/>
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- action game -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="marble madness iigs (trex crack).2mg" size="819264" crc="d400455e" sha1="68526119d1f3b31e01d9b9b52a364323f88b2b58"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mathblst">
-		<description>Math Blaster Plus! (version 1.1) (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Davidson &amp; Associates</publisher>
-		<info name="author" value="Jan Davidson and Cathy Johnson" />
-		<info name="programmer" value="C.K. Haun" />
-		<info name="version" value="1.1" />
-		<info name="usage" value="Requires a 512K Apple IIgs ROM1 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs ROM1 or later. -->
-		<!-- educational program -->
-		<!-- Protection: Bad block check for block $308 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="math blaster plus v1.1 iigs (trex crack).2mg" size="819264" crc="96b3a909" sha1="5c7a1e8172f25ef328239971175b1f28a317fe2a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mathblsta" cloneof="mathblst">
-		<description>Math Blaster Plus! (version 1.0) (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Davidson &amp; Associates</publisher>
-		<info name="author" value="Jan Davidson and Cathy Johnson" />
-		<info name="programmer" value="C.K. Haun" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 512K Apple IIgs ROM1 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs ROM1 or later. -->
-		<!-- educational program -->
-		<!-- Protection: Bad block check for block $308 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="math blaster plus v1.0 iigs (trex crack).2mg" size="819264" crc="37120366" sha1="b6a585415cbac0f69182da911bf7ec298df5fcbc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mthwizrd">
-		<description>Math Wizard (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Unicorn Software</publisher>
-		<info name="programmer" value="William Demas" />
-		<info name="programmer" value="June Stark" />
-		<info name="programmer" value="Joseph B. Hewitt IV" />
-		<info name="usage" value="Requires a 768K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "Math Wizard" is a 1988 educational program developed by William Demas, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="math wizard iigs - disk 1 (trex crack).2mg" size="819264" crc="c02b08b4" sha1="be668ddd56133162ee24cff499bb8bb34590a6c8"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="math wizard iigs - disk 2 (trex crack).2mg" size="819264" crc="81550924" sha1="cc1291f2ba15ad234414b28af3fff34ddc975d49"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mavisbcn">
-		<description>Mavis Beacon Teaches Typing (version 1.8 21-Dec-88) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>The Software Toolworks</publisher>
-		<info name="version" value="1.8 21-Dec-88" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Mavis Beacon Teaches Typing" is a 1987 educational program developed and distributed by The Software Toolworks. -->
-		<!-- mavis.s16 dated 21-Dec-88 - Currently NOT archived: v1.5 (unknown program date) -->
-		<!-- Protection: Bad block check for block $63A -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="mavis beacon teaches typing v1.8 iigs - disk 1 - program disk (trex crack).2mg" size="819264" crc="273ae0b2" sha1="4bea4f4e1d7af7e2e9b69343f1e10c36ccd8cbd4"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Data disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="mavis beacon teaches typing v1.8 iigs - disk 2 - data disk (trex crack).2mg" size="819264" crc="bcc4a599" sha1="38ed4ebd59f8795ff32ab3e4f6052b91c2380a2c"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mavisbcna" cloneof="mavisbcn">
-		<description>Mavis Beacon Teaches Typing (version 1.2 16-Nov-87) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>The Software Toolworks</publisher>
-		<info name="version" value="1.2 16-Nov-88" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Mavis Beacon Teaches Typing" is a 1987 educational program developed and distributed by The Software Toolworks. -->
-		<!-- mavis.s16 dated 16-Nov-87 -->
-		<!-- Protection: Bad block check for block $63A -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="mavis beacon teaches typing v1.2 iigs - disk 1 - program disk (trex crack).2mg" size="819264" crc="c2306cf4" sha1="3dbf4c6ec0ec222958d34a60e997784e1bde97b5"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Data disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="mavis beacon teaches typing v1.2 iigs - disk 2 - data disk (trex crack).2mg" size="819264" crc="ad1aa08d" sha1="66cd3fe6817d70151c9fbcdae9ba42fa13a9cec5"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mean18">
-		<description>Mean 18 (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Accolade</publisher>
-		<info name="programmer" value="Rex Bradford" />
-		<info name="programmer" value="George Karalias" />
-		<info name="programmer" value="Mark Lesser" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Mean 18" is a 1987 sports game developed by Rex Bradford, George Karalias, and Mark Lesser, and distributed by Accolade. -->
-		<!-- This archive includes the three add-on disks that were available separately (Famous Courses Volume II, III, and IV). -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="mean 18 iigs - disk 1 - program disk (trex crack).2mg" size="819264" crc="9471fe69" sha1="2deee7df5ddf5a87dd418fb2973eb12fc2ba6a99"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Famous courses volume II"/>
-			<dataarea name="flop" size="819264">
-				<rom name="mean 18 iigs - disk 2 - famous courses volume ii.2mg" size="819264" crc="0cf5db03" sha1="c71365d8f90dad599de57f094b79d31b27c22394"/>
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 3 - Famous courses volume III"/>
-			<dataarea name="flop" size="819264">
-				<rom name="mean 18 iigs - disk 3 - famous courses volume iii.2mg" size="819264" crc="25ca69e1" sha1="801e200a3024f951f5d3fb38f4e1790c645f5009"/>
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 4 - Famous courses volume IV"/>
-			<dataarea name="flop" size="819264">
-				<rom name="mean 18 iigs - disk 4 - famous courses volume iv.2mg" size="819264" crc="6859eba1" sha1="556a7457104d22f500dc3429087053e9a1056ea5"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mercury">
-		<description>Mercury (version 1.0) (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>MECC</publisher>
-		<info name="partno" value="A249" />
-		<info name="programmer" value="John J. Krenz" />
-		<info name="programmer" value="Brian Nesse" />
-		<info name="programmer" value="Michael Palmquist" />
-		<info name="programmer" value="Steve Splinter" />
-		<info name="programmer" value="Michael Stein" />
-		<info name="programmer" value="Paul Wenker" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 1MB Apple IIgs ROM 01 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 1MB Apple IIgs ROM 01 or later. -->
-		<!-- "Mercury" is a 1989 desktop publishing program developed by John J. Krenz, Brian Nesse, Michael Palmquist, Steve Splinter, Michael Stein, and Paul Wenker, and distributed by MECC. -->
-		<!-- Protection: Bad block check for block $8 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - System disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="mercury v1.0 iigs - disk 1 - system (trex crack).2mg" size="819264" crc="d28c1950" sha1="aeef36625bfdd12e5a7df000222725a2126cfc5d"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="mercury v1.0 iigs - disk 2 - program (trex crack).2mg" size="819264" crc="2682521b" sha1="5fd3948bac00b1ca4e08c79ccb437483798f25a9"/>
-			</dataarea>
-		</part>
-
-	</software>
-	<software name="mulscribe">
-		<description>MultiScribe IIgs (version 3.01c) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>StyleWare</publisher>
-		<info name="developer" value="StyleWare" />
-		<info name="version" value="3.01c" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2025-01-25 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "MultiScrible" is a word-processor featuring the ability to use different fonts, print styles, colors as well as allowing you to add boxes, circles and other designs. -->
-		<!-- First marketed as "Scholastic MutiScrible GS by StyleWare", then it became StyleWare MultiScribe GS and eventually Beagle Bros Software acquired the StyleWare library and rebranded it as BeagleWrite GS. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program" />
-			<dataarea name="flop" size="819264">
-				<rom name="multiscribe gs v3.01c disk 1 - program (trex crack).2mg" size="819264" crc="d63e2246" sha1="8b5b7074f8967a79eb417cdb1a2648638473aa0f" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Utilities" />
-			<dataarea name="flop" size="819264">
-				<rom name="multiscribe gs v3.01c disk 2 - utilities (trex crack).2mg" size="819264" crc="c4a8d1b1" sha1="0e31bb265b031397f8b386916e791e618d3a891e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mcs">
-		<description>Music Construction Set (version 1.0) (cleanly cracked)</description>
-		<year>1986</year>
-		<publisher>Electronic Arts</publisher>
-		<info name="programmer" value="Will Harvey" />
-		<info name="programmer" value="Jim Nitchals" />
-		<info name="programmer" value="Doug Fulton" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 256K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 256K Apple IIgs. -->
-		<!-- audio program -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="music construction set v1.0 iigs (trex crack).2mg" size="819264" crc="278ef676" sha1="22808e777a37118c7cfd0bc639aac756843ce8ce"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="neuromnc">
-		<description>Neuromancer (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Interplay Productions</publisher>
-		<info name="programmer" value="Rebecca Heineman" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- adventure game -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="neuromancer iigs (trex crack).2mg" size="819264" crc="158c6c93" sha1="aee79701fdcbc9204f979087cd420c4b462c3b66"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="paperboy">
-		<description>Paperboy (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Mindscape</publisher>
-		<info name="developer" value="Tengen" />
-		<info name="usage" value="Requires a 256K Apple IIgs ROM 01." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 256K Apple IIgs ROM 01. -->
-		<!-- Protection: Bad block check for block $7 -->
-		<!-- arcade game -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="paperboy iigs (trex crack).2mg" size="819264" crc="a914d4a0" sha1="16990a565fdd157e58481113f30bb6725b38e958"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pipedrm">
-		<description>Pipe Dream (cleanly cracked)</description>
-		<year>1990</year>
-		<publisher>Lucasfilm Games</publisher>
-		<info name="developer" value="Visual Concepts" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Pipe Dream" is a 1990 board game developed by Visual Concepts and distributed by Lucasfilm Games. -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="pipe dream iigs (trex crack).2mg" size="819264" crc="f6e7fdba" sha1="79a4bc5ad012f5ede72bd7336a3f9b7a5b69523b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="qix">
-		<description>Qix (version 1.4? 16-Jan-90) (cleanly cracked)</description>
-		<year>1990</year>
-		<publisher>Taito</publisher>
-		<info name="programmer" value="Ryan Ridges" />
-		<info name="programmer" value="John Lund" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Qix" is a 1990 action game developed by Ryan Ridges and John Lund, and distributed by Taito. -->
-		<!-- Purportedly this is v1.4 - qix.s16 is dated 16-Jan-90 -->
-		<!-- Protection: Excessive zero bits after D5 CC AA header. Then 4 bytes are read through 4 loops with matches recorded. Read matches must equal less then 12 out of 16 reads -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="qix iigs (trex crack).2mg" size="819264" crc="fb968ce0" sha1="2479e40e4477d5a5066225222860cbbaf3235603" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="readrhym">
-		<description>Read and Rhyme (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Unicorn Software</publisher>
-		<info name="programmer" value="William Demas" />
-		<info name="usage" value="Requires a 768K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "Read and Rhyme" is a 1988 educational program developed by William Demas and distributed by Unicorn Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="read and rhyme iigs - disk 1 (trex crack).2mg" size="819264" crc="eb44fed7" sha1="95c4d134ee9b4da201d285fcee8aaedad1d2aa39"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="read and rhyme iigs - disk 2 (trex crack).2mg" size="819264" crc="629bdb2a" sha1="28de9f9b2cef057342a9b000d61d7cc40f32dbcf"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="readarma">
-		<description>Read-a-Rama (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Unicorn Software</publisher>
-		<info name="programmer" value="Stan Brewster" />
-		<info name="programmer" value="Joseph Hewitt" />
-		<info name="usage" value="Requires a 1MB Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 1MB Apple IIgs. -->
-		<!-- "Read-A-Rama" is a 1989 educational program developed by Stan Brewster and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Boot disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="read-a-rama iigs - disk 1 - boot disk (trex crack).2mg" size="819264" crc="5fdb496c" sha1="118e4c715ea81eb2b966dd3a5ef4b51f49ecb55e"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Level 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="read-a-rama iigs - disk 2 - level 1 (trex crack).2mg" size="819264" crc="a935524e" sha1="206ef9a96e4c6fcfec6993023122143c030def7b"/>
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 3 - Level 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="read-a-rama iigs - disk 3 - level 2 (trex crack).2mg" size="819264" crc="d7db9400" sha1="e982c1b621eaf5e6995294c74657c60d4ff96f2f"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rrabbit">
-		<description>Reader Rabbit (version 2.3) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>The Learning Company</publisher>
-		<info name="programmer" value="Pete Rowe" />
-		<info name="programmer" value="Aaron Weiss" />
-		<info name="usage" value="Requires a 256K Apple IIgs." />
-		<info name="version" value="2.3" />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 256K Apple IIgs. -->
-		<!-- educational program -->
-		<!-- Protection: Bad block check for block $7 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="reader rabbit v2.3 iigs (trex crack).2mg" size="819264" crc="b59cc9f2" sha1="3cb739ae7b6c2a967ea649f944cd3d41221f6ba4"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rrabbit22" cloneof="rrabbit">
-		<description>Reader Rabbit (version 2.2) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>The Learning Company</publisher>
-		<info name="programmer" value="Pete Rowe" />
-		<info name="programmer" value="Aaron Weiss" />
-		<info name="usage" value="Requires a 256K Apple IIgs." />
-		<info name="version" value="2.2" />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 256K Apple IIgs. -->
-		<!-- educational program -->
-		<!-- Protection: Bad block check for block $7 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="reader rabbit v2.2 iigs (trex crack).2mg" size="819264" crc="518994ed" sha1="48290f00ea231e7df039b89c74bafcf00ee28854"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rrabbit20" cloneof="rrabbit">
-		<description>Reader Rabbit (version 2.0) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>The Learning Company</publisher>
-		<info name="programmer" value="Pete Rowe" />
-		<info name="programmer" value="Aaron Weiss" />
-		<info name="usage" value="Requires a 256K Apple IIgs." />
-		<info name="version" value="2.0" />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2023-04-13 -->
-		<!-- It requires a 256K Apple IIgs. -->
-		<!-- educational program -->
-		<!-- Protection: Bad block check for block $7 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="reader rabbit v2.0 iigs (trex crack).2mg" size="819264" crc="0d7519e3" sha1="105012eccd7f066a0c3344b8f51b111fff7fc170"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="readandme">
-		<description>Reading and Me (version 1.0) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Davidson &amp; Associates</publisher>
-		<info name="programmer" value="Louis X. Savain" />
-		<info name="programmer" value="C. K. Haun" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- Protection: Bad block check for block $308 -->
-		<!-- educational program -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="reading and me v1.0 iigs - disk 1 - Program (trex crack).2mg" size="819264" crc="b8b3f7fe" sha1="aa86579b20b745639ad4df1f005f81f3b08e351c"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Data disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="reading and me v1.0 iigs - disk 2 - Data (trex crack).2mg" size="819264" crc="18fb2177" sha1="23ecb57d3d935a3c07f18e83bf00676193f9a10a"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="seastrke">
-		<description>Sea Strike (version 1.0) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>PBI Software</publisher>
-		<info name="programmer" value="Richard L. Seaborne" />
-		<info name="programmer" value="Jeff A. Lefferts" />
-		<info name="programmer" value="Mei-Ying Dell'Aquila" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Sea Strike" is a 1987 action game developed by Richard L. Seaborne, Jeff A. Lefferts, and Mei-Ying Dell'Aquila, and distributed by PBI Software. -->
-		<!-- Protection: Bad block check for block $7 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="sea strike v1.0 iigs (trex crack).2mg" size="819264" crc="66f0fc4b" sha1="53c69ba174b0a278ed734f60a10c6cf0adaa64d3"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="srvvly">
-		<description>Serve and Volley (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Accolade</publisher>
-		<info name="programmer" value="Rick Banks" />
-		<info name="programmer" value="Paul Butler" />
-		<info name="programmer" value="Ken Shimizu" />
-		<info name="programmer" value="Danny Chin" />
-		<info name="programmer" value="Paul Battersby" />
-		<info name="programmer" value="Jeffrey J. Sigler" />
-		<info name="programmer" value="Grant Campbell" />
-		<info name="programmer" value="Jay Stevens" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Serve and Volley" is a 1988 sports game developed by Rick Banks, Paul Butler, Ken Shimizu, Danny Chin, Paul Battersby, Jeffrey J. Sigler, Grant Campbell, and Jay Stevens, and distributed by Accolade. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="serve and volley iigs (trex crack).2mg" size="819264" crc="cd53d374" sha1="4f88eaf4855d6ff2bcc1b1c47c73c5a63a0c9cde"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="shanghai">
-		<description>Shanghai (version 15-Sep-87) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Activision</publisher>
-		<info name="programmer" value="Brodie Lockard" />
-		<info name="programmer" value="Ivan Manley" />
-		<info name="version" value="15-Sep-87" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Shanghai" is a 1987 board game developed by Brodie Lockard and Ivan Manley, and distributed by Activision. -->
-		<!-- start.s16 dated 15-Sep-87 -->
-		<!-- Protection: Bad block check for block $7 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="shanghai (15-sep-87) iigs (trex crack).2mg" size="819264" crc="df346841" sha1="04b4006b904d597c2ca848ce496bff86f433e268"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="shanghaia" cloneof="shanghai">
-		<description>Shanghai (version 20-Jan-87) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Activision</publisher>
-		<info name="programmer" value="Brodie Lockard" />
-		<info name="programmer" value="Ivan Manley" />
-		<info name="version" value="20-Jan-87" />
-		<info name="usage" value="Requires a 512K Apple IIgs ROM 01 or earlier." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs ROM 01 or earlier. -->
-		<!-- NOT Compatible with the Apple IIgs ROM03. -->
-		<!-- "Shanghai" is a 1987 board game developed by Brodie Lockard and Ivan Manley, and distributed by Activision. -->
-		<!-- start.s16 dated 20-Jan-87 -->
-		<!-- Protection: Bad block check for block $7 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="shanghai (20-jan-87) iigs (trex crack).2mg" size="819264" crc="c07f0cc5" sha1="03a08b9dbd14a7f672a203b27c90cc120621a4e5"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="showoff">
-		<description>ShowOff (version 1.1) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Brøderbund Software</publisher>
-		<info name="programmer" value="Serge Hervy" />
-		<info name="programmer" value="Jean-Claude Lévy" />
-		<info name="version" value="1.1" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "ShowOff" is a 1987 graphics program developed by Serge Hervy and Jean-Claude Lévy, and distributed by Brøderbund Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="showoff v1.1 iigs - disk 1 - program (trex crack).2mg" size="819264" crc="f0ab3f1c" sha1="33260ca055d031b237eca650c9bf054b341170b5"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Slide show disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="showoff iigs - disk 2 - slide show (trex crack).2mg" size="819264" crc="52348475" sha1="2fc72e0fcd0c398a56e4b4ef5e247c9961bc5a8c"/>
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 3 - Graphics collection - world events"/>
-			<dataarea name="flop" size="819264">
-				<rom name="showoff iigs - disk 3 - graphics collection - world events (trex crack).2mg" size="819264" crc="fa1a5ceb" sha1="b64402b6ace256145ba3bae31682520dca7c79af"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="showoffa" cloneof="showoff">
-		<description>ShowOff (Version 1.0) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Brøderbund Software</publisher>
-		<info name="programmer" value="Serge Hervy" />
-		<info name="programmer" value="Jean-Claude Lévy" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 512K Apple IIgs ROM 01 or earlier." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2023-04-13 -->
-		<!-- It requires a 512K Apple IIgs ROM 01 or earlier. -->
-		<!-- NOT Compatible with the Apple IIgs ROM03. -->
-		<!-- "ShowOff" is a 1987 graphics program developed by Serge Hervy and Jean-Claude Lévy, and distributed by Brøderbund Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="showoff v1.0 iigs - disk 1 - program (trex crack).2mg" size="819264" crc="b04c2763" sha1="f42601d9af1d1441ceac97299e12fd47cd8d5b0b"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Slide show disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="showoff iigs - disk 2 - slide show (trex crack).2mg" size="819264" crc="52348475" sha1="2fc72e0fcd0c398a56e4b4ef5e247c9961bc5a8c"/>
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 3 - Graphics collection - world events"/>
-			<dataarea name="flop" size="819264">
-				<rom name="showoff iigs - disk 3 - graphics collection - world events (trex crack).2mg" size="819264" crc="fa1a5ceb" sha1="b64402b6ace256145ba3bae31682520dca7c79af"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pirates">
-		<description>Sid Meier's Pirates! (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Microprose</publisher>
-		<info name="developer" value="Sid Meier" />
-		<info name="programmer" value="Dan Chang " />
-		<info name="programmer" value="Ed Magnin" />
-		<info name="usage" value="Requires a 256K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2023-02-24 -->
-		<!-- It requires a 256K Apple IIgs. -->
-		<!-- "Pirates!" is a 1987 simulation game developed by Sid Meier, programmed by Dan Chang & Ed Magnin, sound by Ken Lagace & Silas Warner, art by Micheal Haire, Murray Taylor & Max Remington and distributed by Microprose. -->
-		<!-- Protection: Modified ProDOS 8 and altered disk format -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="sid meier's pirates iigs (trex crack).2mg" size="819264" crc="5c53623d" sha1="551eb337651bee99d235a321ed921cf10efeee66" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="slntsvce">
-		<description>Silent Service (version 925.01) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Microprose</publisher>
-		<info name="programmer" value="Sid Meier" />
-		<info name="programmer" value="Ed Magnin" />
-		<info name="programmer" value="Jim Synoski" />
-		<info name="programmer" value="Michael Haire" />
-		<info name="programmer" value="Michele Mahan" />
-		<info name="programmer" value="Silas Warner" />
-		<info name="programmer" value="Al Roireau" />
-		<info name="programmer" value="Larry Martin" />
-		<info name="programmer" value="Edward Bever" />
-		<info name="version" value="925.01" />
-		<info name="usage" value="Requires a 256K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 256K Apple IIgs. -->
-		<!-- "Silent Service" is a 1987 simulation game developed by Sid Meier, Ed Magnin, Jim Synoski, Michael Haire, Michele Mahan, Silas Warner, Al Roireau, Larry Martin, and Edward Bever, and distributed by Microprose. -->
-		<!-- Protection: Bad block check for block $7 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="silent service v925.01 iigs (trex crack).2mg" size="819264" crc="1551b534" sha1="2f1c466c647bb448b081d69233f11d2c45092242"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="silpheed">
-		<description>Silpheed - Super Dogfighter (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Sierra On-Line</publisher>
-		<info name="programmer" value="John Rettig" />
-		<info name="programmer" value="Stuart Goldstein" />
-		<info name="programmer" value="Mark Seibert" />
-		<info name="programmer" value="Satoshi Uesaki" />
-		<info name="programmer" value="Nobuyuki Ogawa" />
-		<info name="programmer" value="Akira Eye" />
-		<info name="programmer" value="Fumihito Kasatani" />
-		<info name="programmer" value="Nobuyuki Aoshima" />
-		<info name="programmer" value="Hiromi Ohba" />
-		<info name="programmer" value="Takeshi Miyaji" />
-		<info name="programmer" value="Osamu Harada" />
-		<info name="programmer" value="Youichi Miyaji" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- action game -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="silpheed - super dogfighter iigs - disk 1 (trex crack).2mg" size="819264" crc="dd81fea4" sha1="14ad4ba49b5e4720ca067694c2d3fdcb8501e3e0"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="silpheed - super dogfighter iigs - disk 2 (trex crack).2mg" size="819264" crc="591e8595" sha1="44160e8078077aaa8e88d4e15338db0fc5098055"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="skatedie">
-		<description>Skate or Die! IIgs (version 1.1 07-Oct-88) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Electronic Arts</publisher>
-		<info name="programmer" value="Michael Kosaka" />
-		<info name="programmer" value="Stephen Landrum" />
-		<info name="programmer" value="David Bunch" />
-		<info name="programmer" value="Michelle Shelfer" />
-		<info name="usage" value="Requires a 512K Apple IIgs. Music requires 768K." />
-		<info name="version" value="1.1 07-Oct-88 - ROM 03 compatible" />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. Music requires 768K. -->
-		<!-- sports game -->
-		<!-- Patched to be compatible with ROM03 -->
-		<!-- sod.sys16 dated 07-Oct-88 -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="skate or die v1.1 iigs (trex crack).2mg" size="819264" crc="dde655cd" sha1="cf40c92a699cf9e7c79f1a25c3f22f32f5a28d46"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="skatediea" cloneof="skatedie">
-		<description>Skate or Die! IIgs (version 1.0 12-Aug-88) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Electronic Arts</publisher>
-		<info name="programmer" value="Michael Kosaka" />
-		<info name="programmer" value="Stephen Landrum" />
-		<info name="programmer" value="David Bunch" />
-		<info name="programmer" value="Michelle Shelfer" />
-		<info name="usage" value="Requires a 512K Apple IIgs. Music requires 768K." />
-		<info name="version" value="1.0 12-Aug-88 - ROM 03 compatible" />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2025-01-25, redump based on WOZ released on 2024-09-02 -->
-		<!-- It requires a 512K Apple IIgs. Music requires 768K. -->
-		<!-- sports game -->
-		<!-- Patched to be compatible with ROM03 -->
-		<!-- sod.sys16 dated 12-Aug-88 -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="skate or die v1.0 iigs (trex crack).2mg" size="819264" crc="f87d1ec3" sha1="9e28b572f9d53fd276066b3701de42d45ee9cc51"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="squest">
-		<description>Space Quest: The Sarien Encounter (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Sierra On-Line</publisher>
-		<info name="programmer" value="Scott Murphy" />
-		<info name="programmer" value="Mark Crowe" />
-		<info name="programmer" value="Jeff Stephenson" />
-		<info name="programmer" value="Chris Iden" />
-		<info name="programmer" value="Sol Ackerman" />
-		<info name="programmer" value="Ken Williams" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- adventure game -->
-		<!-- Protection: Bad block check for block $634 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="space quest - the sarien encounter iigs - disk 1 (trex crack).2mg" size="819264" crc="867688f8" sha1="a882bd87ec2843ab7c1409baf0cbfd32e91ac920"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="space quest - the sarien encounter iigs - disk 2 (trex crack).2mg" size="819264" crc="0ec7a0e8" sha1="e0fce1e36f99fcca7cfd9c3441269294154aa659"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="squest2">
-		<description>Space Quest II: Vohaul's Revenge (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Sierra On-Line</publisher>
-		<info name="programmer" value="Scott Murphy" />
-		<info name="programmer" value="Mark Crowe" />
-		<info name="programmer" value="Jeff Stephenson" />
-		<info name="programmer" value="Chris Iden" />
-		<info name="programmer" value="Sol Ackerman" />
-		<info name="programmer" value="Ken Williams" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- adventure game -->
-		<!-- Protection: Bad block check for block $634 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="space quest ii - vohual's revenge iigs - disk 1 (trex crack).2mg" size="819264" crc="4d463103" sha1="50df27602f17af84e2a2e4e3b221bd87aa98dad0"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="space quest ii - vohual's revenge iigs - disk 2 (trex crack).2mg" size="819264" crc="809875fc" sha1="d90165d8c51d7d54d8a17c4082e8688048950389"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="spiritex">
-		<description>Spirit of Excalibur (cleanly cracked)</description>
-		<year>1991</year>
-		<publisher>Virgin Mastertronic</publisher>
-		<info name="developer" value="Synergistic Software" />
-		<info name="usage" value="Requires a 1MB Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 1MB Apple IIgs. -->
-		<!-- "Spirit of Excalibur" is a 1991 adventure game developed by Synergistic Software and distributed by Virgin Mastertronic. -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="spirit of excalibur - disk 1 (trex crack).2mg" size="819264" crc="feb72edf" sha1="3aae270167a6402d7c029dc476a5d420ccf37cd9"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="spirit of excalibur - disk 2 (trex crack).2mg" size="819264" crc="4116b15e" sha1="7f8784313f36bc882207fdc1c15e40f956281734"/>
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 3"/>
-			<dataarea name="flop" size="819264">
-				<rom name="spirit of excalibur - disk 3 (trex crack).2mg" size="819264" crc="771e825c" sha1="5290f731aa988e6a34a3d6b284f653c02fb9e254"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="strybkwv">
-		<description>Storybook Weaver (version 1.0) (cleanly cracked)</description>
-		<year>1990</year>
-		<publisher>MECC</publisher>
-		<info name="partno" value="A275" />
-		<info name="programmer" value="Charolyn Kapplinger" />
-		<info name="programmer" value="Patricia Korn" />
-		<info name="programmer" value="John J. Krenz" />
-		<info name="programmer" value="Brian S. Nesse" />
-		<info name="programmer" value="Jean Sharp" />
-		<info name="programmer" value="Steve Zehm" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 1MB Apple IIgs ROM 01 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 1MB Apple IIgs ROM 01 or later. -->
-		<!-- "Storybook Weaver" is a 1990 educational program developed by Charolyn Kapplinger, Patricia Korn, John J. Krenz, Brian S. Nesse, Jean Sharp, and Steve Zehm, and distributed by MECC. -->
-		<!-- Protection: Bad block check for block $8 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - System disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="storybook weaver v1.0 iigs - disk 1 - system (trex crack).2mg" size="819264" crc="c6acd3b2" sha1="814f84b31bab49e29f80797dced8bc8692055e4e"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="storybook weaver v1.0 iigs - disk 2 - program (trex crack).2mg" size="819264" crc="5bafb45c" sha1="ddb7117bb3e096be90f638e538c0551409131bec"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="strywvwa">
-		<description>Storybook Weaver - World of Adventure (version 1.0) (cleanly cracked)</description>
-		<year>1991</year>
-		<publisher>MECC</publisher>
-		<info name="partno" value="A276" />
-		<info name="programmer" value="Patricia Korn" />
-		<info name="programmer" value="Brian S. Nesse" />
-		<info name="programmer" value="Dee Dee Roedel " />
-		<info name="programmer" value="Jean Sharp" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 1MB Apple IIgs ROM 01 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 1MB Apple IIgs ROM 01 or later. -->
-		<!-- "Storybook Weaver: World of Adventure" is a 1991 educational program developed by Patricia Korn, Brian S. Nesse, Dee Dee Roedel & Jean Sharp, and distributed by MECC. -->
-		<!-- Protection: Bad block check for block $8 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - System disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="storybook weaver - world of adventure v1.0 iigs - disk 1 - system (trex crack).2mg" size="819264" crc="589e942d" sha1="25ee4d9872302c2f235e3d775a0536a426e610d5"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="storybook weaver - world of adventure v1.0 iigs - disk 2 - program (trex crack).2mg" size="819264" crc="03e3ce87" sha1="86aca233933b10f3f25cdae7692375e60c3f6650"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="strywvmb">
-		<description>Storybook Weaver - World of Make-Believe (version 1.0) (cleanly cracked)</description>
-		<year>1991</year>
-		<publisher>MECC</publisher>
-		<info name="partno" value="A298" />
-		<info name="programmer" value="Charolyn Kapplinger" />
-		<info name="programmer" value="Patricia Korn" />
-		<info name="programmer" value="Jean Sharp" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 1MB Apple IIgs ROM 01 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 1MB Apple IIgs ROM 01 or later. -->
-		<!-- "Storybook Weaver: World of Make-Believe" is a 1991 educational program developed by Charolyn Kapplinger, Patricia Korn, and Jean Sharp, and distributed by MECC. -->
-		<!-- Protection: Bad block check for block $8 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - System disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="storybook weaver - world of make-believe v1.0 iigs - disk 1 - system (trex crack).2mg" size="819264" crc="54e1fb99" sha1="3fc4031f0bda54e2c73ffc3f2ac8a17c1f73fc71"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="storybook weaver - world of make-believe v1.0 iigs - disk 2 - program (trex crack).2mg" size="819264" crc="0c778c48" sha1="91b4b8d9264985b63eda4b34d3140d4414a800fa"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="strsoccr">
-		<description>Street Sports Soccer (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Epyx</publisher>
-		<info name="developer" value="Designer Software" />
-		<info name="usage" value="Requires a 512K Apple IIgs ROM 01 or earlier." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs ROM 01 or earlier. -->
-		<!-- NOT Compatible with the Apple IIgs ROM03. -->
-		<!-- sports game -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="street sports soccer iigs (trex crack).2mg" size="819264" crc="28862df6" sha1="8154843041284a59017021d4783cbe2c4f22c929"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ssicehock">
-		<description>Superstar Ice Hockey (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Mindscape</publisher>
-		<info name="programmer" value="Ed Ringler" />
-		<info name="programmer" value="Andrew Caldwell" />
-		<info name="programmer" value="Clayton Wishoff" />
-		<info name="programmer" value="Simon Ffinch" />
-		<info name="programmer" value="Ed Ringler Sr." />
-		<info name="programmer" value="Chris Oke" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- sports game -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="superstar ice hockey iigs (trex crack).2mg" size="819264" crc="6f405a10" sha1="41e963da1f389f94697c024190bbb89ac3c14421"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="arnights">
-		<description>Tales From The Arabian Nights (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Unicorn Software</publisher>
-		<info name="programmer" value="Stanley Brewster" />
-		<info name="programmer" value="June Stark" />
-		<info name="usage" value="Requires a 768K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "Tales From The Arabian Nights" is a 1988 educational program developed by Stanley Brewster, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="tales from the arabian nights iigs - disk 1 (trex crack).2mg" size="819264" crc="8cbcd73b" sha1="edcf50bf0feaf4aeea58b37249bcff6d0dd74416"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="tales from the arabian nights iigs - disk 2 (trex crack).2mg" size="819264" crc="f02bef73" sha1="f2637f0729b9adedb74e212f486c16b5e46acc34"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="taskfrce">
-		<description>Task Force (cleanly cracked)</description>
-		<year>1990</year>
-		<publisher>Britannica Software</publisher>
-		<info name="programmer" value="Scott L. Patterson" />
-		<info name="programmer" value="Matthew Crysdale" />
-		<info name="programmer" value="Gregory A. Thomas" />
-		<info name="usage" value="Requires a 1MB Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 1MB Apple IIgs. -->
-		<!-- "Task Force" is a 1990 action game developed by Scott L. Patterson, Matthew Crysdale, and Gregory A. Thomas, and distributed by Britannica Software. -->
-		<!-- Protection: Read block $63F with data markers AD AA D5 and compare read data against self generated data -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="task force iigs - disk 1 (trex crack).2mg" size="819264" crc="f6292a39" sha1="2b0f1e7316340adae862ec38f88832a40e258deb"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="task force iigs - disk 2 (trex crack).2mg" size="819264" crc="c4388a54" sha1="722b9cb8fb66a1eb1897efc18bdbd42a94d6d63d"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tetris">
-		<description>Tetris (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Spectrum HoloByte</publisher>
-		<info name="programmer" value="Roland Gustafsson" />
-		<info name="programmer" value="Sean B. Barger" />
-		<info name="programmer" value="Dan Geisler" />
-		<info name="programmer" value="Daniel L. Guerra" />
-		<info name="programmer" value="Jody Sather" />
-		<info name="programmer" value="Ed Bogas" />
-		<info name="programmer" value="Neil Cormia" />
-		<info name="programmer" value="Ty Roberts" />
-		<info name="programmer" value="Gary Clayton" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Tetris" is a 1988 action game developed by Roland Gustafsson, Sean B. Barger, Dan Geisler, Daniel L. Guerra, Jody Sather, Ed Bogas, Neil Cormia, Ty Roberts, and Gary Clayton, and distributed by Spectrum HoloByte. -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="tetris iigs (trex crack).2mg" size="819264" crc="84975e86" sha1="3d3ad67086d6284359b9512282556f174c529b44"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="adsinbad">
-		<description>The Adventures of Sinbad (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Unicorn Software</publisher>
-		<info name="programmer" value="Curt Toumanian" />
-		<info name="programmer" value="Steve Quinn" />
-		<info name="programmer" value="Jeff Hilbers" />
-		<info name="programmer" value="Rob Landeros" />
-		<info name="programmer" value="Russ Truelove" />
-		<info name="programmer" value="Bill Williams" />
-		<info name="programmer" value="Jim Simmons" />
-		<info name="programmer" value="Andrew Caldwell" />
-		<info name="programmer" value="Douglass Sharp" />
-		<info name="usage" value="Requires a 768K Apple IIgs ROM1 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "The Adventures of Sinbad" is a 1988 educational program developed by Stanley Brewster, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the adventures of sinbad iigs - disk 1 (trex crack).2mg" size="819264" crc="f91b3855" sha1="a003757ff7d4edb9d34e0252bc4dd8f190e29751"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the adventures of sinbad iigs - disk 2 (trex crack).2mg" size="819264" crc="db032980" sha1="ba2b15a79e9a03eb6cc3cf12eaea425f28e24973"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="td2">
-		<description>The Duel: Test Drive II (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Accolade</publisher>
-		<info name="programmer" value="Allan Johnson" />
-		<info name="programmer" value="Erik Kiss" />
-		<info name="programmer" value="Amory Wong" />
-		<info name="programmer" value="Don Mattrick" />
-		<info name="programmer" value="Rick Friesen" />
-		<info name="programmer" value="Bruce Dawson" />
-		<info name="programmer" value="Randy Dillon" />
-		<info name="programmer" value="Brad Gour" />
-		<info name="programmer" value="Kris Hatlelid" />
-		<info name="programmer" value="Chris Taylor" />
-		<info name="programmer" value="John Boechler" />
-		<info name="programmer" value="Tony Lee" />
-		<info name="programmer" value="Theresa Henry" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "The Duel: Test Drive II" is a 1989 racing simulation game developed by Allan Johnson, Erik Kiss, Amory Wong, Don Mattrick, Rick Friesen, Bruce Dawson, Randy Dillon, Brad Gour, Kris Hatlelid, Chris Taylor, John Boechler, Tony Lee, and Theresa Henry, and distributed by Accolade. -->
-		<!-- This archive includes the four add-on disks that were available separately (The Muscle Cars, The Supercars, California Challenge and European Challenge). -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the duel - test drive ii iigs (trex crack).2mg" size="819264" crc="24ca8ac2" sha1="3e73dabd7d07f6f38241e03d01404918904943b5"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Muscle cars disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the duel - test drive ii iigs - the muscle cars.2mg" size="819264" crc="4f7d4aaf" sha1="88a813bb0dbf50b0c11f979341dcc337495f45ce"/>
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_3_5">
-			<feature name="part_id" value="Supercars disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the duel - test drive ii iigs - the supercars.2mg" size="819264" crc="4c4b4713" sha1="313ccd55d4dd19c767fb51edbfd41036c34218f1"/>
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_3_5">
-			<feature name="part_id" value="California challenge disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the duel - test drive ii iigs - california challenge.2mg" size="819264" crc="81f34f15" sha1="1fc3a54f01053023086d435ecbd7be702bd93aa1"/>
-			</dataarea>
-		</part>
-		<part name="flop5" interface="floppy_3_5">
-			<feature name="part_id" value="European challenge disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the duel - test drive ii iigs - european challenge.2mg" size="819264" crc="c5ed070e" sha1="a1785f6e152d5d8e92335fb691d14a82a98d57ce"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="chsm2100">
-		<description>The Fidelity Chessmaster 2100 (version 1.1 17-Nov-88) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>The Software Toolworks</publisher>
-		<info name="programmer" value="Troy Heere" />
-		<info name="programmer" value="Mark Manyen" />
-		<info name="version" value="1.1 17-Nov-88" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "The Fidelity Chessmaster 2100" is a 1988 board game developed by Troy Heere and Mark Manyen, and distributed by The Software Toolworks. -->
-		<!-- cm2100.s16 dated 17-Nov-88 -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the fidelity chessmaster 2100 v1.1 iigs - disk 1 (trex crack).2mg" size="819264" crc="eeff8600" sha1="c6ce1d02383ccdbdab9d7b800e2079c046d873a3"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the fidelity chessmaster 2100 v1.1 iigs - disk 2 (trex crack).2mg" size="819264" crc="b5a1edda" sha1="02a6312ae3a72b8f8d08f27d8ac448df61c70790"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="chsm2100a" cloneof="chsm2100">
-		<description>The Fidelity Chessmaster 2100 (version 1.01 28-Sep-88) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>The Software Toolworks</publisher>
-		<info name="programmer" value="Troy Heere" />
-		<info name="programmer" value="Mark Manyen" />
-		<info name="version" value="1.01 28-Sep-88" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "The Fidelity Chessmaster 2100" is a 1988 board game developed by Troy Heere and Mark Manyen, and distributed by The Software Toolworks. -->
-		<!-- cm2100.s16 dated 28-Sep-88 -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the fidelity chessmaster 2100 v1.01 iigs - disk 1 (trex crack).2mg" size="819264" crc="e14b444b" sha1="3cc6b7ba5d58bdbde2331ee5f91f0c97fca47924"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the fidelity chessmaster 2100 v1.01 iigs - disk 2 (trex crack).2mg" size="819264" crc="470bcb76" sha1="f635bcd19ce4f48a2a274144256c7ddf1c63924d"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="grphstd">
-		<description>The Graphics Studio (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Accolade</publisher>
-		<info name="programmer" value="Greg Hospelhorn" />
-		<info name="programmer" value="Peter Wickman" />
-		<info name="programmer" value="Richard Antaki" />
-		<info name="usage" value="Requires a 768K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "The Graphics Studio" is a 1987 graphics program developed by Greg Hospelhorn, Peter Wickman, Richard Antaki, and distributed by Accolade. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="the graphics studio iigs (trex crack).2mg" size="819264" crc="dda653b4" sha1="a7aa41f2286a0f11c20acdac5b7fe4372114aad6"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="immortal">
-		<description>The Immortal (cleanly cracked)</description>
-		<year>1990</year>
-		<publisher>Electronic Arts</publisher>
-		<info name="programmer" value="Will Harvey" />
-		<info name="programmer" value="Ian Gooding" />
-		<info name="programmer" value="Michael Marcanted" />
-		<info name="programmer" value="Brett G. Durrett" />
-		<info name="programmer" value="Douglas Fulton" />
-		<info name="usage" value="Requires a 1MB Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 1MB Apple IIgs. -->
-		<!-- roleplaying game -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Play"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the immortal iigs - disk 1 - play (trex crack).2mg" size="819264" crc="d63f3611" sha1="5ddefe34356f43f4af3d8dff6c3c4dc4180fcdb0"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Graphics"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the immortal iigs - disk 2 - graphics (trex crack).2mg" size="819264" crc="c7a0e1a2" sha1="71d2811ed2c00f78de995e96f577874503d12a69"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kingchgo">
-		<description>The King of Chicago (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Cinemaware</publisher>
-		<info name="programmer" value="Doug Sharp" />
-		<info name="usage" value="Requires a 768K Apple IIgs ROM01 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs ROM01 or later. -->
-		<!-- "The King of Chicago" is a 1988 adventure game developed by Doug Sharp and distributed by Cinemaware. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Reel 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the king of chicago iigs - reel 1 (trex crack).2mg" size="819264" crc="6404e2c0" sha1="ddf23e10ca17712f943ed2e88e95ec6226599fe1"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Reel 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the king of chicago iigs - reel 2 (trex crack).2mg" size="819264" crc="74d2e6cc" sha1="4067dcaa7bd4d0a8efac6359677aeaf35b7bc916"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lstninja">
-		<description>The Last Ninja (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Activision</publisher>
-		<info name="programmer" value="Jeff Silverman" />
-		<info name="programmer" value="John Kroeckel" />
-		<info name="programmer" value="J. David Koch" />
-		<info name="programmer" value="Erol Otus" />
-		<info name="programmer" value="Doug Barnett" />
-		<info name="programmer" value="Russell Lieblich" />
-		<info name="programmer" value="Nicky Robinson" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "The Last Ninja" is a 1988 action game developed by Jeff Silverman, John Kroeckel, J. David Koch, Erol Otus, Doug Barnett, Russell Lieblich, and Nicky Robinson, and distributed by Activision. -->
-		<!-- Protection: Bad block check for block $63F -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="the last ninja iigs (trex crack).2mg" size="819264" crc="1935b58c" sha1="1b4542cd11fa2678a3647b83e35aec5f12a6633b"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="logcmstr">
-		<description>The Logic Master (version 1.5) (cleanly cracked)</description>
-		<year>1990</year>
-		<publisher>Unicorn Software</publisher>
-		<info name="programmer" value="William Demas" />
-		<info name="programmer" value="June Stark" />
-		<info name="version" value="1.5" />
-		<info name="usage" value="Requires a 1MB Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "The Logic Master" is a 1990 educational program developed by William Demas, and June Stark, and distributed by Unicorn Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the logic master v1.5 iigs - disk 1 (trex crack).2mg" size="819264" crc="01ac34b3" sha1="b18c2021f3360684a2156e59de69074c5c3d5b79"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the logic master v1.5 iigs - disk 2 (trex crack).2mg" size="819264" crc="ce00fefc" sha1="a842bb884202af66e865117290c24a279003263e"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="musstdio1">
-		<description>The Music Studio (version 1.0) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Activision</publisher>
-		<info name="programmer" value="Ric Forrester" />
-		<info name="programmer" value="Rick Parfitt" />
-		<info name="programmer" value="Peter Wickman" />
-		<info name="programmer" value="Paul Zuzelo" />
-		<info name="programmer" value="Sally Froud" />
-		<info name="programmer" value="Jeff Cable" />
-		<info name="programmer" value="Carl Bacani" />
-		<info name="programmer" value="Jim Inscore" />
-		<info name="programmer" value="Sydney Williams Lewis" />
-		<info name="programmer" value="Nancy Waisanen" />
-		<info name="programmer" value="Steve Young" />
-		<info name="programmer" value="Laura E. Singer" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<info name="version" value="1.0" />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2026-01-05 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- audio program -->
-		<!-- Protection: Bad block check for block $7 -->
-		<!-- Activision removed the copy protection for v2.0 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program disk" />
-			<dataarea name="flop" size="1296337">
-				<rom name="the music studio v1.0 iigs - disk 1 (trex crack).2mg" size="819264" crc="ea5c86fd" sha1="06b7f4dc8225c5bf0317dcca7ec9ae21093d9b17" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Additional songs and instruments disk" />
-			<dataarea name="flop" size="1296362">
-				<rom name="the music studio iigs - disk 2 - additional songs and instruments.2mg" size="819264" crc="610ea822" sha1="071329f3e8c303086a576fd47d85dccc4f57ee2d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ntsbalpha">
-		<description>The New Talking Stickybear Alphabet (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Optimum Resource</publisher>
-		<info name="developer" value="Optimum Resource" />
-		<info name="usage" value="Requires a 512K Apple IIgs ROM01 or later." />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2025-01-25 -->
-		<!-- It requires a 512K Apple IIgs ROM01 or later. -->
-		<!-- "The New Talking Stickybear Alphabet" is an educational program designed to teach children the alphabet through the use of graphics and speech -->
-		<!-- Protection: Unformatted track $03, Side $01 (bad blocks $54 through $5F) check -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1" />
-			<dataarea name="flop" size="819264">
-				<rom name="the new talking stickybear alphabet iigs disk 1 (trex crack).2mg" size="819264" crc="4f80d28b" sha1="c6b243cc8aa3c2b39658095c5a1b91bbdcd40629" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2" />
-			<dataarea name="flop" size="819264">
-				<rom name="the new talking stickybear alphabet iigs disk 2 (trex crack).2mg" size="819264" crc="35817368" sha1="1426cf78a664e0ec41128fec150c084e9d1f3874" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ntsbopp">
-		<description>The New Talking Stickybear Opposites (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Optimum Resource</publisher>
-		<info name="developer" value="Optimum Resource" />
-		<info name="usage" value="Requires a 512K Apple IIgs ROM01 or later." />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2025-01-25 -->
-		<!-- It requires a 512K Apple IIgs ROM01 or later. -->
-		<!-- "The New Talking Stickybear Opposites" is an educational program designed to teach children opposites through the use of graphics and speech -->
-		<!-- Protection: Unformatted track $03, Side $01 (bad blocks $54 through $5F) check -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="the new talking stickybear opposites iigs (trex crack).2mg" size="819264" crc="a2ce5ec8" sha1="0954c66f8858d26ce70c1926236b4115f705f2c5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ntsbshapes">
-		<description>The New Talking Stickybear Shapes (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Optimum Resource</publisher>
-		<info name="programmer" value="Richard Hefter" />
-		<info name="programmer" value="David Cunningham" />
-		<info name="programmer" value="Susan Dubicki" />
-		<info name="usage" value="Requires a 512K Apple IIgs ROM01 or later." />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2025-01-25 -->
-		<!-- It requires a 512K Apple IIgs ROM01 or later. -->
-		<!-- "The New Talking Stickybear Shapes" is an educational program designed to teach children basic shapes through the use of graphics and speech -->
-		<!-- Protection: Unformatted track $03, Side $01 (bad blocks $54 through $5F) check -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="the new talking stickybear shapes iigs (trex crack).2mg" size="819264" crc="f52125b9" sha1="93967102bb9642aba3607291cf30d6e0a1a01c5e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="printshp">
-		<description>The Print Shop (version 1.0) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Brøderbund Software</publisher>
-		<info name="programmer" value="David Balsam" />
-		<info name="programmer" value="Martin Kahn" />
-		<info name="programmer" value="Corey Kosak" />
-		<info name="programmer" value="Ann E. Kronen" />
-		<info name="programmer" value="Susan E. Schlangen" />
-		<info name="programmer" value="Richard Whittaker" />
-		<info name="programmer" value="Michelle McBride" />
-		<info name="programmer" value="Don Albrecht" />
-		<info name="programmer" value="Leila Bronstein" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 512K Apple IIgs ROM 01 or earlier." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs ROM 01 or earlier. -->
-		<!-- NOT Compatible with the Apple IIgs ROM03. -->
-		<!-- "The Print Shop IIgs" is a 1987 graphics program developed by David Balsam, Martin Kahn, Corey Kosak, Ann E. Kronen, Susan E. Schlangen, Richard Whittaker, Michelle McBride, Don Albrecht, and Leila Bronstein, and distributed by Brøderbund Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="the print shop v1.0 iigs (trex crack).2mg" size="819264" crc="0b761d41" sha1="69b56345568b39fd8aa59455b44a341a600c848e"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="thrdcrir">
-		<description>The Third Courier (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Accolade</publisher>
-		<info name="programmer" value="Carol Manley" />
-		<info name="programmer" value="Ivan Manley" />
-		<info name="programmer" value="Mike Branham" />
-		<info name="programmer" value="Robert Clardy" />
-		<info name="programmer" value="Chris Barker" />
-		<info name="programmer" value="Scott Wallin" />
-		<info name="programmer" value="Miik Nichols" />
-		<info name="programmer" value="Sheldon Safir" />
-		<info name="programmer" value="Mark Wallace" />
-		<info name="usage" value="Requires a 768K Apple IIgs ROM01 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs ROM01 or later. -->
-		<!-- "The Third Courier" is a 1989 adventure game developed by Carol Manley, Ivan Manley, Mike Branham, Robert Clardy, Chris Barker, Scott Wallin, Miik Nichols, Sheldon Safir, and Mark Wallace, and distributed by Accolade. -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the third courier iigs - disk 1 (trex crack).2mg" size="819264" crc="a3a2c00f" sha1="3773681ec07b65085e6e0e311974c0ad28e5f7c7"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the third courier iigs - disk 2 (trex crack).2mg" size="819264" crc="619ff292" sha1="521c9c171ab84cc6a670e541502890c605db3df8"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="twrmyrgl">
-		<description>The Tower of Myraglen (version 1.0) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>PBI Software</publisher>
-		<info name="programmer" value="Richard L. Seaborne" />
-		<info name="programmer" value="Jeff A. Lamberts" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 768K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "The Tower of Myraglen" is a 1987 roleplaying game developed by Richard L. Seaborne and Jeff A. Lamberts, and distributed by PBI Software. -->
-		<!-- Protection: Bad block check for block $7 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Start-up disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the tower of myraglen v1.0 iigs - disk 1 - start-up disk (trex crack).2mg" size="819264" crc="ec1b6795" sha1="8bb9f1a286fe7ec3abcfae2fddf3b3da5eab1507"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the tower of myraglen v1.0 iigs - disk 2 - program disk (trex crack).2mg" size="819264" crc="2173bd50" sha1="8ed4b7fde77680225a0d124d079eacd49563c8bd"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="3stooges">
-		<description>The Three Stooges (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Cinemaware</publisher>
-		<info name="programmer" value="John Cutter" />
-		<info name="programmer" value="Robert Jacob" />
-		<info name="programmer" value="Phyllis Jacob" />
-		<info name="programmer" value="Ed Magnin" />
-		<info name="programmer" value="Russell Truelove" />
-		<info name="programmer" value="Jim Simmons" />
-		<info name="programmer" value="Patrick Cook" />
-		<info name="usage" value="Requires an 1.25MB Apple IIgs ROM01 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 1.25MB Apple IIgs ROM01 or later. -->
-		<!-- "The Three Stooges" is a 1987 adventure game developed by John Cutter, Robert Jacob, Phyllis Jacob, Ed Magnin, Russell Truelove, Jim Simmons, and Patrick Cook and distributed by Cinemaware. -->
-		<!-- Protection: Bad block check for block $10D -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Reel 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="The Three Stooges IIgs - Reel 1 (trex crack).2mg" size="819264" crc="bdde6b7f" sha1="ae839c996f29692326f06066e1d64082120d1f5d"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Reel 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="The Three Stooges IIgs - Reel 2 (trex crack).2mg" size="819264" crc="d1d46abd" sha1="64bdaea99f69fdff61dade0dbe6f2e57668e70a4"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wndanimk">
-		<description>The Wonders of the Animal Kingdom (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Unicorn Software</publisher>
-		<info name="programmer" value="Stan Brewster" />
-		<info name="programmer" value="Joseph Hewitt" />
-		<info name="programmer" value="June Stark" />
-		<info name="usage" value="Requires a 1MB Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 1MB Apple IIgs. -->
-		<!-- "The Wonders of the Animal Kingdom" is a 1989 educational program developed by Stan Brewster, Joseph B. Hewitt IV, and June Stark, and distributed by Unicorn Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the wonders of the animal kingdom iigs - disk 1 (trex crack).2mg" size="819264" crc="d577eacc" sha1="80fd89fe895c4a40ba9b137804307924308cd0b8"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="the wonders of the animal kingdom iigs - disk 2 (trex crack).2mg" size="819264" crc="56212d49" sha1="1126a5de1294aa72dcacba28d3ee32c6754528f8"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wordmstr">
-		<description>The Word Master (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Unicorn Software</publisher>
-		<info name="programmer" value="William Demas" />
-		<info name="programmer" value="Joseph Hewitt" />
-		<info name="usage" value="Requires a 1MB Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 1MB Apple IIgs. -->
-		<!-- "The Word Master" is a 1989 educational program developed by William Demas and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="the word master iigs (trex crack).2mg" size="819264" crc="a1223d2c" sha1="c22fe72a7f88f7dbea37970f77fd0555589016f3"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="thexder">
-		<description>Thexder (version 2.7) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Sierra On-Line</publisher>
-		<info name="programmer" value="H. Godai" />
-		<info name="programmer" value="S. Uesaka" />
-		<info name="programmer" value="Michael D. Branham" />
-		<info name="programmer" value="Robert C. Clardy" />
-		<info name="programmer" value="John P. Conley" />
-		<info name="programmer" value="Lloyd Ollmann, Jr." />
-		<info name="programmer" value="Michael Ormsby" />
-		<info name="version" value="2.7" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- action game -->
-		<!-- Protection: Bad block check for block $634 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="thexder v2.7 iigs (trex crack).2mg" size="819264" crc="7fa5ad73" sha1="acb227363d426c86ab5ac80c126fc430616cb535"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="thexder10" cloneof="thexder">
-		<description>Thexder (version 1.0) (trex crack) (No OS, not self booting)</description>
-		<year>1987</year>
-		<publisher>Sierra On-Line</publisher>
-		<info name="programmer" value="H. Godai" />
-		<info name="programmer" value="S. Uesaka" />
-		<info name="programmer" value="Michael D. Branham" />
-		<info name="programmer" value="Robert C. Clardy" />
-		<info name="programmer" value="John P. Conley" />
-		<info name="programmer" value="Lloyd Ollmann, Jr." />
-		<info name="programmer" value="Michael Ormsby" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- action game -->
-		<!-- Original release by Sierra On-Line - Did NOT come with OS and was NOT self bootable -->
-		<!-- The file "othexder" had been undeleted (and cracked) and is closer to v2.7 in how it's demo sounds fade -->
-		<!-- Protection: Bad block check for block $634 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="thexder v1.0 iigs (trex crack).2mg" size="819264" crc="5a105720" sha1="31061b4561c967d824936c94ce882f2efcb017da"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="topdraw">
-		<description>TopDraw (version 1.01A 04-Aug-87) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>StyleWare</publisher>
-		<info name="programmer" value="Robert A. Hearn" />
-		<info name="programmer" value="Jeff G. Erickson" />
-		<info name="version" value="1.01A 04-Aug-87" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2025-01-25 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "TopDraw" is a professional object-oriented graphics drawing environment. Beagle Bros Software later acquired the StyleWare library and rebranded TopDraw as BeagleDraw. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="topdraw v1.01a iigs (trex crack).2mg" size="819264" crc="d7cf235e" sha1="b488b0cef54cb71f447a0d6b508f86220cb09d4d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="topdraw100a" cloneof="topdraw">
-		<description>TopDraw (version 1.00A 12-Jul-87) (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>StyleWare</publisher>
-		<info name="programmer" value="Robert A. Hearn" />
-		<info name="programmer" value="Jeff G. Erickson" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<info name="version" value="1.00A 12-Jul-87" />
-		<sharedfeat name="compatibility" value="A2GS" />
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- graphics program -->
-		<!-- "TopDraw" is a professional object-oriented graphics drawing environment. Beagle Bros Software later acquired the StyleWare library and rebranded TopDraw as BeagleDraw. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="topdraw v1.00a iigs (trex crack).2mg" size="819264" crc="39e7967f" sha1="35746bbc2232251d96264989705a6e6286bafef5"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="triango">
-		<description>TrianGo (version 1.1 12-Dec-88) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>California Dreams</publisher>
-		<info name="programmer" value="Staszek Bartkowski" />
-		<info name="programmer" value="Marcin Szostakowski" />
-		<info name="programmer" value="Maciej Markuszewski" />
-		<info name="programmer" value="Dorota Błaszczak" />
-		<info name="version" value="1.1 12-Dec-88" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2026-01-05 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "TrianGo" is a 1988 board game developed by Staszek Bartkowski, Marcin Szostakowski, Maciej Markuszewski, Dorota Błaszczak, and distributed by California Dreams. -->
-		<!-- triango.sys16 dated 12-Dec-88 -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="triango v1.1 iigs (trex crack).2mg" size="819264" crc="f8d47b34" sha1="aacc5f57dded29acd945d0f46b046415b2e6e2fb"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="triangoa" cloneof="triango">
-		<description>TrianGo (version 1.0 02-Oct-88) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>California Dreams</publisher>
-		<info name="programmer" value="Staszek Bartkowski" />
-		<info name="programmer" value="Marcin Szostakowski" />
-		<info name="programmer" value="Maciej Markuszewski" />
-		<info name="programmer" value="Dorota Błaszczak" />
-		<info name="version" value="1.0 02-Oct-88" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "TrianGo" is a 1988 board game developed by Staszek Bartkowski, Marcin Szostakowski, Maciej Markuszewski, Dorota Błaszczak, and distributed by California Dreams. -->
-		<!-- triango.sys16 dated 02-Oct-88 -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="triango v1.0 iigs (trex crack).2mg" size="819264" crc="719968cf" sha1="8cfcb54548794c179d7e394f1ada2f53f0578a5e"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="uninvite">
-		<description>Uninvited (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>ICOM Simulations</publisher>
-		<info name="programmer" value="Fred Allen" />
-		<info name="programmer" value="David Marsh" />
-		<info name="programmer" value="Karl Roelofs" />
-		<info name="programmer" value="Todd Squires" />
-		<info name="programmer" value="Craig Erickson" />
-		<info name="programmer" value="Steven Hays" />
-		<info name="programmer" value="Terry Schulenburg" />
-		<info name="programmer" value="Darin Adler" />
-		<info name="programmer" value="Jay Zipnick" />
-		<info name="programmer" value="Waldemar Horwat" />
-		<info name="programmer" value="Mark Waterman" />
-		<info name="programmer" value="Tod Zipnick" />
-		<info name="programmer" value="Billy Wolf" />
-		<info name="usage" value="Requires a 768K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "Uninvited" is a 1988 adventure game developed by Fred Allen, David Marsh, Karl Roelofs, Todd Squires, Craig Erickson, Steven Hays, Terry Schulenburg, Darin Adler, Jay Zipnick, Waldemar Horwat, Mark Waterman, Tod Zipnick, and Billy Wolf, and distributed by ICOM Simulations. -->
-		<!-- Protection: Bad block check for block $7 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - System disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="uninvited iigs - disk 1 - system disk (trex crack).2mg" size="819264" crc="e76d0516" sha1="1ce51656aa8274517d3ecd0314b55294e76023e2"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="uninvited iigs - disk 2 - program disk (trex crack).2mg" size="819264" crc="dcd37fdd" sha1="486497733c8a341982709c87fc864570d630da7d"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="usageogr">
-		<description>USA GeoGraph (Version 1.0) (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>MECC</publisher>
-		<info name="programmer" value="Nelson Whyatt" />
-		<info name="programmer" value="Paul R. Wenker" />
-		<info name="programmer" value="Wayne Studer" />
-		<info name="programmer" value="Steven D. Splinter" />
-		<info name="programmer" value="John L. Krenz" />
-		<info name="programmer" value="Charolyn Kapplinger" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 768K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2023-04-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "USA GeoGraph" is a 1989 educational program developed by Nelson Whyatt, Paul R. Wenker, Wayne Studer, Steven D. Splinter, John L. Krenz, and Charolyn Kapplinger, and distributed by MECC Software. -->
-		<!-- Protection: Bad block check for block $8 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="usa geograph v1.0 iigs - disk 1 - program (trex crack).2mg" size="819264" crc="f968d252" sha1="ebda6798c67d277a15314b97d116f40e6b072ccd" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Information disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="usa geograph v1.0 iigs - disk 2 - Information (trex crack).2mg" size="819264" crc="c5bc2c2c" sha1="6ef5b7be7d2a813387cfb4fa381c76d40d94c6ca" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="vgscraps">
-		<description>Vegas Craps (version 1.0) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>California Dreams</publisher>
-		<info name="programmer" value="Krzysztof Koziarski" />
-		<info name="programmer" value="Maciej Markuszewski" />
-		<info name="programmer" value="Marcin Szostakowski" />
-		<info name="programmer" value="Dorota Błaszczak" />
-		<info name="version" value="1.0" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Vegas Gambler" is a 1988 simulation game developed by Krzysztof Koziarski, Maciej Markuszewski, Marcin Szostakowski, and Dorota Błaszczak, and distributed by California Dreams. -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="vegas craps v1.0 iigs (trex crack).2mg" size="819264" crc="cf206b2a" sha1="eb1731663bd71f9beb0e66f129e3103ac236b629" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="vegasgmb">
-		<description>Vegas Gambler (version 1.1 25-Jul-88) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>California Dreams</publisher>
-		<info name="programmer" value="Marek Jackiewicz" />
-		<info name="programmer" value="Andrzej Miciłkiewicz" />
-		<info name="programmer" value="Marcin Szostakowski" />
-		<info name="programmer" value="Maciej Markuszewski" />
-		<info name="programmer" value="Dorota Błaszczak" />
-		<info name="version" value="1.1 25-Jul-88" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Vegas Gambler" is a 1988 simulation game developed by Marek Jackiewicz, Andrzej Miciłkiewicz, Marcin Szostakowski, Maciej Markuszewski, and Dorota Błaszczak, and distributed by California Dreams. -->
-		<!-- gambler.sys16 dated 25-Jul-88 -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="vegas gambler v1.1 iigs (trex crack).2mg" size="819264" crc="53f1a66e" sha1="f49918fbe8a32f83a17558e1764b14a0b26ca35c"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="vegasgmba" cloneof="vegasgmb">
-		<description>Vegas Gambler (version 1.0 07-Jun-88) (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>California Dreams</publisher>
-		<info name="programmer" value="Marek Jackiewicz" />
-		<info name="programmer" value="Andrzej Miciłkiewicz" />
-		<info name="programmer" value="Marcin Szostakowski" />
-		<info name="programmer" value="Maciej Markuszewski" />
-		<info name="programmer" value="Dorota Błaszczak" />
-		<info name="version" value="1.0 07-Jun-88" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Vegas Gambler" is a 1988 simulation game developed by Marek Jackiewicz, Andrzej Miciłkiewicz, Marcin Szostakowski, Maciej Markuszewski, and Dorota Błaszczak, and distributed by California Dreams. -->
-		<!-- gambler.sys16 dated 07-Jun-88 -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="vegas gambler v1.0 iigs (trex crack).2mg" size="819264" crc="fb0db877" sha1="89662ac60bde13b8f54db4730a9fd3ee4d5c6b3e"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="warmidle">
-		<description>War in Middle Earth (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Melbourne House</publisher>
-		<info name="programmer" value="Ron Harris" />
-		<info name="programmer" value="Robert Clardy" />
-		<info name="programmer" value="Alan B. Clark" />
-		<info name="programmer" value="Graeme Devine" />
-		<info name="programmer" value="Mike Branham" />
-		<info name="programmer" value="Lloyd Ollmann, Jr." />
-		<info name="programmer" value="John Conley" />
-		<info name="programmer" value="Jim McBride" />
-		<info name="programmer" value="Michael Park" />
-		<info name="programmer" value="David Schroeder" />
-		<info name="programmer" value="Michael Ormsby" />
-		<info name="programmer" value="Mike Christy" />
-		<info name="programmer" value="Ann Dickens Clardy" />
-		<info name="programmer" value="Marcus Streets" />
-		<info name="programmer" value="Mark Riley" />
-		<info name="programmer" value="Mike Singleton" />
-		<info name="usage" value="Requires a 768K Apple IIgs ROM01 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 768K Apple IIgs ROM01 or later. -->
-		<!-- "War in Middle Earth" is a 1989 adventure game developed by Ron Harris, Robert Clardy, Alan B. Clark, Graeme Devine, Mike Branham, Lloyd Ollmann, Jr., John Conley, Jim McBride, Michael Park, David Schroeder, Michael Ormsby, Mike Christy, Ann Dickens Clardy, Marcus Streets, Mark Riley, and Mike Singleton, and distributed by Melbourne House. -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="war in middle earth - disk 1 (trex crack).2mg" size="819264" crc="8f6287f7" sha1="4864416d025f1b9b17aba10b8ce47c1075b84279"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="war in middle earth - disk 2 (trex crack).2mg" size="819264" crc="5ced6c65" sha1="83aa06b12b3741e18028da966aa317dce7001d89"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="carmnusa">
-		<description>Where in the U.S.A. is Carmen Sandiego? (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Brøderbund Software</publisher>
-		<info name="programmer" value="Gene Portwood" />
-		<info name="programmer" value="Lauren Elliot" />
-		<info name="programmer" value="Peter Adams" />
-		<info name="programmer" value="Leila Bronstein" />
-		<info name="programmer" value="Julie Glavin" />
-		<info name="programmer" value="Michelle McBride" />
-		<info name="programmer" value="Dan Guerra" />
-		<info name="programmer" value="Les Pardue" />
-		<info name="programmer" value="Bevan Hulfenstein" />
-		<info name="programmer" value="Louis Evans" />
-		<info name="programmer" value="Tom Rettig" />
-		<info name="usage" value="Requires a 1MB Apple IIgs ROM 01 or later." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 1MB Apple IIgs ROM 01 or later. -->
-		<!-- "Where in the U.S.A. is Carmen Sandiego?" is a 1989 educational game developed by Gene Portwood, Lauren Elliot, Peter Adams, Leila Bronstein, Julie Glavin, Michelle McBride, Dan Guerra, Les Pardue, Bevan Hulfenstein, Louis Evans, and Tom Rettig, and distributed by Brøderbund Software. -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="where in the u.s.a. is carmen sandiego iigs - disk 1 (trex crack).2mg" size="819264" crc="43b00548" sha1="6b6a07afdd81acb4bb6493f0248004a449854a4f"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="where in the u.s.a. is carmen sandiego iigs - disk 2 (trex crack).2mg" size="819264" crc="21ccbf7c" sha1="cd74b2163039f448c5b765a6f3d12264df2a3910"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="carmnwld">
-		<description>Where in the World is Carmen Sandiego? (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Brøderbund Software</publisher>
-		<info name="programmer" value="Gene Portwood" />
-		<info name="programmer" value="Lauren Elliott" />
-		<info name="programmer" value="Loring Vogel" />
-		<info name="programmer" value="Leila Bronstein" />
-		<info name="programmer" value="Don Albrecht" />
-		<info name="programmer" value="Michelle McBride" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Where in the World is Carmen Sandiego?" is a 1989 educational game developed by Gene Portwood, Lauren Elliott, Loring Vogel, Leila Bronstein, Don Albrecht, and Michelle McBride, and distributed by Brøderbund Software. -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="819264">
-				<rom name="where in the world is carmen sandiego iigs - disk 1 (trex crack).2mg" size="819264" crc="5953ba60" sha1="ee78c790a74b8ea401eb7ea66f91651d9e5286d7"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
-			<dataarea name="flop" size="819264">
-				<rom name="where in the world is carmen sandiego iigs - disk 2 (trex crack).2mg" size="819264" crc="93417ba2" sha1="76b70ebd2d0974ba3b77de31e0f3f96aee6ed332"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wingames">
-		<description>Winter Games (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Epyx</publisher>
-		<info name="developer" value="Westwood Studios" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- sports game -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="winter games iigs (trex crack).2mg" size="819264" crc="03f522af" sha1="467d2782f572c107f2b9fa7789761d789ce21763"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wldgames">
-		<description>World Games (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Epyx</publisher>
-		<info name="developer" value="Westwood Studios" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- sports game -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="world games iigs (trex crack).2mg" size="819264" crc="6b94c2b7" sha1="34bb9fbd79847d2cbf7c1ad9ba087faa986a16a0"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wldgeogr">
-		<description>World GeoGraph (Version 1.3) (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>MECC</publisher>
-		<info name="programmer" value="Charolyn Kapplinger" />
-		<info name="programmer" value="John L. Krenz" />
-		<info name="programmer" value="Diane Portner" />
-		<info name="programmer" value="Steven D. Splinter" />
-		<info name="programmer" value="Wayne Studer" />
-		<info name="programmer" value="Paul R. Wenker" />
-		<info name="programmer" value="Nelson Whyatt" />
-		<info name="version" value="1.3" />
-		<info name="usage" value="Requires a 768K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2023-04-13 -->
-		<!-- It requires a 768K Apple IIgs. -->
-		<!-- "USA GeoGraph" is a 1989 educational program developed by Charolyn Kapplinger, John L. Krenz, Diane Portner, Steven D. Splinter, Wayne Studer, Paul R. Wenker, and Nelson Whyatt, and distributed by MECC Software. -->
-		<!-- Protection: Bad block check for block $8 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1 - Program disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="world geograph v1.3 iigs - disk 1 - program (trex crack).2mg" size="819264" crc="a296d62a" sha1="15aa6627a08b3c4f3d1c9e7651218311f07e481e" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2 - Information disk"/>
-			<dataarea name="flop" size="819264">
-				<rom name="world geograph v1.3 iigs - disk 2 - Information (trex crack).2mg" size="819264" crc="1ec2c293" sha1="6131f8ea4938f9f180e8a5f0a67d5f8f38d90e22" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wltrgolf">
-		<description>World Tour Golf (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Electronic Arts</publisher>
-		<info name="author" value="Evan and Nicky Robinson and Paul Reiche III" />
-		<info name="programmer" value="John Selhorst" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- sports game -->
-		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="world tour golf iigs (trex crack).2mg" size="819264" crc="bf54fe36" sha1="3b1082b75860d10493c9015c5fd22ef3150c686b"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wcelite">
-		<description>Writer's Choice Elite (cleanly cracked)</description>
-		<year>1987</year>
-		<publisher>Activision</publisher>
-		<info name="programmer" value="Richard Danais" />
-		<info name="programmer" value="Nancy Philippine" />
-		<info name="programmer" value="Bernard Gallet" />
-		<info name="programmer" value="Luc Barthelet" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Writer's Choice Elite" is a 1987 productivity program developed by Richard Danais, Nancy Philippine, Bernard Gallet, and Luc Barthelet, and distributed by Activision. -->
-		<!-- Protection: Bad block check for block $7 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="writer's choice elite iigs (trex crack).2mg" size="819264" crc="d4d891e1" sha1="d7a386e9fc286018505d61eff800ca892bcae304"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="xenocide">
-		<description>Xenocide (version 25-Sep-89) (unprotected)</description>
-		<year>1989</year>
-		<publisher>Micro Revelations</publisher>
-		<info name="programmer" value="Brian Greenstone" />
-		<info name="programmer" value="Dave Triplett" />
-		<info name="version" value="25-Sep-89" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Xenocide" is a 1989 action game developed by Brian Greenstone and Dave Triplett, and distributed by Micro Revelations. -->
-		<!-- xeno.sys16 dated 25-Sep-89 14:23, 63090 bytes long, 121 blocks -->
-		<!-- Unprotected version released by Micro Revelations. -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="xenocide (25-sep-89) iigs.2mg" size="819264" crc="ea4f3204" sha1="a85cca9ca740ecad53a8ccb153a53228989115fb"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="xenocidea" cloneof="xenocide">
-		<description>Xenocide (version 11-Aug-89) (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Micro Revelations</publisher>
-		<info name="programmer" value="Brian Greenstone" />
-		<info name="programmer" value="Dave Triplett" />
-		<info name="version" value="11-Aug-89" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Xenocide" is a 1989 action game developed by Brian Greenstone and Dave Triplett, and distributed by Micro Revelations. -->
-		<!-- xeno.sys16 dated 11-Aug-89 09:34, 65085 bytes long, 129 blocks -->
-		<!-- Protection: Check for Macintosh "tag bytes" on block $4E1 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="xenocide (11-aug-89) iigs (trex crack).2mg" size="819264" crc="00bf834e" sha1="0818389d9586d5e46e0e400a1da51f8a7dd35bcb"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="xenocideb" cloneof="xenocide">
-		<description>Xenocide (version 21-Jul-89) (cleanly cracked)</description>
-		<year>1989</year>
-		<publisher>Micro Revelations</publisher>
-		<info name="programmer" value="Brian Greenstone" />
-		<info name="programmer" value="Dave Triplett" />
-		<info name="version" value="21-Jul-89" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- "Xenocide" is a 1989 action game developed by Brian Greenstone and Dave Triplett, and distributed by Micro Revelations. -->
-		<!-- xeno.sys16 dated 21-JUL-89 11:35, 64996 bytes long, 128 blocks -->
-		<!-- Protection: Check for Macintosh "tag bytes" on block $4E1 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="xenocide (21-jul-89) iigs (trex crack).2mg" size="819264" crc="1358f0ad" sha1="250fcbf30f38f2df388544151399d4d42b434f19"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="zanygolf">
-		<description>Zany Golf (cleanly cracked)</description>
-		<year>1988</year>
-		<publisher>Electronic Arts</publisher>
-		<info name="programmer" value="Will Harvey" />
-		<info name="programmer" value="Jim Nitchals" />
-		<info name="programmer" value="Ian Gooding" />
-		<info name="programmer" value="Doug Fulton" />
-		<info name="usage" value="Requires a 512K Apple IIgs." />
-		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- Dump released: 2021-08-13 -->
-		<!-- It requires a 512K Apple IIgs. -->
-		<!-- sports game -->
-		<!-- Protection: Nibble count on tracks $20 & $21 -->
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="819264">
-				<rom name="zany golf iigs (trex crack).2mg" size="819264" crc="5e917b13" sha1="37658ef75ca9a35277023e66fe0280058d8a237a"/>
-			</dataarea>
-		</part>
-	</software>
-
+<software name="4thinchs">
+<description>4th & Inches (trex crack)</description>
+<year>1987</year>
+<publisher>Accolade</publisher>
+<info name="programmer" value="Tony Manso"/>
+<info name="programmer" value="Ed Bogas"/>
+<info name="programmer" value="Les Pardew"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs -->
+<!--
+ The Team Construction Set was sold separately, but only works with 4th & Inches so it's included as "Disk 2" 
+-->
+<!--
+ The Team Construction Set disk doesn't check itself for being an original, but runs a nibble count on the 4th & Inches disk 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="4th & inches iigs (trex crack).2mg" size="819264" crc="63566084" sha1="2f2780317b64acfee335f14df333f2e6d275632a"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Team Construction disk"/>
+<dataarea name="flop" size="819264">
+<rom name="4th & inches team construction disk iigs (trex crack).2mg" size="819264" crc="85a18133" sha1="3a45fb29a5b0b4ecebd99c396a6c1d2859087e50"/>
+</dataarea>
+</part>
+</software>
+<software name="aesopfbl">
+<description>Aesop's Fables (trex crack)</description>
+<year>1988</year>
+<publisher>Unicorn Software</publisher>
+<info name="programmer" value="William Demas"/>
+<info name="programmer" value="Joseph Hewitt IV"/>
+<info name="programmer" value="June Stark"/>
+<info name="usage" value="Requires a 768K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "Aesop's Fables" is a 1988 educational program developed by William Demas, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="aesop's fables iigs - disk 1 (trex crack).2mg" size="819264" crc="45eceb6d" sha1="82fa0b3d9e303b576ac4e469708860c1cbd88e5b"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="aesop's fables iigs - disk 2 (trex crack).2mg" size="819264" crc="87c1d3ae" sha1="44531b8c40a966d7999397a2f41fbcbff47b4ceb"/>
+</dataarea>
+</part>
+</software>
+<software name="allabamr">
+<description>All About America (trex crack)</description>
+<year>1988</year>
+<publisher>Unicorn Software</publisher>
+<info name="programmer" value="Stanley Brewster"/>
+<info name="programmer" value="June Stark"/>
+<info name="programmer" value="Joseph B. Hewitt IV"/>
+<info name="usage" value="Requires a 768K Apple IIgs ROM 03."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!--
+ It requires a 768K ROM3 Apple IIgs. (crashes on ROM01 Apple IIgs?) 
+-->
+<!--
+ "All About America" is a 1988 educational program developed by Stanley Brewster, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="all about america iigs - disk 1 (trex crack).2mg" size="819264" crc="0ffc52de" sha1="147395c621f0c1075995da84c11980df3add6403"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="all about america iigs - disk 2 (trex crack).2mg" size="819264" crc="dbc50936" sha1="faf94b81dfe45af084ceb82dcc2a08e750aa24f3"/>
+</dataarea>
+</part>
+</software>
+<software name="alandofys">
+<description>Ancient Land of Ys (trex crack)</description>
+<year>1989</year>
+<publisher>Kyodai</publisher>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Ancient Land of Ys" is a 1989 fantasy role playing game developed by Kyodai and distributed by Brøderbund. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="ancient land of ys iigs - disk 1 - program disk (trex crack).2mg" size="819264" crc="1770d1a8" sha1="f298033c84a26f8835a7c29327dffee09ddefcf6"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Data disk"/>
+<dataarea name="flop" size="819264">
+<rom name="ancient land of ys iigs - disk 2 - data disk (trex crack).2mg" size="819264" crc="b4056419" sha1="2a6141344cbaa09b01aae468a86c40c8f9cce1e6"/>
+</dataarea>
+</part>
+</software>
+<software name="arkanoid">
+<description>Arkanoid (version 12-Jan-89) (trex crack)</description>
+<year>1988</year>
+<publisher>Taito</publisher>
+<info name="programmer" value="Ryan Ridges"/>
+<info name="programmer" value="John Lund"/>
+<info name="version" value="12-Jan-89 - ROM 03 compatible"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs -->
+<!--
+ "Arkanoid" is a 1988 action game developed by Ryan Ridges and John Lund, and distributed by Taito America. 
+-->
+<!--
+ The copy protection routines are not compatible with the ROM03, however the cracked version runs on any 512K Apple IIgs 
+-->
+<!-- ark.s16 dated 12-Jan-89 -->
+<!--
+ Protection: Excessive zero bits after D5 CC AA header. Then 4 bytes are read through 4 loops with matches recorded. Read matches must equal less then 12 out of 16 reads 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="arkanoid iigs (12-jan-89) (trex crack).2mg" size="819264" crc="1cd0cc32" sha1="0c8fda06f1ddd7a53d7a0e36276f1fb45e993c42"/>
+</dataarea>
+</part>
+</software>
+<software name="arknoid2">
+<description>
+Arkanoid II: Revenge of Doh (version 29-Aug-89) (trex crack)
+</description>
+<year>1989</year>
+<publisher>Taito</publisher>
+<info name="programmer" value="Ryan Ridges"/>
+<info name="programmer" value="John Lund"/>
+<info name="version" value="29-Aug-89"/>
+<info name="usage" value="Requires a 512K Apple IIgs ROM01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs ROM01 or later. -->
+<!--
+ "Arkanoid II" is a 1989 action game developed by Ryan Ridges and John Lund, and distributed by Taito America. 
+-->
+<!-- ark.s16 dated 29-Aug-89 -->
+<!--
+ Protection: Excessive zero bits after D5 CC AA header. Then 4 bytes are read through 4 loops with matches recorded. Read matches must equal less then 12 out of 16 reads 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="arkanoid ii - revenge of doh iigs (29-aug-89) (trex crack).2mg" size="819264" crc="d9207384" sha1="b04253e088b65df6189268c6e5eade67fb155827"/>
+</dataarea>
+</part>
+</software>
+<software name="arknoid2a" cloneof="arknoid2">
+<description>
+Arkanoid II: Revenge of Doh (version 18-Jul-89) (trex crack)
+</description>
+<year>1989</year>
+<publisher>Taito</publisher>
+<info name="programmer" value="Ryan Ridges"/>
+<info name="programmer" value="John Lund"/>
+<info name="version" value="18-Jul-89"/>
+<info name="usage" value="Requires a 512K Apple IIgs ROM01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs ROM01 or later. -->
+<!--
+ "Arkanoid II" is a 1989 action game developed by Ryan Ridges and John Lund, and distributed by Taito America. 
+-->
+<!-- ark.s16 dated 18-Jul-89 -->
+<!--
+ Protection: Excessive zero bits after D5 CC AA header. Then 4 bytes are read through 4 loops with matches recorded. Read matches must equal less then 12 out of 16 reads 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="arkanoid ii - revenge of doh iigs (18-jul-89) (trex crack).2mg" size="819264" crc="b3b4cd5b" sha1="4d302c876001cf638afa0c58d8254b7f2d138c51"/>
+</dataarea>
+</part>
+</software>
+<software name="btlchess">
+<description>Battle Chess (trex crack)</description>
+<year>1989</year>
+<publisher>Interplay Productions</publisher>
+<info name="programmer" value="Jim Sproul"/>
+<info name="programmer" value="Todd J. Camasta"/>
+<info name="programmer" value="Bruce Schlickbernd"/>
+<info name="programmer" value="Kurt Heiden"/>
+<info name="programmer" value="Bill (Weez) Dugan"/>
+<info name="programmer" value="Thomas R. Decker"/>
+<info name="programmer" value="Troy P. Worrell"/>
+<info name="programmer" value="Michael Quarles"/>
+<info name="programmer" value="Rebecca Heineman"/>
+<info name="programmer" value="Alan Pavlish"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!--
+ board game. The manual at https://archive.org/details/Battle_Chess_Manual 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="battle chess iigs (trex crack).2mg" size="819264" crc="f40de0f7" sha1="8cd2fc36064fe531172d532db948865bce36307a"/>
+</dataarea>
+</part>
+</software>
+<software name="blockout">
+<description>Block Out (version 1.0) (trex crack)</description>
+<year>1989</year>
+<publisher>California Dreams</publisher>
+<info name="programmer" value="Alexander Ustaszewski"/>
+<info name="programmer" value="Marek Jackiewicz"/>
+<info name="programmer" value="Adam Skorupinski"/>
+<info name="programmer" value="Marcin Szostakowski"/>
+<info name="programmer" value="Marcin Grzegorzewski"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Block Out" is a 1989 action game developed by Alexander Ustaszewski, Marek Jackiewicz, Adam Skorupinski, Marcin Szostakowski, and Marcin Grzegorzewski, and distributed by California Dreams. 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="block out v1.0 iigs (trex crack).2mg" size="819264" crc="c15e712f" sha1="fe037f0ac74aea08a82bb7ee748fba77b563d58a"/>
+</dataarea>
+</part>
+</software>
+<software name="bghost">
+<description>Bubble Ghost (trex crack)</description>
+<year>1988</year>
+<publisher>Accolade</publisher>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Bubble Ghost" is a 1988 action game developed by Infogrames and distributed by Accolade. 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="bubble ghost iigs (trex crack).2mg" size="819264" crc="cba0efd6" sha1="e6ac73d5415aab87d4206d49bd1aa5cbc2d558f5"/>
+</dataarea>
+</part>
+</software>
+<software name="bghosthd" cloneof="bghost">
+<description>Bubble Ghost - Hard Drive compatible (trex crack)</description>
+<year>1988</year>
+<publisher>Accolade</publisher>
+<info name="version" value="Hard Drive compatible"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Bubble Ghost" is a 1988 action game developed by Infogrames and distributed by Accolade. 
+-->
+<!--
+ Hard coded path names were replaced with names to use current volume / directory 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="bubble ghost iigs (hard drive mod) (trex crack).2mg" size="819264" crc="6a612172" sha1="02b32bee6e79055f0436f693a6e12563f2d4c1a1"/>
+</dataarea>
+</part>
+</software>
+<software name="calcraft">
+<description>Calendar Crafter (A-194 version 1.2) (trex crack)</description>
+<year>1987</year>
+<publisher>MECC</publisher>
+<info name="partno" value="A-194"/>
+<info name="programmer" value="Gene Breault"/>
+<info name="programmer" value="Charolyn Kapplinger"/>
+<info name="programmer" value="Diane Portner"/>
+<info name="programmer" value="Steven D. Splinter"/>
+<info name="programmer" value="Paul R. Wenker"/>
+<info name="usage" value="Requires a 768K Apple IIgs ROM 01 or later."/>
+<info name="version" value="1.2"/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- productivity program -->
+<!-- Protection: Bad block check for block $8 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="calendar crafter v1.2 iigs(trex crack).2mg" size="819264" crc="65717231" sha1="2f2415385a699fc78a68a3a73ff8470a5fc8df6f"/>
+</dataarea>
+</part>
+</software>
+<software name="calgames">
+<description>California Games (trex crack)</description>
+<year>1988</year>
+<publisher>Epyx</publisher>
+<info name="programmer" value="Jimmy Huey"/>
+<info name="programmer" value="Dan Chang"/>
+<info name="programmer" value="Jenny Martin"/>
+<info name="programmer" value="Sheryl Knowles"/>
+<info name="programmer" value="Bill Bogenreif"/>
+<info name="programmer" value="Matt Householder"/>
+<info name="programmer" value="Ron Fortier"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<!-- sports game -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="california games iigs (trex crack).2mg" size="819264" crc="908b7825" sha1="d276969f7e11b493d10fb2d7b2943c3e668864aa"/>
+</dataarea>
+</part>
+</software>
+<software name="captbld">
+<description>Captain Blood (trex crack)</description>
+<year>1989</year>
+<publisher>Mindscape</publisher>
+<info name="programmer" value="Philippe Ulrich"/>
+<info name="programmer" value="Didier Bouchon"/>
+<info name="programmer" value="Jean-Michel Jarre"/>
+<info name="programmer" value="Alexis Martial"/>
+<info name="programmer" value="Michael Rho"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- simulation game -->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="captain blood iigs (trex crack).2mg" size="819264" crc="7b2dede6" sha1="6ead26e7e2c4d3bb65b3d91e13df784503c9e643"/>
+</dataarea>
+</part>
+</software>
+<software name="cavcobra">
+<description>Cavern Cobra (trex crack)</description>
+<year>1987</year>
+<publisher>PBI Software</publisher>
+<info name="programmer" value="Greg Hale"/>
+<info name="programmer" value="Richard L. Seaborne"/>
+<info name="usage" value="Requires a 768K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "Cavern Cobra" is a 1987 action game developed by Greg Hale and Richard L. Seaborne, and distributed by PBI Software. 
+-->
+<!-- Protection: Bad block check for block $7 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="cavern cobra iigs (trex crack).2mg" size="819264" crc="8345e4a2" sha1="8a3c05ce714b5f3bbbc5bc1d6649530e21c093b3"/>
+</dataarea>
+</part>
+</software>
+<software name="clbbgmn">
+<description>
+Club Backgammon (version 2.0 12-Dec-88) (trex crack)
+</description>
+<year>1988</year>
+<publisher>California Dreams</publisher>
+<info name="programmer" value="Staszek Bartkowski"/>
+<info name="programmer" value="Jarek Olszewski"/>
+<info name="programmer" value="Dorota Błaszczak"/>
+<info name="programmer" value="Maciej Markuszewski"/>
+<info name="programmer" value="Marcin Szostakowski"/>
+<info name="version" value="2.0 12-Dec-88"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!-- gammon.sys16 dated 12-Dec-88 -->
+<!--
+ "Club Backgammon" is a 1988 board game developed by Staszek Bartkowski, Jarek Olszewski, Dorota Błaszczak, Maciej Markuszewski, and Marcin Szostakowski, and distributed by California Dreams. 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="club backgammon v2.0 iigs (trex crack).2mg" size="819264" crc="94bc57d4" sha1="bd32dd7098ddbbeaf89620e1faf32b66df91a4f7"/>
+</dataarea>
+</part>
+</software>
+<software name="clbbgmna" cloneof="clbbgmn">
+<description>
+Club Backgammon (version 1.0 09-May-88) (trex crack)
+</description>
+<year>1988</year>
+<publisher>California Dreams</publisher>
+<info name="programmer" value="Staszek Bartkowski"/>
+<info name="programmer" value="Jarek Olszewski"/>
+<info name="programmer" value="Dorota Błaszczak"/>
+<info name="programmer" value="Maciej Markuszewski"/>
+<info name="programmer" value="Marcin Szostakowski"/>
+<info name="version" value="1.0 09-May-88"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Club Backgammon" is a 1988 board game developed by Staszek Bartkowski, Jarek Olszewski, Dorota Błaszczak, Maciej Markuszewski, and Marcin Szostakowski, and distributed by California Dreams. 
+-->
+<!-- gammon.sys16 dated 09-May-88 -->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="club backgammon v1.0 iigs (trex crack).2mg" size="819264" crc="b511a503" sha1="e0dbfb6311329ca50b88fe4c94b618f360988d88"/>
+</dataarea>
+</part>
+</software>
+<software name="cribgin">
+<description>
+Cribbage King / Gin King (version 1.01) (trex crack)
+</description>
+<year>1989</year>
+<publisher>The Software Toolworks</publisher>
+<info name="programmer" value="Mark Manyen"/>
+<info name="programmer" value="Don Laabs"/>
+<info name="programmer" value="David M. Linnehan"/>
+<info name="programmer" value="Elizabeth Scafati"/>
+<info name="version" value="1.01"/>
+<info name="usage" value="Requires a 1MB Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 1MB Apple IIgs. -->
+<!--
+ "Cribbage King / Gin King" is a 1989 board game developed by Mark Manyen, Don Laabs, David M. Linnehan, and Elizabeth Scafati, and distributed by The Software Toolworks. 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - System disk"/>
+<dataarea name="flop" size="819264">
+<rom name="cribbage king - gin king v1.01 iigs - disk 1 - system.2mg" size="819264" crc="13734d39" sha1="5c501b2e3d17eb8dbc518a7be038953b5eef6f86"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="cribbage king - gin king v1.01 iigs - disk 2 - program (trex crack).2mg" size="819264" crc="a94cd6a5" sha1="50f215f226f14effcb1c29974b94e34a11e66783"/>
+</dataarea>
+</part>
+</software>
+<software name="defcrown">
+<description>Defender of the Crown (trex crack)</description>
+<year>1988</year>
+<publisher>Cinemaware</publisher>
+<info name="programmer" value="Kellyn Beeck"/>
+<info name="programmer" value="James Sachs"/>
+<info name="programmer" value="Ivan Manley"/>
+<info name="programmer" value="Robert Jacob"/>
+<info name="programmer" value="Phyllis Jacob"/>
+<info name="programmer" value="Pat Cook"/>
+<info name="programmer" value="Jim Cuomo"/>
+<info name="programmer" value="Tom Warner"/>
+<info name="programmer" value="Jeff Hilbers"/>
+<info name="programmer" value="Steve Quinn"/>
+<info name="programmer" value="Richard La Barre"/>
+<info name="programmer" value="John Cutter"/>
+<info name="programmer" value="Rob Landeros"/>
+<info name="programmer" value="Doug Smith"/>
+<info name="programmer" value="Betsy Scafati"/>
+<info name="programmer" value="Wayne Brockman"/>
+<info name="usage" value="Requires a 768K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "Defender of the Crown" is a 1988 adventure game developed by Kellyn Beeck, James Sachs, Ivan Manley, Robert Jacob, Phyllis Jacob, Pat Cook, Jim Cuomo, Tom Warner, Jeff Hilbers, Steve Quinn, Richard La Barre, John Cutter, Rob Landeros, Doug Smith, Betsy Scafati, and Wayne Brockman, and distributed by Cinemaware Corporation. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Reel 1"/>
+<dataarea name="flop" size="819264">
+<rom name="defender of the crown iigs - reel 1 (trex crack).2mg" size="819264" crc="c6e42ad9" sha1="798e460a036cd089e714fa4c42477c807942b55d"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Reel 2"/>
+<dataarea name="flop" size="819264">
+<rom name="defender of the crown iigs - reel 2 (trex crack).2mg" size="819264" crc="cecd1d4c" sha1="9a25fc96e8ed25cc5afeab36396e8f376268258b"/>
+</dataarea>
+</part>
+</software>
+<software name="dejavu">
+<description>Déjà Vu (trex crack)</description>
+<year>1988</year>
+<publisher>ICOM Simulations</publisher>
+<info name="programmer" value="Fred Allen"/>
+<info name="programmer" value="David Marsh"/>
+<info name="programmer" value="Karl Roelofs"/>
+<info name="programmer" value="Todd Squires"/>
+<info name="programmer" value="Craig Erickson"/>
+<info name="programmer" value="Kurt Nelson"/>
+<info name="programmer" value="Steven Hays"/>
+<info name="programmer" value="Terry Schulenburg"/>
+<info name="programmer" value="Darin Adler"/>
+<info name="programmer" value="Jay Zipnick"/>
+<info name="programmer" value="Waldermar Horwat"/>
+<info name="programmer" value="Mark Waterman"/>
+<info name="programmer" value="Tod Zipnick"/>
+<info name="usage" value="Requires a 768K Apple IIgs ROM01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs ROM01 or later. -->
+<!--
+ "Deja Vu" is a 1988 adventure game developed by Fred Allen, David Marsh, Karl Roelofs, Todd Squires, Craig Erickson, Kurt Nelson, Steven Hays, Terry Schulenburg, Darin Adler, Jay Zipnick, Waldermar Horwat, Mark Waterman, and Tod Zipnick, and distributed by ICOM Simulations. 
+-->
+<!-- Protection: Bad block check for block $7 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - System disk"/>
+<dataarea name="flop" size="819264">
+<rom name="deja vu iigs - disk 1 - system disk (trex crack).2mg" size="819264" crc="cc772518" sha1="dc2426407b1177a717d93d09416875228b971ce0"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="deja vu iigs - disk 2 - program disk (trex crack).2mg" size="819264" crc="6d60c03b" sha1="f99fee8c3870bfdf4f2483f7801f3c7f9a11a3ff"/>
+</dataarea>
+</part>
+</software>
+<software name="dejavu2">
+<description>Déjà Vu II: Lost in Las Vegas (trex crack)</description>
+<year>1989</year>
+<publisher>Mindscape</publisher>
+<info name="programmer" value="Fred Allen"/>
+<info name="programmer" value="David Marsh"/>
+<info name="programmer" value="Michael Manning"/>
+<info name="programmer" value="Todd Squires"/>
+<info name="programmer" value="David Feldman"/>
+<info name="programmer" value="Paul Snively"/>
+<info name="programmer" value="Brian Baker"/>
+<info name="programmer" value="Karl Roelofs"/>
+<info name="programmer" value="Ed Dluzen"/>
+<info name="programmer" value="Darin Adler"/>
+<info name="programmer" value="Jay Zipnick"/>
+<info name="programmer" value="Waldemar Horwat"/>
+<info name="programmer" value="Julia Ulano"/>
+<info name="programmer" value="Tod Zipnick"/>
+<info name="programmer" value="Mitch Adler"/>
+<info name="usage" value="Requires a 768K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "Déjà Vu II: Lost in Las Vegas" is a 1989 adventure game developed by Fred Allen, David Marsh, Michael Manning, Todd Squires, David Feldman, Paul Snively, Brian Baker, Karl Roelofs, Ed Dluzen, Darin Adler, Jay Zipnick, Waldemar Horwat, Julia Ulano, Tod Zipnick, and Mitch Adler, and distributed by Mindscape. 
+-->
+<!-- Protection: Bad block check for block $7 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - System disk"/>
+<dataarea name="flop" size="819264">
+<rom name="deja vu ii lost in las vegas - disk 1 - system disk (trex crack).2mg" size="819264" crc="9dd61c1e" sha1="ef2237b9d2a8af21f991ee611fc6be16fa370399"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="deja vu ii lost in las vegas iigs - disk 2 - program disk (trex crack).2mg" size="819264" crc="c0361def" sha1="420226429cfb3cf015d7540251863b8445aaa0d7"/>
+</dataarea>
+</part>
+</software>
+<software name="dsgnprnt">
+<description>Designer Prints (A-252 version 1.0) (trex crack)</description>
+<year>1989</year>
+<publisher>MECC</publisher>
+<info name="partno" value="A-252"/>
+<info name="programmer" value="Diane Portner"/>
+<info name="programmer" value="Michael Stein"/>
+<info name="programmer" value="Brian Walker"/>
+<info name="programmer" value="Paul Wenker"/>
+<info name="usage" value="Requires a 768K Apple IIgs ROM 01 or later."/>
+<info name="version" value="1.0"/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- desktop publishing program -->
+<!-- Protection: Bad block check for block $8 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - System disk"/>
+<dataarea name="flop" size="819264">
+<rom name="designer prints v1.0 iigs - disk 1 - system (trex crack).2mg" size="819264" crc="40720257" sha1="91cde62b8b6a1d8420af13580f707cb910ad1e22"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="designer prints v1.0 iigs - disk 2 - program (trex crack).2mg" size="819264" crc="aa1887a9" sha1="2727f3bb37d8cfaae85af20562e0d9f080fa1857"/>
+</dataarea>
+</part>
+</software>
+<software name="dsgnpuzl">
+<description>Designer Puzzles (A-223 version 1.0) (trex crack)</description>
+<year>1989</year>
+<publisher>MECC</publisher>
+<info name="partno" value="A-223"/>
+<info name="programmer" value="Susan Gabrys"/>
+<info name="programmer" value="John J. Krenz"/>
+<info name="programmer" value="Diane Portner"/>
+<info name="programmer" value="Steve Splinter"/>
+<info name="usage" value="Requires a 768K Apple IIgs ROM 01 or later."/>
+<info name="version" value="1.0"/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- desktop publishing program -->
+<!-- Protection: Bad block check for block $8 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - System disk"/>
+<dataarea name="flop" size="819264">
+<rom name="designer puzzles v1.0 iigs - disk 1 - system (trex crack).2mg" size="819264" crc="e1c43cca" sha1="e81f5fb94098806ea04f1d911b21ba46dc4ff4ef"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="designer puzzles v1.0 iigs - disk 2 - program (trex crack).2mg" size="819264" crc="3ac9cb9a" sha1="a48e900f2699fcc85a505a6486fb7635c0d1e1de"/>
+</dataarea>
+</part>
+</software>
+<software name="destryr">
+<description>Destroyer (trex crack)</description>
+<year>1987</year>
+<publisher>Epyx</publisher>
+<info name="programmer" value="Michael Kosaka"/>
+<info name="programmer" value="Chuck Sommerville"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!--
+ Protection: Nibble count on tracks $20 & $21 - 10 separate occurrences (Yes 10!) 
+-->
+<!-- simulation game -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="destroyer iigs (trex crack).2mg" size="819264" crc="a6943b6d" sha1="2160a034da86a894a0615490d55b8c585f0e1fcc"/>
+</dataarea>
+</part>
+</software>
+<software name="dhilchl">
+<description>Downhill Challenge (trex crack)</description>
+<year>1989</year>
+<publisher>Brøderbund Software</publisher>
+<info name="author" value="Christian Bertrand"/>
+<info name="programmer" value="Jean Claude Levy"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Downhill Challenge" is a 1989 sports game designed by Christian Bertrand, ported to the Apple IIgs by Jean Claude Levy, and distributed by Brøderbund Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - System disk"/>
+<dataarea name="flop" size="819264">
+<rom name="downhill challenge iigs - disk 1 - system disk (trex crack).2mg" size="819264" crc="0168462f" sha1="bd7dba9c84634a93360b9a1615debf7908603e95"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Game disk"/>
+<dataarea name="flop" size="819264">
+<rom name="downhill challenge iigs - disk 2 - game disk (trex crack).2mg" size="819264" crc="01d4dd29" sha1="3ae9ec0b5eb5893327eef32167ae3c95fb7c89e3"/>
+</dataarea>
+</part>
+</software>
+<software name="drawplus10">
+<description>Draw Plus (version 1.0) (trex crack)</description>
+<year>1987</year>
+<publisher>Activision</publisher>
+<info name="programmer" value="H. Lamiraux"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2025-01-25 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Draw Plus" is full-color precision drawing program with text and graphics intergraion. 
+-->
+<!--
+ Protection: Bad block check for block $7, later versions dropped the copy protection 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="draw plus v1.0 iigs (trex crack).2mg" size="819264" crc="efddd532" sha1="518ccb81ca6c20686e18c5a88b3d54708c62aba1"/>
+</dataarea>
+</part>
+</software>
+<software name="fantavsn">
+<description>Fantavision (version 2.1) (trex crack)</description>
+<year>1987</year>
+<publisher>Brøderbund Software</publisher>
+<info name="programmer" value="Scott Anderson"/>
+<info name="programmer" value="Ken Rosen"/>
+<info name="version" value="2.1"/>
+<info name="usage" value="Requires a 256K Apple IIgs ROM 01 or earlier."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 256K Apple IIgs ROM 01 or earlier. -->
+<!-- NOT Compatible with the Apple IIgs ROM03. -->
+<!--
+ "Fantavision IIgs" is a 1987 graphics program developed by Scott Anderson and Ken Rosen, and distributed by Brøderbund Software. 
+-->
+<!--
+ About screen shows "BrøderbundS NEW FANTAVISION GS" 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="fantavision v2.1 iigs (trex crack).2mg" size="819264" crc="e0430e48" sha1="cb7762e193296cb3648687424b5911ea4c8d3902"/>
+</dataarea>
+</part>
+</software>
+<software name="fantavsna" cloneof="fantavsn">
+<description>Fantavision (version 1.0) (trex crack)</description>
+<year>1987</year>
+<publisher>Brøderbund Software</publisher>
+<info name="programmer" value="Scott Anderson"/>
+<info name="programmer" value="Ken Rosen"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 256K Apple IIgs ROM 01 or earlier."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 256K Apple IIgs ROM 01 or earlier. -->
+<!-- NOT Compatible with the Apple IIgs ROM03. -->
+<!--
+ "Fantavision IIgs" is a 1987 graphics program developed by Scott Anderson and Ken Rosen, and distributed by Brøderbund Software. 
+-->
+<!--
+ About screen shows "Brøderbund presents FANTAVISION" 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="fantavision v1.0 iigs (trex crack).2mg" size="819264" crc="0a94d284" sha1="09ee33786fef5f1d1eaadeb85ba275c9a451f003"/>
+</dataarea>
+</part>
+</software>
+<software name="fastbrk">
+<description>Fast Break (trex crack)</description>
+<year>1989</year>
+<publisher>Accolade</publisher>
+<info name="programmer" value="Steve Cartwright"/>
+<info name="programmer" value="Greg Hospelhorn"/>
+<info name="programmer" value="George Wong"/>
+<info name="programmer" value="Pam Levins"/>
+<info name="programmer" value="Roseann Mitchell"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Fast Break" is a 1989 sports game developed by Steve Cartwright, Greg Hospelhorn, George Wong, Pam Levins, and Roseann Mitchell, and distributed by Accolade. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="fast break iigs (trex crack).2mg" size="819264" crc="b112c95f" sha1="f145e9973b4849f7cd1759a461832b34d2bf6df4"/>
+</dataarea>
+</part>
+</software>
+<software name="finalass">
+<description>Final Assault (trex crack)</description>
+<year>1988</year>
+<publisher>Epyx</publisher>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Final Assault" is a 1988 sports game developed by Infogrames and distributed by Epyx. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="final assault iigs (trex crack).2mg" size="819264" crc="1de1fae5" sha1="ae7329a9614f2be55232d2f7584b885b3ee3ed61"/>
+</dataarea>
+</part>
+</software>
+<software name="gauntlet">
+<description>Gauntlet (trex crack)</description>
+<year>1988</year>
+<publisher>Mindscape</publisher>
+<info name="developer" value="Atari Games"/>
+<info name="usage" value="Requires a 256K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- Protection: Bad block check for block $7 -->
+<!-- arcade game -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="gauntlet iigs (trex crack).2mg" size="819264" crc="9350598a" sha1="e594829ae86956a4e86a5e7243e82bf7d3606c17"/>
+</dataarea>
+</part>
+</software>
+<software name="gbabsktb">
+<description>
+GBA Championship Basketball: Two-on-Two (trex crack)
+</description>
+<year>1987</year>
+<publisher>Activision</publisher>
+<info name="programmer" value="Paul Terry"/>
+<info name="programmer" value="Jack Thornton"/>
+<info name="programmer" value="Scott Orr"/>
+<info name="programmer" value="John Cutter"/>
+<info name="programmer" value="Troy Lyndon"/>
+<info name="programmer" value="Russell Lieblich"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2023-04-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "GBA Championship Basketball" is a 1987 sports game developed by Paul Terry, Jack Thornton, Scott Orr, John Cutter, Troy Lyndon, and Russell Lieblich, and distributed by Activision. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="gba championship basketball two-on-two iigs (trex crack).2mg" size="819264" crc="2a5318f2" sha1="7220908177bea5ac84c0a17064589549edaeb904"/>
+</dataarea>
+</part>
+</software>
+<software name="geometry">
+<description>Geometry (version 1.0) (trex crack)</description>
+<year>1988</year>
+<publisher>Brøderbund</publisher>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 768K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "Geometry v1.0" is a educational program teaching the concepts of geometry by Sensei Software, and publised by Brøderbund Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - System disk"/>
+<dataarea name="flop" size="819264">
+<rom name="geometry v1.0 iigs - disk 1 - System disk (trex crack).2mg" size="819264" crc="8f090d9b" sha1="c0620fd5df319357f830e109600da3cab2d1f0d4"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="geometry v1.0 iigs - disk 2 (trex crack).2mg" size="819264" crc="e01d0b28" sha1="545c72635f0cc2ff5498ae457fea07c11e09840e"/>
+</dataarea>
+</part>
+<part name="flop3" interface="floppy_3_5">
+<feature name="part_id" value="Disk 3"/>
+<dataarea name="flop" size="819264">
+<rom name="geometry v1.0 iigs - disk 3 (trex crack).2mg" size="819264" crc="6b68ee23" sha1="c5ff132dbdb9deed4a791ab07659563378ed2dee"/>
+</dataarea>
+</part>
+</software>
+<software name="gnrlgolf">
+<description>Gnarly Golf (trex crack)</description>
+<year>1989</year>
+<publisher>Fanfare by Britannica</publisher>
+<info name="programmer" value="Jim Coliz, Jr."/>
+<info name="programmer" value="Darren Bartlett"/>
+<info name="programmer" value="Andy Hildebrand"/>
+<info name="programmer" value="Greg Thomas"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Gnarly Golf" is a 1989 miniture golf / putt game by Jim Coliz Jr & Darren Bartlett of Visual Concepts, Ltd., and distributed by Britannica Software. 
+-->
+<!--
+ Protection: Read block $63F with data markers AD AA D5 and compare read data against self generated data 
+-->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="gnarly golf iigs disk 1 - program (trex crack).2mg" size="819264" crc="b1a3cc99" sha1="6823ceb096d707670168af9e97549fc8787004a1"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Course disk"/>
+<dataarea name="flop" size="819264">
+<rom name="gnarly golf iigs disk 2 - course (trex crack).2mg" size="819264" crc="92373f7e" sha1="a14134e2cf97f11c540c3c2a3016db1bab490b5b"/>
+</dataarea>
+</part>
+</software>
+<software name="gpcirc">
+<description>Grand Prix Circuit (trex crack)</description>
+<year>1989</year>
+<publisher>Accolade</publisher>
+<info name="programmer" value="Don Mattrick"/>
+<info name="programmer" value="Brad Gour"/>
+<info name="programmer" value="Allan Johanson"/>
+<info name="programmer" value="Erik Kiss"/>
+<info name="programmer" value="Amory Wong"/>
+<info name="programmer" value="Rick Friesen"/>
+<info name="programmer" value="Kris Hatlelid"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Grand Prix Circuit" is a 1989 racing simulation game developed by Don Mattrick, Brad Gour, Allan Johanson, Erik Kiss, Amory Wong, Rick Friesen, and Kris Hatlelid, and distributed by Accolade. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="grand prix circuit iigs (trex crack).2mg" size="819264" crc="a8877cb5" sha1="27b4c207a0bcda52c45bffd26302c2e5739e1152"/>
+</dataarea>
+</part>
+</software>
+<software name="gwshoot">
+<description>Great Western Shootout (trex crack)</description>
+<year>1989</year>
+<publisher>Britannica Software</publisher>
+<info name="programmer" value="Scott Patterson"/>
+<info name="programmer" value="Matt Crysdale"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Great Western Shootout" is a 1989 action game developed by Scott Patterson and Matt Crysdale, and distributed by Britannica Software. 
+-->
+<!--
+ Disk 2 was a copy / back-up of the original Game Disk 
+-->
+<!--
+ Protection: Read block $63F with data markers AD AA D5 and compare read data against self generated data 
+-->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Game disk"/>
+<dataarea name="flop" size="819264">
+<rom name="great western shootout iigs - game disk (trex crack).2mg" size="819264" crc="1a4d1dd5" sha1="fe023cce106c4dfac512a215277de15a4eb6992e"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Back-up game disk"/>
+<dataarea name="flop" size="819264">
+<rom name="great western shootout iigs - back-up game disk (trex crack).2mg" size="819264" crc="1a4d1dd5" sha1="fe023cce106c4dfac512a215277de15a4eb6992e"/>
+</dataarea>
+</part>
+</software>
+<software name="hacker2">
+<description>Hacker II: The Doomsday Papers (trex crack)</description>
+<year>1987</year>
+<publisher>Activision</publisher>
+<info name="programmer" value="Steve Cartwright"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Hacker II: The Doomsday Papers" is a 1987 simulation game developed by Steve Cartwright and distributed by Activision. 
+-->
+<!-- Protection: Bad block check for block $7 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="hacker ii - the doomsday papers iigs (trex crack).2mg" size="819264" crc="89341016" sha1="e4a4a4cf5e4a723de531cf90825bbe8b97115109"/>
+</dataarea>
+</part>
+</software>
+<software name="hardball">
+<description>Hardball! (trex crack)</description>
+<year>1987</year>
+<publisher>Accolade</publisher>
+<info name="programmer" value="Dan Thompson"/>
+<info name="programmer" value="Ed Bogas"/>
+<info name="programmer" value="John Boechler"/>
+<info name="programmer" value="Mike Benna"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Hardball!" is a 1987 sports game developed by Dan Thompson, Ed Bogas, John Boechler, and Mike Benna, and distributed by Accolade. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="hardball iigs (trex crack).2mg" size="819264" crc="5dac9206" sha1="55ffa3a5931449ae6c6de43f52f288f7ef3258e5"/>
+</dataarea>
+</part>
+</software>
+<software name="hostage">
+<description>Hostage: Rescue Mission (trex crack)</description>
+<year>1990</year>
+<publisher>Mindscape</publisher>
+<info name="developer" value="Infogrames"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- simulation game -->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="hostage - rescue mission iigs (trex crack).2mg" size="819264" crc="96b1c5b2" sha1="8c541ef7455a4cd5f9cb90093b158b618cdb131c"/>
+</dataarea>
+</part>
+</software>
+<software name="impmiss2">
+<description>Impossible Mission II (trex crack)</description>
+<year>1989</year>
+<publisher>Epyx</publisher>
+<info name="programmer" value="Istvan Cseri"/>
+<info name="programmer" value="Gyula Horvath"/>
+<info name="programmer" value="Pal Komondi"/>
+<info name="programmer" value="Sultan"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- action game -->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="impossible mission ii iigs (trex crack).2mg" size="819264" crc="74ff8279" sha1="53daf3ca16a5f2bee0104e1d6688ce45ead599bc"/>
+</dataarea>
+</part>
+</software>
+<software name="instmus">
+<description>Instant Music</description>
+<year>1987</year>
+<publisher>Electronic Arts</publisher>
+<info name="programmer" value="Bob Campbell"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2026-01-05 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!-- audio program -->
+<!-- Protection: Bad block check for block $63F -->
+<!--
+ This archive includes the two add-on disks that were available separately. 
+-->
+<!-- Electronic Arts' It's Only Rock 'N' Roll -->
+<!-- Electronic Arts' Hot & Cool Jazz Deluxe Library -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="instant music iigs (trex crack).2mg" size="819264" crc="df085767" sha1="6fea4620b343385de318963a8882f171b7dd9c51"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - It's Only Rock 'N' Roll Music disk"/>
+<dataarea name="flop" size="819264">
+<rom name="it's only rock'n'roll music disk.2mg" size="819264" crc="24e05c46" sha1="beadb4dd288cf1bd4d3532f344318a0a7de889db"/>
+</dataarea>
+</part>
+<part name="flop3" interface="floppy_3_5">
+<feature name="part_id" value="Disk 3 - Hot & Cool Jazz Deluxe Library disk"/>
+<dataarea name="flop" size="819264">
+<rom name="hot&cool jazz deluxe library disk.2mg" size="819264" crc="89cc7d25" sha1="0e53bc7cb770a5512b874dbcac1be5db2afd4891"/>
+</dataarea>
+</part>
+</software>
+<software name="nicklaus">
+<description>
+Jack Nicklaus' Greatest 18 Holes of Major Championship Golf (trex crack)
+</description>
+<year>1989</year>
+<publisher>Accolade</publisher>
+<info name="programmer" value="Tony Manso"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Jack Nicklaus' Greatest 18 Holes of Major Championship Golf" is a 1989 sports game developed by Tony Manso and distributed by Accolade. 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<!--
+ This archive includes the four add-on disks that were available separately. 
+-->
+<!--
+ Jack Nicklaus Presents The Major Championship Courses Of 1989 (Includes: Oak Hill - U.S. Open, Royal Troon - British Open & Kemper Lakes - PGA courses) 
+-->
+<!--
+ Jack Nicklaus Presents The Major Championship Courses Of 1990 (Includes: Medinah Country Club, Shoal Creek Golf Club & St. Andrews (Old Course) courses) 
+-->
+<!--
+ Jack Nicklaus Presents The International Course Disk (Includes: St. Mellion Golf Club, St. Creek Golf Club & Australian Golf Club (Sydney) courses) 
+-->
+<!--
+ Jack Nicklaus Presents The Great Courses Of The U.S. Open (Includes: Baltusrol Golf Club, Oakmont Country Club & Pebble Beach courses) 
+-->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="jack nicklaus' greatest 18 holes of major championship golf iigs - disk 1 - program disk (trex crack).2mg" size="819264" crc="fe61da3c" sha1="534a006bc861f17340df146e7735c0c566862b34"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Course disk"/>
+<dataarea name="flop" size="819264">
+<rom name="jack nicklaus' greatest 18 holes of major championship golf iigs - disk 2 - course disk (trex crack).2mg" size="819264" crc="600ed4ff" sha1="42dbe44b840c9512455184c64e1fc0f9b29706d4"/>
+</dataarea>
+</part>
+<part name="flop3" interface="floppy_3_5">
+<feature name="part_id" value="Disk 3 - Championship Courses of 1989"/>
+<dataarea name="flop" size="819264">
+<rom name="jack nicklaus presents the major championship courses of 1989.2mg" size="819264" crc="a307775b" sha1="d7fe58a4c7111c738214fcb250568aa88b475557"/>
+</dataarea>
+</part>
+<part name="flop4" interface="floppy_3_5">
+<feature name="part_id" value="Disk 4 - Championship Courses of 1990"/>
+<dataarea name="flop" size="819264">
+<rom name="jack nicklaus presents the major championship courses of 1990.2mg" size="819264" crc="188c5562" sha1="fd40796422d7233e8d5f4ea607afadae737e69a3"/>
+</dataarea>
+</part>
+<part name="flop5" interface="floppy_3_5">
+<feature name="part_id" value="Disk 5 - U.S. Open Course disk"/>
+<dataarea name="flop" size="819264">
+<rom name="jack nicklaus presents the greatest courses of the u.s. open.2mg" size="819264" crc="1474fa5b" sha1="8686611bdf391237540301bd5ec475e96194e453"/>
+</dataarea>
+</part>
+<part name="flop6" interface="floppy_3_5">
+<feature name="part_id" value="Disk 6 - International Courses"/>
+<dataarea name="flop" size="819264">
+<rom name="jack nicklaus presents the international course Disk.2mg" size="819264" crc="6e19dc44" sha1="e8a393b2d17d98c6a63c4c38c16fb9b921ff1e92"/>
+</dataarea>
+</part>
+</software>
+<software name="jigsaw">
+<description>Jigsaw (version 1.4 - 022988) (trex crack)</description>
+<year>1988</year>
+<publisher>Britannica Software</publisher>
+<info name="programmer" value="Javier Rullan Ruano"/>
+<info name="programmer" value="Huibert Aalbers"/>
+<info name="version" value="1.4"/>
+<info name="usage" value="Requires a 768K Apple IIgs ROM01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs ROM01 or later. -->
+<!--
+ "Jigsaw" is a 1988 board game developed by Javier Rullan Ruano and Huibert Aalbers, and distributed by Britannica Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="jigsaw v1.4 (022988) iigs - disk 1 - program disk (trex crack).2mg" size="819264" crc="24002d06" sha1="b901d7064f5cd65b36f6b9d3767d9692142c8a6b"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Picture library"/>
+<dataarea name="flop" size="819264">
+<rom name="jigsaw v1.4 (022988) iigs - disk 2 - picture library (trex crack).2mg" size="819264" crc="a513c0cb" sha1="d62c330b6e2b1debe2b1b1e5b9d70c6295335658"/>
+</dataarea>
+</part>
+</software>
+<software name="kquest">
+<description>King's Quest - Quest for the Crown (trex crack)</description>
+<year>1987</year>
+<publisher>Sierra On-Line</publisher>
+<info name="author" value="Roberta Williams, Al Lowe, Charles Tingley, Ken MacNeill, Chris Iden, Doug MacNeill, Greg Rowland, and Chris Iden"/>
+<info name="programmer" value="Carlos Escobar"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- Protection: Bad block check for block $634 -->
+<!-- adventure game -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="king's quest - quest for the crown iigs - disk 1 (trex crack).2mg" size="819264" crc="fd8ec559" sha1="ecd22526d022247393e7eb69b76c2ef7e48bee5f"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="king's quest - quest for the crown iigs - disk 2 (trex crack).2mg" size="819264" crc="3f71d689" sha1="d961c10eba23a15f1df851e3d7150c0615d5b78d"/>
+</dataarea>
+</part>
+</software>
+<software name="kquest2">
+<description>
+King's Quest II - Romancing The Throne (trex crack)
+</description>
+<year>1987</year>
+<publisher>Sierra On-Line</publisher>
+<info name="programmer" value="Roberta Williams"/>
+<info name="programmer" value="Jeff Stephenson"/>
+<info name="programmer" value="Chris Iden"/>
+<info name="programmer" value="Robert Heitman"/>
+<info name="programmer" value="Ken Williams"/>
+<info name="programmer" value="Sol Ackerman"/>
+<info name="programmer" value="Scott Murphy"/>
+<info name="programmer" value="Doug MacNeill"/>
+<info name="programmer" value="Mark Crowe"/>
+<info name="programmer" value="Al Lowe"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- Protection: Bad block check for block $634 -->
+<!-- adventure game -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="king's quest ii - romancing the throne iigs - disk 1 (trex crack).2mg" size="819264" crc="b9471715" sha1="c5030ccde3bd9bbb7d4f2735733269ebcb0fc7b4"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="king's quest ii - romancing the throne iigs - disk 2 (trex crack).2mg" size="819264" crc="ca9f6588" sha1="d8f755e80185b6e6e7af43fcb23b72e497941da3"/>
+</dataarea>
+</part>
+</software>
+<software name="kquest3">
+<description>King's Quest III - To Hier is Human (trex crack)</description>
+<year>1988</year>
+<publisher>Sierra On-Line</publisher>
+<info name="programmer" value="Roberta Williams"/>
+<info name="programmer" value="Al Lowe"/>
+<info name="programmer" value="Bob Kernaghan"/>
+<info name="programmer" value="Robert E. Heitman"/>
+<info name="programmer" value="Jeff Stephenson"/>
+<info name="programmer" value="Chris Iden"/>
+<info name="programmer" value="Doug MacNeill"/>
+<info name="programmer" value="Margaret Lowe"/>
+<info name="programmer" value="Dale Carlson"/>
+<info name="programmer" value="Jennifer Cobb"/>
+<info name="programmer" value="Chad Bye"/>
+<info name="programmer" value="Jeremy T. Cromwell"/>
+<info name="programmer" value="Carlos Escobar"/>
+<info name="programmer" value="Annette Childs"/>
+<info name="programmer" value="Greg Steffen"/>
+<info name="programmer" value="Ken Williams"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- Protection: Bad block check for block $634 -->
+<!-- adventure game -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="king's quest iii - to hier is human iigs - disk 1 (trex crack).2mg" size="819264" crc="01929d52" sha1="1861372f15165e7e65c011a721f6488d576ad465"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="king's quest iii - to hier is human iigs - disk 2 (trex crack).2mg" size="819264" crc="55741036" sha1="5a57837dbd0a1dedb054b661fd2527edbc936011"/>
+</dataarea>
+</part>
+</software>
+<software name="lasrforc">
+<description>LaserForce (trex crack)</description>
+<year>1989</year>
+<publisher>Fanfare</publisher>
+<info name="programmer" value="Javier Rullan"/>
+<info name="programmer" value="Huibert Aalbers"/>
+<info name="programmer" value="Thierry Méchain"/>
+<info name="programmer" value="Stéphane Renaudin"/>
+<info name="programmer" value="J-C. Doré"/>
+<info name="programmer" value="Olivier Guichaoua"/>
+<info name="usage" value="Requires a 1.25MB Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 1.25MB Apple IIgs. -->
+<!--
+ "LaserForce" is a 1989 action game developed by Javier Rullan, Huibert Aalbers, Thierry Méchain, Stéphane Renaudin, J-C. Doré, and Olivier Guichaoua, and distributed by Fanfare. 
+-->
+<!--
+ Protection: Read block $63F with data markers AD AA D5 and compare read data against self generated data 
+-->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="laserforce iigs - disk 1 (trex crack).2mg" size="819264" crc="1d6599e8" sha1="631a55cd0efba1fec91674112b7a945f5e29b6b5"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="laserforce iigs - disk 2 (trex crack).2mg" size="819264" crc="fb6e89bb" sha1="660199a65ec7328fd0757f0581c07014d55f0c1a"/>
+</dataarea>
+</part>
+</software>
+<software name="lsl1">
+<description>
+Leisure Suit Larry in The Land of the Lounge Lizards (trex crack)
+</description>
+<year>1987</year>
+<publisher>Sierra On-Line</publisher>
+<info name="programmer" value="Al Lowe"/>
+<info name="programmer" value="Chuck Benton"/>
+<info name="programmer" value="Mark Crowe"/>
+<info name="programmer" value="Jeff Stephenson"/>
+<info name="programmer" value="Chris Iden"/>
+<info name="programmer" value="Bob Heitman"/>
+<info name="programmer" value="Ken Williams"/>
+<info name="programmer" value="Carlos Escobar"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- Protection: Bad block check for block $634 -->
+<!-- adventure game -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="leisure suit larry in the land of the lounge lizards iigs - disk 1 (trex crack).2mg" size="819264" crc="9d33056d" sha1="425395bdda7c2a80969d91e950edeb03a1b212c6"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="leisure suit larry in the land of the lounge lizards iigs - disk 2 (trex crack).2mg" size="819264" crc="e1fa7b20" sha1="cc16b8f8e06f6d22febe375a2ac1372ef81989dd"/>
+</dataarea>
+</part>
+</software>
+<software name="magicmth">
+<description>Magical Myths (trex crack)</description>
+<year>1988</year>
+<publisher>Unicorn Software</publisher>
+<info name="programmer" value="Stan Brewster"/>
+<info name="programmer" value="Joseph B. Hewitt IV"/>
+<info name="programmer" value="June Stark"/>
+<info name="usage" value="Requires a 768K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "Magical Myths" is a 1988 educational program developed by Stanley Brewster, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="magical myths iigs - disk 1 (trex crack).2mg" size="819264" crc="5857246f" sha1="2107f5fd5341414c1fd8e85474b0ca2a98f01748"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="magical myths iigs - disk 2 (trex crack).2mg" size="819264" crc="bf41ab59" sha1="1077a37340c212ff9e875a6c2deac4a3142770a0"/>
+</dataarea>
+</part>
+</software>
+<software name="mancala">
+<description>Mancala (version 1.0) (trex crack)</description>
+<year>1988</year>
+<publisher>California Dreams</publisher>
+<info name="programmer" value="Jarek Olszewski"/>
+<info name="programmer" value="Maciej Markuszewski"/>
+<info name="programmer" value="Marcin Szostakowski"/>
+<info name="programmer" value="Dorota Błaszczak"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Macala" is a 1988 board game developed by Jarek Olszewski, Maciej Markuszewski, Marcin Szostakowski, and Dorota Błaszczak, and distributed by California Dreams. 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="mancala v1.0 iigs (trex crack).2mg" size="819264" crc="027b7cfb" sha1="e7772d01109045cb4f036a8a799fa18a01e2508e"/>
+</dataarea>
+</part>
+</software>
+<software name="marble">
+<description>Marble Madness (trex crack)</description>
+<year>1986</year>
+<publisher>Electronic Arts</publisher>
+<info name="programmer" value="Will Harvey"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<info name="programmer" value="Will Harvey"/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- action game -->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="marble madness iigs (trex crack).2mg" size="819264" crc="d400455e" sha1="68526119d1f3b31e01d9b9b52a364323f88b2b58"/>
+</dataarea>
+</part>
+</software>
+<software name="mathblsta" cloneof="mathblst">
+<description>Math Blaster Plus! (version 1.0) (trex crack)</description>
+<year>1989</year>
+<publisher>Davidson & Associates</publisher>
+<info name="author" value="Jan Davidson and Cathy Johnson"/>
+<info name="programmer" value="C.K. Haun"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 512K Apple IIgs ROM1 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- educational program -->
+<!-- Protection: Bad block check for block $308 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="math blaster plus v1.0 iigs (trex crack).2mg" size="819264" crc="37120366" sha1="b6a585415cbac0f69182da911bf7ec298df5fcbc"/>
+</dataarea>
+</part>
+</software>
+<software name="mathblst">
+<description>Math Blaster Plus! (version 1.1) (trex crack)</description>
+<year>1989</year>
+<publisher>Davidson & Associates</publisher>
+<info name="author" value="Jan Davidson and Cathy Johnson"/>
+<info name="programmer" value="C.K. Haun"/>
+<info name="version" value="1.1"/>
+<info name="usage" value="Requires a 512K Apple IIgs ROM1 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- educational program -->
+<!-- It requires a 512K Apple IIgs ROM1 or later. -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="math blaster plus v1.1 iigs (trex crack).2mg" size="819264" crc="96b3a909" sha1="5c7a1e8172f25ef328239971175b1f28a317fe2a"/>
+</dataarea>
+</part>
+</software>
+<software name="mthwizrd">
+<description>Math Wizard (trex crack)</description>
+<year>1988</year>
+<publisher>Unicorn Software</publisher>
+<info name="programmer" value="William Demas"/>
+<info name="programmer" value="June Stark"/>
+<info name="programmer" value="Joseph B. Hewitt IV"/>
+<info name="usage" value="Requires a 768K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "Math Wizard" is a 1988 educational program developed by William Demas, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="math wizard iigs - disk 1 (trex crack).2mg" size="819264" crc="c02b08b4" sha1="be668ddd56133162ee24cff499bb8bb34590a6c8"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="math wizard iigs - disk 2 (trex crack).2mg" size="819264" crc="81550924" sha1="cc1291f2ba15ad234414b28af3fff34ddc975d49"/>
+</dataarea>
+</part>
+</software>
+<software name="mavisbcn">
+<description>
+Mavis Beacon Teaches Typing (version 1.8 21-Dec-88) (trex crack)
+</description>
+<year>1987</year>
+<publisher>The Software Toolworks</publisher>
+<info name="version" value="1.8"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Mavis Beacon Teaches Typing" is a 1987 educational program developed and distributed by The Software Toolworks. 
+-->
+<!--
+ mavis.s16 dated 21-Dec-88 - Currently NOT archived: v1.5 (unknown program date) 
+-->
+<!-- Protection: Bad block check for block $63A -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="mavis beacon teaches typing v1.8 iigs - disk 1 - program disk (trex crack).2mg" size="819264" crc="273ae0b2" sha1="4bea4f4e1d7af7e2e9b69343f1e10c36ccd8cbd4"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Data disk"/>
+<dataarea name="flop" size="819264">
+<rom name="mavis beacon teaches typing v1.8 iigs - disk 2 - data disk (trex crack).2mg" size="819264" crc="bcc4a599" sha1="38ed4ebd59f8795ff32ab3e4f6052b91c2380a2c"/>
+</dataarea>
+</part>
+</software>
+<software name="mavisbcna" cloneof="mavisbcn">
+<description>
+Mavis Beacon Teaches Typing (version 1.2 16-Nov-87) (trex crack)
+</description>
+<year>1987</year>
+<publisher>The Software Toolworks</publisher>
+<info name="version" value="1.2"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Mavis Beacon Teaches Typing" is a 1987 educational program developed and distributed by The Software Toolworks. 
+-->
+<!-- mavis.s16 dated 16-Nov-87 -->
+<!-- Protection: Bad block check for block $63A -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="mavis beacon teaches typing v1.2 iigs - disk 1 - program disk (trex crack).2mg" size="819264" crc="c2306cf4" sha1="3dbf4c6ec0ec222958d34a60e997784e1bde97b5"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Data disk"/>
+<dataarea name="flop" size="819264">
+<rom name="mavis beacon teaches typing v1.2 iigs - disk 2 - data disk (trex crack).2mg" size="819264" crc="ad1aa08d" sha1="66cd3fe6817d70151c9fbcdae9ba42fa13a9cec5"/>
+</dataarea>
+</part>
+</software>
+<software name="mean18">
+<description>Mean 18 (trex crack)</description>
+<year>1987</year>
+<publisher>Accolade</publisher>
+<info name="programmer" value="Rex Bradford"/>
+<info name="programmer" value="George Karalias"/>
+<info name="programmer" value="Mark Lesser"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Mean 18" is a 1987 sports game developed by Rex Bradford, George Karalias, and Mark Lesser, and distributed by Accolade. 
+-->
+<!--
+ This archive includes the three add-on disks that were available separately (Famous Courses Volume II, III, and IV). 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="mean 18 iigs - disk 1 - program disk (trex crack).2mg" size="819264" crc="9471fe69" sha1="2deee7df5ddf5a87dd418fb2973eb12fc2ba6a99"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Famous courses volume II"/>
+<dataarea name="flop" size="819264">
+<rom name="mean 18 iigs - disk 2 - famous courses volume ii.2mg" size="819264" crc="0cf5db03" sha1="c71365d8f90dad599de57f094b79d31b27c22394"/>
+</dataarea>
+</part>
+<part name="flop3" interface="floppy_3_5">
+<feature name="part_id" value="Disk 3 - Famous courses volume III"/>
+<dataarea name="flop" size="819264">
+<rom name="mean 18 iigs - disk 3 - famous courses volume iii.2mg" size="819264" crc="25ca69e1" sha1="801e200a3024f951f5d3fb38f4e1790c645f5009"/>
+</dataarea>
+</part>
+<part name="flop4" interface="floppy_3_5">
+<feature name="part_id" value="Disk 4 - Famous courses volume IV"/>
+<dataarea name="flop" size="819264">
+<rom name="mean 18 iigs - disk 4 - famous courses volume iv.2mg" size="819264" crc="6859eba1" sha1="556a7457104d22f500dc3429087053e9a1056ea5"/>
+</dataarea>
+</part>
+</software>
+<software name="mercury">
+<description>Mercury (version 1.0) (trex crack)</description>
+<year>1989</year>
+<publisher>MECC</publisher>
+<info name="partno" value="A249"/>
+<info name="programmer" value="John J. Krenz"/>
+<info name="programmer" value="Brian Nesse"/>
+<info name="programmer" value="Michael Palmquist"/>
+<info name="programmer" value="Steve Splinter"/>
+<info name="programmer" value="Michael Stein"/>
+<info name="programmer" value="Paul Wenker"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 1MB Apple IIgs ROM 01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 1MB Apple IIgs ROM 01 or later. -->
+<!--
+ "Mercury" is a 1989 desktop publishing program developed by John J. Krenz, Brian Nesse, Michael Palmquist, Steve Splinter, Michael Stein, and Paul Wenker, and distributed by MECC. 
+-->
+<!-- Protection: Bad block check for block $8 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - System disk"/>
+<dataarea name="flop" size="819264">
+<rom name="mercury v1.0 iigs - disk 1 - system (trex crack).2mg" size="819264" crc="d28c1950" sha1="aeef36625bfdd12e5a7df000222725a2126cfc5d"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="mercury v1.0 iigs - disk 2 - program (trex crack).2mg" size="819264" crc="2682521b" sha1="5fd3948bac00b1ca4e08c79ccb437483798f25a9"/>
+</dataarea>
+</part>
+</software>
+<software name="mulscribe">
+<description>MultiScribe IIgs (version 3.01c) (trex crack)</description>
+<year>1987</year>
+<publisher>StyleWare</publisher>
+<info name="developer" value="StyleWare"/>
+<info name="version" value="3.01c"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2025-01-25 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "MultiScrible" is a word-processor featuring the ability to use different fonts, print styles, colors as well as allowing you to add boxes, circles and other designs. 
+-->
+<!--
+ First marketed as "Scholastic MutiScrible GS by StyleWare", then it became StyleWare MultiScribe GS and eventually Beagle Bros Software acquired the StyleWare library and rebranded it as BeagleWrite GS. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program"/>
+<dataarea name="flop" size="819264">
+<rom name="multiscribe gs v3.01c disk 1 - program (trex crack).2mg" size="819264" crc="d63e2246" sha1="8b5b7074f8967a79eb417cdb1a2648638473aa0f"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Utilities"/>
+<dataarea name="flop" size="819264">
+<rom name="multiscribe gs v3.01c disk 2 - utilities (trex crack).2mg" size="819264" crc="c4a8d1b1" sha1="0e31bb265b031397f8b386916e791e618d3a891e"/>
+</dataarea>
+</part>
+</software>
+<software name="mcs">
+<description>Music Construction Set (version 1.0) (trex crack)</description>
+<year>1986</year>
+<publisher>Electronic Arts</publisher>
+<info name="programmer" value="Will Harvey"/>
+<info name="programmer" value="Jim Nitchals"/>
+<info name="programmer" value="Doug Fulton"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 256K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- audio program -->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="music construction set v1.0 iigs (trex crack).2mg" size="819264" crc="278ef676" sha1="22808e777a37118c7cfd0bc639aac756843ce8ce"/>
+</dataarea>
+</part>
+</software>
+<software name="neuromnc">
+<description>Neuromancer (trex crack)</description>
+<year>1989</year>
+<publisher>Interplay Productions</publisher>
+<info name="programmer" value="Rebecca Heineman"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- adventure game -->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="neuromancer iigs (trex crack).2mg" size="819264" crc="158c6c93" sha1="aee79701fdcbc9204f979087cd420c4b462c3b66"/>
+</dataarea>
+</part>
+</software>
+<software name="paperboy">
+<description>Paperboy (trex crack)</description>
+<year>1988</year>
+<publisher>Mindscape</publisher>
+<info name="developer" value="Tengen"/>
+<info name="usage" value="Requires a 256K Apple IIgs ROM 01."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- Protection: Bad block check for block $7 -->
+<!-- arcade game -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="paperboy iigs (trex crack).2mg" size="819264" crc="a914d4a0" sha1="16990a565fdd157e58481113f30bb6725b38e958"/>
+</dataarea>
+</part>
+</software>
+<software name="pipedrm">
+<description>Pipe Dream (trex crack)</description>
+<year>1990</year>
+<publisher>Lucasfilm Games</publisher>
+<info name="developer" value="Visual Concepts"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Pipe Dream" is a 1990 board game developed by Visual Concepts and distributed by Lucasfilm Games. 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="pipe dream iigs (trex crack).2mg" size="819264" crc="f6e7fdba" sha1="79a4bc5ad012f5ede72bd7336a3f9b7a5b69523b"/>
+</dataarea>
+</part>
+</software>
+<software name="qix">
+<description>Qix (version 1.4? 16-Jan-90) (trex crack)</description>
+<year>1990</year>
+<publisher>Taito</publisher>
+<info name="programmer" value="Ryan Ridges"/>
+<info name="programmer" value="John Lund"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Qix" is a 1990 action game developed by Ryan Ridges and John Lund, and distributed by Taito. 
+-->
+<!--
+ Purportedly this is v1.4 - qix.s16 is dated 16-Jan-90 
+-->
+<!--
+ Protection: Excessive zero bits after D5 CC AA header. Then 4 bytes are read through 4 loops with matches recorded. Read matches must equal less then 12 out of 16 reads 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="qix iigs (trex crack).2mg" size="819264" crc="fb968ce0" sha1="2479e40e4477d5a5066225222860cbbaf3235603"/>
+</dataarea>
+</part>
+</software>
+<software name="readrhym">
+<description>Read and Rhyme (trex crack)</description>
+<year>1988</year>
+<publisher>Unicorn Software</publisher>
+<info name="programmer" value="William Demas"/>
+<info name="usage" value="Requires a 768K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "Read and Rhyme" is a 1988 educational program developed by William Demas and distributed by Unicorn Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="read and rhyme iigs - disk 1 (trex crack).2mg" size="819264" crc="eb44fed7" sha1="95c4d134ee9b4da201d285fcee8aaedad1d2aa39"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="read and rhyme iigs - disk 2 (trex crack).2mg" size="819264" crc="629bdb2a" sha1="28de9f9b2cef057342a9b000d61d7cc40f32dbcf"/>
+</dataarea>
+</part>
+</software>
+<software name="readarma">
+<description>Read-a-Rama (trex crack)</description>
+<year>1989</year>
+<publisher>Unicorn Software</publisher>
+<info name="programmer" value="Stan Brewster"/>
+<info name="programmer" value="Joseph Hewitt"/>
+<info name="usage" value="Requires a 1MB Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 1MB Apple IIgs. -->
+<!--
+ "Read-A-Rama" is a 1989 educational program developed by Stan Brewster and Joseph B. Hewitt IV, and distributed by Unicorn Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Boot disk"/>
+<dataarea name="flop" size="819264">
+<rom name="read-a-rama iigs - disk 1 - boot disk (trex crack).2mg" size="819264" crc="5fdb496c" sha1="118e4c715ea81eb2b966dd3a5ef4b51f49ecb55e"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Level 1"/>
+<dataarea name="flop" size="819264">
+<rom name="read-a-rama iigs - disk 2 - level 1 (trex crack).2mg" size="819264" crc="a935524e" sha1="206ef9a96e4c6fcfec6993023122143c030def7b"/>
+</dataarea>
+</part>
+<part name="flop3" interface="floppy_3_5">
+<feature name="part_id" value="Disk 3 - Level 2"/>
+<dataarea name="flop" size="819264">
+<rom name="read-a-rama iigs - disk 3 - level 2 (trex crack).2mg" size="819264" crc="d7db9400" sha1="e982c1b621eaf5e6995294c74657c60d4ff96f2f"/>
+</dataarea>
+</part>
+</software>
+<software name="rrabbit20" cloneof="rrabbit">
+<description>Reader Rabbit (version 2.0) (trex crack)</description>
+<year>1987</year>
+<publisher>The Learning Company</publisher>
+<info name="programmer" value="Pete Rowe"/>
+<info name="programmer" value="Aaron Weiss"/>
+<info name="usage" value="Requires a 256K Apple IIgs."/>
+<info name="version" value="2.0"/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2023-04-13 -->
+<!-- educational program -->
+<!-- Protection: Bad block check for block $7 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="reader rabbit v2.0 iigs (trex crack).2mg" size="819264" crc="0d7519e3" sha1="105012eccd7f066a0c3344b8f51b111fff7fc170"/>
+</dataarea>
+</part>
+</software>
+<software name="rrabbit22" cloneof="rrabbit">
+<description>Reader Rabbit (version 2.2) (trex crack)</description>
+<year>1987</year>
+<publisher>The Learning Company</publisher>
+<info name="programmer" value="Pete Rowe"/>
+<info name="programmer" value="Aaron Weiss"/>
+<info name="usage" value="Requires a 256K Apple IIgs."/>
+<info name="version" value="2.2"/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- educational program -->
+<!-- Protection: Bad block check for block $7 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="reader rabbit v2.2 iigs (trex crack).2mg" size="819264" crc="518994ed" sha1="48290f00ea231e7df039b89c74bafcf00ee28854"/>
+</dataarea>
+</part>
+</software>
+<software name="rrabbit">
+<description>Reader Rabbit (version 2.3) (trex crack)</description>
+<year>1987</year>
+<publisher>The Learning Company</publisher>
+<info name="programmer" value="Pete Rowe"/>
+<info name="programmer" value="Aaron Weiss"/>
+<info name="usage" value="Requires a 256K Apple IIgs."/>
+<info name="version" value="2.3"/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- educational program -->
+<!-- Protection: Bad block check for block $7 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="reader rabbit v2.3 iigs (trex crack).2mg" size="819264" crc="b59cc9f2" sha1="3cb739ae7b6c2a967ea649f944cd3d41221f6ba4"/>
+</dataarea>
+</part>
+</software>
+<software name="readandme">
+<description>Reading and Me (version 1.0) (trex crack)</description>
+<year>1988</year>
+<publisher>Davidson & Associates</publisher>
+<info name="programmer" value="Louis X. Savain"/>
+<info name="programmer" value="C. K. Haun"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- Protection: Bad block check for block $308 -->
+<!-- educational program -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="reading and me v1.0 iigs - disk 1 - Program (trex crack).2mg" size="819264" crc="b8b3f7fe" sha1="aa86579b20b745639ad4df1f005f81f3b08e351c"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Data disk"/>
+<dataarea name="flop" size="819264">
+<rom name="reading and me v1.0 iigs - disk 2 - Data (trex crack).2mg" size="819264" crc="18fb2177" sha1="23ecb57d3d935a3c07f18e83bf00676193f9a10a"/>
+</dataarea>
+</part>
+</software>
+<software name="seastrke">
+<description>Sea Strike (version 1.0) (trex crack)</description>
+<year>1987</year>
+<publisher>PBI Software</publisher>
+<info name="programmer" value="Richard L. Seaborne"/>
+<info name="programmer" value="Jeff A. Lefferts"/>
+<info name="programmer" value="Mei-Ying Dell'Aquila"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Sea Strike" is a 1987 action game developed by Richard L. Seaborne, Jeff A. Lefferts, and Mei-Ying Dell'Aquila, and distributed by PBI Software. 
+-->
+<!-- Protection: Bad block check for block $7 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="sea strike v1.0 iigs (trex crack).2mg" size="819264" crc="66f0fc4b" sha1="53c69ba174b0a278ed734f60a10c6cf0adaa64d3"/>
+</dataarea>
+</part>
+</software>
+<software name="srvvly">
+<description>Serve and Volley (trex crack)</description>
+<year>1988</year>
+<publisher>Accolade</publisher>
+<info name="programmer" value="Rick Banks"/>
+<info name="programmer" value="Paul Butler"/>
+<info name="programmer" value="Ken Shimizu"/>
+<info name="programmer" value="Danny Chin"/>
+<info name="programmer" value="Paul Battersby"/>
+<info name="programmer" value="Jeffrey J. Sigler"/>
+<info name="programmer" value="Grant Campbell"/>
+<info name="programmer" value="Jay Stevens"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Serve and Volley" is a 1988 sports game developed by Rick Banks, Paul Butler, Ken Shimizu, Danny Chin, Paul Battersby, Jeffrey J. Sigler, Grant Campbell, and Jay Stevens, and distributed by Accolade. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="serve and volley iigs (trex crack).2mg" size="819264" crc="cd53d374" sha1="4f88eaf4855d6ff2bcc1b1c47c73c5a63a0c9cde"/>
+</dataarea>
+</part>
+</software>
+<software name="shanghai">
+<description>Shanghai (version 15-Sep-87) (trex crack)</description>
+<year>1987</year>
+<publisher>Activision</publisher>
+<info name="programmer" value="Brodie Lockard"/>
+<info name="programmer" value="Ivan Manley"/>
+<info name="version" value="15-Sep-87"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Shanghai" is a 1987 board game developed by Brodie Lockard and Ivan Manley, and distributed by Activision. 
+-->
+<!-- start.s16 dated 15-Sep-87 -->
+<!-- Protection: Bad block check for block $7 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="shanghai (15-sep-87) iigs (trex crack).2mg" size="819264" crc="df346841" sha1="04b4006b904d597c2ca848ce496bff86f433e268"/>
+</dataarea>
+</part>
+</software>
+<software name="shanghaia" cloneof="shanghai">
+<description>Shanghai (version 20-Jan-87) (trex crack)</description>
+<year>1987</year>
+<publisher>Activision</publisher>
+<info name="programmer" value="Brodie Lockard"/>
+<info name="programmer" value="Ivan Manley"/>
+<info name="version" value="20-Jan-87"/>
+<info name="usage" value="Requires a 512K Apple IIgs ROM 01 or earlier."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs ROM 01 or earlier. -->
+<!-- NOT Compatible with the Apple IIgs ROM03. -->
+<!--
+ "Shanghai" is a 1987 board game developed by Brodie Lockard and Ivan Manley, and distributed by Activision. 
+-->
+<!-- start.s16 dated 20-Jan-87 -->
+<!-- Protection: Bad block check for block $7 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="shanghai (20-jan-87) iigs (trex crack).2mg" size="819264" crc="c07f0cc5" sha1="03a08b9dbd14a7f672a203b27c90cc120621a4e5"/>
+</dataarea>
+</part>
+</software>
+<software name="showoff">
+<description>ShowOff (version 1.1) (trex crack)</description>
+<year>1987</year>
+<publisher>Brøderbund Software</publisher>
+<info name="programmer" value="Serge Hervy"/>
+<info name="programmer" value="Jean-Claude Lévy"/>
+<info name="version" value="1.1"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "ShowOff" is a 1987 graphics program developed by Serge Hervy and Jean-Claude Lévy, and distributed by Brøderbund Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="showoff v1.1 iigs - disk 1 - program (trex crack).2mg" size="819264" crc="f0ab3f1c" sha1="33260ca055d031b237eca650c9bf054b341170b5"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Slide show disk"/>
+<dataarea name="flop" size="819264">
+<rom name="showoff iigs - disk 2 - slide show (trex crack).2mg" size="819264" crc="52348475" sha1="2fc72e0fcd0c398a56e4b4ef5e247c9961bc5a8c"/>
+</dataarea>
+</part>
+<part name="flop3" interface="floppy_3_5">
+<feature name="part_id" value="Disk 3 - Graphics collection - world events"/>
+<dataarea name="flop" size="819264">
+<rom name="showoff iigs - disk 3 - graphics collection - world events (trex crack).2mg" size="819264" crc="fa1a5ceb" sha1="b64402b6ace256145ba3bae31682520dca7c79af"/>
+</dataarea>
+</part>
+</software>
+<software name="showoffa" cloneof="showoff">
+<description>ShowOff (Version 1.0) (trex crack)</description>
+<year>1987</year>
+<publisher>Brøderbund Software</publisher>
+<info name="programmer" value="Serge Hervy"/>
+<info name="programmer" value="Jean-Claude Lévy"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 512K Apple IIgs ROM 01 or earlier."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2023-04-13 -->
+<!-- It requires a 512K Apple IIgs ROM 01 or earlier. -->
+<!-- NOT Compatible with the Apple IIgs ROM03. -->
+<!--
+ "ShowOff" is a 1987 graphics program developed by Serge Hervy and Jean-Claude Lévy, and distributed by Brøderbund Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="showoff v1.0 iigs - disk 1 - program (trex crack).2mg" size="819264" crc="b04c2763" sha1="f42601d9af1d1441ceac97299e12fd47cd8d5b0b"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Slide show disk"/>
+<dataarea name="flop" size="819264">
+<rom name="showoff iigs - disk 2 - slide show (trex crack).2mg" size="819264" crc="52348475" sha1="2fc72e0fcd0c398a56e4b4ef5e247c9961bc5a8c"/>
+</dataarea>
+</part>
+<part name="flop3" interface="floppy_3_5">
+<feature name="part_id" value="Disk 3 - Graphics collection - world events"/>
+<dataarea name="flop" size="819264">
+<rom name="showoff iigs - disk 3 - graphics collection - world events (trex crack).2mg" size="819264" crc="fa1a5ceb" sha1="b64402b6ace256145ba3bae31682520dca7c79af"/>
+</dataarea>
+</part>
+</software>
+<software name="pirates">
+<description>Sid Meier's Pirates! (trex crack)</description>
+<year>1987</year>
+<publisher>Microprose</publisher>
+<info name="developer" value="Sid Meier"/>
+<info name="programmer" value="Dan Chang "/>
+<info name="programmer" value="Ed Magnin"/>
+<info name="usage" value="Requires a 256K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2023-02-24 -->
+<!-- It requires a 256K Apple IIgs. -->
+<!--
+ "Pirates!" is a 1987 simulation game developed by Sid Meier, programmed by Dan Chang & Ed Magnin, sound by Ken Lagace & Silas Warner, art by Micheal Haire, Murray Taylor & Max Remington and distributed by Microprose. 
+-->
+<!--
+ Protection: Modified ProDOS 8 and altered disk format 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="sid meier's pirates iigs (trex crack).2mg" size="819264" crc="5c53623d" sha1="551eb337651bee99d235a321ed921cf10efeee66"/>
+</dataarea>
+</part>
+</software>
+<software name="slntsvce">
+<description>Silent Service (version 925.01) (trex crack)</description>
+<year>1987</year>
+<publisher>Microprose</publisher>
+<info name="programmer" value="Sid Meier"/>
+<info name="programmer" value="Ed Magnin"/>
+<info name="programmer" value="Jim Synoski"/>
+<info name="programmer" value="Michael Haire"/>
+<info name="programmer" value="Michele Mahan"/>
+<info name="programmer" value="Silas Warner"/>
+<info name="programmer" value="Al Roireau"/>
+<info name="programmer" value="Larry Martin"/>
+<info name="programmer" value="Edward Bever"/>
+<info name="version" value="925.01"/>
+<info name="usage" value="Requires a 256K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 256K Apple IIgs. -->
+<!--
+ "Silent Service" is a 1987 simulation game developed by Sid Meier, Ed Magnin, Jim Synoski, Michael Haire, Michele Mahan, Silas Warner, Al Roireau, Larry Martin, and Edward Bever, and distributed by Microprose. 
+-->
+<!-- Protection: Bad block check for block $7 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="silent service v925.01 iigs (trex crack).2mg" size="819264" crc="1551b534" sha1="2f1c466c647bb448b081d69233f11d2c45092242"/>
+</dataarea>
+</part>
+</software>
+<software name="silpheed">
+<description>Silpheed - Super Dogfighter (trex crack)</description>
+<year>1987</year>
+<publisher>Sierra On-Line</publisher>
+<info name="programmer" value="John Rettig"/>
+<info name="programmer" value="Stuart Goldstein"/>
+<info name="programmer" value="Mark Seibert"/>
+<info name="programmer" value="Satoshi Uesaki"/>
+<info name="programmer" value="Nobuyuki Ogawa"/>
+<info name="programmer" value="Akira Eye"/>
+<info name="programmer" value="Fumihito Kasatani"/>
+<info name="programmer" value="Nobuyuki Aoshima"/>
+<info name="programmer" value="Hiromi Ohba"/>
+<info name="programmer" value="Takeshi Miyaji"/>
+<info name="programmer" value="Osamu Harada"/>
+<info name="programmer" value="Youichi Miyaji"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<!-- action game -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="silpheed - super dogfighter iigs - disk 1 (trex crack).2mg" size="819264" crc="dd81fea4" sha1="14ad4ba49b5e4720ca067694c2d3fdcb8501e3e0"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="silpheed - super dogfighter iigs - disk 2 (trex crack).2mg" size="819264" crc="591e8595" sha1="44160e8078077aaa8e88d4e15338db0fc5098055"/>
+</dataarea>
+</part>
+</software>
+<software name="skatedie">
+<description>
+Skate or Die! IIgs (version 1.1 07-Oct-88) (trex crack)
+</description>
+<year>1988</year>
+<publisher>Electronic Arts</publisher>
+<info name="programmer" value="Michael Kosaka"/>
+<info name="programmer" value="Stephen Landrum"/>
+<info name="programmer" value="David Bunch"/>
+<info name="programmer" value="Michelle Shelfer"/>
+<info name="usage" value="Requires a 512K Apple IIgs. Music requires 768K."/>
+<info name="version" value="1.1 07-Oct-88 - ROM 03 compatible"/>
+<!-- sod.sys16 dated 07-Oct-88 -->
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- sports game -->
+<!-- Patched to be compatible with ROM03 -->
+<!-- sod.sys16 dated 07-Oct-88 -->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="skate or die v1.1 iigs (trex crack).2mg" size="819264" crc="dde655cd" sha1="cf40c92a699cf9e7c79f1a25c3f22f32f5a28d46"/>
+</dataarea>
+</part>
+</software>
+<software name="skatediea" cloneof="skatedie">
+<description>
+Skate or Die! IIgs (version 1.0 12-Aug-88) (trex crack)
+</description>
+<year>1988</year>
+<publisher>Electronic Arts</publisher>
+<info name="programmer" value="Michael Kosaka"/>
+<info name="programmer" value="Stephen Landrum"/>
+<info name="programmer" value="David Bunch"/>
+<info name="programmer" value="Michelle Shelfer"/>
+<info name="usage" value="Requires a 512K Apple IIgs. Music requires 768K."/>
+<info name="version" value="1.0 12-Aug-88 - ROM 03 compatible"/>
+<!-- sod.sys16 dated 12-Aug-88 -->
+<sharedfeat name="compatibility" value="A2GS"/>
+<!--
+ Dump released: 2025-01-25, redump based on WOZ released on 2024-09-02 
+-->
+<!-- sports game -->
+<!-- Patched to be compatible with ROM03 -->
+<!-- sod.sys16 dated 12-Aug-88 -->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="skate or die v1.0 iigs (trex crack).2mg" size="819264" crc="f87d1ec3" sha1="9e28b572f9d53fd276066b3701de42d45ee9cc51"/>
+</dataarea>
+</part>
+</software>
+<software name="squest">
+<description>Space Quest: The Sarien Encounter (trex crack)</description>
+<year>1987</year>
+<publisher>Sierra On-Line</publisher>
+<info name="programmer" value="Scott Murphy"/>
+<info name="programmer" value="Mark Crowe"/>
+<info name="programmer" value="Jeff Stephenson"/>
+<info name="programmer" value="Chris Iden"/>
+<info name="programmer" value="Sol Ackerman"/>
+<info name="programmer" value="Ken Williams"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- Protection: Bad block check for block $634 -->
+<!-- adventure game -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="space quest - the sarien encounter iigs - disk 1 (trex crack).2mg" size="819264" crc="867688f8" sha1="a882bd87ec2843ab7c1409baf0cbfd32e91ac920"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="space quest - the sarien encounter iigs - disk 2 (trex crack).2mg" size="819264" crc="0ec7a0e8" sha1="e0fce1e36f99fcca7cfd9c3441269294154aa659"/>
+</dataarea>
+</part>
+</software>
+<software name="squest2">
+<description>Space Quest II: Vohaul's Revenge (trex crack)</description>
+<year>1988</year>
+<publisher>Sierra On-Line</publisher>
+<info name="programmer" value="Scott Murphy"/>
+<info name="programmer" value="Mark Crowe"/>
+<info name="programmer" value="Jeff Stephenson"/>
+<info name="programmer" value="Chris Iden"/>
+<info name="programmer" value="Sol Ackerman"/>
+<info name="programmer" value="Ken Williams"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- Protection: Bad block check for block $634 -->
+<!-- adventure game -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="space quest ii - vohual's revenge iigs - disk 1 (trex crack).2mg" size="819264" crc="4d463103" sha1="50df27602f17af84e2a2e4e3b221bd87aa98dad0"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="space quest ii - vohual's revenge iigs - disk 2 (trex crack).2mg" size="819264" crc="809875fc" sha1="d90165d8c51d7d54d8a17c4082e8688048950389"/>
+</dataarea>
+</part>
+</software>
+<software name="spiritex">
+<description>Spirit of Excalibur (trex crack)</description>
+<year>1991</year>
+<publisher>Virgin Mastertronic</publisher>
+<info name="developer" value="Synergistic Software"/>
+<info name="usage" value="Requires a 1MB Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 1MB Apple IIgs. -->
+<!--
+ "Spirit of Excalibur" is a 1991 adventure game developed by Synergistic Software and distributed by Virgin Mastertronic. 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="spirit of excalibur - disk 1 (trex crack).2mg" size="819264" crc="feb72edf" sha1="3aae270167a6402d7c029dc476a5d420ccf37cd9"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="spirit of excalibur - disk 2 (trex crack).2mg" size="819264" crc="4116b15e" sha1="7f8784313f36bc882207fdc1c15e40f956281734"/>
+</dataarea>
+</part>
+<part name="flop3" interface="floppy_3_5">
+<feature name="part_id" value="Disk 3"/>
+<dataarea name="flop" size="819264">
+<rom name="spirit of excalibur - disk 3 (trex crack).2mg" size="819264" crc="771e825c" sha1="5290f731aa988e6a34a3d6b284f653c02fb9e254"/>
+</dataarea>
+</part>
+</software>
+<software name="strybkwv">
+<description>Storybook Weaver (version 1.0) (trex crack)</description>
+<year>1990</year>
+<publisher>MECC</publisher>
+<info name="partno" value="A275"/>
+<info name="programmer" value="Charolyn Kapplinger"/>
+<info name="programmer" value="Patricia Korn"/>
+<info name="programmer" value="John J. Krenz"/>
+<info name="programmer" value="Brian S. Nesse"/>
+<info name="programmer" value="Jean Sharp"/>
+<info name="programmer" value="Steve Zehm"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 1MB Apple IIgs ROM 01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 1MB Apple IIgs ROM 01 or later. -->
+<!--
+ "Storybook Weaver" is a 1990 educational program developed by Charolyn Kapplinger, Patricia Korn, John J. Krenz, Brian S. Nesse, Jean Sharp, and Steve Zehm, and distributed by MECC. 
+-->
+<!-- Protection: Bad block check for block $8 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - System disk"/>
+<dataarea name="flop" size="819264">
+<rom name="storybook weaver v1.0 iigs - disk 1 - system (trex crack).2mg" size="819264" crc="c6acd3b2" sha1="814f84b31bab49e29f80797dced8bc8692055e4e"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="storybook weaver v1.0 iigs - disk 2 - program (trex crack).2mg" size="819264" crc="5bafb45c" sha1="ddb7117bb3e096be90f638e538c0551409131bec"/>
+</dataarea>
+</part>
+</software>
+<software name="strywvwa">
+<description>
+Storybook Weaver - World of Adventure (version 1.0) (trex crack)
+</description>
+<year>1991</year>
+<publisher>MECC</publisher>
+<info name="partno" value="A276"/>
+<info name="programmer" value="Patricia Korn"/>
+<info name="programmer" value="Brian S. Nesse"/>
+<info name="programmer" value="Dee Dee Roedel "/>
+<info name="programmer" value="Jean Sharp"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 1MB Apple IIgs ROM 01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 1MB Apple IIgs ROM 01 or later. -->
+<!--
+ "Storybook Weaver: World of Adventure" is a 1991 educational program developed by Patricia Korn, Brian S. Nesse, Dee Dee Roedel & Jean Sharp, and distributed by MECC. 
+-->
+<!-- Protection: Bad block check for block $8 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - System disk"/>
+<dataarea name="flop" size="819264">
+<rom name="storybook weaver - world of adventure v1.0 iigs - disk 1 - system (trex crack).2mg" size="819264" crc="589e942d" sha1="25ee4d9872302c2f235e3d775a0536a426e610d5"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="storybook weaver - world of adventure v1.0 iigs - disk 2 - program (trex crack).2mg" size="819264" crc="03e3ce87" sha1="86aca233933b10f3f25cdae7692375e60c3f6650"/>
+</dataarea>
+</part>
+</software>
+<software name="strywvmb">
+<description>
+Storybook Weaver - World of Make-Believe (version 1.0) (trex crack)
+</description>
+<year>1991</year>
+<publisher>MECC</publisher>
+<info name="partno" value="A298"/>
+<info name="programmer" value="Charolyn Kapplinger"/>
+<info name="programmer" value="Patricia Korn"/>
+<info name="programmer" value="Jean Sharp"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 1MB Apple IIgs ROM 01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 1MB Apple IIgs ROM 01 or later. -->
+<!--
+ "Storybook Weaver: World of Make-Believe" is a 1991 educational program developed by Charolyn Kapplinger, Patricia Korn, and Jean Sharp, and distributed by MECC. 
+-->
+<!-- Protection: Bad block check for block $8 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - System disk"/>
+<dataarea name="flop" size="819264">
+<rom name="storybook weaver - world of make-believe v1.0 iigs - disk 1 - system (trex crack).2mg" size="819264" crc="54e1fb99" sha1="3fc4031f0bda54e2c73ffc3f2ac8a17c1f73fc71"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="storybook weaver - world of make-believe v1.0 iigs - disk 2 - program (trex crack).2mg" size="819264" crc="0c778c48" sha1="91b4b8d9264985b63eda4b34d3140d4414a800fa"/>
+</dataarea>
+</part>
+</software>
+<software name="strsoccr">
+<description>Street Sports Soccer (trex crack)</description>
+<year>1988</year>
+<publisher>Epyx</publisher>
+<info name="developer" value="Designer Software"/>
+<info name="usage" value="Requires a 512K Apple IIgs ROM 01 or earlier."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- sports game -->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="street sports soccer iigs (trex crack).2mg" size="819264" crc="28862df6" sha1="8154843041284a59017021d4783cbe2c4f22c929"/>
+</dataarea>
+</part>
+</software>
+<software name="ssicehock">
+<description>Superstar Ice Hockey (trex crack)</description>
+<year>1988</year>
+<publisher>Mindscape</publisher>
+<info name="programmer" value="Ed Ringler"/>
+<info name="programmer" value="Andrew Caldwell"/>
+<info name="programmer" value="Clayton Wishoff"/>
+<info name="programmer" value="Simon Ffinch"/>
+<info name="programmer" value="Ed Ringler Sr."/>
+<info name="programmer" value="Chris Oke"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- sports game -->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="superstar ice hockey iigs (trex crack).2mg" size="819264" crc="6f405a10" sha1="41e963da1f389f94697c024190bbb89ac3c14421"/>
+</dataarea>
+</part>
+</software>
+<software name="arnights">
+<description>Tales From The Arabian Nights (trex crack)</description>
+<year>1988</year>
+<publisher>Unicorn Software</publisher>
+<info name="programmer" value="Stanley Brewster"/>
+<info name="programmer" value="June Stark"/>
+<info name="usage" value="Requires a 768K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "Tales From The Arabian Nights" is a 1988 educational program developed by Stanley Brewster, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="tales from the arabian nights iigs - disk 1 (trex crack).2mg" size="819264" crc="8cbcd73b" sha1="edcf50bf0feaf4aeea58b37249bcff6d0dd74416"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="tales from the arabian nights iigs - disk 2 (trex crack).2mg" size="819264" crc="f02bef73" sha1="f2637f0729b9adedb74e212f486c16b5e46acc34"/>
+</dataarea>
+</part>
+</software>
+<software name="taskfrce">
+<description>Task Force (trex crack)</description>
+<year>1990</year>
+<publisher>Britannica Software</publisher>
+<info name="programmer" value="Scott L. Patterson"/>
+<info name="programmer" value="Matthew Crysdale"/>
+<info name="programmer" value="Gregory A. Thomas"/>
+<info name="usage" value="Requires a 1MB Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 1MB Apple IIgs. -->
+<!--
+ "Task Force" is a 1990 action game developed by Scott L. Patterson, Matthew Crysdale, and Gregory A. Thomas, and distributed by Britannica Software. 
+-->
+<!--
+ Protection: Read block $63F with data markers AD AA D5 and compare read data against self generated data 
+-->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="task force iigs - disk 1 (trex crack).2mg" size="819264" crc="f6292a39" sha1="2b0f1e7316340adae862ec38f88832a40e258deb"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="task force iigs - disk 2 (trex crack).2mg" size="819264" crc="c4388a54" sha1="722b9cb8fb66a1eb1897efc18bdbd42a94d6d63d"/>
+</dataarea>
+</part>
+</software>
+<software name="tetris">
+<description>Tetris (trex crack)</description>
+<year>1988</year>
+<publisher>Spectrum HoloByte</publisher>
+<info name="programmer" value="Roland Gustafsson"/>
+<info name="programmer" value="Sean B. Barger"/>
+<info name="programmer" value="Dan Geisler"/>
+<info name="programmer" value="Daniel L. Guerra"/>
+<info name="programmer" value="Jody Sather"/>
+<info name="programmer" value="Ed Bogas"/>
+<info name="programmer" value="Neil Cormia"/>
+<info name="programmer" value="Ty Roberts"/>
+<info name="programmer" value="Gary Clayton"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Tetris" is a 1988 action game developed by Roland Gustafsson, Sean B. Barger, Dan Geisler, Daniel L. Guerra, Jody Sather, Ed Bogas, Neil Cormia, Ty Roberts, and Gary Clayton, and distributed by Spectrum HoloByte. 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="tetris iigs (trex crack).2mg" size="819264" crc="84975e86" sha1="3d3ad67086d6284359b9512282556f174c529b44"/>
+</dataarea>
+</part>
+</software>
+<software name="adsinbad">
+<description>The Adventures of Sinbad (trex crack)</description>
+<year>1988</year>
+<publisher>Unicorn Software</publisher>
+<info name="programmer" value="Curt Toumanian"/>
+<info name="programmer" value="Steve Quinn"/>
+<info name="programmer" value="Jeff Hilbers"/>
+<info name="programmer" value="Rob Landeros"/>
+<info name="programmer" value="Russ Truelove"/>
+<info name="programmer" value="Bill Williams"/>
+<info name="programmer" value="Jim Simmons"/>
+<info name="programmer" value="Andrew Caldwell"/>
+<info name="programmer" value="Douglass Sharp"/>
+<info name="usage" value="Requires a 768K Apple IIgs ROM1 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "The Adventures of Sinbad" is a 1988 educational program developed by Stanley Brewster, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="the adventures of sinbad iigs - disk 1 (trex crack).2mg" size="819264" crc="f91b3855" sha1="a003757ff7d4edb9d34e0252bc4dd8f190e29751"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="the adventures of sinbad iigs - disk 2 (trex crack).2mg" size="819264" crc="db032980" sha1="ba2b15a79e9a03eb6cc3cf12eaea425f28e24973"/>
+</dataarea>
+</part>
+</software>
+<software name="td2">
+<description>The Duel: Test Drive II (trex crack)</description>
+<year>1989</year>
+<publisher>Accolade</publisher>
+<info name="programmer" value="Allan Johnson"/>
+<info name="programmer" value="Erik Kiss"/>
+<info name="programmer" value="Amory Wong"/>
+<info name="programmer" value="Don Mattrick"/>
+<info name="programmer" value="Rick Friesen"/>
+<info name="programmer" value="Bruce Dawson"/>
+<info name="programmer" value="Randy Dillon"/>
+<info name="programmer" value="Brad Gour"/>
+<info name="programmer" value="Kris Hatlelid"/>
+<info name="programmer" value="Chris Taylor"/>
+<info name="programmer" value="John Boechler"/>
+<info name="programmer" value="Tony Lee"/>
+<info name="programmer" value="Theresa Henry"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "The Duel: Test Drive II" is a 1989 racing simulation game developed by Allan Johnson, Erik Kiss, Amory Wong, Don Mattrick, Rick Friesen, Bruce Dawson, Randy Dillon, Brad Gour, Kris Hatlelid, Chris Taylor, John Boechler, Tony Lee, and Theresa Henry, and distributed by Accolade. 
+-->
+<!--
+ This archive includes the four add-on disks that were available separately (The Muscle Cars, The Supercars, California Challenge and European Challenge). 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="the duel - test drive ii iigs (trex crack).2mg" size="819264" crc="24ca8ac2" sha1="3e73dabd7d07f6f38241e03d01404918904943b5"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Muscle cars disk"/>
+<dataarea name="flop" size="819264">
+<rom name="the duel - test drive ii iigs - the muscle cars.2mg" size="819264" crc="4f7d4aaf" sha1="88a813bb0dbf50b0c11f979341dcc337495f45ce"/>
+</dataarea>
+</part>
+<part name="flop3" interface="floppy_3_5">
+<feature name="part_id" value="Supercars disk"/>
+<dataarea name="flop" size="819264">
+<rom name="the duel - test drive ii iigs - the supercars.2mg" size="819264" crc="4c4b4713" sha1="313ccd55d4dd19c767fb51edbfd41036c34218f1"/>
+</dataarea>
+</part>
+<part name="flop4" interface="floppy_3_5">
+<feature name="part_id" value="California challenge disk"/>
+<dataarea name="flop" size="819264">
+<rom name="the duel - test drive ii iigs - california challenge.2mg" size="819264" crc="81f34f15" sha1="1fc3a54f01053023086d435ecbd7be702bd93aa1"/>
+</dataarea>
+</part>
+<part name="flop5" interface="floppy_3_5">
+<feature name="part_id" value="European challenge disk"/>
+<dataarea name="flop" size="819264">
+<rom name="the duel - test drive ii iigs - european challenge.2mg" size="819264" crc="c5ed070e" sha1="a1785f6e152d5d8e92335fb691d14a82a98d57ce"/>
+</dataarea>
+</part>
+</software>
+<software name="chsm2100">
+<description>
+The Fidelity Chessmaster 2100 (version 1.1 17-Nov-88) (trex crack)
+</description>
+<year>1988</year>
+<publisher>The Software Toolworks</publisher>
+<info name="programmer" value="Troy Heere"/>
+<info name="programmer" value="Mark Manyen"/>
+<info name="version" value="1.1 17-Nov-88"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "The Fidelity Chessmaster 2100" is a 1988 board game developed by Troy Heere and Mark Manyen, and distributed by The Software Toolworks. 
+-->
+<!-- cm2100.s16 dated 17-Nov-88 -->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="the fidelity chessmaster 2100 v1.1 iigs - disk 1 (trex crack).2mg" size="819264" crc="eeff8600" sha1="c6ce1d02383ccdbdab9d7b800e2079c046d873a3"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="the fidelity chessmaster 2100 v1.1 iigs - disk 2 (trex crack).2mg" size="819264" crc="b5a1edda" sha1="02a6312ae3a72b8f8d08f27d8ac448df61c70790"/>
+</dataarea>
+</part>
+</software>
+<software name="chsm2100a" cloneof="chsm2100">
+<description>
+The Fidelity Chessmaster 2100 (version 1.01 28-Sep-88) (trex crack)
+</description>
+<year>1988</year>
+<publisher>The Software Toolworks</publisher>
+<info name="programmer" value="Troy Heere"/>
+<info name="programmer" value="Mark Manyen"/>
+<info name="version" value="1.01 28-Sep-88"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "The Fidelity Chessmaster 2100" is a 1988 board game developed by Troy Heere and Mark Manyen, and distributed by The Software Toolworks. 
+-->
+<!-- cm2100.s16 dated 28-Sep-88 -->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="the fidelity chessmaster 2100 v1.01 iigs - disk 1 (trex crack).2mg" size="819264" crc="e14b444b" sha1="3cc6b7ba5d58bdbde2331ee5f91f0c97fca47924"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="the fidelity chessmaster 2100 v1.01 iigs - disk 2 (trex crack).2mg" size="819264" crc="470bcb76" sha1="f635bcd19ce4f48a2a274144256c7ddf1c63924d"/>
+</dataarea>
+</part>
+</software>
+<software name="grphstd">
+<description>The Graphics Studio (trex crack)</description>
+<year>1987</year>
+<publisher>Accolade</publisher>
+<info name="programmer" value="Greg Hospelhorn"/>
+<info name="programmer" value="Peter Wickman"/>
+<info name="programmer" value="Richard Antaki"/>
+<info name="usage" value="Requires a 768K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "The Graphics Studio" is a 1987 graphics program developed by Greg Hospelhorn, Peter Wickman, Richard Antaki, and distributed by Accolade. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="the graphics studio iigs (trex crack).2mg" size="819264" crc="dda653b4" sha1="a7aa41f2286a0f11c20acdac5b7fe4372114aad6"/>
+</dataarea>
+</part>
+</software>
+<software name="immortal">
+<description>The Immortal (trex crack)</description>
+<year>1990</year>
+<publisher>Electronic Arts</publisher>
+<info name="programmer" value="Will Harvey"/>
+<info name="programmer" value="Ian Gooding"/>
+<info name="programmer" value="Michael Marcanted"/>
+<info name="programmer" value="Brett G. Durrett"/>
+<info name="programmer" value="Douglas Fulton"/>
+<info name="usage" value="Requires a 1MB Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- roleplaying game -->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Play"/>
+<dataarea name="flop" size="819264">
+<rom name="the immortal iigs - disk 1 - play (trex crack).2mg" size="819264" crc="d63f3611" sha1="5ddefe34356f43f4af3d8dff6c3c4dc4180fcdb0"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Graphics"/>
+<dataarea name="flop" size="819264">
+<rom name="the immortal iigs - disk 2 - graphics (trex crack).2mg" size="819264" crc="c7a0e1a2" sha1="71d2811ed2c00f78de995e96f577874503d12a69"/>
+</dataarea>
+</part>
+</software>
+<software name="kingchgo">
+<description>The King of Chicago (trex crack)</description>
+<year>1988</year>
+<publisher>Cinemaware</publisher>
+<info name="programmer" value="Doug Sharp"/>
+<info name="usage" value="Requires a 768K Apple IIgs ROM01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs ROM01 or later. -->
+<!--
+ "The King of Chicago" is a 1988 adventure game developed by Doug Sharp and distributed by Cinemaware. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Reel 1"/>
+<dataarea name="flop" size="819264">
+<rom name="the king of chicago iigs - reel 1 (trex crack).2mg" size="819264" crc="6404e2c0" sha1="ddf23e10ca17712f943ed2e88e95ec6226599fe1"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Reel 2"/>
+<dataarea name="flop" size="819264">
+<rom name="the king of chicago iigs - reel 2 (trex crack).2mg" size="819264" crc="74d2e6cc" sha1="4067dcaa7bd4d0a8efac6359677aeaf35b7bc916"/>
+</dataarea>
+</part>
+</software>
+<software name="lstninja">
+<description>The Last Ninja (trex crack)</description>
+<year>1988</year>
+<publisher>Activision</publisher>
+<info name="programmer" value="Jeff Silverman"/>
+<info name="programmer" value="John Kroeckel"/>
+<info name="programmer" value="J. David Koch"/>
+<info name="programmer" value="Erol Otus"/>
+<info name="programmer" value="Doug Barnett"/>
+<info name="programmer" value="Russell Lieblich"/>
+<info name="programmer" value="Nicky Robinson"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "The Last Ninja" is a 1988 action game developed by Jeff Silverman, John Kroeckel, J. David Koch, Erol Otus, Doug Barnett, Russell Lieblich, and Nicky Robinson, and distributed by Activision. 
+-->
+<!-- Protection: Bad block check for block $63F -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="the last ninja iigs (trex crack).2mg" size="819264" crc="1935b58c" sha1="1b4542cd11fa2678a3647b83e35aec5f12a6633b"/>
+</dataarea>
+</part>
+</software>
+<software name="logcmstr">
+<description>The Logic Master (version 1.5) (trex crack)</description>
+<year>1990</year>
+<publisher>Unicorn Software</publisher>
+<info name="programmer" value="William Demas"/>
+<info name="programmer" value="June Stark"/>
+<info name="version" value="1.5"/>
+<info name="usage" value="Requires a 1MB Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "The Logic Master" is a 1990 educational program developed by William Demas, and June Stark, and distributed by Unicorn Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="the logic master v1.5 iigs - disk 1 (trex crack).2mg" size="819264" crc="01ac34b3" sha1="b18c2021f3360684a2156e59de69074c5c3d5b79"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="the logic master v1.5 iigs - disk 2 (trex crack).2mg" size="819264" crc="ce00fefc" sha1="a842bb884202af66e865117290c24a279003263e"/>
+</dataarea>
+</part>
+</software>
+<software name="musstdio1">
+<description>The Music Studio (version 1.0) (trex crack)</description>
+<year>1988</year>
+<publisher>Activision</publisher>
+<info name="programmer" value="Ric Forrester"/>
+<info name="programmer" value="Rick Parfitt"/>
+<info name="programmer" value="Peter Wickman"/>
+<info name="programmer" value="Paul Zuzelo"/>
+<info name="programmer" value="Sally Froud"/>
+<info name="programmer" value="Jeff Cable"/>
+<info name="programmer" value="Carl Bacani"/>
+<info name="programmer" value="Jim Inscore"/>
+<info name="programmer" value="Sydney Williams Lewis"/>
+<info name="programmer" value="Nancy Waisanen"/>
+<info name="programmer" value="Steve Young"/>
+<info name="programmer" value="Laura E. Singer"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<info name="version" value="1.0"/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2026-01-05 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!-- audio program -->
+<!-- Protection: Bad block check for block $7 -->
+<!-- Activision removed the copy protection for v2.0 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program disk"/>
+<dataarea name="flop" size="1296337">
+<rom name="the music studio v1.0 iigs - disk 1 (trex crack).2mg" size="819264" crc="ea5c86fd" sha1="06b7f4dc8225c5bf0317dcca7ec9ae21093d9b17"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Additional songs and instruments disk"/>
+<dataarea name="flop" size="1296362">
+<rom name="the music studio iigs - disk 2 - additional songs and instruments.2mg" size="819264" crc="610ea822" sha1="071329f3e8c303086a576fd47d85dccc4f57ee2d"/>
+</dataarea>
+</part>
+</software>
+<software name="ntsbalpha">
+<description>The New Talking Stickybear Alphabet (trex crack)</description>
+<year>1988</year>
+<publisher>Optimum Resource</publisher>
+<info name="developer" value="Optimum Resource"/>
+<info name="usage" value="Requires a 512K Apple IIgs ROM01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2025-01-25 -->
+<!-- It requires a 512K Apple IIgs ROM01 or later. -->
+<!--
+ "The New Talking Stickybear Alphabet" is an educational program designed to teach children the alphabet through the use of graphics and speech 
+-->
+<!--
+ Protection: Unformatted track $03, Side $01 (bad blocks $54 through $5F) check 
+-->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="the new talking stickybear alphabet iigs disk 1 (trex crack).2mg" size="819264" crc="4f80d28b" sha1="c6b243cc8aa3c2b39658095c5a1b91bbdcd40629"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="the new talking stickybear alphabet iigs disk 2 (trex crack).2mg" size="819264" crc="35817368" sha1="1426cf78a664e0ec41128fec150c084e9d1f3874"/>
+</dataarea>
+</part>
+</software>
+<software name="ntsbopp">
+<description>The New Talking Stickybear Opposites (trex crack)</description>
+<year>1988</year>
+<publisher>Optimum Resource</publisher>
+<info name="developer" value="Optimum Resource"/>
+<info name="usage" value="Requires a 512K Apple IIgs ROM01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2025-01-25 -->
+<!-- It requires a 512K Apple IIgs ROM01 or later. -->
+<!--
+ "The New Talking Stickybear Opposites" is an educational program designed to teach children opposites through the use of graphics and speech 
+-->
+<!--
+ Protection: Unformatted track $03, Side $01 (bad blocks $54 through $5F) check 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="the new talking stickybear opposites iigs (trex crack).2mg" size="819264" crc="a2ce5ec8" sha1="0954c66f8858d26ce70c1926236b4115f705f2c5"/>
+</dataarea>
+</part>
+</software>
+<software name="ntsbshapes">
+<description>The New Talking Stickybear Shapes (trex crack)</description>
+<year>1988</year>
+<publisher>Optimum Resource</publisher>
+<info name="programmer" value="Richard Hefter"/>
+<info name="programmer" value="David Cunningham"/>
+<info name="programmer" value="Susan Dubicki"/>
+<info name="usage" value="Requires a 512K Apple IIgs ROM01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2025-01-25 -->
+<!-- It requires a 512K Apple IIgs ROM01 or later. -->
+<!--
+ "The New Talking Stickybear Shapes" is an educational program designed to teach children basic shapes through the use of graphics and speech 
+-->
+<!--
+ Protection: Unformatted track $03, Side $01 (bad blocks $54 through $5F) check 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="the new talking stickybear shapes iigs (trex crack).2mg" size="819264" crc="f52125b9" sha1="93967102bb9642aba3607291cf30d6e0a1a01c5e"/>
+</dataarea>
+</part>
+</software>
+<software name="printshp">
+<description>The Print Shop (version 1.0) (trex crack)</description>
+<year>1987</year>
+<publisher>Brøderbund Software</publisher>
+<info name="programmer" value="David Balsam"/>
+<info name="programmer" value="Martin Kahn"/>
+<info name="programmer" value="Corey Kosak"/>
+<info name="programmer" value="Ann E. Kronen"/>
+<info name="programmer" value="Susan E. Schlangen"/>
+<info name="programmer" value="Richard Whittaker"/>
+<info name="programmer" value="Michelle McBride"/>
+<info name="programmer" value="Don Albrecht"/>
+<info name="programmer" value="Leila Bronstein"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 512K Apple IIgs ROM 01 or earlier."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs ROM 01 or earlier. -->
+<!-- NOT Compatible with the Apple IIgs ROM03. -->
+<!--
+ "The Print Shop IIgs" is a 1987 graphics program developed by David Balsam, Martin Kahn, Corey Kosak, Ann E. Kronen, Susan E. Schlangen, Richard Whittaker, Michelle McBride, Don Albrecht, and Leila Bronstein, and distributed by Brøderbund Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="the print shop v1.0 iigs (trex crack).2mg" size="819264" crc="0b761d41" sha1="69b56345568b39fd8aa59455b44a341a600c848e"/>
+</dataarea>
+</part>
+</software>
+<software name="thrdcrir">
+<description>The Third Courier (trex crack)</description>
+<year>1989</year>
+<publisher>Accolade</publisher>
+<info name="programmer" value="Carol Manley"/>
+<info name="programmer" value="Ivan Manley"/>
+<info name="programmer" value="Mike Branham"/>
+<info name="programmer" value="Robert Clardy"/>
+<info name="programmer" value="Chris Barker"/>
+<info name="programmer" value="Scott Wallin"/>
+<info name="programmer" value="Miik Nichols"/>
+<info name="programmer" value="Sheldon Safir"/>
+<info name="programmer" value="Mark Wallace"/>
+<info name="usage" value="Requires a 768K Apple IIgs ROM01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs ROM01 or later. -->
+<!--
+ "The Third Courier" is a 1989 adventure game developed by Carol Manley, Ivan Manley, Mike Branham, Robert Clardy, Chris Barker, Scott Wallin, Miik Nichols, Sheldon Safir, and Mark Wallace, and distributed by Accolade. 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="the third courier iigs - disk 1 (trex crack).2mg" size="819264" crc="a3a2c00f" sha1="3773681ec07b65085e6e0e311974c0ad28e5f7c7"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="the third courier iigs - disk 2 (trex crack).2mg" size="819264" crc="619ff292" sha1="521c9c171ab84cc6a670e541502890c605db3df8"/>
+</dataarea>
+</part>
+</software>
+<software name="twrmyrgl">
+<description>The Tower of Myraglen (version 1.0) (trex crack)</description>
+<year>1987</year>
+<publisher>PBI Software</publisher>
+<info name="programmer" value="Richard L. Seaborne"/>
+<info name="programmer" value="Jeff A. Lamberts"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 768K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "The Tower of Myraglen" is a 1987 roleplaying game developed by Richard L. Seaborne and Jeff A. Lamberts, and distributed by PBI Software. 
+-->
+<!-- Protection: Bad block check for block $7 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Start-up disk"/>
+<dataarea name="flop" size="819264">
+<rom name="the tower of myraglen v1.0 iigs - disk 1 - start-up disk (trex crack).2mg" size="819264" crc="ec1b6795" sha1="8bb9f1a286fe7ec3abcfae2fddf3b3da5eab1507"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="the tower of myraglen v1.0 iigs - disk 2 - program disk (trex crack).2mg" size="819264" crc="2173bd50" sha1="8ed4b7fde77680225a0d124d079eacd49563c8bd"/>
+</dataarea>
+</part>
+</software>
+<software name="3stooges">
+<description>The Three Stooges (trex crack)</description>
+<year>1987</year>
+<publisher>Cinemaware</publisher>
+<info name="programmer" value="John Cutter"/>
+<info name="programmer" value="Robert Jacob"/>
+<info name="programmer" value="Phyllis Jacob"/>
+<info name="programmer" value="Ed Magnin"/>
+<info name="programmer" value="Russell Truelove"/>
+<info name="programmer" value="Jim Simmons"/>
+<info name="programmer" value="Patrick Cook"/>
+<info name="usage" value="Requires an 1.25MB Apple IIgs ROM01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 1.25MB Apple IIgs ROM01 or later. -->
+<!--
+ "The Three Stooges" is a 1987 adventure game developed by John Cutter, Robert Jacob, Phyllis Jacob, Ed Magnin, Russell Truelove, Jim Simmons, and Patrick Cook and distributed by Cinemaware. 
+-->
+<!-- Protection: Bad block check for block $10D -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Reel 1"/>
+<dataarea name="flop" size="819264">
+<rom name="The Three Stooges IIgs - Reel 1 (trex crack).2mg" size="819264" crc="bdde6b7f" sha1="ae839c996f29692326f06066e1d64082120d1f5d"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Reel 2"/>
+<dataarea name="flop" size="819264">
+<rom name="The Three Stooges IIgs - Reel 2 (trex crack).2mg" size="819264" crc="d1d46abd" sha1="64bdaea99f69fdff61dade0dbe6f2e57668e70a4"/>
+</dataarea>
+</part>
+</software>
+<software name="wndanimk">
+<description>The Wonders of the Animal Kingdom (trex crack)</description>
+<year>1989</year>
+<publisher>Unicorn Software</publisher>
+<info name="programmer" value="Stan Brewster"/>
+<info name="programmer" value="Joseph Hewitt"/>
+<info name="programmer" value="June Stark"/>
+<info name="usage" value="Requires a 1MB Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 1MB Apple IIgs. -->
+<!--
+ "The Wonders of the Animal Kingdom" is a 1989 educational program developed by Stan Brewster, Joseph B. Hewitt IV, and June Stark, and distributed by Unicorn Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="the wonders of the animal kingdom iigs - disk 1 (trex crack).2mg" size="819264" crc="d577eacc" sha1="80fd89fe895c4a40ba9b137804307924308cd0b8"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="the wonders of the animal kingdom iigs - disk 2 (trex crack).2mg" size="819264" crc="56212d49" sha1="1126a5de1294aa72dcacba28d3ee32c6754528f8"/>
+</dataarea>
+</part>
+</software>
+<software name="wordmstr">
+<description>The Word Master (trex crack)</description>
+<year>1989</year>
+<publisher>Unicorn Software</publisher>
+<info name="programmer" value="William Demas"/>
+<info name="programmer" value="Joseph Hewitt"/>
+<info name="usage" value="Requires a 1MB Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 1MB Apple IIgs. -->
+<!--
+ "The Word Master" is a 1989 educational program developed by William Demas and Joseph B. Hewitt IV, and distributed by Unicorn Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="the word master iigs (trex crack).2mg" size="819264" crc="a1223d2c" sha1="c22fe72a7f88f7dbea37970f77fd0555589016f3"/>
+</dataarea>
+</part>
+</software>
+<software name="thexder10" cloneof="thexder">
+<description>
+Thexder (version 1.0) (trex crack) (No OS, not self booting)
+</description>
+<year>1987</year>
+<publisher>Sierra On-Line</publisher>
+<info name="programmer" value="H. Godai"/>
+<info name="programmer" value="S. Uesaka"/>
+<info name="programmer" value="Michael D. Branham"/>
+<info name="programmer" value="Robert C. Clardy"/>
+<info name="programmer" value="John P. Conley"/>
+<info name="programmer" value="Lloyd Ollmann, Jr."/>
+<info name="programmer" value="Michael Ormsby"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!--
+ Original release by Sierra On-Line - Did NOT come with OS and was NOT self bootable 
+-->
+<!--
+ The file "othexder" had been undeleted (and cracked) and is closer to v2.7 in how it's demo sounds fade 
+-->
+<!-- Protection: Bad block check for block $634 -->
+<!-- action game -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="thexder v1.0 iigs (trex crack).2mg" size="819264" crc="5a105720" sha1="31061b4561c967d824936c94ce882f2efcb017da"/>
+</dataarea>
+</part>
+</software>
+<software name="thexder">
+<description>Thexder (version 2.7) (trex crack)</description>
+<year>1987</year>
+<publisher>Sierra On-Line</publisher>
+<info name="programmer" value="H. Godai"/>
+<info name="programmer" value="S. Uesaka"/>
+<info name="programmer" value="Michael D. Branham"/>
+<info name="programmer" value="Robert C. Clardy"/>
+<info name="programmer" value="John P. Conley"/>
+<info name="programmer" value="Lloyd Ollmann, Jr."/>
+<info name="programmer" value="Michael Ormsby"/>
+<info name="version" value="2.7"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- Protection: Bad block check for block $634 -->
+<!-- action game -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="thexder v2.7 iigs (trex crack).2mg" size="819264" crc="7fa5ad73" sha1="acb227363d426c86ab5ac80c126fc430616cb535"/>
+</dataarea>
+</part>
+</software>
+<software name="topdraw">
+<description>TopDraw (version 1.01A (8/4/87)) (trex crack)</description>
+<year>1987</year>
+<publisher>StyleWare</publisher>
+<info name="programmer" value="Robert A. Hearn"/>
+<info name="programmer" value="Jeff G. Erickson"/>
+<info name="version" value="1.01A (8/4/87)"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2025-01-25 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "TopDraw" is a professional object-oriented graphics drawing environment. Beagle Bros Software later acquired the StyleWare library and rebranded TopDraw as BeagleDraw. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="topdraw v1.01a iigs (trex crack).2mg" size="819264" crc="d7cf235e" sha1="b488b0cef54cb71f447a0d6b508f86220cb09d4d"/>
+</dataarea>
+</part>
+</software>
+<software name="topdraw100a" cloneof="topdraw">
+<description>TopDraw (version 1.00A (7/12/87)) (trex crack)</description>
+<year>1987</year>
+<publisher>StyleWare</publisher>
+<info name="programmer" value="Robert A. Hearn"/>
+<info name="programmer" value="Jeff G. Erickson"/>
+<info name="version" value="1.00A (7/12/87)"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- graphics program -->
+<!--
+ TopDraw later became Beagle Draw sold under the Beagle Brothers banner. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="topdraw v1.00a iigs (trex crack).2mg" size="819264" crc="39e7967f" sha1="35746bbc2232251d96264989705a6e6286bafef5"/>
+</dataarea>
+</part>
+</software>
+<software name="triango">
+<description>TrianGo (version 1.1 12-Dec-88) (trex crack)</description>
+<year>1988</year>
+<publisher>California Dreams</publisher>
+<info name="programmer" value="Staszek Bartkowski"/>
+<info name="programmer" value="Marcin Szostakowski"/>
+<info name="programmer" value="Maciej Markuszewski"/>
+<info name="programmer" value="Dorota Błaszczak"/>
+<info name="version" value="1.1 12-Dec-88"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2026-01-05 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "TrianGo" is a 1988 board game developed by Staszek Bartkowski, Marcin Szostakowski, Maciej Markuszewski, Dorota Błaszczak, and distributed by California Dreams. 
+-->
+<!-- triango.sys16 dated 12-Dec-88 -->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="triango v1.1 iigs (trex crack).2mg" size="819264" crc="f8d47b34" sha1="aacc5f57dded29acd945d0f46b046415b2e6e2fb"/>
+</dataarea>
+</part>
+</software>
+<software name="triangoa" cloneof="triango">
+<description>TrianGo (version 1.0 02-Oct-88) (trex crack)</description>
+<year>1988</year>
+<publisher>California Dreams</publisher>
+<info name="programmer" value="Staszek Bartkowski"/>
+<info name="programmer" value="Marcin Szostakowski"/>
+<info name="programmer" value="Maciej Markuszewski"/>
+<info name="programmer" value="Dorota Błaszczak"/>
+<info name="version" value="1.0 02-Oct-88"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "TrianGo" is a 1988 board game developed by Staszek Bartkowski, Marcin Szostakowski, Maciej Markuszewski, Dorota Błaszczak, and distributed by California Dreams. 
+-->
+<!-- triango.sys16 dated 02-Oct-88 -->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="triango v1.0 iigs (trex crack).2mg" size="819264" crc="719968cf" sha1="8cfcb54548794c179d7e394f1ada2f53f0578a5e"/>
+</dataarea>
+</part>
+</software>
+<software name="uninvite">
+<description>Uninvited (trex crack)</description>
+<year>1988</year>
+<publisher>ICOM Simulations</publisher>
+<info name="programmer" value="Fred Allen"/>
+<info name="programmer" value="David Marsh"/>
+<info name="programmer" value="Karl Roelofs"/>
+<info name="programmer" value="Todd Squires"/>
+<info name="programmer" value="Craig Erickson"/>
+<info name="programmer" value="Steven Hays"/>
+<info name="programmer" value="Terry Schulenburg"/>
+<info name="programmer" value="Darin Adler"/>
+<info name="programmer" value="Jay Zipnick"/>
+<info name="programmer" value="Waldemar Horwat"/>
+<info name="programmer" value="Mark Waterman"/>
+<info name="programmer" value="Tod Zipnick"/>
+<info name="programmer" value="Billy Wolf"/>
+<info name="usage" value="Requires a 768K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "Uninvited" is a 1988 adventure game developed by Fred Allen, David Marsh, Karl Roelofs, Todd Squires, Craig Erickson, Steven Hays, Terry Schulenburg, Darin Adler, Jay Zipnick, Waldemar Horwat, Mark Waterman, Tod Zipnick, and Billy Wolf, and distributed by ICOM Simulations. 
+-->
+<!-- Protection: Bad block check for block $7 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - System disk"/>
+<dataarea name="flop" size="819264">
+<rom name="uninvited iigs - disk 1 - system disk (trex crack).2mg" size="819264" crc="e76d0516" sha1="1ce51656aa8274517d3ecd0314b55294e76023e2"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="uninvited iigs - disk 2 - program disk (trex crack).2mg" size="819264" crc="dcd37fdd" sha1="486497733c8a341982709c87fc864570d630da7d"/>
+</dataarea>
+</part>
+</software>
+<software name="usageogr">
+<description>USA GeoGraph (Version 1.0) (trex crack)</description>
+<year>1989</year>
+<publisher>MECC</publisher>
+<info name="programmer" value="Nelson Whyatt"/>
+<info name="programmer" value="Paul R. Wenker"/>
+<info name="programmer" value="Wayne Studer"/>
+<info name="programmer" value="Steven D. Splinter"/>
+<info name="programmer" value="John L. Krenz"/>
+<info name="programmer" value="Charolyn Kapplinger"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 768K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2023-04-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "USA GeoGraph" is a 1989 educational program developed by Nelson Whyatt, Paul R. Wenker, Wayne Studer, Steven D. Splinter, John L. Krenz, and Charolyn Kapplinger, and distributed by MECC Software. 
+-->
+<!-- Protection: Bad block check for block $8 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="usa geograph v1.0 iigs - disk 1 - program (trex crack).2mg" size="819264" crc="f968d252" sha1="ebda6798c67d277a15314b97d116f40e6b072ccd"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Information disk"/>
+<dataarea name="flop" size="819264">
+<rom name="usa geograph v1.0 iigs - disk 2 - Information (trex crack).2mg" size="819264" crc="c5bc2c2c" sha1="6ef5b7be7d2a813387cfb4fa381c76d40d94c6ca"/>
+</dataarea>
+</part>
+</software>
+<software name="vgscraps">
+<description>Vegas Craps (version 1.0) (trex crack)</description>
+<year>1988</year>
+<publisher>California Dreams</publisher>
+<info name="programmer" value="Krzysztof Koziarski"/>
+<info name="programmer" value="Maciej Markuszewski"/>
+<info name="programmer" value="Marcin Szostakowski"/>
+<info name="programmer" value="Dorota Błaszczak"/>
+<info name="version" value="1.0"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Vegas Gambler" is a 1988 simulation game developed by Krzysztof Koziarski, Maciej Markuszewski, Marcin Szostakowski, and Dorota Błaszczak, and distributed by California Dreams. 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="vegas craps v1.0 iigs (trex crack).2mg" size="819264" crc="cf206b2a" sha1="eb1731663bd71f9beb0e66f129e3103ac236b629"/>
+</dataarea>
+</part>
+</software>
+<software name="vegasgmb">
+<description>Vegas Gambler (version 1.1 25-Jul-88) (trex crack)</description>
+<year>1988</year>
+<publisher>California Dreams</publisher>
+<info name="programmer" value="Marek Jackiewicz"/>
+<info name="programmer" value="Andrzej Miciłkiewicz"/>
+<info name="programmer" value="Marcin Szostakowski"/>
+<info name="programmer" value="Maciej Markuszewski"/>
+<info name="programmer" value="Dorota Błaszczak"/>
+<info name="version" value="1.1 25-Jul-88"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Vegas Gambler" is a 1988 simulation game developed by Marek Jackiewicz, Andrzej Miciłkiewicz, Marcin Szostakowski, Maciej Markuszewski, and Dorota Błaszczak, and distributed by California Dreams. 
+-->
+<!-- gambler.sys16 dated 25-Jul-88 -->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="vegas gambler v1.1 iigs (trex crack).2mg" size="819264" crc="53f1a66e" sha1="f49918fbe8a32f83a17558e1764b14a0b26ca35c"/>
+</dataarea>
+</part>
+</software>
+<software name="vegasgmba" cloneof="vegasgmb">
+<description>Vegas Gambler (version 1.0 07-Jun-88) (trex crack)</description>
+<year>1988</year>
+<publisher>California Dreams</publisher>
+<info name="programmer" value="Marek Jackiewicz"/>
+<info name="programmer" value="Andrzej Miciłkiewicz"/>
+<info name="programmer" value="Marcin Szostakowski"/>
+<info name="programmer" value="Maciej Markuszewski"/>
+<info name="programmer" value="Dorota Błaszczak"/>
+<info name="version" value="1.0 07-Jun-88"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Vegas Gambler" is a 1988 simulation game developed by Marek Jackiewicz, Andrzej Miciłkiewicz, Marcin Szostakowski, Maciej Markuszewski, and Dorota Błaszczak, and distributed by California Dreams. 
+-->
+<!-- gambler.sys16 dated 07-Jun-88 -->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="vegas gambler v1.0 iigs (trex crack).2mg" size="819264" crc="fb0db877" sha1="89662ac60bde13b8f54db4730a9fd3ee4d5c6b3e"/>
+</dataarea>
+</part>
+</software>
+<software name="warmidle">
+<description>War in Middle Earth (trex crack)</description>
+<year>1989</year>
+<publisher>Melbourne House</publisher>
+<info name="programmer" value="Ron Harris"/>
+<info name="programmer" value="Robert Clardy"/>
+<info name="programmer" value="Alan B. Clark"/>
+<info name="programmer" value="Graeme Devine"/>
+<info name="programmer" value="Mike Branham"/>
+<info name="programmer" value="Lloyd Ollmann, Jr."/>
+<info name="programmer" value="John Conley"/>
+<info name="programmer" value="Jim McBride"/>
+<info name="programmer" value="Michael Park"/>
+<info name="programmer" value="David Schroeder"/>
+<info name="programmer" value="Michael Ormsby"/>
+<info name="programmer" value="Mike Christy"/>
+<info name="programmer" value="Ann Dickens Clardy"/>
+<info name="programmer" value="Marcus Streets"/>
+<info name="programmer" value="Mark Riley"/>
+<info name="programmer" value="Mike Singleton"/>
+<info name="usage" value="Requires a 768K Apple IIgs ROM01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 768K Apple IIgs ROM01 or later. -->
+<!--
+ "War in Middle Earth" is a 1989 adventure game developed by Ron Harris, Robert Clardy, Alan B. Clark, Graeme Devine, Mike Branham, Lloyd Ollmann, Jr., John Conley, Jim McBride, Michael Park, David Schroeder, Michael Ormsby, Mike Christy, Ann Dickens Clardy, Marcus Streets, Mark Riley, and Mike Singleton, and distributed by Melbourne House. 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="war in middle earth - disk 1 (trex crack).2mg" size="819264" crc="8f6287f7" sha1="4864416d025f1b9b17aba10b8ce47c1075b84279"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="war in middle earth - disk 2 (trex crack).2mg" size="819264" crc="5ced6c65" sha1="83aa06b12b3741e18028da966aa317dce7001d89"/>
+</dataarea>
+</part>
+</software>
+<software name="carmnusa">
+<description>
+Where in the U.S.A. is Carmen Sandiego? (trex crack)
+</description>
+<year>1989</year>
+<publisher>Brøderbund Software</publisher>
+<info name="programmer" value="Gene Portwood"/>
+<info name="programmer" value="Lauren Elliot"/>
+<info name="programmer" value="Peter Adams"/>
+<info name="programmer" value="Leila Bronstein"/>
+<info name="programmer" value="Julie Glavin"/>
+<info name="programmer" value="Michelle McBride"/>
+<info name="programmer" value="Dan Guerra"/>
+<info name="programmer" value="Les Pardue"/>
+<info name="programmer" value="Bevan Hulfenstein"/>
+<info name="programmer" value="Louis Evans"/>
+<info name="programmer" value="Tom Rettig"/>
+<info name="usage" value="Requires a 1MB Apple IIgs ROM 01 or later."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 1MB Apple IIgs ROM 01 or later. -->
+<!--
+ "Where in the U.S.A. is Carmen Sandiego?" is a 1989 educational game developed by Gene Portwood, Lauren Elliot, Peter Adams, Leila Bronstein, Julie Glavin, Michelle McBride, Dan Guerra, Les Pardue, Bevan Hulfenstein, Louis Evans, and Tom Rettig, and distributed by Brøderbund Software. 
+-->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="where in the u.s.a. is carmen sandiego iigs - disk 1 (trex crack).2mg" size="819264" crc="43b00548" sha1="6b6a07afdd81acb4bb6493f0248004a449854a4f"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="where in the u.s.a. is carmen sandiego iigs - disk 2 (trex crack).2mg" size="819264" crc="21ccbf7c" sha1="cd74b2163039f448c5b765a6f3d12264df2a3910"/>
+</dataarea>
+</part>
+</software>
+<software name="carmnwld">
+<description>
+Where in the World is Carmen Sandiego? (trex crack)
+</description>
+<year>1989</year>
+<publisher>Brøderbund Software</publisher>
+<info name="programmer" value="Gene Portwood"/>
+<info name="programmer" value="Lauren Elliott"/>
+<info name="programmer" value="Loring Vogel"/>
+<info name="programmer" value="Leila Bronstein"/>
+<info name="programmer" value="Don Albrecht"/>
+<info name="programmer" value="Michelle McBride"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Where in the World is Carmen Sandiego?" is a 1989 educational game developed by Gene Portwood, Lauren Elliott, Loring Vogel, Leila Bronstein, Don Albrecht, and Michelle McBride, and distributed by Brøderbund Software. 
+-->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1"/>
+<dataarea name="flop" size="819264">
+<rom name="where in the world is carmen sandiego iigs - disk 1 (trex crack).2mg" size="819264" crc="5953ba60" sha1="ee78c790a74b8ea401eb7ea66f91651d9e5286d7"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2"/>
+<dataarea name="flop" size="819264">
+<rom name="where in the world is carmen sandiego iigs - disk 2 (trex crack).2mg" size="819264" crc="93417ba2" sha1="76b70ebd2d0974ba3b77de31e0f3f96aee6ed332"/>
+</dataarea>
+</part>
+</software>
+<software name="wingames">
+<description>Winter Games (trex crack)</description>
+<year>1987</year>
+<publisher>Epyx</publisher>
+<info name="developer" value="Westwood Studios"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- sports game -->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="winter games iigs (trex crack).2mg" size="819264" crc="03f522af" sha1="467d2782f572c107f2b9fa7789761d789ce21763"/>
+</dataarea>
+</part>
+</software>
+<software name="wldgames">
+<description>World Games (trex crack)</description>
+<year>1987</year>
+<publisher>Epyx</publisher>
+<info name="developer" value="Westwood Studios"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- sports game -->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="world games iigs (trex crack).2mg" size="819264" crc="6b94c2b7" sha1="34bb9fbd79847d2cbf7c1ad9ba087faa986a16a0"/>
+</dataarea>
+</part>
+</software>
+<software name="wldgeogr">
+<description>World GeoGraph (Version 1.3) (trex crack)</description>
+<year>1989</year>
+<publisher>MECC</publisher>
+<info name="programmer" value="Charolyn Kapplinger"/>
+<info name="programmer" value="John L. Krenz"/>
+<info name="programmer" value="Diane Portner"/>
+<info name="programmer" value="Steven D. Splinter"/>
+<info name="programmer" value="Wayne Studer"/>
+<info name="programmer" value="Paul R. Wenker"/>
+<info name="programmer" value="Nelson Whyatt"/>
+<info name="version" value="1.3"/>
+<info name="usage" value="Requires a 768K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2023-04-13 -->
+<!-- It requires a 768K Apple IIgs. -->
+<!--
+ "USA GeoGraph" is a 1989 educational program developed by Charolyn Kapplinger, John L. Krenz, Diane Portner, Steven D. Splinter, Wayne Studer, Paul R. Wenker, and Nelson Whyatt, and distributed by MECC Software. 
+-->
+<!-- Protection: Bad block check for block $8 -->
+<part name="flop1" interface="floppy_3_5">
+<feature name="part_id" value="Disk 1 - Program disk"/>
+<dataarea name="flop" size="819264">
+<rom name="world geograph v1.3 iigs - disk 1 - program (trex crack).2mg" size="819264" crc="a296d62a" sha1="15aa6627a08b3c4f3d1c9e7651218311f07e481e"/>
+</dataarea>
+</part>
+<part name="flop2" interface="floppy_3_5">
+<feature name="part_id" value="Disk 2 - Information disk"/>
+<dataarea name="flop" size="819264">
+<rom name="world geograph v1.3 iigs - disk 2 - Information (trex crack).2mg" size="819264" crc="1ec2c293" sha1="6131f8ea4938f9f180e8a5f0a67d5f8f38d90e22"/>
+</dataarea>
+</part>
+</software>
+<software name="wltrgolf">
+<description>World Tour Golf (trex crack)</description>
+<year>1987</year>
+<publisher>Electronic Arts</publisher>
+<info name="author" value="Evan and Nicky Robinson and Paul Reiche III"/>
+<info name="programmer" value="John Selhorst"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- sports game -->
+<!--
+ Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="world tour golf iigs (trex crack).2mg" size="819264" crc="bf54fe36" sha1="3b1082b75860d10493c9015c5fd22ef3150c686b"/>
+</dataarea>
+</part>
+</software>
+<software name="wcelite">
+<description>Writer's Choice Elite (trex crack)</description>
+<year>1987</year>
+<publisher>Activision</publisher>
+<info name="programmer" value="Richard Danais"/>
+<info name="programmer" value="Nancy Philippine"/>
+<info name="programmer" value="Bernard Gallet"/>
+<info name="programmer" value="Luc Barthelet"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Writer's Choice Elite" is a 1987 productivity program developed by Richard Danais, Nancy Philippine, Bernard Gallet, and Luc Barthelet, and distributed by Activision. 
+-->
+<!-- Protection: Bad block check for block $7 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="writer's choice elite iigs (trex crack).2mg" size="819264" crc="d4d891e1" sha1="d7a386e9fc286018505d61eff800ca892bcae304"/>
+</dataarea>
+</part>
+</software>
+<software name="xenocide">
+<description>Xenocide (version 25-Sep-89) (unprotected)</description>
+<year>1989</year>
+<publisher>Micro Revelations</publisher>
+<info name="programmer" value="Brian Greenstone"/>
+<info name="programmer" value="Dave Triplett"/>
+<info name="version" value="25-Sep-89"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Xenocide" is a 1989 action game developed by Brian Greenstone and Dave Triplett, and distributed by Micro Revelations. 
+-->
+<!--
+ xeno.sys16 dated 25-Sep-89 14:23, 63090 bytes long, 121 blocks 
+-->
+<!--
+ Unprotected version released by Micro Revelations. 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="xenocide (25-sep-89) iigs.2mg" size="819264" crc="ea4f3204" sha1="a85cca9ca740ecad53a8ccb153a53228989115fb"/>
+</dataarea>
+</part>
+</software>
+<software name="xenocidea" cloneof="xenocide">
+<description>Xenocide (version 11-Aug-89) (trex crack)</description>
+<year>1989</year>
+<publisher>Micro Revelations</publisher>
+<info name="programmer" value="Brian Greenstone"/>
+<info name="programmer" value="Dave Triplett"/>
+<info name="version" value="11-Aug-89"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Xenocide" is a 1989 action game developed by Brian Greenstone and Dave Triplett, and distributed by Micro Revelations. 
+-->
+<!--
+ xeno.sys16 dated 11-Aug-89 09:34, 65085 bytes long, 129 blocks 
+-->
+<!--
+ Protection: Check for Macintosh "tag bytes" on block $4E1 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="xenocide (11-aug-89) iigs (trex crack).2mg" size="819264" crc="00bf834e" sha1="0818389d9586d5e46e0e400a1da51f8a7dd35bcb"/>
+</dataarea>
+</part>
+</software>
+<software name="xenocideb" cloneof="xenocide">
+<description>Xenocide (version 21-Jul-89) (trex crack)</description>
+<year>1989</year>
+<publisher>Micro Revelations</publisher>
+<info name="programmer" value="Brian Greenstone"/>
+<info name="programmer" value="Dave Triplett"/>
+<info name="version" value="21-Jul-89"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2026-01-05 -->
+<!-- It requires a 512K Apple IIgs. -->
+<!--
+ "Xenocide" is a 1989 action game developed by Brian Greenstone and Dave Triplett, and distributed by Micro Revelations. 
+-->
+<!--
+ xeno.sys16 dated 21-JUL-89 11:35, 64996 bytes long, 128 blocks 
+-->
+<!--
+ Protection: Check for Macintosh "tag bytes" on block $4E1 
+-->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="xenocide (21-jul-89) iigs (trex crack).2mg" size="819264" crc="1358f0ad" sha1="250fcbf30f38f2df388544151399d4d42b434f19"/>
+</dataarea>
+</part>
+</software>
+<software name="zanygolf">
+<description>Zany Golf (trex crack)</description>
+<year>1988</year>
+<publisher>Electronic Arts</publisher>
+<info name="programmer" value="Will Harvey"/>
+<info name="programmer" value="Jim Nitchals"/>
+<info name="programmer" value="Ian Gooding"/>
+<info name="programmer" value="Doug Fulton"/>
+<info name="usage" value="Requires a 512K Apple IIgs."/>
+<sharedfeat name="compatibility" value="A2GS"/>
+<!-- Dump released: 2021-08-13 -->
+<!-- sports game -->
+<!-- Protection: Nibble count on tracks $20 & $21 -->
+<part name="flop1" interface="floppy_3_5">
+<dataarea name="flop" size="819264">
+<rom name="zany golf iigs (trex crack).2mg" size="819264" crc="5e917b13" sha1="37658ef75ca9a35277023e66fe0280058d8a237a"/>
+</dataarea>
+</part>
+</software>
 </softwarelist>


### PR DESCRIPTION
New working software list items
-------------------------------
Instant Music (cleanly cracked) [Brian Troha]
The Music Studio v1.0 (cleanly cracked) [Brian Troha] TrianGo v1.1 (cleanly cracked) [Brian Troha]
Xenocide (version 21-Jul-89) (cleanly cracked) [Brian Troha]


Modifications to apple2gs_flop_clcracked.xml [Brian Troha]
- Presented a standarization for all entries:
  * Added additional line breaks so all entries are formatted the same.
  * Ordered Parents / clones from Newest to oldest - it was mixed and seemingly random
- Removed the link to the Battle Chess manual and comment about needing it for copy protection - it's cracked....
- Added missing "usage" for World Tour Golf
- Changed Top Draw "usage" to "Requires 512K Apple IIgs.", verified via photo of actual 3.5" program disk (v1.01A said 512K & v1.00A said 1MB)
- NOTE: Additional Music Disks (It's Only Rock 'N' Roll, Hot & Cool Jazz and The Music Studio additional songs disk come from the "apple2gs_flop_misc" hash / set.
- Request:  Please leave all titles as "Cleanly cracked" and don't change to trex crack.  EVERY crack in the list is a trex crack. I don't need credit, I just wanted clean cracks of Apple IIgs software in MAME.