### PR TITLE
gbcolor: add South Park prototype ROM

### DIFF
--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -20402,6 +20402,21 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<!-- Reworked into Mary-Kate & Ashley: Get a Clue! (mnaclue)
+	     and Maya the Bee & Her Friends (mayabeef)
+	-->
+	<software name="southprk">
+		<description>South Park (prototype)</description>
+		<year>1999</year>
+		<publisher>Acclaim Entertainment</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="524288">
+				<rom name="south park (prototype).u1" size="524288" crc="e79d411a" sha1="ad9240b30e381cd7b260f5fc78aaaeed00c6b43d" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="spaceinv">
 		<description>Space Invaders (Europe, USA)</description>
 		<year>1999</year>


### PR DESCRIPTION
ROM from here: https://archive.org/details/spgam120

Might make sense as a child of Mary-Kate & Ashley and/or Maya the Bee, but those games already don't have a parent/child relationship. Since this was first developed with the South Park IP, maybe leave it as its own thing.

New working software list items (gbcolor.xml)
---------------------------------------------
South Park (prototype) [DaKoolDood]