### PR TITLE
dataeast/dec0.cpp: Split driver state class per hardware configurations, Updates:

### DIFF
--- a/src/mame/dataeast/dec0.cpp
+++ b/src/mame/dataeast/dec0.cpp
@@ -34,6 +34,7 @@ TODO:
 - background pen in Birdie Try is presumably wrong;
 - Unemulated coin counter, manuals mentions it but nowhere to be found, HW triggered?
 - Pixel clock frequency isn't verified;
+- Verify unknown read/writes in Robocop / Hippodrome, probably HuC6280 Sub CPU related?
 
 Bad Dudes MCU implements a command to calculate a program ROM checksum and
 compare the low byte of the result to a value supplied by the host CPU, but it
@@ -385,50 +386,60 @@ Notes:
 
 /******************************************************************************/
 
-void dec0_state::dec0_control_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void dec0_state::dec0_control_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	switch (offset << 1)
 	{
-		case 0: /* Playfield & Sprite priority */
+		case 0x0: /* Playfield & Sprite priority */
 			priority_w(0, data, mem_mask);
 			break;
 
-		case 2: /* DMA flag */
+		case 0x2: /* DMA flag */
 			m_spriteram->copy();
 			break;
 
-		case 4: /* 6502 sound cpu */
+		case 0x4: /* 6502 sound cpu */
 			if (ACCESSING_BITS_0_7)
 				m_soundlatch->write(data & 0xff);
 			break;
 
-		case 6: /* Intel 8751 microcontroller - Bad Dudes, Heavy Barrel, Birdie Try, Bandit only */
-			dec0_i8751_write(data);
-			break;
-
-		case 8: /* Interrupt ack (VBL - IRQ 6) */
+		case 0x8: /* Interrupt ack (VBL - IRQ 6) */
 			m_maincpu->set_input_line(6, CLEAR_LINE);
 			break;
 
 		case 0xa: /* Mix Psel(?). */
-			logerror("CPU #0 PC %06x: warning - write %02x to unmapped memory address %06x\n",m_maincpu->pc(),data,0x30c010+(offset<<1));
+			logerror("%s: Unknown dec0_control_w write %04x & %04x to %02x\n", machine().describe_context(), data, mem_mask, offset << 1);
 			break;
 
 		case 0xc: /* Cblk - coin blockout.  Seems to be unused by the games */
 			break;
 
-		case 0xe: /* Reset Intel 8751? - not sure, all the games write here at startup */
-			dec0_i8751_reset();
-			logerror("CPU #0 PC %06x: warning - write %02x to unmapped memory address %06x\n",m_maincpu->pc(),data,0x30c010+(offset<<1));
-			break;
-
 		default:
-			logerror("CPU #0 PC %06x: warning - write %02x to unmapped memory address %06x\n",m_maincpu->pc(),data,0x30c010+(offset<<1));
+			logerror("%s: Unknown dec0_control_w write %04x & %04x to %02x\n", machine().describe_context(), data, mem_mask, offset << 1);
 			break;
 	}
 }
 
-void automat_state::automat_control_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void drgninjab_state::dec0_control_w(offs_t offset, u16 data, u16 mem_mask)
+{
+	switch (offset << 1)
+	{
+		case 0x6: /* Intel 8751 microcontroller - Bad Dudes, Heavy Barrel, Birdie Try, Bandit only */
+			dec0_i8751_w(data);
+			break;
+
+		case 0xe: /* Reset Intel 8751? - not sure, all the games write here at startup */
+			dec0_i8751_reset_w();
+			logerror("%s: Unknown dec0_control_w write %04x & %04x to %02x\n", machine().describe_context(), data, mem_mask, offset << 1);
+			break;
+
+		default:
+			dec0_state::dec0_control_w(offset, data, mem_mask);
+			break;
+	}
+}
+
+void automat_state::automat_control_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	switch (offset << 1)
 	{
@@ -437,15 +448,15 @@ void automat_state::automat_control_w(offs_t offset, uint16_t data, uint16_t mem
 				m_soundlatch->write(data & 0xff);
 			break;
 
-		case 12: /* DMA flag */
+		case 0xc: /* DMA flag */
 			//m_spriteram->copy();
 			break;
 #if 0
-		case 8: /* Interrupt ack (VBL - IRQ 6) */
+		case 0x8: /* Interrupt ack (VBL - IRQ 6) */
 			break;
 
 		case 0xa: /* Mix Psel(?). */
-			logerror("CPU #0 PC %06x: warning - write %02x to unmapped memory address %06x\n",m_maincpu->pc(),data,0x30c010+(offset<<1));
+			logerror("%s: Unknown automat_control_w write %04x & %04x to %02x\n", machine().describe_context(), data, mem_mask, offset << 1);
 			break;
 
 		case 0xc: /* Cblk - coin blockout.  Seems to be unused by the games */
@@ -453,7 +464,7 @@ void automat_state::automat_control_w(offs_t offset, uint16_t data, uint16_t mem
 #endif
 
 		default:
-			logerror("CPU #0 PC %06x: warning - write %02x to unmapped memory address %06x\n",m_maincpu->pc(),data,0x30c010+(offset<<1));
+			logerror("%s: Unknown automat_control_w write %04x & %04x to %02x\n", machine().describe_context(), data, mem_mask, offset << 1);
 			break;
 	}
 }
@@ -491,10 +502,10 @@ void dec0_state::dec0_map(address_map &map)
 	map(0x310000, 0x3107ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x314000, 0x3147ff).ram().w(m_palette, FUNC(palette_device::write16_ext)).share("palette_ext");
 
-	map(0x318000, 0x31bfff).ram().share("ram");         // Bandit uses 318000/31c000 which are mirrors but exact mirror patten is unclear
+	map(0x318000, 0x31bfff).ram().share(m_ram);         // Bandit uses 318000/31c000 which are mirrors but exact mirror patten is unclear
 	map(0x31c000, 0x31c7ff).ram().share("spriteram");
 
-	map(0xff8000, 0xffbfff).ram().share("ram");                                 /* Main ram */
+	map(0xff8000, 0xffbfff).ram().share(m_ram);                                 /* Main ram */
 	map(0xffc000, 0xffc7ff).ram().share("spriteram");
 }
 
@@ -507,7 +518,7 @@ void dec0_state::ffantasybl_map(address_map &map)
 	map(0xff87ee, 0xff87ef).portr("VBLANK");
 }
 
-void dec0_state::dec0_tb_map(address_map &map)
+void dec0_8751_state::dec0_tb_map(address_map &map)
 {
 	dec0_map(map);
 	map(0x300010, 0x300017).r("tb0", FUNC(upd4701_device::read_xy)).umask16(0x00ff);
@@ -527,7 +538,7 @@ void robocop_state::main_map(address_map &map)
 void robocop_state::sub_map(address_map &map)
 {
 	map(0x000000, 0x00ffff).rom();
-	map(0x1f0000, 0x1f1fff).ram();                                 /* Main ram */
+	map(0x1f0000, 0x1f1fff).ram();                                 /* Local RAM */
 	map(0x1f2000, 0x1f27ff).rw("dem01", FUNC(mb8421_device::right_r), FUNC(mb8421_device::right_w));  /* Shared ram */
 }
 
@@ -546,45 +557,47 @@ void hippodrm_state::sub_map(address_map &map)
 	map(0x1a0010, 0x1a001f).w(m_tilegen[2], FUNC(deco_bac06_device::pf_control1_8bit_swap_w));
 	map(0x1a1000, 0x1a17ff).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_data_8bit_swap_r), FUNC(deco_bac06_device::pf_data_8bit_swap_w));
 	map(0x1d0000, 0x1d00ff).rw(FUNC(hippodrm_state::prot_r), FUNC(hippodrm_state::prot_w));
-	map(0x1f0000, 0x1f1fff).ram(); /* Main ram */
+	map(0x1f0000, 0x1f1fff).ram(); /* Local RAM */
 }
 
 
-uint16_t dec0_state::slyspy_controls_r(offs_t offset)
+u16 dec0_state::slyspy_controls_r(offs_t offset)
 {
-	switch (offset<<1)
+	switch (offset << 1)
 	{
 		case 0: /* Dip Switches */
-			return ioport("DSW")->read();
+			return m_io_dsw->read();
 
 		case 2: /* Player 1 & Player 2 joysticks & fire buttons */
-			return ioport("INPUTS")->read();
+			return m_io_inputs->read();
 
 		case 4: /* Credits */
-			return ioport("SYSTEM")->read();
+			return m_io_system->read();
 	}
 
-	logerror("Unknown control read at 30c000 %d\n", offset);
+	if (!machine().side_effects_disabled())
+		logerror("%s: Unknown slyspy_controls_r read at %02x\n", machine().describe_context(), offset << 1);
 	return ~0;
 }
 
 // TODO: this can be a timer access, maybe video counter returns (and used as RNG in both games)
-uint16_t slyspy_state::prot_r(offs_t offset)
+u16 slyspy_state::prot_r(offs_t offset)
 {
-	switch (offset<<1)
+	switch (offset << 1)
 	{
 		/* These values are for Boulder Dash, I have no idea what they do in Sly Spy */
-		case 0:     return 0;
-		case 2:     return 0x13;
-		case 4:     return 0;
-		case 6:     return 0x2;
+		case 0x0:   return 0;
+		case 0x2:   return 0x13;
+		case 0x4:   return 0;
+		case 0x6:   return 0x2;
 		// Sly Spy uses this port as RNG, for now let's do same thing as bootleg (i.e. reads 0x306028)
 		// chances are that it actually ties to the main CPU xtal instead.
 		// (reads at 6958 6696)
-		case 0xc:   return m_ram[0x2028/2] >> 8;
+		case 0xc:   return m_ram[0x2028 / 2] >> 8;
 	}
 
-	logerror("%04x, Unknown protection read at 30c000 %d\n", m_maincpu->pc(), offset);
+	if (!machine().side_effects_disabled())
+		logerror("%s: Unknown prot_r read at %02x\n", machine().describe_context(), offset << 1);
 	return 0;
 }
 
@@ -622,17 +635,17 @@ uint16_t slyspy_state::prot_r(offs_t offset)
 
 */
 
-void slyspy_state::prot_state_w(uint16_t data)
+void slyspy_state::prot_state_w(u16 data)
 {
 	m_prot_state = 0;
 	m_pfview.select(m_prot_state);
 }
 
-uint16_t slyspy_state::prot_state_r()
+u16 slyspy_state::prot_state_r()
 {
 	if (!machine().side_effects_disabled())
 	{
-		m_prot_state = (m_prot_state + 1) % 4;
+		m_prot_state = (m_prot_state + 1) & 3;
 		m_pfview.select(m_prot_state);
 	}
 
@@ -678,7 +691,7 @@ void slyspy_state::main_map(address_map &map)
 	map(0x300c00, 0x300fff).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_rowscroll_r), FUNC(deco_bac06_device::pf_rowscroll_w));
 	map(0x301000, 0x3017ff).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
 
-	map(0x304000, 0x307fff).ram().share("ram"); /* Sly Spy main ram */
+	map(0x304000, 0x307fff).ram().share(m_ram); /* Sly Spy main ram */
 	map(0x308000, 0x3087ff).ram().share("spriteram");   /* Sprites */
 	map(0x310000, 0x3107ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x314001, 0x314001).w(m_soundlatch, FUNC(generic_latch_8_device::write));
@@ -691,7 +704,7 @@ void slyspy_state::main_map(address_map &map)
 void dec0_state::midres_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
-	map(0x100000, 0x103fff).ram().share("ram");
+	map(0x100000, 0x103fff).ram().share(m_ram);
 	map(0x120000, 0x1207ff).ram().share("spriteram");
 	map(0x140000, 0x1407ff).w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x160000, 0x160001).w(FUNC(dec0_state::priority_w));
@@ -776,7 +789,7 @@ void slyspy_state::sound_map(address_map &map)
 // Sly Spy sound state protection machine emulation
 // similar to the video state machine
 // current bank is at 0x1f0045, incremented by 1 then here is read
-uint8_t slyspy_state::sound_prot_state_r()
+u8 slyspy_state::sound_prot_state_r()
 {
 	if (!machine().side_effects_disabled())
 	{
@@ -789,7 +802,7 @@ uint8_t slyspy_state::sound_prot_state_r()
 	return 0xff;
 }
 
-uint8_t slyspy_state::sound_prot_state_reset_r()
+u8 slyspy_state::sound_prot_state_reset_r()
 {
 	if (!machine().side_effects_disabled())
 	{
@@ -813,32 +826,31 @@ void dec0_state::midres_s_map(address_map &map)
 }
 
 
-
 void automat_state::machine_start()
 {
 	m_adpcm_toggle[0] = false;
 	m_adpcm_toggle[1] = false;
-	save_item(NAME(m_adpcm_toggle));
-	save_item(NAME(m_automat_scroll_regs));
 
 	m_soundbank->configure_entries(0, 8, memregion("audiocpu")->base(), 0x4000);
 	m_soundbank->set_entry(0);
+
+	save_item(NAME(m_adpcm_toggle));
+	save_item(NAME(m_automat_scroll_regs));
 }
 
 
 /* swizzle the palette writes around so we can use the same gfx plane ordering as the originals */
-uint16_t automat_state::automat_palette_r(offs_t offset)
+u16 automat_state::automat_palette_r(offs_t offset)
 {
-	offset ^=0xf;
+	offset ^= 0xf;
 	return m_paletteram[offset];
 }
 
-void automat_state::automat_palette_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void automat_state::automat_palette_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	offset ^=0xf;
+	offset ^= 0xf;
 	m_palette->write16(offset, data, mem_mask);
 }
-
 
 
 void automat_state::automat_map(address_map &map)
@@ -877,7 +889,7 @@ void automat_state::automat_map(address_map &map)
 
 	map(0x500000, 0x500001).nopw(); // ???
 
-	map(0xff8000, 0xffbfff).ram().share("ram");             /* Main ram */
+	map(0xff8000, 0xffbfff).ram().share(m_ram);             /* Main ram */
 	map(0xffc000, 0xffcfff).ram().share("spriteram");           /* Sprites */
 }
 
@@ -904,7 +916,7 @@ void automat_state::secretab_map(address_map &map)
 	map(0x300800, 0x30087f).ram();
 	map(0x300c00, 0x300fff).ram();
 	map(0x301000, 0x3017ff).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
-	map(0x301800, 0x307fff).ram().share("ram"); /* Sly Spy main ram */
+	map(0x301800, 0x307fff).ram().share(m_ram); /* Sly Spy main ram */
 	map(0x310000, 0x3107ff).rw(FUNC(automat_state::automat_palette_r), FUNC(automat_state::automat_palette_w)).share("palette");
 	map(0xb08000, 0xb08fff).ram().share("spriteram"); /* Sprites */
 }
@@ -913,7 +925,7 @@ void automat_state::secretab_map(address_map &map)
 void automat_state::automat_s_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
-	map(0x8000, 0xbfff).bankr("soundbank");
+	map(0x8000, 0xbfff).bankr(m_soundbank);
 	map(0xc000, 0xc7ff).ram();
 	map(0xc800, 0xc801).rw("2203a", FUNC(ym2203_device::read), FUNC(ym2203_device::write));
 	map(0xd000, 0xd001).rw("2203b", FUNC(ym2203_device::read), FUNC(ym2203_device::write));
@@ -926,7 +938,7 @@ void automat_state::automat_s_map(address_map &map)
 void automat_state::secretab_s_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
-	map(0x8000, 0xbfff).bankr("soundbank");
+	map(0x8000, 0xbfff).bankr(m_soundbank);
 	map(0xc000, 0xc7ff).ram();
 	map(0xc800, 0xc801).rw("2203a", FUNC(ym2203_device::read), FUNC(ym2203_device::write));
 	map(0xd000, 0xd001).rw("ym3812", FUNC(ym3812_device::read), FUNC(ym3812_device::write));
@@ -1884,7 +1896,7 @@ void dec0_state::dec1(machine_config &config)
 }
 
 
-void automat_state::sound_bankswitch_w(uint8_t data)
+void automat_state::sound_bankswitch_w(u8 data)
 {
 	m_msm[0]->reset_w(BIT(data, 3));
 	m_msm[1]->reset_w(BIT(data, 4));
@@ -2057,27 +2069,27 @@ void automat_state::secretab(machine_config &config) // all clocks verified on P
 	msm2.add_route(ALL_OUTPUTS, "mono", 1.0);
 }
 
-void dec0_state::hbarrel(machine_config &config)
+void dec0_8751_state::hbarrel(machine_config &config)
 {
 	dec0(config);
 
 	i8751_device &mcu(I8751(config, m_mcu, XTAL(8'000'000)));
-	mcu.port_in_cb<0>().set(FUNC(dec0_state::dec0_mcu_port0_r));
-	mcu.port_out_cb<0>().set(FUNC(dec0_state::dec0_mcu_port0_w));
-	mcu.port_out_cb<1>().set(FUNC(dec0_state::dec0_mcu_port1_w));
-	mcu.port_out_cb<2>().set(FUNC(dec0_state::dec0_mcu_port2_w));
-	mcu.port_out_cb<3>().set(FUNC(dec0_state::dec0_mcu_port3_w));
+	mcu.port_in_cb<0>().set(FUNC(dec0_8751_state::dec0_mcu_port0_r));
+	mcu.port_out_cb<0>().set(FUNC(dec0_8751_state::dec0_mcu_port0_w));
+	mcu.port_out_cb<1>().set(FUNC(dec0_8751_state::dec0_mcu_port1_w));
+	mcu.port_out_cb<2>().set(FUNC(dec0_8751_state::dec0_mcu_port2_w));
+	mcu.port_out_cb<3>().set(FUNC(dec0_8751_state::dec0_mcu_port3_w));
 
 	/* video hardware */
-	m_screen->set_screen_update(FUNC(dec0_state::screen_update_hbarrel));
-	m_spritegen->set_colpri_callback(FUNC(dec0_state::hbarrel_colpri_cb));
+	m_screen->set_screen_update(FUNC(dec0_8751_state::screen_update_hbarrel));
+	m_spritegen->set_colpri_callback(FUNC(dec0_8751_state::hbarrel_colpri_cb));
 }
 
-void dec0_state::bandit(machine_config &config)
+void dec0_8751_state::bandit(machine_config &config)
 {
 	dec0(config);
 
-	m_maincpu->set_addrmap(AS_PROGRAM, &dec0_state::dec0_tb_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &dec0_8751_state::dec0_tb_map);
 
 	upd4701_device &tb0(UPD4701A(config, "tb0"));
 	tb0.set_portx_tag("track_0");
@@ -2088,65 +2100,65 @@ void dec0_state::bandit(machine_config &config)
 	tb1.set_porty_tag("track_3");
 
 	i8751_device &mcu(I8751(config, m_mcu, XTAL(8'000'000)));
-	mcu.port_in_cb<0>().set(FUNC(dec0_state::dec0_mcu_port0_r));
-	mcu.port_out_cb<0>().set(FUNC(dec0_state::dec0_mcu_port0_w));
-	mcu.port_out_cb<1>().set(FUNC(dec0_state::dec0_mcu_port1_w));
-	mcu.port_out_cb<2>().set(FUNC(dec0_state::dec0_mcu_port2_w));
-	mcu.port_out_cb<3>().set(FUNC(dec0_state::dec0_mcu_port3_w));
+	mcu.port_in_cb<0>().set(FUNC(dec0_8751_state::dec0_mcu_port0_r));
+	mcu.port_out_cb<0>().set(FUNC(dec0_8751_state::dec0_mcu_port0_w));
+	mcu.port_out_cb<1>().set(FUNC(dec0_8751_state::dec0_mcu_port1_w));
+	mcu.port_out_cb<2>().set(FUNC(dec0_8751_state::dec0_mcu_port2_w));
+	mcu.port_out_cb<3>().set(FUNC(dec0_8751_state::dec0_mcu_port3_w));
 
 	/* video hardware */
-	m_screen->set_screen_update(FUNC(dec0_state::screen_update_bandit));
-	m_spritegen->set_colpri_callback(FUNC(dec0_state::bandit_colpri_cb));
+	m_screen->set_screen_update(FUNC(dec0_8751_state::screen_update_bandit));
+	m_spritegen->set_colpri_callback(FUNC(dec0_8751_state::bandit_colpri_cb));
 }
 
-void dec0_state::baddudes(machine_config &config)
+void dec0_8751_state::baddudes(machine_config &config)
 {
 	dec0(config);
 
 	i8751_device &mcu(I8751(config, m_mcu, XTAL(8'000'000)));
-	mcu.port_in_cb<0>().set(FUNC(dec0_state::dec0_mcu_port0_r));
-	mcu.port_out_cb<0>().set(FUNC(dec0_state::dec0_mcu_port0_w));
-	mcu.port_out_cb<1>().set(FUNC(dec0_state::dec0_mcu_port1_w));
-	mcu.port_out_cb<2>().set(FUNC(dec0_state::dec0_mcu_port2_w));
-	mcu.port_out_cb<3>().set(FUNC(dec0_state::dec0_mcu_port3_w));
+	mcu.port_in_cb<0>().set(FUNC(dec0_8751_state::dec0_mcu_port0_r));
+	mcu.port_out_cb<0>().set(FUNC(dec0_8751_state::dec0_mcu_port0_w));
+	mcu.port_out_cb<1>().set(FUNC(dec0_8751_state::dec0_mcu_port1_w));
+	mcu.port_out_cb<2>().set(FUNC(dec0_8751_state::dec0_mcu_port2_w));
+	mcu.port_out_cb<3>().set(FUNC(dec0_8751_state::dec0_mcu_port3_w));
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(dec0_state,baddudes)
+	MCFG_VIDEO_START_OVERRIDE(dec0_8751_state,baddudes)
 
-	m_tilegen[1]->set_tile_callback(FUNC(dec0_state::baddudes_tile_cb));
-	m_tilegen[2]->set_tile_callback(FUNC(dec0_state::baddudes_tile_cb));
+	m_tilegen[1]->set_tile_callback(FUNC(dec0_8751_state::baddudes_tile_cb));
+	m_tilegen[2]->set_tile_callback(FUNC(dec0_8751_state::baddudes_tile_cb));
 
-	m_screen->set_screen_update(FUNC(dec0_state::screen_update_baddudes));
+	m_screen->set_screen_update(FUNC(dec0_8751_state::screen_update_baddudes));
 }
 
-void dec0_state::drgninjab(machine_config &config)
+void drgninjab_state::drgninjab(machine_config &config)
 {
 	dec0(config);
 
 	/* video hardware */
-	MCFG_VIDEO_START_OVERRIDE(dec0_state,baddudes)
+	MCFG_VIDEO_START_OVERRIDE(drgninjab_state,baddudes)
 
-	m_tilegen[1]->set_tile_callback(FUNC(dec0_state::baddudes_tile_cb));
-	m_tilegen[2]->set_tile_callback(FUNC(dec0_state::baddudes_tile_cb));
+	m_tilegen[1]->set_tile_callback(FUNC(drgninjab_state::baddudes_tile_cb));
+	m_tilegen[2]->set_tile_callback(FUNC(drgninjab_state::baddudes_tile_cb));
 
-	m_screen->set_screen_update(FUNC(dec0_state::screen_update_baddudes));
+	m_screen->set_screen_update(FUNC(drgninjab_state::screen_update_baddudes));
 }
 
-void dec0_state::birdtry(machine_config &config)
+void dec0_8751_state::birdtry(machine_config &config)
 {
 	dec0(config);
 
-	m_maincpu->set_addrmap(AS_PROGRAM, &dec0_state::dec0_tb_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &dec0_8751_state::dec0_tb_map);
 
 	// needs a tight sync with the mcu
 	config.set_perfect_quantum(m_maincpu);
 
 	i8751_device &mcu(I8751(config, m_mcu, XTAL(8'000'000)));
-	mcu.port_in_cb<0>().set(FUNC(dec0_state::dec0_mcu_port0_r));
-	mcu.port_out_cb<0>().set(FUNC(dec0_state::dec0_mcu_port0_w));
-	mcu.port_out_cb<1>().set(FUNC(dec0_state::dec0_mcu_port1_w));
-	mcu.port_out_cb<2>().set(FUNC(dec0_state::dec0_mcu_port2_w));
-	mcu.port_out_cb<3>().set(FUNC(dec0_state::dec0_mcu_port3_w));
+	mcu.port_in_cb<0>().set(FUNC(dec0_8751_state::dec0_mcu_port0_r));
+	mcu.port_out_cb<0>().set(FUNC(dec0_8751_state::dec0_mcu_port0_w));
+	mcu.port_out_cb<1>().set(FUNC(dec0_8751_state::dec0_mcu_port1_w));
+	mcu.port_out_cb<2>().set(FUNC(dec0_8751_state::dec0_mcu_port2_w));
+	mcu.port_out_cb<3>().set(FUNC(dec0_8751_state::dec0_mcu_port3_w));
 
 	upd4701_device &tb0(UPD4701A(config, "tb0"));
 	tb0.set_portx_tag("track_0");
@@ -2157,7 +2169,7 @@ void dec0_state::birdtry(machine_config &config)
 	tb1.set_porty_tag("track_3");
 
 	/* video hardware */
-	m_screen->set_screen_update(FUNC(dec0_state::screen_update_birdtry));
+	m_screen->set_screen_update(FUNC(dec0_8751_state::screen_update_birdtry));
 }
 
 void robocop_state::robocop(machine_config &config)
@@ -4328,7 +4340,7 @@ ROM_START( bouldashj )
 ROM_END
 
 
-uint16_t dec0_state::ffantasybl_242024_r()
+u16 dec0_state::ffantasybl_242024_r()
 {
 /*
     000152: 41F9 0024 2020             lea     $242020.l, A0
@@ -4343,51 +4355,51 @@ uint16_t dec0_state::ffantasybl_242024_r()
 
 /******************************************************************************/
 
-//    YEAR, NAME,       PARENT,   MACHINE,    INPUT,      STATE/DEVICE,   INIT,            MONITOR,COMPANY,                 FULLNAME,            FLAGS
-GAME( 1987, hbarrel,    0,        hbarrel,    hbarrel,    dec0_state,     init_hbarrel,    ROT270, "Data East Corporation", "Heavy Barrel (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, hbarrelu,   hbarrel,  hbarrel,    hbarrel,    dec0_state,     init_hbarrel,    ROT270, "Data East USA",         "Heavy Barrel (US, revision 3)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, hbarrelua,  hbarrel,  hbarrel,    hbarrel,    dec0_state,     init_hbarrel,    ROT270, "Data East USA",         "Heavy Barrel (US, revision 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, baddudes,   0,        baddudes,   baddudes,   dec0_state,     init_hbarrel,    ROT0,   "Data East USA",         "Bad Dudes vs. Dragonninja (US, revision 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, drgninja,   baddudes, baddudes,   drgninja,   dec0_state,     init_hbarrel,    ROT0,   "Data East Corporation", "Dragonninja (Japan, revision 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, birdtry,    0,        birdtry,    birdtry,    dec0_state,     init_hbarrel,    ROT270, "Data East Corporation", "Birdie Try (Japan, revision 2, revision 1 MCU)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, birdtrya,   birdtry,  birdtry,    birdtry,    dec0_state,     init_hbarrel,    ROT270, "Data East Corporation", "Birdie Try (Japan, revision 2)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, birdtryb,   birdtry,  birdtry,    birdtry,    dec0_state,     init_hbarrel,    ROT270, "Data East Corporation", "Birdie Try (Japan, sample version)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, robocop,    0,        robocop,    robocop,    robocop_state,  empty_init,      ROT0,   "Data East Corporation", "Robocop (World, revision 4)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, robocopw,   robocop,  robocop,    robocop,    robocop_state,  empty_init,      ROT0,   "Data East Corporation", "Robocop (World, revision 3)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, robocopj,   robocop,  robocop,    robocop,    robocop_state,  empty_init,      ROT0,   "Data East Corporation", "Robocop (Japan)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, robocopu,   robocop,  robocop,    robocop,    robocop_state,  empty_init,      ROT0,   "Data East USA",         "Robocop (US, revision 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, robocopu0,  robocop,  robocop,    robocop,    robocop_state,  empty_init,      ROT0,   "Data East USA",         "Robocop (US, revision 0)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, bandit,     0,        bandit,     bandit,     dec0_state,     init_hbarrel,    ROT90,  "Data East USA / Incredible Technologies",         "Bandit (US prototype)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE ) // Incredible Technologies credited during ending (select track #75). MIG for the ending screen (which may be a btanb).
-GAME( 1989, hippodrm,   0,        hippodrm,   hippodrm,   hippodrm_state, init_hippodrm,   ROT0,   "Data East USA",         "Hippodrome (US)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, ffantasy,   hippodrm, hippodrm,   ffantasy,   hippodrm_state, init_hippodrm,   ROT0,   "Data East Corporation", "Fighting Fantasy (Japan, revision 3)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, ffantasyj,  hippodrm, hippodrm,   ffantasy,   hippodrm_state, init_hippodrm,   ROT0,   "Data East Corporation", "Fighting Fantasy (Japan, revision 2)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, ffantasya,  hippodrm, hippodrm,   ffantasy,   hippodrm_state, init_hippodrm,   ROT0,   "Data East Corporation", "Fighting Fantasy (Japan)", MACHINE_SUPPORTS_SAVE ) // presumably rev 1
-GAME( 1989, ffantasyb,  hippodrm, hippodrm,   ffantasy,   hippodrm_state, init_hippodrm,   ROT0,   "Data East Corporation", "Fighting Fantasy (Japan revision ?)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, secretag,   0,        slyspy,     slyspy,     slyspy_state,   init_slyspy,     ROT0,   "Data East Corporation", "Secret Agent (World, revision 3)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, secretagj,  secretag, slyspy,     slyspy,     slyspy_state,   init_slyspy,     ROT0,   "Data East Corporation", "Secret Agent (Japan, revision 2)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, slyspy,     secretag, slyspy,     slyspy,     slyspy_state,   init_slyspy,     ROT0,   "Data East USA",         "Sly Spy (US, revision 4)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, slyspy3,    secretag, slyspy,     slyspy,     slyspy_state,   init_slyspy,     ROT0,   "Data East USA",         "Sly Spy (US, revision 3)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, slyspy2,    secretag, slyspy,     slyspy,     slyspy_state,   init_slyspy,     ROT0,   "Data East USA",         "Sly Spy (US, revision 2)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, midres,     0,        midres,     midres,     dec0_state,     empty_init,      ROT0,   "Data East Corporation", "Midnight Resistance (World, set 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, midres2,    midres,   midres,     midres2,    dec0_state,     empty_init,      ROT0,   "Data East Corporation", "Midnight Resistance (World, set 2)", MACHINE_SUPPORTS_SAVE ) // uses button 3 for rotating, later rev?
-GAME( 1989, midresu,    midres,   midres,     midres,     dec0_state,     empty_init,      ROT0,   "Data East USA",         "Midnight Resistance (US)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, midresj,    midres,   midres,     midres,     dec0_state,     empty_init,      ROT0,   "Data East Corporation", "Midnight Resistance (Japan)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, bouldash,   0,        slyspy,     bouldash,   slyspy_state,   init_slyspy,     ROT0,   "Data East Corporation (licensed from First Star)", "Boulder Dash / Boulder Dash Part 2 (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1990, bouldashj,  bouldash, slyspy,     bouldash,   slyspy_state,   init_slyspy,     ROT0,   "Data East Corporation (licensed from First Star)", "Boulder Dash / Boulder Dash Part 2 (Japan)", MACHINE_SUPPORTS_SAVE )
+//    YEAR, NAME,       PARENT,   MACHINE,    INPUT,      STATE/DEVICE,    INIT,            MONITOR,COMPANY,                 FULLNAME,            FLAGS
+GAME( 1987, hbarrel,    0,        hbarrel,    hbarrel,    dec0_8751_state, empty_init,      ROT270, "Data East Corporation", "Heavy Barrel (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, hbarrelu,   hbarrel,  hbarrel,    hbarrel,    dec0_8751_state, empty_init,      ROT270, "Data East USA",         "Heavy Barrel (US, revision 3)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, hbarrelua,  hbarrel,  hbarrel,    hbarrel,    dec0_8751_state, empty_init,      ROT270, "Data East USA",         "Heavy Barrel (US, revision 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, baddudes,   0,        baddudes,   baddudes,   dec0_8751_state, empty_init,      ROT0,   "Data East USA",         "Bad Dudes vs. Dragonninja (US, revision 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, drgninja,   baddudes, baddudes,   drgninja,   dec0_8751_state, empty_init,      ROT0,   "Data East Corporation", "Dragonninja (Japan, revision 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, birdtry,    0,        birdtry,    birdtry,    dec0_8751_state, empty_init,      ROT270, "Data East Corporation", "Birdie Try (Japan, revision 2, revision 1 MCU)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, birdtrya,   birdtry,  birdtry,    birdtry,    dec0_8751_state, empty_init,      ROT270, "Data East Corporation", "Birdie Try (Japan, revision 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, birdtryb,   birdtry,  birdtry,    birdtry,    dec0_8751_state, empty_init,      ROT270, "Data East Corporation", "Birdie Try (Japan, sample version)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, robocop,    0,        robocop,    robocop,    robocop_state,   empty_init,      ROT0,   "Data East Corporation", "Robocop (World, revision 4)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, robocopw,   robocop,  robocop,    robocop,    robocop_state,   empty_init,      ROT0,   "Data East Corporation", "Robocop (World, revision 3)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, robocopj,   robocop,  robocop,    robocop,    robocop_state,   empty_init,      ROT0,   "Data East Corporation", "Robocop (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, robocopu,   robocop,  robocop,    robocop,    robocop_state,   empty_init,      ROT0,   "Data East USA",         "Robocop (US, revision 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, robocopu0,  robocop,  robocop,    robocop,    robocop_state,   empty_init,      ROT0,   "Data East USA",         "Robocop (US, revision 0)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, bandit,     0,        bandit,     bandit,     dec0_8751_state, empty_init,      ROT90,  "Data East USA / Incredible Technologies",         "Bandit (US prototype)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE ) // Incredible Technologies credited during ending (select track #75). MIG for the ending screen (which may be a btanb).
+GAME( 1989, hippodrm,   0,        hippodrm,   hippodrm,   hippodrm_state,  init_hippodrm,   ROT0,   "Data East USA",         "Hippodrome (US)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, ffantasy,   hippodrm, hippodrm,   ffantasy,   hippodrm_state,  init_hippodrm,   ROT0,   "Data East Corporation", "Fighting Fantasy (Japan, revision 3)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, ffantasyj,  hippodrm, hippodrm,   ffantasy,   hippodrm_state,  init_hippodrm,   ROT0,   "Data East Corporation", "Fighting Fantasy (Japan, revision 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, ffantasya,  hippodrm, hippodrm,   ffantasy,   hippodrm_state,  init_hippodrm,   ROT0,   "Data East Corporation", "Fighting Fantasy (Japan)", MACHINE_SUPPORTS_SAVE ) // presumably rev 1
+GAME( 1989, ffantasyb,  hippodrm, hippodrm,   ffantasy,   hippodrm_state,  init_hippodrm,   ROT0,   "Data East Corporation", "Fighting Fantasy (Japan revision ?)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, secretag,   0,        slyspy,     slyspy,     slyspy_state,    init_slyspy,     ROT0,   "Data East Corporation", "Secret Agent (World, revision 3)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, secretagj,  secretag, slyspy,     slyspy,     slyspy_state,    init_slyspy,     ROT0,   "Data East Corporation", "Secret Agent (Japan, revision 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, slyspy,     secretag, slyspy,     slyspy,     slyspy_state,    init_slyspy,     ROT0,   "Data East USA",         "Sly Spy (US, revision 4)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, slyspy3,    secretag, slyspy,     slyspy,     slyspy_state,    init_slyspy,     ROT0,   "Data East USA",         "Sly Spy (US, revision 3)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, slyspy2,    secretag, slyspy,     slyspy,     slyspy_state,    init_slyspy,     ROT0,   "Data East USA",         "Sly Spy (US, revision 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, midres,     0,        midres,     midres,     dec0_state,      empty_init,      ROT0,   "Data East Corporation", "Midnight Resistance (World, set 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, midres2,    midres,   midres,     midres2,    dec0_state,      empty_init,      ROT0,   "Data East Corporation", "Midnight Resistance (World, set 2)", MACHINE_SUPPORTS_SAVE ) // uses button 3 for rotating, later rev?
+GAME( 1989, midresu,    midres,   midres,     midres,     dec0_state,      empty_init,      ROT0,   "Data East USA",         "Midnight Resistance (US)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, midresj,    midres,   midres,     midres,     dec0_state,      empty_init,      ROT0,   "Data East Corporation", "Midnight Resistance (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, bouldash,   0,        slyspy,     bouldash,   slyspy_state,    init_slyspy,     ROT0,   "Data East Corporation (licensed from First Star)", "Boulder Dash / Boulder Dash Part 2 (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, bouldashj,  bouldash, slyspy,     bouldash,   slyspy_state,    init_slyspy,     ROT0,   "Data East Corporation (licensed from First Star)", "Boulder Dash / Boulder Dash Part 2 (Japan)", MACHINE_SUPPORTS_SAVE )
 
 // bootlegs
 
 // more or less just an unprotected versions of the game, everything intact
-GAME( 1988, robocopb,   robocop,  robocopb,   robocop,    dec0_state,     empty_init,      ROT0,   "bootleg", "Robocop (World bootleg)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, drgninjab,  baddudes, drgninjab,  drgninja,   dec0_state,     init_drgninja,   ROT0,   "bootleg", "Dragonninja (bootleg)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, robocopb,   robocop,  robocopb,   robocop,    dec0_state,      empty_init,      ROT0,   "bootleg", "Robocop (World bootleg)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, drgninjab,  baddudes, drgninjab,  drgninja,   drgninjab_state, empty_init,      ROT0,   "bootleg", "Dragonninja (bootleg)", MACHINE_SUPPORTS_SAVE )
 
 // this is a common bootleg board
-GAME( 1989, midresb,    midres,   midresb,    midresb,    dec0_state,     empty_init,      ROT0,   "bootleg", "Midnight Resistance (bootleg with 68705)", MACHINE_SUPPORTS_SAVE ) // need to hook up 68705? (probably unused)
-GAME( 1989, midresbj,   midres,   midresbj,   midresb,    dec0_state,     empty_init,      ROT0,   "bootleg", "Midnight Resistance (Joystick bootleg)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, ffantasybl, hippodrm, ffantasybl, ffantasybl, dec0_state,     empty_init,      ROT0,   "bootleg", "Fighting Fantasy (bootleg with 68705)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // 68705 not dumped, might be the same as midresb
-GAME( 1988, drgninjab2, baddudes, drgninjab,  drgninja,   dec0_state,     init_drgninja,   ROT0,   "bootleg", "Dragonninja (bootleg with 68705)", MACHINE_SUPPORTS_SAVE ) // is this the same board as above? (region warning hacked to World, but still shows Japanese text), 68705 dumped but not hooked up
+GAME( 1989, midresb,    midres,   midresb,    midresb,    dec0_state,      empty_init,      ROT0,   "bootleg", "Midnight Resistance (bootleg with 68705)", MACHINE_SUPPORTS_SAVE ) // need to hook up 68705? (probably unused)
+GAME( 1989, midresbj,   midres,   midresbj,   midresb,    dec0_state,      empty_init,      ROT0,   "bootleg", "Midnight Resistance (Joystick bootleg)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, ffantasybl, hippodrm, ffantasybl, ffantasybl, dec0_state,      empty_init,      ROT0,   "bootleg", "Fighting Fantasy (bootleg with 68705)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // 68705 not dumped, might be the same as midresb
+GAME( 1988, drgninjab2, baddudes, drgninjab,  drgninja,   drgninjab_state, empty_init,      ROT0,   "bootleg", "Dragonninja (bootleg with 68705)", MACHINE_SUPPORTS_SAVE ) // is this the same board as above? (region warning hacked to World, but still shows Japanese text), 68705 dumped but not hooked up
 
 // these are different to the above but quite similar to each other
-GAME( 1988, automat,    robocop,  automat,    robocop,    automat_state,  empty_init,      ROT0,   "bootleg", "Automat (bootleg of Robocop)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE ) // sound rom / music from section z with mods for ADPCM?
-GAME( 1989, secretab,   secretag, secretab,   slyspy,     automat_state,  empty_init,      ROT0,   "bootleg", "Secret Agent (bootleg)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 1989, mastbond,   secretag, secretab,   slyspy,     automat_state,  empty_init,      ROT0,   "bootleg", "Master Bond (bootleg of Secret Agent)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME( 1988, automat,    robocop,  automat,    robocop,    automat_state,   empty_init,      ROT0,   "bootleg", "Automat (bootleg of Robocop)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE ) // sound rom / music from section z with mods for ADPCM?
+GAME( 1989, secretab,   secretag, secretab,   slyspy,     automat_state,   empty_init,      ROT0,   "bootleg", "Secret Agent (bootleg)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME( 1989, mastbond,   secretag, secretab,   slyspy,     automat_state,   empty_init,      ROT0,   "bootleg", "Master Bond (bootleg of Secret Agent)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/dataeast/dec0.h
+++ b/src/mame/dataeast/dec0.h
@@ -23,6 +23,7 @@ public:
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
 		m_audiocpu(*this, "audiocpu"),
+		m_mcu(*this, "mcu"),
 		m_soundlatch(*this, "soundlatch"),
 		m_screen(*this, "screen"),
 		m_gfxdecode(*this, "gfxdecode"),
@@ -32,106 +33,139 @@ public:
 		m_palette(*this, "palette"),
 		m_paletteram(*this, "palette"),
 		m_ram(*this, "ram"),
-		m_mcu(*this, "mcu")
+		m_io_inputs(*this, "INPUTS"),
+		m_io_system(*this, "SYSTEM"),
+		m_io_dsw(*this, "DSW"),
+		m_io_an(*this, "AN%u", 0U)
 	{ }
 
 	void dec0_base(machine_config &config);
 	void dec0(machine_config &config);
 	void dec1(machine_config &config);
-	void midres(machine_config &config);
-	void birdtry(machine_config &config);
-	void baddudes(machine_config &config);
-	void midresbj(machine_config &config);
-	void hbarrel(machine_config &config);
-	void bandit(machine_config &config);
-	void midresb(machine_config &config);
 	void ffantasybl(machine_config &config);
-	void drgninjab(machine_config &config);
+	void midres(machine_config &config);
+	void midresbj(machine_config &config);
+	void midresb(machine_config &config);
 	void robocopb(machine_config &config);
 
-	void init_hbarrel();
-	void init_drgninja();
 	void init_ffantasybl();
 
 protected:
-	virtual void machine_start() override ATTR_COLD;
+	virtual void dec0_control_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	virtual u16 dec0_controls_r(offs_t offset);
 
-	required_device<cpu_device> m_maincpu;
-	required_device<cpu_device> m_audiocpu;
-	required_device<generic_latch_8_device> m_soundlatch;
-	required_device<screen_device> m_screen;
-	required_device<gfxdecode_device> m_gfxdecode;
-	optional_device_array<deco_bac06_device, 3> m_tilegen;
-	optional_device<deco_mxc06_device> m_spritegen;
-	required_device<buffered_spriteram16_device> m_spriteram;
-	required_device<palette_device> m_palette;
-	required_shared_ptr<uint16_t> m_paletteram;
-	required_shared_ptr<uint16_t> m_ram;
+	u16 midres_controls_r(offs_t offset);
+	u16 slyspy_controls_r(offs_t offset);
+	void priority_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
-	uint16_t *m_buffered_spriteram = nullptr;
-	uint16_t m_pri = 0U;
-
-	uint16_t dec0_controls_r(offs_t offset);
-	uint16_t slyspy_controls_r(offs_t offset);
-	void priority_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void sprite_mirror_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	DECLARE_VIDEO_START(dec0);
 
 	DECLARE_VIDEO_START(dec0_nodma);
 	DECLARE_VIDEO_START(slyspy);
 
-	uint32_t screen_update_robocop(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u16 ffantasybl_242024_r();
 
-	void robocop_colpri_cb(u32 &colour, u32 &pri_mask);
+	u32 screen_update_robocop(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
 	void baddudes_tile_cb(tile_data &tileinfo, u32 &tile, u32 &colour, u32 &flags);
+
+	void midres_colpri_cb(u32 &colour, u32 &pri_mask);
+	void robocop_colpri_cb(u32 &colour, u32 &pri_mask);
 
 	void set_screen_raw_params(machine_config &config);
 
 	void h6280_decrypt(const char *cputag);
+
 	void dec0_map(address_map &map) ATTR_COLD;
-
-private:
-	enum class mcu_type {
-		EMULATED,
-		BADDUDES_SIM
-	};
-
-	optional_device<cpu_device> m_mcu;
-
-	mcu_type m_game{};
-	uint16_t m_i8751_return = 0U;
-	uint16_t m_i8751_command = 0U;
-	uint8_t m_i8751_ports[4]{};
-
-	void dec0_control_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t midres_controls_r(offs_t offset);
-	uint8_t dec0_mcu_port0_r();
-	void dec0_mcu_port0_w(uint8_t data);
-	void dec0_mcu_port1_w(uint8_t data);
-	void dec0_mcu_port2_w(uint8_t data);
-	void dec0_mcu_port3_w(uint8_t data);
-	uint16_t ffantasybl_242024_r();
-
-	DECLARE_VIDEO_START(dec0);
-	DECLARE_VIDEO_START(baddudes);
-
-	uint32_t screen_update_hbarrel(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_baddudes(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_birdtry(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_bandit(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-
-	void hbarrel_colpri_cb(u32 &colour, u32 &pri_mask);
-	void bandit_colpri_cb(u32 &colour, u32 &pri_mask);
-	void midres_colpri_cb(u32 &colour, u32 &pri_mask);
-
-	void baddudes_i8751_write(int data);
-	void dec0_i8751_write(int data);
-	void dec0_i8751_reset();
-	void ffantasybl_map(address_map &map) ATTR_COLD;
-	void dec0_tb_map(address_map &map) ATTR_COLD;
 	void dec0_s_map(address_map &map) ATTR_COLD;
+	void ffantasybl_map(address_map &map) ATTR_COLD;
 	void midres_map(address_map &map) ATTR_COLD;
 	void midres_s_map(address_map &map) ATTR_COLD;
 	void midresb_map(address_map &map) ATTR_COLD;
+
+	required_device<cpu_device> m_maincpu;
+	required_device<cpu_device> m_audiocpu;
+	optional_device<cpu_device> m_mcu;
+	required_device<generic_latch_8_device> m_soundlatch;
+	required_device<screen_device> m_screen;
+	required_device<gfxdecode_device> m_gfxdecode;
+	optional_device_array<deco_bac06_device, 3> m_tilegen;
+	required_device<deco_mxc06_device> m_spritegen;
+	required_device<buffered_spriteram16_device> m_spriteram;
+	required_device<palette_device> m_palette;
+	required_shared_ptr<u16> m_paletteram;
+	required_shared_ptr<u16> m_ram;
+
+	optional_ioport m_io_inputs;
+	optional_ioport m_io_system;
+	optional_ioport m_io_dsw;
+	optional_ioport_array<2> m_io_an;
+
+	u16 *m_buffered_spriteram = nullptr;
+	u16 m_pri = 0U;
+};
+
+
+// with I8751 MCU, simulated case (including bootleg)
+class drgninjab_state : public dec0_state
+{
+public:
+	drgninjab_state(const machine_config &mconfig, device_type type, const char *tag) :
+		dec0_state(mconfig, type, tag)
+	{ }
+
+	void drgninjab(machine_config &config);
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+
+	virtual void dec0_control_w(offs_t offset, u16 data, u16 mem_mask = ~0) override;
+	virtual u16 dec0_controls_r(offs_t offset) override;
+
+	virtual void dec0_i8751_w(u16 data);
+
+	void dec0_i8751_reset_w(u16 data = 0);
+
+	DECLARE_VIDEO_START(baddudes);
+
+	u32 screen_update_baddudes(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+	u16 m_i8751_return = 0U;
+	u16 m_i8751_command = 0U;
+	u8 m_i8751_ports[4]{};
+};
+
+// above with emulation
+class dec0_8751_state : public drgninjab_state
+{
+public:
+	dec0_8751_state(const machine_config &mconfig, device_type type, const char *tag) :
+		drgninjab_state(mconfig, type, tag)
+	{ }
+
+	void birdtry(machine_config &config);
+	void bandit(machine_config &config);
+	void baddudes(machine_config &config);
+	void hbarrel(machine_config &config);
+
+protected:
+	virtual void dec0_i8751_w(u16 data) override;
+
+private:
+	u8 dec0_mcu_port0_r();
+	void dec0_mcu_port0_w(u8 data);
+	void dec0_mcu_port1_w(u8 data);
+	void dec0_mcu_port2_w(u8 data);
+	void dec0_mcu_port3_w(u8 data);
+
+	u32 screen_update_bandit(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_birdtry(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_hbarrel(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+	void bandit_colpri_cb(u32 &colour, u32 &pri_mask);
+	void hbarrel_colpri_cb(u32 &colour, u32 &pri_mask);
+
+	void dec0_tb_map(address_map &map) ATTR_COLD;
 };
 
 
@@ -169,18 +203,19 @@ public:
 	void init_hippodrm();
 
 private:
-	required_shared_ptr<uint8_t> m_sharedram;
-
-	uint8_t m_prot_msb = 0;
-	uint8_t m_prot_lsb = 0;
-
-	uint8_t prot_r(offs_t offset);
-	void prot_w(offs_t offset, uint8_t data);
-	uint16_t sharedram_r(offs_t offset);
-	void sharedram_w(offs_t offset, uint16_t data);
+	u8 prot_r(offs_t offset);
+	void prot_w(offs_t offset, u8 data);
+	u16 sharedram_r(offs_t offset);
+	void sharedram_w(offs_t offset, u16 data);
+	void sprite_mirror_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
 	void main_map(address_map &map) ATTR_COLD;
 	void sub_map(address_map &map) ATTR_COLD;
+
+	required_shared_ptr<u8> m_sharedram;
+
+	u8 m_prot_msb = 0;
+	u8 m_prot_lsb = 0;
 };
 
 
@@ -202,25 +237,25 @@ protected:
 	virtual void machine_reset() override ATTR_COLD;
 
 private:
-	memory_view m_pfview;
-	memory_view m_sndview;
+	u16 prot_r(offs_t offset);
+	void prot_state_w(u16 data);
+	u16 prot_state_r();
+	u8 sound_prot_state_r();
+	u8 sound_prot_state_reset_r();
 
-	uint8_t m_prot_state = 0;
-	uint8_t m_sound_prot_state = 0;
-
-	uint16_t prot_r(offs_t offset);
-	void prot_state_w(uint16_t data);
-	uint16_t prot_state_r();
-	uint8_t sound_prot_state_r();
-	uint8_t sound_prot_state_reset_r();
-
-	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 	void main_map(address_map &map) ATTR_COLD;
 	void sound_map(address_map &map) ATTR_COLD;
+
+	memory_view m_pfview;
+	memory_view m_sndview;
+
+	u8 m_prot_state = 0;
+	u8 m_sound_prot_state = 0;
 };
 
-
+// bootleg hardware
 class automat_state : public dec0_state
 {
 public:
@@ -236,33 +271,34 @@ public:
 	void secretab(machine_config &config);
 	void automat(machine_config &config);
 
+protected:
+	virtual void machine_start() override ATTR_COLD;
+
 private:
+	void automat_control_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 automat_palette_r(offs_t offset);
+	void automat_palette_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void automat_scroll_w(offs_t offset, u16 data, u16 mem_mask = ~0)
+	{
+		COMBINE_DATA(&m_automat_scroll_regs[offset]);
+	}
+	void sound_bankswitch_w(u8 data);
+	void msm1_vclk_cb(int state);
+	void msm2_vclk_cb(int state);
+
+	u32 screen_update_automat(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_secretab(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void automat_map(address_map &map) ATTR_COLD;
+	void automat_s_map(address_map &map) ATTR_COLD;
+	void secretab_map(address_map &map) ATTR_COLD;
+	void secretab_s_map(address_map &map) ATTR_COLD;
+
 	required_device_array<msm5205_device, 2> m_msm;
 	required_device_array<ls157_device, 2> m_adpcm_select;
 	required_memory_bank m_soundbank;
 
 	bool m_adpcm_toggle[2]{};
-	uint16_t m_automat_scroll_regs[4]{};
-
-	void automat_control_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t automat_palette_r(offs_t offset);
-	void automat_palette_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void automat_scroll_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0)
-	{
-		COMBINE_DATA(&m_automat_scroll_regs[offset]);
-	}
-	void sound_bankswitch_w(uint8_t data);
-	void msm1_vclk_cb(int state);
-	void msm2_vclk_cb(int state);
-
-	virtual void machine_start() override ATTR_COLD;
-
-	uint32_t screen_update_automat(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_secretab(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void automat_map(address_map &map) ATTR_COLD;
-	void automat_s_map(address_map &map) ATTR_COLD;
-	void secretab_map(address_map &map) ATTR_COLD;
-	void secretab_s_map(address_map &map) ATTR_COLD;
+	u16 m_automat_scroll_regs[4]{};
 };
 
 #endif // MAME_DATAEAST_DEC0_H

--- a/src/mame/dataeast/dec0_m.cpp
+++ b/src/mame/dataeast/dec0_m.cpp
@@ -18,56 +18,70 @@ Data East machine functions - Bryan McPhail, mish@tendril.co.uk
 
 /******************************************************************************/
 
-void dec0_state::machine_start()
+void drgninjab_state::machine_start()
 {
+	dec0_state::machine_start();
+
 	save_item(NAME(m_i8751_return));
 	save_item(NAME(m_i8751_command));
 	save_item(NAME(m_i8751_ports));
 }
 
-uint16_t dec0_state::dec0_controls_r(offs_t offset)
+u16 dec0_state::dec0_controls_r(offs_t offset)
 {
-	switch (offset<<1)
+	switch (offset << 1)
 	{
-		case 0: /* Player 1 & 2 joystick & buttons */
-			return ioport("INPUTS")->read();
+		case 0x0: /* Player 1 & 2 joystick & buttons */
+			return m_io_inputs->read();
 
-		case 2: /* Credits, start buttons */
-			return ioport("SYSTEM")->read();
+		case 0x2: /* Credits, start buttons */
+			return m_io_system->read();
 
-		case 4: /* Byte 4: Dipswitch bank 2, Byte 5: Dipswitch Bank 1 */
-			return ioport("DSW")->read();
+		case 0x4: /* Byte 4: Dipswitch bank 2, Byte 5: Dipswitch Bank 1 */
+			return m_io_dsw->read();
 
-		case 8: /* Intel 8751 mc, Bad Dudes, Heavy Barrel & Birdie Try only */
-			//logerror("CPU #0 PC %06x: warning - read i8751 %06x - %04x\n", m_maincpu->pc(), 0x30c000+offset, m_i8751_return);
-			return m_i8751_return;
+		case 0x8: /* MCU data, see below */
+			return 0;
 	}
 
-	logerror("CPU #0 PC %06x: warning - read unmapped memory address %06x\n", m_maincpu->pc(), 0x30c000+offset);
+	if (!machine().side_effects_disabled())
+		logerror("%s: Unknown dec0_controls_r read at %02x\n", machine().describe_context(), offset);
 	return ~0;
+}
+
+u16 drgninjab_state::dec0_controls_r(offs_t offset)
+{
+	switch (offset << 1)
+	{
+		case 0x8: /* Intel 8751 mc, Bad Dudes, Heavy Barrel & Birdie Try only */
+			//logerror("%s: warning - read i8751 %02x - %04x\n", machine().describe_context(), offset, m_i8751_return);
+			return m_i8751_return;
+		default:
+			return dec0_state::dec0_controls_r(offset);
+	}
 }
 
 
 /******************************************************************************/
 
-uint16_t dec0_state::midres_controls_r(offs_t offset)
+u16 dec0_state::midres_controls_r(offs_t offset)
 {
-	switch (offset<<1)
+	switch (offset << 1)
 	{
 		case 0: /* Player 1 Joystick + start, Player 2 Joystick + start */
-			return ioport("INPUTS")->read();
+			return m_io_inputs->read();
 
 		case 2: /* Dipswitches */
-			return ioport("DSW")->read();
+			return m_io_dsw->read();
 
 		case 4: /* Player 1 rotary */
-			return ioport("AN0")->read();
+			return m_io_an[0]->read();
 
 		case 6: /* Player 2 rotary */
-			return ioport("AN1")->read();
+			return m_io_an[1]->read();
 
 		case 8: /* Credits, start buttons */
-			return ioport("SYSTEM")->read();
+			return m_io_system->read();
 
 		case 0xa: // clr.w
 			return 0;
@@ -76,7 +90,8 @@ uint16_t dec0_state::midres_controls_r(offs_t offset)
 			return 0;   /* ?? watchdog ?? */
 	}
 
-	logerror("PC %06x unknown control read at %02x\n", m_maincpu->pc(), 0x180000+(offset<<1));
+	if (!machine().side_effects_disabled())
+		logerror("%s: unknown midres_controls_r read at %06x\n", machine().describe_context(), 0x180000 + (offset << 1));
 	return ~0;
 }
 
@@ -85,31 +100,33 @@ uint16_t dec0_state::midres_controls_r(offs_t offset)
 /******************************************************************************/
 
 
-uint8_t hippodrm_state::prot_r(offs_t offset)
+u8 hippodrm_state::prot_r(offs_t offset)
 {
-//logerror("6280 PC %06x - Read %06x\n",cpu_getpc(),offset+0x1d0000);
+//logerror("%s - prot_r Read %06x\n", machine().describe_context(), offset + 0x1d0000);
 	if (m_prot_lsb == 0x45) return 0x4e;
 	if (m_prot_lsb == 0x92) return 0x15;
 	return 0;
 }
 
-void hippodrm_state::prot_w(offs_t offset, uint8_t data)
+void hippodrm_state::prot_w(offs_t offset, u8 data)
 {
 	switch (offset)
 	{
 		case 4: m_prot_msb = data; break;
 		case 5: m_prot_lsb = data; break;
 	}
-//logerror("6280 PC %06x - Wrote %06x to %04x\n",cpu_getpc(),data,offset+0x1d0000);
+//logerror("%s - prot_w Wrote %02x to %06x\n", machine().describe_context(), data, offset + 0x1d0000);
 }
 
-uint16_t hippodrm_state::sharedram_r(offs_t offset)
+u16 hippodrm_state::sharedram_r(offs_t offset)
 {
-	if (offset == 0) m_maincpu->yield(); /* A wee helper */
+	/* A wee helper */
+	if ((offset == 0) && !machine().side_effects_disabled())
+		m_maincpu->yield();
 	return m_sharedram[offset] & 0xff;
 }
 
-void hippodrm_state::sharedram_w(offs_t offset, uint16_t data)
+void hippodrm_state::sharedram_w(offs_t offset, u16 data)
 {
 	m_sharedram[offset] = data & 0xff;
 }
@@ -151,9 +168,9 @@ void hippodrm_state::sharedram_w(offs_t offset, uint16_t data)
 */
 
 
-uint8_t dec0_state::dec0_mcu_port0_r()
+u8 dec0_8751_state::dec0_mcu_port0_r()
 {
-	uint8_t result = 0xff;
+	u8 result = 0xff;
 
 	// P0 connected to latches
 	if (!BIT(m_i8751_ports[2], 4))
@@ -164,18 +181,18 @@ uint8_t dec0_state::dec0_mcu_port0_r()
 	return result;
 }
 
-void dec0_state::dec0_mcu_port0_w(uint8_t data)
+void dec0_8751_state::dec0_mcu_port0_w(u8 data)
 {
 	m_i8751_ports[0] = data;
 }
 
-void dec0_state::dec0_mcu_port1_w(uint8_t data)
+void dec0_8751_state::dec0_mcu_port1_w(u8 data)
 {
-	logerror("dec0_mcu_port1_w: %02x\n", data);
+	logerror("%s: dec0_mcu_port1_w: %02x\n", machine().describe_context(), data);
 	m_i8751_ports[1] = data;
 }
 
-void dec0_state::dec0_mcu_port2_w(uint8_t data)
+void dec0_8751_state::dec0_mcu_port2_w(u8 data)
 {
 	if (!BIT(data, 2) && BIT(m_i8751_ports[2], 2))
 		m_maincpu->set_input_line(M68K_IRQ_5, HOLD_LINE);
@@ -189,13 +206,13 @@ void dec0_state::dec0_mcu_port2_w(uint8_t data)
 	m_i8751_ports[2] = data;
 }
 
-void dec0_state::dec0_mcu_port3_w(uint8_t data)
+void dec0_8751_state::dec0_mcu_port3_w(u8 data)
 {
-	logerror("dec0_mcu_port3_w: %02x\n", data);
+	logerror("%s: dec0_mcu_port3_w: %02x\n", machine().describe_context(), data);
 	m_i8751_ports[3] = data;
 }
 
-void dec0_state::baddudes_i8751_write(int data)
+void drgninjab_state::dec0_i8751_w(u16 data)
 {
 	m_i8751_return = 0;
 
@@ -219,37 +236,29 @@ void dec0_state::baddudes_i8751_write(int data)
 		case 0x75b: m_i8751_return = 0x70f; break;
 	}
 
-	if (!m_i8751_return) logerror("%s: warning - write unknown command %02x to 8571\n",machine().describe_context(),data);
-	m_maincpu->set_input_line(5, HOLD_LINE);
+	if (!m_i8751_return) logerror("%s: warning - write unknown command %04x to 8751\n", machine().describe_context(), data);
+	m_maincpu->set_input_line(M68K_IRQ_5, HOLD_LINE);
 }
 
-void dec0_state::dec0_i8751_write(int data)
+void dec0_8751_state::dec0_i8751_w(u16 data)
 {
 	m_i8751_command = data;
 
 	/* Writes to this address raise an IRQ on the i8751 microcontroller */
-	switch (m_game)
-	{
-	case mcu_type::EMULATED:
-		if (BIT(m_i8751_ports[2], 3))
-			m_mcu->set_input_line(MCS51_INT1_LINE, ASSERT_LINE);
-		break;
-	case mcu_type::BADDUDES_SIM:
-		baddudes_i8751_write(data);
-		break;
-	}
+	if (BIT(m_i8751_ports[2], 3))
+		m_mcu->set_input_line(MCS51_INT1_LINE, ASSERT_LINE);
 
-	//logerror("%s: warning - write %02x to i8751\n",machine().describe_context(),data);
+	//logerror("%s: warning - write %04x to i8751\n", machine().describe_context(), data);
 }
 
-void dec0_state::dec0_i8751_reset()
+void drgninjab_state::dec0_i8751_reset_w(u16 data)
 {
 	m_i8751_return = m_i8751_command = 0;
 }
 
 /******************************************************************************/
 
-void dec0_state::sprite_mirror_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void hippodrm_state::sprite_mirror_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_spriteram->live()[offset]);
 }
@@ -258,7 +267,7 @@ void dec0_state::sprite_mirror_w(offs_t offset, uint16_t data, uint16_t mem_mask
 
 void dec0_state::h6280_decrypt(const char *cputag)
 {
-	uint8_t *RAM = memregion(cputag)->base();
+	u8 *RAM = memregion(cputag)->base();
 
 	/* Read each byte, decrypt it */
 	for (int i = 0x00000; i < 0x10000; i++)
@@ -267,7 +276,7 @@ void dec0_state::h6280_decrypt(const char *cputag)
 
 void hippodrm_state::init_hippodrm()
 {
-	uint8_t *RAM = memregion("sub")->base();
+	u8 *RAM = memregion("sub")->base();
 
 	h6280_decrypt("sub");
 
@@ -287,14 +296,4 @@ void slyspy_state::init_slyspy()
 
 	save_item(NAME(m_prot_state));
 	save_item(NAME(m_sound_prot_state));
-}
-
-void dec0_state::init_drgninja()
-{
-	m_game = mcu_type::BADDUDES_SIM;
-}
-
-void dec0_state::init_hbarrel()
-{
-	m_game = mcu_type::EMULATED;
 }

--- a/src/mame/dataeast/dec0_v.cpp
+++ b/src/mame/dataeast/dec0_v.cpp
@@ -12,33 +12,33 @@
 
 /******************************************************************************/
 
-void dec0_state::hbarrel_colpri_cb(u32 &colour, u32 &pri_mask)
+void dec0_8751_state::hbarrel_colpri_cb(u32 &colour, u32 &pri_mask)
 {
 	pri_mask = GFX_PMASK_4; // above background, foreground
-	if (colour & 8)
+	if (BIT(colour, 3))
 	{
 		pri_mask |= GFX_PMASK_2; // behind foreground
 	}
 }
 
 /* HB always keeps pf2 on top of pf3, no need explicitly support priority register */
-uint32_t dec0_state::screen_update_hbarrel(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 dec0_8751_state::screen_update_hbarrel(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen.priority().fill(0,cliprect);
-	bool flip = m_tilegen[0]->get_flip_state();
+	const bool flip = m_tilegen[0]->get_flip_state();
 	m_tilegen[0]->set_flip_screen(flip);
 	m_tilegen[1]->set_flip_screen(flip);
 	m_tilegen[2]->set_flip_screen(flip);
 	m_spritegen->set_flip_screen(flip);
 
-	m_tilegen[2]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 1);
-	m_tilegen[1]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 2);
-	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 4);
+	m_tilegen[2]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+	m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 2);
+	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 4);
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
 	return 0;
 }
 
-void dec0_state::bandit_colpri_cb(u32 &colour, u32 &pri_mask)
+void dec0_8751_state::bandit_colpri_cb(u32 &colour, u32 &pri_mask)
 {
 	pri_mask = 0; // above all
 	if (m_pri == 0)
@@ -54,10 +54,10 @@ void dec0_state::bandit_colpri_cb(u32 &colour, u32 &pri_mask)
 	}
 }
 
-uint32_t dec0_state::screen_update_bandit(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 dec0_8751_state::screen_update_bandit(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen.priority().fill(0,cliprect);
-	bool flip = m_tilegen[0]->get_flip_state();
+	const bool flip = m_tilegen[0]->get_flip_state();
 	m_tilegen[0]->set_flip_screen(flip);
 	m_tilegen[1]->set_flip_screen(flip);
 	m_tilegen[2]->set_flip_screen(flip);
@@ -65,15 +65,15 @@ uint32_t dec0_state::screen_update_bandit(screen_device &screen, bitmap_ind16 &b
 
 	if (m_pri == 7)
 	{
-		m_tilegen[1]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 1);
-		m_tilegen[2]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 2);
-		m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 4);
+		m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+		m_tilegen[2]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 4);
 	}
 	else
 	{
-		m_tilegen[2]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 1);
-		m_tilegen[1]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 2);
-		m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 4);
+		m_tilegen[2]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+		m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 4);
 	}
 
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
@@ -84,32 +84,32 @@ uint32_t dec0_state::screen_update_bandit(screen_device &screen, bitmap_ind16 &b
 
 void dec0_state::baddudes_tile_cb(tile_data &tileinfo, u32 &tile, u32 &colour, u32 &flags)
 {
-	tileinfo.group = BIT(colour, 3) ? 1 : 0;
+	tileinfo.group = BIT(colour, 3);
 }
 
-uint32_t dec0_state::screen_update_baddudes(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 drgninjab_state::screen_update_baddudes(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	bool flip = m_tilegen[0]->get_flip_state();
+	const bool flip = m_tilegen[0]->get_flip_state();
 	m_tilegen[0]->set_flip_screen(flip);
 	m_tilegen[1]->set_flip_screen(flip);
 	m_tilegen[2]->set_flip_screen(flip);
 	m_spritegen->set_flip_screen(flip);
 
 	/* WARNING: inverted wrt Midnight Resistance */
-	const u8 fg = (m_pri & 0x01) ? 1 : 2;
-	const u8 bg = (m_pri & 0x01) ? 2 : 1;
-	m_tilegen[bg]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 0);
-	m_tilegen[fg]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER0 | TILEMAP_DRAW_LAYER1, 0);
+	const u8 fg = BIT(m_pri, 0) ? 1 : 2;
+	const u8 bg = BIT(m_pri, 0) ? 2 : 1;
+	m_tilegen[bg]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen[fg]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | TILEMAP_DRAW_LAYER1, 0);
 
-	if (m_pri & 2)
-		m_tilegen[bg]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles /* Foreground pens only */
+	if (BIT(m_pri, 1))
+		m_tilegen[bg]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles /* Foreground pens only */
 
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
 
-	if (m_pri & 4)
-		m_tilegen[fg]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles /* Foreground pens only */
+	if (BIT(m_pri, 2))
+		m_tilegen[fg]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles /* Foreground pens only */
 
-	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 0);
+	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
@@ -123,9 +123,9 @@ uint32_t dec0_state::screen_update_baddudes(screen_device &screen, bitmap_ind16 
 void dec0_state::robocop_colpri_cb(u32 &colour, u32 &pri_mask)
 {
 	pri_mask = 0; // above background, foreground
-	if (m_pri & 0x02)
+	if (BIT(m_pri, 1))
 	{
-		const u32 trans = (m_pri & 0x04) ? 0x08 : 0x00;
+		const u32 trans = BIT(m_pri, 2) ? 0x08 : 0x00;
 		if ((colour & 0x08) == trans)
 			pri_mask |= GFX_PMASK_2; // behind foreground
 	}
@@ -134,34 +134,34 @@ void dec0_state::robocop_colpri_cb(u32 &colour, u32 &pri_mask)
 void dec0_state::midres_colpri_cb(u32 &colour, u32 &pri_mask)
 {
 	pri_mask = 0; // above background, foreground
-	if (m_pri & 0x02)
+	if (BIT(m_pri, 1))
 	{
-		const u32 trans = (m_pri & 0x04) ? 0x00 : 0x08;
+		const u32 trans = BIT(m_pri, 2) ? 0x00 : 0x08;
 		if ((colour & 0x08) == trans)
 			pri_mask |= GFX_PMASK_2; // behind foreground
 	}
 }
 
-uint32_t dec0_state::screen_update_robocop(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 dec0_state::screen_update_robocop(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen.priority().fill(0,cliprect);
 
-	bool flip = m_tilegen[0]->get_flip_state();
+	const bool flip = m_tilegen[0]->get_flip_state();
 	m_tilegen[0]->set_flip_screen(flip);
 	m_tilegen[1]->set_flip_screen(flip);
 	m_tilegen[2]->set_flip_screen(flip);
 	m_spritegen->set_flip_screen(flip);
 
-	const u8 fg = (m_pri & 0x01) ? 2 : 1;
-	const u8 bg = (m_pri & 0x01) ? 1 : 2;
-	m_tilegen[bg]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 1);
-	m_tilegen[fg]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 2);
+	const u8 fg = BIT(m_pri, 0) ? 2 : 1;
+	const u8 bg = BIT(m_pri, 0) ? 1 : 2;
+	m_tilegen[bg]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+	m_tilegen[fg]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 2);
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
-	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 0);
+	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
-uint32_t automat_state::screen_update_automat(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 automat_state::screen_update_automat(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen.priority().fill(0,cliprect);
 
@@ -194,27 +194,27 @@ uint32_t automat_state::screen_update_automat(screen_device &screen, bitmap_ind1
 	m_tilegen[2]->pf_control_1_w(1,m_automat_scroll_regs[0], 0xffff);
 
 
-	bool flip = m_tilegen[0]->get_flip_state();
+	const bool flip = m_tilegen[0]->get_flip_state();
 	m_tilegen[0]->set_flip_screen(flip);
 	m_tilegen[1]->set_flip_screen(flip);
 	m_tilegen[2]->set_flip_screen(flip);
 	m_spritegen->set_flip_screen(flip);
 
-	const u8 fg = (m_pri & 0x01) ? 2 : 1;
-	const u8 bg = (m_pri & 0x01) ? 1 : 2;
-	m_tilegen[bg]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 1);
-	m_tilegen[fg]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 2);
+	const u8 fg = BIT(m_pri, 0) ? 2 : 1;
+	const u8 bg = BIT(m_pri, 0) ? 1 : 2;
+	m_tilegen[bg]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+	m_tilegen[fg]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 2);
 	m_spritegen->draw_sprites_bootleg(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2); // TODO : RAM size
-	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 0);
+	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
 
 /******************************************************************************/
 
-uint32_t dec0_state::screen_update_birdtry(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 dec0_8751_state::screen_update_birdtry(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	bool flip = m_tilegen[0]->get_flip_state();
+	const bool flip = m_tilegen[0]->get_flip_state();
 	m_tilegen[0]->set_flip_screen(flip);
 	m_tilegen[1]->set_flip_screen(flip);
 	m_spritegen->set_flip_screen(flip);
@@ -222,37 +222,37 @@ uint32_t dec0_state::screen_update_birdtry(screen_device &screen, bitmap_ind16 &
 	/* This game doesn't have the extra playfield chip on the game board, but
 	the palette does show through. */
 	bitmap.fill(m_palette->pen(768), cliprect);
-	m_tilegen[1]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 0);
+	m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 0);
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
-	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 0);
+	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
 
 /******************************************************************************/
 
-uint32_t slyspy_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 slyspy_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	bool flip = m_tilegen[0]->get_flip_state();
+	const bool flip = m_tilegen[0]->get_flip_state();
 	m_tilegen[0]->set_flip_screen(flip);
 	m_tilegen[1]->set_flip_screen(flip);
 	m_tilegen[2]->set_flip_screen(flip);
 	m_spritegen->set_flip_screen(flip);
 
-	m_tilegen[2]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 0);
-	m_tilegen[1]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER0 | TILEMAP_DRAW_LAYER1, 0);
+	m_tilegen[2]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | TILEMAP_DRAW_LAYER1, 0);
 
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
 
 	/* Redraw top 8 pens of top 8 palettes over sprites */
-	if (m_pri & 0x80)
-		m_tilegen[1]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles
+	if (BIT(m_pri, 7))
+		m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles
 
-	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,0,0);
+	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0,0);
 	return 0;
 }
 
-uint32_t automat_state::screen_update_secretab(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 automat_state::screen_update_secretab(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	// layer enables seem different... where are they?
 
@@ -282,29 +282,29 @@ uint32_t automat_state::screen_update_secretab(screen_device &screen, bitmap_ind
 	m_tilegen[2]->pf_control_1_w(0,m_automat_scroll_regs[1] - 0x0108, 0xffff);
 	m_tilegen[2]->pf_control_1_w(1,m_automat_scroll_regs[0], 0xffff);
 
-	bool flip = m_tilegen[0]->get_flip_state();
+	const bool flip = m_tilegen[0]->get_flip_state();
 	m_tilegen[0]->set_flip_screen(flip);
 	m_tilegen[1]->set_flip_screen(flip);
 	m_tilegen[2]->set_flip_screen(flip);
 	m_spritegen->set_flip_screen(flip);
 
-	m_tilegen[2]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 0);
-	m_tilegen[1]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER0 | TILEMAP_DRAW_LAYER1, 0);
+	m_tilegen[2]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | TILEMAP_DRAW_LAYER1, 0);
 
 	m_spritegen->draw_sprites_bootleg(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2); // TODO : RAM size
 
 	/* Redraw top 8 pens of top 8 palettes over sprites */
-	if (m_pri & 0x80)
-		m_tilegen[1]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles
+	if (BIT(m_pri, 7))
+		m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles
 
-	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,0,0);
+	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0,0);
 	return 0;
 }
 
 
 /******************************************************************************/
 
-void dec0_state::priority_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void dec0_state::priority_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_pri);
 }
@@ -327,7 +327,7 @@ VIDEO_START_MEMBER(dec0_state,dec0)
 	m_pri = 0;
 }
 
-VIDEO_START_MEMBER(dec0_state,baddudes)
+VIDEO_START_MEMBER(drgninjab_state,baddudes)
 {
 	VIDEO_START_CALL_MEMBER(dec0);
 	m_tilegen[1]->set_transmask(0, 0xffff, 0x0001);


### PR DESCRIPTION
- Reduce literal tag usage and runtime tag lookups
- Add side effect checks for debugger reads
- Fix spacings
- Fix value consistency
- Use shortened typename values for consistency
- Improve logging features
- Make some variables constant
- Use BIT helper for single bit values
- Add / Fix notes