### PR TITLE
playmark/playmark.cpp, playmark/powerbal.cpp, playmark/sderby.cpp: Updates

### DIFF
--- a/src/mame/playmark/playmark.cpp
+++ b/src/mame/playmark/playmark.cpp
@@ -93,7 +93,6 @@ TODO:
 #include "playmark.h"
 
 #include "cpu/m68000/m68000.h"
-#include "cpu/pic16c5x/pic16c5x.h"
 #include "machine/nvram.h"
 #include "screen.h"
 #include "speaker.h"
@@ -101,10 +100,10 @@ TODO:
 
 void playmark_state::coinctrl_w(u8 data)
 {
-	machine().bookkeeping().coin_counter_w(0, data & 0x01);
-	machine().bookkeeping().coin_counter_w(1, data & 0x02);
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 0));
+	machine().bookkeeping().coin_counter_w(1, BIT(data, 1));
 	if (data & 0xfc)
-		logerror("Writing %04x to unknown coin control bits\n", data);
+		logerror("%s: Writing %04x to unknown coin control bits\n", machine().describe_context(), data);
 }
 
 
@@ -114,84 +113,88 @@ void playmark_state::coinctrl_w(u8 data)
 
 ***************************************************************************/
 
-void playmark_state::wbeachvl_coin_eeprom_w(u8 data)
+void wbeachvl_state::coin_eeprom_w(u8 data)
 {
 	// bits 0-3 are coin counters? (only 0 used?)
-	machine().bookkeeping().coin_counter_w(0, data & 0x01);
-	machine().bookkeeping().coin_counter_w(1, data & 0x02);
-	machine().bookkeeping().coin_counter_w(2, data & 0x04);
-	machine().bookkeeping().coin_counter_w(3, data & 0x08);
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 0));
+	machine().bookkeeping().coin_counter_w(1, BIT(data, 1));
+	machine().bookkeeping().coin_counter_w(2, BIT(data, 2));
+	machine().bookkeeping().coin_counter_w(3, BIT(data, 3));
 
 	// bits 5-7 control EEPROM
-	m_eeprom->cs_write((data & 0x20) ? ASSERT_LINE : CLEAR_LINE);
-	m_eeprom->di_write((data & 0x80) >> 7);
-	m_eeprom->clk_write((data & 0x40) ? CLEAR_LINE : ASSERT_LINE);
+	m_eeprom->cs_write(BIT(data, 5) ? ASSERT_LINE : CLEAR_LINE);
+	m_eeprom->di_write(BIT(data, 7));
+	m_eeprom->clk_write(BIT(data, 6) ? CLEAR_LINE : ASSERT_LINE);
 }
 
 void playmark_state::hotmind_coin_eeprom_w(u8 data)
 {
-//  if (data & 0x80) logerror("PC$%06x Writing unknown bits %02x to the Coin/EEPROM port\n", m_maincpu->pcbase(), data);
+//  if (data & 0x80) logerror("%s: Writing unknown bits %02x to the Coin/EEPROM port\n", machine().describe_context(), data);
 
 	luckboomh_dispenser_w(data);
 
-	m_eeprom->cs_write((data & 1) ? ASSERT_LINE : CLEAR_LINE);
-	m_eeprom->di_write((data & 4) >> 2);
-	m_eeprom->clk_write((data & 2) ? ASSERT_LINE : CLEAR_LINE );
+	m_eeprom->cs_write(BIT(data, 0) ? ASSERT_LINE : CLEAR_LINE);
+	m_eeprom->di_write(BIT(data, 2));
+	m_eeprom->clk_write(BIT(data, 1) ? ASSERT_LINE : CLEAR_LINE);
 }
 
 void playmark_state::luckboomh_dispenser_w(u8 data)
 {
-//  if (data & 0x87) logerror("PC$%06x Writing unknown bits %02x to the Coin/EEPROM port\n", m_maincpu->pcbase(), data);
+//  if (data & 0x87) logerror("%s: Writing unknown bits %02x to the Coin/EEPROM port\n", machine().describe_context(), data);
 
-	if (data) {
-		if ((m_dispenser_latch & 0x80) == 0) m_dispenser_latch = 0;
-		if (data & 0x10) {
+	if (data)
+	{
+		if (!BIT(m_dispenser_latch, 7))
+			m_dispenser_latch = 0;
+		if (BIT(data, 4))
+		{
 			m_dispenser_latch |= ((data & 0x10) | 0x80);
 			m_token->motor_w(1);
 		}
 	}
-	else {
+	else
+	{
 		m_dispenser_latch &= 0x7f;
 		m_token->motor_w(BIT(m_dispenser_latch, 4));
 	}
 	m_ticket->motor_w(BIT(data, 3));
 
-	machine().bookkeeping().coin_counter_w(0, data & 0x20);      // Coin In counter - transistor driven
-	machine().bookkeeping().coin_counter_w(1, data & 0x40);      // Token/Ticket Out counter - transistor driven
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 5));      // Coin In counter - transistor driven
+	machine().bookkeeping().coin_counter_w(1, BIT(data, 6));      // Token/Ticket Out counter - transistor driven
 }
 
-void playmark_state::playmark_snd_command_w(u8 data)
+void playmark_state::snd_command_w(u8 data)
 {
-//  logerror("PC$%06x 68K Writing sound command %02x to OKI\n",m_maincpu->pcbase(), data);
+//  logerror("%s: 68K Writing sound command %02x to OKI\n", machine().describe_context(), data);
 
-	m_snd_command = data;
-	m_snd_flag = 1;
+	m_soundlatch->write(data);
 	m_maincpu->yield();
 }
 
-u8 playmark_state::playmark_snd_command_r()
+u8 playmark_state::snd_command_r()
 {
-	int data = 0;
+	u8 data = 0;
 
 	if ((m_oki_control & 0x38) == 0x30)
 	{
-		data = m_snd_command;
-//      logerror("PC$%03x PortB reading %02x from the 68K\n", m_maincpu->pcbase(), data);
+		data = m_soundlatch->read();
+//      logerror("%s: PortB reading %02x from the 68K\n", machine().describe_context(), data);
 	}
 	else if ((m_oki_control & 0x38) == 0x28)
 	{
 		data = (m_oki->read() & 0x0f);
-//      logerror("PC$%03x PortB reading %02x from the OKI status port\n", m_maincpu->pcbase(), data);
+//      logerror("%s: PortB reading %02x from the OKI status port\n", machine().describe_context(), data);
 	}
 
 	return data;
 }
 
-u8 playmark_state::playmark_snd_flag_r()
+u8 playmark_state::snd_flag_r()
 {
-	if (m_snd_flag)
+	if (m_soundlatch->pending_r())
 	{
-		m_snd_flag = 0;
+		if (!machine().side_effects_disabled())
+			m_soundlatch->acknowledge_w();
 		return 0x00;
 	}
 
@@ -199,21 +202,22 @@ u8 playmark_state::playmark_snd_flag_r()
 }
 
 
-void playmark_state::playmark_oki_banking_w(u8 data)
+void playmark_state::oki_bank_w(u8 data)
 {
-	logerror("%s Writing %02x to PortA  (OKI bank select)\n",machine().describe_context(),data);
+	logerror("%s: Writing %02x to PortA  (OKI bank select)\n", machine().describe_context(), data);
 
-	int bank = data & 7;
+	const u8 bank = data & 7;
 
 	m_okibank->set_entry(bank & (m_oki_numbanks - 1));
 }
 
-void playmark_state::playmark_oki_w(u8 data)
+void playmark_state::oki_w(u8 data)
 {
 	m_oki_command = data;
 }
 
-void playmark_state::playmark_snd_control_w(u8 data)
+template <u8 BankMask>
+void playmark_state::snd_control_w(u8 data)
 {
 	/*  This port controls communications to and from the 68K and the OKI device.
 
@@ -223,80 +227,76 @@ void playmark_state::playmark_snd_control_w(u8 data)
 	    5w  Latch write data to OKI? (active low)
 	    4w  Activate read signal to OKI? (active low)
 	    3w  Set Port 1 to read sound to play command from 68K. (active low)
-	    2w  ???  (Read Port B)
-	    1   Not used
-	    0   Not used
+	    2w  ???  (Read Port B), or OKI bank bit 2 in some hardwares
+	    1   OKI bank bit 1 in some hardwares
+	    0   OKI bank bit 0 in some hardwares
 	*/
-	m_oki_control = data;
-
-	if ((data & 0x38) == 0x18)
+	if (BankMask)
 	{
-//      logerror("PC$%03x Writing %02x to OKI1, PortC=%02x, Code=%02x\n",m_maincpu->pcbase(),m_oki_command,m_oki_control,m_snd_command);
-		m_oki->write(m_oki_command);
+		const u8 bank = data & BankMask;
+		m_okibank->set_entry(bank & (m_oki_numbanks - 1));
 	}
-}
-
-void playmark_state::hrdtimes_snd_control_w(u8 data)
-{
-	//  This port controls communications to and from the 68K and the OKI device. See playmark_snd_control_w above. OKI banking is also handled here.
-
-	int bank = data & 3;
-	m_okibank->set_entry(bank & (m_oki_numbanks - 1));
 
 	m_oki_control = data;
 
 	if ((data & 0x38) == 0x18)
 	{
-//      logerror("PC$%03x Writing %02x to OKI1, PortC=%02x, Code=%02x\n",m_maincpu->pcbase(),m_oki_command,m_oki_control,m_snd_command);
+//      logerror("%s: Writing %02x to OKI1, PortC=%02x, Code=%02x\n", machine().describe_context(), m_oki_command, m_oki_control, m_soundlatch->read());
 		m_oki->write(m_oki_command);
 	}
 }
 
-uint8_t playmark_state::wbeachvla_snd_command_r() // TODO: convert the rest of the driver to use generic_latch_8_device and merge this with playmark_snd_command_r
+template <int WordPerTile>
+void playmark_state::txvideoram_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	uint8_t data = 0;
-
-	if ((m_oki_control & 0x38) == 0x30)
-		data = m_soundlatch->read();
-	else if ((m_oki_control & 0x38) == 0x28)
-		data = (m_oki->read() & 0x0f);
-
-	return data;
+	COMBINE_DATA(&m_txtvideoram[offset]);
+	if (WordPerTile > 1)
+		m_tx_tilemap->mark_tile_dirty(offset / WordPerTile);
+	else
+		m_tx_tilemap->mark_tile_dirty(offset);
 }
 
-void playmark_state::wbeachvla_snd_control_w(uint8_t data) // TODO: merge this with playmark_snd_control_w
+template <int WordPerTile>
+void playmark_state::fgvideoram_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	m_oki_control = data;
+	COMBINE_DATA(&m_fgvideoram[offset]);
+	if (WordPerTile > 1)
+		m_fg_tilemap->mark_tile_dirty(offset / WordPerTile);
+	else
+		m_fg_tilemap->mark_tile_dirty(offset);
+}
 
-	m_okibank->set_entry(data & 7);
-
-	if ((data & 0x38) == 0x18)
-	{
-		m_oki->write(m_oki_command);
-	}
+template <int WordPerTile>
+void playmark_state::bgvideoram_w(offs_t offset, u16 data, u16 mem_mask)
+{
+	COMBINE_DATA(&m_bgvideoram[offset]);
+	if (WordPerTile > 1)
+		m_bg_tilemap->mark_tile_dirty(offset / WordPerTile);
+	else
+		m_bg_tilemap->mark_tile_dirty(offset);
 }
 
 /***************************** 68000 Memory Maps ****************************/
 
-void playmark_state::bigtwin_main_map(address_map &map)
+void bigtwin_state::bigtwin_main_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();
 	map(0x304000, 0x304001).noprw();             // watchdog? irq ack?
-	map(0x440000, 0x4403ff).ram().share("spriteram");
-	map(0x500000, 0x500fff).w(FUNC(playmark_state::wbeachvl_fgvideoram_w)).share(m_fgvideoram);
+	map(0x440000, 0x4403ff).ram().share(m_spriteram);
+	map(0x500000, 0x500fff).w(FUNC(bigtwin_state::fgvideoram_w<2>)).share(m_fgvideoram);
 	map(0x501000, 0x501fff).nopw();    // unused RAM?
-	map(0x502000, 0x503fff).w(FUNC(playmark_state::wbeachvl_txvideoram_w)).share(m_txtvideoram);
+	map(0x502000, 0x503fff).w(FUNC(bigtwin_state::txvideoram_w<2>)).share(m_txtvideoram);
 	map(0x504000, 0x50ffff).nopw();    // unused RAM?
-	map(0x510000, 0x51000b).w(FUNC(playmark_state::bigtwin_scroll_w));
+	map(0x510000, 0x51000b).w(FUNC(bigtwin_state::bigtwin_scroll_w));
 	map(0x51000c, 0x51000d).nopw();    // always 3?
-	map(0x600000, 0x67ffff).ram().share(m_bgvideoram);
+	map(0x600000, 0x67ffff).ram().w(FUNC(bigtwin_state::bitmap_w)).share(m_bgvideoram);
 	map(0x700010, 0x700011).portr("SYSTEM");
 	map(0x700012, 0x700013).portr("P1");
 	map(0x700014, 0x700015).portr("P2");
-	map(0x700016, 0x700016).w(FUNC(playmark_state::coinctrl_w));
+	map(0x700016, 0x700016).w(FUNC(bigtwin_state::coinctrl_w));
 	map(0x70001a, 0x70001b).portr("DSW2");
 	map(0x70001c, 0x70001d).portr("DSW1");
-	map(0x70001f, 0x70001f).w(FUNC(playmark_state::playmark_snd_command_w));
+	map(0x70001f, 0x70001f).w(FUNC(bigtwin_state::snd_command_w));
 	map(0x780000, 0x7807ff).w(m_palette, FUNC(palette_device::write16)).share("palette");
 //  map(0xe00000, 0xe00001) ?? written on startup
 	map(0xff0000, 0xffffff).ram();
@@ -305,69 +305,69 @@ void playmark_state::bigtwin_main_map(address_map &map)
 void playmark_state::bigtwinb_main_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();
-	map(0x100000, 0x103fff).ram().w(FUNC(playmark_state::hrdtimes_bgvideoram_w)).share(m_bgvideoram);
-	map(0x104000, 0x107fff).ram().w(FUNC(playmark_state::hrdtimes_fgvideoram_w)).share(m_fgvideoram);
-	map(0x108000, 0x10ffff).ram().w(FUNC(playmark_state::hrdtimes_txvideoram_w)).share(m_txtvideoram);
+	map(0x100000, 0x103fff).ram().w(FUNC(playmark_state::bgvideoram_w<1>)).share(m_bgvideoram);
+	map(0x104000, 0x107fff).ram().w(FUNC(playmark_state::fgvideoram_w<1>)).share(m_fgvideoram);
+	map(0x108000, 0x10ffff).ram().w(FUNC(playmark_state::txvideoram_w<1>)).share(m_txtvideoram);
 	map(0x110000, 0x11000d).w(FUNC(playmark_state::hrdtimes_scroll_w));
-	map(0x201000, 0x2013ff).ram().share("spriteram");
+	map(0x201000, 0x2013ff).ram().share(m_spriteram);
 	map(0x280000, 0x2807ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x300010, 0x300011).portr("SYSTEM");
 	map(0x300012, 0x300013).portr("P1");
 	map(0x300014, 0x300015).portr("P2");
 	map(0x30001a, 0x30001b).portr("DSW2");
 	map(0x30001c, 0x30001d).portr("DSW1");
-	map(0x30001f, 0x30001f).w(FUNC(playmark_state::playmark_snd_command_w));
+	map(0x30001f, 0x30001f).w(FUNC(playmark_state::snd_command_w));
 	map(0x304000, 0x304001).nopw();        // watchdog? irq ack?
 	map(0xff0000, 0xffffff).ram();
 }
 
-void playmark_state::wbeachvl_main_map(address_map &map)
+void wbeachvl_state::wbeachvl_main_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
-	map(0x440000, 0x440fff).ram().share("spriteram");
-	map(0x500000, 0x501fff).ram().w(FUNC(playmark_state::wbeachvl_bgvideoram_w)).share(m_bgvideoram);
-	map(0x504000, 0x505fff).ram().w(FUNC(playmark_state::wbeachvl_fgvideoram_w)).share(m_fgvideoram);
-	map(0x508000, 0x509fff).ram().w(FUNC(playmark_state::wbeachvl_txvideoram_w)).share(m_txtvideoram);
+	map(0x440000, 0x440fff).ram().share(m_spriteram);
+	map(0x500000, 0x501fff).ram().w(FUNC(wbeachvl_state::bgvideoram_w<2>)).share(m_bgvideoram);
+	map(0x504000, 0x505fff).ram().w(FUNC(wbeachvl_state::fgvideoram_w<2>)).share(m_fgvideoram);
+	map(0x508000, 0x509fff).ram().w(FUNC(wbeachvl_state::txvideoram_w<2>)).share(m_txtvideoram);
 	map(0x50f000, 0x50ffff).ram().share(m_rowscroll);
-	map(0x510000, 0x51000b).w(FUNC(playmark_state::wbeachvl_scroll_w));
+	map(0x510000, 0x51000b).w(FUNC(wbeachvl_state::scroll_w));
 	map(0x51000c, 0x51000d).nopw();    // 2 and 3
 //  map(0x700000, 0x700001) ?? written on startup
 	map(0x710010, 0x710011).portr("SYSTEM");
 	map(0x710012, 0x710013).portr("P1");
 	map(0x710014, 0x710015).portr("P2");
-	map(0x710017, 0x710017).w(FUNC(playmark_state::wbeachvl_coin_eeprom_w));
+	map(0x710017, 0x710017).w(FUNC(wbeachvl_state::coin_eeprom_w));
 	map(0x710018, 0x710019).portr("P3");
 	map(0x71001a, 0x71001b).portr("P4");
-//  map(0x71001c, 0x71001d).r(FUNC(playmark_state::playmark_snd_status???));
-	map(0x71001f, 0x71001f).w(FUNC(playmark_state::playmark_snd_command_w));
+//  map(0x71001c, 0x71001d).r(FUNC(wbeachvl_state::playmark_snd_status???));
+	map(0x71001f, 0x71001f).w(FUNC(wbeachvl_state::snd_command_w));
 	map(0x780000, 0x780fff).w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0xff0000, 0xffffff).ram();
 }
 
-void playmark_state::wbeachvla_main_map(address_map &map)
+void wbeachvl_mcs_state::wbeachvla_main_map(address_map &map)
 {
 	wbeachvl_main_map(map);
 
 	map(0x71001f, 0x71001f).w(m_soundlatch, FUNC(generic_latch_8_device::write));
 }
 
-void playmark_state::excelsr_main_map(address_map &map)
+void bigtwin_state::excelsr_main_map(address_map &map)
 {
 	map(0x000000, 0x2fffff).rom();
 	map(0x304000, 0x304001).nopw();                // watchdog? irq ack?
-	map(0x440000, 0x440cff).ram().share("spriteram");
-	map(0x500000, 0x500fff).ram().w(FUNC(playmark_state::wbeachvl_fgvideoram_w)).share(m_fgvideoram);
-	map(0x501000, 0x501fff).ram().w(FUNC(playmark_state::wbeachvl_txvideoram_w)).share(m_txtvideoram);
-	map(0x510000, 0x51000b).w(FUNC(playmark_state::excelsr_scroll_w));
+	map(0x440000, 0x440cff).ram().share(m_spriteram);
+	map(0x500000, 0x500fff).ram().w(FUNC(bigtwin_state::fgvideoram_w<2>)).share(m_fgvideoram);
+	map(0x501000, 0x501fff).ram().w(FUNC(bigtwin_state::txvideoram_w<2>)).share(m_txtvideoram);
+	map(0x510000, 0x51000b).w(FUNC(bigtwin_state::excelsr_scroll_w));
 	map(0x51000c, 0x51000d).nopw();    // 2 and 3
-	map(0x600000, 0x67ffff).ram().share(m_bgvideoram);
+	map(0x600000, 0x67ffff).ram().w(FUNC(bigtwin_state::bitmap_w)).share(m_bgvideoram);
 	map(0x700010, 0x700011).portr("SYSTEM");
 	map(0x700012, 0x700013).portr("P1");
 	map(0x700014, 0x700015).portr("P2");
-	map(0x700016, 0x700016).w(FUNC(playmark_state::coinctrl_w));
+	map(0x700016, 0x700016).w(FUNC(bigtwin_state::coinctrl_w));
 	map(0x70001a, 0x70001b).portr("DSW2");
 	map(0x70001c, 0x70001d).portr("DSW1");
-	map(0x70001f, 0x70001f).w(FUNC(playmark_state::playmark_snd_command_w));
+	map(0x70001f, 0x70001f).w(FUNC(bigtwin_state::snd_command_w));
 	map(0x780000, 0x7807ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0xff0000, 0xffffff).ram();
 }
@@ -377,15 +377,15 @@ void playmark_state::hrdtimes_main_map(address_map &map)
 	map(0x000000, 0x07ffff).rom();
 	map(0x080000, 0x0bffff).ram();
 	map(0x0c0000, 0x0fffff).rom().region("maincpu", 0x0c0000);
-	map(0x100000, 0x1007ff).ram().w(FUNC(playmark_state::hrdtimes_bgvideoram_w)).share(m_bgvideoram); // 32*32?
+	map(0x100000, 0x1007ff).ram().w(FUNC(playmark_state::bgvideoram_w<1>)).share(m_bgvideoram); // 32*32?
 	map(0x100800, 0x103fff).ram();
-	map(0x104000, 0x105fff).ram().w(FUNC(playmark_state::hrdtimes_fgvideoram_w)).share(m_fgvideoram); // 128*32?
+	map(0x104000, 0x105fff).ram().w(FUNC(playmark_state::fgvideoram_w<1>)).share(m_fgvideoram); // 128*32?
 	map(0x106000, 0x107fff).ram();
-	map(0x108000, 0x109fff).ram().w(FUNC(playmark_state::hrdtimes_txvideoram_w)).share(m_txtvideoram); // 64*64?
+	map(0x108000, 0x109fff).ram().w(FUNC(playmark_state::txvideoram_w<1>)).share(m_txtvideoram); // 64*64?
 	map(0x10a000, 0x10bfff).ram();
 	map(0x10c000, 0x10ffff).ram(); // Unused
 	map(0x110000, 0x11000d).w(FUNC(playmark_state::hrdtimes_scroll_w));
-	map(0x200000, 0x200fff).ram().share("spriteram");
+	map(0x200000, 0x200fff).ram().share(m_spriteram);
 	map(0x280000, 0x2807ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x280800, 0x280fff).ram(); // Unused
 	map(0x300010, 0x300011).portr("SYSTEM");
@@ -394,18 +394,18 @@ void playmark_state::hrdtimes_main_map(address_map &map)
 	map(0x300017, 0x300017).w(FUNC(playmark_state::coinctrl_w));
 	map(0x30001a, 0x30001b).portr("DSW2");
 	map(0x30001c, 0x30001d).portr("DSW1");
-	map(0x30001f, 0x30001f).w(FUNC(playmark_state::playmark_snd_command_w));
+	map(0x30001f, 0x30001f).w(FUNC(playmark_state::snd_command_w));
 	map(0x304000, 0x304001).nopw();        // watchdog? irq ack?
 }
 
 void playmark_state::hotmind_main_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();
-	map(0x100000, 0x103fff).ram().w(FUNC(playmark_state::hrdtimes_bgvideoram_w)).share(m_bgvideoram);
-	map(0x104000, 0x107fff).ram().w(FUNC(playmark_state::hrdtimes_fgvideoram_w)).share(m_fgvideoram);
-	map(0x108000, 0x10ffff).ram().w(FUNC(playmark_state::hrdtimes_txvideoram_w)).share(m_txtvideoram);
+	map(0x100000, 0x103fff).ram().w(FUNC(playmark_state::bgvideoram_w<1>)).share(m_bgvideoram);
+	map(0x104000, 0x107fff).ram().w(FUNC(playmark_state::fgvideoram_w<1>)).share(m_fgvideoram);
+	map(0x108000, 0x10ffff).ram().w(FUNC(playmark_state::txvideoram_w<1>)).share(m_txtvideoram);
 	map(0x110000, 0x11000d).w(FUNC(playmark_state::hrdtimes_scroll_w));
-	map(0x200000, 0x200fff).ram().share("spriteram");
+	map(0x200000, 0x200fff).ram().share(m_spriteram);
 	map(0x280000, 0x2807ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x300010, 0x300011).portr("COINS");
 	map(0x300012, 0x300013).portr("P1");
@@ -413,7 +413,7 @@ void playmark_state::hotmind_main_map(address_map &map)
 	map(0x300015, 0x300015).w(FUNC(playmark_state::hotmind_coin_eeprom_w));
 	map(0x30001a, 0x30001b).portr("DSW2");
 	map(0x30001c, 0x30001d).portr("DSW1");
-	map(0x30001f, 0x30001f).w(FUNC(playmark_state::playmark_snd_command_w));
+	map(0x30001f, 0x30001f).w(FUNC(playmark_state::snd_command_w));
 	map(0x304000, 0x304001).nopw();        // watchdog? irq ack?
 	map(0xff0000, 0xffffff).ram();
 }
@@ -421,18 +421,18 @@ void playmark_state::hotmind_main_map(address_map &map)
 void playmark_state::luckboomh_main_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();
-	map(0x100000, 0x103fff).ram().w(FUNC(playmark_state::hrdtimes_bgvideoram_w)).share(m_bgvideoram);
-	map(0x104000, 0x107fff).ram().w(FUNC(playmark_state::hrdtimes_fgvideoram_w)).share(m_fgvideoram);
-	map(0x108000, 0x10ffff).ram().w(FUNC(playmark_state::hrdtimes_txvideoram_w)).share(m_txtvideoram);
+	map(0x100000, 0x103fff).ram().w(FUNC(playmark_state::bgvideoram_w<1>)).share(m_bgvideoram);
+	map(0x104000, 0x107fff).ram().w(FUNC(playmark_state::fgvideoram_w<1>)).share(m_fgvideoram);
+	map(0x108000, 0x10ffff).ram().w(FUNC(playmark_state::txvideoram_w<1>)).share(m_txtvideoram);
 	map(0x110000, 0x11000d).w(FUNC(playmark_state::hrdtimes_scroll_w));
-	map(0x200000, 0x200fff).ram().share("spriteram");
+	map(0x200000, 0x200fff).ram().share(m_spriteram);
 	map(0x280000, 0x2807ff).w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x300010, 0x300011).portr("COINS");
 	map(0x300012, 0x300013).portr("P1");
 	map(0x300014, 0x300015).portr("DISPENSER");
 	map(0x300015, 0x300015).w(FUNC(playmark_state::luckboomh_dispenser_w));
 	map(0x30001c, 0x30001d).portr("SERVICE");
-	map(0x30001f, 0x30001f).w(FUNC(playmark_state::playmark_snd_command_w));
+	map(0x30001f, 0x30001f).w(FUNC(playmark_state::snd_command_w));
 	map(0x304000, 0x304001).nopw();        // watchdog? irq ack?
 	map(0xff0000, 0xff03ff).ram().share("nvram");
 	map(0xff8000, 0xffffff).ram();
@@ -892,9 +892,9 @@ static const gfx_layout spritelayout =
 };
 
 static GFXDECODE_START( gfx_bigtwin )
-	GFXDECODE_ENTRY( "gfx2", 0, spritelayout, 0x200, 16 )   // colors 0x200-0x2ff
-	GFXDECODE_ENTRY( "gfx1", 0, tilelayout,   0x000,  8 )   // colors 0x000-0x07f
-	GFXDECODE_ENTRY( "gfx1", 0, charlayout,   0x080,  8 )   // colors 0x080-0x0ff
+	GFXDECODE_ENTRY( "sprites", 0, spritelayout, 0x200, 16 )   // colors 0x200-0x2ff
+	GFXDECODE_ENTRY( "tiles",   0, tilelayout,   0x000,  8 )   // colors 0x000-0x07f
+	GFXDECODE_ENTRY( "tiles",   0, charlayout,   0x080,  8 )   // colors 0x080-0x0ff
 	// background bitmap uses colors 0x100-0x1ff
 GFXDECODE_END
 
@@ -938,15 +938,15 @@ static const gfx_layout wspritelayout =
 };
 
 static GFXDECODE_START( gfx_wbeachvl )
-	GFXDECODE_ENTRY( "gfx1", 0, wspritelayout, 0x600, 16 )  // colors 0x600-0x7ff
-	GFXDECODE_ENTRY( "gfx1", 0, wtilelayout,   0x000, 16 )  // colors 0x000-0x3ff
-	GFXDECODE_ENTRY( "gfx1", 0, wcharlayout,   0x400,  8 )  // colors 0x400-0x5ff
+	GFXDECODE_ENTRY( "tiles", 0, wspritelayout, 0x600, 16 )  // colors 0x600-0x7ff
+	GFXDECODE_ENTRY( "tiles", 0, wtilelayout,   0x000, 16 )  // colors 0x000-0x3ff
+	GFXDECODE_ENTRY( "tiles", 0, wcharlayout,   0x400,  8 )  // colors 0x400-0x5ff
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_excelsr )
-	GFXDECODE_ENTRY( "gfx2", 0, tilelayout, 0x200, 16 ) // colors 0x200-0x2ff
-	GFXDECODE_ENTRY( "gfx1", 0, tilelayout, 0x000,  8 ) // colors 0x000-0x07f
-	GFXDECODE_ENTRY( "gfx1", 0, tilelayout, 0x080,  8 ) // colors 0x080-0x0ff
+	GFXDECODE_ENTRY( "sprites", 0, tilelayout, 0x200, 16 ) // colors 0x200-0x2ff
+	GFXDECODE_ENTRY( "tiles",   0, tilelayout, 0x000,  8 ) // colors 0x000-0x07f
+	GFXDECODE_ENTRY( "tiles",   0, tilelayout, 0x080,  8 ) // colors 0x080-0x0ff
 	// background bitmap uses colors 0x100-0x1ff
 GFXDECODE_END
 
@@ -1000,39 +1000,39 @@ static const gfx_layout hotmind_charlayout =
 
 
 static GFXDECODE_START( gfx_hrdtimes )
-	GFXDECODE_ENTRY( "gfx2", 0,       hrdtimes_full_layout, 0x200, 32 )    // colors 0x200-0x2ff - Sprites
-	GFXDECODE_ENTRY( "gfx1", 0,       hrdtimes_tilelayout,  0x000, 16 )    // colors 0x000-0x0ff - BG
-	GFXDECODE_ENTRY( "gfx1", 0x80000, hrdtimes_tilelayout,  0x000, 16 )    // colors 0x000-0x0ff - FG
-	GFXDECODE_ENTRY( "gfx1", 0xfc000, hrdtimes_charlayout,  0x100,  8 )    // colors 0x100-0x17f - Text
+	GFXDECODE_ENTRY( "sprites", 0,       hrdtimes_full_layout, 0x200, 32 )    // colors 0x200-0x2ff - Sprites
+	GFXDECODE_ENTRY( "tiles",   0,       hrdtimes_tilelayout,  0x000, 16 )    // colors 0x000-0x0ff - BG
+	GFXDECODE_ENTRY( "tiles",   0x80000, hrdtimes_tilelayout,  0x000, 16 )    // colors 0x000-0x0ff - FG
+	GFXDECODE_ENTRY( "tiles",   0xfc000, hrdtimes_charlayout,  0x100,  8 )    // colors 0x100-0x17f - Text
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_hotmind )
-	GFXDECODE_ENTRY( "gfx2", 0,       hrdtimes_full_layout, 0x200, 32 )    // colors 0x200-0x2ff
-	GFXDECODE_ENTRY( "gfx1", 0,       hrdtimes_tilelayout,  0x000, 16 )    // colors 0x000-0x0ff
-	GFXDECODE_ENTRY( "gfx1", 0x20000, hrdtimes_tilelayout,  0x000, 16 )    // colors 0x000-0x0ff
-	GFXDECODE_ENTRY( "gfx1", 0x30000, hotmind_charlayout,   0x100,  8 )    // colors 0x100-0x17f
+	GFXDECODE_ENTRY( "sprites", 0,       hrdtimes_full_layout, 0x200, 32 )    // colors 0x200-0x2ff
+	GFXDECODE_ENTRY( "tiles",   0,       hrdtimes_tilelayout,  0x000, 16 )    // colors 0x000-0x0ff
+	GFXDECODE_ENTRY( "tiles",   0x20000, hrdtimes_tilelayout,  0x000, 16 )    // colors 0x000-0x0ff
+	GFXDECODE_ENTRY( "tiles",   0x30000, hotmind_charlayout,   0x100,  8 )    // colors 0x100-0x17f
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_luckboomh )
-	GFXDECODE_ENTRY( "gfx2", 0,       hrdtimes_full_layout, 0x200, 32 )    // colors 0x200-0x2ff
-	GFXDECODE_ENTRY( "gfx1", 0,       hrdtimes_full_layout, 0x000, 16 )    // colors 0x000-0x0ff
-	GFXDECODE_ENTRY( "gfx1", 0,       hrdtimes_full_layout, 0x000, 16 )    // colors 0x000-0x0ff
-	GFXDECODE_ENTRY( "gfx1", 0x30000, hotmind_charlayout,   0x100,  8 )    // colors 0x100-0x17f
+	GFXDECODE_ENTRY( "sprites", 0,       hrdtimes_full_layout, 0x200, 32 )    // colors 0x200-0x2ff
+	GFXDECODE_ENTRY( "tiles",   0,       hrdtimes_full_layout, 0x000, 16 )    // colors 0x000-0x0ff
+	GFXDECODE_ENTRY( "tiles",   0,       hrdtimes_full_layout, 0x000, 16 )    // colors 0x000-0x0ff
+	GFXDECODE_ENTRY( "tiles",   0x30000, hotmind_charlayout,   0x100,  8 )    // colors 0x100-0x17f
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_bigtwinb )
-	GFXDECODE_ENTRY( "gfx2", 0,       spritelayout,        0x300, 16 )    // colors 0x300-0x3ff
-	GFXDECODE_ENTRY( "gfx1", 0,       hrdtimes_tilelayout, 0x000, 16 )    // colors 0x000-0x0ff
-	GFXDECODE_ENTRY( "gfx1", 0x40000, hrdtimes_tilelayout, 0x000, 16 )    // colors 0x000-0x0ff
-	GFXDECODE_ENTRY( "gfx1", 0x40000, hotmind_charlayout,  0x200, 16 )    // colors 0x200-0x2ff
+	GFXDECODE_ENTRY( "sprites", 0,       spritelayout,        0x300, 16 )    // colors 0x300-0x3ff
+	GFXDECODE_ENTRY( "tiles",   0,       hrdtimes_tilelayout, 0x000, 16 )    // colors 0x000-0x0ff
+	GFXDECODE_ENTRY( "tiles",   0x40000, hrdtimes_tilelayout, 0x000, 16 )    // colors 0x000-0x0ff
+	GFXDECODE_ENTRY( "tiles",   0x40000, hotmind_charlayout,  0x200, 16 )    // colors 0x200-0x2ff
 GFXDECODE_END
 
 void playmark_base_state::configure_oki_banks()
 {
 	if (m_okibank)
 	{
-		const u32 len    =   memregion("oki")->bytes();
-		u8 *rgn          =   memregion("oki")->base();
+		const u32 len = memregion("oki")->bytes();
+		u8 *rgn = memregion("oki")->base();
 
 		m_oki_numbanks = len / 0x20000;
 
@@ -1043,16 +1043,8 @@ void playmark_base_state::configure_oki_banks()
 
 void playmark_state::machine_start()
 {
-	save_item(NAME(m_bgscrollx));
-	save_item(NAME(m_bgscrolly));
-	save_item(NAME(m_bg_enable));
-	save_item(NAME(m_bg_full_size));
-	save_item(NAME(m_fgscrollx));
-	save_item(NAME(m_fg_rowscroll_enable));
 	save_item(NAME(m_scroll));
 
-	save_item(NAME(m_snd_command));
-	save_item(NAME(m_snd_flag));
 	save_item(NAME(m_oki_control));
 	save_item(NAME(m_oki_command));
 	save_item(NAME(m_dispenser_latch));
@@ -1060,38 +1052,47 @@ void playmark_state::machine_start()
 	configure_oki_banks();
 }
 
-
-
 void playmark_state::machine_reset()
 {
-	m_bgscrollx = 0;
-	m_bgscrolly = 0;
-	m_bg_enable = false;
-	m_bg_full_size = false;
-	m_fgscrollx = 0;
-	m_fg_rowscroll_enable = false;
 	memset(m_scroll, 0, sizeof(m_scroll));
 
-	m_snd_command = 0;
-	m_snd_flag = 0;
 	m_oki_control = 0;
 	m_oki_command = 0;
 	m_dispenser_latch = 0;
 }
 
-void playmark_state::bigtwin(machine_config &config)
+void bigtwin_state::machine_reset()
+{
+	playmark_state::machine_reset();
+	m_bgscrollx = 0;
+	m_bgscrolly = 0;
+	m_bg_enable = false;
+	m_bg_full_size = false;
+}
+
+void wbeachvl_state::machine_reset()
+{
+	playmark_state::machine_reset();
+	m_fgscrollx = 0;
+	m_fg_rowscroll_enable = false;
+}
+
+void bigtwin_state::bigtwin(machine_config &config)
 {
 	// basic machine hardware
 	M68000(config, m_maincpu, 12000000);   // 12 MHz
-	m_maincpu->set_addrmap(AS_PROGRAM, &playmark_state::bigtwin_main_map);
-	m_maincpu->set_vblank_int("screen", FUNC(playmark_state::irq2_line_hold));
+	m_maincpu->set_addrmap(AS_PROGRAM, &bigtwin_state::bigtwin_main_map);
+	m_maincpu->set_vblank_int("screen", FUNC(bigtwin_state::irq2_line_hold));
 
 	PIC16C57(config, m_audio_pic, 12000000);
-	m_audio_pic->write_a().set(FUNC(playmark_state::playmark_oki_banking_w));
-	m_audio_pic->read_b().set(FUNC(playmark_state::playmark_snd_command_r));
-	m_audio_pic->write_b().set(FUNC(playmark_state::playmark_oki_w));
-	m_audio_pic->read_c().set(FUNC(playmark_state::playmark_snd_flag_r));
-	m_audio_pic->write_c().set(FUNC(playmark_state::playmark_snd_control_w));
+	m_audio_pic->write_a().set(FUNC(bigtwin_state::oki_bank_w));
+	m_audio_pic->read_b().set(FUNC(bigtwin_state::snd_command_r));
+	m_audio_pic->write_b().set(FUNC(bigtwin_state::oki_w));
+	m_audio_pic->read_c().set(FUNC(bigtwin_state::snd_flag_r));
+	m_audio_pic->write_c().set(FUNC(bigtwin_state::snd_control_w<0>));
+
+	GENERIC_LATCH_8(config, m_soundlatch);
+	m_soundlatch->set_separate_acknowledge(true);
 
 	// video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
@@ -1099,20 +1100,20 @@ void playmark_state::bigtwin(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	screen.set_size(64*8, 64*8);
 	screen.set_visarea(0*8, 40*8-1, 2*8, 32*8-1);
-	screen.set_screen_update(FUNC(playmark_state::screen_update_bigtwin));
+	screen.set_screen_update(FUNC(bigtwin_state::screen_update_bigtwin));
 	screen.set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_bigtwin);
 	PALETTE(config, m_palette).set_format(palette_device::RRRRGGGGBBBBRGBx, 1024);
 
-	MCFG_VIDEO_START_OVERRIDE(playmark_state,bigtwin)
+	MCFG_VIDEO_START_OVERRIDE(bigtwin_state,bigtwin)
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	OKIM6295(config, m_oki, 1000000, okim6295_device::PIN7_HIGH);
 	m_oki->add_route(ALL_OUTPUTS, "mono", 1.0);
-	m_oki->set_addrmap(0, &playmark_state::oki_map);
+	m_oki->set_addrmap(0, &bigtwin_state::oki_map);
 }
 
 void playmark_state::bigtwinb(machine_config &config)
@@ -1123,11 +1124,14 @@ void playmark_state::bigtwinb(machine_config &config)
 	m_maincpu->set_vblank_int("screen", FUNC(playmark_state::irq2_line_hold));
 
 	PIC16C57(config, m_audio_pic, XTAL(24'000'000)/2);
-	m_audio_pic->write_a().set(FUNC(playmark_state::playmark_oki_banking_w));
-	m_audio_pic->read_b().set(FUNC(playmark_state::playmark_snd_command_r));
-	m_audio_pic->write_b().set(FUNC(playmark_state::playmark_oki_w));
-	m_audio_pic->read_c().set(FUNC(playmark_state::playmark_snd_flag_r));
-	m_audio_pic->write_c().set(FUNC(playmark_state::playmark_snd_control_w));
+	m_audio_pic->write_a().set(FUNC(playmark_state::oki_bank_w));
+	m_audio_pic->read_b().set(FUNC(playmark_state::snd_command_r));
+	m_audio_pic->write_b().set(FUNC(playmark_state::oki_w));
+	m_audio_pic->read_c().set(FUNC(playmark_state::snd_flag_r));
+	m_audio_pic->write_c().set(FUNC(playmark_state::snd_control_w<0>));
+
+	GENERIC_LATCH_8(config, m_soundlatch);
+	m_soundlatch->set_separate_acknowledge(true);
 
 	// video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
@@ -1151,12 +1155,12 @@ void playmark_state::bigtwinb(machine_config &config)
 	m_oki->set_addrmap(0, &playmark_state::oki_map);
 }
 
-void playmark_state::wbeachvl_base(machine_config &config)
+void wbeachvl_state::wbeachvl_base(machine_config &config)
 {
 	// basic machine hardware
 	M68000(config, m_maincpu, 12000000);   // 12 MHz
-	m_maincpu->set_addrmap(AS_PROGRAM, &playmark_state::wbeachvl_main_map);
-	m_maincpu->set_vblank_int("screen", FUNC(playmark_state::irq2_line_hold));
+	m_maincpu->set_addrmap(AS_PROGRAM, &wbeachvl_state::wbeachvl_main_map);
+	m_maincpu->set_vblank_int("screen", FUNC(wbeachvl_state::irq2_line_hold));
 
 	EEPROM_93C46_16BIT(config, "eeprom").default_value(0);
 
@@ -1166,46 +1170,47 @@ void playmark_state::wbeachvl_base(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	screen.set_size(64*8, 64*8);
 	screen.set_visarea(0*8, 40*8-1, 2*8, 32*8-1);
-	screen.set_screen_update(FUNC(playmark_state::screen_update_wbeachvl));
+	screen.set_screen_update(FUNC(wbeachvl_state::screen_update));
 	screen.set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_wbeachvl);
 	PALETTE(config, m_palette).set_format(palette_device::RGBx_555, 2048);
-
-	MCFG_VIDEO_START_OVERRIDE(playmark_state,wbeachvl)
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	OKIM6295(config, m_oki, 1000000, okim6295_device::PIN7_HIGH);
 	m_oki->add_route(ALL_OUTPUTS, "mono", 1.0);
-	m_oki->set_addrmap(0, &playmark_state::oki_map);
+	m_oki->set_addrmap(0, &wbeachvl_state::oki_map);
 }
 
-void playmark_state::wbeachvl_pic(machine_config &config)
+void wbeachvl_state::wbeachvl_pic(machine_config &config)
 {
 	wbeachvl_base(config);
 
 	PIC16C57(config, m_audio_pic, XTAL(24'000'000)/2);    // 12MHz with internal 4x divisor
-	m_audio_pic->write_a().set(FUNC(playmark_state::playmark_oki_banking_w)); // wrong?
-	m_audio_pic->read_b().set(FUNC(playmark_state::playmark_snd_command_r));
-	m_audio_pic->write_b().set(FUNC(playmark_state::playmark_oki_w));
-	m_audio_pic->read_c().set(FUNC(playmark_state::playmark_snd_flag_r));
-	m_audio_pic->write_c().set(FUNC(playmark_state::playmark_snd_control_w));
-//  m_audio_pic->write_c().set(FUNC(playmark_state::hrdtimes_snd_control_w)); // probably closer to this, but this only supports 2 sample bank bits
+	m_audio_pic->write_a().set(FUNC(wbeachvl_state::oki_bank_w)); // wrong?
+	m_audio_pic->read_b().set(FUNC(wbeachvl_state::snd_command_r));
+	m_audio_pic->write_b().set(FUNC(wbeachvl_state::oki_w));
+	m_audio_pic->read_c().set(FUNC(wbeachvl_state::snd_flag_r));
+	m_audio_pic->write_c().set(FUNC(wbeachvl_state::snd_control_w<0>));
+//  m_audio_pic->write_c().set(FUNC(wbeachvl_state::snd_control_w<0x3>)); // probably closer to this, but this only supports 2 sample bank bits
+
+	GENERIC_LATCH_8(config, m_soundlatch);
+	m_soundlatch->set_separate_acknowledge(true);
 }
 
-void playmark_state::wbeachvl_mcs(machine_config &config)
+void wbeachvl_mcs_state::wbeachvl_mcs(machine_config &config)
 {
 	wbeachvl_base(config);
 
-	m_maincpu->set_addrmap(AS_PROGRAM, &playmark_state::wbeachvla_main_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &wbeachvl_mcs_state::wbeachvla_main_map);
 
 	I87C51(config, m_audio_mcs, 24'000'000 / 2); // actually S87C751, clock unverified, near a 24 MHz XTAL
 	//m_audio_mcs->port_in_cb<1>().set(); // TODO: reads something here. pending_r?
-	m_audio_mcs->port_out_cb<1>().set(FUNC(playmark_state::wbeachvla_snd_control_w));
-	m_audio_mcs->port_in_cb<3>().set(FUNC(playmark_state::wbeachvla_snd_command_r));
-	m_audio_mcs->port_out_cb<3>().set(FUNC(playmark_state::playmark_oki_w));
+	m_audio_mcs->port_out_cb<1>().set(FUNC(wbeachvl_mcs_state::snd_control_w<0x7>));
+	m_audio_mcs->port_in_cb<3>().set(FUNC(wbeachvl_mcs_state::snd_command_r));
+	m_audio_mcs->port_out_cb<3>().set(FUNC(wbeachvl_mcs_state::oki_w));
 
 	I87C51(config, "extracpu", 12'000'000); // actually S87C751, clock unverified, on a sub PCB near a 12 MHz XTAL
 
@@ -1213,19 +1218,22 @@ void playmark_state::wbeachvl_mcs(machine_config &config)
 	m_soundlatch->data_pending_callback().set_inputline(m_audio_mcs, MCS51_INT1_LINE, HOLD_LINE);
 }
 
-void playmark_state::excelsr(machine_config &config)
+void bigtwin_state::excelsr(machine_config &config)
 {
 	// basic machine hardware
 	M68000(config, m_maincpu, XTAL(24'000'000)/2);   // 12 MHz
-	m_maincpu->set_addrmap(AS_PROGRAM, &playmark_state::excelsr_main_map);
-	m_maincpu->set_vblank_int("screen", FUNC(playmark_state::irq2_line_hold));
+	m_maincpu->set_addrmap(AS_PROGRAM, &bigtwin_state::excelsr_main_map);
+	m_maincpu->set_vblank_int("screen", FUNC(bigtwin_state::irq2_line_hold));
 
 	PIC16C57(config, m_audio_pic, XTAL(24'000'000)/2);    // 12MHz with internal 4x divisor
-	m_audio_pic->write_a().set(FUNC(playmark_state::playmark_oki_banking_w));
-	m_audio_pic->read_b().set(FUNC(playmark_state::playmark_snd_command_r));
-	m_audio_pic->write_b().set(FUNC(playmark_state::playmark_oki_w));
-	m_audio_pic->read_c().set(FUNC(playmark_state::playmark_snd_flag_r));
-	m_audio_pic->write_c().set(FUNC(playmark_state::playmark_snd_control_w));
+	m_audio_pic->write_a().set(FUNC(bigtwin_state::oki_bank_w));
+	m_audio_pic->read_b().set(FUNC(bigtwin_state::snd_command_r));
+	m_audio_pic->write_b().set(FUNC(bigtwin_state::oki_w));
+	m_audio_pic->read_c().set(FUNC(bigtwin_state::snd_flag_r));
+	m_audio_pic->write_c().set(FUNC(bigtwin_state::snd_control_w<0>));
+
+	GENERIC_LATCH_8(config, m_soundlatch);
+	m_soundlatch->set_separate_acknowledge(true);
 
 	// video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
@@ -1233,20 +1241,20 @@ void playmark_state::excelsr(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	screen.set_size(64*8, 64*8);
 	screen.set_visarea(0*8, 40*8-1, 2*8, 32*8-1);
-	screen.set_screen_update(FUNC(playmark_state::screen_update_excelsr));
+	screen.set_screen_update(FUNC(bigtwin_state::screen_update_excelsr));
 	screen.set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_excelsr);
 	PALETTE(config, m_palette).set_format(palette_device::RRRRGGGGBBBBRGBx, 1024);
 
-	MCFG_VIDEO_START_OVERRIDE(playmark_state,excelsr)
+	MCFG_VIDEO_START_OVERRIDE(bigtwin_state,excelsr)
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
 
 	OKIM6295(config, m_oki, XTAL(1'000'000), okim6295_device::PIN7_HIGH); // 1MHz resonator
 	m_oki->add_route(ALL_OUTPUTS, "mono", 1.0);
-	m_oki->set_addrmap(0, &playmark_state::oki_map);
+	m_oki->set_addrmap(0, &bigtwin_state::oki_map);
 }
 
 void playmark_state::hrdtimes(machine_config &config)
@@ -1257,11 +1265,14 @@ void playmark_state::hrdtimes(machine_config &config)
 	m_maincpu->set_vblank_int("screen", FUNC(playmark_state::irq6_line_hold));
 
 	PIC16C57(config, m_audio_pic, XTAL(24'000'000)/2);    // verified on pcb
-	m_audio_pic->write_a().set(FUNC(playmark_state::playmark_oki_banking_w)); // Banking data output but not wired. Port C is wired to the OKI banking instead
-	m_audio_pic->read_b().set(FUNC(playmark_state::playmark_snd_command_r));
-	m_audio_pic->write_b().set(FUNC(playmark_state::playmark_oki_w));
-	m_audio_pic->read_c().set(FUNC(playmark_state::playmark_snd_flag_r));
-	m_audio_pic->write_c().set(FUNC(playmark_state::hrdtimes_snd_control_w));
+	m_audio_pic->write_a().set(FUNC(playmark_state::oki_bank_w)); // Banking data output but not wired. Port C is wired to the OKI banking instead
+	m_audio_pic->read_b().set(FUNC(playmark_state::snd_command_r));
+	m_audio_pic->write_b().set(FUNC(playmark_state::oki_w));
+	m_audio_pic->read_c().set(FUNC(playmark_state::snd_flag_r));
+	m_audio_pic->write_c().set(FUNC(playmark_state::snd_control_w<0x3>));
+
+	GENERIC_LATCH_8(config, m_soundlatch);
+	m_soundlatch->set_separate_acknowledge(true);
 
 	// video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
@@ -1293,11 +1304,14 @@ void playmark_state::hotmind(machine_config &config)
 	m_maincpu->set_vblank_int("screen", FUNC(playmark_state::irq6_line_hold)); // irq 2 and 6 point to the same location on hotmind
 
 	PIC16C57(config, m_audio_pic, XTAL(24'000'000)/2);    // verified on pcb
-//  m_audio_pic->write_a().set(FUNC(playmark_state::playmark_oki_banking_w)); // Banking data output but not wired. Port C is wired to the OKI banking instead
-	m_audio_pic->read_b().set(FUNC(playmark_state::playmark_snd_command_r));
-	m_audio_pic->write_b().set(FUNC(playmark_state::playmark_oki_w));
-	m_audio_pic->read_c().set(FUNC(playmark_state::playmark_snd_flag_r));
-	m_audio_pic->write_c().set(FUNC(playmark_state::hrdtimes_snd_control_w));
+//  m_audio_pic->write_a().set(FUNC(playmark_state::oki_bank_w)); // Banking data output but not wired. Port C is wired to the OKI banking instead
+	m_audio_pic->read_b().set(FUNC(playmark_state::snd_command_r));
+	m_audio_pic->write_b().set(FUNC(playmark_state::oki_w));
+	m_audio_pic->read_c().set(FUNC(playmark_state::snd_flag_r));
+	m_audio_pic->write_c().set(FUNC(playmark_state::snd_control_w<0x3>));
+
+	GENERIC_LATCH_8(config, m_soundlatch);
+	m_soundlatch->set_separate_acknowledge(true);
 
 	EEPROM_93C46_16BIT(config, "eeprom").default_value(0);
 
@@ -1334,11 +1348,14 @@ void playmark_state::luckboomh(machine_config &config)
 	m_maincpu->set_vblank_int("screen", FUNC(playmark_state::irq6_line_hold));
 
 	PIC16C57(config, m_audio_pic, XTAL(24'000'000)/2);    // verified on pcb
-//  m_audio_pic->write_a().set(FUNC(playmark_state::playmark_oki_banking_w)); // Banking data output but not wired. Port C is wired to the OKI banking instead
-	m_audio_pic->read_b().set(FUNC(playmark_state::playmark_snd_command_r));
-	m_audio_pic->write_b().set(FUNC(playmark_state::playmark_oki_w));
-	m_audio_pic->read_c().set(FUNC(playmark_state::playmark_snd_flag_r));
-	m_audio_pic->write_c().set(FUNC(playmark_state::hrdtimes_snd_control_w));
+//  m_audio_pic->write_a().set(FUNC(playmark_state::oki_bank_w)); // Banking data output but not wired. Port C is wired to the OKI banking instead
+	m_audio_pic->read_b().set(FUNC(playmark_state::snd_command_r));
+	m_audio_pic->write_b().set(FUNC(playmark_state::oki_w));
+	m_audio_pic->read_c().set(FUNC(playmark_state::snd_flag_r));
+	m_audio_pic->write_c().set(FUNC(playmark_state::snd_control_w<0x3>));
+
+	GENERIC_LATCH_8(config, m_soundlatch);
+	m_soundlatch->set_separate_acknowledge(true);
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
@@ -1381,18 +1398,18 @@ ROM_START( bigtwin )
 
 	ROM_REGION( 0x1000, "audiopic", ROMREGION_ERASE00 ) // sound (PIC16C57)
 //  ROM_LOAD( "16c57hs.bin",  0x0000, 0x1000, CRC(b4c95cc3) SHA1(7fc9b141e7782aa5c17310ee06db99d884537c30) )
-	// ROM will be copied here by the init code from "user1"
+	// ROM will be copied here by the init code from "pic_hex"
 
-	ROM_REGION( 0x3000, "user1", 0 )
+	ROM_REGION( 0x3000, "pic_hex", 0 )
 	ROM_LOAD( "pic16c57-hs_bigtwin_015.hex",  0x0000, 0x2d4c, CRC(c07e9375) SHA1(7a6714ab888ea6e37bc037bc7419f0998868cfce) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles", 0 )
 	ROM_LOAD( "4.311",        0x00000, 0x40000, CRC(6f628fbc) SHA1(51cdee457aef79fef5d89d30a173afdf13fbb2ef) )
 	ROM_LOAD( "5.312",        0x40000, 0x40000, CRC(6a9b1752) SHA1(7c78157cd6b3d631704d2aca1a5756c69c87d581) )
 	ROM_LOAD( "6.313",        0x80000, 0x40000, CRC(411cf852) SHA1(1b66cec672b6ec6974d9e82afc6ec58b78c92ee4) )
 	ROM_LOAD( "7.314",        0xc0000, 0x40000, CRC(635c81fd) SHA1(64c787a37fcd1ba7c747ec25ff5b949aad3914ec) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )
+	ROM_REGION( 0x80000, "sprites", 0 )
 	ROM_LOAD( "8.321",        0x00000, 0x20000, CRC(2749644d) SHA1(f506ed1a14ee411eda8a7e639f5572e35b89b13f) )
 	ROM_LOAD( "9.322",        0x20000, 0x20000, CRC(1d1897af) SHA1(0ad00906b94443d7ceef383717b39c6aa8cca241) )
 	ROM_LOAD( "10.323",       0x40000, 0x20000, CRC(2a03432e) SHA1(44722b83093211d88460cbcd9e9c0b638d24ad3e) )
@@ -1409,12 +1426,12 @@ ROM_START( bigtwinb )
 
 	ROM_REGION( 0x1000, "audiopic", ROMREGION_ERASE00 ) // sound (PIC16C57)
 //  ROM_LOAD( "16c57hs.bin",  0x0000, 0x1000, CRC(b4c95cc3) SHA1(7fc9b141e7782aa5c17310ee06db99d884537c30) )
-	// ROM will be copied here by the init code from "user1"
+	// ROM will be copied here by the init code from "pic_hex"
 
-	ROM_REGION( 0x3000, "user1", 0 )
+	ROM_REGION( 0x3000, "pic_hex", 0 )
 	ROM_LOAD( "pic16c57-hs_bigtwin_015.hex",  0x0000, 0x2d4c, CRC(c07e9375) SHA1(7a6714ab888ea6e37bc037bc7419f0998868cfce) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles", 0 )
 	ROM_LOAD16_BYTE( "4.u36", 0x000000, 0x20000, CRC(99aaeacc) SHA1(0281237722d5a94fb9831616ae2ffc8288e78e2c) )
 	ROM_CONTINUE(             0x040000, 0x20000 )
 	ROM_LOAD16_BYTE( "5.u42", 0x000001, 0x20000, CRC(5c1dfd72) SHA1(31fab4d3bd4e8ff5a16daeaff0ccaa4fc8f60c92) )
@@ -1424,7 +1441,7 @@ ROM_START( bigtwinb )
 	ROM_LOAD16_BYTE( "7.u45", 0x080001, 0x20000, CRC(aedb2e6d) SHA1(775e13d328c8ee3c36b9d77ad49fa5a092b85a95) )
 	ROM_CONTINUE(             0x0c0001, 0x20000 )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )
+	ROM_REGION( 0x80000, "sprites", 0 )
 	ROM_LOAD( "11.u86",       0x00000, 0x20000, CRC(2749644d) SHA1(f506ed1a14ee411eda8a7e639f5572e35b89b13f) )
 	ROM_LOAD( "10.u85",       0x20000, 0x20000, CRC(1d1897af) SHA1(0ad00906b94443d7ceef383717b39c6aa8cca241) )
 	ROM_LOAD( "9.u84",        0x40000, 0x20000, CRC(2a03432e) SHA1(44722b83093211d88460cbcd9e9c0b638d24ad3e) )
@@ -1441,12 +1458,12 @@ ROM_START( bigtwinc )
 
 	ROM_REGION( 0x1000, "audiopic", ROMREGION_ERASE00 ) // sound (PIC16C57)
 //  ROM_LOAD( "16c57hs.bin",  0x0000, 0x1000, CRC(b4c95cc3) SHA1(7fc9b141e7782aa5c17310ee06db99d884537c30) )
-	// ROM will be copied here by the init code from "user1"
+	// ROM will be copied here by the init code from "pic_hex"
 
-	ROM_REGION( 0x3000, "user1", 0 )
+	ROM_REGION( 0x3000, "pic_hex", 0 )
 	ROM_LOAD( "pic16c57-hs_bigtwin_015.hex",  0x0000, 0x2d4c, CRC(c07e9375) SHA1(7a6714ab888ea6e37bc037bc7419f0998868cfce) )
 
-	ROM_REGION( 0x100000, "gfx1", 0 )
+	ROM_REGION( 0x100000, "tiles", 0 )
 	ROM_LOAD16_BYTE( "4.u36", 0x000000, 0x20000, CRC(99aaeacc) SHA1(0281237722d5a94fb9831616ae2ffc8288e78e2c) )
 	ROM_CONTINUE(             0x040000, 0x20000 )
 	ROM_LOAD16_BYTE( "5.u42", 0x000001, 0x20000, CRC(5c1dfd72) SHA1(31fab4d3bd4e8ff5a16daeaff0ccaa4fc8f60c92) )
@@ -1456,7 +1473,7 @@ ROM_START( bigtwinc )
 	ROM_LOAD16_BYTE( "7.u45", 0x080001, 0x20000, CRC(aedb2e6d) SHA1(775e13d328c8ee3c36b9d77ad49fa5a092b85a95) )
 	ROM_CONTINUE(             0x0c0001, 0x20000 )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )
+	ROM_REGION( 0x80000, "sprites", 0 )
 	ROM_LOAD( "11.u86",       0x00000, 0x20000, CRC(2749644d) SHA1(f506ed1a14ee411eda8a7e639f5572e35b89b13f) )
 	ROM_LOAD( "10.u85",       0x20000, 0x20000, CRC(1d1897af) SHA1(0ad00906b94443d7ceef383717b39c6aa8cca241) )
 	ROM_LOAD( "9.u84",        0x40000, 0x20000, CRC(2a03432e) SHA1(44722b83093211d88460cbcd9e9c0b638d24ad3e) )
@@ -1475,7 +1492,7 @@ ROM_START( wbeachvl )
 	// 0x1000 rom data (actually 0x800 12-bit words), + 0x9 config bytes
 	ROM_LOAD( "pic16c57",       0x00000, 0x1009, CRC(35439064) SHA1(ab0c5bafd76a2cb2a2e5ddb9d0578fd7e2241e43) )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "tiles", 0 )
 	ROM_LOAD( "wbv_10.bin",   0x000000, 0x80000, CRC(50680f0b) SHA1(ed76ef6ced70ba7e9558162aa94bbe9f19bbabe6) )
 	ROM_LOAD( "wbv_04.bin",   0x080000, 0x80000, CRC(df9cbff1) SHA1(7197939d9c4e8666d37266b6326134cfb4c761da) )
 	ROM_LOAD( "wbv_11.bin",   0x100000, 0x80000, CRC(e59ad0d1) SHA1(70dfc1ea45246fc8e24c96550563ab7a983f3824) )
@@ -1506,7 +1523,7 @@ ROM_START( wbeachvla ) // same as wbeachvl but with S87C751 audio CPU
 	ROM_REGION( 0x1000, "extracpu", ROMREGION_ERASE00 ) // on a small sub PCB with the second JAMMA connector
 	ROM_LOAD( "s87c751.u5",   0x000, 0x800, CRC(54a6004f) SHA1(b7b24e5a812f284099946fcbddd3cf804332f230) )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "tiles", 0 )
 	ROM_LOAD( "wbv_10.bin",   0x000000, 0x80000, CRC(50680f0b) SHA1(ed76ef6ced70ba7e9558162aa94bbe9f19bbabe6) )
 	ROM_LOAD( "wbv_04.bin",   0x080000, 0x80000, CRC(df9cbff1) SHA1(7197939d9c4e8666d37266b6326134cfb4c761da) )
 	ROM_LOAD( "wbv_11.bin",   0x100000, 0x80000, CRC(e59ad0d1) SHA1(70dfc1ea45246fc8e24c96550563ab7a983f3824) )
@@ -1535,7 +1552,7 @@ ROM_START( wbeachvl2 )
 	// 0x1000 rom data (actually 0x800 12-bit words), + 0x9 config bytes
 	ROM_LOAD( "pic16c57",       0x00000, 0x1009, CRC(35439064) SHA1(ab0c5bafd76a2cb2a2e5ddb9d0578fd7e2241e43) )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "tiles", 0 )
 	ROM_LOAD( "wbv_10.bin",   0x000000, 0x80000, CRC(50680f0b) SHA1(ed76ef6ced70ba7e9558162aa94bbe9f19bbabe6) )
 	ROM_LOAD( "wbv_04.bin",   0x080000, 0x80000, CRC(df9cbff1) SHA1(7197939d9c4e8666d37266b6326134cfb4c761da) )
 	ROM_LOAD( "wbv_11.bin",   0x100000, 0x80000, CRC(e59ad0d1) SHA1(70dfc1ea45246fc8e24c96550563ab7a983f3824) )
@@ -1564,7 +1581,7 @@ ROM_START( wbeachvl3 ) // PCB marked PM285
 	// 0x1000 rom data (actually 0x800 12-bit words), + 0x9 config bytes
 	ROM_LOAD( "pic16c57",       0x00000, 0x1009, CRC(35439064) SHA1(ab0c5bafd76a2cb2a2e5ddb9d0578fd7e2241e43) )
 
-	ROM_REGION( 0x600000, "gfx1", 0 )
+	ROM_REGION( 0x600000, "tiles", 0 )
 	ROM_LOAD( "wbv_10.bin",   0x000000, 0x80000, CRC(50680f0b) SHA1(ed76ef6ced70ba7e9558162aa94bbe9f19bbabe6) )
 	ROM_LOAD( "wbv_04.bin",   0x080000, 0x80000, CRC(df9cbff1) SHA1(7197939d9c4e8666d37266b6326134cfb4c761da) )
 	ROM_LOAD( "wbv_11.bin",   0x100000, 0x80000, CRC(e59ad0d1) SHA1(70dfc1ea45246fc8e24c96550563ab7a983f3824) )
@@ -1594,18 +1611,18 @@ ROM_START( excelsr ) // PCB marked EXC
 	ROM_LOAD16_BYTE( "17.u306", 0x200000, 0x80000, CRC(978f9a6b) SHA1(9514b97f071fd20740218a58af877765beffedad) )
 
 	ROM_REGION( 0x1000, "audiopic", ROMREGION_ERASE00 ) // sound (PIC16C57)
-	// ROM will be copied here by the init code from "user1"
+	// ROM will be copied here by the init code from "pic_hex"
 
-	ROM_REGION( 0x3000, "user1", 0 )
+	ROM_REGION( 0x3000, "pic_hex", 0 )
 	ROM_LOAD( "pic16c57-hs_excelsior_i015.hex", 0x0000, 0x2d4c, CRC(022c6941) SHA1(8ead40bfa7aa783b1ce62bd6cfa673cb876e29e7) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD( "26.u311",      0x000000, 0x80000, CRC(c171c059) SHA1(7bc45ef1d588f5f55a461adb91bca382155c1059) )
 	ROM_LOAD( "30.u312",      0x080000, 0x80000, CRC(b4a4c510) SHA1(07951a4c18bb25b10f650fd85b6bab566d0ef971) )
 	ROM_LOAD( "25.u313",      0x100000, 0x80000, CRC(667eec1b) SHA1(9e5ed82a4966244a97d18c27466179771012b305) )
 	ROM_LOAD( "29.u314",      0x180000, 0x80000, CRC(4acb0745) SHA1(6b5feaa5aa088f0cc5799f73ee5f90ed390165a9) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "sprites", 0 )
 	ROM_LOAD( "24.u321",      0x000000, 0x80000, CRC(17f46825) SHA1(6ac0e71498ac668641c0b7134ddd19cc4cc97005) )
 	ROM_LOAD( "28.u322",      0x080000, 0x80000, CRC(a823f2bd) SHA1(c7f1b1ee8f7069522787b6916b8c6e4591b55782) )
 	ROM_LOAD( "23.u323",      0x100000, 0x80000, CRC(d8e1453b) SHA1(a3edb05abe486d4cce30f5caf14be619b6886f7c) )
@@ -1626,18 +1643,18 @@ ROM_START( excelsra )
 	ROM_LOAD16_BYTE( "17.u306", 0x200000, 0x80000, CRC(978f9a6b) SHA1(9514b97f071fd20740218a58af877765beffedad) )
 
 	ROM_REGION( 0x1000, "audiopic", ROMREGION_ERASE00 ) // sound (PIC16C57)
-	// ROM will be copied here by the init code from "user1"
+	// ROM will be copied here by the init code from "pic_hex"
 
-	ROM_REGION( 0x3000, "user1", 0 )
+	ROM_REGION( 0x3000, "pic_hex", 0 )
 	ROM_LOAD( "pic16c57-hs_excelsior_i015.hex", 0x0000, 0x2d4c, CRC(022c6941) SHA1(8ead40bfa7aa783b1ce62bd6cfa673cb876e29e7) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD( "26.u311",      0x000000, 0x80000, CRC(c171c059) SHA1(7bc45ef1d588f5f55a461adb91bca382155c1059) )
 	ROM_LOAD( "30.u312",      0x080000, 0x80000, CRC(b4a4c510) SHA1(07951a4c18bb25b10f650fd85b6bab566d0ef971) )
 	ROM_LOAD( "25.u313",      0x100000, 0x80000, CRC(667eec1b) SHA1(9e5ed82a4966244a97d18c27466179771012b305) )
 	ROM_LOAD( "29.u314",      0x180000, 0x80000, CRC(4acb0745) SHA1(6b5feaa5aa088f0cc5799f73ee5f90ed390165a9) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "sprites", 0 )
 	ROM_LOAD( "24.u321",      0x000000, 0x80000, CRC(17f46825) SHA1(6ac0e71498ac668641c0b7134ddd19cc4cc97005) )
 	ROM_LOAD( "28.u322",      0x080000, 0x80000, CRC(a823f2bd) SHA1(c7f1b1ee8f7069522787b6916b8c6e4591b55782) )
 	ROM_LOAD( "23.u323",      0x100000, 0x80000, CRC(d8e1453b) SHA1(a3edb05abe486d4cce30f5caf14be619b6886f7c) )
@@ -1661,13 +1678,13 @@ ROM_START( hrdtimes ) // PCB marked Hard Times 28-06-94
 	*/
 	ROM_LOAD( "pic16c57.bin", 0x0000, 0x1000, CRC(db307198) SHA1(21e98a69e673f6d48eb48239b4c51f6e7aa19a66) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD16_BYTE( "33.u36",       0x000000, 0x80000, CRC(d1239ce5) SHA1(8e966a39a47f66c5e904ec4357c751e896ed47cb) )
 	ROM_LOAD16_BYTE( "37.u42",       0x000001, 0x80000, CRC(aa692005) SHA1(1e274da358a25ceebdc71cb8f7228ef39348a895) )
 	ROM_LOAD16_BYTE( "34.u39",       0x100000, 0x80000, CRC(e4108c59) SHA1(15f7b53a7bbdc4aefdae31a00be64c419326bfd1) )
 	ROM_LOAD16_BYTE( "38.u45",       0x100001, 0x80000, CRC(ff7cacf3) SHA1(5ed93e86fe3b0b594bdd62e314cd9e2ffd3c2a2a) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "sprites", 0 )
 	ROM_LOAD16_BYTE( "36.u86",       0x000000, 0x80000, CRC(f2fc1ca3) SHA1(f70913d9b89338932e62ca6bb60e5f5e412d7f64) )
 	ROM_LOAD16_BYTE( "40.u85",       0x000001, 0x80000, CRC(368c15f4) SHA1(8ae95fd672448921964c4d0312d7366903362e27) )
 	ROM_LOAD16_BYTE( "35.u84",       0x100000, 0x80000, CRC(7bde46ec) SHA1(1d26d268e1fc937e23ae7d93a1f86386b899a0c2) )
@@ -1693,11 +1710,11 @@ ROM_START( hrdtimesa )
 	*/
 	ROM_LOAD( "pic16c57.bin", 0x0000, 0x1000, CRC(db307198) SHA1(21e98a69e673f6d48eb48239b4c51f6e7aa19a66) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD( "fh1_playmark_ht", 0x000000, 0x100000, CRC(3cca02b0) SHA1(22c57f4192bf81dd26caa6adfb1c80665bdc305c) )
 	ROM_LOAD( "fh2_playmark_ht", 0x100000, 0x100000, CRC(ed699acd) SHA1(23cf1da4e7462f7434e946a80bdd6df0395b3059) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "sprites", 0 )
 	ROM_LOAD( "mh1_playmark_ht", 0x000000, 0x100000, CRC(927e5989) SHA1(b01444a3ff57cc2e10594e23c0343c956ed3ee32) )
 	ROM_LOAD( "mh2_playmark_ht", 0x100000, 0x100000, CRC(e76f001b) SHA1(217c06ca3618275c22e33cfe318ec6c970d4862c) )
 
@@ -1755,13 +1772,13 @@ ROM_START( hotmind ) // PCB marked Hard Times 28-06-94
 	ROM_LOAD16_BYTE( "22.u66",       0x00001, 0x20000, CRC(2c518ec5) SHA1(6d9e81ddb5793d64e22dc0254519b947f6ec6954) )
 
 	ROM_REGION( 0x1000, "audiopic", ROMREGION_ERASE00 ) // sound (PIC16C57)
-	// ROM will be copied here by the init code from "user1"
+	// ROM will be copied here by the init code from "pic_hex"
 
-	ROM_REGION( 0x3000, "user1", 0 )
+	ROM_REGION( 0x3000, "pic_hex", 0 )
 	ROM_LOAD( "hotmind_pic16c57-hs_io15.hex", 0x0000, 0x2d4c, BAD_DUMP CRC(f3300d13) SHA1(78892453c7374ea3d1606cdb81197cc466e2a8c5) )  // protected, contains upper nibble?
 	ROM_LOAD( "hotmind_pic16c57.hex",         0x0000, 0x2d4c, BAD_DUMP CRC(11957803) SHA1(c2f87659819bfcf3a5b43fbccf81988c43b9c9c8) )  // Using modified Excelsior PIC code to make it suite this game
 
-	ROM_REGION( 0x080000, "gfx1", 0 )
+	ROM_REGION( 0x080000, "tiles", 0 )
 	ROM_LOAD16_BYTE( "23.u36",       0x000000, 0x10000, CRC(ddcf60b9) SHA1(0c0fbc44131cb7d36c21bf5aead87b498c5684f5) )
 	ROM_CONTINUE(                    0x020000, 0x10000 )
 	ROM_LOAD16_BYTE( "27.u42",       0x000001, 0x10000, CRC(413bbcf4) SHA1(d82ae9d26df1a69b760b3025048e47ab757d9175) )
@@ -1771,7 +1788,7 @@ ROM_START( hotmind ) // PCB marked Hard Times 28-06-94
 	ROM_LOAD16_BYTE( "28.u45",       0x040001, 0x10000, CRC(8df34d6a) SHA1(ca0d2ca7e0f2a302bc8b1a03c0c18ac72fe105ac) )
 	ROM_CONTINUE(                    0x060001, 0x10000 )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )
+	ROM_REGION( 0x80000, "sprites", 0 )
 	ROM_LOAD16_BYTE( "26.u86",       0x00000, 0x20000, CRC(ff8d3b75) SHA1(5427b70a61dee4c125877e040be21cb1cadb1af5) )
 	ROM_LOAD16_BYTE( "30.u85",       0x00001, 0x20000, CRC(87a640c7) SHA1(818ff3243cb3ed0189988348e6c2e954f0d3dd4f) )
 	ROM_LOAD16_BYTE( "25.u84",       0x40000, 0x20000, CRC(c4fd4445) SHA1(ab0c5a328a312740595b5c92a1050527140518f3) )
@@ -1795,13 +1812,13 @@ ROM_START( hotmindc ) // PCB marked Hard Times 28-06-94
 	ROM_LOAD16_BYTE( "2.u66",       0x00001, 0x20000, CRC(1a27033f) SHA1(8eed0c1db27b7e0ed1df973c3b8f9306690413be) ) // label has a red marker dot on the right of the number
 
 	ROM_REGION( 0x1000, "audiopic", ROMREGION_ERASE00 ) // sound (PIC16C57)
-	// ROM will be copied here by the init code from "user1"
+	// ROM will be copied here by the init code from "pic_hex"
 
-	ROM_REGION( 0x3000, "user1", 0 )
+	ROM_REGION( 0x3000, "pic_hex", 0 )
 	ROM_LOAD( "hotmind_pic16c57-hs_io15.hex", 0x0000, 0x2d4c, BAD_DUMP CRC(f3300d13) SHA1(78892453c7374ea3d1606cdb81197cc466e2a8c5) )  // protected, contains upper nibble?
 	ROM_LOAD( "hotmind_pic16c57.hex",         0x0000, 0x2d4c, BAD_DUMP CRC(11957803) SHA1(c2f87659819bfcf3a5b43fbccf81988c43b9c9c8) )  // Using modified Excelsior PIC code to make it suite this game
 
-	ROM_REGION( 0x080000, "gfx1", 0 )
+	ROM_REGION( 0x080000, "tiles", 0 )
 	ROM_LOAD16_BYTE( "23.u36",       0x000000, 0x10000, CRC(ddcf60b9) SHA1(0c0fbc44131cb7d36c21bf5aead87b498c5684f5) )
 	ROM_CONTINUE(                    0x020000, 0x10000 )
 	ROM_LOAD16_BYTE( "27.u42",       0x000001, 0x10000, CRC(413bbcf4) SHA1(d82ae9d26df1a69b760b3025048e47ab757d9175) )
@@ -1811,7 +1828,7 @@ ROM_START( hotmindc ) // PCB marked Hard Times 28-06-94
 	ROM_LOAD16_BYTE( "28.u45",       0x040001, 0x10000, CRC(8df34d6a) SHA1(ca0d2ca7e0f2a302bc8b1a03c0c18ac72fe105ac) )
 	ROM_CONTINUE(                    0x060001, 0x10000 )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )
+	ROM_REGION( 0x80000, "sprites", 0 )
 	ROM_LOAD16_BYTE( "26.u86",       0x00000, 0x20000, CRC(ff8d3b75) SHA1(5427b70a61dee4c125877e040be21cb1cadb1af5) )
 	ROM_LOAD16_BYTE( "30.u85",       0x00001, 0x20000, CRC(87a640c7) SHA1(818ff3243cb3ed0189988348e6c2e954f0d3dd4f) )
 	ROM_LOAD16_BYTE( "25.u84",       0x40000, 0x20000, CRC(c4fd4445) SHA1(ab0c5a328a312740595b5c92a1050527140518f3) )
@@ -1835,13 +1852,13 @@ ROM_START( luckboomh )
 	ROM_LOAD16_BYTE( "22.u66",       0x00001, 0x20000, CRC(1eb72a39) SHA1(d7ea9985013fd8cb89389829dbff2f2710a2297d) )
 
 	ROM_REGION( 0x2000, "audiopic", ROMREGION_ERASE00 ) // sound (PIC16C57)
-	// ROM will be copied here by the init code from "user1"
+	// ROM will be copied here by the init code from "pic_hex"
 	ROM_LOAD( "luckyboom_pic16c57-hs_io15.bin",  0x00000, 0x2000, BAD_DUMP CRC(c4b9c78e) SHA1(e85766383b22a62f19bf272d86d53c7fb1eb5ac4) ) // protected, contains upper nibble?
 
-	ROM_REGION( 0x3000, "user1", 0 )
+	ROM_REGION( 0x3000, "pic_hex", 0 )
 	ROM_LOAD( "luckyboom_pic16c57.hex", 0x0000, 0x2d4c, BAD_DUMP CRC(5c4b5c39) SHA1(d24a097bb4a134406dd95d3ad5ed912f81a6a849) )  // Using modified Excelsior PIC code to make it suite this game
 
-	ROM_REGION( 0x080000, "gfx1", 0 )
+	ROM_REGION( 0x080000, "tiles", 0 )
 	ROM_LOAD16_BYTE( "23.u36",       0x000000, 0x10000, CRC(71840dd9) SHA1(9d0a75555dedb6fd28bb7c04b863f3ef5a1f8aac) )
 	ROM_CONTINUE(                    0x020000, 0x10000 )
 	ROM_LOAD16_BYTE( "27.u42",       0x000001, 0x10000, CRC(2f86b37f) SHA1(99b1ffc2006f7eb1517f2fcee955391af98ba061) )
@@ -1851,7 +1868,7 @@ ROM_START( luckboomh )
 	ROM_LOAD16_BYTE( "28.u40",       0x040001, 0x10000, CRC(40e65ed1) SHA1(bc75eb816c58eb0f983bb0eaee854c54e306e1da) )
 	ROM_CONTINUE(                    0x060001, 0x10000 )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    // Sprites
+	ROM_REGION( 0x80000, "sprites", 0 )    // Sprites
 	ROM_LOAD16_BYTE( "26.u86",       0x00000, 0x20000, CRC(d3ee7d82) SHA1(b0b3df19d60430e7a9fa29fdfff2183a32986d2d) )
 	ROM_LOAD16_BYTE( "30.u85",       0x00001, 0x20000, CRC(4b8a9558) SHA1(9f0f2d8f50f21cf188ad778c3a0a68ec23380b23) )
 	ROM_LOAD16_BYTE( "25.u84",       0x40000, 0x20000, CRC(e1ab5cf5) SHA1(f76d00537cfd6f09439e44071875bf021622fd07) )
@@ -1863,7 +1880,7 @@ ROM_END
 
 
 
-u8 playmark_state::playmark_asciitohex(u8 data)
+u8 playmark_state::asciitohex(u8 data)
 {
 	// Convert ASCII data to HEX
 
@@ -1874,11 +1891,11 @@ u8 playmark_state::playmark_asciitohex(u8 data)
 	return data;
 }
 
-void playmark_state::playmark_decode_pic_hex_dump(void)
+void playmark_state::decode_pic_hex_dump()
 {
-	u8 *playmark_PICROM_HEX = memregion("user1")->base();
-	u16 *playmark_PICROM = (u16 *)memregion("audiopic")->base();
-	int32_t offs, data;
+	const u8 *const playmark_PICROM_HEX = memregion("pic_hex")->base();
+	u16 *const playmark_PICROM = (u16 *)memregion("audiopic")->base();
+	s32 data;
 	u16 src_pos = 0;
 	u16 dst_pos = 0;
 	u8 data_hi, data_lo;
@@ -1892,15 +1909,15 @@ void playmark_state::playmark_decode_pic_hex_dump(void)
 		{
 			src_pos += 9;
 
-			for (offs = 0; offs < 32; offs += 4)
+			for (int offs = 0; offs < 32; offs += 4)
 			{
-				data_hi = playmark_asciitohex((playmark_PICROM_HEX[src_pos + offs + 0]));
-				data_lo = playmark_asciitohex((playmark_PICROM_HEX[src_pos + offs + 1]));
+				data_hi = asciitohex((playmark_PICROM_HEX[src_pos + offs + 0]));
+				data_lo = asciitohex((playmark_PICROM_HEX[src_pos + offs + 1]));
 				if ((data_hi <= 0x0f) && (data_lo <= 0x0f))
 				{
 					data = (data_hi <<  4) | (data_lo << 0);
-					data_hi = playmark_asciitohex((playmark_PICROM_HEX[src_pos + offs + 2]));
-					data_lo = playmark_asciitohex((playmark_PICROM_HEX[src_pos + offs + 3]));
+					data_hi = asciitohex((playmark_PICROM_HEX[src_pos + offs + 2]));
+					data_lo = asciitohex((playmark_PICROM_HEX[src_pos + offs + 3]));
 
 					if ((data_hi <= 0x0f) && (data_lo <= 0x0f))
 					{
@@ -1922,11 +1939,11 @@ void playmark_state::playmark_decode_pic_hex_dump(void)
 		{
 			src_pos += 9;
 
-			data_hi = playmark_asciitohex((playmark_PICROM_HEX[src_pos + 0]));
-			data_lo = playmark_asciitohex((playmark_PICROM_HEX[src_pos + 1]));
+			data_hi = asciitohex((playmark_PICROM_HEX[src_pos + 0]));
+			data_lo = asciitohex((playmark_PICROM_HEX[src_pos + 1]));
 			data = (data_hi <<  4) | (data_lo << 0);
-			data_hi = playmark_asciitohex((playmark_PICROM_HEX[src_pos + 2]));
-			data_lo = playmark_asciitohex((playmark_PICROM_HEX[src_pos + 3]));
+			data_hi = asciitohex((playmark_PICROM_HEX[src_pos + 2]));
+			data_lo = asciitohex((playmark_PICROM_HEX[src_pos + 3]));
 			data |= (data_hi << 12) | (data_lo << 8);
 
 			m_audio_pic->set_config(data);
@@ -1940,22 +1957,22 @@ void playmark_state::playmark_decode_pic_hex_dump(void)
 
 void playmark_state::init_pic_decode()
 {
-	playmark_decode_pic_hex_dump();
+	decode_pic_hex_dump();
 }
 
 
 
-GAME( 1995, bigtwin,   0,        bigtwin,      bigtwin,   playmark_state, init_pic_decode, ROT0, "Playmark", "Big Twin",                                       MACHINE_SUPPORTS_SAVE )
-GAME( 1995, bigtwinb,  bigtwin,  bigtwinb,     bigtwinb,  playmark_state, init_pic_decode, ROT0, "Playmark", "Big Twin (no girls conversion, set 1)",          MACHINE_SUPPORTS_SAVE )
-GAME( 1995, bigtwinc,  bigtwin,  bigtwinb,     bigtwinb,  playmark_state, init_pic_decode, ROT0, "Playmark", "Big Twin (no girls conversion, set 2)",          MACHINE_SUPPORTS_SAVE )
-GAME( 1995, wbeachvl,  0,        wbeachvl_pic, wbeachvl,  playmark_state, empty_init,      ROT0, "Playmark", "World Beach Volley (set 1, PIC16C57 audio CPU)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE ) // no music due to incorrect OKI banking / PIC hookup
-GAME( 1995, wbeachvla, wbeachvl, wbeachvl_mcs, wbeachvl,  playmark_state, empty_init,      ROT0, "Playmark", "World Beach Volley (set 1, S87C751 audio CPU)",  MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE ) // wrong banking, so some sounds are played at the wrong time
-GAME( 1995, wbeachvl2, wbeachvl, wbeachvl_pic, wbeachvl,  playmark_state, empty_init,      ROT0, "Playmark", "World Beach Volley (set 2)",                     MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 1995, wbeachvl3, wbeachvl, wbeachvl_pic, wbeachvl,  playmark_state, empty_init,      ROT0, "Playmark", "World Beach Volley (set 3)",                     MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 1996, excelsr,   0,        excelsr,      excelsr,   playmark_state, init_pic_decode, ROT0, "Playmark", "Excelsior (set 1)",                              MACHINE_SUPPORTS_SAVE )
-GAME( 1996, excelsra,  excelsr,  excelsr,      excelsr,   playmark_state, init_pic_decode, ROT0, "Playmark", "Excelsior (set 2)",                              MACHINE_SUPPORTS_SAVE )
-GAME( 1994, hrdtimes,  0,        hrdtimes,     hrdtimes,  playmark_state, empty_init,      ROT0, "Playmark", "Hard Times (set 1)",                             MACHINE_SUPPORTS_SAVE )
-GAME( 1994, hrdtimesa, hrdtimes, hrdtimes,     hrdtimes,  playmark_state, empty_init,      ROT0, "Playmark", "Hard Times (set 2)",                             MACHINE_SUPPORTS_SAVE )
-GAME( 1995, hotmind,   0,        hotmind,      hotmind,   playmark_state, init_pic_decode, ROT0, "Playmark", "Hot Mind (Hard Times hardware, set 1)",          MACHINE_SUPPORTS_SAVE )
-GAME( 1995, hotmindc,  hotmind,  hotmind,      hotmind,   playmark_state, init_pic_decode, ROT0, "Playmark", "Hot Mind (Hard Times hardware, set 2)",          MACHINE_SUPPORTS_SAVE )
-GAME( 1996, luckboomh, luckboom, luckboomh,    luckboomh, playmark_state, init_pic_decode, ROT0, "Playmark", "Lucky Boom (Hard Times hardware)",               MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+GAME( 1995, bigtwin,   0,        bigtwin,      bigtwin,   bigtwin_state,      init_pic_decode, ROT0, "Playmark", "Big Twin",                                       MACHINE_SUPPORTS_SAVE )
+GAME( 1995, bigtwinb,  bigtwin,  bigtwinb,     bigtwinb,  playmark_state,     init_pic_decode, ROT0, "Playmark", "Big Twin (no girls conversion, set 1)",          MACHINE_SUPPORTS_SAVE )
+GAME( 1995, bigtwinc,  bigtwin,  bigtwinb,     bigtwinb,  playmark_state,     init_pic_decode, ROT0, "Playmark", "Big Twin (no girls conversion, set 2)",          MACHINE_SUPPORTS_SAVE )
+GAME( 1995, wbeachvl,  0,        wbeachvl_pic, wbeachvl,  wbeachvl_state,     empty_init,      ROT0, "Playmark", "World Beach Volley (set 1, PIC16C57 audio CPU)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE ) // no music due to incorrect OKI banking / PIC hookup
+GAME( 1995, wbeachvla, wbeachvl, wbeachvl_mcs, wbeachvl,  wbeachvl_mcs_state, empty_init,      ROT0, "Playmark", "World Beach Volley (set 1, S87C751 audio CPU)",  MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE ) // wrong banking, so some sounds are played at the wrong time
+GAME( 1995, wbeachvl2, wbeachvl, wbeachvl_pic, wbeachvl,  wbeachvl_state,     empty_init,      ROT0, "Playmark", "World Beach Volley (set 2)",                     MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME( 1995, wbeachvl3, wbeachvl, wbeachvl_pic, wbeachvl,  wbeachvl_state,     empty_init,      ROT0, "Playmark", "World Beach Volley (set 3)",                     MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME( 1996, excelsr,   0,        excelsr,      excelsr,   bigtwin_state,      init_pic_decode, ROT0, "Playmark", "Excelsior (set 1)",                              MACHINE_SUPPORTS_SAVE )
+GAME( 1996, excelsra,  excelsr,  excelsr,      excelsr,   bigtwin_state,      init_pic_decode, ROT0, "Playmark", "Excelsior (set 2)",                              MACHINE_SUPPORTS_SAVE )
+GAME( 1994, hrdtimes,  0,        hrdtimes,     hrdtimes,  playmark_state,     empty_init,      ROT0, "Playmark", "Hard Times (set 1)",                             MACHINE_SUPPORTS_SAVE )
+GAME( 1994, hrdtimesa, hrdtimes, hrdtimes,     hrdtimes,  playmark_state,     empty_init,      ROT0, "Playmark", "Hard Times (set 2)",                             MACHINE_SUPPORTS_SAVE )
+GAME( 1995, hotmind,   0,        hotmind,      hotmind,   playmark_state,     init_pic_decode, ROT0, "Playmark", "Hot Mind (Hard Times hardware, set 1)",          MACHINE_SUPPORTS_SAVE )
+GAME( 1995, hotmindc,  hotmind,  hotmind,      hotmind,   playmark_state,     init_pic_decode, ROT0, "Playmark", "Hot Mind (Hard Times hardware, set 2)",          MACHINE_SUPPORTS_SAVE )
+GAME( 1996, luckboomh, luckboom, luckboomh,    luckboomh, playmark_state,     init_pic_decode, ROT0, "Playmark", "Lucky Boom (Hard Times hardware)",               MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/playmark/playmark.h
+++ b/src/mame/playmark/playmark.h
@@ -17,20 +17,32 @@
 
 class playmark_base_state : public driver_device // base class for powerbal.cpp, too
 {
-public:
+protected:
 	playmark_base_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
-		m_bgvideoram(*this, "bgvideoram"),
-		m_spriteram(*this, "spriteram"),
-		m_sprtranspen(0),
 		m_oki(*this, "oki"),
 		m_okibank(*this, "okibank"),
 		m_maincpu(*this, "maincpu"),
 		m_gfxdecode(*this, "gfxdecode"),
-		m_palette(*this, "palette")
+		m_palette(*this, "palette"),
+		m_bgvideoram(*this, "bgvideoram"),
+		m_spriteram(*this, "spriteram"),
+		m_bg_tilemap(nullptr),
+		m_xoffset(0),
+		m_yoffset(0),
+		m_sprtranspen(0),
+		m_oki_numbanks(0)
 	{ }
 
-protected:
+	void configure_oki_banks();
+
+	// devices
+	required_device<okim6295_device> m_oki;
+	required_memory_bank m_okibank;
+	required_device<cpu_device> m_maincpu;
+	required_device<gfxdecode_device> m_gfxdecode;
+	required_device<palette_device> m_palette;
+
 	// memory pointers
 	required_shared_ptr<u16> m_bgvideoram;
 	required_shared_ptr<u16> m_spriteram;
@@ -44,14 +56,7 @@ protected:
 
 	// misc
 	u8 m_oki_numbanks;
-	void configure_oki_banks();
 
-	// devices
-	required_device<okim6295_device> m_oki;
-	required_memory_bank m_okibank;
-	required_device<cpu_device> m_maincpu;
-	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<palette_device> m_palette;
 };
 
 class playmark_state : public playmark_base_state
@@ -59,25 +64,26 @@ class playmark_state : public playmark_base_state
 public:
 	playmark_state(const machine_config &mconfig, device_type type, const char *tag) :
 		playmark_base_state(mconfig, type, tag),
-		m_fgvideoram(*this, "fgvideoram"),
-		m_txtvideoram(*this, "txtvideoram"),
-		m_rowscroll(*this, "rowscroll"),
 		m_audio_pic(*this, "audiopic"),
-		m_audio_mcs(*this, "audiomcs"),
-		m_soundlatch(*this, "soundlatch"),
 		m_eeprom(*this, "eeprom"),
 		m_ticket(*this, "ticket"),
-		m_token(*this, "token")
+		m_token(*this, "token"),
+		m_soundlatch(*this, "soundlatch"),
+		m_fgvideoram(*this, "fgvideoram"),
+		m_txtvideoram(*this, "txtvideoram"),
+		m_fg_tilemap(nullptr),
+		m_tx_tilemap(nullptr),
+		m_pri_masks{0},
+		m_scroll{0},
+		m_oki_control(0),
+		m_oki_command(0),
+		m_dispenser_latch(0)
 	{ }
 
-	void wbeachvl_mcs(machine_config &config);
-	void wbeachvl_pic(machine_config &config);
 	void hrdtimes(machine_config &config);
 	void luckboomh(machine_config &config);
-	void bigtwin(machine_config &config);
 	void hotmind(machine_config &config);
 	void bigtwinb(machine_config &config);
-	void excelsr(machine_config &config);
 
 	void init_pic_decode();
 
@@ -85,25 +91,20 @@ protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
-private:
+	// devices
+	optional_device<pic16c57_device> m_audio_pic; // all but wbeachvla;
+	optional_device<eeprom_serial_93cxx_device> m_eeprom; // wbeachvl hotmind
+	optional_device<ticket_dispenser_device> m_ticket; // hotmind luckboomh
+	optional_device<ticket_dispenser_device> m_token; // hotmind luckboomh
+	required_device<generic_latch_8_device> m_soundlatch; // all
+
 	// memory pointers
 	required_shared_ptr<u16> m_fgvideoram;
 	required_shared_ptr<u16> m_txtvideoram;
-	optional_shared_ptr<u16> m_rowscroll;// wbeachvl
 
 	// video-related
-	tilemap_t *m_fg_tilemap = nullptr;
-	tilemap_t *m_tx_tilemap = nullptr;
-
-	// bigtwin and excelsr
-	s32 m_bgscrollx = 0;
-	s16 m_bgscrolly = 0;
-	bool m_bg_enable = false;
-	bool m_bg_full_size = false;
-
-	// wbeachvl
-	u32 m_fgscrollx = 0;
-	bool m_fg_rowscroll_enable = false;
+	tilemap_t *m_fg_tilemap;
+	tilemap_t *m_tx_tilemap;
 
 	// all
 	u16 m_pri_masks[3];
@@ -111,83 +112,142 @@ private:
 
 	// misc
 	// all
-	u8 m_snd_command = 0;
-	u8 m_snd_flag = 0;
-	u8 m_oki_control = 0;
-	u8 m_oki_command = 0;
+	u8 m_oki_control;
+	u8 m_oki_command;
 
-	u8 m_dispenser_latch = 0; // hotmind luckboomh
-
-	// devices
-	optional_device<pic16c57_device> m_audio_pic; // all but wbeachvla;
-	optional_device<i87c51_device> m_audio_mcs; // wbeachvla
-	optional_device<generic_latch_8_device> m_soundlatch; // wbeachvla
-	optional_device<eeprom_serial_93cxx_device> m_eeprom; // wbeachvl hotmind
-	optional_device<ticket_dispenser_device> m_ticket; // hotmind luckboomh
-	optional_device<ticket_dispenser_device> m_token; // hotmind luckboomh
+	u8 m_dispenser_latch; // hotmind luckboomh
 
 	void coinctrl_w(u8 data); // bigtwin excelsr hrdtimes
-	void wbeachvl_coin_eeprom_w(u8 data); // wbeachvl
 	void hotmind_coin_eeprom_w(u8 data); // hotmind
 	void luckboomh_dispenser_w(u8 data); // hotmind luckboomh
-	void playmark_snd_command_w(u8 data);
-	u8 playmark_snd_command_r();
-	u8 playmark_snd_flag_r();
-	void playmark_oki_w(u8 data);
-	void playmark_snd_control_w(u8 data);
-	void hrdtimes_snd_control_w(u8 data); // hrdtimes, hotmind, luckboomh
-	void wbeachvl_txvideoram_w(offs_t offset, u16 data, u16 mem_mask = ~0); // bigtwin, wbeachvl, excelsr
-	void wbeachvl_fgvideoram_w(offs_t offset, u16 data, u16 mem_mask = ~0); // bigtwin, wbeachvl, excelsr
-	void wbeachvl_bgvideoram_w(offs_t offset, u16 data, u16 mem_mask = ~0); // wbeachvl
-	void hrdtimes_txvideoram_w(offs_t offset, u16 data, u16 mem_mask = ~0); // bigtwinb, hrdtimes, hotmind, luckboomh
-	void hrdtimes_fgvideoram_w(offs_t offset, u16 data, u16 mem_mask = ~0); // bigtwinb, hrdtimes, hotmind, luckboomh
-	void hrdtimes_bgvideoram_w(offs_t offset, u16 data, u16 mem_mask = ~0); // bigtwinb, hrdtimes, hotmind, luckboomh
-	void bigtwin_scroll_w(offs_t offset, u16 data, u16 mem_mask = ~0); // bigtwin
-	void wbeachvl_scroll_w(offs_t offset, u16 data, u16 mem_mask = ~0); // wbeachvk
-	void excelsr_scroll_w(offs_t offset, u16 data, u16 mem_mask = ~0); // excelsr
+	void oki_bank_w(u8 data);
+	void snd_command_w(u8 data);
+	u8 snd_command_r();
+	u8 snd_flag_r();
+	void oki_w(u8 data);
+	template <u8 BankMask> void snd_control_w(u8 data);
+	template <int WordPerTile> void txvideoram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	template <int WordPerTile> void fgvideoram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	template <int WordPerTile> void bgvideoram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void hrdtimes_scroll_w(offs_t offset, u16 data, u16 mem_mask = ~0); // bigtwinb, hrdtimes, hotmind, luckboomh
-	void playmark_oki_banking_w(u8 data);
-	uint8_t wbeachvla_snd_command_r(); // wbeachvla
-	void wbeachvla_snd_control_w(uint8_t data); // wbeachvla
-	TILE_GET_INFO_MEMBER(bigtwin_get_tx_tile_info); // bigtwin, excelsr
-	TILE_GET_INFO_MEMBER(bigtwin_get_fg_tile_info); // bigtwin, excelsr
-	TILE_GET_INFO_MEMBER(wbeachvl_get_tx_tile_info); // wbeachvk
-	TILE_GET_INFO_MEMBER(wbeachvl_get_fg_tile_info); // wbeachvk
-	TILE_GET_INFO_MEMBER(wbeachvl_get_bg_tile_info); // wbeachvk
 	TILE_GET_INFO_MEMBER(hrdtimes_get_tx_tile_info); // hrdtimes, hotmind, luckboomh
 	TILE_GET_INFO_MEMBER(bigtwinb_get_tx_tile_info); // bigtwinb
 	TILE_GET_INFO_MEMBER(hrdtimes_get_fg_tile_info); // bigtwinb, hrdtimes, hotmind, luckboomh
 	TILE_GET_INFO_MEMBER(hrdtimes_get_bg_tile_info); // bigtwinb, hrdtimes, hotmind, luckboomh
-	DECLARE_VIDEO_START(bigtwin);
 	DECLARE_VIDEO_START(bigtwinb);
-	DECLARE_VIDEO_START(wbeachvl);
-	DECLARE_VIDEO_START(excelsr);
 	DECLARE_VIDEO_START(hotmind);
 	DECLARE_VIDEO_START(hrdtimes);
 	DECLARE_VIDEO_START(luckboomh);
-	TILEMAP_MAPPER_MEMBER(playmark_tilemap_scan_pages); // hrdtimes
-	u32 screen_update_bigtwin(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	TILEMAP_MAPPER_MEMBER(hrdtimes_tilemap_scan_pages); // hrdtimes
 	u32 screen_update_bigtwinb(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	u32 screen_update_wbeachvl(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	u32 screen_update_excelsr(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	u32 screen_update_hrdtimes(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect); // hrdtimes, hotmind, luckboomh
 	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int codeshift); // all but bigtwinb
-	void bigtwinb_draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int codeshift); // bigtwinb
-	void draw_bitmap(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect); // bigtwin, excelsr
-	u8 playmark_asciitohex(u8 data);
-	void playmark_decode_pic_hex_dump(void);
+	void bigtwinb_draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect); // bigtwinb
+	u8 asciitohex(u8 data);
+	void decode_pic_hex_dump();
 
-	void bigtwin_main_map(address_map &map) ATTR_COLD;
 	void bigtwinb_main_map(address_map &map) ATTR_COLD;
-	void excelsr_main_map(address_map &map) ATTR_COLD;
 	void hotmind_main_map(address_map &map) ATTR_COLD;
 	void hrdtimes_main_map(address_map &map) ATTR_COLD;
 	void luckboomh_main_map(address_map &map) ATTR_COLD;
 	void oki_map(address_map &map) ATTR_COLD;
+};
+
+// with bitmap
+class bigtwin_state : public playmark_state
+{
+public:
+	bigtwin_state(const machine_config &mconfig, device_type type, const char *tag) :
+		playmark_state(mconfig, type, tag),
+		m_bg_bitmap(512, 512),
+		m_bgscrollx(0),
+		m_bgscrolly(0),
+		m_bg_enable(false),
+		m_bg_full_size(false)
+	{ }
+
+	void bigtwin(machine_config &config);
+	void excelsr(machine_config &config);
+
+protected:
+	virtual void machine_reset() override ATTR_COLD;
+
+private:
+	// bigtwin and excelsr
+	bitmap_ind16 m_bg_bitmap;
+	s32 m_bgscrollx;
+	s16 m_bgscrolly;
+	bool m_bg_enable;
+	bool m_bg_full_size;
+
+	void bitmap_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void bigtwin_scroll_w(offs_t offset, u16 data, u16 mem_mask = ~0); // bigtwin
+	void excelsr_scroll_w(offs_t offset, u16 data, u16 mem_mask = ~0); // excelsr
+	void init_bitmap();
+	TILE_GET_INFO_MEMBER(bigtwin_get_tx_tile_info); // bigtwin, excelsr
+	TILE_GET_INFO_MEMBER(bigtwin_get_fg_tile_info); // bigtwin, excelsr
+	DECLARE_VIDEO_START(bigtwin);
+	DECLARE_VIDEO_START(excelsr);
+	u32 screen_update_bigtwin(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_excelsr(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void draw_bitmap(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect); // bigtwin, excelsr
+
+	void bigtwin_main_map(address_map &map) ATTR_COLD;
+	void excelsr_main_map(address_map &map) ATTR_COLD;
+};
+
+// with rowscroll
+class wbeachvl_state : public playmark_state
+{
+public:
+	wbeachvl_state(const machine_config &mconfig, device_type type, const char *tag) :
+		playmark_state(mconfig, type, tag),
+		m_rowscroll(*this, "rowscroll"),
+		m_fgscrollx(0),
+		m_fg_rowscroll_enable(false)
+	{ }
+
+	void wbeachvl_pic(machine_config &config);
+
+protected:
+	virtual void machine_reset() override ATTR_COLD;
+	virtual void video_start() override ATTR_COLD;
+
+	// memory pointers
+	required_shared_ptr<u16> m_rowscroll;// wbeachvl
+
+	// wbeachvl
+	u32 m_fgscrollx;
+	bool m_fg_rowscroll_enable;
+
+	void coin_eeprom_w(u8 data); // wbeachvl
+	void scroll_w(offs_t offset, u16 data, u16 mem_mask = ~0); // wbeachvl
+	TILE_GET_INFO_MEMBER(get_tx_tile_info); // wbeachvl
+	TILE_GET_INFO_MEMBER(get_fg_tile_info); // wbeachvl
+	TILE_GET_INFO_MEMBER(get_bg_tile_info); // wbeachvl
+	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
 	void wbeachvl_main_map(address_map &map) ATTR_COLD;
-	void wbeachvla_main_map(address_map &map) ATTR_COLD;
 
 	void wbeachvl_base(machine_config &config);
+};
+
+// uses MCS-51 MCU for audio
+class wbeachvl_mcs_state : public wbeachvl_state
+{
+public:
+	wbeachvl_mcs_state(const machine_config &mconfig, device_type type, const char *tag) :
+		wbeachvl_state(mconfig, type, tag),
+		m_audio_mcs(*this, "audiomcs")
+	{ }
+
+	void wbeachvl_mcs(machine_config &config);
+
+private:
+	// devices
+	required_device<i87c51_device> m_audio_mcs; // wbeachvla
+
+	void wbeachvla_main_map(address_map &map) ATTR_COLD;
 };
 
 #endif // MAME_PLAYMARK_PLAYMARK_H

--- a/src/mame/playmark/playmark_v.cpp
+++ b/src/mame/playmark/playmark_v.cpp
@@ -11,66 +11,68 @@
 
 ***************************************************************************/
 
-TILE_GET_INFO_MEMBER(playmark_state::bigtwin_get_tx_tile_info)
+TILE_GET_INFO_MEMBER(bigtwin_state::bigtwin_get_tx_tile_info)
 {
-	u16 code = m_txtvideoram[2 * tile_index];
-	u16 color = m_txtvideoram[2 * tile_index + 1];
+	const u16 code = m_txtvideoram[2 * tile_index];
+	const u16 color = m_txtvideoram[2 * tile_index + 1];
+
 	tileinfo.set(2, code, color, 0);
 }
 
-TILE_GET_INFO_MEMBER(playmark_state::bigtwin_get_fg_tile_info)
+TILE_GET_INFO_MEMBER(bigtwin_state::bigtwin_get_fg_tile_info)
 {
-	u16 code = m_fgvideoram[2 * tile_index];
-	u16 color = m_fgvideoram[2 * tile_index + 1];
+	const u16 code = m_fgvideoram[2 * tile_index];
+	const u16 color = m_fgvideoram[2 * tile_index + 1];
+
 	tileinfo.set(1, code, color, 0);
 }
 
 
-TILE_GET_INFO_MEMBER(playmark_state::wbeachvl_get_tx_tile_info)
+TILE_GET_INFO_MEMBER(wbeachvl_state::get_tx_tile_info)
 {
-	u16 code = m_txtvideoram[2 * tile_index];
-	u16 color = m_txtvideoram[2 * tile_index + 1];
+	const u16 code = m_txtvideoram[2 * tile_index];
+	const u16 color = m_txtvideoram[2 * tile_index + 1];
 
 	tileinfo.set(2, code, (color >> 2), 0);
 }
 
-TILE_GET_INFO_MEMBER(playmark_state::wbeachvl_get_fg_tile_info)
+TILE_GET_INFO_MEMBER(wbeachvl_state::get_fg_tile_info)
 {
-	u16 code = m_fgvideoram[2 * tile_index];
-	u16 color = m_fgvideoram[2 * tile_index + 1];
+	const u16 code = m_fgvideoram[2 * tile_index];
+	const u16 color = m_fgvideoram[2 * tile_index + 1];
 
-	tileinfo.set(1, (code & 0x7fff), (color >> 2) + 8, (code & 0x8000) ? TILE_FLIPX : 0);
+	tileinfo.set(1, (code & 0x7fff), (color >> 2) + 8, BIT(code, 15) ? TILE_FLIPX : 0);
 }
 
-TILE_GET_INFO_MEMBER(playmark_state::wbeachvl_get_bg_tile_info)
+TILE_GET_INFO_MEMBER(wbeachvl_state::get_bg_tile_info)
 {
-	u16 code = m_bgvideoram[2 * tile_index];
-	u16 color = m_bgvideoram[2 * tile_index + 1];
+	const u16 code = m_bgvideoram[2 * tile_index];
+	const u16 color = m_bgvideoram[2 * tile_index + 1];
 
-	tileinfo.set(1, (code & 0x7fff), (color >> 2), (code & 0x8000) ? TILE_FLIPX : 0);
+	tileinfo.set(1, (code & 0x7fff), (color >> 2), BIT(code, 15) ? TILE_FLIPX : 0);
 }
 
 
 TILE_GET_INFO_MEMBER(playmark_state::hrdtimes_get_tx_tile_info)
 {
-	int code = m_txtvideoram[tile_index] & 0x0fff;
-	int colr = m_txtvideoram[tile_index] & 0xe000;
+	const u16 code = m_txtvideoram[tile_index] & 0x0fff;
+	const u16 colr = m_txtvideoram[tile_index] & 0xe000;
 
 	tileinfo.set(3, code, (colr >> 13), 0);
 }
 
 TILE_GET_INFO_MEMBER(playmark_state::hrdtimes_get_fg_tile_info)
 {
-	int code = m_fgvideoram[tile_index] & 0x1fff;
-	int colr = m_fgvideoram[tile_index] & 0xe000;
+	const u16 code = m_fgvideoram[tile_index] & 0x1fff;
+	const u16 colr = m_fgvideoram[tile_index] & 0xe000;
 
 	tileinfo.set(2, code, (colr >> 13) + 8, 0);
 }
 
 TILE_GET_INFO_MEMBER(playmark_state::hrdtimes_get_bg_tile_info)
 {
-	int code = m_bgvideoram[tile_index] & 0x1fff;
-	int colr = m_bgvideoram[tile_index] & 0xe000;
+	const u16 code = m_bgvideoram[tile_index] & 0x1fff;
+	const u16 colr = m_bgvideoram[tile_index] & 0xe000;
 
 	tileinfo.set(1, code, (colr >> 13), 0);
 }
@@ -78,8 +80,8 @@ TILE_GET_INFO_MEMBER(playmark_state::hrdtimes_get_bg_tile_info)
 
 TILE_GET_INFO_MEMBER(playmark_state::bigtwinb_get_tx_tile_info)
 {
-	int code = m_txtvideoram[tile_index] & 0x0fff;
-	int colr = m_txtvideoram[tile_index] & 0xf000;
+	const u16 code = m_txtvideoram[tile_index] & 0x0fff;
+	const u16 colr = m_txtvideoram[tile_index] & 0xf000;
 
 	tileinfo.set(3, code, (colr >> 12), 0);
 }
@@ -90,10 +92,21 @@ TILE_GET_INFO_MEMBER(playmark_state::bigtwinb_get_tx_tile_info)
 
 ***************************************************************************/
 
-VIDEO_START_MEMBER(playmark_state,bigtwin)
+void bigtwin_state::init_bitmap()
 {
-	m_tx_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(playmark_state::bigtwin_get_tx_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 64, 32);
-	m_fg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(playmark_state::bigtwin_get_fg_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
+	m_bg_bitmap.fill(0x100);
+
+	save_item(NAME(m_bg_bitmap));
+	save_item(NAME(m_bgscrollx));
+	save_item(NAME(m_bgscrolly));
+	save_item(NAME(m_bg_enable));
+	save_item(NAME(m_bg_full_size));
+}
+
+VIDEO_START_MEMBER(bigtwin_state,bigtwin)
+{
+	m_tx_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(bigtwin_state::bigtwin_get_tx_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 64, 32);
+	m_fg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(bigtwin_state::bigtwin_get_fg_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
 
 	m_tx_tilemap->set_transparent_pen(0);
 
@@ -103,6 +116,8 @@ VIDEO_START_MEMBER(playmark_state,bigtwin)
 	m_pri_masks[0] = 0;
 	m_pri_masks[1] = 0;
 	m_pri_masks[2] = 0;
+
+	init_bitmap();
 }
 
 
@@ -126,11 +141,11 @@ VIDEO_START_MEMBER(playmark_state,bigtwinb)
 }
 
 
-VIDEO_START_MEMBER(playmark_state,wbeachvl)
+void wbeachvl_state::video_start()
 {
-	m_tx_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(playmark_state::wbeachvl_get_tx_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 64, 32);
-	m_fg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(playmark_state::wbeachvl_get_fg_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
-	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(playmark_state::wbeachvl_get_bg_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
+	m_tx_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(wbeachvl_state::get_tx_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 64, 32);
+	m_fg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(wbeachvl_state::get_fg_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
+	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(wbeachvl_state::get_bg_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 64, 32);
 
 	m_tx_tilemap->set_transparent_pen(0);
 	m_fg_tilemap->set_transparent_pen(0);
@@ -141,12 +156,15 @@ VIDEO_START_MEMBER(playmark_state,wbeachvl)
 	m_pri_masks[0] = 0xfff0;
 	m_pri_masks[1] = 0xfffc;
 	m_pri_masks[2] = 0;
+
+	save_item(NAME(m_fgscrollx));
+	save_item(NAME(m_fg_rowscroll_enable));
 }
 
-VIDEO_START_MEMBER(playmark_state,excelsr)
+VIDEO_START_MEMBER(bigtwin_state,excelsr)
 {
-	m_tx_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(playmark_state::bigtwin_get_tx_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
-	m_fg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(playmark_state::bigtwin_get_fg_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
+	m_tx_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(bigtwin_state::bigtwin_get_tx_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
+	m_fg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(bigtwin_state::bigtwin_get_fg_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
 
 	m_tx_tilemap->set_transparent_pen(0);
 
@@ -156,6 +174,8 @@ VIDEO_START_MEMBER(playmark_state,excelsr)
 	m_pri_masks[0] = 0;
 	m_pri_masks[1] = 0xfffc;
 	m_pri_masks[2] = 0xfff0;
+
+	init_bitmap();
 }
 
 VIDEO_START_MEMBER(playmark_state,hotmind)
@@ -188,7 +208,7 @@ VIDEO_START_MEMBER(playmark_state,luckboomh)
 	m_tx_tilemap->set_transparent_pen(0);
 	m_fg_tilemap->set_transparent_pen(0);
 
-	m_tx_tilemap->set_scrolldx( -9,  -9);
+	m_tx_tilemap->set_scrolldx(-9,  -9);
 	m_fg_tilemap->set_scrolldx(-11, -11);
 	m_bg_tilemap->set_scrolldx(-13, -13);
 
@@ -203,12 +223,12 @@ VIDEO_START_MEMBER(playmark_state,luckboomh)
 
 
 // Hard Times level 2-4 boss(truck) needs this.. or something similar.
-#define TILES_PER_PAGE_Y    (0x20)
-#define TILES_PER_PAGE_X    (0x20)
-#define PAGES_PER_TMAP_Y    (0x1)
-#define PAGES_PER_TMAP_X    (0x4)
+static constexpr int TILES_PER_PAGE_Y = 0x20;
+static constexpr int TILES_PER_PAGE_X = 0x20;
+static constexpr int PAGES_PER_TMAP_Y = 0x1;
+static constexpr int PAGES_PER_TMAP_X = 0x4;
 
-TILEMAP_MAPPER_MEMBER(playmark_state::playmark_tilemap_scan_pages)
+TILEMAP_MAPPER_MEMBER(playmark_state::hrdtimes_tilemap_scan_pages)
 {
 	return  (col / TILES_PER_PAGE_X) * TILES_PER_PAGE_Y * TILES_PER_PAGE_X * PAGES_PER_TMAP_Y +
 			(col % TILES_PER_PAGE_X) +
@@ -222,7 +242,7 @@ TILEMAP_MAPPER_MEMBER(playmark_state::playmark_tilemap_scan_pages)
 VIDEO_START_MEMBER(playmark_state,hrdtimes)
 {
 	m_tx_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(playmark_state::hrdtimes_get_tx_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 64, 64);
-	m_fg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(playmark_state::hrdtimes_get_fg_tile_info)), tilemap_mapper_delegate(*this, FUNC(playmark_state::playmark_tilemap_scan_pages)), 16, 16, 128, 32);
+	m_fg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(playmark_state::hrdtimes_get_fg_tile_info)), tilemap_mapper_delegate(*this, FUNC(playmark_state::hrdtimes_tilemap_scan_pages)), 16, 16, 128, 32);
 	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(playmark_state::hrdtimes_get_bg_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
 
 	m_tx_tilemap->set_transparent_pen(0);
@@ -246,43 +266,15 @@ VIDEO_START_MEMBER(playmark_state,hrdtimes)
 
 ***************************************************************************/
 
-void playmark_state::wbeachvl_txvideoram_w(offs_t offset, u16 data, u16 mem_mask)
+void bigtwin_state::bitmap_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	COMBINE_DATA(&m_txtvideoram[offset]);
-	m_tx_tilemap->mark_tile_dirty(offset / 2);
+	data = COMBINE_DATA(&m_bgvideoram[offset]);
+	const u32 x = offset & 0x1ff;
+	const u32 y = (offset >> 9) & 0x1ff;
+	m_bg_bitmap.pix(y, x) = 0x100 | (data & 0xff);
 }
 
-void playmark_state::wbeachvl_fgvideoram_w(offs_t offset, u16 data, u16 mem_mask)
-{
-	COMBINE_DATA(&m_fgvideoram[offset]);
-	m_fg_tilemap->mark_tile_dirty(offset / 2);
-}
-
-void playmark_state::wbeachvl_bgvideoram_w(offs_t offset, u16 data, u16 mem_mask)
-{
-	COMBINE_DATA(&m_bgvideoram[offset]);
-	m_bg_tilemap->mark_tile_dirty(offset / 2);
-}
-
-void playmark_state::hrdtimes_txvideoram_w(offs_t offset, u16 data, u16 mem_mask)
-{
-	COMBINE_DATA(&m_txtvideoram[offset]);
-	m_tx_tilemap->mark_tile_dirty(offset);
-}
-
-void playmark_state::hrdtimes_fgvideoram_w(offs_t offset, u16 data, u16 mem_mask)
-{
-	COMBINE_DATA(&m_fgvideoram[offset]);
-	m_fg_tilemap->mark_tile_dirty(offset);
-}
-
-void playmark_state::hrdtimes_bgvideoram_w(offs_t offset, u16 data, u16 mem_mask)
-{
-	COMBINE_DATA(&m_bgvideoram[offset]);
-	m_bg_tilemap->mark_tile_dirty(offset);
-}
-
-void playmark_state::bigtwin_scroll_w(offs_t offset, u16 data, u16 mem_mask)
+void bigtwin_state::bigtwin_scroll_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	data = COMBINE_DATA(&m_scroll[offset]);
 
@@ -300,7 +292,7 @@ void playmark_state::bigtwin_scroll_w(offs_t offset, u16 data, u16 mem_mask)
 	}
 }
 
-void playmark_state::wbeachvl_scroll_w(offs_t offset, u16 data, u16 mem_mask)
+void wbeachvl_state::scroll_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	data = COMBINE_DATA(&m_scroll[offset]);
 
@@ -317,7 +309,7 @@ void playmark_state::wbeachvl_scroll_w(offs_t offset, u16 data, u16 mem_mask)
 	}
 }
 
-void playmark_state::excelsr_scroll_w(offs_t offset, u16 data, u16 mem_mask)
+void bigtwin_state::excelsr_scroll_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	data = COMBINE_DATA(&m_scroll[offset]);
 
@@ -356,14 +348,14 @@ void playmark_state::hrdtimes_scroll_w(offs_t offset, u16 data, u16 mem_mask)
 
 ***************************************************************************/
 
-void playmark_state::draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int codeshift )
+void playmark_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int codeshift)
 {
-	int offs, start_offset = m_spriteram.bytes() / 2 - 4;
-	int height = m_gfxdecode->gfx(0)->height();
-	int colordiv = m_gfxdecode->gfx(0)->granularity() / 16;
+	int start_offset = m_spriteram.bytes() / 2 - 4;
+	const int height = m_gfxdecode->gfx(0)->height();
+	const int colordiv = m_gfxdecode->gfx(0)->granularity() / 16;
 
 	// find the "end of list" to draw the sprites in reverse order
-	for (offs = 4; offs < m_spriteram.bytes() / 2; offs += 4)
+	for (int offs = 4; offs < m_spriteram.bytes() / 2; offs += 4)
 	{
 		if (m_spriteram[offs + 3 - 4] == 0x2000) // end of list marker
 		{
@@ -372,37 +364,37 @@ void playmark_state::draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, 
 		}
 	}
 
-	for (offs = start_offset; offs >= 4; offs -= 4)
+	for (int offs = start_offset; offs >= 4; offs -= 4)
 	{
 		int sy = m_spriteram[offs + 3 - 4];   // -4? what the... ???
 
-		int flipx = sy & 0x4000;
-		int sx = (m_spriteram[offs + 1] & 0x01ff) - 16 - 7;
+		const bool flipx = BIT(sy, 14);
+		const int sx = (m_spriteram[offs + 1] & 0x01ff) - 16 - 7;
 		sy = (256 - 8 - height - sy) & 0xff;
-		int code = m_spriteram[offs + 2] >> codeshift;
-		int color = ((m_spriteram[offs + 1] & 0x3e00) >> 9) / colordiv;
+		const int code = m_spriteram[offs + 2] >> codeshift;
+		const int color = ((m_spriteram[offs + 1] & 0x3e00) >> 9) / colordiv;
 		int pri = (m_spriteram[offs + 1] & 0x8000) >> 15;
 
-		if(!pri && (color & 0x0c) == 0x0c)
+		if (!pri && (color & 0x0c) == 0x0c)
 			pri = 2;
 
 		m_gfxdecode->gfx(0)->prio_transpen(bitmap,cliprect,
 					code,
 					color,
-					flipx,0,
-					sx + m_xoffset,sy + m_yoffset,
-					screen.priority(),m_pri_masks[pri],m_sprtranspen);
+					flipx, 0,
+					sx + m_xoffset, sy + m_yoffset,
+					screen.priority(), m_pri_masks[pri], m_sprtranspen);
 	}
 }
 
 
-void playmark_state::bigtwinb_draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int codeshift )
+void playmark_state::bigtwinb_draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	int offs, start_offset = m_spriteram.bytes() / 2 - 4;
-	int height = m_gfxdecode->gfx(0)->height();
+	int start_offset = m_spriteram.bytes() / 2 - 4;
+	const int height = m_gfxdecode->gfx(0)->height();
 
 	// find the "end of list" to draw the sprites in reverse order
-	for (offs = 4; offs < m_spriteram.bytes() / 2; offs += 4)
+	for (int offs = 4; offs < m_spriteram.bytes() / 2; offs += 4)
 	{
 		if (m_spriteram[offs + 3 - 4] == 0x2000) // end of list marker
 		{
@@ -411,61 +403,53 @@ void playmark_state::bigtwinb_draw_sprites( screen_device &screen, bitmap_ind16 
 		}
 	}
 
-	for (offs = start_offset; offs >= 4; offs -= 4)
+	for (int offs = start_offset; offs >= 4; offs -= 4)
 	{
 		int sy = m_spriteram[offs + 3 - 4];   // -4? what the... ???
 
-		int flipx = sy & 0x4000;
-		int sx = (m_spriteram[offs + 1] & 0x01ff) - 16 - 7;
+		const bool flipx = BIT(sy, 14);
+		const int sx = (m_spriteram[offs + 1] & 0x01ff) - 16 - 7;
 		sy = (256 - 8 - height - sy) & 0xff;
-		int code = m_spriteram[offs + 2] >> codeshift;
-		int color = ((m_spriteram[offs + 1] & 0xf000) >> 12);
+		const int code = m_spriteram[offs + 2] >> 4;
+		const int color = ((m_spriteram[offs + 1] & 0xf000) >> 12);
 
 		m_gfxdecode->gfx(0)->transpen(bitmap,cliprect,
 					code,
 					color,
-					flipx,0,
-					sx + m_xoffset,sy + m_yoffset, m_sprtranspen);
+					flipx, 0,
+					sx + m_xoffset, sy + m_yoffset, m_sprtranspen);
 	}
 }
 
-void playmark_state::draw_bitmap( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect )
+void bigtwin_state::draw_bitmap(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	int count = 0;
-	for (int y = 0; y < 512; y++)
+	const u8 shift = m_bg_full_size ? 0 : 1;
+	for (int y = cliprect.top(); y <= cliprect.bottom(); y++)
 	{
-		for (int x = 0; x < 512; x++)
+		const u32 srcy = ((y - m_bgscrolly) & 0x1ff) << shift;
+		if (srcy >= m_bg_bitmap.height())
+			continue;
+
+		u16 const *const srcline = &m_bg_bitmap.pix(srcy);
+		u16 *const dstline = &bitmap.pix(y);
+		u8 *const priline = &screen.priority().pix(y);
+		for (int x = cliprect.left(); x <= cliprect.right(); x++)
 		{
-			int const color = m_bgvideoram[count] & 0xff;
+			const u32 srcx = ((x - m_bgscrollx) & 0x1ff) << shift;
+			if (srcx >= m_bg_bitmap.width())
+				continue;
 
-			if (color)
+			const u16 pix = srcline[srcx];
+			if ((pix & 0xff) != 0)
 			{
-				if (m_bg_full_size)
-				{
-					bitmap.pix((y + m_bgscrolly) & 0x1ff, (x + m_bgscrollx) & 0x1ff) = 0x100 + color;
-
-					u8 *const pri = &screen.priority().pix((y + m_bgscrolly) & 0x1ff);
-					pri[(x + m_bgscrollx) & 0x1ff] |= 2;
-				}
-				else
-				{
-					// 50% size
-					if(!(x % 2) && !(y % 2))
-					{
-						bitmap.pix((y / 2 + m_bgscrolly) & 0x1ff, (x / 2 + m_bgscrollx) & 0x1ff) = 0x100 + color;
-
-						u8 *const pri = &screen.priority().pix((y / 2 + m_bgscrolly) & 0x1ff);
-						pri[(x / 2 + m_bgscrollx) & 0x1ff] |= 2;
-					}
-				}
+				dstline[x] = pix;
+				priline[x] |= 2;
 			}
-
-			count++;
 		}
 	}
 }
 
-u32 playmark_state::screen_update_bigtwin(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 bigtwin_state::screen_update_bigtwin(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen.priority().fill(0, cliprect);
 
@@ -481,11 +465,11 @@ u32 playmark_state::screen_update_bigtwin(screen_device &screen, bitmap_ind16 &b
 u32 playmark_state::screen_update_bigtwinb(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	// video enabled
-	if (m_scroll[6] & 1)
+	if (BIT(m_scroll[6], 0))
 	{
 		m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 		m_fg_tilemap->draw(screen, bitmap, cliprect, 0, 0);
-		bigtwinb_draw_sprites(screen, bitmap, cliprect, 4);
+		bigtwinb_draw_sprites(screen, bitmap, cliprect);
 		m_tx_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	}
 	else
@@ -493,7 +477,7 @@ u32 playmark_state::screen_update_bigtwinb(screen_device &screen, bitmap_ind16 &
 	return 0;
 }
 
-u32 playmark_state::screen_update_excelsr(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 bigtwin_state::screen_update_excelsr(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen.priority().fill(0, cliprect);
 
@@ -505,7 +489,7 @@ u32 playmark_state::screen_update_excelsr(screen_device &screen, bitmap_ind16 &b
 	return 0;
 }
 
-u32 playmark_state::screen_update_wbeachvl(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 wbeachvl_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	if (m_fg_rowscroll_enable)
 	{
@@ -533,7 +517,7 @@ u32 playmark_state::screen_update_hrdtimes(screen_device &screen, bitmap_ind16 &
 	screen.priority().fill(0, cliprect);
 
 	// video enabled
-	if (m_scroll[6] & 1)
+	if (BIT(m_scroll[6], 0))
 	{
 		m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 1);
 		m_fg_tilemap->draw(screen, bitmap, cliprect, 0, 2);

--- a/src/mame/playmark/powerbal.cpp
+++ b/src/mame/playmark/powerbal.cpp
@@ -19,11 +19,9 @@ Magic Sticks:
 #include "playmark.h"
 
 #include "cpu/m68000/m68000.h"
-#include "machine/eepromser.h"
-#include "sound/okim6295.h"
+
 #include "screen.h"
 #include "speaker.h"
-#include "tilemap.h"
 
 
 namespace {
@@ -33,6 +31,8 @@ class powerbal_state : public playmark_base_state
 public:
 	powerbal_state(const machine_config &mconfig, device_type type, const char *tag)
 		: playmark_base_state(mconfig, type, tag)
+		, m_tilebank(0)
+		, m_bg_yoffset(0)
 	{ }
 
 	void init_powerbal();
@@ -44,14 +44,14 @@ protected:
 	virtual void machine_reset() override ATTR_COLD;
 	virtual void video_start() override ATTR_COLD;
 
-	u8 m_tilebank = 0;
-	s8 m_bg_yoffset = 0;
+	u8 m_tilebank;
+	s8 m_bg_yoffset;
 
 	TILE_GET_INFO_MEMBER(get_bg_tile_info);
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void bgvideoram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void tile_banking_w(u16 data);
-	void oki_banking(u16 data);
+	void tile_bank_w(u16 data);
+	void oki_bank_w(u16 data);
 
 	void oki_map(address_map &map) ATTR_COLD;
 
@@ -74,7 +74,7 @@ protected:
 	virtual void video_start() override ATTR_COLD;
 
 private:
-	void tile_banking_w(u16 data);
+	void tile_bank_w(u16 data);
 
 	void main_map(address_map &map) ATTR_COLD;
 };
@@ -83,10 +83,10 @@ class magicstk_state : public powerbal_state
 {
 public:
 	magicstk_state(const machine_config &mconfig, device_type type, const char *tag)
-		: powerbal_state(mconfig, type, tag),
-		m_eeprom(*this, "eeprom"),
-		m_ticket(*this, "ticket"),
-		m_token(*this, "token")
+		: powerbal_state(mconfig, type, tag)
+		, m_eeprom(*this, "eeprom")
+		, m_ticket(*this, "ticket")
+		, m_token(*this, "token")
 	{ }
 
 	void init_magicstk();
@@ -105,11 +105,11 @@ private:
 
 void magicstk_state::coin_eeprom_w(u8 data)
 {
-	machine().bookkeeping().coin_counter_w(0, data & 0x20);
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 5));
 
-	m_eeprom->cs_write((data & 8) ? ASSERT_LINE : CLEAR_LINE);
-	m_eeprom->di_write((data & 2) >> 1);
-	m_eeprom->clk_write((data & 4) ? CLEAR_LINE : ASSERT_LINE);
+	m_eeprom->cs_write(BIT(data, 3) ? ASSERT_LINE : CLEAR_LINE);
+	m_eeprom->di_write(BIT(data, 1));
+	m_eeprom->clk_write(BIT(data, 2) ? CLEAR_LINE : ASSERT_LINE);
 }
 
 void powerbal_state::bgvideoram_w(offs_t offset, u16 data, u16 mem_mask)
@@ -118,7 +118,7 @@ void powerbal_state::bgvideoram_w(offs_t offset, u16 data, u16 mem_mask)
 	m_bg_tilemap->mark_tile_dirty(offset);
 }
 
-void powerbal_state::tile_banking_w(u16 data)
+void powerbal_state::tile_bank_w(u16 data)
 {
 	if (((data >> 12) & 0x0f) != m_tilebank)
 	{
@@ -127,7 +127,7 @@ void powerbal_state::tile_banking_w(u16 data)
 	}
 }
 
-void atombjt_state::tile_banking_w(u16 data)
+void atombjt_state::tile_bank_w(u16 data)
 {
 	if ((data & 0x0f) != m_tilebank)
 	{
@@ -136,9 +136,9 @@ void atombjt_state::tile_banking_w(u16 data)
 	}
 }
 
-void powerbal_state::oki_banking(u16 data)
+void powerbal_state::oki_bank_w(u16 data)
 {
-	int bank = data & 3;
+	const int bank = data & 3;
 	m_okibank->set_entry(bank & (m_oki_numbanks - 1));
 }
 
@@ -148,7 +148,7 @@ void magicstk_state::main_map(address_map &map)
 	map(0x088000, 0x0883ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x094000, 0x094001).nopw();
 	map(0x094002, 0x094003).nopw();
-	map(0x094004, 0x094005).w(FUNC(magicstk_state::tile_banking_w));
+	map(0x094004, 0x094005).w(FUNC(magicstk_state::tile_bank_w));
 	map(0x098180, 0x09917f).ram().w(FUNC(magicstk_state::bgvideoram_w)).share(m_bgvideoram);
 	map(0x0c2010, 0x0c2011).portr("IN0");
 	map(0x0c2012, 0x0c2013).portr("IN1");
@@ -156,7 +156,7 @@ void magicstk_state::main_map(address_map &map)
 	map(0x0c2015, 0x0c2015).w(FUNC(magicstk_state::coin_eeprom_w));
 	map(0x0c2016, 0x0c2017).portr("DSW1");
 	map(0x0c2018, 0x0c2019).portr("DSW2");
-	map(0x0c201c, 0x0c201d).w(FUNC(magicstk_state::oki_banking));
+	map(0x0c201c, 0x0c201d).w(FUNC(magicstk_state::oki_bank_w));
 	map(0x0c201f, 0x0c201f).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0x0c4000, 0x0c4001).nopw();
 	map(0x0e0000, 0x0fffff).ram();
@@ -169,7 +169,7 @@ void powerbal_state::main_map(address_map &map)
 	map(0x088000, 0x0883ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x094000, 0x094001).nopw();
 	map(0x094002, 0x094003).nopw();
-	map(0x094004, 0x094005).w(FUNC(powerbal_state::tile_banking_w));
+	map(0x094004, 0x094005).w(FUNC(powerbal_state::tile_bank_w));
 	map(0x098000, 0x098fff).ram().w(FUNC(powerbal_state::bgvideoram_w)).share(m_bgvideoram);
 	map(0x099000, 0x09bfff).ram(); // not used
 	map(0x0c2010, 0x0c2011).portr("IN0");
@@ -177,7 +177,7 @@ void powerbal_state::main_map(address_map &map)
 	map(0x0c2014, 0x0c2015).portr("IN2");
 	map(0x0c2016, 0x0c2017).portr("DSW1");
 	map(0x0c2018, 0x0c2019).portr("DSW2");
-	map(0x0c201c, 0x0c201d).w(FUNC(powerbal_state::oki_banking));
+	map(0x0c201c, 0x0c201d).w(FUNC(powerbal_state::oki_bank_w));
 	map(0x0c201f, 0x0c201f).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0x0c4000, 0x0c4001).nopw();
 	map(0x0f0000, 0x0fffff).ram();
@@ -192,7 +192,7 @@ void atombjt_state::main_map(address_map &map)
 	map(0x080008, 0x080009).nopr(); // remnant of the original?
 	map(0x080014, 0x080015).noprw(); // always 1 in this bootleg. Flip-screen switch not present according to dip sheet.
 	map(0x088000, 0x0883ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
-	map(0x094000, 0x094001).w(FUNC(atombjt_state::tile_banking_w));
+	map(0x094000, 0x094001).w(FUNC(atombjt_state::tile_bank_w));
 	map(0x094002, 0x094003).noprw();    // IRQ enable?
 	map(0x09c000, 0x09cfff).mirror(0x1000).ram().w(FUNC(atombjt_state::bgvideoram_w)).share(m_bgvideoram);
 	map(0x0c2010, 0x0c2011).portr("IN0");
@@ -200,7 +200,7 @@ void atombjt_state::main_map(address_map &map)
 	map(0x0c2014, 0x0c2015).portr("IN2");
 	map(0x0c2016, 0x0c2017).portr("DSW1");
 	map(0x0c2018, 0x0c2019).portr("DSW2");
-	map(0x0c201c, 0x0c201d).w(FUNC(atombjt_state::oki_banking));
+	map(0x0c201c, 0x0c201d).w(FUNC(atombjt_state::oki_bank_w));
 	map(0x0c201f, 0x0c201f).rw(m_oki, FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 	map(0x0c4000, 0x0c4001).nopw(); // always 0?
 	map(0x0f0000, 0x0fffff).ram();
@@ -558,10 +558,10 @@ INPUT_PORTS_END
 
 TILE_GET_INFO_MEMBER(powerbal_state::get_bg_tile_info)
 {
-	int code = (m_bgvideoram[tile_index] & 0x07ff) + m_tilebank * 0x800;
-	int colr = m_bgvideoram[tile_index] & 0xf000;
+	u32 code = (m_bgvideoram[tile_index] & 0x07ff) | (m_tilebank << 11);
+	const u16 colr = m_bgvideoram[tile_index] & 0xf000;
 
-	if (m_bgvideoram[tile_index] & 0x800)
+	if (BIT(m_bgvideoram[tile_index], 11))
 		code |= 0x8000;
 
 	tileinfo.set(1, code, colr >> 12, 0);
@@ -569,24 +569,24 @@ TILE_GET_INFO_MEMBER(powerbal_state::get_bg_tile_info)
 
 void powerbal_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	int height = m_gfxdecode->gfx(0)->height();
+	const int height = m_gfxdecode->gfx(0)->height();
 
 	for (int offs = 4; offs < m_spriteram.bytes() / 2; offs += 4)
 	{
 		int sy = m_spriteram[offs + 3 - 4];   // typical Playmark style...
-		if (sy & 0x8000)
+		if (BIT(sy, 15))
 			return; // end of list marker
 
-		int flipx = sy & 0x4000;
-		int sx = (m_spriteram[offs + 1] & 0x01ff) - 16 - 7;
+		const bool flipx = BIT(sy, 14);
+		const int sx = (m_spriteram[offs + 1] & 0x01ff) - 16 - 7;
 		sy = (256 - 8 - height - sy) & 0xff;
-		int code = m_spriteram[offs + 2];
-		int color = (m_spriteram[offs + 1] & 0xf000) >> 12;
+		const int code = m_spriteram[offs + 2];
+		const int color = (m_spriteram[offs + 1] & 0xf000) >> 12;
 
 		m_gfxdecode->gfx(0)->transpen(bitmap, cliprect,
 				code,
 				color,
-				flipx,0,
+				flipx, 0,
 				sx + m_xoffset, sy + m_yoffset, m_sprtranspen);
 	}
 }
@@ -634,8 +634,8 @@ static const gfx_layout tilelayout =
 
 
 static GFXDECODE_START( gfx_powerbal )
-	GFXDECODE_ENTRY( "gfx2", 0, tilelayout,          0x100, 16 )    // colors 0x100-0x1ff
-	GFXDECODE_ENTRY( "gfx1", 0, gfx_8x8x4_planar,    0x000, 16 )    // colors 0x000-0x0ff
+	GFXDECODE_ENTRY( "sprites", 0, tilelayout,       0x100, 16 )    // colors 0x100-0x1ff
+	GFXDECODE_ENTRY( "tiles",   0, gfx_8x8x4_planar, 0x000, 16 )    // colors 0x000-0x0ff
 GFXDECODE_END
 
 
@@ -775,13 +775,13 @@ ROM_START( powerbal )
 	ROM_LOAD16_BYTE( "3.u67",  0x00000, 0x40000, CRC(3aecdde4) SHA1(e78373246d55f120e8d94f4606da874df439b823) )
 	ROM_LOAD16_BYTE( "2.u66",  0x00001, 0x40000, CRC(a4552a19) SHA1(88b84daa1fd36d5c683cf0d6dce341aedbc360d1) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD( "4.u38",        0x000000, 0x80000, CRC(a60aa981) SHA1(46a5d2d2a353a45127a03a104e877ffd150daa92) )
 	ROM_LOAD( "5.u42",        0x080000, 0x80000, CRC(966c71df) SHA1(daf4bcf3d2ef10ea9a5e2e7ea71b3783b9f5b1f0) )
 	ROM_LOAD( "6.u39",        0x100000, 0x80000, CRC(668957b9) SHA1(31fc9328ff6044e17834b6d61a886a8ef2e6570c) )
 	ROM_LOAD( "7.u45",        0x180000, 0x80000, CRC(f5721c66) SHA1(1e8b3a8e82da60378dad7727af21157c4059b071) )
 
-	ROM_REGION( 0x200000, "gfx2", 0 )
+	ROM_REGION( 0x200000, "sprites", 0 )
 	ROM_LOAD( "8.u86",        0x000000, 0x80000, CRC(4130694c) SHA1(581d0035ce1624568f635bd79290be6c587a2533) )
 	ROM_LOAD( "9.u85",        0x080000, 0x80000, CRC(e7bcd2e7) SHA1(01a5e5ac5da2fd79a0c9088f775096b9915bae92) )
 	ROM_LOAD( "10.u84",       0x100000, 0x80000, CRC(90412135) SHA1(499619c72613a1dd63a6504e39b159a18a71f4fa) )
@@ -804,13 +804,13 @@ ROM_START( magicstk )
 	ROM_LOAD16_BYTE( "12.u67", 0x00000, 0x20000, CRC(70a9c66f) SHA1(0cf4b2d0f796e35881d68adc69eca4360d6ad693) )
 	ROM_LOAD16_BYTE( "11.u66", 0x00001, 0x20000, CRC(a9d7c90e) SHA1(e12517776dc14747b4bbe49f93c4d7e83e8eae01) )
 
-	ROM_REGION( 0x80000, "gfx1", 0 )
+	ROM_REGION( 0x80000, "tiles", 0 )
 	ROM_LOAD( "13.u36",       0x00000, 0x20000, CRC(31e52562) SHA1(18ee5ba990d97690ece81e4066a9f0395ddc6f3e) )
 	ROM_LOAD( "14.u42",       0x20000, 0x20000, CRC(b0d35eda) SHA1(a85d45d3b4fbacecf5aa2af9a18ba0ac9f1f9a26) )
 	ROM_LOAD( "15.u39",       0x40000, 0x20000, CRC(af27004b) SHA1(b022020e6bd6fc9ec95f23b6a37911df0768856e) )
 	ROM_LOAD( "16.u45",       0x60000, 0x20000, CRC(0c980db3) SHA1(212129bf86cdc73752be184e579299e03ba6862e) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )
+	ROM_REGION( 0x80000, "sprites", 0 )
 	ROM_LOAD( "17.u86",       0x00000, 0x20000, CRC(ce238006) SHA1(3425a8125d56139fe5d220b0d9d5c9a4af1f4d58) )
 	ROM_LOAD( "18.u85",       0x20000, 0x20000, CRC(3dc88bf6) SHA1(f9c04bca32bae4aa6df38635d73c6a4b8742fbd3) )
 	ROM_LOAD( "19.u84",       0x40000, 0x20000, CRC(ee12d5b2) SHA1(872edff5a35d2725e3dd752a5f609aca995bfeff) )
@@ -831,13 +831,13 @@ ROM_START( hotminda )
 	ROM_LOAD16_BYTE( "rom1.rom",       0x00001, 0x20000, CRC(33aaceba) SHA1(a914400b081eabd869f1ca2c843a91b03af510b1) )
 	ROM_LOAD16_BYTE( "rom2.rom",       0x00000, 0x20000, CRC(f5accd9f) SHA1(12194ea7c35263be9afd91f0abe2041998528af9) )
 
-	ROM_REGION( 0x80000, "gfx1", 0 )
+	ROM_REGION( 0x80000, "tiles", 0 )
 	ROM_LOAD( "rom13.rom",       0x00000, 0x20000, CRC(18d22109) SHA1(52bbb68f4ef5f4d41f5915bef4304784451ca6d8) )
 	ROM_LOAD( "rom14.rom",       0x20000, 0x20000, CRC(f95a1ff6) SHA1(646c59199570ccd11cb53b0b59a6cd03b1b42fac) )
 	ROM_LOAD( "rom15.rom",       0x40000, 0x20000, CRC(8a9ea7ed) SHA1(529c0466df3f0aa050526699099ea7a5da9dbcfe) )
 	ROM_LOAD( "rom16.rom",       0x60000, 0x20000, CRC(df63b642) SHA1(d5df740717193b06267508d169bb5df6214ca13d))
 
-	ROM_REGION( 0x80000, "gfx2", 0 )
+	ROM_REGION( 0x80000, "sprites", 0 )
 	ROM_LOAD( "rom17.rom",       0x00000, 0x20000, CRC(805002cf) SHA1(dc97881bc78dcb753f404b7df2cfd4a071ca8393) )
 	ROM_LOAD( "rom18.rom",       0x20000, 0x20000, CRC(6a9d896b) SHA1(d617a69e6954de3bf7c322529232eadb90034fbc) )
 	ROM_LOAD( "rom19.rom",       0x40000, 0x20000, CRC(223ad90f) SHA1(57b4e364f21aeea24a99deb6bab13019846e8f9b) )
@@ -853,13 +853,13 @@ ROM_START( hotmindb ) // possible bug fix version of the above? Just a couple of
 	ROM_LOAD16_BYTE( "1.u66", 0x00001, 0x20000, CRC(24b1a1df) SHA1(8e909a2a4b9c64ddb845c9102e8f5b70513ed9cf) ) // red dot on the label
 	ROM_LOAD16_BYTE( "2.u77", 0x00000, 0x20000, CRC(f5accd9f) SHA1(12194ea7c35263be9afd91f0abe2041998528af9) ) // red dot on the label
 
-	ROM_REGION( 0x80000, "gfx1", 0 )
+	ROM_REGION( 0x80000, "tiles", 0 )
 	ROM_LOAD( "13.u36", 0x00000, 0x20000, CRC(18d22109) SHA1(52bbb68f4ef5f4d41f5915bef4304784451ca6d8) )
 	ROM_LOAD( "14.u42", 0x20000, 0x20000, CRC(f95a1ff6) SHA1(646c59199570ccd11cb53b0b59a6cd03b1b42fac) )
 	ROM_LOAD( "15.u39", 0x40000, 0x20000, CRC(8a9ea7ed) SHA1(529c0466df3f0aa050526699099ea7a5da9dbcfe) )
 	ROM_LOAD( "16.u45", 0x60000, 0x20000, CRC(df63b642) SHA1(d5df740717193b06267508d169bb5df6214ca13d))
 
-	ROM_REGION( 0x80000, "gfx2", 0 )
+	ROM_REGION( 0x80000, "sprites", 0 )
 	ROM_LOAD( "17.u86", 0x00000, 0x20000, CRC(805002cf) SHA1(dc97881bc78dcb753f404b7df2cfd4a071ca8393) )
 	ROM_LOAD( "18.u85", 0x20000, 0x20000, CRC(6a9d896b) SHA1(d617a69e6954de3bf7c322529232eadb90034fbc) )
 	ROM_LOAD( "19.u84", 0x40000, 0x20000, CRC(223ad90f) SHA1(57b4e364f21aeea24a99deb6bab13019846e8f9b) )
@@ -875,13 +875,13 @@ ROM_START( atombjt ) // based off bjtwina set
 	ROM_LOAD16_BYTE( "22.u67",  0x00000, 0x20000, CRC(bead8c70) SHA1(2694bb0639f6b94119c21faf3810f00ef20b50da) )
 	ROM_LOAD16_BYTE( "21.u66",  0x00001, 0x20000, CRC(73e3d488) SHA1(7deed6e3aeda1902b75746a9b0a2737632425867) )
 
-	ROM_REGION( 0x200000, "gfx1", 0 )
+	ROM_REGION( 0x200000, "tiles", 0 )
 	ROM_LOAD( "23.u36",  0x000000, 0x80000, CRC(a3fb6b91) SHA1(477f5722a6bb23f089f32b677efbf69e9dce4b74) )
 	ROM_LOAD( "24.u42",  0x080000, 0x80000, CRC(4c30e15f) SHA1(f92185743594e4e4573ac3f6c0c091802a08d5bd) )
 	ROM_LOAD( "25.u39",  0x100000, 0x80000, CRC(ff1af60f) SHA1(4fe626c9d59ab9b945535b2f796f13adc900f1ed) )
 	ROM_LOAD( "26.u45",  0x180000, 0x80000, CRC(6cc4e817) SHA1(70f2ab50e228a029d3157c94fe0a79e7aad010bd) )
 
-	ROM_REGION( 0x100000, "gfx2", 0 )
+	ROM_REGION( 0x100000, "sprites", 0 )
 	ROM_LOAD( "27.u86",  0x000000, 0x40000, CRC(5a853e5c) SHA1(dfa4e891f716bbf8a038a14a24276cb690f65230) )
 	ROM_LOAD( "28.u85",  0x040000, 0x40000, CRC(41970bf6) SHA1(85b5677585dbdf96acabb59e6369d62d4c2f0e8e) )
 	ROM_LOAD( "29.u84",  0x080000, 0x40000, CRC(59a7d610) SHA1(0dc39c09f7f55dbd12ddb5e2e4ba9d86a2ba24d8) )

--- a/src/mame/playmark/sderby.cpp
+++ b/src/mame/playmark/sderby.cpp
@@ -187,8 +187,8 @@ private:
 
 TILE_GET_INFO_MEMBER(sderby_state::get_bg_tile_info)
 {
-	int tileno = m_bg_videoram[tile_index * 2];
-	int colour = m_bg_videoram[tile_index * 2 + 1] & 0x0f;
+	const u32 tileno = m_bg_videoram[tile_index * 2];
+	const u32 colour = m_bg_videoram[tile_index * 2 + 1] & 0x0f;
 
 	tileinfo.set(1, tileno, colour, 0);
 }
@@ -202,8 +202,8 @@ void sderby_state::bg_videoram_w(offs_t offset, uint16_t data, uint16_t mem_mask
 
 TILE_GET_INFO_MEMBER(sderby_state::get_md_tile_info)
 {
-	int tileno = m_md_videoram[tile_index * 2];
-	int colour = m_md_videoram[tile_index * 2 + 1] & 0x0f;
+	const u32 tileno = m_md_videoram[tile_index * 2];
+	const u32 colour = m_md_videoram[tile_index * 2 + 1] & 0x0f;
 
 	tileinfo.set(1, tileno, colour + 16, 0);
 }
@@ -217,16 +217,16 @@ void sderby_state::md_videoram_w(offs_t offset, uint16_t data, uint16_t mem_mask
 
 TILE_GET_INFO_MEMBER(sderby_state::get_fg_tile_info)
 {
-	int tileno = m_fg_videoram[tile_index * 2];
-	int colour = m_fg_videoram[tile_index * 2 + 1] & 0x0f;
+	const u32 tileno = m_fg_videoram[tile_index * 2];
+	const u32 colour = m_fg_videoram[tile_index * 2 + 1] & 0x0f;
 
 	tileinfo.set(0, tileno, colour + 32, 0);
 }
 
 TILE_GET_INFO_MEMBER(zw3_state::get_fg_tile_info)
 {
-	int tileno = (m_fg_videoram[tile_index * 2] << 2) | ((m_fg_videoram[tile_index * 2 + 1] & 0xc000) >> 14);
-	int colour = m_fg_videoram[tile_index * 2 + 1] & 0x0f;
+	const u32 tileno = (m_fg_videoram[tile_index * 2] << 2) | ((m_fg_videoram[tile_index * 2 + 1] & 0xc000) >> 14);
+	const u32 colour = m_fg_videoram[tile_index * 2 + 1] & 0x0f;
 
 	tileinfo.set(0, tileno, colour + 32, 0);
 }
@@ -240,19 +240,19 @@ void sderby_state::fg_videoram_w(offs_t offset, uint16_t data, uint16_t mem_mask
 
 void sderby_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	int height = m_gfxdecode->gfx(0)->height();
-	int colordiv = m_gfxdecode->gfx(0)->granularity() / 16;
+	const int height = m_gfxdecode->gfx(0)->height();
+	const int colordiv = m_gfxdecode->gfx(0)->granularity() / 16;
 
 	for (int offs = 4; offs < m_spriteram.bytes() / 2; offs += 4)
 	{
 		int sy = m_spriteram[offs + 3 - 4]; // -4? what the... ???
 		if (sy == 0x2000) return;   // end of list marker
 
-		int flipx = sy & 0x4000;
-		int sx = (m_spriteram[offs + 1] & 0x01ff) - 16 - m_sprites_x_kludge;
+		const bool flipx = BIT(sy, 14);
+		const int sx = (m_spriteram[offs + 1] & 0x01ff) - 16 - m_sprites_x_kludge;
 		sy = (256 - m_sprites_y_kludge - height - sy) & 0xff;
-		int code = m_spriteram[offs + 2];
-		int color = (m_spriteram[offs + 1] & 0x3e00) >> 9;
+		const int code = m_spriteram[offs + 2];
+		const int color = (m_spriteram[offs + 1] & 0x3e00) >> 9;
 
 		m_gfxdecode->gfx(1)->transpen(bitmap, cliprect,
 				code,
@@ -345,7 +345,8 @@ uint16_t sderby_state::input_r(offs_t offset)
 			return 0xffff;          // to avoid game to reset (needs more work)
 	}
 
-	LOGINPUTS("input_r : offset = %x - PC = %06x\n", offset * 2, m_maincpu->pc());
+	if (!machine().side_effects_disabled())
+		LOGINPUTS("%s: input_r : offset = %x - PC = %06x\n", machine().describe_context(), offset * 2, m_maincpu->pc());
 
 	return 0xffff;
 }
@@ -389,7 +390,8 @@ uint16_t sderby_state::roulette_input_r(offs_t offset)
 
 uint16_t sderby_state::rprot_r()
 {
-	LOGCROUPIERMCU("rprot_r : offset = %02x\n", m_maincpu->pc());
+	if (!machine().side_effects_disabled())
+		LOGCROUPIERMCU("%s: rprot_r : offset = %02x\n", machine().describe_context(), m_maincpu->pc());
 
 /* This is the only mask I found that allow a normal play.
    Using other values, the game hangs waiting for response,
@@ -451,7 +453,7 @@ void sderby_state::sderby_out_w(uint16_t data)
 	m_lamps[1] = BIT(data, 1);      // Lamp 2 - BET
 	m_lamps[2] = BIT(data, 15);     // Lamp 3 - END OF RACE
 
-	machine().bookkeeping().coin_counter_w(0, data & 0x2000);
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 13));
 }
 
 
@@ -500,7 +502,7 @@ void sderby_state::scmatto_out_w(uint16_t data)
 	m_lamps[5] = BIT(data, 5);      // Lamp 6 - START
 	m_lamps[6] = BIT(data, 6);      // Lamp 7 - BET
 
-	machine().bookkeeping().coin_counter_w(0, data & 0x2000);
+	machine().bookkeeping().coin_counter_w(0, BIT(data, 13));
 }
 
 


### PR DESCRIPTION
- Split driver state class per hardware configuration
- Add side effect checks for debugger reads
- Use BIT helper for single bit values
- Fix loggings
- Reduce duplicated functions and includes
- Use generic_latch_8_device for sound command port
- Fix namings
- Make some variables constant
- Fix typename values for consistency
- Restrict bitmap draw routine with cliprect
- Reduce preprocessor defines
- Fix spacings
- Fix initializers