### PR TITLE
es5510.cpp: fix `WRITE_REG{16}` macros.

### DIFF
--- a/src/devices/cpu/es5510/es5510.cpp
+++ b/src/devices/cpu/es5510/es5510.cpp
@@ -1115,13 +1115,8 @@ int8_t countLowOnes(int32_t x) {
 	return n;
 }
 
-#if VERBOSE_EXEC
 #define WRITE_REG(r, x) do { r = (x); LOG_EXEC("  . writing %x (%d) to " #r "\n", r, util::sext(r, 24)); } while(0)
-#define WRITE_REG16(r, x) do { r = (((x) >> 8) & 0xffff); LOG_EXEC("  . writing %x (%d) as %x (%d) to " #r "\n", (x)), util::sext((x), 24), r, r); } while(0)
-#else
-#define WRITE_REG(r, x) do { r = (x); } while(0)
-#define WRITE_REG16(r, x) do { r = (((x) >> 8) & 0xffff); } while(0)
-#endif
+#define WRITE_REG16(r, x) do { r = (((x) >> 8) & 0xffff); LOG_EXEC("  . writing %x (%d) as %x (%d) to " #r "\n", (x), util::sext((x), 24), r, r); } while(0)
 
 void es5510_device::write_reg(uint8_t reg, int32_t value)
 {

--- a/src/devices/cpu/es5510/es5510.cpp
+++ b/src/devices/cpu/es5510/es5510.cpp
@@ -1116,11 +1116,11 @@ int8_t countLowOnes(int32_t x) {
 }
 
 #if VERBOSE_EXEC
-#define WRITE_REG(r, x) do { r = value; LOG_EXEC("  . writing %x (%d) to " #r "\n", r, util::sext(r, 24)); } while(0)
-#define WRITE_REG16(r, x) do { r = ((value >> 8) & 0xffff); LOG_EXEC("  . writing %x (%d) as %x (%d) to " #r "\n", value, util::sext(value, 24), r, r); } while(0)
+#define WRITE_REG(r, x) do { r = (x); LOG_EXEC("  . writing %x (%d) to " #r "\n", r, util::sext(r, 24)); } while(0)
+#define WRITE_REG16(r, x) do { r = (((x) >> 8) & 0xffff); LOG_EXEC("  . writing %x (%d) as %x (%d) to " #r "\n", (x)), util::sext((x), 24), r, r); } while(0)
 #else
-#define WRITE_REG(r, x) do { r = value; } while(0)
-#define WRITE_REG16(r, x) do { r = ((value >> 8) & 0xffff); } while(0)
+#define WRITE_REG(r, x) do { r = (x); } while(0)
+#define WRITE_REG16(r, x) do { r = (((x) >> 8) & 0xffff); } while(0)
 #endif
 
 void es5510_device::write_reg(uint8_t reg, int32_t value)


### PR DESCRIPTION
As identified by sjs@sojusrecords.com, the `WRITE_REG` and `WRITE_REG16` macros were not writing their `x` parameter to a register as intended, but were instead writing the contents of the `value` variable from calling code. Quite frequently this happened to be the correct thing to write, which hid the bug.