### PR TITLE
machine/nscsi_hle: allow targets to defer phase transitions

### DIFF
--- a/src/devices/machine/nscsi_hle.cpp
+++ b/src/devices/machine/nscsi_hle.cpp
@@ -191,6 +191,12 @@ void nscsi_full_device::step(bool timeout)
 		break;
 
 	case TARGET_NEXT_CONTROL: {
+		// An empty control queue means the target has deferred the phase
+		// sequence (e.g. a slow medium operation still in progress): hold the
+		// connection in the current state; the deferred scsi_data_in()/
+		// scsi_status_complete() pushes will resume stepping.
+		if(m_buf_control_rpos == m_buf_control_wpos)
+			return;
 		control *ctl = buf_control_pop();
 		switch(ctl->m_action) {
 		case BC_MSG_OR_COMMAND:
@@ -413,6 +419,17 @@ void nscsi_full_device::scsi_status_complete(uint8_t st)
 	c->m_param1 = SM_COMMAND_COMPLETE;
 	c = buf_control_push();
 	c->m_action = BC_BUS_FREE;
+	scsi_resume_deferred();
+}
+
+// Resume a deferred phase sequence: if the state machine is parked in
+// TARGET_NEXT_CONTROL on an empty queue (see step()), freshly pushed control
+// entries need a kick to start processing.  Calls from inside scsi_command()/
+// scsi_message() are no-ops because the state has not advanced yet.
+void nscsi_full_device::scsi_resume_deferred()
+{
+	if(m_scsi_state == TARGET_NEXT_CONTROL && m_buf_control_rpos != m_buf_control_wpos)
+		step(false);
 }
 
 void nscsi_full_device::scsi_data_in(int buf, int size)
@@ -433,6 +450,7 @@ void nscsi_full_device::scsi_data_in(int buf, int size)
 	c->m_action = BC_DATA_IN;
 	c->m_param1 = buf;
 	c->m_param2 = size;
+	scsi_resume_deferred();
 }
 
 void nscsi_full_device::scsi_data_out(int buf, int size)
@@ -442,6 +460,7 @@ void nscsi_full_device::scsi_data_out(int buf, int size)
 	c->m_action = BC_DATA_OUT;
 	c->m_param1 = buf;
 	c->m_param2 = size;
+	scsi_resume_deferred();
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/devices/machine/nscsi_hle.h
+++ b/src/devices/machine/nscsi_hle.h
@@ -534,6 +534,7 @@ protected:
 	void scsi_status_complete(uint8_t st);
 	void scsi_data_in(int buf, int size);
 	void scsi_data_out(int buf, int size);
+	void scsi_resume_deferred();
 
 	struct sense_data {
 		sense_data()


### PR DESCRIPTION
First of a three-part series: #15484 (SA1403D controller) and #15485 (xerox820 driver) stack on this.

## Summary

An `nscsi_full_device` target currently has to queue its entire phase sequence
(data, status, message) before returning from `scsi_command()`, so any command
involving slow media work has to complete synchronously inside the command
dispatch.

This makes `TARGET_NEXT_CONTROL` hold the connection in its current state when
the control queue is empty (instead of popping an invalid entry), and resumes
stepping when `scsi_data_in()` / `scsi_data_out()` / `scsi_status_complete()`
push new entries (`scsi_resume_deferred()`). A target can now return from
`scsi_command()` with nothing queued, run the medium operation off a timer,
and queue the data/status phases when it finishes.

First user: the Shugart SA1403D (next PR in the series), whose floppy section
runs real flux-level wd_fdc operations that take emulated milliseconds.

## Safety

Targets that queue everything up front never present an empty queue at
`TARGET_NEXT_CONTROL`, so they never reach the new hold path, and
`scsi_resume_deferred()` is a no-op while the state machine has not yet
advanced (calls from inside `scsi_command()` dispatch). No behavior change
for existing nscsi devices.

## Testing

- Existing nscsi target user unchanged by inspection (the new path requires an
  empty control queue, which synchronous targets cannot produce).
- Exercised end-to-end by the SA1403D + Xerox 820-II/16-8 SASI machines in the
  stacked PRs: full boot / CP/M-86 chains, including floppy-over-SASI reads,
  writes and formats (test matrix in the driver PR).

