### PR TITLE
tlcs900: Implement EI/RETI interrupt acceptance shadow

### DIFF
--- a/src/devices/cpu/tlcs900/900tbl.hxx
+++ b/src/devices/cpu/tlcs900/900tbl.hxx
@@ -2074,6 +2074,7 @@ void tlcs900_device::op_EI()
 {
 	m_sr.b.h = ( m_sr.b.h & 0x8f ) | ( ( m_imm1.b.l & 0x07 ) << 4 );
 	m_check_irqs = 1;
+	m_irq_inhibit = true;  /* defer interrupt acceptance by 1 instruction */
 }
 
 
@@ -3040,6 +3041,7 @@ void tlcs900_device::op_RETI()
 	m_xssp.d += 4;
 	m_regbank = m_sr.b.h & 0x03;
 	m_check_irqs = 1;
+	m_irq_inhibit = true;  /* defer interrupt acceptance by 1 instruction */
 	m_prefetch_clear = true;
 }
 

--- a/src/devices/cpu/tlcs900/tlcs900.h
+++ b/src/devices/cpu/tlcs900/tlcs900.h
@@ -108,6 +108,7 @@ protected:
 	uint8_t   m_timer_8[6];
 	int     m_timer_change[8];
 	bool    m_prefetch_clear;
+	bool    m_irq_inhibit;  /* interrupt shadow after EI/RETI - defer IRQ acceptance by 1 instruction */
 	uint8_t   m_prefetch_index;
 	uint8_t   m_prefetch[4];
 


### PR DESCRIPTION
## Summary

- After EI or RETI, defer interrupt acceptance by one instruction to match real TLCS-900 hardware behaviour
- Add `m_irq_inhibit` flag to the CPU state, saved/restored across snapshots
- This is the 2nd in a series of 5 planned PRs to get the interactive GUI elements and the Control Panel (HLE via serial) portion of the Technics KN5000 driver to a working state. (The 1st one was PR #14970)

## Problem

On real TLCS-900 hardware, the instruction immediately following EI or RETI is
guaranteed to execute before any interrupt is accepted. The emulator was checking
interrupts immediately, causing level-triggered IRQs to re-dispatch before the
return-address instruction could run.

This manifests in the Technics KN5000 (TMP94C241) where firmware uses
`EI 0; NOP; EI 6` sequences to briefly mask interrupts — the interrupt fires
again on the NOP instead of waiting for the EI 6.

## Reference

Toshiba TMP94C241F Data Sheet, Section 2.6.5 "Interrupt Processing": "After the EI
or RETI instruction, the next instruction is always executed before any interrupt
is accepted."

## Changed files

- `src/devices/cpu/tlcs900/900tbl.hxx` — set `m_irq_inhibit` in `op_EI()` and `op_RETI()`
- `src/devices/cpu/tlcs900/tlcs900.cpp` — init/reset flag, defer IRQ check in `execute_run()`
- `src/devices/cpu/tlcs900/tlcs900.h` — declare `m_irq_inhibit` member