### PR TITLE
apple2video: fix IIgs monochrome confusion

### DIFF
--- a/src/mame/apple/apple2video.cpp
+++ b/src/mame/apple/apple2video.cpp
@@ -100,7 +100,7 @@ void a2_video_device::device_reset()
 	m_monohgr = false;
 	m_newvideo = 0x01;
 	m_rgbmode = 3;  // default to color DHGR
-	m_monochrome = 0; // TODO: never set, but if left uninitialized could cause the emulation to start in monochrome by accident. Default to color for now
+	m_monochrome = 0; // TODO: only affects IIgs composite output
 }
 
 void a2_video_device::txt_w(int state)
@@ -684,8 +684,8 @@ void a2_video_device::hgr_update(screen_device &screen, bitmap_ind16 &bitmap, co
 	int const startcol = (cliprect.left() / 14);
 	int const stopcol = (cliprect.right() / 14) + 1;
 
-	// B&W/Green/Amber monitor, CEC/tk2000 mono HGR mode, or IIgs $C021 monochrome HGR
-	bool const monochrome = monochrome_monitor() || m_monohgr || (m_monochrome & 0x80);
+	// B&W/Green/Amber monitor, CEC/tk2000 mono HGR mode, or IIgs force-monochrome-DHR and 7M
+	bool const monochrome = monochrome_monitor() || m_monohgr || ((m_newvideo & 0x20) && m_dhires);
 
 	// verified on h/w: setting dhires w/o 80col emulates a rev. 0 Apple ][ with no orange/blue
 	uint8_t const bit7_mask = m_dhires ? 0 : 0x80;


### PR DESCRIPTION
(another bug discovered while writing video timing unit tests)

This PR corrects the IIgs monochrome registers to work like hardware:
* C029 NEWVIDEO bit5 affects both DHGR _and_ HGR (but only if C05E 7M timing is active):
![GS_C029_mono_hgr](https://github.com/user-attachments/assets/b9718a8a-38a6-41d0-b052-acc9dd15283e)

* C021 MONOCOLOR only applies to composite output, regardless of video mode:
![GS_C021_mono_composite](https://github.com/user-attachments/assets/b2756280-73f1-445b-9f39-e07c2832cb34)
(in these photos, the IIgs is driving an AppleColor RGB monitor and an Amdek Color-1 composite CRT simultaneously)


apple2gs currently has no video config options to select between RGB/composite displays, so C021 is unused.  Implementing it would require applying NTSC luminance conversion to whatever is in the framebuffer:
![GS_composite_out](https://github.com/user-attachments/assets/e8ae13a1-b80c-4ae7-93c8-3ef627066f17)
![GS_composite_mono](https://github.com/user-attachments/assets/2d094cb9-c49b-4cad-82f1-85bc819aa9a0)
