### PR TITLE
kaneko/suprnova.cpp: Updates and Cleanups

### DIFF
--- a/src/mame/kaneko/suprnova.cpp
+++ b/src/mame/kaneko/suprnova.cpp
@@ -28,7 +28,7 @@ Puzz Loop is currently the only game dumped for all known regions.  This game is
 
 TODO:
 
-Music timing in some games are incorrect
+Music timing in some games is incorrect
 
 galpanis: Are the priorities correct on the KANEKO logo at the start, the invisible faded logo obscures the rotating white lines
 
@@ -704,7 +704,7 @@ void skns_state::io_w(offs_t offset, u32 data, u32 mem_mask)
 					m_maincpu->set_input_line(15, CLEAR_LINE);*/
 
 				/* idle skip for vblokbrk/sarukani, i can't find a better place to put it :-( but i think it works ok unless its making the game too fast */
-				if (m_maincpu->pc() == 0x04013B42)
+				if (m_maincpu->pc() == 0x04013b42)
 				{
 					if (!strcmp(machine().system().name,"vblokbrk") ||
 						!strcmp(machine().system().name,"sarukani"))

--- a/src/mame/kaneko/suprnova.cpp
+++ b/src/mame/kaneko/suprnova.cpp
@@ -26,14 +26,20 @@ Puzz Loop is currently the only game dumped for all known regions.  This game is
    so the "U" location is printed on the label as U4 & U6.  However this same game has also been found on the
    ROM-2-BOARD using EPROMs labeled for the ROM 4 BOARD, but inserted in sockets at U8 & U10
 
-ToDo:
+TODO:
+
+Music timing in some games are incorrect
 
 galpanis: Are the priorities correct on the KANEKO logo at the start, the invisible faded logo obscures the rotating white lines
 
-video:   Sprite Zooming - the current algorithm is leaving gaps, most noticeable in Gals Panic 4, and Jackie Chan which is sharing
-         the sprite hardware.
+cyvern:   Sprite color is incorrect when screen fade
 
-video:   Sprite positions still kludged slightly (see set_sprite_kludge)
+video:    Sprite Zooming - the current algorithm is leaving gaps, most noticeable in Gals Panic 4, and Jackie Chan which is sharing
+          the sprite hardware.
+
+video:    Sprite positions still kludged slightly (see set_sprite_kludge)
+
+video:    Verify sprite lag frames
 
 puzzloopkbl: Different sprite RAM format?
 
@@ -157,43 +163,51 @@ NEP-16
 
 #include "speaker.h"
 
+#define LOG_HIT (1 << 1)
 
-static void hit_calc_orig(uint16_t p, uint16_t s, uint16_t org, uint16_t *l, uint16_t *r)
+#define VERBOSE (0)
+
+#include "logmacro.h"
+
+#define LOGHIT(...)   LOGMASKED(LOG_HIT, __VA_ARGS__) 
+
+static void hit_calc_orig(u16 p, u16 s, u16 org, u16 &l, u16 &r)
 {
-	switch(org & 3) {
-	case 0:
-		*l = p;
-		*r = p+s;
-	break;
-	case 1:
-		*l = p-s/2;
-		*r = *l+s;
-	break;
-	case 2:
-		*l = p-s;
-		*r = p;
-	break;
-	case 3:
-		*l = p-s;
-		*r = p+s;
-	break;
+	switch (org & 3)
+	{
+		case 0:
+			l = p;
+			r = p + s;
+			break;
+		case 1:
+			l = p - s / 2;
+			r = l + s;
+			break;
+		case 2:
+			l = p - s;
+			r = p;
+			break;
+		case 3:
+			l = p - s;
+			r = p + s;
+			break;
 	}
 }
 
-static void hit_calc_axis(uint16_t x1p, uint16_t x1s, uint16_t x2p, uint16_t x2s, uint16_t org,
-				uint16_t *x1_p1, uint16_t *x1_p2, uint16_t *x2_p1, uint16_t *x2_p2,
-				int16_t *x_in, uint16_t *x1tox2)
+static void hit_calc_axis(u16 x1p, u16 x1s, u16 x2p, u16 x2s, u16 org,
+				u16 &x1_p1, u16 &x1_p2, u16 &x2_p1, u16 &x2_p2,
+				s16 &x_in, u16 &x1tox2)
 {
-	uint16_t x1l=0, x1r=0, x2l=0, x2r=0;
-	hit_calc_orig(x1p, x1s, org,      &x1l, &x1r);
-	hit_calc_orig(x2p, x2s, org >> 8, &x2l, &x2r);
+	u16 x1l = 0, x1r = 0, x2l = 0, x2r = 0;
+	hit_calc_orig(x1p, x1s, org,      x1l, x1r);
+	hit_calc_orig(x2p, x2s, org >> 8, x2l, x2r);
 
-	*x1tox2 = x2p-x1p;
-	*x1_p1 = x1p;
-	*x2_p1 = x2p;
-	*x1_p2 = x1r;
-	*x2_p2 = x2l;
-	*x_in = x1r-x2l;
+	x1tox2 = x2p - x1p;
+	x1_p1 = x1p;
+	x2_p1 = x2p;
+	x1_p2 = x1r;
+	x2_p2 = x2l;
+	x_in = x1r - x2l;
 }
 
 void skns_state::hit_recalc()
@@ -201,217 +215,223 @@ void skns_state::hit_recalc()
 	hit_t &hit = m_hit;
 
 	hit_calc_axis(hit.x1p, hit.x1s, hit.x2p, hit.x2s, hit.org,
-		&hit.x1_p1, &hit.x1_p2, &hit.x2_p1, &hit.x2_p2,
-		&hit.x_in, &hit.x1tox2);
+		hit.x1_p1, hit.x1_p2, hit.x2_p1, hit.x2_p2,
+		hit.x_in, hit.x1tox2);
 	hit_calc_axis(hit.y1p, hit.y1s, hit.y2p, hit.y2s, hit.org,
-		&hit.y1_p1, &hit.y1_p2, &hit.y2_p1, &hit.y2_p2,
-		&hit.y_in, &hit.y1toy2);
+		hit.y1_p1, hit.y1_p2, hit.y2_p1, hit.y2_p2,
+		hit.y_in, hit.y1toy2);
 	hit_calc_axis(hit.z1p, hit.z1s, hit.z2p, hit.z2s, hit.org,
-		&hit.z1_p1, &hit.z1_p2, &hit.z2_p1, &hit.z2_p2,
-		&hit.z_in, &hit.z1toz2);
+		hit.z1_p1, hit.z1_p2, hit.z2_p1, hit.z2_p2,
+		hit.z_in, hit.z1toz2);
 
-	hit.flag = 0;
+	const bool x_in_hit = hit.x_in >= 0;
+	const bool y_in_hit = hit.y_in >= 0;
+	const bool z_in_hit = hit.z_in >= 0;
+
+	hit.flag  = 0;
 	hit.flag |= hit.y2p > hit.y1p ? 0x8000 : hit.y2p == hit.y1p ? 0x4000 : 0x2000;
-	hit.flag |= hit.y_in >= 0 ? 0 : 0x1000;
+	hit.flag |= y_in_hit ? 0 : 0x1000;
 	hit.flag |= hit.x2p > hit.x1p ? 0x0800 : hit.x2p == hit.x1p ? 0x0400 : 0x0200;
-	hit.flag |= hit.x_in >= 0 ? 0 : 0x0100;
+	hit.flag |= x_in_hit ? 0 : 0x0100;
 	hit.flag |= hit.z2p > hit.z1p ? 0x0080 : hit.z2p == hit.z1p ? 0x0040 : 0x0020;
-	hit.flag |= hit.z_in >= 0 ? 0 : 0x0010;
-	hit.flag |= hit.x_in >= 0 && hit.y_in >= 0 && hit.z_in >= 0 ? 8 : 0;
-	hit.flag |= hit.z_in >= 0 && hit.x_in >= 0                  ? 4 : 0;
-	hit.flag |= hit.y_in >= 0 && hit.z_in >= 0                  ? 2 : 0;
-	hit.flag |= hit.x_in >= 0 && hit.y_in >= 0                  ? 1 : 0;
-/*  if(0)
-    log_event("HIT", "Recalc, (%d,%d)-(%d,%d)-(%d,%d):(%d,%d)-(%d,%d)-(%d,%d):%04x, (%d,%d,%d), %04x",
-          hit.x1p, hit.x1s, hit.y1p, hit.y1s, hit.z1p, hit.z1s,
-          hit.x2p, hit.x2s, hit.y2p, hit.y2s, hit.z2p, hit.z2s,
-          hit.org,
-          hit.x_in, hit.y_in, hit.z_in, hit.flag);
-*/
+	hit.flag |= z_in_hit ? 0 : 0x0010;
+	hit.flag |= x_in_hit && y_in_hit && z_in_hit ? 8 : 0;
+	hit.flag |= z_in_hit && x_in_hit             ? 4 : 0;
+	hit.flag |= y_in_hit && z_in_hit             ? 2 : 0;
+	hit.flag |= x_in_hit && y_in_hit             ? 1 : 0;
+	LOGHIT("%s: hit_recalc, (%d,%d)-(%d,%d)-(%d,%d):(%d,%d)-(%d,%d)-(%d,%d):%04x, (%d,%d,%d), %04x",
+			machine().describe_context(),
+			hit.x1p, hit.x1s, hit.y1p, hit.y1s, hit.z1p, hit.z1s,
+			hit.x2p, hit.x2s, hit.y2p, hit.y2s, hit.z2p, hit.z2s,
+			hit.org,
+			hit.x_in, hit.y_in, hit.z_in, hit.flag);
 }
 
-void skns_state::hit_w(offs_t offset, uint32_t data)
-//void hit_w(uint32_t adr, uint32_t data, int type)
+void skns_state::hit_w(offs_t offset, u32 data)
+//void hit_w(u32 adr, u32 data, int type)
 {
 	hit_t &hit = m_hit;
-	int adr = offset * 4;
+	const offs_t adr = offset * 4;
 
-	switch(adr) {
-	case 0x00:
-	case 0x28:
-		hit.x1p = data;
-	break;
-	case 0x08:
-	case 0x30:
-		hit.y1p = data;
-	break;
-	case 0x38:
-	case 0x50:
-		hit.z1p = data;
-	break;
-	case 0x04:
-	case 0x2c:
-		hit.x1s = data;
-	break;
-	case 0x0c:
-	case 0x34:
-		hit.y1s = data;
-	break;
-	case 0x3c:
-	case 0x54:
-		hit.z1s = data;
-	break;
-	case 0x10:
-	case 0x58:
-		hit.x2p = data;
-	break;
-	case 0x18:
-	case 0x60:
-		hit.y2p = data;
-	break;
-	case 0x20:
-	case 0x68:
-		hit.z2p = data;
-	break;
-	case 0x14:
-	case 0x5c:
-		hit.x2s = data;
-	break;
-	case 0x1c:
-	case 0x64:
-		hit.y2s = data;
-	break;
-	case 0x24:
-	case 0x6c:
-		hit.z2s = data;
-	break;
-	case 0x70:
-		hit.org = data;
-	break;
-	default:
-//      log_write("HIT", adr, data, type);
-	break;
+	switch (adr)
+	{
+		case 0x00:
+		case 0x28:
+			hit.x1p = data;
+			break;
+		case 0x08:
+		case 0x30:
+			hit.y1p = data;
+			break;
+		case 0x38:
+		case 0x50:
+			hit.z1p = data;
+			break;
+		case 0x04:
+		case 0x2c:
+			hit.x1s = data;
+			break;
+		case 0x0c:
+		case 0x34:
+			hit.y1s = data;
+			break;
+		case 0x3c:
+		case 0x54:
+			hit.z1s = data;
+			break;
+		case 0x10:
+		case 0x58:
+			hit.x2p = data;
+			break;
+		case 0x18:
+		case 0x60:
+			hit.y2p = data;
+			break;
+		case 0x20:
+		case 0x68:
+			hit.z2p = data;
+			break;
+		case 0x14:
+		case 0x5c:
+			hit.x2s = data;
+			break;
+		case 0x1c:
+		case 0x64:
+			hit.y2s = data;
+			break;
+		case 0x24:
+		case 0x6c:
+			hit.z2s = data;
+			break;
+		case 0x70:
+			hit.org = data;
+			break;
+		default:
+			logerror("%s: unknown hit_w write %04x <- %08x", machine().describe_context(), offset, data);
+			break;
 	}
 	hit_recalc();
 }
 
-void skns_state::hit2_w(uint32_t data)
+void skns_state::hit2_w(u32 data)
 {
 	hit_t &hit = m_hit;
 
 	// Decide to unlock on country char of string "FOR xxxxx" in BIOS ROM at offset 0x420
 	// this code simulates behaviour of protection PLD
-	data>>= 24;
+	data >>= 24;
 	hit.disconnect = 1;
 	switch (m_region)
 	{
 		case 'J':
-			if (data == 0) hit.disconnect= 0;
-		break;
+			if (data == 0) hit.disconnect = 0;
+			break;
 		case 'U':
-			if (data == 1) hit.disconnect= 0;
-		break;
+			if (data == 1) hit.disconnect = 0;
+			break;
 		case 'K':
-			if (data == 2) hit.disconnect= 0;
-		break;
+			if (data == 2) hit.disconnect = 0;
+			break;
 		case 'E':
-			if (data == 3) hit.disconnect= 0;
-		break;
+			if (data == 3) hit.disconnect = 0;
+			break;
 		case 'A':
-			if (data < 2) hit.disconnect= 0;
-		break;
+			if (data < 2) hit.disconnect = 0;
+			break;
 		// unknown country id, unlock per default
 		default:
-			hit.disconnect= 0;
-		break;
+			hit.disconnect = 0;
+			break;
 	}
 }
 
 
-uint32_t skns_state::hit_r(offs_t offset)
-//uint32_t hit_r(uint32_t adr, int type)
+u32 skns_state::hit_r(offs_t offset)
+//u32 hit_r(u32 adr, int type)
 {
 	hit_t &hit = m_hit;
-	int adr = offset *4;
+	const offs_t adr = offset * 4;
 
 //  log_read("HIT", adr, type);
 
-	if(hit.disconnect)
+	if (hit.disconnect)
 		return 0x0000;
-	switch(adr) {
-	case 0x28:
-	case 0x2a:
-		return (uint16_t)machine().rand();
-	case 0x00:
-	case 0x10:
-		return (uint16_t)hit.x_in;
-	case 0x04:
-	case 0x14:
-		return (uint16_t)hit.y_in;
-	case 0x18:
-		return (uint16_t)hit.z_in;
-	case 0x08:
-	case 0x1c:
-		return hit.flag;
-	case 0x40:
-		return hit.x1p;
-	case 0x48:
-		return hit.y1p;
-	case 0x50:
-		return hit.z1p;
-	case 0x44:
-		return hit.x1s;
-	case 0x4c:
-		return hit.y1s;
-	case 0x54:
-		return hit.z1s;
-	case 0x58:
-		return hit.x2p;
-	case 0x60:
-		return hit.y2p;
-	case 0x68:
-		return hit.z2p;
-	case 0x5c:
-		return hit.x2s;
-	case 0x64:
-		return hit.y2s;
-	case 0x6c:
-		return hit.z2s;
-	case 0x70:
-		return hit.org;
-	case 0x80:
-		return hit.x1tox2;
-	case 0x84:
-		return hit.y1toy2;
-	case 0x88:
-		return hit.z1toz2;
-	case 0x90:
-		return hit.x1_p1;
-	case 0xa0:
-		return hit.y1_p1;
-	case 0xb0:
-		return hit.z1_p1;
-	case 0x98:
-		return hit.x1_p2;
-	case 0xa8:
-		return hit.y1_p2;
-	case 0xb8:
-		return hit.z1_p2;
-	case 0x94:
-		return hit.x2_p1;
-	case 0xa4:
-		return hit.y2_p1;
-	case 0xb4:
-		return hit.z2_p1;
-	case 0x9c:
-		return hit.x2_p2;
-	case 0xac:
-		return hit.y2_p2;
-	case 0xbc:
-		return hit.z2_p2;
-	default:
-//      log_read("HIT", adr, type);
-	return 0;
+	switch (adr)
+	{
+		case 0x28:
+		case 0x2a:
+			return (u16)machine().rand();
+		case 0x00:
+		case 0x10:
+			return (u16)hit.x_in;
+		case 0x04:
+		case 0x14:
+			return (u16)hit.y_in;
+		case 0x18:
+			return (u16)hit.z_in;
+		case 0x08:
+		case 0x1c:
+			return hit.flag;
+		case 0x40:
+			return hit.x1p;
+		case 0x48:
+			return hit.y1p;
+		case 0x50:
+			return hit.z1p;
+		case 0x44:
+			return hit.x1s;
+		case 0x4c:
+			return hit.y1s;
+		case 0x54:
+			return hit.z1s;
+		case 0x58:
+			return hit.x2p;
+		case 0x60:
+			return hit.y2p;
+		case 0x68:
+			return hit.z2p;
+		case 0x5c:
+			return hit.x2s;
+		case 0x64:
+			return hit.y2s;
+		case 0x6c:
+			return hit.z2s;
+		case 0x70:
+			return hit.org;
+		case 0x80:
+			return hit.x1tox2;
+		case 0x84:
+			return hit.y1toy2;
+		case 0x88:
+			return hit.z1toz2;
+		case 0x90:
+			return hit.x1_p1;
+		case 0xa0:
+			return hit.y1_p1;
+		case 0xb0:
+			return hit.z1_p1;
+		case 0x98:
+			return hit.x1_p2;
+		case 0xa8:
+			return hit.y1_p2;
+		case 0xb8:
+			return hit.z1_p2;
+		case 0x94:
+			return hit.x2_p1;
+		case 0xa4:
+			return hit.y2_p1;
+		case 0xb4:
+			return hit.z2_p1;
+		case 0x9c:
+			return hit.x2_p2;
+		case 0xac:
+			return hit.y2_p2;
+		case 0xbc:
+			return hit.z2_p2;
+		default:
+			if (!machine().side_effects_disabled())
+				logerror("%s: unknown hit_r read at %04x", machine().describe_context(), offset);
+			return 0;
 	}
 }
 
@@ -428,9 +448,9 @@ TIMER_DEVICE_CALLBACK_MEMBER(skns_state::interrupt_callback)
 
 void skns_state::machine_start()
 {
-	m_btiles = memregion("gfx3")->base();
+	m_btiles = memregion("tiles1")->base();
 
-	save_pointer(NAME(m_btiles), memregion("gfx3")->bytes());
+	save_pointer(NAME(m_btiles), memregion("tiles1")->bytes());
 	save_item(NAME(m_hit.x1p));
 	save_item(NAME(m_hit.y1p));
 	save_item(NAME(m_hit.z1p));
@@ -471,20 +491,20 @@ void skns_state::machine_reset()
 	hit_t &hit = m_hit;
 
 	if (m_region != 'A')
-		hit.disconnect= 1;
+		hit.disconnect = 1;
 	else
-		hit.disconnect= 0;
+		hit.disconnect = 0;
 }
 
 
 TIMER_DEVICE_CALLBACK_MEMBER(skns_state::irq)
 {
-	int scanline = param;
+	const int scanline = param;
 
-	if(scanline == 240)
-		m_maincpu->set_input_line(5,HOLD_LINE); //vblank
-	else if(scanline == 0)
-		m_maincpu->set_input_line(1,HOLD_LINE); // spc
+	if (scanline == 240)
+		m_maincpu->set_input_line(5, HOLD_LINE); //vblank
+	else if (scanline == 0)
+		m_maincpu->set_input_line(1, HOLD_LINE); // spc
 }
 
 /**********************************************************************************
@@ -562,16 +582,16 @@ static INPUT_PORTS_START( skns )        /* 3 buttons, 2 players */
 	PORT_BIT( 0x000000ff, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_CUSTOM_MEMBER(FUNC(skns_state::paddle_r<3>)) // Paddle D
 	PORT_BIT( 0xffffff00, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("Paddle.A")
+	PORT_START("PADDLE.A")
 	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("Paddle.B")
+	PORT_START("PADDLE.B")
 	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("Paddle.C")
+	PORT_START("PADDLE.C")
 	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("Paddle.D")
+	PORT_START("PADDLE.D")
 	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
 INPUT_PORTS_END
 
@@ -622,102 +642,109 @@ static INPUT_PORTS_START( puzzloop )    /* 2 buttons, 2 players, paddle */
 	PORT_BIT( 0x00400000, IP_ACTIVE_LOW, IPT_UNUSED )   /* No Button 3 */
 	PORT_BIT( 0x40000000, IP_ACTIVE_LOW, IPT_UNUSED )   /* No Button 3 */
 
-	PORT_MODIFY("Paddle.A")  /* Paddle A */
+	PORT_MODIFY("PADDLE.A")  /* Paddle A */
 	PORT_BIT( 0xff, 0x00, IPT_DIAL ) PORT_SENSITIVITY(100) PORT_KEYDELTA(15) PORT_REVERSE PORT_PLAYER(1)
 
-	PORT_MODIFY("Paddle.B")  /* Paddle B */
+	PORT_MODIFY("PADDLE.B")  /* Paddle B */
 	PORT_BIT( 0xff, 0x00, IPT_DIAL ) PORT_SENSITIVITY(100) PORT_KEYDELTA(15) PORT_REVERSE PORT_PLAYER(2)
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( vblokbrk )    /* 3 buttons, 2 players, paddle */
 	PORT_INCLUDE( skns )
 
-	PORT_MODIFY("Paddle.A")  /* Paddle A */
+	PORT_MODIFY("PADDLE.A")  /* Paddle A */
 	PORT_BIT( 0xff, 0x00, IPT_DIAL ) PORT_SENSITIVITY(100) PORT_KEYDELTA(15) PORT_REVERSE PORT_PLAYER(1)
 
-	PORT_MODIFY("Paddle.B")  /* Paddle B */
+	PORT_MODIFY("PADDLE.B")  /* Paddle B */
 	PORT_BIT( 0xff, 0x00, IPT_DIAL ) PORT_SENSITIVITY(100) PORT_KEYDELTA(15) PORT_REVERSE PORT_PLAYER(2)
 INPUT_PORTS_END
 
 
 
-void skns_state::io_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+void skns_state::io_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	switch(offset) {
-	case 2:
-		if(ACCESSING_BITS_24_31)
-		{ /* Coin Lock/Count */
-//          machine().bookkeeping().coin_counter_w(0, data & 0x01000000);
-//          machine().bookkeeping().coin_counter_w(1, data & 0x02000000);
-//          machine().bookkeeping().coin_lockout_w(0, ~data & 0x04000000);
-//          machine().bookkeeping().coin_lockout_w(1, ~data & 0x08000000); // Works in puzzloop, others behave strange.
-		}
-		if(ACCESSING_BITS_16_23)
-		{ /* Analogue Input Select */
-		}
-		if(ACCESSING_BITS_8_15)
-		{ /* Extended Output - Port A, Mahjong inputs, Comms etc. */
-		}
-		if(ACCESSING_BITS_0_7)
-		{ /* Extended Output - Port B */
-		}
-	break;
-	case 3:
-		if(ACCESSING_BITS_8_15)
-		{ /* Interrupt Clear, do we need these? */
-/*          if(data&0x01)
-                m_maincpu->set_input_line(1,CLEAR_LINE);
-            if(data&0x02)
-                m_maincpu->set_input_line(3,CLEAR_LINE);
-            if(data&0x04)
-                m_maincpu->set_input_line(5,CLEAR_LINE);
-            if(data&0x08)
-                m_maincpu->set_input_line(7,CLEAR_LINE);
-            if(data&0x10)
-                m_maincpu->set_input_line(9,CLEAR_LINE);
-            if(data&0x20)
-                m_maincpu->set_input_line(0xb,CLEAR_LINE);
-            if(data&0x40)
-                m_maincpu->set_input_line(0xd,CLEAR_LINE);
-            if(data&0x80)
-                m_maincpu->set_input_line(0xf,CLEAR_LINE);*/
-
-			/* idle skip for vblokbrk/sarukani, i can't find a better place to put it :-( but i think it works ok unless its making the game too fast */
-			if (m_maincpu->pc()==0x04013B42)
-			{
-				if (!strcmp(machine().system().name,"vblokbrk") ||
-					!strcmp(machine().system().name,"sarukani"))
-					m_maincpu->spin_until_interrupt();
+	switch (offset)
+	{
+		case 2:
+			if (ACCESSING_BITS_24_31)
+			{ /* Coin Lock/Count */
+	//          machine().bookkeeping().coin_counter_w(0, BIT(data, 24));
+	//          machine().bookkeeping().coin_counter_w(1, BIT(data, 25));
+	//          machine().bookkeeping().coin_lockout_w(0, BIT(~data, 26));
+	//          machine().bookkeeping().coin_lockout_w(1, BIT(~data, 27)); // Works in puzzloop, others behave strange.
 			}
+			if (ACCESSING_BITS_16_23)
+			{ /* Analogue Input Select */
+			}
+			if (ACCESSING_BITS_8_15)
+			{ /* Extended Output - Port A, Mahjong inputs, Comms etc. */
+			}
+			if (ACCESSING_BITS_0_7)
+			{ /* Extended Output - Port B */
+			}
+			break;
+		case 3:
+			if (ACCESSING_BITS_8_15)
+			{ /* Interrupt Clear, do we need these? */
+	/*          if (BIT(data, 0))
+					m_maincpu->set_input_line(1, CLEAR_LINE);
+				if (BIT(data, 1))
+					m_maincpu->set_input_line(3, CLEAR_LINE);
+				if (BIT(data, 2))
+					m_maincpu->set_input_line(5, CLEAR_LINE);
+				if (BIT(data, 3))
+					m_maincpu->set_input_line(7, CLEAR_LINE);
+				if (BIT(data, 4))
+					m_maincpu->set_input_line(9, CLEAR_LINE);
+				if (BIT(data, 5))
+					m_maincpu->set_input_line(11, CLEAR_LINE);
+				if (BIT(data, 6))
+					m_maincpu->set_input_line(13, CLEAR_LINE);
+				if (BIT(data, 7))
+					m_maincpu->set_input_line(15, CLEAR_LINE);*/
 
-		}
-		else
-		{
-			logerror("Unk IO Write memmask:%08x offset:%08x data:%08x\n", mem_mask, offset, data);
-		}
-	break;
-	default:
-		logerror("Unk IO Write memmask:%08x offset:%08x data:%08x\n", mem_mask, offset, data);
-	break;
+				/* idle skip for vblokbrk/sarukani, i can't find a better place to put it :-( but i think it works ok unless its making the game too fast */
+				if (m_maincpu->pc() == 0x04013B42)
+				{
+					if (!strcmp(machine().system().name,"vblokbrk") ||
+						!strcmp(machine().system().name,"sarukani"))
+						m_maincpu->spin_until_interrupt();
+				}
+
+			}
+			else
+			{
+				logerror("%s: Unk IO Write memmask:%08x offset:%08x data:%08x\n", machine().describe_context(), mem_mask, offset, data);
+			}
+			break;
+		default:
+			logerror("%s: Unk IO Write memmask:%08x offset:%08x data:%08x\n", machine().describe_context(), mem_mask, offset, data);
+			break;
 	}
 }
 
 /* end old driver code */
 
-void skns_state::v3t_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+void skns_state::v3t_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	COMBINE_DATA(&m_v3t_ram[offset]);
+	data = COMBINE_DATA(&m_v3t_ram[offset]);
 
-	m_gfxdecode->gfx(1)->mark_dirty(offset/0x40);
-	m_gfxdecode->gfx(3)->mark_dirty(offset/0x20);
+	m_gfxdecode->gfx(2)->mark_dirty(offset / 0x40);
+	m_gfxdecode->gfx(3)->mark_dirty(offset / 0x20);
 
-	data = m_v3t_ram[offset];
 // i think we need to swap around to decode .. endian issues?
 
-	m_btiles[offset*4+0] = (data & 0xff000000) >> 24;
-	m_btiles[offset*4+1] = (data & 0x00ff0000) >> 16;
-	m_btiles[offset*4+2] = (data & 0x0000ff00) >> 8;
-	m_btiles[offset*4+3] = (data & 0x000000ff) >> 0;
+	m_btiles[offset * 4 + 0] = (data & 0xff000000) >> 24;
+	m_btiles[offset * 4 + 1] = (data & 0x00ff0000) >> 16;
+	m_btiles[offset * 4 + 2] = (data & 0x0000ff00) >> 8;
+	m_btiles[offset * 4 + 3] = (data & 0x000000ff) >> 0;
+}
+
+template <unsigned Which>
+void skns_state::tilemapram_w(offs_t offset, u32 data, u32 mem_mask)
+{
+	COMBINE_DATA(&m_tilemap_ram[Which][offset]);
+	m_tilemap[Which]->mark_tile_dirty(offset);
 }
 
 void skns_state::skns_map(address_map &map)
@@ -732,30 +759,30 @@ void skns_state::skns_map(address_map &map)
 	map(0x00c00000, 0x00c00001).rw("ymz", FUNC(ymz280b_device::read), FUNC(ymz280b_device::write)); /* ymz280_w (sound) */
 	map(0x01000000, 0x0100000f).rw("rtc", FUNC(msm6242_device::read), FUNC(msm6242_device::write));
 	map(0x01800000, 0x01800003).w(FUNC(skns_state::hit2_w));
-	map(0x02000000, 0x02003fff).ram().share("spriteram"); /* sprite ram */
-	map(0x02100000, 0x0210003f).ram().share("spc_regs"); /* sprite registers */
-	map(0x02400000, 0x0240007f).ram().w(FUNC(skns_state::v3_regs_w)).share("v3_regs"); /* tilemap registers */
-	map(0x02500000, 0x02503fff).ram().w(FUNC(skns_state::tilemapA_w)).share("tilemapa_ram"); /* tilemap A */
-	map(0x02504000, 0x02507fff).ram().w(FUNC(skns_state::tilemapB_w)).share("tilemapb_ram"); /* tilemap B */
-	map(0x02600000, 0x02607fff).ram().share("v3slc_ram"); /* tilemap linescroll */
-	map(0x02a00000, 0x02a0001f).ram().w(FUNC(skns_state::pal_regs_w)).share("pal_regs");
-	map(0x02a40000, 0x02a5ffff).ram().w(FUNC(skns_state::palette_ram_w)).share("palette_ram");
+	map(0x02000000, 0x02003fff).ram().share(m_spriteram); /* sprite ram */
+	map(0x02100000, 0x0210003f).ram().share(m_spc_regs); /* sprite registers */
+	map(0x02400000, 0x0240007f).ram().w(FUNC(skns_state::v3_regs_w)).share(m_v3_regs); /* tilemap registers */
+	map(0x02500000, 0x02503fff).ram().w(FUNC(skns_state::tilemapram_w<0>)).share(m_tilemap_ram[0]); /* tilemap A */
+	map(0x02504000, 0x02507fff).ram().w(FUNC(skns_state::tilemapram_w<1>)).share(m_tilemap_ram[1]); /* tilemap B */
+	map(0x02600000, 0x02607fff).ram().share(m_v3slc_ram); /* tilemap linescroll */
+	map(0x02a00000, 0x02a0001f).ram().w(FUNC(skns_state::pal_regs_w)).share(m_pal_regs);
+	map(0x02a40000, 0x02a5ffff).ram().w(FUNC(skns_state::palette_ram_w)).share(m_palette_ram);
 	map(0x02f00000, 0x02f000ff).rw(FUNC(skns_state::hit_r), FUNC(skns_state::hit_w));
 	map(0x04000000, 0x041fffff).rom().region("game", 0);
-	map(0x04800000, 0x0483ffff).ram().w(FUNC(skns_state::v3t_w)).share("v3t_ram"); /* tilemap b ram based tiles */
+	map(0x04800000, 0x0483ffff).ram().w(FUNC(skns_state::v3t_w)).share(m_v3t_ram); /* tilemap b ram based tiles */
 	map(0x05000000, 0x05000003).nopw();  /* watchdog, probably.  Always writes 0 */
-	map(0x06000000, 0x060fffff).ram().share("main_ram");
-	map(0xc0000000, 0xc0000fff).ram().share("cache_ram"); /* 'cache' RAM */
+	map(0x06000000, 0x060fffff).ram().share(m_main_ram);
+	map(0xc0000000, 0xc0000fff).ram().share(m_cache_ram); /* 'cache' RAM */
 }
 
 /***** GFX DECODE *****/
 
 static GFXDECODE_START( skns_bg )
 	/* "spritegen" is sprites, RLE encoded */
-	GFXDECODE_ENTRY( "gfx2", 0, gfx_16x16x8_raw, 0x000, 128 )
-	GFXDECODE_ENTRY( "gfx3", 0, gfx_16x16x8_raw, 0x000, 128 )
-	GFXDECODE_ENTRY( "gfx2", 0, gfx_16x16x4_packed_lsb, 0x000, 128 )
-	GFXDECODE_ENTRY( "gfx3", 0, gfx_16x16x4_packed_lsb, 0x000, 128 )
+	GFXDECODE_ENTRY( "tiles0", 0, gfx_16x16x8_raw,        0x4000, 64 )
+	GFXDECODE_ENTRY( "tiles0", 0, gfx_16x16x4_packed_lsb, 0x4000, 64 )
+	GFXDECODE_ENTRY( "tiles1", 0, gfx_16x16x8_raw,        0x4000, 64 )
+	GFXDECODE_ENTRY( "tiles1", 0, gfx_16x16x4_packed_lsb, 0x4000, 64 )
 GFXDECODE_END
 
 /***** MACHINE DRIVER *****/
@@ -868,7 +895,7 @@ void skns_state::sknsk(machine_config &config)
 
 /***** IDLE SKIPPING *****/
 
-uint32_t skns_state::gutsn_speedup_r()
+u32 skns_state::gutsn_speedup_r()
 {
 /*
     0402206A: MOV.L   @($8C,PC),R5
@@ -878,39 +905,46 @@ uint32_t skns_state::gutsn_speedup_r()
     04022072: CMP/EQ  R2,R3
     04022074: BT      $0402206C
 */
-	if (m_maincpu->pc()==0x402206e)
+	if (!machine().side_effects_disabled())
 	{
-		if(m_main_ram[0x00078/4] == m_main_ram[0x0c780/4])
-			m_maincpu->spin_until_interrupt();
+		if (m_maincpu->pc() == 0x402206e)
+		{
+			if (m_main_ram[0x00078 / 4] == m_main_ram[0x0c780 / 4])
+				m_maincpu->spin_until_interrupt();
+		}
 	}
-	return m_main_ram[0x0c780/4];
+	return m_main_ram[0x0c780 / 4];
 }
 
-uint32_t skns_state::cyvern_speedup_r()
+u32 skns_state::cyvern_speedup_r()
 {
-	if (m_maincpu->pc()==0x402ebd2) m_maincpu->spin_until_interrupt();
-	return m_main_ram[0x4d3c8/4];
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc() == 0x402ebd2) m_maincpu->spin_until_interrupt();
+	return m_main_ram[0x4d3c8 / 4];
 }
 
-uint32_t skns_state::puzzloopj_speedup_r()
+u32 skns_state::puzzloopj_speedup_r()
 {
-	if (m_maincpu->pc()==0x401dca0) m_maincpu->spin_until_interrupt();
-	return m_main_ram[0x86714/4];
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc() == 0x401dca0) m_maincpu->spin_until_interrupt();
+	return m_main_ram[0x86714 / 4];
 }
 
-uint32_t skns_state::puzzloopa_speedup_r()
+u32 skns_state::puzzloopa_speedup_r()
 {
-	if (m_maincpu->pc()==0x401d9d4) m_maincpu->spin_until_interrupt();
-	return m_main_ram[0x85bcc/4];
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc() == 0x401d9d4) m_maincpu->spin_until_interrupt();
+	return m_main_ram[0x85bcc / 4];
 }
 
-uint32_t skns_state::puzzloopu_speedup_r()
+u32 skns_state::puzzloopu_speedup_r()
 {
-	if (m_maincpu->pc()==0x401dab0) m_maincpu->spin_until_interrupt();
-	return m_main_ram[0x85cec/4];
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc() == 0x401dab0) m_maincpu->spin_until_interrupt();
+	return m_main_ram[0x85cec / 4];
 }
 
-uint32_t skns_state::puzzloope_speedup_r()
+u32 skns_state::puzzloope_speedup_r()
 {
 /*
     0401DA12: MOV.L   @($80,PC),R1
@@ -919,62 +953,72 @@ uint32_t skns_state::puzzloope_speedup_r()
     0401DA18: BF      $0401DA26
     0401DA26: BRA     $0401DA12
 */
-	if (m_maincpu->pc()==0x401da14) m_maincpu->spin_until_interrupt();
-	return m_main_ram[0x81d38/4];
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc() == 0x401da14) m_maincpu->spin_until_interrupt();
+	return m_main_ram[0x81d38 / 4];
 }
 
-uint32_t skns_state::senknow_speedup_r()
+u32 skns_state::senknow_speedup_r()
 {
-	if (m_maincpu->pc()==0x4017dce) m_maincpu->spin_until_interrupt();
-	return m_main_ram[0x0000dc/4];
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc() == 0x4017dce) m_maincpu->spin_until_interrupt();
+	return m_main_ram[0x0000dc / 4];
 }
 
-uint32_t skns_state::teljan_speedup_r()
+u32 skns_state::teljan_speedup_r()
 {
-	if (m_maincpu->pc()==0x401ba32) m_maincpu->spin_until_interrupt();
-	return m_main_ram[0x002fb4/4];
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc() == 0x401ba32) m_maincpu->spin_until_interrupt();
+	return m_main_ram[0x002fb4 / 4];
 }
 
-uint32_t skns_state::jjparads_speedup_r()
+u32 skns_state::jjparads_speedup_r()
 {
-	if (m_maincpu->pc()==0x4015e84) m_maincpu->spin_until_interrupt();
-	return m_main_ram[0x000994/4];
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc() == 0x4015e84) m_maincpu->spin_until_interrupt();
+	return m_main_ram[0x000994 / 4];
 }
 
-uint32_t skns_state::jjparad2_speedup_r()
+u32 skns_state::jjparad2_speedup_r()
 {
-	if (m_maincpu->pc()==0x401620a) m_maincpu->spin_until_interrupt();
-	return m_main_ram[0x000984/4];
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc() == 0x401620a) m_maincpu->spin_until_interrupt();
+	return m_main_ram[0x000984 / 4];
 }
 
-uint32_t skns_state::ryouran_speedup_r()
+u32 skns_state::ryouran_speedup_r()
 {
-	if (m_maincpu->pc()==0x40182ce) m_maincpu->spin_until_interrupt();
-	return m_main_ram[0x000a14/4];
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc() == 0x40182ce) m_maincpu->spin_until_interrupt();
+	return m_main_ram[0x000a14 / 4];
 }
 
-uint32_t skns_state::galpans2_speedup_r()
+u32 skns_state::galpans2_speedup_r()
 {
-	if (m_maincpu->pc()==0x4049ae2) m_maincpu->spin_until_interrupt();
-	return m_main_ram[0x0fb6bc/4];
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc() == 0x4049ae2) m_maincpu->spin_until_interrupt();
+	return m_main_ram[0x0fb6bc / 4];
 }
 
-uint32_t skns_state::panicstr_speedup_r()
+u32 skns_state::panicstr_speedup_r()
 {
-	if (m_maincpu->pc()==0x404e68a) m_maincpu->spin_until_interrupt();
-	return m_main_ram[0x0f19e4/4];
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc() == 0x404e68a) m_maincpu->spin_until_interrupt();
+	return m_main_ram[0x0f19e4 / 4];
 }
 
-uint32_t skns_state::sengekis_speedup_r()// 60006ee  600308e
+u32 skns_state::sengekis_speedup_r()// 60006ee  600308e
 {
-	if (m_maincpu->pc()==0x60006ec) m_maincpu->spin_until_interrupt();
-	return m_main_ram[0xb74bc/4];
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc() == 0x60006ec) m_maincpu->spin_until_interrupt();
+	return m_main_ram[0xb74bc / 4];
 }
 
-uint32_t skns_state::sengekij_speedup_r()// 60006ee  600308e
+u32 skns_state::sengekij_speedup_r()// 60006ee  600308e
 {
-	if (m_maincpu->pc()==0x60006ec) m_maincpu->spin_until_interrupt();
-	return m_main_ram[0xb7380/4];
+	if (!machine().side_effects_disabled())
+		if (m_maincpu->pc() == 0x60006ec) m_maincpu->spin_until_interrupt();
+	return m_main_ram[0xb7380 / 4];
 }
 
 void skns_state::init_drc()
@@ -986,7 +1030,7 @@ void skns_state::init_drc()
 	m_maincpu->sh2drc_add_fastram(0x02600000, 0x02607fff, 0, &m_v3slc_ram[0]);
 }
 
-void skns_state::set_drc_pcflush(uint32_t addr)
+void skns_state::set_drc_pcflush(u32 addr)
 {
 	m_maincpu->sh2drc_add_pcflush(addr);
 }
@@ -1069,9 +1113,9 @@ ROM_START( skns )
 
 	ROM_REGION( 0x800000, "spritegen", ROMREGION_ERASE00 ) // Sprites
 
-	ROM_REGION( 0x800000, "gfx2", ROMREGION_ERASE00 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", ROMREGION_ERASE00 ) // Tiles Plane A
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 
 	ROM_REGION( 0x400000, "ymz", ROMREGION_ERASE00 ) // Samples
 ROM_END
@@ -1088,11 +1132,11 @@ ROM_START( cyvern )
 	ROM_LOAD( "cv100-00.u24", 0x000000, 0x400000, CRC(cd4ae88a) SHA1(925f4ae01a6ad3633be2a61be69e163f05401cf6) )
 	ROM_LOAD( "cv101-00.u20", 0x400000, 0x400000, CRC(a6cb3f0b) SHA1(8d83f44a096ca0a70962ca4c602c4331874c8560) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "cv200-00.u16", 0x000000, 0x400000, CRC(ddc8c67e) SHA1(9b99e87e69e88011e6d693d19ac5e115b4fa50b0) )
 	ROM_LOAD( "cv201-00.u13", 0x400000, 0x400000, CRC(65863321) SHA1(b8b75f50406068ffc3fca3887d2f0a653ca491c9) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "cv210-00.u18", 0x400000, 0x400000, CRC(7486bf3a) SHA1(3b4285ca570e9c5ad396c615bfc054372d1b0162) )
@@ -1112,11 +1156,11 @@ ROM_START( cyvernj )
 	ROM_LOAD( "cv100-00.u24", 0x000000, 0x400000, CRC(cd4ae88a) SHA1(925f4ae01a6ad3633be2a61be69e163f05401cf6) )
 	ROM_LOAD( "cv101-00.u20", 0x400000, 0x400000, CRC(a6cb3f0b) SHA1(8d83f44a096ca0a70962ca4c602c4331874c8560) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "cv200-00.u16", 0x000000, 0x400000, CRC(ddc8c67e) SHA1(9b99e87e69e88011e6d693d19ac5e115b4fa50b0) )
 	ROM_LOAD( "cv201-00.u13", 0x400000, 0x400000, CRC(65863321) SHA1(b8b75f50406068ffc3fca3887d2f0a653ca491c9) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "cv210-00.u18", 0x400000, 0x400000, CRC(7486bf3a) SHA1(3b4285ca570e9c5ad396c615bfc054372d1b0162) )
@@ -1136,11 +1180,11 @@ ROM_START( galpani4 )
 	ROM_LOAD( "gp4-100-00.u24", 0x000000, 0x200000, CRC(1df61f01) SHA1(a9e95bbb3013e8f2fd01243b1b392ff07b4f7d02) )
 	ROM_LOAD( "gp4-101-00.u20", 0x200000, 0x100000, CRC(8e2c9349) SHA1(a58fa9bcc9684ed4558e3395d592b64a1978a902) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gp4-200-00.u16", 0x000000, 0x200000, CRC(f0781376) SHA1(aeab9553a9af922524e528eb2d019cf36b6e2094) )
 	ROM_LOAD( "gp4-201-00.u18", 0x200000, 0x200000, CRC(10c4b183) SHA1(80e05f3932495ad4fc9bf928fa66e6d2931bbb06) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1164,11 +1208,11 @@ ROM_START( galpani4j )
 	ROM_LOAD( "gp4-100-00.u24", 0x000000, 0x200000, CRC(1df61f01) SHA1(a9e95bbb3013e8f2fd01243b1b392ff07b4f7d02) )
 	ROM_LOAD( "gp4-101-00.u20", 0x200000, 0x100000, CRC(8e2c9349) SHA1(a58fa9bcc9684ed4558e3395d592b64a1978a902) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gp4-200-00.u16", 0x000000, 0x200000, CRC(f0781376) SHA1(aeab9553a9af922524e528eb2d019cf36b6e2094) )
 	ROM_LOAD( "gp4-201-00.u18", 0x200000, 0x200000, CRC(10c4b183) SHA1(80e05f3932495ad4fc9bf928fa66e6d2931bbb06) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1187,11 +1231,11 @@ ROM_START( galpani4a ) // ROM-BOARD NEP-16 part number GP04A00068 with extra sou
 	ROM_LOAD( "gp4-100-00.u24", 0x000000, 0x200000, CRC(1df61f01) SHA1(a9e95bbb3013e8f2fd01243b1b392ff07b4f7d02) )
 	ROM_LOAD( "gp4-101-00.u20", 0x200000, 0x100000, CRC(8e2c9349) SHA1(a58fa9bcc9684ed4558e3395d592b64a1978a902) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gp4-200-00.u16", 0x000000, 0x200000, CRC(f0781376) SHA1(aeab9553a9af922524e528eb2d019cf36b6e2094) )
 	ROM_LOAD( "gp4-201-00.u18", 0x200000, 0x200000, CRC(10c4b183) SHA1(80e05f3932495ad4fc9bf928fa66e6d2931bbb06) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1215,11 +1259,11 @@ ROM_START( galpani4k ) /* ROM-BOARD NEP-16 part number GP04K00372 with extra sou
 	ROM_LOAD( "gp4-100-00.u24", 0x000000, 0x200000, CRC(1df61f01) SHA1(a9e95bbb3013e8f2fd01243b1b392ff07b4f7d02) )
 	ROM_LOAD( "gp4-101-00.u20", 0x200000, 0x100000, CRC(8e2c9349) SHA1(a58fa9bcc9684ed4558e3395d592b64a1978a902) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gp4-200-00.u16", 0x000000, 0x200000, CRC(f0781376) SHA1(aeab9553a9af922524e528eb2d019cf36b6e2094) )
 	ROM_LOAD( "gp4-201-00.u18", 0x200000, 0x200000, CRC(10c4b183) SHA1(80e05f3932495ad4fc9bf928fa66e6d2931bbb06) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1245,11 +1289,11 @@ ROM_START( galpaniex ) /* ROM-BOARD NEP-16 part number GP04K01334 with extra sou
 	ROM_LOAD( "gp4-100-00.u24", 0x000000, 0x200000, CRC(1df61f01) SHA1(a9e95bbb3013e8f2fd01243b1b392ff07b4f7d02) )
 	ROM_LOAD( "gp4-101-00.u20", 0x200000, 0x100000, CRC(8e2c9349) SHA1(a58fa9bcc9684ed4558e3395d592b64a1978a902) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gp4-200-00.u16", 0x000000, 0x200000, CRC(f0781376) SHA1(aeab9553a9af922524e528eb2d019cf36b6e2094) )
 	ROM_LOAD( "gp4-201-00.u18", 0x200000, 0x200000, CRC(10c4b183) SHA1(80e05f3932495ad4fc9bf928fa66e6d2931bbb06) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1269,11 +1313,11 @@ ROM_START( galpanidx )
 	ROM_LOAD( "gp4-100-00.u24", 0x000000, 0x200000, CRC(1df61f01) SHA1(a9e95bbb3013e8f2fd01243b1b392ff07b4f7d02) )
 	ROM_LOAD( "gp4-101-00.u20", 0x200000, 0x100000, CRC(8e2c9349) SHA1(a58fa9bcc9684ed4558e3395d592b64a1978a902) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gp4-200-00.u16", 0x000000, 0x200000, CRC(f0781376) SHA1(aeab9553a9af922524e528eb2d019cf36b6e2094) )
 	ROM_LOAD( "gp4-201-00.u18", 0x200000, 0x200000, CRC(10c4b183) SHA1(80e05f3932495ad4fc9bf928fa66e6d2931bbb06) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1293,11 +1337,11 @@ ROM_START( galpanisu )
 	ROM_LOAD( "gp4-100-00.u24", 0x000000, 0x200000, CRC(1df61f01) SHA1(a9e95bbb3013e8f2fd01243b1b392ff07b4f7d02) )
 	ROM_LOAD( "gp4-101-00.u20", 0x200000, 0x100000, CRC(8e2c9349) SHA1(a58fa9bcc9684ed4558e3395d592b64a1978a902) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gp4-200-00.u16", 0x000000, 0x200000, CRC(f0781376) SHA1(aeab9553a9af922524e528eb2d019cf36b6e2094) )
 	ROM_LOAD( "gp4-201-00.u18", 0x200000, 0x200000, CRC(10c4b183) SHA1(80e05f3932495ad4fc9bf928fa66e6d2931bbb06) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1322,11 +1366,11 @@ ROM_START( galpanis )
 	ROM_LOAD( "gps-101-00.u20", 0x400000, 0x400000, CRC(49f764b6) SHA1(9f4289858c3dac625ef623cc381a47b45aa5d8e2) )
 	ROM_LOAD( "gps-102-00.u17", 0x800000, 0x400000, CRC(51980272) SHA1(6c0706d913b33995579aaf0688c4bf26d6d35a78) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gps-200-00.u16", 0x000000, 0x400000, CRC(c146a09e) SHA1(5af5a7b9d9a55ec7aba3fd85a3a0211b92b1b84f) )
 	ROM_LOAD( "gps-201-00.u13", 0x400000, 0x400000, CRC(9dfa2dc6) SHA1(a058c42fd76c23c0e5c8c11f5617fd29e056be7d) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1346,11 +1390,11 @@ ROM_START( galpanise )
 	ROM_LOAD( "gps-101-00.u20", 0x400000, 0x400000, CRC(49f764b6) SHA1(9f4289858c3dac625ef623cc381a47b45aa5d8e2) )
 	ROM_LOAD( "gps-102-00.u17", 0x800000, 0x400000, CRC(51980272) SHA1(6c0706d913b33995579aaf0688c4bf26d6d35a78) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gps-200-00.u16", 0x000000, 0x400000, CRC(c146a09e) SHA1(5af5a7b9d9a55ec7aba3fd85a3a0211b92b1b84f) )
 	ROM_LOAD( "gps-201-00.u13", 0x400000, 0x400000, CRC(9dfa2dc6) SHA1(a058c42fd76c23c0e5c8c11f5617fd29e056be7d) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1370,11 +1414,11 @@ ROM_START( galpanisj )
 	ROM_LOAD( "gps-101-00.u20", 0x400000, 0x400000, CRC(49f764b6) SHA1(9f4289858c3dac625ef623cc381a47b45aa5d8e2) )
 	ROM_LOAD( "gps-102-00.u17", 0x800000, 0x400000, CRC(51980272) SHA1(6c0706d913b33995579aaf0688c4bf26d6d35a78) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gps-200-00.u16", 0x000000, 0x400000, CRC(c146a09e) SHA1(5af5a7b9d9a55ec7aba3fd85a3a0211b92b1b84f) )
 	ROM_LOAD( "gps-201-00.u13", 0x400000, 0x400000, CRC(9dfa2dc6) SHA1(a058c42fd76c23c0e5c8c11f5617fd29e056be7d) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1394,11 +1438,11 @@ ROM_START( galpanisa )
 	ROM_LOAD( "gps-101-00.u20", 0x400000, 0x400000, CRC(49f764b6) SHA1(9f4289858c3dac625ef623cc381a47b45aa5d8e2) )
 	ROM_LOAD( "gps-102-00.u17", 0x800000, 0x400000, CRC(51980272) SHA1(6c0706d913b33995579aaf0688c4bf26d6d35a78) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gps-200-00.u16", 0x000000, 0x400000, CRC(c146a09e) SHA1(5af5a7b9d9a55ec7aba3fd85a3a0211b92b1b84f) )
 	ROM_LOAD( "gps-201-00.u13", 0x400000, 0x400000, CRC(9dfa2dc6) SHA1(a058c42fd76c23c0e5c8c11f5617fd29e056be7d) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1418,11 +1462,11 @@ ROM_START( galpanisk )
 	ROM_LOAD( "gps-101-00.u20", 0x400000, 0x400000, CRC(49f764b6) SHA1(9f4289858c3dac625ef623cc381a47b45aa5d8e2) )
 	ROM_LOAD( "gps-102-00.u17", 0x800000, 0x400000, CRC(51980272) SHA1(6c0706d913b33995579aaf0688c4bf26d6d35a78) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gps-200-00.u16", 0x000000, 0x400000, CRC(c146a09e) SHA1(5af5a7b9d9a55ec7aba3fd85a3a0211b92b1b84f) )
 	ROM_LOAD( "gps-201-00.u13", 0x400000, 0x400000, CRC(9dfa2dc6) SHA1(a058c42fd76c23c0e5c8c11f5617fd29e056be7d) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1442,11 +1486,11 @@ ROM_START( galpaniska )
 	ROM_LOAD( "gps-101-00.u20", 0x400000, 0x400000, CRC(49f764b6) SHA1(9f4289858c3dac625ef623cc381a47b45aa5d8e2) )
 	ROM_LOAD( "gps-102-00.u17", 0x800000, 0x400000, CRC(51980272) SHA1(6c0706d913b33995579aaf0688c4bf26d6d35a78) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gps-200-00.u16", 0x000000, 0x400000, CRC(c146a09e) SHA1(5af5a7b9d9a55ec7aba3fd85a3a0211b92b1b84f) )
 	ROM_LOAD( "gps-201-00.u13", 0x400000, 0x400000, CRC(9dfa2dc6) SHA1(a058c42fd76c23c0e5c8c11f5617fd29e056be7d) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1467,11 +1511,11 @@ ROM_START( galpans2 ) //only the 2 program ROMs were dumped, but mask ROMs are s
 	ROM_LOAD( "gs210200.u8",  0x800000, 0x400000, CRC(25b4f56b) SHA1(f9a33d5ed54a04ecece3035e75508d191bbe74b1) )
 	ROM_LOAD( "gs210300.u32", 0xc00000, 0x400000, CRC(db6d4424) SHA1(0a88dafd0ee2490ff2ef39ce8eb1931c41bdda42) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gs220000.u17", 0x000000, 0x400000, CRC(5caae1c0) SHA1(8f77e4cf018d7290b2d804cbff9fccf0bf4d2404) )
 	ROM_LOAD( "gs220100.u9",  0x400000, 0x400000, CRC(8d51f197) SHA1(19d2afab823ea179918e7bcbf4df2283e77570f0) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "gs221000.u3",  0x400000, 0x400000, CRC(58800a18) SHA1(5e6d55ecd12275662d6f59559e137b759f23fff6) )
@@ -1493,11 +1537,11 @@ ROM_START( galpans2j )
 	ROM_LOAD( "gs210200.u8",  0x800000, 0x400000, CRC(25b4f56b) SHA1(f9a33d5ed54a04ecece3035e75508d191bbe74b1) )
 	ROM_LOAD( "gs210300.u32", 0xc00000, 0x400000, CRC(db6d4424) SHA1(0a88dafd0ee2490ff2ef39ce8eb1931c41bdda42) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gs220000.u17", 0x000000, 0x400000, CRC(5caae1c0) SHA1(8f77e4cf018d7290b2d804cbff9fccf0bf4d2404) )
 	ROM_LOAD( "gs220100.u9",  0x400000, 0x400000, CRC(8d51f197) SHA1(19d2afab823ea179918e7bcbf4df2283e77570f0) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "gs221000.u3",  0x400000, 0x400000, CRC(58800a18) SHA1(5e6d55ecd12275662d6f59559e137b759f23fff6) )
@@ -1519,11 +1563,11 @@ ROM_START( galpans2a )
 	ROM_LOAD( "gs210200.u8",  0x800000, 0x400000, CRC(25b4f56b) SHA1(f9a33d5ed54a04ecece3035e75508d191bbe74b1) )
 	ROM_LOAD( "gs210300.u32", 0xc00000, 0x400000, CRC(db6d4424) SHA1(0a88dafd0ee2490ff2ef39ce8eb1931c41bdda42) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gs220000.u17", 0x000000, 0x400000, CRC(5caae1c0) SHA1(8f77e4cf018d7290b2d804cbff9fccf0bf4d2404) )
 	ROM_LOAD( "gs220100.u9",  0x400000, 0x400000, CRC(8d51f197) SHA1(19d2afab823ea179918e7bcbf4df2283e77570f0) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "gs221000.u3",  0x400000, 0x400000, CRC(58800a18) SHA1(5e6d55ecd12275662d6f59559e137b759f23fff6) )
@@ -1545,11 +1589,11 @@ ROM_START( galpansu ) // standard Kaneko NOVA SYSTEM ROM 4 BOARD cart with genui
 	ROM_LOAD( "gs210200.u8",  0x800000, 0x400000, CRC(25b4f56b) SHA1(f9a33d5ed54a04ecece3035e75508d191bbe74b1) )
 	ROM_LOAD( "gs210300.u32", 0xc00000, 0x400000, CRC(db6d4424) SHA1(0a88dafd0ee2490ff2ef39ce8eb1931c41bdda42) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gs220000.u17", 0x000000, 0x400000, CRC(5caae1c0) SHA1(8f77e4cf018d7290b2d804cbff9fccf0bf4d2404) )
 	ROM_LOAD( "gs220100.u9",  0x400000, 0x400000, CRC(8d51f197) SHA1(19d2afab823ea179918e7bcbf4df2283e77570f0) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "gs221000.u3",  0x400000, 0x400000, CRC(58800a18) SHA1(5e6d55ecd12275662d6f59559e137b759f23fff6) )
@@ -1568,11 +1612,11 @@ The ROM board is wired to accept 16MBit SOP44 maskROMs.
 The actual ROMs used are 32M. There are some wire mods to enable the
 higher capacity ROMs, basically wiring pin 44 of the SOP44's to
 some logic to enable it.
-All of the SOP44 ROMs are from Gals Panic 2, but because Gals Panic 2
+All of the SOP44 ROMs are from Gals Panic S2, but because Gals Panic S2
 uses a different ROM board the Gals Panic SU ROMs are at different
 locations.
 For Gals Panic SU, the 32M ROMs can be taken from the existing
-Gals Panic 2 set.
+Gals Panic S2 set.
 
 */
 
@@ -1589,11 +1633,11 @@ ROM_START( galpansua )
 	ROM_LOAD( "17", 0x800000, 0x400000, CRC(25b4f56b) SHA1(f9a33d5ed54a04ecece3035e75508d191bbe74b1) ) // == gs210200.u8
 	ROM_LOAD( "32", 0xc00000, 0x400000, CRC(db6d4424) SHA1(0a88dafd0ee2490ff2ef39ce8eb1931c41bdda42) ) // == gs210300.u32
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "16", 0x000000, 0x400000, CRC(5caae1c0) SHA1(8f77e4cf018d7290b2d804cbff9fccf0bf4d2404) ) // == gs220000.u17
 	ROM_LOAD( "13", 0x400000, 0x400000, CRC(8d51f197) SHA1(19d2afab823ea179918e7bcbf4df2283e77570f0) ) // == gs220100.u9
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "7",  0x400000, 0x400000, CRC(58800a18) SHA1(5e6d55ecd12275662d6f59559e137b759f23fff6) ) // == gs221000.u3
@@ -1612,10 +1656,10 @@ ROM_START( galpans3 )
 	ROM_REGION( 0x1000000, "spritegen", 0 ) // Sprites
 	ROM_LOAD( "u24.bin", 0x000000, 0x800000, CRC(70613168) SHA1(637c50e733dbc0226b1e0acc8000faa7e8977cb6) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "u16.bin", 0x000000, 0x800000, CRC(a96daf2a) SHA1(40f4c32158d320146aeeac34c15ca6816a6876bc) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1633,10 +1677,10 @@ ROM_START( gutsn )
 	ROM_REGION( 0x400000, "spritegen", 0 ) // Sprites
 	ROM_LOAD( "gts10000.u24", 0x000000, 0x400000, CRC(1959979e) SHA1(92a68784664dd833ca6fcca1b15cd46b9365d081) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "gts20000.u16", 0x000000, 0x400000, CRC(c443aac3) SHA1(b0416a09ead26077e9276bae98d94eeb1cf86877) )
 
-	ROM_REGION( 0x400000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x400000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1655,10 +1699,10 @@ ROM_START( panicstr )
 	ROM_LOAD( "ps-10000.u24", 0x000000, 0x400000, CRC(294b2f14) SHA1(90cbd0acdaa2d89d208c28aae33ab57c03624089) )
 	ROM_LOAD( "ps110100.u20", 0x400000, 0x400000, CRC(e292f393) SHA1(b0914f7f0abf9f821f2592c289ea4e3b3e7f819a) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "ps120000.u16", 0x000000, 0x400000, CRC(d772ac15) SHA1(6bf7b9bfccdcb7481b21fa2ab9b683d79033a192) )
 
-	ROM_REGION( 0x400000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x400000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1676,10 +1720,10 @@ ROM_START( puzzloop )
 	ROM_REGION( 0x800000, "spritegen", 0 ) // Sprites
 	ROM_LOAD( "pzl10000.u24", 0x000000, 0x400000, CRC(35bf6897) SHA1(8a1f1f5234a61971a62401633de1dec1920fc4da) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "pzl20000.u16", 0x000000, 0x400000, CRC(ff558e68) SHA1(69a50c8100edbf2d5d92ce14b3f079f76c544bdd) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "pzl21000.u18", 0x400000, 0x400000, CRC(c8b3be64) SHA1(6da9ca8b963ebf10df6bc02bd1bdc66392e2fa60) )
@@ -1698,10 +1742,10 @@ ROM_START( puzzloope )
 	ROM_REGION( 0x800000, "spritegen", 0 ) // Sprites
 	ROM_LOAD( "pzl10000.u24", 0x000000, 0x400000, CRC(35bf6897) SHA1(8a1f1f5234a61971a62401633de1dec1920fc4da) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "pzl20000.u16", 0x000000, 0x400000, CRC(ff558e68) SHA1(69a50c8100edbf2d5d92ce14b3f079f76c544bdd) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "pzl21000.u18", 0x400000, 0x400000, CRC(c8b3be64) SHA1(6da9ca8b963ebf10df6bc02bd1bdc66392e2fa60) )
@@ -1720,10 +1764,10 @@ ROM_START( puzzloopj )
 	ROM_REGION( 0x800000, "spritegen", 0 ) // Sprites
 	ROM_LOAD( "pzl10000.u24", 0x000000, 0x400000, CRC(35bf6897) SHA1(8a1f1f5234a61971a62401633de1dec1920fc4da) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "pzl20000.u16", 0x000000, 0x400000, CRC(ff558e68) SHA1(69a50c8100edbf2d5d92ce14b3f079f76c544bdd) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "pzl21000.u18", 0x400000, 0x400000, CRC(c8b3be64) SHA1(6da9ca8b963ebf10df6bc02bd1bdc66392e2fa60) )
@@ -1742,10 +1786,10 @@ ROM_START( puzzloopa )
 	ROM_REGION( 0x800000, "spritegen", 0 ) // Sprites
 	ROM_LOAD( "pzl10000.u24", 0x000000, 0x400000, CRC(35bf6897) SHA1(8a1f1f5234a61971a62401633de1dec1920fc4da) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "pzl20000.u16", 0x000000, 0x400000, CRC(ff558e68) SHA1(69a50c8100edbf2d5d92ce14b3f079f76c544bdd) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "pzl21000.u18", 0x400000, 0x400000, CRC(c8b3be64) SHA1(6da9ca8b963ebf10df6bc02bd1bdc66392e2fa60) )
@@ -1764,10 +1808,10 @@ ROM_START( puzzloopk )
 	ROM_REGION( 0x800000, "spritegen", 0 ) // Sprites
 	ROM_LOAD( "pzl10000.u24", 0x000000, 0x400000, CRC(35bf6897) SHA1(8a1f1f5234a61971a62401633de1dec1920fc4da) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "pzl20000.u16", 0x000000, 0x400000, CRC(ff558e68) SHA1(69a50c8100edbf2d5d92ce14b3f079f76c544bdd) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "pzl21000.u18", 0x400000, 0x400000, CRC(c8b3be64) SHA1(6da9ca8b963ebf10df6bc02bd1bdc66392e2fa60) )
@@ -1786,10 +1830,10 @@ ROM_START( puzzloopkbl )
 	ROM_REGION( 0x800000, "spritegen", 0 ) // Sprites
 	ROM_LOAD( "l1.u10", 0x000000, 0x400000, CRC(35bf6897) SHA1(8a1f1f5234a61971a62401633de1dec1920fc4da) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "l2.u98", 0x000000, 0x400000, CRC(ff558e68) SHA1(69a50c8100edbf2d5d92ce14b3f079f76c544bdd) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "l3.u99", 0x400000, 0x400000, CRC(c8b3be64) SHA1(6da9ca8b963ebf10df6bc02bd1bdc66392e2fa60) )
@@ -1808,10 +1852,10 @@ ROM_START( puzzloopu )
 	ROM_REGION( 0x800000, "spritegen", 0 ) // Sprites
 	ROM_LOAD( "pzl10000.u24", 0x000000, 0x400000, CRC(35bf6897) SHA1(8a1f1f5234a61971a62401633de1dec1920fc4da) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "pzl20000.u16", 0x000000, 0x400000, CRC(ff558e68) SHA1(69a50c8100edbf2d5d92ce14b3f079f76c544bdd) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "pzl21000.u18", 0x400000, 0x400000, CRC(c8b3be64) SHA1(6da9ca8b963ebf10df6bc02bd1bdc66392e2fa60) )
@@ -1832,10 +1876,10 @@ ROM_START( jjparads )
 	ROM_LOAD( "jp101-00.u20", 0x400000, 0x400000, CRC(70cc8c24) SHA1(a4805ce19f512b047829548b635e68690d714175) )
 	ROM_LOAD( "jp102-00.u17", 0x800000, 0x400000, CRC(35401c1e) SHA1(38fe86a08555bb823b8d64ac043330aaaa6b8892) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x200000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "jp200-00.u16", 0x000000, 0x200000, CRC(493d63db) SHA1(4b8fe7ff1ae14a914a675ce4072a4d9e5cfc08b0) )
 
-	ROM_REGION( 0x400000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x400000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1855,11 +1899,11 @@ ROM_START( jjparad2 )
 	ROM_LOAD( "jp210100.u20", 0x400000, 0x400000, CRC(42415e0c) SHA1(f7bff86d55fa9002fbd14e4c62f9d3df8faaf7d0) )
 	ROM_LOAD( "jp210200.u8",  0x800000, 0x400000, CRC(26731745) SHA1(8939d36b82b10b1010e4b924e6b9fdd4742efe48) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "jp220000.u17", 0x000000, 0x400000, CRC(d0e71873) SHA1(c6ffba3624e6d4c2d4e12ef7d88a02cbc3867b18) )
 	ROM_LOAD( "jp220100.u9",  0x400000, 0x400000, CRC(4c7d964d) SHA1(3352cd866a64466f4f5a990c2c5e3e28e7028a99) )
 
-	ROM_REGION( 0x400000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x400000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1880,11 +1924,11 @@ ROM_START( sengekis )
 	ROM_LOAD( "ss102-00.u8",  0x800000, 0x400000, CRC(0845eafe) SHA1(663b163bf4e87c7df0030e791f95b1a5827de315) )
 	ROM_LOAD( "ss103-00.u32", 0xc00000, 0x400000, CRC(ee451ac9) SHA1(01cc6b6f371c0090a6a7f4c33d05f4b9a6c59fee) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "ss200-00.u17", 0x000000, 0x400000, CRC(cd773976) SHA1(38b8df5e685be65c3fde09f9e585591f678632d4) )
 	ROM_LOAD( "ss201-00.u9",  0x400000, 0x400000, CRC(301fad4c) SHA1(15faf37eeec5cc46afcb4bd236345b5c3dd647ac) )
 
-	ROM_REGION( 0x600000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x600000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "ss210-00.u3",  0x400000, 0x200000, CRC(c3697805) SHA1(bd41064e3527cdc4b9a4ab9c423c916309b3f057) )
@@ -1906,11 +1950,11 @@ ROM_START( sengekisj )
 	ROM_LOAD( "ss102-00.u8",  0x800000, 0x400000, CRC(0845eafe) SHA1(663b163bf4e87c7df0030e791f95b1a5827de315) )
 	ROM_LOAD( "ss103-00.u32", 0xc00000, 0x400000, CRC(ee451ac9) SHA1(01cc6b6f371c0090a6a7f4c33d05f4b9a6c59fee) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "ss200-00.u17", 0x000000, 0x400000, CRC(cd773976) SHA1(38b8df5e685be65c3fde09f9e585591f678632d4) )
 	ROM_LOAD( "ss201-00.u9",  0x400000, 0x400000, CRC(301fad4c) SHA1(15faf37eeec5cc46afcb4bd236345b5c3dd647ac) )
 
-	ROM_REGION( 0x600000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x600000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "ss210-00.u3",  0x400000, 0x200000, CRC(c3697805) SHA1(bd41064e3527cdc4b9a4ab9c423c916309b3f057) )
@@ -1930,11 +1974,11 @@ ROM_START( senknow )
 	ROM_LOAD( "snw10000.u21", 0x000000, 0x400000, CRC(5133c69c) SHA1(d279df3ffd005dbf0930a8e40eaf2467f8653284) )
 	ROM_LOAD( "snw10100.u20", 0x400000, 0x400000, CRC(9dafe03f) SHA1(978b4597ff2a54ac5049fd64798e8173b29dd363) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "snw20000.u17", 0x000000, 0x400000, CRC(d5fe5f8c) SHA1(817d8d0a5fbc0c50dc3c592f938150f82df97cec) )
 	ROM_LOAD( "snw20100.u9",  0x400000, 0x400000, CRC(c0037846) SHA1(3267b142ebce47e1717250239d98fdb4af7964f8) )
 
-	ROM_REGION( 0x800000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x800000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 	ROM_LOAD( "snw21000.u3",  0x400000, 0x400000, CRC(f5c23e79) SHA1(b509680001c3205b289f43d4f44aaaa7f896419b) )
@@ -1955,10 +1999,10 @@ ROM_START( teljan )
 	ROM_LOAD( "tj101-00.u20", 0x400000, 0x400000, CRC(82f570e1) SHA1(3ba9d1775f897052aca5cff2edbf575399101c5c) )
 	ROM_LOAD( "tj102-00.u17", 0x800000, 0x400000, CRC(ace875dc) SHA1(be97c895beeac979c5704986e818d4f3cfa00e49) )
 
-	ROM_REGION( 0x400000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x400000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "tj200-00.u16", 0x000000, 0x400000, CRC(be0f90b2) SHA1(1848a65f244e1e8a3ff7ab38e76f86cabca8b47e) )
 
-	ROM_REGION( 0x400000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x400000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -1979,11 +2023,11 @@ ROM_START( ryouran )
 	ROM_LOAD( "or101-00.u20", 0x400000, 0x400000, CRC(fe06bf12) SHA1(f3a2f88aed65bcc1c16f37fd4c0011e3538128f7) )
 	ROM_LOAD( "or102-00.u17", 0x800000, 0x400000, CRC(f2a5237b) SHA1(b8871f9c0f3864c334ec9a8146cf7dd1961ecb94) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "or200-00.u16", 0x000000, 0x400000, CRC(4c4701a8) SHA1(7b397b553ba86bba2ee82228cabdf2179e878d69) )
 	ROM_LOAD( "or201-00.u13", 0x400000, 0x400000, CRC(a94064aa) SHA1(5d736f810ffdbb6ada5c5efcb5fb29eedafc3e2f) )
 
-	ROM_REGION( 0x400000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x400000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -2003,11 +2047,11 @@ ROM_START( ryourano )
 	ROM_LOAD( "or101-00.u20", 0x400000, 0x400000, CRC(fe06bf12) SHA1(f3a2f88aed65bcc1c16f37fd4c0011e3538128f7) )
 	ROM_LOAD( "or102-00.u17", 0x800000, 0x400000, CRC(f2a5237b) SHA1(b8871f9c0f3864c334ec9a8146cf7dd1961ecb94) )
 
-	ROM_REGION( 0x800000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x800000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "or200-00.u16", 0x000000, 0x400000, CRC(4c4701a8) SHA1(7b397b553ba86bba2ee82228cabdf2179e878d69) )
 	ROM_LOAD( "or201-00.u13", 0x400000, 0x400000, CRC(a94064aa) SHA1(5d736f810ffdbb6ada5c5efcb5fb29eedafc3e2f) )
 
-	ROM_REGION( 0x400000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x400000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -2026,10 +2070,10 @@ ROM_START( vblokbrk )
 	ROM_LOAD( "sk-100-00.u24", 0x000000, 0x200000, CRC(151dd88a) SHA1(87bb1039a9883f721a315760eb2c4abe4a94046f) )
 	ROM_LOAD( "sk-101.u20",    0x200000, 0x100000, CRC(779cce23) SHA1(70147b36d982524ba9921823e481ce8fbb5daa26) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x200000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "sk-200-00.u16", 0x000000, 0x200000, CRC(2e297c61) SHA1(4071b945a1294fbc3d18fab1f144bf09af4349e8) )
 
-	ROM_REGION( 0x400000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x400000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -2048,10 +2092,10 @@ ROM_START( vblokbrka )
 	ROM_LOAD( "sk-100-00.u24", 0x000000, 0x200000, CRC(151dd88a) SHA1(87bb1039a9883f721a315760eb2c4abe4a94046f) )
 	ROM_LOAD( "sk-101.u20",    0x200000, 0x100000, CRC(779cce23) SHA1(70147b36d982524ba9921823e481ce8fbb5daa26) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x200000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "sk-200-00.u16", 0x000000, 0x200000, CRC(2e297c61) SHA1(4071b945a1294fbc3d18fab1f144bf09af4349e8) )
 
-	ROM_REGION( 0x400000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x400000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 
@@ -2070,10 +2114,10 @@ ROM_START( sarukani )
 	ROM_LOAD( "sk-100-00.u24", 0x000000, 0x200000, CRC(151dd88a) SHA1(87bb1039a9883f721a315760eb2c4abe4a94046f) )
 	ROM_LOAD( "sk-101.u20",    0x200000, 0x100000, CRC(779cce23) SHA1(70147b36d982524ba9921823e481ce8fbb5daa26) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 ) // Tiles Plane A
+	ROM_REGION( 0x200000, "tiles0", 0 ) // Tiles Plane A
 	ROM_LOAD( "sk-200-00.u16", 0x000000, 0x200000, CRC(2e297c61) SHA1(4071b945a1294fbc3d18fab1f144bf09af4349e8) )
 
-	ROM_REGION( 0x400000, "gfx3", ROMREGION_ERASE00 ) // Tiles Plane B
+	ROM_REGION( 0x400000, "tiles1", ROMREGION_ERASE00 ) // Tiles Plane B
 	// First 0x040000 bytes (0x03ff Tiles) are RAM Based Tiles
 	// 0x040000 - 0x3fffff empty?
 

--- a/src/mame/kaneko/suprnova.h
+++ b/src/mame/kaneko/suprnova.h
@@ -28,60 +28,65 @@ public:
 		m_spriteram(*this,"spriteram"),
 		m_spc_regs(*this, "spc_regs"),
 		m_v3_regs(*this, "v3_regs"),
-		m_tilemapA_ram(*this, "tilemapa_ram"),
-		m_tilemapB_ram(*this, "tilemapb_ram"),
+		m_tilemap_ram(*this, "tilemap%c_ram", 'a'),
 		m_v3slc_ram(*this, "v3slc_ram"),
 		m_pal_regs(*this, "pal_regs"),
 		m_palette_ram(*this, "palette_ram"),
 		m_v3t_ram(*this, "v3t_ram"),
 		m_main_ram(*this, "main_ram"),
 		m_cache_ram(*this, "cache_ram"),
-		m_paddle(*this, "Paddle.%c", 'A')
+		m_paddle(*this, "PADDLE.%c", 'A')
 	{ }
 
-	void sknsk(machine_config &config);
-	void sknsu(machine_config &config);
-	void sknsa(machine_config &config);
-	void sknsj(machine_config &config);
-	void sknse(machine_config &config);
-	void skns(machine_config &config);
+	void sknsk(machine_config &config) ATTR_COLD;
+	void sknsu(machine_config &config) ATTR_COLD;
+	void sknsa(machine_config &config) ATTR_COLD;
+	void sknsj(machine_config &config) ATTR_COLD;
+	void sknse(machine_config &config) ATTR_COLD;
+	void skns(machine_config &config) ATTR_COLD;
 
-	void init_sengekis();
-	void init_cyvern();
-	void init_puzzloopa();
-	void init_teljan();
-	void init_panicstr();
-	void init_puzzloope();
-	void init_sengekij();
-	void init_puzzloopj();
-	void init_sarukani();
-	void init_gutsn();
-	void init_jjparad2();
-	void init_galpans3();
-	void init_jjparads();
-	void init_galpans2();
-	void init_galpanis();
-	void init_puzzloopu();
-	void init_senknow();
-	void init_galpani4();
-	void init_ryouran();
+	void init_sengekis() ATTR_COLD;
+	void init_cyvern() ATTR_COLD;
+	void init_puzzloopa() ATTR_COLD;
+	void init_teljan() ATTR_COLD;
+	void init_panicstr() ATTR_COLD;
+	void init_puzzloope() ATTR_COLD;
+	void init_sengekij() ATTR_COLD;
+	void init_puzzloopj() ATTR_COLD;
+	void init_sarukani() ATTR_COLD;
+	void init_gutsn() ATTR_COLD;
+	void init_jjparad2() ATTR_COLD;
+	void init_galpans3() ATTR_COLD;
+	void init_jjparads() ATTR_COLD;
+	void init_galpans2() ATTR_COLD;
+	void init_galpanis() ATTR_COLD;
+	void init_puzzloopu() ATTR_COLD;
+	void init_senknow() ATTR_COLD;
+	void init_galpani4() ATTR_COLD;
+	void init_ryouran() ATTR_COLD;
 
 	template <int P> ioport_value paddle_r();
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+	virtual void machine_reset() override ATTR_COLD;
+	virtual void video_start() override ATTR_COLD;
+	virtual void video_reset() override ATTR_COLD;
 
 private:
 	struct hit_t
 	{
-		uint16_t x1p = 0, y1p = 0, z1p = 0, x1s = 0, y1s = 0, z1s = 0;
-		uint16_t x2p = 0, y2p = 0, z2p = 0, x2s = 0, y2s = 0, z2s = 0;
-		uint16_t org = 0;
+		u16 x1p = 0, y1p = 0, z1p = 0, x1s = 0, y1s = 0, z1s = 0;
+		u16 x2p = 0, y2p = 0, z2p = 0, x2s = 0, y2s = 0, z2s = 0;
+		u16 org = 0;
 
-		uint16_t x1_p1 = 0, x1_p2 = 0, y1_p1 = 0, y1_p2 = 0, z1_p1 = 0, z1_p2 = 0;
-		uint16_t x2_p1 = 0, x2_p2 = 0, y2_p1 = 0, y2_p2 = 0, z2_p1 = 0, z2_p2 = 0;
-		uint16_t x1tox2 = 0, y1toy2 = 0, z1toz2 = 0;
-		int16_t x_in = 0, y_in = 0, z_in = 0;
-		uint16_t flag = 0;
+		u16 x1_p1 = 0, x1_p2 = 0, y1_p1 = 0, y1_p2 = 0, z1_p1 = 0, z1_p2 = 0;
+		u16 x2_p1 = 0, x2_p2 = 0, y2_p1 = 0, y2_p2 = 0, z2_p1 = 0, z2_p2 = 0;
+		u16 x1tox2 = 0, y1toy2 = 0, z1toz2 = 0;
+		s16 x_in = 0, y_in = 0, z_in = 0;
+		u16 flag = 0;
 
-		uint8_t disconnect = 0;
+		u8 disconnect = 0;
 	};
 
 	required_device<sh7604_device> m_maincpu;
@@ -90,17 +95,16 @@ private:
 	required_device<palette_device> m_palette;
 	required_device<screen_device> m_screen;
 
-	required_shared_ptr<uint32_t> m_spriteram;
-	required_shared_ptr<uint32_t> m_spc_regs;
-	required_shared_ptr<uint32_t> m_v3_regs;
-	required_shared_ptr<uint32_t> m_tilemapA_ram;
-	required_shared_ptr<uint32_t> m_tilemapB_ram;
-	required_shared_ptr<uint32_t> m_v3slc_ram;
-	required_shared_ptr<uint32_t> m_pal_regs;
-	required_shared_ptr<uint32_t> m_palette_ram;
-	required_shared_ptr<uint32_t> m_v3t_ram;
-	required_shared_ptr<uint32_t> m_main_ram;
-	required_shared_ptr<uint32_t> m_cache_ram;
+	required_shared_ptr<u32> m_spriteram;
+	required_shared_ptr<u32> m_spc_regs;
+	required_shared_ptr<u32> m_v3_regs;
+	required_shared_ptr_array<u32, 2> m_tilemap_ram;
+	required_shared_ptr<u32> m_v3slc_ram;
+	required_shared_ptr<u32> m_pal_regs;
+	required_shared_ptr<u32> m_palette_ram;
+	required_shared_ptr<u32> m_v3t_ram;
+	required_shared_ptr<u32> m_main_ram;
+	required_shared_ptr<u32> m_cache_ram;
 
 	optional_ioport_array<4> m_paddle;
 
@@ -109,84 +113,74 @@ private:
 	bitmap_ind8 m_tilemap_bitmapflags_lower;
 	bitmap_ind16 m_tilemap_bitmap_higher;
 	bitmap_ind8 m_tilemap_bitmapflags_higher;
-	int32_t m_depthA = 0;
-	int32_t m_depthB = 0;
-	int32_t m_use_spc_bright = 0;
-	int32_t m_use_v3_bright = 0;
-	uint8_t m_bright_spc_b = 0;
-	uint8_t m_bright_spc_g = 0;
-	uint8_t m_bright_spc_r = 0;
-	uint8_t m_bright_spc_b_trans = 0;
-	uint8_t m_bright_spc_g_trans = 0;
-	uint8_t m_bright_spc_r_trans = 0;
-	uint8_t m_bright_v3_b = 0;
-	uint8_t m_bright_v3_g = 0;
-	uint8_t m_bright_v3_r = 0;
-	uint8_t m_bright_v3_b_trans = 0;
-	uint8_t m_bright_v3_g_trans = 0;
-	uint8_t m_bright_v3_r_trans = 0;
-	int32_t m_spc_changed = 0;
-	int32_t m_v3_changed = 0;
-	int32_t m_palette_updated = 0;
-	int32_t m_alt_enable_background = 0;
-	int32_t m_alt_enable_sprites = 0;
-	tilemap_t *m_tilemap_A = nullptr;
-	tilemap_t *m_tilemap_B = nullptr;
-	uint8_t *m_btiles = nullptr;
-	uint8_t m_region = 0;
+	bool m_use_spc_bright = false;
+	bool m_use_v3_bright = false;
+	u8 m_bright_spc_b = 0;
+	u8 m_bright_spc_g = 0;
+	u8 m_bright_spc_r = 0;
+	u8 m_bright_spc_b_trans = 0;
+	u8 m_bright_spc_g_trans = 0;
+	u8 m_bright_spc_r_trans = 0;
+	u8 m_bright_v3_b = 0;
+	u8 m_bright_v3_g = 0;
+	u8 m_bright_v3_r = 0;
+	u8 m_bright_v3_b_trans = 0;
+	u8 m_bright_v3_g_trans = 0;
+	u8 m_bright_v3_r_trans = 0;
+	bool m_spc_changed = false;
+	bool m_v3_changed = false;
+	bool m_palette_updated = false;
+	bool m_alt_enable_background = false;
+	bool m_alt_enable_sprites = false;
+	tilemap_t *m_tilemap[2]{nullptr};
+	u8 *m_btiles = nullptr;
+	u8 m_region = 0;
 
-	void hit_w(offs_t offset, uint32_t data);
-	void hit2_w(uint32_t data);
-	uint32_t hit_r(offs_t offset);
-	void io_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void v3t_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void pal_regs_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void palette_ram_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void tilemapA_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void tilemapB_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void v3_regs_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	void hit_w(offs_t offset, u32 data);
+	void hit2_w(u32 data);
+	u32 hit_r(offs_t offset);
+	void io_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	void v3t_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	void pal_regs_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	void palette_ram_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	template <unsigned Which> void tilemapram_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	void v3_regs_w(offs_t offset, u32 data, u32 mem_mask = ~0);
 
-	uint32_t gutsn_speedup_r();
-	uint32_t cyvern_speedup_r();
-	uint32_t puzzloopj_speedup_r();
-	uint32_t puzzloopa_speedup_r();
-	uint32_t puzzloopu_speedup_r();
-	uint32_t puzzloope_speedup_r();
-	uint32_t senknow_speedup_r();
-	uint32_t teljan_speedup_r();
-	uint32_t jjparads_speedup_r();
-	uint32_t jjparad2_speedup_r();
-	uint32_t ryouran_speedup_r();
-	uint32_t galpans2_speedup_r();
-	uint32_t panicstr_speedup_r();
-	uint32_t sengekis_speedup_r();
-	uint32_t sengekij_speedup_r();
+	u32 gutsn_speedup_r();
+	u32 cyvern_speedup_r();
+	u32 puzzloopj_speedup_r();
+	u32 puzzloopa_speedup_r();
+	u32 puzzloopu_speedup_r();
+	u32 puzzloope_speedup_r();
+	u32 senknow_speedup_r();
+	u32 teljan_speedup_r();
+	u32 jjparads_speedup_r();
+	u32 jjparad2_speedup_r();
+	u32 ryouran_speedup_r();
+	u32 galpans2_speedup_r();
+	u32 panicstr_speedup_r();
+	u32 sengekis_speedup_r();
+	u32 sengekij_speedup_r();
 
-	virtual void machine_start() override ATTR_COLD;
-	virtual void machine_reset() override ATTR_COLD;
-	virtual void video_start() override ATTR_COLD;
-	virtual void video_reset() override ATTR_COLD;
 	DECLARE_MACHINE_RESET(sknsa);
 	DECLARE_MACHINE_RESET(sknsj);
 	DECLARE_MACHINE_RESET(sknsu);
 	DECLARE_MACHINE_RESET(sknse);
 	DECLARE_MACHINE_RESET(sknsk);
 
-	TILE_GET_INFO_MEMBER(get_tilemap_A_tile_info);
-	TILE_GET_INFO_MEMBER(get_tilemap_B_tile_info);
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	template <unsigned Which> TILE_GET_INFO_MEMBER(get_tile_info);
+	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void screen_vblank(int state);
 
 	TIMER_DEVICE_CALLBACK_MEMBER(interrupt_callback);
 	TIMER_DEVICE_CALLBACK_MEMBER(irq);
-	void draw_roz(bitmap_ind16 &bitmap, bitmap_ind8& bitmapflags, const rectangle &cliprect, tilemap_t *tmap, uint32_t startx, uint32_t starty, int incxx, int incxy, int incyx, int incyy, int wraparound, int columnscroll, uint32_t* scrollram);
-	void palette_set_rgb_brightness (int offset, uint8_t brightness_r, uint8_t brightness_g, uint8_t brightness_b);
+	void draw_roz(bitmap_ind16 &bitmap, bitmap_ind8& bitmapflags, const rectangle &cliprect, tilemap_t *tmap, u32 startx, u32 starty, int incxx, int incxy, int incyx, int incyy, int wraparound, int columnscroll, u32* scrollram);
+	void palette_set_brightness(offs_t offset);
 	void palette_update();
-	void draw_a( bitmap_ind16 &bitmap, bitmap_ind8 &bitmap_flags, const rectangle &cliprect, int tran );
-	void draw_b( bitmap_ind16 &bitmap, bitmap_ind8 &bitmap_flags, const rectangle &cliprect, int tran );
+	void draw_tilemap(bitmap_ind16 &bitmap, bitmap_ind8 &bitmap_flags, const rectangle &cliprect, int which);
 	void hit_recalc();
 	void init_drc();
-	void set_drc_pcflush(uint32_t addr);
+	void set_drc_pcflush(u32 addr);
 
 	void skns_map(address_map &map) ATTR_COLD;
 };

--- a/src/mame/kaneko/suprnova_v.cpp
+++ b/src/mame/kaneko/suprnova_v.cpp
@@ -8,7 +8,7 @@
 #include <algorithm>
 
 /* draws ROZ with linescroll OR columnscroll to 16-bit indexed bitmap */
-void skns_state::draw_roz(bitmap_ind16 &bitmap, bitmap_ind8& bitmapflags, const rectangle &cliprect, tilemap_t *tmap, u32 startx, u32 starty, int incxx, int incxy, int incyx, int incyy, int wraparound, int columnscroll, u32* scrollram)
+void skns_state::draw_roz(bitmap_ind16 &bitmap, bitmap_ind8 &bitmapflags, const rectangle &cliprect, tilemap_t *tmap, u32 startx, u32 starty, int incxx, int incxy, int incyx, int incyy, int wraparound, int columnscroll, u32 *scrollram)
 {
 	//bitmap_ind16 *destbitmap = bitmap;
 	const bitmap_ind16 &srcbitmap = tmap->pixmap();
@@ -17,7 +17,7 @@ void skns_state::draw_roz(bitmap_ind16 &bitmap, bitmap_ind8& bitmapflags, const 
 	const int ymask = srcbitmap.height() - 1;
 	const int widthshifted = srcbitmap.width() << 16;
 	const int heightshifted = srcbitmap.height() << 16;
-//  u8 *pri;
+	//u8 *pri;
 	//const u16 *src;
 	//const u8 *maskptr;
 	//int destadvance = destbitmap->bpp / 8;
@@ -47,7 +47,7 @@ void skns_state::draw_roz(bitmap_ind16 &bitmap, bitmap_ind8& bitmapflags, const 
 		/* loop over columns */
 		while (x <= ex)
 		{
-			if ((wraparound) || (cx < widthshifted && cy < heightshifted)) // not sure how this will cope with no wraparound, but row/col scroll..
+			if (wraparound || (cx < widthshifted && cy < heightshifted)) // not sure how this will cope with no wraparound, but row/col scroll..
 			{
 				const u32 srcx = cx >> 16;
 				const u32 srcy = cy >> 16;
@@ -67,7 +67,7 @@ void skns_state::draw_roz(bitmap_ind16 &bitmap, bitmap_ind8& bitmapflags, const 
 			cx += incxx;
 			cy += incxy;
 			x++;
-//          pri++;
+			//pri++;
 		}
 
 		/* advance in Y */

--- a/src/mame/kaneko/suprnova_v.cpp
+++ b/src/mame/kaneko/suprnova_v.cpp
@@ -7,18 +7,18 @@
 
 
 /* draws ROZ with linescroll OR columnscroll to 16-bit indexed bitmap */
-void skns_state::draw_roz(bitmap_ind16 &bitmap, bitmap_ind8& bitmapflags, const rectangle &cliprect, tilemap_t *tmap, uint32_t startx, uint32_t starty, int incxx, int incxy, int incyx, int incyy, int wraparound, int columnscroll, uint32_t* scrollram)
+void skns_state::draw_roz(bitmap_ind16 &bitmap, bitmap_ind8& bitmapflags, const rectangle &cliprect, tilemap_t *tmap, u32 startx, u32 starty, int incxx, int incxy, int incyx, int incyy, int wraparound, int columnscroll, u32* scrollram)
 {
 	//bitmap_ind16 *destbitmap = bitmap;
 	const bitmap_ind16 &srcbitmap = tmap->pixmap();
 	const bitmap_ind8 &srcbitmapflags = tmap->flagsmap();
-	const int xmask = srcbitmap.width()-1;
-	const int ymask = srcbitmap.height()-1;
+	const int xmask = srcbitmap.width() - 1;
+	const int ymask = srcbitmap.height() - 1;
 	const int widthshifted = srcbitmap.width() << 16;
 	const int heightshifted = srcbitmap.height() << 16;
-//  uint8_t *pri;
-	//const uint16_t *src;
-	//const uint8_t *maskptr;
+//  u8 *pri;
+	//const u16 *src;
+	//const u8 *maskptr;
 	//int destadvance = destbitmap->bpp / 8;
 
 	/* pre-advance based on the cliprect */
@@ -36,27 +36,29 @@ void skns_state::draw_roz(bitmap_ind16 &bitmap, bitmap_ind8& bitmapflags, const 
 	{
 		/* initialize X counters */
 		int x = sx;
-		uint32_t cx = startx;
-		uint32_t cy = starty;
+		u32 cx = startx;
+		u32 cy = starty;
 
 		/* get dest and priority pointers */
-		uint16_t *dest = &bitmap.pix(sy, sx);
-		uint8_t *destflags = &bitmapflags.pix(sy, sx);
+		u16 *const dest = &bitmap.pix(sy);
+		u8 *const destflags = &bitmapflags.pix(sy);
 
 		/* loop over columns */
 		while (x <= ex)
 		{
 			if ((wraparound) || (cx < widthshifted && cy < heightshifted)) // not sure how this will cope with no wraparound, but row/col scroll..
 			{
+				const u32 srcx = cx >> 16;
+				const u32 srcy = cy >> 16;
 				if (columnscroll)
 				{
-					dest[0] = srcbitmap.pix(((cy >> 16) - scrollram[(cx>>16)&0x3ff]) & ymask, (cx >> 16) & xmask);
-					destflags[0] = srcbitmapflags.pix(((cy >> 16) - scrollram[(cx>>16)&0x3ff]) & ymask, (cx >> 16) & xmask);
+					dest[x] = srcbitmap.pix((srcy - scrollram[srcx & 0x3ff]) & ymask, srcx & xmask);
+					destflags[x] = srcbitmapflags.pix((srcy - scrollram[srcx & 0x3ff]) & ymask, srcx & xmask);
 				}
 				else
 				{
-					dest[0] = srcbitmap.pix((cy >> 16) & ymask, ((cx >> 16) - scrollram[(cy>>16)&0x3ff]) & xmask);
-					destflags[0] = srcbitmapflags.pix((cy >> 16) & ymask, ((cx >> 16) - scrollram[(cy>>16)&0x3ff]) & xmask);
+					dest[x] = srcbitmap.pix(srcy & ymask, (srcx - scrollram[srcy & 0x3ff]) & xmask);
+					destflags[x] = srcbitmapflags.pix(srcy & ymask, (srcx - scrollram[srcy & 0x3ff]) & xmask);
 				}
 			}
 
@@ -64,8 +66,6 @@ void skns_state::draw_roz(bitmap_ind16 &bitmap, bitmap_ind8& bitmapflags, const 
 			cx += incxx;
 			cy += incxy;
 			x++;
-			dest++;
-			destflags++;
 //          pri++;
 		}
 
@@ -77,279 +77,204 @@ void skns_state::draw_roz(bitmap_ind16 &bitmap, bitmap_ind8& bitmapflags, const 
 }
 
 
-void skns_state::pal_regs_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+void skns_state::pal_regs_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	COMBINE_DATA(&m_pal_regs[offset]);
-	m_palette_updated =1;
+	data = COMBINE_DATA(&m_pal_regs[offset]);
+	m_palette_updated = true;
 
-	switch ( offset )
+	switch (offset)
 	{
-	/* RWRA regs are for SPRITES */
+		/* RWRA regs are for SPRITES */
+		case (0x00 / 4): // RWRA0
+			if (m_use_spc_bright != BIT(data, 0))
+			{
+				m_use_spc_bright = BIT(data, 0);
+				m_spc_changed = true;
+			}
+			m_alt_enable_sprites = BIT(data, 8);
+			break;
+		case (0x04 / 4): // RWRA1
+			if (m_bright_spc_g != (data & 0xff))
+			{
+				m_bright_spc_g = data & 0xff;
+				m_spc_changed = true;
+			}
+			m_bright_spc_g_trans = (data >> 8) & 0xff;
+			break;
+		case (0x08 / 4): // RWRA2
+			if (m_bright_spc_r != (data & 0xff))
+			{
+				m_bright_spc_r = data & 0xff;
+				m_spc_changed = true;
+			}
+			m_bright_spc_r_trans = (data >> 8) & 0xff;
+			break;
+		case (0x0c / 4): // RWRA3
+			if (m_bright_spc_b != (data & 0xff))
+			{
+				m_bright_spc_b = data & 0xff;
+				m_spc_changed = true;
+			}
+			m_bright_spc_b_trans = (data >> 8) & 0xff;
+			break;
 
-	case (0x00/4): // RWRA0
-		if( m_use_spc_bright != (data&1) ) {
-			m_use_spc_bright = data&1;
-			m_spc_changed = 1;
-		}
-		m_alt_enable_sprites = (data>>8)&1;
-
-
-		break;
-	case (0x04/4): // RWRA1
-		if( m_bright_spc_g != (data&0xff) ) {
-			m_bright_spc_g = data&0xff;
-			m_spc_changed = 1;
-		}
-		m_bright_spc_g_trans = (data>>8) &0xff;
-
-
-		break;
-	case (0x08/4): // RWRA2
-		if( m_bright_spc_r != (data&0xff) ) {
-			m_bright_spc_r = data&0xff;
-			m_spc_changed = 1;
-		}
-		m_bright_spc_r_trans = (data>>8) &0xff;
-
-		break;
-	case (0x0C/4): // RWRA3
-		if( m_bright_spc_b != (data&0xff) ) {
-			m_bright_spc_b = data&0xff;
-			m_spc_changed = 1;
-		}
-		m_bright_spc_b_trans = (data>>8)&0xff;
-
-
-		break;
-
-	/* RWRB regs are for BACKGROUND */
-
-	case (0x10/4): // RWRB0
-		if( m_use_v3_bright != (data&1) ) {
-			m_use_v3_bright = data&1;
-			m_v3_changed = 1;
-		}
-
-		m_alt_enable_background = (data>>8)&1;
-
-		break;
-	case (0x14/4): // RWRB1
-		if( m_bright_v3_g != (data&0xff) ) {
-			m_bright_v3_g = data&0xff;
-			m_v3_changed = 1;
-		}
-
-		m_bright_v3_g_trans = (data>>8)&0xff;
-
-		break;
-	case (0x18/4): // RWRB2
-		if( m_bright_v3_r != (data&0xff) ) {
-			m_bright_v3_r = data&0xff;
-			m_v3_changed = 1;
-		}
-
-		m_bright_v3_r_trans = (data>>8)&0xff;
-
-		break;
-	case (0x1C/4): // RWRB3
-		if( m_bright_v3_b != (data&0xff) ) {
-			m_bright_v3_b = data&0xff;
-			m_v3_changed = 1;
-		}
-
-		m_bright_v3_b_trans = (data>>8)&0xff;
-
-		break;
+		/* RWRB regs are for BACKGROUND */
+		case (0x10 / 4): // RWRB0
+			if (m_use_v3_bright != BIT(data, 0))
+			{
+				m_use_v3_bright = BIT(data, 0);
+				m_v3_changed = true;
+			}
+			m_alt_enable_background = BIT(data, 8);
+			break;
+		case (0x14 / 4): // RWRB1
+			if (m_bright_v3_g != (data & 0xff))
+			{
+				m_bright_v3_g = data & 0xff;
+				m_v3_changed = true;
+			}
+			m_bright_v3_g_trans = (data >> 8) & 0xff;
+			break;
+		case (0x18 / 4): // RWRB2
+			if (m_bright_v3_r != (data & 0xff))
+			{
+				m_bright_v3_r = data & 0xff;
+				m_v3_changed = true;
+			}
+			m_bright_v3_r_trans = (data >> 8) & 0xff;
+			break;
+		case (0x1c / 4): // RWRB3
+			if (m_bright_v3_b != (data & 0xff))
+			{
+				m_bright_v3_b = data & 0xff;
+				m_v3_changed = true;
+			}
+			m_bright_v3_b_trans = (data >> 8) & 0xff;
+			break;
 	}
 }
 
-
-void skns_state::palette_ram_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+void skns_state::palette_set_brightness(offs_t offset)
 {
-	int r,g,b;
-	int brightness_r, brightness_g, brightness_b/*, alpha*/;
-	int use_bright;
+	int b = pal5bit(m_palette_ram[offset] >> 0);
+	int g = pal5bit(m_palette_ram[offset] >> 5);
+	int r = pal5bit(m_palette_ram[offset] >> 10);
+	const int a = pal1bit(m_palette_ram[offset] >> 15);
 
-	COMBINE_DATA(&m_palette_ram[offset]);
-
-	b = ((m_palette_ram[offset] >> 0  ) & 0x1f);
-	g = ((m_palette_ram[offset] >> 5  ) & 0x1f);
-	r = ((m_palette_ram[offset] >> 10  ) & 0x1f);
-
-	//alpha = ((m_palette_ram[offset] >> 15  ) & 0x1);
-
-	if(offset<(0x40*256)) { // 1st half is for Sprites
+	bool use_bright;
+	int brightness_b, brightness_g, brightness_r;
+	if (offset < (0x40 * 256)) // 1st half is for Sprites
+	{
 		use_bright = m_use_spc_bright;
 		brightness_b = m_bright_spc_b;
 		brightness_g = m_bright_spc_g;
 		brightness_r = m_bright_spc_r;
-	} else { // V3 bg's
+	}
+	else // V3 bg's
+	{
 		use_bright = m_use_v3_bright;
 		brightness_b = m_bright_v3_b;
 		brightness_g = m_bright_v3_g;
 		brightness_r = m_bright_v3_r;
 	}
 
-	if(use_bright) {
-		if(brightness_b) b = ((b<<3) * (brightness_b+1))>>8;
+	if (use_bright)
+	{
+		if (brightness_b) b = (b * (brightness_b + 1)) >> 8;
 		else b = 0;
-		if(brightness_g) g = ((g<<3) * (brightness_g+1))>>8;
+		if (brightness_g) g = (g * (brightness_g + 1)) >> 8;
 		else g = 0;
-		if(brightness_r) r = ((r<<3) * (brightness_r+1))>>8;
+		if (brightness_r) r = (r * (brightness_r + 1)) >> 8;
 		else r = 0;
-	} else {
-		b <<= 3;
-		g <<= 3;
-		r <<= 3;
 	}
 
-	m_palette->set_pen_color(offset,rgb_t(r,g,b));
+	m_palette->set_pen_color(offset, rgb_t(a, r, g, b));
 }
 
-
-void skns_state::palette_set_rgb_brightness (int offset, uint8_t brightness_r, uint8_t brightness_g, uint8_t brightness_b)
+void skns_state::palette_ram_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	int use_bright, r, g, b/*, alpha*/;
+	COMBINE_DATA(&m_palette_ram[offset]);
 
-	b = ((m_palette_ram[offset] >> 0  ) & 0x1f);
-	g = ((m_palette_ram[offset] >> 5  ) & 0x1f);
-	r = ((m_palette_ram[offset] >> 10  ) & 0x1f);
-
-	//alpha = ((m_palette_ram[offset] >> 15  ) & 0x1);
-
-	if(offset<(0x40*256)) { // 1st half is for Sprites
-		use_bright = m_use_spc_bright;
-	} else { // V3 bg's
-		use_bright = m_use_v3_bright;
-	}
-
-	if(use_bright) {
-		if(brightness_b) b = ((b<<3) * (brightness_b+1))>>8;
-		else b = 0;
-		if(brightness_g) g = ((g<<3) * (brightness_g+1))>>8;
-		else g = 0;
-		if(brightness_r) r = ((r<<3) * (brightness_r+1))>>8;
-		else r = 0;
-	} else {
-		b <<= 3;
-		g <<= 3;
-		r <<= 3;
-	}
-
-	m_palette->set_pen_color(offset,rgb_t(r,g,b));
+	palette_set_brightness(offset);
 }
 
 
 void skns_state::palette_update()
 {
-	int i;
-
 	if (m_palette_updated)
 	{
-		if(m_spc_changed)
-			for(i=0; i<=((0x40*256)-1); i++)
-				palette_set_rgb_brightness (i, m_bright_spc_r, m_bright_spc_g, m_bright_spc_b);
-
-		if(m_v3_changed)
-			for(i=(0x40*256); i<=((0x80*256)-1); i++)
-				palette_set_rgb_brightness (i, m_bright_v3_r, m_bright_v3_g, m_bright_v3_b);
-		m_palette_updated =0;
+		if (m_spc_changed)
+		{
+			for (int i = 0; i < (0x40 * 256); i++)
+			{
+				palette_set_brightness(i);
+			}
+			m_spc_changed = false;
+		}
+		if (m_v3_changed)
+		{
+			for (int i = (0x40 * 256); i < (0x80 * 256); i++)
+			{
+				palette_set_brightness(i);
+			}
+			m_v3_changed = false;
+		}
+		m_palette_updated = false;
 	}
 }
 
 
-
-TILE_GET_INFO_MEMBER(skns_state::get_tilemap_A_tile_info)
+template <unsigned Which>
+TILE_GET_INFO_MEMBER(skns_state::get_tile_info)
 {
-	int code = ((m_tilemapA_ram[tile_index] & 0x001fffff) >> 0 );
-	int colr = ((m_tilemapA_ram[tile_index] & 0x3f000000) >> 24 );
-	int pri  = ((m_tilemapA_ram[tile_index] & 0x00e00000) >> 21 );
-	int depth = (m_v3_regs[0x0c/4] & 0x0001) << 1;
-	int flags = 0;
+	const u32 code = ((m_tilemap_ram[Which][tile_index] & 0x001fffff) >> 0);
+	const u32 colr = ((m_tilemap_ram[Which][tile_index] & 0x3f000000) >> 24);
+	const u8 pri  = ((m_tilemap_ram[Which][tile_index] & 0x00e00000) >> 21);
+	const u8 depth = BIT(m_v3_regs[0x0c / 4], Which << 3);
+	const u32 flags = TILE_FLIPXY(m_tilemap_ram[Which][tile_index] >> 30);
 
-	if(m_tilemapA_ram[tile_index] & 0x80000000) flags |= TILE_FLIPX;
-	if(m_tilemapA_ram[tile_index] & 0x40000000) flags |= TILE_FLIPY;
-
-	tileinfo.set(0+depth,
+	tileinfo.set((Which << 1) + depth,
 			code,
-			0x40+colr,
+			colr,
 			flags);
 	tileinfo.category = pri;
 
 	//if (pri) popmessage("pri A!! %02x\n", pri);
 }
 
-void skns_state::tilemapA_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+void skns_state::v3_regs_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	COMBINE_DATA(&m_tilemapA_ram[offset]);
-	m_tilemap_A->mark_tile_dirty(offset);
-}
-
-TILE_GET_INFO_MEMBER(skns_state::get_tilemap_B_tile_info)
-{
-	int code = ((m_tilemapB_ram[tile_index] & 0x001fffff) >> 0 );
-	int colr = ((m_tilemapB_ram[tile_index] & 0x3f000000) >> 24 );
-	int pri  = ((m_tilemapB_ram[tile_index] & 0x00e00000) >> 21 );
-	int depth = (m_v3_regs[0x0c/4] & 0x0100) >> 7;
-	int flags = 0;
-
-	if(m_tilemapB_ram[tile_index] & 0x80000000) flags |= TILE_FLIPX;
-	if(m_tilemapB_ram[tile_index] & 0x40000000) flags |= TILE_FLIPY;
-
-	tileinfo.set(1+depth,
-			code,
-			0x40+colr,
-			flags);
-	tileinfo.category = pri;
-
-	//if (pri) popmessage("pri B!! %02x\n", pri); // 02 on cyvern
-}
-
-void skns_state::tilemapB_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-	COMBINE_DATA(&m_tilemapB_ram[offset]);
-	m_tilemap_B->mark_tile_dirty(offset);
-}
-
-void skns_state::v3_regs_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-	COMBINE_DATA(&m_v3_regs[offset]);
+	const u32 old = m_v3_regs[offset];
+	data = COMBINE_DATA(&m_v3_regs[offset]);
 
 	/* if the depth changes we need to dirty the tilemap */
-	if (offset == 0x0c/4)
+	if (offset == 0x0c / 4)
 	{
-		int old_depthA = m_depthA;
-		int old_depthB = m_depthB;
-
-		m_depthA = (m_v3_regs[0x0c/4] & 0x0001) << 1;
-		m_depthB = (m_v3_regs[0x0c/4] & 0x0100) >> 7;
-
-		if (old_depthA != m_depthA) m_tilemap_A->mark_all_dirty();
-		if (old_depthB != m_depthB) m_tilemap_B->mark_all_dirty();
-
+		if (BIT(old ^ data, 0))
+			m_tilemap[0]->mark_all_dirty();
+		if (BIT(old ^ data, 8))
+			m_tilemap[1]->mark_all_dirty();
 	}
 }
 
 
 void skns_state::video_start()
 {
-	m_tilemap_A = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(skns_state::get_tilemap_A_tile_info)), TILEMAP_SCAN_ROWS, 16,16, 64,64);
-	m_tilemap_A->set_transparent_pen(0);
+	m_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(skns_state::get_tile_info<0>)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
+	m_tilemap[0]->set_transparent_pen(0);
 
-	m_tilemap_B = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(skns_state::get_tilemap_B_tile_info)), TILEMAP_SCAN_ROWS, 16,16, 64,64);
-	m_tilemap_B->set_transparent_pen(0);
+	m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(skns_state::get_tile_info<1>)), TILEMAP_SCAN_ROWS, 16, 16, 64, 64);
+	m_tilemap[1]->set_transparent_pen(0);
 
-	m_tilemap_bitmap_lower.allocate(320,240);
-	m_tilemap_bitmapflags_lower.allocate(320,240);
+	m_tilemap_bitmap_lower.allocate(512, 512);
+	m_tilemap_bitmapflags_lower.allocate(512, 512);
 
-	m_tilemap_bitmap_higher.allocate(320,240);
-	m_tilemap_bitmapflags_higher.allocate(320,240);
+	m_tilemap_bitmap_higher.allocate(512, 512);
+	m_tilemap_bitmapflags_higher.allocate(512, 512);
 
-	m_gfxdecode->gfx(2)->set_granularity(256);
+	m_gfxdecode->gfx(1)->set_granularity(256);
 	m_gfxdecode->gfx(3)->set_granularity(256);
 
-	save_item(NAME(m_depthA));
-	save_item(NAME(m_depthB));
 	save_item(NAME(m_use_spc_bright));
 	save_item(NAME(m_use_v3_bright));
 	save_item(NAME(m_bright_spc_b));
@@ -373,76 +298,42 @@ void skns_state::video_start()
 
 void skns_state::video_reset()
 {
-	m_depthA = m_depthB = 0;
-	m_use_spc_bright = m_use_v3_bright = 1;
+	m_use_spc_bright = m_use_v3_bright = true;
 	m_bright_spc_b= m_bright_spc_g = m_bright_spc_r = 0x00;
 	m_bright_spc_b_trans = m_bright_spc_g_trans = m_bright_spc_r_trans = 0x00;
 	m_bright_v3_b = m_bright_v3_g = m_bright_v3_r = 0x00;
 	m_bright_v3_b_trans = m_bright_v3_g_trans = m_bright_v3_r_trans = 0x00;
 
-	m_spc_changed = m_v3_changed = m_palette_updated = 0;
-	m_alt_enable_background = m_alt_enable_sprites = 1;
+	m_spc_changed = m_v3_changed = m_palette_updated = false;
+	m_alt_enable_background = m_alt_enable_sprites = true;
 }
 
-void skns_state::draw_a( bitmap_ind16 &bitmap, bitmap_ind8 &bitmap_flags, const rectangle &cliprect, int tran )
+void skns_state::draw_tilemap(bitmap_ind16 &bitmap, bitmap_ind8 &bitmap_flags, const rectangle &cliprect, int which)
 {
-	int enable_a  = (m_v3_regs[0x10/4] >> 0) & 0x0001;
-	int nowrap_a = (m_v3_regs[0x10/4] >> 0) & 0x0004;
+	const u32 reg_offs = (which ? 0x34 : 0x10) / 4;
+	if (!BIT(m_v3_regs[reg_offs], 0))
+		return;
 
-	uint32_t startx,starty;
-	int incxx,incxy,incyx,incyy;
-	int columnscroll;
+	const bool nowrap = BIT(m_v3_regs[reg_offs], 2);
 
-	//if(nowrap_a) printf("a\n");
+	const u32 startx = m_v3_regs[reg_offs + (0x0c / 4)];
+	const u32 starty = m_v3_regs[reg_offs + (0x10 / 4)];
+	const int incxx  = util::sext(m_v3_regs[reg_offs + (0x14 / 4)] & 0x7ffff, 19);
+	const int incxy  = m_v3_regs[reg_offs + (0x18 / 4)];
+	const int incyx  = m_v3_regs[reg_offs + (0x1c / 4)];
+	const int incyy  = util::sext(m_v3_regs[reg_offs + (0x20 / 4)] & 0x7ffff, 19); // level 3 boss in sengekis
 
-	if (enable_a && m_alt_enable_background)
-	{
-		startx = m_v3_regs[0x1c/4];
-		incyy  = m_v3_regs[0x30/4]&0x7ffff;
-		if (incyy&0x40000) incyy = incyy-0x80000; // level 3 boss in sengekis
-		incyx  = m_v3_regs[0x2c/4];
-		starty = m_v3_regs[0x20/4];
-		incxy  = m_v3_regs[0x28/4];
-		incxx  = m_v3_regs[0x24/4]&0x7ffff;
-		if (incxx&0x40000) incxx = incxx-0x80000;
+	const bool columnscroll = BIT(m_v3_regs[0x0c / 4], which ? 9 : 1); // selects column scroll or rowscroll
 
-		columnscroll = (m_v3_regs[0x0c/4] >> 1) & 0x0001;
-
-		draw_roz(bitmap,bitmap_flags,cliprect, m_tilemap_A, startx << 8,starty << 8,    incxx << 8,incxy << 8,incyx << 8,incyy << 8, !nowrap_a, columnscroll, &m_v3slc_ram[0]);
-		//tilemap_copy_bitmap(bitmap, m_tilemap_bitmap_lower, m_tilemap_bitmapflags_lower);
-	}
+	draw_roz(bitmap, bitmap_flags,
+			cliprect, m_tilemap[which],
+			startx << 8, starty << 8,
+			incxx << 8, incxy << 8, incyx << 8, incyy << 8,
+			!nowrap, columnscroll,
+			&m_v3slc_ram[which << 10]);
 }
 
-void skns_state::draw_b( bitmap_ind16 &bitmap, bitmap_ind8 &bitmap_flags, const rectangle &cliprect, int tran )
-{
-	int enable_b  = (m_v3_regs[0x34/4] >> 0) & 0x0001;
-	int nowrap_b = (m_v3_regs[0x34/4] >> 0) & 0x0004;
-
-	uint32_t startx,starty;
-	int incxx,incxy,incyx,incyy;
-	int columnscroll;
-
-	//if(nowrap_b) printf("b\n");
-
-	if (enable_b && m_alt_enable_background)
-	{
-		startx = m_v3_regs[0x40/4];
-		incyy  = m_v3_regs[0x54/4]&0x7ffff;
-		if (incyy&0x40000) incyy = incyy-0x80000;
-		incyx  = m_v3_regs[0x50/4];
-		starty = m_v3_regs[0x44/4];
-		incxy  = m_v3_regs[0x4c/4];
-		incxx  = m_v3_regs[0x48/4]&0x7ffff;
-		if (incxx&0x40000) incxx = incxx-0x80000;
-
-		columnscroll = (m_v3_regs[0x0c/4] >> 9) & 0x0001; // selects column scroll or rowscroll
-
-		draw_roz(bitmap,bitmap_flags, cliprect, m_tilemap_B, startx << 8,starty << 8,   incxx << 8,incxy << 8,incyx << 8,incyy << 8, !nowrap_b, columnscroll, &m_v3slc_ram[0x1000/4]);
-		//popmessage("%08x %08x %08x %08x %08x %08x", startx, starty, incxx, incyy, incxy, incyx);
-	}
-}
-
-uint32_t skns_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+u32 skns_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	palette_update();
 
@@ -453,44 +344,46 @@ uint32_t skns_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, 
 	m_tilemap_bitmapflags_higher.fill(0);
 
 	{
-		int tran = 0;
+		const int tilemap_pri_a = BIT(m_v3_regs[0x10 / 4], 1);
+		const int tilemap_pri_b = BIT(m_v3_regs[0x34 / 4], 1);
 
-		int supernova_pri_a = (m_v3_regs[0x10/4] & 0x0002)>>1;
-		int supernova_pri_b = (m_v3_regs[0x34/4] & 0x0002)>>1;
+		//popmessage("pri %d %d\n", tilemap_pri_a, tilemap_pri_b);
 
-		//popmessage("pri %d %d\n", supernova_pri_a, supernova_pri_b);
-
-		/*if (!supernova_pri_b) { */
-		draw_b(m_tilemap_bitmap_lower, m_tilemap_bitmapflags_lower, cliprect,tran);// tran = 1;
-		draw_a(m_tilemap_bitmap_higher,m_tilemap_bitmapflags_higher,cliprect,tran);// tran = 1;
+		/*if (!tilemap_pri_b) { */
+		if (m_alt_enable_background)
+		{
+			draw_tilemap(m_tilemap_bitmap_lower,  m_tilemap_bitmapflags_lower,  cliprect, 1);
+			draw_tilemap(m_tilemap_bitmap_higher, m_tilemap_bitmapflags_higher, cliprect, 0);
+		}
 
 		{
-			uint16_t bgpri;
 			pen_t const *const clut = &m_palette->pen(0);
-//          int drawpri;
 
-			for (int y=cliprect.min_y;y<=cliprect.max_y;y++)
+			for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 			{
-				uint16_t const *const src = &m_tilemap_bitmap_lower.pix(y);
-				uint8_t const *const srcflags = &m_tilemap_bitmapflags_lower.pix(y);
+				u16 const *const src = &m_tilemap_bitmap_lower.pix(y);
+				u8 const *const srcflags = &m_tilemap_bitmapflags_lower.pix(y);
 
-				uint16_t const *const src2 = &m_tilemap_bitmap_higher.pix(y);
-				uint8_t const *const src2flags = &m_tilemap_bitmapflags_higher.pix(y);
+				u16 const *const src2 = &m_tilemap_bitmap_higher.pix(y);
+				u8 const *const src2flags = &m_tilemap_bitmapflags_higher.pix(y);
 
-				uint16_t const *const src3 = &m_spritegen->bitmap().pix(y);
+				u16 const *const src3 = &m_spritegen->bitmap().pix(y);
 
-				uint32_t *const dst = &bitmap.pix(y);
+				u32 *const dst = &bitmap.pix(y);
 
-				for (int x=cliprect.min_x;x<=cliprect.max_x;x++)
+				for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
 				{
-					uint16_t pendata  = src[x]&0x7fff;
-					uint16_t pendata2 = src2[x]&0x7fff;
-					uint16_t bgpendata;
-					uint16_t pendata3 = m_alt_enable_sprites ? src3[x]&0x3fff : 0;
+					u16 pendata  = src[x] & 0x7fff;
+					u16 pendata2 = src2[x] & 0x7fff;
+					u16 pendata3 = m_alt_enable_sprites ? src3[x] & 0x3fff : 0;
 
-					uint16_t pri = ((srcflags[x] & 0x07)<<1) | (supernova_pri_b);
-					uint16_t pri2= ((src2flags[x] & 0x07)<<1) | (supernova_pri_a);
-					uint16_t pri3 = ((src3[x]&0xc000)>>12)+3;
+					u16 pri  = ((srcflags[x] & 0x07) << 1) | tilemap_pri_b;
+					u16 pri2 = ((src2flags[x] & 0x07) << 1) | tilemap_pri_a;
+					u16 pri3 = ((src3[x] & 0xc000) >> 12) + 3;
+
+					const bool pendraw = pendata & 0xff;
+					const bool pen2draw = pendata2 & 0xff;
+					const bool pen3draw = pendata3 & 0xff;
 
 					// work out which layers bg pixel has the higher priority
 					//  note, can the bg layers be blended?? sarukani uses an alpha pen for
@@ -499,34 +392,36 @@ uint32_t skns_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, 
 					// this priority mixing is almost certainly still incorrect
 					// bg colour / prioirty handling is now wrong
 
-					if (pri<=pri2) // <= is good for last level of cyvern.. < seem better for galpanis kaneko logo
+					u16 bgpendata;
+					u16 bgpri;
+					if (pri <= pri2) // <= is good for last level of cyvern.. < seem better for galpanis kaneko logo
 					{
-						if (pendata2&0xff)
+						if (pen2draw)
 						{
-							bgpendata = pendata2&0x7fff;
+							bgpendata = pendata2 & 0x7fff;
 							bgpri = pri2;
 						}
-						else if (pendata&0xff)
+						else if (pendraw)
 						{
-							bgpendata = pendata&0x7fff;
+							bgpendata = pendata & 0x7fff;
 							bgpri = pri;
 						}
 						else
 						{
-							bgpendata = pendata2&0x7fff;
+							bgpendata = pendata2 & 0x7fff;
 							bgpri = 0;
 						}
 					}
 					else
 					{
-						if (pendata&0xff)
+						if (pendraw)
 						{
-							bgpendata = pendata&0x7fff;
+							bgpendata = pendata & 0x7fff;
 							bgpri = pri;
 						}
-						else if (pendata2&0xff)
+						else if (pen2draw)
 						{
-							bgpendata = pendata2&0x7fff;
+							bgpendata = pendata2 & 0x7fff;
 							bgpri = pri2;
 						}
 						else
@@ -537,63 +432,51 @@ uint32_t skns_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, 
 					}
 
 					// if the sprites are higher than the bg pixel
-					uint32_t coldat;
+					u32 coldat = 0;
 					if (pri3 > bgpri)
 					{
-						if (pendata3&0xff)
+						if (pen3draw)
 						{
-							uint16_t palvalue = m_palette_ram[pendata3];
-
 							coldat = clut[pendata3];
 
-							if (palvalue&0x8000)
+							if (BIT(coldat, 31))
 							{
-								uint32_t srccolour = clut[bgpendata&0x7fff];
-								uint32_t dstcolour = clut[pendata3&0x3fff];
+								const u32 srccolour = clut[bgpendata & 0x7fff];
+								const u32 dstcolour = clut[pendata3 & 0x3fff];
 
-								int r,g,b;
-								int r2,g2,b2;
+								int r = (srccolour & 0x000000ff) >> 0;
+								int g = (srccolour & 0x0000ff00) >> 8;
+								int b = (srccolour & 0x00ff0000) >> 16;
 
-								r = (srccolour & 0x000000ff)>> 0;
-								g = (srccolour & 0x0000ff00)>> 8;
-								b = (srccolour & 0x00ff0000)>> 16;
-
-								r2 = (dstcolour & 0x000000ff)>> 0;
-								g2 = (dstcolour & 0x0000ff00)>> 8;
-								b2 = (dstcolour & 0x00ff0000)>> 16;
+								int r2 = (dstcolour & 0x000000ff) >> 0;
+								int g2 = (dstcolour & 0x0000ff00) >> 8;
+								int b2 = (dstcolour & 0x00ff0000) >> 16;
 
 								r2 = (r2 * m_bright_spc_r_trans) >> 8;
 								g2 = (g2 * m_bright_spc_g_trans) >> 8;
 								b2 = (b2 * m_bright_spc_b_trans) >> 8;
 
-								r = (r+r2);
-								if (r>255) r = 255;
+								r = std::min(r + r2, 255);
+								g = std::min(g + g2, 255);
+								b = std::min(b + b2, 255);
 
-								g = (g+g2);
-								if (g>255) g = 255;
-
-								b = (b+b2);
-								if (b>255) b = 255;
-
-								dst[x] = (r << 0) | (g << 8) | (b << 16);
+								coldat = (r << 0) | (g << 8) | (b << 16);
 							}
 							else
 							{
 								coldat = clut[pendata3];
-								dst[x] = coldat;
 							}
 						}
 						else
 						{
 							coldat = clut[bgpendata];
-							dst[x] = coldat;
 						}
 					}
 					else
 					{
 						coldat = clut[bgpendata];
-						dst[x] = coldat;
 					}
+					dst[x] = coldat | (0xffu << 24u);
 				}
 			}
 		}

--- a/src/mame/kaneko/suprnova_v.cpp
+++ b/src/mame/kaneko/suprnova_v.cpp
@@ -5,6 +5,7 @@
 #include "emu.h"
 #include "suprnova.h"
 
+#include <algorithm>
 
 /* draws ROZ with linescroll OR columnscroll to 16-bit indexed bitmap */
 void skns_state::draw_roz(bitmap_ind16 &bitmap, bitmap_ind8& bitmapflags, const rectangle &cliprect, tilemap_t *tmap, u32 startx, u32 starty, int incxx, int incxy, int incyx, int incyy, int wraparound, int columnscroll, u32* scrollram)


### PR DESCRIPTION
- Add side effect checks for debugger reads
- Move palette offset and amount in tilemap into gfx decode layouts
- Improvement logging features
- Minor optimizations
- Replace pointers into references
- Reduce duplicates
- Use shortened typename values for consistency
- Fix code style consistency
- Make some variables constant
- Fix spacings
- Fix possible bitmap out of bound errors
- Add notes
- Fix namings