### PR TITLE
fix address lines of Roland PCM cards, add remaining R8 cards

### DIFF
--- a/hash/r8_card.xml
+++ b/hash/r8_card.xml
@@ -3,17 +3,6 @@
 <!--
 license:CC0-1.0
 
-Undumped cards:
-- SN-R8-03 "Sound Effects" 1989
-- SN-R8-04 "Electronic" 1989
-- SN-R8-05 "Jazz" 1989
-- SN-R8-06 "Ethnic Percussion" 1989
-- SN-R8-07 "Mallet" 1990
-- SN-R8-08 "Dry Drums" 1990
-- SN-R8-09 "Power Drums U.S.A." 1990
-- SN-R8-10 "Dance" 1992
-- SN-R8-11 "Metallic Percussion" 1992
-
 
 address/data line scrambling (same as SN-U110):
 
@@ -26,16 +15,16 @@ external internal   external internal
    A4 - - -  A1        D4 - - - D1
    A5 - - -  A2        D5 - - - D3
    A6 - - -  A3        D6 - - - D0
-   A7 - - - A15        D7 - - - D5
-   A8 - - - A13
-   A9 - - - A10
-  A10 - - - A14
+   A7 - - -  A8        D7 - - - D5
+   A8 - - - A10
+   A9 - - - A13
+  A10 - - -  A9
   A11 - - -  A7
-  A12 - - - A12
-  A13 - - - A11
+  A12 - - - A11
+  A13 - - - A12
   A14 - - - A16
-  A15 - - -  A9
-  A16 - - -  A8
+  A15 - - - A14
+  A16 - - - A15
   A17 - - - A17
   A18 - - - A18
 -->
@@ -47,7 +36,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="r8_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-r8-01.bin" size="0x80000" crc="2a9826a7" sha1="96d07c4a6507a06999d5563fb31c03ac8ed1bef7"/>
+				<rom name="sn-r8-01.bin" size="0x80000" crc="c99b164b" sha1="7917c161642c97dcf6e1e6b3b04895d8f49ec1f2"/>
 			</dataarea>
 		</part>
 	</software>
@@ -57,7 +46,67 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="r8_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-r8-02.bin" size="0x80000" crc="e7a87f57" sha1="ee248e0230f10a09b7524f5951ba87ae3756c26a"/>
+				<rom name="sn-r8-02.bin" size="0x80000" crc="b53083a4" sha1="1405581714baeb5dd1ca68b0ad12e57ec65e3264"/>
+			</dataarea>
+		</part>
+	</software>
+	<software name="sn_r8_03">
+		<description>SN-R8-03 Sound Effects</description>
+		<year>1989</year>
+		<publisher>Roland</publisher>
+		<part name="card" interface="r8_card">
+			<dataarea name="rom" size="0x80000">
+				<rom name="sn-r8-03.bin" size="0x80000" crc="b62f7548" sha1="55368255b2294af52bb4745b25a731e562aac994"/>
+			</dataarea>
+		</part>
+	</software>
+	<software name="sn_r8_04">
+		<description>SN-R8-04 Electronic</description>
+		<year>1989</year>
+		<publisher>Roland</publisher>
+		<part name="card" interface="r8_card">
+			<dataarea name="rom" size="0x80000">
+				<rom name="sn-r8-04.bin" size="0x80000" crc="91d62b68" sha1="c7272cee7f585a60095303f8692cd7420a99c354"/>
+			</dataarea>
+		</part>
+	</software>
+	<software name="sn_r8_05">
+		<description>SN-R8-05 Jazz</description>
+		<year>1989</year>
+		<publisher>Roland</publisher>
+		<part name="card" interface="r8_card">
+			<dataarea name="rom" size="0x80000">
+				<rom name="sn-r8-05.bin" size="0x80000" crc="0c9a256c" sha1="1e24fd3663a1eaebd6869e8091e6edfa63f55f07"/>
+			</dataarea>
+		</part>
+	</software>
+	<software name="sn_r8_06">
+		<description>SN-R8-06 Ethnic Percussion</description>
+		<year>1989</year>
+		<publisher>Roland</publisher>
+		<part name="card" interface="r8_card">
+			<dataarea name="rom" size="0x80000">
+				<rom name="sn-r8-06.bin" size="0x80000" crc="3e9d9e29" sha1="b8a55810005a2161329a33ae42e230b3dc9211f7"/>
+			</dataarea>
+		</part>
+	</software>
+	<software name="sn_r8_07">
+		<description>SN-R8-07 Mallet</description>
+		<year>1990</year>
+		<publisher>Roland</publisher>
+		<part name="card" interface="r8_card">
+			<dataarea name="rom" size="0x80000">
+				<rom name="sn-r8-07.bin" size="0x80000" crc="75d3a6e6" sha1="40f2bc4b44a0ea85dde870110243e02b0cc010dd"/>
+			</dataarea>
+		</part>
+	</software>
+	<software name="sn_r8_08">
+		<description>SN-R8-08 Dry Drums</description>
+		<year>1990</year>
+		<publisher>Roland</publisher>
+		<part name="card" interface="r8_card">
+			<dataarea name="rom" size="0x80000">
+				<rom name="sn-r8-08.bin" size="0x80000" crc="5c65e875" sha1="12fd7ce14e9eb340e1baab8ac17b43b7f72cc56a"/>
 			</dataarea>
 		</part>
 	</software>
@@ -67,7 +116,27 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="r8_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-r8-09.bin" size="0x80000" crc="bb3c9453" sha1="68a50437b0665dbc49caeef32be1eb5c73457e88"/>
+				<rom name="sn-r8-09.bin" size="0x80000" crc="c2283ade" sha1="2e394d14332da04e3dda5a0c4e36795a15d474a9"/>
+			</dataarea>
+		</part>
+	</software>
+	<software name="sn_r8_10">
+		<description>SN-R8-10 Dance</description>
+		<year>1992</year>
+		<publisher>Roland</publisher>
+		<part name="card" interface="r8_card">
+			<dataarea name="rom" size="0x80000">
+				<rom name="sn-r8-10.bin" size="0x80000" crc="b89e51b5" sha1="79adce346432514a49afc20401891fafb83eeb74"/>
+			</dataarea>
+		</part>
+	</software>
+	<software name="sn_r8_11">
+		<description>SN-R8-Metallic Percussion</description>
+		<year>1992</year>
+		<publisher>Roland</publisher>
+		<part name="card" interface="r8_card">
+			<dataarea name="rom" size="0x80000">
+				<rom name="sn-r8-11.bin" size="0x80000" crc="4240f92d" sha1="d5672ac12a7f488c0e7d556b967656f08f837efe"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/roland_tnsc2.xml
+++ b/hash/roland_tnsc2.xml
@@ -52,7 +52,7 @@ Releases according to http://www.rolandmuseum.de/indizees/roland_ch.html:
 		<publisher>Roland</publisher>
 		<part name="cart" interface="roland_tnsc2">
 			<dataarea name="rom" size="0x10000">
-				<rom name="tn-sc2-04.bin" size="0x10000" crc="7fd52461" sha1="38e76a348eca1644999361650e2d99f55578a141"/>
+				<rom name="tn-sc2-04.bin" size="0x10000" crc="3c14c84f" sha1="fe69839dc734a8743c8a30c5775246a00266e6db"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/u110_card.xml
+++ b/hash/u110_card.xml
@@ -32,16 +32,16 @@ external internal   external internal
    A4 - - -  A1        D4 - - - D1
    A5 - - -  A2        D5 - - - D3
    A6 - - -  A3        D6 - - - D0
-   A7 - - - A15        D7 - - - D5
-   A8 - - - A13
-   A9 - - - A10
-  A10 - - - A14
+   A7 - - -  A8        D7 - - - D5
+   A8 - - - A10
+   A9 - - - A13
+  A10 - - -  A9
   A11 - - -  A7
-  A12 - - - A12
-  A13 - - - A11
+  A12 - - - A11
+  A13 - - - A12
   A14 - - - A16
-  A15 - - -  A9
-  A16 - - -  A8
+  A15 - - - A14
+  A16 - - - A15
   A17 - - - A17
   A18 - - - A18
 -->
@@ -54,7 +54,7 @@ external internal   external internal
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
 				<!-- Note: The current dump is an overdump due to how address scrambling works. The internal ROM appears to be only 64K. -->
-				<rom name="musitronics_akkordeon.bin" size="0x20000" crc="69e41a1b" sha1="2931181ad60372461e82491a014cb118c68605d8"/>
+				<rom name="musitronics_akkordeon.bin" size="0x20000" crc="12a18917" sha1="6d3f17c44f42b79401416910be624b65b4db8e33"/>
 			</dataarea>
 		</part>
 	</software>
@@ -64,7 +64,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-mv30-01.bin" size="0x80000" crc="9b571919" sha1="873afbac7b1fcd45128952152dc090de48b765c6"/>
+				<rom name="sn-mv30-01.bin" size="0x80000" crc="90ea2ea8" sha1="9f2dced30b9bcc9c4ae841661ee334f1daa6dd68"/>
 			</dataarea>
 		</part>
 	</software>
@@ -74,7 +74,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-mv30-02.bin" size="0x80000" crc="596254dc" sha1="1081973aad7ad5941329d3ab8a20db654c063a2e"/>
+				<rom name="sn-mv30-02.bin" size="0x80000" crc="57c740c9" sha1="bbe0b2aa7badcc5061b648745f1bd957771f134b"/>
 			</dataarea>
 		</part>
 	</software>
@@ -85,7 +85,7 @@ external internal   external internal
 		<!-- Note: The card reports itself with ID 01, which is also used by SN-U110-01. -->
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-spla-01.bin" size="0x80000" crc="809bb699" sha1="2d2119b2d5f81b973076ed8471f329fc0741eebf"/>
+				<rom name="sn-spla-01.bin" size="0x80000" crc="e51284a1" sha1="c248ba8fcfe79c83339132a855dfe047bfa79983"/>
 			</dataarea>
 		</part>
 	</software>
@@ -95,7 +95,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-u110-01.bin" size="0x80000" crc="71fec2e0" sha1="42440bcf0e025dad9182de0a3231f0e00c3a149d"/>
+				<rom name="sn-u110-01.bin" size="0x80000" crc="8a99cfce" sha1="b57b215828d292505c4d5c3e85aefb3e34086514"/>
 			</dataarea>
 		</part>
 	</software>
@@ -105,7 +105,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-u110-02.bin" size="0x80000" crc="335a67cb" sha1="3e1c2fd64c59474426aa8717eb03240bb8b69730"/>
+				<rom name="sn-u110-02.bin" size="0x80000" crc="7f347263" sha1="5e4edc717adcf7e078ea4bc1ce3bd04eacece672"/>
 			</dataarea>
 		</part>
 	</software>
@@ -115,7 +115,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-u110-03.bin" size="0x80000" crc="20a010db" sha1="2d33603fe3217d44d28aec284216581e581a9981"/>
+				<rom name="sn-u110-03.bin" size="0x80000" crc="7f14c801" sha1="1cb93d7bfeb499f22cba316a5732af97d7311a4e"/>
 			</dataarea>
 		</part>
 	</software>
@@ -125,7 +125,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-u110-04.bin" size="0x80000" crc="2653ac2b" sha1="e856625e9efac8ee4026696f46aad4015fb3c097"/>
+				<rom name="sn-u110-04.bin" size="0x80000" crc="39e0e70b" sha1="a369fbb1874c222a0c9e1066275e3174917b3725"/>
 			</dataarea>
 		</part>
 	</software>
@@ -135,7 +135,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-u110-05.bin" size="0x80000" crc="712aa669" sha1="9d67bd73848c1b6c4a9543b8f4abb5794ac2f951"/>
+				<rom name="sn-u110-05.bin" size="0x80000" crc="844b2456" sha1="b1a59971153e0cc5c4c2631a9bdb57433f47ca0e"/>
 			</dataarea>
 		</part>
 	</software>
@@ -145,7 +145,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-u110-06.bin" size="0x80000" crc="5725360d" sha1="d5a8beece04b6da27c6a6b3bddc808c757168a28"/>
+				<rom name="sn-u110-06.bin" size="0x80000" crc="c715c9aa" sha1="02d8dfb9bd45721e34b0eec3db69b3f5e182e7bc"/>
 			</dataarea>
 		</part>
 	</software>
@@ -155,7 +155,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-u110-07.bin" size="0x80000" crc="7a6319c2" sha1="fdcb923b986805e3671fb0962804315d8287cba5"/>
+				<rom name="sn-u110-07.bin" size="0x80000" crc="6fb3a4f4" sha1="1e16c98cf776598b726d4f48ca3f3d677cd32c54"/>
 			</dataarea>
 		</part>
 	</software>
@@ -165,7 +165,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-u110-08.bin" size="0x80000" crc="fef365d2" sha1="ad3ea185cac7d938a9f7fe17d80cab32881e05d7"/>
+				<rom name="sn-u110-08.bin" size="0x80000" crc="104f3974" sha1="71b6f97df6dd4e573db5743c10c77e86d67965a3"/>
 			</dataarea>
 		</part>
 	</software>
@@ -175,7 +175,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-u110-09.bin" size="0x80000" crc="28b03851" sha1="54d07e1b49eedd0f5339999dc0f4690134849f31"/>
+				<rom name="sn-u110-09.bin" size="0x80000" crc="af1c2778" sha1="aea715a0a554c071a2e912894805a8d819802e1d"/>
 			</dataarea>
 		</part>
 	</software>
@@ -185,7 +185,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-u110-10.bin" size="0x80000" crc="7611196a" sha1="056344e4908c2fbde98f77b4d1f5c198c62333e7"/>
+				<rom name="sn-u110-10.bin" size="0x80000" crc="c219c27e" sha1="3249ff037a165e57173bd45c543a665810d2c57b"/>
 			</dataarea>
 		</part>
 	</software>
@@ -195,7 +195,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-u110-11.bin" size="0x80000" crc="57e50aa1" sha1="c15071da567204c84d1a0ae35961caa84ebfa2fc"/>
+				<rom name="sn-u110-11.bin" size="0x80000" crc="0ee5274d" sha1="f5cbe2272d03e21403bfca029476d015f6a34d3a"/>
 			</dataarea>
 		</part>
 	</software>
@@ -205,7 +205,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-u110-12.bin" size="0x80000" crc="4f925426" sha1="c36fb83e720c3bd55d21959927fa616c92105bbc"/>
+				<rom name="sn-u110-12.bin" size="0x80000" crc="39c78747" sha1="bac35550bdd719da4e5dc703d3829523cfee9b8a"/>
 			</dataarea>
 		</part>
 	</software>
@@ -215,7 +215,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-u110-13.bin" size="0x80000" crc="b26fd0b4" sha1="e332d1dd5f0ebf5284501540fdbcc1488e8ef828"/>
+				<rom name="sn-u110-13.bin" size="0x80000" crc="4cbf140a" sha1="4a6ca2b45c83991e62023dfc0114b40baed0e0fd"/>
 			</dataarea>
 		</part>
 	</software>
@@ -225,7 +225,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-u110-14.bin" size="0x80000" crc="7143045d" sha1="b540bd0db7eb2c0914c7cfb5e98ac8c85bd868aa"/>
+				<rom name="sn-u110-14.bin" size="0x80000" crc="cf5e6371" sha1="dfe87d385068201d3a31a55466e171fda614e412"/>
 			</dataarea>
 		</part>
 	</software>
@@ -235,7 +235,7 @@ external internal   external internal
 		<publisher>Roland</publisher>
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
-				<rom name="sn-u110-15.bin" size="0x80000" crc="4e215a4d" sha1="10ad202551632118c5e3bdfb06e6613079217ce9"/>
+				<rom name="sn-u110-15.bin" size="0x80000" crc="2df93109" sha1="56918595d39b480a6a15b7ecc8d1c836cca842a3"/>
 			</dataarea>
 		</part>
 	</software>

--- a/src/mame/roland/roland_cm32p.cpp
+++ b/src/mame/roland/roland_cm32p.cpp
@@ -141,8 +141,7 @@ external internal   external internal
   A17 - - - A17
   A18 - - - A18
 
-Line scramling of A0..A6 and D0..D7 matches the SN-U110 cards.
-For A7..A16 they changed the scrambling.
+Line scramling for the address and data lines matches the SN-U110 cards.
 
 
 PCM ROM Tables
@@ -269,15 +268,11 @@ Some routine locations
 namespace {
 
 // unscramble address: ROM dump offset -> proper (descrambled) offset
-#define UNSCRAMBLE_ADDR_INT(_offset) \
+#define UNSCRAMBLE_ADDR(_offset) \
 	bitswap<19>(_offset,18,17,15,14,16,12,11, 7, 9,13,10, 8, 3, 2, 1, 6, 4, 5, 0)
 // scramble address: proper offset -> ROM dump offset
-#define SCRAMBLE_ADDR_INT(_offset) \
+#define SCRAMBLE_ADDR(_offset) \
 	bitswap<19>(_offset,18,17,14,16,15, 9,13,12, 8,10, 7,11, 3, 1, 2, 6, 5, 4, 0)
-
-// PCM cards use a different address line scrambling
-#define UNSCRAMBLE_ADDR_EXT(_offset) \
-	bitswap<19>(_offset,18,17, 8, 9,16,11,12, 7,14,10,13,15, 3, 2, 1, 6, 4, 5, 0)
 
 #define UNSCRAMBLE_DATA(_data) \
 	bitswap<8>(_data,1,2,7,3,5,0,4,6)
@@ -351,8 +346,7 @@ private:
 
 	void cm32p_map(address_map &map) ATTR_COLD;
 
-	void descramble_rom_internal(u8* dst, const u8* src);
-	void descramble_rom_external(u8* dst, const u8* src);
+	void descramble_pcm_rom(u8* dst, const u8* src);
 
 	bool pcmard_loaded;
 	u8 midi;
@@ -446,7 +440,7 @@ DEVICE_IMAGE_LOAD_MEMBER(cm32p_state::card_load)
 	u8 *dst = reinterpret_cast<u8 *>(memregion("pcm")->base());
 	memcpy(&src[0x080000], base, 0x080000);
 	// descramble PCM card ROM
-	descramble_rom_external(&dst[0x080000], &src[0x080000]);
+	descramble_pcm_rom(&dst[0x080000], &src[0x080000]);
 	pcmard_loaded = true;
 
 	return std::make_pair(std::error_condition(), std::string());
@@ -667,27 +661,18 @@ void cm32p_state::init_cm32p()
 	u8* src = static_cast<u8*>(memregion("pcmorg")->base());
 	u8* dst = static_cast<u8*>(memregion("pcm")->base());
 	// descramble internal ROMs
-	descramble_rom_internal(&dst[0x000000], &src[0x000000]);
-	descramble_rom_internal(&dst[0x100000], &src[0x100000]);
-	descramble_rom_internal(&dst[0x200000], &src[0x200000]);
+	descramble_pcm_rom(&dst[0x000000], &src[0x000000]);
+	descramble_pcm_rom(&dst[0x100000], &src[0x100000]);
+	descramble_pcm_rom(&dst[0x200000], &src[0x200000]);
 	// descramble PCM card ROM
-	descramble_rom_external(&dst[0x080000], &src[0x080000]);
+	descramble_pcm_rom(&dst[0x080000], &src[0x080000]);
 }
 
-void cm32p_state::descramble_rom_internal(u8* dst, const u8* src)
+void cm32p_state::descramble_pcm_rom(u8* dst, const u8* src)
 {
 	for (offs_t srcpos = 0x00; srcpos < 0x80000; srcpos ++)
 	{
-		offs_t dstpos = UNSCRAMBLE_ADDR_INT(srcpos);
-		dst[dstpos] = UNSCRAMBLE_DATA(src[srcpos]);
-	}
-}
-
-void cm32p_state::descramble_rom_external(u8* dst, const u8* src)
-{
-	for (offs_t srcpos = 0x00; srcpos < 0x80000; srcpos ++)
-	{
-		offs_t dstpos = UNSCRAMBLE_ADDR_EXT(srcpos);
+		offs_t dstpos = UNSCRAMBLE_ADDR(srcpos);
 		dst[dstpos] = UNSCRAMBLE_DATA(src[srcpos]);
 	}
 }

--- a/src/mame/roland/roland_r8.cpp
+++ b/src/mame/roland/roland_r8.cpp
@@ -90,8 +90,8 @@ R8 mkII doesn't seem to store the tone list in the program ROM.
 namespace {
 
 // PCM card address line scrambling
-#define UNSCRAMBLE_ADDR_EXT(_offset) \
-	bitswap<19>(_offset,18,17, 8, 9,16,11,12, 7,14,10,13,15, 3, 2, 1, 6, 4, 5, 0)
+#define UNSCRAMBLE_ADDR(_offset) \
+	bitswap<19>(_offset,18,17,15,14,16,12,11, 7, 9,13,10, 8, 3, 2, 1, 6, 4, 5, 0)
 
 #define UNSCRAMBLE_DATA(_data) \
 	bitswap<8>(_data,1,2,7,3,5,0,4,6)
@@ -120,7 +120,7 @@ protected:
 
 	std::pair<std::error_condition, std::string> pcmrom_load(generic_slot_device* pcmcard, int card_id, device_image_interface &image);
 	void pcmrom_unload(int card_id);
-	void descramble_rom_external(u8* dst, const u8* src);
+	void descramble_pcm_rom(u8* dst, const u8* src);
 
 	required_device<upd78k2_device> m_maincpu;
 	required_device<mb87419_mb87420_device> m_pcm;
@@ -209,7 +209,7 @@ std::pair<std::error_condition, std::string> roland_r8_base_state::pcmrom_load(g
 	u8 *dst = reinterpret_cast<u8 *>(memregion("pcm")->base());
 	memcpy(&src[pcm_addr], base, PCMCARD_SIZE);
 	// descramble PCM card ROM
-	descramble_rom_external(&dst[pcm_addr], &src[pcm_addr]);
+	descramble_pcm_rom(&dst[pcm_addr], &src[pcm_addr]);
 	//pcmard_loaded[card_id] = true;
 
 	return std::make_pair(std::error_condition(), std::string());
@@ -326,18 +326,18 @@ void roland_r8_base_state::init_r8()
 
 	for (offs_t addr = 0; addr < memregion("pcmorg")->bytes(); addr += 0x100000)
 	{
-		// TODO: descramble internal ROMs
-		memcpy(&dst[addr + 0x00000], &src[addr + 0x00000], 0x80000);
+		// descramble internal ROMs
+		descramble_pcm_rom(&dst[addr + 0x00000], &src[addr + 0x00000]);
 		// descramble PCM card ROMs
-		descramble_rom_external(&dst[addr + 0x80000], &src[addr + 0x80000]);
+		descramble_pcm_rom(&dst[addr + 0x80000], &src[addr + 0x80000]);
 	}
 }
 
-void roland_r8_base_state::descramble_rom_external(u8* dst, const u8* src)
+void roland_r8_base_state::descramble_pcm_rom(u8* dst, const u8* src)
 {
 	for (offs_t srcpos = 0x00; srcpos < PCMCARD_SIZE; srcpos ++)
 	{
-		offs_t dstpos = UNSCRAMBLE_ADDR_EXT(srcpos);
+		offs_t dstpos = UNSCRAMBLE_ADDR(srcpos);
 		dst[dstpos] = UNSCRAMBLE_DATA(src[srcpos]);
 	}
 }


### PR DESCRIPTION
My original dumps of Roland PCM cards had address lines 8..15 reversed.
I recently noticed this when comparing my own dumps with other dumps of Roland R8 PCM cards that were posted online about 3 years ago.

This PR fixes the dumps, as well as all descrambling code in the MAME drivers.
The descrambling matches the CM-32P's internal ROMs now. (And the contents of the TN-SC2-04 card look sane as well.)

I also added dumps of all the remaining Roland R8 PCM cards. Source is the R-8 wave card collection.
After fixing the address line ordering on my side, the three R8 cards that I dumped by myself matched the dumps from the "wave card collection", so I assume those dumps are good.