### PR TITLE
machine/ncr5385: complete selection as soon as the target responds

### DIFF
--- a/src/devices/machine/ncr5385.cpp
+++ b/src/devices/machine/ncr5385.cpp
@@ -177,7 +177,15 @@ void ncr5385_device::scsi_ctrl_changed()
 			m_state_timer->adjust(attotime::zero);
 	}
 	else if (ctrl & S_BSY)
+	{
 		LOGMASKED(LOG_STATE, "scsi_ctrl_changed 0x%03x arbitration/selection\n", ctrl);
+
+		// the target asserts BSY in response to selection while the initiator is still
+		// asserting SEL; complete the selection as soon as the target responds instead
+		// of waiting out the full selection timeout that SEL_WAIT_BSY was armed with.
+		if (m_state == SEL_WAIT_BSY)
+			m_state_timer->adjust(attotime::zero);
+	}
 	else
 	{
 		LOGMASKED(LOG_STATE, "scsi_ctrl_changed 0x%03x BUS FREE\n", ctrl);
@@ -567,6 +575,8 @@ int ncr5385_device::state_step()
 	case SEL_DELAY:
 		LOGMASKED(LOG_STATE, "selection: BSY cleared\n");
 		m_state = SEL_WAIT_BSY;
+		// this is the upper-bound selection timeout; a responding target completes
+		// the selection early via scsi_ctrl_changed() asserting BSY
 		delay = SCSI_SEL_TIMEOUT;
 
 		// clear BSY, optionally assert ATN


### PR DESCRIPTION
`scsi_ctrl_changed()` only advanced the state machine on a target `BSY` assertion when `SEL` was no longer asserted — the post-selection (bus phase) case. During selection the initiator still asserts `SEL`, so the target's `BSY` response landed in a branch that only logged and never advanced the state machine. `SEL_WAIT_BSY` therefore ran only when its `SCSI_SEL_TIMEOUT` deadline timer fired, so every selection took the full 250 ms.

This advances `SEL_WAIT_BSY` as soon as the target asserts `BSY` (with `SEL` still asserted), so selection completes when the target responds. It is gated on `m_state == SEL_WAIT_BSY`, and `SEL_WAIT_BSY` re-checks `S_BSY` before completing, so nothing else is affected — a non-responding target still falls through to the timeout.

Found while bringing up the National Semiconductor ICM-3216, whose Z80 I/O processor polls the SCSI status register with a short timeout that the 250 ms per selection tripped. The other `ncr5385` users (`tekigw`, `tek440x`, `vp415`) get the same latency/correctness improvement.
