### PR TITLE
Add tape support to Sony NEWS drivers and clean up CD-ROM support

### DIFF
--- a/src/devices/bus/nscsi/cd.cpp
+++ b/src/devices/bus/nscsi/cd.cpp
@@ -57,7 +57,7 @@ nscsi_cdrom_sgi_device::nscsi_cdrom_sgi_device(const machine_config &mconfig, co
 }
 
 nscsi_cdrom_news_device::nscsi_cdrom_news_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	nscsi_cdrom_device(mconfig, NSCSI_CDROM_NEWS, tag, owner, "Sony", "CD-ROM CDU-541", "1.0A", 0x00, 0x05)
+	nscsi_cdrom_device(mconfig, NSCSI_CDROM_NEWS, tag, owner, "SONY", "CD-ROM CDU-541", "1.0A", 0x00, 0x05)
 {
 }
 

--- a/src/devices/bus/nscsi/tape.cpp
+++ b/src/devices/bus/nscsi/tape.cpp
@@ -69,10 +69,12 @@ nscsi_tape_device::nscsi_tape_device(const machine_config &config, const char *t
 {
 }
 
-// NEWS-OS 4 will recognize a few models out of the box. For streaming tape, the Anritsu DMT780 can recognize QIC-24,
-// QIC-120, QIC-150, and QIC-525, making it a flexible choice. Different versions of NEWS-OS may need a different drive.
+// This device uses the IDNT info from an Archive Viper 2150S tape drive, used by Sony in the NWP-546 external tape
+// drive and is supported out-of-the-box by NEWS-OS 4. Some formats may require using different IDNT data, like the
+// Anritsu DMT780 or Archive Viper 2525 for QIC-525, or the Sony SDT-1000 for DAT (among other formats/drives)
+// See /usr/src/sys/newsiodev/stdefs.c for more information (or to compile a kernel with support for other drives)
 nscsi_tape_news_device::nscsi_tape_news_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	nscsi_tape_device(mconfig, NSCSI_TAPE_NEWS, tag, owner, clock, "ANRITSU", "DMT780", "0000")
+	nscsi_tape_device(mconfig, NSCSI_TAPE_NEWS, tag, owner, clock, "ARCHIVE", "VIPER 150", "0000")
 {
 }
 

--- a/src/devices/bus/nscsi/tape.cpp
+++ b/src/devices/bus/nscsi/tape.cpp
@@ -42,25 +42,37 @@ void clear_response(uint8_t (&buf)[N], T len)
 
 
 DEFINE_DEVICE_TYPE(NSCSI_TAPE, nscsi_tape_device, "scsi_tape", "SCSI tape");
+DEFINE_DEVICE_TYPE(NSCSI_TAPE_NEWS, nscsi_tape_news_device, "scsi_tape_news", "SCSI tape NEWS");
 
 //////////////////////////////////////////////////////////////////////////////
 
 // construction
 
-nscsi_tape_device::nscsi_tape_device(const machine_config &config, device_type type, const char *tag, device_t *owner, u32 clock)
+nscsi_tape_device::nscsi_tape_device(const machine_config &config, device_type type, const char *tag, device_t *owner,
+	u32 clock, const std::string_view manufacturer, const std::string_view product, const std::string_view revision)
 	: nscsi_full_device(config, type, tag, owner, clock)
 	, m_image(*this, "image")
 	, m_sequence_counter(0)
 	, m_has_tape(false)
 	, m_tape_changed(false)
 	, m_fixed_block_len(TAPE_DEFAULT_FIXED_BLOCK_LEN)
+	, manufacturer(manufacturer)
+	, product(product)
+	, revision(revision)
 	, m_rw_buf_size(m_fixed_block_len)
 	, m_rw_pending(false)
 {
 }
 
 nscsi_tape_device::nscsi_tape_device(const machine_config &config, const char *tag, device_t *owner, u32 clock)
-	: nscsi_tape_device(config, NSCSI_TAPE, tag, owner, clock)
+	: nscsi_tape_device(config, NSCSI_TAPE, tag, owner, clock, "MAME", "SCSI tape drive", "1.0")
+{
+}
+
+// NEWS-OS 4 will recognize a few models out of the box. For streaming tape, the Anritsu DMT780 can recognize QIC-24,
+// QIC-120, QIC-150, and QIC-525, making it a flexible choice. Different versions of NEWS-OS may need a different drive.
+nscsi_tape_news_device::nscsi_tape_news_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	nscsi_tape_device(mconfig, NSCSI_TAPE_NEWS, tag, owner, clock, "ANRITSU", "DMT780", "0000")
 {
 }
 
@@ -250,9 +262,9 @@ void nscsi_tape_device::handle_inquiry(const u8 lun) // mandatory; SCSI-2 sectio
 	m_scsi_cmdbuf[2] = 0x02; // we're compliant with SCSI-2 only
 	m_scsi_cmdbuf[3] = 0x02; // we use SCSI-2 response format
 	m_scsi_cmdbuf[4] = 32; // additional length
-	strncpy((char *)&m_scsi_cmdbuf[8], "MAME", 8); // vendor
-	strncpy((char *)&m_scsi_cmdbuf[16], "SCSI tape drive", 16); // product
-	strncpy((char *)&m_scsi_cmdbuf[32], "1.0", 4); // revision
+	std::copy_n(manufacturer.data(), std::min(manufacturer.size(),  static_cast<size_t>(8)), &m_scsi_cmdbuf[8]); // drive manufacturer
+	std::copy_n(product.data(), std::min(product.size(),  static_cast<size_t>(16)), &m_scsi_cmdbuf[16]); // product code
+	std::copy_n(revision.data(), std::min(revision.size(),  static_cast<size_t>(4)), &m_scsi_cmdbuf[32]); // product/firmware revision
 	for (u32 i = 8; i < 36; i++) {
 		if (m_scsi_cmdbuf[i] == 0)
 			m_scsi_cmdbuf[i] = ' '; // pad strings with spaces

--- a/src/devices/bus/nscsi/tape.h
+++ b/src/devices/bus/nscsi/tape.h
@@ -10,6 +10,7 @@
 #include "machine/nscsi_hle.h"
 
 DECLARE_DEVICE_TYPE(NSCSI_TAPE, nscsi_tape_device);
+DECLARE_DEVICE_TYPE(NSCSI_TAPE_NEWS, nscsi_tape_news_device)
 
 //////////////////////////////////////////////////////////////////////////////
 
@@ -20,7 +21,7 @@ public:
 	nscsi_tape_device(const machine_config &config, const char *tag, device_t *owner, u32 clock = 0);
 
 protected:
-	nscsi_tape_device(const machine_config &config, device_type type, const char *tag, device_t *owner, u32 clock);
+	nscsi_tape_device(const machine_config &config, device_type type, const char *tag, device_t *owner, u32 clock, const std::string_view manufacturer, const std::string_view product, const std::string_view revision);
 
 	// device_t implementation
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
@@ -62,6 +63,11 @@ protected:
 	bool m_tape_changed; // should we report medium changed next time we receive command
 	u32 m_fixed_block_len; // fixed-length block length
 
+	// INQUIRY data
+	const std::string_view manufacturer;
+	const std::string_view product;
+	const std::string_view revision;
+
 	// state for READ and WRITE
 	u32 m_rw_buf_size; // size of read/write buffer
 	std::unique_ptr<u8[]> m_rw_buf; // read/write buffer
@@ -76,6 +82,12 @@ protected:
 	// state for MODE SELECT
 	u8 m_pl_buf[256]; // parameter list buffer
 	u32 m_pl_len; // length of valid data in parameter list buffer
+};
+
+class nscsi_tape_news_device : public nscsi_tape_device
+{
+public:
+	nscsi_tape_news_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 };
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/mame/sony/news_38xx.cpp
+++ b/src/mame/sony/news_38xx.cpp
@@ -851,8 +851,8 @@ void news_38xx_state::reset_cpu_registers()
 void news_scsi_devices(device_slot_interface &device)
 {
 	device.option_add("harddisk", NSCSI_HARDDISK);
-	device.option_add("cdrom", NSCSI_CDROM);
-	device.option_add("tape", NSCSI_TAPE);
+	device.option_add("cdrom", NSCSI_CDROM_NEWS);
+	device.option_add("tape", NSCSI_TAPE_NEWS);
 }
 
 void news_38xx_state::common(machine_config &config)

--- a/src/mame/sony/news_68k.cpp
+++ b/src/mame/sony/news_68k.cpp
@@ -95,6 +95,7 @@ __|              |         |  |ALS05A| |N82077   |   __             6 x 74F00J->
 #include "machine/nscsi_bus.h"
 #include "bus/nscsi/cd.h"
 #include "bus/nscsi/hd.h"
+#include "bus/nscsi/tape.h"
 #include "bus/rs232/rs232.h"
 
 #include "machine/input_merger.h"
@@ -373,6 +374,7 @@ static void news_scsi_devices(device_slot_interface &device)
 {
 	device.option_add("harddisk", NSCSI_HARDDISK);
 	device.option_add("cdrom", NSCSI_CDROM);
+	device.option_add("tape", NSCSI_TAPE_NEWS);
 }
 
 void news_68k_state::common(machine_config &config)

--- a/src/mame/sony/news_68k.cpp
+++ b/src/mame/sony/news_68k.cpp
@@ -373,7 +373,7 @@ u32 news_68k_state::bus_error_r()
 static void news_scsi_devices(device_slot_interface &device)
 {
 	device.option_add("harddisk", NSCSI_HARDDISK);
-	device.option_add("cdrom", NSCSI_CDROM);
+	device.option_add("cdrom", NSCSI_CDROM_NEWS);
 	device.option_add("tape", NSCSI_TAPE_NEWS);
 }
 

--- a/src/mame/sony/news_68k_iop.cpp
+++ b/src/mame/sony/news_68k_iop.cpp
@@ -796,7 +796,7 @@ namespace
 	static void news_scsi_devices(device_slot_interface &device)
 	{
 		device.option_add("harddisk", NSCSI_HARDDISK);
-		device.option_add("cdrom", NSCSI_CDROM);
+		device.option_add("cdrom", NSCSI_CDROM_NEWS);
 		device.option_add("tape", NSCSI_TAPE_NEWS);
 	}
 

--- a/src/mame/sony/news_68k_iop.cpp
+++ b/src/mame/sony/news_68k_iop.cpp
@@ -797,7 +797,7 @@ namespace
 	{
 		device.option_add("harddisk", NSCSI_HARDDISK);
 		device.option_add("cdrom", NSCSI_CDROM);
-		device.option_add("tape", NSCSI_TAPE);
+		device.option_add("tape", NSCSI_TAPE_NEWS);
 	}
 
 	void news_iop_state::handle_rts(int data)

--- a/src/mame/sony/news_r3k.cpp
+++ b/src/mame/sony/news_r3k.cpp
@@ -26,6 +26,7 @@
 
 #include "bus/nscsi/cd.h"
 #include "bus/nscsi/hd.h"
+#include "bus/nscsi/tape.h"
 #include "bus/rs232/rs232.h"
 #include "cpu/mips/mips1.h"
 #include "imagedev/floppy.h"
@@ -468,6 +469,7 @@ static void news_scsi_devices(device_slot_interface &device)
 {
 	device.option_add("harddisk", NSCSI_HARDDISK);
 	device.option_add("cdrom", NSCSI_CDROM);
+	device.option_add("tape", NSCSI_TAPE_NEWS);
 }
 
 void news_r3k_base_state::common(machine_config &config)

--- a/src/mame/sony/news_r3k.cpp
+++ b/src/mame/sony/news_r3k.cpp
@@ -468,7 +468,7 @@ void news_r3k_base_state::debug_w(u8 data)
 static void news_scsi_devices(device_slot_interface &device)
 {
 	device.option_add("harddisk", NSCSI_HARDDISK);
-	device.option_add("cdrom", NSCSI_CDROM);
+	device.option_add("cdrom", NSCSI_CDROM_NEWS);
 	device.option_add("tape", NSCSI_TAPE_NEWS);
 }
 

--- a/src/mame/sony/news_r4k.cpp
+++ b/src/mame/sony/news_r4k.cpp
@@ -97,6 +97,7 @@
 
 #include "bus/nscsi/cd.h"
 #include "bus/nscsi/hd.h"
+#include "bus/nscsi/tape.h"
 #include "bus/rs232/rs232.h"
 #include "cpu/mips/r4000.h"
 #include "imagedev/floppy.h"
@@ -373,6 +374,7 @@ static void news_scsi_devices(device_slot_interface &device)
 {
 	device.option_add("harddisk", NSCSI_HARDDISK);
 	device.option_add("cdrom", NSCSI_CDROM_NEWS);
+	device.option_add("tape", NSCSI_TAPE_NEWS);
 }
 
 /*


### PR DESCRIPTION
I added a tape drive (with the same structure as the `nscsi/cd.h/cpp` file, I can do something else if preferred, just let me know) that has the IDNT information for the NWP-546 external tape drive. This is recognized by NEWS-OS 4.

<img width="2560" height="1371" alt="tape test" src="https://github.com/user-attachments/assets/09ede6b0-59cb-46bb-9b26-04da63c20dc6" />

While I was at it, I cleaned up the CD-ROM support. I added the CDU-541 for the 5000X driver, but I only did the minimum to get it to work. It wasn't actually recognized as a CD-ROM drive by NEWS-OS, but I didn't catch it at the time because it still worked.

Before the change:
<img width="690" height="451" alt="cd-before-fix" src="https://github.com/user-attachments/assets/4c71c723-38c7-44fc-b97b-3bb49398a165" />

After the change:
<img width="690" height="451" alt="cd-after-fix" src="https://github.com/user-attachments/assets/14cb6501-6c38-412c-9019-28f326527023" />
