### PR TITLE
Fix bootstrap INI priority to allow override by other INI files.

### DIFF
--- a/src/frontend/mame/mameopts.cpp
+++ b/src/frontend/mame/mameopts.cpp
@@ -46,7 +46,7 @@ void mame_options::parse_standard_inis(emu_options &options, std::ostream &error
 			osd_printf_verbose("Parsing %s\n", file.fullpath());
 			try
 			{
-				options.parse_ini_file(static_cast<util::core_file &>(file), OPTION_PRIORITY_MAME_INI, true, false);
+				options.parse_ini_file(static_cast<util::core_file &>(file), OPTION_PRIORITY_BOOTSTRAP, true, false);
 			}
 			catch (options_exception const &ex)
 			{

--- a/src/frontend/mame/mameopts.h
+++ b/src/frontend/mame/mameopts.h
@@ -23,11 +23,11 @@
 // option priorities
 enum
 {
-	// command-line options are HIGH priority
+	// command-line options override everything (HIGH priority)
 	OPTION_PRIORITY_SUBCMD = OPTION_PRIORITY_HIGH,
 	OPTION_PRIORITY_CMDLINE,
 
-	// INI-based options are NORMAL priority, in increasing order:
+	// user INI files, in increasing order of specificity (NORMAL priority)
 	OPTION_PRIORITY_MAME_INI = OPTION_PRIORITY_NORMAL + 1,
 	OPTION_PRIORITY_DEBUG_INI,
 	OPTION_PRIORITY_ORIENTATION_INI,
@@ -37,6 +37,9 @@ enum
 	OPTION_PRIORITY_PARENT_INI,
 	OPTION_PRIORITY_DRIVER_INI,
 	OPTION_PRIORITY_INI,
+
+	// hardcoded bootstrap INI, overridden by everything else (DEFAULT priority)
+	OPTION_PRIORITY_BOOTSTRAP = OPTION_PRIORITY_DEFAULT + 1,
 };
 
 //**************************************************************************


### PR DESCRIPTION
Fixes regression introduced in #15310
Please see https://github.com/mamedev/mame/pull/15310#issuecomment-4582431546
for full issue explanation.

On bootstrap, MAME reads the ini file hardcoded via SDLOPTION_INIPATH with
OPTION_PRIORITY_MAME_INI priority. Later passes use the same priority, so
the hardcoded file's values are never overridden by user INI files.

Fix: introduce OPTION_PRIORITY_BOOTSTRAP = OPTION_PRIORITY_DEFAULT + 1 and
use it for the bootstrap pass, ensuring any subsequent INI pass can override
its values.