### PR TITLE
namco/namcos2_sprite.cpp: Fix sprite masking

### DIFF
--- a/src/mame/namco/namcos2.cpp
+++ b/src/mame/namco/namcos2.cpp
@@ -1788,6 +1788,7 @@ void namcos2_base_state::configure_c45road_standard(machine_config &config)
 void finallap_state::configure_namcos2_sprite_standard(machine_config &config)
 {
 	NAMCOS2_SPRITE(config, m_ns2sprite, 0, m_c116, gfx_namcos2_spr);
+	m_ns2sprite->set_screen(m_screen);
 	m_ns2sprite->set_spriteram_tag("spriteram");
 	m_ns2sprite->set_priority_callback(FUNC(finallap_state::sprite_pri_callback_ns2));
 	m_ns2sprite->set_mix_callback(FUNC(finallap_state::sprite_mix_callback_ns2));
@@ -1905,6 +1906,7 @@ void finallap_state::finallap(machine_config &config)
 	base_fl(config);
 
 	NAMCOS2_SPRITE_FINALLAP(config.replace(), m_ns2sprite, 0, m_c116, gfx_namcos2_spr);
+	m_ns2sprite->set_screen(m_screen);
 	m_ns2sprite->set_spriteram_tag("spriteram");
 	m_ns2sprite->set_priority_callback(FUNC(finallap_state::sprite_pri_callback_ns2));
 	m_ns2sprite->set_mix_callback(FUNC(finallap_state::sprite_mix_callback_ns2));
@@ -2050,6 +2052,7 @@ void metlhawk_state::metlhawk(machine_config &config)
 	m_screen->set_screen_update(FUNC(metlhawk_state::screen_update_metlhawk));
 
 	NAMCOS2_SPRITE_METALHAWK(config, m_ns2sprite, 0, m_c116, gfx_metlhawk_spr);
+	m_ns2sprite->set_screen(m_screen);
 	m_ns2sprite->set_spriteram_tag("spriteram");
 	m_ns2sprite->set_priority_callback(FUNC(metlhawk_state::sprite_pri_callback_ns2));
 	m_ns2sprite->set_mix_callback(FUNC(metlhawk_state::sprite_mix_callback_ns2));

--- a/src/mame/namco/namcos2_sprite.cpp
+++ b/src/mame/namco/namcos2_sprite.cpp
@@ -39,6 +39,7 @@ namcos2_sprite_device::namcos2_sprite_device(const machine_config &mconfig, cons
 namcos2_sprite_device::namcos2_sprite_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock) :
 	device_t(mconfig, type, tag, owner, clock),
 	device_gfx_interface(mconfig, *this),
+	device_video_interface(mconfig, *this),
 	m_spriteram(*this, finder_base::DUMMY_TAG),
 	m_pri_cb(*this),
 	m_mix_cb(*this)
@@ -60,6 +61,9 @@ void namcos2_sprite_device::device_start()
 {
 	m_pri_cb.resolve_safe(0);
 	m_mix_cb.resolve_safe(false);
+
+	screen().register_screen_bitmap(m_renderbitmap);
+	screen().register_screen_bitmap(m_screenbitmap);
 }
 
 /**************************************************************************************/
@@ -67,10 +71,9 @@ void namcos2_sprite_device::device_start()
 /**************************************************************************************/
 
 void namcos2_sprite_device::zdrawgfxzoom(
-		screen_device &screen,
 		bitmap_ind16 &dest_bmp,const rectangle &clip,gfx_element *gfx,
 		u32 code,u32 color,bool flipx,bool flipy,int sx,int sy,
-		int scalex, int scaley, int primask)
+		int scalex, int scaley, u32 prival)
 {
 	if (!scalex || !scaley) return;
 	if (dest_bmp.bpp() == 16)
@@ -144,27 +147,19 @@ void namcos2_sprite_device::zdrawgfxzoom(
 				// skip if inner loop doesn't draw anything
 				if (ex > sx)
 				{
-					bitmap_ind8 &priority_bitmap = screen.priority();
-					if (priority_bitmap.valid())
+					for (int y = sy; y < ey; y++)
 					{
-						for (int y = sy; y < ey; y++)
+						u8 const *const source = source_base + (y_index >> 16) * gfx->rowbytes();
+						u16 *const dest = &dest_bmp.pix(y);
+						int x_index = x_index_base;
+						for (int x = sx; x < ex; x++)
 						{
-							u8 const *const source = source_base + (y_index >> 16) * gfx->rowbytes();
-							u16 *const dest = &dest_bmp.pix(y);
-							u8 *const pri = &priority_bitmap.pix(y);
-							int x_index = x_index_base;
-							for (int x = sx; x < ex; x++)
-							{
-								const u8 c = source[x_index >> 16];
-								if (pri[x] != 0xff)
-								{
-									if (m_mix_cb(dest[x], pri[x], gfx->colorbase(), c + pal, primask))
-										pri[x] = 0xff;
-								}
-								x_index += dx;
-							}
-							y_index += dy;
+							const u8 c = source[x_index >> 16];
+							if (c != 0xff)
+								dest[x] = ((prival & 0xf) << 12) | ((pal + c) & 0xfff);
+							x_index += dx;
 						}
+						y_index += dy;
 					}
 				}
 			}
@@ -172,13 +167,48 @@ void namcos2_sprite_device::zdrawgfxzoom(
 	}
 } /* zdrawgfxzoom */
 
-void namcos2_sprite_device::zdrawgfxzoom(
-		screen_device &screen,
-		bitmap_rgb32 &dest_bmp,const rectangle &clip,gfx_element *gfx,
-		u32 code,u32 color,bool flipx,bool flipy,int sx,int sy,
-		int scalex, int scaley, int primask)
+void namcos2_sprite_device::copybitmap(screen_device &screen, bitmap_ind16 &dest_bmp, const rectangle &clip)
 {
-	/* nop */
+	for (int y = clip.min_y; y <= clip.max_y; y++)
+	{
+		u16 *const src = &m_renderbitmap.pix(y);
+		u16 *const dest = &dest_bmp.pix(y);
+		u8 *const destpri = &screen.priority().pix(y);
+		for (int x = clip.min_x; x <= clip.max_x; x++)
+		{
+			if (src[x] != 0xffff)
+			{
+				const u8 srcpri = (src[x] >> 12) & 0xf;
+				const u16 c = src[x] & 0xfff;
+				m_mix_cb(dest[x], destpri[x], gfx(0)->colorbase(), c, srcpri);
+			}
+		}
+	}
+}
+
+void namcos2_sprite_device::copybitmap(screen_device &screen, bitmap_rgb32 &dest_bmp, const rectangle &clip)
+{
+	device_palette_interface &palette = gfx(0)->palette();
+	const pen_t *pal = palette.pens();
+	for (int y = clip.min_y; y <= clip.max_y; y++)
+	{
+		u16 *const src = &m_renderbitmap.pix(y);
+		u16 *const srcrender = &m_screenbitmap.pix(y);
+		u32 *const dest = &dest_bmp.pix(y);
+		u8 *const destpri = &screen.priority().pix(y);
+		for (int x = clip.min_x; x <= clip.max_x; x++)
+		{
+			if (src[x] != 0xffff)
+			{
+				const u8 srcpri = (src[x] >> 12) & 0xf;
+				const u16 c = src[x] & 0xfff;
+				if (m_mix_cb(srcrender[x], destpri[x], gfx(0)->colorbase(), c, srcpri))
+					dest[x] = pal[srcrender[x]];
+			}
+			else if (srcrender[x] != 0xffff)
+				dest[x] = pal[gfx(0)->colorbase() + srcrender[x]];
+		}
+	}
 }
 
 void namcos2_sprite_device::get_tilenum_and_size(const u16 word0, const u16 word1, u32 &sprn, bool &is_32)
@@ -197,12 +227,30 @@ void namcos2_sprite_finallap_device::get_tilenum_and_size(const u16 word0, const
 	is_32 = BIT(word1, 13);
 }
 
-void namcos2_sprite_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int control)
+template <class BitmapClass>
+void namcos2_sprite_device::draw_common(screen_device &screen, BitmapClass &bitmap, const rectangle &cliprect, int control)
+{
+	m_renderbitmap.fill(0xffff, cliprect);
+	draw_sprites(cliprect, control);
+	copybitmap(screen, bitmap, cliprect);
+}
+
+void namcos2_sprite_device::draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int control)
+{
+	draw_common(screen, bitmap, cliprect, control);
+}
+
+void namcos2_sprite_device::draw(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int control)
+{
+	draw_common(screen, bitmap, cliprect, control);
+}
+
+void namcos2_sprite_device::draw_sprites(const rectangle &cliprect, int control)
 {
 	gfx_element *const sgfx = gfx(0);
 
 	const int offset = (control & 0x000f) * (128 * 4);
-	for (int loop = 127; loop >= 0; loop--)
+	for (int loop = 0; loop < 128; loop++)
 	{
 		/****************************************
 		* word#0
@@ -243,7 +291,7 @@ void namcos2_sprite_device::draw_sprites(screen_device &screen, bitmap_ind16 &bi
 			const int scaley = (sizey << 16) / (is_32 ? 0x20 : 0x10);
 			if (scalex && scaley)
 			{
-				const u32 primask = m_pri_cb(word3 & 0xf);
+				const u32 prival = m_pri_cb(word3 & 0xf);
 				const u16 offset4 = m_spriteram[offset + (loop * 4) + 2];
 				const u32 color  = (word3 >> 4) & 0x000f;
 				const int ypos   = (0x1ff - (word0 & 0x01ff)) - 0x50 + 0x02;
@@ -257,21 +305,20 @@ void namcos2_sprite_device::draw_sprites(screen_device &screen, bitmap_ind16 &bi
 					sgfx->set_source_clip(0, 32, 0, 32);
 
 				zdrawgfxzoom(
-						screen,
-						bitmap,
+						m_renderbitmap,
 						cliprect,
 						sgfx,
 						sprn, color,
 						flipx, flipy,
 						xpos, ypos,
 						scalex, scaley,
-						primask);
+						prival);
 			}
 		}
 	}
 } /* draw_sprites */
 
-void namcos2_sprite_metalhawk_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int control)
+void namcos2_sprite_metalhawk_device::draw_sprites(const rectangle &cliprect, int control)
 {
 	/**
 	 * word#0
@@ -302,7 +349,7 @@ void namcos2_sprite_metalhawk_device::draw_sprites(screen_device &screen, bitmap
 	 *  --------xxxx---- color
 	 *  x--------------- unknown
 	 */
-	for (int loop = 127; loop >= 0; loop--)
+	for (int loop = 0; loop < 128; loop++)
 	{
 		const u16 ypos  = m_spriteram[(loop * 8) + 0];
 		const u16 xpos  = m_spriteram[(loop * 8) + 3];
@@ -313,7 +360,7 @@ void namcos2_sprite_metalhawk_device::draw_sprites(screen_device &screen, bitmap
 		{
 			const u16 attrs = m_spriteram[(loop * 8) + 7];
 
-			const u32 primask = m_pri_cb((attrs & 0xf));
+			const u32 prival = m_pri_cb((attrs & 0xf));
 			const u16 tile  = m_spriteram[(loop * 8) + 1];
 			const u16 flags = m_spriteram[(loop * 8) + 6];
 			const u32 sprn  =  (tile >> 2) & 0x0fff;
@@ -348,15 +395,14 @@ void namcos2_sprite_metalhawk_device::draw_sprites(screen_device &screen, bitmap
 				sgfx->set_source_clip(BIT(tile, 0) ? 16 : 0, 16, BIT(tile, 1) ? 16 : 0, 16);
 
 			zdrawgfxzoom(
-					screen,
-					bitmap,
+					m_renderbitmap,
 					cliprect,
 					sgfx,
 					sprn, color,
 					flipx, flipy,
 					sx, sy,
 					scalex, scaley,
-					primask);
+					prival);
 		}
 	}
 } /* draw_sprites_metalhawk */

--- a/src/mame/namco/namcos2_sprite.h
+++ b/src/mame/namco/namcos2_sprite.h
@@ -9,11 +9,11 @@
 #include "screen.h"
 #include "emupal.h"
 
-class namcos2_sprite_device : public device_t, public device_gfx_interface
+class namcos2_sprite_device : public device_t, public device_gfx_interface, public device_video_interface
 {
 public:
 	using ns2_priority_delegate = device_delegate<u32 (u32 pri)>;
-	using ns2_mix_delegate = device_delegate<bool (u16 &dest, u8 &destpri, u16 colbase, u16 src, u32 primask)>;
+	using ns2_mix_delegate = device_delegate<bool (u16 &dest, u8 &destpri, u16 colbase, u16 src, u32 prival)>;
 
 	// construction/destruction
 	namcos2_sprite_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
@@ -29,7 +29,12 @@ public:
 	template <typename... T> void set_priority_callback(T &&... args) { m_pri_cb.set(std::forward<T>(args)...); }
 	template <typename... T> void set_mix_callback(T &&... args) { m_mix_cb.set(std::forward<T>(args)...); }
 
-	virtual void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int control);
+	void draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int control);
+	void draw(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int control);
+
+	void clear_screen_bitmap() { m_screenbitmap.fill(0xffff); }
+	void clear_screen_bitmap(const rectangle cliprect) { m_screenbitmap.fill(0xffff, cliprect); }
+	bitmap_ind16 &screen_bitmap() { return m_screenbitmap; }
 
 protected:
 	namcos2_sprite_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
@@ -38,15 +43,24 @@ protected:
 	virtual void device_start() override ATTR_COLD;
 
 	// general
-	void zdrawgfxzoom(screen_device &screen, bitmap_ind16 &dest_bmp, const rectangle &clip, gfx_element *gfx, u32 code, u32 color, bool flipx, bool flipy, int sx, int sy, int scalex, int scaley, int primask);
-	void zdrawgfxzoom(screen_device &screen, bitmap_rgb32 &dest_bmp, const rectangle &clip, gfx_element *gfx, u32 code, u32 color, bool flipx, bool flipy, int sx, int sy, int scalex, int scaley, int primask);
+	virtual void draw_sprites(const rectangle &cliprect, int control);
 
 	virtual void get_tilenum_and_size(const u16 word0, const u16 word1, u32 &sprn, bool &is_32);
+
+	void copybitmap(screen_device &screen, bitmap_ind16 &dest_bmp, const rectangle &clip);
+	void copybitmap(screen_device &screen, bitmap_rgb32 &dest_bmp, const rectangle &clip);
+
+	template <class BitmapClass> void draw_common(screen_device &screen, BitmapClass &bitmap, const rectangle &cliprect, int control);
+
+	void zdrawgfxzoom(bitmap_ind16 &dest_bmp, const rectangle &clip, gfx_element *gfx, u32 code, u32 color, bool flipx, bool flipy, int sx, int sy, int scalex, int scaley, u32 prival);
 
 	required_shared_ptr<u16> m_spriteram;
 
 	ns2_priority_delegate m_pri_cb;
 	ns2_mix_delegate m_mix_cb;
+
+	bitmap_ind16 m_renderbitmap;
+	bitmap_ind16 m_screenbitmap;
 };
 
 class namcos2_sprite_finallap_device : public namcos2_sprite_device
@@ -78,7 +92,8 @@ public:
 		set_palette(std::forward<T>(palette_tag));
 	}
 
-	virtual void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int control) override;
+protected:
+	virtual void draw_sprites(const rectangle &cliprect, int control) override;
 };
 
 

--- a/src/mame/namco/namcos2_v.cpp
+++ b/src/mame/namco/namcos2_v.cpp
@@ -93,6 +93,7 @@ bool metlhawk_state::sprite_mix_callback_ns2(u16 &dest, u8 &destpri, u16 colbase
 			{
 				dest = colbase + src;
 			}
+			destpri = primask;
 			return true;
 		}
 	}
@@ -101,7 +102,7 @@ bool metlhawk_state::sprite_mix_callback_ns2(u16 &dest, u8 &destpri, u16 colbase
 
 bool sgunner_state::sprite_mix_callback_c355(u16 &dest, u8 &destpri, u16 colbase, u16 src, int srcpri, int pri)
 {
-	if (srcpri >= destpri)
+	if (destpri <= srcpri)
 	{
 		if ((src & 0xff) != 0xff)
 		{
@@ -166,7 +167,7 @@ u32 namcos2_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, co
 			}
 		}
 	}
-	m_ns2sprite->draw_sprites(screen, bitmap, clip, m_gfx_ctrl);
+	m_ns2sprite->draw(screen, bitmap, clip, m_gfx_ctrl);
 	return 0;
 }
 
@@ -188,7 +189,7 @@ u32 finallap_state::screen_update_finallap(screen_device &screen, bitmap_ind16 &
 		}
 		m_c45_road->draw(screen, bitmap, clip, pri, pri, 0);
 	}
-	m_ns2sprite->draw_sprites(screen, bitmap, clip, m_gfx_ctrl);
+	m_ns2sprite->draw(screen, bitmap, clip, m_gfx_ctrl);
 	return 0;
 }
 
@@ -275,6 +276,6 @@ u32 metlhawk_state::screen_update_metlhawk(screen_device &screen, bitmap_ind16 &
 		}
 		m_c169roz->draw(screen, bitmap, clip, pri, pri, 0);
 	}
-	m_ns2sprite->draw_sprites(screen, bitmap, clip, 0);
+	m_ns2sprite->draw(screen, bitmap, clip, 0);
 	return 0;
 }


### PR DESCRIPTION
This PR fixes MT #09410.
Also adds bitmap_rgb32 support with additional bitmap.