### PR TITLE
namcos12: Fix display range alignment for tektagt

### DIFF
--- a/src/devices/video/psx.h
+++ b/src/devices/video/psx.h
@@ -29,6 +29,7 @@ public:
 	// configuration helpers
 	auto vblank_callback() { return m_vblank_handler.bind(); }
 	int vram_size() { return vramSize; }
+	void set_native_display_range(bool native) { m_native_display_range = native; }
 
 	void write(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	uint32_t read(offs_t offset, uint32_t mem_mask = ~0);
@@ -257,6 +258,7 @@ private:
 	uint32_t n_screenheight;
 	bool m_draw_stp;
 	bool m_check_stp;
+	bool m_native_display_range;
 
 	PACKET m_packet;
 

--- a/src/mame/namco/namcos12.cpp
+++ b/src/mame/namco/namcos12.cpp
@@ -1115,6 +1115,7 @@ public:
 
 		/* video hardware */
 		CXD8654Q(config, m_gpu, 53.693175_MHz_XTAL, 0x200000, m_maincpu.target()).set_screen("screen"); // 2x KM4132G271Qs
+		m_gpu->set_native_display_range(true);
 
 		namcos12_base(config);
 	}
@@ -1138,6 +1139,7 @@ public:
 
 		/* video hardware */
 		CXD8561CQ(config, m_gpu, 53.693175_MHz_XTAL, 0x200000, m_maincpu.target()).set_screen("screen"); // 2x 54V25632As
+		m_gpu->set_native_display_range(true);
 
 		namcos12_base(config);
 


### PR DESCRIPTION
Create native_display_range mode for System 12. This fixes health bar clipping.

---

How it currently appears in MAME 0.285. Notice the overscan on the right:
<img width="640" height="480" alt="0008" src="https://github.com/user-attachments/assets/5bdb0472-d418-4c57-b3de-c22585e772a2" />
<img width="640" height="480" alt="0009" src="https://github.com/user-attachments/assets/65f43f70-f67d-464a-99f2-e54507ebef77" />

With this PR's changes, the health bars align much better:
<img width="640" height="480" alt="0012" src="https://github.com/user-attachments/assets/e6d312af-3f92-4e25-ab32-440f3cfc73ba" />
<img width="640" height="480" alt="0013" src="https://github.com/user-attachments/assets/2f00270a-fc70-4ddb-8130-b507ad3db1dc" />

---

As a side note, Tekken 3 renders the same. Likely safe to apply across System 12.
MAME 0.285:
<img width="640" height="480" alt="0004" src="https://github.com/user-attachments/assets/0a45b66e-6934-4fbb-8d46-22205189dc55" />
<img width="640" height="480" alt="0003" src="https://github.com/user-attachments/assets/a75e3826-8917-4e6c-ba0f-9d344339ba4b" />

And this PR:
<img width="640" height="480" alt="0000" src="https://github.com/user-attachments/assets/d376f08c-a2d0-4b62-828c-faf672954201" />
<img width="640" height="480" alt="0001" src="https://github.com/user-attachments/assets/613b6340-bd30-4c0b-aeb0-3ca7669700ca" />
