### PR TITLE
skeleton/elzet80.cpp: make the screen work

### DIFF
--- a/src/mame/skeleton/elzet80.cpp
+++ b/src/mame/skeleton/elzet80.cpp
@@ -22,7 +22,7 @@ CARDS: (some are optional)
 - EIC (contains PIO, DART, Z80B)
 - Experimenter board (contains PIO, CTC)
 - Video (contains MC6845, 2k vram, 2k attr-ram, chargen roms, 15MHz xtal)
-- CPU (contains Z80, SIO, PIO, 4MHz xtal)
+- CPU (contains Z80, DART, PIO, 4MHz xtal, 4/8K ROM, 2K RAM)
 
 The keyboard plugs into the front by using a stereo audio plug, like you
 have on a modern computer's line-out jack. There's no internal information
@@ -62,7 +62,7 @@ public:
 		, m_ctc(*this, "ctc")
 		, m_dma(*this, "dma")
 		, m_pio(*this, "pio")
-		, m_uart(*this, "uart")
+		, m_dart(*this, "uart")
 		, m_fdc(*this, "fdc")
 		, m_floppy0(*this, "fdc:0")
 		, m_floppy1(*this, "fdc:1")
@@ -85,7 +85,7 @@ private:
 	required_device<z80ctc_device> m_ctc;
 	required_device<z80dma_device> m_dma;
 	required_device<z80pio_device> m_pio;
-	required_device<z80sio_device> m_uart;
+	required_device<z80dart_device> m_dart;
 	required_device<fd1793_device> m_fdc;
 	required_device<floppy_connector> m_floppy0;
 	required_device<floppy_connector> m_floppy1;
@@ -95,10 +95,20 @@ private:
 
 void elzet80_state::mem_map(address_map &map)
 {
+	map(0x0000, 0x0fff).rom(); // CPU card ROM
+	map(0x2000, 0xffff).ram(); // 64K RAM card
+	map(0xe000, 0xe7ff).ram(); // video attribute RAM
+	map(0xe800, 0xefff).ram(); // video character RAM
 }
 
 void elzet80_state::io_map(address_map &map)
 {
+	map(0x00, 0x03).rw(m_pio, FUNC(z80pio_device::read), FUNC(z80pio_device::write));
+	map(0x04, 0x07).rw(m_dart, FUNC(z80dart_device::ba_cd_r), FUNC(z80dart_device::ba_cd_w));
+	map(0x28, 0x28).nopw(); // toggle video memory access
+	map(0x29, 0x29).noprw(); // video card (unused)
+	map(0x2a, 0x2a).noprw(); // 6845 address register
+	map(0x2b, 0x2b).noprw(); // 6845 init register
 	map.global_mask(0xff);
 	map.unmap_value_high();
 }
@@ -135,7 +145,7 @@ void elzet80_state::elzet80(machine_config &config)
 	FLOPPY_CONNECTOR(config, "fdc:1", elzet80_floppies, "fdd", floppy_image_device::default_mfm_floppy_formats).enable_sound(true);
 
 	Z80PIO(config, m_pio);
-	Z80SIO(config, m_uart);
+	Z80DART(config, m_dart, 6144000); // discrete oscillator
 	Z80CTC(config, m_ctc);
 	Z80DMA(config, m_dma);
 }

--- a/src/mame/skeleton/elzet80.cpp
+++ b/src/mame/skeleton/elzet80.cpp
@@ -69,6 +69,7 @@ public:
 		, m_pio(*this, "pio")
 		, m_dart(*this, "uart")
 		, m_crtc(*this, "crtc")
+		, m_p_chargen(*this, "chargen")
 		, m_p_videoram(*this, "videoram")
 		, m_p_colorram(*this, "colorram")
 		, m_palette(*this, "palette")
@@ -86,6 +87,7 @@ protected:
 	virtual void machine_reset() override ATTR_COLD;
 
 private:
+	MC6845_UPDATE_ROW(update_row);
 
 	void mem_map(address_map &map) ATTR_COLD;
 	void io_map(address_map &map) ATTR_COLD;
@@ -97,6 +99,7 @@ private:
 	required_device<z80pio_device> m_pio;
 	required_device<z80dart_device> m_dart;
 	required_device<mc6845_device> m_crtc;
+	required_region_ptr<u8> m_p_chargen;
 	required_shared_ptr<uint8_t> m_p_videoram;
 	required_shared_ptr<uint8_t> m_p_colorram;
 	required_device<palette_device> m_palette;
@@ -107,6 +110,31 @@ private:
 	//required_ioport_array<8> m_io_keyboard;
 };
 
+MC6845_UPDATE_ROW( elzet80_state::update_row )
+{
+	rgb_t const *const pens = m_palette->palette()->entry_list_raw();
+	uint32_t *p = &bitmap.pix(y);
+
+	for (uint16_t x = 0; x < x_count; x++)
+	{
+		uint16_t mem = (ma + x) & 0x7ff;
+		uint8_t chr = m_p_videoram[mem];
+
+		/* get pattern of pixels for that character scanline */
+		uint16_t gfx = m_p_chargen[(chr<<4) | ra] ^ ((x == cursor_x) ? 0x1ff : 0);
+
+		/* Display a scanline of a character (9 pixels) */
+		*p++ = pens[BIT(gfx, 8)];
+		*p++ = pens[BIT(gfx, 7)];
+		*p++ = pens[BIT(gfx, 6)];
+		*p++ = pens[BIT(gfx, 5)];
+		*p++ = pens[BIT(gfx, 4)];
+		*p++ = pens[BIT(gfx, 3)];
+		*p++ = pens[BIT(gfx, 2)];
+		*p++ = pens[BIT(gfx, 1)];
+		*p++ = pens[BIT(gfx, 0)];
+	}
+}
 
 void elzet80_state::mem_map(address_map &map)
 {
@@ -122,7 +150,7 @@ void elzet80_state::io_map(address_map &map)
 	map(0x04, 0x07).rw(m_dart, FUNC(z80dart_device::ba_cd_r), FUNC(z80dart_device::ba_cd_w));
 	map(0x28, 0x28).nopw(); // toggle video memory access
 	map(0x29, 0x29).noprw(); // video card (unused)
-	map(0x2a, 0x2a).w(m_crtc, FUNC(mc6845_device::address_w));
+	map(0x2a, 0x2a).rw(m_crtc, FUNC(mc6845_device::status_r), FUNC(mc6845_device::address_w));
 	map(0x2b, 0x2b).rw(m_crtc, FUNC(mc6845_device::register_r), FUNC(mc6845_device::register_w));
 	map.global_mask(0xff);
 	map.unmap_value_high();
@@ -176,11 +204,14 @@ void elzet80_state::elzet80(machine_config &config)
 	Z80DMA(config, m_dma);
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
-	m_screen->set_refresh_hz(50);
+	m_screen->set_raw(8_MHz_XTAL, 512, 0, 320, 326, 0, 240);
 	m_screen->set_screen_update(m_crtc, FUNC(mc6845_device::screen_update));
 
 	MC6845(config, m_crtc, 4_MHz_XTAL);
 	m_crtc->set_screen(m_screen);
+	m_crtc->set_show_border_area(false);
+	m_crtc->set_char_width(8);
+	m_crtc->set_update_row_callback(FUNC(elzet80_state::update_row));
 
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_elzet);
 	PALETTE(config, m_palette, palette_device::MONOCHROME);

--- a/src/mame/skeleton/elzet80.cpp
+++ b/src/mame/skeleton/elzet80.cpp
@@ -16,7 +16,7 @@ Behind the drives is a cage that can hold up to 8 slots that plug into a
 small motherboard.
 CARDS: (some are optional)
 - Floppy Disk Controller: choice of FDC 2: (basic) or FDC3 (also has 128K RAM)
-    (main chips are PIO, DMA, MB8877A)
+    (main chips are PIO, DMA, MB8877A/SAB1793)
 - Dynamic RAM: choice of 64k or 256k
 - Centronics (contains PIO, CTC)
 - EIC (contains PIO, DART, Z80B)
@@ -25,8 +25,7 @@ CARDS: (some are optional)
 - CPU (contains Z80, DART, PIO, 4MHz xtal, 4/8K ROM, 2K RAM)
 
 The keyboard plugs into the front by using a stereo audio plug, like you
-have on a modern computer's line-out jack. There's no internal information
-for it.
+have on a modern computer's line-out jack. It's using a serial interface.
 
 
 The ELZET/K is a similar computer but is a slightly smaller form factor.
@@ -66,14 +65,18 @@ public:
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
 		, m_pio(*this, "pio")
-		, m_dart(*this, "uart")
+		, m_dart(*this, "dart")
+		, m_pctc(*this, "pctc")
+		, m_ppio(*this, "ppio")
 		, m_crtc(*this, "crtc")
 		, m_p_chargen(*this, "chargen")
 		, m_p_videoram(*this, "videoram")
 		, m_p_colorram(*this, "colorram")
 		, m_palette(*this, "palette")
 		, m_screen(*this, "screen")
+		, m_fdma(*this, "fdma")
 		, m_fdc(*this, "fdc")
+		, m_fpio(*this, "fpio")
 		, m_floppy0(*this, "fdc:0")
 		, m_floppy1(*this, "fdc:1")
 		//, m_io_keyboard(*this, "LINE%d", 0U)
@@ -95,13 +98,17 @@ private:
 	required_device<cpu_device> m_maincpu;
 	required_device<z80pio_device> m_pio;
 	required_device<z80dart_device> m_dart;
+	required_device<z80ctc_device> m_pctc;
+	required_device<z80pio_device> m_ppio;
 	required_device<mc6845_device> m_crtc;
 	required_region_ptr<uint8_t> m_p_chargen;
 	required_shared_ptr<uint8_t> m_p_videoram;
 	required_shared_ptr<uint8_t> m_p_colorram;
 	required_device<palette_device> m_palette;
 	required_device<screen_device> m_screen;
+	required_device<z80dma_device> m_fdma;
 	required_device<fd1793_device> m_fdc;
+	required_device<z80pio_device> m_fpio;
 	required_device<floppy_connector> m_floppy0;
 	required_device<floppy_connector> m_floppy1;
 	//required_ioport_array<8> m_io_keyboard;
@@ -145,10 +152,22 @@ void elzet80_state::io_map(address_map &map)
 {
 	map(0x00, 0x03).rw(m_pio, FUNC(z80pio_device::read), FUNC(z80pio_device::write));
 	map(0x04, 0x07).rw(m_dart, FUNC(z80dart_device::cd_ba_r), FUNC(z80dart_device::cd_ba_w));
+
+	// printer card
+	map(0x20, 0x23).rw(m_pctc, FUNC(z80ctc_device::read), FUNC(z80ctc_device::write));
+	map(0x24, 0x27).rw(m_ppio, FUNC(z80pio_device::read), FUNC(z80pio_device::write));
+
+	// video card
 	map(0x28, 0x28).nopw(); // toggle video memory access
 	map(0x29, 0x29).noprw(); // video card (unused)
 	map(0x2a, 0x2a).rw(m_crtc, FUNC(mc6845_device::status_r), FUNC(mc6845_device::address_w));
 	map(0x2b, 0x2b).rw(m_crtc, FUNC(mc6845_device::register_r), FUNC(mc6845_device::register_w));
+
+	// fdc card
+	map(0x60, 0x63).rw(m_fdma, FUNC(z80dma_device::read), FUNC(z80dma_device::write));
+	map(0x68, 0x6b).rw(m_fdc, FUNC(fd1793_device::read), FUNC(fd1793_device::write));
+	map(0x6c, 0x6f).rw(m_fpio, FUNC(z80pio_device::read), FUNC(z80pio_device::write));
+
 	map.global_mask(0xff);
 	map.unmap_value_high();
 }
@@ -211,6 +230,10 @@ void elzet80_state::elzet80(machine_config &config)
 	rs232b.rxd_handler().set(m_dart, FUNC(z80dart_device::rxb_w));
 	rs232b.dcd_handler().set(m_dart, FUNC(z80dart_device::dcdb_w));
 
+	Z80CTC(config, m_pctc, 4_MHz_XTAL);
+	Z80PIO(config, m_ppio, 4_MHz_XTAL);
+
+	// video
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_raw(15_MHz_XTAL, 512, 0, 320, 326, 0, 240);
 	m_screen->set_screen_update(m_crtc, FUNC(mc6845_device::screen_update));
@@ -224,8 +247,13 @@ void elzet80_state::elzet80(machine_config &config)
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_elzet);
 	PALETTE(config, m_palette, palette_device::MONOCHROME);
 
-	// devices
-	FD1793(config, m_fdc, 1000000);    // unknown where this is derived
+	// floppy
+	Z80DMA(config, m_fdma, 4_MHz_XTAL);
+	m_fdma->out_int_callback().set_inputline(m_maincpu, INPUT_LINE_IRQ0);
+	FD1793(config, m_fdc, 4_MHz_XTAL);
+	Z80PIO(config, m_fpio, 4_MHz_XTAL);
+	m_fpio->out_int_callback().set_inputline(m_maincpu, INPUT_LINE_IRQ0);
+	//m_fpio->out_pa_callback().set(DRIVE SELECT);
 	FLOPPY_CONNECTOR(config, "fdc:0", elzet80_floppies, "fdd", floppy_image_device::default_mfm_floppy_formats).enable_sound(true);
 	FLOPPY_CONNECTOR(config, "fdc:1", elzet80_floppies, "fdd", floppy_image_device::default_mfm_floppy_formats).enable_sound(true);
 }

--- a/src/mame/skeleton/elzet80.cpp
+++ b/src/mame/skeleton/elzet80.cpp
@@ -196,7 +196,10 @@ void elzet80_state::elzet80(machine_config &config)
 	m_maincpu->set_addrmap(AS_IO, &elzet80_state::io_map);
 
 	Z80PIO(config, m_pio, 4_MHz_XTAL);
-	Z80DART(config, m_dart, 6144000); // discrete oscillator
+	m_pio->out_int_callback().set_inputline(m_maincpu, INPUT_LINE_IRQ0);
+
+	Z80DART(config, m_dart, 6144000); // FET-oscillator
+	m_dart->out_int_callback().set_inputline(m_maincpu, INPUT_LINE_IRQ0);
 
 	rs232_port_device &rs232a(RS232_PORT(config, "rs232a", default_rs232_devices, nullptr));
 	rs232a.rxd_handler().set(m_dart, FUNC(z80dart_device::rxa_w));

--- a/src/mame/skeleton/elzet80.cpp
+++ b/src/mame/skeleton/elzet80.cpp
@@ -44,6 +44,7 @@ Status: Just a closet skeleton
 
 #include "emu.h"
 
+#include "bus/rs232/rs232.h"
 #include "cpu/z80/z80.h"
 #include "imagedev/floppy.h"
 #include "machine/z80ctc.h"
@@ -64,8 +65,6 @@ public:
 	elzet80_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
-		, m_ctc(*this, "ctc")
-		, m_dma(*this, "dma")
 		, m_pio(*this, "pio")
 		, m_dart(*this, "uart")
 		, m_crtc(*this, "crtc")
@@ -94,8 +93,6 @@ private:
 
 	floppy_image_device *m_floppy = nullptr;
 	required_device<cpu_device> m_maincpu;
-	required_device<z80ctc_device> m_ctc;
-	required_device<z80dma_device> m_dma;
 	required_device<z80pio_device> m_pio;
 	required_device<z80dart_device> m_dart;
 	required_device<mc6845_device> m_crtc;
@@ -147,7 +144,7 @@ void elzet80_state::mem_map(address_map &map)
 void elzet80_state::io_map(address_map &map)
 {
 	map(0x00, 0x03).rw(m_pio, FUNC(z80pio_device::read), FUNC(z80pio_device::write));
-	map(0x04, 0x07).rw(m_dart, FUNC(z80dart_device::ba_cd_r), FUNC(z80dart_device::ba_cd_w));
+	map(0x04, 0x07).rw(m_dart, FUNC(z80dart_device::cd_ba_r), FUNC(z80dart_device::cd_ba_w));
 	map(0x28, 0x28).nopw(); // toggle video memory access
 	map(0x29, 0x29).noprw(); // video card (unused)
 	map(0x2a, 0x2a).rw(m_crtc, FUNC(mc6845_device::status_r), FUNC(mc6845_device::address_w));
@@ -162,13 +159,13 @@ INPUT_PORTS_END
 static const gfx_layout elzet_charlayout =
 {
 	8, 12,                  /* 8 x 12 characters */
-	256,                    /* 128 characters */
+	256,                    /* 256 characters */
 	1,                      /* 1 bits per pixel */
 	{ 0 },                  /* no bitplanes */
 	/* x offsets */
 	{ 0, 1, 2, 3, 4, 5, 6, 7 },
 	/* y offsets */
-	{ 0*8, 1*8, 2*8, 3*8, 4*8, 5*8, 6*8, 7*8, 8*8, 9*8, 10*8, 11*8  },
+	{ 0*8, 1*8, 2*8, 3*8, 4*8, 5*8, 6*8, 7*8, 8*8, 9*8, 10*8, 11*8, 12*8, 13*8, 14*8, 15*8 },
 	8*16                    /* every char takes 16 bytes */
 };
 
@@ -198,10 +195,18 @@ void elzet80_state::elzet80(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &elzet80_state::mem_map);
 	m_maincpu->set_addrmap(AS_IO, &elzet80_state::io_map);
 
-	Z80PIO(config, m_pio);
+	Z80PIO(config, m_pio, 4_MHz_XTAL);
 	Z80DART(config, m_dart, 6144000); // discrete oscillator
-	Z80CTC(config, m_ctc);
-	Z80DMA(config, m_dma);
+
+	rs232_port_device &rs232a(RS232_PORT(config, "rs232a", default_rs232_devices, nullptr));
+	rs232a.rxd_handler().set(m_dart, FUNC(z80dart_device::rxa_w));
+	rs232a.rxc_handler().set(m_dart, FUNC(z80dart_device::rxca_w));
+	rs232a.cts_handler().set(m_dart, FUNC(z80dart_device::ctsa_w));
+	rs232a.dcd_handler().set(m_dart, FUNC(z80dart_device::dcda_w));
+
+	rs232_port_device &rs232b(RS232_PORT(config, "rs232b", default_rs232_devices, nullptr));
+	rs232b.rxd_handler().set(m_dart, FUNC(z80dart_device::rxb_w));
+	rs232b.dcd_handler().set(m_dart, FUNC(z80dart_device::dcdb_w));
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_raw(8_MHz_XTAL, 512, 0, 320, 326, 0, 240);

--- a/src/mame/skeleton/elzet80.cpp
+++ b/src/mame/skeleton/elzet80.cpp
@@ -36,8 +36,8 @@ The BCS is a box that can be used to convert over 300 floppy-disk formats.
 ***************************************************************************
 
 
-To Do: Everything.
-Status: Just a closet skeleton
+To Do: FDC card, Centronics card, EIC card, Experimenter board, video RAM visibility, keyboard
+Status: Video works, otherwise skeleton
 
 
 ***************************************************************************/
@@ -96,7 +96,7 @@ private:
 	required_device<z80pio_device> m_pio;
 	required_device<z80dart_device> m_dart;
 	required_device<mc6845_device> m_crtc;
-	required_region_ptr<u8> m_p_chargen;
+	required_region_ptr<uint8_t> m_p_chargen;
 	required_shared_ptr<uint8_t> m_p_videoram;
 	required_shared_ptr<uint8_t> m_p_colorram;
 	required_device<palette_device> m_palette;
@@ -212,10 +212,10 @@ void elzet80_state::elzet80(machine_config &config)
 	rs232b.dcd_handler().set(m_dart, FUNC(z80dart_device::dcdb_w));
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
-	m_screen->set_raw(8_MHz_XTAL, 512, 0, 320, 326, 0, 240);
+	m_screen->set_raw(15_MHz_XTAL, 512, 0, 320, 326, 0, 240);
 	m_screen->set_screen_update(m_crtc, FUNC(mc6845_device::screen_update));
 
-	MC6845(config, m_crtc, 4_MHz_XTAL);
+	MC6845(config, m_crtc, 15_MHz_XTAL);
 	m_crtc->set_screen(m_screen);
 	m_crtc->set_show_border_area(false);
 	m_crtc->set_char_width(8);

--- a/src/mame/skeleton/elzet80.cpp
+++ b/src/mame/skeleton/elzet80.cpp
@@ -43,6 +43,7 @@ Status: Just a closet skeleton
 ***************************************************************************/
 
 #include "emu.h"
+
 #include "cpu/z80/z80.h"
 #include "imagedev/floppy.h"
 #include "machine/z80ctc.h"
@@ -50,6 +51,10 @@ Status: Just a closet skeleton
 #include "machine/z80sio.h"
 #include "machine/z80pio.h"
 #include "machine/wd_fdc.h"
+#include "video/mc6845.h"
+
+#include "emupal.h"
+#include "screen.h"
 
 namespace {
 
@@ -63,6 +68,11 @@ public:
 		, m_dma(*this, "dma")
 		, m_pio(*this, "pio")
 		, m_dart(*this, "uart")
+		, m_crtc(*this, "crtc")
+		, m_p_videoram(*this, "videoram")
+		, m_p_colorram(*this, "colorram")
+		, m_palette(*this, "palette")
+		, m_screen(*this, "screen")
 		, m_fdc(*this, "fdc")
 		, m_floppy0(*this, "fdc:0")
 		, m_floppy1(*this, "fdc:1")
@@ -86,6 +96,11 @@ private:
 	required_device<z80dma_device> m_dma;
 	required_device<z80pio_device> m_pio;
 	required_device<z80dart_device> m_dart;
+	required_device<mc6845_device> m_crtc;
+	required_shared_ptr<uint8_t> m_p_videoram;
+	required_shared_ptr<uint8_t> m_p_colorram;
+	required_device<palette_device> m_palette;
+	required_device<screen_device> m_screen;
 	required_device<fd1793_device> m_fdc;
 	required_device<floppy_connector> m_floppy0;
 	required_device<floppy_connector> m_floppy1;
@@ -97,8 +112,8 @@ void elzet80_state::mem_map(address_map &map)
 {
 	map(0x0000, 0x0fff).rom(); // CPU card ROM
 	map(0x2000, 0xffff).ram(); // 64K RAM card
-	map(0xe000, 0xe7ff).ram(); // video attribute RAM
-	map(0xe800, 0xefff).ram(); // video character RAM
+	map(0xe000, 0xe7ff).ram().share("colorram"); // video attribute RAM
+	map(0xe800, 0xefff).ram().share("videoram"); // video character RAM
 }
 
 void elzet80_state::io_map(address_map &map)
@@ -107,8 +122,8 @@ void elzet80_state::io_map(address_map &map)
 	map(0x04, 0x07).rw(m_dart, FUNC(z80dart_device::ba_cd_r), FUNC(z80dart_device::ba_cd_w));
 	map(0x28, 0x28).nopw(); // toggle video memory access
 	map(0x29, 0x29).noprw(); // video card (unused)
-	map(0x2a, 0x2a).noprw(); // 6845 address register
-	map(0x2b, 0x2b).noprw(); // 6845 init register
+	map(0x2a, 0x2a).w(m_crtc, FUNC(mc6845_device::address_w));
+	map(0x2b, 0x2b).rw(m_crtc, FUNC(mc6845_device::register_r), FUNC(mc6845_device::register_w));
 	map.global_mask(0xff);
 	map.unmap_value_high();
 }
@@ -116,6 +131,22 @@ void elzet80_state::io_map(address_map &map)
 static INPUT_PORTS_START( elzet80 )
 INPUT_PORTS_END
 
+static const gfx_layout elzet_charlayout =
+{
+	8, 12,                  /* 8 x 12 characters */
+	256,                    /* 128 characters */
+	1,                      /* 1 bits per pixel */
+	{ 0 },                  /* no bitplanes */
+	/* x offsets */
+	{ 0, 1, 2, 3, 4, 5, 6, 7 },
+	/* y offsets */
+	{ 0*8, 1*8, 2*8, 3*8, 4*8, 5*8, 6*8, 7*8, 8*8, 9*8, 10*8, 11*8  },
+	8*16                    /* every char takes 16 bytes */
+};
+
+static GFXDECODE_START( gfx_elzet )
+	GFXDECODE_ENTRY( "chargen", 0x0000, elzet_charlayout, 0, 1 )
+GFXDECODE_END
 
 void elzet80_state::machine_start()
 {
@@ -139,15 +170,25 @@ void elzet80_state::elzet80(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &elzet80_state::mem_map);
 	m_maincpu->set_addrmap(AS_IO, &elzet80_state::io_map);
 
-	// devices
-	FD1793(config, m_fdc, 1000000);    // unknown where this is derived
-	FLOPPY_CONNECTOR(config, "fdc:0", elzet80_floppies, "fdd", floppy_image_device::default_mfm_floppy_formats).enable_sound(true);
-	FLOPPY_CONNECTOR(config, "fdc:1", elzet80_floppies, "fdd", floppy_image_device::default_mfm_floppy_formats).enable_sound(true);
-
 	Z80PIO(config, m_pio);
 	Z80DART(config, m_dart, 6144000); // discrete oscillator
 	Z80CTC(config, m_ctc);
 	Z80DMA(config, m_dma);
+
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
+	m_screen->set_refresh_hz(50);
+	m_screen->set_screen_update(m_crtc, FUNC(mc6845_device::screen_update));
+
+	MC6845(config, m_crtc, 4_MHz_XTAL);
+	m_crtc->set_screen(m_screen);
+
+	GFXDECODE(config, "gfxdecode", m_palette, gfx_elzet);
+	PALETTE(config, m_palette, palette_device::MONOCHROME);
+
+	// devices
+	FD1793(config, m_fdc, 1000000);    // unknown where this is derived
+	FLOPPY_CONNECTOR(config, "fdc:0", elzet80_floppies, "fdd", floppy_image_device::default_mfm_floppy_formats).enable_sound(true);
+	FLOPPY_CONNECTOR(config, "fdc:1", elzet80_floppies, "fdd", floppy_image_device::default_mfm_floppy_formats).enable_sound(true);
 }
 
 


### PR DESCRIPTION
CPU board:
https://oldcomputers-ddns.org/public/pub/rechner/elzet80/elzet-k/manuals/elzet-k_cpu-iec.pdf
Video board:
https://oldcomputers-ddns.org/public/pub/rechner/elzet80/elzet-k/manuals/elzet-k_video80.pdf

<img width="640" height="300" alt="0000" src="https://github.com/user-attachments/assets/138b8bd1-4cbe-4eb7-b436-5914d3adc9bc" />

I couldn't get the keyboard to work.
According to the documentation it's a serial keyboard so I attached a terminal to both RS232A and B but nothing made IO 0x07 change.

elzet80p has a newer monitor version that seems to reset itself over and over, causing the screen to flicker.
elzet80k is an older one that doesn't do that.