### PR TITLE
upd7810: fix SET_Z on OFFI/ONI instructions

### DIFF
--- a/src/devices/cpu/upd7810/upd7810_opcodes.cpp
+++ b/src/devices/cpu/upd7810/upd7810_opcodes.cpp
@@ -3552,6 +3552,7 @@ void upd7810_device::ONI_PA_xx()
 	RDOPARG( imm );
 	if (pa & imm)
 		PSW |= SK;
+	SET_Z( pa & imm );
 }
 
 /* 64 49: 0110 0100 0100 1001 xxxx xxxx */
@@ -3562,6 +3563,7 @@ void upd7810_device::ONI_PB_xx()
 	RDOPARG( imm );
 	if (pb & imm)
 		PSW |= SK;
+	SET_Z( pb & imm );
 }
 
 /* 64 4a: 0110 0100 0100 1010 xxxx xxxx */
@@ -3572,6 +3574,7 @@ void upd7810_device::ONI_PC_xx()
 	RDOPARG( imm );
 	if (pc & imm)
 		PSW |= SK;
+	SET_Z( pc & imm );
 }
 
 /* 64 4b: 0110 0100 0100 1011 xxxx xxxx */
@@ -3582,6 +3585,7 @@ void upd7810_device::ONI_PD_xx()
 	RDOPARG( imm );
 	if (pd & imm)
 		PSW |= SK;
+	SET_Z( pd & imm );
 }
 
 /* 64 4d: 0110 0100 0100 1101 xxxx xxxx */
@@ -3592,6 +3596,7 @@ void upd7810_device::ONI_PF_xx()
 	RDOPARG( imm );
 	if (pf & imm)
 		PSW |= SK;
+	SET_Z( pf & imm );
 }
 
 /* 64 4e: 0110 0100 0100 1110 xxxx xxxx */
@@ -3602,6 +3607,7 @@ void upd7810_device::ONI_MKH_xx()
 	RDOPARG( imm );
 	if (MKH & imm)
 		PSW |= SK;
+	SET_Z( MKH & imm );
 }
 
 /* 64 4f: 0110 0100 0100 1111 xxxx xxxx */
@@ -3612,6 +3618,7 @@ void upd7810_device::ONI_MKL_xx()
 	RDOPARG( imm );
 	if (MKL & imm)
 		PSW |= SK;
+	SET_Z( MKL & imm );
 }
 
 /* 64 50: 0110 0100 0101 0000 xxxx xxxx */
@@ -3704,6 +3711,7 @@ void upd7810_device::OFFI_PA_xx()
 	RDOPARG( imm );
 	if (0 == (pa & imm))
 		PSW |= SK;
+	SET_Z( pa & imm );
 }
 
 /* 64 59: 0110 0100 0101 1001 xxxx xxxx */
@@ -3714,6 +3722,7 @@ void upd7810_device::OFFI_PB_xx()
 	RDOPARG( imm );
 	if (0 == (pb & imm))
 		PSW |= SK;
+	SET_Z( pb & imm );
 }
 
 /* 64 5a: 0110 0100 0101 1010 xxxx xxxx */
@@ -3724,6 +3733,7 @@ void upd7810_device::OFFI_PC_xx()
 	RDOPARG( imm );
 	if (0 == (pc & imm))
 		PSW |= SK;
+	SET_Z( pc & imm );
 }
 
 /* 64 5b: 0110 0100 0101 1011 xxxx xxxx */
@@ -3734,6 +3744,7 @@ void upd7810_device::OFFI_PD_xx()
 	RDOPARG( imm );
 	if (0 == (pd & imm))
 		PSW |= SK;
+	SET_Z( pd & imm );
 }
 
 /* 64 5d: 0110 0100 0101 1101 xxxx xxxx */
@@ -3744,6 +3755,7 @@ void upd7810_device::OFFI_PF_xx()
 	RDOPARG( imm );
 	if (0 == (pf & imm))
 		PSW |= SK;
+	SET_Z( pf & imm );
 }
 
 /* 64 5e: 0110 0100 0101 1110 xxxx xxxx */
@@ -3754,6 +3766,7 @@ void upd7810_device::OFFI_MKH_xx()
 	RDOPARG( imm );
 	if (0 == (MKH & imm))
 		PSW |= SK;
+	SET_Z( MKH & imm );
 }
 
 /* 64 5f: 0110 0100 0101 1111 xxxx xxxx */
@@ -3764,6 +3777,7 @@ void upd7810_device::OFFI_MKL_xx()
 	RDOPARG( imm );
 	if (0 == (MKL & imm))
 		PSW |= SK;
+	SET_Z( MKL & imm );
 }
 
 /* 64 60: 0110 0100 0110 0000 xxxx xxxx */
@@ -4510,6 +4524,7 @@ void upd7810_device::ONI_ANM_xx()
 	RDOPARG( imm );
 	if (ANM & imm)
 		PSW |= SK;
+	SET_Z( ANM & imm );
 }
 
 /* 64 c9: 0110 0100 1100 1001 xxxx xxxx */
@@ -4520,6 +4535,7 @@ void upd7810_device::ONI_SMH_xx()
 	RDOPARG( imm );
 	if (SMH & imm)
 		PSW |= SK;
+	SET_Z( SMH & imm );
 }
 
 /* 64 cb: 0110 0100 1100 1011 xxxx xxxx */
@@ -4532,6 +4548,7 @@ void upd7810_device::ONI_EOM_xx()
 	RDOPARG( imm );
 	if (eom & imm)
 		PSW |= SK;
+	SET_Z( eom & imm );
 }
 
 /* 64 cd: 0110 0100 1100 1101 xxxx xxxx */
@@ -4542,6 +4559,7 @@ void upd7810_device::ONI_TMM_xx()
 	RDOPARG( imm );
 	if (TMM & imm)
 		PSW |= SK;
+	SET_Z( TMM & imm );
 }
 
 /* 64 d0: 0110 0100 1101 0000 xxxx xxxx */
@@ -4603,6 +4621,7 @@ void upd7810_device::OFFI_ANM_xx()
 	RDOPARG( imm );
 	if (0 == (ANM & imm))
 		PSW |= SK;
+	SET_Z( ANM & imm );
 }
 
 /* 64 d9: 0110 0100 1101 1001 xxxx xxxx */
@@ -4613,6 +4632,7 @@ void upd7810_device::OFFI_SMH_xx()
 	RDOPARG( imm );
 	if (0 == (SMH & imm))
 		PSW |= SK;
+	SET_Z( SMH & imm );
 }
 
 /* 64 db: 0110 0100 1101 1011 xxxx xxxx */
@@ -4625,6 +4645,7 @@ void upd7810_device::OFFI_EOM_xx()
 	RDOPARG( imm );
 	if (0 == (eom & imm))
 		PSW |= SK;
+	SET_Z( eom & imm );
 }
 
 /* 64 dd: 0110 0100 1101 1101 xxxx xxxx */
@@ -4635,6 +4656,7 @@ void upd7810_device::OFFI_TMM_xx()
 	RDOPARG( imm );
 	if (0 == (TMM & imm))
 		PSW |= SK;
+	SET_Z( TMM & imm );
 }
 
 /* 64 e0: 0110 0100 1110 0000 xxxx xxxx */
@@ -6770,6 +6792,7 @@ void upd7810_device::ONI_V_xx()
 	RDOPARG( imm );
 	if (V & imm)
 		PSW |= SK;
+	SET_Z( V & imm );
 }
 
 /* 74 49: 0111 0100 0100 1001 xxxx xxxx */
@@ -6780,6 +6803,7 @@ void upd7810_device::ONI_A_xx()
 	RDOPARG( imm );
 	if (A & imm)
 		PSW |= SK;
+	SET_Z( A & imm );
 }
 
 /* 74 4a: 0111 0100 0100 1010 xxxx xxxx */
@@ -6790,6 +6814,7 @@ void upd7810_device::ONI_B_xx()
 	RDOPARG( imm );
 	if (B & imm)
 		PSW |= SK;
+	SET_Z( B & imm );
 }
 
 /* 74 4b: 0111 0100 0100 1011 xxxx xxxx */
@@ -6800,6 +6825,7 @@ void upd7810_device::ONI_C_xx()
 	RDOPARG( imm );
 	if (C & imm)
 		PSW |= SK;
+	SET_Z( C & imm );
 }
 
 /* 74 4c: 0111 0100 0100 1100 xxxx xxxx */
@@ -6810,6 +6836,7 @@ void upd7810_device::ONI_D_xx()
 	RDOPARG( imm );
 	if (D & imm)
 		PSW |= SK;
+	SET_Z( D & imm );
 }
 
 /* 74 4d: 0111 0100 0100 1101 xxxx xxxx */
@@ -6820,6 +6847,7 @@ void upd7810_device::ONI_E_xx()
 	RDOPARG( imm );
 	if (E & imm)
 		PSW |= SK;
+	SET_Z( E & imm );
 }
 
 /* 74 4e: 0111 0100 0100 1110 xxxx xxxx */
@@ -6830,6 +6858,7 @@ void upd7810_device::ONI_H_xx()
 	RDOPARG( imm );
 	if (H & imm)
 		PSW |= SK;
+	SET_Z( H & imm );
 }
 
 /* 74 4f: 0111 0100 0100 1111 xxxx xxxx */
@@ -6840,6 +6869,7 @@ void upd7810_device::ONI_L_xx()
 	RDOPARG( imm );
 	if (L & imm)
 		PSW |= SK;
+	SET_Z( L & imm );
 }
 
 /* 74 50: 0111 0100 0101 0000 xxxx xxxx */
@@ -6938,6 +6968,7 @@ void upd7810_device::OFFI_V_xx()
 	RDOPARG( imm );
 	if (0 == (V & imm))
 		PSW |= SK;
+	SET_Z( V & imm );
 }
 
 /* 74 59: 0111 0100 0101 1001 xxxx xxxx */
@@ -6948,6 +6979,7 @@ void upd7810_device::OFFI_A_xx()
 	RDOPARG( imm );
 	if (0 == (A & imm))
 		PSW |= SK;
+	SET_Z( A & imm );
 }
 
 /* 74 5a: 0111 0100 0101 1010 xxxx xxxx */
@@ -6958,6 +6990,7 @@ void upd7810_device::OFFI_B_xx()
 	RDOPARG( imm );
 	if (0 == (B & imm))
 		PSW |= SK;
+	SET_Z( B & imm );
 }
 
 /* 74 5b: 0111 0100 0101 1011 xxxx xxxx */
@@ -6968,6 +7001,7 @@ void upd7810_device::OFFI_C_xx()
 	RDOPARG( imm );
 	if (0 == (C & imm))
 		PSW |= SK;
+	SET_Z( C & imm );
 }
 
 /* 74 5c: 0111 0100 0101 1100 xxxx xxxx */
@@ -6978,6 +7012,7 @@ void upd7810_device::OFFI_D_xx()
 	RDOPARG( imm );
 	if (0 == (D & imm))
 		PSW |= SK;
+	SET_Z( D & imm );
 }
 
 /* 74 5d: 0111 0100 0101 1101 xxxx xxxx */
@@ -6988,6 +7023,7 @@ void upd7810_device::OFFI_E_xx()
 	RDOPARG( imm );
 	if (0 == (E & imm))
 		PSW |= SK;
+	SET_Z( E & imm );
 }
 
 /* 74 5e: 0111 0100 0101 1110 xxxx xxxx */
@@ -6998,6 +7034,7 @@ void upd7810_device::OFFI_H_xx()
 	RDOPARG( imm );
 	if (0 == (H & imm))
 		PSW |= SK;
+	SET_Z( H & imm );
 }
 
 /* 74 5f: 0111 0100 0101 1111 xxxx xxxx */
@@ -7008,6 +7045,7 @@ void upd7810_device::OFFI_L_xx()
 	RDOPARG( imm );
 	if (0 == (L & imm))
 		PSW |= SK;
+	SET_Z( L & imm );
 }
 
 /* 74 60: 0111 0100 0110 0000 xxxx xxxx */
@@ -8432,8 +8470,10 @@ void upd7810_device::ONIW_wa_xx()
 	RDOPARG( ea.b.l );
 	RDOPARG( imm );
 
-	if (RM( ea.d ) & imm)
+	uint8_t readmem = RM( ea.d );
+	if (readmem & imm)
 		PSW |= SK;
+	SET_Z( readmem & imm );
 }
 
 /* 46: 0100 0110 xxxx xxxx */
@@ -8565,8 +8605,10 @@ void upd7810_device::OFFIW_wa_xx()
 	RDOPARG( ea.b.l );
 	RDOPARG( imm );
 
-	if (0 == (RM( ea.d ) & imm))
+	uint8_t readmem = RM( ea.d );
+	if (0 == (readmem & imm))
 		PSW |= SK;
+	SET_Z( readmem & imm );
 }
 
 /* 56: 0101 0110 xxxx xxxx */

--- a/src/devices/cpu/upd7810/upd7810_opcodes.cpp
+++ b/src/devices/cpu/upd7810/upd7810_opcodes.cpp
@@ -3550,9 +3550,8 @@ void upd7810_device::ONI_PA_xx()
 	uint8_t pa = RP( UPD7810_PORTA ), imm;
 
 	RDOPARG( imm );
-	if (pa & imm)
-		PSW |= SK;
 	SET_Z( pa & imm );
+	SKIP_NZ;
 }
 
 /* 64 49: 0110 0100 0100 1001 xxxx xxxx */
@@ -3561,9 +3560,8 @@ void upd7810_device::ONI_PB_xx()
 	uint8_t pb = RP( UPD7810_PORTB ), imm;
 
 	RDOPARG( imm );
-	if (pb & imm)
-		PSW |= SK;
 	SET_Z( pb & imm );
+	SKIP_NZ;
 }
 
 /* 64 4a: 0110 0100 0100 1010 xxxx xxxx */
@@ -3572,9 +3570,8 @@ void upd7810_device::ONI_PC_xx()
 	uint8_t pc = RP( UPD7810_PORTC ), imm;
 
 	RDOPARG( imm );
-	if (pc & imm)
-		PSW |= SK;
 	SET_Z( pc & imm );
+	SKIP_NZ;
 }
 
 /* 64 4b: 0110 0100 0100 1011 xxxx xxxx */
@@ -3583,9 +3580,8 @@ void upd7810_device::ONI_PD_xx()
 	uint8_t pd = RP( UPD7810_PORTD ), imm;
 
 	RDOPARG( imm );
-	if (pd & imm)
-		PSW |= SK;
 	SET_Z( pd & imm );
+	SKIP_NZ;
 }
 
 /* 64 4d: 0110 0100 0100 1101 xxxx xxxx */
@@ -3594,9 +3590,8 @@ void upd7810_device::ONI_PF_xx()
 	uint8_t pf = RP( UPD7810_PORTF ), imm;
 
 	RDOPARG( imm );
-	if (pf & imm)
-		PSW |= SK;
 	SET_Z( pf & imm );
+	SKIP_NZ;
 }
 
 /* 64 4e: 0110 0100 0100 1110 xxxx xxxx */
@@ -3605,9 +3600,8 @@ void upd7810_device::ONI_MKH_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (MKH & imm)
-		PSW |= SK;
 	SET_Z( MKH & imm );
+	SKIP_NZ;
 }
 
 /* 64 4f: 0110 0100 0100 1111 xxxx xxxx */
@@ -3616,9 +3610,8 @@ void upd7810_device::ONI_MKL_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (MKL & imm)
-		PSW |= SK;
 	SET_Z( MKL & imm );
+	SKIP_NZ;
 }
 
 /* 64 50: 0110 0100 0101 0000 xxxx xxxx */
@@ -3709,9 +3702,8 @@ void upd7810_device::OFFI_PA_xx()
 	uint8_t pa = RP( UPD7810_PORTA ), imm;
 
 	RDOPARG( imm );
-	if (0 == (pa & imm))
-		PSW |= SK;
 	SET_Z( pa & imm );
+	SKIP_Z;
 }
 
 /* 64 59: 0110 0100 0101 1001 xxxx xxxx */
@@ -3720,9 +3712,8 @@ void upd7810_device::OFFI_PB_xx()
 	uint8_t pb = RP( UPD7810_PORTB ), imm;
 
 	RDOPARG( imm );
-	if (0 == (pb & imm))
-		PSW |= SK;
 	SET_Z( pb & imm );
+	SKIP_Z;
 }
 
 /* 64 5a: 0110 0100 0101 1010 xxxx xxxx */
@@ -3731,9 +3722,8 @@ void upd7810_device::OFFI_PC_xx()
 	uint8_t pc = RP( UPD7810_PORTC ), imm;
 
 	RDOPARG( imm );
-	if (0 == (pc & imm))
-		PSW |= SK;
 	SET_Z( pc & imm );
+	SKIP_Z;
 }
 
 /* 64 5b: 0110 0100 0101 1011 xxxx xxxx */
@@ -3742,9 +3732,8 @@ void upd7810_device::OFFI_PD_xx()
 	uint8_t pd = RP( UPD7810_PORTD ), imm;
 
 	RDOPARG( imm );
-	if (0 == (pd & imm))
-		PSW |= SK;
 	SET_Z( pd & imm );
+	SKIP_Z;
 }
 
 /* 64 5d: 0110 0100 0101 1101 xxxx xxxx */
@@ -3753,9 +3742,8 @@ void upd7810_device::OFFI_PF_xx()
 	uint8_t pf = RP( UPD7810_PORTF ), imm;
 
 	RDOPARG( imm );
-	if (0 == (pf & imm))
-		PSW |= SK;
 	SET_Z( pf & imm );
+	SKIP_Z;
 }
 
 /* 64 5e: 0110 0100 0101 1110 xxxx xxxx */
@@ -3764,9 +3752,8 @@ void upd7810_device::OFFI_MKH_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (0 == (MKH & imm))
-		PSW |= SK;
 	SET_Z( MKH & imm );
+	SKIP_Z;
 }
 
 /* 64 5f: 0110 0100 0101 1111 xxxx xxxx */
@@ -3775,9 +3762,8 @@ void upd7810_device::OFFI_MKL_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (0 == (MKL & imm))
-		PSW |= SK;
 	SET_Z( MKL & imm );
+	SKIP_Z;
 }
 
 /* 64 60: 0110 0100 0110 0000 xxxx xxxx */
@@ -4522,9 +4508,8 @@ void upd7810_device::ONI_ANM_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (ANM & imm)
-		PSW |= SK;
 	SET_Z( ANM & imm );
+	SKIP_NZ;
 }
 
 /* 64 c9: 0110 0100 1100 1001 xxxx xxxx */
@@ -4533,9 +4518,8 @@ void upd7810_device::ONI_SMH_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (SMH & imm)
-		PSW |= SK;
 	SET_Z( SMH & imm );
+	SKIP_NZ;
 }
 
 /* 64 cb: 0110 0100 1100 1011 xxxx xxxx */
@@ -4546,9 +4530,8 @@ void upd7810_device::ONI_EOM_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (eom & imm)
-		PSW |= SK;
 	SET_Z( eom & imm );
+	SKIP_NZ;
 }
 
 /* 64 cd: 0110 0100 1100 1101 xxxx xxxx */
@@ -4557,9 +4540,8 @@ void upd7810_device::ONI_TMM_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (TMM & imm)
-		PSW |= SK;
 	SET_Z( TMM & imm );
+	SKIP_NZ;
 }
 
 /* 64 d0: 0110 0100 1101 0000 xxxx xxxx */
@@ -4619,9 +4601,8 @@ void upd7810_device::OFFI_ANM_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (0 == (ANM & imm))
-		PSW |= SK;
 	SET_Z( ANM & imm );
+	SKIP_Z;
 }
 
 /* 64 d9: 0110 0100 1101 1001 xxxx xxxx */
@@ -4630,9 +4611,8 @@ void upd7810_device::OFFI_SMH_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (0 == (SMH & imm))
-		PSW |= SK;
 	SET_Z( SMH & imm );
+	SKIP_Z;
 }
 
 /* 64 db: 0110 0100 1101 1011 xxxx xxxx */
@@ -4643,9 +4623,8 @@ void upd7810_device::OFFI_EOM_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (0 == (eom & imm))
-		PSW |= SK;
 	SET_Z( eom & imm );
+	SKIP_Z;
 }
 
 /* 64 dd: 0110 0100 1101 1101 xxxx xxxx */
@@ -4654,9 +4633,8 @@ void upd7810_device::OFFI_TMM_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (0 == (TMM & imm))
-		PSW |= SK;
 	SET_Z( TMM & imm );
+	SKIP_Z;
 }
 
 /* 64 e0: 0110 0100 1110 0000 xxxx xxxx */
@@ -6790,9 +6768,8 @@ void upd7810_device::ONI_V_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (V & imm)
-		PSW |= SK;
 	SET_Z( V & imm );
+	SKIP_NZ;
 }
 
 /* 74 49: 0111 0100 0100 1001 xxxx xxxx */
@@ -6801,9 +6778,8 @@ void upd7810_device::ONI_A_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (A & imm)
-		PSW |= SK;
 	SET_Z( A & imm );
+	SKIP_NZ;
 }
 
 /* 74 4a: 0111 0100 0100 1010 xxxx xxxx */
@@ -6812,9 +6788,8 @@ void upd7810_device::ONI_B_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (B & imm)
-		PSW |= SK;
 	SET_Z( B & imm );
+	SKIP_NZ;
 }
 
 /* 74 4b: 0111 0100 0100 1011 xxxx xxxx */
@@ -6823,9 +6798,8 @@ void upd7810_device::ONI_C_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (C & imm)
-		PSW |= SK;
 	SET_Z( C & imm );
+	SKIP_NZ;
 }
 
 /* 74 4c: 0111 0100 0100 1100 xxxx xxxx */
@@ -6834,9 +6808,8 @@ void upd7810_device::ONI_D_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (D & imm)
-		PSW |= SK;
 	SET_Z( D & imm );
+	SKIP_NZ;
 }
 
 /* 74 4d: 0111 0100 0100 1101 xxxx xxxx */
@@ -6845,9 +6818,8 @@ void upd7810_device::ONI_E_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (E & imm)
-		PSW |= SK;
 	SET_Z( E & imm );
+	SKIP_NZ;
 }
 
 /* 74 4e: 0111 0100 0100 1110 xxxx xxxx */
@@ -6856,9 +6828,8 @@ void upd7810_device::ONI_H_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (H & imm)
-		PSW |= SK;
 	SET_Z( H & imm );
+	SKIP_NZ;
 }
 
 /* 74 4f: 0111 0100 0100 1111 xxxx xxxx */
@@ -6867,9 +6838,8 @@ void upd7810_device::ONI_L_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (L & imm)
-		PSW |= SK;
 	SET_Z( L & imm );
+	SKIP_NZ;
 }
 
 /* 74 50: 0111 0100 0101 0000 xxxx xxxx */
@@ -6966,9 +6936,8 @@ void upd7810_device::OFFI_V_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (0 == (V & imm))
-		PSW |= SK;
 	SET_Z( V & imm );
+	SKIP_Z;
 }
 
 /* 74 59: 0111 0100 0101 1001 xxxx xxxx */
@@ -6977,9 +6946,8 @@ void upd7810_device::OFFI_A_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (0 == (A & imm))
-		PSW |= SK;
 	SET_Z( A & imm );
+	SKIP_Z;
 }
 
 /* 74 5a: 0111 0100 0101 1010 xxxx xxxx */
@@ -6988,9 +6956,8 @@ void upd7810_device::OFFI_B_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (0 == (B & imm))
-		PSW |= SK;
 	SET_Z( B & imm );
+	SKIP_Z;
 }
 
 /* 74 5b: 0111 0100 0101 1011 xxxx xxxx */
@@ -6999,9 +6966,8 @@ void upd7810_device::OFFI_C_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (0 == (C & imm))
-		PSW |= SK;
 	SET_Z( C & imm );
+	SKIP_Z;
 }
 
 /* 74 5c: 0111 0100 0101 1100 xxxx xxxx */
@@ -7010,9 +6976,8 @@ void upd7810_device::OFFI_D_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (0 == (D & imm))
-		PSW |= SK;
 	SET_Z( D & imm );
+	SKIP_Z;
 }
 
 /* 74 5d: 0111 0100 0101 1101 xxxx xxxx */
@@ -7021,9 +6986,8 @@ void upd7810_device::OFFI_E_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (0 == (E & imm))
-		PSW |= SK;
 	SET_Z( E & imm );
+	SKIP_Z;
 }
 
 /* 74 5e: 0111 0100 0101 1110 xxxx xxxx */
@@ -7032,9 +6996,8 @@ void upd7810_device::OFFI_H_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (0 == (H & imm))
-		PSW |= SK;
 	SET_Z( H & imm );
+	SKIP_Z;
 }
 
 /* 74 5f: 0111 0100 0101 1111 xxxx xxxx */
@@ -7043,9 +7006,8 @@ void upd7810_device::OFFI_L_xx()
 	uint8_t imm;
 
 	RDOPARG( imm );
-	if (0 == (L & imm))
-		PSW |= SK;
 	SET_Z( L & imm );
+	SKIP_Z;
 }
 
 /* 74 60: 0111 0100 0110 0000 xxxx xxxx */
@@ -8470,10 +8432,8 @@ void upd7810_device::ONIW_wa_xx()
 	RDOPARG( ea.b.l );
 	RDOPARG( imm );
 
-	uint8_t readmem = RM( ea.d );
-	if (readmem & imm)
-		PSW |= SK;
-	SET_Z( readmem & imm );
+	SET_Z( RM( ea.d ) & imm );
+	SKIP_NZ;
 }
 
 /* 46: 0100 0110 xxxx xxxx */
@@ -8605,10 +8565,8 @@ void upd7810_device::OFFIW_wa_xx()
 	RDOPARG( ea.b.l );
 	RDOPARG( imm );
 
-	uint8_t readmem = RM( ea.d );
-	if (0 == (readmem & imm))
-		PSW |= SK;
-	SET_Z( readmem & imm );
+	SET_Z( RM( ea.d ) & imm );
+	SKIP_Z;
 }
 
 /* 56: 0101 0110 xxxx xxxx */


### PR DESCRIPTION
According to the UPD7810 datasheet, the OFF/ON instructions are supposed to affect the Z flag.

This will add SET_Z to the instruction opcode routine.

I considered rewriting it as doing the SET_Z ( x & imm ); first then SKIP_Z; or SKIP_NZ;
if you think that would be better.


=================================


I was also looking at the INR r2  instructions and it seems that it should affect the carry bit according to the datasheet.

INRW_wa
INR_A
INR_B
INR_C

DCR A
DCR_B
DCR_C
DCRW_wa

I see that they restore the original carry bit but it seems to say that CY should be affected by the operation.

