### PR TITLE
esqpump.h: work around `format_output<bool>.apply()` infinite recursion.

### DIFF
--- a/src/devices/sound/esqpump.cpp
+++ b/src/devices/sound/esqpump.cpp
@@ -14,6 +14,52 @@
 #include "emu.h"
 #include "esqpump.h"
 
+#include <iostream>
+
+
+#define PUMP_TRACK_ESP_HALTED 0
+#define PUMP_DETECT_SILENCE 0
+#define PUMP_TRACK_SAMPLES 0
+#define PUMP_TRACK_PROCESSING 0
+#define PUMP_FAKE_ESP_PROCESSING 0
+#define PUMP_REPLACE_ESP_PROGRAM 0
+
+
+#define LOG_ESP_HALTED (1U << 1)
+
+#if PUMP_TRACK_ESP_HALTED
+#define VERBOSE LOG_ESP_HALTED
+#endif
+
+#include "logmacro.h"
+
+namespace sound::esqpump {
+
+struct stats {
+#if PUMP_TRACK_PROCESSING && !PUMP_FAKE_ESP_PROCESSING
+	osd_ticks_t ticks_spent_processing = 0;
+	int samples_processed = 0;
+#endif
+
+#if PUMP_DETECT_SILENCE
+	int silent_for = 0;
+	bool was_silence = true;
+#endif
+
+#if PUMP_TRACK_SAMPLES
+	int last_samples;
+	osd_ticks_t last_ticks;
+	osd_ticks_t next_report_ticks;
+#endif
+
+#if !PUMP_FAKE_ESP_PROCESSING && PUMP_REPLACE_ESP_PROGRAM
+	std::vector<sound_stream::sample_t> e;
+	int ei;
+#endif
+};
+
+}
+
 DEFINE_DEVICE_TYPE(ESQ_5505_5510_PUMP, esq_5505_5510_pump_device, "esq_5505_5510_pump", "Ensoniq 5505/5506 to 5510 interface")
 
 esq_5505_5510_pump_device::esq_5505_5510_pump_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
@@ -22,9 +68,51 @@ esq_5505_5510_pump_device::esq_5505_5510_pump_device(const machine_config &mconf
 	, m_stream(nullptr)
 	, m_esp(*this, finder_base::DUMMY_TAG)
 	, m_esp_halted(true)
-	, ticks_spent_processing(0)
-	, samples_processed(0)
+	, m_stats(std::make_unique<sound::esqpump::stats>())
 {
+}
+
+void esq_5505_5510_pump_device::set_esp_halted(bool esp_halted) {
+	m_esp_halted = esp_halted;
+	LOGMASKED(LOG_ESP_HALTED, "ESP-halted -> %d\n", static_cast<int>(m_esp_halted));
+	if (!esp_halted) {
+#if PUMP_REPLACE_ESP_PROGRAM
+		m_esp->write_reg(245, 0x1d0f << 8); // dlength = 0x3fff, 16-sample delay
+
+		int pc = 0;
+		for (pc = 0; pc < 0xc0; pc++) {
+			m_esp->write_reg(pc, 0);
+		}
+		pc = 0;
+		// replace the ESP program with a simple summing & single-sample delay
+		m_esp->_instr(pc++) = 0xffffeaa09000; // MOV SER0R > grp_a0
+		m_esp->_instr(pc++) = 0xffffeba00000; // ADD SER0L, gpr_a0 > gpr_a0
+		m_esp->_instr(pc++) = 0xffffeca00000; // ADD SER1R, gpr_a0 > gpr_a0
+		m_esp->_instr(pc++) = 0xffffeda00000; // ADD SER1L, gpr_a0 > gpr_a0
+		m_esp->_instr(pc++) = 0xffffeea00000; // ADD SER2R, gpr_a0 > gpr_a0
+
+		m_esp->_instr(pc  ) = 0xffffefa00000; // ADD SER2L, gpr_a0 > gpr_a0; prepare to read from delay 2 instructions from now, offset = 0
+		m_esp->write_reg(pc++, 0); //offset into delay
+
+		m_esp->_instr(pc  ) = 0xffffa0a09508; // MOV gpr_a0 > delay + offset
+		m_esp->write_reg(pc++, 1 << 8); // offset into delay - -1 samples
+
+		m_esp->_instr(pc++) = 0xffff00a19928; // MOV DIL > gpr_a1; read Delay and dump FIFO (so that the value gets written)
+
+		m_esp->_instr(pc++) = 0xffffa1f09000; // MOV gpr_a1 > SER3R
+		m_esp->_instr(pc++) = 0xffffa1f19000; // MOV gpr_a1 > SER3L
+
+		m_esp->_instr(pc++) = 0xffffffff0000; // NO-OP
+		m_esp->_instr(pc++) = 0xffffffff0000; // NO-OP
+		m_esp->_instr(pc++) = 0xfffffffff000; // END
+
+		while (pc < 160) {
+			m_esp->_instr(pc++) = 0xffffffffffff; // no-op
+		}
+#endif
+
+		// m_esp->list_program(print_to_stderr);
+	}
 }
 
 void esq_5505_5510_pump_device::device_start()
@@ -37,22 +125,24 @@ void esq_5505_5510_pump_device::device_start()
 	m_stream = stream_alloc(8, 4, clock(), STREAM_SYNCHRONOUS);
 
 #if PUMP_DETECT_SILENCE
-	silent_for = 500;
-	was_silence = 1;
+	m_stats->silent_for = 500;
+	m_stats->was_silence = 1;
 #endif
-#if !PUMP_FAKE_ESP_PROCESSING
-	ticks_spent_processing = 0;
-	samples_processed = 0;
+
+#if PUMP_TRACK_PROCESSING && !PUMP_FAKE_ESP_PROCESSING
+	m_stats->ticks_spent_processing = 0;
+	m_stats->samples_processed = 0;
 #endif
+
 #if PUMP_TRACK_SAMPLES
-	last_samples = 0;
-	last_ticks = osd_ticks();
-	next_report_ticks = last_ticks + osd_ticks_per_second();
+	m_stats->last_samples = 0;
+	m_stats->last_ticks = osd_ticks();
+	m_stats->next_report_ticks = m_stats->last_ticks + osd_ticks_per_second();
 #endif
 
 #if !PUMP_FAKE_ESP_PROCESSING && PUMP_REPLACE_ESP_PROGRAM
-	e.resize(0x4000);
-	ei = 0;
+	m_stats->e.resize(0x4000);
+	m_stats->ei = 0;
 #endif
 }
 
@@ -65,6 +155,11 @@ void esq_5505_5510_pump_device::sound_stream_update(sound_stream &stream)
 {
 	constexpr sound_stream::sample_t input_scale = 32768.0;
 	constexpr sound_stream::sample_t output_scale = 1.0 / input_scale;
+
+	if (stream.samples() != 1)
+	{
+		logerror("esq_5505_5510_pump processes one sample at a time!\n");
+	}
 
 	// Push the 'Aux' output samples directly into the output stream
 	stream.put(2, 0, stream.get(0, 0));
@@ -82,12 +177,19 @@ void esq_5505_5510_pump_device::sound_stream_update(sound_stream &stream)
 	m_esp->ser_w(6, m_esp->ser_r(0) + m_esp->ser_r(2) + m_esp->ser_r(4));
 	m_esp->ser_w(7, m_esp->ser_r(1) + m_esp->ser_r(3) + m_esp->ser_r(5));
 #else
-	if (!m_esp_halted) {
+
+if (!m_esp_halted) {
+#if PUMP_TRACK_PROCESSING
 		osd_ticks_t a = osd_ticks();
-		m_esp->run_once();
+#endif
+
+m_esp->run_once();
+
+#if PUMP_TRACK_PROCESSING
 		osd_ticks_t b = osd_ticks();
-		ticks_spent_processing += (b - a);
-		samples_processed++;
+		m_stats->ticks_spent_processing += (b - a);
+		m_stats->samples_processed++;
+#endif
 	}
 #endif
 
@@ -100,12 +202,12 @@ void esq_5505_5510_pump_device::sound_stream_update(sound_stream &stream)
 	sound_stream::sample_t el = (stream.get(2, 0)) + (stream.get(4, 0)) + (stream.get(6, 0));
 	sound_stream::sample_t er = (stream.get(3, 0)) + (stream.get(5, 0)) + (stream.get(7, 0));
 	sound_stream::sample_t e_next = el + er;
-	e[(ei + 0x1d0f) % 0x4000] = e_next;
+	m_stats->e[(m_stats->ei + 0x1d0f) % 0x4000] = e_next;
 
-	if (fabs(l - e[ei]) > 1e-5) {
-		util::stream_format(std::cerr, "expected (%d) but have (%d)\n", e[ei], l);
+	if (fabs(l - m_stats->e[m_stats->ei]) > 1e-5) {
+		util::stream_format(std::cerr, "expected (%d) but have (%d)\n", m_stats->e[m_stats->ei], l);
 	}
-	ei = (ei + 1) % 0x4000;
+	m_stats->ei = (m_stats->ei + 1) % 0x4000;
 #endif
 
 	// Write the Processed samples to the output
@@ -113,40 +215,40 @@ void esq_5505_5510_pump_device::sound_stream_update(sound_stream &stream)
 	stream.put(1, 0, r);
 
 #if PUMP_DETECT_SILENCE
-	if (left.get(0) == 0 && right.get(0) == 0) {
-		silent_for++;
+	if (l == 0 && r == 0) {
+		m_stats->silent_for++;
 	} else {
-		silent_for = 0;
+		m_stats->silent_for = 0;
 	}
-	bool silence = silent_for >= 500;
-	if (was_silence != silence) {
+	bool silence = m_stats->silent_for >= 500;
+	if (m_stats->was_silence != silence) {
 		if (!silence) {
 			util::stream_format(std::cerr, ".-*\n");
 		} else {
 			util::stream_format(std::cerr, "*-.\n");
 		}
-		was_silence = silence;
+		m_stats->was_silence = silence;
 	}
 #endif
 
 #if PUMP_TRACK_SAMPLES
-	last_samples += samples;
+	m_stats->last_samples++;
 	osd_ticks_t now = osd_ticks();
-	if (now >= next_report_ticks)
+	if (now >= m_stats->next_report_ticks)
 	{
-		osd_ticks_t elapsed = now - last_ticks;
+		osd_ticks_t elapsed = now - m_stats->last_ticks;
 		osd_ticks_t tps = osd_ticks_per_second();
-		util::stream_format(std::cerr, "Pump: %d samples in %d ticks for %f Hz\n", last_samples, elapsed, last_samples * (double)tps / (double)elapsed);
-		last_ticks = now;
-		while (next_report_ticks <= now) {
-			next_report_ticks += tps;
+		util::stream_format(std::cerr, "Pump: %d samples in %d ticks for %f Hz\n", m_stats->last_samples, elapsed, m_stats->last_samples * (double)tps / (double)elapsed);
+		m_stats->last_ticks = now;
+		while (m_stats->next_report_ticks <= now) {
+			m_stats->next_report_ticks += tps;
 		}
-		last_samples = 0;
+		m_stats->last_samples = 0;
 
 #if !PUMP_FAKE_ESP_PROCESSING
-		util::stream_format(std::cerr, "  ESP spent %d ticks on %d samples, %f ticks per sample\n", ticks_spent_processing, samples_processed, (double)ticks_spent_processing / (double)samples_processed);
-		ticks_spent_processing = 0;
-		samples_processed = 0;
+		util::stream_format(std::cerr, "  ESP spent %d ticks on %d samples, %f ticks per sample\n", m_stats->ticks_spent_processing, m_stats->samples_processed, (double)m_stats->ticks_spent_processing / (double)m_stats->samples_processed);
+		m_stats->ticks_spent_processing = 0;
+		m_stats->samples_processed = 0;
 #endif
 	}
 #endif

--- a/src/devices/sound/esqpump.h
+++ b/src/devices/sound/esqpump.h
@@ -8,6 +8,7 @@
 #include "sound/es5506.h"
 #include "cpu/es5510/es5510.h"
 
+#define PUMP_TRACK_ESP_HALT 0
 #define PUMP_DETECT_SILENCE 0
 #define PUMP_TRACK_SAMPLES 0
 #define PUMP_FAKE_ESP_PROCESSING 0
@@ -21,7 +22,7 @@ public:
 	template <typename T> void set_esp(T &&tag) { m_esp.set_tag(std::forward<T>(tag)); }
 	void set_esp_halted(bool esp_halted) {
 		m_esp_halted = esp_halted;
-		logerror("ESP-halted -> %d\n", m_esp_halted);
+		if constexpr (PUMP_TRACK_ESP_HALT) logerror("ESP-halted -> %d\n", static_cast<int>(m_esp_halted));
 		if (!esp_halted) {
 #if PUMP_REPLACE_ESP_PROGRAM
 			m_esp->write_reg(245, 0x1d0f << 8); // dlength = 0x3fff, 16-sample delay

--- a/src/devices/sound/esqpump.h
+++ b/src/devices/sound/esqpump.h
@@ -8,11 +8,11 @@
 #include "sound/es5506.h"
 #include "cpu/es5510/es5510.h"
 
-#define PUMP_TRACK_ESP_HALT 0
-#define PUMP_DETECT_SILENCE 0
-#define PUMP_TRACK_SAMPLES 0
-#define PUMP_FAKE_ESP_PROCESSING 0
-#define PUMP_REPLACE_ESP_PROGRAM 0
+namespace sound::esqpump {
+
+struct stats;
+
+}
 
 class esq_5505_5510_pump_device : public device_t, public device_sound_interface
 {
@@ -20,48 +20,7 @@ public:
 	esq_5505_5510_pump_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	template <typename T> void set_esp(T &&tag) { m_esp.set_tag(std::forward<T>(tag)); }
-	void set_esp_halted(bool esp_halted) {
-		m_esp_halted = esp_halted;
-		if constexpr (PUMP_TRACK_ESP_HALT) logerror("ESP-halted -> %d\n", static_cast<int>(m_esp_halted));
-		if (!esp_halted) {
-#if PUMP_REPLACE_ESP_PROGRAM
-			m_esp->write_reg(245, 0x1d0f << 8); // dlength = 0x3fff, 16-sample delay
-
-			int pc = 0;
-			for (pc = 0; pc < 0xc0; pc++) {
-				m_esp->write_reg(pc, 0);
-			}
-			pc = 0;
-			// replace the ESP program with a simple summing & single-sample delay
-			m_esp->_instr(pc++) = 0xffffeaa09000; // MOV SER0R > grp_a0
-			m_esp->_instr(pc++) = 0xffffeba00000; // ADD SER0L, gpr_a0 > gpr_a0
-			m_esp->_instr(pc++) = 0xffffeca00000; // ADD SER1R, gpr_a0 > gpr_a0
-			m_esp->_instr(pc++) = 0xffffeda00000; // ADD SER1L, gpr_a0 > gpr_a0
-			m_esp->_instr(pc++) = 0xffffeea00000; // ADD SER2R, gpr_a0 > gpr_a0
-
-			m_esp->_instr(pc  ) = 0xffffefa00000; // ADD SER2L, gpr_a0 > gpr_a0; prepare to read from delay 2 instructions from now, offset = 0
-			m_esp->write_reg(pc++, 0); //offset into delay
-
-			m_esp->_instr(pc  ) = 0xffffa0a09508; // MOV gpr_a0 > delay + offset
-			m_esp->write_reg(pc++, 1 << 8); // offset into delay - -1 samples
-
-			m_esp->_instr(pc++) = 0xffff00a19928; // MOV DIL > gpr_a1; read Delay and dump FIFO (so that the value gets written)
-
-			m_esp->_instr(pc++) = 0xffffa1f09000; // MOV gpr_a1 > SER3R
-			m_esp->_instr(pc++) = 0xffffa1f19000; // MOV gpr_a1 > SER3L
-
-			m_esp->_instr(pc++) = 0xffffffff0000; // NO-OP
-			m_esp->_instr(pc++) = 0xffffffff0000; // NO-OP
-			m_esp->_instr(pc++) = 0xfffffffff000; // END
-
-			while (pc < 160) {
-				m_esp->_instr(pc++) = 0xffffffffffff; // no-op
-			}
-#endif
-
-			// m_esp->list_program(print_to_stderr);
-		}
-	}
+	void set_esp_halted(bool esp_halted);
 	bool get_esp_halted() {
 		return m_esp_halted;
 	}
@@ -85,26 +44,8 @@ private:
 	// Is the ESP halted by the CPU?
 	bool m_esp_halted;
 
-#if !PUMP_FAKE_ESP_PROCESSING
-	osd_ticks_t ticks_spent_processing;
-	int samples_processed;
-#endif
-
-#if PUMP_DETECT_SILENCE
-	int silent_for;
-	bool was_silence;
-#endif
-
-#if PUMP_TRACK_SAMPLES
-	int last_samples;
-	osd_ticks_t last_ticks;
-	osd_ticks_t next_report_ticks;
-#endif
-
-#if !PUMP_FAKE_ESP_PROCESSING && PUMP_REPLACE_ESP_PROGRAM
-	std::vector<sound_stream::sample_t> e;
-	int ei;
-#endif
+	// Statitics and other tracked information.
+	std::unique_ptr<sound::esqpump::stats> m_stats;
 };
 
 DECLARE_DEVICE_TYPE(ESQ_5505_5510_PUMP, esq_5505_5510_pump_device)


### PR DESCRIPTION
Since
https://github.com/mamedev/mame/commit/b946df69fcccd06bd516ddd302ab16ee20896e2c, printing a `bool` causes infinite recursion, as also described in https://github.com/mamedev/mame/commit/b946df69fcccd06bd516ddd302ab16ee20896e2c#commitcomment-187037152 .

This PR explicitly casts a `bool` to `int` before printing, avoiding this issue. It also makes this logging conditional on a compile-time constant, and disables the logging at this time.