### PR TITLE
atari/atarig42.cpp, atari/atarigx2.cpp: Minor optimization

### DIFF
--- a/src/mame/atari/atarig42.h
+++ b/src/mame/atari/atarig42.h
@@ -21,7 +21,7 @@
 
 class atarig42_state : public atarigen_state
 {
-public:
+protected:
 	atarig42_state(const machine_config &mconfig, device_type type, const char *tag) :
 		atarigen_state(mconfig, type, tag),
 		m_jsa(*this, "jsa"),
@@ -33,9 +33,9 @@ public:
 		m_mo_command(*this, "mo_command")
 	{ }
 
-protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void video_start() override ATTR_COLD;
+
 	void video_int_ack_w(uint16_t data = 0);
 	TIMER_DEVICE_CALLBACK_MEMBER(scanline_update);
 	void a2d_select_w(offs_t offset, uint8_t data);
@@ -46,7 +46,8 @@ protected:
 	TILE_GET_INFO_MEMBER(get_playfield_tile_info);
 	TILEMAP_MAPPER_MEMBER(atarig42_playfield_scan);
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void atarig42(machine_config &config);
+
+	void atarig42(machine_config &config) ATTR_COLD;
 	void main_map(address_map &map) ATTR_COLD;
 
 	required_device<atari_jsa_iii_device> m_jsa;
@@ -79,9 +80,13 @@ protected:
 class atarig42_0x200_state : public atarig42_state
 {
 public:
-	using atarig42_state::atarig42_state;
-	void init_roadriot();
-	void atarig42_0x200(machine_config &config);
+	atarig42_0x200_state(const machine_config &mconfig, device_type type, const char *tag) :
+		atarig42_state(mconfig, type, tag)
+	{ }
+
+	void init_roadriot() ATTR_COLD;
+
+	void atarig42_0x200(machine_config &config) ATTR_COLD;
 
 protected:
 	uint16_t roadriot_sloop_data_r(offs_t offset);
@@ -92,10 +97,14 @@ protected:
 class atarig42_0x400_state : public atarig42_state
 {
 public:
-	using atarig42_state::atarig42_state;
-	void init_dangerex();
-	void init_guardian();
-	void atarig42_0x400(machine_config &config);
+	atarig42_0x400_state(const machine_config &mconfig, device_type type, const char *tag) :
+		atarig42_state(mconfig, type, tag)
+	{ }
+
+	void init_dangerex() ATTR_COLD;
+	void init_guardian() ATTR_COLD;
+
+	void atarig42_0x400(machine_config &config) ATTR_COLD;
 
 protected:
 	uint16_t guardians_sloop_data_r(offs_t offset);

--- a/src/mame/atari/atarig42_v.cpp
+++ b/src/mame/atari/atarig42_v.cpp
@@ -49,7 +49,6 @@ TILE_GET_INFO_MEMBER(atarig42_state::get_playfield_tile_info)
 	int const code = (m_playfield_tile_bank << 12) | (data & 0xfff);
 	int const color = (m_playfield_base >> 5) + ((m_playfield_color_bank << 3) & 0x18) + ((data >> 12) & 7);
 	tileinfo.set(0, code, color, BIT(data, 15));
-	tileinfo.category = (m_playfield_color_bank >> 2) & 7;
 }
 
 
@@ -158,14 +157,7 @@ uint32_t atarig42_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 
 	/* draw the playfield */
 	priority_bitmap.fill(0, cliprect);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 0, 0);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 1, 1);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 2, 2);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 3, 3);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 4, 4);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 5, 5);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 6, 6);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 7, 7);
+	m_playfield_tilemap->draw(screen, bitmap, cliprect, 0, (m_playfield_color_bank >> 2) & 7);
 
 	/* copy the motion objects on top */
 	{

--- a/src/mame/atari/atarigx2.h
+++ b/src/mame/atari/atarigx2.h
@@ -35,14 +35,17 @@ public:
 		, m_io_special(*this, "SPECIAL")
 	{ }
 
-	void init_spclords();
-	void init_rrreveng();
-	void init_motofren();
-	void atarigx2_0x200(machine_config &config);
-	void atarigx2_0x400(machine_config &config);
+	void init_spclords() ATTR_COLD;
+	void init_rrreveng() ATTR_COLD;
+	void init_motofren() ATTR_COLD;
+
+	void atarigx2_0x200(machine_config &config) ATTR_COLD;
+	void atarigx2_0x400(machine_config &config) ATTR_COLD;
 
 protected:
 	virtual void video_start() override ATTR_COLD;
+
+private:
 	void video_int_ack_w(uint32_t data = 0);
 	TIMER_DEVICE_CALLBACK_MEMBER(scanline_update);
 	uint32_t special_port2_r();
@@ -59,10 +62,9 @@ protected:
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void atarigx2_mo_control_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 
-	void atarigx2(machine_config &config);
+	void atarigx2(machine_config &config) ATTR_COLD;
 	void main_map(address_map &map) ATTR_COLD;
 
-private:
 	required_device<atari_jsa_iiis_device> m_jsa;
 	optional_device<atari_xga_device> m_xga;
 

--- a/src/mame/atari/atarigx2_v.cpp
+++ b/src/mame/atari/atarigx2_v.cpp
@@ -49,7 +49,6 @@ TILE_GET_INFO_MEMBER(atarigx2_state::get_playfield_tile_info)
 	int const code = (m_playfield_tile_bank << 12) | (data & 0xfff);
 	int const color = (m_playfield_base >> 5) + ((m_playfield_color_bank << 3) & 0x18) + ((data >> 12) & 7);
 	tileinfo.set(0, code, color, BIT(data, 15));
-	tileinfo.category = (m_playfield_color_bank >> 2) & 7;
 }
 
 
@@ -169,14 +168,7 @@ uint32_t atarigx2_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 
 	/* draw the playfield */
 	priority_bitmap.fill(0, cliprect);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 0, 0);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 1, 1);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 2, 2);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 3, 3);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 4, 4);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 5, 5);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 6, 6);
-	m_playfield_tilemap->draw(screen, bitmap, cliprect, 7, 7);
+	m_playfield_tilemap->draw(screen, bitmap, cliprect, 0, (m_playfield_color_bank >> 2) & 7);
 
 	/* copy the motion objects on top */
 	{


### PR DESCRIPTION
- tileinfo.category value for playfield tilemap is controlled by overall bank: it can be optimized to single tilemap draw with variable priority value controlled at bank.