### PR TITLE
multiple synth layouts: rotating knob pointers and click states.

### DIFF
--- a/src/mame/layout/linn_linndrum.lay
+++ b/src/mame/layout/linn_linndrum.lay
@@ -648,7 +648,7 @@ copyright-holders:m1macrophage
 		-----------------------------------------------------------------------
 		-- Slider and knob library starts.
 		-- Can be copied as-is to other layouts.
-		-- version: 10
+		-- version: 11
 		-----------------------------------------------------------------------
 
 		-- Global configuration. Can be overwritten in the resolve_tags callback.
@@ -680,6 +680,7 @@ copyright-holders:m1macrophage
 		-- `dot_id` is optional. If not nil, this script will take control of the
 		-- element's position as the knob rotates. The distance of the dot from
 		-- the center of `clickarea` will be preserved during rotation.
+		-- It is suggested you place the dot at the top-center of the knob.
 		function add_knob(view, clickarea_id, port_name, scale, drag_direction, dot_id)
 			table.insert(widgets, {
 				clickarea     = get_layout_item(view, clickarea_id),
@@ -687,7 +688,7 @@ copyright-holders:m1macrophage
 				is_knob       = true,
 				scale         = scale,
 				is_horizontal = (drag_direction == HORIZONTAL),
-				knob_dot      = get_layout_item(view, dot_id) })
+				knob_dot      = dot_id and get_layout_item(view, dot_id) })
 		end
 
 		function get_layout_item(view, item_id)
@@ -902,4 +903,3 @@ copyright-holders:m1macrophage
 		-----------------------------------------------------------------------
 	]]></script>
 </mamelayout>
-

--- a/src/mame/layout/oberheim_dmx.lay
+++ b/src/mame/layout/oberheim_dmx.lay
@@ -84,7 +84,10 @@ copyright-holders:m1macrophage
 	</element>
 
 	<element name="trimmer-knob">
-		<rect><color red="0.65" green="0.65" blue="0.65"/></rect>
+		<rect>
+			<color state="0" red="0.65" green="0.65" blue="0.65"/>
+			<color state="1" red="0.85" green="0.85" blue="0.85"/>
+		</rect>
 	</element>
 
 	<element name="trimmer-rail">
@@ -108,7 +111,8 @@ copyright-holders:m1macrophage
 	<element name="fader-knob">
 		<rect>
 			<bounds x="0" y="0" width="35" height="35"/>
-			<color red="0.27" green="0.31" blue="0.29"/>
+			<color state="0" red="0.27" green="0.31" blue="0.29"/>
+			<color state="1" red="0.42" green="0.46" blue="0.44"/>
 		</rect>
 		<rect>
 			<bounds x="1" y="16" width="33" height="3"/>
@@ -557,12 +561,12 @@ copyright-holders:m1macrophage
 
 				-- Configure volume faders.
 				for i = 1, 10 do
-					add_vertical_slider(view, "fader_" .. i, "fader_knob_" .. i, "fader_p" .. i)
+					add_slider(view, "fader_" .. i, "fader_knob_" .. i, "fader_p" .. i)
 				end
 
 				-- Configure tuning trimmers.
 				for i = 1, 8 do
-					add_vertical_slider(view, "trimmer_" .. i, "trimmer_knob_" .. i, "pitch_adj_" .. i)
+					add_slider(view, "trimmer_" .. i, "trimmer_knob_" .. i, "pitch_adj_" .. i)
 				end
 
 				view.items["warning"]:set_state(0)
@@ -571,14 +575,24 @@ copyright-holders:m1macrophage
 		-----------------------------------------------------------------------
 		-- Slider and knob library starts.
 		-- Can be copied as-is to other layouts.
+		-- version: 11
 		-----------------------------------------------------------------------
+
+		-- Global configuration. Can be overwritten in the resolve_tags callback.
+		KNOB_DOT_ANGLE_SPAN = 150  -- -/+ 150 degrees from top center.
+		UPDATE_CLICK_STATE = true
+
+		-- Constants.
+		VERTICAL = 0
+		HORIZONTAL = 1
+
 		local widgets = {}   -- Stores slider and knob information.
 		local pointers = {}  -- Tracks pointer state.
 
 		-- The knob's Y position must be animated using <animate inputtag="{port_name}">.
 		-- The click area's vertical size must exactly span the range of the
 		-- knob's movement.
-		function add_vertical_slider(view, clickarea_id, knob_id, port_name)
+		function add_slider(view, clickarea_id, knob_id, port_name)
 			table.insert(widgets, {
 				clickarea   = get_layout_item(view, clickarea_id),
 				slider_knob = get_layout_item(view, knob_id),
@@ -587,13 +601,21 @@ copyright-holders:m1macrophage
 		end
 
 		-- A sweep between the attached field's min and max values requires
-		-- moving the pointer by `scale * clickarea.height` pixes.
-		function add_simplecounter_knob(view, clickarea_id, port_name, scale)
+		-- moving the pointer by `scale * clickarea.height` pixels, when drag
+		-- direction is VERTICAL. Replace `height` with `width` when HORIZONTAL.
+		--
+		-- `dot_id` is optional. If not nil, this script will take control of the
+		-- element's position as the knob rotates. The distance of the dot from
+		-- the center of `clickarea` will be preserved during rotation.
+		-- It is suggested you place the dot at the top-center of the knob.
+		function add_knob(view, clickarea_id, port_name, scale, drag_direction, dot_id)
 			table.insert(widgets, {
-				clickarea = get_layout_item(view, clickarea_id),
-				field     = get_port_field(port_name),
-				is_knob   = true,
-				scale     = scale })
+				clickarea     = get_layout_item(view, clickarea_id),
+				field         = get_port_field(port_name),
+				is_knob       = true,
+				scale         = scale,
+				is_horizontal = (drag_direction == HORIZONTAL),
+				knob_dot      = dot_id and get_layout_item(view, dot_id) })
 		end
 
 		function get_layout_item(view, item_id)
@@ -615,17 +637,44 @@ copyright-holders:m1macrophage
 				field = val
 				break
 			end
+			local field_msg = "Needs to either be an IPT_ADJUSTER, or an analog port with auto-center."
 			if field == nil then
-				emu.print_error("Port: '" .. port_name .."' does not seem to be an IPT_ADJUSTER.")
+				emu.print_error("Port '" .. port_name .."' " .. field_msg)
+				return nil
+			end
+			if field.is_analog and (not field.centerdelta or field.centerdelta == 0) then
+				emu.print_error("Port '" .. port_name .."' " .. field_msg)
 				return nil
 			end
 			return field
 		end
 
+		local function set_click_state(widget, state)
+			if UPDATE_CLICK_STATE then
+				if widget.is_knob then
+					widget.clickarea:set_state(state)
+				else
+					widget.slider_knob:set_state(state)
+				end
+			end
+		end
+
+		local function release_pointer(pointer_id)
+			if pointers[pointer_id] then
+				local widget = widgets[pointers[pointer_id].selected_widget]
+				set_click_state(widget, 0)
+				local field = widget.field
+				if field.is_analog then
+					field:clear_value()
+				end
+			end
+			pointers[pointer_id] = nil
+		end
+
 		local function pointer_updated(type, id, dev, x, y, btn, dn, up, cnt)
 			-- If a button is not pressed, reset the state of the current pointer.
 			if btn & 1 == 0 then
-				pointers[id] = nil
+				release_pointer(id)
 				return
 			end
 
@@ -641,11 +690,13 @@ copyright-holders:m1macrophage
 						relative = false
 					end
 					if found then
+						set_click_state(widgets[i], 1)
 						pointers[id] = {
 							selected_widget = i,
 							relative = relative,
+							start_x = x,
 							start_y = y,
-							start_value = widgets[i].field.user_value }
+							start_value = widgets[i].field.port:read() }
 						break
 					end
 				end
@@ -656,8 +707,7 @@ copyright-holders:m1macrophage
 				return
 			end
 
-			-- A widget is selected. Update its state based on the pointer's Y
-			-- position. It is assumed the attached IO field is an IPT_ADJUSTER.
+			-- A widget is selected. Update its state based on the pointer's position.
 
 			local pointer = pointers[id]
 			local widget = widgets[pointer.selected_widget]
@@ -668,8 +718,13 @@ copyright-holders:m1macrophage
 
 			local new_value
 			if widget.is_knob then
-				local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
-				new_value = pointer.start_value + (pointer.start_y - y) * step_y
+				if widget.is_horizontal then
+					local step_x = value_range / (widget.scale * widget.clickarea.bounds.width)
+					new_value = pointer.start_value + (x - pointer.start_x) * step_x
+				else
+					local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
+					new_value = pointer.start_value + (pointer.start_y - y) * step_y
+				end
 			else
 				local knob_half_height = widget.slider_knob.bounds.height / 2
 				local min_y = widget.clickarea.bounds.y0 + knob_half_height
@@ -689,22 +744,82 @@ copyright-holders:m1macrophage
 			new_value = math.floor(new_value + 0.5)
 			if new_value < min_value then new_value = min_value end
 			if new_value > max_value then new_value = max_value end
-			widget.field.user_value = new_value
+
+			if widget.field.is_analog then
+				widget.field:set_value(new_value)
+			else
+				widget.field.user_value = new_value
+			end
+		end
+
+		local function get_knob_dot_bounds(widget)
+			local dot = widget.knob_dot_cache
+			local value = (widget.field.port:read() - dot.value_min) / dot.value_range
+			local angle = dot.angle_min + value * dot.angle_range
+			local rx = -dot.center_y * math.sin(angle) * dot.aspect
+			local ry = dot.center_y * math.cos(angle)
+			local x = rx + dot.dx
+			local y = ry + dot.dy
+			return emu.render_bounds(x, y, x + dot.width, y + dot.height)
+		end
+
+		local function configure_knob_dots()
+			for i = 1, #widgets do
+				local dot = widgets[i].knob_dot
+				if dot then
+					-- Remove bounds callback, since we need to access the
+					-- configured bounds.
+					dot:set_bounds_callback(nil)
+
+					local field = widgets[i].field
+					local knob_bounds = widgets[i].clickarea.bounds
+					local dot_bounds = dot.bounds
+					local max_angle = KNOB_DOT_ANGLE_SPAN * 2.0 * math.pi / 360.0
+
+					-- Compute the distance of the knob dot from the knob center.
+					local dot_x = dot_bounds.x0 + dot_bounds.width / 2.0
+					local dot_y = dot_bounds.y0 + dot_bounds.height / 2.0
+					local knob_x = knob_bounds.x0 + knob_bounds.width / 2.0
+					local knob_y = knob_bounds.y0 + knob_bounds.height / 2.0
+					local radius = math.sqrt((dot_y - knob_y) ^ 2 + (dot_x - knob_x) ^ 2)
+
+					widgets[i].knob_dot_cache = {
+						width       = dot_bounds.width,
+						height      = dot_bounds.height,
+						aspect      = dot_bounds.aspect,
+						value_min   = field.minvalue,
+						value_range = field.maxvalue - field.minvalue,
+						angle_min   = -max_angle,
+						angle_range = 2.0 * max_angle,
+						center_y    = -radius,
+						dx = knob_bounds.x0 + (knob_bounds.width - dot_bounds.width) / 2.0,
+						dy = knob_bounds.y0 + (knob_bounds.height - dot_bounds.height) / 2.0 }
+
+					dot:set_bounds_callback(
+						function()
+							return get_knob_dot_bounds(widgets[i])
+						end)
+				end
+			end
 		end
 
 		local function pointer_left(type, id, dev, x, y, up, cnt)
-			pointers[id] = nil
+			release_pointer(id)
 		end
 
 		local function pointer_aborted(type, id, dev, x, y, up, cnt)
-			pointers[id] = nil
+			release_pointer(id)
 		end
 
 		local function forget_pointers()
+			for id, pointer in pairs(pointers) do
+				release_pointer(id)
+			end
 			pointers = {}
 		end
 
 		function install_slider_callbacks(view)
+			view:set_recomputed_callback(configure_knob_dots)
 			view:set_pointer_updated_callback(pointer_updated)
 			view:set_pointer_left_callback(pointer_left)
 			view:set_pointer_aborted_callback(pointer_aborted)
@@ -715,4 +830,3 @@ copyright-holders:m1macrophage
 		-----------------------------------------------------------------------
 	]]></script>
 </mamelayout>
-

--- a/src/mame/layout/paia_fatman.lay
+++ b/src/mame/layout/paia_fatman.lay
@@ -189,13 +189,9 @@ copyright-holders:m1macrophage
 			<color red="0.820" green="0.859" blue="0.827"/>
 		</simplecounter>
 	</element>
-	<element name="knob">
+	<element name="knob_background">
 		<!-- Set knob element bounds. -->
 		<rect><color red="0" green="0" blue="0" alpha="0"/><bounds width="178" height="109"/></rect>
-		<!-- Outer knob. -->
-		<disk><color red="0.239" green="0.231" blue="0.227"/><bounds x="52" y="24" width="72" height="72"/></disk>
-		<!-- Inner knob. -->
-		<disk><color red="0.0" green="0.090" blue="0.322"/><bounds x="61" y="33" width="54" height="54"/></disk>
 		<!-- Indicator circles around the knob. -->
 		<disk><color red="0.820" green="0.859" blue="0.827"/><bounds x="45" y="93" width="8" height="8"/></disk>
 		<disk><color red="0.820" green="0.859" blue="0.827"/><bounds x="29" y="54" width="9" height="9"/></disk>
@@ -205,11 +201,39 @@ copyright-holders:m1macrophage
 		<disk><color red="0.820" green="0.859" blue="0.827"/><bounds x="135" y="53" width="13" height="13"/></disk>
 		<disk><color red="0.820" green="0.859" blue="0.827"/><bounds x="119" y="90" width="14" height="14"/></disk>
 	</element>
-	<group name="knob-min-max">
+	<element name="knob_circle">
+		<!-- Outer knob. -->
+		<disk>
+			<color red="0.239" green="0.231" blue="0.227"/>
+			<bounds x="0" y="0" width="1" height="1"/>
+		</disk>
+		<!-- Inner knob. -->
+		<disk>
+			<color state="0" red="0.0" green="0.090" blue="0.322"/>
+			<color state="1" red="0.0" green="0.15" blue="0.45"/>
+			<bounds x="0.125" y="0.125" width="0.75" height="0.75"/>
+		</disk>
+	</element>
+	<element name="knob_dot">
+		<disk>
+			<color state="0" red="0" green="0" blue="0" alpha="0"/>
+			<color state="1" red="0.820" green="0.859" blue="0.827"/>
+		</disk>
+	</element>
+	<group name="knob">
 		<bounds width="178" height="109"/>
-		<element ref="knob">
+		<element ref="knob_background">
 			<bounds x="0" y="0" width="178" height="109"/>
 		</element>
+		<element ref="knob_circle">
+			<bounds x="52" y="24" width="72" height="72"/>
+		</element>
+	</group>
+	<group name="knob-min-max">
+		<bounds width="178" height="109"/>
+		<group ref="knob">
+			<bounds x="0" y="0" width="178" height="109"/>
+		</group>
 		<element ref="text-min">
 			<bounds x="0" y="94" width="40" height="15"/>
 		</element>
@@ -219,8 +243,14 @@ copyright-holders:m1macrophage
 	</group>
 	<group name="knob-fast-slow">
 		<bounds width="178" height="109"/>
-		<element ref="knob">
+		<element ref="knob_background">
 			<bounds x="0" y="0" width="178" height="109"/>
+		</element>
+		<element ref="knob_circle" id="~knob_id~">
+			<bounds x="52" y="24" width="72" height="72"/>
+		</element>
+		<element ref="knob_dot" id="~knob_id~_dot">
+			<bounds x="84" y="26" width="10" height="10"/>
 		</element>
 		<element ref="text-fast">
 			<bounds x="0" y="94" width="40" height="15"/>
@@ -231,7 +261,7 @@ copyright-holders:m1macrophage
 		<element ref="knob-value" inputraw="yes" inputtag="~knob_id~" inputmask="0xffff">
 			<bounds x="68" y="52" width="40" height="16"/>
 		</element>
-		<element ref="transparent-rect" clickthrough="no" id="~knob_id~">
+		<element ref="transparent-rect" clickthrough="no">
 			<!-- Disable clicks on the `simplecounter` above, because they
 			change the value in an unintuitive way. -->
 			<bounds x="61" y="33" width="54" height="54"/>
@@ -334,11 +364,11 @@ copyright-holders:m1macrophage
 		<element ref="text-minus-half"><bounds x="89" y="268" width="40" height="15"/></element>
 		<element ref="text-minus-one"><bounds x="89" y="536" width="40" height="15"/></element>
 		<element ref="text-vco1"><bounds x="89" y="671" width="40" height="15"/></element>
-		<element ref="knob"><bounds x="89" y="174" width="178" height="109"/></element>
+		<group ref="knob"><bounds x="89" y="174" width="178" height="109"/></group>
 		<group ref="knob-min-max"><bounds x="89" y="309" width="178" height="109"/></group>
-		<element ref="knob"><bounds x="89" y="442" width="178" height="109"/></element>
+		<group ref="knob"><bounds x="89" y="442" width="178" height="109"/></group>
 		<element ref="text-unison"><bounds x="89" y="441" width="178" height="14"/></element>
-		<element ref="knob"><bounds x="89" y="577" width="178" height="109"/></element>
+		<group ref="knob"><bounds x="89" y="577" width="178" height="109"/></group>
 		<element ref="text-both"><bounds x="89" y="576" width="178" height="14"/></element>
 		<element ref="text-plus-half"><bounds x="227" y="268" width="40" height="15"/></element>
 		<element ref="text-plus-one"><bounds x="227" y="536" width="40" height="15"/></element>
@@ -420,7 +450,8 @@ copyright-holders:m1macrophage
 
 				local knobs = {"VCF_attack", "VCF_release", "VCA_attack", "VCA_decay", "VCA_sustain", "VCA_release"}
 				for i, knob_id in ipairs(knobs) do
-					add_simplecounter_knob(view, knob_id, knob_id, 1.5)
+					add_knob(view, knob_id, knob_id, 1.5, VERTICAl, knob_id .. "_dot")
+					get_layout_item(view, knob_id .. "_dot"):set_state(1)
 				end
 
 				view.items["warning"]:set_state(0)
@@ -429,14 +460,24 @@ copyright-holders:m1macrophage
 		-----------------------------------------------------------------------
 		-- Slider and knob library starts.
 		-- Can be copied as-is to other layouts.
+		-- version: 11
 		-----------------------------------------------------------------------
+
+		-- Global configuration. Can be overwritten in the resolve_tags callback.
+		KNOB_DOT_ANGLE_SPAN = 150  -- -/+ 150 degrees from top center.
+		UPDATE_CLICK_STATE = true
+
+		-- Constants.
+		VERTICAL = 0
+		HORIZONTAL = 1
+
 		local widgets = {}   -- Stores slider and knob information.
 		local pointers = {}  -- Tracks pointer state.
 
 		-- The knob's Y position must be animated using <animate inputtag="{port_name}">.
 		-- The click area's vertical size must exactly span the range of the
 		-- knob's movement.
-		function add_vertical_slider(view, clickarea_id, knob_id, port_name)
+		function add_slider(view, clickarea_id, knob_id, port_name)
 			table.insert(widgets, {
 				clickarea   = get_layout_item(view, clickarea_id),
 				slider_knob = get_layout_item(view, knob_id),
@@ -445,13 +486,21 @@ copyright-holders:m1macrophage
 		end
 
 		-- A sweep between the attached field's min and max values requires
-		-- moving the pointer by `scale * clickarea.height` pixes.
-		function add_simplecounter_knob(view, clickarea_id, port_name, scale)
+		-- moving the pointer by `scale * clickarea.height` pixels, when drag
+		-- direction is VERTICAL. Replace `height` with `width` when HORIZONTAL.
+		--
+		-- `dot_id` is optional. If not nil, this script will take control of the
+		-- element's position as the knob rotates. The distance of the dot from
+		-- the center of `clickarea` will be preserved during rotation.
+		-- It is suggested you place the dot at the top-center of the knob.
+		function add_knob(view, clickarea_id, port_name, scale, drag_direction, dot_id)
 			table.insert(widgets, {
-				clickarea = get_layout_item(view, clickarea_id),
-				field     = get_port_field(port_name),
-				is_knob   = true,
-				scale     = scale })
+				clickarea     = get_layout_item(view, clickarea_id),
+				field         = get_port_field(port_name),
+				is_knob       = true,
+				scale         = scale,
+				is_horizontal = (drag_direction == HORIZONTAL),
+				knob_dot      = dot_id and get_layout_item(view, dot_id) })
 		end
 
 		function get_layout_item(view, item_id)
@@ -473,17 +522,44 @@ copyright-holders:m1macrophage
 				field = val
 				break
 			end
+			local field_msg = "Needs to either be an IPT_ADJUSTER, or an analog port with auto-center."
 			if field == nil then
-				emu.print_error("Port: '" .. port_name .."' does not seem to be an IPT_ADJUSTER.")
+				emu.print_error("Port '" .. port_name .."' " .. field_msg)
+				return nil
+			end
+			if field.is_analog and (not field.centerdelta or field.centerdelta == 0) then
+				emu.print_error("Port '" .. port_name .."' " .. field_msg)
 				return nil
 			end
 			return field
 		end
 
+		local function set_click_state(widget, state)
+			if UPDATE_CLICK_STATE then
+				if widget.is_knob then
+					widget.clickarea:set_state(state)
+				else
+					widget.slider_knob:set_state(state)
+				end
+			end
+		end
+
+		local function release_pointer(pointer_id)
+			if pointers[pointer_id] then
+				local widget = widgets[pointers[pointer_id].selected_widget]
+				set_click_state(widget, 0)
+				local field = widget.field
+				if field.is_analog then
+					field:clear_value()
+				end
+			end
+			pointers[pointer_id] = nil
+		end
+
 		local function pointer_updated(type, id, dev, x, y, btn, dn, up, cnt)
 			-- If a button is not pressed, reset the state of the current pointer.
 			if btn & 1 == 0 then
-				pointers[id] = nil
+				release_pointer(id)
 				return
 			end
 
@@ -499,11 +575,13 @@ copyright-holders:m1macrophage
 						relative = false
 					end
 					if found then
+						set_click_state(widgets[i], 1)
 						pointers[id] = {
 							selected_widget = i,
 							relative = relative,
+							start_x = x,
 							start_y = y,
-							start_value = widgets[i].field.user_value }
+							start_value = widgets[i].field.port:read() }
 						break
 					end
 				end
@@ -514,8 +592,7 @@ copyright-holders:m1macrophage
 				return
 			end
 
-			-- A widget is selected. Update its state based on the pointer's Y
-			-- position. It is assumed the attached IO field is an IPT_ADJUSTER.
+			-- A widget is selected. Update its state based on the pointer's position.
 
 			local pointer = pointers[id]
 			local widget = widgets[pointer.selected_widget]
@@ -526,8 +603,13 @@ copyright-holders:m1macrophage
 
 			local new_value
 			if widget.is_knob then
-				local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
-				new_value = pointer.start_value + (pointer.start_y - y) * step_y
+				if widget.is_horizontal then
+					local step_x = value_range / (widget.scale * widget.clickarea.bounds.width)
+					new_value = pointer.start_value + (x - pointer.start_x) * step_x
+				else
+					local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
+					new_value = pointer.start_value + (pointer.start_y - y) * step_y
+				end
 			else
 				local knob_half_height = widget.slider_knob.bounds.height / 2
 				local min_y = widget.clickarea.bounds.y0 + knob_half_height
@@ -547,22 +629,82 @@ copyright-holders:m1macrophage
 			new_value = math.floor(new_value + 0.5)
 			if new_value < min_value then new_value = min_value end
 			if new_value > max_value then new_value = max_value end
-			widget.field.user_value = new_value
+
+			if widget.field.is_analog then
+				widget.field:set_value(new_value)
+			else
+				widget.field.user_value = new_value
+			end
+		end
+
+		local function get_knob_dot_bounds(widget)
+			local dot = widget.knob_dot_cache
+			local value = (widget.field.port:read() - dot.value_min) / dot.value_range
+			local angle = dot.angle_min + value * dot.angle_range
+			local rx = -dot.center_y * math.sin(angle) * dot.aspect
+			local ry = dot.center_y * math.cos(angle)
+			local x = rx + dot.dx
+			local y = ry + dot.dy
+			return emu.render_bounds(x, y, x + dot.width, y + dot.height)
+		end
+
+		local function configure_knob_dots()
+			for i = 1, #widgets do
+				local dot = widgets[i].knob_dot
+				if dot then
+					-- Remove bounds callback, since we need to access the
+					-- configured bounds.
+					dot:set_bounds_callback(nil)
+
+					local field = widgets[i].field
+					local knob_bounds = widgets[i].clickarea.bounds
+					local dot_bounds = dot.bounds
+					local max_angle = KNOB_DOT_ANGLE_SPAN * 2.0 * math.pi / 360.0
+
+					-- Compute the distance of the knob dot from the knob center.
+					local dot_x = dot_bounds.x0 + dot_bounds.width / 2.0
+					local dot_y = dot_bounds.y0 + dot_bounds.height / 2.0
+					local knob_x = knob_bounds.x0 + knob_bounds.width / 2.0
+					local knob_y = knob_bounds.y0 + knob_bounds.height / 2.0
+					local radius = math.sqrt((dot_y - knob_y) ^ 2 + (dot_x - knob_x) ^ 2)
+
+					widgets[i].knob_dot_cache = {
+						width       = dot_bounds.width,
+						height      = dot_bounds.height,
+						aspect      = dot_bounds.aspect,
+						value_min   = field.minvalue,
+						value_range = field.maxvalue - field.minvalue,
+						angle_min   = -max_angle,
+						angle_range = 2.0 * max_angle,
+						center_y    = -radius,
+						dx = knob_bounds.x0 + (knob_bounds.width - dot_bounds.width) / 2.0,
+						dy = knob_bounds.y0 + (knob_bounds.height - dot_bounds.height) / 2.0 }
+
+					dot:set_bounds_callback(
+						function()
+							return get_knob_dot_bounds(widgets[i])
+						end)
+				end
+			end
 		end
 
 		local function pointer_left(type, id, dev, x, y, up, cnt)
-			pointers[id] = nil
+			release_pointer(id)
 		end
 
 		local function pointer_aborted(type, id, dev, x, y, up, cnt)
-			pointers[id] = nil
+			release_pointer(id)
 		end
 
 		local function forget_pointers()
+			for id, pointer in pairs(pointers) do
+				release_pointer(id)
+			end
 			pointers = {}
 		end
 
 		function install_slider_callbacks(view)
+			view:set_recomputed_callback(configure_knob_dots)
 			view:set_pointer_updated_callback(pointer_updated)
 			view:set_pointer_left_callback(pointer_left)
 			view:set_pointer_aborted_callback(pointer_aborted)
@@ -573,4 +715,3 @@ copyright-holders:m1macrophage
 		-----------------------------------------------------------------------
 	]]></script>
 </mamelayout>
-

--- a/src/mame/layout/pg1000.lay
+++ b/src/mame/layout/pg1000.lay
@@ -765,15 +765,15 @@ license:CC0-1.0
 					install_slider_callbacks(view)
 
 					for i = 0, 12 do
-						add_vertical_slider(view, "top_slider_" .. i, "knob_top_slider_" .. i, "top_slider_" .. i)
+						add_slider(view, "top_slider_" .. i, "knob_top_slider_" .. i, "top_slider_" .. i)
 					end
 
 					for i = 0, 22 do
-						add_vertical_slider(view, "middle_slider_" .. i, "knob_middle_slider_" .. i, "middle_slider_" .. i)
+						add_slider(view, "middle_slider_" .. i, "knob_middle_slider_" .. i, "middle_slider_" .. i)
 					end
 
 					for i = 0, 19 do
-						add_vertical_slider(view, "bottom_slider_" .. i, "knob_bottom_slider_" .. i, "bottom_slider_" .. i)
+						add_slider(view, "bottom_slider_" .. i, "knob_bottom_slider_" .. i, "bottom_slider_" .. i)
 					end
 
 					-- TODO: Display a warning about how to enable sliders
@@ -782,137 +782,260 @@ license:CC0-1.0
 			end)
 
 		-----------------------------------------------------------------------
-		-- Slider library starts.
+		-- Slider and knob library starts.
 		-- Can be copied as-is to other layouts.
+		-- version: 11
 		-----------------------------------------------------------------------
-		local sliders = {}   -- Stores slider information.
+
+		-- Global configuration. Can be overwritten in the resolve_tags callback.
+		KNOB_DOT_ANGLE_SPAN = 150  -- -/+ 150 degrees from top center.
+		UPDATE_CLICK_STATE = true
+
+		-- Constants.
+		VERTICAL = 0
+		HORIZONTAL = 1
+
+		local widgets = {}   -- Stores slider and knob information.
 		local pointers = {}  -- Tracks pointer state.
 
 		-- The knob's Y position must be animated using <animate inputtag="{port_name}">.
 		-- The click area's vertical size must exactly span the range of the
 		-- knob's movement.
-		function add_vertical_slider(view, clickarea_id, knob_id, port_name)
-			local slider = {}
+		function add_slider(view, clickarea_id, knob_id, port_name)
+			table.insert(widgets, {
+				clickarea   = get_layout_item(view, clickarea_id),
+				slider_knob = get_layout_item(view, knob_id),
+				field       = get_port_field(port_name),
+				is_knob     = false })
+		end
 
-			slider.clickarea = view.items[clickarea_id]
-			if slider.clickarea == nil then
-				emu.print_error("Slider element: '" .. clickarea_id .. "' not found.")
-				return
+		-- A sweep between the attached field's min and max values requires
+		-- moving the pointer by `scale * clickarea.height` pixels, when drag
+		-- direction is VERTICAL. Replace `height` with `width` when HORIZONTAL.
+		--
+		-- `dot_id` is optional. If not nil, this script will take control of the
+		-- element's position as the knob rotates. The distance of the dot from
+		-- the center of `clickarea` will be preserved during rotation.
+		-- It is suggested you place the dot at the top-center of the knob.
+		function add_knob(view, clickarea_id, port_name, scale, drag_direction, dot_id)
+			table.insert(widgets, {
+				clickarea     = get_layout_item(view, clickarea_id),
+				field         = get_port_field(port_name),
+				is_knob       = true,
+				scale         = scale,
+				is_horizontal = (drag_direction == HORIZONTAL),
+				knob_dot      = dot_id and get_layout_item(view, dot_id) })
+		end
+
+		function get_layout_item(view, item_id)
+			local item = view.items[item_id]
+			if item == nil then
+				emu.print_error("Layout element: '" .. item_id .. "' not found.")
 			end
+			return item
+		end
 
-			slider.knob = view.items[knob_id]
-			if slider.knob == nil then
-				emu.print_error("Slider knob element: '" .. knob_id .. "' not found.")
-				return
-			end
-
+		function get_port_field(port_name)
 			local port = file.device:ioport(port_name)
 			if port == nil then
 				emu.print_error("Port: '" .. port_name .. "' not found.")
-				return
+				return nil
 			end
-
-			slider.field = nil
+			local field = nil
 			for k, val in pairs(port.fields) do
-				slider.field = val
+				field = val
 				break
 			end
-			if slider.field == nil then
-				emu.print_error("Port: '" .. port_name .."' does not seem to be an IPT_ADJUSTER.")
-				return
+			local field_msg = "Needs to either be an IPT_ADJUSTER, or an analog port with auto-center."
+			if field == nil then
+				emu.print_error("Port '" .. port_name .."' " .. field_msg)
+				return nil
 			end
+			if field.is_analog and (not field.centerdelta or field.centerdelta == 0) then
+				emu.print_error("Port '" .. port_name .."' " .. field_msg)
+				return nil
+			end
+			return field
+		end
 
-			table.insert(sliders, slider)
+		local function set_click_state(widget, state)
+			if UPDATE_CLICK_STATE then
+				if widget.is_knob then
+					widget.clickarea:set_state(state)
+				else
+					widget.slider_knob:set_state(state)
+				end
+			end
+		end
+
+		local function release_pointer(pointer_id)
+			if pointers[pointer_id] then
+				local widget = widgets[pointers[pointer_id].selected_widget]
+				set_click_state(widget, 0)
+				local field = widget.field
+				if field.is_analog then
+					field:clear_value()
+				end
+			end
+			pointers[pointer_id] = nil
 		end
 
 		local function pointer_updated(type, id, dev, x, y, btn, dn, up, cnt)
 			-- If a button is not pressed, reset the state of the current pointer.
 			if btn & 1 == 0 then
-				pointers[id] = nil
-				for i = 1, #sliders do
-					sliders[i].knob:set_state(0)
-				end
+				release_pointer(id)
 				return
 			end
 
-			-- If a button was just pressed, find the affected slider, if any.
+			-- If a button was just pressed, find the affected widget, if any.
 			if dn & 1 ~= 0 then
-				for i = 1, #sliders do
-					if sliders[i].knob.bounds:includes(x, y) then
-						sliders[i].knob:set_state(1)
+				for i = 1, #widgets do
+					local found, relative
+					if widgets[i].slider_knob and widgets[i].slider_knob.bounds:includes(x, y) then
+						found = true
+						relative = true
+					elseif widgets[i].clickarea.bounds:includes(x, y) then
+						found = true
+						relative = false
+					end
+					if found then
+						set_click_state(widgets[i], 1)
 						pointers[id] = {
-							selected_slider = i,
-							relative = true,
+							selected_widget = i,
+							relative = relative,
+							start_x = x,
 							start_y = y,
-							start_value = sliders[i].field.user_value }
-						break
-					elseif sliders[i].clickarea.bounds:includes(x, y) then
-						sliders[i].knob:set_state(1)
-						pointers[id] = {
-							selected_slider = i,
-							relative = false }
+							start_value = widgets[i].field.port:read() }
 						break
 					end
 				end
 			end
 
-			-- If there is no slider selected by the current pointer, we are done.
+			-- If there is no widget selected by the current pointer, we are done.
 			if pointers[id] == nil then
 				return
 			end
 
-			-- A slider is selected. Update state and, indirectly, slider knob position,
-			-- based on the pointer's Y position. It is assumed the attached IO field is
-			-- an IPT_ADJUSTER.
+			-- A widget is selected. Update its state based on the pointer's position.
 
 			local pointer = pointers[id]
-			local slider = sliders[pointer.selected_slider]
+			local widget = widgets[pointer.selected_widget]
 
-			local min_value = slider.field.minvalue
-			local max_value = slider.field.maxvalue
+			local min_value = widget.field.minvalue
+			local max_value = widget.field.maxvalue
 			local value_range = max_value - min_value
 
-			local knob_half_height = slider.knob.bounds.height / 2
-			local min_y = slider.clickarea.bounds.y0 + knob_half_height
-			local max_y = slider.clickarea.bounds.y1 - knob_half_height
-
-			local new_value = 0
-			if pointer.relative then
-				-- User clicked on the knob. The new value will depend on how much the
-				-- knob was dragged.
-				new_value = pointer.start_value - value_range * (y - pointer.start_y) / (max_y - min_y)
+			local new_value
+			if widget.is_knob then
+				if widget.is_horizontal then
+					local step_x = value_range / (widget.scale * widget.clickarea.bounds.width)
+					new_value = pointer.start_value + (x - pointer.start_x) * step_x
+				else
+					local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
+					new_value = pointer.start_value + (pointer.start_y - y) * step_y
+				end
 			else
-				-- User clicked elsewhere on the slider. The new value will depend on
-				-- the absolute position of the click.
-				new_value = max_value - value_range * (y - min_y) / (max_y - min_y)
+				local knob_half_height = widget.slider_knob.bounds.height / 2
+				local min_y = widget.clickarea.bounds.y0 + knob_half_height
+				local max_y = widget.clickarea.bounds.y1 - knob_half_height
+
+				if pointer.relative then
+					-- User clicked on the knob. The new value will depend on how
+					--  much the knob was dragged.
+					new_value = pointer.start_value - value_range * (y - pointer.start_y) / (max_y - min_y)
+				else
+					-- User clicked elsewhere on the slider. The new value will depend on
+					-- the absolute position of the click.
+					new_value = max_value - value_range * (y - min_y) / (max_y - min_y)
+				end
 			end
 
 			new_value = math.floor(new_value + 0.5)
 			if new_value < min_value then new_value = min_value end
 			if new_value > max_value then new_value = max_value end
-			slider.field.user_value = new_value
+
+			if widget.field.is_analog then
+				widget.field:set_value(new_value)
+			else
+				widget.field.user_value = new_value
+			end
+		end
+
+		local function get_knob_dot_bounds(widget)
+			local dot = widget.knob_dot_cache
+			local value = (widget.field.port:read() - dot.value_min) / dot.value_range
+			local angle = dot.angle_min + value * dot.angle_range
+			local rx = -dot.center_y * math.sin(angle) * dot.aspect
+			local ry = dot.center_y * math.cos(angle)
+			local x = rx + dot.dx
+			local y = ry + dot.dy
+			return emu.render_bounds(x, y, x + dot.width, y + dot.height)
+		end
+
+		local function configure_knob_dots()
+			for i = 1, #widgets do
+				local dot = widgets[i].knob_dot
+				if dot then
+					-- Remove bounds callback, since we need to access the
+					-- configured bounds.
+					dot:set_bounds_callback(nil)
+
+					local field = widgets[i].field
+					local knob_bounds = widgets[i].clickarea.bounds
+					local dot_bounds = dot.bounds
+					local max_angle = KNOB_DOT_ANGLE_SPAN * 2.0 * math.pi / 360.0
+
+					-- Compute the distance of the knob dot from the knob center.
+					local dot_x = dot_bounds.x0 + dot_bounds.width / 2.0
+					local dot_y = dot_bounds.y0 + dot_bounds.height / 2.0
+					local knob_x = knob_bounds.x0 + knob_bounds.width / 2.0
+					local knob_y = knob_bounds.y0 + knob_bounds.height / 2.0
+					local radius = math.sqrt((dot_y - knob_y) ^ 2 + (dot_x - knob_x) ^ 2)
+
+					widgets[i].knob_dot_cache = {
+						width       = dot_bounds.width,
+						height      = dot_bounds.height,
+						aspect      = dot_bounds.aspect,
+						value_min   = field.minvalue,
+						value_range = field.maxvalue - field.minvalue,
+						angle_min   = -max_angle,
+						angle_range = 2.0 * max_angle,
+						center_y    = -radius,
+						dx = knob_bounds.x0 + (knob_bounds.width - dot_bounds.width) / 2.0,
+						dy = knob_bounds.y0 + (knob_bounds.height - dot_bounds.height) / 2.0 }
+
+					dot:set_bounds_callback(
+						function()
+							return get_knob_dot_bounds(widgets[i])
+						end)
+				end
+			end
 		end
 
 		local function pointer_left(type, id, dev, x, y, up, cnt)
-			pointers[id] = nil
+			release_pointer(id)
 		end
 
 		local function pointer_aborted(type, id, dev, x, y, up, cnt)
-			pointers[id] = nil
+			release_pointer(id)
 		end
 
 		local function forget_pointers()
+			for id, pointer in pairs(pointers) do
+				release_pointer(id)
+			end
 			pointers = {}
 		end
 
 		function install_slider_callbacks(view)
+			view:set_recomputed_callback(configure_knob_dots)
 			view:set_pointer_updated_callback(pointer_updated)
 			view:set_pointer_left_callback(pointer_left)
 			view:set_pointer_aborted_callback(pointer_aborted)
 			view:set_forget_pointers_callback(forget_pointers)
 		end
 		-----------------------------------------------------------------------
-		-- Slider library ends.
+		-- Slider and knob library ends.
 		-----------------------------------------------------------------------
 	]]></script>
 

--- a/src/mame/layout/roland_tr707.lay
+++ b/src/mame/layout/roland_tr707.lay
@@ -260,8 +260,16 @@ the visibility and style of elements that differ between the two.
 
 	<element name="sliderwell"><rect><color red="0.20" green="0.21" blue="0.25"/></rect></element>
 	<element name="sliderknob">
-		<rect><bounds x="0" y="0" width="24" height="50"/><color red="0.41" green="0.44" blue="0.47"/></rect>
-		<rect><bounds x="0" y="15" width="24" height="20"/><color red="0.34" green="0.37" blue="0.39"/></rect>
+		<rect>
+			<bounds x="0" y="0" width="24" height="50"/>
+			<color state="0" red="0.41" green="0.44" blue="0.47"/>
+			<color state="1" red="0.61" green="0.64" blue="0.67"/>
+		</rect>
+		<rect>
+			<bounds x="0" y="15" width="24" height="20"/>
+			<color state="0" red="0.34" green="0.37" blue="0.39"/>
+			<color state="1" red="0.51" green="0.54" blue="0.57"/>
+		</rect>
 		<rect><bounds x="0" y="23" width="24" height="4"/><color red="0.83" green="0.83" blue="0.81"/></rect>
 	</element>
 	<group name="slider">
@@ -278,8 +286,16 @@ the visibility and style of elements that differ between the two.
 		<element ref="txt_slider_~slider_i~" name="is727"><bounds x="0" y="222" width="38" height="12"/></element>
 	</group>
 	<element name="mastersliderknob">
-		<rect><bounds x="0" y="0" width="24" height="50"/><color red="0.41" green="0.44" blue="0.47"/></rect>
-		<rect><bounds x="0" y="15" width="24" height="20"/><color red="0.34" green="0.37" blue="0.39"/></rect>
+		<rect>
+			<bounds x="0" y="0" width="24" height="50"/>
+			<color state="0" red="0.41" green="0.44" blue="0.47"/>
+			<color state="1" red="0.61" green="0.64" blue="0.67"/>
+		</rect>
+		<rect>
+			<bounds x="0" y="15" width="24" height="20"/>
+			<color state="0" red="0.34" green="0.37" blue="0.39"/>
+			<color state="1" red="0.51" green="0.54" blue="0.57"/>
+		</rect>
 		<rect><bounds x="0" y="23" width="24" height="4"/><color red="0.86" green="0.41" blue="0.20"/></rect>
 	</element>
 	<group name="masterslider">
@@ -384,7 +400,18 @@ the visibility and style of elements that differ between the two.
 		</text>
 	</element>
 
-	<element name="tempo_knob"><disk><color red="0.34" green="0.37" blue="0.39"/></disk></element>
+	<element name="tempo_knob">
+		<disk>
+			<color state="0" red="0.34" green="0.37" blue="0.39"/>
+			<color state="1" red="0.44" green="0.47" blue="0.49"/>
+		</disk>
+	</element>
+	<element name="tempo_dot">
+		<disk>
+			<color state="0" red="0" green="0" blue="0" alpha="0"/>
+			<color state="1" red="0.86" green="0.41" blue="0.20"/>
+		</disk>
+	</element>
 	<element name="tempo_well"><disk><color red="0.73" green="0.73" blue="0.72"/></disk></element>
 	<element name="tempo_value">
 		<simplecounter maxstate="100" digits="1"><color red="0.86" green="0.41" blue="0.20"/></simplecounter>
@@ -762,7 +789,8 @@ the visibility and style of elements that differ between the two.
 		<element ref="txt_fast"><bounds x="1477" y="612" width="42" height="15"/></element>
 		<element ref="tempo_well"><bounds x="1366" y="480" width="130" height="130"/></element>
 		<element ref="tempo_knob" id="tempo_knob"><bounds x="1381" y="495" width="100" height="100"/></element>
-		<element ref="tempo_value" inputtag="TEMPO" inputmask="0xffff" inputraw="yes">
+		<element ref="tempo_dot" id="tempo_dot"><bounds x="1425" y="504" width="12" height="12"/></element>
+		<element ref="tempo_value" id="tempo_value" inputtag="TEMPO" inputmask="0xffff" inputraw="yes">
 			<bounds x="1386" y="533" width="90" height="24"/>
 		</element>
 		<element ref="transparent" clickthrough="no"><bounds x="1381" y="495" width="100" height="100"/></element>
@@ -933,10 +961,16 @@ the visibility and style of elements that differ between the two.
 				local view = file.views["Default Layout"]
 				install_slider_callbacks(view)
 
-				add_simplecounter_knob(view, "tempo_knob", "TEMPO", 1.5)
-				add_vertical_slider(view, "master_volume_area", "master_volume_knob", "VOLUME")
+				add_knob(view, "tempo_knob", "TEMPO", 1.5, VERTICAL, "tempo_dot")
+				get_layout_item(view, "tempo_dot"):set_state(1)
+				get_layout_item(view, "tempo_value"):set_color_callback(
+					function()
+						return emu.render_color(0, 0, 0, 0)
+					end)
+
+				add_slider(view, "master_volume_area", "master_volume_knob", "VOLUME")
 				for i = 1, 11 do
-					add_vertical_slider(view, "slider_area_" .. i, "slider_knob_" .. i, "SLIDER_" .. i)
+					add_slider(view, "slider_area_" .. i, "slider_knob_" .. i, "SLIDER_" .. i)
 				end
 
 				view.items["warning"]:set_state(0)
@@ -945,14 +979,24 @@ the visibility and style of elements that differ between the two.
 		-----------------------------------------------------------------------
 		-- Slider and knob library starts.
 		-- Can be copied as-is to other layouts.
+		-- version: 11
 		-----------------------------------------------------------------------
+
+		-- Global configuration. Can be overwritten in the resolve_tags callback.
+		KNOB_DOT_ANGLE_SPAN = 150  -- -/+ 150 degrees from top center.
+		UPDATE_CLICK_STATE = true
+
+		-- Constants.
+		VERTICAL = 0
+		HORIZONTAL = 1
+
 		local widgets = {}   -- Stores slider and knob information.
 		local pointers = {}  -- Tracks pointer state.
 
 		-- The knob's Y position must be animated using <animate inputtag="{port_name}">.
 		-- The click area's vertical size must exactly span the range of the
 		-- knob's movement.
-		function add_vertical_slider(view, clickarea_id, knob_id, port_name)
+		function add_slider(view, clickarea_id, knob_id, port_name)
 			table.insert(widgets, {
 				clickarea   = get_layout_item(view, clickarea_id),
 				slider_knob = get_layout_item(view, knob_id),
@@ -961,13 +1005,21 @@ the visibility and style of elements that differ between the two.
 		end
 
 		-- A sweep between the attached field's min and max values requires
-		-- moving the pointer by `scale * clickarea.height` pixes.
-		function add_simplecounter_knob(view, clickarea_id, port_name, scale)
+		-- moving the pointer by `scale * clickarea.height` pixels, when drag
+		-- direction is VERTICAL. Replace `height` with `width` when HORIZONTAL.
+		--
+		-- `dot_id` is optional. If not nil, this script will take control of the
+		-- element's position as the knob rotates. The distance of the dot from
+		-- the center of `clickarea` will be preserved during rotation.
+		-- It is suggested you place the dot at the top-center of the knob.
+		function add_knob(view, clickarea_id, port_name, scale, drag_direction, dot_id)
 			table.insert(widgets, {
-				clickarea = get_layout_item(view, clickarea_id),
-				field     = get_port_field(port_name),
-				is_knob   = true,
-				scale     = scale })
+				clickarea     = get_layout_item(view, clickarea_id),
+				field         = get_port_field(port_name),
+				is_knob       = true,
+				scale         = scale,
+				is_horizontal = (drag_direction == HORIZONTAL),
+				knob_dot      = dot_id and get_layout_item(view, dot_id) })
 		end
 
 		function get_layout_item(view, item_id)
@@ -989,17 +1041,44 @@ the visibility and style of elements that differ between the two.
 				field = val
 				break
 			end
+			local field_msg = "Needs to either be an IPT_ADJUSTER, or an analog port with auto-center."
 			if field == nil then
-				emu.print_error("Port: '" .. port_name .."' does not seem to be an IPT_ADJUSTER.")
+				emu.print_error("Port '" .. port_name .."' " .. field_msg)
+				return nil
+			end
+			if field.is_analog and (not field.centerdelta or field.centerdelta == 0) then
+				emu.print_error("Port '" .. port_name .."' " .. field_msg)
 				return nil
 			end
 			return field
 		end
 
+		local function set_click_state(widget, state)
+			if UPDATE_CLICK_STATE then
+				if widget.is_knob then
+					widget.clickarea:set_state(state)
+				else
+					widget.slider_knob:set_state(state)
+				end
+			end
+		end
+
+		local function release_pointer(pointer_id)
+			if pointers[pointer_id] then
+				local widget = widgets[pointers[pointer_id].selected_widget]
+				set_click_state(widget, 0)
+				local field = widget.field
+				if field.is_analog then
+					field:clear_value()
+				end
+			end
+			pointers[pointer_id] = nil
+		end
+
 		local function pointer_updated(type, id, dev, x, y, btn, dn, up, cnt)
 			-- If a button is not pressed, reset the state of the current pointer.
 			if btn & 1 == 0 then
-				pointers[id] = nil
+				release_pointer(id)
 				return
 			end
 
@@ -1015,11 +1094,13 @@ the visibility and style of elements that differ between the two.
 						relative = false
 					end
 					if found then
+						set_click_state(widgets[i], 1)
 						pointers[id] = {
 							selected_widget = i,
 							relative = relative,
+							start_x = x,
 							start_y = y,
-							start_value = widgets[i].field.user_value }
+							start_value = widgets[i].field.port:read() }
 						break
 					end
 				end
@@ -1030,8 +1111,7 @@ the visibility and style of elements that differ between the two.
 				return
 			end
 
-			-- A widget is selected. Update its state based on the pointer's Y
-			-- position. It is assumed the attached IO field is an IPT_ADJUSTER.
+			-- A widget is selected. Update its state based on the pointer's position.
 
 			local pointer = pointers[id]
 			local widget = widgets[pointer.selected_widget]
@@ -1042,8 +1122,13 @@ the visibility and style of elements that differ between the two.
 
 			local new_value
 			if widget.is_knob then
-				local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
-				new_value = pointer.start_value + (pointer.start_y - y) * step_y
+				if widget.is_horizontal then
+					local step_x = value_range / (widget.scale * widget.clickarea.bounds.width)
+					new_value = pointer.start_value + (x - pointer.start_x) * step_x
+				else
+					local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
+					new_value = pointer.start_value + (pointer.start_y - y) * step_y
+				end
 			else
 				local knob_half_height = widget.slider_knob.bounds.height / 2
 				local min_y = widget.clickarea.bounds.y0 + knob_half_height
@@ -1063,22 +1148,82 @@ the visibility and style of elements that differ between the two.
 			new_value = math.floor(new_value + 0.5)
 			if new_value < min_value then new_value = min_value end
 			if new_value > max_value then new_value = max_value end
-			widget.field.user_value = new_value
+
+			if widget.field.is_analog then
+				widget.field:set_value(new_value)
+			else
+				widget.field.user_value = new_value
+			end
+		end
+
+		local function get_knob_dot_bounds(widget)
+			local dot = widget.knob_dot_cache
+			local value = (widget.field.port:read() - dot.value_min) / dot.value_range
+			local angle = dot.angle_min + value * dot.angle_range
+			local rx = -dot.center_y * math.sin(angle) * dot.aspect
+			local ry = dot.center_y * math.cos(angle)
+			local x = rx + dot.dx
+			local y = ry + dot.dy
+			return emu.render_bounds(x, y, x + dot.width, y + dot.height)
+		end
+
+		local function configure_knob_dots()
+			for i = 1, #widgets do
+				local dot = widgets[i].knob_dot
+				if dot then
+					-- Remove bounds callback, since we need to access the
+					-- configured bounds.
+					dot:set_bounds_callback(nil)
+
+					local field = widgets[i].field
+					local knob_bounds = widgets[i].clickarea.bounds
+					local dot_bounds = dot.bounds
+					local max_angle = KNOB_DOT_ANGLE_SPAN * 2.0 * math.pi / 360.0
+
+					-- Compute the distance of the knob dot from the knob center.
+					local dot_x = dot_bounds.x0 + dot_bounds.width / 2.0
+					local dot_y = dot_bounds.y0 + dot_bounds.height / 2.0
+					local knob_x = knob_bounds.x0 + knob_bounds.width / 2.0
+					local knob_y = knob_bounds.y0 + knob_bounds.height / 2.0
+					local radius = math.sqrt((dot_y - knob_y) ^ 2 + (dot_x - knob_x) ^ 2)
+
+					widgets[i].knob_dot_cache = {
+						width       = dot_bounds.width,
+						height      = dot_bounds.height,
+						aspect      = dot_bounds.aspect,
+						value_min   = field.minvalue,
+						value_range = field.maxvalue - field.minvalue,
+						angle_min   = -max_angle,
+						angle_range = 2.0 * max_angle,
+						center_y    = -radius,
+						dx = knob_bounds.x0 + (knob_bounds.width - dot_bounds.width) / 2.0,
+						dy = knob_bounds.y0 + (knob_bounds.height - dot_bounds.height) / 2.0 }
+
+					dot:set_bounds_callback(
+						function()
+							return get_knob_dot_bounds(widgets[i])
+						end)
+				end
+			end
 		end
 
 		local function pointer_left(type, id, dev, x, y, up, cnt)
-			pointers[id] = nil
+			release_pointer(id)
 		end
 
 		local function pointer_aborted(type, id, dev, x, y, up, cnt)
-			pointers[id] = nil
+			release_pointer(id)
 		end
 
 		local function forget_pointers()
+			for id, pointer in pairs(pointers) do
+				release_pointer(id)
+			end
 			pointers = {}
 		end
 
 		function install_slider_callbacks(view)
+			view:set_recomputed_callback(configure_knob_dots)
 			view:set_pointer_updated_callback(pointer_updated)
 			view:set_pointer_left_callback(pointer_left)
 			view:set_pointer_aborted_callback(pointer_aborted)

--- a/src/mame/layout/sequential_prophet5.lay
+++ b/src/mame/layout/sequential_prophet5.lay
@@ -245,7 +245,7 @@ copyright-holders:m1macrophage
 		<rect>
 			<bounds x="1" y="1" width="20" height="10"/>
 			<color state="0" red="0.29" green="0.29" blue="0.29"/>
-			<color state="1" red="0.45" green="0.45" blue="0.45"/>
+			<color state="1" red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<rect>
 			<bounds x="1" y="11" width="20" height="17"/>
@@ -254,7 +254,7 @@ copyright-holders:m1macrophage
 		<rect>
 			<bounds x="3" y="13" width="16" height="12"/>
 			<color state="0" red="0.26" green="0.26" blue="0.26"/>
-			<color state="1" red="0.45" green="0.45" blue="0.45"/>
+			<color state="1" red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 	</element>
 	<element name="btn_grey">
@@ -265,7 +265,7 @@ copyright-holders:m1macrophage
 		<rect>
 			<bounds x="1" y="1" width="20" height="10"/>
 			<color state="0" red="0.60" green="0.60" blue="0.60"/>
-			<color state="1" red="0.73" green="0.73" blue="0.73"/>
+			<color state="1" red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<rect>
 			<bounds x="1" y="11" width="20" height="17"/>
@@ -274,7 +274,7 @@ copyright-holders:m1macrophage
 		<rect>
 			<bounds x="3" y="13" width="16" height="12"/>
 			<color state="0" red="0.57" green="0.57" blue="0.57"/>
-			<color state="1" red="0.73" green="0.73" blue="0.73"/>
+			<color state="1" red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 	</element>
 	<element name="btn_orange">
@@ -365,17 +365,37 @@ copyright-holders:m1macrophage
 	</element>
 	<element name="knob_black">
 		<disk><bounds x="0" y="0" width="28" height="28"/><color red="0.63" green="0.63" blue="0.63"/></disk>
-		<disk><bounds x="2" y="2" width="24" height="24"/><color red="0.13" green="0.13" blue="0.13"/></disk>
+		<disk>
+			<bounds x="2" y="2" width="24" height="24"/>
+			<color state="0" red="0.13" green="0.13" blue="0.13"/>
+			<color state="1" red="0.35" green="0.35" blue="0.35"/>
+		</disk>
 	</element>
 	<element name="knob_silver">
 		<disk><bounds x="0" y="0" width="28" height="28"/><color red="0.50" green="0.50" blue="0.50"/></disk>
-		<disk><bounds x="2" y="2" width="24" height="24"/><color red="0.67" green="0.67" blue="0.67"/></disk>
+		<disk>
+			<bounds x="2" y="2" width="24" height="24"/>
+			<color state="0" red="0.67" green="0.67" blue="0.67"/>
+			<color state="1" red="0.40" green="0.40" blue="0.40"/>
+		</disk>
 	</element>
 	<element name="knob_black_value">
 		<simplecounter digits="1"><color red="0.86" green="0.86" blue="0.86"/></simplecounter>
 	</element>
 	<element name="knob_silver_value">
 		<simplecounter digits="1"><color red="0.0" green="0.0" blue="0.0"/></simplecounter>
+	</element>
+	<element name="knob_black_dot">
+		<disk>
+			<color state="0" red="0" green="0" blue="0" alpha="0"/>
+			<color state="1" red="0.70" green="0.70" blue="0.70"/>
+		</disk>
+	</element>
+	<element name="knob_silver_dot">
+		<disk>
+			<color state="0" red="0" green="0" blue="0" alpha="0"/>
+			<color state="1" red="0.10" green="0.10" blue="0.10"/>
+		</disk>
 	</element>
 	<group name="knob">
 		<bounds x="0" y="0" width="56" height="62"/>
@@ -384,7 +404,10 @@ copyright-holders:m1macrophage
 		<element ref="~knob_style~" id="~knob_input~">
 			<bounds x="14" y="14" width="28" height="28"/>
 		</element>
-		<element ref="~knob_style~_value" inputtag="~knob_input~" inputmask="0xffff" inputraw="yes">
+		<element ref="~knob_style~_dot" id="~knob_input~_dot">
+			<bounds x="25" y="19" width="4" height="4"/>
+		</element>
+		<element ref="~knob_style~_value" id="~knob_input~_value" inputtag="~knob_input~" inputmask="0xffff" inputraw="yes">
 			<bounds x="18" y="23" width="20" height="10"/>
 		</element>
 		<element ref="transparent" clickthrough="no">
@@ -966,22 +989,36 @@ copyright-holders:m1macrophage
 				add_slider(view, "wheel_pitch", "wheel_pitch_dent", "wheel_pitch")
 				add_slider(view, "wheel_mod", "wheel_mod_dent", "wheel_mod")
 
-				local knob_scale = 1.6
-				add_knob(view, "pot_tune", "pot_tune", knob_scale, VERTICAL)
-				add_knob(view, "pot_volume", "pot_volume", knob_scale, VERTICAL)
+				add_prophet_knob(view, "pot_tune")
+				add_prophet_knob(view, "pot_volume")
 
 				for i = 0, 23 do
-					local knob = "pot_" .. i
-					add_knob(view, knob, knob, knob_scale, VERTICAL)
+					add_prophet_knob(view, "pot_" .. i)
 				end
 
 				view.items["warning"]:set_state(0)
 			end)
 
+		function add_prophet_knob(view, knob_id)
+			add_knob(view, knob_id, knob_id, 1.6, VERTICAL, knob_id .. "_dot")
+			get_layout_item(view, knob_id .. "_dot"):set_state(1)
+			get_layout_item(view, knob_id .. "_value"):set_color_callback(
+				function()
+					return emu.render_color(0, 0, 0, 0)
+				end)
+		end
+
 		-----------------------------------------------------------------------
 		-- Slider and knob library starts.
 		-- Can be copied as-is to other layouts.
+		-- version: 11
 		-----------------------------------------------------------------------
+
+		-- Global configuration. Can be overwritten in the resolve_tags callback.
+		KNOB_DOT_ANGLE_SPAN = 150  -- -/+ 150 degrees from top center.
+		UPDATE_CLICK_STATE = true
+
+		-- Constants.
 		VERTICAL = 0
 		HORIZONTAL = 1
 
@@ -1000,14 +1037,21 @@ copyright-holders:m1macrophage
 		end
 
 		-- A sweep between the attached field's min and max values requires
-		-- moving the pointer by `scale * clickarea.height` pixes.
-		function add_knob(view, clickarea_id, port_name, scale, drag_direction)
+		-- moving the pointer by `scale * clickarea.height` pixels, when drag
+		-- direction is VERTICAL. Replace `height` with `width` when HORIZONTAL.
+		--
+		-- `dot_id` is optional. If not nil, this script will take control of the
+		-- element's position as the knob rotates. The distance of the dot from
+		-- the center of `clickarea` will be preserved during rotation.
+		-- It is suggested you place the dot at the top-center of the knob.
+		function add_knob(view, clickarea_id, port_name, scale, drag_direction, dot_id)
 			table.insert(widgets, {
 				clickarea     = get_layout_item(view, clickarea_id),
 				field         = get_port_field(port_name),
 				is_knob       = true,
 				scale         = scale,
-				is_horizontal = (drag_direction == HORIZONTAL) })
+				is_horizontal = (drag_direction == HORIZONTAL),
+				knob_dot      = dot_id and get_layout_item(view, dot_id) })
 		end
 
 		function get_layout_item(view, item_id)
@@ -1041,9 +1085,21 @@ copyright-holders:m1macrophage
 			return field
 		end
 
+		local function set_click_state(widget, state)
+			if UPDATE_CLICK_STATE then
+				if widget.is_knob then
+					widget.clickarea:set_state(state)
+				else
+					widget.slider_knob:set_state(state)
+				end
+			end
+		end
+
 		local function release_pointer(pointer_id)
 			if pointers[pointer_id] then
-				local field = widgets[pointers[pointer_id].selected_widget].field
+				local widget = widgets[pointers[pointer_id].selected_widget]
+				set_click_state(widget, 0)
+				local field = widget.field
 				if field.is_analog then
 					field:clear_value()
 				end
@@ -1070,6 +1126,7 @@ copyright-holders:m1macrophage
 						relative = false
 					end
 					if found then
+						set_click_state(widgets[i], 1)
 						pointers[id] = {
 							selected_widget = i,
 							relative = relative,
@@ -1131,6 +1188,57 @@ copyright-holders:m1macrophage
 			end
 		end
 
+		local function get_knob_dot_bounds(widget)
+			local dot = widget.knob_dot_cache
+			local value = (widget.field.port:read() - dot.value_min) / dot.value_range
+			local angle = dot.angle_min + value * dot.angle_range
+			local rx = -dot.center_y * math.sin(angle) * dot.aspect
+			local ry = dot.center_y * math.cos(angle)
+			local x = rx + dot.dx
+			local y = ry + dot.dy
+			return emu.render_bounds(x, y, x + dot.width, y + dot.height)
+		end
+
+		local function configure_knob_dots()
+			for i = 1, #widgets do
+				local dot = widgets[i].knob_dot
+				if dot then
+					-- Remove bounds callback, since we need to access the
+					-- configured bounds.
+					dot:set_bounds_callback(nil)
+
+					local field = widgets[i].field
+					local knob_bounds = widgets[i].clickarea.bounds
+					local dot_bounds = dot.bounds
+					local max_angle = KNOB_DOT_ANGLE_SPAN * 2.0 * math.pi / 360.0
+
+					-- Compute the distance of the knob dot from the knob center.
+					local dot_x = dot_bounds.x0 + dot_bounds.width / 2.0
+					local dot_y = dot_bounds.y0 + dot_bounds.height / 2.0
+					local knob_x = knob_bounds.x0 + knob_bounds.width / 2.0
+					local knob_y = knob_bounds.y0 + knob_bounds.height / 2.0
+					local radius = math.sqrt((dot_y - knob_y) ^ 2 + (dot_x - knob_x) ^ 2)
+
+					widgets[i].knob_dot_cache = {
+						width       = dot_bounds.width,
+						height      = dot_bounds.height,
+						aspect      = dot_bounds.aspect,
+						value_min   = field.minvalue,
+						value_range = field.maxvalue - field.minvalue,
+						angle_min   = -max_angle,
+						angle_range = 2.0 * max_angle,
+						center_y    = -radius,
+						dx = knob_bounds.x0 + (knob_bounds.width - dot_bounds.width) / 2.0,
+						dy = knob_bounds.y0 + (knob_bounds.height - dot_bounds.height) / 2.0 }
+
+					dot:set_bounds_callback(
+						function()
+							return get_knob_dot_bounds(widgets[i])
+						end)
+				end
+			end
+		end
+
 		local function pointer_left(type, id, dev, x, y, up, cnt)
 			release_pointer(id)
 		end
@@ -1147,6 +1255,7 @@ copyright-holders:m1macrophage
 		end
 
 		function install_slider_callbacks(view)
+			view:set_recomputed_callback(configure_knob_dots)
 			view:set_pointer_updated_callback(pointer_updated)
 			view:set_pointer_left_callback(pointer_left)
 			view:set_pointer_aborted_callback(pointer_aborted)

--- a/src/mame/layout/sequential_sixtrak.lay
+++ b/src/mame/layout/sequential_sixtrak.lay
@@ -582,12 +582,12 @@ copyright-holders:m1macrophage
 
 	<!-- knob elements -->
 
-	<element name="knob_background">
+	<element name="knob_tickmarks">
 		<image><data><![CDATA[
 			<svg width="50" height="50">
 				<!-- tickmarks around the knob -->
-				<g stroke="#d4d4d4" stroke-width="0.5" transform="translate(24.5, 24.5)>
-					<line x1="0" y1="0" x2="0" y2="-25"/>
+				<g stroke="#d4d4d4" stroke-width="0.5" transform="translate(25, 25)>
+					<line x1="0" y1="0" x2="0" y2="-24"/>
 					<line transform="rotate(30)" x1="0" y1="0" x2="0" y2="-24"/>
 					<line transform="rotate(60)" x1="0" y1="0" x2="0" y2="-24"/>
 					<line transform="rotate(90)" x1="0" y1="0" x2="0" y2="-24"/>
@@ -599,10 +599,6 @@ copyright-holders:m1macrophage
 					<line transform="rotate(300)" x1="0" y1="0" x2="0" y2="-24"/>
 					<line transform="rotate(330)" x1="0" y1="0" x2="0" y2="-24"/>
 				</g>
-
-				<!-- outer and inner knob -->
-				<circle fill="#1a1a1a" cx="24.5" cy="24.5" r="20"/>
-				<circle fill="#535353" cx="24.5" cy="24.5" r="13"/>
 			</svg>
 		]]></data></image>
 	</element>
@@ -709,6 +705,18 @@ copyright-holders:m1macrophage
 		</text>
 	</element>
 
+	<element name="knob_circle">
+		<disk>
+			<bounds x="0" y="0" width="1" height="1"/>
+			<color red="0.10" green="0.10" blue="0.10"/>
+		</disk>
+		<disk>
+			<bounds x="0.2" y="0.2" width="0.6" height="0.6"/>
+			<color state="0" red="0.33" green="0.33" blue="0.33"/>
+			<color state="1" red="0.47" green="0.47" blue="0.47"/>
+		</disk>
+	</element>
+
 	<element name="knob_value">
 		<simplecounter digits="1"><color red="1" green="1" blue="1"/></simplecounter>
 	</element>
@@ -717,16 +725,29 @@ copyright-holders:m1macrophage
 		<rect><color red="0" green="0" blue="0" alpha="0"/></rect>
 	</element>
 
+	<element name="knob_dot">
+		<disk>
+			<color state="0" red="0" green="0" blue="0" alpha="0"/>
+			<color state="1" red="0.83" green="0.83" blue="0.83"/>
+		</disk>
+	</element>
+
 	<group name="knob">
 		<bounds x="0" y="0" width="50" height="50"/>
-		<element ref="knob_background" id="~input~">
+		<element ref="knob_tickmarks">
 			<bounds x="0" y="0" width="50" height="50"/>
 		</element>
-		<element ref="knob_value" inputtag="~input~" inputmask="0xffff" inputraw="yes">
+		<element ref="knob_circle" id="~input~">
+			<bounds x="5" y="5" width="40" height="40"/>
+		</element>
+		<element ref="knob_value" id="~input~_value" inputtag="~input~" inputmask="0xffff" inputraw="yes">
 			<bounds x="10" y="20" width="30" height="10"/>
 		</element>
 		<element ref="knob_value_cover" clickthrough="no">
 			<bounds x="10" y="20" width="30" height="10"/>
+		</element>
+		<element ref="knob_dot" id="~input~_dot">
+			<bounds x="23" y="15" width="4" height="4"/>
 		</element>
 	</group>
 
@@ -750,7 +771,10 @@ copyright-holders:m1macrophage
 	</element>
 
 	<element name="wheel_dent">
-		<rect><color red="0.33" green="0.33" blue="0.33"/></rect>
+		<rect>
+			<color state="0" red="0.33" green="0.33" blue="0.33"/>
+			<color state="1" red="0.50" green="0.50" blue="0.50"/>
+		</rect>
 	</element>
 
 	<group name="wheel">
@@ -1046,11 +1070,11 @@ copyright-holders:m1macrophage
 				local view = file.views["Default Layout"]
 				install_slider_callbacks(view)
 
-				add_knob(view, "track_volume_knob", "track_volume_knob", 1.2, HORIZONTAL)
-				add_knob(view, "speed_knob", "speed_knob", 1.2, HORIZONTAL)
-				add_knob(view, "value_knob", "value_knob", 2, HORIZONTAL)
-				add_knob(view, "tune_knob", "tune_knob", 2, HORIZONTAL)
-				add_knob(view, "master_volume_knob", "master_volume_knob", 1.2, HORIZONTAL)
+				add_sixtrak_knob(view, "track_volume_knob", 1.2)
+				add_sixtrak_knob(view, "speed_knob", 1.2)
+				add_sixtrak_knob(view, "value_knob", 2)
+				add_sixtrak_knob(view, "tune_knob", 2)
+				add_sixtrak_knob(view, "master_volume_knob", 1.2)
 
 				add_slider(view, "pitch_wheel", "pitch_wheel_dent", "wheel_0")
 				add_slider(view, "mod_wheel", "mod_wheel_dent", "wheel_1")
@@ -1058,10 +1082,26 @@ copyright-holders:m1macrophage
 				view.items["warning"]:set_state(0)
 			end)
 
+		function add_sixtrak_knob(view, knob_id, scale)
+			add_knob(view, knob_id, knob_id, scale, HORIZONTAL, knob_id .. "_dot")
+			get_layout_item(view, knob_id .. "_dot"):set_state(1)
+			get_layout_item(view, knob_id .. "_value"):set_color_callback(
+				function()
+					return emu.render_color(0, 0, 0, 0)
+				end)
+		end
+
 		-----------------------------------------------------------------------
 		-- Slider and knob library starts.
 		-- Can be copied as-is to other layouts.
+		-- version: 11
 		-----------------------------------------------------------------------
+
+		-- Global configuration. Can be overwritten in the resolve_tags callback.
+		KNOB_DOT_ANGLE_SPAN = 150  -- -/+ 150 degrees from top center.
+		UPDATE_CLICK_STATE = true
+
+		-- Constants.
 		VERTICAL = 0
 		HORIZONTAL = 1
 
@@ -1080,14 +1120,21 @@ copyright-holders:m1macrophage
 		end
 
 		-- A sweep between the attached field's min and max values requires
-		-- moving the pointer by `scale * clickarea.height` pixes.
-		function add_knob(view, clickarea_id, port_name, scale, drag_direction)
+		-- moving the pointer by `scale * clickarea.height` pixels, when drag
+		-- direction is VERTICAL. Replace `height` with `width` when HORIZONTAL.
+		--
+		-- `dot_id` is optional. If not nil, this script will take control of the
+		-- element's position as the knob rotates. The distance of the dot from
+		-- the center of `clickarea` will be preserved during rotation.
+		-- It is suggested you place the dot at the top-center of the knob.
+		function add_knob(view, clickarea_id, port_name, scale, drag_direction, dot_id)
 			table.insert(widgets, {
 				clickarea     = get_layout_item(view, clickarea_id),
 				field         = get_port_field(port_name),
 				is_knob       = true,
 				scale         = scale,
-				is_horizontal = (drag_direction == HORIZONTAL) })
+				is_horizontal = (drag_direction == HORIZONTAL),
+				knob_dot      = dot_id and get_layout_item(view, dot_id) })
 		end
 
 		function get_layout_item(view, item_id)
@@ -1121,9 +1168,21 @@ copyright-holders:m1macrophage
 			return field
 		end
 
+		local function set_click_state(widget, state)
+			if UPDATE_CLICK_STATE then
+				if widget.is_knob then
+					widget.clickarea:set_state(state)
+				else
+					widget.slider_knob:set_state(state)
+				end
+			end
+		end
+
 		local function release_pointer(pointer_id)
 			if pointers[pointer_id] then
-				local field = widgets[pointers[pointer_id].selected_widget].field
+				local widget = widgets[pointers[pointer_id].selected_widget]
+				set_click_state(widget, 0)
+				local field = widget.field
 				if field.is_analog then
 					field:clear_value()
 				end
@@ -1150,6 +1209,7 @@ copyright-holders:m1macrophage
 						relative = false
 					end
 					if found then
+						set_click_state(widgets[i], 1)
 						pointers[id] = {
 							selected_widget = i,
 							relative = relative,
@@ -1211,6 +1271,57 @@ copyright-holders:m1macrophage
 			end
 		end
 
+		local function get_knob_dot_bounds(widget)
+			local dot = widget.knob_dot_cache
+			local value = (widget.field.port:read() - dot.value_min) / dot.value_range
+			local angle = dot.angle_min + value * dot.angle_range
+			local rx = -dot.center_y * math.sin(angle) * dot.aspect
+			local ry = dot.center_y * math.cos(angle)
+			local x = rx + dot.dx
+			local y = ry + dot.dy
+			return emu.render_bounds(x, y, x + dot.width, y + dot.height)
+		end
+
+		local function configure_knob_dots()
+			for i = 1, #widgets do
+				local dot = widgets[i].knob_dot
+				if dot then
+					-- Remove bounds callback, since we need to access the
+					-- configured bounds.
+					dot:set_bounds_callback(nil)
+
+					local field = widgets[i].field
+					local knob_bounds = widgets[i].clickarea.bounds
+					local dot_bounds = dot.bounds
+					local max_angle = KNOB_DOT_ANGLE_SPAN * 2.0 * math.pi / 360.0
+
+					-- Compute the distance of the knob dot from the knob center.
+					local dot_x = dot_bounds.x0 + dot_bounds.width / 2.0
+					local dot_y = dot_bounds.y0 + dot_bounds.height / 2.0
+					local knob_x = knob_bounds.x0 + knob_bounds.width / 2.0
+					local knob_y = knob_bounds.y0 + knob_bounds.height / 2.0
+					local radius = math.sqrt((dot_y - knob_y) ^ 2 + (dot_x - knob_x) ^ 2)
+
+					widgets[i].knob_dot_cache = {
+						width       = dot_bounds.width,
+						height      = dot_bounds.height,
+						aspect      = dot_bounds.aspect,
+						value_min   = field.minvalue,
+						value_range = field.maxvalue - field.minvalue,
+						angle_min   = -max_angle,
+						angle_range = 2.0 * max_angle,
+						center_y    = -radius,
+						dx = knob_bounds.x0 + (knob_bounds.width - dot_bounds.width) / 2.0,
+						dy = knob_bounds.y0 + (knob_bounds.height - dot_bounds.height) / 2.0 }
+
+					dot:set_bounds_callback(
+						function()
+							return get_knob_dot_bounds(widgets[i])
+						end)
+				end
+			end
+		end
+
 		local function pointer_left(type, id, dev, x, y, up, cnt)
 			release_pointer(id)
 		end
@@ -1227,6 +1338,7 @@ copyright-holders:m1macrophage
 		end
 
 		function install_slider_callbacks(view)
+			view:set_recomputed_callback(configure_knob_dots)
 			view:set_pointer_updated_callback(pointer_updated)
 			view:set_pointer_left_callback(pointer_left)
 			view:set_pointer_aborted_callback(pointer_aborted)


### PR DESCRIPTION
* Made knob dots optional in reference script (in `linn_linndrum.lay`).
* Copied latest slider script to multiple layouts, and added rotating knob pointers, and knob and slider click states.
* `pg1000.lay` already supported click states with local script modifications. Just copied over the latest script that handles click states natively.
