### PR TITLE
Sega Rally Audio Fix -MSLC field on monitor register (0x408) read

### DIFF
--- a/src/devices/sound/scsp.cpp
+++ b/src/devices/sound/scsp.cpp
@@ -924,8 +924,14 @@ void scsp_device::UpdateRegR(int reg)
 				u32 SGC = (slot->EG.state) & 3;
 				u32 CA = (slot->cur_addr >> (SHIFT + 12)) & 0xf;
 				u32 EG = (0x1f - (slot->EG.volume >> (EG_SHIFT + 5))) & 0x1f;
-				/* note: according to the manual MSLC is write only, CA, SGC and EG read only.  */
-				m_udata.data[0x8/2] =  /*(MSLC << 11) |*/ (CA << 7) | (SGC << 5) | EG;
+				/* note: per the manual MSLC is write-only and CA/SGC/EG are read-only,
+				   but the MSLC field must be preserved in the internal register.
+				   Software selects a slot via MSLC once and then polls this register
+				   repeatedly to read that slot's CA (current play address) - e.g. to
+				   pace streaming / double-buffered PCM voices. Zeroing MSLC on read
+				   makes every poll after the first monitor slot 0 instead of the
+				   selected slot, so streaming voices get refilled off the wrong slot. */
+				m_udata.data[0x8/2] = (MSLC << 11) | (CA << 7) | (SGC << 5) | EG;
 			}
 			break;
 


### PR DESCRIPTION
`scsp_device::UpdateRegR` case 8/9 — the MSLC/CA/SGC/EG monitor register at offset 0x408 — wrote back CA/SGC/EG but **zeroed the MSLC slot-select field**; the `(MSLC << 11)` term was commented out:

```c
m_udata.data[0x8/2] =  /*(MSLC << 11) |*/ (CA << 7) | (SGC << 5) | EG;
```

Software writes MSLC once to choose which slot to monitor, then polls this register repeatedly to read that slot's **CA** (current play address) — typically to pace streaming / double-buffered PCM voices. Because the read zeroed MSLC, every poll after the first returned **slot 0's** play position instead of the selected slot's, so streaming voices were refilled off the wrong slot. Audibly this is intermittent wrong-voice notes / random beeps in streamed BGM.

MSLC is write-only from software's view, but the internal register field must persist between reads. The fix preserves it, matching SCSP hardware behaviour:

```c
m_udata.data[0x8/2] = (MSLC << 11) | (CA << 7) | (SGC << 5) | EG;
```

### Reproduction (Sega Rally Championship, `srallyc`)
1. Press the **Service** button to enter the test menu.
2. Cycle to the **Sound Test** menu.
3. Select the **second BGM** item.
4. Listen from ~**26 s** in: before the fix, random beeps/artifacts appear in the streamed music; after, it plays clean.

### Audio (attached)
- [bad_audio.mp3](https://github.com/user-attachments/files/28977866/bad_audio.mp3) — before (MSLC wiped)
-  [fixed_audio.mp3](https://github.com/user-attachments/files/28977878/fixed_audio.mp3) — after (MSLC preserved)


Both captured from the same build, differing only by this one-line change.
