### PR TITLE
Simplify handling of clang targets, fix clang build on aarch64 and riscv64

### DIFF
--- a/makefile
+++ b/makefile
@@ -1007,17 +1007,7 @@ $(info GCC $(GCC_VERSION) detected)
 else # CLANG_VERSION
 $(info Clang $(CLANG_VERSION) detected)
 ifneq ($(TARGETOS),asmjs)
-ifeq ($(ARCHITECTURE),_x64)
-ARCHITECTURE := _x64_clang
-else ifneq ($(filter aarch64%,$(UNAME_M)),)
-ARCHITECTURE := _arm64_clang
-else ifneq ($(filter aarch64%,$(UNAME_P)),)
-ARCHITECTURE := _arm64_clang
-else ifneq ($(filter arm64%,$(UNAME_M)),)
-ARCHITECTURE := _arm64_clang
-else
-ARCHITECTURE := _x86_clang
-endif
+ARCHITECTURE := $(ARCHITECTURE)_clang
 endif # asmjs
 endif # CLANG_VERSION
 
@@ -1265,15 +1255,15 @@ linux_x64_clang: generate $(PROJECTDIR)/$(MAKETYPE)-linux-clang/Makefile
 	$(SILENT) $(MAKE) $(MAKEPARAMS) -C $(PROJECTDIR)/$(MAKETYPE)-linux-clang config=$(CONFIG)64 precompile
 	$(SILENT) $(MAKE) $(MAKEPARAMS) -C $(PROJECTDIR)/$(MAKETYPE)-linux-clang config=$(CONFIG)64
 
-.PHONY: linux_arm64_clang
-linux_arm64_clang: generate $(PROJECTDIR)/$(MAKETYPE)-linux-clang/Makefile
-	$(SILENT) $(MAKE) $(MAKEPARAMS) -C $(PROJECTDIR)/$(MAKETYPE)-linux-clang config=$(CONFIG)64 precompile
-	$(SILENT) $(MAKE) $(MAKEPARAMS) -C $(PROJECTDIR)/$(MAKETYPE)-linux-clang config=$(CONFIG)64
-
 .PHONY: linux_x86_clang
 linux_x86_clang: generate $(PROJECTDIR)/$(MAKETYPE)-linux-clang/Makefile
 	$(SILENT) $(MAKE) $(MAKEPARAMS) -C $(PROJECTDIR)/$(MAKETYPE)-linux-clang config=$(CONFIG)32 precompile
 	$(SILENT) $(MAKE) $(MAKEPARAMS) -C $(PROJECTDIR)/$(MAKETYPE)-linux-clang config=$(CONFIG)32
+
+.PHONY: linux_clang
+linux_clang: generate $(PROJECTDIR)/$(MAKETYPE)-linux-clang/Makefile
+	$(SILENT) $(MAKE) $(MAKEPARAMS) -C $(PROJECTDIR)/$(MAKETYPE)-linux-clang config=$(CONFIG) precompile
+	$(SILENT) $(MAKE) $(MAKEPARAMS) -C $(PROJECTDIR)/$(MAKETYPE)-linux-clang config=$(CONFIG)
 
 #-------------------------------------------------
 # gmake-osx
@@ -1304,11 +1294,6 @@ $(PROJECTDIR)/$(MAKETYPE)-osx-clang/Makefile: makefile $(SCRIPTS) $(GENIE)
 
 .PHONY: macosx_x64_clang
 macosx_x64_clang: generate $(PROJECTDIR)/$(MAKETYPE)-osx-clang/Makefile
-	$(MAKE) $(MAKEPARAMS) -C $(PROJECTDIR)/$(MAKETYPE)-osx-clang config=$(CONFIG)64 precompile
-	$(SILENT) $(MAKE) $(MAKEPARAMS) -C $(PROJECTDIR)/$(MAKETYPE)-osx-clang config=$(CONFIG)64
-
-.PHONY: macosx_arm64_clang
-macosx_arm64_clang: generate $(PROJECTDIR)/$(MAKETYPE)-osx-clang/Makefile
 	$(SILENT) $(MAKE) $(MAKEPARAMS) -C $(PROJECTDIR)/$(MAKETYPE)-osx-clang config=$(CONFIG)64 precompile
 	$(SILENT) $(MAKE) $(MAKEPARAMS) -C $(PROJECTDIR)/$(MAKETYPE)-osx-clang config=$(CONFIG)64
 
@@ -1445,11 +1430,6 @@ openbsd_x64: generate $(PROJECTDIR)/$(MAKETYPE)-openbsd/Makefile
 	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-openbsd config=$(CONFIG)64 precompile
 	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-openbsd config=$(CONFIG)64
 
-.PHONY: openbsd_arm64
-openbsd_arm64: generate $(PROJECTDIR)/$(MAKETYPE)-openbsd/Makefile
-	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-openbsd config=$(CONFIG)64 precompile
-	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-openbsd config=$(CONFIG)64
-
 .PHONY: openbsd
 openbsd: openbsd_x86
 
@@ -1467,11 +1447,6 @@ $(PROJECTDIR)/$(MAKETYPE)-openbsd-clang/Makefile: makefile $(SCRIPTS) $(GENIE)
 
 .PHONY: openbsd_x64_clang
 openbsd_x64_clang: generate $(PROJECTDIR)/$(MAKETYPE)-openbsd-clang/Makefile
-	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-openbsd-clang config=$(CONFIG)64 precompile
-	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-openbsd-clang config=$(CONFIG)64
-
-.PHONY: openbsd_arm64_clang
-openbsd_arm64_clang: generate $(PROJECTDIR)/$(MAKETYPE)-openbsd-clang/Makefile
 	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-openbsd-clang config=$(CONFIG)64 precompile
 	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-openbsd-clang config=$(CONFIG)64
 


### PR DESCRIPTION
This PR fixes building on `riscv64` and `aarch64` using clang by ensuring `-m64` is getting passed instead of `-m32`.
I am not quite happy with the amount of copy-paste needed. The issue is that gcc does not support `-m64` parameter on `aarch64` or `riscv64`, meaning that the `ARCHITECTURE` parameter needs to be set to an empty value in order to prevent genie from adding the parameter to the generated makefiles.
Unfortunately, clang logic relies on `ARCHITECTURE` being set to `x64` in order to pick the 64-bit config, and falls back to 32-bit target otherwise. While clang does support `-m32` and `-m64` on `aarch64` and `riscv64`, it does not help if we end up picking the wrong one.
I can think of the following alternative approaches:

1. Set `ARCHITECTURE` to blank after the clang logic block
2. Explicitly check for `x86` and only pick the 32-bit target if it is found, fall back to 64-bit otherwise. This might make sense given where 32-bit support is these days in general.

Input is welcome.