### PR TITLE
bus/nscsi: move the opt-in seek-timing model into nscsi_harddisk_device

### DIFF
--- a/src/devices/bus/nscsi/dtc510.cpp
+++ b/src/devices/bus/nscsi/dtc510.cpp
@@ -44,11 +44,6 @@ nscsi_dtc510_device::nscsi_dtc510_device(const machine_config &mconfig, const ch
 	std::fill(std::begin(m_param), std::end(m_param), 0);
 }
 
-void nscsi_dtc510_device::device_reset()
-{
-	nscsi_harddisk_device::device_reset();
-}
-
 bool nscsi_dtc510_device::scsi_command_done(uint8_t command, uint8_t length)
 {
 	switch(command >> 5) {
@@ -93,7 +88,7 @@ void nscsi_dtc510_device::scsi_command()
 			scsi_status_complete(SS_NOT_READY);
 			m_scsi_sense_buffer[0] = SK_DRIVE_NOT_READY;
 		} else {
-			// lba = 0;
+			m_last_cylinder = 0;   // recalibrate returns the heads to track 0
 			scsi_status_complete(SS_GOOD);
 		}
 		break;
@@ -262,8 +257,12 @@ attotime nscsi_dtc510_device::scsi_data_command_delay()
 	case SC_SEEK:
 	case SC_ASSIGN_ALT_TRACK:
 	case SC_RETENTION:
-		// average seek time of NEC D5126A hard disk
-		return attotime::from_msec(85);
+		// Legacy default (unchanged unless a driver calls set_seek_timing()): the
+		// flat average-seek time of the NEC D5126A.  With a model configured,
+		// defer to the base's cylinder-aware timing.
+		if (!m_seek_model)
+			return attotime::from_msec(85);
+		return seek_time(get_u24be(&m_scsi_cmdbuf[1]) & 0x1fffff);
 
 	default:
 		return attotime::zero;

--- a/src/devices/bus/nscsi/dtc510.h
+++ b/src/devices/bus/nscsi/dtc510.h
@@ -95,8 +95,6 @@ protected:
 		SK_FORMAT_ERROR         = 0x1a
 	};
 
-	virtual void device_reset() override ATTR_COLD;
-
 	virtual bool scsi_command_done(uint8_t command, uint8_t length) override;
 	virtual void scsi_command() override;
 	virtual uint8_t scsi_get_data(int id, int pos) override;

--- a/src/devices/bus/nscsi/hd.cpp
+++ b/src/devices/bus/nscsi/hd.cpp
@@ -6,6 +6,8 @@
 
 #include "multibyte.h"
 
+#include <cmath>
+
 #define LOG_COMMAND     (1U << 1)
 #define LOG_DATA        (1U << 2)
 #define LOG_UNSUPPORTED (1U << 3)
@@ -57,6 +59,84 @@ void nscsi_harddisk_device::device_reset()
 		image->get_inquiry_data(m_inquiry_data);
 	}
 	cur_lba = -1;
+	m_last_cylinder = -1;
+}
+
+void nscsi_harddisk_device::set_seek_timing(uint32_t track_us, uint32_t average_us, uint32_t full_us, uint32_t rpm, uint8_t interleave)
+{
+	m_seek_track_us = track_us;
+	m_seek_range_us = (full_us > track_us) ? (full_us - track_us) : 0;
+	m_rpm           = rpm ? rpm : 3600;
+	m_interleave    = interleave ? interleave : 1;
+	// Fit seek(d) = track + range * (d/ncyl)^exp so an average-length seek
+	// (~1/3 of full stroke) costs average_us.
+	const double num = double(average_us) - double(track_us);
+	const double den = double(full_us)    - double(track_us);
+	m_seek_exp = (num > 0.0 && den > 0.0) ? std::log(num / den) / std::log(1.0 / 3.0) : 1.0;
+	m_seek_model = true;
+}
+
+// Cylinder-aware seek delay for the block at lba.  A real drive seeks only when
+// the target cylinder changes; sequential I/O on one cylinder pays only
+// rotational latency, scaled by the format interleave.  Tracks the head cylinder
+// across commands so sustained reads on one cylinder are not billed a seek each.
+// The exponent fitted in set_seek_timing() captures a controller's "burst mode"
+// multi-cylinder seek -- faster than naive track-to-track stepping over a long
+// seek, but still cheap for short ones.
+attotime nscsi_harddisk_device::seek_time(uint32_t lba)
+{
+	uint32_t spt = 1, spc = 1, ncyl = 1;
+	if (image->exists())
+	{
+		const auto &info = image->get_info();
+		spt  = info.sectors ? info.sectors : 1;          // sectors per track
+		spc  = info.heads * spt;  if (!spc)  spc = 1;    // sectors per cylinder
+		ncyl = info.cylinders ? info.cylinders : 1;
+	}
+	const int target = int(lba / spc);
+	const int dist = (m_last_cylinder < 0) ? int(ncyl)
+		: (target > m_last_cylinder ? target - m_last_cylinder
+					  : m_last_cylinder - target);
+	m_last_cylinder = target;
+
+	const uint32_t rev_us = 60u * 1000000u / m_rpm;   // one revolution
+	uint32_t us;
+	if (dist == 0)
+		// Same cylinder: consecutive logical sectors arrive after the interleave
+		// gap (interleave revolutions to read one track of spt sectors).
+		us = (rev_us * m_interleave) / spt;
+	else
+		// Cylinder change: ~half a revolution rotational latency + a distance-
+		// scaled seek between the track-to-track and full-stroke times.
+		us = rev_us / 2 + m_seek_track_us
+			+ uint32_t(double(m_seek_range_us) * std::pow(double(dist) / double(ncyl), m_seek_exp));
+	return attotime::from_usec(us);
+}
+
+// Command execution delay.  Inert (returns the base zero delay) until a driver
+// calls set_seek_timing(); then the generic SCSI READ/WRITE/SEEK opcodes (6- and
+// 10-byte) are billed a cylinder-aware seek.  Subclasses with their own command
+// set override this and call seek_time() for the relevant opcodes.
+attotime nscsi_harddisk_device::scsi_data_command_delay()
+{
+	if (!m_seek_model)
+		return attotime::zero;
+
+	switch (m_scsi_cmdbuf[0])
+	{
+	case 0x08: // READ (6)
+	case 0x0a: // WRITE (6)
+	case 0x0b: // SEEK (6)
+		return seek_time(get_u24be(&m_scsi_cmdbuf[1]) & 0x1fffff);
+
+	case 0x28: // READ (10)
+	case 0x2a: // WRITE (10)
+	case 0x2b: // SEEK (10)
+		return seek_time(get_u32be(&m_scsi_cmdbuf[2]));
+
+	default:
+		return attotime::zero;
+	}
 }
 
 void nscsi_harddisk_device::device_add_mconfig(machine_config &config)

--- a/src/devices/bus/nscsi/hd.h
+++ b/src/devices/bus/nscsi/hd.h
@@ -14,6 +14,48 @@ public:
 	nscsi_harddisk_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 	void set_default_model_name(const std::string_view &model);
 
+	// Optional, driver-supplied cylinder-aware seek-timing model, shared by all
+	// hard-disk controllers built on this device.  With no call the device keeps
+	// its inherited behaviour (the subclass's legacy flat delay, or none for a
+	// plain NSCSI_HARDDISK), so existing users are byte-for-byte unchanged.  A
+	// driver opts in once the controller is attached at a slot, e.g. from
+	// machine_start().  Once set, a command pays a real seek only when the target
+	// cylinder changes; consecutive sectors on one cylinder pay only rotational
+	// latency scaled by the interleave.
+	//
+	// Deriving the five parameters -- all four times come from the drive's OEM
+	// manual / datasheet; only interleave comes from the host's disk format:
+	//
+	//   track_us   - track-to-track (single-cylinder) seek time, in microseconds.
+	//   average_us - average (random) seek time, in microseconds.  Manufacturers
+	//                quote this for a seek over ~1/3 of the stroke; the model
+	//                solves its curve's exponent so a 1/3-stroke seek costs
+	//                exactly this value (track-to-track and full-stroke anchor
+	//                the ends).
+	//   full_us    - full-stroke (maximum) seek time, in microseconds.  Use the
+	//                "maximum" seek figure; head settling is normally already
+	//                included in the quoted seek times.
+	//   rpm        - spindle speed.  One revolution = 60e6 / rpm us; a same-
+	//                cylinder read costs interleave revolutions per track of
+	//                spt sectors, and a seek adds a half-revolution of latency.
+	//   interleave - the sector interleave the host CBIOS formatted the media
+	//                with (1 = 1:1, 2 = 2:1, ...).  This is a property of the
+	//                FORMAT, not the drive, and sets the single-cylinder
+	//                sequential transfer rate.
+	//
+	// The cylinder count is taken from the mounted CHD's geometry, so one call
+	// serves differently-sized members of a drive family (e.g. ST-506 153 cyl
+	// vs ST-412 306 cyl).  If a datasheet gives only two of the three seek
+	// times, pass the missing one equal to a neighbour (e.g. average_us =
+	// full_us); the fit then degrades gracefully toward a flat per-seek cost.
+	//
+	// Example -- Seagate ST-506 / ST-412 (ST412 OEM manual, April 1982): 3600
+	// RPM, track-to-track 3 ms, average 85 ms, full-stroke 205 ms, 1:1 format:
+	//     if (auto *s = dynamic_cast<nscsi_harddisk_device *>(subdevice("sasi:0:s1410")))
+	//         s->set_seek_timing(3000, 85000, 205000, 3600, 1);
+	//
+	void set_seek_timing(uint32_t track_us, uint32_t average_us, uint32_t full_us, uint32_t rpm, uint8_t interleave);
+
 protected:
 	nscsi_harddisk_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
@@ -24,6 +66,14 @@ protected:
 	virtual void scsi_command() override;
 	virtual uint8_t scsi_get_data(int id, int pos) override;
 	virtual void scsi_put_data(int buf, int offset, uint8_t data) override;
+	virtual attotime scsi_data_command_delay() override;
+
+	// Cylinder-aware seek delay for the block at lba, using the model configured
+	// by set_seek_timing().  Updates the tracked head position.  Subclasses with
+	// their own command dispatch call this from scsi_data_command_delay() for the
+	// commands that move the heads; the base applies it to the generic SCSI
+	// READ/WRITE/SEEK (6- and 10-byte) opcodes.
+	attotime seek_time(uint32_t lba);
 
 	required_device<harddisk_image_device> image;
 	std::string m_default_model_name;
@@ -32,6 +82,17 @@ protected:
 	int bytes_per_sector;
 
 	std::vector<u8> m_inquiry_data;
+
+	// Seek-timing model state (configured by set_seek_timing(); while
+	// m_seek_model is false the model is inert and scsi_data_command_delay()
+	// returns the base zero delay -- no change for existing users).
+	bool     m_seek_model = false;
+	int      m_last_cylinder = -1;   // current head cylinder (-1 = unknown)
+	uint8_t  m_interleave = 1;       // sector interleave (1 = 1:1)
+	uint32_t m_rpm = 3600;           // spindle speed -> rotational latency
+	uint32_t m_seek_track_us = 0;    // track-to-track seek time
+	uint32_t m_seek_range_us = 0;    // full-stroke minus track-to-track
+	double   m_seek_exp = 1.0;       // seek(d) = track + range*(d/ncyl)^exp
 };
 
 DECLARE_DEVICE_TYPE(NSCSI_HARDDISK, nscsi_harddisk_device)

--- a/src/devices/bus/nscsi/s1410.cpp
+++ b/src/devices/bus/nscsi/s1410.cpp
@@ -5,8 +5,6 @@
 
 #include "multibyte.h"
 
-#include <cmath>
-
 #define LOG_COMMAND (1U << 1)
 #define LOG_DATA    (1U << 2)
 
@@ -34,22 +32,6 @@ void nscsi_s1410_device::device_reset()
 	params[5] = 0;
 	params[6] = 64;
 	params[7] = 11;
-
-	m_last_cylinder = -1;
-}
-
-void nscsi_s1410_device::set_seek_timing(uint32_t track_us, uint32_t average_us, uint32_t full_us, uint32_t rpm, uint8_t interleave)
-{
-	m_seek_track_us = track_us;
-	m_seek_range_us = (full_us > track_us) ? (full_us - track_us) : 0;
-	m_rpm           = rpm ? rpm : 3600;
-	m_interleave    = interleave ? interleave : 1;
-	// Fit seek(d) = track + range * (d/ncyl)^exp so an average-length seek
-	// (~1/3 of full stroke) costs average_us.
-	const double num = double(average_us) - double(track_us);
-	const double den = double(full_us)    - double(track_us);
-	m_seek_exp = (num > 0.0 && den > 0.0) ? std::log(num / den) / std::log(1.0 / 3.0) : 1.0;
-	m_seek_model = true;
 }
 
 bool nscsi_s1410_device::scsi_command_done(uint8_t command, uint8_t length)
@@ -244,44 +226,13 @@ attotime nscsi_s1410_device::scsi_data_command_delay()
 	case SC_READ:
 	case SC_WRITE:
 	case SC_SEEK:
-	{
-		// Legacy default (unchanged unless a driver calls set_seek_timing()):
-		// a flat average-seek delay charged on every command, matching the
-		// older NEC D5126A approximation used by the existing s1410 users.
+		// Legacy default (unchanged unless a driver calls set_seek_timing()): a
+		// flat average-seek delay charged on every command, matching the older
+		// NEC D5126A approximation the existing s1410 users rely on.  With a
+		// model configured, defer to the base's cylinder-aware timing.
 		if (!m_seek_model)
 			return attotime::from_msec(85);
-
-		// A real drive seeks only when the target cylinder changes; sequential
-		// I/O on one cylinder pays only rotational latency, scaled by the
-		// format interleave.  Track the head cylinder and bill streaming or a
-		// real seek accordingly.  For the ST-506/ST-412 the model fits
-		// track-to-track 3 ms, average 85 ms and full-stroke 205 ms with
-		// exp ~= 0.82, capturing the drive's "burst mode" multi-cylinder seek
-		// (faster than naive 3 ms/cyl stepping for long seeks, but still cheap
-		// for short ones).
-		uint32_t spt = 1, spc = 1, ncyl = 1;
-		if (image->exists())
-		{
-			const auto &info = image->get_info();
-			spt  = info.sectors ? info.sectors : 1;
-			spc  = info.heads * spt;  if (!spc)  spc = 1;
-			ncyl = info.cylinders ? info.cylinders : 1;
-		}
-		const int target = int((get_u24be(&m_scsi_cmdbuf[1]) & 0x1fffff) / spc);
-		const int dist = (m_last_cylinder < 0) ? int(ncyl)
-			: (target > m_last_cylinder ? target - m_last_cylinder
-						  : m_last_cylinder - target);
-		m_last_cylinder = target;
-
-		const uint32_t rev_us = 60u * 1000000u / m_rpm;
-		uint32_t us;
-		if (dist == 0)
-			us = (rev_us * m_interleave) / spt;
-		else
-			us = rev_us / 2 + m_seek_track_us
-				+ uint32_t(double(m_seek_range_us) * std::pow(double(dist) / double(ncyl), m_seek_exp));
-		return attotime::from_usec(us);
-	}
+		return seek_time(get_u24be(&m_scsi_cmdbuf[1]) & 0x1fffff);
 
 	default:
 		return attotime::zero;

--- a/src/devices/bus/nscsi/s1410.h
+++ b/src/devices/bus/nscsi/s1410.h
@@ -13,32 +13,16 @@ class nscsi_s1410_device : public nscsi_harddisk_device
 public:
 	nscsi_s1410_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	// Optional, driver-supplied seek-timing model.  With no call the device keeps
-	// its legacy flat 85 ms per-command delay, so existing users (victor9k,
-	// mikromik, x37_sasi, db4105, idpartner_sasi) are unchanged.  Arguments:
-	// published seek times in microseconds (track-to-track, average,
-	// full-stroke), spindle speed (RPM), and the format's sector interleave.
+	// The opt-in cylinder-aware seek-timing model lives in nscsi_harddisk_device;
+	// set_seek_timing() is inherited.  With no call this controller keeps its
+	// legacy flat 85 ms per-command delay (see scsi_data_command_delay()), so
+	// existing users (victor9k, mikromik, x37_sasi, db4105, idpartner_sasi) are
+	// unchanged.  Example -- a Seagate ST-506/ST-412 (ST412 OEM manual, April
+	// 1982: 3600 RPM, track-to-track 3 ms, average 85 ms, full-stroke 205 ms),
+	// media formatted 1:1; configure once attached, e.g. from machine_start():
 	//
-	// Examples -- the Seagate ST-506 (153 cyl, 5 MB formatted) and ST-412
-	// (306 cyl, 10 MB formatted) share the same timing specification in the
-	// ST412 OEM manual (April 1982): 3600 RPM; track-to-track 3 ms; average
-	// 85 ms; full-stroke (maximum) 205 ms with "fast seek / burst mode"
-	// (settling already included).  Sector interleave depends on the host
-	// CBIOS's format -- 1:1 for the Big Board II's Cal-Tex monitor.
-	//
-	// Configure once the controller is attached at a slot, e.g. from
-	// machine_start():
-	//
-	//   ST-506 (5 MB):
 	//     if (auto *s = dynamic_cast<nscsi_s1410_device *>(subdevice("sasi:0:s1410")))
 	//         s->set_seek_timing(3000, 85000, 205000, 3600, 1);
-	//
-	//   ST-412 (10 MB; identical parameters -- the burst-mode model adapts to
-	//   whatever physical cylinder count the CHD's GDDD metadata reports):
-	//     if (auto *s = dynamic_cast<nscsi_s1410_device *>(subdevice("sasi:0:s1410")))
-	//         s->set_seek_timing(3000, 85000, 205000, 3600, 1);
-	//
-	void set_seek_timing(uint32_t track_us, uint32_t average_us, uint32_t full_us, uint32_t rpm, uint8_t interleave);
 
 protected:
 	// SCSI status returns
@@ -108,16 +92,6 @@ protected:
 	virtual attotime scsi_data_command_delay() override;
 
 	uint8_t params[8];
-
-	// Seek-timing model state (set by set_seek_timing(); when m_seek_model is
-	// false the device uses the legacy flat 85 ms per-command delay).
-	bool     m_seek_model = false;
-	int      m_last_cylinder = -1;   // current head cylinder (-1 = unknown)
-	uint8_t  m_interleave = 1;       // sector interleave (1 = 1:1)
-	uint32_t m_rpm = 3600;           // spindle speed -> rotational latency
-	uint32_t m_seek_track_us = 0;    // track-to-track seek time
-	uint32_t m_seek_range_us = 0;    // full-stroke minus track-to-track
-	double   m_seek_exp = 1.0;       // seek(d) = track + range*(d/ncyl)^exp
 };
 
 DECLARE_DEVICE_TYPE(NSCSI_S1410, nscsi_s1410_device)


### PR DESCRIPTION
## Summary

The cylinder-aware seek-timing model added to the Xebec S1410 (#15411) and
proposed for the DTC-510 (#15406) was identical copy/paste between the two
controllers. As suggested by @MooglyGuy on #15406, this hoists the model up
into their common base, `nscsi_harddisk_device`, so it is written once and is
available to any hard-disk controller built on it (including a plain
`NSCSI_HARDDISK`) without subclassing.

**Supersedes #15406** (DTC-510), which is closed in favour of this.

## What moves, and what deliberately does not

- **The opt-in model moves up.** `set_seek_timing()`, the model state, the
  fitted-exponent math (`seek_time()`), and a generic `scsi_data_command_delay()`
  now live in `nscsi_harddisk_device`.
- **The legacy flat 85 ms delay deliberately stays down** in `s1410` and
  `dtc510`. It is a per-controller quirk (Curt Coder added it to s1410 for
  abc1600 formatting; dtc510 inherited it for pc9801), not a property of all
  hard disks. Hoisting it would change behaviour for every `NSCSI_HARDDISK`
  user; keeping it local does not.

## Safety: no change for existing users

The base `scsi_data_command_delay()` returns `attotime::zero` (its inherited
default) unless a driver has called `set_seek_timing()`. So:

- Every current `nscsi_harddisk_device` user is byte-for-byte unchanged.
- `s1410` and `dtc510` keep their exact legacy behaviour: with no
  `set_seek_timing()` call they return the flat 85 ms for their own command
  set; the only difference is they now delegate the *model* branch to the base
  instead of carrying a private copy of it.

There is still no in-tree caller; this is groundwork (a Toshiba T-200/T-250
driver in development uses it for the machine's CDC 9410 Finch).

## Model

When configured, a command pays a real seek only when the target cylinder
changes (derived from the LBA and the CHD geometry); consecutive sectors on
one cylinder pay only rotational latency scaled by the format interleave. The
seek curve is fitted from the drive's published track-to-track / average /
full-stroke figures. The base applies this to the generic SCSI READ/WRITE/SEEK
opcodes in **both** their 6-byte (0x08/0x0a/0x0b) and 10-byte
(0x28/0x2a/0x2b) forms; subclasses with their own dispatch call `seek_time()`
for whatever opcodes move the heads.

## Parameter documentation

`set_seek_timing()`'s header comment now documents how to derive each of the
five parameters from an OEM manual, including the convention that the quoted
"average" seek is a ~1/3-stroke seek (which anchors the fitted exponent) and a
fallback when a datasheet supplies only two of the three seek times.

## Testing

- The `bus/nscsi` sources compile clean with no new warnings.
- `s1410` users (victor9k, mikromik, x37_sasi, db4105, idpartner_sasi) and the
  `dtc510` user (pc9801_27) are unchanged — the legacy path is untouched and
  the model is inert without a `set_seek_timing()` call.