### PR TITLE
osd: add serial output provider

### DIFF
--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -1096,9 +1096,16 @@ OSD Output Options
     to connect external outputs such as the LED lights for the Player 1/2 start
     buttons on certain arcade machines.
 
-    You can choose from: ``auto``, ``none``, ``console`` or ``network``
+    You can choose from: ``auto``, ``none``, ``console``, ``network``,
+    or ``serial``.
 
     Note that network port is fixed at 8000.
+
+    The ``serial`` provider writes output notifications as ``name = value``
+    lines (newline-terminated) to a configured serial port - useful for
+    driving external arcade I/O hardware such as ticket dispensers, coin
+    hoppers, and lamp boards.  Configure the port and baud rate with the
+    options below.
 
     Example:
         .. code-block:: bash
@@ -1109,6 +1116,39 @@ OSD Output Options
             ...
             led0 = 1
             led0 = 0
+
+
+.. _mame-commandline-output-serial-port:
+
+**-output_serial_port** *<port>*
+
+    Selects the serial port the ``serial`` output provider writes to.
+    Accepts platform-native port names, for example ``COM4`` on Windows
+    or ``/dev/ttyUSB0`` on Linux.
+
+    The default is empty; if no port is set when ``-output serial`` is
+    selected, the provider fails to initialise and MAME falls back to
+    ``-output none``.
+
+    Example:
+        .. code-block:: bash
+
+            mame ddboy -output serial -output_serial_port COM4
+
+.. _mame-commandline-output-serial-baud:
+
+**-output_serial_baud** *<rate>*
+
+    Sets the baud rate for the ``serial`` output provider.
+
+    The default is ``9600``.  Heavier games with frequent output
+    activity (e.g. many lamps blinking) may benefit from a higher rate
+    such as ``115200``.
+
+    Example:
+        .. code-block:: bash
+
+            mame ddboy -output serial -output_serial_port COM4 -output_serial_baud 115200
 
 
 .. _mame-commandline-configoptions:

--- a/docs/source/commandline/commandline-index.rst
+++ b/docs/source/commandline/commandline-index.rst
@@ -79,6 +79,8 @@ OSD Output Options
 ~~~~~~~~~~~~~~~~~~
 
 | :ref:`output <mame-commandline-output>`
+| :ref:`output_serial_port <mame-commandline-output-serial-port>`
+| :ref:`output_serial_baud <mame-commandline-output-serial-baud>`
 
 
 Configuration Options

--- a/scripts/src/osd/modules.lua
+++ b/scripts/src/osd/modules.lua
@@ -123,6 +123,7 @@ function osdmodulesbuild()
 		MAME_DIR .. "src/osd/modules/output/network.cpp",
 		MAME_DIR .. "src/osd/modules/output/none.cpp",
 		MAME_DIR .. "src/osd/modules/output/output_module.h",
+		MAME_DIR .. "src/osd/modules/output/serial.cpp",
 		MAME_DIR .. "src/osd/modules/output/win32_output.cpp",
 		MAME_DIR .. "src/osd/modules/output/win32_output.h",
 		MAME_DIR .. "src/osd/modules/render/blit13.ipp",

--- a/src/osd/modules/lib/osdobj_common.cpp
+++ b/src/osd/modules/lib/osdobj_common.cpp
@@ -45,6 +45,8 @@ const options_entry osd_options::s_option_entries[] =
 
 	{ nullptr,                                   nullptr,          core_options::option_type::HEADER,    "OSD OUTPUT OPTIONS" },
 	{ OSD_OUTPUT_PROVIDER,                       OSDOPTVAL_AUTO,   core_options::option_type::STRING,    "provider for output notifications: " },
+	{ OSDOPTION_OUTPUT_SERIAL_PORT,              "",               core_options::option_type::STRING,    "serial port for 'serial' output provider (e.g. COM4, /dev/ttyUSB0)" },
+	{ OSDOPTION_OUTPUT_SERIAL_BAUD,              "9600",           core_options::option_type::INTEGER,   "serial port baud rate for 'serial' output provider" },
 
 	{ nullptr,                                   nullptr,          core_options::option_type::HEADER,    "OSD INPUT OPTIONS" },
 	{ OSD_KEYBOARDINPUT_PROVIDER,                OSDOPTVAL_AUTO,   core_options::option_type::STRING,    "provider for keyboard input: " },
@@ -330,6 +332,7 @@ void osd_common_t::register_options()
 	REGISTER_MODULE(m_mod_man, OUTPUT_NONE);
 	REGISTER_MODULE(m_mod_man, OUTPUT_CONSOLE);
 	REGISTER_MODULE(m_mod_man, OUTPUT_NETWORK);
+	REGISTER_MODULE(m_mod_man, OUTPUT_SERIAL);
 	REGISTER_MODULE(m_mod_man, OUTPUT_WIN32);
 
 

--- a/src/osd/modules/lib/osdobj_common.h
+++ b/src/osd/modules/lib/osdobj_common.h
@@ -85,6 +85,9 @@
 
 #define OSDOPTION_NETWORK_PROVIDER      "networkprovider"
 
+#define OSDOPTION_OUTPUT_SERIAL_PORT    "output_serial_port"
+#define OSDOPTION_OUTPUT_SERIAL_BAUD    "output_serial_baud"
+
 #define OSDOPTION_BGFX_PATH             "bgfx_path"
 #define OSDOPTION_BGFX_BACKEND          "bgfx_backend"
 #define OSDOPTION_BGFX_DEBUG            "bgfx_debug"

--- a/src/osd/modules/output/serial.cpp
+++ b/src/osd/modules/output/serial.cpp
@@ -1,0 +1,255 @@
+// license:BSD-3-Clause
+// copyright-holders:Nadav Weiss
+/***************************************************************************
+
+    serial.cpp
+
+    Serial port output interface.
+
+    Forwards MAME output notifications as "name = value\n" lines over a
+    serial port.  Intended for driving external arcade hardware (ticket
+    dispensers, coin hoppers, lamp boards) through a user-space bridge.
+
+***************************************************************************/
+
+#include "output_module.h"
+
+#include "modules/lib/osdobj_common.h"
+#include "modules/osdmodule.h"
+
+#include "osdcore.h"
+#include "strformat.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <termios.h>
+#include <unistd.h>
+#endif
+
+
+namespace osd {
+
+namespace {
+
+#if defined(_WIN32)
+
+class serial_port
+{
+public:
+	serial_port() : m_handle(INVALID_HANDLE_VALUE) { }
+	~serial_port() { close(); }
+
+	bool open(const std::string &port, unsigned baud)
+	{
+		// Windows requires "\\.\COMn" form for COM ports above COM9, and it
+		// also works for COM1-COM9, so always use it.
+		std::string path = "\\\\.\\" + port;
+		m_handle = CreateFileA(
+				path.c_str(),
+				GENERIC_READ | GENERIC_WRITE,
+				0,
+				nullptr,
+				OPEN_EXISTING,
+				0,
+				nullptr);
+		if (m_handle == INVALID_HANDLE_VALUE)
+			return false;
+
+		DCB dcb = {};
+		dcb.DCBlength = sizeof(dcb);
+		if (!GetCommState(m_handle, &dcb))
+		{
+			close();
+			return false;
+		}
+		dcb.BaudRate = baud;
+		dcb.ByteSize = 8;
+		dcb.Parity = NOPARITY;
+		dcb.StopBits = ONESTOPBIT;
+		dcb.fBinary = TRUE;
+		dcb.fParity = FALSE;
+		dcb.fOutxCtsFlow = FALSE;
+		dcb.fOutxDsrFlow = FALSE;
+		dcb.fDtrControl = DTR_CONTROL_ENABLE;
+		dcb.fRtsControl = RTS_CONTROL_ENABLE;
+		dcb.fOutX = FALSE;
+		dcb.fInX = FALSE;
+		if (!SetCommState(m_handle, &dcb))
+		{
+			close();
+			return false;
+		}
+
+		// No blocking: zero write timeouts so a stuck host can't stall MAME.
+		COMMTIMEOUTS timeouts = {};
+		timeouts.ReadIntervalTimeout = MAXDWORD;
+		timeouts.WriteTotalTimeoutConstant = 0;
+		timeouts.WriteTotalTimeoutMultiplier = 0;
+		SetCommTimeouts(m_handle, &timeouts);
+
+		return true;
+	}
+
+	void close()
+	{
+		if (m_handle != INVALID_HANDLE_VALUE)
+		{
+			CloseHandle(m_handle);
+			m_handle = INVALID_HANDLE_VALUE;
+		}
+	}
+
+	bool write(const char *data, std::size_t length)
+	{
+		if (m_handle == INVALID_HANDLE_VALUE)
+			return false;
+		DWORD written = 0;
+		return WriteFile(m_handle, data, DWORD(length), &written, nullptr) != 0;
+	}
+
+private:
+	HANDLE m_handle;
+};
+
+#else
+
+class serial_port
+{
+public:
+	serial_port() : m_fd(-1) { }
+	~serial_port() { close(); }
+
+	bool open(const std::string &port, unsigned baud)
+	{
+		m_fd = ::open(port.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK);
+		if (m_fd < 0)
+			return false;
+
+		termios tio = {};
+		if (tcgetattr(m_fd, &tio) != 0)
+		{
+			close();
+			return false;
+		}
+
+		cfmakeraw(&tio);
+		tio.c_cflag |= CLOCAL | CREAD;
+		tio.c_cflag &= ~CRTSCTS;
+		tio.c_cflag = (tio.c_cflag & ~CSIZE) | CS8;
+		tio.c_cflag &= ~PARENB;
+		tio.c_cflag &= ~CSTOPB;
+		tio.c_iflag &= ~(IXON | IXOFF | IXANY);
+
+		speed_t speed = baud_to_speed(baud);
+		cfsetispeed(&tio, speed);
+		cfsetospeed(&tio, speed);
+
+		if (tcsetattr(m_fd, TCSANOW, &tio) != 0)
+		{
+			close();
+			return false;
+		}
+
+		return true;
+	}
+
+	void close()
+	{
+		if (m_fd >= 0)
+		{
+			::close(m_fd);
+			m_fd = -1;
+		}
+	}
+
+	bool write(const char *data, std::size_t length)
+	{
+		if (m_fd < 0)
+			return false;
+		ssize_t written = ::write(m_fd, data, length);
+		return written == ssize_t(length);
+	}
+
+private:
+	static speed_t baud_to_speed(unsigned baud)
+	{
+		switch (baud)
+		{
+			case 1200:   return B1200;
+			case 2400:   return B2400;
+			case 4800:   return B4800;
+			case 9600:   return B9600;
+			case 19200:  return B19200;
+			case 38400:  return B38400;
+			case 57600:  return B57600;
+			case 115200: return B115200;
+			default:     return B9600;
+		}
+	}
+
+	int m_fd;
+};
+
+#endif
+
+
+class output_serial : public osd_module, public output_module
+{
+public:
+	output_serial() :
+		osd_module(OSD_OUTPUT_PROVIDER, "serial"),
+		output_module()
+	{
+	}
+
+	virtual int init(osd_interface &osd, const osd_options &options) override
+	{
+		const char *port = options.value(OSDOPTION_OUTPUT_SERIAL_PORT);
+		if (port == nullptr || port[0] == '\0')
+		{
+			osd_printf_error("serial output: no port configured (set -%s)\n", OSDOPTION_OUTPUT_SERIAL_PORT);
+			return -1;
+		}
+
+		unsigned baud = 9600;
+		if (options.exists(OSDOPTION_OUTPUT_SERIAL_BAUD))
+			baud = unsigned(options.int_value(OSDOPTION_OUTPUT_SERIAL_BAUD));
+
+		if (!m_port.open(port, baud))
+		{
+			osd_printf_error("serial output: failed to open %s at %u baud\n", port, baud);
+			return -1;
+		}
+
+		osd_printf_verbose("serial output: opened %s at %u baud\n", port, baud);
+		return 0;
+	}
+
+	virtual void exit() override
+	{
+		m_port.close();
+	}
+
+	// output_module
+
+	virtual void notify(const char *outname, int32_t value) override
+	{
+		auto msg = util::string_format("%s = %d\n", ((outname == nullptr) ? "none" : outname), value);
+		m_port.write(msg.data(), msg.size());
+	}
+
+private:
+	serial_port m_port;
+};
+
+} // anonymous namespace
+
+} // namespace osd
+
+MODULE_DEFINITION(OUTPUT_SERIAL, osd::output_serial)


### PR DESCRIPTION
## osd: add serial output provider

Adds a new OSD output module that streams MAME output notifications
over a serial port, with the same neutral one-way semantics as the
existing `network` provider - every `notify(name, value)` becomes one
`name = value\n` line on the wire.

### Motivation

MAME's existing output providers (`console`, `network`, `windows`)
are software notification channels.  Real arcade hardware that
implements core arcade behaviour - ticket dispensers, coin hoppers,
coin acceptors, lamp boards - talks serial natively.  Today the only
way to bridge MAME to that hardware is to take `-output network`,
write a userspace TCP-to-serial process, and ship/maintain it
alongside MAME.

For the very common "MAME → COM port → I/O board" topology a
built-in module is simpler, has fewer moving parts, and matches user
expectations.  Operators running games on a real cabinet (ddboy,
shuriboy, fuusenpn, tsupenta, mariorou, tsukande, and similar
ticket/medal games) get a drop-in path to drive their hardware.

### Design

Architecturally identical to `src/osd/modules/output/network.cpp`:

- Implements `osd_module + output_module`, registers under the
  `output` provider type as `serial`.
- `notify()` formats `"%s = %d\n"` and writes synchronously to the
  port.  Writes are non-blocking (`WriteTotalTimeoutConstant = 0` on
  Windows, `O_NONBLOCK` on POSIX) so a stuck/disconnected host can
  never stall the emulation thread.
- Cross-platform via straight Win32 (`CreateFileA` + `SetCommState`)
  and POSIX `termios`.  No third-party deps; no changes to anything
  outside `src/osd/modules/output/` and the small option/registration
  edits below.

Two new CLI options:

- `-output_serial_port <name>` - port name, e.g. `COM4` /
  `/dev/ttyUSB0`.  Empty by default; if no port is set when
  `-output serial` is selected, init logs a clear error and MAME
  falls back to `-output none` (same fallback flow as any other
  failed module).
- `-output_serial_baud <rate>` - defaults to `9600`.

### Testing

- Built and ran against `ddboy` (Konami medal,
  `src/mame/konami/konmedal.cpp`).
- Verified ROM via `mame -verifyroms ddboy` (good).
- Played the game end-to-end with a real serial listener attached:
  - lamp activity (`lamp0 = 1` / `lamp0 = 0`) appears during attract
    mode at the expected ~130 ms cadence
  - inserting a coin stops the lamp blink (game leaves attract)
  - on a 4-ticket payout, the wire shows exactly four
    `hopper = 0 → 1` rising edges at the 100 ms period the driver
    configures via `HOPPER(config, "hopper", attotime::from_msec(100))`
  - all lines newline-terminated, no truncation, no out-of-order
    interleaving with other outputs (lamp + hopper coexist
    correctly)
- `srcclean` run against the new file and the touched files; zero
  changes.

### Scope / non-goals

Intentionally one-way (MAME → wire only).  Adding an input/feedback
path (e.g. external sensor pulses driving the ticket dispenser
device) is a much bigger design conversation - there is no clean
MAME-core API today for OSD modules to inject data into a specific
emulated device, and the right answer probably lives at the device
or input layer rather than the output layer.  Out of scope for this
PR.

### Where this fits in practice

This module is the upstream-side counterpart to Arcadeify, a
plug-and-play PCB that sits between a PC running MAME and physical
arcade hardware (ticket dispenser, coin hopper, coin acceptor,
panel buttons).  Arcadeify already speaks serial; with this module
MAME can drive it directly without any user-side bridge process.
The same module is equally usable by anyone with a different
serial-attached I/O board.

Inputs (coin pulses, button presses) reach MAME through a separate
HID-keyboard path on the controller side, which is why this module
is deliberately output-only.

### Files

- new: `src/osd/modules/output/serial.cpp`
- modified: `scripts/src/osd/modules.lua` (one line, register file)
- modified: `src/osd/modules/lib/osdobj_common.{h,cpp}` (option
  defines, option entries, `REGISTER_MODULE` line)
- modified: `docs/source/commandline/commandline-{all,index}.rst`
  (document the provider and its two options)
