### PR TITLE
DRC: Restore floating point mode across calls to C code

### DIFF
--- a/src/devices/cpu/drcbec.cpp
+++ b/src/devices/cpu/drcbec.cpp
@@ -779,7 +779,11 @@ int drcbe_c::execute(code_handle &entry)
 
 			case MAKE_OPCODE_SHORT(OP_DEBUG, 4, 0):     // DEBUG   pc
 				if (m_device.machine().debug_flags & DEBUG_FLAG_CALL_HOOK)
+				{
+					std::fesetround(feround);
 					m_device.debug()->instruction_hook(PARAM0);
+					std::fesetround(rounding_map[m_state.fmod & 0x03]);
+				}
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_HASHJMP, 4, 0):   // HASHJMP mode,pc,handle
@@ -861,7 +865,9 @@ int drcbe_c::execute(code_handle &entry)
 				[[fallthrough]];
 
 			case MAKE_OPCODE_SHORT(OP_CALLC, 4, 0):
+				std::fesetround(feround);
 				(*inst[0].cfunc)(inst[1].v);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_RECOVER, 4, 0):   // RECOVER dst,mapvar
@@ -1054,51 +1060,75 @@ int drcbe_c::execute(code_handle &entry)
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_READ1, 4, 0):     // READ    dst,src1,space_BYTE
+				std::fesetround(feround);
 				PARAM0 = SPACEPARAM2.read_byte(PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_READ2, 4, 0):     // READ    dst,src1,space_WORD
+				std::fesetround(feround);
 				PARAM0 = SPACEPARAM2.read_word(PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_READ4, 4, 0):     // READ    dst,src1,space_DWORD
+				std::fesetround(feround);
 				PARAM0 = SPACEPARAM2.read_dword(PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_READM1, 4, 0):    // READM   dst,src1,mask,space_BYTE
+				std::fesetround(feround);
 				PARAM0 = SPACEPARAM3.read_byte(PARAM1, PARAM2);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_READM2, 4, 0):    // READM   dst,src1,mask,space_WORD
+				std::fesetround(feround);
 				PARAM0 = SPACEPARAM3.read_word(PARAM1, PARAM2);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_READM4, 4, 0):    // READM   dst,src1,mask,space_DWORD
+				std::fesetround(feround);
 				PARAM0 = SPACEPARAM3.read_dword(PARAM1, PARAM2);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_WRITE1, 4, 0):    // WRITE   dst,src1,space_BYTE
+				std::fesetround(feround);
 				SPACEPARAM2.write_byte(PARAM0, PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_WRITE2, 4, 0):    // WRITE   dst,src1,space_WORD
+				std::fesetround(feround);
 				SPACEPARAM2.write_word(PARAM0, PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_WRITE4, 4, 0):    // WRITE   dst,src1,space_DWORD
+				std::fesetround(feround);
 				SPACEPARAM2.write_dword(PARAM0, PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_WRITEM1, 4, 0):   // WRITEM  dst,src1,mask,space_BYTE
+				std::fesetround(feround);
 				SPACEPARAM3.write_byte(PARAM0, PARAM1, PARAM2);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_WRITEM2, 4, 0):   // WRITEM  dst,src1,mask,space_WORD
+				std::fesetround(feround);
 				SPACEPARAM3.write_word(PARAM0, PARAM1, PARAM2);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_WRITEM4, 4, 0):   // WRITEM  dst,src1,mask,space_DWORD
+				std::fesetround(feround);
 				SPACEPARAM3.write_dword(PARAM0, PARAM1, PARAM2);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_CARRY, 4, 0):     // CARRY   src,bitnum
@@ -1709,67 +1739,99 @@ int drcbe_c::execute(code_handle &entry)
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_READ1, 8, 0):     // DREAD   dst,src1,space_BYTE
+				std::fesetround(feround);
 				DPARAM0 = SPACEPARAM2.read_byte(PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_READ2, 8, 0):     // DREAD   dst,src1,space_WORD
+				std::fesetround(feround);
 				DPARAM0 = SPACEPARAM2.read_word(PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_READ4, 8, 0):     // DREAD   dst,src1,space_DWORD
+				std::fesetround(feround);
 				DPARAM0 = SPACEPARAM2.read_dword(PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_READ8, 8, 0):     // DREAD   dst,src1,space_QWORD
+				std::fesetround(feround);
 				DPARAM0 = SPACEPARAM2.read_qword(PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_READM1, 8, 0):    // DREADM  dst,src1,mask,space_BYTE
+				std::fesetround(feround);
 				DPARAM0 = SPACEPARAM3.read_byte(PARAM1, DPARAM2);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_READM2, 8, 0):    // DREADM  dst,src1,mask,space_WORD
+				std::fesetround(feround);
 				DPARAM0 = SPACEPARAM3.read_word(PARAM1, DPARAM2);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_READM4, 8, 0):    // DREADM  dst,src1,mask,space_DWORD
+				std::fesetround(feround);
 				DPARAM0 = SPACEPARAM3.read_dword(PARAM1, DPARAM2);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_READM8, 8, 0):    // DREADM  dst,src1,mask,space_QWORD
+				std::fesetround(feround);
 				DPARAM0 = SPACEPARAM3.read_qword(PARAM1, DPARAM2);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_WRITE1, 8, 0):    // DWRITE  dst,src1,space_BYTE
+				std::fesetround(feround);
 				SPACEPARAM2.write_byte(PARAM0, PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_WRITE2, 8, 0):    // DWRITE  dst,src1,space_WORD
+				std::fesetround(feround);
 				SPACEPARAM2.write_word(PARAM0, PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_WRITE4, 8, 0):    // DWRITE  dst,src1,space_DWORD
+				std::fesetround(feround);
 				SPACEPARAM2.write_dword(PARAM0, PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_WRITE8, 8, 0):    // DWRITE  dst,src1,space_QWORD
+				std::fesetround(feround);
 				SPACEPARAM2.write_qword(PARAM0, DPARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_WRITEM1, 8, 0):   // DWRITEM dst,src1,mask,space_BYTE
+				std::fesetround(feround);
 				SPACEPARAM3.write_byte(PARAM0, DPARAM1, DPARAM2);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_WRITEM2, 8, 0):   // DWRITEM dst,src1,mask,space_WORD
+				std::fesetround(feround);
 				SPACEPARAM3.write_word(PARAM0, DPARAM1, DPARAM2);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_WRITEM4, 8, 0):   // DWRITEM dst,src1,mask,space_DWORD
+				std::fesetround(feround);
 				SPACEPARAM3.write_dword(PARAM0, DPARAM1, DPARAM2);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_WRITEM8, 8, 0):   // DWRITEM dst,src1,mask,space_QWORD
+				std::fesetround(feround);
 				SPACEPARAM3.write_qword(PARAM0, DPARAM1, DPARAM2);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_CARRY, 8, 0):     // DCARRY  src,bitnum
@@ -2174,11 +2236,15 @@ int drcbe_c::execute(code_handle &entry)
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_FREAD, 4, 0):     // FSREAD  dst,src1,space
+				std::fesetround(feround);
 				PARAM0 = SPACEPARAM2.read_dword(PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_FWRITE, 4, 0):    // FSWRITE dst,src1,space
+				std::fesetround(feround);
 				SPACEPARAM2.write_dword(PARAM0, PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_FMOV, 4, 1):      // FSMOV   dst,src[,c]
@@ -2305,11 +2371,15 @@ int drcbe_c::execute(code_handle &entry)
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_FREAD, 8, 0):     // FDREAD  dst,src1,space
+				std::fesetround(feround);
 				DPARAM0 = SPACEPARAM2.read_qword(PARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_FWRITE, 8, 0):    // FDWRITE dst,src1,space
+				std::fesetround(feround);
 				SPACEPARAM2.write_qword(PARAM0, DPARAM1);
+				std::fesetround(rounding_map[m_state.fmod & 0x03]);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_FMOV, 8, 1):      // FDMOV   dst,src[,c]

--- a/src/devices/cpu/drcbex86.cpp
+++ b/src/devices/cpu/drcbex86.cpp
@@ -10,6 +10,8 @@
 
    Future improvements/changes:
 
+    * Restore floating point environment when calling out to C code
+
     * Optimize to avoid unnecessary reloads
         - especially EDX for 64-bit operations
         - also FCMP/FLAGS has unnecessary PUSHF/POP EAX


### PR DESCRIPTION
Since I brought this up in a discussion and got no reaction, creating a PR to force the issue.

UML has an instruction for changing the floating point rounding mode.  The back-ends all have ways to implement this.  The thing is, this can affects most floating point arithmetic.  If this isn't restored across calls to C functions, code will be running with the recompiled code's floating point environment rather than what would usually be the default floating point environment.  In the case of the debugger hook function, this can include MAME's rendering and UI code, as well as the debugger UI code.

There's also the risk of weird things happening if the C runtime library's floating point environment gets out of sync with the the host CPU's floating point control state, or code in a memory handler calling a maths library function that needs to temporarily change the host CPU's floating point control state and restores it to the state the C runtime library thinks it should be in, not the state the generated code thinks it left it in.

This makes the generated code for the AArch64, x86-64 and C back-ends restore the floating point environment across calls to C code.  This will obviously have some performance impact on emulated memory reads/writes and calls to C functions.

@galibert can you give an opinion on this?