### PR TITLE
sound/cem3394.cpp: Removed artificial pulse width limiting.

### DIFF
--- a/src/devices/sound/cem3394.cpp
+++ b/src/devices/sound/cem3394.cpp
@@ -47,19 +47,6 @@ static constexpr double EXTERNAL_VOLUME = PULSE_VOLUME;
 #define ENABLE_EXTERNAL     1
 
 
-// pulse shaping parameters
-// can be enabled with configure_limit_pw(true)
-// examples:
-//    hat trick - skidding ice sounds too loud if minimum width is too big
-//    snake pit - melody during first level too soft if minimum width is too small
-//    snake pit - bonus counter at the end of level
-//    snacks'n jaxson - laugh at end of level is too soft if minimum width is too small
-
-#define LIMIT_WIDTH         1
-#define MINIMUM_WIDTH       0.2
-#define MAXIMUM_WIDTH       0.8
-
-
 /********************************************************************************
 
     From the datasheet:
@@ -140,7 +127,6 @@ cem3394_device::cem3394_device(const machine_config &mconfig, const char *tag, d
 	m_vco_zero_freq(500.0),
 	m_filter_zero_freq(1300.0),
 	m_hpf_k(0),
-	m_limit_pw(false),
 	m_values{-1}, // will be initialized in device_start()
 	m_wave_select(0),
 	m_volume(0),
@@ -178,12 +164,6 @@ cem3394_device &cem3394_device::configure(double r_vco, double c_vco, double c_v
 
 	LOGMASKED(LOG_CONFIG, "CEM3394 config - vco zero freq: %f, filter zero freq: %f, sample rate: %d\n",
 			  m_vco_zero_freq, m_filter_zero_freq, int(sample_rate));
-	return *this;
-}
-
-cem3394_device &cem3394_device::configure_limit_pw(bool limit_pw)
-{
-	m_limit_pw = limit_pw;
 	return *this;
 }
 
@@ -436,8 +416,6 @@ void cem3394_device::set_voltage_internal(int input, double voltage)
 			else
 			{
 				m_pulse_width = voltage * 0.5;
-				if (LIMIT_WIDTH && m_limit_pw)
-					m_pulse_width = MINIMUM_WIDTH + (MAXIMUM_WIDTH - MINIMUM_WIDTH) * m_pulse_width;
 				m_wave_select |= WAVE_PULSE;
 			}
 			LOGMASKED(LOG_CONTROL_CHANGES, "PULSE_WI=%6.3fV -> raw=%f adj=%f\n", voltage, voltage * 0.5, m_pulse_width);

--- a/src/devices/sound/cem3394.h
+++ b/src/devices/sound/cem3394.h
@@ -37,8 +37,6 @@ public:
 	// c_ac: Pin 17 - AC-coupling capacitor on the VCF output.
 	cem3394_device &configure(double r_vco, double c_vco, double c_vcf, double c_ac) ATTR_COLD;
 
-	cem3394_device &configure_limit_pw(bool limit_pw) ATTR_COLD;
-
 protected:
 	// device-level overrides
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
@@ -83,7 +81,6 @@ private:
 	double m_vco_zero_freq;           // frequency of VCO at 0.0V
 	double m_filter_zero_freq;        // frequency of filter at 0.0V
 	double m_hpf_k;                   // RC filter coefficient for AC coupling
-	bool m_limit_pw;                  // whether to clamp the pulse width.
 
 	// device state
 

--- a/src/mame/midway/sente6vb.cpp
+++ b/src/mame/midway/sente6vb.cpp
@@ -144,7 +144,6 @@ void sente6vb_device::device_add_mconfig(machine_config &config)
 	{
 		CEM3394(config, cem_device, 0);
 		cem_device->configure(RES_K(301), CAP_U(0.002), CAP_U(0.033), CAP_U(10)); // R1, C1, C11, C3 on voice 0 (U1)
-		cem_device->configure_limit_pw(true);
 		cem_device->add_route(ALL_OUTPUTS, "mono", 0.50);
 		ac_noise.add_route(0, *cem_device, 1.0);
 	}


### PR DESCRIPTION
The real hardware doesn't limit the pulse width.

This limiting was added a long time ago, possibly to compensate for other inaccuracies? Though it might be causing its own problems: the light gun issue [here](https://github.com/mamedev/mame/pull/14531#issuecomment-3702865200) seems to be because of this.

PRs over the last few months have improved CEM3394 accuracy. So whatever was being compensated for might be fixed. And if it isn't, the limiting would just be masking the underlying problem.

Regarding the examples in the comments, the ones that were tested (the first two) sound fine.