### PR TITLE
sinclair/*: Fixed various bugs

### DIFF
--- a/src/mame/sinclair/specnext.cpp
+++ b/src/mame/sinclair/specnext.cpp
@@ -58,7 +58,7 @@
 
 namespace {
 
-#define TIMINGS_PERFECT     1
+#define TIMINGS_PERFECT     0
 
 constexpr u8 INT_PRIORITY_LINE     = 0;
 constexpr u8 INT_PRIORITY_UART0_RX = 1;

--- a/src/mame/sinclair/spectrum.cpp
+++ b/src/mame/sinclair/spectrum.cpp
@@ -331,7 +331,7 @@ void spectrum_state::spectrum_rom_w(offs_t offset, uint8_t data)
 
 uint8_t spectrum_state::spectrum_rom_r(offs_t offset)
 {
-	return m_exp->romcs()
+	return (m_exp && m_exp->romcs())
 		? m_exp->mreq_r(offset)
 		: m_rom[offset];
 }

--- a/src/mame/sinclair/sprinter.cpp
+++ b/src/mame/sinclair/sprinter.cpp
@@ -1027,7 +1027,7 @@ void sprinter_state::check_accel(bool is_read, offs_t offset, u8 &data)
 			if (BIT(m_acc_dir, 2)) // block operation
 			{
 				// fastram doesn't apply waits, hence m_wait_cycles_count is not updated
-				if (is_read && ~(m_pages[BIT(offset, 14, 2)] & BANK_FASTRAM_MASK))
+				if (is_read && (~m_pages[BIT(offset, 14, 2)] & BANK_FASTRAM_MASK))
 					m_maincpu->adjust_icount(m_wait_ticks_count);
 
 				m_maincpu->set_input_line(Z80_INPUT_LINE_WAIT, ASSERT_LINE);
@@ -1181,6 +1181,8 @@ template <u8 Bank> u8 sprinter_state::ram_r(offs_t offset)
 template <u8 Bank> void sprinter_state::ram_w(offs_t offset, u8 data)
 {
 	static_assert(Bank < 4, "unexpected bank number");
+	if (m_access_state == ACCEL_GO)
+		return;
 
 	do_mem_wait(3);
 


### PR DESCRIPTION
specnext.cpp: "dot commands" loading issue with NextZXOS - switched back to safer sdcard implementation which not such sensitive to timings.
spectrum.cpp: focus on debugger memory window crashing the emulator if exp devices are not activated.
sprinter.cpp: typo in fastram memory check; drop write if following access supported by the accelerator.
