### PR TITLE
cpu/i86: support port I/O wait states (IOCHRDY)

### DIFF
--- a/src/devices/cpu/i86/i186.cpp
+++ b/src/devices/cpu/i86/i186.cpp
@@ -578,6 +578,11 @@ void i80186_cpu_device::execute_run()
 							do
 							{
 								i_insb();
+								if (m_io_stall)
+								{
+									m_io_stall = false;
+									break;
+								}
 								c--;
 							} while (c > 0 && m_icount > 0);
 						}
@@ -592,6 +597,11 @@ void i80186_cpu_device::execute_run()
 							do
 							{
 								i_insw();
+								if (m_io_stall)
+								{
+									m_io_stall = false;
+									break;
+								}
 								c--;
 							} while (c > 0 && m_icount > 0);
 						}
@@ -606,6 +616,11 @@ void i80186_cpu_device::execute_run()
 							do
 							{
 								i_outsb();
+								if (m_io_stall)
+								{
+									m_io_stall = false;
+									break;
+								}
 								c--;
 							} while (c > 0 && m_icount > 0);
 						}
@@ -620,6 +635,11 @@ void i80186_cpu_device::execute_run()
 							do
 							{
 								i_outsw();
+								if (m_io_stall)
+								{
+									m_io_stall = false;
+									break;
+								}
 								c--;
 							} while (c > 0 && m_icount > 0);
 						}

--- a/src/devices/cpu/i86/i286.cpp
+++ b/src/devices/cpu/i86/i286.cpp
@@ -1891,10 +1891,10 @@ reg.base = BASE(desc); (void)(r); reg.limit = LIMIT(desc); }
 
 					switch (next)
 					{
-						case 0x6c:  CLK(OVERRIDE); if (c) do { i_insb();  c--; } while (c>0 && m_icount>0);          m_regs.w[CX]=c; m_seg_prefix = false; m_seg_prefix_next = false; break;
-						case 0x6d:  CLK(OVERRIDE); if (c) do { i_insw();  c--; } while (c>0 && m_icount>0);          m_regs.w[CX]=c; m_seg_prefix = false; m_seg_prefix_next = false; break;
-						case 0x6e:  CLK(OVERRIDE); if (c) do { i_outsb(); c--; } while (c>0 && m_icount>0);          m_regs.w[CX]=c; m_seg_prefix = false; m_seg_prefix_next = false; break;
-						case 0x6f:  CLK(OVERRIDE); if (c) do { i_outsw(); c--; } while (c>0 && m_icount>0);          m_regs.w[CX]=c; m_seg_prefix = false; m_seg_prefix_next = false; break;
+						case 0x6c:  CLK(OVERRIDE); if (c) do { i_insb();  if (m_io_stall) { m_io_stall = false; break; } c--; } while (c>0 && m_icount>0);          m_regs.w[CX]=c; m_seg_prefix = false; m_seg_prefix_next = false; break;
+						case 0x6d:  CLK(OVERRIDE); if (c) do { i_insw();  if (m_io_stall) { m_io_stall = false; break; } c--; } while (c>0 && m_icount>0);          m_regs.w[CX]=c; m_seg_prefix = false; m_seg_prefix_next = false; break;
+						case 0x6e:  CLK(OVERRIDE); if (c) do { i_outsb(); if (m_io_stall) { m_io_stall = false; break; } c--; } while (c>0 && m_icount>0);          m_regs.w[CX]=c; m_seg_prefix = false; m_seg_prefix_next = false; break;
+						case 0x6f:  CLK(OVERRIDE); if (c) do { i_outsw(); if (m_io_stall) { m_io_stall = false; break; } c--; } while (c>0 && m_icount>0);          m_regs.w[CX]=c; m_seg_prefix = false; m_seg_prefix_next = false; break;
 						default:
 							// Decrement IP and pass on
 							m_ip -= 1 + (m_seg_prefix_next ? 1 : 0);

--- a/src/devices/cpu/i86/i86.cpp
+++ b/src/devices/cpu/i86/i86.cpp
@@ -510,6 +510,7 @@ void i8086_common_cpu_device::device_start()
 	save_item(NAME(m_sregs));
 	save_item(NAME(m_ip));
 	save_item(NAME(m_prev_ip));
+	save_item(NAME(m_io_stall));
 	save_item(NAME(m_TF));
 	save_item(NAME(m_IF));
 	save_item(NAME(m_DF));
@@ -2057,23 +2058,47 @@ bool i8086_common_cpu_device::common_op(uint8_t op)
 			break;
 
 		case 0xe4: // i_inal
-			if (m_lock) m_lock_handler(1);
-			m_regs.b[AL] = read_port_byte( fetch() );
-			if (m_lock) { m_lock_handler(0); m_lock = false; }
-			CLK(IN_IMM8);
+			{
+				if (m_lock) m_lock_handler(1);
+				uint8_t const v = read_port_byte( fetch() );
+				if (m_lock) { m_lock_handler(0); m_lock = false; }
+				if (access_to_be_redone())
+				{
+					// the device wait-stated the cycle; restart
+					m_ip = m_prev_ip;
+					m_icount -= 4;
+					break;
+				}
+				m_regs.b[AL] = v;
+				CLK(IN_IMM8);
+			}
 			break;
 
 		case 0xe5: // i_inax
 			{
 				uint8_t port = fetch();
 
-				m_regs.w[AX] = read_port_word(port);
+				uint16_t const v = read_port_word(port);
+				if (access_to_be_redone())
+				{
+					m_ip = m_prev_ip;
+					m_icount -= 4;
+					break;
+				}
+				m_regs.w[AX] = v;
 				CLK(IN_IMM16);
 			}
 			break;
 
 		case 0xe6: // i_outal
 			write_port_byte_al(fetch());
+			if (access_to_be_redone())
+			{
+				// the device wait-stated the cycle; restart
+				m_ip = m_prev_ip;
+				m_icount -= 4;
+				break;
+			}
 			CLK(OUT_IMM8);
 			break;
 
@@ -2082,6 +2107,13 @@ bool i8086_common_cpu_device::common_op(uint8_t op)
 				uint8_t port = fetch();
 
 				write_port_word(port, m_regs.w[AX]);
+				if (access_to_be_redone())
+				{
+					// the device wait-stated the cycle; restart
+					m_ip = m_prev_ip;
+					m_icount -= 4;
+					break;
+				}
 				CLK(OUT_IMM16);
 			}
 			break;
@@ -2130,21 +2162,44 @@ bool i8086_common_cpu_device::common_op(uint8_t op)
 			break;
 
 		case 0xec: // i_inaldx
-			m_regs.b[AL] = read_port_byte(m_regs.w[DX]);
-			CLK(IN_DX8);
+			{
+				uint8_t const v = read_port_byte(m_regs.w[DX]);
+				if (access_to_be_redone())
+				{
+					m_ip = m_prev_ip;
+					m_icount -= 4;
+					break;
+				}
+				m_regs.b[AL] = v;
+				CLK(IN_DX8);
+			}
 			break;
 
 		case 0xed: // i_inaxdx
 			{
 				uint32_t port = m_regs.w[DX];
 
-				m_regs.w[AX] = read_port_word(port);
+				uint16_t const v = read_port_word(port);
+				if (access_to_be_redone())
+				{
+					m_ip = m_prev_ip;
+					m_icount -= 4;
+					break;
+				}
+				m_regs.w[AX] = v;
 				CLK(IN_DX16);
 			}
 			break;
 
 		case 0xee: // i_outdxal
 			write_port_byte_al(m_regs.w[DX]);
+			if (access_to_be_redone())
+			{
+				// the device wait-stated the cycle; restart
+				m_ip = m_prev_ip;
+				m_icount -= 4;
+				break;
+			}
 			CLK(OUT_DX8);
 			break;
 
@@ -2153,6 +2208,13 @@ bool i8086_common_cpu_device::common_op(uint8_t op)
 				uint32_t port = m_regs.w[DX];
 
 				write_port_word(port, m_regs.w[AX]);
+				if (access_to_be_redone())
+				{
+					// the device wait-stated the cycle; restart
+					m_ip = m_prev_ip;
+					m_icount -= 4;
+					break;
+				}
 				CLK(OUT_DX16);
 			}
 			break;

--- a/src/devices/cpu/i86/i86.h
+++ b/src/devices/cpu/i86/i86.h
@@ -284,6 +284,7 @@ protected:
 
 	uint16_t  m_ip;
 	uint16_t  m_prev_ip;
+	bool      m_io_stall = false;   // I/O wait-state (IOCHRDY) restart pending
 
 	int32_t   m_SignVal;
 	uint32_t  m_AuxVal, m_OverVal, m_ZeroVal, m_CarryVal, m_ParityVal; /* 0 or non-0 valued flags */

--- a/src/devices/cpu/i86/i86inline.h
+++ b/src/devices/cpu/i86/i86inline.h
@@ -496,7 +496,16 @@ inline void i8086_common_cpu_device::ExpandFlags(uint16_t f)
 inline void i8086_common_cpu_device::i_insb()
 {
 	uint32_t ea = calc_addr(ES, m_regs.w[DI], 1, I8086_WRITE);
-	write_byte(ea, read_port_byte(m_regs.w[DX]));
+	uint8_t const data = read_port_byte(m_regs.w[DX]);
+	if (access_to_be_redone())
+	{
+		// the device wait-stated the cycle; restart the instruction
+		m_io_stall = true;
+		m_ip = m_prev_ip;
+		m_icount -= 4;
+		return;
+	}
+	write_byte(ea, data);
 	m_regs.w[DI] += -2 * m_DF + 1;
 	CLK(IN_IMM8);
 }
@@ -504,7 +513,15 @@ inline void i8086_common_cpu_device::i_insb()
 inline void i8086_common_cpu_device::i_insw()
 {
 	uint32_t ea = calc_addr(ES, m_regs.w[DI], 2, I8086_WRITE);
-	write_word(ea, read_port_word(m_regs.w[DX]));
+	uint16_t const data = read_port_word(m_regs.w[DX]);
+	if (access_to_be_redone())
+	{
+		m_io_stall = true;
+		m_ip = m_prev_ip;
+		m_icount -= 4;
+		return;
+	}
+	write_word(ea, data);
 	m_regs.w[DI] += -4 * m_DF + 2;
 	CLK(IN_IMM16);
 }
@@ -512,6 +529,14 @@ inline void i8086_common_cpu_device::i_insw()
 inline void i8086_common_cpu_device::i_outsb()
 {
 	write_port_byte(m_regs.w[DX], GetMemB(DS, m_regs.w[SI]));
+	if (access_to_be_redone())
+	{
+		// the device wait-stated the cycle; restart the instruction
+		m_io_stall = true;
+		m_ip = m_prev_ip;
+		m_icount -= 4;
+		return;
+	}
 	m_regs.w[SI] += -2 * m_DF + 1;
 	CLK(OUT_IMM8);
 }
@@ -519,6 +544,13 @@ inline void i8086_common_cpu_device::i_outsb()
 inline void i8086_common_cpu_device::i_outsw()
 {
 	write_port_word(m_regs.w[DX], GetMemW(DS, m_regs.w[SI]));
+	if (access_to_be_redone())
+	{
+		m_io_stall = true;
+		m_ip = m_prev_ip;
+		m_icount -= 4;
+		return;
+	}
 	m_regs.w[SI] += -4 * m_DF + 2;
 	CLK(OUT_IMM16);
 }


### PR DESCRIPTION
IN/OUT/INS/OUTS (and the 80186/80286 REP forms) restart the bus cycle when a device wait-states it via retry_access(), so ISA IOCHRDY can be modelled. Register/SI/DI/CX updates are deferred until the access completes; behavior is unchanged for devices that never request a retry.

Developed for and tested with a 74LS646-latched coprocessor board on ibm5170 whose PAL wait-states both directions of host port I/O (hardware-paced REP INSW/OUTSW with no software polling); also regression-tested ibm5150/5160/5170 DOS boots.