### PR TITLE
machine/ns32082: fix PTE address composition; bypass interrupt-ack cycles

### DIFF
--- a/src/devices/machine/ns32082.cpp
+++ b/src/devices/machine/ns32082.cpp
@@ -394,6 +394,12 @@ ns32082_device::translate_result ns32082_device::translate(address_space &space,
 	if ((!(m_msr & MSR_TU) && user) || (!(m_msr & MSR_TS) && !user))
 		return COMPLETE;
 
+	// interrupt-acknowledge and end-of-interrupt cycles address the
+	// interrupt controller at a fixed physical address and are not
+	// translated
+	if (st >= ns32000::ST_IAM && st <= ns32000::ST_EIC)
+		return COMPLETE;
+
 	// treat WRVAL as write
 	write |= m_state == WRVAL;
 
@@ -487,7 +493,7 @@ ns32082_device::translate_result ns32082_device::translate(address_space &space,
 	if ((!(pte2 & PTE_R) || (write && !(pte2 & PTE_M))) && !suppress)
 		space.write_word(pte2_address, u16(pte2 | (write ? PTE_M : 0) | PTE_R));
 
-	address = ((pte1 & PTE_MS) >> 7) | (pte2 & PTE_PFN) | (address & VA_OFFSET);
+	address = ((pte2 & PTE_MS) >> 7) | (pte2 & PTE_PFN) | (address & VA_OFFSET);
 	LOGMASKED(LOG_TRANSLATE, "translate complete 0x%08x\n", address);
 
 	if (m_state == RDVAL || m_state == WRVAL)


### PR DESCRIPTION
Two fixes found bringing up a demand-paged UNIX System V R2 on an NS32016+NS32082 board:

1. translate() composed the physical address from the level-1 PTE's MS bit instead of the level-2 PTE's.
2. Interrupt-acknowledge / end-of-interrupt cycles (ST 4-7) are now passed through untranslated: the ICU sits at a fixed physical address that no OS maps, so translating these cycles aborts inside interrupt entry as soon as supervisor translation is on.

Tested: full SVR2 boot with supervisor+user dual-space translation and demand-paged exec; vectored interrupts and RETI under active translation.