### PR TITLE
epson/qx10.cpp: implement semidisk battery backed ramdisk card

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -2151,6 +2151,8 @@ if BUSES["EPSON_QX"] then
 		MAME_DIR .. "src/devices/bus/epson_qx/multifont.h",
 		MAME_DIR .. "src/devices/bus/epson_qx/option.cpp",
 		MAME_DIR .. "src/devices/bus/epson_qx/option.h",
+		MAME_DIR .. "src/devices/bus/epson_qx/semidisk.cpp",
+		MAME_DIR .. "src/devices/bus/epson_qx/semidisk.h",
 		MAME_DIR .. "src/devices/bus/epson_qx/sound_card.cpp",
 		MAME_DIR .. "src/devices/bus/epson_qx/sound_card.h",
 	}

--- a/src/devices/bus/epson_qx/cqgmem.cpp
+++ b/src/devices/bus/epson_qx/cqgmem.cpp
@@ -129,7 +129,7 @@ void cqgmem_device::write(offs_t offset, uint8_t data)
 
 void cqgmem_device::io_map(address_map &map)
 {
-	map(0x00, 0x06).w(FUNC(cqgmem_device::write));
+	map(0x00, 0x06).mirror(0xff00).w(FUNC(cqgmem_device::write));
 }
 
 } // namespace bus::epson_qx

--- a/src/devices/bus/epson_qx/cr1510.cpp
+++ b/src/devices/bus/epson_qx/cr1510.cpp
@@ -56,7 +56,7 @@ void cr1510_device::device_reset()
 
 void cr1510_device::map(address_map &map)
 {
-	map(0x00, 0x07).rw(m_hdd, FUNC(wd1000_device::read), FUNC(wd1000_device::write));
+	map(0x00, 0x07).mirror(0xff00).rw(m_hdd, FUNC(wd1000_device::read), FUNC(wd1000_device::write));
 }
 
 } // namespace bus::epson_qx

--- a/src/devices/bus/epson_qx/ide.cpp
+++ b/src/devices/bus/epson_qx/ide.cpp
@@ -104,7 +104,7 @@ void ide_device::write(offs_t offset, uint8_t data)
 
 void ide_device::map(address_map &map)
 {
-	map(0x00, 0x0f).rw(FUNC(ide_device::read), FUNC(ide_device::write));
+	map(0x00, 0x0f).mirror(0xff00).rw(FUNC(ide_device::read), FUNC(ide_device::write));
 }
 
 } // namespace bus::epson_qx

--- a/src/devices/bus/epson_qx/multifont.cpp
+++ b/src/devices/bus/epson_qx/multifont.cpp
@@ -283,7 +283,7 @@ void multifont_device::rom_map(address_map &map)
 
 void multifont_device::map(address_map &map)
 {
-	map(0x00, 0x01).rw(FUNC(multifont_device::read), FUNC(multifont_device::write));
+	map(0x00, 0x01).mirror(0xff00).rw(FUNC(multifont_device::read), FUNC(multifont_device::write));
 }
 
 } // namespace bus::epson_qx

--- a/src/devices/bus/epson_qx/option.cpp
+++ b/src/devices/bus/epson_qx/option.cpp
@@ -12,6 +12,7 @@
 #include "cr1510.h"
 #include "ide.h"
 #include "multifont.h"
+#include "semidisk.h"
 #include "sound_card.h"
 
 DEFINE_DEVICE_TYPE(EPSON_QX_OPTION_BUS_SLOT, bus::epson_qx::option_slot_device, "epson_qx_option_slot", "QX-10 Option slot")
@@ -198,6 +199,7 @@ void option_bus_devices(device_slot_interface &device)
 	device.option_add("cr1510", EPSON_QX_OPTION_CR1510);
 	device.option_add("ide", EPSON_QX_OPTION_IDE);
 	device.option_add("multifont", EPSON_QX_OPTION_MULTIFONT);
+	device.option_add("semidisk", EPSON_QX_OPTION_SEMIDISK);
 	device.option_add("ym2149", EPSON_QX_OPTION_YM2149);
 }
 

--- a/src/devices/bus/epson_qx/semidisk.cpp
+++ b/src/devices/bus/epson_qx/semidisk.cpp
@@ -1,0 +1,148 @@
+// license:BSD-3-Clause
+// copyright-holders:Brian Johnson
+/*******************************************************************
+ *
+ * Semidisk Card
+ *
+ *******************************************************************/
+
+#include "emu.h"
+#include "semidisk.h"
+
+//**************************************************************************
+//  EPSON SEMIDISK DEVICE
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(EPSON_QX_OPTION_SEMIDISK, bus::epson_qx::semidisk_device, "epson_qx_option_semidisk", "Semidisk RAM Disk")
+
+namespace bus::epson_qx {
+
+static constexpr uint32_t BANK_SIZE = 512 * 1024;
+static constexpr uint8_t  NUM_BANKS = 4;
+static constexpr uint32_t RAM_SIZE = BANK_SIZE * NUM_BANKS;
+
+INPUT_PORTS_START( semidisk )
+	PORT_START("CONFIG")
+	PORT_CONFNAME(0x01, 0x01, "Battery Backup")
+	PORT_CONFSETTING(0x01, "Enabled")
+	PORT_CONFSETTING(0x00, "Disabled")
+INPUT_PORTS_END
+
+//-------------------------------------------------
+//  semidisk_device - constructor
+//-------------------------------------------------
+semidisk_device::semidisk_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, EPSON_QX_OPTION_SEMIDISK, tag, owner, clock),
+	device_nvram_interface(mconfig, *this),
+	device_option_expansion_interface(mconfig, *this),
+	m_config(*this, "CONFIG")
+{
+}
+
+//-------------------------------------------------
+//  device_input_ports - device-specific ports
+//-------------------------------------------------
+ioport_constructor semidisk_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME( semidisk );
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+void semidisk_device::device_start()
+{
+	m_ram = std::make_unique<uint8_t[]>(RAM_SIZE);
+
+	address_space &space = m_bus->iospace();
+	space.install_device(0xe0, 0xe3, *this, &semidisk_device::map);
+
+	save_pointer(NAME(m_ram), RAM_SIZE);
+	save_item(NAME(m_track));
+	save_item(NAME(m_sector));
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+void semidisk_device::device_reset()
+{
+	m_sector = 0;
+	m_track = 0;
+}
+
+//-------------------------------------------------
+//  nvram implementation
+//-------------------------------------------------
+void semidisk_device::nvram_default()
+{
+	memset(m_ram.get(), 0, RAM_SIZE);
+}
+
+bool semidisk_device::nvram_read(util::read_stream &file)
+{
+	if (!(m_config->read() & 0x01)) {
+		return false;
+	}
+
+	auto const [err, actual] = util::read(file, m_ram.get(), RAM_SIZE);
+	return !err && (actual == RAM_SIZE);
+}
+
+bool semidisk_device::nvram_write(util::write_stream &file)
+{
+	if (!(m_config->read() & 0x01)) {
+		memset(m_ram.get(), 0, RAM_SIZE);
+	}
+
+	auto const [err, actual] = util::write(file, m_ram.get(), RAM_SIZE);
+	return !err;
+}
+
+//-------------------------------------------------
+//  I/O implementation
+//-------------------------------------------------
+void semidisk_device::map(address_map &map)
+{
+	map(0x00, 0x00).select(0xff00).rw(FUNC(semidisk_device::data_r), FUNC(semidisk_device::data_w));
+	map(0x02, 0x03).mirror(0xff00).w(FUNC(semidisk_device::reg_w));
+}
+
+uint8_t semidisk_device::data_r(offs_t offset)
+{
+	uint8_t bank = (m_sector >> 4) & 0x0f;
+	uint8_t sector = m_sector & 0x0f;
+	uint8_t byte_addr = (offset >> 8) & 0x7f;
+	uint32_t ram_offset = (bank * BANK_SIZE) + (m_track * 16 * 128) + (sector * 128) + byte_addr;
+
+	if (bank < NUM_BANKS) {
+		return m_ram[ram_offset & (RAM_SIZE - 1)];
+	}
+	return 0xff;
+}
+
+void semidisk_device::data_w(offs_t offset, uint8_t data)
+{
+	uint8_t bank = (m_sector >> 4) & 0x0f;
+	uint8_t sector = m_sector & 0x0f;
+	uint8_t byte_addr = (offset >> 8) & 0x7f;
+	uint32_t ram_offset = (bank * BANK_SIZE) + (m_track * 16 * 128) + (sector * 128) + byte_addr;
+
+	if (bank < NUM_BANKS) {
+		m_ram[ram_offset & (RAM_SIZE - 1)] = data;
+	}
+}
+
+void semidisk_device::reg_w(offs_t offset, uint8_t data)
+{
+	switch(offset & 0xff) {
+	case 0:
+		m_track = data;
+		break;
+	case 1:
+		m_sector = data;
+		break;
+	}
+}
+
+} // namespace bus::epson_qx

--- a/src/devices/bus/epson_qx/semidisk.h
+++ b/src/devices/bus/epson_qx/semidisk.h
@@ -1,0 +1,65 @@
+// license:BSD-3-Clause
+// copyright-holders:Brian Johnson
+/*******************************************************************
+ *
+ * Semidisk RAM disk card
+ *
+ *******************************************************************/
+
+#ifndef MAME_BUS_EPSON_QX_SEMIDISK_H
+#define MAME_BUS_EPSON_QX_SEMIDISK_H
+
+#pragma once
+
+#include "bus/epson_qx/option.h"
+#include "machine/nvram.h"
+
+namespace bus::epson_qx {
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+/* Epson Semidisk Device */
+
+class semidisk_device : public device_t, public device_nvram_interface, public device_option_expansion_interface
+{
+public:
+	// construction/destruction
+	semidisk_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// optional information overrides
+	virtual ioport_constructor device_input_ports() const override;
+
+	// nvram interface overrides
+	virtual void nvram_default() override;
+	virtual bool nvram_read(util::read_stream &file) override;
+	virtual bool nvram_write(util::write_stream &file) override;
+
+	uint8_t data_r(offs_t offset);
+	void data_w(offs_t offset, uint8_t data);
+	void reg_w(offs_t offset, uint8_t data);
+
+	void map(address_map &map);
+private:
+	required_ioport m_config;
+
+	std::unique_ptr<uint8_t[]> m_ram;
+
+	uint8_t m_track;
+	uint8_t m_sector;
+};
+
+} // namespace bus::epson_qx
+
+// device type definition
+DECLARE_DEVICE_TYPE_NS(EPSON_QX_OPTION_SEMIDISK, bus::epson_qx, semidisk_device)
+
+
+#endif // MAME_BUS_EPSON_QX_SEMIDISK_H
+

--- a/src/devices/bus/epson_qx/sound_card.cpp
+++ b/src/devices/bus/epson_qx/sound_card.cpp
@@ -102,9 +102,9 @@ void ym2149_sound_card_device::device_reset()
 
 void ym2149_sound_card_device::map(address_map &map)
 {
-	map(0x01, 0x01).r(m_ssg, FUNC(ym2149_device::data_r));
-	map(0x00, 0x01).w(m_ssg, FUNC(ym2149_device::address_data_w));
-	map(0x02, 0x03).rw(m_mpu401, FUNC(mpu401_device::mpu_r), FUNC(mpu401_device::mpu_w));
+	map(0x01, 0x01).mirror(0xff00).r(m_ssg, FUNC(ym2149_device::data_r));
+	map(0x00, 0x01).mirror(0xff00).w(m_ssg, FUNC(ym2149_device::address_data_w));
+	map(0x02, 0x03).mirror(0xff00).rw(m_mpu401, FUNC(mpu401_device::mpu_r), FUNC(mpu401_device::mpu_w));
 }
 
 void ym2149_sound_card_device::mpu_irq_out(int state)

--- a/src/mame/epson/qx10.cpp
+++ b/src/mame/epson/qx10.cpp
@@ -744,27 +744,27 @@ void qx10_state::qx10_mem(address_map &map)
 
 void qx10_state::qx10_io(address_map &map)
 {
-	map.global_mask(0xff);
-	map(0x00, 0x03).rw(m_pit_1, FUNC(pit8253_device::read), FUNC(pit8253_device::write));
-	map(0x04, 0x07).rw(m_pit_2, FUNC(pit8253_device::read), FUNC(pit8253_device::write));
-	map(0x08, 0x09).rw(m_pic_m, FUNC(pic8259_device::read), FUNC(pic8259_device::write));
-	map(0x0c, 0x0d).rw(m_pic_s, FUNC(pic8259_device::read), FUNC(pic8259_device::write));
-	map(0x10, 0x13).rw(m_scc, FUNC(upd7201_device::cd_ba_r), FUNC(upd7201_device::cd_ba_w));
-	map(0x14, 0x17).rw(m_ppi, FUNC(i8255_device::read), FUNC(i8255_device::write));
-	map(0x18, 0x1b).portr("DSW").w(FUNC(qx10_state::qx10_18_w));
-	map(0x1c, 0x1f).w(FUNC(qx10_state::prom_sel_w));
-	map(0x20, 0x23).w(FUNC(qx10_state::cmos_sel_w));
-	map(0x2c, 0x2c).portr("CONFIG");
-	map(0x2d, 0x2d).rw(FUNC(qx10_state::vram_bank_r), FUNC(qx10_state::vram_bank_w));
-	map(0x30, 0x33).rw(FUNC(qx10_state::qx10_30_r), FUNC(qx10_state::fdd_motor_w));
-	map(0x34, 0x35).m(m_fdc, FUNC(upd765a_device::map));
-	map(0x38, 0x39).rw(m_hgdc, FUNC(upd7220_device::read), FUNC(upd7220_device::write));
-	map(0x3a, 0x3a).w(FUNC(qx10_state::zoom_w));
+	map.unmap_value_high();
+	map(0x00, 0x03).mirror(0xff00).rw(m_pit_1, FUNC(pit8253_device::read), FUNC(pit8253_device::write));
+	map(0x04, 0x07).mirror(0xff00).rw(m_pit_2, FUNC(pit8253_device::read), FUNC(pit8253_device::write));
+	map(0x08, 0x09).mirror(0xff00).rw(m_pic_m, FUNC(pic8259_device::read), FUNC(pic8259_device::write));
+	map(0x0c, 0x0d).mirror(0xff00).rw(m_pic_s, FUNC(pic8259_device::read), FUNC(pic8259_device::write));
+	map(0x10, 0x13).mirror(0xff00).rw(m_scc, FUNC(upd7201_device::cd_ba_r), FUNC(upd7201_device::cd_ba_w));
+	map(0x14, 0x17).mirror(0xff00).rw(m_ppi, FUNC(i8255_device::read), FUNC(i8255_device::write));
+	map(0x18, 0x1b).mirror(0xff00).portr("DSW").w(FUNC(qx10_state::qx10_18_w));
+	map(0x1c, 0x1f).mirror(0xff00).w(FUNC(qx10_state::prom_sel_w));
+	map(0x20, 0x23).mirror(0xff00).w(FUNC(qx10_state::cmos_sel_w));
+	map(0x2c, 0x2c).mirror(0xff00).portr("CONFIG");
+	map(0x2d, 0x2d).mirror(0xff00).rw(FUNC(qx10_state::vram_bank_r), FUNC(qx10_state::vram_bank_w));
+	map(0x30, 0x33).mirror(0xff00).rw(FUNC(qx10_state::qx10_30_r), FUNC(qx10_state::fdd_motor_w));
+	map(0x34, 0x35).mirror(0xff00).m(m_fdc, FUNC(upd765a_device::map));
+	map(0x38, 0x39).mirror(0xff00).rw(m_hgdc, FUNC(upd7220_device::read), FUNC(upd7220_device::write));
+	map(0x3a, 0x3a).mirror(0xff00).w(FUNC(qx10_state::zoom_w));
 //  map(0x3b, 0x3b) GDC light pen req
-	map(0x3c, 0x3c).rw(m_rtc, FUNC(mc146818_device::data_r), FUNC(mc146818_device::data_w));
-	map(0x3d, 0x3d).w(m_rtc, FUNC(mc146818_device::address_w));
-	map(0x40, 0x4f).rw(m_dma_1, FUNC(am9517a_device::read), FUNC(am9517a_device::write));
-	map(0x50, 0x5f).rw(m_dma_2, FUNC(am9517a_device::read), FUNC(am9517a_device::write));
+	map(0x3c, 0x3c).mirror(0xff00).rw(m_rtc, FUNC(mc146818_device::data_r), FUNC(mc146818_device::data_w));
+	map(0x3d, 0x3d).mirror(0xff00).w(m_rtc, FUNC(mc146818_device::address_w));
+	map(0x40, 0x4f).mirror(0xff00).rw(m_dma_1, FUNC(am9517a_device::read), FUNC(am9517a_device::write));
+	map(0x50, 0x5f).mirror(0xff00).rw(m_dma_2, FUNC(am9517a_device::read), FUNC(am9517a_device::write));
 }
 
 /* Input ports */


### PR DESCRIPTION
This adds support the QX-10 semidisk card which was a battery backed 2MB RAM disk card for the QX-10 with native support in TPM/Valdocs.