### PR TITLE
netlist: Check for mismatched number of parameters passed to device macros at compile-time 

### DIFF
--- a/src/lib/netlist/build/create_devinc.py
+++ b/src/lib/netlist/build/create_devinc.py
@@ -38,25 +38,21 @@ def process_entry(srcfile, name, params):
     pusage = ""
     pauto = ""
     pcount = 0
-    immediate_params = True
     for x in params.split(","):
         if x.startswith('@'):
             pauto = pauto + ", " + x[1:]
         elif len(x) > 0:
             if x.startswith('+'):
-                immediate_params = False
                 x = x[1:]
-                if x[0].isdigit():
-                    x = '_'+x
             pusage = pusage + ", " + x
             pcount += 1
     print("// usage       : {}(name{})".format(name, pusage))
     if len(pauto) > 0:
         print("// auto connect: {}".format(pauto[2:]))
-    print("#define {}(name{})                                                   \\".format(name, pusage if immediate_params else ", ..."))
-    if pcount > 0 and not immediate_params:
+    print("#define {}(name{})                                                   \\".format(name, ", ..." if pcount > 0 else ""))
+    if pcount > 0:
         print("\t__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == {}, \"{}: Mismatched number of parameters passed, expected {} but got \" PSTRINGIFY(PNARGS(__VA_ARGS__)));) \\".format(pcount, name, pcount))
-    print("\tNET_REGISTER_DEV({}, name{})".format(name, pusage if immediate_params else " __VA_OPT__(,) __VA_ARGS__"))
+    print("\tNET_REGISTER_DEV({}, name{})".format(name, " __VA_OPT__(,) __VA_ARGS__" if pcount > 0 else ""))
     print("")
 
 

--- a/src/lib/netlist/build/create_devinc.py
+++ b/src/lib/netlist/build/create_devinc.py
@@ -18,18 +18,6 @@ if sys.version_info > (3, ):
 
 # globals
 
-linewidth = 100
-tabwidth = 4
-def mac_out(text):
-    global linewidth
-    temp = text.replace('\t'," "*tabwidth)
-    padding = linewidth-len(temp)
-    if padding < 0:
-        linewidth = len(temp)+5
-        padding = 5
-
-    print(text + " "*padding + "\\")
-
 last_src = ""
 
 def process_srcfile(srcfile):
@@ -61,9 +49,9 @@ def process_entry(srcfile, name, params):
     print("// usage       : {}(name{})".format(name, pusage))
     if len(pauto) > 0:
         print("// auto connect: {}".format(pauto[2:]))
-    mac_out("#define {}(name{})".format(name, ", ..." if pcount > 0 else ""))
+    print("#define {}(name{}) \\".format(name, ", ..." if pcount > 0 else ""))
     if pcount > 0:
-        mac_out("\t__VA_OPT__(CHECK_PARAM_COUNT({}, PNARGS(__VA_ARGS__), {}))".format(name, pcount))
+        print("\t__VA_OPT__(NET_CHECK_PARAM_COUNT({}, PNARGS(__VA_ARGS__), {})) \\".format(name, pcount))
     print("\tNET_REGISTER_DEV({}, name{})".format(name, " __VA_OPT__(,) __VA_ARGS__" if pcount > 0 else ""))
     print("")
 
@@ -114,8 +102,8 @@ def file_header():
     print("")
     print("#include \"../nl_setup.h\"")
     print("")
-    print("#define CHECK_PARAM_COUNT(dev, nargs, N) \\")
-    print("\tstatic_assert(nargs == N, #dev\": Mismatched number of parameters passed, expected \" #N \" but got \" #nargs);")
+    print("#define NET_CHECK_PARAM_COUNT(dev, nargs, N) \\")
+    print("\tstatic_assert(nargs == N, #dev\": Mismatched number of parameters passed, expected \" #N \" but got \" PSTRINGIFY(nargs));")
     print("")
 
 def file_footer():

--- a/src/lib/netlist/build/create_devinc.py
+++ b/src/lib/netlist/build/create_devinc.py
@@ -35,20 +35,28 @@ def process_entry_external(srcfile, name):
 
 def process_entry(srcfile, name, params):
     process_srcfile(srcfile)
-    p = re.sub("\+","",params)
-    ps = p.split(",")
     pusage = ""
     pauto = ""
-    for x in ps:
-        if x[0:1] == "@":
+    pcount = 0
+    immediate_params = True
+    for x in params.split(","):
+        if x.startswith('@'):
             pauto = pauto + ", " + x[1:]
-        else:
+        elif len(x) > 0:
+            if x.startswith('+'):
+                immediate_params = False
+                x = x[1:]
+                if x[0].isdigit():
+                    x = '_'+x
             pusage = pusage + ", " + x
+            pcount += 1
     print("// usage       : {}(name{})".format(name, pusage))
     if len(pauto) > 0:
         print("// auto connect: {}".format(pauto[2:]))
-    print("#define {}(...)                                                   \\".format(name))
-    print("\tNET_REGISTER_DEVEXT({}, __VA_ARGS__)".format(name))
+    print("#define {}(name{})                                                   \\".format(name, pusage if immediate_params else ", ..."))
+    if pcount > 0 and not immediate_params:
+        print("\t__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == {}, \"{}: Mismatched number of parameters passed, expected {} but got \" PSTRINGIFY(PNARGS(__VA_ARGS__)));) \\".format(pcount, name, pcount))
+    print("\tNET_REGISTER_DEV({}, name{})".format(name, pusage if immediate_params else " __VA_OPT__(,) __VA_ARGS__"))
     print("")
 
 

--- a/src/lib/netlist/build/create_devinc.py
+++ b/src/lib/netlist/build/create_devinc.py
@@ -18,6 +18,18 @@ if sys.version_info > (3, ):
 
 # globals
 
+linewidth = 100
+tabwidth = 4
+def mac_out(text):
+    global linewidth
+    temp = text.replace('\t'," "*tabwidth)
+    padding = linewidth-len(temp)
+    if padding < 0:
+        linewidth = len(temp)+5
+        padding = 5
+
+    print(text + " "*padding + "\\")
+
 last_src = ""
 
 def process_srcfile(srcfile):
@@ -49,9 +61,9 @@ def process_entry(srcfile, name, params):
     print("// usage       : {}(name{})".format(name, pusage))
     if len(pauto) > 0:
         print("// auto connect: {}".format(pauto[2:]))
-    print("#define {}(name{})                                                   \\".format(name, ", ..." if pcount > 0 else ""))
+    mac_out("#define {}(name{})".format(name, ", ..." if pcount > 0 else ""))
     if pcount > 0:
-        print("\t__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == {}, \"{}: Mismatched number of parameters passed, expected {} but got \" PSTRINGIFY(PNARGS(__VA_ARGS__)));) \\".format(pcount, name, pcount))
+        mac_out("\t__VA_OPT__(CHECK_PARAM_COUNT({}, PNARGS(__VA_ARGS__), {}))".format(name, pcount))
     print("\tNET_REGISTER_DEV({}, name{})".format(name, " __VA_OPT__(,) __VA_ARGS__" if pcount > 0 else ""))
     print("")
 
@@ -101,6 +113,9 @@ def file_header():
     print("#ifndef __PLIB_PREPROCESSOR__\n")
     print("")
     print("#include \"../nl_setup.h\"")
+    print("")
+    print("#define CHECK_PARAM_COUNT(dev, nargs, N) \\")
+    print("\tstatic_assert(nargs == N, #dev\": Mismatched number of parameters passed, expected \" #N \" but got \" #nargs);")
     print("")
 
 def file_footer():

--- a/src/lib/netlist/generated/nld_devinc.h
+++ b/src/lib/netlist/generated/nld_devinc.h
@@ -9,21 +9,21 @@
 
 #include "../nl_setup.h"
 
-#define CHECK_PARAM_COUNT(dev, nargs, N) \
-	static_assert(nargs == N, #dev": Mismatched number of parameters passed, expected " #N " but got " #nargs);
+#define NET_CHECK_PARAM_COUNT(dev, nargs, N) \
+	static_assert(nargs == N, #dev": Mismatched number of parameters passed, expected " #N " but got " PSTRINGIFY(nargs));
 
 // ---------------------------------------------------------------------
 // Source: ../analog/nld_bjt.cpp
 // ---------------------------------------------------------------------
 
 // usage       : QBJT_EB(name, MODEL)
-#define QBJT_EB(name, ...)                                                                          \
-	__VA_OPT__(CHECK_PARAM_COUNT(QBJT_EB, PNARGS(__VA_ARGS__), 1))                                  \
+#define QBJT_EB(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(QBJT_EB, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(QBJT_EB, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : QBJT_SW(name, MODEL)
-#define QBJT_SW(name, ...)                                                                          \
-	__VA_OPT__(CHECK_PARAM_COUNT(QBJT_SW, PNARGS(__VA_ARGS__), 1))                                  \
+#define QBJT_SW(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(QBJT_SW, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(QBJT_SW, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -31,8 +31,8 @@
 // ---------------------------------------------------------------------
 
 // usage       : MOSFET(name, MODEL)
-#define MOSFET(name, ...)                                                                           \
-	__VA_OPT__(CHECK_PARAM_COUNT(MOSFET, PNARGS(__VA_ARGS__), 1))                                   \
+#define MOSFET(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(MOSFET, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(MOSFET, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -40,8 +40,8 @@
 // ---------------------------------------------------------------------
 
 // usage       : OPAMP(name, MODEL)
-#define OPAMP(name, ...)                                                                            \
-	__VA_OPT__(CHECK_PARAM_COUNT(OPAMP, PNARGS(__VA_ARGS__), 1))                                    \
+#define OPAMP(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(OPAMP, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(OPAMP, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -49,11 +49,11 @@
 // ---------------------------------------------------------------------
 
 // usage       : SWITCH(name)
-#define SWITCH(name)                                                                                \
+#define SWITCH(name) \
 	NET_REGISTER_DEV(SWITCH, name)
 
 // usage       : SWITCH2(name)
-#define SWITCH2(name)                                                                               \
+#define SWITCH2(name) \
 	NET_REGISTER_DEV(SWITCH2, name)
 
 // ---------------------------------------------------------------------
@@ -61,27 +61,27 @@
 // ---------------------------------------------------------------------
 
 // usage       : VCVS(name, G)
-#define VCVS(name, ...)                                                                             \
-	__VA_OPT__(CHECK_PARAM_COUNT(VCVS, PNARGS(__VA_ARGS__), 1))                                     \
+#define VCVS(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(VCVS, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(VCVS, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : VCCS(name, G)
-#define VCCS(name, ...)                                                                             \
-	__VA_OPT__(CHECK_PARAM_COUNT(VCCS, PNARGS(__VA_ARGS__), 1))                                     \
+#define VCCS(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(VCCS, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(VCCS, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CCCS(name, G)
-#define CCCS(name, ...)                                                                             \
-	__VA_OPT__(CHECK_PARAM_COUNT(CCCS, PNARGS(__VA_ARGS__), 1))                                     \
+#define CCCS(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(CCCS, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(CCCS, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CCVS(name, G)
-#define CCVS(name, ...)                                                                             \
-	__VA_OPT__(CHECK_PARAM_COUNT(CCVS, PNARGS(__VA_ARGS__), 1))                                     \
+#define CCVS(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(CCVS, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(CCVS, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : LVCCS(name)
-#define LVCCS(name)                                                                                 \
+#define LVCCS(name) \
 	NET_REGISTER_DEV(LVCCS, name)
 
 // ---------------------------------------------------------------------
@@ -89,48 +89,48 @@
 // ---------------------------------------------------------------------
 
 // usage       : RES(name, R)
-#define RES(name, ...)                                                                              \
-	__VA_OPT__(CHECK_PARAM_COUNT(RES, PNARGS(__VA_ARGS__), 1))                                      \
+#define RES(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(RES, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(RES, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : POT(name, R)
-#define POT(name, ...)                                                                              \
-	__VA_OPT__(CHECK_PARAM_COUNT(POT, PNARGS(__VA_ARGS__), 1))                                      \
+#define POT(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(POT, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(POT, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : POT2(name, R)
-#define POT2(name, ...)                                                                             \
-	__VA_OPT__(CHECK_PARAM_COUNT(POT2, PNARGS(__VA_ARGS__), 1))                                     \
+#define POT2(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(POT2, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(POT2, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CAP(name, C)
-#define CAP(name, ...)                                                                              \
-	__VA_OPT__(CHECK_PARAM_COUNT(CAP, PNARGS(__VA_ARGS__), 1))                                      \
+#define CAP(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(CAP, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(CAP, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : IND(name, L)
-#define IND(name, ...)                                                                              \
-	__VA_OPT__(CHECK_PARAM_COUNT(IND, PNARGS(__VA_ARGS__), 1))                                      \
+#define IND(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(IND, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(IND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : DIODE(name, MODEL)
-#define DIODE(name, ...)                                                                            \
-	__VA_OPT__(CHECK_PARAM_COUNT(DIODE, PNARGS(__VA_ARGS__), 1))                                    \
+#define DIODE(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(DIODE, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(DIODE, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : ZDIODE(name, MODEL)
-#define ZDIODE(name, ...)                                                                           \
-	__VA_OPT__(CHECK_PARAM_COUNT(ZDIODE, PNARGS(__VA_ARGS__), 1))                                   \
+#define ZDIODE(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(ZDIODE, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(ZDIODE, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : VS(name, V)
-#define VS(name, ...)                                                                               \
-	__VA_OPT__(CHECK_PARAM_COUNT(VS, PNARGS(__VA_ARGS__), 1))                                       \
+#define VS(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(VS, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(VS, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CS(name, I)
-#define CS(name, ...)                                                                               \
-	__VA_OPT__(CHECK_PARAM_COUNT(CS, PNARGS(__VA_ARGS__), 1))                                       \
+#define CS(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(CS, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(CS, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -139,8 +139,8 @@
 
 // usage       : RAM_2102A(name, CEQ, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, RWQ, DI)
 // auto connect: VCC, GND
-#define RAM_2102A(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(RAM_2102A, PNARGS(__VA_ARGS__), 13))                               \
+#define RAM_2102A(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(RAM_2102A, PNARGS(__VA_ARGS__), 13)) \
 	NET_REGISTER_DEV(RAM_2102A, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -149,8 +149,8 @@
 
 // usage       : CD4006(name, CLOCK, D1, D2, D3, D4, D1P4, D1P4S, D2P4, D2P5, D3P4, D4P4, D4P5)
 // auto connect: VCC, GND
-#define CD4006(name, ...)                                                                           \
-	__VA_OPT__(CHECK_PARAM_COUNT(CD4006, PNARGS(__VA_ARGS__), 12))                                  \
+#define CD4006(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(CD4006, PNARGS(__VA_ARGS__), 12)) \
 	NET_REGISTER_DEV(CD4006, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -159,8 +159,8 @@
 
 // usage       : CD4013(name, CLOCK, DATA, RESET, SET)
 // auto connect: VDD, VSS
-#define CD4013(name, ...)                                                                           \
-	__VA_OPT__(CHECK_PARAM_COUNT(CD4013, PNARGS(__VA_ARGS__), 4))                                   \
+#define CD4013(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(CD4013, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(CD4013, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -168,11 +168,11 @@
 // ---------------------------------------------------------------------
 
 // usage       : CD4017(name)
-#define CD4017(name)                                                                                \
+#define CD4017(name) \
 	NET_REGISTER_DEV(CD4017, name)
 
 // usage       : CD4022(name)
-#define CD4022(name)                                                                                \
+#define CD4022(name) \
 	NET_REGISTER_DEV(CD4022, name)
 
 // ---------------------------------------------------------------------
@@ -180,12 +180,12 @@
 // ---------------------------------------------------------------------
 
 // usage       : CD4020(name, IP, RESET, VDD, VSS)
-#define CD4020(name, ...)                                                                           \
-	__VA_OPT__(CHECK_PARAM_COUNT(CD4020, PNARGS(__VA_ARGS__), 4))                                   \
+#define CD4020(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(CD4020, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(CD4020, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CD4024(name)
-#define CD4024(name)                                                                                \
+#define CD4024(name) \
 	NET_REGISTER_DEV(CD4024, name)
 
 // ---------------------------------------------------------------------
@@ -194,8 +194,8 @@
 
 // usage       : CD4029(name, PE, J1, J2, J3, J4, CI, UD, BD, CLK)
 // auto connect: VCC, GND
-#define CD4029(name, ...)                                                                           \
-	__VA_OPT__(CHECK_PARAM_COUNT(CD4029, PNARGS(__VA_ARGS__), 9))                                   \
+#define CD4029(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(CD4029, PNARGS(__VA_ARGS__), 9)) \
 	NET_REGISTER_DEV(CD4029, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -204,8 +204,8 @@
 
 // usage       : CD4042(name, D1, D2, D3, D4, POL, CLK)
 // auto connect: VCC, GND
-#define CD4042(name, ...)                                                                           \
-	__VA_OPT__(CHECK_PARAM_COUNT(CD4042, PNARGS(__VA_ARGS__), 6))                                   \
+#define CD4042(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(CD4042, PNARGS(__VA_ARGS__), 6)) \
 	NET_REGISTER_DEV(CD4042, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -213,7 +213,7 @@
 // ---------------------------------------------------------------------
 
 // usage       : CD4053_GATE(name)
-#define CD4053_GATE(name)                                                                           \
+#define CD4053_GATE(name) \
 	NET_REGISTER_DEV(CD4053_GATE, name)
 
 // ---------------------------------------------------------------------
@@ -221,7 +221,7 @@
 // ---------------------------------------------------------------------
 
 // usage       : CD4066_GATE(name)
-#define CD4066_GATE(name)                                                                           \
+#define CD4066_GATE(name) \
 	NET_REGISTER_DEV(CD4066_GATE, name)
 
 // ---------------------------------------------------------------------
@@ -230,8 +230,8 @@
 
 // usage       : CD4076(name, I1, I2, I3, I4, ID1, ID2, OD1, OD2)
 // auto connect: VCC, GND
-#define CD4076(name, ...)                                                                           \
-	__VA_OPT__(CHECK_PARAM_COUNT(CD4076, PNARGS(__VA_ARGS__), 8))                                   \
+#define CD4076(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(CD4076, PNARGS(__VA_ARGS__), 8)) \
 	NET_REGISTER_DEV(CD4076, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -239,7 +239,7 @@
 // ---------------------------------------------------------------------
 
 // usage       : CD4316_GATE(name)
-#define CD4316_GATE(name)                                                                           \
+#define CD4316_GATE(name) \
 	NET_REGISTER_DEV(CD4316_GATE, name)
 
 // ---------------------------------------------------------------------
@@ -248,14 +248,14 @@
 
 // usage       : TTL_74107(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74107(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74107, PNARGS(__VA_ARGS__), 4))                                \
+#define TTL_74107(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74107, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(TTL_74107, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_74107A(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74107A(name, ...)                                                                       \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74107A, PNARGS(__VA_ARGS__), 4))                               \
+#define TTL_74107A(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74107A, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(TTL_74107A, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -264,14 +264,14 @@
 
 // usage       : TTL_74113(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74113(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74113, PNARGS(__VA_ARGS__), 4))                                \
+#define TTL_74113(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74113, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(TTL_74113, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_74113A(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74113A(name, ...)                                                                       \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74113A, PNARGS(__VA_ARGS__), 4))                               \
+#define TTL_74113A(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74113A, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(TTL_74113A, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -279,19 +279,19 @@
 // ---------------------------------------------------------------------
 
 // usage       : TTL_74123(name)
-#define TTL_74123(name)                                                                             \
+#define TTL_74123(name) \
 	NET_REGISTER_DEV(TTL_74123, name)
 
 // usage       : TTL_74121(name)
-#define TTL_74121(name)                                                                             \
+#define TTL_74121(name) \
 	NET_REGISTER_DEV(TTL_74121, name)
 
 // usage       : CD4538(name)
-#define CD4538(name)                                                                                \
+#define CD4538(name) \
 	NET_REGISTER_DEV(CD4538, name)
 
 // usage       : TTL_9602(name)
-#define TTL_9602(name)                                                                              \
+#define TTL_9602(name) \
 	NET_REGISTER_DEV(TTL_9602, name)
 
 // ---------------------------------------------------------------------
@@ -299,11 +299,11 @@
 // ---------------------------------------------------------------------
 
 // usage       : TTL_74125_GATE(name)
-#define TTL_74125_GATE(name)                                                                        \
+#define TTL_74125_GATE(name) \
 	NET_REGISTER_DEV(TTL_74125_GATE, name)
 
 // usage       : TTL_74126_GATE(name)
-#define TTL_74126_GATE(name)                                                                        \
+#define TTL_74126_GATE(name) \
 	NET_REGISTER_DEV(TTL_74126_GATE, name)
 
 // ---------------------------------------------------------------------
@@ -312,8 +312,8 @@
 
 // usage       : TTL_74153(name, C0, C1, C2, C3, A, B, G)
 // auto connect: VCC, GND
-#define TTL_74153(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74153, PNARGS(__VA_ARGS__), 7))                                \
+#define TTL_74153(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74153, PNARGS(__VA_ARGS__), 7)) \
 	NET_REGISTER_DEV(TTL_74153, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -322,14 +322,14 @@
 
 // usage       : TTL_74161(name, CLK, ENP, ENT, CLRQ, LOADQ, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_74161(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74161, PNARGS(__VA_ARGS__), 9))                                \
+#define TTL_74161(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74161, PNARGS(__VA_ARGS__), 9)) \
 	NET_REGISTER_DEV(TTL_74161, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_74161_FIXME(name, A, B, C, D, CLRQ, LOADQ, CLK, ENP, ENT)
 // auto connect: VCC, GND
-#define TTL_74161_FIXME(name, ...)                                                                  \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74161_FIXME, PNARGS(__VA_ARGS__), 9))                          \
+#define TTL_74161_FIXME(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74161_FIXME, PNARGS(__VA_ARGS__), 9)) \
 	NET_REGISTER_DEV(TTL_74161_FIXME, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -338,8 +338,8 @@
 
 // usage       : TTL_74163(name, CLK, ENP, ENT, CLRQ, LOADQ, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_74163(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74163, PNARGS(__VA_ARGS__), 9))                                \
+#define TTL_74163(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74163, PNARGS(__VA_ARGS__), 9)) \
 	NET_REGISTER_DEV(TTL_74163, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -348,8 +348,8 @@
 
 // usage       : TTL_74164(name, A, B, CLRQ, CLK)
 // auto connect: VCC, GND
-#define TTL_74164(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74164, PNARGS(__VA_ARGS__), 4))                                \
+#define TTL_74164(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74164, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(TTL_74164, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -358,8 +358,8 @@
 
 // usage       : TTL_74165(name, CLK, CLKINH, SH_LDQ, SER, A, B, C, D, E, F, G, H)
 // auto connect: VCC, GND
-#define TTL_74165(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74165, PNARGS(__VA_ARGS__), 12))                               \
+#define TTL_74165(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74165, PNARGS(__VA_ARGS__), 12)) \
 	NET_REGISTER_DEV(TTL_74165, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -368,8 +368,8 @@
 
 // usage       : TTL_74166(name, CLK, CLKINH, SH_LDQ, SER, A, B, C, D, E, F, G, H, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74166(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74166, PNARGS(__VA_ARGS__), 13))                               \
+#define TTL_74166(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74166, PNARGS(__VA_ARGS__), 13)) \
 	NET_REGISTER_DEV(TTL_74166, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -378,8 +378,8 @@
 
 // usage       : TTL_74174(name, CLK, D1, D2, D3, D4, D5, D6, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74174(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74174, PNARGS(__VA_ARGS__), 8))                                \
+#define TTL_74174(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74174, PNARGS(__VA_ARGS__), 8)) \
 	NET_REGISTER_DEV(TTL_74174, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -388,8 +388,8 @@
 
 // usage       : TTL_74175(name, CLK, D1, D2, D3, D4, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74175(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74175, PNARGS(__VA_ARGS__), 6))                                \
+#define TTL_74175(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74175, PNARGS(__VA_ARGS__), 6)) \
 	NET_REGISTER_DEV(TTL_74175, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -398,8 +398,8 @@
 
 // usage       : TTL_74192(name, A, B, C, D, CLEAR, LOADQ, CU, CD)
 // auto connect: VCC, GND
-#define TTL_74192(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74192, PNARGS(__VA_ARGS__), 8))                                \
+#define TTL_74192(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74192, PNARGS(__VA_ARGS__), 8)) \
 	NET_REGISTER_DEV(TTL_74192, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -408,8 +408,8 @@
 
 // usage       : TTL_74193(name, A, B, C, D, CLEAR, LOADQ, CU, CD)
 // auto connect: VCC, GND
-#define TTL_74193(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74193, PNARGS(__VA_ARGS__), 8))                                \
+#define TTL_74193(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74193, PNARGS(__VA_ARGS__), 8)) \
 	NET_REGISTER_DEV(TTL_74193, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -418,8 +418,8 @@
 
 // usage       : TTL_74194(name, CLK, S0, S1, SRIN, A, B, C, D, SLIN, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74194(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74194, PNARGS(__VA_ARGS__), 10))                               \
+#define TTL_74194(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74194, PNARGS(__VA_ARGS__), 10)) \
 	NET_REGISTER_DEV(TTL_74194, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -428,8 +428,8 @@
 
 // usage       : TTL_74365(name, G1Q, G2Q, A1, A2, A3, A4, A5, A6)
 // auto connect: VCC, GND
-#define TTL_74365(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74365, PNARGS(__VA_ARGS__), 8))                                \
+#define TTL_74365(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74365, PNARGS(__VA_ARGS__), 8)) \
 	NET_REGISTER_DEV(TTL_74365, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -437,7 +437,7 @@
 // ---------------------------------------------------------------------
 
 // usage       : TTL_74377_GATE(name)
-#define TTL_74377_GATE(name)                                                                        \
+#define TTL_74377_GATE(name) \
 	NET_REGISTER_DEV(TTL_74377_GATE, name)
 
 // ---------------------------------------------------------------------
@@ -446,8 +446,8 @@
 
 // usage       : TTL_74393(name, CP, MR)
 // auto connect: VCC, GND
-#define TTL_74393(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74393, PNARGS(__VA_ARGS__), 2))                                \
+#define TTL_74393(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74393, PNARGS(__VA_ARGS__), 2)) \
 	NET_REGISTER_DEV(TTL_74393, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -456,8 +456,8 @@
 
 // usage       : TTL_7448(name, A, B, C, D, LTQ, BIQ, RBIQ)
 // auto connect: VCC, GND
-#define TTL_7448(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7448, PNARGS(__VA_ARGS__), 7))                                 \
+#define TTL_7448(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7448, PNARGS(__VA_ARGS__), 7)) \
 	NET_REGISTER_DEV(TTL_7448, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -466,8 +466,8 @@
 
 // usage       : TTL_7450_ANDORINVERT(name, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_7450_ANDORINVERT(name, ...)                                                             \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7450_ANDORINVERT, PNARGS(__VA_ARGS__), 4))                     \
+#define TTL_7450_ANDORINVERT(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7450_ANDORINVERT, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(TTL_7450_ANDORINVERT, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -476,14 +476,14 @@
 
 // usage       : TTL_7473(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_7473(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7473, PNARGS(__VA_ARGS__), 4))                                 \
+#define TTL_7473(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7473, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(TTL_7473, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7473A(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_7473A(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7473A, PNARGS(__VA_ARGS__), 4))                                \
+#define TTL_7473A(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7473A, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(TTL_7473A, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -492,8 +492,8 @@
 
 // usage       : TTL_7474(name, CLK, D, CLRQ, PREQ)
 // auto connect: VCC, GND
-#define TTL_7474(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7474, PNARGS(__VA_ARGS__), 4))                                 \
+#define TTL_7474(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7474, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(TTL_7474, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -501,11 +501,11 @@
 // ---------------------------------------------------------------------
 
 // usage       : TTL_7475_GATE(name)
-#define TTL_7475_GATE(name)                                                                         \
+#define TTL_7475_GATE(name) \
 	NET_REGISTER_DEV(TTL_7475_GATE, name)
 
 // usage       : TTL_7477_GATE(name)
-#define TTL_7477_GATE(name)                                                                         \
+#define TTL_7477_GATE(name) \
 	NET_REGISTER_DEV(TTL_7477_GATE, name)
 
 // ---------------------------------------------------------------------
@@ -514,8 +514,8 @@
 
 // usage       : TTL_7483(name, A1, A2, A3, A4, B1, B2, B3, B4, C0)
 // auto connect: VCC, GND
-#define TTL_7483(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7483, PNARGS(__VA_ARGS__), 9))                                 \
+#define TTL_7483(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7483, PNARGS(__VA_ARGS__), 9)) \
 	NET_REGISTER_DEV(TTL_7483, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -524,8 +524,8 @@
 
 // usage       : TTL_7485(name, A0, A1, A2, A3, B0, B1, B2, B3, LTIN, EQIN, GTIN)
 // auto connect: VCC, GND
-#define TTL_7485(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7485, PNARGS(__VA_ARGS__), 11))                                \
+#define TTL_7485(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7485, PNARGS(__VA_ARGS__), 11)) \
 	NET_REGISTER_DEV(TTL_7485, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -534,8 +534,8 @@
 
 // usage       : TTL_7490(name, A, B, R1, R2, R91, R92)
 // auto connect: VCC, GND
-#define TTL_7490(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7490, PNARGS(__VA_ARGS__), 6))                                 \
+#define TTL_7490(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7490, PNARGS(__VA_ARGS__), 6)) \
 	NET_REGISTER_DEV(TTL_7490, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -544,8 +544,8 @@
 
 // usage       : TTL_7492(name, A, B, R1, R2)
 // auto connect: VCC, GND
-#define TTL_7492(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7492, PNARGS(__VA_ARGS__), 4))                                 \
+#define TTL_7492(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7492, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(TTL_7492, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -554,8 +554,8 @@
 
 // usage       : TTL_7493(name, CLKA, CLKB, R1, R2)
 // auto connect: VCC, GND
-#define TTL_7493(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7493, PNARGS(__VA_ARGS__), 4))                                 \
+#define TTL_7493(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7493, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(TTL_7493, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -564,8 +564,8 @@
 
 // usage       : TTL_7497(name, CLK, STRBQ, ENQ, UNITYQ, CLR, B0, B1, B2, B3, B4, B5)
 // auto connect: VCC, GND
-#define TTL_7497(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7497, PNARGS(__VA_ARGS__), 11))                                \
+#define TTL_7497(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7497, PNARGS(__VA_ARGS__), 11)) \
 	NET_REGISTER_DEV(TTL_7497, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -574,8 +574,8 @@
 
 // usage       : SN74LS629(name, CAP)
 // auto connect: VCC, GND
-#define SN74LS629(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(SN74LS629, PNARGS(__VA_ARGS__), 1))                                \
+#define SN74LS629(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(SN74LS629, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(SN74LS629, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -584,8 +584,8 @@
 
 // usage       : TTL_8277(name, RESET, CLK, CLKA, D0A, D1A, DSA, CLKB, D0B, D1B, DSB)
 // auto connect: VCC, GND
-#define TTL_8277(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_8277, PNARGS(__VA_ARGS__), 10))                                \
+#define TTL_8277(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_8277, PNARGS(__VA_ARGS__), 10)) \
 	NET_REGISTER_DEV(TTL_8277, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -594,8 +594,8 @@
 
 // usage       : PROM_82S115(name, CE1Q, CE2, A0, A1, A2, A3, A4, A5, A6, A7, A8, STROBE)
 // auto connect: VCC, GND
-#define PROM_82S115(name, ...)                                                                      \
-	__VA_OPT__(CHECK_PARAM_COUNT(PROM_82S115, PNARGS(__VA_ARGS__), 12))                             \
+#define PROM_82S115(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(PROM_82S115, PNARGS(__VA_ARGS__), 12)) \
 	NET_REGISTER_DEV(PROM_82S115, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -603,7 +603,7 @@
 // ---------------------------------------------------------------------
 
 // usage       : TTL_82S16(name)
-#define TTL_82S16(name)                                                                             \
+#define TTL_82S16(name) \
 	NET_REGISTER_DEV(TTL_82S16, name)
 
 // ---------------------------------------------------------------------
@@ -612,8 +612,8 @@
 
 // usage       : TTL_9310(name, CLK, ENP, ENT, CLRQ, LOADQ, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_9310(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_9310, PNARGS(__VA_ARGS__), 9))                                 \
+#define TTL_9310(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_9310, PNARGS(__VA_ARGS__), 9)) \
 	NET_REGISTER_DEV(TTL_9310, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -622,8 +622,8 @@
 
 // usage       : TTL_9316(name, CLK, ENP, ENT, CLRQ, LOADQ, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_9316(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_9316, PNARGS(__VA_ARGS__), 9))                                 \
+#define TTL_9316(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_9316, PNARGS(__VA_ARGS__), 9)) \
 	NET_REGISTER_DEV(TTL_9316, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -631,8 +631,8 @@
 // ---------------------------------------------------------------------
 
 // usage       : TTL_9321(name, E, A0, A1)
-#define TTL_9321(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_9321, PNARGS(__VA_ARGS__), 3))                                 \
+#define TTL_9321(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_9321, PNARGS(__VA_ARGS__), 3)) \
 	NET_REGISTER_DEV(TTL_9321, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -641,8 +641,8 @@
 
 // usage       : TTL_9322(name, SELECT, A1, B1, A2, B2, A3, B3, A4, B4, STROBE)
 // auto connect: VCC, GND
-#define TTL_9322(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_9322, PNARGS(__VA_ARGS__), 10))                                \
+#define TTL_9322(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_9322, PNARGS(__VA_ARGS__), 10)) \
 	NET_REGISTER_DEV(TTL_9322, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -651,8 +651,8 @@
 
 // usage       : TTL_AM2847(name, CP, INA, INB, INC, IND, RCA, RCB, RCC, RCD)
 // auto connect: VSS, VDD
-#define TTL_AM2847(name, ...)                                                                       \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_AM2847, PNARGS(__VA_ARGS__), 9))                               \
+#define TTL_AM2847(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_AM2847, PNARGS(__VA_ARGS__), 9)) \
 	NET_REGISTER_DEV(TTL_AM2847, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -661,8 +661,8 @@
 
 // usage       : TTL_9314(name, EQ, MRQ, S0Q, S1Q, S2Q, S3Q, D0, D1, D2, D3)
 // auto connect: VCC, GND
-#define TTL_9314(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_9314, PNARGS(__VA_ARGS__), 10))                                \
+#define TTL_9314(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_9314, PNARGS(__VA_ARGS__), 10)) \
 	NET_REGISTER_DEV(TTL_9314, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -671,8 +671,8 @@
 
 // usage       : TTL_9334(name, CQ, EQ, D, A0, A1, A2)
 // auto connect: VCC, GND
-#define TTL_9334(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_9334, PNARGS(__VA_ARGS__), 6))                                 \
+#define TTL_9334(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_9334, PNARGS(__VA_ARGS__), 6)) \
 	NET_REGISTER_DEV(TTL_9334, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -680,11 +680,11 @@
 // ---------------------------------------------------------------------
 
 // usage       : NETDEV_RSFF(name)
-#define NETDEV_RSFF(name)                                                                           \
+#define NETDEV_RSFF(name) \
 	NET_REGISTER_DEV(NETDEV_RSFF, name)
 
 // usage       : NETDEV_DELAY(name)
-#define NETDEV_DELAY(name)                                                                          \
+#define NETDEV_DELAY(name) \
 	NET_REGISTER_DEV(NETDEV_DELAY, name)
 
 // ---------------------------------------------------------------------
@@ -692,13 +692,13 @@
 // ---------------------------------------------------------------------
 
 // usage       : LOG(name, I)
-#define LOG(name, ...)                                                                              \
-	__VA_OPT__(CHECK_PARAM_COUNT(LOG, PNARGS(__VA_ARGS__), 1))                                      \
+#define LOG(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(LOG, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(LOG, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : LOGD(name, I, I2)
-#define LOGD(name, ...)                                                                             \
-	__VA_OPT__(CHECK_PARAM_COUNT(LOGD, PNARGS(__VA_ARGS__), 2))                                     \
+#define LOGD(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(LOGD, PNARGS(__VA_ARGS__), 2)) \
 	NET_REGISTER_DEV(LOGD, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -706,7 +706,7 @@
 // ---------------------------------------------------------------------
 
 // usage       : MM5837(name)
-#define MM5837(name)                                                                                \
+#define MM5837(name) \
 	NET_REGISTER_DEV(MM5837, name)
 
 // ---------------------------------------------------------------------
@@ -714,11 +714,11 @@
 // ---------------------------------------------------------------------
 
 // usage       : NE555(name)
-#define NE555(name)                                                                                 \
+#define NE555(name) \
 	NET_REGISTER_DEV(NE555, name)
 
 // usage       : MC1455P(name)
-#define MC1455P(name)                                                                               \
+#define MC1455P(name) \
 	NET_REGISTER_DEV(MC1455P, name)
 
 // ---------------------------------------------------------------------
@@ -726,8 +726,8 @@
 // ---------------------------------------------------------------------
 
 // usage       : R2R_DAC(name, VIN, R, N)
-#define R2R_DAC(name, ...)                                                                          \
-	__VA_OPT__(CHECK_PARAM_COUNT(R2R_DAC, PNARGS(__VA_ARGS__), 3))                                  \
+#define R2R_DAC(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(R2R_DAC, PNARGS(__VA_ARGS__), 3)) \
 	NET_REGISTER_DEV(R2R_DAC, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -736,38 +736,38 @@
 
 // usage       : PROM_82S126(name, CE1Q, CE2Q, A0, A1, A2, A3, A4, A5, A6, A7)
 // auto connect: VCC, GND
-#define PROM_82S126(name, ...)                                                                      \
-	__VA_OPT__(CHECK_PARAM_COUNT(PROM_82S126, PNARGS(__VA_ARGS__), 10))                             \
+#define PROM_82S126(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(PROM_82S126, PNARGS(__VA_ARGS__), 10)) \
 	NET_REGISTER_DEV(PROM_82S126, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : PROM_74S287(name, CE1Q, CE2Q, A0, A1, A2, A3, A4, A5, A6, A7)
 // auto connect: VCC, GND
-#define PROM_74S287(name, ...)                                                                      \
-	__VA_OPT__(CHECK_PARAM_COUNT(PROM_74S287, PNARGS(__VA_ARGS__), 10))                             \
+#define PROM_74S287(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(PROM_74S287, PNARGS(__VA_ARGS__), 10)) \
 	NET_REGISTER_DEV(PROM_74S287, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : PROM_82S123(name, CEQ, A0, A1, A2, A3, A4)
 // auto connect: VCC, GND
-#define PROM_82S123(name, ...)                                                                      \
-	__VA_OPT__(CHECK_PARAM_COUNT(PROM_82S123, PNARGS(__VA_ARGS__), 6))                              \
+#define PROM_82S123(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(PROM_82S123, PNARGS(__VA_ARGS__), 6)) \
 	NET_REGISTER_DEV(PROM_82S123, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : EPROM_2716(name, CE2Q, CE1Q, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)
 // auto connect: VCC, GND
-#define EPROM_2716(name, ...)                                                                       \
-	__VA_OPT__(CHECK_PARAM_COUNT(EPROM_2716, PNARGS(__VA_ARGS__), 13))                              \
+#define EPROM_2716(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(EPROM_2716, PNARGS(__VA_ARGS__), 13)) \
 	NET_REGISTER_DEV(EPROM_2716, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : PROM_MK28000(name, OE1, OE2, ARQ, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)
 // auto connect: VCC, GND
-#define PROM_MK28000(name, ...)                                                                     \
-	__VA_OPT__(CHECK_PARAM_COUNT(PROM_MK28000, PNARGS(__VA_ARGS__), 14))                            \
+#define PROM_MK28000(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(PROM_MK28000, PNARGS(__VA_ARGS__), 14)) \
 	NET_REGISTER_DEV(PROM_MK28000, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : ROM_MCM14524(name, EN, CLK, A0, A1, A2, A3, A4, A5, A6, A7)
 // auto connect: VCC, GND
-#define ROM_MCM14524(name, ...)                                                                     \
-	__VA_OPT__(CHECK_PARAM_COUNT(ROM_MCM14524, PNARGS(__VA_ARGS__), 10))                            \
+#define ROM_MCM14524(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(ROM_MCM14524, PNARGS(__VA_ARGS__), 10)) \
 	NET_REGISTER_DEV(ROM_MCM14524, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -775,8 +775,8 @@
 // ---------------------------------------------------------------------
 
 // usage       : SCHMITT_TRIGGER(name, STMODEL)
-#define SCHMITT_TRIGGER(name, ...)                                                                  \
-	__VA_OPT__(CHECK_PARAM_COUNT(SCHMITT_TRIGGER, PNARGS(__VA_ARGS__), 1))                          \
+#define SCHMITT_TRIGGER(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(SCHMITT_TRIGGER, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(SCHMITT_TRIGGER, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -784,93 +784,93 @@
 // ---------------------------------------------------------------------
 
 // usage       : PARAMETER(name)
-#define PARAMETER(name)                                                                             \
+#define PARAMETER(name) \
 	NET_REGISTER_DEV(PARAMETER, name)
 
 // usage       : NC_PIN(name)
-#define NC_PIN(name)                                                                                \
+#define NC_PIN(name) \
 	NET_REGISTER_DEV(NC_PIN, name)
 
 // usage       : FRONTIER_DEV(name, I, G, Q)
-#define FRONTIER_DEV(name, ...)                                                                     \
-	__VA_OPT__(CHECK_PARAM_COUNT(FRONTIER_DEV, PNARGS(__VA_ARGS__), 3))                             \
+#define FRONTIER_DEV(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(FRONTIER_DEV, PNARGS(__VA_ARGS__), 3)) \
 	NET_REGISTER_DEV(FRONTIER_DEV, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : AFUNC(name, N, FUNC)
-#define AFUNC(name, ...)                                                                            \
-	__VA_OPT__(CHECK_PARAM_COUNT(AFUNC, PNARGS(__VA_ARGS__), 2))                                    \
+#define AFUNC(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(AFUNC, PNARGS(__VA_ARGS__), 2)) \
 	NET_REGISTER_DEV(AFUNC, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : ANALOG_INPUT(name, IN)
-#define ANALOG_INPUT(name, ...)                                                                     \
-	__VA_OPT__(CHECK_PARAM_COUNT(ANALOG_INPUT, PNARGS(__VA_ARGS__), 1))                             \
+#define ANALOG_INPUT(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(ANALOG_INPUT, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(ANALOG_INPUT, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CLOCK(name, FREQ)
-#define CLOCK(name, ...)                                                                            \
-	__VA_OPT__(CHECK_PARAM_COUNT(CLOCK, PNARGS(__VA_ARGS__), 1))                                    \
+#define CLOCK(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(CLOCK, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(CLOCK, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : VARCLOCK(name, N, FUNC)
-#define VARCLOCK(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(VARCLOCK, PNARGS(__VA_ARGS__), 2))                                 \
+#define VARCLOCK(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(VARCLOCK, PNARGS(__VA_ARGS__), 2)) \
 	NET_REGISTER_DEV(VARCLOCK, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : EXTCLOCK(name, FREQ, PATTERN)
-#define EXTCLOCK(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(EXTCLOCK, PNARGS(__VA_ARGS__), 2))                                 \
+#define EXTCLOCK(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(EXTCLOCK, PNARGS(__VA_ARGS__), 2)) \
 	NET_REGISTER_DEV(EXTCLOCK, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : SYS_DSW(name, I, 1, 2)
-#define SYS_DSW(name, ...)                                                                          \
-	__VA_OPT__(CHECK_PARAM_COUNT(SYS_DSW, PNARGS(__VA_ARGS__), 3))                                  \
+#define SYS_DSW(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(SYS_DSW, PNARGS(__VA_ARGS__), 3)) \
 	NET_REGISTER_DEV(SYS_DSW, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : SYS_DSW2(name)
-#define SYS_DSW2(name)                                                                              \
+#define SYS_DSW2(name) \
 	NET_REGISTER_DEV(SYS_DSW2, name)
 
 // usage       : SYS_COMPD(name)
-#define SYS_COMPD(name)                                                                             \
+#define SYS_COMPD(name) \
 	NET_REGISTER_DEV(SYS_COMPD, name)
 
 // usage       : SYS_PULSE(name, DELAY, DURATION, INVERT_INPUT, INVERT_OUTPUT)
-#define SYS_PULSE(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(SYS_PULSE, PNARGS(__VA_ARGS__), 4))                                \
+#define SYS_PULSE(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(SYS_PULSE, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(SYS_PULSE, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : SYS_NOISE_MT_U(name, SIGMA)
-#define SYS_NOISE_MT_U(name, ...)                                                                   \
-	__VA_OPT__(CHECK_PARAM_COUNT(SYS_NOISE_MT_U, PNARGS(__VA_ARGS__), 1))                           \
+#define SYS_NOISE_MT_U(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(SYS_NOISE_MT_U, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(SYS_NOISE_MT_U, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : SYS_NOISE_MT_N(name, SIGMA)
-#define SYS_NOISE_MT_N(name, ...)                                                                   \
-	__VA_OPT__(CHECK_PARAM_COUNT(SYS_NOISE_MT_N, PNARGS(__VA_ARGS__), 1))                           \
+#define SYS_NOISE_MT_N(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(SYS_NOISE_MT_N, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(SYS_NOISE_MT_N, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : MAINCLOCK(name, FREQ)
-#define MAINCLOCK(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(MAINCLOCK, PNARGS(__VA_ARGS__), 1))                                \
+#define MAINCLOCK(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(MAINCLOCK, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(MAINCLOCK, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : GNDA(name)
-#define GNDA(name)                                                                                  \
+#define GNDA(name) \
 	NET_REGISTER_DEV(GNDA, name)
 
 // usage       : LOGIC_INPUT8(name, IN, MODEL)
-#define LOGIC_INPUT8(name, ...)                                                                     \
-	__VA_OPT__(CHECK_PARAM_COUNT(LOGIC_INPUT8, PNARGS(__VA_ARGS__), 2))                             \
+#define LOGIC_INPUT8(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(LOGIC_INPUT8, PNARGS(__VA_ARGS__), 2)) \
 	NET_REGISTER_DEV(LOGIC_INPUT8, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : LOGIC_INPUT(name, IN, MODEL)
-#define LOGIC_INPUT(name, ...)                                                                      \
-	__VA_OPT__(CHECK_PARAM_COUNT(LOGIC_INPUT, PNARGS(__VA_ARGS__), 2))                              \
+#define LOGIC_INPUT(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(LOGIC_INPUT, PNARGS(__VA_ARGS__), 2)) \
 	NET_REGISTER_DEV(LOGIC_INPUT, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_INPUT(name, IN)
-#define TTL_INPUT(name, ...)                                                                        \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_INPUT, PNARGS(__VA_ARGS__), 1))                                \
+#define TTL_INPUT(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_INPUT, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(TTL_INPUT, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -879,8 +879,8 @@
 
 // usage       : ROM_TMS4800(name, AR, OE1, OE2, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)
 // auto connect: VCC, GND
-#define ROM_TMS4800(name, ...)                                                                      \
-	__VA_OPT__(CHECK_PARAM_COUNT(ROM_TMS4800, PNARGS(__VA_ARGS__), 14))                             \
+#define ROM_TMS4800(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(ROM_TMS4800, PNARGS(__VA_ARGS__), 14)) \
 	NET_REGISTER_DEV(ROM_TMS4800, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -888,12 +888,12 @@
 // ---------------------------------------------------------------------
 
 // usage       : TTL_TRISTATE(name, CEQ1, D1, CEQ2, D2)
-#define TTL_TRISTATE(name, ...)                                                                     \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_TRISTATE, PNARGS(__VA_ARGS__), 4))                             \
+#define TTL_TRISTATE(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_TRISTATE, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(TTL_TRISTATE, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_TRISTATE3(name)
-#define TTL_TRISTATE3(name)                                                                         \
+#define TTL_TRISTATE3(name) \
 	NET_REGISTER_DEV(TTL_TRISTATE3, name)
 
 // ---------------------------------------------------------------------
@@ -926,128 +926,128 @@ NETLIST_EXTERNAL(base_lib)
 // ---------------------------------------------------------------------
 
 // usage       : CD4001_GATE(name)
-#define CD4001_GATE(name)                                                                           \
+#define CD4001_GATE(name) \
 	NET_REGISTER_DEV(CD4001_GATE, name)
 
 // usage       : CD4011_GATE(name)
-#define CD4011_GATE(name)                                                                           \
+#define CD4011_GATE(name) \
 	NET_REGISTER_DEV(CD4011_GATE, name)
 
 // usage       : CD4030_GATE(name)
-#define CD4030_GATE(name)                                                                           \
+#define CD4030_GATE(name) \
 	NET_REGISTER_DEV(CD4030_GATE, name)
 
 // usage       : CD4049_GATE(name)
-#define CD4049_GATE(name)                                                                           \
+#define CD4049_GATE(name) \
 	NET_REGISTER_DEV(CD4049_GATE, name)
 
 // usage       : CD4069_GATE(name)
-#define CD4069_GATE(name)                                                                           \
+#define CD4069_GATE(name) \
 	NET_REGISTER_DEV(CD4069_GATE, name)
 
 // usage       : CD4070_GATE(name)
-#define CD4070_GATE(name)                                                                           \
+#define CD4070_GATE(name) \
 	NET_REGISTER_DEV(CD4070_GATE, name)
 
 // usage       : CD4071_GATE(name)
-#define CD4071_GATE(name)                                                                           \
+#define CD4071_GATE(name) \
 	NET_REGISTER_DEV(CD4071_GATE, name)
 
 // usage       : CD4081_GATE(name)
-#define CD4081_GATE(name)                                                                           \
+#define CD4081_GATE(name) \
 	NET_REGISTER_DEV(CD4081_GATE, name)
 
 NETLIST_EXTERNAL(cd4xxx_lib)
 // usage       : CD4001_DIP(name)
-#define CD4001_DIP(name)                                                                            \
+#define CD4001_DIP(name) \
 	NET_REGISTER_DEV(CD4001_DIP, name)
 
 // usage       : CD4011_DIP(name)
-#define CD4011_DIP(name)                                                                            \
+#define CD4011_DIP(name) \
 	NET_REGISTER_DEV(CD4011_DIP, name)
 
 // usage       : CD4030_DIP(name)
-#define CD4030_DIP(name)                                                                            \
+#define CD4030_DIP(name) \
 	NET_REGISTER_DEV(CD4030_DIP, name)
 
 // usage       : CD4049_DIP(name)
-#define CD4049_DIP(name)                                                                            \
+#define CD4049_DIP(name) \
 	NET_REGISTER_DEV(CD4049_DIP, name)
 
 // usage       : CD4069_DIP(name)
-#define CD4069_DIP(name)                                                                            \
+#define CD4069_DIP(name) \
 	NET_REGISTER_DEV(CD4069_DIP, name)
 
 // usage       : CD4070_DIP(name)
-#define CD4070_DIP(name)                                                                            \
+#define CD4070_DIP(name) \
 	NET_REGISTER_DEV(CD4070_DIP, name)
 
 // usage       : CD4071_DIP(name)
-#define CD4071_DIP(name)                                                                            \
+#define CD4071_DIP(name) \
 	NET_REGISTER_DEV(CD4071_DIP, name)
 
 // usage       : CD4081_DIP(name)
-#define CD4081_DIP(name)                                                                            \
+#define CD4081_DIP(name) \
 	NET_REGISTER_DEV(CD4081_DIP, name)
 
 // usage       : CD4006_DIP(name)
-#define CD4006_DIP(name)                                                                            \
+#define CD4006_DIP(name) \
 	NET_REGISTER_DEV(CD4006_DIP, name)
 
 // usage       : CD4013_DIP(name)
-#define CD4013_DIP(name)                                                                            \
+#define CD4013_DIP(name) \
 	NET_REGISTER_DEV(CD4013_DIP, name)
 
 // usage       : CD4017_DIP(name)
-#define CD4017_DIP(name)                                                                            \
+#define CD4017_DIP(name) \
 	NET_REGISTER_DEV(CD4017_DIP, name)
 
 // usage       : CD4022_DIP(name)
-#define CD4022_DIP(name)                                                                            \
+#define CD4022_DIP(name) \
 	NET_REGISTER_DEV(CD4022_DIP, name)
 
 // usage       : CD4020_DIP(name)
-#define CD4020_DIP(name)                                                                            \
+#define CD4020_DIP(name) \
 	NET_REGISTER_DEV(CD4020_DIP, name)
 
 // usage       : CD4024_DIP(name)
-#define CD4024_DIP(name)                                                                            \
+#define CD4024_DIP(name) \
 	NET_REGISTER_DEV(CD4024_DIP, name)
 
 // usage       : CD4029_DIP(name)
-#define CD4029_DIP(name)                                                                            \
+#define CD4029_DIP(name) \
 	NET_REGISTER_DEV(CD4029_DIP, name)
 
 // usage       : CD4042_DIP(name)
-#define CD4042_DIP(name)                                                                            \
+#define CD4042_DIP(name) \
 	NET_REGISTER_DEV(CD4042_DIP, name)
 
 // usage       : CD4053_DIP(name)
-#define CD4053_DIP(name)                                                                            \
+#define CD4053_DIP(name) \
 	NET_REGISTER_DEV(CD4053_DIP, name)
 
 // usage       : CD4066_DIP(name)
-#define CD4066_DIP(name)                                                                            \
+#define CD4066_DIP(name) \
 	NET_REGISTER_DEV(CD4066_DIP, name)
 
 // usage       : CD4016_DIP(name)
-#define CD4016_DIP(name)                                                                            \
+#define CD4016_DIP(name) \
 	NET_REGISTER_DEV(CD4016_DIP, name)
 
 // usage       : CD4076_DIP(name)
-#define CD4076_DIP(name)                                                                            \
+#define CD4076_DIP(name) \
 	NET_REGISTER_DEV(CD4076_DIP, name)
 
 // usage       : CD4316_DIP(name)
-#define CD4316_DIP(name)                                                                            \
+#define CD4316_DIP(name) \
 	NET_REGISTER_DEV(CD4316_DIP, name)
 
 // usage       : CD4538_DIP(name)
-#define CD4538_DIP(name)                                                                            \
+#define CD4538_DIP(name) \
 	NET_REGISTER_DEV(CD4538_DIP, name)
 
 // usage       : MM5837_DIP(name)
-#define MM5837_DIP(name)                                                                            \
+#define MM5837_DIP(name) \
 	NET_REGISTER_DEV(MM5837_DIP, name)
 
 // ---------------------------------------------------------------------
@@ -1056,95 +1056,95 @@ NETLIST_EXTERNAL(cd4xxx_lib)
 
 NETLIST_EXTERNAL(opamp_lib)
 // usage       : opamp_layout_4_4_11(name)
-#define opamp_layout_4_4_11(name)                                                                   \
+#define opamp_layout_4_4_11(name) \
 	NET_REGISTER_DEV(opamp_layout_4_4_11, name)
 
 // usage       : opamp_layout_2_8_4(name)
-#define opamp_layout_2_8_4(name)                                                                    \
+#define opamp_layout_2_8_4(name) \
 	NET_REGISTER_DEV(opamp_layout_2_8_4, name)
 
 // usage       : opamp_layout_2_13_9_4(name)
-#define opamp_layout_2_13_9_4(name)                                                                 \
+#define opamp_layout_2_13_9_4(name) \
 	NET_REGISTER_DEV(opamp_layout_2_13_9_4, name)
 
 // usage       : opamp_layout_1_7_4(name)
-#define opamp_layout_1_7_4(name)                                                                    \
+#define opamp_layout_1_7_4(name) \
 	NET_REGISTER_DEV(opamp_layout_1_7_4, name)
 
 // usage       : opamp_layout_1_8_5(name)
-#define opamp_layout_1_8_5(name)                                                                    \
+#define opamp_layout_1_8_5(name) \
 	NET_REGISTER_DEV(opamp_layout_1_8_5, name)
 
 // usage       : opamp_layout_1_11_6(name)
-#define opamp_layout_1_11_6(name)                                                                   \
+#define opamp_layout_1_11_6(name) \
 	NET_REGISTER_DEV(opamp_layout_1_11_6, name)
 
 // usage       : MB3614_DIP(name)
-#define MB3614_DIP(name)                                                                            \
+#define MB3614_DIP(name) \
 	NET_REGISTER_DEV(MB3614_DIP, name)
 
 // usage       : MC3340_DIP(name)
-#define MC3340_DIP(name)                                                                            \
+#define MC3340_DIP(name) \
 	NET_REGISTER_DEV(MC3340_DIP, name)
 
 // usage       : TL081_DIP(name)
-#define TL081_DIP(name)                                                                             \
+#define TL081_DIP(name) \
 	NET_REGISTER_DEV(TL081_DIP, name)
 
 // usage       : TL082_DIP(name)
-#define TL082_DIP(name)                                                                             \
+#define TL082_DIP(name) \
 	NET_REGISTER_DEV(TL082_DIP, name)
 
 // usage       : TL084_DIP(name)
-#define TL084_DIP(name)                                                                             \
+#define TL084_DIP(name) \
 	NET_REGISTER_DEV(TL084_DIP, name)
 
 // usage       : LM324_DIP(name)
-#define LM324_DIP(name)                                                                             \
+#define LM324_DIP(name) \
 	NET_REGISTER_DEV(LM324_DIP, name)
 
 // usage       : LM348_DIP(name)
-#define LM348_DIP(name)                                                                             \
+#define LM348_DIP(name) \
 	NET_REGISTER_DEV(LM348_DIP, name)
 
 // usage       : LM358_DIP(name)
-#define LM358_DIP(name)                                                                             \
+#define LM358_DIP(name) \
 	NET_REGISTER_DEV(LM358_DIP, name)
 
 // usage       : LM2902_DIP(name)
-#define LM2902_DIP(name)                                                                            \
+#define LM2902_DIP(name) \
 	NET_REGISTER_DEV(LM2902_DIP, name)
 
 // usage       : UA741_DIP8(name)
-#define UA741_DIP8(name)                                                                            \
+#define UA741_DIP8(name) \
 	NET_REGISTER_DEV(UA741_DIP8, name)
 
 // usage       : UA741_DIP10(name)
-#define UA741_DIP10(name)                                                                           \
+#define UA741_DIP10(name) \
 	NET_REGISTER_DEV(UA741_DIP10, name)
 
 // usage       : UA741_DIP14(name)
-#define UA741_DIP14(name)                                                                           \
+#define UA741_DIP14(name) \
 	NET_REGISTER_DEV(UA741_DIP14, name)
 
 // usage       : MC1558_DIP(name)
-#define MC1558_DIP(name)                                                                            \
+#define MC1558_DIP(name) \
 	NET_REGISTER_DEV(MC1558_DIP, name)
 
 // usage       : LM747_DIP(name)
-#define LM747_DIP(name)                                                                             \
+#define LM747_DIP(name) \
 	NET_REGISTER_DEV(LM747_DIP, name)
 
 // usage       : LM747A_DIP(name)
-#define LM747A_DIP(name)                                                                            \
+#define LM747A_DIP(name) \
 	NET_REGISTER_DEV(LM747A_DIP, name)
 
 // usage       : LM3900(name)
-#define LM3900(name)                                                                                \
+#define LM3900(name) \
 	NET_REGISTER_DEV(LM3900, name)
 
 // usage       : AN6551_SIL(name)
-#define AN6551_SIL(name)                                                                            \
+#define AN6551_SIL(name) \
 	NET_REGISTER_DEV(AN6551_SIL, name)
 
 // ---------------------------------------------------------------------
@@ -1152,24 +1152,24 @@ NETLIST_EXTERNAL(opamp_lib)
 // ---------------------------------------------------------------------
 
 // usage       : MC14584B_GATE(name)
-#define MC14584B_GATE(name)                                                                         \
+#define MC14584B_GATE(name) \
 	NET_REGISTER_DEV(MC14584B_GATE, name)
 
 NETLIST_EXTERNAL(otheric_lib)
 // usage       : MC14584B_DIP(name)
-#define MC14584B_DIP(name)                                                                          \
+#define MC14584B_DIP(name) \
 	NET_REGISTER_DEV(MC14584B_DIP, name)
 
 // usage       : NE566_DIP(name)
-#define NE566_DIP(name)                                                                             \
+#define NE566_DIP(name) \
 	NET_REGISTER_DEV(NE566_DIP, name)
 
 // usage       : NE555_DIP(name)
-#define NE555_DIP(name)                                                                             \
+#define NE555_DIP(name) \
 	NET_REGISTER_DEV(NE555_DIP, name)
 
 // usage       : MC1455P_DIP(name)
-#define MC1455P_DIP(name)                                                                           \
+#define MC1455P_DIP(name) \
 	NET_REGISTER_DEV(MC1455P_DIP, name)
 
 // ---------------------------------------------------------------------
@@ -1178,43 +1178,43 @@ NETLIST_EXTERNAL(otheric_lib)
 
 NETLIST_EXTERNAL(roms_lib)
 // usage       : PROM_82S123_DIP(name)
-#define PROM_82S123_DIP(name)                                                                       \
+#define PROM_82S123_DIP(name) \
 	NET_REGISTER_DEV(PROM_82S123_DIP, name)
 
 // usage       : PROM_82S126_DIP(name)
-#define PROM_82S126_DIP(name)                                                                       \
+#define PROM_82S126_DIP(name) \
 	NET_REGISTER_DEV(PROM_82S126_DIP, name)
 
 // usage       : PROM_74S287_DIP(name)
-#define PROM_74S287_DIP(name)                                                                       \
+#define PROM_74S287_DIP(name) \
 	NET_REGISTER_DEV(PROM_74S287_DIP, name)
 
 // usage       : EPROM_2716_DIP(name)
-#define EPROM_2716_DIP(name)                                                                        \
+#define EPROM_2716_DIP(name) \
 	NET_REGISTER_DEV(EPROM_2716_DIP, name)
 
 // usage       : TTL_82S16_DIP(name)
-#define TTL_82S16_DIP(name)                                                                         \
+#define TTL_82S16_DIP(name) \
 	NET_REGISTER_DEV(TTL_82S16_DIP, name)
 
 // usage       : PROM_82S115_DIP(name)
-#define PROM_82S115_DIP(name)                                                                       \
+#define PROM_82S115_DIP(name) \
 	NET_REGISTER_DEV(PROM_82S115_DIP, name)
 
 // usage       : PROM_MK28000_DIP(name)
-#define PROM_MK28000_DIP(name)                                                                      \
+#define PROM_MK28000_DIP(name) \
 	NET_REGISTER_DEV(PROM_MK28000_DIP, name)
 
 // usage       : ROM_MCM14524_DIP(name)
-#define ROM_MCM14524_DIP(name)                                                                      \
+#define ROM_MCM14524_DIP(name) \
 	NET_REGISTER_DEV(ROM_MCM14524_DIP, name)
 
 // usage       : RAM_2102A_DIP(name)
-#define RAM_2102A_DIP(name)                                                                         \
+#define RAM_2102A_DIP(name) \
 	NET_REGISTER_DEV(RAM_2102A_DIP, name)
 
 // usage       : ROM_TMS4800_DIP(name)
-#define ROM_TMS4800_DIP(name)                                                                       \
+#define ROM_TMS4800_DIP(name) \
 	NET_REGISTER_DEV(ROM_TMS4800_DIP, name)
 
 // ---------------------------------------------------------------------
@@ -1223,519 +1223,519 @@ NETLIST_EXTERNAL(roms_lib)
 
 // usage       : TTL_7400_NAND(name, A, B)
 // auto connect: VCC, GND
-#define TTL_7400_NAND(name, ...)                                                                    \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7400_NAND, PNARGS(__VA_ARGS__), 2))                            \
+#define TTL_7400_NAND(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7400_NAND, PNARGS(__VA_ARGS__), 2)) \
 	NET_REGISTER_DEV(TTL_7400_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7402_NOR(name, A, B)
 // auto connect: VCC, GND
-#define TTL_7402_NOR(name, ...)                                                                     \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7402_NOR, PNARGS(__VA_ARGS__), 2))                             \
+#define TTL_7402_NOR(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7402_NOR, PNARGS(__VA_ARGS__), 2)) \
 	NET_REGISTER_DEV(TTL_7402_NOR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7404_INVERT(name, A)
 // auto connect: VCC, GND
-#define TTL_7404_INVERT(name, ...)                                                                  \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7404_INVERT, PNARGS(__VA_ARGS__), 1))                          \
+#define TTL_7404_INVERT(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7404_INVERT, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(TTL_7404_INVERT, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7406_GATE(name)
-#define TTL_7406_GATE(name)                                                                         \
+#define TTL_7406_GATE(name) \
 	NET_REGISTER_DEV(TTL_7406_GATE, name)
 
 // usage       : TTL_7407_GATE(name)
-#define TTL_7407_GATE(name)                                                                         \
+#define TTL_7407_GATE(name) \
 	NET_REGISTER_DEV(TTL_7407_GATE, name)
 
 // usage       : TTL_7408_GATE(name)
-#define TTL_7408_GATE(name)                                                                         \
+#define TTL_7408_GATE(name) \
 	NET_REGISTER_DEV(TTL_7408_GATE, name)
 
 // usage       : TTL_7408_AND(name, A, B)
 // auto connect: VCC, GND
-#define TTL_7408_AND(name, ...)                                                                     \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7408_AND, PNARGS(__VA_ARGS__), 2))                             \
+#define TTL_7408_AND(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7408_AND, PNARGS(__VA_ARGS__), 2)) \
 	NET_REGISTER_DEV(TTL_7408_AND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7410_NAND(name, A, B, C)
 // auto connect: VCC, GND
-#define TTL_7410_NAND(name, ...)                                                                    \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7410_NAND, PNARGS(__VA_ARGS__), 3))                            \
+#define TTL_7410_NAND(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7410_NAND, PNARGS(__VA_ARGS__), 3)) \
 	NET_REGISTER_DEV(TTL_7410_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7410_GATE(name)
-#define TTL_7410_GATE(name)                                                                         \
+#define TTL_7410_GATE(name) \
 	NET_REGISTER_DEV(TTL_7410_GATE, name)
 
 // usage       : TTL_7411_AND(name, A, B, C)
 // auto connect: VCC, GND
-#define TTL_7411_AND(name, ...)                                                                     \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7411_AND, PNARGS(__VA_ARGS__), 3))                             \
+#define TTL_7411_AND(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7411_AND, PNARGS(__VA_ARGS__), 3)) \
 	NET_REGISTER_DEV(TTL_7411_AND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7411_GATE(name)
-#define TTL_7411_GATE(name)                                                                         \
+#define TTL_7411_GATE(name) \
 	NET_REGISTER_DEV(TTL_7411_GATE, name)
 
 // usage       : TTL_7416_GATE(name)
-#define TTL_7416_GATE(name)                                                                         \
+#define TTL_7416_GATE(name) \
 	NET_REGISTER_DEV(TTL_7416_GATE, name)
 
 // usage       : TTL_7417_GATE(name)
-#define TTL_7417_GATE(name)                                                                         \
+#define TTL_7417_GATE(name) \
 	NET_REGISTER_DEV(TTL_7417_GATE, name)
 
 // usage       : TTL_7420_NAND(name, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_7420_NAND(name, ...)                                                                    \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7420_NAND, PNARGS(__VA_ARGS__), 4))                            \
+#define TTL_7420_NAND(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7420_NAND, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(TTL_7420_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7421_AND(name, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_7421_AND(name, ...)                                                                     \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7421_AND, PNARGS(__VA_ARGS__), 4))                             \
+#define TTL_7421_AND(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7421_AND, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(TTL_7421_AND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7425_NOR(name, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_7425_NOR(name, ...)                                                                     \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7425_NOR, PNARGS(__VA_ARGS__), 4))                             \
+#define TTL_7425_NOR(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7425_NOR, PNARGS(__VA_ARGS__), 4)) \
 	NET_REGISTER_DEV(TTL_7425_NOR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7427_NOR(name, A, B, C)
 // auto connect: VCC, GND
-#define TTL_7427_NOR(name, ...)                                                                     \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7427_NOR, PNARGS(__VA_ARGS__), 3))                             \
+#define TTL_7427_NOR(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7427_NOR, PNARGS(__VA_ARGS__), 3)) \
 	NET_REGISTER_DEV(TTL_7427_NOR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7430_NAND(name, A, B, C, D, E, F, G, H)
 // auto connect: VCC, GND
-#define TTL_7430_NAND(name, ...)                                                                    \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7430_NAND, PNARGS(__VA_ARGS__), 8))                            \
+#define TTL_7430_NAND(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7430_NAND, PNARGS(__VA_ARGS__), 8)) \
 	NET_REGISTER_DEV(TTL_7430_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7432_OR(name, A, B)
 // auto connect: VCC, GND
-#define TTL_7432_OR(name, ...)                                                                      \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7432_OR, PNARGS(__VA_ARGS__), 2))                              \
+#define TTL_7432_OR(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7432_OR, PNARGS(__VA_ARGS__), 2)) \
 	NET_REGISTER_DEV(TTL_7432_OR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7437_NAND(name, A, B)
-#define TTL_7437_NAND(name, ...)                                                                    \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7437_NAND, PNARGS(__VA_ARGS__), 2))                            \
+#define TTL_7437_NAND(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7437_NAND, PNARGS(__VA_ARGS__), 2)) \
 	NET_REGISTER_DEV(TTL_7437_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7438_NAND(name, A, B)
-#define TTL_7438_NAND(name, ...)                                                                    \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7438_NAND, PNARGS(__VA_ARGS__), 2))                            \
+#define TTL_7438_NAND(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7438_NAND, PNARGS(__VA_ARGS__), 2)) \
 	NET_REGISTER_DEV(TTL_7438_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7442(name)
-#define TTL_7442(name)                                                                              \
+#define TTL_7442(name) \
 	NET_REGISTER_DEV(TTL_7442, name)
 
 // usage       : TTL_7486_XOR(name, A, B)
 // auto connect: VCC, GND
-#define TTL_7486_XOR(name, ...)                                                                     \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7486_XOR, PNARGS(__VA_ARGS__), 2))                             \
+#define TTL_7486_XOR(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_7486_XOR, PNARGS(__VA_ARGS__), 2)) \
 	NET_REGISTER_DEV(TTL_7486_XOR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_74139_GATE(name)
-#define TTL_74139_GATE(name)                                                                        \
+#define TTL_74139_GATE(name) \
 	NET_REGISTER_DEV(TTL_74139_GATE, name)
 
 // usage       : TTL_74147_GATE(name)
-#define TTL_74147_GATE(name)                                                                        \
+#define TTL_74147_GATE(name) \
 	NET_REGISTER_DEV(TTL_74147_GATE, name)
 
 // usage       : TTL_74148_GATE(name)
-#define TTL_74148_GATE(name)                                                                        \
+#define TTL_74148_GATE(name) \
 	NET_REGISTER_DEV(TTL_74148_GATE, name)
 
 // usage       : TTL_74151_GATE(name)
-#define TTL_74151_GATE(name)                                                                        \
+#define TTL_74151_GATE(name) \
 	NET_REGISTER_DEV(TTL_74151_GATE, name)
 
 // usage       : TTL_74155A_GATE(name)
-#define TTL_74155A_GATE(name)                                                                       \
+#define TTL_74155A_GATE(name) \
 	NET_REGISTER_DEV(TTL_74155A_GATE, name)
 
 // usage       : TTL_74155B_GATE(name)
-#define TTL_74155B_GATE(name)                                                                       \
+#define TTL_74155B_GATE(name) \
 	NET_REGISTER_DEV(TTL_74155B_GATE, name)
 
 // usage       : TTL_74156A_GATE(name)
-#define TTL_74156A_GATE(name)                                                                       \
+#define TTL_74156A_GATE(name) \
 	NET_REGISTER_DEV(TTL_74156A_GATE, name)
 
 // usage       : TTL_74156B_GATE(name)
-#define TTL_74156B_GATE(name)                                                                       \
+#define TTL_74156B_GATE(name) \
 	NET_REGISTER_DEV(TTL_74156B_GATE, name)
 
 // usage       : TTL_74157_GATE(name)
-#define TTL_74157_GATE(name)                                                                        \
+#define TTL_74157_GATE(name) \
 	NET_REGISTER_DEV(TTL_74157_GATE, name)
 
 // usage       : TTL_74260_NOR(name, A, B, C, D, E)
 // auto connect: VCC, GND
-#define TTL_74260_NOR(name, ...)                                                                    \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74260_NOR, PNARGS(__VA_ARGS__), 5))                            \
+#define TTL_74260_NOR(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_74260_NOR, PNARGS(__VA_ARGS__), 5)) \
 	NET_REGISTER_DEV(TTL_74260_NOR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_74279A(name)
-#define TTL_74279A(name)                                                                            \
+#define TTL_74279A(name) \
 	NET_REGISTER_DEV(TTL_74279A, name)
 
 // usage       : TTL_74279B(name)
-#define TTL_74279B(name)                                                                            \
+#define TTL_74279B(name) \
 	NET_REGISTER_DEV(TTL_74279B, name)
 
 // usage       : TTL_74368_GATE(name)
-#define TTL_74368_GATE(name)                                                                        \
+#define TTL_74368_GATE(name) \
 	NET_REGISTER_DEV(TTL_74368_GATE, name)
 
 // usage       : TTL_9312(name, A, B, C, G, D0, D1, D2, D3, D4, D5, D6, D7)
 // auto connect: VCC, GND
-#define TTL_9312(name, ...)                                                                         \
-	__VA_OPT__(CHECK_PARAM_COUNT(TTL_9312, PNARGS(__VA_ARGS__), 12))                                \
+#define TTL_9312(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(TTL_9312, PNARGS(__VA_ARGS__), 12)) \
 	NET_REGISTER_DEV(TTL_9312, name __VA_OPT__(,) __VA_ARGS__)
 
 NETLIST_EXTERNAL(ttl74xx_lib)
 // usage       : TTL_7400_DIP(name)
-#define TTL_7400_DIP(name)                                                                          \
+#define TTL_7400_DIP(name) \
 	NET_REGISTER_DEV(TTL_7400_DIP, name)
 
 // usage       : TTL_7402_DIP(name)
-#define TTL_7402_DIP(name)                                                                          \
+#define TTL_7402_DIP(name) \
 	NET_REGISTER_DEV(TTL_7402_DIP, name)
 
 // usage       : TTL_7404_DIP(name)
-#define TTL_7404_DIP(name)                                                                          \
+#define TTL_7404_DIP(name) \
 	NET_REGISTER_DEV(TTL_7404_DIP, name)
 
 // usage       : TTL_7406_DIP(name)
-#define TTL_7406_DIP(name)                                                                          \
+#define TTL_7406_DIP(name) \
 	NET_REGISTER_DEV(TTL_7406_DIP, name)
 
 // usage       : TTL_7407_DIP(name)
-#define TTL_7407_DIP(name)                                                                          \
+#define TTL_7407_DIP(name) \
 	NET_REGISTER_DEV(TTL_7407_DIP, name)
 
 // usage       : TTL_7408_DIP(name)
-#define TTL_7408_DIP(name)                                                                          \
+#define TTL_7408_DIP(name) \
 	NET_REGISTER_DEV(TTL_7408_DIP, name)
 
 // usage       : TTL_7410_DIP(name)
-#define TTL_7410_DIP(name)                                                                          \
+#define TTL_7410_DIP(name) \
 	NET_REGISTER_DEV(TTL_7410_DIP, name)
 
 // usage       : TTL_7411_DIP(name)
-#define TTL_7411_DIP(name)                                                                          \
+#define TTL_7411_DIP(name) \
 	NET_REGISTER_DEV(TTL_7411_DIP, name)
 
 // usage       : TTL_7414_GATE(name)
-#define TTL_7414_GATE(name)                                                                         \
+#define TTL_7414_GATE(name) \
 	NET_REGISTER_DEV(TTL_7414_GATE, name)
 
 // usage       : TTL_74LS14_GATE(name)
-#define TTL_74LS14_GATE(name)                                                                       \
+#define TTL_74LS14_GATE(name) \
 	NET_REGISTER_DEV(TTL_74LS14_GATE, name)
 
 // usage       : TTL_7414_DIP(name)
-#define TTL_7414_DIP(name)                                                                          \
+#define TTL_7414_DIP(name) \
 	NET_REGISTER_DEV(TTL_7414_DIP, name)
 
 // usage       : TTL_74LS14_DIP(name)
-#define TTL_74LS14_DIP(name)                                                                        \
+#define TTL_74LS14_DIP(name) \
 	NET_REGISTER_DEV(TTL_74LS14_DIP, name)
 
 // usage       : TTL_7416_DIP(name)
-#define TTL_7416_DIP(name)                                                                          \
+#define TTL_7416_DIP(name) \
 	NET_REGISTER_DEV(TTL_7416_DIP, name)
 
 // usage       : TTL_7417_DIP(name)
-#define TTL_7417_DIP(name)                                                                          \
+#define TTL_7417_DIP(name) \
 	NET_REGISTER_DEV(TTL_7417_DIP, name)
 
 // usage       : TTL_7420_DIP(name)
-#define TTL_7420_DIP(name)                                                                          \
+#define TTL_7420_DIP(name) \
 	NET_REGISTER_DEV(TTL_7420_DIP, name)
 
 // usage       : TTL_7421_DIP(name)
-#define TTL_7421_DIP(name)                                                                          \
+#define TTL_7421_DIP(name) \
 	NET_REGISTER_DEV(TTL_7421_DIP, name)
 
 // usage       : TTL_7425_DIP(name)
-#define TTL_7425_DIP(name)                                                                          \
+#define TTL_7425_DIP(name) \
 	NET_REGISTER_DEV(TTL_7425_DIP, name)
 
 // usage       : TTL_7427_DIP(name)
-#define TTL_7427_DIP(name)                                                                          \
+#define TTL_7427_DIP(name) \
 	NET_REGISTER_DEV(TTL_7427_DIP, name)
 
 // usage       : TTL_7430_DIP(name)
-#define TTL_7430_DIP(name)                                                                          \
+#define TTL_7430_DIP(name) \
 	NET_REGISTER_DEV(TTL_7430_DIP, name)
 
 // usage       : TTL_7432_DIP(name)
-#define TTL_7432_DIP(name)                                                                          \
+#define TTL_7432_DIP(name) \
 	NET_REGISTER_DEV(TTL_7432_DIP, name)
 
 // usage       : TTL_7437_DIP(name)
-#define TTL_7437_DIP(name)                                                                          \
+#define TTL_7437_DIP(name) \
 	NET_REGISTER_DEV(TTL_7437_DIP, name)
 
 // usage       : TTL_7438_DIP(name)
-#define TTL_7438_DIP(name)                                                                          \
+#define TTL_7438_DIP(name) \
 	NET_REGISTER_DEV(TTL_7438_DIP, name)
 
 // usage       : TTL_7442_DIP(name)
-#define TTL_7442_DIP(name)                                                                          \
+#define TTL_7442_DIP(name) \
 	NET_REGISTER_DEV(TTL_7442_DIP, name)
 
 // usage       : TTL_7448_DIP(name)
-#define TTL_7448_DIP(name)                                                                          \
+#define TTL_7448_DIP(name) \
 	NET_REGISTER_DEV(TTL_7448_DIP, name)
 
 // usage       : TTL_7450_DIP(name)
-#define TTL_7450_DIP(name)                                                                          \
+#define TTL_7450_DIP(name) \
 	NET_REGISTER_DEV(TTL_7450_DIP, name)
 
 // usage       : TTL_7473_DIP(name)
-#define TTL_7473_DIP(name)                                                                          \
+#define TTL_7473_DIP(name) \
 	NET_REGISTER_DEV(TTL_7473_DIP, name)
 
 // usage       : TTL_7473A_DIP(name)
-#define TTL_7473A_DIP(name)                                                                         \
+#define TTL_7473A_DIP(name) \
 	NET_REGISTER_DEV(TTL_7473A_DIP, name)
 
 // usage       : TTL_7474_DIP(name)
-#define TTL_7474_DIP(name)                                                                          \
+#define TTL_7474_DIP(name) \
 	NET_REGISTER_DEV(TTL_7474_DIP, name)
 
 // usage       : TTL_7475_DIP(name)
-#define TTL_7475_DIP(name)                                                                          \
+#define TTL_7475_DIP(name) \
 	NET_REGISTER_DEV(TTL_7475_DIP, name)
 
 // usage       : TTL_7477_DIP(name)
-#define TTL_7477_DIP(name)                                                                          \
+#define TTL_7477_DIP(name) \
 	NET_REGISTER_DEV(TTL_7477_DIP, name)
 
 // usage       : TTL_7483_DIP(name)
-#define TTL_7483_DIP(name)                                                                          \
+#define TTL_7483_DIP(name) \
 	NET_REGISTER_DEV(TTL_7483_DIP, name)
 
 // usage       : TTL_7485_DIP(name)
-#define TTL_7485_DIP(name)                                                                          \
+#define TTL_7485_DIP(name) \
 	NET_REGISTER_DEV(TTL_7485_DIP, name)
 
 // usage       : TTL_7486_DIP(name)
-#define TTL_7486_DIP(name)                                                                          \
+#define TTL_7486_DIP(name) \
 	NET_REGISTER_DEV(TTL_7486_DIP, name)
 
 // usage       : TTL_7490_DIP(name)
-#define TTL_7490_DIP(name)                                                                          \
+#define TTL_7490_DIP(name) \
 	NET_REGISTER_DEV(TTL_7490_DIP, name)
 
 // usage       : TTL_7492_DIP(name)
-#define TTL_7492_DIP(name)                                                                          \
+#define TTL_7492_DIP(name) \
 	NET_REGISTER_DEV(TTL_7492_DIP, name)
 
 // usage       : TTL_7493_DIP(name)
-#define TTL_7493_DIP(name)                                                                          \
+#define TTL_7493_DIP(name) \
 	NET_REGISTER_DEV(TTL_7493_DIP, name)
 
 // usage       : TTL_7497_DIP(name)
-#define TTL_7497_DIP(name)                                                                          \
+#define TTL_7497_DIP(name) \
 	NET_REGISTER_DEV(TTL_7497_DIP, name)
 
 // usage       : TTL_74107_DIP(name)
-#define TTL_74107_DIP(name)                                                                         \
+#define TTL_74107_DIP(name) \
 	NET_REGISTER_DEV(TTL_74107_DIP, name)
 
 // usage       : TTL_74107A_DIP(name)
-#define TTL_74107A_DIP(name)                                                                        \
+#define TTL_74107A_DIP(name) \
 	NET_REGISTER_DEV(TTL_74107A_DIP, name)
 
 // usage       : TTL_74113_DIP(name)
-#define TTL_74113_DIP(name)                                                                         \
+#define TTL_74113_DIP(name) \
 	NET_REGISTER_DEV(TTL_74113_DIP, name)
 
 // usage       : TTL_74113A_DIP(name)
-#define TTL_74113A_DIP(name)                                                                        \
+#define TTL_74113A_DIP(name) \
 	NET_REGISTER_DEV(TTL_74113A_DIP, name)
 
 // usage       : TTL_74121_DIP(name)
-#define TTL_74121_DIP(name)                                                                         \
+#define TTL_74121_DIP(name) \
 	NET_REGISTER_DEV(TTL_74121_DIP, name)
 
 // usage       : TTL_74123_DIP(name)
-#define TTL_74123_DIP(name)                                                                         \
+#define TTL_74123_DIP(name) \
 	NET_REGISTER_DEV(TTL_74123_DIP, name)
 
 // usage       : TTL_9602_DIP(name)
-#define TTL_9602_DIP(name)                                                                          \
+#define TTL_9602_DIP(name) \
 	NET_REGISTER_DEV(TTL_9602_DIP, name)
 
 // usage       : TTL_74125_DIP(name)
-#define TTL_74125_DIP(name)                                                                         \
+#define TTL_74125_DIP(name) \
 	NET_REGISTER_DEV(TTL_74125_DIP, name)
 
 // usage       : TTL_74126_DIP(name)
-#define TTL_74126_DIP(name)                                                                         \
+#define TTL_74126_DIP(name) \
 	NET_REGISTER_DEV(TTL_74126_DIP, name)
 
 // usage       : TTL_74139_DIP(name)
-#define TTL_74139_DIP(name)                                                                         \
+#define TTL_74139_DIP(name) \
 	NET_REGISTER_DEV(TTL_74139_DIP, name)
 
 // usage       : TTL_74147_DIP(name)
-#define TTL_74147_DIP(name)                                                                         \
+#define TTL_74147_DIP(name) \
 	NET_REGISTER_DEV(TTL_74147_DIP, name)
 
 // usage       : TTL_74148_DIP(name)
-#define TTL_74148_DIP(name)                                                                         \
+#define TTL_74148_DIP(name) \
 	NET_REGISTER_DEV(TTL_74148_DIP, name)
 
 // usage       : TTL_74151_DIP(name)
-#define TTL_74151_DIP(name)                                                                         \
+#define TTL_74151_DIP(name) \
 	NET_REGISTER_DEV(TTL_74151_DIP, name)
 
 // usage       : TTL_74153_DIP(name)
-#define TTL_74153_DIP(name)                                                                         \
+#define TTL_74153_DIP(name) \
 	NET_REGISTER_DEV(TTL_74153_DIP, name)
 
 // usage       : TTL_74155_DIP(name)
-#define TTL_74155_DIP(name)                                                                         \
+#define TTL_74155_DIP(name) \
 	NET_REGISTER_DEV(TTL_74155_DIP, name)
 
 // usage       : TTL_74156_DIP(name)
-#define TTL_74156_DIP(name)                                                                         \
+#define TTL_74156_DIP(name) \
 	NET_REGISTER_DEV(TTL_74156_DIP, name)
 
 // usage       : TTL_74157_DIP(name)
-#define TTL_74157_DIP(name)                                                                         \
+#define TTL_74157_DIP(name) \
 	NET_REGISTER_DEV(TTL_74157_DIP, name)
 
 // usage       : TTL_74161_DIP(name)
-#define TTL_74161_DIP(name)                                                                         \
+#define TTL_74161_DIP(name) \
 	NET_REGISTER_DEV(TTL_74161_DIP, name)
 
 // usage       : TTL_74163_DIP(name)
-#define TTL_74163_DIP(name)                                                                         \
+#define TTL_74163_DIP(name) \
 	NET_REGISTER_DEV(TTL_74163_DIP, name)
 
 // usage       : TTL_74164_DIP(name)
-#define TTL_74164_DIP(name)                                                                         \
+#define TTL_74164_DIP(name) \
 	NET_REGISTER_DEV(TTL_74164_DIP, name)
 
 // usage       : TTL_74165_DIP(name)
-#define TTL_74165_DIP(name)                                                                         \
+#define TTL_74165_DIP(name) \
 	NET_REGISTER_DEV(TTL_74165_DIP, name)
 
 // usage       : TTL_74166_DIP(name)
-#define TTL_74166_DIP(name)                                                                         \
+#define TTL_74166_DIP(name) \
 	NET_REGISTER_DEV(TTL_74166_DIP, name)
 
 // usage       : TTL_74174_DIP(name)
-#define TTL_74174_DIP(name)                                                                         \
+#define TTL_74174_DIP(name) \
 	NET_REGISTER_DEV(TTL_74174_DIP, name)
 
 // usage       : TTL_74175_DIP(name)
-#define TTL_74175_DIP(name)                                                                         \
+#define TTL_74175_DIP(name) \
 	NET_REGISTER_DEV(TTL_74175_DIP, name)
 
 // usage       : TTL_74192_DIP(name)
-#define TTL_74192_DIP(name)                                                                         \
+#define TTL_74192_DIP(name) \
 	NET_REGISTER_DEV(TTL_74192_DIP, name)
 
 // usage       : TTL_74193_DIP(name)
-#define TTL_74193_DIP(name)                                                                         \
+#define TTL_74193_DIP(name) \
 	NET_REGISTER_DEV(TTL_74193_DIP, name)
 
 // usage       : TTL_74194_DIP(name)
-#define TTL_74194_DIP(name)                                                                         \
+#define TTL_74194_DIP(name) \
 	NET_REGISTER_DEV(TTL_74194_DIP, name)
 
 // usage       : TTL_74260_DIP(name)
-#define TTL_74260_DIP(name)                                                                         \
+#define TTL_74260_DIP(name) \
 	NET_REGISTER_DEV(TTL_74260_DIP, name)
 
 // usage       : TTL_74279_DIP(name)
-#define TTL_74279_DIP(name)                                                                         \
+#define TTL_74279_DIP(name) \
 	NET_REGISTER_DEV(TTL_74279_DIP, name)
 
 // usage       : TTL_74290_DIP(name)
-#define TTL_74290_DIP(name)                                                                         \
+#define TTL_74290_DIP(name) \
 	NET_REGISTER_DEV(TTL_74290_DIP, name)
 
 // usage       : TTL_74293_DIP(name)
-#define TTL_74293_DIP(name)                                                                         \
+#define TTL_74293_DIP(name) \
 	NET_REGISTER_DEV(TTL_74293_DIP, name)
 
 // usage       : TTL_74365_DIP(name)
-#define TTL_74365_DIP(name)                                                                         \
+#define TTL_74365_DIP(name) \
 	NET_REGISTER_DEV(TTL_74365_DIP, name)
 
 // usage       : TTL_74368_DIP(name)
-#define TTL_74368_DIP(name)                                                                         \
+#define TTL_74368_DIP(name) \
 	NET_REGISTER_DEV(TTL_74368_DIP, name)
 
 // usage       : TTL_74377_DIP(name)
-#define TTL_74377_DIP(name)                                                                         \
+#define TTL_74377_DIP(name) \
 	NET_REGISTER_DEV(TTL_74377_DIP, name)
 
 // usage       : TTL_74378_DIP(name)
-#define TTL_74378_DIP(name)                                                                         \
+#define TTL_74378_DIP(name) \
 	NET_REGISTER_DEV(TTL_74378_DIP, name)
 
 // usage       : TTL_74379_DIP(name)
-#define TTL_74379_DIP(name)                                                                         \
+#define TTL_74379_DIP(name) \
 	NET_REGISTER_DEV(TTL_74379_DIP, name)
 
 // usage       : TTL_74393_DIP(name)
-#define TTL_74393_DIP(name)                                                                         \
+#define TTL_74393_DIP(name) \
 	NET_REGISTER_DEV(TTL_74393_DIP, name)
 
 // usage       : SN74LS629_DIP(name)
-#define SN74LS629_DIP(name)                                                                         \
+#define SN74LS629_DIP(name) \
 	NET_REGISTER_DEV(SN74LS629_DIP, name)
 
 // usage       : TTL_9310_DIP(name)
-#define TTL_9310_DIP(name)                                                                          \
+#define TTL_9310_DIP(name) \
 	NET_REGISTER_DEV(TTL_9310_DIP, name)
 
 // usage       : TTL_9312_DIP(name)
-#define TTL_9312_DIP(name)                                                                          \
+#define TTL_9312_DIP(name) \
 	NET_REGISTER_DEV(TTL_9312_DIP, name)
 
 // usage       : TTL_9314_DIP(name)
-#define TTL_9314_DIP(name)                                                                          \
+#define TTL_9314_DIP(name) \
 	NET_REGISTER_DEV(TTL_9314_DIP, name)
 
 // usage       : TTL_9316_DIP(name)
-#define TTL_9316_DIP(name)                                                                          \
+#define TTL_9316_DIP(name) \
 	NET_REGISTER_DEV(TTL_9316_DIP, name)
 
 // usage       : TTL_9321_DIP(name)
-#define TTL_9321_DIP(name)                                                                          \
+#define TTL_9321_DIP(name) \
 	NET_REGISTER_DEV(TTL_9321_DIP, name)
 
 // usage       : TTL_9322_DIP(name)
-#define TTL_9322_DIP(name)                                                                          \
+#define TTL_9322_DIP(name) \
 	NET_REGISTER_DEV(TTL_9322_DIP, name)
 
 // usage       : TTL_9334_DIP(name)
-#define TTL_9334_DIP(name)                                                                          \
+#define TTL_9334_DIP(name) \
 	NET_REGISTER_DEV(TTL_9334_DIP, name)
 
 // usage       : TTL_8277_DIP(name)
-#define TTL_8277_DIP(name)                                                                          \
+#define TTL_8277_DIP(name) \
 	NET_REGISTER_DEV(TTL_8277_DIP, name)
 
 // usage       : TTL_AM2847_DIP(name)
-#define TTL_AM2847_DIP(name)                                                                        \
+#define TTL_AM2847_DIP(name) \
 	NET_REGISTER_DEV(TTL_AM2847_DIP, name)
 
 // ---------------------------------------------------------------------
@@ -1743,8 +1743,8 @@ NETLIST_EXTERNAL(ttl74xx_lib)
 // ---------------------------------------------------------------------
 
 // usage       : SOLVER(name, FREQ)
-#define SOLVER(name, ...)                                                                           \
-	__VA_OPT__(CHECK_PARAM_COUNT(SOLVER, PNARGS(__VA_ARGS__), 1))                                   \
+#define SOLVER(name, ...) \
+	__VA_OPT__(NET_CHECK_PARAM_COUNT(SOLVER, PNARGS(__VA_ARGS__), 1)) \
 	NET_REGISTER_DEV(SOLVER, name __VA_OPT__(,) __VA_ARGS__)
 
 #endif // __PLIB_PREPROCESSOR__

--- a/src/lib/netlist/generated/nld_devinc.h
+++ b/src/lib/netlist/generated/nld_devinc.h
@@ -9,18 +9,21 @@
 
 #include "../nl_setup.h"
 
+#define CHECK_PARAM_COUNT(dev, nargs, N) \
+	static_assert(nargs == N, #dev": Mismatched number of parameters passed, expected " #N " but got " #nargs);
+
 // ---------------------------------------------------------------------
 // Source: ../analog/nld_bjt.cpp
 // ---------------------------------------------------------------------
 
 // usage       : QBJT_EB(name, MODEL)
-#define QBJT_EB(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "QBJT_EB: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define QBJT_EB(name, ...)                                                                          \
+	__VA_OPT__(CHECK_PARAM_COUNT(QBJT_EB, PNARGS(__VA_ARGS__), 1))                                  \
 	NET_REGISTER_DEV(QBJT_EB, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : QBJT_SW(name, MODEL)
-#define QBJT_SW(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "QBJT_SW: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define QBJT_SW(name, ...)                                                                          \
+	__VA_OPT__(CHECK_PARAM_COUNT(QBJT_SW, PNARGS(__VA_ARGS__), 1))                                  \
 	NET_REGISTER_DEV(QBJT_SW, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -28,8 +31,8 @@
 // ---------------------------------------------------------------------
 
 // usage       : MOSFET(name, MODEL)
-#define MOSFET(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "MOSFET: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define MOSFET(name, ...)                                                                           \
+	__VA_OPT__(CHECK_PARAM_COUNT(MOSFET, PNARGS(__VA_ARGS__), 1))                                   \
 	NET_REGISTER_DEV(MOSFET, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -37,8 +40,8 @@
 // ---------------------------------------------------------------------
 
 // usage       : OPAMP(name, MODEL)
-#define OPAMP(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "OPAMP: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define OPAMP(name, ...)                                                                            \
+	__VA_OPT__(CHECK_PARAM_COUNT(OPAMP, PNARGS(__VA_ARGS__), 1))                                    \
 	NET_REGISTER_DEV(OPAMP, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -46,11 +49,11 @@
 // ---------------------------------------------------------------------
 
 // usage       : SWITCH(name)
-#define SWITCH(name)                                                   \
+#define SWITCH(name)                                                                                \
 	NET_REGISTER_DEV(SWITCH, name)
 
 // usage       : SWITCH2(name)
-#define SWITCH2(name)                                                   \
+#define SWITCH2(name)                                                                               \
 	NET_REGISTER_DEV(SWITCH2, name)
 
 // ---------------------------------------------------------------------
@@ -58,27 +61,27 @@
 // ---------------------------------------------------------------------
 
 // usage       : VCVS(name, G)
-#define VCVS(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "VCVS: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define VCVS(name, ...)                                                                             \
+	__VA_OPT__(CHECK_PARAM_COUNT(VCVS, PNARGS(__VA_ARGS__), 1))                                     \
 	NET_REGISTER_DEV(VCVS, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : VCCS(name, G)
-#define VCCS(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "VCCS: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define VCCS(name, ...)                                                                             \
+	__VA_OPT__(CHECK_PARAM_COUNT(VCCS, PNARGS(__VA_ARGS__), 1))                                     \
 	NET_REGISTER_DEV(VCCS, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CCCS(name, G)
-#define CCCS(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "CCCS: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define CCCS(name, ...)                                                                             \
+	__VA_OPT__(CHECK_PARAM_COUNT(CCCS, PNARGS(__VA_ARGS__), 1))                                     \
 	NET_REGISTER_DEV(CCCS, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CCVS(name, G)
-#define CCVS(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "CCVS: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define CCVS(name, ...)                                                                             \
+	__VA_OPT__(CHECK_PARAM_COUNT(CCVS, PNARGS(__VA_ARGS__), 1))                                     \
 	NET_REGISTER_DEV(CCVS, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : LVCCS(name)
-#define LVCCS(name)                                                   \
+#define LVCCS(name)                                                                                 \
 	NET_REGISTER_DEV(LVCCS, name)
 
 // ---------------------------------------------------------------------
@@ -86,48 +89,48 @@
 // ---------------------------------------------------------------------
 
 // usage       : RES(name, R)
-#define RES(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "RES: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define RES(name, ...)                                                                              \
+	__VA_OPT__(CHECK_PARAM_COUNT(RES, PNARGS(__VA_ARGS__), 1))                                      \
 	NET_REGISTER_DEV(RES, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : POT(name, R)
-#define POT(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "POT: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define POT(name, ...)                                                                              \
+	__VA_OPT__(CHECK_PARAM_COUNT(POT, PNARGS(__VA_ARGS__), 1))                                      \
 	NET_REGISTER_DEV(POT, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : POT2(name, R)
-#define POT2(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "POT2: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define POT2(name, ...)                                                                             \
+	__VA_OPT__(CHECK_PARAM_COUNT(POT2, PNARGS(__VA_ARGS__), 1))                                     \
 	NET_REGISTER_DEV(POT2, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CAP(name, C)
-#define CAP(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "CAP: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define CAP(name, ...)                                                                              \
+	__VA_OPT__(CHECK_PARAM_COUNT(CAP, PNARGS(__VA_ARGS__), 1))                                      \
 	NET_REGISTER_DEV(CAP, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : IND(name, L)
-#define IND(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "IND: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define IND(name, ...)                                                                              \
+	__VA_OPT__(CHECK_PARAM_COUNT(IND, PNARGS(__VA_ARGS__), 1))                                      \
 	NET_REGISTER_DEV(IND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : DIODE(name, MODEL)
-#define DIODE(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "DIODE: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define DIODE(name, ...)                                                                            \
+	__VA_OPT__(CHECK_PARAM_COUNT(DIODE, PNARGS(__VA_ARGS__), 1))                                    \
 	NET_REGISTER_DEV(DIODE, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : ZDIODE(name, MODEL)
-#define ZDIODE(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "ZDIODE: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define ZDIODE(name, ...)                                                                           \
+	__VA_OPT__(CHECK_PARAM_COUNT(ZDIODE, PNARGS(__VA_ARGS__), 1))                                   \
 	NET_REGISTER_DEV(ZDIODE, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : VS(name, V)
-#define VS(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "VS: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define VS(name, ...)                                                                               \
+	__VA_OPT__(CHECK_PARAM_COUNT(VS, PNARGS(__VA_ARGS__), 1))                                       \
 	NET_REGISTER_DEV(VS, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CS(name, I)
-#define CS(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "CS: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define CS(name, ...)                                                                               \
+	__VA_OPT__(CHECK_PARAM_COUNT(CS, PNARGS(__VA_ARGS__), 1))                                       \
 	NET_REGISTER_DEV(CS, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -136,8 +139,8 @@
 
 // usage       : RAM_2102A(name, CEQ, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, RWQ, DI)
 // auto connect: VCC, GND
-#define RAM_2102A(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 13, "RAM_2102A: Mismatched number of parameters passed, expected 13 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define RAM_2102A(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(RAM_2102A, PNARGS(__VA_ARGS__), 13))                               \
 	NET_REGISTER_DEV(RAM_2102A, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -146,8 +149,8 @@
 
 // usage       : CD4006(name, CLOCK, D1, D2, D3, D4, D1P4, D1P4S, D2P4, D2P5, D3P4, D4P4, D4P5)
 // auto connect: VCC, GND
-#define CD4006(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 12, "CD4006: Mismatched number of parameters passed, expected 12 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define CD4006(name, ...)                                                                           \
+	__VA_OPT__(CHECK_PARAM_COUNT(CD4006, PNARGS(__VA_ARGS__), 12))                                  \
 	NET_REGISTER_DEV(CD4006, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -156,8 +159,8 @@
 
 // usage       : CD4013(name, CLOCK, DATA, RESET, SET)
 // auto connect: VDD, VSS
-#define CD4013(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "CD4013: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define CD4013(name, ...)                                                                           \
+	__VA_OPT__(CHECK_PARAM_COUNT(CD4013, PNARGS(__VA_ARGS__), 4))                                   \
 	NET_REGISTER_DEV(CD4013, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -165,11 +168,11 @@
 // ---------------------------------------------------------------------
 
 // usage       : CD4017(name)
-#define CD4017(name)                                                   \
+#define CD4017(name)                                                                                \
 	NET_REGISTER_DEV(CD4017, name)
 
 // usage       : CD4022(name)
-#define CD4022(name)                                                   \
+#define CD4022(name)                                                                                \
 	NET_REGISTER_DEV(CD4022, name)
 
 // ---------------------------------------------------------------------
@@ -177,12 +180,12 @@
 // ---------------------------------------------------------------------
 
 // usage       : CD4020(name, IP, RESET, VDD, VSS)
-#define CD4020(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "CD4020: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define CD4020(name, ...)                                                                           \
+	__VA_OPT__(CHECK_PARAM_COUNT(CD4020, PNARGS(__VA_ARGS__), 4))                                   \
 	NET_REGISTER_DEV(CD4020, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CD4024(name)
-#define CD4024(name)                                                   \
+#define CD4024(name)                                                                                \
 	NET_REGISTER_DEV(CD4024, name)
 
 // ---------------------------------------------------------------------
@@ -191,8 +194,8 @@
 
 // usage       : CD4029(name, PE, J1, J2, J3, J4, CI, UD, BD, CLK)
 // auto connect: VCC, GND
-#define CD4029(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "CD4029: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define CD4029(name, ...)                                                                           \
+	__VA_OPT__(CHECK_PARAM_COUNT(CD4029, PNARGS(__VA_ARGS__), 9))                                   \
 	NET_REGISTER_DEV(CD4029, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -201,8 +204,8 @@
 
 // usage       : CD4042(name, D1, D2, D3, D4, POL, CLK)
 // auto connect: VCC, GND
-#define CD4042(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 6, "CD4042: Mismatched number of parameters passed, expected 6 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define CD4042(name, ...)                                                                           \
+	__VA_OPT__(CHECK_PARAM_COUNT(CD4042, PNARGS(__VA_ARGS__), 6))                                   \
 	NET_REGISTER_DEV(CD4042, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -210,7 +213,7 @@
 // ---------------------------------------------------------------------
 
 // usage       : CD4053_GATE(name)
-#define CD4053_GATE(name)                                                   \
+#define CD4053_GATE(name)                                                                           \
 	NET_REGISTER_DEV(CD4053_GATE, name)
 
 // ---------------------------------------------------------------------
@@ -218,7 +221,7 @@
 // ---------------------------------------------------------------------
 
 // usage       : CD4066_GATE(name)
-#define CD4066_GATE(name)                                                   \
+#define CD4066_GATE(name)                                                                           \
 	NET_REGISTER_DEV(CD4066_GATE, name)
 
 // ---------------------------------------------------------------------
@@ -227,8 +230,8 @@
 
 // usage       : CD4076(name, I1, I2, I3, I4, ID1, ID2, OD1, OD2)
 // auto connect: VCC, GND
-#define CD4076(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 8, "CD4076: Mismatched number of parameters passed, expected 8 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define CD4076(name, ...)                                                                           \
+	__VA_OPT__(CHECK_PARAM_COUNT(CD4076, PNARGS(__VA_ARGS__), 8))                                   \
 	NET_REGISTER_DEV(CD4076, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -236,7 +239,7 @@
 // ---------------------------------------------------------------------
 
 // usage       : CD4316_GATE(name)
-#define CD4316_GATE(name)                                                   \
+#define CD4316_GATE(name)                                                                           \
 	NET_REGISTER_DEV(CD4316_GATE, name)
 
 // ---------------------------------------------------------------------
@@ -245,14 +248,14 @@
 
 // usage       : TTL_74107(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74107(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_74107: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74107(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74107, PNARGS(__VA_ARGS__), 4))                                \
 	NET_REGISTER_DEV(TTL_74107, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_74107A(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74107A(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_74107A: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74107A(name, ...)                                                                       \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74107A, PNARGS(__VA_ARGS__), 4))                               \
 	NET_REGISTER_DEV(TTL_74107A, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -261,14 +264,14 @@
 
 // usage       : TTL_74113(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74113(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_74113: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74113(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74113, PNARGS(__VA_ARGS__), 4))                                \
 	NET_REGISTER_DEV(TTL_74113, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_74113A(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74113A(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_74113A: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74113A(name, ...)                                                                       \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74113A, PNARGS(__VA_ARGS__), 4))                               \
 	NET_REGISTER_DEV(TTL_74113A, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -276,19 +279,19 @@
 // ---------------------------------------------------------------------
 
 // usage       : TTL_74123(name)
-#define TTL_74123(name)                                                   \
+#define TTL_74123(name)                                                                             \
 	NET_REGISTER_DEV(TTL_74123, name)
 
 // usage       : TTL_74121(name)
-#define TTL_74121(name)                                                   \
+#define TTL_74121(name)                                                                             \
 	NET_REGISTER_DEV(TTL_74121, name)
 
 // usage       : CD4538(name)
-#define CD4538(name)                                                   \
+#define CD4538(name)                                                                                \
 	NET_REGISTER_DEV(CD4538, name)
 
 // usage       : TTL_9602(name)
-#define TTL_9602(name)                                                   \
+#define TTL_9602(name)                                                                              \
 	NET_REGISTER_DEV(TTL_9602, name)
 
 // ---------------------------------------------------------------------
@@ -296,11 +299,11 @@
 // ---------------------------------------------------------------------
 
 // usage       : TTL_74125_GATE(name)
-#define TTL_74125_GATE(name)                                                   \
+#define TTL_74125_GATE(name)                                                                        \
 	NET_REGISTER_DEV(TTL_74125_GATE, name)
 
 // usage       : TTL_74126_GATE(name)
-#define TTL_74126_GATE(name)                                                   \
+#define TTL_74126_GATE(name)                                                                        \
 	NET_REGISTER_DEV(TTL_74126_GATE, name)
 
 // ---------------------------------------------------------------------
@@ -309,8 +312,8 @@
 
 // usage       : TTL_74153(name, C0, C1, C2, C3, A, B, G)
 // auto connect: VCC, GND
-#define TTL_74153(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 7, "TTL_74153: Mismatched number of parameters passed, expected 7 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74153(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74153, PNARGS(__VA_ARGS__), 7))                                \
 	NET_REGISTER_DEV(TTL_74153, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -319,14 +322,14 @@
 
 // usage       : TTL_74161(name, CLK, ENP, ENT, CLRQ, LOADQ, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_74161(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "TTL_74161: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74161(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74161, PNARGS(__VA_ARGS__), 9))                                \
 	NET_REGISTER_DEV(TTL_74161, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_74161_FIXME(name, A, B, C, D, CLRQ, LOADQ, CLK, ENP, ENT)
 // auto connect: VCC, GND
-#define TTL_74161_FIXME(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "TTL_74161_FIXME: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74161_FIXME(name, ...)                                                                  \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74161_FIXME, PNARGS(__VA_ARGS__), 9))                          \
 	NET_REGISTER_DEV(TTL_74161_FIXME, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -335,8 +338,8 @@
 
 // usage       : TTL_74163(name, CLK, ENP, ENT, CLRQ, LOADQ, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_74163(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "TTL_74163: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74163(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74163, PNARGS(__VA_ARGS__), 9))                                \
 	NET_REGISTER_DEV(TTL_74163, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -345,8 +348,8 @@
 
 // usage       : TTL_74164(name, A, B, CLRQ, CLK)
 // auto connect: VCC, GND
-#define TTL_74164(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_74164: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74164(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74164, PNARGS(__VA_ARGS__), 4))                                \
 	NET_REGISTER_DEV(TTL_74164, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -355,8 +358,8 @@
 
 // usage       : TTL_74165(name, CLK, CLKINH, SH_LDQ, SER, A, B, C, D, E, F, G, H)
 // auto connect: VCC, GND
-#define TTL_74165(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 12, "TTL_74165: Mismatched number of parameters passed, expected 12 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74165(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74165, PNARGS(__VA_ARGS__), 12))                               \
 	NET_REGISTER_DEV(TTL_74165, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -365,8 +368,8 @@
 
 // usage       : TTL_74166(name, CLK, CLKINH, SH_LDQ, SER, A, B, C, D, E, F, G, H, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74166(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 13, "TTL_74166: Mismatched number of parameters passed, expected 13 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74166(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74166, PNARGS(__VA_ARGS__), 13))                               \
 	NET_REGISTER_DEV(TTL_74166, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -375,8 +378,8 @@
 
 // usage       : TTL_74174(name, CLK, D1, D2, D3, D4, D5, D6, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74174(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 8, "TTL_74174: Mismatched number of parameters passed, expected 8 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74174(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74174, PNARGS(__VA_ARGS__), 8))                                \
 	NET_REGISTER_DEV(TTL_74174, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -385,8 +388,8 @@
 
 // usage       : TTL_74175(name, CLK, D1, D2, D3, D4, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74175(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 6, "TTL_74175: Mismatched number of parameters passed, expected 6 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74175(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74175, PNARGS(__VA_ARGS__), 6))                                \
 	NET_REGISTER_DEV(TTL_74175, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -395,8 +398,8 @@
 
 // usage       : TTL_74192(name, A, B, C, D, CLEAR, LOADQ, CU, CD)
 // auto connect: VCC, GND
-#define TTL_74192(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 8, "TTL_74192: Mismatched number of parameters passed, expected 8 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74192(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74192, PNARGS(__VA_ARGS__), 8))                                \
 	NET_REGISTER_DEV(TTL_74192, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -405,8 +408,8 @@
 
 // usage       : TTL_74193(name, A, B, C, D, CLEAR, LOADQ, CU, CD)
 // auto connect: VCC, GND
-#define TTL_74193(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 8, "TTL_74193: Mismatched number of parameters passed, expected 8 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74193(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74193, PNARGS(__VA_ARGS__), 8))                                \
 	NET_REGISTER_DEV(TTL_74193, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -415,8 +418,8 @@
 
 // usage       : TTL_74194(name, CLK, S0, S1, SRIN, A, B, C, D, SLIN, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74194(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 10, "TTL_74194: Mismatched number of parameters passed, expected 10 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74194(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74194, PNARGS(__VA_ARGS__), 10))                               \
 	NET_REGISTER_DEV(TTL_74194, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -425,8 +428,8 @@
 
 // usage       : TTL_74365(name, G1Q, G2Q, A1, A2, A3, A4, A5, A6)
 // auto connect: VCC, GND
-#define TTL_74365(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 8, "TTL_74365: Mismatched number of parameters passed, expected 8 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74365(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74365, PNARGS(__VA_ARGS__), 8))                                \
 	NET_REGISTER_DEV(TTL_74365, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -434,7 +437,7 @@
 // ---------------------------------------------------------------------
 
 // usage       : TTL_74377_GATE(name)
-#define TTL_74377_GATE(name)                                                   \
+#define TTL_74377_GATE(name)                                                                        \
 	NET_REGISTER_DEV(TTL_74377_GATE, name)
 
 // ---------------------------------------------------------------------
@@ -443,8 +446,8 @@
 
 // usage       : TTL_74393(name, CP, MR)
 // auto connect: VCC, GND
-#define TTL_74393(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_74393: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74393(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74393, PNARGS(__VA_ARGS__), 2))                                \
 	NET_REGISTER_DEV(TTL_74393, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -453,8 +456,8 @@
 
 // usage       : TTL_7448(name, A, B, C, D, LTQ, BIQ, RBIQ)
 // auto connect: VCC, GND
-#define TTL_7448(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 7, "TTL_7448: Mismatched number of parameters passed, expected 7 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7448(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7448, PNARGS(__VA_ARGS__), 7))                                 \
 	NET_REGISTER_DEV(TTL_7448, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -463,8 +466,8 @@
 
 // usage       : TTL_7450_ANDORINVERT(name, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_7450_ANDORINVERT(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7450_ANDORINVERT: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7450_ANDORINVERT(name, ...)                                                             \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7450_ANDORINVERT, PNARGS(__VA_ARGS__), 4))                     \
 	NET_REGISTER_DEV(TTL_7450_ANDORINVERT, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -473,14 +476,14 @@
 
 // usage       : TTL_7473(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_7473(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7473: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7473(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7473, PNARGS(__VA_ARGS__), 4))                                 \
 	NET_REGISTER_DEV(TTL_7473, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7473A(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_7473A(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7473A: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7473A(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7473A, PNARGS(__VA_ARGS__), 4))                                \
 	NET_REGISTER_DEV(TTL_7473A, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -489,8 +492,8 @@
 
 // usage       : TTL_7474(name, CLK, D, CLRQ, PREQ)
 // auto connect: VCC, GND
-#define TTL_7474(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7474: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7474(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7474, PNARGS(__VA_ARGS__), 4))                                 \
 	NET_REGISTER_DEV(TTL_7474, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -498,11 +501,11 @@
 // ---------------------------------------------------------------------
 
 // usage       : TTL_7475_GATE(name)
-#define TTL_7475_GATE(name)                                                   \
+#define TTL_7475_GATE(name)                                                                         \
 	NET_REGISTER_DEV(TTL_7475_GATE, name)
 
 // usage       : TTL_7477_GATE(name)
-#define TTL_7477_GATE(name)                                                   \
+#define TTL_7477_GATE(name)                                                                         \
 	NET_REGISTER_DEV(TTL_7477_GATE, name)
 
 // ---------------------------------------------------------------------
@@ -511,8 +514,8 @@
 
 // usage       : TTL_7483(name, A1, A2, A3, A4, B1, B2, B3, B4, C0)
 // auto connect: VCC, GND
-#define TTL_7483(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "TTL_7483: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7483(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7483, PNARGS(__VA_ARGS__), 9))                                 \
 	NET_REGISTER_DEV(TTL_7483, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -521,8 +524,8 @@
 
 // usage       : TTL_7485(name, A0, A1, A2, A3, B0, B1, B2, B3, LTIN, EQIN, GTIN)
 // auto connect: VCC, GND
-#define TTL_7485(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 11, "TTL_7485: Mismatched number of parameters passed, expected 11 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7485(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7485, PNARGS(__VA_ARGS__), 11))                                \
 	NET_REGISTER_DEV(TTL_7485, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -531,8 +534,8 @@
 
 // usage       : TTL_7490(name, A, B, R1, R2, R91, R92)
 // auto connect: VCC, GND
-#define TTL_7490(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 6, "TTL_7490: Mismatched number of parameters passed, expected 6 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7490(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7490, PNARGS(__VA_ARGS__), 6))                                 \
 	NET_REGISTER_DEV(TTL_7490, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -541,8 +544,8 @@
 
 // usage       : TTL_7492(name, A, B, R1, R2)
 // auto connect: VCC, GND
-#define TTL_7492(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7492: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7492(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7492, PNARGS(__VA_ARGS__), 4))                                 \
 	NET_REGISTER_DEV(TTL_7492, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -551,8 +554,8 @@
 
 // usage       : TTL_7493(name, CLKA, CLKB, R1, R2)
 // auto connect: VCC, GND
-#define TTL_7493(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7493: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7493(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7493, PNARGS(__VA_ARGS__), 4))                                 \
 	NET_REGISTER_DEV(TTL_7493, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -561,8 +564,8 @@
 
 // usage       : TTL_7497(name, CLK, STRBQ, ENQ, UNITYQ, CLR, B0, B1, B2, B3, B4, B5)
 // auto connect: VCC, GND
-#define TTL_7497(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 11, "TTL_7497: Mismatched number of parameters passed, expected 11 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7497(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7497, PNARGS(__VA_ARGS__), 11))                                \
 	NET_REGISTER_DEV(TTL_7497, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -571,8 +574,8 @@
 
 // usage       : SN74LS629(name, CAP)
 // auto connect: VCC, GND
-#define SN74LS629(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "SN74LS629: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define SN74LS629(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(SN74LS629, PNARGS(__VA_ARGS__), 1))                                \
 	NET_REGISTER_DEV(SN74LS629, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -581,8 +584,8 @@
 
 // usage       : TTL_8277(name, RESET, CLK, CLKA, D0A, D1A, DSA, CLKB, D0B, D1B, DSB)
 // auto connect: VCC, GND
-#define TTL_8277(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 10, "TTL_8277: Mismatched number of parameters passed, expected 10 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_8277(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_8277, PNARGS(__VA_ARGS__), 10))                                \
 	NET_REGISTER_DEV(TTL_8277, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -591,8 +594,8 @@
 
 // usage       : PROM_82S115(name, CE1Q, CE2, A0, A1, A2, A3, A4, A5, A6, A7, A8, STROBE)
 // auto connect: VCC, GND
-#define PROM_82S115(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 12, "PROM_82S115: Mismatched number of parameters passed, expected 12 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define PROM_82S115(name, ...)                                                                      \
+	__VA_OPT__(CHECK_PARAM_COUNT(PROM_82S115, PNARGS(__VA_ARGS__), 12))                             \
 	NET_REGISTER_DEV(PROM_82S115, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -600,7 +603,7 @@
 // ---------------------------------------------------------------------
 
 // usage       : TTL_82S16(name)
-#define TTL_82S16(name)                                                   \
+#define TTL_82S16(name)                                                                             \
 	NET_REGISTER_DEV(TTL_82S16, name)
 
 // ---------------------------------------------------------------------
@@ -609,8 +612,8 @@
 
 // usage       : TTL_9310(name, CLK, ENP, ENT, CLRQ, LOADQ, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_9310(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "TTL_9310: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_9310(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_9310, PNARGS(__VA_ARGS__), 9))                                 \
 	NET_REGISTER_DEV(TTL_9310, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -619,8 +622,8 @@
 
 // usage       : TTL_9316(name, CLK, ENP, ENT, CLRQ, LOADQ, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_9316(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "TTL_9316: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_9316(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_9316, PNARGS(__VA_ARGS__), 9))                                 \
 	NET_REGISTER_DEV(TTL_9316, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -628,8 +631,8 @@
 // ---------------------------------------------------------------------
 
 // usage       : TTL_9321(name, E, A0, A1)
-#define TTL_9321(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 3, "TTL_9321: Mismatched number of parameters passed, expected 3 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_9321(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_9321, PNARGS(__VA_ARGS__), 3))                                 \
 	NET_REGISTER_DEV(TTL_9321, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -638,8 +641,8 @@
 
 // usage       : TTL_9322(name, SELECT, A1, B1, A2, B2, A3, B3, A4, B4, STROBE)
 // auto connect: VCC, GND
-#define TTL_9322(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 10, "TTL_9322: Mismatched number of parameters passed, expected 10 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_9322(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_9322, PNARGS(__VA_ARGS__), 10))                                \
 	NET_REGISTER_DEV(TTL_9322, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -648,8 +651,8 @@
 
 // usage       : TTL_AM2847(name, CP, INA, INB, INC, IND, RCA, RCB, RCC, RCD)
 // auto connect: VSS, VDD
-#define TTL_AM2847(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "TTL_AM2847: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_AM2847(name, ...)                                                                       \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_AM2847, PNARGS(__VA_ARGS__), 9))                               \
 	NET_REGISTER_DEV(TTL_AM2847, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -658,8 +661,8 @@
 
 // usage       : TTL_9314(name, EQ, MRQ, S0Q, S1Q, S2Q, S3Q, D0, D1, D2, D3)
 // auto connect: VCC, GND
-#define TTL_9314(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 10, "TTL_9314: Mismatched number of parameters passed, expected 10 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_9314(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_9314, PNARGS(__VA_ARGS__), 10))                                \
 	NET_REGISTER_DEV(TTL_9314, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -668,8 +671,8 @@
 
 // usage       : TTL_9334(name, CQ, EQ, D, A0, A1, A2)
 // auto connect: VCC, GND
-#define TTL_9334(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 6, "TTL_9334: Mismatched number of parameters passed, expected 6 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_9334(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_9334, PNARGS(__VA_ARGS__), 6))                                 \
 	NET_REGISTER_DEV(TTL_9334, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -677,11 +680,11 @@
 // ---------------------------------------------------------------------
 
 // usage       : NETDEV_RSFF(name)
-#define NETDEV_RSFF(name)                                                   \
+#define NETDEV_RSFF(name)                                                                           \
 	NET_REGISTER_DEV(NETDEV_RSFF, name)
 
 // usage       : NETDEV_DELAY(name)
-#define NETDEV_DELAY(name)                                                   \
+#define NETDEV_DELAY(name)                                                                          \
 	NET_REGISTER_DEV(NETDEV_DELAY, name)
 
 // ---------------------------------------------------------------------
@@ -689,13 +692,13 @@
 // ---------------------------------------------------------------------
 
 // usage       : LOG(name, I)
-#define LOG(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "LOG: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define LOG(name, ...)                                                                              \
+	__VA_OPT__(CHECK_PARAM_COUNT(LOG, PNARGS(__VA_ARGS__), 1))                                      \
 	NET_REGISTER_DEV(LOG, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : LOGD(name, I, I2)
-#define LOGD(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "LOGD: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define LOGD(name, ...)                                                                             \
+	__VA_OPT__(CHECK_PARAM_COUNT(LOGD, PNARGS(__VA_ARGS__), 2))                                     \
 	NET_REGISTER_DEV(LOGD, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -703,7 +706,7 @@
 // ---------------------------------------------------------------------
 
 // usage       : MM5837(name)
-#define MM5837(name)                                                   \
+#define MM5837(name)                                                                                \
 	NET_REGISTER_DEV(MM5837, name)
 
 // ---------------------------------------------------------------------
@@ -711,11 +714,11 @@
 // ---------------------------------------------------------------------
 
 // usage       : NE555(name)
-#define NE555(name)                                                   \
+#define NE555(name)                                                                                 \
 	NET_REGISTER_DEV(NE555, name)
 
 // usage       : MC1455P(name)
-#define MC1455P(name)                                                   \
+#define MC1455P(name)                                                                               \
 	NET_REGISTER_DEV(MC1455P, name)
 
 // ---------------------------------------------------------------------
@@ -723,8 +726,8 @@
 // ---------------------------------------------------------------------
 
 // usage       : R2R_DAC(name, VIN, R, N)
-#define R2R_DAC(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 3, "R2R_DAC: Mismatched number of parameters passed, expected 3 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define R2R_DAC(name, ...)                                                                          \
+	__VA_OPT__(CHECK_PARAM_COUNT(R2R_DAC, PNARGS(__VA_ARGS__), 3))                                  \
 	NET_REGISTER_DEV(R2R_DAC, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -733,38 +736,38 @@
 
 // usage       : PROM_82S126(name, CE1Q, CE2Q, A0, A1, A2, A3, A4, A5, A6, A7)
 // auto connect: VCC, GND
-#define PROM_82S126(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 10, "PROM_82S126: Mismatched number of parameters passed, expected 10 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define PROM_82S126(name, ...)                                                                      \
+	__VA_OPT__(CHECK_PARAM_COUNT(PROM_82S126, PNARGS(__VA_ARGS__), 10))                             \
 	NET_REGISTER_DEV(PROM_82S126, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : PROM_74S287(name, CE1Q, CE2Q, A0, A1, A2, A3, A4, A5, A6, A7)
 // auto connect: VCC, GND
-#define PROM_74S287(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 10, "PROM_74S287: Mismatched number of parameters passed, expected 10 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define PROM_74S287(name, ...)                                                                      \
+	__VA_OPT__(CHECK_PARAM_COUNT(PROM_74S287, PNARGS(__VA_ARGS__), 10))                             \
 	NET_REGISTER_DEV(PROM_74S287, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : PROM_82S123(name, CEQ, A0, A1, A2, A3, A4)
 // auto connect: VCC, GND
-#define PROM_82S123(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 6, "PROM_82S123: Mismatched number of parameters passed, expected 6 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define PROM_82S123(name, ...)                                                                      \
+	__VA_OPT__(CHECK_PARAM_COUNT(PROM_82S123, PNARGS(__VA_ARGS__), 6))                              \
 	NET_REGISTER_DEV(PROM_82S123, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : EPROM_2716(name, CE2Q, CE1Q, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)
 // auto connect: VCC, GND
-#define EPROM_2716(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 13, "EPROM_2716: Mismatched number of parameters passed, expected 13 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define EPROM_2716(name, ...)                                                                       \
+	__VA_OPT__(CHECK_PARAM_COUNT(EPROM_2716, PNARGS(__VA_ARGS__), 13))                              \
 	NET_REGISTER_DEV(EPROM_2716, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : PROM_MK28000(name, OE1, OE2, ARQ, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)
 // auto connect: VCC, GND
-#define PROM_MK28000(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 14, "PROM_MK28000: Mismatched number of parameters passed, expected 14 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define PROM_MK28000(name, ...)                                                                     \
+	__VA_OPT__(CHECK_PARAM_COUNT(PROM_MK28000, PNARGS(__VA_ARGS__), 14))                            \
 	NET_REGISTER_DEV(PROM_MK28000, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : ROM_MCM14524(name, EN, CLK, A0, A1, A2, A3, A4, A5, A6, A7)
 // auto connect: VCC, GND
-#define ROM_MCM14524(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 10, "ROM_MCM14524: Mismatched number of parameters passed, expected 10 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define ROM_MCM14524(name, ...)                                                                     \
+	__VA_OPT__(CHECK_PARAM_COUNT(ROM_MCM14524, PNARGS(__VA_ARGS__), 10))                            \
 	NET_REGISTER_DEV(ROM_MCM14524, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -772,8 +775,8 @@
 // ---------------------------------------------------------------------
 
 // usage       : SCHMITT_TRIGGER(name, STMODEL)
-#define SCHMITT_TRIGGER(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "SCHMITT_TRIGGER: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define SCHMITT_TRIGGER(name, ...)                                                                  \
+	__VA_OPT__(CHECK_PARAM_COUNT(SCHMITT_TRIGGER, PNARGS(__VA_ARGS__), 1))                          \
 	NET_REGISTER_DEV(SCHMITT_TRIGGER, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -781,93 +784,93 @@
 // ---------------------------------------------------------------------
 
 // usage       : PARAMETER(name)
-#define PARAMETER(name)                                                   \
+#define PARAMETER(name)                                                                             \
 	NET_REGISTER_DEV(PARAMETER, name)
 
 // usage       : NC_PIN(name)
-#define NC_PIN(name)                                                   \
+#define NC_PIN(name)                                                                                \
 	NET_REGISTER_DEV(NC_PIN, name)
 
 // usage       : FRONTIER_DEV(name, I, G, Q)
-#define FRONTIER_DEV(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 3, "FRONTIER_DEV: Mismatched number of parameters passed, expected 3 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define FRONTIER_DEV(name, ...)                                                                     \
+	__VA_OPT__(CHECK_PARAM_COUNT(FRONTIER_DEV, PNARGS(__VA_ARGS__), 3))                             \
 	NET_REGISTER_DEV(FRONTIER_DEV, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : AFUNC(name, N, FUNC)
-#define AFUNC(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "AFUNC: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define AFUNC(name, ...)                                                                            \
+	__VA_OPT__(CHECK_PARAM_COUNT(AFUNC, PNARGS(__VA_ARGS__), 2))                                    \
 	NET_REGISTER_DEV(AFUNC, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : ANALOG_INPUT(name, IN)
-#define ANALOG_INPUT(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "ANALOG_INPUT: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define ANALOG_INPUT(name, ...)                                                                     \
+	__VA_OPT__(CHECK_PARAM_COUNT(ANALOG_INPUT, PNARGS(__VA_ARGS__), 1))                             \
 	NET_REGISTER_DEV(ANALOG_INPUT, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CLOCK(name, FREQ)
-#define CLOCK(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "CLOCK: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define CLOCK(name, ...)                                                                            \
+	__VA_OPT__(CHECK_PARAM_COUNT(CLOCK, PNARGS(__VA_ARGS__), 1))                                    \
 	NET_REGISTER_DEV(CLOCK, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : VARCLOCK(name, N, FUNC)
-#define VARCLOCK(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "VARCLOCK: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define VARCLOCK(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(VARCLOCK, PNARGS(__VA_ARGS__), 2))                                 \
 	NET_REGISTER_DEV(VARCLOCK, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : EXTCLOCK(name, FREQ, PATTERN)
-#define EXTCLOCK(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "EXTCLOCK: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define EXTCLOCK(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(EXTCLOCK, PNARGS(__VA_ARGS__), 2))                                 \
 	NET_REGISTER_DEV(EXTCLOCK, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : SYS_DSW(name, I, 1, 2)
-#define SYS_DSW(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 3, "SYS_DSW: Mismatched number of parameters passed, expected 3 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define SYS_DSW(name, ...)                                                                          \
+	__VA_OPT__(CHECK_PARAM_COUNT(SYS_DSW, PNARGS(__VA_ARGS__), 3))                                  \
 	NET_REGISTER_DEV(SYS_DSW, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : SYS_DSW2(name)
-#define SYS_DSW2(name)                                                   \
+#define SYS_DSW2(name)                                                                              \
 	NET_REGISTER_DEV(SYS_DSW2, name)
 
 // usage       : SYS_COMPD(name)
-#define SYS_COMPD(name)                                                   \
+#define SYS_COMPD(name)                                                                             \
 	NET_REGISTER_DEV(SYS_COMPD, name)
 
 // usage       : SYS_PULSE(name, DELAY, DURATION, INVERT_INPUT, INVERT_OUTPUT)
-#define SYS_PULSE(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "SYS_PULSE: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define SYS_PULSE(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(SYS_PULSE, PNARGS(__VA_ARGS__), 4))                                \
 	NET_REGISTER_DEV(SYS_PULSE, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : SYS_NOISE_MT_U(name, SIGMA)
-#define SYS_NOISE_MT_U(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "SYS_NOISE_MT_U: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define SYS_NOISE_MT_U(name, ...)                                                                   \
+	__VA_OPT__(CHECK_PARAM_COUNT(SYS_NOISE_MT_U, PNARGS(__VA_ARGS__), 1))                           \
 	NET_REGISTER_DEV(SYS_NOISE_MT_U, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : SYS_NOISE_MT_N(name, SIGMA)
-#define SYS_NOISE_MT_N(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "SYS_NOISE_MT_N: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define SYS_NOISE_MT_N(name, ...)                                                                   \
+	__VA_OPT__(CHECK_PARAM_COUNT(SYS_NOISE_MT_N, PNARGS(__VA_ARGS__), 1))                           \
 	NET_REGISTER_DEV(SYS_NOISE_MT_N, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : MAINCLOCK(name, FREQ)
-#define MAINCLOCK(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "MAINCLOCK: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define MAINCLOCK(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(MAINCLOCK, PNARGS(__VA_ARGS__), 1))                                \
 	NET_REGISTER_DEV(MAINCLOCK, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : GNDA(name)
-#define GNDA(name)                                                   \
+#define GNDA(name)                                                                                  \
 	NET_REGISTER_DEV(GNDA, name)
 
 // usage       : LOGIC_INPUT8(name, IN, MODEL)
-#define LOGIC_INPUT8(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "LOGIC_INPUT8: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define LOGIC_INPUT8(name, ...)                                                                     \
+	__VA_OPT__(CHECK_PARAM_COUNT(LOGIC_INPUT8, PNARGS(__VA_ARGS__), 2))                             \
 	NET_REGISTER_DEV(LOGIC_INPUT8, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : LOGIC_INPUT(name, IN, MODEL)
-#define LOGIC_INPUT(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "LOGIC_INPUT: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define LOGIC_INPUT(name, ...)                                                                      \
+	__VA_OPT__(CHECK_PARAM_COUNT(LOGIC_INPUT, PNARGS(__VA_ARGS__), 2))                              \
 	NET_REGISTER_DEV(LOGIC_INPUT, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_INPUT(name, IN)
-#define TTL_INPUT(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "TTL_INPUT: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_INPUT(name, ...)                                                                        \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_INPUT, PNARGS(__VA_ARGS__), 1))                                \
 	NET_REGISTER_DEV(TTL_INPUT, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -876,8 +879,8 @@
 
 // usage       : ROM_TMS4800(name, AR, OE1, OE2, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)
 // auto connect: VCC, GND
-#define ROM_TMS4800(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 14, "ROM_TMS4800: Mismatched number of parameters passed, expected 14 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define ROM_TMS4800(name, ...)                                                                      \
+	__VA_OPT__(CHECK_PARAM_COUNT(ROM_TMS4800, PNARGS(__VA_ARGS__), 14))                             \
 	NET_REGISTER_DEV(ROM_TMS4800, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
@@ -885,12 +888,12 @@
 // ---------------------------------------------------------------------
 
 // usage       : TTL_TRISTATE(name, CEQ1, D1, CEQ2, D2)
-#define TTL_TRISTATE(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_TRISTATE: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_TRISTATE(name, ...)                                                                     \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_TRISTATE, PNARGS(__VA_ARGS__), 4))                             \
 	NET_REGISTER_DEV(TTL_TRISTATE, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_TRISTATE3(name)
-#define TTL_TRISTATE3(name)                                                   \
+#define TTL_TRISTATE3(name)                                                                         \
 	NET_REGISTER_DEV(TTL_TRISTATE3, name)
 
 // ---------------------------------------------------------------------
@@ -923,128 +926,128 @@ NETLIST_EXTERNAL(base_lib)
 // ---------------------------------------------------------------------
 
 // usage       : CD4001_GATE(name)
-#define CD4001_GATE(name)                                                   \
+#define CD4001_GATE(name)                                                                           \
 	NET_REGISTER_DEV(CD4001_GATE, name)
 
 // usage       : CD4011_GATE(name)
-#define CD4011_GATE(name)                                                   \
+#define CD4011_GATE(name)                                                                           \
 	NET_REGISTER_DEV(CD4011_GATE, name)
 
 // usage       : CD4030_GATE(name)
-#define CD4030_GATE(name)                                                   \
+#define CD4030_GATE(name)                                                                           \
 	NET_REGISTER_DEV(CD4030_GATE, name)
 
 // usage       : CD4049_GATE(name)
-#define CD4049_GATE(name)                                                   \
+#define CD4049_GATE(name)                                                                           \
 	NET_REGISTER_DEV(CD4049_GATE, name)
 
 // usage       : CD4069_GATE(name)
-#define CD4069_GATE(name)                                                   \
+#define CD4069_GATE(name)                                                                           \
 	NET_REGISTER_DEV(CD4069_GATE, name)
 
 // usage       : CD4070_GATE(name)
-#define CD4070_GATE(name)                                                   \
+#define CD4070_GATE(name)                                                                           \
 	NET_REGISTER_DEV(CD4070_GATE, name)
 
 // usage       : CD4071_GATE(name)
-#define CD4071_GATE(name)                                                   \
+#define CD4071_GATE(name)                                                                           \
 	NET_REGISTER_DEV(CD4071_GATE, name)
 
 // usage       : CD4081_GATE(name)
-#define CD4081_GATE(name)                                                   \
+#define CD4081_GATE(name)                                                                           \
 	NET_REGISTER_DEV(CD4081_GATE, name)
 
 NETLIST_EXTERNAL(cd4xxx_lib)
 // usage       : CD4001_DIP(name)
-#define CD4001_DIP(name)                                                   \
+#define CD4001_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4001_DIP, name)
 
 // usage       : CD4011_DIP(name)
-#define CD4011_DIP(name)                                                   \
+#define CD4011_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4011_DIP, name)
 
 // usage       : CD4030_DIP(name)
-#define CD4030_DIP(name)                                                   \
+#define CD4030_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4030_DIP, name)
 
 // usage       : CD4049_DIP(name)
-#define CD4049_DIP(name)                                                   \
+#define CD4049_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4049_DIP, name)
 
 // usage       : CD4069_DIP(name)
-#define CD4069_DIP(name)                                                   \
+#define CD4069_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4069_DIP, name)
 
 // usage       : CD4070_DIP(name)
-#define CD4070_DIP(name)                                                   \
+#define CD4070_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4070_DIP, name)
 
 // usage       : CD4071_DIP(name)
-#define CD4071_DIP(name)                                                   \
+#define CD4071_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4071_DIP, name)
 
 // usage       : CD4081_DIP(name)
-#define CD4081_DIP(name)                                                   \
+#define CD4081_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4081_DIP, name)
 
 // usage       : CD4006_DIP(name)
-#define CD4006_DIP(name)                                                   \
+#define CD4006_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4006_DIP, name)
 
 // usage       : CD4013_DIP(name)
-#define CD4013_DIP(name)                                                   \
+#define CD4013_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4013_DIP, name)
 
 // usage       : CD4017_DIP(name)
-#define CD4017_DIP(name)                                                   \
+#define CD4017_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4017_DIP, name)
 
 // usage       : CD4022_DIP(name)
-#define CD4022_DIP(name)                                                   \
+#define CD4022_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4022_DIP, name)
 
 // usage       : CD4020_DIP(name)
-#define CD4020_DIP(name)                                                   \
+#define CD4020_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4020_DIP, name)
 
 // usage       : CD4024_DIP(name)
-#define CD4024_DIP(name)                                                   \
+#define CD4024_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4024_DIP, name)
 
 // usage       : CD4029_DIP(name)
-#define CD4029_DIP(name)                                                   \
+#define CD4029_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4029_DIP, name)
 
 // usage       : CD4042_DIP(name)
-#define CD4042_DIP(name)                                                   \
+#define CD4042_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4042_DIP, name)
 
 // usage       : CD4053_DIP(name)
-#define CD4053_DIP(name)                                                   \
+#define CD4053_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4053_DIP, name)
 
 // usage       : CD4066_DIP(name)
-#define CD4066_DIP(name)                                                   \
+#define CD4066_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4066_DIP, name)
 
 // usage       : CD4016_DIP(name)
-#define CD4016_DIP(name)                                                   \
+#define CD4016_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4016_DIP, name)
 
 // usage       : CD4076_DIP(name)
-#define CD4076_DIP(name)                                                   \
+#define CD4076_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4076_DIP, name)
 
 // usage       : CD4316_DIP(name)
-#define CD4316_DIP(name)                                                   \
+#define CD4316_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4316_DIP, name)
 
 // usage       : CD4538_DIP(name)
-#define CD4538_DIP(name)                                                   \
+#define CD4538_DIP(name)                                                                            \
 	NET_REGISTER_DEV(CD4538_DIP, name)
 
 // usage       : MM5837_DIP(name)
-#define MM5837_DIP(name)                                                   \
+#define MM5837_DIP(name)                                                                            \
 	NET_REGISTER_DEV(MM5837_DIP, name)
 
 // ---------------------------------------------------------------------
@@ -1053,95 +1056,95 @@ NETLIST_EXTERNAL(cd4xxx_lib)
 
 NETLIST_EXTERNAL(opamp_lib)
 // usage       : opamp_layout_4_4_11(name)
-#define opamp_layout_4_4_11(name)                                                   \
+#define opamp_layout_4_4_11(name)                                                                   \
 	NET_REGISTER_DEV(opamp_layout_4_4_11, name)
 
 // usage       : opamp_layout_2_8_4(name)
-#define opamp_layout_2_8_4(name)                                                   \
+#define opamp_layout_2_8_4(name)                                                                    \
 	NET_REGISTER_DEV(opamp_layout_2_8_4, name)
 
 // usage       : opamp_layout_2_13_9_4(name)
-#define opamp_layout_2_13_9_4(name)                                                   \
+#define opamp_layout_2_13_9_4(name)                                                                 \
 	NET_REGISTER_DEV(opamp_layout_2_13_9_4, name)
 
 // usage       : opamp_layout_1_7_4(name)
-#define opamp_layout_1_7_4(name)                                                   \
+#define opamp_layout_1_7_4(name)                                                                    \
 	NET_REGISTER_DEV(opamp_layout_1_7_4, name)
 
 // usage       : opamp_layout_1_8_5(name)
-#define opamp_layout_1_8_5(name)                                                   \
+#define opamp_layout_1_8_5(name)                                                                    \
 	NET_REGISTER_DEV(opamp_layout_1_8_5, name)
 
 // usage       : opamp_layout_1_11_6(name)
-#define opamp_layout_1_11_6(name)                                                   \
+#define opamp_layout_1_11_6(name)                                                                   \
 	NET_REGISTER_DEV(opamp_layout_1_11_6, name)
 
 // usage       : MB3614_DIP(name)
-#define MB3614_DIP(name)                                                   \
+#define MB3614_DIP(name)                                                                            \
 	NET_REGISTER_DEV(MB3614_DIP, name)
 
 // usage       : MC3340_DIP(name)
-#define MC3340_DIP(name)                                                   \
+#define MC3340_DIP(name)                                                                            \
 	NET_REGISTER_DEV(MC3340_DIP, name)
 
 // usage       : TL081_DIP(name)
-#define TL081_DIP(name)                                                   \
+#define TL081_DIP(name)                                                                             \
 	NET_REGISTER_DEV(TL081_DIP, name)
 
 // usage       : TL082_DIP(name)
-#define TL082_DIP(name)                                                   \
+#define TL082_DIP(name)                                                                             \
 	NET_REGISTER_DEV(TL082_DIP, name)
 
 // usage       : TL084_DIP(name)
-#define TL084_DIP(name)                                                   \
+#define TL084_DIP(name)                                                                             \
 	NET_REGISTER_DEV(TL084_DIP, name)
 
 // usage       : LM324_DIP(name)
-#define LM324_DIP(name)                                                   \
+#define LM324_DIP(name)                                                                             \
 	NET_REGISTER_DEV(LM324_DIP, name)
 
 // usage       : LM348_DIP(name)
-#define LM348_DIP(name)                                                   \
+#define LM348_DIP(name)                                                                             \
 	NET_REGISTER_DEV(LM348_DIP, name)
 
 // usage       : LM358_DIP(name)
-#define LM358_DIP(name)                                                   \
+#define LM358_DIP(name)                                                                             \
 	NET_REGISTER_DEV(LM358_DIP, name)
 
 // usage       : LM2902_DIP(name)
-#define LM2902_DIP(name)                                                   \
+#define LM2902_DIP(name)                                                                            \
 	NET_REGISTER_DEV(LM2902_DIP, name)
 
 // usage       : UA741_DIP8(name)
-#define UA741_DIP8(name)                                                   \
+#define UA741_DIP8(name)                                                                            \
 	NET_REGISTER_DEV(UA741_DIP8, name)
 
 // usage       : UA741_DIP10(name)
-#define UA741_DIP10(name)                                                   \
+#define UA741_DIP10(name)                                                                           \
 	NET_REGISTER_DEV(UA741_DIP10, name)
 
 // usage       : UA741_DIP14(name)
-#define UA741_DIP14(name)                                                   \
+#define UA741_DIP14(name)                                                                           \
 	NET_REGISTER_DEV(UA741_DIP14, name)
 
 // usage       : MC1558_DIP(name)
-#define MC1558_DIP(name)                                                   \
+#define MC1558_DIP(name)                                                                            \
 	NET_REGISTER_DEV(MC1558_DIP, name)
 
 // usage       : LM747_DIP(name)
-#define LM747_DIP(name)                                                   \
+#define LM747_DIP(name)                                                                             \
 	NET_REGISTER_DEV(LM747_DIP, name)
 
 // usage       : LM747A_DIP(name)
-#define LM747A_DIP(name)                                                   \
+#define LM747A_DIP(name)                                                                            \
 	NET_REGISTER_DEV(LM747A_DIP, name)
 
 // usage       : LM3900(name)
-#define LM3900(name)                                                   \
+#define LM3900(name)                                                                                \
 	NET_REGISTER_DEV(LM3900, name)
 
 // usage       : AN6551_SIL(name)
-#define AN6551_SIL(name)                                                   \
+#define AN6551_SIL(name)                                                                            \
 	NET_REGISTER_DEV(AN6551_SIL, name)
 
 // ---------------------------------------------------------------------
@@ -1149,24 +1152,24 @@ NETLIST_EXTERNAL(opamp_lib)
 // ---------------------------------------------------------------------
 
 // usage       : MC14584B_GATE(name)
-#define MC14584B_GATE(name)                                                   \
+#define MC14584B_GATE(name)                                                                         \
 	NET_REGISTER_DEV(MC14584B_GATE, name)
 
 NETLIST_EXTERNAL(otheric_lib)
 // usage       : MC14584B_DIP(name)
-#define MC14584B_DIP(name)                                                   \
+#define MC14584B_DIP(name)                                                                          \
 	NET_REGISTER_DEV(MC14584B_DIP, name)
 
 // usage       : NE566_DIP(name)
-#define NE566_DIP(name)                                                   \
+#define NE566_DIP(name)                                                                             \
 	NET_REGISTER_DEV(NE566_DIP, name)
 
 // usage       : NE555_DIP(name)
-#define NE555_DIP(name)                                                   \
+#define NE555_DIP(name)                                                                             \
 	NET_REGISTER_DEV(NE555_DIP, name)
 
 // usage       : MC1455P_DIP(name)
-#define MC1455P_DIP(name)                                                   \
+#define MC1455P_DIP(name)                                                                           \
 	NET_REGISTER_DEV(MC1455P_DIP, name)
 
 // ---------------------------------------------------------------------
@@ -1175,43 +1178,43 @@ NETLIST_EXTERNAL(otheric_lib)
 
 NETLIST_EXTERNAL(roms_lib)
 // usage       : PROM_82S123_DIP(name)
-#define PROM_82S123_DIP(name)                                                   \
+#define PROM_82S123_DIP(name)                                                                       \
 	NET_REGISTER_DEV(PROM_82S123_DIP, name)
 
 // usage       : PROM_82S126_DIP(name)
-#define PROM_82S126_DIP(name)                                                   \
+#define PROM_82S126_DIP(name)                                                                       \
 	NET_REGISTER_DEV(PROM_82S126_DIP, name)
 
 // usage       : PROM_74S287_DIP(name)
-#define PROM_74S287_DIP(name)                                                   \
+#define PROM_74S287_DIP(name)                                                                       \
 	NET_REGISTER_DEV(PROM_74S287_DIP, name)
 
 // usage       : EPROM_2716_DIP(name)
-#define EPROM_2716_DIP(name)                                                   \
+#define EPROM_2716_DIP(name)                                                                        \
 	NET_REGISTER_DEV(EPROM_2716_DIP, name)
 
 // usage       : TTL_82S16_DIP(name)
-#define TTL_82S16_DIP(name)                                                   \
+#define TTL_82S16_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_82S16_DIP, name)
 
 // usage       : PROM_82S115_DIP(name)
-#define PROM_82S115_DIP(name)                                                   \
+#define PROM_82S115_DIP(name)                                                                       \
 	NET_REGISTER_DEV(PROM_82S115_DIP, name)
 
 // usage       : PROM_MK28000_DIP(name)
-#define PROM_MK28000_DIP(name)                                                   \
+#define PROM_MK28000_DIP(name)                                                                      \
 	NET_REGISTER_DEV(PROM_MK28000_DIP, name)
 
 // usage       : ROM_MCM14524_DIP(name)
-#define ROM_MCM14524_DIP(name)                                                   \
+#define ROM_MCM14524_DIP(name)                                                                      \
 	NET_REGISTER_DEV(ROM_MCM14524_DIP, name)
 
 // usage       : RAM_2102A_DIP(name)
-#define RAM_2102A_DIP(name)                                                   \
+#define RAM_2102A_DIP(name)                                                                         \
 	NET_REGISTER_DEV(RAM_2102A_DIP, name)
 
 // usage       : ROM_TMS4800_DIP(name)
-#define ROM_TMS4800_DIP(name)                                                   \
+#define ROM_TMS4800_DIP(name)                                                                       \
 	NET_REGISTER_DEV(ROM_TMS4800_DIP, name)
 
 // ---------------------------------------------------------------------
@@ -1220,519 +1223,519 @@ NETLIST_EXTERNAL(roms_lib)
 
 // usage       : TTL_7400_NAND(name, A, B)
 // auto connect: VCC, GND
-#define TTL_7400_NAND(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_7400_NAND: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7400_NAND(name, ...)                                                                    \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7400_NAND, PNARGS(__VA_ARGS__), 2))                            \
 	NET_REGISTER_DEV(TTL_7400_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7402_NOR(name, A, B)
 // auto connect: VCC, GND
-#define TTL_7402_NOR(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_7402_NOR: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7402_NOR(name, ...)                                                                     \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7402_NOR, PNARGS(__VA_ARGS__), 2))                             \
 	NET_REGISTER_DEV(TTL_7402_NOR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7404_INVERT(name, A)
 // auto connect: VCC, GND
-#define TTL_7404_INVERT(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "TTL_7404_INVERT: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7404_INVERT(name, ...)                                                                  \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7404_INVERT, PNARGS(__VA_ARGS__), 1))                          \
 	NET_REGISTER_DEV(TTL_7404_INVERT, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7406_GATE(name)
-#define TTL_7406_GATE(name)                                                   \
+#define TTL_7406_GATE(name)                                                                         \
 	NET_REGISTER_DEV(TTL_7406_GATE, name)
 
 // usage       : TTL_7407_GATE(name)
-#define TTL_7407_GATE(name)                                                   \
+#define TTL_7407_GATE(name)                                                                         \
 	NET_REGISTER_DEV(TTL_7407_GATE, name)
 
 // usage       : TTL_7408_GATE(name)
-#define TTL_7408_GATE(name)                                                   \
+#define TTL_7408_GATE(name)                                                                         \
 	NET_REGISTER_DEV(TTL_7408_GATE, name)
 
 // usage       : TTL_7408_AND(name, A, B)
 // auto connect: VCC, GND
-#define TTL_7408_AND(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_7408_AND: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7408_AND(name, ...)                                                                     \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7408_AND, PNARGS(__VA_ARGS__), 2))                             \
 	NET_REGISTER_DEV(TTL_7408_AND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7410_NAND(name, A, B, C)
 // auto connect: VCC, GND
-#define TTL_7410_NAND(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 3, "TTL_7410_NAND: Mismatched number of parameters passed, expected 3 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7410_NAND(name, ...)                                                                    \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7410_NAND, PNARGS(__VA_ARGS__), 3))                            \
 	NET_REGISTER_DEV(TTL_7410_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7410_GATE(name)
-#define TTL_7410_GATE(name)                                                   \
+#define TTL_7410_GATE(name)                                                                         \
 	NET_REGISTER_DEV(TTL_7410_GATE, name)
 
 // usage       : TTL_7411_AND(name, A, B, C)
 // auto connect: VCC, GND
-#define TTL_7411_AND(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 3, "TTL_7411_AND: Mismatched number of parameters passed, expected 3 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7411_AND(name, ...)                                                                     \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7411_AND, PNARGS(__VA_ARGS__), 3))                             \
 	NET_REGISTER_DEV(TTL_7411_AND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7411_GATE(name)
-#define TTL_7411_GATE(name)                                                   \
+#define TTL_7411_GATE(name)                                                                         \
 	NET_REGISTER_DEV(TTL_7411_GATE, name)
 
 // usage       : TTL_7416_GATE(name)
-#define TTL_7416_GATE(name)                                                   \
+#define TTL_7416_GATE(name)                                                                         \
 	NET_REGISTER_DEV(TTL_7416_GATE, name)
 
 // usage       : TTL_7417_GATE(name)
-#define TTL_7417_GATE(name)                                                   \
+#define TTL_7417_GATE(name)                                                                         \
 	NET_REGISTER_DEV(TTL_7417_GATE, name)
 
 // usage       : TTL_7420_NAND(name, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_7420_NAND(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7420_NAND: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7420_NAND(name, ...)                                                                    \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7420_NAND, PNARGS(__VA_ARGS__), 4))                            \
 	NET_REGISTER_DEV(TTL_7420_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7421_AND(name, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_7421_AND(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7421_AND: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7421_AND(name, ...)                                                                     \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7421_AND, PNARGS(__VA_ARGS__), 4))                             \
 	NET_REGISTER_DEV(TTL_7421_AND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7425_NOR(name, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_7425_NOR(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7425_NOR: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7425_NOR(name, ...)                                                                     \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7425_NOR, PNARGS(__VA_ARGS__), 4))                             \
 	NET_REGISTER_DEV(TTL_7425_NOR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7427_NOR(name, A, B, C)
 // auto connect: VCC, GND
-#define TTL_7427_NOR(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 3, "TTL_7427_NOR: Mismatched number of parameters passed, expected 3 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7427_NOR(name, ...)                                                                     \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7427_NOR, PNARGS(__VA_ARGS__), 3))                             \
 	NET_REGISTER_DEV(TTL_7427_NOR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7430_NAND(name, A, B, C, D, E, F, G, H)
 // auto connect: VCC, GND
-#define TTL_7430_NAND(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 8, "TTL_7430_NAND: Mismatched number of parameters passed, expected 8 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7430_NAND(name, ...)                                                                    \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7430_NAND, PNARGS(__VA_ARGS__), 8))                            \
 	NET_REGISTER_DEV(TTL_7430_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7432_OR(name, A, B)
 // auto connect: VCC, GND
-#define TTL_7432_OR(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_7432_OR: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7432_OR(name, ...)                                                                      \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7432_OR, PNARGS(__VA_ARGS__), 2))                              \
 	NET_REGISTER_DEV(TTL_7432_OR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7437_NAND(name, A, B)
-#define TTL_7437_NAND(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_7437_NAND: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7437_NAND(name, ...)                                                                    \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7437_NAND, PNARGS(__VA_ARGS__), 2))                            \
 	NET_REGISTER_DEV(TTL_7437_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7438_NAND(name, A, B)
-#define TTL_7438_NAND(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_7438_NAND: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7438_NAND(name, ...)                                                                    \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7438_NAND, PNARGS(__VA_ARGS__), 2))                            \
 	NET_REGISTER_DEV(TTL_7438_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7442(name)
-#define TTL_7442(name)                                                   \
+#define TTL_7442(name)                                                                              \
 	NET_REGISTER_DEV(TTL_7442, name)
 
 // usage       : TTL_7486_XOR(name, A, B)
 // auto connect: VCC, GND
-#define TTL_7486_XOR(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_7486_XOR: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_7486_XOR(name, ...)                                                                     \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_7486_XOR, PNARGS(__VA_ARGS__), 2))                             \
 	NET_REGISTER_DEV(TTL_7486_XOR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_74139_GATE(name)
-#define TTL_74139_GATE(name)                                                   \
+#define TTL_74139_GATE(name)                                                                        \
 	NET_REGISTER_DEV(TTL_74139_GATE, name)
 
 // usage       : TTL_74147_GATE(name)
-#define TTL_74147_GATE(name)                                                   \
+#define TTL_74147_GATE(name)                                                                        \
 	NET_REGISTER_DEV(TTL_74147_GATE, name)
 
 // usage       : TTL_74148_GATE(name)
-#define TTL_74148_GATE(name)                                                   \
+#define TTL_74148_GATE(name)                                                                        \
 	NET_REGISTER_DEV(TTL_74148_GATE, name)
 
 // usage       : TTL_74151_GATE(name)
-#define TTL_74151_GATE(name)                                                   \
+#define TTL_74151_GATE(name)                                                                        \
 	NET_REGISTER_DEV(TTL_74151_GATE, name)
 
 // usage       : TTL_74155A_GATE(name)
-#define TTL_74155A_GATE(name)                                                   \
+#define TTL_74155A_GATE(name)                                                                       \
 	NET_REGISTER_DEV(TTL_74155A_GATE, name)
 
 // usage       : TTL_74155B_GATE(name)
-#define TTL_74155B_GATE(name)                                                   \
+#define TTL_74155B_GATE(name)                                                                       \
 	NET_REGISTER_DEV(TTL_74155B_GATE, name)
 
 // usage       : TTL_74156A_GATE(name)
-#define TTL_74156A_GATE(name)                                                   \
+#define TTL_74156A_GATE(name)                                                                       \
 	NET_REGISTER_DEV(TTL_74156A_GATE, name)
 
 // usage       : TTL_74156B_GATE(name)
-#define TTL_74156B_GATE(name)                                                   \
+#define TTL_74156B_GATE(name)                                                                       \
 	NET_REGISTER_DEV(TTL_74156B_GATE, name)
 
 // usage       : TTL_74157_GATE(name)
-#define TTL_74157_GATE(name)                                                   \
+#define TTL_74157_GATE(name)                                                                        \
 	NET_REGISTER_DEV(TTL_74157_GATE, name)
 
 // usage       : TTL_74260_NOR(name, A, B, C, D, E)
 // auto connect: VCC, GND
-#define TTL_74260_NOR(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 5, "TTL_74260_NOR: Mismatched number of parameters passed, expected 5 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_74260_NOR(name, ...)                                                                    \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_74260_NOR, PNARGS(__VA_ARGS__), 5))                            \
 	NET_REGISTER_DEV(TTL_74260_NOR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_74279A(name)
-#define TTL_74279A(name)                                                   \
+#define TTL_74279A(name)                                                                            \
 	NET_REGISTER_DEV(TTL_74279A, name)
 
 // usage       : TTL_74279B(name)
-#define TTL_74279B(name)                                                   \
+#define TTL_74279B(name)                                                                            \
 	NET_REGISTER_DEV(TTL_74279B, name)
 
 // usage       : TTL_74368_GATE(name)
-#define TTL_74368_GATE(name)                                                   \
+#define TTL_74368_GATE(name)                                                                        \
 	NET_REGISTER_DEV(TTL_74368_GATE, name)
 
 // usage       : TTL_9312(name, A, B, C, G, D0, D1, D2, D3, D4, D5, D6, D7)
 // auto connect: VCC, GND
-#define TTL_9312(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 12, "TTL_9312: Mismatched number of parameters passed, expected 12 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define TTL_9312(name, ...)                                                                         \
+	__VA_OPT__(CHECK_PARAM_COUNT(TTL_9312, PNARGS(__VA_ARGS__), 12))                                \
 	NET_REGISTER_DEV(TTL_9312, name __VA_OPT__(,) __VA_ARGS__)
 
 NETLIST_EXTERNAL(ttl74xx_lib)
 // usage       : TTL_7400_DIP(name)
-#define TTL_7400_DIP(name)                                                   \
+#define TTL_7400_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7400_DIP, name)
 
 // usage       : TTL_7402_DIP(name)
-#define TTL_7402_DIP(name)                                                   \
+#define TTL_7402_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7402_DIP, name)
 
 // usage       : TTL_7404_DIP(name)
-#define TTL_7404_DIP(name)                                                   \
+#define TTL_7404_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7404_DIP, name)
 
 // usage       : TTL_7406_DIP(name)
-#define TTL_7406_DIP(name)                                                   \
+#define TTL_7406_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7406_DIP, name)
 
 // usage       : TTL_7407_DIP(name)
-#define TTL_7407_DIP(name)                                                   \
+#define TTL_7407_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7407_DIP, name)
 
 // usage       : TTL_7408_DIP(name)
-#define TTL_7408_DIP(name)                                                   \
+#define TTL_7408_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7408_DIP, name)
 
 // usage       : TTL_7410_DIP(name)
-#define TTL_7410_DIP(name)                                                   \
+#define TTL_7410_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7410_DIP, name)
 
 // usage       : TTL_7411_DIP(name)
-#define TTL_7411_DIP(name)                                                   \
+#define TTL_7411_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7411_DIP, name)
 
 // usage       : TTL_7414_GATE(name)
-#define TTL_7414_GATE(name)                                                   \
+#define TTL_7414_GATE(name)                                                                         \
 	NET_REGISTER_DEV(TTL_7414_GATE, name)
 
 // usage       : TTL_74LS14_GATE(name)
-#define TTL_74LS14_GATE(name)                                                   \
+#define TTL_74LS14_GATE(name)                                                                       \
 	NET_REGISTER_DEV(TTL_74LS14_GATE, name)
 
 // usage       : TTL_7414_DIP(name)
-#define TTL_7414_DIP(name)                                                   \
+#define TTL_7414_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7414_DIP, name)
 
 // usage       : TTL_74LS14_DIP(name)
-#define TTL_74LS14_DIP(name)                                                   \
+#define TTL_74LS14_DIP(name)                                                                        \
 	NET_REGISTER_DEV(TTL_74LS14_DIP, name)
 
 // usage       : TTL_7416_DIP(name)
-#define TTL_7416_DIP(name)                                                   \
+#define TTL_7416_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7416_DIP, name)
 
 // usage       : TTL_7417_DIP(name)
-#define TTL_7417_DIP(name)                                                   \
+#define TTL_7417_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7417_DIP, name)
 
 // usage       : TTL_7420_DIP(name)
-#define TTL_7420_DIP(name)                                                   \
+#define TTL_7420_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7420_DIP, name)
 
 // usage       : TTL_7421_DIP(name)
-#define TTL_7421_DIP(name)                                                   \
+#define TTL_7421_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7421_DIP, name)
 
 // usage       : TTL_7425_DIP(name)
-#define TTL_7425_DIP(name)                                                   \
+#define TTL_7425_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7425_DIP, name)
 
 // usage       : TTL_7427_DIP(name)
-#define TTL_7427_DIP(name)                                                   \
+#define TTL_7427_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7427_DIP, name)
 
 // usage       : TTL_7430_DIP(name)
-#define TTL_7430_DIP(name)                                                   \
+#define TTL_7430_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7430_DIP, name)
 
 // usage       : TTL_7432_DIP(name)
-#define TTL_7432_DIP(name)                                                   \
+#define TTL_7432_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7432_DIP, name)
 
 // usage       : TTL_7437_DIP(name)
-#define TTL_7437_DIP(name)                                                   \
+#define TTL_7437_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7437_DIP, name)
 
 // usage       : TTL_7438_DIP(name)
-#define TTL_7438_DIP(name)                                                   \
+#define TTL_7438_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7438_DIP, name)
 
 // usage       : TTL_7442_DIP(name)
-#define TTL_7442_DIP(name)                                                   \
+#define TTL_7442_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7442_DIP, name)
 
 // usage       : TTL_7448_DIP(name)
-#define TTL_7448_DIP(name)                                                   \
+#define TTL_7448_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7448_DIP, name)
 
 // usage       : TTL_7450_DIP(name)
-#define TTL_7450_DIP(name)                                                   \
+#define TTL_7450_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7450_DIP, name)
 
 // usage       : TTL_7473_DIP(name)
-#define TTL_7473_DIP(name)                                                   \
+#define TTL_7473_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7473_DIP, name)
 
 // usage       : TTL_7473A_DIP(name)
-#define TTL_7473A_DIP(name)                                                   \
+#define TTL_7473A_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_7473A_DIP, name)
 
 // usage       : TTL_7474_DIP(name)
-#define TTL_7474_DIP(name)                                                   \
+#define TTL_7474_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7474_DIP, name)
 
 // usage       : TTL_7475_DIP(name)
-#define TTL_7475_DIP(name)                                                   \
+#define TTL_7475_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7475_DIP, name)
 
 // usage       : TTL_7477_DIP(name)
-#define TTL_7477_DIP(name)                                                   \
+#define TTL_7477_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7477_DIP, name)
 
 // usage       : TTL_7483_DIP(name)
-#define TTL_7483_DIP(name)                                                   \
+#define TTL_7483_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7483_DIP, name)
 
 // usage       : TTL_7485_DIP(name)
-#define TTL_7485_DIP(name)                                                   \
+#define TTL_7485_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7485_DIP, name)
 
 // usage       : TTL_7486_DIP(name)
-#define TTL_7486_DIP(name)                                                   \
+#define TTL_7486_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7486_DIP, name)
 
 // usage       : TTL_7490_DIP(name)
-#define TTL_7490_DIP(name)                                                   \
+#define TTL_7490_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7490_DIP, name)
 
 // usage       : TTL_7492_DIP(name)
-#define TTL_7492_DIP(name)                                                   \
+#define TTL_7492_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7492_DIP, name)
 
 // usage       : TTL_7493_DIP(name)
-#define TTL_7493_DIP(name)                                                   \
+#define TTL_7493_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7493_DIP, name)
 
 // usage       : TTL_7497_DIP(name)
-#define TTL_7497_DIP(name)                                                   \
+#define TTL_7497_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_7497_DIP, name)
 
 // usage       : TTL_74107_DIP(name)
-#define TTL_74107_DIP(name)                                                   \
+#define TTL_74107_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74107_DIP, name)
 
 // usage       : TTL_74107A_DIP(name)
-#define TTL_74107A_DIP(name)                                                   \
+#define TTL_74107A_DIP(name)                                                                        \
 	NET_REGISTER_DEV(TTL_74107A_DIP, name)
 
 // usage       : TTL_74113_DIP(name)
-#define TTL_74113_DIP(name)                                                   \
+#define TTL_74113_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74113_DIP, name)
 
 // usage       : TTL_74113A_DIP(name)
-#define TTL_74113A_DIP(name)                                                   \
+#define TTL_74113A_DIP(name)                                                                        \
 	NET_REGISTER_DEV(TTL_74113A_DIP, name)
 
 // usage       : TTL_74121_DIP(name)
-#define TTL_74121_DIP(name)                                                   \
+#define TTL_74121_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74121_DIP, name)
 
 // usage       : TTL_74123_DIP(name)
-#define TTL_74123_DIP(name)                                                   \
+#define TTL_74123_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74123_DIP, name)
 
 // usage       : TTL_9602_DIP(name)
-#define TTL_9602_DIP(name)                                                   \
+#define TTL_9602_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_9602_DIP, name)
 
 // usage       : TTL_74125_DIP(name)
-#define TTL_74125_DIP(name)                                                   \
+#define TTL_74125_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74125_DIP, name)
 
 // usage       : TTL_74126_DIP(name)
-#define TTL_74126_DIP(name)                                                   \
+#define TTL_74126_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74126_DIP, name)
 
 // usage       : TTL_74139_DIP(name)
-#define TTL_74139_DIP(name)                                                   \
+#define TTL_74139_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74139_DIP, name)
 
 // usage       : TTL_74147_DIP(name)
-#define TTL_74147_DIP(name)                                                   \
+#define TTL_74147_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74147_DIP, name)
 
 // usage       : TTL_74148_DIP(name)
-#define TTL_74148_DIP(name)                                                   \
+#define TTL_74148_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74148_DIP, name)
 
 // usage       : TTL_74151_DIP(name)
-#define TTL_74151_DIP(name)                                                   \
+#define TTL_74151_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74151_DIP, name)
 
 // usage       : TTL_74153_DIP(name)
-#define TTL_74153_DIP(name)                                                   \
+#define TTL_74153_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74153_DIP, name)
 
 // usage       : TTL_74155_DIP(name)
-#define TTL_74155_DIP(name)                                                   \
+#define TTL_74155_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74155_DIP, name)
 
 // usage       : TTL_74156_DIP(name)
-#define TTL_74156_DIP(name)                                                   \
+#define TTL_74156_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74156_DIP, name)
 
 // usage       : TTL_74157_DIP(name)
-#define TTL_74157_DIP(name)                                                   \
+#define TTL_74157_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74157_DIP, name)
 
 // usage       : TTL_74161_DIP(name)
-#define TTL_74161_DIP(name)                                                   \
+#define TTL_74161_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74161_DIP, name)
 
 // usage       : TTL_74163_DIP(name)
-#define TTL_74163_DIP(name)                                                   \
+#define TTL_74163_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74163_DIP, name)
 
 // usage       : TTL_74164_DIP(name)
-#define TTL_74164_DIP(name)                                                   \
+#define TTL_74164_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74164_DIP, name)
 
 // usage       : TTL_74165_DIP(name)
-#define TTL_74165_DIP(name)                                                   \
+#define TTL_74165_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74165_DIP, name)
 
 // usage       : TTL_74166_DIP(name)
-#define TTL_74166_DIP(name)                                                   \
+#define TTL_74166_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74166_DIP, name)
 
 // usage       : TTL_74174_DIP(name)
-#define TTL_74174_DIP(name)                                                   \
+#define TTL_74174_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74174_DIP, name)
 
 // usage       : TTL_74175_DIP(name)
-#define TTL_74175_DIP(name)                                                   \
+#define TTL_74175_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74175_DIP, name)
 
 // usage       : TTL_74192_DIP(name)
-#define TTL_74192_DIP(name)                                                   \
+#define TTL_74192_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74192_DIP, name)
 
 // usage       : TTL_74193_DIP(name)
-#define TTL_74193_DIP(name)                                                   \
+#define TTL_74193_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74193_DIP, name)
 
 // usage       : TTL_74194_DIP(name)
-#define TTL_74194_DIP(name)                                                   \
+#define TTL_74194_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74194_DIP, name)
 
 // usage       : TTL_74260_DIP(name)
-#define TTL_74260_DIP(name)                                                   \
+#define TTL_74260_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74260_DIP, name)
 
 // usage       : TTL_74279_DIP(name)
-#define TTL_74279_DIP(name)                                                   \
+#define TTL_74279_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74279_DIP, name)
 
 // usage       : TTL_74290_DIP(name)
-#define TTL_74290_DIP(name)                                                   \
+#define TTL_74290_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74290_DIP, name)
 
 // usage       : TTL_74293_DIP(name)
-#define TTL_74293_DIP(name)                                                   \
+#define TTL_74293_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74293_DIP, name)
 
 // usage       : TTL_74365_DIP(name)
-#define TTL_74365_DIP(name)                                                   \
+#define TTL_74365_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74365_DIP, name)
 
 // usage       : TTL_74368_DIP(name)
-#define TTL_74368_DIP(name)                                                   \
+#define TTL_74368_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74368_DIP, name)
 
 // usage       : TTL_74377_DIP(name)
-#define TTL_74377_DIP(name)                                                   \
+#define TTL_74377_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74377_DIP, name)
 
 // usage       : TTL_74378_DIP(name)
-#define TTL_74378_DIP(name)                                                   \
+#define TTL_74378_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74378_DIP, name)
 
 // usage       : TTL_74379_DIP(name)
-#define TTL_74379_DIP(name)                                                   \
+#define TTL_74379_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74379_DIP, name)
 
 // usage       : TTL_74393_DIP(name)
-#define TTL_74393_DIP(name)                                                   \
+#define TTL_74393_DIP(name)                                                                         \
 	NET_REGISTER_DEV(TTL_74393_DIP, name)
 
 // usage       : SN74LS629_DIP(name)
-#define SN74LS629_DIP(name)                                                   \
+#define SN74LS629_DIP(name)                                                                         \
 	NET_REGISTER_DEV(SN74LS629_DIP, name)
 
 // usage       : TTL_9310_DIP(name)
-#define TTL_9310_DIP(name)                                                   \
+#define TTL_9310_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_9310_DIP, name)
 
 // usage       : TTL_9312_DIP(name)
-#define TTL_9312_DIP(name)                                                   \
+#define TTL_9312_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_9312_DIP, name)
 
 // usage       : TTL_9314_DIP(name)
-#define TTL_9314_DIP(name)                                                   \
+#define TTL_9314_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_9314_DIP, name)
 
 // usage       : TTL_9316_DIP(name)
-#define TTL_9316_DIP(name)                                                   \
+#define TTL_9316_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_9316_DIP, name)
 
 // usage       : TTL_9321_DIP(name)
-#define TTL_9321_DIP(name)                                                   \
+#define TTL_9321_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_9321_DIP, name)
 
 // usage       : TTL_9322_DIP(name)
-#define TTL_9322_DIP(name)                                                   \
+#define TTL_9322_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_9322_DIP, name)
 
 // usage       : TTL_9334_DIP(name)
-#define TTL_9334_DIP(name)                                                   \
+#define TTL_9334_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_9334_DIP, name)
 
 // usage       : TTL_8277_DIP(name)
-#define TTL_8277_DIP(name)                                                   \
+#define TTL_8277_DIP(name)                                                                          \
 	NET_REGISTER_DEV(TTL_8277_DIP, name)
 
 // usage       : TTL_AM2847_DIP(name)
-#define TTL_AM2847_DIP(name)                                                   \
+#define TTL_AM2847_DIP(name)                                                                        \
 	NET_REGISTER_DEV(TTL_AM2847_DIP, name)
 
 // ---------------------------------------------------------------------
@@ -1740,8 +1743,8 @@ NETLIST_EXTERNAL(ttl74xx_lib)
 // ---------------------------------------------------------------------
 
 // usage       : SOLVER(name, FREQ)
-#define SOLVER(name, ...)                                                   \
-	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "SOLVER: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+#define SOLVER(name, ...)                                                                           \
+	__VA_OPT__(CHECK_PARAM_COUNT(SOLVER, PNARGS(__VA_ARGS__), 1))                                   \
 	NET_REGISTER_DEV(SOLVER, name __VA_OPT__(,) __VA_ARGS__)
 
 #endif // __PLIB_PREPROCESSOR__

--- a/src/lib/netlist/generated/nld_devinc.h
+++ b/src/lib/netlist/generated/nld_devinc.h
@@ -14,28 +14,32 @@
 // ---------------------------------------------------------------------
 
 // usage       : QBJT_EB(name, MODEL)
-#define QBJT_EB(name, MODEL)                                                   \
-	NET_REGISTER_DEV(QBJT_EB, name, MODEL)
+#define QBJT_EB(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "QBJT_EB: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(QBJT_EB, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : QBJT_SW(name, MODEL)
-#define QBJT_SW(name, MODEL)                                                   \
-	NET_REGISTER_DEV(QBJT_SW, name, MODEL)
+#define QBJT_SW(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "QBJT_SW: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(QBJT_SW, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../analog/nld_mosfet.cpp
 // ---------------------------------------------------------------------
 
 // usage       : MOSFET(name, MODEL)
-#define MOSFET(name, MODEL)                                                   \
-	NET_REGISTER_DEV(MOSFET, name, MODEL)
+#define MOSFET(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "MOSFET: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(MOSFET, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../analog/nld_opamps.cpp
 // ---------------------------------------------------------------------
 
 // usage       : OPAMP(name, MODEL)
-#define OPAMP(name, MODEL)                                                   \
-	NET_REGISTER_DEV(OPAMP, name, MODEL)
+#define OPAMP(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "OPAMP: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(OPAMP, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../analog/nld_switches.cpp
@@ -54,20 +58,24 @@
 // ---------------------------------------------------------------------
 
 // usage       : VCVS(name, G)
-#define VCVS(name, G)                                                   \
-	NET_REGISTER_DEV(VCVS, name, G)
+#define VCVS(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "VCVS: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(VCVS, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : VCCS(name, G)
-#define VCCS(name, G)                                                   \
-	NET_REGISTER_DEV(VCCS, name, G)
+#define VCCS(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "VCCS: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(VCCS, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CCCS(name, G)
-#define CCCS(name, G)                                                   \
-	NET_REGISTER_DEV(CCCS, name, G)
+#define CCCS(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "CCCS: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(CCCS, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CCVS(name, G)
-#define CCVS(name, G)                                                   \
-	NET_REGISTER_DEV(CCVS, name, G)
+#define CCVS(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "CCVS: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(CCVS, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : LVCCS(name)
 #define LVCCS(name)                                                   \
@@ -78,40 +86,49 @@
 // ---------------------------------------------------------------------
 
 // usage       : RES(name, R)
-#define RES(name, R)                                                   \
-	NET_REGISTER_DEV(RES, name, R)
+#define RES(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "RES: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(RES, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : POT(name, R)
-#define POT(name, R)                                                   \
-	NET_REGISTER_DEV(POT, name, R)
+#define POT(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "POT: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(POT, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : POT2(name, R)
-#define POT2(name, R)                                                   \
-	NET_REGISTER_DEV(POT2, name, R)
+#define POT2(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "POT2: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(POT2, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CAP(name, C)
-#define CAP(name, C)                                                   \
-	NET_REGISTER_DEV(CAP, name, C)
+#define CAP(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "CAP: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(CAP, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : IND(name, L)
-#define IND(name, L)                                                   \
-	NET_REGISTER_DEV(IND, name, L)
+#define IND(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "IND: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(IND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : DIODE(name, MODEL)
-#define DIODE(name, MODEL)                                                   \
-	NET_REGISTER_DEV(DIODE, name, MODEL)
+#define DIODE(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "DIODE: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(DIODE, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : ZDIODE(name, MODEL)
-#define ZDIODE(name, MODEL)                                                   \
-	NET_REGISTER_DEV(ZDIODE, name, MODEL)
+#define ZDIODE(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "ZDIODE: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(ZDIODE, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : VS(name, V)
-#define VS(name, V)                                                   \
-	NET_REGISTER_DEV(VS, name, V)
+#define VS(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "VS: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(VS, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CS(name, I)
-#define CS(name, I)                                                   \
-	NET_REGISTER_DEV(CS, name, I)
+#define CS(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "CS: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(CS, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_2102a.cpp
@@ -554,8 +571,9 @@
 
 // usage       : SN74LS629(name, CAP)
 // auto connect: VCC, GND
-#define SN74LS629(name, CAP)                                                   \
-	NET_REGISTER_DEV(SN74LS629, name, CAP)
+#define SN74LS629(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "SN74LS629: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(SN74LS629, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_8277.cpp
@@ -705,8 +723,9 @@
 // ---------------------------------------------------------------------
 
 // usage       : R2R_DAC(name, VIN, R, N)
-#define R2R_DAC(name, VIN, R, N)                                                   \
-	NET_REGISTER_DEV(R2R_DAC, name, VIN, R, N)
+#define R2R_DAC(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 3, "R2R_DAC: Mismatched number of parameters passed, expected 3 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(R2R_DAC, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_roms.cpp
@@ -753,8 +772,9 @@
 // ---------------------------------------------------------------------
 
 // usage       : SCHMITT_TRIGGER(name, STMODEL)
-#define SCHMITT_TRIGGER(name, STMODEL)                                                   \
-	NET_REGISTER_DEV(SCHMITT_TRIGGER, name, STMODEL)
+#define SCHMITT_TRIGGER(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "SCHMITT_TRIGGER: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(SCHMITT_TRIGGER, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_system.cpp
@@ -774,26 +794,31 @@
 	NET_REGISTER_DEV(FRONTIER_DEV, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : AFUNC(name, N, FUNC)
-#define AFUNC(name, N, FUNC)                                                   \
-	NET_REGISTER_DEV(AFUNC, name, N, FUNC)
+#define AFUNC(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "AFUNC: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(AFUNC, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : ANALOG_INPUT(name, IN)
-#define ANALOG_INPUT(name, IN)                                                   \
-	NET_REGISTER_DEV(ANALOG_INPUT, name, IN)
+#define ANALOG_INPUT(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "ANALOG_INPUT: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(ANALOG_INPUT, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : CLOCK(name, FREQ)
-#define CLOCK(name, FREQ)                                                   \
-	NET_REGISTER_DEV(CLOCK, name, FREQ)
+#define CLOCK(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "CLOCK: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(CLOCK, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : VARCLOCK(name, N, FUNC)
-#define VARCLOCK(name, N, FUNC)                                                   \
-	NET_REGISTER_DEV(VARCLOCK, name, N, FUNC)
+#define VARCLOCK(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "VARCLOCK: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(VARCLOCK, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : EXTCLOCK(name, FREQ, PATTERN)
-#define EXTCLOCK(name, FREQ, PATTERN)                                                   \
-	NET_REGISTER_DEV(EXTCLOCK, name, FREQ, PATTERN)
+#define EXTCLOCK(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "EXTCLOCK: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(EXTCLOCK, name __VA_OPT__(,) __VA_ARGS__)
 
-// usage       : SYS_DSW(name, I, _1, _2)
+// usage       : SYS_DSW(name, I, 1, 2)
 #define SYS_DSW(name, ...)                                                   \
 	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 3, "SYS_DSW: Mismatched number of parameters passed, expected 3 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
 	NET_REGISTER_DEV(SYS_DSW, name __VA_OPT__(,) __VA_ARGS__)
@@ -807,36 +832,43 @@
 	NET_REGISTER_DEV(SYS_COMPD, name)
 
 // usage       : SYS_PULSE(name, DELAY, DURATION, INVERT_INPUT, INVERT_OUTPUT)
-#define SYS_PULSE(name, DELAY, DURATION, INVERT_INPUT, INVERT_OUTPUT)                                                   \
-	NET_REGISTER_DEV(SYS_PULSE, name, DELAY, DURATION, INVERT_INPUT, INVERT_OUTPUT)
+#define SYS_PULSE(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "SYS_PULSE: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(SYS_PULSE, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : SYS_NOISE_MT_U(name, SIGMA)
-#define SYS_NOISE_MT_U(name, SIGMA)                                                   \
-	NET_REGISTER_DEV(SYS_NOISE_MT_U, name, SIGMA)
+#define SYS_NOISE_MT_U(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "SYS_NOISE_MT_U: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(SYS_NOISE_MT_U, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : SYS_NOISE_MT_N(name, SIGMA)
-#define SYS_NOISE_MT_N(name, SIGMA)                                                   \
-	NET_REGISTER_DEV(SYS_NOISE_MT_N, name, SIGMA)
+#define SYS_NOISE_MT_N(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "SYS_NOISE_MT_N: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(SYS_NOISE_MT_N, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : MAINCLOCK(name, FREQ)
-#define MAINCLOCK(name, FREQ)                                                   \
-	NET_REGISTER_DEV(MAINCLOCK, name, FREQ)
+#define MAINCLOCK(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "MAINCLOCK: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(MAINCLOCK, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : GNDA(name)
 #define GNDA(name)                                                   \
 	NET_REGISTER_DEV(GNDA, name)
 
 // usage       : LOGIC_INPUT8(name, IN, MODEL)
-#define LOGIC_INPUT8(name, IN, MODEL)                                                   \
-	NET_REGISTER_DEV(LOGIC_INPUT8, name, IN, MODEL)
+#define LOGIC_INPUT8(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "LOGIC_INPUT8: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(LOGIC_INPUT8, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : LOGIC_INPUT(name, IN, MODEL)
-#define LOGIC_INPUT(name, IN, MODEL)                                                   \
-	NET_REGISTER_DEV(LOGIC_INPUT, name, IN, MODEL)
+#define LOGIC_INPUT(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "LOGIC_INPUT: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(LOGIC_INPUT, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_INPUT(name, IN)
-#define TTL_INPUT(name, IN)                                                   \
-	NET_REGISTER_DEV(TTL_INPUT, name, IN)
+#define TTL_INPUT(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "TTL_INPUT: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_INPUT, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_tms4800.cpp
@@ -1708,8 +1740,9 @@ NETLIST_EXTERNAL(ttl74xx_lib)
 // ---------------------------------------------------------------------
 
 // usage       : SOLVER(name, FREQ)
-#define SOLVER(name, FREQ)                                                   \
-	NET_REGISTER_DEV(SOLVER, name, FREQ)
+#define SOLVER(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "SOLVER: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(SOLVER, name __VA_OPT__(,) __VA_ARGS__)
 
 #endif // __PLIB_PREPROCESSOR__
 

--- a/src/lib/netlist/generated/nld_devinc.h
+++ b/src/lib/netlist/generated/nld_devinc.h
@@ -14,104 +14,104 @@
 // ---------------------------------------------------------------------
 
 // usage       : QBJT_EB(name, MODEL)
-#define QBJT_EB(...)                                                   \
-	NET_REGISTER_DEVEXT(QBJT_EB, __VA_ARGS__)
+#define QBJT_EB(name, MODEL)                                                   \
+	NET_REGISTER_DEV(QBJT_EB, name, MODEL)
 
 // usage       : QBJT_SW(name, MODEL)
-#define QBJT_SW(...)                                                   \
-	NET_REGISTER_DEVEXT(QBJT_SW, __VA_ARGS__)
+#define QBJT_SW(name, MODEL)                                                   \
+	NET_REGISTER_DEV(QBJT_SW, name, MODEL)
 
 // ---------------------------------------------------------------------
 // Source: ../analog/nld_mosfet.cpp
 // ---------------------------------------------------------------------
 
 // usage       : MOSFET(name, MODEL)
-#define MOSFET(...)                                                   \
-	NET_REGISTER_DEVEXT(MOSFET, __VA_ARGS__)
+#define MOSFET(name, MODEL)                                                   \
+	NET_REGISTER_DEV(MOSFET, name, MODEL)
 
 // ---------------------------------------------------------------------
 // Source: ../analog/nld_opamps.cpp
 // ---------------------------------------------------------------------
 
 // usage       : OPAMP(name, MODEL)
-#define OPAMP(...)                                                   \
-	NET_REGISTER_DEVEXT(OPAMP, __VA_ARGS__)
+#define OPAMP(name, MODEL)                                                   \
+	NET_REGISTER_DEV(OPAMP, name, MODEL)
 
 // ---------------------------------------------------------------------
 // Source: ../analog/nld_switches.cpp
 // ---------------------------------------------------------------------
 
-// usage       : SWITCH(name, )
-#define SWITCH(...)                                                   \
-	NET_REGISTER_DEVEXT(SWITCH, __VA_ARGS__)
+// usage       : SWITCH(name)
+#define SWITCH(name)                                                   \
+	NET_REGISTER_DEV(SWITCH, name)
 
-// usage       : SWITCH2(name, )
-#define SWITCH2(...)                                                   \
-	NET_REGISTER_DEVEXT(SWITCH2, __VA_ARGS__)
+// usage       : SWITCH2(name)
+#define SWITCH2(name)                                                   \
+	NET_REGISTER_DEV(SWITCH2, name)
 
 // ---------------------------------------------------------------------
 // Source: ../analog/nlid_fourterm.cpp
 // ---------------------------------------------------------------------
 
 // usage       : VCVS(name, G)
-#define VCVS(...)                                                   \
-	NET_REGISTER_DEVEXT(VCVS, __VA_ARGS__)
+#define VCVS(name, G)                                                   \
+	NET_REGISTER_DEV(VCVS, name, G)
 
 // usage       : VCCS(name, G)
-#define VCCS(...)                                                   \
-	NET_REGISTER_DEVEXT(VCCS, __VA_ARGS__)
+#define VCCS(name, G)                                                   \
+	NET_REGISTER_DEV(VCCS, name, G)
 
 // usage       : CCCS(name, G)
-#define CCCS(...)                                                   \
-	NET_REGISTER_DEVEXT(CCCS, __VA_ARGS__)
+#define CCCS(name, G)                                                   \
+	NET_REGISTER_DEV(CCCS, name, G)
 
 // usage       : CCVS(name, G)
-#define CCVS(...)                                                   \
-	NET_REGISTER_DEVEXT(CCVS, __VA_ARGS__)
+#define CCVS(name, G)                                                   \
+	NET_REGISTER_DEV(CCVS, name, G)
 
-// usage       : LVCCS(name, )
-#define LVCCS(...)                                                   \
-	NET_REGISTER_DEVEXT(LVCCS, __VA_ARGS__)
+// usage       : LVCCS(name)
+#define LVCCS(name)                                                   \
+	NET_REGISTER_DEV(LVCCS, name)
 
 // ---------------------------------------------------------------------
 // Source: ../analog/nlid_twoterm.cpp
 // ---------------------------------------------------------------------
 
 // usage       : RES(name, R)
-#define RES(...)                                                   \
-	NET_REGISTER_DEVEXT(RES, __VA_ARGS__)
+#define RES(name, R)                                                   \
+	NET_REGISTER_DEV(RES, name, R)
 
 // usage       : POT(name, R)
-#define POT(...)                                                   \
-	NET_REGISTER_DEVEXT(POT, __VA_ARGS__)
+#define POT(name, R)                                                   \
+	NET_REGISTER_DEV(POT, name, R)
 
 // usage       : POT2(name, R)
-#define POT2(...)                                                   \
-	NET_REGISTER_DEVEXT(POT2, __VA_ARGS__)
+#define POT2(name, R)                                                   \
+	NET_REGISTER_DEV(POT2, name, R)
 
 // usage       : CAP(name, C)
-#define CAP(...)                                                   \
-	NET_REGISTER_DEVEXT(CAP, __VA_ARGS__)
+#define CAP(name, C)                                                   \
+	NET_REGISTER_DEV(CAP, name, C)
 
 // usage       : IND(name, L)
-#define IND(...)                                                   \
-	NET_REGISTER_DEVEXT(IND, __VA_ARGS__)
+#define IND(name, L)                                                   \
+	NET_REGISTER_DEV(IND, name, L)
 
 // usage       : DIODE(name, MODEL)
-#define DIODE(...)                                                   \
-	NET_REGISTER_DEVEXT(DIODE, __VA_ARGS__)
+#define DIODE(name, MODEL)                                                   \
+	NET_REGISTER_DEV(DIODE, name, MODEL)
 
 // usage       : ZDIODE(name, MODEL)
-#define ZDIODE(...)                                                   \
-	NET_REGISTER_DEVEXT(ZDIODE, __VA_ARGS__)
+#define ZDIODE(name, MODEL)                                                   \
+	NET_REGISTER_DEV(ZDIODE, name, MODEL)
 
 // usage       : VS(name, V)
-#define VS(...)                                                   \
-	NET_REGISTER_DEVEXT(VS, __VA_ARGS__)
+#define VS(name, V)                                                   \
+	NET_REGISTER_DEV(VS, name, V)
 
 // usage       : CS(name, I)
-#define CS(...)                                                   \
-	NET_REGISTER_DEVEXT(CS, __VA_ARGS__)
+#define CS(name, I)                                                   \
+	NET_REGISTER_DEV(CS, name, I)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_2102a.cpp
@@ -119,8 +119,9 @@
 
 // usage       : RAM_2102A(name, CEQ, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, RWQ, DI)
 // auto connect: VCC, GND
-#define RAM_2102A(...)                                                   \
-	NET_REGISTER_DEVEXT(RAM_2102A, __VA_ARGS__)
+#define RAM_2102A(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 13, "RAM_2102A: Mismatched number of parameters passed, expected 13 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(RAM_2102A, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_4006.cpp
@@ -128,8 +129,9 @@
 
 // usage       : CD4006(name, CLOCK, D1, D2, D3, D4, D1P4, D1P4S, D2P4, D2P5, D3P4, D4P4, D4P5)
 // auto connect: VCC, GND
-#define CD4006(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4006, __VA_ARGS__)
+#define CD4006(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 12, "CD4006: Mismatched number of parameters passed, expected 12 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(CD4006, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_4013.cpp
@@ -137,32 +139,34 @@
 
 // usage       : CD4013(name, CLOCK, DATA, RESET, SET)
 // auto connect: VDD, VSS
-#define CD4013(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4013, __VA_ARGS__)
+#define CD4013(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "CD4013: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(CD4013, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_4017.cpp
 // ---------------------------------------------------------------------
 
-// usage       : CD4017(name, )
-#define CD4017(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4017, __VA_ARGS__)
+// usage       : CD4017(name)
+#define CD4017(name)                                                   \
+	NET_REGISTER_DEV(CD4017, name)
 
-// usage       : CD4022(name, )
-#define CD4022(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4022, __VA_ARGS__)
+// usage       : CD4022(name)
+#define CD4022(name)                                                   \
+	NET_REGISTER_DEV(CD4022, name)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_4020.cpp
 // ---------------------------------------------------------------------
 
 // usage       : CD4020(name, IP, RESET, VDD, VSS)
-#define CD4020(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4020, __VA_ARGS__)
+#define CD4020(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "CD4020: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(CD4020, name __VA_OPT__(,) __VA_ARGS__)
 
-// usage       : CD4024(name, )
-#define CD4024(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4024, __VA_ARGS__)
+// usage       : CD4024(name)
+#define CD4024(name)                                                   \
+	NET_REGISTER_DEV(CD4024, name)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_4029.cpp
@@ -170,8 +174,9 @@
 
 // usage       : CD4029(name, PE, J1, J2, J3, J4, CI, UD, BD, CLK)
 // auto connect: VCC, GND
-#define CD4029(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4029, __VA_ARGS__)
+#define CD4029(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "CD4029: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(CD4029, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_4042.cpp
@@ -179,24 +184,25 @@
 
 // usage       : CD4042(name, D1, D2, D3, D4, POL, CLK)
 // auto connect: VCC, GND
-#define CD4042(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4042, __VA_ARGS__)
+#define CD4042(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 6, "CD4042: Mismatched number of parameters passed, expected 6 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(CD4042, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_4053.cpp
 // ---------------------------------------------------------------------
 
-// usage       : CD4053_GATE(name, )
-#define CD4053_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4053_GATE, __VA_ARGS__)
+// usage       : CD4053_GATE(name)
+#define CD4053_GATE(name)                                                   \
+	NET_REGISTER_DEV(CD4053_GATE, name)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_4066.cpp
 // ---------------------------------------------------------------------
 
-// usage       : CD4066_GATE(name, )
-#define CD4066_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4066_GATE, __VA_ARGS__)
+// usage       : CD4066_GATE(name)
+#define CD4066_GATE(name)                                                   \
+	NET_REGISTER_DEV(CD4066_GATE, name)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_4076.cpp
@@ -204,16 +210,17 @@
 
 // usage       : CD4076(name, I1, I2, I3, I4, ID1, ID2, OD1, OD2)
 // auto connect: VCC, GND
-#define CD4076(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4076, __VA_ARGS__)
+#define CD4076(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 8, "CD4076: Mismatched number of parameters passed, expected 8 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(CD4076, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_4316.cpp
 // ---------------------------------------------------------------------
 
-// usage       : CD4316_GATE(name, )
-#define CD4316_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4316_GATE, __VA_ARGS__)
+// usage       : CD4316_GATE(name)
+#define CD4316_GATE(name)                                                   \
+	NET_REGISTER_DEV(CD4316_GATE, name)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74107.cpp
@@ -221,13 +228,15 @@
 
 // usage       : TTL_74107(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74107(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74107, __VA_ARGS__)
+#define TTL_74107(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_74107: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74107, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_74107A(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74107A(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74107A, __VA_ARGS__)
+#define TTL_74107A(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_74107A: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74107A, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74113.cpp
@@ -235,45 +244,47 @@
 
 // usage       : TTL_74113(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74113(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74113, __VA_ARGS__)
+#define TTL_74113(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_74113: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74113, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_74113A(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74113A(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74113A, __VA_ARGS__)
+#define TTL_74113A(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_74113A: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74113A, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74123.cpp
 // ---------------------------------------------------------------------
 
-// usage       : TTL_74123(name, )
-#define TTL_74123(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74123, __VA_ARGS__)
+// usage       : TTL_74123(name)
+#define TTL_74123(name)                                                   \
+	NET_REGISTER_DEV(TTL_74123, name)
 
-// usage       : TTL_74121(name, )
-#define TTL_74121(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74121, __VA_ARGS__)
+// usage       : TTL_74121(name)
+#define TTL_74121(name)                                                   \
+	NET_REGISTER_DEV(TTL_74121, name)
 
-// usage       : CD4538(name, )
-#define CD4538(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4538, __VA_ARGS__)
+// usage       : CD4538(name)
+#define CD4538(name)                                                   \
+	NET_REGISTER_DEV(CD4538, name)
 
-// usage       : TTL_9602(name, )
-#define TTL_9602(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9602, __VA_ARGS__)
+// usage       : TTL_9602(name)
+#define TTL_9602(name)                                                   \
+	NET_REGISTER_DEV(TTL_9602, name)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74125.cpp
 // ---------------------------------------------------------------------
 
-// usage       : TTL_74125_GATE(name, )
-#define TTL_74125_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74125_GATE, __VA_ARGS__)
+// usage       : TTL_74125_GATE(name)
+#define TTL_74125_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_74125_GATE, name)
 
-// usage       : TTL_74126_GATE(name, )
-#define TTL_74126_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74126_GATE, __VA_ARGS__)
+// usage       : TTL_74126_GATE(name)
+#define TTL_74126_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_74126_GATE, name)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74153.cpp
@@ -281,8 +292,9 @@
 
 // usage       : TTL_74153(name, C0, C1, C2, C3, A, B, G)
 // auto connect: VCC, GND
-#define TTL_74153(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74153, __VA_ARGS__)
+#define TTL_74153(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 7, "TTL_74153: Mismatched number of parameters passed, expected 7 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74153, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74161.cpp
@@ -290,13 +302,15 @@
 
 // usage       : TTL_74161(name, CLK, ENP, ENT, CLRQ, LOADQ, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_74161(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74161, __VA_ARGS__)
+#define TTL_74161(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "TTL_74161: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74161, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_74161_FIXME(name, A, B, C, D, CLRQ, LOADQ, CLK, ENP, ENT)
 // auto connect: VCC, GND
-#define TTL_74161_FIXME(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74161_FIXME, __VA_ARGS__)
+#define TTL_74161_FIXME(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "TTL_74161_FIXME: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74161_FIXME, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74163.cpp
@@ -304,8 +318,9 @@
 
 // usage       : TTL_74163(name, CLK, ENP, ENT, CLRQ, LOADQ, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_74163(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74163, __VA_ARGS__)
+#define TTL_74163(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "TTL_74163: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74163, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74164.cpp
@@ -313,8 +328,9 @@
 
 // usage       : TTL_74164(name, A, B, CLRQ, CLK)
 // auto connect: VCC, GND
-#define TTL_74164(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74164, __VA_ARGS__)
+#define TTL_74164(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_74164: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74164, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74165.cpp
@@ -322,8 +338,9 @@
 
 // usage       : TTL_74165(name, CLK, CLKINH, SH_LDQ, SER, A, B, C, D, E, F, G, H)
 // auto connect: VCC, GND
-#define TTL_74165(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74165, __VA_ARGS__)
+#define TTL_74165(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 12, "TTL_74165: Mismatched number of parameters passed, expected 12 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74165, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74166.cpp
@@ -331,8 +348,9 @@
 
 // usage       : TTL_74166(name, CLK, CLKINH, SH_LDQ, SER, A, B, C, D, E, F, G, H, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74166(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74166, __VA_ARGS__)
+#define TTL_74166(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 13, "TTL_74166: Mismatched number of parameters passed, expected 13 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74166, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74174.cpp
@@ -340,8 +358,9 @@
 
 // usage       : TTL_74174(name, CLK, D1, D2, D3, D4, D5, D6, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74174(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74174, __VA_ARGS__)
+#define TTL_74174(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 8, "TTL_74174: Mismatched number of parameters passed, expected 8 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74174, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74175.cpp
@@ -349,8 +368,9 @@
 
 // usage       : TTL_74175(name, CLK, D1, D2, D3, D4, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74175(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74175, __VA_ARGS__)
+#define TTL_74175(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 6, "TTL_74175: Mismatched number of parameters passed, expected 6 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74175, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74192.cpp
@@ -358,8 +378,9 @@
 
 // usage       : TTL_74192(name, A, B, C, D, CLEAR, LOADQ, CU, CD)
 // auto connect: VCC, GND
-#define TTL_74192(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74192, __VA_ARGS__)
+#define TTL_74192(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 8, "TTL_74192: Mismatched number of parameters passed, expected 8 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74192, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74193.cpp
@@ -367,8 +388,9 @@
 
 // usage       : TTL_74193(name, A, B, C, D, CLEAR, LOADQ, CU, CD)
 // auto connect: VCC, GND
-#define TTL_74193(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74193, __VA_ARGS__)
+#define TTL_74193(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 8, "TTL_74193: Mismatched number of parameters passed, expected 8 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74193, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74194.cpp
@@ -376,8 +398,9 @@
 
 // usage       : TTL_74194(name, CLK, S0, S1, SRIN, A, B, C, D, SLIN, CLRQ)
 // auto connect: VCC, GND
-#define TTL_74194(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74194, __VA_ARGS__)
+#define TTL_74194(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 10, "TTL_74194: Mismatched number of parameters passed, expected 10 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74194, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74365.cpp
@@ -385,16 +408,17 @@
 
 // usage       : TTL_74365(name, G1Q, G2Q, A1, A2, A3, A4, A5, A6)
 // auto connect: VCC, GND
-#define TTL_74365(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74365, __VA_ARGS__)
+#define TTL_74365(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 8, "TTL_74365: Mismatched number of parameters passed, expected 8 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74365, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74377.cpp
 // ---------------------------------------------------------------------
 
-// usage       : TTL_74377_GATE(name, )
-#define TTL_74377_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74377_GATE, __VA_ARGS__)
+// usage       : TTL_74377_GATE(name)
+#define TTL_74377_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_74377_GATE, name)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74393.cpp
@@ -402,8 +426,9 @@
 
 // usage       : TTL_74393(name, CP, MR)
 // auto connect: VCC, GND
-#define TTL_74393(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74393, __VA_ARGS__)
+#define TTL_74393(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_74393: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74393, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_7448.cpp
@@ -411,8 +436,9 @@
 
 // usage       : TTL_7448(name, A, B, C, D, LTQ, BIQ, RBIQ)
 // auto connect: VCC, GND
-#define TTL_7448(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7448, __VA_ARGS__)
+#define TTL_7448(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 7, "TTL_7448: Mismatched number of parameters passed, expected 7 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7448, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_7450.cpp
@@ -420,8 +446,9 @@
 
 // usage       : TTL_7450_ANDORINVERT(name, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_7450_ANDORINVERT(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7450_ANDORINVERT, __VA_ARGS__)
+#define TTL_7450_ANDORINVERT(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7450_ANDORINVERT: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7450_ANDORINVERT, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_7473.cpp
@@ -429,13 +456,15 @@
 
 // usage       : TTL_7473(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_7473(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7473, __VA_ARGS__)
+#define TTL_7473(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7473: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7473, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7473A(name, CLK, J, K, CLRQ)
 // auto connect: VCC, GND
-#define TTL_7473A(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7473A, __VA_ARGS__)
+#define TTL_7473A(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7473A: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7473A, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_7474.cpp
@@ -443,20 +472,21 @@
 
 // usage       : TTL_7474(name, CLK, D, CLRQ, PREQ)
 // auto connect: VCC, GND
-#define TTL_7474(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7474, __VA_ARGS__)
+#define TTL_7474(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7474: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7474, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_7475.cpp
 // ---------------------------------------------------------------------
 
-// usage       : TTL_7475_GATE(name, )
-#define TTL_7475_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7475_GATE, __VA_ARGS__)
+// usage       : TTL_7475_GATE(name)
+#define TTL_7475_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_7475_GATE, name)
 
-// usage       : TTL_7477_GATE(name, )
-#define TTL_7477_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7477_GATE, __VA_ARGS__)
+// usage       : TTL_7477_GATE(name)
+#define TTL_7477_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_7477_GATE, name)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_7483.cpp
@@ -464,8 +494,9 @@
 
 // usage       : TTL_7483(name, A1, A2, A3, A4, B1, B2, B3, B4, C0)
 // auto connect: VCC, GND
-#define TTL_7483(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7483, __VA_ARGS__)
+#define TTL_7483(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "TTL_7483: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7483, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_7485.cpp
@@ -473,8 +504,9 @@
 
 // usage       : TTL_7485(name, A0, A1, A2, A3, B0, B1, B2, B3, LTIN, EQIN, GTIN)
 // auto connect: VCC, GND
-#define TTL_7485(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7485, __VA_ARGS__)
+#define TTL_7485(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 11, "TTL_7485: Mismatched number of parameters passed, expected 11 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7485, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_7490.cpp
@@ -482,8 +514,9 @@
 
 // usage       : TTL_7490(name, A, B, R1, R2, R91, R92)
 // auto connect: VCC, GND
-#define TTL_7490(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7490, __VA_ARGS__)
+#define TTL_7490(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 6, "TTL_7490: Mismatched number of parameters passed, expected 6 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7490, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_7492.cpp
@@ -491,8 +524,9 @@
 
 // usage       : TTL_7492(name, A, B, R1, R2)
 // auto connect: VCC, GND
-#define TTL_7492(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7492, __VA_ARGS__)
+#define TTL_7492(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7492: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7492, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_7493.cpp
@@ -500,8 +534,9 @@
 
 // usage       : TTL_7493(name, CLKA, CLKB, R1, R2)
 // auto connect: VCC, GND
-#define TTL_7493(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7493, __VA_ARGS__)
+#define TTL_7493(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7493: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7493, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_7497.cpp
@@ -509,8 +544,9 @@
 
 // usage       : TTL_7497(name, CLK, STRBQ, ENQ, UNITYQ, CLR, B0, B1, B2, B3, B4, B5)
 // auto connect: VCC, GND
-#define TTL_7497(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7497, __VA_ARGS__)
+#define TTL_7497(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 11, "TTL_7497: Mismatched number of parameters passed, expected 11 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7497, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_74ls629.cpp
@@ -518,8 +554,8 @@
 
 // usage       : SN74LS629(name, CAP)
 // auto connect: VCC, GND
-#define SN74LS629(...)                                                   \
-	NET_REGISTER_DEVEXT(SN74LS629, __VA_ARGS__)
+#define SN74LS629(name, CAP)                                                   \
+	NET_REGISTER_DEV(SN74LS629, name, CAP)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_8277.cpp
@@ -527,8 +563,9 @@
 
 // usage       : TTL_8277(name, RESET, CLK, CLKA, D0A, D1A, DSA, CLKB, D0B, D1B, DSB)
 // auto connect: VCC, GND
-#define TTL_8277(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_8277, __VA_ARGS__)
+#define TTL_8277(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 10, "TTL_8277: Mismatched number of parameters passed, expected 10 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_8277, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_82s115.cpp
@@ -536,16 +573,17 @@
 
 // usage       : PROM_82S115(name, CE1Q, CE2, A0, A1, A2, A3, A4, A5, A6, A7, A8, STROBE)
 // auto connect: VCC, GND
-#define PROM_82S115(...)                                                   \
-	NET_REGISTER_DEVEXT(PROM_82S115, __VA_ARGS__)
+#define PROM_82S115(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 12, "PROM_82S115: Mismatched number of parameters passed, expected 12 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(PROM_82S115, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_82s16.cpp
 // ---------------------------------------------------------------------
 
-// usage       : TTL_82S16(name, )
-#define TTL_82S16(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_82S16, __VA_ARGS__)
+// usage       : TTL_82S16(name)
+#define TTL_82S16(name)                                                   \
+	NET_REGISTER_DEV(TTL_82S16, name)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_9310.cpp
@@ -553,8 +591,9 @@
 
 // usage       : TTL_9310(name, CLK, ENP, ENT, CLRQ, LOADQ, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_9310(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9310, __VA_ARGS__)
+#define TTL_9310(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "TTL_9310: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_9310, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_9316.cpp
@@ -562,16 +601,18 @@
 
 // usage       : TTL_9316(name, CLK, ENP, ENT, CLRQ, LOADQ, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_9316(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9316, __VA_ARGS__)
+#define TTL_9316(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "TTL_9316: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_9316, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_9321.cpp
 // ---------------------------------------------------------------------
 
 // usage       : TTL_9321(name, E, A0, A1)
-#define TTL_9321(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9321, __VA_ARGS__)
+#define TTL_9321(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 3, "TTL_9321: Mismatched number of parameters passed, expected 3 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_9321, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_9322.cpp
@@ -579,8 +620,9 @@
 
 // usage       : TTL_9322(name, SELECT, A1, B1, A2, B2, A3, B3, A4, B4, STROBE)
 // auto connect: VCC, GND
-#define TTL_9322(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9322, __VA_ARGS__)
+#define TTL_9322(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 10, "TTL_9322: Mismatched number of parameters passed, expected 10 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_9322, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_am2847.cpp
@@ -588,8 +630,9 @@
 
 // usage       : TTL_AM2847(name, CP, INA, INB, INC, IND, RCA, RCB, RCC, RCD)
 // auto connect: VSS, VDD
-#define TTL_AM2847(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_AM2847, __VA_ARGS__)
+#define TTL_AM2847(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 9, "TTL_AM2847: Mismatched number of parameters passed, expected 9 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_AM2847, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_dm9314.cpp
@@ -597,8 +640,9 @@
 
 // usage       : TTL_9314(name, EQ, MRQ, S0Q, S1Q, S2Q, S3Q, D0, D1, D2, D3)
 // auto connect: VCC, GND
-#define TTL_9314(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9314, __VA_ARGS__)
+#define TTL_9314(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 10, "TTL_9314: Mismatched number of parameters passed, expected 10 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_9314, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_dm9334.cpp
@@ -606,60 +650,63 @@
 
 // usage       : TTL_9334(name, CQ, EQ, D, A0, A1, A2)
 // auto connect: VCC, GND
-#define TTL_9334(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9334, __VA_ARGS__)
+#define TTL_9334(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 6, "TTL_9334: Mismatched number of parameters passed, expected 6 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_9334, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_legacy.cpp
 // ---------------------------------------------------------------------
 
-// usage       : NETDEV_RSFF(name, )
-#define NETDEV_RSFF(...)                                                   \
-	NET_REGISTER_DEVEXT(NETDEV_RSFF, __VA_ARGS__)
+// usage       : NETDEV_RSFF(name)
+#define NETDEV_RSFF(name)                                                   \
+	NET_REGISTER_DEV(NETDEV_RSFF, name)
 
-// usage       : NETDEV_DELAY(name, )
-#define NETDEV_DELAY(...)                                                   \
-	NET_REGISTER_DEVEXT(NETDEV_DELAY, __VA_ARGS__)
+// usage       : NETDEV_DELAY(name)
+#define NETDEV_DELAY(name)                                                   \
+	NET_REGISTER_DEV(NETDEV_DELAY, name)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_log.cpp
 // ---------------------------------------------------------------------
 
 // usage       : LOG(name, I)
-#define LOG(...)                                                   \
-	NET_REGISTER_DEVEXT(LOG, __VA_ARGS__)
+#define LOG(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "LOG: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(LOG, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : LOGD(name, I, I2)
-#define LOGD(...)                                                   \
-	NET_REGISTER_DEVEXT(LOGD, __VA_ARGS__)
+#define LOGD(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "LOGD: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(LOGD, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_mm5837.cpp
 // ---------------------------------------------------------------------
 
-// usage       : MM5837(name, )
-#define MM5837(...)                                                   \
-	NET_REGISTER_DEVEXT(MM5837, __VA_ARGS__)
+// usage       : MM5837(name)
+#define MM5837(name)                                                   \
+	NET_REGISTER_DEV(MM5837, name)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_ne555.cpp
 // ---------------------------------------------------------------------
 
-// usage       : NE555(name, )
-#define NE555(...)                                                   \
-	NET_REGISTER_DEVEXT(NE555, __VA_ARGS__)
+// usage       : NE555(name)
+#define NE555(name)                                                   \
+	NET_REGISTER_DEV(NE555, name)
 
-// usage       : MC1455P(name, )
-#define MC1455P(...)                                                   \
-	NET_REGISTER_DEVEXT(MC1455P, __VA_ARGS__)
+// usage       : MC1455P(name)
+#define MC1455P(name)                                                   \
+	NET_REGISTER_DEV(MC1455P, name)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_r2r_dac.cpp
 // ---------------------------------------------------------------------
 
 // usage       : R2R_DAC(name, VIN, R, N)
-#define R2R_DAC(...)                                                   \
-	NET_REGISTER_DEVEXT(R2R_DAC, __VA_ARGS__)
+#define R2R_DAC(name, VIN, R, N)                                                   \
+	NET_REGISTER_DEV(R2R_DAC, name, VIN, R, N)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_roms.cpp
@@ -667,121 +714,129 @@
 
 // usage       : PROM_82S126(name, CE1Q, CE2Q, A0, A1, A2, A3, A4, A5, A6, A7)
 // auto connect: VCC, GND
-#define PROM_82S126(...)                                                   \
-	NET_REGISTER_DEVEXT(PROM_82S126, __VA_ARGS__)
+#define PROM_82S126(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 10, "PROM_82S126: Mismatched number of parameters passed, expected 10 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(PROM_82S126, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : PROM_74S287(name, CE1Q, CE2Q, A0, A1, A2, A3, A4, A5, A6, A7)
 // auto connect: VCC, GND
-#define PROM_74S287(...)                                                   \
-	NET_REGISTER_DEVEXT(PROM_74S287, __VA_ARGS__)
+#define PROM_74S287(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 10, "PROM_74S287: Mismatched number of parameters passed, expected 10 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(PROM_74S287, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : PROM_82S123(name, CEQ, A0, A1, A2, A3, A4)
 // auto connect: VCC, GND
-#define PROM_82S123(...)                                                   \
-	NET_REGISTER_DEVEXT(PROM_82S123, __VA_ARGS__)
+#define PROM_82S123(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 6, "PROM_82S123: Mismatched number of parameters passed, expected 6 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(PROM_82S123, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : EPROM_2716(name, CE2Q, CE1Q, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)
 // auto connect: VCC, GND
-#define EPROM_2716(...)                                                   \
-	NET_REGISTER_DEVEXT(EPROM_2716, __VA_ARGS__)
+#define EPROM_2716(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 13, "EPROM_2716: Mismatched number of parameters passed, expected 13 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(EPROM_2716, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : PROM_MK28000(name, OE1, OE2, ARQ, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)
 // auto connect: VCC, GND
-#define PROM_MK28000(...)                                                   \
-	NET_REGISTER_DEVEXT(PROM_MK28000, __VA_ARGS__)
+#define PROM_MK28000(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 14, "PROM_MK28000: Mismatched number of parameters passed, expected 14 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(PROM_MK28000, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : ROM_MCM14524(name, EN, CLK, A0, A1, A2, A3, A4, A5, A6, A7)
 // auto connect: VCC, GND
-#define ROM_MCM14524(...)                                                   \
-	NET_REGISTER_DEVEXT(ROM_MCM14524, __VA_ARGS__)
+#define ROM_MCM14524(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 10, "ROM_MCM14524: Mismatched number of parameters passed, expected 10 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(ROM_MCM14524, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_schmitt.cpp
 // ---------------------------------------------------------------------
 
 // usage       : SCHMITT_TRIGGER(name, STMODEL)
-#define SCHMITT_TRIGGER(...)                                                   \
-	NET_REGISTER_DEVEXT(SCHMITT_TRIGGER, __VA_ARGS__)
+#define SCHMITT_TRIGGER(name, STMODEL)                                                   \
+	NET_REGISTER_DEV(SCHMITT_TRIGGER, name, STMODEL)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_system.cpp
 // ---------------------------------------------------------------------
 
-// usage       : PARAMETER(name, )
-#define PARAMETER(...)                                                   \
-	NET_REGISTER_DEVEXT(PARAMETER, __VA_ARGS__)
+// usage       : PARAMETER(name)
+#define PARAMETER(name)                                                   \
+	NET_REGISTER_DEV(PARAMETER, name)
 
-// usage       : NC_PIN(name, )
-#define NC_PIN(...)                                                   \
-	NET_REGISTER_DEVEXT(NC_PIN, __VA_ARGS__)
+// usage       : NC_PIN(name)
+#define NC_PIN(name)                                                   \
+	NET_REGISTER_DEV(NC_PIN, name)
 
 // usage       : FRONTIER_DEV(name, I, G, Q)
-#define FRONTIER_DEV(...)                                                   \
-	NET_REGISTER_DEVEXT(FRONTIER_DEV, __VA_ARGS__)
+#define FRONTIER_DEV(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 3, "FRONTIER_DEV: Mismatched number of parameters passed, expected 3 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(FRONTIER_DEV, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : AFUNC(name, N, FUNC)
-#define AFUNC(...)                                                   \
-	NET_REGISTER_DEVEXT(AFUNC, __VA_ARGS__)
+#define AFUNC(name, N, FUNC)                                                   \
+	NET_REGISTER_DEV(AFUNC, name, N, FUNC)
 
 // usage       : ANALOG_INPUT(name, IN)
-#define ANALOG_INPUT(...)                                                   \
-	NET_REGISTER_DEVEXT(ANALOG_INPUT, __VA_ARGS__)
+#define ANALOG_INPUT(name, IN)                                                   \
+	NET_REGISTER_DEV(ANALOG_INPUT, name, IN)
 
 // usage       : CLOCK(name, FREQ)
-#define CLOCK(...)                                                   \
-	NET_REGISTER_DEVEXT(CLOCK, __VA_ARGS__)
+#define CLOCK(name, FREQ)                                                   \
+	NET_REGISTER_DEV(CLOCK, name, FREQ)
 
 // usage       : VARCLOCK(name, N, FUNC)
-#define VARCLOCK(...)                                                   \
-	NET_REGISTER_DEVEXT(VARCLOCK, __VA_ARGS__)
+#define VARCLOCK(name, N, FUNC)                                                   \
+	NET_REGISTER_DEV(VARCLOCK, name, N, FUNC)
 
 // usage       : EXTCLOCK(name, FREQ, PATTERN)
-#define EXTCLOCK(...)                                                   \
-	NET_REGISTER_DEVEXT(EXTCLOCK, __VA_ARGS__)
+#define EXTCLOCK(name, FREQ, PATTERN)                                                   \
+	NET_REGISTER_DEV(EXTCLOCK, name, FREQ, PATTERN)
 
-// usage       : SYS_DSW(name, I, 1, 2)
-#define SYS_DSW(...)                                                   \
-	NET_REGISTER_DEVEXT(SYS_DSW, __VA_ARGS__)
+// usage       : SYS_DSW(name, I, _1, _2)
+#define SYS_DSW(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 3, "SYS_DSW: Mismatched number of parameters passed, expected 3 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(SYS_DSW, name __VA_OPT__(,) __VA_ARGS__)
 
-// usage       : SYS_DSW2(name, )
-#define SYS_DSW2(...)                                                   \
-	NET_REGISTER_DEVEXT(SYS_DSW2, __VA_ARGS__)
+// usage       : SYS_DSW2(name)
+#define SYS_DSW2(name)                                                   \
+	NET_REGISTER_DEV(SYS_DSW2, name)
 
-// usage       : SYS_COMPD(name, )
-#define SYS_COMPD(...)                                                   \
-	NET_REGISTER_DEVEXT(SYS_COMPD, __VA_ARGS__)
+// usage       : SYS_COMPD(name)
+#define SYS_COMPD(name)                                                   \
+	NET_REGISTER_DEV(SYS_COMPD, name)
 
 // usage       : SYS_PULSE(name, DELAY, DURATION, INVERT_INPUT, INVERT_OUTPUT)
-#define SYS_PULSE(...)                                                   \
-	NET_REGISTER_DEVEXT(SYS_PULSE, __VA_ARGS__)
+#define SYS_PULSE(name, DELAY, DURATION, INVERT_INPUT, INVERT_OUTPUT)                                                   \
+	NET_REGISTER_DEV(SYS_PULSE, name, DELAY, DURATION, INVERT_INPUT, INVERT_OUTPUT)
 
 // usage       : SYS_NOISE_MT_U(name, SIGMA)
-#define SYS_NOISE_MT_U(...)                                                   \
-	NET_REGISTER_DEVEXT(SYS_NOISE_MT_U, __VA_ARGS__)
+#define SYS_NOISE_MT_U(name, SIGMA)                                                   \
+	NET_REGISTER_DEV(SYS_NOISE_MT_U, name, SIGMA)
 
 // usage       : SYS_NOISE_MT_N(name, SIGMA)
-#define SYS_NOISE_MT_N(...)                                                   \
-	NET_REGISTER_DEVEXT(SYS_NOISE_MT_N, __VA_ARGS__)
+#define SYS_NOISE_MT_N(name, SIGMA)                                                   \
+	NET_REGISTER_DEV(SYS_NOISE_MT_N, name, SIGMA)
 
 // usage       : MAINCLOCK(name, FREQ)
-#define MAINCLOCK(...)                                                   \
-	NET_REGISTER_DEVEXT(MAINCLOCK, __VA_ARGS__)
+#define MAINCLOCK(name, FREQ)                                                   \
+	NET_REGISTER_DEV(MAINCLOCK, name, FREQ)
 
-// usage       : GNDA(name, )
-#define GNDA(...)                                                   \
-	NET_REGISTER_DEVEXT(GNDA, __VA_ARGS__)
+// usage       : GNDA(name)
+#define GNDA(name)                                                   \
+	NET_REGISTER_DEV(GNDA, name)
 
 // usage       : LOGIC_INPUT8(name, IN, MODEL)
-#define LOGIC_INPUT8(...)                                                   \
-	NET_REGISTER_DEVEXT(LOGIC_INPUT8, __VA_ARGS__)
+#define LOGIC_INPUT8(name, IN, MODEL)                                                   \
+	NET_REGISTER_DEV(LOGIC_INPUT8, name, IN, MODEL)
 
 // usage       : LOGIC_INPUT(name, IN, MODEL)
-#define LOGIC_INPUT(...)                                                   \
-	NET_REGISTER_DEVEXT(LOGIC_INPUT, __VA_ARGS__)
+#define LOGIC_INPUT(name, IN, MODEL)                                                   \
+	NET_REGISTER_DEV(LOGIC_INPUT, name, IN, MODEL)
 
 // usage       : TTL_INPUT(name, IN)
-#define TTL_INPUT(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_INPUT, __VA_ARGS__)
+#define TTL_INPUT(name, IN)                                                   \
+	NET_REGISTER_DEV(TTL_INPUT, name, IN)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_tms4800.cpp
@@ -789,20 +844,22 @@
 
 // usage       : ROM_TMS4800(name, AR, OE1, OE2, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)
 // auto connect: VCC, GND
-#define ROM_TMS4800(...)                                                   \
-	NET_REGISTER_DEVEXT(ROM_TMS4800, __VA_ARGS__)
+#define ROM_TMS4800(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 14, "ROM_TMS4800: Mismatched number of parameters passed, expected 14 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(ROM_TMS4800, name __VA_OPT__(,) __VA_ARGS__)
 
 // ---------------------------------------------------------------------
 // Source: ../devices/nld_tristate.cpp
 // ---------------------------------------------------------------------
 
 // usage       : TTL_TRISTATE(name, CEQ1, D1, CEQ2, D2)
-#define TTL_TRISTATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_TRISTATE, __VA_ARGS__)
+#define TTL_TRISTATE(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_TRISTATE: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_TRISTATE, name __VA_OPT__(,) __VA_ARGS__)
 
-// usage       : TTL_TRISTATE3(name, )
-#define TTL_TRISTATE3(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_TRISTATE3, __VA_ARGS__)
+// usage       : TTL_TRISTATE3(name)
+#define TTL_TRISTATE3(name)                                                   \
+	NET_REGISTER_DEV(TTL_TRISTATE3, name)
 
 // ---------------------------------------------------------------------
 // Source: ../generated/nlm_modules_lib.cpp
@@ -833,297 +890,297 @@ NETLIST_EXTERNAL(base_lib)
 // Source: ../macro/nlm_cd4xxx_lib.cpp
 // ---------------------------------------------------------------------
 
-// usage       : CD4001_GATE(name, )
-#define CD4001_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4001_GATE, __VA_ARGS__)
+// usage       : CD4001_GATE(name)
+#define CD4001_GATE(name)                                                   \
+	NET_REGISTER_DEV(CD4001_GATE, name)
 
-// usage       : CD4011_GATE(name, )
-#define CD4011_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4011_GATE, __VA_ARGS__)
+// usage       : CD4011_GATE(name)
+#define CD4011_GATE(name)                                                   \
+	NET_REGISTER_DEV(CD4011_GATE, name)
 
-// usage       : CD4030_GATE(name, )
-#define CD4030_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4030_GATE, __VA_ARGS__)
+// usage       : CD4030_GATE(name)
+#define CD4030_GATE(name)                                                   \
+	NET_REGISTER_DEV(CD4030_GATE, name)
 
-// usage       : CD4049_GATE(name, )
-#define CD4049_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4049_GATE, __VA_ARGS__)
+// usage       : CD4049_GATE(name)
+#define CD4049_GATE(name)                                                   \
+	NET_REGISTER_DEV(CD4049_GATE, name)
 
-// usage       : CD4069_GATE(name, )
-#define CD4069_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4069_GATE, __VA_ARGS__)
+// usage       : CD4069_GATE(name)
+#define CD4069_GATE(name)                                                   \
+	NET_REGISTER_DEV(CD4069_GATE, name)
 
-// usage       : CD4070_GATE(name, )
-#define CD4070_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4070_GATE, __VA_ARGS__)
+// usage       : CD4070_GATE(name)
+#define CD4070_GATE(name)                                                   \
+	NET_REGISTER_DEV(CD4070_GATE, name)
 
-// usage       : CD4071_GATE(name, )
-#define CD4071_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4071_GATE, __VA_ARGS__)
+// usage       : CD4071_GATE(name)
+#define CD4071_GATE(name)                                                   \
+	NET_REGISTER_DEV(CD4071_GATE, name)
 
-// usage       : CD4081_GATE(name, )
-#define CD4081_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4081_GATE, __VA_ARGS__)
+// usage       : CD4081_GATE(name)
+#define CD4081_GATE(name)                                                   \
+	NET_REGISTER_DEV(CD4081_GATE, name)
 
 NETLIST_EXTERNAL(cd4xxx_lib)
-// usage       : CD4001_DIP(name, )
-#define CD4001_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4001_DIP, __VA_ARGS__)
+// usage       : CD4001_DIP(name)
+#define CD4001_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4001_DIP, name)
 
-// usage       : CD4011_DIP(name, )
-#define CD4011_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4011_DIP, __VA_ARGS__)
+// usage       : CD4011_DIP(name)
+#define CD4011_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4011_DIP, name)
 
-// usage       : CD4030_DIP(name, )
-#define CD4030_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4030_DIP, __VA_ARGS__)
+// usage       : CD4030_DIP(name)
+#define CD4030_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4030_DIP, name)
 
-// usage       : CD4049_DIP(name, )
-#define CD4049_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4049_DIP, __VA_ARGS__)
+// usage       : CD4049_DIP(name)
+#define CD4049_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4049_DIP, name)
 
-// usage       : CD4069_DIP(name, )
-#define CD4069_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4069_DIP, __VA_ARGS__)
+// usage       : CD4069_DIP(name)
+#define CD4069_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4069_DIP, name)
 
-// usage       : CD4070_DIP(name, )
-#define CD4070_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4070_DIP, __VA_ARGS__)
+// usage       : CD4070_DIP(name)
+#define CD4070_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4070_DIP, name)
 
-// usage       : CD4071_DIP(name, )
-#define CD4071_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4071_DIP, __VA_ARGS__)
+// usage       : CD4071_DIP(name)
+#define CD4071_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4071_DIP, name)
 
-// usage       : CD4081_DIP(name, )
-#define CD4081_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4081_DIP, __VA_ARGS__)
+// usage       : CD4081_DIP(name)
+#define CD4081_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4081_DIP, name)
 
-// usage       : CD4006_DIP(name, )
-#define CD4006_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4006_DIP, __VA_ARGS__)
+// usage       : CD4006_DIP(name)
+#define CD4006_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4006_DIP, name)
 
-// usage       : CD4013_DIP(name, )
-#define CD4013_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4013_DIP, __VA_ARGS__)
+// usage       : CD4013_DIP(name)
+#define CD4013_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4013_DIP, name)
 
-// usage       : CD4017_DIP(name, )
-#define CD4017_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4017_DIP, __VA_ARGS__)
+// usage       : CD4017_DIP(name)
+#define CD4017_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4017_DIP, name)
 
-// usage       : CD4022_DIP(name, )
-#define CD4022_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4022_DIP, __VA_ARGS__)
+// usage       : CD4022_DIP(name)
+#define CD4022_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4022_DIP, name)
 
-// usage       : CD4020_DIP(name, )
-#define CD4020_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4020_DIP, __VA_ARGS__)
+// usage       : CD4020_DIP(name)
+#define CD4020_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4020_DIP, name)
 
-// usage       : CD4024_DIP(name, )
-#define CD4024_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4024_DIP, __VA_ARGS__)
+// usage       : CD4024_DIP(name)
+#define CD4024_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4024_DIP, name)
 
-// usage       : CD4029_DIP(name, )
-#define CD4029_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4029_DIP, __VA_ARGS__)
+// usage       : CD4029_DIP(name)
+#define CD4029_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4029_DIP, name)
 
-// usage       : CD4042_DIP(name, )
-#define CD4042_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4042_DIP, __VA_ARGS__)
+// usage       : CD4042_DIP(name)
+#define CD4042_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4042_DIP, name)
 
-// usage       : CD4053_DIP(name, )
-#define CD4053_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4053_DIP, __VA_ARGS__)
+// usage       : CD4053_DIP(name)
+#define CD4053_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4053_DIP, name)
 
-// usage       : CD4066_DIP(name, )
-#define CD4066_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4066_DIP, __VA_ARGS__)
+// usage       : CD4066_DIP(name)
+#define CD4066_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4066_DIP, name)
 
-// usage       : CD4016_DIP(name, )
-#define CD4016_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4016_DIP, __VA_ARGS__)
+// usage       : CD4016_DIP(name)
+#define CD4016_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4016_DIP, name)
 
-// usage       : CD4076_DIP(name, )
-#define CD4076_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4076_DIP, __VA_ARGS__)
+// usage       : CD4076_DIP(name)
+#define CD4076_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4076_DIP, name)
 
-// usage       : CD4316_DIP(name, )
-#define CD4316_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4316_DIP, __VA_ARGS__)
+// usage       : CD4316_DIP(name)
+#define CD4316_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4316_DIP, name)
 
-// usage       : CD4538_DIP(name, )
-#define CD4538_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(CD4538_DIP, __VA_ARGS__)
+// usage       : CD4538_DIP(name)
+#define CD4538_DIP(name)                                                   \
+	NET_REGISTER_DEV(CD4538_DIP, name)
 
-// usage       : MM5837_DIP(name, )
-#define MM5837_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(MM5837_DIP, __VA_ARGS__)
+// usage       : MM5837_DIP(name)
+#define MM5837_DIP(name)                                                   \
+	NET_REGISTER_DEV(MM5837_DIP, name)
 
 // ---------------------------------------------------------------------
 // Source: ../macro/nlm_opamp_lib.cpp
 // ---------------------------------------------------------------------
 
 NETLIST_EXTERNAL(opamp_lib)
-// usage       : opamp_layout_4_4_11(name, )
-#define opamp_layout_4_4_11(...)                                                   \
-	NET_REGISTER_DEVEXT(opamp_layout_4_4_11, __VA_ARGS__)
+// usage       : opamp_layout_4_4_11(name)
+#define opamp_layout_4_4_11(name)                                                   \
+	NET_REGISTER_DEV(opamp_layout_4_4_11, name)
 
-// usage       : opamp_layout_2_8_4(name, )
-#define opamp_layout_2_8_4(...)                                                   \
-	NET_REGISTER_DEVEXT(opamp_layout_2_8_4, __VA_ARGS__)
+// usage       : opamp_layout_2_8_4(name)
+#define opamp_layout_2_8_4(name)                                                   \
+	NET_REGISTER_DEV(opamp_layout_2_8_4, name)
 
-// usage       : opamp_layout_2_13_9_4(name, )
-#define opamp_layout_2_13_9_4(...)                                                   \
-	NET_REGISTER_DEVEXT(opamp_layout_2_13_9_4, __VA_ARGS__)
+// usage       : opamp_layout_2_13_9_4(name)
+#define opamp_layout_2_13_9_4(name)                                                   \
+	NET_REGISTER_DEV(opamp_layout_2_13_9_4, name)
 
-// usage       : opamp_layout_1_7_4(name, )
-#define opamp_layout_1_7_4(...)                                                   \
-	NET_REGISTER_DEVEXT(opamp_layout_1_7_4, __VA_ARGS__)
+// usage       : opamp_layout_1_7_4(name)
+#define opamp_layout_1_7_4(name)                                                   \
+	NET_REGISTER_DEV(opamp_layout_1_7_4, name)
 
-// usage       : opamp_layout_1_8_5(name, )
-#define opamp_layout_1_8_5(...)                                                   \
-	NET_REGISTER_DEVEXT(opamp_layout_1_8_5, __VA_ARGS__)
+// usage       : opamp_layout_1_8_5(name)
+#define opamp_layout_1_8_5(name)                                                   \
+	NET_REGISTER_DEV(opamp_layout_1_8_5, name)
 
-// usage       : opamp_layout_1_11_6(name, )
-#define opamp_layout_1_11_6(...)                                                   \
-	NET_REGISTER_DEVEXT(opamp_layout_1_11_6, __VA_ARGS__)
+// usage       : opamp_layout_1_11_6(name)
+#define opamp_layout_1_11_6(name)                                                   \
+	NET_REGISTER_DEV(opamp_layout_1_11_6, name)
 
-// usage       : MB3614_DIP(name, )
-#define MB3614_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(MB3614_DIP, __VA_ARGS__)
+// usage       : MB3614_DIP(name)
+#define MB3614_DIP(name)                                                   \
+	NET_REGISTER_DEV(MB3614_DIP, name)
 
-// usage       : MC3340_DIP(name, )
-#define MC3340_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(MC3340_DIP, __VA_ARGS__)
+// usage       : MC3340_DIP(name)
+#define MC3340_DIP(name)                                                   \
+	NET_REGISTER_DEV(MC3340_DIP, name)
 
-// usage       : TL081_DIP(name, )
-#define TL081_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TL081_DIP, __VA_ARGS__)
+// usage       : TL081_DIP(name)
+#define TL081_DIP(name)                                                   \
+	NET_REGISTER_DEV(TL081_DIP, name)
 
-// usage       : TL082_DIP(name, )
-#define TL082_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TL082_DIP, __VA_ARGS__)
+// usage       : TL082_DIP(name)
+#define TL082_DIP(name)                                                   \
+	NET_REGISTER_DEV(TL082_DIP, name)
 
-// usage       : TL084_DIP(name, )
-#define TL084_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TL084_DIP, __VA_ARGS__)
+// usage       : TL084_DIP(name)
+#define TL084_DIP(name)                                                   \
+	NET_REGISTER_DEV(TL084_DIP, name)
 
-// usage       : LM324_DIP(name, )
-#define LM324_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(LM324_DIP, __VA_ARGS__)
+// usage       : LM324_DIP(name)
+#define LM324_DIP(name)                                                   \
+	NET_REGISTER_DEV(LM324_DIP, name)
 
-// usage       : LM348_DIP(name, )
-#define LM348_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(LM348_DIP, __VA_ARGS__)
+// usage       : LM348_DIP(name)
+#define LM348_DIP(name)                                                   \
+	NET_REGISTER_DEV(LM348_DIP, name)
 
-// usage       : LM358_DIP(name, )
-#define LM358_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(LM358_DIP, __VA_ARGS__)
+// usage       : LM358_DIP(name)
+#define LM358_DIP(name)                                                   \
+	NET_REGISTER_DEV(LM358_DIP, name)
 
-// usage       : LM2902_DIP(name, )
-#define LM2902_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(LM2902_DIP, __VA_ARGS__)
+// usage       : LM2902_DIP(name)
+#define LM2902_DIP(name)                                                   \
+	NET_REGISTER_DEV(LM2902_DIP, name)
 
-// usage       : UA741_DIP8(name, )
-#define UA741_DIP8(...)                                                   \
-	NET_REGISTER_DEVEXT(UA741_DIP8, __VA_ARGS__)
+// usage       : UA741_DIP8(name)
+#define UA741_DIP8(name)                                                   \
+	NET_REGISTER_DEV(UA741_DIP8, name)
 
-// usage       : UA741_DIP10(name, )
-#define UA741_DIP10(...)                                                   \
-	NET_REGISTER_DEVEXT(UA741_DIP10, __VA_ARGS__)
+// usage       : UA741_DIP10(name)
+#define UA741_DIP10(name)                                                   \
+	NET_REGISTER_DEV(UA741_DIP10, name)
 
-// usage       : UA741_DIP14(name, )
-#define UA741_DIP14(...)                                                   \
-	NET_REGISTER_DEVEXT(UA741_DIP14, __VA_ARGS__)
+// usage       : UA741_DIP14(name)
+#define UA741_DIP14(name)                                                   \
+	NET_REGISTER_DEV(UA741_DIP14, name)
 
-// usage       : MC1558_DIP(name, )
-#define MC1558_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(MC1558_DIP, __VA_ARGS__)
+// usage       : MC1558_DIP(name)
+#define MC1558_DIP(name)                                                   \
+	NET_REGISTER_DEV(MC1558_DIP, name)
 
-// usage       : LM747_DIP(name, )
-#define LM747_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(LM747_DIP, __VA_ARGS__)
+// usage       : LM747_DIP(name)
+#define LM747_DIP(name)                                                   \
+	NET_REGISTER_DEV(LM747_DIP, name)
 
-// usage       : LM747A_DIP(name, )
-#define LM747A_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(LM747A_DIP, __VA_ARGS__)
+// usage       : LM747A_DIP(name)
+#define LM747A_DIP(name)                                                   \
+	NET_REGISTER_DEV(LM747A_DIP, name)
 
-// usage       : LM3900(name, )
-#define LM3900(...)                                                   \
-	NET_REGISTER_DEVEXT(LM3900, __VA_ARGS__)
+// usage       : LM3900(name)
+#define LM3900(name)                                                   \
+	NET_REGISTER_DEV(LM3900, name)
 
-// usage       : AN6551_SIL(name, )
-#define AN6551_SIL(...)                                                   \
-	NET_REGISTER_DEVEXT(AN6551_SIL, __VA_ARGS__)
+// usage       : AN6551_SIL(name)
+#define AN6551_SIL(name)                                                   \
+	NET_REGISTER_DEV(AN6551_SIL, name)
 
 // ---------------------------------------------------------------------
 // Source: ../macro/nlm_otheric_lib.cpp
 // ---------------------------------------------------------------------
 
-// usage       : MC14584B_GATE(name, )
-#define MC14584B_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(MC14584B_GATE, __VA_ARGS__)
+// usage       : MC14584B_GATE(name)
+#define MC14584B_GATE(name)                                                   \
+	NET_REGISTER_DEV(MC14584B_GATE, name)
 
 NETLIST_EXTERNAL(otheric_lib)
-// usage       : MC14584B_DIP(name, )
-#define MC14584B_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(MC14584B_DIP, __VA_ARGS__)
+// usage       : MC14584B_DIP(name)
+#define MC14584B_DIP(name)                                                   \
+	NET_REGISTER_DEV(MC14584B_DIP, name)
 
-// usage       : NE566_DIP(name, )
-#define NE566_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(NE566_DIP, __VA_ARGS__)
+// usage       : NE566_DIP(name)
+#define NE566_DIP(name)                                                   \
+	NET_REGISTER_DEV(NE566_DIP, name)
 
-// usage       : NE555_DIP(name, )
-#define NE555_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(NE555_DIP, __VA_ARGS__)
+// usage       : NE555_DIP(name)
+#define NE555_DIP(name)                                                   \
+	NET_REGISTER_DEV(NE555_DIP, name)
 
-// usage       : MC1455P_DIP(name, )
-#define MC1455P_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(MC1455P_DIP, __VA_ARGS__)
+// usage       : MC1455P_DIP(name)
+#define MC1455P_DIP(name)                                                   \
+	NET_REGISTER_DEV(MC1455P_DIP, name)
 
 // ---------------------------------------------------------------------
 // Source: ../macro/nlm_roms_lib.cpp
 // ---------------------------------------------------------------------
 
 NETLIST_EXTERNAL(roms_lib)
-// usage       : PROM_82S123_DIP(name, )
-#define PROM_82S123_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(PROM_82S123_DIP, __VA_ARGS__)
+// usage       : PROM_82S123_DIP(name)
+#define PROM_82S123_DIP(name)                                                   \
+	NET_REGISTER_DEV(PROM_82S123_DIP, name)
 
-// usage       : PROM_82S126_DIP(name, )
-#define PROM_82S126_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(PROM_82S126_DIP, __VA_ARGS__)
+// usage       : PROM_82S126_DIP(name)
+#define PROM_82S126_DIP(name)                                                   \
+	NET_REGISTER_DEV(PROM_82S126_DIP, name)
 
-// usage       : PROM_74S287_DIP(name, )
-#define PROM_74S287_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(PROM_74S287_DIP, __VA_ARGS__)
+// usage       : PROM_74S287_DIP(name)
+#define PROM_74S287_DIP(name)                                                   \
+	NET_REGISTER_DEV(PROM_74S287_DIP, name)
 
-// usage       : EPROM_2716_DIP(name, )
-#define EPROM_2716_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(EPROM_2716_DIP, __VA_ARGS__)
+// usage       : EPROM_2716_DIP(name)
+#define EPROM_2716_DIP(name)                                                   \
+	NET_REGISTER_DEV(EPROM_2716_DIP, name)
 
-// usage       : TTL_82S16_DIP(name, )
-#define TTL_82S16_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_82S16_DIP, __VA_ARGS__)
+// usage       : TTL_82S16_DIP(name)
+#define TTL_82S16_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_82S16_DIP, name)
 
-// usage       : PROM_82S115_DIP(name, )
-#define PROM_82S115_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(PROM_82S115_DIP, __VA_ARGS__)
+// usage       : PROM_82S115_DIP(name)
+#define PROM_82S115_DIP(name)                                                   \
+	NET_REGISTER_DEV(PROM_82S115_DIP, name)
 
-// usage       : PROM_MK28000_DIP(name, )
-#define PROM_MK28000_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(PROM_MK28000_DIP, __VA_ARGS__)
+// usage       : PROM_MK28000_DIP(name)
+#define PROM_MK28000_DIP(name)                                                   \
+	NET_REGISTER_DEV(PROM_MK28000_DIP, name)
 
-// usage       : ROM_MCM14524_DIP(name, )
-#define ROM_MCM14524_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(ROM_MCM14524_DIP, __VA_ARGS__)
+// usage       : ROM_MCM14524_DIP(name)
+#define ROM_MCM14524_DIP(name)                                                   \
+	NET_REGISTER_DEV(ROM_MCM14524_DIP, name)
 
-// usage       : RAM_2102A_DIP(name, )
-#define RAM_2102A_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(RAM_2102A_DIP, __VA_ARGS__)
+// usage       : RAM_2102A_DIP(name)
+#define RAM_2102A_DIP(name)                                                   \
+	NET_REGISTER_DEV(RAM_2102A_DIP, name)
 
-// usage       : ROM_TMS4800_DIP(name, )
-#define ROM_TMS4800_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(ROM_TMS4800_DIP, __VA_ARGS__)
+// usage       : ROM_TMS4800_DIP(name)
+#define ROM_TMS4800_DIP(name)                                                   \
+	NET_REGISTER_DEV(ROM_TMS4800_DIP, name)
 
 // ---------------------------------------------------------------------
 // Source: ../macro/nlm_ttl74xx_lib.cpp
@@ -1131,478 +1188,528 @@ NETLIST_EXTERNAL(roms_lib)
 
 // usage       : TTL_7400_NAND(name, A, B)
 // auto connect: VCC, GND
-#define TTL_7400_NAND(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7400_NAND, __VA_ARGS__)
+#define TTL_7400_NAND(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_7400_NAND: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7400_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7402_NOR(name, A, B)
 // auto connect: VCC, GND
-#define TTL_7402_NOR(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7402_NOR, __VA_ARGS__)
+#define TTL_7402_NOR(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_7402_NOR: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7402_NOR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7404_INVERT(name, A)
 // auto connect: VCC, GND
-#define TTL_7404_INVERT(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7404_INVERT, __VA_ARGS__)
+#define TTL_7404_INVERT(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 1, "TTL_7404_INVERT: Mismatched number of parameters passed, expected 1 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7404_INVERT, name __VA_OPT__(,) __VA_ARGS__)
 
-// usage       : TTL_7406_GATE(name, )
-#define TTL_7406_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7406_GATE, __VA_ARGS__)
+// usage       : TTL_7406_GATE(name)
+#define TTL_7406_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_7406_GATE, name)
 
-// usage       : TTL_7407_GATE(name, )
-#define TTL_7407_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7407_GATE, __VA_ARGS__)
+// usage       : TTL_7407_GATE(name)
+#define TTL_7407_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_7407_GATE, name)
 
-// usage       : TTL_7408_GATE(name, )
-#define TTL_7408_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7408_GATE, __VA_ARGS__)
+// usage       : TTL_7408_GATE(name)
+#define TTL_7408_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_7408_GATE, name)
 
 // usage       : TTL_7408_AND(name, A, B)
 // auto connect: VCC, GND
-#define TTL_7408_AND(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7408_AND, __VA_ARGS__)
+#define TTL_7408_AND(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_7408_AND: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7408_AND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7410_NAND(name, A, B, C)
 // auto connect: VCC, GND
-#define TTL_7410_NAND(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7410_NAND, __VA_ARGS__)
+#define TTL_7410_NAND(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 3, "TTL_7410_NAND: Mismatched number of parameters passed, expected 3 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7410_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
-// usage       : TTL_7410_GATE(name, )
-#define TTL_7410_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7410_GATE, __VA_ARGS__)
+// usage       : TTL_7410_GATE(name)
+#define TTL_7410_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_7410_GATE, name)
 
 // usage       : TTL_7411_AND(name, A, B, C)
 // auto connect: VCC, GND
-#define TTL_7411_AND(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7411_AND, __VA_ARGS__)
+#define TTL_7411_AND(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 3, "TTL_7411_AND: Mismatched number of parameters passed, expected 3 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7411_AND, name __VA_OPT__(,) __VA_ARGS__)
 
-// usage       : TTL_7411_GATE(name, )
-#define TTL_7411_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7411_GATE, __VA_ARGS__)
+// usage       : TTL_7411_GATE(name)
+#define TTL_7411_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_7411_GATE, name)
 
-// usage       : TTL_7416_GATE(name, )
-#define TTL_7416_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7416_GATE, __VA_ARGS__)
+// usage       : TTL_7416_GATE(name)
+#define TTL_7416_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_7416_GATE, name)
 
-// usage       : TTL_7417_GATE(name, )
-#define TTL_7417_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7417_GATE, __VA_ARGS__)
+// usage       : TTL_7417_GATE(name)
+#define TTL_7417_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_7417_GATE, name)
 
 // usage       : TTL_7420_NAND(name, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_7420_NAND(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7420_NAND, __VA_ARGS__)
+#define TTL_7420_NAND(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7420_NAND: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7420_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7421_AND(name, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_7421_AND(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7421_AND, __VA_ARGS__)
+#define TTL_7421_AND(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7421_AND: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7421_AND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7425_NOR(name, A, B, C, D)
 // auto connect: VCC, GND
-#define TTL_7425_NOR(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7425_NOR, __VA_ARGS__)
+#define TTL_7425_NOR(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 4, "TTL_7425_NOR: Mismatched number of parameters passed, expected 4 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7425_NOR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7427_NOR(name, A, B, C)
 // auto connect: VCC, GND
-#define TTL_7427_NOR(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7427_NOR, __VA_ARGS__)
+#define TTL_7427_NOR(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 3, "TTL_7427_NOR: Mismatched number of parameters passed, expected 3 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7427_NOR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7430_NAND(name, A, B, C, D, E, F, G, H)
 // auto connect: VCC, GND
-#define TTL_7430_NAND(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7430_NAND, __VA_ARGS__)
+#define TTL_7430_NAND(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 8, "TTL_7430_NAND: Mismatched number of parameters passed, expected 8 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7430_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7432_OR(name, A, B)
 // auto connect: VCC, GND
-#define TTL_7432_OR(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7432_OR, __VA_ARGS__)
+#define TTL_7432_OR(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_7432_OR: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7432_OR, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7437_NAND(name, A, B)
-#define TTL_7437_NAND(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7437_NAND, __VA_ARGS__)
+#define TTL_7437_NAND(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_7437_NAND: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7437_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
 // usage       : TTL_7438_NAND(name, A, B)
-#define TTL_7438_NAND(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7438_NAND, __VA_ARGS__)
+#define TTL_7438_NAND(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_7438_NAND: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7438_NAND, name __VA_OPT__(,) __VA_ARGS__)
 
-// usage       : TTL_7442(name, )
-#define TTL_7442(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7442, __VA_ARGS__)
+// usage       : TTL_7442(name)
+#define TTL_7442(name)                                                   \
+	NET_REGISTER_DEV(TTL_7442, name)
 
 // usage       : TTL_7486_XOR(name, A, B)
 // auto connect: VCC, GND
-#define TTL_7486_XOR(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7486_XOR, __VA_ARGS__)
+#define TTL_7486_XOR(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 2, "TTL_7486_XOR: Mismatched number of parameters passed, expected 2 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_7486_XOR, name __VA_OPT__(,) __VA_ARGS__)
 
-// usage       : TTL_74139_GATE(name, )
-#define TTL_74139_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74139_GATE, __VA_ARGS__)
+// usage       : TTL_74139_GATE(name)
+#define TTL_74139_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_74139_GATE, name)
 
-// usage       : TTL_74155A_GATE(name, )
-#define TTL_74155A_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74155A_GATE, __VA_ARGS__)
+// usage       : TTL_74147_GATE(name)
+#define TTL_74147_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_74147_GATE, name)
 
-// usage       : TTL_74155B_GATE(name, )
-#define TTL_74155B_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74155B_GATE, __VA_ARGS__)
+// usage       : TTL_74148_GATE(name)
+#define TTL_74148_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_74148_GATE, name)
 
-// usage       : TTL_74156A_GATE(name, )
-#define TTL_74156A_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74156A_GATE, __VA_ARGS__)
+// usage       : TTL_74151_GATE(name)
+#define TTL_74151_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_74151_GATE, name)
 
-// usage       : TTL_74156B_GATE(name, )
-#define TTL_74156B_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74156B_GATE, __VA_ARGS__)
+// usage       : TTL_74155A_GATE(name)
+#define TTL_74155A_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_74155A_GATE, name)
 
-// usage       : TTL_74157_GATE(name, )
-#define TTL_74157_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74157_GATE, __VA_ARGS__)
+// usage       : TTL_74155B_GATE(name)
+#define TTL_74155B_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_74155B_GATE, name)
+
+// usage       : TTL_74156A_GATE(name)
+#define TTL_74156A_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_74156A_GATE, name)
+
+// usage       : TTL_74156B_GATE(name)
+#define TTL_74156B_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_74156B_GATE, name)
+
+// usage       : TTL_74157_GATE(name)
+#define TTL_74157_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_74157_GATE, name)
 
 // usage       : TTL_74260_NOR(name, A, B, C, D, E)
 // auto connect: VCC, GND
-#define TTL_74260_NOR(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74260_NOR, __VA_ARGS__)
+#define TTL_74260_NOR(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 5, "TTL_74260_NOR: Mismatched number of parameters passed, expected 5 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_74260_NOR, name __VA_OPT__(,) __VA_ARGS__)
 
-// usage       : TTL_74279A(name, )
-#define TTL_74279A(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74279A, __VA_ARGS__)
+// usage       : TTL_74279A(name)
+#define TTL_74279A(name)                                                   \
+	NET_REGISTER_DEV(TTL_74279A, name)
 
-// usage       : TTL_74279B(name, )
-#define TTL_74279B(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74279B, __VA_ARGS__)
+// usage       : TTL_74279B(name)
+#define TTL_74279B(name)                                                   \
+	NET_REGISTER_DEV(TTL_74279B, name)
 
-// usage       : TTL_9312(name, )
-#define TTL_9312(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9312, __VA_ARGS__)
+// usage       : TTL_74368_GATE(name)
+#define TTL_74368_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_74368_GATE, name)
+
+// usage       : TTL_9312(name, A, B, C, G, D0, D1, D2, D3, D4, D5, D6, D7)
+// auto connect: VCC, GND
+#define TTL_9312(name, ...)                                                   \
+	__VA_OPT__(static_assert(PNARGS(__VA_ARGS__) == 12, "TTL_9312: Mismatched number of parameters passed, expected 12 but got " PSTRINGIFY(PNARGS(__VA_ARGS__)));) \
+	NET_REGISTER_DEV(TTL_9312, name __VA_OPT__(,) __VA_ARGS__)
 
 NETLIST_EXTERNAL(ttl74xx_lib)
-// usage       : TTL_7400_DIP(name, )
-#define TTL_7400_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7400_DIP, __VA_ARGS__)
-
-// usage       : TTL_7402_DIP(name, )
-#define TTL_7402_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7402_DIP, __VA_ARGS__)
-
-// usage       : TTL_7404_DIP(name, )
-#define TTL_7404_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7404_DIP, __VA_ARGS__)
-
-// usage       : TTL_7406_DIP(name, )
-#define TTL_7406_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7406_DIP, __VA_ARGS__)
-
-// usage       : TTL_7407_DIP(name, )
-#define TTL_7407_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7407_DIP, __VA_ARGS__)
-
-// usage       : TTL_7408_DIP(name, )
-#define TTL_7408_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7408_DIP, __VA_ARGS__)
-
-// usage       : TTL_7410_DIP(name, )
-#define TTL_7410_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7410_DIP, __VA_ARGS__)
-
-// usage       : TTL_7411_DIP(name, )
-#define TTL_7411_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7411_DIP, __VA_ARGS__)
-
-// usage       : TTL_7414_GATE(name, )
-#define TTL_7414_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7414_GATE, __VA_ARGS__)
-
-// usage       : TTL_74LS14_GATE(name, )
-#define TTL_74LS14_GATE(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74LS14_GATE, __VA_ARGS__)
-
-// usage       : TTL_7414_DIP(name, )
-#define TTL_7414_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7414_DIP, __VA_ARGS__)
-
-// usage       : TTL_74LS14_DIP(name, )
-#define TTL_74LS14_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74LS14_DIP, __VA_ARGS__)
-
-// usage       : TTL_7416_DIP(name, )
-#define TTL_7416_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7416_DIP, __VA_ARGS__)
-
-// usage       : TTL_7417_DIP(name, )
-#define TTL_7417_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7417_DIP, __VA_ARGS__)
-
-// usage       : TTL_7420_DIP(name, )
-#define TTL_7420_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7420_DIP, __VA_ARGS__)
-
-// usage       : TTL_7421_DIP(name, )
-#define TTL_7421_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7421_DIP, __VA_ARGS__)
-
-// usage       : TTL_7425_DIP(name, )
-#define TTL_7425_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7425_DIP, __VA_ARGS__)
-
-// usage       : TTL_7427_DIP(name, )
-#define TTL_7427_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7427_DIP, __VA_ARGS__)
-
-// usage       : TTL_7430_DIP(name, )
-#define TTL_7430_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7430_DIP, __VA_ARGS__)
-
-// usage       : TTL_7432_DIP(name, )
-#define TTL_7432_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7432_DIP, __VA_ARGS__)
-
-// usage       : TTL_7437_DIP(name, )
-#define TTL_7437_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7437_DIP, __VA_ARGS__)
-
-// usage       : TTL_7438_DIP(name, )
-#define TTL_7438_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7438_DIP, __VA_ARGS__)
-
-// usage       : TTL_7442_DIP(name, )
-#define TTL_7442_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7442_DIP, __VA_ARGS__)
-
-// usage       : TTL_7448_DIP(name, )
-#define TTL_7448_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7448_DIP, __VA_ARGS__)
-
-// usage       : TTL_7450_DIP(name, )
-#define TTL_7450_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7450_DIP, __VA_ARGS__)
-
-// usage       : TTL_7473_DIP(name, )
-#define TTL_7473_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7473_DIP, __VA_ARGS__)
-
-// usage       : TTL_7473A_DIP(name, )
-#define TTL_7473A_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7473A_DIP, __VA_ARGS__)
-
-// usage       : TTL_7474_DIP(name, )
-#define TTL_7474_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7474_DIP, __VA_ARGS__)
-
-// usage       : TTL_7475_DIP(name, )
-#define TTL_7475_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7475_DIP, __VA_ARGS__)
-
-// usage       : TTL_7477_DIP(name, )
-#define TTL_7477_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7477_DIP, __VA_ARGS__)
-
-// usage       : TTL_7483_DIP(name, )
-#define TTL_7483_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7483_DIP, __VA_ARGS__)
-
-// usage       : TTL_7485_DIP(name, )
-#define TTL_7485_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7485_DIP, __VA_ARGS__)
-
-// usage       : TTL_7486_DIP(name, )
-#define TTL_7486_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7486_DIP, __VA_ARGS__)
-
-// usage       : TTL_7490_DIP(name, )
-#define TTL_7490_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7490_DIP, __VA_ARGS__)
-
-// usage       : TTL_7492_DIP(name, )
-#define TTL_7492_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7492_DIP, __VA_ARGS__)
-
-// usage       : TTL_7493_DIP(name, )
-#define TTL_7493_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7493_DIP, __VA_ARGS__)
-
-// usage       : TTL_7497_DIP(name, )
-#define TTL_7497_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_7497_DIP, __VA_ARGS__)
-
-// usage       : TTL_74107_DIP(name, )
-#define TTL_74107_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74107_DIP, __VA_ARGS__)
-
-// usage       : TTL_74107A_DIP(name, )
-#define TTL_74107A_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74107A_DIP, __VA_ARGS__)
-
-// usage       : TTL_74113_DIP(name, )
-#define TTL_74113_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74113_DIP, __VA_ARGS__)
-
-// usage       : TTL_74113A_DIP(name, )
-#define TTL_74113A_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74113A_DIP, __VA_ARGS__)
-
-// usage       : TTL_74121_DIP(name, )
-#define TTL_74121_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74121_DIP, __VA_ARGS__)
-
-// usage       : TTL_74123_DIP(name, )
-#define TTL_74123_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74123_DIP, __VA_ARGS__)
-
-// usage       : TTL_9602_DIP(name, )
-#define TTL_9602_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9602_DIP, __VA_ARGS__)
-
-// usage       : TTL_74125_DIP(name, )
-#define TTL_74125_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74125_DIP, __VA_ARGS__)
-
-// usage       : TTL_74126_DIP(name, )
-#define TTL_74126_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74126_DIP, __VA_ARGS__)
-
-// usage       : TTL_74139_DIP(name, )
-#define TTL_74139_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74139_DIP, __VA_ARGS__)
-
-// usage       : TTL_74153_DIP(name, )
-#define TTL_74153_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74153_DIP, __VA_ARGS__)
-
-// usage       : TTL_74155_DIP(name, )
-#define TTL_74155_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74155_DIP, __VA_ARGS__)
-
-// usage       : TTL_74156_DIP(name, )
-#define TTL_74156_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74156_DIP, __VA_ARGS__)
-
-// usage       : TTL_74157_DIP(name, )
-#define TTL_74157_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74157_DIP, __VA_ARGS__)
-
-// usage       : TTL_74161_DIP(name, )
-#define TTL_74161_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74161_DIP, __VA_ARGS__)
-
-// usage       : TTL_74163_DIP(name, )
-#define TTL_74163_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74163_DIP, __VA_ARGS__)
-
-// usage       : TTL_74164_DIP(name, )
-#define TTL_74164_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74164_DIP, __VA_ARGS__)
-
-// usage       : TTL_74165_DIP(name, )
-#define TTL_74165_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74165_DIP, __VA_ARGS__)
-
-// usage       : TTL_74166_DIP(name, )
-#define TTL_74166_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74166_DIP, __VA_ARGS__)
-
-// usage       : TTL_74174_DIP(name, )
-#define TTL_74174_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74174_DIP, __VA_ARGS__)
-
-// usage       : TTL_74175_DIP(name, )
-#define TTL_74175_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74175_DIP, __VA_ARGS__)
-
-// usage       : TTL_74192_DIP(name, )
-#define TTL_74192_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74192_DIP, __VA_ARGS__)
-
-// usage       : TTL_74193_DIP(name, )
-#define TTL_74193_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74193_DIP, __VA_ARGS__)
-
-// usage       : TTL_74194_DIP(name, )
-#define TTL_74194_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74194_DIP, __VA_ARGS__)
-
-// usage       : TTL_74260_DIP(name, )
-#define TTL_74260_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74260_DIP, __VA_ARGS__)
-
-// usage       : TTL_74279_DIP(name, )
-#define TTL_74279_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74279_DIP, __VA_ARGS__)
-
-// usage       : TTL_74290_DIP(name, )
-#define TTL_74290_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74290_DIP, __VA_ARGS__)
-
-// usage       : TTL_74293_DIP(name, )
-#define TTL_74293_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74293_DIP, __VA_ARGS__)
-
-// usage       : TTL_74365_DIP(name, )
-#define TTL_74365_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74365_DIP, __VA_ARGS__)
-
-// usage       : TTL_74377_DIP(name, )
-#define TTL_74377_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74377_DIP, __VA_ARGS__)
-
-// usage       : TTL_74378_DIP(name, )
-#define TTL_74378_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74378_DIP, __VA_ARGS__)
-
-// usage       : TTL_74379_DIP(name, )
-#define TTL_74379_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74379_DIP, __VA_ARGS__)
-
-// usage       : TTL_74393_DIP(name, )
-#define TTL_74393_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_74393_DIP, __VA_ARGS__)
-
-// usage       : SN74LS629_DIP(name, )
-#define SN74LS629_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(SN74LS629_DIP, __VA_ARGS__)
-
-// usage       : TTL_9310_DIP(name, )
-#define TTL_9310_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9310_DIP, __VA_ARGS__)
-
-// usage       : TTL_9312_DIP(name, )
-#define TTL_9312_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9312_DIP, __VA_ARGS__)
-
-// usage       : TTL_9314_DIP(name, )
-#define TTL_9314_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9314_DIP, __VA_ARGS__)
-
-// usage       : TTL_9316_DIP(name, )
-#define TTL_9316_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9316_DIP, __VA_ARGS__)
-
-// usage       : TTL_9321_DIP(name, )
-#define TTL_9321_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9321_DIP, __VA_ARGS__)
-
-// usage       : TTL_9322_DIP(name, )
-#define TTL_9322_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9322_DIP, __VA_ARGS__)
-
-// usage       : TTL_9334_DIP(name, )
-#define TTL_9334_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_9334_DIP, __VA_ARGS__)
-
-// usage       : TTL_8277_DIP(name, )
-#define TTL_8277_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_8277_DIP, __VA_ARGS__)
-
-// usage       : TTL_AM2847_DIP(name, )
-#define TTL_AM2847_DIP(...)                                                   \
-	NET_REGISTER_DEVEXT(TTL_AM2847_DIP, __VA_ARGS__)
+// usage       : TTL_7400_DIP(name)
+#define TTL_7400_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7400_DIP, name)
+
+// usage       : TTL_7402_DIP(name)
+#define TTL_7402_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7402_DIP, name)
+
+// usage       : TTL_7404_DIP(name)
+#define TTL_7404_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7404_DIP, name)
+
+// usage       : TTL_7406_DIP(name)
+#define TTL_7406_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7406_DIP, name)
+
+// usage       : TTL_7407_DIP(name)
+#define TTL_7407_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7407_DIP, name)
+
+// usage       : TTL_7408_DIP(name)
+#define TTL_7408_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7408_DIP, name)
+
+// usage       : TTL_7410_DIP(name)
+#define TTL_7410_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7410_DIP, name)
+
+// usage       : TTL_7411_DIP(name)
+#define TTL_7411_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7411_DIP, name)
+
+// usage       : TTL_7414_GATE(name)
+#define TTL_7414_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_7414_GATE, name)
+
+// usage       : TTL_74LS14_GATE(name)
+#define TTL_74LS14_GATE(name)                                                   \
+	NET_REGISTER_DEV(TTL_74LS14_GATE, name)
+
+// usage       : TTL_7414_DIP(name)
+#define TTL_7414_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7414_DIP, name)
+
+// usage       : TTL_74LS14_DIP(name)
+#define TTL_74LS14_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74LS14_DIP, name)
+
+// usage       : TTL_7416_DIP(name)
+#define TTL_7416_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7416_DIP, name)
+
+// usage       : TTL_7417_DIP(name)
+#define TTL_7417_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7417_DIP, name)
+
+// usage       : TTL_7420_DIP(name)
+#define TTL_7420_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7420_DIP, name)
+
+// usage       : TTL_7421_DIP(name)
+#define TTL_7421_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7421_DIP, name)
+
+// usage       : TTL_7425_DIP(name)
+#define TTL_7425_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7425_DIP, name)
+
+// usage       : TTL_7427_DIP(name)
+#define TTL_7427_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7427_DIP, name)
+
+// usage       : TTL_7430_DIP(name)
+#define TTL_7430_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7430_DIP, name)
+
+// usage       : TTL_7432_DIP(name)
+#define TTL_7432_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7432_DIP, name)
+
+// usage       : TTL_7437_DIP(name)
+#define TTL_7437_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7437_DIP, name)
+
+// usage       : TTL_7438_DIP(name)
+#define TTL_7438_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7438_DIP, name)
+
+// usage       : TTL_7442_DIP(name)
+#define TTL_7442_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7442_DIP, name)
+
+// usage       : TTL_7448_DIP(name)
+#define TTL_7448_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7448_DIP, name)
+
+// usage       : TTL_7450_DIP(name)
+#define TTL_7450_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7450_DIP, name)
+
+// usage       : TTL_7473_DIP(name)
+#define TTL_7473_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7473_DIP, name)
+
+// usage       : TTL_7473A_DIP(name)
+#define TTL_7473A_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7473A_DIP, name)
+
+// usage       : TTL_7474_DIP(name)
+#define TTL_7474_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7474_DIP, name)
+
+// usage       : TTL_7475_DIP(name)
+#define TTL_7475_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7475_DIP, name)
+
+// usage       : TTL_7477_DIP(name)
+#define TTL_7477_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7477_DIP, name)
+
+// usage       : TTL_7483_DIP(name)
+#define TTL_7483_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7483_DIP, name)
+
+// usage       : TTL_7485_DIP(name)
+#define TTL_7485_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7485_DIP, name)
+
+// usage       : TTL_7486_DIP(name)
+#define TTL_7486_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7486_DIP, name)
+
+// usage       : TTL_7490_DIP(name)
+#define TTL_7490_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7490_DIP, name)
+
+// usage       : TTL_7492_DIP(name)
+#define TTL_7492_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7492_DIP, name)
+
+// usage       : TTL_7493_DIP(name)
+#define TTL_7493_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7493_DIP, name)
+
+// usage       : TTL_7497_DIP(name)
+#define TTL_7497_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_7497_DIP, name)
+
+// usage       : TTL_74107_DIP(name)
+#define TTL_74107_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74107_DIP, name)
+
+// usage       : TTL_74107A_DIP(name)
+#define TTL_74107A_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74107A_DIP, name)
+
+// usage       : TTL_74113_DIP(name)
+#define TTL_74113_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74113_DIP, name)
+
+// usage       : TTL_74113A_DIP(name)
+#define TTL_74113A_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74113A_DIP, name)
+
+// usage       : TTL_74121_DIP(name)
+#define TTL_74121_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74121_DIP, name)
+
+// usage       : TTL_74123_DIP(name)
+#define TTL_74123_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74123_DIP, name)
+
+// usage       : TTL_9602_DIP(name)
+#define TTL_9602_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_9602_DIP, name)
+
+// usage       : TTL_74125_DIP(name)
+#define TTL_74125_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74125_DIP, name)
+
+// usage       : TTL_74126_DIP(name)
+#define TTL_74126_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74126_DIP, name)
+
+// usage       : TTL_74139_DIP(name)
+#define TTL_74139_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74139_DIP, name)
+
+// usage       : TTL_74147_DIP(name)
+#define TTL_74147_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74147_DIP, name)
+
+// usage       : TTL_74148_DIP(name)
+#define TTL_74148_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74148_DIP, name)
+
+// usage       : TTL_74151_DIP(name)
+#define TTL_74151_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74151_DIP, name)
+
+// usage       : TTL_74153_DIP(name)
+#define TTL_74153_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74153_DIP, name)
+
+// usage       : TTL_74155_DIP(name)
+#define TTL_74155_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74155_DIP, name)
+
+// usage       : TTL_74156_DIP(name)
+#define TTL_74156_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74156_DIP, name)
+
+// usage       : TTL_74157_DIP(name)
+#define TTL_74157_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74157_DIP, name)
+
+// usage       : TTL_74161_DIP(name)
+#define TTL_74161_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74161_DIP, name)
+
+// usage       : TTL_74163_DIP(name)
+#define TTL_74163_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74163_DIP, name)
+
+// usage       : TTL_74164_DIP(name)
+#define TTL_74164_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74164_DIP, name)
+
+// usage       : TTL_74165_DIP(name)
+#define TTL_74165_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74165_DIP, name)
+
+// usage       : TTL_74166_DIP(name)
+#define TTL_74166_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74166_DIP, name)
+
+// usage       : TTL_74174_DIP(name)
+#define TTL_74174_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74174_DIP, name)
+
+// usage       : TTL_74175_DIP(name)
+#define TTL_74175_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74175_DIP, name)
+
+// usage       : TTL_74192_DIP(name)
+#define TTL_74192_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74192_DIP, name)
+
+// usage       : TTL_74193_DIP(name)
+#define TTL_74193_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74193_DIP, name)
+
+// usage       : TTL_74194_DIP(name)
+#define TTL_74194_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74194_DIP, name)
+
+// usage       : TTL_74260_DIP(name)
+#define TTL_74260_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74260_DIP, name)
+
+// usage       : TTL_74279_DIP(name)
+#define TTL_74279_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74279_DIP, name)
+
+// usage       : TTL_74290_DIP(name)
+#define TTL_74290_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74290_DIP, name)
+
+// usage       : TTL_74293_DIP(name)
+#define TTL_74293_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74293_DIP, name)
+
+// usage       : TTL_74365_DIP(name)
+#define TTL_74365_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74365_DIP, name)
+
+// usage       : TTL_74368_DIP(name)
+#define TTL_74368_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74368_DIP, name)
+
+// usage       : TTL_74377_DIP(name)
+#define TTL_74377_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74377_DIP, name)
+
+// usage       : TTL_74378_DIP(name)
+#define TTL_74378_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74378_DIP, name)
+
+// usage       : TTL_74379_DIP(name)
+#define TTL_74379_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74379_DIP, name)
+
+// usage       : TTL_74393_DIP(name)
+#define TTL_74393_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_74393_DIP, name)
+
+// usage       : SN74LS629_DIP(name)
+#define SN74LS629_DIP(name)                                                   \
+	NET_REGISTER_DEV(SN74LS629_DIP, name)
+
+// usage       : TTL_9310_DIP(name)
+#define TTL_9310_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_9310_DIP, name)
+
+// usage       : TTL_9312_DIP(name)
+#define TTL_9312_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_9312_DIP, name)
+
+// usage       : TTL_9314_DIP(name)
+#define TTL_9314_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_9314_DIP, name)
+
+// usage       : TTL_9316_DIP(name)
+#define TTL_9316_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_9316_DIP, name)
+
+// usage       : TTL_9321_DIP(name)
+#define TTL_9321_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_9321_DIP, name)
+
+// usage       : TTL_9322_DIP(name)
+#define TTL_9322_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_9322_DIP, name)
+
+// usage       : TTL_9334_DIP(name)
+#define TTL_9334_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_9334_DIP, name)
+
+// usage       : TTL_8277_DIP(name)
+#define TTL_8277_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_8277_DIP, name)
+
+// usage       : TTL_AM2847_DIP(name)
+#define TTL_AM2847_DIP(name)                                                   \
+	NET_REGISTER_DEV(TTL_AM2847_DIP, name)
 
 // ---------------------------------------------------------------------
 // Source: ../solver/nld_solver.cpp
 // ---------------------------------------------------------------------
 
 // usage       : SOLVER(name, FREQ)
-#define SOLVER(...)                                                   \
-	NET_REGISTER_DEVEXT(SOLVER, __VA_ARGS__)
+#define SOLVER(name, FREQ)                                                   \
+	NET_REGISTER_DEV(SOLVER, name, FREQ)
 
 #endif // __PLIB_PREPROCESSOR__
 

--- a/src/lib/netlist/macro/nlm_ttl74xx_lib.cpp
+++ b/src/lib/netlist/macro/nlm_ttl74xx_lib.cpp
@@ -3493,8 +3493,7 @@ static TRUTH_TABLE(TTL_74368_GATE, 5, 4, "")
 	TT_FAMILY("74XX")
 }
 
-static TRUTH_TABLE(TTL_9312, 12, 2,
-				   "+A,+B,+C,+G,+D0,+D1,+D2,+D3,+D4,+D5,+D6,+D7,@VCC,@GND")
+static TRUTH_TABLE(TTL_9312, 12, 2, "+A,+B,+C,+G,+D0,+D1,+D2,+D3,+D4,+D5,+D6,+D7,@VCC,@GND")
 {
 	TT_HEAD(" C, B, A, G,D0,D1,D2,D3,D4,D5,D6,D7| Y,YQ")
 	TT_LINE(" X, X, X, 1, X, X, X, X, X, X, X, X| 0, 1|33,19")

--- a/src/lib/netlist/nl_setup.cpp
+++ b/src/lib/netlist/nl_setup.cpp
@@ -93,21 +93,6 @@ namespace netlist
 	}
 
 	void
-	nlparse_t::register_dev(const pstring &                     classname,
-							std::initializer_list<const char *> more_parameters)
-	{
-		std::vector<pstring> params;
-		const auto *         i(more_parameters.begin());
-		pstring              name(*i);
-		++i;
-		for (; i != more_parameters.end(); ++i)
-		{
-			params.emplace_back(*i);
-		}
-		register_dev(classname, name, params);
-	}
-
-	void
 	nlparse_t::register_dev(const pstring &classname, const pstring &name,
 							const std::vector<pstring> &params_and_connections,
 							factory::element_t **       factory_element)

--- a/src/lib/netlist/nl_setup.h
+++ b/src/lib/netlist/nl_setup.h
@@ -36,11 +36,8 @@
 	setup.register_dip_alias_arr(#pin1 ", " #__VA_ARGS__);
 
 // to be used to reference new library truth table devices
-#define NET_REGISTER_DEV(type, name) setup.register_dev(#type, #name);
-
-// name is first element so that __VA_ARGS__ always has one element
-#define NET_REGISTER_DEVEXT(type, ...)                                         \
-	setup.register_dev(#type, {PSTRINGIFY_VA(__VA_ARGS__)});
+#define NET_REGISTER_DEV(type, name, ...)				       \
+	setup.register_dev(#type, #name __VA_OPT__(, {PSTRINGIFY_VA(__VA_ARGS__)}));
 
 #define NET_CONNECT(name, input, output)                                       \
 	setup.register_link(#name "." #input, #output);
@@ -184,8 +181,6 @@ namespace netlist
 		void register_dev(const pstring &classname, const pstring &name,
 						  const std::vector<pstring> &params_and_connections,
 						  factory::element_t **factory_element = nullptr);
-		void register_dev(const pstring                      &classname,
-						  std::initializer_list<const char *> more_parameters);
 		void register_dev(const pstring &classname, const pstring &name)
 		{
 			register_dev(classname, name, std::vector<pstring>());

--- a/src/lib/netlist/prg/nltool.cpp
+++ b/src/lib/netlist/prg/nltool.cpp
@@ -933,7 +933,7 @@ void tool_app_t::header_entry(const netlist::factory::element_t *e)
 		mac_out("// auto connect: " + avs.substr(2), false);
 
 	mac_out("#define " + e->name() + "(...)");
-	mac_out("\tNET_REGISTER_DEVEXT(" + e->name() +", __VA_ARGS__)", false);
+	mac_out("\tNET_REGISTER_DEV(" + e->name() +", __VA_ARGS__)", false);
 	mac_out("", false);
 }
 


### PR DESCRIPTION
According to ``nl_setup::register_dev`` rules, the device macro must either be passed with the exact number of params supported by the device or no params at all. 

This PR adds some compile-time checking for that, so that when the developer forgets to fully specify all the parameters for a netlist device, they can get a compile-time error rather than a runtime exception or ``validity`` fail.

* Also this removes ``NET_REGISTER_DEVEXT`` macro, not needed anymore after the introduction of C++20 ``__VA_OPT__`` that allows more flexible "overloading" with its original ``NET_REGISTER_DEV`` counterpart
* * Consequently this also removes the ``nl_setup::register_dev`` overload that was specifically made for that macro.