### PR TITLE
video/huc6260.cpp: Split battlera specific VCE into separated device class, Updates:

### DIFF
--- a/src/devices/video/huc6260.cpp
+++ b/src/devices/video/huc6260.cpp
@@ -14,6 +14,9 @@
     VSync is low for 4095 master cycles (3 lines).
     VSync changes 30 master cycles after HSync would go low.
 
+	TODO:
+	- any differences between battlera VCE and HuC6260?
+
 **********************************************************************/
 
 #include "emu.h"
@@ -48,11 +51,17 @@ void huc6260_device::palette_init()
 }
 
 
-DEFINE_DEVICE_TYPE(HUC6260, huc6260_device, "huc6260", "Hudson HuC6260 VCE")
+DEFINE_DEVICE_TYPE(HUC6260,      huc6260_device,      "huc6260",      "Hudson HuC6260 VCE")
+DEFINE_DEVICE_TYPE(BATTLERA_VCE, battlera_vce_device, "battlera_vce", "Data East Battle Rangers VCE")
 
 
 huc6260_device::huc6260_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
-	device_t(mconfig, HUC6260, tag, owner, clock),
+	huc6260_device(mconfig, HUC6260, tag, owner, clock)
+{
+}
+
+huc6260_device::huc6260_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock) :
+	device_t(mconfig, type, tag, owner, clock),
 	device_palette_interface(mconfig, *this),
 	device_video_interface(mconfig, *this),
 	m_next_pixel_data_cb(*this, 0),
@@ -70,6 +79,11 @@ huc6260_device::huc6260_device(const machine_config &mconfig, const char *tag, d
 	m_pixel_data(0),
 	m_pixel_clock(0),
 	m_timer(nullptr)
+{
+}
+
+battlera_vce_device::battlera_vce_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
+	huc6260_device(mconfig, BATTLERA_VCE, tag, owner, clock)
 {
 }
 
@@ -197,16 +211,16 @@ u32 huc6260_device::screen_update(screen_device &screen, bitmap_ind16 &bitmap, c
 
 
 // the battlera arcade board reads/writes the palette directly
-u8 huc6260_device::palette_direct_read(offs_t offset)
+u8 battlera_vce_device::palette_direct_read(offs_t offset)
 {
-	if (BIT(~offset, 0)) return m_palette[offset >> 1];
-	else return m_palette[offset >> 1] >> 8;
+	const u8 shift = BIT(offset, 0) << 3;
+	return m_palette[offset >> 1] >> shift;
 }
 
-void huc6260_device::palette_direct_write(offs_t offset, u8 data)
+void battlera_vce_device::palette_direct_write(offs_t offset, u8 data)
 {
-	if (BIT(~offset, 0)) m_palette[offset >> 1] = (m_palette[offset >> 1] & 0xff00) | data;
-	else m_palette[offset >> 1] = (m_palette[offset >> 1] & 0x00ff) | (data << 8);
+	const u8 shift = BIT(offset, 0) << 3;
+	m_palette[offset >> 1] = (m_palette[offset >> 1] & ~(0xff << shift)) | (u32(data & 0xff) << shift);
 }
 
 u8 huc6260_device::read(offs_t offset)
@@ -242,19 +256,19 @@ void huc6260_device::write(offs_t offset, u8 data)
 			break;
 
 		case 0x02:  /* Color table address LSB */
-			m_address = ((m_address & 0xff00) | data) & 0x1ff;
+			m_address = (m_address & 0x100) | data;
 			break;
 
 		case 0x03:  /* Color table address MSB */
-			m_address = ((m_address & 0x00ff) | (data << 8)) & 0x1ff;
+			m_address = ((m_address & 0x0ff) | (BIT(data, 0) << 8)) & 0x1ff;
 			break;
 
 		case 0x04:  /* Color table data LSB */
-			m_palette[m_address] = ((m_palette[m_address] & 0xff00) | data) & 0x1ff;
+			m_palette[m_address] = (m_palette[m_address] & 0x100) | data;
 			break;
 
 		case 0x05:  /* Color table data MSB */
-			m_palette[m_address] = ((m_palette[m_address] & 0x00ff) | (data << 8)) & 0x1ff;
+			m_palette[m_address] = ((m_palette[m_address] & 0x0ff) | (BIT(data, 0) << 8)) & 0x1ff;
 
 			/* Increment internal address */
 			m_address = (m_address + 1) & 0x1ff;

--- a/src/devices/video/huc6260.h
+++ b/src/devices/video/huc6260.h
@@ -36,10 +36,10 @@ public:
 	u8 read(offs_t offset);
 	void write(offs_t offset, u8 data);
 
-	u8 palette_direct_read(offs_t offset);
-	void palette_direct_write(offs_t offset, u8 data);
-
 protected:
+	// construction/destruction
+	huc6260_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
+
 	// device-level overrides
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
@@ -48,7 +48,6 @@ protected:
 
 	TIMER_CALLBACK_MEMBER(update_events);
 
-private:
 	void palette_init();
 
 	/* Callback function to retrieve pixel data */
@@ -81,6 +80,18 @@ private:
 };
 
 
-DECLARE_DEVICE_TYPE(HUC6260, huc6260_device)
+class battlera_vce_device : public huc6260_device
+{
+public:
+	// construction/destruction
+	battlera_vce_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	u8 palette_direct_read(offs_t offset);
+	void palette_direct_write(offs_t offset, u8 data);
+};
+
+
+DECLARE_DEVICE_TYPE(HUC6260,      huc6260_device)
+DECLARE_DEVICE_TYPE(BATTLERA_VCE, battlera_vce_device)
 
 #endif // MAME_VIDEO_HUC6260_H

--- a/src/mame/dataeast/battlera.cpp
+++ b/src/mame/dataeast/battlera.cpp
@@ -17,7 +17,7 @@
     Extra sound chips (YM2203 & Oki M5205), and extra HuC6280 processor to drive them.
     Twice as much VRAM (128kb).
 
-    Todo:
+    TODO:
     - There seems to be a bug with a stuck note from the YM2203 FM channel
       at the start of scene 3 and near the ending when your characters are
       flying over a forest in a helicopter.
@@ -116,7 +116,7 @@ public:
 		, m_audiocpu(*this, "audiocpu")
 		, m_msm(*this, "msm")
 		, m_screen(*this, "screen")
-		, m_huc6260(*this, "huc6260")
+		, m_vce(*this, "vce")
 		, m_soundlatch(*this, "soundlatch")
 		, m_inputs(*this, { "IN0", "IN1", "IN2", "DSW2", "DSW1" })
 	{ }
@@ -132,7 +132,7 @@ private:
 	required_device<h6280_device> m_audiocpu;
 	required_device<msm5205_device> m_msm;
 	required_device<screen_device> m_screen;
-	required_device<huc6260_device> m_huc6260;
+	required_device<battlera_vce_device> m_vce;
 	required_device<generic_latch_8_device> m_soundlatch;
 	required_ioport_array<5> m_inputs;
 
@@ -190,10 +190,10 @@ void battlera_state::main_prg_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();
 	map(0x1e0800, 0x1e0800).w(m_soundlatch, FUNC(generic_latch_8_device::write));
-	map(0x1e1000, 0x1e13ff).rw(m_huc6260, FUNC(huc6260_device::palette_direct_read), FUNC(huc6260_device::palette_direct_write)).share("paletteram");
+	map(0x1e1000, 0x1e13ff).rw(m_vce, FUNC(battlera_vce_device::palette_direct_read), FUNC(battlera_vce_device::palette_direct_write)).share("paletteram");
 	map(0x1f0000, 0x1f1fff).ram(); // Main RAM
 	map(0x1fe000, 0x1fe3ff).rw("huc6270", FUNC(huc6270_device::read8), FUNC(huc6270_device::write8));
-	map(0x1fe400, 0x1fe7ff).rw(m_huc6260, FUNC(huc6260_device::read), FUNC(huc6260_device::write));
+	map(0x1fe400, 0x1fe7ff).rw(m_vce, FUNC(battlera_vce_device::read), FUNC(battlera_vce_device::write)); // is game writes here?
 }
 
 void battlera_state::main_portmap(address_map &map)
@@ -318,15 +318,15 @@ void battlera_state::battlera(machine_config &config)
 
 	// video hardware
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
-	m_screen->set_raw(21.477272_MHz_XTAL, huc6260_device::WPF, 64, 64 + 1024 + 64, huc6260_device::LPF, 18, 18 + 242);
-	m_screen->set_screen_update(m_huc6260, FUNC(huc6260_device::screen_update));
-	m_screen->set_palette(m_huc6260);
+	m_screen->set_raw(21.477272_MHz_XTAL, battlera_vce_device::WPF, 64, 64 + 1024 + 64, battlera_vce_device::LPF, 18, 18 + 242);
+	m_screen->set_screen_update(m_vce, FUNC(battlera_vce_device::screen_update));
+	m_screen->set_palette(m_vce);
 
-	HUC6260(config, m_huc6260, 21.477272_MHz_XTAL);
-	m_huc6260->next_pixel_data().set("huc6270", FUNC(huc6270_device::next_pixel));
-	m_huc6260->time_til_next_event().set("huc6270", FUNC(huc6270_device::time_until_next_event));
-	m_huc6260->vsync_changed().set("huc6270", FUNC(huc6270_device::vsync_changed));
-	m_huc6260->hsync_changed().set("huc6270", FUNC(huc6270_device::hsync_changed));
+	BATTLERA_VCE(config, m_vce, 21.477272_MHz_XTAL);
+	m_vce->next_pixel_data().set("huc6270", FUNC(huc6270_device::next_pixel));
+	m_vce->time_til_next_event().set("huc6270", FUNC(huc6270_device::time_until_next_event));
+	m_vce->vsync_changed().set("huc6270", FUNC(huc6270_device::vsync_changed));
+	m_vce->hsync_changed().set("huc6270", FUNC(huc6270_device::hsync_changed));
 
 	huc6270_device &huc6270(HUC6270(config, "huc6270", 21.477272_MHz_XTAL));
 	huc6270.set_vram_size(0x20000);

--- a/src/mame/nec/pce.cpp
+++ b/src/mame/nec/pce.cpp
@@ -58,7 +58,6 @@ Super System Card:
 #include "bus/pce/pce_acard.h"
 #include "bus/pce/pce_rom.h"
 #include "bus/pce/pce_scdsys.h"
-#include "cpu/h6280/h6280.h"
 #include "sound/cdda.h"
 #include "sound/msm5205.h"
 #include "video/huc6202.h"

--- a/src/mame/pce/ggconnie.cpp
+++ b/src/mame/pce/ggconnie.cpp
@@ -26,8 +26,6 @@
 #include "machine/msm6242.h"
 #include "sound/okim6295.h"
 #include "video/huc6202.h"
-#include "video/huc6260.h"
-#include "video/huc6270.h"
 
 #include "screen.h"
 #include "speaker.h"

--- a/src/mame/pce/paranoia.cpp
+++ b/src/mame/pce/paranoia.cpp
@@ -41,9 +41,6 @@ HuC6280A (Hudson)
 #include "cpu/z80/z80.h"
 #include "cpu/i8085/i8085.h"
 #include "machine/i8155.h"
-#include "video/huc6260.h"
-#include "video/huc6270.h"
-#include "cpu/h6280/h6280.h"
 #include "screen.h"
 #include "speaker.h"
 

--- a/src/mame/pce/pcecommn.cpp
+++ b/src/mame/pce/pcecommn.cpp
@@ -5,8 +5,6 @@
 
 #include "pcecommn.h"
 
-#include "cpu/h6280/h6280.h"
-
 #include "screen.h"
 
 // other values are unused at arcade bootlegs?

--- a/src/mame/pce/tourvis.cpp
+++ b/src/mame/pce/tourvis.cpp
@@ -178,10 +178,7 @@ http://blog.system11.org/?p=1943
 #include "emu.h"
 #include "pcecommn.h"
 
-#include "cpu/h6280/h6280.h"
 #include "cpu/i8085/i8085.h"
-#include "video/huc6260.h"
-#include "video/huc6270.h"
 #include "machine/i8155.h"
 
 #include "bus/generic/slot.h"

--- a/src/mame/pce/uapce.cpp
+++ b/src/mame/pce/uapce.cpp
@@ -113,10 +113,7 @@ Alien Crush & Pac_Land: dumps made from PC-Engine dumps of JP versions
 #include "emu.h"
 #include "pcecommn.h"
 
-#include "cpu/h6280/h6280.h"
 #include "cpu/z80/z80.h"
-#include "video/huc6260.h"
-#include "video/huc6270.h"
 #include "sound/discrete.h"
 
 #include "screen.h"


### PR DESCRIPTION
video/huc6260.cpp:
- Use BIT helper for single bit values (ex: data in odd address of 8 bit accessing)
- Simplify shifting data method

dataeast/battlera.cpp:
- Add notes

nec/pce.cpp, pce/pcecommn.cpp and related drivers:
- Reduce duplicated includes