### PR TITLE
`emuopts,driver,video,luascript,cucaracha`: allow more flexible  frame rate for screenless devices.

### DIFF
--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -1873,6 +1873,23 @@ Core Performance Options
 
             mame gradius4 -frameskip 2
 
+.. _mame-commandline-screenless-framerate:
+
+**-screenless_framerate** *<frames per second>*
+
+    Specifies the frame rate to use for devices that do not have a screen.
+
+    Set to `0` (in fact any value less than `1`) to use the device's default,
+    usually MAME's built-on default of 60 frames per second.
+
+    The default value is **-screenless_framerate 0**, i.e., use the default
+		screenless framerate.
+
+    Example:
+        .. code-block:: bash
+
+            mame sd132 -screenless_framerate 12
+
 .. _mame-commandline-secondstorun:
 
 **-seconds_to_run** / **-str** *<seconds>*

--- a/docs/source/commandline/commandline-index.rst
+++ b/docs/source/commandline/commandline-index.rst
@@ -143,6 +143,7 @@ Core Performance Options
 
 | :ref:`[no]autoframeskip <mame-commandline-noautoframeskip>`
 | :ref:`frameskip <mame-commandline-frameskip>`
+| :ref:`screenless_framerate <mame-commandline-screenless-framerate>`
 | :ref:`seconds_to_run <mame-commandline-secondstorun>`
 | :ref:`[no]throttle <mame-commandline-nothrottle>`
 | :ref:`[no]sleep <mame-commandline-nosleep>`

--- a/docs/source/luascript/ref-core.rst
+++ b/docs/source/luascript/ref-core.rst
@@ -372,6 +372,14 @@ video.frameskip (read/write)
     The number of emulated video frames to skip drawing out of every twelve, or
     -1 to automatically adjust the number of frames to skip to maintain the
     target emulation speed.
+video.screenless_framerate (read/write)
+    The frame rate to use when the emulated machine does not have a screen.
+    Set `0` (in fact, any value less than `1`) to use the device's default,
+    usually MAME's default of 60 frames per second.
+    
+    Corresponds to the
+    :ref:`screenless_framerate <mame-commandline-screenless-framerate>` command
+    line option, but can override its value at runtime.
 video.speed_percent (read-only)
     The current emulated speed as a percentage of the full speed adjusted by the
     speed factor.

--- a/src/emu/driver.cpp
+++ b/src/emu/driver.cpp
@@ -11,6 +11,7 @@
 #include "emu.h"
 #include "image.h"
 #include "drivenum.h"
+#include "screen.h"
 #include "tilemap.h"
 
 
@@ -253,6 +254,17 @@ void driver_device::device_reset_after_children()
 }
 
 
+//-------------------------------------------------
+//  default_screenless_frame_period - returns
+//  the frame rate to use for screenless devices.
+//  Override in subclasses that need something other
+//  than the default 60 frames per second.
+//-------------------------------------------------
+
+attoseconds_t driver_device::default_screenless_frame_period() const
+{
+	return screen_device::DEFAULT_FRAME_PERIOD.as_attoseconds();
+}
 
 //**************************************************************************
 //  INTERRUPT GENERATION CALLBACK HELPERS

--- a/src/emu/driver.h
+++ b/src/emu/driver.h
@@ -142,6 +142,9 @@ public:
 
 	virtual std::vector<std::string> searchpath() const override;
 
+	// support for screenless devices with non-default frame rates
+	virtual attoseconds_t default_screenless_frame_period() const;
+
 protected:
 	// helpers called at startup
 	virtual void driver_start();

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -95,6 +95,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_SPEED "(0.1-100)",                          "1.0",       core_options::option_type::FLOAT,      "controls the speed of gameplay, relative to realtime; smaller numbers are slower" },
 	{ OPTION_REFRESHSPEED ";rs",                         "0",         core_options::option_type::BOOLEAN,    "automatically adjust emulation speed to keep the emulated refresh rate slower than the host screen" },
 	{ OPTION_LOWLATENCY ";lolat",                        "0",         core_options::option_type::BOOLEAN,    "draws new frame before throttling to reduce input latency" },
+	{ OPTION_SCREENLESS_FRAMERATE,                       "0",         core_options::option_type::INTEGER,    "frame rate when the device has no screen" },
 
 	// render options
 	{ nullptr,                                           nullptr,     core_options::option_type::HEADER,     "CORE RENDER OPTIONS" },

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -81,6 +81,7 @@
 #define OPTION_SPEED                "speed"
 #define OPTION_REFRESHSPEED         "refreshspeed"
 #define OPTION_LOWLATENCY           "lowlatency"
+#define OPTION_SCREENLESS_FRAMERATE "screenless_framerate"
 
 // core render options
 #define OPTION_KEEPASPECT           "keepaspect"
@@ -366,6 +367,7 @@ public:
 	float speed() const { return float_value(OPTION_SPEED); }
 	bool refresh_speed() const { return m_refresh_speed; }
 	bool low_latency() const { return bool_value(OPTION_LOWLATENCY); }
+	float screenless_framerate() const { return float_value(OPTION_SCREENLESS_FRAMERATE); }
 
 	// core render options
 	bool keep_aspect() const { return bool_value(OPTION_KEEPASPECT); }

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -107,6 +107,8 @@ video_manager::video_manager(running_machine &machine)
 	, m_frameskip_adjust(0)
 	, m_skipping_this_frame(false)
 	, m_average_oversleep(0)
+	, m_screenless_framerate(machine.options().screenless_framerate())
+	, m_weird_delta_attoseconds(attotime::from_msec(100).as_attoseconds())
 	, m_snap_target(nullptr)
 	, m_snap_native(true)
 	, m_snap_width(0)
@@ -176,7 +178,7 @@ video_manager::video_manager(running_machine &machine)
 	if (no_screens)
 	{
 		m_screenless_frame_timer = machine.scheduler().timer_alloc(timer_expired_delegate(FUNC(video_manager::screenless_update_callback), this));
-		m_screenless_frame_timer->adjust(screen_device::DEFAULT_FRAME_PERIOD, 0, screen_device::DEFAULT_FRAME_PERIOD);
+		update_screenless_frame_timer();
 		machine.output().add_global_notifier(video_notifier_callback, this);
 	}
 }
@@ -202,6 +204,46 @@ void video_manager::set_frameskip(int frameskip)
 		m_auto_frameskip = false;
 		m_frameskip_level = std::min<int>(frameskip, MAX_FRAMESKIP);
 	}
+}
+
+
+//-------------------------------------------------
+//  update_screenless_frame_timer - update the timer used
+//  to schedule frame updates for devices that do not have
+//  a screen.
+//-------------------------------------------------
+
+void video_manager::update_screenless_frame_timer()
+{
+	if (m_screenless_frame_timer != nullptr)
+	{
+		if (m_screenless_framerate >= 1.0f)
+		{
+			attoseconds_t period_attoseconds = HZ_TO_ATTOSECONDS(m_screenless_framerate);
+			attotime period { 0, period_attoseconds };
+			m_screenless_frame_timer->adjust(period, 0, period);
+			m_weird_delta_attoseconds = std::max(m_weird_delta_attoseconds, 11 * (period_attoseconds / 10));
+		}
+		else
+		{
+			attoseconds_t period_attoseconds = downcast<driver_device&>(m_machine.root_device()).default_screenless_frame_period();
+			attotime period { 0, period_attoseconds };
+			m_screenless_frame_timer->adjust(period, 0, period);
+			m_weird_delta_attoseconds = attotime::from_msec(100).as_attoseconds();
+		}
+	}
+}
+
+
+//-------------------------------------------------
+//  set_screenless_framerate - set the frame rate to use
+//  for devices that do not have a screen.
+//-------------------------------------------------
+
+void video_manager::set_screenless_framerate(float screenless_framerate)
+{
+	m_screenless_framerate = screenless_framerate;
+	update_screenless_frame_timer();
 }
 
 
@@ -726,7 +768,8 @@ void video_manager::update_throttle(attotime emutime)
 		// between 0 and 1/10th of a second ... anything outside of this range is obviously
 		// wrong and requires a resync
 		attoseconds_t emu_delta_attoseconds = (emutime - m_throttle_emutime).as_attoseconds();
-		if (emu_delta_attoseconds < 0 || emu_delta_attoseconds >= (ATTOSECONDS_PER_SECOND / (m_speed ? m_speed : 1000)) * 100)
+		attoseconds_t weird_limit_attoseconds = ((1000 / (m_speed ? m_speed : 1000)) * m_weird_delta_attoseconds);
+		if (emu_delta_attoseconds < 0 || emu_delta_attoseconds >= weird_limit_attoseconds)
 		{
 			if (LOG_THROTTLE)
 				machine().logerror("Resync due to weird emutime delta: %s\n", attotime(0, emu_delta_attoseconds).as_string(18));

--- a/src/emu/video.h
+++ b/src/emu/video.h
@@ -53,6 +53,7 @@ public:
 	bool throttled() const { return m_throttled; }
 	float throttle_rate() const { return m_throttle_rate; }
 	bool fastforward() const { return m_fastforward; }
+	float screenless_framerate() const { return m_screenless_framerate; }
 
 	// setters
 	void set_frameskip(int frameskip);
@@ -61,6 +62,7 @@ public:
 	void set_fastforward(bool ffwd) { m_fastforward = ffwd; }
 	void set_output_changed() { m_output_changed = true; }
 	void set_speed_factor(int speed) { m_speed = speed; }
+	void set_screenless_framerate(float screenless_framerate);
 
 	// misc
 	void toggle_record_movie(movie_recording::format format);
@@ -106,6 +108,7 @@ private:
 	void update_frameskip();
 	void update_refresh_speed();
 	void recompute_speed(const attotime &emutime);
+	void update_screenless_frame_timer();
 
 	// snapshot/movie helpers
 	void create_snapshot_bitmap(screen_device *screen);
@@ -155,6 +158,8 @@ private:
 	s8                  m_frameskip_adjust;
 	bool                m_skipping_this_frame;      // flag: true if we are skipping the current frame
 	osd_ticks_t         m_average_oversleep;        // average number of ticks the OSD oversleeps
+	float               m_screenless_framerate;     // no-screen frame rate
+	attoseconds_t       m_weird_delta_attoseconds;  // delta to detect weird sync issues
 
 	// snapshot stuff
 	render_target *     m_snap_target;              // screen shapshot target

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -2205,6 +2205,7 @@ void lua_engine::initialize()
 	video_type["snap_native"] = sol::property(&video_manager::snap_native);
 	video_type["is_recording"] = sol::property(&video_manager::is_recording);
 	video_type["snapshot_target"] = sol::property(&video_manager::snapshot_target);
+	video_type["screenless_framerate"] = sol::property(&video_manager::screenless_framerate, &video_manager::set_screenless_framerate);
 
 
 	auto sound_type = sol().registry().new_usertype<sound_manager>("sound", sol::no_constructor);

--- a/src/mame/taito/cucaracha.cpp
+++ b/src/mame/taito/cucaracha.cpp
@@ -53,6 +53,12 @@ public:
 
 	void cucaracha(machine_config &config) ATTR_COLD;
 
+	// This game has no screen, so would run at a 60Hz frame rate by default.
+	// Provide a 100Hz frame rate here, to match the 100Hz interrupt that
+	// drives emulation, see the call to `m_maincpu->set_periodic_int()`
+	// in the constructor.
+	virtual attoseconds_t default_screenless_frame_period() const override { return HZ_TO_ATTOSECONDS(100); }
+
 protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;


### PR DESCRIPTION
`emuopts,driver,video,luascript,cucaracha`: allow more flexible  frame rate for screenless devices.

Add a command line option:

- `-screenless_framerate` allows setting the target frame rate for devices that do not have a screen, such as the Ensoniq VFX series of synthesizers, or the `cucaracha` game. It allows users to adjust the frame rate, and  thus also the rate at which inputs are processed: a user with a 144Hz touchscreen can make full use of this.

Conversely, a user who does not use the on-screen display or inputs can reduce the frame rate (and thus the from their perspective unnecessary CPU usage).

This is also exposed in LUA: `screenless_framerate` as a property on `video_manager` (i.e., `manager.machine.video.screenless_framerate`), which allows adjusting this to taste at runtime.

This also adds a new member function `driver_device::default_screenless_frame_period()` to allow driver devices to return their preferred default screenless frame rate; and uses this in `cucaracha.cpp` to specify a 100Hz frame rate to match the 100Hz interrupt that appears to drive the game, see https://github.com/mamedev/mame/issues/15383 .