### PR TITLE
netlist: Remove redundant usages of fatal logger

### DIFF
--- a/src/lib/netlist/analog/nld_opamps.cpp
+++ b/src/lib/netlist/analog/nld_opamps.cpp
@@ -119,7 +119,6 @@ namespace netlist
 		{
 			if (m_type < 1 || m_type > 3)
 			{
-				log().fatal(MF_OPAMP_UNKNOWN_TYPE(m_type));
 				throw nl_exception(MF_OPAMP_UNKNOWN_TYPE(m_type));
 			}
 

--- a/src/lib/netlist/core/netlist_state.h
+++ b/src/lib/netlist/core/netlist_state.h
@@ -174,7 +174,6 @@ namespace netlist
 				if (d.first == name)
 				{
 					dev.release();
-					log().fatal(MF_DUPLICATE_NAME_DEVICE_LIST(name));
 					throw nl_exception(MF_DUPLICATE_NAME_DEVICE_LIST(name));
 				}
 			// m_devices.push_back(std::move(dev));

--- a/src/lib/netlist/core/param.h
+++ b/src/lib/netlist/core/param.h
@@ -311,8 +311,6 @@ namespace netlist
 			bool ok = temp.set_from_string(p);
 			if (!ok)
 			{
-				device.state().log().fatal(
-					MF_INVALID_ENUM_CONVERSION_1_2(name, p));
 				throw nl_exception(MF_INVALID_ENUM_CONVERSION_1_2(name, p));
 			}
 			m_param = temp;

--- a/src/lib/netlist/nl_base.cpp
+++ b/src/lib/netlist/nl_base.cpp
@@ -40,7 +40,6 @@ namespace netlist
 			|| plib::dynamic_downcast<const analog_output_t *>(this))
 			return terminal_type::OUTPUT;
 
-		state().log().fatal(MF_UNKNOWN_TYPE_FOR_OBJECT(name()));
 		throw nl_exception(MF_UNKNOWN_TYPE_FOR_OBJECT(name()));
 		// return terminal_type::TERMINAL; // please compiler
 	}
@@ -526,7 +525,6 @@ namespace netlist
 			{
 				if (ret != nullptr)
 				{
-					m_log.fatal(MF_MORE_THAN_ONE_1_DEVICE_FOUND(classname));
 					throw nl_exception(
 						MF_MORE_THAN_ONE_1_DEVICE_FOUND(classname));
 				}
@@ -727,8 +725,6 @@ namespace netlist
 		for (detail::core_terminal_t *t : m_core_terms)
 			if (t == &terminal)
 			{
-				state().log().fatal(
-					MF_NET_1_DUPLICATE_TERMINAL_2(this->name(), t->name()));
 				throw nl_exception(
 					MF_NET_1_DUPLICATE_TERMINAL_2(this->name(), t->name()));
 			}
@@ -761,8 +757,6 @@ namespace netlist
 		for (detail::core_terminal_t *t : core_terms_ref())
 			if (t == &terminal)
 			{
-				state().log().fatal(
-					MF_NET_1_DUPLICATE_TERMINAL_2(this->name(), t->name()));
 				throw nl_exception(
 					MF_NET_1_DUPLICATE_TERMINAL_2(this->name(), t->name()));
 			}
@@ -1011,7 +1005,6 @@ namespace netlist
 		if (plib::dynamic_downcast<const param_ptr_t *>(this))
 			return POINTER;
 
-		state().log().fatal(MF_UNKNOWN_PARAM_TYPE(name()));
 		throw nl_exception(MF_UNKNOWN_PARAM_TYPE(name()));
 	}
 

--- a/src/lib/netlist/nl_factory.cpp
+++ b/src/lib/netlist/nl_factory.cpp
@@ -60,7 +60,6 @@ namespace netlist::factory
 	{
 		if (exists(factory->name()))
 		{
-			m_log.fatal(MF_FACTORY_ALREADY_CONTAINS_1(factory->name()));
 			throw nl_exception(MF_FACTORY_ALREADY_CONTAINS_1(factory->name()));
 		}
 		push_back(std::move(factory));
@@ -74,7 +73,6 @@ namespace netlist::factory
 				return e.get();
 		}
 
-		m_log.fatal(MF_CLASS_1_NOT_FOUND(devname));
 		throw nl_exception(MF_CLASS_1_NOT_FOUND(devname));
 	}
 

--- a/src/lib/netlist/nl_factory.h
+++ b/src/lib/netlist/nl_factory.h
@@ -195,7 +195,7 @@ namespace netlist::factory
 		bool exists(const pstring &name) const noexcept;
 
 	private:
-		log_type &m_log;
+		[[maybe_unused]] log_type &m_log;
 	};
 
 	// -------------------------------------------------------------------------

--- a/src/lib/netlist/nl_parser.cpp
+++ b/src/lib/netlist/nl_parser.cpp
@@ -15,7 +15,6 @@ namespace netlist
 
 	void parser_t::verror(const pstring &msg)
 	{
-		m_setup.log().fatal("{1}", msg);
 		throw nl_exception(plib::pfmt("{1}")(msg));
 	}
 

--- a/src/lib/netlist/nl_setup.cpp
+++ b/src/lib/netlist/nl_setup.cpp
@@ -44,7 +44,6 @@ namespace netlist
 				 .insert({alias, detail::alias_t(type, alias, points_to)})
 				 .second)
 		{
-			log().fatal(MF_ALIAS_ALREAD_EXISTS_1(alias));
 			throw nl_exception(MF_ALIAS_ALREAD_EXISTS_1(alias));
 		}
 	}
@@ -77,8 +76,6 @@ namespace netlist
 		const auto list(plib::psplit(terms, pstring(", ")));
 		if (list.empty() || (list.size() % 2) == 1)
 		{
-			log().fatal(
-				MF_DIP_PINS_MUST_BE_AN_EQUAL_NUMBER_OF_PINS_1(build_fqn("")));
 			throw nl_exception(
 				MF_DIP_PINS_MUST_BE_AN_EQUAL_NUMBER_OF_PINS_1(build_fqn("")));
 		}
@@ -128,7 +125,6 @@ namespace netlist
 		pstring key = build_fqn(name);
 		if (device_exists(key))
 		{
-			log().fatal(MF_DEVICE_ALREADY_EXISTS_1(key));
 			throw nl_exception(MF_DEVICE_ALREADY_EXISTS_1(key));
 		}
 
@@ -150,7 +146,6 @@ namespace netlist
 					{
 						auto err = MF_PARAM_COUNT_MISMATCH_2(
 							name, params_and_connections.size());
-						log().fatal(err);
 						throw nl_exception(err);
 						// break;
 					}
@@ -173,7 +168,6 @@ namespace netlist
 					{
 						auto err = MF_PARAM_COUNT_MISMATCH_2(
 							name, params_and_connections.size());
-						log().fatal(err);
 						throw nl_exception(err);
 					}
 					pstring fully_qualified_name = name + "." + tp;
@@ -190,7 +184,6 @@ namespace netlist
 			{
 				MF_PARAM_COUNT_EXCEEDED_2 err(name,
 											  params_and_connections.size());
-				log().fatal(err);
 				throw nl_exception(err);
 			}
 		}
@@ -204,7 +197,6 @@ namespace netlist
 		const auto name = build_fqn(object_name) + hint_name;
 		if (!m_abstract.m_hints.insert({name, false}).second)
 		{
-			log().fatal(MF_ADDING_HINT_1(name));
 			throw nl_exception(MF_ADDING_HINT_1(name));
 		}
 	}
@@ -220,7 +212,6 @@ namespace netlist
 		const auto list(plib::psplit(terms, pstring(", ")));
 		if (list.size() < 2)
 		{
-			log().fatal(MF_NET_C_NEEDS_AT_LEAST_2_TERMINAL());
 			throw nl_exception(MF_NET_C_NEEDS_AT_LEAST_2_TERMINAL());
 		}
 		for (std::size_t i = 1; i < list.size(); i++)
@@ -235,7 +226,6 @@ namespace netlist
 				[this, &netlist_name](source_netlist_t *src)
 				{ return src->parse(*this, netlist_name); }))
 			return;
-		log().fatal(MF_NOT_FOUND_IN_SOURCE_COLLECTION(netlist_name));
 		throw nl_exception(MF_NOT_FOUND_IN_SOURCE_COLLECTION(netlist_name));
 	}
 
@@ -276,7 +266,6 @@ namespace netlist
 		{
 			if (!m_abstract.m_param_values.insert({fqn, val}).second)
 			{
-				log().fatal(MF_ADDING_PARAMETER_1_TO_PARAMETER_LIST(param));
 				throw nl_exception(
 					MF_ADDING_PARAMETER_1_TO_PARAMETER_LIST(param));
 			}
@@ -351,7 +340,6 @@ namespace netlist
 		}
 		if (!found)
 		{
-			log().fatal(MF_FOUND_NO_OCCURRENCE_OF_1(attach));
 			throw nl_exception(MF_FOUND_NO_OCCURRENCE_OF_1(attach));
 		}
 		register_connection(attach, frontier_name + ".Q");
@@ -481,7 +469,6 @@ namespace netlist
 		}
 		if (!found)
 		{
-			log().fatal(MF_FOUND_NO_OCCURRENCE_OF_1(pin));
 			throw nl_exception(MF_FOUND_NO_OCCURRENCE_OF_1(pin));
 		}
 	}
@@ -595,8 +582,6 @@ namespace netlist
 		log().debug("{1} {2}\n", termtype_as_str(term), term.name());
 		if (!m_terminals.insert({term.name(), &term}).second)
 		{
-			log().fatal(MF_ADDING_1_2_TO_TERMINAL_LIST(termtype_as_str(term),
-													   term.name()));
 			throw nl_exception(MF_ADDING_1_2_TO_TERMINAL_LIST(
 				termtype_as_str(term), term.name()));
 		}
@@ -617,7 +602,6 @@ namespace netlist
 		if (!m_params.insert({param.name(), param_ref_t(param.device(), param)})
 				 .second)
 		{
-			log().fatal(MF_ADDING_PARAMETER_1_TO_PARAMETER_LIST(param.name()));
 			throw nl_exception(
 				MF_ADDING_PARAMETER_1_TO_PARAMETER_LIST(param.name()));
 		}
@@ -721,7 +705,6 @@ namespace netlist
 
 		if (term == nullptr && required)
 		{
-			log().fatal(MF_TERMINAL_1_2_NOT_FOUND(terminal_in, tname));
 			throw nl_exception(MF_TERMINAL_1_2_NOT_FOUND(terminal_in, tname));
 		}
 		if (term != nullptr)
@@ -746,7 +729,6 @@ namespace netlist
 		}
 		if (ret == m_terminals.end() && required)
 		{
-			log().fatal(MF_TERMINAL_1_2_NOT_FOUND(terminal_in, tname));
 			throw nl_exception(MF_TERMINAL_1_2_NOT_FOUND(terminal_in, tname));
 		}
 		detail::core_terminal_t *term = (ret == m_terminals.end()
@@ -757,7 +739,6 @@ namespace netlist
 		{
 			if (required)
 			{
-				log().fatal(MF_OBJECT_1_2_WRONG_TYPE(terminal_in, tname));
 				throw nl_exception(
 					MF_OBJECT_1_2_WRONG_TYPE(terminal_in, tname));
 			}
@@ -776,8 +757,6 @@ namespace netlist
 		auto          ret(m_params.find(resolved_param_name));
 		if (ret == m_params.end())
 		{
-			log().fatal(
-				MF_PARAMETER_1_2_NOT_FOUND(param_in, resolved_param_name));
 			throw nl_exception(
 				MF_PARAMETER_1_2_NOT_FOUND(param_in, resolved_param_name));
 		}
@@ -814,8 +793,6 @@ namespace netlist
 			p->clear_net(); // de-link from all nets ...
 			if (!connect(new_proxy->proxy_term(), *p))
 			{
-				log().fatal(MF_CONNECTING_1_TO_2(new_proxy->proxy_term().name(),
-												 (*p).name()));
 				throw nl_exception(MF_CONNECTING_1_TO_2(
 					new_proxy->proxy_term().name(), (*p).name()));
 			}
@@ -874,8 +851,6 @@ namespace netlist
 					p->clear_net(); // de-link from all nets ...
 					if (!connect(ret->proxy_term(), *p))
 					{
-						log().fatal(MF_CONNECTING_1_TO_2(
-							ret->proxy_term().name(), (*p).name()));
 						throw nl_exception(MF_CONNECTING_1_TO_2(
 							ret->proxy_term().name(), (*p).name()));
 					}
@@ -913,8 +888,6 @@ namespace netlist
 
 		if (this_net.is_rail_net() && other_net.is_rail_net())
 		{
-			log().fatal(
-				MF_MERGE_RAIL_NETS_1_AND_2(this_net.name(), other_net.name()));
 			throw nl_exception(
 				MF_MERGE_RAIL_NETS_1_AND_2(this_net.name(), other_net.name()));
 		}
@@ -936,7 +909,6 @@ namespace netlist
 	{
 		if (input.has_net() && input.net().is_rail_net())
 		{
-			log().fatal(MF_INPUT_1_ALREADY_CONNECTED(input.name()));
 			throw nl_exception(MF_INPUT_1_ALREADY_CONNECTED(input.name()));
 		}
 		if (output.is_analog() && input.is_logic())
@@ -959,8 +931,6 @@ namespace netlist
 				output.net().add_terminal(input);
 			else
 			{
-				log().fatal(
-					ME_TERMINALS_1_2_WITHOUT_NET(input.name(), output.name()));
 				throw nl_exception(
 					ME_TERMINALS_1_2_WITHOUT_NET(input.name(), output.name()));
 			}
@@ -990,7 +960,6 @@ namespace netlist
 		}
 		else
 		{
-			log().fatal(MF_OBJECT_INPUT_TYPE_1(input.name()));
 			throw nl_exception(MF_OBJECT_INPUT_TYPE_1(input.name()));
 		}
 	}
@@ -1028,7 +997,6 @@ namespace netlist
 		}
 		else
 		{
-			log().fatal(MF_OBJECT_OUTPUT_TYPE_1(output.name()));
 			throw nl_exception(MF_OBJECT_OUTPUT_TYPE_1(output.name()));
 		}
 	}
@@ -1259,8 +1227,6 @@ namespace netlist
 				log().warning(MF_CONNECTING_1_TO_2(de_alias(link.first),
 												   de_alias(link.second)));
 
-			log().fatal(
-				MF_LINK_TRIES_EXCEEDED(m_netlist_params->m_max_link_loops()));
 			throw nl_exception(
 				MF_LINK_TRIES_EXCEEDED(m_netlist_params->m_max_link_loops()));
 		}
@@ -1352,7 +1318,6 @@ namespace netlist
 		}
 		if (err)
 		{
-			log().fatal(MF_TERMINALS_WITHOUT_NET());
 			throw nl_exception(MF_TERMINALS_WITHOUT_NET());
 		}
 	}
@@ -1828,7 +1793,6 @@ namespace netlist
 
 		if (error_count > 0)
 		{
-			log().fatal(MF_ERRORS_FOUND(error_count));
 			throw nl_exception(MF_ERRORS_FOUND(error_count));
 		}
 	}

--- a/src/lib/netlist/solver/nld_matrix_solver.cpp
+++ b/src/lib/netlist/solver/nld_matrix_solver.cpp
@@ -184,7 +184,6 @@ namespace netlist::solver
 					}
 					break;
 					case detail::terminal_type::OUTPUT:
-						log().fatal(MF_UNHANDLED_ELEMENT_1_FOUND(p->name()));
 						throw nl_exception(
 							MF_UNHANDLED_ELEMENT_1_FOUND(p->name()));
 				}
@@ -723,7 +722,6 @@ namespace netlist::solver
 			}
 			else
 			{
-				log().fatal(MF_FOUND_TERM_WITH_MISSING_OTHERNET(term->name()));
 				throw nl_exception(
 					MF_FOUND_TERM_WITH_MISSING_OTHERNET(term->name()));
 			}


### PR DESCRIPTION
These loggers were always immediately followed by an exception throw with the very same error message, causing double logging in case of errors.