### PR TITLE
formats/mfi_dsk: drop debug histogram dump that segfaults on small MFI

### DIFF
--- a/src/lib/formats/mfi_dsk.cpp
+++ b/src/lib/formats/mfi_dsk.cpp
@@ -216,20 +216,6 @@ bool mfi_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 			ent++;
 		}
 
-	for(int side=0; side != 2; side++)
-		for(int track=0; track!=46; track++) {
-			std::map<int, int> lengths;
-			const std::vector<uint32_t> &trackbuf = image.get_buffer(track, side, 0);
-			uint32_t cpos = 0;
-			for(uint32_t p : trackbuf) {
-				lengths[p-cpos] ++;
-				cpos = p;
-			}
-			std::ostringstream s;
-			for(const auto &e : lengths)
-				util::stream_format(s, " %d:%d", e.first, e.second);
-			util::stream_format(std::cerr, "%d.%2d:%s\n", side, track, std::move(s).str());
-		}
 	return true;
 }
 


### PR DESCRIPTION
`mfi_format::load()` ended with a debug block that dumped a per-track cell-length histogram to **stderr**, walking a hard-coded 46-track x 2-side grid. `get_buffer()` only bounds-checks with **assert** (compiled out in release builds), so on an MFI smaller than 46 tracks or single-sided the loop indexes track_array past its end and segfaults.

Remove the debug dump; `load()` now just returns once the tracks are in.