### PR TITLE
apple2video: improve more video timing

### DIFF
--- a/src/mame/apple/apple2.cpp
+++ b/src/mame/apple/apple2.cpp
@@ -607,129 +607,18 @@ void apple2_state::inh_w(offs_t offset, u8 data)
 	}
 }
 
-// floating bus code from old machine/apple2: now works reasonably well with French Touch and Deater "vapor lock" stuff
 u8 apple2_state::read_floatingbus()
 {
-	enum
-	{
-		// scanner constants
-		kHBurstClock      =    53, // clock when Color Burst starts
-		kHBurstClocks     =     4, // clocks per Color Burst duration
-		kHClock0State     =  0x18, // H[543210] = 011000
-		kHClocks          =    65, // clocks per horizontal scan (including HBL)
-		kHPEClock         =    40, // clock when HPE (horizontal preset enable) goes low
-		kHPresetClock     =    41, // clock when H state presets
-		kHSyncClock       =    49, // clock when HSync starts
-		kHSyncClocks      =     4, // clocks per HSync duration
-		kNTSCScanLines    =   262, // total scan lines including VBL (NTSC)
-		kNTSCVSyncLine    =   224, // line when VSync starts (NTSC)
-		kPALScanLines     =   312, // total scan lines including VBL (PAL)
-		kPALVSyncLine     =   264, // line when VSync starts (PAL)
-		kVLine0State      = 0x100, // V[543210CBA] = 100000000
-		kVPresetLine      =   256, // line when V state presets
-		kVSyncLines       =     4, // lines per VSync duration
-		kClocksPerVSync   = kHClocks * kNTSCScanLines // FIX: NTSC only?
-	};
+	int h_clock = m_screen->hpos() / 14 + 25; // adjust for set_raw
+	if (h_clock >= 65)
+		h_clock -= 65;
 
-	// vars
-	//
-	int i, Hires, Mixed, Page2, _80Store, ScanLines, /* VSyncLine, ScanCycles,*/
-		h_clock, h_state, h_0, h_1, h_2, h_3, h_4, h_5,
-		v_line, v_state, v_A, v_B, v_C, v_0, v_1, v_2, v_3, v_4, /* v_5, */
-		_hires, addend0, addend1, addend2, sum, address;
+	int v_clock = m_screen->vpos() + (h_clock < 25); // adjust for hpos wrap
+	if (v_clock >= m_screen->height())
+		v_clock -= m_screen->height();
 
-	// video scanner data
-	//
-	i = m_maincpu->total_cycles() % kClocksPerVSync; // cycles into this VSync
-
-	// machine state switches
-	//
-	Hires    = (m_video->get_hires() && m_video->get_graphics()) ? 1 : 0;
-	Mixed    = m_video->get_mix() ? 1 : 0;
-	Page2    = m_video->get_page2() ? 1 : 0;
-	_80Store = 0;
-
-	// calculate video parameters according to display standard
-	//
-	ScanLines  = 1 ? kNTSCScanLines : kPALScanLines; // FIX: NTSC only?
-	// VSyncLine  = 1 ? kNTSCVSyncLine : kPALVSyncLine; // FIX: NTSC only?
-	// ScanCycles = ScanLines * kHClocks;
-
-	// calculate horizontal scanning state
-	h_clock = (i + 63) % kHClocks; // which horizontal scanning clock
-	h_state = kHClock0State + h_clock; // H state bits
-	if (h_clock >= kHPresetClock) // check for horizontal preset
-	{
-		h_state -= 1; // correct for state preset (two 0 states)
-	}
-	h_0 = (h_state >> 0) & 1; // get horizontal state bits
-	h_1 = (h_state >> 1) & 1;
-	h_2 = (h_state >> 2) & 1;
-	h_3 = (h_state >> 3) & 1;
-	h_4 = (h_state >> 4) & 1;
-	h_5 = (h_state >> 5) & 1;
-
-	// calculate vertical scanning state
-	//
-	v_line  = (i / kHClocks) + 192; // which vertical scanning line
-	v_state = kVLine0State + v_line; // V state bits
-	if ((v_line >= kVPresetLine)) // check for previous vertical state preset
-	{
-		v_state -= ScanLines; // compensate for preset
-	}
-	v_A = (v_state >> 0) & 1; // get vertical state bits
-	v_B = (v_state >> 1) & 1;
-	v_C = (v_state >> 2) & 1;
-	v_0 = (v_state >> 3) & 1;
-	v_1 = (v_state >> 4) & 1;
-	v_2 = (v_state >> 5) & 1;
-	v_3 = (v_state >> 6) & 1;
-	v_4 = (v_state >> 7) & 1;
-	//v_5 = (v_state >> 8) & 1;
-
-	// calculate scanning memory address
-	//
-	_hires = Hires;
-	if (Hires && Mixed && (v_4 & v_2))
-	{
-		_hires = 0; // (address is in text memory)
-	}
-
-	addend0 = 0x68; // 1            1            0            1
-	addend1 =              (h_5 << 5) | (h_4 << 4) | (h_3 << 3);
-	addend2 = (v_4 << 6) | (v_3 << 5) | (v_4 << 4) | (v_3 << 3);
-	sum     = (addend0 + addend1 + addend2) & (0x0F << 3);
-
-	address = 0;
-	address |= h_0 << 0; // a0
-	address |= h_1 << 1; // a1
-	address |= h_2 << 2; // a2
-	address |= sum;      // a3 - aa6
-	address |= v_0 << 7; // a7
-	address |= v_1 << 8; // a8
-	address |= v_2 << 9; // a9
-	address |= ((_hires) ? v_A : (1 ^ (Page2 & (1 ^ _80Store)))) << 10; // a10
-	address |= ((_hires) ? v_B : (Page2 & (1 ^ _80Store))) << 11; // a11
-	if (_hires) // hires?
-	{
-		// Y: insert hires only address bits
-		//
-		address |= v_C << 12; // a12
-		address |= (1 ^ (Page2 & (1 ^ _80Store))) << 13; // a13
-		address |= (Page2 & (1 ^ _80Store)) << 14; // a14
-	}
-	else
-	{
-		// N: text, so no higher address bits unless Apple ][, not Apple //e
-		//
-		if ((kHPEClock <= h_clock) && // Y: HBL?
-			(h_clock <= (kHClocks - 1)))
-		{
-			address |= 1 << 12; // Y: a12 (add $1000 to address!)
-		}
-	}
-
-	return m_ram_ptr[address % m_ram_size];
+	const u16 address = m_video->scanner_address(h_clock, v_clock);
+	return ram_r(address);
 }
 
 /***************************************************************************

--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -1520,7 +1520,7 @@ void apple2e_state::accel_full_speed()
 
 void apple2e_state::accel_normal_speed()
 {
-	m_maincpu->set_unscaled_clock(1021800, true); // re-align to PH0
+	m_maincpu->set_unscaled_clock(m_pal ? 1016966 : 1021800, true); // re-align to PH0
 }
 
 void apple2e_state::accel_slot(int slot)

--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -3315,118 +3315,18 @@ void apple2e_state::lc_w(offs_t offset, u8 data)
 	}
 }
 
-// floating bus code from old machine/apple2: now works reasonably well with French Touch and Deater "vapor lock" stuff
 u8 apple2e_state::read_floatingbus()
 {
-	enum
-	{
-		// scanner constants
-		kHBurstClock      =    53, // clock when Color Burst starts
-		kHBurstClocks     =     4, // clocks per Color Burst duration
-		kHClock0State     =  0x18, // H[543210] = 011000
-		kHClocks          =    65, // clocks per horizontal scan (including HBL)
-		kHPEClock         =    40, // clock when HPE (horizontal preset enable) goes low
-		kHPresetClock     =    41, // clock when H state presets
-		kHSyncClock       =    49, // clock when HSync starts
-		kHSyncClocks      =     4, // clocks per HSync duration
-		kNTSCScanLines    =   262, // total scan lines including VBL (NTSC)
-		kNTSCVSyncLine    =   224, // line when VSync starts (NTSC)
-		kPALScanLines     =   312, // total scan lines including VBL (PAL)
-		kPALVSyncLine     =   264, // line when VSync starts (PAL)
-		kVLine0State      = 0x100, // V[543210CBA] = 100000000
-		kVPresetLine      =   256, // line when V state presets
-		kVSyncLines       =     4, // lines per VSync duration
-	};
+	int h_clock = m_screen->hpos() / 14 + 25; // adjust for set_raw
+	if (h_clock >= 65)
+		h_clock -= 65;
 
-	const int kClocksPerVSync = kHClocks * (m_pal ? kPALScanLines : kNTSCScanLines);
+	int v_clock = m_screen->vpos() + (h_clock < 25); // adjust for hpos wrap
+	if (v_clock >= m_screen->height())
+		v_clock -= m_screen->height();
 
-	// vars
-	//
-	int i, Hires, Mixed, Page2, _80Store, ScanLines, /* VSyncLine, ScanCycles,*/
-		h_clock, h_state, h_0, h_1, h_2, h_3, h_4, h_5,
-		v_line, v_state, v_A, v_B, v_C, v_0, v_1, v_2, v_3, v_4, /* v_5, */
-		_hires, addend0, addend1, addend2, sum, address;
-
-	// video scanner data
-	//
-	i = m_maincpu->total_cycles() % kClocksPerVSync; // cycles into this VSync
-
-	// machine state switches
-	//
-	Hires = (m_video->get_hires() && m_video->get_graphics()) ? 1 : 0;
-	Mixed = m_video->get_mix() ? 1 : 0;
-	Page2 = m_video->get_page2() ? 1 : 0;
-	_80Store = m_video->get_80store() ? 1 : 0;
-
-	// calculate video parameters according to display standard
-	// we call this "PAL", but it's also for SECAM
-	ScanLines  = m_pal ? kPALScanLines : kNTSCScanLines;
-
-	// calculate horizontal scanning state
-	h_clock = (i + 63) % kHClocks; // which horizontal scanning clock
-	h_state = kHClock0State + h_clock; // H state bits
-	if (h_clock >= kHPresetClock) // check for horizontal preset
-	{
-		h_state -= 1; // correct for state preset (two 0 states)
-	}
-	h_0 = (h_state >> 0) & 1; // get horizontal state bits
-	h_1 = (h_state >> 1) & 1;
-	h_2 = (h_state >> 2) & 1;
-	h_3 = (h_state >> 3) & 1;
-	h_4 = (h_state >> 4) & 1;
-	h_5 = (h_state >> 5) & 1;
-
-	// calculate vertical scanning state
-	//
-	v_line  = (i / kHClocks) + 192; // which vertical scanning line (MAME starts at blank, not the beginning of the scanning area)
-	v_state = kVLine0State + v_line; // V state bits
-	if ((v_line >= kVPresetLine)) // check for previous vertical state preset
-	{
-		v_state -= ScanLines; // compensate for preset
-	}
-	v_A = (v_state >> 0) & 1; // get vertical state bits
-	v_B = (v_state >> 1) & 1;
-	v_C = (v_state >> 2) & 1;
-	v_0 = (v_state >> 3) & 1;
-	v_1 = (v_state >> 4) & 1;
-	v_2 = (v_state >> 5) & 1;
-	v_3 = (v_state >> 6) & 1;
-	v_4 = (v_state >> 7) & 1;
-	//v_5 = (v_state >> 8) & 1;
-
-	// calculate scanning memory address
-	//
-	_hires = Hires;
-	if (Hires && Mixed && (v_4 & v_2))
-	{
-		_hires = 0; // (address is in text memory)
-	}
-
-	addend0 = 0x68; // 1            1            0            1
-	addend1 =              (h_5 << 5) | (h_4 << 4) | (h_3 << 3);
-	addend2 = (v_4 << 6) | (v_3 << 5) | (v_4 << 4) | (v_3 << 3);
-	sum     = (addend0 + addend1 + addend2) & (0x0F << 3);
-
-	address = 0;
-	address |= h_0 << 0; // a0
-	address |= h_1 << 1; // a1
-	address |= h_2 << 2; // a2
-	address |= sum;      // a3 - aa6
-	address |= v_0 << 7; // a7
-	address |= v_1 << 8; // a8
-	address |= v_2 << 9; // a9
-	address |= ((_hires) ? v_A : (1 ^ (Page2 & (1 ^ _80Store)))) << 10; // a10
-	address |= ((_hires) ? v_B : (Page2 & (1 ^ _80Store))) << 11; // a11
-	if (_hires) // hires?
-	{
-		// Y: insert hires only address bits
-		//
-		address |= v_C << 12; // a12
-		address |= (1 ^ (Page2 & (1 ^ _80Store))) << 13; // a13
-		address |= (Page2 & (1 ^ _80Store)) << 14; // a14
-	}
-
-	return m_ram_ptr[address % m_ram_size];
+	const u16 address = m_video->scanner_address(h_clock, v_clock);
+	return m_ram_ptr[address];
 }
 
 /***************************************************************************

--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -5041,6 +5041,7 @@ void apple2e_state::apple2e_common(machine_config &config, bool enhanced, bool r
 	{
 		APPLE2_VIDEO_COMPOSITE(config, m_video, XTAL(14'318'181)).set_screen(m_screen);
 	}
+	m_video->set_base_model(a2_video_device::model::IIE);
 
 	APPLE2_COMMON(config, m_a2common, XTAL(14'318'181));
 

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -3795,6 +3795,7 @@ void apple2gs_state::apple2gs(machine_config &config)
 	m_rtc->cko_cb().set(FUNC(apple2gs_state::rtc_vgc));
 
 	APPLE2_VIDEO(config, m_video, A2GS_14M).set_screen(m_screen);
+	m_video->set_base_model(a2_video_device::model::IIGS);
 
 	APPLE2_COMMON(config, m_a2common, A2GS_14M).set_GS_cputag(m_maincpu);
 

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -2724,134 +2724,48 @@ void apple2gs_state::lc_01_w(offs_t offset, u8 data)
 	m_ram_ptr[(offset & 0x1fff) + 0x1e000] = data;
 }
 
-// floating bus code from old machine/apple2: needs to be reworked based on real beam position to enable e.g. Bob Bishop's screen splitter
 u8 apple2gs_state::read_floatingbus()
 {
-	enum
+	int h_clock = (m_screen->hpos() - BORDER_LEFT) / 16 + (25 + ALIGN_RFB); // adjust for set_raw
+	if (h_clock >= 65)
+		h_clock -= 65;
+
+	int v_clock = m_screen->vpos();
+	if (v_clock < BORDER_TOP)
+		v_clock += m_screen->height(); // remap top border to bottom of VBL
+	v_clock -= BORDER_TOP;
+	v_clock += (h_clock < (25 - ALIGN_RFB)); // adjust for hpos wrap
+	if (v_clock >= m_screen->height())
+		v_clock -= m_screen->height();
+
+	/*
+	Unlike 8-bit Apples, the IIgs does not redundantly scan video memory during
+	blanking.  The first five HBL cycles are used for Mega II "RAM refresh":
+	during these PH1 cycles (and everywhere after scanline 199) nothing is put
+	onto the data bus.  The floating value is instead the last byte fetched
+	during PH0, of the instruction which invoked this read.  For example:
+		LDA C050 returns C0 (typical softswitch)
+		LDA C250 returns C2 (ROM of a Your Card slot with no card)
+		LDA 50   returns 50 (with direct page C000)
+	*/
+	static bool recurse = false; // no recursion, single thread
+	if (!recurse && ((h_clock < 5) || (v_clock > 199)))
 	{
-		// scanner types
-		kScannerNone = 0, kScannerApple2, kScannerApple2e,
-
-		// scanner constants
-		kHBurstClock      =    53, // clock when Color Burst starts
-		kHBurstClocks     =     4, // clocks per Color Burst duration
-		kHClock0State     =  0x18, // H[543210] = 011000
-		kHClocks          =    65, // clocks per horizontal scan (including HBL)
-		kHPEClock         =    40, // clock when HPE (horizontal preset enable) goes low
-		kHPresetClock     =    41, // clock when H state presets
-		kHSyncClock       =    49, // clock when HSync starts
-		kHSyncClocks      =     4, // clocks per HSync duration
-		kNTSCScanLines    =   262, // total scan lines including VBL (NTSC)
-		kNTSCVSyncLine    =   224, // line when VSync starts (NTSC)
-		kPALScanLines     =   312, // total scan lines including VBL (PAL)
-		kPALVSyncLine     =   264, // line when VSync starts (PAL)
-		kVLine0State      = 0x100, // V[543210CBA] = 100000000
-		kVPresetLine      =   256, // line when V state presets
-		kVSyncLines       =     4, // lines per VSync duration
-		kClocksPerVSync   = kHClocks * kNTSCScanLines // FIX: NTSC only?
-	};
-
-	// vars
-	//
-	int i, Hires, Mixed, Page2, _80Store, ScanLines, /* VSyncLine, ScanCycles,*/
-		h_clock, h_state, h_0, h_1, h_2, h_3, h_4, h_5,
-		v_line, v_state, v_A, v_B, v_C, v_0, v_1, v_2, v_3, v_4, /* v_5, */
-		_hires, addend0, addend1, addend2, sum, address;
-
-	// video scanner data
-	//
-	i = m_maincpu->total_cycles() % kClocksPerVSync; // cycles into this VSync
-
-	// machine state switches
-	//
-	Hires    = (m_video->get_hires() && m_video->get_graphics()) ? 1 : 0;
-	Mixed    = m_video->get_mix() ? 1 : 0;
-	Page2    = m_video->get_page2() ? 1 : 0;
-	_80Store = m_video->get_80store() ? 1 : 0;
-
-	// calculate video parameters according to display standard
-	//
-	ScanLines  = 1 ? kNTSCScanLines : kPALScanLines; // FIX: NTSC only?
-	// VSyncLine  = 1 ? kNTSCVSyncLine : kPALVSyncLine; // FIX: NTSC only?
-	// ScanCycles = ScanLines * kHClocks;
-
-	// calculate horizontal scanning state
-	//
-	h_clock = (i + kHPEClock) % kHClocks; // which horizontal scanning clock
-	h_state = kHClock0State + h_clock; // H state bits
-	if (h_clock >= kHPresetClock) // check for horizontal preset
-	{
-		h_state -= 1; // correct for state preset (two 0 states)
-	}
-	h_0 = (h_state >> 0) & 1; // get horizontal state bits
-	h_1 = (h_state >> 1) & 1;
-	h_2 = (h_state >> 2) & 1;
-	h_3 = (h_state >> 3) & 1;
-	h_4 = (h_state >> 4) & 1;
-	h_5 = (h_state >> 5) & 1;
-
-	// calculate vertical scanning state
-	//
-	v_line  = i / kHClocks; // which vertical scanning line
-	v_state = kVLine0State + v_line; // V state bits
-	if ((v_line >= kVPresetLine)) // check for previous vertical state preset
-	{
-		v_state -= ScanLines; // compensate for preset
-	}
-	v_A = (v_state >> 0) & 1; // get vertical state bits
-	v_B = (v_state >> 1) & 1;
-	v_C = (v_state >> 2) & 1;
-	v_0 = (v_state >> 3) & 1;
-	v_1 = (v_state >> 4) & 1;
-	v_2 = (v_state >> 5) & 1;
-	v_3 = (v_state >> 6) & 1;
-	v_4 = (v_state >> 7) & 1;
-	//v_5 = (v_state >> 8) & 1;
-
-	// calculate scanning memory address
-	//
-	_hires = Hires;
-	if (Hires && Mixed && (v_4 & v_2))
-	{
-		_hires = 0; // (address is in text memory)
-	}
-
-	addend0 = 0x68; // 1            1            0            1
-	addend1 =              (h_5 << 5) | (h_4 << 4) | (h_3 << 3);
-	addend2 = (v_4 << 6) | (v_3 << 5) | (v_4 << 4) | (v_3 << 3);
-	sum     = (addend0 + addend1 + addend2) & (0x0F << 3);
-
-	address = 0;
-	address |= h_0 << 0; // a0
-	address |= h_1 << 1; // a1
-	address |= h_2 << 2; // a2
-	address |= sum;      // a3 - aa6
-	address |= v_0 << 7; // a7
-	address |= v_1 << 8; // a8
-	address |= v_2 << 9; // a9
-	address |= ((_hires) ? v_A : (1 ^ (Page2 & (1 ^ _80Store)))) << 10; // a10
-	address |= ((_hires) ? v_B : (Page2 & (1 ^ _80Store))) << 11; // a11
-	if (_hires) // hires?
-	{
-		// Y: insert hires only address bits
-		//
-		address |= v_C << 12; // a12
-		address |= (1 ^ (Page2 & (1 ^ _80Store))) << 13; // a13
-		address |= (Page2 & (1 ^ _80Store)) << 14; // a14
+		// approximate (for non-flow control instructions) by peeking at PC
+		offs_t pc = m_maincpu->pc();
+		// previous byte, wrapping at bank boundary
+		pc = (pc & 0xFF0000) | ((pc - 1) & 0xFFFF);
+		// prevent recursion via slot firmware or Mega II C07x
+		recurse = true;
+		u8 res = m_maincpu->space(AS_PROGRAM).read_byte(pc);
+		recurse = false;
+		return res;
 	}
 	else
 	{
-		// N: text, so no higher address bits unless Apple ][, not Apple //e
-		//
-		if ((1) && // Apple ][? // FIX: check for Apple ][? (FB is most useful in old games)
-			(kHPEClock <= h_clock) && // Y: HBL?
-			(h_clock <= (kHClocks - 1)))
-		{
-			address |= 1 << 12; // Y: a12 (add $1000 to address!)
-		}
+		const u32 address = m_video->scanner_address_GS(h_clock, v_clock);
+		return m_megaii_ram[address];
 	}
-
-	return m_megaii_ram[address % m_ram_size]; // FIX: this seems to work, but is it right!?
 }
 
 /***************************************************************************

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -1048,7 +1048,15 @@ TIMER_DEVICE_CALLBACK_MEMBER(apple2gs_state::apple2_interrupt)
 	}
 	else if (scanline == ((256+BORDER_TOP) % m_screen->height()))
 	{
-		// TODO: latch LANGSEL here to toggle NTSC/PAL
+		// LANGSEL is latched when wrapping scanline 256
+		const int height = m_video->is_pal_video_mode() ? 312 : 262;
+		if (height != m_screen->height())
+		{
+			// toggle 50/60 Hz, both use 65 1M cycles per scanline
+			m_screen->configure(m_screen->width(), height, m_screen->visible_area(), HZ_TO_ATTOSECONDS(A2GS_1M.dvalue() / (65 * height)));
+			if (scanline >= height)
+				scanline -= height;
+		}
 
 		// "quarter" second IRQ occurs every 16 frames, ~3.75 Hz
 		if ((m_screen->frame_number() & 0xf) == 0)

--- a/src/mame/apple/apple2video.cpp
+++ b/src/mame/apple/apple2video.cpp
@@ -403,7 +403,7 @@ void a2_video_device::delayed_update(int cycles)
 {
 	int hpos = screen().hpos() + (cycles - m_delay_bias) * m_scanner_period;
 	int vpos = screen().vpos();
-	if (hpos > screen().width())
+	if (hpos >= screen().width())
 	{
 		hpos -= screen().width();
 		vpos++;

--- a/src/mame/apple/apple2video.cpp
+++ b/src/mame/apple/apple2video.cpp
@@ -45,6 +45,7 @@ a2_video_device::a2_video_device(const machine_config &mconfig, device_type type
 	: device_t(mconfig, type, tag, owner, clock)
 	, device_palette_interface(mconfig, *this)
 	, device_video_interface(mconfig, *this)
+	, m_base_model(model::II)
 	, m_vidconfig(*this, "a2_video_config") {}
 
 a2_video_device::a2_video_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
@@ -56,11 +57,16 @@ a2_video_device_composite::a2_video_device_composite(const machine_config &mconf
 a2_video_device_composite_rgb::a2_video_device_composite_rgb(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: a2_video_device(mconfig, APPLE2_VIDEO_COMPOSITE_RGB, tag, owner, clock) {}
 
+ALLOW_SAVE_TYPE(a2_video_device::model);
+
 void a2_video_device::device_start()
 {
 	// initialise for device_palette_interface
 	init_palette();
 
+	save_item(NAME(m_base_model));
+	save_item(NAME(m_scanner_period));
+	save_item(NAME(m_delay_bias));
 	save_item(NAME(m_hgr2));
 	save_item(NAME(m_page2));
 	save_item(NAME(m_flash));
@@ -86,6 +92,10 @@ void a2_video_device::device_start()
 
 void a2_video_device::device_reset()
 {
+	// cache derived values for delayed updates
+	m_scanner_period = m_base_model == model::IIGS ? 16 : 14;
+	m_delay_bias = m_base_model == model::IIGS ? 0 : 1;
+
 	// Start in fullscreen hires if there is no character ROM. This is used
 	// by the superga2 and tk2000 drivers, which support no other modes.
 	m_graphics = m_hires = (m_char_ptr == nullptr);
@@ -108,7 +118,7 @@ void a2_video_device::txt_w(int state)
 	if (m_graphics == state) // avoid flickering from II+ refresh polling
 	{
 		// select graphics or text mode
-		screen().update_now();
+		delayed_update(3);
 		m_graphics = !state;
 	}
 }
@@ -118,7 +128,7 @@ void a2_video_device::mix_w(int state)
 	if (m_mix != state)
 	{
 		// select mixed or full mode
-		screen().update_now();
+		delayed_update(3);
 		m_mix = state;
 	}
 }
@@ -127,7 +137,7 @@ void a2_video_device::scr_w(int state)
 {
 	// select primary or secondary page
 	if (!m_80store && (m_page2 != state))
-		screen().update_now();
+		delayed_update(2);
 	m_page2 = state;
 }
 
@@ -136,7 +146,7 @@ void a2_video_device::res_w(int state)
 	if (m_hires != state)
 	{
 		// select lo-res or hi-res
-		screen().update_now();
+		delayed_update(m_base_model == model::IIGS ? 1 : 2);
 		m_hires = state;
 	}
 }
@@ -146,7 +156,7 @@ void a2_video_device::an2_w(int state)
 	if (m_an2 != state)
 	{
 		// select katakana on II_J_PLUS
-		screen().update_now();
+		delayed_update(1);
 		m_an2 = state;
 	}
 }
@@ -154,7 +164,7 @@ void a2_video_device::an2_w(int state)
 void a2_video_device::an3_w(int state)
 {
 	// select double hi-res
-	screen().update_now();
+	delayed_update(1);
 
 	// RGB cards shift in a mode bit on the rising edge
 	if ((m_dhires) && (state))
@@ -171,7 +181,7 @@ void a2_video_device::a80col_w(bool b80Col)
 	if (m_80col != b80Col)
 	{
 		// select 80 or 40 columns
-		screen().update_now();
+		delayed_update(1);
 		m_80col = b80Col;
 	}
 }
@@ -180,7 +190,7 @@ void a2_video_device::a80store_w(bool b80Store)
 {
 	// select PAGE2 aux RAM (displaying PAGE1)
 	if (m_page2 && (m_80store != b80Store))
-		screen().update_now();
+		delayed_update(2);
 	m_80store = b80Store;
 }
 
@@ -189,7 +199,7 @@ void a2_video_device::altcharset_w(bool altch)
 	if (m_altcharset != altch)
 	{
 		// select primary or alternate (MouseText) character set
-		screen().update_now();
+		delayed_update(1);
 		m_altcharset = altch;
 	}
 }
@@ -229,7 +239,7 @@ void a2_video_device::set_GS_langsel(u8 langsel)
 {
 	// select primary language character set
 	if ((m_GS_langsel & 0xe8) != (langsel & 0xe8))
-		screen().update_now();
+		delayed_update(1);
 	m_GS_langsel = langsel;
 }
 
@@ -270,6 +280,17 @@ public:
 
 } reverse_7_bits;
 
+void a2_video_device::delayed_update(int cycles)
+{
+	int hpos = screen().hpos() + (cycles - m_delay_bias) * m_scanner_period;
+	int vpos = screen().vpos();
+	if (hpos > screen().width())
+	{
+		hpos -= screen().width();
+		vpos++;
+	}
+	screen().update_partial(vpos, hpos);
+}
 
 inline bool a2_video_device::use_page_2() const { return m_page2 && !m_80store; }
 

--- a/src/mame/apple/apple2video.cpp
+++ b/src/mame/apple/apple2video.cpp
@@ -113,6 +113,125 @@ void a2_video_device::device_reset()
 	m_monochrome = 0; // TODO: only affects IIgs composite output
 }
 
+/*
+Calculate video scanner address for a given beam position,
+based on the current video mode state.
+Input: h_clock [0...64] with active video from 25,
+       v_clock [0..261/311], active video from 0.
+Callers may apply machine-specific cycle delays to the input,
+and machine-specific ram_size bounds to the output address.
+*/
+u16 a2_video_device::scanner_address(int h_clock, int v_clock)
+{
+	u16 address;
+
+	// vars
+	int Hires, Mixed, Page2,
+		h_state, h_0, h_1, h_2, h_3, h_4, h_5,
+		v_state, v_A, v_B, v_C, v_0, v_1, v_2, v_3, v_4,
+		addend0, addend1, addend2, sum;
+
+	// machine state switches
+	Hires = (m_hires && m_graphics) ? 1 : 0;
+	Mixed = m_mix ? 1 : 0;
+	Page2 = use_page_2() ? 1 : 0;
+
+	// calculate horizontal scanning state
+	h_state = h_clock - (h_clock > 0); // two 0 states: [0, 0...63]
+	h_0 = (h_state >> 0) & 1; // get horizontal state bits
+	h_1 = (h_state >> 1) & 1;
+	h_2 = (h_state >> 2) & 1;
+	h_3 = (h_state >> 3) & 1;
+	h_4 = (h_state >> 4) & 1;
+	h_5 = (h_state >> 5) & 1;
+
+	// calculate vertical scanning state
+	v_state = 256 + v_clock; // V[543210CBA] = 100000000
+	if (v_clock >= 256) // vertical overflow
+	{
+		v_state -= screen().height(); // compensate for preset
+	}
+	v_A = (v_state >> 0) & 1; // get vertical state bits
+	v_B = (v_state >> 1) & 1;
+	v_C = (v_state >> 2) & 1;
+	v_0 = (v_state >> 3) & 1;
+	v_1 = (v_state >> 4) & 1;
+	v_2 = (v_state >> 5) & 1;
+	v_3 = (v_state >> 6) & 1;
+	v_4 = (v_state >> 7) & 1;
+
+	// calculate scanning memory address
+	if (Hires && Mixed && v_4 && v_2)
+	{
+		Hires = 0; // address is in text memory for mixed hires
+	}
+
+	addend0 = 0x0D; // 1            1            0            1
+	addend1 =              (h_5 << 2) | (h_4 << 1) | (h_3 << 0);
+	addend2 = (v_4 << 3) | (v_3 << 2) | (v_4 << 1) | (v_3 << 0);
+	sum     = (addend0 + addend1 + addend2) & 0x0F;
+
+	address  = h_0 << 0; // a0
+	address |= h_1 << 1; // a1
+	address |= h_2 << 2; // a2
+	address |= sum << 3; // a3 - a6
+	address |= v_0 << 7; // a7
+	address |= v_1 << 8; // a8
+	address |= v_2 << 9; // a9
+	if (Hires)
+	{
+		// insert hires-only address bits
+		address |= v_A << 10; // a10
+		address |= v_B << 11; // a11
+		address |= v_C << 12; // a12
+		address |= Page2 ? m_hgr2 : 0x2000; // a13 - a15
+	}
+	else
+	{
+		// insert text-only address bits
+		address |= Page2 ? 0x0800 : 0x0400; // a10 - a11
+
+		if (m_base_model == model::II && (h_clock < 25)) // Apple II HBL
+		{
+			address |= 1 << 12; // a12 (add $1000)
+		}
+	}
+
+	return address;
+}
+
+u32 a2_video_device::scanner_address_GS(int h_clock, int v_clock)
+{
+	u32 address;
+
+	if (BIT(m_newvideo, 7))
+	{
+		// each SHR h_clock reads four bytes, only the last is visible to PH0
+		if (h_clock >= 25) // pixels
+		{
+			const u32 base = 0x16000 - 50 + 1;
+			address = base + (v_clock * 80) + (h_clock * 2);
+		}
+		else if ((h_clock >= 9) && (h_clock <= 16)) // palette
+		{
+			const u32 base = 0x19f00 - 18 + 1;
+			const u32 palette = m_shr_scbs[v_clock] & 0x0f;
+			address = base + (palette * 16) + (h_clock * 2);
+		}
+		else // SCB
+		{
+			const u32 base = 0x19e80;
+			address = base + (v_clock >> 1);
+		}
+	}
+	else // 8-bit modes per Sather, UTAIIe
+	{
+		address = scanner_address(h_clock, v_clock);
+	}
+
+	return address;
+}
+
 void a2_video_device::txt_w(int state)
 {
 	if (m_graphics == state) // avoid flickering from II+ refresh polling

--- a/src/mame/apple/apple2video.h
+++ b/src/mame/apple/apple2video.h
@@ -19,7 +19,7 @@ class a2_video_device : public device_t, public device_palette_interface, public
 {
 public:
 	// Models with different text-mode behavior. II includes the II+ and IIE includes the IIc and IIc Plus.
-	enum class model { II, IIE, PRAVETZ_8C, IIGS, II_J_PLUS, IVEL_ULTRA, DODO };
+	enum class model : u8 { II, II_J_PLUS, IVEL_ULTRA, DODO, IIE, PRAVETZ_8C, IIGS };
 
 	// construction/destruction
 	a2_video_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
@@ -65,6 +65,7 @@ public:
 	void set_GS_border_color(u8 color, u32 rgb) { m_GSborder_colors[color] = rgb; }
 	void set_SHR_scb(u8 shrline, u8 scb) { m_shr_scbs[shrline] = scb; }
 
+	void set_base_model(model base_model)       { m_base_model = base_model; }
 	void set_ram_pointers(u8 *main, u8 *aux)    { m_ram_ptr = main; m_aux_ptr = aux; }
 	void set_aux_mask(u16 aux_mask)             { m_aux_mask = aux_mask; }
 	void set_hgr2(u16 hgr2)                     { m_hgr2 = hgr2; }
@@ -102,6 +103,7 @@ private:
 
 	void render_line(uint16_t *out, uint16_t const *in, int startcol, int stopcol, bool monochrome, bool is_80_column);
 
+	void delayed_update(int cycles);
 	bool use_page_2() const;
 
 	bool composite_monitor();
@@ -131,6 +133,9 @@ private:
 	bool m_monohgr = false;
 	u8 m_GSfg = 0, m_GSbg = 0, m_GSborder = 0, m_newvideo = 0, m_GS_langsel = 0, m_monochrome = 0, m_rgbmode = 0;
 	u8 m_iie_langsw = 0; // language switch/modification on IIe/IIc/IIc+ and clones
+	u8 m_scanner_period;
+	u8 m_delay_bias;
+	model m_base_model;
 	optional_ioport m_vidconfig;
 };
 

--- a/src/mame/apple/apple2video.h
+++ b/src/mame/apple/apple2video.h
@@ -72,6 +72,9 @@ public:
 	void set_char_pointer(u8 *charptr, int size) { m_char_ptr = charptr; m_char_size = size; }
 	void setup_GS_graphics() { m_8bit_graphics = std::make_unique<bitmap_ind16>(560, 192); }
 
+	u16 scanner_address(int h_clock, int v_clock);
+	u32 scanner_address_GS(int h_clock, int v_clock);
+
 	template <model Model, bool Invert, bool Flip>
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 

--- a/src/mame/apple/tk2000.cpp
+++ b/src/mame/apple/tk2000.cpp
@@ -287,134 +287,18 @@ void tk2000_state::c100_w(offs_t offset, uint8_t data)
 	m_ram_ptr[offset + 0xc100] = data;
 }
 
-// floating bus code from old machine/apple2: needs to be reworked based on real beam position to enable e.g. Bob Bishop's screen splitter
 uint8_t tk2000_state::read_floatingbus()
 {
-	enum
-	{
-		// scanner types
-		kScannerNone = 0, kScannerApple2, kScannerApple2e,
+	int h_clock = m_screen->hpos() / 14 + 25; // adjust for set_raw
+	if (h_clock >= 65)
+		h_clock -= 65;
 
-		// scanner constants
-		kHBurstClock      =    53, // clock when Color Burst starts
-		kHBurstClocks     =     4, // clocks per Color Burst duration
-		kHClock0State     =  0x18, // H[543210] = 011000
-		kHClocks          =    65, // clocks per horizontal scan (including HBL)
-		kHPEClock         =    40, // clock when HPE (horizontal preset enable) goes low
-		kHPresetClock     =    41, // clock when H state presets
-		kHSyncClock       =    49, // clock when HSync starts
-		kHSyncClocks      =     4, // clocks per HSync duration
-		kNTSCScanLines    =   262, // total scan lines including VBL (NTSC)
-		kNTSCVSyncLine    =   224, // line when VSync starts (NTSC)
-		kPALScanLines     =   312, // total scan lines including VBL (PAL)
-		kPALVSyncLine     =   264, // line when VSync starts (PAL)
-		kVLine0State      = 0x100, // V[543210CBA] = 100000000
-		kVPresetLine      =   256, // line when V state presets
-		kVSyncLines       =     4, // lines per VSync duration
-		kClocksPerVSync   = kHClocks * kNTSCScanLines // FIX: NTSC only?
-	};
+	int v_clock = m_screen->vpos() + (h_clock < 25); // adjust for hpos wrap
+	if (v_clock >= m_screen->height())
+		v_clock -= m_screen->height();
 
-	// vars
-	//
-	int i, Hires, Mixed, Page2, _80Store, ScanLines, /* VSyncLine, ScanCycles,*/
-		h_clock, h_state, h_0, h_1, h_2, h_3, h_4, h_5,
-		v_line, v_state, v_A, v_B, v_C, v_0, v_1, v_2, v_3, v_4, /* v_5, */
-		_hires, addend0, addend1, addend2, sum, address;
-
-	// video scanner data
-	//
-	i = m_maincpu->total_cycles() % kClocksPerVSync; // cycles into this VSync
-
-	// machine state switches
-	//
-	Hires    = 1;
-	Mixed    = 0;
-	Page2 = m_video->get_page2() ? 1 : 0;
-	_80Store = 0;
-
-	// calculate video parameters according to display standard
-	//
-	ScanLines  = 1 ? kNTSCScanLines : kPALScanLines; // FIX: NTSC only?
-	// VSyncLine  = 1 ? kNTSCVSyncLine : kPALVSyncLine; // FIX: NTSC only?
-	// ScanCycles = ScanLines * kHClocks;
-
-	// calculate horizontal scanning state
-	//
-	h_clock = (i + kHPEClock) % kHClocks; // which horizontal scanning clock
-	h_state = kHClock0State + h_clock; // H state bits
-	if (h_clock >= kHPresetClock) // check for horizontal preset
-	{
-		h_state -= 1; // correct for state preset (two 0 states)
-	}
-	h_0 = (h_state >> 0) & 1; // get horizontal state bits
-	h_1 = (h_state >> 1) & 1;
-	h_2 = (h_state >> 2) & 1;
-	h_3 = (h_state >> 3) & 1;
-	h_4 = (h_state >> 4) & 1;
-	h_5 = (h_state >> 5) & 1;
-
-	// calculate vertical scanning state
-	//
-	v_line  = i / kHClocks; // which vertical scanning line
-	v_state = kVLine0State + v_line; // V state bits
-	if ((v_line >= kVPresetLine)) // check for previous vertical state preset
-	{
-		v_state -= ScanLines; // compensate for preset
-	}
-	v_A = (v_state >> 0) & 1; // get vertical state bits
-	v_B = (v_state >> 1) & 1;
-	v_C = (v_state >> 2) & 1;
-	v_0 = (v_state >> 3) & 1;
-	v_1 = (v_state >> 4) & 1;
-	v_2 = (v_state >> 5) & 1;
-	v_3 = (v_state >> 6) & 1;
-	v_4 = (v_state >> 7) & 1;
-	//v_5 = (v_state >> 8) & 1;
-
-	// calculate scanning memory address
-	//
-	_hires = Hires;
-	if (Hires && Mixed && (v_4 & v_2))
-	{
-		_hires = 0; // (address is in text memory)
-	}
-
-	addend0 = 0x68; // 1            1            0            1
-	addend1 =              (h_5 << 5) | (h_4 << 4) | (h_3 << 3);
-	addend2 = (v_4 << 6) | (v_3 << 5) | (v_4 << 4) | (v_3 << 3);
-	sum     = (addend0 + addend1 + addend2) & (0x0F << 3);
-
-	address = 0;
-	address |= h_0 << 0; // a0
-	address |= h_1 << 1; // a1
-	address |= h_2 << 2; // a2
-	address |= sum;      // a3 - aa6
-	address |= v_0 << 7; // a7
-	address |= v_1 << 8; // a8
-	address |= v_2 << 9; // a9
-	address |= ((_hires) ? v_A : (1 ^ (Page2 & (1 ^ _80Store)))) << 10; // a10
-	address |= ((_hires) ? v_B : (Page2 & (1 ^ _80Store))) << 11; // a11
-	if (_hires) // hires?
-	{
-		// Y: insert hires only address bits
-		//
-		address |= v_C << 12; // a12
-		address |= 1 << 13; // a13
-		address |= (Page2 & (1 ^ _80Store)) << 15; // a15, from a000
-	}
-	else
-	{
-		// N: text, so no higher address bits unless Apple ][, not Apple //e
-		//
-		if ((1) && // Apple ][? // FIX: check for Apple ][? (FB is most useful in old games)
-			(kHPEClock <= h_clock) && // Y: HBL?
-			(h_clock <= (kHClocks - 1)))
-		{
-			address |= 1 << 12; // Y: a12 (add $1000 to address!)
-		}
-	}
-
-	return m_ram_ptr[address % m_ram_size]; // FIX: this seems to work, but is it right!?
+	const u16 address = m_video->scanner_address(h_clock, v_clock);
+	return ram_r(address);
 }
 
 /***************************************************************************


### PR DESCRIPTION
(needs review, see RFC list)

This PR fixes [additional](https://github.com/mamedev/mame/pull/15073) timing-sensitive video interactions and enables 50Hz support:
* apple2video: emulate softswitch-specific delays
* apple2video: improve `read_floatingbus()`
* apple2gs: add 50Hz support
<br>
Code comments:<details>

To implement the video softswitch delays, I have slightly changed the core's `screen().update_now()`.  The alternative is to use a timer callback, and indeed for the 6502 machines this can work.  However I believe that a simple timer implementation _can not_ be correct for apple2gs; consider what should happen with this 65816 instruction:
`	LDA $C054`
If m=0, this is a 16-bit load accessing two adjacent softswitches, and [the operation of each cycle](https://www.brutaldeluxe.fr/documentation/cortland/v7%2065SC816%20opcodes%20Cycle%20by%20cycle%20listing.pdf#page=31) is:
1. 	fetch opcode
2. 	fetch address lo
3. 	fetch address hi
4. 	data read lo C054 (toggling PAGE1, visible on-screen two cycles later)
5. 	data read hi C055 (toggling PAGE2, visible on-screen two cycles later)

On hardware (with appropriate data and timing loop) this results in a one-cycle wide blip of PAGE1:
<img width="480" height="160" alt="Calibrate_16bit" src="https://github.com/user-attachments/assets/12961cfa-ce9f-4e31-bc4c-4ce2e5434a3a" />

A single timer can't implement this, because the second read would void and replace the first read's callback before it fires.  We could use two timers?  But what about more complex RMW instructions, like ASL, ROR, TRB, etc?  At that point, recognize that what we are really trying to accomplish is to flush pending video changes up to a time in the near (0...3 video cycles) future, and so modifying `update_now()` to allow that feels like the right approach.

Also for the softswitch delays, I have added the notion of an `m_base_model` to `a2_video_device`.  Previously, machine-specific video behavior has been either limited to the model-templated text rendering, or via [one-shot accessors](https://github.com/mamedev/mame/pull/14945/changes) like `set_hgr2`.  This PR uses `m_base_model` for machine-specific delays and floating bus behavior, but there are additional areas where it could be used to implement currently un-emulated quirks, which I feel don't fit well into templating:
- 	WNDW blanking at left edge of active video differs between ][+ and later
- 	80-column video placement differs between //e and IIgs
- 	lo-res 7M mode differs between //e and IIgs
- 	mode-change glitches differ between ][+, //e and IIgs

I have also re-ordered the `model` enums chronologically, which may benefit compilers' range-comparison codegen.

About the timing of each softswitch: some transitions show glitching on hardware.  This is not emulated, so the delay implemented here is only approximate.  I have assembled reference photos for many of these transitions across three classes of hardware, using [my VIDSYNC test](https://github.com/mamedev/mame/pull/15073#:~:text=now%20covers%20all%20video%20softswitches):
<img width="900" height="1280" alt="VIDSYNC_Latency_glitches" src="https://github.com/user-attachments/assets/c40ee0af-b0e2-4a52-af64-9c8a1f3a9b29" />
(thanks to @colinleroy for //c PAL and @whscullin for ][+ hardware testing)
<br>

The `read_floatingbus()` changes make five improvements:
- Replace four nearly-duplicate implementations with a shared one, which retains most of the old code, although I have cherry-picked some [later cleanup](https://github.com/AppleWin/AppleWin/commit/779d2d4385c1432d433cb3471c3d4a65c522ba8d).  
- The shared implementation's calling convention requires callers to pass the correct hpos/vpos and apply any machine-specific masking to the resulting RAM address.  This makes the shared implementation NTSC/PAL-agnostic, and removes the [incorrect dependency](https://github.com/mamedev/mame/pull/14053#:~:text=magically%20scan%20faster) on `m_maincpu->total_cycles()`, so now it is possible (with accelerator-aware software) for vaporlock to work on machines which run at > 1 MHz, instead of the addresses irreversibly drifting out of sync when the CPU clock speed changes.
- Making the callers correctly handle `hpos()` wrapping also fixes off-by-one bugs in the old code, so the scanned addresses during HBL now match hardware (see Testing details).
- The previous `(i + 63)` [hard-coded to fix some beam-racing demos](https://github.com/mamedev/mame/blame/4044303cd767b13f5490d69974cae6e8d0cd6f04/src/mame/apple/apple2.cpp#L655) by compensating for a specific softswitch delay is no longer needed, now that the softswitch-specific delays are implemented.
- apple2gs also adds emulation of the [open-bus Mega II cycles](https://www.brutaldeluxe.fr/documentation/cortland/v5/Cortland%20Custom%20ICs%20-%20Wayne%20Lowry%20-%20Preliminary%20notes%20-%2019860214.pdf#page=29).  This breaks [Lancaster-style vaporlock](https://www.tinaja.com/ebooks/enhance_vII.pdf#page=197), matching hardware behavior.  [Other vaporlock techniques](https://www.applefritter.com/content/transmitting-simple-datagram-video-vapor) which don't rely on UNUSED8 screen holes can still work on the IIgs.

The g65816 core does not track the most-recent-byte-fetched, so this apple2gs open-bus code approximately reconstructs it by peeking at the PC, which then has to avoid infinite loop recursion.  This is... not pretty.  But after I wrote that, I found almost identical patterns in the [Sega 315-5195](https://github.com/mamedev/mame/blob/286daa549752f459de0651c8b252d0e5193e5615/src/mame/sega/315_5195.cpp#L77) and the [SNES](https://github.com/mamedev/mame/blob/286daa549752f459de0651c8b252d0e5193e5615/src/mame/nintendo/snes_m.cpp#L225) (which looks broken to me? `m_maincpu->pc()` doesn't handle PB, also bank wrapping?)
<br>

After fixing [all](https://github.com/mamedev/mame/pull/14590) [the](https://github.com/mamedev/mame/pull/14749) [previous](https://github.com/mamedev/mame/pull/15073) timing interactions, the 50Hz changes are straightforwards, dynamically reconfiguring the screen when LANGSEL is latched (but see RFC section...)  Unlike the 8-bit PAL machines, no clock changes are needed for NTSC-50.

</details>
<br>
User-visible changes:<details>

The changes here are exemplified by Sather's "[Little Text Window](https://archive.org/details/Understanding_the_Apple_IIe/page/n67/mode/2up)".  In MAME 0.286 before the [HBL relative timing](https://github.com/mamedev/mame/pull/15073) fixes:
<img width="560" height="32" alt="SATHER LTW_ee_0286_clip" src="https://github.com/user-attachments/assets/37d7c519-9b32-410e-ab5b-ec4d0f2eb80c" />
In 0.287 before this PR:
<img width="560" height="32" alt="SATHER LTW_ee_0287_before_clip" src="https://github.com/user-attachments/assets/9b1bf53e-935e-4154-b70c-8732fef7bc88" />
After this PR:
<img width="560" height="32" alt="SATHER LTW_ee_0287_after_clip" src="https://github.com/user-attachments/assets/e325e572-b235-4387-86ed-9d29a2baedeb" />
The VIDMODES.po (in Testing details) includes a collection of these simple 3rd-party examples.
<br>

Similar changes are visible in real demos, like the center divider in Deater's Megademo:
<img width="560" height="384" alt="MEGADEMO_ee_287_before" src="https://github.com/user-attachments/assets/cdc2b858-9356-43cb-87ed-7c14bff73268" />
...is now missing (matching [hardware behavior](http://deater.net/weave/vmwprod/megademo/cycle_switching.html#:~:text=The%20Starring%20Scenes)):
<img width="560" height="384" alt="MEGADEMO_ee_287_after" src="https://github.com/user-attachments/assets/e54c2ed8-b584-4669-a938-f6f6b8a5ecfe" />
...and in CRAZY CYCLES II and other demos where page flips were previously occuring a couple cycles too far to the right.
<br>

On apple2gs, visible changes from fixing vaporlock drift are less subtle, for example the corruption on the [ending credits screen](https://github.com/AppleWin/AppleWin/issues/241#:~:text=A%20quick%20summary) of [French Touch](http://fr3nch.t0uch.free.fr/)'s ANSI STORY:
<img width="704" height="462" alt="ANSI_STORY_gs_287_before" src="https://github.com/user-attachments/assets/887f0c34-1b46-406c-8aac-d6e8bfd3f80e" />
...is now fixed:
<img width="704" height="462" alt="ANSI_STORY_gs_287_after" src="https://github.com/user-attachments/assets/ea885212-d26f-4c2e-816a-fc0a71473245" />
<br>

With 50Hz emulation in place, the Apple IIgs "Set system standards and 50 hertz" screen [via Ctrl-Option-Reset](https://savagetaylor.com/TIL/TIL02040.pdf) now works as expected.  There is apparently not much Apple IIgs software that _requires_ 50Hz, but one example is [Ninjaforce](https://www.ninjaforce.com/html/products.html)'s [Revenge of the Bobs](https://www.ninjaforce.com/html/products_revenge.html) demo, which at 2.8MHz has some missing vectorballs if run at 60Hz.

Other IIgs-aware and [Hz-aware](https://www.colino.net/wordpress/archives/2026/02/23/the-challenges-of-porting-shufflepuck-cafe-to-the-8-bits-apple-ii/#:~:text=one%20frame%20is%20dropped%20every%20sixth%20frame) examples are [Glider](https://www.colino.net/wordpress/glider-for-apple-ii/) and [Shufflepuck Cafe](https://www.colino.net/wordpress/shufflepuck-cafe-for-apple-ii/).

</details>
<br>
Testing:<details>

There are two disks of focused unit tests (source included):
[VidModes_260421.zip](https://github.com/user-attachments/files/26952329/VidModes_260421.zip)
[FloatBus_260630.zip](https://github.com/user-attachments/files/29534724/FloatBus_260630.zip)
(updated 260630, to remove the CFFF Sanity test after #15619)
<br>

A new VIDMODES test is a "beam-race all the things" dashboard, showing all softswitch latencies and glitches on one screen:
<img width="1024" height="768" alt="VIDMODES_gs_rgb" src="https://github.com/user-attachments/assets/87e681c4-d1d9-44ba-9ec8-ced05723cf66" />

Before this PR without the softswitch-specific delays, the alignments are off by a cycle or two:
<img width="420" height="260" alt="VIDMODES_ee_287_before_clip" src="https://github.com/user-attachments/assets/606194fe-6527-4cd5-9f4f-6e695e5ddbb2" />
After this PR:
<img width="420" height="260" alt="VIDMODES_ee_287_after_clip" src="https://github.com/user-attachments/assets/751a518f-60d3-4089-8f35-b5e929484793" />
...MAME now more closely aligns with hardware:
<img width="420" height="260" alt="VIDMODES_ee_composite_clip" src="https://github.com/user-attachments/assets/bc7773d6-567d-40ec-bcab-89997d463eaf" />
...except the transition glitches aren't emulated, and some 80-column delays are not quite right (see TODO section.)
Results are similar for apple2p. apple2gs was very broken before this PR, since the scanner address drift was unavoidable even when booting at 1 MHz.
<br>

Improvement is also visible in some older tests, which are included in the VIDMODES .po here:

My [previous VIDSYNC test](https://github.com/mamedev/mame/pull/15073#:~:text=updated%20again%20here) has been updated again with support for SCBIRQ sync and apple2jp katakana:
<img width="560" height="384" alt="VIDSYNC_2jp_katakana" src="https://github.com/user-attachments/assets/60822f30-58fc-4f2e-8b4e-bf91c513906c" />
After this PR, it now shows that previous minor alignment glitches are fixed on apple2p and apple2ee.  This test is still broken (out of sync rolling video) on apple2gs, due to [known g65816 timing bugs](https://github.com/mamedev/mame/blob/2b54531dc9a5e23b511a212554d2b4dfb18d1e14/src/devices/cpu/g65816/g65816.cpp#L81) (see TODO section.)

My [previous FLASHHZ test](https://github.com/mamedev/mame/pull/14554#:~:text=dynamically%20toggle) now shows apple2gs works correctly when toggling 50Hz.

My [previous LANGSEL test](https://github.com/mamedev/mame/pull/14590#:~:text=MAME%20must%20be%20running) now works even when not run at 1 MHz, minor alignment glitches are fixed, and apple2gs works correctly when toggling 50Hz.

My [previous IRQTEST test](https://github.com/mamedev/mame/pull/14749#:~:text=updated%20here) now shows that apple2gs 1/4 second IRQs work with both 60 and 50Hz display timings.

My [previous BEAMPOS test](https://github.com/mamedev/mame/pull/15073#:~:text=BEAMPOS%20analytically%20validates) now shows the PAL and F-BUS failures on apple2gs are fixed.  Only the 16BIT failure remains (because MAME's g65816 core is not cycle-exact, it [reads lo and hi bytes on the same cycle](https://github.com/mamedev/mame/blob/49f29790a37ece6aaaeb9f50463f1a040500b21b/src/devices/cpu/g65816/g65816.cpp#L310)...)

Updated versions of my [previous CALIBRATE tests](https://github.com/mamedev/mame/pull/15073#:~:text=simple%20calibration%20gauges) are also included: VPR serves as a negative test for Lancaster-style vaporlock on the IIgs, and GS16BIT demonstrates the adjacent softswitch access pictured above in the code comments.
<br>

Also included is a 3rd-party EXAMPLES folder of classic and more recent beam-racing and floating bus tests:
- BISHOP.SPLIT
- SATHER.SPLIT
- SATHER.UNDER
- SATHER.WINDOW
- MMPHOS.RAINBOW
- QKUMBA.JSRC050
- QKUMBA.JSRC000
- ELLIOT.KILLER
- ELLIOT.WINDOW

These have each been modified to improve compatibility (NTSC/PAL support, VBL differences, disabling Zip Chip, etc) and to make them runnable in sequence from a menu.
<br>

A new FLOATBUS test is a self-driving suite that iterates through every relevant video mode, and:
* draws a test pattern designed to highlight the memory layout of that mode
* reads the entire NTSC/PAL video scan-out via floating bus
* spot-checks a handful of pixels in locations prone to off-by-one errors
* compresses the snapshot and saves it to disk for offline inspection

The snapshots can be converted to GIF on a modern machine.  Mac (fat, unsigned) snap2gif tool and (posix-y) source is included.

The test is aware of ][+ and IIgs-specific floating bus behavior, and produces a set of 9 (or 11 on the IIgs) images, like these:
<img width="910" height="524" alt="P4 HGR2 MIX 60_spotcheck_overlay" src="https://github.com/user-attachments/assets/02487d67-fe08-407f-8ae4-53802ee8017a" />
<img width="910" height="524" alt="P7 GR MIX 60" src="https://github.com/user-attachments/assets/ba4c798b-61d0-476f-8f9b-cc137a03eb10" />
<img width="520" height="312" alt="PB SHR DP 50" src="https://github.com/user-attachments/assets/7ae0f020-0f67-4c46-b155-8b6e19ef4e36" />
(These examples were captured from //e Enhanced and IIgs ROM3 hardware.  HBL/VBL are visualized in gray, open-bus cycles in pink.  Spot-checked locations are circled in yellow in the first image.)

This allows visualization and debugging of the HBL/VBL memory layout, as described by [Bob Bishop](https://web.archive.org/web/20251017162803/http://rich12345.tripod.com/aiivideo/softalk.html#:~:text=Cycle%2Dby%2Dcycle%20map%20of%20video%20frame) and [Jim Sather](https://archive.org/details/understanding_the_apple_ii/page/n99/mode/2up).

Note that 80-column modes are not iterated, as testing shows Sather is correct (in [UTA2e:5-42 point 10](https://archive.org/details/Understanding_the_Apple_IIe/page/n147/mode/2up)) in that AUX memory read by the video scanner is never put on the data bus visible to the CPU.  There is instead some minimal negative testing to show that C00D 80VID doesn't alter the floating bus behavior.  AFAICT, deciphering the floating bus behavior of IIgs SHR video (the SCB, palette, and open-bus timing) is [original research](https://apple2infinitum.slack.com/archives/CPSGNGE05/p1768961181991359?thread_ts=1768922592.450429&cid=CPSGNGE05) not implemented in any other emulator.

Before this PR, apple2gs failed this test completely, due to the video scanner drifting out of sync.  apple2p and apple2e machines mostly worked, but failed spotcheck <i>#</i>4 due to an off-by-one in the HBL: `read_floatingbus()` shifted the hpos over two cycles, but didn't handle the overflow into vpos, so most of HBL was incorrectly shifted down one scanline:
<img width="910" height="524" alt="P4 HGR2 MIX 60_ee_287_broken" src="https://github.com/user-attachments/assets/900dd392-1b3d-4b3c-a33c-293e52080f7a" />

After this PR, all spotchecks now pass except for <i>#</i>6 on apple2p/apple2e.  This is a literal corner-case, caused by a bug in MAME's scheduler (see RFC section.)  Both before and after this PR, there is also a sanity-test failure reading CFFF CLRROM (see TODO section.)

More generally, even the "[emulator-killer](https://apple2infinitum.slack.com/archives/CA8AT5886/p1570821404081200)" qkumba examples [executing softswitches](https://apple2infinitum.slack.com/archives/C055PTN6VC7/p1700746051242479) work correctly (at least with the cycle-accurate 6502 core; the g65816 reads operands on the wrong cycles...)

</details>
<br>
TODO:<details>

* Certain glitch-less 80-column video transitions (C02B LANGSEL, C029 MONO bit, C00F ALTCHAR) actually occur seven 14M cycles later on hardware.  This PR does not attempt to address this, as fixing it would need invasive changes to [render_line*](https://github.com/mamedev/mame/blob/218cf0d247a51d96ae1c77752d116659be976c8c/src/mame/apple/apple2video.cpp#L355) and the various [clipping assumptions](https://github.com/mamedev/mame/blob/218cf0d247a51d96ae1c77752d116659be976c8c/src/mame/apple/apple2video.cpp#L622).  Perhaps revisit this if 80-column placement (for apple2e) is fixed.

* CFFF CLRROM has some edge-case behavior which may require a2bus changes to make it pedantically correct, so is not dealt with here.

* apple2gs now accurately implements SHR floating bus behavior, and the open-bus behavior of the Mega II memory refresh cycles.  However on hardware, non-SHR modes show a rolling pattern (out of sync with the video refresh) during the rest of the HBL/VBL cycles.  This is not yet understood.

* Although this collection of PRs fix many subtle video timing behaviors, apple2gs still has [CPU](https://github.com/mamedev/mame/blob/218cf0d247a51d96ae1c77752d116659be976c8c/src/devices/cpu/g65816/g65816.cpp#L81) and [FPI](https://github.com/mamedev/mame/commit/53a0ae7d11b82ab13564f2c82f43407337343d67) timing problems which break VIDSYNC, QKUMBA.JSRC050, the ECC demo's border effects, TextFunk, 3200 color mode, etc.
</details>
