### PR TITLE
gridcomp/gridrom.cpp: add device for GRiD's ROMs, add Test ROM

### DIFF
--- a/src/mame/gridcomp/gridcomp.cpp
+++ b/src/mame/gridcomp/gridcomp.cpp
@@ -64,6 +64,7 @@
 #include "emu.h"
 
 #include "gridkeyb.h"
+#include "gridrom.h"
 
 #include "bus/ieee488/ieee488.h"
 #include "bus/rs232/rs232.h"
@@ -112,6 +113,8 @@ public:
 		, m_dac(*this, "dac0832")
 		, m_ram(*this, RAM_TAG)
 		, m_tms9914(*this, "hpib")
+		, m_test_rom(*this, "test_rom")
+		, m_app_roms(*this, "app_rom%u", 0U)
 	{ }
 
 	static constexpr feature_type unemulated_features() { return feature::WAN; }
@@ -136,6 +139,8 @@ private:
 	required_device<dac0832_device> m_dac;
 	required_device<ram_device> m_ram;
 	required_device<tms9914_device> m_tms9914;
+	required_device<gridrom_socket_device> m_test_rom;
+	optional_device_array<gridrom_socket_device, 4> m_app_roms;
 
 	bool m_kbd_ready = false;
 	uint16_t m_kbd_data = 0;
@@ -321,6 +326,7 @@ IRQ_CALLBACK_MEMBER(gridcomp_state::irq_callback)
 void gridcomp_state::grid1101_map(address_map &map)
 {
 	map.unmap_value_high();
+	map(0xc0000, 0xcffff).r(m_test_rom, FUNC(gridrom_socket_device::read));
 	map(0xdfe40, 0xdfe4f).w(FUNC(gridcomp_state::grid_sound_w));  // modem controller??
 	map(0xdfe80, 0xdfe83).rw("i7220", FUNC(i7220_device::read), FUNC(i7220_device::write)).umask16(0x00ff);
 	map(0xdfea0, 0xdfeaf).unmaprw(); // ??
@@ -338,7 +344,7 @@ void gridcomp_state::grid1121_map(address_map &map)
 	map.unmap_value_high();
 	map(0x90000, 0x97fff).unmaprw(); // ?? ROM slot
 	map(0x9ff00, 0x9ff0f).unmaprw(); // .r(FUNC(gridcomp_state::grid_9ff0_r)); // ?? ROM?
-	map(0xc0000, 0xcffff).unmaprw(); // ?? ROM slot -- signature expected: 0x4554, 0x5048
+	map(0xc0000, 0xcffff).r(m_test_rom, FUNC(gridrom_socket_device::read));
 	map(0xdfa00, 0xdfdff).rw(FUNC(gridcomp_state::grid_dma_r), FUNC(gridcomp_state::grid_dma_w)); // DMA
 	map(0xdfe00, 0xdfe1f).unmaprw(); // ??
 	map(0xdfe40, 0xdfe4f).w(FUNC(gridcomp_state::grid_sound_w));  // modem controller??
@@ -453,6 +459,13 @@ void gridcomp_state::grid1101(machine_config &config)
 	I8255(config, "modem", 0);
 
 	RAM(config, m_ram).set_default_size("256K").set_default_value(0);
+
+	// It is unknown how much address space is allocated for the test ROM on real Compass.
+	// Based on the assumption that the test ROM should be no larger than 64KB (C000:0 to CFFF:F),
+	// the image size limitation is identical to the allocated space.
+	GRIDROM_SOCKET(config, m_test_rom, gridrom_slot, "test_rom");
+	m_test_rom->set_image_names("test-rom", "test-rom");
+	m_test_rom->set_acceptable_sizes({64*1024});
 }
 
 void gridcomp_state::grid1109(machine_config &config)
@@ -466,6 +479,13 @@ void gridcomp_state::grid1121(machine_config &config)
 	grid1101(config);
 	// m_maincpu->set_clock(XTAL(24'000'000) / 3); // XXX
 	m_maincpu->set_addrmap(AS_PROGRAM, &gridcomp_state::grid1121_map);
+
+	for (int i = 0; i < 4; i++)
+	{
+		GRIDROM_SOCKET(config, m_app_roms[i], gridrom_slot, "app_rom");
+		m_app_roms[i]->set_image_names("app-rom", "app-rom");
+		m_app_roms[i]->set_acceptable_sizes({32*1024, 64*1024, 128*1024});
+	}
 }
 
 void gridcomp_state::grid1129(machine_config &config)

--- a/src/mame/gridcomp/gridrom.cpp
+++ b/src/mame/gridcomp/gridrom.cpp
@@ -1,0 +1,63 @@
+// license:BSD-3-Clause
+// copyright-holders:vklachkov
+
+#include "gridrom.h"
+
+#include <inttypes.h>
+
+#include "bus/generic/rom.h"
+
+DEFINE_DEVICE_TYPE(GRIDROM_SOCKET, gridrom_socket_device, "gridrom_socket", "GRiD's ROM Socket")
+
+device_slot_interface &gridrom_slot(device_slot_interface &device)
+{
+	device.option_add_internal("rom", GENERIC_ROM_PLAIN);
+	return device;
+}
+
+gridrom_socket_device::gridrom_socket_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	generic_slot_device(mconfig, GRIDROM_SOCKET, tag, owner, clock)
+{
+}
+
+gridrom_socket_device::~gridrom_socket_device()
+{
+}
+
+std::pair<std::error_condition, std::string> gridrom_socket_device::call_load()
+{
+	const uint32_t size = loaded_through_softlist() ? get_software_region_length("rom") : length();
+	const std::vector<uint32_t> &sizes = m_acceptable_sizes;
+
+	if (std::find(sizes.begin(), sizes.end(), size) == sizes.end())
+	{
+		std::string sizes_str;
+		for (size_t i = 0; i < sizes.size(); ++i)
+		{
+			if (i != 0) sizes_str += ", ";
+			sizes_str += util::string_format("%" PRIu32, sizes[i]);
+		}
+
+		return std::make_pair(
+				image_error::INVALIDLENGTH,
+				util::string_format("Invalid ROM size: expected one of [%s] bytes, got %" PRIu32, sizes_str.c_str(), size));
+	}
+
+	return generic_slot_device::call_load();
+}
+
+uint8_t gridrom_socket_device::read(offs_t offset)
+{
+	return this->read_rom(offset);
+}
+
+void gridrom_socket_device::set_image_names(std::string type_name, std::string brief_type_name)
+{
+	m_image_type_name = type_name;
+	m_image_brief_type_name = brief_type_name;
+}
+
+void gridrom_socket_device::set_acceptable_sizes(std::vector<uint32_t> values)
+{
+	m_acceptable_sizes = values;
+}

--- a/src/mame/gridcomp/gridrom.h
+++ b/src/mame/gridcomp/gridrom.h
@@ -1,0 +1,49 @@
+// license:BSD-3-Clause
+// copyright-holders:vklachkov
+
+#ifndef MAME_GRIDCOMP_GRIDROM_H
+#define MAME_GRIDCOMP_GRIDROM_H
+
+#pragma once
+
+#include "emu.h"
+#include "bus/generic/slot.h"
+
+device_slot_interface &gridrom_slot(device_slot_interface &device);
+
+class gridrom_socket_device : public generic_slot_device
+{
+public:
+    template <typename T>
+	gridrom_socket_device(machine_config const &mconfig, char const *tag, device_t *owner, T &&opts, char const *intf, char const *exts = nullptr)
+		: gridrom_socket_device(mconfig, tag, owner, u32(0))
+	{
+		opts(*this);
+		set_fixed(false);
+		set_interface(intf);
+		if (exts)
+			set_extensions(exts);
+	}
+
+	gridrom_socket_device(machine_config const &mconfig, char const *tag, device_t *owner, u32 clock = 0);
+	virtual ~gridrom_socket_device();
+
+	std::pair<std::error_condition, std::string> call_load() override;
+	
+    uint8_t read(offs_t offset);
+
+    void set_image_names(std::string type_name, std::string brief_type_name);
+	void set_acceptable_sizes(std::vector<uint32_t> values);
+
+    virtual const char *image_type_name() const noexcept override { return m_image_type_name.c_str(); }
+	virtual const char *image_brief_type_name() const noexcept override { return m_image_brief_type_name.c_str(); }
+
+private:
+	std::string m_image_type_name = "imagerom";
+	std::string m_image_brief_type_name = "rom";
+	std::vector<uint32_t> m_acceptable_sizes = {32*1024, 64*1024, 128*1024};
+};
+
+DECLARE_DEVICE_TYPE(GRIDROM_SOCKET, gridrom_socket_device)
+
+#endif


### PR DESCRIPTION
This PR adds `gridrom_socket_device`/`GRIDROM_SOCKET` for connecting ROMs to GRiD laptops. Unlike `generic_socket_device`, `gridrom_socket_device` allows to change the media name and set strict size limits for the ROM.

To test functionality, I connected a Test ROM to the Compass at `C000:0`-`CFFF:F`. And I added application ROM slots for the Compass II without connecting them to the laptop.

<details>
  <summary>Information about Test ROM for Compass</summary>
We don't know anything about them, but apparently they were 64KB ROMs. The first four bytes of the ROM should be `ETPH`, followed by the code. I don't know who will find this feature useful, but it was a two-line change that made testing GRIDROM_SOCKET convenient.
</details>

List of devices for Compass 1100-1109:

```
SYSTEM           MEDIA NAME       (brief)    IMAGE FILE EXTENSIONS SUPPORTED
---------------- --------------------------- -------------------------------
grid1101         bubble           (mbm)      .bubble
grid1101         test-rom         (test-rom) .bin
```

List of devices for Compass II 1121-1139:

```
SYSTEM           MEDIA NAME       (brief)    IMAGE FILE EXTENSIONS SUPPORTED
---------------- --------------------------- -------------------------------
grid1139         bubble           (mbm)      .bubble
grid1139         test-rom         (test-rom) .bin  
grid1139         app-rom1         (app-rom1) .bin  
grid1139         app-rom2         (app-rom2) .bin  
grid1139         app-rom3         (app-rom3) .bin  
grid1139         app-rom4         (app-rom4) .bin  
```