### PR TITLE
sinclair/specnext.cpp: separated VRAM memory.

### DIFF
--- a/src/mame/sinclair/chloe.cpp
+++ b/src/mame/sinclair/chloe.cpp
@@ -896,7 +896,8 @@ void chloe_state::video_start()
 	spectrum_128_state::video_start();
 
 	const u8 *ram = m_ram->pointer();
-	m_ula_scr->set_host_ram_ptr(ram);
+	m_ula_scr->set_bram_bank5_ptr(ram + (5 << 14));
+	m_ula_scr->set_bram_bank7_ptr(ram + (7 << 14));
 }
 
 

--- a/src/mame/sinclair/screen_ula.cpp
+++ b/src/mame/sinclair/screen_ula.cpp
@@ -102,11 +102,12 @@ void screen_ula_device::draw(screen_device &screen, bitmap_rgb32 &bitmap, const 
 void screen_ula_device::draw_ula(bitmap_rgb32 &bitmap, const rectangle &clip, bool flash, bitmap_ind8 &priority_bitmap, u8 pcode)
 {
 	const bool hicolor = screen_mode() == 2; // timex hicolor
-	const bool timex_alt = !m_ula_shadow_en && screen_mode() == 1;
 	flash &= !m_ulanext_en && !m_ulap_en;
 	const rgb_t gt0 = rgbexpand<3,3,3>((m_global_transparent << 1) | 0, 6, 3, 0);
 	const rgb_t gt1 = rgbexpand<3,3,3>((m_global_transparent << 1) | 1, 6, 3, 0);
-	const u8 *screen_location = m_host_ram_ptr + ((m_ula_shadow_en ? 7 : 5) << 14) + (timex_alt ? 0x2000 : 0);
+	const u8 *screen_location = m_ula_shadow_en ? m_bram_bank7_ptr : m_bram_bank5_ptr;
+	if (screen_mode() == 1) // Timex alt screen
+		screen_location += 0x2000;
 
 	const u16 x2_min = ((clip.left() - m_offset_h) + (m_ula_scroll_x << 1) + m_ula_fine_scroll_x) % (SCREEN_AREA.width() << 1);
 	for (u16 vpos = clip.top(); vpos <= clip.bottom(); vpos++)
@@ -167,7 +168,7 @@ void screen_ula_device::draw_hires(bitmap_rgb32 &bitmap, const rectangle &clip, 
 {
 	const rgb_t gt0 = rgbexpand<3,3,3>((m_global_transparent << 1) | 0, 6, 3, 0);
 	const rgb_t gt1 = rgbexpand<3,3,3>((m_global_transparent << 1) | 1, 6, 3, 0);
-	const u8 *screen_location = m_host_ram_ptr + ((m_ula_shadow_en ? 7 : 5) << 14);
+	const u8 *screen_location = m_ula_shadow_en ? m_bram_bank7_ptr : m_bram_bank5_ptr;
 
 	const u8 attr = 0x40 | (~m_port_ff_reg & 0x38) | BIT(m_port_ff_reg, 3, 3);
 	const std::pair<rgb_t, rgb_t> pi = parse_attribute(attr);

--- a/src/mame/sinclair/screen_ula.h
+++ b/src/mame/sinclair/screen_ula.h
@@ -9,7 +9,8 @@ class screen_ula_device : public device_t, public device_gfx_interface
 {
 
 public:
-	screen_ula_device &set_host_ram_ptr(const u8 *host_ram_ptr) { m_host_ram_ptr = host_ram_ptr; return *this; }
+	screen_ula_device &set_bram_bank5_ptr(const u8 *bram_bank5_ptr) { m_bram_bank5_ptr = bram_bank5_ptr; return *this; }
+	screen_ula_device &set_bram_bank7_ptr(const u8 *bram_bank7_ptr) { m_bram_bank7_ptr = bram_bank7_ptr; return *this; }
 	screen_ula_device &set_palette(const char *tag, u16 base_offset, u16 alt_offset);
 
 	void set_raster_offset(u16 offset_h,  u16 offset_v) { m_offset_h = offset_h; m_offset_v = offset_v; }
@@ -55,7 +56,8 @@ private:
 	static inline constexpr u16 UTM_FALLBACK_PEN = 0x800;
 
 	u16 m_offset_h, m_offset_v;
-	const u8 *m_host_ram_ptr;
+	const u8 *m_bram_bank5_ptr;
+	const u8 *m_bram_bank7_ptr;
 	u8 m_global_transparent;
 	u16 m_palette_base_offset;
 	u16 m_palette_alt_offset;

--- a/src/mame/sinclair/specnext.cpp
+++ b/src/mame/sinclair/specnext.cpp
@@ -110,6 +110,8 @@ public:
 		, m_io_expbus_view(*this, "io_expbus_view")
 		, m_bank_boot_rom(*this, "bootrom")
 		, m_bank_ram(*this, "bank_ram%u", 0U)
+		, m_bram_bank5(*this, "bram_bank5", 0x4000, ENDIANNESS_LITTLE)
+		, m_bram_bank7(*this, "bram_bank7", 0x2000, ENDIANNESS_LITTLE)
 		, m_view0(*this, "mem_view0")
 		, m_view1(*this, "mem_view1")
 		, m_view2(*this, "mem_view2")
@@ -355,6 +357,8 @@ private:
 	memory_view m_io_expbus_view;
 	memory_bank_creator m_bank_boot_rom;
 	memory_bank_array_creator<8> m_bank_ram;
+	memory_share_creator<u8> m_bram_bank5;
+	memory_share_creator<u8> m_bram_bank7;
 	memory_view m_view0, m_view1, m_view2, m_view3, m_view4, m_view5, m_view6, m_view7;
 	required_device<specnext_im2_device> m_im2_line;
 	optional_device<specnext_im2_device> m_im2_uart0_rx;
@@ -830,28 +834,41 @@ void specnext_state::bank_update(u8 bank)
 		}
 
 		if (false) // unused in current implementation, makes compiler happy
-			printf("%d", sram_active + sram_bank5 + sram_romcs_en + sram_mem_hide_n);
+			printf("%d", sram_romcs_en);
 
-		if (cpu_rd_n)
+		if (cpu_rd_n) // write cycle
 		{
 			m_page_shadow[bank] = sram_rdonly ? -1 : sram_A21_A13;
 		}
-		else
+		else // read cycle
 		{
-			const bool ro = sram_rdonly || (m_page_shadow[bank] != sram_A21_A13);
 			if (sram_A21_A13 < m_ram_pages)
 			{
-				m_bank_ram[bank]->set_entry(sram_A21_A13);
-				views[bank].get().select(ro);
-				LOGMEM("%s%d = %x\n", ro ? "ROM" : "RAM", bank, sram_A21_A13);
+				if (!sram_active && !sram_mem_hide_n && (sram_bank5 || sram_bank7))
+				{
+					views[bank].get().select(sram_A21_A13);
+					LOGMEM("RAM%d = bank%d\n", bank, sram_bank5 ? 5 : 7);
+					m_page_shadow[bank] = -1;
+				}
+				else
+				{
+					const bool ro = sram_rdonly || (m_page_shadow[bank] != sram_A21_A13);
+					m_bank_ram[bank]->set_entry(sram_A21_A13);
+					views[bank].get().select(ro);
+					LOGMEM("%s%d = %x\n", ro ? "ROM" : "RAM", bank, sram_A21_A13);
+
+					if (!ro)
+					{
+						if (m_page_shadow[bank] == sram_A21_A13)
+							m_page_shadow[bank] = -1;
+					}
+				}
+
 			}
 			else
-				views[bank].get().disable();
-
-			if (!ro)
 			{
-				if (m_page_shadow[bank] == sram_A21_A13)
-					m_page_shadow[bank] = -1;
+				views[bank].get().disable();
+				m_page_shadow[bank] = -1;
 			}
 		}
 	}
@@ -2959,6 +2976,21 @@ void specnext_state::map_mem(address_map &map)
 		map(0x0000 + i * 0x2000, 0x1fff + i * 0x2000).view(views[i].get());
 		views[i].get()[0](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).bankrw(m_bank_ram[i]);
 		views[i].get()[1](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).bankr(m_bank_ram[i]);
+
+		// bank5
+		views[i].get()[0x2a](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).lrw8(
+			NAME([this](offs_t offset) { return m_bram_bank5[offset & 0x1fff]; }),
+			NAME([this](offs_t offset, u8 data) { m_bram_bank5[offset & 0x1fff] = data; })
+		);
+		views[i].get()[0x2b](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).lrw8(
+			NAME([this](offs_t offset) { return m_bram_bank5[0x2000 + (offset & 0x1fff)]; }),
+			NAME([this](offs_t offset, u8 data) { m_bram_bank5[0x2000 + (offset & 0x1fff)] = data; })
+		);
+		// bank7
+		views[i].get()[0x2e](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).lrw8(
+			NAME([this](offs_t offset) { return m_bram_bank7[offset & 0x1fff]; }),
+			NAME([this](offs_t offset, u8 data) { m_bram_bank7[offset & 0x1fff] = data; })
+		);
 	}
 	views[0].get()[2](0x0000, 0x1fff).bankr(m_bank_boot_rom);
 	views[1].get()[2](0x2000, 0x3fff).bankr(m_bank_boot_rom);
@@ -3292,10 +3324,12 @@ void specnext_state::machine_start()
 	m_bank_boot_rom->configure_entry(0, memregion("maincpu")->base());
 
 	const u8 *ram = m_ram->pointer() + 0x40000;
-	m_ula_scr->set_host_ram_ptr(ram);
-	m_tiles->set_host_ram_ptr(ram);
+	m_ula_scr->set_bram_bank5_ptr(m_bram_bank5.target());
+	m_ula_scr->set_bram_bank7_ptr(m_bram_bank7.target());
+	m_tiles->set_bram_bank5_ptr(m_bram_bank5.target());
+	m_tiles->set_bram_bank7_ptr(m_bram_bank7.target());
 	m_layer2->set_host_ram_ptr(ram);
-	m_lores->set_host_ram_ptr(ram);
+	m_lores->set_bram_bank5_ptr(m_bram_bank5.target());
 
 	m_nr_02_hard_reset = 1;
 
@@ -3940,7 +3974,7 @@ void specnext_state::video_start()
 	prg.install_write_tap(0x0000, 0xbfff, "shadow_w", [this](offs_t offset, u8 &data, u8 mem_mask)
 	{
 		u8 bank8 = offset >> 13;
-		if (m_page_shadow[bank8] >= 0 && m_ram_pages > m_page_shadow[bank8])
+		if (m_page_shadow[bank8] >= 0)
 		{
 			u8 *to = m_ram->pointer() + (m_page_shadow[bank8] << 13);
 			to[offset & 0x1fff] = data;

--- a/src/mame/sinclair/specnext_lores.cpp
+++ b/src/mame/sinclair/specnext_lores.cpp
@@ -49,7 +49,7 @@ void specnext_lores_device::draw(screen_device &screen, bitmap_rgb32 &bitmap, co
 	u16 pen_base = (m_lores_palette_select ? m_palette_alt_offset : m_palette_base_offset);
 	if (m_mode) pen_base |= (((m_ulap_en ? 0b1100 : 0) | m_lores_palette_offset) << 4);
 
-	const u8 *screen_location = m_host_ram_ptr + (5 << 14);
+	const u8 *screen_location = m_bram_bank5_ptr;
 
 	const u16 x4_min = (clip.left() - m_offset_h + (m_scroll_x << 1) + (SCREEN_AREA.width() << 1)) % (SCREEN_AREA.width() << 1);
 	for (u16 vpos = clip.top(); vpos <= clip.bottom(); ++vpos)

--- a/src/mame/sinclair/specnext_lores.h
+++ b/src/mame/sinclair/specnext_lores.h
@@ -11,7 +11,7 @@ class specnext_lores_device : public device_t, public device_gfx_interface
 public:
 	specnext_lores_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	specnext_lores_device &set_host_ram_ptr(const u8 *host_ram_ptr) { m_host_ram_ptr = host_ram_ptr; return *this; }
+	specnext_lores_device &set_bram_bank5_ptr(const u8 *bram_bank5_ptr) { m_bram_bank5_ptr = bram_bank5_ptr; return *this; }
 	specnext_lores_device &set_palette(const char *tag, u16 base_offset, u16 alt_offset);
 
 	void set_raster_offset(u16 offset_h,  u16 offset_v) { m_offset_h = offset_h; m_offset_v = offset_v; }
@@ -40,7 +40,7 @@ protected:
 
 private:
 	u16 m_offset_h, m_offset_v;
-	const u8 *m_host_ram_ptr;
+	const u8 *m_bram_bank5_ptr;
 	u8 m_global_transparent;
 	u16 m_palette_base_offset;
 	u16 m_palette_alt_offset;

--- a/src/mame/sinclair/specnext_tiles.cpp
+++ b/src/mame/sinclair/specnext_tiles.cpp
@@ -102,7 +102,9 @@ void specnext_tiles_device::tilemap_update()
 {
 	if (gfx(0) == nullptr) return;
 
-	const u8 *tiles_offset = m_host_ram_ptr + ((BIT(m_tm_tile_base, 6) ? 7 : 5) << 14) + ((m_tm_tile_base & 0x3f) << 8);
+	const u8 *tiles_offset = BIT(m_tm_tile_base, 6)
+		? m_bram_bank7_ptr + ((m_tm_tile_base & 0x1f) << 8)
+		: m_bram_bank5_ptr + ((m_tm_tile_base & 0x3f) << 8);
 	for (auto i = 0; i < 6; ++i)
 	{
 		gfx(i)->set_source(tiles_offset);
@@ -133,11 +135,9 @@ void specnext_tiles_device::tilemap_update()
 		}
 	}
 
-	m_tiles_info = m_host_ram_ptr;
-	if (BIT(m_tm_map_base, 6))
-		m_tiles_info += (7 << 14) + ((m_tm_map_base & 0x1f) << 8);
-	else
-		m_tiles_info += (5 << 14) + ((m_tm_map_base & 0x3f) << 8);
+	m_tiles_info = BIT(m_tm_map_base, 6)
+		? m_bram_bank7_ptr + ((m_tm_map_base & 0x1f) << 8)
+		: m_bram_bank5_ptr + ((m_tm_map_base & 0x3f) << 8);
 }
 
 void specnext_tiles_device::draw(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, u32 flags, u8 pcode, u8 priority_mask)

--- a/src/mame/sinclair/specnext_tiles.h
+++ b/src/mame/sinclair/specnext_tiles.h
@@ -13,7 +13,8 @@ class specnext_tiles_device : public device_t, public device_gfx_interface
 public:
 	specnext_tiles_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	specnext_tiles_device &set_host_ram_ptr(const u8 *host_ram_ptr) { m_host_ram_ptr = host_ram_ptr; tilemap_update(); return *this; }
+	specnext_tiles_device &set_bram_bank5_ptr(const u8 *bram_bank5_ptr) { m_bram_bank5_ptr = bram_bank5_ptr; tilemap_update(); return *this; }
+	specnext_tiles_device &set_bram_bank7_ptr(const u8 *bram_bank7_ptr) { m_bram_bank7_ptr = bram_bank7_ptr; tilemap_update(); return *this; }
 	specnext_tiles_device &set_palette(const char *tag, u16 base_offset, u16 alt_offset);
 	void tilemap_update();
 
@@ -46,7 +47,8 @@ protected:
 
 	TILE_GET_INFO_MEMBER(get_tile_info);
 
-	const u8 *m_host_ram_ptr;
+	const u8 *m_bram_bank5_ptr;
+	const u8 *m_bram_bank7_ptr;
 	const u8 *m_tiles_info;
 	tilemap_t *m_tilemap[2];
 


### PR DESCRIPTION
The Next moved typical VRAM pages (bank5&7) from SRAM to internal FPGA BRAM. bank7 has only 0x2000 and it's mirrored to the second half - this is also covered in this implementation