### PR TITLE
sega/model2.cpp: delay IRQ mask update by feeding new value to timer callback

### DIFF
--- a/src/mame/sega/model2.cpp
+++ b/src/mame/sega/model2.cpp
@@ -22,8 +22,10 @@
               bypass it by entering then exiting service mode;
     - sgt24h: has input analog issues, steering doesn't center when neutral,
       gas and brake pedals pulses instead of being fixed;
-    - vcop2: stage select has tilemap priority issue, tilemap B (city model) has priority bit set,
-             yet it should appear underneath tilemap A ("shoot to select") which does not
+	- vcop2: stage select has tilemap priority issue, tilemap B (city model) has priority bit set,
+	         yet it should appear underneath tilemap A ("shoot to select") which does not;
+	- srallyc: initial enemy car placement seems to be slightly incorrect for a few cars,
+	           seems to be affected by i960 clock speed, may need wait state emulation to fix
 
     Notes:
     - some analog games can be calibrated in service mode via volume control item ...
@@ -140,8 +142,12 @@ TIMER_DEVICE_CALLBACK_MEMBER(model2_state::model2_timer_cb)
 	m_timerrun[TNum] = 0;
 }
 
-TIMER_CALLBACK_MEMBER(model2_state::check_sound_irq)
+TIMER_CALLBACK_MEMBER(model2_state::irq_mask_delayed_update)
 {
+	// update the interrupt mask
+	m_intena = param;
+
+	// sound interrupt is asserted if either RxRDY or TxRDY is active
 	const u32 line = 1 << 10;
 	if ((m_uart->status_r() & 0x03) && (m_intena & line))
 	{
@@ -178,7 +184,7 @@ void model2_state::machine_start()
 	save_item(NAME(m_geo_write_start_address));
 	save_item(NAME(m_geo_read_start_address));
 
-	m_irq_delay_timer = timer_alloc(FUNC(model2_state::check_sound_irq), this);
+	m_irq_delay_timer = timer_alloc(FUNC(model2_state::irq_mask_delayed_update), this);
 	m_irq_delay_timer->adjust(attotime::never);
 }
 
@@ -934,10 +940,11 @@ void model2_state::irq_ack_w(u32 data)
 
 void model2_state::irq_enable_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	COMBINE_DATA(&m_intena);
+	u32 temp_intena = m_intena;
+	COMBINE_DATA(&temp_intena);
 
-	// delay sound IRQ check by 2 cycles; vcop2 needs this
-	m_irq_delay_timer->adjust(attotime::from_nsec(80));
+	// delay IRQ mask update by 2 cycles; vcop2 needs this
+	m_irq_delay_timer->adjust(attotime::from_nsec(80), temp_intena);
 }
 
 void model2_state::irq_update()
@@ -7498,11 +7505,23 @@ ROM_START( hpyagu98 ) /* Hanguk Pro Yagu 98, Model 2A, ROM board# 834-11342 REV.
 	ROM_LOAD16_WORD_SWAP( "bb-sn-3.36", 0x400000, 0x200000, CRC(e4c938b2) SHA1(3a96433f58a52dea026ab47bf93dc6a9c620e1dd) )
 	ROM_LOAD16_WORD_SWAP( "bb-sn-4.37", 0x600000, 0x200000, CRC(8692fbf3) SHA1(d8e854bba7b54fba85e182d761a9fd02fd13646f) )
 
-	ROM_REGION16_LE(0x80, "eeprom", 0) // EEPROM (required to prevent error #0 on boot)
-	ROM_LOAD("hpyagu98_nvram", 0x00, 0x80, CRC(3634c60f) SHA1(1ab7b74fd05b2d21496af9b2a477c0d197847c55)) // partly handcrafted, same settings as dynabb97 default
+	/*
+		hpyagu98 requires certain values to be set in the EEPROM and backup RAM, otherwise it fails with Error #1:
+		- The values 0xfa, 0xe3, 0xa6 and 0x29 at addresses 0x08 through 0x0b respectively in the EEPROM;
+		- The string "98KOREA PRO B.B." at the start of backup RAM;
+		- The 32-bit magic number 0x5042c660 at address 0x398 in backup RAM;
+		- A 16-bit checksum at address 0x1d4 in backup RAM.
 
-	ROM_REGION(0x4000, "backup1", 0) // Backup RAM (required to prevent error #0 on boot)
-	ROM_LOAD("hpyagu98_backup", 0x0000, 0x4000, CRC(979751d5) SHA1(2f6c6d12b77d7fbd3e44b05f4c21ca479fae782c)) // partly handcrafted
+		It is possible that this may be a form of copy protection to prevent simple duplication of the game ROMs.
+
+		In addition, with the other values unchanged the game/coin options are invalid. These partly handcrafted EEPROM and backup RAM
+		files are provided to allow the game to boot with the game/coin options set to match the defaults for dynabb97.
+	*/
+	ROM_REGION16_LE(0x80, "eeprom", 0) // EEPROM
+	ROM_LOAD("hpyagu98_nvram", 0x00, 0x80, CRC(3634c60f) SHA1(1ab7b74fd05b2d21496af9b2a477c0d197847c55))
+
+	ROM_REGION(0x4000, "backup1", 0) // Backup RAM
+	ROM_LOAD("hpyagu98_backup", 0x0000, 0x4000, CRC(979751d5) SHA1(2f6c6d12b77d7fbd3e44b05f4c21ca479fae782c))
 
 	MODEL2_CPU_BOARD
 	MODEL2A_VID_BOARD

--- a/src/mame/sega/model2.h
+++ b/src/mame/sega/model2.h
@@ -228,7 +228,7 @@ protected:
 	void sound_ready_w(int state);
 	template <int TNum> TIMER_DEVICE_CALLBACK_MEMBER(model2_timer_cb);
 	void scsp_irq(offs_t offset, u8 data);
-	TIMER_CALLBACK_MEMBER(check_sound_irq);
+	TIMER_CALLBACK_MEMBER(irq_mask_delayed_update);
 
 	void render_frame_start();
 	void geo_parse();


### PR DESCRIPTION
This is basically an update to commit 456c228869283dcca16e17d9450d76e75c505009; instead of updating the IRQ mask register straight away, it feeds the new value to the timer callback as suggested by @cuavas. There should no longer be any possibility of `sound_ready_w()` bypassing the 2 cycle delay and firing a sound interrupt too early.