### PR TITLE
bus/nscsi: expose harddisk and tape media images to host-side emulators

### DIFF
--- a/src/devices/bus/nscsi/hd.h
+++ b/src/devices/bus/nscsi/hd.h
@@ -56,6 +56,10 @@ public:
 	//
 	void set_seek_timing(uint32_t track_us, uint32_t average_us, uint32_t full_us, uint32_t rpm, uint8_t interleave);
 
+	// underlying media image, exposed so a host-side high-level emulator can run
+	// commands directly against the media (parallels nscsi_tape_device::image())
+	required_device<harddisk_image_device> image;
+
 protected:
 	nscsi_harddisk_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
@@ -75,7 +79,6 @@ protected:
 	// READ/WRITE/SEEK (6- and 10-byte) opcodes.
 	attotime seek_time(uint32_t lba);
 
-	required_device<harddisk_image_device> image;
 	std::string m_default_model_name;
 	uint8_t block[512];
 	int lba, cur_lba, blocks;

--- a/src/devices/bus/nscsi/tape.h
+++ b/src/devices/bus/nscsi/tape.h
@@ -20,6 +20,10 @@ public:
 	// construction
 	nscsi_tape_device(const machine_config &config, const char *tag, device_t *owner, u32 clock = 0);
 
+	// expose the underlying tape image (parallels nscsi_harddisk_device::image) so a host-side
+	// high-level emulator can run commands directly against the media
+	simh_tape_image_device *image() const { return m_image; }
+
 protected:
 	nscsi_tape_device(const machine_config &config, device_type type, const char *tag, device_t *owner, u32 clock, const std::string_view manufacturer, const std::string_view product, const std::string_view revision);
 


### PR DESCRIPTION
A host-side high-level I/O-processor emulation (such as the ICM-3216 IOP) needs to run SCSI commands directly against the underlying media without going through the nscsi command layer. Make `nscsi_harddisk_device::image` public and add a matching `nscsi_tape_device::image()` accessor returning the `simh_tape_image_device`.

No behavioural change; existing users are unaffected.