### PR TITLE
cpu/ns32000: account for bus width in operand access timing

### DIFF
--- a/src/devices/cpu/ns32000/ns32000.h
+++ b/src/devices/cpu/ns32000/ns32000.h
@@ -67,21 +67,20 @@ protected:
 		SIZE_Q = 7,
 	};
 
-	// time needed to read or write a memory operand
+	// Time needed to read or write a memory operand: the first bus cycle
+	// costs 3 (4 with address translation), each additional one 4 (5).
+	// The number of bus cycles depends on the bus width of the device,
+	// the operand size, and operand alignment.
 	unsigned top(size_code const size, u32 const address = 0) const
 	{
 		unsigned const tmmu = m_mmu ? 1 : 0;
+		unsigned const bytes = size + 1;
+		unsigned const bpt = 1U << Width;
 
-		switch (size)
-		{
-		case SIZE_B: return 3 + tmmu;
-		case SIZE_W: return (address & 1) ? 7 + 2 * tmmu : 3 + tmmu;
-		case SIZE_D: return (address & 1) ? 11 + 3 * tmmu : 7 + 2 * tmmu;
-		case SIZE_Q: return (address & 1) ? 19 + 5 * tmmu : 15 + 4 * tmmu;
-		}
+		// number of bus cycles required for the transfer
+		unsigned const n = (bytes + (address & (bpt - 1)) + (bpt - 1)) >> Width;
 
-		// can't happen
-		return 0;
+		return 3 + (n - 1) * 4 + n * tmmu;
 	}
 
 	struct addr_mode


### PR DESCRIPTION
## Summary

`top()` charged 16-bit-bus operand timings on every NS32000 variant:
the `Width` template parameter was never consulted, so an aligned
32-bit operand cost two bus cycles on an NS32032 -- double the correct
figure -- making 32-bit-bus parts uniformly slow.

The change generalizes `top()` to the device's bus width.  The cycle
structure is the one already implicit in the existing table: first bus
cycle 3 (4 with address translation), each additional one 4, with the
bus-cycle count derived from operand size, alignment, and bus width.

- **Width=1 (NS32016)** reproduces the previous values exactly: no
  behaviour change for any existing 32016 machine.
- **Width=2 (NS32032/32332/32532)** stops double-charging aligned
  32-bit operands.
- **Width=0 (NS32008)** is now correctly charged 8-bit-bus timings
  (it previously received 16-bit values).

## Calibration

Measured against period hardware data: dhrystone 1.1 (LOOPS=50000,
compiled, assembled and linked with the 1985 Green Hills C 1.6.12 /
DSI-32000 AS/LN toolchain running on an emulated Definicon DSI-32,
NS32032-10) and the published dhrystone-list result for the real
board (1282-1315 dhrystones/second):

| | before | after |
|---|---|---|
| 50K-pass binary | ~970 d/s | ~1292 d/s |
| 500K-pass binary | ~1100 d/s | ~1362 d/s |

i.e. from 76-86% of real-hardware speed to 100-106%.

Toolchain, benchmark provenance and the measurement harness:
https://github.com/davidlrand/mame-system-media (Definicon-DSI-32;
a driver PR for the DSI-32 ISA card follows separately).
