### PR TITLE
pc98.xml: New software list item.

### DIFF
--- a/hash/pc98.xml
+++ b/hash/pc98.xml
@@ -1276,7 +1276,7 @@ Utility disk file "BMENU." sports ugly GFX cyan fills (especially noticeable whe
         	<publisher>Microsoft</publisher>
         	<part name="flop1" interface="floppy_3_5">
             		<dataarea name="flop" size="1281968">
-                		<rom name="win95b.img" size="1281968" crc="106cc9fa" sha1="2dde4d7d51494ab5e7805aefcea26ad80a4ba104"/>
+                		<rom name="win95b.d88" size="1281968" crc="106cc9fa" sha1="2dde4d7d51494ab5e7805aefcea26ad80a4ba104"/>
             		</dataarea>
         	</part>
 	</software>


### PR DESCRIPTION
_(redacted -Kale)_ was created by Neko Project 21/W (cause MAME always creating a blank images in unformatted form, which PC-98 Windows installers cannot work with) and filled by NEC Win95 default means.