### PR TITLE
frontend: clear transient UI BIOS option without preserving command-line priority

### DIFF
--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -300,7 +300,7 @@ int mame_machine_manager::execute()
 			if (machine.exit_pending())
 			{
 				m_options.set_system_name("");
-				m_options.set_value(OPTION_BIOS, "", OPTION_PRIORITY_CMDLINE);
+				m_options.get_entry(OPTION_BIOS)->revert(OPTION_PRIORITY_CMDLINE, OPTION_PRIORITY_CMDLINE);
 			}
 		}
 


### PR DESCRIPTION
## Summary

This fixes a BIOS option priority leak when returning from an emulated machine to the internal UI.

When a machine exits, the frontend currently clears `OPTION_BIOS` by setting it to an empty value at `OPTION_PRIORITY_CMDLINE`. This was added on 2022-12-20 in aee2e13bc78e84241cf602617ee1069400886584 to fix [MAMETesters 8292](https://mametesters.org/view.php?id=8292), where a BIOS selected through the UI could remain active after exiting a Neo Geo machine and cause false ROM/CHD warnings when launching other systems.

That intent is still correct: transient BIOS selections made by the UI should be cleared when returning to the empty pseudo-driver.

However, setting `OPTION_BIOS` to an empty value at command-line priority leaves a high-priority empty BIOS option behind. On the next launch from the UI, per-machine INI files are parsed again, but their `bios` setting cannot override the existing command-line-priority empty value.

This is visible when no BIOS selection menu is shown before launching the next machine, for example with `skip_biosmenu 1` in #11313 or `ui simple` in #11314. In those cases, settings such as `kov.ini` with `bios v1` or `magdrop3.ini` with `bios us-e` can be ignored after a previous machine has been run in the same UI session.

## Fix

Revert the command-line-priority BIOS option instead of replacing it with an empty command-line-priority value.

This keeps the original intent of aee2e13 / [MAMETesters 8292](https://mametesters.org/view.php?id=8292): transient BIOS selections made by the UI are still cleared when returning to the empty pseudo-driver. The difference is that the BIOS option is no longer left as an empty value at command-line priority, so per-machine INI files can set `bios` again on the next launch.

## Tested

Manually tested the affected UI relaunch scenarios without observing a regression:

- `skip_biosmenu 1` with a machine-specific BIOS setting
- `ui simple` with a machine-specific BIOS setting
- relaunching machines from the internal UI after exiting a previous machine

## References

Fixes mamedev/mame#11313
Fixes mamedev/mame#11314

Related:

- https://mametesters.org/view.php?id=8292
- https://github.com/mamedev/mame/commit/aee2e13bc78e84241cf602617ee1069400886584

## Disclosure

This issue was diagnosed with help from ChatGPT. The actual fix is just a single frontend line, so it should be small and straightforward to review 🙂.
