### PR TITLE
sequential/prophet5.cpp: Incorporated the CEM3320 filter.

### DIFF
--- a/src/mame/linn/linndrum.cpp
+++ b/src/mame/linn/linndrum.cpp
@@ -758,7 +758,8 @@ void linndrum_audio_device::device_add_mconfig(machine_config &config)
 	// The bass VCF has a cutoff frequency of ~1.4KHz, which transiently
 	// increases to ~100KHz when the voice triggers.
 	LINNDRUM_VCF_EG(config, m_bass_eg, ":trimmer_bass_freq_cv_offset", RES_K(18), RES_K(5.1));  // R135, R133.
-	auto &bass_vcf = CEM3320_LPF4(config, "bass_vcf", CAP_P(150), RES_K(100));
+	auto &bass_vcf = CEM3320_LPF4(config, "bass_vcf", CAP_P(150));
+	bass_vcf.configure_voltage_input(RES_K(91));  // R87.
 	m_mux_volume[MV_BASS]->add_route(0, bass_vcf, 1.0, cem3320_lpf4_device::INPUT_AUDIO);
 	m_bass_eg->add_route(0, bass_vcf, 1.0, cem3320_lpf4_device::INPUT_FREQ);
 
@@ -805,7 +806,8 @@ void linndrum_audio_device::device_add_mconfig(machine_config &config)
 	// The tom VCF has a cutoff frequency of ~650Hz, which transiently
 	// increases to ~46KHz when the voice triggers.
 	LINNDRUM_VCF_EG(config, m_tom_eg, ":trimmer_tom_freq_cv_offset", RES_K(10), RES_K(10));
-	auto &tom_vcf = CEM3320_LPF4(config, "tom_conga_vcf", CAP_P(330), RES_K(100));
+	auto &tom_vcf = CEM3320_LPF4(config, "tom_conga_vcf", CAP_P(330));
+	tom_vcf.configure_voltage_input(RES_K(91));
 	m_tom_dac->add_route(0, tom_vcf, 1.0, cem3320_lpf4_device::INPUT_AUDIO);
 	m_tom_eg->add_route(0, tom_vcf, 1.0, cem3320_lpf4_device::INPUT_FREQ);
 

--- a/src/mame/sequential/prophet5.cpp
+++ b/src/mame/sequential/prophet5.cpp
@@ -36,7 +36,8 @@ and adc_r() for details.
 TODO: Outline of voice architecture.
 
 This driver is based on the Prophet 5 Rev 3.0 technical manual, and is intended
-as an education tool.
+as an education tool. To that end, names for variables, I/O handlers, enums,
+etc., generally match signal names in the schematics.
 
 There is no audio. Running with `-oslog -output console` will display CVs, and
 voice and LED control signals.
@@ -55,10 +56,10 @@ illuminated). The synth is unresponsive while this is happening.
 #include "machine/timer.h"
 #include "sound/dac.h"
 #include "sound/flt_rc.h"
-#include "sound/flt_vol.h"
 #include "sound/mixer.h"
 #include "sound/mm5837.h"
 #include "sound/va_vca.h"
+#include "sound/va_vcf.h"
 #include "video/pwm.h"
 #include "speaker.h"
 
@@ -69,8 +70,10 @@ illuminated). The synth is unresponsive while this is happening.
 #define LOG_ADC         (1U << 3)
 #define LOG_GATE        (1U << 4)
 #define LOG_CALIBRATION (1U << 5)
+#define LOG_PROG_LATCH  (1U << 6)
+#define LOG_FILTER      (1U << 7)
 
-#define VERBOSE (LOG_GENERAL | LOG_CV | LOG_CALIBRATION)
+#define VERBOSE (LOG_GENERAL | LOG_CALIBRATION | LOG_PROG_LATCH | LOG_CV)
 //#define LOG_OUTPUT_FUNC osd_printf_info
 
 #include "logmacro.h"
@@ -143,18 +146,35 @@ public:
 	prophet5_voice_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) ATTR_COLD;
 
 	void gate_w(int state);
+	void filt_sh_w(double cv);
+	void filt_sum_w(double cv);
+	void res_w(double cv);
+
+	DECLARE_INPUT_CHANGED_MEMBER(filter_trimmer_changed);
 
 protected:
 	void device_add_mconfig(machine_config &config) override ATTR_COLD;
 	void device_start() override ATTR_COLD;
+	void device_reset() override ATTR_COLD;
 
 	void sound_stream_update(sound_stream &stream) override;
 
 private:
-	required_device<ca3280_vca_lin_device> m_vca;
+	void update_filter_freq();
 
+	const std::string m_filt_scale_tag;
+	const std::string m_filt_offset_tag;
+
+	device_sound_interface *const m_noise;
 	sound_stream *m_stream = nullptr;
-	device_sound_interface *m_noise = nullptr;
+
+	required_device<cem3320_lpf4_device> m_vcf;
+	required_device<ca3280_vca_lin_device> m_vca;
+	required_ioport m_filt_scale;
+	required_ioport m_filt_offset;
+
+	double m_filt_sh_cv = 0.0;
+	double m_filt_sum_cv = 0.0;
 };
 
 }  // anonymous namespace
@@ -164,8 +184,13 @@ DEFINE_DEVICE_TYPE(PROPHET5_VOICE, prophet5_voice_device, "prophet5_voice", "Pro
 prophet5_voice_device::prophet5_voice_device(const machine_config &mconfig, const char *tag, device_t *owner, device_sound_interface *noise)
 	: device_t(mconfig, PROPHET5_VOICE, tag, owner, 0)
 	, device_sound_interface(mconfig, *this)
-	, m_vca(*this, "vca")
+	, m_filt_scale_tag(util::string_format(":trimmer_%s_filt_scale", basetag()))
+	, m_filt_offset_tag(util::string_format(":trimmer_%s_filt_offset", basetag()))
 	, m_noise(noise)
+	, m_vcf(*this, "vcf")
+	, m_vca(*this, "vca")
+	, m_filt_scale(*this, m_filt_scale_tag.c_str())
+	, m_filt_offset(*this, m_filt_offset_tag.c_str())
 {
 }
 
@@ -179,12 +204,14 @@ void prophet5_voice_device::device_add_mconfig(machine_config &config)
 	if (m_noise)
 		m_noise->add_route(0, "osc_mixer", 1.0 / RES_K(100));  // R4367
 
-	// TODO: NOISE_I2V is not a real resistor. Just undoing the voltage-to-current
-	// conversion above, for further processing. On the real hardware, the
-	// conversion to a voltage is done by the VCF circuit, which is not yet
-	// implemented.
-	constexpr double NOISE_I2V = RES_K(100);
-	MIXER(config, "osc_mixer").add_route(0, m_vca, NOISE_I2V);
+	// Currents from the noise source and oscillators are summed into the VCF input.
+	MIXER(config, "osc_mixer").add_route(0, m_vcf, 1.0, cem3320_lpf4_device::INPUT_AUDIO);
+
+	// The filter's output is scaled by a non-inverting amplifier (U474B, TL082).
+	constexpr double VCF_OUT_GAIN = 1.0 + RES_K(240) / RES_K(100);  // R4500 / R4499
+	CEM3320_LPF4(config, m_vcf, CAP_P(150))
+		.configure_resonance(RES_K(200), RES_K(51), RES_K(3), VCF_OUT_GAIN)  // R4414, R4416, R4415
+		.add_route(0, m_vca, VCF_OUT_GAIN);
 
 	CA3280_VCA_LIN(config, m_vca, RES_K(68), VPLUS, VMINUS)  // R4546
 		.configure_voltage_input(RES_K(20))  // R4548
@@ -193,7 +220,14 @@ void prophet5_voice_device::device_add_mconfig(machine_config &config)
 
 void prophet5_voice_device::device_start()
 {
+	save_item(NAME(m_filt_sh_cv));
+	save_item(NAME(m_filt_sum_cv));
 	m_stream = stream_alloc(1, 1, machine().sample_rate());
+}
+
+void prophet5_voice_device::device_reset()
+{
+	update_filter_freq();
 }
 
 void prophet5_voice_device::sound_stream_update(sound_stream &stream)
@@ -211,6 +245,51 @@ void prophet5_voice_device::gate_w(int state)
 	LOGMASKED(LOG_GATE, "Voice: %s, gate: %d\n", tag(), state);
 }
 
+void prophet5_voice_device::filt_sh_w(double cv)
+{
+	m_filt_sh_cv = cv;
+	update_filter_freq();
+}
+
+void prophet5_voice_device::filt_sum_w(double cv)
+{
+	m_filt_sum_cv = cv;
+	update_filter_freq();
+}
+
+void prophet5_voice_device::res_w(double cv)
+{
+	m_vcf->set_fixed_res_cv(cv);
+	LOGMASKED(LOG_FILTER, "%s: Filter resonance CV: %f, res: %f\n", tag(), cv, m_vcf->get_res());
+}
+
+DECLARE_INPUT_CHANGED_MEMBER(prophet5_voice_device::filter_trimmer_changed)
+{
+	update_filter_freq();
+	LOGMASKED(LOG_CALIBRATION, "%s: Filter frequency: %f\n", tag(), m_vcf->get_freq());
+}
+
+void prophet5_voice_device::update_filter_freq()
+{
+	// Control voltages from multiple sources are summed and inverted by U433B
+	// (LM348 op-amp) and surrounding resistors.
+	// TODO: Only the two firmware-provided sources are emulated at the moment.
+	const double i_filt_sh = m_filt_sh_cv / RES_K(100);  // R4144 (1%)
+	const double i_filt_sum = m_filt_sum_cv / RES_K(100);  //  R4143 (1%)
+	const double r_feedback = RES_K(162) + RES_K(50) * normalized(m_filt_scale);  // R4145 (1%) + R4133
+	const double cv_sum = -r_feedback * (i_filt_sh + i_filt_sum);
+
+	// The summed CV is further scaled and offset by a resistor network.
+	constexpr double R4458 = RES_K(187);  // 1%
+	constexpr double R4459 = RES_K(1.82);  // 1%
+	const double r15v = RES_K(249) + RES_K(100) * normalized(m_filt_offset);  // R4502 (1%) + R4501
+	const double scale = RES_VOLTAGE_DIVIDER(R4458, RES_2_PARALLEL(R4459, r15v));
+	const double offset = VPLUS * RES_VOLTAGE_DIVIDER(r15v, RES_2_PARALLEL(R4458, R4459));
+	const double cv = scale * cv_sum + offset;
+
+	m_vcf->set_fixed_freq_cv(cv);
+	LOGMASKED(LOG_FILTER, "%s: Filter frequency CV: %f, freq: %f\n", tag(), cv, m_vcf->get_freq());
+}
 
 namespace {
 
@@ -224,8 +303,11 @@ public:
 	void select_a440_w(int state);
 	void a440_w(int state);
 
+	void filt_kbd_s_w(int state);
+
 	void cv_w(offs_t cv_index, double cv);
 
+	DECLARE_INPUT_CHANGED_MEMBER(filter_cv_in_changed) { update_filter_sum_cv(); }
 	DECLARE_INPUT_CHANGED_MEMBER(voice_volume_changed) { update_voice_volume(); }
 	DECLARE_INPUT_CHANGED_MEMBER(master_volume_changed) { update_master_volume(); }
 
@@ -235,6 +317,7 @@ protected:
 	void device_reset() override ATTR_COLD;
 
 private:
+	void update_filter_sum_cv();
 	void update_voice_volume();
 	void update_master_volume();
 
@@ -248,8 +331,34 @@ private:
 	required_ioport m_master_vol_pot;  // R113
 	required_ioport m_amp_cv_in_connected;
 	required_ioport m_amp_cv_in;  // J7
+	required_ioport m_filter_cv_in;  // J6
 
+	bool m_filt_kbd_s = false;  // U369D (CD4016)
 	std::array<double, 40> m_cv;
+
+	enum cv_type
+	{
+		CV_FILT_ATTACK = 0, CV_FILT_DECAY, CV_FILT_SUSTAIN, CV_FILT_RELEASE,
+		CV_AMP_ATTACK, CV_AMP_DECAY, CV_AMP_SUSTAIN, CV_AMP_RELEASE,
+		CV_FILT_CUTOFF, CV_FILT_ENV_AMT,
+		CV_MIX_OSC_B, CV_OSC_B_PW,
+		CV_MIX_OSC_A, CV_OSC_A_PW,
+		CV_MIX_NOISE,
+		CV_FILT_RESONANCE,
+		CV_GLIDE,
+		CV_LFO_FREQ, CV_WMOD_SRC_MIX,
+		CV_PMOD_OSC_B, CV_PMOD_ENV_AMT,
+		CV_UNISON,
+		CV_SEQ_OUT,
+		CV_NOT_CONNECTED_1,
+		CV_OSC_1A_SH, CV_OSC_1B_SH,
+		CV_OSC_2A_SH, CV_OSC_2B_SH,
+		CV_OSC_3A_SH, CV_OSC_3B_SH,
+		CV_OSC_4A_SH, CV_OSC_4B_SH,
+		CV_OSC_5A_SH, CV_OSC_5B_SH,
+		CV_FILT_1_SH, CV_FILT_2_SH, CV_FILT_3_SH, CV_FILT_4_SH, CV_FILT_5_SH,
+		CV_NOT_CONNECTED_2,
+	};
 };
 
 }  // anonymous namespace
@@ -264,10 +373,11 @@ prophet5_audio_device::prophet5_audio_device(const machine_config &mconfig, cons
 	, m_parasitic_filter(*this, "parasitic_filter")
 	, m_noise_vca(*this, "noise_vca")
 	, m_master_vol_vca(*this, "master_volume_vca")
-	, m_voice_vol(*this, ":voice_trimmer_volume_%u", 0U)
+	, m_voice_vol(*this, ":trimmer_voice_%u_volume", 0U)
 	, m_master_vol_pot(*this, ":pot_volume")
-	, m_amp_cv_in_connected(*this, ":amp_cv_in_connected")
-	, m_amp_cv_in(*this, ":amp_cv_in")
+	, m_amp_cv_in_connected(*this, ":cv_in_amp_connected")
+	, m_amp_cv_in(*this, ":cv_in_amp")
+	, m_filter_cv_in(*this, ":cv_in_filter")
 {
 	std::fill(m_cv.begin(), m_cv.end(), -1);
 }
@@ -343,6 +453,7 @@ void prophet5_audio_device::device_add_mconfig(machine_config &config)
 
 void prophet5_audio_device::device_start()
 {
+	save_item(NAME(m_filt_kbd_s));
 	save_item(NAME(m_cv));
 }
 
@@ -351,6 +462,7 @@ void prophet5_audio_device::device_reset()
 	for (int i = 0; i < m_cv.size(); ++i)
 		cv_w(i, 0);
 
+	update_filter_sum_cv();
 	update_voice_volume();
 	update_master_volume();
 }
@@ -369,16 +481,23 @@ void prophet5_audio_device::a440_w(int state)
 	m_a440->write(state);
 }
 
+void prophet5_audio_device::filt_kbd_s_w(int state)
+{
+	m_filt_kbd_s = bool(state);
+	LOGMASKED(LOG_PROG_LATCH, "filt_kbd_s = %d\n", m_filt_kbd_s);
+	update_filter_sum_cv();
+}
+
 void prophet5_audio_device::cv_w(offs_t cv_index, double cv)
 {
 	constexpr const char *CV_NAMES[40] =
 	{
-		"FILT ATTACK CV", "FILT DECAY CV", "FILT SUSTAIN CV", "FILT RELEASE CV",
-		"AMP ATTACK CV", "AMP DECAY CV", "AMP SUSTAIN CV", "AMP RELEASE CV",
-		"FILT CUTOFF CV", "FILT ENV AMT CC", "MIX OSC B CC", "OSC B PW CV",
-		"MIX OSC A CC", "OSC A PW CV", "MIX NOISE CC", "FILT RESONANCE CV",
-		"GLIDE CV", "LFO FREQ CV", "WMOD SRC MIX CV", "PMOD OSC B CC",
-		"PMOD ENV AMT CC", "UNISON CV", "SEQ CV OUT", "NOT CONNECTED 1",
+		"FILT ATTACK", "FILT DECAY", "FILT SUSTAIN", "FILT RELEASE",
+		"AMP ATTACK", "AMP DECAY", "AMP SUSTAIN", "AMP RELEASE",
+		"FILT CUTOFF", "FILT ENV AMT", "MIX OSC B", "OSC B PW",
+		"MIX OSC A", "OSC A PW", "MIX NOISE", "FILT RESONANCE",
+		"GLIDE", "LFO FREQ", "WMOD SRC MIX", "PMOD OSC B",
+		"PMOD ENV AMT", "UNISON", "SEQ CV OUT", "NOT CONNECTED 1",
 		"OSC 1A S/H", "OSC 1B S/H", "OSC 2A S/H", "OSC 2B S/H",
 		"OSC 3A S/H", "OSC 3B S/H", "OSC 4A S/H", "OSC 4B S/H",
 		"OSC 5A S/H", "OSC 5B S/H", "FILT 1 S/H", "FILT 2 S/H",
@@ -393,10 +512,48 @@ void prophet5_audio_device::cv_w(offs_t cv_index, double cv)
 
 	switch (cv_index)
 	{
-		case 14:
+		case CV_MIX_NOISE:
 			m_noise_vca->set_fixed_gain_cv(cv2cc(cv, RES_K(75)));  // Q305, R327
 			break;
+
+		case CV_UNISON:
+			if (m_filt_kbd_s)
+				update_filter_sum_cv();
+			break;
+
+		case CV_FILT_RESONANCE:
+			for (prophet5_voice_device *v : m_voices)
+				v->res_w(cv);
+			break;
+
+		case CV_FILT_CUTOFF: update_filter_sum_cv(); break;
+		case CV_FILT_1_SH: m_voices[0]->filt_sh_w(cv); break;
+		case CV_FILT_2_SH: m_voices[1]->filt_sh_w(cv); break;
+		case CV_FILT_3_SH: m_voices[2]->filt_sh_w(cv); break;
+		case CV_FILT_4_SH: m_voices[3]->filt_sh_w(cv); break;
+		case CV_FILT_5_SH: m_voices[4]->filt_sh_w(cv); break;
 	}
+}
+
+void prophet5_audio_device::update_filter_sum_cv()
+{
+	// Multiple cutoff frequency sources are summed and inverted by U367A (
+	// LM348, configured as an inverting mixer) and surrounding resistors.
+	// TODO: The "wmod" source is not yet emulated.
+	// TODO: Glide amount is not yet emulated. The "glide out" CV tracks the
+	// "unison" CV for now, regardless of glide amount.
+	const double i_cv_in = MAX_CV_IN * normalized(m_filter_cv_in) / RES_K(100);  // R374 (1%)
+	const double i_ctf_cv = m_cv[CV_FILT_CUTOFF] / RES_K(100);  // R352 (1%)
+	const double i_glide_out_cv = m_filt_kbd_s ? (m_cv[CV_UNISON] / RES_K(100)) : 0.0;  // R372 (1%)
+	const double mixed_cv= -RES_K(100) * (i_cv_in + i_ctf_cv + i_glide_out_cv);  // R354 (1%)
+
+	// The result is offset and inverted by U367B (LM348) and surrounding resistors.
+	constexpr double i_offset = VPLUS / RES_K(261);  // R356 (1%)
+	const double i_mixed_cv = mixed_cv / RES_K(100);  // R355 (1%)
+	const double filt_sum_cv = -RES_K(100) * (i_mixed_cv + i_offset);  // R357 (1%)
+
+	for (prophet5_voice_device *v : m_voices)
+		v->filt_sum_w(filt_sum_cv);
 }
 
 void prophet5_audio_device::update_voice_volume()
@@ -522,7 +679,7 @@ void prophet5_audio_device::update_master_volume()
 	//              R345
 	//               |
 	//               \  <-- Normally closed. Open when AMP CV IN is connected.
-	//               +-----AMP CV IN (0-5V)
+	//               +-----AMP CV IN
 	//               |
 	// Volume knob: R113----+---- BUFFER (U480A, TL082) --- Master Volume CV
 	//               |      |
@@ -673,13 +830,13 @@ prophet5_state::prophet5_state(const machine_config &mconfig, device_type type, 
 	, m_switches(*this, "switch_row_%u", 0U)
 	, m_record(*this, "record")
 	, m_release_footswitch(*this, "release_footswitch")
-	, m_gate_in(*this, "seq_gate_in")
+	, m_gate_in(*this, "gate_in")
 	, m_gate_in_connected(*this, "gate_in_connected")
 	, m_test_points(*this, "test_points")
 	, m_pots(*this, "pot_%u", 0U)
 	, m_dac_gain(*this, "trimmer_dac_gain")
 	, m_adc_gain(*this, "trimmer_adc_gain")
-	, m_seq_cv_in(*this, "seq_cv_in")
+	, m_seq_cv_in(*this, "cv_in_seq")
 	, m_seq_offset(*this, "trimmer_seq_offset")
 	, m_seq_scale(*this, "trimmer_seq_scale")
 	, m_tune_mux_select(*this, "tune_mux_select")
@@ -1101,6 +1258,7 @@ void prophet5_state::prophet5rev30(machine_config &config)
 	u335.bit_handler<3>().set_output("osc_b_saw");
 	u335.bit_handler<4>().set_output("osc_b_tri");
 	u335.bit_handler<5>().set_output("osc_b_sqr");
+	u335.bit_handler<6>().set_output("osc_b_kbd");  // Actually U341A (4013 flipflop).
 
 	auto &u334 = OUTPUT_LATCH(config, "program_latch_1");
 	u334.bit_handler<0>().set_output("pmod_freq_a");
@@ -1109,6 +1267,7 @@ void prophet5_state::prophet5rev30(machine_config &config)
 	u334.bit_handler<3>().set_output("lfo_saw");
 	u334.bit_handler<4>().set_output("lfo_tri");
 	u334.bit_handler<5>().set_output("lfo_sqr");
+	u334.bit_handler<6>().set(m_audio, FUNC(prophet5_audio_device::filt_kbd_s_w));  // Actually U341B (4013 flipflop).
 
 	auto &u333 = OUTPUT_LATCH(config, "program_latch_2");
 	u333.bit_handler<0>().set_output("wmod_freq_a");
@@ -1187,7 +1346,7 @@ INPUT_PORTS_START(prophet5)
 	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("OSC B TRI")
 	PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("OSC B SQR")
 	PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("OSC B KBD")
-	PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("UNISON")
+	PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("UNISON") PORT_CODE(KEYCODE_U)
 
 	PORT_START("switch_row_1")
 	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("PMOD FREQ A")
@@ -1196,7 +1355,7 @@ INPUT_PORTS_START(prophet5)
 	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("LFO SAW")
 	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("LFO TRI")
 	PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("LFO SQR")
-	PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("FILT KBD")
+	PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("FILT KBD") PORT_CODE(KEYCODE_K)
 	PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("RELEASE")
 
 	PORT_START("switch_row_2")
@@ -1221,7 +1380,7 @@ INPUT_PORTS_START(prophet5)
 
 	PORT_START("switch_row_4")
 	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("RECORD") PORT_CODE(KEYCODE_R)
-	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("BANK SELECT") PORT_CODE(KEYCODE_K)
+	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("BANK SELECT") PORT_CODE(KEYCODE_S)
 	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("A-440") PORT_CODE(KEYCODE_A)
 	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("TUNE")
 	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("TO CASS")
@@ -1239,7 +1398,7 @@ INPUT_PORTS_START(prophet5)
 	PORT_BIT(0xff, IP_ACTIVE_HIGH, IPT_UNUSED)
 
 	PORT_START("switch_row_8")  // C0 - G0 in schematic.
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_C2 PORT_CODE(KEYCODE_Z)
+	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_C2
 	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_CS2
 	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_D2
 	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_DS2
@@ -1250,10 +1409,10 @@ INPUT_PORTS_START(prophet5)
 
 	PORT_START("switch_row_9")  // G#0 - D#1
 	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_GS2
-	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_A2
+	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_A2 PORT_CODE(KEYCODE_Z)
 	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_AS2
 	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_B2
-	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_C3 PORT_CODE(KEYCODE_X)
+	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_C3
 	PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_CS3
 	PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_D3
 	PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_DS3
@@ -1264,12 +1423,12 @@ INPUT_PORTS_START(prophet5)
 	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_FS3
 	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_G3
 	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_GS3
-	PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_A3
+	PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_A3 PORT_CODE(KEYCODE_X)
 	PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_AS3
 	PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_B3
 
 	PORT_START("switch_row_11")  // C2 - G2
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_C4 PORT_CODE(KEYCODE_C)
+	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_C4
 	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_CS4
 	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_D4
 	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_DS4
@@ -1280,10 +1439,10 @@ INPUT_PORTS_START(prophet5)
 
 	PORT_START("switch_row_12")  // G#2 - D#3
 	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_GS4
-	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_A4
+	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_A4 PORT_CODE(KEYCODE_C)
 	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_AS4
 	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_B4
-	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_C5 PORT_CODE(KEYCODE_V)
+	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_C5
 	PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_CS5
 	PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_D4
 	PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_DS4
@@ -1294,12 +1453,12 @@ INPUT_PORTS_START(prophet5)
 	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_FS4
 	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_G5
 	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_GS5
-	PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_A5
+	PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_A5 PORT_CODE(KEYCODE_V)
 	PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_AS5
 	PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_B5
 
 	PORT_START("switch_row_14")  // C4 - G4
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_C6 PORT_CODE(KEYCODE_B)
+	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_C6
 	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_CS6
 	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_D6
 	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_DS6
@@ -1310,10 +1469,10 @@ INPUT_PORTS_START(prophet5)
 
 	PORT_START("switch_row_15")  // G#4 - C5
 	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_GS6
-	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_A6
+	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_A6 PORT_CODE(KEYCODE_B)
 	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_AS6
 	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_B6
-	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_C7 PORT_CODE(KEYCODE_N)
+	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_C7
 	PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_UNUSED)
 	PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_UNUSED)
 	PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_UNUSED)
@@ -1333,7 +1492,7 @@ INPUT_PORTS_START(prophet5)
 	PORT_CONFSETTING(0x00, "Not connected")
 	PORT_CONFSETTING(0x01, "Connected")
 
-	PORT_START("seq_gate_in")
+	PORT_START("gate_in")
 	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("SEQ GATE IN") PORT_CODE(KEYCODE_G)
 		PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(prophet5_state::gate_in_changed), 0)
 
@@ -1468,8 +1627,8 @@ INPUT_PORTS_START(prophet5)
 	// Default value calibrated for the required: Vadcref = Vdac / 2.
 	PORT_ADJUSTER(36, "TRIMMER: ADC GAIN") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(prophet5_state::adc_trimmer_adjusted), 0)
 
-	PORT_START("seq_cv_in")  // J2, external CV input.
-	PORT_ADJUSTER(50, "SEQ CV IN") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(prophet5_state::cv_in_changed), 0)
+	PORT_START("cv_in_seq")  // J2, external CV input.
+	PORT_ADJUSTER(50, "CV IN: SEQ") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(prophet5_state::cv_in_changed), 0)
 
 	PORT_START("trimmer_seq_offset")  // R385, 100K trimmer.
 	PORT_ADJUSTER(50, "TRIMMER: SEQ OFFSET") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(prophet5_state::seq_trimmer_adjusted), 0)
@@ -1479,23 +1638,48 @@ INPUT_PORTS_START(prophet5)
 	// error due to adjuster resolution. Exact calibration works out to 47.3.
 	PORT_ADJUSTER(47, "TRIMMER: SEQ SCALE") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(prophet5_state::seq_trimmer_adjusted), 1)
 
-	PORT_START("amp_cv_in_connected")
+	PORT_START("cv_in_amp_connected")
 	PORT_CONFNAME(0x01, 0x00, "AMPLIFIER CV IN")
 		PORT_CHANGED_MEMBER(AUDIO_TAG, FUNC(prophet5_audio_device::master_volume_changed), 0)
 	PORT_CONFSETTING(0x00, "Not connected")
 	PORT_CONFSETTING(0x01, "Connected")
 
-	PORT_START("amp_cv_in")  // J7, master volume CV input.
-	PORT_ADJUSTER(100, "AMPLIFIER CV IN")
+	PORT_START("cv_in_amp")  // J7, master volume CV input.
+	PORT_ADJUSTER(50, "CV IN: AMPLIFIER")
 		PORT_CHANGED_MEMBER(AUDIO_TAG, FUNC(prophet5_audio_device::master_volume_changed), 0)
 
+	PORT_START("cv_in_filter")  // J6, filter cutoff CV input.
+	// An input of 0V has the same effect as the input not being connected.
+	PORT_ADJUSTER(0, "CV IN: FILTER")
+		PORT_CHANGED_MEMBER(AUDIO_TAG, FUNC(prophet5_audio_device::filter_cv_in_changed), 0)
+
+
+	static std::string voice_tag[5];
 	static std::string volume_name[5];
+	static std::string filt_scale_name[5];
+	static std::string filt_offset_name[5];
+
 	for (int i = 0; i < 5; ++i)
 	{
+		voice_tag[i] = util::string_format("%s:voice_%d", AUDIO_TAG, i);
+
+		// Default values are based on the calibration instructions in the
+		// service manual.
+
 		volume_name[i] = util::string_format("TRIMMER: VOICE %d VOLUME", i);
-		PORT_START(util::string_format("voice_trimmer_volume_%d", i).c_str())
+		PORT_START(util::string_format("trimmer_voice_%d_volume", i).c_str())
 		PORT_ADJUSTER(100, volume_name[i].c_str())
 			PORT_CHANGED_MEMBER(AUDIO_TAG, FUNC(prophet5_audio_device::voice_volume_changed), i);
+
+		filt_scale_name[i] = util::string_format("TRIMMER: VOICE %d FILT SCALE", i);
+		PORT_START(util::string_format("trimmer_voice_%d_filt_scale", i).c_str())
+		PORT_ADJUSTER(14, filt_scale_name[i].c_str())
+			PORT_CHANGED_MEMBER(voice_tag[i].c_str(), FUNC(prophet5_voice_device::filter_trimmer_changed), i)
+
+		filt_offset_name[i] = util::string_format("TRIMMER: VOICE %d FILT OFFSET", i);
+		PORT_START(util::string_format("trimmer_voice_%d_filt_offset", i).c_str())
+		PORT_ADJUSTER(82, filt_offset_name[i].c_str())
+			PORT_CHANGED_MEMBER(voice_tag[i].c_str(), FUNC(prophet5_voice_device::filter_trimmer_changed), i)
 	}
 INPUT_PORTS_END
 


### PR DESCRIPTION
sound/va_vcf.cpp:
* va_vcf_device: Added functions for accessing frequency and resonance gain.
* cem3320_lpf4_device: Removed feedback resistor from the constructor. Most designs use the datasheet recommendation (100K).
* cem3320_lpf4_device: Input stream can be a current, or a voltage by using a resistor. The first configuration is used by the prophet5, while the second one is used by the linndrum.

linn/linndrum.cpp:
* Adapted to the interface changes above.

sequential/prophet5.cpp:
* Incorporated CEM3320, and emulated a subset of its frequency control and trimmers.
* Created and used enums for CV indices.
* Renamed some inputs for better UI organization.

EDIT: Newly working controls: Cutoff and Resonance knobs, Keyboard (tracking) button.

------

Next up: I will look into a proper filter implementation, as suggested [here](https://github.com/mamedev/mame/pull/14680?notification_referrer_id=NT_kwHOChHyK9oAJFJlcG9zaXRvcnk7MTQzMDMwNDg7SXNzdWU7MzczMzYyMzE0Nw#issuecomment-3687433354)