### PR TITLE
Commodore: added machine configuration switch in C16, C64, C128 and C65 to swap joystick ports on the fly, avoiding the need to reset the machine when loading a game that requires joystick to be in the opposite port to the one we plugged it in

### DIFF
--- a/src/mame/commodore/c128.cpp
+++ b/src/mame/commodore/c128.cpp
@@ -78,6 +78,7 @@ public:
 		m_lock(*this, "LOCK"),
 		m_caps(*this, "CAPS"),
 		m_40_80(*this, "40_80"),
+		m_portswap(*this, "JOYSWAP"),
 		m_z80en(0),
 		m_loram(1),
 		m_hiram(1),
@@ -122,6 +123,7 @@ public:
 	required_ioport m_lock;
 	required_ioport m_caps;
 	required_ioport m_40_80;
+	optional_ioport m_portswap;
 
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
@@ -851,6 +853,11 @@ static INPUT_PORTS_START( c128 )
 
 	PORT_START( "40_80" )
 	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD ) PORT_NAME("40/80 DISPLAY") PORT_CODE(KEYCODE_F11) PORT_TOGGLE
+
+	PORT_START( "JOYSWAP" )
+	PORT_CONFNAME( 0x01, 0x00, "Swap joystick ports" )
+	PORT_CONFSETTING( 0x01, "Joystick in swapped port" )
+	PORT_CONFSETTING( 0x00, "Joystick in assigned port" )
 INPUT_PORTS_END
 
 
@@ -1112,23 +1119,25 @@ void c128_state::vic_k_w(uint8_t data)
 uint8_t c128_state::sid_potx_r()
 {
 	uint8_t data = 0xff;
+	vcs_control_port_device *cur1 = m_portswap->read() ? m_joy2 : m_joy1;
+	vcs_control_port_device *cur2 = m_portswap->read() ? m_joy1 : m_joy2;
 
 	switch (m_cia1->pa_r() >> 6)
 	{
-	case 1: data = m_joy1->read_pot_x(); break;
-	case 2: data = m_joy2->read_pot_x(); break;
+	case 1: data = cur1->read_pot_x(); break;
+	case 2: data = cur2->read_pot_x(); break;
 	case 3:
-		if (m_joy1->has_pot_x() && m_joy2->has_pot_x())
+		if (cur1->has_pot_x() && cur2->has_pot_x())
 		{
-			data = 1 / (1 / m_joy1->read_pot_x() + 1 / m_joy2->read_pot_x());
+			data = 1 / (1 / cur1->read_pot_x() + 1 / cur2->read_pot_x());
 		}
-		else if (m_joy1->has_pot_x())
+		else if (cur1->has_pot_x())
 		{
-			data = m_joy1->read_pot_x();
+			data = cur1->read_pot_x();
 		}
-		else if (m_joy2->has_pot_x())
+		else if (cur2->has_pot_x())
 		{
-			data = m_joy2->read_pot_x();
+			data = cur2->read_pot_x();
 		}
 		break;
 	}
@@ -1139,23 +1148,25 @@ uint8_t c128_state::sid_potx_r()
 uint8_t c128_state::sid_poty_r()
 {
 	uint8_t data = 0xff;
+	vcs_control_port_device *cur1 = m_portswap->read() ? m_joy2 : m_joy1;
+	vcs_control_port_device *cur2 = m_portswap->read() ? m_joy1 : m_joy2;
 
 	switch (m_cia1->pa_r() >> 6)
 	{
-	case 1: data = m_joy1->read_pot_y(); break;
-	case 2: data = m_joy2->read_pot_y(); break;
+	case 1: data = cur1->read_pot_y(); break;
+	case 2: data = cur2->read_pot_y(); break;
 	case 3:
-		if (m_joy1->has_pot_y() && m_joy2->has_pot_y())
+		if (cur1->has_pot_y() && cur2->has_pot_y())
 		{
-			data = 1 / (1 / m_joy1->read_pot_y() + 1 / m_joy2->read_pot_y());
+			data = 1 / (1 / cur1->read_pot_y() + 1 / cur2->read_pot_y());
 		}
-		else if (m_joy1->has_pot_y())
+		else if (cur1->has_pot_y())
 		{
-			data = m_joy1->read_pot_y();
+			data = cur1->read_pot_y();
 		}
-		else if (m_joy2->has_pot_y())
+		else if (cur2->has_pot_y())
 		{
-			data = m_joy2->read_pot_y();
+			data = cur2->read_pot_y();
 		}
 		break;
 	}
@@ -1186,9 +1197,10 @@ uint8_t c128_state::cia1_pa_r()
 	*/
 
 	uint8_t data = 0xff;
+	vcs_control_port_device *cur2 = m_portswap->read() ? m_joy1 : m_joy2;
 
 	// joystick
-	uint8_t joy_b = m_joy2->read_joy();
+	uint8_t joy_b = cur2->read_joy();
 
 	data &= (0xf0 | (joy_b & 0x0f));
 	data &= ~(!BIT(joy_b, 5) << 4);
@@ -1233,7 +1245,8 @@ void c128_state::cia1_pa_w(uint8_t data)
 
 	*/
 
-	m_joy2->joy_w(data & 0x1f);
+	vcs_control_port_device *cur2 = m_portswap->read() ? m_joy1 : m_joy2;
+	cur2->joy_w(data & 0x1f);
 }
 
 uint8_t c128_state::cia1_pb_r()
@@ -1254,9 +1267,10 @@ uint8_t c128_state::cia1_pb_r()
 	*/
 
 	uint8_t data = 0xff;
+	vcs_control_port_device *cur1 = m_portswap->read() ? m_joy2 : m_joy1;
 
 	// joystick
-	uint8_t joy_a = m_joy1->read_joy();
+	uint8_t joy_a = cur1->read_joy();
 
 	data &= (0xf0 | (joy_a & 0x0f));
 	data &= ~(!BIT(joy_a, 5) << 4);
@@ -1297,7 +1311,9 @@ void c128_state::cia1_pb_w(uint8_t data)
 
 	*/
 
-	m_joy1->joy_w(data & 0x1f);
+	vcs_control_port_device *cur1 = m_portswap->read() ? m_joy2 : m_joy1;
+
+	cur1->joy_w(data & 0x1f);
 
 	m_vic->lp_w(BIT(data, 4));
 }

--- a/src/mame/commodore/c64.cpp
+++ b/src/mame/commodore/c64.cpp
@@ -70,6 +70,7 @@ public:
 		m_color_ram(*this, "color_ram", 0x400, ENDIANNESS_LITTLE),
 		m_row(*this, "ROW%u", 0),
 		m_lock(*this, "LOCK"),
+		m_portswap(*this, "JOYSWAP"),
 		m_loram(1),
 		m_hiram(1),
 		m_charen(1),
@@ -101,6 +102,7 @@ public:
 	memory_share_creator<uint8_t> m_color_ram;
 	optional_ioport_array<8> m_row;
 	optional_ioport m_lock;
+	optional_ioport m_portswap;
 
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
@@ -844,6 +846,11 @@ static INPUT_PORTS_START( c64 )
 	PORT_START( "LOCK" )
 	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_KEYBOARD ) PORT_NAME("SHIFT LOCK") PORT_CODE(KEYCODE_CAPSLOCK) PORT_TOGGLE PORT_CHAR(UCHAR_MAMEKEY(CAPSLOCK))
 	PORT_BIT( 0x7f, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START( "JOYSWAP" )
+	PORT_CONFNAME( 0x01, 0x00, "Swap joystick ports" )
+	PORT_CONFSETTING( 0x01, "Joystick in swapped port" )
+	PORT_CONFSETTING( 0x00, "Joystick in assigned port" )
 INPUT_PORTS_END
 
 
@@ -874,6 +881,11 @@ INPUT_PORTS_END
 
 static INPUT_PORTS_START( c64gs )
 	// no keyboard
+
+	PORT_START( "JOYSWAP" )
+	PORT_CONFNAME( 0x01, 0x00, "Switch joystick ports" )
+	PORT_CONFSETTING( 0x01, "Joystick in switched port" )
+	PORT_CONFSETTING( 0x00, "Joystick in assigned port" )
 INPUT_PORTS_END
 
 
@@ -899,23 +911,25 @@ INPUT_PORTS_END
 uint8_t c64_state::sid_potx_r()
 {
 	uint8_t data = 0xff;
+	vcs_control_port_device *cur1 = m_portswap->read() ? m_joy2 : m_joy1;
+	vcs_control_port_device *cur2 = m_portswap->read() ? m_joy1 : m_joy2;
 
 	switch (m_cia1->pa_r() >> 6)
 	{
-	case 1: data = m_joy1->read_pot_x(); break;
-	case 2: data = m_joy2->read_pot_x(); break;
+	case 1: data = cur1->read_pot_x(); break;
+	case 2: data = cur2->read_pot_x(); break;
 	case 3:
-		if (m_joy1->has_pot_x() && m_joy2->has_pot_x())
+		if (cur1->has_pot_x() && cur2->has_pot_x())
 		{
-			data = 1 / (1 / m_joy1->read_pot_x() + 1 / m_joy2->read_pot_x());
+			data = 1 / (1 / cur1->read_pot_x() + 1 / cur2->read_pot_x());
 		}
-		else if (m_joy1->has_pot_x())
+		else if (cur1->has_pot_x())
 		{
-			data = m_joy1->read_pot_x();
+			data = cur1->read_pot_x();
 		}
-		else if (m_joy2->has_pot_x())
+		else if (cur2->has_pot_x())
 		{
-			data = m_joy2->read_pot_x();
+			data = cur2->read_pot_x();
 		}
 		break;
 	}
@@ -926,23 +940,25 @@ uint8_t c64_state::sid_potx_r()
 uint8_t c64_state::sid_poty_r()
 {
 	uint8_t data = 0xff;
+	vcs_control_port_device *cur1 = m_portswap->read() ? m_joy2 : m_joy1;
+	vcs_control_port_device *cur2 = m_portswap->read() ? m_joy1 : m_joy2;
 
 	switch (m_cia1->pa_r() >> 6)
 	{
-	case 1: data = m_joy1->read_pot_y(); break;
-	case 2: data = m_joy2->read_pot_y(); break;
+	case 1: data = cur1->read_pot_y(); break;
+	case 2: data = cur2->read_pot_y(); break;
 	case 3:
-		if (m_joy1->has_pot_y() && m_joy2->has_pot_y())
+		if (cur1->has_pot_y() && cur2->has_pot_y())
 		{
-			data = 1 / (1 / m_joy1->read_pot_y() + 1 / m_joy2->read_pot_y());
+			data = 1 / (1 / cur1->read_pot_y() + 1 / cur2->read_pot_y());
 		}
-		else if (m_joy1->has_pot_y())
+		else if (cur1->has_pot_y())
 		{
-			data = m_joy1->read_pot_y();
+			data = cur1->read_pot_y();
 		}
-		else if (m_joy2->has_pot_y())
+		else if (cur2->has_pot_y())
 		{
-			data = m_joy2->read_pot_y();
+			data = cur2->read_pot_y();
 		}
 		break;
 	}
@@ -973,9 +989,10 @@ uint8_t c64_state::cia1_pa_r()
 	*/
 
 	uint8_t data = 0xff;
+	vcs_control_port_device *cur2 = m_portswap->read() ? m_joy1 : m_joy2;
 
 	// joystick
-	uint8_t joy_b = m_joy2->read_joy();
+	uint8_t joy_b = cur2->read_joy();
 
 	data &= (0xf0 | (joy_b & 0x0f));
 	data &= ~(!BIT(joy_b, 5) << 4);
@@ -1041,9 +1058,10 @@ uint8_t c64_state::cia1_pb_r()
 	*/
 
 	uint8_t data = 0xff;
+	vcs_control_port_device *cur1 = m_portswap->read() ? m_joy2 : m_joy1;
 
 	// joystick
-	uint8_t joy_a = m_joy1->read_joy();
+	uint8_t joy_a = cur1->read_joy();
 
 	data &= (0xf0 | (joy_a & 0x0f));
 	data &= ~(!BIT(joy_a, 5) << 4);
@@ -1079,8 +1097,9 @@ void c64_state::cia1_pb_w(uint8_t data)
 	    PB7     ROW7
 
 	*/
+	vcs_control_port_device *cur1 = m_portswap->read() ? m_joy2 : m_joy1;
 
-	m_joy1->joy_w(data & 0x1f);
+	cur1->joy_w(data & 0x1f);
 
 	m_vic->lp_w(BIT(data, 4));
 }
@@ -1103,9 +1122,10 @@ uint8_t c64gs_state::cia1_pa_r()
 	*/
 
 	uint8_t data = 0xff;
+	vcs_control_port_device *cur2 = m_portswap->read() ? m_joy1 : m_joy2;
 
 	// joystick
-	uint8_t joy_b = m_joy2->read_joy();
+	uint8_t joy_b = cur2->read_joy();
 
 	data &= (0xf0 | (joy_b & 0x0f));
 	data &= ~(!BIT(joy_b, 5) << 4);
@@ -1131,9 +1151,10 @@ uint8_t c64gs_state::cia1_pb_r()
 	*/
 
 	uint8_t data = 0xff;
+	vcs_control_port_device *cur1 = m_portswap->read() ? m_joy2 : m_joy1;
 
 	// joystick
-	uint8_t joy_a = m_joy1->read_joy();
+	uint8_t joy_a = cur1->read_joy();
 
 	data &= (0xf0 | (joy_a & 0x0f));
 	data &= ~(!BIT(joy_a, 5) << 4);

--- a/src/mame/commodore/c65.cpp
+++ b/src/mame/commodore/c65.cpp
@@ -324,6 +324,7 @@ public:
 		, m_ipl_rom(*this, "ipl")
 		, m_cart_exp(*this, "cart_exp")
 		, m_exrom_view(*this, "exrom_view")
+		, m_portswap(*this, "JOYSWAP")
 	{ }
 
 	void init_c65();
@@ -367,6 +368,7 @@ private:
 	required_memory_region m_ipl_rom;
 	required_device<generic_slot_device> m_cart_exp;
 	memory_view m_exrom_view;
+	optional_ioport m_portswap;
 
 	uint8_t m_keyb_input[10]{};
 	uint8_t m_keyb_c0_c7 = 0U;
@@ -1097,9 +1099,10 @@ void c65_state::uart_w(offs_t offset, uint8_t data)
 uint8_t c65_state::cia0_porta_r()
 {
 	uint8_t res = 0xff;
+	int cur_joy = m_portswap->read() ? 0 : 1;
 
 	// joystick
-	uint8_t joy_b = m_joy[1]->read_joy();
+	uint8_t joy_b = m_joy[cur_joy]->read_joy();
 
 	res &= (0xf0 | (joy_b & 0x0f));
 	res &= ~(!BIT(joy_b, 5) << 4);
@@ -1112,10 +1115,11 @@ uint8_t c65_state::cia0_portb_r()
 {
 	static const char *const c64ports[] = { "C0", "C1", "C2", "C3", "C4", "C5", "C6", "C7" };
 	static const char *const c65ports[] = { "C8", "C9" };
+	int cur_joy = m_portswap->read() ? 1 : 0;
 	uint8_t res;
 
 	res = 0xff;
-	uint8_t joy_a = m_joy[0]->read_joy();
+	uint8_t joy_a = m_joy[cur_joy]->read_joy();
 
 	res &= (0xf0 | (joy_a & 0x0f));
 	res &= ~(!BIT(joy_a, 5) << 4);
@@ -1141,15 +1145,16 @@ uint8_t c65_state::cia0_portb_r()
 
 void c65_state::cia0_porta_w(uint8_t data)
 {
+	int cur_joy = m_portswap->read() ? 0 : 1;
 	m_keyb_c0_c7 = ~data;
-	m_joy[1]->joy_w(data & 0x1f);
+	m_joy[cur_joy]->joy_w(data & 0x1f);
 //  logerror("%02x\n",m_keyb_c0_c7);
 }
 
 void c65_state::cia0_portb_w(uint8_t data)
 {
-	m_joy[0]->joy_w(data & 0x1f);
-
+	int cur_joy = m_portswap->read() ? 1 : 0;
+	m_joy[cur_joy]->joy_w(data & 0x1f);
 }
 
 /*
@@ -1323,6 +1328,11 @@ static INPUT_PORTS_START( c65 )
 
 	PORT_START("CAPS")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_KEYBOARD ) PORT_NAME("CAPS LOCK") PORT_CODE(KEYCODE_F8) PORT_TOGGLE
+
+	PORT_START( "JOYSWAP" )
+	PORT_CONFNAME( 0x01, 0x00, "Swap joystick ports" )
+	PORT_CONFSETTING( 0x01, "Joystick in swapped port" )
+	PORT_CONFSETTING( 0x00, "Joystick in assigned port" )
 INPUT_PORTS_END
 
 

--- a/src/mame/commodore/plus4.cpp
+++ b/src/mame/commodore/plus4.cpp
@@ -73,6 +73,7 @@ public:
 		m_c2(*this, "c2"),
 		m_row(*this, "ROW%u", 0),
 		m_lock(*this, "LOCK"),
+		m_portswap(*this, "JOYSWAP"),
 		m_addr(0)
 	{ }
 
@@ -100,6 +101,7 @@ protected:
 	optional_memory_region m_c2;
 	required_ioport_array<8> m_row;
 	required_ioport m_lock;
+	optional_ioport m_portswap;
 
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
@@ -570,6 +572,11 @@ static INPUT_PORTS_START( plus4 )
 	PORT_START( "LOCK" )
 	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_KEYBOARD ) PORT_NAME("SHIFT LOCK") PORT_CODE(KEYCODE_CAPSLOCK) PORT_TOGGLE PORT_CHAR(UCHAR_MAMEKEY(CAPSLOCK))
 	PORT_BIT( 0x7f, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START( "JOYSWAP" )
+	PORT_CONFNAME( 0x01, 0x00, "Swap joystick ports" )
+	PORT_CONFSETTING( 0x01, "Joystick in swapped port" )
+	PORT_CONFSETTING( 0x00, "Joystick in assigned port" )
 INPUT_PORTS_END
 
 
@@ -726,11 +733,13 @@ uint8_t plus4_state::ted_k_r(offs_t offset)
 	*/
 
 	uint8_t data = 0xff;
+	vcs_control_port_device *cur1 = m_portswap->read() ? m_joy2 : m_joy1;
+	vcs_control_port_device *cur2 = m_portswap->read() ? m_joy1 : m_joy2;
 
 	// joystick
 	if (!BIT(offset, 2))
 	{
-		uint8_t joy_a = m_joy1->read_joy();
+		uint8_t joy_a = cur1->read_joy();
 
 		data &= (0xf0 | (joy_a & 0x0f));
 		data &= ~(!BIT(joy_a, 5) << 6);
@@ -738,7 +747,7 @@ uint8_t plus4_state::ted_k_r(offs_t offset)
 
 	if (!BIT(offset, 1))
 	{
-		uint8_t joy_b = m_joy2->read_joy();
+		uint8_t joy_b = cur2->read_joy();
 
 		data &= (0xf0 | (joy_b & 0x0f));
 		data &= ~(!BIT(joy_b, 5) << 7);


### PR DESCRIPTION
Quality of life improvement asked by some friends