### PR TITLE
nes.xml: Added two partially working prototypes and two working clones

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -13831,6 +13831,50 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="galagahal" supported="partial">
+		<description>Galaga (prototype)</description>
+		<year>1988?</year>
+		<publisher>HAL Laboratory</publisher>
+		<notes><![CDATA[
+Entirely different from Namco's port. The CHR ROM to this prototype is lost.
+]]></notes>
+		<info name="serial" value="NES-JU-USA"/>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="nrom" />
+			<feature name="pcb" value="HVC-NROM-128" />
+			<feature name="mirroring" value="horizontal" />
+			<dataarea name="prg" size="32768">
+				<rom name="galaga.prg" size="16384" crc="92467be0" sha1="972a2602d1eff57a42263245ecc97ba476a2173c" offset="00000" />
+				<rom size="16384" offset="0x4000" loadflag="reload" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="chr" size="8192" status="nodump" />	<!-- CHR ROM missing -->
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="galagahalg" cloneof="galagahal">
+		<description>Galaga (prototype, with recreated graphics)</description>
+		<year>1988?</year>
+		<publisher>HAL Laboratory</publisher>
+		<notes><![CDATA[
+The graphics for the recreated CHR ROM were mostly sourced from HAL's port of Stargate and from the arcade version of Galaga.
+]]></notes>
+		<info name="serial" value="NES-JU-USA"/>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="nrom" />
+			<feature name="pcb" value="HVC-NROM-128" />
+			<feature name="mirroring" value="horizontal" />
+			<dataarea name="prg" size="32768">
+				<rom name="galaga.prg" size="16384" crc="92467be0" sha1="972a2602d1eff57a42263245ecc97ba476a2173c" offset="00000" />
+				<rom size="16384" offset="0x4000" loadflag="reload" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="chr" size="8192" crc="bab53928" sha1="2c5b17a25e2b7db497096a1d28b3412e4aaa1ed2" offset="00000" status="baddump" /> <!-- Custom CHR ROM with recreated graphics -->
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="galaxiana" cloneof="galaxian">
 		<description>Galaxian (Japan)</description>
 		<year>1984</year>
@@ -29391,6 +29435,62 @@ license:CC0-1.0
 			</dataarea>
 			<dataarea name="chr" size="8192">
 				<rom name="hvc-en-0 chr" size="8192" crc="fccc0f36" sha1="3566709c3c74960ce2ee1e60a85d026e70d7fd2c" offset="00000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="popils" supported="partial">
+		<description>Magical Puzzle Popils (prototype)</description>
+		<year>1989</year>
+		<publisher>Tengen</publisher>
+		<notes><![CDATA[
+The EEPROM chip that contained the sequence data for the music and sound effects could not be found, which means that the game no longer has any audio to play at all.
+]]></notes>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="namcot_3433" />
+			<feature name="pcb" value="TENGEN-800030" />
+			<feature name="mirroring" value="vertical" />
+			<dataarea name="chr" size="0x10000">
+				<rom name="popil chr0.bin" size="0x8000" crc="18fa74c0" sha1="64672be98a4745ceca3863759e586a6778e3958a" offset="0x00000" />
+				<rom name="popil chr1.bin" size="0x8000" crc="5980514c" sha1="8f793c1a9d587a2f60eaa22c14eca2fea53fe71b" offset="0x08000" />
+			</dataarea>
+			<dataarea name="prg" size="0x20000">
+				<rom name="popil prg0.bin" size="0x8000" status="nodump" />	<!-- EEPROM chip for the sound data, not found with the others -->
+				<rom name="popil prg1.bin" size="0x8000" crc="2ce83498" sha1="d3fc1b7cadb9be9de1a6028ef59df700a6e8588a" offset="0x08000" />
+				<rom name="popil prg2.bin" size="0x8000" crc="d0a719a8" sha1="bef214d4670df0b5eb44b1760b58a3b1f87f8fb5" offset="0x10000" />
+				<rom name="popil prg3.bin" size="0x8000" crc="b7b8b773" sha1="cb90b4ddfe0e5b7213905301292882be97f5a852" offset="0x18000" />
+			</dataarea>
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="0x2000">
+				<rom value="0x00" size="0x2000" offset="0" loadflag="fill" />
+			</dataarea>
+		</part>
+	</software>
+	
+	<software name="popilss" cloneof="popils">
+		<description>Magical Puzzle Popils (prototype, with recreated sound)</description>
+		<year>1989</year>
+		<publisher>Tengen</publisher>
+		<notes><![CDATA[
+This mod inserts recreations of the music tracks and sound effects into the prototype. This was done by porting the sequence data of all sounds found in the Game Gear version, along with doing many adjustments (ASDR, vibrato and note transposing edits) to match the audio heard in Jun Amanai’s gameplay videos as closely as possible.
+]]></notes>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="namcot_3433" />
+			<feature name="pcb" value="TENGEN-800030" />
+			<feature name="mirroring" value="vertical" />
+			<dataarea name="chr" size="0x10000">
+				<rom name="popil chr0.bin" size="0x8000" crc="18fa74c0" sha1="64672be98a4745ceca3863759e586a6778e3958a" offset="0x00000" />
+				<rom name="popil chr1.bin" size="0x8000" crc="5980514c" sha1="8f793c1a9d587a2f60eaa22c14eca2fea53fe71b" offset="0x08000" />
+			</dataarea>
+			<dataarea name="prg" size="0x20000">
+				<rom name="prg0" size="0x8000" crc="90da0dd3" sha1="7db3ea71db43d4df7d75851f485d57620d3d57f3" offset="0" status="baddump" /> <!-- EEPROM chip for the sound data, recreated using the Game Gear version's sound data -->
+				<rom name="popil prg1.bin" size="0x8000" crc="2ce83498" sha1="d3fc1b7cadb9be9de1a6028ef59df700a6e8588a" offset="0x08000" />
+				<rom name="popil prg2.bin" size="0x8000" crc="d0a719a8" sha1="bef214d4670df0b5eb44b1760b58a3b1f87f8fb5" offset="0x10000" />
+				<rom name="popil prg3.bin" size="0x8000" crc="b7b8b773" sha1="cb90b4ddfe0e5b7213905301292882be97f5a852" offset="0x18000" />
+			</dataarea>
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="0x2000">
+				<rom value="0x00" size="0x2000" offset="0" loadflag="fill" />
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
Added two partially working entries and two working clones:

- Magical Puzzle Popils (prototype) [VGHF]
- Magical Puzzle Popils (prototype, with recreated sound) [VGHF, Mister Man, ndiddy]
- Galaga (prototype) [VGHF]
- Galaga (prototype, with recreated graphics) [VGHF, Frank Cifaldi, Rushifell, ndiddy]



Context for the Galaga entries with their historical significance, from the Hidden Palace website:
> Atari contracted Nintendo to develop ports of 4 titles that Atari owned the home rights to (Galaga, Joust, Millipede, and Stargate) as launch titles for Atari's version of the Famicom. Nintendo then subcontracted development on these titles to HAL Laboratory. After the deal fell through, HAL eventually released Joust, Millipede, and Stargate themselves, but Galaga never saw a release as Namco had already put out their own Famicom port of Galaga. Namco's port is entirely different from HAL's port.
> The CHR ROM to this prototype is lost, and had to be recreated to make the game fully playable. The graphics for the recreated CHR ROM were mostly sourced from HAL's port of Stargate and from the arcade version of Galaga.


Context for the Popils entries, from Rushifell:
> Magical Puzzle Popils is a puzzle platformer game developed for the NES, with ports for the Turbografx-16 and the Game Gear also being developed around the same time. In the end, however, only the Game Gear port was released, with the other two versions becoming lost media aside of gameplay footage shared by Jun Amanai (the game’s programmer for all versions) through his YouTube channel.
> 
> On December 17 2025, the Video Game History Foundation preserved and released a late prototype of the NES version of Magical Puzzle Popils. While this prototype is fully playable from start to end, unfortunately the EEPROM chip that contained the sequence data for the music and sound effects could not be found, which means that the game no longer has any audio to play at all. Despite this, however, a lot of important sound-related data (sound driver, ADSR envelopes, ROM pointers, channel assignations) is still present in the other EEPROM chips.
> 
> This hack inserts recreations of all publicly available music tracks and sound effects into the prototype. This was done by porting the sequence data of all sounds found in the Game Gear version, along with doing many adjustments (ASDR, vibrato and note transposing edits) to match the audio heard in Jun Amanai’s gameplay videos as closely as possible.