### PR TITLE
apple2: improve Zip Chip emulation

### DIFF
--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -514,6 +514,7 @@ private:
 	int m_accel_stage;
 	u32 m_accel_speed;
 	u8 m_accel_slotspk, m_accel_gameio, m_laser_speed;
+	memory_passthrough_handler m_accel_tap;
 
 	emu_timer *m_strobe_timer;
 	u8  m_next_strobe;
@@ -555,8 +556,8 @@ private:
 	void raise_irq(int irq);
 	void lower_irq(int irq);
 	void update_iic_mouse();
-	void accel_full_speed();
-	void accel_normal_speed();
+	void accel_update_speed();
+	void accel_reset();
 	void accel_temp_delay(int ms, bool condition);
 	void accel_stop_delay();
 	void accel_slot(int slot);
@@ -1265,22 +1266,12 @@ void apple2e_state::machine_reset()
 	m_yirq = false;
 	m_mockingboard4c = false;
 	m_cec_bank = 0;
-	m_accel_unlocked = false;
-	m_accel_stage = 0;
-	m_accel_slotspk = 0xE4; // slots 7, 6, 5, 2 slow
-	m_accel_gameio = 0x40;  // paddle delay on
 	m_accel_present = false;
+	m_accel_unlocked = false;
 	m_accel_temp_slowdown = false;
-	m_accel_disable_delay = false;
 	m_accel_fast = false;
 	m_centronics_busy = false;
 	m_35sel = false;
-
-	// is Zip enabled?
-	if (m_sysconfig.read_safe(0) & 0x10)
-	{
-		m_accel_present = true;
-	}
 
 	// IIe prefers INTCXROM default to off, IIc has it always on
 	if (m_rom_ptr[0x3bc0] == 0x00)
@@ -1310,26 +1301,21 @@ void apple2e_state::machine_reset()
 		m_isiicplus = false;
 	}
 
-	u8 config = m_sysconfig.read_safe(0) & 0x30;
-
-	if (((config & 0x10) == 0x10) || (m_isiicplus))
+	// Zip configuration
+	if ((m_isiicplus) || (m_sysconfig.read_safe(0) & 0x10))
 	{
+		m_accel_present = true;
 		m_accel_speed = 4000000;    // Zip speed, set if present, even if not active initially
-
-		if (((config & 0x20) == 0x20) || (m_isiicplus))
-		{
-			accel_full_speed();
-			m_accel_fast = true;
-		}
+		accel_reset();
 	}
-
-	if (m_accel_laser)
+	else if (m_accel_laser)
 	{
 		m_accel_present = true;
 		m_accel_speed = 1021800;
 		m_accel_slotspk = 0x46; // slots 6, 2, 1 slow
 		if (m_slotdevice[5] != nullptr) m_accel_slotspk |= 0x20;
 		if (m_slotdevice[7] != nullptr) m_accel_slotspk |= 0x80;
+		m_accel_gameio = 0x00;
 	}
 
 	if (m_has_laser_mouse)
@@ -1469,6 +1455,8 @@ void apple2e_state::reset_w(int state)
 		{
 			m_reset_latch = true;
 			m_maincpu->set_input_line(INPUT_LINE_RESET, ASSERT_LINE);
+			if (m_accel_present)
+				accel_reset();
 
 			// All MMU switches off (80STORE, RAMRD, RAMWRT, INTCXROM, ALTZP, SLOTC3ROM, PAGE2, HIRES, INTC8ROM)
 			// Sather, Fig 5.13
@@ -1537,14 +1525,36 @@ void apple2e_state::reset_w(int state)
 /***************************************************************************
     I/O
 ***************************************************************************/
-void apple2e_state::accel_full_speed()
+void apple2e_state::accel_update_speed()
 {
-	m_maincpu->set_unscaled_clock(m_accel_speed);
+	if (!m_accel_fast || m_accel_temp_slowdown)
+	{
+		m_maincpu->set_unscaled_clock(m_pal ? 1016966 : 1021800, true); // re-align to PH0
+	}
+	else
+	{
+		m_maincpu->set_unscaled_clock(m_accel_speed);
+	}
 }
 
-void apple2e_state::accel_normal_speed()
+void apple2e_state::accel_reset()
 {
-	m_maincpu->set_unscaled_clock(m_pal ? 1016966 : 1021800, true); // re-align to PH0
+	if (!m_accel_laser)
+	{
+		m_accel_unlocked = false;
+		m_accel_stage = 0;
+		m_accel_slotspk = 0xE4; // slots 7, 6, 5, 2 slow
+		m_accel_gameio = 0x40;  // paddle delay on
+		m_accel_disable_delay = false;
+
+		// Zip Chip embedded firmware watches for Esc and space keys
+		// This is not emulated, config "Bootup speed" is an approximation
+		m_accel_fast = ((m_isiicplus) || (m_sysconfig.read_safe(0) & 0x20));
+		accel_update_speed();
+	}
+
+	// IIc+ firmware overwrites registers after reset
+	// Laser firmware watches for 1/2/3 keys and overwrites speed
 }
 
 void apple2e_state::accel_temp_delay(int ms, bool condition)
@@ -1552,18 +1562,17 @@ void apple2e_state::accel_temp_delay(int ms, bool condition)
 	// C05B status bit toggles even when accelerator is disabled
 	if ((m_accel_present) && (!m_accel_disable_delay) && (condition))
 	{
-		m_accel_temp_slowdown = true;
 		m_acceltimer->adjust(attotime::from_msec(ms));
-		accel_normal_speed();
+		m_accel_temp_slowdown = true;
+		accel_update_speed();
 	}
 }
 
 void apple2e_state::accel_stop_delay()
 {
-	m_accel_temp_slowdown = false;
 	m_acceltimer->adjust(attotime::never);
-	if (m_accel_fast)
-		accel_full_speed();
+	m_accel_temp_slowdown = false;
+	accel_update_speed();
 }
 
 void apple2e_state::accel_slot(int slot)
@@ -2217,11 +2226,26 @@ u8 apple2e_state::c000_r(offs_t offset)
 		// but this this is incorrect: they only exist on the IIc.
 
 		default:
-			do_io(offset);
-
-			if (m_accel_unlocked)
+			/*
+			When a Zip is present, side-effects to annunciators are skipped
+			IF the accelerator is unlocked AND the current instruction executes
+			from cache.  Cache is not emulated here, but as an approximation,
+			m_accel_fast differentiates all-cached and not-cached.
+			*/
+			if (((offset & 0xf8) != 0x58) || !m_accel_unlocked || !m_accel_fast)
 			{
-				if (offset == 0x5b) // Zip status flags
+				do_io(offset);
+			}
+
+			if (m_accel_unlocked) switch(offset)
+			{
+				case 0x58: return 0xC0; // undocumented, not floating bus
+				case 0x59: return 0x20;
+				case 0x5a: return 0x00;
+				case 0x5d: return 0x00;
+				case 0x5f: return 0x00; // clears C05B bit 6
+
+				case 0x5b: // status flags
 				{
 					// bits 0-1 are cache size; [8, 16, 32, 64]kB
 					const u8 b01 = 0x03;
@@ -2229,15 +2253,26 @@ u8 apple2e_state::c000_r(offs_t offset)
 					const u8 b3 = m_accel_temp_slowdown ? 0x08 : 0x00;
 					// bit 4 is set if the Zip is disabled
 					const u8 b4 = m_accel_fast ? 0x00 : 0x10;
-					// bit 7 is a 1.0035 millisecond clock; the value changes every 0.50175 milliseconds
-					const int time = machine().time().as_ticks(1.0F / 0.00050175F);
+					// bit 5 is set if LC caching is disabled
+					const u8 b5 = BIT(m_accel_gameio, 7) ? 0x20 : 0x00;
+					// bit 7 is a tap on the PH0 clock divided by 1024; edge every 512 cycles
+					const int time = machine().time().as_ticks((m_pal ? 1016966 : 1021800) / 512.0F);
 					const u8 b7 = (time & 1) ? 0x80 : 0x00;
-					return b7 | b4 | b3 | b01;
+					return b7 | b5 | b4 | b3 | b01;
 				}
-				else if (offset == 0x5c)
-				{
+
+				case 0x5c:
 					return m_accel_slotspk;
-				}
+
+				case 0x5e: // synthesizes state, similar to STATEREG
+					return  (m_altzp ? 0x80 : 0x00) |
+							(m_ramrd ? 0x40 : 0x00) |
+							(m_ramwrt ? 0x20 : 0x00) |
+							(m_video->get_80store() ? 0x10 : 0x00) |
+							(m_video->get_hires() ? 0x08 : 0x00) |
+							(m_video->get_page2() ? 0x04 : 0x00) |
+							(m_lcram2 ? 0x00 : 0x02) |
+							(m_lcram ? 0x00 : 0x01);
 			}
 			break;
 	}
@@ -2329,31 +2364,27 @@ void apple2e_state::laser_calc_speed()
 {
 	if (m_laser_fdc_on)
 	{
-		accel_normal_speed();
 		m_accel_fast = false;
-		return;
 	}
-
-	switch ((m_laser_speed & 0xc0) >> 6)
+	else switch ((m_laser_speed & 0xc0) >> 6)
 	{
 		case 0:
 		case 1:
-			accel_normal_speed();
 			m_accel_fast = false;
 			break;
 
 		case 2:
 			m_accel_speed = A2BUS_7M_CLOCK.value()/3;   // 2.38 MHz
 			m_accel_fast = true;
-			accel_full_speed();
 			break;
 
 		case 3:
 			m_accel_speed = A2BUS_7M_CLOCK.value()/2;   // 3.58 MHz
 			m_accel_fast = true;
-			accel_full_speed();
 			break;
 	}
+
+	accel_update_speed();
 }
 
 void apple2e_state::c000_laser_w(offs_t offset, u8 data)
@@ -2526,10 +2557,30 @@ void apple2e_state::c000_w(offs_t offset, u8 data)
 			{
 				if (data == 0x5a)
 				{
-					m_accel_stage++;
-					if (m_accel_stage == 4)
+					if (m_accel_stage == 0)
 					{
-						m_accel_unlocked = true;
+						m_accel_stage = 1;
+						m_accel_tap = m_maincpu->space(AS_PROGRAM).install_write_tap(
+							0x0000, 0xffff, "zip_unlock",
+							[this](offs_t offset, u8 &data, u8 mem_mask)
+						{
+							if(!machine().side_effects_disabled())
+							{
+								if ((offset != 0xc05a) || (data != 0x5a))
+								{
+									// any other write instruction between the first
+									// four 5A writes will invalidate the unlock
+									m_accel_stage = 0;
+									m_accel_tap.remove();
+								}
+								else if (++m_accel_stage == 4)
+								{
+									// at least four writes of 5A in succession
+									m_accel_unlocked = true;
+									m_accel_tap.remove();
+								}
+							}
+						}, &m_accel_tap);
 					}
 				}
 				else if (data == 0xa5)
@@ -2542,17 +2593,17 @@ void apple2e_state::c000_w(offs_t offset, u8 data)
 				{
 					// disable acceleration
 					m_accel_fast = false;
-					accel_normal_speed();
+					accel_update_speed();
 				}
 			}
 			do_io(offset);
 			break;
 
-		case 0x5b: // Zip full speed
+		case 0x5b: // enable acceleration
 			if (m_accel_unlocked)
 			{
 				m_accel_fast = true;
-				accel_full_speed();
+				accel_update_speed();
 			}
 			do_io(offset);
 			break;

--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -434,8 +434,6 @@ public:
 	void mprof3(machine_config &config);
 	void apple2e(machine_config &config);
 	void apple2epal(machine_config &config);
-	void apple2ep(machine_config &config);
-	void apple2eppal(machine_config &config);
 	void apple2c(machine_config &config);
 	void apple2cpal(machine_config &config);
 	void tk3000(machine_config &config);
@@ -5216,18 +5214,6 @@ void apple2e_state::prav8c(machine_config &config)
 	m_screen->set_screen_update(m_video, NAME((&a2_video_device::screen_update<a2_video_device::model::PRAVETZ_8C, false, false>)));
 }
 
-void apple2e_state::apple2ep(machine_config &config)
-{
-	apple2ee(config);
-}
-
-void apple2e_state::apple2eppal(machine_config &config)
-{
-	apple2ep(config);
-	m_maincpu->set_clock(1016966);
-	m_screen->set_raw(1016966 * 14, (65 * 7) * 2, 0, (40 * 7) * 2, 312, 0, 192);
-}
-
 void apple2e_state::apple2c(machine_config &config)
 {
 	apple2e_common(config, true, false);
@@ -6333,11 +6319,11 @@ COMP( 1985, apple2eeuk, apple2e, 0,      apple2eepal,     apple2euk,  apple2e_st
 COMP( 1985, apple2eede, apple2e, 0,      apple2eepal,     apple2ede,  apple2e_state, init_pal,      "Apple Computer",                    "Apple //e (enhanced, Germany)", MACHINE_SUPPORTS_SAVE )
 COMP( 1985, apple2eese, apple2e, 0,      apple2eepal,     apple2ese,  apple2e_state, init_pal,      "Apple Computer",                    "Apple //e (enhanced, Sweden)", MACHINE_SUPPORTS_SAVE )
 COMP( 1985, apple2eefr, apple2e, 0,      apple2eepal,     apple2eefr, apple2e_state, init_pal,      "Apple Computer",                    "Apple //e (enhanced, France)", MACHINE_SUPPORTS_SAVE )
-COMP( 1987, apple2ep,   apple2e, 0,      apple2ep,        apple2epus, apple2e_state, empty_init,    "Apple Computer",                    "Apple //e (Platinum)", MACHINE_SUPPORTS_SAVE )
-COMP( 1987, apple2epuk, apple2e, 0,      apple2eppal,     apple2epuk, apple2e_state, init_pal,      "Apple Computer",                    "Apple //e (Platinum, UK)", MACHINE_SUPPORTS_SAVE )
-COMP( 1987, apple2epde, apple2e, 0,      apple2eppal,     apple2epde, apple2e_state, init_pal,      "Apple Computer",                    "Apple //e (Platinum, Germany)", MACHINE_SUPPORTS_SAVE )
-COMP( 1987, apple2epse, apple2e, 0,      apple2eppal,     apple2epse, apple2e_state, init_pal,      "Apple Computer",                    "Apple //e (Platinum, Sweden)", MACHINE_SUPPORTS_SAVE )
-COMP( 1987, apple2epfr, apple2e, 0,      apple2eppal,     apple2epfr, apple2e_state, init_pal,      "Apple Computer",                    "Apple //e (Platinum, France)", MACHINE_SUPPORTS_SAVE )
+COMP( 1987, apple2ep,   apple2e, 0,      apple2ee,        apple2epus, apple2e_state, empty_init,    "Apple Computer",                    "Apple //e (Platinum)", MACHINE_SUPPORTS_SAVE )
+COMP( 1987, apple2epuk, apple2e, 0,      apple2eepal,     apple2epuk, apple2e_state, init_pal,      "Apple Computer",                    "Apple //e (Platinum, UK)", MACHINE_SUPPORTS_SAVE )
+COMP( 1987, apple2epde, apple2e, 0,      apple2eepal,     apple2epde, apple2e_state, init_pal,      "Apple Computer",                    "Apple //e (Platinum, Germany)", MACHINE_SUPPORTS_SAVE )
+COMP( 1987, apple2epse, apple2e, 0,      apple2eepal,     apple2epse, apple2e_state, init_pal,      "Apple Computer",                    "Apple //e (Platinum, Sweden)", MACHINE_SUPPORTS_SAVE )
+COMP( 1987, apple2epfr, apple2e, 0,      apple2eepal,     apple2epfr, apple2e_state, init_pal,      "Apple Computer",                    "Apple //e (Platinum, France)", MACHINE_SUPPORTS_SAVE )
 COMP( 1984, apple2c,    0,       apple2, apple2c,         apple2cus,  apple2e_state, empty_init,    "Apple Computer",                    "Apple //c" , MACHINE_SUPPORTS_SAVE )
 COMP( 1984, apple2cuk,  apple2c, 0,      apple2cpal,      apple2cuk,  apple2e_state, init_pal,      "Apple Computer",                    "Apple //c (UK)" , MACHINE_SUPPORTS_SAVE )
 COMP( 1984, apple2cde,  apple2c, 0,      apple2cpal,      apple2cde,  apple2e_state, init_pal,      "Apple Computer",                    "Apple //c (Germany)" , MACHINE_SUPPORTS_SAVE )

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -2153,8 +2153,10 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 								{
 									// default:
 									//  if (!(m_speed & SPEED_ALLBANKS)) break; // (not supported)
+									//  [[fallthrough]];
 									case 0x00: case 0x01:
 										if (m_shadow & SHAD_IOLC) break;
+										[[fallthrough]];
 									case 0xe0: case 0xe1:
 										iobank = true;
 								}

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -507,58 +507,13 @@ private:
 	bool m_accel_fast = false;
 	bool m_accel_present = false;
 	bool m_accel_temp_slowdown = false;
+	bool m_accel_warm_boot = false;
 	int m_accel_stage = 0;
 	u32 m_accel_speed = 0;
 	u8 m_accel_slotspk = 0, m_accel_gsxsettings = 0, m_accel_percent = 0;
+	memory_passthrough_handler m_accel_tap;
 
-	void accel_full_speed()
-	{
-		bool isfast = false;
-
-		if (m_speed & SPEED_HIGH)
-		{
-			isfast = true;
-		}
-
-		if ((m_motors_active & (m_speed & 0x0f)) != 0)
-		{
-			isfast = false;
-		}
-
-		if (isfast)
-		{
-			m_maincpu->set_unscaled_clock(m_accel_speed);
-		}
-		else
-		{
-			m_maincpu->set_unscaled_clock(A2GS_1M, true); // re-align with PH0
-		}
-	}
-
-	void accel_normal_speed()
-	{
-		bool isfast = false;
-
-		if (m_speed & SPEED_HIGH)
-		{
-			isfast = true;
-		}
-
-		if ((m_motors_active & (m_speed & 0x0f)) != 0)
-		{
-			isfast = false;
-		}
-
-		if (isfast)
-		{
-			m_maincpu->set_unscaled_clock(A2GS_2_8M);
-		}
-		else
-		{
-			m_maincpu->set_unscaled_clock(A2GS_1M, true); // re-align with PH0
-		}
-	}
-
+	void accel_reset();
 	void accel_temp_delay(int ms, bool condition);
 	void accel_stop_delay();
 	void accel_slot(int slot);
@@ -852,6 +807,7 @@ void apple2gs_state::machine_start()
 	save_item(NAME(m_accel_gsxsettings));
 	save_item(NAME(m_accel_percent));
 	save_item(NAME(m_accel_temp_slowdown));
+	save_item(NAME(m_accel_warm_boot));
 	save_item(NAME(m_accel_speed));
 	save_item(NAME(m_motoroff_time));
 }
@@ -939,14 +895,11 @@ void apple2gs_state::machine_reset()
 	m_maincpu->reset();
 
 	// Setup ZipGS
-	m_accel_unlocked = false;
-	m_accel_stage = 0;
-	m_accel_slotspk = 0x45; // slots 6, 2, and speaker slow
-	m_accel_gsxsettings = 0x59; // paddle and counter slow, CPS, GS
-	m_accel_percent = 0;    // 100% speed
 	m_accel_present = false;
+	m_accel_unlocked = false;
 	m_accel_temp_slowdown = false;
 	m_accel_fast = false;
+	m_accel_warm_boot = false;
 
 	// is Zip enabled?
 	if (m_sysconfig->read() & 0x01)
@@ -955,8 +908,7 @@ void apple2gs_state::machine_reset()
 		m_accel_present = true;
 		int idxSpeed = (m_sysconfig->read() >> 1);
 		m_accel_speed = speeds[idxSpeed];
-		m_accel_fast = true;
-		accel_full_speed();
+		accel_reset();
 	}
 }
 
@@ -996,31 +948,40 @@ void apple2gs_state::lower_irq(int irq)
 
 void apple2gs_state::update_speed()
 {
-	bool isfast = false;
+	const bool isfast = (m_speed & SPEED_HIGH) && !(m_speed & m_motors_active);
+	const bool noaccel = !m_accel_fast || m_accel_temp_slowdown;
+	u32 new_speed = m_accel_speed;
+	m_last_speed = true;
 
-	if (m_speed & SPEED_HIGH)
+	if (isfast && noaccel)
 	{
-		isfast = true;
+		new_speed = A2GS_2_8M.value();
+	}
+	else if (!isfast && (noaccel || BIT(m_accel_gsxsettings, 3)))
+	{
+		new_speed = A2GS_1M.value();
+		m_last_speed = false;
 	}
 
-	if ((m_motors_active & (m_speed & 0x0f)) != 0)
+	m_maincpu->set_unscaled_clock(new_speed, !m_last_speed); // re-align with PH0
+}
+
+void apple2gs_state::accel_reset()
+{
+	if (!m_accel_warm_boot)
 	{
-		isfast = false;
+		m_accel_unlocked = false;
+		m_accel_stage = 0;
+		m_accel_gsxsettings = 0x59; // paddle and counter slow, CPS, GS
+		m_accel_slotspk = 0x45; // slots 6, 2, and speaker slow
+		m_accel_percent = 0; // 100% speed
+		m_accel_fast = true;
+		update_speed();
 	}
 
-	// prevent unnecessary reschedules by only setting this if it changed
-	if (isfast != m_last_speed)
-	{
-		if ((m_accel_present) && (isfast))
-		{
-			accel_full_speed();
-		}
-		else
-		{
-			m_maincpu->set_unscaled_clock(isfast ? A2GS_2_8M : A2GS_1M, !isfast);
-		}
-		m_last_speed = isfast;
-	}
+	// C059 bit 2 shows boot status
+	m_accel_gsxsettings = (m_accel_gsxsettings & ~0x04) | (m_accel_warm_boot ? 0x04 : 0);
+	m_accel_warm_boot = true;
 }
 
 void apple2gs_state::accel_temp_delay(int ms, bool condition)
@@ -1030,7 +991,7 @@ void apple2gs_state::accel_temp_delay(int ms, bool condition)
 	{
 		m_accel_temp_slowdown = true;
 		m_acceltimer->adjust(attotime::from_msec(ms));
-		accel_normal_speed();
+		update_speed();
 	}
 }
 
@@ -1038,8 +999,7 @@ void apple2gs_state::accel_stop_delay()
 {
 	m_accel_temp_slowdown = false;
 	m_acceltimer->adjust(attotime::never);
-	if (m_accel_fast)
-		accel_full_speed();
+	update_speed();
 }
 
 void apple2gs_state::accel_slot(int slot)
@@ -1846,19 +1806,31 @@ u8 apple2gs_state::c000_r(offs_t offset)
 			return m_rom[offset + 0x3c000];
 
 		default:
-			do_io(offset);
-
-			if (m_accel_unlocked)
+			/*
+			When a ZipGS is present, side-effects to annunciators are skipped
+			IF the accelerator is unlocked AND the current instruction executes
+			from cache.  Cache is not emulated here, but as an approximation,
+			m_accel_fast differentiates all-cached and not-cached.
+			*/
+			if (((offset & 0xf8) != 0x58) || !m_accel_unlocked || !m_accel_fast)
 			{
-				if (offset == 0x59)
-				{
+				do_io(offset);
+			}
+
+			if (m_accel_unlocked) switch(offset)
+			{
+				case 0x58: return 0xFF; // undocumented, not floating bus
+				case 0x5d: return 0x00; // "bank"
+				case 0x5e: return 0x00; // cache tag
+				case 0x5f: return 0x00; // clears C05B bit 6
+
+				case 0x59:
 					return m_accel_gsxsettings;
-				}
-				else if (offset == 0x5a)
-				{
+
+				case 0x5a:
 					return m_accel_percent | 0x0f;
-				}
-				else if (offset == 0x5b) // Zip status flags
+
+				case 0x5b: // status flags
 				{
 					// bits 0-1 are cache size: [8, 16, 32, 64]kB
 					const u8 b01 = 0x03;
@@ -1866,16 +1838,17 @@ u8 apple2gs_state::c000_r(offs_t offset)
 					const u8 b3 = m_accel_temp_slowdown ? 0x08 : 0x00;
 					// bit 4 is set if the Zip is disabled
 					const u8 b4 = m_accel_fast ? 0x00 : 0x10;
-					// bit 7 is a 1.0035 millisecond clock; the value changes every 0.50175 milliseconds
-					const int time = machine().time().as_ticks(1.0F / 0.00050175F);
+					// bit 5 is set if LC caching is disabled
+					const u8 b5 = BIT(m_accel_gsxsettings, 7) ? 0x20 : 0x00;
+					// bit 7 is a tap on the PH0 clock divided by 1024; edge every 512 cycles
+					const int time = machine().time().as_ticks(1021800 / 512.0F);
 					const u8 b7 = (time & 1) ? 0x80 : 0x00;
-					return b7 | b4 | b3 | b01;
+					return b7 | b5 | b4 | b3 | b01;
 				}
-				else if (offset == 0x5c)
-				{
+
+				case 0x5c:
 					// C036 motor detection overrides slots 4-7
 					return m_accel_slotspk | (m_speed << 4);
-				}
 			}
 			break;
 	}
@@ -2153,8 +2126,8 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			accel_stop_delay();
 			if (m_accel_unlocked)
 			{
-				m_accel_gsxsettings = data & 0xf8;
-				m_accel_gsxsettings |= 0x01;    // indicate this is a GS
+				m_accel_gsxsettings = (data & 0xf8) | (m_accel_gsxsettings & 0x07);
+				update_speed(); // CPS Follow
 			}
 			do_io(offset);
 			break;
@@ -2165,10 +2138,43 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			{
 				if ((data & 0xf0) == 0x50)
 				{
-					m_accel_stage++;
-					if (m_accel_stage == 4)
+					if (m_accel_stage == 0)
 					{
-						m_accel_unlocked = true;
+						m_accel_stage = 1;
+						m_accel_tap = m_maincpu->space(AS_PROGRAM).install_write_tap(
+							0x000000, 0xffffff, "zip_unlock",
+							[this](offs_t offset, u8 &data, u8 mem_mask)
+						{
+							if(!machine().side_effects_disabled())
+							{
+								bool iobank = false;
+
+								switch(offset >> 16)
+								{
+									// default:
+									//  if (!(m_speed & SPEED_ALLBANKS)) break; // (not supported)
+									case 0x00: case 0x01:
+										if (m_shadow & SHAD_IOLC) break;
+									case 0xe0: case 0xe1:
+										iobank = true;
+								}
+								offset &= 0xFFFF;
+
+								if ((offset != 0xc05a) || ((data & 0xf0) != 0x50) || !iobank)
+								{
+									// any other write instruction between the first
+									// four 5x writes will invalidate the unlock
+									m_accel_stage = 0;
+									m_accel_tap.remove();
+								}
+								else if (++m_accel_stage == 4)
+								{
+									// at least four writes of 5x in succession
+									m_accel_unlocked = true;
+									m_accel_tap.remove();
+								}
+							}
+						}, &m_accel_tap);
 					}
 				}
 				else if ((data & 0xf0) == 0xa0)
@@ -2181,18 +2187,18 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 				{
 					// disable acceleration
 					m_accel_fast = false;
-					accel_normal_speed();
+					update_speed();
 				}
 			}
 			do_io(offset);
 			break;
 
-		case 0x5b: // Zip full speed
+		case 0x5b: // enable acceleration
 			accel_stop_delay();
 			if (m_accel_unlocked)
 			{
 				m_accel_fast = true;
-				accel_full_speed();
+				update_speed();
 			}
 			do_io(offset);
 			break;
@@ -2215,7 +2221,9 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			do_io(offset);
 			break;
 
-		case 0x58:
+		case 0x58: // Zip cold boot
+			m_accel_warm_boot = false;
+			[[fallthrough]];
 		case 0x5e:
 		case 0x5f:
 			accel_stop_delay();
@@ -3367,6 +3375,8 @@ void apple2gs_state::adbmicro_p2_out(u8 data)
 		m_adb_reset_freeze = 2;
 		m_a2bus->reset_bus();
 		m_maincpu->reset();
+		if (m_accel_present)
+			accel_reset();
 		m_video->set_newvideo(0x41);
 
 		m_lcram = false;


### PR DESCRIPTION
(followup #15387)

This PR implements most of the missing Zip Chip register behavior:

* implement Ctrl-Reset interaction
* improve annunciator side-effects
* fix unlocking to be pedantically correct
* implement C05B LC bit
* apple2e: implement C05E state switches
* apple2gs: implement CPSFollow

<br>
Code comments:<details>

`accel_full_speed()` / `accel_normal_speed()` are consolidated into `*update_speed()`.  The previous short-circuit to "prevent unnecessary reschedules" is removed, as the core [already does that](https://github.com/mamedev/mame/blob/3509e702356562c0f8effb8abd2ef4769388af9b/src/emu/device.cpp#L375).

[Previously](https://github.com/mamedev/mame/pull/14397#:~:text=inconsistent%20documentation), C05B bit 5 was not implemented due to inconsistent documentation. //c+ and Zip Chip-8 [hardware testing](https://apple2infinitum.slack.com/archives/CPS2TG28L/p1777998146485029?thread_ts=1777912265.516769&cid=CPS2TG28L) (thanks to David Schmidt and Tom Greene) shows that the [paper manual](https://mirrors.apple2.org.za/ftp.apple.asimov.net/documentation/hardware/accelerators/zip_instruction_manual.pdf#page=12) is wrong (the electronic manual included on the Zip Chip Utilities disk is correct.)

The manual [describes C05B bit 7](https://mirrors.apple2.org.za/ftp.apple.asimov.net/documentation/hardware/accelerators/zip_instruction_manual.pdf#page=14) as both "1.0035 milliseconds" and as "a tap on the Apple Phase 0 clock divided by 1024", but the latter description is the correct one, since the stretched PH0 clock differs depending on the NTSC/PAL XTAL.  ZIPTEST (included below) measures this pulse rate precisely.

The manual's [description of the C05E softswitch bits](https://mirrors.apple2.org.za/ftp.apple.asimov.net/documentation/hardware/accelerators/zip_instruction_manual.pdf#page=13) use "ROMRD" and "RAMBNK"; hardware testing (with ZIPSCAN, included below) shows that these correspond to C012 RDLCRAM and C011 RDLCBNK2 but with inverted polarity.

</details>
<br>
User-visible changes:<details>

Most of this is user-invisible.  For example, unlocking the Zip already worked (after fixing 5x/Ax keys in #15387) in all real-world scenarios.  Now it also works like hardware in unlikely programmer-error scenarios.

On apple2gs, implementing CPSFollow improves the ZipGS CDEV/CDA, FTA SuperZip CDA, and Zippy: now the measured speed shows something approximately correct instead of 1MHz.

On apple2e, implementing C05E improves the Zip Chip Utilities diagnostic, which now shows C05E marching through every bit pattern (although the cache tests still completely fail.)

Ctrl-Reset now more closely matches hardware behavior (always restoring default register state on a //e or //c configured with Zip Chip, and optionally on the IIgs only if C058 was written to.)  The //c+ always overwrites Zip registers during reset, so is unchanged.

</details>
<br>
Testing:<details>

My previous Zip tests are updated again here with improved coverage:
[ZipTest_260607.zip](https://github.com/user-attachments/files/28685203/ZipTest_260607.zip)

After this PR, ZIPTEST now passes all subtests except for the programmable divisor related actual-speed measurements.

A new test ZIPRESET shows how mutating register state interacts with Ctrl-Reset and ZipGS C058 forcing cold-boot.  After this PR, it matches hardware behavior.

Total Replay and [light printer and serial testing](https://github.com/mamedev/mame/pull/15387#:~:text=Light%20printer%20testing) continue to work.

</details>
<br>
TODO:<details>

All of the Zip registers are now implemented _except_ the C05D programmable clock divisor.  I have that prototyped, but there are timing interactions which need more testing.  Some thoughts:

* Cache (and the effect of a cache miss) is not emulated, so all of the Zip timing is only approximate.  Emulating cache is low ROI; other than the Zip Chip Utilities diagnostic, no existing software should depend on the exact behavior.
* [Patent 4794523](https://downloads.reactivemicro.com/Apple%20II%20Items/Hardware/ZIP_CHIP/ZIP%20CHIP%20Patent%204794523.pdf) (which does not exactly match details of shipping product) describes a single-entry write-through buffer to cover the latency of some 6502 stores.  Back-to-back stores (especially to the zero page or at higher clock rates) should stall, but without a compelling example depending on this behavior, this is also low ROI.
* On the other hand, reads from I/O addresses must always be uncached, and this does have an easily-noticable effect in loops like the RDKEY firmware cursor blinking: without the stall, the cursor blinks wildly too fast.  apple2e needs something like `sync_cycle()` in the `c0xx_r()` handlers.  apple2gs actually needs two versions: `slow_cycle()` for 1MHz access, and `sync_cycle()` for uncached access, and this is further complicated by memory refresh stalls.  Accurate emulation of FPI stalls isn't possible because the g65816 core is not cycle-exact (it doesn't access memory on the correct cycles, or issue false-reads), but maybe they can be approximately averaged over time, at least well enough to fix 3200-color mode?

</details>
