### PR TITLE
qx10: Move video subsystem to use a slot based architecutre

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -2193,6 +2193,20 @@ end
 
 ---------------------------------------------------
 --
+--@src/devices/bus/epson_qx/video/video.h,BUSES["EPSON_QX_VIDEO"] = true
+---------------------------------------------------
+
+if BUSES["EPSON_QX_VIDEO"] then
+	files {
+		MAME_DIR .. "src/devices/bus/epson_qx/video/qx_gdc_cards.cpp",
+		MAME_DIR .. "src/devices/bus/epson_qx/video/qx_gdc_cards.h",
+		MAME_DIR .. "src/devices/bus/epson_qx/video/video.cpp",
+		MAME_DIR .. "src/devices/bus/epson_qx/video/video.h",
+	}
+end
+
+---------------------------------------------------
+--
 --@src/devices/bus/epson_sio/epson_sio.h,BUSES["EPSON_SIO"] = true
 ---------------------------------------------------
 if BUSES["EPSON_SIO"] then

--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -2241,6 +2241,20 @@ end
 
 ---------------------------------------------------
 --
+--@src/devices/bus/epson_qx/video/video.h,BUSES["EPSON_QX_VIDEO"] = true
+---------------------------------------------------
+
+if BUSES["EPSON_QX_VIDEO"] then
+	files {
+		MAME_DIR .. "src/devices/bus/epson_qx/video/qx_gdc_cards.cpp",
+		MAME_DIR .. "src/devices/bus/epson_qx/video/qx_gdc_cards.h",
+		MAME_DIR .. "src/devices/bus/epson_qx/video/video.cpp",
+		MAME_DIR .. "src/devices/bus/epson_qx/video/video.h",
+	}
+end
+
+---------------------------------------------------
+--
 --@src/devices/bus/epson_sio/epson_sio.h,BUSES["EPSON_SIO"] = true
 ---------------------------------------------------
 if BUSES["EPSON_SIO"] then

--- a/src/devices/bus/epson_qx/video/qx_gdc_cards.cpp
+++ b/src/devices/bus/epson_qx/video/qx_gdc_cards.cpp
@@ -1,0 +1,360 @@
+// license:BSD-3-Clause
+// copyright-holders:Mariusz Wojcieszek, Angelo Salese, Brian Johnson
+/***************************************************************************
+
+    QX-series uPD7220 (GDC) video cards
+
+***************************************************************************/
+
+#include "emu.h"
+#include "qx_gdc_cards.h"
+
+#include "screen.h"
+
+
+#define SCREEN_TAG ":screen"
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(QX10_VIDEO_GMS, bus::epson_qx::video::q10gms_device, "qx10_video_gms", "Epson Q10GMS Monochrome Graphics Card")
+DEFINE_DEVICE_TYPE(QX10_VIDEO_CMS, bus::epson_qx::video::q10cms_device, "qx10_video_cms", "Epson Q10CMS Color Graphics Card")
+
+
+namespace bus::epson_qx::video {
+
+//-------------------------------------------------
+//  shared chargen ROM
+//-------------------------------------------------
+
+ROM_START(qx_gdc_card)
+	ROM_REGION(0x1000, "chargen", 0)
+	ROM_LOAD("qga.2e", 0x0000, 0x1000, CRC(4120b128) SHA1(9b96f6d78cfd402f8aec7c063ffb70a21b78eff0))
+ROM_END
+
+
+//-------------------------------------------------
+//  shared gfxdecode
+//-------------------------------------------------
+
+/* F4 Character Displayer */
+static const gfx_layout charlayout =
+{
+	8, 16,                         /* 8 x 16 characters */
+	RGN_FRAC(1,1),                 /* 128 characters */
+	1,                             /* 1 bits per pixel */
+	{ 0 },                         /* no bitplanes */
+	/* x offsets */
+	{ 7, 6, 5, 4, 3, 2, 1, 0 },
+	/* y offsets */
+	{ 0*8, 1*8, 2*8, 3*8, 4*8, 5*8, 6*8, 7*8, 8*8, 9*8, 10*8, 11*8, 12*8, 13*8, 14*8, 15*8 },
+	8*16                           /* every char takes 16 bytes */
+};
+
+static GFXDECODE_START(gfx_qx_gdc)
+	GFXDECODE_ENTRY("chargen", 0x0000, charlayout, 1, 1)
+GFXDECODE_END
+
+
+//**************************************************************************
+//  ABSTRACT BASE
+//**************************************************************************
+
+qx_gdc_card_device::qx_gdc_card_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, size_t vram_size)
+	: device_t(mconfig, type, tag, owner, clock)
+	, device_qx_video_interface(mconfig, *this)
+	, m_hgdc(*this, "upd7220")
+	, m_screen(*this, SCREEN_TAG)
+	, m_palette(*this, "palette")
+	, m_chargen(*this, "chargen")
+	, m_vram(*this, "vram", vram_size, ENDIANNESS_LITTLE)
+	, m_zoom(0)
+{
+}
+
+const tiny_rom_entry *qx_gdc_card_device::device_rom_region() const
+{
+	return ROM_NAME(qx_gdc_card);
+}
+
+void qx_gdc_card_device::device_add_mconfig(machine_config &config)
+{
+	PALETTE(config, m_palette, FUNC(qx_gdc_card_device::palette_init), 8);
+	GFXDECODE(config, "gfxdecode", m_palette, gfx_qx_gdc);
+
+	UPD7220(config, m_hgdc, 16.67_MHz_XTAL/4/2);
+	m_hgdc->set_addrmap(0, &qx_gdc_card_device::upd7220_map);
+	m_hgdc->set_display_pixels(FUNC(qx_gdc_card_device::hgdc_display_pixels));
+	m_hgdc->set_draw_text(FUNC(qx_gdc_card_device::hgdc_draw_text));
+	m_hgdc->drq_wr_callback().set(*m_slot, FUNC(video_slot_device::drq_w));
+	m_hgdc->set_screen(SCREEN_TAG);
+}
+
+void qx_gdc_card_device::device_start()
+{
+	save_item(NAME(m_zoom));
+}
+
+void qx_gdc_card_device::install_io(address_space &space)
+{
+	space.install_device(0x2c, 0x2c, *this, &qx_gdc_card_device::id_map);
+	space.install_device(0x38, 0x39, *this, &qx_gdc_card_device::gdc_map);
+	space.install_device(0x3a, 0x3a, *this, &qx_gdc_card_device::zoom_map);
+}
+
+void qx_gdc_card_device::device_reset()
+{
+	m_zoom = 0;
+}
+
+uint32_t qx_gdc_card_device::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	bitmap.fill(m_palette->black_pen(), cliprect);
+	m_hgdc->screen_update(screen, bitmap, cliprect);
+	return 0;
+}
+
+void qx_gdc_card_device::id_map(address_map &map)
+{
+	map(0x00, 0x00).mirror(0xff00).r(FUNC(qx_gdc_card_device::id_r));
+}
+
+void qx_gdc_card_device::gdc_map(address_map &map)
+{
+	map(0x00, 0x01).mirror(0xff00).rw(m_hgdc, FUNC(upd7220_device::read), FUNC(upd7220_device::write));
+}
+
+void qx_gdc_card_device::zoom_map(address_map &map)
+{
+	map(0x00, 0x00).mirror(0xff00).w(FUNC(qx_gdc_card_device::zoom_w));
+}
+
+UPD7220_DRAW_TEXT_LINE_MEMBER(qx_gdc_card_device::hgdc_draw_text)
+{
+	const rgb_t *palette = m_palette->palette()->entry_list_raw();
+	addr &= 0xffff;
+
+	for (int x = 0; x < pitch; x++)
+	{
+		int tile = m_vram[((addr + x) * 2) >> 1] & 0xff;
+		int attr = m_vram[((addr + x) * 2) >> 1] >> 8;
+
+		uint8_t color = text_color(attr);
+
+		for (int yi = 0; yi < lr; yi++)
+		{
+			uint8_t tile_data = m_chargen[tile * 16 + yi];
+
+			if (attr & 8)
+				tile_data ^= 0xff;
+
+			if (cursor_on && cursor_addr == addr + x)
+				tile_data ^= 0xff;
+
+			if (attr & 0x80 && m_screen->frame_number() & 0x10)
+				tile_data = 0;
+
+			for (int xi = 0; xi < 8; xi++)
+			{
+				int res_x = ((x * 8) + xi) * (m_zoom + 1);
+				int res_y = y + (yi * (m_zoom + 1));
+
+				// TODO: cpm22mf:flop2 display random character test will go out of bounds here
+				if (!m_screen->visible_area().contains(res_x, res_y))
+					continue;
+
+				uint8_t pen;
+				if (yi >= 16)
+					pen = 0;
+				else
+					pen = ((tile_data >> xi) & 1) ? color : 0;
+
+				for (int zx = 0; zx <= m_zoom; ++zx)
+				{
+					for (int zy = 0; zy <= m_zoom; ++zy)
+					{
+						if (pen)
+							bitmap.pix(res_y + zy, res_x + zx) = palette[pen];
+					}
+				}
+			}
+		}
+	}
+}
+
+
+//**************************************************************************
+//  MONOCHROME BASE
+//**************************************************************************
+
+qx_gdc_mono_card_device::qx_gdc_mono_card_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
+	: qx_gdc_card_device(mconfig, type, tag, owner, clock, VRAM_SIZE)
+{
+}
+
+void qx_gdc_mono_card_device::palette_init(palette_device &palette) const
+{
+	for (int i = 0; i < 8; i++)
+		palette.set_pen_color(i, rgb_t::black());
+	palette.set_pen_color(1, rgb_t(0x00, 0x9f, 0x00));
+	palette.set_pen_color(2, rgb_t(0x00, 0xff, 0x00));
+}
+
+void qx_gdc_mono_card_device::upd7220_map(address_map &map)
+{
+	map(0x0000, 0xffff).ram().share("vram");
+}
+
+UPD7220_DISPLAY_PIXELS_MEMBER(qx_gdc_mono_card_device::hgdc_display_pixels)
+{
+	rgb_t const *const palette = m_palette->palette()->entry_list_raw();
+	address &= 0xffff;
+	int gfx = m_vram[address];
+
+	for (int xi = 0; xi < 16; xi++)
+	{
+		uint8_t pen = ((gfx >> xi) & 1) ? 1 : 0;
+		for (int z = 0; z <= m_zoom; ++z)
+		{
+			int xval = ((x + xi) * (m_zoom + 1)) + z;
+			if (xval >= bitmap.cliprect().width() * 2)
+				continue;
+			bitmap.pix(y, xval) = palette[pen];
+		}
+	}
+}
+
+
+//**************************************************************************
+//  COLOR BASE
+//**************************************************************************
+
+qx_gdc_color_card_device::qx_gdc_color_card_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
+	: qx_gdc_card_device(mconfig, type, tag, owner, clock, VRAM_SIZE)
+	, m_vram_bank(*this, "vrambank")
+	, m_vram_bank_val(0)
+{
+}
+
+void qx_gdc_color_card_device::device_start()
+{
+	qx_gdc_card_device::device_start();
+
+	m_vram_bank->configure_entries(0, 3, &m_vram[0], 0x20000);
+
+	save_item(NAME(m_vram_bank_val));
+}
+
+void qx_gdc_color_card_device::install_io(address_space &space)
+{
+	qx_gdc_card_device::install_io(space);
+	space.install_device(0x2d, 0x2d, *this, &qx_gdc_color_card_device::bank_map);
+}
+
+void qx_gdc_color_card_device::device_reset()
+{
+	qx_gdc_card_device::device_reset();
+	vram_bank_w(1);
+}
+
+void qx_gdc_color_card_device::palette_init(palette_device &palette) const
+{
+	for (int i = 0; i < 8; i++)
+		palette.set_pen_color(i, pal1bit((i >> 2) & 1), pal1bit((i >> 1) & 1), pal1bit((i >> 0) & 1));
+}
+
+void qx_gdc_color_card_device::upd7220_map(address_map &map)
+{
+	map(0x0000, 0xffff).bankrw("vrambank").mirror(0x30000);
+}
+
+void qx_gdc_color_card_device::vram_bank_w(uint8_t data)
+{
+	m_vram_bank_val = data;
+
+	int bank = -1;
+	if (data & 1)      bank = 0; // B
+	else if (data & 2) bank = 1; // G
+	else if (data & 4) bank = 2; // R
+
+	if (bank >= 0)
+		m_vram_bank->set_entry(bank);
+}
+
+void qx_gdc_color_card_device::bank_map(address_map &map)
+{
+	map(0x00, 0x00).mirror(0xff00).rw(FUNC(qx_gdc_color_card_device::vram_bank_r), FUNC(qx_gdc_color_card_device::vram_bank_w));
+}
+
+UPD7220_DISPLAY_PIXELS_MEMBER(qx_gdc_color_card_device::hgdc_display_pixels)
+{
+	rgb_t const *const palette = m_palette->palette()->entry_list_raw();
+	int gfx[3];
+	address &= 0xffff;
+	gfx[0] = m_vram[address + 0x00000];
+	gfx[1] = m_vram[address + 0x10000];
+	gfx[2] = m_vram[address + 0x20000];
+
+	for (int xi = 0; xi < 16; xi++)
+	{
+		uint8_t pen;
+		pen  = ((gfx[0] >> xi) & 1) ? 1 : 0;
+		pen |= ((gfx[1] >> xi) & 1) ? 2 : 0;
+		pen |= ((gfx[2] >> xi) & 1) ? 4 : 0;
+		for (int z = 0; z <= m_zoom; ++z)
+		{
+			int xval = ((x + xi) * (m_zoom + 1)) + z;
+			if (xval >= bitmap.cliprect().width() * 2)
+				continue;
+			bitmap.pix(y, xval) = palette[pen];
+		}
+	}
+}
+
+
+//**************************************************************************
+//  CONCRETE CARDS
+//**************************************************************************
+
+q10gms_device::q10gms_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: qx_gdc_mono_card_device(mconfig, QX10_VIDEO_GMS, tag, owner, clock)
+{
+}
+
+void q10gms_device::install_io(address_space &space)
+{
+	qx_gdc_mono_card_device::install_io(space);
+	space.install_device(0x3b, 0x3b, *this, &q10gms_device::lightpen_map);
+}
+
+void q10gms_device::lightpen_map(address_map &map)
+{
+	map(0x00, 0x00).mirror(0xff00).r(FUNC(q10gms_device::lightpen_r));
+}
+
+q10cms_device::q10cms_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: qx_gdc_color_card_device(mconfig, QX10_VIDEO_CMS, tag, owner, clock)
+{
+}
+
+void q10cms_device::install_io(address_space &space)
+{
+	qx_gdc_color_card_device::install_io(space);
+	space.install_device(0x3b, 0x3b, *this, &q10cms_device::lightpen_map);
+}
+
+void q10cms_device::lightpen_map(address_map &map)
+{
+	map(0x00, 0x00).mirror(0xff00).r(FUNC(q10cms_device::lightpen_r));
+}
+
+
+void video_cards(device_slot_interface &device)
+{
+	device.option_add("q10gms", QX10_VIDEO_GMS);
+	device.option_add("q10cms", QX10_VIDEO_CMS);
+}
+
+}

--- a/src/devices/bus/epson_qx/video/qx_gdc_cards.h
+++ b/src/devices/bus/epson_qx/video/qx_gdc_cards.h
@@ -1,0 +1,152 @@
+// license:BSD-3-Clause
+// copyright-holders:Mariusz Wojcieszek, Angelo Salese, Brian Johnson
+/***************************************************************************
+
+    QX-series uPD7220 (GDC) video cards
+
+***************************************************************************/
+
+#ifndef MAME_BUS_EPSON_QX_VIDEO_QX_GDC_CARDS_H
+#define MAME_BUS_EPSON_QX_VIDEO_QX_GDC_CARDS_H
+
+#pragma once
+
+#include "video.h"
+
+#include "video/upd7220.h"
+#include "emupal.h"
+
+namespace bus::epson_qx::video {
+
+//**************************************************************************
+//  ABSTRACT BASE
+//**************************************************************************
+
+class qx_gdc_card_device : public device_t, public device_qx_video_interface
+{
+protected:
+	qx_gdc_card_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, size_t vram_size);
+
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
+	virtual const tiny_rom_entry *device_rom_region() const override ATTR_COLD;
+
+	// device_qx_video_interface
+	virtual void install_io(address_space &space) override ATTR_COLD;
+	virtual uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect) override;
+	virtual uint8_t dack_r() override { return m_hgdc->dack_r(); }
+	virtual void dack_w(uint8_t data) override { m_hgdc->dack_w(data); }
+
+	// hooks for derived cards
+	virtual void palette_init(palette_device &palette) const = 0;
+	virtual void upd7220_map(address_map &map) ATTR_COLD = 0;
+	virtual UPD7220_DISPLAY_PIXELS_MEMBER(hgdc_display_pixels) = 0;
+	virtual uint8_t id_r() = 0;
+	virtual uint8_t text_color(uint8_t attr) const = 0;
+
+	UPD7220_DRAW_TEXT_LINE_MEMBER(hgdc_draw_text);
+
+	void id_map(address_map &map) ATTR_COLD;
+	void gdc_map(address_map &map) ATTR_COLD;
+	void zoom_map(address_map &map) ATTR_COLD;
+	void zoom_w(uint8_t data) { m_zoom = data & 0x0f; }
+	uint8_t lightpen_r() { return 0xff; }  // TODO: light pen request
+
+	required_device<upd7220_device> m_hgdc;
+	required_device<screen_device> m_screen;
+	required_device<palette_device> m_palette;
+	required_region_ptr<uint8_t> m_chargen;
+	memory_share_creator<uint16_t> m_vram;
+
+	uint8_t m_zoom;
+};
+
+
+//**************************************************************************
+//  MONOCHROME BASE
+//**************************************************************************
+
+class qx_gdc_mono_card_device : public qx_gdc_card_device
+{
+protected:
+	static constexpr size_t VRAM_SIZE = 0x20000;
+
+	qx_gdc_mono_card_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void palette_init(palette_device &palette) const override;
+	virtual void upd7220_map(address_map &map) override ATTR_COLD;
+	virtual UPD7220_DISPLAY_PIXELS_MEMBER(hgdc_display_pixels) override;
+	virtual uint8_t id_r() override { return 0x00; }
+	virtual uint8_t text_color(uint8_t attr) const override { return (attr & 4) ? 2 : 1; }
+};
+
+
+//**************************************************************************
+//  COLOR BASE
+//**************************************************************************
+
+class qx_gdc_color_card_device : public qx_gdc_card_device
+{
+protected:
+	static constexpr size_t VRAM_SIZE = 0x60000;
+
+	qx_gdc_color_card_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+	virtual void install_io(address_space &space) override ATTR_COLD;
+
+	virtual void palette_init(palette_device &palette) const override;
+	virtual void upd7220_map(address_map &map) override ATTR_COLD;
+	virtual UPD7220_DISPLAY_PIXELS_MEMBER(hgdc_display_pixels) override;
+	virtual uint8_t id_r() override { return 0x01; }
+	virtual uint8_t text_color(uint8_t attr) const override { return 1; }
+
+private:
+	void bank_map(address_map &map) ATTR_COLD;
+	uint8_t vram_bank_r() { return m_vram_bank_val; }
+	void vram_bank_w(uint8_t data);
+
+	memory_bank_creator m_vram_bank;
+	uint8_t m_vram_bank_val;
+};
+
+
+//**************************************************************************
+//  CONCRETE CARDS
+//**************************************************************************
+
+class q10gms_device : public qx_gdc_mono_card_device
+{
+public:
+	q10gms_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	virtual void install_io(address_space &space) override ATTR_COLD;
+
+private:
+	void lightpen_map(address_map &map) ATTR_COLD;
+};
+
+class q10cms_device : public qx_gdc_color_card_device
+{
+public:
+	q10cms_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	virtual void install_io(address_space &space) override ATTR_COLD;
+
+private:
+	void lightpen_map(address_map &map) ATTR_COLD;
+};
+
+void video_cards(device_slot_interface &device);
+
+} // namespace bus::epson_qx::video
+
+
+DECLARE_DEVICE_TYPE_NS(QX10_VIDEO_GMS, bus::epson_qx::video, q10gms_device)
+DECLARE_DEVICE_TYPE_NS(QX10_VIDEO_CMS, bus::epson_qx::video, q10cms_device)
+
+#endif // MAME_BUS_EPSON_QX_VIDEO_QX_GDC_CARDS_H

--- a/src/devices/bus/epson_qx/video/video.cpp
+++ b/src/devices/bus/epson_qx/video/video.cpp
@@ -1,0 +1,86 @@
+// license:BSD-3-Clause
+// copyright-holders:Brian Johnson
+/***************************************************************************
+
+    QX-10 Video Slot
+
+***************************************************************************/
+
+#include "emu.h"
+#include "video.h"
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(EPSON_QX_VIDEO_SLOT, bus::epson_qx::video::video_slot_device, "epson_qx_video_slot", "Epson QX-10 Video Slot")
+
+
+namespace bus::epson_qx::video {
+
+//**************************************************************************
+//  SLOT DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  video_slot_device - constructor
+//-------------------------------------------------
+
+video_slot_device::video_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, EPSON_QX_VIDEO_SLOT, tag, owner, clock)
+	, device_single_card_slot_interface<device_qx_video_interface>(mconfig, *this)
+	, m_iospace(*this, finder_base::DUMMY_TAG, -1)
+	, m_drq_cb(*this)
+	, m_card(nullptr)
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void video_slot_device::device_start()
+{
+	m_card = get_card_device();
+	if (m_card)
+		m_card->install_io(*m_iospace);
+}
+
+uint8_t video_slot_device::dack_r()
+{
+	if (m_card)
+		return m_card->dack_r();
+	return 0xff;
+}
+
+void video_slot_device::dack_w(uint8_t data)
+{
+	if (m_card)
+		m_card->dack_w(data);
+}
+
+uint32_t video_slot_device::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	if (m_card)
+		return m_card->screen_update(screen, bitmap, cliprect);
+	bitmap.fill(rgb_t::black(), cliprect);
+	return 0;
+}
+
+
+//**************************************************************************
+//  VIDEO CARD INTERFACE
+//**************************************************************************
+
+//-------------------------------------------------
+//  device_qx_video_interface - constructor
+//-------------------------------------------------
+
+device_qx_video_interface::device_qx_video_interface(const machine_config &mconfig, device_t &device)
+	: device_interface(device, "epson_qx_video")
+{
+	m_slot = dynamic_cast<video_slot_device *>(device.owner());
+}
+
+}

--- a/src/devices/bus/epson_qx/video/video.h
+++ b/src/devices/bus/epson_qx/video/video.h
@@ -1,0 +1,89 @@
+// license:BSD-3-Clause
+// copyright-holders:Brian Johnson
+/***************************************************************************
+
+    QX-10 Video Slot
+
+***************************************************************************/
+
+#ifndef MAME_BUS_EPSON_QX_VIDEO_VIDEO_H
+#define MAME_BUS_EPSON_QX_VIDEO_VIDEO_H
+
+#pragma once
+
+#include "screen.h"
+
+namespace bus::epson_qx::video {
+
+//**************************************************************************
+//  FORWARD DECLARATIONS
+//**************************************************************************
+
+class device_qx_video_interface;
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+class video_slot_device : public device_t, public device_single_card_slot_interface<device_qx_video_interface>
+{
+public:
+	// construction/destruction
+	template <typename T>
+	video_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, T &&opts, const char *dflt)
+		: video_slot_device(mconfig, tag, owner, 0U)
+	{
+		option_reset();
+		opts(*this);
+		set_default_option(dflt);
+		set_fixed(false);
+	}
+	video_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// configuration
+	template <typename T> void set_iospace(T &&tag, int spacenum) { m_iospace.set_tag(std::forward<T>(tag), spacenum); }
+
+	// callbacks
+	auto drq_callback() { return m_drq_cb.bind(); }
+
+	// called from card
+	void drq_w(int state) { m_drq_cb(state); }
+
+	// called from host
+	uint8_t dack_r();
+	void dack_w(uint8_t data);
+	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+
+protected:
+	// device_t implementation
+	virtual void device_start() override ATTR_COLD;
+
+private:
+	required_address_space m_iospace;
+	devcb_write_line m_drq_cb;
+
+	device_qx_video_interface *m_card;
+};
+
+
+class device_qx_video_interface : public device_interface
+{
+public:
+	virtual void install_io(address_space &space) ATTR_COLD {}
+
+	virtual uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect) = 0;
+	virtual uint8_t dack_r() { return 0xff; }
+	virtual void dack_w(uint8_t data) {}
+
+protected:
+	device_qx_video_interface(const machine_config &mconfig, device_t &device);
+
+	video_slot_device *m_slot;
+};
+
+} // namespace bus::epson_qx::video
+
+
+DECLARE_DEVICE_TYPE_NS(EPSON_QX_VIDEO_SLOT, bus::epson_qx::video, video_slot_device)
+
+#endif // MAME_BUS_EPSON_QX_VIDEO_VIDEO_H

--- a/src/mame/epson/qx10.cpp
+++ b/src/mame/epson/qx10.cpp
@@ -39,6 +39,8 @@
 #include "bus/centronics/ctronics.h"
 #include "bus/epson_qx/keyboard/keyboard.h"
 #include "bus/epson_qx/option.h"
+#include "bus/epson_qx/video/qx_gdc_cards.h"
+#include "bus/epson_qx/video/video.h"
 #include "bus/rs232/rs232.h"
 #include "cpu/z80/z80.h"
 #include "imagedev/floppy.h"
@@ -54,9 +56,7 @@
 #include "machine/upd765.h"
 #include "machine/z80sio.h"
 #include "sound/spkrdev.h"
-#include "video/upd7220.h"
 
-#include "emupal.h"
 #include "speaker.h"
 #include "screen.h"
 #include "softlist_dev.h"
@@ -87,11 +87,11 @@ public:
 		m_dma_2(*this, "8237dma_2"),
 		m_fdc(*this, "upd765"),
 		m_floppy(*this, "upd765:%u", 0U),
-		m_hgdc(*this, "upd7220"),
 		m_rtc(*this, "rtc"),
 		m_kbd(*this, "kbd"),
 		m_centronics(*this, "centronics"),
 		m_bus(*this, "bus"),
+		m_video_slot(*this, "video"),
 		m_speaker(*this, "speaker"),
 		m_maincpu(*this, "maincpu"),
 		m_screen(*this, "screen"),
@@ -101,19 +101,13 @@ public:
 		m_ram(*this, RAM_TAG),
 		m_rambank(*this, "rambank"),
 		m_cmosram(*this, "cmosram", 0x800, ENDIANNESS_LITTLE),
-		m_nvram(*this, "cmosram"),
-		m_video_ram(*this, "vram", 0x60000, ENDIANNESS_LITTLE),
-		m_vram_bank(*this, "vrambank"),
-		m_char_rom(*this, "chargen"),
-		m_palette(*this, "palette")
+		m_nvram(*this, "cmosram")
 	{
 	}
 
 	void qx10(machine_config &config);
 
 private:
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
@@ -128,13 +122,10 @@ private:
 	void update_fdd_motor(uint8_t state);
 	void fdd_motor_w(uint8_t data);
 	uint8_t qx10_30_r();
-	void zoom_w(uint8_t data);
 	void tc_w(int state);
 	void sqw_out(uint8_t state);
 	IRQ_CALLBACK_MEMBER( inta_call );
 	uint8_t get_slave_ack(offs_t offset);
-	uint8_t vram_bank_r();
-	void vram_bank_w(uint8_t data);
 	uint8_t memory_read_byte(offs_t offset);
 	void memory_write_byte(offs_t offset, uint8_t data);
 
@@ -154,15 +145,10 @@ private:
 
 	DECLARE_QUICKLOAD_LOAD_MEMBER(quickload_cb);
 
-	void qx10_palette(palette_device &palette) const;
 	void dma_hrq_changed(int state);
-
-	UPD7220_DISPLAY_PIXELS_MEMBER( hgdc_display_pixels );
-	UPD7220_DRAW_TEXT_LINE_MEMBER( hgdc_draw_text );
 
 	void qx10_io(address_map &map) ATTR_COLD;
 	void qx10_mem(address_map &map) ATTR_COLD;
-	void upd7220_map(address_map &map) ATTR_COLD;
 
 	required_device<pit8253_device> m_pit_1;
 	required_device<pit8253_device> m_pit_2;
@@ -174,11 +160,11 @@ private:
 	required_device<am9517a_device> m_dma_2;
 	required_device<upd765a_device> m_fdc;
 	required_device_array<floppy_connector, 2> m_floppy;
-	required_device<upd7220_device> m_hgdc;
 	required_device<mc146818_device> m_rtc;
 	required_device<bus::epson_qx::keyboard::keyboard_port_device> m_kbd;
 	required_device<centronics_device> m_centronics;
 	required_device<bus::epson_qx::option_bus_device> m_bus;
+	required_device<bus::epson_qx::video::video_slot_device> m_video_slot;
 	required_device<speaker_sound_device>   m_speaker;
 	required_device<cpu_device> m_maincpu;
 	required_device<screen_device> m_screen;
@@ -189,10 +175,6 @@ private:
 	memory_bank_creator m_rambank;
 	memory_share_creator<u8> m_cmosram;
 	required_device<nvram_device> m_nvram;
-	memory_share_creator<uint16_t> m_video_ram;
-	memory_bank_creator m_vram_bank;
-	required_region_ptr<uint8_t> m_char_rom;
-	required_device<palette_device> m_palette;
 
 	/* FDD */
 	int     m_fdcint = 0;
@@ -217,109 +199,7 @@ private:
 	int     m_membank = 0;
 	int     m_memprom = 0;
 	int     m_memcmos = 0;
-
-	uint8_t m_vram_bank_val = 0;
-	uint8_t m_color_mode = 0;
-	uint8_t m_zoom = 0;
 };
-
-UPD7220_DISPLAY_PIXELS_MEMBER( qx10_state::hgdc_display_pixels )
-{
-	rgb_t const *const palette = m_palette->palette()->entry_list_raw();
-	int gfx[3];
-	address &= 0xffff;
-	if(m_color_mode)
-	{
-		gfx[0] = m_video_ram[address + 0x00000];
-		gfx[1] = m_video_ram[address + 0x10000];
-		gfx[2] = m_video_ram[address + 0x20000];
-	}
-	else
-	{
-		gfx[0] = m_video_ram[address];
-		gfx[1] = 0;
-		gfx[2] = 0;
-	}
-
-	for(int xi=0;xi<16;xi++)
-	{
-		uint8_t pen;
-		pen = ((gfx[0] >> xi) & 1) ? 1 : 0;
-		pen|= ((gfx[1] >> xi) & 1) ? 2 : 0;
-		pen|= ((gfx[2] >> xi) & 1) ? 4 : 0;
-		for (int z = 0; z <= m_zoom; ++z)
-		{
-			int xval = ((x+xi)*(m_zoom+1))+z;
-			if (xval >= bitmap.cliprect().width() * 2)
-				continue;
-			bitmap.pix(y, xval) = palette[pen];
-		}
-	}
-}
-
-UPD7220_DRAW_TEXT_LINE_MEMBER( qx10_state::hgdc_draw_text )
-{
-	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	addr &= 0xffff;
-
-	for (int x = 0; x < pitch; x++)
-	{
-		int tile = m_video_ram[((addr+x)*2) >> 1] & 0xff;
-		int attr = m_video_ram[((addr+x)*2) >> 1] >> 8;
-
-		// TODO: color mode support
-		uint8_t color = (m_color_mode) ? 1 : (attr & 4) ? 2 : 1;
-
-		for (int yi = 0; yi < lr; yi++)
-		{
-			uint8_t tile_data = (m_char_rom[tile*16+yi]);
-
-			if(attr & 8)
-				tile_data^=0xff;
-
-			if(cursor_on && cursor_addr == addr+x)
-				tile_data^=0xff;
-
-			 //TODO: check for blinking interval
-			if(attr & 0x80 && m_screen->frame_number() & 0x10)
-				tile_data=0;
-
-			for (int xi = 0; xi < 8; xi++)
-			{
-				int res_x = ((x * 8) + xi) * (m_zoom + 1);
-				int res_y = y + (yi * (m_zoom + 1));
-
-				// TODO: cpm22mf:flop2 display random character test will go out of bounds here
-				if(!m_screen->visible_area().contains(res_x, res_y))
-					continue;
-
-				uint8_t pen;
-				if(yi >= 16)
-					pen = 0;
-				else
-					pen = ((tile_data >> xi) & 1) ? color : 0;
-
-				for (int zx = 0; zx <= m_zoom; ++zx)
-				{
-					for (int zy = 0; zy <= m_zoom; ++zy)
-					{
-						if(pen)
-							bitmap.pix(res_y+zy, res_x+zx) = palette[pen];
-					}
-				}
-			}
-		}
-	}
-}
-
-uint32_t qx10_state::screen_update( screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect )
-{
-	bitmap.fill(m_palette->black_pen(), cliprect);
-
-	m_hgdc->screen_update(screen, bitmap, cliprect);
-
-	return 0;
-}
 
 /*
     Sound
@@ -408,11 +288,6 @@ void qx10_state::cmos_sel_w(uint8_t data)
 {
 	m_memcmos = data & 1;
 	update_memory_mapping();
-}
-
-void qx10_state::zoom_w(uint8_t data)
-{
-	m_zoom = data & 0x0f;
 }
 
 /***********************************************************
@@ -691,30 +566,6 @@ uint8_t qx10_state::get_slave_ack(offs_t offset)
 
 */
 
-uint8_t qx10_state::vram_bank_r()
-{
-	return m_vram_bank_val;
-}
-
-void qx10_state::vram_bank_w(uint8_t data)
-{
-	m_vram_bank_val = data;
-
-	if(m_color_mode)
-	{
-		int bank = -1;
-
-		if (data & 1)      { bank = 0; } // B
-		else if (data & 2) { bank = 1; } // G
-		else if (data & 4) { bank = 2; } // R
-
-		if (bank >= 0)
-		{
-			m_vram_bank->set_entry(bank);
-		}
-	}
-}
-
 void qx10_state::qx10_mem(address_map &map)
 {
 	map.unmap_value_high();
@@ -754,13 +605,8 @@ void qx10_state::qx10_io(address_map &map)
 	map(0x18, 0x1b).mirror(0xff00).portr("DSW").w(FUNC(qx10_state::qx10_18_w));
 	map(0x1c, 0x1f).mirror(0xff00).w(FUNC(qx10_state::prom_sel_w));
 	map(0x20, 0x23).mirror(0xff00).w(FUNC(qx10_state::cmos_sel_w));
-	map(0x2c, 0x2c).mirror(0xff00).portr("CONFIG");
-	map(0x2d, 0x2d).mirror(0xff00).rw(FUNC(qx10_state::vram_bank_r), FUNC(qx10_state::vram_bank_w));
 	map(0x30, 0x33).mirror(0xff00).rw(FUNC(qx10_state::qx10_30_r), FUNC(qx10_state::fdd_motor_w));
 	map(0x34, 0x35).mirror(0xff00).m(m_fdc, FUNC(upd765a_device::map));
-	map(0x38, 0x39).mirror(0xff00).rw(m_hgdc, FUNC(upd7220_device::read), FUNC(upd7220_device::write));
-	map(0x3a, 0x3a).mirror(0xff00).w(FUNC(qx10_state::zoom_w));
-//  map(0x3b, 0x3b) GDC light pen req
 	map(0x3c, 0x3c).mirror(0xff00).rw(m_rtc, FUNC(mc146818_device::data_r), FUNC(mc146818_device::data_w));
 	map(0x3d, 0x3d).mirror(0xff00).w(m_rtc, FUNC(mc146818_device::address_w));
 	map(0x40, 0x4f).mirror(0xff00).rw(m_dma_1, FUNC(am9517a_device::read), FUNC(am9517a_device::write));
@@ -808,19 +654,12 @@ static INPUT_PORTS_START( qx10 )
 	PORT_DIPNAME( 0x80, 0x80, DEF_STR( Unknown ) )
 	PORT_DIPSETTING(    0x80, DEF_STR( Off ) )
 	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
-
-	PORT_START("CONFIG")
-	PORT_CONFNAME( 0x03, 0x02, "Video Board" )
-	PORT_CONFSETTING( 0x02, "Monochrome" )
-	PORT_CONFSETTING( 0x01, "Color" )
-	PORT_BIT(0xfc, IP_ACTIVE_LOW, IPT_UNUSED)
 INPUT_PORTS_END
 
 
 void qx10_state::machine_start()
 {
 	m_rambank->configure_entries(0, 4, m_ram->pointer(), 0x10000);
-	m_vram_bank->configure_entries(0, 3, &m_video_ram[0], 0x20000);
 	m_bus->set_memview(m_external_view[0]);
 
 	// FDD
@@ -845,11 +684,6 @@ void qx10_state::machine_start()
 	save_item(NAME(m_membank));
 	save_item(NAME(m_memprom));
 	save_item(NAME(m_memcmos));
-
-	// Video
-	save_item(NAME(m_vram_bank_val));
-	save_item(NAME(m_color_mode));
-	save_item(NAME(m_zoom));
 }
 
 void qx10_state::machine_reset()
@@ -860,64 +694,11 @@ void qx10_state::machine_reset()
 	m_spkr_enable = 0;
 	m_pit1_out0 = 1;
 
-	m_zoom = 0;
-
 	m_external_bank = 0;
 	m_memprom = 0;
 	m_memcmos = 0;
 	m_membank = 0;
 	update_memory_mapping();
-
-	{
-		int i;
-
-		/* TODO: is there a bit that sets this up? */
-		m_color_mode = ioport("CONFIG")->read() & 1;
-		vram_bank_w(1);
-
-		if(m_color_mode) //color
-		{
-			for ( i = 0; i < 8; i++ )
-				m_palette->set_pen_color(i, pal1bit((i >> 2) & 1), pal1bit((i >> 1) & 1), pal1bit((i >> 0) & 1));
-		}
-		else //monochrome
-		{
-			for ( i = 0; i < 8; i++ )
-				m_palette->set_pen_color(i, pal1bit(0), pal1bit(0), pal1bit(0));
-
-			m_palette->set_pen_color(1, 0x00, 0x9f, 0x00);
-			m_palette->set_pen_color(2, 0x00, 0xff, 0x00);
-		}
-	}
-}
-
-/* F4 Character Displayer */
-static const gfx_layout qx10_charlayout =
-{
-	8, 16,                  /* 8 x 16 characters */
-	RGN_FRAC(1,1),          /* 128 characters */
-	1,                  /* 1 bits per pixel */
-	{ 0 },                  /* no bitplanes */
-	/* x offsets */
-	{ 7, 6, 5, 4, 3, 2, 1, 0 },
-	/* y offsets */
-	{  0*8,  1*8,  2*8,  3*8,  4*8,  5*8,  6*8,  7*8, 8*8,  9*8, 10*8, 11*8, 12*8, 13*8, 14*8, 15*8 },
-	8*16                    /* every char takes 16 bytes */
-};
-
-static GFXDECODE_START( gfx_qx10 )
-	GFXDECODE_ENTRY( "chargen", 0x0000, qx10_charlayout, 1, 1 )
-GFXDECODE_END
-
-
-void qx10_state::qx10_palette(palette_device &palette) const
-{
-	// ...
-}
-
-void qx10_state::upd7220_map(address_map &map)
-{
-	map(0x0000, 0xffff).bankrw("vrambank").mirror(0x30000);
 }
 
 void qx10_state::qx10(machine_config &config)
@@ -930,10 +711,12 @@ void qx10_state::qx10(machine_config &config)
 
 	/* video hardware */
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
-	m_screen->set_screen_update(FUNC(qx10_state::screen_update));
 	m_screen->set_raw(16.67_MHz_XTAL, 872, 152, 792, 421, 4, 404);
-	GFXDECODE(config, "gfxdecode", m_palette, gfx_qx10);
-	PALETTE(config, m_palette, FUNC(qx10_state::qx10_palette), 8);
+	m_screen->set_screen_update(m_video_slot, FUNC(bus::epson_qx::video::video_slot_device::screen_update));
+
+	EPSON_QX_VIDEO_SLOT(config, m_video_slot, bus::epson_qx::video::video_cards, "q10gms");
+	m_video_slot->set_iospace(m_maincpu, AS_IO);
+	m_video_slot->drq_callback().set(m_dma_1, FUNC(am9517a_device::dreq1_w)).invert();
 
 	/* Devices */
 
@@ -992,9 +775,9 @@ void qx10_state::qx10(machine_config &config)
 	m_dma_1->in_memr_callback().set(FUNC(qx10_state::memory_read_byte));
 	m_dma_1->out_memw_callback().set(FUNC(qx10_state::memory_write_byte));
 	m_dma_1->in_ior_callback<0>().set(m_fdc, FUNC(upd765a_device::dma_r));
-	m_dma_1->in_ior_callback<1>().set(m_hgdc, FUNC(upd7220_device::dack_r));
+	m_dma_1->in_ior_callback<1>().set(m_video_slot, FUNC(bus::epson_qx::video::video_slot_device::dack_r));
 	m_dma_1->out_iow_callback<0>().set(m_fdc, FUNC(upd765a_device::dma_w));
-	m_dma_1->out_iow_callback<1>().set(m_hgdc, FUNC(upd7220_device::dack_w));
+	m_dma_1->out_iow_callback<1>().set(m_video_slot, FUNC(bus::epson_qx::video::video_slot_device::dack_w));
 
 	AM9517A(config, m_dma_2, MAIN_CLK/4);
 	m_dma_2->dreq_active_low();
@@ -1003,13 +786,6 @@ void qx10_state::qx10(machine_config &config)
 	m_ppi->out_pa_callback().set("prndata", FUNC(output_latch_device::write));
 	m_ppi->in_pb_callback().set(FUNC(qx10_state::portb_r));
 	m_ppi->out_pc_callback().set(FUNC(qx10_state::portc_w));
-
-	UPD7220(config, m_hgdc, 16.67_MHz_XTAL/4/2);
-	m_hgdc->set_addrmap(0, &qx10_state::upd7220_map);
-	m_hgdc->set_display_pixels(FUNC(qx10_state::hgdc_display_pixels));
-	m_hgdc->set_draw_text(FUNC(qx10_state::hgdc_draw_text));
-	m_hgdc->drq_wr_callback().set(m_dma_1, FUNC(am9517a_device::dreq1_w)).invert();
-	m_hgdc->set_screen("screen");
 
 	MC146818(config, m_rtc, 32.768_kHz_XTAL);
 	m_rtc->irq().set(m_pic_s, FUNC(pic8259_device::ir2_w));
@@ -1097,11 +873,6 @@ ROM_START( qx10 )
 	ROM_RELOAD(0x800, 0x800)
 	ROM_RELOAD(0x1000, 0x800)
 	ROM_RELOAD(0x1800, 0x800)
-
-	ROM_REGION( 0x1000, "chargen", 0 )
-//  ROM_LOAD( "qge.2e",   0x0000, 0x0800, BAD_DUMP CRC(ed93cb81) SHA1(579e68bde3f4184ded7d89b72c6936824f48d10b))  //this one contains special characters only
-//  ROM_LOAD( "qge.2e",   0x0000, 0x1000, BAD_DUMP CRC(eb31a2d5) SHA1(6dc581bf2854a07ae93b23b6dfc9c7abd3c0569e))
-	ROM_LOAD( "qga.2e",   0x0000, 0x1000, CRC(4120b128) SHA1(9b96f6d78cfd402f8aec7c063ffb70a21b78eff0))
 ROM_END
 
 } // anonymous namespace

--- a/src/mame/epson/qx10.cpp
+++ b/src/mame/epson/qx10.cpp
@@ -39,6 +39,8 @@
 #include "bus/centronics/ctronics.h"
 #include "bus/epson_qx/keyboard/keyboard.h"
 #include "bus/epson_qx/option.h"
+#include "bus/epson_qx/video/qx_gdc_cards.h"
+#include "bus/epson_qx/video/video.h"
 #include "bus/rs232/rs232.h"
 #include "cpu/z80/z80.h"
 #include "imagedev/floppy.h"
@@ -54,9 +56,7 @@
 #include "machine/upd765.h"
 #include "machine/z80sio.h"
 #include "sound/spkrdev.h"
-#include "video/upd7220.h"
 
-#include "emupal.h"
 #include "speaker.h"
 #include "screen.h"
 #include "softlist_dev.h"
@@ -87,11 +87,11 @@ public:
 		m_dma_2(*this, "8237dma_2"),
 		m_fdc(*this, "upd765"),
 		m_floppy(*this, "upd765:%u", 0U),
-		m_hgdc(*this, "upd7220"),
 		m_rtc(*this, "rtc"),
 		m_kbd(*this, "kbd"),
 		m_centronics(*this, "centronics"),
 		m_bus(*this, "bus"),
+		m_video_slot(*this, "video"),
 		m_speaker(*this, "speaker"),
 		m_maincpu(*this, "maincpu"),
 		m_screen(*this, "screen"),
@@ -101,19 +101,13 @@ public:
 		m_ram(*this, RAM_TAG),
 		m_rambank(*this, "rambank"),
 		m_cmosram(*this, "cmosram", 0x800, ENDIANNESS_LITTLE),
-		m_nvram(*this, "cmosram"),
-		m_video_ram(*this, "vram", 0x60000, ENDIANNESS_LITTLE),
-		m_vram_bank(*this, "vrambank"),
-		m_char_rom(*this, "chargen"),
-		m_palette(*this, "palette")
+		m_nvram(*this, "cmosram")
 	{
 	}
 
 	void qx10(machine_config &config);
 
 private:
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
@@ -128,13 +122,10 @@ private:
 	void update_fdd_motor(uint8_t state);
 	void fdd_motor_w(uint8_t data);
 	uint8_t qx10_30_r();
-	void zoom_w(uint8_t data);
 	void tc_w(int state);
 	void sqw_out(uint8_t state);
 	IRQ_CALLBACK_MEMBER( inta_call );
 	uint8_t get_slave_ack(offs_t offset);
-	uint8_t vram_bank_r();
-	void vram_bank_w(uint8_t data);
 	uint8_t memory_read_byte(offs_t offset);
 	void memory_write_byte(offs_t offset, uint8_t data);
 
@@ -154,15 +145,10 @@ private:
 
 	DECLARE_QUICKLOAD_LOAD_MEMBER(quickload_cb);
 
-	void qx10_palette(palette_device &palette) const;
 	void dma_hrq_changed(int state);
-
-	UPD7220_DISPLAY_PIXELS_MEMBER( hgdc_display_pixels );
-	UPD7220_DRAW_TEXT_LINE_MEMBER( hgdc_draw_text );
 
 	void qx10_io(address_map &map) ATTR_COLD;
 	void qx10_mem(address_map &map) ATTR_COLD;
-	void upd7220_map(address_map &map) ATTR_COLD;
 
 	required_device<pit8253_device> m_pit_1;
 	required_device<pit8253_device> m_pit_2;
@@ -174,11 +160,11 @@ private:
 	required_device<am9517a_device> m_dma_2;
 	required_device<upd765a_device> m_fdc;
 	required_device_array<floppy_connector, 2> m_floppy;
-	required_device<upd7220_device> m_hgdc;
 	required_device<mc146818_device> m_rtc;
 	required_device<bus::epson_qx::keyboard::keyboard_port_device> m_kbd;
 	required_device<centronics_device> m_centronics;
 	required_device<bus::epson_qx::option_bus_device> m_bus;
+	required_device<bus::epson_qx::video::video_slot_device> m_video_slot;
 	required_device<speaker_sound_device>   m_speaker;
 	required_device<z80_device> m_maincpu;
 	required_device<screen_device> m_screen;
@@ -189,10 +175,6 @@ private:
 	memory_bank_creator m_rambank;
 	memory_share_creator<u8> m_cmosram;
 	required_device<nvram_device> m_nvram;
-	memory_share_creator<uint16_t> m_video_ram;
-	memory_bank_creator m_vram_bank;
-	required_region_ptr<uint8_t> m_char_rom;
-	required_device<palette_device> m_palette;
 
 	/* FDD */
 	int     m_fdcint = 0;
@@ -217,109 +199,7 @@ private:
 	int     m_membank = 0;
 	int     m_memprom = 0;
 	int     m_memcmos = 0;
-
-	uint8_t m_vram_bank_val = 0;
-	uint8_t m_color_mode = 0;
-	uint8_t m_zoom = 0;
 };
-
-UPD7220_DISPLAY_PIXELS_MEMBER( qx10_state::hgdc_display_pixels )
-{
-	rgb_t const *const palette = m_palette->palette()->entry_list_raw();
-	int gfx[3];
-	address &= 0xffff;
-	if(m_color_mode)
-	{
-		gfx[0] = m_video_ram[address + 0x00000];
-		gfx[1] = m_video_ram[address + 0x10000];
-		gfx[2] = m_video_ram[address + 0x20000];
-	}
-	else
-	{
-		gfx[0] = m_video_ram[address];
-		gfx[1] = 0;
-		gfx[2] = 0;
-	}
-
-	for(int xi=0;xi<16;xi++)
-	{
-		uint8_t pen;
-		pen = ((gfx[0] >> xi) & 1) ? 1 : 0;
-		pen|= ((gfx[1] >> xi) & 1) ? 2 : 0;
-		pen|= ((gfx[2] >> xi) & 1) ? 4 : 0;
-		for (int z = 0; z <= m_zoom; ++z)
-		{
-			int xval = ((x+xi)*(m_zoom+1))+z;
-			if (xval >= bitmap.cliprect().width() * 2)
-				continue;
-			bitmap.pix(y, xval) = palette[pen];
-		}
-	}
-}
-
-UPD7220_DRAW_TEXT_LINE_MEMBER( qx10_state::hgdc_draw_text )
-{
-	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	addr &= 0xffff;
-
-	for (int x = 0; x < pitch; x++)
-	{
-		int tile = m_video_ram[((addr+x)*2) >> 1] & 0xff;
-		int attr = m_video_ram[((addr+x)*2) >> 1] >> 8;
-
-		// TODO: color mode support
-		uint8_t color = (m_color_mode) ? 1 : (attr & 4) ? 2 : 1;
-
-		for (int yi = 0; yi < lr; yi++)
-		{
-			uint8_t tile_data = (m_char_rom[tile*16+yi]);
-
-			if(attr & 8)
-				tile_data^=0xff;
-
-			if(cursor_on && cursor_addr == addr+x)
-				tile_data^=0xff;
-
-			 //TODO: check for blinking interval
-			if(attr & 0x80 && m_screen->frame_number() & 0x10)
-				tile_data=0;
-
-			for (int xi = 0; xi < 8; xi++)
-			{
-				int res_x = ((x * 8) + xi) * (m_zoom + 1);
-				int res_y = y + (yi * (m_zoom + 1));
-
-				// TODO: cpm22mf:flop2 display random character test will go out of bounds here
-				if(!m_screen->visible_area().contains(res_x, res_y))
-					continue;
-
-				uint8_t pen;
-				if(yi >= 16)
-					pen = 0;
-				else
-					pen = ((tile_data >> xi) & 1) ? color : 0;
-
-				for (int zx = 0; zx <= m_zoom; ++zx)
-				{
-					for (int zy = 0; zy <= m_zoom; ++zy)
-					{
-						if(pen)
-							bitmap.pix(res_y+zy, res_x+zx) = palette[pen];
-					}
-				}
-			}
-		}
-	}
-}
-
-uint32_t qx10_state::screen_update( screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect )
-{
-	bitmap.fill(m_palette->black_pen(), cliprect);
-
-	m_hgdc->screen_update(screen, bitmap, cliprect);
-
-	return 0;
-}
 
 /*
     Sound
@@ -408,11 +288,6 @@ void qx10_state::cmos_sel_w(uint8_t data)
 {
 	m_memcmos = data & 1;
 	update_memory_mapping();
-}
-
-void qx10_state::zoom_w(uint8_t data)
-{
-	m_zoom = data & 0x0f;
 }
 
 /***********************************************************
@@ -691,30 +566,6 @@ uint8_t qx10_state::get_slave_ack(offs_t offset)
 
 */
 
-uint8_t qx10_state::vram_bank_r()
-{
-	return m_vram_bank_val;
-}
-
-void qx10_state::vram_bank_w(uint8_t data)
-{
-	m_vram_bank_val = data;
-
-	if(m_color_mode)
-	{
-		int bank = -1;
-
-		if (data & 1)      { bank = 0; } // B
-		else if (data & 2) { bank = 1; } // G
-		else if (data & 4) { bank = 2; } // R
-
-		if (bank >= 0)
-		{
-			m_vram_bank->set_entry(bank);
-		}
-	}
-}
-
 void qx10_state::qx10_mem(address_map &map)
 {
 	map.unmap_value_high();
@@ -754,13 +605,8 @@ void qx10_state::qx10_io(address_map &map)
 	map(0x18, 0x1b).mirror(0xff00).portr("DSW").w(FUNC(qx10_state::qx10_18_w));
 	map(0x1c, 0x1f).mirror(0xff00).w(FUNC(qx10_state::prom_sel_w));
 	map(0x20, 0x23).mirror(0xff00).w(FUNC(qx10_state::cmos_sel_w));
-	map(0x2c, 0x2c).mirror(0xff00).portr("CONFIG");
-	map(0x2d, 0x2d).mirror(0xff00).rw(FUNC(qx10_state::vram_bank_r), FUNC(qx10_state::vram_bank_w));
 	map(0x30, 0x33).mirror(0xff00).rw(FUNC(qx10_state::qx10_30_r), FUNC(qx10_state::fdd_motor_w));
 	map(0x34, 0x35).mirror(0xff00).m(m_fdc, FUNC(upd765a_device::map));
-	map(0x38, 0x39).mirror(0xff00).rw(m_hgdc, FUNC(upd7220_device::read), FUNC(upd7220_device::write));
-	map(0x3a, 0x3a).mirror(0xff00).w(FUNC(qx10_state::zoom_w));
-//  map(0x3b, 0x3b) GDC light pen req
 	map(0x3c, 0x3c).mirror(0xff00).rw(m_rtc, FUNC(mc146818_device::data_r), FUNC(mc146818_device::data_w));
 	map(0x3d, 0x3d).mirror(0xff00).w(m_rtc, FUNC(mc146818_device::address_w));
 	map(0x40, 0x4f).mirror(0xff00).rw(m_dma_1, FUNC(am9517a_device::read), FUNC(am9517a_device::write));
@@ -808,19 +654,12 @@ static INPUT_PORTS_START( qx10 )
 	PORT_DIPNAME( 0x80, 0x80, DEF_STR( Unknown ) )
 	PORT_DIPSETTING(    0x80, DEF_STR( Off ) )
 	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
-
-	PORT_START("CONFIG")
-	PORT_CONFNAME( 0x03, 0x02, "Video Board" )
-	PORT_CONFSETTING( 0x02, "Monochrome" )
-	PORT_CONFSETTING( 0x01, "Color" )
-	PORT_BIT(0xfc, IP_ACTIVE_LOW, IPT_UNUSED)
 INPUT_PORTS_END
 
 
 void qx10_state::machine_start()
 {
 	m_rambank->configure_entries(0, 4, m_ram->pointer(), 0x10000);
-	m_vram_bank->configure_entries(0, 3, &m_video_ram[0], 0x20000);
 	m_bus->set_memview(m_external_view[0]);
 
 	// FDD
@@ -845,11 +684,6 @@ void qx10_state::machine_start()
 	save_item(NAME(m_membank));
 	save_item(NAME(m_memprom));
 	save_item(NAME(m_memcmos));
-
-	// Video
-	save_item(NAME(m_vram_bank_val));
-	save_item(NAME(m_color_mode));
-	save_item(NAME(m_zoom));
 }
 
 void qx10_state::machine_reset()
@@ -860,64 +694,11 @@ void qx10_state::machine_reset()
 	m_spkr_enable = 0;
 	m_pit1_out0 = 1;
 
-	m_zoom = 0;
-
 	m_external_bank = 0;
 	m_memprom = 0;
 	m_memcmos = 0;
 	m_membank = 0;
 	update_memory_mapping();
-
-	{
-		int i;
-
-		/* TODO: is there a bit that sets this up? */
-		m_color_mode = ioport("CONFIG")->read() & 1;
-		vram_bank_w(1);
-
-		if(m_color_mode) //color
-		{
-			for ( i = 0; i < 8; i++ )
-				m_palette->set_pen_color(i, pal1bit((i >> 2) & 1), pal1bit((i >> 1) & 1), pal1bit((i >> 0) & 1));
-		}
-		else //monochrome
-		{
-			for ( i = 0; i < 8; i++ )
-				m_palette->set_pen_color(i, pal1bit(0), pal1bit(0), pal1bit(0));
-
-			m_palette->set_pen_color(1, 0x00, 0x9f, 0x00);
-			m_palette->set_pen_color(2, 0x00, 0xff, 0x00);
-		}
-	}
-}
-
-/* F4 Character Displayer */
-static const gfx_layout qx10_charlayout =
-{
-	8, 16,                  /* 8 x 16 characters */
-	RGN_FRAC(1,1),          /* 128 characters */
-	1,                  /* 1 bits per pixel */
-	{ 0 },                  /* no bitplanes */
-	/* x offsets */
-	{ 7, 6, 5, 4, 3, 2, 1, 0 },
-	/* y offsets */
-	{  0*8,  1*8,  2*8,  3*8,  4*8,  5*8,  6*8,  7*8, 8*8,  9*8, 10*8, 11*8, 12*8, 13*8, 14*8, 15*8 },
-	8*16                    /* every char takes 16 bytes */
-};
-
-static GFXDECODE_START( gfx_qx10 )
-	GFXDECODE_ENTRY( "chargen", 0x0000, qx10_charlayout, 1, 1 )
-GFXDECODE_END
-
-
-void qx10_state::qx10_palette(palette_device &palette) const
-{
-	// ...
-}
-
-void qx10_state::upd7220_map(address_map &map)
-{
-	map(0x0000, 0xffff).bankrw("vrambank").mirror(0x30000);
 }
 
 void qx10_state::qx10(machine_config &config)
@@ -931,10 +712,12 @@ void qx10_state::qx10(machine_config &config)
 
 	/* video hardware */
 	SCREEN(config, m_screen);
-	m_screen->set_screen_update(FUNC(qx10_state::screen_update));
 	m_screen->set_raw(16.67_MHz_XTAL, 872, 152, 792, 421, 4, 404);
-	GFXDECODE(config, "gfxdecode", m_palette, gfx_qx10);
-	PALETTE(config, m_palette, FUNC(qx10_state::qx10_palette), 8);
+	m_screen->set_screen_update(m_video_slot, FUNC(bus::epson_qx::video::video_slot_device::screen_update));
+
+	EPSON_QX_VIDEO_SLOT(config, m_video_slot, bus::epson_qx::video::video_cards, "q10gms");
+	m_video_slot->set_iospace(m_maincpu, AS_IO);
+	m_video_slot->drq_callback().set(m_dma_1, FUNC(am9517a_device::dreq1_w)).invert();
 
 	/* Devices */
 
@@ -993,9 +776,9 @@ void qx10_state::qx10(machine_config &config)
 	m_dma_1->in_memr_callback().set(FUNC(qx10_state::memory_read_byte));
 	m_dma_1->out_memw_callback().set(FUNC(qx10_state::memory_write_byte));
 	m_dma_1->in_ior_callback<0>().set(m_fdc, FUNC(upd765a_device::dma_r));
-	m_dma_1->in_ior_callback<1>().set(m_hgdc, FUNC(upd7220_device::dack_r));
+	m_dma_1->in_ior_callback<1>().set(m_video_slot, FUNC(bus::epson_qx::video::video_slot_device::dack_r));
 	m_dma_1->out_iow_callback<0>().set(m_fdc, FUNC(upd765a_device::dma_w));
-	m_dma_1->out_iow_callback<1>().set(m_hgdc, FUNC(upd7220_device::dack_w));
+	m_dma_1->out_iow_callback<1>().set(m_video_slot, FUNC(bus::epson_qx::video::video_slot_device::dack_w));
 
 	AM9517A(config, m_dma_2, MAIN_CLK/4);
 	m_dma_2->dreq_active_low();
@@ -1004,13 +787,6 @@ void qx10_state::qx10(machine_config &config)
 	m_ppi->out_pa_callback().set("prndata", FUNC(output_latch_device::write));
 	m_ppi->in_pb_callback().set(FUNC(qx10_state::portb_r));
 	m_ppi->out_pc_callback().set(FUNC(qx10_state::portc_w));
-
-	UPD7220(config, m_hgdc, 16.67_MHz_XTAL/4/2);
-	m_hgdc->set_addrmap(0, &qx10_state::upd7220_map);
-	m_hgdc->set_display_pixels(FUNC(qx10_state::hgdc_display_pixels));
-	m_hgdc->set_draw_text(FUNC(qx10_state::hgdc_draw_text));
-	m_hgdc->drq_wr_callback().set(m_dma_1, FUNC(am9517a_device::dreq1_w)).invert();
-	m_hgdc->set_screen("screen");
 
 	MC146818(config, m_rtc, 32.768_kHz_XTAL);
 	m_rtc->irq().set(m_pic_s, FUNC(pic8259_device::ir2_w));
@@ -1098,11 +874,6 @@ ROM_START( qx10 )
 	ROM_RELOAD(0x800, 0x800)
 	ROM_RELOAD(0x1000, 0x800)
 	ROM_RELOAD(0x1800, 0x800)
-
-	ROM_REGION( 0x1000, "chargen", 0 )
-//  ROM_LOAD( "qge.2e",   0x0000, 0x0800, BAD_DUMP CRC(ed93cb81) SHA1(579e68bde3f4184ded7d89b72c6936824f48d10b))  //this one contains special characters only
-//  ROM_LOAD( "qge.2e",   0x0000, 0x1000, BAD_DUMP CRC(eb31a2d5) SHA1(6dc581bf2854a07ae93b23b6dfc9c7abd3c0569e))
-	ROM_LOAD( "qga.2e",   0x0000, 0x1000, CRC(4120b128) SHA1(9b96f6d78cfd402f8aec7c063ffb70a21b78eff0))
 ROM_END
 
 } // anonymous namespace


### PR DESCRIPTION
This updates the QX-10 system to use a slot based graphics system, to allow selecting either the color board or monochrome. This is more accurate to real hardware which used two distinct boards, rather then having some config knob that switches between modes.  