### PR TITLE
adp/stella8085.cpp: Fix 4040 board IO

### DIFF
--- a/src/mame/adp/stella8085.cpp
+++ b/src/mame/adp/stella8085.cpp
@@ -154,8 +154,8 @@ void stella8085_state::program_4040_map(address_map &map)
 void stella8085_state::io_map(address_map &map)
 {
 	map(0x00, 0x00).w(FUNC(stella8085_state::io00));
-	map(0x50, 0x51).rw("kdc", FUNC(i8279_device::read), FUNC(i8279_device::write));
-	map(0x60, 0x6f).rw("muart", FUNC(i8256_device::read), FUNC(i8256_device::write));
+	map(0x50, 0x51).rw(m_kdc, FUNC(i8279_device::read), FUNC(i8279_device::write));
+	map(0x60, 0x6f).rw(m_uart, FUNC(i8256_device::read), FUNC(i8256_device::write));
 	map(0x70, 0x73).rw(m_ppi, FUNC(i8255_device::read), FUNC(i8255_device::write));
 	// map(0x80, 0x8f) //Y8 ICC5 empty socket
 	map(0x90, 0x9f).rw(FUNC(stella8085_state::io9r),FUNC(stella8085_state::io9w)); //Y9 wired to rtc circuits but somehow memory mapped in hardware
@@ -165,8 +165,8 @@ void stella8085_state::io_4040_map(address_map &map)
 {
 	map(0x00, 0x00).w(FUNC(stella8085_state::io00));
 	map(0x70, 0x73).rw(m_ppi, FUNC(i8255_device::read), FUNC(i8255_device::write));
-	map(0x80, 0x81).rw("kdc", FUNC(i8279_device::read), FUNC(i8279_device::write));
-	map(0x90, 0x9f).rw("muart", FUNC(i8256_device::read), FUNC(i8256_device::write));
+	map(0x80, 0x81).rw(m_kdc, FUNC(i8279_device::read), FUNC(i8279_device::write));
+	map(0x90, 0x9f).rw(m_uart, FUNC(i8256_device::read), FUNC(i8256_device::write));
 }
 
 /*********************************************
@@ -579,7 +579,7 @@ void stella8085_state::dicemstr(machine_config &config)
 	RTC62421(config, "rtc", 32.768_kHz_XTAL);
 
 	SPEAKER(config, "mono").front_center();
-	BEEP(config, "beeper", 0)
+	BEEP(config, m_beep, 0)
 		.add_route(ALL_OUTPUTS, "mono", 0.50);
 }
 
@@ -612,7 +612,7 @@ void stella8085_state::doppelpot(machine_config &config)
 	MC146818(config, "rtc", 32.768_kHz_XTAL);
 
 	SPEAKER(config, "mono").front_center();
-	BEEP(config, "beeper", 0)
+	BEEP(config, m_beep, 0)
 		.add_route(ALL_OUTPUTS, "mono", 0.50);
 }
 

--- a/src/mame/adp/stella8085.cpp
+++ b/src/mame/adp/stella8085.cpp
@@ -83,10 +83,11 @@ private:
 	required_device<beep_device> m_beep;
 	emu_timer *m_sound_timer;
 
-	void program_map(address_map &map) ATTR_COLD;
 	void large_program_map(address_map &map) ATTR_COLD;
-	void small_program_map(address_map &map) ATTR_COLD;
+	void program_map(address_map &map) ATTR_COLD;
+	void program_4040_map(address_map &map) ATTR_COLD;
 	void io_map(address_map &map) ATTR_COLD;
+	void io_4040_map(address_map &map) ATTR_COLD;
 
 	// I8256 ports
 	uint8_t lw_r(); //P1.0-P1.3
@@ -124,6 +125,13 @@ void stella8085_state::machine_start()
 	save_item(NAME(m_digit));
 }
 
+void stella8085_state::large_program_map(address_map &map)
+{
+	map(0x0000, 0x7fff).rom(); // ICE6
+	map(0x8000, 0x9fff).ram(); // ICC6
+	map(0xa000, 0xffff).rom(); // ICD6
+}
+
 void stella8085_state::program_map(address_map &map)
 {
 	map(0x0000, 0x8fff).rom(); // ICE6, ICD6, ICC5
@@ -132,14 +140,7 @@ void stella8085_state::program_map(address_map &map)
 	map(0xc000, 0xc7ff).ram(); // ICC6
 }
 
-void stella8085_state::large_program_map(address_map &map)
-{
-	map(0x0000, 0x7fff).rom(); // ICE6
-	map(0x8000, 0x9fff).ram(); // ICC6
-	map(0xa000, 0xffff).rom(); // ICD6
-}
-
-void stella8085_state::small_program_map(address_map &map)
+void stella8085_state::program_4040_map(address_map &map)
 {
 	map(0x0000, 0x4fff).rom();
 	map(0x5000, 0x5fff).ram();
@@ -158,6 +159,17 @@ void stella8085_state::io_map(address_map &map)
 	map(0x73, 0x73).w(FUNC(stella8085_state::io73)); // probably extra lamps
 	// map(0x80, 0x8f) //Y8 ICC5 empty socket
 	map(0x90, 0x9f).rw(FUNC(stella8085_state::io9r),FUNC(stella8085_state::io9w)); //Y9 wired to rtc circuits but somehow memory mapped in hardware
+}
+
+void stella8085_state::io_4040_map(address_map &map)
+{
+	map(0x00, 0x00).w(FUNC(stella8085_state::io00));
+	map(0x70, 0x70).w(FUNC(stella8085_state::io70));
+	map(0x71, 0x71).w(FUNC(stella8085_state::io71));
+	map(0x72, 0x72).w(FUNC(stella8085_state::sounddev));
+	map(0x73, 0x73).w(FUNC(stella8085_state::io73));
+	map(0x80, 0x81).rw("kdc", FUNC(i8279_device::read), FUNC(i8279_device::write));
+	map(0x90, 0x9f).rw("muart", FUNC(i8256_device::read), FUNC(i8256_device::write));
 }
 
 /*********************************************
@@ -600,7 +612,8 @@ void stella8085_state::doppelpot(machine_config &config)
 void stella8085_state::excellent(machine_config &config)
 {
 	doppelpot(config);
-	m_maincpu->set_addrmap(AS_PROGRAM, &stella8085_state::small_program_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &stella8085_state::program_4040_map);
+	m_maincpu->set_addrmap(AS_IO, &stella8085_state::io_4040_map);
 }
 
 ROM_START( bahia )

--- a/src/mame/adp/stella8085.cpp
+++ b/src/mame/adp/stella8085.cpp
@@ -109,7 +109,6 @@ private:
 	void io70(uint8_t data) ATTR_COLD;
 	void io71(uint8_t data) ATTR_COLD;
 	void sounddev(uint8_t data) ATTR_COLD;
-	void io73(uint8_t data) ATTR_COLD;
 	uint8_t io9r() ATTR_COLD;
 	void io9w(uint8_t data) ATTR_COLD;
 
@@ -365,11 +364,6 @@ void stella8085_state::sounddev(uint8_t data)
 	uint8_t length = data & 0x30;
 	uint8_t octave = data & 0xc0;
 	makesound(tone, octave, 60*(length+1)); // 60 is not correct
-}
-
-void stella8085_state::io73(uint8_t data)
-{
-	//old boards
 }
 
 void stella8085_state::makesound(uint8_t tone, uint8_t octave, uint8_t length)

--- a/src/mame/adp/stella8085.cpp
+++ b/src/mame/adp/stella8085.cpp
@@ -29,6 +29,7 @@ Nova Kniffi reference: https://www.youtube.com/watch?v=YBq2Z1irXek
 #include "emu.h"
 
 #include "cpu/i8085/i8085.h"
+#include "machine/i8255.h"
 #include "machine/i8256.h"
 #include "machine/i8279.h"
 #include "machine/mc146818.h"
@@ -52,6 +53,7 @@ public:
 	stella8085_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
+		m_ppi(*this, "ppi"),
 		m_uart(*this, "muart"),
 		m_kdc(*this, "kdc"),
 		m_tz(*this, "TZ%u", 0U),
@@ -74,6 +76,7 @@ private:
 	bool m_kbd_bd = false;
 
 	required_device<cpu_device> m_maincpu;
+	required_device<i8255_device> m_ppi;
 	required_device<i8256_device> m_uart;
 	required_device<i8279_device> m_kdc;
 	required_ioport_array<8> m_tz;
@@ -153,10 +156,7 @@ void stella8085_state::io_map(address_map &map)
 	map(0x00, 0x00).w(FUNC(stella8085_state::io00));
 	map(0x50, 0x51).rw("kdc", FUNC(i8279_device::read), FUNC(i8279_device::write));
 	map(0x60, 0x6f).rw("muart", FUNC(i8256_device::read), FUNC(i8256_device::write));
-	map(0x70, 0x70).w(FUNC(stella8085_state::io70));
-	map(0x71, 0x71).w(FUNC(stella8085_state::io71));
-	map(0x72, 0x72).w(FUNC(stella8085_state::sounddev));
-	map(0x73, 0x73).w(FUNC(stella8085_state::io73)); // probably extra lamps
+	map(0x70, 0x73).rw(m_ppi, FUNC(i8255_device::read), FUNC(i8255_device::write));
 	// map(0x80, 0x8f) //Y8 ICC5 empty socket
 	map(0x90, 0x9f).rw(FUNC(stella8085_state::io9r),FUNC(stella8085_state::io9w)); //Y9 wired to rtc circuits but somehow memory mapped in hardware
 }
@@ -164,10 +164,7 @@ void stella8085_state::io_map(address_map &map)
 void stella8085_state::io_4040_map(address_map &map)
 {
 	map(0x00, 0x00).w(FUNC(stella8085_state::io00));
-	map(0x70, 0x70).w(FUNC(stella8085_state::io70));
-	map(0x71, 0x71).w(FUNC(stella8085_state::io71));
-	map(0x72, 0x72).w(FUNC(stella8085_state::sounddev));
-	map(0x73, 0x73).w(FUNC(stella8085_state::io73));
+	map(0x70, 0x73).rw(m_ppi, FUNC(i8255_device::read), FUNC(i8255_device::write));
 	map(0x80, 0x81).rw("kdc", FUNC(i8279_device::read), FUNC(i8279_device::write));
 	map(0x90, 0x9f).rw("muart", FUNC(i8256_device::read), FUNC(i8256_device::write));
 }
@@ -565,6 +562,11 @@ void stella8085_state::dicemstr(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &stella8085_state::large_program_map);
 	m_maincpu->set_addrmap(AS_IO, &stella8085_state::io_map);
 
+	I8255(config, m_ppi);
+	m_ppi->out_pa_callback().set(FUNC(stella8085_state::io70));
+	m_ppi->out_pb_callback().set(FUNC(stella8085_state::io71));
+	m_ppi->out_pc_callback().set(FUNC(stella8085_state::sounddev));
+
 	I8256(config, m_uart, 10.240_MHz_XTAL / 2); // divider not verified
 	m_uart->int_callback().set_inputline(m_maincpu, I8085_INTR_LINE);
 
@@ -586,6 +588,11 @@ void stella8085_state::doppelpot(machine_config &config)
 	I8085A(config, m_maincpu, 6.144_MHz_XTAL);
 	m_maincpu->set_addrmap(AS_PROGRAM, &stella8085_state::program_map);
 	m_maincpu->set_addrmap(AS_IO, &stella8085_state::io_map);
+
+	I8255(config, m_ppi);
+	m_ppi->out_pa_callback().set(FUNC(stella8085_state::io70));
+	m_ppi->out_pb_callback().set(FUNC(stella8085_state::io71));
+	m_ppi->out_pc_callback().set(FUNC(stella8085_state::sounddev));
 
 	I8256(config, m_uart, 6.144_MHz_XTAL / 2);
 	m_uart->int_callback().set_inputline(m_maincpu, I8085_INTR_LINE);


### PR DESCRIPTION
This maps the correct IO addresses for the 4040 boards, making bahia,disc,dpplstrt and discoly interactable.
This also clears up what IO 0x73 is, it's the 8255 control register.
The 8255 was replaced with discrete ICs and a fixed direction during the transition to 4087 but software on there will still set up the control registers.

This is best visible on discoly, before it would do nothing.
With this change it will blink the fault lamp and after pressing Up 1,- + Initialize it will show a fault code on the service display.