### PR TITLE
metro/metro.cpp: Fix metadata:

### DIFF
--- a/src/mame/metro/metro.cpp
+++ b/src/mame/metro/metro.cpp
@@ -75,7 +75,7 @@ To Do:
     causes scrolling glitches in some games.  Test cases Mouse Go Go
     title screen, GunMaster title screen.  Changing it can cause
     excessive slowdown in said games however.
--   karatour, ladykill, 3kokushi: understand what the irq source 5 is really tied to.
+-   karatour, ladykill, 3kokushi: understand what the IRQ source 5 is really tied to.
     All these games also have a vblank delay check outside irq routine,
     cfr. PC=1322 in karatour;
 -   vmetal: ES8712 actually controls a M6585 and an unknown logic selector chip.
@@ -84,11 +84,11 @@ To Do:
 
 Notes:
 
--   To enter service mode in ladykill, 3kokushi: toggle the dip switch and reset
+-   To enter service mode in ladykill, 3kokushi: toggle the DIP switch and reset
     keeping start 2 pressed.
 -   Sprite zoom in Mouja at the end of a match looks wrong, but it's been verified
     to be the same on the original board
--   vmetal: has Sega and Taito logos in the roms ?!
+-   vmetal: has Sega and Taito logos in the ROMs?!
 
 driver modified by Hau
 ***************************************************************************/
@@ -96,11 +96,11 @@ driver modified by Hau
 #include "emu.h"
 #include "metro.h"
 
-#include "cpu/z80/z80.h"
+#include "cpu/h8/h83006.h"
 #include "cpu/m68000/m68000.h"
 #include "cpu/upd7810/upd7810.h"
-#include "cpu/h8/h83006.h"
 #include "cpu/z8/z8.h"
+#include "cpu/z80/z80.h"
 #include "machine/watchdog.h"
 #include "sound/msm5205.h"
 #include "sound/ymopl.h"
@@ -160,12 +160,12 @@ TIMER_DEVICE_CALLBACK_MEMBER(metro_state::bangball_scanline)
 	int const scanline = param;
 
 	// vblank irq
-	if(scanline == 224)
+	if (scanline == 224)
 	{
 		m_vdp2->set_irq(4); // ???
 		m_vdp2->screen_eof(ASSERT_LINE);
 	}
-	else if(scanline < 224 && (m_vdp2->irq_enable() & 2) == 0)
+	else if (scanline < 224 && (m_vdp2->irq_enable() & 2) == 0)
 	{
 		// pretty likely hblank irq (pressing a button when clearing a stage)
 		m_vdp2->set_irq(1);
@@ -269,7 +269,7 @@ void metro_upd7810_state::soundstatus_w(u8 data)
 	m_soundstatus = data & 0x01;
 }
 
-template<int Mask>
+template <int Mask>
 void metro_upd7810_state::upd7810_rombank_w(u8 data)
 {
 	m_audiobank->set_entry((data >> 4) & Mask);
@@ -404,7 +404,7 @@ void metro_state::coin_lockout_1word_w(u8 data)
 	machine().bookkeeping().coin_counter_w(0, BIT(data, 0));
 	machine().bookkeeping().coin_counter_w(1, BIT(data, 1));
 
-	if (data & ~3)  logerror("CPU #0 PC %06X : unknown bits of coin lockout written: %04X\n", m_maincpu->pc(), data);
+	if (data & ~3) logerror("CPU #0 PC %06X : unknown bits of coin lockout written: %04X\n", m_maincpu->pc(), data);
 }
 
 // value written doesn't matter, also each counted coin gets reported after one full second.
@@ -414,7 +414,7 @@ void metro_state::coin_lockout_4words_w(offs_t offset, u16 data)
 	machine().bookkeeping().coin_counter_w((offset >> 1) & 1, offset & 1);
 //  machine().bookkeeping().coin_lockout_w((offset >> 1) & 1, offset & 1);
 
-	if (data & ~1)  logerror("CPU #0 PC %06X : unknown bits of coin lockout written: %04X\n", m_maincpu->pc(), data);
+	if (data & ~1) logerror("CPU #0 PC %06X : unknown bits of coin lockout written: %04X\n", m_maincpu->pc(), data);
 }
 
 /***************************************************************************
@@ -434,9 +434,9 @@ void metro_state::coin_lockout_4words_w(offs_t offset, u16 data)
 
 void metro_upd7810_state::upd7810_map(address_map &map)
 {
-	map(0x0000, 0x3fff).rom();         // External ROM
-	map(0x4000, 0x7fff).bankr(m_audiobank);    // External ROM (Banked)
-	map(0x8000, 0x87ff).ram();         // External RAM
+	map(0x0000, 0x3fff).rom();              // External ROM
+	map(0x4000, 0x7fff).bankr(m_audiobank); // External ROM (Banked)
+	map(0x8000, 0x87ff).ram();              // External RAM
 }
 
 /*****************/
@@ -547,16 +547,16 @@ void metro_state::batlbubl_map(address_map &map)
 
 void metro_state::msgogo_map(address_map &map)
 {
-	map(0x000000, 0x07ffff).rom();                                             // ROM
+	map(0x000000, 0x07ffff).rom();                                                 // ROM
 	map(0x100000, 0x17ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0x200000, 0x200001).portr("COINS");                              // Inputs
-	map(0x200002, 0x200003).portr("JOYS");                               //
-	map(0x200006, 0x200007).nopr();                                         //
-	map(0x200002, 0x200009).w(FUNC(metro_state::coin_lockout_4words_w));              // Coin Lockout
-	map(0x300000, 0x31ffff).r(FUNC(metro_state::balcube_dsw_r));                             // 3 x DSW
-	map(0x400001, 0x400001).r("ymf", FUNC(ymf278b_device::read));   // Sound
+	map(0x200000, 0x200001).portr("COINS");                                        // Inputs
+	map(0x200002, 0x200003).portr("JOYS");                                         //
+	map(0x200006, 0x200007).nopr();                                                //
+	map(0x200002, 0x200009).w(FUNC(metro_state::coin_lockout_4words_w));           // Coin Lockout
+	map(0x300000, 0x31ffff).r(FUNC(metro_state::balcube_dsw_r));                   // 3 x DSW
+	map(0x400001, 0x400001).r("ymf", FUNC(ymf278b_device::read));                  // Sound
 	map(0x400000, 0x40000b).w("ymf", FUNC(ymf278b_device::write)).umask16(0x00ff); //
-	map(0xf00000, 0xf0ffff).ram().mirror(0x0f0000);                         // RAM (mirrored)
+	map(0xf00000, 0xf0ffff).ram().mirror(0x0f0000);                                // RAM (mirrored)
 }
 
 /***************************************************************************
@@ -565,16 +565,16 @@ void metro_state::msgogo_map(address_map &map)
 
 void metro_upd7810_state::daitorid_map(address_map &map)
 {
-	map(0x000000, 0x03ffff).rom();                                             // ROM
+	map(0x000000, 0x03ffff).rom();                                               // ROM
 	map(0x400000, 0x47ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0x4788a9, 0x4788a9).w(FUNC(metro_upd7810_state::sound_data_w));                       // To Sound CPU
-	map(0x800000, 0x80ffff).ram().mirror(0x0f0000);                         // RAM (mirrored)
+	map(0x4788a9, 0x4788a9).w(FUNC(metro_upd7810_state::sound_data_w));          // To Sound CPU
+	map(0x800000, 0x80ffff).ram().mirror(0x0f0000);                              // RAM (mirrored)
 	map(0xc00000, 0xc00001).portr("IN0");
-	map(0xc00001, 0xc00001).w(FUNC(metro_upd7810_state::soundstatus_w));  // To Sound CPU
-	map(0xc00002, 0xc00003).portr("IN1");                                //
-	map(0xc00004, 0xc00005).portr("DSW0");                               //
-	map(0xc00006, 0xc00007).portr("IN2");                                //
-	map(0xc00002, 0xc00009).w(FUNC(metro_upd7810_state::coin_lockout_4words_w));              // Coin Lockout
+	map(0xc00001, 0xc00001).w(FUNC(metro_upd7810_state::soundstatus_w));         // To Sound CPU
+	map(0xc00002, 0xc00003).portr("IN1");                                        //
+	map(0xc00004, 0xc00005).portr("DSW0");                                       //
+	map(0xc00006, 0xc00007).portr("IN2");                                        //
+	map(0xc00002, 0xc00009).w(FUNC(metro_upd7810_state::coin_lockout_4words_w)); // Coin Lockout
 }
 
 
@@ -584,16 +584,16 @@ void metro_upd7810_state::daitorid_map(address_map &map)
 
 void metro_upd7810_state::dharma_map(address_map &map)
 {
-	map(0x000000, 0x03ffff).rom();                                             // ROM
-	map(0x400000, 0x40ffff).ram().mirror(0x0f0000);                         // RAM (mirrored)
+	map(0x000000, 0x03ffff).rom();                                               // ROM
+	map(0x400000, 0x40ffff).ram().mirror(0x0f0000);                              // RAM (mirrored)
 	map(0x800000, 0x87ffff).m(m_vdp2, FUNC(imagetek_i4220_device::v2_map));
-	map(0x8788a9, 0x8788a9).w(FUNC(metro_upd7810_state::sound_data_w));                       // To Sound CPU
+	map(0x8788a9, 0x8788a9).w(FUNC(metro_upd7810_state::sound_data_w));          // To Sound CPU
 	map(0xc00000, 0xc00001).portr("IN0");
-	map(0xc00001, 0xc00001).w(FUNC(metro_upd7810_state::soundstatus_w));  // To Sound CPU
-	map(0xc00002, 0xc00003).portr("IN1");                                //
-	map(0xc00004, 0xc00005).portr("DSW0");                               //
-	map(0xc00006, 0xc00007).portr("IN2");                                //
-	map(0xc00002, 0xc00009).w(FUNC(metro_upd7810_state::coin_lockout_4words_w));              // Coin Lockout
+	map(0xc00001, 0xc00001).w(FUNC(metro_upd7810_state::soundstatus_w));         // To Sound CPU
+	map(0xc00002, 0xc00003).portr("IN1");                                        //
+	map(0xc00004, 0xc00005).portr("DSW0");                                       //
+	map(0xc00006, 0xc00007).portr("IN2");                                        //
+	map(0xc00002, 0xc00009).w(FUNC(metro_upd7810_state::coin_lockout_4words_w)); // Coin Lockout
 }
 
 
@@ -1063,7 +1063,7 @@ void vmetal_state::vmetal_control_w(u8 data)
 	/* Lower nibble is the coin control bits shown in
 	   service mode, but in game mode they're different */
 	machine().bookkeeping().coin_counter_w(0, BIT(data, 2));
-	machine().bookkeeping().coin_counter_w(1, BIT(data, 3));  // 2nd coin schute activates coin 0 counter in game mode??
+	machine().bookkeeping().coin_counter_w(1, BIT(data, 3));  // 2nd coin chute activates coin 0 counter in game mode??
 //  machine().bookkeeping().coin_lockout_w(0, BIT(data, 0));  // always on in game mode??
 	machine().bookkeeping().coin_lockout_w(1, BIT(data, 1));  // never activated in game mode??
 
@@ -1934,10 +1934,10 @@ static INPUT_PORTS_START( lastfort )
 	COINS
 
 	PORT_START("IN1")   /*$c00006*/
-	JOY_LSB(1, BUTTON1, UNKNOWN, UNKNOWN, UNKNOWN)      // BUTTON2 and BUTTON3 in "test mode" only*/
+	JOY_LSB(1, BUTTON1, UNKNOWN, UNKNOWN, UNKNOWN)      // BUTTON2 and BUTTON3 in "test mode" only
 
 	PORT_START("IN2")   /*$c00008*/
-	JOY_LSB(2, BUTTON1, UNKNOWN, UNKNOWN, UNKNOWN)      /*BUTTON2 and BUTTON3 in "test mode" only*/
+	JOY_LSB(2, BUTTON1, UNKNOWN, UNKNOWN, UNKNOWN)      // BUTTON2 and BUTTON3 in "test mode" only
 
 	PORT_START("DSW0")  /*$c0000a*/
 	COINAGE_SERVICE_LOC(SW1)
@@ -4717,7 +4717,7 @@ Video: Imagetek I4220 071 9430WK440
 
 SW3 - Not Populated
 
-ms_ja-1.1    tms27c240 <-- Is there an undumped MS_WA1 World rom??
+ms_ja-1.1    tms27c240 <-- Is there an undumped MS_WA1 World ROM??
 ms_wa-2.2    tms27c240
 ms_wa-3.3    tms27c240
 ms_wa-4.4    tms27c240
@@ -5487,7 +5487,7 @@ GAME( 1992, pangpomsn, pangpoms, pangpoms,  pangpoms,   metro_upd7810_state, emp
 GAME( 1992, skyalert,  0,        skyalert,  skyalert,   metro_upd7810_state, empty_init,    ROT270, "Metro",                                           "Sky Alert", MACHINE_SUPPORTS_SAVE )
 GAME( 1993, ladykill,  0,        karatour,  ladykill,   metro_upd7810_state, init_karatour, ROT90,  "Yanyaka (Mitchell license)",                      "Lady Killer", MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
 GAME( 1993, moegonta,  ladykill, karatour,  moegonta,   metro_upd7810_state, init_karatour, ROT90,  "Yanyaka",                                         "Moeyo Gonta!! (Japan)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
-// Japanese subtitle in japanese set, english otherwise: Kanji title is same regardless region
+// Japanese subtitle in Japanese set, English otherwise; Kanji title is the same regardless region
 GAME( 1994, lastfort,  0,        lastfort,  lastfort,   metro_upd7810_state, empty_init,    ROT0,   "Metro",                                           "Last Fortress - Toride (Japan, VG420 PCB)", MACHINE_SUPPORTS_SAVE ) // VG420 PCB
 GAME( 1994, lastforte, lastfort, lastfort,  lastfero,   metro_upd7810_state, empty_init,    ROT0,   "Metro",                                           "Last Fortress - Toride (China, Rev C)", MACHINE_SUPPORTS_SAVE )
 GAME( 1994, lastfortea,lastfort, lastfort,  lastfero,   metro_upd7810_state, empty_init,    ROT0,   "Metro",                                           "Last Fortress - Toride (China, Rev A)", MACHINE_SUPPORTS_SAVE )
@@ -5499,7 +5499,7 @@ GAME( 1994, lastfortg, lastfort, lastforg,  ladykill,   metro_upd7810_state, ini
 // MTR5260 / MTR527
 GAME( 1993, poitto,    0,        poitto,    poitto,     metro_upd7810_state, empty_init,    ROT0,   "Metro / Able Corp.",                              "Poitto! (Japan revision D)", MACHINE_SUPPORTS_SAVE )
 GAME( 1993, poittoc,   poitto,   poitto,    poitto,     metro_upd7810_state, empty_init,    ROT0,   "Metro / Able Corp.",                              "Poitto! (revision C)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // missing 1 program ROM
-// All set except korean region has "DHARMA" subtitle
+// All set except Korean region has "DHARMA" subtitle
 GAME( 1994, dharma,    0,        dharma,    dharma,     metro_upd7810_state, init_dharmak,  ROT0,   "Metro",                                           "Dharma Doujou", MACHINE_SUPPORTS_SAVE )
 GAME( 1994, dharmag,   dharma,   dharma,    dharma,     metro_upd7810_state, init_dharmak,  ROT0,   "Metro",                                           "Dharma Doujou (Germany)", MACHINE_SUPPORTS_SAVE )
 GAME( 1994, dharmaj,   dharma,   dharma,    dharma,     metro_upd7810_state, empty_init,    ROT0,   "Metro",                                           "Dharma Doujou (Japan)", MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
- Add region specific title, Describe region in some set
- Some sets are not having regional warning screen. but in-game texts are enough to describe region.
- Fix toride2gg set title (non-adauchi gaiden set unlike previously described metadata)
- Add distributor metadata for lastfortk set

- Non-'adauchi gaiden' revision toride2 set is should be splitted from parent set?