### PR TITLE
hash/sony_news.xml: Add NWU-671CA (NWF-671C) install tapes for NEWS-OS 4.1C

### DIFF
--- a/hash/sony_news.xml
+++ b/hash/sony_news.xml
@@ -5,6 +5,32 @@ license:CC0-1.0
 -->
 <softwarelist name="sony_news" description="Sony NEWS software">
 
+	<software name="nwu_671ca" supported="no">
+		<description>NEWS-OS Release 4.1CA Install Kit</description>
+		<year>1991</year>
+		<publisher>Sony</publisher>
+		<notes>The second tape is damaged, and there is no known-good dump of the installer floppy. However, the NWF-672RB installation floppy supports both RISC and CISC machines and works with this tape set.</notes>
+		<sharedfeat name="compatibility" value="CISC" />
+
+		<!-- Source: bitsavers.org -->
+		<!-- The volume markers all list the build date as 07/15/91. -->
+		<!-- The markers also identify the kit as NWF-671C. The NWU prefix on the tape label, used above, is specific to the US release. Each tape is still marked with their original NWF volume names in the data.-->
+		<part name="install_tape_1" interface="tape">
+			<feature name="part_id" value="NEWS-OS Install Kit NWF-671C Vol.1" />
+			<!-- This tape contains Vol.1 alone -->
+			<dataarea name="tape" size="30979140">
+				<rom name="4.1CA_1.tap" size="30979140" crc="4e5c7e10" sha1="c977e9ab5ad75691e1d8570b636601a6e8c57ca5" />
+			</dataarea>
+		</part>
+		<part name="install_tape_2" interface="tape">
+			<feature name="part_id" value="NEWS-OS Install Kit NWF-671C Vol.2-4" />
+			<!-- This tape contains Vol.2-4 and is damaged. The installation will stop and the SCSI tape driver will throw a fatal error if you select anything past `lbpfil` on the feature select screen. -->
+			<dataarea name="tape" size="74870912">
+				<rom name="4.1CA_2.tap" status="baddump" size="74870912" crc="d495d3bd" sha1="b9b14151e417f4989e08efc296181ac1ff2048ca" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="nwf_672rb" supported="partial">
 		<description>NEWS-OS Release 4.1R Version Up Kit</description>
 		<year>1991</year>


### PR DESCRIPTION
Credit for this dump goes to Bitsavers :)

Validation passes:
```sh
$ ./mame -verifysoftware
sony_news:nwu_671ca: 4.1CA_2.tap (74870912 bytes) - NEEDS REDUMP
romset sony_news:nwu_671ca is best available
romset sony_news:nwf_672rb is good
romset sony_news:nwf_683rd1 is good
3 romsets found in 3 software lists, 3 romsets were OK.
```

However, I have marked it as not supported, for two reasons.
1. The available dump for this install kit does not include the floppy disks. That said, you can use the ones from the RISC install kit (the labels on the floppy say C/R and the install works OK in MAME, with the exception of item 2).
2. The second tape is a bad dump - it was apparently damaged, per the dump log from the original dumper (Bitsavers). Therefore, on top of needing redump for preservation purposes, the SCSI tape driver in MAME will throw a fatal error if you try to install anything past the `lbpfil` item on the features screen.

Version stamp files from the tapes used for the metadata, let me know if there are any 
changes I need to make:

From tape 1:
```
NEWS-OS Install Kit NWF-671C Vol.1

machine: banjo.sm.sony.co.jp
device:  /dev/nrst00
date:    Mon Jul 15 17:56:06 JST 1991
user:    root
```

From tape 2:
```
NEWS-OS Install Kit NWF-671C Vol.2

machine: banjo.sm.sony.co.jp
device:  /dev/nrst01
date:    Mon Jul 15 17:08:50 JST 1991
user:    root
```

```
NEWS-OS Install Kit NWF-671C Vol.3

machine: banjo.sm.sony.co.jp
device:  /dev/nrst01
date:    Mon Jul 15 17:13:54 JST 1991
user:    root
```

```
NEWS-OS Install Kit NWF-671C Vol.4

machine: banjo.sm.sony.co.jp
device:  /dev/nrst01
date:    Mon Jul 15 17:17:22 JST 1991
user:    root
```