### PR TITLE
frontend/mameopts.cpp: Fall back to settings from INI files later in the search path

### DIFF
--- a/src/frontend/mame/mameopts.cpp
+++ b/src/frontend/mame/mameopts.cpp
@@ -50,6 +50,7 @@ void mame_options::parse_standard_inis(emu_options &options, std::ostream &error
 			}
 			catch (options_exception const &ex)
 			{
+				util::stream_format(error_stream, "While parsing %s:\n%s\n", file.fullpath(), ex.message());
 			}
 		}
 	}

--- a/src/frontend/mame/mameopts.cpp
+++ b/src/frontend/mame/mameopts.cpp
@@ -36,9 +36,25 @@
 
 void mame_options::parse_standard_inis(emu_options &options, std::ostream &error_stream, const game_driver *driver)
 {
-	// parse the INI file defined by the platform (e.g., "mame.ini")
-	// we do this twice so that the first file can change the INI path
-	parse_one_ini(options, emulator_info::get_configname(), OPTION_PRIORITY_MAME_INI);
+	// parse exactly one of the main INI file to pick up and apply inipath and [no]readconfig
+	{
+		emu_file file(options.ini_path(), OPEN_FLAG_READ);
+		osd_printf_verbose("Attempting load of %s.ini\n", emulator_info::get_configname());
+		std::error_condition const filerr = file.open(std::string(emulator_info::get_configname()) + ".ini");
+		if (!filerr)
+		{
+			osd_printf_verbose("Parsing %s\n", file.fullpath());
+			try
+			{
+				options.parse_ini_file(static_cast<util::core_file &>(file), OPTION_PRIORITY_MAME_INI, true, false);
+			}
+			catch (options_exception const &ex)
+			{
+			}
+		}
+	}
+
+	// now parse the main INI file following the potentially updated search path
 	parse_one_ini(options, emulator_info::get_configname(), OPTION_PRIORITY_MAME_INI, &error_stream);
 
 	// debug mode: parse "debug.ini" as well
@@ -122,21 +138,19 @@ void mame_options::parse_one_ini(emu_options &options, const char *basename, int
 	// open the file; if we fail, that's ok
 	emu_file file(options.ini_path(), OPEN_FLAG_READ);
 	osd_printf_verbose("Attempting load of %s.ini\n", basename);
-	std::error_condition const filerr = file.open(std::string(basename) + ".ini");
-	if (filerr)
-		return;
-
-	// parse the file
-	osd_printf_verbose("Parsing %s.ini\n", basename);
-	try
+	for (std::error_condition filerr = file.open(std::string(basename) + ".ini"); !filerr; filerr = file.open_next())
 	{
-		options.parse_ini_file(static_cast<util::core_file &>(file), priority, priority < OPTION_PRIORITY_DRIVER_INI, false);
-	}
-	catch (options_exception &ex)
-	{
-		if (error_stream)
-			util::stream_format(*error_stream, "While parsing %s:\n%s\n", file.fullpath(), ex.message());
-		return;
+		// parse the file
+		osd_printf_verbose("Parsing %s\n", file.fullpath());
+		try
+		{
+			options.parse_ini_file(static_cast<util::core_file &>(file), priority, priority < OPTION_PRIORITY_DRIVER_INI, false);
+		}
+		catch (options_exception const &ex)
+		{
+			if (error_stream)
+				util::stream_format(*error_stream, "While parsing %s:\n%s\n", file.fullpath(), ex.message());
+		}
 	}
 }
 

--- a/src/lib/util/options.cpp
+++ b/src/lib/util/options.cpp
@@ -19,6 +19,7 @@
 #include <cstdlib>
 #include <locale>
 #include <sstream>
+#include <unordered_set>
 
 
 const int core_options::MAX_UNADORNED_OPTIONS;
@@ -977,6 +978,7 @@ void core_options::parse_command_line(const std::vector<std::string> &args, int 
 
 void core_options::parse_ini_file(util::core_file &inifile, int priority, bool ignore_unknown_options, bool always_override)
 {
+	std::unordered_set<entry *> entries_set;
 	std::ostringstream error_stream;
 	condition_type condition = condition_type::NONE;
 
@@ -1035,8 +1037,37 @@ void core_options::parse_ini_file(util::core_file &inifile, int priority, bool i
 			continue;
 		}
 
-		// set the new data
-		do_set_value(*curentry, trim_spaces_and_quotes(optiondata), priority, error_stream, condition, true);
+		// ensure INI files found earlier in the path have priority
+		std::string_view const trimmed = trim_spaces_and_quotes(optiondata);
+		if (entries_set.find(curentry.get()) != entries_set.end())
+		{
+			do_set_value(*curentry, trimmed, priority, error_stream, condition, true);
+		}
+		if (curentry->priority() < priority)
+		{
+			do_set_value(*curentry, trimmed, priority, error_stream, condition, true);
+			entries_set.emplace(curentry.get());
+		}
+		else
+		{
+			// just validate if the entry already has the same or higher priority and we didn't set it
+			try
+			{
+				curentry->validate(trimmed);
+			}
+			catch (options_warning_exception const &ex)
+			{
+				// we want to aggregate option exceptions
+				error_stream << ex.message();
+				condition = std::max(condition, condition_type::WARN);
+			}
+			catch (options_error_exception const &ex)
+			{
+				// we want to aggregate option exceptions
+				error_stream << ex.message();
+				condition = std::max(condition, condition_type::ERR);
+			}
+		}
 	}
 
 	// did we have any errors that may need to be aggregated?


### PR DESCRIPTION
This is a non-trivial change, so I’m opening a pull request.  The main immediately visible effect will be on MAME distributions that provide system-wide defaults in /etc/mame/mame.ini or similar.

Right now, MAME will stop looking for INI files as soon as it finds one with the name it’s looking for.  For example on Linux, the default `inipath` setting is `$HOME/.mame;.;ini` so if MAME finds a mame.ini in `~/.mame`, it won’t look for one in the working directory at all.

With this change, MAME will read mame.ini (or whatever INI file it’s looking for) for all the directories in the search path.  Settings in files earlier in the search path will override settings in files later in the search path.

For a practical example, supposed the `inipath` setting is set to `.;$HOME/.mame`.

Suppose mame.ini in the working directory contains:
```
window 1
```

and suppose mame.ini in `~/.mame` contains:
```
window 0
confirm_quit 1
```

Right now, MAME will stop after parsing the first file, so the effective options will be `-window`.  With this change, the effective options will be `-window -confirm_quit` (the `window` setting from the first INI file will take precedence, but the `confirm_quit` setting from the second INI file will take effect).

This won’t affect people who use `-createconfig` or save settings from the internal UI, as that writes out *all* the settings, not just settings you change.  It only affects people who create INI files with a subset of settings and have multiple similarly named INI files in the search path.

@rb6502, @galibert and @belegdol, what are your opinions on making this change?