### PR TITLE
GPL951xx milestone (begin splitting from GPL162xx, hack removal in driver, cleanup)

### DIFF
--- a/src/devices/machine/generalplus_gpce4_soc.cpp
+++ b/src/devices/machine/generalplus_gpce4_soc.cpp
@@ -1019,7 +1019,7 @@ void generalplus_gpce4_soc_device::fiq2_sel_w(u16 data)
 // 15  SPIEN
 // 14  ---
 // 13  LBM
-// 12  SPICS_IO
+// 12  SPICS_IO (0 = SPI_CS controlled by I/O, 1 = SPI_CS auto controlled) 
 //
 // 11  SPIRST
 // 10  ---
@@ -1061,8 +1061,8 @@ void generalplus_gpce4_soc_device::spi2_rxstatus_w(u16 data)
 
 // SPI2_TXSTATUS
 //
-// 15  SPITXIF
-// 14  SPITXIEN
+// 15  SPITXIF     (SPI Transmit Interrupt Flag, Read 0 = Not Occured, Read 1 = Occured, Write 0 = No Effect, Write 1 = Clear flag)
+// 14  SPITXIEN    (SPI Transmit Interrupt Enable)
 // 13  --
 // 12  --
 //
@@ -1071,12 +1071,12 @@ void generalplus_gpce4_soc_device::spi2_rxstatus_w(u16 data)
 //  9  --
 //  8  --
 //
-//  7  TXFLEV[3]
+//  7  TXFLEV[3] - Transmit FIFO interrupt level register (how many empty slots when issuing an IRQ)
 //  6  TXFLEV[2]
 //  5  TXFLEV[1]
 //  4  TXFLEX[0]
 //
-//  3  TXFFLAG[3]
+//  3  TXFFLAG[3] - Transmit FIFO Data Level - how much data is in FIFO
 //  2  TXFFLAG[2]
 //  1  TXFFLAG[1]
 //  0  TXFFLAG[0]
@@ -1115,7 +1115,7 @@ u16 generalplus_gpce4_soc_device::spi2_rxdata_r()
 // 11  ---
 // 10  ---
 //  9  OVER
-//  8  SMART
+//  8  SMART   (0 = Normal Interrupt Clear, 1 = Smart Interrupt Clear)
 //
 //  7  ---
 //  6  ---

--- a/src/devices/machine/generalplus_gpl1625x_soc.cpp
+++ b/src/devices/machine/generalplus_gpl1625x_soc.cpp
@@ -854,7 +854,7 @@ vbaby code is very differet, attempts to load NAND block manually, not with DMA
 
 // all tilemap registers etc. appear to be in the same place as the above system, including the 'extra' ones not on the earlier models
 // so it's likely this is built on top of that just with NAND support
-void generalplus_gpac800_device::gpac800_internal_map(address_map& map)
+void generalplus_gpac800_device::gpac800_internal_map(address_map &map)
 {
 	sunplus_gcm394_base_device::base_internal_map(map);
 
@@ -907,7 +907,7 @@ u16 generalplus_gpspispi_device::spi_unk_7943_r()
 	return 0x0007;
 }
 
-void generalplus_gpspispi_device::gpspispi_internal_map(address_map& map)
+void generalplus_gpspispi_device::gpspispi_internal_map(address_map &map)
 {
 	sunplus_gcm394_base_device::base_internal_map(map);
 

--- a/src/devices/machine/generalplus_gpl1625x_soc.cpp
+++ b/src/devices/machine/generalplus_gpl1625x_soc.cpp
@@ -568,12 +568,12 @@
 DEFINE_DEVICE_TYPE(GPAC800,   generalplus_gpac800_device,  "gpac800",    "GeneralPlus GPL1625x System-on-a-Chip (with NAND handling)")
 DEFINE_DEVICE_TYPE(GP_SPISPI, generalplus_gpspispi_device, "gpac800spi", "GeneralPlus GPL1625x System-on-a-Chip (with SPI handling)")
 
-generalplus_gpac800_device::generalplus_gpac800_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+generalplus_gpac800_device::generalplus_gpac800_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
 	sunplus_gcm394_base_device(mconfig, GPAC800, tag, owner, clock, address_map_constructor(FUNC(generalplus_gpac800_device::gpac800_internal_map), this))
 {
 }
 
-generalplus_gpspispi_device::generalplus_gpspispi_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+generalplus_gpspispi_device::generalplus_gpspispi_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
 	sunplus_gcm394_base_device(mconfig, GP_SPISPI, tag, owner, clock, address_map_constructor(FUNC(generalplus_gpspispi_device::gpspispi_internal_map), this))
 {
 }
@@ -583,7 +583,7 @@ generalplus_gpspispi_device::generalplus_gpspispi_device(const machine_config &m
 // HY27UF081G2A = AD F1 80 1D
 // H27U518S2C   = AD 76
 
-uint16_t generalplus_gpac800_device::nand_7854_r()
+u16 generalplus_gpac800_device::nand_7854_r()
 {
 	// TODO: use actual NAND / Smart Media devices once this is better understood.
 	// The games have extensive checks on startup to determine the flash types, but then it appears that
@@ -604,7 +604,7 @@ uint16_t generalplus_gpac800_device::nand_7854_r()
 	{
 		logerror("%s:sunplus_gcm394_base_device::nand_7854_r   READ IDENT byte %d\n", machine().describe_context(), m_curblockaddr);
 
-		uint8_t data = 0x00;
+		u8 data = 0x00;
 
 		if (m_romtype == 0)
 		{
@@ -640,7 +640,7 @@ uint16_t generalplus_gpac800_device::nand_7854_r()
 	{
 		//logerror("%s:sunplus_gcm394_base_device::nand_7854_r   READ DATA byte %d\n", machine().describe_context(), m_curblockaddr);
 
-		uint8_t data = m_nand_read_cb(m_effectiveaddress + m_curblockaddr);
+		u8 data = m_nand_read_cb(m_effectiveaddress + m_curblockaddr);
 
 		m_curblockaddr++;
 
@@ -663,13 +663,13 @@ uint16_t generalplus_gpac800_device::nand_7854_r()
 
 // 7998
 
-void generalplus_gpac800_device::nand_command_w(uint16_t data)
+void generalplus_gpac800_device::nand_command_w(u16 data)
 {
 	logerror("%s:sunplus_gcm394_base_device::nand_command_w %04x\n", machine().describe_context(), data);
 	m_nandcommand = data;
 }
 
-void generalplus_gpac800_device::nand_addr_low_w(uint16_t data)
+void generalplus_gpac800_device::nand_addr_low_w(u16 data)
 {
 	logerror("%s:sunplus_gcm394_base_device::nand_addr_low_w %04x\n", machine().describe_context(), data);
 	m_nand_addr_low = data;
@@ -678,9 +678,9 @@ void generalplus_gpac800_device::nand_addr_low_w(uint16_t data)
 
 void generalplus_gpac800_device::recalculate_calculate_effective_nand_address()
 {
-	uint8_t type = m_nand_7856 & 0xf;
-	uint8_t shift = 0;
-	uint32_t page_offset = 0;
+	u8 type = m_nand_7856 & 0xf;
+	u8 shift = 0;
+	u32 page_offset = 0;
 
 	if (type == 7)
 		shift = 4;
@@ -692,18 +692,18 @@ void generalplus_gpac800_device::recalculate_calculate_effective_nand_address()
 	else if (m_nandcommand == 0x50)
 		page_offset = 512;
 
-	uint32_t nandaddress = (m_nand_addr_high << 16) | m_nand_addr_low;
+	u32 nandaddress = (m_nand_addr_high << 16) | m_nand_addr_low;
 
 	if (m_nand_7850 & 0x4000)
 		nandaddress *= 2;
 
-	uint32_t page = type ? nandaddress : /*(m_nand_7850 & 0x4000) ?*/ nandaddress >> 8 /*: nandaddress >> 9*/;
+	u32 page = type ? nandaddress : /*(m_nand_7850 & 0x4000) ?*/ nandaddress >> 8 /*: nandaddress >> 9*/;
 	m_effectiveaddress = (page * 528 + page_offset) << shift;
 
 	logerror("%s: Requested address is %08x, translating to %08x\n", machine().describe_context(), nandaddress, m_effectiveaddress);
 }
 
-void generalplus_gpac800_device::nand_addr_high_w(uint16_t data)
+void generalplus_gpac800_device::nand_addr_high_w(u16 data)
 {
 	logerror("%s:sunplus_gcm394_base_device::nand_addr_high_w %04x\n", machine().describe_context(), data);
 	m_nand_addr_high = data;
@@ -713,25 +713,25 @@ void generalplus_gpac800_device::nand_addr_high_w(uint16_t data)
 	m_curblockaddr = 0;
 }
 
-void generalplus_gpac800_device::nand_dma_ctrl_w(uint16_t data)
+void generalplus_gpac800_device::nand_dma_ctrl_w(u16 data)
 {
 	logerror("%s:sunplus_gcm394_base_device::nand_dma_ctrl_w(?) %04x\n", machine().describe_context(), data);
 	m_nand_dma_ctrl = data;
 }
 
-uint16_t generalplus_gpac800_device::nand_7850_status_r()
+u16 generalplus_gpac800_device::nand_7850_status_r()
 {
 	// 0x8000 = ready
 	return m_nand_7850 | 0x8000;
 }
 
-void generalplus_gpac800_device::nand_7850_w(uint16_t data)
+void generalplus_gpac800_device::nand_7850_w(u16 data)
 {
 	logerror("%s:sunplus_gcm394_base_device::nand_7850_w %04x\n", machine().describe_context(), data);
 	m_nand_7850 = data;
 }
 
-void generalplus_gpac800_device::nand_7856_type_w(uint16_t data)
+void generalplus_gpac800_device::nand_7856_type_w(u16 data)
 {
 	logerror("%s:sunplus_gcm394_base_device::nand_7856_type_w %04x\n", machine().describe_context(), data);
 	m_nand_7856 = data;
@@ -741,38 +741,38 @@ void generalplus_gpac800_device::nand_7856_type_w(uint16_t data)
 	m_curblockaddr = 0;
 }
 
-void generalplus_gpac800_device::nand_7857_w(uint16_t data)
+void generalplus_gpac800_device::nand_7857_w(u16 data)
 {
 	logerror("%s:sunplus_gcm394_base_device::nand_7857_w %04x\n", machine().describe_context(), data);
 	m_nand_7857 = data;
 }
 
-void generalplus_gpac800_device::nand_785b_w(uint16_t data)
+void generalplus_gpac800_device::nand_785b_w(u16 data)
 {
 	logerror("%s:sunplus_gcm394_base_device::nand_785b_w %04x\n", machine().describe_context(), data);
 	m_nand_785b = data;
 }
 
-void generalplus_gpac800_device::nand_785c_w(uint16_t data)
+void generalplus_gpac800_device::nand_785c_w(u16 data)
 {
 	logerror("%s:sunplus_gcm394_base_device::nand_785c_w %04x\n", machine().describe_context(), data);
 	m_nand_785c = data;
 }
 
-void generalplus_gpac800_device::nand_785d_w(uint16_t data)
+void generalplus_gpac800_device::nand_785d_w(u16 data)
 {
 	logerror("%s:sunplus_gcm394_base_device::nand_785d_w %04x\n", machine().describe_context(), data);
 	m_nand_785d = data;
 }
 
 // [:maincpu] ':maincpu' (00146D)  jak_tsm
-uint16_t generalplus_gpac800_device::nand_785e_r()
+u16 generalplus_gpac800_device::nand_785e_r()
 {
 	return 0x0000;
 }
 
 //[:maincpu] ':maincpu' (001490)  jak_tsm
-uint16_t generalplus_gpac800_device::nand_ecc_low_byte_error_flag_1_r()
+u16 generalplus_gpac800_device::nand_ecc_low_byte_error_flag_1_r()
 {
 	return 0x0000;
 }
@@ -902,7 +902,7 @@ void generalplus_gpac800_device::device_reset()
 }
 
 
-uint16_t generalplus_gpspispi_device::spi_unk_7943_r()
+u16 generalplus_gpspispi_device::spi_unk_7943_r()
 {
 	return 0x0007;
 }

--- a/src/devices/machine/generalplus_gpl1625x_soc.h
+++ b/src/devices/machine/generalplus_gpl1625x_soc.h
@@ -13,14 +13,14 @@ class generalplus_gpac800_device : public sunplus_gcm394_base_device
 {
 public:
 	template <typename T>
-	generalplus_gpac800_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&screen_tag) :
+	generalplus_gpac800_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, T &&screen_tag) :
 		generalplus_gpac800_device(mconfig, tag, owner, clock)
 	{
 		m_screen.set_tag(std::forward<T>(screen_tag));
 		m_csbase = 0x30000;
 	}
 
-	generalplus_gpac800_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	generalplus_gpac800_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 protected:
 	void gpac800_internal_map(address_map &map) ATTR_COLD;
@@ -31,36 +31,36 @@ protected:
 private:
 	void recalculate_calculate_effective_nand_address();
 
-	uint16_t nand_7850_status_r();
-	uint16_t nand_7854_r();
-	void nand_dma_ctrl_w(uint16_t data);
-	void nand_7850_w(uint16_t data);
-	void nand_command_w(uint16_t data);
-	void nand_addr_low_w(uint16_t data);
-	void nand_addr_high_w(uint16_t data);
-	uint16_t nand_ecc_low_byte_error_flag_1_r();
-	void nand_7856_type_w(uint16_t data);
-	void nand_7857_w(uint16_t data);
-	void nand_785b_w(uint16_t data);
-	void nand_785c_w(uint16_t data);
-	void nand_785d_w(uint16_t data);
-	uint16_t nand_785e_r();
+	u16 nand_7850_status_r();
+	u16 nand_7854_r();
+	void nand_dma_ctrl_w(u16 data);
+	void nand_7850_w(u16 data);
+	void nand_command_w(u16 data);
+	void nand_addr_low_w(u16 data);
+	void nand_addr_high_w(u16 data);
+	u16 nand_ecc_low_byte_error_flag_1_r();
+	void nand_7856_type_w(u16 data);
+	void nand_7857_w(u16 data);
+	void nand_785b_w(u16 data);
+	void nand_785c_w(u16 data);
+	void nand_785d_w(u16 data);
+	u16 nand_785e_r();
 
-	uint16_t m_nandcommand;
+	u16 m_nandcommand;
 
-	uint16_t m_nand_addr_low;
-	uint16_t m_nand_addr_high;
+	u16 m_nand_addr_low;
+	u16 m_nand_addr_high;
 
-	uint16_t m_nand_dma_ctrl;
-	uint16_t m_nand_7850;
-	uint16_t m_nand_785d;
-	uint16_t m_nand_785c;
-	uint16_t m_nand_785b;
-	uint16_t m_nand_7856;
-	uint16_t m_nand_7857;
+	u16 m_nand_dma_ctrl;
+	u16 m_nand_7850;
+	u16 m_nand_785d;
+	u16 m_nand_785c;
+	u16 m_nand_785b;
+	u16 m_nand_7856;
+	u16 m_nand_7857;
 
 	int m_curblockaddr;
-	uint32_t m_effectiveaddress;
+	u32 m_effectiveaddress;
 };
 
 
@@ -68,14 +68,14 @@ class generalplus_gpspispi_device : public sunplus_gcm394_base_device
 {
 public:
 	template <typename T>
-	generalplus_gpspispi_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&screen_tag) :
+	generalplus_gpspispi_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, T &&screen_tag) :
 		generalplus_gpspispi_device(mconfig, tag, owner, clock)
 	{
 		m_screen.set_tag(std::forward<T>(screen_tag));
 		m_csbase = 0x30000;
 	}
 
-	generalplus_gpspispi_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	generalplus_gpspispi_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 protected:
 	void gpspispi_internal_map(address_map &map) ATTR_COLD;
@@ -84,7 +84,7 @@ protected:
 	//virtual void device_reset() override ATTR_COLD;
 
 private:
-	uint16_t spi_unk_7943_r();
+	u16 spi_unk_7943_r();
 };
 
 DECLARE_DEVICE_TYPE(GPAC800, generalplus_gpac800_device)

--- a/src/devices/machine/generalplus_gpl162xx_soc.cpp
+++ b/src/devices/machine/generalplus_gpl162xx_soc.cpp
@@ -321,9 +321,9 @@ uint16_t sunplus_gcm394_base_device::system_7a54_r()
 
 // **************************************** 78xx region with some handling *************************************************
 
-uint16_t sunplus_gcm394_base_device::unkarea_780f_status_r()
+uint16_t sunplus_gcm394_base_device::power_state_r()
 {
-	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_780f_status_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::power_state_r\n", machine().describe_context());
 	return 0x0002;
 }
 
@@ -335,18 +335,18 @@ uint16_t sunplus_gcm394_base_device::unkarea_78fb_status_r()
 }
 
 // sets bit 0x0002 then expects it to have cleared
-uint16_t sunplus_gcm394_base_device::unkarea_7819_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7819_r\n", machine().describe_context()); return m_7819 & ~ 0x0002; }
-void sunplus_gcm394_base_device::unkarea_7819_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7819_w %04x\n", machine().describe_context(), data); m_7819 = data; }
+uint16_t sunplus_gcm394_base_device::cache_ctrl_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::cache_ctrl_r\n", machine().describe_context()); return m_cache_ctrl & ~ 0x0002; }
+void sunplus_gcm394_base_device::cache_ctrl_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::cache_ctrl_w %04x\n", machine().describe_context(), data); m_cache_ctrl = data; }
 
 // ****************************************  78xx region stubs *************************************************
 
 uint16_t sunplus_gcm394_base_device::unkarea_782d_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_782d_r\n", machine().describe_context()); return m_782d; }
 void sunplus_gcm394_base_device::unkarea_782d_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_782d_w %04x\n", machine().describe_context(), data); m_782d = data; }
 
-uint16_t sunplus_gcm394_base_device::unkarea_7803_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7803_r\n", machine().describe_context()); return m_7803; }
-void sunplus_gcm394_base_device::unkarea_7803_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7803_w %04x\n", machine().describe_context(), data); m_7803 = data; }
+uint16_t sunplus_gcm394_base_device::unkarea_7803_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7803_r\n", machine().describe_context()); return m_sys_ctrl; }
+void sunplus_gcm394_base_device::unkarea_7803_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7803_w %04x\n", machine().describe_context(), data); m_sys_ctrl = data; }
 
-void sunplus_gcm394_base_device::unkarea_7807_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7807_w %04x\n", machine().describe_context(), data); m_7807 = data; }
+void sunplus_gcm394_base_device::clock_ctrl_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::clock_ctrl_w %04x\n", machine().describe_context(), data); m_clock_ctrl = data; }
 
 void sunplus_gcm394_base_device::waitmode_enter_780c_w(uint16_t data)
 {
@@ -381,10 +381,10 @@ void sunplus_gcm394_base_device::unkarea_7816_w(uint16_t data)
 	m_7816 = data;
 }
 
-void sunplus_gcm394_base_device::unkarea_7817_w(uint16_t data)
+void sunplus_gcm394_base_device::pllchange_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7817_w %04x\n", machine().describe_context(), data);
-	m_7817 = data;
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::pllchange_w %04x\n", machine().describe_context(), data);
+	m_pllchange = data;
 }
 
 void sunplus_gcm394_base_device::chipselect_csx_memory_device_control_w(offs_t offset, uint16_t data)
@@ -423,277 +423,355 @@ void sunplus_gcm394_base_device::unkarea_7835_w(uint16_t data) { LOGMASKED(LOG_G
 
 // Port A
 
-uint16_t sunplus_gcm394_base_device::ioarea_7860_porta_r()
+uint16_t sunplus_gcm394_base_device::ioa_data_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7860_porta_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_data_r\n", machine().describe_context());
 	return m_porta_in();
 }
 
-void sunplus_gcm394_base_device::ioarea_7860_porta_w(uint16_t data)
+void sunplus_gcm394_base_device::ioa_data_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7860_porta_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_data_w %04x\n", machine().describe_context(), data);
 	m_porta_out(data);
 }
 
-uint16_t sunplus_gcm394_base_device::ioarea_7861_porta_buffer_r()
+uint16_t sunplus_gcm394_base_device::ioa_buffer_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7861_porta_buffer_r\n", machine().describe_context());
-	return 0x0000;// 0xffff;// m_7861;
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_buffer_r\n", machine().describe_context());
+	return 0x0000;// 0xffff;
 }
 
-void sunplus_gcm394_base_device::ioarea_7861_porta_buffer_w(uint16_t data)
+void sunplus_gcm394_base_device::ioa_buffer_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7861_porta_buffer_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_buffer_w %04x\n", machine().describe_context(), data);
 }
 
-uint16_t sunplus_gcm394_base_device::ioarea_7862_porta_direction_r()
+uint16_t sunplus_gcm394_base_device::ioa_dir_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7862_porta_direction_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_dir_r\n", machine().describe_context());
 	return m_7862_porta_direction;
 }
 
-void sunplus_gcm394_base_device::ioarea_7862_porta_direction_w(uint16_t data)
+void sunplus_gcm394_base_device::ioa_dir_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7862_porta_direction_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_dir_w %04x\n", machine().describe_context(), data);
 	m_7862_porta_direction = data;
 }
 
-uint16_t sunplus_gcm394_base_device::ioarea_7863_porta_attribute_r()
+uint16_t sunplus_gcm394_base_device::ioa_attrib_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7863_porta_attribute_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_attrib_r\n", machine().describe_context());
 	return m_7863_porta_attribute;
 }
 
-void sunplus_gcm394_base_device::ioarea_7863_porta_attribute_w(uint16_t data)
+void sunplus_gcm394_base_device::ioa_attrib_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7863_porta_attribute_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_attrib_w %04x\n", machine().describe_context(), data);
 	m_7863_porta_attribute = data;
 }
 
 // Port B
 
-uint16_t sunplus_gcm394_base_device::ioarea_7868_portb_r()
+uint16_t sunplus_gcm394_base_device::iob_buffer_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7868_portb_r\n", machine().describe_context());
-	return m_portb_in();
-}
-
-uint16_t sunplus_gcm394_base_device::ioarea_7869_portb_buffer_r()
-{
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7869_portb_buffer_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_buffer_r\n", machine().describe_context());
 	return machine().rand();
 }
 
-void sunplus_gcm394_base_device::ioarea_7869_portb_buffer_w(uint16_t data)
+void sunplus_gcm394_base_device::iob_buffer_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7869_portb_buffer_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_buffer_w %04x\n", machine().describe_context(), data);
 	m_portb_out(data); // buffer writes must update output state too, beijuehh requires it for banking
 }
 
-void sunplus_gcm394_base_device::ioarea_7868_portb_w(uint16_t data)
+uint16_t sunplus_gcm394_base_device::iob_data_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7868_portb_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_data_r\n", machine().describe_context());
+	return m_portb_in();
+}
+
+void sunplus_gcm394_base_device::iob_data_w(uint16_t data)
+{
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_data_w %04x\n", machine().describe_context(), data);
 	m_portb_out(data);
 }
 
-uint16_t sunplus_gcm394_base_device::ioarea_786a_portb_direction_r()
+uint16_t sunplus_gcm394_base_device::iob_dir_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_786a_portb_direction_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_dir_r\n", machine().describe_context());
 	return m_786a_portb_direction;
 }
 
-void sunplus_gcm394_base_device::ioarea_786a_portb_direction_w(uint16_t data)
+void sunplus_gcm394_base_device::iob_dir_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_786a_portb_direction_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_dir_w %04x\n", machine().describe_context(), data);
 	m_786a_portb_direction = data;
 }
 
-uint16_t sunplus_gcm394_base_device::ioarea_786b_portb_attribute_r()
+uint16_t sunplus_gcm394_base_device::iob_attrib_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_786b_portb_attribute_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_attrib_r\n", machine().describe_context());
 	return m_786b_portb_attribute;
 }
 
-void sunplus_gcm394_base_device::ioarea_786b_portb_attribute_w(uint16_t data)
+void sunplus_gcm394_base_device::iob_attrib_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_786b_portb_attribute_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_attrib_w %04x\n", machine().describe_context(), data);
 	m_786b_portb_attribute = data;
 }
 
 // Port C
 
-uint16_t sunplus_gcm394_base_device::ioarea_7870_portc_r()
+uint16_t sunplus_gcm394_base_device::ioc_data_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7870_portc_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_data_r\n", machine().describe_context());
 	return m_portc_in();
 }
 
-void sunplus_gcm394_base_device::ioarea_7870_portc_w(uint16_t data)
+void sunplus_gcm394_base_device::ioc_data_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7870_portc_w %04x\n", machine().describe_context(), data);
-	m_7870 = data;
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_data_w %04x\n", machine().describe_context(), data);
+	m_ioc_data = data;
 	m_portc_out(data);
 }
 
-uint16_t sunplus_gcm394_base_device::ioarea_7871_portc_buffer_r()
+uint16_t sunplus_gcm394_base_device::ioc_buffer_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7871_portc_buffer_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_buffer_r\n", machine().describe_context());
 	return 0xffff;// m_7871;
 }
 
-void sunplus_gcm394_base_device::ioarea_7871_portc_buffer_w(uint16_t data)
+void sunplus_gcm394_base_device::ioc_buffer_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7871_portc_buffer_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_buffer_w %04x\n", machine().describe_context(), data);
 }
 
-
-uint16_t sunplus_gcm394_base_device::ioarea_7872_portc_direction_r()
+uint16_t sunplus_gcm394_base_device::ioc_dir_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7872_portc_direction_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_dir_r\n", machine().describe_context());
 	return m_7872_portc_direction;
 }
 
-void sunplus_gcm394_base_device::ioarea_7872_portc_direction_w(uint16_t data)
+void sunplus_gcm394_base_device::ioc_dir_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7872_portc_direction_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_dir_w %04x\n", machine().describe_context(), data);
 	m_7872_portc_direction = data;
 }
 
-uint16_t sunplus_gcm394_base_device::ioarea_7873_portc_attribute_r()
+uint16_t sunplus_gcm394_base_device::ioc_attrib_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7873_portc_attribute_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_attrib_r\n", machine().describe_context());
 	return m_7873_portc_attribute;
 }
 
-void sunplus_gcm394_base_device::ioarea_7873_portc_attribute_w(uint16_t data)
+void sunplus_gcm394_base_device::ioc_attrib_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7873_portc_attribute_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_attrib_w %04x\n", machine().describe_context(), data);
 	m_7873_portc_attribute = data;
 }
 
 // Port D
 
-uint16_t sunplus_gcm394_base_device::ioarea_7878_portd_r()
+uint16_t sunplus_gcm394_base_device::iod_data_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7878_portd_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_data_r\n", machine().describe_context());
 	return m_portd_in();
 }
 
-void sunplus_gcm394_base_device::ioarea_7878_portd_w(uint16_t data)
+void sunplus_gcm394_base_device::iod_data_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7878_portd_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_data_w %04x\n", machine().describe_context(), data);
 	//m_7878 = data;
 	m_portd_out(data);
 }
 
-uint16_t sunplus_gcm394_base_device::ioarea_7879_portd_buffer_r()
+uint16_t sunplus_gcm394_base_device::iod_buffer_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7879_portd_buffer_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_buffer_r\n", machine().describe_context());
 	return 0xffff;// m_7871;
 }
 
-void sunplus_gcm394_base_device::ioarea_7879_portd_buffer_w(uint16_t data)
+void sunplus_gcm394_base_device::iod_buffer_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_7879_portd_buffer_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_buffer_w %04x\n", machine().describe_context(), data);
 	m_portd_out(data); // buffer writes must update output state too, beijuehh requires it for banking
 }
 
-
-uint16_t sunplus_gcm394_base_device::ioarea_787a_portd_direction_r()
+uint16_t sunplus_gcm394_base_device::iod_dir_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_787a_portd_direction_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_dir_r\n", machine().describe_context());
 	return m_787a_portd_direction;
 }
 
-void sunplus_gcm394_base_device::ioarea_787a_portd_direction_w(uint16_t data)
+void sunplus_gcm394_base_device::iod_dir_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_787a_portd_direction_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_dir_w %04x\n", machine().describe_context(), data);
 	m_787a_portd_direction = data;
 }
 
-uint16_t sunplus_gcm394_base_device::ioarea_787b_portd_attribute_r()
+uint16_t sunplus_gcm394_base_device::iod_attib_r()
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_787b_portd_attribute_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_attib_r\n", machine().describe_context());
 	return m_787b_portd_attribute;
 }
 
-void sunplus_gcm394_base_device::ioarea_787b_portd_attribute_w(uint16_t data)
+void sunplus_gcm394_base_device::iod_attib_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioarea_787b_portd_attribute_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_attib_w %04x\n", machine().describe_context(), data);
 	m_787b_portd_attribute = data;
 }
 
-uint16_t sunplus_gcm394_base_device::unkarea_7882_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7882_r\n", machine().describe_context()); return 0xffff;// m_7882;
-}
-void sunplus_gcm394_base_device::unkarea_7882_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7882_w %04x\n", machine().describe_context(), data); m_7882 = data; }
-uint16_t sunplus_gcm394_base_device::unkarea_7883_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7883_r\n", machine().describe_context()); return 0xffff;// m_7883;
-}
-void sunplus_gcm394_base_device::unkarea_7883_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7883_w %04x\n", machine().describe_context(), data); m_7883 = data; }
-
-void sunplus_gcm394_base_device::unkarea_78a0_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78a0_w %04x\n", machine().describe_context(), data); m_78a0 = data; }
-
-uint16_t sunplus_gcm394_base_device::unkarea_78a0_r()
+uint16_t sunplus_gcm394_base_device::iod_drv_r()
 {
-	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78a0_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_drv_r\n", machine().describe_context());
+	return 0xffff;
+}
+
+void sunplus_gcm394_base_device::iod_drv_w(uint16_t data)
+{
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_drv_w %04x\n", machine().describe_context(), data);
+}
+
+uint16_t sunplus_gcm394_base_device::iod_mux_r()
+{
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_mux_r\n", machine().describe_context());
+	return 0xffff;
+}
+
+void sunplus_gcm394_base_device::iod_mux_w(uint16_t data)
+{
+	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_mux_w %04x\n", machine().describe_context(), data);
+}
+
+uint16_t sunplus_gcm394_base_device::ioe_dir_r()
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::ioe_dir_r\n", machine().describe_context());
+	return m_ioe_dir;
+}
+
+void sunplus_gcm394_base_device::ioe_dir_w(uint16_t data)
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::ioe_dir_w %04x\n", machine().describe_context(), data);
+	m_ioe_dir = data;
+}
+
+uint16_t sunplus_gcm394_base_device::ioe_attrib_r()
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::ioe_attrib_r\n", machine().describe_context());
+	return m_ioe_attrib;
+}
+
+void sunplus_gcm394_base_device::ioe_attrib_w(uint16_t data)
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::ioe_attrib_w %04x\n", machine().describe_context(), data);
+	m_ioe_attrib = data;
+}
+
+void sunplus_gcm394_base_device::int_status1_w(uint16_t data)
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::int_status1_w %04x\n", machine().describe_context(), data);
+	m_int_status1 = data;
+}
+
+uint16_t sunplus_gcm394_base_device::int_status1_r()
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::int_status1_r\n", machine().describe_context());
 	return 0x0000;// machine().rand();
 }
 
-uint16_t sunplus_gcm394_base_device::unkarea_78a1_r()
+uint16_t sunplus_gcm394_base_device::int_status2_r()
 {
-	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78a1_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::int_status2_r\n", machine().describe_context());
 	return 0xffff;// machine().rand();
 }
 
-void sunplus_gcm394_base_device::unkarea_78a4_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78a4_w %04x\n", machine().describe_context(), data); m_78a4 = data; }
-void sunplus_gcm394_base_device::unkarea_78a5_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78a5_w %04x\n", machine().describe_context(), data); m_78a5 = data; }
-void sunplus_gcm394_base_device::unkarea_78a6_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78a6_w %04x\n", machine().describe_context(), data); m_78a6 = data; }
-
-void sunplus_gcm394_base_device::unkarea_78a8_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78a8_w %04x\n", machine().describe_context(), data); m_78a8 = data; }
-
-
-void sunplus_gcm394_base_device::unkarea_78b0_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78b0_w %04x\n", machine().describe_context(), data); m_78b0 = data; }
-void sunplus_gcm394_base_device::unkarea_78b1_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78b1_w %04x\n", machine().describe_context(), data); m_78b1 = data; }
-
-uint16_t sunplus_gcm394_base_device::unkarea_78b2_r()
+void sunplus_gcm394_base_device::int_priority_1_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78b2_r\n", machine().describe_context());
-	return 0xffff;// m_78b2;
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::int_priority_1_w %04x\n", machine().describe_context(), data);
+	m_int_priority_1 = data;
 }
 
-void sunplus_gcm394_base_device::unkarea_78b2_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78b2_w %04x\n", machine().describe_context(), data); m_78b2 = data; }
-
-void sunplus_gcm394_base_device::unkarea_78b8_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78b8_w %04x\n", machine().describe_context(), data); m_78b8 = data; }
-
-
-uint16_t sunplus_gcm394_base_device::unkarea_78f0_r()
+void sunplus_gcm394_base_device::int_priority_2_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78f0_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::int_priority_2_w %04x\n", machine().describe_context(), data);
+	m_int_priority_2 = data;
+}
+
+void sunplus_gcm394_base_device::int_priority_3_w(uint16_t data)
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::int_priority_3_w %04x\n", machine().describe_context(), data);
+	m_int_priority_3 = data;
+}
+
+void sunplus_gcm394_base_device::mint_ctrl_w(uint16_t data)
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::mint_ctrl_w %04x\n", machine().describe_context(), data);
+	m_misc_int_ctrl = data;
+}
+
+void sunplus_gcm394_base_device::timebasea_ctrl_w(uint16_t data)
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timebasea_ctrl_w %04x\n", machine().describe_context(), data);
+	m_timebasea_ctrl = data;
+}
+
+void sunplus_gcm394_base_device::timebaseb_ctrl_w(uint16_t data)
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timebaseb_ctrl_w %04x\n", machine().describe_context(), data);
+	m_timebaseb_ctrl = data;
+}
+
+uint16_t sunplus_gcm394_base_device::timebasec_ctrl_r()
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timebasec_ctrl_r\n", machine().describe_context());
+	return 0xffff;// m_timebasec_ctrl;
+}
+
+void sunplus_gcm394_base_device::timebasec_ctrl_w(uint16_t data)
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timebasec_ctrl_w %04x\n", machine().describe_context(), data);
+	m_timebasec_ctrl = data;
+}
+
+void sunplus_gcm394_base_device::timebase_reset_w(uint16_t data)
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timebase_reset_w %04x\n", machine().describe_context(), data);
+	m_timebase_reset = data;
+}
+
+uint16_t sunplus_gcm394_base_device::cha_ctrl_r()
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::cha_ctrl_r\n", machine().describe_context());
 	return 0xffff;
 }
 
-void sunplus_gcm394_base_device::unkarea_78f0_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78f0_w %04x\n", machine().describe_context(), data); m_78f0 = data; }
-
-uint16_t sunplus_gcm394_base_device::unkarea_78c0_r()
+void sunplus_gcm394_base_device::cha_ctrl_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78c0_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::cha_ctrl_w %04x\n", machine().describe_context(), data);
+	m_cha_ctrl = data;
+}
+
+uint16_t sunplus_gcm394_base_device::timera_ctrl_r()
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timera_ctrl_r\n", machine().describe_context());
 	return machine().rand();
 }
 
-uint16_t sunplus_gcm394_base_device::unkarea_78c8_r()
+uint16_t sunplus_gcm394_base_device::timerb_ctrl_r()
 {
-	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78c8_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timerb_ctrl_r\n", machine().describe_context());
 	return 0xffff;
 }
 
-uint16_t sunplus_gcm394_base_device::unkarea_78d0_r()
+uint16_t sunplus_gcm394_base_device::timerc_ctrl_r()
 {
-	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78d0_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timerc_ctrl_r\n", machine().describe_context());
 	return machine().rand();
 }
 
-uint16_t sunplus_gcm394_base_device::unkarea_78d8_r()
+uint16_t sunplus_gcm394_base_device::timerd_ctrl_r()
 {
-	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78d8_r\n", machine().describe_context());
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timerd_ctrl_r\n", machine().describe_context());
 	return machine().rand();
 }
 
@@ -703,38 +781,37 @@ uint16_t sunplus_gcm394_base_device::unkarea_7904_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7904_r\n", machine().describe_context());
 	return machine().rand(); // lazertag waits on a bit, status flag for something?
-
 }
 
-uint16_t sunplus_gcm394_base_device::unkarea_7934_r()
+uint16_t sunplus_gcm394_base_device::rtc_ctrl_r()
 {
 	// does this return data written, or is it a status flag?
-	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7934_r\n", machine().describe_context());
-	return m_7934;
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::rtc_ctrl_r\n", machine().describe_context());
+	return m_rtc_ctrl;
 }
 
-void sunplus_gcm394_base_device::unkarea_7934_w(uint16_t data)
+void sunplus_gcm394_base_device::rtc_ctrl_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7934_w %04x\n", machine().describe_context(), data);
-	m_7934 = data;
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::rtc_ctrl_w %04x\n", machine().describe_context(), data);
+	m_rtc_ctrl = data;
 }
 
 // value of 7935 is read then written in irq6, nothing happens unless bit 0x0100 was set, which could be some kind of irq source being acked?
-uint16_t sunplus_gcm394_base_device::unkarea_7935_r()
+uint16_t sunplus_gcm394_base_device::rtc_int_status_r()
 {
-	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7935_r\n", machine().describe_context());
-	return m_7935;
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::rtc_int_status_r\n", machine().describe_context());
+	return m_rtc_int_status;
 }
 
-void sunplus_gcm394_base_device::unkarea_7935_w(uint16_t data)
+void sunplus_gcm394_base_device::rtc_int_status_w(uint16_t data)
 {
-	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7935_w %04x\n", machine().describe_context(), data);
-	m_7935 &= ~data;
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::rtc_int_status_w %04x\n", machine().describe_context(), data);
+	m_rtc_int_status &= ~data;
 	//checkirq6();
 }
 
-uint16_t sunplus_gcm394_base_device::unkarea_7936_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7936_r\n", machine().describe_context()); return 0x0000; }
-void sunplus_gcm394_base_device::unkarea_7936_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7936_w %04x\n", machine().describe_context(), data); m_7936 = data; }
+uint16_t sunplus_gcm394_base_device::rtc_int_ctrl_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::rtc_int_ctrl_r\n", machine().describe_context()); return 0x0000; }
+void sunplus_gcm394_base_device::rtc_int_ctrl_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::rtc_int_ctrl_w %04x\n", machine().describe_context(), data); m_rtc_int_ctrl = data; }
 
 // **************************************** 794x SPI *************************************************
 
@@ -1173,9 +1250,9 @@ void sunplus_gcm394_base_device::base_internal_map(address_map &map)
 	map(0x007010, 0x007015).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap0_regs_r), FUNC(gcm394_base_video_device::tmap0_regs_w));
 	map(0x007016, 0x00701b).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap1_regs_r), FUNC(gcm394_base_video_device::tmap1_regs_w));
 
-	map(0x00701c, 0x00701c).w(m_spg_video, FUNC(gcm394_base_video_device::video_701c_w)); // these 3 are written together in paccon
-	map(0x00701d, 0x00701d).w(m_spg_video, FUNC(gcm394_base_video_device::video_701d_w));
-	map(0x00701e, 0x00701e).w(m_spg_video, FUNC(gcm394_base_video_device::video_701e_w));
+	map(0x00701c, 0x00701c).w(m_spg_video, FUNC(gcm394_base_video_device::vcomp_value_w)); // these 3 are written together in paccon
+	map(0x00701d, 0x00701d).w(m_spg_video, FUNC(gcm394_base_video_device::vcomp_offset_w));
+	map(0x00701e, 0x00701e).w(m_spg_video, FUNC(gcm394_base_video_device::vcomp_step_w));
 
 	// tilebase LSBs
 	map(0x007020, 0x007020).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap0_tilebase_lsb_r), FUNC(gcm394_base_video_device::tmap0_tilebase_lsb_w));           // tilebase, written with other tmap0 regs
@@ -1184,7 +1261,7 @@ void sunplus_gcm394_base_device::base_internal_map(address_map &map)
 	map(0x007023, 0x007023).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap2_tilebase_lsb_r), FUNC(gcm394_base_video_device::tmap2_tilebase_lsb_w));           // written with other tmap2 regs (roz layer or line layer?)
 	map(0x007024, 0x007024).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap3_tilebase_lsb_r), FUNC(gcm394_base_video_device::tmap3_tilebase_lsb_w));           // written with other tmap3 regs (roz layer or line layer?)
 
-	map(0x00702a, 0x00702a).w(m_spg_video, FUNC(gcm394_base_video_device::video_702a_w)); // blend level control
+	map(0x00702a, 0x00702a).w(m_spg_video, FUNC(gcm394_base_video_device::blending_w)); // blend level control
 
 	// tilebase MSBs
 	map(0x00702b, 0x00702b).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap0_tilebase_msb_r), FUNC(gcm394_base_video_device::tmap0_tilebase_msb_w));           // written with other tmap0 regs
@@ -1217,19 +1294,19 @@ void sunplus_gcm394_base_device::base_internal_map(address_map &map)
 	// these don't exist on older SPG
 	map(0x00707c, 0x00707c).r(m_spg_video, FUNC(gcm394_base_video_device::video_707c_r)); // wrlshunt polls this waiting for 0x8000, is this some kind of manual port-based data upload?
 
-	map(0x00707e, 0x00707e).w(m_spg_video, FUNC(gcm394_base_video_device::video_707e_spritebank_w));                                                         // written around same time as DMA, seems to select alt sprite bank
-	map(0x00707f, 0x00707f).rw(m_spg_video, FUNC(gcm394_base_video_device::video_707f_r), FUNC(gcm394_base_video_device::video_707f_w));
+	map(0x00707e, 0x00707e).w(m_spg_video, FUNC(gcm394_base_video_device::ppu_ram_bank_w));                                                         // written around same time as DMA, seems to select alt sprite bank
+	map(0x00707f, 0x00707f).rw(m_spg_video, FUNC(gcm394_base_video_device::ppu_enable_r), FUNC(gcm394_base_video_device::ppu_enable_w));
 
 	// another set of registers for something?
-	map(0x007080, 0x007080).w(m_spg_video, FUNC(gcm394_base_video_device::video_7080_w));
-	map(0x007081, 0x007081).w(m_spg_video, FUNC(gcm394_base_video_device::video_7081_w));
-	map(0x007082, 0x007082).w(m_spg_video, FUNC(gcm394_base_video_device::video_7082_w));
-	map(0x007083, 0x007083).rw(m_spg_video, FUNC(gcm394_base_video_device::video_7083_r), FUNC(gcm394_base_video_device::video_7083_w));
-	map(0x007084, 0x007084).w(m_spg_video, FUNC(gcm394_base_video_device::video_7084_w));
-	map(0x007085, 0x007085).w(m_spg_video, FUNC(gcm394_base_video_device::video_7085_w));
-	map(0x007086, 0x007086).w(m_spg_video, FUNC(gcm394_base_video_device::video_7086_w));
-	map(0x007087, 0x007087).w(m_spg_video, FUNC(gcm394_base_video_device::video_7087_w));
-	map(0x007088, 0x007088).w(m_spg_video, FUNC(gcm394_base_video_device::video_7088_w));
+	map(0x007080, 0x007080).w(m_spg_video, FUNC(gcm394_base_video_device::tv_saturation_w));
+	map(0x007081, 0x007081).w(m_spg_video, FUNC(gcm394_base_video_device::tv_hue_w));
+	map(0x007082, 0x007082).w(m_spg_video, FUNC(gcm394_base_video_device::tv_brightness_w));
+	map(0x007083, 0x007083).rw(m_spg_video, FUNC(gcm394_base_video_device::tv_sharpness_r), FUNC(gcm394_base_video_device::tv_sharpness_w));
+	map(0x007084, 0x007084).w(m_spg_video, FUNC(gcm394_base_video_device::tv_y_gain_w));
+	map(0x007085, 0x007085).w(m_spg_video, FUNC(gcm394_base_video_device::tv_y_delay_w));
+	map(0x007086, 0x007086).w(m_spg_video, FUNC(gcm394_base_video_device::tv_v_position_w));
+	map(0x007087, 0x007087).w(m_spg_video, FUNC(gcm394_base_video_device::tv_h_position_w));
+	map(0x007088, 0x007088).w(m_spg_video, FUNC(gcm394_base_video_device::tv_videodac_w));
 
 	map(0x0070e0, 0x0070e0).r(m_spg_video, FUNC(gcm394_base_video_device::video_70e0_prng_r)); // gormiti checks this
 
@@ -1250,21 +1327,21 @@ void sunplus_gcm394_base_device::base_internal_map(address_map &map)
 
 	map(0x007803, 0x007803).rw(FUNC(sunplus_gcm394_base_device::unkarea_7803_r), FUNC(sunplus_gcm394_base_device::unkarea_7803_w));
 
-	map(0x007807, 0x007807).w(FUNC(sunplus_gcm394_base_device::unkarea_7807_w));
+	map(0x007807, 0x007807).w(FUNC(sunplus_gcm394_base_device::clock_ctrl_w));
 	// 7808
 
 	// 780a
 
 	map(0x00780c, 0x00780c).w(FUNC(sunplus_gcm394_base_device::waitmode_enter_780c_w));
 
-	map(0x00780f, 0x00780f).r(FUNC(sunplus_gcm394_base_device::unkarea_780f_status_r));
+	map(0x00780f, 0x00780f).r(FUNC(sunplus_gcm394_base_device::power_state_r));
 
 	map(0x007810, 0x007810).rw(FUNC(sunplus_gcm394_base_device::membankswitch_7810_r), FUNC(sunplus_gcm394_base_device::membankswitch_7810_w));  // 7810 Bank Switch Control Register  (P_BankSwitch_Ctrl) (maybe)
 
-	map(0x007819, 0x007819).rw(FUNC(sunplus_gcm394_base_device::unkarea_7819_r), FUNC(sunplus_gcm394_base_device::unkarea_7819_w));
+	map(0x007819, 0x007819).rw(FUNC(sunplus_gcm394_base_device::cache_ctrl_r), FUNC(sunplus_gcm394_base_device::cache_ctrl_w));
 
 	map(0x007816, 0x007816).w(FUNC(sunplus_gcm394_base_device::unkarea_7816_w));
-	map(0x007817, 0x007817).w(FUNC(sunplus_gcm394_base_device::unkarea_7817_w));
+	map(0x007817, 0x007817).w(FUNC(sunplus_gcm394_base_device::pllchange_w));
 
 	// ######################################################################################################################################################################################
 	// 782x region = memory config / control
@@ -1294,36 +1371,35 @@ void sunplus_gcm394_base_device::base_internal_map(address_map &map)
 	// 786x - 787x - IO related?
 	// ######################################################################################################################################################################################
 
-	map(0x007860, 0x007860).rw(FUNC(sunplus_gcm394_base_device::ioarea_7860_porta_r), FUNC(sunplus_gcm394_base_device::ioarea_7860_porta_w)); //    7860  I/O PortA Data Register
-	map(0x007861, 0x007861).rw(FUNC(sunplus_gcm394_base_device::ioarea_7861_porta_buffer_r), FUNC(sunplus_gcm394_base_device::ioarea_7861_porta_buffer_w)); // 7861  I/O PortA Buffer Register
-	map(0x007862, 0x007862).rw(FUNC(sunplus_gcm394_base_device::ioarea_7862_porta_direction_r), FUNC(sunplus_gcm394_base_device::ioarea_7862_porta_direction_w));  // 7862  I/O PortA Direction Register
-	map(0x007863, 0x007863).rw(FUNC(sunplus_gcm394_base_device::ioarea_7863_porta_attribute_r), FUNC(sunplus_gcm394_base_device::ioarea_7863_porta_attribute_w)); //    7863  I/O PortA Attribute Register
+	map(0x007860, 0x007860).rw(FUNC(sunplus_gcm394_base_device::ioa_data_r), FUNC(sunplus_gcm394_base_device::ioa_data_w)); //    7860  I/O PortA Data Register
+	map(0x007861, 0x007861).rw(FUNC(sunplus_gcm394_base_device::ioa_buffer_r), FUNC(sunplus_gcm394_base_device::ioa_buffer_w)); // 7861  I/O PortA Buffer Register
+	map(0x007862, 0x007862).rw(FUNC(sunplus_gcm394_base_device::ioa_dir_r), FUNC(sunplus_gcm394_base_device::ioa_dir_w));  // 7862  I/O PortA Direction Register
+	map(0x007863, 0x007863).rw(FUNC(sunplus_gcm394_base_device::ioa_attrib_r), FUNC(sunplus_gcm394_base_device::ioa_attrib_w)); //    7863  I/O PortA Attribute Register
 
-	map(0x007868, 0x007868).rw(FUNC(sunplus_gcm394_base_device::ioarea_7868_portb_r), FUNC(sunplus_gcm394_base_device::ioarea_7868_portb_w)); // on startup   // 7868  I/O PortB Data Register
-	map(0x007869, 0x007869).rw(FUNC(sunplus_gcm394_base_device::ioarea_7869_portb_buffer_r), FUNC(sunplus_gcm394_base_device::ioarea_7869_portb_buffer_w)); //  7869  I/O PortB Buffer Register   // jak_s500
-	map(0x00786a, 0x00786a).rw(FUNC(sunplus_gcm394_base_device::ioarea_786a_portb_direction_r), FUNC(sunplus_gcm394_base_device::ioarea_786a_portb_direction_w)); // 786a  I/O PortB Direction Register
-	map(0x00786b, 0x00786b).rw(FUNC(sunplus_gcm394_base_device::ioarea_786b_portb_attribute_r), FUNC(sunplus_gcm394_base_device::ioarea_786b_portb_attribute_w)); // 786b  I/O PortB Attribute Register
+	map(0x007868, 0x007868).rw(FUNC(sunplus_gcm394_base_device::iob_data_r), FUNC(sunplus_gcm394_base_device::iob_data_w)); // on startup   // 7868  I/O PortB Data Register
+	map(0x007869, 0x007869).rw(FUNC(sunplus_gcm394_base_device::iob_buffer_r), FUNC(sunplus_gcm394_base_device::iob_buffer_w)); //  7869  I/O PortB Buffer Register   // jak_s500
+	map(0x00786a, 0x00786a).rw(FUNC(sunplus_gcm394_base_device::iob_dir_r), FUNC(sunplus_gcm394_base_device::iob_dir_w)); // 786a  I/O PortB Direction Register
+	map(0x00786b, 0x00786b).rw(FUNC(sunplus_gcm394_base_device::iob_attrib_r), FUNC(sunplus_gcm394_base_device::iob_attrib_w)); // 786b  I/O PortB Attribute Register
 	// 786c  I/O PortB Latch / Wakeup
 
-	map(0x007870, 0x007870).rw(FUNC(sunplus_gcm394_base_device::ioarea_7870_portc_r) ,FUNC(sunplus_gcm394_base_device::ioarea_7870_portc_w)); // 7870  I/O PortC Data Register
-	map(0x007871, 0x007871).rw(FUNC(sunplus_gcm394_base_device::ioarea_7871_portc_buffer_r), FUNC(sunplus_gcm394_base_device::ioarea_7871_portc_buffer_w)); // 7871  I/O PortC Buffer Register
-	map(0x007872, 0x007872).rw(FUNC(sunplus_gcm394_base_device::ioarea_7872_portc_direction_r), FUNC(sunplus_gcm394_base_device::ioarea_7872_portc_direction_w)); // 7872  I/O PortC Direction Register
-	map(0x007873, 0x007873).rw(FUNC(sunplus_gcm394_base_device::ioarea_7873_portc_attribute_r), FUNC(sunplus_gcm394_base_device::ioarea_7873_portc_attribute_w)); // 7873  I/O PortC Attribute Register
+	map(0x007870, 0x007870).rw(FUNC(sunplus_gcm394_base_device::ioc_data_r) ,FUNC(sunplus_gcm394_base_device::ioc_data_w)); // 7870  I/O PortC Data Register
+	map(0x007871, 0x007871).rw(FUNC(sunplus_gcm394_base_device::ioc_buffer_r), FUNC(sunplus_gcm394_base_device::ioc_buffer_w)); // 7871  I/O PortC Buffer Register
+	map(0x007872, 0x007872).rw(FUNC(sunplus_gcm394_base_device::ioc_dir_r), FUNC(sunplus_gcm394_base_device::ioc_dir_w)); // 7872  I/O PortC Direction Register
+	map(0x007873, 0x007873).rw(FUNC(sunplus_gcm394_base_device::ioc_attrib_r), FUNC(sunplus_gcm394_base_device::ioc_attrib_w)); // 7873  I/O PortC Attribute Register
 
 	// 7874 (data 0x1249) (bkrankp data 0x36db)
 
-	map(0x007878, 0x007878).rw(FUNC(sunplus_gcm394_base_device::ioarea_7878_portd_r) ,FUNC(sunplus_gcm394_base_device::ioarea_7878_portd_w)); // 7878  I/O PortD Data Register
-	map(0x007879, 0x007879).rw(FUNC(sunplus_gcm394_base_device::ioarea_7879_portd_buffer_r), FUNC(sunplus_gcm394_base_device::ioarea_7879_portd_buffer_w)); // 7879  I/O PortD Buffer Register
-	map(0x00787a, 0x00787a).rw(FUNC(sunplus_gcm394_base_device::ioarea_787a_portd_direction_r), FUNC(sunplus_gcm394_base_device::ioarea_787a_portd_direction_w)); // 787a  I/O PortD Direction Register
-	map(0x00787b, 0x00787b).rw(FUNC(sunplus_gcm394_base_device::ioarea_787b_portd_attribute_r), FUNC(sunplus_gcm394_base_device::ioarea_787b_portd_attribute_w)); // 787b  I/O PortD Attribute Register
-
-	// 787c (data 0x1249) (bkrankp data 0x36db)
-	// 787e (data 0x1249) (bkrankp data 0x36db)
+	map(0x007878, 0x007878).rw(FUNC(sunplus_gcm394_base_device::iod_data_r) ,FUNC(sunplus_gcm394_base_device::iod_data_w)); // 7878  I/O PortD Data Register
+	map(0x007879, 0x007879).rw(FUNC(sunplus_gcm394_base_device::iod_buffer_r), FUNC(sunplus_gcm394_base_device::iod_buffer_w)); // 7879  I/O PortD Buffer Register
+	map(0x00787a, 0x00787a).rw(FUNC(sunplus_gcm394_base_device::iod_dir_r), FUNC(sunplus_gcm394_base_device::iod_dir_w)); // 787a  I/O PortD Direction Register
+	map(0x00787b, 0x00787b).rw(FUNC(sunplus_gcm394_base_device::iod_attib_r), FUNC(sunplus_gcm394_base_device::iod_attib_w)); // 787b  I/O PortD Attribute Register
+	map(0x00787c, 0x00787c).rw(FUNC(sunplus_gcm394_base_device::iod_drv_r), FUNC(sunplus_gcm394_base_device::iod_drv_w)); // P_IOD_Drv - I/O PortD Driving Capability Register
+	map(0x00787d, 0x00787d).rw(FUNC(sunplus_gcm394_base_device::iod_mux_r), FUNC(sunplus_gcm394_base_device::iod_mux_w)); // 787e (data 0x1249) (bkrankp data 0x36db)
 
 	// 7880
 
-	map(0x007882, 0x007882).rw(FUNC(sunplus_gcm394_base_device::unkarea_7882_r), FUNC(sunplus_gcm394_base_device::unkarea_7882_w));
-	map(0x007883, 0x007883).rw(FUNC(sunplus_gcm394_base_device::unkarea_7883_r), FUNC(sunplus_gcm394_base_device::unkarea_7883_w));
+	map(0x007882, 0x007882).rw(FUNC(sunplus_gcm394_base_device::ioe_dir_r), FUNC(sunplus_gcm394_base_device::ioe_dir_w));
+	map(0x007883, 0x007883).rw(FUNC(sunplus_gcm394_base_device::ioe_attrib_r), FUNC(sunplus_gcm394_base_device::ioe_attrib_w));
 
 	// 0x7888 (data 0x1249) (bkrankp data 0x36db), written with 7874 / 787c / 787e above
 
@@ -1331,38 +1407,39 @@ void sunplus_gcm394_base_device::base_internal_map(address_map &map)
 	// 78ax - interrupt controller?
 	// ######################################################################################################################################################################################
 
-	map(0x0078a0, 0x0078a0).rw(FUNC(sunplus_gcm394_base_device::unkarea_78a0_r), FUNC(sunplus_gcm394_base_device::unkarea_78a0_w));
-	map(0x0078a1, 0x0078a1).r(FUNC(sunplus_gcm394_base_device::unkarea_78a1_r));
+	map(0x0078a0, 0x0078a0).rw(FUNC(sunplus_gcm394_base_device::int_status1_r), FUNC(sunplus_gcm394_base_device::int_status1_w));
+	map(0x0078a1, 0x0078a1).r(FUNC(sunplus_gcm394_base_device::int_status2_r));
 
-	map(0x0078a4, 0x0078a4).w(FUNC(sunplus_gcm394_base_device::unkarea_78a4_w));
-	map(0x0078a5, 0x0078a5).w(FUNC(sunplus_gcm394_base_device::unkarea_78a5_w));
-	map(0x0078a6, 0x0078a6).w(FUNC(sunplus_gcm394_base_device::unkarea_78a6_w));
+	map(0x0078a4, 0x0078a4).w(FUNC(sunplus_gcm394_base_device::int_priority_1_w));
+	map(0x0078a5, 0x0078a5).w(FUNC(sunplus_gcm394_base_device::int_priority_2_w));
+	map(0x0078a6, 0x0078a6).w(FUNC(sunplus_gcm394_base_device::int_priority_3_w));
 
-	map(0x0078a8, 0x0078a8).w(FUNC(sunplus_gcm394_base_device::unkarea_78a8_w));
+	map(0x0078a8, 0x0078a8).w(FUNC(sunplus_gcm394_base_device::mint_ctrl_w));
 
 	// ######################################################################################################################################################################################
 	// 78bx - timer control?
 	// ######################################################################################################################################################################################
 
-	map(0x0078b0, 0x0078b0).w(FUNC(sunplus_gcm394_base_device::unkarea_78b0_w));  // 78b0 TimeBase A Control Register (P_TimeBaseA_Ctrl)
-	map(0x0078b1, 0x0078b1).w(FUNC(sunplus_gcm394_base_device::unkarea_78b1_w));  // 78b1 TimeBase B Control Register (P_TimeBaseB_Ctrl)
-	map(0x0078b2, 0x0078b2).rw(FUNC(sunplus_gcm394_base_device::unkarea_78b2_r), FUNC(sunplus_gcm394_base_device::unkarea_78b2_w));  // 78b2 TimeBase C Control Register (P_TimeBaseC_Ctrl)
+	map(0x0078b0, 0x0078b0).w(FUNC(sunplus_gcm394_base_device::timebasea_ctrl_w));  // 78b0 TimeBase A Control Register (P_TimeBaseA_Ctrl)
+	map(0x0078b1, 0x0078b1).w(FUNC(sunplus_gcm394_base_device::timebaseb_ctrl_w));  // 78b1 TimeBase B Control Register (P_TimeBaseB_Ctrl)
+	map(0x0078b2, 0x0078b2).rw(FUNC(sunplus_gcm394_base_device::timebasec_ctrl_r), FUNC(sunplus_gcm394_base_device::timebasec_ctrl_w));  // 78b2 TimeBase C Control Register (P_TimeBaseC_Ctrl)
 
-	map(0x0078b8, 0x0078b8).w(FUNC(sunplus_gcm394_base_device::unkarea_78b8_w));  // 78b8 TimeBase Counter Reset Register  (P_TimeBase_Reset)
+	map(0x0078b8, 0x0078b8).w(FUNC(sunplus_gcm394_base_device::timebase_reset_w));  // 78b8 TimeBase Counter Reset Register  (P_TimeBase_Reset)
 
-	map(0x0078c0, 0x0078c0).r(FUNC(sunplus_gcm394_base_device::unkarea_78c0_r)); // beijuehh
+	map(0x0078c0, 0x0078c0).r(FUNC(sunplus_gcm394_base_device::timera_ctrl_r)); // beijuehh
 
-	map(0x0078c8, 0x0078c8).r(FUNC(sunplus_gcm394_base_device::unkarea_78c8_r)); // dressmtv
+	map(0x0078c8, 0x0078c8).r(FUNC(sunplus_gcm394_base_device::timerb_ctrl_r)); // dressmtv
 
-	map(0x0078d0, 0x0078d0).r(FUNC(sunplus_gcm394_base_device::unkarea_78d0_r)); // jak_s500
-	map(0x0078d8, 0x0078d8).r(FUNC(sunplus_gcm394_base_device::unkarea_78d8_r)); // jak_tsh
+	map(0x0078d0, 0x0078d0).r(FUNC(sunplus_gcm394_base_device::timerc_ctrl_r)); // jak_s500
+
+	map(0x0078d8, 0x0078d8).r(FUNC(sunplus_gcm394_base_device::timerd_ctrl_r)); // jak_tsh
 
 
 	// ######################################################################################################################################################################################
 	// 78fx - unknown
 	// ######################################################################################################################################################################################
 
-	map(0x0078f0, 0x0078f0).rw(FUNC(sunplus_gcm394_base_device::unkarea_78f0_r), FUNC(sunplus_gcm394_base_device::unkarea_78f0_w));
+	map(0x0078f0, 0x0078f0).rw(FUNC(sunplus_gcm394_base_device::cha_ctrl_r), FUNC(sunplus_gcm394_base_device::cha_ctrl_w));
 
 	map(0x0078fb, 0x0078fb).r(FUNC(sunplus_gcm394_base_device::unkarea_78fb_status_r));
 
@@ -1372,10 +1449,9 @@ void sunplus_gcm394_base_device::base_internal_map(address_map &map)
 
 	map(0x007904, 0x007904).r(FUNC(sunplus_gcm394_base_device::unkarea_7904_r)); // lazertag after a while
 
-	// possible rtc?
-	map(0x007934, 0x007934).rw(FUNC(sunplus_gcm394_base_device::unkarea_7934_r), FUNC(sunplus_gcm394_base_device::unkarea_7934_w));
-	map(0x007935, 0x007935).rw(FUNC(sunplus_gcm394_base_device::unkarea_7935_r), FUNC(sunplus_gcm394_base_device::unkarea_7935_w));
-	map(0x007936, 0x007936).rw(FUNC(sunplus_gcm394_base_device::unkarea_7936_r), FUNC(sunplus_gcm394_base_device::unkarea_7936_w));
+	map(0x007934, 0x007934).rw(FUNC(sunplus_gcm394_base_device::rtc_ctrl_r), FUNC(sunplus_gcm394_base_device::rtc_ctrl_w));
+	map(0x007935, 0x007935).rw(FUNC(sunplus_gcm394_base_device::rtc_int_status_r), FUNC(sunplus_gcm394_base_device::rtc_int_status_w));
+	map(0x007936, 0x007936).rw(FUNC(sunplus_gcm394_base_device::rtc_int_ctrl_r), FUNC(sunplus_gcm394_base_device::rtc_int_ctrl_w));
 
 	// ######################################################################################################################################################################################
 	// 794x - SPI
@@ -1401,6 +1477,7 @@ void sunplus_gcm394_base_device::base_internal_map(address_map &map)
 	// 7axx region = system (including dma)
 	// ######################################################################################################################################################################################
 
+	// USB?
 	map(0x007a35, 0x007a35).r(FUNC(sunplus_gcm394_base_device::system_7a35_r)); // wlsair60
 	map(0x007a37, 0x007a37).r(FUNC(sunplus_gcm394_base_device::system_7a37_r)); // wlsair60
 	map(0x007a39, 0x007a39).r(FUNC(sunplus_gcm394_base_device::system_7a39_r)); // wlsair60
@@ -1507,43 +1584,41 @@ void sunplus_gcm394_base_device::device_start()
 	m_unk_timer->adjust(attotime::never);
 
 	save_item(NAME(m_dma_params));
-	save_item(NAME(m_7803));
-	save_item(NAME(m_7807));
+	save_item(NAME(m_sys_ctrl));
+	save_item(NAME(m_clock_ctrl));
 	save_item(NAME(m_membankswitch_7810));
 	save_item(NAME(m_7816));
-	save_item(NAME(m_7817));
-	save_item(NAME(m_7819));
+	save_item(NAME(m_pllchange));
+	save_item(NAME(m_cache_ctrl));
 	save_item(NAME(m_782x));
 	save_item(NAME(m_782d));
 	save_item(NAME(m_7835));
-	save_item(NAME(m_7860));
-	save_item(NAME(m_7861));
 	save_item(NAME(m_7862_porta_direction));
 	save_item(NAME(m_7863_porta_attribute));
 
 	save_item(NAME(m_786a_portb_direction));
 	save_item(NAME(m_786b_portb_attribute));
 
-	save_item(NAME(m_7870));
+	save_item(NAME(m_ioc_data));
 	//save_item(NAME(m_7871));
 	save_item(NAME(m_7872_portc_direction));
 	save_item(NAME(m_7873_portc_attribute));
-	save_item(NAME(m_7882));
-	save_item(NAME(m_7883));
-	save_item(NAME(m_78a0));
-	save_item(NAME(m_78a4));
-	save_item(NAME(m_78a5));
-	save_item(NAME(m_78a6));
-	save_item(NAME(m_78a8));
-	save_item(NAME(m_78b0));
-	save_item(NAME(m_78b1));
-	save_item(NAME(m_78b2));
-	save_item(NAME(m_78b8));
-	save_item(NAME(m_78f0));
+	save_item(NAME(m_ioe_dir));
+	save_item(NAME(m_ioe_attrib));
+	save_item(NAME(m_int_status1));
+	save_item(NAME(m_int_priority_1));
+	save_item(NAME(m_int_priority_2));
+	save_item(NAME(m_int_priority_3));
+	save_item(NAME(m_misc_int_ctrl));
+	save_item(NAME(m_timebasea_ctrl));
+	save_item(NAME(m_timebaseb_ctrl));
+	save_item(NAME(m_timebasec_ctrl));
+	save_item(NAME(m_timebase_reset));
+	save_item(NAME(m_cha_ctrl));
 	save_item(NAME(m_78fb));
-	save_item(NAME(m_7934));
-	save_item(NAME(m_7935));
-	save_item(NAME(m_7936));
+	save_item(NAME(m_rtc_ctrl));
+	save_item(NAME(m_rtc_int_status));
+	save_item(NAME(m_rtc_int_ctrl));
 	save_item(NAME(m_7960));
 	save_item(NAME(m_7961));
 	save_item(NAME(m_system_dma_memtype));
@@ -1569,14 +1644,14 @@ void sunplus_gcm394_base_device::device_reset()
 	m_78fb = 0x0000;
 	m_782d = 0x0000;
 
-	m_7807 = 0x0000;
+	m_clock_ctrl = 0x0000;
 
 	m_membankswitch_7810 = 0x0001;
 
 	m_7816 = 0x0000;
-	m_7817 = 0x0000;
+	m_pllchange = 0x0000;
 
-	m_7819 = 0x0000;
+	m_cache_ctrl = 0x0000;
 
 	m_782x[0] = 0x0000;
 	m_782x[1] = 0x0000;
@@ -1586,46 +1661,42 @@ void sunplus_gcm394_base_device::device_reset()
 
 	m_7835 = 0x0000;
 
-	m_7860 = 0x0000;
-
-	m_7861 = 0x0000;
-
 	m_7862_porta_direction = 0x0000;
 	m_7863_porta_attribute = 0x0000;
 
 	m_786a_portb_direction = 0x0000;
 	m_786b_portb_attribute = 0x0000;
 
-	m_7870 = 0x0000;
+	m_ioc_data = 0x0000;
 
 	//m_7871 = 0x0000;
 
 	m_7872_portc_direction = 0x0000;
 	m_7873_portc_attribute = 0x0000;
 
-	m_7882 = 0x0000;
-	m_7883 = 0x0000;
+	m_ioe_dir = 0x0000;
+	m_ioe_attrib = 0x0000;
 
-	m_78a0 = 0x0000;
+	m_int_status1 = 0x0000;
 
-	m_78a4 = 0x0000;
-	m_78a5 = 0x0000;
-	m_78a6 = 0x0000;
+	m_int_priority_1 = 0x0000;
+	m_int_priority_2 = 0x0000;
+	m_int_priority_3 = 0x0000;
 
-	m_78a8 = 0x0000;
+	m_misc_int_ctrl = 0x0000;
 
-	m_78b0 = 0x0000;
-	m_78b1 = 0x0000;
-	m_78b2 = 0x0000;
+	m_timebasea_ctrl = 0x0000;
+	m_timebaseb_ctrl = 0x0000;
+	m_timebasec_ctrl = 0x0000;
 
-	m_78b8 = 0x0000;
-	m_78f0 = 0x0000;
+	m_timebase_reset = 0x0000;
+	m_cha_ctrl = 0x0000;
 
 	// 79xx unknown
 
-	m_7934 = 0x0000;
-	m_7935 = 0x0000;
-	m_7936 = 0x0000;
+	m_rtc_ctrl = 0x0000;
+	m_rtc_int_status = 0x0000;
+	m_rtc_int_ctrl = 0x0000;
 
 	m_7960 = 0x0000;
 	m_7961 = 0x0000;
@@ -1655,7 +1726,7 @@ IRQ_CALLBACK_MEMBER(sunplus_gcm394_base_device::irq_vector_cb)
 void sunplus_gcm394_base_device::checkirq6()
 {
 /*
-    if (m_7935 & 0x0100)
+    if (m_rtc_int_status & 0x0100)
         set_state_unsynced(UNSP_IRQ6_LINE, ASSERT_LINE);
     else
         set_state_unsynced(UNSP_IRQ6_LINE, CLEAR_LINE);
@@ -1689,7 +1760,7 @@ void sunplus_gcm394_base_device::checkirq6()
 
 TIMER_CALLBACK_MEMBER(sunplus_gcm394_base_device::unknown_tick)
 {
-	m_7935 |= 0x0100;
+	m_rtc_int_status |= 0x0100;
 
 	if (m_alt_periodic_irq)
 		set_state_unsynced(UNSP_IRQ4_LINE, ASSERT_LINE);

--- a/src/devices/machine/generalplus_gpl162xx_soc.cpp
+++ b/src/devices/machine/generalplus_gpl162xx_soc.cpp
@@ -37,7 +37,7 @@
 
 DEFINE_DEVICE_TYPE(GCM394, sunplus_gcm394_device, "gcm394", "GeneralPlus GPL16250 System-on-a-Chip")
 
-sunplus_gcm394_base_device::sunplus_gcm394_base_device(const machine_config& mconfig, device_type type, const char* tag, device_t* owner, uint32_t clock, address_map_constructor internal) :
+sunplus_gcm394_base_device::sunplus_gcm394_base_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, address_map_constructor internal) :
 	unsp_20_device(mconfig, type, tag, owner, clock, internal),
 	device_mixer_interface(mconfig, *this),
 	m_screen(*this, finder_base::DUMMY_TAG),
@@ -66,7 +66,7 @@ sunplus_gcm394_base_device::sunplus_gcm394_base_device(const machine_config& mco
 {
 }
 
-sunplus_gcm394_device::sunplus_gcm394_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+sunplus_gcm394_device::sunplus_gcm394_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
 	sunplus_gcm394_base_device(mconfig, GCM394, tag, owner, clock)
 {
 }
@@ -74,7 +74,7 @@ sunplus_gcm394_device::sunplus_gcm394_device(const machine_config &mconfig, cons
 
 
 
-void sunplus_gcm394_base_device::default_cs_callback(uint16_t cs0, uint16_t cs1, uint16_t cs2, uint16_t cs3, uint16_t cs4)
+void sunplus_gcm394_base_device::default_cs_callback(u16 cs0, u16 cs1, u16 cs2, u16 cs3, u16 cs4)
 {
 	logerror("callback not hooked\n");
 }
@@ -82,14 +82,14 @@ void sunplus_gcm394_base_device::default_cs_callback(uint16_t cs0, uint16_t cs1,
 
 // **************************************** SYSTEM DMA device *************************************************
 
-uint16_t sunplus_gcm394_base_device::read_dma_params(int channel, int offset)
+u16 sunplus_gcm394_base_device::read_dma_params(int channel, int offset)
 {
-	uint16_t retdata = m_dma_params[offset][channel];
+	u16 retdata = m_dma_params[offset][channel];
 	LOGMASKED(LOG_GCM394_SYSDMA, "%s:sunplus_gcm394_base_device::read_dma_params (channel %01x) %01x returning %04x\n", machine().describe_context(), channel, offset, retdata);
 	return retdata;
 }
 
-void sunplus_gcm394_base_device::write_dma_params(int channel, int offset, uint16_t data)
+void sunplus_gcm394_base_device::write_dma_params(int channel, int offset, u16 data)
 {
 	LOGMASKED(LOG_GCM394_SYSDMA, "%s:sunplus_gcm394_base_device::write_dma_params (channel %01x) %01x %04x\n", machine().describe_context(), channel, offset, data);
 
@@ -118,43 +118,43 @@ void sunplus_gcm394_base_device::write_dma_params(int channel, int offset, uint1
 }
 
 
-uint16_t sunplus_gcm394_base_device::system_dma_params_channel0_r(offs_t offset)
+u16 sunplus_gcm394_base_device::system_dma_params_channel0_r(offs_t offset)
 {
 	return read_dma_params(0, offset);
 }
 
 
-void sunplus_gcm394_base_device::system_dma_params_channel0_w(offs_t offset, uint16_t data)
+void sunplus_gcm394_base_device::system_dma_params_channel0_w(offs_t offset, u16 data)
 {
 	write_dma_params(0, offset, data);
 }
 
-uint16_t sunplus_gcm394_base_device::system_dma_params_channel1_r(offs_t offset)
+u16 sunplus_gcm394_base_device::system_dma_params_channel1_r(offs_t offset)
 {
 	return read_dma_params(1, offset);
 }
 
-void sunplus_gcm394_base_device::system_dma_params_channel1_w(offs_t offset, uint16_t data)
+void sunplus_gcm394_base_device::system_dma_params_channel1_w(offs_t offset, u16 data)
 {
 	write_dma_params(1, offset, data);
 }
 
-uint16_t sunplus_gcm394_base_device::system_dma_params_channel2_r(offs_t offset)
+u16 sunplus_gcm394_base_device::system_dma_params_channel2_r(offs_t offset)
 {
 	return read_dma_params(2, offset);
 }
 
-void sunplus_gcm394_base_device::system_dma_params_channel2_w(offs_t offset, uint16_t data)
+void sunplus_gcm394_base_device::system_dma_params_channel2_w(offs_t offset, u16 data)
 {
 	write_dma_params(2, offset, data);
 }
 
-uint16_t sunplus_gcm394_base_device::system_dma_params_channel3_r(offs_t offset)
+u16 sunplus_gcm394_base_device::system_dma_params_channel3_r(offs_t offset)
 {
 	return read_dma_params(3, offset);
 }
 
-void sunplus_gcm394_base_device::system_dma_params_channel3_w(offs_t offset, uint16_t data)
+void sunplus_gcm394_base_device::system_dma_params_channel3_w(offs_t offset, u16 data)
 {
 	write_dma_params(3, offset, data);
 }
@@ -162,7 +162,7 @@ void sunplus_gcm394_base_device::system_dma_params_channel3_w(offs_t offset, uin
 
 
 
-uint16_t sunplus_gcm394_base_device::system_dma_status_r()
+u16 sunplus_gcm394_base_device::system_dma_status_r()
 {
 	LOGMASKED(LOG_GCM394_SYSDMA, "%s:sunplus_gcm394_base_device::system_dma_status_r (7abf)\n", machine().describe_context());
 
@@ -174,10 +174,10 @@ uint16_t sunplus_gcm394_base_device::system_dma_status_r()
 
 void sunplus_gcm394_base_device::trigger_systemm_dma(int channel)
 {
-	uint16_t mode = m_dma_params[0][channel];
-	uint32_t source = m_dma_params[1][channel] | (m_dma_params[4][channel] << 16);
-	uint32_t dest = m_dma_params[2][channel] | (m_dma_params[5][channel] << 16) ;
-	uint32_t length = m_dma_params[3][channel] | (m_dma_params[6][channel] << 16);
+	u16 mode = m_dma_params[0][channel];
+	u32 source = m_dma_params[1][channel] | (m_dma_params[4][channel] << 16);
+	u32 dest = m_dma_params[2][channel] | (m_dma_params[5][channel] << 16) ;
+	u32 length = m_dma_params[3][channel] | (m_dma_params[6][channel] << 16);
 	int sourcedelta = 0;
 	int destdelta = 0;
 
@@ -200,7 +200,7 @@ void sunplus_gcm394_base_device::trigger_systemm_dma(int channel)
 
 	for (int i = 0; i < length; i++)
 	{
-		uint16_t val;
+		u16 val;
 		if (mode & 0x1000)
 		{
 			val = (read_space(source) & 0xFF) | (read_space(source) << 8);
@@ -238,20 +238,20 @@ void sunplus_gcm394_base_device::trigger_systemm_dma(int channel)
 	//machine().debug_break();
 }
 
-void sunplus_gcm394_base_device::system_dma_7abf_unk_w(uint16_t data)
+void sunplus_gcm394_base_device::system_dma_7abf_unk_w(u16 data)
 {
 	// if this isn't trigger, is it enable? (which could maybe used as similar if DMA only starts to happen if unmasked?)
 
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::system_dma_7abf_unk_w %04x\n", machine().describe_context(), data);
 }
 
-uint16_t sunplus_gcm394_base_device::system_dma_memtype_r()
+u16 sunplus_gcm394_base_device::system_dma_memtype_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::system_dma_memtype_r\n", machine().describe_context());
 	return m_system_dma_memtype;
 }
 
-void sunplus_gcm394_base_device::system_dma_memtype_w(uint16_t data)
+void sunplus_gcm394_base_device::system_dma_memtype_w(u16 data)
 {
 	static char const* const types[16] =
 	{
@@ -282,38 +282,38 @@ void sunplus_gcm394_base_device::system_dma_memtype_w(uint16_t data)
 
 }
 
-uint16_t sunplus_gcm394_base_device::system_7a35_r()
+u16 sunplus_gcm394_base_device::system_7a35_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::system_7a35_r\n", machine().describe_context());
 	return machine().rand();
 }
 
-uint16_t sunplus_gcm394_base_device::system_7a37_r()
+u16 sunplus_gcm394_base_device::system_7a37_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::system_7a37_r\n", machine().describe_context());
 	return machine().rand();
 }
 
-uint16_t sunplus_gcm394_base_device::system_7a39_r()
+u16 sunplus_gcm394_base_device::system_7a39_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::system_7a39_r\n", machine().describe_context());
 	return machine().rand();
 }
 
 
-uint16_t sunplus_gcm394_base_device::system_7a3a_r()
+u16 sunplus_gcm394_base_device::system_7a3a_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::system_7a3a_r\n", machine().describe_context());
 	return machine().rand();
 }
 
-uint16_t sunplus_gcm394_base_device::system_7a46_r()
+u16 sunplus_gcm394_base_device::system_7a46_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::system_7a46_r\n", machine().describe_context());
 	return machine().rand();
 }
 
-uint16_t sunplus_gcm394_base_device::system_7a54_r()
+u16 sunplus_gcm394_base_device::system_7a54_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::system_7a54_r\n", machine().describe_context());
 	return machine().rand();
@@ -321,13 +321,13 @@ uint16_t sunplus_gcm394_base_device::system_7a54_r()
 
 // **************************************** 78xx region with some handling *************************************************
 
-uint16_t sunplus_gcm394_base_device::power_state_r()
+u16 sunplus_gcm394_base_device::power_state_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::power_state_r\n", machine().describe_context());
 	return 0x0002;
 }
 
-uint16_t sunplus_gcm394_base_device::unkarea_78fb_status_r()
+u16 sunplus_gcm394_base_device::unkarea_78fb_status_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_78fb_status_r\n", machine().describe_context());
 	m_78fb ^= 0x0100; // status flag for something?
@@ -335,20 +335,20 @@ uint16_t sunplus_gcm394_base_device::unkarea_78fb_status_r()
 }
 
 // sets bit 0x0002 then expects it to have cleared
-uint16_t sunplus_gcm394_base_device::cache_ctrl_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::cache_ctrl_r\n", machine().describe_context()); return m_cache_ctrl & ~ 0x0002; }
-void sunplus_gcm394_base_device::cache_ctrl_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::cache_ctrl_w %04x\n", machine().describe_context(), data); m_cache_ctrl = data; }
+u16 sunplus_gcm394_base_device::cache_ctrl_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::cache_ctrl_r\n", machine().describe_context()); return m_cache_ctrl & ~ 0x0002; }
+void sunplus_gcm394_base_device::cache_ctrl_w(u16 data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::cache_ctrl_w %04x\n", machine().describe_context(), data); m_cache_ctrl = data; }
 
 // ****************************************  78xx region stubs *************************************************
 
-uint16_t sunplus_gcm394_base_device::unkarea_782d_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_782d_r\n", machine().describe_context()); return m_782d; }
-void sunplus_gcm394_base_device::unkarea_782d_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_782d_w %04x\n", machine().describe_context(), data); m_782d = data; }
+u16 sunplus_gcm394_base_device::unkarea_782d_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_782d_r\n", machine().describe_context()); return m_782d; }
+void sunplus_gcm394_base_device::unkarea_782d_w(u16 data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_782d_w %04x\n", machine().describe_context(), data); m_782d = data; }
 
-uint16_t sunplus_gcm394_base_device::unkarea_7803_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7803_r\n", machine().describe_context()); return m_sys_ctrl; }
-void sunplus_gcm394_base_device::unkarea_7803_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7803_w %04x\n", machine().describe_context(), data); m_sys_ctrl = data; }
+u16 sunplus_gcm394_base_device::unkarea_7803_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7803_r\n", machine().describe_context()); return m_sys_ctrl; }
+void sunplus_gcm394_base_device::unkarea_7803_w(u16 data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7803_w %04x\n", machine().describe_context(), data); m_sys_ctrl = data; }
 
-void sunplus_gcm394_base_device::clock_ctrl_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::clock_ctrl_w %04x\n", machine().describe_context(), data); m_clock_ctrl = data; }
+void sunplus_gcm394_base_device::clock_ctrl_w(u16 data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::clock_ctrl_w %04x\n", machine().describe_context(), data); m_clock_ctrl = data; }
 
-void sunplus_gcm394_base_device::waitmode_enter_780c_w(uint16_t data)
+void sunplus_gcm394_base_device::waitmode_enter_780c_w(u16 data)
 {
 	// LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::waitmode_enter_780c_w %04x\n", machine().describe_context(), data);
 	// must be followed by 6 nops to ensure wait mode is entered
@@ -357,13 +357,13 @@ void sunplus_gcm394_base_device::waitmode_enter_780c_w(uint16_t data)
 // this gets stored / modified / restored before certain memory accesses (
 // used extensively during SDRAM checks in jak_gtg and jak_car2
 
-uint16_t sunplus_gcm394_base_device::membankswitch_7810_r()
+u16 sunplus_gcm394_base_device::membankswitch_7810_r()
 {
 //  LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::membankswitch_7810_r\n", machine().describe_context());
 	return m_membankswitch_7810;
 }
 
-void sunplus_gcm394_base_device::membankswitch_7810_w(uint16_t data)
+void sunplus_gcm394_base_device::membankswitch_7810_w(u16 data)
 {
 //  if (m_membankswitch_7810 != data)
 //  LOGMASKED(LOG_GCM394,"%s:sunplus_gcm394_base_device::membankswitch_7810_w %04x\n", machine().describe_context(), data);
@@ -375,19 +375,19 @@ void sunplus_gcm394_base_device::membankswitch_7810_w(uint16_t data)
 }
 
 
-void sunplus_gcm394_base_device::unkarea_7816_w(uint16_t data)
+void sunplus_gcm394_base_device::unkarea_7816_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7816_w %04x\n", machine().describe_context(), data);
 	m_7816 = data;
 }
 
-void sunplus_gcm394_base_device::pllchange_w(uint16_t data)
+void sunplus_gcm394_base_device::pllchange_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::pllchange_w %04x\n", machine().describe_context(), data);
 	m_pllchange = data;
 }
 
-void sunplus_gcm394_base_device::chipselect_csx_memory_device_control_w(offs_t offset, uint16_t data)
+void sunplus_gcm394_base_device::chipselect_csx_memory_device_control_w(offs_t offset, u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::chipselect_csx_memory_device_control_w %04x (782x registers offset %d)\n", machine().describe_context(), data, offset);
 	m_782x[offset] = data;
@@ -401,9 +401,9 @@ void sunplus_gcm394_base_device::chipselect_csx_memory_device_control_w(offs_t o
 		"(11) NAND FLASH",
 	};
 
-	uint8_t cs_wait =  data & 0x000f;
-	uint8_t cs_warat = (data & 0x0030)>>4;
-	uint8_t cs_md    = (data & 0x00c0)>>6;
+	u8 cs_wait =  data & 0x000f;
+	u8 cs_warat = (data & 0x0030)>>4;
+	u8 cs_md    = (data & 0x00c0)>>6;
 	int cs_size  = (data & 0xff00)>>8;
 
 	logerror("CS%d set to size: %02x (%08x words) md: %01x %s   warat: %01x wait: %01x\n", offset, cs_size, (cs_size+1)*0x10000, cs_md, md[cs_md], cs_warat, cs_wait);
@@ -417,54 +417,54 @@ void sunplus_gcm394_base_device::device_post_load()
 	m_cs_callback(m_782x[0], m_782x[1], m_782x[2], m_782x[3], m_782x[4]);
 }
 
-void sunplus_gcm394_base_device::unkarea_7835_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7835_w %04x\n", machine().describe_context(), data); m_7835 = data; }
+void sunplus_gcm394_base_device::unkarea_7835_w(u16 data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7835_w %04x\n", machine().describe_context(), data); m_7835 = data; }
 
 // IO here?
 
 // Port A
 
-uint16_t sunplus_gcm394_base_device::ioa_data_r()
+u16 sunplus_gcm394_base_device::ioa_data_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_data_r\n", machine().describe_context());
 	return m_porta_in();
 }
 
-void sunplus_gcm394_base_device::ioa_data_w(uint16_t data)
+void sunplus_gcm394_base_device::ioa_data_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_data_w %04x\n", machine().describe_context(), data);
 	m_porta_out(data);
 }
 
-uint16_t sunplus_gcm394_base_device::ioa_buffer_r()
+u16 sunplus_gcm394_base_device::ioa_buffer_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_buffer_r\n", machine().describe_context());
 	return 0x0000;// 0xffff;
 }
 
-void sunplus_gcm394_base_device::ioa_buffer_w(uint16_t data)
+void sunplus_gcm394_base_device::ioa_buffer_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_buffer_w %04x\n", machine().describe_context(), data);
 }
 
-uint16_t sunplus_gcm394_base_device::ioa_dir_r()
+u16 sunplus_gcm394_base_device::ioa_dir_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_dir_r\n", machine().describe_context());
 	return m_7862_porta_direction;
 }
 
-void sunplus_gcm394_base_device::ioa_dir_w(uint16_t data)
+void sunplus_gcm394_base_device::ioa_dir_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_dir_w %04x\n", machine().describe_context(), data);
 	m_7862_porta_direction = data;
 }
 
-uint16_t sunplus_gcm394_base_device::ioa_attrib_r()
+u16 sunplus_gcm394_base_device::ioa_attrib_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_attrib_r\n", machine().describe_context());
 	return m_7863_porta_attribute;
 }
 
-void sunplus_gcm394_base_device::ioa_attrib_w(uint16_t data)
+void sunplus_gcm394_base_device::ioa_attrib_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioa_attrib_w %04x\n", machine().describe_context(), data);
 	m_7863_porta_attribute = data;
@@ -472,49 +472,49 @@ void sunplus_gcm394_base_device::ioa_attrib_w(uint16_t data)
 
 // Port B
 
-uint16_t sunplus_gcm394_base_device::iob_buffer_r()
+u16 sunplus_gcm394_base_device::iob_buffer_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_buffer_r\n", machine().describe_context());
 	return machine().rand();
 }
 
-void sunplus_gcm394_base_device::iob_buffer_w(uint16_t data)
+void sunplus_gcm394_base_device::iob_buffer_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_buffer_w %04x\n", machine().describe_context(), data);
 	m_portb_out(data); // buffer writes must update output state too, beijuehh requires it for banking
 }
 
-uint16_t sunplus_gcm394_base_device::iob_data_r()
+u16 sunplus_gcm394_base_device::iob_data_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_data_r\n", machine().describe_context());
 	return m_portb_in();
 }
 
-void sunplus_gcm394_base_device::iob_data_w(uint16_t data)
+void sunplus_gcm394_base_device::iob_data_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_data_w %04x\n", machine().describe_context(), data);
 	m_portb_out(data);
 }
 
-uint16_t sunplus_gcm394_base_device::iob_dir_r()
+u16 sunplus_gcm394_base_device::iob_dir_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_dir_r\n", machine().describe_context());
 	return m_786a_portb_direction;
 }
 
-void sunplus_gcm394_base_device::iob_dir_w(uint16_t data)
+void sunplus_gcm394_base_device::iob_dir_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_dir_w %04x\n", machine().describe_context(), data);
 	m_786a_portb_direction = data;
 }
 
-uint16_t sunplus_gcm394_base_device::iob_attrib_r()
+u16 sunplus_gcm394_base_device::iob_attrib_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_attrib_r\n", machine().describe_context());
 	return m_786b_portb_attribute;
 }
 
-void sunplus_gcm394_base_device::iob_attrib_w(uint16_t data)
+void sunplus_gcm394_base_device::iob_attrib_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iob_attrib_w %04x\n", machine().describe_context(), data);
 	m_786b_portb_attribute = data;
@@ -522,49 +522,49 @@ void sunplus_gcm394_base_device::iob_attrib_w(uint16_t data)
 
 // Port C
 
-uint16_t sunplus_gcm394_base_device::ioc_data_r()
+u16 sunplus_gcm394_base_device::ioc_data_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_data_r\n", machine().describe_context());
 	return m_portc_in();
 }
 
-void sunplus_gcm394_base_device::ioc_data_w(uint16_t data)
+void sunplus_gcm394_base_device::ioc_data_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_data_w %04x\n", machine().describe_context(), data);
 	m_ioc_data = data;
 	m_portc_out(data);
 }
 
-uint16_t sunplus_gcm394_base_device::ioc_buffer_r()
+u16 sunplus_gcm394_base_device::ioc_buffer_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_buffer_r\n", machine().describe_context());
 	return 0xffff;// m_7871;
 }
 
-void sunplus_gcm394_base_device::ioc_buffer_w(uint16_t data)
+void sunplus_gcm394_base_device::ioc_buffer_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_buffer_w %04x\n", machine().describe_context(), data);
 }
 
-uint16_t sunplus_gcm394_base_device::ioc_dir_r()
+u16 sunplus_gcm394_base_device::ioc_dir_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_dir_r\n", machine().describe_context());
 	return m_7872_portc_direction;
 }
 
-void sunplus_gcm394_base_device::ioc_dir_w(uint16_t data)
+void sunplus_gcm394_base_device::ioc_dir_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_dir_w %04x\n", machine().describe_context(), data);
 	m_7872_portc_direction = data;
 }
 
-uint16_t sunplus_gcm394_base_device::ioc_attrib_r()
+u16 sunplus_gcm394_base_device::ioc_attrib_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_attrib_r\n", machine().describe_context());
 	return m_7873_portc_attribute;
 }
 
-void sunplus_gcm394_base_device::ioc_attrib_w(uint16_t data)
+void sunplus_gcm394_base_device::ioc_attrib_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::ioc_attrib_w %04x\n", machine().describe_context(), data);
 	m_7873_portc_attribute = data;
@@ -572,204 +572,204 @@ void sunplus_gcm394_base_device::ioc_attrib_w(uint16_t data)
 
 // Port D
 
-uint16_t sunplus_gcm394_base_device::iod_data_r()
+u16 sunplus_gcm394_base_device::iod_data_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_data_r\n", machine().describe_context());
 	return m_portd_in();
 }
 
-void sunplus_gcm394_base_device::iod_data_w(uint16_t data)
+void sunplus_gcm394_base_device::iod_data_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_data_w %04x\n", machine().describe_context(), data);
 	//m_7878 = data;
 	m_portd_out(data);
 }
 
-uint16_t sunplus_gcm394_base_device::iod_buffer_r()
+u16 sunplus_gcm394_base_device::iod_buffer_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_buffer_r\n", machine().describe_context());
 	return 0xffff;// m_7871;
 }
 
-void sunplus_gcm394_base_device::iod_buffer_w(uint16_t data)
+void sunplus_gcm394_base_device::iod_buffer_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_buffer_w %04x\n", machine().describe_context(), data);
 	m_portd_out(data); // buffer writes must update output state too, beijuehh requires it for banking
 }
 
-uint16_t sunplus_gcm394_base_device::iod_dir_r()
+u16 sunplus_gcm394_base_device::iod_dir_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_dir_r\n", machine().describe_context());
 	return m_787a_portd_direction;
 }
 
-void sunplus_gcm394_base_device::iod_dir_w(uint16_t data)
+void sunplus_gcm394_base_device::iod_dir_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_dir_w %04x\n", machine().describe_context(), data);
 	m_787a_portd_direction = data;
 }
 
-uint16_t sunplus_gcm394_base_device::iod_attib_r()
+u16 sunplus_gcm394_base_device::iod_attib_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_attib_r\n", machine().describe_context());
 	return m_787b_portd_attribute;
 }
 
-void sunplus_gcm394_base_device::iod_attib_w(uint16_t data)
+void sunplus_gcm394_base_device::iod_attib_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_attib_w %04x\n", machine().describe_context(), data);
 	m_787b_portd_attribute = data;
 }
 
-uint16_t sunplus_gcm394_base_device::iod_drv_r()
+u16 sunplus_gcm394_base_device::iod_drv_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_drv_r\n", machine().describe_context());
 	return 0xffff;
 }
 
-void sunplus_gcm394_base_device::iod_drv_w(uint16_t data)
+void sunplus_gcm394_base_device::iod_drv_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_drv_w %04x\n", machine().describe_context(), data);
 }
 
-uint16_t sunplus_gcm394_base_device::iod_mux_r()
+u16 sunplus_gcm394_base_device::iod_mux_r()
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_mux_r\n", machine().describe_context());
 	return 0xffff;
 }
 
-void sunplus_gcm394_base_device::iod_mux_w(uint16_t data)
+void sunplus_gcm394_base_device::iod_mux_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_IO, "%s:sunplus_gcm394_base_device::iod_mux_w %04x\n", machine().describe_context(), data);
 }
 
-uint16_t sunplus_gcm394_base_device::ioe_dir_r()
+u16 sunplus_gcm394_base_device::ioe_dir_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::ioe_dir_r\n", machine().describe_context());
 	return m_ioe_dir;
 }
 
-void sunplus_gcm394_base_device::ioe_dir_w(uint16_t data)
+void sunplus_gcm394_base_device::ioe_dir_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::ioe_dir_w %04x\n", machine().describe_context(), data);
 	m_ioe_dir = data;
 }
 
-uint16_t sunplus_gcm394_base_device::ioe_attrib_r()
+u16 sunplus_gcm394_base_device::ioe_attrib_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::ioe_attrib_r\n", machine().describe_context());
 	return m_ioe_attrib;
 }
 
-void sunplus_gcm394_base_device::ioe_attrib_w(uint16_t data)
+void sunplus_gcm394_base_device::ioe_attrib_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::ioe_attrib_w %04x\n", machine().describe_context(), data);
 	m_ioe_attrib = data;
 }
 
-void sunplus_gcm394_base_device::int_status1_w(uint16_t data)
+void sunplus_gcm394_base_device::int_status1_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::int_status1_w %04x\n", machine().describe_context(), data);
 	m_int_status1 = data;
 }
 
-uint16_t sunplus_gcm394_base_device::int_status1_r()
+u16 sunplus_gcm394_base_device::int_status1_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::int_status1_r\n", machine().describe_context());
 	return 0x0000;// machine().rand();
 }
 
-uint16_t sunplus_gcm394_base_device::int_status2_r()
+u16 sunplus_gcm394_base_device::int_status2_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::int_status2_r\n", machine().describe_context());
 	return 0xffff;// machine().rand();
 }
 
-void sunplus_gcm394_base_device::int_priority_1_w(uint16_t data)
+void sunplus_gcm394_base_device::int_priority_1_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::int_priority_1_w %04x\n", machine().describe_context(), data);
 	m_int_priority_1 = data;
 }
 
-void sunplus_gcm394_base_device::int_priority_2_w(uint16_t data)
+void sunplus_gcm394_base_device::int_priority_2_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::int_priority_2_w %04x\n", machine().describe_context(), data);
 	m_int_priority_2 = data;
 }
 
-void sunplus_gcm394_base_device::int_priority_3_w(uint16_t data)
+void sunplus_gcm394_base_device::int_priority_3_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::int_priority_3_w %04x\n", machine().describe_context(), data);
 	m_int_priority_3 = data;
 }
 
-void sunplus_gcm394_base_device::mint_ctrl_w(uint16_t data)
+void sunplus_gcm394_base_device::mint_ctrl_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::mint_ctrl_w %04x\n", machine().describe_context(), data);
 	m_misc_int_ctrl = data;
 }
 
-void sunplus_gcm394_base_device::timebasea_ctrl_w(uint16_t data)
+void sunplus_gcm394_base_device::timebasea_ctrl_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timebasea_ctrl_w %04x\n", machine().describe_context(), data);
 	m_timebasea_ctrl = data;
 }
 
-void sunplus_gcm394_base_device::timebaseb_ctrl_w(uint16_t data)
+void sunplus_gcm394_base_device::timebaseb_ctrl_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timebaseb_ctrl_w %04x\n", machine().describe_context(), data);
 	m_timebaseb_ctrl = data;
 }
 
-uint16_t sunplus_gcm394_base_device::timebasec_ctrl_r()
+u16 sunplus_gcm394_base_device::timebasec_ctrl_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timebasec_ctrl_r\n", machine().describe_context());
 	return 0xffff;// m_timebasec_ctrl;
 }
 
-void sunplus_gcm394_base_device::timebasec_ctrl_w(uint16_t data)
+void sunplus_gcm394_base_device::timebasec_ctrl_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timebasec_ctrl_w %04x\n", machine().describe_context(), data);
 	m_timebasec_ctrl = data;
 }
 
-void sunplus_gcm394_base_device::timebase_reset_w(uint16_t data)
+void sunplus_gcm394_base_device::timebase_reset_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timebase_reset_w %04x\n", machine().describe_context(), data);
 	m_timebase_reset = data;
 }
 
-uint16_t sunplus_gcm394_base_device::cha_ctrl_r()
+u16 sunplus_gcm394_base_device::cha_ctrl_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::cha_ctrl_r\n", machine().describe_context());
 	return 0xffff;
 }
 
-void sunplus_gcm394_base_device::cha_ctrl_w(uint16_t data)
+void sunplus_gcm394_base_device::cha_ctrl_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::cha_ctrl_w %04x\n", machine().describe_context(), data);
 	m_cha_ctrl = data;
 }
 
-uint16_t sunplus_gcm394_base_device::timera_ctrl_r()
+u16 sunplus_gcm394_base_device::timera_ctrl_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timera_ctrl_r\n", machine().describe_context());
 	return machine().rand();
 }
 
-uint16_t sunplus_gcm394_base_device::timerb_ctrl_r()
+u16 sunplus_gcm394_base_device::timerb_ctrl_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timerb_ctrl_r\n", machine().describe_context());
 	return 0xffff;
 }
 
-uint16_t sunplus_gcm394_base_device::timerc_ctrl_r()
+u16 sunplus_gcm394_base_device::timerc_ctrl_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timerc_ctrl_r\n", machine().describe_context());
 	return machine().rand();
 }
 
-uint16_t sunplus_gcm394_base_device::timerd_ctrl_r()
+u16 sunplus_gcm394_base_device::timerd_ctrl_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::timerd_ctrl_r\n", machine().describe_context());
 	return machine().rand();
@@ -777,75 +777,75 @@ uint16_t sunplus_gcm394_base_device::timerd_ctrl_r()
 
 // **************************************** 793x uknown region stubs *************************************************
 
-uint16_t sunplus_gcm394_base_device::unkarea_7904_r()
+u16 sunplus_gcm394_base_device::unkarea_7904_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7904_r\n", machine().describe_context());
 	return machine().rand(); // lazertag waits on a bit, status flag for something?
 }
 
-uint16_t sunplus_gcm394_base_device::rtc_ctrl_r()
+u16 sunplus_gcm394_base_device::rtc_ctrl_r()
 {
 	// does this return data written, or is it a status flag?
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::rtc_ctrl_r\n", machine().describe_context());
 	return m_rtc_ctrl;
 }
 
-void sunplus_gcm394_base_device::rtc_ctrl_w(uint16_t data)
+void sunplus_gcm394_base_device::rtc_ctrl_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::rtc_ctrl_w %04x\n", machine().describe_context(), data);
 	m_rtc_ctrl = data;
 }
 
 // value of 7935 is read then written in irq6, nothing happens unless bit 0x0100 was set, which could be some kind of irq source being acked?
-uint16_t sunplus_gcm394_base_device::rtc_int_status_r()
+u16 sunplus_gcm394_base_device::rtc_int_status_r()
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::rtc_int_status_r\n", machine().describe_context());
 	return m_rtc_int_status;
 }
 
-void sunplus_gcm394_base_device::rtc_int_status_w(uint16_t data)
+void sunplus_gcm394_base_device::rtc_int_status_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::rtc_int_status_w %04x\n", machine().describe_context(), data);
 	m_rtc_int_status &= ~data;
 	//checkirq6();
 }
 
-uint16_t sunplus_gcm394_base_device::rtc_int_ctrl_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::rtc_int_ctrl_r\n", machine().describe_context()); return 0x0000; }
-void sunplus_gcm394_base_device::rtc_int_ctrl_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::rtc_int_ctrl_w %04x\n", machine().describe_context(), data); m_rtc_int_ctrl = data; }
+u16 sunplus_gcm394_base_device::rtc_int_ctrl_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::rtc_int_ctrl_r\n", machine().describe_context()); return 0x0000; }
+void sunplus_gcm394_base_device::rtc_int_ctrl_w(u16 data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::rtc_int_ctrl_w %04x\n", machine().describe_context(), data); m_rtc_int_ctrl = data; }
 
 // **************************************** 794x SPI *************************************************
 
 // these are related to the accelerometer values on jak_g500 (8-bit signed) and also the SPI reads for bkrankp
-uint16_t sunplus_gcm394_base_device::spi_7944_rxdata_r()
+u16 sunplus_gcm394_base_device::spi_7944_rxdata_r()
 {
 	LOGMASKED(LOG_GCM394_SPI, "%s:sunplus_gcm394_base_device::spi_7944_rxdata_r\n", machine().describe_context());
 	return machine().rand();
 }
 
-uint16_t sunplus_gcm394_base_device::spi_7945_misc_control_reg_r()
+u16 sunplus_gcm394_base_device::spi_7945_misc_control_reg_r()
 {
 	LOGMASKED(LOG_GCM394_SPI, "%s:sunplus_gcm394_base_device::spi_7945_misc_control_reg_r\n", machine().describe_context());
 	return machine().rand();// &0x0007;
 }
 
-void sunplus_gcm394_base_device::spi_7942_txdata_w(uint16_t data)
+void sunplus_gcm394_base_device::spi_7942_txdata_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_SPI, "%s:sunplus_gcm394_base_device::spi_7942_txdata_w %04x\n", machine().describe_context(), data);
 }
 
 // **************************************** 796x unknown *************************************************
 
-void sunplus_gcm394_base_device::unkarea_7960_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7960_w %04x\n", machine().describe_context(), data); m_7960 = data; }
+void sunplus_gcm394_base_device::unkarea_7960_w(u16 data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7960_w %04x\n", machine().describe_context(), data); m_7960 = data; }
 
 // 7961 and 7962 are used by dressmtv when detecting battery status, adc?
-uint16_t sunplus_gcm394_base_device::unkarea_7961_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7961_r\n", machine().describe_context()); return 0xffff; /* return m_7961; */ }
-void sunplus_gcm394_base_device::unkarea_7961_w(uint16_t data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7961_w %04x\n", machine().describe_context(), data); m_7961 = data; }
+u16 sunplus_gcm394_base_device::unkarea_7961_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7961_r\n", machine().describe_context()); return 0xffff; /* return m_7961; */ }
+void sunplus_gcm394_base_device::unkarea_7961_w(u16 data) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7961_w %04x\n", machine().describe_context(), data); m_7961 = data; }
 
-uint16_t sunplus_gcm394_base_device::unkarea_7962_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7962_r\n", machine().describe_context()); return 0xffff; }
+u16 sunplus_gcm394_base_device::unkarea_7962_r() { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7962_r\n", machine().describe_context()); return 0xffff; }
 
 // **************************************** fallthrough logger etc. *************************************************
 
-uint16_t sunplus_gcm394_base_device::unk_r(offs_t offset)
+u16 sunplus_gcm394_base_device::unk_r(offs_t offset)
 {
 	switch (offset)
 	{
@@ -857,7 +857,7 @@ uint16_t sunplus_gcm394_base_device::unk_r(offs_t offset)
 	return 0x0000;
 }
 
-void sunplus_gcm394_base_device::unk_w(offs_t offset, uint16_t data)
+void sunplus_gcm394_base_device::unk_w(offs_t offset, u16 data)
 {
 
 	switch (offset)
@@ -1517,16 +1517,16 @@ void sunplus_gcm394_base_device::gcm394_internal_map(address_map& map)
 	map(0x200000, 0x3fffff).rw(FUNC(sunplus_gcm394_base_device::cs_bank_space_r), FUNC(sunplus_gcm394_base_device::cs_bank_space_w));
 }
 
-uint16_t sunplus_gcm394_base_device::cs_space_r(offs_t offset)
+u16 sunplus_gcm394_base_device::cs_space_r(offs_t offset)
 {
 	return m_cs_space->read_word(offset);
 }
 
-void sunplus_gcm394_base_device::cs_space_w(offs_t offset, uint16_t data)
+void sunplus_gcm394_base_device::cs_space_w(offs_t offset, u16 data)
 {
 	m_cs_space->write_word(offset, data);
 }
-uint16_t sunplus_gcm394_base_device::cs_bank_space_r(offs_t offset)
+u16 sunplus_gcm394_base_device::cs_bank_space_r(offs_t offset)
 {
 	int bank = m_membankswitch_7810 & 0x3f;
 	int realoffset = offset + (bank * 0x200000) - m_csbase;
@@ -1540,7 +1540,7 @@ uint16_t sunplus_gcm394_base_device::cs_bank_space_r(offs_t offset)
 	return m_cs_space->read_word(realoffset);
 }
 
-void sunplus_gcm394_base_device::cs_bank_space_w(offs_t offset, uint16_t data)
+void sunplus_gcm394_base_device::cs_bank_space_w(offs_t offset, u16 data)
 {
 	int bank = m_membankswitch_7810 & 0x3f;
 	int realoffset = offset + (bank * 0x200000) - m_csbase;
@@ -1556,11 +1556,11 @@ void sunplus_gcm394_base_device::cs_bank_space_w(offs_t offset, uint16_t data)
 
 
 
-uint16_t sunplus_gcm394_base_device::internalrom_lower32_r(offs_t offset)
+u16 sunplus_gcm394_base_device::internalrom_lower32_r(offs_t offset)
 {
 	if (m_boot_mode == 0)
 	{
-		uint16_t* introm = (uint16_t*)m_internalrom->base();
+		u16* introm = (u16*)m_internalrom->base();
 		return introm[offset];
 	}
 	else
@@ -1568,7 +1568,7 @@ uint16_t sunplus_gcm394_base_device::internalrom_lower32_r(offs_t offset)
 		if (!m_cs_space)
 			return 0x0000;
 
-		uint16_t val = m_cs_space->read_word(offset+0x8000);
+		u16 val = m_cs_space->read_word(offset+0x8000);
 		return val;
 	}
 }
@@ -1781,10 +1781,10 @@ void sunplus_gcm394_base_device::videoirq_w(int state)
 	set_state_unsynced(UNSP_IRQ5_LINE, state);
 }
 
-uint16_t sunplus_gcm394_base_device::read_space(offs_t offset)
+u16 sunplus_gcm394_base_device::read_space(offs_t offset)
 {
 	address_space &space = this->space(AS_PROGRAM);
-	uint16_t val;
+	u16 val;
 	if (offset < m_csbase)
 	{
 		val = space.read_word(offset);
@@ -1799,7 +1799,7 @@ uint16_t sunplus_gcm394_base_device::read_space(offs_t offset)
 
 
 
-void sunplus_gcm394_base_device::write_space(offs_t offset, uint16_t data)
+void sunplus_gcm394_base_device::write_space(offs_t offset, u16 data)
 {
 	address_space &space = this->space(AS_PROGRAM);
 	if (offset < m_csbase)

--- a/src/devices/machine/generalplus_gpl162xx_soc.cpp
+++ b/src/devices/machine/generalplus_gpl162xx_soc.cpp
@@ -1503,7 +1503,7 @@ void sunplus_gcm394_base_device::base_internal_map(address_map &map)
 
 }
 
-void sunplus_gcm394_base_device::gcm394_internal_map(address_map& map)
+void sunplus_gcm394_base_device::gcm394_internal_map(address_map &map)
 {
 	sunplus_gcm394_base_device::base_internal_map(map);
 
@@ -1560,7 +1560,7 @@ u16 sunplus_gcm394_base_device::internalrom_lower32_r(offs_t offset)
 {
 	if (m_boot_mode == 0)
 	{
-		u16* introm = (u16*)m_internalrom->base();
+		u16 *introm = (u16*)m_internalrom->base();
 		return introm[offset];
 	}
 	else

--- a/src/devices/machine/generalplus_gpl162xx_soc.h
+++ b/src/devices/machine/generalplus_gpl162xx_soc.h
@@ -22,7 +22,7 @@ typedef device_delegate<void (u16, u16, u16, u16, u16)> sunplus_gcm394_cs_callba
 class sunplus_gcm394_base_device : public unsp_20_device, public device_mixer_interface
 {
 public:
-	sunplus_gcm394_base_device(const machine_config& mconfig, device_type type, const char* tag, device_t* owner, u32 clock) :
+	sunplus_gcm394_base_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock) :
 		sunplus_gcm394_base_device(mconfig, type, tag, owner, clock, address_map_constructor(FUNC(sunplus_gcm394_base_device::gcm394_internal_map), this))
 	{
 	}
@@ -68,9 +68,9 @@ public:
 	u16 get_ram_addr(u32 addr) { return m_mainram[addr]; }
 
 protected:
-	sunplus_gcm394_base_device(const machine_config& mconfig, device_type type, const char* tag, device_t* owner, u32 clock, address_map_constructor internal);
+	sunplus_gcm394_base_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, address_map_constructor internal);
 
-	virtual void device_add_mconfig(machine_config& config) override ATTR_COLD;
+	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 	virtual void device_post_load() override ATTR_COLD;

--- a/src/devices/machine/generalplus_gpl162xx_soc.h
+++ b/src/devices/machine/generalplus_gpl162xx_soc.h
@@ -17,12 +17,12 @@
 #include "generalplus_gpl162xx_soc_video.h"
 #include "spg2xx_audio.h"
 
-typedef device_delegate<void (uint16_t, uint16_t, uint16_t, uint16_t, uint16_t)> sunplus_gcm394_cs_callback_device;
+typedef device_delegate<void (u16, u16, u16, u16, u16)> sunplus_gcm394_cs_callback_device;
 
 class sunplus_gcm394_base_device : public unsp_20_device, public device_mixer_interface
 {
 public:
-	sunplus_gcm394_base_device(const machine_config& mconfig, device_type type, const char* tag, device_t* owner, uint32_t clock) :
+	sunplus_gcm394_base_device(const machine_config& mconfig, device_type type, const char* tag, device_t* owner, u32 clock) :
 		sunplus_gcm394_base_device(mconfig, type, tag, owner, clock, address_map_constructor(FUNC(sunplus_gcm394_base_device::gcm394_internal_map), this))
 	{
 	}
@@ -50,7 +50,7 @@ public:
 		m_spg_video.lookup()->set_cs_video_space(tag, no, m_csbase);
 	}
 
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect) { return m_spg_video->screen_update(screen, bitmap, cliprect); }
+	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect) { return m_spg_video->screen_update(screen, bitmap, cliprect); }
 
 	void vblank(int state) { m_spg_video->vblank(state); }
 
@@ -58,17 +58,17 @@ public:
 	void set_alt_periodic_irq(bool alt) { m_alt_periodic_irq = alt; }
 
 	IRQ_CALLBACK_MEMBER(irq_vector_cb);
-	void default_cs_callback(uint16_t cs0, uint16_t cs1, uint16_t cs2, uint16_t cs3, uint16_t cs4 );
+	void default_cs_callback(u16 cs0, u16 cs1, u16 cs2, u16 cs3, u16 cs4 );
 
 	void set_legacy_video_mode() { m_spg_video->set_legacy_video_mode(); }
 	void set_disallow_resolution_control() { m_spg_video->set_disallow_resolution_control(); }
 
 	void set_romtype(int romtype) { m_romtype = romtype; }
 
-	uint16_t get_ram_addr(uint32_t addr) { return m_mainram[addr]; }
+	u16 get_ram_addr(u32 addr) { return m_mainram[addr]; }
 
 protected:
-	sunplus_gcm394_base_device(const machine_config& mconfig, device_type type, const char* tag, device_t* owner, uint32_t clock, address_map_constructor internal);
+	sunplus_gcm394_base_device(const machine_config& mconfig, device_type type, const char* tag, device_t* owner, u32 clock, address_map_constructor internal);
 
 	virtual void device_add_mconfig(machine_config& config) override ATTR_COLD;
 	virtual void device_start() override ATTR_COLD;
@@ -96,242 +96,240 @@ protected:
 
 	devcb_read16 m_nand_read_cb;
 	optional_address_space m_cs_space;
-	uint32_t m_csbase;
+	u32 m_csbase;
 
-	uint16_t m_dma_params[8][4];
+	u16 m_dma_params[8][4];
 	bool m_dma_latched[4];
 
 	// unk 78xx
-	uint16_t m_7803;
+	u16 m_sys_ctrl;
 
-	uint16_t m_7807;
+	u16 m_clock_ctrl;
 
-	uint16_t m_membankswitch_7810;
+	u16 m_membankswitch_7810;
 
-	uint16_t m_7816;
-	uint16_t m_7817;
+	u16 m_7816;
+	u16 m_pllchange;
 
-	uint16_t m_7819;
+	u16 m_cache_ctrl;
 
-	uint16_t m_782x[5];
+	u16 m_782x[5];
 
-	uint16_t m_782d;
+	u16 m_782d;
 
-	uint16_t m_7835;
+	u16 m_7835;
 
-	uint16_t m_7860;
+	u16 m_7862_porta_direction;
+	u16 m_7863_porta_attribute;
 
-	uint16_t m_7861;
+	u16 m_786a_portb_direction;
+	u16 m_786b_portb_attribute;
 
-	uint16_t m_7862_porta_direction;
-	uint16_t m_7863_porta_attribute;
+	u16 m_7872_portc_direction;
+	u16 m_7873_portc_attribute;
 
-	uint16_t m_786a_portb_direction;
-	uint16_t m_786b_portb_attribute;
+	u16 m_787a_portd_direction;
+	u16 m_787b_portd_attribute;
 
-	uint16_t m_7872_portc_direction;
-	uint16_t m_7873_portc_attribute;
+	u16 m_ioc_data;
 
-	uint16_t m_787a_portd_direction;
-	uint16_t m_787b_portd_attribute;
+	u16 m_ioe_dir;
+	u16 m_ioe_attrib;
 
-	uint16_t m_7870;
+	u16 m_int_status1;
 
-	//uint16_t m_7871;
+	u16 m_int_priority_1;
+	u16 m_int_priority_2;
+	u16 m_int_priority_3;
 
+	u16 m_misc_int_ctrl;
 
-	uint16_t m_7882;
-	uint16_t m_7883;
+	u16 m_timebasea_ctrl;
+	u16 m_timebaseb_ctrl;
+	u16 m_timebasec_ctrl;
 
-	uint16_t m_78a0;
+	u16 m_timebase_reset;
 
-	uint16_t m_78a4;
-	uint16_t m_78a5;
-	uint16_t m_78a6;
+	u16 m_cha_ctrl;
 
-	uint16_t m_78a8;
-
-	uint16_t m_78b0;
-	uint16_t m_78b1;
-	uint16_t m_78b2;
-
-	uint16_t m_78b8;
-
-	uint16_t m_78f0;
-
-	uint16_t m_78fb;
+	u16 m_78fb;
 
 	// unk 79xx
-	uint16_t m_7934;
-	uint16_t m_7935;
-	uint16_t m_7936;
+	u16 m_rtc_ctrl;
+	u16 m_rtc_int_status;
+	u16 m_rtc_int_ctrl;
 
-	uint16_t m_7960;
-	uint16_t m_7961;
+	u16 m_7960;
+	u16 m_7961;
 
-	uint16_t m_system_dma_memtype;
+	u16 m_system_dma_memtype;
 
-	uint16_t internalrom_lower32_r(offs_t offset);
+	u16 internalrom_lower32_r(offs_t offset);
 
-	uint16_t cs_space_r(offs_t offset);
-	void cs_space_w(offs_t offset, uint16_t data);
-	uint16_t cs_bank_space_r(offs_t offset);
-	void cs_bank_space_w(offs_t offset, uint16_t data);
+	u16 cs_space_r(offs_t offset);
+	void cs_space_w(offs_t offset, u16 data);
+	u16 cs_bank_space_r(offs_t offset);
+	void cs_bank_space_w(offs_t offset, u16 data);
 	int m_romtype;
 
-private:
+protected:
 	devcb_read16 m_space_read_cb;
 	devcb_write16 m_space_write_cb;
 	devcb_write_line m_dma_complete_cb;
 
-	uint16_t unk_r(offs_t offset);
-	void unk_w(offs_t offset, uint16_t data);
+	u16 unk_r(offs_t offset);
+	void unk_w(offs_t offset, u16 data);
 
-	void write_dma_params(int channel, int offset, uint16_t data);
-	uint16_t read_dma_params(int channel, int offset);
+	void write_dma_params(int channel, int offset, u16 data);
+	u16 read_dma_params(int channel, int offset);
 	void trigger_systemm_dma(int channel);
 
-	uint16_t system_dma_params_channel0_r(offs_t offset);
-	void system_dma_params_channel0_w(offs_t offset, uint16_t data);
-	uint16_t system_dma_params_channel1_r(offs_t offset);
-	void system_dma_params_channel1_w(offs_t offset, uint16_t data);
-	uint16_t system_dma_params_channel2_r(offs_t offset);
-	void system_dma_params_channel2_w(offs_t offset, uint16_t data);
-	uint16_t system_dma_params_channel3_r(offs_t offset);
-	void system_dma_params_channel3_w(offs_t offset, uint16_t data);
-	uint16_t system_dma_status_r();
-	void system_dma_7abf_unk_w(uint16_t data);
-	uint16_t system_dma_memtype_r();
-	void system_dma_memtype_w(uint16_t data);
+	u16 system_dma_params_channel0_r(offs_t offset);
+	void system_dma_params_channel0_w(offs_t offset, u16 data);
+	u16 system_dma_params_channel1_r(offs_t offset);
+	void system_dma_params_channel1_w(offs_t offset, u16 data);
+	u16 system_dma_params_channel2_r(offs_t offset);
+	void system_dma_params_channel2_w(offs_t offset, u16 data);
+	u16 system_dma_params_channel3_r(offs_t offset);
+	void system_dma_params_channel3_w(offs_t offset, u16 data);
+	u16 system_dma_status_r();
+	void system_dma_7abf_unk_w(u16 data);
+	u16 system_dma_memtype_r();
+	void system_dma_memtype_w(u16 data);
 
-	uint16_t unkarea_780f_status_r();
-	uint16_t unkarea_78fb_status_r();
+	u16 power_state_r();
+	u16 unkarea_78fb_status_r();
 
-	uint16_t unkarea_7803_r();
-	void unkarea_7803_w(uint16_t data);
+	u16 unkarea_7803_r();
+	void unkarea_7803_w(u16 data);
 
-	void unkarea_7807_w(uint16_t data);
+	void clock_ctrl_w(u16 data);
 
-	void waitmode_enter_780c_w(uint16_t data);
+	void waitmode_enter_780c_w(u16 data);
 
-	uint16_t membankswitch_7810_r();
-	void membankswitch_7810_w(uint16_t data);
+	u16 membankswitch_7810_r();
+	void membankswitch_7810_w(u16 data);
 
-	void unkarea_7816_w(uint16_t data);
-	void unkarea_7817_w(uint16_t data);
+	void unkarea_7816_w(u16 data);
+	void pllchange_w(u16 data);
 
-	uint16_t unkarea_7819_r();
-	void unkarea_7819_w(uint16_t data);
+	u16 cache_ctrl_r();
+	void cache_ctrl_w(u16 data);
 
-	void chipselect_csx_memory_device_control_w(offs_t offset, uint16_t data);
+	void chipselect_csx_memory_device_control_w(offs_t offset, u16 data);
 
-	void unkarea_7835_w(uint16_t data);
+	void unkarea_7835_w(u16 data);
 
-	uint16_t unkarea_782d_r();
-	void unkarea_782d_w(uint16_t data);
+	u16 unkarea_782d_r();
+	void unkarea_782d_w(u16 data);
 
 	// Port A
-	uint16_t ioarea_7860_porta_r();
-	void ioarea_7860_porta_w(uint16_t data);
-	uint16_t ioarea_7861_porta_buffer_r();
-	void ioarea_7861_porta_buffer_w(uint16_t data);
-	uint16_t ioarea_7862_porta_direction_r();
-	void ioarea_7862_porta_direction_w(uint16_t data);
-	uint16_t ioarea_7863_porta_attribute_r();
-	void ioarea_7863_porta_attribute_w(uint16_t data);
+	u16 ioa_data_r();
+	void ioa_data_w(u16 data);
+	u16 ioa_buffer_r();
+	void ioa_buffer_w(u16 data);
+	u16 ioa_dir_r();
+	void ioa_dir_w(u16 data);
+	u16 ioa_attrib_r();
+	void ioa_attrib_w(u16 data);
 
 	// Port B
-	uint16_t ioarea_7868_portb_r();
-	void ioarea_7868_portb_w(uint16_t data);
-	uint16_t ioarea_7869_portb_buffer_r();
-	void ioarea_7869_portb_buffer_w(uint16_t data);
-	uint16_t ioarea_786a_portb_direction_r();
-	void ioarea_786a_portb_direction_w(uint16_t data);
-	uint16_t ioarea_786b_portb_attribute_r();
-	void ioarea_786b_portb_attribute_w(uint16_t data);
+	u16 iob_data_r();
+	void iob_data_w(u16 data);
+	u16 iob_buffer_r();
+	void iob_buffer_w(u16 data);
+	u16 iob_dir_r();
+	void iob_dir_w(u16 data);
+	u16 iob_attrib_r();
+	void iob_attrib_w(u16 data);
 
 	// Port C
-	uint16_t ioarea_7870_portc_r();
-	void ioarea_7870_portc_w(uint16_t data);
-	uint16_t ioarea_7871_portc_buffer_r();
-	void ioarea_7871_portc_buffer_w(uint16_t data);
-	uint16_t ioarea_7872_portc_direction_r();
-	void ioarea_7872_portc_direction_w(uint16_t data);
-	uint16_t ioarea_7873_portc_attribute_r();
-	void ioarea_7873_portc_attribute_w(uint16_t data);
+	u16 ioc_data_r();
+	void ioc_data_w(u16 data);
+	u16 ioc_buffer_r();
+	void ioc_buffer_w(u16 data);
+	u16 ioc_dir_r();
+	void ioc_dir_w(u16 data);
+	u16 ioc_attrib_r();
+	void ioc_attrib_w(u16 data);
 
 	// Port D
-	uint16_t ioarea_7878_portd_r();
-	void ioarea_7878_portd_w(uint16_t data);
-	uint16_t ioarea_7879_portd_buffer_r();
-	void ioarea_7879_portd_buffer_w(uint16_t data);
-	uint16_t ioarea_787a_portd_direction_r();
-	void ioarea_787a_portd_direction_w(uint16_t data);
-	uint16_t ioarea_787b_portd_attribute_r();
-	void ioarea_787b_portd_attribute_w(uint16_t data);
+	u16 iod_data_r();
+	void iod_data_w(u16 data);
+	u16 iod_buffer_r();
+	void iod_buffer_w(u16 data);
+	u16 iod_dir_r();
+	void iod_dir_w(u16 data);
+	u16 iod_attib_r();
+	void iod_attib_w(u16 data);
+	u16 iod_drv_r();
+	void iod_drv_w(u16 data);
+	u16 iod_mux_r();
+	void iod_mux_w(u16 data);
 
-	uint16_t unkarea_7882_r();
-	void unkarea_7882_w(uint16_t data);
-	uint16_t unkarea_7883_r();
-	void unkarea_7883_w(uint16_t data);
 
-	void unkarea_78a0_w(uint16_t data);
+	u16 ioe_dir_r();
+	void ioe_dir_w(u16 data);
+	u16 ioe_attrib_r();
+	void ioe_attrib_w(u16 data);
 
-	uint16_t unkarea_78a0_r();
-	uint16_t unkarea_78a1_r();
+	void int_status1_w(u16 data);
 
-	void unkarea_78a4_w(uint16_t data);
-	void unkarea_78a5_w(uint16_t data);
-	void unkarea_78a6_w(uint16_t data);
+	u16 int_status1_r();
+	u16 int_status2_r();
 
-	void unkarea_78a8_w(uint16_t data);
+	void int_priority_1_w(u16 data);
+	void int_priority_2_w(u16 data);
+	void int_priority_3_w(u16 data);
 
-	void unkarea_78b0_w(uint16_t data);
-	void unkarea_78b1_w(uint16_t data);
+	void mint_ctrl_w(u16 data);
 
-	uint16_t unkarea_78b2_r();
-	void unkarea_78b2_w(uint16_t data);
+	void timebasea_ctrl_w(u16 data);
+	void timebaseb_ctrl_w(u16 data);
 
-	void unkarea_78b8_w(uint16_t data);
+	u16 timebasec_ctrl_r();
+	void timebasec_ctrl_w(u16 data);
 
-	uint16_t unkarea_78c0_r();
-	uint16_t unkarea_78c8_r();
+	void timebase_reset_w(u16 data);
 
-	uint16_t unkarea_78d0_r();
-	uint16_t unkarea_78d8_r();
+	u16 timera_ctrl_r();
+	u16 timerb_ctrl_r();
 
-	uint16_t unkarea_78f0_r();
-	void unkarea_78f0_w(uint16_t data);
+	u16 timerc_ctrl_r();
+	u16 timerd_ctrl_r();
 
-	uint16_t unkarea_7904_r();
+	u16 cha_ctrl_r();
+	void cha_ctrl_w(u16 data);
 
-	uint16_t unkarea_7934_r();
-	void unkarea_7934_w(uint16_t data);
+	u16 unkarea_7904_r();
 
-	uint16_t unkarea_7935_r();
-	void unkarea_7935_w(uint16_t data);
+	u16 rtc_ctrl_r();
+	void rtc_ctrl_w(u16 data);
 
-	uint16_t unkarea_7936_r();
-	void unkarea_7936_w(uint16_t data);
+	u16 rtc_int_status_r();
+	void rtc_int_status_w(u16 data);
 
-	uint16_t spi_7944_rxdata_r();
-	uint16_t spi_7945_misc_control_reg_r();
-	void spi_7942_txdata_w(uint16_t data);
+	u16 rtc_int_ctrl_r();
+	void rtc_int_ctrl_w(u16 data);
 
-	void unkarea_7960_w(uint16_t data);
-	uint16_t unkarea_7961_r();
-	void unkarea_7961_w(uint16_t data);
-	uint16_t unkarea_7962_r();
+	u16 spi_7944_rxdata_r();
+	u16 spi_7945_misc_control_reg_r();
+	void spi_7942_txdata_w(u16 data);
+
+	void unkarea_7960_w(u16 data);
+	u16 unkarea_7961_r();
+	void unkarea_7961_w(u16 data);
+	u16 unkarea_7962_r();
 
 	void videoirq_w(int state);
 	void audioirq_w(int state);
 
-	uint16_t system_7a35_r();
-	uint16_t system_7a37_r();
-	uint16_t system_7a39_r();
-	uint16_t system_7a3a_r();
-	uint16_t system_7a46_r();
-	uint16_t system_7a54_r();
+	u16 system_7a35_r();
+	u16 system_7a37_r();
+	u16 system_7a39_r();
+	u16 system_7a3a_r();
+	u16 system_7a46_r();
+	u16 system_7a54_r();
 
 	void checkirq6();
 
@@ -339,8 +337,8 @@ private:
 
 	TIMER_CALLBACK_MEMBER(unknown_tick);
 
-	inline uint16_t read_space(offs_t offset);
-	inline void write_space(offs_t offset, uint16_t data);
+	inline u16 read_space(offs_t offset);
+	inline void write_space(offs_t offset, u16 data);
 
 	bool m_alt_periodic_irq; // might be multiple timers, might be a register to configure, currently a config option.
 
@@ -355,13 +353,13 @@ class sunplus_gcm394_device : public sunplus_gcm394_base_device
 {
 public:
 	template <typename T>
-	sunplus_gcm394_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&screen_tag) :
+	sunplus_gcm394_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, T &&screen_tag) :
 		sunplus_gcm394_device(mconfig, tag, owner, clock)
 	{
 		m_screen.set_tag(std::forward<T>(screen_tag));
 	}
 
-	sunplus_gcm394_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	sunplus_gcm394_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 };
 
 

--- a/src/devices/machine/generalplus_gpl162xx_soc_video.cpp
+++ b/src/devices/machine/generalplus_gpl162xx_soc_video.cpp
@@ -25,7 +25,7 @@ DEFINE_DEVICE_TYPE(GCM394_VIDEO, gcm394_video_device, "gcm394_video", "GeneralPl
 #include "logmacro.h"
 
 
-gcm394_base_video_device::gcm394_base_video_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+gcm394_base_video_device::gcm394_base_video_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock) :
 	device_t(mconfig, type, tag, owner, clock),
 	device_video_interface(mconfig, *this),
 	m_rowscroll(*this, "^rowscroll"), // FIXME: assumption about surrounding system
@@ -44,7 +44,7 @@ gcm394_base_video_device::gcm394_base_video_device(const machine_config &mconfig
 {
 }
 
-gcm394_video_device::gcm394_video_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+gcm394_video_device::gcm394_video_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: gcm394_base_video_device(mconfig, GCM394_VIDEO, tag, owner, clock)
 {
 }
@@ -54,7 +54,7 @@ void gcm394_base_video_device::decodegfx(const char* tag)
 	if (!memregion(tag))
 		return;
 
-	uint8_t* gfxregion = memregion(tag)->base();
+	u8* gfxregion = memregion(tag)->base();
 	int gfxregionsize = memregion(tag)->bytes();
 
 	if (1)
@@ -144,8 +144,8 @@ void gcm394_base_video_device::decodegfx(const char* tag)
 
 	if (1)
 	{
-		const uint32_t texlayout_xoffset[64] = { STEP64(0,2) };
-		const uint32_t texlayout_yoffset[32] = { STEP32(0,2 * 64) };
+		const u32 texlayout_xoffset[64] = { STEP64(0,2) };
+		const u32 texlayout_yoffset[32] = { STEP32(0,2 * 64) };
 
 		gfx_layout obj_layout =
 		{
@@ -318,7 +318,7 @@ void gcm394_base_video_device::device_reset()
 	m_page3_addr_msb = 0;
 }
 
-uint32_t gcm394_base_video_device::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+u32 gcm394_base_video_device::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	// For jak_car2 and jak_gtg the palette entry for 'magenta' in the test mode is intentionally set to a transparent black pen
 	// (it is stored in the palette table in ROM that way, and copied directly) so the only way for the magenta entries on the screen
@@ -331,14 +331,14 @@ uint32_t gcm394_base_video_device::screen_update(screen_device &screen, bitmap_r
 
 	if (0)
 	{
-		uint16_t attr0 = m_tmap0_regs[0];
-		uint16_t attr1 = m_tmap1_regs[0];
-		uint16_t attr2 = m_tmap2_regs[0];
-		uint16_t attr3 = m_tmap3_regs[0];
-		uint16_t ctrl0 = m_tmap0_regs[1];
-		uint16_t ctrl1 = m_tmap1_regs[1];
-		uint16_t ctrl2 = m_tmap2_regs[1];
-		uint16_t ctrl3 = m_tmap3_regs[1];
+		u16 attr0 = m_tmap0_regs[0];
+		u16 attr1 = m_tmap1_regs[0];
+		u16 attr2 = m_tmap2_regs[0];
+		u16 attr3 = m_tmap3_regs[0];
+		u16 ctrl0 = m_tmap0_regs[1];
+		u16 ctrl1 = m_tmap1_regs[1];
+		u16 ctrl2 = m_tmap2_regs[1];
+		u16 ctrl3 = m_tmap3_regs[1];
 
 		popmessage(
 			"p0ct u:%02x Bl:%d HC:%d Ycmp:%d Hcmp:%d RS:%d E:%d WP:%d Rg:%d Bm:%d gfxadr: %08x t:%04x p:%04x\n"
@@ -362,8 +362,8 @@ uint32_t gcm394_base_video_device::screen_update(screen_device &screen, bitmap_r
 		);
 	}
 
-	//const uint16_t bgcol = 0x7c1f; // magenta
-//  const uint16_t bgcol = 0x0000; // black
+	//const u16 bgcol = 0x7c1f; // magenta
+//  const u16 bgcol = 0x0000; // black
 	bool highres = false;
 	if (!m_disallow_resolution_control)
 	{
@@ -381,7 +381,7 @@ uint32_t gcm394_base_video_device::screen_update(screen_device &screen, bitmap_r
 
 	address_space &mem = m_cpu->space(AS_PROGRAM);
 
-	uint32_t sprites_addr;
+	u32 sprites_addr;
 
 	if (m_707f & 0x0040) // FREE == 1
 	{
@@ -392,7 +392,7 @@ uint32_t gcm394_base_video_device::screen_update(screen_device &screen, bitmap_r
 		sprites_addr = m_sprite_7022_gfxbase_lsb * 0x40;
 	}
 
-	for (uint32_t scanline = (uint32_t)cliprect.min_y; scanline <= (uint32_t)cliprect.max_y; scanline++)
+	for (u32 scanline = (u32)cliprect.min_y; scanline <= (u32)cliprect.max_y; scanline++)
 	{
 		m_renderer->new_line(cliprect);
 
@@ -413,7 +413,7 @@ uint32_t gcm394_base_video_device::screen_update(screen_device &screen, bitmap_r
 }
 
 
-void gcm394_base_video_device::write_tmap_scroll(int tmap, uint16_t* regs, int offset, uint16_t data)
+void gcm394_base_video_device::write_tmap_scroll(int tmap, u16* regs, int offset, u16 data)
 {
 	switch (offset)
 	{
@@ -429,7 +429,7 @@ void gcm394_base_video_device::write_tmap_scroll(int tmap, uint16_t* regs, int o
 	}
 }
 
-void gcm394_base_video_device::write_tmap_regs(int tmap, uint16_t* regs, int offset, uint16_t data)
+void gcm394_base_video_device::write_tmap_regs(int tmap, u16* regs, int offset, u16 data)
 {
 	switch (offset)
 	{
@@ -465,7 +465,7 @@ void gcm394_base_video_device::write_tmap_regs(int tmap, uint16_t* regs, int off
 // As the hardware appears to support ROZ these are probably 2 extra tile layers, with the 2 additional words being the ROZ parameters?
 
 
-void gcm394_base_video_device::write_tmap_extrascroll(int tmap, uint16_t* regs, int offset, uint16_t data)
+void gcm394_base_video_device::write_tmap_extrascroll(int tmap, u16* regs, int offset, u16 data)
 {
 	switch (offset)
 	{
@@ -490,7 +490,7 @@ void gcm394_base_video_device::write_tmap_extrascroll(int tmap, uint16_t* regs, 
 
 // **************************************** TILEMAP 0 *************************************************
 
-uint16_t gcm394_base_video_device::tmap0_regs_r(offs_t offset)
+u16 gcm394_base_video_device::tmap0_regs_r(offs_t offset)
 {
 	if (offset < 2)
 	{
@@ -502,7 +502,7 @@ uint16_t gcm394_base_video_device::tmap0_regs_r(offs_t offset)
 	}
 }
 
-void gcm394_base_video_device::tmap0_regs_w(offs_t offset, uint16_t data)
+void gcm394_base_video_device::tmap0_regs_w(offs_t offset, u16 data)
 {
 	LOGMASKED(LOG_GCM394_TMAP_EXTRA, "%s:gcm394_base_video_device::tmap0_regs_w %01x %04x\n", machine().describe_context(), offset, data);
 	if (offset < 2)
@@ -515,24 +515,24 @@ void gcm394_base_video_device::tmap0_regs_w(offs_t offset, uint16_t data)
 	}
 }
 
-uint16_t gcm394_base_video_device::tmap0_tilebase_lsb_r()
+u16 gcm394_base_video_device::tmap0_tilebase_lsb_r()
 {
 	return m_page0_addr_lsb;
 }
 
-void gcm394_base_video_device::tmap0_tilebase_lsb_w(uint16_t data)
+void gcm394_base_video_device::tmap0_tilebase_lsb_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_TMAP, "%s:gcm394_base_video_device::tmap0_tilebase_lsb_w %04x\n", machine().describe_context(), data);
 	m_page0_addr_lsb = data;
 	LOGMASKED(LOG_GCM394_TMAP, "\t(tmap0 tilegfxbase is now %04x%04x)\n", m_page0_addr_msb, m_page0_addr_lsb);
 }
 
-uint16_t gcm394_base_video_device::tmap0_tilebase_msb_r()
+u16 gcm394_base_video_device::tmap0_tilebase_msb_r()
 {
 	return m_page0_addr_msb;
 }
 
-void gcm394_base_video_device::tmap0_tilebase_msb_w(uint16_t data)
+void gcm394_base_video_device::tmap0_tilebase_msb_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_TMAP, "%s:gcm394_base_video_device::tmap0_tilebase_msb_w %04x\n", machine().describe_context(), data);
 	m_page0_addr_msb = data;
@@ -542,7 +542,7 @@ void gcm394_base_video_device::tmap0_tilebase_msb_w(uint16_t data)
 // **************************************** TILEMAP 1 *************************************************
 
 
-uint16_t gcm394_base_video_device::tmap1_regs_r(offs_t offset)
+u16 gcm394_base_video_device::tmap1_regs_r(offs_t offset)
 {
 	if (offset < 2)
 	{
@@ -554,7 +554,7 @@ uint16_t gcm394_base_video_device::tmap1_regs_r(offs_t offset)
 	}
 }
 
-void gcm394_base_video_device::tmap1_regs_w(offs_t offset, uint16_t data)
+void gcm394_base_video_device::tmap1_regs_w(offs_t offset, u16 data)
 {
 	LOGMASKED(LOG_GCM394_TMAP_EXTRA, "%s:gcm394_base_video_device::tmap1_regs_w %01x %04x\n", machine().describe_context(), offset, data);
 	if (offset < 2)
@@ -567,24 +567,24 @@ void gcm394_base_video_device::tmap1_regs_w(offs_t offset, uint16_t data)
 	}
 }
 
-uint16_t gcm394_base_video_device::tmap1_tilebase_lsb_r()
+u16 gcm394_base_video_device::tmap1_tilebase_lsb_r()
 {
 	return m_page1_addr_lsb;
 }
 
-void gcm394_base_video_device::tmap1_tilebase_lsb_w(uint16_t data)
+void gcm394_base_video_device::tmap1_tilebase_lsb_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_TMAP, "%s:gcm394_base_video_device::tmap1_tilebase_lsb_w %04x\n", machine().describe_context(), data);
 	m_page1_addr_lsb = data;
 	LOGMASKED(LOG_GCM394_TMAP, "\t(tmap1 tilegfxbase is now %04x%04x)\n", m_page1_addr_msb, m_page1_addr_lsb);
 }
 
-uint16_t gcm394_base_video_device::tmap1_tilebase_msb_r()
+u16 gcm394_base_video_device::tmap1_tilebase_msb_r()
 {
 	return m_page1_addr_msb;
 }
 
-void gcm394_base_video_device::tmap1_tilebase_msb_w(uint16_t data)
+void gcm394_base_video_device::tmap1_tilebase_msb_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_TMAP, "%s:gcm394_base_video_device::tmap1_tilebase_msb_w %04x\n", machine().describe_context(), data);
 	m_page1_addr_msb = data;
@@ -593,7 +593,7 @@ void gcm394_base_video_device::tmap1_tilebase_msb_w(uint16_t data)
 
 // **************************************** unknown video device 1 (another tilemap? roz? line? zooming sprite layer?) *************************************************
 
-uint16_t gcm394_base_video_device::tmap2_regs_r(offs_t offset)
+u16 gcm394_base_video_device::tmap2_regs_r(offs_t offset)
 {
 	if (offset < 4)
 	{
@@ -605,7 +605,7 @@ uint16_t gcm394_base_video_device::tmap2_regs_r(offs_t offset)
 	}
 }
 
-void gcm394_base_video_device::tmap2_regs_w(offs_t offset, uint16_t data)
+void gcm394_base_video_device::tmap2_regs_w(offs_t offset, u16 data)
 {
 	LOGMASKED(LOG_GCM394_TMAP_EXTRA, "%s:gcm394_base_video_device::tmap2_regs_w %01x %04x\n", machine().describe_context(), offset, data);
 	if (offset < 4)
@@ -618,25 +618,25 @@ void gcm394_base_video_device::tmap2_regs_w(offs_t offset, uint16_t data)
 	}
 }
 
-uint16_t gcm394_base_video_device::tmap2_tilebase_lsb_r()
+u16 gcm394_base_video_device::tmap2_tilebase_lsb_r()
 {
 	return m_page2_addr_lsb;
 }
 
 
-void gcm394_base_video_device::tmap2_tilebase_lsb_w(uint16_t data)
+void gcm394_base_video_device::tmap2_tilebase_lsb_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::tmap2_tilebase_lsb_w %04x\n", machine().describe_context(), data);
 	m_page2_addr_lsb = data;
 	LOGMASKED(LOG_GCM394_TMAP, "\t(unk_vid1 tilegfxbase is now %04x%04x)\n", m_page2_addr_msb, m_page2_addr_lsb);
 }
 
-uint16_t gcm394_base_video_device::tmap2_tilebase_msb_r()
+u16 gcm394_base_video_device::tmap2_tilebase_msb_r()
 {
 	return m_page2_addr_msb;
 }
 
-void gcm394_base_video_device::tmap2_tilebase_msb_w(uint16_t data)
+void gcm394_base_video_device::tmap2_tilebase_msb_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::tmap2_tilebase_msb_w %04x\n", machine().describe_context(), data);
 	m_page2_addr_msb = data;
@@ -645,7 +645,7 @@ void gcm394_base_video_device::tmap2_tilebase_msb_w(uint16_t data)
 
 // **************************************** unknown video device 2 (another tilemap? roz? lines? zooming sprite layer?) *************************************************
 
-uint16_t gcm394_base_video_device::tmap3_regs_r(offs_t offset)
+u16 gcm394_base_video_device::tmap3_regs_r(offs_t offset)
 {
 	if (offset < 4)
 	{
@@ -657,7 +657,7 @@ uint16_t gcm394_base_video_device::tmap3_regs_r(offs_t offset)
 	}
 }
 
-void gcm394_base_video_device::tmap3_regs_w(offs_t offset, uint16_t data)
+void gcm394_base_video_device::tmap3_regs_w(offs_t offset, u16 data)
 {
 	LOGMASKED(LOG_GCM394_TMAP_EXTRA, "%s:gcm394_base_video_device::tmap3_regs_w %01x %04x\n", machine().describe_context(), offset, data);
 	if (offset < 4)
@@ -670,26 +670,26 @@ void gcm394_base_video_device::tmap3_regs_w(offs_t offset, uint16_t data)
 	}
 }
 
-uint16_t gcm394_base_video_device::tmap3_tilebase_lsb_r()
+u16 gcm394_base_video_device::tmap3_tilebase_lsb_r()
 {
 	return m_page3_addr_lsb;
 }
 
 
-void gcm394_base_video_device::tmap3_tilebase_lsb_w(uint16_t data)
+void gcm394_base_video_device::tmap3_tilebase_lsb_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::tmap3_tilebase_lsb_w %04x\n", machine().describe_context(), data);
 	m_page3_addr_lsb = data;
 	LOGMASKED(LOG_GCM394_TMAP, "\t(unk_vid2 tilegfxbase is now %04x%04x)\n", m_page3_addr_msb, m_page3_addr_lsb);
 }
 
-uint16_t gcm394_base_video_device::tmap3_tilebase_msb_r()
+u16 gcm394_base_video_device::tmap3_tilebase_msb_r()
 {
 	return m_page3_addr_msb;
 }
 
 
-void gcm394_base_video_device::tmap3_tilebase_msb_w(uint16_t data)
+void gcm394_base_video_device::tmap3_tilebase_msb_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::tmap3_tilebase_msb_w %04x\n", machine().describe_context(), data);
 	m_page3_addr_msb = data;
@@ -700,38 +700,38 @@ void gcm394_base_video_device::tmap3_tilebase_msb_w(uint16_t data)
 
 // set to 001264c0 in wrlshunt, which point at the menu selectors (game names, arrows etc.)
 
-uint16_t gcm394_base_video_device::sprite_7022_gfxbase_lsb_r()
+u16 gcm394_base_video_device::sprite_7022_gfxbase_lsb_r()
 {
 	return m_sprite_7022_gfxbase_lsb;
 }
 
-void gcm394_base_video_device::sprite_7022_gfxbase_lsb_w(uint16_t data)
+void gcm394_base_video_device::sprite_7022_gfxbase_lsb_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::sprite_7022_gfxbase_lsb_w %04x\n", machine().describe_context(), data);
 	m_sprite_7022_gfxbase_lsb = data;
 	LOGMASKED(LOG_GCM394_TMAP, "\t(sprite tilebase is now %04x%04x)\n", m_sprite_702d_gfxbase_msb, m_sprite_7022_gfxbase_lsb);
 }
 
-uint16_t gcm394_base_video_device::sprite_702d_gfxbase_msb_r()
+u16 gcm394_base_video_device::sprite_702d_gfxbase_msb_r()
 {
 	return m_sprite_702d_gfxbase_msb;
 }
 
-void gcm394_base_video_device::sprite_702d_gfxbase_msb_w(uint16_t data)
+void gcm394_base_video_device::sprite_702d_gfxbase_msb_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::sprite_702d_gfxbase_msb_w %04x\n", machine().describe_context(), data);
 	m_sprite_702d_gfxbase_msb = data;
 	LOGMASKED(LOG_GCM394_TMAP, "\t(sprite tilebase tilegfxbase is now %04x%04x)\n", m_sprite_702d_gfxbase_msb, m_sprite_7022_gfxbase_lsb);
 }
 
-uint16_t gcm394_base_video_device::sprite_7042_extra_r()
+u16 gcm394_base_video_device::sprite_7042_extra_r()
 {
-	uint16_t retdata = m_7042_sprite;
+	u16 retdata = m_7042_sprite;
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::sprite_7042_extra_r (returning: %04x)\n", machine().describe_context(), retdata);
 	return retdata;
 }
 
-void gcm394_base_video_device::sprite_7042_extra_w(uint16_t data)
+void gcm394_base_video_device::sprite_7042_extra_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::sprite_7042_extra_w %04x\n", machine().describe_context(), data);
 	m_7042_sprite = data;
@@ -756,25 +756,25 @@ void gcm394_base_video_device::sprite_7042_extra_w(uint16_t data)
 
 // **************************************** video DMA device *************************************************
 
-void gcm394_base_video_device::video_dma_source_w(uint16_t data)
+void gcm394_base_video_device::video_dma_source_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO_DMA, "%s:gcm394_base_video_device::video_dma_source_w %04x\n", machine().describe_context(), data);
 	m_videodma_source = data;
 }
 
-void gcm394_base_video_device::video_dma_dest_w(uint16_t data)
+void gcm394_base_video_device::video_dma_dest_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO_DMA, "%s:gcm394_base_video_device::video_dma_dest_w %04x\n", machine().describe_context(), data);
 	m_videodma_dest = data;
 }
 
-uint16_t gcm394_base_video_device::video_dma_size_busy_r()
+u16 gcm394_base_video_device::video_dma_size_busy_r()
 {
 	LOGMASKED(LOG_GCM394_VIDEO_DMA, "%s:gcm394_base_video_device::video_dma_size_busy_r\n", machine().describe_context());
 	return 0x0000;
 }
 
-void gcm394_base_video_device::video_dma_size_trigger_w(address_space &space, uint16_t data)
+void gcm394_base_video_device::video_dma_size_trigger_w(address_space &space, u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO_DMA, "%s:gcm394_base_video_device::video_dma_size_trigger_w %04x\n", machine().describe_context(), data);
 	m_videodma_size = data;
@@ -790,7 +790,7 @@ void gcm394_base_video_device::video_dma_size_trigger_w(address_space &space, ui
 
 	for (int i = 0; i <= size; i++)
 	{
-		uint16_t dat = space.read_word(m_videodma_source + i);
+		u16 dat = space.read_word(m_videodma_source + i);
 
 		if ((dest + i) < 0x400)
 			space.write_word(0x7400 + dest + i, dat);
@@ -800,35 +800,35 @@ void gcm394_base_video_device::video_dma_size_trigger_w(address_space &space, ui
 
 	if (m_video_irq_enable & 4)
 	{
-		const uint16_t old = m_video_irq_status;
+		const u16 old = m_video_irq_status;
 		m_video_irq_status |= 4;
-		const uint16_t changed = old ^ (m_video_irq_enable & m_video_irq_status);
+		const u16 changed = old ^ (m_video_irq_enable & m_video_irq_status);
 		if (changed)
 			check_video_irq();
 	}
 }
 
-void gcm394_base_video_device::video_707e_spritebank_w(uint16_t data)
+void gcm394_base_video_device::ppu_ram_bank_w(u16 data)
 {
-	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_707e_spritebank_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::ppu_ram_bank_w %04x\n", machine().describe_context(), data);
 	m_707e_spritebank = data;
 }
 
-uint16_t gcm394_base_video_device::video_707c_r()
+u16 gcm394_base_video_device::video_707c_r()
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_707c_r\n", machine().describe_context());
 	return 0x8000;
 }
 
-uint16_t gcm394_base_video_device::video_707f_r()
+u16 gcm394_base_video_device::ppu_enable_r()
 {
-	uint16_t retdata = m_renderer->get_video_reg_7f();
-	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_707f_r (returning %04x)\n", machine().describe_context(), retdata);
+	u16 retdata = m_renderer->get_video_reg_7f();
+	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::ppu_enable_r (returning %04x)\n", machine().describe_context(), retdata);
 	return retdata;
 }
-void gcm394_base_video_device::video_707f_w(uint16_t data)
+void gcm394_base_video_device::ppu_enable_w(u16 data)
 {
-	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_707f_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::ppu_enable_w %04x\n", machine().describe_context(), data);
 
 	// Format for GPL1625x / GPAC800
 	//
@@ -856,13 +856,13 @@ void gcm394_base_video_device::video_707f_w(uint16_t data)
 	//popmessage("707f is %04x\n", data);
 }
 
-uint16_t gcm394_base_video_device::video_703a_palettebank_r()
+u16 gcm394_base_video_device::video_703a_palettebank_r()
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_703a_palettebank_r\n", machine().describe_context());
 	return m_703a_palettebank;
 }
 
-void gcm394_base_video_device::video_703a_palettebank_w(uint16_t data)
+void gcm394_base_video_device::video_703a_palettebank_w(u16 data)
 {
 	// I don't think bit 0 (0x01) is a bank select, it might be a 'mode select' for how the palette operates.
 	// neither lazertag or tkmag220 set it
@@ -877,65 +877,65 @@ void gcm394_base_video_device::video_703a_palettebank_w(uint16_t data)
 	m_703a_palettebank = data;
 }
 
-uint16_t gcm394_base_video_device::videoirq_source_enable_r()
+u16 gcm394_base_video_device::videoirq_source_enable_r()
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::videoirq_source_enable_r\n", machine().describe_context());
 	return m_video_irq_enable;
 }
 
-void gcm394_base_video_device::videoirq_source_enable_w(uint16_t data)
+void gcm394_base_video_device::videoirq_source_enable_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "videoirq_source_enable_w: Video IRQ Enable = %04x (DMA:%d, Timing:%d, Blanking:%d)\n", data, BIT(data, 2), BIT(data, 1), BIT(data, 0));
-	const uint16_t old = m_video_irq_enable & m_video_irq_status;
+	const u16 old = m_video_irq_enable & m_video_irq_status;
 	m_video_irq_enable = data & 0x0007;
-	const uint16_t changed = old ^ (m_video_irq_enable & m_video_irq_status);
+	const u16 changed = old ^ (m_video_irq_enable & m_video_irq_status);
 	if (changed)
 		check_video_irq();
 }
 
-uint16_t gcm394_base_video_device::video_7063_videoirq_source_r()
+u16 gcm394_base_video_device::video_7063_videoirq_source_r()
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_7063_videoirq_source_r\n", machine().describe_context());
 	return m_video_irq_status;
 }
 
 
-void gcm394_base_video_device::video_7063_videoirq_source_ack_w(uint16_t data)
+void gcm394_base_video_device::video_7063_videoirq_source_ack_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "video_7063_videoirq_source_ack_w: Video IRQ Acknowledge = %04x\n", data);
-	const uint16_t old = m_video_irq_enable & m_video_irq_status;
+	const u16 old = m_video_irq_enable & m_video_irq_status;
 	m_video_irq_status &= ~data;
-	const uint16_t changed = old ^ (m_video_irq_enable & m_video_irq_status);
+	const u16 changed = old ^ (m_video_irq_enable & m_video_irq_status);
 	if (changed)
 		check_video_irq();
 }
 
-void gcm394_base_video_device::video_702a_w(uint16_t data)
+void gcm394_base_video_device::blending_w(u16 data)
 {
-	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_702a_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::blending_w %04x\n", machine().describe_context(), data);
 	m_702a = data;
 	m_renderer->set_video_reg_2a(data);
 }
 
-uint16_t gcm394_base_video_device::video_curline_r()
+u16 gcm394_base_video_device::video_curline_r()
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s: video_r: Current Line: %04x\n", machine().describe_context(), m_screen->vpos());
 	return m_screen->vpos();
 }
 
 // read in IRQ
-uint16_t gcm394_base_video_device::video_7030_brightness_r()
+u16 gcm394_base_video_device::video_7030_brightness_r()
 {
 	/* wrlshunt ends up doing an explicit jump to 0000 shortly after boot if you just return the value written here, however I think that is correct code flow and something else is wrong
 	   as this simply looks like some kind of brightness register - there is code to decrease it from 0xff to 0x00 by 0x5 increments (waiting for it to hit 0x05) and code to do the reverse
 	   either way it really looks like the data written should be read back.
 	*/
-	uint16_t retdat = m_7030_brightness;
+	u16 retdat = m_7030_brightness;
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_7030_brightness_r (returning %04x)\n", machine().describe_context(), retdat);
 	return retdat;
 }
 
-void gcm394_base_video_device::video_7030_brightness_w(uint16_t data)
+void gcm394_base_video_device::video_7030_brightness_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_7030_brightness_w %04x\n", machine().describe_context(), data);
 	m_7030_brightness = data;
@@ -956,7 +956,7 @@ void gcm394_base_video_device::update_raster_split_position()
 		m_screenpos_timer->adjust(attotime::never);
 }
 
-void gcm394_base_video_device::split_irq_ypos_w(uint16_t data)
+void gcm394_base_video_device::split_irq_ypos_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:split_irq_ypos_w %04x\n", machine().describe_context(), data);
 
@@ -964,7 +964,7 @@ void gcm394_base_video_device::split_irq_ypos_w(uint16_t data)
 	update_raster_split_position();
 }
 
-void gcm394_base_video_device::split_irq_xpos_w(uint16_t data)
+void gcm394_base_video_device::split_irq_xpos_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:split_irq_xpos_w %04x\n", machine().describe_context(), data);
 
@@ -972,50 +972,50 @@ void gcm394_base_video_device::split_irq_xpos_w(uint16_t data)
 	update_raster_split_position();
 }
 
-uint16_t gcm394_base_video_device::video_703c_tvcontrol1_r()
+u16 gcm394_base_video_device::video_703c_tvcontrol1_r()
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_703c_tvcontrol1_r\n", machine().describe_context());
 	return m_703c_tvcontrol1;
 }
 
-void gcm394_base_video_device::video_703c_tvcontrol1_w(uint16_t data)
+void gcm394_base_video_device::video_703c_tvcontrol1_w(u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_703c_tvcontrol1_w %04x\n", machine().describe_context(), data);
 	m_703c_tvcontrol1 = data;
 	m_renderer->set_video_reg_3c(data);
 }
 
-uint16_t gcm394_base_video_device::video_7051_r()
+u16 gcm394_base_video_device::video_7051_r()
 {
 	/* related to what ends up crashing wrlshunt? */
-	uint16_t retdat = 0x03ff;
+	u16 retdat = 0x03ff;
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_7051_r (returning %04x)\n", machine().describe_context(), retdat);
 	return retdat;
 }
 
-uint16_t gcm394_base_video_device::video_70e0_prng_r()
+u16 gcm394_base_video_device::video_70e0_prng_r()
 {
 	// several games in the beijuehh use this to generate random pieces / enemies, bit 0x8000 can't be set or it will generate a negative index into tables
-	uint16_t retdat = machine().rand() & 0x7fff;
+	u16 retdat = machine().rand() & 0x7fff;
 	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_70e0_prng_r (returning %04x)\n", machine().describe_context(), retdat);
 	return retdat;
 }
 
 
 // this block get set once, in a single function, could be important
-void gcm394_base_video_device::video_7080_w(uint16_t data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_7080_w %04x\n", machine().describe_context(), data); m_7080 = data; }
-void gcm394_base_video_device::video_7081_w(uint16_t data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_7081_w %04x\n", machine().describe_context(), data); m_7081 = data; }
-void gcm394_base_video_device::video_7082_w(uint16_t data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_7082_w %04x\n", machine().describe_context(), data); m_7082 = data; }
-void gcm394_base_video_device::video_7083_w(uint16_t data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_7083_w %04x\n", machine().describe_context(), data); m_7083 = data; }
-void gcm394_base_video_device::video_7084_w(uint16_t data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_7084_w %04x\n", machine().describe_context(), data); m_7084 = data; }
-void gcm394_base_video_device::video_7085_w(uint16_t data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_7085_w %04x\n", machine().describe_context(), data); m_7085 = data; }
-void gcm394_base_video_device::video_7086_w(uint16_t data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_7086_w %04x\n", machine().describe_context(), data); m_7086 = data; }
-void gcm394_base_video_device::video_7087_w(uint16_t data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_7087_w %04x\n", machine().describe_context(), data); m_7087 = data; }
-void gcm394_base_video_device::video_7088_w(uint16_t data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_7088_w %04x\n", machine().describe_context(), data); m_7088 = data; }
+void gcm394_base_video_device::tv_saturation_w(u16 data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::tv_saturation_w %04x\n", machine().describe_context(), data); m_7080 = data; }
+void gcm394_base_video_device::tv_hue_w(u16 data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::tv_hue_w %04x\n", machine().describe_context(), data); m_7081 = data; }
+void gcm394_base_video_device::tv_brightness_w(u16 data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::tv_brightness_w %04x\n", machine().describe_context(), data); m_7082 = data; }
+void gcm394_base_video_device::tv_sharpness_w(u16 data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::tv_sharpness_w %04x\n", machine().describe_context(), data); m_7083 = data; }
+void gcm394_base_video_device::tv_y_gain_w(u16 data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::tv_y_gain_w %04x\n", machine().describe_context(), data); m_7084 = data; }
+void gcm394_base_video_device::tv_y_delay_w(u16 data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::tv_y_delay_w %04x\n", machine().describe_context(), data); m_7085 = data; }
+void gcm394_base_video_device::tv_v_position_w(u16 data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::tv_v_position_w %04x\n", machine().describe_context(), data); m_7086 = data; }
+void gcm394_base_video_device::tv_h_position_w(u16 data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::tv_h_position_w %04x\n", machine().describe_context(), data); m_7087 = data; }
+void gcm394_base_video_device::tv_videodac_w(u16 data) { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::tv_videodac_w %04x\n", machine().describe_context(), data); m_7088 = data; }
 
-uint16_t gcm394_base_video_device::video_7083_r() { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_7083_r\n", machine().describe_context()); return m_7083; }
+u16 gcm394_base_video_device::tv_sharpness_r() { LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::tv_sharpness_r\n", machine().describe_context()); return m_7083; }
 
-void gcm394_base_video_device::spriteram_w(offs_t offset, uint16_t data)
+void gcm394_base_video_device::spriteram_w(offs_t offset, u16 data)
 {
 	// transfers an additional word for each sprite with this bit set (smartfp) or an entire extra bank (wrlshunt)
 	// wrlshunt instead seems to base if it writes the extra data based on 707f so maybe this is more complex than banking
@@ -1037,7 +1037,7 @@ void gcm394_base_video_device::spriteram_w(offs_t offset, uint16_t data)
 	}
 }
 
-uint16_t gcm394_base_video_device::spriteram_r(offs_t offset)
+u16 gcm394_base_video_device::spriteram_r(offs_t offset)
 {
 	if (m_707e_spritebank == 0x0000)
 	{
@@ -1054,7 +1054,7 @@ uint16_t gcm394_base_video_device::spriteram_r(offs_t offset)
 	}
 }
 
-void gcm394_base_video_device::palette_w(offs_t offset, uint16_t data)
+void gcm394_base_video_device::palette_w(offs_t offset, u16 data)
 {
 	LOGMASKED(LOG_GCM394_VIDEO_PALETTE, "%s:gcm394_base_video_device::palette_w %04x : %04x (value of 0x703a is %04x)\n", machine().describe_context(), offset, data, m_703a_palettebank);
 
@@ -1075,7 +1075,7 @@ void gcm394_base_video_device::palette_w(offs_t offset, uint16_t data)
 
 }
 
-uint16_t gcm394_base_video_device::palette_r(offs_t offset)
+u16 gcm394_base_video_device::palette_r(offs_t offset)
 {
 	if (m_703a_palettebank & 0xfff0)
 	{
@@ -1086,21 +1086,21 @@ uint16_t gcm394_base_video_device::palette_r(offs_t offset)
 	return m_paletteram[offset];
 }
 
-void gcm394_base_video_device::video_701c_w(uint16_t data)
+void gcm394_base_video_device::vcomp_value_w(u16 data)
 {
-	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_701c_w (unknown video reg?) %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::vcomp_value_w (unknown video reg?) %04x\n", machine().describe_context(), data);
 	m_renderer->set_video_reg_1c(data);
 }
 
-void gcm394_base_video_device::video_701d_w(uint16_t data)
+void gcm394_base_video_device::vcomp_offset_w(u16 data)
 {
-	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_701d_w (unknown video reg?) %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::vcomp_offset_w (unknown video reg?) %04x\n", machine().describe_context(), data);
 	m_renderer->set_video_reg_1d(data);
 }
 
-void gcm394_base_video_device::video_701e_w(uint16_t data)
+void gcm394_base_video_device::vcomp_step_w(u16 data)
 {
-	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::video_701e_w (unknown video reg?) %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GCM394_VIDEO, "%s:gcm394_base_video_device::vcomp_step_w (unknown video reg?) %04x\n", machine().describe_context(), data);
 	m_renderer->set_video_reg_1e(data);
 }
 

--- a/src/devices/machine/generalplus_gpl162xx_soc_video.cpp
+++ b/src/devices/machine/generalplus_gpl162xx_soc_video.cpp
@@ -49,12 +49,12 @@ gcm394_video_device::gcm394_video_device(const machine_config &mconfig, const ch
 {
 }
 
-void gcm394_base_video_device::decodegfx(const char* tag)
+void gcm394_base_video_device::decodegfx(const char *tag)
 {
 	if (!memregion(tag))
 		return;
 
-	u8* gfxregion = memregion(tag)->base();
+	u8 *gfxregion = memregion(tag)->base();
 	int gfxregionsize = memregion(tag)->bytes();
 
 	if (1)
@@ -413,7 +413,7 @@ u32 gcm394_base_video_device::screen_update(screen_device &screen, bitmap_rgb32 
 }
 
 
-void gcm394_base_video_device::write_tmap_scroll(int tmap, u16* regs, int offset, u16 data)
+void gcm394_base_video_device::write_tmap_scroll(int tmap, u16 *regs, int offset, u16 data)
 {
 	switch (offset)
 	{
@@ -429,7 +429,7 @@ void gcm394_base_video_device::write_tmap_scroll(int tmap, u16* regs, int offset
 	}
 }
 
-void gcm394_base_video_device::write_tmap_regs(int tmap, u16* regs, int offset, u16 data)
+void gcm394_base_video_device::write_tmap_regs(int tmap, u16 *regs, int offset, u16 data)
 {
 	switch (offset)
 	{
@@ -465,7 +465,7 @@ void gcm394_base_video_device::write_tmap_regs(int tmap, u16* regs, int offset, 
 // As the hardware appears to support ROZ these are probably 2 extra tile layers, with the 2 additional words being the ROZ parameters?
 
 
-void gcm394_base_video_device::write_tmap_extrascroll(int tmap, u16* regs, int offset, u16 data)
+void gcm394_base_video_device::write_tmap_extrascroll(int tmap, u16 *regs, int offset, u16 data)
 {
 	switch (offset)
 	{

--- a/src/devices/machine/generalplus_gpl162xx_soc_video.h
+++ b/src/devices/machine/generalplus_gpl162xx_soc_video.h
@@ -41,10 +41,10 @@ public:
 	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void vblank(int state);
 
-	void write_tmap_scroll(int tmap, u16* regs, int offset, u16 data);
-	void write_tmap_extrascroll(int tmap, u16* regs, int offset, u16 data);
+	void write_tmap_scroll(int tmap, u16 *regs, int offset, u16 data);
+	void write_tmap_extrascroll(int tmap, u16 *regs, int offset, u16 data);
 
-	void write_tmap_regs(int tmap, u16* regs, int offset, u16 data);
+	void write_tmap_regs(int tmap, u16 *regs, int offset, u16 data);
 
 	//void set_paldisplaybank_high(int pal_displaybank_high) { m_pal_displaybank_high = pal_displaybank_high; }
 	void set_legacy_video_mode() { m_use_legacy_mode = true; }
@@ -147,7 +147,7 @@ public:
 	u16 video_70e0_prng_r();
 
 protected:
-	virtual void device_add_mconfig(machine_config& config) override ATTR_COLD;
+	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 
@@ -157,7 +157,7 @@ protected:
 
 	void unk_vid_regs_w(int which, int offset, u16 data);
 
-	void decodegfx(const char* tag);
+	void decodegfx(const char *tag);
 
 	required_shared_ptr<u16> m_rowscroll;
 	required_shared_ptr<u16> m_rowzoom;

--- a/src/devices/machine/generalplus_gpl162xx_soc_video.h
+++ b/src/devices/machine/generalplus_gpl162xx_soc_video.h
@@ -22,7 +22,7 @@
 class gcm394_base_video_device : public device_t, public device_video_interface
 {
 public:
-	gcm394_base_video_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+	gcm394_base_video_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
 
 	auto write_video_irq_callback() { return m_video_irq_cb.bind(); }
 	auto space_read_callback() { return m_space_read_cb.bind(); }
@@ -31,20 +31,20 @@ public:
 		m_cpuspace.set_tag(tag, no);
 		m_renderer.lookup()->set_video_space(tag, no);
 	}
-	template <typename T> void set_cs_video_space(T &&tag, int no, uint32_t csbase)
+	template <typename T> void set_cs_video_space(T &&tag, int no, u32 csbase)
 	{
 		m_cs_space.set_tag(tag, no);
 		m_csbase = csbase;
 		m_renderer.lookup()->set_cs_video_space(tag, no, csbase);
 	}
 
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void vblank(int state);
 
-	void write_tmap_scroll(int tmap, uint16_t* regs, int offset, uint16_t data);
-	void write_tmap_extrascroll(int tmap, uint16_t* regs, int offset, uint16_t data);
+	void write_tmap_scroll(int tmap, u16* regs, int offset, u16 data);
+	void write_tmap_extrascroll(int tmap, u16* regs, int offset, u16 data);
 
-	void write_tmap_regs(int tmap, uint16_t* regs, int offset, uint16_t data);
+	void write_tmap_regs(int tmap, u16* regs, int offset, u16 data);
 
 	//void set_paldisplaybank_high(int pal_displaybank_high) { m_pal_displaybank_high = pal_displaybank_high; }
 	void set_legacy_video_mode() { m_use_legacy_mode = true; }
@@ -53,98 +53,98 @@ public:
 	//void set_pal_sprites(int pal_sprites) { m_pal_sprites = pal_sprites; }
 	//void set_pal_back(int pal_back) { m_pal_back = pal_back; }
 
-	uint16_t tmap0_regs_r(offs_t offset);
-	void tmap0_regs_w(offs_t offset, uint16_t data);
-	uint16_t tmap0_tilebase_lsb_r();
-	uint16_t tmap0_tilebase_msb_r();
-	void tmap0_tilebase_lsb_w(uint16_t data);
-	void tmap0_tilebase_msb_w(uint16_t data);
+	u16 tmap0_regs_r(offs_t offset);
+	void tmap0_regs_w(offs_t offset, u16 data);
+	u16 tmap0_tilebase_lsb_r();
+	u16 tmap0_tilebase_msb_r();
+	void tmap0_tilebase_lsb_w(u16 data);
+	void tmap0_tilebase_msb_w(u16 data);
 
-	uint16_t tmap1_regs_r(offs_t offset);
-	void tmap1_regs_w(offs_t offset, uint16_t data);
-	uint16_t tmap1_tilebase_lsb_r();
-	uint16_t tmap1_tilebase_msb_r();
-	void tmap1_tilebase_lsb_w(uint16_t data);
-	void tmap1_tilebase_msb_w(uint16_t data);
+	u16 tmap1_regs_r(offs_t offset);
+	void tmap1_regs_w(offs_t offset, u16 data);
+	u16 tmap1_tilebase_lsb_r();
+	u16 tmap1_tilebase_msb_r();
+	void tmap1_tilebase_lsb_w(u16 data);
+	void tmap1_tilebase_msb_w(u16 data);
 
-	uint16_t tmap2_regs_r(offs_t offset);
-	void tmap2_regs_w(offs_t offset, uint16_t data);
-	uint16_t tmap2_tilebase_lsb_r();
-	uint16_t tmap2_tilebase_msb_r();
-	void tmap2_tilebase_lsb_w(uint16_t data);
-	void tmap2_tilebase_msb_w(uint16_t data);
+	u16 tmap2_regs_r(offs_t offset);
+	void tmap2_regs_w(offs_t offset, u16 data);
+	u16 tmap2_tilebase_lsb_r();
+	u16 tmap2_tilebase_msb_r();
+	void tmap2_tilebase_lsb_w(u16 data);
+	void tmap2_tilebase_msb_w(u16 data);
 
-	uint16_t tmap3_regs_r(offs_t offset);
-	void tmap3_regs_w(offs_t offset, uint16_t data);
-	uint16_t tmap3_tilebase_lsb_r();
-	uint16_t tmap3_tilebase_msb_r();
-	void tmap3_tilebase_lsb_w(uint16_t data);
-	void tmap3_tilebase_msb_w(uint16_t data);
+	u16 tmap3_regs_r(offs_t offset);
+	void tmap3_regs_w(offs_t offset, u16 data);
+	u16 tmap3_tilebase_lsb_r();
+	u16 tmap3_tilebase_msb_r();
+	void tmap3_tilebase_lsb_w(u16 data);
+	void tmap3_tilebase_msb_w(u16 data);
 
-	void video_701c_w(uint16_t data);
-	void video_701d_w(uint16_t data);
-	void video_701e_w(uint16_t data);
+	void vcomp_value_w(u16 data);
+	void vcomp_offset_w(u16 data);
+	void vcomp_step_w(u16 data);
 
-	uint16_t sprite_7022_gfxbase_lsb_r();
-	uint16_t sprite_702d_gfxbase_msb_r();
+	u16 sprite_7022_gfxbase_lsb_r();
+	u16 sprite_702d_gfxbase_msb_r();
 
-	void sprite_7022_gfxbase_lsb_w(uint16_t data);
-	void sprite_702d_gfxbase_msb_w(uint16_t data);
-	uint16_t sprite_7042_extra_r();
-	void sprite_7042_extra_w(uint16_t data);
+	void sprite_7022_gfxbase_lsb_w(u16 data);
+	void sprite_702d_gfxbase_msb_w(u16 data);
+	u16 sprite_7042_extra_r();
+	void sprite_7042_extra_w(u16 data);
 
-	void video_dma_source_w(uint16_t data);
-	void video_dma_dest_w(uint16_t data);
-	uint16_t video_dma_size_busy_r();
-	void video_dma_size_trigger_w(address_space &space, uint16_t data);
-	void video_707e_spritebank_w(uint16_t data);
+	void video_dma_source_w(u16 data);
+	void video_dma_dest_w(u16 data);
+	u16 video_dma_size_busy_r();
+	void video_dma_size_trigger_w(address_space &space, u16 data);
+	void ppu_ram_bank_w(u16 data);
 
-	uint16_t video_703a_palettebank_r();
-	void video_703a_palettebank_w(uint16_t data);
+	u16 video_703a_palettebank_r();
+	void video_703a_palettebank_w(u16 data);
 
 	void update_raster_split_position();
-	void split_irq_xpos_w(uint16_t data);
-	void split_irq_ypos_w(uint16_t data);
+	void split_irq_xpos_w(u16 data);
+	void split_irq_ypos_w(u16 data);
 
-	uint16_t videoirq_source_enable_r();
-	void videoirq_source_enable_w(uint16_t data);
+	u16 videoirq_source_enable_r();
+	void videoirq_source_enable_w(u16 data);
 
-	uint16_t video_7063_videoirq_source_r();
-	void video_7063_videoirq_source_ack_w(uint16_t data);
+	u16 video_7063_videoirq_source_r();
+	void video_7063_videoirq_source_ack_w(u16 data);
 
-	void video_702a_w(uint16_t data);
-	uint16_t video_7030_brightness_r();
-	void video_7030_brightness_w(uint16_t data);
-	uint16_t video_curline_r();
+	void blending_w(u16 data);
+	u16 video_7030_brightness_r();
+	void video_7030_brightness_w(u16 data);
+	u16 video_curline_r();
 
-	uint16_t video_703c_tvcontrol1_r();
-	void video_703c_tvcontrol1_w(uint16_t data);
+	u16 video_703c_tvcontrol1_r();
+	void video_703c_tvcontrol1_w(u16 data);
 
-	uint16_t video_707c_r();
+	u16 video_707c_r();
 
-	uint16_t video_707f_r();
-	void video_707f_w(uint16_t data);
+	u16 ppu_enable_r();
+	void ppu_enable_w(u16 data);
 
-	void video_7080_w(uint16_t data);
-	void video_7081_w(uint16_t data);
-	void video_7082_w(uint16_t data);
-	void video_7083_w(uint16_t data);
-	void video_7084_w(uint16_t data);
-	void video_7085_w(uint16_t data);
-	void video_7086_w(uint16_t data);
-	void video_7087_w(uint16_t data);
-	void video_7088_w(uint16_t data);
+	void tv_saturation_w(u16 data);
+	void tv_hue_w(u16 data);
+	void tv_brightness_w(u16 data);
+	void tv_sharpness_w(u16 data);
+	void tv_y_gain_w(u16 data);
+	void tv_y_delay_w(u16 data);
+	void tv_v_position_w(u16 data);
+	void tv_h_position_w(u16 data);
+	void tv_videodac_w(u16 data);
 
-	uint16_t video_7083_r();
+	u16 tv_sharpness_r();
 
-	uint16_t palette_r(offs_t offset);
-	void palette_w(offs_t offset, uint16_t data);
+	u16 palette_r(offs_t offset);
+	void palette_w(offs_t offset, u16 data);
 
-	void spriteram_w(offs_t offset, uint16_t data);
-	uint16_t spriteram_r(offs_t offset);
+	void spriteram_w(offs_t offset, u16 data);
+	u16 spriteram_r(offs_t offset);
 
-	uint16_t video_7051_r();
-	uint16_t video_70e0_prng_r();
+	u16 video_7051_r();
+	u16 video_70e0_prng_r();
 
 protected:
 	virtual void device_add_mconfig(machine_config& config) override ATTR_COLD;
@@ -155,12 +155,12 @@ protected:
 
 	inline void check_video_irq();
 
-	void unk_vid_regs_w(int which, int offset, uint16_t data);
+	void unk_vid_regs_w(int which, int offset, u16 data);
 
 	void decodegfx(const char* tag);
 
-	required_shared_ptr<uint16_t> m_rowscroll;
-	required_shared_ptr<uint16_t> m_rowzoom;
+	required_shared_ptr<u16> m_rowscroll;
+	required_shared_ptr<u16> m_rowzoom;
 
 	required_device<unsp_device> m_cpu;
 	required_device<screen_device> m_screen;
@@ -176,67 +176,67 @@ protected:
 	optional_address_space m_cs_space;
 	int m_csbase;
 
-	uint16_t m_page0_addr_lsb;
-	uint16_t m_page0_addr_msb;
+	u16 m_page0_addr_lsb;
+	u16 m_page0_addr_msb;
 
-	uint16_t m_page1_addr_lsb;
-	uint16_t m_page1_addr_msb;
+	u16 m_page1_addr_lsb;
+	u16 m_page1_addr_msb;
 
-	uint16_t m_707e_spritebank;
-	uint16_t m_videodma_size;
-	uint16_t m_videodma_dest;
-	uint16_t m_videodma_source;
+	u16 m_707e_spritebank;
+	u16 m_videodma_size;
+	u16 m_videodma_dest;
+	u16 m_videodma_source;
 
 
 	// video 70xx
-	uint16_t m_tmap0_regs[0x4];
-	uint16_t m_tmap1_regs[0x4];
+	u16 m_tmap0_regs[0x4];
+	u16 m_tmap1_regs[0x4];
 
-	uint16_t m_tmap2_regs[0x4];
-	uint16_t m_tmap3_regs[0x4];
-
-
-	uint16_t m_tmap0_scroll[0x2];
-	uint16_t m_tmap1_scroll[0x2];
-
-	uint16_t m_tmap2_scroll[0x4];
-	uint16_t m_tmap3_scroll[0x4];
+	u16 m_tmap2_regs[0x4];
+	u16 m_tmap3_regs[0x4];
 
 
-	uint16_t m_707f;
-	uint16_t m_703a_palettebank;
-	uint16_t m_video_irq_enable;
-	uint16_t m_video_irq_status;
+	u16 m_tmap0_scroll[0x2];
+	u16 m_tmap1_scroll[0x2];
 
-	uint16_t m_702a;
-	uint16_t m_7030_brightness;
-	uint16_t m_xirqpos;
-	uint16_t m_yirqpos;
-	uint16_t m_703c_tvcontrol1;
+	u16 m_tmap2_scroll[0x4];
+	u16 m_tmap3_scroll[0x4];
 
-	uint16_t m_7042_sprite;
 
-	uint16_t m_7080;
-	uint16_t m_7081;
-	uint16_t m_7082;
-	uint16_t m_7083;
-	uint16_t m_7084;
-	uint16_t m_7085;
-	uint16_t m_7086;
-	uint16_t m_7087;
-	uint16_t m_7088;
+	u16 m_707f;
+	u16 m_703a_palettebank;
+	u16 m_video_irq_enable;
+	u16 m_video_irq_status;
 
-	uint16_t m_sprite_7022_gfxbase_lsb;
-	uint16_t m_sprite_702d_gfxbase_msb;
-	uint16_t m_page2_addr_lsb;
-	uint16_t m_page2_addr_msb;
-	uint16_t m_page3_addr_lsb;
-	uint16_t m_page3_addr_msb;
+	u16 m_702a;
+	u16 m_7030_brightness;
+	u16 m_xirqpos;
+	u16 m_yirqpos;
+	u16 m_703c_tvcontrol1;
+
+	u16 m_7042_sprite;
+
+	u16 m_7080;
+	u16 m_7081;
+	u16 m_7082;
+	u16 m_7083;
+	u16 m_7084;
+	u16 m_7085;
+	u16 m_7086;
+	u16 m_7087;
+	u16 m_7088;
+
+	u16 m_sprite_7022_gfxbase_lsb;
+	u16 m_sprite_702d_gfxbase_msb;
+	u16 m_page2_addr_lsb;
+	u16 m_page2_addr_msb;
+	u16 m_page3_addr_lsb;
+	u16 m_page3_addr_msb;
 
 	emu_timer *m_screenpos_timer;
 
-	uint16_t m_spriteram[0x400*2];
-	uint16_t m_paletteram[0x100*0x10];
+	u16 m_spriteram[0x400*2];
+	u16 m_paletteram[0x100*0x10];
 
 	int m_maxgfxelement;
 
@@ -251,14 +251,14 @@ class gcm394_video_device : public gcm394_base_video_device
 {
 public:
 	template <typename T, typename U>
-	gcm394_video_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&cpu_tag, U &&screen_tag)
+	gcm394_video_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, T &&cpu_tag, U &&screen_tag)
 		: gcm394_video_device(mconfig, tag, owner, clock)
 	{
 		m_cpu.set_tag(std::forward<T>(cpu_tag));
 		m_screen.set_tag(std::forward<U>(screen_tag));
 	}
 
-	gcm394_video_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	gcm394_video_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 };
 
 DECLARE_DEVICE_TYPE(GCM394_VIDEO, gcm394_video_device)

--- a/src/devices/machine/generalplus_gpl951xx_soc.cpp
+++ b/src/devices/machine/generalplus_gpl951xx_soc.cpp
@@ -4,125 +4,621 @@
 #include "emu.h"
 #include "generalplus_gpl951xx_soc.h"
 
+#define LOG_SPIFC     (1U << 1)
 
-void generalplus_gpl951xx_device::ramwrite_w(offs_t offset, uint16_t data)
+#define VERBOSE     (LOG_SPIFC)
+
+#include "logmacro.h"
+
+
+// SPIFC - the directly mapped SPI interface
+// provides 'hardware accelerated' SPI features (composing and sending packets to the SPI device)
+// including XIP (eXecute In Place) support for flat view of SPI ROM
+
+void generalplus_gpl951xx_device::recieve_spi_fifo_data(u8 data)
 {
-	m_mainram[offset] = data;
+	if (m_bytes_in_spifc_rx_fifo < (16 * 2))
+	{
+		m_spifc_rx_fifo[m_bytes_in_spifc_rx_fifo] = data;
+		m_bytes_in_spifc_rx_fifo++;
+	}
 }
 
-uint16_t generalplus_gpl951xx_device::ramread_r(offs_t offset)
+u8 generalplus_gpl951xx_device::get_byte_from_rx_fifo()
 {
-	return m_mainram[offset];
+	u8 ret = m_spifc_rx_fifo[0];
+	if (m_bytes_in_spifc_rx_fifo > 0)
+	{
+
+		for (int i = 1; i < (16 * 2); i++)
+		{
+			m_spifc_rx_fifo[i - 1] = m_spifc_rx_fifo[i];
+		}
+		m_spifc_rx_fifo[(16 * 2) - 1] = 0;
+		m_bytes_in_spifc_rx_fifo--;
+	}
+	return ret;
 }
 
-uint16_t generalplus_gpl951xx_device::spi_direct_7b40_r()
+// this provides hardware accelerated SPI support, handling much of the underlying SPI
+// access, allowing 'easier' use of the device, as well as allowing it to run in XIP
+// mode (eXecute In Place) so the CPU can see it as a flat space
+
+// P_SPIFC_Ctrl1
+
+// 15  tx_done
+// 14  rx_empty
+// 13
+// 12
+// 
+// 11
+// 10
+// 9   ig_clk
+// 8   manual
+// 
+// 7   cmio[1]
+// 6   cmio[0]
+// 5   amio[1]
+// 4   amio[0]
+// 
+// 3   mio[1]
+// 2   mio[0]
+// 1
+// 0   back2idle
+
+u16 generalplus_gpl951xx_device::spifc_ctrl_r()
 {
-	return 0xffff; // doesn't care for now
+	LOGMASKED(LOG_SPIFC, "%s: spifc_ctrl_r\n", machine().describe_context());
+	u16 ret = m_spifc_ctrl;
+
+	ret |= 0x8000; // tx_done
+	if (m_bytes_in_spifc_rx_fifo == 0) ret |= 0x4000; // rx_empty
+	ret |= 0x0001; // back2idle
+
+	return ret;
 }
 
-uint16_t generalplus_gpl951xx_device::spi_direct_79f5_r()
+void generalplus_gpl951xx_device::spifc_ctrl_w(u16 data)
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_ctrl_w %04x\n", machine().describe_context(), data);
+	m_spifc_ctrl = data;
+}
+
+// P_SPIFC_CMD
+//
+// 15
+// 14
+// 13  one_cmd
+// 12
+//
+// 11
+// 10
+//  9  cmd_only
+//  8  wo_cmd
+// 
+//  7  wpif_cmd[7]
+//  6  wpif_cmd[6]
+//  5  wpif_cmd[5]
+//  4  wpif_cmd[4]
+// 
+//  3  wpif_cmd[3]
+//  2  wpif_cmd[2]
+//  1  wpif_cmd[1]
+//  0  wpif_cmd[0]
+
+u16 generalplus_gpl951xx_device::spifc_cmd_r()
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_cmd_r\n", machine().describe_context());
+	return m_spifc_cmd;
+}
+
+void generalplus_gpl951xx_device::spifc_cmd_w(u16 data)
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_cmd_w %02x %02x with param %04x\n", machine().describe_context(), (data & 0xff00) >> 8, data & 0xff, m_spifc_para);
+
+	m_spifc_cmd = data;
+
+	m_spi_reset(1);
+	m_spi_out_cmd(data & 0x00ff);
+
+	// how does byte count work? the FIFO is apparently in words
+	for (int i = 0; i < m_spifc_rx_bc; i++)
+	{
+		// clock it this many times to push data into the fifo?
+		m_spi_out(0x00);
+	}
+
+}
+
+// P_SPIFC_PARA
+//
+// 15
+// 14  wo_enha
+// 13  to_addr
+// 12  wo_addr
+//
+// 11  dummy_ck_cnt[3]
+// 10  dummy_ck_cnt[2]
+// 9   dummy_ck_cnt[1]
+// 8   dummy_ck_cnt[0]
+//
+// 7   enhan_by[7]
+// 6   enhan_by[6]
+// 5   enhan_by[5]
+// 4   enhan_by[4]
+// 
+// 3   enhan_by[4]
+// 2   enhan_by[3]
+// 1   enhan_by[2]
+// 0   enhan_by[1]
+
+
+u16 generalplus_gpl951xx_device::spifc_para_r()
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_para_r\n", machine().describe_context());
+	return m_spifc_para;
+}
+
+void generalplus_gpl951xx_device::spifc_para_w(u16 data)
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_para_w %04x\n", machine().describe_context(), data);
+	m_spifc_para = data;
+}
+
+// P_SPIFC_ADDRL
+// 15-0 low 16 bits of SPIF Address
+
+u16 generalplus_gpl951xx_device::spifc_addrl_r()
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_addrl_r\n", machine().describe_context());
+	return m_spifc_addr & 0x0000ffff;
+}
+
+void generalplus_gpl951xx_device::spifc_addrl_w(u16 data)
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_addrl_w %04x\n", machine().describe_context(), data);
+	m_spifc_addr = (m_spifc_addr & 0xffff0000) | data;
+}
+
+// P_SPIFC_ADDRH
+// 15-0  high 16 bits of SPIF Address
+
+u16 generalplus_gpl951xx_device::spifc_addrh_r()
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_addrh_r\n", machine().describe_context());
+	return (m_spifc_addr & 0xffff0000) >> 16;
+}
+
+void generalplus_gpl951xx_device::spifc_addrh_w(u16 data)
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_addrh_w %04x\n", machine().describe_context(), data);
+	m_spifc_addr = (m_spifc_addr & 0x0000ffff) | (data << 16);
+}
+
+u16 generalplus_gpl951xx_device::spifc_txdat_r()
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_txdat_r\n", machine().describe_context());
+	return 0xffff;
+}
+
+void generalplus_gpl951xx_device::spifc_txdat_w(u16 data)
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_txdat_w %04x\n", machine().describe_context(), data);
+}
+
+// P_SPIFC_RX_Data
+//
+// 15-0  2 bytes of RX_Data
+//
+// write the register once before reading the register once
+
+u16 generalplus_gpl951xx_device::spifc_rxdat_r()
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_rxdat_r\n", machine().describe_context());
+
+	/*
+	for bfpacman
+
+	after auto command bite spifc_cmd_w is set to 9f (ident)
+
+	at 672 R1 will be xx00 (results from device)
+    R2 will be xxxx (results from device)
+
+	continuing to 232 it restores these values and it checks if R1 is 0000 (it shouldn't be)
+
+	at 237 it gets a value of C814 from 0d69 (RAM) and puts it in R1
+	at 239 is compares R1 with R2
+	*/
+
+	return m_spifc_rx_read_latch;
+}
+	
+
+void generalplus_gpl951xx_device::spifc_rxdat_w(u16 data)
+{
+	// write here to latch a word from the fifo into the read register
+	u16 word = get_byte_from_rx_fifo();
+	word = (get_byte_from_rx_fifo() << 8) | word;
+
+	m_spifc_rx_read_latch = word;
+}
+
+
+// P_SPIFC_TX_BC - SPIFC TX byte count register
+//
+// 15-9 unused
+// 8-0  9-bit byte count (TX_BC)
+
+u16 generalplus_gpl951xx_device::spifc_tx_bc_r()
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_tx_bc_r\n", machine().describe_context());
+	return m_spifc_tx_bc;
+}
+
+void generalplus_gpl951xx_device::spifc_tx_bc_w(u16 data)
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_tx_bc_w %04x\n", machine().describe_context(), data);
+	m_spifc_tx_bc = data;
+}
+
+// P_SPIFC_RX_BC - SPIFC RX byte count register
+//
+// 15-9 unused
+// 8-0  9-bit byte count (RX_BC)
+
+u16 generalplus_gpl951xx_device::spifc_rx_bc_r()
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_rx_bc_r\n", machine().describe_context());
+	return m_spifc_rx_bc;
+}
+
+void generalplus_gpl951xx_device::spifc_rx_bc_w(u16 data)
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_rx_bc_w %04x\n", machine().describe_context(), data);
+	m_spifc_rx_bc = data;
+}
+
+u16 generalplus_gpl951xx_device::spifc_timing_r()
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_timing_r\n", machine().describe_context());
+	return m_spifc_timing;
+}
+
+void generalplus_gpl951xx_device::spifc_timing_w(u16 data)
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_timing_w %04x\n", machine().describe_context(), data);
+	m_spifc_timing = data;
+}
+
+// P_SPIFC_Ctrl2
+//
+// 15-8  Ear[7:0] - Extend address range from 24 bits to 32-bits
+// 7-1
+// 0     en - SPF flash controller enable
+
+u16 generalplus_gpl951xx_device::spifc_ctrl2_r()
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_ctrl2_r\n", machine().describe_context());
+	return m_spifc_ctrl2;
+}
+
+void generalplus_gpl951xx_device::spifc_ctrl2_w(u16 data)
+{
+	LOGMASKED(LOG_SPIFC, "%s: spifc_ctrl2_w %04x\n", machine().describe_context(), data);
+	m_spifc_ctrl2 = data;
+}
+
+// Other bits
+
+u16 generalplus_gpl951xx_device::pllsel_r()
+{
+	logerror("%s: pllsel_r\n", machine().describe_context());
+	return m_pllchange;
+}
+
+void generalplus_gpl951xx_device::pllsel_w(uint16_t data)
+{
+	// very similar to pllchange on GPL162xx, but with extra SPI bits
+	logerror("%s: generalplus_gpl951xx_device::pllsel_w %04x\n", machine().describe_context(), data);
+	m_pllchange = data;
+}
+
+
+u16 generalplus_gpl951xx_device::rtc_readdata_r()
 {
 	return 0xffff; // hangs if returning 0
 }
 
-uint16_t generalplus_gpl951xx_device::spi_direct_7b46_r()
-{
-	int i = machine().rand();
-
-	if (i & 1) return 0x01;
-	else return 0x02;
-}
-
-uint16_t generalplus_gpl951xx_device::spi_direct_79f4_r()
+u16 generalplus_gpl951xx_device::rtc_ready_r()
 {
 	// status bits?
 	return machine().rand();
 }
 
 
-uint16_t generalplus_gpl951xx_device::spi_direct_7af0_r()
+u16 generalplus_gpl951xx_device::byte_swap_r()
 {
-	return m_7af0;
+	return m_byteswap;
 }
 
-void generalplus_gpl951xx_device::spi_direct_7af0_w(uint16_t data)
+void generalplus_gpl951xx_device::byte_swap_w(u16 data)
 {
 	// words read from ROM are written here during the checksum routine in RAM, and must
 	// be shifted for the checksum to pass.
-	m_7af0 = data >> 8;
-}
-
-
-uint16_t generalplus_gpl951xx_device::spi_direct_78e8_r()
-{
-	return machine().rand();
+	m_byteswap = ((data & 0xff00) >> 8) | ((data & 0x00ff) << 8);
 }
 
 void generalplus_gpl951xx_device::device_start()
 {
 	sunplus_gcm394_base_device::device_start();
-	save_item(NAME(m_7af0));
+	save_item(NAME(m_byteswap));
+	save_item(NAME(m_gpl951xx_timerg_ctrl));
+	save_item(NAME(m_gpl951xx_timerg_preload));
+	save_item(NAME(m_gpl951xx_timerh_ctrl));
+	save_item(NAME(m_gpl951xx_timerh_preload));
+	save_item(NAME(m_spifc_ctrl));
+	save_item(NAME(m_spifc_ctrl2));
+	save_item(NAME(m_spifc_addr));
+	save_item(NAME(m_spifc_cmd));
+	save_item(NAME(m_spifc_para));
+	save_item(NAME(m_spifc_rx_bc));
+	save_item(NAME(m_spifc_tx_bc));
+	save_item(NAME(m_spifc_timing));
+	save_item(NAME(m_bytes_in_spifc_rx_fifo));
+	save_item(NAME(m_spifc_hackident));
+	save_item(NAME(m_spi_bank));
+	save_item(NAME(m_spifc_rx_fifo));
+	save_item(NAME(m_spifc_rx_read_latch));
 }
 
 void generalplus_gpl951xx_device::device_reset()
 {
 	sunplus_gcm394_base_device::device_reset();
-	m_7af0 = 0;
+	m_byteswap = 0;
+	m_gpl951xx_timerg_ctrl = 0;
+	m_gpl951xx_timerg_preload = 0;
+	m_gpl951xx_timerh_ctrl = 0;
+	m_gpl951xx_timerh_preload = 0;
+	m_spifc_ctrl = 0;
+	m_spifc_ctrl2 = 0;
+	m_spifc_addr = 0;
+	m_spifc_cmd = 0;
+	m_spifc_para = 0;
+	m_spifc_rx_bc = 0;
+	m_spifc_tx_bc = 0;
+	m_spifc_timing = 0;
+	m_bytes_in_spifc_rx_fifo = 0;
+	m_spifc_rx_read_latch = 0;
+
+	m_spi_bank = 0;
+
+	for (int i = 0; i < 16 * 2; i++)
+		m_spifc_rx_fifo[i] = 0;
 }
 
-void generalplus_gpl951xx_device::spi_direct_78e8_w(uint16_t data)
+// Timers
+
+u16 generalplus_gpl951xx_device::gpl951xx_timerg_preload_r()
 {
-	logerror("%s: spi_direct_78e8_w %04x\n", machine().describe_context(), data);
+	logerror("%s: gpl951xx_timerg_preload_r\n", machine().describe_context());
+	return m_gpl951xx_timerg_preload;
+}
+
+void generalplus_gpl951xx_device::gpl951xx_timerg_preload_w(u16 data)
+{
+	logerror("%s: gpl951xx_timerg_preload_w %04x\n", machine().describe_context(), data);
+	m_gpl951xx_timerg_preload = data;
+}
+
+// P_TimerG_Ctrl
+
+// 15  TMGIF/C
+// 14  TMGIE
+// 13  TMGEN
+// 12
+// 11  EXT0SEL[1]
+// 10  EXT0SEL[0]
+// 9   EXT1SEL[1]
+// 8   EXT1SEL[0]
+// 7
+// 6   SRCBSEL[2]
+// 5   SRCBSEL[1]
+// 4   SRCBSEL[0]
+// 3   SRCASEL[3]
+// 2   SRCASEL[2]
+// 1   SRCASEL[1]
+// 0   SRCASEL[0]
+
+u16 generalplus_gpl951xx_device::gpl951xx_timerg_ctrl_r()
+{
+	logerror("%s: gpl951xx_timerg_ctrl_r\n", machine().describe_context());
+	u16 ret = m_gpl951xx_timerg_ctrl;
+	return ret;
+}
+
+void generalplus_gpl951xx_device::gpl951xx_timerg_ctrl_w(u16 data)
+{
+	u8 tmgif_clear = (data & 0x8000) >> 15;
+	u8 tmgie = (data & 0x4000) >> 14;
+	u8 tmgen = (data & 0x2000) >> 13;
+	u8 ext0sel = (data & 0x0c00) >> 10;
+	u8 ext1sel = (data & 0x0300) >> 8;
+	u8 srcbsel = (data & 0x0070) >> 4;
+	u8 srcasel = (data & 0x000f) >> 0;
+
+	logerror("%s: gpl951xx_timerg_ctrl_w %04x (tmgif_clear %01x) (interrupt enabled %01x) (timer enabled %01x) (ext0sel %01x) (ext1sel %01x) (srcbsel %01x) (srcasel %01x)\n", machine().describe_context(), data, tmgif_clear, tmgie, tmgen, ext0sel, ext1sel, srcbsel, srcasel);
+
+	if (data & 0x8000)
+		m_gpl951xx_timerg_ctrl &= 0x7fff;
+
+	if ((data & 0x2000) != (m_gpl951xx_timerg_ctrl & 0x2000))
+	{
+		if (data & 0x2000)
+		{
+			m_timer_g->adjust(attotime::zero, 0, attotime::from_hz(8'000'000));
+		}
+		else
+		{
+			m_timer_g->adjust(attotime::never);
+		}
+	}
+
+	m_gpl951xx_timerg_ctrl = (m_gpl951xx_timerg_ctrl & 0x8000) | (data & 0x7fff);
+}
+
+u16 generalplus_gpl951xx_device::gpl951xx_timerh_preload_r()
+{
+	logerror("%s: gpl951xx_timerh_preload_r\n", machine().describe_context());
+	return m_gpl951xx_timerh_preload;
+}
+
+void generalplus_gpl951xx_device::gpl951xx_timerh_preload_w(u16 data)
+{
+	logerror("%s: gpl951xx_timerh_preload_w %04x\n", machine().describe_context(), data);
+	m_gpl951xx_timerh_preload = data;
+}
+
+// P_TimerH_Ctrl
+
+// 15  TMHIF/C
+// 14  TMHIE
+// 13  TMHEN
+// 12
+// 
+// 11  EXT0SEL[1]
+// 10  EXT0SEL[0]
+// 9   EXT1SEL[1]
+// 8   EXT1SEL[0]
+// 
+// 7
+// 6   SRCBSEL[2]
+// 5   SRCBSEL[1]
+// 4   SRCBSEL[0]
+// 
+// 3   SRCASEL[3]
+// 2   SRCASEL[2]
+// 1   SRCASEL[1]
+// 0   SRCASEL[0]
+
+u16 generalplus_gpl951xx_device::gpl951xx_timerh_ctrl_r()
+{
+	u16 ret = m_gpl951xx_timerh_ctrl;
+	logerror("%s: gpl951xx_timerh_ctrl_r (returning %04x)\n", machine().describe_context(), ret);
+	return ret;
+}
+
+void generalplus_gpl951xx_device::gpl951xx_timerh_ctrl_w(u16 data)
+{
+	u8 tmhif_clear = (data & 0x8000) >> 15;
+	u8 tmhie = (data & 0x4000) >> 14;
+	u8 tmhen = (data & 0x2000) >> 13;
+	u8 ext0sel = (data & 0x0c00) >> 10;
+	u8 ext1sel = (data & 0x0300) >> 8;
+	u8 srcbsel = (data & 0x0070) >> 4;
+	u8 srcasel = (data & 0x000f) >> 0;
+
+	logerror("%s: gpl951xx_timerh_ctrl_w %04x (tmhif_clear %01x) (interrupt enabled %01x) (timer enabled %01x) (ext0sel %01x) (ext1sel %01x) (srcbsel %01x) (srcasel %01x)\n", machine().describe_context(), data, tmhif_clear, tmhie, tmhen, ext0sel, ext1sel, srcbsel, srcasel);
+
+	if (data & 0x8000)
+	{
+		logerror("cleared timerh flag\n");
+		m_gpl951xx_timerh_ctrl &= 0x7fff;
+	}
+
+	if ((data & 0x2000) != (m_gpl951xx_timerh_ctrl & 0x2000))
+	{
+		logerror("changed\n");
+		if (data & 0x2000)
+		{
+			logerror("started timerh\n");
+			m_timer_h->adjust(attotime::zero, 0, attotime::from_hz(8'000'000));
+		}
+		else
+		{
+			m_timer_h->adjust(attotime::never);
+		}
+
+	}
+
+	m_gpl951xx_timerh_ctrl = (m_gpl951xx_timerh_ctrl & 0x8000) | (data & 0x7fff);
+
+}
+
+u16 generalplus_gpl951xx_device::spi_bank_r()
+{
+	LOGMASKED(LOG_SPIFC, "%s: spi_bank_r\n", machine().describe_context());
+	return m_spi_bank;
+}
+
+void generalplus_gpl951xx_device::spi_bank_w(u16 data)
+{
+	LOGMASKED(LOG_SPIFC, "%s: spi_bank_w %04x\n", machine().describe_context(), data);
+	m_spi_bank = data;
+}
+
+
+u16 generalplus_gpl951xx_device::spi_direct_r(offs_t offset)
+{
+	// The GPL951xx chips can see a bank of SPI memory as a flat space
+	// as they will automatically generate SPI signals for random memory
+	// access on demand
+	// 
+	// Emulating it this way is impractical for emulation (DASM wouldn't
+	// work) so we just present it as a flat space directly.
+	if (!m_spiregion)
+		return 0x0000;
+
+	u16 ret = (m_spiregion[((offset * 2) + 0) & (m_spisize-1)]) | (m_spiregion[((offset * 2) + 1) & (m_spisize-1)] << 8);
+	return ret;
+}
+
+u16 generalplus_gpl951xx_device::spi_direct_bank_r(offs_t offset)
+{
+	if (!m_spiregion)
+		return 0x0000;
+
+	offset += 0x1f7000;
+	offset += (m_spi_bank & 0x3f) * 0x200000;
+
+	u16 ret = (m_spiregion[((offset * 2) + 0) & (m_spisize-1)]) | (m_spiregion[((offset * 2) + 1) & (m_spisize-1)] << 8);
+	return ret;
+
 }
 
 void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map& map)
 {
-	sunplus_gcm394_base_device::base_internal_map(map);
+	map(0x000000, 0x0027ff).ram().share("mainram");
 
-	map(0x000000, 0x0027ff).rw(FUNC(generalplus_gpl951xx_device::ramread_r), FUNC(generalplus_gpl951xx_device::ramwrite_w));
-	// TODO: RAM is only 0x2800 on this, like earlier SPG2xx models? unmap the extra from the base_internal_map?
+	map(0x007000, 0x007007).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap2_regs_r), FUNC(gcm394_base_video_device::tmap2_regs_w)); // 7000 - Tx3_X_Position
 
-	// 7000 - Tx3_X_Position
-	// 7001 - Tx3_Y_Position
-	// 7002 - Tx3_X_Offset
-	// 7003 - Tx3_Y_Offset
-	// 7004 - Tx3_Attribute
-	// 7005 - Tx3_Control
-	// 7006 - Tx3_N_PTR
-	// 7007 - Tx3_A_PTR
+	map(0x007010, 0x007015).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap0_regs_r), FUNC(gcm394_base_video_device::tmap0_regs_w));
+	map(0x007016, 0x00701b).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap1_regs_r), FUNC(gcm394_base_video_device::tmap1_regs_w));
+	map(0x00701c, 0x00701c).w(m_spg_video, FUNC(gcm394_base_video_device::vcomp_value_w)); // 701c - VComValue
+	map(0x00701d, 0x00701d).w(m_spg_video, FUNC(gcm394_base_video_device::vcomp_offset_w)); // 701d - VComOffset
+	map(0x00701e, 0x00701e).w(m_spg_video, FUNC(gcm394_base_video_device::vcomp_step_w)); // 701e - VComStep
 
-	// 7010 - Tx1_X_Position
-	// 7011 - Tx1_Y_Position
-	// 7012 - Tx1_Attribute
-	// 7013 - Tx1_Control
-	// 7014 - Tx1_N_PTR
-	// 7015 - Tx1_A_PTR
-	// 7016 - Tx2_X_Position
-	// 7017 - Tx2_Y_Position
-	// 7018 - Tx2_Attribute
-	// 7019 - Tx2_Contro
-	// 701a - Tx2_N_PTR
-	// 701b - Tx2_A_PTR
-	// 701c - VComValue
-	// 701d - VComOffset
-	// 701e - VComStep
+	map(0x007020, 0x007020).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap0_tilebase_lsb_r), FUNC(gcm394_base_video_device::tmap0_tilebase_lsb_w));           // 7020 - Segment_Tx1
+	map(0x007021, 0x007021).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap1_tilebase_lsb_r), FUNC(gcm394_base_video_device::tmap1_tilebase_lsb_w));           // 7021 - Segment_Tx2
+	map(0x007022, 0x007022).rw(m_spg_video, FUNC(gcm394_base_video_device::sprite_7022_gfxbase_lsb_r), FUNC(gcm394_base_video_device::sprite_7022_gfxbase_lsb_w)); // 7022 - Segment_sp
+	map(0x007023, 0x007023).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap2_tilebase_lsb_r), FUNC(gcm394_base_video_device::tmap2_tilebase_lsb_w));           // 7023 - Segment_Tx3
 
-	// 7020 - Segment_Tx1
-	// 7021 - Segment_Tx2
-	// 7022 - Segment_sp
-	// 7023 - Segment_Tx3
 	//
-	// 702a - Blending
-	// 702b - Segment_Tx1H
-	// 702c - Segment_Tx2H
-	// 702d - Segment_spH
-	// 702e - Segment_Tx3H
+	// 
+	// 
+	// 
 	//
-	// 7030 - Fade_Control
+	map(0x00702a, 0x00702a).w(m_spg_video, FUNC(gcm394_base_video_device::blending_w)); // 702a - Blending
+	map(0x00702b, 0x00702b).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap0_tilebase_msb_r), FUNC(gcm394_base_video_device::tmap0_tilebase_msb_w));           // 702b - Segment_Tx1H
+	map(0x00702c, 0x00702c).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap1_tilebase_msb_r), FUNC(gcm394_base_video_device::tmap1_tilebase_msb_w));           // 702c - Segment_Tx2H
+	map(0x00702d, 0x00702d).rw(m_spg_video, FUNC(gcm394_base_video_device::sprite_702d_gfxbase_msb_r), FUNC(gcm394_base_video_device::sprite_702d_gfxbase_msb_w)); // 702d - Segment_spH
+	map(0x00702e, 0x00702e).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap2_tilebase_msb_r), FUNC(gcm394_base_video_device::tmap2_tilebase_msb_w));           // 702e - Segment_Tx3H
+		
 	//
-	// 703a - Palette_Control
+	map(0x007030, 0x007030).rw(m_spg_video, FUNC(gcm394_base_video_device::video_7030_brightness_r), FUNC(gcm394_base_video_device::video_7030_brightness_w)); // 7030 - Fade_Control
 	//
-	// 7042 - SControl
+	map(0x00703a, 0x00703a).rw(m_spg_video, FUNC(gcm394_base_video_device::video_703a_palettebank_r), FUNC(gcm394_base_video_device::video_703a_palettebank_w)); // 703a - Palette_Control
+	//
+	map(0x007042, 0x007042).rw(m_spg_video, FUNC(gcm394_base_video_device::sprite_7042_extra_r), FUNC(gcm394_base_video_device::sprite_7042_extra_w)); // 7042 - SControl
 	//
 	// 7050 - TFT_Ctrl
 	// 7051 - TFT_V_Width
@@ -141,8 +637,8 @@ void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map& map)
 	// 705e - STN_PIC_SEG
 	// 705f - STN_Ctrl1
 	//
-	// 7062 - TFT_INT_EN
-	// 7063 - TFT_INT_CLR
+	map(0x007062, 0x007062).rw(m_spg_video, FUNC(gcm394_base_video_device::videoirq_source_enable_r), FUNC(gcm394_base_video_device::videoirq_source_enable_w));             // 7062 - TFT_INT_EN
+	map(0x007063, 0x007063).rw(m_spg_video, FUNC(gcm394_base_video_device::video_7063_videoirq_source_r), FUNC(gcm394_base_video_device::video_7063_videoirq_source_ack_w)); // 7063 - TFT_INT_CLR
 	// 7064 - US_Ctrl
 	// 7065 - US_Hscaling
 	// 7066 - US_Vscaling
@@ -156,16 +652,16 @@ void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map& map)
 	// 706e - TFT_H_Show_Start
 	// 706f - TFT_H_Show_End
 	//
-	// 7070 - SPDMA_Source
-	// 7071 - SPDMA_Target
-	// 7072 - SPDMA_Number
+	map(0x007070, 0x007070).w(m_spg_video, FUNC(gcm394_base_video_device::video_dma_source_w)); // 7070 - SPDMA_Source
+	map(0x007071, 0x007071).w(m_spg_video, FUNC(gcm394_base_video_device::video_dma_dest_w));   // 7071 - SPDMA_Target
+	map(0x007072, 0x007072).rw(m_spg_video, FUNC(gcm394_base_video_device::video_dma_size_busy_r), FUNC(gcm394_base_video_device::video_dma_size_trigger_w)); // 7072 - SPDMA_Number
 	// 7073 - HB_Ctrl
 	// 7074 - HB_GO
 	//
 	// 707d - BLD_Color
 	//
-	// 707e - PPU_RAM_BANK
-	// 707f - PPU_Enable
+	map(0x00707e, 0x00707e).w(m_spg_video, FUNC(gcm394_base_video_device::ppu_ram_bank_w));    // 707e - PPU_RAM_BANK
+	map(0x00707f, 0x00707f).rw(m_spg_video, FUNC(gcm394_base_video_device::ppu_enable_r), FUNC(gcm394_base_video_device::ppu_enable_w));// 707f - PPU_Enable
 	//
 	// 7080 - STN_SEG
 	// 7081 - STN_COM
@@ -185,13 +681,13 @@ void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map& map)
 	// 70db - Free_Height
 	// 70dc - Free_Width
 	//
-	// 70e0 - Random0 (15-bit)
+	map(0x0070e0, 0x0070e0).r(m_spg_video, FUNC(gcm394_base_video_device::video_70e0_prng_r)); // 70e0 - Random0 (15-bit)
 	// 70e1 - Random1 (15-bit)
 	//
-	// 7100 to 71ff - Tx_Hvoffset
-	// 7200 to 72ff - HCMValue
-	// 7300 to 73ff - Palette (banked)
-	// 7400 to 74ff - Sprite Ram (banked)
+	map(0x007100, 0x0071ff).ram().share("rowscroll"); // 7100 to 71ff - Tx_Hvoffset
+	map(0x007200, 0x0072ff).ram().share("rowzoom"); // 7200 to 72ff - HCMValue
+	map(0x007300, 0x0073ff).rw(m_spg_video, FUNC(gcm394_base_video_device::palette_r), FUNC(gcm394_base_video_device::palette_w)); // 7300 to 73ff - Palette (banked)
+	map(0x007400, 0x0077ff).rw(m_spg_video, FUNC(gcm394_base_video_device::spriteram_r), FUNC(gcm394_base_video_device::spriteram_w)); // 7400 to 74ff - Sprite Ram (banked)
 	//
 	// 7800 - BodyID
 	// 7801 - unused
@@ -200,7 +696,7 @@ void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map& map)
 	// 7804 - CLK_Ctrl0
 	// 7805 - CLK_Ctrl1
 	// 7806 - Reset_Flag
-	// 7807 - Clock_Ctrl
+	map(0x007807, 0x007807).w(FUNC(generalplus_gpl951xx_device::clock_ctrl_w)); // 7807 - Clock_Ctrl
 	// 7808 - LVR_Ctrl
 	// 7809 - PM_Ctrl
 	// 780a - Watchdog_Ctrl
@@ -208,17 +704,17 @@ void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map& map)
 	// 780c - WAIT
 	// 780d - HALT
 	// 780e - unused
-	// 780f - Power_State
-	// 7810 - BankSwitch
+	map(0x00780f, 0x00780f).r(FUNC(generalplus_gpl951xx_device::power_state_r)); // 780f - Power_State
+	map(0x007810, 0x007810).rw(FUNC(generalplus_gpl951xx_device::spi_bank_r), FUNC(generalplus_gpl951xx_device::spi_bank_w)); // 7810 - BankSwitch
 	// 7811 - unused
 	// 7812 - unused
 	// 7813 - unused
 	// 7814 - unused
 	// 7815 - unused
 	// 7816 - unused
-	// 7817 - PLL_Sel
+	map(0x007817, 0x007817).rw(FUNC(generalplus_gpl951xx_device::pllsel_r), FUNC(generalplus_gpl951xx_device::pllsel_w)); // 7817 - PLL_Sel
 	// 7818 - PLLWaitCLK
-	// 7819 - Cache_Ctrl
+	map(0x007819, 0x007819).rw(FUNC(generalplus_gpl951xx_device::cache_ctrl_r), FUNC(generalplus_gpl951xx_device::cache_ctrl_w)); // 7819 - Cache_Ctrl
 	// 781a - Cache_HitRate
 	// 781b - unused
 	// 781c - unused
@@ -259,39 +755,39 @@ void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map& map)
 	// 785e - ECC_ERR0_LB     or BCH_Parity5
 	// 785f - ECC_ERR1_LB     or BCH_Parity6
 
-	// 7860 - IOA_Data
-	// 7861 - IOA_Buffer
-	// 7862 - IOA_Dir
-	// 7863 - IOA_Attrib
+	map(0x007860, 0x007860).rw(FUNC(generalplus_gpl951xx_device::ioa_data_r), FUNC(generalplus_gpl951xx_device::ioa_data_w));                     // 7860 - IOA_Data
+	map(0x007861, 0x007861).rw(FUNC(generalplus_gpl951xx_device::ioa_buffer_r), FUNC(generalplus_gpl951xx_device::ioa_buffer_w));       // 7861 - IOA_Buffer
+	map(0x007862, 0x007862).rw(FUNC(generalplus_gpl951xx_device::ioa_dir_r), FUNC(generalplus_gpl951xx_device::ioa_dir_w)); // 7862 - IOA_Dir
+	map(0x007863, 0x007863).rw(FUNC(generalplus_gpl951xx_device::ioa_attrib_r), FUNC(generalplus_gpl951xx_device::ioa_attrib_w)); // 7863 - IOA_Attrib
 	// 7864 - IOA_Drv
 	// 7865 - IOA_Mux
 	// 7866 - IOA_Latch
 	// 7867 - IOA_KeyEN
 
-	// 7868 - IOB_Data
-	// 7869 - IOB_Buffer
-	// 786a - IOB_Dir
-	// 786b - IOB_Attrib
+	map(0x007868, 0x007868).rw(FUNC(generalplus_gpl951xx_device::iob_data_r), FUNC(generalplus_gpl951xx_device::iob_data_w));                     // 7868 - IOB_Data
+	map(0x007869, 0x007869).rw(FUNC(generalplus_gpl951xx_device::iob_buffer_r), FUNC(generalplus_gpl951xx_device::iob_buffer_w));       // 7869 - IOB_Buffer
+	map(0x00786a, 0x00786a).rw(FUNC(generalplus_gpl951xx_device::iob_dir_r), FUNC(generalplus_gpl951xx_device::iob_dir_w)); // 786a - IOB_Dir
+	map(0x00786b, 0x00786b).rw(FUNC(generalplus_gpl951xx_device::iob_attrib_r), FUNC(generalplus_gpl951xx_device::iob_attrib_w)); // 786b - IOB_Attrib
 	// 786c - IOB_Drv
 	// 786d - IOB_Mux
 	// 786e - IOB_Latch
 	// 786f - IOB_KeyEN
 
-	// 7870 - IOC_Data
-	// 7871 - IOC_Buffer
-	// 7872 - IOC_Dir
-	// 7873 - IOC_Attrib
+	map(0x007870, 0x007870).rw(FUNC(generalplus_gpl951xx_device::ioc_data_r) ,FUNC(generalplus_gpl951xx_device::ioc_data_w));                     // 7870 - IOC_Data
+	map(0x007871, 0x007871).rw(FUNC(generalplus_gpl951xx_device::ioc_buffer_r), FUNC(generalplus_gpl951xx_device::ioc_buffer_w));       // 7871 - IOC_Buffer
+	map(0x007872, 0x007872).rw(FUNC(generalplus_gpl951xx_device::ioc_dir_r), FUNC(generalplus_gpl951xx_device::ioc_dir_w)); // 7872 - IOC_Dir
+	map(0x007873, 0x007873).rw(FUNC(generalplus_gpl951xx_device::ioc_attrib_r), FUNC(generalplus_gpl951xx_device::ioc_attrib_w)); // 7873 - IOC_Attrib	
 	// 7874 - IOC_Drv
 	// 7875 - IOC_Mux
 	// 7876 - IOC_Latch
 	// 7877 - IOC_KeyEN
 
-	// 7878 - IOD_Data
-	// 7879 - IOD_Buffer
-	// 787a - IOD_Dir
-	// 787b - IOD_Attrib
-	// 787c - IOD_Drv
-	// 787d - IOD_Mux
+	map(0x007878, 0x007878).rw(FUNC(generalplus_gpl951xx_device::iod_data_r) ,FUNC(generalplus_gpl951xx_device::iod_data_w));                     // 7878 - IOD_Data
+	map(0x007879, 0x007879).rw(FUNC(generalplus_gpl951xx_device::iod_buffer_r), FUNC(generalplus_gpl951xx_device::iod_buffer_w));       // 7879 - IOD_Buffer
+	map(0x00787a, 0x00787a).rw(FUNC(generalplus_gpl951xx_device::iod_dir_r), FUNC(generalplus_gpl951xx_device::iod_dir_w)); // 787a - IOD_Dir
+	map(0x00787b, 0x00787b).rw(FUNC(generalplus_gpl951xx_device::iod_attib_r), FUNC(generalplus_gpl951xx_device::iod_attib_w)); // 787b - IOD_Attrib
+	map(0x00787c, 0x00787c).rw(FUNC(generalplus_gpl951xx_device::iod_drv_r), FUNC(generalplus_gpl951xx_device::iod_drv_w)); // 787c - IOD_Drv
+	map(0x00787d, 0x00787d).rw(FUNC(generalplus_gpl951xx_device::iod_mux_r), FUNC(generalplus_gpl951xx_device::iod_mux_w)); // 787d - IOD_Mux
 
 	// 7880 - IOE_Data
 	// 7881 - IOE_Buffer
@@ -311,15 +807,15 @@ void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map& map)
 	// 788e - IOF_Latch
 	// 788f - IOF_KeyEN
 
-	// 78a0 - INT_Status1
-	// 78a1 - INT_Status2
+	map(0x0078a0, 0x0078a0).rw(FUNC(generalplus_gpl951xx_device::int_status1_r), FUNC(generalplus_gpl951xx_device::int_status1_w)); // 78a0 - INT_Status1
+	map(0x0078a1, 0x0078a1).r(FUNC(generalplus_gpl951xx_device::int_status2_r)); // 78a1 - INT_Status2
 	// 78a2 - INT_Status3
 	// 78a3 - INT_Priority1
-	// 78a4 - INT_Priority2
-	// 78a5 - INT_Priority3
-	// 78a6 - MINT_Ctrl
+	map(0x0078a4, 0x0078a4).w(FUNC(generalplus_gpl951xx_device::int_priority_1_w)); // 78a4 - INT_Priority2
+	map(0x0078a5, 0x0078a5).w(FUNC(generalplus_gpl951xx_device::int_priority_2_w)); // 78a5 - INT_Priority3
+	map(0x0078a6, 0x0078a6).w(FUNC(generalplus_gpl951xx_device::int_priority_3_w)); // 78a6 - MINT_Ctrl
 	// 78a7 - IOAB_KCIEN
-	// 78a8 - IOC_KCIEN
+	map(0x0078a8, 0x0078a8).w(FUNC(generalplus_gpl951xx_device::mint_ctrl_w)); // 78a8 - IOC_KCIEN
 	// 78a9 - IOE_KCIEN
 	// 78aa - IOF_KCIEN
 	// 78ab - IOAB_KCIFC
@@ -327,11 +823,11 @@ void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map& map)
 	// 78ad - IOE_ KCIFC
 	// 78ae - IOF_ KCIFC
 
-	// 78b0 - TimeBaseA_Ctrl
-	// 78b1 - TimeBaseB_Ctrl
-	// 78b2 - TimeBaseC_Ctrl
+	map(0x0078b0, 0x0078b0).w(FUNC(generalplus_gpl951xx_device::timebasea_ctrl_w)); // 78b0 - TimeBaseA_Ctrl
+	map(0x0078b1, 0x0078b1).w(FUNC(generalplus_gpl951xx_device::timebaseb_ctrl_w)); // 78b1 - TimeBaseB_Ctrl
+	map(0x0078b2, 0x0078b2).rw(FUNC(generalplus_gpl951xx_device::timebasec_ctrl_r), FUNC(generalplus_gpl951xx_device::timebasec_ctrl_w)); // 78b2 - TimeBaseC_Ctrl
 
-	// 78b8 - TimeBase_Reset
+	map(0x0078b8, 0x0078b8).w(FUNC(generalplus_gpl951xx_device::timebase_reset_w)); // 78b8 - TimeBase_Reset
 
 	// 78c0 - I2C_Ctrl
 	// 78c1 - I2C_Status
@@ -341,24 +837,24 @@ void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map& map)
 	// 78c5 - I2C_Clk
 	// 78c6 - I2C_MISC
 
-	// 78e0 - TimerG_Ctrl
+	map(0x0078e0, 0x0078e0).rw(FUNC(generalplus_gpl951xx_device::gpl951xx_timerg_ctrl_r), FUNC(generalplus_gpl951xx_device::gpl951xx_timerg_ctrl_w)); // 78e0 - gpl951xx_timerg_Ctrl
 	// 78e1
-	// 78e2 - TimerG_Preload
+	map(0x0078e2, 0x0078e2).rw(FUNC(generalplus_gpl951xx_device::gpl951xx_timerg_preload_r), FUNC(generalplus_gpl951xx_device::gpl951xx_timerg_preload_w)); // 78e2 - gpl951xx_timerg_Preload
 	// 78e3
 	// 78e4 - TimerG_UpCount
 	// 78e5
 	// 78e6
 	// 78e7
-	map(0x0078e8, 0x0078e8).rw(FUNC(generalplus_gpl951xx_device::spi_direct_78e8_r), FUNC(generalplus_gpl951xx_device::spi_direct_78e8_w)); // TimerH_Ctrl
+	map(0x0078e8, 0x0078e8).rw(FUNC(generalplus_gpl951xx_device::gpl951xx_timerh_ctrl_r), FUNC(generalplus_gpl951xx_device::gpl951xx_timerh_ctrl_w)); // gpl951xx_timerh_Ctrl
 	// 78e9
-	// 78ea - TimerH_Preload
+	map(0x0078ea, 0x0078ea).rw(FUNC(generalplus_gpl951xx_device::gpl951xx_timerh_preload_r), FUNC(generalplus_gpl951xx_device::gpl951xx_timerh_preload_w)); // 78ea - gpl951xx_timerh_Preload
 	// 78eb
 	// 78ec - TimerH_UpCount
 	// 78ed
 	// 78ee
 	// 78ef
 
-	// 78f0 - CHA_Ctrl
+	map(0x0078f0, 0x0078f0).rw(FUNC(generalplus_gpl951xx_device::cha_ctrl_r), FUNC(generalplus_gpl951xx_device::cha_ctrl_w)); // 78f0 - CHA_Ctrl
 	// 78f1 - CHA_Data
 	// 78f2 - CHA_FIFO
 	// 78f3
@@ -427,8 +923,8 @@ void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map& map)
 	// 79f1 - RTC_Addr
 	// 79f2 - RTC_WriteData
 	// 79f3 - RTC_Request
-	map(0x0079f4, 0x0079f4).r(FUNC(generalplus_gpl951xx_device::spi_direct_79f4_r)); // RTC_Ready
-	map(0x0079f5, 0x0079f5).r(FUNC(generalplus_gpl951xx_device::spi_direct_79f5_r)); // RTC_ReadData
+	map(0x0079f4, 0x0079f4).r(FUNC(generalplus_gpl951xx_device::rtc_ready_r)); // RTC_Ready
+	map(0x0079f5, 0x0079f5).r(FUNC(generalplus_gpl951xx_device::rtc_readdata_r)); // RTC_ReadData
 	// 79f6
 	// 79f7
 	// 79f8
@@ -513,29 +1009,15 @@ void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map& map)
 	//
 	// 7a6c - USBD_INTF
 
-	// 7a80 - DMA_Ctrl0
-	// 7a81 - DMA_SRC_AddrL0
-	// 7a82 - DMA_TAR_AddrL0
-	// 7a83 - DMA_TCountL0
-	// 7a84 - DMA_SRC_AddrH0
-	// 7a85 - DMA_TAR_AddrH0
-	// 7a86 - DMA_TCountH0
-	// 7a87 - DMA_MISC0
-	// 7a88 - DMA_Ctrl1
-	// 7a89 - DMA_SRC_AddrL1
-	// 7a8a - DMA_TAR_AddrL1
-	// 7a8b - DMA_TCountL1
-	// 7a8c - DMA_SRC_AddrH1
-	// 7a8d - DMA_TAR_AddrH1
-	// 7a8e - DMA_TCountH1
-	// 7a8f - DMA_MISC1
+	map(0x007a80, 0x007a87).rw(FUNC(generalplus_gpl951xx_device::system_dma_params_channel0_r), FUNC(generalplus_gpl951xx_device::system_dma_params_channel0_w));
+	map(0x007a88, 0x007a8f).rw(FUNC(generalplus_gpl951xx_device::system_dma_params_channel1_r), FUNC(generalplus_gpl951xx_device::system_dma_params_channel1_w));
 	//
 	// 7ab0 - DMA_SPRISize0
 	// 7ab1 - DMA_SPRISize1
 	//
 	// 7abd - DMA_LineLength
-	// 7abe - DMA_SS
-	// 7abf - DMA_INT
+	map(0x007abe, 0x007abe).rw(FUNC(generalplus_gpl951xx_device::system_dma_memtype_r), FUNC(generalplus_gpl951xx_device::system_dma_memtype_w)); // 7abe - DMA_SS
+	map(0x007abf, 0x007abf).rw(FUNC(generalplus_gpl951xx_device::system_dma_status_r), FUNC(generalplus_gpl951xx_device::system_dma_7abf_unk_w)); // 7abf - DMA_INT
 	//
 	// 7ac0 - CTS_Ctrl1
 	// 7ac1 - CTS_CH
@@ -548,7 +1030,7 @@ void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map& map)
 	// 7ac8 - CTS_FIFOLevel
 	// 7ac9 - CTS_CNT
 
-	map(0x007af0, 0x007af0).rw(FUNC(generalplus_gpl951xx_device::spi_direct_7af0_r), FUNC(generalplus_gpl951xx_device::spi_direct_7af0_w)); // Byte_Swap
+	map(0x007af0, 0x007af0).rw(FUNC(generalplus_gpl951xx_device::byte_swap_r), FUNC(generalplus_gpl951xx_device::byte_swap_w)); // Byte_Swap
 	// 7af1 - Nibble_Swap
 	// 7af2 - TwoBit_Swap
 	// 7af3 - Bit_Reverse
@@ -568,33 +1050,57 @@ void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map& map)
 	// 7b31 - KS_Data9
 	// 7b32 - KS_Data10
 
-	map(0x007b40, 0x007b40).r(FUNC(generalplus_gpl951xx_device::spi_direct_7b40_r)).nopw();; // SPIFC_Ctrl1
-	map(0x007b41, 0x007b41).nopw(); // SPIFC_CMD
-	map(0x007b42, 0x007b42).nopw(); // SPIFC_PARA
-	// 7b43 - SPIFC_ADDRL
-	// 7b44 - SPIFC_ADDRH
-	// 7b45 - SPIFC_TX_Dat
-	map(0x007b46, 0x007b46).ram(); // SPIFC_RX_Data - values must be written and read from here, but is there any transformation?
-	map(0x007b47, 0x007b47).nopw(); // SPIFC_TX_BC
-	map(0x007b48, 0x007b48).nopw(); // SPIFC_RX_BC
-	map(0x007b49, 0x007b49).ram(); // SPIFC_TIMING
+	map(0x007b40, 0x007b40).rw(FUNC(generalplus_gpl951xx_device::spifc_ctrl_r), FUNC(generalplus_gpl951xx_device::spifc_ctrl_w)); // SPIFC_Ctrl1
+	map(0x007b41, 0x007b41).rw(FUNC(generalplus_gpl951xx_device::spifc_cmd_r), FUNC(generalplus_gpl951xx_device::spifc_cmd_w)); // SPIFC_CMD
+	map(0x007b42, 0x007b42).rw(FUNC(generalplus_gpl951xx_device::spifc_para_r), FUNC(generalplus_gpl951xx_device::spifc_para_w)); // SPIFC_PARA
+	map(0x007b43, 0x007b43).rw(FUNC(generalplus_gpl951xx_device::spifc_addrl_r), FUNC(generalplus_gpl951xx_device::spifc_addrl_w)); // 7b43 - SPIFC_ADDRL
+	map(0x007b44, 0x007b44).rw(FUNC(generalplus_gpl951xx_device::spifc_addrh_r), FUNC(generalplus_gpl951xx_device::spifc_addrh_w)); // 7b44 - SPIFC_ADDRH
+	map(0x007b45, 0x007b45).rw(FUNC(generalplus_gpl951xx_device::spifc_txdat_r), FUNC(generalplus_gpl951xx_device::spifc_txdat_w)); // 7b45 - SPIFC_TX_Dat
+	map(0x007b46, 0x007b46).rw(FUNC(generalplus_gpl951xx_device::spifc_rxdat_r), FUNC(generalplus_gpl951xx_device::spifc_rxdat_w)); // SPIFC_RX_Data - values must be written and read from here, but is there any transformation?
+	map(0x007b47, 0x007b47).rw(FUNC(generalplus_gpl951xx_device::spifc_tx_bc_r), FUNC(generalplus_gpl951xx_device::spifc_tx_bc_w)); // SPIFC_TX_BC
+	map(0x007b48, 0x007b48).rw(FUNC(generalplus_gpl951xx_device::spifc_rx_bc_r), FUNC(generalplus_gpl951xx_device::spifc_rx_bc_w)); // SPIFC_RX_BC
+	map(0x007b49, 0x007b49).rw(FUNC(generalplus_gpl951xx_device::spifc_timing_r), FUNC(generalplus_gpl951xx_device::spifc_timing_w)); // SPIFC_TIMING
+	// 7b4a
+	map(0x007b4b, 0x007b4b).rw(FUNC(generalplus_gpl951xx_device::spifc_ctrl2_r), FUNC(generalplus_gpl951xx_device::spifc_ctrl2_w)); // 7b4b - SPIFC_Ctrl2
 
-	// 7b4b - SPIFC_Ctrl2
 
-	// 7b80 to 7b9f - Audio
-	// 7c00 to 7cff - Audio
-	// 7e00 to 7eff - Audio
+	map(0x007b80, 0x007bbf).rw(m_spg_audio, FUNC(sunplus_gcm394_audio_device::control_r), FUNC(sunplus_gcm394_audio_device::control_w));
+	map(0x007c00, 0x007dff).rw(m_spg_audio, FUNC(sunplus_gcm394_audio_device::audio_r), FUNC(sunplus_gcm394_audio_device::audio_w));
+	map(0x007e00, 0x007fff).rw(m_spg_audio, FUNC(sunplus_gcm394_audio_device::audio_phase_r), FUNC(sunplus_gcm394_audio_device::audio_phase_w));
 
 	// 8000 - 8fff internal boot ROM (same on all devices of the same type, not OTP)
 
-	map(0x009000, 0x3fffff).rom().region("spidirect", 0);
+	map(0x009000, 0x1fffff).r(FUNC(generalplus_gpl951xx_device::spi_direct_r));
+	map(0x200000, 0x3fffff).r(FUNC(generalplus_gpl951xx_device::spi_direct_bank_r));
 }
 
+TIMER_DEVICE_CALLBACK_MEMBER( generalplus_gpl951xx_device::timer_g_cb )
+{
+	m_gpl951xx_timerg_ctrl |= 0x8000;
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER( generalplus_gpl951xx_device::timer_h_cb )
+{
+	m_gpl951xx_timerh_ctrl |= 0x8000;
+}
+
+void generalplus_gpl951xx_device::device_add_mconfig(machine_config &config)
+{
+	sunplus_gcm394_base_device::device_add_mconfig(config);
+
+	TIMER(config, "timer_g").configure_generic(FUNC(generalplus_gpl951xx_device::timer_g_cb));
+	TIMER(config, "timer_h").configure_generic(FUNC(generalplus_gpl951xx_device::timer_h_cb));
+}
 
 DEFINE_DEVICE_TYPE(GPL951XX, generalplus_gpl951xx_device, "gpl951xx", "GeneralPlus GPL951xx")
 
-generalplus_gpl951xx_device::generalplus_gpl951xx_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	sunplus_gcm394_base_device(mconfig, GPL951XX, tag, owner, clock, address_map_constructor(FUNC(generalplus_gpl951xx_device::gpspi_direct_internal_map), this))
+generalplus_gpl951xx_device::generalplus_gpl951xx_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
+	sunplus_gcm394_base_device(mconfig, GPL951XX, tag, owner, clock, address_map_constructor(FUNC(generalplus_gpl951xx_device::gpspi_direct_internal_map), this)),
+	m_spi_out(*this),
+	m_spi_out_cmd(*this),
+	m_spi_reset(*this),
+	m_timer_g(*this, "timer_g"),
+	m_timer_h(*this, "timer_h")
 {
 }
 

--- a/src/devices/machine/generalplus_gpl951xx_soc.cpp
+++ b/src/devices/machine/generalplus_gpl951xx_soc.cpp
@@ -316,7 +316,7 @@ u16 generalplus_gpl951xx_device::pllsel_r()
 	return m_pllchange;
 }
 
-void generalplus_gpl951xx_device::pllsel_w(uint16_t data)
+void generalplus_gpl951xx_device::pllsel_w(u16 data)
 {
 	// very similar to pllchange on GPL162xx, but with extra SPI bits
 	logerror("%s: generalplus_gpl951xx_device::pllsel_w %04x\n", machine().describe_context(), data);

--- a/src/devices/machine/generalplus_gpl951xx_soc.cpp
+++ b/src/devices/machine/generalplus_gpl951xx_soc.cpp
@@ -585,7 +585,7 @@ u16 generalplus_gpl951xx_device::spi_direct_bank_r(offs_t offset)
 
 }
 
-void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map& map)
+void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map &map)
 {
 	map(0x000000, 0x0027ff).ram().share("mainram");
 

--- a/src/devices/machine/generalplus_gpl951xx_soc.cpp
+++ b/src/devices/machine/generalplus_gpl951xx_soc.cpp
@@ -50,17 +50,17 @@ u8 generalplus_gpl951xx_device::get_byte_from_rx_fifo()
 // 14  rx_empty
 // 13
 // 12
-// 
+//
 // 11
 // 10
 // 9   ig_clk
 // 8   manual
-// 
+//
 // 7   cmio[1]
 // 6   cmio[0]
 // 5   amio[1]
 // 4   amio[0]
-// 
+//
 // 3   mio[1]
 // 2   mio[0]
 // 1
@@ -95,12 +95,12 @@ void generalplus_gpl951xx_device::spifc_ctrl_w(u16 data)
 // 10
 //  9  cmd_only
 //  8  wo_cmd
-// 
+//
 //  7  wpif_cmd[7]
 //  6  wpif_cmd[6]
 //  5  wpif_cmd[5]
 //  4  wpif_cmd[4]
-// 
+//
 //  3  wpif_cmd[3]
 //  2  wpif_cmd[2]
 //  1  wpif_cmd[1]
@@ -146,7 +146,7 @@ void generalplus_gpl951xx_device::spifc_cmd_w(u16 data)
 // 6   enhan_by[6]
 // 5   enhan_by[5]
 // 4   enhan_by[4]
-// 
+//
 // 3   enhan_by[4]
 // 2   enhan_by[3]
 // 1   enhan_by[2]
@@ -222,7 +222,7 @@ u16 generalplus_gpl951xx_device::spifc_rxdat_r()
 	after auto command bite spifc_cmd_w is set to 9f (ident)
 
 	at 672 R1 will be xx00 (results from device)
-    R2 will be xxxx (results from device)
+	R2 will be xxxx (results from device)
 
 	continuing to 232 it restores these values and it checks if R1 is 0000 (it shouldn't be)
 
@@ -232,7 +232,7 @@ u16 generalplus_gpl951xx_device::spifc_rxdat_r()
 
 	return m_spifc_rx_read_latch;
 }
-	
+
 
 void generalplus_gpl951xx_device::spifc_rxdat_w(u16 data)
 {
@@ -484,17 +484,17 @@ void generalplus_gpl951xx_device::gpl951xx_timerh_preload_w(u16 data)
 // 14  TMHIE
 // 13  TMHEN
 // 12
-// 
+//
 // 11  EXT0SEL[1]
 // 10  EXT0SEL[0]
 // 9   EXT1SEL[1]
 // 8   EXT1SEL[0]
-// 
+//
 // 7
 // 6   SRCBSEL[2]
 // 5   SRCBSEL[1]
 // 4   SRCBSEL[0]
-// 
+//
 // 3   SRCASEL[3]
 // 2   SRCASEL[2]
 // 1   SRCASEL[1]
@@ -562,7 +562,7 @@ u16 generalplus_gpl951xx_device::spi_direct_r(offs_t offset)
 	// The GPL951xx chips can see a bank of SPI memory as a flat space
 	// as they will automatically generate SPI signals for random memory
 	// access on demand
-	// 
+	//
 	// Emulating it this way is impractical for emulation (DASM wouldn't
 	// work) so we just present it as a flat space directly.
 	if (!m_spiregion)
@@ -603,16 +603,16 @@ void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map &map)
 	map(0x007023, 0x007023).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap2_tilebase_lsb_r), FUNC(gcm394_base_video_device::tmap2_tilebase_lsb_w));           // 7023 - Segment_Tx3
 
 	//
-	// 
-	// 
-	// 
+	//
+	//
+	//
 	//
 	map(0x00702a, 0x00702a).w(m_spg_video, FUNC(gcm394_base_video_device::blending_w)); // 702a - Blending
 	map(0x00702b, 0x00702b).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap0_tilebase_msb_r), FUNC(gcm394_base_video_device::tmap0_tilebase_msb_w));           // 702b - Segment_Tx1H
 	map(0x00702c, 0x00702c).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap1_tilebase_msb_r), FUNC(gcm394_base_video_device::tmap1_tilebase_msb_w));           // 702c - Segment_Tx2H
 	map(0x00702d, 0x00702d).rw(m_spg_video, FUNC(gcm394_base_video_device::sprite_702d_gfxbase_msb_r), FUNC(gcm394_base_video_device::sprite_702d_gfxbase_msb_w)); // 702d - Segment_spH
 	map(0x00702e, 0x00702e).rw(m_spg_video, FUNC(gcm394_base_video_device::tmap2_tilebase_msb_r), FUNC(gcm394_base_video_device::tmap2_tilebase_msb_w));           // 702e - Segment_Tx3H
-		
+
 	//
 	map(0x007030, 0x007030).rw(m_spg_video, FUNC(gcm394_base_video_device::video_7030_brightness_r), FUNC(gcm394_base_video_device::video_7030_brightness_w)); // 7030 - Fade_Control
 	//
@@ -776,7 +776,7 @@ void generalplus_gpl951xx_device::gpspi_direct_internal_map(address_map &map)
 	map(0x007870, 0x007870).rw(FUNC(generalplus_gpl951xx_device::ioc_data_r) ,FUNC(generalplus_gpl951xx_device::ioc_data_w));                     // 7870 - IOC_Data
 	map(0x007871, 0x007871).rw(FUNC(generalplus_gpl951xx_device::ioc_buffer_r), FUNC(generalplus_gpl951xx_device::ioc_buffer_w));       // 7871 - IOC_Buffer
 	map(0x007872, 0x007872).rw(FUNC(generalplus_gpl951xx_device::ioc_dir_r), FUNC(generalplus_gpl951xx_device::ioc_dir_w)); // 7872 - IOC_Dir
-	map(0x007873, 0x007873).rw(FUNC(generalplus_gpl951xx_device::ioc_attrib_r), FUNC(generalplus_gpl951xx_device::ioc_attrib_w)); // 7873 - IOC_Attrib	
+	map(0x007873, 0x007873).rw(FUNC(generalplus_gpl951xx_device::ioc_attrib_r), FUNC(generalplus_gpl951xx_device::ioc_attrib_w)); // 7873 - IOC_Attrib
 	// 7874 - IOC_Drv
 	// 7875 - IOC_Mux
 	// 7876 - IOC_Latch

--- a/src/devices/machine/generalplus_gpl951xx_soc.cpp
+++ b/src/devices/machine/generalplus_gpl951xx_soc.cpp
@@ -204,6 +204,7 @@ u16 generalplus_gpl951xx_device::spifc_txdat_r()
 void generalplus_gpl951xx_device::spifc_txdat_w(u16 data)
 {
 	LOGMASKED(LOG_SPIFC, "%s: spifc_txdat_w %04x\n", machine().describe_context(), data);
+	m_spi_out(data & 0xff);
 }
 
 // P_SPIFC_RX_Data

--- a/src/devices/machine/generalplus_gpl951xx_soc.cpp
+++ b/src/devices/machine/generalplus_gpl951xx_soc.cpp
@@ -365,7 +365,6 @@ void generalplus_gpl951xx_device::device_start()
 	save_item(NAME(m_spifc_tx_bc));
 	save_item(NAME(m_spifc_timing));
 	save_item(NAME(m_bytes_in_spifc_rx_fifo));
-	save_item(NAME(m_spifc_hackident));
 	save_item(NAME(m_spi_bank));
 	save_item(NAME(m_spifc_rx_fifo));
 	save_item(NAME(m_spifc_rx_read_latch));

--- a/src/devices/machine/generalplus_gpl951xx_soc.h
+++ b/src/devices/machine/generalplus_gpl951xx_soc.h
@@ -8,11 +8,13 @@
 
 #include "generalplus_gpl162xx_soc.h"
 
+#include "machine/timer.h"
+
 class generalplus_gpl951xx_device : public sunplus_gcm394_base_device
 {
 public:
 	template <typename T>
-	generalplus_gpl951xx_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&screen_tag) :
+	generalplus_gpl951xx_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, T &&screen_tag) :
 		generalplus_gpl951xx_device(mconfig, tag, owner, clock)
 	{
 		m_screen.set_tag(std::forward<T>(screen_tag));
@@ -21,27 +23,116 @@ public:
 		m_csbase = 0xffffffff;
 	}
 
-	generalplus_gpl951xx_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	generalplus_gpl951xx_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	void set_spi_romregion(u8 *region, u32 size) { m_spiregion = region; m_spisize = size; }
+
+	auto spi_out() { return m_spi_out.bind(); }
+	auto spi_out_cmd() { return m_spi_out_cmd.bind(); }
+	auto spi_reset() { return m_spi_reset.bind(); }
+
+	void recieve_spi_fifo_data(u8 data);
 
 protected:
+	virtual void device_add_mconfig(machine_config& config) override ATTR_COLD;
+
 	void gpspi_direct_internal_map(address_map &map) ATTR_COLD;
 
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 
 private:
-	uint16_t ramread_r(offs_t offset);
-	void ramwrite_w(offs_t offset, uint16_t data);
-	uint16_t spi_direct_7b40_r();
-	uint16_t spi_direct_7b46_r();
-	uint16_t spi_direct_7af0_r();
-	void spi_direct_7af0_w(uint16_t data);
-	uint16_t spi_direct_79f5_r();
-	uint16_t spi_direct_78e8_r();
-	void spi_direct_78e8_w(uint16_t data);
-	uint16_t spi_direct_79f4_r();
+	// SPIFC interface
 
-	uint16_t m_7af0;
+	u16 spifc_ctrl_r();
+	void spifc_ctrl_w(u16 data);
+	u16 spifc_cmd_r();
+	void spifc_cmd_w(u16 data);
+	u16 spifc_para_r();
+	void spifc_para_w(u16 data);
+	u16 spifc_addrl_r();
+	void spifc_addrl_w(u16 data);
+	u16 spifc_addrh_r();
+	void spifc_addrh_w(u16 data);
+	u16 spifc_txdat_r();
+	void spifc_txdat_w(u16 data);
+	u16 spifc_rxdat_r();
+	void spifc_rxdat_w(u16 data);
+	u16 spifc_tx_bc_r();
+	void spifc_tx_bc_w(u16 data);
+	u16 spifc_rx_bc_r();
+	void spifc_rx_bc_w(u16 data);
+	u16 spifc_timing_r();
+	void spifc_timing_w(u16 data);
+	u16 spifc_ctrl2_r();
+	void spifc_ctrl2_w(u16 data);
+
+	u16 pllsel_r();
+	void pllsel_w(uint16_t data);
+
+	// Byte swap etc.
+	u16 byte_swap_r();
+	void byte_swap_w(u16 data);
+
+	// RTC
+	u16 rtc_readdata_r();
+	u16 rtc_ready_r();
+
+	// Timers (different compared to GPL162xx)
+	u16 gpl951xx_timerg_ctrl_r();
+	void gpl951xx_timerg_ctrl_w(u16 data);
+	u16 gpl951xx_timerg_preload_r();
+	void gpl951xx_timerg_preload_w(u16 data);
+	u16 gpl951xx_timerh_ctrl_r();
+	void gpl951xx_timerh_ctrl_w(u16 data);
+	u16 gpl951xx_timerh_preload_r();
+	void gpl951xx_timerh_preload_w(u16 data);
+
+	u16 spi_bank_r();
+	void spi_bank_w(u16 data);
+
+	u16 spi_direct_r(offs_t offset);
+	u16 spi_direct_bank_r(offs_t offset);
+
+	u8 get_byte_from_rx_fifo();
+
+	TIMER_DEVICE_CALLBACK_MEMBER(timer_g_cb);
+	TIMER_DEVICE_CALLBACK_MEMBER(timer_h_cb);
+
+	u16 m_byteswap;
+
+	u16 m_gpl951xx_timerg_preload;
+	u16 m_gpl951xx_timerg_ctrl;
+	u16 m_gpl951xx_timerh_preload;
+	u16 m_gpl951xx_timerh_ctrl;
+
+	u16 m_spifc_ctrl;
+	u16 m_spifc_ctrl2;
+	u32 m_spifc_addr;
+	u16 m_spifc_cmd;
+	u16 m_spifc_para;
+	u16 m_spifc_rx_bc;
+	u16 m_spifc_tx_bc;
+	u16 m_spifc_timing;
+	u32 m_spifc_hackident; // hack, this should come from SPI command 9f
+	u8  m_bytes_in_spifc_rx_fifo;
+	u8 m_spifc_rx_fifo[16 * 2];
+	u16 m_spifc_rx_read_latch;
+
+	u16 m_spi_bank;
+
+
+	// config
+	u8 *m_spiregion;
+	u32 m_spisize;
+
+	devcb_write8 m_spi_out;
+	devcb_write8 m_spi_out_cmd;
+	devcb_write8 m_spi_reset;
+
+	// devices
+	required_device<timer_device> m_timer_g;
+	required_device<timer_device> m_timer_h;
 };
 
 DECLARE_DEVICE_TYPE(GPL951XX, generalplus_gpl951xx_device)

--- a/src/devices/machine/generalplus_gpl951xx_soc.h
+++ b/src/devices/machine/generalplus_gpl951xx_soc.h
@@ -114,13 +114,11 @@ private:
 	u16 m_spifc_rx_bc;
 	u16 m_spifc_tx_bc;
 	u16 m_spifc_timing;
-	u32 m_spifc_hackident; // hack, this should come from SPI command 9f
-	u8  m_bytes_in_spifc_rx_fifo;
+	u8 m_bytes_in_spifc_rx_fifo;
 	u8 m_spifc_rx_fifo[16 * 2];
 	u16 m_spifc_rx_read_latch;
 
 	u16 m_spi_bank;
-
 
 	// config
 	u8 *m_spiregion;

--- a/src/devices/machine/generalplus_gpl951xx_soc.h
+++ b/src/devices/machine/generalplus_gpl951xx_soc.h
@@ -34,7 +34,7 @@ public:
 	void recieve_spi_fifo_data(u8 data);
 
 protected:
-	virtual void device_add_mconfig(machine_config& config) override ATTR_COLD;
+	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 
 	void gpspi_direct_internal_map(address_map &map) ATTR_COLD;
 
@@ -68,7 +68,7 @@ private:
 	void spifc_ctrl2_w(u16 data);
 
 	u16 pllsel_r();
-	void pllsel_w(uint16_t data);
+	void pllsel_w(u16 data);
 
 	// Byte swap etc.
 	u16 byte_swap_r();

--- a/src/devices/machine/generic_spi_flash.cpp
+++ b/src/devices/machine/generic_spi_flash.cpp
@@ -27,17 +27,23 @@ generic_spi_flash_device::generic_spi_flash_device(const machine_config &mconfig
 
 void generic_spi_flash_device::device_start()
 {
-	save_item(NAME(m_spiaddr));
+	save_item(NAME(m_spi_addr));
 	save_item(NAME(m_spi_state));
-	save_item(NAME(m_spilatch));
+	save_item(NAME(m_spi_latch));
+	save_item(NAME(m_spi_state_step));
+	save_item(NAME(m_spi_statusreg));
+	save_item(NAME(m_spi_configreg));
+
 	m_spi_statusreg = 0;
+	m_spi_configreg = 0;
+	m_spi_state_step = 0;
 }
 
 void generic_spi_flash_device::device_reset()
 {
-	m_spiaddr = 0;
+	m_spi_addr = 0;
 	m_spi_state = 0;
-	m_spilatch = 0;
+	m_spi_latch = 0;
 }
 
 void generic_spi_flash_device::get_command(u8 data)
@@ -163,16 +169,16 @@ void generic_spi_flash_device::process_read_command(u8 data)
 	switch (m_spi_state_step)
 	{
 	case 0x00:
-		m_spiaddr = (m_spiaddr & 0x00ffff) | (data << 16); m_spi_state_step++;
+		m_spi_addr = (m_spi_addr & 0x00ffff) | (data << 16); m_spi_state_step++;
 		break;
 	case 0x01:
-		m_spiaddr = (m_spiaddr & 0xff00ff) | (data << 8); m_spi_state_step++;
+		m_spi_addr = (m_spi_addr & 0xff00ff) | (data << 8); m_spi_state_step++;
 		break;
 	case 0x02:
-		m_spiaddr = (m_spiaddr & 0xffff00) | (data); m_spi_state_step++;
+		m_spi_addr = (m_spi_addr & 0xffff00) | (data); m_spi_state_step++;
 		break;
 	default:
-		m_spilatch = m_spiptr[(m_spiaddr++) & (m_length - 1)];
+		m_spi_latch = m_spiptr[(m_spi_addr++) & (m_length - 1)];
 		break;
 	}
 }
@@ -182,19 +188,19 @@ void generic_spi_flash_device::process_hsread_command(u8 data)
 	switch (m_spi_state_step)
 	{
 	case 0x00:
-		m_spiaddr = (m_spiaddr & 0x00ffff) | (data << 16); m_spi_state_step++;
+		m_spi_addr = (m_spi_addr & 0x00ffff) | (data << 16); m_spi_state_step++;
 		break;
 	case 0x01:
-		m_spiaddr = (m_spiaddr & 0xff00ff) | (data << 8); m_spi_state_step++;
+		m_spi_addr = (m_spi_addr & 0xff00ff) | (data << 8); m_spi_state_step++;
 		break;
 	case 0x02:
-		m_spiaddr = (m_spiaddr & 0xffff00) | (data); m_spi_state_step++;
+		m_spi_addr = (m_spi_addr & 0xffff00) | (data); m_spi_state_step++;
 		break;
 	case 0x03:
 		/* dummy */  m_spi_state_step++;
 		break;
 	default:
-		m_spilatch = m_spiptr[(m_spiaddr++) & (m_length - 1)];
+		m_spi_latch = m_spiptr[(m_spi_addr++) & (m_length - 1)];
 		break;
 	}
 }
@@ -205,19 +211,19 @@ void generic_spi_flash_device::process_read4_command(u8 data)
 	switch (m_spi_state_step)
 	{
 	case 0x00:
-		m_spiaddr = (m_spiaddr & 0x00ffff) | (data << 16); m_spi_state_step++;
+		m_spi_addr = (m_spi_addr & 0x00ffff) | (data << 16); m_spi_state_step++;
 		break;
 	case 0x01:
-		m_spiaddr = (m_spiaddr & 0xff00ff) | (data << 8); m_spi_state_step++;
+		m_spi_addr = (m_spi_addr & 0xff00ff) | (data << 8); m_spi_state_step++;
 		break;
 	case 0x02:
-		m_spiaddr = (m_spiaddr & 0xffff00) | (data); m_spi_state_step++;
+		m_spi_addr = (m_spi_addr & 0xffff00) | (data); m_spi_state_step++;
 		break;
 	case 0x03: case 0x04: case 0x05:
 		/* dummy */  m_spi_state_step++;
 		break;
 	default:
-		m_spilatch = m_spiptr[(m_spiaddr++) & (m_length - 1)];
+		m_spi_latch = m_spiptr[(m_spi_addr++) & (m_length - 1)];
 		break;
 	}
 }
@@ -227,17 +233,17 @@ void generic_spi_flash_device::process_write_command(u8 data)
 	switch (m_spi_state_step)
 	{
 	case 0x00:
-		m_spiaddr = (m_spiaddr & 0x00ffff) | (data << 16); m_spi_state_step++;
+		m_spi_addr = (m_spi_addr & 0x00ffff) | (data << 16); m_spi_state_step++;
 		break;
 	case 0x01:
-		m_spiaddr = (m_spiaddr & 0xff00ff) | (data << 8); m_spi_state_step++;
+		m_spi_addr = (m_spi_addr & 0xff00ff) | (data << 8); m_spi_state_step++;
 		break;
 	case 0x02:
-		m_spiaddr = (m_spiaddr & 0xffff00) | (data); m_spi_state_step++;
+		m_spi_addr = (m_spi_addr & 0xffff00) | (data); m_spi_state_step++;
 		break;
 	default:
 		LOGMASKED(LOG_SPI, "Write SPI data %02x\n", data);
-		m_spiptr[(m_spiaddr++) & (m_length - 1)] = data;
+		m_spiptr[(m_spi_addr++) & (m_length - 1)] = data;
 		break;
 	}
 }
@@ -247,14 +253,14 @@ void generic_spi_flash_device::process_sector_erase_command(u8 data)
 	switch (m_spi_state_step)
 	{
 	case 0x00:
-		m_spiaddr = (m_spiaddr & 0x00ffff) | (data << 16); m_spi_state_step++;
+		m_spi_addr = (m_spi_addr & 0x00ffff) | (data << 16); m_spi_state_step++;
 		break;
 	case 0x01:
-		m_spiaddr = (m_spiaddr & 0xff00ff) | (data << 8); m_spi_state_step++;
+		m_spi_addr = (m_spi_addr & 0xff00ff) | (data << 8); m_spi_state_step++;
 		break;
 	case 0x02:
-		m_spiaddr = (m_spiaddr & 0xffff00) | (data); m_spi_state_step++;
-		LOGMASKED(LOG_SPI, "SPI set to Erase Sector with address %08x\n", m_spiaddr);
+		m_spi_addr = (m_spi_addr & 0xffff00) | (data); m_spi_state_step++;
+		LOGMASKED(LOG_SPI, "SPI set to Erase Sector with address %08x\n", m_spi_addr);
 		break;
 	default:
 		LOGMASKED(LOG_SPI, "%s unexpected byte %02x when writing sector erase address\n", data);
@@ -267,7 +273,8 @@ void generic_spi_flash_device::process_status_write_command(u8 data)
 	switch (m_spi_state_step)
 	{
 	case 0x00:
-		LOGMASKED(LOG_SPI, "status write step 1\n");
+		LOGMASKED(LOG_SPI, "status write step 1 (config register)\n");
+		m_spi_configreg = data;
 		if (m_multibyte_status_write != 0)
 			m_spi_state_step++;
 		else
@@ -275,7 +282,8 @@ void generic_spi_flash_device::process_status_write_command(u8 data)
 		break;
 
 	case 0x01:
-		LOGMASKED(LOG_SPI, "status write step 2\n");
+		LOGMASKED(LOG_SPI, "status write step 2 (status register)\n");
+		m_spi_statusreg = data;
 		m_spi_state = READY_FOR_COMMAND;
 		break;
 	}
@@ -287,7 +295,7 @@ void generic_spi_flash_device::process_status_read_command(u8 data)
 	{
 	case 0x00:
 		LOGMASKED(LOG_SPI, "status read step 1\n");
-		m_spilatch = m_spi_statusreg;
+		m_spi_latch = m_spi_statusreg;
 
 		if (m_multibyte_status_read != 0)
 			m_spi_state_step++;
@@ -297,7 +305,19 @@ void generic_spi_flash_device::process_status_read_command(u8 data)
 
 	case 0x01:
 		LOGMASKED(LOG_SPI, "status read step 2\n");
-		m_spilatch = 0x00;
+		m_spi_latch = 0x00;
+		m_spi_state = READY_FOR_COMMAND;
+		break;
+	}
+}
+
+void generic_spi_flash_device::process_config_read_command(u8 data)
+{
+	switch (m_spi_state_step)
+	{
+	case 0x00:
+		LOGMASKED(LOG_SPI, "process_config_read_command\n");
+		m_spi_latch = m_spi_configreg;
 		m_spi_state = READY_FOR_COMMAND;
 		break;
 	}
@@ -306,7 +326,7 @@ void generic_spi_flash_device::process_status_read_command(u8 data)
 void generic_spi_flash_device::process_status2_read_command(u8 data)
 {
 	LOGMASKED(LOG_SPI, "status2 read\n");
-	m_spilatch = m_spi_statusreg;
+	m_spi_latch = m_spi_statusreg;
 	m_spi_state = READY_FOR_COMMAND;
 }
 
@@ -346,17 +366,17 @@ void generic_spi_flash_device::process_status_rdid_command(u8 data)
 	switch (m_spi_state_step)
 	{
 	case 0x00:
-		m_spilatch = m_idbytes[0];
+		m_spi_latch = m_idbytes[0];
 		m_spi_state_step++;
 		break;
 
 	case 0x01:
-		m_spilatch = m_idbytes[1];
+		m_spi_latch = m_idbytes[1];
 		m_spi_state_step++;
 		break;
 
 	case 0x02:
-		m_spilatch = m_idbytes[2];
+		m_spi_latch = m_idbytes[2];
 		//m_spi_state = READY_FOR_COMMAND; // loops on reading the ID?
 		break;
 	}
@@ -395,6 +415,7 @@ void generic_spi_flash_device::write(u8 data)
 		break;
 
 	case COMMAND_15_RDCR:
+		process_config_read_command(data);
 		break;
 
 	case COMMAND_20_SE:

--- a/src/devices/machine/generic_spi_flash.cpp
+++ b/src/devices/machine/generic_spi_flash.cpp
@@ -8,7 +8,7 @@
 
 #define LOG_SPI (1U << 1)
 
-#define VERBOSE     (0)
+#define VERBOSE     (LOG_SPI)
 
 #include "logmacro.h"
 
@@ -30,6 +30,7 @@ void generic_spi_flash_device::device_start()
 	save_item(NAME(m_spiaddr));
 	save_item(NAME(m_spi_state));
 	save_item(NAME(m_spilatch));
+	m_spi_statusreg = 0;
 }
 
 void generic_spi_flash_device::device_reset()
@@ -70,26 +71,59 @@ void generic_spi_flash_device::get_command(u8 data)
 	{
 		LOGMASKED(LOG_SPI, "Set SPI to WREN (Write Enable)\n");
 		m_spi_state = READY_FOR_COMMAND;
+		m_spi_statusreg |= 0x02;
 	}
 	else if (data == COMMAND_04_WRDI)
 	{
 		LOGMASKED(LOG_SPI, "Set SPI to WRDI (Write Disable)\n");
 		m_spi_state = READY_FOR_COMMAND;
+		m_spi_statusreg &= ~0x02;
 	}
 	else if (data == COMMAND_02_PP)
 	{
 		LOGMASKED(LOG_SPI, "Set SPI to PP (Page Program)\n");
 		m_spi_state = COMMAND_02_PP;
 	}
+	else if (data == COMMAND_11_UNKNOWN)
+	{
+		LOGMASKED(LOG_SPI, "Set SPI to COMMAND_11_UNKNOWN\n");
+		m_spi_state = COMMAND_11_UNKNOWN;
+	}
+	else if (data == COMMAND_15_RDCR)
+	{
+		LOGMASKED(LOG_SPI, "Set SPI to COMMAND_15_RDCR (Read Configuration Register)\n");
+		m_spi_state = COMMAND_15_RDCR;
+	}
 	else if (data == COMMAND_20_SE)
 	{
 		LOGMASKED(LOG_SPI, "Set SPI to SE (Sector Erase)\n");
 		m_spi_state = COMMAND_20_SE;
 	}
+	else if (data == COMMAND_31_UNKNOWN)
+	{
+		LOGMASKED(LOG_SPI, "Set SPI to COMMAND_31_UNKNOWN\n");
+		m_spi_state = COMMAND_31_UNKNOWN;
+	}
+	else if (data == COMMAND_35_RDSR2)
+	{
+		LOGMASKED(LOG_SPI, "Set SPI to COMMAND_35_RDSR2\n");
+		m_spi_state = COMMAND_35_RDSR2;
+	}
+	else if (data == COMMAND_66_ENABLE_RESET)
+	{
+		LOGMASKED(LOG_SPI, "Set SPI to ENABLE_RESET\n");
+		m_spi_state = READY_FOR_COMMAND;
+	}
 	else if (data == COMMAND_90_REMS)
 	{
 		LOGMASKED(LOG_SPI, "Set SPI to REMS (Read Electronic Manufacturer & Device ID)\n");
 		m_spi_state = COMMAND_90_REMS;
+	}
+	else if (data == COMMAND_99_RESET)
+	{
+		// must be issued after 66
+		LOGMASKED(LOG_SPI, "Set SPI to RESET\n");
+		m_spi_state = READY_FOR_COMMAND;
 	}
 	else if (data == COMMAND_AB_RDP)
 	{
@@ -105,6 +139,16 @@ void generic_spi_flash_device::get_command(u8 data)
 	{
 		LOGMASKED(LOG_SPI, "Set SPI to 4READ (Quad I/O read with configurable dummy bytes)\n");
 		m_spi_state = COMMAND_EB_4READ;
+	}
+	else if (data == COMMAND_EC_UNKNOWN)
+	{
+		LOGMASKED(LOG_SPI, "Set SPI to COMMAND_EC_UNKNOWN\n");
+		m_spi_state = COMMAND_EC_UNKNOWN;
+	}
+	else if (data == COMMAND_FF_CRMR)
+	{
+		LOGMASKED(LOG_SPI, "Set SPI to CRMR (Continuous Read Mode Reset)\n");
+		m_spi_state = READY_FOR_COMMAND;
 	}
 	else
 	{
@@ -243,7 +287,8 @@ void generic_spi_flash_device::process_status_read_command(u8 data)
 	{
 	case 0x00:
 		LOGMASKED(LOG_SPI, "status read step 1\n");
-		m_spilatch = 0x00;
+		m_spilatch = m_spi_statusreg;
+
 		if (m_multibyte_status_read != 0)
 			m_spi_state_step++;
 		else
@@ -258,6 +303,12 @@ void generic_spi_flash_device::process_status_read_command(u8 data)
 	}
 }
 
+void generic_spi_flash_device::process_status2_read_command(u8 data)
+{
+	LOGMASKED(LOG_SPI, "status2 read\n");
+	m_spilatch = m_spi_statusreg;
+	m_spi_state = READY_FOR_COMMAND;
+}
 
 void generic_spi_flash_device::process_status_rems_command(u8 data)
 {
@@ -306,7 +357,7 @@ void generic_spi_flash_device::process_status_rdid_command(u8 data)
 
 	case 0x02:
 		m_spilatch = m_idbytes[2];
-		m_spi_state = READY_FOR_COMMAND;
+		//m_spi_state = READY_FOR_COMMAND; // loops on reading the ID?
 		break;
 	}
 }
@@ -340,8 +391,21 @@ void generic_spi_flash_device::write(u8 data)
 		process_hsread_command(data);
 		break;
 
+	case COMMAND_11_UNKNOWN:
+		break;
+
+	case COMMAND_15_RDCR:
+		break;
+
 	case COMMAND_20_SE:
 		process_sector_erase_command(data);
+		break;
+
+	case COMMAND_31_UNKNOWN:
+		break;
+
+	case COMMAND_35_RDSR2:
+		process_status2_read_command(data);
 		break;
 
 	case COMMAND_90_REMS:
@@ -354,6 +418,9 @@ void generic_spi_flash_device::write(u8 data)
 
 	case COMMAND_EB_4READ:
 		process_read4_command(data);
+		break;
+
+	case COMMAND_EC_UNKNOWN:
 		break;
 	}
 }

--- a/src/devices/machine/generic_spi_flash.cpp
+++ b/src/devices/machine/generic_spi_flash.cpp
@@ -8,7 +8,7 @@
 
 #define LOG_SPI (1U << 1)
 
-#define VERBOSE     (LOG_SPI)
+#define VERBOSE     (0)
 
 #include "logmacro.h"
 

--- a/src/devices/machine/generic_spi_flash.h
+++ b/src/devices/machine/generic_spi_flash.h
@@ -16,7 +16,7 @@ public:
 
 	u8 read()
 	{
-		return m_spilatch;
+		return m_spi_latch;
 	}
 
 	void set_ready()
@@ -97,12 +97,14 @@ private:
 	void process_status_read_command(u8 data);
 	void process_status2_read_command(u8 data);
 	void process_status_rdid_command(u8 data);
+	void process_config_read_command(u8 data);
 
-	u32 m_spiaddr;
+	u32 m_spi_addr;
 	u8 m_spi_state;
-	u8 m_spilatch;
+	u8 m_spi_latch;
 	u8 m_spi_state_step;
 	u8 m_spi_statusreg;
+	u8 m_spi_configreg;
 
 	// config
 	u8 *m_spiptr;

--- a/src/devices/machine/generic_spi_flash.h
+++ b/src/devices/machine/generic_spi_flash.h
@@ -29,6 +29,11 @@ public:
 	void set_single_byte_status_read() { m_multibyte_status_read = 0; };
 	void set_single_byte_status_writes() { m_multibyte_status_write = 0; };
 
+	void set_jedec_manufacturer(u8 byte) { m_idbytes[0] = byte; }
+	void set_jedec_memtype(u8 byte) { m_idbytes[1] = byte; }
+	void set_jedec_capacity(u8 byte) { m_idbytes[2] = byte; }
+
+
 protected:
 	// device-level overrides
 	virtual void device_start() override ATTR_COLD;
@@ -53,9 +58,22 @@ private:
 
 		COMMAND_0B_FAST_READ = 0x0b,
 
+		COMMAND_11_UNKNOWN = 0x11, // wiwcs
+
+		COMMAND_15_RDCR = 0x15,
+
 		COMMAND_20_SE = 0x20,
 
+		COMMAND_31_UNKNOWN = 0x31,
+
+		COMMAND_35_RDSR2 = 0x35,
+
+		COMMAND_66_ENABLE_RESET = 0x66,
+
 		COMMAND_90_REMS = 0x90,
+
+		COMMAND_99_RESET = 0x99,
+
 		COMMAND_9F_RDID = 0x9f,
 
 		COMMAND_AB_RDP = 0xab,
@@ -63,6 +81,9 @@ private:
 		COMMAND_B9_DP = 0xb9,
 
 		COMMAND_EB_4READ = 0xeb,
+
+		COMMAND_EC_UNKNOWN = 0xec,
+		COMMAND_FF_CRMR = 0xff,
 	};
 
 	void get_command(u8 data);
@@ -74,12 +95,14 @@ private:
 	void process_status_write_command(u8 data);
 	void process_status_rems_command(u8 data);
 	void process_status_read_command(u8 data);
+	void process_status2_read_command(u8 data);
 	void process_status_rdid_command(u8 data);
 
 	u32 m_spiaddr;
 	u8 m_spi_state;
 	u8 m_spilatch;
 	u8 m_spi_state_step;
+	u8 m_spi_statusreg;
 
 	// config
 	u8 *m_spiptr;

--- a/src/mame/tvgames/generalplus_gpl16250.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250.cpp
@@ -90,7 +90,7 @@ void gcm394_game_state::cs3_w(offs_t offset, u16 data) { logerror("cs3_w %06x %0
 u16 gcm394_game_state::cs4_r(offs_t offset) { logerror("cs4_r %06n", offset); return 0x0000; }
 void gcm394_game_state::cs4_w(offs_t offset, u16 data) { logerror("cs4_w %06x %04x\n", offset, data); }
 
-void gcm394_game_state::cs_map_base(address_map& map)
+void gcm394_game_state::cs_map_base(address_map &map)
 {
 }
 

--- a/src/mame/tvgames/generalplus_gpl16250.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250.cpp
@@ -71,51 +71,51 @@
 #include "generalplus_gpl16250.h"
 
 
-uint16_t gcm394_game_state::cs0_r(offs_t offset)
+u16 gcm394_game_state::cs0_r(offs_t offset)
 {
 	return m_romregion[offset & 0x3fffff];
 }
 
-void gcm394_game_state::cs0_w(offs_t offset, uint16_t data)
+void gcm394_game_state::cs0_w(offs_t offset, u16 data)
 {
 	logerror("cs0_w %04x %04x (to ROM!)\n", offset, data);
 }
 
-uint16_t gcm394_game_state::cs1_r(offs_t offset) { logerror("cs1_r %06n", offset); return 0x0000; }
-void gcm394_game_state::cs1_w(offs_t offset, uint16_t data) { logerror("cs1_w %06x %04x\n", offset, data); }
-uint16_t gcm394_game_state::cs2_r(offs_t offset) { logerror("cs2_r %06n", offset); return 0x0000; }
-void gcm394_game_state::cs2_w(offs_t offset, uint16_t data) { logerror("cs2_w %06x %04x\n", offset, data); }
-uint16_t gcm394_game_state::cs3_r(offs_t offset) { logerror("cs3_r %06n", offset); return 0x0000; }
-void gcm394_game_state::cs3_w(offs_t offset, uint16_t data) { logerror("cs3_w %06x %04x\n", offset, data); }
-uint16_t gcm394_game_state::cs4_r(offs_t offset) { logerror("cs4_r %06n", offset); return 0x0000; }
-void gcm394_game_state::cs4_w(offs_t offset, uint16_t data) { logerror("cs4_w %06x %04x\n", offset, data); }
+u16 gcm394_game_state::cs1_r(offs_t offset) { logerror("cs1_r %06n", offset); return 0x0000; }
+void gcm394_game_state::cs1_w(offs_t offset, u16 data) { logerror("cs1_w %06x %04x\n", offset, data); }
+u16 gcm394_game_state::cs2_r(offs_t offset) { logerror("cs2_r %06n", offset); return 0x0000; }
+void gcm394_game_state::cs2_w(offs_t offset, u16 data) { logerror("cs2_w %06x %04x\n", offset, data); }
+u16 gcm394_game_state::cs3_r(offs_t offset) { logerror("cs3_r %06n", offset); return 0x0000; }
+void gcm394_game_state::cs3_w(offs_t offset, u16 data) { logerror("cs3_w %06x %04x\n", offset, data); }
+u16 gcm394_game_state::cs4_r(offs_t offset) { logerror("cs4_r %06n", offset); return 0x0000; }
+void gcm394_game_state::cs4_w(offs_t offset, u16 data) { logerror("cs4_w %06x %04x\n", offset, data); }
 
 void gcm394_game_state::cs_map_base(address_map& map)
 {
 }
 
-uint16_t gcm394_game_state::porta_r()
+u16 gcm394_game_state::porta_r()
 {
-	uint16_t data = m_io[0]->read();
+	u16 data = m_io[0]->read();
 	logerror("Port A Read: %04x\n", data);
 	return data;
 }
 
-uint16_t gcm394_game_state::portb_r()
+u16 gcm394_game_state::portb_r()
 {
-	uint16_t data = m_io[1]->read();
+	u16 data = m_io[1]->read();
 	logerror("Port B Read: %04x\n", data);
 	return data;
 }
 
-uint16_t gcm394_game_state::portc_r()
+u16 gcm394_game_state::portc_r()
 {
-	uint16_t data = m_io[2]->read();
+	u16 data = m_io[2]->read();
 	logerror("Port C Read: %04x\n", data);
 	return data;
 }
 
-void gcm394_game_state::porta_w(uint16_t data)
+void gcm394_game_state::porta_w(u16 data)
 {
 	logerror("%s: Port A:WRITE %04x\n", machine().describe_context(), data);
 }
@@ -177,7 +177,7 @@ device_memory_interface::space_config_vector gcm394_game_state::memory_space_con
 	return space_config_vector{ std::make_pair(0, &m_full_mem_config) };
 }
 
-void gcm394_game_state::cs_callback(uint16_t cs0, uint16_t cs1, uint16_t cs2, uint16_t cs3, uint16_t cs4)
+void gcm394_game_state::cs_callback(u16 cs0, u16 cs1, u16 cs2, u16 cs3, u16 cs4)
 {
 	address_space &external = space(0);
 

--- a/src/mame/tvgames/generalplus_gpl16250.h
+++ b/src/mame/tvgames/generalplus_gpl16250.h
@@ -7,7 +7,6 @@
 
 #include "bus/generic/carts.h"
 #include "bus/generic/slot.h"
-#include "machine/generalplus_gpl951xx_soc.h"
 #include "machine/generalplus_gpl1625x_soc.h"
 
 #include "screen.h"

--- a/src/mame/tvgames/generalplus_gpl16250.h
+++ b/src/mame/tvgames/generalplus_gpl16250.h
@@ -17,7 +17,7 @@
 class gcm394_game_state : public driver_device, public device_memory_interface
 {
 public:
-	gcm394_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+	gcm394_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		device_memory_interface(mconfig, *this),
 		m_maincpu(*this, "maincpu"),
@@ -33,18 +33,18 @@ public:
 
 	void cs_map_base(address_map &map) ATTR_COLD;
 
-	virtual uint16_t cs0_r(offs_t offset);
-	virtual void cs0_w(offs_t offset, uint16_t data);
-	virtual uint16_t cs1_r(offs_t offset);
-	virtual void cs1_w(offs_t offset, uint16_t data);
-	virtual uint16_t cs2_r(offs_t offset);
-	virtual void cs2_w(offs_t offset, uint16_t data);
-	virtual uint16_t cs3_r(offs_t offset);
-	virtual void cs3_w(offs_t offset, uint16_t data);
-	virtual uint16_t cs4_r(offs_t offset);
-	virtual void cs4_w(offs_t offset, uint16_t data);
+	virtual u16 cs0_r(offs_t offset);
+	virtual void cs0_w(offs_t offset, u16 data);
+	virtual u16 cs1_r(offs_t offset);
+	virtual void cs1_w(offs_t offset, u16 data);
+	virtual u16 cs2_r(offs_t offset);
+	virtual void cs2_w(offs_t offset, u16 data);
+	virtual u16 cs3_r(offs_t offset);
+	virtual void cs3_w(offs_t offset, u16 data);
+	virtual u16 cs4_r(offs_t offset);
+	virtual void cs4_w(offs_t offset, u16 data);
 
-	void cs_callback(uint16_t cs0, uint16_t cs1, uint16_t cs2, uint16_t cs3, uint16_t cs4);
+	void cs_callback(u16 cs0, u16 cs1, u16 cs2, u16 cs3, u16 cs4);
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
@@ -52,13 +52,13 @@ protected:
 
 	virtual space_config_vector memory_space_config() const override ATTR_COLD;
 
-	virtual uint16_t porta_r();
-	virtual uint16_t portb_r();
-	virtual uint16_t portc_r();
-	virtual void porta_w(uint16_t data);
+	virtual u16 porta_r();
+	virtual u16 portb_r();
+	virtual u16 portc_r();
+	virtual void porta_w(u16 data);
 
-	virtual uint16_t read_external_space(offs_t offset) { return m_memory.read_word(offset); }
-	virtual void write_external_space(offs_t offset, uint16_t data) { m_memory.write_word(offset, data); }
+	virtual u16 read_external_space(offs_t offset) { return m_memory.read_word(offset); }
+	virtual void write_external_space(offs_t offset, u16 data) { m_memory.write_word(offset, data); }
 
 	memory_access<32, 1, -1, ENDIANNESS_BIG>::specific m_memory;
 
@@ -67,7 +67,7 @@ protected:
 
 	required_ioport_array<3> m_io;
 
-	optional_region_ptr<uint16_t> m_romregion;
+	optional_region_ptr<u16> m_romregion;
 
 	const address_space_config m_full_mem_config;
 };

--- a/src/mame/tvgames/generalplus_gpl16250_mobigo.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_mobigo.cpp
@@ -82,7 +82,7 @@ INPUT_PORTS_END
 
 DEVICE_IMAGE_LOAD_MEMBER(mobigo2_state::cart_load)
 {
-	uint32_t const size = m_cart->common_get_size("rom");
+	u32 const size = m_cart->common_get_size("rom");
 	m_cart->rom_alloc(size, GENERIC_ROM16_WIDTH, ENDIANNESS_LITTLE);
 	m_cart->common_load_rom(m_cart->get_rom_base(), size, "rom");
 	return std::make_pair(std::error_condition(), std::string());
@@ -90,7 +90,7 @@ DEVICE_IMAGE_LOAD_MEMBER(mobigo2_state::cart_load)
 
 DEVICE_IMAGE_LOAD_MEMBER(mobigo_state::cart_load)
 {
-	uint32_t const size = m_cart->common_get_size("rom");
+	u32 const size = m_cart->common_get_size("rom");
 	m_cart->rom_alloc(size, GENERIC_ROM16_WIDTH, ENDIANNESS_LITTLE);
 	m_cart->common_load_rom(m_cart->get_rom_base(), size, "rom");
 	return std::make_pair(std::error_condition(), std::string());

--- a/src/mame/tvgames/generalplus_gpl16250_nand.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_nand.cpp
@@ -31,27 +31,27 @@
 #include "generalplus_gpl16250_nand.h"
 #include "softlist_dev.h"
 
-uint16_t generalplus_gpac800_game_state::cs0_r(offs_t offset)
+u16 generalplus_gpac800_game_state::cs0_r(offs_t offset)
 {
 	return m_sdram2[offset & 0xffff];
 }
 
-void generalplus_gpac800_game_state::cs0_w(offs_t offset, uint16_t data)
+void generalplus_gpac800_game_state::cs0_w(offs_t offset, u16 data)
 {
 	m_sdram2[offset & 0xffff] = data;
 }
 
-uint16_t generalplus_gpac800_game_state::cs1_r(offs_t offset)
+u16 generalplus_gpac800_game_state::cs1_r(offs_t offset)
 {
 	return m_sdram[offset & (m_sdram_kwords-1)];
 }
 
-void generalplus_gpac800_game_state::cs1_w(offs_t offset, uint16_t data)
+void generalplus_gpac800_game_state::cs1_w(offs_t offset, u16 data)
 {
 	m_sdram[offset & (m_sdram_kwords-1)] = data;
 }
 
-uint8_t generalplus_gpac800_game_state::read_nand(offs_t offset)
+u8 generalplus_gpac800_game_state::read_nand(offs_t offset)
 {
 	if (!m_nandregion)
 		return 0x0000;
@@ -132,7 +132,7 @@ void generalplus_gpac800_game_state::generalplus_gpac800(machine_config &config)
 
 DEVICE_IMAGE_LOAD_MEMBER(generalplus_gpac800_vbaby_game_state::cart_load)
 {
-	uint32_t const size = m_cart->common_get_size("rom");
+	u32 const size = m_cart->common_get_size("rom");
 
 	m_cart->rom_alloc(size, GENERIC_ROM16_WIDTH, ENDIANNESS_LITTLE);
 	m_cart->common_load_rom(m_cart->get_rom_base(), size, "rom");
@@ -715,7 +715,7 @@ void generalplus_gpac800_game_state::machine_start()
 
 void generalplus_gpac800_game_state::nand_create_stripped_region()
 {
-	uint8_t* rom = m_nandregion;
+	u8* rom = m_nandregion;
 	int size = memregion("nandrom")->bytes();
 	m_size = size;
 
@@ -786,7 +786,7 @@ void generalplus_gpac800_game_state::machine_reset()
 		// copy a block of code from the NAND to RAM
 		for (int i = 0; i < m_initial_copy_words; i++)
 		{
-			uint16_t word = m_strippedrom[(i * 2) + 0] | (m_strippedrom[(i * 2) + 1] << 8);
+			u16 word = m_strippedrom[(i * 2) + 0] | (m_strippedrom[(i * 2) + 1] << 8);
 
 			mem.write_word(dest + i, word);
 		}
@@ -797,7 +797,7 @@ void generalplus_gpac800_game_state::machine_reset()
 		   so these must trampoline (although 20xxx currently isn't handled as RAM, so that needs more
 		   thought anyway
 		*/
-		uint16_t* internal = (uint16_t*)memregion("maincpu:internal")->base();
+		u16* internal = (u16*)memregion("maincpu:internal")->base();
 
 		int addr;
 		addr = (m_vectorbase + 0x0a) & 0x000fffff;

--- a/src/mame/tvgames/generalplus_gpl16250_nand.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_nand.cpp
@@ -74,7 +74,7 @@ void generalplus_gpac800_game_state::dma_complete_hacks(int state)
 
 	// note, these patch the code copied to SRAM so the 'PROGRAM ROM' check fails (it passes otherwise)
 
-	address_space& mem = m_maincpu->space(AS_PROGRAM);
+	address_space &mem = m_maincpu->space(AS_PROGRAM);
 
 	//if (mem.read_word(0x4368c) == 0x4846)
 	//  mem.write_word(0x4368c, 0x4840);    // cars 2 force service mode
@@ -715,7 +715,7 @@ void generalplus_gpac800_game_state::machine_start()
 
 void generalplus_gpac800_game_state::nand_create_stripped_region()
 {
-	u8* rom = m_nandregion;
+	u8 *rom = m_nandregion;
 	int size = memregion("nandrom")->bytes();
 	m_size = size;
 
@@ -750,7 +750,7 @@ void generalplus_gpac800_game_state::nand_create_stripped_region()
 void generalplus_gpac800_game_state::machine_reset()
 {
 	// configure CS defaults
-	address_space& mem = m_maincpu->space(AS_PROGRAM);
+	address_space &mem = m_maincpu->space(AS_PROGRAM);
 	mem.write_word(0x007820, 0x0047);
 	mem.write_word(0x007821, 0xff47);
 	mem.write_word(0x007822, 0x00c7);
@@ -767,7 +767,7 @@ void generalplus_gpac800_game_state::machine_reset()
 
 		// simulate bootstrap / internal ROM
 
-		address_space& mem = m_maincpu->space(AS_PROGRAM);
+		address_space &mem = m_maincpu->space(AS_PROGRAM);
 
 		/* Offset(h) 00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
 		   00000000 (50 47 61 6E 64 6E 61 6E 64 6E)-- -- -- -- -- --  PGandnandn------
@@ -797,7 +797,7 @@ void generalplus_gpac800_game_state::machine_reset()
 		   so these must trampoline (although 20xxx currently isn't handled as RAM, so that needs more
 		   thought anyway
 		*/
-		u16* internal = (u16*)memregion("maincpu:internal")->base();
+		u16 *internal = (u16*)memregion("maincpu:internal")->base();
 
 		int addr;
 		addr = (m_vectorbase + 0x0a) & 0x000fffff;

--- a/src/mame/tvgames/generalplus_gpl16250_nand.h
+++ b/src/mame/tvgames/generalplus_gpl16250_nand.h
@@ -18,7 +18,7 @@
 class generalplus_gpac800_game_state : public gcm394_game_state
 {
 public:
-	generalplus_gpac800_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+	generalplus_gpac800_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		gcm394_game_state(mconfig, type, tag),
 		m_nandregion(*this, "nandrom"),
 		m_sdram_kwords(0x400000), // 0x400000 words (0x800000 bytes)
@@ -41,24 +41,24 @@ protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
-	uint8_t read_nand(offs_t offset);
+	u8 read_nand(offs_t offset);
 
-	virtual uint16_t cs0_r(offs_t offset) override;
-	virtual void cs0_w(offs_t offset, uint16_t data) override;
-	virtual uint16_t cs1_r(offs_t offset) override;
-	virtual void cs1_w(offs_t offset, uint16_t data) override;
+	virtual u16 cs0_r(offs_t offset) override;
+	virtual void cs0_w(offs_t offset, u16 data) override;
+	virtual u16 cs1_r(offs_t offset) override;
+	virtual void cs1_w(offs_t offset, u16 data) override;
 
-	std::vector<uint16_t> m_sdram;
-	std::vector<uint16_t> m_sdram2;
+	std::vector<u16> m_sdram;
+	std::vector<u16> m_sdram2;
 
 private:
 	void nand_create_stripped_region();
 
 	void dma_complete_hacks(int state);
 
-	optional_region_ptr<uint8_t> m_nandregion;
+	optional_region_ptr<u8> m_nandregion;
 
-	std::vector<uint8_t> m_strippedrom;
+	std::vector<u8> m_strippedrom;
 	int m_strippedsize = 0;
 	int m_size = 0;
 	int m_nandblocksize = 0;
@@ -73,7 +73,7 @@ private:
 class generalplus_gpac800_vbaby_game_state : public generalplus_gpac800_game_state
 {
 public:
-	generalplus_gpac800_vbaby_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+	generalplus_gpac800_vbaby_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		generalplus_gpac800_game_state(mconfig, type, tag),
 		m_cart(*this, "cartslot")
 	{

--- a/src/mame/tvgames/generalplus_gpl16250_rom.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_rom.cpp
@@ -21,7 +21,7 @@ namespace {
 class tkmag220_game_state : public gcm394_game_state
 {
 public:
-	tkmag220_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+	tkmag220_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		gcm394_game_state(mconfig, type, tag)
 	{
 	}
@@ -32,9 +32,9 @@ protected:
 	virtual void machine_reset() override ATTR_COLD;
 
 private:
-	virtual uint16_t cs0_r(offs_t offset) override;
+	virtual u16 cs0_r(offs_t offset) override;
 
-	void tkmag220_portd_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void tkmag220_portd_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
 	int m_upperbase = 0;
 };
@@ -43,7 +43,7 @@ private:
 class beijuehh_game_state : public gcm394_game_state
 {
 public:
-	beijuehh_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+	beijuehh_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		gcm394_game_state(mconfig, type, tag)
 	{
 	}
@@ -54,28 +54,28 @@ protected:
 	virtual void machine_reset() override ATTR_COLD;
 
 private:
-	virtual uint16_t cs0_r(offs_t offset) override;
+	virtual u16 cs0_r(offs_t offset) override;
 
-	void beijuehh_portb_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void beijuehh_portd_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void beijuehh_portb_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void beijuehh_portd_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
 	int m_upperbase = 0;
 
-	uint16_t m_portb_data = 0U;
-	uint16_t m_portd_data = 0U;
-	uint8_t m_bank = 0U;
+	u16 m_portb_data = 0U;
+	u16 m_portd_data = 0U;
+	u8 m_bank = 0U;
 };
 
 
 class gameu_handheld_game_state : public gcm394_game_state
 {
 public:
-	gameu_handheld_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+	gameu_handheld_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		gcm394_game_state(mconfig, type, tag)
 	{
 	}
 
-	virtual uint16_t cs0_r(offs_t offset) override;
+	virtual u16 cs0_r(offs_t offset) override;
 
 	void gameu(machine_config &config) ATTR_COLD;
 
@@ -88,16 +88,16 @@ protected:
 	virtual void machine_reset() override ATTR_COLD;
 
 private:
-	void gameu_porta_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void gameu_portb_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void gameu_portc_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void gameu_portd_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void gameu_porta_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void gameu_portb_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void gameu_portc_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void gameu_portd_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
-	uint32_t m_upperbase;
-	uint16_t m_porta_data;
-	uint16_t m_portb_data;
-	uint16_t m_portc_data;
-	uint16_t m_portd_data;
+	u32 m_upperbase;
+	u16 m_porta_data;
+	u16 m_portb_data;
+	u16 m_portc_data;
+	u16 m_portd_data;
 };
 
 
@@ -547,7 +547,7 @@ void tkmag220_game_state::tkmag220(machine_config &config)
 	m_maincpu->portd_out().set(FUNC(tkmag220_game_state::tkmag220_portd_w));
 }
 
-void tkmag220_game_state::tkmag220_portd_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void tkmag220_game_state::tkmag220_portd_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (m_maincpu->pc() < 0x10000)
 	{
@@ -565,7 +565,7 @@ void tkmag220_game_state::tkmag220_portd_w(offs_t offset, uint16_t data, uint16_
 }
 
 
-uint16_t tkmag220_game_state::cs0_r(offs_t offset)
+u16 tkmag220_game_state::cs0_r(offs_t offset)
 {
 	// [:] installing cs0 handler start_address 00000000 end_address 007fffff
 	return m_romregion[(offset & 0x07fffff) + m_upperbase];
@@ -600,7 +600,7 @@ void beijuehh_game_state::beijuehh(machine_config &config)
 }
 
 
-void beijuehh_game_state::beijuehh_portb_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void beijuehh_game_state::beijuehh_portb_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (m_maincpu->pc() < 0xf000)
 	{
@@ -623,7 +623,7 @@ void beijuehh_game_state::beijuehh_portb_w(offs_t offset, uint16_t data, uint16_
 }
 
 
-void beijuehh_game_state::beijuehh_portd_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void beijuehh_game_state::beijuehh_portd_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (m_maincpu->pc() < 0xf000)
 	{
@@ -646,7 +646,7 @@ void beijuehh_game_state::beijuehh_portd_w(offs_t offset, uint16_t data, uint16_
 }
 
 
-uint16_t beijuehh_game_state::cs0_r(offs_t offset)
+u16 beijuehh_game_state::cs0_r(offs_t offset)
 {
 	// [:] installing cs0 handler start_address 00000000 end_address 003fffff
 	return m_romregion[(offset & 0x03fffff) + m_upperbase];
@@ -690,30 +690,30 @@ void gameu_handheld_game_state::gameu(machine_config &config)
 	m_screen->set_visarea(0, (160)-1, 0, (128)-1); // appears to be the correct resolution for the LCD panel
 }
 
-uint16_t gameu_handheld_game_state::cs0_r(offs_t offset)
+u16 gameu_handheld_game_state::cs0_r(offs_t offset)
 {
 	return m_romregion[(offset & 0x00fffff) + m_upperbase];
 }
 
-void gameu_handheld_game_state::gameu_porta_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void gameu_handheld_game_state::gameu_porta_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	logerror("%s: porta write %04x\n", machine().describe_context(), data);
 	m_porta_data = data;
 }
 
-void gameu_handheld_game_state::gameu_portb_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void gameu_handheld_game_state::gameu_portb_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	logerror("%s: portb write %04x\n", machine().describe_context(), data);
 	m_portb_data = data;
 }
 
-void gameu_handheld_game_state::gameu_portc_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void gameu_handheld_game_state::gameu_portc_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	logerror("%s: portc write %04x\n", machine().describe_context(), data);
 	m_portc_data = data;
 }
 
-void gameu_handheld_game_state::gameu_portd_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void gameu_handheld_game_state::gameu_portd_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	// hacky, maybe we need better direction/attribute handling on the ports in the core?
 	m_portd_data = data;
@@ -722,7 +722,7 @@ void gameu_handheld_game_state::gameu_portd_w(offs_t offset, uint16_t data, uint
 	{
 		logerror("%s: portd write %04x %04x\n", machine().describe_context(), data, mem_mask);
 
-		uint8_t bank = (data & 0xfc00) >> 10;
+		u8 bank = (data & 0xfc00) >> 10;
 		m_upperbase = bank * 0x40000;
 	}
 
@@ -752,7 +752,7 @@ void gameu_handheld_game_state::machine_reset()
 
 void gameu_handheld_game_state::init_gameu()
 {
-	uint16_t *ROM = (uint16_t*)memregion("maincpu")->base();
+	u16 *ROM = (u16*)memregion("maincpu")->base();
 	int size = memregion("maincpu")->bytes();
 
 	for (int i = 0; i < size/2; i++)
@@ -771,7 +771,7 @@ void gameu_handheld_game_state::init_gameu50()
 	init_gameu();
 
 	// why do we need these? it will jump to 0 after the menu selection (prior to fadeout and bank select) otherwise, which can't be correct
-	uint16_t *ROM = (uint16_t*)memregion("maincpu")->base();
+	u16 *ROM = (u16*)memregion("maincpu")->base();
 	int base = 0x19c9a;
 	ROM[(base + 0x00) / 2] = 0xf165;
 	ROM[(base + 0x02) / 2] = 0xf165;
@@ -790,7 +790,7 @@ void gameu_handheld_game_state::init_gameu108()
 {
 	init_gameu();
 
-	uint16_t *ROM = (uint16_t*)memregion("maincpu")->base();
+	u16 *ROM = (u16*)memregion("maincpu")->base();
 
 	// why do we need these? it will jump to 0 after the menu selection (prior to fadeout and bank select) otherwise, which can't be correct
 	ROM[(0x1aa48) / 2] = 0xf165;

--- a/src/mame/tvgames/generalplus_gpl16250_romram.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_romram.cpp
@@ -282,23 +282,23 @@ static INPUT_PORTS_START( jak_ths )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 INPUT_PORTS_END
 
-uint16_t wrlshunt_game_state::cs0_r(offs_t offset)
+u16 wrlshunt_game_state::cs0_r(offs_t offset)
 {
 	return m_romregion[offset & m_romwords_mask];
 }
 
-void wrlshunt_game_state::cs0_w(offs_t offset, uint16_t data)
+void wrlshunt_game_state::cs0_w(offs_t offset, u16 data)
 {
 	logerror("cs0_w write to ROM?\n");
 	//m_romregion[offset & 0x3ffffff] = data;
 }
 
-uint16_t wrlshunt_game_state::cs1_r(offs_t offset)
+u16 wrlshunt_game_state::cs1_r(offs_t offset)
 {
 	return m_sdram[offset & 0x3fffff];
 }
 
-void wrlshunt_game_state::cs1_w(offs_t offset, uint16_t data)
+void wrlshunt_game_state::cs1_w(offs_t offset, u16 data)
 {
 	m_sdram[offset & 0x3fffff] = data;
 }
@@ -335,14 +335,14 @@ void wrlshunt_game_state::gpl16250_romram(machine_config &config)
 	gcm394_game_state::base(config);
 }
 
-uint16_t wrlshunt_game_state::porta_r()
+u16 wrlshunt_game_state::porta_r()
 {
-	uint16_t data = m_io[0]->read();
+	u16 data = m_io[0]->read();
 	logerror("%s: Port A Read: %04x\n",  machine().describe_context(), data);
 	return data;
 }
 
-void wrlshunt_game_state::porta_w(uint16_t data)
+void wrlshunt_game_state::porta_w(u16 data)
 {
 	logerror("%s: Port A:WRITE %04x\n", machine().describe_context(), data);
 
@@ -355,9 +355,9 @@ void wrlshunt_game_state::porta_w(uint16_t data)
 
 
 
-uint16_t jak_s500_game_state::porta_r()
+u16 jak_s500_game_state::porta_r()
 {
-	uint16_t data = m_io[0]->read();
+	u16 data = m_io[0]->read();
 	logerror("%s: Port A Read: %04x\n", machine().describe_context(), data);
 
 	// these are debug helpers to access the test modes while we don't have the
@@ -383,9 +383,9 @@ uint16_t jak_s500_game_state::porta_r()
 	return data;
 }
 
-uint16_t jak_s500_game_state::portb_r()
+u16 jak_s500_game_state::portb_r()
 {
-	uint16_t data = m_io[1]->read();
+	u16 data = m_io[1]->read();
 	logerror("%s: Port B Read: %04x\n", machine().describe_context(), data);
 	return data;
 }
@@ -426,7 +426,7 @@ void jak_prft_game_state::machine_reset()
 }
 
 
-uint16_t paccon_game_state::paccon_speedup_hack_r()
+u16 paccon_game_state::paccon_speedup_hack_r()
 {
 	u32 const pc = m_maincpu->pc();
 	if (pc == 0x30033)
@@ -434,7 +434,7 @@ uint16_t paccon_game_state::paccon_speedup_hack_r()
 	return m_maincpu->get_ram_addr(0x6593);
 }
 
-uint16_t jak_pf_game_state::jak_pf_speedup_hack_r()
+u16 jak_pf_game_state::jak_pf_speedup_hack_r()
 {
 	u32 const pc = m_maincpu->pc();
 	if (pc == 0x30010)
@@ -442,7 +442,7 @@ uint16_t jak_pf_game_state::jak_pf_speedup_hack_r()
 	return m_maincpu->get_ram_addr(0x0001);
 }
 
-uint16_t jak_pf_game_state::jak_pf_speedup_hack2_r()
+u16 jak_pf_game_state::jak_pf_speedup_hack2_r()
 {
 	u32 const pc = m_maincpu->pc();
 	if (pc == 0x2611b4)

--- a/src/mame/tvgames/generalplus_gpl16250_romram.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_romram.cpp
@@ -347,7 +347,7 @@ void wrlshunt_game_state::porta_w(u16 data)
 	logerror("%s: Port A:WRITE %04x\n", machine().describe_context(), data);
 
 	// HACK
-	address_space& mem = m_maincpu->space(AS_PROGRAM);
+	address_space &mem = m_maincpu->space(AS_PROGRAM);
 	if (mem.read_word(0x5b354) == 0xafd0)   // wrlshubt - skip check (EEPROM?)
 		mem.write_word(0x5b354, 0xB403);
 }
@@ -363,7 +363,7 @@ u16 jak_s500_game_state::porta_r()
 	// these are debug helpers to access the test modes while we don't have the
 	// secret codes / controls mapped properly
 
-	//address_space& mem = m_maincpu->space(AS_PROGRAM);
+	//address_space &mem = m_maincpu->space(AS_PROGRAM);
 
 	//if (mem.read_word(0x22b408) == 0x4846)
 	//  mem.write_word(0x22b408, 0x4840);    // jak_s500 force service mode

--- a/src/mame/tvgames/generalplus_gpl16250_romram.h
+++ b/src/mame/tvgames/generalplus_gpl16250_romram.h
@@ -18,7 +18,7 @@
 class wrlshunt_game_state : public gcm394_game_state
 {
 public:
-	wrlshunt_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+	wrlshunt_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		gcm394_game_state(mconfig, type, tag)
 	{
 	}
@@ -32,16 +32,16 @@ protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
-	virtual uint16_t porta_r() override;
-	virtual void porta_w(uint16_t data) override;
+	virtual u16 porta_r() override;
+	virtual void porta_w(u16 data) override;
 
-	std::vector<uint16_t> m_sdram;
+	std::vector<u16> m_sdram;
 
 private:
-	virtual uint16_t cs0_r(offs_t offset) override;
-	virtual void cs0_w(offs_t offset, uint16_t data) override;
-	virtual uint16_t cs1_r(offs_t offset) override;
-	virtual void cs1_w(offs_t offset, uint16_t data) override;
+	virtual u16 cs0_r(offs_t offset) override;
+	virtual void cs0_w(offs_t offset, u16 data) override;
+	virtual u16 cs1_r(offs_t offset) override;
+	virtual void cs1_w(offs_t offset, u16 data) override;
 
 	//required_shared_ptr<u16> m_mainram;
 
@@ -51,7 +51,7 @@ private:
 class jak_s500_game_state : public wrlshunt_game_state
 {
 public:
-	jak_s500_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+	jak_s500_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		wrlshunt_game_state(mconfig, type, tag)
 	{
 	}
@@ -59,14 +59,14 @@ public:
 protected:
 	virtual void machine_reset() override ATTR_COLD;
 
-	virtual uint16_t porta_r() override;
-	virtual uint16_t portb_r() override;
+	virtual u16 porta_r() override;
+	virtual u16 portb_r() override;
 };
 
 class lazertag_game_state : public jak_s500_game_state
 {
 public:
-	lazertag_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+	lazertag_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		jak_s500_game_state(mconfig, type, tag)
 	{
 	}
@@ -79,7 +79,7 @@ protected:
 class paccon_game_state : public jak_s500_game_state
 {
 public:
-	paccon_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+	paccon_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		jak_s500_game_state(mconfig, type, tag)
 	{
 	}
@@ -88,13 +88,13 @@ protected:
 	virtual void machine_reset() override ATTR_COLD;
 
 private:
-	uint16_t paccon_speedup_hack_r();
+	u16 paccon_speedup_hack_r();
 };
 
 class jak_pf_game_state : public jak_s500_game_state
 {
 public:
-	jak_pf_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+	jak_pf_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		jak_s500_game_state(mconfig, type, tag)
 	{
 	}
@@ -103,15 +103,15 @@ protected:
 	virtual void machine_reset() override ATTR_COLD;
 
 private:
-	uint16_t jak_pf_speedup_hack_r();
-	uint16_t jak_pf_speedup_hack2_r();
+	u16 jak_pf_speedup_hack_r();
+	u16 jak_pf_speedup_hack2_r();
 };
 
 
 class jak_prft_game_state : public jak_s500_game_state
 {
 public:
-	jak_prft_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+	jak_prft_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		jak_s500_game_state(mconfig, type, tag)
 	{
 	}

--- a/src/mame/tvgames/generalplus_gpl16250_spi.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_spi.cpp
@@ -266,9 +266,9 @@ ROM_END
 void generalplus_gpspispi_game_state::init_spi()
 {
 	int vectorbase = 0x2fe0;
-	u8* spirom = memregion("maincpu")->base();
+	u8 *spirom = memregion("maincpu")->base();
 
-	address_space& mem = m_maincpu->space(AS_PROGRAM);
+	address_space &mem = m_maincpu->space(AS_PROGRAM);
 
 	/*  Offset(h) 00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
 
@@ -295,7 +295,7 @@ void generalplus_gpspispi_game_state::init_spi()
 	}
 
 	// these vectors must either directly point to RAM, or at least redirect there after some code
-	u16* internal = (u16*)memregion("maincpu:internal")->base();
+	u16 *internal = (u16*)memregion("maincpu:internal")->base();
 	internal[0x7ff5] = vectorbase + 0x0a;
 	internal[0x7ff6] = vectorbase + 0x0c;
 	internal[0x7ff7] = dest + 0x20; // point boot vector at code in RAM (probably in reality points to internal code that copies the first block)

--- a/src/mame/tvgames/generalplus_gpl16250_spi.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_spi.cpp
@@ -17,7 +17,7 @@ namespace {
 class generalplus_gpspispi_game_state : public gcm394_game_state
 {
 public:
-	generalplus_gpspispi_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+	generalplus_gpspispi_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		gcm394_game_state(mconfig, type, tag)
 	{
 	}
@@ -35,7 +35,7 @@ protected:
 class generalplus_gpspispi_bkrankp_game_state : public generalplus_gpspispi_game_state
 {
 public:
-	generalplus_gpspispi_bkrankp_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+	generalplus_gpspispi_bkrankp_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		generalplus_gpspispi_game_state(mconfig, type, tag),
 		m_cart(*this, "cartslot")
 	{
@@ -98,7 +98,7 @@ void generalplus_gpspispi_game_state::generalplus_gpspispi(machine_config &confi
 
 DEVICE_IMAGE_LOAD_MEMBER(generalplus_gpspispi_bkrankp_game_state::cart_load)
 {
-	uint32_t const size = m_cart->common_get_size("rom");
+	u32 const size = m_cart->common_get_size("rom");
 
 	m_cart->rom_alloc(size, GENERIC_ROM16_WIDTH, ENDIANNESS_LITTLE);
 	m_cart->common_load_rom(m_cart->get_rom_base(), size, "rom");
@@ -266,7 +266,7 @@ ROM_END
 void generalplus_gpspispi_game_state::init_spi()
 {
 	int vectorbase = 0x2fe0;
-	uint8_t* spirom = memregion("maincpu")->base();
+	u8* spirom = memregion("maincpu")->base();
 
 	address_space& mem = m_maincpu->space(AS_PROGRAM);
 
@@ -289,13 +289,13 @@ void generalplus_gpspispi_game_state::init_spi()
 	// copy a block of code from the NAND to RAM
 	for (int i = 0; i < 0x2000; i++)
 	{
-		uint16_t word = spirom[(i * 2) + 0] | (spirom[(i * 2) + 1] << 8);
+		u16 word = spirom[(i * 2) + 0] | (spirom[(i * 2) + 1] << 8);
 
 		mem.write_word(dest + i, word);
 	}
 
 	// these vectors must either directly point to RAM, or at least redirect there after some code
-	uint16_t* internal = (uint16_t*)memregion("maincpu:internal")->base();
+	u16* internal = (u16*)memregion("maincpu:internal")->base();
 	internal[0x7ff5] = vectorbase + 0x0a;
 	internal[0x7ff6] = vectorbase + 0x0c;
 	internal[0x7ff7] = dest + 0x20; // point boot vector at code in RAM (probably in reality points to internal code that copies the first block)

--- a/src/mame/tvgames/generalplus_gpl162xx_lcdtype.cpp
+++ b/src/mame/tvgames/generalplus_gpl162xx_lcdtype.cpp
@@ -607,7 +607,7 @@ void gpl162xx_lcdtype_state::system_dma_params_channel0_w(offs_t offset, u16 dat
 
 			if ((mode == 0x4009) || (mode == 0x6009))
 			{
-				address_space& mem = m_maincpu->space(AS_PROGRAM);
+				address_space &mem = m_maincpu->space(AS_PROGRAM);
 
 				for (int i = 0; i < length; i++)
 				{

--- a/src/mame/tvgames/generalplus_gpl162xx_lcdtype.cpp
+++ b/src/mame/tvgames/generalplus_gpl162xx_lcdtype.cpp
@@ -63,76 +63,76 @@ private:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
 	required_device<unsp_20_device> m_maincpu;
-	required_region_ptr<uint16_t> m_mainrom;
-	required_shared_ptr<uint16_t> m_mainram;
+	required_region_ptr<u16> m_mainrom;
+	required_shared_ptr<u16> m_mainram;
 
 	required_device<palette_device> m_palette;
 	required_device<screen_device> m_screen;
 
 	void map(address_map &map) ATTR_COLD;
 
-	required_region_ptr<uint8_t> m_spirom;
+	required_region_ptr<u8> m_spirom;
 
-	uint16_t unk_7abf_r();
-	uint16_t io_7860_r();
-	uint16_t unk_780f_r();
+	u16 unk_7abf_r();
+	u16 io_7860_r();
+	u16 unk_780f_r();
 
-	void io_7860_w(uint16_t data);
-	uint16_t m_7860;
+	void io_7860_w(u16 data);
+	u16 m_7860;
 
-	void unk_7862_w(uint16_t data);
-	void unk_7863_w(uint16_t data);
+	void unk_7862_w(u16 data);
+	void unk_7863_w(u16 data);
 
-	void unk_7868_w(uint16_t data);
-	uint16_t unk_7868_r();
-	uint16_t m_7868;
+	void unk_7868_w(u16 data);
+	u16 unk_7868_r();
+	u16 m_7868;
 
-	void bankswitch_707e_w(uint16_t data);
-	uint16_t bankswitch_707e_r();
-	uint16_t m_707e_bank;
+	void bankswitch_707e_w(u16 data);
+	u16 bankswitch_707e_r();
+	u16 m_707e_bank;
 
-	void bankswitch_703a_w(uint16_t data);
-	uint16_t bankswitch_703a_r();
-	uint16_t m_703a_bank;
+	void bankswitch_703a_w(u16 data);
+	u16 bankswitch_703a_r();
+	u16 m_703a_bank;
 
-	void bankedram_7300_w(offs_t offset, uint16_t data);
-	uint16_t bankedram_7300_r(offs_t offset);
-	uint16_t m_bankedram_7300[0x400];
+	void bankedram_7300_w(offs_t offset, u16 data);
+	u16 bankedram_7300_r(offs_t offset);
+	u16 m_bankedram_7300[0x400];
 
-	void bankedram_7400_w(offs_t offset, uint16_t data);
-	uint16_t bankedram_7400_r(offs_t offset);
-	uint16_t m_bankedram_7400[0x800];
+	void bankedram_7400_w(offs_t offset, u16 data);
+	u16 bankedram_7400_r(offs_t offset);
+	u16 m_bankedram_7400[0x800];
 
-	void system_dma_params_channel0_w(offs_t offset, uint16_t data);
-	uint16_t system_dma_params_channel0_r(offs_t offset);
+	void system_dma_params_channel0_w(offs_t offset, u16 data);
+	u16 system_dma_params_channel0_r(offs_t offset);
 
-	uint16_t m_dmaregs[8];
+	u16 m_dmaregs[8];
 
-	void lcd_w(uint16_t data);
-	void lcd_command_w(uint16_t data);
+	void lcd_w(u16 data);
+	void lcd_command_w(u16 data);
 
-	uint16_t spi_misc_control_r();
-	uint16_t spi_rx_fifo_r();
-	void spi_tx_fifo_w(uint16_t data);
+	u16 spi_misc_control_r();
+	u16 spi_rx_fifo_r();
+	void spi_tx_fifo_w(u16 data);
 
-	void spi_control_w(uint16_t data);
+	void spi_control_w(u16 data);
 
-	void spi_process_tx_data(uint8_t data);
-	uint8_t spi_process_rx();
-	uint8_t spi_rx();
-	uint8_t spi_rx_fast();
+	void spi_process_tx_data(u8 data);
+	u8 spi_process_rx();
+	u8 spi_rx();
+	u8 spi_rx_fast();
 
-	uint8_t m_rx_fifo[5]; // actually 8 bytes? or 8 half-bytes?
+	u8 m_rx_fifo[5]; // actually 8 bytes? or 8 half-bytes?
 
-	uint32_t m_spiaddress;
+	u32 m_spiaddress;
 
-	uint16_t unk_78a1_r();
-	uint16_t m_78a1;
-	uint16_t unk_78d8_r();
-	void unk_78d8_w(uint16_t data);
+	u16 unk_78a1_r();
+	u16 m_78a1;
+	u16 unk_78d8_r();
+	void unk_78d8_w(u16 data);
 
 	enum spistate : int
 	{
@@ -165,10 +165,10 @@ private:
 	lcdstate m_lcdstate;
 	int m_lastlcdcommand;
 
-	uint8_t m_displaybuffer[0x40000];
+	u8 m_displaybuffer[0x40000];
 	int m_lcdaddr;
 
-	uint16_t io_7870_r();
+	u16 io_7870_r();
 	required_ioport m_io_in0;
 	required_ioport m_io_in1;
 	required_device<bl_handhelds_menucontrol_device> m_menucontrol;
@@ -176,17 +176,17 @@ private:
 	void screen_vblank(int state);
 };
 
-uint32_t gpl162xx_lcdtype_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+u32 gpl162xx_lcdtype_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	int count = 0;
 	for (int y = 0; y < 256; y++)
 	{
-		uint32_t *const dst = &bitmap.pix(y);
+		u32 *const dst = &bitmap.pix(y);
 
 		for (int x = 0; x < 320; x++)
 		{
 			// 8-bit values get pumped through a 256 word table in internal ROM and converted to words
-			uint16_t dat = m_displaybuffer[(count * 2) + 1] | (m_displaybuffer[(count * 2) + 0] << 8);
+			u16 dat = m_displaybuffer[(count * 2) + 1] | (m_displaybuffer[(count * 2) + 0] << 8);
 
 			int b = ((dat >> 0) & 0x1f) << 3;
 			int g = ((dat >> 5) & 0x3f) << 2;
@@ -279,19 +279,19 @@ static INPUT_PORTS_START( gpl162xx_lcdtype )
 	PORT_DIPSETTING(      0x8000, "8000" )
 INPUT_PORTS_END
 
-uint16_t gpl162xx_lcdtype_state::unk_7abf_r()
+u16 gpl162xx_lcdtype_state::unk_7abf_r()
 {
 	return 0x0001;
 }
 
-uint16_t gpl162xx_lcdtype_state::io_7860_r()
+u16 gpl162xx_lcdtype_state::io_7860_r()
 {
-	uint16_t ret = m_io_in0->read();
+	u16 ret = m_io_in0->read();
 	LOGMASKED(LOG_GPL162XX_LCDTYPE_IO_PORT, "%s: io_7860_r %02x\n", machine().describe_context(), ret);
 	return ret;
 }
 
-void gpl162xx_lcdtype_state::io_7860_w(uint16_t data)
+void gpl162xx_lcdtype_state::io_7860_w(u16 data)
 {
 	m_menucontrol->data_w((data & 0x10)>>4);
 	m_menucontrol->clock_w((data & 0x20)>>5);
@@ -299,11 +299,11 @@ void gpl162xx_lcdtype_state::io_7860_w(uint16_t data)
 	m_7860 = data;
 }
 
-void gpl162xx_lcdtype_state::unk_7862_w(uint16_t data)
+void gpl162xx_lcdtype_state::unk_7862_w(u16 data)
 {
 }
 
-void gpl162xx_lcdtype_state::unk_7863_w(uint16_t data)
+void gpl162xx_lcdtype_state::unk_7863_w(u16 data)
 {
 	// probably port direction (or 7862 is?)
 	if (data == 0x3cf7)
@@ -312,18 +312,18 @@ void gpl162xx_lcdtype_state::unk_7863_w(uint16_t data)
 	}
 }
 
-uint16_t gpl162xx_lcdtype_state::unk_780f_r()
+u16 gpl162xx_lcdtype_state::unk_780f_r()
 {
 	return 0x0002;
 }
 
-uint16_t gpl162xx_lcdtype_state::spi_misc_control_r()
+u16 gpl162xx_lcdtype_state::spi_misc_control_r()
 {
 	LOGMASKED(LOG_GPL162XX_LCDTYPE,"%s: spi_misc_control_r\n", machine().describe_context());
 	return 0x0000;
 }
 
-uint16_t gpl162xx_lcdtype_state::spi_rx_fifo_r()
+u16 gpl162xx_lcdtype_state::spi_rx_fifo_r()
 {
 	if (m_spistate == SPI_STATE_READING_FAST)
 		return spi_rx_fast();
@@ -332,7 +332,7 @@ uint16_t gpl162xx_lcdtype_state::spi_rx_fifo_r()
 	return spi_rx();
 }
 
-void gpl162xx_lcdtype_state::spi_process_tx_data(uint8_t data)
+void gpl162xx_lcdtype_state::spi_process_tx_data(u8 data)
 {
 	LOGMASKED(LOG_GPL162XX_LCDTYPE,"transmitting %02x\n", data);
 
@@ -444,7 +444,7 @@ void gpl162xx_lcdtype_state::spi_process_tx_data(uint8_t data)
 	}
 }
 
-uint8_t gpl162xx_lcdtype_state::spi_process_rx()
+u8 gpl162xx_lcdtype_state::spi_process_rx()
 {
 
 	switch (m_spistate)
@@ -452,7 +452,7 @@ uint8_t gpl162xx_lcdtype_state::spi_process_rx()
 	case SPI_STATE_READING:
 	case SPI_STATE_READING_FAST:
 	{
-		uint8_t dat = m_spirom[m_spiaddress & 0x7fffff];
+		u8 dat = m_spirom[m_spiaddress & 0x7fffff];
 
 		LOGMASKED(LOG_GPL162XX_LCDTYPE,"reading SPI %02x from SPI Address %08x (adjusted word offset %08x)\n", dat, m_spiaddress, (m_spiaddress/2)+0x20000);
 		m_spiaddress++;
@@ -470,9 +470,9 @@ uint8_t gpl162xx_lcdtype_state::spi_process_rx()
 }
 
 
-uint8_t gpl162xx_lcdtype_state::spi_rx()
+u8 gpl162xx_lcdtype_state::spi_rx()
 {
-	uint8_t ret = m_rx_fifo[0];
+	u8 ret = m_rx_fifo[0];
 
 	m_rx_fifo[0] = m_rx_fifo[1];
 	m_rx_fifo[1] = m_rx_fifo[2];
@@ -482,9 +482,9 @@ uint8_t gpl162xx_lcdtype_state::spi_rx()
 	return ret;
 }
 
-uint8_t gpl162xx_lcdtype_state::spi_rx_fast()
+u8 gpl162xx_lcdtype_state::spi_rx_fast()
 {
-	uint8_t ret = m_rx_fifo[0];
+	u8 ret = m_rx_fifo[0];
 
 	m_rx_fifo[0] = m_rx_fifo[1];
 	m_rx_fifo[1] = m_rx_fifo[2];
@@ -495,7 +495,7 @@ uint8_t gpl162xx_lcdtype_state::spi_rx_fast()
 	return ret;
 }
 
-void gpl162xx_lcdtype_state::spi_tx_fifo_w(uint16_t data)
+void gpl162xx_lcdtype_state::spi_tx_fifo_w(u16 data)
 {
 	data &= 0x00ff;
 	LOGMASKED(LOG_GPL162XX_LCDTYPE,"%s: spi_tx_fifo_w %04x\n", machine().describe_context(), data);
@@ -505,7 +505,7 @@ void gpl162xx_lcdtype_state::spi_tx_fifo_w(uint16_t data)
 
 // this is probably 'port b' but when SPI is enabled some points of this can become SPI control pins
 // it's accessed after each large data transfer, probably to reset the SPI into 'ready for command' state?
-void gpl162xx_lcdtype_state::unk_7868_w(uint16_t data)
+void gpl162xx_lcdtype_state::unk_7868_w(u16 data)
 {
 	LOGMASKED(LOG_GPL162XX_LCDTYPE_IO_PORT, "%s: unk_7868_w %04x (Port B + SPI reset?)\n", machine().describe_context(), data);
 
@@ -523,47 +523,47 @@ void gpl162xx_lcdtype_state::unk_7868_w(uint16_t data)
 	m_7868 = data;
 }
 
-uint16_t gpl162xx_lcdtype_state::unk_7868_r()
+u16 gpl162xx_lcdtype_state::unk_7868_r()
 {
 	return m_7868;
 }
 
-void gpl162xx_lcdtype_state::bankswitch_707e_w(uint16_t data)
+void gpl162xx_lcdtype_state::bankswitch_707e_w(u16 data)
 {
 	LOGMASKED(LOG_GPL162XX_LCDTYPE,"%s: bankswitch_707e_w %04x\n", machine().describe_context(), data);
 	m_707e_bank = data;
 }
 
-uint16_t gpl162xx_lcdtype_state::bankswitch_707e_r()
+u16 gpl162xx_lcdtype_state::bankswitch_707e_r()
 {
 	return m_707e_bank;
 }
 
 
-void gpl162xx_lcdtype_state::bankswitch_703a_w(uint16_t data)
+void gpl162xx_lcdtype_state::bankswitch_703a_w(u16 data)
 {
 	LOGMASKED(LOG_GPL162XX_LCDTYPE,"%s: bankswitch_703a_w %04x\n", machine().describe_context(), data);
 	m_703a_bank = data;
 }
 
-uint16_t gpl162xx_lcdtype_state::bankswitch_703a_r()
+u16 gpl162xx_lcdtype_state::bankswitch_703a_r()
 {
 	return m_703a_bank;
 }
 
-void gpl162xx_lcdtype_state::bankedram_7300_w(offs_t offset, uint16_t data)
+void gpl162xx_lcdtype_state::bankedram_7300_w(offs_t offset, u16 data)
 {
 	offset |= (m_703a_bank & 0x000c) << 6;
 	m_bankedram_7300[offset] = data;
 }
 
-uint16_t gpl162xx_lcdtype_state::bankedram_7300_r(offs_t offset)
+u16 gpl162xx_lcdtype_state::bankedram_7300_r(offs_t offset)
 {
 	offset |= (m_703a_bank & 0x000c) << 6;
 	return m_bankedram_7300[offset];
 }
 
-void gpl162xx_lcdtype_state::bankedram_7400_w(offs_t offset, uint16_t data)
+void gpl162xx_lcdtype_state::bankedram_7400_w(offs_t offset, u16 data)
 {
 	if (m_707e_bank & 1)
 	{
@@ -575,7 +575,7 @@ void gpl162xx_lcdtype_state::bankedram_7400_w(offs_t offset, uint16_t data)
 	}
 }
 
-uint16_t gpl162xx_lcdtype_state::bankedram_7400_r(offs_t offset)
+u16 gpl162xx_lcdtype_state::bankedram_7400_r(offs_t offset)
 {
 	if (m_707e_bank & 1)
 	{
@@ -587,7 +587,7 @@ uint16_t gpl162xx_lcdtype_state::bankedram_7400_r(offs_t offset)
 	}
 }
 
-void gpl162xx_lcdtype_state::system_dma_params_channel0_w(offs_t offset, uint16_t data)
+void gpl162xx_lcdtype_state::system_dma_params_channel0_w(offs_t offset, u16 data)
 {
 	m_dmaregs[offset] = data;
 
@@ -597,10 +597,10 @@ void gpl162xx_lcdtype_state::system_dma_params_channel0_w(offs_t offset, uint16_
 		{
 			LOGMASKED(LOG_GPL162XX_LCDTYPE,"%s: system_dma_params_channel0_w %01x %04x (DMA Mode)\n", machine().describe_context(), offset, data);
 
-			uint16_t mode = m_dmaregs[0];
-			uint32_t source = m_dmaregs[1] | (m_dmaregs[4] << 16);
-			uint32_t dest = m_dmaregs[2] | (m_dmaregs[5] << 16) ;
-			uint32_t length = m_dmaregs[3] | (m_dmaregs[6] << 16);
+			u16 mode = m_dmaregs[0];
+			u32 source = m_dmaregs[1] | (m_dmaregs[4] << 16);
+			u32 dest = m_dmaregs[2] | (m_dmaregs[5] << 16) ;
+			u32 length = m_dmaregs[3] | (m_dmaregs[6] << 16);
 
 			if ((mode != 0x0200) && (mode != 0x4009) && (mode != 0x6009))
 				fatalerror("unknown dma mode write %04x\n", data);
@@ -611,7 +611,7 @@ void gpl162xx_lcdtype_state::system_dma_params_channel0_w(offs_t offset, uint16_
 
 				for (int i = 0; i < length; i++)
 				{
-					uint16_t dat = mem.read_word(source);
+					u16 dat = mem.read_word(source);
 
 					if (mode & 0x2000)
 					{
@@ -663,35 +663,35 @@ void gpl162xx_lcdtype_state::system_dma_params_channel0_w(offs_t offset, uint16_
 	}
 }
 
-uint16_t gpl162xx_lcdtype_state::system_dma_params_channel0_r(offs_t offset)
+u16 gpl162xx_lcdtype_state::system_dma_params_channel0_r(offs_t offset)
 {
 	LOGMASKED(LOG_GPL162XX_LCDTYPE,"%s: system_dma_params_channel0_r %01x\n", machine().describe_context(), offset);
 	return m_dmaregs[offset];
 }
 
-uint16_t gpl162xx_lcdtype_state::io_7870_r()
+u16 gpl162xx_lcdtype_state::io_7870_r()
 {
 	LOGMASKED(LOG_GPL162XX_LCDTYPE_IO_PORT, "%s: io_7870_r (IO port)\n", machine().describe_context() );
 	return m_io_in1->read();
 }
 
-void gpl162xx_lcdtype_state::spi_control_w(uint16_t data)
+void gpl162xx_lcdtype_state::spi_control_w(u16 data)
 {
 	LOGMASKED(LOG_GPL162XX_LCDTYPE,"%s: spi_control_w %04x\n", machine().describe_context(), data);
 }
 
-uint16_t gpl162xx_lcdtype_state::unk_78a1_r()
+u16 gpl162xx_lcdtype_state::unk_78a1_r()
 {
 	// checked in interrupt, code skipped entirely if this isn't set
 	return m_78a1;
 }
 
-uint16_t gpl162xx_lcdtype_state::unk_78d8_r()
+u16 gpl162xx_lcdtype_state::unk_78d8_r()
 {
 	return 0xffff;
 }
 
-void gpl162xx_lcdtype_state::unk_78d8_w(uint16_t data)
+void gpl162xx_lcdtype_state::unk_78d8_w(u16 data)
 {
 	// written in IRQ, possible ack
 	if (data & 0x8000)
@@ -750,7 +750,7 @@ void gpl162xx_lcdtype_state::map(address_map &map)
 	map(0x20fc00, 0x20fc00).w(FUNC(gpl162xx_lcdtype_state::lcd_w));
 }
 
-void gpl162xx_lcdtype_state::lcd_command_w(uint16_t data)
+void gpl162xx_lcdtype_state::lcd_command_w(u16 data)
 {
 	data &= 0xff;
 
@@ -777,7 +777,7 @@ void gpl162xx_lcdtype_state::lcd_command_w(uint16_t data)
 	}
 }
 
-void gpl162xx_lcdtype_state::lcd_w(uint16_t data)
+void gpl162xx_lcdtype_state::lcd_w(u16 data)
 {
 	data &= 0xff; // definitely looks like 8-bit port as 16-bit values are shifted and rewritten
 	LOGMASKED(LOG_GPL162XX_LCDTYPE,"%s: lcd_w %02x\n", machine().describe_context(), data);

--- a/src/mame/tvgames/generalplus_gpl951xx.cpp
+++ b/src/mame/tvgames/generalplus_gpl951xx.cpp
@@ -1,30 +1,34 @@
 // license:BSD-3-Clause
 // copyright-holders:David Haywood
-/*
-    These seem to be GPL16250 related based on video register use
-    however the SPI ROM maps directly into CPU space, where you'd
-    expect internal ROM to be?!
-
-    It has been confirmed that Pacman/Fix It Felix/Ms Pacman can
-    be swapped onto the same PCB, so either there is no internal
-    area (runs direct from SPI?) or it's the same between games.
-*/
 
 #include "emu.h"
-#include "generalplus_gpl16250.h"
 
+#include "screen.h"
+#include "speaker.h"
+
+#include "machine/generalplus_gpl951xx_soc.h"
+#include "machine/generic_spi_flash.h"
 
 namespace {
 
-class generalplus_gpspi_direct_game_state : public gcm394_game_state
+class generalplus_gpl951xx_game_state : public driver_device
 {
 public:
-	generalplus_gpspi_direct_game_state(const machine_config& mconfig, device_type type, const char* tag) :
-		gcm394_game_state(mconfig, type, tag)
+	generalplus_gpl951xx_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+		driver_device(mconfig, type, tag),
+		m_maincpu(*this, "maincpu"),
+		m_screen(*this, "screen"),
+		m_genspi(*this, "spi"),
+		m_io(*this, "IN%u", 0U)
 	{
 	}
 
-	void generalplus_gpspi_direct(machine_config &config) ATTR_COLD;
+	void bfpacman(machine_config &config) ATTR_COLD;
+	void fixitflx(machine_config &config) ATTR_COLD;
+	void wiwcs(machine_config &config) ATTR_COLD;
+	void poke(machine_config &config) ATTR_COLD;
+	void flufflav(machine_config &config) ATTR_COLD;
+	void puni(machine_config &config) ATTR_COLD;
 
 	void init_fif() ATTR_COLD;
 
@@ -32,22 +36,66 @@ protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
-	virtual uint16_t cs0_r(offs_t offset) override;
+	void gpl951xx(machine_config &config) ATTR_COLD;
+
+	uint16_t porta_r();
+	uint16_t portb_r();
+	uint16_t portc_r();
+	void porta_w(uint16_t data);
+
+	void spi_reset(u8 data);
+	void spi_access_from_soc(u8 data);
+	void spi_cmd_access_from_soc(u8 data);
+
+	required_device<generalplus_gpl951xx_device> m_maincpu;
+	required_device<screen_device> m_screen;
+	required_device<generic_spi_flash_device> m_genspi;
+	required_ioport_array<3> m_io;
 };
 
-void generalplus_gpspi_direct_game_state::machine_start()
+
+uint16_t generalplus_gpl951xx_game_state::porta_r()
 {
-	gcm394_game_state::machine_start();
+	uint16_t data = m_io[0]->read();
+	logerror("Port A Read: %04x\n", data);
+	return data;
 }
 
-void generalplus_gpspi_direct_game_state::machine_reset()
+uint16_t generalplus_gpl951xx_game_state::portb_r()
 {
-	cs_callback(0x00, 0x00, 0x00, 0x00, 0x00);
+	uint16_t data = m_io[1]->read();
+	logerror("Port B Read: %04x\n", data);
+	return data;
+}
 
+uint16_t generalplus_gpl951xx_game_state::portc_r()
+{
+	uint16_t data = m_io[2]->read();
+	logerror("Port C Read: %04x\n", data);
+	return data;
+}
+
+void generalplus_gpl951xx_game_state::porta_w(uint16_t data)
+{
+	logerror("%s: Port A:WRITE %04x\n", machine().describe_context(), data);
+}
+
+void generalplus_gpl951xx_game_state::machine_start()
+{
+	m_genspi->set_rom_ptr(memregion("spi")->base());
+	m_genspi->set_rom_size(memregion("spi")->bytes());
+	m_maincpu->set_spi_romregion(memregion("spi")->base(), memregion("spi")->bytes());
+}
+
+void generalplus_gpl951xx_game_state::machine_reset()
+{
 	m_maincpu->reset(); // reset CPU so vector gets read etc.
 }
 
 static INPUT_PORTS_START( bfmpac )
+	PORT_START("IN0")
+	PORT_START("IN1")
+
 	PORT_START("IN2")
 	PORT_DIPNAME( 0x0001, 0x0000, "0" )
 	PORT_DIPSETTING(      0x0000, DEF_STR( Off ) )
@@ -85,9 +133,6 @@ static INPUT_PORTS_START( bfmpac )
 	PORT_DIPNAME( 0x8000, 0x0000, DEF_STR( Unknown ) )
 	PORT_DIPSETTING(      0x0000, DEF_STR( Off ) )
 	PORT_DIPSETTING(      0x8000, DEF_STR( On ) )
-
-	PORT_START("IN1")
-	PORT_START("IN0")
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( bfspyhnt )
@@ -97,30 +142,42 @@ static INPUT_PORTS_START( bfspyhnt )
 	PORT_BIT( 0x4000, IP_ACTIVE_HIGH, IPT_BUTTON2 )
 INPUT_PORTS_END
 
-
-uint16_t generalplus_gpspi_direct_game_state::cs0_r(offs_t offset)
+void generalplus_gpl951xx_game_state::spi_reset(u8 data)
 {
-	// TODO: is cs_space even used by this type?
-	return 0x00;
+	m_genspi->reset();
 }
 
-void generalplus_gpspi_direct_game_state::generalplus_gpspi_direct(machine_config &config)
+void generalplus_gpl951xx_game_state::spi_access_from_soc(u8 data)
 {
-	set_addrmap(0, &generalplus_gpspi_direct_game_state::cs_map_base);
+	logerror("spi_access_from_soc %02x\n", data);
+	m_genspi->write(data);
+	m_maincpu->recieve_spi_fifo_data(m_genspi->read());
+}
 
+void generalplus_gpl951xx_game_state::spi_cmd_access_from_soc(u8 data)
+{
+	logerror("spi_cmd_access_from_soc %02x\n", data);
+	m_genspi->write(data);
+}
+
+
+
+void generalplus_gpl951xx_game_state::gpl951xx(machine_config &config)
+{
 	GPL951XX(config, m_maincpu, 96000000/2, m_screen);
-	m_maincpu->porta_in().set(FUNC(generalplus_gpspi_direct_game_state::porta_r));
-	m_maincpu->portb_in().set(FUNC(generalplus_gpspi_direct_game_state::portb_r));
-	m_maincpu->portc_in().set(FUNC(generalplus_gpspi_direct_game_state::portc_r));
-	m_maincpu->porta_out().set(FUNC(generalplus_gpspi_direct_game_state::porta_w));
-	m_maincpu->space_read_callback().set(FUNC(generalplus_gpspi_direct_game_state::read_external_space));
-	m_maincpu->space_write_callback().set(FUNC(generalplus_gpspi_direct_game_state::write_external_space));
+	m_maincpu->porta_in().set(FUNC(generalplus_gpl951xx_game_state::porta_r));
+	m_maincpu->portb_in().set(FUNC(generalplus_gpl951xx_game_state::portb_r));
+	m_maincpu->portc_in().set(FUNC(generalplus_gpl951xx_game_state::portc_r));
+	m_maincpu->porta_out().set(FUNC(generalplus_gpl951xx_game_state::porta_w));
 	m_maincpu->set_irq_acknowledge_callback(m_maincpu, FUNC(sunplus_gcm394_base_device::irq_vector_cb));
 	m_maincpu->add_route(ALL_OUTPUTS, "speaker", 0.5, 0);
 	m_maincpu->add_route(ALL_OUTPUTS, "speaker", 0.5, 1);
 	m_maincpu->set_bootmode(0);
-	m_maincpu->set_cs_config_callback(FUNC(gcm394_game_state::cs_callback));
 	m_maincpu->set_cs_space(DEVICE_SELF, 0);
+	m_maincpu->spi_out().set(FUNC(generalplus_gpl951xx_game_state::spi_access_from_soc));
+	m_maincpu->spi_out_cmd().set(FUNC(generalplus_gpl951xx_game_state::spi_cmd_access_from_soc));
+	m_maincpu->spi_reset().set(FUNC(generalplus_gpl951xx_game_state::spi_reset));
+;
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	//m_screen->set_refresh_hz(20); // 20hz update gives more correct speed (and working inputs) in fixitflx and bfdigdug, but speed should probably be limited in some other way
@@ -130,18 +187,66 @@ void generalplus_gpspi_direct_game_state::generalplus_gpspi_direct(machine_confi
 	m_screen->set_screen_update("maincpu", FUNC(sunplus_gcm394_device::screen_update));
 	m_screen->screen_vblank().set(m_maincpu, FUNC(sunplus_gcm394_device::vblank));
 
+	GENERIC_SPI_FLASH(config, m_genspi, 0);
+
 	SPEAKER(config, "speaker", 2).front();
 }
 
-// Is there an internal ROM that gets mapped out or can this type really execute directly from scrambled SPI?
-// there doesn't appear to be anywhere to map an internal ROM, nor access to it, so I think they just execute
-// from SPI
+void generalplus_gpl951xx_game_state::bfpacman(machine_config &config)
+{
+	gpl951xx(config);
+	m_genspi->set_jedec_manufacturer(0xc8);
+	m_genspi->set_jedec_memtype(0x40);
+	m_genspi->set_jedec_capacity(0x14);
+}
+
+void generalplus_gpl951xx_game_state::fixitflx(machine_config &config)
+{
+	gpl951xx(config);
+	m_genspi->set_jedec_manufacturer(0xc8);
+	m_genspi->set_jedec_memtype(0x40);
+	m_genspi->set_jedec_capacity(0x15);
+}
+
+void generalplus_gpl951xx_game_state::wiwcs(machine_config &config)
+{
+	gpl951xx(config);
+	m_genspi->set_jedec_manufacturer(0xc8);
+	m_genspi->set_jedec_memtype(0x40);
+	m_genspi->set_jedec_capacity(0x17);
+}
+
+void generalplus_gpl951xx_game_state::poke(machine_config &config)
+{
+	gpl951xx(config);
+	m_genspi->set_jedec_manufacturer(0xc2);
+	m_genspi->set_jedec_memtype(0x20);
+	m_genspi->set_jedec_capacity(0x19);
+}
+
+void generalplus_gpl951xx_game_state::flufflav(machine_config &config)
+{
+	gpl951xx(config);
+	m_genspi->set_jedec_manufacturer(0xc2);
+	m_genspi->set_jedec_memtype(0x20);
+	m_genspi->set_jedec_capacity(0x16);
+}
+
+void generalplus_gpl951xx_game_state::puni(machine_config &config)
+{
+	gpl951xx(config);
+	m_genspi->set_jedec_manufacturer(0xc2);
+	m_genspi->set_jedec_memtype(0x20);
+	m_genspi->set_jedec_capacity(0x17);
+}
+
+// There should be a small internal ROM (0x4000) bytes that does some basic setup
 
 ROM_START( fixitflx )
 	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
 	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP )
 
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x200000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "fixitfelix_md25q16csig_c84015.bin", 0x0000, 0x200000, CRC(605c6863) SHA1(4f6cc2e8388e20eb90c6b05265273650eeea56eb) )
 ROM_END
 
@@ -149,7 +254,7 @@ ROM_START( wiwcs )
 	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
 	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP )
 
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "wwcs.img", 0x0000, 0x800000, CRC(9b86bc45) SHA1(17721c662642a257d3e0f56e351a9a80d75d9110) )
 
 	ROM_REGION16_BE(0x400, "i2c", ROMREGION_ERASE00)
@@ -160,7 +265,7 @@ ROM_START( bfpacman )
 	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
 	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP )
 
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x100000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "basicfunpacman_25q80_c84014.bin", 0x0000, 0x100000, CRC(dd39fc64) SHA1(48c0e1eb729f61b7359e1fd52b7faab56817dfe8) )
 ROM_END
 
@@ -168,7 +273,7 @@ ROM_START( bfmpac )
 	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
 	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP )
 
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x100000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "mspacman_25q80_c84014.bin", 0x0000, 0x100000, CRC(c0c3f8ce) SHA1(30da9b14f1a2c966167c97da9b8329f2f7f73291) )
 ROM_END
 
@@ -176,7 +281,7 @@ ROM_START( bfdigdug )
 	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
 	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP )
 
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x100000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "arcadeclassicsdigdug_25q80csig_c84014.bin", 0x0000, 0x100000, CRC(4030bc46) SHA1(8c086c96b9822e95c1862012786d6d6e59e0387e) )
 ROM_END
 
@@ -184,7 +289,7 @@ ROM_START( bfgalaga )
 	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
 	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP )
 
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x100000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "arcadeclassicsgalaga_25q80csig_c84014.bin", 0x0000, 0x100000, CRC(69982c9d) SHA1(0f8f403fefa7d8a9fdfcc04dca5a67919b662c7e) )
 ROM_END
 
@@ -192,7 +297,7 @@ ROM_START( bfspyhnt )
 	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
 	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP )
 
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x200000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "arcadeclassicsspyhunter_md25q16csig_c84015.bin", 0x0000, 0x200000, CRC(1f1eaabd) SHA1(1c484e0b0749123cfa1ac6d1959aefa6ed09ab20) )
 
 	// also has a 24C04 (to store high scores?)
@@ -202,235 +307,229 @@ ROM_START( bftetris )
 	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
 	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP )
 
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x200000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "arcadeclassicstetris_25q16ct_c84015.bin", 0x0000, 0x200000, CRC(a97e1bab) SHA1(400944d310d5d5fccb2c6d048d7bf0cb00da09de) )
 ROM_END
 
 
 
 ROM_START( punirune )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "25l64.ic103", 0x0000, 0x800000, CRC(0737edc0) SHA1(fce19d91a0522a75e676197fb18645b8c6a273b8) )
 ROM_END
 
 ROM_START( punij1m )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "japan_v1pcb_mint_25l6433f.ic103", 0x0000, 0x800000, CRC(76f28b5b) SHA1(be04d60c88df52951dd51eab2f5bf5f1dc2405e8) )
 ROM_END
 
 ROM_START( punij1pk ) // this might be the same software revision as punij1m with different save (or default save) data
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "japan_v1pcb_pink_25l6433f.ic103", 0x0000, 0x800000, CRC(9268c881) SHA1(10bacfa48b3d02956d804396b652829ff868d947) )
 ROM_END
 
 ROM_START( punij1pu ) // different software revision to punij1m / punij1pk but same case style
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "japan_v1pcb_purple_25l6433f.ic103", 0x0000, 0x800000, CRC(5b73bcb6) SHA1(109b6fa29693e7622c528d95d2a995d37a1cd8ca) )
 ROM_END
 
 ROM_START( punij2pk )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "japan_v2pcb_pink_gpr25l64.ic103", 0x0000, 0x800000, CRC(7ae9f009) SHA1(d762634a0442ff231837f9481a1203933c070df0) )
 ROM_END
 
 ROM_START( punifrnd )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "25oh64.ic3", 0x0000, 0x800000, CRC(622ca9b3) SHA1(4206393a4458ffcdb63352e743481865532fe8b5) )
 ROM_END
 
 ROM_START( punistar )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "xm25qh64c.ic3", 0x0000, 0x800000, CRC(72f54f23) SHA1(902955764d0b61decc057eb3afaf2960cf2134c6) )
 ROM_END
 
 ROM_START( flufflav )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x400000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "gpr25l320.u2", 0x0000, 0x400000, CRC(67bcd4cb) SHA1(5ffb140bf8e4608b5420a649aede3946923f6dac) )
 ROM_END
 
 ROM_START( pockrmsr )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "25l6433f.ic102", 0x0000, 0x800000, CRC(4b899ca1) SHA1(5e57aaa0598563c08f3b3e4f26447a3902ca51dc) )
 ROM_END
 
 ROM_START( pokgoget )
-	ROM_REGION16_BE(0x2000000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x2000000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "mx25l25645g.u1", 0x0000, 0x2000000, CRC(a76ae22f) SHA1(3fa5eeedb3fe343a7707d76710298377b22b0681) )
 ROM_END
 
 ROM_START( pokebala )
-	ROM_REGION16_BE(0x2000000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x2000000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "mx25l25645g.u4", 0x0000, 0x2000000, CRC(e35d434a) SHA1(74061831b25476ec8aa7dec5f9d64ff79b0db88e) )
 ROM_END
 
 ROM_START( pokeissh )
-	ROM_REGION16_BE(0x2000000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x2000000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "mx25l25645g.u1", 0x0000, 0x2000000, CRC(1eaf3457) SHA1(a7f16ad7abfc13c67d8e50f462882a771b6777ab) )
 ROM_END
 
 ROM_START( pokemech )
-	ROM_REGION16_BE(0x2000000, "maincpu:spidirect", ROMREGION_ERASE00)
+	ROM_REGION16_BE(0x2000000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "mx25l25645g.u1", 0x0000, 0x2000000, CRC(e170dede) SHA1(4b07cfcc92e6af412ad0e5c9852b7075a15bd75c) )
 ROM_END
 
 ROM_START( smkcatch )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00 )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "gpr25l64.u2", 0x0000, 0x800000,  CRC(e2f52c4a) SHA1(f79862d27152cff8f96151c672d9762a3897a593) )
 ROM_END
 
 ROM_START( smkguras )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00 )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "gpr25l64.u3", 0x0000, 0x800000, CRC(96b61464) SHA1(59fada02e1ea983c56304b27b3f4cb1fba221cb0) )
 ROM_END
 
 ROM_START( smkgurasa ) // code is the same, some data area differs, could be different factory defaults, or user data, remove later if redundant
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00 )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "xm25qh64c.u3", 0x0000, 0x800000, CRC(2c9e82af) SHA1(8c475783eafbeaeb88d62b145758ad3487410222) )
 ROM_END
 
 ROM_START( smkgacha )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00 )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "kg25l64.u2", 0x0000, 0x800000, CRC(eb461d92) SHA1(7481e8b3f2eaa9c8d992f3d9c58c1c7e3f27b380) )
 ROM_END
 
 ROM_START( dsgnpal )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00 )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "gpr25l64.ic2", 0x0000, 0x800000, CRC(a1017ea8) SHA1(bd4b553ff71e763cd3fd726c49f5408eac3b7984) )
 ROM_END
 
 ROM_START( segapet1 )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00 )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "pink_gpr25l64.ic3", 0x0000, 0x800000, CRC(3bb709d1) SHA1(8a1b34d6cdd856685182d19b86c5cb68a006f816) )
 ROM_END
 
 ROM_START( segapet1a )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00 )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "yellow_gpr25l64.ic3", 0x0000, 0x800000, CRC(073218b8) SHA1(8501e69dc2b2cda9e4c289a14d6a16fe832e722c) )
 ROM_END
 
 ROM_START( segapet2 )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00 )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "purple_gpr25l64.ic3", 0x0000, 0x800000, CRC(e223eabf) SHA1(fa88173361af7f8cb7651bd7ccb73d7137eb6cf9) )
 ROM_END
 
 ROM_START( segapet2a )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00 )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "orange_gpr25l64.ic3", 0x0000, 0x800000, CRC(25605da6) SHA1(2733f30037551b2e5895efbb19ed953e81405141) )
 ROM_END
 
 ROM_START( segapet3 )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00 )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "pink_gpr25l64.ic3", 0x0000, 0x800000, CRC(4b60f556) SHA1(3487c7b42e1b818ac1fe3a9429320519574ca4ac) )
 ROM_END
 
 ROM_START( segapet3a )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00 )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "blue_gpr25l64.ic3", 0x0000, 0x800000, CRC(02a63c63) SHA1(54d8c1c52a30d7b2a21f69439d9ff2ef7b2a606b) )
 ROM_END
 
 ROM_START( segaptdx )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00 )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "gpr25l640.ic3", 0x0000, 0x800000, CRC(971837c5) SHA1(b0e639fbd1e2b41934a98fde8425ded84f1a8159) )
 ROM_END
 
 ROM_START( bubltea )
-	ROM_REGION16_BE(0x800000, "maincpu:spidirect", ROMREGION_ERASE00 )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "gpr25l64.ic2", 0x0000, 0x800000, CRC(a6d73241) SHA1(bc67d932ffc83d91dc2d64f40bbce08c1e8b9f4e) )
 ROM_END
 
-void generalplus_gpspi_direct_game_state::init_fif()
+void generalplus_gpl951xx_game_state::init_fif()
 {
-	uint16_t* spirom16 = (uint16_t*)memregion("maincpu:spidirect")->base();
-	for (int i = 0; i < 0x800000 / 2; i++)
+	u16* spirom16 = (u16*)memregion("spi")->base();
+	for (int i = 0; i < memregion("spi")->bytes() / 2; i++)
 	{
 		spirom16[i] = bitswap<16>(spirom16[i] ^ 0xdd0d,
 			3, 1, 11, 9, 6, 14, 0, 2, 8, 7, 13, 15, 4, 5, 12, 10);
 	}
-
-	// the games upload some self-check code to 0x100 in RAM, it's unclear what it is checking, skip it for now
-	// goto mr -> nop
-	if (spirom16[0x00d8] == 0xf161) spirom16[0x00d8] = 0xf165; // fixitflx, bfpacman, bfmpac
-	if (spirom16[0x00ac] == 0xf161) spirom16[0x00ac] = 0xf165; // wiwcs, bfgalaga, bfdigdug, bfspyhnt
-	if (spirom16[0x00a2] == 0xf161) spirom16[0x00a2] = 0xf165; // bftetris
 }
 
 } // anonymous namespace
 
-CONS(2017, fixitflx, 0, 0, generalplus_gpspi_direct, bfmpac, generalplus_gpspi_direct_game_state, init_fif, "Basic Fun", "Fix It Felix Jr. (mini arcade)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS(2018, wiwcs,    0, 0, generalplus_gpspi_direct, bfmpac, generalplus_gpspi_direct_game_state, init_fif, "Basic Fun", "Where in the World Is Carmen Sandiego? (handheld)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS(2018, bfpacman, 0, 0, generalplus_gpspi_direct, bfmpac, generalplus_gpspi_direct_game_state, init_fif, "Basic Fun", "Pac-Man (mini arcade)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS(2017, bfmpac,   0, 0, generalplus_gpspi_direct, bfmpac, generalplus_gpspi_direct_game_state, init_fif, "Basic Fun", "Ms. Pac-Man (mini arcade)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS(2017, bfgalaga, 0, 0, generalplus_gpspi_direct, bfmpac, generalplus_gpspi_direct_game_state, init_fif, "Basic Fun", "Galaga (mini arcade)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS(2018, bfdigdug, 0, 0, generalplus_gpspi_direct, bfmpac, generalplus_gpspi_direct_game_state, init_fif, "Basic Fun", "Dig Dug (mini arcade)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS(2019, bfspyhnt, 0, 0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, init_fif, "Basic Fun", "Spy Hunter (mini arcade)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS(2019, bftetris, 0, 0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, init_fif, "Basic Fun", "Tetris (mini arcade)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2017, fixitflx, 0, 0, fixitflx, bfmpac,   generalplus_gpl951xx_game_state, init_fif, "Basic Fun", "Fix It Felix Jr. (mini arcade)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2018, wiwcs,    0, 0, wiwcs,    bfmpac,   generalplus_gpl951xx_game_state, init_fif, "Basic Fun", "Where in the World Is Carmen Sandiego? (handheld)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2018, bfpacman, 0, 0, bfpacman, bfmpac,   generalplus_gpl951xx_game_state, init_fif, "Basic Fun", "Pac-Man (mini arcade)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2017, bfmpac,   0, 0, bfpacman, bfmpac,   generalplus_gpl951xx_game_state, init_fif, "Basic Fun", "Ms. Pac-Man (mini arcade)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2017, bfgalaga, 0, 0, bfpacman, bfmpac,   generalplus_gpl951xx_game_state, init_fif, "Basic Fun", "Galaga (mini arcade)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2018, bfdigdug, 0, 0, bfpacman, bfmpac,   generalplus_gpl951xx_game_state, init_fif, "Basic Fun", "Dig Dug (mini arcade)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2019, bfspyhnt, 0, 0, fixitflx, bfspyhnt, generalplus_gpl951xx_game_state, init_fif, "Basic Fun", "Spy Hunter (mini arcade)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2019, bftetris, 0, 0, fixitflx, bfspyhnt, generalplus_gpl951xx_game_state, init_fif, "Basic Fun", "Tetris (mini arcade)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
 // games below use GPL95101 series chips, which might be different but are definitely unSP2.0 chips that run from SPI directly
 
 // unclear if colour matches, but there are multiple generations of these at least
 // uses PUNIRUNZU_MAIN_V3 pcb
-CONS(2021, punirune, 0, 0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Takara Tomy", "Punirunes (PUNIRUNZU_MAIN_V3, pastel blue, Europe)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, punirune, 0, 0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Takara Tomy", "Punirunes (PUNIRUNZU_MAIN_V3, pastel blue, Europe)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
 // the case on these looks like the European release, including English title logo.  CPU is a glob, PUNIRUNZU_MAIN_DICE_V1 on PCB
-CONS(2021, punij1m,  punirune, 0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Takara Tomy", "Punirunes (PUNIRUNZU_MAIN_DICE_V1, mint, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS(2021, punij1pk, punirune, 0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Takara Tomy", "Punirunes (PUNIRUNZU_MAIN_DICE_V1, pink, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS(2021, punij1pu, punirune, 0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Takara Tomy", "Punirunes (PUNIRUNZU_MAIN_DICE_V1, purple, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, punij1m,  punirune, 0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Takara Tomy", "Punirunes (PUNIRUNZU_MAIN_DICE_V1, mint, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, punij1pk, punirune, 0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Takara Tomy", "Punirunes (PUNIRUNZU_MAIN_DICE_V1, pink, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, punij1pu, punirune, 0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Takara Tomy", "Punirunes (PUNIRUNZU_MAIN_DICE_V1, purple, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
 // the case on these is similar to the above, but the text is in Japanese, uses PUNIRUNZU_MAIN_V2 on pcb
-CONS(2021, punij2pk, punirune, 0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Takara Tomy", "Punirunes (PUNIRUNZU_MAIN_V2, pink, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, punij2pk, punirune, 0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Takara Tomy", "Punirunes (PUNIRUNZU_MAIN_V2, pink, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
 // has a link feature
-CONS(2021, punifrnd, 0,        0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Takara Tomy", "Punirunes Punitomo Tsuushin (hot pink, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, punifrnd, 0,        0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Takara Tomy", "Punirunes Punitomo Tsuushin (hot pink, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
-CONS(2021, punistar, 0,        0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Takara Tomy", "Punirunes Punistarz (pink, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, punistar, 0,        0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Takara Tomy", "Punirunes Punistarz (pink, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
 // 'Poo' emoji shaped item, comes in multiple colours, has a solder pad which might change between units
 // this was dumped from the 'Lavender' unit
-CONS(2021, flufflav, 0,        0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Happinet", "Fuwatcho Uncho Fuwa Fuwa (lavender, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, flufflav, 0,        0, flufflav, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Happinet", "Fuwatcho Uncho Fuwa Fuwa (lavender, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
 // available in 2 colours, ROM confirmed to be the same on both
-CONS(2021, pockrmsr,  0,        0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Bandai", "Pocket Room - Sanrio Characters (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, pockrmsr,  0,        0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Bandai", "Pocket Room - Sanrio Characters (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
 // Pocket Monsters ガチッとゲットだぜ! モンスターボールゴー! - Pocket Monsters is printed on the inner shell, but not the box?
-CONS(2021, pokgoget, 0,        0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Takara Tomy", "Gachitto Get da ze! Monster Ball Go! (210406, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, pokgoget, 0,        0, poke, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Takara Tomy", "Gachitto Get da ze! Monster Ball Go! (210406, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 // ガチッとゲットだぜ! モンスターボール
-CONS(2021, pokebala, 0,        0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Takara Tomy", "Gachitto Get da ze! Monster Ball (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, pokebala, 0,        0, poke, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Takara Tomy", "Gachitto Get da ze! Monster Ball (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 // ポケモンといっしょ！モンスターボール
-CONS(2021, pokeissh, 0,        0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Takara Tomy", "Pokemon to Issho! Monster Ball (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, pokeissh, 0,        0, poke, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Takara Tomy", "Pokemon to Issho! Monster Ball (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 // めちゃナゲ! モンスターボール
-CONS(2021, pokemech, 0,        0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Takara Tomy", "Mecha Nage! Monster Ball (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, pokemech, 0,        0, poke, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Takara Tomy", "Mecha Nage! Monster Ball (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
 // 2020 (device) / 2021 (box) version of Sumikko Gurashi a cloud shaped device
 // Sumikko Gurashi - Sumikko Catch (すみっコぐらし すみっコキャッチ)
-CONS( 2021, smkcatch, 0, 0, generalplus_gpspi_direct, bfmpac, generalplus_gpspi_direct_game_state, empty_init,  "San-X / Tomy", "Sumikko Gurashi - Sumikko Catch (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS( 2021, smkcatch, 0, 0, puni, bfmpac, generalplus_gpl951xx_game_state, empty_init,  "San-X / Tomy", "Sumikko Gurashi - Sumikko Catch (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
 // or Sumikko Gurashi - Sumikko Catch DX (すみっコぐらし すみっコキャッチDX) = Sumikko Catch with pouch and strap
 
 // is there a subtitle for this one? it's different to the others
-CONS( 201?, smkguras,  0,        0, generalplus_gpspi_direct, bfmpac, generalplus_gpspi_direct_game_state, empty_init,  "San-X / Tomy", "Sumikko Gurashi DX (Japan, set 1)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
-CONS( 201?, smkgurasa, smkguras, 0, generalplus_gpspi_direct, bfmpac, generalplus_gpspi_direct_game_state, empty_init,  "San-X / Tomy", "Sumikko Gurashi DX (Japan, set 2)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS( 201?, smkguras,  0,        0, puni, bfmpac, generalplus_gpl951xx_game_state, empty_init,  "San-X / Tomy", "Sumikko Gurashi DX (Japan, set 1)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS( 201?, smkgurasa, smkguras, 0, puni, bfmpac, generalplus_gpl951xx_game_state, empty_init,  "San-X / Tomy", "Sumikko Gurashi DX (Japan, set 2)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
 
-CONS( 2021, smkgacha,  0,        0, generalplus_gpspi_direct, bfmpac, generalplus_gpspi_direct_game_state, empty_init,  "San-X / Tomy", "Sumikko Gacha (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS( 2021, smkgacha,  0,        0, puni, bfmpac, generalplus_gpl951xx_game_state, empty_init,  "San-X / Tomy", "Sumikko Gacha (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
 
 // there seem to be different versions of this available, is the software the same?
-CONS( 201?, dsgnpal, 0, 0, generalplus_gpspi_direct, bfmpac, generalplus_gpspi_direct_game_state, empty_init,  "Tomy", "Kiratto Pri-Chan Design Palette (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS( 201?, dsgnpal, 0, 0, puni, bfmpac, generalplus_gpl951xx_game_state, empty_init,  "Tomy", "Kiratto Pri-Chan Design Palette (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
 
 // for these Sega Toys pets the clones might end up being duplicates with only different user data, however they might also have different factory default data for each colour
 // もっちりペット もっちまるず
-CONS( 2018, segapet1,  0,        0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Sega Toys", "Mocchiri Pet Mocchimaruzu (2018 version, set 1)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS( 2018, segapet1a, segapet1, 0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Sega Toys", "Mocchiri Pet Mocchimaruzu (2018 version, set 2)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS( 2018, segapet1,  0,        0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Sega Toys", "Mocchiri Pet Mocchimaruzu (2018 version, set 1)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS( 2018, segapet1a, segapet1, 0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Sega Toys", "Mocchiri Pet Mocchimaruzu (2018 version, set 2)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 // a 'DX' version (dated 2020) also exists, unclear if it's different software or just different packaging with bonuses
 
 // also もっちりペット もっちまるず
-CONS( 2019, segapet2,  0,        0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Sega Toys", "Mocchiri Pet Mocchimaruzu (2019 version, set 1)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS( 2019, segapet2a, segapet2, 0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Sega Toys", "Mocchiri Pet Mocchimaruzu (2019 version, set 2)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS( 2019, segapet2,  0,        0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Sega Toys", "Mocchiri Pet Mocchimaruzu (2019 version, set 1)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS( 2019, segapet2a, segapet2, 0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Sega Toys", "Mocchiri Pet Mocchimaruzu (2019 version, set 2)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
 // these ones have motors in the ears and a more fluffy cover
 // もっちふわペット もっちまるず
-CONS( 2020, segapet3,  0,        0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Sega Toys", "Mocchifuwa Pet Mocchimaruzu (set 1)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS( 2020, segapet3a, segapet3, 0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Sega Toys", "Mocchifuwa Pet Mocchimaruzu (set 2)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS( 2020, segapet3,  0,        0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Sega Toys", "Mocchifuwa Pet Mocchimaruzu (set 1)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS( 2020, segapet3a, segapet3, 0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Sega Toys", "Mocchifuwa Pet Mocchimaruzu (set 2)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
 // DX version of the first game, 2020 on box, updated fabric cover, still has 2018 on case, but different software?
-CONS( 2020, segaptdx,  0,        0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Sega Toys", "Mocchiri Pet Mocchimaruzu DX", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS( 2020, segaptdx,  0,        0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Sega Toys", "Mocchiri Pet Mocchimaruzu DX", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
 // まぜまぜミックス！ぷにタピちゃん
-CONS( 201?, bubltea,   0,        0, generalplus_gpspi_direct, bfspyhnt, generalplus_gpspi_direct_game_state, empty_init, "Bandai", "Mazemaze Mix! Puni Tapi-chan (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS( 201?, bubltea,   0,        0, puni, bfspyhnt, generalplus_gpl951xx_game_state, empty_init, "Bandai", "Mazemaze Mix! Puni Tapi-chan (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)

--- a/src/mame/tvgames/generalplus_gpl951xx.cpp
+++ b/src/mame/tvgames/generalplus_gpl951xx.cpp
@@ -14,7 +14,7 @@ namespace {
 class generalplus_gpl951xx_game_state : public driver_device
 {
 public:
-	generalplus_gpl951xx_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+	generalplus_gpl951xx_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
 		m_screen(*this, "screen"),
@@ -38,10 +38,10 @@ protected:
 
 	void gpl951xx(machine_config &config) ATTR_COLD;
 
-	uint16_t porta_r();
-	uint16_t portb_r();
-	uint16_t portc_r();
-	void porta_w(uint16_t data);
+	u16 porta_r();
+	u16 portb_r();
+	u16 portc_r();
+	void porta_w(u16 data);
 
 	void spi_reset(u8 data);
 	void spi_access_from_soc(u8 data);
@@ -54,28 +54,28 @@ protected:
 };
 
 
-uint16_t generalplus_gpl951xx_game_state::porta_r()
+u16 generalplus_gpl951xx_game_state::porta_r()
 {
-	uint16_t data = m_io[0]->read();
+	u16 data = m_io[0]->read();
 	logerror("Port A Read: %04x\n", data);
 	return data;
 }
 
-uint16_t generalplus_gpl951xx_game_state::portb_r()
+u16 generalplus_gpl951xx_game_state::portb_r()
 {
-	uint16_t data = m_io[1]->read();
+	u16 data = m_io[1]->read();
 	logerror("Port B Read: %04x\n", data);
 	return data;
 }
 
-uint16_t generalplus_gpl951xx_game_state::portc_r()
+u16 generalplus_gpl951xx_game_state::portc_r()
 {
-	uint16_t data = m_io[2]->read();
+	u16 data = m_io[2]->read();
 	logerror("Port C Read: %04x\n", data);
 	return data;
 }
 
-void generalplus_gpl951xx_game_state::porta_w(uint16_t data)
+void generalplus_gpl951xx_game_state::porta_w(u16 data)
 {
 	logerror("%s: Port A:WRITE %04x\n", machine().describe_context(), data);
 }
@@ -445,7 +445,7 @@ ROM_END
 
 void generalplus_gpl951xx_game_state::init_fif()
 {
-	u16* spirom16 = (u16*)memregion("spi")->base();
+	u16 *spirom16 = (u16*)memregion("spi")->base();
 	for (int i = 0; i < memregion("spi")->bytes() / 2; i++)
 	{
 		spirom16[i] = bitswap<16>(spirom16[i] ^ 0xdd0d,


### PR DESCRIPTION
- began splitting GPL951xx state from GPL162xx state
- improve function naming / logging in GPL162xx / GPL951xx
- rough/preliminary implementation of some GPL951xx features
- removed start-up code bypass hack for bfpacman, bfdigdug, bfspyhnt etc. as they can now properly identify the SPI ROM
- a few comment updates in GPCE4
- use u8 / u16 / u32 in touched files rather than the uintxx_t form + other general cleanups