### PR TITLE
imagedev/floppy: batch sequential flux writes

### DIFF
--- a/docs/source/techspecs/floppy.rst
+++ b/docs/source/techspecs/floppy.rst
@@ -409,6 +409,29 @@ A number of methods are provided to simplify writing the converter classes.
 
 The read/write interface is designed to work asynchronously, e.g. somewhat independently of the current time.
 
+**get_next_transition(from_when)**
+
+  Returns the attotime of the next flux transition after *from_when*.  Returns ``attotime::never`` when there is no upcoming transition.
+
+**write_start(when)**
+
+  Activates the write gate at time *when*.  No effect when no disk is loaded, the motor is off or the media is write-protected.
+
+**write_flux_change(when)**
+
+  Records a single flux transition at time *when*.  Buffered until a flush or end.  If *when* is not after the most recently buffered transition, later entries are discarded first; this handles speculative re-execution transparently.
+
+**write_end(when)**
+
+  Deactivates the write gate.  Buffered transitions earlier than *when* are flushed to the track with the write span ending at *when*.
+
+**write_flush(when)**
+
+  Commits buffered transitions earlier than *when* without deactivating the write gate.  Transitions at or after *when* are retained for a subsequent flush or end.
+
+**set_write_splice(when)**
+
+  Sets the track write-splice position to the angular position corresponding to *when*.
 
 
 .. [1] Cylinder is a hard-drive term somewhat improperly used for floppies.  It comes from the fact that hard-drives are similar to floppies but include a series of stacked disks with a read/write head on each.  The heads are physically linked and all point to the same circle on every disk at a given time, making the accessed area look like a cylinder.  Hence the name.

--- a/src/devices/bus/a2bus/agat_fdc.cpp
+++ b/src/devices/bus/a2bus/agat_fdc.cpp
@@ -138,9 +138,6 @@ private:
 
 	uint8_t last_6502_write;
 	bool mode_write, write_desync;
-	attotime write_start_time;
-	attotime write_buffer[32];
-	int write_position;
 
 	int m_seektime;
 	int m_waittime;
@@ -238,8 +235,6 @@ void a2bus_agat_fdc_device::device_start()
 	save_item(NAME(last_6502_write));
 	save_item(NAME(mode_write));
 	save_item(NAME(write_desync));
-	save_item(NAME(write_start_time));
-	save_item(NAME(write_position));
 }
 
 void a2bus_agat_fdc_device::device_reset()
@@ -249,8 +244,6 @@ void a2bus_agat_fdc_device::device_reset()
 	mode_write = false;
 	write_desync = false;
 	last_6502_write = 0x00;
-	write_start_time = attotime::never;
-	write_position = 0;
 }
 
 void a2bus_agat_fdc_device::reset_from_bus()
@@ -400,15 +393,6 @@ TIMER_CALLBACK_MEMBER(a2bus_agat_fdc_device::lss_sync)
 					m_d15->pc2_w(0);
 					if (mode_write)
 					{
-						if(write_position) {
-							LOGWRITE("writing %d transitions\n", write_position);
-							attotime now = cycles_to_time(cycles);
-							if(floppy)
-								floppy->write_flux(write_start_time, now, write_position, write_buffer);
-							write_start_time = now;
-							write_position = 0;
-						}
-
 						if (write_desync)
 						{
 							live_write_raw(0x2d55);
@@ -430,8 +414,10 @@ TIMER_CALLBACK_MEMBER(a2bus_agat_fdc_device::lss_sync)
 					cur_live.shift_reg <<= 2;
 					if (b)
 					{
-						if (b & 2) write_buffer[write_position++] = cycles_to_time(cycles);
-						if (b & 1) write_buffer[write_position++] = cycles_to_time(cycles + 8);
+						if (floppy && (b & 2))
+							floppy->write_flux_change(cycles_to_time(cycles));
+						if (floppy && (b & 1))
+							floppy->write_flux_change(cycles_to_time(cycles + 8));
 					}
 				}
 			}
@@ -588,6 +574,8 @@ uint8_t a2bus_agat_fdc_device::d14_i_b()
 void a2bus_agat_fdc_device::d14_o_c(uint8_t data)
 {
 	const bool new_write = BIT(data, 6) & BIT(data, 7);
+	const attotime now = machine().time();
+	floppy_image_device *const old_floppy = floppy;
 	m_unit = BIT(data, 3);
 
 	switch (m_unit)
@@ -598,6 +586,13 @@ void a2bus_agat_fdc_device::d14_o_c(uint8_t data)
 	case 1:
 		floppy = floppy1 ? floppy1->get_device() : nullptr;
 		break;
+	}
+
+	if (mode_write && old_floppy != floppy)
+	{
+		if (old_floppy)
+			old_floppy->write_end(now);
+		mode_write = false;
 	}
 
 	if (floppy)
@@ -617,10 +612,10 @@ void a2bus_agat_fdc_device::d14_o_c(uint8_t data)
 		LOGWRITE("n_w %d (%d)\n", new_write, mode_write);
 		address |= 0x100;
 		if(!mode_write) {
-			write_start_time = machine().time();
-			write_position = 0;
-			if(floppy)
-				floppy->set_write_splice(write_start_time);
+			if(floppy) {
+				floppy->set_write_splice(now);
+				floppy->write_start(now);
+			}
 			mode_write = true;
 		}
 	}
@@ -628,9 +623,9 @@ void a2bus_agat_fdc_device::d14_o_c(uint8_t data)
 	{
 		address &= 0xff;
 		if(mode_write) {
-			LOGWRITE("write->read: writing %d transitions\n", write_position);
-			if(floppy && write_position)
-				floppy->write_flux(write_start_time, machine().time(), write_position, write_buffer);
+			LOGWRITE("write->read\n");
+			if(floppy)
+				floppy->write_end(now);
 			mode_write = false;
 		}
 	}

--- a/src/devices/bus/hp9845_io/hp9885.cpp
+++ b/src/devices/bus/hp9845_io/hp9885.cpp
@@ -430,7 +430,7 @@ TIMER_CALLBACK_MEMBER(hp9885_device::bit_byte_tick)
 						} else {
 							m_word_cnt = 130;
 							set_state(FSM_WR_DATA);
-							m_pll.start_writing(m_pll.ctime);
+							m_pll.start_writing(m_pll.ctime, m_drive);
 							m_had_transition = false;
 							wr_word(m_input);
 							set_ibf(false);
@@ -624,7 +624,7 @@ void hp9885_device::floppy_index_cb(floppy_image_device *floppy , int state)
 			// See bit_byte_tick function
 			m_word_cnt = 167;
 			m_pll.set_clock(attotime::from_usec(HALF_CELL_US));
-			m_pll.start_writing(machine().time());
+			m_pll.start_writing(machine().time(), m_drive);
 			m_pll.read_reset(machine().time());
 			m_had_transition = false;
 			// Start by writing 1st sync word

--- a/src/devices/bus/ieee488/c2040fdc.cpp
+++ b/src/devices/bus/ieee488/c2040fdc.cpp
@@ -93,8 +93,6 @@ c2040_fdc_device::c2040_fdc_device(const machine_config &mconfig, const char *ta
 	cur_live.tm = attotime::never;
 	cur_live.state = IDLE;
 	cur_live.next_state = -1;
-	cur_live.write_position = 0;
-	cur_live.write_start_time = attotime::never;
 	cur_live.drv_sel = m_drv_sel;
 }
 
@@ -194,29 +192,24 @@ void c2040_fdc_device::rollback()
 
 void c2040_fdc_device::start_writing(const attotime &tm)
 {
-	cur_live.write_start_time = tm;
-	cur_live.write_position = 0;
+	if(get_floppy())
+		get_floppy()->write_start(tm);
 }
 
 void c2040_fdc_device::stop_writing(const attotime &tm)
 {
-	commit(tm);
-	cur_live.write_start_time = attotime::never;
+	if(get_floppy())
+		get_floppy()->write_end(tm);
 }
 
 bool c2040_fdc_device::write_next_bit(bool bit, const attotime &limit)
 {
-	if(cur_live.write_start_time.is_never()) {
-		cur_live.write_start_time = cur_live.tm;
-		cur_live.write_position = 0;
-	}
-
 	attotime etime = cur_live.tm + m_period;
 	if(etime > limit)
 		return true;
 
-	if(bit && cur_live.write_position < std::size(cur_live.write_buffer))
-		cur_live.write_buffer[cur_live.write_position++] = cur_live.tm - m_period;
+	if(bit && get_floppy())
+		get_floppy()->write_flux_change(cur_live.tm - m_period);
 
 	if (LOG) logerror("%s write bit %u (%u)\n", cur_live.tm.as_string(), cur_live.bit_counter, bit);
 
@@ -225,16 +218,8 @@ bool c2040_fdc_device::write_next_bit(bool bit, const attotime &limit)
 
 void c2040_fdc_device::commit(const attotime &tm)
 {
-	if(cur_live.write_start_time.is_never() || tm == cur_live.write_start_time || !cur_live.write_position)
-		return;
-
-	if (LOG) logerror("%s committing %u transitions since %s\n", tm.as_string(), cur_live.write_position, cur_live.write_start_time.as_string());
-
 	if(get_floppy())
-		get_floppy()->write_flux(cur_live.write_start_time, tm, cur_live.write_position, cur_live.write_buffer);
-
-	cur_live.write_start_time = tm;
-	cur_live.write_position = 0;
+		get_floppy()->write_flush(tm);
 }
 
 void c2040_fdc_device::live_delay(int state)
@@ -281,8 +266,6 @@ void c2040_fdc_device::live_abort()
 	cur_live.tm = attotime::never;
 	cur_live.state = IDLE;
 	cur_live.next_state = -1;
-	cur_live.write_position = 0;
-	cur_live.write_start_time = attotime::never;
 
 	cur_live.ready = 1;
 	cur_live.sync = 1;

--- a/src/devices/bus/ieee488/c2040fdc.h
+++ b/src/devices/bus/ieee488/c2040fdc.h
@@ -81,9 +81,6 @@ protected:
 
 		uint8_t pi;
 		uint16_t shift_reg_write;
-		attotime write_start_time;
-		attotime write_buffer[32];
-		int write_position;
 	};
 
 	// device_t implementation

--- a/src/devices/bus/ieee488/c8050fdc.cpp
+++ b/src/devices/bus/ieee488/c8050fdc.cpp
@@ -252,9 +252,9 @@ void c8050_fdc_device::pll_reset(const attotime &when)
 	cur_pll.set_clock(attotime::from_hz(clock() / (16 - m_ds)));
 }
 
-void c8050_fdc_device::pll_start_writing(const attotime &tm)
+void c8050_fdc_device::pll_start_writing(const attotime &tm, floppy_image_device *floppy)
 {
-	cur_pll.start_writing(tm);
+	cur_pll.start_writing(tm, floppy);
 	pll_reset(cur_live.tm);
 }
 
@@ -558,7 +558,7 @@ void c8050_fdc_device::rw_sel_w(int state)
 		if (m_rw_sel) {
 			pll_stop_writing(get_floppy(), cur_live.tm);
 		} else {
-			pll_start_writing(cur_live.tm);
+			pll_start_writing(cur_live.tm, get_floppy());
 		}
 		live_run();
 	}

--- a/src/devices/bus/ieee488/c8050fdc.h
+++ b/src/devices/bus/ieee488/c8050fdc.h
@@ -101,7 +101,7 @@ protected:
 	void checkpoint();
 	void rollback();
 	void pll_reset(const attotime &when);
-	void pll_start_writing(const attotime &tm);
+	void pll_start_writing(const attotime &tm, floppy_image_device *floppy);
 	void pll_commit(floppy_image_device *floppy, const attotime &tm);
 	void pll_stop_writing(floppy_image_device *floppy, const attotime &tm);
 	int pll_get_next_bit(attotime &tm, floppy_image_device *floppy, const attotime &limit);

--- a/src/devices/bus/ieee488/hp9895.cpp
+++ b/src/devices/bus/ieee488/hp9895.cpp
@@ -255,6 +255,10 @@ private:
 
 	// PLL
 	fdc_pll_t m_pll;
+
+	// Write loopback buffer for read-during-write verification
+	attotime m_loopback_buf[32];
+	int m_loopback_pos;
 };
 
 hp9895_device::hp9895_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
@@ -315,6 +319,8 @@ void hp9895_device::device_start()
 	save_item(NAME(m_sync_cnt));
 	save_item(NAME(m_hiden));
 	save_item(NAME(m_mgnena));
+	save_item(NAME(m_loopback_buf));
+	save_item(NAME(m_loopback_pos));
 
 	m_timeout_timer = timer_alloc(FUNC(hp9895_device::timeout_timer_tick), this);
 	m_byte_timer = timer_alloc(FUNC(hp9895_device::byte_timer_tick), this);
@@ -349,6 +355,7 @@ void hp9895_device::device_reset()
 	m_sync_cnt = 0;
 	m_hiden = false;
 	m_mgnena = false;
+	m_loopback_pos = 0;
 	m_timeout_timer->reset();
 	m_byte_timer->reset();
 	m_half_bit_timer->reset();
@@ -390,6 +397,7 @@ TIMER_CALLBACK_MEMBER(hp9895_device::byte_timer_tick)
 		// Writing
 		m_pll.commit(get_write_device() , sdok_time);
 		m_pll.ctime = sdok_time;
+		m_loopback_pos = 0;
 
 		// Check for AMDT when in loopback mode
 		if (!m_lckup && !m_amdt && BIT(m_cntl_reg , REG_CNTL_READON_BIT)) {
@@ -687,7 +695,8 @@ void hp9895_device::cntl_w(uint8_t data)
 		if (!old_writon && new_writon) {
 			// Writing enabled
 			LOGMASKED(LOG_LEVEL0, "Start writing\n");
-			m_pll.start_writing(machine().time());
+			m_pll.start_writing(machine().time(), get_write_device());
+			m_loopback_pos = 0;
 			m_wr_context = 0;
 			m_had_transition = false;
 		} else if (old_writon && !new_writon) {
@@ -896,10 +905,9 @@ void hp9895_device::get_next_transition(const attotime& from_when , attotime& ed
 	edge = attotime::never;
 
 	if (BIT(m_cntl_reg , REG_CNTL_WRITON_BIT)) {
-		// Loop back write transitions into reading data path
-		for (int idx = 0; idx < m_pll.write_position; idx++) {
-			if (m_pll.write_buffer[ idx ] >= from_when) {
-				edge = m_pll.write_buffer[ idx ];
+		for (int idx = 0; idx < m_loopback_pos; idx++) {
+			if (m_loopback_buf[idx] >= from_when) {
+				edge = m_loopback_buf[idx];
 				break;
 			}
 		}
@@ -946,9 +954,14 @@ void hp9895_device::write_bit(bool data_bit , bool clock_bit)
 	// else... IBM mode, nothing to do
 
 	attotime dummy;
+	floppy_image_device *wd = get_write_device();
 
-	m_pll.write_next_bit(clock_bit , dummy , nullptr , attotime::never);
-	m_pll.write_next_bit(data_bit , dummy , nullptr , attotime::never);
+	if(clock_bit && m_loopback_pos < int(std::size(m_loopback_buf)))
+		m_loopback_buf[m_loopback_pos++] = m_pll.ctime + m_pll.period/2;
+	m_pll.write_next_bit(clock_bit , dummy , wd , attotime::never);
+	if(data_bit && m_loopback_pos < int(std::size(m_loopback_buf)))
+		m_loopback_buf[m_loopback_pos++] = m_pll.ctime + m_pll.period/2;
+	m_pll.write_next_bit(data_bit , dummy , wd , attotime::never);
 }
 
 ROM_START(hp9895)

--- a/src/devices/bus/multibus/isbc202.cpp
+++ b/src/devices/bus/multibus/isbc202.cpp
@@ -1074,7 +1074,7 @@ void isbc202_device::set_rd_wr(bool new_rd , bool new_wr)
 		// Start writing
 		LOG_WR("Start WR\n");
 		m_pll.set_clock(attotime::from_usec(HALF_BIT_CELL_US));
-		m_pll.start_writing(machine().time());
+		m_pll.start_writing(machine().time(), m_current_drive);
 		m_pll.ctime = machine().time();
 		m_last_data_bit = false;
 		m_byte_timer->adjust(attotime::from_usec(HALF_BIT_CELL_US * 14));

--- a/src/devices/bus/s100/vectordualmode.cpp
+++ b/src/devices/bus/s100/vectordualmode.cpp
@@ -238,6 +238,12 @@ void s100_vector_dualmode_device::start_of_sector()
 		// op completed
 		m_byte_timer->enable(false);
 		m_busy = false;
+		if(m_fdd_writing) {
+			floppy_image_device *floppy = m_floppy[m_drive]->get_device();
+			if(floppy)
+				floppy->write_end(machine().time());
+			m_fdd_writing = false;
+		}
 		if (m_read)
 			m_ram[274] = 0; // Ignore ECC
 		return;
@@ -258,6 +264,10 @@ void s100_vector_dualmode_device::start_of_sector()
 				m_byte_timer->adjust(tm - machine().time());
 			}
 		} else {
+			floppy_image_device *floppy = m_floppy[m_drive]->get_device();
+			if(floppy)
+				floppy->write_start(machine().time());
+			m_fdd_writing = true;
 			m_pending_size = 0;
 			m_byte_timer->adjust(attotime::zero);
 		}
@@ -277,18 +287,16 @@ TIMER_CALLBACK_MEMBER(s100_vector_dualmode_device::byte_cb)
 		m_byte_timer->adjust(tm - machine().time());
 	} else {
 		if (m_pending_size == 16) {
-			attotime start_time = machine().time() - half_bitcell_size*m_pending_size;
-			attotime tm = start_time + attotime::from_usec(1);
-			attotime buf[8];
-			int pos = 0;
-			while (m_pending_size) {
-				if (m_pending_byte & (1 << --m_pending_size))
-					buf[pos++] = tm;
-				tm += half_bitcell_size;
-			}
+			attotime tm = machine().time() - half_bitcell_size*m_pending_size + attotime::from_usec(1);
 			floppy_image_device *floppy = m_floppy[m_drive]->get_device();
-			if (floppy)
-				floppy->write_flux(start_time, machine().time(), pos, buf);
+			if(floppy) {
+				while (m_pending_size) {
+					if (m_pending_byte & (1 << --m_pending_size))
+						floppy->write_flux_change(tm);
+					tm += half_bitcell_size;
+				}
+			} else
+				m_pending_size = 0;
 		}
 		uint8_t last = m_cmar ? m_ram[m_cmar-1] : 0;
 		m_pending_byte = mfm_byte(m_ram[m_cmar++], last);
@@ -314,6 +322,7 @@ void s100_vector_dualmode_device::device_start()
 	save_item(NAME(m_sector));
 	save_item(NAME(m_fdd_sector_counter));
 	save_item(NAME(m_read));
+	save_item(NAME(m_fdd_writing));
 	save_item(NAME(m_busy));
 	save_item(NAME(m_last_sector_pulse));
 	save_item(NAME(m_pending_byte));
@@ -328,6 +337,7 @@ void s100_vector_dualmode_device::device_reset()
 	// U18
 	m_sector = 0;
 	m_read = false;
+	m_fdd_writing = false;
 	// U60
 	m_motor_on_timer->enable(false);
 }

--- a/src/devices/bus/s100/vectordualmode.h
+++ b/src/devices/bus/s100/vectordualmode.h
@@ -39,6 +39,7 @@ private:
 	uint8_t m_sector;
 	uint8_t m_fdd_sector_counter;
 	bool m_read;
+	bool m_fdd_writing;
 	bool m_busy;
 	emu_timer *m_motor_on_timer;
 	attotime m_last_sector_pulse; // fdd

--- a/src/devices/bus/vtech/memexp/floppy.cpp
+++ b/src/devices/bus/vtech/memexp/floppy.cpp
@@ -102,7 +102,7 @@ vtech_floppy_controller_device::vtech_floppy_controller_device(const machine_con
 	vtech_memexp_device(mconfig, VTECH_FLOPPY_CONTROLLER, tag, owner, clock),
 	m_memexp(*this, "mem"),
 	m_floppy(*this, "%u", 0U),
-	m_selected_floppy(nullptr), m_latch(0), m_shifter(0), m_latching_inverter(false), m_current_cyl(0), m_write_position(0)
+	m_selected_floppy(nullptr), m_latch(0), m_shifter(0), m_latching_inverter(false), m_current_cyl(0)
 {
 }
 
@@ -120,10 +120,8 @@ void vtech_floppy_controller_device::device_start()
 	save_item(NAME(m_latching_inverter));
 	save_item(NAME(m_current_cyl));
 	save_item(NAME(m_last_latching_inverter_update_time));
-	save_item(NAME(m_write_start_time));
-	save_item(NAME(m_write_position));
 
-	// TODO: save m_write_buffer and rebuild m_selected_floppy after load
+	// TODO: rebuild m_selected_floppy after load
 
 	// Obvious bugs... must have worked by sheer luck and very subtle
 	// timings.  Our current z80 is not subtle enough.
@@ -144,9 +142,6 @@ void vtech_floppy_controller_device::device_reset()
 	m_shifter = 0x00;
 	m_latching_inverter = false;
 	m_last_latching_inverter_update_time = machine().time();
-	m_write_start_time = attotime::never;
-	m_write_position = 0;
-	std::fill(std::begin(m_write_buffer), std::end(m_write_buffer), attotime::zero);
 }
 
 
@@ -173,8 +168,8 @@ void vtech_floppy_controller_device::latch_w(uint8_t data)
 
 	if(newflop != m_selected_floppy) {
 		update_latching_inverter();
-		flush_writes();
 		if(m_selected_floppy) {
+			m_selected_floppy->write_end(machine().time());
 			m_selected_floppy->mon_w(1);
 			m_selected_floppy->setup_index_pulse_cb(floppy_image_device::index_pulse_cb());
 		}
@@ -205,23 +200,19 @@ void vtech_floppy_controller_device::latch_w(uint8_t data)
 
 	if(diff & 0x40) {
 		if(!(m_latch & 0x40)) {
-			m_write_start_time = machine().time();
-			m_write_position = 0;
-			if(m_selected_floppy)
-				m_selected_floppy->set_write_splice(m_write_start_time);
-
+			if(m_selected_floppy) {
+				m_selected_floppy->write_start(machine().time());
+				m_selected_floppy->set_write_splice(machine().time());
+			}
 		} else {
 			update_latching_inverter();
-			flush_writes();
-			m_write_start_time = attotime::never;
+			if(m_selected_floppy)
+				m_selected_floppy->write_end(machine().time());
 		}
 	}
 	if(!(m_latch & 0x40) && (diff & 0x20)) {
-		if(m_write_position == std::size(m_write_buffer)) {
-			update_latching_inverter();
-			flush_writes(true);
-		}
-		m_write_buffer[m_write_position++] = machine().time();
+		if(m_selected_floppy)
+			m_selected_floppy->write_flux_change(machine().time());
 	}
 }
 
@@ -282,43 +273,6 @@ void vtech_floppy_controller_device::update_latching_inverter()
 void vtech_floppy_controller_device::index_callback(floppy_image_device *floppy, int state)
 {
 	update_latching_inverter();
-	flush_writes(true);
-}
-
-void vtech_floppy_controller_device::flush_writes(bool keep_margin)
-{
-	if(!m_selected_floppy || m_write_start_time == attotime::never)
-		return;
-
-	// Beware of time travel.  Index pulse callback (which flushes)
-	// can be called with a machine().time() inferior to the last
-	// m_write_buffer value if the calling cpu instructions are not
-	// suspendable.
-
-	attotime limit = machine().time();
-	int kept_pos = m_write_position;
-	int kept_count = 0;
-	while(kept_pos > 0 && m_write_buffer[kept_pos-1] >= limit) {
-		kept_pos--;
-		kept_count++;
-	}
-
-	if(keep_margin) {
-		attotime last = kept_pos ? m_write_buffer[kept_pos-1] : m_write_start_time;
-		attotime delta = limit-last;
-		delta = delta / 2;
-		limit = limit - delta;
-	}
-	m_write_position -= kept_count;
-	if(m_write_position && m_write_buffer[0] == m_write_start_time) {
-		if(m_write_position)
-			std::copy_n(m_write_buffer + 1, m_write_position - 1, m_write_buffer);
-		m_write_position--;
-	}
-	m_selected_floppy->write_flux(m_write_start_time, limit, m_write_position, m_write_buffer);
-	m_write_start_time = limit;
-
-	if(kept_count != 0)
-		std::copy_n(m_write_buffer + kept_pos, kept_count, m_write_buffer);
-	m_write_position = kept_count;
+	if(m_selected_floppy)
+		m_selected_floppy->write_flush(machine().time());
 }

--- a/src/devices/bus/vtech/memexp/floppy.h
+++ b/src/devices/bus/vtech/memexp/floppy.h
@@ -53,14 +53,11 @@ private:
 
 	void index_callback(floppy_image_device *floppy, int state);
 	void update_latching_inverter();
-	void flush_writes(bool keep_margin = false);
 
 	uint8_t m_latch, m_shifter;
 	bool m_latching_inverter;
 	int m_current_cyl;
 	attotime m_last_latching_inverter_update_time;
-	attotime m_write_start_time, m_write_buffer[32];
-	int m_write_position;
 };
 
 // device type definition

--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -297,12 +297,10 @@ floppy_image_device::floppy_image_device(const machine_config &mconfig, device_t
 	m_amplifier_freakout_time(attotime::from_usec(16)),
 	m_image_dirty(false),
 	m_track_dirty(false),
-	m_pending_write(false),
-	m_pending_write_cyl(0),
-	m_pending_write_ss(0),
-	m_pending_write_subcyl(0),
-	m_pending_write_start(0),
-	m_pending_write_end(0),
+	m_writing(false),
+	m_write_cyl(0),
+	m_write_ss(0),
+	m_write_subcyl(0),
 	m_ready_counter(0),
 	m_make_sound(false),
 	m_sound_out(*this, FLOPSND_TAG)
@@ -508,7 +506,8 @@ void floppy_image_device::setup_write(const floppy_image_format_t *_output_forma
 
 void floppy_image_device::commit_image()
 {
-	flush_pending_write();
+	if(m_writing)
+		write_do_flush(machine().time());
 	m_image_dirty = false;
 	if(!m_output_format || !m_output_format->supports_save())
 		return;
@@ -655,8 +654,8 @@ std::pair<std::error_condition, const floppy_image_format_t *> floppy_image_devi
 void floppy_image_device::init_floppy_load(bool write_supported)
 {
 	cache_clear();
-	m_pending_write = false;
-	m_pending_write_flux_change_positions.clear();
+	m_writing = false;
+	m_write_transition_times.clear();
 	m_revolution_start_time = m_mon ? attotime::never : machine().time();
 	m_revolution_count = 0;
 
@@ -1101,7 +1100,8 @@ void floppy_image_device::cache_clear()
 
 void floppy_image_device::cache_fill(const attotime &when)
 {
-	flush_pending_write();
+	if(m_writing)
+		write_do_flush(when);
 	std::vector<uint32_t> &buf = m_image->get_buffer(m_cyl, m_ss, m_subcyl);
 	uint32_t const cells = buf.size();
 	if(cells <= 1) {
@@ -1188,7 +1188,7 @@ bool floppy_image_device::writing_disabled() const
 	return m_wpt || (m_phases & 2);
 }
 
-void floppy_image_device::write_flux(const attotime &start, const attotime &end, int transition_count, const attotime *transitions)
+void floppy_image_device::write_start(const attotime &when)
 {
 	if(!m_image || m_mon)
 		return;
@@ -1196,53 +1196,76 @@ void floppy_image_device::write_flux(const attotime &start, const attotime &end,
 	if(writing_disabled())
 		return;
 
+	if(m_writing)
+		write_do_flush(when);
+
+	m_writing = true;
+	m_write_cyl = m_cyl;
+	m_write_ss = m_ss;
+	m_write_subcyl = m_subcyl;
+	m_write_start_time = when;
+	m_write_transition_times.clear();
 	m_image_dirty = true;
 	m_track_dirty = true;
-	cache_clear();
-
-	std::vector<wspan> wspans(1);
-
-	attotime base;
-	wspans[0].start = find_position(base, start);
-	wspans[0].end   = find_position(base, end);
-
-	for(int i=0; i != transition_count; i++)
-		wspans[0].flux_change_positions.push_back(find_position(base, transitions[i]));
-
-	wspan_split_on_wrap(wspans);
-
-	for(const auto &ws : wspans) {
-		if(!m_pending_write || m_pending_write_cyl != m_cyl || m_pending_write_ss != m_ss || m_pending_write_subcyl != m_subcyl || m_pending_write_end != ws.start) {
-			flush_pending_write();
-			m_pending_write = true;
-			m_pending_write_cyl = m_cyl;
-			m_pending_write_ss = m_ss;
-			m_pending_write_subcyl = m_subcyl;
-			m_pending_write_start = ws.start;
-			m_pending_write_end = ws.start;
-			m_pending_write_flux_change_positions.clear();
-		}
-
-		m_pending_write_end = ws.end;
-		m_pending_write_flux_change_positions.insert(
-				m_pending_write_flux_change_positions.end(),
-				ws.flux_change_positions.begin(),
-				ws.flux_change_positions.end());
-	}
 }
 
-
-void floppy_image_device::flush_pending_write()
+void floppy_image_device::write_flux_change(const attotime &when)
 {
-	if(!m_pending_write)
+	if(!m_writing)
+		return;
+
+	// Some controllers speculatively run ahead of machine time then
+	// replay from an earlier point.  Discard stale entries so the
+	// replayed transitions replace them cleanly.
+	if(!m_write_transition_times.empty() && when <= m_write_transition_times.back()) {
+		auto it = std::lower_bound(m_write_transition_times.begin(), m_write_transition_times.end(), when);
+		m_write_transition_times.erase(it, m_write_transition_times.end());
+	}
+	// Best-effort rewind if replay crosses a flush boundary.  Does not
+	// reconstruct transitions already committed to the track, but no
+	// current controller replays across a committed flush point.
+	if(when < m_write_start_time)
+		m_write_start_time = when;
+	m_write_transition_times.push_back(when);
+}
+
+void floppy_image_device::write_end(const attotime &when)
+{
+	if(!m_writing)
+		return;
+
+	write_do_flush(when);
+	m_writing = false;
+}
+
+void floppy_image_device::write_flush(const attotime &when)
+{
+	if(!m_writing)
+		return;
+
+	write_do_flush(when);
+}
+
+void floppy_image_device::write_do_flush(const attotime &when)
+{
+	int committed = 0;
+	for(int i = 0; i != int(m_write_transition_times.size()); i++)
+		if(m_write_transition_times[i] < when)
+			committed = i + 1;
+
+	if(when == m_write_start_time && !committed)
 		return;
 
 	std::vector<wspan> wspans(1);
-	wspans[0].start = m_pending_write_start;
-	wspans[0].end = m_pending_write_end;
-	wspans[0].flux_change_positions.swap(m_pending_write_flux_change_positions);
+	attotime base;
+	wspans[0].start = find_position(base, m_write_start_time);
+	wspans[0].end = find_position(base, when);
+	for(int i = 0; i != committed; i++)
+		wspans[0].flux_change_positions.push_back(find_position(base, m_write_transition_times[i]));
 
-	std::vector<uint32_t> &buf = m_image->get_buffer(m_pending_write_cyl, m_pending_write_ss, m_pending_write_subcyl);
+	wspan_split_on_wrap(wspans);
+
+	std::vector<uint32_t> &buf = m_image->get_buffer(m_write_cyl, m_write_ss, m_write_subcyl);
 	if(buf.empty()) {
 		buf.push_back(floppy_image::MG_N);
 		buf.push_back(floppy_image::MG_E | 199999999);
@@ -1251,7 +1274,9 @@ void floppy_image_device::flush_pending_write()
 	wspan_remove_damaged(wspans, buf);
 	wspan_write(wspans, buf);
 
-	m_pending_write = false;
+	if(committed)
+		m_write_transition_times.erase(m_write_transition_times.begin(), m_write_transition_times.begin() + committed);
+	m_write_start_time = when;
 	cache_clear();
 }
 
@@ -1378,7 +1403,8 @@ void floppy_image_device::wspan_write(const std::vector<wspan> &wspans, std::vec
 void floppy_image_device::set_write_splice(const attotime &when)
 {
 	if(m_image && !m_mon) {
-		flush_pending_write();
+		if(m_writing)
+			write_do_flush(when);
 		m_image_dirty = true;
 		attotime base;
 		int splice_pos = find_position(base, when);

--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -297,6 +297,12 @@ floppy_image_device::floppy_image_device(const machine_config &mconfig, device_t
 	m_amplifier_freakout_time(attotime::from_usec(16)),
 	m_image_dirty(false),
 	m_track_dirty(false),
+	m_pending_write(false),
+	m_pending_write_cyl(0),
+	m_pending_write_ss(0),
+	m_pending_write_subcyl(0),
+	m_pending_write_start(0),
+	m_pending_write_end(0),
 	m_ready_counter(0),
 	m_make_sound(false),
 	m_sound_out(*this, FLOPSND_TAG)
@@ -502,6 +508,7 @@ void floppy_image_device::setup_write(const floppy_image_format_t *_output_forma
 
 void floppy_image_device::commit_image()
 {
+	flush_pending_write();
 	m_image_dirty = false;
 	if(!m_output_format || !m_output_format->supports_save())
 		return;
@@ -648,6 +655,8 @@ std::pair<std::error_condition, const floppy_image_format_t *> floppy_image_devi
 void floppy_image_device::init_floppy_load(bool write_supported)
 {
 	cache_clear();
+	m_pending_write = false;
+	m_pending_write_flux_change_positions.clear();
 	m_revolution_start_time = m_mon ? attotime::never : machine().time();
 	m_revolution_count = 0;
 
@@ -1092,6 +1101,7 @@ void floppy_image_device::cache_clear()
 
 void floppy_image_device::cache_fill(const attotime &when)
 {
+	flush_pending_write();
 	std::vector<uint32_t> &buf = m_image->get_buffer(m_cyl, m_ss, m_subcyl);
 	uint32_t const cells = buf.size();
 	if(cells <= 1) {
@@ -1201,8 +1211,38 @@ void floppy_image_device::write_flux(const attotime &start, const attotime &end,
 
 	wspan_split_on_wrap(wspans);
 
-	std::vector<uint32_t> &buf = m_image->get_buffer(m_cyl, m_ss, m_subcyl);
+	for(const auto &ws : wspans) {
+		if(!m_pending_write || m_pending_write_cyl != m_cyl || m_pending_write_ss != m_ss || m_pending_write_subcyl != m_subcyl || m_pending_write_end != ws.start) {
+			flush_pending_write();
+			m_pending_write = true;
+			m_pending_write_cyl = m_cyl;
+			m_pending_write_ss = m_ss;
+			m_pending_write_subcyl = m_subcyl;
+			m_pending_write_start = ws.start;
+			m_pending_write_end = ws.start;
+			m_pending_write_flux_change_positions.clear();
+		}
 
+		m_pending_write_end = ws.end;
+		m_pending_write_flux_change_positions.insert(
+				m_pending_write_flux_change_positions.end(),
+				ws.flux_change_positions.begin(),
+				ws.flux_change_positions.end());
+	}
+}
+
+
+void floppy_image_device::flush_pending_write()
+{
+	if(!m_pending_write)
+		return;
+
+	std::vector<wspan> wspans(1);
+	wspans[0].start = m_pending_write_start;
+	wspans[0].end = m_pending_write_end;
+	wspans[0].flux_change_positions.swap(m_pending_write_flux_change_positions);
+
+	std::vector<uint32_t> &buf = m_image->get_buffer(m_pending_write_cyl, m_pending_write_ss, m_pending_write_subcyl);
 	if(buf.empty()) {
 		buf.push_back(floppy_image::MG_N);
 		buf.push_back(floppy_image::MG_E | 199999999);
@@ -1211,6 +1251,7 @@ void floppy_image_device::write_flux(const attotime &start, const attotime &end,
 	wspan_remove_damaged(wspans, buf);
 	wspan_write(wspans, buf);
 
+	m_pending_write = false;
 	cache_clear();
 }
 
@@ -1337,6 +1378,7 @@ void floppy_image_device::wspan_write(const std::vector<wspan> &wspans, std::vec
 void floppy_image_device::set_write_splice(const attotime &when)
 {
 	if(m_image && !m_mon) {
+		flush_pending_write();
 		m_image_dirty = true;
 		attotime base;
 		int splice_pos = find_position(base, when);

--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -293,6 +293,12 @@ floppy_image_device::floppy_image_device(const machine_config &mconfig, device_t
 	m_amplifier_freakout_time(attotime::from_usec(16)),
 	m_image_dirty(false),
 	m_track_dirty(false),
+	m_pending_write(false),
+	m_pending_write_cyl(0),
+	m_pending_write_ss(0),
+	m_pending_write_subcyl(0),
+	m_pending_write_start(0),
+	m_pending_write_end(0),
 	m_ready_counter(0),
 	m_make_sound(false),
 	m_sound_out(*this, FLOPSND_TAG)
@@ -498,6 +504,7 @@ void floppy_image_device::setup_write(const floppy_image_format_t *_output_forma
 
 void floppy_image_device::commit_image()
 {
+	flush_pending_write();
 	m_image_dirty = false;
 	if(!m_output_format || !m_output_format->supports_save())
 		return;
@@ -649,6 +656,8 @@ std::pair<std::error_condition, const floppy_image_format_t *> floppy_image_devi
 void floppy_image_device::init_floppy_load(bool write_supported)
 {
 	cache_clear();
+	m_pending_write = false;
+	m_pending_write_flux_change_positions.clear();
 	m_revolution_start_time = m_mon ? attotime::never : machine().time();
 	m_revolution_count = 0;
 
@@ -1125,6 +1134,7 @@ void floppy_image_device::cache_clear()
 
 void floppy_image_device::cache_fill(const attotime &when)
 {
+	flush_pending_write();
 	std::vector<uint32_t> &buf = m_image->get_buffer(m_cyl, m_ss, m_subcyl);
 	uint32_t const cells = buf.size();
 	if(cells <= 1) {
@@ -1234,8 +1244,38 @@ void floppy_image_device::write_flux(const attotime &start, const attotime &end,
 
 	wspan_split_on_wrap(wspans);
 
-	std::vector<uint32_t> &buf = m_image->get_buffer(m_cyl, m_ss, m_subcyl);
+	for(const auto &ws : wspans) {
+		if(!m_pending_write || m_pending_write_cyl != m_cyl || m_pending_write_ss != m_ss || m_pending_write_subcyl != m_subcyl || m_pending_write_end != ws.start) {
+			flush_pending_write();
+			m_pending_write = true;
+			m_pending_write_cyl = m_cyl;
+			m_pending_write_ss = m_ss;
+			m_pending_write_subcyl = m_subcyl;
+			m_pending_write_start = ws.start;
+			m_pending_write_end = ws.start;
+			m_pending_write_flux_change_positions.clear();
+		}
 
+		m_pending_write_end = ws.end;
+		m_pending_write_flux_change_positions.insert(
+				m_pending_write_flux_change_positions.end(),
+				ws.flux_change_positions.begin(),
+				ws.flux_change_positions.end());
+	}
+}
+
+
+void floppy_image_device::flush_pending_write()
+{
+	if(!m_pending_write)
+		return;
+
+	std::vector<wspan> wspans(1);
+	wspans[0].start = m_pending_write_start;
+	wspans[0].end = m_pending_write_end;
+	wspans[0].flux_change_positions.swap(m_pending_write_flux_change_positions);
+
+	std::vector<uint32_t> &buf = m_image->get_buffer(m_pending_write_cyl, m_pending_write_ss, m_pending_write_subcyl);
 	if(buf.empty()) {
 		buf.push_back(floppy_image::MG_N);
 		buf.push_back(floppy_image::MG_E | 199999999);
@@ -1244,6 +1284,7 @@ void floppy_image_device::write_flux(const attotime &start, const attotime &end,
 	wspan_remove_damaged(wspans, buf);
 	wspan_write(wspans, buf);
 
+	m_pending_write = false;
 	cache_clear();
 }
 
@@ -1370,6 +1411,7 @@ void floppy_image_device::wspan_write(const std::vector<wspan> &wspans, std::vec
 void floppy_image_device::set_write_splice(const attotime &when)
 {
 	if(m_image && !m_mon) {
+		flush_pending_write();
 		m_image_dirty = true;
 		attotime base;
 		int splice_pos = find_position(base, when);

--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -293,12 +293,10 @@ floppy_image_device::floppy_image_device(const machine_config &mconfig, device_t
 	m_amplifier_freakout_time(attotime::from_usec(16)),
 	m_image_dirty(false),
 	m_track_dirty(false),
-	m_pending_write(false),
-	m_pending_write_cyl(0),
-	m_pending_write_ss(0),
-	m_pending_write_subcyl(0),
-	m_pending_write_start(0),
-	m_pending_write_end(0),
+	m_writing(false),
+	m_write_cyl(0),
+	m_write_ss(0),
+	m_write_subcyl(0),
 	m_ready_counter(0),
 	m_make_sound(false),
 	m_sound_out(*this, FLOPSND_TAG)
@@ -504,7 +502,8 @@ void floppy_image_device::setup_write(const floppy_image_format_t *_output_forma
 
 void floppy_image_device::commit_image()
 {
-	flush_pending_write();
+	if(m_writing)
+		write_do_flush(machine().time());
 	m_image_dirty = false;
 	if(!m_output_format || !m_output_format->supports_save())
 		return;
@@ -656,8 +655,8 @@ std::pair<std::error_condition, const floppy_image_format_t *> floppy_image_devi
 void floppy_image_device::init_floppy_load(bool write_supported)
 {
 	cache_clear();
-	m_pending_write = false;
-	m_pending_write_flux_change_positions.clear();
+	m_writing = false;
+	m_write_transition_times.clear();
 	m_revolution_start_time = m_mon ? attotime::never : machine().time();
 	m_revolution_count = 0;
 
@@ -1134,7 +1133,8 @@ void floppy_image_device::cache_clear()
 
 void floppy_image_device::cache_fill(const attotime &when)
 {
-	flush_pending_write();
+	if(m_writing)
+		write_do_flush(when);
 	std::vector<uint32_t> &buf = m_image->get_buffer(m_cyl, m_ss, m_subcyl);
 	uint32_t const cells = buf.size();
 	if(cells <= 1) {
@@ -1221,7 +1221,7 @@ bool floppy_image_device::writing_disabled() const
 	return m_wpt || (m_phases & 2);
 }
 
-void floppy_image_device::write_flux(const attotime &start, const attotime &end, int transition_count, const attotime *transitions)
+void floppy_image_device::write_start(const attotime &when)
 {
 	if(!m_image || m_mon)
 		return;
@@ -1229,53 +1229,76 @@ void floppy_image_device::write_flux(const attotime &start, const attotime &end,
 	if(writing_disabled())
 		return;
 
+	if(m_writing)
+		write_do_flush(when);
+
+	m_writing = true;
+	m_write_cyl = m_cyl;
+	m_write_ss = m_ss;
+	m_write_subcyl = m_subcyl;
+	m_write_start_time = when;
+	m_write_transition_times.clear();
 	m_image_dirty = true;
 	m_track_dirty = true;
-	cache_clear();
-
-	std::vector<wspan> wspans(1);
-
-	attotime base;
-	wspans[0].start = find_position(base, start);
-	wspans[0].end   = find_position(base, end);
-
-	for(int i=0; i != transition_count; i++)
-		wspans[0].flux_change_positions.push_back(find_position(base, transitions[i]));
-
-	wspan_split_on_wrap(wspans);
-
-	for(const auto &ws : wspans) {
-		if(!m_pending_write || m_pending_write_cyl != m_cyl || m_pending_write_ss != m_ss || m_pending_write_subcyl != m_subcyl || m_pending_write_end != ws.start) {
-			flush_pending_write();
-			m_pending_write = true;
-			m_pending_write_cyl = m_cyl;
-			m_pending_write_ss = m_ss;
-			m_pending_write_subcyl = m_subcyl;
-			m_pending_write_start = ws.start;
-			m_pending_write_end = ws.start;
-			m_pending_write_flux_change_positions.clear();
-		}
-
-		m_pending_write_end = ws.end;
-		m_pending_write_flux_change_positions.insert(
-				m_pending_write_flux_change_positions.end(),
-				ws.flux_change_positions.begin(),
-				ws.flux_change_positions.end());
-	}
 }
 
-
-void floppy_image_device::flush_pending_write()
+void floppy_image_device::write_flux_change(const attotime &when)
 {
-	if(!m_pending_write)
+	if(!m_writing)
+		return;
+
+	// Some controllers speculatively run ahead of machine time then
+	// replay from an earlier point.  Discard stale entries so the
+	// replayed transitions replace them cleanly.
+	if(!m_write_transition_times.empty() && when <= m_write_transition_times.back()) {
+		auto it = std::lower_bound(m_write_transition_times.begin(), m_write_transition_times.end(), when);
+		m_write_transition_times.erase(it, m_write_transition_times.end());
+	}
+	// Best-effort rewind if replay crosses a flush boundary.  Does not
+	// reconstruct transitions already committed to the track, but no
+	// current controller replays across a committed flush point.
+	if(when < m_write_start_time)
+		m_write_start_time = when;
+	m_write_transition_times.push_back(when);
+}
+
+void floppy_image_device::write_end(const attotime &when)
+{
+	if(!m_writing)
+		return;
+
+	write_do_flush(when);
+	m_writing = false;
+}
+
+void floppy_image_device::write_flush(const attotime &when)
+{
+	if(!m_writing)
+		return;
+
+	write_do_flush(when);
+}
+
+void floppy_image_device::write_do_flush(const attotime &when)
+{
+	int committed = 0;
+	for(int i = 0; i != int(m_write_transition_times.size()); i++)
+		if(m_write_transition_times[i] < when)
+			committed = i + 1;
+
+	if(when == m_write_start_time && !committed)
 		return;
 
 	std::vector<wspan> wspans(1);
-	wspans[0].start = m_pending_write_start;
-	wspans[0].end = m_pending_write_end;
-	wspans[0].flux_change_positions.swap(m_pending_write_flux_change_positions);
+	attotime base;
+	wspans[0].start = find_position(base, m_write_start_time);
+	wspans[0].end = find_position(base, when);
+	for(int i = 0; i != committed; i++)
+		wspans[0].flux_change_positions.push_back(find_position(base, m_write_transition_times[i]));
 
-	std::vector<uint32_t> &buf = m_image->get_buffer(m_pending_write_cyl, m_pending_write_ss, m_pending_write_subcyl);
+	wspan_split_on_wrap(wspans);
+
+	std::vector<uint32_t> &buf = m_image->get_buffer(m_write_cyl, m_write_ss, m_write_subcyl);
 	if(buf.empty()) {
 		buf.push_back(floppy_image::MG_N);
 		buf.push_back(floppy_image::MG_E | 199999999);
@@ -1284,7 +1307,9 @@ void floppy_image_device::flush_pending_write()
 	wspan_remove_damaged(wspans, buf);
 	wspan_write(wspans, buf);
 
-	m_pending_write = false;
+	if(committed)
+		m_write_transition_times.erase(m_write_transition_times.begin(), m_write_transition_times.begin() + committed);
+	m_write_start_time = when;
 	cache_clear();
 }
 
@@ -1411,7 +1436,8 @@ void floppy_image_device::wspan_write(const std::vector<wspan> &wspans, std::vec
 void floppy_image_device::set_write_splice(const attotime &when)
 {
 	if(m_image && !m_mon) {
-		flush_pending_write();
+		if(m_writing)
+			write_do_flush(when);
 		m_image_dirty = true;
 		attotime base;
 		int splice_pos = find_position(base, when);

--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -321,7 +321,10 @@ public:
 
 	attotime time_next_index();
 	attotime get_next_transition(const attotime &from_when);
-	void write_flux(const attotime &start, const attotime &end, int transition_count, const attotime *transitions);
+	void write_start(const attotime &when);
+	void write_flux_change(const attotime &when);
+	void write_end(const attotime &when);
+	void write_flush(const attotime &when);
 	void set_write_splice(const attotime &when);
 	int get_sides() { return m_sides; }
 	uint32_t get_form_factor() const;
@@ -407,10 +410,10 @@ protected:
 	bool m_cache_weak;
 
 	bool m_image_dirty, m_track_dirty;
-	bool m_pending_write;
-	int m_pending_write_cyl, m_pending_write_ss, m_pending_write_subcyl;
-	int m_pending_write_start, m_pending_write_end;
-	std::vector<int> m_pending_write_flux_change_positions;
+	bool m_writing;
+	int m_write_cyl, m_write_ss, m_write_subcyl;
+	attotime m_write_start_time;
+	std::vector<attotime> m_write_transition_times;
 	int m_ready_counter;
 
 	load_cb m_cur_load_cb;
@@ -440,7 +443,7 @@ protected:
 	attotime position_to_time(const attotime &base, int position) const;
 
 	void commit_image();
-	void flush_pending_write();
+	void write_do_flush(const attotime &when);
 
 	u32 hash32(u32 val) const;
 

--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -407,6 +407,10 @@ protected:
 	bool m_cache_weak;
 
 	bool m_image_dirty, m_track_dirty;
+	bool m_pending_write;
+	int m_pending_write_cyl, m_pending_write_ss, m_pending_write_subcyl;
+	int m_pending_write_start, m_pending_write_end;
+	std::vector<int> m_pending_write_flux_change_positions;
 	int m_ready_counter;
 
 	load_cb m_cur_load_cb;
@@ -436,6 +440,7 @@ protected:
 	attotime position_to_time(const attotime &base, int position) const;
 
 	void commit_image();
+	void flush_pending_write();
 
 	u32 hash32(u32 val) const;
 

--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -231,6 +231,10 @@ protected:
 	bool m_cache_weak;
 
 	bool m_image_dirty, m_track_dirty;
+	bool m_pending_write;
+	int m_pending_write_cyl, m_pending_write_ss, m_pending_write_subcyl;
+	int m_pending_write_start, m_pending_write_end;
+	std::vector<int> m_pending_write_flux_change_positions;
 	int m_ready_counter;
 
 	load_cb m_cur_load_cb;
@@ -260,6 +264,7 @@ protected:
 	attotime position_to_time(const attotime &base, int position) const;
 
 	void commit_image();
+	void flush_pending_write();
 
 	u32 hash32(u32 val) const;
 

--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -145,7 +145,10 @@ public:
 
 	attotime time_next_index();
 	attotime get_next_transition(const attotime &from_when);
-	void write_flux(const attotime &start, const attotime &end, int transition_count, const attotime *transitions);
+	void write_start(const attotime &when);
+	void write_flux_change(const attotime &when);
+	void write_end(const attotime &when);
+	void write_flush(const attotime &when);
 	void set_write_splice(const attotime &when);
 	int get_sides() { return m_sides; }
 	uint32_t get_form_factor() const;
@@ -231,10 +234,10 @@ protected:
 	bool m_cache_weak;
 
 	bool m_image_dirty, m_track_dirty;
-	bool m_pending_write;
-	int m_pending_write_cyl, m_pending_write_ss, m_pending_write_subcyl;
-	int m_pending_write_start, m_pending_write_end;
-	std::vector<int> m_pending_write_flux_change_positions;
+	bool m_writing;
+	int m_write_cyl, m_write_ss, m_write_subcyl;
+	attotime m_write_start_time;
+	std::vector<attotime> m_write_transition_times;
 	int m_ready_counter;
 
 	load_cb m_cur_load_cb;
@@ -264,7 +267,7 @@ protected:
 	attotime position_to_time(const attotime &base, int position) const;
 
 	void commit_image();
-	void flush_pending_write();
+	void write_do_flush(const attotime &when);
 
 	u32 hash32(u32 val) const;
 

--- a/src/devices/machine/64h156.cpp
+++ b/src/devices/machine/64h156.cpp
@@ -75,7 +75,6 @@ c64h156_device::c64h156_device(const machine_config &mconfig, const char *tag, d
 	cur_live.tm = attotime::never;
 	cur_live.state = IDLE;
 	cur_live.next_state = -1;
-	cur_live.write_start_time = attotime::never;
 }
 
 
@@ -170,29 +169,24 @@ void c64h156_device::rollback()
 
 void c64h156_device::start_writing(const attotime &tm)
 {
-	cur_live.write_start_time = tm;
-	cur_live.write_position = 0;
+	if(m_floppy)
+		m_floppy->write_start(tm);
 }
 
 void c64h156_device::stop_writing(const attotime &tm)
 {
-	commit(tm);
-	cur_live.write_start_time = attotime::never;
+	if(m_floppy)
+		m_floppy->write_end(tm);
 }
 
 bool c64h156_device::write_next_bit(bool bit, const attotime &limit)
 {
-	if(cur_live.write_start_time.is_never()) {
-		cur_live.write_start_time = cur_live.tm;
-		cur_live.write_position = 0;
-	}
-
 	attotime etime = cur_live.tm + m_period;
 	if(etime > limit)
 		return true;
 
-	if(bit && cur_live.write_position < std::size(cur_live.write_buffer))
-		cur_live.write_buffer[cur_live.write_position++] = cur_live.tm - m_period;
+	if(bit && m_floppy)
+		m_floppy->write_flux_change(cur_live.tm - m_period);
 
 	LOG("%s write bit %u (%u)\n", cur_live.tm.as_string(), cur_live.bit_counter, bit);
 
@@ -201,15 +195,8 @@ bool c64h156_device::write_next_bit(bool bit, const attotime &limit)
 
 void c64h156_device::commit(const attotime &tm)
 {
-	if(cur_live.write_start_time.is_never() || tm == cur_live.write_start_time || !cur_live.write_position)
-		return;
-
-	LOG("%s committing %u transitions since %s\n", tm.as_string(), cur_live.write_position, cur_live.write_start_time.as_string());
-
-	m_floppy->write_flux(cur_live.write_start_time, tm, cur_live.write_position, cur_live.write_buffer);
-
-	cur_live.write_start_time = tm;
-	cur_live.write_position = 0;
+	if(m_floppy)
+		m_floppy->write_flush(tm);
 }
 
 void c64h156_device::live_delay(int state)
@@ -256,8 +243,6 @@ void c64h156_device::live_abort()
 	cur_live.tm = attotime::never;
 	cur_live.state = IDLE;
 	cur_live.next_state = -1;
-	cur_live.write_position = 0;
-	cur_live.write_start_time = attotime::never;
 
 	cur_live.sync = 1;
 	cur_live.byte = 1;

--- a/src/devices/machine/64h156.cpp
+++ b/src/devices/machine/64h156.cpp
@@ -75,7 +75,6 @@ c64h156_device::c64h156_device(const machine_config &mconfig, const char *tag, d
 	cur_live.tm = attotime::never;
 	cur_live.state = IDLE;
 	cur_live.next_state = -1;
-	cur_live.write_start_time = attotime::never;
 }
 
 
@@ -170,49 +169,41 @@ void c64h156_device::rollback()
 
 void c64h156_device::start_writing(const attotime &tm)
 {
-	cur_live.write_start_time = tm;
-	cur_live.write_position = 0;
+	if(m_floppy)
+		m_floppy->write_start(tm);
+	cur_live.write_transition_count = 0;
 }
 
 void c64h156_device::stop_writing(const attotime &tm)
 {
-	commit(tm, true);
-	cur_live.write_start_time = attotime::never;
+	if(m_floppy)
+		m_floppy->write_end(tm);
+	cur_live.write_transition_count = 0;
 }
 
 bool c64h156_device::write_next_bit(bool bit, const attotime &limit)
 {
-	if(cur_live.write_start_time.is_never()) {
-		cur_live.write_start_time = cur_live.tm;
-		cur_live.write_position = 0;
-	}
-
 	attotime etime = cur_live.tm + m_period;
 	if(etime > limit)
 		return true;
 
-	if(bit && cur_live.write_position < std::size(cur_live.write_buffer))
-		cur_live.write_buffer[cur_live.write_position++] = cur_live.tm - m_period;
+	if(bit && m_floppy) {
+		m_floppy->write_flux_change(cur_live.tm - m_period);
+		cur_live.write_transition_count++;
+	}
 
 	LOG("%s write bit %u (%u)\n", cur_live.tm.as_string(), cur_live.bit_counter, bit);
 
 	return false;
 }
 
-void c64h156_device::commit(const attotime &tm, bool force)
+void c64h156_device::commit(const attotime &tm)
 {
-	if(cur_live.write_start_time.is_never() || tm == cur_live.write_start_time || !cur_live.write_position)
+	if(!m_floppy || cur_live.write_transition_count < WRITE_BATCH_SIZE)
 		return;
 
-	if(!force && cur_live.write_position < std::size(cur_live.write_buffer))
-		return;
-
-	LOG("%s committing %u transitions since %s\n", tm.as_string(), cur_live.write_position, cur_live.write_start_time.as_string());
-
-	m_floppy->write_flux(cur_live.write_start_time, tm, cur_live.write_position, cur_live.write_buffer);
-
-	cur_live.write_start_time = tm;
-	cur_live.write_position = 0;
+	m_floppy->write_flush(tm);
+	cur_live.write_transition_count = 0;
 }
 
 void c64h156_device::live_delay(int state)
@@ -259,8 +250,6 @@ void c64h156_device::live_abort()
 	cur_live.tm = attotime::never;
 	cur_live.state = IDLE;
 	cur_live.next_state = -1;
-	cur_live.write_position = 0;
-	cur_live.write_start_time = attotime::never;
 
 	cur_live.sync = 1;
 	cur_live.byte = 1;

--- a/src/devices/machine/64h156.h
+++ b/src/devices/machine/64h156.h
@@ -136,9 +136,6 @@ private:
 
 		uint8_t yb = 0;
 		uint8_t shift_reg_write = 0;
-		attotime write_start_time;
-		attotime write_buffer[32];
-		int write_position = 0;
 	};
 
 	devcb_write_line m_write_atn;

--- a/src/devices/machine/64h156.h
+++ b/src/devices/machine/64h156.h
@@ -109,6 +109,8 @@ protected:
 	TIMER_CALLBACK_MEMBER(update_tick);
 
 private:
+	static constexpr unsigned WRITE_BATCH_SIZE = 32;
+
 	enum {
 		IDLE,
 		RUNNING,
@@ -136,9 +138,7 @@ private:
 
 		uint8_t yb = 0;
 		uint8_t shift_reg_write = 0;
-		attotime write_start_time;
-		attotime write_buffer[32];
-		int write_position = 0;
+		unsigned write_transition_count = 0;
 	};
 
 	devcb_write_line m_write_atn;
@@ -168,7 +168,7 @@ private:
 	void rollback();
 	bool write_next_bit(bool bit, const attotime &limit);
 	void start_writing(const attotime &tm);
-	void commit(const attotime &tm, bool force = false);
+	void commit(const attotime &tm);
 	void stop_writing(const attotime &tm);
 	void live_delay(int state);
 	void live_sync();

--- a/src/devices/machine/fdc_pll.cpp
+++ b/src/devices/machine/fdc_pll.cpp
@@ -16,8 +16,6 @@ void fdc_pll_t::set_clock(const attotime &_period)
 void fdc_pll_t::reset(const attotime &when)
 {
 	read_reset(when);
-	write_position = 0;
-	write_start_time = attotime::never;
 }
 
 void fdc_pll_t::read_reset(const attotime &when)
@@ -27,27 +25,22 @@ void fdc_pll_t::read_reset(const attotime &when)
 	freq_hist = 0;
 }
 
-void fdc_pll_t::start_writing(const attotime &tm)
+void fdc_pll_t::start_writing(const attotime &tm, floppy_image_device *floppy)
 {
-	write_start_time = tm;
-	write_position = 0;
+	if(floppy)
+		floppy->write_start(tm);
 }
 
 void fdc_pll_t::stop_writing(floppy_image_device *floppy, const attotime &tm)
 {
-	commit(floppy, tm);
-	write_start_time = attotime::never;
+	if(floppy)
+		floppy->write_end(tm);
 }
 
 void fdc_pll_t::commit(floppy_image_device *floppy, const attotime &tm)
 {
-	if(write_start_time.is_never() || tm == write_start_time)
-		return;
-
 	if(floppy)
-		floppy->write_flux(write_start_time, tm, write_position, write_buffer);
-	write_start_time = tm;
-	write_position = 0;
+		floppy->write_flush(tm);
 }
 
 int fdc_pll_t::get_next_bit(attotime &tm, floppy_image_device *floppy, const attotime &limit)
@@ -118,17 +111,12 @@ int fdc_pll_t::feed_read_data(attotime &tm, const attotime& edge, const attotime
 
 bool fdc_pll_t::write_next_bit(bool bit, attotime &tm, floppy_image_device *floppy, const attotime &limit)
 {
-	if(write_start_time.is_never()) {
-		write_start_time = ctime;
-		write_position = 0;
-	}
-
 	attotime etime = ctime + period;
 	if(etime > limit)
 		return true;
 
-	if(bit && write_position < std::size(write_buffer))
-		write_buffer[write_position++] = ctime + period/2;
+	if(bit && floppy)
+		floppy->write_flux_change(ctime + period/2);
 
 	tm = etime;
 	ctime = etime;

--- a/src/devices/machine/fdc_pll.h
+++ b/src/devices/machine/fdc_pll.h
@@ -15,9 +15,6 @@ class fdc_pll_t {
 public:
 	attotime ctime, period, min_period, max_period, period_adjust_base, phase_adjust;
 
-	attotime write_start_time;
-	attotime write_buffer[32];
-	int write_position = 0;
 	int freq_hist = 0;
 
 	void set_clock(const attotime &period);
@@ -26,7 +23,7 @@ public:
 	int get_next_bit(attotime &tm, floppy_image_device *floppy, const attotime &limit);
 	int feed_read_data(attotime &tm, const attotime& edge, const attotime &limit);
 	bool write_next_bit(bool bit, attotime &tm, floppy_image_device *floppy, const attotime &limit);
-	void start_writing(const attotime &tm);
+	void start_writing(const attotime &tm, floppy_image_device *floppy);
 	void commit(floppy_image_device *floppy, const attotime &tm);
 	void stop_writing(floppy_image_device *floppy, const attotime &tm);
 };

--- a/src/devices/machine/hdc92x4.cpp
+++ b/src/devices/machine/hdc92x4.cpp
@@ -2725,6 +2725,7 @@ void hdc92x4_device::live_run_until(attotime limit)
 
 		case WRITE_DAM_SYNC:
 			LOGMASKED(LOG_DETAIL, "Write sync zeros\n");
+			m_pll.start_writing(m_live_state.time, m_floppy);
 
 			// Clear the overrun/underrun flag
 			set_bits(m_register_r[INT_STATUS], ST_OVRUN, false);
@@ -2866,7 +2867,7 @@ void hdc92x4_device::live_run_until(attotime limit)
 		case FORMAT_TRACK:
 			LOGMASKED(LOG_LIVE, "FORMAT_TRACK\n");
 			m_live_state.state = WRITE_GAP0;
-			m_pll.start_writing(m_live_state.time);
+			m_pll.start_writing(m_live_state.time, m_floppy);
 			break;
 
 		case WRITE_GAP0:
@@ -3487,6 +3488,7 @@ void hdc92x4_device::live_run_hd_until(attotime limit)
 
 		case WRITE_DAM_SYNC:
 			LOGMASKED(LOG_DETAIL, "Write sync zeros\n");
+			m_pll.start_writing(m_live_state.time, m_floppy);
 
 			// Clear the overrun/underrun flag
 			set_bits(m_register_r[INT_STATUS], ST_OVRUN, false);

--- a/src/devices/machine/i8271.cpp
+++ b/src/devices/machine/i8271.cpp
@@ -563,6 +563,7 @@ void i8271_device::live_run(attotime limit)
 			return;
 
 		case WRITE_SECTOR_DATA:
+			cur_live.pll.start_writing(cur_live.tm, cur_live.fi->dev);
 			if(cur_live.byte_counter < 6)
 				live_write_fm(0x00);
 			else if(cur_live.byte_counter < 7) {
@@ -1416,7 +1417,7 @@ void i8271_device::format_track_continue(floppy_info &fi)
 		case WAIT_INDEX_DONE:
 			logerror("index found, writing track\n");
 			fi.sub_state = TRACK_DONE;
-			cur_live.pll.start_writing(machine().time());
+			cur_live.pll.start_writing(machine().time(), cur_live.fi->dev);
 			set_drq(true);
 			live_start(fi, WRITE_TRACK_PRE_SECTORS);
 			return;

--- a/src/devices/machine/iwm.cpp
+++ b/src/devices/machine/iwm.cpp
@@ -37,9 +37,6 @@ void iwm_device::device_start()
 	save_item(NAME(m_next_state_change));
 	save_item(NAME(m_sync_update));
 	save_item(NAME(m_async_update));
-	save_item(NAME(m_flux_write_start));
-	save_item(NAME(m_flux_write));
-	save_item(NAME(m_flux_write_count));
 	save_item(NAME(m_q3_clock));
 	save_item(NAME(m_q3_clock_active));
 	save_item(NAME(m_active));
@@ -72,8 +69,6 @@ void iwm_device::device_reset()
 	m_control = 0x00;
 	m_wsh = 0x00;
 	m_rsh = 0x00;
-	m_flux_write_start = 0;
-	m_flux_write_count = 0;
 	m_rw_bit_count = 0;
 	m_devsel = 0;
 	m_devsel_cb(0);
@@ -83,7 +78,8 @@ void iwm_device::device_reset()
 TIMER_CALLBACK_MEMBER(iwm_device::update_timer_tick)
 {
 	if(m_active == MODE_DELAY) {
-		flush_write();
+		if(m_floppy)
+			m_floppy->write_end(machine().time());
 		m_active = MODE_IDLE;
 		m_rw = MODE_IDLE;
 		m_rw_state = S_IDLE;
@@ -102,7 +98,8 @@ void iwm_device::set_floppy(floppy_image_device *floppy)
 		return;
 
 	sync();
-	flush_write();
+	if(m_floppy)
+		m_floppy->write_end(machine().time());
 
 	LOG("floppy %s\n", floppy ? floppy->tag() : "-");
 
@@ -139,37 +136,6 @@ void iwm_device::write(offs_t offset, u8 data)
 	control(offset, data);
 }
 
-void iwm_device::flush_write(u64 when)
-{
-	if(!m_flux_write_start)
-		return;
-
-	if(!when)
-		when = m_last_sync;
-
-	if(when > m_flux_write_start) {
-		bool last_on_edge = m_flux_write_count && m_flux_write[m_flux_write_count-1] == when;
-		if(last_on_edge)
-			m_flux_write_count--;
-
-		attotime start = cycles_to_time(m_flux_write_start);
-		attotime end = cycles_to_time(when);
-		std::vector<attotime> fluxes(m_flux_write_count);
-		for(u32 i=0; i != m_flux_write_count; i++)
-			fluxes[i] = cycles_to_time(m_flux_write[i]);
-
-		if(m_floppy)
-			m_floppy->write_flux(start, end, m_flux_write_count, m_flux_write_count ? &fluxes[0] : nullptr);
-
-		m_flux_write_count = 0;
-		if(last_on_edge)
-			m_flux_write[m_flux_write_count++] = when;
-		m_flux_write_start = when;
-
-	} else
-		m_flux_write_count = 0;
-}
-
 void iwm_device::control(int offset, u8 data)
 {
 	sync();
@@ -198,7 +164,8 @@ void iwm_device::control(int offset, u8 data)
 		if((m_control & 0x80) == 0x00) {
 			if(m_rw != MODE_READ) {
 				if(m_rw == MODE_WRITE) {
-					flush_write();
+					if(m_floppy)
+						m_floppy->write_end(machine().time());
 					write_clock_stop();
 				}
 				m_rw = MODE_READ;
@@ -217,12 +184,13 @@ void iwm_device::control(int offset, u8 data)
 				m_next_state_change = 0;
 				write_clock_start();
 				if(m_floppy)
-					m_floppy->set_write_splice(cycles_to_time(m_flux_write_start));
+					m_floppy->set_write_splice(cycles_to_time(m_last_sync));
 			}
 		}
 	} else {
 		if(m_active == MODE_ACTIVE) {
-			flush_write();
+			if(m_floppy)
+				m_floppy->write_end(machine().time());
 			if(m_mode & 0x04) {
 				write_clock_stop();
 				m_active = MODE_IDLE;
@@ -371,8 +339,8 @@ void iwm_device::write_clock_start()
 		m_q3_clock_active = true;
 		m_last_sync = machine().time().as_ticks(m_q3_clock);
 	}
-	m_flux_write_start = m_last_sync;
-	m_flux_write_count = 0;
+	if(m_floppy)
+		m_floppy->write_start(cycles_to_time(m_last_sync));
 }
 
 void iwm_device::write_clock_stop()
@@ -381,7 +349,6 @@ void iwm_device::write_clock_stop()
 		m_q3_clock_active = false;
 		m_last_sync = machine().time().as_ticks(clock());
 	}
-	m_flux_write_start = 0;
 }
 
 void iwm_device::sync()
@@ -476,7 +443,6 @@ void iwm_device::sync()
 				m_last_sync = m_next_state_change;
 			switch(m_rw_state) {
 			case S_IDLE:
-				m_flux_write_count = 0;
 				if(m_mode & 0x02) {
 					m_rw_state = SW_WINDOW_LOAD;
 					m_rw_bit_count = 8;
@@ -491,7 +457,8 @@ void iwm_device::sync()
 			case SW_WINDOW_LOAD:
 				if(m_whd & 0x80) {
 					logerror("underrun\n");
-					flush_write(next_sync);
+					if(m_floppy)
+						m_floppy->write_end(cycles_to_time(next_sync));
 					write_clock_stop();
 					m_whd &= ~0x40;
 					m_last_sync = next_sync;
@@ -507,15 +474,14 @@ void iwm_device::sync()
 
 			case SW_WINDOW_MIDDLE:
 				if(m_wsh & 0x80)
-					m_flux_write[m_flux_write_count++] = m_last_sync;
+					if(m_floppy)
+						m_floppy->write_flux_change(cycles_to_time(m_last_sync));
 				m_wsh <<= 1;
 				m_rw_state = SW_WINDOW_END;
 				m_next_state_change = m_last_sync + half_window_size();
 				break;
 
 			case SW_WINDOW_END:
-				if(m_flux_write_count == m_flux_write.size())
-					flush_write();
 				if(m_mode & 0x02) {
 					m_rw_bit_count --;
 					if(m_rw_bit_count == 0) {

--- a/src/devices/machine/iwm.h
+++ b/src/devices/machine/iwm.h
@@ -61,9 +61,6 @@ private:
 	floppy_image_device *m_floppy;
 	emu_timer *m_timer;
 	u64 m_last_sync, m_next_state_change, m_sync_update, m_async_update;
-	u64 m_flux_write_start;
-	std::array<u64, 65536> m_flux_write;
-	u32 m_flux_write_count;
 	u32 m_q3_clock;
 	int m_active, m_rw, m_rw_state;
 	u8 m_data, m_whd, m_mode, m_status, m_control, m_rw_bit_count;
@@ -82,7 +79,6 @@ private:
 	u64 half_window_size() const;
 	u64 read_register_update_delay() const;
 	inline bool is_sync() const;
-	void flush_write(u64 when = 0);
 	void write_clock_start();
 	void write_clock_stop();
 };

--- a/src/devices/machine/mc6843.cpp
+++ b/src/devices/machine/mc6843.cpp
@@ -662,7 +662,7 @@ void mc6843_device::live_start(int state, bool start_writing)
 	m_cur_live.pll.reset(m_cur_live.tm);
 	m_cur_live.pll.set_clock(attotime::from_ticks(2, clock()));
 	if(start_writing)
-		m_cur_live.pll.start_writing(machine().time());
+		m_cur_live.pll.start_writing(machine().time(), m_floppy);
 
 	m_checkpoint_live = m_cur_live;
 
@@ -930,7 +930,7 @@ void mc6843_device::live_run(attotime limit)
 		case L_DAM_WRITE_BYTE: {
 			int byte = (6+1+128+2) - (m_cur_live.bit_counter >> 4);
 			if(!byte) {
-				m_cur_live.pll.start_writing(m_cur_live.tm);
+				m_cur_live.pll.start_writing(m_cur_live.tm, m_floppy);
 				m_cur_live.shift_reg = 0xaaaa;
 
 			} else if(byte <= 5) {

--- a/src/devices/machine/swim1.cpp
+++ b/src/devices/machine/swim1.cpp
@@ -29,9 +29,6 @@ void swim1_device::device_start()
 	m_sync_timer = timer_alloc(FUNC(swim1_device::ism_periodic_sync), this);
 
 	save_item(NAME(m_last_sync));
-	save_item(NAME(m_flux_write_start));
-	save_item(NAME(m_flux_write));
-	save_item(NAME(m_flux_write_count));
 
 	save_item(NAME(m_ism_param));
 	save_item(NAME(m_ism_mode));
@@ -85,8 +82,6 @@ void swim1_device::device_reset()
 	m_floppy = nullptr;
 
 	m_last_sync = machine().time().as_ticks(clock());
-	m_flux_write_start = 0;
-	m_flux_write_count = 0;
 
 	m_iwm_next_state_change = 0;
 	m_iwm_active = MODE_IDLE;
@@ -115,7 +110,8 @@ void swim1_device::set_floppy(floppy_image_device *floppy)
 		return;
 
 	sync();
-	flush_write();
+	if(m_floppy)
+		m_floppy->write_end(machine().time());
 
 	LOG("floppy %s\n", floppy ? floppy->tag() : "-");
 
@@ -356,13 +352,13 @@ void swim1_device::ism_write(offs_t offset, u8 data)
 		// Entering write mode
 		m_ism_current_bit = 0;
 		LOG("%s write start %s %s floppy=%p\n", machine().time().to_string(), m_ism_setup & 0x40 ? "gcr" : "mfm", m_ism_setup & 0x08 ? "fclk/2" : "fclk", m_floppy);
-		m_flux_write_start = m_last_sync;
-		m_flux_write_count = 0;
+		if(m_floppy)
+			m_floppy->write_start(cycles_to_time(m_last_sync));
 
 	} else if((prev_mode & 0x18) == 0x18 && (m_ism_mode & 0x18) != 0x18) {
 		// Exiting write mode
-		flush_write();
-		m_flux_write_start = 0;
+		if(m_floppy)
+			m_floppy->write_end(cycles_to_time(m_last_sync));
 		m_ism_current_bit = 0xff;
 		m_ism_half_cycles_before_change = 0;
 		LOG("%s write end\n", machine().time().to_string());
@@ -384,7 +380,8 @@ void swim1_device::ism_write(offs_t offset, u8 data)
 
 	} else if((prev_mode & 0x18) == 0x08 && (m_ism_mode & 0x18) != 0x08) {
 		// Exiting read mode
-		flush_write();
+		if(m_floppy)
+			m_floppy->write_flush(cycles_to_time(m_last_sync));
 		m_ism_current_bit = 0xff;
 		m_ism_half_cycles_before_change = 0;
 		LOG("%s read end\n", machine().time().to_string());
@@ -394,7 +391,8 @@ void swim1_device::ism_write(offs_t offset, u8 data)
 TIMER_CALLBACK_MEMBER(swim1_device::update)
 {
 	if(m_iwm_active == MODE_DELAY) {
-		flush_write();
+		if(m_floppy)
+			m_floppy->write_end(machine().time());
 		m_iwm_active = MODE_IDLE;
 		m_iwm_rw = MODE_IDLE;
 		m_iwm_rw_state = S_IDLE;
@@ -404,37 +402,6 @@ TIMER_CALLBACK_MEMBER(swim1_device::update)
 		m_iwm_status &= ~0x20;
 		m_iwm_whd &= ~0x40;
 	}
-}
-
-void swim1_device::flush_write(u64 when)
-{
-	if(!m_flux_write_start)
-		return;
-
-	if(!when)
-		when = m_last_sync;
-
-	if(when > m_flux_write_start) {
-		bool last_on_edge = m_flux_write_count && m_flux_write[m_flux_write_count-1] == when;
-		if(last_on_edge)
-			m_flux_write_count--;
-
-		attotime start = cycles_to_time(m_flux_write_start);
-		attotime end = cycles_to_time(when);
-		std::vector<attotime> fluxes(m_flux_write_count);
-		for(u32 i=0; i != m_flux_write_count; i++)
-			fluxes[i] = cycles_to_time(m_flux_write[i]);
-
-		if(m_floppy)
-			m_floppy->write_flux(start, end, m_flux_write_count, m_flux_write_count ? &fluxes[0] : nullptr);
-
-		m_flux_write_count = 0;
-		if(last_on_edge)
-			m_flux_write[m_flux_write_count++] = when;
-		m_flux_write_start = when;
-
-	} else
-		m_flux_write_count = 0;
 }
 
 void swim1_device::iwm_control(int offset, u8 data)
@@ -467,8 +434,8 @@ void swim1_device::iwm_control(int offset, u8 data)
 		if((m_iwm_control & 0x80) == 0x00) {
 			if(m_iwm_rw != MODE_READ) {
 				if(m_iwm_rw == MODE_WRITE) {
-					flush_write();
-					m_flux_write_start = 0;
+					if(m_floppy)
+						m_floppy->write_end(cycles_to_time(m_last_sync));
 				}
 				m_iwm_rw = MODE_READ;
 				m_iwm_rw_state = S_IDLE;
@@ -484,17 +451,17 @@ void swim1_device::iwm_control(int offset, u8 data)
 				m_iwm_rw_state = S_IDLE;
 				m_iwm_whd |= 0x40;
 				m_iwm_next_state_change = 0;
-				m_flux_write_start = m_last_sync;
-				m_flux_write_count = 0;
-				if(m_floppy)
-					m_floppy->set_write_splice(cycles_to_time(m_flux_write_start));
+				if(m_floppy) {
+					m_floppy->write_start(cycles_to_time(m_last_sync));
+					m_floppy->set_write_splice(cycles_to_time(m_last_sync));
+				}
 			}
 		}
 	} else {
 		if(m_iwm_active == MODE_ACTIVE) {
-			flush_write();
+			if(m_floppy)
+				m_floppy->write_end(cycles_to_time(m_last_sync));
 			if(m_iwm_mode & 0x04) {
-				m_flux_write_start = 0;
 				m_iwm_active = MODE_IDLE;
 				m_iwm_rw = MODE_IDLE;
 				m_iwm_rw_state = S_IDLE;
@@ -791,7 +758,6 @@ void swim1_device::iwm_sync()
 				m_last_sync = m_iwm_next_state_change;
 			switch(m_iwm_rw_state) {
 			case S_IDLE:
-				m_flux_write_count = 0;
 				if(m_iwm_mode & 0x02) {
 					m_iwm_rw_state = SW_WINDOW_LOAD;
 					m_iwm_rw_bit_count = 8;
@@ -806,8 +772,8 @@ void swim1_device::iwm_sync()
 			case SW_WINDOW_LOAD:
 				if(m_iwm_whd & 0x80) {
 					LOG("underrun\n");
-					flush_write();
-					m_flux_write_start = 0;
+					if(m_floppy)
+						m_floppy->write_end(cycles_to_time(m_last_sync));
 					m_iwm_whd &= ~0x40;
 					m_last_sync = next_sync;
 					m_iwm_rw_state = SW_UNDERRUN;
@@ -822,15 +788,14 @@ void swim1_device::iwm_sync()
 
 			case SW_WINDOW_MIDDLE:
 				if(m_iwm_wsh & 0x80)
-					m_flux_write[m_flux_write_count++] = m_last_sync;
+					if(m_floppy)
+						m_floppy->write_flux_change(cycles_to_time(m_last_sync));
 				m_iwm_wsh <<= 1;
 				m_iwm_rw_state = SW_WINDOW_END;
 				m_iwm_next_state_change = m_last_sync + iwm_half_window_size();
 				break;
 
 			case SW_WINDOW_END:
-				if(m_flux_write_count == m_flux_write.size())
-					flush_write();
 				if(m_iwm_mode & 0x02) {
 					m_iwm_rw_bit_count --;
 					if(m_iwm_rw_bit_count == 0) {
@@ -907,9 +872,8 @@ void swim1_device::ism_sync()
 					m_ism_tss_output = 0;
 				}
 				if(bit) {
-					if(m_flux_write_count == m_flux_write.size())
-						flush_write(next_sync - cycles);
-					m_flux_write[m_flux_write_count ++] = next_sync - cycles;
+					if(m_floppy)
+						m_floppy->write_flux_change(cycles_to_time(next_sync - cycles));
 					m_ism_half_cycles_before_change = m_ism_param[P_TIME1] + 2*2;
 				} else
 					m_ism_half_cycles_before_change = m_ism_param[P_TIME0] + 2*2;
@@ -927,7 +891,8 @@ void swim1_device::ism_sync()
 					u16 r = ism_fifo_pop();
 					if(r == 0xffff && !m_ism_error) {
 						m_ism_error |= 0x01;
-						flush_write();
+						if(m_floppy)
+							m_floppy->write_end(cycles_to_time(m_last_sync));
 						m_ism_current_bit = 0xff;
 						m_ism_half_cycles_before_change = 0;
 						m_ism_mode &= ~8;

--- a/src/devices/machine/swim1.cpp
+++ b/src/devices/machine/swim1.cpp
@@ -18,7 +18,6 @@ swim1_device::swim1_device(const machine_config &mconfig, const char *tag, devic
 	applefdintf_device(mconfig, SWIM1, tag, owner, clock),
 	m_floppy(nullptr),
 	m_timer(nullptr),
-	m_flux_write{},
 	m_last_sync(0),
 	m_ism_error(0),
 	m_ism_fifo_pos(0),
@@ -46,9 +45,6 @@ void swim1_device::device_start()
 	m_sync_timer = timer_alloc(FUNC(swim1_device::ism_periodic_sync), this);
 
 	save_item(NAME(m_last_sync));
-	save_item(NAME(m_flux_write_start));
-	save_item(NAME(m_flux_write));
-	save_item(NAME(m_flux_write_count));
 
 	save_item(NAME(m_ism_param));
 	save_item(NAME(m_ism_mode));
@@ -102,8 +98,6 @@ void swim1_device::device_reset()
 	m_floppy = nullptr;
 
 	m_last_sync = machine().time().as_ticks(clock());
-	m_flux_write_start = 0;
-	m_flux_write_count = 0;
 
 	m_iwm_next_state_change = 0;
 	m_iwm_active = MODE_IDLE;
@@ -132,7 +126,8 @@ void swim1_device::set_floppy(floppy_image_device *floppy)
 		return;
 
 	sync();
-	flush_write();
+	if(m_floppy)
+		m_floppy->write_end(machine().time());
 
 	LOG("floppy %s\n", floppy ? floppy->tag() : "-");
 
@@ -373,13 +368,13 @@ void swim1_device::ism_write(offs_t offset, u8 data)
 		// Entering write mode
 		m_ism_current_bit = 0;
 		LOG("%s write start %s %s floppy=%p\n", machine().time().to_string(), m_ism_setup & 0x40 ? "gcr" : "mfm", m_ism_setup & 0x08 ? "fclk/2" : "fclk", m_floppy);
-		m_flux_write_start = m_last_sync;
-		m_flux_write_count = 0;
+		if(m_floppy)
+			m_floppy->write_start(cycles_to_time(m_last_sync));
 
 	} else if((prev_mode & 0x18) == 0x18 && (m_ism_mode & 0x18) != 0x18) {
 		// Exiting write mode
-		flush_write();
-		m_flux_write_start = 0;
+		if(m_floppy)
+			m_floppy->write_end(cycles_to_time(m_last_sync));
 		m_ism_current_bit = 0xff;
 		m_ism_half_cycles_before_change = 0;
 		LOG("%s write end\n", machine().time().to_string());
@@ -401,7 +396,8 @@ void swim1_device::ism_write(offs_t offset, u8 data)
 
 	} else if((prev_mode & 0x18) == 0x08 && (m_ism_mode & 0x18) != 0x08) {
 		// Exiting read mode
-		flush_write();
+		if(m_floppy)
+			m_floppy->write_flush(cycles_to_time(m_last_sync));
 		m_ism_current_bit = 0xff;
 		m_ism_half_cycles_before_change = 0;
 		LOG("%s read end\n", machine().time().to_string());
@@ -411,7 +407,8 @@ void swim1_device::ism_write(offs_t offset, u8 data)
 TIMER_CALLBACK_MEMBER(swim1_device::update)
 {
 	if(m_iwm_active == MODE_DELAY) {
-		flush_write();
+		if(m_floppy)
+			m_floppy->write_end(machine().time());
 		m_iwm_active = MODE_IDLE;
 		m_iwm_rw = MODE_IDLE;
 		m_iwm_rw_state = S_IDLE;
@@ -421,37 +418,6 @@ TIMER_CALLBACK_MEMBER(swim1_device::update)
 		m_iwm_status &= ~0x20;
 		m_iwm_whd &= ~0x40;
 	}
-}
-
-void swim1_device::flush_write(u64 when)
-{
-	if(!m_flux_write_start)
-		return;
-
-	if(!when)
-		when = m_last_sync;
-
-	if(when > m_flux_write_start) {
-		bool last_on_edge = m_flux_write_count && m_flux_write[m_flux_write_count-1] == when;
-		if(last_on_edge)
-			m_flux_write_count--;
-
-		attotime start = cycles_to_time(m_flux_write_start);
-		attotime end = cycles_to_time(when);
-		std::vector<attotime> fluxes(m_flux_write_count);
-		for(u32 i=0; i != m_flux_write_count; i++)
-			fluxes[i] = cycles_to_time(m_flux_write[i]);
-
-		if(m_floppy)
-			m_floppy->write_flux(start, end, m_flux_write_count, m_flux_write_count ? &fluxes[0] : nullptr);
-
-		m_flux_write_count = 0;
-		if(last_on_edge)
-			m_flux_write[m_flux_write_count++] = when;
-		m_flux_write_start = when;
-
-	} else
-		m_flux_write_count = 0;
 }
 
 void swim1_device::iwm_control(int offset, u8 data)
@@ -484,8 +450,8 @@ void swim1_device::iwm_control(int offset, u8 data)
 		if((m_iwm_control & 0x80) == 0x00) {
 			if(m_iwm_rw != MODE_READ) {
 				if(m_iwm_rw == MODE_WRITE) {
-					flush_write();
-					m_flux_write_start = 0;
+					if(m_floppy)
+						m_floppy->write_end(cycles_to_time(m_last_sync));
 				}
 				m_iwm_rw = MODE_READ;
 				m_iwm_rw_state = S_IDLE;
@@ -501,17 +467,17 @@ void swim1_device::iwm_control(int offset, u8 data)
 				m_iwm_rw_state = S_IDLE;
 				m_iwm_whd |= 0x40;
 				m_iwm_next_state_change = 0;
-				m_flux_write_start = m_last_sync;
-				m_flux_write_count = 0;
-				if(m_floppy)
-					m_floppy->set_write_splice(cycles_to_time(m_flux_write_start));
+				if(m_floppy) {
+					m_floppy->write_start(cycles_to_time(m_last_sync));
+					m_floppy->set_write_splice(cycles_to_time(m_last_sync));
+				}
 			}
 		}
 	} else {
 		if(m_iwm_active == MODE_ACTIVE) {
-			flush_write();
+			if(m_floppy)
+				m_floppy->write_end(cycles_to_time(m_last_sync));
 			if(m_iwm_mode & 0x04) {
-				m_flux_write_start = 0;
 				m_iwm_active = MODE_IDLE;
 				m_iwm_rw = MODE_IDLE;
 				m_iwm_rw_state = S_IDLE;
@@ -808,7 +774,6 @@ void swim1_device::iwm_sync()
 				m_last_sync = m_iwm_next_state_change;
 			switch(m_iwm_rw_state) {
 			case S_IDLE:
-				m_flux_write_count = 0;
 				if(m_iwm_mode & 0x02) {
 					m_iwm_rw_state = SW_WINDOW_LOAD;
 					m_iwm_rw_bit_count = 8;
@@ -823,8 +788,8 @@ void swim1_device::iwm_sync()
 			case SW_WINDOW_LOAD:
 				if(m_iwm_whd & 0x80) {
 					LOG("underrun\n");
-					flush_write();
-					m_flux_write_start = 0;
+					if(m_floppy)
+						m_floppy->write_end(cycles_to_time(m_last_sync));
 					m_iwm_whd &= ~0x40;
 					m_last_sync = next_sync;
 					m_iwm_rw_state = SW_UNDERRUN;
@@ -839,15 +804,14 @@ void swim1_device::iwm_sync()
 
 			case SW_WINDOW_MIDDLE:
 				if(m_iwm_wsh & 0x80)
-					m_flux_write[m_flux_write_count++] = m_last_sync;
+					if(m_floppy)
+						m_floppy->write_flux_change(cycles_to_time(m_last_sync));
 				m_iwm_wsh <<= 1;
 				m_iwm_rw_state = SW_WINDOW_END;
 				m_iwm_next_state_change = m_last_sync + iwm_half_window_size();
 				break;
 
 			case SW_WINDOW_END:
-				if(m_flux_write_count == m_flux_write.size())
-					flush_write();
 				if(m_iwm_mode & 0x02) {
 					m_iwm_rw_bit_count --;
 					if(m_iwm_rw_bit_count == 0) {
@@ -924,9 +888,8 @@ void swim1_device::ism_sync()
 					m_ism_tss_output = 0;
 				}
 				if(bit) {
-					if(m_flux_write_count == m_flux_write.size())
-						flush_write(next_sync - cycles);
-					m_flux_write[m_flux_write_count ++] = next_sync - cycles;
+					if(m_floppy)
+						m_floppy->write_flux_change(cycles_to_time(next_sync - cycles));
 					m_ism_half_cycles_before_change = m_ism_param[P_TIME1] + 2*2;
 				} else
 					m_ism_half_cycles_before_change = m_ism_param[P_TIME0] + 2*2;
@@ -944,7 +907,8 @@ void swim1_device::ism_sync()
 					u16 r = ism_fifo_pop();
 					if(r == 0xffff && !m_ism_error) {
 						m_ism_error |= 0x01;
-						flush_write();
+						if(m_floppy)
+							m_floppy->write_end(cycles_to_time(m_last_sync));
 						m_ism_current_bit = 0xff;
 						m_ism_half_cycles_before_change = 0;
 						m_ism_mode &= ~8;

--- a/src/devices/machine/swim1.h
+++ b/src/devices/machine/swim1.h
@@ -81,9 +81,6 @@ private:
 	floppy_image_device *m_floppy;
 	emu_timer *m_timer;
 
-	u64 m_flux_write_start;
-	std::array<u64, 32> m_flux_write;
-	u32 m_flux_write_count;
 	u64 m_last_sync;
 
 	u8 m_ism_param[16];
@@ -117,7 +114,6 @@ private:
 
 	u64 time_to_cycles(const attotime &tm) const;
 	attotime cycles_to_time(u64 cycles) const;
-	void flush_write(u64 when = 0);
 
 	u64 iwm_window_size() const;
 	u64 iwm_half_window_size() const;

--- a/src/devices/machine/swim2.cpp
+++ b/src/devices/machine/swim2.cpp
@@ -44,9 +44,6 @@ void swim2_device::device_start()
 	save_item(NAME(m_tss_output));
 	save_item(NAME(m_sr));
 	save_item(NAME(m_mfm_sync_counter));
-	save_item(NAME(m_flux_write_start));
-	save_item(NAME(m_flux_write));
-	save_item(NAME(m_flux_write_count));
 }
 
 void swim2_device::device_reset()
@@ -72,9 +69,6 @@ void swim2_device::device_reset()
 	m_sel35_cb(true);
 	m_hdsel_cb(false);
 	m_dat1byte_cb(CLEAR_LINE);
-	m_flux_write_start = 0;
-	m_flux_write_count = 0;
-	std::fill(m_flux_write.begin(), m_flux_write.end(), 0);
 
 	m_last_sync = machine().time().as_ticks(clock());
 }
@@ -85,7 +79,8 @@ void swim2_device::set_floppy(floppy_image_device *floppy)
 		return;
 
 	sync();
-	flush_write();
+	if(m_floppy)
+		m_floppy->write_end(machine().time());
 
 	m_floppy = floppy;
 	update_phases();
@@ -95,34 +90,6 @@ void swim2_device::set_floppy(floppy_image_device *floppy)
 floppy_image_device *swim2_device::get_floppy() const
 {
 	return m_floppy;
-}
-
-void swim2_device::flush_write(u64 when)
-{
-	if(!m_flux_write_start)
-		return;
-
-	if(!when)
-		when = m_last_sync;
-
-	if(m_floppy && when > m_flux_write_start) {
-		bool last_on_edge = m_flux_write_count && m_flux_write[m_flux_write_count-1] == when;
-		if(last_on_edge)
-			m_flux_write_count--;
-
-		attotime start = cycles_to_time(m_flux_write_start);
-		attotime end = cycles_to_time(when);
-		std::vector<attotime> fluxes(m_flux_write_count);
-		for(u32 i=0; i != m_flux_write_count; i++)
-			fluxes[i] = cycles_to_time(m_flux_write[i]);
-		m_floppy->write_flux(start, end, m_flux_write_count, m_flux_write_count ? &fluxes[0] : nullptr);
-
-		m_flux_write_count = 0;
-		if(last_on_edge)
-			m_flux_write[m_flux_write_count++] = when;
-		m_flux_write_start = when;
-	} else
-		m_flux_write_count = 0;
 }
 
 void swim2_device::show_mode() const
@@ -306,13 +273,13 @@ void swim2_device::write(offs_t offset, u8 data)
 		// Entering write mode
 		m_current_bit = 0;
 		LOG("%s write start %s %s floppy=%p\n", machine().time().to_string(), m_setup & 0x40 ? "gcr" : "mfm", m_setup & 0x08 ? "fclk/2" : "fclk", m_floppy);
-		m_flux_write_start = m_last_sync;
-		m_flux_write_count = 0;
+		if(m_floppy)
+			m_floppy->write_start(cycles_to_time(m_last_sync));
 
 	} else if((prev_mode & 0x18) == 0x18 && (m_mode & 0x18) != 0x18) {
 		// Exiting write mode
-		flush_write();
-		m_flux_write_start = 0;
+		if(m_floppy)
+			m_floppy->write_end(machine().time());
 		m_current_bit = 0xff;
 		m_half_cycles_before_change = 0;
 		LOG("%s write end\n", machine().time().to_string());
@@ -333,7 +300,8 @@ void swim2_device::write(offs_t offset, u8 data)
 
 	} else if((prev_mode & 0x18) == 0x08 && (m_mode & 0x18) != 0x08) {
 		// Exiting read mode
-		flush_write();
+		if(m_floppy)
+			m_floppy->write_flush(machine().time());
 		m_current_bit = 0xff;
 		m_half_cycles_before_change = 0;
 		LOG("%s read end\n", machine().time().to_string());
@@ -426,9 +394,8 @@ void swim2_device::sync()
 					m_tss_output = 0;
 				}
 				if(bit) {
-					if(m_flux_write_count == m_flux_write.size())
-						flush_write(next_sync - (cycles >> 1));
-					m_flux_write[m_flux_write_count ++] = next_sync - (cycles >> 1);
+					if(m_floppy)
+						m_floppy->write_flux_change(cycles_to_time(next_sync - (cycles >> 1)));
 					m_half_cycles_before_change = 63;
 				} else
 					m_half_cycles_before_change = m_setup & 0x40 ? 63 : 31;
@@ -446,7 +413,8 @@ void swim2_device::sync()
 					u16 r = fifo_pop();
 					if(r == 0xffff && !m_error) {
 						m_error |= 0x01;
-						flush_write();
+						if(m_floppy)
+							m_floppy->write_end(machine().time());
 						m_current_bit = 0xff;
 						m_half_cycles_before_change = 0;
 						m_mode &= ~8;

--- a/src/devices/machine/swim2.h
+++ b/src/devices/machine/swim2.h
@@ -52,9 +52,6 @@ private:
 	u32 m_half_cycles_before_change;
 
 	u64 m_last_sync;
-	u64 m_flux_write_start;
-	std::array<u64, 32> m_flux_write;
-	u32 m_flux_write_count;
 
 	fdc_pll_t m_pll;
 
@@ -64,7 +61,6 @@ private:
 	void fifo_clear();
 	bool fifo_push(u16 data);
 	u16 fifo_pop();
-	void flush_write(u64 when = 0);
 	void show_mode() const;
 
 	void crc_update(int bit);

--- a/src/devices/machine/swim3.cpp
+++ b/src/devices/machine/swim3.cpp
@@ -475,7 +475,7 @@ void swim3_device::live_start(int state, bool start_writing)
 	m_cur_live.pll.reset(m_cur_live.tm);
 	m_cur_live.pll.set_clock(attotime::from_ticks(cycles_per_cell[(m_setup >> 2) & 3], clock()));
 	if(start_writing)
-		m_cur_live.pll.start_writing(machine().time());
+		m_cur_live.pll.start_writing(machine().time(), m_floppy);
 
 	logerror("PLL %s clock %s\n", start_writing ? "write" : "read", attotime::from_ticks(cycles_per_cell[(m_setup >> 2) & 3], clock()).to_string());
 

--- a/src/devices/machine/swim3.cpp
+++ b/src/devices/machine/swim3.cpp
@@ -686,7 +686,7 @@ void swim3_device::live_start(int state, bool start_writing)
 	m_cur_live.pll.reset(m_cur_live.tm);
 	m_cur_live.pll.set_clock(period);
 	if(start_writing)
-		m_cur_live.pll.start_writing(machine().time());
+		m_cur_live.pll.start_writing(machine().time(), m_floppy);
 
 	LOG("PLL %s clock %s\n", start_writing ? "write" : "read", period.to_string());
 
@@ -1100,7 +1100,7 @@ void swim3_device::live_run(attotime limit)
 			LOG("%s write gate open\n", m_cur_live.tm.to_string());
 			m_cur_sector &= 0x7f;
 			m_cur_live.pll.set_clock(cell_period(((m_setup >> 6) & 1) | ((m_setup >> 2) & 2)));
-			m_cur_live.pll.start_writing(m_cur_live.tm);
+			m_cur_live.pll.start_writing(m_cur_live.tm, m_floppy);
 			if(m_floppy)
 				m_floppy->set_write_splice(m_cur_live.tm);
 			m_cur_live.data_bit_context = false;   // the preceding $4e gap byte ends in a 0

--- a/src/devices/machine/upd765.cpp
+++ b/src/devices/machine/upd765.cpp
@@ -1180,6 +1180,7 @@ void upd765_family_device::live_run(attotime limit)
 			return;
 
 		case WRITE_SECTOR_DATA:
+			cur_live.pll.start_writing(cur_live.tm, cur_live.fi->dev);
 			if(mfm) {
 				if(cur_live.byte_counter < 12)
 					live_write_mfm(0x00);
@@ -2475,7 +2476,7 @@ void upd765_family_device::format_track_continue(floppy_info &fi)
 		case WAIT_INDEX_DONE:
 			LOGSTATE("WAIT_INDEX_DONE\n");
 			fi.sub_state = TRACK_DONE;
-			cur_live.pll.start_writing(machine().time());
+			cur_live.pll.start_writing(machine().time(), cur_live.fi->dev);
 			LOGSTATE("WRITE_TRACK_PRE_SECTORS\n");
 			live_start(fi, WRITE_TRACK_PRE_SECTORS);
 			return;

--- a/src/devices/machine/upd765.cpp
+++ b/src/devices/machine/upd765.cpp
@@ -1196,6 +1196,7 @@ void upd765_family_device::live_run(attotime limit)
 			return;
 
 		case WRITE_SECTOR_DATA:
+			cur_live.pll.start_writing(cur_live.tm, cur_live.fi->dev);
 			if(mfm) {
 				if(cur_live.byte_counter < 12)
 					live_write_mfm(0x00);
@@ -2499,7 +2500,7 @@ void upd765_family_device::format_track_continue(floppy_info &fi)
 		case WAIT_INDEX_DONE:
 			LOGSTATE("WAIT_INDEX_DONE\n");
 			fi.sub_state = TRACK_DONE;
-			cur_live.pll.start_writing(machine().time());
+			cur_live.pll.start_writing(machine().time(), cur_live.fi->dev);
 			LOGSTATE("WRITE_TRACK_PRE_SECTORS\n");
 			live_start(fi, WRITE_TRACK_PRE_SECTORS);
 			return;

--- a/src/devices/machine/wd_fdc.cpp
+++ b/src/devices/machine/wd_fdc.cpp
@@ -912,7 +912,7 @@ void wd_fdc_device_base::write_track_continue()
 			LOGSTATE("WAIT_INDEX_DONE\n");
 			sub_state = TRACK_DONE;
 			live_start(WRITE_TRACK_DATA);
-			pll_start_writing(machine().time());
+			pll_start_writing(machine().time(), floppy);
 			return;
 
 		case TRACK_DONE:
@@ -2321,7 +2321,7 @@ void wd_fdc_device_base::live_run(attotime limit)
 					cur_live.bit_counter = 16;
 					cur_live.byte_counter = 0;
 					cur_live.data_bit_context = cur_live.data_reg & 1;
-					pll_start_writing(cur_live.tm);
+					pll_start_writing(cur_live.tm, floppy);
 					live_write_fm(0x00);
 				}
 				break;
@@ -2331,7 +2331,7 @@ void wd_fdc_device_base::live_run(attotime limit)
 				cur_live.bit_counter = 16;
 				cur_live.byte_counter = 0;
 				cur_live.data_bit_context = cur_live.data_reg & 1;
-				pll_start_writing(cur_live.tm);
+				pll_start_writing(cur_live.tm, floppy);
 				live_write_mfm(0x00);
 				break;
 			}
@@ -2441,9 +2441,9 @@ void wd_fdc_analog_device_base::pll_reset(bool fm, bool enmf, const attotime &wh
 	cur_pll.set_clock(clocks_to_attotime(clocks));
 }
 
-void wd_fdc_analog_device_base::pll_start_writing(const attotime &tm)
+void wd_fdc_analog_device_base::pll_start_writing(const attotime &tm, floppy_image_device *floppy)
 {
-	cur_pll.start_writing(tm);
+	cur_pll.start_writing(tm, floppy);
 }
 
 void wd_fdc_analog_device_base::pll_commit(floppy_image_device *floppy, const attotime &tm)
@@ -2495,9 +2495,9 @@ void wd_fdc_digital_device_base::pll_reset(bool fm, bool enmf, const attotime &w
 	cur_pll.set_clock(clocks_to_attotime(clocks));
 }
 
-void wd_fdc_digital_device_base::pll_start_writing(const attotime &tm)
+void wd_fdc_digital_device_base::pll_start_writing(const attotime &tm, floppy_image_device *floppy)
 {
-	cur_pll.start_writing(tm);
+	cur_pll.start_writing(tm, floppy);
 }
 
 void wd_fdc_digital_device_base::pll_commit(floppy_image_device *floppy, const attotime &tm)
@@ -2548,8 +2548,6 @@ void wd_fdc_digital_device_base::digital_pll_t::reset(const attotime &when)
 	phase_sub = 0x00;
 	freq_add  = 0x00;
 	freq_sub  = 0x00;
-	write_position = 0;
-	write_start_time = attotime::never;
 }
 
 int wd_fdc_digital_device_base::digital_pll_t::get_next_bit(attotime &tm, floppy_image_device *floppy, const attotime &limit)
@@ -2632,25 +2630,20 @@ int wd_fdc_digital_device_base::digital_pll_t::get_next_bit(attotime &tm, floppy
 	return bit;
 }
 
-void wd_fdc_digital_device_base::digital_pll_t::start_writing(const attotime &tm)
+void wd_fdc_digital_device_base::digital_pll_t::start_writing(const attotime &tm, floppy_image_device *floppy)
 {
-	write_start_time = tm;
-	write_position = 0;
+	if(floppy)
+		floppy->write_start(tm);
 }
 
 void wd_fdc_digital_device_base::digital_pll_t::stop_writing(floppy_image_device *floppy, const attotime &tm)
 {
-	commit(floppy, tm);
-	write_start_time = attotime::never;
+	if(floppy)
+		floppy->write_end(tm);
 }
 
 bool wd_fdc_digital_device_base::digital_pll_t::write_next_bit(bool bit, attotime &tm, floppy_image_device *floppy, const attotime &limit)
 {
-	if(write_start_time.is_never()) {
-		write_start_time = ctime;
-		write_position = 0;
-	}
-
 	for(;;) {
 		attotime etime = ctime+delays[slot];
 		if(etime > limit)
@@ -2658,8 +2651,8 @@ bool wd_fdc_digital_device_base::digital_pll_t::write_next_bit(bool bit, attotim
 		uint16_t pre_counter = counter;
 		counter += increment;
 		if(bit && !(pre_counter & 0x400) && (counter & 0x400))
-			if(write_position < std::size(write_buffer))
-				write_buffer[write_position++] = etime;
+			if(floppy)
+				floppy->write_flux_change(etime);
 		slot++;
 		tm = etime;
 		if(counter & 0x800)
@@ -2676,13 +2669,8 @@ bool wd_fdc_digital_device_base::digital_pll_t::write_next_bit(bool bit, attotim
 
 void wd_fdc_digital_device_base::digital_pll_t::commit(floppy_image_device *floppy, const attotime &tm)
 {
-	if(write_start_time.is_never() || tm == write_start_time)
-		return;
-
 	if(floppy)
-		floppy->write_flux(write_start_time, tm, write_position, write_buffer);
-	write_start_time = tm;
-	write_position = 0;
+		floppy->write_flush(tm);
 }
 
 fd1771_device::fd1771_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) : wd_fdc_analog_device_base(mconfig, FD1771, tag, owner, clock)

--- a/src/devices/machine/wd_fdc.h
+++ b/src/devices/machine/wd_fdc.h
@@ -123,7 +123,7 @@ protected:
 	virtual int settle_time() const;
 
 	virtual void pll_reset(bool fm, bool enmf, const attotime &when) = 0;
-	virtual void pll_start_writing(const attotime &tm) = 0;
+	virtual void pll_start_writing(const attotime &tm, floppy_image_device *floppy) = 0;
 	virtual void pll_commit(floppy_image_device *floppy, const attotime &tm) = 0;
 	virtual void pll_stop_writing(floppy_image_device *floppy, const attotime &tm) = 0;
 	virtual int pll_get_next_bit(attotime &tm, floppy_image_device *floppy, const attotime &limit) = 0;
@@ -381,7 +381,7 @@ protected:
 	wd_fdc_analog_device_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
 	virtual void pll_reset(bool fm, bool enmf, const attotime &when) override;
-	virtual void pll_start_writing(const attotime &tm) override;
+	virtual void pll_start_writing(const attotime &tm, floppy_image_device *floppy) override;
 	virtual void pll_commit(floppy_image_device *floppy, const attotime &tm) override;
 	virtual void pll_stop_writing(floppy_image_device *floppy, const attotime &tm) override;
 	virtual int pll_get_next_bit(attotime &tm, floppy_image_device *floppy, const attotime &limit) override;
@@ -400,7 +400,7 @@ protected:
 	static constexpr int wd_digital_step_times[4] = { 12000, 24000, 40000, 60000 };
 
 	virtual void pll_reset(bool fm, bool enmf, const attotime &when) override;
-	virtual void pll_start_writing(const attotime &tm) override;
+	virtual void pll_start_writing(const attotime &tm, floppy_image_device *floppy) override;
 	virtual void pll_commit(floppy_image_device *floppy, const attotime &tm) override;
 	virtual void pll_stop_writing(floppy_image_device *floppy, const attotime &tm) override;
 	virtual int pll_get_next_bit(attotime &tm, floppy_image_device *floppy, const attotime &limit) override;
@@ -420,15 +420,11 @@ private:
 
 		attotime delays[42];
 
-		attotime write_start_time;
-		attotime write_buffer[32];
-		int write_position;
-
 		void set_clock(const attotime &period);
 		void reset(const attotime &when);
 		int get_next_bit(attotime &tm, floppy_image_device *floppy, const attotime &limit);
 		bool write_next_bit(bool bit, attotime &tm, floppy_image_device *floppy, const attotime &limit);
-		void start_writing(const attotime &tm);
+		void start_writing(const attotime &tm, floppy_image_device *floppy);
 		void commit(floppy_image_device *floppy, const attotime &tm);
 		void stop_writing(floppy_image_device *floppy, const attotime &tm);
 	};

--- a/src/devices/machine/wozfdc.cpp
+++ b/src/devices/machine/wozfdc.cpp
@@ -91,8 +91,6 @@ void wozfdc_device::device_start()
 	save_item(NAME(cycles));
 	save_item(NAME(data_reg));
 	save_item(NAME(address));
-	save_item(NAME(write_start_time));
-	save_item(NAME(write_position));
 	save_item(NAME(write_line_active));
 	save_item(NAME(drvsel));
 	save_item(NAME(enable1));
@@ -108,8 +106,6 @@ void wozfdc_device::device_reset()
 	cycles = time_to_cycles(machine().time());
 	data_reg = 0x00;
 	address = 0x00;
-	write_start_time = attotime::never;
-	write_position = 0;
 	write_line_active = false;
 	external_io_select = false;
 
@@ -308,19 +304,18 @@ void wozfdc_device::control(int offset)
 				if(active)
 					address &= ~0x08;
 				mode_write = false;
-				attotime now = machine().time();
 				if(floppy)
-					floppy->write_flux(write_start_time, now, write_position, write_buffer);
+					floppy->write_end(machine().time());
 			}
 			break;
 		case 0xf:
 			if(!mode_write) {
 				if(active) {
 					address |= 0x08;
-					write_start_time = machine().time();
-					write_position = 0;
-					if(floppy)
-						floppy->set_write_splice(write_start_time);
+					if(floppy) {
+						floppy->write_start(machine().time());
+						floppy->set_write_splice(machine().time());
+					}
 				}
 				mode_write = true;
 			}
@@ -348,11 +343,11 @@ void wozfdc_device::lss_start()
 	cycles = time_to_cycles(machine().time());
 	data_reg = 0x00;
 	address &= ~0x0e;
-	write_position = 0;
-	write_start_time = mode_write ? machine().time() : attotime::never;
 	write_line_active = false;
-	if(mode_write && floppy)
-		floppy->set_write_splice(write_start_time);
+	if(mode_write && floppy) {
+		floppy->write_start(machine().time());
+		floppy->set_write_splice(machine().time());
+	}
 }
 
 void wozfdc_device::lss_sync(uint64_t extra_cycles)
@@ -387,14 +382,8 @@ void wozfdc_device::lss_sync(uint64_t extra_cycles)
 				if((write_line_active && !(address & 0x80)) ||
 					(!write_line_active && (address & 0x80))) {
 					write_line_active = !write_line_active;
-					assert(write_position != 32);
-					write_buffer[write_position++] = cycles_to_time(cycles);
-				} else if(write_position >= 30) {
-					attotime now = cycles_to_time(cycles);
 					if(floppy)
-						floppy->write_flux(write_start_time, now, write_position, write_buffer);
-					write_start_time = now;
-					write_position = 0;
+						floppy->write_flux_change(cycles_to_time(cycles));
 				}
 			}
 

--- a/src/devices/machine/wozfdc.cpp
+++ b/src/devices/machine/wozfdc.cpp
@@ -90,8 +90,6 @@ void wozfdc_device::device_start()
 	save_item(NAME(cycles));
 	save_item(NAME(data_reg));
 	save_item(NAME(address));
-	save_item(NAME(write_start_time));
-	save_item(NAME(write_position));
 	save_item(NAME(write_line_active));
 	save_item(NAME(drvsel));
 	save_item(NAME(enable1));
@@ -107,8 +105,6 @@ void wozfdc_device::device_reset()
 	cycles = time_to_cycles(machine().time());
 	data_reg = 0x00;
 	address = 0x00;
-	write_start_time = attotime::never;
-	write_position = 0;
 	write_line_active = false;
 	external_io_select = false;
 
@@ -310,19 +306,18 @@ void wozfdc_device::control(int offset)
 				if(active)
 					address &= ~0x08;
 				mode_write = false;
-				attotime now = machine().time();
 				if(floppy)
-					floppy->write_flux(write_start_time, now, write_position, write_buffer);
+					floppy->write_end(machine().time());
 			}
 			break;
 		case 0xf:
 			if(!mode_write) {
 				if(active) {
 					address |= 0x08;
-					write_start_time = machine().time();
-					write_position = 0;
-					if(floppy)
-						floppy->set_write_splice(write_start_time);
+					if(floppy) {
+						floppy->write_start(machine().time());
+						floppy->set_write_splice(machine().time());
+					}
 				}
 				mode_write = true;
 			}
@@ -350,11 +345,11 @@ void wozfdc_device::lss_start()
 	cycles = time_to_cycles(machine().time());
 	data_reg = 0x00;
 	address &= ~0x0e;
-	write_position = 0;
-	write_start_time = mode_write ? machine().time() : attotime::never;
 	write_line_active = false;
-	if(mode_write && floppy)
-		floppy->set_write_splice(write_start_time);
+	if(mode_write && floppy) {
+		floppy->write_start(machine().time());
+		floppy->set_write_splice(machine().time());
+	}
 }
 
 void wozfdc_device::lss_sync(uint64_t extra_cycles)
@@ -389,14 +384,8 @@ void wozfdc_device::lss_sync(uint64_t extra_cycles)
 				if((write_line_active && !(address & 0x80)) ||
 					(!write_line_active && (address & 0x80))) {
 					write_line_active = !write_line_active;
-					assert(write_position != 32);
-					write_buffer[write_position++] = cycles_to_time(cycles);
-				} else if(write_position >= 30) {
-					attotime now = cycles_to_time(cycles);
 					if(floppy)
-						floppy->write_flux(write_start_time, now, write_position, write_buffer);
-					write_start_time = now;
-					write_position = 0;
+						floppy->write_flux_change(cycles_to_time(cycles));
 				}
 			}
 

--- a/src/devices/machine/wozfdc.h
+++ b/src/devices/machine/wozfdc.h
@@ -62,9 +62,6 @@ protected:
 
 	uint64_t cycles;
 	uint8_t data_reg, address;
-	attotime write_start_time;
-	attotime write_buffer[32];
-	int write_position;
 	bool write_line_active;
 
 	const uint8_t *m_rom_p6;

--- a/src/devices/machine/wozfdc.h
+++ b/src/devices/machine/wozfdc.h
@@ -62,9 +62,6 @@ protected:
 
 	uint64_t cycles;
 	uint8_t data_reg, address;
-	attotime write_start_time;
-	attotime write_buffer[32];
-	int write_position;
 	bool write_line_active;
 
 	uint8_t last_6502_write;

--- a/src/mame/act/victor9k_fdc.cpp
+++ b/src/mame/act/victor9k_fdc.cpp
@@ -1031,7 +1031,7 @@ void victor_9000_fdc_device::drw_w(int state)
 		}
 		else
 		{
-			pll_start_writing(cur_live.tm);
+			pll_start_writing(cur_live.tm, get_floppy());
 		}
 		checkpoint();
 		live_run();
@@ -1112,10 +1112,10 @@ void victor_9000_fdc_device::pll_reset(const attotime &when)
 	cur_pll.set_clock(attotime::from_nsec(2130));
 }
 
-void victor_9000_fdc_device::pll_start_writing(const attotime &tm)
+void victor_9000_fdc_device::pll_start_writing(const attotime &tm, floppy_image_device *floppy)
 {
 	pll_reset(cur_live.tm);
-	cur_pll.start_writing(tm);
+	cur_pll.start_writing(tm, floppy);
 }
 
 void victor_9000_fdc_device::pll_commit(floppy_image_device *floppy, const attotime &tm)

--- a/src/mame/act/victor9k_fdc.cpp
+++ b/src/mame/act/victor9k_fdc.cpp
@@ -1029,7 +1029,7 @@ void victor_9000_fdc_device::drw_w(int state)
 		}
 		else
 		{
-			pll_start_writing(cur_live.tm);
+			pll_start_writing(cur_live.tm, get_floppy());
 		}
 		checkpoint();
 		live_run();
@@ -1110,10 +1110,10 @@ void victor_9000_fdc_device::pll_reset(const attotime &when)
 	cur_pll.set_clock(attotime::from_nsec(2130));
 }
 
-void victor_9000_fdc_device::pll_start_writing(const attotime &tm)
+void victor_9000_fdc_device::pll_start_writing(const attotime &tm, floppy_image_device *floppy)
 {
 	pll_reset(cur_live.tm);
-	cur_pll.start_writing(tm);
+	cur_pll.start_writing(tm, floppy);
 }
 
 void victor_9000_fdc_device::pll_commit(floppy_image_device *floppy, const attotime &tm)

--- a/src/mame/act/victor9k_fdc.h
+++ b/src/mame/act/victor9k_fdc.h
@@ -164,7 +164,7 @@ private:
 	floppy_image_device* get_floppy();
 	void live_start();
 	void pll_reset(const attotime &when);
-	void pll_start_writing(const attotime &tm);
+	void pll_start_writing(const attotime &tm, floppy_image_device *floppy);
 	void pll_commit(floppy_image_device *floppy, const attotime &tm);
 	void pll_stop_writing(floppy_image_device *floppy, const attotime &tm);
 	int pll_get_next_bit(attotime &tm, floppy_image_device *floppy, const attotime &limit);

--- a/src/mame/amiga/paulafdc.cpp
+++ b/src/mame/amiga/paulafdc.cpp
@@ -380,7 +380,7 @@ void paula_fdc_device::dma_check()
 	if(was_writing && !(dskbyt & 0x2000))
 		cur_live.pll.stop_writing(floppy, cur_live.tm);
 	if(!was_writing && (dskbyt & 0x2000))
-		cur_live.pll.start_writing(cur_live.tm);
+		cur_live.pll.start_writing(cur_live.tm, floppy);
 }
 
 void paula_fdc_device::adkcon_set(uint16_t data)
@@ -647,25 +647,20 @@ int paula_fdc_device::pll_t::get_next_bit(attotime &tm, floppy_image_device *flo
 	return bit;
 }
 
-void paula_fdc_device::pll_t::start_writing(const attotime & tm)
+void paula_fdc_device::pll_t::start_writing(const attotime & tm, floppy_image_device *floppy)
 {
-	write_start_time = tm;
-	write_position = 0;
+	if(floppy)
+		floppy->write_start(tm);
 }
 
 void paula_fdc_device::pll_t::stop_writing(floppy_image_device *floppy, const attotime &tm)
 {
-	commit(floppy, tm);
-	write_start_time = attotime::never;
+	if(floppy)
+		floppy->write_end(tm);
 }
 
 bool paula_fdc_device::pll_t::write_next_bit(bool bit, attotime &tm, floppy_image_device *floppy, const attotime &limit)
 {
-	if(write_start_time.is_never()) {
-		write_start_time = ctime;
-		write_position = 0;
-	}
-
 	for(;;) {
 		attotime etime = ctime+delays[slot];
 		if(etime > limit)
@@ -673,8 +668,8 @@ bool paula_fdc_device::pll_t::write_next_bit(bool bit, attotime &tm, floppy_imag
 		uint16_t pre_counter = counter;
 		counter += increment;
 		if(bit && !(pre_counter & 0x400) && (counter & 0x400))
-			if(write_position < std::size(write_buffer))
-				write_buffer[write_position++] = etime;
+			if(floppy)
+				floppy->write_flux_change(etime);
 		slot++;
 		tm = etime;
 		if(counter & 0x800)
@@ -692,11 +687,6 @@ bool paula_fdc_device::pll_t::write_next_bit(bool bit, attotime &tm, floppy_imag
 
 void paula_fdc_device::pll_t::commit(floppy_image_device *floppy, const attotime &tm)
 {
-	if(write_start_time.is_never() || tm == write_start_time)
-		return;
-
 	if(floppy)
-		floppy->write_flux(write_start_time, tm, write_position, write_buffer);
-	write_start_time = tm;
-	write_position = 0;
+		floppy->write_flush(tm);
 }

--- a/src/mame/amiga/paulafdc.cpp
+++ b/src/mame/amiga/paulafdc.cpp
@@ -377,7 +377,7 @@ void paula_fdc_device::dma_check()
 	if(was_writing && !(dskbyt & 0x2000))
 		cur_live.pll.stop_writing(floppy, cur_live.tm);
 	if(!was_writing && (dskbyt & 0x2000))
-		cur_live.pll.start_writing(cur_live.tm);
+		cur_live.pll.start_writing(cur_live.tm, floppy);
 }
 
 void paula_fdc_device::adkcon_set(uint16_t data)
@@ -644,25 +644,20 @@ int paula_fdc_device::pll_t::get_next_bit(attotime &tm, floppy_image_device *flo
 	return bit;
 }
 
-void paula_fdc_device::pll_t::start_writing(const attotime & tm)
+void paula_fdc_device::pll_t::start_writing(const attotime & tm, floppy_image_device *floppy)
 {
-	write_start_time = tm;
-	write_position = 0;
+	if(floppy)
+		floppy->write_start(tm);
 }
 
 void paula_fdc_device::pll_t::stop_writing(floppy_image_device *floppy, const attotime &tm)
 {
-	commit(floppy, tm);
-	write_start_time = attotime::never;
+	if(floppy)
+		floppy->write_end(tm);
 }
 
 bool paula_fdc_device::pll_t::write_next_bit(bool bit, attotime &tm, floppy_image_device *floppy, const attotime &limit)
 {
-	if(write_start_time.is_never()) {
-		write_start_time = ctime;
-		write_position = 0;
-	}
-
 	for(;;) {
 		attotime etime = ctime+delays[slot];
 		if(etime > limit)
@@ -670,8 +665,8 @@ bool paula_fdc_device::pll_t::write_next_bit(bool bit, attotime &tm, floppy_imag
 		uint16_t pre_counter = counter;
 		counter += increment;
 		if(bit && !(pre_counter & 0x400) && (counter & 0x400))
-			if(write_position < std::size(write_buffer))
-				write_buffer[write_position++] = etime;
+			if(floppy)
+				floppy->write_flux_change(etime);
 		slot++;
 		tm = etime;
 		if(counter & 0x800)
@@ -689,11 +684,6 @@ bool paula_fdc_device::pll_t::write_next_bit(bool bit, attotime &tm, floppy_imag
 
 void paula_fdc_device::pll_t::commit(floppy_image_device *floppy, const attotime &tm)
 {
-	if(write_start_time.is_never() || tm == write_start_time)
-		return;
-
 	if(floppy)
-		floppy->write_flux(write_start_time, tm, write_position, write_buffer);
-	write_start_time = tm;
-	write_position = 0;
+		floppy->write_flush(tm);
 }

--- a/src/mame/amiga/paulafdc.h
+++ b/src/mame/amiga/paulafdc.h
@@ -67,15 +67,11 @@ private:
 
 		attotime delays[38];
 
-		attotime write_start_time;
-		attotime write_buffer[32];
-		int write_position;
-
 		void set_clock(const attotime &period);
 		void reset(const attotime &when);
 		int get_next_bit(attotime &tm, floppy_image_device *floppy, const attotime &limit);
 		bool write_next_bit(bool bit, attotime &tm, floppy_image_device *floppy, const attotime &limit);
-		void start_writing(const attotime &tm);
+		void start_writing(const attotime &tm, floppy_image_device *floppy);
 		void commit(floppy_image_device *floppy, const attotime &tm);
 		void stop_writing(floppy_image_device *floppy, const attotime &tm);
 	};


### PR DESCRIPTION
Replace the batched write_flux(start, end, count, transitions) interface
with an event-driven streaming interface: write_start, write_flux_change,
write_end and write_flush.  This makes the floppy device own the write-gate
lifecycle and the transition buffer rather than requiring every controller
to maintain its own.

Some floppy controllers commit generated write flux in very small spans.
This is especially visible while formatting, where a controller can emit a
full track byte-by-byte.  With the old interface each commit edited the
persistent track vector immediately, making format operations orders of
magnitude slower than the emulated disk timing.  The new interface solves
this naturally: transitions accumulate in the floppy device and are written
to the track representation only at flush points.

write_start activates the write gate and snapshots the current track
identity.  write_flux_change appends a single transition timestamp to an
internal buffer.  write_end deactivates the write gate and flushes buffered
transitions to the track.  write_flush commits transitions earlier than a
given time without ending the write, retaining later transitions for a
subsequent flush or end.

All controllers now call write_flux_change directly as transitions are
generated rather than maintaining local buffers.  Controllers that use
speculative execution with checkpoint/rollback (wd_fdc, 64h156, c2040fdc,
paulafdc) previously needed local 32-entry write buffers to avoid
duplicating transitions after rollback.  The floppy device now handles this
transparently: write_flux_change detects out-of-sequence timestamps and
discards stale entries, so replayed transitions replace their predecessors
cleanly.

The hp9895 controller supports simultaneous read and write for write-with-
verify loopback.  It previously read back transitions from the fdc_pll
write buffer.  Since that buffer no longer exists, hp9895 now maintains its
own loopback buffer that captures transition times as they are generated
and serves them back through get_next_transition when the write gate is
active.

Add a floppy parameter to fdc_pll_t::start_writing so that write_start is
called on the floppy device at the correct point in the PLL lifecycle.
All controllers that use fdc_pll_t (wd_fdc, swim3, mc6843, upd765, i8271,
hdc92x4, hp9885, isbc202, c8050fdc, victor9k_fdc, hp9895) now pass their
floppy pointer through start_writing.  The same change applies to the
wd_fdc digital PLL and the paulafdc PLL.

The old fdc_pll_t::write_next_bit had a lazy-init path that implicitly
started writing on the first bit if start_writing had not been called.
Three controllers (upd765, i8271, hdc92x4) relied on this for sector
writes -- only their format-track paths called start_writing explicitly.
That lazy init is removed; the sector-write paths now call start_writing
at the point where they transition from reading gap data to writing sector
data.