### PR TITLE
toaplan/gp9001.cpp: Updates

### DIFF
--- a/src/mame/toaplan/enmadaio.cpp
+++ b/src/mame/toaplan/enmadaio.cpp
@@ -39,12 +39,8 @@ public:
 
 	void init_enmadaio() ATTR_COLD;
 
-protected:
-	virtual void video_start() override ATTR_COLD;
-
 private:
-
-	void enmadaio_oki_bank_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void oki_bank_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void enmadaio_68k_mem(address_map &map) ATTR_COLD;
 	void enmadaio_oki(address_map &map) ATTR_COLD;
 
@@ -57,20 +53,13 @@ private:
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 	required_memory_bank m_okibank;
-	bitmap_ind8 m_custom_priority_bitmap;
 };
-
-void enmadaio_state::video_start()
-{
-	m_screen->register_screen_bitmap(m_custom_priority_bitmap);
-	m_vdp->custom_priority_bitmap = &m_custom_priority_bitmap;
-}
 
 u32 enmadaio_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(0, cliprect);
-	m_custom_priority_bitmap.fill(0, cliprect);
-	m_vdp->render_vdp(bitmap, cliprect);
+	screen.priority().fill(0, cliprect);
+	m_vdp->render_vdp(bitmap, cliprect, screen.priority());
 	return 0;
 }
 
@@ -294,7 +283,7 @@ static INPUT_PORTS_START( enmadaio )
 INPUT_PORTS_END
 
 
-void enmadaio_state::enmadaio_oki_bank_w(offs_t offset, u16 data, u16 mem_mask)
+void enmadaio_state::oki_bank_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	data &= mem_mask;
 
@@ -304,7 +293,7 @@ void enmadaio_state::enmadaio_oki_bank_w(offs_t offset, u16 data, u16 mem_mask)
 	}
 	else
 	{
-		logerror("enmadaio_oki_bank_w >=0x60 (%04x)\n",data);
+		logerror("%s: oki_bank_w >=0x60 (%04x)\n", machine().describe_context(), data);
 	}
 }
 
@@ -328,7 +317,7 @@ void enmadaio_state::enmadaio_68k_mem(address_map &map)
 	map(0x700018, 0x700019).portr("SYS");
 	map(0x70001c, 0x70001d).portr("UNK"); //.portr("SYS");
 
-	map(0x700020, 0x700021).w(FUNC(enmadaio_state::enmadaio_oki_bank_w)); // oki bank
+	map(0x700020, 0x700021).w(FUNC(enmadaio_state::oki_bank_w)); // oki bank
 
 	map(0x700028, 0x700029).nopw();
 	map(0x70003c, 0x70003d).nopw();

--- a/src/mame/toaplan/fixeight.cpp
+++ b/src/mame/toaplan/fixeight.cpp
@@ -107,7 +107,6 @@ protected:
 	required_device<toaplan_txtilemap_device> m_tx_tilemap;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
-	bitmap_ind8 m_custom_priority_bitmap;
 };
 
 class fixeight_bootleg_state : public fixeight_state
@@ -164,17 +163,14 @@ void fixeight_state::screen_vblank(int state)
 u32 fixeight_bootleg_state::screen_update_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(0, cliprect);
-	m_custom_priority_bitmap.fill(0, cliprect);
-	m_vdp->render_vdp(bitmap, cliprect);
+	screen.priority().fill(0, cliprect);
+	m_vdp->render_vdp(bitmap, cliprect, screen.priority());
 	m_tx_tilemap->draw_tilemap_bootleg(screen, bitmap, cliprect);
 	return 0;
 }
 
 void fixeight_bootleg_state::video_start()
 {
-	m_screen->register_screen_bitmap(m_custom_priority_bitmap);
-	m_vdp->custom_priority_bitmap = &m_custom_priority_bitmap;
-
 	/* This bootleg has additional layer offsets on the VDP */
 	m_vdp->set_tm_extra_offsets(0, -0x1d6 - 26, -0x1ef - 15, 0, 0);
 	m_vdp->set_tm_extra_offsets(1, -0x1d8 - 22, -0x1ef - 15, 0, 0);
@@ -187,9 +183,6 @@ void fixeight_bootleg_state::video_start()
 
 void fixeight_state::video_start()
 {
-	m_screen->register_screen_bitmap(m_custom_priority_bitmap);
-	m_vdp->custom_priority_bitmap = &m_custom_priority_bitmap;
-
 	m_tx_tilemap->gfx(0)->set_source(reinterpret_cast<u8 *>(m_tx_gfxram.target()));
 }
 
@@ -197,8 +190,8 @@ void fixeight_state::video_start()
 u32 fixeight_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(0, cliprect);
-	m_custom_priority_bitmap.fill(0, cliprect);
-	m_vdp->render_vdp(bitmap, cliprect);
+	screen.priority().fill(0, cliprect);
+	m_vdp->render_vdp(bitmap, cliprect, screen.priority());
 	m_tx_tilemap->draw_tilemap(screen, bitmap, cliprect);
 	return 0;
 }

--- a/src/mame/toaplan/ghox.cpp
+++ b/src/mame/toaplan/ghox.cpp
@@ -48,7 +48,6 @@ public:
 protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
-	virtual void video_start() override ATTR_COLD;
 
 private:
 	void ghox_68k_mem(address_map &map) ATTR_COLD;
@@ -70,22 +69,14 @@ private:
 	required_device<gp9001vdp_device> m_vdp;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
-	bitmap_ind8 m_custom_priority_bitmap;
 };
-
-
-void ghox_state::video_start()
-{
-	m_screen->register_screen_bitmap(m_custom_priority_bitmap);
-	m_vdp->custom_priority_bitmap = &m_custom_priority_bitmap;
-}
 
 
 u32 ghox_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(0, cliprect);
-	m_custom_priority_bitmap.fill(0, cliprect);
-	m_vdp->render_vdp(bitmap, cliprect);
+	screen.priority().fill(0, cliprect);
+	m_vdp->render_vdp(bitmap, cliprect, screen.priority());
 	return 0;
 }
 

--- a/src/mame/toaplan/gp9001.h
+++ b/src/mame/toaplan/gp9001.h
@@ -25,14 +25,12 @@ public:
 
 	auto vint_out_cb() { return m_vint_out_cb.bind(); }
 
-	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, const u8* primap);
-	void draw_custom_tilemap(bitmap_ind16 &bitmap, const rectangle &cliprect, int layer, const u8* priremap, const u8* pri_enable);
-	void render_vdp(bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, bitmap_ind8 &primap);
+	void draw_custom_tilemap(bitmap_ind16 &bitmap, const rectangle &cliprect, bitmap_ind8 &primap, int layer);
+	void render_vdp(bitmap_ind16 &bitmap, const rectangle &cliprect, bitmap_ind8 &primap);
 	void screen_eof();
 	void create_tilemaps();
 	void init_scroll_regs();
-
-	bitmap_ind8 *custom_priority_bitmap;
 
 	void map(address_map &map) ATTR_COLD;
 

--- a/src/mame/toaplan/kbash.cpp
+++ b/src/mame/toaplan/kbash.cpp
@@ -43,12 +43,8 @@ public:
 	void kbash(machine_config &config) ATTR_COLD;
 
 protected:
-	virtual void video_start() override ATTR_COLD;
-
 	void kbash_68k_mem(address_map &map) ATTR_COLD;
 	void kbash_v25_mem(address_map &map) ATTR_COLD;
-
-	void kbash_oki_bankswitch_w(u8 data);
 
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void screen_vblank(int state);
@@ -64,7 +60,6 @@ protected:
 	required_device<okim6295_device> m_oki;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
-	bitmap_ind8 m_custom_priority_bitmap;
 };
 
 class kbash2_state : public kbash_state
@@ -77,23 +72,18 @@ public:
 
 	void kbash2(machine_config &config) ATTR_COLD;
 
-protected:
+private:
+	void oki_bankswitch_w(u8 data);
 	void kbash2_68k_mem(address_map &map) ATTR_COLD;
 
 	required_device<okim6295_device> m_musicoki;
 };
 
-void kbash_state::video_start()
-{
-	m_screen->register_screen_bitmap(m_custom_priority_bitmap);
-	m_vdp->custom_priority_bitmap = &m_custom_priority_bitmap;
-}
-
 u32 kbash_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(0, cliprect);
-	m_custom_priority_bitmap.fill(0, cliprect);
-	m_vdp->render_vdp(bitmap, cliprect);
+	screen.priority().fill(0, cliprect);
+	m_vdp->render_vdp(bitmap, cliprect, screen.priority());
 	return 0;
 }
 
@@ -107,7 +97,7 @@ void kbash_state::screen_vblank(int state)
 
 
 
-void kbash_state::kbash_oki_bankswitch_w(u8 data)
+void kbash2_state::oki_bankswitch_w(u8 data)
 {
 	m_oki->set_rom_bank(data & 1);
 }
@@ -273,7 +263,7 @@ void kbash2_state::kbash2_68k_mem(address_map &map)
 	map(0x200018, 0x200019).portr("SYS");
 	map(0x200021, 0x200021).rw(m_musicoki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0x200025, 0x200025).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
-	map(0x200029, 0x200029).w(FUNC(kbash2_state::kbash_oki_bankswitch_w));
+	map(0x200029, 0x200029).w(FUNC(kbash2_state::oki_bankswitch_w));
 	map(0x20002c, 0x20002d).r(m_vdp, FUNC(gp9001vdp_device::vdpcount_r));
 	map(0x300000, 0x30000d).rw(m_vdp, FUNC(gp9001vdp_device::read), FUNC(gp9001vdp_device::write));
 	map(0x400000, 0x400fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
@@ -496,8 +486,8 @@ ROM_END
 
 } // anonymous namespace
 
-GAME( 1993, kbash,       0,        kbash,        kbash,      kbash_state, empty_init,    ROT0,   "Toaplan / Atari", "Knuckle Bash",                 MACHINE_SUPPORTS_SAVE ) // Atari license shown for some regions.
-GAME( 1993, kbashk,      kbash,    kbash,        kbashk,     kbash_state, empty_init,    ROT0,   "Toaplan / Taito", "Knuckle Bash (Korean PCB)",    MACHINE_SUPPORTS_SAVE ) // Japan region has optional Taito license, maybe the original Japan release?
-GAME( 1993, kbashp,      kbash,    kbash,        kbash,      kbash_state, empty_init,    ROT0,   "Toaplan / Taito", "Knuckle Bash (location test)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, kbash,       0,        kbash,        kbash,      kbash_state,  empty_init,    ROT0,   "Toaplan / Atari", "Knuckle Bash",                 MACHINE_SUPPORTS_SAVE ) // Atari license shown for some regions.
+GAME( 1993, kbashk,      kbash,    kbash,        kbashk,     kbash_state,  empty_init,    ROT0,   "Toaplan / Taito", "Knuckle Bash (Korean PCB)",    MACHINE_SUPPORTS_SAVE ) // Japan region has optional Taito license, maybe the original Japan release?
+GAME( 1993, kbashp,      kbash,    kbash,        kbash,      kbash_state,  empty_init,    ROT0,   "Toaplan / Taito", "Knuckle Bash (location test)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1999, kbash2,      0,        kbash2,       kbash2,     kbash2_state, empty_init,    ROT0,   "bootleg",         "Knuckle Bash 2 (bootleg)",  MACHINE_SUPPORTS_SAVE )
+GAME( 1999, kbash2,      0,        kbash2,       kbash2,     kbash2_state, empty_init,    ROT0,   "bootleg",         "Knuckle Bash 2 (bootleg of Knuckle Bash)",  MACHINE_SUPPORTS_SAVE )

--- a/src/mame/toaplan/pipibibi.cpp
+++ b/src/mame/toaplan/pipibibi.cpp
@@ -46,7 +46,6 @@ public:
 	void pipibibs(machine_config &config) ATTR_COLD;
 
 protected:
-	virtual void video_start() override ATTR_COLD;
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void screen_vblank(int state);
 
@@ -62,7 +61,6 @@ protected:
 	required_device<gp9001vdp_device> m_vdp;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
-	bitmap_ind8 m_custom_priority_bitmap;
 };
 
 class pipibibi_bootleg_state : public pipibibi_state
@@ -81,18 +79,12 @@ private:
 	void pipibibi_bootleg_68k_mem(address_map &map) ATTR_COLD;
 };
 
-void pipibibi_state::video_start()
-{
-	m_screen->register_screen_bitmap(m_custom_priority_bitmap);
-	m_vdp->custom_priority_bitmap = &m_custom_priority_bitmap;
-}
-
 
 u32 pipibibi_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(0, cliprect);
-	m_custom_priority_bitmap.fill(0, cliprect);
-	m_vdp->render_vdp(bitmap, cliprect);
+	screen.priority().fill(0, cliprect);
+	m_vdp->render_vdp(bitmap, cliprect, screen.priority());
 	return 0;
 }
 

--- a/src/mame/toaplan/raizing.cpp
+++ b/src/mame/toaplan/raizing.cpp
@@ -120,8 +120,8 @@ void raizing_base_state::reset_audiocpu(int state)
 u32 raizing_base_state::screen_update_base(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(0, cliprect);
-	m_custom_priority_bitmap.fill(0, cliprect);
-	m_vdp->render_vdp(bitmap, cliprect);
+	screen.priority().fill(0, cliprect);
+	m_vdp->render_vdp(bitmap, cliprect, screen.priority());
 
 	return 0;
 }
@@ -140,14 +140,6 @@ u32 raizing_base_state::screen_update(screen_device &screen, bitmap_ind16 &bitma
 	screen_update_base(screen, bitmap, cliprect);
 	m_tx_tilemap->draw_tilemap(screen, bitmap, cliprect);
 	return 0;
-}
-
-
-
-void raizing_base_state::bgaregga_common_video_start()
-{
-	m_screen->register_screen_bitmap(m_custom_priority_bitmap);
-	m_vdp->custom_priority_bitmap = &m_custom_priority_bitmap;
 }
 
 
@@ -233,7 +225,6 @@ public:
 
 protected:
 	virtual void machine_reset() override ATTR_COLD;
-	virtual void video_start() override ATTR_COLD;
 
 private:
 	void bgaregga_68k_mem(address_map &map) ATTR_COLD;
@@ -251,9 +242,6 @@ public:
 
 	void bgareggabl(machine_config &config) ATTR_COLD;
 
-protected:
-	virtual void video_start() override ATTR_COLD;
-
 private:
 	u32 screen_update_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 };
@@ -269,9 +257,6 @@ public:
 	void mahoudai(machine_config &config) ATTR_COLD;
 	void shippumd(machine_config &config) ATTR_COLD;
 
-protected:
-	virtual void video_start() override ATTR_COLD;
-
 private:
 	void mahoudai_68k_mem(address_map &map) ATTR_COLD;
 	void shippumd_68k_mem(address_map &map) ATTR_COLD;
@@ -279,25 +264,6 @@ private:
 
 	void shippumd_coin_w(u8 data);
 };
-
-
-void bgaregga_state::video_start()
-{
-	bgaregga_common_video_start();
-}
-
-void sstriker_state::video_start()
-{
-	bgaregga_common_video_start();
-}
-
-void bgaregga_bootleg_state::video_start()
-{
-	m_screen->register_screen_bitmap(m_custom_priority_bitmap);
-	m_vdp->custom_priority_bitmap = &m_custom_priority_bitmap;
-}
-
-
 
 
 u32 bgaregga_bootleg_state::screen_update_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)

--- a/src/mame/toaplan/raizing.h
+++ b/src/mame/toaplan/raizing.h
@@ -51,7 +51,6 @@ protected:
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 	// used by bgaregga + batrider etc.
-	void bgaregga_common_video_start();
 	void raizing_z80_bankswitch_w(u8 data);
 	void raizing_oki_bankswitch_w(offs_t offset, u8 data);
 	void install_raizing_okibank(int chip);
@@ -97,7 +96,6 @@ protected:
 	optional_device_array<generic_latch_8_device, 4> m_soundlatch; // tekipaki, batrider, bgaregga, batsugun
 	optional_region_ptr_array<u8, 2> m_oki_rom;
 	required_device<toaplan_coincounter_device> m_coincounter;
-	bitmap_ind8 m_custom_priority_bitmap;
 };
 
 #endif // MAME_TOAPLAN_RAIZING_H

--- a/src/mame/toaplan/raizing_batrider.cpp
+++ b/src/mame/toaplan/raizing_batrider.cpp
@@ -286,9 +286,6 @@ void batrider_state::video_start()
 {
 	raizing_base_state::video_start();
 
-	m_screen->register_screen_bitmap(m_custom_priority_bitmap);
-	m_vdp->custom_priority_bitmap = &m_custom_priority_bitmap;
-
 	m_vdp->disable_sprite_buffer(); // disable buffering on this game
 
 	// Create the Text tilemap for this game

--- a/src/mame/toaplan/snowbro2.cpp
+++ b/src/mame/toaplan/snowbro2.cpp
@@ -40,14 +40,12 @@ public:
 	void snowbro2b3(machine_config &config) ATTR_COLD;
 
 protected:
-	virtual void video_start() override ATTR_COLD;
-
 	void snowbro2_68k_mem(address_map &map) ATTR_COLD;
 	void snowbro2b3_68k_mem(address_map &map) ATTR_COLD;
 
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void screen_vblank(int state);
-	void sb2_oki_bankswitch_w(u8 data);
+	void oki_bankswitch_w(u8 data);
 
 private:
 	required_device<m68000_base_device> m_maincpu;
@@ -55,21 +53,14 @@ private:
 	required_device<okim6295_device> m_oki;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
-	bitmap_ind8 m_custom_priority_bitmap;
 };
 
-
-void snowbro2_state::video_start()
-{
-	m_screen->register_screen_bitmap(m_custom_priority_bitmap);
-	m_vdp->custom_priority_bitmap = &m_custom_priority_bitmap;
-}
 
 u32 snowbro2_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(0, cliprect);
-	m_custom_priority_bitmap.fill(0, cliprect);
-	m_vdp->render_vdp(bitmap, cliprect);
+	screen.priority().fill(0, cliprect);
+	m_vdp->render_vdp(bitmap, cliprect, screen.priority());
 	return 0;
 }
 
@@ -81,7 +72,7 @@ void snowbro2_state::screen_vblank(int state)
 	}
 }
 
-void snowbro2_state::sb2_oki_bankswitch_w(u8 data)
+void snowbro2_state::oki_bankswitch_w(u8 data)
 {
 	m_oki->set_rom_bank(data & 1);
 }
@@ -293,7 +284,7 @@ void snowbro2_state::snowbro2_68k_mem(address_map &map)
 	map(0x700014, 0x700015).portr("IN3");
 	map(0x700018, 0x700019).portr("IN4");
 	map(0x70001c, 0x70001d).portr("SYS");
-	map(0x700031, 0x700031).w(FUNC(snowbro2_state::sb2_oki_bankswitch_w));
+	map(0x700031, 0x700031).w(FUNC(snowbro2_state::oki_bankswitch_w));
 	map(0x700035, 0x700035).w("coincounter", FUNC(toaplan_coincounter_device::coin_w));
 }
 
@@ -311,7 +302,7 @@ void snowbro2_state::snowbro2b3_68k_mem(address_map &map)
 	map(0x700014, 0x700015).portr("IN3");
 	map(0x700018, 0x700019).portr("IN4");
 	map(0x700035, 0x700035).w("coincounter", FUNC(toaplan_coincounter_device::coin_w));
-	map(0x700041, 0x700041).w(FUNC(snowbro2_state::sb2_oki_bankswitch_w));
+	map(0x700041, 0x700041).w(FUNC(snowbro2_state::oki_bankswitch_w));
 	map(0xff0000, 0xff2fff).rw(m_vdp, FUNC(gp9001vdp_device::bootleg_videoram16_r), FUNC(gp9001vdp_device::bootleg_videoram16_w));
 	map(0xff3000, 0xff37ff).rw(m_vdp, FUNC(gp9001vdp_device::bootleg_spriteram16_r), FUNC(gp9001vdp_device::bootleg_spriteram16_w));
 	map(0xff8000, 0xff800f).w(m_vdp, FUNC(gp9001vdp_device::bootleg_scroll_w));

--- a/src/mame/toaplan/sunwise.cpp
+++ b/src/mame/toaplan/sunwise.cpp
@@ -58,8 +58,6 @@ public:
 	void pwrkick(machine_config &config);
 
 protected:
-	virtual void video_start() override ATTR_COLD;
-
 	void common_mem(address_map &map) ATTR_COLD;
 	void pwrkick_68k_mem(address_map &map) ATTR_COLD;
 	void othldrby_68k_mem(address_map &map) ATTR_COLD;
@@ -67,7 +65,7 @@ protected:
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void screen_vblank(int state);
 
-	void sw_oki_bankswitch_w(u8 data);
+	void oki_bankswitch_w(u8 data);
 
 private:
 	void pwrkick_coin_w(u8 data);
@@ -81,21 +79,13 @@ private:
 	required_device<okim6295_device> m_oki;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
-	bitmap_ind8 m_custom_priority_bitmap;
 };
-
-void sunwise_state::video_start()
-{
-	m_screen->register_screen_bitmap(m_custom_priority_bitmap);
-	m_vdp->custom_priority_bitmap = &m_custom_priority_bitmap;
-}
-
 
 u32 sunwise_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(0, cliprect);
-	m_custom_priority_bitmap.fill(0, cliprect);
-	m_vdp->render_vdp(bitmap, cliprect);
+	screen.priority().fill(0, cliprect);
+	m_vdp->render_vdp(bitmap, cliprect, screen.priority());
 	return 0;
 }
 
@@ -107,7 +97,7 @@ void sunwise_state::screen_vblank(int state)
 	}
 }
 
-void sunwise_state::sw_oki_bankswitch_w(u8 data)
+void sunwise_state::oki_bankswitch_w(u8 data)
 {
 	m_oki->set_rom_bank(data & 1);
 }
@@ -419,7 +409,7 @@ void sunwise_state::common_mem(address_map &map)
 	map(0x700004, 0x700005).portr("DSWA");
 	map(0x700008, 0x700009).portr("DSWB");
 	map(0x70001c, 0x70001d).portr("SYS");
-	map(0x700031, 0x700031).w(FUNC(sunwise_state::sw_oki_bankswitch_w));
+	map(0x700031, 0x700031).w(FUNC(sunwise_state::oki_bankswitch_w));
 }
 
 void sunwise_state::pwrkick_68k_mem(address_map &map)

--- a/src/mame/toaplan/tekipaki.cpp
+++ b/src/mame/toaplan/tekipaki.cpp
@@ -52,9 +52,6 @@ public:
 
 	int c2map_r();
 
-protected:
-	virtual void video_start() override ATTR_COLD;
-
 private:
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void screen_vblank(int state);
@@ -69,22 +66,14 @@ private:
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 	optional_device<generic_latch_8_device> m_soundlatch;
-	bitmap_ind8 m_custom_priority_bitmap;
 };
-
-
-void tekipaki_state::video_start()
-{
-	m_screen->register_screen_bitmap(m_custom_priority_bitmap);
-	m_vdp->custom_priority_bitmap = &m_custom_priority_bitmap;
-}
 
 
 u32 tekipaki_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(0, cliprect);
-	m_custom_priority_bitmap.fill(0, cliprect);
-	m_vdp->render_vdp(bitmap, cliprect);
+	screen.priority().fill(0, cliprect);
+	m_vdp->render_vdp(bitmap, cliprect, screen.priority());
 	return 0;
 }
 

--- a/src/mame/toaplan/truxton2.cpp
+++ b/src/mame/toaplan/truxton2.cpp
@@ -54,8 +54,8 @@ protected:
 	virtual void video_start() override ATTR_COLD;
 
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-
 	void screen_vblank(int state);
+
 	void tx_gfxram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void truxton2_68k_mem(address_map &map) ATTR_COLD;
 
@@ -68,9 +68,7 @@ private:
 	required_device<toaplan_txtilemap_device> m_tx_tilemap;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
-	bitmap_ind8 m_custom_priority_bitmap;
 };
-
 
 
 void truxton2_state::screen_vblank(int state)
@@ -82,12 +80,11 @@ void truxton2_state::screen_vblank(int state)
 }
 
 
-
 u32 truxton2_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(0, cliprect);
-	m_custom_priority_bitmap.fill(0, cliprect);
-	m_vdp->render_vdp(bitmap, cliprect);
+	screen.priority().fill(0, cliprect);
+	m_vdp->render_vdp(bitmap, cliprect, screen.priority());
 	m_tx_tilemap->draw_tilemap(screen, bitmap, cliprect);
 	return 0;
 }
@@ -104,9 +101,6 @@ void truxton2_state::tx_gfxram_w(offs_t offset, u16 data, u16 mem_mask)
 
 void truxton2_state::video_start()
 {
-	m_screen->register_screen_bitmap(m_custom_priority_bitmap);
-	m_vdp->custom_priority_bitmap = &m_custom_priority_bitmap;
-
 	m_tx_tilemap->gfx(0)->set_source(reinterpret_cast<u8 *>(m_tx_gfxram.target()));
 }
 

--- a/src/mame/toaplan/vfive.cpp
+++ b/src/mame/toaplan/vfive.cpp
@@ -47,11 +47,11 @@ public:
 		, m_palette(*this, "palette")
 		, m_coincounter(*this, "coincounter")
 	{ }
+
 	void vfive(machine_config &config);
 
 protected:
 	virtual void machine_reset() override ATTR_COLD;
-	virtual void video_start() override ATTR_COLD;
 
 private:
 	void vfive_68k_mem(address_map &map) ATTR_COLD;
@@ -72,21 +72,14 @@ private:
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 	required_device<toaplan_coincounter_device> m_coincounter;
-	bitmap_ind8 m_custom_priority_bitmap;
 };
 
-
-void vfive_state::video_start()
-{
-	m_screen->register_screen_bitmap(m_custom_priority_bitmap);
-	m_vdp->custom_priority_bitmap = &m_custom_priority_bitmap;
-}
 
 u32 vfive_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(0, cliprect);
-	m_custom_priority_bitmap.fill(0, cliprect);
-	m_vdp->render_vdp(bitmap, cliprect);
+	screen.priority().fill(0, cliprect);
+	m_vdp->render_vdp(bitmap, cliprect, screen.priority());
 	return 0;
 }
 


### PR DESCRIPTION
- Remove unnecessary custom_priority_bitmap and priority remap table, Use argument (screen.priority()) instead.
- Fix filename
- Reduce literal tag usage
- Fix logging
- Make some variables constant

toaplan/*.cpp: (for uses GP9001 hardware)
- Fix namings
- Remove unnecessary priority bitmap variable
- Suppress side effects for debugger reads
- Remove unnecessary video_start override

toaplan/kbash.cpp:
- Move kbash2 specific MSM6295 bankswitching into kbash2_state
- Fix metadata for describe original game of bootleg