### PR TITLE
namcops2.cpp: Document offline English version of Battle Gear 3

### DIFF
--- a/src/mame/namco/namcops2.cpp
+++ b/src/mame/namco/namcops2.cpp
@@ -27,7 +27,7 @@ Games on System 246/256/S256 include.....
 Name from title screen                           System   Media ID            (HDD/CD/DVD)  Cart ID   Revision               Company/Year                  Notes
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Battle Gear 3 (Japan)........................... XX34XXX  M9005793A VER.2.04J  HDD (20GB)   NM00010   B3900065A              Taito 2002                    \  HDD: Western Digital WD200EB; all require Taito JVS Universal I/O board K91X0951A otherwise no boot-up
-Battle Gear 3 (Export).......................... XX34XXX  M9005793A VER.2.04J  HDD (20GB)   NM00010  *B3900068B/C(?)         Taito 2002                     | Dongle selects region (J/O) using same HDDs
+Battle Gear 3 (Export).......................... XX34XXX  M9005793A VER.2.04J  HDD (20GB)   NM00010  *B3900065B/C(?)         Taito 2002                     | Dongle selects region (J/O) using same HDDs
 Battle Gear 3 (Export, Offline)................. XX34XXX  M900????A VER.2.0xE? HDD (20GB)   NM00010? *B3900071A              Taito 2002                     | No online service (NESYS) support, instead having local leaderboards
 Battle Gear 3 (US).............................. ------X  M9005951A VER.2.00A  HDD (30GB)   NM00010?  B3900068A              Taito 2002                     | 2004 Betson release; contrary to flyer, does *not* remove Honda cars (contrast sidebs2u/batlgear)
 Battle Gear 3 Tuned (Japan)..................... XX34XXX  M9006066A VER.2.03J  HDD (30GB)   NM00015  *B3900074B              Taito 2003                     | HDD: Maxtor Fireball 3 30GB 2F030L0


### PR DESCRIPTION
Dongle ID `B3900068A` [(in this PR)](https://github.com/mamedev/mame/pull/12093) was originally thought to be offline English version, but turned out to be the Betson US English one (region `A` with Honda disclaimers). mokonaXVI recently pointed out about [this post](https://www.arcade-projects.com/threads/what-kind-of-wires-i-o-boards-are-needed-to-run-system-246-racing-games.904/#post-12531) which has a different dongle ID (`B3900071A`) for Battle Gear 3, which is likely to be [the offline English version](https://youtu.be/d_ibssSC4Fs) (region `E`).

Unfortunately, the post does not include HDD ID, but much like the US version required editing for different server and Honda-related disclaimers, I believe the offline one has a different HDD ID as well to replace online support with local leaderboards.
