### PR TITLE
namco/namco_c45road.cpp, namco/tceptor.cpp: Updates

### DIFF
--- a/src/mame/namco/namco_c45road.cpp
+++ b/src/mame/namco/namco_c45road.cpp
@@ -67,11 +67,17 @@ GFXDECODE_END
 
 void namco_c45_road_device::map(address_map &map)
 {
-	map(0x00000, 0x0ffff).ram().w(FUNC(namco_c45_road_device::tilemap_w)).share("tmapram");
-	map(0x10000, 0x1f9ff).ram().w(FUNC(namco_c45_road_device::tileram_w)).share("tileram");
-	map(0x1fa00, 0x1ffff).ram().share("lineram");
+	map(0x00000, 0x0ffff).ram().w(FUNC(namco_c45_road_device::tilemap_w)).share(m_tmapram);
+	map(0x10000, 0x1f9ff).ram().w(FUNC(namco_c45_road_device::tileram_w)).share(m_tileram);
+	map(0x1fa00, 0x1ffff).ram().share(m_lineram);
 }
 
+void namco_c45_road_device::writeonly_map(address_map &map)
+{
+	map(0x00000, 0x0ffff).w(FUNC(namco_c45_road_device::tilemap_w)).share(m_tmapram);
+	map(0x10000, 0x1f9ff).w(FUNC(namco_c45_road_device::tileram_w)).share(m_tileram);
+	map(0x1fa00, 0x1ffff).writeonly().share(m_lineram);
+}
 
 //-------------------------------------------------
 //  namco_c45_road_device -- constructor
@@ -80,8 +86,6 @@ void namco_c45_road_device::map(address_map &map)
 namco_c45_road_device::namco_c45_road_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	device_t(mconfig, NAMCO_C45_ROAD, tag, owner, clock),
 	device_gfx_interface(mconfig, *this, gfxinfo),
-	device_memory_interface(mconfig, *this),
-	m_space_config("c45", ENDIANNESS_BIG, 16, 17, 0, address_map_constructor(FUNC(namco_c45_road_device::map), this)),
 	m_tmapram(*this, "tmapram"),
 	m_tileram(*this, "tileram"),
 	m_lineram(*this, "lineram"),
@@ -89,32 +93,6 @@ namco_c45_road_device::namco_c45_road_device(const machine_config &mconfig, cons
 	m_transparent_color(~0),
 	m_xoffset(0)
 {
-}
-
-
-
-// We need these trampolines for now because uplift_submaps()
-// can't deal with address maps that contain RAM.
-// We need to explicitly use device_memory_interface::space()
-// because read/write handlers have a parameter called 'space'
-
-//-------------------------------------------------
-//  read -- CPU read from our address space
-//-------------------------------------------------
-
-uint16_t namco_c45_road_device::read(offs_t offset)
-{
-	return device_memory_interface::space().read_word(offset*2);
-}
-
-
-//-------------------------------------------------
-//  write -- CPU write to our address space
-//-------------------------------------------------
-
-void namco_c45_road_device::write(offs_t offset, uint16_t data, uint16_t mem_mask)
-{
-	device_memory_interface::space().write_word(offset*2, data, mem_mask);
 }
 
 
@@ -147,7 +125,7 @@ void namco_c45_road_device::tileram_w(offs_t offset, uint16_t data, uint16_t mem
 void namco_c45_road_device::draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int pri, uint8_t prival, uint8_t primask)
 {
 	bitmap_ind16 &source_bitmap = m_tilemap->pixmap();
-	unsigned yscroll = m_lineram[0x3fe/2];
+	const uint32_t yscroll = m_lineram[0x3fe/2];
 
 	// loop over scanlines
 	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
@@ -158,34 +136,32 @@ void namco_c45_road_device::draw(screen_device &screen, bitmap_ind16 &bitmap, co
 			continue;
 
 		// skip if we don't have a valid zoom factor
-		unsigned zoomx = m_lineram[0x400/2 + y + 15] & 0x3ff;
+		const uint32_t zoomx = m_lineram[0x400/2 + y + 15] & 0x3ff;
 		if (zoomx == 0)
 			continue;
 
 		// skip if we don't have a valid source increment
-		unsigned sourcey = m_lineram[0x200/2 + y + 15] + yscroll;
-		const uint16_t *source_gfx = &source_bitmap.pix(sourcey & (ROAD_TILEMAP_HEIGHT - 1));
-		unsigned dsourcex = (ROAD_TILEMAP_WIDTH << 16) / zoomx;
+		const uint32_t sourcey = m_lineram[0x200/2 + y + 15] + yscroll;
+		const uint16_t *const source_gfx = &source_bitmap.pix(sourcey & (ROAD_TILEMAP_HEIGHT - 1));
+		const uint32_t dsourcex = (ROAD_TILEMAP_WIDTH << 16) / zoomx;
 		if (dsourcex == 0)
 			continue;
 
 		// mask off priority bits and sign-extend
-		screenx &= 0x0fff;
-		if (screenx & 0x0800)
-			screenx |= ~0x7ff;
+		screenx = util::sext(screenx & 0x0fff, 12);
 
 		// adjust the horizontal placement
 		screenx += m_xoffset; // needs adjustment to left
 
 		int numpixels = (44 * ROAD_TILE_SIZE << 16) / dsourcex;
-		unsigned sourcex = 0;
+		uint32_t sourcex = 0;
 
 		// crop left
 		int clip_pixels = cliprect.min_x - screenx;
 		if (clip_pixels > 0)
 		{
 			numpixels -= clip_pixels;
-			sourcex += dsourcex*clip_pixels;
+			sourcex += dsourcex * clip_pixels;
 			screenx = cliprect.min_x;
 		}
 
@@ -197,8 +173,8 @@ void namco_c45_road_device::draw(screen_device &screen, bitmap_ind16 &bitmap, co
 		// TBA: work out palette mapping for Final Lap, Suzuka
 
 		// BUT: support transparent color for Thunder Ceptor
-		uint16_t *dest = &bitmap.pix(y);
-		uint8_t *destpri = &screen.priority().pix(y);
+		uint16_t *const dest = &bitmap.pix(y);
+		uint8_t *const destpri = &screen.priority().pix(y);
 		if (m_transparent_color != ~0)
 		{
 			while (numpixels-- > 0)
@@ -245,19 +221,6 @@ void namco_c45_road_device::device_start()
 
 
 //-------------------------------------------------
-//  memory_space_config - return a description of
-//  any address spaces owned by this device
-//-------------------------------------------------
-
-device_memory_interface::space_config_vector namco_c45_road_device::memory_space_config() const
-{
-	return space_config_vector {
-		std::make_pair(0, &m_space_config)
-	};
-}
-
-
-//-------------------------------------------------
 //  get_road_info -- tilemap callback
 //-------------------------------------------------
 
@@ -265,8 +228,8 @@ TILE_GET_INFO_MEMBER( namco_c45_road_device::get_road_info )
 {
 	// ------xx xxxxxxxx tile number
 	// xxxxxx-- -------- palette select
-	uint16_t data = m_tmapram[tile_index];
-	int tile = data & 0x3ff;
-	int color = data >> 10;
+	const uint16_t data = m_tmapram[tile_index];
+	const int tile = data & 0x3ff;
+	const int color = data >> 10;
 	tileinfo.set(0, tile, color, 0);
 }

--- a/src/mame/namco/namco_c45road.h
+++ b/src/mame/namco/namco_c45road.h
@@ -16,17 +16,14 @@
 
 // ======================> namco_c45_road_device
 
-class namco_c45_road_device : public device_t, public device_gfx_interface, public device_memory_interface
+class namco_c45_road_device : public device_t, public device_gfx_interface
 {
 public:
 	// construction/destruction
 	namco_c45_road_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 
 	void map(address_map &map) ATTR_COLD;
-
-	// read/write handlers
-	uint16_t read(offs_t offset);
-	void write(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void writeonly_map(address_map &map) ATTR_COLD;
 
 	// C45 Land (Road) Emulation
 	void set_transparent_color(pen_t pen) { m_transparent_color = pen; }
@@ -37,7 +34,6 @@ public:
 protected:
 	// device-level overrides
 	virtual void device_start() override ATTR_COLD;
-	virtual space_config_vector memory_space_config() const override;
 
 private:
 	// constants
@@ -53,10 +49,9 @@ private:
 	DECLARE_GFXDECODE_MEMBER(gfxinfo);
 	void tilemap_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void tileram_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	TILE_GET_INFO_MEMBER( get_road_info );
+	TILE_GET_INFO_MEMBER(get_road_info);
 
 	// internal state
-	address_space_config        m_space_config;
 	required_shared_ptr<uint16_t> m_tmapram;
 	required_shared_ptr<uint16_t> m_tileram;
 	required_shared_ptr<uint16_t> m_lineram;

--- a/src/mame/namco/namcos2.cpp
+++ b/src/mame/namco/namcos2.cpp
@@ -743,7 +743,7 @@ void finallap_state::common_finallap_am(address_map &map)
 	map(0x300000, 0x33ffff).r(FUNC(finallap_state::finallap_prot_r));
 	map(0x800000, 0x80ffff).ram().share(m_spriteram);
 	map(0x840000, 0x840001).rw(FUNC(finallap_state::gfx_ctrl_r), FUNC(finallap_state::gfx_ctrl_w));
-	map(0x880000, 0x89ffff).rw(m_c45_road, FUNC(namco_c45_road_device::read), FUNC(namco_c45_road_device::write));
+	map(0x880000, 0x89ffff).m(m_c45_road, FUNC(namco_c45_road_device::map));
 	map(0x8c0000, 0x8c0001).nopw();
 }
 
@@ -814,7 +814,7 @@ void sgunner_state::common_suzuka8h_am(address_map &map)
 	map(0x81a000, 0x81a001).nopw(); /* enable? - or maybe sprite DMA / buffering which is currently done automatically by setting m_c355spr->set_buffer(1); */
 	map(0x840000, 0x840001).nopr();
 	map(0x900000, 0x900007).rw(m_c355spr, FUNC(namco_c355spr_device::position_r), FUNC(namco_c355spr_device::position_w));
-	map(0xa00000, 0xa1ffff).rw(m_c45_road, FUNC(namco_c45_road_device::read), FUNC(namco_c45_road_device::write));
+	map(0xa00000, 0xa1ffff).m(m_c45_road, FUNC(namco_c45_road_device::map));
 	map(0xf00000, 0xf00007).rw(FUNC(sgunner_state::namcos2_68k_key_r), FUNC(sgunner_state::namcos2_68k_key_w));
 }
 
@@ -3266,7 +3266,7 @@ ROM_START( finalap3bl ) // bootleg set
 	NAMCOS2_DATA_LOAD_E_128K( "flt1d0.13s",  0x000000, CRC(80004966) SHA1(112b2a9b0ea792d5dbff1b9cf904da788aeede29) )
 	NAMCOS2_DATA_LOAD_O_128K( "flt1d1.13p",  0x000000, CRC(a2e93e8c) SHA1(9c8a5431a79153a70eb6939d16e0a5a6be235e75) )
 
-	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* prom for road colors */
+	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* PROM for road colors */
 	ROM_LOAD( "fl1-3.5b", 0, 0x100, CRC(d179d99a) SHA1(4e64f284c74d2b77f893bd28aaa6489084056aa2) )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
@@ -3544,7 +3544,7 @@ ROM_START( fourtrax )
 	NAMCOS2_DATA_LOAD_E_256K( "fx_dat2.13r", 0x100000, CRC(71e4a5a0) SHA1(a0188c920a43c5e69e25464627094b6b6ed26a59) )
 	NAMCOS2_DATA_LOAD_O_256K( "fx_dat3.13n", 0x100000, CRC(605725f7) SHA1(b94ce0ec37f879a5e46a097058cb2dd57e2281f1) )
 
-	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* prom for road colors */
+	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* PROM for road colors */
 	ROM_LOAD( "fx1_1.5b", 0, 0x100, CRC(85ffd753) SHA1(7dbc8c295204877f41289141a146aa4f5f9f9c96) )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
@@ -3603,7 +3603,7 @@ ROM_START( fourtraxj )
 	NAMCOS2_DATA_LOAD_E_256K( "fx_dat2.13r", 0x100000, CRC(71e4a5a0) SHA1(a0188c920a43c5e69e25464627094b6b6ed26a59) )
 	NAMCOS2_DATA_LOAD_O_256K( "fx_dat3.13n", 0x100000, CRC(605725f7) SHA1(b94ce0ec37f879a5e46a097058cb2dd57e2281f1) )
 
-	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* prom for road colors */
+	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* PROM for road colors */
 	ROM_LOAD( "fx1_1.5b", 0, 0x100, CRC(85ffd753) SHA1(7dbc8c295204877f41289141a146aa4f5f9f9c96) )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
@@ -3673,7 +3673,7 @@ ROM_START( fourtraxa )
 	NAMCOS2_DATA_LOAD_E_256K( "fx_dat2.13r", 0x100000, CRC(71e4a5a0) SHA1(a0188c920a43c5e69e25464627094b6b6ed26a59) )
 	NAMCOS2_DATA_LOAD_O_256K( "fx_dat3.13n", 0x100000, CRC(605725f7) SHA1(b94ce0ec37f879a5e46a097058cb2dd57e2281f1) )
 
-	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* prom for road colors */
+	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* PROM for road colors */
 	ROM_LOAD( "fx1_1.5b", 0, 0x100, CRC(85ffd753) SHA1(7dbc8c295204877f41289141a146aa4f5f9f9c96) )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
@@ -4796,7 +4796,7 @@ ROM_START( suzuka8h )
 	NAMCOS2_DATA_LOAD_O_256K( "eh1-d1.13p",  0x000000, CRC(9825d5bf) SHA1(720f0e90c69a2e0c48889d510a15102768226a67) )
 	NAMCOS2_DATA_LOAD_O_256K( "eh1-d3.13n",  0x100000, CRC(f46d301f) SHA1(70797fd584735844539553efcad53e11239ec10e) )
 
-	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* prom for road colors */
+	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* PROM for road colors */
 	ROM_LOAD( "ehs1_landdt.10w", 0, 0x100, CRC(cde7e8a6) SHA1(860273daf2e649418746adf50a67ae33f9f3740c) )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
@@ -4843,7 +4843,7 @@ ROM_START( suzuka8hj )
 	NAMCOS2_DATA_LOAD_O_256K( "eh1-d1.13p",  0x000000, CRC(9825d5bf) SHA1(720f0e90c69a2e0c48889d510a15102768226a67) )
 	NAMCOS2_DATA_LOAD_O_256K( "eh1-d3.13n",  0x100000, CRC(f46d301f) SHA1(70797fd584735844539553efcad53e11239ec10e) )
 
-	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* prom for road colors */
+	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* PROM for road colors */
 	ROM_LOAD( "ehs1_landdt.10w", 0, 0x100, CRC(cde7e8a6) SHA1(860273daf2e649418746adf50a67ae33f9f3740c) )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
@@ -4896,7 +4896,7 @@ ROM_START( suzuk8h2 )
 	NAMCOS2_DATA_LOAD_E_512K( "ehs1-dat2.13r",  0x100000, CRC(087da1f3) SHA1(e9c4ba0383e883502c0f45ae6e6d5daba4eccb01) )
 	NAMCOS2_DATA_LOAD_O_512K( "ehs1-dat3.13n",  0x100000, CRC(85aecb3f) SHA1(00ab6104dee0cd0fbdb0235b88b41e4d26794f98) )
 
-	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* prom for road colors */
+	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* PROM for road colors */
 	ROM_LOAD( "ehs1-landdt.10w", 0, 0x100, CRC(cde7e8a6) SHA1(860273daf2e649418746adf50a67ae33f9f3740c) )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
@@ -4949,7 +4949,7 @@ ROM_START( suzuk8h2j )
 	NAMCOS2_DATA_LOAD_E_512K( "ehs1-dat2.13r",  0x100000, CRC(087da1f3) SHA1(e9c4ba0383e883502c0f45ae6e6d5daba4eccb01) )
 	NAMCOS2_DATA_LOAD_O_512K( "ehs1-dat3.13n",  0x100000, CRC(85aecb3f) SHA1(00ab6104dee0cd0fbdb0235b88b41e4d26794f98) )
 
-	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* prom for road colors */
+	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* PROM for road colors */
 	ROM_LOAD( "ehs1-landdt.10w", 0, 0x100, CRC(cde7e8a6) SHA1(860273daf2e649418746adf50a67ae33f9f3740c) )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
@@ -5404,7 +5404,7 @@ ROM_START( luckywld )
 	ROM_LOAD16_BYTE( "lw1voi1.3m",  0x000000, 0x080000, CRC(b3e57993) SHA1(ff7071fc2e2c00f0cf819860c2a9be353474920a) )
 	ROM_LOAD16_BYTE( "lw1voi2.3l",  0x100000, 0x080000, CRC(cd8b86a2) SHA1(54bbc91e995ea0c33874ce6fe5c3f014e173da07) )
 
-	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* prom for road colors */
+	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* PROM for road colors */
 	ROM_LOAD( "lw1ld8.10w", 0, 0x100, CRC(29058c73) SHA1(4916d6bdb7f78e6803698cab32d1586ea457dfc8) )
 
 	ROM_REGION( 0x2000, "nvram", 0 ) /* default settings, including calibration - see notes with inputs */
@@ -5466,7 +5466,7 @@ ROM_START( luckywldj )
 	ROM_LOAD16_BYTE( "lw1voi1.3m",  0x000000, 0x080000, CRC(b3e57993) SHA1(ff7071fc2e2c00f0cf819860c2a9be353474920a) )
 	ROM_LOAD16_BYTE( "lw1voi2.3l",  0x100000, 0x080000, CRC(cd8b86a2) SHA1(54bbc91e995ea0c33874ce6fe5c3f014e173da07) )
 
-	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* prom for road colors */
+	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* PROM for road colors */
 	ROM_LOAD( "lw1ld8.10w", 0, 0x100, CRC(29058c73) SHA1(4916d6bdb7f78e6803698cab32d1586ea457dfc8) )
 
 	ROM_REGION( 0x2000, "nvram", 0 ) /* default settings, including calibration - see notes with inputs */

--- a/src/mame/namco/tceptor.cpp
+++ b/src/mame/namco/tceptor.cpp
@@ -103,14 +103,14 @@ uint8_t tceptor_state::input1_r()
 void tceptor_state::m6809_map(address_map &map)
 {
 	map(0x0000, 0x17ff).ram();
-	map(0x1800, 0x1bff).ram().w(FUNC(tceptor_state::tceptor_tile_ram_w)).share("tile_ram");
-	map(0x1c00, 0x1fff).ram().w(FUNC(tceptor_state::tceptor_tile_attr_w)).share("tile_attr");
-	map(0x2000, 0x3fff).ram().w(FUNC(tceptor_state::tceptor_bg_ram_w)).share("bg_ram"); // background (VIEW RAM)
+	map(0x1800, 0x1bff).ram().w(FUNC(tceptor_state::tceptor_tile_ram_w)).share(m_tile_ram);
+	map(0x1c00, 0x1fff).ram().w(FUNC(tceptor_state::tceptor_tile_attr_w)).share(m_tile_attr);
+	map(0x2000, 0x3fff).ram().w(FUNC(tceptor_state::tceptor_bg_ram_w)).share(m_bg_ram); // background (VIEW RAM)
 	map(0x4000, 0x43ff).rw(m_cus30, FUNC(namco_cus30_device::namcos1_cus30_r), FUNC(namco_cus30_device::namcos1_cus30_w));
 	map(0x4800, 0x4800).w(FUNC(tceptor_state::tceptor2_shutter_w));
 	map(0x4f00, 0x4f07).rw("adc", FUNC(adc0808_device::data_r), FUNC(adc0808_device::address_offset_start_w));
 	map(0x5000, 0x5006).w(FUNC(tceptor_state::tceptor_bg_scroll_w));
-	map(0x6000, 0x7fff).ram().share("m68k_shared_ram"); // COM RAM
+	map(0x6000, 0x7fff).ram().share(m_m68k_shared_ram); // COM RAM
 	map(0x8000, 0x8000).w(FUNC(tceptor_state::m6809_irq_disable_w));
 	map(0x8800, 0x8800).w(FUNC(tceptor_state::m6809_irq_enable_w));
 	map(0x8000, 0xffff).rom();
@@ -119,12 +119,12 @@ void tceptor_state::m6809_map(address_map &map)
 
 void tceptor_state::m6502_a_map(address_map &map)
 {
-	map(0x0000, 0x00ff).ram().share("share2");
+	map(0x0000, 0x00ff).ram().share("soundshared");
 	map(0x0100, 0x01ff).ram();
 	map(0x0200, 0x02ff).ram();
 	map(0x0300, 0x030f).ram();
 	map(0x2000, 0x2001).rw("ymsnd", FUNC(ym2151_device::read), FUNC(ym2151_device::write));
-	map(0x3000, 0x30ff).ram().share("share3");
+	map(0x3000, 0x30ff).ram().share("mcushared");
 	map(0x3c01, 0x3c01).nopw();
 	map(0x8000, 0xffff).rom();
 }
@@ -132,7 +132,7 @@ void tceptor_state::m6502_a_map(address_map &map)
 
 void tceptor_state::m6502_b_map(address_map &map)
 {
-	map(0x0000, 0x00ff).ram().share("share2");
+	map(0x0000, 0x00ff).ram().share("soundshared");
 	map(0x0100, 0x01ff).ram();
 	map(0x4000, 0x4000).w("dac", FUNC(dac_byte_interface::data_w));
 	map(0x5000, 0x5000).nopw(); // voice ctrl??
@@ -147,7 +147,7 @@ void tceptor_state::m68k_map(address_map &map)
 	map(0x200000, 0x203fff).ram(); // M68K ERROR 0
 	map(0x300000, 0x300001).nopw();
 	map(0x400000, 0x4001ff).writeonly().share("sprite_ram");
-	map(0x500000, 0x51ffff).w(m_c45_road, FUNC(namco_c45_road_device::write));
+	map(0x500000, 0x51ffff).m(m_c45_road, FUNC(namco_c45_road_device::writeonly_map));
 	map(0x600000, 0x600001).w(FUNC(tceptor_state::m68k_irq_enable_w)); // not sure
 	map(0x700000, 0x703fff).rw(FUNC(tceptor_state::m68k_shared_r), FUNC(tceptor_state::m68k_shared_w)).umask16(0x00ff);
 }
@@ -158,7 +158,7 @@ void tceptor_state::mcu_map(address_map &map)
 	map(0x1000, 0x13ff).rw(m_cus30, FUNC(namco_cus30_device::namcos1_cus30_r), FUNC(namco_cus30_device::namcos1_cus30_w));
 	map(0x1400, 0x154d).ram();
 	map(0x17c0, 0x17ff).ram();
-	map(0x2000, 0x20ff).ram().share("share3");
+	map(0x2000, 0x20ff).ram().share("mcushared");
 	map(0x2100, 0x2100).r(FUNC(tceptor_state::dsw0_r));
 	map(0x2101, 0x2101).r(FUNC(tceptor_state::dsw1_r));
 	map(0x2200, 0x2200).r(FUNC(tceptor_state::input0_r));
@@ -255,12 +255,12 @@ static const gfx_layout tile_layout =
 };
 
 static GFXDECODE_START( gfx_tceptor )
-	GFXDECODE_ENTRY( "gfx1", 0, tile_layout,     0,  256 )
+	GFXDECODE_ENTRY( "txtiles", 0, tile_layout,     0,  256 )
 
 	/* decode in video_start */
-	//GFXDECODE_ENTRY( "gfx2", 0, bg_layout,    2048,   64 )
-	//GFXDECODE_ENTRY( "gfx3", 0, spr16_layout, 1024,   64 )
-	//GFXDECODE_ENTRY( "gfx4", 0, spr32_layout, 1024,   64 )
+	//GFXDECODE_ENTRY( "bgtiles", 0, bg_layout,    2048,   64 )
+	//GFXDECODE_ENTRY( "spr16tiles", 0, spr16_layout, 1024,   64 )
+	//GFXDECODE_ENTRY( "spr32tiles", 0, spr32_layout, 1024,   64 )
 GFXDECODE_END
 
 
@@ -316,6 +316,8 @@ void tceptor_state::tceptor(machine_config &config)
 	adc.in_callback<3>().set_ioport("STICKY");
 
 	/* video hardware */
+	BUFFERED_SPRITERAM16(config, m_sprite_ram);
+
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_tceptor);
 	PALETTE(config, m_palette, FUNC(tceptor_state::tceptor_palette), 4096, 1024);
 
@@ -328,8 +330,8 @@ void tceptor_state::tceptor(machine_config &config)
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	m_screen->set_size(38*8, 32*8);
 	m_screen->set_visarea(2*8, 34*8-1 + 2*8, 0*8, 28*8-1 + 0);
-	m_screen->set_screen_update(FUNC(tceptor_state::screen_update_tceptor));
-	m_screen->screen_vblank().set(FUNC(tceptor_state::screen_vblank_tceptor));
+	m_screen->set_screen_update(FUNC(tceptor_state::screen_update));
+	m_screen->screen_vblank().set(FUNC(tceptor_state::screen_vblank));
 	m_screen->set_palette(m_palette);
 
 	/* sound hardware */
@@ -378,18 +380,18 @@ ROM_START( tceptor )
 	ROM_REGION( 0x4000, "mcusub", 0 )
 	ROM_LOAD( "tc1-2.3a",       0x0000, 0x4000, CRC(b6def610) SHA1(d0eada92a25d0243206fb8239374f5757caaea47) ) /* subprogram for the mcu */
 
-	ROM_REGION( 0x02000, "gfx1", 0 )    // text tilemap
+	ROM_REGION( 0x02000, "txtiles", 0 )    // text tilemap
 	ROM_LOAD( "tc1-18.6b",  0x00000, 0x02000, CRC(662b5650) SHA1(ba82fe5efd1011854a6d0d7d87075475b65c0601) )
 
-	ROM_REGION( 0x10000, "gfx2", 0 )    // background
+	ROM_REGION( 0x10000, "bgtiles", 0 )    // background
 	ROM_LOAD( "tc1-20.10e", 0x00000, 0x08000, CRC(3e5054b7) SHA1(ed359f8659a4a46d5ff7299d0da10550b1496db8) )
 	ROM_LOAD( "tc1-19.10d", 0x08000, 0x04000, CRC(7406e6e7) SHA1(61ad77667e94fd7e11037da2721f7bbe0130286a) )
 
-	ROM_REGION( 0x10000, "gfx3", 0 )    // 16x16 sprites
+	ROM_REGION( 0x10000, "spr16tiles", 0 )    // 16x16 sprites
 	ROM_LOAD( "tc1-16.8t",  0x00000, 0x08000, CRC(7c72be33) SHA1(397e11727b86688d550c28fbdcb864bb9335d891) )
 	ROM_LOAD( "tc1-15.10t", 0x08000, 0x08000, CRC(51268075) SHA1(75b6b935c6721adbc984795b9bf0a791fb8b209e) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 )    // 32x32 sprites
+	ROM_REGION( 0x80000, "spr32tiles", 0 )    // 32x32 sprites
 	ROM_LOAD( "tc1-8.8m",   0x00000, 0x10000, CRC(192a1f1f) SHA1(8424a6a19c080da0a83e173e33915f4d9326f379) )
 	ROM_LOAD( "tc1-10.8p",  0x10000, 0x08000, CRC(7876bcef) SHA1(09180b26d0eab51de18a13723f46d763541979fb) )
 	ROM_RELOAD(             0x18000, 0x08000 )
@@ -437,18 +439,18 @@ ROM_START( tceptor2 )
 	ROM_REGION( 0x4000, "mcusub", 0 )
 	ROM_LOAD( "tc1-2.3a",       0x0000, 0x4000, CRC(b6def610) SHA1(d0eada92a25d0243206fb8239374f5757caaea47) ) /* subprogram for the mcu */
 
-	ROM_REGION( 0x02000, "gfx1", 0 )    // text tilemap
+	ROM_REGION( 0x02000, "txtiles", 0 )    // text tilemap
 	ROM_LOAD( "tc1-18.6b",  0x00000, 0x02000, CRC(662b5650) SHA1(ba82fe5efd1011854a6d0d7d87075475b65c0601) )
 
-	ROM_REGION( 0x10000, "gfx2", 0 )    // background
+	ROM_REGION( 0x10000, "bgtiles", 0 )    // background
 	ROM_LOAD( "tc2-20.10e", 0x00000, 0x08000, CRC(e72738fc) SHA1(53664400f343acdc1d8cf7e00e261ae42b857a5f) )
 	ROM_LOAD( "tc2-19.10d", 0x08000, 0x04000, CRC(9c221e21) SHA1(58bcbb998dcf2190cf46dd3d22b116ac673285a6) )
 
-	ROM_REGION( 0x10000, "gfx3", 0 )    // 16x16 sprites
+	ROM_REGION( 0x10000, "spr16tiles", 0 )    // 16x16 sprites
 	ROM_LOAD( "tc2-16.8t",  0x00000, 0x08000, CRC(dcf4da96) SHA1(e953cb46d60171271128b3e0ef4e958d1fab1d04) )
 	ROM_LOAD( "tc2-15.10t", 0x08000, 0x08000, CRC(fb0a9f89) SHA1(cc9be6ff542b5d5e6ad3baca7a355b9bd31b3dd1) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 )    // 32x32 sprites
+	ROM_REGION( 0x80000, "spr32tiles", 0 )    // 32x32 sprites
 	ROM_LOAD( "tc2-8.8m",   0x00000, 0x10000, CRC(03528d79) SHA1(237810fa55c36b6d87c7e02e02f19feb64e5a11f) )
 	ROM_LOAD( "tc2-10.8p",  0x10000, 0x10000, CRC(561105eb) SHA1(101a0e48a740ce4acc34a7d1a50191bb857e7371) )
 	ROM_LOAD( "tc2-12.8r",  0x20000, 0x10000, CRC(626ca8fb) SHA1(0b51ced00b3de1f672f6f8c7cc5dd9e2ea2e4f8d) )

--- a/src/mame/namco/tceptor.h
+++ b/src/mame/namco/tceptor.h
@@ -5,8 +5,11 @@
 
 #pragma once
 
-#include "sound/namco.h"
 #include "namco_c45road.h"
+
+#include "sound/namco.h"
+#include "video/bufsprite.h"
+
 #include "emupal.h"
 #include "screen.h"
 #include "tilemap.h"
@@ -53,7 +56,7 @@ private:
 	required_shared_ptr<uint8_t> m_tile_attr;
 	required_shared_ptr<uint8_t> m_bg_ram;
 	required_shared_ptr<uint8_t> m_m68k_shared_ram;
-	required_shared_ptr<uint16_t> m_sprite_ram;
+	required_device<buffered_spriteram16_device> m_sprite_ram;
 
 	required_device<namco_c45_road_device> m_c45_road;
 	required_device<screen_device> m_screen;
@@ -75,10 +78,9 @@ private:
 	int32_t m_bg_scroll_x[2]{};
 	int32_t m_bg_scroll_y[2]{};
 	bitmap_ind16 m_temp_bitmap;
-	std::unique_ptr<uint16_t[]> m_sprite_ram_buffered;
 	std::unique_ptr<uint8_t[]> m_decoded_16;
 	std::unique_ptr<uint8_t[]> m_decoded_32;
-	int m_is_mask_spr[1024/16]{};
+	bool m_is_mask_spr[1024/16]{};
 
 	uint8_t m68k_shared_r(offs_t offset);
 	void m68k_shared_w(offs_t offset, uint8_t data);
@@ -102,8 +104,8 @@ private:
 	TILE_GET_INFO_MEMBER(get_bg1_tile_info);
 	TILE_GET_INFO_MEMBER(get_bg2_tile_info);
 	void tceptor_palette(palette_device &palette);
-	uint32_t screen_update_tceptor(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void screen_vblank_tceptor(int state);
+	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void screen_vblank(int state);
 	INTERRUPT_GEN_MEMBER(m6809_vb_interrupt);
 	INTERRUPT_GEN_MEMBER(m68k_vb_interrupt);
 	INTERRUPT_GEN_MEMBER(mcu_vb_interrupt);

--- a/src/mame/namco/tceptor_v.cpp
+++ b/src/mame/namco/tceptor_v.cpp
@@ -76,11 +76,11 @@ void tceptor_state::tceptor_palette(palette_device &palette)
 
 	// setup sprite mask color map
 	// tceptor2: only 0x23
-	std::fill(std::begin(m_is_mask_spr), std::end(m_is_mask_spr), 0);
+	std::fill(std::begin(m_is_mask_spr), std::end(m_is_mask_spr), false);
 	for (int i = 0; i < 0x400; i++)
 	{
 		if (palette.pen_indirect(i | 0x400) == SPR_MASK_COLOR)
-			m_is_mask_spr[i >> 4] = 1;
+			m_is_mask_spr[i >> 4] = true;
 	}
 }
 
@@ -89,8 +89,8 @@ void tceptor_state::tceptor_palette(palette_device &palette)
 
 inline int tceptor_state::get_tile_addr(int tile_index)
 {
-	int x = tile_index / 28;
-	int y = tile_index % 28;
+	int const x = tile_index / 28;
+	int const y = tile_index % 28;
 
 	switch (x)
 	{
@@ -105,9 +105,9 @@ inline int tceptor_state::get_tile_addr(int tile_index)
 
 TILE_GET_INFO_MEMBER(tceptor_state::get_tx_tile_info)
 {
-	int offset = get_tile_addr(tile_index);
-	int code = m_tile_ram[offset];
-	int color = m_tile_attr[offset];
+	int const offset = get_tile_addr(tile_index);
+	int const code = m_tile_ram[offset];
+	int const color = m_tile_attr[offset];
 
 	tileinfo.group = color;
 
@@ -164,18 +164,18 @@ void tceptor_state::tceptor_tile_attr_w(offs_t offset, uint8_t data)
 
 TILE_GET_INFO_MEMBER(tceptor_state::get_bg1_tile_info)
 {
-	uint16_t data = m_bg_ram[tile_index * 2] | (m_bg_ram[tile_index * 2 + 1] << 8);
-	int code = (data & 0x3ff) | 0x000;
-	int color = (data & 0xfc00) >> 10;
+	uint16_t const data = m_bg_ram[tile_index * 2] | (m_bg_ram[tile_index * 2 + 1] << 8);
+	int const code = (data & 0x3ff) | 0x000;
+	int const color = (data & 0xfc00) >> 10;
 
 	tileinfo.set(m_bg, code, color, 0);
 }
 
 TILE_GET_INFO_MEMBER(tceptor_state::get_bg2_tile_info)
 {
-	uint16_t data = m_bg_ram[tile_index * 2 + 0x1000] | (m_bg_ram[tile_index * 2 + 1 + 0x1000] << 8);
-	int code = (data & 0x3ff) | 0x400;
-	int color = (data & 0xfc00) >> 10;
+	uint16_t const data = m_bg_ram[tile_index * 2 + 0x1000] | (m_bg_ram[tile_index * 2 + 1 + 0x1000] << 8);
+	int const code = (data & 0x3ff) | 0x400;
+	int const color = (data & 0xfc00) >> 10;
 
 	tileinfo.set(m_bg, code, color, 0);
 }
@@ -233,15 +233,14 @@ void tceptor_state::decode_bg(const char * region)
 		128
 	};
 
-	int gfx_index = m_bg;
+	int const gfx_index = m_bg;
 	uint8_t *src = memregion(region)->base() + 0x8000;
-	int len = 0x8000;
-	int i;
+	int const len = 0x8000;
 
 	std::vector<uint8_t> buffer(len);
 
 	/* expand rom tc2-19.10d */
-	for (i = 0; i < len / 2; i++)
+	for (int i = 0; i < len / 2; i++)
 	{
 		buffer[i*2+1] = src[i] & 0x0f;
 		buffer[i*2] = (src[i] & 0xf0) >> 4;
@@ -280,13 +279,12 @@ void tceptor_state::decode_sprite16(const char * region)
 	};
 
 	uint8_t *src = memregion(region)->base();
-	int len = memregion(region)->bytes();
-	int i, y;
+	int const len = memregion(region)->bytes();
 
 	m_decoded_16 = std::make_unique<uint8_t[]>(len);
 
-	for (i = 0; i < len / (4*4*16); i++)
-		for (y = 0; y < 16; y++)
+	for (int i = 0; i < len / (4*4*16); i++)
+		for (int y = 0; y < 16; y++)
 		{
 			memcpy(&m_decoded_16[(i*4 + 0) * (2*16*16/8) + y * (2*16/8)],
 					&src[i * (2*32*32/8) + y * (2*32/8)],
@@ -330,14 +328,13 @@ void tceptor_state::decode_sprite32(const char * region)
 	};
 
 	uint8_t *src = memregion(region)->base();
-	int len = memregion(region)->bytes();
-	int total = spr32_layout.total;
-	int size = spr32_layout.charincrement / 8;
-	int i;
+	int const len = memregion(region)->bytes();
+	int const total = spr32_layout.total;
+	int const size = spr32_layout.charincrement / 8;
 
 	m_decoded_32 = make_unique_clear<uint8_t[]>(len);
 
-	for (i = 0; i < total; i++)
+	for (int i = 0; i < total; i++)
 	{
 		int code;
 
@@ -355,8 +352,6 @@ void tceptor_state::video_start()
 {
 	int gfx_index;
 
-	m_sprite_ram_buffered = make_unique_clear<uint16_t[]>(0x200/2);
-
 	/* find first empty slot to decode gfx */
 	for (gfx_index = 0; gfx_index < MAX_GFX_ELEMENTS; gfx_index++)
 		if (m_gfxdecode->gfx(gfx_index) == nullptr)
@@ -364,13 +359,13 @@ void tceptor_state::video_start()
 	assert(gfx_index + 4 <= MAX_GFX_ELEMENTS);
 
 	m_bg = gfx_index++;
-	decode_bg("gfx2");
+	decode_bg("bgtiles");
 
 	m_sprite16 = gfx_index++;
-	decode_sprite16("gfx3");
+	decode_sprite16("spr16tiles");
 
 	m_sprite32 = gfx_index++;
-	decode_sprite32("gfx4");
+	decode_sprite32("spr32tiles");
 
 	/* allocate temp bitmaps */
 	m_screen->register_screen_bitmap(m_temp_bitmap);
@@ -386,11 +381,8 @@ void tceptor_state::video_start()
 	m_bg_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(tceptor_state::get_bg1_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 64, 32);
 	m_bg_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(tceptor_state::get_bg2_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 64, 32);
 
-	save_pointer(NAME(m_sprite_ram_buffered), 0x200 / 2);
-	save_item(NAME(m_bg_scroll_x[0]));
-	save_item(NAME(m_bg_scroll_y[0]));
-	save_item(NAME(m_bg_scroll_x[1]));
-	save_item(NAME(m_bg_scroll_y[1]));
+	save_item(NAME(m_bg_scroll_x));
+	save_item(NAME(m_bg_scroll_y));
 }
 
 
@@ -419,23 +411,23 @@ void tceptor_state::video_start()
 
 void tceptor_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, int sprite_priority)
 {
-	uint16_t *mem1 = &m_sprite_ram_buffered[0x000/2];
-	uint16_t *mem2 = &m_sprite_ram_buffered[0x100/2];
-	int need_mask = 0;
+	const uint16_t *const mem1 = &m_sprite_ram->buffer()[0x000/2];
+	const uint16_t *const mem2 = &m_sprite_ram->buffer()[0x100/2];
+	bool need_mask = false;
 
 	for (int i = 0; i < 0x100; i += 2)
 	{
 		int scalex = (mem1[1 + i] & 0xfc00) << 1;
 		int scaley = (mem1[0 + i] & 0xfc00) << 1;
-		int pri = 7 - ((mem1[1 + i] & 0x3c0) >> 6);
+		int const pri = 7 - ((mem1[1 + i] & 0x3c0) >> 6);
 
 		if (pri == sprite_priority && scalex && scaley)
 		{
 			int x = mem2[1 + i] & 0x3ff;
 			int y = 512 - (mem2[0 + i] & 0x3ff);
-			int flipx = mem2[0 + i] & 0x4000;
-			int flipy = mem2[0 + i] & 0x8000;
-			int color = mem1[1 + i] & 0x3f;
+			int const flipx = BIT(mem2[0 + i], 14);
+			int const flipy = BIT(mem2[0 + i], 15);
+			int const color = mem1[1 + i] & 0x3f;
 			int gfx;
 			int code;
 
@@ -458,7 +450,7 @@ void tceptor_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect
 					// backup previous bitmap
 					copybitmap(m_temp_bitmap, bitmap, 0, 0, 0, 0, cliprect);
 
-				need_mask = 1;
+				need_mask = true;
 			}
 
 			// round off
@@ -492,11 +484,10 @@ void tceptor_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect
 }
 
 
-uint32_t tceptor_state::screen_update_tceptor(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t tceptor_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	rectangle rect;
-	int pri;
-	int bg_center = 144 - ((((m_bg_scroll_x[0] + m_bg_scroll_x[1] ) & 0x1ff) - 288) / 2);
+	int const bg_center = 144 - ((((m_bg_scroll_x[0] + m_bg_scroll_x[1] ) & 0x1ff) - 288) / 2);
 
 	// left background
 	rect = cliprect;
@@ -512,7 +503,7 @@ uint32_t tceptor_state::screen_update_tceptor(screen_device &screen, bitmap_ind1
 	m_bg_tilemap[1]->set_scrolly(0, m_bg_scroll_y[1] + 20); // 32?
 	m_bg_tilemap[1]->draw(screen, bitmap, rect, 0, 0);
 
-	for (pri = 0; pri < 8; pri++)
+	for (int pri = 0; pri < 8; pri++)
 	{
 		m_c45_road->draw(screen, bitmap, cliprect, pri * 2);
 		m_c45_road->draw(screen, bitmap, cliprect, pri * 2 + 1);
@@ -523,12 +514,12 @@ uint32_t tceptor_state::screen_update_tceptor(screen_device &screen, bitmap_ind1
 	return 0;
 }
 
-void tceptor_state::screen_vblank_tceptor(int state)
+void tceptor_state::screen_vblank(int state)
 {
 	// rising edge
 	if (state)
 	{
-		memcpy(m_sprite_ram_buffered.get(), m_sprite_ram, 0x200);
+		m_sprite_ram->copy();
 
 		if (m_m6809_irq_enable)
 			m_maincpu->set_input_line(0, HOLD_LINE);


### PR DESCRIPTION
namco/namco_c45road.cpp:
- Use .m for address map instead trampolines
- Remove device_memory_interface related stuffs (not needed due to above)
- Make some variables constant
- Use util::sext for sign extend
- Fix typename values
- Reduce literal tag usages

namco/tceptor.cpp:
- Fix typename for boolean variables
- Make some variables constant
- Reduce literal tag usages
- Use bufsprite.h for buffered sprite RAM
- Fix namings
- Fix save states