### PR TITLE
machine/ncr5380: fix pseudo-DMA initiator stalls and self-reset IRQ

### DIFF
--- a/src/devices/machine/ncr5380.cpp
+++ b/src/devices/machine/ncr5380.cpp
@@ -195,7 +195,13 @@ void ncr5380_device::scsi_ctrl_changed()
 				m_state = IDLE;
 				m_state_timer->enable(false);
 
-				set_drq(true);
+				// A phase change ends the DMA transfer.  DRQ must be deasserted:
+				// the chip can only request a DMA byte while the bus phase matches
+				// TCR, so leaving DRQ asserted with phase-match clear is wrong and
+				// hangs pseudo-DMA drivers that poll (DRQ && !PHASEMATCH) for the
+				// end of a transfer (e.g. NetBSD/pc532 ncr_pdma_out's "final DREQ"
+				// wait).  The phase-change interrupt is the signal to software.
+				set_drq(false);
 				set_irq(true);
 			}
 		}
@@ -263,9 +269,12 @@ void ncr5380_device::icmd_w(u8 data)
 	{
 		LOG("scsi reset issued\n");
 		device_reset();
+		// a host-commanded reset (ICR R̅S̅T̅) must not interrupt this chip:
+		// device_reset() has already deasserted IRQ, and the bus does not
+		// reflect a device's own R̅S̅T̅ back to it, so scsi_ctrl_changed() is
+		// not re-entered here.  Only an externally-initiated reset interrupts.
+		// (Without this the NetBSD/pc532 monitor aborts on the spurious IRQ.)
 		m_scsi_bus->ctrl_w(m_scsi_refid, S_RST, S_RST);
-
-		set_irq(true);
 	}
 
 	m_icmd = (m_icmd & ~IC_WRITE) | (data & IC_WRITE);
@@ -505,6 +514,13 @@ int ncr5380_device::state_step()
 
 			delay = -1;
 		}
+		else
+			// no REQ yet: poll at the SCSI REQ/ACK period.  Re-arming at zero
+			// would spin with emulated time frozen, so the target could never
+			// change the bus -- hanging the emulation (seen booting Minix
+			// 1.3/pc532, whose root-mount read polls REQ in a window NetBSD's
+			// timing skipped).  100 ns lets time advance so the target responds.
+			delay = 100;
 		break;
 	case DMA_IN_ACK:
 		if (!(ctrl & S_REQ))
@@ -514,6 +530,8 @@ int ncr5380_device::state_step()
 			// clear ACK
 			m_scsi_bus->ctrl_w(m_scsi_refid, 0, S_ACK);
 		}
+		else
+			delay = 100; // REQ still asserted: poll for the target to deassert it
 		break;
 
 	case DMA_OUT_DRQ:
@@ -523,19 +541,18 @@ int ncr5380_device::state_step()
 		delay = -1;
 		break;
 	case DMA_OUT_REQ:
-		if (ctrl & S_REQ)
+		if ((ctrl & S_REQ) && (ctrl & S_PHASE_MASK) == (m_tcmd & TC_PHASE))
 		{
-			if ((ctrl & S_PHASE_MASK) == (m_tcmd & TC_PHASE))
-			{
-				LOGMASKED(LOG_DMA, "dma out: 0x%02x\n", m_odata);
+			LOGMASKED(LOG_DMA, "dma out: 0x%02x\n", m_odata);
 
-				m_state = DMA_OUT_ACK;
+			m_state = DMA_OUT_ACK;
 
-				// assert data and ACK
-				m_scsi_bus->data_w(m_scsi_refid, m_odata);
-				m_scsi_bus->ctrl_w(m_scsi_refid, S_ACK, S_ACK);
-			}
+			// assert data and ACK
+			m_scsi_bus->data_w(m_scsi_refid, m_odata);
+			m_scsi_bus->ctrl_w(m_scsi_refid, S_ACK, S_ACK);
 		}
+		else
+			delay = 100; // no REQ yet in the expected phase: poll
 		break;
 	case DMA_OUT_ACK:
 		if (!(ctrl & S_REQ))
@@ -554,6 +571,8 @@ int ncr5380_device::state_step()
 			m_scsi_bus->data_w(m_scsi_refid, 0);
 			m_scsi_bus->ctrl_w(m_scsi_refid, 0, S_ACK);
 		}
+		else
+			delay = 100; // REQ still asserted: poll for the target to deassert it
 		break;
 	}
 


### PR DESCRIPTION
Three independent fixes to the ncr5380 family, found bringing up the pc532's
DP8490 as a CPU-driven pseudo-DMA initiator. Each is small; the rationale is in
the code comments.

1. **`state_timer` no-progress poll.** A DMA wait-state (`DMA_IN_REQ`/`_ACK`,
   `DMA_OUT_REQ`/`_ACK`) that makes no progress returns delay 0, and the state
   timer then re-armed at 0 ns — freezing emulated time, so the target could
   never change REQ/phase and the whole emulation wedged. Re-arm a no-progress
   zero-delay wait at the SCSI REQ/ACK period (100 ns) so time advances and the
   target can respond.

2. **DRQ deassert on phase change.** A bus phase change ends a DMA transfer, but
   DRQ was left asserted. A pseudo-DMA driver that polls `DRQ && !PHASEMATCH` to
   detect end-of-transfer (e.g. NetBSD/pc532 `ncr_pdma_out`'s "final DREQ" wait)
   then hangs. Deassert DRQ — the phase-change interrupt is the signal to
   software.

3. **No self-interrupt on a host-commanded bus reset.** When the host asserts
   RST via ICR, `icmd_w` drove RST on the bus and then raised an interrupt — but
   a reset the host initiated itself must not self-interrupt. `device_reset()`
   (called just before) already deasserts IRQ, and the nscsi bus does not
   reflect a device's own RST back to it (`regen_ctrl` skips the driving
   device), so the chip never sees its own reset and `scsi_ctrl_changed()` is
   not re-entered. The fix is simply to drop that explicit interrupt in
   `icmd_w`; an externally-initiated reset still interrupts as before. (The
   pc532 ROM monitor asserts RST, then aborts on the spurious IRQ.)

## Testing

- NetBSD/pc532 1.5.3 boots from a SCSI disk on the DP8490 to a shell (probes
  `ncr0`/`sd0`, mounts root) — the pseudo-DMA path that previously stalled.
- The changes are narrowly scoped: (1) only re-times a wait-state that
  previously spun at zero delay; (2) only the DMA-mode phase-change path; (3)
  only the host-driven ICR /RST path — so targets and non-pseudo-DMA initiators
  are unaffected by construction.

## AI assistance

Per the contribution policy: Claude Opus 4.8 (via Claude Code) assisted with
diagnosis and drafting; all changes were reviewed and validated by me.