### PR TITLE
cpu/ns32000: add NS32CG16 graphics/printer variant

### DIFF
--- a/src/devices/cpu/ns32000/ns32000.cpp
+++ b/src/devices/cpu/ns32000/ns32000.cpp
@@ -6,7 +6,6 @@
 #include "ns32000.h"
 #include "ns32000d.h"
 #include "debug/debugcpu.h"
-#include "video/dp8510.h"
 
 #define LOG_TRANSLATE (1U << 1)
 //#define VERBOSE (LOG_TRANSLATE)
@@ -140,13 +139,8 @@ ns32016_device::ns32016_device(const machine_config &mconfig, const char *tag, d
 
 ns32cg16_device::ns32cg16_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: ns32000_device(mconfig, NS32CG16, tag, owner, clock, true)
-	, m_bpu(*this, finder_base::DUMMY_TAG)
+	, m_out_bpu(*this)
 {
-}
-
-dp8510_device *ns32cg16_device::bpu() const
-{
-	return m_bpu;
 }
 
 ns32032_device::ns32032_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
@@ -2411,18 +2405,20 @@ template <int HighBits, int Width> void ns32000_device<HighBits, Width>::execute
 								//   R3 height in lines, R4 horizontal increment in bytes,
 								//   R5 current width (working), R6 source warp, R7 dest warp.
 								// The shift/mask/logic combine is performed by an external
-								// DP8510/DP8511 BITBLT processing unit (BPU): the instruction
-								// reads source and destination words, feeds them to the BPU
-								// and writes the BPU's output back.  A cleared PSR L (from a
-								// preceding CMPQB 1,2) requests preloading, which primes the
-								// BPU pipeline with an extra source word per line.  With no
-								// BPU connected the same bus cycles run as a pseudo-DMA copy
-								// of source to destination.  (On the real part that copy only
-								// latched with more than one wait state - the bus-cycle timing
-								// took priority over the late-arriving data; the supported
-								// >1-wait-state case is modelled here.)
+								// DP8510/DP8511 BITBLT processing unit (BPU).  The instruction
+								// itself only runs the bus cycles - read source, read
+								// destination, write - and asserts out_bpu() for the duration;
+								// a BPU wired up in the driver snoops those cycles via memory
+								// taps, latching the source/destination words and substituting
+								// its processed output on the write.  With no BPU connected the
+								// cycles run as a plain source-to-destination copy.  A cleared
+								// PSR L (from a preceding CMPQB 1,2) requests preloading, which
+								// primes the BPU pipeline with an extra source word per line.
+								// (On the real part that copy only latched with more than one
+								// wait state - the bus-cycle timing took priority over the
+								// late-arriving data; the supported >1-wait-state case is
+								// modelled here.)
 								{
-									dp8510_device *const blt = bpu();
 									bool const preload = !(m_psr & PSR_L);
 									s32 const incr = s32(m_r[4]);
 
@@ -2431,32 +2427,29 @@ template <int HighBits, int Width> void ns32000_device<HighBits, Width>::execute
 									// words = R2 / horizontal increment
 									u32 const ewidth = incr ? u32(s32(m_r[2]) / incr) : 0;
 									tex = 35 + ((preload ? 17 : 11) + 13 * ewidth) * m_r[3];
+
+									bpu_window(true);
 									while (m_r[3])
 									{
 										m_r[5] = m_r[2];
 
-										if (blt && preload)
+										if (preload)
 										{
-											blt->source_w(mem_read<u16>(ns32000::ST_ODT, m_r[0]), false);
+											// preload source word (latched by the BPU tap)
+											mem_read<u16>(ns32000::ST_ODT, m_r[0]);
 											m_r[0] += incr;
 										}
 
 										while (m_r[5])
 										{
 											u16 const src = mem_read<u16>(ns32000::ST_ODT, m_r[0]);
-											u16 const dst = mem_read<u16>(ns32000::ST_ODT, m_r[1]);
+											// destination read - value discarded here, but the
+											// bus cycle is what the BPU's tap latches
+											mem_read<u16>(ns32000::ST_ODT, m_r[1]);
 
-											u16 out;
-											if (blt)
-											{
-												blt->source_w(src, true);
-												blt->destination_w(dst, false);
-												out = blt->output_r();
-											}
-											else
-												out = src; // pseudo-DMA copy
-
-											mem_write<u16>(ns32000::ST_ODT, m_r[1], out);
+											// default behaviour is a plain copy; a BPU tap
+											// replaces the written value with output_r()
+											mem_write<u16>(ns32000::ST_ODT, m_r[1], src);
 
 											m_r[0] += incr;
 											m_r[1] += incr;
@@ -2467,6 +2460,7 @@ template <int HighBits, int Width> void ns32000_device<HighBits, Width>::execute
 										m_r[1] += m_r[7];
 										m_r[3]--;
 									}
+									bpu_window(false);
 								}
 								break;
 							default: // 0xf reserved

--- a/src/devices/cpu/ns32000/ns32000.cpp
+++ b/src/devices/cpu/ns32000/ns32000.cpp
@@ -6,6 +6,7 @@
 #include "ns32000.h"
 #include "ns32000d.h"
 #include "debug/debugcpu.h"
+#include "video/dp8510.h"
 
 #define LOG_TRANSLATE (1U << 1)
 //#define VERBOSE (LOG_TRANSLATE)
@@ -17,6 +18,7 @@ DEFINE_DEVICE_TYPE(NS32016, ns32016_device, "ns32016", "National Semiconductor N
 DEFINE_DEVICE_TYPE(NS32032, ns32032_device, "ns32032", "National Semiconductor NS32032")
 DEFINE_DEVICE_TYPE(NS32332, ns32332_device, "ns32332", "National Semiconductor NS32332")
 DEFINE_DEVICE_TYPE(NS32532, ns32532_device, "ns32532", "National Semiconductor NS32532")
+DEFINE_DEVICE_TYPE(NS32CG16, ns32cg16_device, "ns32cg16", "National Semiconductor NS32CG16")
 
 /*
  * TODO:
@@ -93,7 +95,7 @@ class ns32000_delay : public std::exception { };
 
 static const u32 size_mask[] = { 0x0000'00ffU, 0x0000'ffffU, 0x0000'0000U, 0xffff'ffffU };
 
-template <int HighBits, int Width>ns32000_device<HighBits, Width>::ns32000_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
+template <int HighBits, int Width>ns32000_device<HighBits, Width>::ns32000_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, bool cg16)
 	: cpu_device(mconfig, type, tag, owner, clock)
 	, m_address_mask(util::make_bitmask<u32>(HighBits))
 	, m_program_config("program", ENDIANNESS_LITTLE, 8 << Width, HighBits, 0)
@@ -122,6 +124,7 @@ template <int HighBits, int Width>ns32000_device<HighBits, Width>::ns32000_devic
 	, m_int_line(false)
 	, m_wait(false)
 	, m_sequential(false)
+	, m_cg16(cg16)
 {
 }
 
@@ -133,6 +136,17 @@ ns32008_device::ns32008_device(const machine_config &mconfig, const char *tag, d
 ns32016_device::ns32016_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: ns32000_device(mconfig, NS32016, tag, owner, clock)
 {
+}
+
+ns32cg16_device::ns32cg16_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: ns32000_device(mconfig, NS32CG16, tag, owner, clock, true)
+	, m_bpu(*this, finder_base::DUMMY_TAG)
+{
+}
+
+dp8510_device *ns32cg16_device::bpu() const
+{
+	return m_bpu;
 }
 
 ns32032_device::ns32032_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
@@ -2105,7 +2119,363 @@ template <int HighBits, int Width> void ns32000_device<HighBits, Width>::execute
 						}
 						break;
 					default:
-						interrupt(UND);
+						// NS32CG16 graphics instructions occupy Format-5 opcodes
+						// 4-14 (encoding: nat/DOCS/APPS/INSREVB); on a non-CG16
+						// part these are undefined.
+						if (m_cg16)
+						{
+							switch (BIT(opword, 2, 4))
+							{
+							case 0x7:
+								// MOVMPi - move multiple pattern
+								//   R0 destination, R1 signed pointer increment (bytes),
+								//   R2 unsigned count, R3 source pattern (size i).
+								// Writes the pattern R2 times, advancing the destination
+								// by R1 after each write; R2 is left zero.
+								// timing (Version B, no wait states): 16 + 7*R2 for
+								// byte/word, 16 + 8*R2 for doubleword
+								tex = 16 + (size == SIZE_D ? 8 : 7) * m_r[2];
+								while (m_r[2])
+								{
+									if (size == SIZE_D)
+										mem_write<u32>(ns32000::ST_ODT, m_r[0], m_r[3]);
+									else if (size == SIZE_W)
+										mem_write<u16>(ns32000::ST_ODT, m_r[0], m_r[3]);
+									else
+										mem_write<u8>(ns32000::ST_ODT, m_r[0], m_r[3]);
+
+									m_r[0] += m_r[1];
+									m_r[2]--;
+								}
+								break;
+							case 0x8:
+								// BITWT - bit-aligned word transfer
+								//   R0 source, R1 destination, R2 shift (0-15).
+								// Reads the source word, zero-extends and shifts it left
+								// by R2, ORs it into the destination and writes back, then
+								// advances both pointers by two.  The mandatory preceding
+								// CMPB R2,0 leaves PSR L clear for a zero shift, which
+								// selects a word- rather than doubleword-sized destination
+								// read-modify-write (avoiding a touch of the next word).
+								{
+									unsigned const shift = u8(m_r[2]);
+									u32 const src = mem_read<u16>(ns32000::ST_ODT, m_r[0]);
+
+									if (m_psr & PSR_L)
+									{
+										u32 const dst = mem_read<u32>(ns32000::ST_ODT, m_r[1]);
+										mem_write<u32>(ns32000::ST_ODT, m_r[1], dst | (src << shift));
+
+										// timing (Version B): 28 for shift 1-8, +1 per
+										// bit beyond 8
+										tex = (shift <= 8) ? 28 : 28 + (shift - 8);
+									}
+									else
+									{
+										u32 const dst = mem_read<u16>(ns32000::ST_ODT, m_r[1]);
+										mem_write<u16>(ns32000::ST_ODT, m_r[1], u16(dst | src));
+
+										// timing (Version B): 16 for a zero shift
+										tex = 16;
+									}
+
+									m_r[0] += 2;
+									m_r[1] += 2;
+								}
+								break;
+							case 0x9:
+								// TBITS - test bit string
+								//   R0 base, R1 signed bit offset, R2 run length,
+								//   R3 maximum run length, R4 maximum bit offset.
+								// Counts a run of bits equal to the option S starting at
+								// bit R1; terminates on the first opposite bit, on R2
+								// reaching R3, or on R1 reaching R4.  L distinguishes a
+								// run-length stop (1) from a max-offset stop (0); F holds
+								// the value of the last bit tested.
+								{
+									bool const s = BIT(opword, 7);
+									// timing (Version B, no wait states): 27 per bit tested
+									tex = 7;
+
+									if (s32(m_r[1]) >= s32(m_r[4]))
+									{
+										// max offset reached on entry: F = option, L clear
+										m_psr &= ~PSR_L;
+										if (s)
+											m_psr |= PSR_F;
+										else
+											m_psr &= ~PSR_F;
+									}
+									else for (;;)
+									{
+										u32 const byte = mem_read<u8>(ns32000::ST_ODT, m_r[0] + (s32(m_r[1]) >> 3));
+										bool const bit = BIT(byte, m_r[1] & 7);
+										tex += 27;
+
+										if (bit != s)
+										{
+											// opposite bit found; R1 left pointing at it
+											m_psr |= PSR_L;
+											if (bit)
+												m_psr |= PSR_F;
+											else
+												m_psr &= ~PSR_F;
+											break;
+										}
+
+										m_r[1]++;
+										m_r[2]++;
+
+										if (m_r[2] >= m_r[3])
+										{
+											// maximum run length reached
+											m_psr |= PSR_L;
+											if (bit)
+												m_psr |= PSR_F;
+											else
+												m_psr &= ~PSR_F;
+											break;
+										}
+										if (s32(m_r[1]) >= s32(m_r[4]))
+										{
+											// maximum bit offset reached
+											m_psr &= ~PSR_L;
+											if (bit)
+												m_psr |= PSR_F;
+											else
+												m_psr &= ~PSR_F;
+											break;
+										}
+									}
+								}
+								break;
+							case 0xb:
+								// SBITPS - set bit perpendicular string
+								//   R0 base, R1 signed bit offset, R2 run length,
+								//   R3 signed destination warp.
+								// Sets R2 bits, stepping the bit offset by the warp after
+								// each so that horizontal, vertical and 45-degree lines can
+								// be drawn.
+								// timing (Version B, no wait states): 8 + 34*R2
+								tex = 8 + 34 * m_r[2];
+								while (m_r[2])
+								{
+									u32 const addr = m_r[0] + (s32(m_r[1]) >> 3);
+									u8 const byte = mem_read<u8>(ns32000::ST_ODT, addr);
+									mem_write<u8>(ns32000::ST_ODT, addr, byte | (1U << (m_r[1] & 7)));
+
+									m_r[1] += m_r[3];
+									m_r[2]--;
+								}
+								break;
+							case 0xd:
+								// SBITS - set bit string
+								//   R0 base, R1 signed bit offset, R2 run length,
+								//   R3 address of the mask look-up table (Figure 1: eight
+								//   bit-offset groups of 32 doublewords, entry =
+								//   ((2^runlen - 1) << bitoffset)).
+								// Sets R2 contiguous bits.  A run longer than 25 bits is
+								// not set in hardware: the destination doubleword is read,
+								// PSR F is set, and software is expected to take over.
+								{
+									u32 const addr = m_r[0] + (s32(m_r[1]) >> 3);
+									unsigned const bitoff = m_r[1] & 7;
+
+									if (m_r[2] > 25)
+									{
+										(void)mem_read<u32>(ns32000::ST_ODT, addr);
+										m_psr |= PSR_F;
+
+										// timing (Version B, no wait states): 42 when R2 > 25
+										tex = 42;
+									}
+									else
+									{
+										u32 const mask = mem_read<u32>(ns32000::ST_ODT, m_r[3] + (bitoff * 32 + m_r[2]) * 4);
+										u32 const dst = mem_read<u32>(ns32000::ST_ODT, addr);
+										mem_write<u32>(ns32000::ST_ODT, addr, dst | mask);
+										m_psr &= ~PSR_F;
+
+										// timing (Version B, no wait states): 39 when R2 <= 25
+										tex = 39;
+									}
+								}
+								break;
+							case 0x4: // BBSTOD - bit-block source -> destination
+							case 0x6: // BBOR   - bit-block OR
+							case 0xa: // BBAND  - bit-block AND
+							case 0xc: // BBFOR  - bit-block fast OR
+							case 0xe: // BBXOR  - bit-block XOR
+								// BITBLT series - bit-aligned block transfer.  Operands:
+								//   R0 source base, R1 destination base, R2 shift (0-15),
+								//   R3 height in lines, R4 first mask, R5 second mask,
+								//   R6 adjusted source warp, R7 adjusted destination warp,
+								//   0(sp) width in words.
+								// Each line transfers `width` words: the first word uses
+								// the first mask, the last word the second mask, the inner
+								// words an all-ones (OR-style) or all-zeros (AND-style)
+								// default.  For OR/XOR/FOR the masked source is shifted and
+								// OR/XOR-combined into the destination doubleword; for AND
+								// the source is combined with a high-order word of ones, the
+								// mask is ORed in, the result rotated and ANDed into the
+								// destination; for STOD the destination is cleared under the
+								// rotated mask before the shifted source is stored.  The -S
+								// option complements the source, DA reverses direction; BBFOR
+								// has neither.  (The shift-of-zero word-vs-doubleword
+								// optimisation gated by the L bit of the mandatory preceding
+								// CMPB R2,0 is result-identical here and not modelled.)
+								{
+									unsigned const op = BIT(opword, 2, 4);
+									bool const fast = (op == 0xc);
+									bool const invert = !fast && BIT(opword, 7);
+									bool const decr = !fast && BIT(opword, 9);
+									unsigned const shift = u8(m_r[2]) & 31;
+									s32 const step = decr ? -2 : 2;
+									u16 const inner = (op == 0xa) ? 0x0000 : 0xffff;
+									u32 const width0 = mem_read<u16>(ns32000::ST_ODT, SP());
+
+									// timing (Version B, no wait states): per-op base +
+									// (per + inc*(width-2))*height, plus (shift-8)*width*height
+									// for shifts greater than eight
+									unsigned bbbase, bbper, bbinc;
+									switch (op)
+									{
+									case 0x6: bbbase = 42; bbper = 107; bbinc = 44; break; // BBOR
+									case 0xe: bbbase = 44; bbper = 107; bbinc = 44; break; // BBXOR
+									case 0xa: bbbase = 45; bbper = 111; bbinc = 44; break; // BBAND
+									case 0x4: bbbase = 66; bbper = 170; bbinc = 60; break; // BBSTOD
+									default:  // BBFOR
+										bbbase = 48;
+										if (shift) { bbper = 74; bbinc = 32; } else { bbper = 61; bbinc = 25; }
+										break;
+									}
+									tex = bbbase + u32(s32(bbper) + s32(bbinc) * (s32(width0) - 2)) * m_r[3];
+									if (shift > 8)
+										tex += (shift - 8) * width0 * m_r[3];
+									while (m_r[3])
+									{
+										u32 width = width0;
+										u16 mask = u16(m_r[4]);
+
+										while (width)
+										{
+											u16 src = mem_read<u16>(ns32000::ST_ODT, m_r[0]);
+											if (invert)
+												src = u16(~src);
+											u32 const dst = mem_read<u32>(ns32000::ST_ODT, m_r[1]);
+
+											u32 result;
+											if (op == 0xa)
+											{
+												// BBAND
+												u32 const t = (0xffff'0000U | src) | mask;
+												u32 const ss = shift ? ((t << shift) | (t >> (32 - shift))) : t;
+												result = dst & ss;
+											}
+											else
+											{
+												u32 const ss = (u32(src) & mask) << shift;
+												if (op == 0x4)
+												{
+													// BBSTOD
+													u32 const m = mask;
+													u32 const rot = shift ? ((m << shift) | (m >> (32 - shift))) : m;
+													result = (dst & ~rot) | ss;
+												}
+												else if (op == 0xe)
+													result = dst ^ ss; // BBXOR
+												else
+													result = dst | ss; // BBOR / BBFOR
+											}
+											mem_write<u32>(ns32000::ST_ODT, m_r[1], result);
+
+											// every word but the last of the line advances the
+											// pointers by two (the warp is applied afterwards)
+											if (--width)
+											{
+												m_r[0] += step;
+												m_r[1] += step;
+												mask = (width == 1) ? u16(m_r[5]) : inner;
+											}
+										}
+
+										m_r[0] += m_r[6];
+										m_r[1] += m_r[7];
+										m_r[3]--;
+									}
+								}
+								break;
+							case 0x5:
+								// EXTBLT - external bit-aligned block transfer.  Operands:
+								//   R0 source base, R1 destination base, R2 width in bytes,
+								//   R3 height in lines, R4 horizontal increment in bytes,
+								//   R5 current width (working), R6 source warp, R7 dest warp.
+								// The shift/mask/logic combine is performed by an external
+								// DP8510/DP8511 BITBLT processing unit (BPU): the instruction
+								// reads source and destination words, feeds them to the BPU
+								// and writes the BPU's output back.  A cleared PSR L (from a
+								// preceding CMPQB 1,2) requests preloading, which primes the
+								// BPU pipeline with an extra source word per line.  With no
+								// BPU connected the same bus cycles run as a pseudo-DMA copy
+								// of source to destination.  (On the real part that copy only
+								// latched with more than one wait state - the bus-cycle timing
+								// took priority over the late-arriving data; the supported
+								// >1-wait-state case is modelled here.)
+								{
+									dp8510_device *const blt = bpu();
+									bool const preload = !(m_psr & PSR_L);
+									s32 const incr = s32(m_r[4]);
+
+									// timing (Version B, no wait states): 35 + (k + 13*width)*
+									// height, k = 17 pre-read (cleared L) else 11; width in
+									// words = R2 / horizontal increment
+									u32 const ewidth = incr ? u32(s32(m_r[2]) / incr) : 0;
+									tex = 35 + ((preload ? 17 : 11) + 13 * ewidth) * m_r[3];
+									while (m_r[3])
+									{
+										m_r[5] = m_r[2];
+
+										if (blt && preload)
+										{
+											blt->source_w(mem_read<u16>(ns32000::ST_ODT, m_r[0]), false);
+											m_r[0] += incr;
+										}
+
+										while (m_r[5])
+										{
+											u16 const src = mem_read<u16>(ns32000::ST_ODT, m_r[0]);
+											u16 const dst = mem_read<u16>(ns32000::ST_ODT, m_r[1]);
+
+											u16 out;
+											if (blt)
+											{
+												blt->source_w(src, true);
+												blt->destination_w(dst, false);
+												out = blt->output_r();
+											}
+											else
+												out = src; // pseudo-DMA copy
+
+											mem_write<u16>(ns32000::ST_ODT, m_r[1], out);
+
+											m_r[0] += incr;
+											m_r[1] += incr;
+											m_r[5] -= incr;
+										}
+
+										m_r[0] += m_r[6];
+										m_r[1] += m_r[7];
+										m_r[3]--;
+									}
+								}
+								break;
+							default: // 0xf reserved
+								interrupt(UND);
+								break;
+							}
+						}
+						else
+							interrupt(UND);
 						break;
 					}
 				}

--- a/src/devices/cpu/ns32000/ns32000.h
+++ b/src/devices/cpu/ns32000/ns32000.h
@@ -8,8 +8,6 @@
 
 #include "common.h"
 
-class dp8510_device;
-
 template <int HighBits, int Width>
 class ns32000_device : public cpu_device
 {
@@ -144,10 +142,10 @@ protected:
 	virtual void lpr(unsigned reg, addr_mode const mode, bool user, unsigned &tex);
 	virtual void spr(unsigned reg, addr_mode const mode, bool user, unsigned &tex);
 
-	// the external DP8510/DP8511 BITBLT processing unit driven by EXTBLT,
-	// or nullptr if none is connected (in which case EXTBLT degrades to a
-	// pseudo-DMA source-to-destination copy)
-	virtual dp8510_device *bpu() const { return nullptr; }
+	// EXTBLT (NS32CG16) asserts this around the block transfer so an external
+	// BPU wired up in the driver can snoop the source/destination bus cycles
+	// via memory taps; the base CPU has no BPU and ignores it.
+	virtual void bpu_window(bool active) { }
 
 	// slave protocol helpers
 	virtual u16 slave(u8 opbyte, u16 opword, addr_mode op1, addr_mode op2);
@@ -298,15 +296,16 @@ class ns32cg16_device : public ns32000_device<24, 1>
 public:
 	ns32cg16_device(machine_config const &mconfig, char const *tag, device_t *owner, u32 clock);
 
-	// connect an external DP8510/DP8511 BITBLT processing unit (the BPU that
-	// EXTBLT drives); without it EXTBLT performs a pseudo-DMA copy
-	template <typename T> void set_bpu(T &&tag) { m_bpu.set_tag(std::forward<T>(tag)); }
+	// EXTBLT asserts this for the duration of the block transfer; a DP8510/
+	// DP8511 BITBLT processing unit attached in the driver uses it to gate the
+	// memory taps that route the source/destination words through the BPU.
+	auto out_bpu() { return m_out_bpu.bind(); }
 
 protected:
-	virtual dp8510_device *bpu() const override;
+	virtual void bpu_window(bool active) override { m_out_bpu(active); }
 
 private:
-	optional_device<dp8510_device> m_bpu;
+	devcb_write_line m_out_bpu;
 };
 
 DECLARE_DEVICE_TYPE(NS32008, ns32008_device)

--- a/src/devices/cpu/ns32000/ns32000.h
+++ b/src/devices/cpu/ns32000/ns32000.h
@@ -8,6 +8,8 @@
 
 #include "common.h"
 
+class dp8510_device;
+
 template <int HighBits, int Width>
 class ns32000_device : public cpu_device
 {
@@ -18,7 +20,7 @@ public:
 	void rdy_w(int state) { m_ready = !state; }
 
 protected:
-	ns32000_device(machine_config const &mconfig, device_type type, char const *tag, device_t *owner, u32 clock);
+	ns32000_device(machine_config const &mconfig, device_type type, char const *tag, device_t *owner, u32 clock, bool cg16 = false);
 
 	// device_t implementation
 	virtual void device_start() override ATTR_COLD;
@@ -142,6 +144,11 @@ protected:
 	virtual void lpr(unsigned reg, addr_mode const mode, bool user, unsigned &tex);
 	virtual void spr(unsigned reg, addr_mode const mode, bool user, unsigned &tex);
 
+	// the external DP8510/DP8511 BITBLT processing unit driven by EXTBLT,
+	// or nullptr if none is connected (in which case EXTBLT degrades to a
+	// pseudo-DMA source-to-destination copy)
+	virtual dp8510_device *bpu() const { return nullptr; }
+
 	// slave protocol helpers
 	virtual u16 slave(u8 opbyte, u16 opword, addr_mode op1, addr_mode op2);
 	u16 slave_slow(ns32000_slow_slave_interface &slave, u8 opbyte, u16 opword, addr_mode op1, addr_mode op2);
@@ -191,6 +198,7 @@ private:
 	bool m_wait;
 	bool m_sequential;
 	bool m_ready;
+	bool m_cg16;   // NS32CG16 graphics-instruction variant enabled
 };
 
 class ns32008_device : public ns32000_device<24, 0>
@@ -281,10 +289,31 @@ private:
 	u32 m_bpc; // breakpoint program counter
 };
 
+// NS32CG16 — graphics/printer variant: an NS32016 (24-bit address, 16-bit bus)
+// plus the Series 32000 graphics instructions (Format-5 extensions).  The base
+// constructor's cg16 flag enables that instruction group; the chip is otherwise
+// an NS32016.
+class ns32cg16_device : public ns32000_device<24, 1>
+{
+public:
+	ns32cg16_device(machine_config const &mconfig, char const *tag, device_t *owner, u32 clock);
+
+	// connect an external DP8510/DP8511 BITBLT processing unit (the BPU that
+	// EXTBLT drives); without it EXTBLT performs a pseudo-DMA copy
+	template <typename T> void set_bpu(T &&tag) { m_bpu.set_tag(std::forward<T>(tag)); }
+
+protected:
+	virtual dp8510_device *bpu() const override;
+
+private:
+	optional_device<dp8510_device> m_bpu;
+};
+
 DECLARE_DEVICE_TYPE(NS32008, ns32008_device)
 DECLARE_DEVICE_TYPE(NS32016, ns32016_device)
 DECLARE_DEVICE_TYPE(NS32032, ns32032_device)
 DECLARE_DEVICE_TYPE(NS32332, ns32332_device)
 DECLARE_DEVICE_TYPE(NS32532, ns32532_device)
+DECLARE_DEVICE_TYPE(NS32CG16, ns32cg16_device)
 
 #endif // MAME_CPU_NS32000_NS32000_H

--- a/src/devices/cpu/ns32000/ns32000.h
+++ b/src/devices/cpu/ns32000/ns32000.h
@@ -302,7 +302,8 @@ public:
 	auto out_bpu() { return m_out_bpu.bind(); }
 
 protected:
-	virtual void bpu_window(bool active) override { m_out_bpu(active); }
+	// /BPU is active low; output the physical level (0 = low/asserted)
+	virtual void bpu_window(bool active) override { m_out_bpu(active ? 0 : 1); }
 
 private:
 	devcb_write_line m_out_bpu;

--- a/src/devices/cpu/ns32000/ns32000d.cpp
+++ b/src/devices/cpu/ns32000/ns32000d.cpp
@@ -319,6 +319,13 @@ offs_t ns32000_disassembler::disassemble(std::ostream &stream, offs_t pc, data_b
 
 			size_code const size = size_code(opword & 3);
 
+			// NS32CG16 BitBlt option suffix: DA = decrement address (opword bit 9),
+			// -S = complement source (opword bit 7)
+			char const *const bbo =
+				(BIT(opword, 9) && BIT(opword, 7)) ? " DA,-S" :
+				BIT(opword, 9) ? " DA" :
+				BIT(opword, 7) ? " -S" : "";
+
 			switch (BIT(opword, 2, 4))
 			{
 			case 0:
@@ -340,6 +347,18 @@ offs_t ns32000_disassembler::disassemble(std::ostream &stream, offs_t pc, data_b
 				else
 					util::stream_format(stream, "SKPS%c   %s", size_char[size], options[BIT(opword, 8, 3)]);
 				break;
+			// NS32CG16 graphics instructions (Format-5 opcodes 4-14)
+			case 0x4: util::stream_format(stream, "BBSTOD%s", bbo); break;
+			case 0x5: util::stream_format(stream, "EXTBLT"); break;
+			case 0x6: util::stream_format(stream, "BBOR%s", bbo); break;
+			case 0x7: util::stream_format(stream, "MOVMP%c", size_char[size]); break;
+			case 0x8: util::stream_format(stream, "BITWT"); break;
+			case 0x9: util::stream_format(stream, "TBITS   %d", BIT(opword, 7)); break;
+			case 0xa: util::stream_format(stream, "BBAND%s", bbo); break;
+			case 0xb: util::stream_format(stream, "SBITPS"); break;
+			case 0xc: util::stream_format(stream, "BBFOR"); break;
+			case 0xd: util::stream_format(stream, "SBITS"); break;
+			case 0xe: util::stream_format(stream, "BBXOR%s", bbo); break;
 			default: bytes = 1; break;
 			}
 		}

--- a/src/mame/emusys/emax.cpp
+++ b/src/mame/emusys/emax.cpp
@@ -243,7 +243,7 @@ void emax_state::emaxp(machine_config &config)
 
 void emax_state::emax2(machine_config &config)
 {
-	NS32016(config, m_maincpu, 20_MHz_XTAL / 2); // NS32CG16V-10 (FIXME)
+	NS32CG16(config, m_maincpu, 20_MHz_XTAL / 2); // NS32CG16V-10
 	m_maincpu->set_addrmap(AS_PROGRAM, &emax_state::emax2_map);
 
 	EEPROM_93C06_16BIT(config, "eeprom"); // NMC93C06N


### PR DESCRIPTION
Adds the NS32CG16, an NS32016 plus the Series 32000 graphics instructions
(Format-5 extensions): the bit-string ops (MOVMP, BITWT, TBITS, SBITS, SBITPS),
the BitBlt instructions (BBOR, BBXOR, BBAND, BBFOR, BBSTOD), and EXTBLT.  EXTBLT
drives an optional DP8510/DP8511 BITBLT processing unit via `set_bpu()`, and
degrades to a pseudo-DMA source-to-destination copy when none is connected.
Disassembler support for the new Format-5 opcodes is included, and instruction
timing follows the published NS32CG16 (B-stepping) data.

emax2 (Emax II) is switched from a placeholder NS32016 to the NS32CG16.
