### PR TITLE
sound/segapcm.cpp: Split discrete logic variant and 315-5218 variant, Updates:

### DIFF
--- a/src/devices/sound/segapcm.cpp
+++ b/src/devices/sound/segapcm.cpp
@@ -9,22 +9,95 @@
 
 #include <algorithm>
 
-// device type definition
-DEFINE_DEVICE_TYPE(SEGAPCM, segapcm_device, "segapcm", "Sega PCM")
+// constants
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+constexpr unsigned segapcm_device<MaxVoices, Divider, AddrBits>::MAX_VOICES;
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+constexpr unsigned segapcm_device<MaxVoices, Divider, AddrBits>::CLOCK_DIVIDER;
 
+// device type definition
+DEFINE_DEVICE_TYPE(SEGAPCM_DISCRETE, segapcm_discrete_device, "segapcm_discrete", "Sega PCM (Discrete logic)")
+DEFINE_DEVICE_TYPE(SEGA_315_5218,    sega_315_5218_device,    "sega_315_5218",    "Sega 315-5218 PCM")
+
+// reg      function
+// ------------------------------------------------
+// 0x00     ?
+// 0x01     ?
+// 0x02     volume left
+// 0x03     volume right
+// 0x04     loop address (08-15)
+// 0x05     loop address (16-23)
+// 0x06     end address
+// 0x07     address delta
+// 0x80     ?
+// 0x81     ?
+// 0x82     ?
+// 0x83     ?
+// 0x84     current address (08-15), 00-07 is internal?
+// 0x85     current address (16-23)
+// 0x86     bit 0: channel disable?
+//          bit 1: loop disable
+//          other bits: bank
+// 0x87     ?
+
+// only lower half of register set is valid
+void segapcm_discrete_device::map(address_map &map)
+{
+	map.unmap_value_high();
+	map(0x00, 0xff).ram().share(m_ram); // for debug, or scratchpad RAM?
+	map(0x42, 0x42).select(0x38).rw(FUNC(segapcm_discrete_device::voice_lvol_r), FUNC(segapcm_discrete_device::voice_lvol_w));
+	map(0x43, 0x43).select(0x38).rw(FUNC(segapcm_discrete_device::voice_rvol_r), FUNC(segapcm_discrete_device::voice_rvol_w));
+	map(0x44, 0x45).select(0x38).rw(FUNC(segapcm_discrete_device::voice_loop_r), FUNC(segapcm_discrete_device::voice_loop_w));
+	map(0x46, 0x46).select(0x38).rw(FUNC(segapcm_discrete_device::voice_end_r), FUNC(segapcm_discrete_device::voice_end_w));
+	map(0x47, 0x47).select(0x38).rw(FUNC(segapcm_discrete_device::voice_freq_r), FUNC(segapcm_discrete_device::voice_freq_w));
+	map(0xc4, 0xc5).select(0x38).rw(FUNC(segapcm_discrete_device::voice_addr_r), FUNC(segapcm_discrete_device::voice_addr_w));
+	map(0xc6, 0xc6).select(0x38).rw(FUNC(segapcm_discrete_device::voice_ctrl_r), FUNC(segapcm_discrete_device::voice_ctrl_w));
+}
+
+void sega_315_5218_device::map(address_map &map)
+{
+	map.unmap_value_high();
+	map(0x00, 0xff).ram().share(m_ram); // for debug, or scratchpad RAM?
+	map(0x02, 0x02).select(0x78).rw(FUNC(sega_315_5218_device::voice_lvol_r), FUNC(sega_315_5218_device::voice_lvol_w));
+	map(0x03, 0x03).select(0x78).rw(FUNC(sega_315_5218_device::voice_rvol_r), FUNC(sega_315_5218_device::voice_rvol_w));
+	map(0x04, 0x05).select(0x78).rw(FUNC(sega_315_5218_device::voice_loop_r), FUNC(sega_315_5218_device::voice_loop_w));
+	map(0x06, 0x06).select(0x78).rw(FUNC(sega_315_5218_device::voice_end_r), FUNC(sega_315_5218_device::voice_end_w));
+	map(0x07, 0x07).select(0x78).rw(FUNC(sega_315_5218_device::voice_freq_r), FUNC(sega_315_5218_device::voice_freq_w));
+	map(0x84, 0x85).select(0x78).rw(FUNC(sega_315_5218_device::voice_addr_r), FUNC(sega_315_5218_device::voice_addr_w));
+	map(0x86, 0x86).select(0x78).rw(FUNC(sega_315_5218_device::voice_ctrl_r), FUNC(sega_315_5218_device::voice_ctrl_w));
+}
 
 //-------------------------------------------------
 //  segapcm_device - constructor
 //-------------------------------------------------
 
-segapcm_device::segapcm_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: device_t(mconfig, SEGAPCM, tag, owner, clock)
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+segapcm_device<MaxVoices, Divider, AddrBits>::segapcm_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, type, tag, owner, clock)
 	, device_sound_interface(mconfig, *this)
-	, device_rom_interface(mconfig, *this)
-	, m_ram(nullptr)
+	, device_rom_interface<AddrBits>(mconfig, *this)
+	, m_ram(*this, "ram")
 	, m_bankshift(12)
 	, m_bankmask(0x70)
 	, m_stream(nullptr)
+{
+}
+
+//-------------------------------------------------
+//  segapcm_discrete_device - constructor
+//-------------------------------------------------
+
+segapcm_discrete_device::segapcm_discrete_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: segapcm_device<8, 64, 16>(mconfig, SEGAPCM_DISCRETE, tag, owner, clock)
+{
+}
+
+//-------------------------------------------------
+//  sega_315_5218_device - constructor
+//-------------------------------------------------
+
+sega_315_5218_device::sega_315_5218_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: segapcm_device<16, 128, 21>(mconfig, SEGA_315_5218, tag, owner, clock)
 {
 }
 
@@ -33,16 +106,25 @@ segapcm_device::segapcm_device(const machine_config &mconfig, const char *tag, d
 //  device_start - device-specific startup
 //-------------------------------------------------
 
-void segapcm_device::device_start()
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+void segapcm_device<MaxVoices, Divider, AddrBits>::device_start()
 {
-	m_ram = std::make_unique<uint8_t[]>(0x800);
+	std::fill_n(&m_ram[0], m_ram.length(), 0xff);
 
-	std::fill(&m_ram[0], &m_ram[0x800], 0xff);
+	m_stream = stream_alloc(0, 2, clock() / CLOCK_DIVIDER);
 
-	m_stream = stream_alloc(0, 2, clock() / 128);
+	for (auto & elem : m_voice)
+		elem.host = this;
 
-	save_item(NAME(m_low));
-	save_pointer(NAME(m_ram), 0x800);
+	save_item(STRUCT_MEMBER(m_voice, addr));
+	save_item(STRUCT_MEMBER(m_voice, loop));
+	save_item(STRUCT_MEMBER(m_voice, end));
+	save_item(STRUCT_MEMBER(m_voice, freq));
+	save_item(STRUCT_MEMBER(m_voice, lvol));
+	save_item(STRUCT_MEMBER(m_voice, rvol));
+	save_item(STRUCT_MEMBER(m_voice, ctrl));
+	save_item(STRUCT_MEMBER(m_voice, lout));
+	save_item(STRUCT_MEMBER(m_voice, rout));
 }
 
 
@@ -51,9 +133,10 @@ void segapcm_device::device_start()
 //  changes
 //-------------------------------------------------
 
-void segapcm_device::device_clock_changed()
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+void segapcm_device<MaxVoices, Divider, AddrBits>::device_clock_changed()
 {
-	m_stream->set_sample_rate(clock() / 128);
+	m_stream->set_sample_rate(clock() / CLOCK_DIVIDER);
 }
 
 
@@ -62,7 +145,8 @@ void segapcm_device::device_clock_changed()
 //  ROM banking changes
 //-------------------------------------------------
 
-void segapcm_device::rom_bank_pre_change()
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+void segapcm_device<MaxVoices, Divider, AddrBits>::rom_bank_pre_change()
 {
 	m_stream->update();
 }
@@ -72,86 +156,172 @@ void segapcm_device::rom_bank_pre_change()
 //  sound_stream_update - handle a stream update
 //-------------------------------------------------
 
-void segapcm_device::sound_stream_update(sound_stream &stream)
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+void segapcm_device<MaxVoices, Divider, AddrBits>::sound_stream_update(sound_stream &stream)
 {
-	// reg      function
-	// ------------------------------------------------
-	// 0x00     ?
-	// 0x01     ?
-	// 0x02     volume left
-	// 0x03     volume right
-	// 0x04     loop address (08-15)
-	// 0x05     loop address (16-23)
-	// 0x06     end address
-	// 0x07     address delta
-	// 0x80     ?
-	// 0x81     ?
-	// 0x82     ?
-	// 0x83     ?
-	// 0x84     current address (08-15), 00-07 is internal?
-	// 0x85     current address (16-23)
-	// 0x86     bit 0: channel disable?
-	//          bit 1: loop disable
-	//          other bits: bank
-	// 0x87     ?
-
-	/* loop over channels */
-	for (int ch = 0; ch < 16; ch++)
+	/* loop over streams */
+	for (int i = 0; i < stream.samples(); i++)
 	{
-		uint8_t *regs = m_ram.get()+8*ch;
-
-		/* only process active channels */
-		if (!(regs[0x86]&1))
+		int32_t lout = 0, rout = 0;
+		for (int ch = 0; ch < MAX_VOICES; ch++)
 		{
-			int offset = (regs[0x86] & m_bankmask) << m_bankshift;
-			uint32_t addr = (regs[0x85] << 16) | (regs[0x84] << 8) | m_low[ch];
-			uint32_t loop = (regs[0x05] << 16) | (regs[0x04] << 8);
-			uint8_t end = regs[6] + 1;
-			int i;
-
-			/* loop over samples on this channel */
-			for (i = 0; i < stream.samples(); i++)
-			{
-				int8_t v;
-
-				/* handle looping if we've hit the end */
-				if ((addr >> 16) == end)
-				{
-					if (regs[0x86] & 2)
-					{
-						regs[0x86] |= 1;
-						break;
-					}
-					else addr = loop;
-				}
-
-				/* fetch the sample */
-				v = read_byte(offset + (addr >> 8)) - 0x80;
-
-				/* apply panning and advance */
-				stream.add_int(0, i, v * (regs[2] & 0x7f), 32768);
-				stream.add_int(1, i, v * (regs[3] & 0x7f), 32768);
-				addr = (addr + regs[7]) & 0xffffff;
-			}
-
-			/* store back the updated address */
-			regs[0x84] = addr >> 8;
-			regs[0x85] = addr >> 16;
-			m_low[ch] = regs[0x86] & 1 ? 0 : addr;
+			voice_t &voice = m_voice[ch];
+			voice.tick(m_bankmask, m_bankshift);
+			lout += voice.lout;
+			rout += voice.rout;
 		}
+		stream.put_int(0, i, lout, 32768);
+		stream.put_int(1, i, rout, 32768);
 	}
 }
 
-
-void segapcm_device::write(offs_t offset, uint8_t data)
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+void segapcm_device<MaxVoices, Divider, AddrBits>::voice_t::tick(uint32_t bankmask, uint32_t bankshift)
 {
-	m_stream->update();
-	m_ram[offset & 0x07ff] = data;
+	// only process active channels
+	lout = rout = 0;
+	if (BIT(~ctrl, 0))
+	{
+		// handle looping if we've hit the end
+		if ((addr >> 16) == end)
+		{
+			if (BIT(ctrl, 1))
+			{
+				ctrl |= 1;
+				return;
+			}
+			else
+				addr = (uint32_t(loop) << 8);
+		}
+		// fetch the sample
+		const uint32_t bank = (ctrl & bankmask) << bankshift;
+		const int8_t v = host->read_byte(bank + (addr >> 8)) - 0x80;
+		// apply panning and advance
+		lout = v * (lvol & 0x7f);
+		rout = v * (rvol & 0x7f);
+		addr = (addr + freq) & 0xffffff;
+	}
+	else
+		addr &= 0xffff00;
 }
 
-
-uint8_t segapcm_device::read(offs_t offset)
+// read/write handlers
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_addr_r(offs_t offset)
 {
 	m_stream->update();
-	return m_ram[offset & 0x07ff];
+	voice_t &voice = m_voice[offset >> 3];
+	const uint8_t shift = 8 + ((offset & 1) << 3);
+	return (voice.addr >> shift) & 0xff;
 }
+
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_loop_r(offs_t offset)
+{
+	m_stream->update();
+	voice_t &voice = m_voice[offset >> 3];
+	const uint8_t shift = (offset & 1) << 3;
+	return (voice.loop >> shift) & 0xff;
+}
+
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_end_r(offs_t offset)
+{
+	m_stream->update();
+	voice_t &voice = m_voice[offset >> 3];
+	return voice.end;
+}
+
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_freq_r(offs_t offset)
+{
+	m_stream->update();
+	voice_t &voice = m_voice[offset >> 3];
+	return voice.freq;
+}
+
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_lvol_r(offs_t offset)
+{
+	m_stream->update();
+	voice_t &voice = m_voice[offset >> 3];
+	return voice.lvol;
+}
+
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_rvol_r(offs_t offset)
+{
+	m_stream->update();
+	voice_t &voice = m_voice[offset >> 3];
+	return voice.rvol;
+}
+
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_ctrl_r(offs_t offset)
+{
+	m_stream->update();
+	voice_t &voice = m_voice[offset >> 3];
+	return voice.ctrl;
+}
+
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+void segapcm_device<MaxVoices, Divider, AddrBits>::voice_addr_w(offs_t offset, uint8_t data)
+{
+	m_stream->update();
+	voice_t &voice = m_voice[offset >> 3];
+	const uint8_t shift = 8 + ((offset & 1) << 3);
+	voice.addr = (voice.addr & ~(0xff << shift)) | (uint32_t(data) << shift);
+}
+
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+void segapcm_device<MaxVoices, Divider, AddrBits>::voice_loop_w(offs_t offset, uint8_t data)
+{
+	m_stream->update();
+	voice_t &voice = m_voice[offset >> 3];
+	const uint8_t shift = (offset & 1) << 3;
+	voice.loop = (voice.loop & ~(0xff << shift)) | (uint32_t(data) << shift);
+}
+
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+void segapcm_device<MaxVoices, Divider, AddrBits>::voice_end_w(offs_t offset, uint8_t data)
+{
+	m_stream->update();
+	voice_t &voice = m_voice[offset >> 3];
+	voice.end = data;
+}
+
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+void segapcm_device<MaxVoices, Divider, AddrBits>::voice_freq_w(offs_t offset, uint8_t data)
+{
+	m_stream->update();
+	voice_t &voice = m_voice[offset >> 3];
+	voice.freq = data;
+}
+
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+void segapcm_device<MaxVoices, Divider, AddrBits>::voice_lvol_w(offs_t offset, uint8_t data)
+{
+	m_stream->update();
+	voice_t &voice = m_voice[offset >> 3];
+	voice.lvol = data;
+}
+
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+void segapcm_device<MaxVoices, Divider, AddrBits>::voice_rvol_w(offs_t offset, uint8_t data)
+{
+	m_stream->update();
+	voice_t &voice = m_voice[offset >> 3];
+	voice.rvol = data;
+}
+
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
+void segapcm_device<MaxVoices, Divider, AddrBits>::voice_ctrl_w(offs_t offset, uint8_t data)
+{
+	m_stream->update();
+	voice_t &voice = m_voice[offset >> 3];
+	voice.ctrl = data;
+}
+
+// template class definition
+template class segapcm_device<8, 64, 16>;
+template class segapcm_device<16, 128, 21>;

--- a/src/devices/sound/segapcm.cpp
+++ b/src/devices/sound/segapcm.cpp
@@ -9,12 +9,6 @@
 
 #include <algorithm>
 
-// constants
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-constexpr unsigned segapcm_device<MaxVoices, Divider, AddrBits>::MAX_VOICES;
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-constexpr unsigned segapcm_device<MaxVoices, Divider, AddrBits>::CLOCK_DIVIDER;
-
 // device type definition
 DEFINE_DEVICE_TYPE(SEGAPCM_DISCRETE, segapcm_discrete_device, "segapcm_discrete", "Sega PCM (Discrete logic)")
 DEFINE_DEVICE_TYPE(SEGA_315_5218,    sega_315_5218_device,    "sega_315_5218",    "Sega 315-5218 PCM")
@@ -43,7 +37,6 @@ DEFINE_DEVICE_TYPE(SEGA_315_5218,    sega_315_5218_device,    "sega_315_5218",  
 // only lower half of register set is valid
 void segapcm_discrete_device::map(address_map &map)
 {
-	map.unmap_value_high();
 	map(0x00, 0xff).ram().share(m_ram); // for debug, or scratchpad RAM?
 	map(0x42, 0x42).select(0x38).rw(FUNC(segapcm_discrete_device::voice_lvol_r), FUNC(segapcm_discrete_device::voice_lvol_w));
 	map(0x43, 0x43).select(0x38).rw(FUNC(segapcm_discrete_device::voice_rvol_r), FUNC(segapcm_discrete_device::voice_rvol_w));
@@ -56,7 +49,6 @@ void segapcm_discrete_device::map(address_map &map)
 
 void sega_315_5218_device::map(address_map &map)
 {
-	map.unmap_value_high();
 	map(0x00, 0xff).ram().share(m_ram); // for debug, or scratchpad RAM?
 	map(0x02, 0x02).select(0x78).rw(FUNC(sega_315_5218_device::voice_lvol_r), FUNC(sega_315_5218_device::voice_lvol_w));
 	map(0x03, 0x03).select(0x78).rw(FUNC(sega_315_5218_device::voice_rvol_r), FUNC(sega_315_5218_device::voice_rvol_w));

--- a/src/devices/sound/segapcm.cpp
+++ b/src/devices/sound/segapcm.cpp
@@ -180,8 +180,7 @@ void segapcm_device<MaxVoices>::sound_stream_update(sound_stream &stream)
 	}
 }
 
-template<unsigned MaxVoices>
-void segapcm_device<MaxVoices>::voice_t::tick()
+void segapcm_base_device::voice_t::tick()
 {
 	// only process active channels
 	lout = rout = 0;

--- a/src/devices/sound/segapcm.cpp
+++ b/src/devices/sound/segapcm.cpp
@@ -61,16 +61,25 @@ void sega_315_5218_device::map(address_map &map)
 }
 
 //-------------------------------------------------
+//  segapcm_base_device - constructor
+//-------------------------------------------------
+
+segapcm_base_device::segapcm_base_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, type, tag, owner, clock)
+	, device_sound_interface(mconfig, *this)
+	, device_rom_interface<21>(mconfig, *this)
+	, m_ram(*this, "ram")
+	, m_stream(nullptr)
+{
+}
+
+//-------------------------------------------------
 //  segapcm_device - constructor
 //-------------------------------------------------
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-segapcm_device<MaxVoices, Divider, AddrBits>::segapcm_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
-	: device_t(mconfig, type, tag, owner, clock)
-	, device_sound_interface(mconfig, *this)
-	, device_rom_interface<AddrBits>(mconfig, *this)
-	, m_ram(*this, "ram")
-	, m_stream(nullptr)
+template<unsigned MaxVoices>
+segapcm_device<MaxVoices>::segapcm_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
+	: segapcm_base_device(mconfig, type, tag, owner, clock)
 {
 }
 
@@ -79,7 +88,7 @@ segapcm_device<MaxVoices, Divider, AddrBits>::segapcm_device(const machine_confi
 //-------------------------------------------------
 
 segapcm_discrete_device::segapcm_discrete_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: segapcm_device<8, 64, 16>(mconfig, SEGAPCM_DISCRETE, tag, owner, clock)
+	: segapcm_device<8>(mconfig, SEGAPCM_DISCRETE, tag, owner, clock)
 {
 }
 
@@ -88,7 +97,7 @@ segapcm_discrete_device::segapcm_discrete_device(const machine_config &mconfig, 
 //-------------------------------------------------
 
 sega_315_5218_device::sega_315_5218_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: segapcm_device<16, 128, 21>(mconfig, SEGA_315_5218, tag, owner, clock)
+	: segapcm_device<16>(mconfig, SEGA_315_5218, tag, owner, clock)
 	, m_bankshift(12)
 	, m_bankmask(0x70)
 {
@@ -99,10 +108,15 @@ sega_315_5218_device::sega_315_5218_device(const machine_config &mconfig, const 
 //  device_start - device-specific startup
 //-------------------------------------------------
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-void segapcm_device<MaxVoices, Divider, AddrBits>::device_start()
+void segapcm_base_device::device_start()
 {
 	std::fill_n(&m_ram[0], m_ram.length(), 0xff);
+}
+
+template<unsigned MaxVoices>
+void segapcm_device<MaxVoices>::device_start()
+{
+	segapcm_base_device::device_start();
 
 	m_stream = stream_alloc(0, 2, clock() / CLOCK_DIVIDER);
 
@@ -126,8 +140,8 @@ void segapcm_device<MaxVoices, Divider, AddrBits>::device_start()
 //  changes
 //-------------------------------------------------
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-void segapcm_device<MaxVoices, Divider, AddrBits>::device_clock_changed()
+template<unsigned MaxVoices>
+void segapcm_device<MaxVoices>::device_clock_changed()
 {
 	m_stream->set_sample_rate(clock() / CLOCK_DIVIDER);
 }
@@ -138,8 +152,7 @@ void segapcm_device<MaxVoices, Divider, AddrBits>::device_clock_changed()
 //  ROM banking changes
 //-------------------------------------------------
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-void segapcm_device<MaxVoices, Divider, AddrBits>::rom_bank_pre_change()
+void segapcm_base_device::rom_bank_pre_change()
 {
 	m_stream->update();
 }
@@ -149,27 +162,26 @@ void segapcm_device<MaxVoices, Divider, AddrBits>::rom_bank_pre_change()
 //  sound_stream_update - handle a stream update
 //-------------------------------------------------
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-void segapcm_device<MaxVoices, Divider, AddrBits>::sound_stream_update(sound_stream &stream)
+template<unsigned MaxVoices>
+void segapcm_device<MaxVoices>::sound_stream_update(sound_stream &stream)
 {
 	/* loop over streams */
 	for (int i = 0; i < stream.samples(); i++)
 	{
 		int32_t lout = 0, rout = 0;
-		for (int ch = 0; ch < MAX_VOICES; ch++)
+		for (auto &elem : m_voice)
 		{
-			voice_t &voice = m_voice[ch];
-			voice.tick();
-			lout += voice.lout;
-			rout += voice.rout;
+			elem.tick();
+			lout += elem.lout;
+			rout += elem.rout;
 		}
 		stream.put_int(0, i, lout, 32768);
 		stream.put_int(1, i, rout, 32768);
 	}
 }
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-void segapcm_device<MaxVoices, Divider, AddrBits>::voice_t::tick()
+template<unsigned MaxVoices>
+void segapcm_device<MaxVoices>::voice_t::tick()
 {
 	// only process active channels
 	lout = rout = 0;
@@ -199,8 +211,8 @@ void segapcm_device<MaxVoices, Divider, AddrBits>::voice_t::tick()
 }
 
 // read/write handlers
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_addr_r(offs_t offset)
+template<unsigned MaxVoices>
+uint8_t segapcm_device<MaxVoices>::voice_addr_r(offs_t offset)
 {
 	m_stream->update();
 	voice_t &voice = m_voice[offset >> 3];
@@ -208,8 +220,8 @@ uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_addr_r(offs_t offset
 	return (voice.addr >> shift) & 0xff;
 }
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_loop_r(offs_t offset)
+template<unsigned MaxVoices>
+uint8_t segapcm_device<MaxVoices>::voice_loop_r(offs_t offset)
 {
 	m_stream->update();
 	voice_t &voice = m_voice[offset >> 3];
@@ -217,48 +229,48 @@ uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_loop_r(offs_t offset
 	return (voice.loop >> shift) & 0xff;
 }
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_end_r(offs_t offset)
+template<unsigned MaxVoices>
+uint8_t segapcm_device<MaxVoices>::voice_end_r(offs_t offset)
 {
 	m_stream->update();
 	voice_t &voice = m_voice[offset >> 3];
 	return voice.end;
 }
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_freq_r(offs_t offset)
+template<unsigned MaxVoices>
+uint8_t segapcm_device<MaxVoices>::voice_freq_r(offs_t offset)
 {
 	m_stream->update();
 	voice_t &voice = m_voice[offset >> 3];
 	return voice.freq;
 }
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_lvol_r(offs_t offset)
+template<unsigned MaxVoices>
+uint8_t segapcm_device<MaxVoices>::voice_lvol_r(offs_t offset)
 {
 	m_stream->update();
 	voice_t &voice = m_voice[offset >> 3];
 	return voice.lvol;
 }
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_rvol_r(offs_t offset)
+template<unsigned MaxVoices>
+uint8_t segapcm_device<MaxVoices>::voice_rvol_r(offs_t offset)
 {
 	m_stream->update();
 	voice_t &voice = m_voice[offset >> 3];
 	return voice.rvol;
 }
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-uint8_t segapcm_device<MaxVoices, Divider, AddrBits>::voice_ctrl_r(offs_t offset)
+template<unsigned MaxVoices>
+uint8_t segapcm_device<MaxVoices>::voice_ctrl_r(offs_t offset)
 {
 	m_stream->update();
 	voice_t &voice = m_voice[offset >> 3];
 	return voice.ctrl;
 }
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-void segapcm_device<MaxVoices, Divider, AddrBits>::voice_addr_w(offs_t offset, uint8_t data)
+template<unsigned MaxVoices>
+void segapcm_device<MaxVoices>::voice_addr_w(offs_t offset, uint8_t data)
 {
 	m_stream->update();
 	voice_t &voice = m_voice[offset >> 3];
@@ -266,8 +278,8 @@ void segapcm_device<MaxVoices, Divider, AddrBits>::voice_addr_w(offs_t offset, u
 	voice.addr = (voice.addr & ~(0xff << shift)) | (uint32_t(data) << shift);
 }
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-void segapcm_device<MaxVoices, Divider, AddrBits>::voice_loop_w(offs_t offset, uint8_t data)
+template<unsigned MaxVoices>
+void segapcm_device<MaxVoices>::voice_loop_w(offs_t offset, uint8_t data)
 {
 	m_stream->update();
 	voice_t &voice = m_voice[offset >> 3];
@@ -275,40 +287,40 @@ void segapcm_device<MaxVoices, Divider, AddrBits>::voice_loop_w(offs_t offset, u
 	voice.loop = (voice.loop & ~(0xff << shift)) | (uint32_t(data) << shift);
 }
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-void segapcm_device<MaxVoices, Divider, AddrBits>::voice_end_w(offs_t offset, uint8_t data)
+template<unsigned MaxVoices>
+void segapcm_device<MaxVoices>::voice_end_w(offs_t offset, uint8_t data)
 {
 	m_stream->update();
 	voice_t &voice = m_voice[offset >> 3];
 	voice.end = data;
 }
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-void segapcm_device<MaxVoices, Divider, AddrBits>::voice_freq_w(offs_t offset, uint8_t data)
+template<unsigned MaxVoices>
+void segapcm_device<MaxVoices>::voice_freq_w(offs_t offset, uint8_t data)
 {
 	m_stream->update();
 	voice_t &voice = m_voice[offset >> 3];
 	voice.freq = data;
 }
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-void segapcm_device<MaxVoices, Divider, AddrBits>::voice_lvol_w(offs_t offset, uint8_t data)
+template<unsigned MaxVoices>
+void segapcm_device<MaxVoices>::voice_lvol_w(offs_t offset, uint8_t data)
 {
 	m_stream->update();
 	voice_t &voice = m_voice[offset >> 3];
 	voice.lvol = data;
 }
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-void segapcm_device<MaxVoices, Divider, AddrBits>::voice_rvol_w(offs_t offset, uint8_t data)
+template<unsigned MaxVoices>
+void segapcm_device<MaxVoices>::voice_rvol_w(offs_t offset, uint8_t data)
 {
 	m_stream->update();
 	voice_t &voice = m_voice[offset >> 3];
 	voice.rvol = data;
 }
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-void segapcm_device<MaxVoices, Divider, AddrBits>::voice_ctrl_w(offs_t offset, uint8_t data)
+template<unsigned MaxVoices>
+void segapcm_device<MaxVoices>::voice_ctrl_w(offs_t offset, uint8_t data)
 {
 	m_stream->update();
 	voice_t &voice = m_voice[offset >> 3];
@@ -316,5 +328,5 @@ void segapcm_device<MaxVoices, Divider, AddrBits>::voice_ctrl_w(offs_t offset, u
 }
 
 // template class definition
-template class segapcm_device<8, 64, 16>;
-template class segapcm_device<16, 128, 21>;
+template class segapcm_device<8>;
+template class segapcm_device<16>;

--- a/src/devices/sound/segapcm.cpp
+++ b/src/devices/sound/segapcm.cpp
@@ -77,7 +77,7 @@ segapcm_base_device::segapcm_base_device(const machine_config &mconfig, device_t
 //  segapcm_device - constructor
 //-------------------------------------------------
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 segapcm_device<MaxVoices>::segapcm_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
 	: segapcm_base_device(mconfig, type, tag, owner, clock)
 {
@@ -113,14 +113,14 @@ void segapcm_base_device::device_start()
 	std::fill_n(&m_ram[0], m_ram.length(), 0xff);
 }
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 void segapcm_device<MaxVoices>::device_start()
 {
 	segapcm_base_device::device_start();
 
 	m_stream = stream_alloc(0, 2, clock() / CLOCK_DIVIDER);
 
-	for (auto & elem : m_voice)
+	for (auto &elem : m_voice)
 		elem.host = this;
 
 	save_item(STRUCT_MEMBER(m_voice, addr));
@@ -140,7 +140,7 @@ void segapcm_device<MaxVoices>::device_start()
 //  changes
 //-------------------------------------------------
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 void segapcm_device<MaxVoices>::device_clock_changed()
 {
 	m_stream->set_sample_rate(clock() / CLOCK_DIVIDER);
@@ -162,7 +162,7 @@ void segapcm_base_device::rom_bank_pre_change()
 //  sound_stream_update - handle a stream update
 //-------------------------------------------------
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 void segapcm_device<MaxVoices>::sound_stream_update(sound_stream &stream)
 {
 	/* loop over streams */
@@ -210,7 +210,7 @@ void segapcm_base_device::voice_t::tick()
 }
 
 // read/write handlers
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 uint8_t segapcm_device<MaxVoices>::voice_addr_r(offs_t offset)
 {
 	m_stream->update();
@@ -219,7 +219,7 @@ uint8_t segapcm_device<MaxVoices>::voice_addr_r(offs_t offset)
 	return (voice.addr >> shift) & 0xff;
 }
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 uint8_t segapcm_device<MaxVoices>::voice_loop_r(offs_t offset)
 {
 	m_stream->update();
@@ -228,7 +228,7 @@ uint8_t segapcm_device<MaxVoices>::voice_loop_r(offs_t offset)
 	return (voice.loop >> shift) & 0xff;
 }
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 uint8_t segapcm_device<MaxVoices>::voice_end_r(offs_t offset)
 {
 	m_stream->update();
@@ -236,7 +236,7 @@ uint8_t segapcm_device<MaxVoices>::voice_end_r(offs_t offset)
 	return voice.end;
 }
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 uint8_t segapcm_device<MaxVoices>::voice_freq_r(offs_t offset)
 {
 	m_stream->update();
@@ -244,7 +244,7 @@ uint8_t segapcm_device<MaxVoices>::voice_freq_r(offs_t offset)
 	return voice.freq;
 }
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 uint8_t segapcm_device<MaxVoices>::voice_lvol_r(offs_t offset)
 {
 	m_stream->update();
@@ -252,7 +252,7 @@ uint8_t segapcm_device<MaxVoices>::voice_lvol_r(offs_t offset)
 	return voice.lvol;
 }
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 uint8_t segapcm_device<MaxVoices>::voice_rvol_r(offs_t offset)
 {
 	m_stream->update();
@@ -260,7 +260,7 @@ uint8_t segapcm_device<MaxVoices>::voice_rvol_r(offs_t offset)
 	return voice.rvol;
 }
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 uint8_t segapcm_device<MaxVoices>::voice_ctrl_r(offs_t offset)
 {
 	m_stream->update();
@@ -268,7 +268,7 @@ uint8_t segapcm_device<MaxVoices>::voice_ctrl_r(offs_t offset)
 	return voice.ctrl;
 }
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 void segapcm_device<MaxVoices>::voice_addr_w(offs_t offset, uint8_t data)
 {
 	m_stream->update();
@@ -277,7 +277,7 @@ void segapcm_device<MaxVoices>::voice_addr_w(offs_t offset, uint8_t data)
 	voice.addr = (voice.addr & ~(0xff << shift)) | (uint32_t(data) << shift);
 }
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 void segapcm_device<MaxVoices>::voice_loop_w(offs_t offset, uint8_t data)
 {
 	m_stream->update();
@@ -286,7 +286,7 @@ void segapcm_device<MaxVoices>::voice_loop_w(offs_t offset, uint8_t data)
 	voice.loop = (voice.loop & ~(0xff << shift)) | (uint32_t(data) << shift);
 }
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 void segapcm_device<MaxVoices>::voice_end_w(offs_t offset, uint8_t data)
 {
 	m_stream->update();
@@ -294,7 +294,7 @@ void segapcm_device<MaxVoices>::voice_end_w(offs_t offset, uint8_t data)
 	voice.end = data;
 }
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 void segapcm_device<MaxVoices>::voice_freq_w(offs_t offset, uint8_t data)
 {
 	m_stream->update();
@@ -302,7 +302,7 @@ void segapcm_device<MaxVoices>::voice_freq_w(offs_t offset, uint8_t data)
 	voice.freq = data;
 }
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 void segapcm_device<MaxVoices>::voice_lvol_w(offs_t offset, uint8_t data)
 {
 	m_stream->update();
@@ -310,7 +310,7 @@ void segapcm_device<MaxVoices>::voice_lvol_w(offs_t offset, uint8_t data)
 	voice.lvol = data;
 }
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 void segapcm_device<MaxVoices>::voice_rvol_w(offs_t offset, uint8_t data)
 {
 	m_stream->update();
@@ -318,7 +318,7 @@ void segapcm_device<MaxVoices>::voice_rvol_w(offs_t offset, uint8_t data)
 	voice.rvol = data;
 }
 
-template<unsigned MaxVoices>
+template <unsigned MaxVoices>
 void segapcm_device<MaxVoices>::voice_ctrl_w(offs_t offset, uint8_t data)
 {
 	m_stream->update();
@@ -326,6 +326,6 @@ void segapcm_device<MaxVoices>::voice_ctrl_w(offs_t offset, uint8_t data)
 	voice.ctrl = data;
 }
 
-// template class definition
+// template class instantiation
 template class segapcm_device<8>;
 template class segapcm_device<16>;

--- a/src/devices/sound/segapcm.cpp
+++ b/src/devices/sound/segapcm.cpp
@@ -31,7 +31,8 @@ DEFINE_DEVICE_TYPE(SEGA_315_5218,    sega_315_5218_device,    "sega_315_5218",  
 // 0x85     current address (16-23)
 // 0x86     bit 0: channel disable?
 //          bit 1: loop disable
-//          other bits: bank
+//          bit 7: unknown (discrete logic)
+//          other bits: bank (315-5218)
 // 0x87     ?
 
 // only lower half of register set is valid
@@ -69,8 +70,6 @@ segapcm_device<MaxVoices, Divider, AddrBits>::segapcm_device(const machine_confi
 	, device_sound_interface(mconfig, *this)
 	, device_rom_interface<AddrBits>(mconfig, *this)
 	, m_ram(*this, "ram")
-	, m_bankshift(12)
-	, m_bankmask(0x70)
 	, m_stream(nullptr)
 {
 }
@@ -90,6 +89,8 @@ segapcm_discrete_device::segapcm_discrete_device(const machine_config &mconfig, 
 
 sega_315_5218_device::sega_315_5218_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: segapcm_device<16, 128, 21>(mconfig, SEGA_315_5218, tag, owner, clock)
+	, m_bankshift(12)
+	, m_bankmask(0x70)
 {
 }
 
@@ -158,7 +159,7 @@ void segapcm_device<MaxVoices, Divider, AddrBits>::sound_stream_update(sound_str
 		for (int ch = 0; ch < MAX_VOICES; ch++)
 		{
 			voice_t &voice = m_voice[ch];
-			voice.tick(m_bankmask, m_bankshift);
+			voice.tick();
 			lout += voice.lout;
 			rout += voice.rout;
 		}
@@ -168,7 +169,7 @@ void segapcm_device<MaxVoices, Divider, AddrBits>::sound_stream_update(sound_str
 }
 
 template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-void segapcm_device<MaxVoices, Divider, AddrBits>::voice_t::tick(uint32_t bankmask, uint32_t bankshift)
+void segapcm_device<MaxVoices, Divider, AddrBits>::voice_t::tick()
 {
 	// only process active channels
 	lout = rout = 0;
@@ -186,7 +187,7 @@ void segapcm_device<MaxVoices, Divider, AddrBits>::voice_t::tick(uint32_t bankma
 				addr = (uint32_t(loop) << 8);
 		}
 		// fetch the sample
-		const uint32_t bank = (ctrl & bankmask) << bankshift;
+		const uint32_t bank = host->get_bank(ctrl);
 		const int8_t v = host->read_byte(bank + (addr >> 8)) - 0x80;
 		// apply panning and advance
 		lout = v * (lvol & 0x7f);

--- a/src/devices/sound/segapcm.h
+++ b/src/devices/sound/segapcm.h
@@ -15,14 +15,31 @@
 //  TYPE DEFINITIONS
 //**************************************************************************
 
-template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
-class segapcm_device : public device_t,
-					   public device_sound_interface,
-					   public device_rom_interface<AddrBits>
+class segapcm_base_device : public device_t,
+							public device_sound_interface,
+							public device_rom_interface<21>
+{
+protected:
+	segapcm_base_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override ATTR_COLD;
+
+	// device_rom_interface overrides
+	virtual void rom_bank_pre_change() override;
+
+	virtual uint32_t get_bank(uint8_t ctrl) { return 0; }
+
+	required_shared_ptr<uint8_t> m_ram;
+	sound_stream* m_stream;
+};
+
+template<unsigned MaxVoices>
+class segapcm_device : public segapcm_base_device
 {
 protected:
 	static constexpr unsigned MAX_VOICES = MaxVoices;  // max voices
-	static constexpr unsigned CLOCK_DIVIDER = Divider; // clock divider for generate output rate
+	static constexpr unsigned CLOCK_DIVIDER = MaxVoices * 8; // clock divider for generate output rate
 
 	segapcm_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
@@ -32,28 +49,6 @@ protected:
 
 	// sound stream update overrides
 	virtual void sound_stream_update(sound_stream &stream) override;
-
-	// device_rom_interface overrides
-	virtual void rom_bank_pre_change() override;
-
-	virtual uint32_t get_bank(uint8_t ctrl) { return 0; }
-
-	struct voice_t
-	{
-		void tick();
-
-		segapcm_device<MaxVoices, Divider, AddrBits> *host;
-
-		uint32_t addr = ~0; // current address (16.8 fixed point)
-		uint16_t loop = ~0; // loop address
-		uint8_t end = ~0;   // end address (bit 16-8 valid)
-		uint8_t freq = ~0;  // frequency
-		uint8_t lvol = ~0;  // left volume
-		uint8_t rvol = ~0;  // right volume
-		uint8_t ctrl = ~0;  // control bits
-		int32_t lout = 0;   // left output
-		int32_t rout = 0;   // right output
-	};
 
 	// read/write handlers
 	uint8_t voice_addr_r(offs_t offset);
@@ -72,15 +67,30 @@ protected:
 	void voice_rvol_w(offs_t offset, uint8_t data);
 	void voice_ctrl_w(offs_t offset, uint8_t data);
 
-	required_shared_ptr<uint8_t> m_ram;
-
 private:
+	struct voice_t
+	{
+		void tick();
+
+		segapcm_device *host;
+
+		uint32_t addr = ~0; // current address (16.8 fixed point)
+		uint16_t loop = ~0; // loop address
+		uint8_t end = ~0;   // end address (bit 16-8 valid)
+		uint8_t freq = ~0;  // frequency
+		uint8_t lvol = ~0;  // left volume
+		uint8_t rvol = ~0;  // right volume
+		uint8_t ctrl = ~0;  // control bits
+		int32_t lout = 0;   // left output
+		int32_t rout = 0;   // right output
+	};
+
 	voice_t m_voice[MaxVoices];
-	sound_stream* m_stream;
 };
 
 
-class segapcm_discrete_device : public segapcm_device<8, 64, 16>
+// no bankswitch support?
+class segapcm_discrete_device : public segapcm_device<8>
 {
 public:
 	segapcm_discrete_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
@@ -88,7 +98,7 @@ public:
 	void map(address_map &map) ATTR_COLD;
 };
 
-class sega_315_5218_device : public segapcm_device<16, 128, 21>
+class sega_315_5218_device : public segapcm_device<16>
 {
 public:
 	static constexpr int BANK_256    = 11;
@@ -120,7 +130,7 @@ DECLARE_DEVICE_TYPE(SEGA_315_5218,    sega_315_5218_device)
 //  EXTERNAL TEMPLATE INSTANTIATIONS
 //**************************************************************************
 
-extern template class segapcm_device<8, 64, 16>;
-extern template class segapcm_device<16, 128, 21>;
+extern template class segapcm_device<8>;
+extern template class segapcm_device<16>;
 
 #endif // MAME_SOUND_SEGAPCM_H

--- a/src/devices/sound/segapcm.h
+++ b/src/devices/sound/segapcm.h
@@ -36,11 +36,13 @@ protected:
 	// device_rom_interface overrides
 	virtual void rom_bank_pre_change() override;
 
+	virtual uint32_t get_bank(uint8_t ctrl) { return 0; }
+
 	struct voice_t
 	{
-		void tick(uint32_t bankmask, uint32_t bankshift);
+		void tick();
 
-		device_rom_interface<AddrBits> *host;
+		segapcm_device<MaxVoices, Divider, AddrBits> *host;
 
 		uint32_t addr = ~0; // current address (16.8 fixed point)
 		uint16_t loop = ~0; // loop address
@@ -72,9 +74,6 @@ protected:
 
 	required_shared_ptr<uint8_t> m_ram;
 
-	int m_bankshift;
-	int m_bankmask;
-
 private:
 	voice_t m_voice[MaxVoices];
 	sound_stream* m_stream;
@@ -105,6 +104,13 @@ public:
 	void set_bank(int bank) { m_bankshift = (bank & 0xf); m_bankmask = (0x70 | ((bank >> 16) & 0xfc)); }
 
 	void map(address_map &map) ATTR_COLD;
+
+protected:
+	virtual uint32_t get_bank(uint8_t ctrl) override { return (ctrl & m_bankmask) << m_bankshift; }
+
+private:
+	int m_bankshift;
+	int m_bankmask;
 };
 
 DECLARE_DEVICE_TYPE(SEGAPCM_DISCRETE, segapcm_discrete_device)

--- a/src/devices/sound/segapcm.h
+++ b/src/devices/sound/segapcm.h
@@ -15,27 +15,17 @@
 //  TYPE DEFINITIONS
 //**************************************************************************
 
+template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
 class segapcm_device : public device_t,
-					   public device_sound_interface,
-					   public device_rom_interface<21>
+							public device_sound_interface,
+							public device_rom_interface<AddrBits>
 {
-public:
-	static constexpr int BANK_256    = 11;
-	static constexpr int BANK_512    = 12;
-	static constexpr int BANK_12M    = 13;
-	static constexpr int BANK_MASK7  = 0x70 << 16;
-	static constexpr int BANK_MASKF  = 0xf0 << 16;
-	static constexpr int BANK_MASKF8 = 0xf8 << 16;
-
-	segapcm_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-	// configuration
-	void set_bank(int bank) { m_bankshift = (bank & 0xf); m_bankmask = (0x70|((bank >> 16) & 0xfc)); }
-
-	void write(offs_t offset, uint8_t data);
-	uint8_t read(offs_t offset);
-
 protected:
+	static constexpr unsigned MAX_VOICES = MaxVoices;  // max voices
+	static constexpr unsigned CLOCK_DIVIDER = Divider; // clock divider for generate output rate
+
+	segapcm_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
 	// device-level overrides
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_clock_changed() override;
@@ -46,14 +36,84 @@ protected:
 	// device_rom_interface overrides
 	virtual void rom_bank_pre_change() override;
 
-private:
-	std::unique_ptr<uint8_t[]> m_ram;
-	uint8_t m_low[16];
+	struct voice_t
+	{
+		void tick(uint32_t bankmask, uint32_t bankshift);
+
+		device_rom_interface<AddrBits> *host;
+
+		uint32_t addr = ~0; // current address (16.8 fixed point)
+		uint16_t loop = ~0; // loop address
+		uint8_t end = ~0;   // end address (bit 16-8 valid)
+		uint8_t freq = ~0;  // frequency
+		uint8_t lvol = ~0;  // left volume
+		uint8_t rvol = ~0;  // right volume
+		uint8_t ctrl = ~0;  // control bits
+		int32_t lout = 0;   // left output
+		int32_t rout = 0;   // right output
+	};
+
+	uint8_t voice_addr_r(offs_t offset);
+	uint8_t voice_loop_r(offs_t offset);
+	uint8_t voice_end_r(offs_t offset);
+	uint8_t voice_freq_r(offs_t offset);
+	uint8_t voice_lvol_r(offs_t offset);
+	uint8_t voice_rvol_r(offs_t offset);
+	uint8_t voice_ctrl_r(offs_t offset);
+
+	void voice_addr_w(offs_t offset, uint8_t data);
+	void voice_loop_w(offs_t offset, uint8_t data);
+	void voice_end_w(offs_t offset, uint8_t data);
+	void voice_freq_w(offs_t offset, uint8_t data);
+	void voice_lvol_w(offs_t offset, uint8_t data);
+	void voice_rvol_w(offs_t offset, uint8_t data);
+	void voice_ctrl_w(offs_t offset, uint8_t data);
+
+	required_shared_ptr<uint8_t> m_ram;
+
 	int m_bankshift;
 	int m_bankmask;
+
+private:
+	voice_t m_voice[MaxVoices];
 	sound_stream* m_stream;
 };
 
-DECLARE_DEVICE_TYPE(SEGAPCM, segapcm_device)
+
+class segapcm_discrete_device : public segapcm_device<8, 64, 16>
+{
+public:
+	segapcm_discrete_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	void map(address_map &map) ATTR_COLD;
+};
+
+class sega_315_5218_device : public segapcm_device<16, 128, 21>
+{
+public:
+	static constexpr int BANK_256    = 11;
+	static constexpr int BANK_512    = 12;
+	static constexpr int BANK_12M    = 13;
+	static constexpr int BANK_MASK7  = 0x70 << 16;
+	static constexpr int BANK_MASKF  = 0xf0 << 16;
+	static constexpr int BANK_MASKF8 = 0xf8 << 16;
+
+	sega_315_5218_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// configuration
+	void set_bank(int bank) { m_bankshift = (bank & 0xf); m_bankmask = (0x70 | ((bank >> 16) & 0xfc)); }
+
+	void map(address_map &map) ATTR_COLD;
+};
+
+DECLARE_DEVICE_TYPE(SEGAPCM_DISCRETE, segapcm_discrete_device)
+DECLARE_DEVICE_TYPE(SEGA_315_5218,    sega_315_5218_device)
+
+//**************************************************************************
+//  EXTERNAL TEMPLATE INSTANTIATIONS
+//**************************************************************************
+
+extern template class segapcm_device<8, 64, 16>;
+extern template class segapcm_device<16, 128, 21>;
 
 #endif // MAME_SOUND_SEGAPCM_H

--- a/src/devices/sound/segapcm.h
+++ b/src/devices/sound/segapcm.h
@@ -22,7 +22,7 @@ class segapcm_base_device : public device_t,
 protected:
 	segapcm_base_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
-	// device-level overrides
+	// device_t implementation
 	virtual void device_start() override ATTR_COLD;
 
 	// device_rom_interface overrides
@@ -48,7 +48,7 @@ protected:
 	};
 
 	required_shared_ptr<uint8_t> m_ram;
-	sound_stream* m_stream;
+	sound_stream *m_stream;
 };
 
 template<unsigned MaxVoices>
@@ -60,11 +60,11 @@ protected:
 
 	segapcm_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
-	// device-level overrides
+	// device_t implementation
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_clock_changed() override;
 
-	// sound stream update overrides
+	// device_sound_interface implementation
 	virtual void sound_stream_update(sound_stream &stream) override;
 
 	// read/write handlers

--- a/src/devices/sound/segapcm.h
+++ b/src/devices/sound/segapcm.h
@@ -30,6 +30,23 @@ protected:
 
 	virtual uint32_t get_bank(uint8_t ctrl) { return 0; }
 
+	struct voice_t
+	{
+		void tick();
+
+		segapcm_base_device *host;
+
+		uint32_t addr = ~0; // current address (16.8 fixed point)
+		uint16_t loop = ~0; // loop address
+		uint8_t end = ~0;   // end address (bit 16-8 valid)
+		uint8_t freq = ~0;  // frequency
+		uint8_t lvol = ~0;  // left volume
+		uint8_t rvol = ~0;  // right volume
+		uint8_t ctrl = ~0;  // control bits
+		int32_t lout = 0;   // left output
+		int32_t rout = 0;   // right output
+	};
+
 	required_shared_ptr<uint8_t> m_ram;
 	sound_stream* m_stream;
 };
@@ -68,23 +85,6 @@ protected:
 	void voice_ctrl_w(offs_t offset, uint8_t data);
 
 private:
-	struct voice_t
-	{
-		void tick();
-
-		segapcm_device *host;
-
-		uint32_t addr = ~0; // current address (16.8 fixed point)
-		uint16_t loop = ~0; // loop address
-		uint8_t end = ~0;   // end address (bit 16-8 valid)
-		uint8_t freq = ~0;  // frequency
-		uint8_t lvol = ~0;  // left volume
-		uint8_t rvol = ~0;  // right volume
-		uint8_t ctrl = ~0;  // control bits
-		int32_t lout = 0;   // left output
-		int32_t rout = 0;   // right output
-	};
-
 	voice_t m_voice[MaxVoices];
 };
 

--- a/src/devices/sound/segapcm.h
+++ b/src/devices/sound/segapcm.h
@@ -17,8 +17,8 @@
 
 template<unsigned MaxVoices, unsigned Divider, unsigned AddrBits>
 class segapcm_device : public device_t,
-							public device_sound_interface,
-							public device_rom_interface<AddrBits>
+					   public device_sound_interface,
+					   public device_rom_interface<AddrBits>
 {
 protected:
 	static constexpr unsigned MAX_VOICES = MaxVoices;  // max voices
@@ -53,6 +53,7 @@ protected:
 		int32_t rout = 0;   // right output
 	};
 
+	// read/write handlers
 	uint8_t voice_addr_r(offs_t offset);
 	uint8_t voice_loop_r(offs_t offset);
 	uint8_t voice_end_r(offs_t offset);

--- a/src/mame/sega/segahang.cpp
+++ b/src/mame/sega/segahang.cpp
@@ -678,7 +678,7 @@ void segahang_state::sound_map_2203(address_map &map)
 	map(0x0000, 0x7fff).rom();
 	map(0xc000, 0xc7ff).mirror(0x0800).ram();
 	map(0xd000, 0xd001).mirror(0x0ffe).rw("ymsnd", FUNC(ym2203_device::read), FUNC(ym2203_device::write));
-	map(0xe000, 0xe0ff).mirror(0x0f00).rw("pcm", FUNC(segapcm_device::read), FUNC(segapcm_device::write));
+	map(0xe000, 0xe0ff).mirror(0x0f00).m("pcm", FUNC(segapcm_discrete_device::map));
 }
 
 void segahang_state::sound_portmap_2203(address_map &map)
@@ -692,7 +692,7 @@ void segahang_state::sound_map_2151(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x0000, 0x7fff).rom();
-	map(0xf000, 0xf0ff).mirror(0x700).rw("pcm", FUNC(segapcm_device::read), FUNC(segapcm_device::write));
+	map(0xf000, 0xf0ff).mirror(0x700).m("pcm", FUNC(sega_315_5218_device::map));
 	map(0xf800, 0xffff).ram();
 }
 
@@ -1090,8 +1090,7 @@ void segahang_state::sound_board_2203(machine_config &config)
 	ymsnd.add_route(3, "speaker", 0.15, 0);
 	ymsnd.add_route(3, "speaker", 0.15, 1);
 
-	segapcm_device &pcm(SEGAPCM(config, "pcm", 8_MHz_XTAL));
-	pcm.set_bank(segapcm_device::BANK_512);
+	segapcm_discrete_device &pcm(SEGAPCM_DISCRETE(config, "pcm", 8_MHz_XTAL / 2));
 	pcm.add_route(0, "speaker", 0.40, 0);
 	pcm.add_route(1, "speaker", 0.40, 1);
 }
@@ -1127,8 +1126,8 @@ void segahang_state::sound_board_2203x2(machine_config &config)
 	ym2.add_route(3, "speaker", 0.15, 0);
 	ym2.add_route(3, "speaker", 0.15, 1);
 
-	segapcm_device &pcm(SEGAPCM(config, "pcm", 8_MHz_XTAL / 2));
-	pcm.set_bank(segapcm_device::BANK_512);
+	sega_315_5218_device &pcm(SEGA_315_5218(config, "pcm", 8_MHz_XTAL / 2));
+	pcm.set_bank(sega_315_5218_device::BANK_512);
 	pcm.add_route(0, "speaker", 0.40, 0);
 	pcm.add_route(1, "speaker", 0.40, 1);
 }
@@ -1148,8 +1147,8 @@ void segahang_state::sound_board_2151(machine_config &config)
 	ymsnd.add_route(0, "speaker", 0.30, 0);
 	ymsnd.add_route(1, "speaker", 0.30, 1);
 
-	segapcm_device &pcm(SEGAPCM(config, "pcm", 8_MHz_XTAL / 2));
-	pcm.set_bank(segapcm_device::BANK_512);
+	sega_315_5218_device &pcm(SEGA_315_5218(config, "pcm", 8_MHz_XTAL / 2));
+	pcm.set_bank(sega_315_5218_device::BANK_512);
 	pcm.add_route(0, "speaker", 0.70, 0);
 	pcm.add_route(1, "speaker", 0.70, 1);
 }

--- a/src/mame/sega/segaorun.cpp
+++ b/src/mame/sega/segaorun.cpp
@@ -1223,7 +1223,7 @@ void segaorun_state::sound_map(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x0000, 0xefff).rom();
-	map(0xf000, 0xf0ff).mirror(0x0700).rw("pcm", FUNC(segapcm_device::read), FUNC(segapcm_device::write));
+	map(0xf000, 0xf0ff).mirror(0x0700).m("pcm", FUNC(sega_315_5218_device::map));
 	map(0xf800, 0xffff).ram();
 }
 
@@ -1537,8 +1537,8 @@ void segaorun_state::outrun_base(machine_config &config)
 	ymsnd.add_route(0, "speaker", 0.30, 0);
 	ymsnd.add_route(1, "speaker", 0.30, 1);
 
-	segapcm_device &pcm(SEGAPCM(config, "pcm", 16_MHz_XTAL / 4));
-	pcm.set_bank(segapcm_device::BANK_512);
+	sega_315_5218_device &pcm(SEGA_315_5218(config, "pcm", 16_MHz_XTAL / 4));
+	pcm.set_bank(sega_315_5218_device::BANK_512);
 	pcm.add_route(0, "speaker", 0.70, 0);
 	pcm.add_route(1, "speaker", 0.70, 1);
 }

--- a/src/mame/sega/segaxbd.cpp
+++ b/src/mame/sega/segaxbd.cpp
@@ -1075,7 +1075,7 @@ void segaxbd_state::sound_map(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x0000, 0xefff).rom();
-	map(0xf000, 0xf0ff).mirror(0x0700).rw("pcm", FUNC(segapcm_device::read), FUNC(segapcm_device::write));
+	map(0xf000, 0xf0ff).mirror(0x0700).m("pcm", FUNC(sega_315_5218_device::map));
 	map(0xf800, 0xffff).ram();
 }
 
@@ -1100,7 +1100,7 @@ void segaxbd_state::smgp_sound2_map(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x0000, 0xefff).rom();
-	map(0xf000, 0xf0ff).mirror(0x0700).rw("pcm2", FUNC(segapcm_device::read), FUNC(segapcm_device::write));
+	map(0xf000, 0xf0ff).mirror(0x0700).m("pcm2", FUNC(sega_315_5218_device::map));
 	map(0xf800, 0xffff).ram();
 }
 
@@ -1853,8 +1853,8 @@ void segaxbd_state::xboard_base_mconfig(machine_config &config)
 	ymsnd.add_route(0, "speaker", 0.15, 0);
 	ymsnd.add_route(1, "speaker", 0.15, 1);
 
-	segapcm_device &pcm(SEGAPCM(config, "pcm", SOUND_CLOCK/4));
-	pcm.set_bank(segapcm_device::BANK_512);
+	sega_315_5218_device &pcm(SEGA_315_5218(config, "pcm", SOUND_CLOCK/4));
+	pcm.set_bank(sega_315_5218_device::BANK_512);
 	pcm.add_route(0, "speaker", 0.35, 0);
 	pcm.add_route(1, "speaker", 0.35, 1);
 }
@@ -2034,8 +2034,8 @@ void segaxbd_smgp_fd1094_state::device_add_mconfig(machine_config &config)
 	// sound hardware
 	SPEAKER(config, "rear", 2).rear();
 
-	segapcm_device &pcm2(SEGAPCM(config, "pcm2", SOUND_CLOCK/4));
-	pcm2.set_bank(segapcm_device::BANK_512);
+	sega_315_5218_device &pcm2(SEGA_315_5218(config, "pcm2", SOUND_CLOCK/4));
+	pcm2.set_bank(sega_315_5218_device::BANK_512);
 	pcm2.add_route(0, "rear", 0.35, 0);
 	pcm2.add_route(1, "rear", 0.35, 1);
 }
@@ -2078,8 +2078,8 @@ void segaxbd_smgp_state::device_add_mconfig(machine_config &config)
 	// sound hardware
 	SPEAKER(config, "rear", 2).rear();
 
-	segapcm_device &pcm2(SEGAPCM(config, "pcm2", SOUND_CLOCK/4));
-	pcm2.set_bank(segapcm_device::BANK_512);
+	sega_315_5218_device &pcm2(SEGA_315_5218(config, "pcm2", SOUND_CLOCK/4));
+	pcm2.set_bank(sega_315_5218_device::BANK_512);
 	pcm2.add_route(0, "rear", 0.35, 0);
 	pcm2.add_route(1, "rear", 0.35, 1);
 }

--- a/src/mame/sega/segaybd.cpp
+++ b/src/mame/sega/segaybd.cpp
@@ -1011,7 +1011,7 @@ void segaybd_state::sound_map(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x0000, 0xefff).rom();
-	map(0xf000, 0xf0ff).mirror(0x0700).rw("pcm", FUNC(segapcm_device::read), FUNC(segapcm_device::write));
+	map(0xf000, 0xf0ff).mirror(0x0700).m("pcm", FUNC(sega_315_5218_device::map));
 	map(0xf800, 0xffff).ram();
 }
 
@@ -1713,8 +1713,8 @@ void segaybd_state::yboard(machine_config &config)
 	ymsnd.add_route(0, "speaker", 0.30, 0);
 	ymsnd.add_route(1, "speaker", 0.30, 1);
 
-	segapcm_device &pcm(SEGAPCM(config, "pcm", SOUND_CLOCK/8));
-	pcm.set_bank(segapcm_device::BANK_12M | segapcm_device::BANK_MASKF8);
+	sega_315_5218_device &pcm(SEGA_315_5218(config, "pcm", SOUND_CLOCK/8));
+	pcm.set_bank(sega_315_5218_device::BANK_12M | sega_315_5218_device::BANK_MASKF8);
 	pcm.add_route(0, "speaker", 0.70, 0);
 	pcm.add_route(1, "speaker", 0.70, 1);
 }

--- a/src/mame/virtual/vgmplay.cpp
+++ b/src/mame/virtual/vgmplay.cpp
@@ -490,7 +490,7 @@ private:
 	required_device_array<ym2413_device, 2> m_ym2413;
 	required_device_array<ym2612_device, 2> m_ym2612;
 	required_device_array<ym2151_device, 2> m_ym2151;
-	required_device_array<segapcm_device, 2> m_segapcm;
+	required_device_array<sega_315_5218_device, 2> m_segapcm;
 	required_device<rf5c68_device> m_rf5c68;
 	required_device_array<ym2203_device, 2> m_ym2203;
 	required_device_array<ym2608_device, 2> m_ym2608;
@@ -1771,10 +1771,13 @@ void vgmplay_device::execute_run()
 			{
 				pulse_act_led(CT_SEGAPCM);
 				uint16_t offset = m_file->read_word(m_pc + 1);
-				if (offset & 0x8000)
-					m_io->write_byte(A_SEGAPCM_1 + (offset & 0x7fff), m_file->read_byte(m_pc + 3));
-				else
-					m_io->write_byte(A_SEGAPCM_0 + (offset & 0x7fff), m_file->read_byte(m_pc + 3));
+				if ((offset & 0x7fff) <= 0xff) // only low 8 bit of offset is valid
+				{
+					if (offset & 0x8000)
+						m_io->write_byte(A_SEGAPCM_1 + (offset & 0x7fff), m_file->read_byte(m_pc + 3));
+					else
+						m_io->write_byte(A_SEGAPCM_0 + (offset & 0x7fff), m_file->read_byte(m_pc + 3));
+				}
 				m_pc += 4;
 				break;
 			}
@@ -3371,8 +3374,8 @@ void vgmplay_state::soundchips_map(address_map &map)
 	map(vgmplay_device::A_YM2612_1, vgmplay_device::A_YM2612_1 + 3).w(m_ym2612[1], FUNC(ym2612_device::write));
 	map(vgmplay_device::A_YM2151_0, vgmplay_device::A_YM2151_0 + 1).w(m_ym2151[0], FUNC(ym2151_device::write));
 	map(vgmplay_device::A_YM2151_1, vgmplay_device::A_YM2151_1 + 1).w(m_ym2151[1], FUNC(ym2151_device::write));
-	map(vgmplay_device::A_SEGAPCM_0, vgmplay_device::A_SEGAPCM_0 + 0x7ff).w(m_segapcm[0], FUNC(segapcm_device::write));
-	map(vgmplay_device::A_SEGAPCM_1, vgmplay_device::A_SEGAPCM_1 + 0x7ff).w(m_segapcm[1], FUNC(segapcm_device::write));
+	map(vgmplay_device::A_SEGAPCM_0, vgmplay_device::A_SEGAPCM_0 + 0xff).m(m_segapcm[0], FUNC(sega_315_5218_device::map));
+	map(vgmplay_device::A_SEGAPCM_1, vgmplay_device::A_SEGAPCM_1 + 0xff).m(m_segapcm[1], FUNC(sega_315_5218_device::map));
 	map(vgmplay_device::A_RF5C68, vgmplay_device::A_RF5C68 + 0xf).w(m_rf5c68, FUNC(rf5c68_device::rf5c68_w));
 	map(vgmplay_device::A_RF5C68_RAM, vgmplay_device::A_RF5C68_RAM + 0xffff).w(m_rf5c68, FUNC(rf5c68_device::rf5c68_mem_w));
 	map(vgmplay_device::A_YM2203_0, vgmplay_device::A_YM2203_0 + 1).w(m_ym2203[0], FUNC(ym2203_device::write));
@@ -3698,12 +3701,12 @@ void vgmplay_state::vgmplay(machine_config &config)
 	m_ym2151[1]->add_route(0, m_viz, 1, 0);
 	m_ym2151[1]->add_route(1, m_viz, 1, 1);
 
-	SEGAPCM(config, m_segapcm[0], 0);
+	SEGA_315_5218(config, m_segapcm[0], 0);
 	m_segapcm[0]->set_addrmap(0, &vgmplay_state::segapcm_map<0>);
 	m_segapcm[0]->add_route(0, m_viz, 1, 0);
 	m_segapcm[0]->add_route(1, m_viz, 1, 1);
 
-	SEGAPCM(config, m_segapcm[1], 0);
+	SEGA_315_5218(config, m_segapcm[1], 0);
 	m_segapcm[1]->set_addrmap(0, &vgmplay_state::segapcm_map<1>);
 	m_segapcm[1]->add_route(0, m_viz, 1, 0);
 	m_segapcm[1]->add_route(1, m_viz, 1, 1);

--- a/src/mame/virtual/vgmplay.cpp
+++ b/src/mame/virtual/vgmplay.cpp
@@ -1770,13 +1770,18 @@ void vgmplay_device::execute_run()
 			case 0xc0:
 			{
 				pulse_act_led(CT_SEGAPCM);
-				uint16_t offset = m_file->read_word(m_pc + 1);
-				if ((offset & 0x7fff) <= 0xff) // only low 8 bit of offset is valid
+				const uint16_t offset = m_file->read_word(m_pc + 1);
+				const uint8_t data = m_file->read_byte(m_pc + 3);
+				if ((offset & 0x7ff) <= 0xff) // only low 11 bit of offset is checked
 				{
 					if (offset & 0x8000)
-						m_io->write_byte(A_SEGAPCM_1 + (offset & 0x7fff), m_file->read_byte(m_pc + 3));
+						m_io->write_byte(A_SEGAPCM_1 + (offset & 0xff), data);
 					else
-						m_io->write_byte(A_SEGAPCM_0 + (offset & 0x7fff), m_file->read_byte(m_pc + 3));
+						m_io->write_byte(A_SEGAPCM_0 + (offset & 0xff), data);
+				}
+				else
+				{
+					logerror("%s: Unknown Sega PCM %d write %04x = %02x\n", machine().describe_context(), (offset & 0x8000) >> 15, offset & 0x7fff, data);
 				}
 				m_pc += 4;
 				break;


### PR DESCRIPTION
- Fix output rate divider for both variant
- Use struct for voice registers
- Use address map to replace read/write handlers
- Use shared_ptr for register RAM