### PR TITLE
sound/swp30: saturate AWM2 interpolation output to prevent wrap clicks

### DIFF
--- a/src/devices/sound/swp30.cpp
+++ b/src/devices/sound/swp30.cpp
@@ -688,12 +688,16 @@ std::pair<s16, bool> swp30_device::streaming_block::step(memory_access<25, 2, -2
 	// Not perfectly exact, there are some rounding-like issues from
 	// time to time
 	s32 index = (m_pos_dec >> 4) & 2047;
-	s16 result = (
+	// The 4-tap cubic interpolation can overshoot past full scale near loud
+	// peaks; saturate to s16 instead of letting the store wrap (a full-scale
+	// sign flip = an audible click on loud notes).
+	s32 racc = (
 				  - interpolation_table[0][index ^ 2047] * val0
 				  + interpolation_table[1][index ^ 2047] * val1
 				  + interpolation_table[1][index       ] * val2
 				  - interpolation_table[0][index       ] * val3
 				  ) >> 10;
+	s16 result = std::clamp<s32>(racc, -0x8000, 0x7fff);
 
 	u32 pitch = m_pitch + pitch_lfo;
 	if(m_finetune_active) {


### PR DESCRIPTION
### Problem

On the SWP30 (MU100 etc.), loud notes produce an occasional one-sample full-scale "click" — most noticeable on bright, sustained, near-full-scale instruments (e.g. GM strings). Quiet notes are unaffected, so it presents as an intermittent tick on some notes but not others.

### Root cause

In `swp30_device::streaming_block::step()` the 4-tap cubic interpolation result is stored directly into an `s16`. Cubic interpolation overshoots the input range near peaks, so when the source samples approach full scale the interpolated value exceeds the s16 range and the store **wraps** (+32767 → −32768), i.e. a single-sample sign inversion = an audible click.

Trace of the raw streamed value across one glitch (climbing smoothly, then wrapping):

```
... 26793 -> 30115 -> 32220 -> -32561 -> 32549 -> 31051 ...
                              ^ wrap here
```

### Fix

Accumulate in `s32` and saturate to the s16 range with `std::clamp`. Real hardware saturates (a wrap would be audibly broken), so this also matches hardware behaviour.

### Testing

Played GM patches through the `mu100` driver and recorded with `-wavwrite`, counting impulse (2nd-difference) clicks over the rendered audio:

| material            | before | after |
|---------------------|:------:|:-----:|
| 6 sustained notes   |   3    |   0   |
| full GM song        |  15+   |   0   |
| quiet/decay patches |   0    |   0   |

Audio that never overshoots is bit-identical before/after; only the previously-wrapping samples change (now saturated).

Note: this is distinct from #11976 (envelope release abruptness) — a separate interpolation-overflow defect, though both manifest as "clicks".
