### PR TITLE
samsung/spc1000.cpp: Corrected AY-3-8910 clock to 2MHz

### DIFF
--- a/src/mame/samsung/spc1000.cpp
+++ b/src/mame/samsung/spc1000.cpp
@@ -494,7 +494,7 @@ void spc1000_state::spc1000(machine_config &config)
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
-	ay8910_device &ay8910(AY8910(config, "ay8910", XTAL(4'000'000) / 1));
+	ay8910_device &ay8910(AY8910(config, "ay8910", XTAL(4'000'000) / 2));
 	ay8910.port_a_read_callback().set(FUNC(spc1000_state::porta_r));
 	ay8910.port_b_write_callback().set("cent_data_out", FUNC(output_latch_device::write));
 	ay8910.add_route(ALL_OUTPUTS, "mono", 1.00);


### PR DESCRIPTION
Corrected the AY-3-8910 clock frequency in the Samsung SPC-1000 driver. The PSG on this system is clocked at half the CPU frequency (4MHz / 2 = 2MHz), which is necessary for the sound to be played at the correct pitch and speed.