### PR TITLE
nintendo/nes_vt369_vtunknown.cpp: Add 36-in-1 Classic Games phone case

### DIFF
--- a/src/devices/video/ppu2c0x.cpp
+++ b/src/devices/video/ppu2c0x.cpp
@@ -299,6 +299,16 @@ u8 ppu2c0x_device::readbyte(offs_t address)
 	return space().read_byte(address);
 }
 
+u8 ppu2c0x_device::ppu_vram_direct_read(offs_t address)
+{
+	return readbyte(address);
+}
+
+void ppu2c0x_device::ppu_vram_direct_write(offs_t address, u8 data)
+{
+	writebyte(address, data);
+}
+
 
 //-------------------------------------------------
 //  writebyte - write a byte at the given address
@@ -1381,6 +1391,11 @@ u16 ppu2c0x_device::get_vram_dest()
 void ppu2c0x_device::set_vram_dest(u16 dest)
 {
 	m_videomem_addr = dest;
+}
+
+void ppu2c0x_device::reload_refresh_data()
+{
+	m_refresh_data = m_refresh_latch;
 }
 
 /*************************************

--- a/src/devices/video/ppu2c0x.h
+++ b/src/devices/video/ppu2c0x.h
@@ -99,6 +99,10 @@ public:
 
 	u16 get_vram_dest();
 	void set_vram_dest(u16 dest);
+	void reload_refresh_data();
+
+	u8 ppu_vram_direct_read(offs_t address);
+	void ppu_vram_direct_write(offs_t address, u8 data);
 
 	bool in_vblanking() { return (m_scanline >= m_vblank_first_scanline - 1); }
 protected:

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -992,11 +992,7 @@ void ppu_vt3xx_device::shift_tile_plane_data(u8 &pix)
 void ppu_vt3xx_device::draw_background(u8 *line_priority)
 {
 	const bool is_vt369_64_byte_names = (m_newvid_1c == 0x12) && (m_newvid_1d == 0x09) && (m_newvid_1e == 0x0f)
-			&& (m_204x_screenregs[0] == 0x40) && (m_204x_screenregs[1] == 0xa1)
-			&& (m_204x_screenregs[2] == 0x00) && (m_204x_screenregs[3] == 0x78)
-			&& (m_204x_screenregs[4] == 0xff) && (m_204x_screenregs[5] == 0x04)
-			&& (m_204x_screenregs[6] == 0x0a) && (m_204x_screenregs[7] == 0xd8)
-			&& (m_204x_screenregs[8] == 0x0a) && (m_204x_screenregs[9] == 0x00);
+			&& BIT(m_tilebases_2x[0], 4);
 
 	if (!is_vt369_64_byte_names)
 	{

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -991,7 +991,14 @@ void ppu_vt3xx_device::shift_tile_plane_data(u8 &pix)
 
 void ppu_vt3xx_device::draw_background(u8 *line_priority)
 {
-	if ((m_newvid_1c != 0x12) || (m_newvid_1d != 0x09) || (m_newvid_1e != 0x0f))
+	const bool is_vt369_64_byte_names = (m_newvid_1c == 0x12) && (m_newvid_1d == 0x09) && (m_newvid_1e == 0x0f)
+			&& (m_204x_screenregs[0] == 0x40) && (m_204x_screenregs[1] == 0xa1)
+			&& (m_204x_screenregs[2] == 0x00) && (m_204x_screenregs[3] == 0x78)
+			&& (m_204x_screenregs[4] == 0xff) && (m_204x_screenregs[5] == 0x04)
+			&& (m_204x_screenregs[6] == 0x0a) && (m_204x_screenregs[7] == 0xd8)
+			&& (m_204x_screenregs[8] == 0x0a) && (m_204x_screenregs[9] == 0x00);
+
+	if (!is_vt369_64_byte_names)
 	{
 		ppu_vt03_device::draw_background(line_priority);
 		return;

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -249,6 +249,7 @@ void ppu_vt03_device::device_start()
 	save_item(NAME(m_newvid_1d));
 	save_item(NAME(m_newvid_1e));
 	save_item(NAME(m_tilebases_2x));
+	save_item(NAME(m_vt369_dma_vram_target));
 }
 
 void ppu_vt03_device::device_reset()
@@ -281,6 +282,8 @@ void ppu_vt03_device::device_reset()
 
 	for (int i = 0; i < 4; i++)
 		m_tilebases_2x[i] = 0x00;
+
+	m_vt369_dma_vram_target = 0;
 }
 
 
@@ -838,12 +841,9 @@ void ppu_vt3xx_device::write(offs_t offset, u8 data)
 	if (((offset & 7) == PPU_ADDRESS) && (m_newvid_1c == 0x12) && (m_newvid_1d == 0x09) && (m_newvid_1e == 0x0f))
 	{
 		if (m_toggle)
-			set_vram_dest((get_vram_dest() & 0xff00) | data);
+			m_vt369_dma_vram_target = (m_vt369_dma_vram_target & 0xff00) | data;
 		else
-			set_vram_dest((get_vram_dest() & 0x00ff) | ((data & (m_videoram_addr_mask >> 8)) << 8));
-
-		m_toggle = !m_toggle;
-		return;
+			m_vt369_dma_vram_target = (m_vt369_dma_vram_target & 0x00ff) | ((data & (m_videoram_addr_mask >> 8)) << 8);
 	}
 
 	const bool was_rendering = (m_regs[PPU_CONTROL1] & (PPU_CONTROL1_BACKGROUND | PPU_CONTROL1_SPRITES)) != 0;
@@ -992,7 +992,7 @@ void ppu_vt3xx_device::shift_tile_plane_data(u8 &pix)
 void ppu_vt3xx_device::draw_background(u8 *line_priority)
 {
 	const bool is_vt369_64_byte_names = (m_newvid_1c == 0x12) && (m_newvid_1d == 0x09) && (m_newvid_1e == 0x0f)
-			&& BIT(m_tilebases_2x[0], 4);
+			&& BIT(m_tilebases_2x[0], 4) && (m_tilebases_2x[2] == 0x08);
 
 	if (!is_vt369_64_byte_names)
 	{

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -283,6 +283,7 @@ void ppu_vt03_device::device_reset()
 		m_tilebases_2x[i] = 0x00;
 }
 
+
 u8 ppu_vt03_device::get_m_read_bg4_bg3()
 {
 	return m_read_bg4_bg3;
@@ -685,6 +686,9 @@ void ppu_vt3xx_device::device_start()
 
 	save_item(NAME(m_204x_screenregs));
 	save_item(NAME(m_2008_spritehigh));
+	save_item(NAME(m_201f_ext));
+	save_item(NAME(m_2024_lightgun1_y));
+	save_item(NAME(m_2050_lcdc));
 }
 
 void ppu_vt3xx_device::device_reset()
@@ -695,11 +699,15 @@ void ppu_vt3xx_device::device_reset()
 		m_204x_screenregs[i] = 0x00;
 
 	m_2008_spritehigh = 0;
+	m_201f_ext = 0;
+	m_2024_lightgun1_y = 0;
+	m_2050_lcdc = 0;
 }
 
 u8 ppu_vt3xx_device::extvidreg_201c_r(offs_t offset) { return m_newvid_1c; }
 u8 ppu_vt3xx_device::extvidreg_201d_r(offs_t offset) { return m_newvid_1d; }
 u8 ppu_vt3xx_device::extvidreg_201e_r(offs_t offset) { return m_newvid_1e; }
+u8 ppu_vt3xx_device::lightgun1_y_2024_r() { return m_2024_lightgun1_y; }
 u8 ppu_vt3xx_device::tilebases_202x_r(offs_t offset) { return m_tilebases_2x[offset]; }
 
 void ppu_vt3xx_device::extvidreg_201c_w(offs_t offset, u8 data) { m_newvid_1c = data; logerror("%s: extvidreg_201c_w %02x\n", machine().describe_context(), data); }
@@ -714,6 +722,16 @@ void ppu_vt3xx_device::extvidreg_201e_w(offs_t offset, u8 data)
 	*/
 	m_newvid_1e = data;
 	logerror("%s: extvidreg_201e_w %02x\n", machine().describe_context(), data);
+}
+
+void ppu_vt3xx_device::extvidreg_201f_w(u8 data)
+{
+	m_201f_ext = data;
+}
+
+void ppu_vt3xx_device::lightgun1_y_2024_w(u8 data)
+{
+	m_2024_lightgun1_y = data;
 }
 
 void ppu_vt3xx_device::tilebases_202x_w(offs_t offset, u8 data)
@@ -757,6 +775,8 @@ void ppu_vt3xx_device::lcdc_regs_w(offs_t offset, u8 data)
 
 		// lxcypkdp uses this on the menus, they must rotate the rendering somehow as this is vertical and the games are horizontal!
 		{ 0, 127, 0, 159, { 0x80, 0xfe, 0x00, 0x50, 0xff, 0x04, 0x00, 0xa8, 0x04, 0x00 }, },
+
+		{ 0, 255, 0, 239, { 0x40, 0xa1, 0x00, 0x78, 0xff, 0x04, 0x0a, 0xd8, 0x0a, 0x00 }, }, // 36pcase language selector
 
 		// configurations used for 'regular' output
 		{ 0, 255, 0, 239, { 0xa0, 0x57, 0x09, 0x40, 0x93, 0x04, 0x00, 0x83, 0x08, 0x00 }, }, // full mode for the 0, 159, 0, 127 config
@@ -808,6 +828,36 @@ void ppu_vt3xx_device::lcdc_regs_w(offs_t offset, u8 data)
 	}
 }
 
+void ppu_vt3xx_device::lcdc_2050_w(u8 data)
+{
+	m_2050_lcdc = data;
+}
+
+void ppu_vt3xx_device::write(offs_t offset, u8 data)
+{
+	if (((offset & 7) == PPU_ADDRESS) && (m_newvid_1c == 0x12) && (m_newvid_1d == 0x09) && (m_newvid_1e == 0x0f))
+	{
+		if (m_toggle)
+			set_vram_dest((get_vram_dest() & 0xff00) | data);
+		else
+			set_vram_dest((get_vram_dest() & 0x00ff) | ((data & (m_videoram_addr_mask >> 8)) << 8));
+
+		m_toggle = !m_toggle;
+		return;
+	}
+
+	const bool was_rendering = (m_regs[PPU_CONTROL1] & (PPU_CONTROL1_BACKGROUND | PPU_CONTROL1_SPRITES)) != 0;
+
+	ppu_vt03_device::write(offset, data);
+
+	if (((offset & 7) == PPU_CONTROL1) && (m_newvid_1c == 0x12) && (m_newvid_1d == 0x09) && (m_newvid_1e == 0x0f))
+	{
+		const bool is_rendering = (m_regs[PPU_CONTROL1] & (PPU_CONTROL1_BACKGROUND | PPU_CONTROL1_SPRITES)) != 0;
+		if (!was_rendering && is_rendering)
+			reload_refresh_data();
+	}
+}
+
 // vt3xx tile modes are no longer planar, but the tile code provides ROM offsets that
 // would be, this converts them to offsets that give us the data we want.
 offs_t ppu_vt3xx_device::recalculate_offsets_8x8x4packed_tile(int address, int va34)
@@ -828,7 +878,7 @@ offs_t ppu_vt3xx_device::recalculate_offsets_8x8x8packed_tile(int address, int v
 	int colorbits = get_m_read_bg4_bg3();
 	int tileline = address & 0x0007;
 	int tileplane = address & 0x0008;
-	int tilenum = address & 0x0ff0;
+	int tilenum = address & (((m_newvid_1c == 0x12) && (m_newvid_1d == 0x09) && (m_newvid_1e == 0x0f)) ? 0xfff0 : 0x0ff0);
 	int finaloffset = (tilenum << 2) | (tileline << 3) | (tileplane >> 1) | va34;
 	finaloffset += colorbits * 0x4000;
 	return finaladdr + finaloffset;
@@ -884,14 +934,18 @@ void ppu_vt3xx_device::read_tile_plane_data(int address, int color)
 		{
 			if ((m_newvid_1c & 0x03) == 0x02)
 			{
-				m_planebuf[0] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 0) & 0x1fff, 0));
-				m_planebuf[1] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 8) & 0x1fff, 0));
-				m_planebuf[2] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 0) & 0x1fff, 1));
-				m_planebuf[3] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 8) & 0x1fff, 1));
-				m_planebuf[4] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 0) & 0x1fff, 2));
-				m_planebuf[5] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 8) & 0x1fff, 2));
-				m_planebuf[6] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 0) & 0x1fff, 3));
-				m_planebuf[7] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile((address + 8) & 0x1fff, 3));
+				const bool is_vt369_8bpp_wide_tile = (m_newvid_1c == 0x12) && (m_newvid_1d == 0x09) && (m_newvid_1e == 0x0f);
+				const int address0 = is_vt369_8bpp_wide_tile ? (address + 0) : ((address + 0) & 0x1fff);
+				const int address8 = is_vt369_8bpp_wide_tile ? (address + 8) : ((address + 8) & 0x1fff);
+
+				m_planebuf[0] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile(address0, 0));
+				m_planebuf[1] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile(address8, 0));
+				m_planebuf[2] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile(address0, 1));
+				m_planebuf[3] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile(address8, 1));
+				m_planebuf[4] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile(address0, 2));
+				m_planebuf[5] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile(address8, 2));
+				m_planebuf[6] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile(address0, 3));
+				m_planebuf[7] = m_read_onespace_with_relative(recalculate_offsets_8x8x8packed_tile(address8, 3));
 			}
 			else
 			{
@@ -932,6 +986,83 @@ void ppu_vt3xx_device::shift_tile_plane_data(u8 &pix)
 			}
 		}
 		m_whichpixel++;
+	}
+}
+
+void ppu_vt3xx_device::draw_background(u8 *line_priority)
+{
+	if ((m_newvid_1c != 0x12) || (m_newvid_1d != 0x09) || (m_newvid_1e != 0x0f))
+	{
+		ppu_vt03_device::draw_background(line_priority);
+		return;
+	}
+
+	const u8 scroll_x_coarse = m_refresh_data & 0x001f;
+	const u8 scroll_y_coarse = (m_refresh_data & 0x03e0) >> 5;
+	const u16 nametable = m_refresh_data & 0x0c00;
+	const u8 scroll_y_fine = (m_refresh_data & 0x7000) >> 12;
+
+	int x = scroll_x_coarse;
+	const u8 source_y_coarse = (scroll_y_coarse + (BIT(nametable, 11) ? 30 : 0)) & 0x1f;
+	const u8 source_y_fine = scroll_y_fine;
+
+	int tile_index = 0x2000 + source_y_coarse * 64;
+
+	int start_x = (m_x_fine ^ 0x07) - 7;
+	u32 *dest = &m_bitmap.pix(m_scanline, start_x);
+
+	m_tilecount = 0;
+
+	while (m_tilecount < 34)
+	{
+		const int index1 = tile_index + x * 2;
+		const int page2 = readbyte(index1) | (readbyte(index1 + 1) << 8);
+		const int color = 0;
+
+		if (!m_latch.isnull())
+			m_latch((m_tile_page << 10) | (page2 << 4));
+
+		if (start_x < VISIBLE_SCREEN_WIDTH)
+		{
+			const int address = (m_tile_page ? 0x1000 : 0) + (page2 * 16) + source_y_fine;
+			read_tile_plane_data(address, color);
+
+			for (int i = 0; i < 8; i++)
+			{
+				u8 pix;
+				shift_tile_plane_data(pix);
+
+				if ((start_x + i) >= 0 && (start_x + i) < VISIBLE_SCREEN_WIDTH)
+				{
+					draw_tile_pixel(pix, color, m_back_color, dest);
+
+					if (pix)
+						line_priority[start_x + i] |= 0x02;
+				}
+				dest++;
+			}
+
+			start_x += 8;
+
+			x++;
+			if (x > 31)
+			{
+				x = 0;
+			}
+		}
+		m_tilecount++;
+	}
+
+	if (!(m_regs[PPU_CONTROL1] & PPU_CONTROL1_BACKGROUND_L8))
+	{
+		dest = &m_bitmap.pix(m_scanline);
+		for (int i = 0; i < 8; i++)
+		{
+			draw_back_pen(dest, m_back_color);
+			dest++;
+
+			line_priority[i] ^= 0x02;
+		}
 	}
 }
 
@@ -1266,7 +1397,6 @@ void ppu_vt3xx_device::draw_sprites_standard_res(u8 *line_priority)
 				if (xpos + pixel >= 0)
 					draw_extended_sprite_pixel_high(m_bitmap, pixel_data, pixel, xpos, pal, bpp, line_priority);
 			}
-
 		}
 	}
 }

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -81,6 +81,8 @@ public:
 	u16 get_newmode_spritebase() { return m_tilebases_2x[2] | (m_tilebases_2x[3] << 8); }
 	u8 vt3xx_extended_palette_r(offs_t offset) { return m_vt3xx_palette[offset]; }
 	void vt3xx_extended_palette_w(offs_t offset, u8 data) { /*logerror("%s: extended palette write %04x %02x\n", machine().describe_context(), offset, data);*/ m_vt3xx_palette[offset] = data; }
+	u16 vt369_dma_vram_target() const { return m_vt369_dma_vram_target; }
+	void set_vt369_dma_vram_target(u16 target) { m_vt369_dma_vram_target = target; }
 
 	u8 get_m_read_bg4_bg3();
 	u8 get_speva2_speva0();
@@ -133,6 +135,7 @@ protected:
 	u8 m_tilebases_2x[4];
 
 	u8 m_vt3xx_palette[0x400];
+	u16 m_vt369_dma_vram_target;
 
 	static constexpr unsigned YUV444_COLOR = (0x40 * 8);
 private:

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -178,16 +178,21 @@ public:
 	u8 extvidreg_201c_r(offs_t offset);
 	u8 extvidreg_201d_r(offs_t offset);
 	u8 extvidreg_201e_r(offs_t offset);
+	u8 lightgun1_y_2024_r();
 	u8 tilebases_202x_r(offs_t offset);
 
 	void extvidreg_201c_w(offs_t offset, u8 data);
 	void extvidreg_201d_w(offs_t offset, u8 data);
 	void extvidreg_201e_w(offs_t offset, u8 data);
+	void extvidreg_201f_w(u8 data);
+	void lightgun1_y_2024_w(u8 data);
 	void tilebases_202x_w(offs_t offset, u8 data);
 	void lcdc_regs_w(offs_t offset, u8 data);
+	void lcdc_2050_w(u8 data);
 
 	u8 spritehigh_2008_r() { return m_2008_spritehigh; }
 	void spritehigh_2008_w(u8 data) { m_2008_spritehigh = data; logerror("%s: spritehigh_2008_w %02x\n", machine().describe_context(), data); }
+	virtual void write(offs_t offset, u8 data) override;
 
 protected:
 	virtual void device_start() override ATTR_COLD;
@@ -196,6 +201,7 @@ protected:
 private:
 	virtual void read_tile_plane_data(int address, int color) override;
 	virtual void shift_tile_plane_data(u8 &pix) override;
+	virtual void draw_background(u8 *line_priority) override;
 	virtual void draw_sprites(u8 *line_priority) override;
 	u8 vt3xx_palette_r(offs_t offset);
 	void vt3xx_palette_w(offs_t offset, u8 data);
@@ -215,6 +221,9 @@ private:
 
 	u8 m_204x_screenregs[0xa];
 	u8 m_2008_spritehigh;
+	u8 m_201f_ext;
+	u8 m_2024_lightgun1_y;
+	u8 m_2050_lcdc;
 };
 
 

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -768,7 +768,10 @@ void vt36x_gtct885_state::vt36x_altswap_2mb_36pcase(machine_config &config)
 	m_soc->io_4153_read_callback().set(FUNC(vt36x_gtct885_state::gtct885_prot_r));
 	m_soc->io_4152_write_callback().set(FUNC(vt36x_gtct885_state::gtct885_prot_w));
 
+	m_soc->enable_36pcase_gpio();
 	VT_MENU_PROTECTION(config, m_protection);
+	m_protection->set_read_start_byte(1);
+	m_protection->enable_36pcase_late_protocol();
 }
 
 void vt4ffx_goretrop_state::vt4ffx_32mb_goretrop(machine_config &config)
@@ -1183,8 +1186,10 @@ ROM_START( 36pcase )
 	ROM_REGION( 0x200000, "mainrom", 0 )
 	ROM_LOAD( "25q16.ic3", 0x00000, 0x200000, CRC(a8edb73e) SHA1(1028656530e411607ffa3b63788b42e41bf971d7) )
 
+	VT3XX_INTERNAL_NO_SWAP // verified for this set
+
 	ROM_REGION( 0x100, "protection", 0 ) // data from additional 8-pin chip for protection (put at 0xe01 in RAM) (checks for something before this)
-	ROM_LOAD( "mystery chip.bin", 0x00000, 0x100, NO_DUMP )
+	ROM_LOAD( "serial-rom.bin", 0x00000, 0x100, CRC(877fb90b) SHA1(f8aa2512460244b03fb2f3c013f063c836adf1bd) )
 ROM_END
 
 
@@ -1839,7 +1844,7 @@ CONS( 201?, 240in1ar,  0,  0,  vt36x_altswap_32mb_4banks_red5mam, vt369, vt36x_s
 CONS( 2020, nubsupmf,   0,      0,  vt36x_altswap_4mb, vt369, vt36x_state, empty_init, "<unknown>", "NubSup Mini Game Fan", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 
 // protected both with accesses involving 41e7 / 41eb / 414f (probably more IO ports, to get 2 bytes in RAM) and the serial devices to get ~0x100 bytes of code
-CONS( 202?, 36pcase,    0,      0,  vt36x_altswap_2mb_36pcase, vt369, vt36x_gtct885_state, empty_init, "<unknown>", "36-in-1 Classic Games phone case", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+CONS( 202?, 36pcase,    0,      0,  vt36x_altswap_2mb_36pcase, vt369, vt36x_gtct885_state, empty_init, "<unknown>", "36-in-1 Classic Games phone case", MACHINE_IMPERFECT_GRAPHICS )
 
 
 /*****************************************************************************

--- a/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
@@ -37,7 +37,10 @@ vt3xx_soc_base_device::vt3xx_soc_base_device(const machine_config &mconfig, devi
 	m_soundcpu(*this, "soundcpu"),
 	m_bank6000(0),
 	m_bank6000_enable(0),
+	m_411f(0),
 	m_sound_timer(nullptr),
+	m_36pcase_lcdc_nmi_timer(nullptr),
+	m_36pcase_deferred_oam_dma_timer(nullptr),
 	m_internal_rom(*this, "internal"),
 	m_soundram(*this, "soundram"),
 	m_vt369adpcm(*this, "vt369adpcm"),
@@ -96,7 +99,7 @@ void vt3xx_soc_base_device::device_add_mconfig(machine_config &config)
 
 	PPU_VT3XX(config.replace(), m_ppu, RP2A03_NTSC_XTAL);
 	m_ppu->set_cpu_tag(m_maincpu);
-	m_ppu->int_callback().set_inputline(m_maincpu, INPUT_LINE_NMI);
+	m_ppu->int_callback().set(FUNC(vt3xx_soc_base_device::ppu_nmi));
 	m_ppu->read_bg().set(FUNC(vt3xx_soc_base_device::chr_r));
 	m_ppu->read_sp().set(FUNC(vt3xx_soc_base_device::spr_r));
 	m_ppu->read_onespace_with_relative().set(FUNC(vt3xx_soc_base_device::read_onespace_bus_with_relative_offset));
@@ -124,10 +127,55 @@ void vt3xx_soc_base_device::vt369_soundcpu_control_w(u8 data)
 		m_soundcpu->set_input_line(INPUT_LINE_RESET, ASSERT_LINE);
 }
 
+u8 vt3xx_soc_base_device::vt369_soundram_r(offs_t offset)
+{
+	return m_soundram[offset & 0x7ff];
+}
+
+void vt3xx_soc_base_device::vt369_soundram_w(offs_t offset, u8 data)
+{
+	m_soundram[offset & 0x7ff] = data;
+}
+
+u8 vt3xx_soc_base_device::vt369_ppu_mirror_r(offs_t offset)
+{
+	return m_ppu->ppu_vram_direct_read(0x2000 + (offset & 0x0fff));
+}
+
+void vt3xx_soc_base_device::vt369_ppu_mirror_w(offs_t offset, u8 data)
+{
+	const offs_t address = 0x2000 + (offset & 0x0fff);
+	m_ppu->ppu_vram_direct_write(address, data);
+}
+
 void vt3xx_soc_base_device::vt369_relative_w(offs_t offset, u8 data)
 {
 	logerror("%s: vt369_relative_w %02x %02x\n", machine().describe_context(), offset,  data);
 	m_relative[offset] = data;
+}
+
+void vt3xx_soc_base_device::ppu_nmi(int state)
+{
+	m_maincpu->set_input_line(INPUT_LINE_NMI, state ? ASSERT_LINE : CLEAR_LINE);
+}
+
+TIMER_CALLBACK_MEMBER(vt3xx_soc_base_device::assert_36pcase_lcdc_nmi)
+{
+	if (m_36pcase_gpio_enabled)
+	{
+		m_maincpu->pulse_input_line(INPUT_LINE_NMI, attotime::zero);
+		m_36pcase_lcdc_nmi_timer->adjust(m_screen->frame_period());
+	}
+}
+
+void vt3xx_soc_base_device::vt3xx_2050_w(u8 data)
+{
+	downcast<ppu_vt3xx_device &>(*m_ppu).lcdc_2050_w(data);
+
+	if (m_36pcase_gpio_enabled && BIT(data, 0))
+		m_36pcase_lcdc_nmi_timer->adjust(m_screen->frame_period() + m_screen->time_until_pos(240, 120));
+	else if (m_36pcase_gpio_enabled)
+		m_36pcase_lcdc_nmi_timer->adjust(attotime::never);
 }
 
 u8 vt3xx_soc_base_device::read_internal(offs_t offset)
@@ -209,6 +257,25 @@ void vt3xx_soc_base_device::highres_sprite_dma_w(u8 data)
 	}
 }
 
+TIMER_CALLBACK_MEMBER(vt3xx_soc_base_device::flush_36pcase_deferred_oam_dma)
+{
+	for (int req = 0; req < m_36pcase_deferred_oam_dma_count; req++)
+	{
+		const u16 src = m_36pcase_deferred_oam_dma_src[req];
+		const u16 dst = m_36pcase_deferred_oam_dma_dst[req];
+		const int length = m_36pcase_deferred_oam_dma_len[req] ? m_36pcase_deferred_oam_dma_len[req] : 0x100;
+
+		for (int i = 0; i < length; i++)
+		{
+			const u8 read_data = m_maincpu->space(AS_PROGRAM).read_byte(src + i);
+			m_ppu->set_spriteram_value((dst + i) & 0x1ff, read_data);
+		}
+	}
+
+	m_36pcase_deferred_oam_dma_count = 0;
+	m_36pcase_deferred_oam_dma_next = 0;
+}
+
 void vt3xx_soc_base_device::vt369_map(address_map &map)
 {
 	map(0x0000, 0x1fff).ram(); // 8k RAM?
@@ -231,13 +298,16 @@ void vt3xx_soc_base_device::vt369_map(address_map &map)
 	map(0x201c, 0x201c).rw(m_ppu, FUNC(ppu_vt3xx_device::extvidreg_201c_r), FUNC(ppu_vt3xx_device::extvidreg_201c_w));
 	map(0x201d, 0x201d).rw(m_ppu, FUNC(ppu_vt3xx_device::extvidreg_201d_r), FUNC(ppu_vt3xx_device::extvidreg_201d_w));
 	map(0x201e, 0x201e).rw(m_ppu, FUNC(ppu_vt3xx_device::extvidreg_201e_r), FUNC(ppu_vt3xx_device::extvidreg_201e_w));
-	map(0x201f, 0x201f).r(m_ppu, FUNC(ppu_vt3xx_device::gun2_y_r));
+	map(0x201f, 0x201f).rw(m_ppu, FUNC(ppu_vt3xx_device::gun2_y_r), FUNC(ppu_vt3xx_device::extvidreg_201f_w));
 
 	map(0x2020, 0x2023).rw(m_ppu, FUNC(ppu_vt3xx_device::tilebases_202x_r), FUNC(ppu_vt3xx_device::tilebases_202x_w));
+	map(0x2024, 0x2024).rw(m_ppu, FUNC(ppu_vt3xx_device::lightgun1_y_2024_r), FUNC(ppu_vt3xx_device::lightgun1_y_2024_w));
 
 	map(0x2040, 0x2049).w(m_ppu, FUNC(ppu_vt3xx_device::lcdc_regs_w));
+	map(0x2050, 0x2050).w(FUNC(vt3xx_soc_base_device::vt3xx_2050_w));
+	map(0x2102, 0x2102).w(FUNC(vt3xx_soc_base_device::vt3xx_2102_w));
 
-	map(0x3000, 0x3fff).ram(); // 240in1ar clears this region (does it only exist on some SoCs?)
+	map(0x3000, 0x3fff).rw(FUNC(vt3xx_soc_base_device::vt369_ppu_mirror_r), FUNC(vt3xx_soc_base_device::vt369_ppu_mirror_w));
 
 	map(0x4000, 0x4017).w(m_apu, FUNC(nes_apu_vt_device::write));
 
@@ -269,34 +339,36 @@ void vt3xx_soc_base_device::vt369_map(address_map &map)
 	map(0x411c, 0x411c).w(FUNC(vt3xx_soc_base_device::vt369_411c_bank6000_enable_w));
 	map(0x411d, 0x411d).w(FUNC(vt3xx_soc_base_device::vt369_411d_w));
 	map(0x411e, 0x411e).w(FUNC(vt3xx_soc_base_device::vt369_411e_w));
+	map(0x411f, 0x411f).rw(FUNC(vt3xx_soc_base_device::vt3xx_411f_status_r), FUNC(vt3xx_soc_base_device::vt3xx_411f_w));
 
-	// 412d
+	map(0x412d, 0x412d).w(FUNC(vt3xx_soc_base_device::vt3xx_412d_w));
 
 	// the ALU is not VT1682 compatible
 	map(0x4130, 0x4137).rw(FUNC(vt3xx_soc_base_device::alu_r), FUNC(vt3xx_soc_base_device::alu_w));
 	map(0x4138, 0x413d).rw(FUNC(vt3xx_soc_base_device::alu_r), FUNC(vt3xx_soc_base_device::alu_w)); // mirror or 2nd ALU?
 
-	// 4144
-	// 4147
+	map(0x4144, 0x4147).rw(FUNC(vt3xx_soc_base_device::vt3xx_4144_latch_r), FUNC(vt3xx_soc_base_device::vt3xx_4144_latch_w));
 
 	// based on nesvt270, otrail, pixel246 this looks like another I/O port?
 	map(0x4148, 0x4148).rw(FUNC(vt3xx_soc_base_device::vt_414x_port_direction_r), FUNC(vt3xx_soc_base_device::vt_414x_port_direction_w));
 	map(0x414a, 0x414a).rw(FUNC(vt3xx_soc_base_device::vt_414a_port_in_r), FUNC(vt3xx_soc_base_device::vt_414a_port_out_w));
 	map(0x414b, 0x414b).rw(FUNC(vt3xx_soc_base_device::vt_414b_port_in_r), FUNC(vt3xx_soc_base_device::vt_414b_port_out_w));
-
-	map(0x414f, 0x414f).r(FUNC(vt3xx_soc_base_device::vt369_414f_r));
+	map(0x414c, 0x414f).rw(FUNC(vt3xx_soc_base_device::vt3xx_414c_latch_r), FUNC(vt3xx_soc_base_device::vt3xx_414c_latch_w));
 
 	// several games use these addresses for what seem to be extra protection data
 	map(0x4150, 0x4150).rw(FUNC(vt3xx_soc_base_device::vt_415x_port_direction_r), FUNC(vt3xx_soc_base_device::vt_415x_port_direction_w));
 	// 4151 also sometimes written
 	map(0x4152, 0x4152).rw(FUNC(vt3xx_soc_base_device::vt_4152_port_in_r), FUNC(vt3xx_soc_base_device::vt_4152_port_out_w));
 	map(0x4153, 0x4153).rw(FUNC(vt3xx_soc_base_device::vt_4153_port_in_r), FUNC(vt3xx_soc_base_device::vt_4153_port_out_w));
-	// 0x4158 is written before the above
+	map(0x4158, 0x4158).w(FUNC(vt3xx_soc_base_device::vt3xx_4158_w)); // written before the above
 
+	map(0x4155, 0x4157).rw(FUNC(vt3xx_soc_base_device::vt3xx_4155_latch_r), FUNC(vt3xx_soc_base_device::vt3xx_4155_latch_w));
+	map(0x415a, 0x415b).rw(FUNC(vt3xx_soc_base_device::vt3xx_415a_latch_r), FUNC(vt3xx_soc_base_device::vt3xx_415a_latch_w));
 	map(0x415c, 0x415c).r(FUNC(vt3xx_soc_base_device::vt369_415c_r)); // related to getting into menus in some games
 
 	map(0x4160, 0x4161).w(FUNC(vt3xx_soc_base_device::vt369_relative_w));
 	map(0x4162, 0x4162).w(FUNC(vt3xx_soc_base_device::vt369_soundcpu_control_w));
+	map(0x4165, 0x4165).w(FUNC(vt3xx_soc_base_device::vt3xx_4165_w));
 
 	// 4175
 
@@ -308,11 +380,13 @@ void vt3xx_soc_base_device::vt369_map(address_map &map)
 
 	map(0x41b0, 0x41bf).r(FUNC(vt3xx_soc_base_device::vt369_41bx_r)).w(FUNC(vt3xx_soc_base_device::vt369_41bx_w));
 
-	map(0x41e6, 0x41e6).w(FUNC(vt3xx_soc_base_device::extra_io_41e6_w)); // banking on red5mam
+	map(0x41e4, 0x41e5).rw(FUNC(vt3xx_soc_base_device::vt3xx_41e4_latch_r), FUNC(vt3xx_soc_base_device::vt3xx_41e4_latch_w));
+	map(0x41e6, 0x41e6).rw(FUNC(vt3xx_soc_base_device::vt3xx_41e6_latch_r), FUNC(vt3xx_soc_base_device::vt3xx_41e6_latch_w)); // banking on red5mam
+	map(0x41e7, 0x41eb).rw(FUNC(vt3xx_soc_base_device::vt3xx_41e7_latch_r), FUNC(vt3xx_soc_base_device::vt3xx_41e7_latch_w));
 
 	map(0x4201, 0x4201).w(FUNC(vt3xx_soc_base_device::highres_sprite_dma_w));
 
-	// 4304
+	map(0x4304, 0x4304).w(FUNC(vt3xx_soc_base_device::vt3xx_4304_w));
 
 	// 4310-4315 SD Card data out
 	// 4318-431b SD Card data in
@@ -324,7 +398,7 @@ void vt3xx_soc_base_device::vt369_map(address_map &map)
 	// 4327
 	// 4328
 
-	map(0x4800, 0x4fff).ram().share("soundram"); // sound program for 2nd CPU is uploaded here, but some sets aren't uploading anything, do they rely on an internal ROM? other DMA? possibility to map ROM?
+	map(0x4800, 0x4fff).rw(FUNC(vt3xx_soc_base_device::vt369_soundram_r), FUNC(vt3xx_soc_base_device::vt369_soundram_w)).share("soundram"); // sound program for 2nd CPU is uploaded here, but some sets aren't uploading anything, do they rely on an internal ROM? other DMA? possibility to map ROM?
 
 	map(0x6000, 0x7fff).r(FUNC(vt3xx_soc_base_device::vt369_6000_r)).w(FUNC(vt3xx_soc_base_device::vt369_6000_w));
 
@@ -345,16 +419,51 @@ void vt3xx_soc_base_device::vt_dma_w(u8 data)
 
 		logerror("%s: attempting to do NEW style dma src %04x length %04x dest type %d\n", machine().describe_context(), src_addr, length, m_vdma_ctrl & 1);
 
-		for (int i = 0; i < length; i++)
+		if (m_36pcase_gpio_enabled && (m_vdma_ctrl & 1))
 		{
-			u8 read_data = m_maincpu->space(AS_PROGRAM).read_byte(src_addr + i);
-			if (m_vdma_ctrl & 1)
+			u16 dma_dest = m_ppu->get_vram_dest();
+
+			for (int i = 0; i < length; i++)
 			{
-				m_maincpu->space(AS_PROGRAM).write_byte(0x2007, read_data);
+				const u8 read_data = m_maincpu->space(AS_PROGRAM).read_byte(src_addr + i);
+				m_ppu->ppu_vram_direct_write(dma_dest & 0x3fff, read_data);
+				dma_dest = (dma_dest + 1) & 0x3fff;
+			}
+
+			m_ppu->set_vram_dest(dma_dest);
+		}
+		else
+		{
+			if (m_36pcase_gpio_enabled && !(m_vdma_ctrl & 1))
+			{
+				if (m_36pcase_deferred_oam_dma_count < std::size(m_36pcase_deferred_oam_dma_src))
+				{
+					const int slot = m_36pcase_deferred_oam_dma_count++;
+					m_36pcase_deferred_oam_dma_src[slot] = src_addr;
+					m_36pcase_deferred_oam_dma_dst[slot] = m_36pcase_deferred_oam_dma_next & 0x1ff;
+					m_36pcase_deferred_oam_dma_len[slot] = length & 0xff;
+					m_36pcase_deferred_oam_dma_next = (m_36pcase_deferred_oam_dma_next + length) & 0x1ff;
+					m_36pcase_deferred_oam_dma_timer->adjust(attotime::from_msec(2));
+				}
+				else
+				{
+					logerror("%s: 36pcase deferred oam dma queue overflow src=%04x length=%04x\n", machine().describe_context(), src_addr, length);
+				}
 			}
 			else
 			{
-				m_maincpu->space(AS_PROGRAM).write_byte(0x2004, read_data);
+				for (int i = 0; i < length; i++)
+				{
+					const u8 read_data = m_maincpu->space(AS_PROGRAM).read_byte(src_addr + i);
+					if (m_vdma_ctrl & 1)
+					{
+						m_maincpu->space(AS_PROGRAM).write_byte(0x2007, read_data);
+					}
+					else
+					{
+						m_maincpu->space(AS_PROGRAM).write_byte(0x2004, read_data);
+					}
+				}
 			}
 		}
 	}
@@ -474,7 +583,155 @@ u8 vt3xx_soc_base_device::vt_414b_port_in_r()
 
 
 
-void vt3xx_soc_base_device::extra_io_41e6_w(u8 data) { logerror("%s: extra_io_41e6_w %02x (external banking?)\n", machine().describe_context(), data); m_41e6_write_cb(data); }
+
+u8 vt3xx_soc_base_device::vt3xx_36pcase_gpio_bus_latch() const
+{
+	return (m_414x_gpio[0x0f] & 0x1f) | ((m_41ex_gpio[0x07] & 0x1c) << 3);
+}
+
+u8 vt3xx_soc_base_device::vt3xx_36pcase_gpio_bus_r()
+{
+	if (m_36pcase_gpio_response_pos < m_36pcase_gpio_response_len)
+		return m_36pcase_gpio_response[m_36pcase_gpio_response_pos];
+
+	return vt3xx_36pcase_gpio_bus_latch();
+}
+
+void vt3xx_soc_base_device::vt3xx_36pcase_gpio_bus_w()
+{
+	m_36pcase_gpio_write_history[0] = m_36pcase_gpio_write_history[1];
+	m_36pcase_gpio_write_history[1] = vt3xx_36pcase_gpio_bus_latch();
+
+	if ((m_36pcase_gpio_write_history[0] == 0x00) && (m_36pcase_gpio_write_history[1] == 0x00))
+	{
+		// The menu waits for this two-byte response before applying the LCD/GPIO table at f7d6.
+		m_36pcase_gpio_response[0] = 0x93;
+		m_36pcase_gpio_response[1] = 0x35;
+		m_36pcase_gpio_response_pos = 0;
+		m_36pcase_gpio_response_len = 2;
+	}
+}
+
+void vt3xx_soc_base_device::vt3xx_36pcase_gpio_advance_response()
+{
+	if (m_36pcase_gpio_response_pos < m_36pcase_gpio_response_len)
+		m_36pcase_gpio_response_pos++;
+}
+
+u8 vt3xx_soc_base_device::vt3xx_4144_latch_r(offs_t offset)
+{
+	const u8 reg = 0x04 + offset;
+	logerror("%s: vt3xx_414x_latch_r %02x\n", machine().describe_context(), reg);
+	return m_414x_gpio[reg];
+}
+
+void vt3xx_soc_base_device::vt3xx_4144_latch_w(offs_t offset, u8 data)
+{
+	const u8 reg = 0x04 + offset;
+	logerror("%s: vt3xx_414x_latch_w %02x %02x\n", machine().describe_context(), reg, data);
+
+	const u8 old = m_414x_gpio[reg];
+	m_414x_gpio[reg] = data;
+
+	if (m_36pcase_gpio_enabled && (reg == 0x07) && !BIT(old, 5) && BIT(data, 5))
+		vt3xx_36pcase_gpio_bus_w();
+}
+
+u8 vt3xx_soc_base_device::vt3xx_414c_latch_r(offs_t offset)
+{
+	const u8 reg = 0x0c + offset;
+	logerror("%s: vt3xx_414x_latch_r %02x\n", machine().describe_context(), reg);
+
+	if (m_36pcase_gpio_enabled && (reg == 0x0f))
+		return (m_414x_gpio[reg] & 0xe0) | (vt3xx_36pcase_gpio_bus_r() & 0x1f);
+
+	return m_414x_gpio[reg];
+}
+
+void vt3xx_soc_base_device::vt3xx_414c_latch_w(offs_t offset, u8 data)
+{
+	const u8 reg = 0x0c + offset;
+	logerror("%s: vt3xx_414x_latch_w %02x %02x\n", machine().describe_context(), reg, data);
+	m_414x_gpio[reg] = data;
+}
+
+u8 vt3xx_soc_base_device::vt3xx_4155_latch_r(offs_t offset)
+{
+	const u8 reg = 0x05 + offset;
+	logerror("%s: vt3xx_415x_latch_r %02x\n", machine().describe_context(), reg);
+	return m_415x_gpio[reg];
+}
+
+void vt3xx_soc_base_device::vt3xx_4155_latch_w(offs_t offset, u8 data)
+{
+	const u8 reg = 0x05 + offset;
+	logerror("%s: vt3xx_415x_latch_w %02x %02x\n", machine().describe_context(), reg, data);
+	m_415x_gpio[reg] = data;
+}
+
+u8 vt3xx_soc_base_device::vt3xx_415a_latch_r(offs_t offset)
+{
+	const u8 reg = 0x0a + offset;
+	logerror("%s: vt3xx_415x_latch_r %02x\n", machine().describe_context(), reg);
+	return m_415x_gpio[reg];
+}
+
+void vt3xx_soc_base_device::vt3xx_415a_latch_w(offs_t offset, u8 data)
+{
+	const u8 reg = 0x0a + offset;
+	logerror("%s: vt3xx_415x_latch_w %02x %02x\n", machine().describe_context(), reg, data);
+	m_415x_gpio[reg] = data;
+}
+
+u8 vt3xx_soc_base_device::vt3xx_41e4_latch_r(offs_t offset)
+{
+	const u8 reg = 0x04 + offset;
+	logerror("%s: vt3xx_41ex_latch_r %02x\n", machine().describe_context(), reg);
+	return m_41ex_gpio[reg];
+}
+
+void vt3xx_soc_base_device::vt3xx_41e4_latch_w(offs_t offset, u8 data)
+{
+	const u8 reg = 0x04 + offset;
+	logerror("%s: vt3xx_41ex_latch_w %02x %02x\n", machine().describe_context(), reg, data);
+	m_41ex_gpio[reg] = data;
+}
+
+u8 vt3xx_soc_base_device::vt3xx_41e6_latch_r()
+{
+	logerror("%s: vt3xx_41ex_latch_r 06\n", machine().describe_context());
+	return m_41ex_gpio[0x06];
+}
+
+void vt3xx_soc_base_device::vt3xx_41e6_latch_w(u8 data)
+{
+	logerror("%s: vt3xx_41ex_latch_w 06 %02x (external banking?)\n", machine().describe_context(), data);
+	m_41ex_gpio[0x06] = data;
+	m_41e6_write_cb(data);
+}
+
+u8 vt3xx_soc_base_device::vt3xx_41e7_latch_r(offs_t offset)
+{
+	const u8 reg = 0x07 + offset;
+	logerror("%s: vt3xx_41ex_latch_r %02x\n", machine().describe_context(), reg);
+
+	if (m_36pcase_gpio_enabled && (reg == 0x07))
+		return (m_41ex_gpio[reg] & 0xe3) | ((vt3xx_36pcase_gpio_bus_r() >> 3) & 0x1c);
+
+	return m_41ex_gpio[reg];
+}
+
+void vt3xx_soc_base_device::vt3xx_41e7_latch_w(offs_t offset, u8 data)
+{
+	const u8 reg = 0x07 + offset;
+	logerror("%s: vt3xx_41ex_latch_w %02x %02x\n", machine().describe_context(), reg, data);
+
+	const u8 old = m_41ex_gpio[reg];
+	m_41ex_gpio[reg] = data;
+
+	if (m_36pcase_gpio_enabled && (reg == 0x0b) && !BIT(old, 4) && BIT(data, 4))
+		vt3xx_36pcase_gpio_advance_response();
+}
 
 void vt3xx_soc_base_device::update_timer()
 {
@@ -698,6 +955,43 @@ void vt3xx_soc_base_device::vt369_411e_w(u8 data)
 	m_411e_write_cb(data);
 }
 
+u8 vt3xx_soc_base_device::vt3xx_411f_status_r()
+{
+	logerror("%s: vt3xx_411f_status_r %02x\n", machine().describe_context(), m_411f);
+	return m_411f;
+}
+
+void vt3xx_soc_base_device::vt3xx_411f_w(u8 data)
+{
+	logerror("%s: vt3xx_411f_w %02x\n", machine().describe_context(), data);
+	m_411f = data;
+}
+
+void vt3xx_soc_base_device::vt3xx_412d_w(u8 data)
+{
+	logerror("%s: vt3xx_412d_w %02x\n", machine().describe_context(), data);
+}
+
+void vt3xx_soc_base_device::vt3xx_4158_w(u8 data)
+{
+	logerror("%s: vt3xx_4158_w %02x\n", machine().describe_context(), data);
+}
+
+void vt3xx_soc_base_device::vt3xx_4165_w(u8 data)
+{
+	logerror("%s: vt3xx_4165_w %02x\n", machine().describe_context(), data);
+}
+
+void vt3xx_soc_base_device::vt3xx_2102_w(u8 data)
+{
+	logerror("%s: vt3xx_2102_w %02x\n", machine().describe_context(), data);
+}
+
+void vt3xx_soc_base_device::vt3xx_4304_w(u8 data)
+{
+	logerror("%s: vt3xx_4304_w %02x\n", machine().describe_context(), data);
+}
+
 
 void vt3xx_soc_base_device::vt369_4112_bank6000_select_w(u8 data)
 {
@@ -782,14 +1076,18 @@ void vt3xx_soc_base_device::device_start()
 	m_6000_ram.resize(0x2000);
 	m_bank6000 = 0;
 	m_bank6000_enable = 0;
+	m_411f = 0;
 
 	m_sound_timer = timer_alloc(FUNC(vt3xx_soc_base_device::sound_timer_expired), this);
+	m_36pcase_lcdc_nmi_timer = timer_alloc(FUNC(vt3xx_soc_base_device::assert_36pcase_lcdc_nmi), this);
+	m_36pcase_deferred_oam_dma_timer = timer_alloc(FUNC(vt3xx_soc_base_device::flush_36pcase_deferred_oam_dma), this);
 
 	save_item(NAME(m_timerperiod));
 	save_item(NAME(m_timercontrol));
 	save_item(NAME(m_6000_ram));
 	save_item(NAME(m_bank6000));
 	save_item(NAME(m_bank6000_enable));
+	save_item(NAME(m_411f));
 	save_item(NAME(m_alu_params));
 	save_item(NAME(m_sound_adder_addr));
 	save_item(NAME(m_sound_adder_result));
@@ -803,7 +1101,18 @@ void vt3xx_soc_base_device::device_start()
 	save_item(NAME(m_414x_port_direction));
 	save_item(NAME(m_414a_port_data));
 	save_item(NAME(m_414b_port_data));
-
+	save_item(NAME(m_414x_gpio));
+	save_item(NAME(m_415x_gpio));
+	save_item(NAME(m_41ex_gpio));
+	save_item(NAME(m_36pcase_gpio_write_history));
+	save_item(NAME(m_36pcase_gpio_response));
+	save_item(NAME(m_36pcase_gpio_response_pos));
+	save_item(NAME(m_36pcase_gpio_response_len));
+	save_item(NAME(m_36pcase_deferred_oam_dma_src));
+	save_item(NAME(m_36pcase_deferred_oam_dma_dst));
+	save_item(NAME(m_36pcase_deferred_oam_dma_len));
+	save_item(NAME(m_36pcase_deferred_oam_dma_count));
+	save_item(NAME(m_36pcase_deferred_oam_dma_next));
 	m_ppu->space(AS_PROGRAM).install_readwrite_handler(0x3c00, 0x3fff, read8sm_delegate(*this, FUNC(vt3xx_soc_base_device::vt3xx_palette_r)), write8sm_delegate(*this, FUNC(vt3xx_soc_base_device::vt3xx_palette_w)));
 }
 
@@ -817,6 +1126,7 @@ void vt3xx_soc_base_device::device_reset()
 
 	m_timerperiod = 0;
 	m_timercontrol = 0;
+	m_411f = 0;
 
 	m_sound_adder_addr[0] = 0;
 	m_sound_adder_addr[1] = 0;
@@ -831,6 +1141,8 @@ void vt3xx_soc_base_device::device_reset()
 		m_sound_dac[i] = 0;
 
 	m_sound_timer->adjust(attotime::never);
+	m_36pcase_lcdc_nmi_timer->adjust(attotime::never);
+	m_36pcase_deferred_oam_dma_timer->adjust(attotime::never);
 
 	m_415x_port_direction = 0x00;
 	m_4152_port_data = 0x00;
@@ -838,6 +1150,20 @@ void vt3xx_soc_base_device::device_reset()
 	m_414x_port_direction = 0x00;
 	m_414a_port_data = 0x00;
 	m_414b_port_data = 0x00;
+
+	for (int i = 0; i < 0x10; i++)
+	{
+		m_414x_gpio[i] = 0x00;
+		m_415x_gpio[i] = 0x00;
+		m_41ex_gpio[i] = 0x00;
+	}
+
+	m_36pcase_gpio_write_history[0] = 0xff;
+	m_36pcase_gpio_write_history[1] = 0xff;
+	m_36pcase_gpio_response_pos = 0;
+	m_36pcase_gpio_response_len = 0;
+	m_36pcase_deferred_oam_dma_count = 0;
+	m_36pcase_deferred_oam_dma_next = 0;
 }
 
 
@@ -862,15 +1188,12 @@ void vt3xx_soc_base_device::vt369_41bx_w(offs_t offset, u8 data)
 }
 
 
-u8 vt3xx_soc_base_device::vt369_414f_r()
-{
-	logerror("%s: vt369_414f_r (unknown)\n", machine().describe_context());
-	return 0xff;
-}
-
 u8 vt3xx_soc_base_device::vt369_415c_r()
 {
 	logerror("%s: vt369_415c_r (unknown - important)\n", machine().describe_context());
+	if (m_36pcase_gpio_enabled)
+		return 0x10;
+
 	// returning 0x00 allows zonefusn and lexi30 (and many other lexibook sets) to show menus, but stops sealvt from showing anything
 	// returning 0xff allows sealvt to show the boot screen
 	// 0xf0 allows all those to boot?

--- a/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
@@ -421,7 +421,7 @@ void vt3xx_soc_base_device::vt_dma_w(u8 data)
 
 		if (m_36pcase_gpio_enabled && (m_vdma_ctrl & 1))
 		{
-			u16 dma_dest = m_ppu->get_vram_dest();
+			u16 dma_dest = m_ppu->vt369_dma_vram_target();
 
 			for (int i = 0; i < length; i++)
 			{
@@ -430,7 +430,7 @@ void vt3xx_soc_base_device::vt_dma_w(u8 data)
 				dma_dest = (dma_dest + 1) & 0x3fff;
 			}
 
-			m_ppu->set_vram_dest(dma_dest);
+			m_ppu->set_vt369_dma_vram_target(dma_dest);
 		}
 		else
 		{

--- a/src/mame/nintendo/nes_vt369_vtunknown_soc.h
+++ b/src/mame/nintendo/nes_vt369_vtunknown_soc.h
@@ -21,6 +21,7 @@ public:
 	auto io_414a_write_callback() { return m_io_414a_write_callback.bind(); }
 	auto io_414b_read_callback() { return m_io_414b_read_callback.bind(); }
 	auto io_414b_write_callback() { return m_io_414b_write_callback.bind(); }
+	void enable_36pcase_gpio() { m_36pcase_gpio_enabled = true; }
 
 protected:
 	vt3xx_soc_base_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
@@ -34,7 +35,20 @@ protected:
 	u8 vt369_41bx_r(offs_t offset);
 	void vt369_41bx_w(offs_t offset, u8 data);
 
-	u8 vt369_414f_r();
+	u8 vt3xx_4144_latch_r(offs_t offset);
+	void vt3xx_4144_latch_w(offs_t offset, u8 data);
+	u8 vt3xx_414c_latch_r(offs_t offset);
+	void vt3xx_414c_latch_w(offs_t offset, u8 data);
+	u8 vt3xx_4155_latch_r(offs_t offset);
+	void vt3xx_4155_latch_w(offs_t offset, u8 data);
+	u8 vt3xx_415a_latch_r(offs_t offset);
+	void vt3xx_415a_latch_w(offs_t offset, u8 data);
+	u8 vt3xx_41e4_latch_r(offs_t offset);
+	void vt3xx_41e4_latch_w(offs_t offset, u8 data);
+	u8 vt3xx_41e6_latch_r();
+	void vt3xx_41e6_latch_w(u8 data);
+	u8 vt3xx_41e7_latch_r(offs_t offset);
+	void vt3xx_41e7_latch_w(offs_t offset, u8 data);
 
 	u8 vt_415x_port_direction_r();
 	u8 vt_4152_port_in_r();
@@ -49,8 +63,6 @@ protected:
 	u8 vt_414b_port_in_r();
 	void vt_414a_port_out_w(u8 data);
 	u8 vt_414a_port_in_r();
-
-	void extra_io_41e6_w(u8 data);
 
 	u8 vt369_415c_r();
 
@@ -67,11 +79,25 @@ protected:
 	void highres_sprite_dma_w(u8 data);
 
 	void vt369_soundcpu_control_w(u8 data);
+	u8 vt369_soundram_r(offs_t offset);
+	void vt369_soundram_w(offs_t offset, u8 data);
+	u8 vt369_ppu_mirror_r(offs_t offset);
+	void vt369_ppu_mirror_w(offs_t offset, u8 data);
 	void vt369_4112_bank6000_select_w(u8 data);
 	void vt369_411c_bank6000_enable_w(u8 data);
 	void vt369_411d_w(u8 data);
 	void vt369_411e_w(u8 data);
+	u8 vt3xx_411f_status_r();
+	void vt3xx_411f_w(u8 data);
+	void vt3xx_412d_w(u8 data);
+	void vt3xx_4158_w(u8 data);
+	void vt3xx_4165_w(u8 data);
+	void vt3xx_2102_w(u8 data);
+	void vt3xx_2050_w(u8 data);
+	void vt3xx_4304_w(u8 data);
 	void vt369_relative_w(offs_t offset, u8 data);
+	void ppu_nmi(int state);
+	TIMER_CALLBACK_MEMBER(flush_36pcase_deferred_oam_dma);
 
 	u8 read_internal(offs_t offset);
 
@@ -106,6 +132,7 @@ private:
 	void do_sound_adpcm_decode();
 
 	TIMER_CALLBACK_MEMBER(sound_timer_expired);
+	TIMER_CALLBACK_MEMBER(assert_36pcase_lcdc_nmi);
 	void update_timer();
 
 	required_device<cpu_device> m_soundcpu;
@@ -113,6 +140,7 @@ private:
 
 	u8 m_bank6000;
 	u8 m_bank6000_enable;
+	u8 m_411f;
 
 	u8 m_415x_port_direction;
 	u8 m_4152_port_data;
@@ -121,12 +149,27 @@ private:
 	u8 m_414x_port_direction;
 	u8 m_414a_port_data;
 	u8 m_414b_port_data;
+	u8 m_414x_gpio[0x10]{};
+	u8 m_415x_gpio[0x10]{};
+	u8 m_41ex_gpio[0x10]{};
+	bool m_36pcase_gpio_enabled = false;
+	u8 m_36pcase_gpio_write_history[2]{};
+	u8 m_36pcase_gpio_response[2]{};
+	u8 m_36pcase_gpio_response_pos = 0;
+	u8 m_36pcase_gpio_response_len = 0;
+	u16 m_36pcase_deferred_oam_dma_src[4]{};
+	u16 m_36pcase_deferred_oam_dma_dst[4]{};
+	u8 m_36pcase_deferred_oam_dma_len[4]{};
+	u8 m_36pcase_deferred_oam_dma_count = 0;
+	u16 m_36pcase_deferred_oam_dma_next = 0;
 
 	u16 m_timerperiod;
 	u8 m_timercontrol;
 	u8 m_alu_params[8];
 
 	emu_timer *m_sound_timer;
+	emu_timer *m_36pcase_lcdc_nmi_timer;
+	emu_timer *m_36pcase_deferred_oam_dma_timer;
 	u8 m_sound_adder_addr[2];
 	u8 m_sound_adpcm_addr[2];
 	u8 m_sound_adder_result[2];
@@ -146,6 +189,11 @@ private:
 	devcb_write8 m_io_414a_write_callback;
 	devcb_read8 m_io_414b_read_callback;
 	devcb_write8 m_io_414b_write_callback;
+
+	u8 vt3xx_36pcase_gpio_bus_r();
+	u8 vt3xx_36pcase_gpio_bus_latch() const;
+	void vt3xx_36pcase_gpio_bus_w();
+	void vt3xx_36pcase_gpio_advance_response();
 };
 
 class vt369_soc_introm_noswap_device : public vt3xx_soc_base_device

--- a/src/mame/nintendo/nes_vt_soc.cpp
+++ b/src/mame/nintendo/nes_vt_soc.cpp
@@ -345,12 +345,14 @@ void nes_vt02_vt03_soc_device::scrambled_410x_w(u16 offset, u8 data)
 
 	case 0x1:
 		// latch timer value
+		logerror("%s: vt03_410x_w timer latch %02x\n", machine().describe_context(), data);
 		m_410x[0x1] = data;
 		m_timer_running = 0;
 		break;
 
 	case 0x2:
 		// load latched value and start counting
+		logerror("%s: vt03_410x_w timer reload/start %02x (latch %02x)\n", machine().describe_context(), data, m_410x[0x1]);
 		m_410x[0x2] = data; // value doesn't matter?
 		m_timer_val = m_410x[0x1];
 
@@ -363,6 +365,7 @@ void nes_vt02_vt03_soc_device::scrambled_410x_w(u16 offset, u8 data)
 		break;
 
 	case 0x3:
+		logerror("%s: vt03_410x_w irq disable %02x\n", machine().describe_context(), data);
 		m_maincpu->set_input_line(M6502_IRQ_LINE, CLEAR_LINE);
 		// disable timer irq
 		m_410x[0x3] = data; // value doesn't matter?
@@ -371,6 +374,7 @@ void nes_vt02_vt03_soc_device::scrambled_410x_w(u16 offset, u8 data)
 
 	case 0x4:
 		// enable timer irq
+		logerror("%s: vt03_410x_w irq enable %02x\n", machine().describe_context(), data);
 		m_410x[0x4] = data; // value doesn't matter?
 		m_timer_irq_enabled = 1;
 		break;
@@ -493,7 +497,11 @@ void nes_vt02_vt03_soc_device::video_irq(bool hblank, int scanline, bool vblank,
 		}
 
 		if (irqstate)
+		{
+			logerror("%s: vt03 video irq assert hblank=%d scanline=%d vblank=%d blanked=%d timer=%d latch=%02x ctrl=%02x\n",
+					machine().describe_context(), hblank, scanline, vblank, blanked, m_timer_val, m_410x[0x1], m_410x[0x0b]);
 			m_maincpu->set_input_line(M6502_IRQ_LINE, ASSERT_LINE);
+		}
 		//else
 		//  m_maincpu->set_input_line(M6502_IRQ_LINE, CLEAR_LINE);
 	}

--- a/src/mame/nintendo/nes_vt_soc.cpp
+++ b/src/mame/nintendo/nes_vt_soc.cpp
@@ -345,14 +345,14 @@ void nes_vt02_vt03_soc_device::scrambled_410x_w(u16 offset, u8 data)
 
 	case 0x1:
 		// latch timer value
-		logerror("%s: vt03_410x_w timer latch %02x\n", machine().describe_context(), data);
+		LOG("%s: vt03_410x_w timer latch %02x\n", machine().describe_context(), data);
 		m_410x[0x1] = data;
 		m_timer_running = 0;
 		break;
 
 	case 0x2:
 		// load latched value and start counting
-		logerror("%s: vt03_410x_w timer reload/start %02x (latch %02x)\n", machine().describe_context(), data, m_410x[0x1]);
+		LOG("%s: vt03_410x_w timer reload/start %02x (latch %02x)\n", machine().describe_context(), data, m_410x[0x1]);
 		m_410x[0x2] = data; // value doesn't matter?
 		m_timer_val = m_410x[0x1];
 
@@ -365,7 +365,7 @@ void nes_vt02_vt03_soc_device::scrambled_410x_w(u16 offset, u8 data)
 		break;
 
 	case 0x3:
-		logerror("%s: vt03_410x_w irq disable %02x\n", machine().describe_context(), data);
+		LOG("%s: vt03_410x_w irq disable %02x\n", machine().describe_context(), data);
 		m_maincpu->set_input_line(M6502_IRQ_LINE, CLEAR_LINE);
 		// disable timer irq
 		m_410x[0x3] = data; // value doesn't matter?
@@ -374,7 +374,7 @@ void nes_vt02_vt03_soc_device::scrambled_410x_w(u16 offset, u8 data)
 
 	case 0x4:
 		// enable timer irq
-		logerror("%s: vt03_410x_w irq enable %02x\n", machine().describe_context(), data);
+		LOG("%s: vt03_410x_w irq enable %02x\n", machine().describe_context(), data);
 		m_410x[0x4] = data; // value doesn't matter?
 		m_timer_irq_enabled = 1;
 		break;
@@ -498,7 +498,7 @@ void nes_vt02_vt03_soc_device::video_irq(bool hblank, int scanline, bool vblank,
 
 		if (irqstate)
 		{
-			logerror("%s: vt03 video irq assert hblank=%d scanline=%d vblank=%d blanked=%d timer=%d latch=%02x ctrl=%02x\n",
+			LOG("%s: vt03 video irq assert hblank=%d scanline=%d vblank=%d blanked=%d timer=%d latch=%02x ctrl=%02x\n",
 					machine().describe_context(), hblank, scanline, vblank, blanked, m_timer_val, m_410x[0x1], m_410x[0x0b]);
 			m_maincpu->set_input_line(M6502_IRQ_LINE, ASSERT_LINE);
 		}

--- a/src/mame/nintendo/vt_menu_protection.cpp
+++ b/src/mame/nintendo/vt_menu_protection.cpp
@@ -21,6 +21,23 @@ uint8_t vt_menu_protection_device::read()
 	return m_protlatch;
 }
 
+u8 vt_menu_protection_device::compute_36pcase_late_response(u8 data)
+{
+	switch (data)
+	{
+	case 0x02:
+		return 0x01;
+	case 0x4a:
+		return 0x00;
+	case 0x6d:
+		return 0x1e;
+	case 0xb2:
+		return 0x02;
+	default:
+		return 0x00;
+	}
+}
+
 void vt_menu_protection_device::write_enable(int state)
 {
 	if (bool(state) != m_in_enable)
@@ -63,7 +80,13 @@ void vt_menu_protection_device::write_clock(int state)
 					{
 						logerror("(read bytes)\n");
 						m_protectionstate = 2;
-						m_protreadposition = 0;
+						m_protreadposition = m_read_start_byte * 8;
+					}
+					else if (m_36pcase_late_protocol && (m_command == 0x10))
+					{
+						m_protectionstate = 3;
+						m_command = 0;
+						m_commandbits = 8;
 					}
 					else
 					{
@@ -83,6 +106,27 @@ void vt_menu_protection_device::write_clock(int state)
 
 				m_protreadposition++;
 			}
+			else if (m_protectionstate == 3)
+			{
+				m_command = (m_command << 1) | (m_in_data ? 1 : 0);
+				m_commandbits--;
+
+				if (m_commandbits == 0)
+				{
+					m_36pcase_late_response = compute_36pcase_late_response(m_command);
+					m_36pcase_late_response_pos = 0;
+					m_protectionstate = 4;
+				}
+			}
+			else if (m_protectionstate == 4)
+			{
+				const u8 readbit = BIT(m_36pcase_late_response, ~m_36pcase_late_response_pos & 7);
+
+				m_protlatch = readbit;
+
+				if (++m_36pcase_late_response_pos == 8)
+					m_protectionstate = 0;
+			}
 		}
 	}
 
@@ -99,8 +143,11 @@ void vt_menu_protection_device::device_start()
 	save_item(NAME(m_command));
 	save_item(NAME(m_commandbits));
 	save_item(NAME(m_protectionstate));
-	save_item(NAME(m_protlatch));;
+	save_item(NAME(m_protlatch));
+	save_item(NAME(m_read_start_byte));
 	save_item(NAME(m_protreadposition));
+	save_item(NAME(m_36pcase_late_response));
+	save_item(NAME(m_36pcase_late_response_pos));
 	save_item(NAME(m_in_data));
 	save_item(NAME(m_in_enable));
 	save_item(NAME(m_in_clock));
@@ -113,4 +160,6 @@ void vt_menu_protection_device::device_reset()
 	m_protectionstate = 0;
 	m_protlatch = 0;
 	m_protreadposition = 0;
+	m_36pcase_late_response = 0;
+	m_36pcase_late_response_pos = 0;
 }

--- a/src/mame/nintendo/vt_menu_protection.h
+++ b/src/mame/nintendo/vt_menu_protection.h
@@ -15,19 +15,27 @@ public:
 	void write_clock(int state);
 	void write_data(int state);
 	void write_enable(int state);
+	void set_read_start_byte(u8 byte) { m_read_start_byte = byte; }
+	void enable_36pcase_late_protocol() { m_36pcase_late_protocol = true; }
 
 protected:
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 
 private:
+	u8 compute_36pcase_late_response(u8 data);
+
 	required_memory_region m_extrarom;
 
 	u8 m_command;
 	u8 m_commandbits;
 	u8 m_protectionstate;
 	u8 m_protlatch;
+	u8 m_read_start_byte = 0;
 	u16 m_protreadposition;
+	u8 m_36pcase_late_response;
+	u8 m_36pcase_late_response_pos;
+	bool m_36pcase_late_protocol = false;
 	bool m_in_data;
 	bool m_in_enable;
 	bool m_in_clock;


### PR DESCRIPTION
I saw a video called "Dumping and reverse engineering a very cheap NES phone case" by Poking Technology and was quite intrigued by the approach, however the ending wasn't too satisfying so I decided to try poking the technology myself. 

And now it works: 
<img width="256" height="240" alt="image" src="https://github.com/user-attachments/assets/20e4c8cd-b4fe-4550-88b5-26f2e04f3ecf" />
<img width="256" height="240" alt="image" src="https://github.com/user-attachments/assets/016f917b-6d27-4626-af3b-08daa524fffe" />

36pcase.zip should contain:
```
25q16.ic3        2,097,152 bytes  CRC a8edb73e
internal.bin         4,096 bytes  CRC da5850f0
serial-rom.bin         256 bytes  CRC 877fb90b
```

serial-rom.bin replaces the earlier NO_DUMP "mystery chip.bin" entry (again, thanks mr. Poking for using such an extravagant method of dumping the ROM).

- Added ROM definitions for the verified external, internal and serial dumps for the 36-in-1 Classic Games phone case.
- Added the VT3xx split GPIO/protection exchanges needed by this hardware.
- Added the LCDC/tilemap and DMA behaviour needed for the language selector, game menu and selected games to boot.

new WORKING machines
--------------
36-in-1 Classic Games phone case [naorunaoru]