### PR TITLE
emu/drawgfx.cpp: Added alternative render which doesn't allow color index escape palette range.

### DIFF
--- a/src/emu/drawgfx.cpp
+++ b/src/emu/drawgfx.cpp
@@ -1198,7 +1198,7 @@ void gfx_element::prio_zoom_opaque(bitmap_rgb32 &dest, const rectangle &cliprect
 void gfx_element::prio_zoom_transpen(bitmap_ind16 &dest, const rectangle &cliprect,
 		u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty,
 		u32 scalex, u32 scaley, bitmap_ind8 &priority, u32 pmask,
-		u32 trans_pen)
+		u32 trans_pen, bool colorwraps)
 {
 	// non-zoom case
 	if (scalex == 0x10000 && scaley == 0x10000)
@@ -1226,14 +1226,24 @@ void gfx_element::prio_zoom_transpen(bitmap_ind16 &dest, const rectangle &clipre
 	pmask |= 1 << 31;
 
 	// render
-	color = colorbase() + granularity() * (color % colors());
-	drawgfxzoom_core(dest, cliprect, code, flipx, flipy, destx, desty, scalex, scaley, priority, [pmask, trans_pen, color](u16 &destp, u8 &pri, const u8 &srcp) { PIXEL_OP_REBASE_TRANSPEN_PRIORITY(destp, pri, srcp); });
+	if (!colorwraps)
+	{
+		color = colorbase() + granularity() * (color % colors());
+		drawgfxzoom_core(dest, cliprect, code, flipx, flipy, destx, desty, scalex, scaley, priority, [pmask, trans_pen, color](u16 &destp, u8 &pri, const u8 &srcp) { PIXEL_OP_REBASE_TRANSPEN_PRIORITY(destp, pri, srcp); });
+	}
+	else
+	{
+		const u32 clrbase = colorbase();
+		const u32 clroffset = granularity() * color;
+		const u32 clrsize = colors();
+		drawgfxzoom_core(dest, cliprect, code, flipx, flipy, destx, desty, scalex, scaley, priority, [pmask, trans_pen, clrbase, clroffset, clrsize	](u16 &destp, u8 &pri, const u8 &srcp) { PIXEL_OP_REBASE_TRANSPEN_PRIORITY_COLORWRAPS(destp, pri, srcp); });
+	}
 }
 
 void gfx_element::prio_zoom_transpen(bitmap_rgb32 &dest, const rectangle &cliprect,
 		u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty,
 		u32 scalex, u32 scaley, bitmap_ind8 &priority, u32 pmask,
-		u32 trans_pen)
+		u32 trans_pen, bool colorwraps)
 {
 	// non-zoom case
 	if (scalex == 0x10000 && scaley == 0x10000)
@@ -1261,8 +1271,18 @@ void gfx_element::prio_zoom_transpen(bitmap_rgb32 &dest, const rectangle &clipre
 	pmask |= 1 << 31;
 
 	// render
-	const pen_t *paldata = m_palette->pens() + colorbase() + granularity() * (color % colors());
-	drawgfxzoom_core(dest, cliprect, code, flipx, flipy, destx, desty, scalex, scaley, priority, [pmask, trans_pen, paldata](u32 &destp, u8 &pri, const u8 &srcp) { PIXEL_OP_REMAP_TRANSPEN_PRIORITY(destp, pri, srcp); });
+	if (!colorwraps)
+	{
+		const pen_t *paldata = m_palette->pens() + colorbase() + granularity() * (color % colors());
+		drawgfxzoom_core(dest, cliprect, code, flipx, flipy, destx, desty, scalex, scaley, priority, [pmask, trans_pen, paldata](u32 &destp, u8 &pri, const u8 &srcp) { PIXEL_OP_REMAP_TRANSPEN_PRIORITY(destp, pri, srcp); });
+	}
+	else
+	{
+		const pen_t *paldata = m_palette->pens() + colorbase();
+		const u32 paloffset = granularity() * color;
+		const u32 palsize = colors();
+		drawgfxzoom_core(dest, cliprect, code, flipx, flipy, destx, desty, scalex, scaley, priority, [pmask, trans_pen, paldata, paloffset, palsize](u32 &destp, u8 &pri, const u8 &srcp) { PIXEL_OP_REMAP_TRANSPEN_PRIORITY_PALWRAPS(destp, pri, srcp); });
+	}
 }
 
 

--- a/src/emu/drawgfx.h
+++ b/src/emu/drawgfx.h
@@ -261,8 +261,8 @@ public:
 	// specific prio_zoom implementations for each transparency type
 	void prio_zoom_opaque(bitmap_ind16 &dest, const rectangle &cliprect, u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty, u32 scalex, u32 scaley, bitmap_ind8 &priority, u32 pmask);
 	void prio_zoom_opaque(bitmap_rgb32 &dest, const rectangle &cliprect, u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty, u32 scalex, u32 scaley, bitmap_ind8 &priority, u32 pmask);
-	void prio_zoom_transpen(bitmap_ind16 &dest, const rectangle &cliprect, u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty, u32 scalex, u32 scaley, bitmap_ind8 &priority, u32 pmask, u32 transpen);
-	void prio_zoom_transpen(bitmap_rgb32 &dest, const rectangle &cliprect, u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty, u32 scalex, u32 scaley, bitmap_ind8 &priority, u32 pmask, u32 transpen);
+	void prio_zoom_transpen(bitmap_ind16 &dest, const rectangle &cliprect, u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty, u32 scalex, u32 scaley, bitmap_ind8 &priority, u32 pmask, u32 transpen, bool colorwraps = false);
+	void prio_zoom_transpen(bitmap_rgb32 &dest, const rectangle &cliprect, u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty, u32 scalex, u32 scaley, bitmap_ind8 &priority, u32 pmask, u32 transpen, bool colorwraps = false);
 	void prio_zoom_transpen_raw(bitmap_ind16 &dest, const rectangle &cliprect, u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty, u32 scalex, u32 scaley, bitmap_ind8 &priority, u32 pmask, u32 transpen);
 	void prio_zoom_transpen_raw(bitmap_rgb32 &dest, const rectangle &cliprect, u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty, u32 scalex, u32 scaley, bitmap_ind8 &priority, u32 pmask, u32 transpen);
 	void prio_zoom_transmask(bitmap_ind16 &dest, const rectangle &cliprect, u32 code, u32 color, int flipx, int flipy, s32 destx, s32 desty, u32 scalex, u32 scaley, bitmap_ind8 &priority, u32 pmask, u32 transmask);

--- a/src/emu/drawgfxt.ipp
+++ b/src/emu/drawgfxt.ipp
@@ -198,6 +198,18 @@ do                                                                              
 	}                                                                               \
 }                                                                                   \
 while (0)
+#define PIXEL_OP_REMAP_TRANSPEN_PRIORITY_PALWRAPS(DEST, PRIORITY, SOURCE)           \
+do                                                                                  \
+{                                                                                   \
+	u32 srcdata = (SOURCE);                                                         \
+	if (srcdata != trans_pen)                                                       \
+	{                                                                               \
+		if (((1 << ((PRIORITY) & 0x1f)) & pmask) == 0)                              \
+			(DEST) = paldata[(srcdata + paloffset) % palsize];                      \
+		(PRIORITY) = 31;                                                            \
+	}                                                                               \
+}                                                                                   \
+while (0)
 
 /*-------------------------------------------------
     PIXEL_OP_REBASE_TRANSPEN - render all pixels
@@ -221,6 +233,18 @@ do                                                                              
 	{                                                                               \
 		if (((1 << ((PRIORITY) & 0x1f)) & pmask) == 0)                              \
 			(DEST) = color + srcdata;                                               \
+		(PRIORITY) = 31;                                                            \
+	}                                                                               \
+}                                                                                   \
+while (0)
+#define PIXEL_OP_REBASE_TRANSPEN_PRIORITY_COLORWRAPS(DEST, PRIORITY, SOURCE)        \
+do                                                                                  \
+{                                                                                   \
+	u32 srcdata = (SOURCE);                                                         \
+	if (srcdata != trans_pen)                                                       \
+	{                                                                               \
+		if (((1 << ((PRIORITY) & 0x1f)) & pmask) == 0)                              \
+			(DEST) = clrbase + ((clroffset + srcdata) % clrsize);                   \
 		(PRIORITY) = 31;                                                            \
 	}                                                                               \
 }                                                                                   \

--- a/src/mame/sinclair/specnext_sprites.cpp
+++ b/src/mame/sinclair/specnext_sprites.cpp
@@ -92,7 +92,7 @@ void specnext_sprites_device::draw(screen_device &screen, bitmap_rgb32 &bitmap, 
 			, destx, desty
 			, 0x20000 << spr.xscale, 0x10000 << spr.yscale
 			, screen.priority(), pmask
-			, m_transp_colour & (spr.h ? 0x0f : 0xff));
+			, m_transp_colour & (spr.h ? 0x0f : 0xff), true);
 	}
 }
 


### PR DESCRIPTION
I'm adding variant to the existing render which helps index not overflow palette limits.

In the existing implementation let's say we have:

* 256 pens in the palette
* granularity 16 and requested tile color 8
* initial calculation will move us to offset 128: `const pen_t *paldata = m_palette->pens() + colorbase() + granularity() * (color % colors());`
* then _pixelop_: `(DEST) = paldata[srcdata];`

Imagine within this configuration pixels in tile are still using _256_ pens. Then _pixelop_ can access the index **>256**

I personally suspect initial implementation was done for performance but has luck of awarding such cases.
