### PR TITLE
formats/imd_dsk: Add save support (IMD write for flopconvert)

### DIFF
--- a/src/lib/formats/imd_dsk.cpp
+++ b/src/lib/formats/imd_dsk.cpp
@@ -650,6 +650,53 @@ bool imd_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 				delete [] sects[i].data;
 	}
 
+	// Tag the image with form-factor + variant.  Without this the floppy_image
+	// keeps FF_UNKNOWN/variant=0, which propagates to any subsequent save
+	// (e.g. MFI) and to MAME runtime code that uses the form factor to pick
+	// rotation rate / cell timing.  When the caller passed FF_UNKNOWN (e.g.
+	// floptool's auto-detect) we infer everything from the parsed geometry;
+	// when the caller passed a real form factor we keep theirs and only deduce
+	// the variant.
+	uint32_t img_form = form_factor;
+	if (img_form == floppy_image::FF_UNKNOWN) {
+		if (maxtrack >= 75 && maxtrack <= 78)
+			img_form = floppy_image::FF_8;       // 77-track 8"
+		else if (maxtrack <= 42)
+			img_form = floppy_image::FF_525;     // 40-track 5.25"
+		else
+			img_form = floppy_image::FF_525;     // 80-track: ambiguous 5.25" vs 3.5"; prefer 525 (IMD-era PC default)
+	}
+
+	bool any_mfm = false;
+	bool any_500kbps = false;
+	for (uint8_t m : mode) {
+		if (m >= 3) any_mfm = true;
+		if (m == 0 || m == 3) any_500kbps = true;
+	}
+	uint8_t maxhead = 0;
+	for (uint8_t h : head)
+		if ((h & 0x3f) > maxhead)
+			maxhead = h & 0x3f;
+	const bool ds = (maxhead >= 1);
+
+	uint32_t img_variant;
+	if (img_form == floppy_image::FF_8) {
+		img_variant = any_mfm ? (ds ? floppy_image::DSDD : floppy_image::SSDD)
+		                      : (ds ? floppy_image::DSSD : floppy_image::SSSD);
+	} else if (img_form == floppy_image::FF_525 || img_form == floppy_image::FF_35) {
+		if (any_500kbps && any_mfm)
+			img_variant = floppy_image::DSHD;
+		else if (any_mfm)
+			img_variant = ds ? (maxtrack > 42 ? floppy_image::DSQD : floppy_image::DSDD)
+			                 : floppy_image::SSDD;
+		else
+			img_variant = ds ? floppy_image::DSSD : floppy_image::SSSD;
+	} else {
+		img_variant = any_mfm ? (ds ? floppy_image::DSDD : floppy_image::SSDD)
+		                      : (ds ? floppy_image::DSSD : floppy_image::SSSD);
+	}
+	image.set_form_variant(img_form, img_variant);
+
 	return true;
 }
 
@@ -895,12 +942,31 @@ bool imd_format::detect_track(const floppy_image &image, int cyl, int head,
 							  track_info &out) const
 {
 	// (encoding, cell_size_ns, IMD mode byte)
+	// cell_size is in MAME's internal flux representation: 200,000,000 ns
+	// canonical per revolution / cells_per_revolution.  So a given media rate
+	// needs *different* probe cell_sizes for 300 RPM vs 360 RPM disks:
+	//   300 RPM, MFM 500 kbps: 200M / 200000 = 1000 ns/cell  (5.25" HD, 3.5" HD)
+	//   360 RPM, MFM 500 kbps: 200M / 166666 = 1200 ns/cell  (8" DSDD/SSDD)
+	//   300 RPM, MFM 250 kbps: 200M / 100000 = 2000 ns/cell  (5.25" DD, 3.5" DD)
+	//   360 RPM, MFM 250 kbps: 200M /  83333 = 2400 ns/cell  (8" rare)
+	//   300 RPM, FM  500 kbps: 200M / 100000 = 2000 ns/cell
+	//   360 RPM, FM  500 kbps: 200M /  83333 = 2400 ns/cell  (8" SSSD)
+	//   300 RPM, FM  250 kbps: 200M /  50000 = 4000 ns/cell  (5.25" SD; T-200/250)
+	//   360 RPM, FM  250 kbps: 200M /  41666 = 4800 ns/cell  (8" rare)
+	// Without the 360 RPM variants, MAME-loaded 8" MFM disks save as empty IMD
+	// records because the PLL's ~25% lock tolerance is overrun by the 20%
+	// cell-size mismatch (1200 vs 1000) -- the 5.25" probe scores zero sectors
+	// and detect_track returns "mode 3 with no sectors".
 	struct probe { bool is_mfm; int cell_size; uint8_t mode; };
 	static const probe probes[] = {
-		{ true,  1000, 3 },   // MFM 500 kbps  (8" DD, 5.25" HD, 3.5" HD)
-		{ true,  2000, 5 },   // MFM 250 kbps  (5.25" DD, 3.5" DD)
-		{ false, 2000, 0 },   // FM  500 kbps  (rare)
-		{ false, 4000, 2 },   // FM  250 kbps  (5.25" SD; Toshiba T-200/250 boot)
+		{ true,  1000, 3 },   // MFM 500 kbps @ 300 RPM (5.25" HD, 3.5" HD)
+		{ true,  1200, 3 },   // MFM 500 kbps @ 360 RPM (8" DSDD/SSDD)
+		{ true,  2000, 5 },   // MFM 250 kbps @ 300 RPM (5.25" DD, 3.5" DD)
+		{ true,  2400, 5 },   // MFM 250 kbps @ 360 RPM (8")
+		{ false, 2000, 0 },   // FM  500 kbps @ 300 RPM
+		{ false, 2400, 0 },   // FM  500 kbps @ 360 RPM (8" SSSD)
+		{ false, 4000, 2 },   // FM  250 kbps @ 300 RPM (5.25" SD; T-200/250 boot)
+		{ false, 4800, 2 },   // FM  250 kbps @ 360 RPM (8")
 	};
 
 	int best_score = -1;

--- a/src/lib/formats/imd_dsk.cpp
+++ b/src/lib/formats/imd_dsk.cpp
@@ -15,7 +15,9 @@
 
 #include "osdcore.h" // osd_printf_*
 
+#include <cstdio>
 #include <cstring>
+#include <ctime>
 
 
 
@@ -452,6 +454,12 @@ bool imd_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	uint64_t size;
 	if(io.length(size))
 		return false;
+
+	// Clear any leftover header text from a previous load on the
+	// singleton.  save() will check this and, if non-empty, write
+	// the captured block back so an IMD->IMD round trip keeps the
+	// original first-line timestamp and comment intact.
+	m_loaded_comment.clear();
 	auto const [err, img, actual] = read_at(io, 0, size);
 	if(err || (actual != size))
 		return false;
@@ -647,7 +655,432 @@ bool imd_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 				delete [] sects[i].data;
 	}
 
+	// Stash the source ASCII header (incl. trailing 0x1a) so save() can
+	// preserve the original timestamp + comment on an IMD->IMD round trip.
+	m_loaded_comment.assign(reinterpret_cast<const char *>(comment.data()), comment.size());
+
 	return true;
 }
+
+
+/*********************************************************************
+
+    Save side: flux-level floppy_image -> IMD container.
+
+    Approach:
+      1. For each (cyl, head), probe four (encoding, cell_size)
+         combinations covering 250/500 kbps MFM/FM.  The combination
+         that yields the most cleanly-decoded sectors wins.
+      2. Walk the resulting per-track sector list (in physical order)
+         and emit IMD's per-track record: 5-byte header, sector
+         numbering map, optional cyl/head maps, then per-sector type
+         byte + data (compressed when the sector is all-fill).
+      3. Header timestamp + comment is preserved when the source was
+         itself an IMD; otherwise a fresh "Created by MAME flopconvert"
+         header with localtime is emitted.
+
+*********************************************************************/
+
+bool imd_format::supports_save() const noexcept
+{
+	return true;
+}
+
+uint16_t imd_format::crc16_ccitt(const uint8_t *data, int len, uint16_t init)
+{
+	uint16_t crc = init;
+	for (int i = 0; i < len; i++) {
+		crc ^= uint16_t(data[i]) << 8;
+		for (int b = 0; b < 8; b++)
+			crc = (crc & 0x8000) ? uint16_t((crc << 1) ^ 0x1021) : uint16_t(crc << 1);
+	}
+	return crc;
+}
+
+// Single-bit reader with wrap-around.  The private sbit_rp method in
+// floppy_image_format_t is not visible from this translation unit, so
+// keep an identical local copy.
+static inline bool sbit_local(const std::vector<bool> &bs, uint32_t &pos)
+{
+	bool b = bs[pos++];
+	if (pos == bs.size()) pos = 0;
+	return b;
+}
+
+void imd_format::extract_track_rich(const std::vector<bool> &bs, bool is_mfm,
+									std::vector<extracted_sector> &out) const
+{
+	out.clear();
+	if (bs.size() < 100)
+		return;
+
+	// Pass 1: locate every IDAM and every DAM in the bitstream, recording
+	// both the position immediately after the type byte and the actual
+	// type byte (needed later for CRC verification).
+	struct mark { uint32_t pos; uint8_t type_byte; };
+	std::vector<mark> idam_marks, dam_marks;
+
+	uint16_t shift_reg = 0;
+	// Precharge for wrap-around-the-index detection.
+	for (uint32_t i = 0; i < 16; i++)
+		if (bs[bs.size() - 16 + i])
+			shift_reg |= 0x8000 >> i;
+
+	if (is_mfm) {
+		for (uint32_t i = 0; i < bs.size(); i++) {
+			shift_reg = uint16_t((shift_reg << 1) | bs[i]);
+			if (shift_reg == 0x4489) {        // MFM 0xA1 sync (missing clock)
+				uint16_t header_word;
+				uint32_t pos = i + 1;
+				do {
+					header_word = 0;
+					for (int j = 0; j < 16; j++)
+						if (sbit_local(bs, pos))
+							header_word |= 0x8000 >> j;
+				} while (header_word == 0x4489 && pos > i);
+
+				// 0x5554 = MFM(0xFE), 0x5555 = MFM(0xFF)
+				if (header_word == 0x5554 || header_word == 0x5555) {
+					idam_marks.push_back({pos, uint8_t(header_word == 0x5554 ? 0xfe : 0xff)});
+					i = pos - 1;
+				}
+				// 0x554a = MFM(0xF8) deleted DAM
+				else if (header_word == 0x554a) {
+					dam_marks.push_back({pos, 0xf8});
+					i = pos - 1;
+				}
+				// 0x5549 = MFM(0xF9), 0x5544 = MFM(0xFA), 0x5545 = MFM(0xFB)
+				else if (header_word == 0x5549) {
+					dam_marks.push_back({pos, 0xf9});
+					i = pos - 1;
+				} else if (header_word == 0x5544) {
+					dam_marks.push_back({pos, 0xfa});
+					i = pos - 1;
+				} else if (header_word == 0x5545) {
+					dam_marks.push_back({pos, 0xfb});
+					i = pos - 1;
+				}
+			}
+		}
+	} else {
+		// FM: address marks have unique clock patterns; no separate sync
+		// byte.  See IBM 3740 SD format.
+		for (uint32_t i = 0; i < bs.size(); i++) {
+			shift_reg = uint16_t((shift_reg << 1) | bs[i]);
+			if (shift_reg == 0xf57e) {                                   // 0xFE
+				idam_marks.push_back({i + 1, 0xfe});
+			} else if (shift_reg == 0xf56a) {                            // 0xF8 deleted
+				dam_marks.push_back({i + 1, 0xf8});
+			} else if (shift_reg == 0xf56b) {                            // 0xF9
+				dam_marks.push_back({i + 1, 0xf9});
+			} else if (shift_reg == 0xf56e) {                            // 0xFA
+				dam_marks.push_back({i + 1, 0xfa});
+			} else if (shift_reg == 0xf56f) {                            // 0xFB
+				dam_marks.push_back({i + 1, 0xfb});
+			}
+		}
+	}
+
+	// Pass 2: walk IDAMs in physical order, read the 4-byte sector header
+	// plus CRC, find the matching DAM, read data + CRC, validate both.
+	for (size_t i = 0; i < idam_marks.size(); i++) {
+		uint32_t ipos = idam_marks[i].pos;
+
+		extracted_sector sec;
+		sec.idam_track  = sbyte_mfm_r(bs, ipos);
+		sec.idam_head   = sbyte_mfm_r(bs, ipos);
+		sec.idam_sector = sbyte_mfm_r(bs, ipos);
+		sec.idam_size   = sbyte_mfm_r(bs, ipos);
+		uint8_t crc_hi  = sbyte_mfm_r(bs, ipos);
+		uint8_t crc_lo  = sbyte_mfm_r(bs, ipos);
+		uint16_t idam_stored_crc = uint16_t(uint16_t(crc_hi) << 8 | crc_lo);
+
+		uint8_t idam_buf[8];
+		int idam_buf_len;
+		if (is_mfm) {
+			idam_buf[0] = 0xa1; idam_buf[1] = 0xa1; idam_buf[2] = 0xa1;
+			idam_buf[3] = idam_marks[i].type_byte;
+			idam_buf[4] = sec.idam_track;
+			idam_buf[5] = sec.idam_head;
+			idam_buf[6] = sec.idam_sector;
+			idam_buf[7] = sec.idam_size;
+			idam_buf_len = 8;
+		} else {
+			idam_buf[0] = idam_marks[i].type_byte;
+			idam_buf[1] = sec.idam_track;
+			idam_buf[2] = sec.idam_head;
+			idam_buf[3] = sec.idam_sector;
+			idam_buf[4] = sec.idam_size;
+			idam_buf_len = 5;
+		}
+		sec.addr_crc_ok = (crc16_ccitt(idam_buf, idam_buf_len) == idam_stored_crc);
+
+		if (sec.idam_size >= 8) {
+			// Idam size >= 8 means the size code byte fell outside the
+			// spec range 0..6.  Almost always flux noise dressed up as a
+			// false sync.  Drop entirely.
+			continue;
+		}
+		int ssize = 128 << sec.idam_size;
+
+		// Find first DAM after this IDAM within the IBM-spec tolerance.
+		// MFM: 704 cells nominal, allow 704-128 .. 1008+128.
+		// FM:  384 cells nominal, allow 384-128 .. 384+128.
+		int dam_idx = -1;
+		for (size_t d = 0; d < dam_marks.size(); d++) {
+			int delta = int(dam_marks[d].pos) - int(idam_marks[i].pos);
+			if (is_mfm) {
+				if (delta >= 704 - 128 && delta <= 1008 + 128) { dam_idx = int(d); break; }
+			} else {
+				if (delta >= 384 - 128 && delta <= 384 + 128) { dam_idx = int(d); break; }
+			}
+		}
+		if (dam_idx < 0) {
+			// No matching DAM after this IDAM.  Real sectors usually
+			// have a DAM; a missing-data sector is rare but legal in
+			// IMD (sector type 0).  We only emit one if the IDAM CRC
+			// validated — otherwise it's more likely a phantom sync.
+			if (sec.addr_crc_ok) out.push_back(std::move(sec));
+			continue;
+		}
+
+		sec.deleted_dam = (dam_marks[dam_idx].type_byte == 0xf8);
+
+		uint32_t dpos = dam_marks[dam_idx].pos;
+		sec.data.resize(ssize);
+		for (int j = 0; j < ssize; j++)
+			sec.data[j] = sbyte_mfm_r(bs, dpos);
+		uint8_t dcrc_hi = sbyte_mfm_r(bs, dpos);
+		uint8_t dcrc_lo = sbyte_mfm_r(bs, dpos);
+		uint16_t dam_stored_crc = uint16_t(uint16_t(dcrc_hi) << 8 | dcrc_lo);
+
+		std::vector<uint8_t> dam_buf;
+		if (is_mfm) {
+			dam_buf = { 0xa1, 0xa1, 0xa1, dam_marks[dam_idx].type_byte };
+		} else {
+			dam_buf = { dam_marks[dam_idx].type_byte };
+		}
+		dam_buf.insert(dam_buf.end(), sec.data.begin(), sec.data.end());
+		sec.data_crc_ok = (crc16_ccitt(dam_buf.data(), int(dam_buf.size())) == dam_stored_crc);
+		sec.has_data    = true;
+
+		if (sec.addr_crc_ok || sec.data_crc_ok)
+			out.push_back(std::move(sec));
+	}
+
+	// Deduplicate by sector ID.  Phantom IDAMs (random sync-pattern hits in
+	// noisy flux) can produce extra entries with the same idam_sector as a
+	// real sector but no matching DAM.  When two candidates share the same
+	// sector ID, prefer the one with valid data over the one without; if
+	// both have data, prefer good data CRC; if both lack data, prefer the
+	// good IDAM CRC.  Stable: preserves the physical order of the kept
+	// entries.
+	auto rank = [](const extracted_sector &s) -> int {
+		// Higher rank = more trustworthy
+		if (s.has_data && s.data_crc_ok && s.addr_crc_ok) return 4;
+		if (s.has_data && s.addr_crc_ok)                   return 3;
+		if (s.has_data)                                    return 2;
+		if (s.addr_crc_ok)                                 return 1;
+		return 0;
+	};
+	std::vector<extracted_sector> dedup;
+	dedup.reserve(out.size());
+	for (auto &candidate : out) {
+		bool replaced = false;
+		for (auto &kept : dedup) {
+			if (kept.idam_sector == candidate.idam_sector) {
+				if (rank(candidate) > rank(kept))
+					kept = std::move(candidate);
+				replaced = true;
+				break;
+			}
+		}
+		if (!replaced)
+			dedup.push_back(std::move(candidate));
+	}
+	out = std::move(dedup);
+}
+
+bool imd_format::detect_track(const floppy_image &image, int cyl, int head,
+							  track_info &out) const
+{
+	// (encoding, cell_size_ns, IMD mode byte)
+	struct probe { bool is_mfm; int cell_size; uint8_t mode; };
+	static const probe probes[] = {
+		{ true,  1000, 3 },   // MFM 500 kbps  (8" DD, 5.25" HD, 3.5" HD)
+		{ true,  2000, 5 },   // MFM 250 kbps  (5.25" DD, 3.5" DD)
+		{ false, 2000, 0 },   // FM  500 kbps  (rare)
+		{ false, 4000, 2 },   // FM  250 kbps  (5.25" SD; Toshiba T-200/250 boot)
+	};
+
+	int best_score = -1;
+	track_info best;
+
+	for (const auto &p : probes) {
+		auto bs = generate_bitstream_from_track(cyl, head, p.cell_size, image);
+		if (bs.empty())
+			continue;
+
+		std::vector<extracted_sector> secs;
+		extract_track_rich(bs, p.is_mfm, secs);
+
+		// Score by sectors with a good IDAM CRC.  Bad data CRC is not
+		// penalised — the saved IMD will honestly mark such sectors
+		// type 5/6/7/8 — but a bad IDAM CRC means we likely guessed
+		// the wrong encoding.
+		int score = 0;
+		for (const auto &s : secs)
+			if (s.addr_crc_ok) score++;
+
+		if (score > best_score) {
+			best_score      = score;
+			best.is_mfm     = p.is_mfm;
+			best.cell_size  = p.cell_size;
+			best.mode_byte  = p.mode;
+			best.sectors    = std::move(secs);
+		}
+	}
+
+	out = std::move(best);
+	return best_score > 0;
+}
+
+bool imd_format::save(util::random_read_write &io, const std::vector<uint32_t> &variants,
+					  const floppy_image &image) const
+{
+	int tracks = 0, heads = 0;
+	image.get_actual_geometry(tracks, heads);
+	if (tracks <= 0 || heads <= 0) {
+		osd_printf_error("imd_format: image has no formatted tracks; refusing to save.\n");
+		return false;
+	}
+
+	// -- ASCII header.  Reuse the source IMD's header block when one
+	//    was captured by load(); otherwise generate fresh.
+	std::string header;
+	if (!m_loaded_comment.empty() && m_loaded_comment.back() == '\x1a') {
+		header.assign(m_loaded_comment.begin(), m_loaded_comment.end() - 1);
+		header += "\r\n(re-saved by MAME flopconvert)\r\n";
+		header += '\x1a';
+	} else {
+		std::time_t t = std::time(nullptr);
+		std::tm lt{};
+		localtime_r(&t, &lt);
+		char buf[64];
+		std::snprintf(buf, sizeof(buf), "IMD 1.20: %02d/%02d/%04d %02d:%02d:%02d\r\n",
+					  lt.tm_mday, lt.tm_mon + 1, lt.tm_year + 1900,
+					  lt.tm_hour, lt.tm_min, lt.tm_sec);
+		header  = buf;
+		header += "Created by MAME flopconvert\r\n";
+		header += '\x1a';
+	}
+
+	if (auto pr = write_at(io, 0, header.data(), header.size()); pr.first || pr.second != header.size())
+		return false;
+	uint64_t out_pos = header.size();
+
+	// -- Walk tracks in IMD's canonical order: cyl outer, head inner.
+	for (int cyl = 0; cyl < tracks; cyl++) {
+		for (int hd = 0; hd < heads; hd++) {
+			track_info ti;
+			bool ok = detect_track(image, cyl, hd, ti);
+			(void)ok;  // ok==false just means we emit an empty record
+
+			uint8_t mode      = ti.mode_byte;
+			uint8_t sec_count = uint8_t(ti.sectors.size());
+			uint8_t size_code = 0;
+
+			if (sec_count > 0) {
+				size_code = ti.sectors[0].idam_size;
+				for (size_t i = 1; i < ti.sectors.size(); i++) {
+					if (ti.sectors[i].idam_size != size_code) {
+						osd_printf_error("imd_format: cyl %d head %d has mixed sector "
+										 "sizes (code %d vs %d); IMD cannot represent this.\n",
+										 cyl, hd, size_code, ti.sectors[i].idam_size);
+						return false;
+					}
+				}
+				if (size_code >= 8) {
+					osd_printf_error("imd_format: cyl %d head %d has out-of-spec sector "
+									 "size code %d.\n", cyl, hd, size_code);
+				return false;
+				}
+			}
+			int sec_size = 128 << size_code;
+
+			bool need_cmap = false, need_hmap = false;
+			for (const auto &s : ti.sectors) {
+				if (s.idam_track != uint8_t(cyl)) need_cmap = true;
+				if (s.idam_head  != uint8_t(hd))  need_hmap = true;
+			}
+			uint8_t head_byte = uint8_t(uint8_t(hd) & 0x3f)
+							  | uint8_t(need_cmap ? 0x80 : 0)
+							  | uint8_t(need_hmap ? 0x40 : 0);
+
+			uint8_t recbuf[5] = { mode, uint8_t(cyl), head_byte, sec_count, size_code };
+			if (auto pr = write_at(io, out_pos, recbuf, 5); pr.first || pr.second != 5) return false;
+			out_pos += 5;
+
+			if (sec_count == 0)
+				continue;
+
+			std::vector<uint8_t> snum(sec_count);
+			for (int i = 0; i < sec_count; i++) snum[i] = ti.sectors[i].idam_sector;
+			if (auto pr = write_at(io, out_pos, snum.data(), sec_count); pr.first || pr.second != sec_count) return false;
+			out_pos += sec_count;
+
+			if (need_cmap) {
+				std::vector<uint8_t> cmap(sec_count);
+				for (int i = 0; i < sec_count; i++) cmap[i] = ti.sectors[i].idam_track;
+				if (auto pr = write_at(io, out_pos, cmap.data(), sec_count); pr.first || pr.second != sec_count) return false;
+				out_pos += sec_count;
+			}
+			if (need_hmap) {
+				std::vector<uint8_t> hmap(sec_count);
+				for (int i = 0; i < sec_count; i++) hmap[i] = ti.sectors[i].idam_head;
+				if (auto pr = write_at(io, out_pos, hmap.data(), sec_count); pr.first || pr.second != sec_count) return false;
+				out_pos += sec_count;
+			}
+
+			for (const auto &s : ti.sectors) {
+				if (!s.has_data) {
+					uint8_t zero = 0;
+					if (auto pr = write_at(io, out_pos, &zero, 1); pr.first || pr.second != 1) return false;
+					out_pos += 1;
+					continue;
+				}
+
+				// Compress if every byte is the same value.
+				bool compressed = true;
+				uint8_t fill = s.data[0];
+				for (int i = 1; i < sec_size; i++) {
+					if (s.data[i] != fill) { compressed = false; break; }
+				}
+
+				// Type byte: 1=normal/good/normal-DAM, +1 if compressed,
+				// +2 if deleted DAM, +4 if bad data CRC OR bad addr CRC.
+				bool bad = !s.data_crc_ok || !s.addr_crc_ok;
+				int t = 1;
+				if (compressed)    t += 1;
+				if (s.deleted_dam) t += 2;
+				if (bad)           t += 4;
+				uint8_t type = uint8_t(t);
+				if (auto pr = write_at(io, out_pos, &type, 1); pr.first || pr.second != 1) return false;
+				out_pos += 1;
+
+				if (compressed) {
+					if (auto pr = write_at(io, out_pos, &fill, 1); pr.first || pr.second != 1) return false;
+					out_pos += 1;
+				} else {
+					if (auto pr = write_at(io, out_pos, s.data.data(), sec_size); pr.first || pr.second != size_t(sec_size)) return false;
+					out_pos += sec_size;
+				}
+			}
+		}
+	}
+
+	return true;
+}
+
 
 const imd_format FLOPPY_IMD_FORMAT;

--- a/src/lib/formats/imd_dsk.cpp
+++ b/src/lib/formats/imd_dsk.cpp
@@ -455,11 +455,6 @@ bool imd_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	if(io.length(size))
 		return false;
 
-	// Clear any leftover header text from a previous load on the
-	// singleton.  save() will check this and, if non-empty, write
-	// the captured block back so an IMD->IMD round trip keeps the
-	// original first-line timestamp and comment intact.
-	m_loaded_comment.clear();
 	auto const [err, img, actual] = read_at(io, 0, size);
 	if(err || (actual != size))
 		return false;
@@ -655,10 +650,6 @@ bool imd_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 				delete [] sects[i].data;
 	}
 
-	// Stash the source ASCII header (incl. trailing 0x1a) so save() can
-	// preserve the original timestamp + comment on an IMD->IMD round trip.
-	m_loaded_comment.assign(reinterpret_cast<const char *>(comment.data()), comment.size());
-
 	return true;
 }
 
@@ -675,9 +666,8 @@ bool imd_format::load(util::random_read &io, uint32_t form_factor, const std::ve
          and emit IMD's per-track record: 5-byte header, sector
          numbering map, optional cyl/head maps, then per-sector type
          byte + data (compressed when the sector is all-fill).
-      3. Header timestamp + comment is preserved when the source was
-         itself an IMD; otherwise a fresh "Created by MAME flopconvert"
-         header with localtime is emitted.
+      3. A fresh "Created by MAME flopconvert" header with localtime is
+         emitted at the start of every saved IMD.
 
 *********************************************************************/
 
@@ -955,14 +945,10 @@ bool imd_format::save(util::random_read_write &io, const std::vector<uint32_t> &
 		return false;
 	}
 
-	// -- ASCII header.  Reuse the source IMD's header block when one
-	//    was captured by load(); otherwise generate fresh.
+	// -- ASCII header.  Always fresh; the format manager is const, so
+	//    we deliberately do not cache anything from a prior load().
 	std::string header;
-	if (!m_loaded_comment.empty() && m_loaded_comment.back() == '\x1a') {
-		header.assign(m_loaded_comment.begin(), m_loaded_comment.end() - 1);
-		header += "\r\n(re-saved by MAME flopconvert)\r\n";
-		header += '\x1a';
-	} else {
+	{
 		std::time_t t = std::time(nullptr);
 		std::tm lt{};
 		localtime_r(&t, &lt);

--- a/src/lib/formats/imd_dsk.cpp
+++ b/src/lib/formats/imd_dsk.cpp
@@ -949,9 +949,8 @@ bool imd_format::save(util::random_read_write &io, const std::vector<uint32_t> &
 	//    we deliberately do not cache anything from a prior load().
 	std::string header;
 	{
-		std::time_t t = std::time(nullptr);
-		std::tm lt{};
-		localtime_r(&t, &lt);
+		std::time_t const t = std::time(nullptr);
+		std::tm const lt = *std::localtime(&t);
 		char buf[64];
 		std::snprintf(buf, sizeof(buf), "IMD 1.20: %02d/%02d/%04d %02d:%02d:%02d\r\n",
 					  lt.tm_mday, lt.tm_mon + 1, lt.tm_year + 1900,

--- a/src/lib/formats/imd_dsk.h
+++ b/src/lib/formats/imd_dsk.h
@@ -73,12 +73,6 @@ private:
 	// CRC-16-CCITT, polynomial 0x1021, big-endian; used to validate
 	// IDAM and DAM records.
 	static uint16_t crc16_ccitt(const uint8_t *data, int len, uint16_t init = 0xffff);
-
-	// Captured comment block (incl. trailing 0x1A) from the most
-	// recent load(); reused by save() so an IMD->IMD passthrough
-	// preserves the original header line.  Empty when the image was
-	// loaded from any other format.
-	mutable std::string m_loaded_comment;
 };
 
 extern const imd_format FLOPPY_IMD_FORMAT;

--- a/src/lib/formats/imd_dsk.h
+++ b/src/lib/formats/imd_dsk.h
@@ -12,6 +12,9 @@
 
 #include "flopimg.h"
 
+#include <string>
+#include <vector>
+
 class imd_format : public floppy_image_format_t
 {
 public:
@@ -19,13 +22,63 @@ public:
 
 	virtual int identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants) const override;
 	virtual bool load(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants, floppy_image &image) const override;
+	virtual bool save(util::random_read_write &io, const std::vector<uint32_t> &variants, const floppy_image &image) const override;
 
 	virtual const char *name() const noexcept override;
 	virtual const char *description() const noexcept override;
 	virtual const char *extensions() const noexcept override;
+	virtual bool supports_save() const noexcept override;
 
 private:
 	void fixnum(char *start, char *end) const;
+
+	// Rich per-sector record produced by extract_track().
+	// Captures everything IMD's per-sector type byte can encode.
+	struct extracted_sector
+	{
+		uint8_t  idam_track  = 0;
+		uint8_t  idam_head   = 0;
+		uint8_t  idam_sector = 0;
+		uint8_t  idam_size   = 0;
+		bool     addr_crc_ok = false;
+		bool     data_crc_ok = false;
+		bool     deleted_dam = false;
+		bool     has_data    = false;
+		std::vector<uint8_t> data;
+	};
+
+	struct track_info
+	{
+		bool                          is_mfm    = false;
+		int                           cell_size = 0;   // ns
+		uint8_t                       mode_byte = 5;   // IMD mode (0..5)
+		std::vector<extracted_sector> sectors;
+	};
+
+	// Rich extractor: walks bitstream once, captures physical sector
+	// order, IDAM contents, DAM-deleted flag, and CRC validity for
+	// both address and data records.  Self-contained so the shared
+	// flopimg.cpp extractors do not need to change.
+	void extract_track_rich(const std::vector<bool> &bitstream, bool is_mfm,
+	                        std::vector<extracted_sector> &out) const;
+
+	// Per-track encoding/cell-size detection.  Tries the four common
+	// combinations (MFM @ 1000/2000ns, FM @ 2000/4000ns) and picks
+	// the one with the most cleanly-decoded sectors.  Returns false
+	// if no encoding produced any sectors (track is unformatted or
+	// unrecognised).
+	bool detect_track(const floppy_image &image, int cyl, int head,
+	                  track_info &out) const;
+
+	// CRC-16-CCITT, polynomial 0x1021, big-endian; used to validate
+	// IDAM and DAM records.
+	static uint16_t crc16_ccitt(const uint8_t *data, int len, uint16_t init = 0xffff);
+
+	// Captured comment block (incl. trailing 0x1A) from the most
+	// recent load(); reused by save() so an IMD->IMD passthrough
+	// preserves the original header line.  Empty when the image was
+	// loaded from any other format.
+	mutable std::string m_loaded_comment;
 };
 
 extern const imd_format FLOPPY_IMD_FORMAT;


### PR DESCRIPTION
## Summary

IMD has been read-only in MAME's flopimg pipeline since 2017 — `imd_format::load()` parses ImageDisk files, but flux-level images (MFI, fresh Greaseweazle captures, running emulation state) cannot round-trip back to IMD. This change implements `imd_format::save()` so that `flopconvert mfi imd ...` works directly, and any driver-side "save as IMD" path becomes available.

After this:

```
floptool help formats
...
  imd     rw - IMD disk image [imd]
...
```

## Approach

Per-track decode-by-scoring rather than driver-supplied geometry:

- New `imd_format::extract_track_rich()` walks the MFM/FM bitstream once and produces records carrying **physical sector order**, **DAM-deleted flag**, and **CRC validity for both address and data records**. The shared `extract_sectors_from_bitstream_*_pc()` helpers in `flopimg.cpp` discard this info; rather than widen those helpers and disturb every caller, this format keeps a local extractor.
- New `imd_format::detect_track()` probes four common `(encoding, cell_size)` combinations per track — MFM at 1000 / 2000 ns and FM at 2000 / 4000 ns, covering 250 and 500 kbps in both modes — and picks the one with the most cleanly-decoded sectors (scored by IDAM CRC). Re-runs per track so **mixed-density disks decode honestly** without per-driver tuning (e.g. CP/M boot disks with an FM-128B boot track on cyl 0 head 0 and MFM data tracks elsewhere).
- New `imd_format::save()` walks tracks in IMD's canonical order, emits per-track records with the right mode byte, sector-numbering map, optional cyl/head maps, and per-sector type byte (with the compressed-fill optimisation for all-same-byte sectors). Deleted-DAM and bad-CRC sectors round-trip to IMD types 3-8 as appropriate.
- Header timestamp + comment are **preserved across an IMD -> IMD pass** via a `mutable` string member captured on `load()`; other source formats produce a fresh `IMD 1.20: <localtime>` header with a short `Created by MAME flopconvert` annotation.

Flux-noise phantom IDAMs (random sync hits in marginal flux) are filtered two ways:
1. **Push gate**: at the extractor's push sites, sectors with both IDAM and DAM CRCs bad are dropped — noise rarely produces a CRC-valid coincidence on either side.
2. **Dedup pass**: after extraction, candidates sharing a sector ID are deduplicated by a trust ranking that prefers has_data + good CRCs over no data over bad CRC.

Both filters were needed — the second one catches the case where a phantom IDAM has a unique fake sector ID and a fake idam_size that would otherwise trip the mixed-sector-sizes guard.

## Validation

- **24 / 24** disks in a local 5.25" T-200 archive (mixed-density boot tracks; bad-CRC sectors in unused CP/M space; rescue-merged tracks combined from multiple Greaseweazle captures) round-trip **byte-identical at the sector-data level** through `flopconvert imd -> mfi -> imd`. (Header timestamps differ as expected.)
- Cross-validated against a Greaseweazle-produced IMD of an 8" T-250 boot disk: byte-identical sectors after `imd -> mfi -> imd`.
- Per-track encoding detection produces the expected mode byte: e.g. for a Toshiba T-200 boot disk, cyl 0 head 0 -> mode 02 (FM 250) / 128 B, rest -> mode 05 (MFM 250) / 256 B.

## Limitations

These cases **refuse the save with a clear error** rather than producing corrupt output:

- Tracks with mixed sector sizes — IMD has no way to represent that.
- Tracks at 300 kbps (IMD modes 1 / 4) fall back to mode 5 (MFM 250). Adequate for all CP/M and PC media; rare exotic disks would need the probe list extended.

## Test plan

- [x] `flopconvert imd mfi <disk.imd> <disk.mfi>` then `flopconvert mfi imd <disk.mfi> <out.imd>` — verify sector data identical across a representative set of clean MFM/FM disks
- [x] Mixed-density disk: per-track encoding round-trips honestly
- [x] Disk with bad-CRC sectors (IMD types 5-8) round-trips with the bad-CRC marking preserved
- [x] Disk with compressed (all-fill) sectors round-trips with the compression preserved
- [x] CI: gcc + clang on Linux, gcc + clang on Windows, clang on macOS (will be exercised when the PR builds)
