### PR TITLE
emu/debug/dvmemory.cpp: Recomputing memory view based on evaluated start address value.

### DIFF
--- a/src/emu/debug/dvmemory.cpp
+++ b/src/emu/debug/dvmemory.cpp
@@ -717,11 +717,18 @@ bool debug_view_memory::needs_recompute()
 {
 	bool recompute = m_recompute;
 
+	offs_t val = m_expression.value();
+	// checks if evaluated expression value has changed since last time
+	if (val != m_expression_computed)
+	{
+		m_expression_computed = val;
+		m_expression.mark_dirty();
+	}
+
 	// handle expression changes
 	if (m_expression.dirty())
 	{
 		const debug_view_memory_source &source = downcast<const debug_view_memory_source &>(*m_source);
-		offs_t val = m_expression.value();
 		if (source.m_memintf)
 		{
 			const address_space_config *config = m_no_translation ? source.m_memintf->space_config(source.m_spacenum) : source.m_memintf->logical_space_config(source.m_spacenum);

--- a/src/emu/debug/dvmemory.h
+++ b/src/emu/debug/dvmemory.h
@@ -134,6 +134,7 @@ private:
 
 	// internal state
 	debug_view_expression m_expression;         // expression describing the start address
+	offs_t              m_expression_computed;  // latest value of computed expression
 	u32                 m_chunks_per_row;       // number of chunks displayed per line
 	u8                  m_bytes_per_chunk;      // bytes per chunk
 	u8                  m_steps_per_chunk;      // bytes per chunk


### PR DESCRIPTION
Memory View start address input allows to use expression (easiest to try `PC`), but content of the view is not updated if evaluated value changed.
This PR brings this updates.
