### PR TITLE
nes_vt369_vtunknown attempting to understand the extra port / protection on gtct885 a bit better

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -36206,6 +36206,7 @@ unk128vt
 unk198vt
 unkra200
 vibes240
+vibes240a
 zl383
 zonefusn
 

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -73,6 +73,7 @@ protected:
 
 	void extbank_w(u8 data);
 	void extbank_red5mam_w(u8 data);
+	void extbank_h12p1000_w(u8 data);
 
 private:
 	/* Extra IO */
@@ -90,6 +91,7 @@ public:
 	void vt_external_space_map_32mbyte(address_map &map) ATTR_COLD;
 	void vt_external_space_map_32mbyte_bank(address_map &map) ATTR_COLD;
 	void vt_external_space_map_16mbyte(address_map &map) ATTR_COLD;
+	void vt_external_space_map_16mbyte_bank(address_map &map) ATTR_COLD;
 	void vt_external_space_map_8mbyte(address_map &map) ATTR_COLD;
 	void vt_external_space_map_4mbyte(address_map &map) ATTR_COLD;
 	void vt_external_space_map_2mbyte(address_map &map) ATTR_COLD;
@@ -125,7 +127,8 @@ public:
 	void vt36x_32mb(machine_config& config);
 	void vt36x_32mb_2banks_lexi(machine_config& config);
 	void vt36x_32mb_2banks_lexi300(machine_config& config);
-
+	void vt36x_h12p1000(machine_config& config);
+	
 	void vt36x_swap(machine_config& config);
 	void vt36x_swap_2mb(machine_config& config);
 	void vt36x_swap_4mb(machine_config& config);
@@ -236,6 +239,11 @@ u8 vt369_state::vt_rom_banked_r(offs_t offset)
 void vt369_state::vt_external_space_map_32mbyte(address_map &map)
 {
 	map(0x0000000, 0x1ffffff).rom().region("mainrom", 0);
+}
+
+void vt369_state::vt_external_space_map_16mbyte_bank(address_map &map)
+{
+	map(0x0000000, 0x0ffffff).r(FUNC(vt369_state::vt_rom_banked_r));
 }
 
 void vt369_state::vt_external_space_map_32mbyte_bank(address_map &map)
@@ -464,9 +472,15 @@ void vt36x_state::vt36x_altswap_16mb(machine_config& config)
 
 void vt369_base_state::extbank_red5mam_w(u8 data)
 {
-//  printf("extbank_red5mam_w %02x\n", data);
 	m_ahigh = ((data & 0x03) << 25);
 }
+
+void vt369_base_state::extbank_h12p1000_w(u8 data)
+{
+	m_ahigh = ((data & 0x02) << 23);
+}
+
+
 
 void vt36x_state::vt36x_altswap_32mb_4banks_red5mam(machine_config& config)
 {
@@ -596,6 +610,13 @@ void vt36x_gtct885_state::vt36x_8mb_gtct885(machine_config& config)
 
 	// doesn't seem to be a standard EEPROM, but whatever is there must supply 0x100 bytes?
 	//EEPROM_93C56_8BIT(config, m_eeprom).default_value(1);
+}
+
+void vt36x_state::vt36x_h12p1000(machine_config& config)
+{
+	vt36x_16mb(config);
+	m_soc->set_addrmap(AS_PROGRAM, &vt36x_state::vt_external_space_map_16mbyte_bank);
+	m_soc->io_4139_write_callback().set(FUNC(vt36x_gtct885_state::extbank_h12p1000_w));
 }
 
 
@@ -925,6 +946,9 @@ ROM_END
 ROM_START( 36pcase )
 	ROM_REGION( 0x200000, "mainrom", 0 )
 	ROM_LOAD( "25q16.ic3", 0x00000, 0x200000, CRC(a8edb73e) SHA1(1028656530e411607ffa3b63788b42e41bf971d7) )
+
+	ROM_REGION( 0x100, "extra", 0 ) // data from additional 8-pin chip for protection (put at 0xe01 in RAM) (checks for something before this)
+	ROM_LOAD( "mystery chip.bin", 0x00000, 0x100, NO_DUMP )
 ROM_END
 
 
@@ -1163,6 +1187,9 @@ ROM_END
 ROM_START( rbbrite )
 	ROM_REGION( 0x100000, "mainrom", 0 )
 	ROM_LOAD( "coleco_rainbowbrite_29dl800ba_000422cb.bin", 0x00000, 0x100000, CRC(d2ad0d7d) SHA1(4423a5aa2eda20b3621ab46e951ac08dc2d24789) )
+
+	ROM_REGION( 0x100, "extra", 0 ) // data from additional 8-pin chip for protection (put at 0x701 in RAM)
+	ROM_LOAD( "mystery chip.bin", 0x00000, 0x100, NO_DUMP )
 
 	VT3XX_INTERNAL_NO_SWAP // not verified for this set, used for testing
 ROM_END
@@ -1545,7 +1572,7 @@ CONS( 201?, 240in1ar,  0,  0,  vt36x_altswap_32mb_4banks_red5mam, vt369, vt36x_s
 // portable fan + famiclone combo handheld, very similar to 240in1ar
 CONS( 2020, nubsupmf,   0,      0,  vt36x_altswap_4mb, vt369, vt36x_state, empty_init, "<unknown>", "NubSup Mini Game Fan", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 
-// protected?
+// protected
 CONS( 202?, 36pcase,    0,      0,  vt36x_altswap_2mb, vt369, vt36x_state, empty_init, "<unknown>", "36-in-1 Classic Games phone case", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 
 
@@ -1575,13 +1602,6 @@ CONS( 202?, zl383,    0,        0,  vt36x_vibesswap_8mb,  vt369, vt36x_state, em
 
 CONS( 202?, retro620, 0,        0,  vt36x_vibesswap_16mb, vt369, vt36x_state, empty_init, "<unknown>", "Retro FC 620-in-1", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 
-// has extra protection?
-CONS( 2018, rbbrite,    0,        0,  vt369_unk_1mb, vt369, vt36x_state, empty_init, "Coleco", "Rainbow Brite (mini-arcade)", MACHINE_NOT_WORKING )
-
-// there's also a 250+ version of the unit below at least; protection(?) is similar to rbbrite
-CONS( 2018, goretrop,  0,         0,  vt369_unk_32mb, vt369, vt36x_state, empty_init,    "Retro-Bit", "Go Retro Portable 260+ Games", MACHINE_NOT_WORKING )
-CONS( 2018, goretropa, goretrop,  0,  vt369_unk_32mb, vt369, vt36x_state, empty_init,    "Retro-Bit", "Go Retro Portable 260+ Games (older)", MACHINE_NOT_WORKING ) // doesn't have commando or higemaru
-
 // all games after the first 180 listed on the menu are duplicates. BTANB: games 501-520 are mislabeled duplicates: e.g., "511. Exerion" actually loads Pac-Man.
 // unused routines suggest this was originally developed for nes_vt42xx.cpp hardware (cf. g9_666, g5_500 with the same bitswap)
 // there are other S10 units available
@@ -1596,8 +1616,7 @@ CONS( 202?, 500in1hh,  0,  0,  vt36x_gbox2020_16mb, vt369, vt36x_state, empty_in
 // there were also 'F1' units, shaped like a car, ROM may or may not be the same
 CONS( 202?, f5_620,    0,  0,  vt36x_16mb,        vt369, vt36x_state, init_f5_620,   "<unknown>", "F5 Handheld Game Console (620-in-1)",  MACHINE_NOT_WORKING )
 
-// banking(?) issues, some games don't boot (writes data to ALU mirror, then some other ports)
-CONS( 202?, h12p1000,  0,        0,  vt36x,     vt369, vt36x_state, empty_init, "<unknown>", "H12 Pro 1000 in 1 Handheld Game Console", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+CONS( 202?, h12p1000,  0,        0,  vt36x_h12p1000,     vt369, vt36x_state, empty_init, "<unknown>", "H12 Pro 1000 in 1 Handheld Game Console", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 
 /*****************************************************************************
 * below are VT369 games that use SQI / SPI ROM
@@ -1695,3 +1714,12 @@ CONS( 202?, a6plus,    0,        0,  vt36x_8mb, vt369, vt36x_state, empty_init, 
 
 // available in red and white cases, ROM is the same, uploads sound prog so definitely 36x
 CONS( 202?, unk198vt, 0,        0,  vt36x_8mb,  vt369, vt36x_state, empty_init, "<unknown>", "198-in-1 Handheld Console", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+
+// has extra protection (using ports at 4138 / 4139, copied to 0x701)
+CONS( 2018, rbbrite,    0,        0,  vt369_unk_1mb, vt369, vt36x_state, empty_init, "Coleco", "Rainbow Brite (mini-arcade)", MACHINE_NOT_WORKING )
+
+// there's also a 250+ version of the unit below at least
+// has extra protection (using ports at 4138 / 4139, copied to 0x701)
+CONS( 2018, goretrop,  0,         0,  vt369_unk_32mb, vt369, vt36x_state, empty_init,    "Retro-Bit", "Go Retro Portable 260+ Games", MACHINE_NOT_WORKING )
+CONS( 2018, goretropa, goretrop,  0,  vt369_unk_32mb, vt369, vt36x_state, empty_init,    "Retro-Bit", "Go Retro Portable 260+ Games (older)", MACHINE_NOT_WORKING ) // doesn't have commando or higemaru
+

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -1150,6 +1150,7 @@ ROM_START( rd5_240 )
 
 	ROM_REGION( 0x100, "extra", 0 ) // data from additional 8-pin chip for protection
 	ROM_LOAD( "mystery chip.bin", 0x00000, 0x100, NO_DUMP )
+	ROM_FILL(           0x000, 0x100, 0x60) // RTS opcodes work
 ROM_END
 
 ROM_START( myarccn )
@@ -1744,7 +1745,7 @@ CONS( 201?, lxcyber,    mc_tv200, 0,  vt36x_8mb, vt369, vt36x_state, empty_init,
  // menu is protected with code from extra ROM
 CONS( 201?, gtct885,    mc_tv200, 0,  vt36x_8mb_gtct885, vt369, vt36x_gtct885_state, empty_init, "Gaming Tech",  "Gaming Tech CT-885", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
  // similar to above, but with 40 extra games, menu is protected with code from extra ROM (although RTS opcodes seem to work)
-CONS( 201?, rd5_240,    0,        0,  vt36x_8mb, vt369, vt36x_state, empty_init, "Red5",         "Mini Arcade Machine 240-in-1 (Red5)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+CONS( 201?, rd5_240,    0,        0,  vt36x_8mb_gtct885, vt369, vt36x_gtct885_state, empty_init, "Red5",         "Mini Arcade Machine 240-in-1 (Red5)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 
 CONS( 201?, hkb502,   0,      0,  vt36x_4mb, vt369, vt36x_state, empty_init, "<unknown>", "HKB-502 268-in-1 (set 1)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 CONS( 201?, hkb502a,  hkb502, 0,  vt36x_4mb, vt369, vt36x_state, empty_init, "<unknown>", "HKB-502 268-in-1 (set 2)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -157,15 +157,26 @@ class vt36x_gtct885_state : public vt36x_state
 {
 public:
 	vt36x_gtct885_state(const machine_config& mconfig, device_type type, const char* tag) :
-		vt36x_state(mconfig, type, tag)
+		vt36x_state(mconfig, type, tag),
+		m_extrarom(*this, "extra")
 	{ }
 
 	void vt36x_8mb_gtct885(machine_config& config);
 
 private:
+	virtual void machine_start() override ATTR_COLD;
+	virtual void machine_reset() override ATTR_COLD;
 
 	u8 gtct885_prot_r();
 	void gtct885_prot_w(u8 data);
+	u8 m_command;
+	u8 m_commandbits;
+	u8 m_protectionstate;
+	u8 m_protold;
+	u8 m_protlatch;
+	u16 m_protreadposition;
+
+	required_region_ptr<uint8_t> m_extrarom;
 };
 
 class vt36x_tetrtin_state : public vt36x_state
@@ -480,13 +491,99 @@ void vt369_base_state::extbank_h12p1000_w(u8 data)
 	m_ahigh = ((data & 0x02) << 23);
 }
 
-// unknown protection device supplying ~0x100 bytes of code (currently in "extra" region)
+
+
+
+// has an unknown protection device supplying ~0x100 bytes of code (currently in "extra" region)
+
+void vt36x_gtct885_state::machine_start()
+{
+	vt36x_state::machine_start();
+	save_item(NAME(m_command));
+	save_item(NAME(m_commandbits));
+	save_item(NAME(m_protectionstate));
+	save_item(NAME(m_protold));
+	save_item(NAME(m_protlatch));;
+	save_item(NAME(m_protreadposition));
+}
+
+void vt36x_gtct885_state::machine_reset()
+{
+	vt36x_state::machine_reset();
+	m_command = 0;
+	m_commandbits = 0;
+	m_protectionstate = 0;
+	m_protold = 0;
+	m_protlatch = 0;
+	m_protreadposition = 0;
+}
+
 void vt36x_gtct885_state::gtct885_prot_w(u8 data)
 {
 	logerror("%s: gtct885_prot_w %02x\n", machine().describe_context(), data);
 	// direction is set to 0x38 before writing here
 	// so 0x20, 0x10, and 0x08 are outputs
 	// some kind of serial device
+
+	if ((data & 0x10) != (m_protold & 0x10))
+	{
+		if (!(data & 0x10))
+		{
+			m_protectionstate = 1; // ready to get command
+			m_commandbits = 8;
+			logerror("protection state ready\n");
+		}
+		else
+		{
+			m_protectionstate = 0; // device not selected?
+			logerror("protection state deselect\n");
+		}
+	}
+
+	if ((data & 0x08) != (m_protold & 0x08))
+	{
+		if (data & 0x08)
+		{
+			if (m_protectionstate == 1)
+			{
+				m_command = (m_command << 1) | ((data & 0x20) >> 5);
+				m_commandbits--;
+
+				logerror("a %02x\n", m_commandbits);
+
+				if (m_commandbits == 0)
+				{
+					logerror("got command %02x\n", m_command);
+
+					if (m_command == 0x30)
+					{
+						logerror("(read bytes)\n");
+						m_protectionstate = 2;
+						m_protreadposition = 0;
+					}
+					else
+					{
+						logerror("(unknown command)\n");
+						m_protectionstate = 0;
+					}
+				}
+			}
+			else if (m_protectionstate == 2)
+			{
+				u8 readdat = m_extrarom[m_protreadposition >> 3];
+				u8 readbit = readdat >> (7 - (m_protreadposition & 7));
+				readbit &= 1;
+
+				logerror("reading bit at byte %02x bit %1x (byte is %02x bit read is %1x)\n", m_protreadposition >> 3, m_protreadposition & 7, readdat, readbit);
+
+				m_protlatch = readbit;
+
+				m_protreadposition++;
+			}
+		}
+	}
+
+	m_protold = data;
 }
 
 u8 vt36x_gtct885_state::gtct885_prot_r()
@@ -494,8 +591,7 @@ u8 vt36x_gtct885_state::gtct885_prot_r()
 	logerror("%s: gtct885_prot_r\n", machine().describe_context());
 	// direction is set to 0x18 before reading here
 	// 0x20 is input (gets shifted into carry, then rotated into RAM)
-	u8 bit = 0;
-	return bit << 5;
+	return m_protlatch << 5;
 }
 
 void vt36x_state::vt36x_altswap_32mb_4banks_red5mam(machine_config& config)

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -1153,6 +1153,12 @@ ROM_START( vibes240 )
 	ROM_LOAD( "s29gl128p11tfi01.bin", 0x000000, 0x1000000, BAD_DUMP CRC(c04c5527) SHA1(58737084e1b1a2862f50f07feeab79593ca13862) )
 ROM_END
 
+ROM_START( vibes240a )
+	ROM_REGION( 0x1000000, "mainrom", 0 )
+	// wouldn't read consistently
+	ROM_LOAD( "vibes.u2", 0x000000, 0x1000000, BAD_DUMP CRC(a747971a) SHA1(2399d4f32d0054a06397bead069b498e634dbe37) )
+ROM_END
+
 ROM_START( retro620 )
 	ROM_REGION( 0x1000000, "mainrom", 0 )
 	ROM_LOAD( "620in1_retrofc.bin", 0x00000, 0x1000000, CRC(2698f4e5) SHA1(8b9551c22071c48a7ebc1635ca37ebe7a3b33c4b) ) // BGA on subboard
@@ -1583,7 +1589,10 @@ CONS( 2020, gbox2020, gbox2019, 0, vt36x_gbox2020_16mb, vt369, vt36x_state, empt
 CONS( 2018, rsps300,  0,        0,  vt36x_rsps300swap_16mb, vt369, vt36x_state, empty_init,   "Sup", "Retro Station Pocket System GB-40 300 in 1",  MACHINE_NOT_WORKING )
 
 // unknown tech, probably from 2021, probably VT369, ROM wouldn't read consistently
-CONS( 202?, vibes240, 0,        0,  vt36x_vibesswap_16mb, vt369, vt36x_state, empty_init, "<unknown>", "Vibes Retro Pocket Gamer 240-in-1", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+// several games don't work (eg. Curly Monkey 2, maybe due to bad dump?)
+CONS( 202?, vibes240, 0,        0,  vt36x_vibesswap_16mb, vt369, vt36x_state, empty_init, "<unknown>", "Vibes Retro Pocket Gamer 240-in-1 (set 1)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+// also a bad dump, different encryption, but Curly Monkey 2 works here, only first 2 opcodes are encrypted
+CONS( 202?, vibes240a,vibes240, 0,  vt36x_gbox2020_16mb,  vt369, vt36x_state, empty_init, "<unknown>", "Vibes Retro Pocket Gamer 240-in-1 (set 2)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 
 // has TUI (holiday company) logo on packaging, no other manufacturer details
 CONS( 201?, tui240,     0,        0,  vt36x_gbox2020_8mb,    vt369, vt36x_state, init_tui240, "<unknown>",  "TUI 240-in-1", MACHINE_NOT_WORKING )

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -150,7 +150,6 @@ public:
 	void vt36x_rsps300swap_16mb(machine_config& config);
 
 	void vt369_unk(machine_config& config);
-	void vt369_unk_1mb(machine_config& config);
 	void vt369_unk_16mb(machine_config& config);
 };
 
@@ -180,6 +179,7 @@ public:
 	{ }
 
 	void vt36x_32mb_goretrop(machine_config& config);
+	void vt36x_1mb_rbbrite(machine_config& config);
 
 private:
 	u8 goretrop_prot_r();
@@ -396,12 +396,6 @@ void vt36x_state::vt369_unk_16mb(machine_config& config)
 {
 	vt369_unk(config);
 	m_soc->set_addrmap(AS_PROGRAM, &vt36x_state::vt_external_space_map_16mbyte);
-}
-
-void vt36x_state::vt369_unk_1mb(machine_config& config)
-{
-	vt369_unk(config);
-	m_soc->set_addrmap(AS_PROGRAM, &vt36x_state::vt_external_space_map_1mbyte);
 }
 
 // New mystery handheld architecture, VTxx derived
@@ -661,6 +655,12 @@ void vt36x_goretrop_state::vt36x_32mb_goretrop(machine_config& config)
 	m_soc->io_4139_write_callback().set(FUNC(vt36x_goretrop_state::goretrop_prot_w));
 
 	VT_MENU_PROTECTION(config, m_protection, 0);
+}
+
+void vt36x_goretrop_state::vt36x_1mb_rbbrite(machine_config& config)
+{
+	vt36x_32mb_goretrop(config);
+	m_soc->set_addrmap(AS_PROGRAM, &vt36x_state::vt_external_space_map_1mbyte);
 }
 
 void vt36x_state::vt36x_h12p1000(machine_config& config)
@@ -1246,8 +1246,15 @@ ROM_START( rbbrite )
 	ROM_REGION( 0x100000, "mainrom", 0 )
 	ROM_LOAD( "coleco_rainbowbrite_29dl800ba_000422cb.bin", 0x00000, 0x100000, CRC(d2ad0d7d) SHA1(4423a5aa2eda20b3621ab46e951ac08dc2d24789) )
 
-	ROM_REGION( 0x100, "extra", 0 ) // data from additional 8-pin chip for protection (put at 0x701 in RAM)
+	ROM_REGION( 0x100, "protection", 0 ) // data from additional 8-pin chip for protection (put at 0x701 in RAM)
 	ROM_LOAD( "mystery chip.bin", 0x00000, 0x100, NO_DUMP )
+	ROM_FILL( 0x000, 0x100, 0x60) // wants actual code here, just RTS opcodes don't work
+	// jumps to 0706
+	// jumps to 072b
+	// jumps to 072f
+	// jumps to 0743
+	// jumps to 07d9
+	// (same addresses as goretrop, maybe same data is expected)
 
 	VT3XX_INTERNAL_NO_SWAP // not verified for this set, used for testing
 ROM_END
@@ -1310,6 +1317,9 @@ ROM_START( goretrop )
 	ROM_REGION( 0x100, "protection", 0 ) // data from additional 8-pin chip for protection (copied to 0x701 - 0x7ff)
 	ROM_LOAD( "mystery chip.bin", 0x00000, 0x100, NO_DUMP )
 	ROM_FILL( 0x000, 0x100, 0x60) // wants actual code here, just RTS opcodes don't work
+	// jumps to 072b
+	// jumps to 072f after putting a value in a
+	// jumps to 0743 after putting a value in x
 ROM_END
 
 ROM_START( goretropa )
@@ -1763,7 +1773,7 @@ CONS( 202?, a6plus,    0,        0,  vt36x_8mb, vt369, vt36x_state, empty_init, 
 CONS( 202?, unk198vt, 0,        0,  vt36x_8mb,  vt369, vt36x_state, empty_init, "<unknown>", "198-in-1 Handheld Console", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 
 // has extra protection (using ports at 4138 / 4139, copied to 0x701)
-CONS( 2018, rbbrite,    0,        0,  vt369_unk_1mb, vt369, vt36x_state, empty_init, "Coleco", "Rainbow Brite (mini-arcade)", MACHINE_NOT_WORKING )
+CONS( 2018, rbbrite,    0,        0,  vt36x_1mb_rbbrite, vt369, vt36x_goretrop_state, empty_init, "Coleco", "Rainbow Brite (mini-arcade)", MACHINE_NOT_WORKING )
 
 // there's also a 250+ version of the unit below at least
 // has extra protection (using ports at 4138 / 4139, copied to 0x701)

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -465,6 +465,11 @@ void vt36x_state::vt36x_altswap_16mb(machine_config& config)
 	m_soc->set_addrmap(AS_PROGRAM, &vt36x_state::vt_external_space_map_16mbyte);
 }
 
+void vt369_base_state::extbank_w(u8 data)
+{
+	m_ahigh = (data & 0x01) ? (1 << 25) : 0x0;
+}
+
 void vt369_base_state::extbank_red5mam_w(u8 data)
 {
 	m_ahigh = ((data & 0x03) << 25);
@@ -475,7 +480,23 @@ void vt369_base_state::extbank_h12p1000_w(u8 data)
 	m_ahigh = ((data & 0x02) << 23);
 }
 
+// unknown protection device supplying ~0x100 bytes of code (currently in "extra" region)
+void vt36x_gtct885_state::gtct885_prot_w(u8 data)
+{
+	logerror("%s: gtct885_prot_w %02x\n", machine().describe_context(), data);
+	// direction is set to 0x38 before writing here
+	// so 0x20, 0x10, and 0x08 are outputs
+	// some kind of serial device
+}
 
+u8 vt36x_gtct885_state::gtct885_prot_r()
+{
+	logerror("%s: gtct885_prot_r\n", machine().describe_context());
+	// direction is set to 0x18 before reading here
+	// 0x20 is input (gets shifted into carry, then rotated into RAM)
+	u8 bit = 0;
+	return bit << 5;
+}
 
 void vt36x_state::vt36x_altswap_32mb_4banks_red5mam(machine_config& config)
 {
@@ -578,11 +599,6 @@ void vt36x_state::vt36x_32mb(machine_config& config)
 	m_soc->set_addrmap(AS_PROGRAM, &vt36x_state::vt_external_space_map_32mbyte);
 }
 
-void vt369_base_state::extbank_w(u8 data)
-{
-	m_ahigh = (data & 0x01) ? (1 << 25) : 0x0;
-}
-
 void vt36x_state::vt36x_32mb_2banks_lexi(machine_config& config)
 {
 	vt36x_32mb(config);
@@ -608,7 +624,7 @@ void vt36x_state::vt36x_h12p1000(machine_config& config)
 {
 	vt36x_16mb(config);
 	m_soc->set_addrmap(AS_PROGRAM, &vt36x_state::vt_external_space_map_16mbyte_bank);
-	m_soc->io_4139_write_callback().set(FUNC(vt36x_gtct885_state::extbank_h12p1000_w));
+	m_soc->io_4139_write_callback().set(FUNC(vt36x_state::extbank_h12p1000_w));
 }
 
 
@@ -1429,24 +1445,6 @@ void vt369_state::init_tui240()
 	}
 }
 
-
-// unknown protection device supplying ~0x100 bytes of code (currently in "extra" region)
-void vt36x_gtct885_state::gtct885_prot_w(u8 data)
-{
-	logerror("%s: gtct885_prot_w %02x\n", machine().describe_context(), data);
-	// direction is set to 0x38 before writing here
-	// so 0x20, 0x10, and 0x08 are outputs
-	// some kind of serial device
-}
-
-u8 vt36x_gtct885_state::gtct885_prot_r()
-{
-	logerror("%s: gtct885_prot_r\n", machine().describe_context());
-	// direction is set to 0x18 before reading here
-	// 0x20 is input (gets shifted into carry, then rotated into RAM)
-	u8 bit = 0;
-	return bit << 5;
-}
 
 } // anonymous namespace
 

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -21,7 +21,9 @@
   ***************************************************************************/
 
 #include "emu.h"
+
 #include "nes_vt369_vtunknown_soc.h"
+#include "vt_menu_protection.h"
 
 #include "multibyte.h"
 
@@ -158,7 +160,7 @@ class vt36x_gtct885_state : public vt36x_state
 public:
 	vt36x_gtct885_state(const machine_config& mconfig, device_type type, const char* tag) :
 		vt36x_state(mconfig, type, tag),
-		m_extrarom(*this, "extra")
+		m_protection(*this, "protection")
 	{ }
 
 	void vt36x_8mb_gtct885(machine_config& config);
@@ -169,14 +171,8 @@ private:
 
 	u8 gtct885_prot_r();
 	void gtct885_prot_w(u8 data);
-	u8 m_command;
-	u8 m_commandbits;
-	u8 m_protectionstate;
-	u8 m_protold;
-	u8 m_protlatch;
-	u16 m_protreadposition;
 
-	required_region_ptr<uint8_t> m_extrarom;
+	required_device<vt_menu_protection_device> m_protection;
 };
 
 class vt36x_tetrtin_state : public vt36x_state
@@ -499,99 +495,29 @@ void vt369_base_state::extbank_h12p1000_w(u8 data)
 void vt36x_gtct885_state::machine_start()
 {
 	vt36x_state::machine_start();
-	save_item(NAME(m_command));
-	save_item(NAME(m_commandbits));
-	save_item(NAME(m_protectionstate));
-	save_item(NAME(m_protold));
-	save_item(NAME(m_protlatch));;
-	save_item(NAME(m_protreadposition));
 }
 
 void vt36x_gtct885_state::machine_reset()
 {
 	vt36x_state::machine_reset();
-	m_command = 0;
-	m_commandbits = 0;
-	m_protectionstate = 0;
-	m_protold = 0;
-	m_protlatch = 0;
-	m_protreadposition = 0;
 }
 
 void vt36x_gtct885_state::gtct885_prot_w(u8 data)
 {
-	logerror("%s: gtct885_prot_w %02x\n", machine().describe_context(), data);
 	// direction is set to 0x38 before writing here
 	// so 0x20, 0x10, and 0x08 are outputs
 	// some kind of serial device
 
-	if ((data & 0x10) != (m_protold & 0x10))
-	{
-		if (!(data & 0x10))
-		{
-			m_protectionstate = 1; // ready to get command
-			m_commandbits = 8;
-			logerror("protection state ready\n");
-		}
-		else
-		{
-			m_protectionstate = 0; // device not selected?
-			logerror("protection state deselect\n");
-		}
-	}
-
-	if ((data & 0x08) != (m_protold & 0x08))
-	{
-		if (data & 0x08)
-		{
-			if (m_protectionstate == 1)
-			{
-				m_command = (m_command << 1) | ((data & 0x20) >> 5);
-				m_commandbits--;
-
-				logerror("a %02x\n", m_commandbits);
-
-				if (m_commandbits == 0)
-				{
-					logerror("got command %02x\n", m_command);
-
-					if (m_command == 0x30)
-					{
-						logerror("(read bytes)\n");
-						m_protectionstate = 2;
-						m_protreadposition = 0;
-					}
-					else
-					{
-						logerror("(unknown command)\n");
-						m_protectionstate = 0;
-					}
-				}
-			}
-			else if (m_protectionstate == 2)
-			{
-				u8 readdat = m_extrarom[m_protreadposition >> 3];
-				u8 readbit = readdat >> (7 - (m_protreadposition & 7));
-				readbit &= 1;
-
-				logerror("reading bit at byte %02x bit %1x (byte is %02x bit read is %1x)\n", m_protreadposition >> 3, m_protreadposition & 7, readdat, readbit);
-
-				m_protlatch = readbit;
-
-				m_protreadposition++;
-			}
-		}
-	}
-
-	m_protold = data;
+	m_protection->write_data((data & 0x20) ? true : false);
+	m_protection->write_enable((data & 0x10) ? true : false);
+	m_protection->write_clock((data & 0x08) ? true : false);
 }
 
 u8 vt36x_gtct885_state::gtct885_prot_r()
 {
-	logerror("%s: gtct885_prot_r\n", machine().describe_context());
 	// direction is set to 0x18 before reading here
 	// 0x20 is input (gets shifted into carry, then rotated into RAM)
-	return m_protlatch << 5;
+	return m_protection->read() ? 0x20 : 0x00;
 }
 
 void vt36x_state::vt36x_altswap_32mb_4banks_red5mam(machine_config& config)
@@ -714,6 +640,8 @@ void vt36x_gtct885_state::vt36x_8mb_gtct885(machine_config& config)
 	vt36x_8mb(config);
 	m_soc->io_4153_read_callback().set(FUNC(vt36x_gtct885_state::gtct885_prot_r));
 	m_soc->io_4152_write_callback().set(FUNC(vt36x_gtct885_state::gtct885_prot_w));
+
+	VT_MENU_PROTECTION(config, m_protection, 0);
 }
 
 void vt36x_state::vt36x_h12p1000(machine_config& config)
@@ -1140,7 +1068,7 @@ ROM_START( gtct885 )
 	ROM_REGION( 0x800000, "mainrom", 0 )
 	ROM_LOAD( "ct-885 g25q64c.bin", 0x00000, 0x800000, CRC(a5b2b568) SHA1(79de79364fa731e421627ec68e3bfa9d311aa7fc) )
 
-	ROM_REGION( 0x100, "extra", 0 ) // data from additional 8-pin chip for protection (might not be an eeprom) (copied to 0xe01 - 0xeff)
+	ROM_REGION( 0x100, "protection", 0 ) // data from additional 8-pin chip for protection (might not be an eeprom) (copied to 0xe01 - 0xeff)
 	ROM_LOAD( "mystery chip.bin", 0x00000, 0x100, CRC(8173c1c2) SHA1(7521a4676166a81a79209638491026b2d8e32895) )
 ROM_END
 
@@ -1148,7 +1076,7 @@ ROM_START( rd5_240 )
 	ROM_REGION( 0x800000, "mainrom", 0 )
 	ROM_LOAD( "red5.bin", 0x00000, 0x800000, CRC(0e564e73) SHA1(c29a927c830ab3876e9b63e2d41bef962c05518f) )
 
-	ROM_REGION( 0x100, "extra", 0 ) // data from additional 8-pin chip for protection
+	ROM_REGION( 0x100, "protection", 0 ) // data from additional 8-pin chip for protection
 	ROM_LOAD( "mystery chip.bin", 0x00000, 0x100, NO_DUMP )
 	ROM_FILL(           0x000, 0x100, 0x60) // RTS opcodes work
 ROM_END

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -23,8 +23,6 @@
 #include "emu.h"
 #include "nes_vt369_vtunknown_soc.h"
 
-//#include "machine/eepromser.h"
-
 #include "multibyte.h"
 
 namespace {
@@ -160,7 +158,6 @@ class vt36x_gtct885_state : public vt36x_state
 public:
 	vt36x_gtct885_state(const machine_config& mconfig, device_type type, const char* tag) :
 		vt36x_state(mconfig, type, tag)
-		//m_eeprom(*this, "eeprom")
 	{ }
 
 	void vt36x_8mb_gtct885(machine_config& config);
@@ -169,8 +166,6 @@ private:
 
 	u8 gtct885_prot_r();
 	void gtct885_prot_w(u8 data);
-
-	//required_device<eeprom_serial_93cxx_device> m_eeprom;
 };
 
 class vt36x_tetrtin_state : public vt36x_state
@@ -607,9 +602,6 @@ void vt36x_gtct885_state::vt36x_8mb_gtct885(machine_config& config)
 	vt36x_8mb(config);
 	m_soc->io_4153_read_callback().set(FUNC(vt36x_gtct885_state::gtct885_prot_r));
 	m_soc->io_4152_write_callback().set(FUNC(vt36x_gtct885_state::gtct885_prot_w));
-
-	// doesn't seem to be a standard EEPROM, but whatever is there must supply 0x100 bytes?
-	//EEPROM_93C56_8BIT(config, m_eeprom).default_value(1);
 }
 
 void vt36x_state::vt36x_h12p1000(machine_config& config)
@@ -1036,7 +1028,7 @@ ROM_START( gtct885 )
 	ROM_REGION( 0x800000, "mainrom", 0 )
 	ROM_LOAD( "ct-885 g25q64c.bin", 0x00000, 0x800000, CRC(a5b2b568) SHA1(79de79364fa731e421627ec68e3bfa9d311aa7fc) )
 
-	ROM_REGION( 0x100, "eeprom", 0 ) // data from additional 8-pin chip for protection (might not be an eeprom) (copied to 0xe01 - 0xeff)
+	ROM_REGION( 0x100, "extra", 0 ) // data from additional 8-pin chip for protection (might not be an eeprom) (copied to 0xe01 - 0xeff)
 	ROM_LOAD( "mystery chip.bin", 0x00000, 0x100, CRC(8173c1c2) SHA1(7521a4676166a81a79209638491026b2d8e32895) )
 ROM_END
 
@@ -1438,19 +1430,22 @@ void vt369_state::init_tui240()
 }
 
 
+// unknown protection device supplying ~0x100 bytes of code (currently in "extra" region)
 void vt36x_gtct885_state::gtct885_prot_w(u8 data)
 {
 	logerror("%s: gtct885_prot_w %02x\n", machine().describe_context(), data);
-	//m_eeprom->di_write((data & 0x20) ? 1 : 0);
-	//m_eeprom->cs_write((data & 0x10) ? CLEAR_LINE : ASSERT_LINE);
-	//m_eeprom->clk_write((data & 0x08) ? ASSERT_LINE : CLEAR_LINE);
+	// direction is set to 0x38 before writing here
+	// so 0x20, 0x10, and 0x08 are outputs
+	// some kind of serial device
 }
 
 u8 vt36x_gtct885_state::gtct885_prot_r()
 {
 	logerror("%s: gtct885_prot_r\n", machine().describe_context());
-	u8 bit = 0;//  m_eeprom->do_read();
-	return (bit << 5);
+	// direction is set to 0x18 before reading here
+	// 0x20 is input (gets shifted into carry, then rotated into RAM)
+	u8 bit = 0;
+	return bit << 5;
 }
 
 } // anonymous namespace

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -23,6 +23,8 @@
 #include "emu.h"
 #include "nes_vt369_vtunknown_soc.h"
 
+//#include "machine/eepromser.h"
+
 #include "multibyte.h"
 
 namespace {
@@ -103,7 +105,7 @@ public:
 protected:
 	u8 vt_rom_banked_r(offs_t offset);
 
-	required_device<nes_vt02_vt03_soc_device> m_soc;
+	required_device<vt3xx_soc_base_device> m_soc;
 };
 
 
@@ -148,6 +150,24 @@ public:
 	void vt369_unk_1mb(machine_config& config);
 	void vt369_unk_16mb(machine_config& config);
 	void vt369_unk_32mb(machine_config& config);
+};
+
+class vt36x_gtct885_state : public vt36x_state
+{
+public:
+	vt36x_gtct885_state(const machine_config& mconfig, device_type type, const char* tag) :
+		vt36x_state(mconfig, type, tag)
+		//m_eeprom(*this, "eeprom")
+	{ }
+
+	void vt36x_8mb_gtct885(machine_config& config);
+
+private:
+
+	u8 gtct885_prot_r();
+	void gtct885_prot_w(u8 data);
+
+	//required_device<eeprom_serial_93cxx_device> m_eeprom;
 };
 
 class vt36x_tetrtin_state : public vt36x_state
@@ -558,7 +578,7 @@ void vt36x_state::vt36x_32mb_2banks_lexi(machine_config& config)
 {
 	vt36x_32mb(config);
 	m_soc->set_addrmap(AS_PROGRAM, &vt36x_state::vt_external_space_map_32mbyte_bank);
-	m_soc->set_4150_write_cb().set(FUNC(vt36x_state::extbank_w));
+	m_soc->io_4152_write_callback().set(FUNC(vt36x_state::extbank_w));
 }
 
 void vt36x_state::vt36x_32mb_2banks_lexi300(machine_config& config)
@@ -567,6 +587,17 @@ void vt36x_state::vt36x_32mb_2banks_lexi300(machine_config& config)
 	m_soc->set_addrmap(AS_PROGRAM, &vt36x_state::vt_external_space_map_32mbyte_bank);
 	m_soc->set_411e_write_cb().set(FUNC(vt36x_state::extbank_w)); // could be on 411d
 }
+
+void vt36x_gtct885_state::vt36x_8mb_gtct885(machine_config& config)
+{
+	vt36x_8mb(config);
+	m_soc->io_4153_read_callback().set(FUNC(vt36x_gtct885_state::gtct885_prot_r));
+	m_soc->io_4152_write_callback().set(FUNC(vt36x_gtct885_state::gtct885_prot_w));
+
+	// doesn't seem to be a standard EEPROM, but whatever is there must supply 0x100 bytes?
+	//EEPROM_93C56_8BIT(config, m_eeprom).default_value(1);
+}
+
 
 static INPUT_PORTS_START( vt369 )
 	PORT_START("IO0")
@@ -981,7 +1012,7 @@ ROM_START( gtct885 )
 	ROM_REGION( 0x800000, "mainrom", 0 )
 	ROM_LOAD( "ct-885 g25q64c.bin", 0x00000, 0x800000, CRC(a5b2b568) SHA1(79de79364fa731e421627ec68e3bfa9d311aa7fc) )
 
-	ROM_REGION( 0x100, "extra", 0 ) // data from additional 8-pin chip for protection
+	ROM_REGION( 0x100, "eeprom", 0 ) // data from additional 8-pin chip for protection (might not be an eeprom) (copied to 0xe01 - 0xeff)
 	ROM_LOAD( "mystery chip.bin", 0x00000, 0x100, CRC(8173c1c2) SHA1(7521a4676166a81a79209638491026b2d8e32895) )
 ROM_END
 
@@ -1190,11 +1221,17 @@ both sets have 225 bonus games
 ROM_START( goretrop )
 	ROM_REGION( 0x2000000, "mainrom", 0 )
 	ROM_LOAD( "goretroportable.bin", 0x00000, 0x2000000, CRC(e7279dd3) SHA1(5f096ce22e46f112c2cc6588cb1c527f4f0430b5) )
+
+	ROM_REGION( 0x100, "extra", 0 ) // data from additional 8-pin chip for protection (copied to 0x701 - 0x7ff)
+	ROM_LOAD( "mystery chip.bin", 0x00000, 0x100, NO_DUMP )
 ROM_END
 
 ROM_START( goretropa )
 	ROM_REGION( 0x2000000, "mainrom", 0 )
 	ROM_LOAD( "goretro.bin", 0x00000, 0x2000000, CRC(e2c579cc) SHA1(b5cb8883d1f0b238fc9966ac635583dd5c66bcfe) )
+
+	ROM_REGION( 0x100, "extra", 0 ) // data from additional 8-pin chip for protection (copied to 0x701 - 0x7ff)
+	ROM_LOAD( "mystery chip.bin", 0x00000, 0x100, NO_DUMP )
 ROM_END
 
 ROM_START( s10fake )
@@ -1373,6 +1410,21 @@ void vt369_state::init_tui240()
 	}
 }
 
+
+void vt36x_gtct885_state::gtct885_prot_w(u8 data)
+{
+	logerror("%s: gtct885_prot_w %02x\n", machine().describe_context(), data);
+	//m_eeprom->di_write((data & 0x20) ? 1 : 0);
+	//m_eeprom->cs_write((data & 0x10) ? CLEAR_LINE : ASSERT_LINE);
+	//m_eeprom->clk_write((data & 0x08) ? ASSERT_LINE : CLEAR_LINE);
+}
+
+u8 vt36x_gtct885_state::gtct885_prot_r()
+{
+	logerror("%s: gtct885_prot_r\n", machine().describe_context());
+	u8 bit = 0;//  m_eeprom->do_read();
+	return (bit << 5);
+}
 
 } // anonymous namespace
 
@@ -1573,7 +1625,7 @@ CONS( 201?, unkra200,   mc_tv200, 0,  vt36x_8mb, vt369, vt36x_state, empty_init,
 CONS( 201?, dgun2577,   mc_tv200, 0,  vt36x_8mb, vt369, vt36x_state, empty_init, "dreamGEAR",    "My Arcade Retro Machine 200-in-1 (DGUN-2577)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 CONS( 201?, lxcyber,    mc_tv200, 0,  vt36x_8mb, vt369, vt36x_state, empty_init, "Lexibook",     "Cyber Arcade 200-in-1", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
  // menu is protected with code from extra ROM
-CONS( 201?, gtct885,    mc_tv200, 0,  vt36x_8mb, vt369, vt36x_state, empty_init, "Gaming Tech",  "Gaming Tech CT-885", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+CONS( 201?, gtct885,    mc_tv200, 0,  vt36x_8mb_gtct885, vt369, vt36x_gtct885_state, empty_init, "Gaming Tech",  "Gaming Tech CT-885", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
  // similar to above, but with 40 extra games, menu is protected with code from extra ROM (although RTS opcodes seem to work)
 CONS( 201?, rd5_240,    0,        0,  vt36x_8mb, vt369, vt36x_state, empty_init, "Red5",         "Mini Arcade Machine 240-in-1 (Red5)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -128,7 +128,7 @@ public:
 	void vt36x_32mb_2banks_lexi(machine_config& config);
 	void vt36x_32mb_2banks_lexi300(machine_config& config);
 	void vt36x_h12p1000(machine_config& config);
-	
+
 	void vt36x_swap(machine_config& config);
 	void vt36x_swap_2mb(machine_config& config);
 	void vt36x_swap_4mb(machine_config& config);
@@ -152,7 +152,6 @@ public:
 	void vt369_unk(machine_config& config);
 	void vt369_unk_1mb(machine_config& config);
 	void vt369_unk_16mb(machine_config& config);
-	void vt369_unk_32mb(machine_config& config);
 };
 
 class vt36x_gtct885_state : public vt36x_state
@@ -166,11 +165,25 @@ public:
 	void vt36x_8mb_gtct885(machine_config& config);
 
 private:
-	virtual void machine_start() override ATTR_COLD;
-	virtual void machine_reset() override ATTR_COLD;
-
 	u8 gtct885_prot_r();
 	void gtct885_prot_w(u8 data);
+
+	required_device<vt_menu_protection_device> m_protection;
+};
+
+class vt36x_goretrop_state : public vt36x_state
+{
+public:
+	vt36x_goretrop_state(const machine_config& mconfig, device_type type, const char* tag) :
+		vt36x_state(mconfig, type, tag),
+		m_protection(*this, "protection")
+	{ }
+
+	void vt36x_32mb_goretrop(machine_config& config);
+
+private:
+	u8 goretrop_prot_r();
+	void goretrop_prot_w(u8 data);
 
 	required_device<vt_menu_protection_device> m_protection;
 };
@@ -391,13 +404,6 @@ void vt36x_state::vt369_unk_1mb(machine_config& config)
 	m_soc->set_addrmap(AS_PROGRAM, &vt36x_state::vt_external_space_map_1mbyte);
 }
 
-void vt36x_state::vt369_unk_32mb(machine_config& config)
-{
-	vt369_unk(config);
-	m_soc->set_addrmap(AS_PROGRAM, &vt36x_state::vt_external_space_map_32mbyte);
-}
-
-
 // New mystery handheld architecture, VTxx derived
 void vt36x_state::vt36x(machine_config &config)
 {
@@ -492,16 +498,6 @@ void vt369_base_state::extbank_h12p1000_w(u8 data)
 
 // has an unknown protection device supplying ~0x100 bytes of code (currently in "extra" region)
 
-void vt36x_gtct885_state::machine_start()
-{
-	vt36x_state::machine_start();
-}
-
-void vt36x_gtct885_state::machine_reset()
-{
-	vt36x_state::machine_reset();
-}
-
 void vt36x_gtct885_state::gtct885_prot_w(u8 data)
 {
 	// direction is set to 0x38 before writing here
@@ -518,6 +514,20 @@ u8 vt36x_gtct885_state::gtct885_prot_r()
 	// direction is set to 0x18 before reading here
 	// 0x20 is input (gets shifted into carry, then rotated into RAM)
 	return m_protection->read() ? 0x20 : 0x00;
+}
+
+void vt36x_goretrop_state::goretrop_prot_w(u8 data)
+{
+	// direction is set to 0x0e before writing here
+	m_protection->write_data((data & 0x08) ? true : false);
+	m_protection->write_enable((data & 0x04) ? true : false);
+	m_protection->write_clock((data & 0x02) ? false : true);
+}
+
+u8 vt36x_goretrop_state::goretrop_prot_r()
+{
+	// direction set to 0x06 before reading
+	return (m_protection->read() ? 0x08 : 0x00);
 }
 
 void vt36x_state::vt36x_altswap_32mb_4banks_red5mam(machine_config& config)
@@ -640,6 +650,15 @@ void vt36x_gtct885_state::vt36x_8mb_gtct885(machine_config& config)
 	vt36x_8mb(config);
 	m_soc->io_4153_read_callback().set(FUNC(vt36x_gtct885_state::gtct885_prot_r));
 	m_soc->io_4152_write_callback().set(FUNC(vt36x_gtct885_state::gtct885_prot_w));
+
+	VT_MENU_PROTECTION(config, m_protection, 0);
+}
+
+void vt36x_goretrop_state::vt36x_32mb_goretrop(machine_config& config)
+{
+	vt36x_32mb(config);
+	m_soc->io_4139_read_callback().set(FUNC(vt36x_goretrop_state::goretrop_prot_r));
+	m_soc->io_4139_write_callback().set(FUNC(vt36x_goretrop_state::goretrop_prot_w));
 
 	VT_MENU_PROTECTION(config, m_protection, 0);
 }
@@ -1078,7 +1097,7 @@ ROM_START( rd5_240 )
 
 	ROM_REGION( 0x100, "protection", 0 ) // data from additional 8-pin chip for protection
 	ROM_LOAD( "mystery chip.bin", 0x00000, 0x100, NO_DUMP )
-	ROM_FILL(           0x000, 0x100, 0x60) // RTS opcodes work
+	ROM_FILL( 0x000, 0x100, 0x60) // RTS opcodes work
 ROM_END
 
 ROM_START( myarccn )
@@ -1288,15 +1307,16 @@ ROM_START( goretrop )
 	ROM_REGION( 0x2000000, "mainrom", 0 )
 	ROM_LOAD( "goretroportable.bin", 0x00000, 0x2000000, CRC(e7279dd3) SHA1(5f096ce22e46f112c2cc6588cb1c527f4f0430b5) )
 
-	ROM_REGION( 0x100, "extra", 0 ) // data from additional 8-pin chip for protection (copied to 0x701 - 0x7ff)
+	ROM_REGION( 0x100, "protection", 0 ) // data from additional 8-pin chip for protection (copied to 0x701 - 0x7ff)
 	ROM_LOAD( "mystery chip.bin", 0x00000, 0x100, NO_DUMP )
+	ROM_FILL( 0x000, 0x100, 0x60) // wants actual code here, just RTS opcodes don't work
 ROM_END
 
 ROM_START( goretropa )
 	ROM_REGION( 0x2000000, "mainrom", 0 )
 	ROM_LOAD( "goretro.bin", 0x00000, 0x2000000, CRC(e2c579cc) SHA1(b5cb8883d1f0b238fc9966ac635583dd5c66bcfe) )
 
-	ROM_REGION( 0x100, "extra", 0 ) // data from additional 8-pin chip for protection (copied to 0x701 - 0x7ff)
+	ROM_REGION( 0x100, "protection", 0 ) // data from additional 8-pin chip for protection (copied to 0x701 - 0x7ff)
 	ROM_LOAD( "mystery chip.bin", 0x00000, 0x100, NO_DUMP )
 ROM_END
 
@@ -1747,6 +1767,6 @@ CONS( 2018, rbbrite,    0,        0,  vt369_unk_1mb, vt369, vt36x_state, empty_i
 
 // there's also a 250+ version of the unit below at least
 // has extra protection (using ports at 4138 / 4139, copied to 0x701)
-CONS( 2018, goretrop,  0,         0,  vt369_unk_32mb, vt369, vt36x_state, empty_init,    "Retro-Bit", "Go Retro Portable 260+ Games", MACHINE_NOT_WORKING )
-CONS( 2018, goretropa, goretrop,  0,  vt369_unk_32mb, vt369, vt36x_state, empty_init,    "Retro-Bit", "Go Retro Portable 260+ Games (older)", MACHINE_NOT_WORKING ) // doesn't have commando or higemaru
+CONS( 2018, goretrop,  0,         0,  vt36x_32mb_goretrop, vt369, vt36x_goretrop_state, empty_init,    "Retro-Bit", "Go Retro Portable 260+ Games", MACHINE_NOT_WORKING )
+CONS( 2018, goretropa, goretrop,  0,  vt36x_32mb_goretrop, vt369, vt36x_goretrop_state, empty_init,    "Retro-Bit", "Go Retro Portable 260+ Games (older)", MACHINE_NOT_WORKING ) // doesn't have commando or higemaru
 

--- a/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
@@ -305,7 +305,7 @@ void vt3xx_soc_base_device::vt369_map(address_map &map)
 	//map(0x4138, 0x413d).rw(FUNC(vt3xx_soc_base_device::alu_r), FUNC(vt3xx_soc_base_device::alu_w)); // mirror or 2nd ALU? (probably not, see below)
 
 	map(0x4138, 0x4138).rw(FUNC(vt3xx_soc_base_device::vt_413x_port_direction_r), FUNC(vt3xx_soc_base_device::vt_413x_port_direction_w));
-	map(0x4139, 0x4139).rw(FUNC(vt3xx_soc_base_device::vt_415x_port_in_r), FUNC(vt3xx_soc_base_device::vt_413x_port_out_w));
+	map(0x4139, 0x4139).rw(FUNC(vt3xx_soc_base_device::vt_413x_port_in_r), FUNC(vt3xx_soc_base_device::vt_413x_port_out_w));
 	// 413f is also written, could config the port?
 
 	// 4144

--- a/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
@@ -49,7 +49,9 @@ vt3xx_soc_base_device::vt3xx_soc_base_device(const machine_config& mconfig, devi
 	m_soundram(*this, "soundram"),
 	m_vt369adpcm(*this, "vt369adpcm"),
 	m_leftdac(*this, "leftdac"),
-	m_rightdac(*this, "rightdac")
+	m_rightdac(*this, "rightdac"),
+	m_io_415x_write_callback(*this),
+	m_io_415x_read_callback(*this, 0xff)
 {
 }
 
@@ -306,10 +308,10 @@ void vt3xx_soc_base_device::vt369_map(address_map &map)
 	map(0x414f, 0x414f).r(FUNC(vt3xx_soc_base_device::vt369_414f_r));
 
 	// several games use these addresses for what seem to be extra protection data
-	map(0x4150, 0x4150).rw(FUNC(vt3xx_soc_base_device::extra_rom_prot_4150_r), FUNC(vt3xx_soc_base_device::extra_rom_prot_4150_w));
+	map(0x4150, 0x4150).rw(FUNC(vt3xx_soc_base_device::vt_415x_port_direction_r), FUNC(vt3xx_soc_base_device::vt_415x_port_direction_w));
 	// 4151 also sometimes written
-	map(0x4152, 0x4152).rw(FUNC(vt3xx_soc_base_device::extra_rom_prot_4152_r), FUNC(vt3xx_soc_base_device::extra_rom_prot_4152_w));
-	map(0x4153, 0x4153).r(FUNC(vt3xx_soc_base_device::extra_rom_prot_4153_r)); // extra SPI? / SEEPROM port?
+	map(0x4152, 0x4152).rw(FUNC(vt3xx_soc_base_device::vt_415x_port_out_r), FUNC(vt3xx_soc_base_device::vt_415x_port_out_w));
+	map(0x4153, 0x4153).rw(FUNC(vt3xx_soc_base_device::vt_415x_port_in_r), FUNC(vt3xx_soc_base_device::vt_415x_port_in_w));
 	// 0x4158 is written before the above
 
 	map(0x415c, 0x415c).r(FUNC(vt3xx_soc_base_device::vt369_415c_r)); // related to getting into menus in some games
@@ -370,13 +372,43 @@ void vt3xx_soc_base_device::vt_dma_w(u8 data)
 }
 
 // this reads from the 'extra ROM' area (serial style protocol) and code is copied on gtct885 to e00 in RAM, jumps to it at EDF9: jsr $0e1c
-// extra_rom_prot_4153_r is used by lxccminn, lxccplan and dgun2561 to check battery state instead? reports low battery and does nothing else if unhappy
-u8 vt3xx_soc_base_device::extra_rom_prot_4153_r() { logerror("%s: extra_rom_prot_4153_r (protection? / extra SPI device?)\n", machine().describe_context()); return 0xff; }
+// vt_415x_port_in_r is used by lxccminn, lxccplan and dgun2561 to check battery state instead? reports low battery and does nothing else if unhappy
 // pactin and tetrtin use these for something similar, seems to want code/data for jumps?
-u8 vt3xx_soc_base_device::extra_rom_prot_4150_r() { logerror("%s: extra_rom_prot_4150_r (protection? / extra SPI device?)\n", machine().describe_context()); return machine().rand(); }
-u8 vt3xx_soc_base_device::extra_rom_prot_4152_r() { logerror("%s: extra_rom_prot_4152_r (protection? / extra SPI device?)\n", machine().describe_context()); return machine().rand(); }
-void vt3xx_soc_base_device::extra_rom_prot_4152_w(u8 data) { logerror("%s: extra_rom_prot_4152_w %02x (protection? / extra SPI device?)\n", machine().describe_context(), data); }
-void vt3xx_soc_base_device::extra_rom_prot_4150_w(u8 data) { logerror("%s: extra_rom_prot_4150_w %02x (protection? / extra SPI device?)\n", machine().describe_context(), data); m_4150_write_cb(data); }
+
+// 4150 - direction port (high = write)
+// this gets changed before writes to 4152, or reads from 4153
+u8 vt3xx_soc_base_device::vt_415x_port_direction_r() { logerror("%s: vt_415x_port_direction_r (port 4152/3 direction)\n", machine().describe_context()); return m_415x_port_direction; }
+void vt3xx_soc_base_device::vt_415x_port_direction_w(u8 data) { logerror("%s: vt_415x_port_direction_w %02x (port 4152/3 direction)\n", machine().describe_context(), data); m_415x_port_direction = data; }
+
+// 4152 - write port (can also read last thing written?)
+u8 vt3xx_soc_base_device::vt_415x_port_out_r()
+{
+	// return the last write
+	logerror("%s: vt_415x_port_out_r\n", machine().describe_context());
+	return m_415x_port_data;
+}
+
+void vt3xx_soc_base_device::vt_415x_port_out_w(u8 data)
+{
+	logerror("%s: vt_415x_port_out_w %02x (with direction register %02x)\n", machine().describe_context(), data, m_415x_port_direction);
+	m_415x_port_data = data;
+	// TODO: use direction register
+	m_io_415x_write_callback(data);
+}
+
+// 4153
+u8 vt3xx_soc_base_device::vt_415x_port_in_r()
+{
+	logerror("%s: vt_415x_port_in_r (with direction register %02x)\n", machine().describe_context(), m_415x_port_direction);
+	// TODO: use the direction register
+	return m_io_415x_read_callback();
+}
+
+void vt3xx_soc_base_device::vt_415x_port_in_w(u8 data)
+{
+	// write to the in port, might not exist / not be used at all
+	logerror("%s: vt_415x_port_in_w %02x (writing to input port?!) (with direction register %02x)\n", machine().describe_context(), data, m_415x_port_direction);
+}
 
 void vt3xx_soc_base_device::extra_io_41e6_w(u8 data) { logerror("%s: extra_io_41e6_w %02x (external banking?)\n", machine().describe_context(), data); m_41e6_write_cb(data); }
 
@@ -701,6 +733,9 @@ void vt3xx_soc_base_device::device_start()
 	save_item(NAME(m_sound_adpcm_result));
 	save_item(NAME(m_sound_dac));
 
+	save_item(NAME(m_415x_port_direction));
+	save_item(NAME(m_415x_port_data));
+
 	m_ppu->space(AS_PROGRAM).install_readwrite_handler(0x3c00, 0x3fff, read8sm_delegate(*this, FUNC(vt3xx_soc_base_device::vt3xx_palette_r)), write8sm_delegate(*this, FUNC(vt3xx_soc_base_device::vt3xx_palette_w)));
 }
 
@@ -728,6 +763,9 @@ void vt3xx_soc_base_device::device_reset()
 		m_sound_dac[i] = 0;
 
 	m_sound_timer->adjust(attotime::never);
+
+	m_415x_port_direction = 0x00;
+	m_415x_port_data = 0x00;
 }
 
 
@@ -883,13 +921,15 @@ void vt369_soc_introm_rsps300swap_device::device_start()
 	m_encryption_allowed = true;
 }
 
+/////////
+
 void vt369_soc_introm_vibesswap_device::vibes_411c_w(u8 data)
 {
 	if (m_encryption_allowed)
 	{
 		if (data == 0x05)
 			downcast<rp2a03_core_swap_op_d5_d6&>(*m_maincpu).set_encryption_state(false);
-		else if (data == 0x07 || data == 0x87)
+		else if (data == 0x07 || data == 0x87) // why 0x07 to enable in some cases here?
 			downcast<rp2a03_core_swap_op_d5_d6&>(*m_maincpu).set_encryption_state(true);
 		else
 			logerror("%s: vibes_411c_w %02x (unknown)\n", machine().describe_context(), data);
@@ -901,6 +941,8 @@ void vt369_soc_introm_vibesswap_device::nes_vt_vibes_map(address_map &map)
 	vt3xx_soc_base_device::vt369_map(map);
 	map(0x411c, 0x411c).w(FUNC(vt369_soc_introm_vibesswap_device::vibes_411c_w));
 }
+
+/////////
 
 void vt369_soc_introm_gbox2020_device::gbox_411c_w(u8 data)
 {
@@ -928,6 +970,31 @@ void vt369_soc_introm_gbox2020_device::device_add_mconfig(machine_config& config
 	m_maincpu->set_addrmap(AS_PROGRAM, &vt369_soc_introm_gbox2020_device::nes_vt_gbox_map);
 }
 
+/////////
+
+void vt369_soc_introm_rsps300swap_device::rsps_411c_w(u8 data)
+{
+	if (m_encryption_allowed)
+	{
+		if (data == 0x05)
+			downcast<rp2a03_core_swap_op_d5_d6&>(*m_maincpu).set_encryption_state(false);
+		else
+			logerror("%s: gbox_411c_w %02x (unknown)\n", machine().describe_context(), data);
+	}
+}
+
+void vt369_soc_introm_rsps300swap_device::nes_vt_rsps_map(address_map &map)
+{
+	vt3xx_soc_base_device::vt369_map(map);
+	map(0x411c, 0x411c).w(FUNC(vt369_soc_introm_rsps300swap_device::rsps_411c_w));
+}
+
+void vt369_soc_introm_rsps300swap_device::device_add_mconfig(machine_config& config)
+{
+	vt369_soc_introm_noswap_device::device_add_mconfig(config);
+
+	m_maincpu->set_addrmap(AS_PROGRAM, &vt369_soc_introm_rsps300swap_device::nes_vt_rsps_map);
+}
 
 /***********************************************************************************************************************************************************/
 /* this might also just be the same as vt369 but with the games not using all features */

--- a/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
@@ -51,7 +51,9 @@ vt3xx_soc_base_device::vt3xx_soc_base_device(const machine_config& mconfig, devi
 	m_leftdac(*this, "leftdac"),
 	m_rightdac(*this, "rightdac"),
 	m_io_415x_write_callback(*this),
-	m_io_415x_read_callback(*this, 0xff)
+	m_io_415x_read_callback(*this, 0xff),
+	m_io_413x_write_callback(*this),
+	m_io_413x_read_callback(*this, 0xff)
 {
 }
 
@@ -300,7 +302,11 @@ void vt3xx_soc_base_device::vt369_map(address_map &map)
 
 	// the ALU is not VT1682 compatible
 	map(0x4130, 0x4137).rw(FUNC(vt3xx_soc_base_device::alu_r), FUNC(vt3xx_soc_base_device::alu_w));
-	map(0x4138, 0x413d).rw(FUNC(vt3xx_soc_base_device::alu_r), FUNC(vt3xx_soc_base_device::alu_w)); // mirror or 2nd ALU?
+	//map(0x4138, 0x413d).rw(FUNC(vt3xx_soc_base_device::alu_r), FUNC(vt3xx_soc_base_device::alu_w)); // mirror or 2nd ALU? (probably not, see below)
+
+	map(0x4138, 0x4138).rw(FUNC(vt3xx_soc_base_device::vt_413x_port_direction_r), FUNC(vt3xx_soc_base_device::vt_413x_port_direction_w));
+	map(0x4139, 0x4139).rw(FUNC(vt3xx_soc_base_device::vt_415x_port_in_r), FUNC(vt3xx_soc_base_device::vt_413x_port_out_w));
+	// 413f is also written, could config the port?
 
 	// 4144
 	// 4147
@@ -377,8 +383,17 @@ void vt3xx_soc_base_device::vt_dma_w(u8 data)
 
 // 4150 - direction port (high = write)
 // this gets changed before writes to 4152, or reads from 4153
-u8 vt3xx_soc_base_device::vt_415x_port_direction_r() { logerror("%s: vt_415x_port_direction_r (port 4152/3 direction)\n", machine().describe_context()); return m_415x_port_direction; }
-void vt3xx_soc_base_device::vt_415x_port_direction_w(u8 data) { logerror("%s: vt_415x_port_direction_w %02x (port 4152/3 direction)\n", machine().describe_context(), data); m_415x_port_direction = data; }
+u8 vt3xx_soc_base_device::vt_415x_port_direction_r()
+{
+	logerror("%s: vt_415x_port_direction_r (port 4152/3 direction)\n", machine().describe_context());
+	return m_415x_port_direction;
+}
+
+void vt3xx_soc_base_device::vt_415x_port_direction_w(u8 data)
+{
+	logerror("%s: vt_415x_port_direction_w %02x (port 4152/3 direction)\n", machine().describe_context(), data);
+	m_415x_port_direction = data;
+}
 
 // 4152 - write port (can also read last thing written?)
 u8 vt3xx_soc_base_device::vt_415x_port_out_r()
@@ -409,6 +424,38 @@ void vt3xx_soc_base_device::vt_415x_port_in_w(u8 data)
 	// write to the in port, might not exist / not be used at all
 	logerror("%s: vt_415x_port_in_w %02x (writing to input port?!) (with direction register %02x)\n", machine().describe_context(), data, m_415x_port_direction);
 }
+
+// goretrop seems to use a port with 4138 as direction, and 4139 as data for a similar protection
+
+u8 vt3xx_soc_base_device::vt_413x_port_direction_r()
+{
+	logerror("%s: vt_413x_port_direction_r (port 4139 direction)\n", machine().describe_context());
+	return m_413x_port_direction;
+}
+
+void vt3xx_soc_base_device::vt_413x_port_direction_w(u8 data)
+{
+	logerror("%s: vt_413x_port_direction_w %02x (port 4139 direction)\n", machine().describe_context(), data);
+	m_413x_port_direction = data;
+}
+
+void vt3xx_soc_base_device::vt_413x_port_out_w(u8 data)
+{
+	logerror("%s: vt_413x_port_out_w %02x (with direction register %02x)\n", machine().describe_context(), data, m_413x_port_direction);
+	// TODO: pass direction register
+	m_413x_port_data = data;
+	m_io_413x_write_callback(data & m_413x_port_direction);
+}
+
+u8 vt3xx_soc_base_device::vt_413x_port_in_r()
+{
+	logerror("%s: vt_413x_port_in_r (with direction register %02x)\n", machine().describe_context(), m_413x_port_direction);
+	// TODO: pass the direction register
+	u8 ret = m_io_413x_read_callback();
+	return (ret & ~m_413x_port_direction) | (m_413x_port_data & m_413x_port_direction);
+}
+
+
 
 void vt3xx_soc_base_device::extra_io_41e6_w(u8 data) { logerror("%s: extra_io_41e6_w %02x (external banking?)\n", machine().describe_context(), data); m_41e6_write_cb(data); }
 
@@ -735,6 +782,8 @@ void vt3xx_soc_base_device::device_start()
 
 	save_item(NAME(m_415x_port_direction));
 	save_item(NAME(m_415x_port_data));
+	save_item(NAME(m_413x_port_direction));
+	save_item(NAME(m_413x_port_data));
 
 	m_ppu->space(AS_PROGRAM).install_readwrite_handler(0x3c00, 0x3fff, read8sm_delegate(*this, FUNC(vt3xx_soc_base_device::vt3xx_palette_r)), write8sm_delegate(*this, FUNC(vt3xx_soc_base_device::vt3xx_palette_w)));
 }
@@ -766,6 +815,8 @@ void vt3xx_soc_base_device::device_reset()
 
 	m_415x_port_direction = 0x00;
 	m_415x_port_data = 0x00;
+	m_413x_port_direction = 0x00;
+	m_413x_port_data = 0x00;
 }
 
 

--- a/src/mame/nintendo/nes_vt369_vtunknown_soc.h
+++ b/src/mame/nintendo/nes_vt369_vtunknown_soc.h
@@ -17,7 +17,8 @@ public:
 
 	auto io_4153_read_callback() { return m_io_415x_read_callback.bind(); }
 	auto io_4152_write_callback() { return m_io_415x_write_callback.bind(); }
-
+	auto io_4139_read_callback() { return m_io_413x_read_callback.bind(); }
+	auto io_4139_write_callback() { return m_io_413x_write_callback.bind(); }
 
 protected:
 	vt3xx_soc_base_device(const machine_config& mconfig, device_type type, const char* tag, device_t* owner, u32 clock);
@@ -39,6 +40,11 @@ protected:
 	void vt_415x_port_direction_w(u8 data);
 	void vt_415x_port_out_w(u8 data);
 	void vt_415x_port_in_w(u8 data);
+
+	u8 vt_413x_port_direction_r();
+	void vt_413x_port_direction_w(u8 data);
+	void vt_413x_port_out_w(u8 data);
+	u8 vt_413x_port_in_r();
 
 	void extra_io_41e6_w(u8 data);
 
@@ -102,6 +108,9 @@ private:
 	u8 m_415x_port_direction;
 	u8 m_415x_port_data;
 
+	u8 m_413x_port_direction;
+	u8 m_413x_port_data;
+
 	u16 m_timerperiod;
 	u8 m_timercontrol;
 	u8 m_alu_params[8];
@@ -120,6 +129,8 @@ private:
 	required_device<dac_16bit_r2r_twos_complement_device> m_rightdac;
 	devcb_write8 m_io_415x_write_callback;
 	devcb_read8 m_io_415x_read_callback;
+	devcb_write8 m_io_413x_write_callback;
+	devcb_read8 m_io_413x_read_callback;
 };
 
 class vt369_soc_introm_noswap_device : public vt3xx_soc_base_device

--- a/src/mame/nintendo/nes_vt369_vtunknown_soc.h
+++ b/src/mame/nintendo/nes_vt369_vtunknown_soc.h
@@ -15,6 +15,10 @@ class vt3xx_soc_base_device : public nes_vt02_vt03_soc_device
 public:
 	vt3xx_soc_base_device(const machine_config& mconfig, const char* tag, device_t* owner, u32 clock);
 
+	auto io_4153_read_callback() { return m_io_415x_read_callback.bind(); }
+	auto io_4152_write_callback() { return m_io_415x_write_callback.bind(); }
+
+
 protected:
 	vt3xx_soc_base_device(const machine_config& mconfig, device_type type, const char* tag, device_t* owner, u32 clock);
 
@@ -29,11 +33,12 @@ protected:
 
 	u8 vt369_414f_r();
 
-	u8 extra_rom_prot_4150_r();
-	u8 extra_rom_prot_4152_r();
-	u8 extra_rom_prot_4153_r();
-	void extra_rom_prot_4150_w(u8 data);
-	void extra_rom_prot_4152_w(u8 data);
+	u8 vt_415x_port_direction_r();
+	u8 vt_415x_port_out_r();
+	u8 vt_415x_port_in_r();
+	void vt_415x_port_direction_w(u8 data);
+	void vt_415x_port_out_w(u8 data);
+	void vt_415x_port_in_w(u8 data);
 
 	void extra_io_41e6_w(u8 data);
 
@@ -94,6 +99,9 @@ private:
 	u8 m_bank6000 = 0;
 	u8 m_bank6000_enable = 0;
 
+	u8 m_415x_port_direction;
+	u8 m_415x_port_data;
+
 	u16 m_timerperiod;
 	u8 m_timercontrol;
 	u8 m_alu_params[8];
@@ -110,6 +118,8 @@ private:
 	required_device<vt369_adpcm_decoder_device> m_vt369adpcm;
 	required_device<dac_16bit_r2r_twos_complement_device> m_leftdac;
 	required_device<dac_16bit_r2r_twos_complement_device> m_rightdac;
+	devcb_write8 m_io_415x_write_callback;
+	devcb_read8 m_io_415x_read_callback;
 };
 
 class vt369_soc_introm_noswap_device : public vt3xx_soc_base_device
@@ -196,7 +206,13 @@ public:
 	vt369_soc_introm_rsps300swap_device(const machine_config& mconfig, const char* tag, device_t* owner, u32 clock);
 
 protected:
+	virtual void device_add_mconfig(machine_config& config) override ATTR_COLD;
 	virtual void device_start() override ATTR_COLD;
+
+	void rsps_411c_w(u8 data);
+
+	void nes_vt_rsps_map(address_map &map) ATTR_COLD;
+
 };
 
 class vt3xx_soc_unk_dg_device : public vt3xx_soc_base_device

--- a/src/mame/nintendo/nes_vt_soc.cpp
+++ b/src/mame/nintendo/nes_vt_soc.cpp
@@ -89,7 +89,6 @@ nes_vt02_vt03_soc_device::nes_vt02_vt03_soc_device(const machine_config& mconfig
 	m_initial_e000_bank(0xff),
 	m_ntram(nullptr),
 	m_chrram(nullptr),
-	m_4150_write_cb(*this),
 	m_411e_write_cb(*this),
 	m_41e6_write_cb(*this),
 	m_space_config("program", ENDIANNESS_LITTLE, 8, 25, 0, address_map_constructor(FUNC(nes_vt02_vt03_soc_device::program_map), this)),

--- a/src/mame/nintendo/nes_vt_soc.h
+++ b/src/mame/nintendo/nes_vt_soc.h
@@ -19,7 +19,6 @@ public:
 
 	void vt03_8000_mapper_w(offs_t offset, u8 data);
 
-	auto set_4150_write_cb() { return m_4150_write_cb.bind(); }
 	auto set_411e_write_cb() { return m_411e_write_cb.bind(); }
 	auto set_41e6_write_cb() { return m_41e6_write_cb.bind(); }
 
@@ -139,7 +138,6 @@ protected:
 	std::unique_ptr<u8[]> m_chrram;
 
 
-	devcb_write8 m_4150_write_cb;
 	devcb_write8 m_411e_write_cb;
 	devcb_write8 m_41e6_write_cb;
 

--- a/src/mame/nintendo/vt_menu_protection.cpp
+++ b/src/mame/nintendo/vt_menu_protection.cpp
@@ -55,7 +55,8 @@ void vt_menu_protection_device::write_clock(bool state)
 				{
 					logerror("got command %02x\n", m_command);
 
-					if (m_command == 0x30)
+					// gtct885 uses command 0x30 to read, goretrop uses command 0x20 
+					if ((m_command == 0x30) || (m_command == 0x20))
 					{
 						logerror("(read bytes)\n");
 						m_protectionstate = 2;

--- a/src/mame/nintendo/vt_menu_protection.cpp
+++ b/src/mame/nintendo/vt_menu_protection.cpp
@@ -1,0 +1,116 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+
+#include "emu.h"
+
+#include "vt_menu_protection.h"
+
+DEFINE_DEVICE_TYPE(VT_MENU_PROTECTION, vt_menu_protection_device, "vtmenuprot", "VT Menu Protection")
+
+vt_menu_protection_device::vt_menu_protection_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, VT_MENU_PROTECTION, tag, owner, clock),
+	m_extrarom(*this, DEVICE_SELF)
+{
+}
+
+uint8_t vt_menu_protection_device::read()
+{
+	return m_protlatch;
+}
+
+void vt_menu_protection_device::write_enable(bool state)
+{
+	if (state != m_enable)
+	{
+		if (!state)
+		{
+			m_protectionstate = 1; // ready to get command
+			m_commandbits = 8;
+			logerror("protection state ready\n");
+		}
+		else
+		{
+			m_protectionstate = 0; // device not selected?
+			logerror("protection state deselect\n");
+		}
+	}
+
+	m_enable = state;
+}
+
+void vt_menu_protection_device::write_clock(bool state)
+{
+	if (state != m_clock)
+	{
+		if (state)
+		{
+			if (m_protectionstate == 1)
+			{
+				m_command = (m_command << 1) | (m_data ? 1:0);
+				m_commandbits--;
+
+				logerror("a %02x\n", m_commandbits);
+
+				if (m_commandbits == 0)
+				{
+					logerror("got command %02x\n", m_command);
+
+					if (m_command == 0x30)
+					{
+						logerror("(read bytes)\n");
+						m_protectionstate = 2;
+						m_protreadposition = 0;
+					}
+					else
+					{
+						logerror("(unknown command)\n");
+						m_protectionstate = 0;
+					}
+				}
+			}
+			else if (m_protectionstate == 2)
+			{
+				u8 readbyte = m_extrarom->base()[m_protreadposition >> 3];
+				u8 readbit = readbyte >> (7 - (m_protreadposition & 7));
+				readbit &= 1;
+
+				logerror("reading bit at byte %02x bit %1x (byte is %02x bit read is %1x)\n", m_protreadposition >> 3, m_protreadposition & 7, readbyte, readbit);
+
+				m_protlatch = readbit;
+
+				m_protreadposition++;
+			}
+		}
+	}
+
+	m_clock = state;
+}
+
+void vt_menu_protection_device::write_data(bool state)
+{
+	m_data = state;
+}
+
+void vt_menu_protection_device::device_start()
+{
+	save_item(NAME(m_command));
+	save_item(NAME(m_commandbits));
+	save_item(NAME(m_protectionstate));
+	save_item(NAME(m_protlatch));;
+	save_item(NAME(m_protreadposition));
+	save_item(NAME(m_data));
+	save_item(NAME(m_enable));
+	save_item(NAME(m_clock));
+}
+
+void vt_menu_protection_device::device_reset()
+{
+	m_command = 0;
+	m_commandbits = 0;
+	m_protectionstate = 0;
+	m_protlatch = 0;
+	m_protreadposition = 0;
+	m_data = false;
+	m_enable = false;
+	m_clock = false;
+}

--- a/src/mame/nintendo/vt_menu_protection.h
+++ b/src/mame/nintendo/vt_menu_protection.h
@@ -1,0 +1,39 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+
+#ifndef MAME_NINTENDO_VT_MENU_PROTECTION_H
+#define MAME_NINTENDO_VT_MENU_PROTECTION_H
+
+#pragma once
+
+DECLARE_DEVICE_TYPE(VT_MENU_PROTECTION, vt_menu_protection_device)
+
+
+class vt_menu_protection_device :  public device_t
+{
+public:
+	vt_menu_protection_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	uint8_t read();
+	void write_clock(bool state);
+	void write_data(bool state);
+	void write_enable(bool state);
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+private:
+	u8 m_command;
+	u8 m_commandbits;
+	u8 m_protectionstate;
+	u8 m_protlatch;
+	u16 m_protreadposition;
+	bool m_data;
+	bool m_enable;
+	bool m_state;
+
+	required_memory_region m_extrarom;
+};
+
+#endif // MAME_NINTENDO_VT_MENU_PROTECTION_H

--- a/src/mame/nintendo/vt_menu_protection.h
+++ b/src/mame/nintendo/vt_menu_protection.h
@@ -31,7 +31,6 @@ private:
 	u16 m_protreadposition;
 	bool m_data;
 	bool m_enable;
-	bool m_state;
 
 	required_memory_region m_extrarom;
 };


### PR DESCRIPTION
- nes_vt369_vtunknown attempt to understand the extra port / protection on gtct885 a bit better
- hook up a protection device that allows gtct885 and rd5_240 to boot
- hook up the device to goretro and rbbrite, but they don't work as we lack the code the device supplies
- hook lexibook banking up to the port data write, not the direction write
- added encryption disable for rsps300 type

new NOT WORKING clones
--------------
Vibes Retro Pocket Gamer 240-in-1 (set 2) [Team Europe]