### PR TITLE
sinclair/next/specnext.cpp: SIGSEGV failure under investigation

### DIFF
--- a/src/mame/sinclair/next/specnext.cpp
+++ b/src/mame/sinclair/next/specnext.cpp
@@ -3000,7 +3000,8 @@ void specnext_state::map_mem(address_map &map)
 		map(0x0000 + i * 0x2000, 0x1fff + i * 0x2000).noprw();
 		map(0x0000 + i * 0x2000, 0x1fff + i * 0x2000).view(views[i].get());
 		views[i].get()[0](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).bankrw(m_bank_ram[i]);
-		views[i].get()[1](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).bankr(m_bank_ram[i]);
+		views[i].get()[1](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).bankr(m_bank_ram[i])
+			.lw8(NAME([](offs_t, u8) {})); // SIGSEGV failure under investigation
 
 		// bank5
 		views[i].get()[0x2a](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).lrw8(


### PR DESCRIPTION
Very strange issue. Hoping for @galibert help...
Without doing this (.nopw() doesn't help as well) I'm catching SIGSEGV when write here despite on RO handler still trying to dispatch beyond available memory:
```
Stop reason: signal SIGSEGV: address not mapped to object (fault address=0x55c0e3103198)
bt all
* thread #1, name = 'mame', stop reason = signal SIGSEGV: address not mapped to object (fault address=0x55c0e3103198)
  * frame #0: 0x0000555556c70d63 mame`handler_entry_write_dispatch<13, 0, 0>::write_interruptible(unsigned int, unsigned char, unsigned char) const + 19
    frame #1: 0x000055555710f402 mame`handler_entry_write_tap<0, 0>::write_interruptible(unsigned int, unsigned char, unsigned char) const + 82
    frame #2: 0x0000555555d90323 mame`z80n_device::execute_run() + 155395
    frame #3: 0x00005555573e7f8b mame`device_scheduler::timeslice() + 811
    frame #4: 0x0000555557378568 mame`running_machine::run(bool) + 920
    frame #5: 0x0000555557e74950 mame`mame_machine_manager::execute() + 432
    frame #6: 0x0000555557f128dc mame`cli_frontend::start_execution(mame_machine_manager*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&) + 492
    frame #7: 0x0000555557f13c89 mame`cli_frontend::execute(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>&) + 57
    frame #8: 0x0000555557e75bc6 mame`emulator_info::start_frontend(emu_options&, osd_interface&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>&) + 38
    frame #9: 0x00005555574f6884 mame`main + 164
    frame #10: 0x00007ffff5a31f77 libc.so.6`__libc_start_call_main(main=(mame`main), argc=15, argv=0x00007fffffffe208) at libc_start_call_main.h:58:16
    frame #11: 0x00007ffff5a32027 libc.so.6`__libc_start_main_impl(main=(mame`main), argc=15, argv=0x00007fffffffe208, init=<unavailable>, fini=<unavailable>, rtld_fini=<unavailable>, stack_end=0x00007fffffffe1f8) at libc-start.c:360:3
    frame #12: 0x0000555555b91bb1 mame`_start + 33
  thread #2, name = 'mame'
    frame #0: 0x00007ffff5aa5ffe libc.so.6`__syscall_cancel_arch_end at syscall_cancel.S:56
    frame #1: 0x00007ffff5a9a7a4 libc.so.6`__internal_syscall_cancel(a1=<unavailable>, a2=<unavailable>, a3=<unavailable>, a4=<unavailable>, a5=<unavailable>, a6=<unavailable>, nr=202) at cancellation.c:49:12
    frame #2: 0x00007ffff5a9adbc libc.so.6`__futex_abstimed_wait_common64(private=<unavailable>, futex_word=<unavailable>, expected=<unavailable>, op=<unavailable>, abstime=<unavailable>, cancel=<unavailable>) at futex-internal.c:57:12 [inlined]
    frame #3: 0x00007ffff5a9ada0 libc.so.6`__futex_abstimed_wait_common(futex_word=<unavailable>, expected=<unavailable>, clockid=<unavailable>, abstime=<unavailable>, private=<unavailable>, cancel=<unavailable>) at futex-internal.c:87:9
    frame #4: 0x00007ffff5a9d50d libc.so.6`__pthread_cond_wait_common(cond=0x00007fffeeab20e8, mutex=0x00007fffeeab20c0, clockid=<unavailable>, abstime=0x00007fffedaa0b18) at pthread_cond_wait.c:421:13
    frame #5: 0x00007ffff5a9d4c0 libc.so.6`___pthread_cond_timedwait64(cond=0x00007fffeeab20e8, mutex=0x00007fffeeab20c0, abstime=0x00007fffedaa0b18) at pthread_cond_wait.c:478:10
    frame #6: 0x0000555557e68a5e mame`bx::Semaphore::wait(int) + 174
    frame #7: 0x0000555557d6c36b mame`bgfx::Context::renderFrame(int) + 299
    frame #8: 0x0000555557d7db34 mame`bgfx::Context::renderThread(bx::Thread*, void*) + 52
    frame #9: 0x0000555557e6e11f mame`bx::ThreadInternal::threadFunc(void*) + 31
    frame #10: 0x00007ffff5a9dda9 libc.so.6`start_thread(arg=<unavailable>) at pthread_create.c:448:8
    frame #11: 0x00007ffff5b1ce08 libc.so.6`__clone3 at clone3.S:78
  thread #3, name = 'mame:disk$0'
    frame #0: 0x00007ffff5aa5ffe libc.so.6`__syscall_cancel_arch_end at syscall_cancel.S:56
    frame #1: 0x00007ffff5a9a7a4 libc.so.6`__internal_syscall_cancel(a1=<unavailable>, a2=<unavailable>, a3=<unavailable>, a4=<unavailable>, a5=<unavailable>, a6=<unavailable>, nr=202) at cancellation.c:49:12
    frame #2: 0x00007ffff5a9adbc libc.so.6`__futex_abstimed_wait_common64(private=<unavailable>, futex_word=<unavailable>, expected=<unavailable>, op=<unavailable>, abstime=<unavailable>, cancel=<unavailable>) at futex-internal.c:57:12 [inlined]
    frame #3: 0x00007ffff5a9ada0 libc.so.6`__futex_abstimed_wait_common(futex_word=<unavailable>, expected=<unavailable>, clockid=<unavailable>, abstime=<unavailable>, private=<unavailable>, cancel=<unavailable>) at futex-internal.c:87:9
    frame #4: 0x00007ffff5a9d348 libc.so.6`__pthread_cond_wait_common(cond=0x00007fffe824d050, mutex=0x00007fffe824d020, clockid=0, abstime=0x0000000000000000) at pthread_cond_wait.c:421:13
    frame #5: 0x00007ffff5a9d2f0 libc.so.6`___pthread_cond_wait(cond=0x00007fffe824d050, mutex=0x00007fffe824d020) at pthread_cond_wait.c:453:10
    frame #6: 0x00007fffe0c946ad libgallium-26.0.8-1.so`___lldb_unnamed_symbol_6946a0 + 13
    frame #7: 0x00007fffe0c4aaac libgallium-26.0.8-1.so`___lldb_unnamed_symbol_64aa20 + 140
    frame #8: 0x00007fffe0c945db libgallium-26.0.8-1.so`___lldb_unnamed_symbol_6945c0 + 27
    frame #9: 0x00007ffff5a9dda9 libc.so.6`start_thread(arg=<unavailable>) at pthread_create.c:448:8
    frame #10: 0x00007ffff5b1ce08 libc.so.6`__clone3 at clone3.S:78
  thread #4, name = 'mame:sh0'
    frame #0: 0x00007ffff5aa5ffe libc.so.6`__syscall_cancel_arch_end at syscall_cancel.S:56
    frame #1: 0x00007ffff5a9a7a4 libc.so.6`__internal_syscall_cancel(a1=<unavailable>, a2=<unavailable>, a3=<unavailable>, a4=<unavailable>, a5=<unavailable>, a6=<unavailable>, nr=202) at cancellation.c:49:12
    frame #2: 0x00007ffff5a9adbc libc.so.6`__futex_abstimed_wait_common64(private=<unavailable>, futex_word=<unavailable>, expected=<unavailable>, op=<unavailable>, abstime=<unavailable>, cancel=<unavailable>) at futex-internal.c:57:12 [inlined]
    frame #3: 0x00007ffff5a9ada0 libc.so.6`__futex_abstimed_wait_common(futex_word=<unavailable>, expected=<unavailable>, clockid=<unavailable>, abstime=<unavailable>, private=<unavailable>, cancel=<unavailable>) at futex-internal.c:87:9
    frame #4: 0x00007ffff5a9d348 libc.so.6`__pthread_cond_wait_common(cond=0x00007fffe8259508, mutex=0x00007fffe82594d8, clockid=0, abstime=0x0000000000000000) at pthread_cond_wait.c:421:13
    frame #5: 0x00007ffff5a9d2f0 libc.so.6`___pthread_cond_wait(cond=0x00007fffe8259508, mutex=0x00007fffe82594d8) at pthread_cond_wait.c:453:10
    frame #6: 0x00007fffe0c946ad libgallium-26.0.8-1.so`___lldb_unnamed_symbol_6946a0 + 13
    frame #7: 0x00007fffe0c4aaac libgallium-26.0.8-1.so`___lldb_unnamed_symbol_64aa20 + 140
    frame #8: 0x00007fffe0c945db libgallium-26.0.8-1.so`___lldb_unnamed_symbol_6945c0 + 27
    frame #9: 0x00007ffff5a9dda9 libc.so.6`start_thread(arg=<unavailable>) at pthread_create.c:448:8
    frame #10: 0x00007ffff5b1ce08 libc.so.6`__clone3 at clone3.S:78
  thread #5, name = 'mame:traceq0'
    frame #0: 0x00007ffff5aa5ffe libc.so.6`__syscall_cancel_arch_end at syscall_cancel.S:56
    frame #1: 0x00007ffff5a9a7a4 libc.so.6`__internal_syscall_cancel(a1=<unavailable>, a2=<unavailable>, a3=<unavailable>, a4=<unavailable>, a5=<unavailable>, a6=<unavailable>, nr=202) at cancellation.c:49:12
    frame #2: 0x00007ffff5a9adbc libc.so.6`__futex_abstimed_wait_common64(private=<unavailable>, futex_word=<unavailable>, expected=<unavailable>, op=<unavailable>, abstime=<unavailable>, cancel=<unavailable>) at futex-internal.c:57:12 [inlined]
    frame #3: 0x00007ffff5a9ada0 libc.so.6`__futex_abstimed_wait_common(futex_word=<unavailable>, expected=<unavailable>, clockid=<unavailable>, abstime=<unavailable>, private=<unavailable>, cancel=<unavailable>) at futex-internal.c:87:9
    frame #4: 0x00007ffff5a9d348 libc.so.6`__pthread_cond_wait_common(cond=0x00007fffe828e000, mutex=0x00007fffe828dfd0, clockid=0, abstime=0x0000000000000000) at pthread_cond_wait.c:421:13
    frame #5: 0x00007ffff5a9d2f0 libc.so.6`___pthread_cond_wait(cond=0x00007fffe828e000, mutex=0x00007fffe828dfd0) at pthread_cond_wait.c:453:10
    frame #6: 0x00007fffe0c946ad libgallium-26.0.8-1.so`___lldb_unnamed_symbol_6946a0 + 13
    frame #7: 0x00007fffe0c4aaac libgallium-26.0.8-1.so`___lldb_unnamed_symbol_64aa20 + 140
    frame #8: 0x00007fffe0c945db libgallium-26.0.8-1.so`___lldb_unnamed_symbol_6945c0 + 27
    frame #9: 0x00007ffff5a9dda9 libc.so.6`start_thread(arg=<unavailable>) at pthread_create.c:448:8
    frame #10: 0x00007ffff5b1ce08 libc.so.6`__clone3 at clone3.S:78
  thread #6, name = 'mame:gdrv0'
    frame #0: 0x00007ffff5aa5ffe libc.so.6`__syscall_cancel_arch_end at syscall_cancel.S:56
    frame #1: 0x00007ffff5a9a7a4 libc.so.6`__internal_syscall_cancel(a1=<unavailable>, a2=<unavailable>, a3=<unavailable>, a4=<unavailable>, a5=<unavailable>, a6=<unavailable>, nr=202) at cancellation.c:49:12
    frame #2: 0x00007ffff5a9adbc libc.so.6`__futex_abstimed_wait_common64(private=<unavailable>, futex_word=<unavailable>, expected=<unavailable>, op=<unavailable>, abstime=<unavailable>, cancel=<unavailable>) at futex-internal.c:57:12 [inlined]
    frame #3: 0x00007ffff5a9ada0 libc.so.6`__futex_abstimed_wait_common(futex_word=<unavailable>, expected=<unavailable>, clockid=<unavailable>, abstime=<unavailable>, private=<unavailable>, cancel=<unavailable>) at futex-internal.c:87:9
    frame #4: 0x00007ffff5a9d348 libc.so.6`__pthread_cond_wait_common(cond=0x00007fffe80909d8, mutex=0x00007fffe80909a8, clockid=0, abstime=0x0000000000000000) at pthread_cond_wait.c:421:13
    frame #5: 0x00007ffff5a9d2f0 libc.so.6`___pthread_cond_wait(cond=0x00007fffe80909d8, mutex=0x00007fffe80909a8) at pthread_cond_wait.c:453:10
    frame #6: 0x00007fffe0c946ad libgallium-26.0.8-1.so`___lldb_unnamed_symbol_6946a0 + 13
    frame #7: 0x00007fffe0c4aaac libgallium-26.0.8-1.so`___lldb_unnamed_symbol_64aa20 + 140
    frame #8: 0x00007fffe0c945db libgallium-26.0.8-1.so`___lldb_unnamed_symbol_6945c0 + 27
    frame #9: 0x00007ffff5a9dda9 libc.so.6`start_thread(arg=<unavailable>) at pthread_create.c:448:8
    frame #10: 0x00007ffff5b1ce08 libc.so.6`__clone3 at clone3.S:78
  thread #7, name = 'SDLPwAudioPlug'
    frame #0: 0x00007ffff5aa5ffe libc.so.6`__syscall_cancel_arch_end at syscall_cancel.S:56
    frame #1: 0x00007ffff5a9a7a4 libc.so.6`__internal_syscall_cancel(a1=<unavailable>, a2=<unavailable>, a3=<unavailable>, a4=<unavailable>, a5=0, a6=0, nr=232) at cancellation.c:49:12
    frame #2: 0x00007ffff5a9a7ed libc.so.6`__syscall_cancel(a1=<unavailable>, a2=<unavailable>, a3=<unavailable>, a4=<unavailable>, a5=0, a6=0, nr=232) at cancellation.c:75:16
    frame #3: 0x00007ffff5b1d0cd libc.so.6`epoll_wait(epfd=<unavailable>, events=<unavailable>, maxevents=<unavailable>, timeout=<unavailable>) at epoll_wait.c:30:10
    frame #4: 0x00007fffecc5cb09 libspa-support.so`___lldb_unnamed_symbol_29a90 + 121
    frame #5: 0x00007fffecc3b307 libspa-support.so`___lldb_unnamed_symbol_8270 + 151
    frame #6: 0x00007fffec1bc611 libpipewire-0.3.so.0`___lldb_unnamed_symbol_be570 + 161
    frame #7: 0x00007ffff5a9dda9 libc.so.6`start_thread(arg=<unavailable>) at pthread_create.c:448:8
    frame #8: 0x00007ffff5b1ce08 libc.so.6`__clone3 at clone3.S:78
  thread #8, name = 'mame'
    frame #0: 0x00005555574f46ea mame`audio_resampler_hq::apply_copy(emu::detail::output_buffer_flat<float> const&, std::vector<short, std::allocator<short>>&, unsigned int, int, unsigned long, unsigned int, float, unsigned int) const + 346
    frame #1: 0x000055555740b85c mame`sound_manager::run_effects() + 2396
    frame #2: 0x00007ffff5ced206 libstdc++.so.6`___lldb_unnamed_symbol_ed1f0 + 22
    frame #3: 0x00007ffff5a9dda9 libc.so.6`start_thread(arg=<unavailable>) at pthread_create.c:448:8
    frame #4: 0x00007ffff5b1ce08 libc.so.6`__clone3 at clone3.S:78
  thread #9, name = 'SDLAudioP15'
    frame #0: 0x00007ffff5aa5ffe libc.so.6`__syscall_cancel_arch_end at syscall_cancel.S:56
    frame #1: 0x00007ffff5a9a7a4 libc.so.6`__internal_syscall_cancel(a1=<unavailable>, a2=<unavailable>, a3=<unavailable>, a4=<unavailable>, a5=0, a6=0, nr=232) at cancellation.c:49:12
    frame #2: 0x00007ffff5a9a7ed libc.so.6`__syscall_cancel(a1=<unavailable>, a2=<unavailable>, a3=<unavailable>, a4=<unavailable>, a5=0, a6=0, nr=232) at cancellation.c:75:16
    frame #3: 0x00007ffff5b1d0cd libc.so.6`epoll_wait(epfd=<unavailable>, events=<unavailable>, maxevents=<unavailable>, timeout=<unavailable>) at epoll_wait.c:30:10
    frame #4: 0x00007fffecc5cb09 libspa-support.so`___lldb_unnamed_symbol_29a90 + 121
    frame #5: 0x00007fffecc3b307 libspa-support.so`___lldb_unnamed_symbol_8270 + 151
    frame #6: 0x00007fffec1bc611 libpipewire-0.3.so.0`___lldb_unnamed_symbol_be570 + 161
    frame #7: 0x00007ffff5a9dda9 libc.so.6`start_thread(arg=<unavailable>) at pthread_create.c:448:8
    frame #8: 0x00007ffff5b1ce08 libc.so.6`__clone3 at clone3.S:78

Process exited with code 9.
```

But even with this when I exit MAME, it still doing this dirty: `corrupted size vs. prev_size`