### PR TITLE
homebrew/et532.cpp, bus/nscsi/et532.cpp: George Scolaro ET532 (new working system)

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -4062,6 +4062,8 @@ if BUSES["NSCSI"] then
 		MAME_DIR .. "src/devices/bus/nscsi/devices.h",
 		MAME_DIR .. "src/devices/bus/nscsi/dtc510.cpp",
 		MAME_DIR .. "src/devices/bus/nscsi/dtc510.h",
+		MAME_DIR .. "src/devices/bus/nscsi/et532.cpp",
+		MAME_DIR .. "src/devices/bus/nscsi/et532.h",
 		MAME_DIR .. "src/devices/bus/nscsi/hd.cpp",
 		MAME_DIR .. "src/devices/bus/nscsi/hd.h",
 		MAME_DIR .. "src/devices/bus/nscsi/pc8801_30.cpp",

--- a/src/devices/bus/nscsi/et532.cpp
+++ b/src/devices/bus/nscsi/et532.cpp
@@ -1,0 +1,329 @@
+// license:BSD-3-Clause
+// copyright-holders:Dave Rand
+
+/*
+ * ET532 board core + SCSI slot card.
+ *
+ * et532_board_device is the whole ET532 machine (NS32532 cluster, DRAM, EPROM,
+ * COPS MAC EEPROM, two SCC2698 octal UARTs = 16 serial lines, DP8390 Ethernet,
+ * DP8490 SCSI with CPU-driven pseudo-DMA, and the non-vectored /INT merger).  It
+ * is shared by the stand-alone `et532' system driver (homebrew/et532.cpp) and by
+ * et532_scsi_device below.  The board's DP8490 (tag "dp8490") is left for the
+ * owner to place on a bus:
+ *   - stand-alone: a private nscsi bus with disk/tape, board = initiator (J4);
+ *   - slot card:   a host nscsi bus, board = target (the in-system 532SC role).
+ * Which role the DP8490 plays is a firmware choice (MODE_TARGET), not wiring.
+ *
+ * et532_scsi_device wraps the board as an nscsi slot card so it can drop into an
+ * NSCSI_CONNECTOR on a host bus (the PC532 expansion SCSI bus).  The on-board
+ * NS32532 runs the SFP (Serial/SCSI Frame Protocol) firmware that answers the host.
+ *
+ * See docs/et532/ET532-SLAVE-LOG.txt for the slave-role design.
+ */
+
+#include "emu.h"
+#include "et532.h"
+
+DEFINE_DEVICE_TYPE(ET532_BOARD, et532_board_device, "et532_board", "ET532 board")
+DEFINE_DEVICE_TYPE(ET532_SCSI,  et532_scsi_device,  "et532_scsi",  "ET532 SCSI coprocessor card")
+
+namespace {
+
+ROM_START(et532_board)
+	ROM_REGION32_LE(0x10000, "eprom", 0)
+	ROM_LOAD("et532_monitor.bin", 0x0000, 0x10000, CRC(9c024fab) SHA1(c8f3651768efe8282ceb914a99c2355735be8976))
+ROM_END
+
+} // anonymous namespace
+
+
+//**************************************************************************
+//  ET532 BOARD CORE
+//**************************************************************************
+
+ALLOW_SAVE_TYPE(et532_board_device::dma_state)
+
+et532_board_device::et532_board_device(machine_config const &mconfig, char const *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, ET532_BOARD, tag, owner, clock)
+	, m_cpu(*this, "cpu")
+	, m_fpu(*this, "fpu")
+	, m_scsi(*this, "dp8490")
+	, m_net(*this, "dp8390")
+	, m_eeprom(*this, "eeprom")
+	, m_duart(*this, "duart%u", 0U)
+	, m_serial(*this, "serial%u", 0U)
+	, m_irqs(*this, "irqs")
+	, m_net_ram{}
+	, m_drq(false)
+	, m_irq(false)
+	, m_dma(0)
+	, m_state(IDLE)
+{
+}
+
+void et532_board_device::device_start()
+{
+	save_item(NAME(m_net_ram));
+	save_item(NAME(m_drq));
+	save_item(NAME(m_irq));
+	save_item(NAME(m_dma));
+	save_item(NAME(m_state));
+}
+
+void et532_board_device::device_reset()
+{
+	m_drq = false;
+	m_irq = false;
+	m_dma = 0;
+	m_state = IDLE;
+}
+
+const tiny_rom_entry *et532_board_device::device_rom_region() const
+{
+	return ROM_NAME(et532_board);
+}
+
+// DP8390 local packet RAM (the 6264 SRAM)
+u8 et532_board_device::net_ram_r(offs_t offset)
+{
+	return m_net_ram[offset & 0x1fff];
+}
+
+void et532_board_device::net_ram_w(offs_t offset, u8 data)
+{
+	m_net_ram[offset & 0x1fff] = data;
+}
+
+// COPS: 93C46 serial EEPROM holding the Ethernet MAC (COPETH GAL).  write bit0=CS,
+// bit1=SK, bit2=DI; read bit0=DO.
+u8 et532_board_device::cops_r(offs_t offset)
+{
+	return m_eeprom->do_read();
+}
+
+void et532_board_device::cops_w(offs_t offset, u8 data)
+{
+	m_eeprom->cs_write(BIT(data, 0));
+	m_eeprom->clk_write(BIT(data, 1));
+	m_eeprom->di_write(BIT(data, 2));
+}
+
+// CPU-driven pseudo-DMA for the SCSI controller (NS32532 dynamic bus sizing + cycle
+// extension), exactly as on the pc532.
+void et532_board_device::drq_w(int state)
+{
+	if (state)
+	{
+		switch (m_state)
+		{
+		case RD1: m_dma |= u32(m_scsi->dma_r()) << 8; m_state = RD2; break;
+		case RD2: m_dma |= u32(m_scsi->dma_r()) << 16; m_state = RD3; break;
+		case RD3: m_dma |= u32(m_scsi->dma_r()) << 24; m_state = RD4; break;
+
+		case WR3: m_scsi->dma_w(m_dma >> 8); m_state = WR2; break;
+		case WR2: m_scsi->dma_w(m_dma >> 16); m_state = WR1; break;
+		case WR1: m_scsi->dma_w(m_dma >> 24); m_state = IDLE; break;
+
+		default:
+			break;
+		}
+	}
+
+	m_drq = state;
+}
+
+void et532_board_device::irq_w(int state)
+{
+	if (state)
+	{
+		switch (m_state)
+		{
+		case RD1:
+		case RD2:
+		case RD3:
+			m_state = RD4;
+			break;
+
+		case WR3:
+		case WR2:
+		case WR1:
+			m_state = IDLE;
+			break;
+
+		default:
+			break;
+		}
+	}
+
+	m_irq = state;
+}
+
+u32 et532_board_device::dma_r(offs_t offset, u32 mem_mask)
+{
+	u32 data = 0;
+
+	if (!machine().side_effects_disabled())
+	{
+		switch (m_state)
+		{
+		case IDLE:
+			if (m_drq && !m_irq)
+			{
+				m_dma = m_scsi->dma_r();
+				m_state = RD1;
+
+				m_cpu->rdy_w(1);
+			}
+			break;
+
+		case RD1:
+		case RD2:
+		case RD3:
+			m_cpu->rdy_w(1);
+			break;
+
+		case RD4:
+			data = m_dma;
+			m_state = IDLE;
+			break;
+
+		default:
+			break;
+		}
+	}
+
+	return data;
+}
+
+void et532_board_device::dma_w(offs_t offset, u32 data, u32 mem_mask)
+{
+	if (m_state == IDLE)
+	{
+		if (m_drq)
+		{
+			m_dma = data;
+			m_scsi->dma_w(m_dma >> 0);
+			m_state = WR3;
+		}
+	}
+	else
+		m_cpu->rdy_w(1);
+}
+
+template <unsigned ST> void et532_board_device::cpu_map(address_map &map)
+{
+	map(0x0000'0000, 0x0000'ffff).rom().region("eprom", 0);
+	map(0x0400'0000, 0x047f'ffff).ram().share("ram"); // 8MB DRAM
+
+	map(0x0800'0000, 0x0800'0000).rw(FUNC(et532_board_device::cops_r), FUNC(et532_board_device::cops_w));
+
+	map(0x1000'0000, 0x1000'003f).m(m_duart[0], FUNC(scc2698b_device::map)); // OCT0: serial 0-7
+	map(0x1040'0000, 0x1040'003f).m(m_duart[1], FUNC(scc2698b_device::map)); // OCT1: serial 8-15
+	map(0x1100'0000, 0x1100'0007).m(m_scsi, FUNC(dp8490_device::map));       // SCSI registers
+	map(0x1180'0000, 0x1180'000f).rw(m_net, FUNC(dp8390d_device::cs_read), FUNC(dp8390d_device::cs_write));
+	map(0x11c0'0000, 0x11c0'0000).lrw8(
+			NAME([this](offs_t offset) { return u8(m_net->remote_read()); }),
+			NAME([this](offs_t offset, u8 data) { m_net->remote_write(data); }));
+
+	map(0x2000'0000, 0x27ff'ffff).rw(FUNC(et532_board_device::dma_r), FUNC(et532_board_device::dma_w));
+}
+
+void et532_board_device::device_add_mconfig(machine_config &config)
+{
+	NS32532(config, m_cpu, 40_MHz_XTAL / 2);
+	m_cpu->set_addrmap(AS_PROGRAM, &et532_board_device::cpu_map<0>);
+	m_cpu->set_addrmap(ns32000::ST_IAM, &et532_board_device::cpu_map<ns32000::ST_IAM>);
+	m_cpu->set_addrmap(ns32000::ST_ODT, &et532_board_device::cpu_map<ns32000::ST_ODT>);
+
+	NS32381(config, m_fpu, 40_MHz_XTAL / 2);
+	m_cpu->set_fpu(m_fpu);
+
+	// no NS32202 ICU: OR all maskable interrupt sources to the NS32532 /INT
+	INPUT_MERGER_ANY_HIGH(config, m_irqs);
+	m_irqs->output_handler().set_inputline(m_cpu, INPUT_LINE_IRQ0);
+
+	// DP8490 SCSI; the owner attaches it to a bus (private = initiator, host = target)
+	DP8490(config, m_scsi);
+	m_scsi->drq_handler().set(FUNC(et532_board_device::drq_w));
+	m_scsi->irq_handler().append(m_irqs, FUNC(input_merger_device::in_w<0>));
+	m_scsi->irq_handler().append(FUNC(et532_board_device::irq_w));
+
+	// Ethernet
+	DP8390D(config, m_net);
+	m_net->irq_callback().set(m_irqs, FUNC(input_merger_device::in_w<1>));
+	m_net->mem_read_callback().set(FUNC(et532_board_device::net_ram_r));
+	m_net->mem_write_callback().set(FUNC(et532_board_device::net_ram_w));
+
+	EEPROM_93C46_16BIT(config, m_eeprom);
+
+	// two SCC2698 octal UARTs = 16 serial lines
+	SCC2698B(config, m_duart[0], 3.6864_MHz_XTAL);
+	m_duart[0]->intr_A().set(m_irqs, FUNC(input_merger_device::in_w<2>));
+	m_duart[0]->intr_B().set(m_irqs, FUNC(input_merger_device::in_w<3>));
+	m_duart[0]->intr_C().set(m_irqs, FUNC(input_merger_device::in_w<4>));
+	m_duart[0]->intr_D().set(m_irqs, FUNC(input_merger_device::in_w<5>));
+
+	SCC2698B(config, m_duart[1], 3.6864_MHz_XTAL);
+	m_duart[1]->intr_A().set(m_irqs, FUNC(input_merger_device::in_w<6>));
+	m_duart[1]->intr_B().set(m_irqs, FUNC(input_merger_device::in_w<7>));
+	m_duart[1]->intr_C().set(m_irqs, FUNC(input_merger_device::in_w<8>));
+	m_duart[1]->intr_D().set(m_irqs, FUNC(input_merger_device::in_w<9>));
+
+	for (unsigned i = 0; i < 16; i++)
+		RS232_PORT(config, m_serial[i], default_rs232_devices, (i == 0) ? "terminal" : nullptr);
+
+	m_duart[0]->tx_callback<'a'>().set(m_serial[0], FUNC(rs232_port_device::write_txd));
+	m_serial[0]->rxd_handler().set(m_duart[0], FUNC(scc2698b_device::port_a_rx_w));
+	m_duart[0]->tx_callback<'b'>().set(m_serial[1], FUNC(rs232_port_device::write_txd));
+	m_serial[1]->rxd_handler().set(m_duart[0], FUNC(scc2698b_device::port_b_rx_w));
+	m_duart[0]->tx_callback<'c'>().set(m_serial[2], FUNC(rs232_port_device::write_txd));
+	m_serial[2]->rxd_handler().set(m_duart[0], FUNC(scc2698b_device::port_c_rx_w));
+	m_duart[0]->tx_callback<'d'>().set(m_serial[3], FUNC(rs232_port_device::write_txd));
+	m_serial[3]->rxd_handler().set(m_duart[0], FUNC(scc2698b_device::port_d_rx_w));
+	m_duart[0]->tx_callback<'e'>().set(m_serial[4], FUNC(rs232_port_device::write_txd));
+	m_serial[4]->rxd_handler().set(m_duart[0], FUNC(scc2698b_device::port_e_rx_w));
+	m_duart[0]->tx_callback<'f'>().set(m_serial[5], FUNC(rs232_port_device::write_txd));
+	m_serial[5]->rxd_handler().set(m_duart[0], FUNC(scc2698b_device::port_f_rx_w));
+	m_duart[0]->tx_callback<'g'>().set(m_serial[6], FUNC(rs232_port_device::write_txd));
+	m_serial[6]->rxd_handler().set(m_duart[0], FUNC(scc2698b_device::port_g_rx_w));
+	m_duart[0]->tx_callback<'h'>().set(m_serial[7], FUNC(rs232_port_device::write_txd));
+	m_serial[7]->rxd_handler().set(m_duart[0], FUNC(scc2698b_device::port_h_rx_w));
+
+	m_duart[1]->tx_callback<'a'>().set(m_serial[8], FUNC(rs232_port_device::write_txd));
+	m_serial[8]->rxd_handler().set(m_duart[1], FUNC(scc2698b_device::port_a_rx_w));
+	m_duart[1]->tx_callback<'b'>().set(m_serial[9], FUNC(rs232_port_device::write_txd));
+	m_serial[9]->rxd_handler().set(m_duart[1], FUNC(scc2698b_device::port_b_rx_w));
+	m_duart[1]->tx_callback<'c'>().set(m_serial[10], FUNC(rs232_port_device::write_txd));
+	m_serial[10]->rxd_handler().set(m_duart[1], FUNC(scc2698b_device::port_c_rx_w));
+	m_duart[1]->tx_callback<'d'>().set(m_serial[11], FUNC(rs232_port_device::write_txd));
+	m_serial[11]->rxd_handler().set(m_duart[1], FUNC(scc2698b_device::port_d_rx_w));
+	m_duart[1]->tx_callback<'e'>().set(m_serial[12], FUNC(rs232_port_device::write_txd));
+	m_serial[12]->rxd_handler().set(m_duart[1], FUNC(scc2698b_device::port_e_rx_w));
+	m_duart[1]->tx_callback<'f'>().set(m_serial[13], FUNC(rs232_port_device::write_txd));
+	m_serial[13]->rxd_handler().set(m_duart[1], FUNC(scc2698b_device::port_f_rx_w));
+	m_duart[1]->tx_callback<'g'>().set(m_serial[14], FUNC(rs232_port_device::write_txd));
+	m_serial[14]->rxd_handler().set(m_duart[1], FUNC(scc2698b_device::port_g_rx_w));
+	m_duart[1]->tx_callback<'h'>().set(m_serial[15], FUNC(rs232_port_device::write_txd));
+	m_serial[15]->rxd_handler().set(m_duart[1], FUNC(scc2698b_device::port_h_rx_w));
+}
+
+
+//**************************************************************************
+//  ET532 SCSI SLOT CARD
+//**************************************************************************
+
+et532_scsi_device::et532_scsi_device(machine_config const &mconfig, char const *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, ET532_SCSI, tag, owner, clock)
+	, nscsi_slot_card_interface(mconfig, *this, "board:dp8490")
+	, m_board(*this, "board")
+{
+}
+
+void et532_scsi_device::device_start()
+{
+}
+
+void et532_scsi_device::device_add_mconfig(machine_config &config)
+{
+	ET532_BOARD(config, m_board, 40_MHz_XTAL);
+}

--- a/src/devices/bus/nscsi/et532.h
+++ b/src/devices/bus/nscsi/et532.h
@@ -1,0 +1,93 @@
+// license:BSD-3-Clause
+// copyright-holders:Dave Rand
+
+#ifndef MAME_BUS_NSCSI_ET532_H
+#define MAME_BUS_NSCSI_ET532_H
+
+#pragma once
+
+#include "machine/nscsi_bus.h"
+
+#include "bus/rs232/rs232.h"
+#include "cpu/ns32000/ns32000.h"
+#include "machine/dp8390.h"
+#include "machine/eepromser.h"
+#include "machine/input_merger.h"
+#include "machine/ncr5380.h"   // dp8490
+#include "machine/ns32081.h"
+#include "machine/scc2698b.h"
+
+// ET532 board core (NS32532 + FPU + DRAM + EPROM + COPS + 2x SCC2698 + 16 rs232 +
+// DP8390 Ethernet + DP8490 SCSI + CPU-driven pseudo-DMA), shared by BOTH the
+// stand-alone et532 system driver and the et532 SCSI slot card.  The board's
+// DP8490 is exposed (tag "dp8490") for whatever bus the owner attaches it to:
+// the stand-alone driver puts it on a private bus with disk/tape (initiator role);
+// the slot card hands it to a host nscsi bus (target role).  The role is a firmware
+// choice (MODE_TARGET), not the wiring.
+class et532_board_device : public device_t
+{
+public:
+	et532_board_device(machine_config const &mconfig, char const *tag, device_t *owner, u32 clock);
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
+	virtual const tiny_rom_entry *device_rom_region() const override ATTR_COLD;
+
+	template <unsigned ST> void cpu_map(address_map &map) ATTR_COLD;
+
+private:
+	void drq_w(int state);
+	void irq_w(int state);
+	u32 dma_r(offs_t offset, u32 mem_mask);
+	void dma_w(offs_t offset, u32 data, u32 mem_mask);
+
+	u8 net_ram_r(offs_t offset);
+	void net_ram_w(offs_t offset, u8 data);
+	u8 cops_r(offs_t offset);
+	void cops_w(offs_t offset, u8 data);
+
+	required_device<ns32532_device> m_cpu;
+	required_device<ns32381_device> m_fpu;
+	required_device<dp8490_device> m_scsi;
+	required_device<dp8390d_device> m_net;
+	required_device<eeprom_serial_93cxx_device> m_eeprom;
+	required_device_array<scc2698b_device, 2> m_duart;
+	required_device_array<rs232_port_device, 16> m_serial;
+	required_device<input_merger_device> m_irqs;
+
+	u8 m_net_ram[0x2000]; // 8KB DP8390 packet buffer (6264 SRAM)
+
+	bool m_drq;
+	bool m_irq;
+	u32 m_dma;
+	enum dma_state : unsigned
+	{
+		IDLE,
+		WR1, WR2, WR3,
+		RD1, RD2, RD3, RD4,
+	}
+	m_state;
+};
+
+// ET532 as an intelligent SCSI slot card: drops into an NSCSI_CONNECTOR on a host
+// nscsi bus (e.g. the PC532 532SC/DP8490 expansion bus), presenting the board's
+// DP8490 as the SCSI device while the on-board NS32532 runs the SFP firmware.
+class et532_scsi_device : public device_t, public nscsi_slot_card_interface
+{
+public:
+	et532_scsi_device(machine_config const &mconfig, char const *tag, device_t *owner, u32 clock);
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
+
+private:
+	required_device<et532_board_device> m_board;
+};
+
+DECLARE_DEVICE_TYPE(ET532_BOARD, et532_board_device)
+DECLARE_DEVICE_TYPE(ET532_SCSI, et532_scsi_device)
+
+#endif // MAME_BUS_NSCSI_ET532_H

--- a/src/devices/machine/dp8390.cpp
+++ b/src/devices/machine/dp8390.cpp
@@ -69,7 +69,6 @@ void dp8390_device::do_tx() {
 	int i;
 	uint32_t high16 = (m_regs.dcr & 4)?m_regs.rsar<<16:0;
 	if(m_reset) return;
-	if(LOOPBACK) return;  // TODO: loopback
 	m_regs.tsr = 0;
 	if(m_regs.tbcr > 1518) logerror("dp8390: trying to send overlong frame\n");
 	if(!m_regs.tbcr) { // ? Bochs says solaris actually does this
@@ -80,6 +79,18 @@ void dp8390_device::do_tx() {
 
 	buf.resize(m_regs.tbcr);
 	for(i = 0; i < m_regs.tbcr; i++) buf[i] = m_mem_read_cb(high16 + (m_regs.tpsr << 8) + i);
+
+	if(LOOPBACK) {
+		// internal loopback: route the assembled frame back through the
+		// receiver (normal address filtering and ring buffering), as NIC
+		// self-tests expect
+		recv(&buf[0], m_regs.tbcr);
+		m_regs.tsr = 1;
+		m_regs.isr |= 2;
+		m_regs.cr &= ~4;
+		check_irq();
+		return;
+	}
 
 	if(send(&buf[0], m_regs.tbcr)) {
 		m_regs.tsr = 1;

--- a/src/mame/homebrew/et532.cpp
+++ b/src/mame/homebrew/et532.cpp
@@ -1,0 +1,81 @@
+// license:BSD-3-Clause
+// copyright-holders:Dave Rand
+
+/*
+ * George Scolaro's ET532 — an Ethernet/serial variant of the pc532 (532 Baby AT),
+ * here as a STAND-ALONE system (the J4-jumpered "not in a K532 system" mode).
+ *
+ * The whole board is the shared et532_board_device (bus/nscsi/et532.{h,cpp}) —
+ * NS32532 cluster, 8MB DRAM, EPROM, COPS MAC EEPROM, two SCC2698 octal UARTs (16
+ * serial lines), DP8390 Ethernet, and a DP8490 SCSI with CPU-driven pseudo-DMA.
+ * This driver wraps that core for stand-alone operation: the board's DP8490 is the
+ * SCSI INITIATOR on a private bus carrying disk/tape.  The very same core also
+ * drops onto a host bus as the et532_scsi slot card (the in-system 532SC role,
+ * board = target); the two are peers — see docs/et532/ET532-SLAVE-LOG.txt.
+ *
+ * The ET532 was designed (rev 1A, 1989) but never built, so there is no original
+ * firmware: the EPROM is a purpose-built monitor written from scratch with the
+ * Definicon DSI-32 NS32k toolchain (banner, console echo, examine/deposit/go,
+ * console + block-0 SCSI loaders, signature+checksum autoboot).
+ *
+ * Sources:
+ *  - ET532 schematic (PROJECT:ET532, rev 1A, (C) 1988-90 George Scolaro)
+ *  - PAL equations: KSER/PALS/{DEC32,DRAMC,DRAMEN,WAIT,COPETH}.TDL
+ *  - pc532.cpp (Patrick Mackinlay) — the device-wiring template this is based on
+ */
+
+#include "emu.h"
+
+#include "bus/nscsi/et532.h"
+
+#include "machine/nscsi_bus.h"
+#include "bus/nscsi/hd.h"
+#include "bus/nscsi/tape.h"
+
+namespace {
+
+class et532_state : public driver_device
+{
+public:
+	et532_state(machine_config const &mconfig, device_type type, char const *tag)
+		: driver_device(mconfig, type, tag)
+		, m_board(*this, "board")
+		, m_scsi(*this, "board:dp8490")
+	{
+	}
+
+	void et532(machine_config &config);
+
+private:
+	required_device<et532_board_device> m_board;
+	required_device<dp8490_device> m_scsi;
+};
+
+static void scsi_devices(device_slot_interface &device)
+{
+	device.option_add("harddisk", NSCSI_HARDDISK);
+	device.option_add("tape", NSCSI_TAPE);
+}
+
+void et532_state::et532(machine_config &config)
+{
+	ET532_BOARD(config, m_board, 40_MHz_XTAL);
+
+	// stand-alone (J4): the board's DP8490 is the initiator on a private 532SC bus
+	auto &scsi(NSCSI_BUS(config, "scsi"));
+	NSCSI_CONNECTOR(config, "scsi:1", scsi_devices, "harddisk", false);
+	NSCSI_CONNECTOR(config, "scsi:2", scsi_devices, "tape", false);
+	NSCSI_CONNECTOR(config, "scsi:3", scsi_devices, nullptr, false);
+	NSCSI_CONNECTOR(config, "scsi:4", scsi_devices, nullptr, false);
+	NSCSI_CONNECTOR(config, "scsi:5", scsi_devices, nullptr, false);
+	NSCSI_CONNECTOR(config, "scsi:6", scsi_devices, nullptr, false);
+	scsi.set_external_device(7, m_scsi);
+}
+
+ROM_START(et532)
+ROM_END
+
+} // anonymous namespace
+
+/*   YEAR  NAME   PARENT  COMPAT  MACHINE  INPUT  CLASS        INIT        COMPANY           FULLNAME                       FLAGS */
+COMP(1989, et532, 0,      0,      et532,   0,     et532_state, empty_init, "George Scolaro", "ET532 (NS32532 + Ethernet)",  MACHINE_NO_SOUND_HW)

--- a/src/mame/homebrew/pc532.cpp
+++ b/src/mame/homebrew/pc532.cpp
@@ -33,6 +33,7 @@
 
 // busses and connectors
 #include "bus/rs232/rs232.h"
+#include "bus/nscsi/et532.h"
 #include "bus/nscsi/hd.h"
 #include "bus/nscsi/tape.h"
 
@@ -379,6 +380,7 @@ template <unsigned ST> void pc532_state::cpu_map(address_map &map)
 
 static void scsi_devices(device_slot_interface &device)
 {
+	device.option_add("et532", ET532_SCSI); // ET532 serial/ethernet coprocessor card (532SC)
 	device.option_add("harddisk", NSCSI_HARDDISK);
 	device.option_add("tape", NSCSI_TAPE);
 }

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -20925,6 +20925,9 @@ d6809
 @source:homebrew/dcebridge.cpp
 dcebridge
 
+@source:homebrew/et532.cpp
+et532
+
 @source:homebrew/gigatron.cpp
 gigatron
 


### PR DESCRIPTION
Refresh of the original submission: the driver is restructured as a shared board device with two front ends, the system is now marked working, and the DP8390's internal loopback is implemented so the Ethernet datapath is testable.

- `bus/nscsi/et532.cpp`: the board core — NS32532 + NS32381, 8MB DRAM, two SCC2698 octal UARTs (16 serial lines), DP8390 Ethernet with an 8KB packet SRAM and a 93C46 MAC EEPROM, and a DP8490 SCSI with the same CPU-driven pseudo-DMA as the pc532 — emulated from the schematic and PAL equations, plus the slot-card wrapper.
- `homebrew/et532.cpp`: the stand-alone system; the board's DP8490 initiates on a private bus with disk and tape.
- `homebrew/pc532.cpp`: offer the card on the expansion SCSI connectors, where the on-board firmware drives the same DP8490 as a SCSI **target** (the in-system role; needs the 5380 target mode from #15657).
- `machine/dp8390.cpp`: implement internal loopback (the file's TODO) — loopback frames route back through the receiver instead of being discarded.

The ET532 (rev 1A, 1989) was designed but never built, so there is no original firmware; the EPROM is a purpose-built monitor (console + block-0 SCSI loaders, signature/checksum autoboot) assembled with the period Definicon NS32k toolchain.

Exercised: monitor console; firmware download and a vendor-CDB protocol from a pc532/System V host, including card-initiated reselection of the host; all 16 serial ports with host termio control; and the DP8390 datapath both directions — remote DMA in and out, transmit, and receive back through the ring in internal loopback, verified byte-for-byte from the host side.
