### PR TITLE
Fix mem-mem MOV on i8089

### DIFF
--- a/src/devices/cpu/i8089/i8089_channel.cpp
+++ b/src/devices/cpu/i8089/i8089_channel.cpp
@@ -540,6 +540,8 @@ int i8089_channel_device::execute_run()
 			uint16_t op2 = m_iop->read_word(m_r[TP].t, m_r[TP].w);
 			set_reg(TP, m_r[TP].w + 2);
 			int mm2 = (op2 >> 8) & 0x03;
+			// fix-up the second half of the instruction
+			if (mm2 == BC) mm2 = PP;
 
 			if (w) mov_mm(mm, mm2, o, offset((op2 >> 1) & 0x03, mm2, w));
 			else   movb_mm(mm, mm2, o, offset((op2 >> 1) & 0x03, mm2, w));


### PR DESCRIPTION
The base register for memory operations was being fixed up to handle the PP register. But memory-to-memory MOVs act like two instructions, and the second half was being decoded ad-hoc without that fixup. This adds that fixup to the second half.