### PR TITLE
bus/nscsi/s1410: Add an optional cylinder-aware seek-timing model

### DIFF
--- a/src/devices/bus/nscsi/s1410.cpp
+++ b/src/devices/bus/nscsi/s1410.cpp
@@ -5,6 +5,8 @@
 
 #include "multibyte.h"
 
+#include <cmath>
+
 #define LOG_COMMAND (1U << 1)
 #define LOG_DATA    (1U << 2)
 
@@ -32,6 +34,22 @@ void nscsi_s1410_device::device_reset()
 	params[5] = 0;
 	params[6] = 64;
 	params[7] = 11;
+
+	m_last_cylinder = -1;
+}
+
+void nscsi_s1410_device::set_seek_timing(uint32_t track_us, uint32_t average_us, uint32_t full_us, uint32_t rpm, uint8_t interleave)
+{
+	m_seek_track_us = track_us;
+	m_seek_range_us = (full_us > track_us) ? (full_us - track_us) : 0;
+	m_rpm           = rpm ? rpm : 3600;
+	m_interleave    = interleave ? interleave : 1;
+	// Fit seek(d) = track + range * (d/ncyl)^exp so an average-length seek
+	// (~1/3 of full stroke) costs average_us.
+	const double num = double(average_us) - double(track_us);
+	const double den = double(full_us)    - double(track_us);
+	m_seek_exp = (num > 0.0 && den > 0.0) ? std::log(num / den) / std::log(1.0 / 3.0) : 1.0;
+	m_seek_model = true;
 }
 
 bool nscsi_s1410_device::scsi_command_done(uint8_t command, uint8_t length)
@@ -226,8 +244,44 @@ attotime nscsi_s1410_device::scsi_data_command_delay()
 	case SC_READ:
 	case SC_WRITE:
 	case SC_SEEK:
-		// average seek time of NEC D5126A hard disk
-		return attotime::from_msec(85);
+	{
+		// Legacy default (unchanged unless a driver calls set_seek_timing()):
+		// a flat average-seek delay charged on every command, matching the
+		// older NEC D5126A approximation used by the existing s1410 users.
+		if (!m_seek_model)
+			return attotime::from_msec(85);
+
+		// A real drive seeks only when the target cylinder changes; sequential
+		// I/O on one cylinder pays only rotational latency, scaled by the
+		// format interleave.  Track the head cylinder and bill streaming or a
+		// real seek accordingly.  For the ST-506/ST-412 the model fits
+		// track-to-track 3 ms, average 85 ms and full-stroke 205 ms with
+		// exp ~= 0.82, capturing the drive's "burst mode" multi-cylinder seek
+		// (faster than naive 3 ms/cyl stepping for long seeks, but still cheap
+		// for short ones).
+		uint32_t spt = 1, spc = 1, ncyl = 1;
+		if (image->exists())
+		{
+			const auto &info = image->get_info();
+			spt  = info.sectors ? info.sectors : 1;
+			spc  = info.heads * spt;  if (!spc)  spc = 1;
+			ncyl = info.cylinders ? info.cylinders : 1;
+		}
+		const int target = int((get_u24be(&m_scsi_cmdbuf[1]) & 0x1fffff) / spc);
+		const int dist = (m_last_cylinder < 0) ? int(ncyl)
+			: (target > m_last_cylinder ? target - m_last_cylinder
+						  : m_last_cylinder - target);
+		m_last_cylinder = target;
+
+		const uint32_t rev_us = 60u * 1000000u / m_rpm;
+		uint32_t us;
+		if (dist == 0)
+			us = (rev_us * m_interleave) / spt;
+		else
+			us = rev_us / 2 + m_seek_track_us
+				+ uint32_t(double(m_seek_range_us) * std::pow(double(dist) / double(ncyl), m_seek_exp));
+		return attotime::from_usec(us);
+	}
 
 	default:
 		return attotime::zero;

--- a/src/devices/bus/nscsi/s1410.h
+++ b/src/devices/bus/nscsi/s1410.h
@@ -13,6 +13,33 @@ class nscsi_s1410_device : public nscsi_harddisk_device
 public:
 	nscsi_s1410_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
+	// Optional, driver-supplied seek-timing model.  With no call the device keeps
+	// its legacy flat 85 ms per-command delay, so existing users (victor9k,
+	// mikromik, x37_sasi, db4105, idpartner_sasi) are unchanged.  Arguments:
+	// published seek times in microseconds (track-to-track, average,
+	// full-stroke), spindle speed (RPM), and the format's sector interleave.
+	//
+	// Examples -- the Seagate ST-506 (153 cyl, 5 MB formatted) and ST-412
+	// (306 cyl, 10 MB formatted) share the same timing specification in the
+	// ST412 OEM manual (April 1982): 3600 RPM; track-to-track 3 ms; average
+	// 85 ms; full-stroke (maximum) 205 ms with "fast seek / burst mode"
+	// (settling already included).  Sector interleave depends on the host
+	// CBIOS's format -- 1:1 for the Big Board II's Cal-Tex monitor.
+	//
+	// Configure once the controller is attached at a slot, e.g. from
+	// machine_start():
+	//
+	//   ST-506 (5 MB):
+	//     if (auto *s = dynamic_cast<nscsi_s1410_device *>(subdevice("sasi:0:s1410")))
+	//         s->set_seek_timing(3000, 85000, 205000, 3600, 1);
+	//
+	//   ST-412 (10 MB; identical parameters -- the burst-mode model adapts to
+	//   whatever physical cylinder count the CHD's GDDD metadata reports):
+	//     if (auto *s = dynamic_cast<nscsi_s1410_device *>(subdevice("sasi:0:s1410")))
+	//         s->set_seek_timing(3000, 85000, 205000, 3600, 1);
+	//
+	void set_seek_timing(uint32_t track_us, uint32_t average_us, uint32_t full_us, uint32_t rpm, uint8_t interleave);
+
 protected:
 	// SCSI status returns
 	enum {
@@ -81,6 +108,16 @@ protected:
 	virtual attotime scsi_data_command_delay() override;
 
 	uint8_t params[8];
+
+	// Seek-timing model state (set by set_seek_timing(); when m_seek_model is
+	// false the device uses the legacy flat 85 ms per-command delay).
+	bool     m_seek_model = false;
+	int      m_last_cylinder = -1;   // current head cylinder (-1 = unknown)
+	uint8_t  m_interleave = 1;       // sector interleave (1 = 1:1)
+	uint32_t m_rpm = 3600;           // spindle speed -> rotational latency
+	uint32_t m_seek_track_us = 0;    // track-to-track seek time
+	uint32_t m_seek_range_us = 0;    // full-stroke minus track-to-track
+	double   m_seek_exp = 1.0;       // seek(d) = track + range*(d/ncyl)^exp
 };
 
 DECLARE_DEVICE_TYPE(NSCSI_S1410, nscsi_s1410_device)


### PR DESCRIPTION
## Summary

Adds an optional, cylinder-aware seek-timing model to the Xebec S1410
SASI Winchester controller, mirroring the approach taken for the
DTC-510 in #15406.  No call from a driver -> behavior is **unchanged**
for the existing s1410 users (victor9k, mikromik, x37_sasi, db4105,
idpartner_sasi); they continue to see the legacy flat 85 ms
per-command delay.

## API

```c++
void set_seek_timing(uint32_t track_us,
                     uint32_t average_us,
                     uint32_t full_us,
                     uint32_t rpm,
                     uint8_t  interleave);
```

The first three arguments are the drive's published seek times in
microseconds; `rpm` is spindle speed; `interleave` is the sector
interleave of the format.  Called once after the controller is
attached at a slot, typically from `machine_start()`.

## Model

`scsi_data_command_delay()` is replaced for `READ` / `WRITE` / `SEEK`
with:

- **same cylinder** (`dist == 0`): only `rev_us * interleave / spt`,
  so sequential I/O on one cylinder pays only the rotational gap.
- **cylinder change**: `rev_us / 2` (half-revolution rotational
  latency) + `track_us` + `range_us * (dist / ncyl)^exp`.

`range_us = full_us - track_us`, and `exp` is solved from the three
calibration points so an average-length seek (~1/3 stroke) costs
exactly `average_us`.  For the ST-506/ST-412 (track 3 ms, avg 85 ms,
full 205 ms) this gives `exp ~= 0.82`, which captures the
controller's "burst mode" multi-cylinder seek: faster than naive
3 ms/cyl stepping for long seeks while remaining cheap for short
ones.

Head position is tracked across commands (`m_last_cylinder`), so
sustained sequential reads on one cylinder are no longer billed an
average seek per sector -- the dominant cost the old flat 85 ms
delay imposed.

## ST-506 and ST-412 examples

The header documents both invocations side by side.  They use
identical parameters because the controller's burst mode adapts to
the CHD's reported cylinder count via `image->get_info().cylinders`;
the 5 MB ST-506 (153 cyl) and 10 MB ST-412 (306 cyl) are
distinguished only by physical media size, not by the timing call:

```c++
// Seagate ST-506 (5 MB, 153 cyl):
if (auto *s = dynamic_cast<nscsi_s1410_device *>(subdevice("sasi:0:s1410")))
    s->set_seek_timing(3000, 85000, 205000, 3600, 1);

// Seagate ST-412 (10 MB, 306 cyl) -- identical parameters:
if (auto *s = dynamic_cast<nscsi_s1410_device *>(subdevice("sasi:0:s1410")))
    s->set_seek_timing(3000, 85000, 205000, 3600, 1);
```

Timing per the **ST412 OEM Manual (April 1982)**: 3600 RPM,
track-to-track 3 ms, average 85 ms, full-stroke (max) 205 ms with
"fast seek / burst mode" (settling already included), 32 sec/track,
256 B/sector.  Sector interleave is the host CBIOS's responsibility
-- 1:1 for the Big Board II's Cal-Tex monitor.

## Compatibility

No existing in-tree driver calls `set_seek_timing()`, so behavior for
all current s1410 users is identical: `m_seek_model` stays `false`
and the legacy `return attotime::from_msec(85)` branch is taken
unchanged.  New drivers (e.g. a Big Board II 8" SASI workstation;
work in progress out-of-tree) opt in by adding one call from
`machine_start()`.

## Validation

With a Big Board II driver calling
`set_seek_timing(3000, 85000, 205000, 3600, 1)` against a 153-cyl
ST-506 CHD, observed times match the user's first-hand experience
with the real hardware -- both the snappiness of sustained streaming
on one cylinder and the painfully-slow head movement of long seeks
("painfully slow stepper design", per the report that originally
motivated this change).

## Test plan
- [ ] `make SUBTARGET=tiny SOURCES=src/mame/xerox/bigbord2.cpp` builds
- [ ] `mame -listdevices victor9k | grep -i s1410` unchanged
- [ ] No call to `set_seek_timing()` -> `mame victor9k` floppy/HD
      behavior identical to master
- [ ] Boot a driver that opts in -> sustained read throughput on a
      single cylinder no longer pays an 85 ms-per-sector penalty;
      long random seeks bill ~205 ms
