### PR TITLE
apple2: improve accelerator delay emulation

### DIFF
--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -506,6 +506,7 @@ private:
 	bool m_accel_fast;
 	bool m_accel_present;
 	bool m_accel_temp_slowdown;
+	bool m_accel_disable_delay;
 	int m_accel_stage;
 	u32 m_accel_speed;
 	u8 m_accel_slotspk, m_accel_gameio, m_laser_speed;
@@ -552,7 +553,10 @@ private:
 	void update_iic_mouse();
 	void accel_full_speed();
 	void accel_normal_speed();
+	void accel_temp_delay(int ms, bool condition);
+	void accel_stop_delay();
 	void accel_slot(int slot);
+	void laser_slot(int slot);
 	void laser_calc_speed();
 
 	u8 m_cec_remap[0x40000];
@@ -1184,6 +1188,7 @@ void apple2e_state::machine_start()
 	save_item(NAME(m_accel_slotspk));
 	save_item(NAME(m_accel_gameio));
 	save_item(NAME(m_accel_temp_slowdown));
+	save_item(NAME(m_accel_disable_delay));
 	save_item(NAME(m_accel_laser));
 	save_item(NAME(m_accel_speed));
 	save_item(NAME(m_next_strobe));
@@ -1258,10 +1263,11 @@ void apple2e_state::machine_reset()
 	m_cec_bank = 0;
 	m_accel_unlocked = false;
 	m_accel_stage = 0;
-	m_accel_slotspk = 0x41; // speaker and slot 6 slow
+	m_accel_slotspk = 0xE4; // slots 7, 6, 5, 2 slow
 	m_accel_gameio = 0x40;  // paddle delay on
 	m_accel_present = false;
 	m_accel_temp_slowdown = false;
+	m_accel_disable_delay = false;
 	m_accel_fast = false;
 	m_centronics_busy = false;
 	m_35sel = false;
@@ -1286,6 +1292,7 @@ void apple2e_state::machine_reset()
 		{
 			m_isiicplus = true;
 			m_accel_present = true;
+			// firmware sets m_accel_slotspk to 0x67: slots 6, 5, 2, 1 and speaker slow
 		}
 		else
 		{
@@ -1316,6 +1323,9 @@ void apple2e_state::machine_reset()
 	{
 		m_accel_present = true;
 		m_accel_speed = 1021800;
+		m_accel_slotspk = 0x46; // slots 6, 2, 1 slow
+		if (m_slotdevice[5] != nullptr) m_accel_slotspk |= 0x20;
+		if (m_slotdevice[7] != nullptr) m_accel_slotspk |= 0x80;
 	}
 
 	if (m_has_laser_mouse)
@@ -1533,24 +1543,40 @@ void apple2e_state::accel_normal_speed()
 	m_maincpu->set_unscaled_clock(m_pal ? 1016966 : 1021800, true); // re-align to PH0
 }
 
-void apple2e_state::accel_slot(int slot)
+void apple2e_state::accel_temp_delay(int ms, bool condition)
 {
-	if ((m_accel_present) && (m_accel_slotspk & (1 << slot)) && !machine().side_effects_disabled())
+	// C05B status bit toggles even when accelerator is disabled
+	if ((m_accel_present) && (!m_accel_disable_delay) && (condition))
 	{
 		m_accel_temp_slowdown = true;
-		m_acceltimer->adjust(attotime::from_msec(52));
+		m_acceltimer->adjust(attotime::from_msec(ms));
 		accel_normal_speed();
 	}
 }
 
-TIMER_DEVICE_CALLBACK_MEMBER(apple2e_state::accel_timer)
+void apple2e_state::accel_stop_delay()
 {
-	if (m_accel_fast)
-	{
-		accel_full_speed();
-	}
 	m_accel_temp_slowdown = false;
 	m_acceltimer->adjust(attotime::never);
+	if (m_accel_fast)
+		accel_full_speed();
+}
+
+void apple2e_state::accel_slot(int slot)
+{
+	if (!machine().side_effects_disabled())
+		accel_temp_delay(52, BIT(m_accel_slotspk, slot));
+}
+
+void apple2e_state::laser_slot(int slot)
+{
+	if ((m_accel_laser) && !machine().side_effects_disabled())
+		accel_temp_delay(52, BIT(m_accel_slotspk, slot));
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER(apple2e_state::accel_timer)
+{
+	accel_stop_delay();
 }
 
 void apple2e_state::auxbank_update()
@@ -1885,12 +1911,7 @@ void apple2e_state::do_io(int offset)
 	{
 		m_speaker_state ^= 1;
 		m_speaker->level_w(m_speaker_state);
-		if ((m_accel_present) && (m_accel_slotspk & 1))
-		{
-			m_accel_temp_slowdown = true;
-			m_acceltimer->adjust(attotime::from_msec(5));
-			accel_normal_speed();
-		}
+		accel_temp_delay(5, (m_accel_slotspk & 1));
 		return;
 	}
 
@@ -2018,20 +2039,15 @@ void apple2e_state::do_io(int offset)
 		case 0x68:  // IIgs STATE register, which ProDOS touches
 			break;
 
-		// trigger joypad read
-		case 0x70: case 0x71: case 0x72: case 0x73: case 0x74: case 0x75: case 0x76: case 0x77:
+		case 0x70:  // PTRIG
+			// Zip paddle delay
+			accel_temp_delay(5, BIT(m_accel_gameio, 6));
+			[[fallthrough]];
+		case 0x71: case 0x72: case 0x73: case 0x74: case 0x75: case 0x76: case 0x77:
 		case 0x78: case 0x79: case 0x7a: case 0x7b: case 0x7c: case 0x7d: case 0x7e: case 0x7f:
 			if ((m_isiic) || (m_isace500))
 			{
 				lower_irq(IRQ_VBL);
-			}
-
-			// Zip paddle flag
-			if ((m_accel_present) && (BIT(m_accel_gameio, 6)))
-			{
-				m_accel_temp_slowdown = true;
-				m_acceltimer->adjust(attotime::from_msec(5));
-				accel_normal_speed();
 			}
 
 			// 558 monostable one-shot timers; a running timer cannot be restarted
@@ -2548,6 +2564,22 @@ void apple2e_state::c000_w(offs_t offset, u8 data)
 			do_io(offset);
 			break;
 
+		case 0x5e: // Zip delay
+			if (m_accel_unlocked)
+			{
+				if (BIT(data, 7))
+				{
+					m_accel_disable_delay = true;
+					accel_stop_delay();
+				}
+				else
+				{
+					m_accel_disable_delay = false;
+				}
+			}
+			do_io(offset);
+			break;
+
 		case 0x5f: // Zip game I/O flags
 			if (m_accel_unlocked)
 			{
@@ -2841,6 +2873,8 @@ void apple2e_state::c080_w(offs_t offset, u8 data)
 	}
 	else
 	{
+		accel_slot(slot);
+
 		if ((m_isiicplus) && (slot == 6))
 		{
 			m_iwm->write(offset % 0x10, data);
@@ -2954,17 +2988,16 @@ u8 apple2e_state::read_int_rom(int slotbias, int offset)
 	return m_rom_ptr[slotbias + offset];
 }
 
-u8 apple2e_state::c100_r(offs_t offset)  { accel_slot(1 + ((offset >> 8) & 0x7)); return read_slot_rom(1, offset); }
-u8 apple2e_state::c100_int_r(offs_t offset)  { accel_slot(1 + ((offset >> 8) & 0x7)); return read_int_rom(0x100, offset); }
-u8 apple2e_state::c100_int_bank_r(offs_t offset)  { accel_slot(1 + ((offset >> 8) & 0x7)); return read_int_rom(0x4100, offset); }
+u8 apple2e_state::c100_r(offs_t offset)  { return read_slot_rom(1, offset); }
+u8 apple2e_state::c100_int_r(offs_t offset)  { return read_int_rom(0x100, offset); }
+u8 apple2e_state::c100_int_bank_r(offs_t offset)  { return read_int_rom(0x4100, offset); }
 u8 apple2e_state::c100_cec_r(offs_t offset)  { return m_rom_ptr[0xc100 + offset]; }
 u8 apple2e_state::c100_cec_bank_r(offs_t offset)  { return m_rom_ptr[0x4100 + offset]; }
-void apple2e_state::c100_w(offs_t offset, u8 data) { accel_slot(1); write_slot_rom(1, offset, data); }
-u8 apple2e_state::c300_r(offs_t offset)  { accel_slot(3 + ((offset >> 8) & 0x7)); return read_slot_rom(3, offset); }
+void apple2e_state::c100_w(offs_t offset, u8 data) { write_slot_rom(1, offset, data); }
+u8 apple2e_state::c300_r(offs_t offset)  { return read_slot_rom(3, offset); }
 
 u8 apple2e_state::c300_int_r(offs_t offset)
 {
-	accel_slot(3 + ((offset >> 8) & 0x7));
 	if ((!m_slotc3rom) && !machine().side_effects_disabled())
 	{
 		m_intc8rom = true;
@@ -2975,7 +3008,6 @@ u8 apple2e_state::c300_int_r(offs_t offset)
 
 u8 apple2e_state::c300_int_bank_r(offs_t offset)
 {
-	accel_slot(3 + ((offset >> 8) & 0x7));
 	if ((!m_slotc3rom) && !machine().side_effects_disabled())
 	{
 		m_intc8rom = true;
@@ -2986,7 +3018,6 @@ u8 apple2e_state::c300_int_bank_r(offs_t offset)
 
 void apple2e_state::c300_w(offs_t offset, u8 data)
 {
-	accel_slot(3 + ((offset >> 8) & 0x7));
 	if ((!m_slotc3rom) && !machine().side_effects_disabled())
 	{
 		m_intc8rom = true;
@@ -2999,10 +3030,10 @@ void apple2e_state::c300_w(offs_t offset, u8 data)
 u8 apple2e_state::c300_cec_r(offs_t offset)  { return m_rom_ptr[0xc300 + offset]; }
 u8 apple2e_state::c300_cec_bank_r(offs_t offset)  { return m_rom_ptr[0x4300 + offset]; }
 
-u8 apple2e_state::c400_r(offs_t offset)  { accel_slot(4 + ((offset >> 8) & 0x7)); return read_slot_rom(4, offset); }
+u8 apple2e_state::c400_r(offs_t offset)  { laser_slot(4 + ((offset >> 8) & 0x7)); return read_slot_rom(4, offset); }
 u8 apple2e_state::c400_int_r(offs_t offset)
 {
-	accel_slot(4 + ((offset >> 8) & 0x7));
+	laser_slot(4 + ((offset >> 8) & 0x7));
 	if ((offset < 0x100) && (m_mockingboard4c))
 	{
 		return read_slot_rom(4, offset);
@@ -3013,7 +3044,6 @@ u8 apple2e_state::c400_int_r(offs_t offset)
 
 u8 apple2e_state::c400_int_bank_r(offs_t offset)
 {
-	accel_slot(4 + ((offset >> 8) & 0x7));
 	if ((offset < 0x100) && (m_mockingboard4c))
 	{
 		return read_slot_rom(4, offset);
@@ -3024,7 +3054,7 @@ u8 apple2e_state::c400_int_bank_r(offs_t offset)
 
 void apple2e_state::c400_w(offs_t offset, u8 data)
 {
-	accel_slot(4 + ((offset >> 8) & 0x7));
+	laser_slot(4 + ((offset >> 8) & 0x7));
 	if ((m_isiic) && (offset < 0x100))
 	{
 		m_mockingboard4c = true;
@@ -3062,6 +3092,7 @@ u8 apple2e_state::c800_r(offs_t offset)
 
 	if ((m_cnxx_slot > 0) && (m_slotdevice[m_cnxx_slot] != nullptr))
 	{
+		laser_slot(m_cnxx_slot);
 		return m_slotdevice[m_cnxx_slot]->read_c800(offset&0xfff);
 	}
 
@@ -3151,6 +3182,8 @@ u8 apple2e_state::c800_int_r(offs_t offset)
 		return m_rom_ptr[m_ace500rombank + offset];
 	}
 
+	if (m_cnxx_slot > 0)
+		laser_slot(m_cnxx_slot);
 	return m_rom_ptr[0x800 + offset];
 }
 
@@ -3202,6 +3235,7 @@ void apple2e_state::c800_w(offs_t offset, u8 data)
 
 	if ((m_cnxx_slot > 0) && (m_slotdevice[m_cnxx_slot] != nullptr))
 	{
+		laser_slot(m_cnxx_slot);
 		m_slotdevice[m_cnxx_slot]->write_c800(offset&0xfff, data);
 	}
 
@@ -3414,15 +3448,15 @@ void apple2e_state::base_map(address_map &map)
 	m_0000bank[1](0x0000, 0x01ff).rw(FUNC(apple2e_state::auxram0000_r), FUNC(apple2e_state::auxram0000_w));
 
 	map(0x0200, 0x03ff).view(m_0200bank);
-	m_0200bank[0](0x0200, 0x03ff).rw(FUNC(apple2e_state::ram0200_r), FUNC(apple2e_state::ram0200_w));         // wr 0 rd 0
-	m_0200bank[1](0x0200, 0x03ff).rw(FUNC(apple2e_state::auxram0200_r), FUNC(apple2e_state::ram0200_w));      // wr 0 rd 1
-	m_0200bank[2](0x0200, 0x03ff).rw(FUNC(apple2e_state::ram0200_r), FUNC(apple2e_state::auxram0200_w));      // wr 1 rd 0
+	m_0200bank[0](0x0200, 0x03ff).rw(FUNC(apple2e_state::ram0200_r), FUNC(apple2e_state::ram0200_w));       // wr 0 rd 0
+	m_0200bank[1](0x0200, 0x03ff).rw(FUNC(apple2e_state::auxram0200_r), FUNC(apple2e_state::ram0200_w));    // wr 0 rd 1
+	m_0200bank[2](0x0200, 0x03ff).rw(FUNC(apple2e_state::ram0200_r), FUNC(apple2e_state::auxram0200_w));    // wr 1 rd 0
 	m_0200bank[3](0x0200, 0x03ff).rw(FUNC(apple2e_state::auxram0200_r), FUNC(apple2e_state::auxram0200_w)); // wr 1 rd 1
 
 	map(0x0400, 0x07ff).view(m_0400bank);
-	m_0400bank[0](0x0400, 0x07ff).rw(FUNC(apple2e_state::ram0400_r), FUNC(apple2e_state::ram0400_w));         // wr 0 rd 0
-	m_0400bank[1](0x0400, 0x07ff).rw(FUNC(apple2e_state::auxram0400_r), FUNC(apple2e_state::ram0400_w));      // wr 0 rd 1
-	m_0400bank[2](0x0400, 0x07ff).rw(FUNC(apple2e_state::ram0400_r), FUNC(apple2e_state::auxram0400_w));      // wr 1 rd 0
+	m_0400bank[0](0x0400, 0x07ff).rw(FUNC(apple2e_state::ram0400_r), FUNC(apple2e_state::ram0400_w));       // wr 0 rd 0
+	m_0400bank[1](0x0400, 0x07ff).rw(FUNC(apple2e_state::auxram0400_r), FUNC(apple2e_state::ram0400_w));    // wr 0 rd 1
+	m_0400bank[2](0x0400, 0x07ff).rw(FUNC(apple2e_state::ram0400_r), FUNC(apple2e_state::auxram0400_w));    // wr 1 rd 0
 	m_0400bank[3](0x0400, 0x07ff).rw(FUNC(apple2e_state::auxram0400_r), FUNC(apple2e_state::auxram0400_w)); // wr 1 rd 1
 
 	map(0x0800, 0x1fff).view(m_0800bank);
@@ -3492,26 +3526,34 @@ void apple2e_state::apple2c_map(address_map &map)
 {
 	base_map(map);
 	map(0xc000, 0xc07f).r(FUNC(apple2e_state::c000_iic_r));
-	map(0xc098, 0xc09b).rw(m_acia1, FUNC(mos6551_device::read), FUNC(mos6551_device::write));
-	map(0xc0a8, 0xc0ab).rw(m_acia2, FUNC(mos6551_device::read), FUNC(mos6551_device::write));
+	map(0xc098, 0xc09b).lrw8(
+		[this](offs_t offset)          { accel_slot(1); return m_acia1->read(offset); }, "acia1_r",
+		[this](offs_t offset, u8 data) { accel_slot(1); m_acia1->write(offset, data); }, "acia1_w");
+	map(0xc0a8, 0xc0ab).lrw8(
+		[this](offs_t offset)          { accel_slot(2); return m_acia2->read(offset); }, "acia2_r",
+		[this](offs_t offset, u8 data) { accel_slot(2); m_acia2->write(offset, data); }, "acia2_w");
 }
 
 void apple2e_state::apple2c_memexp_map(address_map &map)
 {
-	base_map(map);
-	map(0xc000, 0xc07f).r(FUNC(apple2e_state::c000_iic_r));
-	map(0xc098, 0xc09b).rw(m_acia1, FUNC(mos6551_device::read), FUNC(mos6551_device::write));
-	map(0xc0a8, 0xc0ab).rw(m_acia2, FUNC(mos6551_device::read), FUNC(mos6551_device::write));
-	map(0xc0c0, 0xc0c3).rw(FUNC(apple2e_state::memexp_r), FUNC(apple2e_state::memexp_w));
+	apple2c_map(map);
+	map(0xc0c0, 0xc0c3).lrw8(
+		[this](offs_t offset)          { accel_slot(4); return memexp_r(offset); }, "memexp_r",
+		[this](offs_t offset, u8 data) { accel_slot(4); memexp_w(offset, data);  }, "memexp_w");
 }
 
 void apple2e_state::laser128_map(address_map &map)
 {
 	base_map(map);
 	map(0xc000, 0xc07f).rw(FUNC(apple2e_state::c000_laser_r), FUNC(apple2e_state::c000_laser_w));
-	map(0xc090, 0xc097).w(FUNC(apple2e_state::laserprn_w));
-	map(0xc098, 0xc09b).rw(m_acia1, FUNC(mos6551_device::read), FUNC(mos6551_device::write));
-	map(0xc0a8, 0xc0ab).rw(m_acia2, FUNC(mos6551_device::read), FUNC(mos6551_device::write));
+	map(0xc090, 0xc097).lw8(
+		[this](u8 data)                { accel_slot(1); laserprn_w(data); }, "laserprn_w");
+	map(0xc098, 0xc09b).lrw8(
+		[this](offs_t offset)          { accel_slot(1); return m_acia1->read(offset); }, "acia1_r",
+		[this](offs_t offset, u8 data) { accel_slot(1); m_acia1->write(offset, data); }, "acia1_w");
+	map(0xc0a8, 0xc0ab).lrw8(
+		[this](offs_t offset)          { accel_slot(2); return m_acia2->read(offset); }, "acia2_r",
+		[this](offs_t offset, u8 data) { accel_slot(2); m_acia2->write(offset, data); }, "acia2_w");
 	map(0xc0c0, 0xc0cf).rw(FUNC(apple2e_state::laser_mouse_r), FUNC(apple2e_state::laser_mouse_w));
 	map(0xc0d0, 0xc0d3).rw(FUNC(apple2e_state::memexp_r), FUNC(apple2e_state::memexp_w));
 	map(0xc0e0, 0xc0ef).rw(m_iwm, FUNC(applefdintf_device::read), FUNC(applefdintf_device::write));

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -559,6 +559,8 @@ private:
 		}
 	}
 
+	void accel_temp_delay(int ms, bool condition);
+	void accel_stop_delay();
 	void accel_slot(int slot);
 };
 
@@ -939,8 +941,8 @@ void apple2gs_state::machine_reset()
 	// Setup ZipGS
 	m_accel_unlocked = false;
 	m_accel_stage = 0;
-	m_accel_slotspk = 0x41; // speaker and slot 6 slow
-	m_accel_gsxsettings = 0x49; // paddle slow, CPS, GS
+	m_accel_slotspk = 0x45; // slots 6, 2, and speaker slow
+	m_accel_gsxsettings = 0x59; // paddle and counter slow, CPS, GS
 	m_accel_percent = 0;    // 100% speed
 	m_accel_present = false;
 	m_accel_temp_slowdown = false;
@@ -967,14 +969,14 @@ void apple2gs_state::raise_irq(int irq)
 		if (!(m_intflag & INTFLAG_IRQASSERTED))
 		{
 			//printf("raise IRQ %d (mask %x)\n", irq, m_irqmask);
-			// TODO: Zip AppleTalk slowdown
+			// Zip AppleTalk delay
+			accel_temp_delay(5, BIT(m_accel_gsxsettings, 5));
 
 			m_intflag |= INTFLAG_IRQASSERTED;
 			m_maincpu->set_input_line(G65816_LINE_IRQ, ASSERT_LINE);
 		}
 	}
 }
-
 
 void apple2gs_state::lower_irq(int irq)
 {
@@ -1021,24 +1023,34 @@ void apple2gs_state::update_speed()
 	}
 }
 
-void apple2gs_state::accel_slot(int slot)
+void apple2gs_state::accel_temp_delay(int ms, bool condition)
 {
-	if ((m_accel_present) && (m_accel_slotspk & (1 << slot)) && !machine().side_effects_disabled())
+	// C05B status bit toggles even when accelerator is disabled
+	if ((m_accel_present) && (condition))
 	{
 		m_accel_temp_slowdown = true;
-		m_acceltimer->adjust(attotime::from_msec(52));
+		m_acceltimer->adjust(attotime::from_msec(ms));
 		accel_normal_speed();
 	}
 }
 
-TIMER_DEVICE_CALLBACK_MEMBER(apple2gs_state::accel_timer)
+void apple2gs_state::accel_stop_delay()
 {
-	if (m_accel_fast)
-	{
-		accel_full_speed();
-	}
 	m_accel_temp_slowdown = false;
 	m_acceltimer->adjust(attotime::never);
+	if (m_accel_fast)
+		accel_full_speed();
+}
+
+void apple2gs_state::accel_slot(int slot)
+{
+	if (!machine().side_effects_disabled())
+		accel_temp_delay(52, BIT(m_accel_slotspk | (m_speed << 4), slot));
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER(apple2gs_state::accel_timer)
+{
+	accel_stop_delay();
 }
 
 /***************************************************************************
@@ -1366,9 +1378,6 @@ void apple2gs_state::do_io(int offset)
 
 	switch (offset)
 	{
-		case 0x20:
-			break;
-
 		case 0x28:  // ROMSWITCH - not used by the IIgs firmware or SSW, but does exist at least on ROM 0/1 (need to test on ROM 3 hw)
 			if (!m_is_rom3)
 			{
@@ -1387,7 +1396,13 @@ void apple2gs_state::do_io(int offset)
 		case 0x2a:  // 16-bit access to NEWVIDEO
 			break;
 
-		case 0x30:
+		case 0x2e:  // VERTCNT
+		case 0x7e:
+			// Zip counter delay
+			accel_temp_delay(5, BIT(m_accel_gsxsettings, 4));
+			break;
+
+		case 0x30:  // SPKR
 			m_speaker_state ^= 1;
 			if (m_speaker_state)
 			{
@@ -1398,12 +1413,7 @@ void apple2gs_state::do_io(int offset)
 				m_speaker->level_w(0);
 			}
 
-			if ((m_accel_present) && (m_accel_slotspk & 1))
-			{
-				m_accel_temp_slowdown = true;
-				m_acceltimer->adjust(attotime::from_msec(5));
-				accel_normal_speed();
-			}
+			accel_temp_delay(5, (m_accel_slotspk & 1));
 			break;
 
 		case 0x37:  // DMAREG, 16-bit access to CYAREG
@@ -1497,14 +1507,6 @@ void apple2gs_state::do_io(int offset)
 			break;
 
 		case 0x70:  // PTRIG triggers paddles on read or write
-			// Zip paddle slowdown (does ZipGS also use the old Zip flag?)
-			if ((m_accel_present) && BIT(m_accel_gsxsettings, 6))
-			{
-				m_accel_temp_slowdown = true;
-				m_acceltimer->adjust(attotime::from_msec(5));
-				accel_normal_speed();
-			}
-
 			// 558 monostable one-shot timers; a running timer cannot be restarted
 			if (machine().time().as_double() >= m_joystick_x1_time)
 			{
@@ -1522,6 +1524,10 @@ void apple2gs_state::do_io(int offset)
 			{
 				m_joystick_y2_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl3_r();
 			}
+			[[fallthrough]];
+		case 0x20:
+			// Zip paddle delay
+			accel_temp_delay(5, BIT(m_accel_gsxsettings, 6));
 			break;
 
 		default:
@@ -1684,7 +1690,7 @@ u8 apple2gs_state::c000_r(offs_t offset)
 		case 0x23:  // VGCINT
 			return m_vgcint;
 
-		case 0x24:  // MOUSEDATA */
+		case 0x24:  // MOUSEDATA
 			return keyglu_816_read(GLU_MOUSEX);
 
 		case 0x25:  // KEYMODREG
@@ -1706,6 +1712,8 @@ u8 apple2gs_state::c000_r(offs_t offset)
 			return m_slotromsel;
 
 		case 0x2e:  // VERTCNT
+			do_io(offset); // Zip delay
+
 			// reading VERTCNT clears SCB status
 			if (!machine().side_effects_disabled())
 				clear_vgcint(~VGCINT_SCANLINE);
@@ -1830,8 +1838,11 @@ u8 apple2gs_state::c000_r(offs_t offset)
 					(m_intcxrom ? 0x01 : 0x00);
 
 		// The ROM IRQ vectors point here (0x70 returns floating bus)
+		case 0x7e:
+			do_io(offset); // Zip delay
+			[[fallthrough]];
 		case 0x71: case 0x72: case 0x73: case 0x74: case 0x75: case 0x76: case 0x77:
-		case 0x78: case 0x79: case 0x7a: case 0x7b: case 0x7c: case 0x7d: case 0x7e: case 0x7f:
+		case 0x78: case 0x79: case 0x7a: case 0x7b: case 0x7c: case 0x7d: case 0x7f:
 			return m_rom[offset + 0x3c000];
 
 		default:
@@ -1862,7 +1873,8 @@ u8 apple2gs_state::c000_r(offs_t offset)
 				}
 				else if (offset == 0x5c)
 				{
-					return m_accel_slotspk;
+					// C036 motor detection overrides slots 4-7
+					return m_accel_slotspk | (m_speed << 4);
 				}
 			}
 			break;
@@ -1966,9 +1978,6 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			keyglu_816_write(GLU_C010, data);
 			break;
 
-		case 0x20:
-			break;
-
 		case 0x21:  // MONOCHROME
 			m_video->set_GS_monochrome(data);
 			break;
@@ -1993,12 +2002,7 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 
 		case 0x26:  // DATAREG
 			// allow ADBuC sync if the Zip is on
-			if (m_accel_present)
-			{
-				m_accel_temp_slowdown = true;
-				m_acceltimer->adjust(attotime::from_msec(30));
-				accel_normal_speed();
-			}
+			accel_temp_delay(30, true);
 			keyglu_816_write(GLU_COMMAND, data);
 			break;
 
@@ -2146,6 +2150,7 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			break;
 
 		case 0x59: // Zip GS-specific settings
+			accel_stop_delay();
 			if (m_accel_unlocked)
 			{
 				m_accel_gsxsettings = data & 0xf8;
@@ -2155,9 +2160,10 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			break;
 
 		case 0x5a: // Zip accelerator unlock
+			accel_stop_delay();
 			if (m_sysconfig->read() & 0x01)
 			{
-				if (data == 0x5a)
+				if ((data & 0xf0) == 0x50)
 				{
 					m_accel_stage++;
 					if (m_accel_stage == 4)
@@ -2165,7 +2171,7 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 						m_accel_unlocked = true;
 					}
 				}
-				else if (data == 0xa5)
+				else if ((data & 0xf0) == 0xa0)
 				{
 					// lock
 					m_accel_unlocked = false;
@@ -2182,6 +2188,7 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			break;
 
 		case 0x5b: // Zip full speed
+			accel_stop_delay();
 			if (m_accel_unlocked)
 			{
 				m_accel_fast = true;
@@ -2191,6 +2198,7 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			break;
 
 		case 0x5c: // Zip slot/speaker flags
+			accel_stop_delay();
 			if (m_accel_unlocked)
 			{
 				m_accel_slotspk = data;
@@ -2199,10 +2207,18 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			break;
 
 		case 0x5d: // Zip speed percentage
+			accel_stop_delay();
 			if (m_accel_unlocked)
 			{
 				m_accel_percent = data;
 			}
+			do_io(offset);
+			break;
+
+		case 0x58:
+		case 0x5e:
+		case 0x5f:
+			accel_stop_delay();
 			do_io(offset);
 			break;
 
@@ -2311,6 +2327,8 @@ void apple2gs_state::c080_w(offs_t offset, u8 data)
 	}
 	else
 	{
+		accel_slot(slot);
+
 		if (slot >= 4)
 		{
 			if ((offset & 0xf) == 0x9)
@@ -2397,7 +2415,6 @@ u8 apple2gs_state::c100_r(offs_t offset)
 {
 	const int slot = ((offset>>8) & 0xf) + 1;
 
-	accel_slot(slot);
 	slow_cycle();
 
 	// SETSLOTCXROM is disabled, so the $C02D SLOT register controls what's in each slot
@@ -2413,7 +2430,6 @@ void apple2gs_state::c100_w(offs_t offset, u8 data)
 {
 	const int slot = ((offset>>8) & 0xf) + 1;
 
-	accel_slot(slot);
 	slow_cycle();
 
 	if (BIT(m_slotromsel, slot))
@@ -2422,15 +2438,14 @@ void apple2gs_state::c100_w(offs_t offset, u8 data)
 	}
 }
 
-u8 apple2gs_state::c300_int_r(offs_t offset)  { accel_slot(3 + ((offset >> 8) & 0x7)); slow_cycle(); return read_int_rom(0x3c300, offset); }
-u8 apple2gs_state::c300_r(offs_t offset)  { accel_slot(3 + ((offset >> 8) & 0x7)); slow_cycle(); return read_slot_rom(3, offset); }
-void apple2gs_state::c300_w(offs_t offset, u8 data) { accel_slot(3 + ((offset >> 8) & 0x7)); slow_cycle(); write_slot_rom(3, offset, data); }
+u8 apple2gs_state::c300_int_r(offs_t offset)  { slow_cycle(); return read_int_rom(0x3c300, offset); }
+u8 apple2gs_state::c300_r(offs_t offset)  { slow_cycle(); return read_slot_rom(3, offset); }
+void apple2gs_state::c300_w(offs_t offset, u8 data) { slow_cycle(); write_slot_rom(3, offset, data); }
 
 u8 apple2gs_state::c400_r(offs_t offset)
 {
 	const int slot = ((offset>>8) & 0xf) + 4;
 
-	accel_slot(slot);
 	slow_cycle();
 
 	if (!BIT(m_slotromsel, slot))
@@ -2445,7 +2460,6 @@ void apple2gs_state::c400_w(offs_t offset, u8 data)
 {
 	const int slot = ((offset>>8) & 0xf) + 4;
 
-	accel_slot(slot);
 	slow_cycle();
 
 	if (BIT(m_slotromsel, slot))


### PR DESCRIPTION
(followup #15313, #14397)

This PR corrects the emulation of temporary accelerator delays to match observed Zip Chip and ZipGS hardware behavior, and Laser 128EX documentation.

There are various delay differences in hardware behavior, summarizing here:

* ZipGS and Zip both do software-configurable slot delay on DEVSEL C0nx, but not IOSEL Cnxx or C800 ROM 
* Laser does hardware-configurable slot delay on some DEVSEL C0nx, IOSEL Cnxx, and C800 ROM
* ZipGS optional speaker delay on C030, Zip on C03x, Laser no delay
* ZipGS optional paddle delay on C020/70, Zip only on C070, Laser no delay
* ZipGS-only optional video counter delay on C02E/7E, optional IRQ delay
* ZipGS cancels any current delay on a write to any Zip register, Zip Chip only cancels when bit 7 of C05E is set (and this continues to disable all future delays until unset.)

All of that matches the existing ([apocryphal](https://gswv.apple2.org.za/a2zine/faqs/Csa2ACCEL.html#010)) documentation, except for [the C03x speaker part](https://mirrors.apple2.org.za/ftp.apple.asimov.net/documentation/hardware/accelerators/zip_instruction_manual.pdf#page=14) which is not surprising, just undocumented.

The IIgs also has undocumented slot delay interaction with the C036 motor-on detection bits: in addition to slowing to 1MHz when the motor is actually on, the slot 4-7 bits override reads of the Zip's C05C slot register.  This is indirectly user-observable by toggling CDA > Slots > Slot 6 (and rebooting): the "Disk Port" default will cause the firmware to detect Disk ][ firmware in slot 6 and set the corresponding C036 motor-on bit during boot, which causes the Zip to temporarily delay on any C0Ex access (even when C05C or [the hardware DIP switch](http://www.apple-iigs.info/doc/fichiers/zipgs.pdf#page=4) is set to force slot 6 "fast".)

I verified these changes against a 15MHz/64k ZipGSX in an Apple IIgs ROM3.
Thanks to David Schmidt @david-schmidt and Tom Greene @txgx42 for //c+ and Zip Chip-8 [hardware testing](https://apple2infinitum.slack.com/archives/CPS2TG28L/p1777998146485029?thread_ts=1777912265.516769&cid=CPS2TG28L).
<br>
Code comments:<details>

* apple2gs simply deletes most `accel_slot()` uses, athough `c080_w()` adds it (testing of this must carefully avoid false-read cycles in i.e. STA,Y)
* apple2e removes some `accel_slot()` uses, and `laser_slot()` wraps Laser-only cases 
* unprotected `address_map` handlers are wrapped in lambdas
* `accel_temp_delay()` and `accel_stop_delay()` helpers simply reduce copy-paste (and bottleneck instrumentation)

The Laser 128 family has unemulated [hardware switches](https://archive.org/details/laser128128ex128ex2usersguidebasicmanual1989ocr/page/n13/mode/2up) to toggle INT/EXT PORT 5 and PORT 7 which [interact with the acceleration](https://archive.org/details/Laser_128_Series_Technical_Reference_Manual/page/n281/mode/2up).  Currently laser128, laser128o and las128ex have slots 5 and 7 hardcoded to accept external `a2bus` devices (so the slot 5 ramdisk via `-ramsize` can't work), while las128e2 has them hardcoded to internal (so i.e. `-sl7 cffa2` can't work.)  This PR doesn't attempt to address that, but for now, I have hooked up `m_accel_slotspk` to slow down slots 5 and 7 only when devices are in those slots.
</details>
<br>
User-visible changes:<details>

The most noticeable change is that apple2e/c machines configured with a Zip Chip now boot with a high-pitched beep.  This matches hardware behavior [audible here](https://youtu.be/4CcLMHRsU04?t=54).  (apple2cp firmware overwrites the Zip registers during boot so the beep is slow, but [slightly off-pitch for other reasons](https://blondihacks.com/apple-iic-plus-fixing-the-beep/).)

Zip Chip Utilities are unchanged (System Check passes, Cache Diagnostics fail.)
The ZipGS 1.2 CDA and FTA Zip CDA are slightly improved: they now show the Slot and Misc settings match the expected defaults.  Andy McFadden's [Zippy](https://fadden.com/apple2/misc.html#misc%20applications%20(section)) is now usable.

This won't affect users with the default Zip settings, but if slot 3 is programmatically set to "slow" then the PR#3 80-column firmware now remains fast like hardware.  Before this PR it was noticeably slow due to the incorrect IOSEL delays.

Implementing the IIgs counter delay fixes some tearing visible in FTA Modulae, "Fill Mode Three-Dee":
<img width="704" height="462" alt="MODULAE_tearing_before" src="https://github.com/user-attachments/assets/3d819ce3-d98b-4d84-9a5f-db92c28c08b8" />
</details>
<br>
Testing:<details>

Total Replay's Zip (and Laser) acceleration continues to work, speeding up for decompression and disabling for play (or relying on CPS Follow on the IIgs.)
	
Light printer testing of `-sl1 grapplus -sl1:grapplus:prn ap2000`, `-sl1 parallel -sl1:parallel:prn ap2000`, `-parallel ap2000`) via PR#1 or [Combined Enhanced Graphics](https://forums.bannister.org/ubbthreads.php?ubb=showflat&Number=118091#Post118091) continues to work.

Light serial testing of `-modem null_modem -bitbanger modem.txt` (configuring Laser Ctrl-P-Reset > Serial and Machine Configuration > RS-232 to matching 7N1 9600 or 19200 baud) via PR#2 continues to work.  las128ex and las128e2 (toggling speeds with Ctrl-1/2/3-Reset) now slow down serial access to 1 MHz [per the documentation](https://archive.org/details/Laser_128_Series_Technical_Reference_Manual/page/n281/mode/2up); listing a large BASIC program over serial is noticeably slower.

On apple2cp, the serial port continues to work after [configuring manually](https://archive.org/details/AppleIIcTechnicalReference2ndEd/page/n209/mode/2up):
```
PR#2
Ctrl-A 1D
Ctrl-A 15B
Ctrl-A L
```

My [previous](https://github.com/mamedev/mame/pull/14397#:~:text=WIP%20test%20suite) WIP unit tests are updated here:
[ZipTest_260527.zip](https://github.com/user-attachments/files/28313054/ZipTest_260527.zip)

ZIPSCAN now shows that the delay cancel works, and the un/lock keys and read/write I/O locations match hardware:
<img width="704" height="462" alt="ZIPSCAN_gs_287_after" src="https://github.com/user-attachments/assets/7b366b72-97c6-49c5-a157-5cd8be0a71f8" />

ZIPTEST shows several failures before this PR:
<img width="560" height="384" alt="ZIPTEST_cp_287_before" src="https://github.com/user-attachments/assets/c34c4ab0-4889-4ae9-a3eb-4739b4829dd4" />

After this PR, all of the delay-related subtests are fixed:
<img width="560" height="384" alt="ZIPTEST_cp_287_after" src="https://github.com/user-attachments/assets/ce801213-cf0c-4bbf-8957-beb4efc7fad6" />

There are still problems with unlocking, the LC status, the 8-bit bank switches, and the programmable clock speed, all to be addressed in a future PR.
</details>
