### PR TITLE
imagedev/floppy: add a get_image() accessor for the mounted image

### DIFF
--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -293,6 +293,7 @@ public:
 
 	int get_cyl() const { return m_cyl; }
 	bool on_track() const { return !m_subcyl; }
+	floppy_image *get_image() const { return m_image.get(); } // for HLE controllers that read the mounted image directly
 
 	virtual void mon_w(int state);
 	bool ready_r();


### PR DESCRIPTION
Adds a small public accessor returning the `floppy_image` the drive currently holds:

```cpp
floppy_image *get_image() const { return m_image.get(); }
```

This is for **high-level controller emulations that decode the mounted media themselves** rather than going through an FDC — e.g. the Shugart **SA1403D** SASI controller (a SASI/floppy bridge), which reads the image to serve sectors over the bus.

Prerequisite for the SA1403D HLE (#15456) and the Xerox 820-II SASI driver (#15457).
