### PR TITLE
sega/model1: fix Virtua Fighter collision via TGP copro-RAM port model

### DIFF
--- a/src/mame/sega/model1_m.cpp
+++ b/src/mame/sega/model1_m.cpp
@@ -151,21 +151,22 @@ u32 model1_state::copro_ramadr_r(offs_t offset)
 	return m_copro_ram_adr[offset >> 3];
 }
 
+// Sega Model 1 stores vertices to test in RAM at 4 bytes each (X, Y, Z, radius)
+// so a loop wanting to walk all of the X positions needs to skip 4 bytes each time.
+// Page 4 of the coprocessor RAM (0x40000) is used for this purpose, and the low bits
+// of the address are used to select which of the 4 values is being read/written.
+
 void model1_state::copro_ramdata_w(offs_t offset, u32 data, u32 mem_mask)
 {
-	if(m_copro_ram_adr[offset >> 3] & 0x40000) {
-		COMBINE_DATA(&m_copro_ram_data[0x1000 | (m_copro_ram_adr[offset >> 3] & 0x1fff)]);
-	} else {
-		COMBINE_DATA(&m_copro_ram_data[m_copro_ram_adr[offset >> 3] & 0x1fff]);
-	}
-	m_copro_ram_adr[offset >> 3] ++;
+	COMBINE_DATA(&m_copro_ram_data[m_copro_ram_adr[offset >> 3] & 0x1fff]);
+	m_copro_ram_adr[offset >> 3] += (m_copro_ram_adr[offset >> 3] & 0x40000) ? 4 : 1;
 }
 
 u32 model1_state::copro_ramdata_r(offs_t offset)
 {
-	u32 val = (m_copro_ram_adr[offset >> 3] & 0x40000) ? m_copro_ram_data[0x1000 | (m_copro_ram_adr[offset >> 3] & 0x1fff)] : m_copro_ram_data[m_copro_ram_adr[offset >> 3] & 0x1fff];
+	u32 val = m_copro_ram_data[m_copro_ram_adr[offset >> 3] & 0x1fff];
 	if(!machine().side_effects_disabled())
-		m_copro_ram_adr[offset >> 3] ++;
+		m_copro_ram_adr[offset >> 3] += (m_copro_ram_adr[offset >> 3] & 0x40000) ? 4 : 1;
 	return val;
 }
 


### PR DESCRIPTION
## Summary

BEWARE - Claude Opus 4.8 was used during the development of the fix in https://github.com/frangarcj/geometrizer/
Later Claude Opus 4.8 was used to write this Pull Request in order to have it well explained. As you can see it is just 4 lines of code in MAME that I could have made without a BS fuckass LLM.

Fixes Virtua Fighter's broken collision detection — skipped knockdowns and the well-known "both fighters fall on a single hit" double-knockdown in the attract demo. The driver's source already flagged this as *"collision detection significantly broken due to imperfect TGP RAM port emulation or hookup"*; this addresses the port model.

The collision broadphase runs on the TGP (MB86233) via op 0x63, which reads bone positions through the copro-RAM data port. Two related issues in the **TGP-side** `copro_ramdata_r`/`copro_ramdata_w`:

1. **Address decode.** The page bits above bit 13 (`0x10000`/`0x40000`) are not wired to the 0x2000-word RAM, so the cell is simply `adr & 0x1fff`. The previous `0x40000 -> 0x1000 | (adr & 0x1fff)` fold disconnected op 0x63's bone-position reader (page 4) from its page-1 writer, leaving it reading a zeroed region.

2. **Port stride.** Bone positions are stored as interleaved 4-word `{x, y, z, radius}` records. op 0x63 reads them **column-wise**, selecting a lane via the low address bits, so the page-4 channel must advance by the 4-word record. The port auto-incremented by 1, interleaving the three spatial axes into shifted windows, so the AABB broadphase could not separate the two fighters and dropped legitimate hits.

Both are halves of the same port bug; neither alone is sufficient. The `v60_copro_ram_r/w` (V60 side) handlers are untouched — they never reach the page-4 channel.

## Microcode evidence

Disassembly of the VF copro ROM (`315-5724.bin`) confirms the access pattern. The op 0x63 reader, per lane, sets the address to a page-1 base plus a page-3 index immediate (`lia #0x3000L`, lane `L ∈ {0,1,2,3}` = x/y/z/radius — all four lanes present, so the record is 4 words), summing to a page-4 address, then `rep`-reads one lane across all bones:

```
mov  $0x35, d        ; d = base (e.g. 0x10900, page 1)
lia  #0x3000L        ; index = page 3 | lane
addd                 ; d = 0x10900 + 0x3000L = 0x4090L   (page 4)
mov  d, $0 (e)       ; set the port address register
rep #30; mov $1(e),(x1+1)   ; read one lane across all bones
```

So the `0x40000` the port sees is the arithmetic sum of the page-1 base and page-3 index; the stride is the record width (4). There is no separate page-2 channel anywhere in the microcode.

## Validation

V60 breakpoint trace (`FFB519` = HIT-CONFIRMED, `FEB585` = HIT-PROCESSED) over an identical 60-emulated-second attract demo, before vs after:

| | before | after |
|---|---|---|
| HIT-PROCESSED (`FEB585`) | 332 | 146 |
| HIT-CONFIRMED (`FFB519`) | 35 | 32 |
| same-pass reciprocal double (opposite-direction confirms within one collision pass) | 1 | **0** |

The fix prunes spurious broadphase candidates (HIT-PROCESSED roughly halves) while keeping the legitimate confirms, and eliminates the same-pass reciprocal double-knockdown. Confirmed visually: the attract-demo double-knockdown is gone.

## Safety across all Model 1 copro microcodes

There are only three TGP copro programs across the whole Model 1 lineup; I disassembled all of them and checked for the page channel and copro-RAM data-port use:

| game(s) | copro ROM | page bits used | `copro_ramdata` accesses |
|---|---|---|---|
| Virtua Fighter | `315-5724` | `0x10000` writer + `0x30000` index → page 4 | 37 |
| Wing War / Star Wars Arcade / Netmerc | `315-5711` | none | 0 (never touches the data port) |
| Virtua Racing / Virtua Formula | `315-5573` | none | 8, all on page 0 |

Only VF ever sets the `0x40000` bit, so for every other Model 1 title both changes are exact no-ops: SWA/Wing War/Netmerc never use the copro-RAM data port at all, and VR/Virtua Formula use it only on page 0 (where `decode13` reduces to the old `& 0x1fff` and the stride stays 1). VR was additionally verified to produce bit-identical copro-RAM contents before/after.

## Notes

- `315-5724.bin` is flagged `BAD_DUMP`, but this shows VF's collision problem is the port model rather than the dump.
- The stride is the 4-word record width observed in VF's op 0x63 stream; since VF is the only title using the page-4 channel, no other title is affected. A Sega Model 1 copro-board schematic would still be welcome to confirm whether the controller decodes the stride from the page bits or from a record-size counter.