### PR TITLE
sound/cem3340.cpp: Anti-aliasing. Streaming frequency and PW control.

### DIFF
--- a/src/devices/sound/cem3340.cpp
+++ b/src/devices/sound/cem3340.cpp
@@ -24,7 +24,9 @@ constexpr float PW_MAX = VCC / 3.0F;
 // See "supplies" section in the datasheet. The minimum for both triangle and
 // ramp is always 0.
 constexpr float TRIANGLE_MAX = VCC / 3.0F;
+constexpr float TRIANGLE_MIN = 0.0F;
 constexpr float RAMP_MAX = 2.0F * VCC / 3.0F;
+constexpr float RAMP_MIN = 0.0F;
 
 // Computing the exact PULSE max is somewhat involved, and depends on both:
 // the pulldown resistor at the PULSE output, and the pulldown voltage (see
@@ -49,7 +51,8 @@ cem3340_device::cem3340_device(const machine_config &mconfig, const char *tag, d
 	, m_freq(10.0F)
 	, m_pw_cv(-1)
 	, m_pw(0.5F)
-	, m_ramp(0.0F)
+	, m_step(0.0F)
+	, m_phase(0.0F)
 {
 }
 
@@ -58,12 +61,10 @@ cem3340_device::cem3340_device(const machine_config &mconfig, const char *tag, d
 {
 }
 
-cem3340_device &cem3340_device::set_freq_cc(float freq_cc)
+void cem3340_device::set_freq_cc_internal(float freq_cc)
 {
 	if (freq_cc == m_freq_cc)
-		return *this;
-	if (m_stream)
-		m_stream->update();
+		return;
 
 	// Equations shown and/or described in the datasheet.
 	const float iom = (22.0F * VT / RT) * (1.0F - freq_cc * RZ / 3.0F);  // Output current of the multiplier.
@@ -71,8 +72,26 @@ cem3340_device &cem3340_device::set_freq_cc(float freq_cc)
 	const float iref = VCC / m_rr;  // Reference input current at pin 13.
 	const float ieg = iref * expf(-vb / VT);  // Output current of the exponential converter.
 	m_freq = 3.0F * ieg / (2.0F * VCC * m_cf);  // Oscillation frequency.
-
+	m_step = m_freq / float(m_stream->sample_rate());
 	m_freq_cc = freq_cc;
+}
+
+void cem3340_device::set_pw_cv_internal(float pw_cv)
+{
+	if (pw_cv == m_pw_cv)
+		return;
+	m_pw = std::clamp(pw_cv, 0.0F, PW_MAX) / PW_MAX;
+	m_pw_cv = pw_cv;
+}
+
+cem3340_device &cem3340_device::set_freq_cc(float freq_cc)
+{
+	if (!m_stream)  // Need to know the sample rate.
+		fatalerror("%s: set_freq_cc() cannot be called before device_start().\n", tag());
+	if (freq_cc == m_freq_cc)
+		return *this;
+	m_stream->update();
+	set_freq_cc_internal(freq_cc);
 	return *this;
 }
 
@@ -82,44 +101,149 @@ cem3340_device &cem3340_device::set_pw_cv(float pw_cv)
 		return *this;
 	if (m_stream)
 		m_stream->update();
-	m_pw = std::clamp(pw_cv, 0.0F, PW_MAX) / PW_MAX;
-	m_pw_cv = pw_cv;
+	set_pw_cv_internal(pw_cv);
 	return *this;
+}
+
+float cem3340_device::get_freq()
+{
+	if (BIT(get_sound_requested_inputs_mask(), INPUT_FREQ))
+		m_stream->update();
+	return m_freq;
 }
 
 void cem3340_device::device_start()
 {
-	m_stream = stream_alloc(0, 3, machine().sample_rate());
+	m_stream = stream_alloc(get_sound_requested_inputs(), get_sound_requested_outputs(), machine().sample_rate());
 	save_item(NAME(m_freq_cc));
 	save_item(NAME(m_freq));
 	save_item(NAME(m_pw_cv));
 	save_item(NAME(m_pw));
-	save_item(NAME(m_ramp));
+	save_item(NAME(m_step));
+	save_item(NAME(m_phase));
+}
+
+// Implementation is based on:
+// https://www.martin-finke.de/articles/audio-plugins-018-polyblep-oscillator/
+float cem3340_device::poly_blep(float phase) const
+{
+	float val = 0;
+	if (phase < m_step)
+	{
+		const float t = phase / m_step;
+		val = t + t - t * t - 1.0F;
+	}
+	else if (phase > 1.0F - m_step)
+	{
+		const float t = (phase - 1.0F) / m_step;
+		val = t + t + t * t + 1.0F;
+	}
+	return val;
+}
+
+// Implementation is based on:
+// https://dsp.stackexchange.com/questions/54790/polyblamp-anti-aliasing-in-c
+float cem3340_device::poly_blamp(float phase) const
+{
+	float y = 0.0F;
+	if (0.0F <= phase && phase < 2.0F * m_step)
+	{
+		const float x = phase / m_step;
+		const float u = 2.0F - x;
+		const float u2 = u * u;
+		y -= u * u2 * u2;
+		if (phase < m_step)
+		{
+			const float v = 1.0F - x;
+			const float v2 = v * v;
+			y += 4.0F * v * v2 * v2;
+		}
+	}
+	return y * m_step / 15.0F;
+}
+
+// Converts from [-1, 1] to [min_value, max_value]
+static inline float transform(float x, float min_value, float max_value)
+{
+	return (max_value - min_value) * (x + 1.0F) / 2.0F + min_value;
+}
+
+// A faster way to do fmod(x, 1.0F). At the time of this writing, the "-bench"
+// speed on the prophet5 (11 CEM3340s) improves from ~1480% to ~1680% when
+// switching from fmodf(x, 1.0F) to fmodf1(x).
+static inline float fmodf1(float x)
+{
+	// No need to worry about a negative `x` in this application.
+	if (x >= 1.0F)
+		x -= floorf(x);
+	return x;
 }
 
 void cem3340_device::sound_stream_update(sound_stream &stream)
 {
-	const float step = m_freq / float(m_stream->sample_rate());
+	const bool streaming_freq = BIT(get_sound_requested_inputs_mask(), INPUT_FREQ);
+	const bool streaming_pw = BIT(get_sound_requested_inputs_mask(), INPUT_PW);
+
+	const bool tri_out = BIT(get_sound_requested_outputs_mask(), OUTPUT_TRIANGLE);
+	const bool ramp_out = BIT(get_sound_requested_outputs_mask(), OUTPUT_RAMP);
+	const bool pulse_out = BIT(get_sound_requested_outputs_mask(), OUTPUT_PULSE);
+
 	const int n = stream.samples();
 
 	for (int i = 0; i < n; ++i)
 	{
-		m_ramp += step;
-		if (m_ramp >= 1.0F)
-			m_ramp -= floorf(m_ramp);
+		if (streaming_freq)
+			set_freq_cc_internal(stream.get(INPUT_FREQ, i));
+		if (streaming_pw)
+			set_pw_cv_internal(stream.get(INPUT_PW, i));
 
-		float triangle = m_ramp;
-		if (triangle > 0.5F)
-			triangle = 1.0F - m_ramp;
-		triangle *= 2;  // Convert range to [0, 1].
+		// Uses the PolyBLEP (for ramp and pulse) and PolyBLAMP (for triangle)
+		// algorithms to generate anti-aliased waveforms. Those algorithms start
+		// with the "naive" versions of the waveforms, and then apply
+		// corrections at waveform discontinuities.
+		// See references in poly_blep() and poly_blamp().
 
-		stream.put(OUTPUT_TRIANGLE, i, TRIANGLE_MAX * triangle);
-		stream.put(OUTPUT_RAMP, i, RAMP_MAX * m_ramp);
+		// Needed for both the ramp and triangle waveforms.
+		const float naive_ramp = 2.0F * m_phase - 1.0F;  // [-1, 1]
 
-		// The pulse waveform is generated by a comparator on the ramp waveform,
-		// wired such that it goes high when the PW CV is larger than the
-		// (scaled) ramp waveform.
-		stream.put(OUTPUT_PULSE, i, m_ramp < m_pw ? PULSE_MAX : PULSE_MIN);
+		if (ramp_out)
+		{
+			const float ramp = naive_ramp - poly_blep(m_phase);
+			stream.put(OUTPUT_RAMP, i, transform(ramp, RAMP_MIN, RAMP_MAX));
+		}
+
+		if (pulse_out)
+		{
+			// The pulse waveform is generated by a comparator on the ramp
+			// waveform, wired such that it goes high when the PW CV is larger
+			// than the (scaled) ramp waveform.
+			float pulse = (m_phase < m_pw) ? 1.0F : -1.0F;
+			pulse += poly_blep(m_phase);
+			pulse -= poly_blep(fmodf1(m_phase + (1.0F - m_pw)));
+			stream.put(OUTPUT_PULSE, i, transform(pulse, PULSE_MIN, PULSE_MAX));
+		}
+
+		if (tri_out)
+		{
+			// See reference in poly_blamp(). Note that the signs of the
+			// corrections below are opposite of those in the reference, because
+			// the triangle wave in the reference is inverted.
+
+			float triangle = 1.0F - 2.0F * fabsf(naive_ramp);
+
+			// Correction at the bottom corner of the triangle.
+			triangle -= poly_blamp(m_phase);
+			triangle -= poly_blamp(1.0F - m_phase);
+
+			// Correction at the top corner of the triangle.
+			const float peak_phase = fmodf1(m_phase + 0.5F);
+			triangle += poly_blamp(peak_phase);
+			triangle += poly_blamp(1.0F - peak_phase);
+
+			stream.put(OUTPUT_TRIANGLE, i, transform(triangle, TRIANGLE_MIN, TRIANGLE_MAX));
+		}
+
+		m_phase = fmodf1(m_phase + m_step);
 	}
 }
 

--- a/src/devices/sound/cem3340.h
+++ b/src/devices/sound/cem3340.h
@@ -11,13 +11,19 @@ DECLARE_DEVICE_TYPE(CEM3340, cem3340_device)
 // A CEM3340 voltage-controlled oscillator.
 //
 // TODO:
-// - Band limiting.
-// - Streaming frequency and pulse width control.
-// - Hard and soft sync.
+// - Hard and soft sync inputs.
+// - Linear FM input.
+// - High frequency tracking input.
 // - Hardcoded a lot of external components to the recommended values.
 class cem3340_device : public device_t, public device_sound_interface
 {
 public:
+	enum input
+	{
+		INPUT_FREQ = 0,
+		INPUT_PW
+	};
+
 	enum output
 	{
 		OUTPUT_TRIANGLE = 0,
@@ -33,13 +39,19 @@ public:
 	cem3340_device &set_freq_cc(float freq_cc);  // Frequency control current.
 	cem3340_device &set_pw_cv(float pw_cv);  // Pulse width control voltage.
 
-	float get_freq() const { return m_freq; }
+	float get_freq();
 
 protected:
 	void device_start() override ATTR_COLD;
 	void sound_stream_update(sound_stream &stream) override;
 
 private:
+	void set_freq_cc_internal(float freq_cc);
+	void set_pw_cv_internal(float pw_cv);
+
+	float poly_blep(float phase) const;
+	float poly_blamp(float phase) const;
+
 	// configuration
 	const float m_cf;
 	const float m_rr;
@@ -50,7 +62,8 @@ private:
 	float m_freq;
 	float m_pw_cv;
 	float m_pw;
-	float m_ramp;
+	float m_step;
+	float m_phase;  // 0-1
 };
 
 #endif  // MAME_SOUND_CEM3340_H


### PR DESCRIPTION
* Used the *PolyBLEP* algorithm for the ramp and pulse waves.
* Used the *PolyBLAMP* algorithm for the triangle wave.
* Made waveform outputs conditional on the output actually being connected.
* Added support for streaming control of the frequency control current and pulse width control voltage.

Effects of anti-aliasing:
![comparison](https://github.com/m1macrophage/synthesizerstate/blob/main/cem3340/cem3340_aa.png?raw=true)

* From top to bottom: ramp, pulse and triangle waveforms.
* Each spectogram shows a sequence of notes, increasing by 1 octave per step.
* *Before* (left column): the ramp and pulse waveforms suffered from significant aliasing. Aliasing on the triangle wave was only noticeable at high frequencies.
* *After* (right column): Significant reduction in aliasing on all waveforms. The ramp and pulse spectra look much cleaner, and the triangle is missing some of the "stray" harmonics in the top octaves.

