### PR TITLE
sound/[va_eg, va_ops]: Added CEM3310 and misc stream processing helpers.

### DIFF
--- a/scripts/src/sound.lua
+++ b/scripts/src/sound.lua
@@ -1202,6 +1202,18 @@ if SOUNDS["VA_EG"] then
 end
 
 --------------------------------------------------
+-- Virtual analog operations
+--@src/devices/sound/va_ops.h,SOUNDS["VA_OPS"] = true
+--------------------------------------------------
+
+if SOUNDS["VA_OPS"] then
+	files {
+		MAME_DIR .. "src/devices/sound/va_ops.cpp",
+		MAME_DIR .. "src/devices/sound/va_ops.h",
+	}
+end
+
+--------------------------------------------------
 -- Virtual analog voltage-controlled amplifiers (VCAs)
 --@src/devices/sound/va_vca.h,SOUNDS["VA_VCA"] = true
 --------------------------------------------------

--- a/src/devices/sound/va_eg.cpp
+++ b/src/devices/sound/va_eg.cpp
@@ -8,7 +8,6 @@
 // The envelope is considered completed after this many time constants.
 static constexpr const float TIME_CONSTANTS_TO_END = 10;
 
-DEFINE_DEVICE_TYPE(VA_RC_EG, va_rc_eg_device, "va_rc_eg", "RC-based Envelope Generator")
 
 va_rc_eg_device::va_rc_eg_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, VA_RC_EG, tag, owner, clock)
@@ -130,7 +129,7 @@ void va_rc_eg_device::sound_stream_update(sound_stream &stream)
 	assert(stream.input_count() == 0 && stream.output_count() == 1);
 	attotime t = stream.start_time();
 
-	if (t >= m_t_end_approx)
+	if (converged(t))
 	{
 		// Avoid expensive get_v() calls if the envelope stage has completed.
 		stream.fill(0, m_v_end);
@@ -158,3 +157,188 @@ void va_rc_eg_device::snapshot()
 	}
 	m_t_end_approx = m_t_start + attotime::from_double(TIME_CONSTANTS_TO_END * m_r * m_c);
 }
+
+
+cem3310_device::cem3310_device(const machine_config &mconfig, const char *tag, device_t *owner, float rx, float cx)
+	: device_t(mconfig, CEM3310, tag, owner, 0)
+	, device_sound_interface(mconfig, *this)
+	, m_rx(rx)
+	, m_cx(cx)
+	, m_stream(nullptr)
+	, m_attack_timer(nullptr)
+	, m_rc(*this, "rc")
+	, m_phase(PHASE_RELEASE)
+	, m_gate(false)
+	, m_attack_cv(0)
+	, m_decay_cv(0)
+	, m_sustain_cv(0)
+	, m_release_cv(0)
+{
+}
+
+cem3310_device::cem3310_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: cem3310_device(mconfig, tag, owner, RES_K(24), CAP_U(0.039))  // Example values in the datasheet.
+{
+}
+
+void cem3310_device::attack_w(float cv)
+{
+	if (cv == m_attack_cv)
+		return;
+	m_stream->update();
+	m_attack_cv = cv;
+	update_rc();
+}
+
+void cem3310_device::decay_w(float cv)
+{
+	if (cv == m_decay_cv)
+		return;
+	m_stream->update();
+	m_decay_cv = cv;
+	update_rc();
+}
+
+void cem3310_device::sustain_w(float cv)
+{
+	if (cv == m_sustain_cv)
+		return;
+	m_stream->update();
+	m_sustain_cv = cv;
+	update_rc();
+}
+
+void cem3310_device::release_w(float cv)
+{
+	if (cv == m_release_cv)
+		return;
+	m_stream->update();
+	m_release_cv = cv;
+	update_rc();
+}
+
+void cem3310_device::gate_w(int state)
+{
+	const bool gate = bool(state);
+	if (gate == m_gate)
+		return;
+
+	m_stream->update();
+	if (!m_gate && gate)
+		m_phase = PHASE_ATTACK;
+	else
+		m_phase = PHASE_RELEASE;
+	m_gate = gate;
+	update_rc();
+}
+
+void cem3310_device::device_add_mconfig(machine_config &config)
+{
+	VA_RC_EG(config, m_rc).set_c(m_cx);
+}
+
+void cem3310_device::device_start()
+{
+	m_stream = stream_alloc(0, 1, SAMPLE_RATE_OUTPUT_ADAPTIVE);
+	m_attack_timer = timer_alloc(FUNC(cem3310_device::attack_timer_tick), this);
+
+	save_item(NAME(m_phase));
+	save_item(NAME(m_gate));
+	save_item(NAME(m_attack_cv));
+	save_item(NAME(m_decay_cv));
+	save_item(NAME(m_sustain_cv));
+	save_item(NAME(m_release_cv));
+}
+
+void cem3310_device::device_reset()
+{
+	update_rc();
+}
+
+void cem3310_device::sound_stream_update(sound_stream &stream)
+{
+	attotime t = stream.start_time();
+	if (m_rc->converged(t))
+	{
+		// Avoid repeated calls to get_v() if the envelope stage has completed.
+		stream.fill(0, m_rc->get_v(t));
+		return;
+	}
+
+	const int n = stream.samples();
+	const attotime dt = stream.sample_period();
+	for (int i = 0; i < n; ++i, t += dt)
+		stream.put(0, i, m_rc->get_v(t));
+}
+
+void cem3310_device::update_rc()
+{
+	float target_v = 0;
+	float rate_cv = 0;
+	switch (m_phase)
+	{
+		case PHASE_ATTACK:
+			target_v = VZ;
+			rate_cv = m_attack_cv;
+			break;
+		case PHASE_DECAY:
+			target_v = m_sustain_cv;
+			rate_cv = m_decay_cv;
+			break;
+		case PHASE_RELEASE:
+			target_v = 0;
+			rate_cv = m_release_cv;
+			break;
+		default:
+			fatalerror("%s: Unrecognized EG phase\n", tag());
+	}
+
+	// According to the datasheet, the equivalent RC constant is:
+	//   RC = Rx * Cx * exp(-VC / VT)
+	// where VC is the rate CV of the current EG phase, and VT is the thermal voltage.
+	// m_rc is configured with Cx as its capacitor. So to achieve the required
+	// time constant, we set its resistor to:
+	//   R = Rx * exp(-VC / VT)
+	m_rc->set_r(m_rx * expf(-rate_cv / VT));
+	m_rc->set_target_v(target_v);
+
+	// If in the attack phase, set up a timer to switch to the decay phase once
+	// peak voltage is reached.
+	m_attack_timer->reset();
+	if (m_phase == PHASE_ATTACK)
+	{
+		const attotime dt = m_rc->get_dt(VP);
+		if (!dt.is_never())
+		{
+			m_attack_timer->adjust(dt);
+		}
+		else
+		{
+			// Extremely unlikely. Requires update_rc() getting called at
+			// exactly the time when the attack phase ends. Using 'assert' to
+			// ensure this gets noticed in debug builds, as it likely points to
+			// a bug.
+			assert(false);
+			logerror("Voltage (%f) greater than 5V during attack phase.\n", m_rc->get_v());
+			attack_timer_tick(0);  // Enter decay phase immediately.
+		}
+	}
+}
+
+TIMER_CALLBACK_MEMBER(cem3310_device::attack_timer_tick)
+{
+	assert(m_phase == PHASE_ATTACK);
+	if (m_phase != PHASE_ATTACK)
+	{
+		logerror("Attack timer elapsed when not in attack phase.\n");
+		return;
+	}
+
+	m_stream->update();
+	m_phase = PHASE_DECAY;
+	update_rc();
+}
+
+
+DEFINE_DEVICE_TYPE(VA_RC_EG, va_rc_eg_device, "va_rc_eg", "RC-based Envelope Generator")
+DEFINE_DEVICE_TYPE(CEM3310, cem3310_device, "cem3310", "CEM3310 Envelope Generator")

--- a/src/devices/sound/va_eg.h
+++ b/src/devices/sound/va_eg.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+DECLARE_DEVICE_TYPE(VA_RC_EG, va_rc_eg_device)
+DECLARE_DEVICE_TYPE(CEM3310, cem3310_device)
+
+
 // Building block for emulating envelope generators (EGs) based on a single RC
 // circuit. The controlling source sets a target voltage and the device
 // interpolates up or down to it through a RC circuit. The voltage is published
@@ -53,6 +57,9 @@ public:
 	// impossible to reach.
 	attotime get_dt(float v) const;
 
+	// Returns true if the voltage converged to the target by time `t`.
+	bool converged(const attotime &t) const { return t >= m_t_end_approx; }
+
 protected:
 	void device_start() override ATTR_COLD;
 	void sound_stream_update(sound_stream &stream) override;
@@ -72,6 +79,69 @@ private:
 	attotime m_t_end_approx;
 };
 
-DECLARE_DEVICE_TYPE(VA_RC_EG, va_rc_eg_device)
+
+// Emulates a CEM3310 envelope generator.
+// The rate CVs (attack, decay, release) are usually negative voltages.
+// The sustain CV is a positive voltage, usually 0-5V.
+// The output stream contains voltages, usually 0-5V.
+//
+// The emulation is accurate for the typical configuration. The behavior for
+// less common configurations (e.g. sustain voltage above 5V, independent gate
+// and trigger signals) is not yet emulated. The longer version of the datasheet
+// has relevant info.
+class cem3310_device : public device_t, public device_sound_interface
+{
+public:
+	// rx - Resistor Rx connecting pin 10 (Iin) and pin 2 (ENV Out).
+	// cx - Capacitor Cx at pin 1 (Cap).
+	cem3310_device(const machine_config &mconfig, const char *tag, device_t *owner, float rx, float cx) ATTR_COLD;
+	cem3310_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) ATTR_COLD;
+
+	void attack_w(float cv);
+	void decay_w(float cv);
+	void sustain_w(float cv);
+	void release_w(float cv);
+
+	// Assumes the trigger pin is connected to the gate pin via a capacitor.
+	// Independent control of the trigger input is not yet emulated.
+	void gate_w(int state);
+
+protected:
+	void device_add_mconfig(machine_config &config) override ATTR_COLD;
+	void device_start() override ATTR_COLD;
+	void device_reset() override ATTR_COLD;
+	void sound_stream_update(sound_stream &stream) override;
+
+private:
+	void update_rc();
+	TIMER_CALLBACK_MEMBER(attack_timer_tick);
+
+	enum phase
+	{
+		PHASE_ATTACK = 0,
+		PHASE_DECAY,
+		PHASE_RELEASE
+	};
+
+	// Using the constant names in the datasheet.
+	static inline constexpr float VP = 5.0F;  // Envelope peak voltage.
+	static inline constexpr float VZ = 6.5F;  // Attack asymptote voltage (voltage target).
+	static inline constexpr float VT = 0.026F;  // Thermal voltage at room temperature.
+
+	const float m_rx;
+	const float m_cx;
+
+	sound_stream *m_stream;
+	emu_timer *m_attack_timer;
+
+	required_device<va_rc_eg_device> m_rc;
+
+	s8 m_phase;
+	bool m_gate;
+	float m_attack_cv;
+	float m_decay_cv;
+	float m_sustain_cv;
+	float m_release_cv;
+};
 
 #endif  // MAME_SOUND_VA_EG_H

--- a/src/devices/sound/va_ops.cpp
+++ b/src/devices/sound/va_ops.cpp
@@ -1,0 +1,76 @@
+// license:BSD-3-Clause
+// copyright-holders:m1macrophage
+
+#include "emu.h"
+#include "va_ops.h"
+
+va_const_device::va_const_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, VA_CONST, tag, owner, clock)
+	, device_sound_interface(mconfig, *this)
+	, m_stream(nullptr)
+	, m_value(0)
+{
+}
+
+va_const_device &va_const_device::set_value(float value)
+{
+	if (m_stream)
+		m_stream->update();
+	m_value = value;
+	return *this;
+}
+
+void va_const_device::device_start()
+{
+	m_stream = stream_alloc(0, 1, SAMPLE_RATE_OUTPUT_ADAPTIVE);
+	save_item(NAME(m_value));
+}
+
+void va_const_device::sound_stream_update(sound_stream &stream)
+{
+	stream.fill(0, m_value);
+}
+
+
+va_scale_offset_device::va_scale_offset_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, VA_SCALE_OFFSET, tag, owner, clock)
+	, device_sound_interface(mconfig, *this)
+	, m_stream(nullptr)
+	, m_scale(1)
+	, m_offset(0)
+{
+}
+
+va_scale_offset_device &va_scale_offset_device::set_scale(float scale)
+{
+	if (m_stream)
+		m_stream->update();
+	m_scale = scale;
+	return *this;
+}
+
+va_scale_offset_device &va_scale_offset_device::set_offset(float offset)
+{
+	if (m_stream)
+		m_stream->update();
+	m_offset = offset;
+	return *this;
+}
+
+void va_scale_offset_device::device_start()
+{
+	save_item(NAME(m_scale));
+	save_item(NAME(m_offset));
+	m_stream = stream_alloc(1, 1, SAMPLE_RATE_OUTPUT_ADAPTIVE);
+}
+
+void va_scale_offset_device::sound_stream_update(sound_stream &stream)
+{
+	const int n = stream.samples();
+	for (int i = 0; i < n; ++i)
+		stream.put(0, i, m_scale * stream.get(0, i) + m_offset);
+}
+
+
+DEFINE_DEVICE_TYPE(VA_CONST, va_const_device, "va_const", "Constant value stream")
+DEFINE_DEVICE_TYPE(VA_SCALE_OFFSET, va_scale_offset_device, "va_scale_offset", "Scale and offset")

--- a/src/devices/sound/va_ops.h
+++ b/src/devices/sound/va_ops.h
@@ -1,0 +1,59 @@
+// license:BSD-3-Clause
+// copyright-holders:m1macrophage
+
+// A collection of sound devices for performing operations on streams. These
+// can naturally be inserted into stream processing pipelines.
+// Useful for emulating circuits that process control or modulation signals in
+// synthesizers, among other things.
+
+#ifndef MAME_SOUND_VA_OPS_H
+#define MAME_SOUND_VA_OPS_H
+
+#pragma once
+
+DECLARE_DEVICE_TYPE(VA_CONST, va_const_device)
+DECLARE_DEVICE_TYPE(VA_SCALE_OFFSET, va_scale_offset_device)
+
+
+// Outputs a constant value to a stream. This is meant for things like
+// firmware-controlled control voltages and other slow-changing signals. This is
+// not meant for audio-rate signals, as there is no attempt at antialiasing.
+class va_const_device : public device_t, public device_sound_interface
+{
+public:
+	va_const_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0) ATTR_COLD;
+
+	va_const_device &set_value(float value);
+
+protected:
+	void device_start() override ATTR_COLD;
+	void sound_stream_update(sound_stream &stream) override;
+
+private:
+	sound_stream *m_stream;
+	float m_value;
+};
+
+
+// Scales and offsets the input stream. Useful for emulating certain op-amp and
+// resistor network circuits.
+class va_scale_offset_device :  public device_t, public device_sound_interface
+{
+public:
+	va_scale_offset_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0) ATTR_COLD;
+
+	va_scale_offset_device &set_scale(float scale);
+	va_scale_offset_device &set_offset(float offset);
+
+protected:
+	void device_start() override ATTR_COLD;
+	void sound_stream_update(sound_stream &stream) override;
+
+private:
+	sound_stream *m_stream;
+	float m_scale;
+	float m_offset;
+};
+
+
+#endif  // MAME_SOUND_VA_OPS_H


### PR DESCRIPTION
sound/va_eg.cpp:
* Added CEM3310 implementation.

sound/va_ops.cpp:
* Added device for converting a constant (e.g. control voltages) to a stream, for processing by subsequent stream processing devices.
* Added device for scaling and offseting a signal, for modeling certain op-amp and resistor network circuits.

These are verified on the prophet5 implementation. Submitting as separate PR to keep the size manageable, and since the prophet5 changes build off of a pending PR (#14895)