### PR TITLE
hash/jazz.xml: new Windows NT hard disk images

### DIFF
--- a/hash/jazz.xml
+++ b/hash/jazz.xml
@@ -6,15 +6,15 @@ license:CC0-1.0
 <softwarelist name="jazz" description="Jazz software">
 
 	<software name="winnt31">
-	    <description>Windows NT 3.1</description>
-	    <year>1994</year>
-	    <publisher>Microsoft</publisher>
+		<description>Windows NT 3.1</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
 
-	    <part name="hdd" interface="scsi_hdd">
-	        <diskarea name="harddriv">
-	            <disk name="winnt31" sha1="efaf73e45eca35e45f447d41d12bbd091c298d8e" writeable="yes" />
-	        </diskarea>
-	    </part>
+		<part name="hdd" interface="scsi_hdd">
+			<diskarea name="harddriv">
+				<disk name="jazz_winnt31" sha1="efaf73e45eca35e45f447d41d12bbd091c298d8e" writeable="yes" />
+			</diskarea>
+		</part>
 	</software>
 
 	<software name="winnt35">
@@ -36,7 +36,7 @@ license:CC0-1.0
 
 		<part name="hdd" interface="scsi_hdd">
 			<diskarea name="harddriv">
-				<disk name="winnt351" sha1="5df584a05972371d2133b03809066b2cdc4a5438" writeable="yes" />
+				<disk name="jazz_winnt351" sha1="5df584a05972371d2133b03809066b2cdc4a5438" writeable="yes" />
 			</diskarea>
 		</part>
 	</software>
@@ -48,7 +48,7 @@ license:CC0-1.0
 
 		<part name="hdd" interface="scsi_hdd">
 			<diskarea name="harddriv">
-				<disk name="winnt40" sha1="e8241ac72bb61e8fb2ca4b5b3827edb06e8b4595" writeable="yes" />
+				<disk name="jazz_winnt40" sha1="e8241ac72bb61e8fb2ca4b5b3827edb06e8b4595" writeable="yes" />
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
For Windows NT 3.1, 3.51, and 4.0, these disk images were created by using the installation discs defined in generic_cdrom.xml.

All of these images have the following properties:
 * Half-gigabyte hard disk image
 * Single FAT partition for both ARC osloader and operating system
 * Installation date and time reflect those found on the installation CDs.

Like my FreeDOS 1.3 and 1.4 hard disks defined in ibm5170_hdd.xml, each of these was also created while recording an INP and can be recreated from these input recordings. They are located at <https://chiselapp.com/user/chungy/repository/mame-reprod-chd/dir?ci=c15788dc4dd087c9&name=jazz-nt>

Windows NT 3.5 has consistently failed to install from a blank hard disk, only producing a BSOD at the end of text mode setup.  Not just from the installation image provided by generic_cdrom, but I tried several variants from MSDN disks, both debug and release builds, and the same behavior across all of them.  It works as an upgrade from NT 3.1, but I am not willing to depend on that for this sort of image. There is an existing winnt35 image dating to 2020, but I do not know how Patrick Mackinlay first created this image (possible MAME regression?).