### PR TITLE
osd/sdl: process events after raising window on macOS to ensure input focus

### DIFF
--- a/src/osd/sdl/video.cpp
+++ b/src/osd/sdl/video.cpp
@@ -73,7 +73,17 @@ bool sdl_osd_interface::video_init()
 	}
 
 	if (m_render->is_interactive())
-		SDL_RaiseWindow(dynamic_cast<sdl_window_info &>(*osd_common_t::s_window_list.front()).platform_window());
+	{
+		SDL_Window *const sdlwindow = dynamic_cast<sdl_window_info &>(*osd_common_t::s_window_list.front()).platform_window();
+		SDL_RaiseWindow(sdlwindow);
+
+#ifdef SDLMAME_MACOSX
+		// ensure focus is acquired before the input modules start polling
+		process_events();
+		if (!has_focus())
+			osd_printf_verbose("Window did not acquire input focus\n");
+#endif
+	}
 
 	return true;
 }

--- a/src/osd/sdl3/video.cpp
+++ b/src/osd/sdl3/video.cpp
@@ -73,7 +73,17 @@ bool sdl_osd_interface::video_init()
 	}
 
 	if (m_render->is_interactive())
-		SDL_RaiseWindow(dynamic_cast<sdl_window_info &>(*osd_common_t::s_window_list.front()).platform_window());
+	{
+		SDL_Window *const sdlwindow = dynamic_cast<sdl_window_info &>(*osd_common_t::s_window_list.front()).platform_window();
+		SDL_RaiseWindow(sdlwindow);
+
+#ifdef SDLMAME_MACOSX
+		// ensure focus is acquired before the input modules start polling
+		process_events();
+		if (!has_focus())
+			osd_printf_verbose("Window did not acquire input focus\n");
+#endif
+	}
 
 	return true;
 }


### PR DESCRIPTION
## Summary
- On macOS, keyboard and mouse input is intermittently lost on startup because `m_focus_window` is not set when the input modules begin polling
- `SDL_RaiseWindow()` returns before macOS has granted input focus, so the `FOCUS_GAINED` event sits unprocessed in SDL's event queue
- Calling `process_events()` after raising the window dequeues the focus event and sets `m_focus_window` before input polling starts
- Guarded with `#ifdef SDLMAME_MACOSX` since the race is macOS-specific
- Applied to both `sdl/` and `sdl3/` backends

## Test plan
- Tested on Apple M2, macOS 26.3.1
- Launched MAME twenty times in a loop, confirmed `has_focus()` returns true on every run with the fix
- Manual testing confirms keyboard input works on first launch

Fixes #10612