### PR TITLE
input/input_sdl3.cpp: pump CF run loop before enumerating game controllers on macOS

### DIFF
--- a/src/osd/modules/input/input_sdl3.cpp
+++ b/src/osd/modules/input/input_sdl3.cpp
@@ -42,6 +42,10 @@
 #include <tuple>
 #include <utility>
 
+#ifdef __APPLE__
+#include <CoreFoundation/CoreFoundation.h>
+#endif
+
 // winnt.h defines this
 #ifdef DELETE
 #undef DELETE
@@ -2747,6 +2751,13 @@ public:
 		sdl_joystick_module_base::input_init(machine);
 
 		osd_printf_verbose("Game Controller: Start initialization\n");
+
+#ifdef __APPLE__
+		// allow GCController to discover devices asynchronously
+		CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, false);
+#endif
+		SDL_PumpEvents();
+
 		int stick_count = 0;
 		const auto joysticks = SDL_GetJoysticks(&stick_count);
 		for (int physical_stick = 0; physical_stick < stick_count; physical_stick++)


### PR DESCRIPTION
Fixes #15021

On macOS, SDL3's GCController backend discovers USB game controllers
asynchronously through the Core Foundation run loop. When
`SDL_GetJoysticks()` is called during `input_init()`, the run loop
hasn't had time to process, so USB controllers (e.g. Xbox Series X/S)
are not detected.

This adds a `CFRunLoopRunInMode()` call before enumeration to give the
GCController backend time to discover devices, followed by
`SDL_PumpEvents()` to process the resulting SDL events.

Tested on macOS 15.4 (Apple M2) with SDL 3.4.2. Xbox Series X/S
controller (VID 0x045E) connected via USB detected reliably on every
launch (10/10).

See also: https://github.com/libsdl-org/SDL/issues/11742