### PR TITLE
wd1000.cpp: Set ID not found error properly

### DIFF
--- a/src/devices/machine/wd1000.cpp
+++ b/src/devices/machine/wd1000.cpp
@@ -230,33 +230,27 @@ void wd1000_device::end_command()
 	set_intrq(1);
 }
 
+bool wd1000_device::validate_id_field()
+{
+	harddisk_image_device *file = m_drives[drive()];
+	const auto &info = file->get_info();
+	int16_t sector = m_sector_number - m_sector_base;
+	if (m_cylinder > info.cylinders ||
+	    head() >= info.heads || sector < 0 ||
+	    sector >= info.sectors ||
+	    sector_bytes() != info.sectorbytes) {
+		return false;
+	}
+	return true;
+}
+
 int wd1000_device::get_lbasector()
 {
 	harddisk_image_device *file = m_drives[drive()];
 	const auto &info = file->get_info();
 	int lbasector;
 
-	if (m_cylinder > info.cylinders)
-	{
-		logerror("%s: Unexpected cylinder %d for range 0 to %d\n", machine().describe_context(), m_cylinder, info.cylinders - 1);
-	}
-
-	if (head() >= info.heads)
-	{
-		logerror("%s: Unexpected head %d for range 0 to %d\n", machine().describe_context(), head(), info.heads - 1);
-	}
-
 	int16_t sector = m_sector_number - m_sector_base;
-
-	if (sector < 0 || sector >= info.sectors)
-	{
-		logerror("%s: Unexpected sector number %d for range %d to %d\n", machine().describe_context(), m_sector_number, m_sector_base, info.sectors + m_sector_base);
-	}
-
-	if (sector_bytes() != info.sectorbytes)
-	{
-		logerror("%s: Unexpected sector bytes %d, expected %d\n", machine().describe_context(), sector_bytes(), info.sectorbytes);
-	}
 
 	lbasector = m_cylinder;
 	lbasector *= info.heads;
@@ -568,8 +562,14 @@ void wd1000_device::cmd_restore()
 void wd1000_device::cmd_read_sector()
 {
 	harddisk_image_device *file = m_drives[drive()];
-	uint8_t dma = BIT(m_command, 3);
 
+	if (!validate_id_field()) {
+		set_error(ERR_ID);
+		end_command();
+		return;
+	}
+
+	uint8_t dma = BIT(m_command, 3);
 	file->read(get_lbasector(), m_buffer);
 
 	m_buffer_index = 0;
@@ -589,6 +589,12 @@ void wd1000_device::cmd_read_sector()
 void wd1000_device::cmd_write_sector()
 {
 	harddisk_image_device *file = m_drives[drive()];
+
+	if (!validate_id_field()) {
+		set_error(ERR_ID);
+		end_command();
+		return;
+	}
 
 	if (m_buffer_index != sector_bytes())
 	{

--- a/src/devices/machine/wd1000.h
+++ b/src/devices/machine/wd1000.h
@@ -86,6 +86,7 @@ private:
 	attotime get_stepping_rate();
 	void start_command();
 	void end_command();
+	bool validate_id_field();
 	int get_lbasector();
 
 	int head() { return (m_sdh >> 0) & 0x07; }


### PR DESCRIPTION
This makes the wd1000 controller report the ID not found error condition on read or write operations. This fixes an issue with valdocs on the QX010 not detecting a CR1510 hard drive properly. This is due to Valdocs probing the hard disk geometry via the read command and expecting the drive to report an error if the geometry is incorrect.