### PR TITLE
Fix INI_PATH quoting in sdl_cfg.lua

### DIFF
--- a/scripts/src/osd/sdl3_cfg.lua
+++ b/scripts/src/osd/sdl3_cfg.lua
@@ -31,7 +31,7 @@ end
 
 if _OPTIONS["SDL_INI_PATH"]~=nil then
 	defines {
-		"'INI_PATH=\"" .. _OPTIONS["SDL_INI_PATH"] .. "\"'",
+		"INI_PATH=\"" .. _OPTIONS["SDL_INI_PATH"] .. "\"",
 	}
 end
 

--- a/scripts/src/osd/sdl_cfg.lua
+++ b/scripts/src/osd/sdl_cfg.lua
@@ -31,7 +31,7 @@ end
 
 if _OPTIONS["SDL_INI_PATH"]~=nil then
 	defines {
-		"'INI_PATH=\"" .. _OPTIONS["SDL_INI_PATH"] .. "\"'",
+		"INI_PATH=\"" .. _OPTIONS["SDL_INI_PATH"] .. "\"",
 	}
 end
 


### PR DESCRIPTION
The extra single quotes around the INI_PATH definition cause a build failure with gcc15 and later.