### PR TITLE
upd765: fix Read Track setting spurious ST1 No Data status

### DIFF
--- a/src/devices/machine/upd765.cpp
+++ b/src/devices/machine/upd765.cpp
@@ -2342,10 +2342,9 @@ void upd765_family_device::read_track_continue(floppy_info &fi)
 						cur_live.idbuf[1],
 						cur_live.idbuf[2],
 						cur_live.idbuf[3]);
-			if(!sector_matches())
-				st1 |= ST1_ND;
-			else
-				st1 &= ~ST1_ND;
+			// Read Track does not compare sector IDs (UPD765/8272A datasheet:
+			// "data is read continuously from index hole ... the sector number
+			// is not compared").  Do not set ST1_ND based on sector matching.
 
 			sector_size = calc_sector_size(command[5]);
 			fifo_expect(sector_size, false);


### PR DESCRIPTION
## Summary

- Fix incorrect `ST1_ND` (No Data) status being set during Read Track commands
- The UPD765/8272A datasheet states that Read Track does not compare sector IDs: *"data is read continuously from index hole ... the sector number is not compared"*
- The emulation was calling `sector_matches()` for each sector found on the track, setting `ST1_ND` whenever the sector's R field didn't match `command[4]` — which is almost always the case since Read Track reads sectors sequentially (R=1,2,3,...,EOT) but the command specifies only one R value

## How it was found

The Regnecentralen RC703 boot PROM (rob357) uses Read Track to load the boot sectors and checks ST1 for errors with a mask of `0xB5` (EN, DE, OR, ND, MA). The spurious `ST1_ND` caused every Read Track to be reported as failed, preventing boot. The RC702 boot PROM (roa375) was unaffected because it uses Read Data instead of Read Track.

## Test plan

- [x] RC702 maxi (8" DSDD, roa375 PROM, Read Data path) — boots CP/M
- [x] RC702 mini (5.25" DD, roa375 PROM, Read Data path) — boots CP/M
- [x] RC703 mini (5.25" QD, rob357 PROM, Read Track path) — boots CP/M
- [x] RC703 maxi (8" DSDD, rob357 PROM, Read Track path) — boots CP/M (was broken before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)