### PR TITLE
sony/news_r3k.cpp: Specify LANCE clock to fix NEWS-OS 4 and 5

### DIFF
--- a/src/mame/sony/news_r3k.cpp
+++ b/src/mame/sony/news_r3k.cpp
@@ -501,7 +501,7 @@ void news_r3k_base_state::common(machine_config &config)
 	m_scc->out_rtsb_callback().set(m_serial[1], FUNC(rs232_port_device::write_rts));
 	m_scc->out_txdb_callback().set(m_serial[1], FUNC(rs232_port_device::write_txd));
 
-	AM7990(config, m_net);
+	AM7990(config, m_net, 20_MHz_XTAL / 2);
 	m_net->intr_out().set(FUNC(news_r3k_base_state::irq_w<LANCE>)).invert();
 	m_net->dma_in().set([this](offs_t offset) { return m_net_ram[offset >> 1]; });
 	m_net->dma_out().set([this](offs_t offset, u16 data, u16 mem_mask) { COMBINE_DATA(&m_net_ram[offset >> 1]); });


### PR DESCRIPTION
NEWS-OS 4 and 5 don't boot on master at the moment due to a change in the LANCE driver that requires the clock to be set for it to function correctly. With this change, the r3k driver can boot both again.