### PR TITLE
plugins/hiscore/hiscore.dat: add support to Double Point

### DIFF
--- a/plugins/hiscore/hiscore.dat
+++ b/plugins/hiscore/hiscore.dat
@@ -8804,6 +8804,7 @@ oigas:
 ;@s:misc/gumbo.cpp
 
 dblpoint:
+dblpointd:
 @:maincpu,program,80000,32,43,0 ; players names
 @:maincpu,program,824b2,1e,0,1 ; all other data
 


### PR DESCRIPTION
How can this game still not acquire the hiscore save support after 20+ years of indwelling in the MAME base?