### PR TITLE
imagedev/floppy: derive twosid_r() from media variant

### DIFF
--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -940,6 +940,15 @@ bool floppy_image_device::twosid_r()
 	case floppy_image::SSQD:
 	case floppy_image::SSQD16:
 		return true;
+	case 0:
+		{
+			// The loaded format did not tag a variant; fall back to the
+			// observed geometry so formats that never call set_variant()
+			// keep their previous behaviour (no regression).
+			int tracks = 0, heads = 0;
+			m_image->get_actual_geometry(tracks, heads);
+			return heads == 1;
+		}
 	default:
 		return false;
 	}

--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -921,11 +921,28 @@ void floppy_image_device::check_led()
 
 bool floppy_image_device::twosid_r()
 {
-	int tracks = 0, heads = 0;
-
-	if (m_image) m_image->get_actual_geometry(tracks, heads);
-
-	return heads == 1;
+	// Report media-sided-ness from the variant tag, not from observed track
+	// data.  Drives sense single- vs double-sided media physically (e.g. 8"
+	// Shugart TS# on pin 30, derived from index-hole position); the answer
+	// must come from the media itself, not from whether the host happens to
+	// have written to head 1 yet.  An unformatted SSSD diskette is still SS.
+	if (!m_image)
+		return false;
+	switch (m_image->get_variant()) {
+	case floppy_image::SSSD:
+	case floppy_image::SSSD10:
+	case floppy_image::SSSD16:
+	case floppy_image::SSSD32:
+	case floppy_image::SSDD:
+	case floppy_image::SSDD10:
+	case floppy_image::SSDD16:
+	case floppy_image::SSDD32:
+	case floppy_image::SSQD:
+	case floppy_image::SSQD16:
+		return true;
+	default:
+		return false;
+	}
 }
 
 bool floppy_image_device::floppy_is_hd()


### PR DESCRIPTION
Reads media-sided-ness from the floppy_image variant tag instead of `get_actual_geometry()`.

Real drives sense single- vs double-sided physically (8" Shugart TS# on pin 30, derived from index-hole position); the signal comes from the media, not from whether the host has happened to write to head 1.

Before: a freshly-mounted unformatted SSSD image (`get_actual_geometry` returns 0 heads) reports TWO-SIDED to the host BIOS, and the answer can flip permanently once a host writes spurious data to head 1.

After: SS variants always report single-sided; DS variants always report double-sided; an unformatted SSSD diskette is correctly recognised as single-sided.

No call-site changes needed — all existing `twosid_r()` consumers and the uPD765 ST3 plumbing already do the right thing once the function returns correctly.

## Test plan

- [x] Builds clean against current `upstream/master`.
- [x] `floptool flopcreate mfi u8sssd xfer.mfi` → mount on a 2-head 8" system → BIOS now sees TWO-SIDED = false; CP/M `FORMAT` correctly produces a single-sided diskette.
