### PR TITLE
apple2video: fix ivelultr/dodo/laser2c text rendering

### DIFF
--- a/src/mame/apple/apple2video.cpp
+++ b/src/mame/apple/apple2video.cpp
@@ -655,7 +655,7 @@ unsigned a2_video_device::get_text_character(uint32_t code, int row)
 
 	/* look up the character data */
 	unsigned bits = m_char_ptr[code * 8 + row];
-	bits = ((Model == model::IVEL_ULTRA && Invert && !Flip) || Model == model::DODO) ? (bits >> 1) : (bits & 0x7f);
+	bits = (Model == model::IVEL_ULTRA || Model == model::DODO) ? ((bits >> 2) | ((bits & 2) << 5)) : (bits & 0x7f);
 	bits ^= invert_mask;
 	return Flip ? reverse_7_bits[bits] : bits;
 }
@@ -803,17 +803,16 @@ void a2_video_device::text_update(screen_device &screen, bitmap_ind16 &bitmap, c
 
 // explicit instantiations
 template void a2_video_device::text_update<a2_video_device::model::II, true, true>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
-template void a2_video_device::text_update<a2_video_device::model::II, true, false>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
 template void a2_video_device::text_update<a2_video_device::model::II, false, true>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
-template void a2_video_device::text_update<a2_video_device::model::II, false, false>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
 template void a2_video_device::text_update<a2_video_device::model::IIE, true, true>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
 template void a2_video_device::text_update<a2_video_device::model::IIE, true, false>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
 template void a2_video_device::text_update<a2_video_device::model::IIE, false, true>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
 template void a2_video_device::text_update<a2_video_device::model::IIE, false, false>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
-template void a2_video_device::text_update<a2_video_device::model::IIGS, false, false>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
+template void a2_video_device::text_update<a2_video_device::model::PRAVETZ_8C, false, false>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
+template void a2_video_device::text_update<a2_video_device::model::IIGS, true, false>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
 template void a2_video_device::text_update<a2_video_device::model::II_J_PLUS, true, true>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
 template void a2_video_device::text_update<a2_video_device::model::IVEL_ULTRA, true, false>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
-template void a2_video_device::text_update<a2_video_device::model::IVEL_ULTRA, false, true>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
+template void a2_video_device::text_update<a2_video_device::model::DODO, true, false>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
 
 void a2_video_device::hgr_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow)
 {
@@ -1219,9 +1218,7 @@ uint32_t a2_video_device::screen_update(screen_device &screen, bitmap_ind16 &bit
 
 // explicit instantiations
 template uint32_t a2_video_device::screen_update<a2_video_device::model::II, true, true>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-template uint32_t a2_video_device::screen_update<a2_video_device::model::II, true, false>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 template uint32_t a2_video_device::screen_update<a2_video_device::model::II, false, true>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-template uint32_t a2_video_device::screen_update<a2_video_device::model::II, false, false>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 template uint32_t a2_video_device::screen_update<a2_video_device::model::IIE, true, true>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 template uint32_t a2_video_device::screen_update<a2_video_device::model::IIE, true, false>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 template uint32_t a2_video_device::screen_update<a2_video_device::model::IIE, false, true>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
@@ -1230,7 +1227,6 @@ template uint32_t a2_video_device::screen_update<a2_video_device::model::PRAVETZ
 template uint32_t a2_video_device::screen_update<a2_video_device::model::IIGS, true, false>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 template uint32_t a2_video_device::screen_update<a2_video_device::model::II_J_PLUS, true, true>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 template uint32_t a2_video_device::screen_update<a2_video_device::model::IVEL_ULTRA, true, false>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-template uint32_t a2_video_device::screen_update<a2_video_device::model::IVEL_ULTRA, false, true>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 template uint32_t a2_video_device::screen_update<a2_video_device::model::DODO, true, false>(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 static INPUT_PORTS_START( a2_vidconfig_composite );

--- a/src/mame/apple/superga2.cpp
+++ b/src/mame/apple/superga2.cpp
@@ -209,7 +209,7 @@ void superga2_state::superga2(machine_config &config)
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_raw(1021800 * 14, 65 * 14, 0, 40 * 14, 262, 0, 192);
-	m_screen->set_screen_update(m_video, NAME((&a2_video_device::screen_update<a2_video_device::model::II, false, false>)));
+	m_screen->set_screen_update(m_video, NAME((&a2_video_device::screen_update<a2_video_device::model::II, true, true>)));
 	m_screen->set_palette(m_video);
 
 	/* sound hardware */

--- a/src/mame/apple/tk2000.cpp
+++ b/src/mame/apple/tk2000.cpp
@@ -452,7 +452,7 @@ void tk2000_state::tk2000(machine_config &config)
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_raw(1021800 * 14, 65 * 14, 0, 40 * 14, 262, 0, 192);
-	m_screen->set_screen_update(m_video, NAME((&a2_video_device::screen_update<a2_video_device::model::II, false, false>)));
+	m_screen->set_screen_update(m_video, NAME((&a2_video_device::screen_update<a2_video_device::model::II, true, true>)));
 	m_screen->set_palette(m_video);
 
 	/* sound hardware */


### PR DESCRIPTION
(followup #14999)

This PR fixes text rendering on ivelultr/dodo/laser2c: these clones display text characters shifted one pixel too far to the right, which is mostly visible with INVERSE text:
<img width="42" height="64" alt="ivelultr_ASCII_0287" src="https://github.com/user-attachments/assets/c23c14ed-708e-4fbc-a5c6-3460f7669690" /> <img width="42" height="64" alt="dodo_laser2c_0287" src="https://github.com/user-attachments/assets/853433f1-3c2f-4434-b5cd-64bb3cb6102b" />

After this PR, text rendering aligns with other Apples and clones:
<img width="42" height="64" alt="ivelultr_ASCII_0287_after" src="https://github.com/user-attachments/assets/45d4ef24-bfb2-4e97-9339-2a43e226aa43" /> <img width="42" height="64" alt="dodo_laser2c_0287_after" src="https://github.com/user-attachments/assets/c032a1b0-bf2c-44a1-8ebb-2d13766c1a38" />

I don't have direct experience with these clones, but it also matches the references I was able to find online:
* [This video](https://youtu.be/SKMQlrjuG08?t=55) (using ASCII not YU, so C with caron "č" appears as "~") shows inverse "D" and "_" character spacing on IVEL ULTRA hardware
* The original thread dumping dodo ("GTAC Wiederbelebung" "Do-Do") contains a photo showing the cursor spacing on hardware
* [This video](https://www.youtube.com/watch?v=u33FhdRC3kY&t=413s) shows cursor spacing on Laser ][c hardware

<img width="70" height="110" alt="ivelultr_ASCII_reference" src="https://github.com/user-attachments/assets/7599d619-6028-4a2b-bd59-178bf8ce8f3f" /> <img width="70" height="110" alt="dodo_reference" src="https://github.com/user-attachments/assets/467b6f39-ab44-466f-aaf0-c1be05cb718a" /> <img width="70" height="110" alt="laser2c_reference" src="https://github.com/user-attachments/assets/1e50d6b1-bec2-4fbb-bfef-da8526747f77" />
<br>
This PR also cleans up the `screen_update()` and `text_update()` template instantiation to match what is actually used.

<br>
Code comments:<details>

Auditing the various apple2 character ROMs shows there are three classes of text bitmap layout (plus inversion):

1. **flip**:		all apple2 EXCEPT ivelultr/dodo/laser2c, and spectred/ace500/2200
2. **shift & flip**:	ivelultr/dodo/laser2c
3. **no flip**:		all apple2e EXCEPT spectred/ace500/2200, and apple2gs

The **shift** case was [briefly handled](https://github.com/mamedev/mame/blob/f8ecff4d11fca5000d5d581995d5341c32cb4440/src/mame/apple/apple2video.cpp#L477) by an `Invert, Flip` template combination, but this broke [when apple2gs changed](https://github.com/mamedev/mame/issues/14999) to use `Invert`, so is now handled with explicit `a2_video_device::model`s.  That's fine.  But the shift by `>> 1` wasn't enough.

`>> 2` works for all characters except 0xFF which fills all 7 bits in ivelultr (ASCII page) and dodo ROMs.  I don't know how IVEL ULTRA hardware implements this, but based on the [reverse engineering of a different GTAC clone](https://github.com/pfiliberti/gtac-appleclone/blob/main/fontrom/gtac_fontrom_info.txt), it's likely that the chargen shifters keep all 7 bits and just swizzle the order.  So this code rotates bit 1 into bit 6, such that character 0xFF properly fills all seven pixels.

<br>
For the instantiation cleanup, there are four fixes:

1. `<II, true, false>` is now replaced by `<DODO, true, false>`
2. `<II, false, false>` was only used by superga2 and tk2000, which have no text modes, so make them match apple2p and delete the unused instantiation
3. `<IVEL_ULTRA, false, true>` was briefly added for albert, but is now unused
4. make `text_update()` match `screen_update()`

Removing unused instantiations shrinks a clang arm64 release (O3, no LTO) binary by about 4kB.

</details>
<br>
TODO:<details>
I noticed a few other things while auditing:

* It's unclear why [craft2p is marked IMPERFECT GRAPHICS](https://github.com/mamedev/mame/blob/1e5263494af307699e72b463ce8ee180684c1c5c/src/mame/apple/apple2.cpp#L1232).  The char ROM has two language pages, but they are both Portuguese.  Is it dumped incorrectly?
* ivelultr is [commented as "wider character cell"](https://github.com/mamedev/mame/blob/1e5263494af307699e72b463ce8ee180684c1c5c/src/mame/apple/apple2.cpp#L1233) but the video hardware uses regular 7x8 cells, only the alignment of the ROM bitmap differs, which this PR fixes
* pravetz8m_chr has four language pages.  There is an [unemulated dip switch](https://retroroundup.com/2020/02/04/pravetz-8m/#:~:text=different%C2%A0%20keyboard%20layouts) but I haven't found documentation on it.
* It's unclear how to toggle language pages on tk3000 or laser128*
</details>
