### PR TITLE
cpu/mips3: Fix DRC debugger interaction for register and memory modifications

### DIFF
--- a/src/devices/cpu/mips/mips3.h
+++ b/src/devices/cpu/mips/mips3.h
@@ -320,6 +320,7 @@ public:
 
 protected:
 	// device_t implementation
+	virtual void device_debug_setup() override ATTR_COLD;
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 	virtual void device_stop() override ATTR_COLD;
@@ -486,6 +487,7 @@ protected:
 
 												/* internal stuff */
 	uint8_t         m_drc_cache_dirty;          /* true if we need to flush the cache */
+	uint32_t        m_drc_iregs_dirty;          /* true if debugger modified fast integer registers */
 
 												/* tables */
 	uint8_t         m_fpmode[4];                /* FPU mode table */


### PR DESCRIPTION
# Summary

When debugging MIPS3 code running under the DRC, two things were broken: changing a register value in the debugger had no effect (the DRC kept using its own cached copy), and patching instructions in memory didn't do anything either since the DRC just kept running its already-translated code.

# Details

The DRC maps hot registers to internal UML integer registers for performance. The problem is that the debugger writes to the memory-backed register array, not those internal registers — so any change made during a breakpoint was immediately overwritten when execution resumed. The old code knew about this and even logged an error message.

Similarly, there was no mechanism to tell the DRC that memory contents had changed. If you patched an opcode through the debugger, the DRC would happily keep running the stale translated block.

**Register reload**: A `m_drc_iregs_dirty` flag is set in `state_import` when the debugger writes to a register that lives in a fast UML ireg. After each `UML_DEBUG` hook, the generated code tests this flag and reloads the internal registers from the memory-backed array when set. The flag is declared as `uint32_t` rather than `uint8_t` because `UML_MOV`/`UML_TEST` operate on 32 bits wide data, using a smaller type would corrupt the adjacent `m_fpmode` table.

**Cache invalidation**: `device_debug_setup` hooks the symbol table's `set_memory_modified_func` callback to set `m_drc_cache_dirty`, which is checked at the top of `execute_run` and triggers a full cache flush before the next execution slice.

# Related issue

https://github.com/mamedev/mame/issues/4904

