### PR TITLE
Fix black screen when launching with -video soft on macOS

### DIFF
--- a/src/osd/modules/render/drawsdl3soft.cpp
+++ b/src/osd/modules/render/drawsdl3soft.cpp
@@ -144,6 +144,19 @@ void renderer_sdl1::setup_texture(const osd_dim &size)
 
 	fmt = (m_scale_mode.pixel_format ? m_scale_mode.pixel_format : mode->format);
 
+	// The software renderer does not write the alpha channel, leaving it as zero.
+	// On macOS this causes all color channels to be multiplied to zero, producing a black screen.
+	// Map alpha formats to their opaque equivalents so SDL treats the alpha byte as
+	// padding and fills it with 0xFF when blitting to the window surface.
+	switch (SDL_PixelFormat(fmt))
+	{
+		case SDL_PIXELFORMAT_ARGB8888: fmt = SDL_PIXELFORMAT_XRGB8888; break;
+		case SDL_PIXELFORMAT_ABGR8888: fmt = SDL_PIXELFORMAT_XBGR8888; break;
+		case SDL_PIXELFORMAT_RGBA8888: fmt = SDL_PIXELFORMAT_RGBX8888; break;
+		case SDL_PIXELFORMAT_BGRA8888: fmt = SDL_PIXELFORMAT_BGRX8888; break;
+		default: break;
+	}
+
 	if (m_scale_mode.is_scale)
 	{
 		int m_hw_scale_width = 0;


### PR DESCRIPTION
After updating to SDL3, when launching MAME with software rendering on MacOS, a blank black screen is displayed while emulation is still working.

Debugging showed that MAME does not use the alpha channel, and on MacOS this results in a black screen. I don't know if this is a bug, a feature, or if this problem exists on other platforms. As a solution, I mapped A(RGB/BGR) to X(RGB/BGR). This is a non-destructive change that fixes the bug and should not affect rendering on other operating systems.