### PR TITLE
`emuopts,machine,driver,video,osdcore,luascript,cucaracha`: allow more flexible time synchronization and frame rate

### DIFF
--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -1873,6 +1873,23 @@ Core Performance Options
 
             mame gradius4 -frameskip 2
 
+.. _mame-commandline-screenless-framerate:
+
+**-screenless_framerate** *<frames per second>*
+
+    Specifies the frame rate to use for devices that do not have a screen.
+
+    Set to `0` (in fact any value less than `1`) to use the device's default,
+    usually MAME's built-on default of 60 frames per second.
+
+    The default value is **-screenless_framerate 0**, i.e., use the default
+		screenless framerate.
+
+    Example:
+        .. code-block:: bash
+
+            mame sd132 -screenless_framerate 12
+
 .. _mame-commandline-secondstorun:
 
 **-seconds_to_run** / **-str** *<seconds>*

--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -228,22 +228,22 @@ overwritten.
             <?xml version="1.0"?>
             <!DOCTYPE mame [
             <!ELEMENT mame (machine+)>
-	            <!ATTLIST mame build CDATA #IMPLIED>
-	            <!ATTLIST mame debug (yes|no) "no">
-	            <!ATTLIST mame mameconfig CDATA #REQUIRED>
-	            <!ELEMENT machine (description, year?, manufacturer?, biosset*, rom*, disk*, device_ref*, sample*, chip*, display*, sound?, input?, dipswitch*, configuration*, port*, adjuster*, driver?, feature*, device*, slot*, softwarelist*, ramoption*)>
-		            <!ATTLIST machine name CDATA #REQUIRED>
-		            <!ATTLIST machine sourcefile CDATA #IMPLIED>
+              <!ATTLIST mame build CDATA #IMPLIED>
+              <!ATTLIST mame debug (yes|no) "no">
+              <!ATTLIST mame mameconfig CDATA #REQUIRED>
+              <!ELEMENT machine (description, year?, manufacturer?, biosset*, rom*, disk*, device_ref*, sample*, chip*, display*, sound?, input?, dipswitch*, configuration*, port*, adjuster*, driver?, feature*, device*, slot*, softwarelist*, ramoption*)>
+                <!ATTLIST machine name CDATA #REQUIRED>
+                <!ATTLIST machine sourcefile CDATA #IMPLIED>
             ...
             <mame build="0.216 (mame0216-154-gabddfb0404c-dirty)" debug="no" mameconfig="10">
-            	<machine name="galaxian" sourcefile="galaxian.cpp">
-		            <description>Galaxian (Namco set 1)</description>
-		            <year>1979</year>
-		            <manufacturer>Namco</manufacturer>
+              <machine name="galaxian" sourcefile="galaxian.cpp">
+                <description>Galaxian (Namco set 1)</description>
+                <year>1979</year>
+                <manufacturer>Namco</manufacturer>
                     ...
-            	<machine name="z80" sourcefile="src/devices/cpu/z80/z80.cpp" isdevice="yes" runnable="no">
-		            <description>Zilog Z80</description>
-	        </machine>
+              <machine name="z80" sourcefile="src/devices/cpu/z80/z80.cpp" isdevice="yes" runnable="no">
+                <description>Zilog Z80</description>
+          </machine>
             </mame>
 
 .. Tip:: Output from this command is typically more useful if redirected to
@@ -597,25 +597,25 @@ overwritten.
             <?xml version="1.0"?>
             <!DOCTYPE softwarelists [
             <!ELEMENT softwarelists (softwarelist*)>
-	            <!ELEMENT softwarelist (software+)>
-		            <!ATTLIST softwarelist name CDATA #REQUIRED>
-		            <!ATTLIST softwarelist description CDATA #IMPLIED>
-		            <!ELEMENT software (description, year, publisher, info*, sharedfeat*, part*)>
+              <!ELEMENT softwarelist (software+)>
+                <!ATTLIST softwarelist name CDATA #REQUIRED>
+                <!ATTLIST softwarelist description CDATA #IMPLIED>
+                <!ELEMENT software (description, year, publisher, info*, sharedfeat*, part*)>
                     ...
             <softwarelists>
-	            <softwarelist name="coco_cart" description="Tandy Radio Shack Color Computer cartridges">
-		            <software name="7cardstd">
-			            <description>7 Card Stud</description>
-			            <year>1983</year>
-			            <publisher>Tandy</publisher>
-			            <info name="developer" value="Intelligent Software"/>
-			            <info name="serial" value="26-3074"/>
-			            <part name="cart" interface="coco_cart">
-				            <dataarea name="rom" size="8192">
-					            <rom name="7 card stud (1983) (26-3074) (intelligent software).rom" size="8192" crc="f38d8c97" sha1="5cfcb699ce09840dbb52714c8d91b3d86d3a86c3"/>
-				            </dataarea>
-			            </part>
-		            </software>
+              <softwarelist name="coco_cart" description="Tandy Radio Shack Color Computer cartridges">
+                <software name="7cardstd">
+                  <description>7 Card Stud</description>
+                  <year>1983</year>
+                  <publisher>Tandy</publisher>
+                  <info name="developer" value="Intelligent Software"/>
+                  <info name="serial" value="26-3074"/>
+                  <part name="cart" interface="coco_cart">
+                    <dataarea name="rom" size="8192">
+                      <rom name="7 card stud (1983) (26-3074) (intelligent software).rom" size="8192" crc="f38d8c97" sha1="5cfcb699ce09840dbb52714c8d91b3d86d3a86c3"/>
+                    </dataarea>
+                  </part>
+                </software>
                     ...
 
 .. _mame-commandline-verifysoftware:
@@ -653,22 +653,22 @@ overwritten.
             <?xml version="1.0"?>
             <!DOCTYPE softwarelists [
             <!ELEMENT softwarelists (softwarelist*)>
-	            <!ELEMENT softwarelist (software+)>
-		            <!ATTLIST softwarelist name CDATA #REQUIRED>
-		            <!ATTLIST softwarelist description CDATA #IMPLIED>
-		            <!ELEMENT software (description, year, publisher, info*, sharedfeat*, part*)>
-			            <!ATTLIST software name CDATA #REQUIRED>
-			            <!ATTLIST software cloneof CDATA #IMPLIED>
-			            <!ATTLIST software supported (yes|partial|no) "yes">
-			            <!ELEMENT description (#PCDATA)>
-			            <!ELEMENT year (#PCDATA)>
-			            <!ELEMENT publisher (#PCDATA)>
-			            <!ELEMENT info EMPTY>
-				            <!ATTLIST info name CDATA #REQUIRED>
-				            <!ATTLIST info value CDATA #IMPLIED>
-			            <!ELEMENT sharedfeat EMPTY>
-				            <!ATTLIST sharedfeat name CDATA #REQUIRED>
-				            <!ATTLIST sharedfeat value CDATA #IMPLIED>
+              <!ELEMENT softwarelist (software+)>
+                <!ATTLIST softwarelist name CDATA #REQUIRED>
+                <!ATTLIST softwarelist description CDATA #IMPLIED>
+                <!ELEMENT software (description, year, publisher, info*, sharedfeat*, part*)>
+                  <!ATTLIST software name CDATA #REQUIRED>
+                  <!ATTLIST software cloneof CDATA #IMPLIED>
+                  <!ATTLIST software supported (yes|partial|no) "yes">
+                  <!ELEMENT description (#PCDATA)>
+                  <!ELEMENT year (#PCDATA)>
+                  <!ELEMENT publisher (#PCDATA)>
+                  <!ELEMENT info EMPTY>
+                    <!ATTLIST info name CDATA #REQUIRED>
+                    <!ATTLIST info value CDATA #IMPLIED>
+                  <!ELEMENT sharedfeat EMPTY>
+                    <!ATTLIST sharedfeat name CDATA #REQUIRED>
+                    <!ATTLIST sharedfeat value CDATA #IMPLIED>
                         ...
 
 .. _mame-commandline-verifysoftlist:
@@ -1978,6 +1978,26 @@ Core Performance Options
         .. code-block:: bash
 
             mame pacman -refreshspeed
+
+.. _mame-commandline-sync-interval:
+
+**-sync_interval** *<interval>*
+
+    Specify an explicit interval between attempts to synchronize emulated and
+    real time (instead of synchronizing and maybe throttling once per frame),
+    according to the current throtting and speed settings, in microseconds of
+    simulated time: that is, after approximately each *<interval>* microseconds
+    of elapsed simulated time, try to synchronize simulated and real time.
+
+    An *<interval>* of ``0`` disables this, letting synchronization happen
+    once per frame.
+
+    The default is ``0``.
+
+    Example:,
+        .. code-block:: bash
+
+            mame sd132 -sync_interval 1000
 
 .. _mame-commandline-numprocessors:
 

--- a/docs/source/commandline/commandline-index.rst
+++ b/docs/source/commandline/commandline-index.rst
@@ -149,6 +149,7 @@ Core Performance Options
 | :ref:`[no]sleep <mame-commandline-nosleep>`
 | :ref:`speed <mame-commandline-speed>`
 | :ref:`[no]refreshspeed <mame-commandline-norefreshspeed>`
+| :ref:`sync_interval <mame-commandline-sync-interval>`
 | :ref:`numprocessors <mame-commandline-numprocessors>`
 | :ref:`bench <mame-commandline-bench>`
 | :ref:`[no]lowlatency <mame-commandline-lowlatency>`

--- a/docs/source/commandline/commandline-index.rst
+++ b/docs/source/commandline/commandline-index.rst
@@ -143,6 +143,7 @@ Core Performance Options
 
 | :ref:`[no]autoframeskip <mame-commandline-noautoframeskip>`
 | :ref:`frameskip <mame-commandline-frameskip>`
+| :ref:`screenless_framerate <mame-commandline-screenless-framerate>`
 | :ref:`seconds_to_run <mame-commandline-secondstorun>`
 | :ref:`[no]throttle <mame-commandline-nothrottle>`
 | :ref:`[no]sleep <mame-commandline-nosleep>`

--- a/docs/source/luascript/ref-core.rst
+++ b/docs/source/luascript/ref-core.rst
@@ -372,6 +372,14 @@ video.frameskip (read/write)
     The number of emulated video frames to skip drawing out of every twelve, or
     -1 to automatically adjust the number of frames to skip to maintain the
     target emulation speed.
+video.screenless_framerate (read/write)
+    The frame rate to use when the emulated machine does not have a screen.
+    Set `0` (in fact, any value less than `1`) to use the device's default,
+    usually MAME's default of 60 frames per second.
+    
+    Corresponds to the
+    :ref:`screenless_framerate <mame-commandline-screenless-framerate>` command
+    line option, but can override its value at runtime.
 video.speed_percent (read-only)
     The current emulated speed as a percentage of the full speed adjusted by the
     speed factor.

--- a/docs/source/luascript/ref-core.rst
+++ b/docs/source/luascript/ref-core.rst
@@ -277,6 +277,12 @@ machine.options (read-only)
     emulation session.
 machine.samplerate (read-only)
     The output audio sample rate in Hertz.
+machine.sync_interval
+    Attempt to synchronize simulated time with real time at an interval of
+    this many microseconds of simulated time, independent of frame rate.
+    Set to `0` to disable. Corresponds to the
+    :ref:`sync_interval <mame-commandline-sync-interval>` command line option,
+    but can override its value at runtime.
 machine.paused (read-only)
     A Boolean indicating whether emulation is not currently running, usually
     because the session has been paused or the emulated system has not completed
@@ -381,7 +387,7 @@ video.screenless_framerate (read/write)
     :ref:`screenless_framerate <mame-commandline-screenless-framerate>` command
     line option, but can override its value at runtime.
 video.speed_percent (read-only)
-    The current emulated speed as a percentage of the full speed adjusted by the
+    The current emulated speed as a percentage ofma the full speed adjusted by the
     speed factor.
 video.effective_frameskip (read-only)
     The number of emulated frames that are skipped out of every twelve.

--- a/src/emu/driver.cpp
+++ b/src/emu/driver.cpp
@@ -11,6 +11,7 @@
 #include "emu.h"
 #include "image.h"
 #include "drivenum.h"
+#include "screen.h"
 #include "tilemap.h"
 
 
@@ -253,6 +254,17 @@ void driver_device::device_reset_after_children()
 }
 
 
+//-------------------------------------------------
+//  default_screenless_frame_period - returns
+//  the frame rate to use for screenless devices.
+//  Override in subclasses that need something other
+//  than the default 60 frames per second.
+//-------------------------------------------------
+
+attoseconds_t driver_device::default_screenless_frame_period() const
+{
+	return screen_device::DEFAULT_FRAME_PERIOD.as_attoseconds();
+}
 
 //**************************************************************************
 //  INTERRUPT GENERATION CALLBACK HELPERS

--- a/src/emu/driver.h
+++ b/src/emu/driver.h
@@ -142,6 +142,9 @@ public:
 
 	virtual std::vector<std::string> searchpath() const override;
 
+	// support for screenless devices with non-default frame rates
+	virtual attoseconds_t default_screenless_frame_period() const;
+
 protected:
 	// helpers called at startup
 	virtual void driver_start();

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -96,6 +96,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_REFRESHSPEED ";rs",                         "0",         core_options::option_type::BOOLEAN,    "automatically adjust emulation speed to keep the emulated refresh rate slower than the host screen" },
 	{ OPTION_LOWLATENCY ";lolat",                        "0",         core_options::option_type::BOOLEAN,    "draws new frame before throttling to reduce input latency" },
 	{ OPTION_SCREENLESS_FRAMERATE,                       "0",         core_options::option_type::INTEGER,    "frame rate when the device has no screen" },
+	{ OPTION_SYNC_INTERVAL,                              "0",         core_options::option_type::INTEGER,    "throttle whenever system and real time drift this number of microseconds apart" },
 
 	// render options
 	{ nullptr,                                           nullptr,     core_options::option_type::HEADER,     "CORE RENDER OPTIONS" },

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -95,6 +95,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_SPEED "(0.1-100)",                          "1.0",       core_options::option_type::FLOAT,      "controls the speed of gameplay, relative to realtime; smaller numbers are slower" },
 	{ OPTION_REFRESHSPEED ";rs",                         "0",         core_options::option_type::BOOLEAN,    "automatically adjust emulation speed to keep the emulated refresh rate slower than the host screen" },
 	{ OPTION_LOWLATENCY ";lolat",                        "0",         core_options::option_type::BOOLEAN,    "draws new frame before throttling to reduce input latency" },
+	{ OPTION_SCREENLESS_FRAMERATE,                       "0",         core_options::option_type::INTEGER,    "frame rate when the device has no screen" },
 
 	// render options
 	{ nullptr,                                           nullptr,     core_options::option_type::HEADER,     "CORE RENDER OPTIONS" },

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -81,6 +81,7 @@
 #define OPTION_SPEED                "speed"
 #define OPTION_REFRESHSPEED         "refreshspeed"
 #define OPTION_LOWLATENCY           "lowlatency"
+#define OPTION_SCREENLESS_FRAMERATE "screenless_framerate"
 
 // core render options
 #define OPTION_KEEPASPECT           "keepaspect"
@@ -366,6 +367,7 @@ public:
 	float speed() const { return float_value(OPTION_SPEED); }
 	bool refresh_speed() const { return m_refresh_speed; }
 	bool low_latency() const { return bool_value(OPTION_LOWLATENCY); }
+	float screenless_framerate() const { return float_value(OPTION_SCREENLESS_FRAMERATE); }
 
 	// core render options
 	bool keep_aspect() const { return bool_value(OPTION_KEEPASPECT); }

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -82,6 +82,7 @@
 #define OPTION_REFRESHSPEED         "refreshspeed"
 #define OPTION_LOWLATENCY           "lowlatency"
 #define OPTION_SCREENLESS_FRAMERATE "screenless_framerate"
+#define OPTION_SYNC_INTERVAL        "sync_interval"
 
 // core render options
 #define OPTION_KEEPASPECT           "keepaspect"
@@ -368,6 +369,7 @@ public:
 	bool refresh_speed() const { return m_refresh_speed; }
 	bool low_latency() const { return bool_value(OPTION_LOWLATENCY); }
 	float screenless_framerate() const { return float_value(OPTION_SCREENLESS_FRAMERATE); }
+	uint32_t sync_interval() const { return int_value(OPTION_SYNC_INTERVAL); }
 
 	// core render options
 	bool keep_aspect() const { return bool_value(OPTION_KEEPASPECT); }

--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -81,6 +81,8 @@ running_machine::running_machine(const machine_config &_config, machine_manager 
 	, m_rand_seed(0x9d14abd7)
 	, m_basename(_config.gamedrv().name)
 	, m_sample_rate(_config.options().sample_rate())
+	, m_sync_interval_usec(_config.options().sync_interval())
+	, m_sync_interval(attotime::from_usec(_config.options().sync_interval()))
 	, m_saveload_schedule(saveload_schedule::NONE)
 	, m_saveload_schedule_time(attotime::zero)
 	, m_saveload_searchpath(nullptr)
@@ -345,6 +347,8 @@ int running_machine::run(bool quiet)
 		emscripten_set_running_machine(this);
 #endif
 
+		attotime next_sync = time() + m_sync_interval;
+
 		// run the CPUs until a reset or exit
 		while ((!m_hard_reset_pending && !m_exit_pending) || m_saveload_schedule != saveload_schedule::NONE)
 		{
@@ -352,7 +356,20 @@ int running_machine::run(bool quiet)
 
 			// execute CPUs if not paused
 			if (!m_paused)
+			{
 				m_scheduler.timeslice();
+				if (m_sync_interval_usec > 0)
+				{
+					attotime now = time();
+					if (now >= next_sync)
+					{
+						if (m_video->throttled() && !m_video->fastforward())
+							m_video->update_throttle(now);
+						while (now >= next_sync)
+							next_sync += m_sync_interval;
+					}
+				}
+			}
 			// otherwise, just pump video updates and sound mapping updates through
 			else
 			{

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -159,6 +159,9 @@ public:
 	bool scheduled_event_pending() const { return m_exit_pending || m_hard_reset_pending; }
 	bool allow_logging() const { return !m_logerror_list.empty(); }
 
+	uint32_t sync_interval() { return m_sync_interval_usec; }
+	void set_sync_interval(uint32_t sync_interval) { m_sync_interval_usec = sync_interval; m_sync_interval = attotime::from_usec(sync_interval); }
+
 	// fetch items by name
 	template <class DeviceClass> [[deprecated("absolute tag lookup; use subdevice or finder instead")]] inline DeviceClass *device(const char *tag) { return downcast<DeviceClass *>(root_device().subdevice(tag)); }
 
@@ -299,6 +302,10 @@ private:
 	int                     m_sample_rate;          // the digital audio sample rate
 	std::unique_ptr<emu_file>  m_logfile;           // pointer to the active error.log file
 	std::unique_ptr<emu_file>  m_debuglogfile;      // pointer to the active debug.log file
+
+	// throttling state
+	uint32_t                m_sync_interval_usec;   // synchronize real & machine time at this interval in microseconds of machine time
+	attotime                m_sync_interval;        // time sychronization interval in attotime
 
 	// load/save management
 	enum class saveload_schedule

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -107,6 +107,8 @@ video_manager::video_manager(running_machine &machine)
 	, m_frameskip_adjust(0)
 	, m_skipping_this_frame(false)
 	, m_average_oversleep(0)
+	, m_screenless_framerate(machine.options().screenless_framerate())
+	, m_weird_delta_attoseconds(attotime::from_msec(100).as_attoseconds())
 	, m_snap_target(nullptr)
 	, m_snap_native(true)
 	, m_snap_width(0)
@@ -176,7 +178,7 @@ video_manager::video_manager(running_machine &machine)
 	if (no_screens)
 	{
 		m_screenless_frame_timer = machine.scheduler().timer_alloc(timer_expired_delegate(FUNC(video_manager::screenless_update_callback), this));
-		m_screenless_frame_timer->adjust(screen_device::DEFAULT_FRAME_PERIOD, 0, screen_device::DEFAULT_FRAME_PERIOD);
+		update_screenless_frame_timer();
 		machine.output().add_global_notifier(video_notifier_callback, this);
 	}
 }
@@ -202,6 +204,46 @@ void video_manager::set_frameskip(int frameskip)
 		m_auto_frameskip = false;
 		m_frameskip_level = std::min<int>(frameskip, MAX_FRAMESKIP);
 	}
+}
+
+
+//-------------------------------------------------
+//  update_screenless_frame_timer - update the timer used
+//  to schedule frame updates for devices that do not have
+//  a screen.
+//-------------------------------------------------
+
+void video_manager::update_screenless_frame_timer()
+{
+	if (m_screenless_frame_timer != nullptr)
+	{
+		if (m_screenless_framerate >= 1.0f)
+		{
+			attoseconds_t period_attoseconds = HZ_TO_ATTOSECONDS(m_screenless_framerate);
+			attotime period { 0, period_attoseconds };
+			m_screenless_frame_timer->adjust(period, 0, period);
+			m_weird_delta_attoseconds = std::max(m_weird_delta_attoseconds, 11 * (period_attoseconds / 10));
+		}
+		else
+		{
+			attoseconds_t period_attoseconds = downcast<driver_device&>(m_machine.root_device()).default_screenless_frame_period();
+			attotime period { 0, period_attoseconds };
+			m_screenless_frame_timer->adjust(period, 0, period);
+			m_weird_delta_attoseconds = attotime::from_msec(100).as_attoseconds();
+		}
+	}
+}
+
+
+//-------------------------------------------------
+//  set_screenless_framerate - set the frame rate to use
+//  for devices that do not have a screen.
+//-------------------------------------------------
+
+void video_manager::set_screenless_framerate(float screenless_framerate)
+{
+	m_screenless_framerate = screenless_framerate;
+	update_screenless_frame_timer();
 }
 
 
@@ -726,7 +768,8 @@ void video_manager::update_throttle(attotime emutime)
 		// between 0 and 1/10th of a second ... anything outside of this range is obviously
 		// wrong and requires a resync
 		attoseconds_t emu_delta_attoseconds = (emutime - m_throttle_emutime).as_attoseconds();
-		if (emu_delta_attoseconds < 0 || emu_delta_attoseconds >= (ATTOSECONDS_PER_SECOND / (m_speed ? m_speed : 1000)) * 100)
+		attoseconds_t weird_limit_attoseconds = ((1000 / (m_speed ? m_speed : 1000)) * m_weird_delta_attoseconds);
+		if (emu_delta_attoseconds < 0 || emu_delta_attoseconds >= weird_limit_attoseconds)
 		{
 			if (LOG_THROTTLE)
 				machine().logerror("Resync due to weird emutime delta: %s\n", attotime(0, emu_delta_attoseconds).as_string(18));

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -260,6 +260,7 @@ void video_manager::frame_update(bool from_debugger)
 	bool skipped_it = m_skipping_this_frame;
 	bool const update_screens = (phase == machine_phase::RUNNING) && (!machine().paused() || machine().options().update_in_pause());
 	bool anything_changed = update_screens && finish_screen_updates();
+	bool machine_syncs = machine().sync_interval() != 0;
 
 	// update inputs and draw the user interface
 	machine().osd().input_update(true);
@@ -278,7 +279,7 @@ void video_manager::frame_update(bool from_debugger)
 
 	// if we're throttling, synchronize before rendering
 	attotime current_time = machine().time();
-	if (!from_debugger && phase > machine_phase::INIT && !m_low_latency && effective_throttle())
+	if (!from_debugger && phase > machine_phase::INIT && !m_low_latency && !machine_syncs && effective_throttle())
 		update_throttle(current_time);
 
 	// ask the OSD to update
@@ -288,7 +289,7 @@ void video_manager::frame_update(bool from_debugger)
 	}
 
 	// we synchronize after rendering instead of before, if low latency mode is enabled
-	if (!from_debugger && phase > machine_phase::INIT && m_low_latency && effective_throttle())
+	if (!from_debugger && phase > machine_phase::INIT && m_low_latency && !machine_syncs && effective_throttle())
 		update_throttle(current_time);
 
 	machine().osd().input_update(false);

--- a/src/emu/video.h
+++ b/src/emu/video.h
@@ -53,6 +53,7 @@ public:
 	bool throttled() const { return m_throttled; }
 	float throttle_rate() const { return m_throttle_rate; }
 	bool fastforward() const { return m_fastforward; }
+	float screenless_framerate() const { return m_screenless_framerate; }
 
 	// setters
 	void set_frameskip(int frameskip);
@@ -61,6 +62,7 @@ public:
 	void set_fastforward(bool ffwd) { m_fastforward = ffwd; }
 	void set_output_changed() { m_output_changed = true; }
 	void set_speed_factor(int speed) { m_speed = speed; }
+	void set_screenless_framerate(float screenless_framerate);
 
 	// misc
 	void toggle_record_movie(movie_recording::format format);
@@ -106,6 +108,7 @@ private:
 	void update_frameskip();
 	void update_refresh_speed();
 	void recompute_speed(const attotime &emutime);
+	void update_screenless_frame_timer();
 
 	// snapshot/movie helpers
 	void create_snapshot_bitmap(screen_device *screen);
@@ -155,6 +158,8 @@ private:
 	s8                  m_frameskip_adjust;
 	bool                m_skipping_this_frame;      // flag: true if we are skipping the current frame
 	osd_ticks_t         m_average_oversleep;        // average number of ticks the OSD oversleeps
+	float               m_screenless_framerate;     // no-screen frame rate
+	attoseconds_t       m_weird_delta_attoseconds;  // delta to detect weird sync issues
 
 	// snapshot stuff
 	render_target *     m_snap_target;              // screen shapshot target

--- a/src/emu/video.h
+++ b/src/emu/video.h
@@ -90,6 +90,9 @@ public:
 	void add_sound_to_recording(const s16 *sound, int numsamples);
 	bool is_recording() const { return !m_movie_recordings.empty(); }
 
+	// throttling helper, visible for running_machine.
+	void update_throttle(attotime emutime);
+
 private:
 	// internal helpers
 	void exit();
@@ -103,7 +106,6 @@ private:
 	// speed and throttling helpers
 	int original_speed_setting() const;
 	bool finish_screen_updates();
-	void update_throttle(attotime emutime);
 	osd_ticks_t throttle_until_ticks(osd_ticks_t target_ticks);
 	void update_frameskip();
 	void update_refresh_speed();

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -2205,6 +2205,7 @@ void lua_engine::initialize()
 	video_type["snap_native"] = sol::property(&video_manager::snap_native);
 	video_type["is_recording"] = sol::property(&video_manager::is_recording);
 	video_type["snapshot_target"] = sol::property(&video_manager::snapshot_target);
+	video_type["screenless_framerate"] = sol::property(&video_manager::screenless_framerate, &video_manager::set_screenless_framerate);
 
 
 	auto sound_type = sol().registry().new_usertype<sound_manager>("sound", sol::no_constructor);

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -1488,6 +1488,7 @@ void lua_engine::initialize()
 			});
 	machine_type["options"] = sol::property(&running_machine::options);
 	machine_type["samplerate"] = sol::property(&running_machine::sample_rate);
+	machine_type["sync_interval"] = sol::property(&running_machine::sync_interval, &running_machine::set_sync_interval);
 	machine_type["paused"] = sol::property(&running_machine::paused);
 	machine_type["exit_pending"] = sol::property(&running_machine::exit_pending);
 	machine_type["hard_reset_pending"] = sol::property(&running_machine::hard_reset_pending);

--- a/src/mame/taito/cucaracha.cpp
+++ b/src/mame/taito/cucaracha.cpp
@@ -53,6 +53,12 @@ public:
 
 	void cucaracha(machine_config &config) ATTR_COLD;
 
+	// This game has no screen, so would run at a 60Hz frame rate by default.
+	// Provide a 100Hz frame rate here, to match the 100Hz interrupt that
+	// drives emulation, see the call to `m_maincpu->set_periodic_int()`
+	// in the constructor.
+	virtual attoseconds_t default_screenless_frame_period() const override { return HZ_TO_ATTOSECONDS(100); }
+
 protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;

--- a/src/osd/osdcore.cpp
+++ b/src/osd/osdcore.cpp
@@ -174,6 +174,34 @@ void osd_sleep(osd_ticks_t duration) noexcept
 // sleep_for appears to oversleep on Windows with gcc 8
 	Sleep(duration / (osd_ticks_per_second() / 1000));
 #else
+
+#if 0
+	using units = std::chrono::duration<double, std::ratio<1, 1'000>>;
+  static constexpr int SLEEP_WINDOW { 1000 };
+	static constexpr int REPORT_EVERY { SLEEP_WINDOW };
+	static osd_ticks_t sleeps[SLEEP_WINDOW] { 0 };
+	static osd_ticks_t total_sleep_ticks { 0 };
+	static uint32_t n_sleeps { 0 };
+	static int sleep_index { 0 };
+	static int sleep_window { 0 };
+
+	n_sleeps++;
+	total_sleep_ticks -= sleeps[sleep_index];
+	sleeps[sleep_index++] = duration;
+	total_sleep_ticks += duration;
+	sleep_index %= SLEEP_WINDOW;
+
+	if (sleep_window < SLEEP_WINDOW)
+		sleep_window++;
+
+	if (!(n_sleeps % REPORT_EVERY)) {
+		auto accumulated_duration = std::chrono::high_resolution_clock::duration(total_sleep_ticks);
+		auto accumulated_units = std::chrono::duration_cast<units>(accumulated_duration);
+		auto average_units = accumulated_units / sleep_window;	
+		osd_printf_error("Sleeping %lu times, %d moving average %f ms\n", n_sleeps, sleep_window, average_units.count());
+	}
+#endif
+
 	std::this_thread::sleep_for(std::chrono::high_resolution_clock::duration(duration));
 #endif
 }


### PR DESCRIPTION
`emuopts,machine,driver,video,osdcore,luascript`: allow more flexible time synchronization.

NOTE: this PR is based on https://github.com/mamedev/mame/pull/15481  and currently contains its commit https://github.com/cbrunschen/mame/commit/81ba217401ad0932639db7e4501b5cf8b7fd667d .

This is a draft PR, for discussion, picking apart, improving if possible, etc.

It does the following.

Add a command line option:

- `-sync_interval` specifies a number of microseconds; after each such interval, the simulation loop inside `running_machine` attempts to synchronize simulated time with real time. To do this, it uses the existing `video_manager`'s `update_throttling` function.

`-sync_interval` allows the user to spread emulated processing more evenly across each emulated frame. This allows external inputs such as MIDI to be processed much closer in simulated time to when they happen in real time, reducing latency, but more importantly, jitter in these inputs.

With a fixed 60Hz screenless frame rate ~= 16ms between frames, the `sd1` on my laptop actually only uses about 2ms of real time to emulate those 16ms of simulated time. With the current code, that means 2ms of processing followed by 14ms of sleeping.

However that also means that any MIDI events that arrive during those 14ms of sleep will all be processed as if they had arrived together exactly at the start of the next slice of processing; and even an event that arrived during processing will have been handled at the wrong simulated time: if the event arrived 1ms real-time into the processing, that corresponds to 8ms of simulated time. So any MIDI events will be processed with somewhere between 0 and 14ms of jitter.

Incidentally, this jitter is less problematic on a slower computer, where emulated time runs closer to real time: on a machine that is 1/4 as fast, emulating 16ms of simulated time would take 8ms of the elapsed 16ms, so jitter would only be +-4ms instead of +-7ms.

`-sync_interval` allows the user to reduce this jitter significantly, by slicing processing more finely than on just a frame-by-frame basis, reduciing jitter from +-7ms to less than 1ms on my laptop (with `-sync_interval 500` giving excellent results on my laptop).

If the user is mainly going to control a device through extrnal inputs such as when playing an emulated synth through MIDI, these can be combined to reduce the frame rate (and thus overall CPU usage) but keep input processing tightly connected to real time.

It is also exposed in LUA: `sync_interval` as a property on `running_machine`, (i.e., `manager.machine.sync_interval`), which allows adjusting this to taste at runtime.

Together with https://github.com/mamedev/mame/pull/15481 which adds the `-screenless_framerate` command line option and variable, this can be used to demonstrate its effectiveness: If I run the `sd132` with a suitable midi input and feed it MIDI events, I can set `screenless_framerate` to something ridiculously low like `7`, and hear playback of the incoming events be effectively quantized to 7ths of a second; and then setting `sync_interval` to `500` retains the slow framerate, but allows external MIDI event processing to happen much closer to the correct real time, and the music to sound perfectly normal. Admittedly this is an exaggerated example, but it does show what is happening.

Together these changes all seems to work, and achieve what I'm trying to do: 
- allow devices without a screen to specify an appropriate default frame rate
  - and allow the user to override that frame rate
    - which allows users to increase the rate of input processing, which happens at the frame rate
- allow the user to optionally decouple emulate-to-real-time-synchronization from video frame rate
  - and to specify how frequently that synchronization happens
    - which allows the user to reduce jitter between incoming real-time external events and when in simulated time they are processed

And it does all this while changing as little about the code as possible.

That, of course, may not be the best approach. 

For one thing, there are some arbitrary choices in here that are certainly worth replacing with better ones, such as the names of the command line flags and variables/functions; and of course, the choice of microseconds as the unit for `sync_interval`.

For another, my changes expose parts of `video_manager` so that `running_machine` can use them, which even to me does not look ideal.

One thought I had was that the throttling code seems to already be rather decoupled from the rest of what `video_manager` does; and it might be possible to separate that code into a new class (strawman name `sync_manager`) that could then be accessed by both `video_manager` and `running_machine`; but I didn't want to start by making such a rather more substantial change before I knew if this idea would have any conceptual traction.

While it does merge cleanly and seems to run very well in all my testing, I'm creating this as a _draft_ PR: after all I'm also sure that there are scenarios that I have missed (though, since everything here is optional, there should be no impact unless those options are invoked).

So I would love to hear any and all feedback on this - both the overall concept and the implementation.

