### PR TITLE
Increment PC after exchange for opcode 0x30

### DIFF
--- a/src/devices/cpu/scmp/scmp.cpp
+++ b/src/devices/cpu/scmp/scmp.cpp
@@ -356,6 +356,7 @@ void scmp_device::execute_one(int opcode)
 						tmp = m_AC;
 						m_AC = GET_PTR_REG(ptr)->b.l;
 						GET_PTR_REG(ptr)->b.l = tmp;
+						if ( opcode == 0x30 ) m_PC.w.l = ADD12(m_PC.w.l,1); // After exchange CPU increment PC, like XPPC
 						break;
 			case 0x34:  case 0x35 :case 0x36: case 0x37:
 						// XPAH


### PR DESCRIPTION
If you change the value of XPAL or XPAH (0), you must increment it in the same way as XPPC, but there is no decrement before that. My LedMatchOctal program does not run correctly in the MAME emulator without this modification, even though it runs fine on a real MK14 machine and also runs fine in the Python emulator. When handling the PC, the increment always takes place.