### PR TITLE
Ensuring that on Windows, `ClipCursor(nullptr)` is only invoked if we previously clipped the cursor

### DIFF
--- a/src/osd/windows/window.cpp
+++ b/src/osd/windows/window.cpp
@@ -226,6 +226,7 @@ win_window_info::win_window_info(
 	, m_resize_state(RESIZE_STATE_NORMAL)
 	, m_main(nullptr)
 	, m_attached_mode(false)
+	, m_cursor_clipped(false)
 	, m_pointer_mask(0)
 	, m_next_pointer(0)
 	, m_next_ptrdev(0)
@@ -253,11 +254,16 @@ void win_window_info::capture_pointer()
 	ClientToScreen(platform_window(), &reinterpret_cast<POINT *>(&bounds)[0]);
 	ClientToScreen(platform_window(), &reinterpret_cast<POINT *>(&bounds)[1]);
 	ClipCursor(&bounds);
+	m_cursor_clipped = true;
 }
 
 void win_window_info::release_pointer()
 {
-	ClipCursor(nullptr);
+	if (m_cursor_clipped)
+	{
+		ClipCursor(nullptr);
+		m_cursor_clipped = false;
+	}
 }
 
 void win_window_info::hide_pointer()

--- a/src/osd/windows/window.h
+++ b/src/osd/windows/window.h
@@ -172,6 +172,7 @@ private:
 
 	win_window_info *   m_main;
 	bool                m_attached_mode;
+	bool                m_cursor_clipped;
 
 	// these functions first appear in Windows 8/Server 2012
 	OSD_DYNAMIC_API(user32, "User32.dll", "User32.dll");


### PR DESCRIPTION
On Windows, cursor clipping is global and needlessly invoking `ClipCursor(nullptr)` will interfere with other applications that might also be trying to clip the cursor.  With this change, MAME will only invoke `ClipCursor(nullptr)` if MAME previously clipped the cursor.