### PR TITLE
esqvfd.cpp, esq1by22_eps.lay: Add an Ensoniq EPS family VFD display layout

### DIFF
--- a/src/mame/ensoniq/esqvfd.cpp
+++ b/src/mame/ensoniq/esqvfd.cpp
@@ -8,7 +8,7 @@
 #include "emu.h"
 #include "esqvfd.h"
 
-#include "esq1by22.lh"
+#include "esq1by22_eps.lh"
 #include "esq2by40.lh"
 #include "esq2by40_vfx.lh"
 
@@ -480,7 +480,7 @@ void esq2x40_vfx_device::update_display()
 
 void esq1x22_device::device_add_mconfig(machine_config &config)
 {
-	config.set_default_layout(layout_esq1by22);
+	config.set_default_layout(layout_esq1by22_eps);
 }
 
 

--- a/src/mame/layout/esq1by22_eps.lay
+++ b/src/mame/layout/esq1by22_eps.lay
@@ -1,0 +1,241 @@
+<?xml version="1.0"?>
+<!--
+license:CC0-1.0
+-->
+<!-- 2026-06-09: Initial version based on `esq2by40_vfx.lay`.  [Christian Brunschen] -->
+
+<mamelayout version="2">
+
+  <!-- The VFD elements -->
+  <element name="segments" defstate="0">
+		<led14seg>
+			<color red="0.45" green="1.0" blue="0.95" />
+		</led14seg>
+  </element>
+
+  <element name="dot" defstate="0">
+		<disk statemask="0x4000" state="0"><color red="0.06" green="0.12" blue="0.10" /></disk>
+		<disk statemask="0x4000" state="0x4000"><color red="0.45" green="1.00" blue="0.95" /></disk>
+  </element>
+
+  <element name="underline" defstate="0">
+		<rect statemask="0x8000" state="0"><color red="0.06" green="0.12" blue="0.10" /></rect>
+		<rect statemask="0x8000" state="0x8000"><color red="0.45" green="1.00" blue="0.95" /></rect>
+  </element>
+
+  <group name="char_cell">
+		<bounds x="0" y="0" width="342" height="572" />
+		<element ref="segments" name="~input~"><bounds x="50" y="69" width="214" height="311" /></element>
+		<element ref="dot" name="~input~"><bounds x="253" y="337" width="42" height="42" /></element>
+		<element ref="underline" name="~input~"><bounds x="43" y="441" width="183" height="25" /></element>
+  </group>
+
+	<!-- Text elements -->
+	<element name="text_LOAD_i">
+		<rect state="0"><color red="0.06" green="0.12" blue="0.10" /></rect>
+		<rect state="1"><color red="0.45" green="1.00" blue="0.95" /></rect>
+		<text string="LOAD"><color red="0" green="0" blue="0" /></text>
+	</element>
+
+	<element name="text_INST">
+		<text string="INST" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="INST" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_MIDI">
+		<text string="MIDI" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="MIDI" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_SYSTEM">
+		<text string="SYSTEM" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="SYSTEM" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_LAYER">
+		<text string="LAYER" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="LAYER" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_STOP">
+		<text string="STOP" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="STOP" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_PLAY">
+		<text string="PLAY" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="PLAY" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_REC_i">
+		<rect state="0"><color red="0.06" green="0.12" blue="0.10" /></rect>
+		<rect state="1"><color red="0.45" green="1.00" blue="0.95" /></rect>
+		<text string="REC"><color red="0" green="0" blue="0" /></text>
+	</element>
+
+	<element name="text_ODUB_i">
+		<rect state="0"><color red="0.06" green="0.12" blue="0.10" /></rect>
+		<rect state="1"><color red="0.45" green="1.00" blue="0.95" /></rect>
+		<text string="ODUB"><color red="0" green="0" blue="0" /></text>
+	</element>
+
+	<element name="text_ENV">
+		<text string="ENV" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="ENV" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_CMD_i">
+		<rect state="0"><color red="0.06" green="0.12" blue="0.10" /></rect>
+		<rect state="1"><color red="0.45" green="1.00" blue="0.95" /></rect>
+		<text string="CMD"><color red="0" green="0" blue="0" /></text>
+	</element>
+
+	<element name="text_SEQ">
+		<text string="SEQ" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="SEQ" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_SONG">
+		<text string="SONG" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="SONG" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_PITCH">
+		<text string="PITCH" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="PITCH" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_FILTER">
+		<text string="FILTER" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="FILTER" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_REP">
+		<text string="REP" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="REP" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_STEP">
+		<text string="STEP" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="STEP" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_AMP">
+		<text string="AMP" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="AMP" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_EDIT_i">
+		<rect state="0"><color red="0.06" green="0.12" blue="0.10" /></rect>
+		<rect state="1"><color red="0.45" green="1.00" blue="0.95" /></rect>
+		<text string="EDIT"><color red="0" green="0" blue="0" /></text>
+	</element>
+
+	<element name="text_MACRO">
+		<text string="MACRO" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="MACRO" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_BANK">
+		<text string="BANK" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="BANK" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_LFO">
+		<text string="LFO" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="LFO" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_WAVE">
+		<text string="WAVE" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="WAVE" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_CLOCK">
+		<text string="CLOCK" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="CLOCK" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_BEAT">
+		<text string="BEAT" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="BEAT" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_BAR">
+		<text string="BAR" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="BAR" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<element name="text_TRACK">
+		<text string="TRACK" state="0"><color red="0.06" green="0.12" blue="0.10" /></text>
+		<text string="TRACK" state="1"><color red="0.45" green="1.00" blue="0.95" /></text>
+	</element>
+
+	<!-- Background -->
+  <element name="vfd_background">
+		<rect><color red="0.0" green="0.0" blue="0.0" /></rect>
+  </element>
+
+	<group name="chars">
+		<!-- Character elements -->
+		<repeat count="1">
+			<param name="s" start="0" increment="40" />
+			<param name="y" start="0" increment="572" />
+			<repeat count="22">
+				<param name="n" start="~s~" increment="1" />
+				<param name="x" start="0" increment="342" />
+
+				<param name="input" value="vfd~n~" />
+				<group ref="char_cell">
+					<bounds x="~x~" y="~y~" width="342" height="572" />
+				</group>
+
+			</repeat>
+		</repeat>
+	</group>
+
+	<view name="Default Layout">
+
+		<element ref="vfd_background">
+			<bounds x="0" y="0" width="122" height="24.274854" />
+		</element>
+
+		<!-- Text Elements -->
+		<element ref="text_LOAD_i"><bounds x="1" y="1" width="10.52832" height="3.5" /></element>
+		<element ref="text_INST"><bounds x="12.52832" y="1" width="8.80663" height="3.5" /></element>
+		<element ref="text_MIDI"><bounds x="22.33495" y="1" width="8.161" height="3.5" /></element>
+		<element ref="text_SYSTEM"><bounds x="31.49595" y="1" width="15.89725" height="3.5" /></element>
+		<element ref="text_LAYER"><bounds x="48.3932" y="1" width="12.39159" height="3.5" /></element>
+		<element ref="text_STOP"><bounds x="110.54342" y="1" width="10.45658" height="3.5" /></element>
+		<element ref="text_PLAY"><bounds x="99.94391" y="1" width="9.59951" height="3.5" /></element>
+		<element ref="text_REC_i"><bounds x="90.78101" y="1" width="8.16289" height="3.5" /></element>
+		<element ref="text_ODUB_i"><bounds x="78.61084" y="1" width="11.17017" height="3.5" /></element>
+		<element ref="text_ENV"><bounds x="69.66127" y="1" width="7.94957" height="3.5" /></element>
+		<element ref="text_CMD_i"><bounds x="1" y="4.7" width="8.80475" height="3.5" /></element>
+		<element ref="text_SEQ"><bounds x="10.80475" y="4.7" width="8.16478" height="3.5" /></element>
+		<element ref="text_SONG"><bounds x="19.96953" y="4.7" width="11.38538" height="3.5" /></element>
+		<element ref="text_PITCH"><bounds x="32.35491" y="4.7" width="11.59871" height="3.5" /></element>
+		<element ref="text_FILTER"><bounds x="44.95361" y="4.7" width="13.03155" height="3.5" /></element>
+		<element ref="text_REP"><bounds x="113.05043" y="4.7" width="7.94957" height="3.5" /></element>
+		<element ref="text_STEP"><bounds x="101.95254" y="4.7" width="10.0979" height="3.5" /></element>
+		<element ref="text_SEQ"><bounds x="92.78776" y="4.7" width="8.16478" height="3.5" /></element>
+		<element ref="text_SONG"><bounds x="80.40237" y="4.7" width="11.38538" height="3.5" /></element>
+		<element ref="text_AMP"><bounds x="71.02427" y="4.7" width="8.3781" height="3.5" /></element>
+		<element ref="text_EDIT_i"><bounds x="1" y="8.4" width="8.80663" height="3.5" /></element>
+		<element ref="text_MACRO"><bounds x="10.80663" y="8.4" width="14.39078" height="3.5" /></element>
+		<element ref="text_BANK"><bounds x="26.19741" y="8.4" width="10.52832" height="3.5" /></element>
+		<element ref="text_LFO"><bounds x="37.72573" y="8.4" width="7.51915" height="3.5" /></element>
+		<element ref="text_WAVE"><bounds x="46.24488" y="8.4" width="11.10221" height="3.5" /></element>
+		<element ref="text_CLOCK"><bounds x="107.67961" y="8.4" width="13.32039" height="3.5" /></element>
+		<element ref="text_BEAT"><bounds x="96.86866" y="8.4" width="9.81095" height="3.5" /></element>
+		<element ref="text_BAR"><bounds x="87.91909" y="8.4" width="7.94957" height="3.5" /></element>
+		<element ref="text_TRACK"><bounds x="73.8158" y="8.4" width="13.10329" height="3.5" /></element>
+
+		<!-- Characters -->
+		<group ref="chars">
+			<bounds x="0" y="16" width="122" height="9.274854" />
+		</group>
+
+	</view>
+
+</mamelayout>


### PR DESCRIPTION
Adds the individual word segments above the 1x22 character display area, as seen in pictures of EPS family keyboards.

<img width="900" height="361" alt="eps16+display" src="https://github.com/user-attachments/assets/ebb35e38-465d-4ce1-9b03-f25c813810e4" />

Sizes & placement are approximate, generated based on the Arimo font rather than measurements on an actual display.

None of these new segments are connected to any outputs this time, but this gives at least a somewhat better visual representation.
