### PR TITLE
Fixing the overload order for the LUA wrapper for `options.entries[...]:value(...)`

### DIFF
--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -1357,17 +1357,17 @@ void lua_engine::initialize()
 			else
 				e.set_value(val ? "1" : "0", OPTION_PRIORITY_CMDLINE);
 		},
+		[this](core_options::entry &e, int val) {
+			if(e.type() != core_options::option_type::INTEGER && e.type() != core_options::option_type::FLOAT)
+				luaL_error(m_lua_state, "Cannot set option to wrong type");
+			else
+				e.set_value(string_format("%d", val), OPTION_PRIORITY_CMDLINE);
+		},
 		[this](core_options::entry &e, float val) {
 			if(e.type() != core_options::option_type::FLOAT)
 				luaL_error(m_lua_state, "Cannot set option to wrong type");
 			else
 				e.set_value(string_format("%f", val), OPTION_PRIORITY_CMDLINE);
-		},
-		[this](core_options::entry &e, int val) {
-			if(e.type() != core_options::option_type::INTEGER)
-				luaL_error(m_lua_state, "Cannot set option to wrong type");
-			else
-				e.set_value(string_format("%d", val), OPTION_PRIORITY_CMDLINE);
 		},
 		[this](core_options::entry &e, const char *val) {
 			if(e.type() != core_options::option_type::STRING && e.type() != core_options::option_type::PATH && e.type() != core_options::option_type::MULTIPATH)


### PR DESCRIPTION
Overloads specified with `sol::overload()` are evaluated in sequential order.  Prior to this change, the overload for `float` was before the overload for `int`.  This means that in practice, the overload for `float` was always called even if the value and the option in question was an integer.  Because the wrappers error if the types do not match, this would make `option_type::INTEGER` entries unusable.

This change flips the order and makes the overload for `int` work with both `option_type::INTEGER` and `option_type::FLOAT`.