### PR TITLE
esq5505.cpp and more: Cleanup Ensoniq VFX family layout loading.

### DIFF
--- a/src/mame/ensoniq/esq5505.cpp
+++ b/src/mame/ensoniq/esq5505.cpp
@@ -188,6 +188,11 @@
 #include <cstdarg>
 #include <cstdio>
 
+#include "sd1.lh"
+#include "sd132.lh"
+#include "vfx.lh"
+#include "vfxsd.lh"
+
 
 //#define VERBOSE 1
 #include "logmacro.h"
@@ -240,10 +245,10 @@ public:
 		, m_seqram_nvram(*this, "seqram")
 	{ }
 
-	void vfx(machine_config &config, int vfx_panel_type = esqpanel2x40_vfx_device::VFX) ATTR_COLD;
-	void vfxsd(machine_config &config, int vfx_panel_type = esqpanel2x40_vfx_device::VFX_SD) ATTR_COLD;
-	void sd1(machine_config &config, int vfx_panel_type = esqpanel2x40_vfx_device::SD_1) ATTR_COLD;
-	void sd132(machine_config &config, int vfx_panel_type = esqpanel2x40_vfx_device::SD_1_32) ATTR_COLD;
+	void vfx(machine_config &config) ATTR_COLD;
+	void vfxsd(machine_config &config) ATTR_COLD;
+	void sd1(machine_config &config) ATTR_COLD;
+	void sd132(machine_config &config) ATTR_COLD;
 	void eps(machine_config &config) ATTR_COLD;
 	void sq1(machine_config &config) ATTR_COLD;
 	void ks32(machine_config &config) ATTR_COLD;
@@ -803,17 +808,19 @@ void esq5505_state::common(machine_config &config)
 	m_otis->add_route(7, "pump", 1.0, 7);
 }
 
-void esq5505_state::vfx(machine_config &config, int panel_type)
+void esq5505_state::vfx(machine_config &config)
 {
 	common(config);
 
 	ENSONIQ_VFX_CARTRIDGE(config, m_cart);
 
-	ESQPANEL2X40_VFX(config, m_panel, panel_type);
+	ESQPANEL2X40_VFX(config, m_panel);
 	m_panel->write_tx().set(m_duart, FUNC(mc68681_device::rx_b_w));
 	m_panel->write_analog().set(FUNC(esq5505_state::analog_w));
 
 	NVRAM(config, m_osram_nvram, nvram_device::DEFAULT_NONE);
+
+	config.set_default_layout(layout_vfx);
 }
 
 void esq5505_state::eps(machine_config &config)
@@ -839,9 +846,9 @@ void esq5505_state::eps(machine_config &config)
 	m_dmac->dma8_write<0>().set(m_fdc, FUNC(wd1772_device::data_w));
 }
 
-void esq5505_state::vfxsd(machine_config &config, int panel_type)
+void esq5505_state::vfxsd(machine_config &config)
 {
-	vfx(config, panel_type);
+	vfx(config);
 	m_maincpu->set_addrmap(AS_PROGRAM, &esq5505_state::vfxsd_map);
 	// and nvram for the sequencer RAM as well
 	NVRAM(config, m_seqram_nvram, nvram_device::DEFAULT_NONE);
@@ -855,24 +862,28 @@ void esq5505_state::vfxsd(machine_config &config, int panel_type)
 
 	// software list
 	SOFTWARE_LIST(config, "vfxsd_flop").set_original("vfxsd_flop");
+
+	config.set_default_layout(layout_vfxsd);
 }
 
-void esq5505_state::sd1(machine_config &config, int panel_type)
+void esq5505_state::sd1(machine_config &config)
 {
-	// Like the VFX-SD but with its own panel type
-	vfxsd(config, panel_type);
+	// Like the VFX-SD but with its own software list and layout
+	vfxsd(config);
 
 	// software list
 	SOFTWARE_LIST(config, "sd1_flop").set_original("sd1_flop");
+
+	config.set_default_layout(layout_sd1);
 }
 
 // Like the sd1, but with some clock speeds faster.
-void esq5505_state::sd132(machine_config &config, int panel_type)
+void esq5505_state::sd132(machine_config &config)
 {
 	auto clock = 30.47618_MHz_XTAL / 2;
 
-	// Like the SD-1 but with its own panel type
-	sd1(config, panel_type);
+	// Like the SD-1 but with different clocks, software and layout
+	sd1(config);
 	m_duart->set_clock(4'000'000);
 
 	m_maincpu->set_clock(clock);
@@ -881,6 +892,8 @@ void esq5505_state::sd132(machine_config &config, int panel_type)
 
 	// software list
 	SOFTWARE_LIST(config, "sd132_flop").set_original("sd132_flop");
+
+	config.set_default_layout(layout_sd132);
 }
 
 // 32-voice machines with the VFX-SD type config

--- a/src/mame/ensoniq/esqpanel.cpp
+++ b/src/mame/ensoniq/esqpanel.cpp
@@ -22,12 +22,6 @@
 #include "logmacro.h"
 
 
-#include "esq2by40_vfx.lh"
-#include "sd1.lh"
-#include "sd132.lh"
-#include "vfx.lh"
-#include "vfxsd.lh"
-
 
 //**************************************************************************
 // External panel support
@@ -763,22 +757,10 @@ esqpanel2x40_esq1_device::esqpanel2x40_esq1_device(const machine_config &mconfig
 void esqpanel2x40_vfx_device::device_add_mconfig(machine_config &config)
 {
 	ESQ2X40_VFX(config, m_vfd, 60);
-
-	if (m_panel_type == VFX)
-		config.set_default_layout(layout_vfx);
-	else if (m_panel_type == VFX_SD)
-		config.set_default_layout(layout_vfxsd);
-	else if (m_panel_type == SD_1)
-		config.set_default_layout(layout_sd1);
-	else if (m_panel_type == SD_1_32)
-		config.set_default_layout(layout_sd132);
-	else // lowest common demonimator as the default: just the VFD.
-		config.set_default_layout(layout_esq2by40_vfx);
 }
 
-esqpanel2x40_vfx_device::esqpanel2x40_vfx_device(const machine_config &mconfig, const char *tag, device_t *owner, int panel_type, uint32_t clock) :
+esqpanel2x40_vfx_device::esqpanel2x40_vfx_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	esqpanel_device(mconfig, ESQPANEL2X40_VFX, tag, owner, clock),
-	m_panel_type(panel_type),
 	m_vfd(*this, "vfd"),
 	m_lights(*this, "lights"),
 	m_buttons_0(*this, "buttons_0"),

--- a/src/mame/ensoniq/esqpanel.h
+++ b/src/mame/ensoniq/esqpanel.h
@@ -109,23 +109,13 @@ protected:
 
 class esqpanel2x40_vfx_device : public esqpanel_device {
 public:
-	esqpanel2x40_vfx_device(const machine_config &mconfig, const char *tag, device_t *owner, int panel_type = UNKNOWN, uint32_t clock = 0);
+	esqpanel2x40_vfx_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 
 	DECLARE_INPUT_CHANGED_MEMBER(button_change);
 	DECLARE_INPUT_CHANGED_MEMBER(patch_select_change);
 	DECLARE_INPUT_CHANGED_MEMBER(analog_value_change);
 	DECLARE_INPUT_CHANGED_MEMBER(key_change);
 	void set_floppy_active(bool floppy_active) override;
-
-	void set_family_member(int family_member);
-
-	enum panel_types : int {
-		UNKNOWN = 0,
-		VFX,
-		VFX_SD,
-		SD_1,
-		SD_1_32
-	};
 
 protected:
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
@@ -143,8 +133,6 @@ protected:
 	static constexpr uint8_t AT_BLINK       = 0x02;
 
 private:
-	int m_panel_type;
-
 	emu_timer *m_blink_timer = nullptr;
 	uint8_t m_blink_phase;
 

--- a/src/mame/ensoniq/esqvfd.cpp
+++ b/src/mame/ensoniq/esqvfd.cpp
@@ -10,6 +10,7 @@
 
 #include "esq1by22.lh"
 #include "esq2by40.lh"
+#include "esq2by40_vfx.lh"
 
 #define LOG_DISPLAY_COMMANDS (1U << 1)
 #define LOGDC(...) LOGMASKED(LOG_DISPLAY_COMMANDS, __VA_ARGS__)
@@ -438,9 +439,7 @@ esq2x40_vfx_device::esq2x40_vfx_device(const machine_config &mconfig, const char
 
 void esq2x40_vfx_device::device_add_mconfig(machine_config &config)
 {
-	// Do not set a default layout. This display must be used
-	// within a layout that includes the VFD elements, such as
-	// vfx.lay, vfxsd.lay or sd1.lay.
+	config.set_default_layout(layout_esq2by40_vfx);
 }
 
 // Handles blinking of underline and of entire character,

--- a/src/mame/layout/esq2by40_vfx.lay
+++ b/src/mame/layout/esq2by40_vfx.lay
@@ -51,7 +51,7 @@ license:CC0-1.0
 			<param name="n" start="~s~" increment="1" />
 			<param name="x" start="0" increment="342" />
 
-			<param name="input" value="vfd:vfd~n~" />
+			<param name="input" value="vfd~n~" />
 			<group ref="vfd_cell">
 				<bounds x="~x~" y="~y~" width="342" height="572" />
 			</group>

--- a/src/mame/layout/sd1.lay
+++ b/src/mame/layout/sd1.lay
@@ -287,7 +287,7 @@
 				<param name="n" start="~s~" increment="1" />
 				<param name="x" start="0" increment="342" />
 
-				<param name="input" value="vfd:vfd~n~" />
+				<param name="input" value="panel:vfd:vfd~n~" />
 				<group ref="vfd_cell">
 					<bounds x="~x~" y="~y~" width="342" height="572" />
 				</group>
@@ -1012,19 +1012,19 @@
 		<element ref="text_L_data_entry">
 			<bounds x="47.5" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="buttons_32" inputmask="0x80000000">
+		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="panel:buttons_32" inputmask="0x80000000">
 			<bounds x="47.5" y="60" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="buttons_32" inputmask="0x40000000">
+		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="panel:buttons_32" inputmask="0x40000000">
 			<bounds x="47.5" y="35" width="15.8" height="5" />
 		</element>
 		<param name="slider_id" value="volume" />
-		<param name="port_name" value="analog_volume" />
+		<param name="port_name" value="panel:analog_volume" />
 		<group ref="slider">
 			<bounds x="0" y="15" width="20" height="60" />
 		</group>
 		<param name="slider_id" value="data_entry" />
-		<param name="port_name" value="analog_data_entry" />
+		<param name="port_name" value="panel:analog_data_entry" />
 		<group ref="slider">
 			<bounds x="70" y="15" width="20" height="60" />
 		</group>
@@ -1082,64 +1082,64 @@
 		<group ref="vfd">
 			<bounds x="12" y="32.50936" width="221" height="18.48129" />
 		</group>
-		<element ref="button_15_8x5_screen" id="button_50__display_below_left" inputtag="buttons_32" inputmask="0x00040000">
+		<element ref="button_15_8x5_screen" id="button_50__display_below_left" inputtag="panel:buttons_32" inputmask="0x00040000">
 			<bounds x="60" y="65.5" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_44__display_below_middle" inputtag="buttons_32" inputmask="0x00001000">
+		<element ref="button_15_8x5_screen" id="button_44__display_below_middle" inputtag="panel:buttons_32" inputmask="0x00001000">
 			<bounds x="126" y="65.5" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_45__display_below_right" inputtag="buttons_32" inputmask="0x00002000">
+		<element ref="button_15_8x5_screen" id="button_45__display_below_right" inputtag="panel:buttons_32" inputmask="0x00002000">
 			<bounds x="192" y="65.5" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_58__display_above_left" inputtag="buttons_32" inputmask="0x04000000">
+		<element ref="button_15_8x5_screen" id="button_58__display_above_left" inputtag="panel:buttons_32" inputmask="0x04000000">
 			<bounds x="60" y="13" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_42__diplay_above_center" inputtag="buttons_32" inputmask="0x00000400">
+		<element ref="button_15_8x5_screen" id="button_42__diplay_above_center" inputtag="panel:buttons_32" inputmask="0x00000400">
 			<bounds x="126" y="13" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_43__display_above_right" inputtag="buttons_32" inputmask="0x00000800">
+		<element ref="button_15_8x5_screen" id="button_43__display_above_right" inputtag="panel:buttons_32" inputmask="0x00000800">
 			<bounds x="193" y="13" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_52__cartbankset" inputtag="buttons_32" inputmask="0x00100000">
+		<element ref="button_15_8x10_light" id="button_52__cartbankset" inputtag="panel:buttons_32" inputmask="0x00100000">
 			<bounds x="0" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_53__sounds" inputtag="buttons_32" inputmask="0x00200000">
+		<element ref="button_15_8x10_light" id="button_53__sounds" inputtag="panel:buttons_32" inputmask="0x00200000">
 			<bounds x="15.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_54__presets" inputtag="buttons_32" inputmask="0x00400000">
+		<element ref="button_15_8x10_light" id="button_54__presets" inputtag="panel:buttons_32" inputmask="0x00400000">
 			<bounds x="31.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_51__seq" inputtag="buttons_32" inputmask="0x00080000">
+		<element ref="button_15_8x10_light" id="button_51__seq" inputtag="panel:buttons_32" inputmask="0x00080000">
 			<bounds x="47.4" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_55__0" inputtag="buttons_32" inputmask="0x00800000">
+		<element ref="button_15_8x10_medium" id="button_55__0" inputtag="panel:buttons_32" inputmask="0x00800000">
 			<bounds x="87" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_56__1" inputtag="buttons_32" inputmask="0x01000000">
+		<element ref="button_15_8x10_medium" id="button_56__1" inputtag="panel:buttons_32" inputmask="0x01000000">
 			<bounds x="102.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_57__2" inputtag="buttons_32" inputmask="0x02000000">
+		<element ref="button_15_8x10_medium" id="button_57__2" inputtag="panel:buttons_32" inputmask="0x02000000">
 			<bounds x="118.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_46__3" inputtag="buttons_32" inputmask="0x00004000">
+		<element ref="button_15_8x10_medium" id="button_46__3" inputtag="panel:buttons_32" inputmask="0x00004000">
 			<bounds x="134.4" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_47__4" inputtag="buttons_32" inputmask="0x00008000">
+		<element ref="button_15_8x10_medium" id="button_47__4" inputtag="panel:buttons_32" inputmask="0x00008000">
 			<bounds x="150.2" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_48__5" inputtag="buttons_32" inputmask="0x00010000">
+		<element ref="button_15_8x10_medium" id="button_48__5" inputtag="panel:buttons_32" inputmask="0x00010000">
 			<bounds x="166" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_49__6" inputtag="buttons_32" inputmask="0x00020000">
+		<element ref="button_15_8x10_medium" id="button_49__6" inputtag="panel:buttons_32" inputmask="0x00020000">
 			<bounds x="181.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_35__7" inputtag="buttons_32" inputmask="0x00000008">
+		<element ref="button_15_8x10_medium" id="button_35__7" inputtag="panel:buttons_32" inputmask="0x00000008">
 			<bounds x="197.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_34__8" inputtag="buttons_32" inputmask="0x00000004">
+		<element ref="button_15_8x10_medium" id="button_34__8" inputtag="panel:buttons_32" inputmask="0x00000004">
 			<bounds x="213.4" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_25__9" inputtag="buttons_0" inputmask="0x02000000">
+		<element ref="button_15_8x10_medium" id="button_25__9" inputtag="panel:buttons_0" inputmask="0x02000000">
 			<bounds x="229.2" y="82" width="15.8" height="10" />
 		</element>
 		<element name="lights" ref="light_15">
@@ -1421,124 +1421,124 @@
 		<element ref="text_L_programming">
 			<bounds x="120" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_29_replace_program" inputtag="buttons_0" inputmask="0x20000000">
+		<element ref="button_15_8x10_medium" id="button_29_replace_program" inputtag="panel:buttons_0" inputmask="0x20000000">
 			<bounds x="0" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_5_select_voice" inputtag="buttons_0" inputmask="0x00000020">
+		<element ref="button_15_8x10_medium" id="button_5_select_voice" inputtag="panel:buttons_0" inputmask="0x00000020">
 			<bounds x="120" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_9_copy" inputtag="buttons_0" inputmask="0x00000200">
+		<element ref="button_15_8x10_medium" id="button_9_copy" inputtag="panel:buttons_0" inputmask="0x00000200">
 			<bounds x="135.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_3_write" inputtag="buttons_0" inputmask="0x00000008">
+		<element ref="button_15_8x10_medium" id="button_3_write" inputtag="panel:buttons_0" inputmask="0x00000008">
 			<bounds x="151.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_8_compare" inputtag="buttons_0" inputmask="0x00000100">
+		<element ref="button_15_8x10_medium" id="button_8_compare" inputtag="panel:buttons_0" inputmask="0x00000100">
 			<bounds x="167.4" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_26_patch_select" inputtag="buttons_0" inputmask="0x04000000">
+		<element ref="button_15_8x5_dark" id="button_26_patch_select" inputtag="panel:buttons_0" inputmask="0x04000000">
 			<bounds x="0" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_27_midi" inputtag="buttons_0" inputmask="0x08000000">
+		<element ref="button_15_8x5_dark" id="button_27_midi" inputtag="panel:buttons_0" inputmask="0x08000000">
 			<bounds x="15.8" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_28_effects" inputtag="buttons_0" inputmask="0x10000000">
+		<element ref="button_15_8x5_dark" id="button_28_effects" inputtag="panel:buttons_0" inputmask="0x10000000">
 			<bounds x="31.6" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_39_key_zone" inputtag="buttons_32" inputmask="0x00000080">
+		<element ref="button_15_8x5_dark" id="button_39_key_zone" inputtag="panel:buttons_32" inputmask="0x00000080">
 			<bounds x="0" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_40_transpose" inputtag="buttons_32" inputmask="0x00000100">
+		<element ref="button_15_8x5_dark" id="button_40_transpose" inputtag="panel:buttons_32" inputmask="0x00000100">
 			<bounds x="15.8" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_41_release" inputtag="buttons_32" inputmask="0x00000200">
+		<element ref="button_15_8x5_dark" id="button_41_release" inputtag="panel:buttons_32" inputmask="0x00000200">
 			<bounds x="31.6" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_36_volume" inputtag="buttons_32" inputmask="0x00000010">
+		<element ref="button_15_8x5_dark" id="button_36_volume" inputtag="panel:buttons_32" inputmask="0x00000010">
 			<bounds x="0" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_37_pan" inputtag="buttons_32" inputmask="0x00000020">
+		<element ref="button_15_8x5_dark" id="button_37_pan" inputtag="panel:buttons_32" inputmask="0x00000020">
 			<bounds x="15.8" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_38_timbre" inputtag="buttons_32" inputmask="0x00000040">
+		<element ref="button_15_8x5_dark" id="button_38_timbre" inputtag="panel:buttons_32" inputmask="0x00000040">
 			<bounds x="31.6" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_4_wave" inputtag="buttons_0" inputmask="0x00000010">
+		<element ref="button_15_8x5_dark" id="button_4_wave" inputtag="panel:buttons_0" inputmask="0x00000010">
 			<bounds x="120" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_6_mod_mixer" inputtag="buttons_0" inputmask="0x00000040">
+		<element ref="button_15_8x5_dark" id="button_6_mod_mixer" inputtag="panel:buttons_0" inputmask="0x00000040">
 			<bounds x="135.8" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_2_program_control" inputtag="buttons_0" inputmask="0x00000004">
+		<element ref="button_15_8x5_dark" id="button_2_program_control" inputtag="panel:buttons_0" inputmask="0x00000004">
 			<bounds x="151.6" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_7_effects" inputtag="buttons_0" inputmask="0x00000080">
+		<element ref="button_15_8x5_dark" id="button_7_effects" inputtag="panel:buttons_0" inputmask="0x00000080">
 			<bounds x="167.4" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_11_pitch" inputtag="buttons_0" inputmask="0x00000800">
+		<element ref="button_15_8x5_dark" id="button_11_pitch" inputtag="panel:buttons_0" inputmask="0x00000800">
 			<bounds x="120" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_13_pitch_mod" inputtag="buttons_0" inputmask="0x00002000">
+		<element ref="button_15_8x5_dark" id="button_13_pitch_mod" inputtag="panel:buttons_0" inputmask="0x00002000">
 			<bounds x="135.8" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_15_filters" inputtag="buttons_0" inputmask="0x00008000">
+		<element ref="button_15_8x5_dark" id="button_15_filters" inputtag="panel:buttons_0" inputmask="0x00008000">
 			<bounds x="151.6" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_17_output" inputtag="buttons_0" inputmask="0x00020000">
+		<element ref="button_15_8x5_dark" id="button_17_output" inputtag="panel:buttons_0" inputmask="0x00020000">
 			<bounds x="167.4" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_10_lfo" inputtag="buttons_0" inputmask="0x00000400">
+		<element ref="button_15_8x5_dark" id="button_10_lfo" inputtag="panel:buttons_0" inputmask="0x00000400">
 			<bounds x="120" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_12_env1" inputtag="buttons_0" inputmask="0x00001000">
+		<element ref="button_15_8x5_dark" id="button_12_env1" inputtag="panel:buttons_0" inputmask="0x00001000">
 			<bounds x="135.8" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_14_env2" inputtag="buttons_0" inputmask="0x00004000">
+		<element ref="button_15_8x5_dark" id="button_14_env2" inputtag="panel:buttons_0" inputmask="0x00004000">
 			<bounds x="151.6" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_16_env3" inputtag="buttons_0" inputmask="0x00010000">
+		<element ref="button_15_8x5_dark" id="button_16_env3" inputtag="panel:buttons_0" inputmask="0x00010000">
 			<bounds x="167.4" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_30_1_6" inputtag="buttons_0" inputmask="0x40000000">
+		<element ref="button_15_8x10_medium" id="button_30_1_6" inputtag="panel:buttons_0" inputmask="0x40000000">
 			<bounds x="15.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_31_7_12" inputtag="buttons_0" inputmask="0x80000000">
+		<element ref="button_15_8x10_medium" id="button_31_7_12" inputtag="panel:buttons_0" inputmask="0x80000000">
 			<bounds x="31.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_19_rec" inputtag="buttons_0" inputmask="0x00080000">
+		<element ref="button_15_8x10_medium" id="button_19_rec" inputtag="panel:buttons_0" inputmask="0x00080000">
 			<bounds x="60" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_22_stop_cont" inputtag="buttons_0" inputmask="0x00400000">
+		<element ref="button_15_8x10_medium" id="button_22_stop_cont" inputtag="panel:buttons_0" inputmask="0x00400000">
 			<bounds x="75.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_23_play" inputtag="buttons_0" inputmask="0x00800000">
+		<element ref="button_15_8x10_medium" id="button_23_play" inputtag="panel:buttons_0" inputmask="0x00800000">
 			<bounds x="91.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_32_click" inputtag="buttons_32" inputmask="0x00000001">
+		<element ref="button_15_8x5_dark" id="button_32_click" inputtag="panel:buttons_32" inputmask="0x00000001">
 			<bounds x="60" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_18_seq_control" inputtag="buttons_0" inputmask="0x00040000">
+		<element ref="button_15_8x5_dark" id="button_18_seq_control" inputtag="panel:buttons_0" inputmask="0x00040000">
 			<bounds x="75.8" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_33_locate" inputtag="buttons_32" inputmask="0x00000002">
+		<element ref="button_15_8x5_dark" id="button_33_locate" inputtag="panel:buttons_32" inputmask="0x00000002">
 			<bounds x="91.6" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_60_song" inputtag="buttons_32" inputmask="0x10000000">
+		<element ref="button_15_8x5_dark" id="button_60_song" inputtag="panel:buttons_32" inputmask="0x10000000">
 			<bounds x="60" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_59_seq" inputtag="buttons_32" inputmask="0x08000000">
+		<element ref="button_15_8x5_dark" id="button_59_seq" inputtag="panel:buttons_32" inputmask="0x08000000">
 			<bounds x="75.8" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_61_track" inputtag="buttons_32" inputmask="0x20000000">
+		<element ref="button_15_8x5_dark" id="button_61_track" inputtag="panel:buttons_32" inputmask="0x20000000">
 			<bounds x="91.6" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_light" id="button_20_master" inputtag="buttons_0" inputmask="0x00100000">
+		<element ref="button_15_8x5_light" id="button_20_master" inputtag="panel:buttons_0" inputmask="0x00100000">
 			<bounds x="60" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_light" id="button_21_storage" inputtag="buttons_0" inputmask="0x00200000">
+		<element ref="button_15_8x5_light" id="button_21_storage" inputtag="panel:buttons_0" inputmask="0x00200000">
 			<bounds x="75.8" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_light" id="button_24_midi_control" inputtag="buttons_0" inputmask="0x01000000">
+		<element ref="button_15_8x5_light" id="button_24_midi_control" inputtag="panel:buttons_0" inputmask="0x01000000">
 			<bounds x="91.69" y="22" width="15.8" height="5" />
 		</element>
 		<element name="lights" ref="light_5">
@@ -1658,19 +1658,19 @@
 		<element ref="text_L_mod">
 			<bounds x="66.5" y="93.87737" width="15" height="4.44107" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_1" inputtag="patch_select" inputmask="0x2">
+		<element ref="psel_9x12" id="patch_select_1" inputtag="panel:patch_select" inputmask="0x2">
 			<bounds x="6" y="2" width="9" height="12" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_0" inputtag="patch_select" inputmask="0x1">
+		<element ref="psel_9x12" id="patch_select_0" inputtag="panel:patch_select" inputmask="0x1">
 			<bounds x="21" y="2" width="9" height="12" />
 		</element>
 		<param name="wheel_id" value="pitch_bend" />
-		<param name="port_name" value="analog_pitch_bend" />
+		<param name="port_name" value="panel:analog_pitch_bend" />
 		<group ref="wheel">
 			<bounds x="29.5" y="26" width="13" height="66" />
 		</group>
 		<param name="wheel_id" value="mod_wheel" />
-		<param name="port_name" value="analog_mod_wheel" />
+		<param name="port_name" value="panel:analog_mod_wheel" />
 		<group ref="wheel">
 			<bounds x="66.5" y="26" width="13" height="66" />
 		</group>
@@ -2202,19 +2202,19 @@
 		<element ref="text_L_mod">
 			<bounds x="53" y="93.87737" width="15" height="4.44107" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_1" inputtag="patch_select" inputmask="0x2">
+		<element ref="psel_9x12" id="patch_select_1" inputtag="panel:patch_select" inputmask="0x2">
 			<bounds x="6" y="2" width="9" height="12" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_0" inputtag="patch_select" inputmask="0x1">
+		<element ref="psel_9x12" id="patch_select_0" inputtag="panel:patch_select" inputmask="0x1">
 			<bounds x="21" y="2" width="9" height="12" />
 		</element>
 		<param name="wheel_id" value="pitch_bend" />
-		<param name="port_name" value="analog_pitch_bend" />
+		<param name="port_name" value="panel:analog_pitch_bend" />
 		<group ref="wheel">
 			<bounds x="20" y="26" width="13" height="66" />
 		</group>
 		<param name="wheel_id" value="mod_wheel" />
-		<param name="port_name" value="analog_mod_wheel" />
+		<param name="port_name" value="panel:analog_mod_wheel" />
 		<group ref="wheel">
 			<bounds x="53" y="26" width="13" height="66" />
 		</group>
@@ -2531,7 +2531,7 @@
 			<bounds x="0" y="96.87737" width="35" height="4.44107" />
 		</element>
 		<param name="slider_id" value="volume" />
-		<param name="port_name" value="analog_volume" />
+		<param name="port_name" value="panel:analog_volume" />
 		<group ref="slider">
 			<bounds x="0" y="15" width="20" height="60" />
 		</group>
@@ -2544,10 +2544,10 @@
 		<element ref="text_L_patch_select">
 			<bounds x="0" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_1" inputtag="patch_select" inputmask="0x2">
+		<element ref="psel_9x12" id="patch_select_1" inputtag="panel:patch_select" inputmask="0x2">
 			<bounds x="0" y="55" width="9" height="12" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_0" inputtag="patch_select" inputmask="0x1">
+		<element ref="psel_9x12" id="patch_select_0" inputtag="panel:patch_select" inputmask="0x1">
 			<bounds x="15" y="55" width="9" height="12" />
 		</element>
 	</group>
@@ -2565,14 +2565,14 @@
 		<element ref="text_L_data_entry">
 			<bounds x="0" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="buttons_32" inputmask="0x80000000">
+		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="panel:buttons_32" inputmask="0x80000000">
 			<bounds x="0" y="60" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="buttons_32" inputmask="0x40000000">
+		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="panel:buttons_32" inputmask="0x40000000">
 			<bounds x="0" y="35" width="15.8" height="5" />
 		</element>
 		<param name="slider_id" value="data_entry" />
-		<param name="port_name" value="analog_data_entry" />
+		<param name="port_name" value="panel:analog_data_entry" />
 		<group ref="slider">
 			<bounds x="20" y="15" width="20" height="60" />
 		</group>
@@ -2771,13 +2771,13 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
 							media_change_notifiers[":cart"] = add_media_change_notifier(view, "media_cartridge", ":cart")
 							media_change_notifiers[":wd1772:0:35dd"] = add_media_change_notifier(view, "media_floppy", ":wd1772:0:35dd")
-							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "analog_pitch_bend", true, true))
-							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "analog_mod_wheel", true, false))
-							manager:addHandler(KeyboardHandler:create(view, "full_keyboard_background", "full_keyboard_key_", "key_", 3, 5))
+							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "panel:analog_pitch_bend", true, true))
+							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "panel:analog_mod_wheel", true, false))
+							manager:addHandler(KeyboardHandler:create(view, "full_keyboard_background", "full_keyboard_key_", "panel:key_", 3, 5))
 						end
 
 						if view.unqualified_name == "Compact" then
@@ -2787,11 +2787,11 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
-							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "analog_pitch_bend", true, true))
-							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "analog_mod_wheel", true, false))
-							manager:addHandler(KeyboardHandler:create(view, "compact_keyboard_background", "compact_keyboard_key_", "key_", 4, 3))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "panel:analog_pitch_bend", true, true))
+							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "panel:analog_mod_wheel", true, false))
+							manager:addHandler(KeyboardHandler:create(view, "compact_keyboard_background", "compact_keyboard_key_", "panel:key_", 4, 3))
 						end
 
 						if view.unqualified_name == "Panel" then
@@ -2801,8 +2801,8 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
 						end
 
 						if view.unqualified_name == "Tablet" then
@@ -2812,8 +2812,8 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
 						end
 					end
 				end

--- a/src/mame/layout/sd132.lay
+++ b/src/mame/layout/sd132.lay
@@ -287,7 +287,7 @@
 				<param name="n" start="~s~" increment="1" />
 				<param name="x" start="0" increment="342" />
 
-				<param name="input" value="vfd:vfd~n~" />
+				<param name="input" value="panel:vfd:vfd~n~" />
 				<group ref="vfd_cell">
 					<bounds x="~x~" y="~y~" width="342" height="572" />
 				</group>
@@ -1015,19 +1015,19 @@
 		<element ref="text_L_data_entry">
 			<bounds x="47.5" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="buttons_32" inputmask="0x80000000">
+		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="panel:buttons_32" inputmask="0x80000000">
 			<bounds x="47.5" y="60" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="buttons_32" inputmask="0x40000000">
+		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="panel:buttons_32" inputmask="0x40000000">
 			<bounds x="47.5" y="35" width="15.8" height="5" />
 		</element>
 		<param name="slider_id" value="volume" />
-		<param name="port_name" value="analog_volume" />
+		<param name="port_name" value="panel:analog_volume" />
 		<group ref="slider">
 			<bounds x="0" y="15" width="20" height="60" />
 		</group>
 		<param name="slider_id" value="data_entry" />
-		<param name="port_name" value="analog_data_entry" />
+		<param name="port_name" value="panel:analog_data_entry" />
 		<group ref="slider">
 			<bounds x="70" y="15" width="20" height="60" />
 		</group>
@@ -1085,64 +1085,64 @@
 		<group ref="vfd">
 			<bounds x="12" y="32.50936" width="221" height="18.48129" />
 		</group>
-		<element ref="button_15_8x5_screen" id="button_50__display_below_left" inputtag="buttons_32" inputmask="0x00040000">
+		<element ref="button_15_8x5_screen" id="button_50__display_below_left" inputtag="panel:buttons_32" inputmask="0x00040000">
 			<bounds x="60" y="65.5" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_44__display_below_middle" inputtag="buttons_32" inputmask="0x00001000">
+		<element ref="button_15_8x5_screen" id="button_44__display_below_middle" inputtag="panel:buttons_32" inputmask="0x00001000">
 			<bounds x="126" y="65.5" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_45__display_below_right" inputtag="buttons_32" inputmask="0x00002000">
+		<element ref="button_15_8x5_screen" id="button_45__display_below_right" inputtag="panel:buttons_32" inputmask="0x00002000">
 			<bounds x="192" y="65.5" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_58__display_above_left" inputtag="buttons_32" inputmask="0x04000000">
+		<element ref="button_15_8x5_screen" id="button_58__display_above_left" inputtag="panel:buttons_32" inputmask="0x04000000">
 			<bounds x="60" y="13" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_42__diplay_above_center" inputtag="buttons_32" inputmask="0x00000400">
+		<element ref="button_15_8x5_screen" id="button_42__diplay_above_center" inputtag="panel:buttons_32" inputmask="0x00000400">
 			<bounds x="126" y="13" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_43__display_above_right" inputtag="buttons_32" inputmask="0x00000800">
+		<element ref="button_15_8x5_screen" id="button_43__display_above_right" inputtag="panel:buttons_32" inputmask="0x00000800">
 			<bounds x="193" y="13" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_52__cartbankset" inputtag="buttons_32" inputmask="0x00100000">
+		<element ref="button_15_8x10_light" id="button_52__cartbankset" inputtag="panel:buttons_32" inputmask="0x00100000">
 			<bounds x="0" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_53__sounds" inputtag="buttons_32" inputmask="0x00200000">
+		<element ref="button_15_8x10_light" id="button_53__sounds" inputtag="panel:buttons_32" inputmask="0x00200000">
 			<bounds x="15.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_54__presets" inputtag="buttons_32" inputmask="0x00400000">
+		<element ref="button_15_8x10_light" id="button_54__presets" inputtag="panel:buttons_32" inputmask="0x00400000">
 			<bounds x="31.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_51__seq" inputtag="buttons_32" inputmask="0x00080000">
+		<element ref="button_15_8x10_light" id="button_51__seq" inputtag="panel:buttons_32" inputmask="0x00080000">
 			<bounds x="47.4" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_55__0" inputtag="buttons_32" inputmask="0x00800000">
+		<element ref="button_15_8x10_medium" id="button_55__0" inputtag="panel:buttons_32" inputmask="0x00800000">
 			<bounds x="87" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_56__1" inputtag="buttons_32" inputmask="0x01000000">
+		<element ref="button_15_8x10_medium" id="button_56__1" inputtag="panel:buttons_32" inputmask="0x01000000">
 			<bounds x="102.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_57__2" inputtag="buttons_32" inputmask="0x02000000">
+		<element ref="button_15_8x10_medium" id="button_57__2" inputtag="panel:buttons_32" inputmask="0x02000000">
 			<bounds x="118.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_46__3" inputtag="buttons_32" inputmask="0x00004000">
+		<element ref="button_15_8x10_medium" id="button_46__3" inputtag="panel:buttons_32" inputmask="0x00004000">
 			<bounds x="134.4" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_47__4" inputtag="buttons_32" inputmask="0x00008000">
+		<element ref="button_15_8x10_medium" id="button_47__4" inputtag="panel:buttons_32" inputmask="0x00008000">
 			<bounds x="150.2" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_48__5" inputtag="buttons_32" inputmask="0x00010000">
+		<element ref="button_15_8x10_medium" id="button_48__5" inputtag="panel:buttons_32" inputmask="0x00010000">
 			<bounds x="166" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_49__6" inputtag="buttons_32" inputmask="0x00020000">
+		<element ref="button_15_8x10_medium" id="button_49__6" inputtag="panel:buttons_32" inputmask="0x00020000">
 			<bounds x="181.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_35__7" inputtag="buttons_32" inputmask="0x00000008">
+		<element ref="button_15_8x10_medium" id="button_35__7" inputtag="panel:buttons_32" inputmask="0x00000008">
 			<bounds x="197.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_34__8" inputtag="buttons_32" inputmask="0x00000004">
+		<element ref="button_15_8x10_medium" id="button_34__8" inputtag="panel:buttons_32" inputmask="0x00000004">
 			<bounds x="213.4" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_25__9" inputtag="buttons_0" inputmask="0x02000000">
+		<element ref="button_15_8x10_medium" id="button_25__9" inputtag="panel:buttons_0" inputmask="0x02000000">
 			<bounds x="229.2" y="82" width="15.8" height="10" />
 		</element>
 		<element name="lights" ref="light_15">
@@ -1424,124 +1424,124 @@
 		<element ref="text_L_programming">
 			<bounds x="120" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_29_replace_program" inputtag="buttons_0" inputmask="0x20000000">
+		<element ref="button_15_8x10_medium" id="button_29_replace_program" inputtag="panel:buttons_0" inputmask="0x20000000">
 			<bounds x="0" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_5_select_voice" inputtag="buttons_0" inputmask="0x00000020">
+		<element ref="button_15_8x10_medium" id="button_5_select_voice" inputtag="panel:buttons_0" inputmask="0x00000020">
 			<bounds x="120" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_9_copy" inputtag="buttons_0" inputmask="0x00000200">
+		<element ref="button_15_8x10_medium" id="button_9_copy" inputtag="panel:buttons_0" inputmask="0x00000200">
 			<bounds x="135.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_3_write" inputtag="buttons_0" inputmask="0x00000008">
+		<element ref="button_15_8x10_medium" id="button_3_write" inputtag="panel:buttons_0" inputmask="0x00000008">
 			<bounds x="151.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_8_compare" inputtag="buttons_0" inputmask="0x00000100">
+		<element ref="button_15_8x10_medium" id="button_8_compare" inputtag="panel:buttons_0" inputmask="0x00000100">
 			<bounds x="167.4" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_26_patch_select" inputtag="buttons_0" inputmask="0x04000000">
+		<element ref="button_15_8x5_dark" id="button_26_patch_select" inputtag="panel:buttons_0" inputmask="0x04000000">
 			<bounds x="0" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_27_midi" inputtag="buttons_0" inputmask="0x08000000">
+		<element ref="button_15_8x5_dark" id="button_27_midi" inputtag="panel:buttons_0" inputmask="0x08000000">
 			<bounds x="15.8" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_28_effects" inputtag="buttons_0" inputmask="0x10000000">
+		<element ref="button_15_8x5_dark" id="button_28_effects" inputtag="panel:buttons_0" inputmask="0x10000000">
 			<bounds x="31.6" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_39_key_zone" inputtag="buttons_32" inputmask="0x00000080">
+		<element ref="button_15_8x5_dark" id="button_39_key_zone" inputtag="panel:buttons_32" inputmask="0x00000080">
 			<bounds x="0" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_40_transpose" inputtag="buttons_32" inputmask="0x00000100">
+		<element ref="button_15_8x5_dark" id="button_40_transpose" inputtag="panel:buttons_32" inputmask="0x00000100">
 			<bounds x="15.8" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_41_release" inputtag="buttons_32" inputmask="0x00000200">
+		<element ref="button_15_8x5_dark" id="button_41_release" inputtag="panel:buttons_32" inputmask="0x00000200">
 			<bounds x="31.6" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_36_volume" inputtag="buttons_32" inputmask="0x00000010">
+		<element ref="button_15_8x5_dark" id="button_36_volume" inputtag="panel:buttons_32" inputmask="0x00000010">
 			<bounds x="0" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_37_pan" inputtag="buttons_32" inputmask="0x00000020">
+		<element ref="button_15_8x5_dark" id="button_37_pan" inputtag="panel:buttons_32" inputmask="0x00000020">
 			<bounds x="15.8" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_38_timbre" inputtag="buttons_32" inputmask="0x00000040">
+		<element ref="button_15_8x5_dark" id="button_38_timbre" inputtag="panel:buttons_32" inputmask="0x00000040">
 			<bounds x="31.6" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_4_wave" inputtag="buttons_0" inputmask="0x00000010">
+		<element ref="button_15_8x5_dark" id="button_4_wave" inputtag="panel:buttons_0" inputmask="0x00000010">
 			<bounds x="120" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_6_mod_mixer" inputtag="buttons_0" inputmask="0x00000040">
+		<element ref="button_15_8x5_dark" id="button_6_mod_mixer" inputtag="panel:buttons_0" inputmask="0x00000040">
 			<bounds x="135.8" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_2_program_control" inputtag="buttons_0" inputmask="0x00000004">
+		<element ref="button_15_8x5_dark" id="button_2_program_control" inputtag="panel:buttons_0" inputmask="0x00000004">
 			<bounds x="151.6" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_7_effects" inputtag="buttons_0" inputmask="0x00000080">
+		<element ref="button_15_8x5_dark" id="button_7_effects" inputtag="panel:buttons_0" inputmask="0x00000080">
 			<bounds x="167.4" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_11_pitch" inputtag="buttons_0" inputmask="0x00000800">
+		<element ref="button_15_8x5_dark" id="button_11_pitch" inputtag="panel:buttons_0" inputmask="0x00000800">
 			<bounds x="120" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_13_pitch_mod" inputtag="buttons_0" inputmask="0x00002000">
+		<element ref="button_15_8x5_dark" id="button_13_pitch_mod" inputtag="panel:buttons_0" inputmask="0x00002000">
 			<bounds x="135.8" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_15_filters" inputtag="buttons_0" inputmask="0x00008000">
+		<element ref="button_15_8x5_dark" id="button_15_filters" inputtag="panel:buttons_0" inputmask="0x00008000">
 			<bounds x="151.6" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_17_output" inputtag="buttons_0" inputmask="0x00020000">
+		<element ref="button_15_8x5_dark" id="button_17_output" inputtag="panel:buttons_0" inputmask="0x00020000">
 			<bounds x="167.4" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_10_lfo" inputtag="buttons_0" inputmask="0x00000400">
+		<element ref="button_15_8x5_dark" id="button_10_lfo" inputtag="panel:buttons_0" inputmask="0x00000400">
 			<bounds x="120" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_12_env1" inputtag="buttons_0" inputmask="0x00001000">
+		<element ref="button_15_8x5_dark" id="button_12_env1" inputtag="panel:buttons_0" inputmask="0x00001000">
 			<bounds x="135.8" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_14_env2" inputtag="buttons_0" inputmask="0x00004000">
+		<element ref="button_15_8x5_dark" id="button_14_env2" inputtag="panel:buttons_0" inputmask="0x00004000">
 			<bounds x="151.6" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_16_env3" inputtag="buttons_0" inputmask="0x00010000">
+		<element ref="button_15_8x5_dark" id="button_16_env3" inputtag="panel:buttons_0" inputmask="0x00010000">
 			<bounds x="167.4" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_30_1_6" inputtag="buttons_0" inputmask="0x40000000">
+		<element ref="button_15_8x10_medium" id="button_30_1_6" inputtag="panel:buttons_0" inputmask="0x40000000">
 			<bounds x="15.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_31_7_12" inputtag="buttons_0" inputmask="0x80000000">
+		<element ref="button_15_8x10_medium" id="button_31_7_12" inputtag="panel:buttons_0" inputmask="0x80000000">
 			<bounds x="31.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_19_rec" inputtag="buttons_0" inputmask="0x00080000">
+		<element ref="button_15_8x10_medium" id="button_19_rec" inputtag="panel:buttons_0" inputmask="0x00080000">
 			<bounds x="60" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_22_stop_cont" inputtag="buttons_0" inputmask="0x00400000">
+		<element ref="button_15_8x10_medium" id="button_22_stop_cont" inputtag="panel:buttons_0" inputmask="0x00400000">
 			<bounds x="75.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_23_play" inputtag="buttons_0" inputmask="0x00800000">
+		<element ref="button_15_8x10_medium" id="button_23_play" inputtag="panel:buttons_0" inputmask="0x00800000">
 			<bounds x="91.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_32_click" inputtag="buttons_32" inputmask="0x00000001">
+		<element ref="button_15_8x5_dark" id="button_32_click" inputtag="panel:buttons_32" inputmask="0x00000001">
 			<bounds x="60" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_18_seq_control" inputtag="buttons_0" inputmask="0x00040000">
+		<element ref="button_15_8x5_dark" id="button_18_seq_control" inputtag="panel:buttons_0" inputmask="0x00040000">
 			<bounds x="75.8" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_33_locate" inputtag="buttons_32" inputmask="0x00000002">
+		<element ref="button_15_8x5_dark" id="button_33_locate" inputtag="panel:buttons_32" inputmask="0x00000002">
 			<bounds x="91.6" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_60_song" inputtag="buttons_32" inputmask="0x10000000">
+		<element ref="button_15_8x5_dark" id="button_60_song" inputtag="panel:buttons_32" inputmask="0x10000000">
 			<bounds x="60" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_59_seq" inputtag="buttons_32" inputmask="0x08000000">
+		<element ref="button_15_8x5_dark" id="button_59_seq" inputtag="panel:buttons_32" inputmask="0x08000000">
 			<bounds x="75.8" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_61_track" inputtag="buttons_32" inputmask="0x20000000">
+		<element ref="button_15_8x5_dark" id="button_61_track" inputtag="panel:buttons_32" inputmask="0x20000000">
 			<bounds x="91.6" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_light" id="button_20_master" inputtag="buttons_0" inputmask="0x00100000">
+		<element ref="button_15_8x5_light" id="button_20_master" inputtag="panel:buttons_0" inputmask="0x00100000">
 			<bounds x="60" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_light" id="button_21_storage" inputtag="buttons_0" inputmask="0x00200000">
+		<element ref="button_15_8x5_light" id="button_21_storage" inputtag="panel:buttons_0" inputmask="0x00200000">
 			<bounds x="75.8" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_light" id="button_24_midi_control" inputtag="buttons_0" inputmask="0x01000000">
+		<element ref="button_15_8x5_light" id="button_24_midi_control" inputtag="panel:buttons_0" inputmask="0x01000000">
 			<bounds x="91.69" y="22" width="15.8" height="5" />
 		</element>
 		<element name="lights" ref="light_5">
@@ -1661,19 +1661,19 @@
 		<element ref="text_L_mod">
 			<bounds x="66.5" y="93.87737" width="15" height="4.44107" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_1" inputtag="patch_select" inputmask="0x2">
+		<element ref="psel_9x12" id="patch_select_1" inputtag="panel:patch_select" inputmask="0x2">
 			<bounds x="6" y="2" width="9" height="12" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_0" inputtag="patch_select" inputmask="0x1">
+		<element ref="psel_9x12" id="patch_select_0" inputtag="panel:patch_select" inputmask="0x1">
 			<bounds x="21" y="2" width="9" height="12" />
 		</element>
 		<param name="wheel_id" value="pitch_bend" />
-		<param name="port_name" value="analog_pitch_bend" />
+		<param name="port_name" value="panel:analog_pitch_bend" />
 		<group ref="wheel">
 			<bounds x="29.5" y="26" width="13" height="66" />
 		</group>
 		<param name="wheel_id" value="mod_wheel" />
-		<param name="port_name" value="analog_mod_wheel" />
+		<param name="port_name" value="panel:analog_mod_wheel" />
 		<group ref="wheel">
 			<bounds x="66.5" y="26" width="13" height="66" />
 		</group>
@@ -2205,19 +2205,19 @@
 		<element ref="text_L_mod">
 			<bounds x="53" y="93.87737" width="15" height="4.44107" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_1" inputtag="patch_select" inputmask="0x2">
+		<element ref="psel_9x12" id="patch_select_1" inputtag="panel:patch_select" inputmask="0x2">
 			<bounds x="6" y="2" width="9" height="12" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_0" inputtag="patch_select" inputmask="0x1">
+		<element ref="psel_9x12" id="patch_select_0" inputtag="panel:patch_select" inputmask="0x1">
 			<bounds x="21" y="2" width="9" height="12" />
 		</element>
 		<param name="wheel_id" value="pitch_bend" />
-		<param name="port_name" value="analog_pitch_bend" />
+		<param name="port_name" value="panel:analog_pitch_bend" />
 		<group ref="wheel">
 			<bounds x="20" y="26" width="13" height="66" />
 		</group>
 		<param name="wheel_id" value="mod_wheel" />
-		<param name="port_name" value="analog_mod_wheel" />
+		<param name="port_name" value="panel:analog_mod_wheel" />
 		<group ref="wheel">
 			<bounds x="53" y="26" width="13" height="66" />
 		</group>
@@ -2534,7 +2534,7 @@
 			<bounds x="0" y="96.87737" width="35" height="4.44107" />
 		</element>
 		<param name="slider_id" value="volume" />
-		<param name="port_name" value="analog_volume" />
+		<param name="port_name" value="panel:analog_volume" />
 		<group ref="slider">
 			<bounds x="0" y="15" width="20" height="60" />
 		</group>
@@ -2547,10 +2547,10 @@
 		<element ref="text_L_patch_select">
 			<bounds x="0" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_1" inputtag="patch_select" inputmask="0x2">
+		<element ref="psel_9x12" id="patch_select_1" inputtag="panel:patch_select" inputmask="0x2">
 			<bounds x="0" y="55" width="9" height="12" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_0" inputtag="patch_select" inputmask="0x1">
+		<element ref="psel_9x12" id="patch_select_0" inputtag="panel:patch_select" inputmask="0x1">
 			<bounds x="15" y="55" width="9" height="12" />
 		</element>
 	</group>
@@ -2568,14 +2568,14 @@
 		<element ref="text_L_data_entry">
 			<bounds x="0" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="buttons_32" inputmask="0x80000000">
+		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="panel:buttons_32" inputmask="0x80000000">
 			<bounds x="0" y="60" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="buttons_32" inputmask="0x40000000">
+		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="panel:buttons_32" inputmask="0x40000000">
 			<bounds x="0" y="35" width="15.8" height="5" />
 		</element>
 		<param name="slider_id" value="data_entry" />
-		<param name="port_name" value="analog_data_entry" />
+		<param name="port_name" value="panel:analog_data_entry" />
 		<group ref="slider">
 			<bounds x="20" y="15" width="20" height="60" />
 		</group>
@@ -2781,13 +2781,13 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
 							media_change_notifiers[":cart"] = add_media_change_notifier(view, "media_cartridge", ":cart")
 							media_change_notifiers[":wd1772:0:35dd"] = add_media_change_notifier(view, "media_floppy", ":wd1772:0:35dd")
-							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "analog_pitch_bend", true, true))
-							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "analog_mod_wheel", true, false))
-							manager:addHandler(KeyboardHandler:create(view, "full_keyboard_background", "full_keyboard_key_", "key_", 3, 5))
+							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "panel:analog_pitch_bend", true, true))
+							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "panel:analog_mod_wheel", true, false))
+							manager:addHandler(KeyboardHandler:create(view, "full_keyboard_background", "full_keyboard_key_", "panel:key_", 3, 5))
 						end
 
 						if view.unqualified_name == "Compact" then
@@ -2797,11 +2797,11 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
-							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "analog_pitch_bend", true, true))
-							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "analog_mod_wheel", true, false))
-							manager:addHandler(KeyboardHandler:create(view, "compact_keyboard_background", "compact_keyboard_key_", "key_", 4, 3))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "panel:analog_pitch_bend", true, true))
+							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "panel:analog_mod_wheel", true, false))
+							manager:addHandler(KeyboardHandler:create(view, "compact_keyboard_background", "compact_keyboard_key_", "panel:key_", 4, 3))
 						end
 
 						if view.unqualified_name == "Panel" then
@@ -2811,8 +2811,8 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
 						end
 
 						if view.unqualified_name == "Tablet" then
@@ -2822,8 +2822,8 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
 						end
 					end
 				end

--- a/src/mame/layout/vfx.lay
+++ b/src/mame/layout/vfx.lay
@@ -235,7 +235,7 @@
 				<param name="n" start="~s~" increment="1" />
 				<param name="x" start="0" increment="342" />
 
-				<param name="input" value="vfd:vfd~n~" />
+				<param name="input" value="panel:vfd:vfd~n~" />
 				<group ref="vfd_cell">
 					<bounds x="~x~" y="~y~" width="342" height="572" />
 				</group>
@@ -897,19 +897,19 @@
 		<element ref="text_L_data_entry">
 			<bounds x="47.5" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="buttons_32" inputmask="0x80000000">
+		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="panel:buttons_32" inputmask="0x80000000">
 			<bounds x="47.5" y="60" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="buttons_32" inputmask="0x40000000">
+		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="panel:buttons_32" inputmask="0x40000000">
 			<bounds x="47.5" y="35" width="15.8" height="5" />
 		</element>
 		<param name="slider_id" value="volume" />
-		<param name="port_name" value="analog_volume" />
+		<param name="port_name" value="panel:analog_volume" />
 		<group ref="slider">
 			<bounds x="0" y="15" width="20" height="60" />
 		</group>
 		<param name="slider_id" value="data_entry" />
-		<param name="port_name" value="analog_data_entry" />
+		<param name="port_name" value="panel:analog_data_entry" />
 		<group ref="slider">
 			<bounds x="70" y="15" width="20" height="60" />
 		</group>
@@ -964,61 +964,61 @@
 		<group ref="vfd">
 			<bounds x="12" y="32.50936" width="221" height="18.48129" />
 		</group>
-		<element ref="button_15_8x5_screen" id="button_50__display_below_left" inputtag="buttons_32" inputmask="0x00040000">
+		<element ref="button_15_8x5_screen" id="button_50__display_below_left" inputtag="panel:buttons_32" inputmask="0x00040000">
 			<bounds x="60" y="65.5" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_44__display_below_middle" inputtag="buttons_32" inputmask="0x00001000">
+		<element ref="button_15_8x5_screen" id="button_44__display_below_middle" inputtag="panel:buttons_32" inputmask="0x00001000">
 			<bounds x="126" y="65.5" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_45__display_below_right" inputtag="buttons_32" inputmask="0x00002000">
+		<element ref="button_15_8x5_screen" id="button_45__display_below_right" inputtag="panel:buttons_32" inputmask="0x00002000">
 			<bounds x="192" y="65.5" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_58__display_above_left" inputtag="buttons_32" inputmask="0x04000000">
+		<element ref="button_15_8x5_screen" id="button_58__display_above_left" inputtag="panel:buttons_32" inputmask="0x04000000">
 			<bounds x="60" y="13" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_42__diplay_above_center" inputtag="buttons_32" inputmask="0x00000400">
+		<element ref="button_15_8x5_screen" id="button_42__diplay_above_center" inputtag="panel:buttons_32" inputmask="0x00000400">
 			<bounds x="126" y="13" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_43__display_above_right" inputtag="buttons_32" inputmask="0x00000800">
+		<element ref="button_15_8x5_screen" id="button_43__display_above_right" inputtag="panel:buttons_32" inputmask="0x00000800">
 			<bounds x="193" y="13" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_52__cartbankset" inputtag="buttons_32" inputmask="0x00100000">
+		<element ref="button_15_8x10_light" id="button_52__cartbankset" inputtag="panel:buttons_32" inputmask="0x00100000">
 			<bounds x="0" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_53__sounds" inputtag="buttons_32" inputmask="0x00200000">
+		<element ref="button_15_8x10_light" id="button_53__sounds" inputtag="panel:buttons_32" inputmask="0x00200000">
 			<bounds x="15.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_54__presets" inputtag="buttons_32" inputmask="0x00400000">
+		<element ref="button_15_8x10_light" id="button_54__presets" inputtag="panel:buttons_32" inputmask="0x00400000">
 			<bounds x="31.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_55__0" inputtag="buttons_32" inputmask="0x00800000">
+		<element ref="button_15_8x10_medium" id="button_55__0" inputtag="panel:buttons_32" inputmask="0x00800000">
 			<bounds x="87" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_56__1" inputtag="buttons_32" inputmask="0x01000000">
+		<element ref="button_15_8x10_medium" id="button_56__1" inputtag="panel:buttons_32" inputmask="0x01000000">
 			<bounds x="102.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_57__2" inputtag="buttons_32" inputmask="0x02000000">
+		<element ref="button_15_8x10_medium" id="button_57__2" inputtag="panel:buttons_32" inputmask="0x02000000">
 			<bounds x="118.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_46__3" inputtag="buttons_32" inputmask="0x00004000">
+		<element ref="button_15_8x10_medium" id="button_46__3" inputtag="panel:buttons_32" inputmask="0x00004000">
 			<bounds x="134.4" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_47__4" inputtag="buttons_32" inputmask="0x00008000">
+		<element ref="button_15_8x10_medium" id="button_47__4" inputtag="panel:buttons_32" inputmask="0x00008000">
 			<bounds x="150.2" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_48__5" inputtag="buttons_32" inputmask="0x00010000">
+		<element ref="button_15_8x10_medium" id="button_48__5" inputtag="panel:buttons_32" inputmask="0x00010000">
 			<bounds x="166" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_49__6" inputtag="buttons_32" inputmask="0x00020000">
+		<element ref="button_15_8x10_medium" id="button_49__6" inputtag="panel:buttons_32" inputmask="0x00020000">
 			<bounds x="181.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_35__7" inputtag="buttons_32" inputmask="0x00000008">
+		<element ref="button_15_8x10_medium" id="button_35__7" inputtag="panel:buttons_32" inputmask="0x00000008">
 			<bounds x="197.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_34__8" inputtag="buttons_32" inputmask="0x00000004">
+		<element ref="button_15_8x10_medium" id="button_34__8" inputtag="panel:buttons_32" inputmask="0x00000004">
 			<bounds x="213.4" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_25__9" inputtag="buttons_0" inputmask="0x02000000">
+		<element ref="button_15_8x10_medium" id="button_25__9" inputtag="panel:buttons_0" inputmask="0x02000000">
 			<bounds x="229.2" y="82" width="15.8" height="10" />
 		</element>
 		<element name="lights" ref="light_15">
@@ -1240,97 +1240,97 @@
 		<element ref="text_L_programming">
 			<bounds x="120" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_29_replace_program" inputtag="buttons_0" inputmask="0x20000000">
+		<element ref="button_15_8x10_medium" id="button_29_replace_program" inputtag="panel:buttons_0" inputmask="0x20000000">
 			<bounds x="0" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_5_select_voice" inputtag="buttons_0" inputmask="0x00000020">
+		<element ref="button_15_8x10_medium" id="button_5_select_voice" inputtag="panel:buttons_0" inputmask="0x00000020">
 			<bounds x="120" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_9_copy" inputtag="buttons_0" inputmask="0x00000200">
+		<element ref="button_15_8x10_medium" id="button_9_copy" inputtag="panel:buttons_0" inputmask="0x00000200">
 			<bounds x="135.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_3_write" inputtag="buttons_0" inputmask="0x00000008">
+		<element ref="button_15_8x10_medium" id="button_3_write" inputtag="panel:buttons_0" inputmask="0x00000008">
 			<bounds x="151.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_8_compare" inputtag="buttons_0" inputmask="0x00000100">
+		<element ref="button_15_8x10_medium" id="button_8_compare" inputtag="panel:buttons_0" inputmask="0x00000100">
 			<bounds x="167.4" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_26_patch_select" inputtag="buttons_0" inputmask="0x04000000">
+		<element ref="button_15_8x5_dark" id="button_26_patch_select" inputtag="panel:buttons_0" inputmask="0x04000000">
 			<bounds x="0" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_27_midi" inputtag="buttons_0" inputmask="0x08000000">
+		<element ref="button_15_8x5_dark" id="button_27_midi" inputtag="panel:buttons_0" inputmask="0x08000000">
 			<bounds x="15.8" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_28_effects" inputtag="buttons_0" inputmask="0x10000000">
+		<element ref="button_15_8x5_dark" id="button_28_effects" inputtag="panel:buttons_0" inputmask="0x10000000">
 			<bounds x="31.6" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_39_key_zone" inputtag="buttons_32" inputmask="0x00000080">
+		<element ref="button_15_8x5_dark" id="button_39_key_zone" inputtag="panel:buttons_32" inputmask="0x00000080">
 			<bounds x="0" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_40_transpose" inputtag="buttons_32" inputmask="0x00000100">
+		<element ref="button_15_8x5_dark" id="button_40_transpose" inputtag="panel:buttons_32" inputmask="0x00000100">
 			<bounds x="15.8" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_41_release" inputtag="buttons_32" inputmask="0x00000200">
+		<element ref="button_15_8x5_dark" id="button_41_release" inputtag="panel:buttons_32" inputmask="0x00000200">
 			<bounds x="31.6" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_36_volume" inputtag="buttons_32" inputmask="0x00000010">
+		<element ref="button_15_8x5_dark" id="button_36_volume" inputtag="panel:buttons_32" inputmask="0x00000010">
 			<bounds x="0" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_37_pan" inputtag="buttons_32" inputmask="0x00000020">
+		<element ref="button_15_8x5_dark" id="button_37_pan" inputtag="panel:buttons_32" inputmask="0x00000020">
 			<bounds x="15.8" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_38_timbre" inputtag="buttons_32" inputmask="0x00000040">
+		<element ref="button_15_8x5_dark" id="button_38_timbre" inputtag="panel:buttons_32" inputmask="0x00000040">
 			<bounds x="31.6" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_4_wave" inputtag="buttons_0" inputmask="0x00000010">
+		<element ref="button_15_8x5_dark" id="button_4_wave" inputtag="panel:buttons_0" inputmask="0x00000010">
 			<bounds x="120" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_6_mod_mixer" inputtag="buttons_0" inputmask="0x00000040">
+		<element ref="button_15_8x5_dark" id="button_6_mod_mixer" inputtag="panel:buttons_0" inputmask="0x00000040">
 			<bounds x="135.8" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_2_program_control" inputtag="buttons_0" inputmask="0x00000004">
+		<element ref="button_15_8x5_dark" id="button_2_program_control" inputtag="panel:buttons_0" inputmask="0x00000004">
 			<bounds x="151.6" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_7_effects" inputtag="buttons_0" inputmask="0x00000080">
+		<element ref="button_15_8x5_dark" id="button_7_effects" inputtag="panel:buttons_0" inputmask="0x00000080">
 			<bounds x="167.4" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_11_pitch" inputtag="buttons_0" inputmask="0x00000800">
+		<element ref="button_15_8x5_dark" id="button_11_pitch" inputtag="panel:buttons_0" inputmask="0x00000800">
 			<bounds x="120" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_13_pitch_mod" inputtag="buttons_0" inputmask="0x00002000">
+		<element ref="button_15_8x5_dark" id="button_13_pitch_mod" inputtag="panel:buttons_0" inputmask="0x00002000">
 			<bounds x="135.8" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_15_filters" inputtag="buttons_0" inputmask="0x00008000">
+		<element ref="button_15_8x5_dark" id="button_15_filters" inputtag="panel:buttons_0" inputmask="0x00008000">
 			<bounds x="151.6" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_17_output" inputtag="buttons_0" inputmask="0x00020000">
+		<element ref="button_15_8x5_dark" id="button_17_output" inputtag="panel:buttons_0" inputmask="0x00020000">
 			<bounds x="167.4" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_10_lfo" inputtag="buttons_0" inputmask="0x00000400">
+		<element ref="button_15_8x5_dark" id="button_10_lfo" inputtag="panel:buttons_0" inputmask="0x00000400">
 			<bounds x="120" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_12_env1" inputtag="buttons_0" inputmask="0x00001000">
+		<element ref="button_15_8x5_dark" id="button_12_env1" inputtag="panel:buttons_0" inputmask="0x00001000">
 			<bounds x="135.8" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_14_env2" inputtag="buttons_0" inputmask="0x00004000">
+		<element ref="button_15_8x5_dark" id="button_14_env2" inputtag="panel:buttons_0" inputmask="0x00004000">
 			<bounds x="151.6" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_16_env3" inputtag="buttons_0" inputmask="0x00010000">
+		<element ref="button_15_8x5_dark" id="button_16_env3" inputtag="panel:buttons_0" inputmask="0x00010000">
 			<bounds x="167.4" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_30_a" inputtag="buttons_0" inputmask="0x40000000">
+		<element ref="button_15_8x10_medium" id="button_30_a" inputtag="panel:buttons_0" inputmask="0x40000000">
 			<bounds x="15.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_31_b" inputtag="buttons_0" inputmask="0x80000000">
+		<element ref="button_15_8x10_medium" id="button_31_b" inputtag="panel:buttons_0" inputmask="0x80000000">
 			<bounds x="31.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_20_master" inputtag="buttons_0" inputmask="0x00100000">
+		<element ref="button_15_8x10_light" id="button_20_master" inputtag="panel:buttons_0" inputmask="0x00100000">
 			<bounds x="60" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_21_storage" inputtag="buttons_0" inputmask="0x00200000">
+		<element ref="button_15_8x10_light" id="button_21_storage" inputtag="panel:buttons_0" inputmask="0x00200000">
 			<bounds x="75.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_24_midi_control" inputtag="buttons_0" inputmask="0x01000000">
+		<element ref="button_15_8x10_light" id="button_24_midi_control" inputtag="panel:buttons_0" inputmask="0x01000000">
 			<bounds x="91.6" y="82" width="15.8" height="10" />
 		</element>
 		<element name="lights" ref="light_5">
@@ -1435,19 +1435,19 @@
 		<element ref="text_L_mod">
 			<bounds x="66.5" y="93.87737" width="15" height="4.44107" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_1" inputtag="patch_select" inputmask="0x2">
+		<element ref="psel_9x12" id="patch_select_1" inputtag="panel:patch_select" inputmask="0x2">
 			<bounds x="6" y="2" width="9" height="12" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_0" inputtag="patch_select" inputmask="0x1">
+		<element ref="psel_9x12" id="patch_select_0" inputtag="panel:patch_select" inputmask="0x1">
 			<bounds x="21" y="2" width="9" height="12" />
 		</element>
 		<param name="wheel_id" value="pitch_bend" />
-		<param name="port_name" value="analog_pitch_bend" />
+		<param name="port_name" value="panel:analog_pitch_bend" />
 		<group ref="wheel">
 			<bounds x="29.5" y="26" width="13" height="66" />
 		</group>
 		<param name="wheel_id" value="mod_wheel" />
-		<param name="port_name" value="analog_mod_wheel" />
+		<param name="port_name" value="panel:analog_mod_wheel" />
 		<group ref="wheel">
 			<bounds x="66.5" y="26" width="13" height="66" />
 		</group>
@@ -1979,19 +1979,19 @@
 		<element ref="text_L_mod">
 			<bounds x="53" y="93.87737" width="15" height="4.44107" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_1" inputtag="patch_select" inputmask="0x2">
+		<element ref="psel_9x12" id="patch_select_1" inputtag="panel:patch_select" inputmask="0x2">
 			<bounds x="6" y="2" width="9" height="12" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_0" inputtag="patch_select" inputmask="0x1">
+		<element ref="psel_9x12" id="patch_select_0" inputtag="panel:patch_select" inputmask="0x1">
 			<bounds x="21" y="2" width="9" height="12" />
 		</element>
 		<param name="wheel_id" value="pitch_bend" />
-		<param name="port_name" value="analog_pitch_bend" />
+		<param name="port_name" value="panel:analog_pitch_bend" />
 		<group ref="wheel">
 			<bounds x="20" y="26" width="13" height="66" />
 		</group>
 		<param name="wheel_id" value="mod_wheel" />
-		<param name="port_name" value="analog_mod_wheel" />
+		<param name="port_name" value="panel:analog_mod_wheel" />
 		<group ref="wheel">
 			<bounds x="53" y="26" width="13" height="66" />
 		</group>
@@ -2308,7 +2308,7 @@
 			<bounds x="0" y="96.87737" width="35" height="4.44107" />
 		</element>
 		<param name="slider_id" value="volume" />
-		<param name="port_name" value="analog_volume" />
+		<param name="port_name" value="panel:analog_volume" />
 		<group ref="slider">
 			<bounds x="0" y="15" width="20" height="60" />
 		</group>
@@ -2321,10 +2321,10 @@
 		<element ref="text_L_patch_select">
 			<bounds x="0" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_1" inputtag="patch_select" inputmask="0x2">
+		<element ref="psel_9x12" id="patch_select_1" inputtag="panel:patch_select" inputmask="0x2">
 			<bounds x="0" y="55" width="9" height="12" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_0" inputtag="patch_select" inputmask="0x1">
+		<element ref="psel_9x12" id="patch_select_0" inputtag="panel:patch_select" inputmask="0x1">
 			<bounds x="15" y="55" width="9" height="12" />
 		</element>
 	</group>
@@ -2342,14 +2342,14 @@
 		<element ref="text_L_data_entry">
 			<bounds x="0" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="buttons_32" inputmask="0x80000000">
+		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="panel:buttons_32" inputmask="0x80000000">
 			<bounds x="0" y="60" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="buttons_32" inputmask="0x40000000">
+		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="panel:buttons_32" inputmask="0x40000000">
 			<bounds x="0" y="35" width="15.8" height="5" />
 		</element>
 		<param name="slider_id" value="data_entry" />
-		<param name="port_name" value="analog_data_entry" />
+		<param name="port_name" value="panel:analog_data_entry" />
 		<group ref="slider">
 			<bounds x="20" y="15" width="20" height="60" />
 		</group>
@@ -2542,12 +2542,12 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
 							media_change_notifiers[":cart"] = add_media_change_notifier(view, "media_cartridge", ":cart")
-							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "analog_pitch_bend", true, true))
-							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "analog_mod_wheel", true, false))
-							manager:addHandler(KeyboardHandler:create(view, "full_keyboard_background", "full_keyboard_key_", "key_", 3, 5))
+							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "panel:analog_pitch_bend", true, true))
+							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "panel:analog_mod_wheel", true, false))
+							manager:addHandler(KeyboardHandler:create(view, "full_keyboard_background", "full_keyboard_key_", "panel:key_", 3, 5))
 						end
 
 						if view.unqualified_name == "Compact" then
@@ -2557,11 +2557,11 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
-							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "analog_pitch_bend", true, true))
-							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "analog_mod_wheel", true, false))
-							manager:addHandler(KeyboardHandler:create(view, "compact_keyboard_background", "compact_keyboard_key_", "key_", 4, 3))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "panel:analog_pitch_bend", true, true))
+							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "panel:analog_mod_wheel", true, false))
+							manager:addHandler(KeyboardHandler:create(view, "compact_keyboard_background", "compact_keyboard_key_", "panel:key_", 4, 3))
 						end
 
 						if view.unqualified_name == "Panel" then
@@ -2571,8 +2571,8 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
 						end
 
 						if view.unqualified_name == "Tablet" then
@@ -2582,8 +2582,8 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
 						end
 					end
 				end

--- a/src/mame/layout/vfxsd.lay
+++ b/src/mame/layout/vfxsd.lay
@@ -287,7 +287,7 @@
 				<param name="n" start="~s~" increment="1" />
 				<param name="x" start="0" increment="342" />
 
-				<param name="input" value="vfd:vfd~n~" />
+				<param name="input" value="panel:vfd:vfd~n~" />
 				<group ref="vfd_cell">
 					<bounds x="~x~" y="~y~" width="342" height="572" />
 				</group>
@@ -1012,19 +1012,19 @@
 		<element ref="text_L_data_entry">
 			<bounds x="47.5" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="buttons_32" inputmask="0x80000000">
+		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="panel:buttons_32" inputmask="0x80000000">
 			<bounds x="47.5" y="60" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="buttons_32" inputmask="0x40000000">
+		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="panel:buttons_32" inputmask="0x40000000">
 			<bounds x="47.5" y="35" width="15.8" height="5" />
 		</element>
 		<param name="slider_id" value="volume" />
-		<param name="port_name" value="analog_volume" />
+		<param name="port_name" value="panel:analog_volume" />
 		<group ref="slider">
 			<bounds x="0" y="15" width="20" height="60" />
 		</group>
 		<param name="slider_id" value="data_entry" />
-		<param name="port_name" value="analog_data_entry" />
+		<param name="port_name" value="panel:analog_data_entry" />
 		<group ref="slider">
 			<bounds x="70" y="15" width="20" height="60" />
 		</group>
@@ -1082,64 +1082,64 @@
 		<group ref="vfd">
 			<bounds x="12" y="32.50936" width="221" height="18.48129" />
 		</group>
-		<element ref="button_15_8x5_screen" id="button_50__display_below_left" inputtag="buttons_32" inputmask="0x00040000">
+		<element ref="button_15_8x5_screen" id="button_50__display_below_left" inputtag="panel:buttons_32" inputmask="0x00040000">
 			<bounds x="60" y="65.5" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_44__display_below_middle" inputtag="buttons_32" inputmask="0x00001000">
+		<element ref="button_15_8x5_screen" id="button_44__display_below_middle" inputtag="panel:buttons_32" inputmask="0x00001000">
 			<bounds x="126" y="65.5" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_45__display_below_right" inputtag="buttons_32" inputmask="0x00002000">
+		<element ref="button_15_8x5_screen" id="button_45__display_below_right" inputtag="panel:buttons_32" inputmask="0x00002000">
 			<bounds x="192" y="65.5" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_58__display_above_left" inputtag="buttons_32" inputmask="0x04000000">
+		<element ref="button_15_8x5_screen" id="button_58__display_above_left" inputtag="panel:buttons_32" inputmask="0x04000000">
 			<bounds x="60" y="13" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_42__diplay_above_center" inputtag="buttons_32" inputmask="0x00000400">
+		<element ref="button_15_8x5_screen" id="button_42__diplay_above_center" inputtag="panel:buttons_32" inputmask="0x00000400">
 			<bounds x="126" y="13" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_screen" id="button_43__display_above_right" inputtag="buttons_32" inputmask="0x00000800">
+		<element ref="button_15_8x5_screen" id="button_43__display_above_right" inputtag="panel:buttons_32" inputmask="0x00000800">
 			<bounds x="193" y="13" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_52__cartbankset" inputtag="buttons_32" inputmask="0x00100000">
+		<element ref="button_15_8x10_light" id="button_52__cartbankset" inputtag="panel:buttons_32" inputmask="0x00100000">
 			<bounds x="0" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_53__sounds" inputtag="buttons_32" inputmask="0x00200000">
+		<element ref="button_15_8x10_light" id="button_53__sounds" inputtag="panel:buttons_32" inputmask="0x00200000">
 			<bounds x="15.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_54__presets" inputtag="buttons_32" inputmask="0x00400000">
+		<element ref="button_15_8x10_light" id="button_54__presets" inputtag="panel:buttons_32" inputmask="0x00400000">
 			<bounds x="31.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_light" id="button_51__seq" inputtag="buttons_32" inputmask="0x00080000">
+		<element ref="button_15_8x10_light" id="button_51__seq" inputtag="panel:buttons_32" inputmask="0x00080000">
 			<bounds x="47.4" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_55__0" inputtag="buttons_32" inputmask="0x00800000">
+		<element ref="button_15_8x10_medium" id="button_55__0" inputtag="panel:buttons_32" inputmask="0x00800000">
 			<bounds x="87" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_56__1" inputtag="buttons_32" inputmask="0x01000000">
+		<element ref="button_15_8x10_medium" id="button_56__1" inputtag="panel:buttons_32" inputmask="0x01000000">
 			<bounds x="102.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_57__2" inputtag="buttons_32" inputmask="0x02000000">
+		<element ref="button_15_8x10_medium" id="button_57__2" inputtag="panel:buttons_32" inputmask="0x02000000">
 			<bounds x="118.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_46__3" inputtag="buttons_32" inputmask="0x00004000">
+		<element ref="button_15_8x10_medium" id="button_46__3" inputtag="panel:buttons_32" inputmask="0x00004000">
 			<bounds x="134.4" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_47__4" inputtag="buttons_32" inputmask="0x00008000">
+		<element ref="button_15_8x10_medium" id="button_47__4" inputtag="panel:buttons_32" inputmask="0x00008000">
 			<bounds x="150.2" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_48__5" inputtag="buttons_32" inputmask="0x00010000">
+		<element ref="button_15_8x10_medium" id="button_48__5" inputtag="panel:buttons_32" inputmask="0x00010000">
 			<bounds x="166" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_49__6" inputtag="buttons_32" inputmask="0x00020000">
+		<element ref="button_15_8x10_medium" id="button_49__6" inputtag="panel:buttons_32" inputmask="0x00020000">
 			<bounds x="181.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_35__7" inputtag="buttons_32" inputmask="0x00000008">
+		<element ref="button_15_8x10_medium" id="button_35__7" inputtag="panel:buttons_32" inputmask="0x00000008">
 			<bounds x="197.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_34__8" inputtag="buttons_32" inputmask="0x00000004">
+		<element ref="button_15_8x10_medium" id="button_34__8" inputtag="panel:buttons_32" inputmask="0x00000004">
 			<bounds x="213.4" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_25__9" inputtag="buttons_0" inputmask="0x02000000">
+		<element ref="button_15_8x10_medium" id="button_25__9" inputtag="panel:buttons_0" inputmask="0x02000000">
 			<bounds x="229.2" y="82" width="15.8" height="10" />
 		</element>
 		<element name="lights" ref="light_15">
@@ -1421,124 +1421,124 @@
 		<element ref="text_L_programming">
 			<bounds x="120" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_29_replace_program" inputtag="buttons_0" inputmask="0x20000000">
+		<element ref="button_15_8x10_medium" id="button_29_replace_program" inputtag="panel:buttons_0" inputmask="0x20000000">
 			<bounds x="0" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_5_select_voice" inputtag="buttons_0" inputmask="0x00000020">
+		<element ref="button_15_8x10_medium" id="button_5_select_voice" inputtag="panel:buttons_0" inputmask="0x00000020">
 			<bounds x="120" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_9_copy" inputtag="buttons_0" inputmask="0x00000200">
+		<element ref="button_15_8x10_medium" id="button_9_copy" inputtag="panel:buttons_0" inputmask="0x00000200">
 			<bounds x="135.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_3_write" inputtag="buttons_0" inputmask="0x00000008">
+		<element ref="button_15_8x10_medium" id="button_3_write" inputtag="panel:buttons_0" inputmask="0x00000008">
 			<bounds x="151.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_8_compare" inputtag="buttons_0" inputmask="0x00000100">
+		<element ref="button_15_8x10_medium" id="button_8_compare" inputtag="panel:buttons_0" inputmask="0x00000100">
 			<bounds x="167.4" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_26_patch_select" inputtag="buttons_0" inputmask="0x04000000">
+		<element ref="button_15_8x5_dark" id="button_26_patch_select" inputtag="panel:buttons_0" inputmask="0x04000000">
 			<bounds x="0" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_27_midi" inputtag="buttons_0" inputmask="0x08000000">
+		<element ref="button_15_8x5_dark" id="button_27_midi" inputtag="panel:buttons_0" inputmask="0x08000000">
 			<bounds x="15.8" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_28_effects" inputtag="buttons_0" inputmask="0x10000000">
+		<element ref="button_15_8x5_dark" id="button_28_effects" inputtag="panel:buttons_0" inputmask="0x10000000">
 			<bounds x="31.6" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_39_key_zone" inputtag="buttons_32" inputmask="0x00000080">
+		<element ref="button_15_8x5_dark" id="button_39_key_zone" inputtag="panel:buttons_32" inputmask="0x00000080">
 			<bounds x="0" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_40_transpose" inputtag="buttons_32" inputmask="0x00000100">
+		<element ref="button_15_8x5_dark" id="button_40_transpose" inputtag="panel:buttons_32" inputmask="0x00000100">
 			<bounds x="15.8" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_41_release" inputtag="buttons_32" inputmask="0x00000200">
+		<element ref="button_15_8x5_dark" id="button_41_release" inputtag="panel:buttons_32" inputmask="0x00000200">
 			<bounds x="31.6" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_36_volume" inputtag="buttons_32" inputmask="0x00000010">
+		<element ref="button_15_8x5_dark" id="button_36_volume" inputtag="panel:buttons_32" inputmask="0x00000010">
 			<bounds x="0" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_37_pan" inputtag="buttons_32" inputmask="0x00000020">
+		<element ref="button_15_8x5_dark" id="button_37_pan" inputtag="panel:buttons_32" inputmask="0x00000020">
 			<bounds x="15.8" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_38_timbre" inputtag="buttons_32" inputmask="0x00000040">
+		<element ref="button_15_8x5_dark" id="button_38_timbre" inputtag="panel:buttons_32" inputmask="0x00000040">
 			<bounds x="31.6" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_4_wave" inputtag="buttons_0" inputmask="0x00000010">
+		<element ref="button_15_8x5_dark" id="button_4_wave" inputtag="panel:buttons_0" inputmask="0x00000010">
 			<bounds x="120" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_6_mod_mixer" inputtag="buttons_0" inputmask="0x00000040">
+		<element ref="button_15_8x5_dark" id="button_6_mod_mixer" inputtag="panel:buttons_0" inputmask="0x00000040">
 			<bounds x="135.8" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_2_program_control" inputtag="buttons_0" inputmask="0x00000004">
+		<element ref="button_15_8x5_dark" id="button_2_program_control" inputtag="panel:buttons_0" inputmask="0x00000004">
 			<bounds x="151.6" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_7_effects" inputtag="buttons_0" inputmask="0x00000080">
+		<element ref="button_15_8x5_dark" id="button_7_effects" inputtag="panel:buttons_0" inputmask="0x00000080">
 			<bounds x="167.4" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_11_pitch" inputtag="buttons_0" inputmask="0x00000800">
+		<element ref="button_15_8x5_dark" id="button_11_pitch" inputtag="panel:buttons_0" inputmask="0x00000800">
 			<bounds x="120" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_13_pitch_mod" inputtag="buttons_0" inputmask="0x00002000">
+		<element ref="button_15_8x5_dark" id="button_13_pitch_mod" inputtag="panel:buttons_0" inputmask="0x00002000">
 			<bounds x="135.8" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_15_filters" inputtag="buttons_0" inputmask="0x00008000">
+		<element ref="button_15_8x5_dark" id="button_15_filters" inputtag="panel:buttons_0" inputmask="0x00008000">
 			<bounds x="151.6" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_17_output" inputtag="buttons_0" inputmask="0x00020000">
+		<element ref="button_15_8x5_dark" id="button_17_output" inputtag="panel:buttons_0" inputmask="0x00020000">
 			<bounds x="167.4" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_10_lfo" inputtag="buttons_0" inputmask="0x00000400">
+		<element ref="button_15_8x5_dark" id="button_10_lfo" inputtag="panel:buttons_0" inputmask="0x00000400">
 			<bounds x="120" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_12_env1" inputtag="buttons_0" inputmask="0x00001000">
+		<element ref="button_15_8x5_dark" id="button_12_env1" inputtag="panel:buttons_0" inputmask="0x00001000">
 			<bounds x="135.8" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_14_env2" inputtag="buttons_0" inputmask="0x00004000">
+		<element ref="button_15_8x5_dark" id="button_14_env2" inputtag="panel:buttons_0" inputmask="0x00004000">
 			<bounds x="151.6" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_16_env3" inputtag="buttons_0" inputmask="0x00010000">
+		<element ref="button_15_8x5_dark" id="button_16_env3" inputtag="panel:buttons_0" inputmask="0x00010000">
 			<bounds x="167.4" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_30_1_6" inputtag="buttons_0" inputmask="0x40000000">
+		<element ref="button_15_8x10_medium" id="button_30_1_6" inputtag="panel:buttons_0" inputmask="0x40000000">
 			<bounds x="15.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_31_7_12" inputtag="buttons_0" inputmask="0x80000000">
+		<element ref="button_15_8x10_medium" id="button_31_7_12" inputtag="panel:buttons_0" inputmask="0x80000000">
 			<bounds x="31.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_19_rec" inputtag="buttons_0" inputmask="0x00080000">
+		<element ref="button_15_8x10_medium" id="button_19_rec" inputtag="panel:buttons_0" inputmask="0x00080000">
 			<bounds x="60" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_22_stop_cont" inputtag="buttons_0" inputmask="0x00400000">
+		<element ref="button_15_8x10_medium" id="button_22_stop_cont" inputtag="panel:buttons_0" inputmask="0x00400000">
 			<bounds x="75.8" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x10_medium" id="button_23_play" inputtag="buttons_0" inputmask="0x00800000">
+		<element ref="button_15_8x10_medium" id="button_23_play" inputtag="panel:buttons_0" inputmask="0x00800000">
 			<bounds x="91.6" y="82" width="15.8" height="10" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_32_click" inputtag="buttons_32" inputmask="0x00000001">
+		<element ref="button_15_8x5_dark" id="button_32_click" inputtag="panel:buttons_32" inputmask="0x00000001">
 			<bounds x="60" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_18_seq_control" inputtag="buttons_0" inputmask="0x00040000">
+		<element ref="button_15_8x5_dark" id="button_18_seq_control" inputtag="panel:buttons_0" inputmask="0x00040000">
 			<bounds x="75.8" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_33_locate" inputtag="buttons_32" inputmask="0x00000002">
+		<element ref="button_15_8x5_dark" id="button_33_locate" inputtag="panel:buttons_32" inputmask="0x00000002">
 			<bounds x="91.6" y="62" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_60_song" inputtag="buttons_32" inputmask="0x10000000">
+		<element ref="button_15_8x5_dark" id="button_60_song" inputtag="panel:buttons_32" inputmask="0x10000000">
 			<bounds x="60" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_59_seq" inputtag="buttons_32" inputmask="0x08000000">
+		<element ref="button_15_8x5_dark" id="button_59_seq" inputtag="panel:buttons_32" inputmask="0x08000000">
 			<bounds x="75.8" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_61_track" inputtag="buttons_32" inputmask="0x20000000">
+		<element ref="button_15_8x5_dark" id="button_61_track" inputtag="panel:buttons_32" inputmask="0x20000000">
 			<bounds x="91.6" y="42" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_light" id="button_20_master" inputtag="buttons_0" inputmask="0x00100000">
+		<element ref="button_15_8x5_light" id="button_20_master" inputtag="panel:buttons_0" inputmask="0x00100000">
 			<bounds x="60" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_light" id="button_21_storage" inputtag="buttons_0" inputmask="0x00200000">
+		<element ref="button_15_8x5_light" id="button_21_storage" inputtag="panel:buttons_0" inputmask="0x00200000">
 			<bounds x="75.8" y="22" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_light" id="button_24_midi_control" inputtag="buttons_0" inputmask="0x01000000">
+		<element ref="button_15_8x5_light" id="button_24_midi_control" inputtag="panel:buttons_0" inputmask="0x01000000">
 			<bounds x="91.69" y="22" width="15.8" height="5" />
 		</element>
 		<element name="lights" ref="light_5">
@@ -1658,19 +1658,19 @@
 		<element ref="text_L_mod">
 			<bounds x="66.5" y="93.87737" width="15" height="4.44107" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_1" inputtag="patch_select" inputmask="0x2">
+		<element ref="psel_9x12" id="patch_select_1" inputtag="panel:patch_select" inputmask="0x2">
 			<bounds x="6" y="2" width="9" height="12" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_0" inputtag="patch_select" inputmask="0x1">
+		<element ref="psel_9x12" id="patch_select_0" inputtag="panel:patch_select" inputmask="0x1">
 			<bounds x="21" y="2" width="9" height="12" />
 		</element>
 		<param name="wheel_id" value="pitch_bend" />
-		<param name="port_name" value="analog_pitch_bend" />
+		<param name="port_name" value="panel:analog_pitch_bend" />
 		<group ref="wheel">
 			<bounds x="29.5" y="26" width="13" height="66" />
 		</group>
 		<param name="wheel_id" value="mod_wheel" />
-		<param name="port_name" value="analog_mod_wheel" />
+		<param name="port_name" value="panel:analog_mod_wheel" />
 		<group ref="wheel">
 			<bounds x="66.5" y="26" width="13" height="66" />
 		</group>
@@ -2202,19 +2202,19 @@
 		<element ref="text_L_mod">
 			<bounds x="53" y="93.87737" width="15" height="4.44107" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_1" inputtag="patch_select" inputmask="0x2">
+		<element ref="psel_9x12" id="patch_select_1" inputtag="panel:patch_select" inputmask="0x2">
 			<bounds x="6" y="2" width="9" height="12" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_0" inputtag="patch_select" inputmask="0x1">
+		<element ref="psel_9x12" id="patch_select_0" inputtag="panel:patch_select" inputmask="0x1">
 			<bounds x="21" y="2" width="9" height="12" />
 		</element>
 		<param name="wheel_id" value="pitch_bend" />
-		<param name="port_name" value="analog_pitch_bend" />
+		<param name="port_name" value="panel:analog_pitch_bend" />
 		<group ref="wheel">
 			<bounds x="20" y="26" width="13" height="66" />
 		</group>
 		<param name="wheel_id" value="mod_wheel" />
-		<param name="port_name" value="analog_mod_wheel" />
+		<param name="port_name" value="panel:analog_mod_wheel" />
 		<group ref="wheel">
 			<bounds x="53" y="26" width="13" height="66" />
 		</group>
@@ -2531,7 +2531,7 @@
 			<bounds x="0" y="96.87737" width="35" height="4.44107" />
 		</element>
 		<param name="slider_id" value="volume" />
-		<param name="port_name" value="analog_volume" />
+		<param name="port_name" value="panel:analog_volume" />
 		<group ref="slider">
 			<bounds x="0" y="15" width="20" height="60" />
 		</group>
@@ -2544,10 +2544,10 @@
 		<element ref="text_L_patch_select">
 			<bounds x="0" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_1" inputtag="patch_select" inputmask="0x2">
+		<element ref="psel_9x12" id="patch_select_1" inputtag="panel:patch_select" inputmask="0x2">
 			<bounds x="0" y="55" width="9" height="12" />
 		</element>
-		<element ref="psel_9x12" id="patch_select_0" inputtag="patch_select" inputmask="0x1">
+		<element ref="psel_9x12" id="patch_select_0" inputtag="panel:patch_select" inputmask="0x1">
 			<bounds x="15" y="55" width="9" height="12" />
 		</element>
 	</group>
@@ -2565,14 +2565,14 @@
 		<element ref="text_L_data_entry">
 			<bounds x="0" y="96.87737" width="35" height="4.44107" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="buttons_32" inputmask="0x80000000">
+		<element ref="button_15_8x5_dark" id="button_63__decrement" inputtag="panel:buttons_32" inputmask="0x80000000">
 			<bounds x="0" y="60" width="15.8" height="5" />
 		</element>
-		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="buttons_32" inputmask="0x40000000">
+		<element ref="button_15_8x5_dark" id="button_62__increment" inputtag="panel:buttons_32" inputmask="0x40000000">
 			<bounds x="0" y="35" width="15.8" height="5" />
 		</element>
 		<param name="slider_id" value="data_entry" />
-		<param name="port_name" value="analog_data_entry" />
+		<param name="port_name" value="panel:analog_data_entry" />
 		<group ref="slider">
 			<bounds x="20" y="15" width="20" height="60" />
 		</group>
@@ -2771,13 +2771,13 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
 							media_change_notifiers[":cart"] = add_media_change_notifier(view, "media_cartridge", ":cart")
 							media_change_notifiers[":wd1772:0:35dd"] = add_media_change_notifier(view, "media_floppy", ":wd1772:0:35dd")
-							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "analog_pitch_bend", true, true))
-							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "analog_mod_wheel", true, false))
-							manager:addHandler(KeyboardHandler:create(view, "full_keyboard_background", "full_keyboard_key_", "key_", 3, 5))
+							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "panel:analog_pitch_bend", true, true))
+							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "panel:analog_mod_wheel", true, false))
+							manager:addHandler(KeyboardHandler:create(view, "full_keyboard_background", "full_keyboard_key_", "panel:key_", 3, 5))
 						end
 
 						if view.unqualified_name == "Compact" then
@@ -2787,11 +2787,11 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
-							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "analog_pitch_bend", true, true))
-							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "analog_mod_wheel", true, false))
-							manager:addHandler(KeyboardHandler:create(view, "compact_keyboard_background", "compact_keyboard_key_", "key_", 4, 3))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "wheel_pitch_bend", "wheel_knob_pitch_bend", "panel:analog_pitch_bend", true, true))
+							manager:addHandler(SliderHandler:create(view, "wheel_mod_wheel", "wheel_knob_mod_wheel", "panel:analog_mod_wheel", true, false))
+							manager:addHandler(KeyboardHandler:create(view, "compact_keyboard_background", "compact_keyboard_key_", "panel:key_", 4, 3))
 						end
 
 						if view.unqualified_name == "Panel" then
@@ -2801,8 +2801,8 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
 						end
 
 						if view.unqualified_name == "Tablet" then
@@ -2812,8 +2812,8 @@
 							local manager = PointerManager:create(view)
 							pointer_managers[view_name] = manager
 
-							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "analog_volume"))
-							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "analog_data_entry"))
+							manager:addHandler(SliderHandler:create(view, "slider_volume", "slider_knob_volume", "panel:analog_volume"))
+							manager:addHandler(SliderHandler:create(view, "slider_data_entry", "slider_knob_data_entry", "panel:analog_data_entry"))
 						end
 					end
 				end


### PR DESCRIPTION
Since the recent output_finder changes, output names are now resolved relative to the device that creates them. When the layouts are loaded by the esqpanel device, but the outputs created by the esqvfd device contained within it, then for the layout to find the outputs it must use a qualified name - "vfd:vfd~n~".

But if we have to use qualified names for some things, we might as well use them for more things throughout the keyboard-specific layouts (vfx, vfxsd, sd1, sd132): such as for finding ioports that might not be on the device that is loading the layout.

This allows us to move the setting of these layouts from the esqpanel device (from which ioports can be resolved without a qualified name when _it_ loads the layouts) to the keyoard class (`esq5505_state')'s member functions that configure each keyboard - since from there, the qualified names allow us to find not only outputs for use by the esqvfd device, but also io ports that are on the esqpanel device.

This in turn allows us to get rid of passing a "panel type" in to the esqpanel device so that it would set the correct layout - it no longer has to do that.

We can also now set a default layout on the esqvfd2x40_vfx device, just as on the other esqvfd devilces, for completeless if nothing else.

All in all a lot simpler and cleaner, I think.

Code updated, and layouts regenerated accordingly.