### PR TITLE
machine/cxd1185.cpp: Ensure appropriate SCSI ID register is mapped

### DIFF
--- a/src/devices/machine/cxd1185.cpp
+++ b/src/devices/machine/cxd1185.cpp
@@ -59,7 +59,7 @@ void cxd1185_device::map(address_map &map)
 	map(0x3, 0x3).rw(FUNC(cxd1185_device::int_req_r<1>), FUNC(cxd1185_device::environ_w));
 	map(0x4, 0x4).rw(FUNC(cxd1185_device::scsi_ctrl_monitor_r), FUNC(cxd1185_device::timer_w));
 	map(0x5, 0x5).r(FUNC(cxd1185_device::fifo_status_r));
-	map(0x6, 0x6).rw(FUNC(cxd1185_device::scsi_id_r), FUNC(cxd1185_device::scsi_id_w));
+	map(0x6, 0x6).rw(FUNC(cxd1185_device::scsi_idr_r), FUNC(cxd1185_device::scsi_idr_w));
 	map(0x7, 0x7).rw(FUNC(cxd1185_device::count_r<0>), FUNC(cxd1185_device::count_w<0>));
 	map(0x8, 0x8).rw(FUNC(cxd1185_device::count_r<1>), FUNC(cxd1185_device::count_w<1>));
 	map(0x9, 0x9).rw(FUNC(cxd1185_device::count_r<2>), FUNC(cxd1185_device::count_w<2>));

--- a/src/devices/machine/cxd1185.h
+++ b/src/devices/machine/cxd1185.h
@@ -41,7 +41,7 @@ protected:
 	template <unsigned Register> u8 int_req_r();
 	u8 scsi_ctrl_monitor_r();
 	u8 fifo_status_r();
-	u8 scsi_id_r() { return m_scsi_id; }
+	u8 scsi_idr_r() { return m_scsi_idr; }
 	template <unsigned Byte> u8 count_r() { return u8(m_count >> (Byte * 8)); }
 	template <unsigned Register> u8 int_auth_r() { return m_int_auth[Register]; }
 	u8 mode_r() { return m_mode; }
@@ -53,7 +53,7 @@ protected:
 	void scsi_data_w(u8 data);
 	void environ_w(u8 data);
 	void timer_w(u8 data);
-	void scsi_id_w(u8 data) { m_scsi_id = data; }
+	void scsi_idr_w(u8 data) { m_scsi_idr = data; }
 	template <unsigned Byte> void count_w(u8 data) { m_count &= ~(0xffU << (Byte * 8)); m_count |= u32(data) << (Byte * 8); }
 	template <unsigned Register> void int_auth_w(u8 data);
 	void mode_w(u8 data) { m_mode = data; }


### PR DESCRIPTION
When the save states were fixed, this mapping was not updated as well, which causes machines that use the CXD1185 to always target ID 0. This commit fixes that by updating the mapping to use the ID register rather than the ID inherited from its superclass.