### PR TITLE
sound/va_ops.cpp: Used SAMPLE_RATE_INPUT_ADAPTIVE for VA_SCALE_OFFSET.

### DIFF
--- a/src/devices/sound/va_ops.cpp
+++ b/src/devices/sound/va_ops.cpp
@@ -63,7 +63,7 @@ void va_scale_offset_device::device_start()
 {
 	save_item(NAME(m_scale));
 	save_item(NAME(m_offset));
-	m_stream = stream_alloc(1, 1, SAMPLE_RATE_OUTPUT_ADAPTIVE);
+	m_stream = stream_alloc(1, 1, SAMPLE_RATE_INPUT_ADAPTIVE);
 }
 
 void va_scale_offset_device::sound_stream_update(sound_stream &stream)


### PR DESCRIPTION
VA_SCALE_OFFSET is typically used to process control signals. Applying an offset to those is common. Control signals eventually make their way to sound devices (e.g. filters, VCAs), some of which oversample.

Using SAMPLE_RATE_INPUT_ADAPTIVE ensures control signals are not oversampled before they arrive to such an audio device, since this is not needed.

Benchmark results (`-window -bench 120 prophet5r30`). Before: ~1365%, after: ~1450%