### PR TITLE
Kn5000 interactive control panel

### DIFF
--- a/src/mame/layout/kn5000.lay
+++ b/src/mame/layout/kn5000.lay
@@ -757,79 +757,79 @@ license:CC0-1.0
 	<element ref="dark_round_button" inputtag="CPL_SEG7" inputmask="0x08"><!-- screen button: exit --><bounds x="889" y="362" width="29" height="29"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG1" inputmask="0x01"><bounds x="227" y="477" width="37" height="21"/></element>
-	<element name="CPL_1" ref="green_led"><!-- COMPOSER: MEMORY --><bounds x="242" y="469" width="5" height="5"/></element>
+	<element name="cpl_led_1" ref="green_led"><!-- COMPOSER: MEMORY --><bounds x="242" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG1" inputmask="0x02"><bounds x="262" y="477" width="37" height="21"/></element>
-	<element name="CPL_2" ref="green_led"><!-- COMPOSER: MENU --><bounds x="277" y="469" width="5" height="5"/></element>
+	<element name="cpl_led_2" ref="green_led"><!-- COMPOSER: MENU --><bounds x="277" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG1" inputmask="0x04"><bounds x="297" y="477" width="37" height="21"/></element>
-	<element name="CPL_3" ref="green_led"><!-- SOUND ARRANGER: SET --><bounds x="312" y="469" width="5" height="5"/></element>
+	<element name="cpl_led_3" ref="green_led"><!-- SOUND ARRANGER: SET --><bounds x="312" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG1" inputmask="0x08"><bounds x="332" y="477" width="37" height="21"/></element>
-	<element name="CPL_4" ref="green_led"><!-- SOUND ARRANGER: ON/OFF --><bounds x="348" y="469" width="5" height="5"/></element>
+	<element name="cpl_led_4" ref="green_led"><!-- SOUND ARRANGER: ON/OFF --><bounds x="348" y="469" width="5" height="5"/></element>
 
 	<element id="tempo_program_encoder" ref="tempo_encoder"><bounds x="591" y="460" width="91" height="91"/></element>
 	<element id="tempo_program_encoder_finger" ref="tempo_encoder_finger"><bounds x="641" y="512" width="27" height="27"/></element>
 
 	<element ref="light_ellipse_button" inputtag="CPL_SEG1" inputmask="0x10"><bounds x="444" y="455" width="81" height="23"/></element>
-	<element name="CPL_5" ref="green_led"><!-- MUSIC STYLIST: ONE TOUCH PLAY --><bounds x="483" y="448" width="5" height="5"/></element>
+	<element name="cpl_led_5" ref="green_led"><!-- MUSIC STYLIST: ONE TOUCH PLAY --><bounds x="483" y="448" width="5" height="5"/></element>
 
 	<element ref="dark_half_left_ellipse_button" inputtag="CPL_SEG1" inputmask="0x20"><!-- fade in --><bounds x="444" y="500" width="41" height="23"/></element>
-	<element name="CPL_6" ref="green_led"><!-- FADE IN --><bounds x="452" y="497" width="5" height="5"/></element>
+	<element name="cpl_led_6" ref="green_led"><!-- FADE IN --><bounds x="452" y="497" width="5" height="5"/></element>
 
 	<element ref="dark_half_right_ellipse_button" inputtag="CPL_SEG1" inputmask="0x40"><!-- fade out --><bounds x="484" y="500" width="41" height="23"/></element>
-	<element name="CPL_7" ref="green_led"><!-- FADE OUT --><bounds x="513" y="497" width="5" height="5"/></element>
+	<element name="cpl_led_7" ref="green_led"><!-- FADE OUT --><bounds x="513" y="497" width="5" height="5"/></element>
 
-	<element name="CPL_8" ref="red_led"><!-- DISPLAY HOLD --><bounds x="863" y="354" width="5" height="5"/></element>
+	<element name="cpl_led_8" ref="red_led"><!-- DISPLAY HOLD --><bounds x="863" y="354" width="5" height="5"/></element>
 
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG6" inputmask="0x01"><bounds x="95" y="529" width="37" height="21"/></element>
-	<element name="CPL_9" ref="red_led"><!-- U.S. TRAD --><bounds x="111" y="521" width="5" height="5"/></element>
+	<element name="cpl_led_9" ref="red_led"><!-- U.S. TRAD --><bounds x="111" y="521" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG6" inputmask="0x02"><bounds x="130" y="529" width="37" height="21"/></element>
-	<element name="CPL_10" ref="red_led"><!-- COUNTRY --><bounds x="146" y="521" width="5" height="5"/></element>
+	<element name="cpl_led_10" ref="red_led"><!-- COUNTRY --><bounds x="146" y="521" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG6" inputmask="0x04"><bounds x="165" y="529" width="37" height="21"/></element>
-	<element name="CPL_11" ref="red_led"><!-- LATIN --><bounds x="181" y="521" width="5" height="5"/></element>
+	<element name="cpl_led_11" ref="red_led"><!-- LATIN --><bounds x="181" y="521" width="5" height="5"/></element>
 
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG6" inputmask="0x08"><bounds x="25" y="582" width="37" height="21"/></element>
-	<element name="CPL_12" ref="red_led"><!-- MARCH & WALTZ --><bounds x="41" y="573" width="5" height="5"/></element>
+	<element name="cpl_led_12" ref="red_led"><!-- MARCH & WALTZ --><bounds x="41" y="573" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG6" inputmask="0x10"><bounds x="60" y="582" width="37" height="21"/></element>
-	<element name="CPL_13" ref="red_led"><!-- PARTY TIME --><bounds x="76" y="573" width="5" height="5"/></element>
+	<element name="cpl_led_13" ref="red_led"><!-- PARTY TIME --><bounds x="76" y="573" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG6" inputmask="0x20"><bounds x="95" y="582" width="37" height="21"/></element>
-	<element name="CPL_14" ref="red_led"><!-- SHOWTIME & TRAD DANCE --><bounds x="111" y="573" width="5" height="5"/></element>
+	<element name="cpl_led_14" ref="red_led"><!-- SHOWTIME & TRAD DANCE --><bounds x="111" y="573" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG6" inputmask="0x40"><bounds x="130" y="582" width="37" height="21"/></element>
-	<element name="CPL_15" ref="red_led"><!-- WORLD --><bounds x="146" y="573" width="5" height="5"/></element>
+	<element name="cpl_led_15" ref="red_led"><!-- WORLD --><bounds x="146" y="573" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG6" inputmask="0x80"><bounds x="165" y="582" width="37" height="21"/></element>
-	<element name="CPL_16" ref="green_led"><!-- CUSTOM --><bounds x="181" y="573" width="5" height="5"/></element>
+	<element name="cpl_led_16" ref="green_led"><!-- CUSTOM --><bounds x="181" y="573" width="5" height="5"/></element>
 
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG0" inputmask="0x01"><bounds x="25" y="477" width="37" height="21"/></element>
-	<element name="CPL_17" ref="red_led"><!-- STANDARD ROCK --><bounds x="41" y="469" width="5" height="5"/></element>
+	<element name="cpl_led_17" ref="red_led"><!-- STANDARD ROCK --><bounds x="41" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG0" inputmask="0x02"><bounds x="60" y="477" width="37" height="21"/></element>
-	<element name="CPL_18" ref="red_led"><!-- R & ROLL & BLUES --><bounds x="76" y="469" width="5" height="5"/></element>
+	<element name="cpl_led_18" ref="red_led"><!-- R & ROLL & BLUES --><bounds x="76" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG0" inputmask="0x04"><bounds x="95" y="477" width="37" height="21"/></element>
-	<element name="CPL_19" ref="red_led"><!-- POP & BALLAD --><bounds x="111" y="469" width="5" height="5"/></element>
+	<element name="cpl_led_19" ref="red_led"><!-- POP & BALLAD --><bounds x="111" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG0" inputmask="0x08"><bounds x="130" y="477" width="37" height="21"/></element>
-	<element name="CPL_20" ref="red_led"><!-- FUNK & FUSION --><bounds x="146" y="469" width="5" height="5"/></element>
+	<element name="cpl_led_20" ref="red_led"><!-- FUNK & FUSION --><bounds x="146" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG0" inputmask="0x10"><bounds x="165" y="477" width="37" height="21"/></element>
-	<element name="CPL_21" ref="red_led"><!-- SOUL & MODERN DANCE --><bounds x="181" y="469" width="5" height="5"/></element>
+	<element name="cpl_led_21" ref="red_led"><!-- SOUL & MODERN DANCE --><bounds x="181" y="469" width="5" height="5"/></element>
 
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG0" inputmask="0x20"><bounds x="25" y="529" width="37" height="21"/></element>
-	<element name="CPL_22" ref="red_led"><!-- BIG BAND & SWING --><bounds x="41" y="521" width="5" height="5"/></element>
+	<element name="cpl_led_22" ref="red_led"><!-- BIG BAND & SWING --><bounds x="41" y="521" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPL_SEG0" inputmask="0x40"><bounds x="60" y="529" width="37" height="21"/></element>
-	<element name="CPL_23" ref="red_led"><!-- JAZZ COMBO --><bounds x="76" y="521" width="5" height="5"/></element>
+	<element name="cpl_led_23" ref="red_led"><!-- JAZZ COMBO --><bounds x="76" y="521" width="5" height="5"/></element>
 
 	<element ref="music_note"><bounds x="58" y="225" width="6" height="11"/></element>
 	<element ref="light_pill_button" inputtag="CPL_SEG3" inputmask="0x01"><!-- DEMO --><bounds x="25" y="247" width="37" height="21"/></element>
@@ -837,7 +837,7 @@ license:CC0-1.0
 	<element ref="dark_pill_button" inputtag="CPL_SEG3" inputmask="0x02"><!-- MSP: BANK --><bounds x="111" y="247" width="37" height="21"/></element>
 	<element ref="dark_pill_button" inputtag="CPL_SEG3" inputmask="0x04"><!-- MSP: MENU --><bounds x="184" y="247" width="37" height="21"/></element>
 	<element ref="dark_pill_button" inputtag="CPL_SEG3" inputmask="0x08"><!-- MSP: STOP/RECORD --><bounds x="260" y="247" width="37" height="21"/></element>
-	<element name="CPL_24" ref="green_led"><!-- MSP: MENU --><bounds x="200" y="236" width="5" height="5"/></element>
+	<element name="cpl_led_24" ref="green_led"><!-- MSP: MENU --><bounds x="200" y="236" width="5" height="5"/></element>
 
 	<element ref="msp_corner_button" inputtag="CPL_SEG5" inputmask="0x01"><!-- MSP 1 --><orientation flipx="no" flipy="no"/><bounds x="111" y="293" width="63" height="39"/></element>
 	<element ref="msp_middle_button" inputtag="CPL_SEG5" inputmask="0x02"><!-- MSP 2 --><orientation flipx="no" flipy="no"/><bounds x="173" y="292" width="61" height="40"/></element>
@@ -851,206 +851,206 @@ license:CC0-1.0
 	<element ref="line"><bounds x="221" y="589" width="6" height="1"/></element>
 
 	<element ref="light_31x31_button" inputtag="CPL_SEG4" inputmask="0x01"><bounds x="228" y="572" width="31" height="31"/></element>
-	<element name="CPL_25" ref="red_led"><!-- VARIATION & MSA 1 --><bounds x="241" y="563" width="5" height="5"/></element>
+	<element name="cpl_led_25" ref="red_led"><!-- VARIATION & MSA 1 --><bounds x="241" y="563" width="5" height="5"/></element>
 
 	<element ref="light_31x31_button" inputtag="CPL_SEG4" inputmask="0x02"><bounds x="264" y="572" width="31" height="31"/></element>
-	<element name="CPL_26" ref="red_led"><!-- VARIATION & MSA 2 --><bounds x="277" y="563" width="5" height="5"/></element>
+	<element name="cpl_led_26" ref="red_led"><!-- VARIATION & MSA 2 --><bounds x="277" y="563" width="5" height="5"/></element>
 
 	<element ref="light_31x31_button" inputtag="CPL_SEG4" inputmask="0x04"><bounds x="300" y="572" width="31" height="31"/></element>
-	<element name="CPL_27" ref="red_led"><!-- VARIATION & MSA 3 --><bounds x="312" y="563" width="5" height="5"/></element>
+	<element name="cpl_led_27" ref="red_led"><!-- VARIATION & MSA 3 --><bounds x="312" y="563" width="5" height="5"/></element>
 
 	<element ref="light_31x31_button" inputtag="CPL_SEG4" inputmask="0x08"><bounds x="336" y="572" width="31" height="31"/></element>
-	<element name="CPL_28" ref="red_led"><!-- VARIATION & MSA 4 --><bounds x="348" y="563" width="5" height="5"/></element>
+	<element name="cpl_led_28" ref="red_led"><!-- VARIATION & MSA 4 --><bounds x="348" y="563" width="5" height="5"/></element>
 
 	<element ref="light_21x21_button" inputtag="CPL_SEG4" inputmask="0x10"><bounds x="233" y="529" width="21" height="21"/></element>
-	<element name="CPL_29" ref="red_led"><!-- MUSIC STYLE ARRANGER --><bounds x="241" y="521" width="5" height="5"/></element>
+	<element name="cpl_led_29" ref="red_led"><!-- MUSIC STYLE ARRANGER --><bounds x="241" y="521" width="5" height="5"/></element>
 
 	<element ref="light_37x21_button" inputtag="CPL_SEG4" inputmask="0x20"><!-- SPLIT POINT --><bounds x="297" y="529" width="37" height="21"/></element>
 
 	<element ref="light_37x21_button" inputtag="CPL_SEG4" inputmask="0x40"><bounds x="332" y="529" width="37" height="21"/></element>
-	<element name="CPL_30" ref="green_led"><!-- AUTO PLAY CHORD --><bounds x="348" y="521" width="5" height="5"/></element>
+	<element name="cpl_led_30" ref="green_led"><!-- AUTO PLAY CHORD --><bounds x="348" y="521" width="5" height="5"/></element>
 
 	<element ref="dark_curved_30x34_button" inputtag="CPL_SEG2" inputmask="0x01"><bounds x="444" y="571" width="30" height="34"/></element>
-	<element name="CPL_33" ref="red_led"><!-- FILL IN 1 --><bounds x="455" y="558" width="5" height="5"/></element>
+	<element name="cpl_led_33" ref="red_led"><!-- FILL IN 1 --><bounds x="455" y="558" width="5" height="5"/></element>
 
 	<element ref="dark_curved_30x34_button" inputtag="CPL_SEG2" inputmask="0x02"><bounds x="479" y="571" width="30" height="34"/></element>
-	<element name="CPL_34" ref="red_led"><!-- FILL IN 2 --><bounds x="490" y="558" width="5" height="5"/></element>
+	<element name="cpl_led_34" ref="red_led"><!-- FILL IN 2 --><bounds x="490" y="558" width="5" height="5"/></element>
 
 	<element ref="dark_curved_30x34_button" inputtag="CPL_SEG2" inputmask="0x04"><bounds x="520" y="571" width="30" height="34"/></element>
-	<element name="CPL_35" ref="red_led"><!-- INTRO & ENDING 1 --><bounds x="533" y="558" width="5" height="5"/></element>
+	<element name="cpl_led_35" ref="red_led"><!-- INTRO & ENDING 1 --><bounds x="533" y="558" width="5" height="5"/></element>
 
 	<element ref="dark_curved_30x34_button" inputtag="CPL_SEG2" inputmask="0x08"><bounds x="555" y="571" width="30" height="34"/></element>
-	<element name="CPL_36" ref="red_led"><!-- INTRO & ENDING 2 --><bounds x="569" y="558" width="5" height="5"/></element>
+	<element name="cpl_led_36" ref="red_led"><!-- INTRO & ENDING 2 --><bounds x="569" y="558" width="5" height="5"/></element>
 
 	<element ref="split_point_indicator"><bounds x="266" y="619" width="5" height="8"/></element>
-	<element name="CPL_37" ref="red_led"><!-- SPLIT POINT INDICATOR (LEFT) --><bounds x="266" y="612" width="5" height="5"/></element>
+	<element name="cpl_led_37" ref="red_led"><!-- SPLIT POINT INDICATOR (LEFT) --><bounds x="266" y="612" width="5" height="5"/></element>
 
 	<element ref="split_point_indicator"><bounds x="434" y="619" width="5" height="8"/></element>
-	<element name="CPL_38" ref="red_led"><!-- SPLIT POINT INDICATOR (CENTER) --><bounds x="434" y="612" width="5" height="5"/></element>
+	<element name="cpl_led_38" ref="red_led"><!-- SPLIT POINT INDICATOR (CENTER) --><bounds x="434" y="612" width="5" height="5"/></element>
 
 	<element ref="split_point_indicator"><bounds x="640" y="619" width="5" height="8"/></element>
-	<element name="CPL_39" ref="red_led"><!-- SPLIT POINT INDICATOR (RIGHT) --><bounds x="640" y="612" width="5" height="5"/></element>
+	<element name="cpl_led_39" ref="red_led"><!-- SPLIT POINT INDICATOR (RIGHT) --><bounds x="640" y="612" width="5" height="5"/></element>
 
-	<element name="CPL_40" ref="green_led"><!-- TEMPO/PROGRAM --><bounds x="636" y="448" width="5" height="5"/></element>
+	<element name="cpl_led_40" ref="green_led"><!-- TEMPO/PROGRAM --><bounds x="636" y="448" width="5" height="5"/></element>
 
-	<element name="CPL_49" ref="red_led"><!-- OTHER PARTS/TR --><bounds x="430" y="354" width="5" height="5"/></element>
+	<element name="cpl_led_49" ref="red_led"><!-- OTHER PARTS/TR --><bounds x="430" y="354" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG3" inputmask="0x01"><bounds x="855" y="476" width="37" height="21"/></element>
-	<element name="CPR_1" ref="red_led"><!-- EFFECT: SUSTAIN --><bounds x="872" y="469" width="5" height="5"/></element>
+	<element name="cpr_led_1" ref="red_led"><!-- EFFECT: SUSTAIN --><bounds x="872" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG3" inputmask="0x02"><bounds x="890" y="476" width="37" height="21"/></element>
-	<element name="CPR_2" ref="red_led"><!-- EFFECT: DIGITAL EFFECT --><bounds x="907" y="469" width="5" height="5"/></element>
+	<element name="cpr_led_2" ref="red_led"><!-- EFFECT: DIGITAL EFFECT --><bounds x="907" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG3" inputmask="0x04"><bounds x="925" y="476" width="37" height="21"/></element>
-	<element name="CPR_3" ref="red_led"><!-- EFFECT: DSP EFFECT --><bounds x="942" y="469" width="5" height="5"/></element>
+	<element name="cpr_led_3" ref="red_led"><!-- EFFECT: DSP EFFECT --><bounds x="942" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG3" inputmask="0x08"><bounds x="960" y="476" width="37" height="21"/></element>
-	<element name="CPR_4" ref="red_led"><!-- EFFECT: DIGITAL REVERB --><bounds x="977" y="469" width="5" height="5"/></element>
+	<element name="cpr_led_4" ref="red_led"><!-- EFFECT: DIGITAL REVERB --><bounds x="977" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG3" inputmask="0x10"><bounds x="995" y="476" width="37" height="21"/></element>
-	<element name="CPR_5" ref="red_led"><!-- EFFECT: ACOUSTIC ILLUSION --><bounds x="1013" y="469" width="5" height="5"/></element>
+	<element name="cpr_led_5" ref="red_led"><!-- EFFECT: ACOUSTIC ILLUSION --><bounds x="1013" y="469" width="5" height="5"/></element>
 
 
 	<element ref="light_37x21_button" inputtag="CPR_SEG5" inputmask="0x08"><bounds x="979" y="235" width="37" height="21"/></element>
-	<element name="CPR_6" ref="green_led"><!-- SEQUENCER: PLAY --><bounds x="996" y="226" width="5" height="5"/></element>
+	<element name="cpr_led_6" ref="green_led"><!-- SEQUENCER: PLAY --><bounds x="996" y="226" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG5" inputmask="0x10"><bounds x="1030" y="235" width="37" height="21"/></element>
 	<element ref="red_line"><bounds x="1040" y="244" width="19" height="4"/></element>
-	<element name="CPR_7" ref="green_led"><!-- SEQUENCER: EASY REC --><bounds x="1047" y="226" width="5" height="5"/></element>
+	<element name="cpr_led_7" ref="green_led"><!-- SEQUENCER: EASY REC --><bounds x="1047" y="226" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG5" inputmask="0x20"><bounds x="1065" y="235" width="37" height="21"/></element>
-	<element name="CPR_8" ref="green_led"><!-- SEQUENCER: MENU --><bounds x="1082" y="226" width="5" height="5"/></element>
+	<element name="cpr_led_8" ref="green_led"><!-- SEQUENCER: MENU --><bounds x="1082" y="226" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG2" inputmask="0x01"><bounds x="1052" y="476" width="37" height="21"/></element>
-	<element name="CPR_9" ref="red_led"><!-- PIANO --><bounds x="1067" y="469" width="5" height="5"/></element>
+	<element name="cpr_led_9" ref="red_led"><!-- PIANO --><bounds x="1067" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG2" inputmask="0x02"><bounds x="1087" y="476" width="37" height="21"/></element>
-	<element name="CPR_10" ref="red_led"><!-- GUITAR --><bounds x="1103" y="469" width="5" height="5"/></element>
+	<element name="cpr_led_10" ref="red_led"><!-- GUITAR --><bounds x="1103" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG2" inputmask="0x04"><bounds x="1122" y="476" width="37" height="21"/></element>
-	<element name="CPR_11" ref="red_led"><!-- STRINGS & VOCAL --><bounds x="1138" y="469" width="5" height="5"/></element>
+	<element name="cpr_led_11" ref="red_led"><!-- STRINGS & VOCAL --><bounds x="1138" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG2" inputmask="0x08"><bounds x="1157" y="476" width="37" height="21"/></element>
-	<element name="CPR_12" ref="red_led"><!-- BRASS --><bounds x="1173" y="469" width="5" height="5"/></element>
+	<element name="cpr_led_12" ref="red_led"><!-- BRASS --><bounds x="1173" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG2" inputmask="0x10"><bounds x="1192" y="476" width="37" height="21"/></element>
-	<element name="CPR_13" ref="red_led"><!-- FLUTE --><bounds x="1208" y="469" width="5" height="5"/></element>
+	<element name="cpr_led_13" ref="red_led"><!-- FLUTE --><bounds x="1208" y="469" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG2" inputmask="0x20"><bounds x="1227" y="476" width="37" height="21"/></element>
-	<element name="CPR_14" ref="red_led"><!-- SAX & REED --><bounds x="1243" y="469" width="5" height="5"/></element>
+	<element name="cpr_led_14" ref="red_led"><!-- SAX & REED --><bounds x="1243" y="469" width="5" height="5"/></element>
 
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG2" inputmask="0x40"><bounds x="1052" y="528" width="37" height="21"/></element>
-	<element name="CPR_15" ref="red_led"><!-- MALLET & ORCH PERC --><bounds x="1067" y="521" width="5" height="5"/></element>
+	<element name="cpr_led_15" ref="red_led"><!-- MALLET & ORCH PERC --><bounds x="1067" y="521" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG2" inputmask="0x80"><bounds x="1087" y="528" width="37" height="21"/></element>
-	<element name="CPR_16" ref="red_led"><!-- WORLD PERC --><bounds x="1103" y="521" width="5" height="5"/></element>
+	<element name="cpr_led_16" ref="red_led"><!-- WORLD PERC --><bounds x="1103" y="521" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG1" inputmask="0x01"><bounds x="1122" y="528" width="37" height="21"/></element>
-	<element name="CPR_17" ref="red_led"><!-- ORGAN & ACCORDION --><bounds x="1138" y="521" width="5" height="5"/></element>
+	<element name="cpr_led_17" ref="red_led"><!-- ORGAN & ACCORDION --><bounds x="1138" y="521" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG1" inputmask="0x02"><bounds x="1157" y="528" width="37" height="21"/></element>
-	<element name="CPR_18" ref="red_led"><!-- ORCHESTRAL PAD --><bounds x="1173" y="521" width="5" height="5"/></element>
+	<element name="cpr_led_18" ref="red_led"><!-- ORCHESTRAL PAD --><bounds x="1173" y="521" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG1" inputmask="0x04"><bounds x="1192" y="528" width="37" height="21"/></element>
-	<element name="CPR_19" ref="red_led"><!-- SYNTH --><bounds x="1208" y="521" width="5" height="5"/></element>
+	<element name="cpr_led_19" ref="red_led"><!-- SYNTH --><bounds x="1208" y="521" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG1" inputmask="0x08"><bounds x="1227" y="528" width="37" height="21"/></element>
-	<element name="CPR_20" ref="red_led"><!-- BASS --><bounds x="1243" y="521" width="5" height="5"/></element>
+	<element name="cpr_led_20" ref="red_led"><!-- BASS --><bounds x="1243" y="521" width="5" height="5"/></element>
 
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG1" inputmask="0x10"><bounds x="1052" y="581" width="37" height="21"/></element>
 	<element ref="line"><bounds x="1061" y="589" width="19" height="4"/></element>
-	<element name="CPR_21" ref="red_led"><!-- DIGITAL DRAWBAR --><bounds x="1067" y="573" width="5" height="5"/></element>
+	<element name="cpr_led_21" ref="red_led"><!-- DIGITAL DRAWBAR --><bounds x="1067" y="573" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG1" inputmask="0x20"><bounds x="1087" y="581" width="37" height="21"/></element>
 	<element ref="line"><bounds x="1096" y="589" width="19" height="4"/></element>
-	<element name="CPR_22" ref="red_led"><!-- ACCORDION REGISTER --><bounds x="1103" y="573" width="5" height="5"/></element>
+	<element name="cpr_led_22" ref="red_led"><!-- ACCORDION REGISTER --><bounds x="1103" y="573" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG1" inputmask="0x40"><bounds x="1122" y="581" width="37" height="21"/></element>
-	<element name="CPR_23" ref="red_led"><!-- GM SPECIAL --><bounds x="1138" y="573" width="5" height="5"/></element>
+	<element name="cpr_led_23" ref="red_led"><!-- GM SPECIAL --><bounds x="1138" y="573" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG1" inputmask="0x80"><bounds x="1157" y="581" width="37" height="21"/></element>
-	<element name="CPR_24" ref="red_led"><!-- DRUM KITS --><bounds x="1173" y="573" width="5" height="5"/></element>
+	<element name="cpr_led_24" ref="red_led"><!-- DRUM KITS --><bounds x="1173" y="573" width="5" height="5"/></element>
 
 	<element ref="line"><bounds x="973" y="296" width="7" height="1"/></element>
 	<element ref="line"><bounds x="973" y="296" width="1" height="52"/></element>
 	<element ref="line"><bounds x="973" y="348" width="7" height="1"/></element>
 
 	<element ref="dark_25x25_button" inputtag="CPR_SEG6" inputmask="0x01"><bounds x="980" y="335" width="25" height="25"/></element>
-	<element name="CPR_25" ref="green_led"><!-- PANEL MEMORY 1 --><bounds x="988" y="327" width="5" height="5"/></element>
+	<element name="cpr_led_25" ref="green_led"><!-- PANEL MEMORY 1 --><bounds x="988" y="327" width="5" height="5"/></element>
 
 	<element ref="dark_25x25_button" inputtag="CPR_SEG6" inputmask="0x02"><bounds x="1017" y="335" width="25" height="25"/></element>
-	<element name="CPR_26" ref="green_led"><!-- PANEL MEMORY 2 --><bounds x="1024" y="327" width="5" height="5"/></element>
+	<element name="cpr_led_26" ref="green_led"><!-- PANEL MEMORY 2 --><bounds x="1024" y="327" width="5" height="5"/></element>
 
 	<element ref="dark_25x25_button" inputtag="CPR_SEG6" inputmask="0x04"><bounds x="1054" y="335" width="25" height="25"/></element>
-	<element name="CPR_27" ref="green_led"><!-- PANEL MEMORY 3 --><bounds x="1061" y="327" width="5" height="5"/></element>
+	<element name="cpr_led_27" ref="green_led"><!-- PANEL MEMORY 3 --><bounds x="1061" y="327" width="5" height="5"/></element>
 
 	<element ref="dark_25x25_button" inputtag="CPR_SEG6" inputmask="0x08"><bounds x="1090" y="335" width="25" height="25"/></element>
-	<element name="CPR_28" ref="green_led"><!-- PANEL MEMORY 4 --><bounds x="1098" y="327" width="5" height="5"/></element>
+	<element name="cpr_led_28" ref="green_led"><!-- PANEL MEMORY 4 --><bounds x="1098" y="327" width="5" height="5"/></element>
 
 	<element ref="dark_25x25_button" inputtag="CPR_SEG6" inputmask="0x10"><bounds x="1127" y="335" width="25" height="25"/></element>
-	<element name="CPR_29" ref="green_led"><!-- PANEL MEMORY 5 --><bounds x="1135" y="327" width="5" height="5"/></element>
+	<element name="cpr_led_29" ref="green_led"><!-- PANEL MEMORY 5 --><bounds x="1135" y="327" width="5" height="5"/></element>
 
 	<element ref="dark_25x25_button" inputtag="CPR_SEG6" inputmask="0x20"><bounds x="1164" y="335" width="25" height="25"/></element>
-	<element name="CPR_30" ref="green_led"><!-- PANEL MEMORY 6 --><bounds x="1172" y="327" width="5" height="5"/></element>
+	<element name="cpr_led_30" ref="green_led"><!-- PANEL MEMORY 6 --><bounds x="1172" y="327" width="5" height="5"/></element>
 
 	<element ref="dark_25x25_button" inputtag="CPR_SEG6" inputmask="0x40"><bounds x="1201" y="335" width="25" height="25"/></element>
-	<element name="CPR_31" ref="green_led"><!-- PANEL MEMORY 7 --><bounds x="1209" y="327" width="5" height="5"/></element>
+	<element name="cpr_led_31" ref="green_led"><!-- PANEL MEMORY 7 --><bounds x="1209" y="327" width="5" height="5"/></element>
 
 	<element ref="dark_25x25_button" inputtag="CPR_SEG6" inputmask="0x80"><bounds x="1238" y="335" width="25" height="25"/></element>
-	<element name="CPR_32" ref="green_led"><!-- PANEL MEMORY 8 --><bounds x="1245" y="327" width="5" height="5"/></element>
+	<element name="cpr_led_32" ref="green_led"><!-- PANEL MEMORY 8 --><bounds x="1245" y="327" width="5" height="5"/></element>
 
 
 	<element ref="light_21x21_button" inputtag="CPR_SEG4" inputmask="0x01"><bounds x="864" y="529" width="21" height="21"/></element>
-	<element name="CPR_33" ref="red_led"><!-- PART SELECT: LEFT --><bounds x="872" y="521" width="5" height="5"/></element>
+	<element name="cpr_led_33" ref="red_led"><!-- PART SELECT: LEFT --><bounds x="872" y="521" width="5" height="5"/></element>
 
 	<element ref="light_21x21_button" inputtag="CPR_SEG4" inputmask="0x02"><bounds x="899" y="529" width="21" height="21"/></element>
-	<element name="CPR_34" ref="red_led"><!-- PART SELECT: RIGHT 2 --><bounds x="907" y="521" width="5" height="5"/></element>
+	<element name="cpr_led_34" ref="red_led"><!-- PART SELECT: RIGHT 2 --><bounds x="907" y="521" width="5" height="5"/></element>
 
 	<element ref="light_21x21_button" inputtag="CPR_SEG4" inputmask="0x04"><bounds x="933" y="529" width="21" height="21"/></element>
-	<element name="CPR_35" ref="red_led"><!-- PART SELECT: RIGHT 1 --><bounds x="941" y="521" width="5" height="5"/></element>
+	<element name="cpr_led_35" ref="red_led"><!-- PART SELECT: RIGHT 1 --><bounds x="941" y="521" width="5" height="5"/></element>
 
 
 	<element ref="dark_pill_button" inputtag="CPR_SEG4" inputmask="0x08"><bounds x="994" y="528" width="37" height="21"/></element>
-	<element name="CPR_36" ref="green_led"><!-- ENTERTAINER --><bounds x="1010" y="521" width="5" height="5"/></element>
+	<element name="cpr_led_36" ref="green_led"><!-- ENTERTAINER --><bounds x="1010" y="521" width="5" height="5"/></element>
 
 
 	<element ref="light_31x31_button" inputtag="CPR_SEG4" inputmask="0x10"><bounds x="859" y="574" width="31" height="31"/></element>
-	<element name="CPR_37" ref="red_led"><!-- CONDUCTOR: LEFT --><bounds x="872" y="564" width="5" height="5"/></element>
+	<element name="cpr_led_37" ref="red_led"><!-- CONDUCTOR: LEFT --><bounds x="872" y="564" width="5" height="5"/></element>
 
 	<element ref="light_31x31_button" inputtag="CPR_SEG4" inputmask="0x20"><bounds x="893" y="574" width="31" height="31"/></element>
-	<element name="CPR_38" ref="red_led"><!-- CONDUCTOR: RIGHT 2 --><bounds x="907" y="564" width="5" height="5"/></element>
+	<element name="cpr_led_38" ref="red_led"><!-- CONDUCTOR: RIGHT 2 --><bounds x="907" y="564" width="5" height="5"/></element>
 
 	<element ref="light_31x31_button" inputtag="CPR_SEG4" inputmask="0x40"><bounds x="927" y="574" width="31" height="31"/></element>
-	<element name="CPR_39" ref="red_led"><!-- CONDUCTOR: RIGHT 1 --><bounds x="941" y="564" width="5" height="5"/></element>
+	<element name="cpr_led_39" ref="red_led"><!-- CONDUCTOR: RIGHT 1 --><bounds x="941" y="564" width="5" height="5"/></element>
 
 
 	<element ref="dark_pill_button" inputtag="CPR_SEG4" inputmask="0x80"><bounds x="994" y="580" width="37" height="21"/></element>
-	<element name="CPR_40" ref="red_led"><!-- TECHNI CHORD --><bounds x="1010" y="573" width="5" height="5"/></element>
+	<element name="cpr_led_40" ref="red_led"><!-- TECHNI CHORD --><bounds x="1010" y="573" width="5" height="5"/></element>
 
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG10" inputmask="0x04"><bounds x="1121" y="235" width="37" height="21"/></element>
-	<element name="CPR_49" ref="green_led"><!-- MENU: SOUND --><bounds x="1138" y="226" width="5" height="5"/></element>
+	<element name="cpr_led_49" ref="green_led"><!-- MENU: SOUND --><bounds x="1138" y="226" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG10" inputmask="0x08"><bounds x="1156" y="235" width="37" height="21"/></element>
-	<element name="CPR_50" ref="green_led"><!-- MENU: CONTROL --><bounds x="1173" y="226" width="5" height="5"/></element>
+	<element name="cpr_led_50" ref="green_led"><!-- MENU: CONTROL --><bounds x="1173" y="226" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG10" inputmask="0x10"><bounds x="1191" y="235" width="37" height="21"/></element>
-	<element name="CPR_51" ref="green_led"><!-- MENU: MIDI --><bounds x="1208" y="226" width="5" height="5"/></element>
+	<element name="cpr_led_51" ref="green_led"><!-- MENU: MIDI --><bounds x="1208" y="226" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG10" inputmask="0x20"><bounds x="1226" y="235" width="37" height="21"/></element>
-	<element name="CPR_52" ref="green_led"><!-- MENU: DISK --><bounds x="1244" y="226" width="5" height="5"/></element>
+	<element name="cpr_led_52" ref="green_led"><!-- MENU: DISK --><bounds x="1244" y="226" width="5" height="5"/></element>
 
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG9" inputmask="0x40"><bounds x="1192" y="581" width="37" height="21"/></element>
-	<element name="CPR_57" ref="green_led"><!-- MEMORY A --><bounds x="1208" y="573" width="5" height="5"/></element>
+	<element name="cpr_led_57" ref="green_led"><!-- MEMORY A --><bounds x="1208" y="573" width="5" height="5"/></element>
 
 	<element ref="dark_37x21_button" inputtag="CPR_SEG9" inputmask="0x80"><bounds x="1227" y="581" width="37" height="21"/></element>
-	<element name="CPR_58" ref="green_led"><!-- MEMORY B --><bounds x="1243" y="573" width="5" height="5"/></element>
+	<element name="cpr_led_58" ref="green_led"><!-- MEMORY B --><bounds x="1243" y="573" width="5" height="5"/></element>
 
 	<element ref="dark_curved_18x34_button" inputtag="CPR_SEG8" inputmask="0x40"><bounds x="774" y="571" width="18" height="34"/></element>
-	<element name="CPR_61" ref="red_led"><!-- SYNCHRO & BREAK --><bounds x="780" y="558" width="5" height="5"/></element>
+	<element name="cpr_led_61" ref="red_led"><!-- SYNCHRO & BREAK --><bounds x="780" y="558" width="5" height="5"/></element>
 
 	<element ref="dark_curved_27x34_button" inputtag="CPR_SEG8" inputmask="0x80"><!-- TAP TEMPO --><bounds x="805" y="571" width="27" height="34"/></element>
 
@@ -1058,21 +1058,21 @@ license:CC0-1.0
 	<element ref="dark_half_right_ellipse_button" inputtag="CPR_SEG0" inputmask="0x40"><!-- TRANSPOSE + --><bounds x="788" y="455" width="41" height="23"/></element>
 
 	<element ref="dark_half_left_ellipse_button" inputtag="CPR_SEG8" inputmask="0x08"><!-- MINUS --><bounds x="748" y="503" width="41" height="23"/></element>
-	<element name="CPR_62" ref="red_led"><!-- R1/R2 OCTAVE MINUS --><bounds x="756" y="497" width="5" height="5"/></element>
+	<element name="cpr_led_62" ref="red_led"><!-- R1/R2 OCTAVE MINUS --><bounds x="756" y="497" width="5" height="5"/></element>
 	<element ref="dark_half_right_ellipse_button" inputtag="CPR_SEG8" inputmask="0x10"><!-- PLUS --><bounds x="788" y="503" width="41" height="23"/></element>
-	<element name="CPR_63" ref="red_led"><!-- R1/R2 OCTAVE PLUS --><bounds x="817" y="497" width="5" height="5"/></element>
+	<element name="cpr_led_63" ref="red_led"><!-- R1/R2 OCTAVE PLUS --><bounds x="817" y="497" width="5" height="5"/></element>
 
 	<element ref="dark_pill_button" inputtag="CPR_SEG7" inputmask="0x01"><!-- SEQUENCER: SET --><bounds x="979" y="286" width="37" height="21"/></element>
 	<element ref="red_line"><bounds x="988" y="295" width="19" height="4"/></element>
 	<element ref="dark_pill_button" inputtag="CPR_SEG7" inputmask="0x02"><!-- SEQUENCER: NEXT BANK --><bounds x="1031" y="286" width="37" height="21"/></element>
 	<element ref="dark_pill_button" inputtag="CPR_SEG7" inputmask="0x04"><!-- SEQUENCER: BANK VIEW --><bounds x="1082" y="286" width="37" height="21"/></element>
-	<element name="CPR_64" ref="green_led"><!-- BANK VIEW --><bounds x="1098" y="277" width="5" height="5"/></element>
+	<element name="cpr_led_64" ref="green_led"><!-- BANK VIEW --><bounds x="1098" y="277" width="5" height="5"/></element>
 
 	<element ref="light_curved_53x34_button" inputtag="CPR_SEG8" inputmask="0x20"><!-- START/STOP --><bounds x="687" y="571" width="53" height="34"/></element>
-	<element name="CPR_65" ref="red_led"><!-- BEAT #1 --><bounds x="685" y="558" width="5" height="5"/></element>
-	<element name="CPR_66" ref="green_led"><!-- BEAT #2 --><bounds x="700" y="558" width="5" height="5"/></element>
-	<element name="CPR_67" ref="green_led"><!-- BEAT #3 --><bounds x="716" y="558" width="5" height="5"/></element>
-	<element name="CPR_68" ref="green_led"><!-- BEAT #4 --><bounds x="732" y="558" width="5" height="5"/></element>
+	<element name="cpr_led_65" ref="red_led"><!-- BEAT #1 --><bounds x="685" y="558" width="5" height="5"/></element>
+	<element name="cpr_led_66" ref="green_led"><!-- BEAT #2 --><bounds x="700" y="558" width="5" height="5"/></element>
+	<element name="cpr_led_67" ref="green_led"><!-- BEAT #3 --><bounds x="716" y="558" width="5" height="5"/></element>
+	<element name="cpr_led_68" ref="green_led"><!-- BEAT #4 --><bounds x="732" y="558" width="5" height="5"/></element>
 
 	<element ref="black_transparent_rect"><bounds x="1232" y="5" width="46" height="26" /></element>
 	<element ref="maincpu_text"><bounds x="1235" y="8" width="30" height="8"/></element>

--- a/src/mame/matsushita/kn5000.cpp
+++ b/src/mame/matsushita/kn5000.cpp
@@ -9,12 +9,14 @@
 #include "emu.h"
 #include "bus/technics/kn5000/hdae5000.h"
 #include "cpu/tlcs900/tmp94c241.h"
+#include "cpu/tlcs900/tmp94c241_serial.h"
 #include "imagedev/floppy.h"
 #include "machine/gen_latch.h"
 #include "machine/upd765.h"
 #include "video/pc_vga.h"
 #include "screen.h"
 #include "kn5000.lh"
+#include "kn5000_cpanel.h"
 
 class mn89304_vga_device : public svga_device
 {
@@ -91,6 +93,7 @@ class kn5000_state : public driver_device
 public:
 	kn5000_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
+		, m_cpanel(*this, "cpanel")
 		, m_maincpu(*this, "maincpu")
 		, m_subcpu(*this, "subcpu")
 		, m_maincpu_latch(*this, "maincpu_latch")
@@ -102,16 +105,15 @@ public:
 		, m_CPR_SEG(*this, "CPR_SEG%u", 0U)
 		, m_checking_device_led_cn11(*this, "checking_device_led_cn11")
 		, m_checking_device_led_cn12(*this, "checking_device_led_cn12")
-		, m_CPL_LED(*this, "CPL_%u", 0U)
-		, m_CPR_LED(*this, "CPR_%u", 0U)
-		, m_led_row(0)
 		, m_mstat(0)
 		, m_sstat(0)
+		, m_cpanel_inta(0)
 	{ }
 
 	void kn5000(machine_config &config);
 
 private:
+	required_device<kn5000_cpanel_device> m_cpanel;
 	required_device<tmp94c241_device> m_maincpu;
 	required_device<tmp94c241_device> m_subcpu;
 	required_device<generic_latch_8_device> m_maincpu_latch;
@@ -124,18 +126,12 @@ private:
 	required_ioport_array<11> m_CPR_SEG; // buttons on "Control Panel Right" PCB
 	output_finder<> m_checking_device_led_cn11;
 	output_finder<> m_checking_device_led_cn12;
-	output_finder<50> m_CPL_LED;
-	output_finder<69> m_CPR_LED;
-	uint8_t m_led_row;
 	uint8_t m_mstat;
 	uint8_t m_sstat;
+	uint8_t m_cpanel_inta;
 
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
-
-	uint8_t cpanel_left_buttons_r(offs_t offset);
-	uint8_t cpanel_right_buttons_r(offs_t offset);
-	void cpanel_leds_w(offs_t offset, uint8_t data);
 
 	void maincpu_mem(address_map &map) ATTR_COLD;
 	void subcpu_mem(address_map &map) ATTR_COLD;
@@ -144,9 +140,7 @@ private:
 void kn5000_state::maincpu_mem(address_map &map)
 {
 	map(0x000000, 0x0fffff).ram(); // 1Mbyte = 2 * 4Mbit DRAMs @ IC9, IC10 (CS3)
-	map(0x008e4a, 0x008e54).r(FUNC(kn5000_state::cpanel_right_buttons_r));
-	map(0x008e5a, 0x008e64).r(FUNC(kn5000_state::cpanel_left_buttons_r));
-	map(0x008f38, 0x008f39).w(FUNC(kn5000_state::cpanel_leds_w));
+	// Button states and LED control are handled via serial protocol to cpanel HLE device
 	//FIXME: map(0x110000, 0x11ffff).m(m_fdc, FUNC(upd765a_device::map)); // Floppy Controller @ IC208
 	//FIXME: map(0x120000, 0x12ffff).w(m_fdc, FUNC(upd765a_device::dack_w)); // Floppy DMA Acknowledge
 	map(0x140000, 0x14ffff).r(m_maincpu_latch, FUNC(generic_latch_8_device::read)); // @ IC23
@@ -451,182 +445,24 @@ static INPUT_PORTS_START(kn5000)
 INPUT_PORTS_END
 
 
-uint8_t kn5000_state::cpanel_left_buttons_r(offs_t offset)
-{
-	return m_CPL_SEG[offset]->read();
-}
-
-uint8_t kn5000_state::cpanel_right_buttons_r(offs_t offset)
-{
-	return m_CPR_SEG[offset]->read();
-}
-
-
-void kn5000_state::cpanel_leds_w(offs_t offset, uint8_t data)
-{
-	if ((offset & 1) == 0)
-		m_led_row = data;
-
-	if ((offset & 1) == 1)
-	{
-		switch (m_led_row)
-		{
-			case 0x00:
-				m_CPR_LED[1] = BIT(data, 0); // D101 - EFFECT: SUSTAIN
-				m_CPR_LED[2] = BIT(data, 1); // D102 - EFFECT: DIGITAL EFFECT
-				m_CPR_LED[3] = BIT(data, 2); // D103 - EFFECT: DSP EFFECT
-				m_CPR_LED[4] = BIT(data, 3); // D104 - EFFECT: DIGITAL REVERB
-				m_CPR_LED[5] = BIT(data, 4); // D105 - EFFECT: ACCOUSTIC ILLUSION
-				m_CPR_LED[6] = BIT(data, 5); // D106 - SEQUENCER: PLAY
-				m_CPR_LED[7] = BIT(data, 6); // D107 - SEQUENCER: EASY REC
-				m_CPR_LED[8] = BIT(data, 7); // D108 - SEQUENCER: MENU
-				break;
-
-			case 0x01:
-				m_CPR_LED[9] = BIT(data, 0); // D109 - PIANO
-				m_CPR_LED[10] = BIT(data, 1); // D110 - GUITAR
-				m_CPR_LED[11] = BIT(data, 2); // D111 - STRINGS & VOCAL
-				m_CPR_LED[12] = BIT(data, 3); // D112 - BRASS
-				m_CPR_LED[13] = BIT(data, 4); // D113 - FLUTE
-				m_CPR_LED[14] = BIT(data, 5); // D114 - SAX & REED
-				m_CPR_LED[15] = BIT(data, 6); // D115 - MALLET & ORCH PERC
-				m_CPR_LED[16] = BIT(data, 7); // D116 - WORLD PERC
-				break;
-
-			case 0x02:
-				m_CPR_LED[17] = BIT(data, 0); // D117 - ORGAN & ACCORDION
-				m_CPR_LED[18] = BIT(data, 1); // D118 - ORCHESTRAL PAD
-				m_CPR_LED[19] = BIT(data, 2); // D119 - SYNTH
-				m_CPR_LED[20] = BIT(data, 3); // D120 - BASS
-				m_CPR_LED[21] = BIT(data, 4); // D121 - DIGITAL DRAWBAR
-				m_CPR_LED[22] = BIT(data, 5); // D122 - ACCORDION REGISTER
-				m_CPR_LED[23] = BIT(data, 6); // D123 - GM SPECIAL
-				m_CPR_LED[24] = BIT(data, 7); // D124 - DRUM KITS
-				break;
-
-			case 0x03:
-				m_CPR_LED[25] = BIT(data, 0); // D125 - PANEL MEMORY 1
-				m_CPR_LED[26] = BIT(data, 1); // D126 - PANEL MEMORY 2
-				m_CPR_LED[27] = BIT(data, 2); // D127 - PANEL MEMORY 3
-				m_CPR_LED[28] = BIT(data, 3); // D128 - PANEL MEMORY 4
-				m_CPR_LED[29] = BIT(data, 4); // D129 - PANEL MEMORY 5
-				m_CPR_LED[30] = BIT(data, 5); // D130 - PANEL MEMORY 6
-				m_CPR_LED[31] = BIT(data, 6); // D131 - PANEL MEMORY 7
-				m_CPR_LED[32] = BIT(data, 7); // D132 - PANEL MEMORY 8
-				break;
-
-			case 0x04:
-				m_CPR_LED[33] = BIT(data, 0); // D133 - PART SELECT: LEFT
-				m_CPR_LED[34] = BIT(data, 1); // D134 - PART SELECT: RIGHT 2
-				m_CPR_LED[35] = BIT(data, 2); // D135 - PART SELECT: RIGHT 1
-				m_CPR_LED[36] = BIT(data, 3); // D136 - ENTERTAINER
-				m_CPR_LED[37] = BIT(data, 4); // D137 - CONDUCTOR: LEFT
-				m_CPR_LED[38] = BIT(data, 5); // D138 - CONDUCTOR: RIGHT 2
-				m_CPR_LED[39] = BIT(data, 6); // D139 - CONDUCTOR: RIGHT 1
-				m_CPR_LED[40] = BIT(data, 7); // D140 - TECHNI CHORD
-				break;
-
-			case 0x08:
-				m_CPR_LED[49] = BIT(data, 0); // D149 - MENU: SOUND
-				m_CPR_LED[50] = BIT(data, 1); // D150 - MENU: CONTROL
-				m_CPR_LED[51] = BIT(data, 2); // D151 - MENU: MIDI
-				m_CPR_LED[52] = BIT(data, 3); // D152 - MENU: DISK
-				break;
-
-			case 0x0a:
-				m_CPR_LED[57] = BIT(data, 0); // D157 - MEMORY A
-				m_CPR_LED[58] = BIT(data, 1); // D158 - MEMORY B
-				break;
-
-			case 0x0b:
-				m_CPR_LED[61] = BIT(data, 0); // D161 - SYNCHRO & BREAK
-				m_CPR_LED[62] = BIT(data, 1); // D162 - R1/R2 OCTAVE MINUS
-				m_CPR_LED[63] = BIT(data, 2); // D163 - R1/R2 OCTAVE PLUS
-				m_CPR_LED[64] = BIT(data, 3); // D164 - BANK VIEW
-				break;
-
-			case 0x0c:
-				m_CPR_LED[65] = BIT(data, 0); // D165 - START/STOP 1 BEAT
-				m_CPR_LED[66] = BIT(data, 1); // D166 - START/STOP 2 BEAT
-				m_CPR_LED[67] = BIT(data, 2); // D167 - START/STOP 3 BEAT
-				m_CPR_LED[68] = BIT(data, 3); // D168 - START/STOP 4 BEAT
-				break;
-
-			case 0xc0:
-				m_CPL_LED[1] = BIT(data, 0); // D101 - COMPOSER: MEMORY
-				m_CPL_LED[2] = BIT(data, 1); // D102 - COMPOSER: MENU
-				m_CPL_LED[3] = BIT(data, 2); // D103 - SOUND ARRANGER: SET
-				m_CPL_LED[4] = BIT(data, 3); // D104 - SOUND ARRANGER: ON/OFF
-				m_CPL_LED[5] = BIT(data, 4); // D105 - MUSIC STYLIST
-				m_CPL_LED[6] = BIT(data, 5); // D106 - FADE IN
-				m_CPL_LED[7] = BIT(data, 6); // D107 - FADE OUT
-				m_CPL_LED[8] = BIT(data, 7); // D108 - DISPLAY HOLD
-				break;
-
-			case 0xc1:
-				m_CPL_LED[9] = BIT(data, 0); // D109 - U.S. TRAD
-				m_CPL_LED[10] = BIT(data, 1); // D110 - COUNTRY
-				m_CPL_LED[11] = BIT(data, 2); // D111 - LATIN
-				m_CPL_LED[12] = BIT(data, 3); // D112 - MARCH & WALTZ
-				m_CPL_LED[13] = BIT(data, 4); // D113 - PARTY TIME
-				m_CPL_LED[14] = BIT(data, 5); // D114 - SHOW TIME & TRAD DANCE
-				m_CPL_LED[15] = BIT(data, 6); // D115 - WORLD
-				m_CPL_LED[16] = BIT(data, 7); // D116 - CUSTOM
-				break;
-
-			case 0xc2:
-				m_CPL_LED[17] = BIT(data, 0); // D117 - STANDARD ROCK
-				m_CPL_LED[18] = BIT(data, 1); // D118 - R & ROLL & BLUES
-				m_CPL_LED[19] = BIT(data, 2); // D119 - POP & BALLAD
-				m_CPL_LED[20] = BIT(data, 3); // D120 - FUNK & FUSION
-				m_CPL_LED[21] = BIT(data, 4); // D121 - SOUL & MODERN DANCE
-				m_CPL_LED[22] = BIT(data, 5); // D122 - BIG BAND & SWING
-				m_CPL_LED[23] = BIT(data, 6); // D123 - JAZZ COMBO
-				m_CPL_LED[24] = BIT(data, 7); // D124 - MANUAL SEQUENCE PADS: MENU
-				break;
-
-			case 0xc3:
-				m_CPL_LED[25] = BIT(data, 0); // D125 - VARIATION & MSA 1
-				m_CPL_LED[26] = BIT(data, 1); // D126 - VARIATION & MSA 2
-				m_CPL_LED[27] = BIT(data, 2); // D127 - VARIATION & MSA 3
-				m_CPL_LED[28] = BIT(data, 3); // D128 - VARIATION & MSA 4
-				m_CPL_LED[29] = BIT(data, 4); // D129 - MUSIC STYLE ARRANGER
-				m_CPL_LED[30] = BIT(data, 5); // D130 - AUTO PLAY CHORD
-				break;
-
-			case 0xc4:
-				m_CPL_LED[33] = BIT(data, 0); // D133 - FILL IN 1
-				m_CPL_LED[34] = BIT(data, 1); // D134 - FILL IN 2
-				m_CPL_LED[35] = BIT(data, 2); // D135 - INTRO & ENDING 1
-				m_CPL_LED[36] = BIT(data, 3); // D136 - INTRO & ENDING 2
-				m_CPL_LED[37] = BIT(data, 4); // D137 - SPLIT POINT INDICATOR (LEFT)
-				m_CPL_LED[38] = BIT(data, 5); // D138 - SPLIT POINT INDICATOR (CENTER)
-				m_CPL_LED[39] = BIT(data, 6); // D139 - SPLIT POINT INDICATOR (RIGHT)
-				m_CPL_LED[40] = BIT(data, 7); // D140 - TEMPO/PROGRAM
-				break;
-
-			case 0xc8:
-				m_CPL_LED[49] = BIT(data, 0); // D149 - OTHER PARTS/TR
-				break;
-
-			case 0xff:
-				break;
-		}
-	}
-	return;
-}
 
 void kn5000_state::machine_start()
 {
 	save_item(NAME(m_mstat));
 	save_item(NAME(m_sstat));
+	save_item(NAME(m_cpanel_inta));
 
 	m_extension->program_map(m_maincpu->space(AS_PROGRAM));
 
 	m_checking_device_led_cn11.resolve();
 	m_checking_device_led_cn12.resolve();
-	m_CPL_LED.resolve();
-	m_CPR_LED.resolve();
+
+	// Connect button input ports to control panel HLE device
+	for (int i = 0; i < 11; i++)
+	{
+		m_cpanel->set_cpl_port(i, m_CPL_SEG[i].target());
+		m_cpanel->set_cpr_port(i, m_CPR_SEG[i].target());
+	}
 }
 
 void kn5000_state::machine_reset()
@@ -687,13 +523,26 @@ void kn5000_state::kn5000(machine_config &config)
 	//   bit 0 (input) = +5v
 	//   bit 2 (input) = HDDRDY
 	//   bit 4 (?) = MICSNS
-	m_maincpu->porte_read().set_constant(1); //checked at EF05A6 (v10 ROM)
-	// FIXME: Bit 0 should only be 1 if the
-	// optional hard-drive extension board is disabled;
+	//   bit 5 (input) = INTA (control panel interrupt)
+	m_maincpu->porte_read().set([this] {
+		// Bit 0: +5v (always 1 when no HDD extension)
+		// Bit 5: INTA from control panel (active HIGH — firmware checks BIT 5,(PE); JR NZ)
+		return 0x01 | (m_cpanel_inta ? 0x20 : 0x00);
+	});
 
 
-	// MAINCPU PORT F:
-	//   bit 2 (OUTPUT) = Something related to "RESET CONTROL" circuits?
+	// MAINCPU PORT F: shared with serial interface pins
+	//   bit 0 = TXD0 (MIDI TX)
+	//   bit 1 = RXD0 (MIDI RX)
+	//   bit 2 = SCLK0 (disabled by firmware — MIDI uses no clock)
+	//   bit 4 = TXD1 (control panel data)
+	//   bit 5 = RXD1 (control panel data)
+	//   bit 6 (input) = SCLK1 pin state — a routine in the main CPU's
+	//     implementation of the control panel protocol polls this to confirm
+	//     the serial clock is idle (HIGH) before sending commands.
+	//     Without it, the firmware times out after 200 retries and displays
+	//     "ERROR in CPU data transmission".
+	m_maincpu->portf_read().set_constant(0x40);
 
 
 	// MAINCPU PORT G:
@@ -727,8 +576,18 @@ void kn5000_state::kn5000(machine_config &config)
 
 
 	// RX0/TX0 = MRXD/MTXD
-	// RX1/TX1 = CPDATA
-	// SCLK1   = CPSCK
+
+	// RX1/TX1 = CPDATA, SCLK1 = CPSCK — wired to control panel HLE
+	auto &cpanel(KN5000_CPANEL(config, "cpanel"));
+	m_maincpu->m_serial[1].lookup()->txd().set(cpanel, FUNC(kn5000_cpanel_device::rxd));
+	m_maincpu->m_serial[1].lookup()->sclk_out().set(cpanel, FUNC(kn5000_cpanel_device::sioclk));
+	m_maincpu->m_serial[1].lookup()->tx_start().set(cpanel, FUNC(kn5000_cpanel_device::tx_start));
+	cpanel.txd().set(m_maincpu->m_serial[1], FUNC(tmp94c241_serial_device::rxd));
+	cpanel.sclk_out().set(m_maincpu->m_serial[1], FUNC(tmp94c241_serial_device::sioclk));
+	cpanel.inta().set([this] (int state) {
+		m_cpanel_inta = state;
+		m_maincpu->set_input_line(TLCS900_INTA, state ? ASSERT_LINE : CLEAR_LINE);
+	});
 
 	// AN0 = EXP (expression pedal?)
 	// AN1 = AFT

--- a/src/mame/matsushita/kn5000_cpanel.cpp
+++ b/src/mame/matsushita/kn5000_cpanel.cpp
@@ -1,0 +1,913 @@
+// license:GPL2+
+// copyright-holders:Felipe Sanches
+/***************************************************************************
+
+	KN5000 control panel HLE
+
+	Emulates the two Mitsubishi M37471M2196S MCUs on the control panel.
+
+	Protocol Summary:
+	-----------------
+	- Commands are 2-byte sequences from main CPU
+	- Command byte encoding: bits 7-5 = panel (001=left, 111=right),
+	  bits 4-0 = command type (0=basic query, 2=analog register query,
+	  3=extended read, 5=data mode)
+	- Response packets have type encoded in bits 5-3:
+	    Type 0,1: Button state (bits 7:6 select panel: 00=right, 11=left)
+	    Type 2: Encoder (absolute 8-bit ADC value, NOT delta)
+	    Type 3-5: Sync/ACK
+	    Type 6,7: Multi-byte data
+
+	See: https://felipesanches.github.io/kn5000-docs/control-panel-protocol/
+
+***************************************************************************/
+
+#include "emu.h"
+#include "kn5000_cpanel.h"
+
+#define LOG_COMMANDS (1U << 1)
+#define LOG_SERIAL   (1U << 2)
+#define LOG_BUTTONS  (1U << 3)
+#define LOG_LEDS     (1U << 4)
+
+#define VERBOSE 0
+#include "logmacro.h"
+
+DEFINE_DEVICE_TYPE(KN5000_CPANEL, kn5000_cpanel_device, "kn5000_cpanel", "KN5000 Control Panel HLE")
+
+kn5000_cpanel_device::kn5000_cpanel_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, KN5000_CPANEL, tag, owner, clock),
+	m_timer(nullptr),
+	m_idle_detect_timer(nullptr),
+	m_self_clock_timer(nullptr),
+	m_baud_rate(0),
+	m_rx_clock_count(8),
+	m_rx_shift_register(0),
+	m_rxd(1),
+	m_sioclk_state(0),
+	m_tx_clock_count(0),
+	m_tx_shift_register(0xff),
+	m_tx_skip_first_falling(false),
+	m_cmd_index(0),
+	m_initialized(false),
+	m_self_clocking(false),
+	m_inta_asserted(false),
+	m_accept_next_byte(false),
+	m_tx_output_enabled(true),
+	m_next_accept(false),
+	m_next_tx_output_enabled(true),
+	m_rx_waiting_for_start(true),
+	m_self_clock_bytes_sent(0),
+	m_txd_cb(*this),
+	m_sclk_out_cb(*this),
+	m_inta_cb(*this),
+	m_cpl_leds(*this, "cpl_led_%u", 0U),
+	m_cpr_leds(*this, "cpr_led_%u", 0U)
+{
+	std::fill(std::begin(m_cmd_buffer), std::end(m_cmd_buffer), 0);
+	std::fill(std::begin(m_last_button_state), std::end(m_last_button_state), 0);
+	std::fill(std::begin(m_pending_button_state), std::end(m_pending_button_state), 0);
+	std::fill(std::begin(m_cpl_ports), std::end(m_cpl_ports), nullptr);
+	std::fill(std::begin(m_cpr_ports), std::end(m_cpr_ports), nullptr);
+}
+
+void kn5000_cpanel_device::device_start()
+{
+	m_timer = timer_alloc(FUNC(kn5000_cpanel_device::timer_callback), this);
+	m_idle_detect_timer = timer_alloc(FUNC(kn5000_cpanel_device::idle_detect_callback), this);
+	m_self_clock_timer = timer_alloc(FUNC(kn5000_cpanel_device::self_clock_callback), this);
+	m_button_scan_timer = timer_alloc(FUNC(kn5000_cpanel_device::button_scan_callback), this);
+
+	// Resolve LED outputs
+	m_cpl_leds.resolve();
+	m_cpr_leds.resolve();
+
+	// Save state
+	save_item(NAME(m_baud_rate));
+	save_item(NAME(m_rx_clock_count));
+	save_item(NAME(m_rx_shift_register));
+	save_item(NAME(m_rxd));
+	save_item(NAME(m_sioclk_state));
+	save_item(NAME(m_tx_clock_count));
+	save_item(NAME(m_tx_shift_register));
+	save_item(NAME(m_tx_skip_first_falling));
+	save_item(NAME(m_cmd_buffer));
+	save_item(NAME(m_cmd_index));
+	save_item(NAME(m_initialized));
+	save_item(NAME(m_self_clocking));
+	save_item(NAME(m_inta_asserted));
+	save_item(NAME(m_accept_next_byte));
+	save_item(NAME(m_tx_output_enabled));
+	save_item(NAME(m_next_accept));
+	save_item(NAME(m_next_tx_output_enabled));
+	save_item(NAME(m_rx_waiting_for_start));
+	save_item(NAME(m_self_clock_bytes_sent));
+	save_item(NAME(m_last_button_state));
+	save_item(NAME(m_pending_button_state));
+
+	// Initial state - line idle high
+	m_txd_cb(1);
+}
+
+void kn5000_cpanel_device::device_reset()
+{
+	m_baud_rate = 0;
+	m_rx_clock_count = 8;
+	m_tx_clock_count = 0;
+	m_tx_skip_first_falling = false;
+	m_cmd_index = 0;
+	m_initialized = false;
+	m_self_clocking = false;
+	m_inta_asserted = false;
+	m_accept_next_byte = false;
+	m_tx_output_enabled = true;
+	m_next_accept = false;
+	m_next_tx_output_enabled = true;
+	m_rx_waiting_for_start = true;
+	m_self_clock_bytes_sent = 0;
+
+	// Clear TX queue
+	while (!m_tx_queue.empty())
+		m_tx_queue.pop();
+
+	m_idle_detect_timer->reset(attotime::never);
+	m_self_clock_timer->reset(attotime::never);
+
+	// Proactive button scan: real panel MCUs continuously monitor their
+	// button matrices and push change notifications via INTA.  The
+	// firmware's steady-state polling only queries one segment (E0 13 =
+	// right panel segment 3), relying on MCU-initiated INTA for changes
+	// on other segments.  7ms (~143 Hz) is responsive enough for UI use
+	// and coprime with likely command cycle times to avoid phase-lock.
+	m_button_scan_timer->adjust(attotime::from_msec(7), 0, attotime::from_msec(7));
+
+	std::fill(std::begin(m_last_button_state), std::end(m_last_button_state), 0);
+	std::fill(std::begin(m_pending_button_state), std::end(m_pending_button_state), 0);
+}
+
+void kn5000_cpanel_device::set_baudrate(uint16_t br)
+{
+	m_baud_rate = br;
+	LOGMASKED(LOG_SERIAL, "Baud rate set to %d\n", br);
+
+	if (br)
+	{
+		m_timer->adjust(attotime::from_hz(m_baud_rate), 0, attotime::from_hz(m_baud_rate));
+	}
+	else
+	{
+		m_timer->reset(attotime::never);
+	}
+}
+
+void kn5000_cpanel_device::rxd(int state)
+{
+	m_rxd = state;
+}
+
+void kn5000_cpanel_device::tx_start(int state)
+{
+	// Called when CPU starts transmitting a new byte.
+	// state=1: real byte (PFFC enabled, SCLK pin driven)
+	// state=0: phantom byte (PFFC disabled, pin high-Z)
+	LOGMASKED(LOG_SERIAL, "tx_start: state=%d (%s byte) rx_count=%d\n",
+		state, state ? "real" : "phantom", m_rx_clock_count);
+
+	// Defer the new accept/output state to the next byte boundary.
+	// INTTX1 fires for byte N+1 before rising edge 8 completes byte N's
+	// reception, so applying immediately would use the wrong accept state
+	// for the byte currently being received.
+	m_next_accept = (state != 0);
+	m_next_tx_output_enabled = (state != 0);
+
+	// Allow RX counting to begin.  Between bytes, the baud rate timer may
+	// drive extra edges for internal RX completion; m_rx_waiting_for_start
+	// prevents those from being counted as data bits.
+	m_rx_waiting_for_start = false;
+
+	if (m_rx_clock_count == 8)
+	{
+		// At byte boundary — safe to apply immediately
+		m_accept_next_byte = m_next_accept;
+		m_tx_output_enabled = m_next_tx_output_enabled;
+	}
+
+	// idle_detect is not cancelled here.  The sliding window in sioclk()
+	// re-arms on every edge and fires after the LAST edge, which correctly
+	// handles both the firmware's chained TX state machine (phantom bytes
+	// after real commands) and polled serial modes (dummy bytes drain the
+	// TX queue before idle_detect fires).
+}
+
+void kn5000_cpanel_device::sioclk(int state)
+{
+	if (m_sioclk_state == state)
+		return;
+
+	m_sioclk_state = state;
+
+	// Sliding idle_detect window: retrigger on every edge while response
+	// data is pending.  Fires 50µs after the last external clock edge,
+	// which is after the firmware's phantom bytes complete but before
+	// its WaitTXReady delay (~375µs) checks the INTA line.
+	if (!m_self_clocking && (m_tx_clock_count > 0 || !m_tx_queue.empty()))
+	{
+		m_idle_detect_timer->adjust(attotime::from_usec(50));
+	}
+
+	LOGMASKED(LOG_SERIAL, "sioclk state=%d rxd=%d rx_count=%d tx_count=%d\n",
+		state, m_rxd, m_rx_clock_count, m_tx_clock_count);
+
+	if (state)
+	{
+		// Rising edge: sample RXD bit from CPU.
+		// Skip during self-clocking (CPU's TXD holds stale data) and
+		// while waiting for tx_start (baud rate timer drives extra edges
+		// between bytes that would desync byte boundaries).
+		if (!m_self_clocking && !m_rx_waiting_for_start && m_rx_clock_count > 0)
+		{
+			m_rx_shift_register >>= 1;
+			m_rx_shift_register |= (m_rxd << 7);
+			m_rx_clock_count--;
+
+			LOGMASKED(LOG_SERIAL, "RX bit: %d, shift_reg=%02X, count=%d\n",
+				m_rxd, m_rx_shift_register, m_rx_clock_count);
+
+			if (m_rx_clock_count == 0)
+			{
+				// Full byte received
+				m_rx_clock_count = 8;
+				process_received_byte(m_rx_shift_register);
+
+				// Apply deferred tx_start flags at byte boundary
+				m_accept_next_byte = m_next_accept;
+				m_tx_output_enabled = m_next_tx_output_enabled;
+
+				// Wait for next tx_start before counting another byte.
+				// This prevents orphan edges from starting a new byte.
+				m_rx_waiting_for_start = true;
+			}
+		}
+	}
+	else
+	{
+		// Falling edge: output TXD bit for CPU to sample on next rising edge.
+		// Suppress output during phantom byte edges (PFFC off) to keep
+		// response data intact for later INTA-driven delivery.
+		if (!m_tx_output_enabled)
+		{
+			// Phantom byte edge — hold response data
+		}
+		else if (m_tx_skip_first_falling)
+		{
+			// Skip this falling edge - bit 0 was pre-output and we need to give
+			// CPU a rising edge to sample it before we output bit 1
+			LOGMASKED(LOG_SERIAL, "skipping first falling edge (bit 0 already on line)\n");
+			m_tx_skip_first_falling = false;
+		}
+		else if (m_tx_clock_count > 0)
+		{
+			if (m_tx_clock_count == 8)
+			{
+				// First bit of a chained byte (loaded from queue) — output bit 0 without shifting
+				LOGMASKED(LOG_SERIAL, "TX bit 0 (chained): %d, shift_reg=%02X\n",
+					m_tx_shift_register & 1, m_tx_shift_register);
+				m_txd_cb(m_tx_shift_register & 1);
+				m_tx_clock_count--;
+			}
+			else
+			{
+				// Normal operation: shift out the next bit
+				m_tx_shift_register >>= 1;
+				LOGMASKED(LOG_SERIAL, "TX bit: %d, shift_reg=%02X, count=%d\n",
+					m_tx_shift_register & 1, m_tx_shift_register, m_tx_clock_count);
+				m_txd_cb(m_tx_shift_register & 1);
+				m_tx_clock_count--;
+			}
+
+			if (m_tx_clock_count == 0)
+			{
+				// Track bytes sent during self-clocking for packet-pause.
+				// Must count HERE (tx_clock_count==0, before queue refill
+				// sets it to 8) — self_clock_callback's rising-edge check
+				// would never see 0 for intermediate bytes.
+				if (m_self_clocking)
+					m_self_clock_bytes_sent++;
+
+				// Byte sent, check for more
+				if (!m_tx_queue.empty())
+				{
+					m_tx_shift_register = m_tx_queue.front();
+					m_tx_queue.pop();
+					m_tx_clock_count = 8;  // Full 8 bits — don't pre-output yet
+
+					LOGMASKED(LOG_SERIAL, "TX next byte queued: %02X (no pre-output)\n",
+						m_tx_shift_register);
+
+					// Don't pre-output: bit 7 of previous byte is still on the line
+					// and needs to be sampled by CPU on the next rising edge.
+					// Bit 0 of new byte will be output on the next falling edge.
+				}
+				else
+				{
+					// Transmission complete — leave the last bit on the line.
+					// Do NOT call m_txd_cb(1) here: that would overwrite bit 7
+					// of the last byte before the CPU samples it on the next
+					// rising edge. The line will be updated when send_byte()
+					// pre-outputs the next byte's bit 0.
+					LOGMASKED(LOG_SERIAL, "TX done, holding last bit\n");
+				}
+			}
+		}
+	}
+}
+
+void kn5000_cpanel_device::send_byte(uint8_t data)
+{
+	LOGMASKED(LOG_SERIAL, "send_byte(%02X) tx_count=%d queue_size=%zu sioclk_state=%d\n",
+		data, m_tx_clock_count, m_tx_queue.size(), m_sioclk_state);
+
+	if (m_tx_clock_count == 0 && !m_tx_skip_first_falling)
+	{
+		// Start sending immediately
+		m_tx_shift_register = data;
+		m_tx_clock_count = 7;  // 7 more bits to send after pre-outputting bit 0
+
+		// Pre-output first bit immediately so CPU can sample it on the first rising edge
+		m_txd_cb(m_tx_shift_register & 1);
+		LOGMASKED(LOG_SERIAL, "TX start: byte=%02X, pre-output bit=%d\n",
+			data, data & 1);
+
+		// Only skip the first falling edge if clock is currently HIGH.
+		// If clock is HIGH: next edge = falling (skip it)
+		// If clock is LOW: next edge = rising (CPU samples), then falling outputs bit 1 (no skip)
+		m_tx_skip_first_falling = (m_sioclk_state == 1);
+		LOGMASKED(LOG_SERIAL, "TX skip_first_falling=%d\n", m_tx_skip_first_falling);
+	}
+	else
+	{
+		// Queue for later
+		m_tx_queue.push(data);
+		LOGMASKED(LOG_SERIAL, "TX queued: byte=%02X\n", data);
+	}
+}
+
+void kn5000_cpanel_device::process_received_byte(uint8_t data)
+{
+	LOGMASKED(LOG_SERIAL, "RX byte: %02X (cmd_index=%d, accept=%d)\n",
+		data, m_cmd_index, m_accept_next_byte);
+
+	// Reject phantom bytes (PFFC-off phases in firmware TX state machine).
+	// The accept flag is managed by tx_start's deferred mechanism, not
+	// consumed here.
+	if (!m_accept_next_byte)
+	{
+		LOGMASKED(LOG_SERIAL, "skipping unsolicited/phantom byte %02X\n", data);
+		return;
+	}
+
+	// Ignore 0xFF when it appears as a command byte (first byte of pair).
+	// In synchronous serial mode, the CPU must send dummy bytes to clock in
+	// response data. These dummy 0xFF bytes are not valid commands — without
+	// this filter they would be paired with the next real command byte,
+	// misaligning the 2-byte command parser and potentially triggering
+	// unintended LED commands or sync responses.
+	if (m_cmd_index == 0 && data == 0xFF)
+	{
+		LOGMASKED(LOG_SERIAL, "ignoring dummy byte 0xFF as command\n");
+		return;
+	}
+
+	m_cmd_buffer[m_cmd_index++] = data;
+
+	if (m_cmd_index >= 2)
+	{
+		// Full 2-byte command received
+		process_command();
+		m_cmd_index = 0;
+	}
+}
+
+void kn5000_cpanel_device::process_command()
+{
+	uint8_t cmd = m_cmd_buffer[0];
+	uint8_t param = m_cmd_buffer[1];
+
+	LOGMASKED(LOG_COMMANDS, "Command: %02X %02X\n", cmd, param);
+
+	switch (cmd)
+	{
+	// Initialization commands — respond with sync.
+	// These are sent one at a time during boot (not in rapid batches
+	// like LED commands), so response accumulation isn't an issue.
+	// The firmware checks for the sync response; without it, the
+	// "ERROR in CPU data transmission" dialog appears.
+	case 0x1f:  // Init sequence (left)
+	case 0x1d:
+	case 0x1e:
+	case 0xdd:  // Setup mode
+		LOGMASKED(LOG_COMMANDS, "Init command\n");
+		send_sync_packet();
+		m_initialized = true;
+		break;
+
+	// Query commands
+	// The param byte encodes a segment index in bits 3-0.  Bit 4 is a mode
+	// flag used by the panel MCUs (e.g., 0x10 = segment 0 scan mode, 0x13 =
+	// segment 3 scan mode).  The HLE extracts the segment via param & 0x0F.
+	// Param 0x00 (no flag, segment 0) is a sync/ping — everything else with
+	// a valid segment (0-11) returns button data.
+	// Query commands — command type in bits 4-0:
+	//   0x20 (type 0): Basic left panel query (ping, poll segment, status)
+	//   0x25 (type 5): Left panel data mode (bulk button state request,
+	//                  used only in CPanel_ReadAllButtons during boot)
+	case 0x20:
+	case 0x25:
+	{
+		int segment = param & 0x0f;
+		if (param == 0x00)
+		{
+			send_sync_packet();
+		}
+		else if (segment <= 0x0b)
+		{
+			// Segment 0x0B is a hardware status register — return
+			// WITHOUT panel flag so firmware stores at offset 11.
+			send_button_packet(segment, (segment <= 0x0a));
+		}
+		else
+		{
+			send_sync_packet();
+		}
+		break;
+	}
+
+	//   0xE0 (type 0): Basic right panel query (ping, steady-state poll)
+	case 0xe0:
+	{
+		int segment = param & 0x0f;
+		if (param == 0x00)
+		{
+			send_sync_packet();
+		}
+		else if (segment <= 0x0b)
+		{
+			send_button_packet(segment, false);  // right panel
+		}
+		else
+		{
+			send_sync_packet();
+		}
+		break;
+	}
+
+	//   0xE2 (type 2): Right panel analog register query — requests
+	//                  encoder/analog controller values.  The real MCU
+	//                  responds with Type 2 encoder packets (absolute
+	//                  ADC values for modwheel, volume, etc.).
+	//                  Used in CPanel_ReadAllButtons with params 0x04, 0x11.
+	// TODO: When analog controller inputs are implemented, respond with
+	// Type 2 encoder packets here instead of sync.
+	case 0xe2:
+		send_sync_packet();
+		break;
+
+	//   0xE3 (type 3): Right panel extended read — requests button state
+	//                  with additional status.  Used in CPanel_InitButtonState
+	//                  with param 0x10.
+	case 0xe3:
+	{
+		int segment = param & 0x0f;
+		if (segment <= 0x0b)
+		{
+			send_button_packet(segment, false);  // right panel
+		}
+		else
+		{
+			send_sync_packet();
+		}
+		break;
+	}
+
+	case 0x2b:  // Init button state array (left)
+		send_all_button_states(true);
+		break;
+
+	case 0xeb:  // Init button state array (right)
+		send_all_button_states(false);
+		break;
+
+	// LED control commands - right panel (no response — real MCUs process silently)
+	case 0x00:
+	case 0x01:
+	case 0x02:
+	case 0x03:
+	case 0x04:
+	case 0x08:
+	case 0x0a:
+	case 0x0b:
+	case 0x0c:
+		process_led_command(cmd, param);
+		break;
+
+	// LED control commands - left panel (no response)
+	case 0xc0:
+	case 0xc1:
+	case 0xc2:
+	case 0xc3:
+	case 0xc4:
+	case 0xc8:
+		process_led_command(cmd, param);
+		break;
+
+	default:
+		// Unknown command — do not respond.  Real panel MCUs process
+		// many commands (LCD, encoders, etc.) silently.
+		LOGMASKED(LOG_COMMANDS, "Unknown command %02X %02X (no response)\n", cmd, param);
+		break;
+	}
+
+	// Arm idle detection for INTA-based response delivery.  The sliding
+	// window in sioclk() retriggers on every edge and fires 50µs after
+	// the last edge, handling both firmware phantom bytes and polled modes.
+	if (!m_self_clocking && (m_tx_clock_count > 0 || !m_tx_queue.empty()))
+	{
+		m_idle_detect_timer->adjust(attotime::from_usec(50));
+	}
+}
+
+void kn5000_cpanel_device::send_sync_packet()
+{
+	// Type 3 sync packet: bits 5-3 = 011 = 0x18
+	send_byte(0x18);
+	send_byte(0x00);
+}
+
+uint8_t kn5000_cpanel_device::read_button_segment(int segment, bool is_left_panel)
+{
+	if (segment < 0 || segment > 10)
+		return 0;
+
+	ioport_port *port = is_left_panel ? m_cpl_ports[segment] : m_cpr_ports[segment];
+	if (port)
+	{
+		return port->read() & 0xff;
+	}
+	return 0;
+}
+
+void kn5000_cpanel_device::send_button_packet(int segment, bool is_left_panel)
+{
+	// Button packet header: bits 7:6 = panel (00=right, 11=left),
+	// bits 5:3 = type (0/1 for buttons), bits 3:0 = segment index.
+	// The firmware dispatches via a ROM lookup table that only maps
+	// bits 7:6=00 and bits 7:6=11 to valid event indices.
+
+	uint8_t state = read_button_segment(segment, is_left_panel);
+
+	uint8_t header = (segment & 0x0f);
+	if (is_left_panel)
+		header |= 0xC0;  // Left panel: bits 7:6 = 11
+
+	send_byte(header);
+	send_byte(state);
+
+	LOGMASKED(LOG_BUTTONS, "Button packet: seg=%d left=%d state=%02X\n",
+		segment, is_left_panel, state);
+
+	// Track state for change detection
+	int state_idx = is_left_panel ? (segment + 11) : segment;
+	m_last_button_state[state_idx] = state;
+	m_pending_button_state[state_idx] = state;
+}
+
+void kn5000_cpanel_device::send_all_button_states(bool is_left_panel)
+{
+	// Send all 11 segments for the requested panel
+	for (int seg = 0; seg <= 10; seg++)
+	{
+		send_button_packet(seg, is_left_panel);
+	}
+}
+
+
+void kn5000_cpanel_device::process_led_command(uint8_t row, uint8_t data)
+{
+	LOGMASKED(LOG_LEDS, "LED command: row=%02X data=%02X\n", row, data);
+
+	switch (row)
+	{
+	// Right panel LED rows
+	case 0x00:
+		m_cpr_leds[1] = BIT(data, 0);  // D101 - EFFECT: SUSTAIN
+		m_cpr_leds[2] = BIT(data, 1);  // D102 - EFFECT: DIGITAL EFFECT
+		m_cpr_leds[3] = BIT(data, 2);  // D103 - EFFECT: DSP EFFECT
+		m_cpr_leds[4] = BIT(data, 3);  // D104 - EFFECT: DIGITAL REVERB
+		m_cpr_leds[5] = BIT(data, 4);  // D105 - EFFECT: ACOUSTIC ILLUSION
+		m_cpr_leds[6] = BIT(data, 5);  // D106 - SEQUENCER: PLAY
+		m_cpr_leds[7] = BIT(data, 6);  // D107 - SEQUENCER: EASY REC
+		m_cpr_leds[8] = BIT(data, 7);  // D108 - SEQUENCER: MENU
+		break;
+
+	case 0x01:
+		m_cpr_leds[9] = BIT(data, 0);   // D109 - PIANO
+		m_cpr_leds[10] = BIT(data, 1);  // D110 - GUITAR
+		m_cpr_leds[11] = BIT(data, 2);  // D111 - STRINGS & VOCAL
+		m_cpr_leds[12] = BIT(data, 3);  // D112 - BRASS
+		m_cpr_leds[13] = BIT(data, 4);  // D113 - FLUTE
+		m_cpr_leds[14] = BIT(data, 5);  // D114 - SAX & REED
+		m_cpr_leds[15] = BIT(data, 6);  // D115 - MALLET & ORCH PERC
+		m_cpr_leds[16] = BIT(data, 7);  // D116 - WORLD PERC
+		break;
+
+	case 0x02:
+		m_cpr_leds[17] = BIT(data, 0);  // D117 - ORGAN & ACCORDION
+		m_cpr_leds[18] = BIT(data, 1);  // D118 - ORCHESTRAL PAD
+		m_cpr_leds[19] = BIT(data, 2);  // D119 - SYNTH
+		m_cpr_leds[20] = BIT(data, 3);  // D120 - BASS
+		m_cpr_leds[21] = BIT(data, 4);  // D121 - DIGITAL DRAWBAR
+		m_cpr_leds[22] = BIT(data, 5);  // D122 - ACCORDION REGISTER
+		m_cpr_leds[23] = BIT(data, 6);  // D123 - GM SPECIAL
+		m_cpr_leds[24] = BIT(data, 7);  // D124 - DRUM KITS
+		break;
+
+	case 0x03:
+		m_cpr_leds[25] = BIT(data, 0);  // D125 - PANEL MEMORY 1
+		m_cpr_leds[26] = BIT(data, 1);  // D126 - PANEL MEMORY 2
+		m_cpr_leds[27] = BIT(data, 2);  // D127 - PANEL MEMORY 3
+		m_cpr_leds[28] = BIT(data, 3);  // D128 - PANEL MEMORY 4
+		m_cpr_leds[29] = BIT(data, 4);  // D129 - PANEL MEMORY 5
+		m_cpr_leds[30] = BIT(data, 5);  // D130 - PANEL MEMORY 6
+		m_cpr_leds[31] = BIT(data, 6);  // D131 - PANEL MEMORY 7
+		m_cpr_leds[32] = BIT(data, 7);  // D132 - PANEL MEMORY 8
+		break;
+
+	case 0x04:
+		m_cpr_leds[33] = BIT(data, 0);  // D133 - PART SELECT: LEFT
+		m_cpr_leds[34] = BIT(data, 1);  // D134 - PART SELECT: RIGHT 2
+		m_cpr_leds[35] = BIT(data, 2);  // D135 - PART SELECT: RIGHT 1
+		m_cpr_leds[36] = BIT(data, 3);  // D136 - ENTERTAINER
+		m_cpr_leds[37] = BIT(data, 4);  // D137 - CONDUCTOR: LEFT
+		m_cpr_leds[38] = BIT(data, 5);  // D138 - CONDUCTOR: RIGHT 2
+		m_cpr_leds[39] = BIT(data, 6);  // D139 - CONDUCTOR: RIGHT 1
+		m_cpr_leds[40] = BIT(data, 7);  // D140 - TECHNI CHORD
+		break;
+
+	case 0x08:
+		m_cpr_leds[49] = BIT(data, 0);  // D149 - MENU: SOUND
+		m_cpr_leds[50] = BIT(data, 1);  // D150 - MENU: CONTROL
+		m_cpr_leds[51] = BIT(data, 2);  // D151 - MENU: MIDI
+		m_cpr_leds[52] = BIT(data, 3);  // D152 - MENU: DISK
+		break;
+
+	case 0x0a:
+		m_cpr_leds[57] = BIT(data, 0);  // D157 - MEMORY A
+		m_cpr_leds[58] = BIT(data, 1);  // D158 - MEMORY B
+		break;
+
+	case 0x0b:
+		m_cpr_leds[61] = BIT(data, 0);  // D161 - SYNCHRO & BREAK
+		m_cpr_leds[62] = BIT(data, 1);  // D162 - R1/R2 OCTAVE MINUS
+		m_cpr_leds[63] = BIT(data, 2);  // D163 - R1/R2 OCTAVE PLUS
+		m_cpr_leds[64] = BIT(data, 3);  // D164 - BANK VIEW
+		break;
+
+	case 0x0c:
+		m_cpr_leds[65] = BIT(data, 0);  // D165 - START/STOP 1 BEAT
+		m_cpr_leds[66] = BIT(data, 1);  // D166 - START/STOP 2 BEAT
+		m_cpr_leds[67] = BIT(data, 2);  // D167 - START/STOP 3 BEAT
+		m_cpr_leds[68] = BIT(data, 3);  // D168 - START/STOP 4 BEAT
+		break;
+
+	// Left panel LED rows
+	case 0xc0:
+		m_cpl_leds[1] = BIT(data, 0);  // D101 - COMPOSER: MEMORY
+		m_cpl_leds[2] = BIT(data, 1);  // D102 - COMPOSER: MENU
+		m_cpl_leds[3] = BIT(data, 2);  // D103 - SOUND ARRANGER: SET
+		m_cpl_leds[4] = BIT(data, 3);  // D104 - SOUND ARRANGER: ON/OFF
+		m_cpl_leds[5] = BIT(data, 4);  // D105 - MUSIC STYLIST
+		m_cpl_leds[6] = BIT(data, 5);  // D106 - FADE IN
+		m_cpl_leds[7] = BIT(data, 6);  // D107 - FADE OUT
+		m_cpl_leds[8] = BIT(data, 7);  // D108 - DISPLAY HOLD
+		break;
+
+	case 0xc1:
+		m_cpl_leds[9] = BIT(data, 0);   // D109 - U.S. TRAD
+		m_cpl_leds[10] = BIT(data, 1);  // D110 - COUNTRY
+		m_cpl_leds[11] = BIT(data, 2);  // D111 - LATIN
+		m_cpl_leds[12] = BIT(data, 3);  // D112 - MARCH & WALTZ
+		m_cpl_leds[13] = BIT(data, 4);  // D113 - PARTY TIME
+		m_cpl_leds[14] = BIT(data, 5);  // D114 - SHOW TIME & TRAD DANCE
+		m_cpl_leds[15] = BIT(data, 6);  // D115 - WORLD
+		m_cpl_leds[16] = BIT(data, 7);  // D116 - CUSTOM
+		break;
+
+	case 0xc2:
+		m_cpl_leds[17] = BIT(data, 0);  // D117 - STANDARD ROCK
+		m_cpl_leds[18] = BIT(data, 1);  // D118 - R & ROLL & BLUES
+		m_cpl_leds[19] = BIT(data, 2);  // D119 - POP & BALLAD
+		m_cpl_leds[20] = BIT(data, 3);  // D120 - FUNK & FUSION
+		m_cpl_leds[21] = BIT(data, 4);  // D121 - SOUL & MODERN DANCE
+		m_cpl_leds[22] = BIT(data, 5);  // D122 - BIG BAND & SWING
+		m_cpl_leds[23] = BIT(data, 6);  // D123 - JAZZ COMBO
+		m_cpl_leds[24] = BIT(data, 7);  // D124 - MANUAL SEQUENCE PADS: MENU
+		break;
+
+	case 0xc3:
+		m_cpl_leds[25] = BIT(data, 0);  // D125 - VARIATION & MSA 1
+		m_cpl_leds[26] = BIT(data, 1);  // D126 - VARIATION & MSA 2
+		m_cpl_leds[27] = BIT(data, 2);  // D127 - VARIATION & MSA 3
+		m_cpl_leds[28] = BIT(data, 3);  // D128 - VARIATION & MSA 4
+		m_cpl_leds[29] = BIT(data, 4);  // D129 - MUSIC STYLE ARRANGER
+		m_cpl_leds[30] = BIT(data, 5);  // D130 - AUTO PLAY CHORD
+		break;
+
+	case 0xc4:
+		m_cpl_leds[33] = BIT(data, 0);  // D133 - FILL IN 1
+		m_cpl_leds[34] = BIT(data, 1);  // D134 - FILL IN 2
+		m_cpl_leds[35] = BIT(data, 2);  // D135 - INTRO & ENDING 1
+		m_cpl_leds[36] = BIT(data, 3);  // D136 - INTRO & ENDING 2
+		m_cpl_leds[37] = BIT(data, 4);  // D137 - SPLIT POINT INDICATOR (LEFT)
+		m_cpl_leds[38] = BIT(data, 5);  // D138 - SPLIT POINT INDICATOR (CENTER)
+		m_cpl_leds[39] = BIT(data, 6);  // D139 - SPLIT POINT INDICATOR (RIGHT)
+		m_cpl_leds[40] = BIT(data, 7);  // D140 - TEMPO/PROGRAM
+		break;
+
+	case 0xc8:
+		m_cpl_leds[49] = BIT(data, 0);  // D149 - OTHER PARTS/TR
+		break;
+	}
+}
+
+TIMER_CALLBACK_MEMBER(kn5000_cpanel_device::timer_callback)
+{
+	// Timer drives the serial clock when we have data to send
+	if (m_tx_clock_count > 0 || !m_tx_queue.empty())
+	{
+		// Toggle clock to shift out data
+		m_sclk_out_cb(1);
+		m_sclk_out_cb(0);
+	}
+}
+
+TIMER_CALLBACK_MEMBER(kn5000_cpanel_device::idle_detect_callback)
+{
+	// External SCLK has been idle — assert INTA and self-clock the response.
+	// On real hardware, the panel MCU drives SCLK after detecting idle.
+
+	if (m_tx_clock_count > 0 || !m_tx_queue.empty())
+	{
+		// Enable TX output — response data was frozen during phantom bytes
+		m_tx_output_enabled = true;
+
+		if (m_inta_asserted)
+		{
+			// Multi-packet: pulse INTA to re-trigger the interrupt
+			LOGMASKED(LOG_SERIAL, "re-triggering INTA for next packet (%zu bytes queued)\n",
+				m_tx_queue.size());
+			m_inta_cb(0);
+			m_inta_cb(1);
+		}
+		else
+		{
+			LOGMASKED(LOG_SERIAL, "SCLK idle, asserting INTA\n");
+			m_inta_asserted = true;
+			m_inta_cb(1);
+		}
+
+		// Reset byte counter for this INTA cycle
+		m_self_clock_bytes_sent = 0;
+
+		// Brief delay lets the CPU's INTA ISR enable receive mode
+		m_self_clocking = true;
+		m_self_clock_timer->adjust(attotime::from_usec(20), 0, attotime::from_hz(250000));
+	}
+}
+
+TIMER_CALLBACK_MEMBER(kn5000_cpanel_device::self_clock_callback)
+{
+	// Toggle SCLK to shift out response data
+	int new_state = m_sioclk_state ^ 1;
+	m_sclk_out_cb(new_state);
+
+	// Check completion after rising edges (CPU samples last bit)
+	if (new_state == 1)
+	{
+		if (m_tx_queue.empty() && m_tx_clock_count == 0)
+		{
+			// All response data sent — stop self-clocking and deassert INTA.
+			LOGMASKED(LOG_SERIAL, "self-clock TX complete (%d bytes), deasserting INTA\n",
+				m_self_clock_bytes_sent);
+			m_self_clocking = false;
+			m_self_clock_timer->reset(attotime::never);
+
+			if (m_inta_asserted)
+			{
+				m_inta_asserted = false;
+				m_inta_cb(0);
+			}
+
+			// Button scan timer runs periodically (set in device_reset),
+			// no need to reschedule from here.
+		}
+		else if (m_self_clock_bytes_sent >= 2)
+		{
+			// Pause after each 2-byte packet — firmware processes one
+			// packet per INTA cycle.  Keep INTA asserted to block
+			// WaitTXReady while more data is queued.
+			LOGMASKED(LOG_SERIAL, "self-clock pausing after 2-byte packet, %zu bytes queued\n",
+				m_tx_queue.size());
+			m_self_clocking = false;
+			m_self_clock_timer->reset(attotime::never);
+
+			// Schedule next packet after 20µs (enough for INTA ISR)
+			m_idle_detect_timer->adjust(attotime::from_usec(20));
+		}
+	}
+}
+
+TIMER_CALLBACK_MEMBER(kn5000_cpanel_device::button_scan_callback)
+{
+	// Periodic button matrix scan (~143 Hz).  Real panel MCUs continuously
+	// scan and push change notifications via INTA, independent of polling.
+	// Per-segment confirmation: changes must be stable for 2 consecutive
+	// scans (14ms) before being reported, filtering transient glitches.
+
+	if (!m_initialized)
+		return;
+
+	// Don't queue changes while a serial transaction is in progress
+	if (m_self_clocking || m_inta_asserted)
+		return;
+	if (!m_rx_waiting_for_start)
+		return;
+
+	bool changed = false;
+
+	// Scan right panel segments 0-10
+	for (int seg = 0; seg <= 10; seg++)
+	{
+		if (!m_cpr_ports[seg])
+			continue;
+		uint8_t state = m_cpr_ports[seg]->read() & 0xff;
+		if (state != m_last_button_state[seg])
+		{
+			// State differs from last confirmed — check if pending agrees
+			if (state == m_pending_button_state[seg])
+			{
+				// Stable for 2 scans: confirmed change
+				LOGMASKED(LOG_BUTTONS, "confirmed right seg %d change (%02X->%02X)\n",
+					seg, m_last_button_state[seg], state);
+				send_button_packet(seg, false);
+				changed = true;
+			}
+			else
+			{
+				// First observation — record as pending, wait for confirmation
+				LOGMASKED(LOG_BUTTONS, "pending right seg %d change (%02X->%02X)\n",
+					seg, m_last_button_state[seg], state);
+				m_pending_button_state[seg] = state;
+			}
+		}
+		else
+		{
+			// Matches confirmed state — reset pending
+			m_pending_button_state[seg] = state;
+		}
+	}
+
+	// Scan left panel segments 0-10
+	for (int seg = 0; seg <= 10; seg++)
+	{
+		if (!m_cpl_ports[seg])
+			continue;
+		int idx = seg + 11;
+		uint8_t state = m_cpl_ports[seg]->read() & 0xff;
+		if (state != m_last_button_state[idx])
+		{
+			if (state == m_pending_button_state[idx])
+			{
+				LOGMASKED(LOG_BUTTONS, "confirmed left seg %d change (%02X->%02X)\n",
+					seg, m_last_button_state[idx], state);
+				send_button_packet(seg, true);
+				changed = true;
+			}
+			else
+			{
+				LOGMASKED(LOG_BUTTONS, "pending left seg %d change (%02X->%02X)\n",
+					seg, m_last_button_state[idx], state);
+				m_pending_button_state[idx] = state;
+			}
+		}
+		else
+		{
+			m_pending_button_state[idx] = state;
+		}
+	}
+
+	if (changed)
+	{
+		LOGMASKED(LOG_BUTTONS, "confirmed button change, triggering INTA delivery\n");
+		m_idle_detect_timer->adjust(attotime::from_usec(50));
+	}
+}

--- a/src/mame/matsushita/kn5000_cpanel.h
+++ b/src/mame/matsushita/kn5000_cpanel.h
@@ -1,0 +1,124 @@
+// license:GPL2+
+// copyright-holders:Felipe Sanches
+/***************************************************************************
+
+	KN5000 control panel HLE
+
+	Emulates the two Mitsubishi M37471M2196S MCUs on the control panel.
+	Since no ROM dumps are available, this uses High Level Emulation based
+	on reverse engineering of the main CPU firmware protocol.
+
+	Protocol documentation: https://felipesanches.github.io/kn5000-docs/control-panel-protocol/
+
+***************************************************************************/
+
+#ifndef MAME_MATSUSHITA_KN5000_CPANEL_H
+#define MAME_MATSUSHITA_KN5000_CPANEL_H
+
+#pragma once
+
+#include <queue>
+
+class kn5000_cpanel_device :
+	public device_t
+{
+public:
+	kn5000_cpanel_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+
+	// Serial interface from main CPU
+	void rxd(int state);
+	void sioclk(int state);
+	void tx_start(int state);  // Called when CPU starts a new byte transmission
+
+	// Callbacks to main CPU
+	auto txd() { return m_txd_cb.bind(); }
+	auto sclk_out() { return m_sclk_out_cb.bind(); }
+	auto inta() { return m_inta_cb.bind(); }
+
+	// Configuration
+	void set_baudrate(uint16_t br);
+
+	// Button input port setters (called from main driver)
+	void set_cpl_port(int n, ioport_port *port) { m_cpl_ports[n] = port; }
+	void set_cpr_port(int n, ioport_port *port) { m_cpr_ports[n] = port; }
+
+protected:
+	// device_t overrides
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+	TIMER_CALLBACK_MEMBER(timer_callback);
+	TIMER_CALLBACK_MEMBER(idle_detect_callback);
+	TIMER_CALLBACK_MEMBER(self_clock_callback);
+	TIMER_CALLBACK_MEMBER(button_scan_callback);
+
+private:
+	// Serial communication
+	void send_byte(uint8_t data);
+	void process_received_byte(uint8_t data);
+	void process_command();
+
+	// Response generation
+	void send_sync_packet();
+	void send_button_packet(int segment, bool is_left_panel);
+	void send_all_button_states(bool is_left_panel);
+
+	// LED control
+	void process_led_command(uint8_t row, uint8_t data);
+
+	// Read button state from input ports
+	uint8_t read_button_segment(int segment, bool is_left_panel);
+
+	// Timers
+	emu_timer *m_timer;
+	emu_timer *m_idle_detect_timer;
+	emu_timer *m_self_clock_timer;
+	emu_timer *m_button_scan_timer;
+	uint16_t m_baud_rate;
+
+	// Serial RX state
+	uint8_t m_rx_clock_count;
+	uint8_t m_rx_shift_register;
+	uint8_t m_rxd;
+	uint8_t m_sioclk_state;
+
+	// Serial TX state
+	uint8_t m_tx_clock_count;
+	uint8_t m_tx_shift_register;
+	std::queue<uint8_t> m_tx_queue;
+	bool m_tx_skip_first_falling;  // Skip first falling edge after pre-outputting bit 0
+
+	// Command buffer (2-byte commands)
+	uint8_t m_cmd_buffer[2];
+	uint8_t m_cmd_index;
+
+	// Protocol state
+	bool m_initialized;
+	bool m_self_clocking;
+	bool m_inta_asserted;
+	bool m_accept_next_byte;   // false = next received byte is phantom (PFFC-off), skip it
+	bool m_tx_output_enabled;  // false = suppress TX output during phantom byte clock edges
+	bool m_next_accept;        // Deferred accept_next_byte (applied at next byte boundary)
+	bool m_next_tx_output_enabled;  // Deferred tx_output_enabled (applied at next byte boundary)
+	bool m_rx_waiting_for_start;    // Ignore RX edges until next tx_start
+	uint8_t m_self_clock_bytes_sent;  // Bytes sent in current INTA cycle
+	uint8_t m_last_button_state[22];  // 11 segments * 2 panels (confirmed)
+	uint8_t m_pending_button_state[22];  // Per-segment confirmation buffer
+
+	// Callbacks
+	devcb_write_line m_txd_cb;
+	devcb_write_line m_sclk_out_cb;
+	devcb_write_line m_inta_cb;
+
+	// Input port pointers (set by main driver)
+	ioport_port *m_cpl_ports[11];  // Left panel segments 0-10
+	ioport_port *m_cpr_ports[11];  // Right panel segments 0-10
+
+	// LED outputs
+	output_finder<50> m_cpl_leds;  // Left panel LEDs (CPL_0 through CPL_49)
+	output_finder<69> m_cpr_leds;  // Right panel LEDs (CPR_0 through CPR_68)
+};
+
+DECLARE_DEVICE_TYPE(KN5000_CPANEL, kn5000_cpanel_device)
+
+#endif // MAME_MATSUSHITA_KN5000_CPANEL_H


### PR DESCRIPTION
This is the result of my past many weeks of reverse engineering the control panel protocol for Technics KN5000. The previous kn5000/tlcs900 PRs brought us CPU support for serial port devices and micro-dma transfers and sub-cpu init, which are all somewhat related to this major milestone.

Here we finally fix the subcpu payload loading by storing the code as compressed assets (which is what the real system does) instead of unpacked ones which were better for analysis, but less truthful to the system's memory layout. With this, we don't get "Sound Name Error" messages anymore and, instead, we see actual instrument names in the UI.

<img width="1503" height="855" alt="image" src="https://github.com/user-attachments/assets/bf2e65e1-3c3c-41d7-a060-3e6869d96fe9" />

Also, this provides an HLE implementation of the control panel protocol (because the cpanel microcontrollers are currently not dumped - those are maskrom chips that were not decapped yet).

The protocol is not fully understood yet, but this initial implementation is good enough to get it to a working state in the driver. There are multiple commands which are treated equally, while I suspect they were supposed to have subtle differences in their behavior (otherwise why would there be more than a single command value for each of them?), so additional research will be needed. But for now I think it is acceptable to at least have something that allows interactive use and which is not a hack.

I will not mark this as a draft because I would be happy to have it merged as is. But I am also open to feedback from code-reviewers and I can make additional changes if needed. Just bare in mind that HLE implementation is, by definition, speculative.

Let me know what you think and I'll be glad to eventually make additional commits.

A short video can also be seen at https://www.youtube.com/watch?v=gX5oR9YOMJE

