### PR TITLE
emu/debug: Allowed device_state_interface to participate in global symtable state

### DIFF
--- a/src/emu/debug/express.cpp
+++ b/src/emu/debug/express.cpp
@@ -372,6 +372,8 @@ symbol_table::symbol_table(running_machine &machine, table_type type, symbol_tab
 	, m_memintf(dynamic_cast<device_memory_interface *>(device))
 	, m_memory_modified(nullptr)
 {
+	assert(type != table_type::CPU_STATE || device != nullptr);
+	assert(type != table_type::BUILTIN_GLOBALS || device == nullptr);
 }
 
 

--- a/src/emu/debug/express.h
+++ b/src/emu/debug/express.h
@@ -178,7 +178,7 @@ public:
 	{
 		CPU_STATE,         // CPU registers, etc.
 		BUILTIN_GLOBALS,   // Built-in MAME global symbols (e.g., beamx, beamy, frame, etc.)
-						   // (also used for tables outside debugger: lua scripts, cheat engine)
+		                   // (also used for tables outside debugger: lua scripts, cheat engine)
 	};
 
 	// construction/destruction

--- a/src/mame/sinclair/specnext.cpp
+++ b/src/mame/sinclair/specnext.cpp
@@ -99,11 +99,12 @@ struct video_timings_info {
 	u16 hdmi_ysync;
 };
 
-class specnext_state : public spectrum_128_state
+class specnext_state : public spectrum_128_state, public device_state_interface
 {
 public:
 	specnext_state(const machine_config &mconfig, device_type type, const char *tag)
 		: spectrum_128_state(mconfig, type, tag)
+		, device_state_interface(mconfig, *this)
 		, m_maincpu(*this, "maincpu")
 		, m_io_expbus_view(*this, "io_expbus_view")
 		, m_bank_boot_rom(*this, "bootrom")
@@ -151,6 +152,7 @@ protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void device_post_load() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
+	virtual void state_import(const device_state_entry &entry) override;
 	void reset_hard();
 	virtual void video_start() override ATTR_COLD;
 	virtual void spectrum_128_update_memory() override {}
@@ -3467,6 +3469,22 @@ void specnext_state::machine_start()
 	save_item(NAME(m_spi_miso_dat));
 	save_item(NAME(m_i2c_scl_data));
 	save_item(NAME(m_i2c_sda_data));
+
+	state_add(0, "mmu0", m_mmu[0]).callimport();
+	state_add(1, "mmu1", m_mmu[1]).callimport();
+	state_add(2, "mmu2", m_mmu[2]).callimport();
+	state_add(3, "mmu3", m_mmu[3]).callimport();
+	state_add(4, "mmu4", m_mmu[4]).callimport();
+	state_add(5, "mmu5", m_mmu[5]).callimport();
+	state_add(6, "mmu6", m_mmu[6]).callimport();
+	state_add(7, "mmu7", m_mmu[7]).callimport();
+}
+
+void specnext_state::state_import(const device_state_entry &entry)
+{
+	if (entry.index() < 8) {
+		bank_update(entry.index());
+	}
 }
 
 void specnext_state::device_post_load()


### PR DESCRIPTION
After this, for device which implements device_state_interface we can access state from global symtable.
CPU (exec) devices continue to publish their state to separate CPU symtables (child of GLOBAL).

~~Also suggesting to rename `machine().debugger().cpu()` to `machine().debugger().state()` as "cpu" confusing term in this context as far as we can have multiple cpu.~~ <<< will do separately, if requested