### PR TITLE
namcos2.cpp: add additional Final Lap 2 set, redump tile ROMs for finalap2j

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -34538,6 +34538,7 @@ dsabera
 dsaberj
 finalap2
 finalap2j
+finalap2jb
 finalap3
 finalap3a
 finalap3bl

--- a/src/mame/namco/namcos2.cpp
+++ b/src/mame/namco/namcos2.cpp
@@ -2956,23 +2956,76 @@ ROM_START( finalap2j )
 	ROM_LOAD32_BYTE( "fl2obj5",  0x200001, 0x80000, CRC(d74ae0d3) SHA1(96c9798378da7bdc127ed7d02a4dd14dfd142550) )
 	ROM_LOAD32_BYTE( "fl2obj7",  0x200000, 0x80000, CRC(5ca68c93) SHA1(fa326992338843ccfa458a5b85ba58537da666d0) )
 
-	// The Japanese version should not be using the same ROMs as the World version here, causes corrupt text in attract mode should probably be fls1
 	ROM_REGION( 0x200000, "c123tmap", 0 ) /* Tiles */
-	ROM_LOAD( "fls2chr0",  0x000000, 0x40000, BAD_DUMP CRC(7bbda499) SHA1(cf6ff072a40063cbe41eae1f60b29447a0020926) )
-	ROM_LOAD( "fls2chr1",  0x040000, 0x40000, BAD_DUMP CRC(ac8940e5) SHA1(449687d38cf830445df713ed4d675ed94ca5b375) )
-	ROM_LOAD( "fls2chr2",  0x080000, 0x40000, BAD_DUMP CRC(1756173d) SHA1(c912163979098387aea9a0580e9ca55c1f7275f3) )
-	ROM_LOAD( "fls2chr3",  0x0c0000, 0x40000, BAD_DUMP CRC(69032785) SHA1(cfcd12bea730f724444188c206adcdb5e755eb7d) )
-	ROM_LOAD( "fls2chr4",  0x100000, 0x40000, BAD_DUMP CRC(8216cf42) SHA1(79820435584d769b63649b554574486dbcd6f468) )
-	ROM_LOAD( "fls2chr5",  0x140000, 0x40000, BAD_DUMP CRC(dc3e8e1c) SHA1(a7968cfa0ca2639364507b42526f10cf1b2000f4) )
-	ROM_LOAD( "fls2chr6",  0x180000, 0x40000, BAD_DUMP CRC(1ef4bdde) SHA1(ceb36c021450efa4cb0fee278fa0b9d65f7d1f05) )
-	ROM_LOAD( "fls2chr7",  0x1c0000, 0x40000, BAD_DUMP CRC(53dafcde) SHA1(f9d9460349b34bda95b8c206af7ce2347c951214) )
+	ROM_LOAD( "fls_chr0.bin",  0x000000, 0x40000, CRC(fdc8f3b6) SHA1(5178605eb6f7de688ff501bed4db35bd6a3ec65d) )
+	ROM_LOAD( "fls_chr1.bin",  0x040000, 0x40000, CRC(dd5917d9) SHA1(7afd74f5c1c32d952d5c0bf842c6dcfd59be9fb2) )
+	ROM_LOAD( "fls_chr2.bin",  0x080000, 0x40000, CRC(1756173d) SHA1(c912163979098387aea9a0580e9ca55c1f7275f3) )
+	ROM_LOAD( "fls_chr3.bin",  0x0c0000, 0x40000, CRC(69032785) SHA1(cfcd12bea730f724444188c206adcdb5e755eb7d) )
+	ROM_LOAD( "fls_chr4.bin",  0x100000, 0x40000, CRC(8216cf42) SHA1(79820435584d769b63649b554574486dbcd6f468) )
+	ROM_LOAD( "fls_chr5.bin",  0x140000, 0x40000, CRC(099e704c) SHA1(f479656e02dcc3fe91cb2a8bd25f48afa5177e1b) )
+	ROM_LOAD( "fls_chr6.bin",  0x180000, 0x40000, CRC(d97fe308) SHA1(4ee3bf3cc06e8024a97d2ba7e98981bd9739c935) )
+	ROM_LOAD( "fls_chr7.bin",  0x1c0000, 0x40000, CRC(cc43dea8) SHA1(1c26224bafc989ac6bab4b76c48011dab4c601b7) )
 
 	ROM_REGION( 0x080000, "c123tmap:mask", 0 ) /* Mask shape */
-	NAMCOS2_GFXROM_LOAD_256K( "fls2sha",  0x000000, BAD_DUMP CRC(f7b40a85) SHA1(a458a1cc0dae757fe8a15cb5f5ae46d3c033df00) )
+	NAMCOS2_GFXROM_LOAD_256K( "fls_sha.bin",  0x000000, CRC(f9ca8962) SHA1(1b8d29eb021afbbb6c00f168e8b092a153a58630) )
 
 	ROM_REGION16_BE( 0x200000, "data_rom", 0 ) /* Shared data ROMs */
 	NAMCOS2_DATA_LOAD_E_256K( "fls2dat0.13s",  0x000000, CRC(f1af432c) SHA1(c514261a49ceb5c3ba0246519ba5d02e9a20d950) )
 	NAMCOS2_DATA_LOAD_O_256K( "fls2dat1.13p",  0x000000, CRC(8719533e) SHA1(98d2767da6f7f67da7af15e8cfed95adb04b7427) )
+
+	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* PROM for road colors */
+	ROM_LOAD( "fl1-3.5b", 0, 0x100, CRC(d179d99a) SHA1(4e64f284c74d2b77f893bd28aaa6489084056aa2) )
+
+	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
+	ROM_LOAD16_BYTE( "flsvoi1",  0x000000, 0x080000, CRC(590be52f) SHA1(9ef2728dd533979b6019b422fc4961a6085428b4) )
+	ROM_LOAD16_BYTE( "flsvoi2",  0x100000, 0x080000, CRC(204b3c27) SHA1(80cd13bfe2a4b3039b4a120b905674e46b8b3b9c) )
+
+	ROM_REGION( 0x2000, "nvram", 0 ) /* default settings, including calibration */
+	ROM_LOAD( "finalap2.nv",  0x000000, 0x2000, CRC(c7ae5d0a) SHA1(9527e44accec0ec9d1990138d1b0bfc71957cc8a) )
+ROM_END
+
+/* FINAL LAP 2 (Japan, rev B) */
+ROM_START( finalap2jb )
+	ROM_REGION( 0x040000, "maincpu", 0 ) /* Master CPU */
+	ROM_LOAD16_BYTE( "fls1_mp0b.bin", 0x000000, 0x020000, CRC(ea09d01b) SHA1(e4fb4871d968ec4f039dae41512d507fbf1a9bd7) )
+	ROM_LOAD16_BYTE( "fls_mp1b.bin",  0x000001, 0x020000, CRC(5e20b03a) SHA1(7bc2be986f795eeaeb1087710fd27f73788a8574) )
+
+	ROM_REGION( 0x040000, "slave", 0 ) /* Slave CPU */
+	ROM_LOAD16_BYTE( "fls1sp0b",  0x000000, 0x020000, CRC(8bf15d9c) SHA1(b6c14a9d06e99d03636fd6eb2163a18e2bbcc4b1) )
+	ROM_LOAD16_BYTE( "fls1sp1b",  0x000001, 0x020000, CRC(c1a31086) SHA1(55317b72a219ffbfe00bf62ad2a635790d56f84e) )
+
+	ROM_REGION( 0x020000, "audiocpu", 0 ) /* Sound CPU (Banked) */
+	ROM_LOAD( "flss0",  0x000000, 0x020000, CRC(c07cc10a) SHA1(012f19a8014a77fdf0409241c0223b2c0c247357) )
+
+	ROM_REGION( 0x8000, "c65mcu:external", ROMREGION_ERASE00 ) /* I/O MCU */
+	ROM_LOAD( "sys2c65c.bin",  0x000000, 0x008000, CRC(a5b2a4ff) SHA1(068bdfcc71a5e83706e8b23330691973c1c214dc) )
+
+	ROM_REGION( 0x400000, "sprite", 0 ) /* Sprites */
+	ROM_LOAD32_BYTE( "fl2obj0",  0x000003, 0x80000, CRC(3657dd7a) SHA1(8f286ec0642b09ff42bf0dbd784ae257d4ab278a) )
+	ROM_LOAD32_BYTE( "fl2obj2",  0x000002, 0x80000, CRC(8ac933fd) SHA1(b158df2ec55f49ec05861075c8d7bd265361dab0) )
+	ROM_LOAD32_BYTE( "fl2obj4",  0x000001, 0x80000, CRC(e7b989e6) SHA1(485e8148510edd1645f5b4fbbc9a53e8bf1c3e5f) )
+	ROM_LOAD32_BYTE( "fl2obj6",  0x000000, 0x80000, CRC(4936583d) SHA1(0145e89fdb5db28cb8f8ce59572729e83d8fad7c) )
+	ROM_LOAD32_BYTE( "fl2obj1",  0x200003, 0x80000, CRC(3cebf419) SHA1(bfdf1b768920e55850173a5bcd1007608e1a4f56) )
+	ROM_LOAD32_BYTE( "fl2obj3",  0x200002, 0x80000, CRC(0959ed55) SHA1(00e640d449cb47da0e65baa798743395c7a1f632) )
+	ROM_LOAD32_BYTE( "fl2obj5",  0x200001, 0x80000, CRC(d74ae0d3) SHA1(96c9798378da7bdc127ed7d02a4dd14dfd142550) )
+	ROM_LOAD32_BYTE( "fl2obj7",  0x200000, 0x80000, CRC(5ca68c93) SHA1(fa326992338843ccfa458a5b85ba58537da666d0) )
+
+	ROM_REGION( 0x200000, "c123tmap", 0 ) /* Tiles */
+	ROM_LOAD( "fls_chr0.bin",  0x000000, 0x40000, CRC(fdc8f3b6) SHA1(5178605eb6f7de688ff501bed4db35bd6a3ec65d) )
+	ROM_LOAD( "fls_chr1.bin",  0x040000, 0x40000, CRC(dd5917d9) SHA1(7afd74f5c1c32d952d5c0bf842c6dcfd59be9fb2) )
+	ROM_LOAD( "fls_chr2.bin",  0x080000, 0x40000, CRC(1756173d) SHA1(c912163979098387aea9a0580e9ca55c1f7275f3) )
+	ROM_LOAD( "fls_chr3.bin",  0x0c0000, 0x40000, CRC(69032785) SHA1(cfcd12bea730f724444188c206adcdb5e755eb7d) )
+	ROM_LOAD( "fls_chr4.bin",  0x100000, 0x40000, CRC(8216cf42) SHA1(79820435584d769b63649b554574486dbcd6f468) )
+	ROM_LOAD( "fls_chr5.bin",  0x140000, 0x40000, CRC(099e704c) SHA1(f479656e02dcc3fe91cb2a8bd25f48afa5177e1b) )
+	ROM_LOAD( "fls_chr6.bin",  0x180000, 0x40000, CRC(d97fe308) SHA1(4ee3bf3cc06e8024a97d2ba7e98981bd9739c935) )
+	ROM_LOAD( "fls_chr7.bin",  0x1c0000, 0x40000, CRC(cc43dea8) SHA1(1c26224bafc989ac6bab4b76c48011dab4c601b7) )
+
+	ROM_REGION( 0x080000, "c123tmap:mask", 0 ) /* Mask shape */
+	NAMCOS2_GFXROM_LOAD_256K( "fls_sha.bin",  0x000000, CRC(f9ca8962) SHA1(1b8d29eb021afbbb6c00f168e8b092a153a58630) )
+
+	ROM_REGION16_BE( 0x200000, "data_rom", 0 ) /* Shared data ROMs */
+	NAMCOS2_DATA_LOAD_E_256K( "fls1_dat0.bin",  0x000000, CRC(2f993682) SHA1(e83e2a60adc334fb76861fa01ca1ae94beaa2ff6) )
+	NAMCOS2_DATA_LOAD_O_256K( "fls1_dat1.bin",  0x000000, CRC(8719533e) SHA1(98d2767da6f7f67da7af15e8cfed95adb04b7427) )
 
 	ROM_REGION( 0x100, "c45_road:clut", 0 ) /* PROM for road colors */
 	ROM_LOAD( "fl1-3.5b", 0, 0x100, CRC(d179d99a) SHA1(4e64f284c74d2b77f893bd28aaa6489084056aa2) )
@@ -5759,6 +5812,7 @@ GAME(  1990, dsaberj,    dsaber,   base3,    base,     namcos2_state,  init_dsab
 
 GAMEL( 1990, finalap2,   0,        finalap2, finallap, finallap_state, init_finalap2, ROT0,   "Namco", "Final Lap 2", MACHINE_IMPERFECT_GRAPHICS | MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE, layout_finallap )
 GAMEL( 1990, finalap2j,  finalap2, finalap2, finallap, finallap_state, init_finalap2, ROT0,   "Namco", "Final Lap 2 (Japan)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE, layout_finallap )
+GAMEL( 1990, finalap2jb, finalap2, finalap2, finallap, finallap_state, init_finalap2, ROT0,   "Namco", "Final Lap 2 (Japan, Rev B)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE, layout_finallap )
 
 GAME(  1990, gollygho,   0,        base,     gollygho, gollygho_state, init_gollygho, ROT180, "Namco", "Golly! Ghost!", MACHINE_REQUIRES_ARTWORK | MACHINE_SUPPORTS_SAVE )
 


### PR DESCRIPTION
Before and after:
<img width="288" height="224" alt="0000" src="https://github.com/user-attachments/assets/3f45f988-4f64-49c2-9de0-3004c24555d0" /><img width="288" height="224" alt="0002" src="https://github.com/user-attachments/assets/189cec8c-f1bd-41b7-a50d-d4ad3aa3be58" />

New working clones
----------
Final Lap 2 (Japan, Rev B) [Devin Acker]