### PR TITLE
cpu/m68000: Update bftst to use reluctant reads when fetching data from memory

### DIFF
--- a/src/devices/cpu/m68000/m68k_in.lst
+++ b/src/devices/cpu/m68000/m68k_in.lst
@@ -1914,7 +1914,9 @@ e8c0 ffc0 bftst    l ADXWLdx    234fc:13
 	mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
 	mask_long = mask_base >> offset;
 
-	data_long = m68ki_read_32(ea);
+	data_long = (offset + width) <= 8  ? m68ki_read_8(ea) << 24 :
+				(offset + width) <= 16 ? m68ki_read_16(ea) << 16 :
+				m68ki_read_32(ea);
 	m_n_flag = ((data_long & (0x80000000 >> offset))<<offset)>>24;
 	m_not_z_flag = data_long & mask_long;
 	m_v_flag = VFLAG_CLEAR;

--- a/src/devices/cpu/m68000/m68kops.cpp
+++ b/src/devices/cpu/m68000/m68kops.cpp
@@ -7323,7 +7323,9 @@ void m68000_musashi_device::xe8d0_bftst_l_ai_234fc()
 	mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
 	mask_long = mask_base >> offset;
 
-	data_long = m68ki_read_32(ea);
+	data_long = (offset + width) <= 8  ? m68ki_read_8(ea) << 24 :
+				(offset + width) <= 16 ? m68ki_read_16(ea) << 16 :
+				m68ki_read_32(ea);
 	m_n_flag = ((data_long & (0x80000000 >> offset))<<offset)>>24;
 	m_not_z_flag = data_long & mask_long;
 	m_v_flag = VFLAG_CLEAR;
@@ -7366,7 +7368,9 @@ void m68000_musashi_device::xe8e8_bftst_l_di_234fc()
 	mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
 	mask_long = mask_base >> offset;
 
-	data_long = m68ki_read_32(ea);
+	data_long = (offset + width) <= 8  ? m68ki_read_8(ea) << 24 :
+				(offset + width) <= 16 ? m68ki_read_16(ea) << 16 :
+				m68ki_read_32(ea);
 	m_n_flag = ((data_long & (0x80000000 >> offset))<<offset)>>24;
 	m_not_z_flag = data_long & mask_long;
 	m_v_flag = VFLAG_CLEAR;
@@ -7409,7 +7413,9 @@ void m68000_musashi_device::xe8f0_bftst_l_ix_234fc()
 	mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
 	mask_long = mask_base >> offset;
 
-	data_long = m68ki_read_32(ea);
+	data_long = (offset + width) <= 8  ? m68ki_read_8(ea) << 24 :
+				(offset + width) <= 16 ? m68ki_read_16(ea) << 16 :
+				m68ki_read_32(ea);
 	m_n_flag = ((data_long & (0x80000000 >> offset))<<offset)>>24;
 	m_not_z_flag = data_long & mask_long;
 	m_v_flag = VFLAG_CLEAR;
@@ -7452,7 +7458,9 @@ void m68000_musashi_device::xe8f8_bftst_l_aw_234fc()
 	mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
 	mask_long = mask_base >> offset;
 
-	data_long = m68ki_read_32(ea);
+	data_long = (offset + width) <= 8  ? m68ki_read_8(ea) << 24 :
+				(offset + width) <= 16 ? m68ki_read_16(ea) << 16 :
+				m68ki_read_32(ea);
 	m_n_flag = ((data_long & (0x80000000 >> offset))<<offset)>>24;
 	m_not_z_flag = data_long & mask_long;
 	m_v_flag = VFLAG_CLEAR;
@@ -7495,7 +7503,9 @@ void m68000_musashi_device::xe8f9_bftst_l_al_234fc()
 	mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
 	mask_long = mask_base >> offset;
 
-	data_long = m68ki_read_32(ea);
+	data_long = (offset + width) <= 8  ? m68ki_read_8(ea) << 24 :
+				(offset + width) <= 16 ? m68ki_read_16(ea) << 16 :
+				m68ki_read_32(ea);
 	m_n_flag = ((data_long & (0x80000000 >> offset))<<offset)>>24;
 	m_not_z_flag = data_long & mask_long;
 	m_v_flag = VFLAG_CLEAR;
@@ -7538,7 +7548,9 @@ void m68000_musashi_device::xe8fa_bftst_l_pcdi_234fc()
 	mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
 	mask_long = mask_base >> offset;
 
-	data_long = m68ki_read_32(ea);
+	data_long = (offset + width) <= 8  ? m68ki_read_8(ea) << 24 :
+				(offset + width) <= 16 ? m68ki_read_16(ea) << 16 :
+				m68ki_read_32(ea);
 	m_n_flag = ((data_long & (0x80000000 >> offset))<<offset)>>24;
 	m_not_z_flag = data_long & mask_long;
 	m_v_flag = VFLAG_CLEAR;
@@ -7581,7 +7593,9 @@ void m68000_musashi_device::xe8fb_bftst_l_pcix_234fc()
 	mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
 	mask_long = mask_base >> offset;
 
-	data_long = m68ki_read_32(ea);
+	data_long = (offset + width) <= 8  ? m68ki_read_8(ea) << 24 :
+				(offset + width) <= 16 ? m68ki_read_16(ea) << 16 :
+				m68ki_read_32(ea);
 	m_n_flag = ((data_long & (0x80000000 >> offset))<<offset)>>24;
 	m_not_z_flag = data_long & mask_long;
 	m_v_flag = VFLAG_CLEAR;


### PR DESCRIPTION
When working on the NWS-1250 (#15364), I was seeing occasional segmentation faults (more easily reproduced in the 12MB RAM configuration and in the NEWS-OS 4.1C install process). I have traced out the results of my debug below, but I am not a 68k expert, so I would appreciate a second set of eyes on this! I might have missed something.

First, the offending kernel stack trace:
<img width="1739" height="657" alt="mem_bus_error" src="https://github.com/user-attachments/assets/914c7bc4-8a59-457c-bd9f-c6918d587461" />

The instruction causing a bus error is 0x8005dda8.

Instruction: BFTST (A5) {30:2}; (2+)
A5 = 0x80a0dffc bit 30 is at byte address 0x80a0dfff, and the instruction is testing the last two bits in the page because of the following walk:

TC = 0x80c019a0 (0b10000000110000000001100110100000)
  E -> 1 (translation enabled)
  U -> 0b00000 (unused)
SRE -> 0 (supervisor root pointer disabled)
FCL -> 0 (function code lookup disabled, first table level indexed by logic address field defined by TIA)
 PS -> 0b1100 (4KiB)
 IS -> 0b0000 (no shift)
TIA -> 0b0001 (1 bit for top level)
TIB -> 0b1001 (9 bits for second level)
TIC -> 0b1010 (10 bits for third level)
TID -> 0b0000 (stops before fourth level)

A5 = 0x80a0dffc
0x80a0dffc -> top level bit = 1, crp + 8 * 1 = 0xa2800 + 8 * 1 = 0xa2808 has the level 1 descriptor
0xc00a2808 = 0x01ff010a 0x000a2000 -> second level (9) bits = 0x2, 0xa2000 + 4 * 2 = 0xa2008 has the level 2 descriptor
0xc00a2008 = 0x0009600a -> third level (10) bits are 0x20d, 0x96000 + 0x20d * 4 = 0x96834 (PTE)
0xc0096834 = 0x00bbd019

Results of the table walk:
<img width="1042" height="1321" alt="mem_walk" src="https://github.com/user-attachments/assets/82ceec2b-ba77-48cc-b5d1-697b04b31962" />



However, the next PTE is 0. Therefore, when the `bftst` instruction calls m68ki_read_32(0x80a0dfff), it hits a bus error after the first byte.
Based on how some others like `bfext` are implemented (like in `xebd0_bfexts_l_ai_234fc`, which is an example of one that uses the change applied to `bftst` here), it seems like this is a bug. However, I see some of the other bitflag instructions are implemented like `bftst`, so I am not 100% sure.