### PR TITLE
esq5505.cpp: UART is an mc68681_device, not an scn2681_device.

### DIFF
--- a/src/mame/ensoniq/esq5505.cpp
+++ b/src/mame/ensoniq/esq5505.cpp
@@ -775,7 +775,7 @@ void esq5505_state::common(machine_config &config)
 
 	auto &mdin(MIDI_PORT(config, "mdin"));
 	midiin_slot(mdin);
-	mdin.rxd_handler().set(m_duart, FUNC(scn2681_device::rx_a_w)); // route MIDI Tx send directly to 68681 channel A Rx
+	mdin.rxd_handler().set(m_duart, FUNC(mc68681_device::rx_a_w)); // route MIDI Tx send directly to 68681 channel A Rx
 
 	midiout_slot(MIDI_PORT(config, "mdout"));
 
@@ -906,7 +906,7 @@ void esq5505_state::common32(machine_config &config)
 
 	auto &mdin(MIDI_PORT(config, "mdin"));
 	midiin_slot(mdin);
-	mdin.rxd_handler().set(m_duart, FUNC(scn2681_device::rx_a_w)); // route MIDI Tx send directly to 68681 channel A Rx
+	mdin.rxd_handler().set(m_duart, FUNC(mc68681_device::rx_a_w)); // route MIDI Tx send directly to 68681 channel A Rx
 
 	midiout_slot(MIDI_PORT(config, "mdout"));
 


### PR DESCRIPTION
In esq5505.cpp, `m_uart` is an `mc68681_device`;  line 263: 

> `required_device<mc68681_device> m_duart;`

But on lines 778 and 909, MIDI input is directed to a callback of `scn2681_device::rx_a_w`:

> `mdin.rxd_handler().set(m_duart, FUNC(scn2681_device::rx_a_w)); // route MIDI Tx send directly to 68681 channel A Rx`

Both are subclasses of `duart_base_device` and inherit the same `rx_a_w` method, so this currently works, but it seems better to use the correct class.

In contrast, on multiple lines, the `m_panel`'s output is directed `m_duart`'s `mc68681_device::rx_b_w`, for example line 813:

> `m_panel->write_tx().set(m_duart, FUNC(mc68681_device::rx_b_w));` 

So this change will also make it consistent across `rx_a_w` and `rx_b_w`.
