### PR TITLE
apple2video: fix -aux std80 crash 

### DIFF
--- a/src/devices/bus/a2bus/a2eauxslot.h
+++ b/src/devices/bus/a2bus/a2eauxslot.h
@@ -110,7 +110,6 @@ public:
 	virtual u8 *get_vram_ptr() = 0;
 	virtual u8 *get_auxbank_ptr() = 0;
 	virtual u16 get_auxbank_mask() = 0;
-	virtual bool allow_dhr() { return true; }
 
 	device_a2eauxslot_card_interface *next() const { return m_next; }
 

--- a/src/devices/bus/a2bus/a2eext80col.h
+++ b/src/devices/bus/a2bus/a2eext80col.h
@@ -38,7 +38,6 @@ protected:
 	virtual u8 *get_vram_ptr() override;
 	virtual u8 *get_auxbank_ptr() override;
 	virtual u16 get_auxbank_mask() override;
-	virtual bool allow_dhr() override { return true; }
 
 private:
 	u8 m_ram[64*1024];

--- a/src/devices/bus/a2bus/a2eramworks3.h
+++ b/src/devices/bus/a2bus/a2eramworks3.h
@@ -36,7 +36,6 @@ protected:
 	virtual u8 *get_vram_ptr() override;
 	virtual u8 *get_auxbank_ptr() override;
 	virtual u16 get_auxbank_mask() override;
-	virtual bool allow_dhr() override { return true; }
 	virtual void write_c07x(u8 offset, u8 data) override;
 
 	int m_bank;

--- a/src/devices/bus/a2bus/a2estd80col.cpp
+++ b/src/devices/bus/a2bus/a2estd80col.cpp
@@ -4,7 +4,7 @@
 
     a2estd80col.cpp
 
-    Apple IIe Standard 80 Column Card (2K of RAM, no double-hi-res)
+    Apple IIe Standard 80 Column Card (1K of RAM, no double-hi-res)
 
 *********************************************************************/
 

--- a/src/devices/bus/a2bus/a2estd80col.h
+++ b/src/devices/bus/a2bus/a2estd80col.h
@@ -38,7 +38,6 @@ protected:
 	virtual u8 *get_vram_ptr() override;
 	virtual u8 *get_auxbank_ptr() override;
 	virtual u16 get_auxbank_mask() override;
-	virtual bool allow_dhr() override { return false; }  // we don't allow DHR
 
 private:
 	u8 m_ram[0x400];

--- a/src/mame/apple/apple2video.cpp
+++ b/src/mame/apple/apple2video.cpp
@@ -883,7 +883,7 @@ void a2_video_device::dhgr_update(screen_device &screen, bitmap_ind16 &bitmap, c
 
 	for (int row = beginrow; row <= endrow; row++)
 	{
-		uint32_t const address = page + ((((row/8) & 0x07) << 7) | (((row/8) & 0x18) * 5)) | ((row & 7) << 10);
+		uint32_t const address = page + ((((row/8) & 0x07) << 7) | (((row/8) & 0x18) * 5) | ((row & 7) << 10));
 		uint8_t const *const vram_row = m_ram_ptr + address;
 		uint8_t const *const vaux_row = m_aux_ptr + (address & m_aux_mask);
 

--- a/src/mame/apple/apple2video.cpp
+++ b/src/mame/apple/apple2video.cpp
@@ -684,7 +684,7 @@ void a2_video_device::lores_update(screen_device &screen, bitmap_ind16 &bitmap, 
 		/* calculate address */
 		uint32_t const address = start_address + ((((row/8) & 0x07) << 7) | (((row/8) & 0x18) * 5));
 		uint8_t const *const vram = m_ram_ptr + address;
-		uint8_t const *const vaux = Double ? (m_aux_ptr + address) : nullptr;
+		uint8_t const *const vaux = Double ? (m_aux_ptr + (address & m_aux_mask)) : nullptr;
 		auto const NIBBLE = [&row] (auto byte) { return ((byte) >> (row & 4)) & 0x0f; };
 		if (render_perfect_blocks)
 		{
@@ -870,7 +870,7 @@ void a2_video_device::hgr_update(screen_device &screen, bitmap_ind16 &bitmap, co
 
 void a2_video_device::dhgr_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow)
 {
-	int const page = use_page_2() ? m_hgr2 : 0x2000;
+	uint32_t const page = use_page_2() ? m_hgr2 : 0x2000;
 	int const rgbmode = rgb_monitor() ? m_rgbmode : -1;
 
 	beginrow = (std::max)(beginrow, cliprect.top());
@@ -881,14 +881,11 @@ void a2_video_device::dhgr_update(screen_device &screen, bitmap_ind16 &bitmap, c
 	// B&W/Green/Amber monitor, IIgs force-monochrome-DHR setting, or IIe RGB card monochrome DHR
 	bool const monochrome = monochrome_monitor() || (m_newvideo & 0x20) || rgbmode == 0;
 
-	uint8_t const *const vram = &m_ram_ptr[page];
-	uint8_t const *const vaux = (m_aux_ptr ? m_aux_ptr : vram) + page;
-
 	for (int row = beginrow; row <= endrow; row++)
 	{
-		int const offset = ((((row/8) & 0x07) << 7) | (((row/8) & 0x18) * 5)) | ((row & 7) << 10);
-		uint8_t const *const vram_row = vram + offset;
-		uint8_t const *const vaux_row = vaux + offset;
+		uint32_t const address = page + ((((row/8) & 0x07) << 7) | (((row/8) & 0x18) * 5)) | ((row & 7) << 10);
+		uint8_t const *const vram_row = m_ram_ptr + address;
+		uint8_t const *const vaux_row = m_aux_ptr + (address & m_aux_mask);
 
 		uint16_t *p = &bitmap.pix(row);
 


### PR DESCRIPTION
This PR fixes apple2e* crashing when using `-aux std80` and displaying DGR or DHGR.

To reproduce:

1. `mame apple2ee -aux std80`  (no disk)
2. Ctrl-Reset to prompt
3. HGR  (or GR)
4. PR#3
5. CALL -151
6. C05E

[apple2ee_std80_dhgr_crash.txt](https://github.com/user-attachments/files/27070692/apple2ee_std80_dhgr_crash.txt)

Most software will check for 128k before attempting to use DHGR, but this also reproduces when running anything that blindly displays DHGR or DGR, for example the VIDMODES test on this disk image:
[VidModes_260424.zip](https://github.com/user-attachments/files/27070696/VidModes_260424.zip)

...although the crash is due to OOB access, so it depends on your system malloc (and ASLR etc.)  On my system a crash in a release build is rare without libgmalloc.
A debug ASAN build (`ARCHOPTS="-fsanitize=address"`) shows the problem immediately:
[apple2ee_std80_dhgr_asan.txt](https://github.com/user-attachments/files/27070765/apple2ee_std80_dhgr_asan.txt)
...and similarly with DGR:
[apple2ee_std80_dgr_asan.txt](https://github.com/user-attachments/files/27070766/apple2ee_std80_dgr_asan.txt)

80-column text (including page2) was not affected, because `a2_video_device::text_update()` applies `m_aux_mask`.  This commit applies similar logic to `lores_update()` and `dhgr_update()`.

I also removed `allow_dhr()` from `a2eauxslot` cards; this was unused.  `get_auxbank_mask()` fulfills the requirement well enough:  MAME does not emulate the early Rev-A Apple //e where C05E DHIRESON isn't functional, but if it did, that indication of DHGR support belongs in the apple2e motherboard and not the auxslot card.
