### PR TITLE
apple2video: fix -ramsize crash

### DIFF
--- a/src/mame/apple/apple2.cpp
+++ b/src/mame/apple/apple2.cpp
@@ -315,7 +315,8 @@ void apple2_state::machine_start()
 	save_item(NAME(m_reset_latch));
 
 	// setup video pointers
-	m_video->set_ram_pointers(m_ram_ptr, m_ram_ptr);
+	m_video->set_ram_pointers(m_ram_ptr, nullptr);
+	m_video->set_ram_masks(m_ram_size-1, 0);
 	m_video->set_char_pointer(memregion("gfx1")->base(), memregion("gfx1")->bytes());
 }
 

--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -990,7 +990,7 @@ void apple2e_state::machine_start()
 
 	// setup video pointers
 	m_video->set_ram_pointers(m_ram_ptr, m_aux_ptr);
-	m_video->set_aux_mask(m_aux_mask);
+	m_video->set_ram_masks(0xffff, m_aux_mask);
 	m_video->set_char_pointer(memregion("gfx1")->base(), memregion("gfx1")->bytes());
 
 	// IOU events occur at the rightmost edge of active video

--- a/src/mame/apple/apple2video.cpp
+++ b/src/mame/apple/apple2video.cpp
@@ -833,19 +833,34 @@ void a2_video_device::hgr_update(screen_device &screen, bitmap_ind16 &bitmap, co
 	for (int row = beginrow; row <= endrow; row++)
 	{
 		unsigned const address = start_address + (((row/8) & 0x07) << 7) + (((row/8) & 0x18) * 5) + ((row & 7) << 10);
-		uint8_t const *const vram_row = &m_ram_ptr[address];
-
-		uint16_t words[40];
-
-		unsigned last_output_bit = 0;
-
-		for (int col = std::max(0, startcol-1); col < std::min(stopcol+1, 40); col++)
+		static const uint16_t empty_words[40] =
 		{
-			unsigned word = double_7_bits[vram_row[col] & 0x7f];
-			if (vram_row[col] & bit7_mask)
-				word = (word * 2 + last_output_bit) & 0x3fff;
-			words[col] = word;
-			last_output_bit = word >> 13;
+			// empty RAM socket causes TTL input to float high
+			0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff,
+			0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff,
+			0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff,
+			0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff,
+			0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff, 0x3fff
+		};
+		uint16_t ram_words[40];
+		uint16_t *words;
+
+		if (address > m_ram_mask)
+			words = (uint16_t *)empty_words;
+		else
+		{
+			uint8_t const *const vram_row = &m_ram_ptr[address];
+			unsigned last_output_bit = 0;
+			words = ram_words;
+
+			for (int col = std::max(0, startcol-1); col < std::min(stopcol+1, 40); col++)
+			{
+				unsigned word = double_7_bits[vram_row[col] & 0x7f];
+				if (vram_row[col] & bit7_mask)
+					word = (word * 2 + last_output_bit) & 0x3fff;
+				words[col] = word;
+				last_output_bit = word >> 13;
+			}
 		}
 
 		if (rgb_monitor())

--- a/src/mame/apple/apple2video.h
+++ b/src/mame/apple/apple2video.h
@@ -67,7 +67,7 @@ public:
 
 	void set_base_model(model base_model)       { m_base_model = base_model; }
 	void set_ram_pointers(u8 *main, u8 *aux)    { m_ram_ptr = main; m_aux_ptr = aux; }
-	void set_aux_mask(u16 aux_mask)             { m_aux_mask = aux_mask; }
+	void set_ram_masks(u16 ram_mask, u16 aux_mask) { m_ram_mask = ram_mask; m_aux_mask = aux_mask; }
 	void set_hgr2(u16 hgr2)                     { m_hgr2 = hgr2; }
 	void set_char_pointer(u8 *charptr, int size) { m_char_ptr = charptr; m_char_size = size; }
 	void setup_GS_graphics() { m_8bit_graphics = std::make_unique<bitmap_ind16>(560, 192); }
@@ -120,7 +120,7 @@ private:
 	int monochrome_hue();
 
 	u8 *m_ram_ptr = nullptr, *m_aux_ptr = nullptr, *m_char_ptr = nullptr;
-	u16 m_aux_mask = 0xffff;
+	u16 m_ram_mask = 0xffff, m_aux_mask = 0xffff;
 	u16 m_hgr2 = 0x4000;
 	int m_char_size = 0;
 	bool m_page2 = false;

--- a/src/mame/apple/superga2.cpp
+++ b/src/mame/apple/superga2.cpp
@@ -100,7 +100,7 @@ void superga2_state::machine_start()
 	save_item(NAME(m_speaker_state));
 
 	// setup video pointers
-	m_video->set_ram_pointers(m_ram_ptr, m_ram_ptr);
+	m_video->set_ram_pointers(m_ram_ptr, nullptr);
 	m_video->set_char_pointer(nullptr, 0);  // no text modes on this machine
 }
 

--- a/src/mame/apple/tk2000.cpp
+++ b/src/mame/apple/tk2000.cpp
@@ -150,7 +150,7 @@ void tk2000_state::machine_start()
 	save_item(NAME(m_ctrl_key));
 
 	// setup video pointers
-	m_video->set_ram_pointers(m_ram_ptr, m_ram_ptr);
+	m_video->set_ram_pointers(m_ram_ptr, nullptr);
 	m_video->set_char_pointer(nullptr, 0);  // no text modes on this machine
 	m_video->set_hgr2(0xa000);
 }


### PR DESCRIPTION
([another](https://github.com/mamedev/mame/pull/15252) config-specific crash)

This PR fixes apple2 and apple2p crashing with low-memory `-ramsize` configs

To reproduce:
1. `mame apple2p -ramsize 16k` <no disk>
2. Ctrl-Reset to prompt
3. HGR2

or
1. `mame apple2 -ramsize 12k` <no disk>
2. 2000<E000.FFFFM N C053:0 N C057:0 N C050:0

Result: OOB access, UB (MAME might crash, or show random garbage on screen.)
On my system a crash in a release build is rare without libgmalloc.
A debug ASAN build (`ARCHOPTS="-fsanitize=address"`) shows the problem immediately:
[apple2_12k_HGR_asan.txt](https://github.com/user-attachments/files/27143247/apple2_12k_HGR_asan.txt)


Expected Result:
The first apple2p case should show the screen entirely white.
The second apple2 case should show the screen as alternating rows of colored static (copied from E000) and white (only half of the HGR RAM is installed):
<img width="560" height="384" alt="apple2_12k_HGR" src="https://github.com/user-attachments/assets/32091827-fa3e-437d-8f22-1dbbed11ecc1" />

[Hardware testing](https://apple2infinitum.slack.com/archives/CPS2TG28L/p1777228620951269) (thanks to @whscullin and Tom Greene) shows that empty RAM sockets read as 0xFF both from the CPU and the video scanner (probably because unconnected TTL inputs float high, similar to C06x gameio.)
<br>
Code comments:<details>

I made `a2_video_device::hgr_update()` check for HGR addresses exceeding the machine's `ram_size`, mirroring the logic in `apple2_state::ram_r()`.  This adds a usually-not-taken branch to every HGR line, for all machines.  An alternate implementation would be to pad apple2's `m_ram` allocation up to at least 24k, and then one-time-init any excess over the requested `-ramsize` to 0xFF.  That would be zero overhead in `a2_video_device`, but maybe more obfuscated, re-interpreting `m_ram_size` around a re-alloc.

MAME currently doesn't support the [non-contiguous 12K](https://apple2history.org/dl/Apple_II_Redbook.pdf#page=142) "HIRES" memory configuration.  To support that, range comparisons would need to change to something like a 4K page bitmap mask.
</details>
