### PR TITLE
Linked-play support for Taito's Gunbuster

### DIFF
--- a/src/mame/taito/gunbustr.cpp
+++ b/src/mame/taito/gunbustr.cpp
@@ -49,6 +49,7 @@
 #include "taito_en.h"
 #include "taitoio.h"
 #include "tc0480scp.h"
+#include "gunbustr_l.h"
 
 #include "cpu/m68000/m68020.h"
 #include "machine/eepromser.h"
@@ -82,7 +83,7 @@ public:
 		m_tc0480scp(*this, "tc0480scp"),
 		m_ram(*this,"ram"),
 		m_spriteram(*this,"spriteram"),
-		m_netram(*this,"netram"),
+		m_link(*this, "link"),
 		m_eeprom(*this, "eeprom"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
@@ -94,7 +95,6 @@ public:
 
 	{
 		m_coin_lockout = true;
-		link_netintf_init(mconfig);
 	}
 
 	void gunbustr(machine_config &config);
@@ -123,7 +123,7 @@ private:
 	required_device<tc0480scp_device> m_tc0480scp;
 	required_shared_ptr<u32> m_ram;
 	required_shared_ptr<u32> m_spriteram;
-	required_shared_ptr<u32> m_netram;
+	required_device<gunbustr_link_device> m_link;
 	required_device<eeprom_serial_93cxx_device> m_eeprom;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
@@ -147,62 +147,6 @@ private:
 	bool m_coin_lockout;
 	std::unique_ptr<gb_tempsprite[]> m_spritelist{};
 	emu_timer *m_interrupt5_timer = nullptr;
-
-	// Networking support below here
-	enum gb_linkcmd_type
-	{
-		LINKCMD_NOP = 0,
-		LINKCMD_SEND_NODE_ID,
-		LINKCMD_SEND_LOCK,
-		LINKCMD_SEND_CTRL,
-		LINKCMD_RECV_DATA,
-		LINKCMD_SEND_DATA,
-	};
-
-	struct gb_linkcmd
-	{
-		u32 type;
-		u32 nodeid;
-		u32 data;
-	};
-
-	emu_timer *m_link_connect_timer;
-	osd_file::ptr m_link_rx;
-	osd_file::ptr m_link_tx;
-	char m_link_localhost[256];
-	char m_link_remotehost[256];
-
-	// Network setup
-	bool link_netintf_init(const machine_config &mconfig);
-	TIMER_CALLBACK_MEMBER(link_netintf_callback);
-	void link_netintf_socket_check(void);
-	void link_begin(void);
-
-	// Raw network interface
-	bool link_netintf_recvblock(void *buf, size_t bytes);
-	bool link_netintf_sendblock(const void *buf, size_t bytes);
-	bool link_netintf_fetch_cmd(gb_linkcmd *cmd);
-	bool link_netintf_send_cmd(const gb_linkcmd *cmd);
-
-	// Network node update
-	void link_update(void);
-
-	// Data transfer
-	void link_send_data(u8 nodeid);
-	void link_recv_data(u8 nodeid);
-	void link_send_lock(u8 nodeid, u16 data);
-	void link_send_id(u8 nodeid, u16 data);
-	void link_send_ctrl(u8 nodeid);
-
-	// Memory handlers
-	void link_ctrl_w(u8 nodeid, u32 data, u32 mem_mask);
-	void link0_ctrl_w(offs_t offset, u32 data, u32 mem_mask = ~u32(0));
-	void link1_ctrl_w(offs_t offset, u32 data, u32 mem_mask = ~u32(0));
-	u32 link_ctrl_r(u8 nodeid);
-	u32 link0_ctrl_r(offs_t offset);
-	u32 link1_ctrl_r(offs_t offset);
-	u32 link_ram_r(offs_t offset);
-	void link_ram_w(offs_t offset, u32 data, u32 mem_mask);
 };
 
 
@@ -483,303 +427,6 @@ void gunbustr_state::gun_w(u32 data)
 	m_interrupt5_timer->adjust(m_maincpu->cycles_to_attotime(10000));
 }
 
-/***********************************************************
-             NETWORK INTERFACE
-***********************************************************/
-bool gunbustr_state::link_netintf_init(const machine_config &mconfig)
-{
-	snprintf(m_link_localhost,sizeof(m_link_localhost), "socket.%s:%s",
-			mconfig.options().comm_localhost(), mconfig.options().comm_localport());
-	snprintf(m_link_remotehost,sizeof(m_link_remotehost), "socket.%s:%s",
-			mconfig.options().comm_remotehost(), mconfig.options().comm_remoteport());
-
-	return true;
-}
-
-void gunbustr_state::link_netintf_socket_check(void)
-{
-	// check rx socket
-	if (!m_link_rx)
-	{
-		LOGMASKED(LOG_LINKPROC, "listen on %s\n", m_link_localhost);
-		uint64_t filesize; // unused
-		osd_file::open(m_link_localhost, OPEN_FLAG_CREATE, m_link_rx, filesize);
-	}
-	// check tx socket
-	if (!m_link_tx)
-	{
-		// TODO: How to make this non-blocking?
-		LOGMASKED(LOG_LINKPROC, "connect to %s\n", m_link_remotehost);
-		uint64_t filesize; // unused
-		osd_file::open(m_link_remotehost, 0, m_link_tx, filesize);
-	}
-}
-
-// TODO: Use a thread instead of a timer so we can avoid blocking emulation...
-TIMER_CALLBACK_MEMBER(gunbustr_state::link_netintf_callback)
-{
-	m_link_connect_timer->adjust(attotime::never);
-	link_netintf_socket_check();
-	m_link_connect_timer->adjust(attotime::from_nsec(1000));
-}
-
-void gunbustr_state::link_begin(void)
-{
-	m_link_connect_timer = timer_alloc(FUNC(gunbustr_state::link_netintf_callback), this);
-	m_link_connect_timer->adjust(attotime::from_hz(100000));
-}
-
-bool gunbustr_state::link_netintf_recvblock(void *buf, size_t bytes)
-{
-	if (!m_link_rx) return false;
-
-	std::uint32_t amt = 0;
-	std::error_condition err = m_link_rx->read(buf, 0, bytes, amt);
-	if (err)
-	{
-		LOGMASKED(LOG_LINKRX, "RX ERROR [%s]\n", err.message().c_str());
-		return false;
-	}
-	if (amt != bytes)
-	{
-		LOGMASKED(LOG_LINKRX, "RX NOT ENOUGH %d => %d\n", bytes, amt);
-		return false;
-	}
-	return true;
-}
-
-bool gunbustr_state::link_netintf_sendblock(const void *buf, size_t bytes)
-{
-	if(!m_link_tx) return false;
-
-	std::uint32_t amt = 0;
-	std::error_condition err = m_link_tx->write(buf, 0, bytes, amt);
-	if (err)
-	{
-		LOGMASKED(LOG_LINKPROC, "TX ERROR [%s]\n", err.message().c_str());
-		m_link_tx = nullptr;
-		return false;
-	}
-	if (amt != bytes)
-	{
-		LOGMASKED(LOG_LINKTX, "TX NOT ENOUGH %d => %d\n", bytes, amt);
-		return false;
-	}
-	return true;
-}
-
-bool gunbustr_state::link_netintf_fetch_cmd(gb_linkcmd *cmd)
-{
-	*cmd = (gb_linkcmd){};
-	u8 cmdpkt[12] = {0};
-	if (!link_netintf_recvblock(cmdpkt, 12))
-	{
-		cmd->type = LINKCMD_NOP;
-		return false;
-	}
-	cmd->type = (cmdpkt[ 3] <<24) |
-				(cmdpkt[ 2] <<16) |
-				(cmdpkt[ 1] << 8) |
-				(cmdpkt[ 0] << 0);
-	cmd->nodeid =	(cmdpkt[ 7] <<24) |
-					(cmdpkt[ 6] <<16) |
-					(cmdpkt[ 5] << 8) |
-					(cmdpkt[ 4] << 0);
-	cmd->data = (cmdpkt[11] <<24) |
-				(cmdpkt[10] <<16) |
-				(cmdpkt[ 9] << 8) |
-				(cmdpkt[ 8] << 0);
-	return true;
-}
-
-bool gunbustr_state::link_netintf_send_cmd(const gb_linkcmd *cmd)
-{
-	const u8 cmdpkt[12] =
-	{
-		(u8)(cmd->type >> 0),
-		(u8)(cmd->type >> 8),
-		(u8)(cmd->type >>16),
-		(u8)(cmd->type >>24),
-		(u8)(cmd->nodeid >> 0),
-		(u8)(cmd->nodeid >> 8),
-		(u8)(cmd->nodeid >>16),
-		(u8)(cmd->nodeid >>24),
-		(u8)(cmd->data >> 0),
-		(u8)(cmd->data >> 8),
-		(u8)(cmd->data >>16),
-		(u8)(cmd->data >>24),
-	};
-	return link_netintf_sendblock(cmdpkt, 12);
-}
-
-/***********************************************************
-             NETWORK PROTOCOL
-***********************************************************/
-void gunbustr_state::link_update(void)
-{
-	gb_linkcmd cmd;
-	while (link_netintf_fetch_cmd(&cmd))
-	{
-		switch (cmd.type)
-		{
-			default:
-				break;
-			case LINKCMD_RECV_DATA:
-				LOGMASKED(LOG_LINKPROC, "[proc] RecvData %d\n", cmd.nodeid);
-				link_netintf_sendblock(&m_netram[0x40*cmd.nodeid], 0xFC);
-				break;
-			case LINKCMD_SEND_DATA:
-				LOGMASKED(LOG_LINKPROC, "[proc] SendData %d\n", cmd.nodeid);
-				link_netintf_recvblock(&m_netram[0x40*cmd.nodeid], 0xFC);
-				break;
-			case LINKCMD_SEND_CTRL:
-				LOGMASKED(LOG_LINKPROC, "[proc] RecvCtrl %d\n", cmd.nodeid);
-				m_netram[0x40*cmd.nodeid+0x3F] = cmd.data;
-				break;
-			case LINKCMD_SEND_LOCK:
-				LOGMASKED(LOG_LINKPROC, "[proc] SendLock %d 0x%X\n", cmd.nodeid, cmd.data);
-				m_netram[0x40*cmd.nodeid+0x3F] &= ~(0xFFFF<<16);
-				m_netram[0x40*cmd.nodeid+0x3F] |= cmd.data << 16;
-				break;
-			case LINKCMD_SEND_NODE_ID:
-				LOGMASKED(LOG_LINKPROC, "[proc] SendNodeId %d 0x%X\n", cmd.nodeid, cmd.data);
-				m_netram[0x40*cmd.nodeid+0x3F] &= ~0xFFFF;
-				m_netram[0x40*cmd.nodeid+0x3F] |= cmd.data;
-				break;
-		}
-	}
-}
-
-void gunbustr_state::link_recv_data(u8 nodeid)
-{
-	gb_linkcmd cmd =
-	{
-		.type = LINKCMD_RECV_DATA,
-		.nodeid = nodeid,
-	};
-	link_netintf_send_cmd(&cmd);
-	link_netintf_recvblock(&m_netram[0x40*nodeid], 0xFC);
-}
-
-void gunbustr_state::link_send_data(u8 nodeid)
-{
-	gb_linkcmd cmd =
-	{
-		.type = LINKCMD_SEND_DATA,
-		.nodeid = nodeid,
-	};
-	link_netintf_send_cmd(&cmd);
-	link_netintf_sendblock(&m_netram[0x40*nodeid], 0xFC);
-}
-
-void gunbustr_state::link_send_lock(u8 nodeid, u16 data)
-{
-	gb_linkcmd cmd =
-	{
-		.type = LINKCMD_SEND_LOCK,
-		.nodeid = nodeid,
-		.data = data,
-	};
-	link_netintf_send_cmd(&cmd);
-}
-
-void gunbustr_state::link_send_id(u8 nodeid, u16 data)
-{
-	gb_linkcmd cmd =
-	{
-		.type = LINKCMD_SEND_NODE_ID,
-		.nodeid = nodeid,
-		.data = data,
-	};
-	link_netintf_send_cmd(&cmd);
-}
-
-void gunbustr_state::link_send_ctrl(u8 nodeid)
-{
-	gb_linkcmd cmd =
-	{
-		.type = LINKCMD_SEND_CTRL,
-		.nodeid = nodeid,
-		.data = m_netram[0x40*nodeid+0x3F],
-	};
-	link_netintf_send_cmd(&cmd);
-}
-
-/***********************************************************
-             NETWORK "REGISTER" INTERFACE
-***********************************************************/
-u32 gunbustr_state::link_ctrl_r(u8 nodeid)
-{
-	link_update();
-	link_send_ctrl(nodeid); // why is this correct?...
-	return m_netram[0x40*nodeid + 0x3F];
-}
-
-void gunbustr_state::link_ctrl_w(u8 nodeid, u32 data, u32 mem_mask)
-{
-	link_update();
-	u32 prev_ctrl = m_netram[0x40*nodeid + 0x3F];
-	COMBINE_DATA(&m_netram[0x40*nodeid + 0x3F]);
-
-	if (ACCESSING_BITS_0_15) // Writing to "ID" port
-	{
-		u16 v = data & 0xFFFF;
-		link_send_id(nodeid, v);
-	}
-
-	if (ACCESSING_BITS_16_31) // Writing to "lock" port
-	{
-		u16 v = (data >> 16);
-		u16 prev = (prev_ctrl >> 16);
-
-		link_send_lock(nodeid, v);
-
-		if ((prev & ~v) & 2) // Write release
-		{
-			link_send_data(nodeid);
-		}
-
-		if ((v & ~prev) & 1) // Read assert
-		{
-			// sync opposite node
-			link_recv_data(nodeid ^ 1);
-		}
-	}
-
-	link_update();
-}
-
-u32 gunbustr_state::link0_ctrl_r(offs_t offset)
-{
-	return link_ctrl_r(0);
-}
-
-void gunbustr_state::link0_ctrl_w(offs_t offset, u32 data, u32 mem_mask)
-{
-	link_ctrl_w(0, data, mem_mask);
-}
-
-u32 gunbustr_state::link1_ctrl_r(offs_t offset)
-{
-	return link_ctrl_r(1);
-}
-
-void gunbustr_state::link1_ctrl_w(offs_t offset, u32 data, u32 mem_mask)
-{
-	link_ctrl_w(1, data, mem_mask);
-}
-
-u32 gunbustr_state::link_ram_r(offs_t offset)
-{
-	link_update();
-	return m_netram[offset];
-}
-
-void gunbustr_state::link_ram_w(offs_t offset, u32 data, u32 mem_mask)
-{
-	link_update();
-	COMBINE_DATA(&m_netram[offset]);
-}
 
 /***********************************************************
              MEMORY STRUCTURES
@@ -797,10 +444,7 @@ void gunbustr_state::prg_map(address_map &map)
 	map(0x800000, 0x80ffff).rw(m_tc0480scp, FUNC(tc0480scp_device::ram_r), FUNC(tc0480scp_device::ram_w));
 	map(0x830000, 0x83002f).rw(m_tc0480scp, FUNC(tc0480scp_device::ctrl_r), FUNC(tc0480scp_device::ctrl_w));
 	map(0x900000, 0x901fff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette");
-	map(0xc00000, 0xc001ff).mirror(0x3e00).rw(FUNC(gunbustr_state::link_ram_r),FUNC(gunbustr_state::link_ram_w)).ram().share(m_netram); // network RAM
-	// These aren't hooked up by hardware, but the networking protocol makes this a perfect hook
-	map(0xc000fc, 0xc000ff).mirror(0x3e00).rw(FUNC(gunbustr_state::link0_ctrl_r),FUNC(gunbustr_state::link0_ctrl_w)); // network control (ID=0)
-	map(0xc001fc, 0xc001ff).mirror(0x3e00).rw(FUNC(gunbustr_state::link1_ctrl_r),FUNC(gunbustr_state::link1_ctrl_w)); // network control (ID=1)
+	map(0xc00000, 0xc001ff).mirror(0x3e00).m(m_link, FUNC(gunbustr_link_device::map));
 }
 
 /***********************************************************
@@ -839,7 +483,7 @@ static INPUT_PORTS_START( gunbustr )
 	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(2)
 
 	PORT_START("PORT03")
-	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER(1) // DMAON (6-A5)
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_CUSTOM ) // DMAON (6-A5)
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_UNKNOWN ) // OUTPUT 1
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_UNKNOWN ) // Z0 (Z-3)
 	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_UNKNOWN ) // Z1 (Z-4)
@@ -929,6 +573,8 @@ void gunbustr_state::gunbustr(machine_config &config)
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_gunbustr);
 	PALETTE(config, m_palette).set_format(palette_device::xRGB_555, 4096);
+
+	GUNBUSTR_LINK(config, m_link, 1000); // fake clock
 
 	TC0480SCP(config, m_tc0480scp, 0);
 	m_tc0480scp->set_palette(m_palette);
@@ -1062,8 +708,6 @@ void gunbustr_state::init_gunbustr()
 	m_maincpu->space(AS_PROGRAM).install_read_handler(0x203acc, 0x203acf, read32smo_delegate(*this, FUNC(gunbustr_state::main_cycle_r)));
 
 	m_interrupt5_timer = timer_alloc(FUNC(gunbustr_state::trigger_irq5), this);
-
-	link_begin();
 }
 
 void gunbustr_state::init_gunbustrj()

--- a/src/mame/taito/gunbustr.cpp
+++ b/src/mame/taito/gunbustr.cpp
@@ -1,11 +1,12 @@
 // license:BSD-3-Clause
-// copyright-holders: Bryan McPhail, David Graves
+// copyright-holders: Bryan McPhail, David Graves, Alex "trap15" Marshall
 
 /****************************************************************************
 
     Gunbuster (c) 1992 Taito
 
     Driver by Bryan McPhail & David Graves.
+    Network support by Alex "trap15" Marshall.
 
     Board Info:
 
@@ -40,11 +41,10 @@
         FLIPX support in the video chips is not quite correct - the Taito logo is wrong,
         and the floor in the Doom levels has horizontal scrolling where it shouldn't.
 
-        No networked machine support
-
 ***************************************************************************/
 
 #include "emu.h"
+#include "emuopts.h"
 
 #include "taito_en.h"
 #include "taitoio.h"
@@ -58,16 +58,18 @@
 #include "screen.h"
 #include "speaker.h"
 
-
 // configurable logging
-#define LOG_BADSPRITES     (1U << 1)
+#define LOG_BADSPRITES	(1U << 1)
+#define LOG_LINKPROC	(1U << 2)
+#define LOG_LINKTX		(1U << 3)
+#define LOG_LINKRX		(1U << 4)
 
+//#define VERBOSE (LOG_GENERAL | LOG_LINKPROC)
 //#define VERBOSE (LOG_GENERAL | LOG_BADSPRITES)
 
 #include "logmacro.h"
 
 #define LOGBADSPRITES(...)     LOGMASKED(LOG_BADSPRITES,     __VA_ARGS__)
-
 
 namespace {
 
@@ -80,6 +82,7 @@ public:
 		m_tc0480scp(*this, "tc0480scp"),
 		m_ram(*this,"ram"),
 		m_spriteram(*this,"spriteram"),
+		m_netram(*this,"netram"),
 		m_eeprom(*this, "eeprom"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
@@ -91,6 +94,7 @@ public:
 
 	{
 		m_coin_lockout = true;
+		link_netintf_init(mconfig);
 	}
 
 	void gunbustr(machine_config &config);
@@ -119,6 +123,7 @@ private:
 	required_device<tc0480scp_device> m_tc0480scp;
 	required_shared_ptr<u32> m_ram;
 	required_shared_ptr<u32> m_spriteram;
+	required_shared_ptr<u32> m_netram;
 	required_device<eeprom_serial_93cxx_device> m_eeprom;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
@@ -142,6 +147,62 @@ private:
 	bool m_coin_lockout;
 	std::unique_ptr<gb_tempsprite[]> m_spritelist{};
 	emu_timer *m_interrupt5_timer = nullptr;
+
+	// Networking support below here
+	enum gb_linkcmd_type
+	{
+		LINKCMD_NOP = 0,
+		LINKCMD_SEND_NODE_ID,
+		LINKCMD_SEND_LOCK,
+		LINKCMD_SEND_CTRL,
+		LINKCMD_RECV_DATA,
+		LINKCMD_SEND_DATA,
+	};
+
+	struct gb_linkcmd
+	{
+		u32 type;
+		u32 nodeid;
+		u32 data;
+	};
+
+	emu_timer *m_link_connect_timer;
+	osd_file::ptr m_link_rx;
+	osd_file::ptr m_link_tx;
+	char m_link_localhost[256];
+	char m_link_remotehost[256];
+
+	// Network setup
+	bool link_netintf_init(const machine_config &mconfig);
+	TIMER_CALLBACK_MEMBER(link_netintf_callback);
+	void link_netintf_socket_check(void);
+	void link_begin(void);
+
+	// Raw network interface
+	bool link_netintf_recvblock(void *buf, size_t bytes);
+	bool link_netintf_sendblock(const void *buf, size_t bytes);
+	bool link_netintf_fetch_cmd(gb_linkcmd *cmd);
+	bool link_netintf_send_cmd(const gb_linkcmd *cmd);
+
+	// Network node update
+	void link_update(void);
+
+	// Data transfer
+	void link_send_data(u8 nodeid);
+	void link_recv_data(u8 nodeid);
+	void link_send_lock(u8 nodeid, u16 data);
+	void link_send_id(u8 nodeid, u16 data);
+	void link_send_ctrl(u8 nodeid);
+
+	// Memory handlers
+	void link_ctrl_w(u8 nodeid, u32 data, u32 mem_mask);
+	void link0_ctrl_w(offs_t offset, u32 data, u32 mem_mask = ~u32(0));
+	void link1_ctrl_w(offs_t offset, u32 data, u32 mem_mask = ~u32(0));
+	u32 link_ctrl_r(u8 nodeid);
+	u32 link0_ctrl_r(offs_t offset);
+	u32 link1_ctrl_r(offs_t offset);
+	u32 link_ram_r(offs_t offset);
+	void link_ram_w(offs_t offset, u32 data, u32 mem_mask);
 };
 
 
@@ -410,8 +471,6 @@ void gunbustr_state::motor_control_w(u32 data)
 	m_hit_lamp = BIT(data, 18);
 }
 
-
-
 u32 gunbustr_state::gun_r()
 {
 	return (m_io_light_x[0]->read() << 24) | (m_io_light_y[0]->read() << 16) |
@@ -424,6 +483,303 @@ void gunbustr_state::gun_w(u32 data)
 	m_interrupt5_timer->adjust(m_maincpu->cycles_to_attotime(10000));
 }
 
+/***********************************************************
+             NETWORK INTERFACE
+***********************************************************/
+bool gunbustr_state::link_netintf_init(const machine_config &mconfig)
+{
+	snprintf(m_link_localhost,sizeof(m_link_localhost), "socket.%s:%s",
+			mconfig.options().comm_localhost(), mconfig.options().comm_localport());
+	snprintf(m_link_remotehost,sizeof(m_link_remotehost), "socket.%s:%s",
+			mconfig.options().comm_remotehost(), mconfig.options().comm_remoteport());
+
+	return true;
+}
+
+void gunbustr_state::link_netintf_socket_check(void)
+{
+	// check rx socket
+	if (!m_link_rx)
+	{
+		LOGMASKED(LOG_LINKPROC, "listen on %s\n", m_link_localhost);
+		uint64_t filesize; // unused
+		osd_file::open(m_link_localhost, OPEN_FLAG_CREATE, m_link_rx, filesize);
+	}
+	// check tx socket
+	if (!m_link_tx)
+	{
+		// TODO: How to make this non-blocking?
+		LOGMASKED(LOG_LINKPROC, "connect to %s\n", m_link_remotehost);
+		uint64_t filesize; // unused
+		osd_file::open(m_link_remotehost, 0, m_link_tx, filesize);
+	}
+}
+
+// TODO: Use a thread instead of a timer so we can avoid blocking emulation...
+TIMER_CALLBACK_MEMBER(gunbustr_state::link_netintf_callback)
+{
+	m_link_connect_timer->adjust(attotime::never);
+	link_netintf_socket_check();
+	m_link_connect_timer->adjust(attotime::from_nsec(1000));
+}
+
+void gunbustr_state::link_begin(void)
+{
+	m_link_connect_timer = timer_alloc(FUNC(gunbustr_state::link_netintf_callback), this);
+	m_link_connect_timer->adjust(attotime::from_hz(100000));
+}
+
+bool gunbustr_state::link_netintf_recvblock(void *buf, size_t bytes)
+{
+	if (!m_link_rx) return false;
+
+	std::uint32_t amt = 0;
+	std::error_condition err = m_link_rx->read(buf, 0, bytes, amt);
+	if (err)
+	{
+		LOGMASKED(LOG_LINKRX, "RX ERROR [%s]\n", err.message().c_str());
+		return false;
+	}
+	if (amt != bytes)
+	{
+		LOGMASKED(LOG_LINKRX, "RX NOT ENOUGH %d => %d\n", bytes, amt);
+		return false;
+	}
+	return true;
+}
+
+bool gunbustr_state::link_netintf_sendblock(const void *buf, size_t bytes)
+{
+	if(!m_link_tx) return false;
+
+	std::uint32_t amt = 0;
+	std::error_condition err = m_link_tx->write(buf, 0, bytes, amt);
+	if (err)
+	{
+		LOGMASKED(LOG_LINKPROC, "TX ERROR [%s]\n", err.message().c_str());
+		m_link_tx = nullptr;
+		return false;
+	}
+	if (amt != bytes)
+	{
+		LOGMASKED(LOG_LINKTX, "TX NOT ENOUGH %d => %d\n", bytes, amt);
+		return false;
+	}
+	return true;
+}
+
+bool gunbustr_state::link_netintf_fetch_cmd(gb_linkcmd *cmd)
+{
+	*cmd = (gb_linkcmd){};
+	u8 cmdpkt[12] = {0};
+	if (!link_netintf_recvblock(cmdpkt, 12))
+	{
+		cmd->type = LINKCMD_NOP;
+		return false;
+	}
+	cmd->type = (cmdpkt[ 3] <<24) |
+				(cmdpkt[ 2] <<16) |
+				(cmdpkt[ 1] << 8) |
+				(cmdpkt[ 0] << 0);
+	cmd->nodeid =	(cmdpkt[ 7] <<24) |
+					(cmdpkt[ 6] <<16) |
+					(cmdpkt[ 5] << 8) |
+					(cmdpkt[ 4] << 0);
+	cmd->data = (cmdpkt[11] <<24) |
+				(cmdpkt[10] <<16) |
+				(cmdpkt[ 9] << 8) |
+				(cmdpkt[ 8] << 0);
+	return true;
+}
+
+bool gunbustr_state::link_netintf_send_cmd(const gb_linkcmd *cmd)
+{
+	const u8 cmdpkt[12] =
+	{
+		(u8)(cmd->type >> 0),
+		(u8)(cmd->type >> 8),
+		(u8)(cmd->type >>16),
+		(u8)(cmd->type >>24),
+		(u8)(cmd->nodeid >> 0),
+		(u8)(cmd->nodeid >> 8),
+		(u8)(cmd->nodeid >>16),
+		(u8)(cmd->nodeid >>24),
+		(u8)(cmd->data >> 0),
+		(u8)(cmd->data >> 8),
+		(u8)(cmd->data >>16),
+		(u8)(cmd->data >>24),
+	};
+	return link_netintf_sendblock(cmdpkt, 12);
+}
+
+/***********************************************************
+             NETWORK PROTOCOL
+***********************************************************/
+void gunbustr_state::link_update(void)
+{
+	gb_linkcmd cmd;
+	while (link_netintf_fetch_cmd(&cmd))
+	{
+		switch (cmd.type)
+		{
+			default:
+				break;
+			case LINKCMD_RECV_DATA:
+				LOGMASKED(LOG_LINKPROC, "[proc] RecvData %d\n", cmd.nodeid);
+				link_netintf_sendblock(&m_netram[0x40*cmd.nodeid], 0xFC);
+				break;
+			case LINKCMD_SEND_DATA:
+				LOGMASKED(LOG_LINKPROC, "[proc] SendData %d\n", cmd.nodeid);
+				link_netintf_recvblock(&m_netram[0x40*cmd.nodeid], 0xFC);
+				break;
+			case LINKCMD_SEND_CTRL:
+				LOGMASKED(LOG_LINKPROC, "[proc] RecvCtrl %d\n", cmd.nodeid);
+				m_netram[0x40*cmd.nodeid+0x3F] = cmd.data;
+				break;
+			case LINKCMD_SEND_LOCK:
+				LOGMASKED(LOG_LINKPROC, "[proc] SendLock %d 0x%X\n", cmd.nodeid, cmd.data);
+				m_netram[0x40*cmd.nodeid+0x3F] &= ~(0xFFFF<<16);
+				m_netram[0x40*cmd.nodeid+0x3F] |= cmd.data << 16;
+				break;
+			case LINKCMD_SEND_NODE_ID:
+				LOGMASKED(LOG_LINKPROC, "[proc] SendNodeId %d 0x%X\n", cmd.nodeid, cmd.data);
+				m_netram[0x40*cmd.nodeid+0x3F] &= ~0xFFFF;
+				m_netram[0x40*cmd.nodeid+0x3F] |= cmd.data;
+				break;
+		}
+	}
+}
+
+void gunbustr_state::link_recv_data(u8 nodeid)
+{
+	gb_linkcmd cmd =
+	{
+		.type = LINKCMD_RECV_DATA,
+		.nodeid = nodeid,
+	};
+	link_netintf_send_cmd(&cmd);
+	link_netintf_recvblock(&m_netram[0x40*nodeid], 0xFC);
+}
+
+void gunbustr_state::link_send_data(u8 nodeid)
+{
+	gb_linkcmd cmd =
+	{
+		.type = LINKCMD_SEND_DATA,
+		.nodeid = nodeid,
+	};
+	link_netintf_send_cmd(&cmd);
+	link_netintf_sendblock(&m_netram[0x40*nodeid], 0xFC);
+}
+
+void gunbustr_state::link_send_lock(u8 nodeid, u16 data)
+{
+	gb_linkcmd cmd =
+	{
+		.type = LINKCMD_SEND_LOCK,
+		.nodeid = nodeid,
+		.data = data,
+	};
+	link_netintf_send_cmd(&cmd);
+}
+
+void gunbustr_state::link_send_id(u8 nodeid, u16 data)
+{
+	gb_linkcmd cmd =
+	{
+		.type = LINKCMD_SEND_NODE_ID,
+		.nodeid = nodeid,
+		.data = data,
+	};
+	link_netintf_send_cmd(&cmd);
+}
+
+void gunbustr_state::link_send_ctrl(u8 nodeid)
+{
+	gb_linkcmd cmd =
+	{
+		.type = LINKCMD_SEND_CTRL,
+		.nodeid = nodeid,
+		.data = m_netram[0x40*nodeid+0x3F],
+	};
+	link_netintf_send_cmd(&cmd);
+}
+
+/***********************************************************
+             NETWORK "REGISTER" INTERFACE
+***********************************************************/
+u32 gunbustr_state::link_ctrl_r(u8 nodeid)
+{
+	link_update();
+	link_send_ctrl(nodeid); // why is this correct?...
+	return m_netram[0x40*nodeid + 0x3F];
+}
+
+void gunbustr_state::link_ctrl_w(u8 nodeid, u32 data, u32 mem_mask)
+{
+	link_update();
+	u32 prev_ctrl = m_netram[0x40*nodeid + 0x3F];
+	COMBINE_DATA(&m_netram[0x40*nodeid + 0x3F]);
+
+	if (ACCESSING_BITS_0_15) // Writing to "ID" port
+	{
+		u16 v = data & 0xFFFF;
+		link_send_id(nodeid, v);
+	}
+
+	if (ACCESSING_BITS_16_31) // Writing to "lock" port
+	{
+		u16 v = (data >> 16);
+		u16 prev = (prev_ctrl >> 16);
+
+		link_send_lock(nodeid, v);
+
+		if ((prev & ~v) & 2) // Write release
+		{
+			link_send_data(nodeid);
+		}
+
+		if ((v & ~prev) & 1) // Read assert
+		{
+			// sync opposite node
+			link_recv_data(nodeid ^ 1);
+		}
+	}
+
+	link_update();
+}
+
+u32 gunbustr_state::link0_ctrl_r(offs_t offset)
+{
+	return link_ctrl_r(0);
+}
+
+void gunbustr_state::link0_ctrl_w(offs_t offset, u32 data, u32 mem_mask)
+{
+	link_ctrl_w(0, data, mem_mask);
+}
+
+u32 gunbustr_state::link1_ctrl_r(offs_t offset)
+{
+	return link_ctrl_r(1);
+}
+
+void gunbustr_state::link1_ctrl_w(offs_t offset, u32 data, u32 mem_mask)
+{
+	link_ctrl_w(1, data, mem_mask);
+}
+
+u32 gunbustr_state::link_ram_r(offs_t offset)
+{
+	link_update();
+	return m_netram[offset];
+}
+
+void gunbustr_state::link_ram_w(offs_t offset, u32 data, u32 mem_mask)
+{
+	link_update();
+	COMBINE_DATA(&m_netram[offset]);
+}
 
 /***********************************************************
              MEMORY STRUCTURES
@@ -441,7 +797,10 @@ void gunbustr_state::prg_map(address_map &map)
 	map(0x800000, 0x80ffff).rw(m_tc0480scp, FUNC(tc0480scp_device::ram_r), FUNC(tc0480scp_device::ram_w));
 	map(0x830000, 0x83002f).rw(m_tc0480scp, FUNC(tc0480scp_device::ctrl_r), FUNC(tc0480scp_device::ctrl_w));
 	map(0x900000, 0x901fff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette");
-	map(0xc00000, 0xc03fff).ram(); // network RAM ?
+	map(0xc00000, 0xc001ff).mirror(0x3e00).rw(FUNC(gunbustr_state::link_ram_r),FUNC(gunbustr_state::link_ram_w)).ram().share(m_netram); // network RAM
+	// These aren't hooked up by hardware, but the networking protocol makes this a perfect hook
+	map(0xc000fc, 0xc000ff).mirror(0x3e00).rw(FUNC(gunbustr_state::link0_ctrl_r),FUNC(gunbustr_state::link0_ctrl_w)); // network control (ID=0)
+	map(0xc001fc, 0xc001ff).mirror(0x3e00).rw(FUNC(gunbustr_state::link1_ctrl_r),FUNC(gunbustr_state::link1_ctrl_w)); // network control (ID=1)
 }
 
 /***********************************************************
@@ -449,27 +808,7 @@ void gunbustr_state::prg_map(address_map &map)
 ***********************************************************/
 
 static INPUT_PORTS_START( gunbustr )
-	PORT_START("SPECIAL")
-	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER(1)  // Freeze input
-	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_UNKNOWN )
-	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_UNKNOWN )
-	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_UNKNOWN )
-	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_UNKNOWN )
-	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_UNKNOWN )
-	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_UNKNOWN )
-	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER("eeprom", FUNC(eeprom_serial_93cxx_device::do_read))
-
-	PORT_START("INPUTS")
-	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER(1)
-	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER(1)
-	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_PLAYER(1)
-	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_JOYSTICK_RIGHT ) PORT_8WAY PORT_PLAYER(1)
-	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(1)
-	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(1)
-	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(2)
-	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(2)
-
-	PORT_START("EXTRA")
+	PORT_START("PORT00")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER(2)
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER(2)
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_PLAYER(2)
@@ -479,15 +818,45 @@ static INPUT_PORTS_START( gunbustr )
 	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_UNKNOWN )
 	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_UNKNOWN )
 
-	PORT_START("SYSTEM")
+	PORT_START("PORT01")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_UNKNOWN ) // INPUT 0
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_UNKNOWN ) // INPUT 1
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_UNKNOWN )
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_UNKNOWN )
+	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_UNKNOWN )
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_UNKNOWN )
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_UNKNOWN )
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_UNKNOWN )
+
+	PORT_START("PORT02")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER(1)
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER(1)
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_PLAYER(1)
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_JOYSTICK_RIGHT ) PORT_8WAY PORT_PLAYER(1)
+	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(1)
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(1)
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(2)
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(2)
+
+	PORT_START("PORT03")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER(1) // DMAON (6-A5)
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_UNKNOWN ) // OUTPUT 1
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_UNKNOWN ) // Z0 (Z-3)
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_UNKNOWN ) // Z1 (Z-4)
+	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_UNKNOWN ) // EEP CS
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_UNKNOWN ) // EEP SK
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_UNKNOWN ) // EEP DI
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER("eeprom", FUNC(eeprom_serial_93cxx_device::do_read))
+
+	PORT_START("PORTB")
 	PORT_SERVICE_NO_TOGGLE( 0x01, IP_ACTIVE_LOW )
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_SERVICE1 )
 	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_COIN1 )
 	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_COIN2 )
 	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_START1 )
 	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_START2 )
-	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_UNKNOWN )
-	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_UNKNOWN )
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_UNKNOWN ) // NC
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_UNKNOWN ) // NC
 
 	// Light gun inputs
 
@@ -539,14 +908,15 @@ void gunbustr_state::gunbustr(machine_config &config)
 	EEPROM_93C46_16BIT(config, "eeprom");
 
 	tc0510nio_device &tc0510nio(TC0510NIO(config, "tc0510nio", 0));
-	tc0510nio.read_0_callback().set_ioport("EXTRA");
-	tc0510nio.read_2_callback().set_ioport("INPUTS");
-	tc0510nio.read_3_callback().set_ioport("SPECIAL");
+	tc0510nio.read_0_callback().set_ioport("PORT00");
+	tc0510nio.read_1_callback().set_ioport("PORT01");
+	tc0510nio.read_2_callback().set_ioport("PORT02");
+	tc0510nio.read_3_callback().set_ioport("PORT03");
 	tc0510nio.write_3_callback().set("eeprom", FUNC(eeprom_serial_93cxx_device::clk_write)).bit(5);
 	tc0510nio.write_3_callback().append("eeprom", FUNC(eeprom_serial_93cxx_device::di_write)).bit(6);
 	tc0510nio.write_3_callback().append("eeprom", FUNC(eeprom_serial_93cxx_device::cs_write)).bit(4);
 	tc0510nio.write_4_callback().set(FUNC(gunbustr_state::coin_word_w));
-	tc0510nio.read_7_callback().set_ioport("SYSTEM");
+	tc0510nio.read_7_callback().set_ioport("PORTB");
 
 	// video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
@@ -692,6 +1062,8 @@ void gunbustr_state::init_gunbustr()
 	m_maincpu->space(AS_PROGRAM).install_read_handler(0x203acc, 0x203acf, read32smo_delegate(*this, FUNC(gunbustr_state::main_cycle_r)));
 
 	m_interrupt5_timer = timer_alloc(FUNC(gunbustr_state::trigger_irq5), this);
+
+	link_begin();
 }
 
 void gunbustr_state::init_gunbustrj()
@@ -705,6 +1077,6 @@ void gunbustr_state::init_gunbustrj()
 } // anonymous namespace
 
 
-GAME( 1992, gunbustr,  0,        gunbustr, gunbustr, gunbustr_state, init_gunbustr, ORIENTATION_FLIP_X, "Taito Corporation Japan",   "Gunbuster (World)", MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE )
-GAME( 1992, gunbustru, gunbustr, gunbustr, gunbustr, gunbustr_state, init_gunbustr, ORIENTATION_FLIP_X, "Taito America Corporation", "Gunbuster (US)",    MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE )
-GAME( 1992, gunbustrj, gunbustr, gunbustr, gunbustr, gunbustr_state, init_gunbustrj,ORIENTATION_FLIP_X, "Taito Corporation",         "Gunbuster (Japan)", MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE )
+GAME( 1992, gunbustr,  0,        gunbustr, gunbustr, gunbustr_state, init_gunbustr, ORIENTATION_FLIP_X, "Taito Corporation Japan",   "Gunbuster (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1992, gunbustru, gunbustr, gunbustr, gunbustr, gunbustr_state, init_gunbustr, ORIENTATION_FLIP_X, "Taito America Corporation", "Gunbuster (US)",    MACHINE_SUPPORTS_SAVE )
+GAME( 1992, gunbustrj, gunbustr, gunbustr, gunbustr, gunbustr_state, init_gunbustrj,ORIENTATION_FLIP_X, "Taito Corporation",         "Gunbuster (Japan)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/taito/gunbustr.cpp
+++ b/src/mame/taito/gunbustr.cpp
@@ -44,7 +44,6 @@
 ***************************************************************************/
 
 #include "emu.h"
-#include "emuopts.h"
 
 #include "taito_en.h"
 #include "taitoio.h"
@@ -61,11 +60,7 @@
 
 // configurable logging
 #define LOG_BADSPRITES	(1U << 1)
-#define LOG_LINKPROC	(1U << 2)
-#define LOG_LINKTX		(1U << 3)
-#define LOG_LINKRX		(1U << 4)
 
-//#define VERBOSE (LOG_GENERAL | LOG_LINKPROC)
 //#define VERBOSE (LOG_GENERAL | LOG_BADSPRITES)
 
 #include "logmacro.h"

--- a/src/mame/taito/gunbustr_l.cpp
+++ b/src/mame/taito/gunbustr_l.cpp
@@ -1,0 +1,430 @@
+// license:BSD-3-Clause
+// copyright-holders:Alex "trap15" Marshall
+
+/****************************************************************************
+
+    Gunbuster Link "Controller"
+
+    The link system utilizes a 256 word share RAM, logically split into
+    two banks of 128. For some reason the memory test clears 8192 words,
+    might be a leftover from Double Axle which uses 8192 word share RAM.
+
+    The last two words of each bank are used for control words,
+    the former ($7E) being a 'lock' control for the given network node,
+    and the latter ($7F) being an 'ID' value for the node.
+    It doesn't seem to actually use any hardware-enforced locking,
+    and software never seems to read back the lock values,
+    so in theory race conditions could be possible. This seems to
+    only avoid issues because each node strictly only writes "real"
+    data into its own bank. Since locks aren't read back, clobbering
+    each other's lock words has no impact.
+
+    At startup, a node places $FF00|selfID into the 'ID' word, checks
+    if the write succeeded (check for RAM presence), then checks for
+    the presence of the opposite ID value in the opposite bank. If this
+    fails, "COMMUNICATION ERROR" occurs.
+
+    When a node wants to read a bank, it will write $0001 to the lock
+    control of the _opposite_ bank, then read the data, then clear the lock.
+    When a node wants to write a bank, it will write $0002 to the lock
+    control of _that_ bank, then write the data, then clear the lock.
+    In theory this should mean a node only ever writes to its own lock word,
+    but in practice the code reads back both its bank and the other's bank,
+    so it has to write both lock words.
+
+    Every frame, the nodes synchronize with each other over their share
+    RAM banks, only writing to its own. Every frame should increase the
+    longword at $7C~$7D in its bank, and if that longword doesn't increase
+    for 16 consecutive frames, "COMMUNICATION CUT" occurs.
+
+ ***************************************************************************/
+
+#include "emu.h"
+#include "gunbustr_l.h"
+#include "emuopts.h"
+
+// configurable logging
+#define LOG_LINKPROC	(1U << 1)
+#define LOG_LINKTX		(1U << 2)
+#define LOG_LINKRX		(1U << 3)
+
+//#define VERBOSE (LOG_GENERAL | LOG_LINKPROC)
+
+#include "logmacro.h"
+
+//**************************************************************************
+//  DEVICE SETUP
+//**************************************************************************
+
+// device type definition
+DEFINE_DEVICE_TYPE(GUNBUSTR_LINK, gunbustr_link_device, "gunbustr_l", "Gunbuster Link Controller")
+
+#define BASEADDR_NODE(x) ((x) * LINKWORD_COUNT*2)
+
+void gunbustr_link_device::map(address_map &map)
+{
+	map(BASEADDR_NODE(0)+              0,BASEADDR_NODE(0)+LINKWORD_CTRL*2-1)
+		.rw(FUNC(gunbustr_link_device::ram0_r), FUNC(gunbustr_link_device::ram0_w));
+	map(BASEADDR_NODE(0)+LINKWORD_CTRL*2,BASEADDR_NODE(0)+LINKWORD_COUNT*2-1)
+		.rw(FUNC(gunbustr_link_device::ctrl0_r), FUNC(gunbustr_link_device::ctrl0_w));
+
+	map(BASEADDR_NODE(1)+              0,BASEADDR_NODE(1)+LINKWORD_CTRL*2-1)
+		.rw(FUNC(gunbustr_link_device::ram1_r), FUNC(gunbustr_link_device::ram1_w));
+	map(BASEADDR_NODE(1)+LINKWORD_CTRL*2,BASEADDR_NODE(1)+LINKWORD_COUNT*2-1)
+		.rw(FUNC(gunbustr_link_device::ctrl1_r), FUNC(gunbustr_link_device::ctrl1_w));
+}
+
+//-------------------------------------------------
+//  gunbustr_link_device - constructor
+//-------------------------------------------------
+
+gunbustr_link_device::gunbustr_link_device( const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock ) :
+	device_t(mconfig, GUNBUSTR_LINK, tag, owner, clock),
+	device_execute_interface(mconfig, *this),
+	m_icount(0)
+{
+	snprintf(m_localhost,sizeof(m_localhost), "socket.%s:%s",
+			mconfig.options().comm_localhost(), mconfig.options().comm_localport());
+	m_localhost[sizeof(m_localhost)-1] = '\0';
+	snprintf(m_remotehost,sizeof(m_remotehost), "socket.%s:%s",
+			mconfig.options().comm_remotehost(), mconfig.options().comm_remoteport());
+	m_remotehost[sizeof(m_remotehost)-1] = '\0';
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//------------------------------------------------
+
+void gunbustr_link_device::device_start()
+{
+	// set our instruction counter
+	set_icountptr(m_icount);
+
+	save_item(NAME(m_ram));
+}
+
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void gunbustr_link_device::device_reset()
+{
+}
+
+
+//-------------------------------------------------
+//  execute_run - device update
+//-------------------------------------------------
+
+void gunbustr_link_device::execute_run()
+{
+	while (m_icount > 0)
+	{
+		phy_rx_check();
+		phy_tx_check();
+		// no reason to check it multiple times in a row
+		m_icount = 0;
+	}
+}
+
+
+//**************************************************************************
+//  "PHYSICAL" NETWORK HANDLING
+//**************************************************************************
+
+bool gunbustr_link_device::phy_rx_check(void)
+{
+	if (m_line_rx) return true;
+
+	LOGMASKED(LOG_LINKPROC, "listen on %s\n", m_localhost);
+	uint64_t filesize; // unused
+	osd_file::open(m_localhost, OPEN_FLAG_CREATE, m_line_rx, filesize);
+
+	return !!m_line_rx;
+}
+
+bool gunbustr_link_device::phy_tx_check(void)
+{
+	if (m_line_tx) return true;
+
+	// TODO: How to make this non-blocking?
+	LOGMASKED(LOG_LINKPROC, "connect to %s\n", m_remotehost);
+	uint64_t filesize; // unused
+	osd_file::open(m_remotehost, 0, m_line_tx, filesize);
+
+	return !!m_line_tx;
+}
+
+bool gunbustr_link_device::phy_recv_raw(void *buf, size_t bytes)
+{
+	if (!m_line_rx) return false;
+
+	uint32_t amt = 0;
+	std::error_condition err = m_line_rx->read(buf, 0, bytes, amt);
+	if (err)
+	{
+		LOGMASKED(LOG_LINKRX, "RX ERROR [%s]\n", err.message().c_str());
+		return false;
+	}
+	if (amt != bytes)
+	{
+		LOGMASKED(LOG_LINKRX, "RX NOT ENOUGH %d => %d\n", bytes, amt);
+		return false;
+	}
+	return true;
+}
+
+bool gunbustr_link_device::phy_send_raw(const void *buf, size_t bytes)
+{
+	if(!m_line_tx) return false;
+
+	uint32_t amt = 0;
+	std::error_condition err = m_line_tx->write(buf, 0, bytes, amt);
+	if (err)
+	{
+		LOGMASKED(LOG_LINKPROC, "TX ERROR [%s]\n", err.message().c_str());
+		// TX error almost certainly requires a reconnect, so disconnect now.
+		m_line_tx = nullptr;
+		return false;
+	}
+	if (amt != bytes)
+	{
+		LOGMASKED(LOG_LINKTX, "TX NOT ENOUGH %d => %d\n", bytes, amt);
+		return false;
+	}
+	return true;
+}
+
+// Ensure network format is the same for all machines
+#ifdef BIGENDIAN
+# define BE32(x) (x)
+#else
+# define BE32(x) (	(((x) >> 24) & 0x000000FF) | \
+					(((x) >>  8) & 0x0000FF00) | \
+					(((x) <<  8) & 0x00FF0000) | \
+					(((x) << 24) & 0xFF000000U))
+#endif
+
+bool gunbustr_link_device::phy_recv_cmd(linkcmd *cmd)
+{
+	uint32_t cmdpkt[3];
+	if (!phy_recv_raw(cmdpkt, sizeof(cmdpkt)))
+	{
+		cmd->type = LINKCMD_NOP;
+		return false;
+	}
+	cmd->type	= BE32(cmdpkt[0]);
+	cmd->nodeid = BE32(cmdpkt[1]);
+	cmd->data	= BE32(cmdpkt[2]);
+	return true;
+}
+
+bool gunbustr_link_device::phy_send_cmd(const linkcmd *cmd)
+{
+	uint32_t cmdpkt[3];
+	cmdpkt[0] = BE32(cmd->type);
+	cmdpkt[1] = BE32(cmd->nodeid);
+	cmdpkt[2] = BE32(cmd->data);
+	return phy_send_raw(cmdpkt, sizeof(cmdpkt));
+}
+
+bool gunbustr_link_device::phy_recv_ram(uint8_t nodeid)
+{
+	return phy_recv_raw(m_ram[nodeid], LINKWORD_PAYLOAD_COUNT*2);
+}
+
+bool gunbustr_link_device::phy_send_ram(uint8_t nodeid)
+{
+	return phy_send_raw(m_ram[nodeid], LINKWORD_PAYLOAD_COUNT*2);
+}
+
+//**************************************************************************
+//  LINK PROTOCOL HANDLING
+//**************************************************************************
+
+void gunbustr_link_device::link_update(void)
+{
+	linkcmd cmd;
+	while (phy_recv_cmd(&cmd))
+	{
+		if(cmd.nodeid > 2) continue;
+
+		switch (cmd.type)
+		{
+			default:
+				break;
+			case LINKCMD_RECV_DATA:
+				LOGMASKED(LOG_LINKPROC, "[proc] RecvData %d\n", cmd.nodeid);
+				phy_send_ram(cmd.nodeid);
+				break;
+			case LINKCMD_SEND_DATA:
+				LOGMASKED(LOG_LINKPROC, "[proc] SendData %d\n", cmd.nodeid);
+				phy_recv_ram(cmd.nodeid);
+				break;
+			case LINKCMD_SEND_CTRL:
+				LOGMASKED(LOG_LINKPROC, "[proc] RecvCtrl %d\n", cmd.nodeid);
+				m_ram[cmd.nodeid][LINKWORD_LOCK] = (uint16_t)(cmd.data >>16);
+				m_ram[cmd.nodeid][LINKWORD_ID] = (uint16_t)(cmd.data >> 0);
+				break;
+			case LINKCMD_SEND_LOCK:
+				LOGMASKED(LOG_LINKPROC, "[proc] SendLock %d 0x%X\n", cmd.nodeid, cmd.data);
+				m_ram[cmd.nodeid][LINKWORD_LOCK] = cmd.data;
+				break;
+			case LINKCMD_SEND_NODE_ID:
+				LOGMASKED(LOG_LINKPROC, "[proc] SendNodeId %d 0x%X\n", cmd.nodeid, cmd.data);
+				m_ram[cmd.nodeid][LINKWORD_ID] = cmd.data;
+				break;
+		}
+	}
+}
+
+void gunbustr_link_device::link_recv_data(uint8_t nodeid)
+{
+	linkcmd cmd =
+	{
+		.type = LINKCMD_RECV_DATA,
+		.nodeid = nodeid,
+	};
+	phy_send_cmd(&cmd);
+	phy_recv_ram(nodeid);
+}
+
+void gunbustr_link_device::link_send_data(uint8_t nodeid)
+{
+	linkcmd cmd =
+	{
+		.type = LINKCMD_SEND_DATA,
+		.nodeid = nodeid,
+	};
+	phy_send_cmd(&cmd);
+	phy_send_ram(nodeid);
+}
+
+void gunbustr_link_device::link_send_lock(uint8_t nodeid)
+{
+	linkcmd cmd =
+	{
+		.type = LINKCMD_SEND_LOCK,
+		.nodeid = nodeid,
+		.data = m_ram[nodeid][LINKWORD_LOCK],
+	};
+	phy_send_cmd(&cmd);
+}
+
+void gunbustr_link_device::link_send_id(uint8_t nodeid)
+{
+	linkcmd cmd =
+	{
+		.type = LINKCMD_SEND_NODE_ID,
+		.nodeid = nodeid,
+		.data = m_ram[nodeid][LINKWORD_ID],
+	};
+	phy_send_cmd(&cmd);
+}
+
+void gunbustr_link_device::link_send_ctrl(uint8_t nodeid)
+{
+	linkcmd cmd =
+	{
+		.type = LINKCMD_SEND_CTRL,
+		.nodeid = nodeid,
+		.data = ((uint32_t)m_ram[nodeid][LINKWORD_LOCK] << 16) |
+				m_ram[nodeid][LINKWORD_ID],
+	};
+	phy_send_cmd(&cmd);
+}
+
+//**************************************************************************
+//  MEMORY INTERFACE
+//**************************************************************************
+
+uint16_t gunbustr_link_device::ram_r(uint8_t nodeid, offs_t offset)
+{
+	link_update();
+	return m_ram[nodeid][offset];
+}
+
+void gunbustr_link_device::ram_w(uint8_t nodeid, offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	link_update();
+	COMBINE_DATA(&m_ram[nodeid][offset]);
+}
+
+uint16_t gunbustr_link_device::ctrl_r(uint8_t nodeid, offs_t offset)
+{
+	link_update();
+	link_send_ctrl(nodeid); // why is this correct?...
+	return m_ram[nodeid][LINKWORD_CTRL + offset];
+}
+
+void gunbustr_link_device::ctrl_w(uint8_t nodeid, offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	link_update();
+	uint16_t prev = m_ram[nodeid][LINKWORD_CTRL + offset];
+	uint16_t now = COMBINE_DATA(&m_ram[nodeid][LINKWORD_CTRL + offset]);
+
+	switch (LINKWORD_CTRL + offset)
+	{
+		case LINKWORD_LOCK:
+			link_send_lock(nodeid);
+
+			if ((prev & ~now) & 2) // Write release
+			{
+				link_send_data(nodeid);
+			}
+
+			if ((now & ~prev) & 1) // Read assert
+			{
+				// sync opposite node
+				link_recv_data(nodeid ^ 1);
+			}
+			break;
+		case LINKWORD_ID:
+			link_send_id(nodeid);
+			break;
+	}
+
+	link_update();
+}
+
+uint16_t gunbustr_link_device::ctrl0_r(offs_t offset)
+{
+	return ctrl_r(0, offset);
+}
+
+void gunbustr_link_device::ctrl0_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	ctrl_w(0, offset, data, mem_mask);
+}
+
+uint16_t gunbustr_link_device::ctrl1_r(offs_t offset)
+{
+	return ctrl_r(1, offset);
+}
+
+void gunbustr_link_device::ctrl1_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	ctrl_w(1, offset, data, mem_mask);
+}
+
+uint16_t gunbustr_link_device::ram0_r(offs_t offset)
+{
+	return ram_r(0, offset);
+}
+
+void gunbustr_link_device::ram0_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	ram_w(0, offset, data, mem_mask);
+}
+
+uint16_t gunbustr_link_device::ram1_r(offs_t offset)
+{
+	return ram_r(1, offset);
+}
+
+void gunbustr_link_device::ram1_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	ram_w(1, offset, data, mem_mask);
+}

--- a/src/mame/taito/gunbustr_l.h
+++ b/src/mame/taito/gunbustr_l.h
@@ -1,0 +1,104 @@
+// license:BSD-3-Clause
+// copyright-holders:Alex "trap15" Marshall
+
+/****************************************************************************
+
+    Gunbuster Link "Controller"
+
+ ***************************************************************************/
+
+#ifndef MAME_TAITO_GUNBUSTR_L_H
+#define MAME_TAITO_GUNBUSTR_L_H
+
+#pragma once
+
+class gunbustr_link_device : public device_t,
+					   public device_execute_interface
+{
+public:
+	// construction/destruction
+	gunbustr_link_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	void map(address_map &map) ATTR_COLD;
+
+protected:
+	// device-level overrides
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+	virtual void execute_run() override;
+
+	int m_icount;
+
+private:
+	enum linkcmd_type
+	{
+		LINKCMD_NOP = 0,
+		LINKCMD_SEND_NODE_ID,
+		LINKCMD_SEND_LOCK,
+		LINKCMD_SEND_CTRL,
+		LINKCMD_RECV_DATA,
+		LINKCMD_SEND_DATA,
+	};
+
+	enum linkram_ofs
+	{
+		LINKWORD_CTRL = 0x7E,
+		LINKWORD_LOCK = 0x7E,
+		LINKWORD_ID = 0x7F,
+		LINKWORD_COUNT = 0x80,
+		LINKWORD_PAYLOAD_COUNT = 0x7E,
+	};
+
+	struct linkcmd
+	{
+		uint32_t type;
+		uint32_t nodeid;
+		uint32_t data;
+	};
+
+	// internal state
+	uint16_t m_ram[2][LINKWORD_COUNT];
+
+	osd_file::ptr m_line_rx;
+	osd_file::ptr m_line_tx;
+	char m_localhost[256];
+	char m_remotehost[256];
+
+	// 'Physical' network handling
+	bool phy_rx_check(void);
+	bool phy_tx_check(void);
+	bool phy_recv_raw(void *buf, size_t bytes);
+	bool phy_send_raw(const void *buf, size_t bytes);
+	bool phy_recv_cmd(linkcmd *cmd);
+	bool phy_send_cmd(const linkcmd *cmd);
+	bool phy_recv_ram(uint8_t nodeid);
+	bool phy_send_ram(uint8_t nodeid);
+
+	// Link 'protocol' handling
+	void link_update(void);
+	void link_recv_data(uint8_t nodeid);
+	void link_send_data(uint8_t nodeid);
+	void link_send_lock(uint8_t nodeid);
+	void link_send_id(uint8_t nodeid);
+	void link_send_ctrl(uint8_t nodeid);
+
+	// Memory handlers
+	uint16_t ctrl_r(uint8_t nodeid, offs_t offset);
+	void ctrl_w(uint8_t nodeid, offs_t offset, uint16_t data, uint16_t mem_mask);
+	uint16_t ctrl0_r(offs_t offset);
+	void ctrl0_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~uint16_t(0));
+	uint16_t ctrl1_r(offs_t offset);
+	void ctrl1_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~uint16_t(0));
+
+	uint16_t ram_r(uint8_t nodeid, offs_t offset);
+	void ram_w(uint8_t nodeid, offs_t offset, uint16_t data, uint16_t mem_mask);
+	uint16_t ram0_r(offs_t offset);
+	void ram0_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~uint16_t(0));
+	uint16_t ram1_r(offs_t offset);
+	void ram1_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~uint16_t(0));
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(GUNBUSTR_LINK, gunbustr_link_device)
+
+#endif // MAME_TAITO_GUNBUSTR_L_H


### PR DESCRIPTION
I've added an implementation of the link system for Taito's Gunbuster.

There are 2 input/output pins between each board, but I haven't found how they're used so they're only mentioned in comments. The actual communication system happens entirely over a small shared RAM buffer.

They generally pretty consistently use the last two words as control words for the "ownership" of each buffer, so I was able to utilize those to only send RAM contents over the network when the ownership transfers. The actual synchronization of the control words is a bit of a mystery, I'm not entirely sure why it works honestly 😅 But it does work very well, and anything more proper looking didn't work. However, I must say I've only tested localhost thus far, I don't know how "fragile" networking support is allowed to be.

As for the linked-play itself, it's quite neat, so I hope some people will enjoy this. When trying to get it set up, the two emulated machines need to be reset at a somewhat similar time; there's a decent amount of variance allowed, but it's not too hard to get a bad timing.