### PR TITLE
cpu/ns32000: add a translation look-aside buffer to the NS32532 on-chip MMU

### DIFF
--- a/src/devices/cpu/ns32000/ns32000.cpp
+++ b/src/devices/cpu/ns32000/ns32000.cpp
@@ -3898,6 +3898,28 @@ void ns32532_device::device_reset()
 	m_mcr = 0;
 	m_msr = 0;
 	m_dcr = 0;
+
+	tlb_flush();
+}
+
+void ns32532_device::tlb_flush()
+{
+	for (tlb_entry &e : m_tlb)
+		e.valid = false;
+}
+
+void ns32532_device::tlb_flush_as(bool as)
+{
+	for (tlb_entry &e : m_tlb)
+		if (e.as == as)
+			e.valid = false;
+}
+
+void ns32532_device::tlb_invalidate(u32 va, bool as)
+{
+	tlb_entry &e = m_tlb[(va >> 12) & (TLB_ENTRIES - 1)];
+	if (e.valid && e.tag == (va >> 12) && e.as == as)
+		e.valid = false;
 }
 
 device_memory_interface::space_config_vector ns32532_device::memory_space_config() const
@@ -3986,12 +4008,38 @@ ns32000_mmu_interface::translate_result ns32532_device::translate(address_space 
 	if ((!user && !(m_mcr & MCR_TS)) || (user && !(m_mcr & MCR_TU)))
 		return COMPLETE;
 
-	// TODO: translation look-aside buffer
-
 	bool const address_space = (m_mcr & MCR_DS) && user;
 	unsigned const access_level = (user && !(m_mcr & MCR_AO))
 		? ((write || st == ns32000::ST_RMW) ? PL_URW : PL_URO)
 		: ((write || st == ns32000::ST_RMW) ? PL_SRW : PL_SRO);
+
+	// translation look-aside buffer: a hit avoids the two page-table reads
+	bool const rmw = (write || st == ns32000::ST_RMW);
+	u32 const tlb_vpn = address >> 12;
+	tlb_entry &tlb = m_tlb[tlb_vpn & (TLB_ENTRIES - 1)];
+	if (tlb.valid && tlb.tag == tlb_vpn && tlb.as == address_space)
+	{
+		if (unsigned(tlb.pl) < access_level)
+		{
+			if (!suppress)
+			{
+				m_msr = MSR(st, user, write, TEX_PROT);
+				m_tear = address;
+				return ABORT;
+			}
+			else
+				return CANCEL;
+		}
+
+		// a write to a page whose modified bit is not yet recorded must fall
+		// through to the walk so that PTE.M gets set in the page table
+		if (!(rmw && !tlb.m))
+		{
+			address = tlb.pfn | BIT(address, 0, 12);
+
+			return COMPLETE;
+		}
+	}
 
 	LOGMASKED(LOG_TRANSLATE, "translate address_space %d access_level %d page table 0x%08x address 0x%08x\n",
 		address_space, access_level, m_ptb[address_space], address);
@@ -4071,6 +4119,21 @@ ns32000_mmu_interface::translate_result ns32532_device::translate(address_space 
 	// set modified and referenced
 	if ((!(pte2 & PTE_R) || ((write || st == ns32000::ST_RMW) && !(pte2 & PTE_M))) && !suppress)
 		m_bus[ns32000::ST_PT2].write_dword(pte2_address, pte2 | ((write || st == ns32000::ST_RMW) ? PTE_M : 0) | PTE_R);
+
+	// update the translation look-aside buffer (not on suppressed probes, which
+	// do not set the PTE R/M bits).  The effective protection level is the more
+	// restrictive of the two levels; the recorded M bit reflects the page table
+	// after the (possible) write above.
+	if (!suppress)
+	{
+		tlb.valid = true;
+		tlb.tag = tlb_vpn;
+		tlb.as = address_space;
+		tlb.pfn = pte2 & PTE_PFN;
+		tlb.pl = u8(std::min<u32>(pte1 & PTE_PL, pte2 & PTE_PL));
+		tlb.ci = bool(pte2 & PTE_CI);
+		tlb.m = bool(pte2 & PTE_M) || rmw;
+	}
 
 	address = (pte2 & PTE_PFN) | BIT(address, 0, 12);
 	LOGMASKED(LOG_TRANSLATE, "translate complete 0x%08x\n", address);
@@ -4209,13 +4272,13 @@ u16 ns32532_device::slave(u8 opbyte, u16 opword, addr_mode op1, addr_mode op2)
 			switch (BIT(opword, 7, 4))
 			{
 			case 0x8: break;
-			case 0x9: m_mcr = gen_read(op1); break;
+			case 0x9: m_mcr = gen_read(op1); tlb_flush(); break;
 			case 0xa: m_msr = gen_read(op1); break;
 			case 0xb: m_tear = gen_read(op1); break;
-			case 0xc: m_ptb[0] = gen_read(op1) & ~0xfffU; break; // TODO: invalidate TLB
-			case 0xd: m_ptb[1] = gen_read(op1) & ~0xfffU; break; // TODO: invalidate TLB
-			case 0xe: gen_read(op1); break; // ivar0
-			case 0xf: gen_read(op1); break; // ivar1
+			case 0xc: m_ptb[0] = gen_read(op1) & ~0xfffU; tlb_flush_as(0); break; // loading PTBn invalidates its address space
+			case 0xd: m_ptb[1] = gen_read(op1) & ~0xfffU; tlb_flush_as(1); break;
+			case 0xe: tlb_invalidate(gen_read(op1), 0); break; // ivar0: purge one page in AS0
+			case 0xf: tlb_invalidate(gen_read(op1), 1); break; // ivar1: purge one page in AS1
 			default:
 				interrupt(UND);
 				break;

--- a/src/devices/cpu/ns32000/ns32000.h
+++ b/src/devices/cpu/ns32000/ns32000.h
@@ -251,6 +251,29 @@ private:
 	u32 m_mcr;     // memory management control
 	u32 m_msr;     // memory management status
 
+	// translation look-aside buffer (Section 3.4.4).  Caches completed page
+	// table walks so the common case avoids two extra memory reads per access.
+	// Modelled with more entries than the real 64-entry TLB purely for emulation
+	// speed; capacity does not affect correctness as long as invalidation (PTBn
+	// load, IVARn write) is exact.  R/M bits follow the hardware: a write to a
+	// cached page whose recorded M bit is clear still walks, to set PTE.M.
+	struct tlb_entry
+	{
+		u32  tag;   // virtual page number (address >> 12)
+		u32  pfn;   // physical frame (PTE.PFN, page-aligned)
+		u8   pl;    // effective (most restrictive) protection level
+		bool as;    // address space
+		bool ci;    // cache inhibit
+		bool m;     // level-2 PTE modified bit
+		bool valid;
+	};
+	static constexpr unsigned TLB_ENTRIES = 1024; // power of two
+	tlb_entry m_tlb[TLB_ENTRIES];
+
+	void tlb_flush();                      // invalidate all entries
+	void tlb_flush_as(bool as);            // invalidate one address space (PTBn load)
+	void tlb_invalidate(u32 va, bool as);  // invalidate one page (IVARn write)
+
 	// debug registers
 	u32 m_dcr; // debug condition
 	u32 m_dsr; // debug status


### PR DESCRIPTION
The NS32532's on-chip MMU re-walks the two-level page table on every
translation. This adds a 1024-entry direct-mapped TLB keyed by virtual page
number and address space (DS bit), caching the resulting page-frame number,
protection level, cache-inhibit and modified bits. A hit returns the mapping
without the two page-table reads.

Correctness — the TLB is invalidated on every event that changes a mapping:

- full flush on reset and on a write to MCR (LMR);
- per-address-space flush on a PTB0/PTB1 reload;
- single-entry invalidate on IVAR0/IVAR1.

A hit re-checks the cached protection level against the access, and treats a
cached read-only/clean entry as a miss for a write so the page-table walk can
set the M bit — so the cached result is the same the walk would produce.

Scope: this touches `ns32532_device` only (its on-chip MMU). The NS32016 and
NS32032 use the external NS32082 MMU — a different translate path — and are
unaffected.

## Testing

- `pc532` validates; builds clean against current master.
- **NetBSD 1.5.3/pc532** boots the GENERIC kernel to single-user with the TLB
  active: device probe, root mount (ffs) on `sd0a`, then a working shell —
  `uname -a` reports `NetBSD 1.5.3 ... pc532`, `sysctl hw.machine` → `pc532`,
  `ls -la /` reads the root filesystem. Both supervisor and user-space paging
  are served through the TLB with no regression.

## AI assistance

Per the contribution policy: Claude Opus 4.8 (via Claude Code) assisted; all
changes reviewed and validated by me.