### PR TITLE
g65816: XBA always takes 3 cycles

### DIFF
--- a/src/devices/cpu/g65816/g65816op.ipp
+++ b/src/devices/cpu/g65816/g65816op.ipp
@@ -1437,7 +1437,7 @@
 #undef OP_XBA
 #if FLAG_SET_M
 #define OP_XBA()                                                            \
-			CLK(CLK_OP + CLK_IMPLIED);                                      \
+			CLK(CLK_OP + CLK_IMPLIED + 1);                                  \
 			FLAG_Z = REGISTER_B>>8;                                             \
 			REGISTER_B = REGISTER_A<<8;                                             \
 			REGISTER_A = FLAG_Z;                                                    \


### PR DESCRIPTION
XBA operation [is not affected by the m mode flag](https://archive.org/details/0893037893ProgrammingThe65816/page/523/mode/2up), and [always takes three cycles](https://www.westerndesigncenter.com/wdc/documentation/w65c816s.pdf#page=40).

I verified the cycle count in beam-racing code on Apple IIgs hardware.

I sanity-checked the operation of common IIgs software, and [a handful of SNES carts](https://github.com/mamedev/mame/pull/14277#issuecomment-3382801316): no obvious user-visible changes (although, instrumentation shows that XBA is quite often executed with m=1, so overall emulation speed will now be slightly slower, closer to hardware.)
