### PR TITLE
blktiger, blktigera: Added US region description to title

### DIFF
--- a/src/mame/capcom/blktiger.cpp
+++ b/src/mame/capcom/blktiger.cpp
@@ -1065,8 +1065,8 @@ void blktiger_state::init_blktigerb3()
 } // anonymous namespace
 
 
-GAME( 1987, blktiger,   0,        mcu,   blktiger, blktiger_mcu_state, empty_init,      ROT0, "Capcom",  "Black Tiger",                 MACHINE_SUPPORTS_SAVE )
-GAME( 1987, blktigera,  blktiger, mcu,   blktiger, blktiger_mcu_state, empty_init,      ROT0, "Capcom",  "Black Tiger (older)",         MACHINE_SUPPORTS_SAVE )
+GAME( 1987, blktiger,   0,        mcu,   blktiger, blktiger_mcu_state, empty_init,      ROT0, "Capcom",  "Black Tiger (US)",            MACHINE_SUPPORTS_SAVE )
+GAME( 1987, blktigera,  blktiger, mcu,   blktiger, blktiger_mcu_state, empty_init,      ROT0, "Capcom",  "Black Tiger (US, older)",     MACHINE_SUPPORTS_SAVE )
 GAME( 1987, blktigerb1, blktiger, nomcu, blktiger, blktiger_state,     empty_init,      ROT0, "bootleg", "Black Tiger (bootleg set 1)", MACHINE_SUPPORTS_SAVE )
 GAME( 1987, blktigerb2, blktiger, nomcu, blktiger, blktiger_state,     empty_init,      ROT0, "bootleg", "Black Tiger (bootleg set 2)", MACHINE_SUPPORTS_SAVE )
 GAME( 1987, blkdrgon,   blktiger, mcu,   blktiger, blktiger_mcu_state, empty_init,      ROT0, "Capcom",  "Black Dragon (Japan)",        MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
When these games boot up, they show a region warning indicating use only in North America (US and Canada) before going to the attract mode. Hence, the descriptions of these are updated to include the region.