### PR TITLE
hd44780: fix char size selection in 2-line mode

### DIFF
--- a/src/devices/video/hd44780.cpp
+++ b/src/devices/video/hd44780.cpp
@@ -660,7 +660,10 @@ void hd44780_base_device::control_write(u8 data)
 		}
 		m_first_cmd = true;
 
-		m_char_size = BIT(m_ir, 2) ? 10 : 8;
+		if (BIT(m_ir, 3))
+			m_char_size = 8; // 5x10 chars not available in 2 line mode
+		else
+			m_char_size = BIT(m_ir, 2) ? 10 : 8;
 		m_data_len  = BIT(m_ir, 4) ? 8 : 4;
 		m_num_line  = BIT(m_ir, 3) + 1;
 		correct_ac();


### PR DESCRIPTION
On the HD44780 and clones, the character size bit is only available in single line mode. This fixes CGRAM characters on `s700` and `x7000`, which set both bits for some reason.

Before and after:

<img width="288" height="24" alt="image" src="https://github.com/user-attachments/assets/d5d6dab4-2319-4eb4-a1e3-6ddef60ac840" />
<br/>
<img width="288" height="24" alt="image" src="https://github.com/user-attachments/assets/508cb25a-462b-4e6b-b453-42f6c33790c8" />
