### PR TITLE
added a JAKKS Plug and Play clone (working) + a Lexibook SPG293 based unit (not working) + 1 working SPG24x unit

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -47851,8 +47851,8 @@ cybrtvbb
 cybrtvfe
 discpal
 disppal
-lexizeus
 lexiseal
+lexizeus
 pokermor
 vgcaplet
 vgcap35

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -47810,6 +47810,7 @@ jak_xmenp
 jak_capc
 jak_care
 jak_dbz
+jak_dbza
 jak_disf
 jak_disn
 jak_dora

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -47849,10 +47849,11 @@ tvtchsb
 arcade3d
 cybrtvbb
 cybrtvfe
-lexizeus
-lexiseal
 discpal
 disppal
+lexizeus
+lexiseal
+pokermor
 vgcaplet
 vgcap35
 vsplus

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -47662,6 +47662,7 @@ sstarkar
 
 @source:tvgames/spg29x.cpp
 bratzlfe
+gameclik
 hyprscan
 jak_bbh
 jak_bbsf

--- a/src/mame/tvgames/elan_ep3a19a.cpp
+++ b/src/mame/tvgames/elan_ep3a19a.cpp
@@ -213,4 +213,4 @@ CONS( 2007, tvbg3c, 0, 0, elan_ep3a19a_1mb, tvbg_2button, elan_ep3a19a_state, in
 // hybrid system with an LCD game on the controller (uses a separate MCU glob, not emulated)
 // "Credit:XiAn Hummer Software Studio(CHINA) Tel:86-29-84270600 Email:HummerSoft@126.com Http://www.hummersoft.com" string in ROM
 CONS( 2006, lexiig10, 0, 0, elan_ep3a19a_2mb_pal_fast, lexiig10, elan_ep3a19a_state, empty_init, "Lexibook", "Color Console IG10 (DualMax 20 in 1 TV part)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
-// Sunnyflyer 30-in-1 contains the games from lexiig10 so probably fits here too ( https://blog.12bit.club/?post=6 )
+// Sunnyflyer 30-in-1 looks similar to lexiig10 (especially the Bomberman clone) so probably fits here too ( https://blog.12bit.club/?post=6 )

--- a/src/mame/tvgames/spg29x.cpp
+++ b/src/mame/tvgames/spg29x.cpp
@@ -589,6 +589,14 @@ ROM_START( zonefamf )
 	//has 1x 48LC8M16A2 (128Mbit/16MByte SDRAM) for loading game into
 ROM_END
 
+ROM_START( gameclik )
+	ROM_REGION( 0x8400000, "nand", 0 )
+	ROM_LOAD("k9f1g08u0b.u6", 0x000000, 0x8400000, CRC(4a02463d) SHA1(e21263dad17c83281bcbeac621b6e7bd6e161809) )
+
+	ROM_REGION( 0x008000, "spg290", ROMREGION_32BIT | ROMREGION_LE )
+	ROM_LOAD32_DWORD("internal.rom", 0x000000, 0x008000, NO_DUMP)
+ROM_END
+
 ROM_START( prail07 )
 	ROM_REGION( 0x8400000, "nand", 0 )
 	ROM_LOAD("hy27uf081g2a.u13", 0x000000, 0x8400000, CRC(2bbe73a7) SHA1(f6af701a372f2600ed4d7df957d8fcaf164bb61b) )
@@ -626,6 +634,9 @@ COMP( 201?, zonefamf,  0,      0,      spg29x, hyperscan, spg29x_zonefamf_game_s
 COMP( 2007, prail07,   0,      0,      spg29x, hyperscan, spg29x_zonefamf_game_state, nand_zonefamf,"Takara Tomy", "Boku wa Plarail Untenshi - Shinkansen de Ikou! (2007 version) (Japan)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
 
 CONS( 2007, bratzlfe,  0,      0,      spg29x, hyperscan, spg29x_game_state, empty_init,  "MGA", "Bratz Life",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+
+// looks like one of the mid-gen Compact Cyber Arcade units, but with a camera. Has SPG293 strings in the NAND
+COMP( 2010, gameclik,  0,      0,      spg29x, hyperscan, spg29x_zonefamf_game_state, nand_zonefamf,"Lexibook", "Gameclick (JL2400)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
 
 // the sets in spg29x_lexibook_jg7425.cpp probably also belong here, as they use an SPG293 which has the same peripheral mappings (but they make use of additional features)
 // see emu293 https://github.com/gatecat/emu293

--- a/src/mame/tvgames/spg2xx_jakks_gkr.cpp
+++ b/src/mame/tvgames/spg2xx_jakks_gkr.cpp
@@ -667,6 +667,11 @@ ROM_START( jak_dbz )
 	ROM_LOAD16_WORD_SWAP( "jakksdragonballzgkr.bin", 0x000000, 0x200000, CRC(d52c3b20) SHA1(fd5ce41c143cad9bca3372054f4ff98b52c33874) )
 ROM_END
 
+ROM_START( jak_dbza )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "jakks_dbz.bin", 0x000000, 0x200000, CRC(5878a32d) SHA1(eb9c28c45486c31727536a6853d7987dc365bfa5) )
+ROM_END
+
 ROM_START( jak_sith )
 	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "jakksstarwarsgkr.bin", 0x000000, 0x200000, CRC(932cde19) SHA1(b88b748c235e9eeeda574e4d5b4077ae9da6fbd0) )
@@ -711,11 +716,12 @@ CONS( 2005, jak_dprs,  0,        0, jakks_gkr_dp_i2c, jak_dpr_i2c,  jakks_gkr_st
 CONS( 2005, jak_sith,  0,        0, jakks_gkr_sw_i2c, jak_sith_i2c, jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Griptonite Games",        "Star Wars - Revenge of the Sith (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses SW keys (1 released)
 CONS( 2005, jak_sithp, jak_sith, 0, jakks_gkr_sw_i2c, jak_sith_i2c, jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Griptonite Games",        "Star Wars - Revenge of the Sith (JAKKS Pacific TV Game, Game-Key Ready, prototype)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // ^
 CONS( 2006, jak_swot,  0,        0, jakks_gkr_sw_i2c, jak_sith_i2c, jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Amaze Entertainment",     "Star Wars - Original Trilogy (JAKKS Pacific TV Game)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // was designed with SW keys in mind, but retail lacked the port
-CONS( 2005, jak_dbz,   0,        0, jakks_gkr_1m_i2c, jak_gkr_i2c,  jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Handheld Games",          "Dragon Ball Z (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // DB (no game-keys released, 1 in development but cancelled)
+CONS( 2005, jak_dbz,   0,        0, jakks_gkr_1m_i2c, jak_gkr_i2c,  jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Handheld Games",          "Dragon Ball Z (JAKKS Pacific TV Game, Game-Key Ready, set 1)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // DB (no game-keys released, 1 in development but cancelled)
+CONS( 2005, jak_dbza,  jak_dbz,  0, jakks_gkr_1m_i2c, jak_gkr_i2c,  jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Handheld Games",          "Dragon Ball Z (JAKKS Pacific TV Game, Game-Key Ready, set 2)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // ^
 CONS( 2005, jak_mpac,  0,        0, jakks_gkr_nm_i2c, jak_nm_i2c,   jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Namco / HotGen Ltd",      "Ms. Pac-Man Collection 5-in-1 (JAKKS Pacific TV Game, Game-Key Ready) (07 FEB 2005 A SKU F)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses NM (3 keys available [Dig Dug, New Rally-X], [Rally-X, Pac-Man, Bosconian], [Pac-Man, Bosconian])
 CONS( 2005, jak_capc,  0,        0, jakks_gkr_cc_i2c, jak_cc_i2c,   jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Capcom / HotGen Ltd",     "Capcom 3-in-1 (1942, Commando, Ghosts'n Goblins) (JAKKS Pacific TV Game, Game-Key Ready) (29 MAR 2005 B)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses CC keys (no game-keys released)
 CONS( 2005, jak_wof,   0,        0, jakks_gkr_wf_i2c, jak_wf_i2c,   jakks_gkr_state, empty_init, "JAKKS Pacific Inc / HotGen Ltd",              "Wheel of Fortune (JAKKS Pacific TV Game, Game-Key Ready) (Jul 11 2005 ORIG)",  MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // uses WF keys (no game-keys released)  analog wheel not emulated
 // There is a 'Second Edition' version of Wheel of Fortune with a Gold case, GameKey port removed, and a '2' over the usual Game Key Ready logo, internals are different too, not Game-Key Ready
 CONS( 2004, jak_spdm,  0,        0, jakks_gkr_mv_i2c, jak_gkr_i2c,  jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Digital Eclipse",         "Spider-Man (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) //  MV (1 key available)
-CONS( 2005, jak_pooh,  0,        0, jakks_gkr_wp,     jak_pooh,     jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Backbone Entertainment",  "Winnie the Pooh - Piglet's Special Day (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // WP (no game-keys released)
+CONS( 2005, jak_pooh,  0,        0, jakks_gkr_wp,     jak_pooh,     jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Backbone Entertainment",  "Winnie the Pooh - Piglet's Special Day (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // WP
 CONS( 2005, jak_care,  0,        0, jakks_gkr_cb,     jak_care,     jakks_gkr_state, empty_init, "JAKKS Pacific Inc / Backbone Entertainment",  "Care Bears TV Games (JAKKS Pacific TV Game, Game-Key Ready)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // CB (no game-keys released)

--- a/src/mame/tvgames/spg2xx_lexibook.cpp
+++ b/src/mame/tvgames/spg2xx_lexibook.cpp
@@ -531,10 +531,10 @@ ROM_END
 
 CONS( 200?, lexizeus,    0,     0,        lexizeus,     lexizeus, spg2xx_lexizeus_game_state, init_zeus, "Lexibook / JungleTac", "Zeus IG900 20-in-1 (US?)",          MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // bad sound and some corrupt bg tilemap entries in Tiger Rescue, verify ROM data (same game runs in Zone 60 without issue)
 
-CONS( 200?, arcade3d,    0,     0,        lexizeus,     lexiseal, spg2xx_lexizeus_game_state, init_zeus, "Millennium 2000 GmbH / JungleTac", "Millennium Arcade 3D 15-in-1",          MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // bad sound and some corrupt bg tilemap entries in Tiger Rescue, verify ROM data (same game runs in Zone 60 without issue)
+CONS( 200?, arcade3d,    0,     0,        lexizeus,     lexiseal, spg2xx_lexizeus_game_state, init_zeus, "Millennium 2000 GmbH / JungleTac", "Millennium Arcade 3D 15-in-1",          MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 
 // 2007.08.02 Rev 05 on PCB
-CONS( 2007, pokermor,    0,     0,        lexizeus,     pokermor, spg2xx_lexizeus_game_state, init_zeus, "SA.BI.NE trend", "Poker & More 18-in-1 (Germany)",          MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // bad sound and some corrupt bg tilemap entries in Tiger Rescue, verify ROM data (same game runs in Zone 60 without issue)
+CONS( 2007, pokermor,    0,     0,        lexizeus,     pokermor, spg2xx_lexizeus_game_state, init_zeus, "SA.BI.NE trend", "Poker & More 18-in-1 (Germany)",          MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) 
 
 CONS( 200?, vsplus,      0,     0,        vsplus,     vsplus, spg2xx_vsplus_game_state, init_vsplus, "<unknown> / JungleTac", "Vs Power Plus 30-in-1",          MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 

--- a/src/mame/tvgames/spg2xx_lexibook.cpp
+++ b/src/mame/tvgames/spg2xx_lexibook.cpp
@@ -246,6 +246,13 @@ static INPUT_PORTS_START( lexiseal )
 	PORT_BIT( 0xfffc, IP_ACTIVE_LOW, IPT_UNUSED )
 INPUT_PORTS_END
 
+static INPUT_PORTS_START( pokermor )
+	PORT_INCLUDE(lexiseal)
+
+	PORT_MODIFY("P3")
+	PORT_BIT( 0x0003, IP_ACTIVE_LOW, IPT_UNUSED ) // rapid fire buttons function, but don't exist on hardware
+INPUT_PORTS_END
+
 static INPUT_PORTS_START( cybrtvbb )
 	PORT_INCLUDE( lexiseal )
 
@@ -406,6 +413,11 @@ ROM_START( lexizeus )
 	ROM_LOAD16_WORD_SWAP( "lexibook1g900us.bin", 0x0000, 0x800000, CRC(c2370806) SHA1(cbb599c29c09b62b6a9951c724cd9fc496309cf9))
 ROM_END
 
+ROM_START( pokermor )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "29dl640e.u3", 0x000000, 0x800000, CRC(2f3cad70) SHA1(45e89eb948e4e84637f84427bfd1ab47c3637447) )
+ROM_END
+
 ROM_START( arcade3d )
 	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "arcade3d.u3", 0x0000, 0x800000, CRC(130843a5) SHA1(f6494a34d162e702121cf71d384a4e57e0113498) )
@@ -520,6 +532,9 @@ ROM_END
 CONS( 200?, lexizeus,    0,     0,        lexizeus,     lexizeus, spg2xx_lexizeus_game_state, init_zeus, "Lexibook / JungleTac", "Zeus IG900 20-in-1 (US?)",          MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // bad sound and some corrupt bg tilemap entries in Tiger Rescue, verify ROM data (same game runs in Zone 60 without issue)
 
 CONS( 200?, arcade3d,    0,     0,        lexizeus,     lexiseal, spg2xx_lexizeus_game_state, init_zeus, "Millennium 2000 GmbH / JungleTac", "Millennium Arcade 3D 15-in-1",          MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // bad sound and some corrupt bg tilemap entries in Tiger Rescue, verify ROM data (same game runs in Zone 60 without issue)
+
+// 2007.08.02 Rev 05 on PCB
+CONS( 2007, pokermor,    0,     0,        lexizeus,     pokermor, spg2xx_lexizeus_game_state, init_zeus, "SA.BI.NE trend", "Poker & More 18-in-1 (Germany)",          MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // bad sound and some corrupt bg tilemap entries in Tiger Rescue, verify ROM data (same game runs in Zone 60 without issue)
 
 CONS( 200?, vsplus,      0,     0,        vsplus,     vsplus, spg2xx_vsplus_game_state, init_vsplus, "<unknown> / JungleTac", "Vs Power Plus 30-in-1",          MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 


### PR DESCRIPTION
new WORKING machine
----------
Poker & More 18-in-1 (Germany) [Team Europe]

new WORKING clones
---------------
Dragon Ball Z (JAKKS Pacific TV Game, Game-Key Ready, set 2) [Team Europe]

new NOT WORKING systems
---------------
Gameclick (JL2400) [Team Europe]