### PR TITLE
namcos12.cpp: kartduel: add MACHINE_NODEVICE_LAN flag

### DIFF
--- a/src/mame/namco/namcos12.cpp
+++ b/src/mame/namco/namcos12.cpp
@@ -18,6 +18,7 @@
     - sws2001 crashes at random times in-game, and always after the opening video. You can spam insert coin and start to get in-game.
     - sws2000 also crashes after opening video
     - toukon3 has garbage graphics
+	- kartduel has unemulated link support
 
 Namco System 12 - Arcade Playstation-based Hardware
 ===================================================
@@ -3667,7 +3668,7 @@ GAME( 2000, sws2000,    0,        coh700b,  namcos12, namcos12_state,         em
 // truckk can't be a Japanese set despite the game title still being in Japanese.  The option for in-game Japanese text is disabled in this set, and it has a Parental Advisory screen usually associated with US releases
 // TKK1 is probably the Japanese release, although a TKK1 CD contains identical data to a TKK2 CD, so any difference is in the ROM data rather than the CD
 GAME( 2000, truckk,     0,        truckk,   truckk,   truckk_state,           empty_init, ROT0, "Metro / Namco",   "Truck Kyosokyoku (US?, TKK2/VER.A)", MACHINE_IMPERFECT_SOUND ) /* KC056 */
-GAME( 2000, kartduel,   0,        kartduel, kartduel, kartduel_state,         empty_init, ROT0, "Gaps / Namco",    "Kart Duel (World, KTD2/VER.A)", 0 ) /* KC057 */
-GAME( 2000, kartduelja, kartduel, kartduel, kartduel, kartduel_state,         empty_init, ROT0, "Gaps / Namco",    "Kart Duel (Japan, KTD1/VER.A)", 0 ) /* KC057 */
+GAME( 2000, kartduel,   0,        kartduel, kartduel, kartduel_state,         empty_init, ROT0, "Gaps / Namco",    "Kart Duel (World, KTD2/VER.A)", MACHINE_NODEVICE_LAN ) /* KC057 */
+GAME( 2000, kartduelja, kartduel, kartduel, kartduel, kartduel_state,         empty_init, ROT0, "Gaps / Namco",    "Kart Duel (Japan, KTD1/VER.A)", MACHINE_NODEVICE_LAN ) /* KC057 */
 GAME( 2000, g13knd,     0,        golgo13,  golgo13,  golgo13_state,          empty_init, ROT0, "Eighting / Raizing / Namco", "Golgo 13 Kiseki no Dandou (Japan, GLS1/VER.A)", 0 ) /* KC059 */
 GAME( 2001, sws2001,    0,        coh716,   namcos12, namcos12_altbank_state, empty_init, ROT0, "Namco",           "Super World Stadium 2001 (Japan, SS11/VER.A)", MACHINE_NOT_WORKING ) /* KC061 */


### PR DESCRIPTION
Kart Duel has a multiplayer functionality as indicated on the test menu:

<img width="320" height="240" alt="0008" src="https://github.com/user-attachments/assets/87fab353-3edc-45e0-8d75-11c8cd05c7c7" />
<img width="320" height="240" alt="0009" src="https://github.com/user-attachments/assets/6ad7a714-3808-4d5f-85a4-38bd2a95020e" />

[The PR fixing kartduel](https://github.com/mamedev/mame/pull/11483) also mentioned that lack of link PCB emulation once caused framerate issues.

---

EDIT: Also mentioned in ADS (bookkeeping):

<img width="320" height="240" alt="0011" src="https://github.com/user-attachments/assets/8fc288e5-b22b-4924-a229-bb0853e48255" />
<img width="320" height="240" alt="0010" src="https://github.com/user-attachments/assets/f47ad2b3-9846-4750-871f-b8b12a01c63d" />
