### PR TITLE
machine/wd1010: disable verbose logging by default

### DIFF
--- a/src/devices/machine/wd1010.cpp
+++ b/src/devices/machine/wd1010.cpp
@@ -15,7 +15,7 @@
 #define LOG_REGS    (1U << 4)
 #define LOG_DATA    (1U << 5)
 
-#define VERBOSE  (LOG_CMD | LOG_INT | LOG_SEEK | LOG_REGS | LOG_DATA)
+#define VERBOSE  (0)
 //#define LOG_OUTPUT_STREAM std::cout
 
 #include "logmacro.h"


### PR DESCRIPTION
`wd1010.cpp` is committed with

    #define VERBOSE  (LOG_CMD | LOG_INT | LOG_SEEK | LOG_REGS | LOG_DATA)

i.e. every log category enabled, so every WD1010 user (`tekigw`, `tandy2k`, `unixpc`, `kaypro`) floods `error.log` with per-command / per-register / per-seek traces under `-log`. Reset to `(0)`, matching the convention for committed device code; the individual `LOG_*` categories remain defined for anyone who wants to re-enable them while debugging.
