### PR TITLE
psikyo/psikyosh.cpp: Updates

### DIFF
--- a/src/mame/psikyo/psikyosh.cpp
+++ b/src/mame/psikyo/psikyosh.cpp
@@ -32,8 +32,12 @@ There appear to be multiple revisions of this board
  ---------------------------------
  Dragon Blaze (c)2000
  Tetris The Grand Master 2 (c)2000
- Tetris The Grand Master 2 Plus (c)2000 (Confirmed by Japump to be a Dragon Blaze upgraded board)
- GunBarich (c)2001 (Appears to be a Dragon Blaze upgraded board, easily replaced chips have been swapped)
+ Tetris The Grand Master 2 Plus (c)2000 (Confirmed by Japump to be a
+ Dragon Blaze upgraded board)
+
+ GunBarich (c)2001 (Appears to be a Dragon Blaze upgraded board, easily
+ replaced chips have been swapped)
+
  Mahjong G-Taste (c)2002
 
  The PS5v2 board is only different physically.
@@ -46,15 +50,16 @@ YMF278B-F (80 pin PQFP) & YAC513 (16 pin SOIC)
 93C56 EEPROM
 ( 93c56 is a 93c46 with double the address space. )
 
-To Do:
-  - see notes in video file -
+TODO:
+  - see notes in psikyo/psikyosh_v.cpp -
 
 
 *-----------------------------------*
 |         Tips and Tricks           |
 *-----------------------------------*
 
-Hold Button during booting to test roms (Checksum 16-bit, on Words for gfx and Bytes for sound) for:
+Hold Button during booting to test roms (Checksum 16-bit, on Words for gfx and
+Bytes for sound) for:
 
 Daraku:           PL1 Button 1 (passes, doesn't test sound)
 Space Bomber:     PL1 Start (passes all, only if bit 0x40 is set. But then EEPROM resets?)
@@ -340,10 +345,11 @@ ROM Usage
 #include "sound/ymopl.h"
 #include "speaker.h"
 
+static constexpr XTAL MASTER_CLOCK = 57.272727_MHz_XTAL;   // main oscillator frequency
 
 static GFXDECODE_START( gfx_psikyosh )
-	GFXDECODE_ENTRY( "gfx1", 0, gfx_16x16x4_packed_msb, 0x000, 0x100 ) // 4bpp tiles
-	GFXDECODE_ENTRY( "gfx1", 0, gfx_16x16x8_raw,        0x000, 0x100 ) // 8bpp tiles
+	GFXDECODE_ENTRY( "gfx", 0, gfx_16x16x4_packed_msb, 0x000, 0x100 ) // 4bpp tiles
+	GFXDECODE_ENTRY( "gfx", 0, gfx_16x16x8_raw,        0x000, 0x100 ) // 8bpp tiles
 GFXDECODE_END
 
 void psikyosh_state::eeprom_w(u8 data)
@@ -492,12 +498,12 @@ P1KEY11  29|30  P2KEY11
 		u32 const start_depressed = ~value & 0x01000000;
 		keys |= start_depressed ? 1 << (std::size(key_codes) - 1) : 0; // and bung it in at the end
 
-		value |= 0xFFFF0000; // set top word
+		value |= 0xffff0000; // set top word
 		do {
 			// since we can't handle multiple keys, just return the first one depressed
 			if ((keys & which_key) && (count < std::size(key_codes)))
 			{
-				value &= ~((u32)(key_codes[count]) << 16); // mask in selected word as IP_ACTIVE_LOW
+				value &= ~(u32(key_codes[count]) << 16); // mask in selected word as IP_ACTIVE_LOW
 				break;
 			}
 			which_key <<= 1;
@@ -516,14 +522,14 @@ void psikyosh_state::ps3v1_map(address_map &map)
 	map(0x00000000, 0x000fffff).rom(); // program ROM (1 meg)
 	map(0x02000000, 0x020fffff).rom().region("maincpu", 0x100000); // data ROM
 // video chip
-	map(0x03000000, 0x0300ffff).ram().share("spriteram"); // sprite and backgrounds are share this area (video banks 0-1f)
+	map(0x03000000, 0x0300ffff).ram().w(FUNC(psikyosh_state::spriteram_w)).share(m_spriteram); // sprite and backgrounds are share this area (video banks 0-1f)
 	map(0x03040000, 0x03044fff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette"); // palette..
-	map(0x03050000, 0x030501ff).ram().share("zoomram"); // sprite zoom lookup table
+	map(0x03050000, 0x030501ff).ram().share(m_zoomram); // sprite zoom lookup table
 	map(0x0305ffdc, 0x0305ffdf).r("watchdog", FUNC(watchdog_timer_device::reset32_r)).w(FUNC(psikyosh_state::irqctrl_w)); // also writes to this address - might be vblank reads?
-	map(0x0305ffe0, 0x0305ffff).ram().w(FUNC(psikyosh_state::vidregs_w)).share("vidregs"); //  video registers
-	map(0x03060000, 0x0307ffff).bankr("gfxbank"); // data for rom tests (gfx), data is controlled by vidreg
+	map(0x0305ffe0, 0x0305ffff).ram().w(FUNC(psikyosh_state::vidregs_w)).share(m_vidregs); //  video registers
+	map(0x03060000, 0x0307ffff).bankr(m_gfxrombank); // data for rom tests (gfx), data is controlled by vidreg
 // rom mapping
-	map(0x04060000, 0x0407ffff).bankr("gfxbank"); // data for rom tests (gfx) (Mirrored?)
+	map(0x04060000, 0x0407ffff).bankr(m_gfxrombank); // data for rom tests (gfx) (Mirrored?)
 // sound chip
 	map(0x05000000, 0x05000007).rw("ymf", FUNC(ymf278b_device::read), FUNC(ymf278b_device::write));
 // inputs/eeprom
@@ -531,7 +537,7 @@ void psikyosh_state::ps3v1_map(address_map &map)
 	map(0x05800004, 0x05800007).portr("JP4");
 	map(0x05800004, 0x05800004).w(FUNC(psikyosh_state::eeprom_w));
 // ram
-	map(0x06000000, 0x060fffff).ram().share("ram"); // main RAM (1 meg)
+	map(0x06000000, 0x060fffff).ram().share(m_ram); // main RAM (1 meg)
 }
 
 // ps5, ps5v2
@@ -546,16 +552,16 @@ void psikyosh_state::ps5_map(address_map &map)
 // sound chip
 	map(0x03100000, 0x03100007).rw("ymf", FUNC(ymf278b_device::read), FUNC(ymf278b_device::write));
 // video chip
-	map(0x04000000, 0x0400ffff).ram().share("spriteram"); // sprite and backgrounds are share this area (video banks 0-1f)
+	map(0x04000000, 0x0400ffff).ram().w(FUNC(psikyosh_state::spriteram_w)).share(m_spriteram); // sprite and backgrounds are share this area (video banks 0-1f)
 	map(0x04040000, 0x04044fff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette");
-	map(0x04050000, 0x040501ff).ram().share("zoomram"); // sprite zoom lookup table
+	map(0x04050000, 0x040501ff).ram().share(m_zoomram); // sprite zoom lookup table
 	map(0x0405ffdc, 0x0405ffdf).nopr().w(FUNC(psikyosh_state::irqctrl_w)); // also writes to this address - might be vblank reads?
-	map(0x0405ffe0, 0x0405ffff).ram().w(FUNC(psikyosh_state::vidregs_w)).share("vidregs"); // video registers
-	map(0x04060000, 0x0407ffff).bankr("gfxbank"); // data for rom tests (gfx), data is controlled by vidreg
+	map(0x0405ffe0, 0x0405ffff).ram().w(FUNC(psikyosh_state::vidregs_w)).share(m_vidregs); // video registers
+	map(0x04060000, 0x0407ffff).bankr(m_gfxrombank); // data for rom tests (gfx), data is controlled by vidreg
 // rom mapping
 	map(0x05000000, 0x0507ffff).rom().region("maincpu", 0x100000); // data ROM
 // ram
-	map(0x06000000, 0x060fffff).ram().share("ram");
+	map(0x06000000, 0x060fffff).ram().share(m_ram);
 }
 
 // mahjong
@@ -571,10 +577,10 @@ void psikyosh_state::s1945iiibl_map(address_map &map)
 	ps5_map(map);
 
 	map(0x00000000, 0x001fffff).rom(); // bootleg has the data both in a separate chip and at the end of the 2 program ROMs. Why?
-	map(0x04003000, 0x040031ff).ram().share("zoomram"); // sprite zoom lookup table is inside of spriteram instead of external like in the original
+	map(0x04003000, 0x040031ff).ram().share(m_zoomram); // sprite zoom lookup table is inside of spriteram instead of external like in the original
 	map(0x04050000, 0x040501ff).unmaprw();
 	map(0x04053fdc, 0x04053fdf).nopr().w(FUNC(psikyosh_state::irqctrl_w));
-	map(0x04053fe0, 0x04053fff).ram().w(FUNC(psikyosh_state::vidregs_w)).share("vidregs");
+	map(0x04053fe0, 0x04053fff).ram().w(FUNC(psikyosh_state::vidregs_w)).share(m_vidregs);
 	map(0x0405ffdc, 0x0405ffdf).unmaprw();
 	map(0x0405ffe0, 0x0405ffff).unmaprw();
 	map(0x05000000, 0x0507ffff).rom().region("maincpu", 0x200000); // data ROM
@@ -584,10 +590,10 @@ void psikyosh_state::s1945iiibla_map(address_map &map)
 {
 	ps5_map(map);
 
-	map(0x04003000, 0x040031ff).ram().share("zoomram");
+	map(0x04003000, 0x040031ff).ram().share(m_zoomram);
 	map(0x04030000, 0x040301ff).ram(); // fails RAM test otherwise
 	map(0x04053fdc, 0x04053fdf).nopr().w(FUNC(psikyosh_state::irqctrl_w));
-	map(0x04053fe0, 0x04053fff).ram().w(FUNC(psikyosh_state::vidregs_w)).share("vidregs");
+	map(0x04053fe0, 0x04053fff).ram().w(FUNC(psikyosh_state::vidregs_w)).share(m_vidregs);
 	map(0x0405ffdc, 0x0405ffdf).unmaprw();
 	map(0x0405ffe0, 0x0405ffff).unmaprw();
 }
@@ -830,7 +836,7 @@ INPUT_PORTS_END
 
 void psikyosh_state::machine_start()
 {
-	m_gfxrombank->configure_entries(0, 0x1000, memregion("gfx1")->base(), 0x20000);
+	m_gfxrombank->configure_entries(0, 0x1000, memregion("gfx")->base(), 0x20000);
 }
 
 
@@ -848,8 +854,8 @@ void psikyosh_state::psikyo3v1(machine_config &config)
 	/* video hardware */
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_refresh_hz(60);
-	m_screen->set_size(64*8, 32*8);
-	m_screen->set_visarea(0, 40*8-1, 0, 28*8-1);
+	m_screen->set_size(64 * 8, 32 * 8);
+	m_screen->set_visarea(0, 40 * 8 - 1, 0, 28 * 8 - 1);
 	m_screen->set_screen_update(FUNC(psikyosh_state::screen_update));
 	m_screen->screen_vblank().set(FUNC(psikyosh_state::screen_vblank));
 
@@ -886,7 +892,7 @@ void psikyosh_state::psikyo5_240(machine_config &config)
 
 	/* Measured Hsync 16.165 KHz, Vsync 61.68 Hz */
 	/* Ideally this would be driven off the video register. However, it doesn't change at runtime and MAME will pick a better screen resolution if it knows upfront */
-	m_screen->set_raw(MASTER_CLOCK/8, 443, 0, 40*8, 262, 0, 30*8);
+	m_screen->set_raw(MASTER_CLOCK / 8, 443, 0, 40 * 8, 262, 0, 30 * 8);
 }
 
 void psikyosh_state::s1945iiibl(machine_config &config)
@@ -916,7 +922,7 @@ ROM_START( soldivid )
 	ROM_LOAD32_WORD_SWAP( "2-prog_l.u18", 0x000002, 0x080000, CRC(cf179b04) SHA1(343f00a81cffd44334a4db81b6b828b7cf73c1e8) )
 	ROM_LOAD32_WORD_SWAP( "1-prog_h.u17", 0x000000, 0x080000, CRC(f467d1c4) SHA1(a011e6f310a54f09efa0bf4597783cd78c05ad6f) )
 
-	ROM_REGION( 0x3800000, "gfx1", ROMREGION_ERASE00 )
+	ROM_REGION( 0x3800000, "gfx", ROMREGION_ERASE00 )
 	/* This Space Empty! */
 	ROM_LOAD32_WORD_SWAP( "4l.u10", 0x2000000, 0x400000, CRC(9eb9f269) SHA1(4a4d90eefe62b5462f5ed5e062eea7b6b4900f85) )
 	ROM_LOAD32_WORD_SWAP( "4h.u31", 0x2000002, 0x400000, CRC(7c76cfe7) SHA1(14e291e840a4afe3802fe1847615c5e806d7492a) )
@@ -934,7 +940,7 @@ ROM_START( soldividk )
 	ROM_LOAD32_WORD_SWAP( "9-prog_lk.u18", 0x000002, 0x080000, CRC(b534029d) SHA1(a96ca55e6694c5537d489d40bc890c376bbce933) )
 	ROM_LOAD32_WORD_SWAP( "8-prog_hk.u17", 0x000000, 0x080000, CRC(a48e3206) SHA1(d560286972de2a0baa5369672a0190b7bd421843) )
 
-	ROM_REGION( 0x3800000, "gfx1", ROMREGION_ERASE00 )
+	ROM_REGION( 0x3800000, "gfx", ROMREGION_ERASE00 )
 	/* This Space Empty! */
 	ROM_LOAD32_WORD_SWAP( "4l.u10", 0x2000000, 0x400000, CRC(9eb9f269) SHA1(4a4d90eefe62b5462f5ed5e062eea7b6b4900f85) )
 	ROM_LOAD32_WORD_SWAP( "4h.u31", 0x2000002, 0x400000, CRC(7c76cfe7) SHA1(14e291e840a4afe3802fe1847615c5e806d7492a) )
@@ -952,7 +958,7 @@ ROM_START( s1945ii )
 	ROM_LOAD32_WORD_SWAP( "2_prog_l.u18", 0x000002, 0x080000, CRC(20a911b8) SHA1(82ba7b93bd621fc45a4dc2722752077b59a0a233) )
 	ROM_LOAD32_WORD_SWAP( "1_prog_h.u17", 0x000000, 0x080000, CRC(4c0fe85e) SHA1(74f810a1c3e9d629c8b190f68d73ce07b11f77b7) )
 
-	ROM_REGION( 0x2000000, "gfx1", 0 )  /* Tiles */
+	ROM_REGION( 0x2000000, "gfx", 0 )  /* Tiles */
 	ROM_LOAD32_WORD( "0l.u4",    0x0000000, 0x400000, CRC(bfacf98d) SHA1(19954f12881e6e95e808bd1f2c2f5a425786727f) )
 	ROM_LOAD32_WORD( "0h.u13",   0x0000002, 0x400000, CRC(1266f67c) SHA1(cf93423a827aa92aa54afbbecf8509d2590edc9b) )
 	ROM_LOAD32_WORD( "1l.u3",    0x0800000, 0x400000, CRC(2d3332c9) SHA1(f2e54100a48061bfd589e8765f59ca051176a38b) )
@@ -976,7 +982,7 @@ ROM_START( daraku )
 	ROM_LOAD32_WORD_SWAP( "3_prog_h.u17", 0x000000, 0x080000, CRC(7a9cf601) SHA1(8df464ce3fd02b30dd2ab77828594f4916375fd5) )
 	ROM_LOAD16_WORD_SWAP( "prog.u16",     0x100000, 0x100000, CRC(3742e990) SHA1(dd4b8777e57245151b3d520ed1bdab207530420b) )
 
-	ROM_REGION( 0x3400000, "gfx1", 0 )
+	ROM_REGION( 0x3400000, "gfx", 0 )
 	ROM_LOAD32_WORD( "0l.u4",  0x0000000, 0x400000, CRC(565d8427) SHA1(090ce9213c530d29e488cfb89bb39fd7169985d5) )
 	ROM_LOAD32_WORD( "0h.u13", 0x0000002, 0x400000, CRC(9a602630) SHA1(ab176490b36aec7ce30d1cf20b57c02c926c59d3) )
 	ROM_LOAD32_WORD( "1l.u3",  0x0800000, 0x400000, CRC(ac5ce8e1) SHA1(7df6a04ea2530cc669581474e8b8ee6f59caae1b) )
@@ -1004,7 +1010,7 @@ ROM_START( sbomber ) /* Version B - Only shows "Version B" when set to Japan reg
 	ROM_LOAD32_WORD_SWAP( "1-b_pr_l.u18", 0x000002, 0x080000, CRC(52d12225) SHA1(0a31a5d557414e7bf51dc6f7fbdd417a20b78df1) )
 	ROM_LOAD32_WORD_SWAP( "1-b_pr_h.u17", 0x000000, 0x080000, CRC(1bbd0345) SHA1(c6ccb7c97cc9e9ea298c1883d1dd5563907a7255) )
 
-	ROM_REGION( 0x2800000, "gfx1", 0 )
+	ROM_REGION( 0x2800000, "gfx", 0 )
 	ROM_LOAD32_WORD( "0l.u4",  0x0000000, 0x400000, CRC(b7e4ac51) SHA1(70e802b6235932116496a77ee0c78a256e85aff3) )
 	ROM_LOAD32_WORD( "0h.u13", 0x0000002, 0x400000, CRC(235e6c27) SHA1(c597d7b5bef4edac1474ad0024cfb33eb1257106) )
 	ROM_LOAD32_WORD( "1l.u3",  0x0800000, 0x400000, CRC(3c88c48c) SHA1(d1ce4ab60ba18449bbd96e29c310e060a0bb6de6) )
@@ -1028,7 +1034,7 @@ ROM_START( sbombera ) /* Original version */
 	ROM_LOAD32_WORD_SWAP( "2.u18", 0x000002, 0x080000, CRC(57819a26) SHA1(d7a6fc957e39adf97762ab0a35b91aa17ec026e0) )
 	ROM_LOAD32_WORD_SWAP( "1.u17", 0x000000, 0x080000, CRC(c388e847) SHA1(cbf4f2e191894160bdf0290d72cf20c222aaf7a7) )
 
-	ROM_REGION( 0x2800000, "gfx1", 0 )
+	ROM_REGION( 0x2800000, "gfx", 0 )
 	ROM_LOAD32_WORD( "0l.u4",  0x0000000, 0x400000, CRC(b7e4ac51) SHA1(70e802b6235932116496a77ee0c78a256e85aff3) )
 	ROM_LOAD32_WORD( "0h.u13", 0x0000002, 0x400000, CRC(235e6c27) SHA1(c597d7b5bef4edac1474ad0024cfb33eb1257106) )
 	ROM_LOAD32_WORD( "1l.u3",  0x0800000, 0x400000, CRC(3c88c48c) SHA1(d1ce4ab60ba18449bbd96e29c310e060a0bb6de6) )
@@ -1055,7 +1061,7 @@ ROM_START( gunbird2 ) /* Internal date string shows Oct 07 16:05 */
 	ROM_LOAD32_WORD_SWAP( "1_prog_h.u17", 0x000000, 0x080000, CRC(7328d8bf) SHA1(c640de1ab5b32400b2d77e0dc6e3ee0f78ab7803) )
 	ROM_LOAD16_WORD_SWAP( "3_pdata.u1",   0x100000, 0x080000, CRC(a5b697e6) SHA1(947f124fa585c2cf77c6571af7559bd652897b89) )
 
-	ROM_REGION( 0x3800000, "gfx1", 0 )
+	ROM_REGION( 0x3800000, "gfx", 0 )
 	ROM_LOAD32_WORD( "0l.u3",  0x0000000, 0x800000, CRC(5c826bc8) SHA1(74fb6b242b4c5fe5365cfcc3029ed6da4cf3a621) )
 	ROM_LOAD32_WORD( "0h.u10", 0x0000002, 0x800000, CRC(3df0cb6c) SHA1(271d276fa0f63d84e458223316a9517865fc2255) )
 	ROM_LOAD32_WORD( "1l.u4",  0x1000000, 0x800000, CRC(1558358d) SHA1(e3b9c3da4e9b29ffa9568b57d14fe2b600aead68) )
@@ -1093,7 +1099,7 @@ ROM_START( gunbird2a ) /* Internal date string shows Oct 08 17:02 - No specific 
 	ROM_LOAD32_WORD_SWAP( "prog_h.u17", 0x000000, 0x080000, CRC(cb0cb826) SHA1(8827e9ebfedbc63dbf41c6a5c994a691a6d63fdb) )
 	ROM_LOAD16_WORD_SWAP( "pdata.u1",   0x100000, 0x080000, CRC(23751839) SHA1(4762685d1f6843e8e53eae6c014e66b98fa15eb7) )
 
-	ROM_REGION( 0x3800000, "gfx1", 0 )
+	ROM_REGION( 0x3800000, "gfx", 0 )
 	ROM_LOAD32_WORD( "0l.u3",  0x0000000, 0x800000, CRC(5c826bc8) SHA1(74fb6b242b4c5fe5365cfcc3029ed6da4cf3a621) )
 	ROM_LOAD32_WORD( "0h.u10", 0x0000002, 0x800000, CRC(3df0cb6c) SHA1(271d276fa0f63d84e458223316a9517865fc2255) )
 	ROM_LOAD32_WORD( "1l.u4",  0x1000000, 0x800000, CRC(1558358d) SHA1(e3b9c3da4e9b29ffa9568b57d14fe2b600aead68) )
@@ -1116,7 +1122,7 @@ ROM_START( s1945iii )
 	ROM_LOAD32_WORD_SWAP( "1_progh.u17", 0x000000, 0x080000, CRC(1b8a5a18) SHA1(718a176bd48e16f964fcb07c568b5227cfc0515f) )
 	ROM_LOAD16_WORD_SWAP( "3_data.u1",   0x100000, 0x080000, CRC(8ff5f7d3) SHA1(420a3d7f2d5ab6a56789d36b418431f12f5f73f5) )
 
-	ROM_REGION( 0x3800000, "gfx1", 0 )
+	ROM_REGION( 0x3800000, "gfx", 0 )
 	ROM_LOAD32_WORD( "0l.u3",  0x0000000, 0x800000, CRC(70a0d52c) SHA1(c9d9534da59123b577dc22020273b94ccdeeb67d) )
 	ROM_LOAD32_WORD( "0h.u10", 0x0000002, 0x800000, CRC(4dcd22b4) SHA1(2df7a7d08df17d2a62d574fccc8ba40aaae21a13) )
 	ROM_LOAD32_WORD( "1l.u4",  0x1000000, 0x800000, CRC(de1042ff) SHA1(468f6dfd5c1f2084c573b6851e314ff2826dc350) )
@@ -1142,7 +1148,7 @@ ROM_START( s1945iiibl ) // BM1045 PCB - has HD6417098 CPU + YMF268-F sound chip 
 	ROM_LOAD16_WORD_SWAP( "083351_10-01-13.u3", 0x200000, 0x080000, CRC(f76eb183) SHA1(457f6f959c0885b64ec35a3046f2f0b60798a2e0) ) // M27C160, u3 also written with a marker on the label
 	ROM_IGNORE(                                           0x180000 ) // 11xxxxxxxxxxxxxxxxxxx = 0xFF
 
-	ROM_REGION( 0x3800000, "gfx1", 0 ) // not dumped for this bootleg, which actually has 4x 26L12811MC-12 MTPs
+	ROM_REGION( 0x3800000, "gfx", 0 ) // not dumped for this bootleg, which actually has 4x 26L12811MC-12 MTPs
 	ROM_LOAD32_WORD( "0l.u3",  0x0000000, 0x800000, BAD_DUMP CRC(70a0d52c) SHA1(c9d9534da59123b577dc22020273b94ccdeeb67d) )
 	ROM_LOAD32_WORD( "0h.u10", 0x0000002, 0x800000, BAD_DUMP CRC(4dcd22b4) SHA1(2df7a7d08df17d2a62d574fccc8ba40aaae21a13) )
 	ROM_LOAD32_WORD( "1l.u4",  0x1000000, 0x800000, BAD_DUMP CRC(de1042ff) SHA1(468f6dfd5c1f2084c573b6851e314ff2826dc350) )
@@ -1165,7 +1171,7 @@ ROM_START( s1945iiibla ) // SK000420 PCB
 	ROM_LOAD32_WORD_SWAP( "u1", 0x000000, 0x080000, CRC(f67016d0) SHA1(3b52690c450524d54a0c74639049f1b648b6ceb9) )
 	ROM_LOAD16_WORD_SWAP( "u2", 0x100000, 0x080000, CRC(4922685b) SHA1(9af39abeed55459981d6dd74aaeff35293c66892) )
 
-	ROM_REGION( 0x3800000, "gfx1", 0 ) // data verified same as original PCB
+	ROM_REGION( 0x3800000, "gfx", 0 ) // data verified same as original PCB
 	ROM_LOAD32_WORD( "0l",  0x0000000, 0x800000, CRC(70a0d52c) SHA1(c9d9534da59123b577dc22020273b94ccdeeb67d) ) // mask ROMs with silkscreened labels
 	ROM_LOAD32_WORD( "0h",  0x0000002, 0x800000, CRC(4dcd22b4) SHA1(2df7a7d08df17d2a62d574fccc8ba40aaae21a13) )
 	ROM_LOAD32_WORD( "1l",  0x1000000, 0x800000, CRC(de1042ff) SHA1(468f6dfd5c1f2084c573b6851e314ff2826dc350) )
@@ -1194,7 +1200,7 @@ ROM_START( dragnblz )
 	ROM_LOAD32_WORD_SWAP( "2prog_h.u21",   0x000000, 0x080000, CRC(fc5eade8) SHA1(e5d05543641e4a3900b0d42e0d5f75734683d635) )
 	ROM_LOAD32_WORD_SWAP( "1prog_l.u22",   0x000002, 0x080000, CRC(95d6fd02) SHA1(2b2830e7fa66cbd13666191762bfddc40571caec) )
 
-	ROM_REGION( 0x2c00000, "gfx1", ROMREGION_ERASE00 )  /* Sprites */
+	ROM_REGION( 0x2c00000, "gfx", ROMREGION_ERASE00 )  /* Sprites */
 	ROM_LOAD32_WORD( "1l.u4",  0x0400000, 0x200000, CRC(c2eb565c) SHA1(07e41b36cc03a87f28d091754fdb0d1a7316a532) )
 	ROM_LOAD32_WORD( "1h.u12", 0x0400002, 0x200000, CRC(23cb46b7) SHA1(005b7cc40eea103688a64a72c219c7535970dbfb) )
 	ROM_LOAD32_WORD( "2l.u5",  0x0800000, 0x200000, CRC(bc256aea) SHA1(1f1d678e8a63513a95f296b8a07d2ea485d1e53f) )
@@ -1236,7 +1242,7 @@ ROM_START( gnbarich )
 	ROM_LOAD32_WORD_SWAP( "2-prog_l.u21",   0x000000, 0x080000, CRC(c136cd9c) SHA1(ab66c4f5196a66a97dbb5832336a203421cf40fa) )
 	ROM_LOAD32_WORD_SWAP( "1-prog_h.u22",   0x000002, 0x080000, CRC(6588fc96) SHA1(3db29fcf17e8b2aee465319b557bd3e45bc966b2) )
 
-	ROM_REGION( 0x2c00000, "gfx1", ROMREGION_ERASE00 )  /* Sprites */
+	ROM_REGION( 0x2c00000, "gfx", ROMREGION_ERASE00 )  /* Sprites */
 //  ROM_LOAD32_WORD( "1l.u4",  0x0400000, 0x200000, CRC(c2eb565c) SHA1(07e41b36cc03a87f28d091754fdb0d1a7316a532) ) /* From Dragon Blaze */
 //  ROM_LOAD32_WORD( "1h.u12", 0x0400002, 0x200000, CRC(23cb46b7) SHA1(005b7cc40eea103688a64a72c219c7535970dbfb) ) /* From Dragon Blaze */
 //  ROM_LOAD32_WORD( "2l.u5",  0x0800000, 0x200000, CRC(bc256aea) SHA1(1f1d678e8a63513a95f296b8a07d2ea485d1e53f) ) /* From Dragon Blaze */
@@ -1270,7 +1276,7 @@ ROM_START( mjgtaste )
 	ROM_LOAD32_WORD_SWAP( "2.u21",   0x000000, 0x080000, CRC(5f2041dc) SHA1(f3862ffdb8df0cf921ce1cb0236935731e7729a7) )
 	ROM_LOAD32_WORD_SWAP( "1.u22",   0x000002, 0x080000, CRC(f5ff7876) SHA1(4c909db9c97f29fd79df6dacd29762688701b973) )
 
-	ROM_REGION( 0x2c00000, "gfx1", ROMREGION_ERASE00 )  /* Sprites */
+	ROM_REGION( 0x2c00000, "gfx", ROMREGION_ERASE00 )  /* Sprites */
 	ROM_LOAD32_WORD( "1l.u4",  0x0400000, 0x200000, CRC(30da42b1) SHA1(8485f2c0e7769b50b95d962afe14fa7ae74cd887) )
 	ROM_LOAD32_WORD( "1h.u12", 0x0400002, 0x200000, CRC(629c1d44) SHA1(61909091328bb7b6d3e6e0bff91e14c9b4b86c2c) )
 	ROM_LOAD32_WORD( "2l.u5",  0x0800000, 0x200000, CRC(1f6126ab) SHA1(e9fc70ca42798c04a4d4e1ef1113a59477c77fdc) )
@@ -1304,7 +1310,7 @@ ROM_START( tgm2 )
 	ROM_LOAD32_WORD_SWAP( "2.u21",   0x000000, 0x080000, CRC(b19f6c31) SHA1(c58346c575db71262aebc3993743cb031c41e4af) )
 	ROM_LOAD32_WORD_SWAP( "1.u22",   0x000002, 0x080000, CRC(c521bf24) SHA1(0ee5b9f74b6b8bcc01b2270c53f30d99e877ed64) )
 
-	ROM_REGION( 0x3000000, "gfx1", ROMREGION_ERASE00 )  /* Sprites */
+	ROM_REGION( 0x3000000, "gfx", ROMREGION_ERASE00 )  /* Sprites */
 	// Lower positions not populated
 	ROM_LOAD32_WORD( "81ts_3l.u6",   0x0c00000, 0x200000, CRC(d77cff9c) SHA1(93ee48c350110ebf9a80cca95c599c90a523147d) )
 	ROM_LOAD32_WORD( "82ts_3h.u14",  0x0c00002, 0x200000, CRC(f012b583) SHA1(907e1c93cbfa6a0285f96c53f5ccb63e313053d7) )
@@ -1336,7 +1342,7 @@ ROM_START( tgm2p )
 	ROM_LOAD32_WORD_SWAP( "2b.u21",   0x000000, 0x080000, CRC(38bc626c) SHA1(783e8413b11f1fa08d331b09ef4ed63f62b87ead) )
 	ROM_LOAD32_WORD_SWAP( "1b.u22",   0x000002, 0x080000, CRC(7599fb19) SHA1(3f7e81756470c173cc17a7e7dee91437571fd0c3) )
 
-	ROM_REGION( 0x3000000, "gfx1", ROMREGION_ERASE00 )  /* Sprites */
+	ROM_REGION( 0x3000000, "gfx", ROMREGION_ERASE00 )  /* Sprites */
 	// Lower positions not populated
 	ROM_LOAD32_WORD( "81ts_3l.u6",   0x0c00000, 0x200000, CRC(d77cff9c) SHA1(93ee48c350110ebf9a80cca95c599c90a523147d) )
 	ROM_LOAD32_WORD( "82ts_3h.u14",  0x0c00002, 0x200000, CRC(f012b583) SHA1(907e1c93cbfa6a0285f96c53f5ccb63e313053d7) )
@@ -1366,7 +1372,6 @@ ROM_END
 void psikyosh_state::init_ps3()
 {
 	m_maincpu->sh2drc_set_options(SH2DRC_FASTEST_OPTIONS);
-	m_maincpu->sh2drc_add_fastram(0x03000000, 0x0300ffff, 0, &m_spriteram[0]);
 	m_maincpu->sh2drc_add_fastram(0x03050000, 0x030501ff, 0, &m_zoomram[0]);
 	m_maincpu->sh2drc_add_fastram(0x06000000, 0x060fffff, 0, &m_ram[0]);
 }
@@ -1374,7 +1379,6 @@ void psikyosh_state::init_ps3()
 void psikyosh_state::init_ps5()
 {
 	m_maincpu->sh2drc_set_options(SH2DRC_FASTEST_OPTIONS);
-	m_maincpu->sh2drc_add_fastram(0x04000000, 0x0400ffff, 0, &m_spriteram[0]);
 	m_maincpu->sh2drc_add_fastram(0x04050000, 0x040501ff, 0, &m_zoomram[0]);
 	m_maincpu->sh2drc_add_fastram(0x06000000, 0x060fffff, 0, &m_ram[0]);
 }
@@ -1382,7 +1386,6 @@ void psikyosh_state::init_ps5()
 void psikyosh_state::init_s1945iiibl()
 {
 	m_maincpu->sh2drc_set_options(SH2DRC_FASTEST_OPTIONS);
-	m_maincpu->sh2drc_add_fastram(0x04000000, 0x0400ffff, 0, &m_spriteram[0]);
 	m_maincpu->sh2drc_add_fastram(0x04003000, 0x040031ff, 0, &m_zoomram[0]); // zoomram is in spriteram here
 	m_maincpu->sh2drc_add_fastram(0x06000000, 0x060fffff, 0, &m_ram[0]);
 }

--- a/src/mame/psikyo/psikyosh.cpp
+++ b/src/mame/psikyo/psikyosh.cpp
@@ -58,7 +58,7 @@ TODO:
 |         Tips and Tricks           |
 *-----------------------------------*
 
-Hold Button during booting to test roms (Checksum 16-bit, on Words for gfx and
+Hold Button during booting to test ROMs (Checksum 16-bit, on Words for gfx and
 Bytes for sound) for:
 
 Daraku:           PL1 Button 1 (passes, doesn't test sound)
@@ -343,7 +343,9 @@ ROM Usage
 #include "machine/eepromser.h"
 #include "machine/watchdog.h"
 #include "sound/ymopl.h"
+
 #include "speaker.h"
+
 
 static constexpr XTAL MASTER_CLOCK = 57.272727_MHz_XTAL;   // main oscillator frequency
 
@@ -359,7 +361,7 @@ void psikyosh_state::eeprom_w(u8 data)
 	m_eeprom->clk_write(BIT(data, 6));
 
 	if (data & ~0xe0)
-		logerror("Unk EEPROM write %x\n", data);
+		logerror("Unknown EEPROM write %x\n", data);
 }
 
 INTERRUPT_GEN_MEMBER(psikyosh_state::interrupt)
@@ -397,7 +399,7 @@ u32 psikyosh_state::mjgtaste_input_r()
 Mahjong keyboard encoder -> JAMMA adapter (SK-G001). Created to allow the use of a Mahjong panel with the existing, recycled Dragon Blaze boards.
 PCB contains what looks like an MCU of some description labeled "TMIBOD 4", undumped
 PCB maps keyboard lines onto JAMMA P1 controls
-Normally the demultiplexing is taken care of in hardware (e.g. metro.c, ssv.c), but here the game code has to do it.
+Normally the demultiplexing is taken care of in hardware (e.g. metro/metro.cpp, seta/ssv.cpp), but here the game code has to do it.
 
 Standard Mahjong keyboard encoder
       /---------------- KEY7
@@ -518,49 +520,49 @@ P1KEY11  29|30  P2KEY11
 // ps3v1
 void psikyosh_state::ps3v1_map(address_map &map)
 {
-// rom mapping
+// ROM mapping
 	map(0x00000000, 0x000fffff).rom(); // program ROM (1 meg)
 	map(0x02000000, 0x020fffff).rom().region("maincpu", 0x100000); // data ROM
 // video chip
-	map(0x03000000, 0x0300ffff).ram().w(FUNC(psikyosh_state::spriteram_w)).share(m_spriteram); // sprite and backgrounds are share this area (video banks 0-1f)
+	map(0x03000000, 0x0300ffff).ram().w(FUNC(psikyosh_state::spriteram_w)).share(m_spriteram); // sprite and backgrounds share this area (video banks 0-1f)
 	map(0x03040000, 0x03044fff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette"); // palette..
 	map(0x03050000, 0x030501ff).ram().share(m_zoomram); // sprite zoom lookup table
 	map(0x0305ffdc, 0x0305ffdf).r("watchdog", FUNC(watchdog_timer_device::reset32_r)).w(FUNC(psikyosh_state::irqctrl_w)); // also writes to this address - might be vblank reads?
 	map(0x0305ffe0, 0x0305ffff).ram().w(FUNC(psikyosh_state::vidregs_w)).share(m_vidregs); //  video registers
-	map(0x03060000, 0x0307ffff).bankr(m_gfxrombank); // data for rom tests (gfx), data is controlled by vidreg
-// rom mapping
-	map(0x04060000, 0x0407ffff).bankr(m_gfxrombank); // data for rom tests (gfx) (Mirrored?)
+	map(0x03060000, 0x0307ffff).bankr(m_gfxrombank); // data for ROM tests (gfx), data is controlled by vidreg
+// ROM mapping
+	map(0x04060000, 0x0407ffff).bankr(m_gfxrombank); // data for ROM tests (gfx) (Mirrored?)
 // sound chip
 	map(0x05000000, 0x05000007).rw("ymf", FUNC(ymf278b_device::read), FUNC(ymf278b_device::write));
 // inputs/eeprom
 	map(0x05800000, 0x05800003).portr("INPUTS");
 	map(0x05800004, 0x05800007).portr("JP4");
 	map(0x05800004, 0x05800004).w(FUNC(psikyosh_state::eeprom_w));
-// ram
+// RAM
 	map(0x06000000, 0x060fffff).ram().share(m_ram); // main RAM (1 meg)
 }
 
 // ps5, ps5v2
 void psikyosh_state::ps5_map(address_map &map)
 {
-// rom mapping
+// ROM mapping
 	map(0x00000000, 0x000fffff).rom(); // program ROM (1 meg)
-// inputs/eeprom
+// inputs/EEPROM
 	map(0x03000000, 0x03000003).portr("INPUTS");
 	map(0x03000004, 0x03000007).portr("JP4");
 	map(0x03000004, 0x03000004).w(FUNC(psikyosh_state::eeprom_w));
 // sound chip
 	map(0x03100000, 0x03100007).rw("ymf", FUNC(ymf278b_device::read), FUNC(ymf278b_device::write));
 // video chip
-	map(0x04000000, 0x0400ffff).ram().w(FUNC(psikyosh_state::spriteram_w)).share(m_spriteram); // sprite and backgrounds are share this area (video banks 0-1f)
+	map(0x04000000, 0x0400ffff).ram().w(FUNC(psikyosh_state::spriteram_w)).share(m_spriteram); // sprite and backgrounds share this area (video banks 0-1f)
 	map(0x04040000, 0x04044fff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette");
 	map(0x04050000, 0x040501ff).ram().share(m_zoomram); // sprite zoom lookup table
 	map(0x0405ffdc, 0x0405ffdf).nopr().w(FUNC(psikyosh_state::irqctrl_w)); // also writes to this address - might be vblank reads?
 	map(0x0405ffe0, 0x0405ffff).ram().w(FUNC(psikyosh_state::vidregs_w)).share(m_vidregs); // video registers
-	map(0x04060000, 0x0407ffff).bankr(m_gfxrombank); // data for rom tests (gfx), data is controlled by vidreg
-// rom mapping
+	map(0x04060000, 0x0407ffff).bankr(m_gfxrombank); // data for ROM tests (gfx), data is controlled by vidreg
+// ROM mapping
 	map(0x05000000, 0x0507ffff).rom().region("maincpu", 0x100000); // data ROM
-// ram
+// RAM
 	map(0x06000000, 0x060fffff).ram().share(m_ram);
 }
 

--- a/src/mame/psikyo/psikyosh.h
+++ b/src/mame/psikyo/psikyosh.h
@@ -5,13 +5,13 @@
 
 #pragma once
 
-#include "machine/eepromser.h"
 #include "cpu/sh/sh7604.h"
+#include "machine/eepromser.h"
+
 #include "emupal.h"
 #include "screen.h"
+#include "tilemap.h"
 
-
-#define MASTER_CLOCK 57272700   // main oscillator frequency
 
 /* Psikyo PS6406B */
 
@@ -22,6 +22,11 @@ class psikyosh_state : public driver_device
 public:
 	psikyosh_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
+		m_maincpu(*this, "maincpu"),
+		m_eeprom(*this, "eeprom"),
+		m_gfxdecode(*this, "gfxdecode"),
+		m_screen(*this, "screen"),
+		m_palette(*this, "palette"),
 		m_spriteram(*this, "spriteram"),
 		m_zoomram(*this, "zoomram"),
 		m_vidregs(*this, "vidregs"),
@@ -29,12 +34,7 @@ public:
 		m_gfxrombank(*this, "gfxbank"),
 		m_controller_io(*this, "CONTROLLER"),
 		m_inputs(*this, "INPUTS"),
-		m_mahjong_io(*this, "MAHJONG"),
-		m_maincpu(*this, "maincpu"),
-		m_eeprom(*this, "eeprom"),
-		m_gfxdecode(*this, "gfxdecode"),
-		m_screen(*this, "screen"),
-		m_palette(*this, "palette")
+		m_mahjong_io(*this, "MAHJONG")
 	{ }
 
 	void psikyo3v1(machine_config &config);
@@ -53,6 +53,13 @@ protected:
 	virtual void video_start() override ATTR_COLD;
 
 private:
+	/* devices */
+	required_device<sh7604_device> m_maincpu;
+	required_device<eeprom_serial_93cxx_device> m_eeprom;
+	required_device<gfxdecode_device> m_gfxdecode;
+	required_device<screen_device> m_screen;
+	required_device<palette_device> m_palette;
+
 	/* memory pointers */
 	required_shared_ptr<u32> m_spriteram;
 	required_shared_ptr<u32> m_zoomram;
@@ -81,18 +88,20 @@ private:
 
 	bitmap_ind8                 m_zoom_bitmap;
 	bitmap_ind16                m_z_bitmap;
-	bitmap_rgb32                m_bg_bitmap;
 	std::unique_ptr<u16[]>      m_bg_zoom;
 	std::unique_ptr<u8[]>       m_alphatable;
 	std::unique_ptr<struct sprite_t []> m_spritelist;
 	const struct sprite_t *m_sprite_end;
 
-	/* devices */
-	required_device<sh7604_device> m_maincpu;
-	required_device<eeprom_serial_93cxx_device> m_eeprom;
-	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<screen_device> m_screen;
-	required_device<palette_device> m_palette;
+	struct tilemap_info
+	{
+		// 2 color depths per tilemap
+		tilemap_t *tmap[2]{nullptr};
+		u32 vram_base = 0;
+	};
+
+	// up to 32 slots
+	tilemap_info m_tilemap[32];
 
 	bool const FLIPSCREEN() { return ((m_vidregs[3] & 0x0000c000) == 0x0000c000); } // currently ignored
 
@@ -101,10 +110,13 @@ private:
 	bool const BG_LAYER_ENABLE(u8 const n) { return ((m_vidregs[7] << (4 * n)) & 0x00008000); }
 
 	u8 const BG_TYPE(u8 const n) { return ((m_vidregs[6] << (8 * n)) & 0x7f000000) >> 24; }
-	bool const BG_LINE(u8 const n)    { return ((m_vidregs[6] << (8 * n)) & 0x80000000); }
+	bool const BG_LINE(u8 const n) { return ((m_vidregs[6] << (8 * n)) & 0x80000000); }
 
 	u8 const SPRITE_PRI(u8 const n) { return ((m_vidregs[2] << (4 * n)) & 0xf0000000) >> 28; }
 
+	template<int Depth> TILE_GET_INFO_MEMBER(get_tile_info);
+
+	void spriteram_w(offs_t offset, u32 data, u32 mem_mask);
 	void irqctrl_w(u32 data);
 	void vidregs_w(offs_t offset, u32 data, u32 mem_mask);
 	u32 mjgtaste_input_r();
@@ -112,18 +124,13 @@ private:
 	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void screen_vblank(int state);
 	INTERRUPT_GEN_MEMBER(interrupt);
-	void draw_scanline32_alpha(bitmap_rgb32 &bitmap, s32 destx, s32 desty, s32 length, const u32 *srcptr, int alpha);
-	void draw_scanline32_argb(bitmap_rgb32 &bitmap, s32 destx, s32 desty, s32 length, const u32 *srcptr);
-	void draw_scanline32_transpen(bitmap_rgb32 &bitmap, s32 destx, s32 desty, s32 length, const u32 *srcptr);
-	void draw_bglayer(u8 const layer, bitmap_rgb32 &bitmap, const rectangle &cliprect, u8 const req_pri);
-	void cache_bitmap(s16 const scanline, gfx_element *gfx, u8 const size, u8 const tilebank, s16 const alpha, u8 *last_bank);
-	void draw_bglayerscroll(u8 const layer, bitmap_rgb32 &bitmap, const rectangle &cliprect, u8 const req_pri);
+	void draw_single_tilemap(u8 const layer, bitmap_rgb32 &bitmap, const rectangle &cliprect, u8 const req_pri);
 	void draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect, u8 const req_pri);
 	void draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect, u8 const req_pri);
 	void get_sprites();
 	void prelineblend(bitmap_rgb32 &bitmap, const rectangle &cliprect );
 	void postlineblend(bitmap_rgb32 &bitmap, const rectangle &cliprect, u8 const req_pri);
-	void psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangle &clip, gfx_element *gfx,
+	void drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangle &clip, gfx_element *gfx,
 	u32 const code, u16 const color, u8 const flipx, u8 const flipy, s32 const offsx, s32 const offsy,
 	s16 const alpha, u32 const zoomx, u32 const zoomy, u8 const wide, u8 const high, u16 const z);
 	void ps3v1_map(address_map &map) ATTR_COLD;

--- a/src/mame/psikyo/psikyosh_v.cpp
+++ b/src/mame/psikyo/psikyosh_v.cpp
@@ -2,108 +2,128 @@
 // copyright-holders:David Haywood, Paul Priest
 /*
 Psikyo PS6406B (PS3v1/PS5/PS5v2):
-See src/mame/drivers/psikyosh.cpp for more info
+See src/mame/psikyo/psikyosh.cpp for more info
 
-Hardware is extremely flexible (and luckily underused, although we now have a relatively complete implementation :). Many effects are subtle (e.g. fades, scanline effects).
+Hardware is extremely flexible (and luckily underused, although we now have a
+relatively complete implementation :). Many effects are subtle (e.g. fades,
+scanline effects).
 
 Banks:
-There are 32 data banks of 0x800 bytes starting at 0x3000000 (ps3) / 0x4000000 (ps5/ps5v2)
+There are 32 data banks of 0x800 bytes starting at:
+0x3000000 (ps3) / 0x4000000 (ps5/ps5v2)
 
 Can be one of:
-* a set of adjacent banks for sprites (we always use the first 7 banks currently, looks to be configurable in vidregs
+* a set of adjacent banks for sprites (we always use the first 7 banks
+  currently, looks to be configurable in vidregs
 * a sprite draw list (max 1024 sprites, always in bank 07?)
-* pre (i.e. screen clear) + post (i.e. drawn with a non-zero priority) line-fill/blend layer (usually bank 08)
+* pre (i.e. screen clear) + post (i.e. drawn with a non-zero priority)
+  line-fill/blend layer (usually bank 08)
 * tilemap tiles (or 2 adjacent banks for large tilemaps) (usually banks 0c-1f)
-* xscroll/yscroll, pri/xzoom/alpha/bank per-layer (of which there are four) -> which points to another tilebank per-layer (usually bank 0a/0b)
-* xscroll/yscroll, pri/xzoom/alpha/bank per-scanline (typically 224) -> which points to another tilebank per-line (usually bank 0c/0d)
+* xscroll/yscroll, pri/xzoom/alpha/bank per-layer (of which there are four) ->
+  which points to another tilebank per-layer (usually bank 0a/0b)
+* xscroll/yscroll, pri/xzoom/alpha/bank per-scanline (typically 224) -> which
+  points to another tilebank per-line (usually bank 0c/0d)
 
-Most games use bank 0x0a and 0x0b for the registers for double-buffering, which then refer to other banks for the tiles. If they use line-effects, they tend to populate the per-line registers into one of the other banks e.g. daraku or S1945II test+level 7+level8 boss and S1945III levels 7+8, soldivid final boss.
+Most games use bank 0x0a and 0x0b for the registers for double-buffering, which
+then refer to other banks for the tiles. If they use line-effects, they tend to
+populate the per-line registers into one of the other banks e.g. daraku or
+S1945II test+level 7+level8 boss and S1945III levels 7+8, soldivid final boss.
 */
 
 /*
 BG Scroll/Priority/Zoom/Alpha/Tilebank registers:
-Either at 0x30053f0/4/8 (For 0a), 0x3005bf0/4/8 (For 0b) etc. (i.e. in the middle of a bank) Or per-line in a bank
-   0x?vvv?xxx - v = vertical scroll - x = x scroll
-Either at 0x30057f0/4/8 (For 0a), 0x3005ff0/4/8 (For 0b) etc. (i.e. at the end of the bank) Or per-line in a bank
-   0xppzzaabb - p = priority, z = zoom/expand(00 is none), a = alpha value/effect, b = tilebank
+Either at 0x30053f0/4/8 (For 0a), 0x3005bf0/4/8 (For 0b) etc.
+   (i.e. in the middle of a bank) Or per-line in a bank
+   0x?yyy?xxx -
+   v = y scroll
+   x = x scroll
+Either at 0x30057f0/4/8 (For 0a), 0x3005ff0/4/8 (For 0b) etc.
+   (i.e. at the end of the bank) Or per-line in a bank
+   0xppzzaabb -
+   p = priority
+   z = zoom/expand(00 is none)
+   a = alpha value/effect
+   b = tilebank
 
 Video Registers: at 0x305ffe0 for ps3 or 0x405ffe0 for ps5/ps5v2:
-0x00 -- ffffffff alpha values for sprites, 8-bits per value (0-0x3f, 0x80 indicates per-pen alpha). sbomberb = 0000 3830 2820 1810
+0x00 -- ffffffff alpha values for sprites, 8-bits per value (0-0x3f, 0x80
+                 indicates per-pen alpha). sbomberb = 0000 3830 2820 1810
 0x04 -- ffffffff above continued.
 0x08 -- ffff0000 priority values for sprites, 4-bits per value
-        0000ff00 unknown. always 20. number of addressable banks? boards are populated with 20.
-        000000f0 unknown. s1945ii/s1945iii/gunbird2/gnbarich/tgm2/dragnblz/sbomber/mjgtaste sets to c. soldivid/daraku is 0. another bank select?
+        0000ff00 unknown. always 20. number of addressable banks? boards are
+		         populated with 20.
+        000000f0 unknown. s1945ii/s1945iii/gunbird2/gnbarich/tgm2/dragnblz/
+		         sbomber/mjgtaste sets to c. soldivid/daraku is 0. another bank
+				 select?
         0000000f is priority for per-line post-blending
-0x0c -- 3f3f3f3f unknown. A table of 4 6-bit values. usually 0f102038. tgm2 is 0a172838.
+0x0c -- 3f3f3f3f unknown. A table of 4 6-bit values. usually 0f102038. tgm2 is
+                 0a172838.
         c0c00000 unknown. unused?
         0000c000 is flipscreen (currently ignored). presumably flipy<<1|flipx.
-        000000c0 is screen size select. 0 is 224 lines, c is 240 (see tgm2, not confirmed).
+        000000c0 is screen size select. 0 is 224 lines, c is 240 (see tgm2, not
+		         confirmed).
 0x10 -- ffff0000 is always 00aa
-        0000f000 number of banks for sprites (not confirmed). mjgtaste/tgm2/sbomber/s1945ii/dragnblz/gnbarich is 3, gunbird2/s1945iii is 2, soldivid/daraku is b.
-        00000fff Controls gfx data bank available to be read by SH-2 for verification.
+        0000f000 number of banks for sprites (not confirmed). mjgtaste/tgm2/
+		         sbomber/s1945ii/dragnblz/gnbarich is 3, gunbird2/s1945iii is
+				 2, soldivid/daraku is b.
+        00000fff Controls gfx data bank available to be read by SH-2 for
+		         verification.
 0x14 -- ffffffff always 83ff000e
-0x18 -- ffffffff bank for tilemaps. As follows for the different tilemaps: 11223344. Bit 0x80 indicates use of line effects and the bank should be used to look up the tile-bank per line.
+0x18 -- ffffffff bank for tilemaps. As follows for the different tilemaps:
+                 11223344. Bit 0x80 indicates use of line effects and the bank
+				 should be used to look up the tile-bank per line.
 0x1c -- ff000000 controls bank for 'pre'/'post' values
         00ff0000 unknown, always 0?
-        0000ffff enable bits for 4 tilemaps. 8 is enable. 4 indicates 8bpp tiles. 1 is size select for tilemap
+        0000ffff enable bits for 4 tilemaps. 8 is enable. 4 indicates 8bpp
+		         tiles. 1 is size select for tilemap
 */
 
 /*
 TODO:
-* Correct sprite-sprite priority? Currently this is strictly in the order of the sprites in the sprite list. However, there's an additional priority parameter which looks to split the sprites into 4 discrete sets with decreasing priority. In addition to the sprite-tilemap mixing the only way I can think to emulate this is how the hardware would work. Iterate over the sprite list 4 times rendering the sprites to a bitmap, and then mix each pixel against the tilemaps and other elements with comparable priority. This will be pretty slow though. Justification: The unknown priority bits are used to separate score/enemy bullets from ships/enemies from incidental effects. daraku appears to have a black, screen-filling srite which it uses for a flash immediately efore the screen fade/white flash when doing special moves. Currently obscured behind the other sprites.
+* Correct sprite-sprite priority? Currently this is strictly in the order of
+  the sprites in the sprite list. However, there's an additional priority
+  parameter which looks to split the sprites into 4 discrete sets with
+  decreasing priority. In addition to the sprite-tilemap mixing the only way
+  I can think to emulate this is how the hardware would work. Iterate over
+  the sprite list 4 times rendering the sprites to a bitmap, and then mix each
+  pixel against the tilemaps and other elements with comparable priority. This
+  will be pretty slow though. Justification: The unknown priority bits are used
+  to separate score/enemy bullets from ships/enemies from incidental effects.
+  daraku appears to have a black, screen-filling srite which it uses for a
+  flash immediately efore the screen fade/white flash when doing special moves.
+  Currently obscured behind the other sprites.
 * Perform tests on real hardware to document limits and remaining registers
 ** Fix background line zoom to be pixel-correct. There must be an internal LUT.
-** Confirm existence of 4th tilemap layer on real hw by configuring it. No games ever get as far as enabling it.
-** Confirm sprite-sprite priority behaviours (two overlapping sprites in sprite list order, with differing priorities etc.)
-** Figure out why the sprite zoom is not 100% when we even have a lookup table. See TGM2 MT report. Possibly we should offset calcs by half a pixel (i.e. start in the middle of the first source pixel rather than corner).
+** Confirm existence of 4th tilemap layer on real hw by configuring it. No
+   games ever get as far as enabling it.
+** Confirm sprite-sprite priority behaviours (two overlapping sprites in
+   sprite list order, with differing priorities etc.)
+** Figure out why the sprite zoom is not 100% when we even have a lookup table.
+   See TGM2 MT report. Possibly we should offset calcs by half a pixel (i.e.
+   start in the middle of the first source pixel rather than corner).
 ** Figure out screen size registers and xflip/yflip
-* Hookup configurable sprite banks (not needed? reports of tgm2 dropping sprites when busy on real hw)
+* Hookup configurable sprite banks (not needed? reports of tgm2 dropping
+  sprites when busy on real hw)
 * Hookup screen size select
 * Flip screen, located but not implemented. wait until tilemaps.
-* The stuff might be converted to use the tilemaps once all the features is worked out ...
-The only viable way to do this is to have one tilemap per bank (0x0a-0x20), and every pair of adjacent banks for large tilemaps. This is rather than having one per background layer, due to the line effects. Would also need to support all of the logic relating to alpha table blending, row and column scroll/zoom etc.
+* The stuff might be converted to use the tilemaps once all the features is
+  worked out ...
+  The only viable way to do this is to have one tilemap per bank (0x0a-0x20),
+  and every pair of adjacent banks for large tilemaps. This is rather than
+  having one per background layer, due to the line effects. Would also need to
+  support all of the logic relating to alpha table blending, row and column
+  scroll/zoom etc.
 */
 
 #include "emu.h"
-#include "drawgfxt.ipp"
 #include "psikyosh.h"
 
 #include <algorithm>
 
-static constexpr u32 BG_TRANSPEN = 0x00ff00ff; // used for representing transparency in temporary bitmaps
-
 //#define DEBUG_KEYS
 //#define DEBUG_MESSAGE
 
-// take ARGB pixel with stored alpha and blend in to RGB32 bitmap
-#define PIXEL_OP_COPY_TRANSPEN_ARGBRENDER32(DEST, SOURCE)                                           \
-do                                                                                                  \
-{                                                                                                   \
-	const rgb_t srcdata = (SOURCE);                                                                 \
-	if (srcdata != transpen)                                                                        \
-		(DEST) = alpha_blend_r32((DEST), srcdata, srcdata.a());                                     \
-}                                                                                                   \
-while (0)
-// take RGB pixel with separate alpha and blend in to RGB32 bitmap
-#define PIXEL_OP_COPY_TRANSPEN_ALPHARENDER32(DEST, SOURCE)                                          \
-do                                                                                                  \
-{                                                                                                   \
-	const u32 srcdata = (SOURCE);                                                                   \
-	if (srcdata != transpen)                                                                        \
-		(DEST) = alpha_blend_r32((DEST), srcdata, alpha);                                           \
-}                                                                                                   \
-while (0)
-// take ARGB pixel with stored alpha and copy in to RGB32 bitmap, scipping BG_TRANSPEN
-#define PIXEL_OP_COPY_TRANSPEN_RENDER32(DEST, SOURCE)                                               \
-do                                                                                                  \
-{                                                                                                   \
-	const u32 srcdata = (SOURCE);                                                                   \
-	if (srcdata != transpen)                                                                        \
-		(DEST) = srcdata;                                                                           \
-}                                                                                                   \
-while (0)
-
-static inline void pixop_transparent_priority(u8 source, u32 *dest, u16 *pri, const pen_t *pal, u16 z)
+static inline void pixop_transparent_priority(u8 source, u32 *dest, u16 *pri, pen_t const *pal, u16 z)
 {
 	if (z >= *pri)
 	{
@@ -115,13 +135,13 @@ static inline void pixop_transparent_priority(u8 source, u32 *dest, u16 *pri, co
 	}
 }
 
-static inline void pixop_transparent(u8 source, u32 *dest, const pen_t *pal)
+static inline void pixop_transparent(u8 source, u32 *dest, pen_t const *pal)
 {
 	if (source != 0)
 		*dest = pal[source];
 }
 
-static inline void pixop_transparent_alpha_priority(u8 source, u32 *dest, u16 *pri, const pen_t *pal, u16 z, s16 alpha)
+static inline void pixop_transparent_alpha_priority(u8 source, u32 *dest, u16 *pri, pen_t const *pal, u16 z, s16 alpha)
 {
 	if (z >= *pri)
 	{
@@ -133,13 +153,13 @@ static inline void pixop_transparent_alpha_priority(u8 source, u32 *dest, u16 *p
 	}
 }
 
-static inline void pixop_transparent_alpha(u8 source, u32 *dest, const pen_t *pal, s16 alpha)
+static inline void pixop_transparent_alpha(u8 source, u32 *dest, pen_t const *pal, s16 alpha)
 {
 	if (source != 0)
 		*dest = alpha_blend_r32(*dest, pal[source], alpha);
 }
 
-static inline void pixop_transparent_alphatable_priority(u8 source, u32 *dest, u16 *pri, const pen_t *pal, u16 z, u8 *alphatable)
+static inline void pixop_transparent_alphatable_priority(u8 source, u32 *dest, u16 *pri, pen_t const *pal, u16 z, u8 *alphatable)
 {
 	if (z >= *pri)
 	{
@@ -155,7 +175,7 @@ static inline void pixop_transparent_alphatable_priority(u8 source, u32 *dest, u
 	}
 }
 
-static inline void pixop_transparent_alphatable(u8 source, u32 *dest, const pen_t *pal, u8 *alphatable)
+static inline void pixop_transparent_alphatable(u8 source, u32 *dest, pen_t const *pal, u8 *alphatable)
 {
 	if (source != 0)
 	{
@@ -165,232 +185,120 @@ static inline void pixop_transparent_alphatable(u8 source, u32 *dest, const pen_
 			*dest = alpha_blend_r32(*dest, pal[source], alphatable[source]);
 	}
 }
-/*-------------------------------------------------
-    draw_scanline32_alpha - take an RGB-encoded u32
-    scanline and alpha-blend it into the destination bitmap
--------------------------------------------------*/
-void psikyosh_state::draw_scanline32_alpha(bitmap_rgb32 &bitmap, s32 destx, s32 desty, s32 length, const u32 *srcptr, int alpha)
-{
-	drawscanline_core(bitmap, destx, desty, length, srcptr, [alpha, transpen = BG_TRANSPEN](u32 &destp, const u32 &srcp) { PIXEL_OP_COPY_TRANSPEN_ALPHARENDER32(destp, srcp); });
-}
-
-/*-------------------------------------------------
-    draw_scanline32_argb - take an ARGB-encoded u32
-    scanline and alpha-blend it into the destination bitmap
--------------------------------------------------*/
-void psikyosh_state::draw_scanline32_argb(bitmap_rgb32 &bitmap, s32 destx, s32 desty, s32 length, const u32 *srcptr)
-{
-	drawscanline_core(bitmap, destx, desty, length, srcptr, [transpen = BG_TRANSPEN](u32 &destp, const u32 &srcp) { PIXEL_OP_COPY_TRANSPEN_ARGBRENDER32(destp, srcp); });
-}
-
-/*-------------------------------------------------
-    draw_scanline32_tranpens - take an RGB-encoded u32
-    scanline and copy it into the destination bitmap, testing for the special ARGB transpen
--------------------------------------------------*/
-void psikyosh_state::draw_scanline32_transpen(bitmap_rgb32 &bitmap, s32 destx, s32 desty, s32 length, const u32 *srcptr)
-{
-	drawscanline_core(bitmap, destx, desty, length, srcptr, [transpen = BG_TRANSPEN](u32 &destp, const u32 &srcp) { PIXEL_OP_COPY_TRANSPEN_RENDER32(destp, srcp); });
-}
-
 
 /* Psikyo PS6406B */
 /* --- BACKGROUNDS --- */
 
-/* 'Normal' layers, no line/columnscroll. No per-line effects.
-Zooming isn't supported just because it's not used and it would be slow */
-void psikyosh_state::draw_bglayer(u8 const layer, bitmap_rgb32 &bitmap, const rectangle &cliprect, u8 const req_pri)
+void psikyosh_state::spriteram_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	assert(!BG_LINE(layer));
-
-	gfx_element *gfx = BG_DEPTH_8BPP(layer) ? m_gfxdecode->gfx(1) : m_gfxdecode->gfx(0);
-	u8 const size = BG_LARGE(layer) ? 32 : 16;
-	u16 const height = 16 * size;
-
-	u8 const regbank = BG_TYPE(layer);
-
-	u16 const scrollx = (m_spriteram[(regbank * 0x800) / 4 + 0x3f0 / 4 + (layer * 0x04) / 4] & 0x000001ff) >> 0;
-	u16 const scrolly = (m_spriteram[(regbank * 0x800) / 4 + 0x3f0 / 4 + (layer * 0x04) / 4] & 0x03ff0000) >> 16;
-
-	u8 const tilebank = (m_spriteram[(regbank * 0x800) / 4 + 0x7f0 / 4 + (layer * 0x04) / 4] & 0x000000ff) >> 0;
-	s16 alpha         = (m_spriteram[(regbank * 0x800) / 4 + 0x7f0 / 4 + (layer * 0x04) / 4] & 0x00003f00) >> 8;
-	u8 const alphamap = (m_spriteram[(regbank * 0x800) / 4 + 0x7f0 / 4 + (layer * 0x04) / 4] & 0x00008000) >> 15;
-	u8 const zoom     = (m_spriteram[(regbank * 0x800) / 4 + 0x7f0 / 4 + (layer * 0x04) / 4] & 0x00ff0000) >> 16;
-	u8 const pri      = (m_spriteram[(regbank * 0x800) / 4 + 0x7f0 / 4 + (layer * 0x04) / 4] & 0xff000000) >> 24;
-
-	if (pri != req_pri)
-		return;
-
-	if (alphamap) /* alpha values are per-pen */
-		alpha = -1;
-	else
-		alpha = pal6bit(0x3f - alpha);  /* 0x3f-0x00 maps to 0x00-0xff */
-
-	if (zoom)
-		popmessage("draw_bglayer() zoom not implemented\nContact MAMEDEV");
-
-	if ((tilebank >= 0x0a) && (tilebank <= 0x1f)) /* 20 banks of 0x800 bytes. filter garbage. */
+	COMBINE_DATA(&m_spriteram[offset]);
+	for (int i = 0; i < 2; i++)
 	{
-		u8 basey = ((0x400 - scrolly + cliprect.top() - 1) & (height - 1)) >> 4;
-		for (int sy = (cliprect.top() - 1) >> 4; sy <= cliprect.bottom() >> 4; sy++)
-		{
-			u8 basex = ((0x200 - scrollx + cliprect.left() - 1) & 0x1ff) >> 4;
-			for (int sx = (cliprect.left() - 1) >> 4; sx <= cliprect.right() >> 4; sx++)
-			{
-				u32 const tileno = (m_spriteram[(tilebank * 0x800) / 4 + (((basey & 0x1f) << 5) | (basex & 0x1f))] & 0x0007ffff);
-				u8 const colour  = (m_spriteram[(tilebank * 0x800) / 4 + (((basey & 0x1f) << 5) | (basex & 0x1f))] & 0xff000000) >> 24;
-
-				gfx->alphatable(bitmap, cliprect, tileno, colour, 0, 0, (16 * sx) + (scrollx & 0xf), (16 * sy) + (scrolly & 0xf), alpha, m_alphatable.get()); /* normal */
-
-				basex++;
-			}
-			basey = ((basey + 1) & ((height >> 4) - 1));
-		}
+		m_tilemap[(offset >> 9) & 0x1f].tmap[i]->mark_tile_dirty(offset & 0x1ff);
 	}
 }
 
-
-/* populate bg_bitmap for the given bank if it's not already */
-void psikyosh_state::cache_bitmap(s16 const scanline, gfx_element *gfx, u8 const size, u8 const tilebank, s16 const alpha, u8 *last_bank)
+template<int Depth>
+TILE_GET_INFO_MEMBER(psikyosh_state::get_tile_info)
 {
-	// test if the tile row is the cached one or not
-	u8 const sy = scanline / 16;
+	tilemap_info *const layer = (tilemap_info *)tilemap.user_data();
+	u32 const data = m_spriteram[layer->vram_base + tile_index];
+	u32 const tileno = data & 0x0007ffff;
+	u32 const colour = (data & 0xff000000) >> 24;
 
-	assert(sy >= 0 && sy < 32);
-
-	if (tilebank != last_bank[sy])
-	{
-		rectangle cliprect;
-		u16 const minsy = sy * 16;
-		u16 const maxsy = minsy + 16 - 1;
-
-		cliprect.set(0, m_bg_bitmap.width() - 1, minsy, maxsy );
-		cliprect &= m_bg_bitmap.cliprect();
-
-		m_bg_bitmap.fill(BG_TRANSPEN, cliprect);
-		u16 const height = size * 16;
-
-		u32 offs = 32 * sy;
-		for (int sx = 0; sx < 32; sx++)
-		{
-			u32 const tileno = (m_spriteram[(tilebank * 0x800) / 4 + offs] & 0x0007ffff);
-			u32 const colour = (m_spriteram[(tilebank * 0x800) / 4 + offs] & 0xff000000) >> 24;
-			int need_alpha = alpha < 0 ? -1 : 0xff; // store per-pen alpha in bitmap, otherwise don't since we'll need it per-line
-
-			if (tileno) // valid tile, but blank in all games?
-				gfx->alphastore(m_bg_bitmap, m_bg_bitmap.cliprect(), tileno, colour, 0, 0, (16 * sx) & 0x1ff, ((16 * sy) & (height - 1)), need_alpha, m_alphatable.get());
-
-			offs++;
-		}
-		last_bank[sy] = tilebank;
-	}
+	tileinfo.set(Depth, tileno, colour & 0xf0, 0);
+	// store low 4 bit of color in category and mix later
+	// for keep per-pixel alpha blend information
+	tileinfo.category = colour & 0x0f;
 }
-
 
 /* Row Scroll/Zoom and/or Column Zoom, has per-column Alpha/Bank/Priority
-Bitmap is first rendered to an ARGB image, taking into account the per-pen alpha (if used).
-From there we extract data as we compose the image, one scanline at a time, blending the ARGB pixels
-into the RGB32 bitmap (with either the alpha information from the ARGB, or per-line alpha */
-void psikyosh_state::draw_bglayerscroll(u8 const layer, bitmap_rgb32 &bitmap, const rectangle &cliprect, u8 const req_pri)
+Bitmap is first rendered to an ARGB image, taking into account the per-pen
+alpha (if used).
+From there we extract data as we compose the image, one scanline at a time,
+blending the ARGB pixels into the RGB32 bitmap (with either the alpha
+information from the ARGB, or per-line alpha */
+void psikyosh_state::draw_single_tilemap(u8 const layer, bitmap_rgb32 &bitmap, const rectangle &cliprect, u8 const req_pri)
 {
-	assert(BG_LINE(layer));
+	u8 const linebank = BG_TYPE(layer);
+	if (linebank > 0x1f) // fix possible oob access
+		return;
 
-	gfx_element *gfx = BG_DEPTH_8BPP(layer) ? m_gfxdecode->gfx(1) : m_gfxdecode->gfx(0);
+	pen_t const *const pal = m_palette->pens();
 	u8 const size = BG_LARGE(layer) ? 32 : 16;
 	u16 const height = size * 16;
 
-	u8 const linebank = BG_TYPE(layer);
+	u32 const fixed_regaddr = (0x3f0 / 4) + layer;
+	u32 const *const scroll_reg = &m_spriteram[(linebank * 0x800) / 4];
+	// pri, zoom, alpha, bank
+	u32 const *const pzab_reg   = &m_spriteram[(linebank * 0x800) / 4 + 0x400 / 4];
 
-	/* cache rendered bitmap */
-	u8 last_bank[32]; // corresponds to bank of bitmap in m_bg_bitmap. bg_bitmap is split into 16/32-rows of one-tile high each
-	for (auto & elem : last_bank) elem = -1;
-
-	int const scr_width = cliprect.width();
-	u32 *scroll_reg = &m_spriteram[(linebank * 0x800) / 4 + cliprect.top()];
-	u32 *pzab_reg   = &m_spriteram[(linebank * 0x800) / 4 + cliprect.top() + 0x400 / 4]; // pri, zoom, alpha, bank
-
-// now, for each scanline, check priority,
-// extract the relevant scanline from the bitmap, after applying per-scanline vscroll,
-// stretch it and scroll it into another buffer
-// write it with alpha
+	// now, for each scanline, check priority,
+	// extract the relevant scanline from the bitmap, after applying
+	// per-scanline vscroll,
+	// stretch it and scroll it into another buffer
+	// write it with alpha
 	for (int scanline = cliprect.top(); scanline <= cliprect.bottom(); scanline++)
 	{
-		u8 const pri = (*pzab_reg & 0xff000000) >> 24;
+		u32 const regaddr = (BG_LINE(layer) ? scanline : fixed_regaddr) & 0xff;
+		u8 const pri = (pzab_reg[regaddr] & 0xff000000) >> 24;
+		if (pri != req_pri)
+			continue;
 
-		if (pri == req_pri)
+		u8 const tilebank  = (pzab_reg[regaddr] & 0x000000ff) >> 0;
+		/* 20 banks of 0x800 bytes. filter garbage. */
+		if ((tilebank >= 0x0a) && (tilebank <= 0x1f))
 		{
-			u16 const scrollx  = (*scroll_reg & 0x000001ff) >> 0;
-			u16 const scrolly  = (*scroll_reg & 0x03ff0000) >> 16;
+			u16 const scrollx  = (scroll_reg[regaddr] & 0x000001ff) >> 0;
+			u16 const scrolly  = (scroll_reg[regaddr] & 0x01ff0000) >> 16;
 
-			u8 const zoom      = (*pzab_reg & 0x00ff0000) >> 16;
-			u8 const alphamap  = (*pzab_reg & 0x00008000) >> 15;
-			s16 alpha          = (*pzab_reg & 0x00003f00) >> 8;
-			u8 const tilebank  = (*pzab_reg & 0x000000ff) >> 0;
+			u8 const zoom      = (pzab_reg[regaddr] & 0x00ff0000) >> 16;
+			u8 const alphamap  = (pzab_reg[regaddr] & 0x00008000) >> 15;
+			s16 alpha          = (pzab_reg[regaddr] & 0x00003f00) >> 8;
 
-			if (alphamap) /* alpha values are per-pen */
-				alpha = -1;
-			else
+			if (!alphamap)
 				alpha = pal6bit(0x3f - alpha);
 
-			if ((tilebank >= 0x0a) && (tilebank <= 0x1f)) /* 20 banks of 0x800 bytes. filter garbage. */
+			u16 const srcy = (scanline - scrolly) & (height - 1);
+			tilemap_t *tmap = m_tilemap[(tilebank + (srcy >> 8)) & 0x1f].tmap[BG_DEPTH_8BPP(layer) ? 1 : 0];
+			u32 *const dst = &bitmap.pix(scanline);
+			u16 const *const srcbitmap = &tmap->pixmap().pix(srcy & 0xff);
+			u8 const *const srcflagsmap = &tmap->flagsmap().pix(srcy & 0xff);
+
+			for (int drawx = cliprect.left(), xcnt = m_bg_zoom[zoom] * cliprect.left(); drawx <= cliprect.right(); drawx++, xcnt += m_bg_zoom[zoom])
 			{
-				u16 const tilemap_scanline = (scanline - scrolly + 0x400) & (height - 1);
-
-				// render reelvant tiles to temp bitmap, assume bank changes infrequently/never. render alpha as per-pen
-				cache_bitmap(tilemap_scanline, gfx, size, tilebank, alpha, last_bank);
-
-				/* zoomy and 'wibbly' effects - extract an entire row from tilemap */
-				auto profile2 = g_profiler.start(PROFILER_USER2);
-				u32 tilemap_line[32 * 16];
-				u32 scr_line[64 * 8];
-				std::copy_n(&m_bg_bitmap.pix(tilemap_scanline, 0), 0x200, tilemap_line);
-				profile2.stop();
-
-				/* slow bit, needs optimising. apply scrollx and zoomx by assembling scanline from row */
+				u16 const srcx = ((xcnt >> 10) - scrollx) & 0x1ff;
+				u8 const pix = srcbitmap[srcx] & 0xff;
+				if (pix != 0)
 				{
-					auto profile3 = g_profiler.start(PROFILER_USER3);
-					if (zoom)
+					u32 const color = pal[(pix + ((srcbitmap[srcx] & 0xf00) | ((srcflagsmap[srcx] & 0xf) << 4))) & 0xfff];
+					if (alphamap)
 					{
-						u16 const step = m_bg_zoom[zoom];
-						int jj = (0x400 << 10) + (step * cliprect.left()); // ensure +ve for mod
-						for (int ii = cliprect.left(); ii <= cliprect.right(); ii++)
-						{
-							scr_line[ii] = tilemap_line[((jj>>10) - scrollx) & 0x1ff];
-							jj += step;
-						}
+						if (m_alphatable[pix] == 0xff)
+							dst[drawx] = color;
+						else if (m_alphatable[pix] > 0)
+							dst[drawx] = alpha_blend_r32(dst[drawx], color, m_alphatable[pix]);
 					}
 					else
 					{
-						for (int ii = cliprect.left(); ii <= cliprect.right(); ii++)
-							scr_line[ii] = tilemap_line[(ii - scrollx + 0x400) & 0x1ff];
+						if (alpha == 0xff)
+							dst[drawx] = color;
+						else if (alpha > 0)
+							dst[drawx] = alpha_blend_r32(dst[drawx], color, alpha);
 					}
-					// stop profiling USER3
 				}
-
-				/* blend line into output */
-				auto profile4 = g_profiler.start(PROFILER_USER4);
-				if (alpha == 0xff)
-					draw_scanline32_transpen(bitmap, cliprect.left(), scanline, scr_width, &scr_line[cliprect.left()]);
-				else if (alpha > 0)
-					draw_scanline32_alpha(bitmap, cliprect.left(), scanline, scr_width, &scr_line[cliprect.left()], alpha);
-				else if (alpha < 0)
-					draw_scanline32_argb(bitmap, cliprect.left(), scanline, scr_width, &scr_line[cliprect.left()]);
 			}
 		}
-
-		scroll_reg++;
-		pzab_reg++;
 	}
 }
 
-/* 3 BG layers, with priority */
+/* 4 BG layers, with priority */
 void psikyosh_state::draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect, u8 const req_pri)
 {
-	int i;
-
 #ifdef DEBUG_KEYS
-	const int lay_keys[8] = {KEYCODE_Q, KEYCODE_W, KEYCODE_E, KEYCODE_R};
+	int const lay_keys[8] = {KEYCODE_Q, KEYCODE_W, KEYCODE_E, KEYCODE_R};
 	bool lay_debug = false;
-	for (i = 0; i <= 3; i++)
+	for (int i = 0; i <= 3; i++)
 	{
 		if (machine().input().code_pressed(lay_keys[i]))
 			lay_debug = true;
@@ -399,7 +307,7 @@ void psikyosh_state::draw_background(bitmap_rgb32 &bitmap, const rectangle &clip
 #endif
 
 	/* 1st-4th layers */
-	for (i = 0; i <= 3; i++)
+	for (int i = 0; i <= 3; i++)
 	{
 #ifdef DEBUG_KEYS
 		if (lay_debug && !machine().input().code_pressed(lay_keys[i]))
@@ -409,24 +317,24 @@ void psikyosh_state::draw_background(bitmap_rgb32 &bitmap, const rectangle &clip
 		if (!BG_LAYER_ENABLE(i))
 			continue;
 
-		if (BG_LINE(i)) /* per-line alpha, scroll, zoom etc. check the priority for the first scanline */
-			draw_bglayerscroll(i, bitmap, cliprect, req_pri);
-		else /* not per-line alpha, scroll, zoom etc. */
-			draw_bglayer(i, bitmap, cliprect, req_pri);
-
+		draw_single_tilemap(i, bitmap, cliprect, req_pri);
 	}
 }
 
 /* --- SPRITES --- */
 
 /* 32-bit ONLY */
-/* zoomx/y are pixel slopes in 6.10 fixed point, not scale. 0x400 is 1:1. drawgfx zoom algorithm doesn't produce identical results to hardware. */
-/* high/wide are number of tiles wide/high up to max size of zoom_bitmap in either direction */
-/* code is index of first tile and incremented across rows then down columns (adjusting for flip obviously) */
+/* zoomx/y are pixel slopes in 6.10 fixed point, not scale. 0x400 is 1:1.
+   drawgfx zoom algorithm doesn't produce identical results to hardware. */
+/* high/wide are number of tiles wide/high up to max size of zoom_bitmap in
+   either direction */
+/* code is index of first tile and incremented across rows then down columns
+   (adjusting for flip obviously) */
 /* sx and sy is top-left of entire sprite regardless of flip */
-/* Note that Level 5-4 of sbomberb boss is perfect! (Alpha blended zoomed) as well as S1945II logo */
+/* Note that Level 5-4 of sbomberb boss is perfect! (Alpha blended zoomed) as
+   well as S1945II logo */
 /* pixel is only plotted if z is >= priority_buffer[y][x] */
-void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangle &clip, gfx_element *gfx,
+void psikyosh_state::drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangle &clip, gfx_element *gfx,
 		u32 const code, u16 const color, u8 const flipx, u8 const flipy, s32 const offsx, s32 const offsy,
 		s16 const alpha, u32 const zoomx, u32 const zoomy, u8 const wide, u8 const high, u16 const z)
 {
@@ -462,8 +370,8 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 			{
 				for (int xtile = xstart; xtile != xend; xtile += xinc)
 				{
-					const pen_t *pal = &m_palette->pen(gfx->colorbase() + gfx->granularity() * (color % gfx->colors()));
-					const u8 *code_base = gfx->get_data((code + code_offset++) % gfx->elements());
+					pen_t const *pal = &m_palette->pen(gfx->colorbase() + gfx->granularity() * (color % gfx->colors()));
+					u8 const *code_base = gfx->get_data((code + code_offset++) % gfx->elements());
 
 					int x_index_base, y_index;
 
@@ -484,27 +392,27 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 					if (sx < myclip.left())
 					{
 						// clip left
-						const int pixels = myclip.left() - sx;
+						int const pixels = myclip.left() - sx;
 						sx += pixels;
 						x_index_base += xinc * pixels;
 					}
 					if (sy < myclip.top())
 					{
 						// clip top
-						const int pixels = myclip.top() - sy;
+						int const pixels = myclip.top() - sy;
 						sy += pixels;
 						y_index += yinc * pixels;
 					}
 					if (ex > myclip.right() + 1)
 					{
 						// clip right
-						const int pixels = ex - myclip.right() - 1;
+						int const pixels = ex - myclip.right() - 1;
 						ex -= pixels;
 					}
 					if (ey > myclip.bottom() + 1)
 					{
 						// clip bottom
-						const int pixels = ey - myclip.bottom() - 1;
+						int const pixels = ey - myclip.bottom() - 1;
 						ey -= pixels;
 					}
 
@@ -516,11 +424,11 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 						{
 							if (z > 0)
 							{
-								const u8 *source = code_base + (y_index) * gfx->rowbytes() + x_index_base;
+								u8 const *source = code_base + (y_index) * gfx->rowbytes() + x_index_base;
 								u32 *dest = &dest_bmp.pix(sy, sx);
 								u16 *pri = &m_z_bitmap.pix(sy, sx);
-								const int src_modulo = yinc * gfx->rowbytes() - xinc * (ex - sx);
-								const int dst_modulo = dest_bmp.rowpixels() - (ex - sx);
+								int const src_modulo = yinc * gfx->rowbytes() - xinc * (ex - sx);
+								int const dst_modulo = dest_bmp.rowpixels() - (ex - sx);
 
 								for (int y = sy; y < ey; y++)
 								{
@@ -538,10 +446,10 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 							}
 							else
 							{
-								const u8 *source = code_base + y_index * gfx->rowbytes() + x_index_base;
+								u8 const *source = code_base + y_index * gfx->rowbytes() + x_index_base;
 								u32 *dest = &dest_bmp.pix(sy, sx);
-								const int src_modulo = yinc * gfx->rowbytes() - xinc * (ex - sx);
-								const int dst_modulo = dest_bmp.rowpixels() - (ex - sx);
+								int const src_modulo = yinc * gfx->rowbytes() - xinc * (ex - sx);
+								int const dst_modulo = dest_bmp.rowpixels() - (ex - sx);
 
 								for (int y = sy; y < ey; y++)
 								{
@@ -562,11 +470,11 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 						{
 							if (z > 0)
 							{
-								const u8 *source = code_base + y_index * gfx->rowbytes() + x_index_base;
+								u8 const *source = code_base + y_index * gfx->rowbytes() + x_index_base;
 								u32 *dest = &dest_bmp.pix(sy, sx);
 								u16 *pri = &m_z_bitmap.pix(sy, sx);
-								const int src_modulo = yinc * gfx->rowbytes() - xinc * (ex - sx);
-								const int dst_modulo = dest_bmp.rowpixels() - (ex - sx);
+								int const src_modulo = yinc * gfx->rowbytes() - xinc * (ex - sx);
+								int const dst_modulo = dest_bmp.rowpixels() - (ex - sx);
 
 								for (int y = sy; y < ey; y++)
 								{
@@ -584,10 +492,10 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 							}
 							else
 							{
-								const u8 *source = code_base + y_index * gfx->rowbytes() + x_index_base;
+								u8 const *source = code_base + y_index * gfx->rowbytes() + x_index_base;
 								u32 *dest = &dest_bmp.pix(sy, sx);
-								const int src_modulo = yinc * gfx->rowbytes() - xinc * (ex - sx);
-								const int dst_modulo = dest_bmp.rowpixels() - (ex - sx);
+								int const src_modulo = yinc * gfx->rowbytes() - xinc * (ex - sx);
+								int const dst_modulo = dest_bmp.rowpixels() - (ex - sx);
 
 								for (int y = sy; y < ey; y++)
 								{
@@ -608,11 +516,11 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 						{
 							if (z > 0)
 							{
-								const u8 *source = code_base + y_index * gfx->rowbytes() + x_index_base;
+								u8 const *source = code_base + y_index * gfx->rowbytes() + x_index_base;
 								u32 *dest = &dest_bmp.pix(sy, sx);
 								u16 *pri = &m_z_bitmap.pix(sy, sx);
-								const int src_modulo = yinc * gfx->rowbytes() - xinc * (ex - sx);
-								const int dst_modulo = dest_bmp.rowpixels() - (ex - sx);
+								int const src_modulo = yinc * gfx->rowbytes() - xinc * (ex - sx);
+								int const dst_modulo = dest_bmp.rowpixels() - (ex - sx);
 
 								for (int y = sy; y < ey; y++)
 								{
@@ -630,10 +538,10 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 							}
 							else
 							{
-								const u8 *source = code_base + y_index * gfx->rowbytes() + x_index_base;
+								u8 const *source = code_base + y_index * gfx->rowbytes() + x_index_base;
 								u32 *dest = &dest_bmp.pix(sy, sx);
-								const int src_modulo = yinc * gfx->rowbytes() - xinc * (ex - sx);
-								const int dst_modulo = dest_bmp.rowpixels() - (ex - sx);
+								int const src_modulo = yinc * gfx->rowbytes() - xinc * (ex - sx);
+								int const dst_modulo = dest_bmp.rowpixels() - (ex - sx);
 
 								for (int y = sy; y < ey; y++)
 								{
@@ -662,15 +570,15 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 		{
 			for (int xtile = 0; xtile < wide; xtile++)
 			{
-				const u8 *code_base = gfx->get_data((code + code_offset++) % gfx->elements());
+				u8 const *code_base = gfx->get_data((code + code_offset++) % gfx->elements());
 				for (int ypixel = 0; ypixel < gfx->height(); ypixel++)
 				{
-					const u8 *source = code_base + ypixel * gfx->rowbytes();
-					u8 *dest = &m_zoom_bitmap.pix(ypixel + ytile*gfx->height());
+					u8 const *source = code_base + ypixel * gfx->rowbytes();
+					u8 *dest = &m_zoom_bitmap.pix(ypixel + ytile * gfx->height());
 
 					for (int xpixel = 0; xpixel < gfx->width(); xpixel++)
 					{
-						dest[xpixel + xtile*gfx->width()] = source[xpixel];
+						dest[xpixel + xtile * gfx->width()] = source[xpixel];
 					}
 				}
 			}
@@ -679,10 +587,10 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 		// Start drawing
 		if (gfx)
 		{
-			const pen_t *pal = &m_palette->pen(gfx->colorbase() + gfx->granularity() * (color % gfx->colors()));
+			pen_t const *pal = &m_palette->pen(gfx->colorbase() + gfx->granularity() * (color % gfx->colors()));
 
-			const int sprite_screen_height = ((high * gfx->height() * (0x400 * 0x400)) / zoomy + 0x200) >> 10; /* Round up to nearest pixel */
-			const int sprite_screen_width = ((wide * gfx->width() * (0x400 * 0x400)) / zoomx + 0x200) >> 10;
+			int const sprite_screen_height = ((high * gfx->height() * (0x400 * 0x400)) / zoomy + 0x200) >> 10; /* Round up to nearest pixel */
+			int const sprite_screen_width = ((wide * gfx->width() * (0x400 * 0x400)) / zoomx + 0x200) >> 10;
 
 			if (sprite_screen_width && sprite_screen_height)
 			{
@@ -708,27 +616,27 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 				if (sx < myclip.left())
 				{
 					// clip left
-					const int pixels = myclip.left() - sx;
+					int const pixels = myclip.left() - sx;
 					sx += pixels;
 					x_index_base += pixels * dx;
 				}
 				if (sy < myclip.top())
 				{
 					// clip top
-					const int pixels = myclip.top() - sy;
+					int const pixels = myclip.top() - sy;
 					sy += pixels;
 					y_index += pixels * dy;
 				}
 				if (ex > myclip.right() + 1)
 				{
 					// clip right
-					const int pixels = ex-myclip.right() - 1;
+					int const pixels = ex-myclip.right() - 1;
 					ex -= pixels;
 				}
 				if (ey > myclip.bottom() + 1)
 				{
 					// clip bottom
-					const int pixels = ey-myclip.bottom() - 1;
+					int const pixels = ey-myclip.bottom() - 1;
 					ey -= pixels;
 				}
 
@@ -743,7 +651,7 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 						{
 							for (int y = sy; y < ey; y++)
 							{
-								const u8 *source = &m_zoom_bitmap.pix(y_index >> 10);
+								u8 const *source = &m_zoom_bitmap.pix(y_index >> 10);
 								u32 *dest = &dest_bmp.pix(y);
 								u16 *pri = &m_z_bitmap.pix(y);
 
@@ -761,7 +669,7 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 						{
 							for (int y = sy; y < ey; y++)
 							{
-								const u8 *source = &m_zoom_bitmap.pix(y_index >> 10);
+								u8 const *source = &m_zoom_bitmap.pix(y_index >> 10);
 								u32 *dest = &dest_bmp.pix(y);
 
 								int x_index = x_index_base;
@@ -783,7 +691,7 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 						{
 							for (int y = sy; y < ey; y++)
 							{
-								const u8 *source = &m_zoom_bitmap.pix(y_index >> 10);
+								u8 const *source = &m_zoom_bitmap.pix(y_index >> 10);
 								u32 *dest = &dest_bmp.pix(y);
 								u16 *pri = &m_z_bitmap.pix(y);
 
@@ -801,7 +709,7 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 						{
 							for (int y = sy; y < ey; y++)
 							{
-								const u8 *source = &m_zoom_bitmap.pix(y_index >> 10);
+								u8 const *source = &m_zoom_bitmap.pix(y_index >> 10);
 								u32 *dest = &dest_bmp.pix(y);
 
 								int x_index = x_index_base;
@@ -823,7 +731,7 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 						{
 							for (int y = sy; y < ey; y++)
 							{
-								const u8 *source = &m_zoom_bitmap.pix(y_index >> 10);
+								u8 const *source = &m_zoom_bitmap.pix(y_index >> 10);
 								u32 *dest = &dest_bmp.pix(y);
 								u16 *pri = &m_z_bitmap.pix(y);
 
@@ -841,7 +749,7 @@ void psikyosh_state::psikyosh_drawgfxzoom(bitmap_rgb32 &dest_bmp, const rectangl
 						{
 							for (int y = sy; y < ey; y++)
 							{
-								const u8 *source = &m_zoom_bitmap.pix(y_index >> 10);
+								u8 const *source = &m_zoom_bitmap.pix(y_index >> 10);
 								u32 *dest = &dest_bmp.pix(y);
 
 								int x_index = x_index_base;
@@ -866,8 +774,10 @@ void psikyosh_state::get_sprites()
 {
 	/*- Sprite Format 0x0000 - 0x37ff -**
 
-	0 ---- --yy yyyy yyyy | ---- --xx xxxx xxxx  1  F-?? hhhh ZZZZ ZZZZ | f-PP wwww zzzz zzzz
-	2 pppp pppp -aaa -nnn | nnnn nnnn nnnn nnnn  3  ---- ---- ---- ---- | ---- ---- ---- ----
+	0 ---- --yy yyyy yyyy | ---- --xx xxxx xxxx
+	1 F-?? hhhh ZZZZ ZZZZ | f-PP wwww zzzz zzzz
+	2 pppp pppp -aaa -nnn | nnnn nnnn nnnn nnnn
+	3 ---- ---- ---- ---- | ---- ---- ---- ----
 
 	y = ypos
 	x = xpos
@@ -885,10 +795,12 @@ void psikyosh_state::get_sprites()
 
 	p = palette
 
-	a = alpha blending, selects which of the 8 alpha values in vid_regs[0-1] to use
+	a = alpha blending, selects which of the 8 alpha values in vid_regs[0-1] to
+	    use
 
 	P = priority
-	Points to a 4-bit entry in vid_regs[2] which provides a priority comparable with the bg layer's priorities.
+	Points to a 4-bit entry in vid_regs[2] which provides a priority comparable
+	with the bg layer's priorities.
 	However, sprite-sprite priority needs to be preserved.
 	daraku and soldivid only use the lsb
 
@@ -905,43 +817,40 @@ void psikyosh_state::get_sprites()
 	while (listcntr < listlen)
 	{
 		u16 const listdat = list[listcntr];
-		u16 const sprnum = (listdat & 0x03ff) * 4;
+		u16 const sprnum = (listdat & 0x03ff) << 2;
 
-		s32 ypos = (m_spriteram[sprnum + 0] & 0x03ff0000) >> 16;
-		s32 xpos = (m_spriteram[sprnum + 0] & 0x000003ff) >> 00;
+		s32 const ypos = (m_spriteram[sprnum + 0] & 0x03ff0000) >> 16;
+		s32 const xpos = (m_spriteram[sprnum + 0] & 0x000003ff) >> 00;
 
-		if (ypos & 0x200) ypos -= 0x400;
-		if (xpos & 0x200) xpos -= 0x400;
-
-		sprite_ptr->ypos    = ypos;
-		sprite_ptr->xpos    = xpos;
+		sprite_ptr->ypos    = util::sext(ypos, 10);
+		sprite_ptr->xpos    = util::sext(xpos, 10);
 		sprite_ptr->high    = ((m_spriteram[sprnum + 1] & 0x0f000000) >> 24) + 1;
 		sprite_ptr->wide    = ((m_spriteram[sprnum + 1] & 0x00000f00) >> 8) + 1;
 
-		sprite_ptr->flpy    = (m_spriteram[sprnum + 1] & 0x80000000) >> 31;
+		sprite_ptr->flpy    = BIT(m_spriteram[sprnum + 1], 31) >> 31;
 		sprite_ptr->spr_pri = (m_spriteram[sprnum + 1] & 0x30000000) >> 28;
-		sprite_ptr->flpx    = (m_spriteram[sprnum + 1] & 0x00008000) >> 15;
+		sprite_ptr->flpx    = BIT(m_spriteram[sprnum + 1], 15) >> 15;
 		sprite_ptr->bg_pri  = (m_spriteram[sprnum + 1] & 0x00003000) >> 12;
 
 		sprite_ptr->zoomy   = (m_spriteram[sprnum + 1] & 0x00ff0000) >> 16;
 		sprite_ptr->zoomx   = (m_spriteram[sprnum + 1] & 0x000000ff) >> 00;
 
 		sprite_ptr->tnum    = (m_spriteram[sprnum + 2] & 0x0007ffff) >> 00;
-		sprite_ptr->dpth    = (m_spriteram[sprnum + 2] & 0x00800000) >> 23;
-		sprite_ptr->colr    = (m_spriteram[sprnum + 2] & 0xff000000) >> 24;
-
 		sprite_ptr->alpha   = (m_spriteram[sprnum + 2] & 0x00700000) >> 20;
+		sprite_ptr->dpth    = BIT(m_spriteram[sprnum + 2], 23);
+		sprite_ptr->colr    = (m_spriteram[sprnum + 2] & 0xff000000) >> 24;
 
 		sprite_ptr++;
 		listcntr++;
-		if (listdat & 0x4000) break;
+		if (BIT(listdat, 14))
+			break;
 	}
 	m_sprite_end = sprite_ptr;
 }
 
 void psikyosh_state::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect, u8 const req_pri)
 {
-	const input_code spr_keys[8] = {KEYCODE_Y, KEYCODE_U, KEYCODE_I, KEYCODE_O};
+	input_code const spr_keys[8] = {KEYCODE_Y, KEYCODE_U, KEYCODE_I, KEYCODE_O};
 	bool spr_debug = false;
 #ifdef DEBUG_KEYS
 	for (int i = 0; i <= 3; i++)
@@ -964,32 +873,34 @@ void psikyosh_state::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprec
 		// sprite vs backgrounds pri
 		if (bg_pri == req_pri)
 		{
-			u32 const zoomy   = zoom_table[sprite_ptr->zoomy];
-			u32 const zoomx   = zoom_table[sprite_ptr->zoomx];
-			s16 alpha         = sprite_ptr->alpha;
+			u32 const zoomy = zoom_table[sprite_ptr->zoomy];
+			u32 const zoomx = zoom_table[sprite_ptr->zoomx];
 
-			bool const alphamap = BIT(alpha_table[alpha], 7);
-			alpha = alpha_table[alpha] & 0x3f;
-
-			gfx_element *const gfx = sprite_ptr->dpth ? m_gfxdecode->gfx(1) : m_gfxdecode->gfx(0);
-
-			if (alphamap) /* alpha values are per-pen */
-				alpha = -1;
-			else
-				alpha = pal6bit(0x3f - alpha); /* 0x3f-0x00 maps to 0x00-0xff */
-
-			if (!spr_debug || machine().input().code_pressed(spr_keys[sprite_ptr->spr_pri]))
+			/* Avoid division-by-zero when table contains 0 (Uninitialised/Bug) */
+			if (zoomy && zoomx) 
 			{
-				/* start drawing */
-				if (zoomy && zoomx) /* Avoid division-by-zero when table contains 0 (Uninitialised/Bug) */
+				s16 alpha = sprite_ptr->alpha;
+
+				bool const alphamap = BIT(alpha_table[alpha], 7);
+				alpha = alpha_table[alpha] & 0x3f;
+
+				gfx_element *const gfx = m_gfxdecode->gfx(sprite_ptr->dpth ? 1 : 0);
+
+				if (alphamap) /* alpha values are per-pen */
+					alpha = -1;
+				else
+					alpha = pal6bit(0x3f - alpha); /* 0x3f-0x00 maps to 0x00-0xff */
+
+				if (!spr_debug || machine().input().code_pressed(spr_keys[sprite_ptr->spr_pri]))
 				{
-					psikyosh_drawgfxzoom(bitmap, cliprect, gfx,
+					/* start drawing */
+					drawgfxzoom(bitmap, cliprect, gfx,
 										sprite_ptr->tnum, sprite_ptr->colr,
 										sprite_ptr->flpx, sprite_ptr->flpy,
 										sprite_ptr->xpos, sprite_ptr->ypos, alpha,
 										zoomx, zoomy, sprite_ptr->wide, sprite_ptr->high, i);
+					/* end drawing */
 				}
-				/* end drawing */
 			}
 		}
 		i++;
@@ -999,19 +910,27 @@ void psikyosh_state::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprec
 
 void psikyosh_state::prelineblend(bitmap_rgb32 &bitmap, const rectangle &cliprect )
 {
+	assert(bitmap.bpp() == 32);
+
 	/* There are 224 values for pre-lineblending. Using one for every row currently */
 	/* I suspect that it should be blended against black by the amount specified as
 	   gnbarich sets the 0x000000ff to 0x7f in test mode whilst the others use 0x80.
 	   tgm2 sets it to 0x00 on warning screen. Likely has no effect. */
-	u8 const bank = (m_vidregs[7] & 0xff000000) >> 24; /* bank is always 8 (0x4000) except for daraku/soldivid */
-	u32 const *linefill = &m_spriteram[(bank * 0x800) / 4]; /* Per row */
+	/* bank is always 8 (0x4000) except for daraku/soldivid */
+	u8 const bank = (m_vidregs[7] & 0xff000000) >> 24; 
+	if (bank > 0x1f) // avoid possible oob access
+	{
+		bitmap.fill(m_palette->black_pen(), cliprect);
+		return;
+	}
 
-	assert(bitmap.bpp() == 32);
+	/* Per row */
+	u32 const *linefill = &m_spriteram[(bank * 0x800) / 4]; 
 
 	auto profile8 = g_profiler.start(PROFILER_USER8);
 	for (int y = cliprect.top(); y <= cliprect.bottom(); y++)
 	{
-		u32 *dstline = &bitmap.pix(y);
+		u32 *const dstline = &bitmap.pix(y);
 
 		/* linefill[y] & 0xff does what? */
 		for (int x = cliprect.left(); x <= cliprect.right(); x++)
@@ -1022,29 +941,35 @@ void psikyosh_state::prelineblend(bitmap_rgb32 &bitmap, const rectangle &cliprec
 
 void psikyosh_state::postlineblend(bitmap_rgb32 &bitmap, const rectangle &cliprect, u8 const req_pri)
 {
-	/* There are 224 values for post-lineblending. Using one for every row currently */
-	u8 const bank  = (m_vidregs[7] & 0xff000000) >> 24; /* bank is always 8 (i.e. 0x4000) except for daraku/soldivid */
-	u32 const *lineblend = &m_spriteram[(bank * 0x800) / 4 + 0x400 / 4]; /* Per row */
-
 	assert(bitmap.bpp() == 32);
 
 	if ((m_vidregs[2] & 0xf) != req_pri)
 		return;
 
+	/* There are 224 values for post-lineblending. Using one for every row currently */
+	/* bank is always 8 (i.e. 0x4000) except for daraku/soldivid */
+	u8 const bank  = (m_vidregs[7] & 0xff000000) >> 24;
+	if (bank > 0x1f) // avoid possible oob access
+		return;
+
+	/* Per row */
+	u32 const *lineblend = &m_spriteram[(bank * 0x800) / 4 + 0x400 / 4];
+
 	auto profile8 = g_profiler.start(PROFILER_USER8);
 	for (int y = cliprect.top(); y <= cliprect.bottom(); y++)
 	{
-		u32 *dstline = &bitmap.pix(y);
+		u32 *const dstline = &bitmap.pix(y);
+		u32 const color = lineblend[y];
 
-		if (lineblend[y] & 0x80) /* solid */
+		if (BIT(color, 7)) /* solid */
 		{
 			for (int x = cliprect.left(); x <= cliprect.right(); x++)
-				dstline[x] = lineblend[y] >> 8;
+				dstline[x] = color >> 8;
 		}
-		else if (lineblend[y] & 0x7f) /* blended */
+		else if (color & 0x7f) /* blended */
 		{
 			for (int x = cliprect.left(); x <= cliprect.right(); x++)
-				dstline[x] = alpha_blend_r32(dstline[x], lineblend[y] >> 8, 2 * (lineblend[y] & 0x7f));
+				dstline[x] = alpha_blend_r32(dstline[x], color >> 8, (color & 0x7f) << 1);
 		}
 	}
 }
@@ -1055,21 +980,36 @@ void psikyosh_state::video_start()
 	m_spritelist = std::make_unique<struct sprite_t []>(0x800/2);
 	m_sprite_end = m_spritelist.get();
 
-	m_screen->register_screen_bitmap(m_z_bitmap); /* z-buffer */
+	for (int i = 0; i < 32; i++)
+	{
+		tilemap_info &tmap = m_tilemap[i];
+
+		tmap.tmap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(psikyosh_state::get_tile_info<0>)), TILEMAP_SCAN_ROWS, 16,16, 32,16);
+		tmap.tmap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(psikyosh_state::get_tile_info<1>)), TILEMAP_SCAN_ROWS, 16,16, 32,16);
+
+		for (int j = 0; j < 2; j++)
+		{
+			tmap.tmap[j]->set_user_data(&m_tilemap[i]);
+			tmap.tmap[j]->set_transparent_pen(0);
+		}
+
+		tmap.vram_base = i << 9;
+	}
+
+	m_z_bitmap.allocate(1024, 1024); /* z-buffer */
 	m_zoom_bitmap.allocate(16*16, 16*16); /* temp buffer for assembling sprites */
-	m_bg_bitmap.allocate(32*16, 32*16); /* temp buffer for assembling tilemaps */
 	m_bg_zoom = std::make_unique<u16[]>(256);
 	m_alphatable = std::make_unique<u8[]>(256);
 
-	m_gfxdecode->gfx(1)->set_granularity(16); /* 256 colour sprites with palette selectable on 16 colour boundaries */
+	/* 256 colour sprites with palette selectable on 16 colour boundaries */
+	m_gfxdecode->gfx(1)->set_granularity(16); 
 
 	/* Pens 0xc0-0xff have a gradient of alpha values associated with them */
-	int i;
-	for (i = 0; i < 0xc0; i++)
+	for (int i = 0; i < 0xc0; i++)
 	{
 		m_alphatable[i] = 0xff;
 	}
-	for (i = 0; i < 0x40; i++)
+	for (int i = 0; i < 0x40; i++)
 	{
 		int const alpha = pal6bit(0x3f - i);
 		m_alphatable[i + 0xc0] = alpha;
@@ -1077,29 +1017,26 @@ void psikyosh_state::video_start()
 
 	/* precompute the background zoom table. verified against hardware.
 	   unsure of the precision, we use .10 fixed point like the sprites */
-	for (i = 0; i < 0x100; i++)
+	for (int i = 0; i < 0x100; i++)
 	{
 		m_bg_zoom[i] = (64 * 0x400) / (i + 64);
 	}
 
 	save_item(NAME(m_z_bitmap));
 	save_item(NAME(m_zoom_bitmap));
-	save_item(NAME(m_bg_bitmap));
 	save_pointer(NAME(m_bg_zoom), 256);
 }
 
 
 u32 psikyosh_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)/* Note the z-buffer on each sprite to get correct priority */
 {
-	int i;
-
 	// show only the priority associated with a given keypress(s) and/or hide sprites/tilemaps
-	int pri_debug = false;
-	int sprites = true;
-	int backgrounds = true;
-	const input_code pri_keys[8] = {KEYCODE_Z, KEYCODE_X, KEYCODE_C, KEYCODE_V, KEYCODE_B, KEYCODE_N, KEYCODE_M, KEYCODE_K};
+	bool pri_debug = false;
+	bool sprites = true;
+	bool backgrounds = true;
+	input_code const pri_keys[8] = {KEYCODE_Z, KEYCODE_X, KEYCODE_C, KEYCODE_V, KEYCODE_B, KEYCODE_N, KEYCODE_M, KEYCODE_K};
 #ifdef DEBUG_KEYS
-	for (i = 0; i <= 7; i++)
+	for (int i = 0; i <= 7; i++)
 	{
 		if (machine().input().code_pressed(pri_keys[i]))
 			pri_debug = true;
@@ -1124,17 +1061,19 @@ popmessage   ("%08x %08x %08x %08x\n%08x %08x %08x %08x",
 	m_z_bitmap.fill(0, cliprect); /* z-buffer */
 
 	prelineblend(bitmap, cliprect); // fills screen
-	for (i = 0; i <= 7; i++)
+	for (int i = 0; i <= 7; i++)
 	{
 		if (!pri_debug || machine().input().code_pressed(pri_keys[i]))
 		{
+			// When same priority bg's have higher pri
 			if (sprites)
-				draw_sprites(bitmap, cliprect, i); // When same priority bg's have higher pri
+				draw_sprites(bitmap, cliprect, i);
 
 			if (backgrounds)
 				draw_background(bitmap, cliprect, i);
 
-			postlineblend(bitmap, cliprect, i); // assume this has highest priority at same priority level
+			// assume this has highest priority at same priority level
+			postlineblend(bitmap, cliprect, i); 
 		}
 	}
 	return 0;

--- a/src/mame/psikyo/psikyosh_v.cpp
+++ b/src/mame/psikyo/psikyosh_v.cpp
@@ -204,12 +204,12 @@ TILE_GET_INFO_MEMBER(psikyosh_state::get_tile_info)
 	tilemap_info *const layer = (tilemap_info *)tilemap.user_data();
 	u32 const data = m_spriteram[layer->vram_base + tile_index];
 	u32 const tileno = data & 0x0007ffff;
-	u32 const colour = (data & 0xff000000) >> 24;
+	u32 const color  = (data & 0xff000000) >> 24;
 
-	tileinfo.set(Depth, tileno, colour & 0xf0, 0);
+	tileinfo.set(Depth, tileno, color & 0xf0, 0);
 	// store low 4 bit of color in category and mix later
 	// for keep per-pixel alpha blend information
-	tileinfo.category = colour & 0x0f;
+	tileinfo.category = color & 0x0f;
 }
 
 /* Row Scroll/Zoom and/or Column Zoom, has per-column Alpha/Bank/Priority
@@ -1001,7 +1001,7 @@ void psikyosh_state::video_start()
 	m_bg_zoom = std::make_unique<u16[]>(256);
 	m_alphatable = std::make_unique<u8[]>(256);
 
-	/* 256 colour sprites with palette selectable on 16 colour boundaries */
+	/* 256 color sprites with palette selectable on 16 color boundaries */
 	m_gfxdecode->gfx(1)->set_granularity(16); 
 
 	/* Pens 0xc0-0xff have a gradient of alpha values associated with them */


### PR DESCRIPTION
- Reduce duplicates
- Make tilemap function into use tilemap.h
- Remove unnecessary functions
- Minor optimizations
- Add/Fix notes
- Fix namings
- Reduce literal tag usages
- Make some variables constant
- Use BIT helper for single bit values
- Fix typenames
- Reduce preprocessor defines