### PR TITLE
Connect I8087 to GRiD Compass

### DIFF
--- a/src/mame/gridcomp/gridcomp.cpp
+++ b/src/mame/gridcomp/gridcomp.cpp
@@ -70,6 +70,7 @@
 #include "cpu/i86/i86.h"
 #include "gridkeyb.h"
 #include "machine/i7220.h"
+#include "machine/i8087.h"
 #include "machine/i80130.h"
 #include "machine/i8255.h"
 #include "machine/mm58174.h"
@@ -127,7 +128,7 @@ protected:
 	virtual void machine_reset() override ATTR_COLD;
 
 private:
-	required_device<cpu_device> m_maincpu;
+	required_device<i8086_cpu_device> m_maincpu;
 	required_device<i80130_device> m_osp;
 	required_device<mm58174_device> m_rtc;
 	required_device<i8255_device> m_modem;
@@ -351,6 +352,12 @@ void gridcomp_state::grid1101(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &gridcomp_state::grid1101_map);
 	m_maincpu->set_addrmap(AS_IO, &gridcomp_state::grid1101_io);
 	m_maincpu->set_irq_acknowledge_callback(FUNC(gridcomp_state::irq_callback));
+	m_maincpu->esc_opcode_handler().set("i8087", FUNC(i8087_device::insn_w));
+	m_maincpu->esc_data_handler().set("i8087", FUNC(i8087_device::addr_w));
+
+	i8087_device &i8087(I8087(config, "i8087", XTAL(15'000'000) / 3));
+	i8087.set_space_86(m_maincpu, AS_PROGRAM);
+	i8087.busy().set_inputline(m_maincpu, INPUT_LINE_TEST);
 
 	I80130(config, m_osp, XTAL(15'000'000)/3);
 	m_osp->irq().set_inputline("maincpu", 0);


### PR DESCRIPTION
The Intel 8087 FPU is a mandatory component in GRiD Compass laptops. Without it, programs typically don't work or crash the system. For example, `Clock~Run~`

Before:

<img width="502" height="408.5" alt="Screenshot 2026-01-14 at 12 39 32" src="https://github.com/user-attachments/assets/49c8fcde-a484-41e5-8711-4bec8409eb68" />

(Random glitches and exceptions)

After:

<img width="625.5" height="476" alt="Screenshot 2026-01-14 at 12 59 31" src="https://github.com/user-attachments/assets/bde3c721-c0e5-4725-9b14-cb8e33710172" />

But there are still issues with the game FlakAttack. It no longer freezes, but it renders incorrectly:

<img width="628" height="474.5" alt="Screenshot 2026-01-14 at 12 30 14" src="https://github.com/user-attachments/assets/5fe855a8-8ee2-418a-81dc-c7910af36397" />