### PR TITLE
fix(sh7604): fix three register access bugs

### DIFF
--- a/src/devices/cpu/sh/sh7604.cpp
+++ b/src/devices/cpu/sh/sh7604.cpp
@@ -1036,7 +1036,7 @@ void sh7604_device::vcra_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 
 uint16_t sh7604_device::vcrb_r()
 {
-	return m_vcrb;
+	return m_vcrb & 0x7f7f;
 }
 
 void sh7604_device::vcrb_w(offs_t offset, uint16_t data, uint16_t mem_mask)
@@ -1067,7 +1067,7 @@ uint16_t sh7604_device::vcrd_r()
 void sh7604_device::vcrd_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	COMBINE_DATA(&m_vcrd);
-	m_irq_vector.fov = (m_vcrc >> 8) & 0x7f;
+	m_irq_vector.fov = (m_vcrd >> 8) & 0x7f;
 	sh2_recalc_irq();
 }
 
@@ -1629,7 +1629,7 @@ void sh7604_device::dmaor_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 	if (ACCESSING_BITS_0_7)
 	{
 		uint8_t old = m_dmaor & 0xf;
-		m_dmaor = (data & ~6) | (old & m_dmaor & 6); // TODO: should this be old & data & 6? bug?
+		m_dmaor = (data & ~6) | (old & data & 6);
 		sh2_dmac_check(0);
 		sh2_dmac_check(1);
 	}


### PR DESCRIPTION
Three bugs in the SH7604 peripheral register handling, found by cross-referencing against the Hitachi SH7604 Hardware Manual and the Saturn MiSTer FPGA implementation.

### Changes

**1. `vcrd_w`: FOV interrupt vector read from wrong register**

```cpp
// Before:
m_irq_vector.fov = (m_vcrc >> 8) & 0x7f;
// After:
m_irq_vector.fov = (m_vcrd >> 8) & 0x7f;
```

`vcrd_w` is the write handler for VCRD (0xFFFFFE68), which holds the FRT overflow interrupt vector in bits 14–8. The code was reading `m_vcrc` (the FRT input-capture / output-compare vector register) instead of `m_vcrd`. This meant writing VCRD never actually updated the FOV vector — it silently re-latched whatever was in VCRC. Any game or program relying on a custom FRT overflow vector via VCRD would get the wrong handler.

**2. `dmaor_w`: AE and NMIF flags could never be cleared**

```cpp
// Before:
m_dmaor = (data & ~6) | (old & m_dmaor & 6);
// After:
m_dmaor = (data & ~6) | (old & data & 6);
```

DMAOR bits 2 (AE — address error) and 1 (NMIF — NMI flag) are specified as "write 0 to clear" flags (§9.2.7). The original code computed `old & m_dmaor & 6`, but since `old` was assigned from `m_dmaor` on the previous line, this reduced to `m_dmaor & m_dmaor & 6` = `m_dmaor & 6`, unconditionally preserving both flags regardless of the written data. Once set, AE or NMIF could never be cleared, permanently disabling DMA (the DMAC requires both flags to be 0 to operate). The existing TODO comment on this line already suspected this was a bug. The fix uses `old & data & 6`, which is standard W0-clear behavior: writing 0 clears the flag, writing 1 leaves it unchanged.

**3. `vcrb_r`: reserved bits not masked on read**

```cpp
// Before:
return m_vcrb;
// After:
return m_vcrb & 0x7f7f;
```

VCRB (0xFFFFFE64) holds the SCI transmit and transmit-end interrupt vectors in bits 14–8 and 6–0 respectively. Bits 15 and 7 are reserved and should always read 0 per the hardware manual. Every other VCR register (`vcra_r`, `vcrc_r`, `vcrd_r`, `vcrwdt_r`) already applies the appropriate mask — VCRB was the only one missing it.
