### PR TITLE
NES related devices: Fix dead link, Updates

### DIFF
--- a/src/devices/bus/nes/disksys.cpp
+++ b/src/devices/bus/nes/disksys.cpp
@@ -346,9 +346,12 @@ uint8_t nes_disksys_device::read_ex(offs_t offset)
 			// bit6 - End of Head (1 when disk head is on the most inner track)
 			// bit7 - Disk Data Read/Write Enable (1 when disk is readable/writable)
 			ret = m_fds_status0 | 0x80;
-			// clear the disk IRQ detect and byte transfer flags
-			m_fds_status0 &= ~0x03;
-			set_irq_line(CLEAR_LINE);
+			if (!machine().side_effects_disabled())
+			{
+				// clear the disk IRQ detect and byte transfer flags
+				m_fds_status0 &= ~0x03;
+				set_irq_line(CLEAR_LINE);
+			}
 			break;
 		case 0x11:
 			// $4031 - data latch
@@ -357,19 +360,26 @@ uint8_t nes_disksys_device::read_ex(offs_t offset)
 				ret = 0;
 			else if (m_fds_current_side && m_read_mode)
 			{
-				ret = m_fds_data[(m_fds_current_side - 1) * 65500 + m_fds_head_position++];
-				if (m_fds_head_position == 65500)
+				ret = m_fds_data[(m_fds_current_side - 1) * 65500 + m_fds_head_position];
+				if (!machine().side_effects_disabled())
 				{
-					printf("end of disk reached!\n");
-					m_fds_status0 |= 0x40;
-					m_fds_head_position -= 2;
+					m_fds_head_position++;
+					if (m_fds_head_position == 65500)
+					{
+						logerror("%s: end of disk reached!\n", machine().describe_context());
+						m_fds_status0 |= 0x40;
+						m_fds_head_position -= 2;
+					}
 				}
 			}
 			else
 				ret = 0;
 			// clear the byte transfer flag
-			m_fds_status0 &= ~0x02;
-			set_irq_line(CLEAR_LINE);
+			if (!machine().side_effects_disabled())
+			{
+				m_fds_status0 &= ~0x02;
+				set_irq_line(CLEAR_LINE);
+			}
 			break;
 		case 0x12:
 			// $4032 - disk status 1:
@@ -382,11 +392,14 @@ uint8_t nes_disksys_device::read_ex(offs_t offset)
 			{
 				// If we've switched disks, report "no disk" for a few reads
 				ret = 1;
-				m_fds_count++;
-				if (m_fds_count == 50)
+				if (!machine().side_effects_disabled())
 				{
-					m_fds_last_side = m_fds_current_side;
-					m_fds_count = 0;
+					m_fds_count++;
+					if (m_fds_count == 50)
+					{
+						m_fds_last_side = m_fds_current_side;
+						m_fds_count = 0;
+					}
 				}
 			}
 			else

--- a/src/devices/bus/nes/nes_slot.cpp
+++ b/src/devices/bus/nes/nes_slot.cpp
@@ -48,7 +48,7 @@
  You can find the latest version of the doc at http://www.romhacking.net/docs/362/
 
  A lot of details have been based on the researches carried on at NesDev forums (by Blargg, Quietust and many more)
- and collected on the NesDev Wiki http://wiki.nesdev.com/
+ and collected on the NesDev Wiki https://www.nesdev.org/wiki
 
  Particular thanks go to
  - Martin Freij for his work on NEStopia

--- a/src/devices/sound/namco_163.cpp
+++ b/src/devices/sound/namco_163.cpp
@@ -4,7 +4,11 @@
 
     Namco 163 internal sound emulation by cam900
     4 bit wavetable (variable length), 1 ~ 8 channel
-    Reference : https://wiki.nesdev.com/w/index.php/Namco_163_audio
+    Reference : https://www.nesdev.org/wiki/Namco_163_audio
+
+    TODO:
+    - Internal RAM can be battery-backed
+      See https://www.nesdev.org/wiki/INES_Mapper_019 for details
 
 ***************************************************************************/
 

--- a/src/devices/sound/rp2c33_snd.cpp
+++ b/src/devices/sound/rp2c33_snd.cpp
@@ -299,7 +299,7 @@ inline void rp2c33_sound_device::exec_mod()
 		m_mod_acc += m_mod_freq; // input clock * frequency / 65536
 		while (m_mod_acc > 0xffff)
 		{
-			int val = m_mod_table[((m_mod_addr++) >> 1) & 0x1f] & 7;
+			const int val = m_mod_table[((m_mod_addr++) >> 1) & 0x1f] & 7;
 			m_mod_acc -= (1 << 16);
 			if (val == 4)
 				m_mod_pos = 0;

--- a/src/devices/sound/vrc6.cpp
+++ b/src/devices/sound/vrc6.cpp
@@ -8,8 +8,8 @@
     Emulation by R. Belmont
 
     References:
-    http://wiki.nesdev.com/w/index.php/VRC6_audio
-    http://nesdev.com/vrcvi.txt
+    https://www.nesdev.org/wiki/VRC6_audio
+    https://www.nesdev.org/vrcvi.txt
 
 ***************************************************************************/
 

--- a/src/mame/nintendo/nes_vt_soc.cpp
+++ b/src/mame/nintendo/nes_vt_soc.cpp
@@ -328,7 +328,9 @@ u8 nes_vt02_vt03_soc_device::vt03_410x_r(offs_t offset)
 }
 
 
-// Source: https://wiki.nesdev.com/w/index.php/NES_2.0_submappers/Proposals#NES_2.0_Mapper_256
+// Source:
+// - https://www.nesdev.org/wiki/NES_2.0_submappers#NES_2.0_Mapper_256
+// - https://www.nesdev.org/wiki/NES_2.0_Mapper_256
 
 void nes_vt02_vt03_soc_device::scrambled_410x_w(u16 offset, u8 data)
 {


### PR DESCRIPTION
bus/nes/disksys.cpp:
- Suppress side effects for debugger reads

sound/namco_163.cpp:
- Add notes for internal RAM

sound/rp2c33_snd.cpp:
- Make some variables constant

nintendo/nes_vt_soc.cpp:
- Fix dead link
- Add notes