### PR TITLE
esqvfd,esqlcd: make esqvfd use fixed size output_finder for the VFD characters and segments.

### DIFF
--- a/src/mame/ensoniq/esq1.cpp
+++ b/src/mame/ensoniq/esq1.cpp
@@ -428,7 +428,7 @@ private:
 	required_device<scn2681_device> m_duart;
 	required_device<esq1_filters> m_filters;
 	optional_device<wd1772_device> m_fdc;
-	optional_device<esqpanel2x40_device> m_panel;
+	optional_device<esqpanel2x40_esq1_device> m_panel;
 	required_ioport m_volume_slider;
 	required_ioport m_data_entry_slider;
 	required_ioport m_pitch_wheel;
@@ -663,10 +663,10 @@ void esq1_state::esq1(machine_config &config)
 	m_duart->set_clocks(8_MHz_XTAL / 16, 8_MHz_XTAL / 16, 8_MHz_XTAL / 8, 8_MHz_XTAL / 8);
 	m_duart->irq_cb().set("mainirq", FUNC(input_merger_device::in_w<0>));
 	m_duart->a_tx_cb().set(m_mdout, FUNC(midi_port_device::write_txd));
-	m_duart->b_tx_cb().set(m_panel, FUNC(esqpanel2x40_device::rx_w));
+	m_duart->b_tx_cb().set(m_panel, FUNC(esqpanel2x40_esq1_device::rx_w));
 	m_duart->outport_cb().set(FUNC(esq1_state::duart_output));
 
-	ESQPANEL2X40(config, m_panel);
+	ESQPANEL2X40_ESQ1(config, m_panel);
 	m_panel->write_tx().set(m_duart, FUNC(scn2681_device::rx_b_w));
 
 	auto &mdin(MIDI_PORT(config, "mdin"));

--- a/src/mame/ensoniq/esqlcd.cpp
+++ b/src/mame/ensoniq/esqlcd.cpp
@@ -11,7 +11,7 @@
 //#define VERBOSE 1
 #include "logmacro.h"
 
-DEFINE_DEVICE_TYPE(ESQ2X16_SQ1, esq2x16_sq1_device, "esq2x16_sq1", "Ensoniq 2x16 VFD (SQ-1 variant)")
+DEFINE_DEVICE_TYPE(ESQ2X16_SQ1, esq2x16_sq1_device, "esq2x16_sq1", "Ensoniq 2x16 LCD (SQ-1 variant)")
 
 // --- SQ1 - Parduz --------------------------------------------------------------------------------------------------------------------------
 
@@ -305,7 +305,7 @@ void esq2x16_sq1_device::write_char(uint8_t data)
 }
 //--------------------------------------------------------------------------------------------------------------------------------------------
 esq2x16_sq1_device::esq2x16_sq1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	esqvfd_device(mconfig, ESQ2X16_SQ1, tag, owner, clock, make_dimensions<2, 16>(*this)),
+	device_t(mconfig, ESQ2X16_SQ1, tag, owner, clock),
 	m_lcdPix(*this, "pg_%u%03u", 1U, 0U),
 	m_leds(*this, "rLed_%u", 0U)
 {
@@ -325,6 +325,15 @@ void esq2x16_sq1_device::update_display()
 			}
 		}
 	}
+}
+//--------------------------------------------------------------------------------------------------------------------------------------------
+void esq2x16_sq1_device::device_start()
+{
+	save_item(NAME(m_lcdpg));
+	save_item(NAME(m_lcdPage));
+	save_item(NAME(m_lcdPos));
+	save_item(NAME(m_lcdSavedPos));
+	save_item(NAME(m_lcd_command));
 }
 //--------------------------------------------------------------------------------------------------------------------------------------------
 void esq2x16_sq1_device::device_reset()

--- a/src/mame/ensoniq/esqlcd.h
+++ b/src/mame/ensoniq/esqlcd.h
@@ -10,15 +10,16 @@
 
 // --- SQ1 - Parduz --------------------------------------------------------------------------------------------------------------------------
 
-class esq2x16_sq1_device : public esqvfd_device {
+class esq2x16_sq1_device : public device_t {
 public:
 	esq2x16_sq1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	virtual void write_char(uint8_t data) override;
-	virtual void update_display() override;
+	virtual void write_char(uint8_t data);
+	virtual void update_display();
 
 protected:
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
+	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 
 	uint8_t m_lcdpg[4][32]{};

--- a/src/mame/ensoniq/esqpanel.cpp
+++ b/src/mame/ensoniq/esqpanel.cpp
@@ -413,10 +413,10 @@ namespace esqpanel {
 //  DEVICE DEFINITIONS
 //**************************************************************************
 
-DEFINE_DEVICE_TYPE(ESQPANEL1X22,     esqpanel1x22_device,     "esqpanel122",     "Ensoniq front panel with 1x22 VFD")
-DEFINE_DEVICE_TYPE(ESQPANEL2X40,     esqpanel2x40_device,     "esqpanel240",     "Ensoniq front panel with 2x40 VFD")
-DEFINE_DEVICE_TYPE(ESQPANEL2X40_VFX, esqpanel2x40_vfx_device, "esqpanel240_vfx", "Ensoniq front panel with 2x40 VFD for VFX family")
-DEFINE_DEVICE_TYPE(ESQPANEL2X16_SQ1, esqpanel2x16_sq1_device, "esqpanel216_sq1", "Ensoniq front panel with 2x16 LCD")
+DEFINE_DEVICE_TYPE(ESQPANEL1X22,      esqpanel1x22_device,     "esqpanel122",      "Ensoniq front panel with 1x22 VFD")
+DEFINE_DEVICE_TYPE(ESQPANEL2X40_ESQ1, esqpanel2x40_esq1_device,     "esqpanel240_esq1", "Ensoniq front panel with 2x40 VFD for ESQ1 family")
+DEFINE_DEVICE_TYPE(ESQPANEL2X40_VFX,  esqpanel2x40_vfx_device, "esqpanel240_vfx",  "Ensoniq front panel with 2x40 VFD for VFX family")
+DEFINE_DEVICE_TYPE(ESQPANEL2X16_SQ1,  esqpanel2x16_sq1_device, "esqpanel216_sq1",  "Ensoniq front panel with 2x16 LCD")
 
 //**************************************************************************
 //  LIVE DEVICE
@@ -745,14 +745,14 @@ esqpanel1x22_device::esqpanel1x22_device(const machine_config &mconfig, const ch
 
 /* panel with 2x40 VFD display used in the ESQ-1, SQ-80 */
 
-void esqpanel2x40_device::device_add_mconfig(machine_config &config)
+void esqpanel2x40_esq1_device::device_add_mconfig(machine_config &config)
 {
-	ESQ2X40(config, m_vfd, 60);
+	ESQ2X40_ESQ1(config, m_vfd, 60);
 }
 
 
-esqpanel2x40_device::esqpanel2x40_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	esqpanel_device(mconfig, ESQPANEL2X40, tag, owner, clock),
+esqpanel2x40_esq1_device::esqpanel2x40_esq1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	esqpanel_device(mconfig, ESQPANEL2X40_ESQ1, tag, owner, clock),
 	m_vfd(*this, "vfd")
 {
 	m_eps_mode = false;

--- a/src/mame/ensoniq/esqpanel.h
+++ b/src/mame/ensoniq/esqpanel.h
@@ -95,16 +95,16 @@ protected:
 	required_device<esq1x22_device> m_vfd;
 };
 
-class esqpanel2x40_device : public esqpanel_device {
+class esqpanel2x40_esq1_device : public esqpanel_device {
 public:
-	esqpanel2x40_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+	esqpanel2x40_esq1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 
 protected:
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 
 	virtual void send_to_display(uint8_t data) override { m_vfd->write_char(data); }
 
-	required_device<esq2x40_device> m_vfd;
+	required_device<esq2x40_esq1_device> m_vfd;
 };
 
 class esqpanel2x40_vfx_device : public esqpanel_device {
@@ -191,10 +191,10 @@ protected:
 	required_device<esq2x16_sq1_device> m_vfd;
 };
 
-DECLARE_DEVICE_TYPE(ESQPANEL1X22,     esqpanel1x22_device)
-DECLARE_DEVICE_TYPE(ESQPANEL2X40,     esqpanel2x40_device)
-DECLARE_DEVICE_TYPE(ESQPANEL2X40_VFX, esqpanel2x40_vfx_device)
-DECLARE_DEVICE_TYPE(ESQPANEL2X40_SQ1, esqpanel2x40_sq1_device)
-DECLARE_DEVICE_TYPE(ESQPANEL2X16_SQ1, esqpanel2x16_sq1_device)
+DECLARE_DEVICE_TYPE(ESQPANEL1X22,      esqpanel1x22_device)
+DECLARE_DEVICE_TYPE(ESQPANEL2X40_ESQ1, esqpanel2x40_esq1_device)
+DECLARE_DEVICE_TYPE(ESQPANEL2X40_VFX,  esqpanel2x40_vfx_device)
+DECLARE_DEVICE_TYPE(ESQPANEL2X40_SQ1,  esqpanel2x40_sq1_device)
+DECLARE_DEVICE_TYPE(ESQPANEL2X16_SQ1,  esqpanel2x16_sq1_device)
 
 #endif // MAME_ENSONIQ_ESQPANEL_H

--- a/src/mame/ensoniq/esqvfd.cpp
+++ b/src/mame/ensoniq/esqvfd.cpp
@@ -128,22 +128,31 @@ esqvfd_device::esqvfd_device(const machine_config &mconfig, device_type type, co
 	device_t(mconfig, type, tag, owner, clock),
 	m_rows(rows),
 	m_cols(cols),
-	m_chars(rows * cols),
-	m_attrs(rows * cols),
-	m_dirty(rows * cols)
+	m_blink_on(false),
+	m_cursx(0),
+	m_cursy(0),
+	m_savedx(0),
+	m_savedy(0),
+	m_curattr(0),
+	m_lastchar(0)
 {
 }
 
 void esqvfd_device::device_start()
 {
+	m_storage = std::make_unique_clear<uint8_t []>(m_rows * m_cols * 3);
+	m_chars = std::span(&m_storage[0], m_rows * m_cols);
+	m_attrs = std::span(&m_storage[m_rows * m_cols], m_rows * m_cols);
+	m_dirty = std::span(&m_storage[m_rows * m_cols * 2], m_rows * m_cols);
+
 	save_item(NAME(m_cursx));
 	save_item(NAME(m_cursy));
 	save_item(NAME(m_savedx));
 	save_item(NAME(m_savedy));
 	save_item(NAME(m_curattr));
-	save_item(NAME(m_chars));
-	save_item(NAME(m_attrs));
-	save_item(NAME(m_dirty));
+	save_pointer(&m_chars.data(), "m_chars", m_rows * m_cols);
+	save_pointer(&m_attrs.data(), "m_attrs", m_rows * m_cols);
+	save_pointer(&m_dirty.data(), "m_dirty", m_rows * m_cols);
 	save_item(NAME(m_lastchar));
 	save_item(NAME(m_blink_on));
 }

--- a/src/mame/ensoniq/esqvfd.cpp
+++ b/src/mame/ensoniq/esqvfd.cpp
@@ -459,7 +459,7 @@ void esq2x40_vfx_device::update_display()
 						segments = char_segments;
 				}
 
-				m_vfds[(row * m_cols) + col] = segments;
+				set_vfd(row, col, segments);
 
 				dirty(row, col) = 0;
 			}

--- a/src/mame/ensoniq/esqvfd.cpp
+++ b/src/mame/ensoniq/esqvfd.cpp
@@ -18,10 +18,10 @@
 
 #include "logmacro.h"
 
-DEFINE_DEVICE_TYPE(ESQ1X22,     esq1x22_device,     "esq1x22",     "Ensoniq 1x22 VFD")
-DEFINE_DEVICE_TYPE(ESQ2X40,     esq2x40_device,     "esq2x40",     "Ensoniq 2x40 VFD")
-DEFINE_DEVICE_TYPE(ESQ2X40_SQ1, esq2x40_sq1_device, "esq2x40_sq1", "Ensoniq 2x40 VFD (SQ-1 variant)")
-DEFINE_DEVICE_TYPE(ESQ2X40_VFX, esq2x40_vfx_device, "esq2x40_vfx", "Ensoniq 2x40 VFD (VFX Family variant)")
+DEFINE_DEVICE_TYPE(ESQ1X22,      esq1x22_device,      "esq1x22",      "Ensoniq 1x22 VFD")
+DEFINE_DEVICE_TYPE(ESQ2X40_ESQ1, esq2x40_esq1_device, "esq2x40_esq1", "Ensoniq 2x40 VFD")
+DEFINE_DEVICE_TYPE(ESQ2X40_SQ1,  esq2x40_sq1_device,  "esq2x40_sq1",  "Ensoniq 2x40 VFD (SQ-1 variant)")
+DEFINE_DEVICE_TYPE(ESQ2X40_VFX,  esq2x40_vfx_device,  "esq2x40_vfx",  "Ensoniq 2x40 VFD (VFX Family variant)")
 
 // adapted from bfm_bd1, rearranged to work with ASCII data used by the Ensoniq h/w
 static const uint16_t font[] = {
@@ -126,9 +126,11 @@ static const uint16_t font[] = {
 
 esqvfd_device::esqvfd_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, int rows, int cols) :
 	device_t(mconfig, type, tag, owner, clock),
-	m_vfds(*this, "vfd%u", 0U),
 	m_rows(rows),
-	m_cols(cols)
+	m_cols(cols),
+	m_chars(rows * cols),
+	m_attrs(rows * cols),
+	m_dirty(rows * cols)
 {
 }
 
@@ -148,14 +150,10 @@ void esqvfd_device::device_start()
 
 void esqvfd_device::device_reset()
 {
-	m_cursx = m_cursy = 0;
+	clear_display();
 	m_savedx = m_savedy = 0;
-	m_curattr = AT_NORMAL;
 	m_lastchar = 0;
 	m_blink_on = false;
-	memset(m_chars, 0, sizeof(m_chars));
-	memset(m_attrs, 0, sizeof(m_attrs));
-	memset(m_dirty, 1, sizeof(m_attrs));
 }
 
 // generic display update; can override from child classes if not good enough
@@ -163,16 +161,16 @@ void esqvfd_device::update_display()
 {
 	for (int row = 0; row < m_rows; row++) {
 		for (int col = 0; col < m_cols; col++) {
-			if (m_dirty[row][col]) {
-				uint32_t segdata = conv_segments(font[m_chars[row][col]]);
+			if (dirty(row, col)) {
+				uint32_t segdata = conv_segments(font[chars(row, col)]);
 
 				// digits:
-				m_vfds[(row * m_cols) + col] = segdata;
+				set_vfd(row, col, segdata);
 
 				// underlines:
-				m_vfds[(row * m_cols) + col + (m_rows * m_cols)] = (m_attrs[row][col] & AT_UNDERLINE) ? 1 : 0;
+				set_vfd(row + m_rows, col, (attrs(row, col) & AT_UNDERLINE) ? 1 : 0);
 
-				m_dirty[row][col] = 0;
+				dirty(row, col) = 0;
 			}
 		}
 	}
@@ -206,22 +204,25 @@ void esqvfd_device::set_blink_on(bool blink_on)
 
 	for (int row = 0; row < m_rows; row++) {
 		for (int col = 0; col < m_cols; col++) {
-			m_dirty[row][col] |= m_attrs[row][col] & AT_BLINK;
+			dirty(row, col) |= attrs(row, col) & AT_BLINK;
 		}
 	}
 	update_display();
 }
 
-void esqvfd_device::clear()
+void esqvfd_device::clear_display()
 {
 	m_cursx = m_cursy = m_curattr = 0;
-	memset(m_chars, 0, sizeof(m_chars));
-	memset(m_attrs, 0, sizeof(m_attrs));
-	memset(m_dirty, 1, sizeof(m_dirty));
-
-	update_display();
+	std::fill(m_chars.begin(), m_chars.end(), 0);
+	std::fill(m_attrs.begin(), m_attrs.end(), 0);
+	std::fill(m_dirty.begin(), m_dirty.end(), 1);
 }
 
+void esqvfd_device::clear()
+{
+	clear_display();
+	update_display();
+}
 
 /* 2x40 VFD display used in the ESQ-1, VFX-SD, SD-1, and others */
 
@@ -238,11 +239,11 @@ void esq2x40_device::write_char(uint8_t data)
 		for (uint8_t j = 0; j < m_rows; j++) {
 			for (uint8_t i = 0; i < m_cols; i++) {
 				if (m_cursy == j && i >= m_cursx && i < m_cursx + data)
-					m_attrs[j][i] |= AT_UNDERLINE;
+					attrs(j, i) |= AT_UNDERLINE;
 				else
-					m_attrs[j][i] &= ~AT_UNDERLINE;
+					attrs(j, i) &= ~AT_UNDERLINE;
 
-				m_dirty[j][i] = 1;
+				dirty(j, i) = 1;
 			}
 		}
 
@@ -302,14 +303,14 @@ void esq2x40_device::write_char(uint8_t data)
 				break;
 
 			case 0xd9:  // underline current character
-				m_attrs[m_cursy][m_cursx] |= AT_UNDERLINE;
-				m_dirty[m_cursy][m_cursx] = 1;
+				attrs(m_cursy, m_cursx) |= AT_UNDERLINE;
+				dirty(m_cursy, m_cursx) = 1;
 				LOGDC("set underline at (%d,%d)\n", m_cursy, m_cursx);
 				break;
 
 			case 0xdb:  // de-underline current character
-				m_attrs[m_cursy][m_cursx] &= ~AT_UNDERLINE;
-				m_dirty[m_cursy][m_cursx] = 1;
+				attrs(m_cursy, m_cursx) &= ~AT_UNDERLINE;
+				dirty(m_cursy, m_cursx) = 1;
 				LOGDC("clear underline at (%d,%d)\n", m_cursy, m_cursx);
 				break;
 
@@ -328,7 +329,7 @@ void esq2x40_device::write_char(uint8_t data)
 			case 0xf6:  // restore cursor position
 				m_cursx = m_savedx;
 				m_cursy = m_savedy;
-				m_curattr = m_attrs[m_cursy][m_cursx];
+				m_curattr = attrs(m_cursy, m_cursx);
 				LOGDC("restore cursor position (%d,%d) attr %x\n", m_cursy, m_cursx, m_curattr);
 				break;
 
@@ -346,9 +347,9 @@ void esq2x40_device::write_char(uint8_t data)
 				break;
 		}
 	} else if ((data >= 0x20) && (data <= 0x5f)) {
-		m_chars[m_cursy][m_cursx] = data - ' ';
-		m_attrs[m_cursy][m_cursx] = m_curattr;
-		m_dirty[m_cursy][m_cursx] = 1;
+		chars(m_cursy, m_cursx) = data - ' ';
+		attrs(m_cursy, m_cursx) = m_curattr;
+		dirty(m_cursy, m_cursx) = 1;
 
 		cursor_right();
 		LOGDC("char '%c', cursor now (%d,%d)\n", data, m_cursy, m_cursx);
@@ -363,26 +364,26 @@ bool esq2x40_device::write_contents(std::ostream &o)
 {
 	o.put((char) 0xd6); // clear screen
 
-	uint8_t attrs = 0;
+	uint8_t attr = 0;
 	for (int row = 0; row < 2; row++) {
 		o.put((char) (0x80 + (40 * row))); // move to first column this row
 
 		for (int col = 0; col < 40; col++) {
-			if (m_attrs[row][col] != attrs) {
-				attrs = m_attrs[row][col];
+			if (attrs(row, col) != attr) {
+				attr = attrs(row, col);
 
 				o.put((char) 0xd1); // all attributes off
 
-				if (attrs & AT_BLINK) {
+				if (attr & AT_BLINK) {
 					o.put((char) 0xd0); // blink on
 				}
 
-				if (attrs & AT_UNDERLINE) {
+				if (attr & AT_UNDERLINE) {
 					o.put((char) 0xd3); // underline
 				}
 			}
 
-			o.put((char) (m_chars[row][col] + ' '));
+			o.put((char) (chars(row, col) + ' '));
 		}
 	}
 
@@ -403,8 +404,9 @@ esq2x40_device::esq2x40_device(const machine_config &mconfig, device_type type, 
 {
 }
 
-esq2x40_device::esq2x40_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	esq2x40_device(mconfig, ESQ2X40, tag, owner, clock)
+esq2x40_esq1_device::esq2x40_esq1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	esq2x40_device(mconfig, ESQ2X40_ESQ1, tag, owner, clock),
+	m_vfds(*this, "vfd%u", 0U)
 {
 }
 
@@ -420,7 +422,8 @@ const tiny_rom_entry *esq2x40_vfx_device::device_rom_region() const
 
 esq2x40_vfx_device::esq2x40_vfx_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	esq2x40_device(mconfig, ESQ2X40_VFX, tag, owner, clock),
-	m_font(*this, "font")
+	m_font(*this, "font"),
+	m_vfds(*this, "vfd%u", 0U)
 {
 }
 
@@ -436,11 +439,11 @@ void esq2x40_vfx_device::update_display()
 {
 	for (int row = 0; row < m_rows; row++) {
 		for (int col = 0; col < m_cols; col++) {
-			if (m_dirty[row][col]) {
-				uint8_t c = m_chars[row][col];
+			if (dirty(row, col)) {
+				uint8_t c = chars(row, col);
 
 				uint16_t char_segments = m_font[c < 96 ? c : 0];
-				auto attr = m_attrs[row][col];
+				auto attr = attrs(row, col);
 				uint16_t segments;
 
 				if ((attr & AT_BLINK) && !m_blink_on) {
@@ -458,14 +461,14 @@ void esq2x40_vfx_device::update_display()
 
 				m_vfds[(row * m_cols) + col] = segments;
 
-				m_dirty[row][col] = 0;
+				dirty(row, col) = 0;
 			}
 		}
 	}
 }
 
 
-/* 1x22 display from the VFX (not right, but it'll do for now) */
+/* 1x22 display for the EPS family (not right, but it'll do for now) */
 
 void esq1x22_device::device_add_mconfig(machine_config &config)
 {
@@ -478,10 +481,6 @@ void esq1x22_device::write_char(uint8_t data)
 	if (data >= 0x60) {
 		switch (data) {
 			case 'f':   // clear screen
-				m_cursx = m_cursy = 0;
-				memset(m_chars, 0, sizeof(m_chars));
-				memset(m_attrs, 0, sizeof(m_attrs));
-				memset(m_dirty, 1, sizeof(m_dirty));
 				break;
 
 			default:
@@ -490,8 +489,8 @@ void esq1x22_device::write_char(uint8_t data)
 		}
 	} else {
 		if ((data >= 0x20) && (data <= 0x5f)) {
-			m_chars[0][m_cursx] = data - ' ';
-			m_dirty[0][m_cursx] = 1;
+			chars(0, m_cursx) = data - ' ';
+			dirty(0, m_cursx) = 1;
 			m_cursx++;
 
 			if (m_cursx >= 23) {
@@ -504,7 +503,8 @@ void esq1x22_device::write_char(uint8_t data)
 }
 
 esq1x22_device::esq1x22_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	esqvfd_device(mconfig, ESQ1X22, tag, owner, clock, 1, 22)
+	esqvfd_device(mconfig, ESQ1X22, tag, owner, clock, 1, 22),
+	m_vfds(*this, "vfd%u", 0U)
 {
 }
 
@@ -528,9 +528,9 @@ void esq2x40_sq1_device::write_char(uint8_t data)
 	} else if (m_wait88shift) {
 		m_wait88shift = false;
 	} else if ((data >= 0x20) && (data <= 0x7f)) {
-		m_chars[m_cursy][m_cursx] = data - ' ';
-		m_attrs[m_cursy][m_cursx] = m_curattr;
-		m_dirty[m_cursy][m_cursx] = 1;
+		chars(m_cursy, m_cursx) = data - ' ';
+		attrs(m_cursy, m_cursx) = m_curattr;
+		dirty(m_cursy, m_cursx) = 1;
 		m_cursx++;
 
 		if (m_cursx >= 39) {
@@ -539,10 +539,7 @@ void esq2x40_sq1_device::write_char(uint8_t data)
 
 		update_display();
 	} else if (data == 0x83) {
-		m_cursx = m_cursy = 0;
-		memset(m_chars, 0, sizeof(m_chars));
-		memset(m_attrs, 0, sizeof(m_attrs));
-		memset(m_dirty, 1, sizeof(m_dirty));
+		clear_display();
 	} else if (data == 0x87) {
 		m_wait87shift = true;
 	} else if (data == 0x88) {
@@ -553,7 +550,8 @@ void esq2x40_sq1_device::write_char(uint8_t data)
 }
 
 esq2x40_sq1_device::esq2x40_sq1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	esqvfd_device(mconfig, ESQ2X40_SQ1, tag, owner, clock, 2, 40)
+	esqvfd_device(mconfig, ESQ2X40_SQ1, tag, owner, clock, 2, 40),
+	m_vfds(*this, "vfd%u", 0U)
 {
 	m_wait87shift = false;
 	m_wait88shift = false;

--- a/src/mame/ensoniq/esqvfd.cpp
+++ b/src/mame/ensoniq/esqvfd.cpp
@@ -124,11 +124,11 @@ static const uint16_t font[] = {
 	0x0000, // 0000 0000 0000 0000 (DEL)
 };
 
-esqvfd_device::esqvfd_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, dimensions_param &&dimensions) :
+esqvfd_device::esqvfd_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, int rows, int cols) :
 	device_t(mconfig, type, tag, owner, clock),
-	m_vfds(std::move(std::get<0>(dimensions))),
-	m_rows(std::get<1>(dimensions)),
-	m_cols(std::get<2>(dimensions))
+	m_vfds(*this, "vfd%u", 0U),
+	m_rows(rows),
+	m_cols(cols)
 {
 }
 
@@ -167,10 +167,10 @@ void esqvfd_device::update_display()
 				uint32_t segdata = conv_segments(font[m_chars[row][col]]);
 
 				// digits:
-				m_vfds->set((row * m_cols) + col, segdata);
+				m_vfds[(row * m_cols) + col] = segdata;
 
 				// underlines:
-				m_vfds->set((row * m_cols) + col + (m_rows * m_cols), (m_attrs[row][col] & AT_UNDERLINE) ? 1 : 0);
+				m_vfds[(row * m_cols) + col + (m_rows * m_cols)] = (m_attrs[row][col] & AT_UNDERLINE) ? 1 : 0;
 
 				m_dirty[row][col] = 0;
 			}
@@ -399,7 +399,7 @@ bool esq2x40_device::write_contents(std::ostream &o)
 
 
 esq2x40_device::esq2x40_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
-	esqvfd_device(mconfig, type, tag, owner, clock, make_dimensions<2, 40>(*this))
+	esqvfd_device(mconfig, type, tag, owner, clock, 2, 40)
 {
 }
 
@@ -456,7 +456,7 @@ void esq2x40_vfx_device::update_display()
 						segments = char_segments;
 				}
 
-				m_vfds->set((row * m_cols) + col, segments);
+				m_vfds[(row * m_cols) + col] = segments;
 
 				m_dirty[row][col] = 0;
 			}
@@ -504,7 +504,7 @@ void esq1x22_device::write_char(uint8_t data)
 }
 
 esq1x22_device::esq1x22_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	esqvfd_device(mconfig, ESQ1X22, tag, owner, clock, make_dimensions<1, 22>(*this))
+	esqvfd_device(mconfig, ESQ1X22, tag, owner, clock, 1, 22)
 {
 }
 
@@ -553,7 +553,7 @@ void esq2x40_sq1_device::write_char(uint8_t data)
 }
 
 esq2x40_sq1_device::esq2x40_sq1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	esqvfd_device(mconfig, ESQ2X40_SQ1, tag, owner, clock, make_dimensions<2, 40>(*this))
+	esqvfd_device(mconfig, ESQ2X40_SQ1, tag, owner, clock, 2, 40)
 {
 	m_wait87shift = false;
 	m_wait88shift = false;

--- a/src/mame/ensoniq/esqvfd.h
+++ b/src/mame/ensoniq/esqvfd.h
@@ -4,10 +4,12 @@
 #define MAME_ENSONIQ_ESQVFD_H
 
 #include <memory>
+#include <span>
 #include <tuple>
 
 
-class esqvfd_device : public device_t {
+class esqvfd_device : public device_t
+{
 public:
 	void write(uint8_t data) { write_char(data); }
 
@@ -35,25 +37,27 @@ protected:
 	uint8_t &attrs(unsigned row, unsigned col) { return m_attrs[index_for(row, col)]; }
 	uint8_t &dirty(unsigned row, unsigned col) { return m_dirty[index_for(row, col)]; }
 
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
 	static constexpr uint8_t AT_NORMAL      = 0x00;
 	static constexpr uint8_t AT_UNDERLINE   = 0x01;
 	static constexpr uint8_t AT_BLINK       = 0x02;
 
-	virtual void device_start() override ATTR_COLD;
-	virtual void device_reset() override ATTR_COLD;
-
-	int m_rows = 0, m_cols = 0;
-	bool m_blink_on = false;
-	int m_cursx = 0, m_cursy = 0;
-	int m_savedx = 0, m_savedy = 0;
-	uint8_t m_curattr = 0;
-	uint8_t m_lastchar = 0;
-	std::vector<uint8_t> m_chars;
-	std::vector<uint8_t> m_attrs;
-	std::vector<uint8_t> m_dirty;
+	int const m_rows, m_cols;
+	std::unique_ptr<uint8_t []> m_storage;
+	std::span<uint8_t> m_chars;
+	std::span<uint8_t> m_attrs;
+	std::span<uint8_t> m_dirty;
+	bool m_blink_on;
+	int16_t m_cursx, m_cursy;
+	int16_t m_savedx, m_savedy;
+	uint8_t m_curattr;
+	uint8_t m_lastchar;
 };
 
-class esq1x22_device : public esqvfd_device {
+class esq1x22_device : public esqvfd_device
+{
 public:
 	esq1x22_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
@@ -70,7 +74,8 @@ private:
 
 // Virtual superclass for ESQ1- and VFX-family 2x40 displays,
 // allowing common code to be shared.
-class esq2x40_device : public esqvfd_device {
+class esq2x40_device : public esqvfd_device
+{
 public:
 	esq2x40_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
@@ -81,7 +86,8 @@ protected:
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 };
 
-class esq2x40_esq1_device : public esq2x40_device {
+class esq2x40_esq1_device : public esq2x40_device
+{
 public:
 	esq2x40_esq1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
@@ -92,7 +98,8 @@ private:
 	output_finder<2 * 40 * 2> m_vfds;
 };
 
-class esq2x40_vfx_device : public esq2x40_device {
+class esq2x40_vfx_device : public esq2x40_device
+{
 public:
 	esq2x40_vfx_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 	virtual void update_display() override;
@@ -102,7 +109,7 @@ protected:
 
 	// device-level overrides
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
-	const tiny_rom_entry *device_rom_region() const override;
+	const tiny_rom_entry *device_rom_region() const override ATTR_COLD;
 
 private:
 	required_region_ptr<u16> m_font;

--- a/src/mame/ensoniq/esqvfd.h
+++ b/src/mame/ensoniq/esqvfd.h
@@ -14,6 +14,7 @@ public:
 	virtual void write_char(uint8_t data) = 0;
 	virtual void update_display();
 	virtual bool write_contents(std::ostream &o) { return false; }
+	virtual void clear_display();
 	virtual void clear();
 	virtual void cursor_left();
 	virtual void cursor_right();
@@ -25,6 +26,15 @@ public:
 protected:
 	esqvfd_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, int rows, int cols);
 
+	virtual void set_vfd(unsigned index, uint32_t value) = 0;
+
+	int index_for(unsigned row, unsigned col) { return row * m_cols + col; }
+
+	void set_vfd(unsigned row, unsigned col, uint32_t value) { set_vfd(index_for(row, col), value); }
+	uint8_t &chars(unsigned row, unsigned col) { return m_chars[index_for(row, col)]; }
+	uint8_t &attrs(unsigned row, unsigned col) { return m_attrs[index_for(row, col)]; }
+	uint8_t &dirty(unsigned row, unsigned col) { return m_dirty[index_for(row, col)]; }
+
 	static constexpr uint8_t AT_NORMAL      = 0x00;
 	static constexpr uint8_t AT_UNDERLINE   = 0x01;
 	static constexpr uint8_t AT_BLINK       = 0x02;
@@ -32,16 +42,15 @@ protected:
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 
-	output_finder<160> m_vfds;
+	int m_rows = 0, m_cols = 0;
 	bool m_blink_on = false;
 	int m_cursx = 0, m_cursy = 0;
 	int m_savedx = 0, m_savedy = 0;
-	int const m_rows = 0, m_cols = 0;
 	uint8_t m_curattr = 0;
 	uint8_t m_lastchar = 0;
-	uint8_t m_chars[2][40]{};
-	uint8_t m_attrs[2][40]{};
-	uint8_t m_dirty[2][40]{};
+	std::vector<uint8_t> m_chars;
+	std::vector<uint8_t> m_attrs;
+	std::vector<uint8_t> m_dirty;
 };
 
 class esq1x22_device : public esqvfd_device {
@@ -51,15 +60,19 @@ public:
 	virtual void write_char(uint8_t data) override;
 
 protected:
+	virtual void set_vfd(unsigned index, uint32_t value) override { m_vfds[index] = value; }
+
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 
 private:
+	output_finder<1 * 22 * 2> m_vfds;
 };
 
+// Virtual superclass for ESQ1- and VFX-family 2x40 displays,
+// allowing common code to be shared.
 class esq2x40_device : public esqvfd_device {
 public:
 	esq2x40_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
-	esq2x40_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	virtual void write_char(uint8_t data) override;
 	virtual bool write_contents(std::ostream &o) override;
@@ -68,18 +81,32 @@ protected:
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 };
 
+class esq2x40_esq1_device : public esq2x40_device {
+public:
+	esq2x40_esq1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	virtual void set_vfd(unsigned index, uint32_t value) override { m_vfds[index] = value; }
+
+private:
+	output_finder<2 * 40 * 2> m_vfds;
+};
+
 class esq2x40_vfx_device : public esq2x40_device {
 public:
 	esq2x40_vfx_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 	virtual void update_display() override;
 
 protected:
+	virtual void set_vfd(unsigned index, uint32_t value) override { m_vfds[index] = value; }
+
 	// device-level overrides
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 	const tiny_rom_entry *device_rom_region() const override;
 
 private:
 	required_region_ptr<u16> m_font;
+	output_finder<2 * 40> m_vfds;
 };
 
 class esq2x40_sq1_device : public esqvfd_device {
@@ -89,15 +116,18 @@ public:
 	virtual void write_char(uint8_t data) override;
 
 protected:
+	virtual void set_vfd(unsigned index, uint32_t value) override { m_vfds[index] = value; }
+
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 
 private:
+	output_finder<2 * 40 * 2> m_vfds;
 	bool m_wait87shift, m_wait88shift;
 };
 
-DECLARE_DEVICE_TYPE(ESQ1X22,     esq1x22_device)
-DECLARE_DEVICE_TYPE(ESQ2X40,     esq2x40_device)
-DECLARE_DEVICE_TYPE(ESQ2X40_SQ1, esq2x40_sq1_device)
-DECLARE_DEVICE_TYPE(ESQ2X40_VFX, esq2x40_vfx_device)
+DECLARE_DEVICE_TYPE(ESQ1X22,      esq1x22_device)
+DECLARE_DEVICE_TYPE(ESQ2X40_ESQ1, esq2x40_esq1_device)
+DECLARE_DEVICE_TYPE(ESQ2X40_SQ1,  esq2x40_sq1_device)
+DECLARE_DEVICE_TYPE(ESQ2X40_VFX,  esq2x40_vfx_device)
 
 #endif // MAME_ENSONIQ_ESQVFD_H

--- a/src/mame/ensoniq/esqvfd.h
+++ b/src/mame/ensoniq/esqvfd.h
@@ -23,24 +23,7 @@ public:
 	static uint32_t conv_segments(uint16_t segin) { return bitswap<15>(segin, 12, 11, 7, 6, 4, 10, 3, 14, 15, 0, 13, 9, 5, 1, 2); }
 
 protected:
-	class output_helper {
-	public:
-		typedef std::unique_ptr<output_helper> ptr;
-		virtual ~output_helper() { }
-		virtual int32_t set(unsigned n, int32_t value) = 0;
-	};
-
-	template <unsigned N> class output_helper_impl : public output_helper, protected output_manager::output_finder<void, N> {
-	public:
-		output_helper_impl(device_t &device) : output_manager::output_finder<void, N>(device, "vfd%u", 0U) { }
-		virtual int32_t set(unsigned n, int32_t value) override { return this->operator[](n) = value; }
-	};
-
-	typedef std::tuple<output_helper::ptr, int, int> dimensions_param;
-
-	template <int R, int C> static dimensions_param make_dimensions(device_t &device) { return dimensions_param(std::make_unique<output_helper_impl<2 * R * C> >(device), R, C); }
-
-	esqvfd_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, dimensions_param &&dimensions);
+	esqvfd_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, int rows, int cols);
 
 	static constexpr uint8_t AT_NORMAL      = 0x00;
 	static constexpr uint8_t AT_UNDERLINE   = 0x01;
@@ -49,7 +32,7 @@ protected:
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 
-	output_helper::ptr m_vfds;
+	output_finder<160> m_vfds;
 	bool m_blink_on = false;
 	int m_cursx = 0, m_cursy = 0;
 	int m_savedx = 0, m_savedy = 0;
@@ -89,8 +72,6 @@ class esq2x40_vfx_device : public esq2x40_device {
 public:
 	esq2x40_vfx_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 	virtual void update_display() override;
-
-	template <int R, int C> static dimensions_param make_dimensions(device_t &device) { return dimensions_param(std::make_unique<output_helper_impl<R * C> >(device), R, C); }
 
 protected:
 	// device-level overrides

--- a/src/mame/ensoniq/esqvfd.h
+++ b/src/mame/ensoniq/esqvfd.h
@@ -26,11 +26,11 @@ public:
 protected:
 	esqvfd_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, int rows, int cols);
 
-	virtual void set_vfd(unsigned index, uint32_t value) = 0;
+	virtual void set_vfd_at_index(unsigned index, uint32_t value) = 0;
 
 	int index_for(unsigned row, unsigned col) { return row * m_cols + col; }
 
-	void set_vfd(unsigned row, unsigned col, uint32_t value) { set_vfd(index_for(row, col), value); }
+	void set_vfd(unsigned row, unsigned col, uint32_t value) { set_vfd_at_index(index_for(row, col), value); }
 	uint8_t &chars(unsigned row, unsigned col) { return m_chars[index_for(row, col)]; }
 	uint8_t &attrs(unsigned row, unsigned col) { return m_attrs[index_for(row, col)]; }
 	uint8_t &dirty(unsigned row, unsigned col) { return m_dirty[index_for(row, col)]; }
@@ -60,7 +60,7 @@ public:
 	virtual void write_char(uint8_t data) override;
 
 protected:
-	virtual void set_vfd(unsigned index, uint32_t value) override { m_vfds[index] = value; }
+	virtual void set_vfd_at_index(unsigned index, uint32_t value) override { m_vfds[index] = value; }
 
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 
@@ -86,7 +86,7 @@ public:
 	esq2x40_esq1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	virtual void set_vfd(unsigned index, uint32_t value) override { m_vfds[index] = value; }
+	virtual void set_vfd_at_index(unsigned index, uint32_t value) override { m_vfds[index] = value; }
 
 private:
 	output_finder<2 * 40 * 2> m_vfds;
@@ -98,7 +98,7 @@ public:
 	virtual void update_display() override;
 
 protected:
-	virtual void set_vfd(unsigned index, uint32_t value) override { m_vfds[index] = value; }
+	virtual void set_vfd_at_index(unsigned index, uint32_t value) override { m_vfds[index] = value; }
 
 	// device-level overrides
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
@@ -116,7 +116,7 @@ public:
 	virtual void write_char(uint8_t data) override;
 
 protected:
-	virtual void set_vfd(unsigned index, uint32_t value) override { m_vfds[index] = value; }
+	virtual void set_vfd_at_index(unsigned index, uint32_t value) override { m_vfds[index] = value; }
 
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 

--- a/src/mame/layout/esq2by40_vfx.lay
+++ b/src/mame/layout/esq2by40_vfx.lay
@@ -51,7 +51,7 @@ license:CC0-1.0
 			<param name="n" start="~s~" increment="1" />
 			<param name="x" start="0" increment="342" />
 
-			<param name="input" value="vfd~n~" />
+			<param name="input" value="vfd:vfd~n~" />
 			<group ref="vfd_cell">
 				<bounds x="~x~" y="~y~" width="342" height="572" />
 			</group>

--- a/src/mame/layout/sd1.lay
+++ b/src/mame/layout/sd1.lay
@@ -287,7 +287,7 @@
 				<param name="n" start="~s~" increment="1" />
 				<param name="x" start="0" increment="342" />
 
-				<param name="input" value="vfd~n~" />
+				<param name="input" value="vfd:vfd~n~" />
 				<group ref="vfd_cell">
 					<bounds x="~x~" y="~y~" width="342" height="572" />
 				</group>

--- a/src/mame/layout/sd1.lay
+++ b/src/mame/layout/sd1.lay
@@ -2577,6 +2577,15 @@
 			<bounds x="20" y="15" width="20" height="60" />
 		</group>
 	</group>
+	<group name="DisplayOnly">
+		<bounds x="11" y="30.75936" width="223" height="20.48129" />
+		<element ref="rect_glass">
+			<bounds x="11" y="30.75936" width="223" height="20.48129" />
+		</element>
+		<group ref="vfd">
+			<bounds x="12" y="32.50936" width="221" height="18.48129" />
+		</group>
+	</group>
 
 	<view name="Full">
 		<element ref="rect_black">
@@ -2739,6 +2748,11 @@
 			<bounds x="42.5" y="86.36667" width="190" height="12.66667" />
 		</element>
 	</view>
+	<view name="Display">
+		<group ref="DisplayOnly">
+			<bounds x="11" y="30.75936" width="223" height="20.48129" />
+		</group>
+	</view>
 	<script>
 		<![CDATA[
 			-- Keep track of the pointer managers
@@ -2749,13 +2763,14 @@
 			file:set_resolve_tags_callback(
 				function ()
 					for view_name, view in pairs(file.views) do
-						-- Hide the warning about requiring the Layout plugin.
-						view.items["plugin_warning"]:set_state(0)
-
-						local manager = PointerManager:create(view)
-						pointer_managers[view_name] = manager
 
 						if view.unqualified_name == "Full" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 							media_change_notifiers[":cart"] = add_media_change_notifier(view, "media_cartridge", ":cart")
@@ -2766,6 +2781,12 @@
 						end
 
 						if view.unqualified_name == "Compact" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "analog_pitch_bend", true, true))
@@ -2774,11 +2795,23 @@
 						end
 
 						if view.unqualified_name == "Panel" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 						end
 
 						if view.unqualified_name == "Tablet" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 						end
@@ -3108,12 +3141,17 @@
 				local full_width = octaves_width + w_white
 
 				local function find_12_key(x, y, w, h)
-					if x > octaves_width then
+					if x < 0 or full_width < x then
+						return nil
+					end
+
+					if octaves_width <= x then
 						return 12 * n_octaves
 					end
 
 					local octave, kx = math.modf((x / w) * (full_width / octave_shift))
 					if octave == n_octaves then
+						-- this should already have been taken care of by the above
 						return 12 * octave
 					end
 
@@ -3167,6 +3205,9 @@
 			KeyboardHandler = {}
 
 			function KeyboardHandler:create(view, clickarea_id, key_id_prefix, port_prefix, from_octave, n_octaves)
+				local from_key = 12 * from_octave
+				local n_keys = 12 * n_octaves + 1
+
 				local instance = {
 					view = view,
 					clickarea = view.items[clickarea_id],
@@ -3190,10 +3231,7 @@
 					return nil
 				end
 
-				local from_key = 12 * from_octave
-				local n_keys = 12 * n_octaves + 1
-
-				for i = 0, n_keys -1 do
+				for i = 0, n_keys - 1 do
 					local key_info = k12[(i % 12) + 1]
 					local key = {
 						id = key_id_prefix .. i,
@@ -3217,7 +3255,7 @@
 
 					function key:updateViewItemState()
 						if self.pressure > 0 then
-							self.item:set_state(127 + key.pressure)
+							self.item:set_state(127 + self.pressure)
 						elseif self.velocity > 0 then
 							self.item:set_state(self.velocity)
 						else

--- a/src/mame/layout/sd132.lay
+++ b/src/mame/layout/sd132.lay
@@ -2580,6 +2580,15 @@
 			<bounds x="20" y="15" width="20" height="60" />
 		</group>
 	</group>
+	<group name="DisplayOnly">
+		<bounds x="11" y="30.75936" width="223" height="20.48129" />
+		<element ref="rect_glass">
+			<bounds x="11" y="30.75936" width="223" height="20.48129" />
+		</element>
+		<group ref="vfd">
+			<bounds x="12" y="32.50936" width="221" height="18.48129" />
+		</group>
+	</group>
 
 	<view name="Full">
 		<element ref="rect_black">
@@ -2749,6 +2758,11 @@
 			<bounds x="42.5" y="86.36667" width="190" height="12.66667" />
 		</element>
 	</view>
+	<view name="Display">
+		<group ref="DisplayOnly">
+			<bounds x="11" y="30.75936" width="223" height="20.48129" />
+		</group>
+	</view>
 	<script>
 		<![CDATA[
 			-- Keep track of the pointer managers
@@ -2759,13 +2773,14 @@
 			file:set_resolve_tags_callback(
 				function ()
 					for view_name, view in pairs(file.views) do
-						-- Hide the warning about requiring the Layout plugin.
-						view.items["plugin_warning"]:set_state(0)
-
-						local manager = PointerManager:create(view)
-						pointer_managers[view_name] = manager
 
 						if view.unqualified_name == "Full" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 							media_change_notifiers[":cart"] = add_media_change_notifier(view, "media_cartridge", ":cart")
@@ -2776,6 +2791,12 @@
 						end
 
 						if view.unqualified_name == "Compact" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "analog_pitch_bend", true, true))
@@ -2784,11 +2805,23 @@
 						end
 
 						if view.unqualified_name == "Panel" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 						end
 
 						if view.unqualified_name == "Tablet" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 						end
@@ -3118,12 +3151,17 @@
 				local full_width = octaves_width + w_white
 
 				local function find_12_key(x, y, w, h)
-					if x > octaves_width then
+					if x < 0 or full_width < x then
+						return nil
+					end
+
+					if octaves_width <= x then
 						return 12 * n_octaves
 					end
 
 					local octave, kx = math.modf((x / w) * (full_width / octave_shift))
 					if octave == n_octaves then
+						-- this should already have been taken care of by the above
 						return 12 * octave
 					end
 
@@ -3177,6 +3215,9 @@
 			KeyboardHandler = {}
 
 			function KeyboardHandler:create(view, clickarea_id, key_id_prefix, port_prefix, from_octave, n_octaves)
+				local from_key = 12 * from_octave
+				local n_keys = 12 * n_octaves + 1
+
 				local instance = {
 					view = view,
 					clickarea = view.items[clickarea_id],
@@ -3200,10 +3241,7 @@
 					return nil
 				end
 
-				local from_key = 12 * from_octave
-				local n_keys = 12 * n_octaves + 1
-
-				for i = 0, n_keys -1 do
+				for i = 0, n_keys - 1 do
 					local key_info = k12[(i % 12) + 1]
 					local key = {
 						id = key_id_prefix .. i,
@@ -3227,7 +3265,7 @@
 
 					function key:updateViewItemState()
 						if self.pressure > 0 then
-							self.item:set_state(127 + key.pressure)
+							self.item:set_state(127 + self.pressure)
 						elseif self.velocity > 0 then
 							self.item:set_state(self.velocity)
 						else

--- a/src/mame/layout/sd132.lay
+++ b/src/mame/layout/sd132.lay
@@ -287,7 +287,7 @@
 				<param name="n" start="~s~" increment="1" />
 				<param name="x" start="0" increment="342" />
 
-				<param name="input" value="vfd~n~" />
+				<param name="input" value="vfd:vfd~n~" />
 				<group ref="vfd_cell">
 					<bounds x="~x~" y="~y~" width="342" height="572" />
 				</group>

--- a/src/mame/layout/vfx.lay
+++ b/src/mame/layout/vfx.lay
@@ -235,7 +235,7 @@
 				<param name="n" start="~s~" increment="1" />
 				<param name="x" start="0" increment="342" />
 
-				<param name="input" value="vfd~n~" />
+				<param name="input" value="vfd:vfd~n~" />
 				<group ref="vfd_cell">
 					<bounds x="~x~" y="~y~" width="342" height="572" />
 				</group>

--- a/src/mame/layout/vfx.lay
+++ b/src/mame/layout/vfx.lay
@@ -2354,6 +2354,15 @@
 			<bounds x="20" y="15" width="20" height="60" />
 		</group>
 	</group>
+	<group name="DisplayOnly">
+		<bounds x="11" y="30.75936" width="223" height="20.48129" />
+		<element ref="rect_glass">
+			<bounds x="11" y="30.75936" width="223" height="20.48129" />
+		</element>
+		<group ref="vfd">
+			<bounds x="12" y="32.50936" width="221" height="18.48129" />
+		</group>
+	</group>
 
 	<view name="Full">
 		<element ref="rect_black">
@@ -2510,6 +2519,11 @@
 			<bounds x="42.5" y="86.36667" width="190" height="12.66667" />
 		</element>
 	</view>
+	<view name="Display">
+		<group ref="DisplayOnly">
+			<bounds x="11" y="30.75936" width="223" height="20.48129" />
+		</group>
+	</view>
 	<script>
 		<![CDATA[
 			-- Keep track of the pointer managers
@@ -2520,13 +2534,14 @@
 			file:set_resolve_tags_callback(
 				function ()
 					for view_name, view in pairs(file.views) do
-						-- Hide the warning about requiring the Layout plugin.
-						view.items["plugin_warning"]:set_state(0)
-
-						local manager = PointerManager:create(view)
-						pointer_managers[view_name] = manager
 
 						if view.unqualified_name == "Full" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 							media_change_notifiers[":cart"] = add_media_change_notifier(view, "media_cartridge", ":cart")
@@ -2536,6 +2551,12 @@
 						end
 
 						if view.unqualified_name == "Compact" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "analog_pitch_bend", true, true))
@@ -2544,11 +2565,23 @@
 						end
 
 						if view.unqualified_name == "Panel" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 						end
 
 						if view.unqualified_name == "Tablet" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 						end
@@ -2878,12 +2911,17 @@
 				local full_width = octaves_width + w_white
 
 				local function find_12_key(x, y, w, h)
-					if x > octaves_width then
+					if x < 0 or full_width < x then
+						return nil
+					end
+
+					if octaves_width <= x then
 						return 12 * n_octaves
 					end
 
 					local octave, kx = math.modf((x / w) * (full_width / octave_shift))
 					if octave == n_octaves then
+						-- this should already have been taken care of by the above
 						return 12 * octave
 					end
 
@@ -2937,6 +2975,9 @@
 			KeyboardHandler = {}
 
 			function KeyboardHandler:create(view, clickarea_id, key_id_prefix, port_prefix, from_octave, n_octaves)
+				local from_key = 12 * from_octave
+				local n_keys = 12 * n_octaves + 1
+
 				local instance = {
 					view = view,
 					clickarea = view.items[clickarea_id],
@@ -2960,10 +3001,7 @@
 					return nil
 				end
 
-				local from_key = 12 * from_octave
-				local n_keys = 12 * n_octaves + 1
-
-				for i = 0, n_keys -1 do
+				for i = 0, n_keys - 1 do
 					local key_info = k12[(i % 12) + 1]
 					local key = {
 						id = key_id_prefix .. i,
@@ -2987,7 +3025,7 @@
 
 					function key:updateViewItemState()
 						if self.pressure > 0 then
-							self.item:set_state(127 + key.pressure)
+							self.item:set_state(127 + self.pressure)
 						elseif self.velocity > 0 then
 							self.item:set_state(self.velocity)
 						else

--- a/src/mame/layout/vfxsd.lay
+++ b/src/mame/layout/vfxsd.lay
@@ -287,7 +287,7 @@
 				<param name="n" start="~s~" increment="1" />
 				<param name="x" start="0" increment="342" />
 
-				<param name="input" value="vfd~n~" />
+				<param name="input" value="vfd:vfd~n~" />
 				<group ref="vfd_cell">
 					<bounds x="~x~" y="~y~" width="342" height="572" />
 				</group>

--- a/src/mame/layout/vfxsd.lay
+++ b/src/mame/layout/vfxsd.lay
@@ -2577,6 +2577,15 @@
 			<bounds x="20" y="15" width="20" height="60" />
 		</group>
 	</group>
+	<group name="DisplayOnly">
+		<bounds x="11" y="30.75936" width="223" height="20.48129" />
+		<element ref="rect_glass">
+			<bounds x="11" y="30.75936" width="223" height="20.48129" />
+		</element>
+		<group ref="vfd">
+			<bounds x="12" y="32.50936" width="221" height="18.48129" />
+		</group>
+	</group>
 
 	<view name="Full">
 		<element ref="rect_black">
@@ -2739,6 +2748,11 @@
 			<bounds x="42.5" y="86.36667" width="190" height="12.66667" />
 		</element>
 	</view>
+	<view name="Display">
+		<group ref="DisplayOnly">
+			<bounds x="11" y="30.75936" width="223" height="20.48129" />
+		</group>
+	</view>
 	<script>
 		<![CDATA[
 			-- Keep track of the pointer managers
@@ -2749,13 +2763,14 @@
 			file:set_resolve_tags_callback(
 				function ()
 					for view_name, view in pairs(file.views) do
-						-- Hide the warning about requiring the Layout plugin.
-						view.items["plugin_warning"]:set_state(0)
-
-						local manager = PointerManager:create(view)
-						pointer_managers[view_name] = manager
 
 						if view.unqualified_name == "Full" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 							media_change_notifiers[":cart"] = add_media_change_notifier(view, "media_cartridge", ":cart")
@@ -2766,6 +2781,12 @@
 						end
 
 						if view.unqualified_name == "Compact" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "analog_pitch_bend", true, true))
@@ -2774,11 +2795,23 @@
 						end
 
 						if view.unqualified_name == "Panel" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 						end
 
 						if view.unqualified_name == "Tablet" then
+							-- Hide the warning about requiring the Layout plugin.
+							view.items["plugin_warning"]:set_state(0)
+
+							local manager = PointerManager:create(view)
+							pointer_managers[view_name] = manager
+
 							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
 							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
 						end
@@ -3108,12 +3141,17 @@
 				local full_width = octaves_width + w_white
 
 				local function find_12_key(x, y, w, h)
-					if x > octaves_width then
+					if x < 0 or full_width < x then
+						return nil
+					end
+
+					if octaves_width <= x then
 						return 12 * n_octaves
 					end
 
 					local octave, kx = math.modf((x / w) * (full_width / octave_shift))
 					if octave == n_octaves then
+						-- this should already have been taken care of by the above
 						return 12 * octave
 					end
 
@@ -3167,6 +3205,9 @@
 			KeyboardHandler = {}
 
 			function KeyboardHandler:create(view, clickarea_id, key_id_prefix, port_prefix, from_octave, n_octaves)
+				local from_key = 12 * from_octave
+				local n_keys = 12 * n_octaves + 1
+
 				local instance = {
 					view = view,
 					clickarea = view.items[clickarea_id],
@@ -3190,10 +3231,7 @@
 					return nil
 				end
 
-				local from_key = 12 * from_octave
-				local n_keys = 12 * n_octaves + 1
-
-				for i = 0, n_keys -1 do
+				for i = 0, n_keys - 1 do
 					local key_info = k12[(i % 12) + 1]
 					local key = {
 						id = key_id_prefix .. i,
@@ -3217,7 +3255,7 @@
 
 					function key:updateViewItemState()
 						if self.pressure > 0 then
-							self.item:set_state(127 + key.pressure)
+							self.item:set_state(127 + self.pressure)
 						elseif self.velocity > 0 then
 							self.item:set_state(self.velocity)
 						else


### PR DESCRIPTION
esqvfd,esqlcd: use fixed size output_finder for the VFD characters and segments.

Fixes https://github.com/mamedev/mame/issues/15449 .

Also decouple `esqlcd` from `esqvfd` devices; they are separate.
