### PR TITLE
LUA:  Fixing an issue setting float options

### DIFF
--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -1360,19 +1360,14 @@ void lua_engine::initialize()
 			else
 				e.set_value(val ? 1 : 0, OPTION_PRIORITY_CMDLINE);
 		},
-		[] (core_options::entry &e, sol::this_state s, int val)
-		{
-			if (e.type() != core_options::option_type::INTEGER)
-				luaL_error(s, "Cannot set option to wrong type");
-			else
-				e.set_value(val, OPTION_PRIORITY_CMDLINE);
-		},
 		[] (core_options::entry &e, sol::this_state s, float val)
 		{
-			if (e.type() != core_options::option_type::FLOAT)
-				luaL_error(s, "Cannot set option to wrong type");
-			else
+			if (e.type() == core_options::option_type::FLOAT)
 				e.set_value(val, OPTION_PRIORITY_CMDLINE);
+			else if (e.type() == core_options::option_type::INTEGER && static_cast<int>(val) == val)
+				e.set_value(static_cast<int>(val), OPTION_PRIORITY_CMDLINE);
+			else
+				luaL_error(s, "Cannot set option to wrong type");
 		},
 		[] (core_options::entry &e, sol::this_state s, const char *val)
 		{


### PR DESCRIPTION
LUA only has a `number` type, and as such currently the handler for options of type `int` is going to intercept floating point numbers, even if they can't be cast to integers.  This can be reproduced with the following command:

```
manager.options.entries['beam_dot_size']:value(2.5)
```

With this change, there is a single handler for LUA type `number` that takes a `float` and can set integer options provided that the `float` can be represented as an `int` losslessly.