### PR TITLE
gridcomp/gridcomp.cpp: implement RS232

### DIFF
--- a/src/mame/gridcomp/gridcomp.cpp
+++ b/src/mame/gridcomp/gridcomp.cpp
@@ -74,7 +74,6 @@
 #include "machine/i80130.h"
 #include "machine/i8087.h"
 #include "machine/i8255.h"
-#include "machine/clock.h"
 #include "machine/mm58174.h"
 #include "machine/ram.h"
 #include "machine/tms9914.h"
@@ -83,7 +82,6 @@
 
 #include "emupal.h"
 #include "screen.h"
-#include "softlist.h"
 #include "speaker.h"
 
 #define LOG_KEYBOARD  (1U << 1)


### PR DESCRIPTION
TL;DR: This PR fixes the UART i8274 chip connections to the GRiD Compass laptop.

## GRiD Compass and Serial

The GRiD Compass uses a proprietary 19-pin connector that provides RS232, RS422, and +10V/-10V power. The circuit uses PAL chips that configure the signal source for TxC, RxC, and also SC for GPIB. There's no PAL dump available, only some circuit diagrams and approximate connection descriptions from @ConventionalMemories and @JDat...

Instead of emulating the PAL chip logic, I connected the i8274's TxC/RxC directly to 80130 baud. I also fixed the swapped `cd` `ba` pins, set the correct i8274 address for the GRiD Compass II and configured interrupt.

Additionally, I updated the device list. It now includes a simple serial printer (without software flow control) that works with the `MinimumSerial~Printer~` driver, plus two mice: Microsoft Mouse and Logitech Mouse. Both mice only work in GRiDPaint. On macOS, both mice behave erratically, but this appears to be a broader MAME issue on macOS rather than an emulation problem. The Mouse Systems mouse is commented out because it doesn't work for some reason.

Video showing the mouse working on this branch:

https://github.com/user-attachments/assets/93370a89-b33d-450b-9edc-ae8ba9cc74c6

P.S. My goal now isn't to achieve perfect Compass emulation — I just want to make GRiD OS 3.1 programs work correctly without obvious artifacts in MAME.