### PR TITLE
DRC: Add support for generating invariant code

### DIFF
--- a/src/devices/cpu/drcbec.cpp
+++ b/src/devices/cpu/drcbec.cpp
@@ -464,7 +464,6 @@ drcbe_c::drcbe_c(drcuml_state &drcuml, device_t &device, drc_cache &cache, uint3
 	drcbe_interface(drcuml, cache, device),
 	m_hash(cache, modes, addrbits, ignorebits),
 	m_map(cache, 0xaaaaaaaa55555555),
-	m_labels(cache),
 	m_fixup_delegate(&drcbe_c::fixup_label, this)
 {
 }
@@ -520,8 +519,10 @@ void drcbe_c::generate(drcuml_block &block, const instruction *instlist, uint32_
 	m_map.block_begin(block);
 
 	// begin codegen; fail if we can't
-	drccodeptr *cachetop = m_cache.begin_codegen((numinst + regclears) * sizeof(drcbec_instruction) * 4);
-	if (cachetop == nullptr)
+	drccodeptr *cachetop = block.invariant()
+			? m_cache.begin_codegen_invariant((numinst + regclears) * sizeof(drcbec_instruction) * 4)
+			: m_cache.begin_codegen((numinst + regclears) * sizeof(drcbec_instruction) * 4);
+	if (!cachetop)
 		block.abort();
 
 	// compute the base by aligning the cache top to an even multiple of drcbec_instruction

--- a/src/devices/cpu/drcbeut.h
+++ b/src/devices/cpu/drcbeut.h
@@ -74,8 +74,10 @@ private:
 
 	std::vector<drccodeptr **> m_l1blocks;
 	std::vector<drccodeptr *> m_l2blocks;
-	std::size_t m_next_l1_block;
-	std::size_t m_next_l2_block;
+	std::vector<bool> m_invariant_modes;
+	uint32_t m_next_l1_block;
+	uint32_t m_next_l2_block;
+	uint32_t m_invariant_mode_count;
 
 	// internal state
 	drc_cache &             m_cache;                // cache where allocations come from
@@ -129,10 +131,11 @@ private:
 	using map_entry_vector = std::vector<map_entry>;
 
 	// internal state
-	drc_cache &         m_cache;            // pointer to the cache
-	uint64_t            m_uniquevalue;      // unique value used to find the table
-	uint32_t            m_mapvalue[uml::MAPVAR_END - uml::MAPVAR_M0]; // array of current values
-	map_entry_vector    m_entry_list;       // list of entries
+	drc_cache &             m_cache;            // pointer to the cache
+	uint64_t                m_uniquevalue;      // unique value used to find the table
+	uint32_t                m_mapvalue[uml::MAPVAR_END - uml::MAPVAR_M0]; // array of current values
+	map_entry_vector        m_entry_list;       // list of entries
+	std::vector<uint32_t>   m_out_temp;         // buffer for building output
 };
 
 
@@ -145,7 +148,7 @@ class drc_label_list
 {
 public:
 	// construction/destruction
-	drc_label_list(drc_cache &cache);
+	drc_label_list();
 	~drc_label_list();
 
 	// block begin/end
@@ -167,6 +170,7 @@ private:
 	struct label_fixup
 	{
 		label_entry *       label;          // the label in question
+		void *              param;          // user parameter value
 		drc_label_fixup_delegate callback;  // callback
 	};
 	using label_fixup_list = std::list<label_fixup>;
@@ -174,13 +178,10 @@ private:
 	// internal helpers
 	void reset(bool fatal_on_leftovers);
 	label_entry &find_or_allocate(uml::code_label label);
-	void oob_callback(drccodeptr *codeptr, void *param1, void *param2);
 
 	// internal state
-	drc_cache &         m_cache;            // pointer to the cache
 	label_entry_list    m_list;             // head of the live list
-	label_fixup_list    m_fixup_list;       // list of pending oob fixups
-	drc_oob_delegate    m_oob_callback_delegate; // pre-computed delegate
+	label_fixup_list    m_fixup_list;       // list of pending fixups
 	label_entry_list    m_free_labels;
 	label_fixup_list    m_free_fixups;
 };

--- a/src/devices/cpu/drcbex64.cpp
+++ b/src/devices/cpu/drcbex64.cpp
@@ -610,7 +610,7 @@ private:
 	void calculate_status_flags_mul(Assembler &a, const uml::instruction &inst, Gp const &lo, Gp const &hi);
 	void calculate_status_flags_mullw(Assembler &a, const uml::instruction &inst, Gp const &lo, Gp const &hi);
 
-	size_t emit(CodeHolder &ch);
+	size_t emit(CodeHolder &ch, bool invariant);
 
 	// internal state
 	drc_hash_table          m_hash;                 // hash table state
@@ -630,6 +630,8 @@ private:
 	x86code *               m_endofblock;           // end of block handler
 
 	near_state &            m_near;
+
+	bool                    m_invariant_block;      // are we generating an invariant block?
 
 	resolved_member_function m_debug_cpu_instruction_hook;
 	resolved_member_function m_drcmap_get_value;
@@ -1022,6 +1024,7 @@ drcbe_x64::drcbe_x64(drcuml_state &drcuml, device_t &device, drc_cache &cache, u
 	, m_nocode(nullptr)
 	, m_endofblock(nullptr)
 	, m_near(*cache.alloc_near<near_state>())
+	, m_invariant_block(false)
 {
 	// check for optional CPU features
 	const auto &x86_features = CpuInfo::host().features().x86();
@@ -1103,71 +1106,6 @@ drcbe_x64::drcbe_x64(drcuml_state &drcuml, device_t &device, drc_cache &cache, u
 		m_log = x86log_context::create(filename);
 		m_log_asmjit = fopen(std::string("drcbex64_asmjit_").append(device.shortname()).append(".asm").c_str(), "w");
 	}
-}
-
-
-//-------------------------------------------------
-//  ~drcbe_x64 - destructor
-//-------------------------------------------------
-
-drcbe_x64::~drcbe_x64()
-{
-	// free the log context
-	m_log.reset();
-
-	if (m_log_asmjit)
-		fclose(m_log_asmjit);
-}
-
-size_t drcbe_x64::emit(CodeHolder &ch)
-{
-	Error err;
-
-	// the following three calls aren't currently required, but may be if
-	// other asmjist features are used in future
-	if (false)
-	{
-		err = ch.flatten();
-		if (err != kErrorOk)
-			throw emu_fatalerror("asmjit::CodeHolder::flatten() error %u", std::underlying_type_t<Error>(err));
-
-		err = ch.resolve_cross_section_fixups();
-		if (err != kErrorOk)
-			throw emu_fatalerror("asmjit::CodeHolder::resolve_cross_section_fixups() error %u", std::underlying_type_t<Error>(err));
-
-		err = ch.relocate_to_base(ch.base_address());
-		if (err != kErrorOk)
-			throw emu_fatalerror("asmjit::CodeHolder::relocate_to_base() error %u", std::underlying_type_t<Error>(err));
-	}
-
-	size_t const alignment = ch.base_address() - uintptr_t(m_cache.top());
-	size_t const code_size = ch.code_size();
-
-	// test if enough room remains in drc cache
-	drccodeptr *cachetop = m_cache.begin_codegen(alignment + code_size);
-	if (!cachetop)
-		return 0;
-
-	err = ch.copy_flattened_data(drccodeptr(ch.base_address()), code_size, CopySectionFlags::kPadTargetBuffer);
-	if (err != kErrorOk)
-		throw emu_fatalerror("asmjit::CodeHolder::copy_flattened_data() error %u", std::underlying_type_t<Error>(err));
-
-	// update the drc cache and end codegen
-	*cachetop += alignment + code_size;
-	m_cache.end_codegen();
-
-	return code_size;
-}
-
-//-------------------------------------------------
-//  reset - reset back-end specific state
-//-------------------------------------------------
-
-void drcbe_x64::reset()
-{
-	// output a note to the log
-	if (m_log)
-		m_log->printf("%s", "\n\n===========\nCACHE RESET\n===========\n\n");
 
 	// generate a little bit of glue code to set up the environment
 	x86code *dst = (x86code *)m_cache.top();
@@ -1231,7 +1169,7 @@ void drcbe_x64::reset()
 	smart_call_r64(a, (x86code *)entrypoint, rax);
 
 	// emit the generated code
-	const size_t bytes = emit(ch);
+	const size_t bytes = emit(ch, true);
 
 	if (m_log)
 	{
@@ -1241,9 +1179,77 @@ void drcbe_x64::reset()
 		m_log->disasm_code_range("end_of_block", m_endofblock, dst + bytes);
 	}
 
+	// set the "no code" pointer
+	m_hash.set_default_codeptr(m_nocode);
+}
+
+
+//-------------------------------------------------
+//  ~drcbe_x64 - destructor
+//-------------------------------------------------
+
+drcbe_x64::~drcbe_x64()
+{
+	// free the log context
+	m_log.reset();
+
+	if (m_log_asmjit)
+		fclose(m_log_asmjit);
+}
+
+size_t drcbe_x64::emit(CodeHolder &ch, bool invariant)
+{
+	Error err;
+
+	// the following three calls aren't currently required, but may be if
+	// other asmjit features are used in future
+	if (false)
+	{
+		err = ch.flatten();
+		if (err != kErrorOk)
+			throw emu_fatalerror("asmjit::CodeHolder::flatten() error %u", std::underlying_type_t<Error>(err));
+
+		err = ch.resolve_cross_section_fixups();
+		if (err != kErrorOk)
+			throw emu_fatalerror("asmjit::CodeHolder::resolve_cross_section_fixups() error %u", std::underlying_type_t<Error>(err));
+
+		err = ch.relocate_to_base(ch.base_address());
+		if (err != kErrorOk)
+			throw emu_fatalerror("asmjit::CodeHolder::relocate_to_base() error %u", std::underlying_type_t<Error>(err));
+	}
+
+	size_t const alignment = ch.base_address() - uintptr_t(m_cache.top());
+	size_t const code_size = ch.code_size();
+
+	// try to allocate space from the DRC cache
+	auto space = invariant
+			? m_cache.alloc_invariant(alignment + code_size, std::align_val_t(1))
+			: m_cache.alloc_transient(alignment + code_size, std::align_val_t(1));
+	if (!space)
+		return 0;
+
+	assert(uintptr_t(space) <= ch.base_address());
+	err = ch.copy_flattened_data(drccodeptr(ch.base_address()), code_size, CopySectionFlags::kPadTargetBuffer);
+	if (err != kErrorOk)
+		throw emu_fatalerror("asmjit::CodeHolder::copy_flattened_data() error %u", std::underlying_type_t<Error>(err));
+
+	osd::invalidate_instruction_cache(drccodeptr(ch.base_address()), code_size);
+
+	return code_size;
+}
+
+//-------------------------------------------------
+//  reset - reset back-end specific state
+//-------------------------------------------------
+
+void drcbe_x64::reset()
+{
+	// output a note to the log
+	if (m_log)
+		m_log->printf("%s", "\n\n===========\nCACHE RESET\n===========\n\n");
+
 	// reset our hash tables
 	m_hash.reset();
-	m_hash.set_default_codeptr(m_nocode);
 }
 
 
@@ -1277,6 +1283,7 @@ void drcbe_x64::generate(drcuml_block &block, const instruction *instlist, u32 n
 	// tell all of our utility objects that a block is beginning
 	m_hash.block_begin(block, instlist, numinst);
 	m_map.block_begin(block);
+	m_invariant_block = block.invariant();
 
 	// compute the base by aligning the cache top to a cache line
 	auto [err, linesize] = osd_get_cache_line_size();
@@ -1352,7 +1359,7 @@ void drcbe_x64::generate(drcuml_block &block, const instruction *instlist, u32 n
 	a.jmp(imm(m_endofblock));
 
 	// emit the generated code
-	size_t const bytes = emit(ch);
+	size_t const bytes = emit(ch, block.invariant());
 	if (!bytes)
 		block.abort();
 
@@ -2041,58 +2048,57 @@ void drcbe_x64::op_hashjmp(Assembler &a, const instruction &inst)
 
 	// load the stack base
 	Label nocode = a.new_label();
-	a.mov(rsp, MABS(&m_near.stacksave));                                            // mov   rsp,[stacksave]
+	a.mov(rsp, MABS(&m_near.stacksave));
 
 	// fixed mode cases
 	if (modep.is_immediate() && m_hash.populate_mode(modep.immediate()))
 	{
-		if (pcp.is_immediate())
+		if (pcp.is_immediate() && !m_invariant_block)
 		{
 			// a straight immediate jump is direct, though we need the PC in EAX in case of failure
-			u32 l1val = (pcp.immediate() >> m_hash.l1shift()) & m_hash.l1mask();
-			u32 l2val = (pcp.immediate() >> m_hash.l2shift()) & m_hash.l2mask();
-			a.short_().lea(gpq(REG_PARAM1), ptr(nocode));                               // lea   rcx,[rip+nocode]
-			a.jmp(MABS(&m_hash.base()[modep.immediate()][l1val][l2val]));               // jmp   hash[modep][l1val][l2val]
+			const u32 l1val = (pcp.immediate() >> m_hash.l1shift()) & m_hash.l1mask();
+			const u32 l2val = (pcp.immediate() >> m_hash.l2shift()) & m_hash.l2mask();
+			a.short_().lea(gpq(REG_PARAM1), ptr(nocode));
+			a.jmp(MABS(&m_hash.base()[modep.immediate()][l1val][l2val]));
 		}
 		else
 		{
 			// a fixed mode but variable PC
-			mov_reg_param(a, eax, pcp);                                                 // mov   eax,pcp
-			a.mov(edx, eax);                                                            // mov   edx,eax
-			a.shr(edx, m_hash.l1shift());                                               // shr   edx,l1shift
-			a.and_(eax, m_hash.l2mask() << m_hash.l2shift());                           // and  eax,l2mask << l2shift
+			mov_reg_param(a, eax, pcp);
+			a.mov(edx, eax);
+			a.shr(edx, m_hash.l1shift());
+			a.and_(eax, m_hash.l2mask() << m_hash.l2shift());
 			a.mov(rdx, ptr(rbp, rdx, 3, offset_from_rbp(&m_hash.base()[modep.immediate()][0])));
-																						// mov   rdx,hash[modep+edx*8]
-			a.short_().lea(gpq(REG_PARAM1), ptr(nocode));                               // lea   rcx,[rip+nocode]
-			a.jmp(ptr(rdx, rax, 3 - m_hash.l2shift()));                                 // jmp   [rdx+rax*shift]
+			a.short_().lea(gpq(REG_PARAM1), ptr(nocode));
+			a.jmp(ptr(rdx, rax, 3 - m_hash.l2shift()));
 		}
 	}
 	else
 	{
 		// variable mode
-		Gp modereg = modep.select_register(ecx);
-		mov_reg_param(a, modereg, modep);                                               // mov   modereg,modep
-		a.mov(rcx, ptr(rbp, modereg, 3, offset_from_rbp(m_hash.base())));               // mov   rcx,hash[modereg*8]
+		const Gp modereg = modep.select_register(ecx);
+		mov_reg_param(a, modereg, modep);
+		a.mov(rcx, ptr(rbp, modereg, 3, offset_from_rbp(m_hash.base())));
 
 		if (pcp.is_immediate())
 		{
 			// fixed PC
-			u32 l1val = (pcp.immediate() >> m_hash.l1shift()) & m_hash.l1mask();
-			u32 l2val = (pcp.immediate() >> m_hash.l2shift()) & m_hash.l2mask();
-			a.mov(rdx, ptr(rcx, l1val * 8));                                            // mov   rdx,[rcx+l1val*8]
-			a.short_().lea(gpq(REG_PARAM1), ptr(nocode));                               // lea   rcx,[rip+nocode]
-			a.jmp(ptr(rdx, l2val * 8));                                                 // jmp   [l2val*8]
+			const u32 l1val = (pcp.immediate() >> m_hash.l1shift()) & m_hash.l1mask();
+			const u32 l2val = (pcp.immediate() >> m_hash.l2shift()) & m_hash.l2mask();
+			a.mov(rdx, ptr(rcx, l1val * 8));
+			a.short_().lea(gpq(REG_PARAM1), ptr(nocode));
+			a.jmp(ptr(rdx, l2val * 8));
 		}
 		else
 		{
 			// variable PC
-			mov_reg_param(a, eax, pcp);                                                 // mov   eax,pcp
-			a.mov(edx, eax);                                                            // mov   edx,eax
-			a.shr(edx, m_hash.l1shift());                                               // shr   edx,l1shift
-			a.mov(rdx, ptr(rcx, rdx, 3));                                               // mov   rdx,[rcx+rdx*8]
-			a.and_(eax, m_hash.l2mask() << m_hash.l2shift());                           // and   eax,l2mask << l2shift
-			a.short_().lea(gpq(REG_PARAM1), ptr(nocode));                               // lea   rcx,[rip+nocode]
-			a.jmp(ptr(rdx, rax, 3 - m_hash.l2shift()));                                 // jmp   [rdx+rax*shift]
+			mov_reg_param(a, eax, pcp);
+			a.mov(edx, eax);
+			a.shr(edx, m_hash.l1shift());
+			a.mov(rdx, ptr(rcx, rdx, 3));
+			a.and_(eax, m_hash.l2mask() << m_hash.l2shift());
+			a.short_().lea(gpq(REG_PARAM1), ptr(nocode));
+			a.jmp(ptr(rdx, rax, 3 - m_hash.l2shift()));
 		}
 	}
 
@@ -2101,8 +2107,8 @@ void drcbe_x64::op_hashjmp(Assembler &a, const instruction &inst)
 	if (LOG_HASHJMPS)
 		smart_call_m64(a, &m_near.debug_log_hashjmp_fail);
 
-	mov_mem_param(a, MABS(&m_state.exp, 4), pcp);                                       // mov   [exp],param
-	a.call(MABS(exp.handle().codeptr_addr()));                                          // call  [exp]
+	mov_mem_param(a, MABS(&m_state.exp, 4), pcp);
+	a.call(MABS(exp.handle().codeptr_addr()));
 }
 
 

--- a/src/devices/cpu/drcbex86.cpp
+++ b/src/devices/cpu/drcbex86.cpp
@@ -634,14 +634,13 @@ private:
 	void emit_fld_p(Assembler &a, int size, be_parameter const &param);
 	void emit_fstp_p(Assembler &a, int size, be_parameter const &param);
 
-	size_t emit(asmjit::CodeHolder &ch);
+	size_t emit(asmjit::CodeHolder &ch, bool invariant);
 
 	// internal state
 	drc_hash_table          m_hash;                 // hash table state
 	drc_map_variables       m_map;                  // code map
 	x86log_context::ptr     m_log;                  // logging
 	FILE *                  m_log_asmjit;
-	bool                    m_logged_common;        // logged common code already?
 	bool const              m_sse3;                 // do we have SSE3 support?
 
 	x86_entry_point_func    m_entry;                // entry point
@@ -660,6 +659,7 @@ private:
 	x86code *               m_last_upper_pc;        // PC after instruction where we last stored an upper register
 	uint32_t *              m_last_upper_addr;      // address where we last stored an upper register
 	double                  m_fptemp;               // temporary storage for floating point
+	bool                    m_invariant_block;      // are we generating an invariant block?
 
 	uint16_t                m_fpumode;              // saved FPU mode
 	uint16_t                m_fmodesave;            // temporary location for saving
@@ -1022,7 +1022,6 @@ drcbe_x86::drcbe_x86(drcuml_state &drcuml, device_t &device, drc_cache &cache, u
 	, m_hash(cache, modes, addrbits, ignorebits)
 	, m_map(cache, 0)
 	, m_log_asmjit(nullptr)
-	, m_logged_common(false)
 	, m_sse3(CpuInfo::host().features().x86().has_sse3())
 	, m_entry(nullptr)
 	, m_exit(nullptr)
@@ -1037,6 +1036,7 @@ drcbe_x86::drcbe_x86(drcuml_state &drcuml, device_t &device, drc_cache &cache, u
 	, m_last_upper_pc(nullptr)
 	, m_last_upper_addr(nullptr)
 	, m_fptemp(0)
+	, m_invariant_block(false)
 	, m_fpumode(0)
 	, m_fmodesave(0)
 	, m_stacksave(nullptr)
@@ -1092,71 +1092,6 @@ drcbe_x86::drcbe_x86(drcuml_state &drcuml, device_t &device, drc_cache &cache, u
 		m_log = x86log_context::create(filename);
 		m_log_asmjit = fopen(std::string("drcbex86_asmjit_").append(device.shortname()).append(".asm").c_str(), "w");
 	}
-}
-
-
-//-------------------------------------------------
-//  ~drcbe_x86 - destructor
-//-------------------------------------------------
-
-drcbe_x86::~drcbe_x86()
-{
-	// free the log context
-	m_log.reset();
-
-	if (m_log_asmjit)
-		fclose(m_log_asmjit);
-}
-
-size_t drcbe_x86::emit(CodeHolder &ch)
-{
-	Error err;
-
-	// the following three calls aren't currently required, but may be if
-	// other asmjist features are used in future
-	if (false)
-	{
-		err = ch.flatten();
-		if (err != kErrorOk)
-			throw emu_fatalerror("asmjit::CodeHolder::flatten() error %u", std::underlying_type_t<Error>(err));
-
-		err = ch.resolve_cross_section_fixups();
-		if (err != kErrorOk)
-			throw emu_fatalerror("asmjit::CodeHolder::resolve_cross_section_fixups() error %u", std::underlying_type_t<Error>(err));
-
-		err = ch.relocate_to_base(ch.base_address());
-		if (err != kErrorOk)
-			throw emu_fatalerror("asmjit::CodeHolder::relocate_to_base() error %u", std::underlying_type_t<Error>(err));
-	}
-
-	size_t const alignment = ch.base_address() - uint64_t(m_cache.top());
-	size_t const code_size = ch.code_size();
-
-	// test if enough room remains in drc cache
-	drccodeptr *cachetop = m_cache.begin_codegen(alignment + code_size);
-	if (cachetop == nullptr)
-		return 0;
-
-	err = ch.copy_flattened_data(drccodeptr(ch.base_address()), code_size, CopySectionFlags::kPadTargetBuffer);
-	if (err != kErrorOk)
-		throw emu_fatalerror("asmjit::CodeHolder::copy_flattened_data() error %u", std::underlying_type_t<Error>(err));
-
-	// update the drc cache and end codegen
-	*cachetop += alignment + code_size;
-	m_cache.end_codegen();
-
-	return code_size;
-}
-
-//-------------------------------------------------
-//  reset - reset back-end specific state
-//-------------------------------------------------
-
-void drcbe_x86::reset()
-{
-	// output a note to the log
-	if (m_log)
-		m_log->printf("%s", "\n\n===========\nCACHE RESET\n===========\n\n");
 
 	// generate a little bit of glue code to set up the environment
 	x86code *dst = (x86code *)m_cache.top();
@@ -1306,9 +1241,9 @@ void drcbe_x86::reset()
 
 
 	// emit the generated code
-	size_t bytes = emit(ch);
+	size_t const bytes = emit(ch, true);
 
-	if (m_log && !m_logged_common)
+	if (m_log)
 	{
 		m_log->disasm_code_range("entry_point", dst, m_exit);
 		m_log->disasm_code_range("exit_point", m_exit, m_nocode);
@@ -1316,13 +1251,79 @@ void drcbe_x86::reset()
 		m_log->disasm_code_range("end_of_block", m_endofblock, m_save);
 		m_log->disasm_code_range("save", m_save, m_restore);
 		m_log->disasm_code_range("restore", m_restore, dst + bytes);
-
-		m_logged_common = true;
 	}
+
+	// set the "no code" pointer
+	m_hash.set_default_codeptr(m_nocode);
+}
+
+
+//-------------------------------------------------
+//  ~drcbe_x86 - destructor
+//-------------------------------------------------
+
+drcbe_x86::~drcbe_x86()
+{
+	// free the log context
+	m_log.reset();
+
+	if (m_log_asmjit)
+		fclose(m_log_asmjit);
+}
+
+size_t drcbe_x86::emit(CodeHolder &ch, bool invariant)
+{
+	Error err;
+
+	// the following three calls aren't currently required, but may be if
+	// other asmjit features are used in future
+	if (false)
+	{
+		err = ch.flatten();
+		if (err != kErrorOk)
+			throw emu_fatalerror("asmjit::CodeHolder::flatten() error %u", std::underlying_type_t<Error>(err));
+
+		err = ch.resolve_cross_section_fixups();
+		if (err != kErrorOk)
+			throw emu_fatalerror("asmjit::CodeHolder::resolve_cross_section_fixups() error %u", std::underlying_type_t<Error>(err));
+
+		err = ch.relocate_to_base(ch.base_address());
+		if (err != kErrorOk)
+			throw emu_fatalerror("asmjit::CodeHolder::relocate_to_base() error %u", std::underlying_type_t<Error>(err));
+	}
+
+	size_t const alignment = ch.base_address() - uint64_t(m_cache.top());
+	size_t const code_size = ch.code_size();
+
+	// try to allocate space from the DRC cache
+	auto space = invariant
+			? m_cache.alloc_invariant(alignment + code_size, std::align_val_t(1))
+			: m_cache.alloc_transient(alignment + code_size, std::align_val_t(1));
+	if (!space)
+		return 0;
+
+	assert(uintptr_t(space) <= ch.base_address());
+	err = ch.copy_flattened_data(drccodeptr(ch.base_address()), code_size, CopySectionFlags::kPadTargetBuffer);
+	if (err != kErrorOk)
+		throw emu_fatalerror("asmjit::CodeHolder::copy_flattened_data() error %u", std::underlying_type_t<Error>(err));
+
+	osd::invalidate_instruction_cache(drccodeptr(ch.base_address()), code_size);
+
+	return code_size;
+}
+
+//-------------------------------------------------
+//  reset - reset back-end specific state
+//-------------------------------------------------
+
+void drcbe_x86::reset()
+{
+	// output a note to the log
+	if (m_log)
+		m_log->printf("%s", "\n\n===========\nCACHE RESET\n===========\n\n");
 
 	// reset our hash tables
 	m_hash.reset();
-	m_hash.set_default_codeptr(m_nocode);
 }
 
 
@@ -1356,6 +1357,7 @@ void drcbe_x86::generate(drcuml_block &block, const instruction *instlist, uint3
 	// tell all of our utility objects that a block is beginning
 	m_hash.block_begin(block, instlist, numinst);
 	m_map.block_begin(block);
+	m_invariant_block = block.invariant();
 
 	// compute the base by aligning the cache top to a cache line
 	auto [err, linesize] = osd_get_cache_line_size();
@@ -1429,7 +1431,7 @@ void drcbe_x86::generate(drcuml_block &block, const instruction *instlist, uint3
 	a.jmp(imm(m_endofblock));
 
 	// emit the generated code
-	size_t const bytes = emit(ch);
+	size_t const bytes = emit(ch, block.invariant());
 	if (!bytes)
 		block.abort();
 
@@ -3083,60 +3085,60 @@ void drcbe_x86::op_hashjmp(Assembler &a, const instruction &inst)
 	}
 
 	// load the stack base one word early so we end up at the right spot after our call below
-	a.mov(esp, MABS(&m_hashstacksave));                                                 // mov   esp,[hashstacksave]
+	a.mov(esp, MABS(&m_hashstacksave));
 
-	if (modep.is_immediate() && m_hash.is_mode_populated(modep.immediate()))
+	if (modep.is_immediate() && m_hash.populate_mode(modep.immediate()))
 	{
 		// fixed mode cases
-		if (pcp.is_immediate())
+		if (pcp.is_immediate() && !m_invariant_block)
 		{
 			// a straight immediate jump is direct, though we need the PC in EAX in case of failure
-			uint32_t l1val = (pcp.immediate() >> m_hash.l1shift()) & m_hash.l1mask();
-			uint32_t l2val = (pcp.immediate() >> m_hash.l2shift()) & m_hash.l2mask();
-			a.call(MABS(&m_hash.base()[modep.immediate()][l1val][l2val]));              // call  hash[modep][l1val][l2val]
+			uint32_t const l1val = (pcp.immediate() >> m_hash.l1shift()) & m_hash.l1mask();
+			uint32_t const l2val = (pcp.immediate() >> m_hash.l2shift()) & m_hash.l2mask();
+			a.call(MABS(&m_hash.base()[modep.immediate()][l1val][l2val]));
 		}
 		else
 		{
 			// a fixed mode but variable PC
-			emit_mov_r32_p32(a, eax, pcp);                                              // mov   eax,pcp
-			a.mov(edx, eax);                                                            // mov   edx,eax
-			a.shr(edx, m_hash.l1shift());                                               // shr   edx,l1shift
-			a.and_(eax, m_hash.l2mask() << m_hash.l2shift());                           // and  eax,l2mask << l2shift
-			a.mov(edx, ptr(uintptr_t(&m_hash.base()[modep.immediate()][0]), edx, 2));   // mov   edx,hash[modep+edx*4]
-			a.call(ptr(edx, eax, 2 - m_hash.l2shift()));                                // call  [edx+eax*shift]
+			emit_mov_r32_p32(a, eax, pcp);
+			a.mov(edx, eax);
+			a.shr(edx, m_hash.l1shift());
+			a.and_(eax, m_hash.l2mask() << m_hash.l2shift());
+			a.mov(edx, ptr(uintptr_t(&m_hash.base()[modep.immediate()][0]), edx, 2));
+			a.call(ptr(edx, eax, 2 - m_hash.l2shift()));
 		}
 	}
 	else
 	{
 		// variable mode
 		Gp const modereg = modep.select_register(ecx);
-		emit_mov_r32_p32(a, modereg, modep);                                            // mov   modereg,modep
-		a.mov(ecx, ptr(uintptr_t(m_hash.base()), modereg, 2));                          // mov   ecx,hash[modereg*4]
+		emit_mov_r32_p32(a, modereg, modep);
+		a.mov(ecx, ptr(uintptr_t(m_hash.base()), modereg, 2));
 
 		if (pcp.is_immediate())
 		{
 			// fixed PC
-			uint32_t l1val = (pcp.immediate() >> m_hash.l1shift()) & m_hash.l1mask();
-			uint32_t l2val = (pcp.immediate() >> m_hash.l2shift()) & m_hash.l2mask();
-			a.mov(edx, ptr(ecx, l1val*4));                                              // mov   edx,[ecx+l1val*4]
-			a.call(ptr(edx, l2val*4));                                                  // call  [l2val*4]
+			uint32_t const l1val = (pcp.immediate() >> m_hash.l1shift()) & m_hash.l1mask();
+			uint32_t const l2val = (pcp.immediate() >> m_hash.l2shift()) & m_hash.l2mask();
+			a.mov(edx, ptr(ecx, l1val * 4));
+			a.call(ptr(edx, l2val * 4));
 		}
 		else
 		{
 			// variable PC
-			emit_mov_r32_p32(a, eax, pcp);                                              // mov   eax,pcp
-			a.mov(edx, eax);                                                            // mov   edx,eax
-			a.shr(edx, m_hash.l1shift());                                               // shr   edx,l1shift
-			a.mov(edx, ptr(ecx, edx, 2));                                               // mov   edx,[ecx+edx*4]
-			a.and_(eax, m_hash.l2mask() << m_hash.l2shift());                           // and  eax,l2mask << l2shift
-			a.call(ptr(edx, eax, 2 - m_hash.l2shift()));                                // call  [edx+eax*shift]
+			emit_mov_r32_p32(a, eax, pcp);
+			a.mov(edx, eax);
+			a.shr(edx, m_hash.l1shift());
+			a.mov(edx, ptr(ecx, edx, 2));
+			a.and_(eax, m_hash.l2mask() << m_hash.l2shift());
+			a.call(ptr(edx, eax, 2 - m_hash.l2shift()));
 		}
 	}
 
 	// in all cases, if there is no code, we return here to generate the exception
-	emit_mov_m32_p32(a, MABS(&m_state.exp, 4), pcp);                                    // mov   [exp],param
-	a.sub(esp, 4);                                                                      // sub   esp,4
-	a.call(MABS(exp.handle().codeptr_addr()));                                          // call  [exp]
+	emit_mov_m32_p32(a, MABS(&m_state.exp, 4), pcp);
+	a.sub(esp, 4);
+	a.call(MABS(exp.handle().codeptr_addr()));
 }
 
 
@@ -7244,9 +7246,9 @@ void drcbe_x86::op_ffrint(Assembler &a, const instruction &inst)
 	parameter const &sizep = inst.param(2);
 	assert(sizep.is_size());
 
-	// 4-byte integer case
 	if (sizep.size() == SIZE_DWORD)
 	{
+		// 4-byte integer case
 		if (srcp.is_immediate())
 		{
 			a.mov(MABS(&m_fptemp, 4), srcp.immediate());                                // mov   [fptemp],srcp
@@ -7260,10 +7262,9 @@ void drcbe_x86::op_ffrint(Assembler &a, const instruction &inst)
 			a.fild(MABS(m_reglo[srcp.ireg()], 4));                                      // fild  reglo[srcp]
 		}
 	}
-
-	// 8-bit integer case
 	else if (sizep.size() == SIZE_QWORD)
 	{
+		// 8-bit integer case
 		if (srcp.is_immediate())
 		{
 			a.mov(MABS(&m_fptemp, 4), srcp.immediate());                                // mov   [fptemp],srcp

--- a/src/devices/cpu/drccache.h
+++ b/src/devices/cpu/drccache.h
@@ -40,10 +40,6 @@
 typedef uint8_t *drccodeptr;
 
 
-// helper template for oob codegen
-typedef delegate<void (drccodeptr *, void *, void *)> drc_oob_delegate;
-
-
 class drc_cache
 {
 public:
@@ -60,15 +56,16 @@ public:
 	drccodeptr top() const { return m_top; }
 
 	// pointer checking
-	bool contains_pointer(const void *ptr) const { return ((const drccodeptr)ptr >= m_near && (const drccodeptr)ptr < m_near + m_size); }
-	bool contains_near_pointer(const void *ptr) const { return ((const drccodeptr)ptr >= m_near && (const drccodeptr)ptr < m_neartop); }
+	bool contains_pointer(const void *ptr) const { return ((drccodeptr)ptr >= m_near && (drccodeptr)ptr < m_near + m_size); }
+	bool contains_near_pointer(const void *ptr) const { return ((drccodeptr)ptr >= m_near && (drccodeptr)ptr < m_neartop); }
 	bool generating_code() const { return (m_codegen != nullptr); }
 
 	// cache memory allocation
 	void flush() noexcept;
 	void *alloc(std::size_t bytes, std::align_val_t align) noexcept;
 	void *alloc_near(std::size_t bytes, std::align_val_t align) noexcept;
-	void *alloc_temporary(std::size_t bytes, std::align_val_t align) noexcept;
+	void *alloc_invariant(std::size_t bytes, std::align_val_t align) noexcept;
+	void *alloc_transient(std::size_t bytes, std::align_val_t align) noexcept;
 	void dealloc(void *memory, std::size_t bytes) noexcept;
 
 	template <typename T, typename... Params>
@@ -111,8 +108,8 @@ public:
 
 	// codegen helpers
 	drccodeptr *begin_codegen(uint32_t reserve_bytes) noexcept;
+	drccodeptr *begin_codegen_invariant(uint32_t reserve_bytes) noexcept;
 	drccodeptr end_codegen();
-	void request_oob_codegen(drc_oob_delegate &&callback, void *param1 = nullptr, void *param2 = nullptr);
 
 	void codegen_complete() noexcept
 	{
@@ -121,9 +118,6 @@ public:
 	}
 
 private:
-	// largest block of code that can be generated at once
-	static constexpr std::size_t CODEGEN_MAX_BYTES = 128 * 1024;
-
 	// minimum alignment, in bytes (must be power of 2)
 	static constexpr std::size_t CACHE_ALIGNMENT = std::max<std::size_t>(alignof(std::max_align_t), 8);
 
@@ -132,13 +126,6 @@ private:
 
 	// size of "near" area at the base of the cache
 	static constexpr std::size_t NEAR_CACHE_SIZE = 128 * 1024;
-
-	struct oob_handler
-	{
-		drc_oob_delegate    m_callback;     // callback function
-		void *              m_param1;       // 1st pointer parameter
-		void *              m_param2;       // 2nd pointer parameter
-	};
 
 	struct free_link
 	{
@@ -158,17 +145,15 @@ private:
 	drccodeptr  m_near;             // pointer to the near part of the cache
 	drccodeptr  m_neartop;          // unallocated area of near cache
 	drccodeptr  m_base;             // end of near cache
-	drccodeptr  m_top;              // end of temporary allocations and code
+	drccodeptr  m_invartop;         // end of invariant allocations and code
+	drccodeptr  m_top;              // end of transient allocations and code
 	drccodeptr  m_rwbase;           // start of writable portion of cache
 	drccodeptr  m_limit;            // limit for temporary allocations and code (page-aligned)
 	drccodeptr  m_end;              // first allocated byte in cache
 	drccodeptr  m_codegen;          // start of current generated code block
 	std::size_t m_size;             // size of the cache in bytes
 	bool        m_rwx;              // whether pages can be simultaneously writable and executable
-
-	// oob management
-	std::list<oob_handler>  m_oob_list;      // list of active oob handlers
-	std::list<oob_handler>  m_oob_free;      // list of recyclable oob handlers
+	bool        m_invargen;         // whether we're generating invariant code
 
 	// free lists
 	free_link_array         m_free;

--- a/src/devices/cpu/e132xs/e132xs.cpp
+++ b/src/devices/cpu/e132xs/e132xs.cpp
@@ -1619,10 +1619,13 @@ void hyperstone_device::device_start()
 		m_drcuml->symbol_add(&m_core->arg0, sizeof(uint32_t), "arg0");
 		m_drcuml->symbol_add(&m_core->arg1, sizeof(uint32_t), "arg1");
 
-		/* initialize the front-end helper */
+		// initialize the front-end helper
 		m_drcfe = std::make_unique<e132xs_frontend>(*this, COMPILE_BACKWARDS_BYTES, COMPILE_FORWARDS_BYTES, m_single_instruction_mode ? 1 : COMPILE_MAX_SEQUENCE);
 
-		/* mark the cache dirty so it is updated on next execute */
+		// generate invariant code
+		generate_invariant();
+
+		// mark the cache dirty so it is updated on next execute
 		m_cache_dirty = true;
 	}
 
@@ -1783,7 +1786,7 @@ void gms30c2132_device::device_start()
 
 void hyperstone_device::device_reset()
 {
-	//TODO: Add different reset initializations for BCR, MCR, FCR, TPR
+	// TODO: Add different reset initializations for BCR, MCR, FCR, TPR
 
 	m_core->tr_clocks_per_tick = 2;
 

--- a/src/devices/cpu/e132xs/e132xs.h
+++ b/src/devices/cpu/e132xs/e132xs.h
@@ -479,7 +479,7 @@ private:
 
 	void execute_run_drc();
 	void flush_drc_cache();
-	void code_flush_cache();
+	void generate_invariant();
 	void code_compile_block(uint8_t mode, offs_t pc);
 	//void load_fast_iregs(drcuml_block &block);
 	//void save_fast_iregs(drcuml_block &block);

--- a/src/devices/cpu/e132xs/e132xsdrc.cpp
+++ b/src/devices/cpu/e132xs/e132xsdrc.cpp
@@ -150,7 +150,7 @@ void hyperstone_device::execute_run_drc()
 	// reset the cache if dirty
 	if (m_cache_dirty)
 	{
-		code_flush_cache();
+		m_drcuml->reset();
 		m_cache_dirty = false;
 	}
 
@@ -166,7 +166,7 @@ void hyperstone_device::execute_run_drc()
 		else if (execute_result == EXECUTE_UNMAPPED_CODE)
 			fatalerror("Attempted to execute unmapped code at PC=%08X\n", m_core->global_regs[0]);
 		else if (execute_result == EXECUTE_RESET_CACHE)
-			code_flush_cache();
+			m_drcuml->reset();
 		else if (execute_result == EXECUTE_OUT_OF_CYCLES)
 			break;
 	}
@@ -190,18 +190,14 @@ void hyperstone_device::flush_drc_cache()
 }
 
 /*-------------------------------------------------
-    code_flush_cache - flush the cache and
-    regenerate static code
+    generate_invariant - generate static code
 -------------------------------------------------*/
 
-void hyperstone_device::code_flush_cache()
+void hyperstone_device::generate_invariant()
 {
-	/* empty the transient cache contents */
-	m_drcuml->reset();
-
 	try
 	{
-		drcuml_block &block(m_drcuml->begin_block(640));
+		drcuml_block &block(m_drcuml->begin_invariant_block(640));
 		uml::code_label label = 1;
 
 		// generate the entry point and out-of-cycles handlers
@@ -359,7 +355,7 @@ void hyperstone_device::code_compile_block(uint8_t mode, offs_t pc)
 		}
 		catch (const drcuml_block::abort_compilation &)
 		{
-			code_flush_cache();
+			m_drcuml->reset();
 		}
 	}
 }


### PR DESCRIPTION
This allows back-ends and CPU cores to keep invariant code across code cache resets.  Impact for CPU core developers is minimal.  Implemented for Hyperstone E1 and PowerPC.  This makes a cache reset substantially cheaper for PowerPC because you’re no longer immediately liable for over 100 KiB of helper functions that won’t have changed since last time.

It should be easy enough for other people to adapt other CPU cores that generate relatively large amounts of invariant code.

Also cleans up a bunch of crud.