### PR TITLE
pc/play4texash.cpp: Additional notes; change name to be same as manual

### DIFF
--- a/src/mame/pc/play4texash.cpp
+++ b/src/mame/pc/play4texash.cpp
@@ -18,6 +18,8 @@ Screen resolution: 1366x768
 Dongle is used to get the GPG passphrase to decrypt /root/loader/ludicus.tar.gz.gpg which contains the software and game.
 GPG passphrase is stored in plaintext in /root/loader/bin/gpgExtract.sh
 
+Existing Play4Texas dump has the date of the last patch as 2011-10-18.
+
 Appears to be based on Play4Pro by Ludicus?
 
 ***********************************************************************************************************************************/
@@ -92,4 +94,4 @@ ROM_END
 } // anonymous namespace
 
 
-GAME(2010, play4texash, 0, play4texash, play4texash, play4texash_state, empty_init, ROT0, "Sleic", "Play4Texas Hold'em", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+GAME(2011, play4texash, 0, play4texash, play4texash, play4texash_state, empty_init, ROT0, "Sleic", "Play4Texas Hold'em", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )


### PR DESCRIPTION
Manual from https://www.recreativas.org/archivo/play4-texas-hold-em-sleic-manual-es.pdf

Software itself appears to have been last updated on 2011-10-18, unsure if I should change the year to 2011 in this case.