### PR TITLE
heathzenith/z100.cpp: Fixed 6845 GVRAM addressing

### DIFF
--- a/src/mame/heathzenith/z100.cpp
+++ b/src/mame/heathzenith/z100.cpp
@@ -430,7 +430,7 @@ MC6845_UPDATE_ROW(z100_state::update_row)
 			else
 			{
 				for (int i = 0; i < 3; i++)
-					dot |= ((m_gvram[((x + ma) & amask) << 4 | (ra & 0xf) | (0x10000 * i)] >> (7 - xi)) & 1) << i; // b, r, g
+					dot |= ((m_gvram[((x + ma + (m_start_addr << 4)) & amask) << 4 | (ra & 0xf) | (0x10000 * i)] >> (7 - xi)) & 1) << i; // b, r, g
 
 				if (x == cursor_x)
 					dot ^= 7;


### PR DESCRIPTION
Fixed the abnormal text scrolling issue in 32k/64k vram modes.

Before (64K):
<img width="640" height="216" alt="0004" src="https://github.com/user-attachments/assets/7e54eda8-53b5-40bd-b257-312733baec64" />
Before (32K):
<img width="640" height="216" alt="0003" src="https://github.com/user-attachments/assets/356e5e79-fdb3-47c9-a727-213c417ce00b" />

After:
<img width="640" height="216" alt="0000" src="https://github.com/user-attachments/assets/befc2886-870d-49b7-837b-0e9295f355d8" />
<img width="640" height="216" alt="0001" src="https://github.com/user-attachments/assets/846a6129-d24b-411c-894e-1cd1bb476b1e" />
<img width="640" height="216" alt="0006" src="https://github.com/user-attachments/assets/54946513-dbfc-4a42-a9c3-456995614191" />
