### PR TITLE
Added support for <piece> elements in software lists.

### DIFF
--- a/src/emu/softlist.cpp
+++ b/src/emu/softlist.cpp
@@ -55,6 +55,24 @@ software_info_item::software_info_item(std::string &&name, std::string &&value) 
 
 
 //**************************************************************************
+//  SOFTWARE PIECE
+//**************************************************************************
+
+//-------------------------------------------------
+//  software_piece_info - constructor
+//-------------------------------------------------
+
+software_piece_info::software_piece_info(std::string &&index, std::string &&title, std::string &&creator, std::string &&alt_title, std::string &&alt_creator) :
+	m_index(index),
+	m_title(title),
+	m_creator(creator),
+	m_alt_title(alt_title),
+	m_alt_creator(alt_creator)
+{
+}
+
+
+//**************************************************************************
 //  SOFTWARE PART
 //**************************************************************************
 
@@ -737,6 +755,22 @@ void softlist_parser::parse_part_start(const char *tagname, const char **attribu
 		else
 		{
 			parse_error("Incomplete feature definition");
+		}
+	}
+
+	// <piece index=''>
+	else if (strcmp(tagname, "piece") == 0)
+	{
+		static char const *const attrnames[] = { "index", "title", "creator", "alt_title", "alt_creator" };
+		auto attrvalues = parse_attributes(attributes, attrnames);
+
+		if (!attrvalues[0].empty() && !attrvalues[1].empty())
+		{
+			m_current_part->m_pieces.emplace_back(std::string(attrvalues[0]), std::string(attrvalues[1]), std::string(attrvalues[2]), std::string(attrvalues[3]), std::string(attrvalues[4]));
+		}
+		else
+		{
+			parse_error("Incomplete piece definition");
 		}
 	}
 

--- a/src/emu/softlist.h
+++ b/src/emu/softlist.h
@@ -80,6 +80,34 @@ private:
 };
 
 
+// a single piece of a software part
+class software_piece_info
+{
+public:
+	// construction/destruction
+	software_piece_info(std::string &&index, std::string &&title, std::string &&creator, std::string &&alt_title, std::string &&alt_creator);
+	software_piece_info(software_piece_info const &) = default;
+	software_piece_info(software_piece_info &&) = default;
+	software_piece_info& operator=(software_piece_info const &) = default;
+	software_piece_info& operator=(software_piece_info &&) = default;
+
+	// getters
+	const std::string &index() const noexcept { return m_index; }
+	const std::string &title() const noexcept { return m_title; }
+	const std::string &creator() const noexcept { return m_creator; }
+	const std::string &alt_title() const noexcept { return m_alt_title; }
+	const std::string &alt_creator() const noexcept { return m_alt_creator; }
+
+private:
+	// internal state
+	std::string         m_index;
+	std::string         m_title;
+	std::string         m_creator;
+	std::string         m_alt_title;
+	std::string         m_alt_creator;
+};
+
+
 // a single part of a software item
 class software_part
 {
@@ -99,6 +127,7 @@ public:
 	const std::string &interface() const noexcept { return m_interface; }
 	const software_info_item::set &features() const noexcept { return m_features; }
 	const std::vector<rom_entry> &romdata() const noexcept { return m_romdata; }
+	const std::vector<software_piece_info> &pieces() const noexcept { return m_pieces; }
 
 	// helpers
 	bool matches_interface(const char *interface_list) const noexcept;
@@ -111,6 +140,7 @@ private:
 	std::string             m_interface;
 	software_info_item::set m_features;
 	std::vector<rom_entry>  m_romdata;
+	std::vector<software_piece_info> m_pieces;
 };
 
 

--- a/src/frontend/mame/clifront.cpp
+++ b/src/frontend/mame/clifront.cpp
@@ -1154,9 +1154,15 @@ const char cli_frontend::s_softlist_xml_dtd[] =
 				"\t\t\t<!ELEMENT sharedfeat EMPTY>\n"
 				"\t\t\t\t<!ATTLIST sharedfeat name CDATA #REQUIRED>\n"
 				"\t\t\t\t<!ATTLIST sharedfeat value CDATA #IMPLIED>\n"
-				"\t\t\t<!ELEMENT part (feature*, dataarea*, diskarea*, dipswitch*)>\n"
+				"\t\t\t<!ELEMENT part (piece*, feature*, dataarea*, diskarea*, dipswitch*)>\n"
 				"\t\t\t\t<!ATTLIST part name CDATA #REQUIRED>\n"
 				"\t\t\t\t<!ATTLIST part interface CDATA #REQUIRED>\n"
+				"\t\t\t\t<!ELEMENT piece EMPTY>\n"
+				"\t\t\t\t\t<!ATTLIST piece index CDATA #REQUIRED>\n"
+				"\t\t\t\t\t<!ATTLIST piece title CDATA #REQUIRED>\n"
+				"\t\t\t\t\t<!ATTLIST piece creator CDATA>\n"
+				"\t\t\t\t\t<!ATTLIST piece alt_title CDATA>\n"
+				"\t\t\t\t\t<!ATTLIST piece alt_creator CDATA>\n"
 				"\t\t\t\t<!ELEMENT feature EMPTY>\n"
 				"\t\t\t\t\t<!ATTLIST feature name CDATA #REQUIRED>\n"
 				"\t\t\t\t\t<!ATTLIST feature value CDATA #IMPLIED>\n"
@@ -1224,6 +1230,18 @@ void cli_frontend::output_single_softlist(std::ostream &out, software_list_devic
 				util::stream_format(out, " interface=\"%s\"", normalize_string(part.interface()));
 
 			out << ">\n";
+
+			for (const auto &piece : part.pieces())
+			{
+				util::stream_format(out, "\t\t\t\t<piece index=\"%s\" title=\"%s\"", normalize_string(piece.index()), normalize_string(piece.title()));
+				if (!piece.creator().empty())
+					util::stream_format(out, " creator=\"%s\"", normalize_string(piece.creator()));
+				if (!piece.alt_title().empty())
+					util::stream_format(out, " alt_title=\"%s\"", normalize_string(piece.alt_title()));
+				if (!piece.alt_creator().empty())
+					util::stream_format(out, " alt_creator=\"%s\"", normalize_string(piece.alt_creator()));
+				out << ">\n";
+			}
 
 			for (const auto &flist : part.features())
 				util::stream_format(out, "\t\t\t\t<feature name=\"%s\" value=\"%s\" />\n", flist.name(), normalize_string(flist.value()));

--- a/src/frontend/mame/ui/utils.cpp
+++ b/src/frontend/mame/ui/utils.cpp
@@ -2082,6 +2082,19 @@ ui_software_info::ui_software_info(
 		if (feature.name() == "alt_title")
 			alttitles.emplace_back(ins.value());
 	}
+
+	if (!p.pieces().empty())
+	{
+		infotext.append(2, '\n');
+		infotext.append(util::string_format(_("swlist-info", "%u pieces"), p.pieces().size()));
+		for (software_piece_info const &piece : p.pieces())
+		{
+			if (piece.creator().empty())
+				infotext.append(1, '\n').append(util::string_format("%s : %s", piece.index(), piece.title()));
+			else
+				infotext.append(1, '\n').append(util::string_format("%s : %s - %s", piece.index(), piece.title(), piece.creator()));
+		}
+	}
 }
 
 // info for starting empty


### PR DESCRIPTION
This is intended to facilitate organization of metadata for software compilations, especially miscellaneous and user-created ones. The pieces are subelements of software parts to potentially allow a separate list of pieces for each part of a large compilation.

The "index" attribute is deliberately not required to be a number. It might conceivably be a timestamp on a cassette tape or a filename on a disk.

The UI for this could use some refinement. Currently the (optional) "alt_title" and "alt_creator" attributes are not shown at all.