### PR TITLE
{flopimg,esq16_dsk}.cpp: Allow specifying explicit start and end sectors when getting PC MFM track data.

### DIFF
--- a/src/lib/formats/esq16_dsk.cpp
+++ b/src/lib/formats/esq16_dsk.cpp
@@ -138,12 +138,12 @@ bool esqimg_format::save(util::random_read_write &io, const std::vector<uint32_t
 	if(sector_count != 10)
 		sector_count = 10;
 
-	uint8_t sectdata[11*512];
+	uint8_t sectdata[10*512];
 	int track_size = sector_count*512;
 
 	for(int track=0; track < track_count; track++) {
 		for(int head=0; head < head_count; head++) {
-			get_track_data_mfm_pc(track, head, image, 2000, 512, sector_count, sectdata);
+			get_track_data_mfm_pc_sectors(track, head, image, 2000, 512, 0, 9, sectdata);
 			/*auto const [err, actual] =*/ write_at(io, (track*head_count + head)*track_size, sectdata, track_size); // FIXME: check for errors
 		}
 	}

--- a/src/lib/formats/flopimg.cpp
+++ b/src/lib/formats/flopimg.cpp
@@ -1715,12 +1715,12 @@ void floppy_image_format_t::get_geometry_mfm_pc(const floppy_image &image, int c
 }
 
 
-void floppy_image_format_t::get_track_data_mfm_pc(int track, int head, const floppy_image &image, int cell_size, int sector_size, int sector_count, uint8_t *sectdata)
+void floppy_image_format_t::get_track_data_mfm_pc_sectors(int track, int head, const floppy_image &image, int cell_size, int sector_size, int start_sector, int end_sector, uint8_t *sectdata)
 {
 	auto bitstream = generate_bitstream_from_track(track, head, cell_size, image);
 	auto sectors = extract_sectors_from_bitstream_mfm_pc(bitstream);
-	for(int sector=1; sector <= sector_count; sector++) {
-		uint8_t *sd = sectdata + (sector-1)*sector_size;
+	for(int sector = start_sector; sector <= end_sector; sector++) {
+		uint8_t *sd = sectdata + (sector - start_sector) * sector_size;
 		if(sector < sectors.size() && !sectors[sector].empty()) {
 			unsigned int asize = sectors[sector].size();
 			if(asize > sector_size)
@@ -1733,6 +1733,10 @@ void floppy_image_format_t::get_track_data_mfm_pc(int track, int head, const flo
 	}
 }
 
+void floppy_image_format_t::get_track_data_mfm_pc(int track, int head, const floppy_image &image, int cell_size, int sector_size, int sector_count, uint8_t *sectdata)
+{
+	get_track_data_mfm_pc_sectors(track, head, image, cell_size, sector_size, 1, sector_count, sectdata);
+}
 
 std::vector<std::vector<uint8_t>> floppy_image_format_t::extract_sectors_from_bitstream_fm_pc(const std::vector<bool> &bitstream)
 {

--- a/src/lib/formats/flopimg.h
+++ b/src/lib/formats/flopimg.h
@@ -376,6 +376,8 @@ protected:
 
 
 	//!  Regenerate the data for a full track.
+	//!  PC-type sectors with MFM encoding and fixed-size, with explicit start and end sectors.
+	static void get_track_data_mfm_pc_sectors(int track, int head, const floppy_image &image, int cell_size, int sector_size, int start_sector, int end_sector, uint8_t *sectdata);
 	//!  PC-type sectors with MFM encoding and fixed-size.
 	static void get_track_data_mfm_pc(int track, int head, const floppy_image &image, int cell_size, int sector_size, int sector_count, uint8_t *sectdata);
 


### PR DESCRIPTION
Ensoniq VFX and EPS family floppies use 10 sectors per track, starting at sector 0 rather than the more common sector 1. The code in `esq16_dsk.cpp` handles this when loading floppy images, but not when saving them. This attempts to fix this in a way that is not only specific to Ensoniq's floppy images, but to possibly other future ones as well.

In `flopimg.cpp`, allow specifying explicit start and end sectors when getting PC MFM track data.

In `esq16_dsk.cpp`, use this to explicitly specifying sectors 0 to 9 when getting the track data to save.