### PR TITLE
debugger/osx: add Edit menu with clipboard shortcuts

### DIFF
--- a/src/osd/modules/debugger/debugosx.mm
+++ b/src/osd/modules/debugger/debugosx.mm
@@ -206,8 +206,17 @@ void debugger_osx::build_menus()
 	{
 		NSMenuItem *item;
 
+		NSMenu *const editMenu = [[NSMenu alloc] initWithTitle:@"Edit"];
+		item = [[NSApp mainMenu] insertItemWithTitle:@"Edit" action:NULL keyEquivalent:@"" atIndex:1];
+		[item setSubmenu:editMenu];
+		[editMenu release];
+
+		[editMenu addItemWithTitle:@"Cut" action:@selector(cut:) keyEquivalent:@"x"];
+		[editMenu addItemWithTitle:@"Copy" action:@selector(copy:) keyEquivalent:@"c"];
+		[editMenu addItemWithTitle:@"Paste" action:@selector(paste:) keyEquivalent:@"v"];
+
 		NSMenu *const debugMenu = [[NSMenu alloc] initWithTitle:@"Debug"];
-		item = [[NSApp mainMenu] insertItemWithTitle:@"Debug" action:NULL keyEquivalent:@"" atIndex:1];
+		item = [[NSApp mainMenu] insertItemWithTitle:@"Debug" action:NULL keyEquivalent:@"" atIndex:2];
 		[item setSubmenu:debugMenu];
 		[debugMenu release];
 


### PR DESCRIPTION
Fixes #15133

The macOS Cocoa debugger only adds Debug and Run menus to the menu bar in `debugger_osx::build_menus()`, so standard Cmd+X/C/V shortcuts are never routed through the responder chain to the command input NSTextField. This adds an Edit menu with Cut, Copy, and Paste items to enable clipboard operations.

Select All is intentionally omitted to avoid conflicting with the existing Cmd+A shortcut for "New Disassembly Window" in the Debug menu.