### PR TITLE
emu/disound.cpp: Improved calculation of sound_requested_outputs_mask.

### DIFF
--- a/src/emu/disound.cpp
+++ b/src/emu/disound.cpp
@@ -313,9 +313,10 @@ void device_sound_interface::sound_before_devices_init()
 	for(sound_route &route : routes()) {
 		device_t *dev = route.m_base.get().subdevice(route.m_target);
 		dev->interface(route.m_interface);
-		if(route.m_output != ALL_OUTPUTS && m_sound_requested_outputs <= route.m_output) {
+		if(route.m_output != ALL_OUTPUTS) {
 			m_sound_requested_outputs_mask |= u64(1) << route.m_output;
-			m_sound_requested_outputs = route.m_output + 1;
+			if(m_sound_requested_outputs <= route.m_output)
+				m_sound_requested_outputs = route.m_output + 1;
 		}
 		route.m_interface->sound_request_input(route.m_input);
 	}


### PR DESCRIPTION
Ensures `m_sound_requested_outputs_mask` is updated even if a device's `add_route(output_index, ...)` calls don't happen in the order of `output_index`.

I noticed this while working on the CEM3340, which will be the first user of `get_sound_requested_outputs_mask()` it seems.

Before this PR, `CEM3340(...).add_route(0, ...).add_route(1, ...)` set the mask correctly, but  `CEM3340(...).add_route(1, ...).add_route(0, ...)` did not. After his PR, both calls set the mask correctly.


