### PR TITLE
i8259: fix OCW3 write behavior

### DIFF
--- a/src/devices/machine/pic8259.cpp
+++ b/src/devices/machine/pic8259.cpp
@@ -206,19 +206,19 @@ uint8_t pic8259_device::read(offs_t offset)
 						m_irq_timer->adjust(attotime::zero);
 					}
 				}
+
+				if (!machine().side_effects_disabled())
+					m_ocw3 &= 0xfb;
 			}
 			else
 			{
-				switch ( m_ocw3 & 0x03 )
+				switch ( m_ocw3 & 0x01 )
 				{
-				case 2:
+				case 0:
 					data = m_irr;
 					break;
-				case 3:
+				case 1:
 					data = m_isr & ~m_imr;
-					break;
-				default:
-					data = 0x00;
 					break;
 				}
 			}
@@ -263,8 +263,13 @@ void pic8259_device::write(offs_t offset, uint8_t data)
 					/* write OCW3 */
 					LOGOCW("pic8259_device::write(): OCW3; data=0x%02X\n", data);
 
+					if (BIT(data, 1))
+						m_ocw3 = (m_ocw3 & 0xfe) | (data & 0x01);
+					if (BIT(data, 2))
+						m_ocw3 |= 0x04;
 					// TODO: special mask mode
-					m_ocw3 = data;
+					if (BIT(data, 6))
+						m_ocw3 = (m_ocw3 & 0xdf) | (data & 0x20);
 				}
 				else if ((data & 0x18) == 0x00)
 				{
@@ -431,7 +436,7 @@ void pic8259_device::device_reset()
 	m_prio = 0;
 	m_imr = 0;
 	m_input = 0;
-	m_ocw3 = 2;
+	m_ocw3 = 0;
 	m_level_trig_mode = 0;
 	m_vector_size = 0;
 	m_cascade = 0;


### PR DESCRIPTION
This was another issue that came up during preliminary work on the Akai S900/S950 drivers. Currently the system fails to poll/handle masked interrupts because of incorrect OCW3 handling. This changes the behavior to:
* only set/clear RIS when RR=1
* only set/clear SMM when ESMM=1
* exit polling mode after one read cycle