### PR TITLE
dvmemory: display 7-bit ASCII

### DIFF
--- a/src/emu/debug/dvmemory.cpp
+++ b/src/emu/debug/dvmemory.cpp
@@ -27,8 +27,9 @@ namespace {
 
 constexpr u8 sanitise_character(u8 ch)
 {
-	// assume ISO-8859-1 (low 256 Unicode codepoints) - tab, soft hyphen, C0 and C1 cause problems
-	return ('\t' == ch) ? ' ' : (0xadU == ch) ? '-' : ((' ' > ch) || (('~' < ch) && (0xa0U > ch))) ? '.' : ch;
+	// reduce to printable 7-bit ASCII
+	ch &= 0x7f;
+	return ((' ' > ch) || ('~' < ch)) ? '.' : ch;
 }
 
 } // anonymous namespace


### PR DESCRIPTION
(for your consideration...)

394e5f1 changed the debugger memory view to use ISO-8869-1 encoding.
This makes it difficult to debug machines which commonly set the high bit in strings.
This PR uses the lowest-common-denominator of printable 7-bit ASCII.

0.287 before this PR:
<img width="1214" height="1006" alt="debugger_ASCII_287_before" src="https://github.com/user-attachments/assets/8ff25552-27ef-42d8-9890-c8a70298708a" />

After this PR:
<img width="1214" height="1006" alt="debugger_ASCII_287_after" src="https://github.com/user-attachments/assets/f03d4487-b434-417a-a246-cf7fb8ad1be9" />

...and the old `isprint()` behavior prior to 394e5f1, circa 0.241:
<img width="1214" height="1006" alt="debugger_ASCII_241_isprint" src="https://github.com/user-attachments/assets/3dd60aa2-91a5-44d3-9e51-0c8c3019382d" />

The printf %c and %s formatter behavior is left unchanged.

