### PR TITLE
bus/scsi/scsihle: deassert REQ between phases; hold BSY in COMMAND

### DIFF
--- a/src/devices/bus/scsi/scsihle.cpp
+++ b/src/devices/bus/scsi/scsihle.cpp
@@ -339,6 +339,14 @@ void scsihle_device::scsi_change_phase(uint8_t newphase)
 	cmd_idx=0;
 	data_idx=0;
 
+	// Deassert REQ at every phase transition so the initiator sees a clean REQ
+	// low->high edge with the new phase's C/D-I/O lines settled.  Otherwise the
+	// per-byte REQ-deassert timer is cancelled by the next phase's re-assert, so
+	// REQ can stay continuously high across (e.g.) COMMAND->DATA-IN and an
+	// initiator that polls the control lines on the REQ edge samples the stale
+	// previous-phase C/D/I/O.
+	output_req(0);
+
 	switch(m_phase)
 	{
 		case SCSI_PHASE_BUS_FREE:
@@ -356,6 +364,7 @@ void scsihle_device::scsi_change_phase(uint8_t newphase)
 			break;
 
 		case SCSI_PHASE_COMMAND:
+			output_bsy(1); // a selected target holds BSY for the whole connection; assert it here so a fast SEL deassert (racing the 50ns sel_timer) cannot leave BSY low in COMMAND
 			output_cd(1);
 			output_io(0);
 			output_msg(0);


### PR DESCRIPTION
Two SCSI-HLE bus-semantics fixes.

1. `scsi_change_phase()` deasserts REQ on entry, so the initiator sees a clean REQ low→high edge with the new phase's C/D-I/O lines settled. Previously the per-byte REQ-deassert timer was cancelled by the next phase's re-assert, leaving REQ continuously high across e.g. COMMAND→DATA-IN, so an initiator that samples the control lines on the REQ edge read the stale previous-phase lines.

2. A selected target asserts BSY on entry to COMMAND, so a fast SEL deassert racing the sel_timer cannot leave BSY low during the connection.

Tested without regression on `v1050` (working; S1410 SASI hard disk: FMTWINCH format + COPYSYS + boot and access) and on an in-development Xerox 820-II SASI host adapter. Other legacy `scsihle` machines (fmtowns, pcd, bebox, rmnimbus, model3, slicer) were not regression-tested locally; both changes are conservative SCSI bus semantics.
