### PR TITLE
tlcs900: Add TMP94C241 LDC control register mappings for DMA

### DIFF
--- a/src/devices/cpu/tlcs900/900tbl.hxx
+++ b/src/devices/cpu/tlcs900/900tbl.hxx
@@ -3930,16 +3930,28 @@ void tlcs900_device::prepare_operands(const tlcs900inst *inst)
 		m_imm1.d = RDOP();
 		switch( m_imm1.d )
 		{
-		case 0x22:
+		case 0x22:	// TMP96C141/TMP95C061/TMP95C063
 			m_p1_reg8 = &m_dmam[0].b.l;
 			break;
-		case 0x26:
+		case 0x26:	// TMP96C141/TMP95C061/TMP95C063
 			m_p1_reg8 = &m_dmam[1].b.l;
 			break;
-		case 0x2a:
+		case 0x2a:	// TMP96C141/TMP95C061/TMP95C063
 			m_p1_reg8 = &m_dmam[2].b.l;
 			break;
-		case 0x2e:
+		case 0x2e:	// TMP96C141/TMP95C061/TMP95C063
+			m_p1_reg8 = &m_dmam[3].b.l;
+			break;
+		case 0x42:	// TMP94C241
+			m_p1_reg8 = &m_dmam[0].b.l;
+			break;
+		case 0x46:	// TMP94C241
+			m_p1_reg8 = &m_dmam[1].b.l;
+			break;
+		case 0x4a:	// TMP94C241
+			m_p1_reg8 = &m_dmam[2].b.l;
+			break;
+		case 0x4e:	// TMP94C241
 			m_p1_reg8 = &m_dmam[3].b.l;
 			break;
 		default:
@@ -3951,16 +3963,28 @@ void tlcs900_device::prepare_operands(const tlcs900inst *inst)
 		m_imm1.d = RDOP();
 		switch( m_imm1.d )
 		{
-		case 0x20:
+		case 0x20:	// TMP96C141/TMP95C061/TMP95C063
 			m_p1_reg16 = &m_dmac[0].w.l;
 			break;
-		case 0x24:
+		case 0x24:	// TMP96C141/TMP95C061/TMP95C063
 			m_p1_reg16 = &m_dmac[1].w.l;
 			break;
-		case 0x28:
+		case 0x28:	// TMP96C141/TMP95C061/TMP95C063
 			m_p1_reg16 = &m_dmac[2].w.l;
 			break;
-		case 0x2c:
+		case 0x2c:	// TMP96C141/TMP95C061/TMP95C063
+			m_p1_reg16 = &m_dmac[3].w.l;
+			break;
+		case 0x40:	// TMP94C241
+			m_p1_reg16 = &m_dmac[0].w.l;
+			break;
+		case 0x44:	// TMP94C241
+			m_p1_reg16 = &m_dmac[1].w.l;
+			break;
+		case 0x48:	// TMP94C241
+			m_p1_reg16 = &m_dmac[2].w.l;
+			break;
+		case 0x4c:	// TMP94C241
 			m_p1_reg16 = &m_dmac[3].w.l;
 			break;
 		default:
@@ -3972,28 +3996,40 @@ void tlcs900_device::prepare_operands(const tlcs900inst *inst)
 		m_imm1.d = RDOP();
 		switch( m_imm1.d )
 		{
-		case 0x00:
+		case 0x00:	// all variants
 			m_p1_reg32 = &m_dmas[0].d;
 			break;
-		case 0x04:
+		case 0x04:	// all variants
 			m_p1_reg32 = &m_dmas[1].d;
 			break;
-		case 0x08:
+		case 0x08:	// all variants
 			m_p1_reg32 = &m_dmas[2].d;
 			break;
-		case 0x0c:
+		case 0x0c:	// all variants
 			m_p1_reg32 = &m_dmas[3].d;
 			break;
-		case 0x10:
+		case 0x10:	// TMP96C141/TMP95C061/TMP95C063
 			m_p1_reg32 = &m_dmad[0].d;
 			break;
-		case 0x14:
+		case 0x14:	// TMP96C141/TMP95C061/TMP95C063
 			m_p1_reg32 = &m_dmad[1].d;
 			break;
-		case 0x18:
+		case 0x18:	// TMP96C141/TMP95C061/TMP95C063
 			m_p1_reg32 = &m_dmad[2].d;
 			break;
-		case 0x1c:
+		case 0x1c:	// TMP96C141/TMP95C061/TMP95C063
+			m_p1_reg32 = &m_dmad[3].d;
+			break;
+		case 0x20:	// TMP94C241
+			m_p1_reg32 = &m_dmad[0].d;
+			break;
+		case 0x24:	// TMP94C241
+			m_p1_reg32 = &m_dmad[1].d;
+			break;
+		case 0x28:	// TMP94C241
+			m_p1_reg32 = &m_dmad[2].d;
+			break;
+		case 0x2c:	// TMP94C241
 			m_p1_reg32 = &m_dmad[3].d;
 			break;
 		default:
@@ -4072,16 +4108,28 @@ void tlcs900_device::prepare_operands(const tlcs900inst *inst)
 		m_imm1.d = RDOP();
 		switch( m_imm1.d )
 		{
-		case 0x22:
+		case 0x22:	// TMP96C141/TMP95C061/TMP95C063
 			m_p2_reg8 = &m_dmam[0].b.l;
 			break;
-		case 0x26:
+		case 0x26:	// TMP96C141/TMP95C061/TMP95C063
 			m_p2_reg8 = &m_dmam[1].b.l;
 			break;
-		case 0x2a:
+		case 0x2a:	// TMP96C141/TMP95C061/TMP95C063
 			m_p2_reg8 = &m_dmam[2].b.l;
 			break;
-		case 0x2e:
+		case 0x2e:	// TMP96C141/TMP95C061/TMP95C063
+			m_p2_reg8 = &m_dmam[3].b.l;
+			break;
+		case 0x42:	// TMP94C241
+			m_p2_reg8 = &m_dmam[0].b.l;
+			break;
+		case 0x46:	// TMP94C241
+			m_p2_reg8 = &m_dmam[1].b.l;
+			break;
+		case 0x4a:	// TMP94C241
+			m_p2_reg8 = &m_dmam[2].b.l;
+			break;
+		case 0x4e:	// TMP94C241
 			m_p2_reg8 = &m_dmam[3].b.l;
 			break;
 		default:
@@ -4093,16 +4141,28 @@ void tlcs900_device::prepare_operands(const tlcs900inst *inst)
 		m_imm1.d = RDOP();
 		switch( m_imm1.d )
 		{
-		case 0x20:
+		case 0x20:	// TMP96C141/TMP95C061/TMP95C063
 			m_p2_reg16 = &m_dmac[0].w.l;
 			break;
-		case 0x24:
+		case 0x24:	// TMP96C141/TMP95C061/TMP95C063
 			m_p2_reg16 = &m_dmac[1].w.l;
 			break;
-		case 0x28:
+		case 0x28:	// TMP96C141/TMP95C061/TMP95C063
 			m_p2_reg16 = &m_dmac[2].w.l;
 			break;
-		case 0x2c:
+		case 0x2c:	// TMP96C141/TMP95C061/TMP95C063
+			m_p2_reg16 = &m_dmac[3].w.l;
+			break;
+		case 0x40:	// TMP94C241
+			m_p2_reg16 = &m_dmac[0].w.l;
+			break;
+		case 0x44:	// TMP94C241
+			m_p2_reg16 = &m_dmac[1].w.l;
+			break;
+		case 0x48:	// TMP94C241
+			m_p2_reg16 = &m_dmac[2].w.l;
+			break;
+		case 0x4c:	// TMP94C241
 			m_p2_reg16 = &m_dmac[3].w.l;
 			break;
 		default:
@@ -4114,28 +4174,40 @@ void tlcs900_device::prepare_operands(const tlcs900inst *inst)
 		m_imm1.d = RDOP();
 		switch( m_imm1.d )
 		{
-		case 0x00:
+		case 0x00:	// all variants
 			m_p2_reg32 = &m_dmas[0].d;
 			break;
-		case 0x04:
+		case 0x04:	// all variants
 			m_p2_reg32 = &m_dmas[1].d;
 			break;
-		case 0x08:
+		case 0x08:	// all variants
 			m_p2_reg32 = &m_dmas[2].d;
 			break;
-		case 0x0c:
+		case 0x0c:	// all variants
 			m_p2_reg32 = &m_dmas[3].d;
 			break;
-		case 0x10:
+		case 0x10:	// TMP96C141/TMP95C061/TMP95C063
 			m_p2_reg32 = &m_dmad[0].d;
 			break;
-		case 0x14:
+		case 0x14:	// TMP96C141/TMP95C061/TMP95C063
 			m_p2_reg32 = &m_dmad[1].d;
 			break;
-		case 0x18:
+		case 0x18:	// TMP96C141/TMP95C061/TMP95C063
 			m_p2_reg32 = &m_dmad[2].d;
 			break;
-		case 0x1c:
+		case 0x1c:	// TMP96C141/TMP95C061/TMP95C063
+			m_p2_reg32 = &m_dmad[3].d;
+			break;
+		case 0x20:	// TMP94C241
+			m_p2_reg32 = &m_dmad[0].d;
+			break;
+		case 0x24:	// TMP94C241
+			m_p2_reg32 = &m_dmad[1].d;
+			break;
+		case 0x28:	// TMP94C241
+			m_p2_reg32 = &m_dmad[2].d;
+			break;
+		case 0x2c:	// TMP94C241
 			m_p2_reg32 = &m_dmad[3].d;
 			break;
 		default:

--- a/src/devices/cpu/tlcs900/dasm900.cpp
+++ b/src/devices/cpu/tlcs900/dasm900.cpp
@@ -1437,7 +1437,17 @@ u32 tlcs900_disassembler::opcode_alignment() const
 tlcs900_disassembler::tlcs900_disassembler()
 	: m_symbols(nullptr)
 	, m_symbol_count(0)
+	, m_cr_symbols(nullptr)
+	, m_cr_symbol_count(0)
 {
+}
+
+char const *tlcs900_disassembler::cr_name(u8 size, u8 encoding) const
+{
+	for (std::size_t i = 0; i < m_cr_symbol_count; i++)
+		if (m_cr_symbols[i].size == size && m_cr_symbols[i].encoding == encoding)
+			return m_cr_symbols[i].name;
+	return nullptr;
 }
 
 offs_t tlcs900_disassembler::disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params)
@@ -1925,79 +1935,34 @@ offs_t tlcs900_disassembler::disassemble(std::ostream &stream, offs_t pc, const 
 
 	case O_CR8:
 		imm = opcodes.r8( pos++ );
-		switch( imm )
 		{
-		case 0x22:
-			util::stream_format(stream, " DMAM0");
-			break;
-		case 0x26:
-			util::stream_format(stream, " DMAM1");
-			break;
-		case 0x2a:
-			util::stream_format(stream, " DMAM2");
-			break;
-		case 0x2e:
-			util::stream_format(stream, " DMAM3");
-			break;
-		default:
-			util::stream_format(stream, " unknown");
-			break;
+			char const *name = cr_name(8, imm);
+			if (name)
+				util::stream_format(stream, " %s", name);
+			else
+				util::stream_format(stream, " unknown");
 		}
 		break;
 
 	case O_CR16:
 		imm = opcodes.r8( pos++ );
-		switch( imm )
 		{
-		case 0x20:
-			util::stream_format(stream, " DMAC0");
-			break;
-		case 0x24:
-			util::stream_format(stream, " DMAC1");
-			break;
-		case 0x28:
-			util::stream_format(stream, " DMAC2");
-			break;
-		case 0x2c:
-			util::stream_format(stream, " DMAC3");
-			break;
-		default:
-			util::stream_format(stream, " unknown");
-			break;
+			char const *name = cr_name(16, imm);
+			if (name)
+				util::stream_format(stream, " %s", name);
+			else
+				util::stream_format(stream, " unknown");
 		}
 		break;
 
 	case O_CR32:
 		imm = opcodes.r8( pos++ );
-		switch( imm )
 		{
-		case 0x00:
-			util::stream_format(stream, " DMAS0");
-			break;
-		case 0x04:
-			util::stream_format(stream, " DMAS1");
-			break;
-		case 0x08:
-			util::stream_format(stream, " DMAS2");
-			break;
-		case 0x0c:
-			util::stream_format(stream, " DMAS3");
-			break;
-		case 0x10:
-			util::stream_format(stream, " DMAD0");
-			break;
-		case 0x14:
-			util::stream_format(stream, " DMAD1");
-			break;
-		case 0x18:
-			util::stream_format(stream, " DMAD2");
-			break;
-		case 0x1c:
-			util::stream_format(stream, " DMAD3");
-			break;
-		default:
-			util::stream_format(stream, " unknown");
-			break;
+			char const *name = cr_name(32, imm);
+			if (name)
+				util::stream_format(stream, " %s", name);
+			else
+				util::stream_format(stream, " unknown");
 		}
 		break;
 
@@ -2113,79 +2078,34 @@ offs_t tlcs900_disassembler::disassemble(std::ostream &stream, offs_t pc, const 
 
 	case O_CR8:
 		imm = opcodes.r8( pos++ );
-		switch( imm )
 		{
-		case 0x22:
-			util::stream_format(stream, ",DMAM0");
-			break;
-		case 0x26:
-			util::stream_format(stream, ",DMAM1");
-			break;
-		case 0x2a:
-			util::stream_format(stream, ",DMAM2");
-			break;
-		case 0x2e:
-			util::stream_format(stream, ",DMAM3");
-			break;
-		default:
-			util::stream_format(stream, ",unknown");
-			break;
+			char const *name = cr_name(8, imm);
+			if (name)
+				util::stream_format(stream, ",%s", name);
+			else
+				util::stream_format(stream, ",unknown");
 		}
 		break;
 
 	case O_CR16:
 		imm = opcodes.r8( pos++ );
-		switch( imm )
 		{
-		case 0x20:
-			util::stream_format(stream, ",DMAC0");
-			break;
-		case 0x24:
-			util::stream_format(stream, ",DMAC1");
-			break;
-		case 0x28:
-			util::stream_format(stream, ",DMAC2");
-			break;
-		case 0x2c:
-			util::stream_format(stream, ",DMAC3");
-			break;
-		default:
-			util::stream_format(stream, ",unknown");
-			break;
+			char const *name = cr_name(16, imm);
+			if (name)
+				util::stream_format(stream, ",%s", name);
+			else
+				util::stream_format(stream, ",unknown");
 		}
 		break;
 
 	case O_CR32:
 		imm = opcodes.r8( pos++ );
-		switch( imm )
 		{
-		case 0x00:
-			util::stream_format(stream, ",DMAS0");
-			break;
-		case 0x04:
-			util::stream_format(stream, ",DMAS1");
-			break;
-		case 0x08:
-			util::stream_format(stream, ",DMAS2");
-			break;
-		case 0x0c:
-			util::stream_format(stream, ",DMAS3");
-			break;
-		case 0x10:
-			util::stream_format(stream, ",DMAD0");
-			break;
-		case 0x14:
-			util::stream_format(stream, ",DMAD1");
-			break;
-		case 0x18:
-			util::stream_format(stream, ",DMAD2");
-			break;
-		case 0x1c:
-			util::stream_format(stream, ",DMAD3");
-			break;
-		default:
-			util::stream_format(stream, ",unknown");
-			break;
+			char const *name = cr_name(32, imm);
+			if (name)
+				util::stream_format(stream, ",%s", name);
+			else
+				util::stream_format(stream, ",unknown");
 		}
 		break;
 

--- a/src/devices/cpu/tlcs900/dasm900.h
+++ b/src/devices/cpu/tlcs900/dasm900.h
@@ -17,10 +17,18 @@ Toshiba TLCS-900/H disassembly
 class tlcs900_disassembler : public util::disasm_interface
 {
 public:
+	// Control register symbol entry for model-specific LDC operand names
+	struct cr_sym { u8 size; u8 encoding; char const *name; };
+
 	tlcs900_disassembler();
 	template <size_t N>
 	tlcs900_disassembler(std::pair<u16, char const *> const (&symbols)[N])
 		: tlcs900_disassembler(symbols, N)
+	{
+	}
+	template <size_t N, size_t CRN>
+	tlcs900_disassembler(std::pair<u16, char const *> const (&symbols)[N], cr_sym const (&cr_symbols)[CRN])
+		: tlcs900_disassembler(symbols, N, cr_symbols, CRN)
 	{
 	}
 
@@ -30,13 +38,21 @@ public:
 private:
 	std::pair<u16, char const *> const *m_symbols;
 	std::size_t m_symbol_count;
+	cr_sym const *m_cr_symbols;
+	std::size_t m_cr_symbol_count;
 
 	tlcs900_disassembler(std::pair<u16, char const *> const symbols[], std::size_t symbol_count)
-		: m_symbols(symbols), m_symbol_count(symbol_count)
+		: m_symbols(symbols), m_symbol_count(symbol_count), m_cr_symbols(nullptr), m_cr_symbol_count(0)
+	{
+	}
+	tlcs900_disassembler(std::pair<u16, char const *> const symbols[], std::size_t symbol_count,
+	                     cr_sym const cr_symbols[], std::size_t cr_symbol_count)
+		: m_symbols(symbols), m_symbol_count(symbol_count), m_cr_symbols(cr_symbols), m_cr_symbol_count(cr_symbol_count)
 	{
 	}
 
 	template <typename T> std::string address(T offset, int size) const;
+	char const *cr_name(u8 size, u8 encoding) const;
 };
 
 #endif // MAME_CPU_TLCS900_DASM900_H

--- a/src/devices/cpu/tlcs900/tmp94c241.cpp
+++ b/src/devices/cpu/tlcs900/tmp94c241.cpp
@@ -1400,7 +1400,14 @@ static std::pair<u16, char const *> const tmp94c241_syms[] = {
 	{ 0x166, "PMEMCR" },
 };
 
+static tlcs900_disassembler::cr_sym const tmp94c241_cr_syms[] = {
+	{ 8,  0x42, "DMAM0" }, { 8,  0x46, "DMAM1" }, { 8,  0x4a, "DMAM2" }, { 8,  0x4e, "DMAM3" },
+	{ 16, 0x40, "DMAC0" }, { 16, 0x44, "DMAC1" }, { 16, 0x48, "DMAC2" }, { 16, 0x4c, "DMAC3" },
+	{ 32, 0x00, "DMAS0" }, { 32, 0x04, "DMAS1" }, { 32, 0x08, "DMAS2" }, { 32, 0x0c, "DMAS3" },
+	{ 32, 0x20, "DMAD0" }, { 32, 0x24, "DMAD1" }, { 32, 0x28, "DMAD2" }, { 32, 0x2c, "DMAD3" },
+};
+
 std::unique_ptr<util::disasm_interface> tmp94c241_device::create_disassembler()
 {
-	return std::make_unique<tlcs900_disassembler>(tmp94c241_syms);
+	return std::make_unique<tlcs900_disassembler>(tmp94c241_syms, tmp94c241_cr_syms);
 }

--- a/src/devices/cpu/tlcs900/tmp95c061.cpp
+++ b/src/devices/cpu/tlcs900/tmp95c061.cpp
@@ -1391,7 +1391,14 @@ static std::pair<u16, char const *> const tmp95c061_syms[] = {
 	{ 0x7c, "DMA0V" }, { 0x7d, "DMA1V" }, { 0x7e, "DMA2V" }, { 0x7f, "DMA3V" }
 };
 
+static tlcs900_disassembler::cr_sym const tmp95c061_cr_syms[] = {
+	{ 8,  0x22, "DMAM0" }, { 8,  0x26, "DMAM1" }, { 8,  0x2a, "DMAM2" }, { 8,  0x2e, "DMAM3" },
+	{ 16, 0x20, "DMAC0" }, { 16, 0x24, "DMAC1" }, { 16, 0x28, "DMAC2" }, { 16, 0x2c, "DMAC3" },
+	{ 32, 0x00, "DMAS0" }, { 32, 0x04, "DMAS1" }, { 32, 0x08, "DMAS2" }, { 32, 0x0c, "DMAS3" },
+	{ 32, 0x10, "DMAD0" }, { 32, 0x14, "DMAD1" }, { 32, 0x18, "DMAD2" }, { 32, 0x1c, "DMAD3" },
+};
+
 std::unique_ptr<util::disasm_interface> tmp95c061_device::create_disassembler()
 {
-	return std::make_unique<tlcs900_disassembler>(tmp95c061_syms);
+	return std::make_unique<tlcs900_disassembler>(tmp95c061_syms, tmp95c061_cr_syms);
 }

--- a/src/devices/cpu/tlcs900/tmp95c063.cpp
+++ b/src/devices/cpu/tlcs900/tmp95c063.cpp
@@ -1448,7 +1448,14 @@ static std::pair<u16, char const *> const tmp95c063_syms[] = {
 	{ 0x9c, "DREFCR1" }, { 0x9d, "DMEMCR1" }, { 0x9e, "DREFCR3" }, { 0x9f, "DMEMCR3" }
 };
 
+static tlcs900_disassembler::cr_sym const tmp95c063_cr_syms[] = {
+	{ 8,  0x22, "DMAM0" }, { 8,  0x26, "DMAM1" }, { 8,  0x2a, "DMAM2" }, { 8,  0x2e, "DMAM3" },
+	{ 16, 0x20, "DMAC0" }, { 16, 0x24, "DMAC1" }, { 16, 0x28, "DMAC2" }, { 16, 0x2c, "DMAC3" },
+	{ 32, 0x00, "DMAS0" }, { 32, 0x04, "DMAS1" }, { 32, 0x08, "DMAS2" }, { 32, 0x0c, "DMAS3" },
+	{ 32, 0x10, "DMAD0" }, { 32, 0x14, "DMAD1" }, { 32, 0x18, "DMAD2" }, { 32, 0x1c, "DMAD3" },
+};
+
 std::unique_ptr<util::disasm_interface> tmp95c063_device::create_disassembler()
 {
-	return std::make_unique<tlcs900_disassembler>(tmp95c063_syms);
+	return std::make_unique<tlcs900_disassembler>(tmp95c063_syms, tmp95c063_cr_syms);
 }

--- a/src/devices/cpu/tlcs900/tmp96c141.cpp
+++ b/src/devices/cpu/tlcs900/tmp96c141.cpp
@@ -229,7 +229,14 @@ static std::pair<u16, char const *> const tmp96c141_syms[] = {
 	{ 0x7c, "DMA0V" }, { 0x7d, "DMA1V" }, { 0x7e, "DMA2V" }, { 0x7f, "DMA3V"}
 };
 
+static tlcs900_disassembler::cr_sym const tmp96c141_cr_syms[] = {
+	{ 8,  0x22, "DMAM0" }, { 8,  0x26, "DMAM1" }, { 8,  0x2a, "DMAM2" }, { 8,  0x2e, "DMAM3" },
+	{ 16, 0x20, "DMAC0" }, { 16, 0x24, "DMAC1" }, { 16, 0x28, "DMAC2" }, { 16, 0x2c, "DMAC3" },
+	{ 32, 0x00, "DMAS0" }, { 32, 0x04, "DMAS1" }, { 32, 0x08, "DMAS2" }, { 32, 0x0c, "DMAS3" },
+	{ 32, 0x10, "DMAD0" }, { 32, 0x14, "DMAD1" }, { 32, 0x18, "DMAD2" }, { 32, 0x1c, "DMAD3" },
+};
+
 std::unique_ptr<util::disasm_interface> tmp96c141_device::create_disassembler()
 {
-	return std::make_unique<tlcs900_disassembler>(tmp96c141_syms);
+	return std::make_unique<tlcs900_disassembler>(tmp96c141_syms, tmp96c141_cr_syms);
 }


### PR DESCRIPTION
## Summary

- Add TMP94C241 DMA control register encodings to the LDC instruction handler in `900tbl.hxx`
- Refactor disassembler CR register names from hardcoded switches into per-variant symbol tables
- No changes to existing TMP96C141/TMP95C061/TMP95C063 behavior

## Problem

The `LDC` (Load Control Register) instruction uses an immediate byte to select which internal register to access. The TMP94C241 places its DMA registers at different offsets than the TMP96C141/TMP95C061/TMP95C063:

| Register | TMP96C141/TMP95C061/TMP95C063 | TMP94C241 |
|----------|-------------------------------|-----------|
| DMAM0-3 (8-bit) | 0x22, 0x26, 0x2A, 0x2E | 0x42, 0x46, 0x4A, 0x4E |
| DMAC0-3 (16-bit) | 0x20, 0x24, 0x28, 0x2C | 0x40, 0x44, 0x48, 0x4C |
| DMAD0-3 (32-bit) | 0x10, 0x14, 0x18, 0x1C | 0x20, 0x24, 0x28, 0x2C |
| DMAS0-3 (32-bit) | 0x00, 0x04, 0x08, 0x0C | 0x00, 0x04, 0x08, 0x0C |

Without the TMP94C241 cases, `LDC cr,DMAMn` writes go to a dummy register and DMA never configures. This blocks the Technics KN5000 (the only driver currently using TMP94C241) from performing HDMA-based firmware payload transfers.

## Changes

**`900tbl.hxx`**: Add TMP94C241 `case` entries to the six existing CR switch blocks in `prepare_operands()`. The encoding values are disjoint between variants so the new cases coexist harmlessly — unreachable cases have zero runtime cost in the compiler's jump table. Each case is annotated with a comment identifying which variant(s) use that encoding.

**`dasm900.h`**: Add `cr_sym` struct and `cr_name()` lookup, paralleling the existing SFR symbol table pattern.

**`dasm900.cpp`**: Replace six hardcoded switch blocks for `O_CR8`/`O_CR16`/`O_CR32` with table-driven lookups via `cr_name()`.

**`tmp94c241.cpp`**, **`tmp96c141.cpp`**, **`tmp95c061.cpp`**, **`tmp95c063.cpp`**: Each variant defines its own `*_cr_syms[]` table passed to the disassembler constructor.

## Test plan

- [x] Verified existing TMP96C141/TMP95C061/TMP95C063 CR register disassembly is unchanged
- [x] Verified TMP94C241 DMA register writes now reach the correct internal registers
- [x] KN5000 HDMA payload transfer completes successfully with this fix applied

## Reference

Toshiba TMP94C241F Data Sheet, Section 5 "DMA Controller", Table 5-1 "DMA Register Map".