### PR TITLE
moog/source.cpp: Incorporated the new OTA-based EG implementation.

### DIFF
--- a/src/devices/sound/va_eg.cpp
+++ b/src/devices/sound/va_eg.cpp
@@ -173,10 +173,11 @@ va_ota_eg_device::va_ota_eg_device(const machine_config &mconfig, const char *ta
 	, device_sound_interface(mconfig, *this)
 	, m_c(c)
 	, m_max_iout_scale(1)
+	, m_plus_scale(1)
+	, m_minus_scale(1)
 	, m_stream(nullptr)
 	, m_converged(true)
 	, m_g(0)
-	, m_max_step(0)
 	, m_target_v(0)
 	, m_iabc(1E-3F)
 	, m_v(0)
@@ -200,6 +201,18 @@ va_ota_eg_device::va_ota_eg_device(const machine_config &mconfig, const char *ta
 va_ota_eg_device::va_ota_eg_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: va_ota_eg_device(mconfig, tag, owner, ota_type::CA3280, CAP_U(1))
 {
+}
+
+va_ota_eg_device &va_ota_eg_device::configure_plus_divider(float r_in, float r_gnd)
+{
+	m_plus_scale = RES_VOLTAGE_DIVIDER(r_in, r_gnd);
+	return *this;
+}
+
+va_ota_eg_device &va_ota_eg_device::configure_minus_divider(float r_in, float r_gnd)
+{
+	m_minus_scale = RES_VOLTAGE_DIVIDER(r_in, r_gnd);
+	return *this;
 }
 
 void va_ota_eg_device::set_target_v(float v)
@@ -227,7 +240,6 @@ void va_ota_eg_device::device_start()
 	m_stream = stream_alloc(0, 1, SAMPLE_RATE_OUTPUT_ADAPTIVE);
 	save_item(NAME(m_converged));
 	save_item(NAME(m_g));
-	save_item(NAME(m_max_step));
 	save_item(NAME(m_target_v));
 	save_item(NAME(m_iabc));
 	save_item(NAME(m_v));
@@ -242,7 +254,6 @@ void va_ota_eg_device::recalc()
 {
 	const float h = 1.0F / float(m_stream->sample_rate());
 	m_g = (h / 2.0F) * m_iabc * m_max_iout_scale / m_c;
-	m_max_step = 2.0F * m_g;
 }
 
 void va_ota_eg_device::sound_stream_update(sound_stream &stream)
@@ -300,11 +311,19 @@ void va_ota_eg_device::sound_stream_update(sound_stream &stream)
 	constexpr float INV_2VT = 1.0F / (2.0F * VT);
 	constexpr float V_OTA_SAT = 10 * VT;
 
+	// If the two inputs are scaled by different amounts, the EG will converge
+	// off target.
+	const float conv_v = m_target_v * m_plus_scale / m_minus_scale;
 	if (m_converged)
 	{
-		stream.fill(0, m_target_v);
+		stream.fill(0, conv_v);
 		return;
 	}
+
+	// Cache some computations for the loop.
+	const float scaled_target_v = m_plus_scale * m_target_v;
+	const float g2 = m_g * 2.0F;
+	const float gvt = m_g * INV_2VT;
 
 	float v_step = 0;
 	const float last_v = m_v;
@@ -312,36 +331,30 @@ void va_ota_eg_device::sound_stream_update(sound_stream &stream)
 
 	for (int i = 0; i < n; ++i)
 	{
-		const float dv = m_target_v - m_v;
+		const float dv = scaled_target_v - m_minus_scale * m_v;
 		if (dv > V_OTA_SAT)
 		{
-			v_step = m_max_step;
+			v_step = g2;
 		}
 		else if (dv < -V_OTA_SAT)
 		{
-			v_step = -m_max_step;
+			v_step = -g2;
 		}
 		else
 		{
 			const float tanhv = tanhf(INV_2VT * dv);
 			const float dtanhv = 1.0F - tanhv * tanhv;  // tanh'(v) = sech(v) ^ 2 = 1 - tanh(v) ^ 2
-			v_step = (2.0F * m_g * tanhv) / (1.0F + m_g * INV_2VT * dtanhv);
+			v_step = (g2 * tanhv) / (1.0F + gvt * dtanhv);
 		}
 		m_v += v_step;
 		stream.put(0, i, m_v);
 	}
 
-	if (fabsf(m_v - last_v) < 1E-15 || fabsf(m_target_v - m_v) < 1E-6)
-	{
+	if (fabsf(m_v - last_v) < 1E-15 || fabsf(conv_v - m_v) < 1E-6)
 		m_converged = true;
-		LOGMASKED(LOG_CONVERGENCE, "%s: converged: %e %e %e - %e %e\n",
-				  tag(), m_target_v, m_target_v - m_v, m_v - last_v, v_step, m_max_step);
-	}
-	else
-	{
-		LOGMASKED(LOG_CONVERGENCE, "%s: NOT converged: %e %e %e - %e %e\n",
-				  tag(), m_target_v, m_target_v - m_v, m_v - last_v, v_step, m_max_step);
-	}
+
+	LOGMASKED(LOG_CONVERGENCE, "%s: converged %d, target: %e %e, deltas %e %e, step: %e %e, current: %e %d\n",
+			  tag(), m_converged, m_target_v, conv_v, conv_v - m_v, m_v - last_v, v_step, g2, m_v, n);
 }
 
 

--- a/src/devices/sound/va_eg.h
+++ b/src/devices/sound/va_eg.h
@@ -80,7 +80,7 @@ private:
 };
 
 // An envelope generator (EG) built around an operational transconductance
-// amplifier (OTA).
+// amplifier (OTA). Its rate is controlled by Iabc.
 //
 // When the EG output is far from the target (e.g. > ~0.2V), the EG will ramp
 // towards the target linearly. As the output approaches the target, the EG ramp
@@ -107,7 +107,9 @@ private:
 // to the negative supply, for OTAs that have it.
 //
 // A variant of the above uses anti-parallel diodes to connect the inputs (e.g.
-// prophet 5 glide EG). That variant behaves pretty much identically.
+// prophet 5 glide EG). This configuration protects the OTA from large voltage
+// differences, but otherwise behaves the same to the above. The values of R
+// don't matter.
 //
 //                                x      Iabc
 //                             ___|__     |
@@ -123,7 +125,25 @@ private:
 //                   |                                          |
 //                   +-------------------- R -------------------+
 //
-// TODO: Implement and document the scaled input variant (e.g. moog source EGs).
+// Another common variant uses voltage dividers at the two inputs. These ensure
+// the voltage difference at the inputs is small, keeping the OTA in its linear
+// region, and producing "RC" curves. In this configuration, the output will
+// converge to: TargetV * scale+ / scale-, where scale = Rgnd / (Rin + Rgnd).
+// For small enough scaling factors, R ~= (2 * VT) / (s * Iabc * scale-).
+//
+//                                x      Iabc
+//                             ___|__     |
+//                            |   |  \    |
+// Target V - Rin+- -+------- |+  Id  \   |
+//                   |        |        \  |
+//                 Rgnd+      |         \ |
+//                   |        |   OTA    OO ---+---- BUFFER --- EG output V
+//                  GND       |         /      |                |
+//                            |        /       C                |
+//                   +------- |-      /        |                |
+//                   |        |______/        GND               |
+//                   |                                          |
+// GND --- RGnd- --- +-------------------- Rin- ----------------+
 //
 class va_ota_eg_device : public device_t, public device_sound_interface
 {
@@ -139,6 +159,10 @@ public:
 	va_ota_eg_device(const machine_config &mconfig, const char *tag, device_t *owner, ota_type ota, float c) ATTR_COLD;
 	va_ota_eg_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) ATTR_COLD;
 
+	// These configure the "scaled input" variant.
+	va_ota_eg_device &configure_plus_divider(float r_in, float r_gnd);
+	va_ota_eg_device &configure_minus_divider(float r_in, float r_gnd);
+
 	void set_target_v(float v);
 	void set_iabc(float iabc);  // Iabc control current in Amperes.
 
@@ -153,12 +177,13 @@ private:
 	// configuration
 	const float m_c;
 	float m_max_iout_scale;
+	float m_plus_scale;
+	float m_minus_scale;
 	sound_stream *m_stream;
 
 	// state
 	bool m_converged;
 	float m_g;  // Caches the product of multiple factors. See recalc().
-	float m_max_step;
 	float m_target_v;
 	float m_iabc;
 	float m_v;

--- a/src/devices/sound/va_ops.cpp
+++ b/src/devices/sound/va_ops.cpp
@@ -3,6 +3,8 @@
 
 #include "emu.h"
 #include "va_ops.h"
+#include "machine/rescap.h"
+
 
 va_const_device::va_const_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: device_t(mconfig, VA_CONST, tag, owner, clock)
@@ -72,5 +74,60 @@ void va_scale_offset_device::sound_stream_update(sound_stream &stream)
 }
 
 
+va_comparator_device::va_comparator_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, VA_COMPARATOR, tag, owner, clock)
+	, device_sound_interface(mconfig, *this)
+	, m_thresh_pos(0.5F)
+	, m_thresh_neg(0.5F)
+	, m_inverted(false)
+	, m_stream(nullptr)
+	, m_state(false)
+{
+}
+
+va_comparator_device &va_comparator_device::configure(float thresh_pos, float thresh_neg, bool inverted)
+{
+	if (thresh_neg > thresh_pos)
+		fatalerror("%s: negative-going threshold needs to be <= positive-going threshold\n", tag());
+	m_thresh_pos = thresh_pos;
+	m_thresh_neg = thresh_neg;
+	m_inverted = inverted;
+	return *this;
+}
+
+va_comparator_device &va_comparator_device::configure(const comp_oc_hyst_config &c)
+{
+	return configure(
+		(c.v_thresh - c.v_pullup) * RES_VOLTAGE_DIVIDER(c.r_thresh, c.r_feedback + c.r_pullup) + c.v_pullup,
+		(c.v_thresh - c.v_minus) * RES_VOLTAGE_DIVIDER(c.r_thresh, c.r_feedback) + c.v_minus, true);
+}
+
+int va_comparator_device::state()
+{
+	m_stream->update();
+	if (m_inverted)
+		return m_state ? 0 : 1;
+	else
+		return m_state ? 1 : 0;
+}
+
+void va_comparator_device::device_start()
+{
+	m_stream = stream_alloc(1, 0, SAMPLE_RATE_INPUT_ADAPTIVE);
+	save_item(NAME(m_state));
+}
+
+void va_comparator_device::sound_stream_update(sound_stream &stream)
+{
+	const int n = stream.samples();
+	for (int i = 0; i < n; ++i)
+	{
+		const float threshold = m_state ? m_thresh_neg : m_thresh_pos;
+		m_state = stream.get(0, i) >= threshold;
+	}
+}
+
+
 DEFINE_DEVICE_TYPE(VA_CONST, va_const_device, "va_const", "Constant value stream")
-DEFINE_DEVICE_TYPE(VA_SCALE_OFFSET, va_scale_offset_device, "va_scale_offset", "Scale and offset")
+DEFINE_DEVICE_TYPE(VA_SCALE_OFFSET, va_scale_offset_device, "va_scale_offset", "Stream scale and offset")
+DEFINE_DEVICE_TYPE(VA_COMPARATOR, va_comparator_device, "va_comparator", "Stream comparator")

--- a/src/devices/sound/va_ops.h
+++ b/src/devices/sound/va_ops.h
@@ -13,6 +13,7 @@
 
 DECLARE_DEVICE_TYPE(VA_CONST, va_const_device)
 DECLARE_DEVICE_TYPE(VA_SCALE_OFFSET, va_scale_offset_device)
+DECLARE_DEVICE_TYPE(VA_COMPARATOR, va_comparator_device)
 
 
 // Outputs a constant value to a stream. This is meant for things like
@@ -53,6 +54,64 @@ private:
 	sound_stream *m_stream;
 	float m_scale;
 	float m_offset;
+};
+
+
+// Emulates various comparator devices and circuits.
+//
+// The positive- and negative-going thresholds and output type can either be
+// configured directly, or by using one of the helpers for specific circuits.
+//
+// Configuration helpers:
+//
+// * comp_oc_hyst_config: Configuration for an open-collector / open-drain
+//   comparator (LM393 or similar), with hysteresis via positive feedback. Acts
+//   like a Schmitt trigger inverter with configurable thresholds and output levels.
+//
+//                                     ______         Vpullup
+//                                    |      \           |
+//                   Input ---------- |-      \       Rpullup
+//                                    |        \         |
+//                                    |  COMP   > -------+------ Output
+//                                    |        /         |
+//                           +------- |+      /          |
+//                           |        |______/           |
+//                           |                           |
+//    Vthresh --- Rthresh ---+--------- Rfeedback--------+
+//
+class va_comparator_device : public device_t, public device_sound_interface
+{
+public:
+	struct comp_oc_hyst_config
+	{
+		const float v_minus;   // Negative supply voltage (often 0V).
+		const float v_pullup;
+		const float r_pullup;
+		const float v_thresh;
+		const float r_thresh;
+		const float r_feedback;
+	};
+
+	va_comparator_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0) ATTR_COLD;
+
+	va_comparator_device &configure(float thresh_pos, float thresh_neg, bool inverted) ATTR_COLD;
+	va_comparator_device &configure(const comp_oc_hyst_config &c) ATTR_COLD;
+
+	int state();
+
+protected:
+	void device_start() override ATTR_COLD;
+	void sound_stream_update(sound_stream &stream) override;
+
+private:
+	// configuration
+	float m_thresh_pos;
+	float m_thresh_neg;
+	bool m_inverted;
+	sound_stream *m_stream;
+
+	// state
+	bool m_state;
 };
 
 

--- a/src/mame/moog/source.cpp
+++ b/src/mame/moog/source.cpp
@@ -43,6 +43,7 @@ interactive layout, and is intended as an educational tool.
 #include "machine/rescap.h"
 #include "machine/timer.h"
 #include "sound/va_eg.h"
+#include "sound/va_ops.h"
 
 #include "moog_source.lh"
 
@@ -74,6 +75,7 @@ public:
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, MAINCPU_TAG)
 		, m_contour(*this, "contour_%d", 0)
+		, m_contour_comp(*this, "contour_comp_%d", 0)
 		, m_contour_rate(*this, "source_nl:cntr_rate_%d", 0)
 		, m_contour_range(*this, "contour_range_%d",0)
 		, m_lfo_timer(*this, "lfo_timer")
@@ -120,7 +122,6 @@ private:
 	void cassette_w(u8 data);
 	void cv_w(offs_t offset, u8 data);
 
-	bool contour_peaked(const va_rc_eg_device &eg) const;
 	float get_keyboard_v() const;
 	u8 keyboard_r();
 	u8 buttons_r(const required_ioport_array<6> &button_io, const char *name) const;
@@ -140,7 +141,8 @@ private:
 
 	required_device<z80_device> m_maincpu;
 
-	required_device_array<va_rc_eg_device, 2> m_contour;
+	required_device_array<va_ota_eg_device, 2> m_contour;
+	required_device_array<va_comparator_device, 2> m_contour_comp;
 	required_device_array<netlist_mame_analog_input_device, 2> m_contour_rate;
 	required_ioport_array<2> m_contour_range;
 
@@ -225,7 +227,6 @@ private:
 	static inline constexpr float VMINUS = -15;  // In Volts.
 	static inline constexpr float MAX_CV = 10;  // In Volts.
 	static inline constexpr float CA3080_VABC = VMINUS + 0.7;  // 1 diode drop above -15.
-	static inline constexpr float CONTOUR_C = CAP_U(0.047);  // C57 (filter), C56 (loudness).
 	static inline constexpr u8 PATTERNS_7447[16] =
 	{
 		0x3f, 0x06, 0x5b, 0x4f, 0x66, 0x6d, 0x7c, 0x07,
@@ -435,50 +436,6 @@ void source_state::cv_w(offs_t offset, u8 data)
 		LOGMASKED(LOG_CV, "CV %d: 0x%02x, %f\n", offset, data, cv);
 }
 
-bool source_state::contour_peaked(const va_rc_eg_device &eg) const
-{
-	// The peak detector circuits for the filter and loudness contour generators
-	// are identical. They are located on board 2, and based on an LM393 comparator
-	// (U41B and U41A respectively). The threshold is set to ~9.984V, with a
-	// +-0.005V hysteresis. The EG output is connected to the inverting input.
-	// The comparator output is 0V when the EG output is above the threshold, and
-	// 5V otherwise (open collector output pulled to 5V via 10K resistors, R193
-	// and R190 respectively).
-
-	constexpr float R192 = RES_M(4.7);  // R188 for loudness EG.
-	constexpr float R191 = RES_K(10);   // R189 for loudness EG.
-	constexpr float RISING_THRESHOLD = 5 * RES_VOLTAGE_DIVIDER(R191, R192) + 5;
-	constexpr float FALLING_THRESHOLD = 10 * RES_VOLTAGE_DIVIDER(R191, R192);
-	static_assert(RISING_THRESHOLD > FALLING_THRESHOLD);
-
-	const float eg_v = eg.get_v();
-	if (eg_v > RISING_THRESHOLD)
-	{
-		return true;
-	}
-	else if (eg_v < FALLING_THRESHOLD)
-	{
-		return false;
-	}
-	else  // eg_v is within the hysteresis range.
-	{
-		// Proper emulation of hysteresis would require a streaming (or otherwise
-		// stateful) comparator. But a heuristic tailored to this use case works
-		// fine: if the EG voltage is falling, assume we hit the 'rising' threshold
-		// in the past, so the 'falling' threshold is the active one.
-
-		// This heuristic will pick the wrong threshold if a key is released while
-		// the EG is within the hysteresis range. But that should be rare (the
-		// hysteresis range is ~0.01V), and inconsequential. The difference in
-		// thresholds is very small, and the firmware is the one that initiates
-		// the EG release and is probably ignoring this input until the next
-		// attack.
-
-		const float future_eg_v = eg.get_v(machine().time() + attotime::from_msec(1));
-		return future_eg_v < eg_v;
-	}
-}
-
 float source_state::get_keyboard_v() const
 {
 	// *** Detect which key is pressed.
@@ -550,11 +507,11 @@ u8 source_state::keyboard_r()
 
 	// D1 - Filter contour peak reached (active low).
 	// D1 <- U32, FILT CNTR <- S22-11 <- Comparator (U41B, LM393).
-	const u8 d1 = contour_peaked(*m_contour[FILTER_CONTOUR]) ? 0 : 1;
+	const u8 d1 = m_contour_comp[FILTER_CONTOUR]->state() ? 1 : 0;
 
 	// D2 - Loudness contour peak reached (active low).
 	// D2 <- U32, LOUD CNTR <- S22-10 <- Comparator (U41A, LM393).
-	const u8 d2 = contour_peaked(*m_contour[LOUDNESS_CONTOUR]) ? 0 : 1;
+	const u8 d2 = m_contour_comp[LOUDNESS_CONTOUR]->state() ? 1 : 0;
 
 	// D3: Octave. <- U32, OCT (P34-2 (octave 0 button) and P34-1 (octave +1
 	//                button) via U2B and U2C).
@@ -668,17 +625,6 @@ template<int Which> TIMER_CALLBACK_MEMBER(source_state::update_contour)
 	constexpr int LEVEL_CV_INDEX =
 		(Which == FILTER_CONTOUR) ? int(CV::FILTER_CONTOUR_LEVEL) : int(CV::LOUDNESS_CONTOUR_LEVEL);
 
-	// All componets are on board 2. All resistors have 1% tolerance.
-	//                           Filter contour          Loudness contour
-	constexpr float R196 = RES_K(18.2);  // R183
-	constexpr float R197 = RES_R(100);   // R184
-	constexpr float R195 = RES_K(20);    // R187
-	constexpr float R194 = RES_R(100);   // R182
-
-	// Voltage dividers at the OTA's + and - inputs.
-	constexpr float OTA_DIVIDER_PLUS = RES_VOLTAGE_DIVIDER(R196, R197);
-	constexpr float OTA_DIVIDER_MINUS = RES_VOLTAGE_DIVIDER(R195, R194);
-
 	if (m_contour_cc[Which] <= 0)
 	{
 		// The netlist solver might transiently send negative values.
@@ -686,20 +632,11 @@ template<int Which> TIMER_CALLBACK_MEMBER(source_state::update_contour)
 		return;
 	}
 
-	// Ideal OTA transconductance at room temparature.
-	const float g = 19.2F * m_contour_cc[Which];
-	// Note the sligh difference in the calculations below, compared to the video
-	// linked above, due to the resistive dividers at the two OTA inputs not
-	// being identical.
-	const float effective_r = 1.0F / (g * OTA_DIVIDER_MINUS);
-	m_contour[Which]->set_r(effective_r);
+	m_contour[Which]->set_iabc(m_contour_cc[Which]);
+	m_contour[Which]->set_target_v(m_cv[LEVEL_CV_INDEX]);
 
-	const float level_cv = m_cv[LEVEL_CV_INDEX];  // 0V - 10V.
-	const float target_v = level_cv * OTA_DIVIDER_PLUS / OTA_DIVIDER_MINUS;  // 0V - ~10.98V.
-	m_contour[Which]->set_target_v(target_v);
-
-	LOGMASKED(LOG_CONTOUR, "%s EG update - Level CV: %f, target_v: %f, R: %f, tau: %f\n",
-			  CONTOUR_NAME, level_cv, target_v, effective_r, effective_r * CONTOUR_C);
+	LOGMASKED(LOG_CONTOUR, "%s EG update - Level CV: %f, Rate CC: %f\n",
+			  CONTOUR_NAME, m_cv[LEVEL_CV_INDEX], m_contour_cc[Which]);
 }
 
 NETDEV_ANALOG_CALLBACK_MEMBER(source_state::lfo_cv_changed)
@@ -864,11 +801,34 @@ void source_state::source(machine_config &config)
 
 	NVRAM(config, NVRAM_TAG, nvram_device::DEFAULT_ALL_0);  // 2x6514: U27, U28.
 
-	VA_RC_EG(config, m_contour[FILTER_CONTOUR]).set_c(CONTOUR_C);  // C57 (Board 2).
-	VA_RC_EG(config, m_contour[LOUDNESS_CONTOUR]).set_c(CONTOUR_C);  // C56 (Board 2).
+	config.set_default_layout(layout_moog_source);
+
+
 	TIMER(config, m_lfo_timer).configure_generic(FUNC(source_state::lfo_timer_tick));
 
-	config.set_default_layout(layout_moog_source);
+	constexpr va_comparator_device::comp_oc_hyst_config comp_config =
+	{
+		.v_minus    = 0,
+		.v_pullup   = 5,
+		.r_pullup   = RES_K(10),   // filter: R193, loudness: R190
+		.v_thresh   = 10,
+		.r_thresh   = RES_K(10),   // filter: R191, loudness: R189
+		.r_feedback = RES_M(4.7),  // filter: R192, loudness, R188
+	};
+
+	for (int i = 0; i < m_contour.size(); ++i)  // All components on board 2.
+	{
+		// Filter: U44, C57, loudness: U42, C56.
+		VA_OTA_EG(config, m_contour[i], va_ota_eg_device::ota_type::CA3080, CAP_U(0.047))
+			// Filter: R196, R197, loudness: R183, R184, all 1%
+			.configure_plus_divider(RES_K(18.2), RES_R(100))
+			// Filter: R195, R194, loudness: R187, R182, all 1%
+			.configure_minus_divider(RES_K(20), RES_R(100))
+			.add_route(0, m_contour_comp[i], 1.0);
+
+		// Threshold is ~9.984V, with a +-0.005V hysteresis.
+		VA_COMPARATOR(config, m_contour_comp[i]).configure(comp_config);
+	}
 
 
 	NETLIST_CPU(config, "source_nl", netlist::config::DEFAULT_CLOCK()).set_source(NETLIST_NAME(moogsource));
@@ -1063,7 +1023,7 @@ INPUT_PORTS_START(source)
 	PORT_BIT(0x040, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_FS3
 	PORT_BIT(0x080, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_G3
 	PORT_BIT(0x100, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_GS3
-	PORT_BIT(0x200, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_A3
+	PORT_BIT(0x200, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_A3 PORT_CODE(KEYCODE_Z)
 	PORT_BIT(0x400, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_AS3
 	PORT_BIT(0x800, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_B3
 


### PR DESCRIPTION
`sound/va_eg.cpp`: Implemented the scaled input variant of the OTA-based EG.
`sound/va_ops.cpp`: Implemented a stream comparator.
`moog/source.cpp`: Used the above to replace the local, approximate implementation of the EG.