### PR TITLE
psx.xml: Added 26 working items + 9 redumped items

### DIFF
--- a/hash/psx.xml
+++ b/hash/psx.xml
@@ -35427,9 +35427,10 @@ Corrupted music during gameplay
 		<rom name="PSone - Wherever, Whenever, Forever. (USA) (No EDC) (Track 2).bin" size="23992752" crc="957803ce" sha1="a863d4134e1ca3730a2938d2ff0238c4d7e92eeb"/>
 		<rom name="PSone - Wherever, Whenever, Forever. (USA) (No EDC) (Track 3).bin" size="1401792" crc="780b1fc7" sha1="d11089e8cd3f7d9fc4dfd1156e1a02f2f992897a"/>
 		-->
-		<description>PSone - Wherever, Whenever, Forever. (USA, No EDC)</description>
+		<description>PSone - Wherever, Whenever, Forever. (USA, no EDC)</description>
 		<year>2001</year>
 		<publisher>Sony Computer Entertainment America</publisher>
+		<info name="copy_protection" value="Anti-modchip"/>
 		<info name="serial" value="SCUS-94799"/>
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="cdrom">
@@ -35446,9 +35447,11 @@ Corrupted music during gameplay
 		<rom name="PSone - Wherever, Whenever, Forever. (USA) (EDC) (Track 2).bin" size="23992752" crc="957803ce" sha1="a863d4134e1ca3730a2938d2ff0238c4d7e92eeb"/>
 		<rom name="PSone - Wherever, Whenever, Forever. (USA) (EDC) (Track 3).bin" size="1401792" crc="780b1fc7" sha1="d11089e8cd3f7d9fc4dfd1156e1a02f2f992897a"/>
 		-->
-		<description>PSone - Wherever, Whenever, Forever. (USA, EDC)</description>
+		<description>PSone - Wherever, Whenever, Forever. (USA, with EDC)</description>
 		<year>2001</year>
 		<publisher>Sony Computer Entertainment America</publisher>
+		<info name="copy_protection" value="Error Detection and Correction (EDC)"/>
+		<info name="copy_protection" value="Anti-modchip"/>
 		<info name="serial" value="SCUS-94799"/>
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="cdrom">


### PR DESCRIPTION
New working software list additions
--------------------------------------------
Advanced Dungeons & Dragons: Iron & Blood - Warriors of Ravenloft (Europe) [Redump]
Agent Armstrong (Europe) [Redump]
Agile Warrior (Japan) [Redump]
Agile Warrior: F-111X (Europe) [Redump]
Allied General (Japan) [Redump]
Animal Football (Europe) [Redump]
Archer Maclean's 3D Pool (Europe) [Redump]
Asteroids (Europe) [Redump]
Asteroids (France) [Redump]
Asteroids (Germany) [Redump]
Asteroids (Italy) [Redump]
Asteroids (Japan, SuperLite 1500 Series) [Redump]
Ayrton Senna Kart Duel (Europe) [Redump]
Ayrton Senna Kart Duel (Japan) [Redump]
Ayrton Senna Kart Duel 2 (Europe) [Redump]
Ayrton Senna KartDuel 2 (Japan) [Redump]
Ayrton Senna Kart Duel Special (Japan) [Redump]
Baby Felix Tennis (Europe) [Redump]
Boxer's Road (Japan) [Redump]
Boxer's Road (Japan) (PlayStation the Best) [Redump]
Bubble Bobble also featuring Rainbow Islands (Europe) [Redump]
Panzer General II: Allied General (Europe) [Redump]
Sampras Extreme Tennis (Europe) [Redump]
Sampras Extreme Tennis (Japan) [Redump]
Septentrion: Out of the Blue (Japan) [Redump]
Septentrion: Out of the Blue (Japan) (Major Wave Series) [Redump]

Redumped software list items
--------------------------------------------
Advan Racing (Japan) [Redump]
Advanced Dungeons & Dragons: Iron & Blood - Warriors of Ravenloft (USA) [Redump]
Advanced Dungeons & Dragons: Iron & Blood - Warriors of Ravenloft (USA, demo) [Redump]
Agent Armstrong: Himitsu Shirei Daisakusen (Japan) [Redump]
Agile Warrior: F-111X (USA) [Redump]
Allied General (USA) [Redump]
Asteroids (USA) [Redump]
Bubble Bobble also featuring Rainbow Islands (USA) [Redump]
Xena - Warrior Princess (USA) [Redump]

Promoted to working
--------------------------------------------
Agent Armstrong: Himitsu Shirei Daisakusen (Japan)