### PR TITLE
Fix key codes with Ctrl key pressed for GRiD Compass

### DIFF
--- a/src/mame/gridcomp/gridkeyb.cpp
+++ b/src/mame/gridcomp/gridkeyb.cpp
@@ -267,8 +267,8 @@ bool grid_keyboard_device::translate(u8 code, u16 &translated) const
 	if (result == 0xff)
 		return false;
 
-	if (ctrl && result >= 0x20)
-		translated = result - 0x20;
+	if (ctrl)
+		translated = result & 0x9f;
 	else
 		translated = result;
 


### PR DESCRIPTION
After the PR https://github.com/mamedev/mame/pull/15051 was merged, I studied the keyboard firmware and the tables from the documentation again. And I discovered that I had handled the Ctrl key incorrectly. Keyboard don't need to subtract 0x20, keyboard need to clear the bits.