### PR TITLE
floppy: fix oob caused by m_step_samplepos dirty trick

### DIFF
--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -1981,7 +1981,8 @@ void floppy_sound_device::sound_stream_update(sound_stream &stream)
 				sampleend = m_sample[m_step_sample-1].data.size();
 
 				// Mix it into the stream value
-				out += m_sample[m_step_sample-1].data[m_step_samplepos++];
+				if (m_step_samplepos < sampleend)
+					out += m_sample[m_step_sample-1].data[m_step_samplepos++];
 				if (m_step_samplepos >= sampleend)
 				{
 					// Step sample done


### PR DESCRIPTION
(noticed during #15329)

This commit fixes an out of bounds access which occurs rarely in `floppy_sound_device::sound_stream_update()`.

To reproduce, do something that plays a lot of track-seeking step samples, for example:
1) `mame laser128 -flop1 <copy II plus> -flop2 <another disk>`
2) COPY, DISK W/ FORMAT, SLOT 6 DRIVE 1, SLOT 6 DRIVE 2, wait
3) repeat step 2 (for me, it triggers on the second iteration)

Result: rarely, the step sample causes out-of-bounds access (possible crash.)  It is triggered by [this code](https://github.com/mamedev/mame/blob/45faab9e7b23878adf14f275bb3b2528de7b6a47/src/devices/imagedev/floppy.cpp#L1956) (instrumentation added):
```
	// yep, a somewhat dirty trick; we don't have to record yet another sample
	m_step_samplepos += 441;
if (m_step_samplepos >= m_sample[m_step_sample-1].data.size())
__builtin_printf("step trick + 441: %d > %ld\n", m_step_samplepos, m_sample[m_step_sample-1].data.size());
```
A debug ASAN build (ARCHOPTS="-fsanitize=address") catches the problem immediately:
```
step trick + 441: 3421 > 3292
SUMMARY: AddressSanitizer: heap-buffer-overflow floppy.cpp:1984 in floppy_sound_device::sound_stream_update(sound_stream&)
```
[laser128_copyiiplus_asan.txt](https://github.com/user-attachments/files/27622467/laser128_copyiiplus_asan.txt)


