### PR TITLE
dsp563xx/hi08: forward DSP HTX writes to the host

### DIFF
--- a/src/devices/cpu/dsp563xx/hi08.cpp
+++ b/src/devices/cpu/dsp563xx/hi08.cpp
@@ -112,7 +112,17 @@ u8 hi08_device::read(offs_t offset)
 	case 6:
 	return m_htx >> 8;
 	case 7:
-	return m_htx >> (m_icr & ICR_HLEND ? 16 : 0);
+	{
+		// Reading the trigger byte (offset 7) consumes the word the DSP
+		// queued via HTX: clear RXDF so the DSP sees HTDE asserted again.
+		u8 const result = m_htx >> (m_icr & ICR_HLEND ? 16 : 0);
+		if (!machine().side_effects_disabled())
+		{
+			m_isr &= ~ISR_RXDF;
+			machine().scheduler().synchronize();
+		}
+		return result;
+	}
 	}
 	return 0;
 }
@@ -187,4 +197,9 @@ u32 hi08_device::hrx_r()
 void hi08_device::htx_w(u32 data)
 {
 	logerror("htx_w %06x (%s)\n", data, machine().describe_context());
+	m_htx = data & 0xffffff;
+	// The DSP has loaded HTX with a word for the host; expose it on the
+	// host-side RX bus and assert HRDF/clear HTDE via ISR_RXDF.
+	m_isr |= ISR_RXDF;
+	machine().scheduler().synchronize();
 }


### PR DESCRIPTION
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/769130ee-1095-472b-b78c-0cd45183b787" />

`void hi08_device::htx_w(u32 data)` only logged the outgoing word; it did not store it in `m_htx` or update `m_isr`. Host-side reads of HRX (offsets 5/6/7) therefore always returned zero and the host never saw ISR_RXDF asserted, so any 80C535 firmware polling HSR for a reply from the DSP after the bootstrap upload would spin forever.

Store the word the DSP placed on HTX into m_htx, raise ISR_RXDF (which in turn asserts host-side HRDF and clears DSP-side HTDE through hsr_r's view), and let the host's read of the trigger byte at offset 7 clear ISR_RXDF so the DSP can transmit the next word.

With this in place virusb boots all the way to its interactive UI: the LCD shows the patch / parameter pages and the panel buttons drive the menu.