### PR TITLE
sony/news_68k.cpp: Fix typo in nws12x0 DIP switch defaults

### DIFF
--- a/src/mame/sony/news_68k.cpp
+++ b/src/mame/sony/news_68k.cpp
@@ -889,7 +889,7 @@ void news_68k_laptop_state::nws1250(machine_config &config)
 
 static INPUT_PORTS_START(nws12x0)
 	PORT_START("SW1")
-	PORT_DIPNAME(0x07, 0x02, "Display") PORT_DIPLOCATION("SW1:1,2,3")
+	PORT_DIPNAME(0x07, 0x05, "Display") PORT_DIPLOCATION("SW1:1,2,3")
 	PORT_DIPSETTING(0x07, "Console")
 	PORT_DIPSETTING(0x05, "LCD")
 	PORT_DIPSETTING(0x00, "Autoselect")


### PR DESCRIPTION
Because my local setup had the LCD switch set in `nws1250.cfg`, I missed the typo in the DIP switch default. Retested after blowing away my cfg directory to make sure the defaults were set correctly this time.