### PR TITLE
cpu/powerpc: implement reservation for lwarx and stwcx instruction pair

### DIFF
--- a/src/devices/cpu/powerpc/ppc.h
+++ b/src/devices/cpu/powerpc/ppc.h
@@ -340,6 +340,9 @@ protected:
 		const char * format;                     /* format string for printing */
 		uint32_t       arg0;                       /* print_debug argument 1 */
 		double       fp0;                        /* floating point 0 */
+		/* reservation monitor for lwarx and stwcx */
+		uint32_t reserve;
+		uint32_t reserve_address;
 	};
 
 	internal_ppc_state *m_core;

--- a/src/devices/cpu/powerpc/ppc.h
+++ b/src/devices/cpu/powerpc/ppc.h
@@ -603,9 +603,11 @@ protected:
 	uml::code_handle *   m_read32[8];                  /* read word */
 	uml::code_handle *   m_read32align[8];             /* read word aligned */
 	uml::code_handle *   m_read32mask[8];              /* read word */
+	uml::code_handle *   m_read32reserve[8];           /* read word reserved */
 	uml::code_handle *   m_write32[8];                 /* write word */
 	uml::code_handle *   m_write32align[8];            /* write word aligned */
 	uml::code_handle *   m_write32mask[8];             /* write word */
+	uml::code_handle *   m_write32reserve[8];          /* write word reserved */
 	uml::code_handle *   m_read64[8];                  /* read double */
 	uml::code_handle *   m_read64mask[8];              /* read double */
 	uml::code_handle *   m_write64[8];                 /* write double */
@@ -682,7 +684,7 @@ protected:
 	void static_generate_out_of_cycles();
 	void static_generate_tlb_mismatch();
 	void static_generate_exception(uint8_t exception, int recover, const char *name);
-	void static_generate_memory_accessor(int mode, int size, int iswrite, int ismasked, const char *name, uml::code_handle *&handleptr, uml::code_handle *masked);
+	void static_generate_memory_accessor(int mode, int size, int iswrite, int ismasked, int isreserve, const char *name, uml::code_handle *&handleptr, uml::code_handle *masked);
 	void static_generate_swap_tgpr();
 	void static_generate_lsw_entries(int mode);
 	void static_generate_stsw_entries(int mode);

--- a/src/devices/cpu/powerpc/ppc.h
+++ b/src/devices/cpu/powerpc/ppc.h
@@ -214,7 +214,7 @@ protected:
 	};
 
 	// construction/destruction
-	ppc_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, int address_bits, int data_bits, powerpc_flavor flavor, uint32_t cap, uint32_t tb_divisor, address_map_constructor internal_map);
+	ppc_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, int address_bits, int data_bits, powerpc_flavor flavor, uint32_t cap, uint32_t tb_divisor, address_map_constructor internal_map, uint32_t reservation_size);
 
 public:
 	virtual ~ppc_device() override;
@@ -582,6 +582,9 @@ protected:
 	/* internal stuff */
 	uint8_t               m_cache_dirty;                /* true if we need to flush the cache */
 
+	/* reservation granularity */
+	uint32_t              m_reservation_mask;
+
 	/* register mappings */
 	uml::parameter   m_regmap[32];                 /* parameter to register mappings for all 32 integer registers */
 	uml::parameter   m_fdregmap[32];               /* parameter to register mappings for all 32 floating point registers */
@@ -684,7 +687,7 @@ protected:
 	void static_generate_out_of_cycles();
 	void static_generate_tlb_mismatch();
 	void static_generate_exception(uint8_t exception, int recover, const char *name);
-	void static_generate_memory_accessor(int mode, int size, int iswrite, int ismasked, int isreserve, const char *name, uml::code_handle *&handleptr, uml::code_handle *masked);
+	void static_generate_memory_accessor(int mode, int size, bool iswrite, bool ismasked, bool isreserve, const char *name, uml::code_handle *&handleptr, uml::code_handle *masked);
 	void static_generate_swap_tgpr();
 	void static_generate_lsw_entries(int mode);
 	void static_generate_stsw_entries(int mode);
@@ -803,7 +806,7 @@ public:
 
 	void internal_ppc4xx(address_map &map) ATTR_COLD;
 protected:
-	ppc4xx_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, powerpc_flavor flavor, uint32_t cap, uint32_t tb_divisor);
+	ppc4xx_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, powerpc_flavor flavor, uint32_t cap, uint32_t tb_divisor, uint32_t reservation_size);
 
 	virtual void execute_set_input(int inputnum, int state) override;
 };

--- a/src/devices/cpu/powerpc/ppccom.cpp
+++ b/src/devices/cpu/powerpc/ppccom.cpp
@@ -838,6 +838,8 @@ void ppc_device::device_start()
 	save_item(NAME(m_core->irq_pending));
 	save_item(NAME(m_tb_zero_cycles));
 	save_item(NAME(m_dec_zero_cycles));
+	save_item(NAME(m_core->reserve));
+	save_item(NAME(m_core->reserve_address));
 
 	// Register debugger state
 	state_add(PPC_PC,    "PC", m_core->pc).formatstr("%08X");
@@ -928,6 +930,8 @@ void ppc_device::device_start()
 	m_drcuml->symbol_add(&m_cmp_cr_table, sizeof(m_cmp_cr_table), "cmp_cr_table");
 	m_drcuml->symbol_add(&m_cmpl_cr_table, sizeof(m_cmpl_cr_table), "cmpl_cr_table");
 	m_drcuml->symbol_add(&m_fcmp_cr_table, sizeof(m_fcmp_cr_table), "fcmp_cr_table");
+	m_drcuml->symbol_add(&m_core->reserve, sizeof(m_core->reserve), "reserve");
+	m_drcuml->symbol_add(&m_core->reserve_address, sizeof(m_core->reserve_address), "reserve_address");
 
 	/* initialize the front-end helper */
 	m_drcfe = std::make_unique<frontend>(*this, COMPILE_BACKWARDS_BYTES, COMPILE_FORWARDS_BYTES, SINGLE_INSTRUCTION_MODE ? 1 : COMPILE_MAX_SEQUENCE);

--- a/src/devices/cpu/powerpc/ppccom.cpp
+++ b/src/devices/cpu/powerpc/ppccom.cpp
@@ -213,7 +213,7 @@ DEFINE_DEVICE_TYPE(PPC740,    ppc740_device,    "ppc740",     "IBM PowerPC 740")
 DEFINE_DEVICE_TYPE(PPC750,    ppc750_device,    "ppc750",     "IBM PowerPC 750")
 
 
-ppc_device::ppc_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, int address_bits, int data_bits, powerpc_flavor flavor, uint32_t cap, uint32_t tb_divisor, address_map_constructor internal_map)
+ppc_device::ppc_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, int address_bits, int data_bits, powerpc_flavor flavor, uint32_t cap, uint32_t tb_divisor, address_map_constructor internal_map, uint32_t reservation_size)
 	: cpu_device(mconfig, type, tag, owner, clock)
 	, device_vtlb_interface(mconfig, *this, AS_PROGRAM)
 	, m_program_config("program", ENDIANNESS_BIG, data_bits, address_bits, 0, internal_map)
@@ -234,6 +234,7 @@ ppc_device::ppc_device(const machine_config &mconfig, device_type type, const ch
 	, m_drcuml(nullptr)
 	, m_drcfe(nullptr)
 	, m_drcoptions(0)
+	, m_reservation_mask(0xffffffff - (reservation_size - 1))
 	, m_dasm(powerpc_disassembler())
 {
 	m_program_config.m_logaddr_width = 32;
@@ -260,32 +261,32 @@ ppc_device::~ppc_device()
 //}
 
 ppc603_device::ppc603_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: ppc_device(mconfig, PPC603, tag, owner, clock, 32, 64, PPC_MODEL_603, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_603_MMU, 4, address_map_constructor())
+	: ppc_device(mconfig, PPC603, tag, owner, clock, 32, 64, PPC_MODEL_603, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_603_MMU, 4, address_map_constructor(), 32)
 {
 }
 
 ppc603e_device::ppc603e_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: ppc_device(mconfig, PPC603E, tag, owner, clock, 32, 64, PPC_MODEL_603E, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_603_MMU, 4, address_map_constructor())
+	: ppc_device(mconfig, PPC603E, tag, owner, clock, 32, 64, PPC_MODEL_603E, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_603_MMU, 4, address_map_constructor(), 32)
 {
 }
 
 ppc603r_device::ppc603r_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: ppc_device(mconfig, PPC603R, tag, owner, clock, 32, 64, PPC_MODEL_603R, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_603_MMU, 4, address_map_constructor())
+	: ppc_device(mconfig, PPC603R, tag, owner, clock, 32, 64, PPC_MODEL_603R, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_603_MMU, 4, address_map_constructor(), 32)
 {
 }
 
 ppc602_device::ppc602_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: ppc_device(mconfig, PPC602, tag, owner, clock, 32, 64, PPC_MODEL_602, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_603_MMU, 4, address_map_constructor())
+	: ppc_device(mconfig, PPC602, tag, owner, clock, 32, 64, PPC_MODEL_602, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_603_MMU, 4, address_map_constructor(), 32)
 {
 }
 
 mpc8240_device::mpc8240_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: ppc_device(mconfig, MPC8240, tag, owner, clock, 32, 64, PPC_MODEL_MPC8240, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_603_MMU, 4/* unknown */, address_map_constructor())
+	: ppc_device(mconfig, MPC8240, tag, owner, clock, 32, 64, PPC_MODEL_MPC8240, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_603_MMU, 4/* unknown */, address_map_constructor(), 32)
 {
 }
 
 ppc601_device::ppc601_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: ppc_device(mconfig, PPC601, tag, owner, clock, 32, 64, PPC_MODEL_601, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_MFIOC | PPCCAP_601BAT | PPCCAP_LEGACY_POWER, 0 /* no TB */, address_map_constructor())
+	: ppc_device(mconfig, PPC601, tag, owner, clock, 32, 64, PPC_MODEL_601, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_MFIOC | PPCCAP_601BAT | PPCCAP_LEGACY_POWER, 0 /* no TB */, address_map_constructor(), 32)
 {
 }
 
@@ -296,17 +297,17 @@ std::unique_ptr<util::disasm_interface> ppc601_device::create_disassembler()
 }
 
 ppc604_device::ppc604_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: ppc_device(mconfig, PPC604, tag, owner, clock, 32, 64, PPC_MODEL_604, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_604_MMU, 4, address_map_constructor())
+	: ppc_device(mconfig, PPC604, tag, owner, clock, 32, 64, PPC_MODEL_604, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_604_MMU, 4, address_map_constructor(), 32)
 {
 }
 
 ppc740_device::ppc740_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: ppc_device(mconfig, PPC740, tag, owner, clock, 32, 64, PPC_MODEL_740, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_604_MMU | PPCCAP_750_TLB , 4, address_map_constructor())
+	: ppc_device(mconfig, PPC740, tag, owner, clock, 32, 64, PPC_MODEL_740, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_604_MMU | PPCCAP_750_TLB , 4, address_map_constructor(), 32)
 {
 }
 
 ppc750_device::ppc750_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: ppc_device(mconfig, PPC750, tag, owner, clock, 32, 64, PPC_MODEL_750, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_604_MMU | PPCCAP_750_TLB, 4, address_map_constructor())
+	: ppc_device(mconfig, PPC750, tag, owner, clock, 32, 64, PPC_MODEL_750, PPCCAP_OEA | PPCCAP_VEA | PPCCAP_FPU | PPCCAP_MISALIGNED | PPCCAP_604_MMU | PPCCAP_750_TLB, 4, address_map_constructor(), 32)
 {
 }
 
@@ -315,23 +316,23 @@ void ppc4xx_device::internal_ppc4xx(address_map &map)
 	map(0x40000000, 0x4000000f).rw(FUNC(ppc4xx_device::ppc4xx_spu_r), FUNC(ppc4xx_device::ppc4xx_spu_w));
 }
 
-ppc4xx_device::ppc4xx_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, powerpc_flavor flavor, uint32_t cap, uint32_t tb_divisor)
-	: ppc_device(mconfig, type, tag, owner, clock, 31, 32, flavor, cap, tb_divisor, address_map_constructor(FUNC(ppc4xx_device::internal_ppc4xx), this))
+ppc4xx_device::ppc4xx_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, powerpc_flavor flavor, uint32_t cap, uint32_t tb_divisor, uint32_t reservation_size)
+	: ppc_device(mconfig, type, tag, owner, clock, 31, 32, flavor, cap, tb_divisor, address_map_constructor(FUNC(ppc4xx_device::internal_ppc4xx), this), reservation_size)
 {
 }
 
 ppc403ga_device::ppc403ga_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: ppc4xx_device(mconfig, PPC403GA, tag, owner, clock, PPC_MODEL_403GA, PPCCAP_4XX, 1)
+	: ppc4xx_device(mconfig, PPC403GA, tag, owner, clock, PPC_MODEL_403GA, PPCCAP_4XX, 1, 16)
 {
 }
 
 ppc403gcx_device::ppc403gcx_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: ppc4xx_device(mconfig, PPC403GCX, tag, owner, clock, PPC_MODEL_403GCX, PPCCAP_4XX, 1)
+	: ppc4xx_device(mconfig, PPC403GCX, tag, owner, clock, PPC_MODEL_403GCX, PPCCAP_4XX, 1, 16)
 {
 }
 
 ppc405gp_device::ppc405gp_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: ppc4xx_device(mconfig, PPC405GP, tag, owner, clock, PPC_MODEL_405GP, PPCCAP_4XX | PPCCAP_VEA, 1)
+	: ppc4xx_device(mconfig, PPC405GP, tag, owner, clock, PPC_MODEL_405GP, PPCCAP_4XX | PPCCAP_VEA, 1, 32)
 {
 }
 

--- a/src/devices/cpu/powerpc/ppccom.cpp
+++ b/src/devices/cpu/powerpc/ppccom.cpp
@@ -620,9 +620,11 @@ void ppc_device::device_start()
 	memset(m_read32, 0, sizeof(m_read32));
 	memset(m_read32align, 0, sizeof(m_read32align));
 	memset(m_read32mask, 0, sizeof(m_read32mask));
+	memset(m_read32reserve, 0, sizeof(m_read32reserve));
 	memset(m_write32, 0, sizeof(m_write32));
 	memset(m_write32align, 0, sizeof(m_write32align));
 	memset(m_write32mask, 0, sizeof(m_write32mask));
+	memset(m_write32reserve, 0, sizeof(m_write32reserve));
 	memset(m_read64, 0, sizeof(m_read64));
 	memset(m_read64mask, 0, sizeof(m_read64mask));
 	memset(m_write64, 0, sizeof(m_write64));
@@ -1004,22 +1006,24 @@ void ppc_device::device_start()
 		/* add subroutines for memory accesses */
 		for (int mode = 0; mode < 8; mode++)
 		{
-			static_generate_memory_accessor(mode, 1, false, false, "read8",       m_read8[mode],       nullptr);
-			static_generate_memory_accessor(mode, 1, true,  false, "write8",      m_write8[mode],      nullptr);
-			static_generate_memory_accessor(mode, 2, false, true,  "read16mask",  m_read16mask[mode],  nullptr);
-			static_generate_memory_accessor(mode, 2, false, false, "read16",      m_read16[mode],      m_read16mask[mode]);
-			static_generate_memory_accessor(mode, 2, true,  true,  "write16mask", m_write16mask[mode], nullptr);
-			static_generate_memory_accessor(mode, 2, true,  false, "write16",     m_write16[mode],     m_write16mask[mode]);
-			static_generate_memory_accessor(mode, 4, false, true,  "read32mask",  m_read32mask[mode],  nullptr);
-			static_generate_memory_accessor(mode, 4, false, false, "read32align", m_read32align[mode], nullptr);
-			static_generate_memory_accessor(mode, 4, false, false, "read32",      m_read32[mode],      m_read32mask[mode]);
-			static_generate_memory_accessor(mode, 4, true,  true,  "write32mask", m_write32mask[mode], nullptr);
-			static_generate_memory_accessor(mode, 4, true,  false, "write32align",m_write32align[mode],nullptr);
-			static_generate_memory_accessor(mode, 4, true,  false, "write32",     m_write32[mode],     m_write32mask[mode]);
-			static_generate_memory_accessor(mode, 8, false, true,  "read64mask",  m_read64mask[mode],  nullptr);
-			static_generate_memory_accessor(mode, 8, false, false, "read64",      m_read64[mode],      m_read64mask[mode]);
-			static_generate_memory_accessor(mode, 8, true,  true,  "write64mask", m_write64mask[mode], nullptr);
-			static_generate_memory_accessor(mode, 8, true,  false, "write64",     m_write64[mode],     m_write64mask[mode]);
+			static_generate_memory_accessor(mode, 1, false, false, false, "read8",         m_read8[mode],         nullptr);
+			static_generate_memory_accessor(mode, 1, true,  false, false, "write8",        m_write8[mode],        nullptr);
+			static_generate_memory_accessor(mode, 2, false, true,  false, "read16mask",    m_read16mask[mode],    nullptr);
+			static_generate_memory_accessor(mode, 2, false, false, false, "read16",        m_read16[mode],        m_read16mask[mode]);
+			static_generate_memory_accessor(mode, 2, true,  true,  false, "write16mask",   m_write16mask[mode],   nullptr);
+			static_generate_memory_accessor(mode, 2, true,  false, false, "write16",       m_write16[mode],       m_write16mask[mode]);
+			static_generate_memory_accessor(mode, 4, false, true,  false, "read32mask",    m_read32mask[mode],    nullptr);
+			static_generate_memory_accessor(mode, 4, false, false, false, "read32align",   m_read32align[mode],   nullptr);
+			static_generate_memory_accessor(mode, 4, false, false, true,  "read32reserve", m_read32reserve[mode], nullptr);
+			static_generate_memory_accessor(mode, 4, false, false, false, "read32",        m_read32[mode],        m_read32mask[mode]);
+			static_generate_memory_accessor(mode, 4, true,  true,  false, "write32mask",   m_write32mask[mode],   nullptr);
+			static_generate_memory_accessor(mode, 4, true,  false, false, "write32align",  m_write32align[mode],  nullptr);
+			static_generate_memory_accessor(mode, 4, true,  false, true,  "write32reserve",m_write32reserve[mode],nullptr);
+			static_generate_memory_accessor(mode, 4, true,  false, false, "write32",       m_write32[mode],       m_write32mask[mode]);
+			static_generate_memory_accessor(mode, 8, false, true,  false, "read64mask",    m_read64mask[mode],    nullptr);
+			static_generate_memory_accessor(mode, 8, false, false, false, "read64",        m_read64[mode],        m_read64mask[mode]);
+			static_generate_memory_accessor(mode, 8, true,  true,  false, "write64mask",   m_write64mask[mode],   nullptr);
+			static_generate_memory_accessor(mode, 8, true,  false, false, "write64",       m_write64[mode],       m_write64mask[mode]);
 			static_generate_lsw_entries(mode);
 			static_generate_stsw_entries(mode);
 		}

--- a/src/devices/cpu/powerpc/ppcdrc.cpp
+++ b/src/devices/cpu/powerpc/ppcdrc.cpp
@@ -996,6 +996,14 @@ void ppc_device::static_generate_memory_accessor(int mode, int size, int iswrite
 		}
 	}
 
+	/* if writing to a reserved memory block, cancel the reservation */
+	if (iswrite)
+	{
+		UML_AND(block, I3, I0, 0xffffffe0);                                 // and     i3,i0,0xffffffe0
+		UML_CMP(block, mem(&m_core->reserve_address), I3);                  // cmp     reserve_address,i3
+		UML_MOVc(block, COND_E, mem(&m_core->reserve), 0);                  // mov     reserve,0,e
+	}
+
 	/* general case: assume paging and perform a translation */
 	if (((m_cap & PPCCAP_OEA) && (mode & MODE_DATA_TRANSLATION)) || (iswrite && (m_cap & PPCCAP_4XX) && (mode & MODE_PROTECTION)))
 	{
@@ -3167,10 +3175,13 @@ bool ppc_device::generate_instruction_1f(drcuml_block &block, compiler_state *co
 			return true;
 
 		case 0x014: /* LWARX */
-			UML_ADD(block, I0, R32Z(G_RA(op)), R32(G_RB(op)));                          // add     i0,ra,rb
-			UML_MAPVAR(block, MAPVAR_DSISR, DSISR_IDX(op));                                 // mapvar  dsisr,DSISR_IDX(op)
-			UML_CALLH(block, *m_read32align[m_core->mode]);             // callh   read32align
-			UML_MOV(block, R32(G_RD(op)), I0);                                          // mov     rd,i0
+			UML_ADD(block, I0, R32Z(G_RA(op)), R32(G_RB(op)));                     // add     i0,ra,rb
+			UML_MOV(block, mem(&m_core->reserve), 1);                              // mov     reserve,1
+			UML_AND(block, I1, I0, 0xffffffe0);                                    // and     i1,i0,0xffffffe0
+			UML_MOV(block, mem(&m_core->reserve_address), I1);                     // mov     reserve_address,i1
+			UML_MAPVAR(block, MAPVAR_DSISR, DSISR_IDX(op));                        // mapvar  dsisr,DSISR_IDX(op)
+			UML_CALLH(block, *m_read32align[m_core->mode]);                        // callh   read32align
+			UML_MOV(block, R32(G_RD(op)), I0);                                     // mov     rd,i0
 			generate_update_cycles(block, compiler, desc->pc + 4, true);           // <update cycles>
 			return true;
 
@@ -3314,18 +3325,19 @@ bool ppc_device::generate_instruction_1f(drcuml_block &block, compiler_state *co
 			return true;
 
 		case 0x096: /* STWCX. */
-			UML_ADD(block, I0, R32Z(G_RA(op)), R32(G_RB(op)));                          // add     i0,ra,rb
-			UML_MOV(block, I1, R32(G_RS(op)));                                          // mov     i1,rs
-			UML_MAPVAR(block, MAPVAR_DSISR, DSISR_IDX(op));                                 // mapvar  dsisr,DSISR_IDX(op)
-			UML_CALLH(block, *m_write32align[m_core->mode]);                // callh   write32align
-			generate_update_cycles(block, compiler, desc->pc + 4, true);           // <update cycles>
-
-			UML_CMP(block, I0, I0);                                             // cmp     i0,i0
-			UML_GETFLGS(block, I0, FLAG_Z | FLAG_C | FLAG_S);                           // getflgs i0,zcs
-			UML_LOAD(block, I0, m_cmp_cr_table, I0, SIZE_BYTE, SCALE_x1);// load    i0,cmp_cr_table,i0,byte
-			UML_OR(block, CR32(0), I0, XERSO32);                               // or      [cr0],i0,[xerso]
-
-			generate_compute_flags(block, desc, true, 0, false);                       // <update flags>
+			UML_CMP(block, mem(&m_core->reserve), 0);                              // cmp     reserve,0
+			UML_JMPc(block, COND_Z, compiler->labelnum);                           // bz      1:
+			UML_ADD(block, I0, R32Z(G_RA(op)), R32(G_RB(op)));                     // add     i0,ra,rb
+			UML_MOV(block, I1, R32(G_RS(op)));                                     // mov     i1,rs
+			UML_MAPVAR(block, MAPVAR_DSISR, DSISR_IDX(op));                        // mapvar  dsisr,DSISR_IDX(op)
+			UML_CALLH(block, *m_write32align[m_core->mode]);                       // callh   write32align
+			UML_MOV(block, mem(&m_core->reserve), 0);                              // mov     reserve,0
+			UML_OR(block, CR32(0), 2, XERSO32);                                    // or      [cr0],2,[xerso]
+			UML_JMP(block, compiler->labelnum + 1);                                // b       2:
+			UML_LABEL(block, compiler->labelnum++);                                // 1:
+			UML_MOV(block, CR32(0), XERSO32);                                      // mov     [cr0],[xerso]
+			UML_LABEL(block, compiler->labelnum++);                                // 2:
+			generate_compute_flags(block, desc, true, 0, false);                   // <update flags>
 			return true;
 
 		case 0x2d5: /* STSWI */

--- a/src/devices/cpu/powerpc/ppcdrc.cpp
+++ b/src/devices/cpu/powerpc/ppcdrc.cpp
@@ -996,14 +996,6 @@ void ppc_device::static_generate_memory_accessor(int mode, int size, int iswrite
 		}
 	}
 
-	/* if writing to a reserved memory block, cancel the reservation */
-	if (iswrite)
-	{
-		UML_AND(block, I3, I0, 0xffffffe0);                                 // and     i3,i0,0xffffffe0
-		UML_CMP(block, mem(&m_core->reserve_address), I3);                  // cmp     reserve_address,i3
-		UML_MOVc(block, COND_E, mem(&m_core->reserve), 0);                  // mov     reserve,0,e
-	}
-
 	/* general case: assume paging and perform a translation */
 	if (((m_cap & PPCCAP_OEA) && (mode & MODE_DATA_TRANSLATION)) || (iswrite && (m_cap & PPCCAP_4XX) && (mode & MODE_PROTECTION)))
 	{
@@ -3337,7 +3329,7 @@ bool ppc_device::generate_instruction_1f(drcuml_block &block, compiler_state *co
 			UML_LABEL(block, compiler->labelnum++);                                // 1:
 			UML_MOV(block, CR32(0), XERSO32);                                      // mov     [cr0],[xerso]
 			UML_LABEL(block, compiler->labelnum++);                                // 2:
-			generate_compute_flags(block, desc, true, 0, false);                   // <update flags>
+			generate_update_cycles(block, compiler, desc->pc + 4, true);           // <update cycles>
 			return true;
 
 		case 0x2d5: /* STSWI */

--- a/src/devices/cpu/powerpc/ppcdrc.cpp
+++ b/src/devices/cpu/powerpc/ppcdrc.cpp
@@ -939,7 +939,7 @@ void ppc_device::static_generate_exception(uint8_t exception, int recover, const
     static_generate_memory_accessor
 ------------------------------------------------------------------*/
 
-void ppc_device::static_generate_memory_accessor(int mode, int size, int iswrite, int ismasked, const char *name, uml::code_handle *&handleptr, uml::code_handle *masked)
+void ppc_device::static_generate_memory_accessor(int mode, int size, int iswrite, int ismasked, int isreserve, const char *name, uml::code_handle *&handleptr, uml::code_handle *masked)
 {
 	/* on entry, address is in I0; data for writes is in I1; masks are in I2 */
 	/* on exit, read result is in I0 */
@@ -1009,6 +1009,27 @@ void ppc_device::static_generate_memory_accessor(int mode, int size, int iswrite
 	else if (m_cap & PPCCAP_4XX)
 		UML_AND(block, I0, I0, 0x7fffffff);                                 // and     i0,i0,0x7fffffff
 	UML_XOR(block, I0, I0, (mode & MODE_LITTLE_ENDIAN) ? (8 - size) : 0);   // xor     i0,i0,8-size
+
+	if (isreserve)
+	{
+		if (iswrite)
+		{
+			int dowrite = label++;
+			UML_CMP(block, mem(&m_core->reserve), 0);                              // cmp     reserve,0
+			UML_JMPc(block, COND_NZ, dowrite);                                     // bnz      1:
+			UML_MOV(block, CR32(0), XERSO32);                                      // mov     [cr0],[xerso]
+			UML_RET(block);                                                        // ret
+			UML_LABEL(block, dowrite);                                             // 1:
+			UML_MOV(block, mem(&m_core->reserve), 0);                              // mov     reserve,0
+			UML_OR(block, CR32(0), 2, XERSO32);                                    // or      [cr0],2,[xerso]
+		}
+		else
+		{
+			UML_MOV(block, mem(&m_core->reserve), 1);                              // mov     reserve,1
+			UML_AND(block, I3, I0, 0xffffffe0);                                    // and     i3,i0,0xffffffe0
+			UML_MOV(block, mem(&m_core->reserve_address), I3);                     // mov     reserve_address,i3
+		}
+	}
 
 	if (!debugger_enabled())
 		for (ramnum = 0; ramnum < PPC_MAX_FASTRAM; ramnum++)
@@ -1304,9 +1325,11 @@ void ppc_device::static_generate_memory_accessor(int mode, int size, int iswrite
 	/* handle an alignment exception */
 	if (alignex != 0)
 	{
-		UML_LABEL(block, alignex);                                                      // alignex:
-		UML_RECOVER(block, SPR32(SPROEA_DSISR), MAPVAR_DSISR);                              // recover [dsisr],DSISR
-		UML_EXH(block, *m_exception[EXCEPTION_ALIGN], I0);                 // exh     align,i0
+		UML_LABEL(block, alignex);                                             // alignex:
+		if (isreserve && iswrite)
+			UML_MOV(block, mem(&m_core->reserve), 0);                          // mov     reserve,0
+		UML_RECOVER(block, SPR32(SPROEA_DSISR), MAPVAR_DSISR);                 // recover [dsisr],DSISR
+		UML_EXH(block, *m_exception[EXCEPTION_ALIGN], I0);                     // exh     align,i0
 	}
 
 	/* handle a TLB miss */
@@ -1324,17 +1347,21 @@ void ppc_device::static_generate_memory_accessor(int mode, int size, int iswrite
 		/* 4XX case: protection exception */
 		if (m_cap & PPCCAP_4XX)
 		{
-			UML_MOV(block, SPR32(SPR4XX_DEAR), I0);                                 // mov     [dear],i0
-			UML_EXH(block, *m_exception[EXCEPTION_DSI], I0);               // exh     dsi,i0
+			if (isreserve && iswrite)
+				UML_MOV(block, mem(&m_core->reserve), 0);                      // mov     reserve,0
+			UML_MOV(block, SPR32(SPR4XX_DEAR), I0);                            // mov     [dear],i0
+			UML_EXH(block, *m_exception[EXCEPTION_DSI], I0);                   // exh     dsi,i0
 		}
 
 		/* 603 case: TLBMISS exception */
 		else if (m_cap & PPCCAP_603_MMU)
 		{
-			UML_MOV(block, SPR32(SPR603_DMISS), I0);                                    // mov     [dmiss],i0
-			UML_MOV(block, SPR32(SPR603_DCMP), mem(&m_core->mmu603_cmp));                      // mov     [dcmp],[mmu603_cmp]
-			UML_MOV(block, SPR32(SPR603_HASH1), mem(&m_core->mmu603_hash[0]));                 // mov     [hash1],[mmu603_hash][0]
-			UML_MOV(block, SPR32(SPR603_HASH2), mem(&m_core->mmu603_hash[1]));                 // mov     [hash2],[mmu603_hash][1]
+			if (isreserve && iswrite)
+				UML_MOV(block, mem(&m_core->reserve), 0);                      // mov     reserve,0
+			UML_MOV(block, SPR32(SPR603_DMISS), I0);                           // mov     [dmiss],i0
+			UML_MOV(block, SPR32(SPR603_DCMP), mem(&m_core->mmu603_cmp));      // mov     [dcmp],[mmu603_cmp]
+			UML_MOV(block, SPR32(SPR603_HASH1), mem(&m_core->mmu603_hash[0])); // mov     [hash1],[mmu603_hash][0]
+			UML_MOV(block, SPR32(SPR603_HASH2), mem(&m_core->mmu603_hash[1])); // mov     [hash2],[mmu603_hash][1]
 			if (iswrite)
 				UML_EXH(block, *m_exception[EXCEPTION_DTLBMISSS], I0);     // exh     dtlbmisss,i0
 			else
@@ -1344,7 +1371,9 @@ void ppc_device::static_generate_memory_accessor(int mode, int size, int iswrite
 		/* general case: DSI exception */
 		else
 		{
-			UML_MOV(block, SPR32(SPROEA_DAR), mem(&m_core->param0));            // mov [dar],[param0]
+			if (isreserve && iswrite)
+				UML_MOV(block, mem(&m_core->reserve), 0);                      // mov     reserve,0
+			UML_MOV(block, SPR32(SPROEA_DAR), mem(&m_core->param0));           // mov [dar],[param0]
 			// signal read or write to cfunc to get proper reason back
 			if (iswrite)
 			{
@@ -3168,11 +3197,8 @@ bool ppc_device::generate_instruction_1f(drcuml_block &block, compiler_state *co
 
 		case 0x014: /* LWARX */
 			UML_ADD(block, I0, R32Z(G_RA(op)), R32(G_RB(op)));                     // add     i0,ra,rb
-			UML_MOV(block, mem(&m_core->reserve), 1);                              // mov     reserve,1
-			UML_AND(block, I1, I0, 0xffffffe0);                                    // and     i1,i0,0xffffffe0
-			UML_MOV(block, mem(&m_core->reserve_address), I1);                     // mov     reserve_address,i1
 			UML_MAPVAR(block, MAPVAR_DSISR, DSISR_IDX(op));                        // mapvar  dsisr,DSISR_IDX(op)
-			UML_CALLH(block, *m_read32align[m_core->mode]);                        // callh   read32align
+			UML_CALLH(block, *m_read32reserve[m_core->mode]);                      // callh   read32reserve
 			UML_MOV(block, R32(G_RD(op)), I0);                                     // mov     rd,i0
 			generate_update_cycles(block, compiler, desc->pc + 4, true);           // <update cycles>
 			return true;
@@ -3317,18 +3343,10 @@ bool ppc_device::generate_instruction_1f(drcuml_block &block, compiler_state *co
 			return true;
 
 		case 0x096: /* STWCX. */
-			UML_CMP(block, mem(&m_core->reserve), 0);                              // cmp     reserve,0
-			UML_JMPc(block, COND_Z, compiler->labelnum);                           // bz      1:
 			UML_ADD(block, I0, R32Z(G_RA(op)), R32(G_RB(op)));                     // add     i0,ra,rb
 			UML_MOV(block, I1, R32(G_RS(op)));                                     // mov     i1,rs
 			UML_MAPVAR(block, MAPVAR_DSISR, DSISR_IDX(op));                        // mapvar  dsisr,DSISR_IDX(op)
-			UML_CALLH(block, *m_write32align[m_core->mode]);                       // callh   write32align
-			UML_MOV(block, mem(&m_core->reserve), 0);                              // mov     reserve,0
-			UML_OR(block, CR32(0), 2, XERSO32);                                    // or      [cr0],2,[xerso]
-			UML_JMP(block, compiler->labelnum + 1);                                // b       2:
-			UML_LABEL(block, compiler->labelnum++);                                // 1:
-			UML_MOV(block, CR32(0), XERSO32);                                      // mov     [cr0],[xerso]
-			UML_LABEL(block, compiler->labelnum++);                                // 2:
+			UML_CALLH(block, *m_write32reserve[m_core->mode]);                     // callh   write32reserve
 			generate_update_cycles(block, compiler, desc->pc + 4, true);           // <update cycles>
 			return true;
 

--- a/src/devices/cpu/powerpc/ppcdrc.cpp
+++ b/src/devices/cpu/powerpc/ppcdrc.cpp
@@ -939,7 +939,7 @@ void ppc_device::static_generate_exception(uint8_t exception, int recover, const
     static_generate_memory_accessor
 ------------------------------------------------------------------*/
 
-void ppc_device::static_generate_memory_accessor(int mode, int size, int iswrite, int ismasked, int isreserve, const char *name, uml::code_handle *&handleptr, uml::code_handle *masked)
+void ppc_device::static_generate_memory_accessor(int mode, int size, bool iswrite, bool ismasked, bool isreserve, const char *name, uml::code_handle *&handleptr, uml::code_handle *masked)
 {
 	/* on entry, address is in I0; data for writes is in I1; masks are in I2 */
 	/* on exit, read result is in I0 */
@@ -1014,8 +1014,8 @@ void ppc_device::static_generate_memory_accessor(int mode, int size, int iswrite
 	{
 		if (iswrite)
 		{
-			int dowrite = label++;
-			UML_CMP(block, mem(&m_core->reserve), 0);                              // cmp     reserve,0
+			const uml::code_label dowrite = label++;
+			UML_TEST(block, mem(&m_core->reserve), 0xffffffff);                    // test    reserve,0xffffffff
 			UML_JMPc(block, COND_NZ, dowrite);                                     // bnz      1:
 			UML_MOV(block, CR32(0), XERSO32);                                      // mov     [cr0],[xerso]
 			UML_RET(block);                                                        // ret
@@ -1026,7 +1026,7 @@ void ppc_device::static_generate_memory_accessor(int mode, int size, int iswrite
 		else
 		{
 			UML_MOV(block, mem(&m_core->reserve), 1);                              // mov     reserve,1
-			UML_AND(block, I3, I0, 0xffffffe0);                                    // and     i3,i0,0xffffffe0
+			UML_AND(block, I3, I0, m_reservation_mask);                            // and     i3,i0,m_reservation_mask
 			UML_MOV(block, mem(&m_core->reserve_address), I3);                     // mov     reserve_address,i3
 		}
 	}


### PR DESCRIPTION
PowerPC has the instructions `lwarx` and `stwcx` which are used to perform atomic update (load-modify-store) operations. `lwarx` loads a word and creates a reservation for a specific memory block; any write to this block will cause the reservation to be lost. `stwcx` checks if the reservation is still valid, and if it is, it writes the updated memory value, clears the reservation and sets the EQ bit of `cr0` to signify success. If it is not valid, it clears the EQ bit to signify failure and no write is performed.

The size of the reserved memory block is implementation-dependent, generally matching the cache line size. For many early PowerPC models, including most of those emulated in MAME, the reservation size is 32 bytes so that is what I have implemented.

This commit fixes a bug in several Model 3 games that causes them to freeze as a result of the previous incorrect implementation of the `lwarx` and `stwcx` instructions.