### PR TITLE
machine/gen_latch.cpp: add a setter for suppressing latch written messages in logerror

### DIFF
--- a/src/devices/bus/nec_fdd/pc80s31k.cpp
+++ b/src/devices/bus/nec_fdd/pc80s31k.cpp
@@ -293,7 +293,12 @@ void pc80s31_device::device_add_mconfig(machine_config &config)
 	}
 
 	for (auto &latch : m_latch)
+	{
 		GENERIC_LATCH_8(config, latch);
+		// log spawns a ton, particularly with 8255 port C intermediate setups,
+		// or with NOP checks for .d88 copy protection workarounds.
+		latch->set_suppress_log_warnings(true);
+	}
 
 	I8255A(config, m_ppi_host);
 	m_ppi_host->in_pa_callback().set(FUNC(pc80s31_device::latch_r<0>));

--- a/src/devices/machine/gen_latch.cpp
+++ b/src/devices/machine/gen_latch.cpp
@@ -33,6 +33,7 @@ DEFINE_DEVICE_TYPE(GENERIC_LATCH_16, generic_latch_16_device, "generic_latch_16"
 
 generic_latch_base_device::generic_latch_base_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock) :
 	device_t(mconfig, type, tag, owner, clock),
+	m_suppress_log(false),
 	m_separate_acknowledge(false),
 	m_latch_written(false),
 	m_data_pending_cb(*this)
@@ -157,7 +158,7 @@ void generic_latch_8_device::sync_callback(s32 param)
 	u8 value = param;
 
 	// if the latch has been written and the value is changed, log a warning
-	if (is_latch_written() && m_latched_value != value)
+	if (is_latch_written() && m_latched_value != value && !m_suppress_log)
 		LOGMASKED(LOG_WARN, "Warning: latch written before being read. Previous: %02x, new: %02x\n", m_latched_value, value);
 
 	// store the new value and mark it not read
@@ -228,7 +229,7 @@ void generic_latch_16_device::sync_callback(s32 param)
 	u16 value = param;
 
 	// if the latch has been written and the value is changed, log a warning
-	if (is_latch_written() && m_latched_value != value)
+	if (is_latch_written() && m_latched_value != value && !m_suppress_log)
 		LOGMASKED(LOG_WARN, "Warning: latch written before being read. Previous: %02x, new: %02x\n", m_latched_value, value);
 
 	// store the new value and mark it not read

--- a/src/devices/machine/gen_latch.h
+++ b/src/devices/machine/gen_latch.h
@@ -39,6 +39,9 @@ public:
 	u8 acknowledge_r(address_space &space);
 	void acknowledge_w(u8 data = 0);
 
+	// configuration option: bus/nec_fdd/pc80s31k doesn't care about reading
+	void set_suppress_log_warnings(bool setting) { m_suppress_log = setting; }
+
 protected:
 	// construction/destruction
 	generic_latch_base_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
@@ -50,6 +53,7 @@ protected:
 	bool is_latch_written() const { return m_latch_written; }
 	void set_latch_written(bool latch_written);
 
+	bool                    m_suppress_log;
 private:
 	void init_callback(s32 param);
 

--- a/src/devices/machine/gen_latch.h
+++ b/src/devices/machine/gen_latch.h
@@ -39,7 +39,7 @@ public:
 	u8 acknowledge_r(address_space &space);
 	void acknowledge_w(u8 data = 0);
 
-	// configuration option: bus/nec_fdd/pc80s31k doesn't care about reading
+	// configuration option: suppress "Warning: latch written before being read" messages in logerror
 	void set_suppress_log_warnings(bool setting) { m_suppress_log = setting; }
 
 protected:


### PR DESCRIPTION
* hook it up to bus/nec_fdd/pc80s31k.cpp as example, where the verbosity is too much to be tolerable;