### PR TITLE
upd765 and derivatives: fix default DRQ behavior during write/scan

### DIFF
--- a/src/devices/machine/upd765.cpp
+++ b/src/devices/machine/upd765.cpp
@@ -776,7 +776,7 @@ void upd765_family_device::fifo_push(uint8_t data, bool internal)
 	int thr = (fifocfg & FIF_THR)+1;
 	if(!fifo_write && (!fifo_expected || fifo_pos >= thr || (fifocfg & FIF_DIS)))
 		enable_transfer();
-	if(fifo_write && (fifo_pos == 16 || !fifo_expected))
+	if(fifo_write && (fifo_pos == 16 || !fifo_expected || (fifocfg & FIF_DIS)))
 		disable_transfer();
 }
 


### PR DESCRIPTION
This was found when troubleshooting floppy issues in the wk1800 driver. Standard uPD765-style FDCs should default to generating one DRQ per byte for write/scan commands rather than behaving like they have the 82072-style FIFO.