### PR TITLE
kaypro/kaypro.cpp: Emulate the WD1002-HD0 hard disk controller on the Kaypro 10

### DIFF
--- a/src/mame/kaypro/kaypro.cpp
+++ b/src/mame/kaypro/kaypro.cpp
@@ -124,6 +124,88 @@ void kaypro84_state::kaypro484_io(address_map &map)
 	map(0x24, 0x24).mirror(3).rw(FUNC(kaypro84_state::rtc_r), FUNC(kaypro84_state::rtc_w));
 }
 
+// Kaypro 10 ('84) with the WD1002-HD0 Winchester controller wired up.
+// 0x80 is the board's sector-buffer data port (the host bursts a 512-byte
+// sector through it with INIR/OTIR, then polls BUSY/DRQ at 0x87); 0x81-0x87
+// are the WD1010 task-file registers 1-7 (error/precomp, sector count, sector
+// number, cyl low, cyl high, SDH, status/command) -- see the V1.9E ROM source.
+void kaypro84_state::kaypro1084_io(address_map &map)
+{
+	kaypro484_io(map);
+	map(0x80, 0x87).rw(FUNC(kaypro84_state::hdc_r), FUNC(kaypro84_state::hdc_w));
+}
+
+// Kaypro 10 (1983, Bd. 81-180) with the WD1002-HD0 wired up.  Same controller
+// at the same ports as the '84, but on the simpler kaypro10_io (no z80pio/RTC).
+void kaypro84_state::kaypro10hd_io(address_map &map)
+{
+	kaypro10_io(map);
+	map(0x80, 0x87).rw(FUNC(kaypro84_state::hdc_r), FUNC(kaypro84_state::hdc_w));
+}
+
+u8 kaypro84_state::hdc_r(offs_t offset)
+{
+	if (offset == 0)   // 0x80: host reads the buffered sector (data already in the buffer)
+	{
+		u8 const data = m_hdc_buf[m_hdc_ptr & 0x1ff];
+		if (!machine().side_effects_disabled())
+			m_hdc_ptr++;
+		return data;
+	}
+	return m_hdc->read(offset);   // 0x81-0x87 -> WD1010 task-file regs 1-7
+}
+
+void kaypro84_state::hdc_w(offs_t offset, u8 data)
+{
+	if (offset == 0)   // 0x80: WD1002 sector-buffer data port
+	{
+		m_hdc_buf[m_hdc_ptr & 0x1ff] = data;
+		if ((m_hdc_ptr++ & 0x1ff) == 0x1ff)
+			m_hdc->brdy_w(1);   // host has filled a full 512-byte sector
+		return;
+	}
+	if (offset == 6)   // SDH (Size/Drive/Head)
+	{
+		// Head select comes from SDH bits 0-2 (MAME's wd1010 takes head via head_w).
+		m_hdc->head_w(data & 0x07);
+		// The Kaypro 10 has one fixed Winchester; its drive-select latch presents it
+		// as WD1010 "drive 1" (dsel01=08h).  Collapse any drive-select onto the single
+		// configured drive (0) so the controller always finds the disk.
+		data &= ~0x18;
+	}
+	if (offset == 7)   // command register: start each command with a clean buffer handshake
+	{
+		m_hdc->brdy_w(0);
+		m_hdc_ptr = 0;
+	}
+	m_hdc->write(offset, data);   // 0x81-0x87 -> WD1010 task-file regs 1-7
+}
+
+// WD1010 <-> board sector buffer: the controller drains/fills the buffer here
+// (no host-side BRDY handshake on these accesses).
+u8 kaypro84_state::hdc_buf_in()
+{
+	u8 const data = m_hdc_buf[m_hdc_ptr & 0x1ff];
+	m_hdc_ptr++;
+	return data;
+}
+
+void kaypro84_state::hdc_buf_out(u8 data)
+{
+	m_hdc_buf[m_hdc_ptr & 0x1ff] = data;
+	// once the controller has filled a whole sector, the board reports buffer-ready so the
+	// READ command completes -- the host then reads the buffer afterward (or not, on a verify).
+	if ((m_hdc_ptr++ & 0x1ff) == 0x1ff)
+		m_hdc->brdy_w(1);
+}
+
+// WD1010 buffer-counter reset (BCR): just rewind the pointer; BRDY is managed at command edges.
+void kaypro84_state::hdc_bcr_w(int state)
+{
+	if (state)
+		m_hdc_ptr = 0;
+}
+
 
 static INPUT_PORTS_START(kaypro)
 	// everything comes from the keyboard device
@@ -412,23 +494,37 @@ void kaypro84_state::kaypro1(machine_config &config)
 	SOFTWARE_LIST(config.replace(), "flop_list").set_original("kaypro").set_filter("G");
 }
 
+// WD1002-HD0 Winchester controller (WD1010-based) + 10MB ST506 drive (Shugart
+// 712 class: 306 cyl x 4 heads x 17 sec x 512 B).  The board's sector buffer is
+// exposed at I/O 0x80; the WD1010 task file at 0x81-0x87 (see the V1.9/V1.9E ROM
+// source).  Both Kaypro 10 boards (81-180 '83 and 81-181 '84) carry the same
+// controller -- only the surrounding I/O map differs -- so share the wiring here.
+void kaypro84_state::add_hdc(machine_config &config)
+{
+	config.device_remove("fdc:1");  // the HD models carry a single floppy drive
+	WD1010(config, m_hdc, 5'000'000);
+	m_hdc->out_bcr_callback().set(FUNC(kaypro84_state::hdc_bcr_w));
+	m_hdc->in_data_callback().set(FUNC(kaypro84_state::hdc_buf_in));
+	m_hdc->out_data_callback().set(FUNC(kaypro84_state::hdc_buf_out));
+	HARDDISK(config, m_hdd, 0);
+}
+
 void kaypro84_state::kaypro10(machine_config &config)
 {
 	kaypro484(config);
-	m_maincpu->set_addrmap(AS_IO, &kaypro84_state::kaypro10_io);
+	m_maincpu->set_addrmap(AS_IO, &kaypro84_state::kaypro10hd_io);
 	m_maincpu->set_daisy_config(kaypro10_daisy_chain);
 	config.device_remove("z80pio");
 	config.device_remove("rtc");
-	config.device_remove("fdc:1");  // only has 1 floppy drive
-	// need to add hard drive & controller
+	add_hdc(config);  // WD1002-HD0 + 10MB drive (also removes fdc:1)
 	SOFTWARE_LIST(config.replace(), "flop_list").set_original("kaypro").set_filter("E");
 }
 
 void kaypro84_state::kaypro1084(machine_config &config)
 {
 	kaypro484(config);
-	config.device_remove("fdc:1");  // only has 1 floppy drive
-	// need to add hard drive & controller
+	m_maincpu->set_addrmap(AS_IO, &kaypro84_state::kaypro1084_io);
+	add_hdc(config);  // WD1002-HD0 + 10MB drive (also removes fdc:1)
 	SOFTWARE_LIST(config.replace(), "flop_list").set_original("kaypro").set_filter("E");
 }
 

--- a/src/mame/kaypro/kaypro.cpp
+++ b/src/mame/kaypro/kaypro.cpp
@@ -129,41 +129,29 @@ void kaypro84_state::kaypro484_io(address_map &map)
 // sector through it with INIR/OTIR, then polls BUSY/DRQ at 0x87); 0x81-0x87
 // are the WD1010 task-file registers 1-7 (error/precomp, sector count, sector
 // number, cyl low, cyl high, SDH, status/command) -- see the V1.9E ROM source.
-void kaypro84_state::kaypro1084_io(address_map &map)
+void kaypro10_state::kaypro1084_io(address_map &map)
 {
 	kaypro484_io(map);
-	map(0x80, 0x87).rw(FUNC(kaypro84_state::hdc_r), FUNC(kaypro84_state::hdc_w));
+	map(0x80, 0x87).rw(FUNC(kaypro10_state::hdc_r), FUNC(kaypro10_state::hdc_w));
+	map(0x80, 0x80).rw(FUNC(kaypro10_state::hdc_data_r), FUNC(kaypro10_state::hdc_data_w));
 }
 
 // Kaypro 10 (1983, Bd. 81-180) with the WD1002-HD0 wired up.  Same controller
 // at the same ports as the '84, but on the simpler kaypro10_io (no z80pio/RTC).
-void kaypro84_state::kaypro10hd_io(address_map &map)
+void kaypro10_state::kaypro10hd_io(address_map &map)
 {
 	kaypro10_io(map);
-	map(0x80, 0x87).rw(FUNC(kaypro84_state::hdc_r), FUNC(kaypro84_state::hdc_w));
+	map(0x80, 0x87).rw(FUNC(kaypro10_state::hdc_r), FUNC(kaypro10_state::hdc_w));
+	map(0x80, 0x80).rw(FUNC(kaypro10_state::hdc_data_r), FUNC(kaypro10_state::hdc_data_w));
 }
 
-u8 kaypro84_state::hdc_r(offs_t offset)
+u8 kaypro10_state::hdc_r(offs_t offset)
 {
-	if (offset == 0)   // 0x80: host reads the buffered sector (data already in the buffer)
-	{
-		u8 const data = m_hdc_buf[m_hdc_ptr & 0x1ff];
-		if (!machine().side_effects_disabled())
-			m_hdc_ptr++;
-		return data;
-	}
-	return m_hdc->read(offset);   // 0x81-0x87 -> WD1010 task-file regs 1-7
+	return m_hdc->read(offset);   // 0x81-0x87 -> WD1010 task-file regs 1-7 (0x80 handled by hdc_data_r)
 }
 
-void kaypro84_state::hdc_w(offs_t offset, u8 data)
+void kaypro10_state::hdc_w(offs_t offset, u8 data)
 {
-	if (offset == 0)   // 0x80: WD1002 sector-buffer data port
-	{
-		m_hdc_buf[m_hdc_ptr & 0x1ff] = data;
-		if ((m_hdc_ptr++ & 0x1ff) == 0x1ff)
-			m_hdc->brdy_w(1);   // host has filled a full 512-byte sector
-		return;
-	}
 	if (offset == 6)   // SDH (Size/Drive/Head)
 	{
 		// Head select comes from SDH bits 0-2 (MAME's wd1010 takes head via head_w).
@@ -178,19 +166,36 @@ void kaypro84_state::hdc_w(offs_t offset, u8 data)
 		m_hdc->brdy_w(0);
 		m_hdc_ptr = 0;
 	}
-	m_hdc->write(offset, data);   // 0x81-0x87 -> WD1010 task-file regs 1-7
+	m_hdc->write(offset, data);   // 0x81-0x87 -> WD1010 task-file regs 1-7 (0x80 handled by hdc_data_w)
+}
+
+// 0x80: the WD1002 board's sector-buffer data port (host side), installed over the
+// main handler above.  The host bursts a 512-byte sector through here with INIR/OTIR.
+u8 kaypro10_state::hdc_data_r()
+{
+	u8 const data = m_hdc_buf[m_hdc_ptr & 0x1ff];
+	if (!machine().side_effects_disabled())
+		m_hdc_ptr++;
+	return data;
+}
+
+void kaypro10_state::hdc_data_w(u8 data)
+{
+	m_hdc_buf[m_hdc_ptr & 0x1ff] = data;
+	if ((m_hdc_ptr++ & 0x1ff) == 0x1ff)
+		m_hdc->brdy_w(1);   // host has filled a full 512-byte sector
 }
 
 // WD1010 <-> board sector buffer: the controller drains/fills the buffer here
 // (no host-side BRDY handshake on these accesses).
-u8 kaypro84_state::hdc_buf_in()
+u8 kaypro10_state::hdc_buf_in()
 {
 	u8 const data = m_hdc_buf[m_hdc_ptr & 0x1ff];
 	m_hdc_ptr++;
 	return data;
 }
 
-void kaypro84_state::hdc_buf_out(u8 data)
+void kaypro10_state::hdc_buf_out(u8 data)
 {
 	m_hdc_buf[m_hdc_ptr & 0x1ff] = data;
 	// once the controller has filled a whole sector, the board reports buffer-ready so the
@@ -200,7 +205,7 @@ void kaypro84_state::hdc_buf_out(u8 data)
 }
 
 // WD1010 buffer-counter reset (BCR): just rewind the pointer; BRDY is managed at command edges.
-void kaypro84_state::hdc_bcr_w(int state)
+void kaypro10_state::hdc_bcr_w(int state)
 {
 	if (state)
 		m_hdc_ptr = 0;
@@ -499,20 +504,20 @@ void kaypro84_state::kaypro1(machine_config &config)
 // exposed at I/O 0x80; the WD1010 task file at 0x81-0x87 (see the V1.9/V1.9E ROM
 // source).  Both Kaypro 10 boards (81-180 '83 and 81-181 '84) carry the same
 // controller -- only the surrounding I/O map differs -- so share the wiring here.
-void kaypro84_state::add_hdc(machine_config &config)
+void kaypro10_state::add_hdc(machine_config &config)
 {
 	config.device_remove("fdc:1");  // the HD models carry a single floppy drive
 	WD1010(config, m_hdc, 5'000'000);
-	m_hdc->out_bcr_callback().set(FUNC(kaypro84_state::hdc_bcr_w));
-	m_hdc->in_data_callback().set(FUNC(kaypro84_state::hdc_buf_in));
-	m_hdc->out_data_callback().set(FUNC(kaypro84_state::hdc_buf_out));
+	m_hdc->out_bcr_callback().set(FUNC(kaypro10_state::hdc_bcr_w));
+	m_hdc->in_data_callback().set(FUNC(kaypro10_state::hdc_buf_in));
+	m_hdc->out_data_callback().set(FUNC(kaypro10_state::hdc_buf_out));
 	HARDDISK(config, m_hdd, 0);
 }
 
-void kaypro84_state::kaypro10(machine_config &config)
+void kaypro10_state::kaypro10(machine_config &config)
 {
 	kaypro484(config);
-	m_maincpu->set_addrmap(AS_IO, &kaypro84_state::kaypro10hd_io);
+	m_maincpu->set_addrmap(AS_IO, &kaypro10_state::kaypro10hd_io);
 	m_maincpu->set_daisy_config(kaypro10_daisy_chain);
 	config.device_remove("z80pio");
 	config.device_remove("rtc");
@@ -520,10 +525,10 @@ void kaypro84_state::kaypro10(machine_config &config)
 	SOFTWARE_LIST(config.replace(), "flop_list").set_original("kaypro").set_filter("E");
 }
 
-void kaypro84_state::kaypro1084(machine_config &config)
+void kaypro10_state::kaypro1084(machine_config &config)
 {
 	kaypro484(config);
-	m_maincpu->set_addrmap(AS_IO, &kaypro84_state::kaypro1084_io);
+	m_maincpu->set_addrmap(AS_IO, &kaypro10_state::kaypro1084_io);
 	add_hdc(config);  // WD1002-HD0 + 10MB drive (also removes fdc:1)
 	SOFTWARE_LIST(config.replace(), "flop_list").set_original("kaypro").set_filter("E");
 }
@@ -807,12 +812,12 @@ ROM_END
 /*    YEAR  NAME          PARENT     COMPAT  MACHINE     INPUT   CLASS           INIT         COMPANY               FULLNAME */
 COMP( 1982, kayproii,     0,         0,      kayproii,   kaypro, kayproii_state, init_kaypro, "Non-Linear Systems", "Kaypro II - 2/83", MACHINE_SUPPORTS_SAVE )
 COMP( 1983, kayproiv,     kayproii,  0,      kayproiv,   kaypro, kayproii_state, init_kaypro, "Non-Linear Systems", "Kaypro IV - 4/83", MACHINE_SUPPORTS_SAVE ) // model 81-004
-COMP( 1983, kaypro10,     0,         0,      kaypro10,   kaypro, kaypro84_state, init_kaypro, "Non-Linear Systems", "Kaypro 10 - 1983", MACHINE_SUPPORTS_SAVE )
+COMP( 1983, kaypro10,     0,         0,      kaypro10,   kaypro, kaypro10_state, init_kaypro, "Non-Linear Systems", "Kaypro 10 - 1983", MACHINE_SUPPORTS_SAVE )
 COMP( 1983, kayproiip88,  kayproii,  0,      kayproii,   kaypro, kayproii_state, init_kaypro, "Kaypro Corporation", "Kaypro 4 plus88 - 4/83" , MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // model 81-004 with an added 8088 daughterboard and rom
 COMP( 1984, kaypro484,    0,         0,      kaypro484,  kaypro, kaypro84_state, init_kaypro, "Kaypro Corporation", "Kaypro 4/84", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // model 81-015
 COMP( 1984, kaypro284,    kaypro484, 0,      kaypro284,  kaypro, kaypro84_state, init_kaypro, "Kaypro Corporation", "Kaypro 2/84", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // model 81-015
 COMP( 1984, kaypro484p88, kaypro484, 0,      kaypro484,  kaypro, kaypro84_state, init_kaypro, "Kaypro Corporation", "Kaypro 4/84 plus88", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // model 81-015 with an added 8088 daughterboard and rom
-COMP( 1984, kaypro1084,   kaypro10,  0,      kaypro1084, kaypro, kaypro84_state, init_kaypro, "Kaypro Corporation", "Kaypro 10", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // model 81-005
+COMP( 1984, kaypro1084,   kaypro10,  0,      kaypro1084, kaypro, kaypro10_state, init_kaypro, "Kaypro Corporation", "Kaypro 10", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // model 81-005
 COMP( 1984, robie,        0,         0,      kaypro4x,   kaypro, kaypro84_state, init_kaypro, "Kaypro Corporation", "Kaypro Robie", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE )
 COMP( 1985, kaypro2x,     kaypro484, 0,      kaypro484,  kaypro, kaypro84_state, init_kaypro, "Kaypro Corporation", "Kaypro 2x", MACHINE_SUPPORTS_SAVE ) // model 81-025
 COMP( 1985, kaypronew2,   0,         0,      kaypronew2, kaypro, kaypro84_state, init_kaypro, "Kaypro Corporation", "Kaypro New 2", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/kaypro/kaypro.h
+++ b/src/mame/kaypro/kaypro.h
@@ -122,14 +122,10 @@ public:
 		: kaypro_state(mconfig, type, tag)
 		, m_crtc(*this, "crtc")
 		, m_rtc(*this, "rtc")
-		, m_hdc(*this, "hdc")
-		, m_hdd(*this, "hdc:0")
 	{}
 
 	void kaypronew2(machine_config &config);
 	void kaypro484(machine_config &config);
-	void kaypro10(machine_config &config);
-	void kaypro1084(machine_config &config);
 	void kaypro284(machine_config &config);
 	void kaypro4x(machine_config &config);
 	void kaypro1(machine_config &config);
@@ -137,19 +133,10 @@ public:
 protected:
 	virtual void machine_start() override ATTR_COLD;
 
-private:
 	void kaypro10_io(address_map &map) ATTR_COLD;
-	void kaypro10hd_io(address_map &map) ATTR_COLD;
 	void kaypro484_io(address_map &map) ATTR_COLD;
-	void kaypro1084_io(address_map &map) ATTR_COLD;
 
-	void add_hdc(machine_config &config);          // shared WD1002-HD0 wiring (kaypro10 + kaypro1084)
-	u8 hdc_r(offs_t offset);
-	void hdc_w(offs_t offset, u8 data);
-	u8 hdc_buf_in();
-	void hdc_buf_out(u8 data);
-	void hdc_bcr_w(int state);
-
+private:
 	u8 kaypro484_87_r();
 	u8 kaypro484_system_port_r();
 	u8 kaypro484_status_r();
@@ -169,15 +156,45 @@ private:
 
 	required_device<mc6845_device> m_crtc;
 	optional_device<mm58167_device> m_rtc;
-	optional_device<wd1010_device> m_hdc;          // WD1002-HD0 Winchester controller (kaypro10/1084)
-	optional_device<harddisk_image_device> m_hdd;
-	std::unique_ptr<u8[]> m_hdc_buf;               // WD1002 board sector buffer
-	u16 m_hdc_ptr = 0U;
 
 	u8 m_mc6845_reg[32]{};
 	u8 m_mc6845_ind = 0U;
 	u16 m_mc6845_video_address = 0U;
 	u8 m_rtc_address = 0U;
+};
+
+class kaypro10_state : public kaypro84_state
+{
+public:
+	kaypro10_state(const machine_config &mconfig, device_type type, const char *tag)
+		: kaypro84_state(mconfig, type, tag)
+		, m_hdc(*this, "hdc")
+		, m_hdd(*this, "hdc:0")
+	{}
+
+	void kaypro10(machine_config &config);
+	void kaypro1084(machine_config &config);
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+
+private:
+	void kaypro10hd_io(address_map &map) ATTR_COLD;
+	void kaypro1084_io(address_map &map) ATTR_COLD;
+
+	void add_hdc(machine_config &config);          // shared WD1002-HD0 wiring (kaypro10 + kaypro1084)
+	u8 hdc_r(offs_t offset);
+	void hdc_w(offs_t offset, u8 data);
+	u8 hdc_data_r();
+	void hdc_data_w(u8 data);
+	u8 hdc_buf_in();
+	void hdc_buf_out(u8 data);
+	void hdc_bcr_w(int state);
+
+	required_device<wd1010_device> m_hdc;          // WD1002-HD0 Winchester controller
+	required_device<harddisk_image_device> m_hdd;
+	std::unique_ptr<u8[]> m_hdc_buf;               // WD1002 board sector buffer
+	u16 m_hdc_ptr = 0U;
 };
 
 #endif // MAME_KAYPRO_KAYPRO_H

--- a/src/mame/kaypro/kaypro.h
+++ b/src/mame/kaypro/kaypro.h
@@ -15,6 +15,7 @@
 #include "video/mc6845.h"
 #include "machine/mm58167.h"
 #include "machine/wd_fdc.h"
+#include "machine/wd1010.h"
 #include "machine/timer.h"
 #include "emupal.h"
 #include "screen.h"
@@ -121,6 +122,8 @@ public:
 		: kaypro_state(mconfig, type, tag)
 		, m_crtc(*this, "crtc")
 		, m_rtc(*this, "rtc")
+		, m_hdc(*this, "hdc")
+		, m_hdd(*this, "hdc:0")
 	{}
 
 	void kaypronew2(machine_config &config);
@@ -136,7 +139,16 @@ protected:
 
 private:
 	void kaypro10_io(address_map &map) ATTR_COLD;
+	void kaypro10hd_io(address_map &map) ATTR_COLD;
 	void kaypro484_io(address_map &map) ATTR_COLD;
+	void kaypro1084_io(address_map &map) ATTR_COLD;
+
+	void add_hdc(machine_config &config);          // shared WD1002-HD0 wiring (kaypro10 + kaypro1084)
+	u8 hdc_r(offs_t offset);
+	void hdc_w(offs_t offset, u8 data);
+	u8 hdc_buf_in();
+	void hdc_buf_out(u8 data);
+	void hdc_bcr_w(int state);
 
 	u8 kaypro484_87_r();
 	u8 kaypro484_system_port_r();
@@ -157,6 +169,10 @@ private:
 
 	required_device<mc6845_device> m_crtc;
 	optional_device<mm58167_device> m_rtc;
+	optional_device<wd1010_device> m_hdc;          // WD1002-HD0 Winchester controller (kaypro10/1084)
+	optional_device<harddisk_image_device> m_hdd;
+	std::unique_ptr<u8[]> m_hdc_buf;               // WD1002 board sector buffer
+	u16 m_hdc_ptr = 0U;
 
 	u8 m_mc6845_reg[32]{};
 	u8 m_mc6845_ind = 0U;

--- a/src/mame/kaypro/kaypro_m.cpp
+++ b/src/mame/kaypro/kaypro_m.cpp
@@ -267,15 +267,17 @@ void kaypro84_state::machine_start()
 
 	if (m_rtc.found())
 		save_item(NAME(m_rtc_address));
+}
 
-	if (m_hdc.found())
-	{
-		m_hdc_buf = std::make_unique<u8[]>(512);
-		save_pointer(NAME(m_hdc_buf), 512);
-		save_item(NAME(m_hdc_ptr));
-		m_hdc->drdy_w(m_hdd->exists() ? 1 : 0);  // WD1002 drive-ready
-		m_hdc->sc_w(1);                          // seek complete (heads at a known track)
-	}
+void kaypro10_state::machine_start()
+{
+	kaypro84_state::machine_start();
+
+	m_hdc_buf = std::make_unique<u8[]>(512);
+	save_pointer(NAME(m_hdc_buf), 512);
+	save_item(NAME(m_hdc_ptr));
+	m_hdc->drdy_w(m_hdd->exists() ? 1 : 0);  // WD1002 drive-ready
+	m_hdc->sc_w(1);                          // seek complete (heads at a known track)
 }
 
 void kaypro_state::machine_reset()

--- a/src/mame/kaypro/kaypro_m.cpp
+++ b/src/mame/kaypro/kaypro_m.cpp
@@ -267,6 +267,15 @@ void kaypro84_state::machine_start()
 
 	if (m_rtc.found())
 		save_item(NAME(m_rtc_address));
+
+	if (m_hdc.found())
+	{
+		m_hdc_buf = std::make_unique<u8[]>(512);
+		save_pointer(NAME(m_hdc_buf), 512);
+		save_item(NAME(m_hdc_ptr));
+		m_hdc->drdy_w(m_hdd->exists() ? 1 : 0);  // WD1002 drive-ready
+		m_hdc->sc_w(1);                          // seek complete (heads at a known track)
+	}
 }
 
 void kaypro_state::machine_reset()


### PR DESCRIPTION
## Summary

Adds emulation of the WD1002-HD0 Winchester controller and its 10 MB ST506 drive to the two Kaypro 10 machine configurations, which previously had floppy-only support (the driver carried a `// need to add hard drive & controller` placeholder):

- `kaypro10` — 1983, mainboard 81-180, V1.9 ROM
- `kaypro1084` — 1984, mainboard 81-181, V1.9E ROM

Both boards use the same controller at the same I/O ports and differ only in the surrounding I/O map (the '83 board has no Z80 PIO / RTC), so the controller wiring is shared through one `add_hdc()` helper.

## Hardware

The WD1002-HD0 is built around the WD1010 task-file controller already emulated in `machine/wd1010.cpp`. On the Kaypro 10 it appears at:

- `0x80` — board sector-buffer data port (the host moves a 512-byte sector through it with a single `INIR`/`OTIR` burst)
- `0x81-0x87` — WD1010 task file (error/precomp, sector count, sector number, cylinder low/high, SDH, status/command)

Drive geometry is 306 cylinders × 4 heads × 17 sectors × 512 bytes (~10 MB); CP/M uses 16 of the 17 sectors per track. An image is created with:

    chdman createhd -o kaypro10.chd -chs 306,4,17 -ss 512

## Implementation notes

- A 512-byte board buffer (`m_hdc_buf`) sits between the host and the WD1010: the host fills/drains it at `0x80` while the controller drains/fills it through the device's data callbacks. Buffer-ready (`brdy_w`) is asserted when a full sector has moved and reset at each command write.
- The Kaypro 10 has a single fixed Winchester whose drive-select latch presents it as WD1010 "drive 1"; the SDH write collapses any drive-select onto the one configured drive so the controller always finds the disk.
- No new device type is introduced — this reuses the existing `wd1010_device` and `harddisk_image_device`. The HD devices are `optional_device`s and the `machine_start` setup is guarded by `m_hdc.found()`, so floppy-only operation is unchanged.

## Provenance

The port map, command set, geometry and buffer/handshake behaviour were derived from period Kaypro 10 CP/M disk-utility and BIOS source and verified against the V1.9 (81-188) and V1.9E (81-302) ROMs.

## Testing

- `kaypro10` and `kaypro1084` both boot CP/M from floppy unchanged.
- With a CHD attached (`-hard1`), the period Kaypro 10 hard-disk utilities run correctly: `FORMAT04.COM` (a partial low-level format that is largely a surface verify) completes, and `FINDBAD.COM` reads the entire disk surface (a full bad-sector scan) without error.
- Floppy-only operation (no `-hard1`) is unaffected.

## Related

`machine/wd1010.cpp` currently ships with `VERBOSE` set to all log categories, so any WD1010 user (including this one) floods `error.log` under `-log`. A separate one-line PR resets that to `(0)`.
