### PR TITLE
generalplus gpce4 refactoring

### DIFF
--- a/scripts/src/machine.lua
+++ b/scripts/src/machine.lua
@@ -3564,6 +3564,7 @@ end
 --@src/devices/machine/generalplus_gpl162xx_soc.h,MACHINES["SPG2XX"] = true
 --@src/devices/machine/generalplus_gpl1625x_soc.h,MACHINES["SPG2XX"] = true
 --@src/devices/machine/generalplus_gpl951xx_soc.h,MACHINES["SPG2XX"] = true
+--@src/devices/machine/generalplus_gpce4_soc.h,MACHINES["SPG2XX"] = true
 ---------------------------------------------------
 
 if MACHINES["SPG2XX"] then
@@ -3590,6 +3591,8 @@ if MACHINES["SPG2XX"] then
 		MAME_DIR .. "src/devices/machine/generalplus_gpl162xx_soc_video.h",
 		MAME_DIR .. "src/devices/machine/generalplus_gpl951xx_soc.cpp",
 		MAME_DIR .. "src/devices/machine/generalplus_gpl951xx_soc.h",
+		MAME_DIR .. "src/devices/machine/generalplus_gpce4_soc.cpp",
+		MAME_DIR .. "src/devices/machine/generalplus_gpce4_soc.h",
 		MAME_DIR .. "src/devices/machine/spg_renderer.cpp",
 		MAME_DIR .. "src/devices/machine/spg_renderer.h",
 		MAME_DIR .. "src/devices/machine/gpl_renderer.cpp",

--- a/src/devices/machine/generalplus_gpce4_soc.cpp
+++ b/src/devices/machine/generalplus_gpce4_soc.cpp
@@ -44,6 +44,7 @@ void generalplus_gpce4_soc_device::device_start()
 	save_item(NAME(m_ioa_buffer));
 	save_item(NAME(m_iob_buffer));
 	save_item(NAME(m_interrupt_ctrl));
+	save_item(NAME(m_interrupt2_ctrl));
 	save_item(NAME(m_timer_ctrl));
 	save_item(NAME(m_io_ctrl));
 	save_item(NAME(m_ioa_attribute));
@@ -72,6 +73,7 @@ void generalplus_gpce4_soc_device::device_reset()
 	m_ioa_buffer = 0;
 	m_iob_buffer = 0;
 	m_interrupt_ctrl = 0;
+	m_interrupt2_ctrl = 0;
 	m_timer_ctrl = 0;
 	m_io_ctrl = 0;
 	m_ioa_attribute = 0;
@@ -92,6 +94,8 @@ void generalplus_gpce4_soc_device::device_add_mconfig(machine_config &config)
 {
 	TIMER(config, "timer_c").configure_periodic(FUNC(generalplus_gpce4_soc_device::timer_c_cb), attotime::from_hz(1000)); // game speed?
 	TIMER(config, "timer_a").configure_periodic(FUNC(generalplus_gpce4_soc_device::timer_a_cb), attotime::from_hz(20000)); // audio
+	TIMER(config, "timer_2hz").configure_periodic(FUNC(generalplus_gpce4_soc_device::timer_2hz_cb), attotime::from_hz(2));
+	TIMER(config, "timer_64hz").configure_periodic(FUNC(generalplus_gpce4_soc_device::timer_64hz_cb), attotime::from_hz(64));
 
 	SPEAKER(config, "speaker").front_center();
 	DAC_16BIT_R2R_TWOS_COMPLEMENT(config, "dac", 0).add_route(ALL_OUTPUTS, "speaker", 1.0); // unknown DAC
@@ -153,7 +157,7 @@ void generalplus_gpce4_soc_device::internal_map(address_map &map)
 	map(0x003043, 0x003043).w(FUNC(generalplus_gpce4_soc_device::ppam_ctrl_w)); // PPAMCtrl
 
 	map(0x003050, 0x003050).rw(FUNC(generalplus_gpce4_soc_device::interrupt_ctrl_r), FUNC(generalplus_gpce4_soc_device::interrupt_ctrl_w)); // INT_Ctrl
-	map(0x003051, 0x003051).w(FUNC(generalplus_gpce4_soc_device::interrupt_status_w)); // INT_Status
+	map(0x003051, 0x003051).rw(FUNC(generalplus_gpce4_soc_device::interrupt_status_r), FUNC(generalplus_gpce4_soc_device::interrupt_status_w)); // INT_Status
 	map(0x003052, 0x003052).rw(FUNC(generalplus_gpce4_soc_device::fiq_sel_r), FUNC(generalplus_gpce4_soc_device::fiq_sel_w)); // FIQ_SEL
 	map(0x003053, 0x003053).rw(FUNC(generalplus_gpce4_soc_device::interrupt2_ctrl_r), FUNC(generalplus_gpce4_soc_device::interrupt2_ctrl_w)); // INT2_Ctrl
 	map(0x003054, 0x003054).rw(FUNC(generalplus_gpce4_soc_device::interrupt2_status_r), FUNC(generalplus_gpce4_soc_device::interrupt2_status_w)); // INT2_Status
@@ -224,6 +228,16 @@ TIMER_DEVICE_CALLBACK_MEMBER( generalplus_gpce4_soc_device::timer_c_cb )
 TIMER_DEVICE_CALLBACK_MEMBER( generalplus_gpce4_soc_device::timer_a_cb )
 {
 	request_interrupt(31);
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER( generalplus_gpce4_soc_device::timer_2hz_cb )
+{
+	request_interrupt(0);
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER( generalplus_gpce4_soc_device::timer_64hz_cb )
+{
+	request_interrupt(2);
 }
 
 // IOA
@@ -545,7 +559,6 @@ u16 generalplus_gpce4_soc_device::interrupt_ctrl_r()
 
 void generalplus_gpce4_soc_device::interrupt_ctrl_w(u16 data)
 {
-	//u16 old = m_interrupt_ctrl;
 	m_interrupt_ctrl = data;
 
 	// 15 IRQ0_TMA          -- enabled in mapacman
@@ -571,21 +584,28 @@ void generalplus_gpce4_soc_device::interrupt_ctrl_w(u16 data)
 u16 generalplus_gpce4_soc_device::interrupt2_status_r()
 {
 	LOGMASKED(LOG_IRQ, "%s: interrupt2_status_r\n", machine().describe_context());
-	return machine().rand();
+	return m_interrupt_status & 0xffff;
 }
 
 void generalplus_gpce4_soc_device::interrupt2_status_w(u16 data)
 {
 	LOGMASKED(LOG_IRQ, "%s: interrupt2_status_w %04x\n", machine().describe_context(), data);
+
+	if (data & 0x0004)
+		clear_interrupt(2);
+
+	if (data & 0x0001)
+		clear_interrupt(0);
 }
 
 u16 generalplus_gpce4_soc_device::interrupt2_ctrl_r()
 {
-	return 0x0000;
+	return m_interrupt2_ctrl;
 }
 
 void generalplus_gpce4_soc_device::interrupt2_ctrl_w(u16 data)
 {
+	m_interrupt2_ctrl = data;
 	// 15  ---
 	//     ---
 	//     ---
@@ -704,6 +724,24 @@ void generalplus_gpce4_soc_device::update_interrupts()
 	{
 		set_input_line(UNSP_IRQ3_LINE, CLEAR_LINE);
 	}
+
+	if ((m_interrupt_status & 0x0000'0001) && (m_interrupt2_ctrl & 0x0001))
+	{
+		set_input_line(UNSP_IRQ7_LINE, ASSERT_LINE);
+	}
+	else
+	{
+		set_input_line(UNSP_IRQ7_LINE, CLEAR_LINE);
+	}
+
+	if ((m_interrupt_status & 0x0000'0004) && (m_interrupt2_ctrl & 0x0004))
+	{
+		set_input_line(UNSP_IRQ7_LINE, ASSERT_LINE);
+	}
+	else
+	{
+		set_input_line(UNSP_IRQ7_LINE, CLEAR_LINE);
+	}
 }
 
 void generalplus_gpce4_soc_device::request_interrupt(int which)
@@ -718,6 +756,12 @@ void generalplus_gpce4_soc_device::clear_interrupt(int which)
 	int bit = 1 << which;
 	m_interrupt_status = (m_interrupt_status & ~bit);
 	update_interrupts();
+}
+
+u16 generalplus_gpce4_soc_device::interrupt_status_r()
+{
+	LOGMASKED(LOG_IRQ, "%s: interrupt_status_r\n", machine().describe_context());
+	return (m_interrupt_status >> 16) & 0xffff;
 }
 
 void generalplus_gpce4_soc_device::interrupt_status_w(u16 data)

--- a/src/devices/machine/generalplus_gpce4_soc.cpp
+++ b/src/devices/machine/generalplus_gpce4_soc.cpp
@@ -1,0 +1,921 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+
+// preliminary emulation, just enough for mapacman to run for now
+
+#include "emu.h"
+
+#include "generalplus_gpce4_soc.h"
+
+#define LOG_IO     (1U << 1)
+#define LOG_TIMERS (1U << 2)
+#define LOG_PWM    (1U << 3)
+#define LOG_MISC   (1U << 4)
+#define LOG_IRQ    (1U << 5)
+#define LOG_SPI1   (1U << 6)
+#define LOG_SPI2   (1U << 7)
+#define LOG_ADC    (1U << 8)
+#define LOG_DAC    (1U << 9)
+
+#define VERBOSE     (0)
+
+#include "logmacro.h"
+
+DEFINE_DEVICE_TYPE(GPCE4, generalplus_gpce4_soc_device, "gpce4", "GeneralPlus GPCE4 series SoC")
+
+generalplus_gpce4_soc_device::generalplus_gpce4_soc_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: unsp_20_device(mconfig, GPCE4, tag, owner, clock, address_map_constructor(FUNC(generalplus_gpce4_soc_device::internal_map), this))
+	, m_porta_in(*this, 0)
+	, m_portb_in(*this, 0)
+	, m_portc_in(*this, 0)
+	, m_porta_out(*this)
+	, m_portb_out(*this)
+	, m_portc_out(*this)
+	, m_spi2_out(*this)
+	, m_dac(*this, "dac")
+	, m_bank(*this, "spibank")
+{
+}
+
+void generalplus_gpce4_soc_device::device_start()
+{
+	unsp_20_device::device_start();
+
+	save_item(NAME(m_ioa_buffer));
+	save_item(NAME(m_iob_buffer));
+	save_item(NAME(m_interrupt_ctrl));
+	save_item(NAME(m_timer_ctrl));
+	save_item(NAME(m_io_ctrl));
+	save_item(NAME(m_ioa_attribute));
+	save_item(NAME(m_iob_attribute));
+	save_item(NAME(m_ioc_attribute));
+	save_item(NAME(m_ioa_direction));
+	save_item(NAME(m_iob_direction));
+	save_item(NAME(m_ioc_direction));
+	save_item(NAME(m_cache_ctrl));
+	save_item(NAME(m_spi_auto_ctrl));
+	save_item(NAME(m_spi_bank));
+	save_item(NAME(m_fiq_sel));
+	save_item(NAME(m_fiq2_sel));
+	save_item(NAME(m_spi2_ctrl));
+
+	set_vectorbase(0x4010);
+
+	m_bank->configure_entries(0, memregion("spi")->bytes() / 0x400000, memregion("spi")->base(), 0x400000);
+	m_bank->set_entry(0);
+}
+
+void generalplus_gpce4_soc_device::device_reset()
+{
+	unsp_20_device::device_reset();
+
+	m_ioa_buffer = 0;
+	m_iob_buffer = 0;
+	m_interrupt_ctrl = 0;
+	m_timer_ctrl = 0;
+	m_io_ctrl = 0;
+	m_ioa_attribute = 0;
+	m_iob_attribute = 0;
+	m_ioc_attribute = 0;
+	m_ioa_direction = 0;
+	m_iob_direction = 0;
+	m_ioc_direction = 0;
+	m_cache_ctrl = 0;
+	m_spi_auto_ctrl = 0;
+	m_spi_bank = 0;
+	m_fiq_sel = 0;
+	m_fiq2_sel = 0;
+	m_spi2_ctrl = 0;
+}
+
+void generalplus_gpce4_soc_device::device_add_mconfig(machine_config &config)
+{
+	TIMER(config, "timer_c").configure_periodic(FUNC(generalplus_gpce4_soc_device::timer_c_cb), attotime::from_hz(1000)); // game speed?
+	TIMER(config, "timer_a").configure_periodic(FUNC(generalplus_gpce4_soc_device::timer_a_cb), attotime::from_hz(20000)); // audio
+
+	SPEAKER(config, "speaker").front_center();
+	DAC_16BIT_R2R_TWOS_COMPLEMENT(config, "dac", 0).add_route(ALL_OUTPUTS, "speaker", 1.0); // unknown DAC
+}
+
+void generalplus_gpce4_soc_device::internal_map(address_map &map)
+{
+	map(0x000000, 0x000fff).ram(); // RAM
+	//map(0x001000, 0x0017ff).ram(); // Cache area, can be configured as RAM instead
+
+	map(0x003000, 0x003000).rw(FUNC(generalplus_gpce4_soc_device::ioa_data_r), FUNC(generalplus_gpce4_soc_device::ioa_data_w)); // IOA_Data
+	map(0x003001, 0x003001).rw(FUNC(generalplus_gpce4_soc_device::ioa_buffer_r), FUNC(generalplus_gpce4_soc_device::ioa_buffer_w)); // IOA_Buffer
+	map(0x003002, 0x003002).rw(FUNC(generalplus_gpce4_soc_device::ioa_direction_r), FUNC(generalplus_gpce4_soc_device::ioa_direction_w)); // IOA_Dir
+	map(0x003003, 0x003003).rw(FUNC(generalplus_gpce4_soc_device::ioa_attribute_r), FUNC(generalplus_gpce4_soc_device::ioa_attribute_w)); // IOA_Attrib
+
+	map(0x003004, 0x003004).rw(FUNC(generalplus_gpce4_soc_device::iob_data_r), FUNC(generalplus_gpce4_soc_device::iob_data_w)); // IOB_Data
+	map(0x003005, 0x003005).rw(FUNC(generalplus_gpce4_soc_device::iob_buffer_r), FUNC(generalplus_gpce4_soc_device::iob_buffer_w)); // IOB_Buffer
+	map(0x003006, 0x003006).rw(FUNC(generalplus_gpce4_soc_device::iob_direction_r), FUNC(generalplus_gpce4_soc_device::iob_direction_w)); // IOB_Dir
+	map(0x003007, 0x003007).rw(FUNC(generalplus_gpce4_soc_device::iob_attribute_r), FUNC(generalplus_gpce4_soc_device::iob_attribute_w)); // IOB_Attrib
+
+	map(0x003008, 0x003008).rw(FUNC(generalplus_gpce4_soc_device::ioc_data_r), FUNC(generalplus_gpce4_soc_device::ioc_data_w)); // IOC_Data
+	map(0x003009, 0x003009).rw(FUNC(generalplus_gpce4_soc_device::ioc_buffer_r), FUNC(generalplus_gpce4_soc_device::ioc_buffer_w)); // IOC_Buffer
+	map(0x00300a, 0x00300a).rw(FUNC(generalplus_gpce4_soc_device::ioc_direction_r), FUNC(generalplus_gpce4_soc_device::ioc_direction_w)); // IOC_Dir
+	map(0x00300b, 0x00300b).rw(FUNC(generalplus_gpce4_soc_device::ioc_attribute_r), FUNC(generalplus_gpce4_soc_device::ioc_attribute_w)); // IOC_Attrib
+
+	// 300c - IOA_WakeUp_Mask
+	// 300d - IOB_WakeUp_Mask
+	// 300e - IOC_WakeUp_Mask
+	map(0x00300f, 0x00300f).rw(FUNC(generalplus_gpce4_soc_device::io_ctrl_r), FUNC(generalplus_gpce4_soc_device::io_ctrl_w)); // IO_Ctrl
+
+	map(0x003010, 0x003010).w(FUNC(generalplus_gpce4_soc_device::timera_data_w)); // TimerA_Data
+	map(0x003011, 0x003011).w(FUNC(generalplus_gpce4_soc_device::timera_counter_w)); // TimerA_CNTR
+	map(0x003012, 0x003012).w(FUNC(generalplus_gpce4_soc_device::timerb_data_w)); // TimerB_Data
+	map(0x003013, 0x003013).w(FUNC(generalplus_gpce4_soc_device::timerb_counter_w)); // TimerB_CNTR
+	map(0x003014, 0x003014).w(FUNC(generalplus_gpce4_soc_device::timerc_data_w)); // TimerC_Data
+	map(0x003015, 0x003015).w(FUNC(generalplus_gpce4_soc_device::timerc_counter_w)); // TimerC_CNTR
+	map(0x003016, 0x003016).rw(FUNC(generalplus_gpce4_soc_device::timer_ctrl_r), FUNC(generalplus_gpce4_soc_device::timer_ctrl_w)); // Timer_Ctrl
+
+	map(0x003020, 0x003020).w(FUNC(generalplus_gpce4_soc_device::pwm0_ctrl_w)); // PWM0_Ctrl
+	map(0x003021, 0x003021).w(FUNC(generalplus_gpce4_soc_device::pwm1_ctrl_w)); // PWM1_Ctrl
+	map(0x003022, 0x003022).w(FUNC(generalplus_gpce4_soc_device::pwm2_ctrl_w)); // PWM2_Ctrl
+	map(0x003023, 0x003023).w(FUNC(generalplus_gpce4_soc_device::pwm3_ctrl_w)); // PWM3_Ctrl
+
+	map(0x003030, 0x003030).w(FUNC(generalplus_gpce4_soc_device::system_clock_w)); // System_Clock
+	// 3031 - System_Reset
+	// 3032 - Reset_LVD_Ctrl
+	map(0x003033, 0x003033).w(FUNC(generalplus_gpce4_soc_device::timebase_clear_w)); // Timebase_Clear
+	map(0x003034, 0x003034).w(FUNC(generalplus_gpce4_soc_device::watchdog_clear_w)); // Watchdog_Clear
+	map(0x003035, 0x003035).w(FUNC(generalplus_gpce4_soc_device::wait_ctrl_w)); // Wait_Ctrl
+	// 3036 - System_Sleep
+
+	map(0x003039, 0x003039).rw(FUNC(generalplus_gpce4_soc_device::cache_ctrl_r), FUNC(generalplus_gpce4_soc_device::cache_ctrl_w)); // Cache_Ctrl
+	// 303a - Cache_Hit_Rate
+	// 303b - Stack_INT_Level
+
+	map(0x003040, 0x003040).w(FUNC(generalplus_gpce4_soc_device::dac_ctrl_w)); // DAC_Ctrl
+	map(0x003041, 0x003041).w(FUNC(generalplus_gpce4_soc_device::dac_cha1_data_w)); // DAC_CH1_Data
+	map(0x003042, 0x003042).w(FUNC(generalplus_gpce4_soc_device::dac_cha2_data_w)); // DAC_CH2_Data
+	map(0x003043, 0x003043).w(FUNC(generalplus_gpce4_soc_device::ppam_ctrl_w)); // PPAMCtrl
+
+	map(0x003050, 0x003050).rw(FUNC(generalplus_gpce4_soc_device::interrupt_ctrl_r), FUNC(generalplus_gpce4_soc_device::interrupt_ctrl_w)); // INT_Ctrl
+	map(0x003051, 0x003051).w(FUNC(generalplus_gpce4_soc_device::interrupt_status_w)); // INT_Status
+	map(0x003052, 0x003052).rw(FUNC(generalplus_gpce4_soc_device::fiq_sel_r), FUNC(generalplus_gpce4_soc_device::fiq_sel_w)); // FIQ_SEL
+	map(0x003053, 0x003053).rw(FUNC(generalplus_gpce4_soc_device::interrupt2_ctrl_r), FUNC(generalplus_gpce4_soc_device::interrupt2_ctrl_w)); // INT2_Ctrl
+	map(0x003054, 0x003054).rw(FUNC(generalplus_gpce4_soc_device::interrupt2_status_r), FUNC(generalplus_gpce4_soc_device::interrupt2_status_w)); // INT2_Status
+	map(0x003055, 0x003055).rw(FUNC(generalplus_gpce4_soc_device::fiq2_sel_r), FUNC(generalplus_gpce4_soc_device::fiq2_sel_w)); // FIQ2_SEL
+
+	map(0x003070, 0x003070).rw(FUNC(generalplus_gpce4_soc_device::adc_ctrl_r), FUNC(generalplus_gpce4_soc_device::adc_ctrl_w)); // ADC_Ctrl
+	map(0x003071, 0x003071).rw(FUNC(generalplus_gpce4_soc_device::adc_data_r), FUNC(generalplus_gpce4_soc_device::adc_data_w)); // ADC_Data
+	map(0x003072, 0x003072).rw(FUNC(generalplus_gpce4_soc_device::adc_linein_bitctrl_r), FUNC(generalplus_gpce4_soc_device::adc_linein_bitctrl_w)); // ADC_LineIn_BitCtrl
+	// 3073 - ADC_PGA_Ctrl
+	// 3074 - ADC_FIFO_Ctrl
+
+	map(0x003090, 0x003090).rw(FUNC(generalplus_gpce4_soc_device::spi2_ctrl_r), FUNC(generalplus_gpce4_soc_device::spi2_ctrl_w)); // SPI2_Ctrl
+	map(0x003091, 0x003091).rw(FUNC(generalplus_gpce4_soc_device::spi2_txstatus_r), FUNC(generalplus_gpce4_soc_device::spi2_txstatus_w)); // SPI2_TXStatus
+	map(0x003092, 0x003092).w(FUNC(generalplus_gpce4_soc_device::spi2_txdata_w)); // SPI2_TXData
+	map(0x003093, 0x003093).rw(FUNC(generalplus_gpce4_soc_device::spi2_rxstatus_r), FUNC(generalplus_gpce4_soc_device::spi2_rxstatus_w)); // SPI2_RXStatus
+	map(0x003094, 0x003094).r(FUNC(generalplus_gpce4_soc_device::spi2_rxdata_r)); // SPI2_RXData 
+	map(0x003095, 0x003095).rw(FUNC(generalplus_gpce4_soc_device::spi2_misc_r), FUNC(generalplus_gpce4_soc_device::spi2_misc_w)); // SPI2_Misc
+
+	// 309a - SPI2_DMA_Start
+	// 309b - SPI2_DMA_BC
+	// 309c - SPI2_RX_DMA_ADDR
+	// 309d - SPI2_TX_DMA_ADDR
+	// 309e - SPI2_DMA_INT_Ctrl
+	// 309f - SPI2_RX_ICE
+
+	// 30b0 - BUF_ACTIVE
+	// 30b1 - LINK_BUF10
+	// 30b2 - LINK_BUF32
+	// 30b3 - LINK_BUF54
+
+	// 30d0 - CTS_Ctrl0
+	// 30d1 - CTS_Ctrl1
+	// 30d2 - CTS_TMADATA
+	// 30d3 - CTS_TMACNT
+	// 30d4 - CTS_TMBDATA
+	// 30d5 - CTS_TMBCNT
+	// 30d6 - CTS_CAPTMB
+	// 30d7 - CTS_MUTCTRL
+
+	map(0x0030e0, 0x0030e0).rw(FUNC(generalplus_gpce4_soc_device::spi_ctrl_r), FUNC(generalplus_gpce4_soc_device::spi_ctrl_w)); // SPI_Ctrl
+	map(0x0030e1, 0x0030e1).w(FUNC(generalplus_gpce4_soc_device::spi_txstatus_w)); // SPI_TXStatus
+	map(0x0030e2, 0x0030e2).w(FUNC(generalplus_gpce4_soc_device::spi_txdata_w)); // SPI_TXData
+	map(0x0030e3, 0x0030e3).w(FUNC(generalplus_gpce4_soc_device::spi_rxstatus_w)); // SPI_RXStatus
+	map(0x0030e4, 0x0030e4).r(FUNC(generalplus_gpce4_soc_device::spi_rxdata_r)); // SPI_RXData
+	map(0x0030e5, 0x0030e5).rw(FUNC(generalplus_gpce4_soc_device::spi_misc_r), FUNC(generalplus_gpce4_soc_device::spi_misc_w)); // SPI_Misc
+	// 30e6 - SPI_Man_Ctrl
+	map(0x0030e7, 0x0030e7).rw(FUNC(generalplus_gpce4_soc_device::spi_auto_ctrl_r), FUNC(generalplus_gpce4_soc_device::spi_auto_ctrl_w)); //  SPI_Auto_Ctrl
+	// 30e8 - SPI_PRGM_BC
+	map(0x0030e9, 0x0030e9).rw(FUNC(generalplus_gpce4_soc_device::spi_bank_r), FUNC(generalplus_gpce4_soc_device::spi_bank_w)); // SPI_BANK
+	// 30ea - SPI_DMA_Start
+	// 30eb - SPI_DMA_BC
+	// 30ec - SPI_RX_DMA_ADDR
+	// 30ed - SPI_TX_DMA_ADDR
+	// 30ee - SPI_DMA_INT_Ctrl
+	// 30ef - SPI_RX_ICE
+
+	map(0x004000, 0x00bfff).rom().region("internal", 0x0000); // 0x4000-0x400f are 'test' vectors, 0x4010 - 0x401f are user vectors, 0x4020 - 0x47ff is 'standard test program' 0x4800+ is custom internal ROM
+	map(0x00c000, 0x00ffff).rom().region("internal", 0x0000);
+
+	map(0x200000, 0x3fffff).bankr("spibank"); // has direct access to SPI ROM
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER( generalplus_gpce4_soc_device::timer_c_cb )
+{
+	request_interrupt(29);
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER( generalplus_gpce4_soc_device::timer_a_cb )
+{
+	request_interrupt(31);
+}
+
+// IOA
+
+u16 generalplus_gpce4_soc_device::ioa_data_r()
+{
+	LOGMASKED(LOG_IO, "%s: m_porta_in\n", machine().describe_context());
+	return m_porta_in();
+}
+
+void generalplus_gpce4_soc_device::ioa_data_w(u16 data)
+{
+	LOGMASKED(LOG_IO, "%s: ioa_data_w %04x\n", machine().describe_context(), data);
+	m_porta_out(data);
+}
+
+u16 generalplus_gpce4_soc_device::ioa_buffer_r()
+{
+	LOGMASKED(LOG_IO, "%s: ioa_buffer_r\n", machine().describe_context());
+	return m_porta_in();
+}
+
+void generalplus_gpce4_soc_device::ioa_buffer_w(u16 data)
+{
+	m_ioa_buffer = data;
+	LOGMASKED(LOG_IO, "%s: ioa_buffer_w %04x\n", machine().describe_context(), data);
+	m_porta_out(data);
+}
+
+u16 generalplus_gpce4_soc_device::ioa_direction_r()
+{
+	LOGMASKED(LOG_IO, "%s: ioa_direction_r\n", machine().describe_context());
+	return m_ioa_direction;
+}
+
+void generalplus_gpce4_soc_device::ioa_direction_w(u16 data)
+{
+	LOGMASKED(LOG_IO, "%s: ioa_direction_w %04x\n", machine().describe_context(), data);
+	m_ioa_direction = data;
+}
+
+u16 generalplus_gpce4_soc_device::ioa_attribute_r()
+{
+	LOGMASKED(LOG_IO, "%s: ioa_attribute_r\n", machine().describe_context());
+	return m_ioa_attribute;
+}
+
+void generalplus_gpce4_soc_device::ioa_attribute_w(u16 data)
+{
+	m_ioa_attribute = data;
+	LOGMASKED(LOG_IO, "%s: ioa_attribute_w %04x\n", machine().describe_context(), data);
+}
+
+// IOB
+
+u16 generalplus_gpce4_soc_device::iob_data_r()
+{
+	LOGMASKED(LOG_IO, "%s: iob_data_r\n", machine().describe_context());
+	return m_portb_in();
+}
+
+void generalplus_gpce4_soc_device::iob_data_w(u16 data)
+{
+	LOGMASKED(LOG_IO, "%s: iob_data_w %04x\n", machine().describe_context(), data);
+	m_portb_out(data);
+}
+
+u16 generalplus_gpce4_soc_device::iob_buffer_r()
+{
+	LOGMASKED(LOG_IO, "%s: iob_buffer_r\n", machine().describe_context());
+	return m_iob_buffer;
+}
+
+void generalplus_gpce4_soc_device::iob_buffer_w(u16 data)
+{
+	m_iob_buffer = data;
+	LOGMASKED(LOG_IO, "%s: iob_buffer_w %04x\n", machine().describe_context(), data);
+	m_portb_out(data);
+}
+
+u16 generalplus_gpce4_soc_device::iob_direction_r()
+{
+	LOGMASKED(LOG_IO, "%s: iob_direction_r\n", machine().describe_context());
+	return m_iob_direction;
+}
+
+void generalplus_gpce4_soc_device::iob_direction_w(u16 data)
+{
+	LOGMASKED(LOG_IO, "%s: iob_direction_w %04x\n", machine().describe_context(), data);
+	m_iob_direction = data;
+}
+
+void generalplus_gpce4_soc_device::iob_attribute_w(u16 data)
+{
+	LOGMASKED(LOG_IO, "%s: iob_attribute_w %04x\n", machine().describe_context(), data);
+	m_iob_attribute = data;
+}
+
+u16 generalplus_gpce4_soc_device::iob_attribute_r()
+{
+	LOGMASKED(LOG_IO, "%s: iob_attribute_r\n", machine().describe_context());
+	return m_iob_attribute;
+}
+
+// IOC
+
+u16 generalplus_gpce4_soc_device::ioc_data_r()
+{
+	LOGMASKED(LOG_IO, "%s: ioc_data_r\n", machine().describe_context());
+	return m_portc_in();
+}
+
+void generalplus_gpce4_soc_device::ioc_data_w(u16 data)
+{
+	LOGMASKED(LOG_IO, "%s: ioc_data_w %04x\n", machine().describe_context(), data);
+	m_portc_out(data);
+}
+
+u16 generalplus_gpce4_soc_device::ioc_buffer_r()
+{
+	LOGMASKED(LOG_IO, "%s: ioc_buffer_r\n", machine().describe_context());
+	return m_portc_in();
+}
+
+void generalplus_gpce4_soc_device::ioc_buffer_w(u16 data)
+{
+	LOGMASKED(LOG_IO, "%s: ioc_buffer_w %04x\n", machine().describe_context(), data);
+	m_portc_out(data);
+}
+
+u16 generalplus_gpce4_soc_device::ioc_direction_r()
+{
+	LOGMASKED(LOG_IO, "%s: ioc_direction_r\n", machine().describe_context());
+	return m_ioc_direction;
+}
+
+void generalplus_gpce4_soc_device::ioc_direction_w(u16 data)
+{
+	LOGMASKED(LOG_IO, "%s: ioc_direction_w %04x\n", machine().describe_context(), data);
+	m_ioc_direction = data;
+}
+
+void generalplus_gpce4_soc_device::ioc_attribute_w(u16 data)
+{
+	LOGMASKED(LOG_IO, "%s: ioc_attribute_w %04x\n", machine().describe_context(), data);
+	m_ioc_attribute = data;
+}
+
+u16 generalplus_gpce4_soc_device::ioc_attribute_r()
+{
+	LOGMASKED(LOG_IO, "%s: ioc_attribute_r\n", machine().describe_context());
+	return m_ioc_attribute;
+}
+
+
+u16 generalplus_gpce4_soc_device::io_ctrl_r()
+{
+	LOGMASKED(LOG_IO, "%s: io_ctrl_r\n", machine().describe_context());
+	return m_io_ctrl;
+}
+
+void generalplus_gpce4_soc_device::io_ctrl_w(u16 data)
+{
+	m_io_ctrl = data;
+	LOGMASKED(LOG_IO, "%s: io_ctrl_w %04x\n", machine().describe_context(), data);
+}
+
+// TIMERS
+
+u16 generalplus_gpce4_soc_device::timer_ctrl_r()
+{
+	LOGMASKED(LOG_TIMERS, "%s: timer_ctrl_r\n", machine().describe_context());
+	return m_timer_ctrl;
+}
+
+void generalplus_gpce4_soc_device::timer_ctrl_w(u16 data)
+{
+	m_timer_ctrl = data;
+	LOGMASKED(LOG_TIMERS, "%s: timer_ctrl_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::timera_data_w(u16 data)
+{
+	LOGMASKED(LOG_TIMERS, "%s: timera_data_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::timera_counter_w(u16 data)
+{
+	LOGMASKED(LOG_TIMERS, "%s: timera_counter_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::timerb_data_w(u16 data)
+{
+	LOGMASKED(LOG_TIMERS, "%s: timerb_data_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::timerb_counter_w(u16 data)
+{
+	LOGMASKED(LOG_TIMERS, "%s: timerb_counter_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::timerc_data_w(u16 data)
+{
+	LOGMASKED(LOG_TIMERS, "%s: timerc_data_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::timerc_counter_w(u16 data)
+{
+	LOGMASKED(LOG_TIMERS, "%s: timerc_counter_w %04x\n", machine().describe_context(), data);
+}
+
+// PWM
+
+void generalplus_gpce4_soc_device::pwm0_ctrl_w(u16 data)
+{
+	LOGMASKED(LOG_PWM, "%s: pwm0_ctrl_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::pwm1_ctrl_w(u16 data)
+{
+	LOGMASKED(LOG_PWM, "%s: pwm1_ctrl_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::pwm2_ctrl_w(u16 data)
+{
+	LOGMASKED(LOG_PWM, "%s: pwm2_ctrl_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::pwm3_ctrl_w(u16 data)
+{
+	LOGMASKED(LOG_PWM, "%s: pwm3_ctrl_w %04x\n", machine().describe_context(), data);
+}
+
+// MISC
+
+void generalplus_gpce4_soc_device::system_clock_w(u16 data)
+{
+	LOGMASKED(LOG_MISC, "%s: system_clock_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::timebase_clear_w(u16 data)
+{
+	LOGMASKED(LOG_MISC, "%s: timebase_clear_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::watchdog_clear_w(u16 data)
+{
+	// writes a lot of 0x5555 here in a block
+	// LOGMASKED(LOG_MISC, "%s: watchdog_clear_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::wait_ctrl_w(u16 data)
+{
+	LOGMASKED(LOG_MISC, "%s: wait_ctrl_w %04x\n", machine().describe_context(), data);
+}
+
+// P_Cache_Ctrl
+//
+// 15  ---
+// 14  ---
+// 13  ---
+// 12  ---
+//
+// 11  ---
+// 10  ---
+//  9  ---
+//  8  ---
+
+//  7  ---
+//  6  ---
+//  5  ---
+//  4  ---
+// 
+//  3  ---
+//  2  ---
+//  1  Cache_Clr
+//  0  Cache_En
+
+u16 generalplus_gpce4_soc_device::cache_ctrl_r()
+{
+	LOGMASKED(LOG_MISC, "%s: cache_ctrl_r\n", machine().describe_context());
+	return m_cache_ctrl & ~0x0002;
+}
+
+void generalplus_gpce4_soc_device::cache_ctrl_w(u16 data)
+{
+	LOGMASKED(LOG_MISC, "%s: cache_ctrl_w %04x\n", machine().describe_context(), data);
+	m_cache_ctrl = data;
+}
+
+// DAC
+
+void generalplus_gpce4_soc_device::dac_ctrl_w(u16 data)
+{
+	LOGMASKED(LOG_DAC, "%s: dac_ctrl_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::dac_cha1_data_w(u16 data)
+{
+	// LOGMASKED(LOG_DAC, "%s: dac_cha1_data_w %04x\n", machine().describe_context(), data);
+	// mapacman only writes 0000 / 7fff / 8000, but is known to have more limited sound than other units
+	m_dac->data_w(data);
+}
+
+void generalplus_gpce4_soc_device::dac_cha2_data_w(u16 data)
+{
+	LOGMASKED(LOG_DAC, "%s: dac_cha2_data_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::ppam_ctrl_w(u16 data)
+{
+	LOGMASKED(LOG_MISC, "%s: ppam_ctrl_w %04x\n", machine().describe_context(), data);
+}
+
+u16 generalplus_gpce4_soc_device::interrupt_ctrl_r()
+{
+	return m_interrupt_ctrl;
+}
+
+void generalplus_gpce4_soc_device::interrupt_ctrl_w(u16 data)
+{
+	//u16 old = m_interrupt_ctrl;
+	m_interrupt_ctrl = data;
+
+	// 15 IRQ0_TMA          -- enabled in mapacman
+	//    IRQ1_TMB
+	//    IRQ2_TMC          -- enabled in mapacman, digicolr
+	//    ---
+	//    IRQ3_ADC
+	//    0
+	//    IRQ3_SPIDMA
+	//  8 IRQ3_SPI2         -- enabled in mapacman
+	//  7 IRQ_SPI
+	//    IRQ3_SPI2DMA
+	//    IRQ4_USB
+	//    IRQ4_KEY
+	//    ---
+	//    0
+	//    IRQ5_EXT1
+	//  0 IRQ5_EXT2
+
+	LOGMASKED(LOG_IRQ, "%s: interrupt_ctrl_w %04x\n", machine().describe_context(), data);
+}
+
+u16 generalplus_gpce4_soc_device::interrupt2_status_r()
+{
+	LOGMASKED(LOG_IRQ, "%s: interrupt2_status_r\n", machine().describe_context());
+	return machine().rand();
+}
+
+void generalplus_gpce4_soc_device::interrupt2_status_w(u16 data)
+{
+	LOGMASKED(LOG_IRQ, "%s: interrupt2_status_w %04x\n", machine().describe_context(), data);
+}
+
+u16 generalplus_gpce4_soc_device::interrupt2_ctrl_r()
+{
+	return 0x0000;
+}
+
+void generalplus_gpce4_soc_device::interrupt2_ctrl_w(u16 data)
+{
+	// 15  ---
+	//     ---
+	//     ---
+	//     IRQ6_CTSTMA
+	//     IRQ6_CTSTMB
+	//     IRQ6_4KHz
+	//     IRQ6_2KHz     -- enabled in digicolr
+	//  8  IRQ6_512Hz
+	//  7  ---
+	//     ---
+	//     IRQ7_STACK
+	//     IRQ7_CPURX
+	//     ---
+	//     IRQ7_64Hz     -- enabled in mapacman, digicolr
+	//     IRQ7_16Hz
+	//  0  IRQ7_2Hz      -- enabled in digicolr
+
+	LOGMASKED(LOG_IRQ, "%s: interrupt2_ctrl_w %04x\n", machine().describe_context(), data);
+}
+
+// SPI1
+
+u16 generalplus_gpce4_soc_device::spi_ctrl_r()
+{
+	LOGMASKED(LOG_SPI1, "%s: spi_ctrl_r\n", machine().describe_context());
+	return machine().rand();
+}
+
+void generalplus_gpce4_soc_device::spi_ctrl_w(u16 data)
+{
+	LOGMASKED(LOG_SPI1, "%s: spi_ctrl_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::spi_misc_w(u16 data)
+{
+	LOGMASKED(LOG_SPI1, "%s: spi_misc_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::spi_txstatus_w(u16 data)
+{
+	LOGMASKED(LOG_SPI1, "%s: spi_txstatus_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::spi_txdata_w(u16 data)
+{
+	LOGMASKED(LOG_SPI1, "%s: spi_txdata_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::spi_rxstatus_w(u16 data)
+{
+	LOGMASKED(LOG_SPI1, "%s: spi_rxstatus_w %04x\n", machine().describe_context(), data);
+}
+
+u16 generalplus_gpce4_soc_device::spi_rxdata_r()
+{
+	LOGMASKED(LOG_SPI1, "%s: spi_rxdata_r\n", machine().describe_context());
+	return machine().rand() & 0x01;
+}
+
+u16 generalplus_gpce4_soc_device::spi_misc_r()
+{
+	LOGMASKED(LOG_SPI1, "%s: spi_misc_r\n", machine().describe_context());
+	return 0x0000;
+}
+
+u16 generalplus_gpce4_soc_device::spi_auto_ctrl_r()
+{
+	LOGMASKED(LOG_SPI1, "%s: spi_auto_ctrl_r\n", machine().describe_context());
+	return m_spi_auto_ctrl;
+}
+
+void generalplus_gpce4_soc_device::spi_auto_ctrl_w(u16 data)
+{
+	LOGMASKED(LOG_SPI1, "%s: spi_auto_ctrl_w %04x\n", machine().describe_context(), data);
+	m_spi_auto_ctrl = data;
+}
+
+u16 generalplus_gpce4_soc_device::spi_bank_r()
+{
+	LOGMASKED(LOG_SPI1, "%s: spi_bank_r\n", machine().describe_context());
+	return m_spi_bank;
+}
+
+void generalplus_gpce4_soc_device::spi_bank_w(u16 data)
+{
+	LOGMASKED(LOG_SPI1, "%s: spi_bank_w %04x\n", machine().describe_context(), data);
+	m_spi_bank = data;
+	m_bank->set_entry(data & 0xf);
+}
+
+void generalplus_gpce4_soc_device::update_interrupts()
+{
+	if ((m_interrupt_status & 0x8000'0000) && (m_interrupt_ctrl & 0x8000))
+	{
+		set_input_line(UNSP_IRQ0_LINE, ASSERT_LINE);
+	}
+	else
+	{
+		set_input_line(UNSP_IRQ0_LINE, CLEAR_LINE);
+	}
+
+	if ((m_interrupt_status & 0x2000'0000) && (m_interrupt_ctrl & 0x2000))
+	{
+		set_input_line(UNSP_IRQ2_LINE, ASSERT_LINE);
+	}
+	else
+	{
+		set_input_line(UNSP_IRQ2_LINE, CLEAR_LINE);
+	}
+
+	if ((m_interrupt_status & 0x0100'0000) && (m_interrupt_ctrl & 0x0100))
+	{
+		set_input_line(UNSP_IRQ3_LINE, ASSERT_LINE);
+	}
+	else
+	{
+		set_input_line(UNSP_IRQ3_LINE, CLEAR_LINE);
+	}
+}
+
+void generalplus_gpce4_soc_device::request_interrupt(int which)
+{
+	int bit = 1 << which;
+	m_interrupt_status = (m_interrupt_status & ~bit) | bit;
+	update_interrupts();
+}
+
+void generalplus_gpce4_soc_device::clear_interrupt(int which)
+{
+	int bit = 1 << which;
+	m_interrupt_status = (m_interrupt_status & ~bit);
+	update_interrupts();
+}
+
+void generalplus_gpce4_soc_device::interrupt_status_w(u16 data)
+{
+	if (data & 0x8000)
+		clear_interrupt(31);
+
+	if (data & 0x2000)
+		clear_interrupt(29);
+
+	if (data & 0x0100)
+		clear_interrupt(24);
+}
+
+u16 generalplus_gpce4_soc_device::fiq_sel_r()
+{
+	return m_fiq_sel;
+}
+
+void generalplus_gpce4_soc_device::fiq_sel_w(u16 data)
+{
+	// each bit refers to an interrupt source that can be redirected to FIQ instead
+	LOGMASKED(LOG_IRQ, "%s: fiq_sel_w %04x\n", machine().describe_context(), data);
+	m_fiq_sel = data;
+}
+
+u16 generalplus_gpce4_soc_device::fiq2_sel_r()
+{
+	return m_fiq2_sel;
+}
+
+void generalplus_gpce4_soc_device::fiq2_sel_w(u16 data)
+{
+	// each bit refers to an interrupt source that can be redirected to FIQ instead
+	LOGMASKED(LOG_IRQ, "%s: fiq2_sel_w %04x\n", machine().describe_context(), data);
+	m_fiq2_sel = data;
+}
+
+// P_SPI2_Ctrl
+//
+// 15  SPIEN
+// 14  ---
+// 13  LBM
+// 12  SPICS_IO
+//
+// 11  SPIRST
+// 10  ---
+//  9  ---
+//  8  MOD
+// 
+//  7  ---
+//  6  ---
+//  5  SCKPHA
+//  4  SCKPOL
+// 
+//  3  ---
+//  2  SCKSEL[2]
+//  1  SCKSEL[1]
+//  0  SCKSEL[0]
+
+u16 generalplus_gpce4_soc_device::spi2_ctrl_r()
+{
+	return m_spi2_ctrl;
+}
+
+void generalplus_gpce4_soc_device::spi2_ctrl_w(u16 data)
+{
+	LOGMASKED(LOG_SPI2, "%s: spi2_ctrl_w %04x\n", machine().describe_context(), data);
+	m_spi2_ctrl = data;
+}
+
+
+u16 generalplus_gpce4_soc_device::spi2_rxstatus_r()
+{
+	LOGMASKED(LOG_SPI2, "%s: spi2_rxstatus_r\n", machine().describe_context());
+	return 0x0000;
+}
+
+void generalplus_gpce4_soc_device::spi2_rxstatus_w(u16 data)
+{
+	LOGMASKED(LOG_SPI2, "%s: spi2_rxstatus_w %04x\n", machine().describe_context(), data);
+}
+
+// SPI2_TXSTATUS
+//
+// 15  SPITXIF
+// 14  SPITXIEN
+// 13  --
+// 12  --
+//
+// 11  --
+// 10  --
+//  9  --
+//  8  --
+// 
+//  7  TXFLEV[3]
+//  6  TXFLEV[2]
+//  5  TXFLEV[1]
+//  4  TXFLEX[0]
+// 
+//  3  TXFFLAG[3]
+//  2  TXFFLAG[2]
+//  1  TXFFLAG[1]
+//  0  TXFFLAG[0]
+
+u16 generalplus_gpce4_soc_device::spi2_txstatus_r()
+{
+	LOGMASKED(LOG_SPI2, "%s: spi2_txstatus_r\n", machine().describe_context());
+	return 0x0000;
+}
+
+void generalplus_gpce4_soc_device::spi2_txstatus_w(u16 data)
+{
+	LOGMASKED(LOG_SPI2, "%s: spi2_txstatus_w %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpce4_soc_device::spi2_txdata_w(u16 data)
+{
+	// only 8-bits are written to FIFO
+	// the SoC turns this into actual SPI signals
+	m_spi2_out(data & 0xff);
+}
+
+u16 generalplus_gpce4_soc_device::spi2_rxdata_r()
+{
+	LOGMASKED(LOG_SPI2, "%s: spi2_rxdata_r\n", machine().describe_context());
+	return 0x0000;
+}
+
+// P_SPI2_MISC
+// 
+// 15  ---
+// 14  ---
+// 13  ---
+// 12  ---
+// 
+// 11  ---
+// 10  ---
+//  9  OVER
+//  8  SMART
+// 
+//  7  ---
+//  6  ---
+//  5  ---
+//  4  BSY
+// 
+//  3  RFF
+//  2  RNE
+//  1  TNF
+//  0  TFE
+
+u16 generalplus_gpce4_soc_device::spi2_misc_r()
+{
+	// loops on bit 0x0010 (BSY) after writing data to 0x3092
+
+	// clrb [3005],12 is used before writing non-pixel data to 0x3092
+	// setb [3005],12 is used after reading from 0x3094
+	//LOGMASKED(LOG_SPI2, "%s: spi2_misc_r\n", machine().describe_context());
+	return 0x0000;
+}
+
+void generalplus_gpce4_soc_device::spi2_misc_w(u16 data)
+{
+	LOGMASKED(LOG_SPI2, "%s: spi2_misc_w %04x\n", machine().describe_context(), data);
+}
+
+// ADC
+
+u16 generalplus_gpce4_soc_device::adc_linein_bitctrl_r()
+{
+	LOGMASKED(LOG_ADC, "%s: adc_linein_bitctrl_r\n", machine().describe_context());
+	return 0x0000;
+}
+
+void generalplus_gpce4_soc_device::adc_linein_bitctrl_w(u16 data)
+{
+	LOGMASKED(LOG_ADC, "%s: adc_linein_bitctrl_w %04x\n", machine().describe_context(), data);
+}
+
+u16 generalplus_gpce4_soc_device::adc_ctrl_r()
+{
+	LOGMASKED(LOG_ADC, "%s: adc_ctrl_r\n", machine().describe_context());
+	return 0x0000;
+}
+
+void generalplus_gpce4_soc_device::adc_ctrl_w(u16 data)
+{
+	LOGMASKED(LOG_ADC, "%s: adc_ctrl_w %04x\n", machine().describe_context(), data);
+}
+
+u16 generalplus_gpce4_soc_device::adc_data_r()
+{
+	LOGMASKED(LOG_ADC, "%s: adc_data_r\n", machine().describe_context());
+	return 0x0000;
+}
+
+void generalplus_gpce4_soc_device::adc_data_w(u16 data)
+{
+	LOGMASKED(LOG_ADC, "%s: adc_data_w %04x\n", machine().describe_context(), data);
+}
+

--- a/src/devices/machine/generalplus_gpce4_soc.h
+++ b/src/devices/machine/generalplus_gpce4_soc.h
@@ -1,0 +1,183 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+#ifndef MAME_MACHINE_GENERALPLUS_GPCE4_SOC_H
+#define MAME_MACHINE_GENERALPLUS_GPCE4_SOC_H
+
+#pragma once
+
+#include "cpu/unsp/unsp.h"
+#include "machine/timer.h"
+#include "sound/dac.h"
+
+#include "speaker.h"
+
+class generalplus_gpce4_soc_device : public unsp_20_device
+{
+public:
+	generalplus_gpce4_soc_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	auto porta_in() { return m_porta_in.bind(); }
+	auto portb_in() { return m_portb_in.bind(); }
+	auto portc_in() { return m_portc_in.bind(); }
+
+	auto porta_out() { return m_porta_out.bind(); }
+	auto portb_out() { return m_portb_out.bind(); }
+	auto portc_out() { return m_portc_out.bind(); }
+
+	auto spi2_out() { return m_spi2_out.bind(); }
+
+	void request_interrupt(int which);
+	void clear_interrupt(int which);
+
+protected:
+	// device-level overrides
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+	virtual void device_add_mconfig(machine_config& config) override ATTR_COLD;
+
+private:
+	void internal_map(address_map &map);
+
+	u16 ioa_data_r();
+	void ioa_data_w(u16 data);
+	u16 ioa_buffer_r();
+	void ioa_buffer_w(u16 data);
+	u16 ioa_direction_r();
+	void ioa_direction_w(u16 data);
+	u16 ioa_attribute_r();
+	void ioa_attribute_w(u16 data);
+
+	u16 iob_data_r();
+	void iob_data_w(u16 data);
+	u16 iob_buffer_r();
+	void iob_buffer_w(u16 data);
+	u16 iob_direction_r();
+	void iob_direction_w(u16 data);
+	u16 iob_attribute_r();
+	void iob_attribute_w(u16 data);
+
+	u16 ioc_data_r();
+	void ioc_data_w(u16 data);
+	u16 ioc_buffer_r();
+	void ioc_buffer_w(u16 data);
+	u16 ioc_direction_r();
+	void ioc_direction_w(u16 data);
+	u16 ioc_attribute_r();
+	void ioc_attribute_w(u16 data);
+
+	u16 io_ctrl_r();
+	void io_ctrl_w(u16 data);
+
+	u16 timer_ctrl_r();
+	void timer_ctrl_w(u16 data);
+
+	void timera_data_w(u16 data);
+	void timera_counter_w(u16 data);
+	void timerb_data_w(u16 data);
+	void timerb_counter_w(u16 data);
+	void timerc_data_w(u16 data);
+	void timerc_counter_w(u16 data);
+
+	void pwm0_ctrl_w(u16 data);
+	void pwm1_ctrl_w(u16 data);
+	void pwm2_ctrl_w(u16 data);
+	void pwm3_ctrl_w(u16 data);
+	
+	void system_clock_w(u16 data);
+
+	void timebase_clear_w(u16 data);
+	void watchdog_clear_w(u16 data);
+	void dac_ctrl_w(u16 data);
+	void dac_cha1_data_w(u16 data);
+	void dac_cha2_data_w(u16 data);
+	void ppam_ctrl_w(u16 data);
+
+	void wait_ctrl_w(u16 data);
+	u16 cache_ctrl_r();
+	void cache_ctrl_w(u16 data);
+
+	u16 interrupt_ctrl_r();
+	void interrupt_ctrl_w(u16 data);
+	void interrupt_status_w(u16 data);
+	u16 fiq_sel_r();
+	void fiq_sel_w(u16 data);
+	u16 fiq2_sel_r();
+	void fiq2_sel_w(u16 data);
+	u16 interrupt2_ctrl_r();
+	void interrupt2_ctrl_w(u16 data);
+	u16 interrupt2_status_r();
+	void interrupt2_status_w(u16 data);
+
+	u16 spi2_ctrl_r();
+	void spi2_ctrl_w(u16 data);
+	u16 spi2_txstatus_r();
+	void spi2_txstatus_w(u16 data);
+	void spi2_txdata_w(u16 data);
+	u16 spi2_rxstatus_r();
+	void spi2_rxstatus_w(u16 data);
+	u16 spi2_rxdata_r();
+	u16 spi2_misc_r();
+	void spi2_misc_w(u16 data);
+
+	u16 spi_ctrl_r();
+	void spi_ctrl_w(u16 data);
+	void spi_txstatus_w(u16 data);
+	void spi_txdata_w(u16 data);
+	void spi_rxstatus_w(u16 data);
+	u16 spi_rxdata_r();
+	u16 spi_misc_r();
+	void spi_misc_w(u16 data);
+	u16 spi_auto_ctrl_r();
+	void spi_auto_ctrl_w(u16 data);
+	u16 spi_bank_r();
+	void spi_bank_w(u16 data);
+
+	u16 adc_data_r();
+	void adc_data_w(u16 data);
+	u16 adc_ctrl_r();
+	void adc_ctrl_w(u16 data);
+	u16 adc_linein_bitctrl_r();
+	void adc_linein_bitctrl_w(u16 data);
+
+	void update_interrupts();
+
+	TIMER_DEVICE_CALLBACK_MEMBER(timer_c_cb);
+	TIMER_DEVICE_CALLBACK_MEMBER(timer_a_cb);
+
+	u16 m_ioa_buffer;
+	u16 m_iob_buffer;
+	u16 m_interrupt_ctrl;
+	u16 m_timer_ctrl;
+	u16 m_io_ctrl;
+	u16 m_ioa_attribute;
+	u16 m_iob_attribute;
+	u16 m_ioc_attribute;
+	u16 m_ioa_direction;
+	u16 m_iob_direction;
+	u16 m_ioc_direction;
+	u16 m_cache_ctrl;
+	u16 m_spi_auto_ctrl;
+	u16 m_spi_bank;
+	u16 m_fiq_sel;
+	u16 m_fiq2_sel;
+	u16 m_spi2_ctrl;
+
+	u32 m_interrupt_status;
+
+	devcb_read16 m_porta_in;
+	devcb_read16 m_portb_in;
+	devcb_read16 m_portc_in;
+
+	devcb_write16 m_porta_out;
+	devcb_write16 m_portb_out;
+	devcb_write16 m_portc_out;
+
+	devcb_write8 m_spi2_out;
+
+	required_device<dac_word_device_base> m_dac;
+	required_memory_bank m_bank;
+};
+
+DECLARE_DEVICE_TYPE(GPCE4, generalplus_gpce4_soc_device)
+
+#endif // MAME_MACHINE_GENERALPLUS_GPCE4_SOC_H

--- a/src/devices/machine/generalplus_gpce4_soc.h
+++ b/src/devices/machine/generalplus_gpce4_soc.h
@@ -98,6 +98,7 @@ private:
 
 	u16 interrupt_ctrl_r();
 	void interrupt_ctrl_w(u16 data);
+	u16 interrupt_status_r();
 	void interrupt_status_w(u16 data);
 	u16 fiq_sel_r();
 	void fiq_sel_w(u16 data);
@@ -143,10 +144,13 @@ private:
 
 	TIMER_DEVICE_CALLBACK_MEMBER(timer_c_cb);
 	TIMER_DEVICE_CALLBACK_MEMBER(timer_a_cb);
+	TIMER_DEVICE_CALLBACK_MEMBER(timer_2hz_cb);
+	TIMER_DEVICE_CALLBACK_MEMBER(timer_64hz_cb);
 
 	u16 m_ioa_buffer;
 	u16 m_iob_buffer;
 	u16 m_interrupt_ctrl;
+	u16 m_interrupt2_ctrl;
 	u16 m_timer_ctrl;
 	u16 m_io_ctrl;
 	u16 m_ioa_attribute;

--- a/src/mame/handheld/bl_handhelds_lcdc.cpp
+++ b/src/mame/handheld/bl_handhelds_lcdc.cpp
@@ -1,6 +1,8 @@
 // license:BSD-3-Clause
 // copyright-holders:David Haywood
 
+// seems to be a ST7735SV
+
 #include "emu.h"
 #include "bl_handhelds_lcdc.h"
 

--- a/src/mame/handheld/generalplus_gpce4.cpp
+++ b/src/mame/handheld/generalplus_gpce4.cpp
@@ -28,7 +28,7 @@
 
 #include "emu.h"
 
-#include "cpu/unsp/unsp.h"
+#include "machine/generalplus_gpce4_soc.h"
 #include "machine/timer.h"
 #include "sound/dac.h"
 
@@ -41,96 +41,69 @@
 
 namespace {
 
-class generalplus_gpl_unknown_state : public driver_device
+class generalplus_gpce4_state : public driver_device
 {
 public:
-	generalplus_gpl_unknown_state(const machine_config &mconfig, device_type type, const char *tag) :
+	generalplus_gpce4_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
-		//m_mainrom(*this, "maincpu"),
-		//m_mainram(*this, "mainram"),
 		m_palette(*this, "palette"),
-		m_screen(*this, "screen"),
-		m_dac(*this, "dac"),
-		m_spirom(*this, "spi"),
-		m_testio(*this, "TEST")
+		m_screen(*this, "screen")
 	{ }
 
-	void generalplus_gpl_unknown(machine_config &config);
+	void generalplus_gpce4(machine_config &config);
 
 	void init_siddr();
 
-private:
+protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
-	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	virtual u32 screen_update(screen_device& screen, bitmap_ind16& bitmap, const rectangle& cliprect) = 0;
+	virtual void spi_from_soc(u8 data) = 0;
 
-	required_device<unsp_12_device> m_maincpu;
-	//required_region_ptr<uint16_t> m_mainrom;
-	//required_shared_ptr<uint16_t> m_mainram;
+	void portb_from_soc(u16 data);
+	void process_lcdc_command_params(u8 data);
+
+	u16 m_display[0x8000];
+	u16 m_displayposx;
+	u8 m_displayposy;
+
+	u8 m_lcdc_command;
+	u16 m_iob;
+	u8 m_spilatch;
+
+	TIMER_DEVICE_CALLBACK_MEMBER(timer);
+
+	required_device<generalplus_gpce4_soc_device> m_maincpu;
 
 	required_device<palette_device> m_palette;
 	required_device<screen_device> m_screen;
-	required_device<dac_word_device_base> m_dac;
-
-	required_region_ptr<uint16_t> m_spirom;
-	required_ioport m_testio;
-
-	uint16_t reg3001_r(offs_t offset);
-	void reg3001_w(offs_t offset, uint16_t data);
-	uint16_t reg3002_r(offs_t offset);
-	void reg3002_w(offs_t offset, uint16_t data);
-	uint16_t reg3003_r(offs_t offset);
-	void reg3003_w(offs_t offset, uint16_t data);
-	uint16_t reg3004_r(offs_t offset);
-	uint16_t reg3005_r(offs_t offset);
-	void reg3005_w(offs_t offset, uint16_t data);
-	uint16_t reg3006_r(offs_t offset);
-	uint16_t reg3007_r(offs_t offset);
-
-	uint16_t reg300f_r(offs_t offset);
-
-	uint16_t reg3016_r(offs_t offset);
-
-	void reg3034_w(offs_t offset, uint16_t data);
-	void reg3041_audiodac_w(offs_t offset, uint16_t data);
-
-	uint16_t reg3050_r(offs_t offset);
-	void reg3050_w(offs_t offset, uint16_t data);
-	void reg3051_w(offs_t offset, uint16_t data);
-	uint16_t reg3052_r(offs_t offset);
-	uint16_t reg3053_r(offs_t offset);
-
-	uint16_t reg3090_r(offs_t offset);
-	uint16_t reg3091_r(offs_t offset);
-	void reg3092_lcd_w(offs_t offset, uint16_t data);
-	uint16_t reg3094_r(offs_t offset);
-	uint16_t reg3095_r(offs_t offset);
-
-	void reg30e0_w(offs_t offset, uint16_t data);
-	void reg30e1_w(offs_t offset, uint16_t data);
-	void reg30e2_w(offs_t offset, uint16_t data);
-	void reg30e3_w(offs_t offset, uint16_t data);
-	uint16_t reg30e4_r(offs_t offset);
-	uint16_t reg30e5_r(offs_t offset);
-
-	TIMER_DEVICE_CALLBACK_MEMBER(timer);
-	TIMER_DEVICE_CALLBACK_MEMBER(timer2);
-	TIMER_DEVICE_CALLBACK_MEMBER(timer3);
-
-	uint16_t m_display[128*2 * 128];
-	int m_displayposx;
-	int m_displayposy;
-	uint16_t m_3001;
-	uint16_t m_3003;
-	uint16_t m_3005;
-	uint16_t m_3050;
-
-	void map(address_map &map) ATTR_COLD;
 };
 
-uint32_t generalplus_gpl_unknown_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+class generalplus_gpce4_mapacman_state : public generalplus_gpce4_state
+{
+public:
+	generalplus_gpce4_mapacman_state(const machine_config &mconfig, device_type type, const char *tag) :
+		generalplus_gpce4_state(mconfig, type, tag)
+	{ }
+
+	virtual u32 screen_update(screen_device& screen, bitmap_ind16& bitmap, const rectangle& cliprect) override;
+	virtual void spi_from_soc(u8 data) override;
+};
+
+class generalplus_gpce4_digicolr_state : public generalplus_gpce4_state
+{
+public:
+	generalplus_gpce4_digicolr_state(const machine_config &mconfig, device_type type, const char *tag) :
+		generalplus_gpce4_state(mconfig, type, tag)
+	{ }
+
+	virtual u32 screen_update(screen_device& screen, bitmap_ind16& bitmap, const rectangle& cliprect) override;
+	virtual void spi_from_soc(u8 data) override;
+};
+
+u32 generalplus_gpce4_mapacman_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	int count = 0;
 	for (int y = 0; y < 128; y++)
@@ -139,10 +112,10 @@ uint32_t generalplus_gpl_unknown_state::screen_update(screen_device &screen, bit
 
 		for (int x = 0; x < 128; x++)
 		{
-			uint8_t pix1 = m_display[count++];
-			uint8_t pix2 = m_display[count++];
+			u8 pix1 = m_display[count++];
+			u8 pix2 = m_display[count++];
 
-			uint16_t pal = ((pix1<<8) | pix2);
+			u16 pal = ((pix1<<8) | pix2);
 
 			dst[x] = pal;
 		}
@@ -150,8 +123,27 @@ uint32_t generalplus_gpl_unknown_state::screen_update(screen_device &screen, bit
 	return 0;
 }
 
+u32 generalplus_gpce4_digicolr_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+{
+	int count = 0;
+	for (int y = 0; y < 96; y++)
+	{
+		u16* dst = &bitmap.pix(y);
 
-static INPUT_PORTS_START( generalplus_gpl_unknown )
+		for (int x = 0; x < 24; x++)
+		{
+			u8 pix1 = m_display[count++];
+			u8 pix2 = m_display[count++];
+
+			u16 pal = ((pix1<<8) | pix2);
+
+			dst[x] = pal;
+		}
+	}
+	return 0;
+}
+
+static INPUT_PORTS_START( generalplus_gpce4 )
 	PORT_START("TEST")
 	PORT_DIPNAME( 0x0001, 0x0000, DEF_STR( Unknown ) )
 	PORT_DIPSETTING(      0x0001, DEF_STR( Off ) )
@@ -193,400 +185,7 @@ static INPUT_PORTS_START( generalplus_gpl_unknown )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 INPUT_PORTS_END
 
-uint16_t generalplus_gpl_unknown_state::reg3001_r(offs_t offset)
-{
-	return m_3001;
-}
-
-void generalplus_gpl_unknown_state::reg3001_w(offs_t offset, uint16_t data)
-{
-	m_3001 = data;
-	logerror("%s: reg3001_w %04x\n", machine().describe_context(), data);
-}
-
-uint16_t generalplus_gpl_unknown_state::reg3002_r(offs_t offset)
-{
-	return 0x0000;//machine().rand();
-}
-
-void generalplus_gpl_unknown_state::reg3002_w(offs_t offset, uint16_t data)
-{
-	//logerror("%s: reg3002_w %04x\n", machine().describe_context(), data);
-}
-
-uint16_t generalplus_gpl_unknown_state::reg3003_r(offs_t offset)
-{
-	return m_3003;
-}
-
-void generalplus_gpl_unknown_state::reg3003_w(offs_t offset, uint16_t data)
-{
-	m_3003 = data;
-	logerror("%s: reg3003_w %04x\n", machine().describe_context(), data);
-}
-
-uint16_t generalplus_gpl_unknown_state::reg3004_r(offs_t offset)
-{
-	return m_testio->read();
-}
-
-uint16_t generalplus_gpl_unknown_state::reg3005_r(offs_t offset)
-{
-	return m_3005;
-}
-
-void generalplus_gpl_unknown_state::reg3005_w(offs_t offset, uint16_t data)
-{
-	m_3005 = data;
-	//logerror("%s: reg3005_w %04x\n", machine().describe_context(), data);
-}
-
-
-uint16_t generalplus_gpl_unknown_state::reg3006_r(offs_t offset)
-{
-	return 0x0000;//machine().rand();
-}
-
-uint16_t generalplus_gpl_unknown_state::reg3007_r(offs_t offset)
-{
-	return 0x0000;//machine().rand();
-}
-
-uint16_t generalplus_gpl_unknown_state::reg300f_r(offs_t offset)
-{
-	return 0x0000;//machine().rand();
-}
-
-uint16_t generalplus_gpl_unknown_state::reg3016_r(offs_t offset)
-{
-	return 0x0000;//machine().rand();
-}
-
-
-
-void generalplus_gpl_unknown_state::reg3034_w(offs_t offset, uint16_t data)
-{
-	// writes a lot of 0x5555 here in a block
-	logerror("%s: reg3034_w %04x\n", machine().describe_context(), data);
-}
-
-void generalplus_gpl_unknown_state::reg3041_audiodac_w(offs_t offset, uint16_t data)
-{
-//  logerror("%s: reg3041_audiodac_w %04x\n", machine().describe_context(), data);
-
-	// mapacman only writes 0000 / 7fff / 8000, but is known to have more limited sound than other units
-
-	m_dac->data_w(data);
-}
-
-uint16_t generalplus_gpl_unknown_state::reg3050_r(offs_t offset)
-{
-	return m_3050;
-}
-
-void generalplus_gpl_unknown_state::reg3050_w(offs_t offset, uint16_t data)
-{
-	uint16_t old = m_3050;
-	m_3050 = data;
-
-	// probably not, but does happen at the end of a line
-	if ((old & 0x0100) != (m_3050 & 0x0100))
-	{
-		if ((m_3050 & 0x0100) == 0x0000)
-		{
-			m_displayposx = 0;
-			m_displayposy++;
-			if (m_displayposy == 128)
-			{
-				m_displayposy = 0;
-			}
-		}
-	}
-
-	//m_displaypos = 0;
-	logerror("%s: reg3050_w %04x\n", machine().describe_context(), data);
-}
-
-uint16_t generalplus_gpl_unknown_state::reg3052_r(offs_t offset)
-{
-	return 0x0000;//machine().rand();
-}
-
-uint16_t generalplus_gpl_unknown_state::reg3053_r(offs_t offset)
-{
-	return 0x0000;//machine().rand();
-}
-
-void generalplus_gpl_unknown_state::reg30e0_w(offs_t offset, uint16_t data)
-{
-	//logerror("%s: reg30e0_w %04x\n", machine().describe_context(), data);
-}
-
-void generalplus_gpl_unknown_state::reg30e1_w(offs_t offset, uint16_t data)
-{
-	//logerror("%s: reg30e1_w %04x\n", machine().describe_context(), data);
-}
-
-void generalplus_gpl_unknown_state::reg30e2_w(offs_t offset, uint16_t data)
-{
-	/* this appears to be querying the SPI Flash, eg.
-	   command 0xab = Read Electonic Signature
-	   command 0x9f = Read ID of the SPI Flash
-
-	[:] ':maincpu' (0075DD): reg3001_w 1c00
-	[:] ':maincpu' (00769B): reg3001_w 0c00
-	[:] ':maincpu' (00769F): reg30e2_w 00ab (WITHOUT m_3001 & 0x1000)
-	[:] ':maincpu' (0076A5): reg3001_w 1c00
-	[:] ':maincpu' (0076A7): reg30e4_r
-	[:] ':maincpu' (0076AF): reg3001_w 0c00
-	[:] ':maincpu' (0076B3): reg30e2_w 009f (WITHOUT m_3001 & 0x1000)
-	[:] ':maincpu' (0076B6): reg30e2_w 0000 (WITHOUT m_3001 & 0x1000)
-	[:] ':maincpu' (0076B8): reg30e2_w 0000 (WITHOUT m_3001 & 0x1000)
-	[:] ':maincpu' (0076BA): reg30e2_w 0000 (WITHOUT m_3001 & 0x1000)
-	[:] ':maincpu' (0076C0): reg30e4_r
-	[:] ':maincpu' (0076C2): reg30e4_r
-	[:] ':maincpu' (0076C4): reg30e4_r
-	[:] ':maincpu' (0076C6): reg30e4_r
-	*/
-	if (!(m_3001 & 0x1000))
-	{
-		logerror("%s: reg30e2_w %04x (WITHOUT m_3001 & 0x1000)\n", machine().describe_context(), data);
-	}
-	else
-	{
-		logerror("%s: reg30e2_w %04x (WITH m_3001 & 0x1000)\n", machine().describe_context(), data);
-	}
-}
-
-void generalplus_gpl_unknown_state::reg30e3_w(offs_t offset, uint16_t data)
-{
-	//logerror("%s: reg30e3_w %04x\n", machine().describe_context(), data);
-}
-
-uint16_t generalplus_gpl_unknown_state::reg30e4_r(offs_t offset)
-{
-	logerror("%s: reg30e4_r\n", machine().describe_context());
-	return machine().rand() & 0x01;
-}
-
-uint16_t generalplus_gpl_unknown_state::reg30e5_r(offs_t offset)
-{
-	// status flag: loops on bit 0x0010 after writes to 0x30e2
-	// and before reading from 0x30e4
-
-	// clrb [3001],12 is also usually executed before write operations
-	// to 0x30e2 and setb [3001],12 befoe the result is read back
-
-	return 0x0000;
-}
-
-/*
-mapacman vectors
-
-004015: 4844        - just reti
-        4845 fiq    - has code, acks by writing 8000 to 3051, very similar to irq0?)
-        4809 boot vector
-        4854 irq 0  - has code, acks by writing 8000 to 3051
-        4863 irq 1  - just acks by writing 4000 to 3051, no payload
-        486A irq 2 (used - needed to pass check on value in RAM changing in boot) acks with 2000 to 3051
-        487D irq 3 (used - needed to pass check on value in RAM changing shortly after) acks with 0100 to 3051?
-        4886 irq 4 - just acks by writing 10 to 3051, no payload
-        488C irq 5 - push/pop/return
-        488F irq 6 - push/pop/return
-        4892 irq 7 - minimal payload, no 3051 ack?
-*/
-
-void generalplus_gpl_unknown_state::reg3051_w(offs_t offset, uint16_t data)
-{
-	if (data & 0x8000)
-		m_maincpu->set_input_line(UNSP_IRQ0_LINE, CLEAR_LINE);
-
-	if (data & 0x2000)
-		m_maincpu->set_input_line(UNSP_IRQ2_LINE, CLEAR_LINE);
-
-	if (data & 0x0100)
-		m_maincpu->set_input_line(UNSP_IRQ3_LINE, CLEAR_LINE);
-
-
-	//logerror("%s: reg3051_w %04x (IRQ Ack?)\n", machine().describe_context(), data);
-}
-
-uint16_t generalplus_gpl_unknown_state::reg3090_r(offs_t offset)
-{
-	return 0x0000;//machine().rand();
-}
-
-uint16_t generalplus_gpl_unknown_state::reg3091_r(offs_t offset)
-{
-	return 0x0000;//machine().rand();
-}
-
-void generalplus_gpl_unknown_state::reg3092_lcd_w(offs_t offset, uint16_t data)
-{
-	if (m_3005 & 0x1000)
-	{
-		//if (m_3005 & 0x0800) // also always set for video writes?
-		{
-			//logerror("%s: reg3092_lcd_w %04x (Video?)\n", machine().describe_context(), data);
-			if ((m_displayposx < 256) && (m_displayposy < 256))
-				m_display[(m_displayposy * 256) + m_displayposx] = data;
-
-			if (data & 0xff00)
-				fatalerror("upper data bits set?\n");
-
-			m_displayposx++;
-
-			/*
-			if (m_displayposx == 256)
-			{
-			    m_displayposy++;
-			    m_displayposx = 0;
-			}
-			*/
-			/*
-			if (m_displayposy == 128)
-			{
-			    m_displayposy = 0;
-			    m_displayposx = 0;
-			}
-			*/
-		}
-	}
-}
-
-uint16_t generalplus_gpl_unknown_state::reg3094_r(offs_t offset)
-{
-	return 0x0000;
-}
-
-uint16_t generalplus_gpl_unknown_state::reg3095_r(offs_t offset)
-{
-	// loops on bit 0x0010 after writing data to 0x3092
-
-	// clrb [3005],12 is used before writing non-pixel data to 0x3092
-	// setb [3005],12 is used after reading from 0x3094
-	return 0x0000;
-}
-
-
-void generalplus_gpl_unknown_state::map(address_map &map)
-{
-	map(0x000000, 0x000fff).ram(); // RAM
-	//map(0x001000, 0x0017ff).ram(); // Cache area, can be configured as RAM instead
-
-	// 3000 - IOA_Data
-	map(0x003001, 0x003001).rw(FUNC(generalplus_gpl_unknown_state::reg3001_r), FUNC(generalplus_gpl_unknown_state::reg3001_w)); // IOA_Buffer
-	map(0x003002, 0x003002).rw(FUNC(generalplus_gpl_unknown_state::reg3002_r), FUNC(generalplus_gpl_unknown_state::reg3002_w)); // IOA_Dir
-	map(0x003003, 0x003003).rw(FUNC(generalplus_gpl_unknown_state::reg3003_r), FUNC(generalplus_gpl_unknown_state::reg3003_w)); // IOA_Attrib
-	map(0x003004, 0x003004).r(FUNC(generalplus_gpl_unknown_state::reg3004_r)); // IOB_Data - input from here is acted upon
-	map(0x003005, 0x003005).rw(FUNC(generalplus_gpl_unknown_state::reg3005_r), FUNC(generalplus_gpl_unknown_state::reg3005_w)); // IOB_Buffer
-	map(0x003006, 0x003006).r(FUNC(generalplus_gpl_unknown_state::reg3006_r)); // IOB_Dir
-	map(0x003007, 0x003007).r(FUNC(generalplus_gpl_unknown_state::reg3007_r)); // IOB_Attrib
-	// 3008 - IOC_Data
-	// 3009 - IOC_Buffer
-	// 300a - IOC_Dir
-	// 300b - IOC_Attrib
-	// 300c - IOA_WakeUp_Mask
-	// 300d - IOB_WakeUp_Mask
-	// 300e - IOC_WakeUp_Mask
-	map(0x00300f, 0x00300f).r(FUNC(generalplus_gpl_unknown_state::reg300f_r)); // IO_Ctrl
-
-	// 3010 - TimerA_Data
-	// 3011 - TimerA_CNTR
-	// 3012 - TimerB_Data
-	// 3013 - TimerB_CNTR
-	// 3014 - TimerC_Data
-	// 3015 - TimerC_CNTR
-	map(0x003016, 0x003016).r(FUNC(generalplus_gpl_unknown_state::reg3016_r)); // 3016 - Timer_Ctrl
-
-	// 3020 - PWM0_Ctrl
-	// 3021 - PWM1_Ctrl
-	// 3022 - PWM2_Ctrl
-	// 3023 - PWM3_Ctrl
-
-	// 3030 - System_Clock
-	// 3031 - System_Reset
-	// 3032 - Reset_LVD_Ctrl
-	// 3033 - Timebase_Clear
-	map(0x003034, 0x003034).w(FUNC(generalplus_gpl_unknown_state::reg3034_w)); // Watchdog_Clear
-	// 3035 - Wait_Ctrl
-	// 3036 - System_Sleep
-
-	// 3039 - Cache_Ctrl
-	// 303a - Cache_Hit_Rate
-	// 303b - Stack_INT_Level
-
-	// 3040 - DAC_Ctrl
-	map(0x003041, 0x003041).w(FUNC(generalplus_gpl_unknown_state::reg3041_audiodac_w)); // DAC_CH1_Data
-	// 3042 - DAC_CH2_Data
-	// 3043 - PPAMCtrl
-
-	map(0x003050, 0x003050).rw(FUNC(generalplus_gpl_unknown_state::reg3050_r), FUNC(generalplus_gpl_unknown_state::reg3050_w)); // INT_Ctrl
-	map(0x003051, 0x003051).w(FUNC(generalplus_gpl_unknown_state::reg3051_w)); // INT_Status
-	map(0x003052, 0x003052).r(FUNC(generalplus_gpl_unknown_state::reg3052_r)); // FIQ_SEL
-	map(0x003053, 0x003053).r(FUNC(generalplus_gpl_unknown_state::reg3053_r)); // INT2_Ctrl
-	// 3054 - INT2_Status
-	// 3055 - FIQ2_SEL
-
-	// 3070 - ADC_Ctrl
-	// 3071 - ADC_Data
-	// 3072 - ADC_LineIn_BitCtrl
-	// 3073 - ADC_PGA_Ctrl
-	// 3074 - ADC_FIFO_Ctrl
-
-	map(0x003090, 0x003090).r(FUNC(generalplus_gpl_unknown_state::reg3090_r)); // SPI2_Ctrl
-	map(0x003091, 0x003091).r(FUNC(generalplus_gpl_unknown_state::reg3091_r)); // SPI2_TXStatus
-	map(0x003092, 0x003092).w(FUNC(generalplus_gpl_unknown_state::reg3092_lcd_w)); // SPI2_TXData
-	// 3093 - SPI2_RXStatus
-	map(0x003094, 0x003094).r(FUNC(generalplus_gpl_unknown_state::reg3094_r)); // SPI2_RXData - potential interesting
-	map(0x003095, 0x003095).r(FUNC(generalplus_gpl_unknown_state::reg3095_r)); // SPI2_Misc - mostly a status flag
-
-	// 309a - SPI2_DMA_Start
-	// 309b - SPI2_DMA_BC
-	// 309c - SPI2_RX_DMA_ADDR
-	// 309d - SPI2_TX_DMA_ADDR
-	// 309e - SPI2_DMA_INT_Ctrl
-	// 309f - SPI2_RX_ICE
-
-	// 30b0 - BUF_ACTIVE
-	// 30b1 - LINK_BUF10
-	// 30b2 - LINK_BUF32
-	// 30b3 - LINK_BUF54
-
-	// 30d0 - CTS_Ctrl0
-	// 30d1 - CTS_Ctrl1
-	// 30d2 - CTS_TMADATA
-	// 30d3 - CTS_TMACNT
-	// 30d4 - CTS_TMBDATA
-	// 30d5 - CTS_TMBCNT
-	// 30d6 - CTS_CAPTMB
-	// 30d7 - CTS_MUTCTRL
-
-	map(0x0030e0, 0x0030e0).w(FUNC(generalplus_gpl_unknown_state::reg30e0_w)); // SPI_Ctrl
-	map(0x0030e1, 0x0030e1).w(FUNC(generalplus_gpl_unknown_state::reg30e1_w)); // SPI_TXStatus
-	map(0x0030e2, 0x0030e2).w(FUNC(generalplus_gpl_unknown_state::reg30e2_w)); // SPI_TXData
-	map(0x0030e3, 0x0030e3).w(FUNC(generalplus_gpl_unknown_state::reg30e3_w)); // SPI_RXStatus
-	map(0x0030e4, 0x0030e4).r(FUNC(generalplus_gpl_unknown_state::reg30e4_r)); // SPI_RXData - potentially interesting (must not return 0x0000 or 'flash error')
-	map(0x0030e5, 0x0030e5).r(FUNC(generalplus_gpl_unknown_state::reg30e5_r)); // SPI_Misc - potentially interesting (also status flag)
-	// 30e6 - SPI_Man_Ctrl
-	// 30e7 - SPI_Auto_Ctrl
-	// 30e8 - SPI_PRGM_BC
-	// 30e9 - SPI_BANK
-	// 30ea - SPI_DMA_Start
-	// 30eb - SPI_DMA_BC
-	// 30ec - SPI_RX_DMA_ADDR
-	// 30ed - SPI_TX_DMA_ADDR
-	// 30ee - SPI_DMA_INT_Ctrl
-	// 30ef - SPI_RX_ICE
-
-	map(0x004000, 0x00bfff).rom().region("maincpu", 0x0000); // 0x4000 - 0x47ff is 'test program'
-	map(0x00c000, 0x00ffff).rom().region("maincpu", 0x0000);
-
-	map(0x200000, 0x3fffff).rom().region("spi", 0x0000); // has direct access to SPI ROM
-}
-
-
-void generalplus_gpl_unknown_state::machine_start()
+void generalplus_gpce4_state::machine_start()
 {
 	for (int color = 0; color < 0x10000; color++)
 	{
@@ -599,67 +198,121 @@ void generalplus_gpl_unknown_state::machine_start()
 	save_item(NAME(m_display));
 	save_item(NAME(m_displayposx));
 	save_item(NAME(m_displayposy));
-	save_item(NAME(m_3001));
-	save_item(NAME(m_3003));
-	save_item(NAME(m_3005));
-	save_item(NAME(m_3050));
+	save_item(NAME(m_lcdc_command));
+	save_item(NAME(m_iob));
+	save_item(NAME(m_spilatch));
 }
 
-void generalplus_gpl_unknown_state::machine_reset()
+void generalplus_gpce4_state::machine_reset()
 {
 	m_displayposx = 0;
 	m_displayposy = 0;
-	m_3001 = 0;
-	m_3003 = 0;
-	m_3005 = 0;
-	m_3050 = 0;
+	m_lcdc_command = 0;
+	m_iob = 0;
+	m_spilatch = 0;
+
+	for (int i = 0; i < 0x8000; i++)
+		m_display[i] = 0;
 }
 
-TIMER_DEVICE_CALLBACK_MEMBER( generalplus_gpl_unknown_state::timer )
+TIMER_DEVICE_CALLBACK_MEMBER( generalplus_gpce4_state::timer )
 {
-	m_maincpu->set_input_line(UNSP_IRQ3_LINE, ASSERT_LINE);
+	m_maincpu->request_interrupt(24);
 }
 
-TIMER_DEVICE_CALLBACK_MEMBER( generalplus_gpl_unknown_state::timer2 )
+void generalplus_gpce4_state::portb_from_soc(u16 data)
 {
-	m_maincpu->set_input_line(UNSP_IRQ2_LINE, ASSERT_LINE);
+	m_iob = data;
 }
 
-TIMER_DEVICE_CALLBACK_MEMBER( generalplus_gpl_unknown_state::timer3 )
+// this should be a ST7735SV, TODO: complete and turn it into a device
+void generalplus_gpce4_state::process_lcdc_command_params(u8 data)
 {
-	m_maincpu->set_input_line(UNSP_IRQ0_LINE, ASSERT_LINE);
+	if (m_lcdc_command == 0x2c)
+	{
+		//logerror("lcd command param for 2c %02x\n", data);
+
+		if ((m_displayposx < 256) && (m_displayposy < 128))
+		{
+			m_display[(m_displayposy * 256) + m_displayposx] = data;
+		}
+
+		m_displayposx++;
+
+		if (m_displayposx == 256)
+		{
+			m_displayposx = 0;
+			m_displayposy++;
+		}
+	}
+	else if (m_lcdc_command == 0x2a)
+	{
+		logerror("lcd command param for 2a %02x\n", data);
+		m_displayposx = 0;
+		m_displayposy = 0;
+	}
+	else if (m_lcdc_command == 0x2b)
+	{
+		logerror("lcd command param for 2b %02x\n", data);
+	}
+	else
+	{
+		logerror("lcd command param for other command %02x\n", data);
+	}
 }
 
-
-
-void generalplus_gpl_unknown_state::generalplus_gpl_unknown(machine_config &config)
+void generalplus_gpce4_mapacman_state::spi_from_soc(u8 data)
 {
-	UNSP_20(config, m_maincpu, 96000000); // internal ROM uses unsp2.0 opcodes, should be 48MHz but glitches (due to timer hookups?)
-	m_maincpu->set_addrmap(AS_PROGRAM, &generalplus_gpl_unknown_state::map);
-	m_maincpu->set_vectorbase(0x4010); // there is also a set of vectors for what looks to be a burn-in test at 4000, maybe external pin selects?
+	m_spilatch = data;
+
+	if (!(m_iob & 0x1000))
+	{
+		m_lcdc_command = data;
+	}
+	else
+	{
+		process_lcdc_command_params(data);
+	}
+}
+
+void generalplus_gpce4_digicolr_state::spi_from_soc(u8 data)
+{
+	m_spilatch = data;
+
+	if (!(m_iob & 0x0400))
+	{
+		m_lcdc_command = data;
+	}
+	else
+	{
+		process_lcdc_command_params(data);
+	}
+}
+
+void generalplus_gpce4_state::generalplus_gpce4(machine_config &config)
+{
+	GPCE4(config, m_maincpu, 96000000); // internal ROM uses unsp2.0 opcodes, should be 48MHz (but unSP2.0 opcode take fewer cycles?)
+	m_maincpu->portb_in().set_ioport("TEST");
+	m_maincpu->portb_out().set(FUNC(generalplus_gpce4_state::portb_from_soc));
+	m_maincpu->spi2_out().set(FUNC(generalplus_gpce4_state::spi_from_soc));
 
 	SCREEN(config, m_screen, SCREEN_TYPE_LCD);
 	m_screen->set_refresh_hz(60);
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(10));
 	m_screen->set_size(128, 128);
-	m_screen->set_visarea(0, 128-1, 0, 128-1); // not the correct resolution
-	m_screen->set_screen_update(FUNC(generalplus_gpl_unknown_state::screen_update));
-	//m_screen->screen_vblank().set(FUNC(generalplus_gpl_unknown_state::screen_vblank));
+	m_screen->set_visarea(0, 128-1, 0, 128-1);
+	m_screen->set_screen_update(FUNC(generalplus_gpce4_state::screen_update));
 	m_screen->set_palette(m_palette);
 
-	SPEAKER(config, "speaker").front_center();
-	DAC_16BIT_R2R_TWOS_COMPLEMENT(config, "dac", 0).add_route(ALL_OUTPUTS, "speaker", 1.0); // unknown DAC
-
-	TIMER(config, "timer").configure_periodic(FUNC(generalplus_gpl_unknown_state::timer), attotime::from_hz(200000)); // draw timer (pushes pixels to the display in the IRQ)
-	TIMER(config, "timer2").configure_periodic(FUNC(generalplus_gpl_unknown_state::timer2), attotime::from_hz(1000)); // game speed?
-	TIMER(config, "timer3").configure_periodic(FUNC(generalplus_gpl_unknown_state::timer3), attotime::from_hz(20000)); // audio
+	// this triggers the SPI2 interrupt, causing pixels to be pushed to the display
+	TIMER(config, "timer").configure_periodic(FUNC(generalplus_gpce4_state::timer), attotime::from_hz(400000));
 
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, 0x10000);
 }
 
-void generalplus_gpl_unknown_state::init_siddr()
+void generalplus_gpce4_state::init_siddr()
 {
-	uint8_t* spirom8 = (uint8_t*)memregion("spi")->base();
+	u8* spirom8 = (u8*)memregion("maincpu:spi")->base();
 	for (int i = 0x3000; i < 0x400000; i++)
 	{
 		spirom8[i] = bitswap<8>(spirom8[i] ^ 0x68,
@@ -669,58 +322,70 @@ void generalplus_gpl_unknown_state::init_siddr()
 
 
 ROM_START( mapacman ) // this is the single game (no games hidden behind solder pads) release
-	ROM_REGION16_BE( 0x18000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION16_BE( 0x18000, "maincpu:internal", ROMREGION_ERASEFF )
 	ROM_LOAD16_WORD_SWAP( "mapacman_internal.rom", 0x000000, 0x10000, CRC(9ea69d2a) SHA1(17f5001794f4454bf5856cfa170834509d68bed0) )
 
-	ROM_REGION16_BE( 0x800000, "spi", ROMREGION_ERASEFF )
+	ROM_REGION16_BE( 0x800000, "maincpu:spi", ROMREGION_ERASEFF )
 	ROM_LOAD16_WORD_SWAP( "fm25q16a.bin", 0x000000, 0x200000, CRC(aeb472ac) SHA1(500c24b725f6d3308ef8cbdf4259f5be556c7c92) )
 ROM_END
 
 ROM_START( taspinv )
-	ROM_REGION16_BE( 0x18000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION16_BE( 0x18000, "maincpu:internal", ROMREGION_ERASEFF )
 	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x000000, 0x18000, NO_DUMP )
 
-	ROM_REGION16_BE( 0x800000, "spi", ROMREGION_ERASEFF )
+	ROM_REGION16_BE( 0x800000, "maincpu:spi", ROMREGION_ERASEFF )
 	ROM_LOAD16_WORD_SWAP( "tinyarcade_spaceinvaders.bin", 0x000000, 0x200000, CRC(11ac4c77) SHA1(398d5eff83a4e94487ed810819085a0e44582908) )
 ROM_END
 
 ROM_START( tagalaga )
-	ROM_REGION16_BE( 0x18000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION16_BE( 0x18000, "maincpu:internal", ROMREGION_ERASEFF )
 	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x000000, 0x18000, NO_DUMP )
 
-	ROM_REGION16_BE( 0x800000, "spi", ROMREGION_ERASEFF )
+	ROM_REGION16_BE( 0x800000, "maincpu:spi", ROMREGION_ERASEFF )
 	ROM_LOAD16_WORD_SWAP( "tinyarcadegalaga_fm25q16a_a14015.bin", 0x000000, 0x200000, CRC(2a91460c) SHA1(ce297642d2d51ce568e93c0c57432446633b2077) )
 ROM_END
 
 ROM_START( parcade )
-	ROM_REGION16_BE( 0x18000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION16_BE( 0x18000, "maincpu:internal", ROMREGION_ERASEFF )
 	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x000000, 0x18000, NO_DUMP )
 
-	ROM_REGION16_BE( 0x800000, "spi", ROMREGION_ERASEFF )
+	ROM_REGION16_BE( 0x800000, "maincpu:spi", ROMREGION_ERASEFF )
 	ROM_LOAD16_WORD_SWAP( "palacearcade_gpr25l3203_c22016.bin", 0x000000, 0x400000, CRC(98fbd2a1) SHA1(ffc19aadd53ead1f9f3472475606941055ca09f9) )
 ROM_END
 
 ROM_START( taturtf )
-	ROM_REGION16_BE( 0x18000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION16_BE( 0x18000, "maincpu:internal", ROMREGION_ERASEFF )
 	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x000000, 0x18000, NO_DUMP )
 
-	ROM_REGION16_BE( 0x800000, "spi", ROMREGION_ERASEFF )
+	ROM_REGION16_BE( 0x800000, "maincpu:spi", ROMREGION_ERASEFF )
 	ROM_LOAD16_WORD_SWAP( "tinyarcadeturtlefighter_25q32bst16_684016.bin", 0x000000, 0x400000, CRC(8e046f2d) SHA1(e48492cf953f22a47fa2b88a8f96a1e459b8c487) )
 ROM_END
 
-ROM_START( digicolr )
-	ROM_REGION16_BE( 0x18000, "maincpu", ROMREGION_ERASEFF )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x000000, 0x18000, NO_DUMP )
+/*
 
-	ROM_REGION16_BE( 0x800000, "spi", ROMREGION_ERASEFF )
-	ROM_LOAD16_WORD_SWAP( "mx25l6433f.u2", 0x000000, 0x800000, CRC(9999e2a0) SHA1(4af880e5e2bb1c820b0ec19acf1b5f858bfa1ab0) )
+(this is correct for at least some of the digimon units)
+MCU : Generalplus GPCE4064B
+SPI Flash IC : Macronix MX25L6433F
+LCD Driver : Sitronix ST7735SV
+LCD module : TCXD011IBLON-3
+Sound unit is a piezo disc.
+
+*/
+
+ROM_START( digicolr )
+	ROM_REGION16_BE( 0x18000, "maincpu:internal", ROMREGION_ERASEFF )
+	ROM_LOAD16_WORD_SWAP( "digicolr_unsp.bin", 0x000000, 0x10000, CRC(24815b43) SHA1(d245d1e868d0357f9410cd325a3786b45a8365d2) )
+
+	ROM_REGION16_BE( 0x800000, "maincpu:spi", ROMREGION_ERASEFF )
+	ROM_LOAD16_WORD_SWAP( "mx25l6433f.u2", 0x000000, 0x800000, CRC(c515cab8) SHA1(a8b04280acae0c4db1a82ea9b46ade398e41f72b) )
+	//ROM_LOAD16_WORD_SWAP( "mx25l6433f.u2", 0x000000, 0x800000, CRC(9999e2a0) SHA1(4af880e5e2bb1c820b0ec19acf1b5f858bfa1ab0) )
 ROM_END
 
 ROM_START( siddr )
-	ROM_REGION16_BE( 0x40000, "maincpu", ROMREGION_ERASE00 )
+	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP )
 
-	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x800000, "maincpu:spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "ddr-toy.bin", 0x0000, 0x400000, CRC(873cbcc8) SHA1(bdd3d12adb1284991a3f8aaa8e451e3a55931267) )
 ROM_END
 
@@ -729,19 +394,18 @@ ROM_END
 
 
 // The 'Micro Arcade' units are credit card sized handheld devices
-CONS( 2017, mapacman,      0,       0,      generalplus_gpl_unknown,   generalplus_gpl_unknown, generalplus_gpl_unknown_state, empty_init, "Super Impulse", "Pac-Man (Micro Arcade)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2017, mapacman,      0,       0,      generalplus_gpce4,   generalplus_gpce4, generalplus_gpce4_mapacman_state, empty_init, "Super Impulse", "Pac-Man (Micro Arcade)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 
 // The 'Tiny Arcade' units are arcade cabinets on a keyring.
-CONS( 2017, taspinv,       0,       0,      generalplus_gpl_unknown,   generalplus_gpl_unknown, generalplus_gpl_unknown_state, empty_init, "Super Impulse", "Space Invaders (Tiny Arcade)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2017, taspinv,       0,       0,      generalplus_gpce4,   generalplus_gpce4, generalplus_gpce4_mapacman_state, empty_init, "Super Impulse", "Space Invaders (Tiny Arcade)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 
-CONS( 2017, tagalaga,      0,       0,      generalplus_gpl_unknown,   generalplus_gpl_unknown, generalplus_gpl_unknown_state, empty_init, "Super Impulse", "Galaga (Tiny Arcade)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2017, tagalaga,      0,       0,      generalplus_gpce4,   generalplus_gpce4, generalplus_gpce4_mapacman_state, empty_init, "Super Impulse", "Galaga (Tiny Arcade)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 
-CONS( 2017, parcade,       0,       0,      generalplus_gpl_unknown,   generalplus_gpl_unknown, generalplus_gpl_unknown_state, empty_init, "Hasbro", "Palace Arcade (Tiny Arcade)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2017, parcade,       0,       0,      generalplus_gpce4,   generalplus_gpce4, generalplus_gpce4_mapacman_state, empty_init, "Hasbro", "Palace Arcade (Tiny Arcade)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 
-CONS( 2019, taturtf,       0,       0,      generalplus_gpl_unknown,   generalplus_gpl_unknown, generalplus_gpl_unknown_state, empty_init, "Super Impulse", "Teenage Mutant Ninja Turtles - Turtle Fighter (Tiny Arcade)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2019, taturtf,       0,       0,      generalplus_gpce4,   generalplus_gpce4, generalplus_gpce4_mapacman_state, empty_init, "Super Impulse", "Teenage Mutant Ninja Turtles - Turtle Fighter (Tiny Arcade)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+
+CONS( 2021, digicolr,      0,       0,      generalplus_gpce4,   generalplus_gpce4, generalplus_gpce4_digicolr_state, empty_init, "Bandai", "Digimon Color", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 
 // Probably not identical hardware, but still not direct mapped SPI.  External ROM after 0x3000 is encrypted (maybe decrypted in software) seems to have jumps to internal ROM
-CONS( 2021, siddr,         0,       0,      generalplus_gpl_unknown,   generalplus_gpl_unknown, generalplus_gpl_unknown_state, init_siddr, "Super Impulse", "Dance Dance Revolution - Broadwalk Arcade", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-
-CONS( 2021, digicolr,      0,       0,      generalplus_gpl_unknown,   generalplus_gpl_unknown, generalplus_gpl_unknown_state, empty_init, "Bandai", "Digimon Color", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-
+CONS( 2021, siddr,         0,       0,      generalplus_gpce4,   generalplus_gpce4, generalplus_gpce4_mapacman_state, init_siddr, "Super Impulse", "Dance Dance Revolution - Broadwalk Arcade", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/handheld/generalplus_gpce4.cpp
+++ b/src/mame/handheld/generalplus_gpce4.cpp
@@ -65,7 +65,6 @@ protected:
 	void process_lcdc_command_params(u8 data);
 
 	u16 m_iob;
-	u8 m_spilatch;
 
 	TIMER_DEVICE_CALLBACK_MEMBER(timer);
 
@@ -145,11 +144,11 @@ INPUT_PORTS_END
 void generalplus_gpce4_state::machine_start()
 {
 	save_item(NAME(m_iob));
-	save_item(NAME(m_spilatch));
 }
 
 void generalplus_gpce4_state::machine_reset()
 {
+	m_iob = 0;
 }
 
 TIMER_DEVICE_CALLBACK_MEMBER( generalplus_gpce4_state::timer )
@@ -164,8 +163,6 @@ void generalplus_gpce4_state::portb_from_soc(u16 data)
 
 void generalplus_gpce4_mapacman_state::spi_from_soc(u8 data)
 {
-	m_spilatch = data;
-
 	if (!(m_iob & 0x0800))
 	{
 		m_lcdc->lcdc_command_w(data);
@@ -178,8 +175,6 @@ void generalplus_gpce4_mapacman_state::spi_from_soc(u8 data)
 
 void generalplus_gpce4_digicolr_state::spi_from_soc(u8 data)
 {
-	m_spilatch = data;
-
 	if (!(m_iob & 0x0400))
 	{
 		m_lcdc->lcdc_command_w(data);

--- a/src/mame/handheld/generalplus_gpce4.cpp
+++ b/src/mame/handheld/generalplus_gpce4.cpp
@@ -30,11 +30,10 @@
 
 #include "machine/generalplus_gpce4_soc.h"
 #include "machine/timer.h"
-#include "sound/dac.h"
 
-#include "emupal.h"
+#include "bl_handhelds_lcdc.h"
+
 #include "screen.h"
-#include "speaker.h"
 
 #include "logmacro.h"
 
@@ -47,8 +46,8 @@ public:
 	generalplus_gpce4_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
-		m_palette(*this, "palette"),
-		m_screen(*this, "screen")
+		m_screen(*this, "screen"),
+		m_lcdc(*this, "lcdc")
 	{ }
 
 	void generalplus_gpce4(machine_config &config);
@@ -59,26 +58,21 @@ protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
-	virtual u32 screen_update(screen_device& screen, bitmap_ind16& bitmap, const rectangle& cliprect) = 0;
+	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	virtual void spi_from_soc(u8 data) = 0;
 
 	void portb_from_soc(u16 data);
 	void process_lcdc_command_params(u8 data);
 
-	u16 m_display[0x8000];
-	u16 m_displayposx;
-	u8 m_displayposy;
-
-	u8 m_lcdc_command;
 	u16 m_iob;
 	u8 m_spilatch;
 
 	TIMER_DEVICE_CALLBACK_MEMBER(timer);
 
 	required_device<generalplus_gpce4_soc_device> m_maincpu;
-
-	required_device<palette_device> m_palette;
 	required_device<screen_device> m_screen;
+	required_device<bl_handhelds_lcdc_device> m_lcdc;
+
 };
 
 class generalplus_gpce4_mapacman_state : public generalplus_gpce4_state
@@ -88,7 +82,6 @@ public:
 		generalplus_gpce4_state(mconfig, type, tag)
 	{ }
 
-	virtual u32 screen_update(screen_device& screen, bitmap_ind16& bitmap, const rectangle& cliprect) override;
 	virtual void spi_from_soc(u8 data) override;
 };
 
@@ -99,48 +92,12 @@ public:
 		generalplus_gpce4_state(mconfig, type, tag)
 	{ }
 
-	virtual u32 screen_update(screen_device& screen, bitmap_ind16& bitmap, const rectangle& cliprect) override;
 	virtual void spi_from_soc(u8 data) override;
 };
 
-u32 generalplus_gpce4_mapacman_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 generalplus_gpce4_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	int count = 0;
-	for (int y = 0; y < 128; y++)
-	{
-		u16* dst = &bitmap.pix(y);
-
-		for (int x = 0; x < 128; x++)
-		{
-			u8 pix1 = m_display[count++];
-			u8 pix2 = m_display[count++];
-
-			u16 pal = ((pix1<<8) | pix2);
-
-			dst[x] = pal;
-		}
-	}
-	return 0;
-}
-
-u32 generalplus_gpce4_digicolr_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
-{
-	int count = 0;
-	for (int y = 0; y < 96; y++)
-	{
-		u16* dst = &bitmap.pix(y);
-
-		for (int x = 0; x < 24; x++)
-		{
-			u8 pix1 = m_display[count++];
-			u8 pix2 = m_display[count++];
-
-			u16 pal = ((pix1<<8) | pix2);
-
-			dst[x] = pal;
-		}
-	}
-	return 0;
+	return m_lcdc->render_to_bitmap(screen, bitmap, cliprect);
 }
 
 static INPUT_PORTS_START( generalplus_gpce4 )
@@ -187,32 +144,12 @@ INPUT_PORTS_END
 
 void generalplus_gpce4_state::machine_start()
 {
-	for (int color = 0; color < 0x10000; color++)
-	{
-		const u8 r = pal5bit(color >> 11);
-		const u8 g = pal6bit(color >> 5);
-		const u8 b = pal5bit(color & 0x1f);
-		m_palette->set_pen_color(color, rgb_t(r, g, b));
-	}
-
-	save_item(NAME(m_display));
-	save_item(NAME(m_displayposx));
-	save_item(NAME(m_displayposy));
-	save_item(NAME(m_lcdc_command));
 	save_item(NAME(m_iob));
 	save_item(NAME(m_spilatch));
 }
 
 void generalplus_gpce4_state::machine_reset()
 {
-	m_displayposx = 0;
-	m_displayposy = 0;
-	m_lcdc_command = 0;
-	m_iob = 0;
-	m_spilatch = 0;
-
-	for (int i = 0; i < 0x8000; i++)
-		m_display[i] = 0;
 }
 
 TIMER_DEVICE_CALLBACK_MEMBER( generalplus_gpce4_state::timer )
@@ -225,53 +162,17 @@ void generalplus_gpce4_state::portb_from_soc(u16 data)
 	m_iob = data;
 }
 
-// this should be a ST7735SV, TODO: complete and turn it into a device
-void generalplus_gpce4_state::process_lcdc_command_params(u8 data)
-{
-	if (m_lcdc_command == 0x2c)
-	{
-		//logerror("lcd command param for 2c %02x\n", data);
-
-		if ((m_displayposx < 256) && (m_displayposy < 128))
-		{
-			m_display[(m_displayposy * 256) + m_displayposx] = data;
-		}
-
-		m_displayposx++;
-
-		if (m_displayposx == 256)
-		{
-			m_displayposx = 0;
-			m_displayposy++;
-		}
-	}
-	else if (m_lcdc_command == 0x2a)
-	{
-		logerror("lcd command param for 2a %02x\n", data);
-		m_displayposx = 0;
-		m_displayposy = 0;
-	}
-	else if (m_lcdc_command == 0x2b)
-	{
-		logerror("lcd command param for 2b %02x\n", data);
-	}
-	else
-	{
-		logerror("lcd command param for other command %02x\n", data);
-	}
-}
-
 void generalplus_gpce4_mapacman_state::spi_from_soc(u8 data)
 {
 	m_spilatch = data;
 
-	if (!(m_iob & 0x1000))
+	if (!(m_iob & 0x0800))
 	{
-		m_lcdc_command = data;
+		m_lcdc->lcdc_command_w(data);
 	}
 	else
 	{
-		process_lcdc_command_params(data);
+		m_lcdc->lcdc_data_w(data);
 	}
 }
 
@@ -281,11 +182,11 @@ void generalplus_gpce4_digicolr_state::spi_from_soc(u8 data)
 
 	if (!(m_iob & 0x0400))
 	{
-		m_lcdc_command = data;
+		m_lcdc->lcdc_command_w(data);
 	}
 	else
 	{
-		process_lcdc_command_params(data);
+		m_lcdc->lcdc_data_w(data);
 	}
 }
 
@@ -302,12 +203,11 @@ void generalplus_gpce4_state::generalplus_gpce4(machine_config &config)
 	m_screen->set_size(128, 128);
 	m_screen->set_visarea(0, 128-1, 0, 128-1);
 	m_screen->set_screen_update(FUNC(generalplus_gpce4_state::screen_update));
-	m_screen->set_palette(m_palette);
 
 	// this triggers the SPI2 interrupt, causing pixels to be pushed to the display
-	TIMER(config, "timer").configure_periodic(FUNC(generalplus_gpce4_state::timer), attotime::from_hz(400000));
+	TIMER(config, "timer").configure_periodic(FUNC(generalplus_gpce4_state::timer), attotime::from_hz(300000));
 
-	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, 0x10000);
+	BL_HANDHELDS_LCDC(config, m_lcdc, 0);
 }
 
 void generalplus_gpce4_state::init_siddr()


### PR DESCRIPTION
- moved GeneralPlus GPCE4 series SoC emulation from driver file into a device [David Haywood]
- begin to flesh out GPCE4 emulation a little more [David Haywood]
- move mapacman away from make-believe hookups to something a little more grounded in reality now that the chip has been identified [David Haywood]
- added internal ROM for digicolr set, replace with clean dump [Harold Seo]
- removed local implementation of LCDC previously used by mapacman and replaced it with the bl_handhelds_lcdc.cpp device, which looks like it's actually a ST7735SV (which is what these use) [David Haywood]
- mapacman display is now more stable [David Haywood]
