### PR TITLE
m68000: handle each fault within an instruction as it occurs

### DIFF
--- a/src/devices/cpu/m68000/m68kcpu.cpp
+++ b/src/devices/cpu/m68000/m68kcpu.cpp
@@ -1915,6 +1915,10 @@ void m68000_musashi_device::init32hmmu(address_space &space, address_space &ospa
 //         do not call set_input_line(M68K_LINE_BUSERROR) when using rerun flag
 void m68000_musashi_device::set_buserror_details(u32 fault_addr, u8 rw, u8 fc, bool rerun)
 {
+	// ignore subsequent bus errors within instruction
+	if (m_mmu_tmp_buserror_occurred)
+		return;
+
 	if (m_can_instruction_restart && rerun) m_mmu_tmp_buserror_occurred = true; // hack for external MMU
 
 	// save values for 68000 specific bus error


### PR DESCRIPTION
This change makes Musashi-based 68k CPUs with external MMUs ignore subsequent bus errors triggered within a single instruction. The change only affects systems which are using `rerun==true` (i.e., systems with external MMUs), which at time of writing in master are `sgi/ip2.cpp` and `sony/news_68k_iop.cpp`. The former is unaffected, while the latter has its own logic to avoid triggering such faults.

The idea is that the first bus error (fault) should halt the instruction and be handled before the instruction is resumed (restarted, in the current Musashi implementation) and any subsequent bus errors triggered. Without this change, Sun-2 code gets confused and fails to handle the correct fault.

See https://github.com/mamedev/mame/issues/9170 for some history and further details.