### PR TITLE
LUA:  Ensuring that `entry:default_value()` returns the correct type

### DIFF
--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -1398,7 +1398,23 @@ void lua_engine::initialize()
 			}
 		}));
 	core_options_entry_type.set("description", &core_options::entry::description);
-	core_options_entry_type.set("default_value", &core_options::entry::default_value);
+	core_options_entry_type.set("default_value",
+		[](core_options::entry &e, sol::this_state s) -> sol::object
+		{
+			if (e.type() == core_options::option_type::INVALID)
+				return sol::lua_nil;
+			switch (e.type())
+			{
+			case core_options::option_type::BOOLEAN:
+				return sol::make_object(s, e.bool_default_value());
+			case core_options::option_type::INTEGER:
+				return sol::make_object(s, e.int_default_value());
+			case core_options::option_type::FLOAT:
+				return sol::make_object(s, e.float_default_value());
+			default:
+				return sol::make_object(s, e.default_value());
+			}
+		});
 	core_options_entry_type.set("minimum", &core_options::entry::minimum);
 	core_options_entry_type.set("maximum", &core_options::entry::maximum);
 	core_options_entry_type.set("has_range", &core_options::entry::has_range);

--- a/src/lib/util/options.cpp
+++ b/src/lib/util/options.cpp
@@ -200,6 +200,38 @@ float core_options::entry::float_value() const
 
 
 //-------------------------------------------------
+//  entry::int_default_value
+//-------------------------------------------------
+
+int core_options::entry::int_default_value() const
+{
+	std::istringstream str(default_value());
+	str.imbue(std::locale::classic());
+	int ival;
+	if (str >> ival)
+		return ival;
+	else
+		return 0;
+}
+
+
+//-------------------------------------------------
+//  entry::float_default_value
+//-------------------------------------------------
+
+float core_options::entry::float_default_value() const
+{
+	std::istringstream str(default_value());
+	str.imbue(std::locale::classic());
+	float fval;
+	if (str >> fval)
+		return fval;
+	else
+		return 0.0F;
+}
+
+
+//-------------------------------------------------
 //  entry::copy_from
 //-------------------------------------------------
 

--- a/src/lib/util/options.h
+++ b/src/lib/util/options.h
@@ -134,6 +134,9 @@ public:
 		bool bool_value() const { return int_value() != 0; }
 		int int_value() const;
 		float float_value() const;
+		bool bool_default_value() const { return int_default_value() != 0; }
+		int int_default_value() const;
+		float float_default_value() const;
 		int priority() const noexcept { return m_priority; }
 		void set_priority(int priority) noexcept { m_priority = priority; }
 		option_type type() const noexcept { return m_type; }


### PR DESCRIPTION
`entry:default_value()` was always returning string.  A consequence of this problem is that the following LUA commands would error

```
manager.options.entries['beam_dot_size']:value(manager.options.entries['beam_dot_size']:default_value())
manager.options.entries['frameskip']:value(manager.options.entries['frameskip']:default_value())
```

With this change, `default_value()` will return objects of the correct type