### PR TITLE
es5510.cpp: round DOL towards -infinity after all.

### DIFF
--- a/src/devices/cpu/es5510/es5510.cpp
+++ b/src/devices/cpu/es5510/es5510.cpp
@@ -23,6 +23,11 @@
 #include <cstdio>
 #include <algorithm>
 
+// Should writes to DOL, which is 16 bits wide, round towards zero?
+// This seems to fix a noise issue, but may not be what the hardware does.
+// Currently being investigated.
+#define DOL_ROUND_TOWARDS_ZERO 0
+
 #define VERBOSE_EXEC 0
 
 #define LOG_EXECUTION (1U << 1)
@@ -91,6 +96,8 @@ inline int32_t add(int32_t a, int32_t b, uint8_t &flags) {
 	return result & 0x00ffffff;
 }
 
+#if DOL_ROUND_TOWARDS_ZERO
+
 // When writing a 24-bit value to 16-bit DOL, round the value
 // towards 0 rather than -infinity.
 inline int16_t round_24_to_16(int32_t dol24)
@@ -99,6 +106,17 @@ inline int16_t round_24_to_16(int32_t dol24)
 	bool const add = BIT(dol24, 23) && ((dol24 & 0xff) != 0);
 	return int16_t((dol24 >> 8) + (add ? 1 : 0));
 }
+
+#else  // !DOL_ROUND_TOWARDS_ZERO <=> round towards -infinity
+
+// When writing a 24-bit value to 16-bit DOL, shift away the
+// low-order 8 bits, rounding towards -infinity.
+inline int16_t round_24_to_16(int32_t dol24)
+{
+	return int16_t(dol24 >> 8);
+}
+
+#endif  // DOL_ROUND_TOWARDS_ZERO
 
 inline int32_t saturate(int32_t value, uint8_t &flags, bool negative)
 {


### PR DESCRIPTION
This partially reverts the functional change in
https://github.com/mamedev/mame/pull/15527; but keeps the code and makes it a compile-time choice, for now, while this continuies to be investigated.

It also keeps the changes that made DIL and DOL actually 16 bits wide.

All based on investigation by @guilioz in
[this comment](https://github.com/mamedev/mame/pull/15527#issuecomment-4711323638) by @guilioz, which appears to show that the hardware ESP does _not_ round towards zero after all.