### PR TITLE
hp48: Make hp48gp only usable with the Version R ROM

### DIFF
--- a/src/mame/hp/hp48.cpp
+++ b/src/mame/hp/hp48.cpp
@@ -1255,13 +1255,12 @@ void hp48_state::hp49g(machine_config &config)
  */
 
 
-/* These ROMS are common to the G, GX, and G+ models.
+/* These ROMS are common to the G and GX models.
    The ROM detects whether it runs a G or a GX by simply testing the memory:
    if there are 32 KB (i.e., addresses wraps-around at 0x10000), it is a G; if there are
    128 KB, it is a GX.
    When a G is detected, some specially optimized routines may be used (they use the fact that
    no extension may be physically present).
-   The G+ model has always revision R.
  */
 ROM_START( hp48gx )
 	ROM_REGION( 0x80000, "maincpu", 0 )
@@ -1288,8 +1287,15 @@ ROM_START( hp48gx )
 ROM_END
 
 #define rom_hp48g  rom_hp48gx
-#define rom_hp48gp rom_hp48gx
 
+/* The G+ model first shipped in 1998 and only comes with the Version R ROM from 1993. */
+ROM_START( hp48gp )
+	ROM_REGION( 0x80000, "maincpu", 0 )
+
+	ROM_SYSTEM_BIOS( 0, "r", "Version R" )
+	ROM_LOAD( "gxrom-r", 0x00000, 0x80000, CRC(00ee1a62) SHA1(5705fc9ea791916c4456ac35e22275862411db9b) )
+
+ROM_END
 
 /* These ROMS are common to the S and SX models.
    The only difference is that, the S being later, it was only shipped with revisions


### PR DESCRIPTION
This calculator shipped late in the 48 life, five years after Hewlett Packard already ceased software development.  As such, it only ever came with the last revision ROM from the GX and G lines.