### PR TITLE
tms320c2x: some optimizations

### DIFF
--- a/src/devices/cpu/tms320c2x/tms320c2x.cpp
+++ b/src/devices/cpu/tms320c2x/tms320c2x.cpp
@@ -542,7 +542,6 @@ inline void tms320c2x_device::GETDATA(int shift, int signext)
 
 	/* next ARP */
 	if (m_opcode.b.l & 0x80) MODIFY_AR_ARP<IgnoreARPHack>();
-
 }
 
 inline void tms320c2x_device::PUTDATA(uint16_t data)

--- a/src/devices/cpu/tms320c2x/tms320c2x.h
+++ b/src/devices/cpu/tms320c2x/tms320c2x.h
@@ -139,32 +139,30 @@ protected:
 	uint16_t  m_STR0, m_STR1;
 	uint8_t   m_IFR;
 	uint8_t   m_RPTC;
-	PAIR    m_ACC;
-	PAIR    m_Preg;
+	PAIR      m_ACC;
+	PAIR      m_Preg;
 	uint16_t  m_Treg;
 	uint16_t  m_AR[8]; // 5 for TMS32020, 8 for rest
 	uint16_t  m_STACK[8]; // 4 level for TMS32020, 8 level for rest
-	PAIR    m_ALU;
+	PAIR      m_ALU;
 	uint16_t  m_drr, m_dxr, m_tim, m_prd, m_imr, m_greg;
 
-	uint16_t m_fixed_STR1;
+	uint16_t  m_fixed_STR1;
 
 	uint8_t   m_timerover;
 
 	/********************** Status data ****************************/
 	PAIR    m_opcode;
-	int     m_idle;
-	int     m_hold;
-	int     m_external_mem_access;    /** required for hold mode. Implement it ! */
+	bool    m_idle;
+	bool    m_hold;
 	int     m_init_load_addr;         /* 0=No, 1=Yes, 2=Once for repeat mode */
-	int     m_tms320c2x_irq_cycles;
 	int     m_tms320c2x_dec_cycles;
 
-	PAIR    m_oldacc;
+	PAIR      m_oldacc;
 	uint32_t  m_memaccess;
-	int     m_icount;
-	int     m_mHackIgnoreARP;          /* special handling for lst, lst1 instructions */
-	int     m_waiting_for_serial_frame;
+	bool is_mem_access_external() { return m_memaccess >= 0x800; }
+	int       m_icount;
+	bool      m_waiting_for_serial_frame;
 
 	uint16_t drr_r();
 	void drr_w(uint16_t data);
@@ -186,8 +184,8 @@ protected:
 	void MODIFY_DP(int data);
 	void MODIFY_PM(int data);
 	void MODIFY_ARP(int data);
-	uint16_t reverse_carry_add(uint16_t arg0, uint16_t arg1 );
-	void MODIFY_AR_ARP();
+	uint16_t reverse_carry_add(uint16_t arg0, uint16_t arg1);
+	template <bool IgnoreARPHack> void MODIFY_AR_ARP();
 	void CALCULATE_ADD_CARRY();
 	void CALCULATE_SUB_CARRY();
 	void CALCULATE_ADD_OVERFLOW(int32_t addval);
@@ -195,9 +193,11 @@ protected:
 	uint16_t POP_STACK();
 	void PUSH_STACK(uint16_t data);
 	void SHIFT_Preg_TO_ALU();
-	void GETDATA(int shift,int signext);
+	template <bool IgnoreARPHack> void GETDATA();
+	void GETDATA(int shift, int signext);
 	void PUTDATA(uint16_t data);
 	void PUTDATA_SST(uint16_t data);
+
 	void opcodes_CE();
 	void opcodes_Dx();
 	void illegal();
@@ -250,22 +250,8 @@ protected:
 	void lack();
 	void lact();
 	void lalk();
-	void lar_ar0();
-	void lar_ar1();
-	void lar_ar2();
-	void lar_ar3();
-	void lar_ar4();
-	void lar_ar5();
-	void lar_ar6();
-	void lar_ar7();
-	void lark_ar0();
-	void lark_ar1();
-	void lark_ar2();
-	void lark_ar3();
-	void lark_ar4();
-	void lark_ar5();
-	void lark_ar6();
-	void lark_ar7();
+	template <unsigned N> void lar_ar();
+	template <unsigned N> void lark_ar();
 	void ldp();
 	void ldpk();
 	void lph();
@@ -310,14 +296,7 @@ protected:
 	void rxf();
 	void sach();
 	void sacl();
-	void sar_ar0();
-	void sar_ar1();
-	void sar_ar2();
-	void sar_ar3();
-	void sar_ar4();
-	void sar_ar5();
-	void sar_ar6();
-	void sar_ar7();
+	template <unsigned N> void sar_ar();
 	void sblk();
 	void sbrk_ar();
 	void sc();
@@ -353,6 +332,7 @@ protected:
 	void zalh();
 	void zalr();
 	void zals();
+
 	int process_IRQs();
 	void process_timer(int clocks);
 };

--- a/src/devices/cpu/tms320c2x/tms320c2x.h
+++ b/src/devices/cpu/tms320c2x/tms320c2x.h
@@ -193,8 +193,7 @@ protected:
 	uint16_t POP_STACK();
 	void PUSH_STACK(uint16_t data);
 	void SHIFT_Preg_TO_ALU();
-	template <bool IgnoreARPHack> void GETDATA();
-	void GETDATA(int shift, int signext);
+	template <bool IgnoreARPHack> void GETDATA(int shift, int signext);
 	void PUTDATA(uint16_t data);
 	void PUTDATA_SST(uint16_t data);
 

--- a/src/mame/misc/coolpool.cpp
+++ b/src/mame/misc/coolpool.cpp
@@ -174,7 +174,6 @@ protected:
 
 	void misc_w(uint16_t data);
 	uint16_t dsp_bio_line_r();
-	uint16_t dsp_hold_line_r();
 
 	TMS340X0_SCANLINE_RGB32_CB_MEMBER(scanline);
 
@@ -627,13 +626,6 @@ uint16_t _9ballsht_state::dsp_bio_line_r()
 	return m_main2dsp->pending_r() ? CLEAR_LINE : ASSERT_LINE;
 }
 
-
-uint16_t _9ballsht_state::dsp_hold_line_r()
-{
-	return CLEAR_LINE;  // ???
-}
-
-
 /*************************************
  *
  *  IOP ROM and DAC access
@@ -985,8 +977,8 @@ void _9ballsht_state::_9ballsht(machine_config &config)
 	dsp.set_addrmap(AS_PROGRAM, &_9ballsht_state::dsp_pgm_map);
 	dsp.set_addrmap(AS_IO, &_9ballsht_state::nballsht_dsp_io_map);
 	dsp.bio_in_cb().set(FUNC(_9ballsht_state::dsp_bio_line_r));
-	dsp.hold_in_cb().set(FUNC(_9ballsht_state::dsp_hold_line_r));
-//  dsp.hold_ack_out_cb().set(FUNC(_9ballsht_state::dsp_HOLDA_signal_w));
+	//dsp.hold_in_cb().set(FUNC(_9ballsht_state::dsp_hold_line_r));
+	//dsp.hold_ack_out_cb().set(FUNC(_9ballsht_state::dsp_HOLDA_signal_w));
 
 	GENERIC_LATCH_16(config, m_main2dsp);
 	// ??? I have no idea who should generate this!

--- a/src/mame/namco/namcos21_dsp.cpp
+++ b/src/mame/namco/namcos21_dsp.cpp
@@ -264,7 +264,6 @@ void namcos21_dsp_device::device_add_mconfig(machine_config &config)
 	dsp.set_addrmap(AS_DATA, &namcos21_dsp_device::winrun_dsp_data);
 	dsp.set_addrmap(AS_IO, &namcos21_dsp_device::winrun_dsp_io);
 	dsp.bio_in_cb().set(FUNC(namcos21_dsp_device::winrun_poly_reset_r));
-	dsp.hold_in_cb().set_constant(0);
 	dsp.hold_ack_out_cb().set_nop();
 	dsp.xf_out_cb().set_nop();
 }

--- a/src/mame/namco/namcos21_dsp_c67.cpp
+++ b/src/mame/namco/namcos21_dsp_c67.cpp
@@ -129,7 +129,6 @@ void namcos21_dsp_c67_device::device_add_mconfig(machine_config &config)
 	dspmaster.set_addrmap(AS_PROGRAM, &namcos21_dsp_c67_device::master_dsp_program);
 	dspmaster.set_addrmap(AS_DATA, &namcos21_dsp_c67_device::master_dsp_data);
 	dspmaster.set_addrmap(AS_IO, &namcos21_dsp_c67_device::master_dsp_io);
-	dspmaster.hold_in_cb().set_constant(0);
 	dspmaster.hold_ack_out_cb().set_nop();
 	dspmaster.xf_out_cb().set(FUNC(namcos21_dsp_c67_device::dsp_xf_w));
 

--- a/src/mame/namco/namcos22.cpp
+++ b/src/mame/namco/namcos22.cpp
@@ -2242,22 +2242,6 @@ void namcos22_state::pdp_handle_commands(u16 offs)
 	}
 }
 
-u16 namcos22_state::dsp_hold_signal_r()
-{
-	/* STUB */
-	return 0;
-}
-
-void namcos22_state::dsp_hold_ack_w(u16 data)
-{
-	/* STUB */
-}
-
-void namcos22_state::dsp_xf_output_w(u16 data)
-{
-	/* STUB */
-}
-
 void namcos22_state::dsp_unk2_w(u16 data)
 {
 	/**
@@ -3760,9 +3744,9 @@ void namcos22_state::namcos22(machine_config &config)
 	master.set_addrmap(AS_DATA, &namcos22_state::master_dsp_data);
 	master.set_addrmap(AS_IO, &namcos22_state::master_dsp_io);
 	master.bio_in_cb().set(FUNC(namcos22_state::pdp_status_r));
-	master.hold_in_cb().set(FUNC(namcos22_state::dsp_hold_signal_r));
-	master.hold_ack_out_cb().set(FUNC(namcos22_state::dsp_hold_ack_w));
-	master.xf_out_cb().set(FUNC(namcos22_state::dsp_xf_output_w));
+	//master.hold_in_cb().set(FUNC(namcos22_state::dsp_hold_signal_r));
+	//master.hold_ack_out_cb().set(FUNC(namcos22_state::dsp_hold_ack_w));
+	//master.xf_out_cb().set(FUNC(namcos22_state::dsp_xf_output_w));
 	master.dr_in_cb().set(FUNC(namcos22_state::master_serial_io_r));
 	master.set_vblank_int("screen", FUNC(namcos22_state::dsp_vblank_irq));
 	TIMER(config, "dsp_serial").configure_periodic(FUNC(namcos22_state::dsp_serial_pulse), attotime::from_hz(SERIAL_IO_PERIOD));
@@ -3772,9 +3756,9 @@ void namcos22_state::namcos22(machine_config &config)
 	slave.set_addrmap(AS_DATA, &namcos22_state::slave_dsp_data);
 	slave.set_addrmap(AS_IO, &namcos22_state::slave_dsp_io);
 	slave.bio_in_cb().set(FUNC(namcos22_state::dsp_slave_bioz_r));
-	slave.hold_in_cb().set(FUNC(namcos22_state::dsp_hold_signal_r));
-	slave.hold_ack_out_cb().set(FUNC(namcos22_state::dsp_hold_ack_w));
-	slave.xf_out_cb().set(FUNC(namcos22_state::dsp_xf_output_w));
+	//slave.hold_in_cb().set(FUNC(namcos22_state::dsp_hold_signal_r));
+	//slave.hold_ack_out_cb().set(FUNC(namcos22_state::dsp_hold_ack_w));
+	//slave.xf_out_cb().set(FUNC(namcos22_state::dsp_xf_output_w));
 	slave.dx_out_cb().set(FUNC(namcos22_state::slave_serial_io_w));
 
 	NAMCO_C74(config, m_mcu, 49.152_MHz_XTAL/3); // C74 on the CPU board has no periodic interrupts, it runs entirely off Timer A0

--- a/src/mame/namco/namcos22.h
+++ b/src/mame/namco/namcos22.h
@@ -289,9 +289,6 @@ protected:
 	void namcos22_dspram16_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	u16 pdp_status_r();
 	u16 pdp_begin_r();
-	u16 dsp_hold_signal_r();
-	void dsp_hold_ack_w(u16 data);
-	void dsp_xf_output_w(u16 data);
 	void point_address_w(u16 data);
 	void point_loword_iw(u16 data);
 	void point_hiword_w(u16 data);


### PR DESCRIPTION
This is a sucessor to my previous PR https://github.com/mamedev/mame/pull/14479 after @cuavas broke it with his renaming changes

Here the benchmark results from clang-x64 build (done with ``-bench 300``):
```
benchmarking victlapa...
254.33 -> 254.85 (0.52)
250.91 -> 254.92 (4.01)
251.28 -> 254.37 (3.09)
251.70 -> 254.06 (2.36)

benchmarking adillor...
148.92 -> 147.59 (-1.33)
148.62 -> 148.87 (0.25)
148.78 -> 149.23 (0.45)
146.78 -> 149.00 (2.22)

benchmarking alpinerd...
116.44 -> 115.98 (-0.46)
116.24 -> 115.92 (-0.32)
116.06 -> 116.39 (0.33)
115.86 -> 116.06 (0.20)

benchmarking cybrcomm...
165.43 -> 168.59 (3.16)
170.65 -> 172.03 (1.38)
170.15 -> 172.40 (2.25)
170.37 -> 171.26 (0.89)

benchmarking raverace...
139.77 -> 140.15 (0.38)
139.00 -> 140.47 (1.47)
138.32 -> 140.83 (2.51)
139.02 -> 139.45 (0.43)

benchmarking acedrive...
141.75 -> 141.79 (0.04)
140.69 -> 142.13 (1.44)
140.32 -> 141.50 (1.18)
141.10 -> 141.96 (0.86)

benchmarking winrun91...
244.38 -> 250.36 (5.98)
244.07 -> 249.12 (5.05)
244.93 -> 248.70 (3.77)
247.36 -> 250.57 (3.21)

benchmarking winrungp...
240.20 -> 240.21 (0.01)
234.34 -> 240.38 (6.04)
239.03 -> 240.08 (1.05)
237.82 -> 240.64 (2.82)
```
(The bechmarks may have been influenced by CPU throttling while running them, so they can't be 100% accurate)