### PR TITLE
hash/gba.xml: Mark Miteluode - Lingdian Renwu (China) as partially supported

### DIFF
--- a/hash/gba.xml
+++ b/hash/gba.xml
@@ -22902,7 +22902,7 @@ Hangs during cutscene after beating Maxim for best ending path (i.e. before real
 		</part>
 	</software>
 
-	<software name="metroid0c" cloneof="metroid0">
+	<software name="metroid0c" cloneof="metroid0" supported="partial">
 		<description>Miteluode - Lingdian Renwu (China)</description>
 		<year>2005</year>
 		<publisher>iQue</publisher>


### PR DESCRIPTION
This is the Chinese localized version of Metroid: Zero Mission and was missed in 640a127266f5b30ead7e74e3aa7b7b749cc48be0 when marking the other versions as partially supported.  For the same reason: the embedded NES “Original Metroid” does not function properly.

Just to make sure it even includes the mode, I played the whole game just to unlock it. Haha.

<img width="973" height="680" alt="Screenshot_20260130_143621" src="https://github.com/user-attachments/assets/304348ae-a3fb-429c-ad3b-2bad3dc5cd24" />
