### PR TITLE
tk2000: fix cassette and page2

### DIFF
--- a/src/mame/apple/apple2video.cpp
+++ b/src/mame/apple/apple2video.cpp
@@ -636,7 +636,7 @@ template void a2_video_device::text_update<a2_video_device::model::IVEL_ULTRA, f
 
 void a2_video_device::hgr_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow)
 {
-	unsigned const start_address = use_page_2() ? 0x4000 : 0x2000;
+	unsigned const start_address = use_page_2() ? m_hgr2 : 0x2000;
 
 	beginrow = (std::max)(beginrow, cliprect.top());
 	endrow = (std::min)(endrow, cliprect.bottom());
@@ -689,7 +689,7 @@ void a2_video_device::hgr_update(screen_device &screen, bitmap_ind16 &bitmap, co
 
 void a2_video_device::dhgr_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow)
 {
-	int const page = use_page_2() ? 0x4000 : 0x2000;
+	int const page = use_page_2() ? m_hgr2 : 0x2000;
 	int const rgbmode = rgb_monitor() ? m_rgbmode : -1;
 
 	beginrow = (std::max)(beginrow, cliprect.top());

--- a/src/mame/apple/apple2video.h
+++ b/src/mame/apple/apple2video.h
@@ -66,6 +66,7 @@ public:
 
 	void set_ram_pointers(u8 *main, u8 *aux)    { m_ram_ptr = main; m_aux_ptr = aux; }
 	void set_aux_mask(u16 aux_mask)             { m_aux_mask = aux_mask; }
+	void set_hgr2(u16 hgr2)                     { m_hgr2 = hgr2; }
 	void set_char_pointer(u8 *charptr, int size) { m_char_ptr = charptr; m_char_size = size; }
 	void setup_GS_graphics() { m_8bit_graphics = std::make_unique<bitmap_ind16>(560, 192); }
 
@@ -114,6 +115,7 @@ private:
 
 	u8 *m_ram_ptr = nullptr, *m_aux_ptr = nullptr, *m_char_ptr = nullptr;
 	u16 m_aux_mask = 0xffff;
+	u16 m_hgr2 = 0x4000;
 	int m_char_size = 0;
 	bool m_page2 = false;
 	bool m_flash = false;

--- a/src/mame/apple/superga2.cpp
+++ b/src/mame/apple/superga2.cpp
@@ -9,7 +9,7 @@
 
     Only one game is known (a Mario Bros. hack/translation patch).
 
-    Info: http://agatcomp.ru/Pravetz/SuperGames.shtml
+    Info: http://agatcomp.ru/Pravetz/Hard/SuperGames.shtml
 
     To do:
     - verify palette, pixel and cpu clocks


### PR DESCRIPTION
(side-effects of my ongoing tinkering with apple2video timing...)

* cassette input is [documented as bit7 of C010](http://www.apple-iigs.info/doc/fichiers/TK2000%20II%20Manual%20teecnico.pdf#page=75) KBIN (not C06X like apple2p)
* HGR page2 is [documented as A000-BFFF](http://www.apple-iigs.info/doc/fichiers/TK2000%20II%20Manual%20teecnico.pdf#page=97) (not 4000-5FFF like apple2p)

This is enough to get various software working in tk2000 and mpf2 via `LOADT` of cassette audio ("TK2000 GAME SERVER"):
<img width="560" height="384" alt="mpf2_BOLO" src="https://github.com/user-attachments/assets/12b41ca1-b304-4543-80ff-15b969244d2b" />

<img width="560" height="384" alt="tk2000_Karateka" src="https://github.com/user-attachments/assets/1ad2b4cf-1288-4613-9b54-005e89d0cca5" />

<img width="560" height="384" alt="tk2000_Minotauro" src="https://github.com/user-attachments/assets/62384bb3-2e94-4cf3-a245-227149e7abd8" />

<img width="560" height="384" alt="tk2000_Suicida" src="https://github.com/user-attachments/assets/f7a66616-5802-42b9-8f0e-f66b87df04d3" />
