### PR TITLE
2 missing save items in snk/snk.cpp driver

### DIFF
--- a/src/mame/snk/snk_v.cpp
+++ b/src/mame/snk/snk_v.cpp
@@ -194,7 +194,6 @@ void snk_state::register_save_state()
 	save_item(NAME(m_sprite_split_point));
 	save_item(NAME(m_bg_tile_offset));
 	save_item(NAME(m_tx_tile_offset));
-	save_item(NAME(m_drawmode_table));
 }
 
 VIDEO_START_MEMBER(snk_state,_3bpp_shadow)


### PR DESCRIPTION
It was the _m_bg_tile_offset_ and _m_tx_tile_offset_. I hope after their saving the all games from this driver would get an all rights to have save-supported status.