### PR TITLE
ppc: Fix little endian mode for instruction accesses by the dynamic recompiler frontend

### DIFF
--- a/src/devices/cpu/powerpc/ppcdrc.cpp
+++ b/src/devices/cpu/powerpc/ppcdrc.cpp
@@ -330,7 +330,7 @@ void ppc_device::code_compile_block(uint8_t mode, offs_t pc)
 	auto profile = g_profiler.start(PROFILER_DRC_COMPILE);
 
 	// get a description of this sequence
-	desclist = m_drcfe->describe_code(pc);
+	desclist = m_drcfe->describe_code(pc, (mode & MODE_LITTLE_ENDIAN) != 0);
 	if (m_drcuml->logging() || m_drcuml->logging_native())
 		log_opcode_desc(desclist, 0);
 

--- a/src/devices/cpu/powerpc/ppcfe.cpp
+++ b/src/devices/cpu/powerpc/ppcfe.cpp
@@ -199,10 +199,10 @@ ppc_device::frontend::~frontend()
 {
 }
 
-ppc_device::opcode_desc const *ppc_device::frontend::describe_code(offs_t startpc)
+ppc_device::opcode_desc const *ppc_device::frontend::describe_code(offs_t startpc, bool little_endian)
 {
 	return do_describe_code(
-			[this] (opcode_desc &desc, opcode_desc const *prev) { return describe(desc, prev); },
+			[this, little_endian] (opcode_desc &desc, opcode_desc const *prev) { return describe(desc, prev, little_endian); },
 			startpc);
 }
 
@@ -212,7 +212,7 @@ ppc_device::opcode_desc const *ppc_device::frontend::describe_code(offs_t startp
 //  instruction
 //-------------------------------------------------
 
-bool ppc_device::frontend::describe(opcode_desc &desc, const opcode_desc *prev)
+bool ppc_device::frontend::describe(opcode_desc &desc, const opcode_desc *prev, bool little_endian)
 {
 	int regnum;
 
@@ -227,6 +227,12 @@ bool ppc_device::frontend::describe(opcode_desc &desc, const opcode_desc *prev)
 		desc.set_virtual_noop();
 		desc.set_end_sequence();
 		return true;
+	}
+	
+	// swizzle the physical address if in little endian mode
+	if (little_endian)
+	{
+		desc.physpc ^= (sizeof(uint64_t) - sizeof(uint32_t));
 	}
 
 	// fetch the opcode

--- a/src/devices/cpu/powerpc/ppcfe.h
+++ b/src/devices/cpu/powerpc/ppcfe.h
@@ -153,10 +153,10 @@ public:
 	frontend(ppc_device &ppc, uint32_t window_start, uint32_t window_end, uint32_t max_sequence);
 	~frontend();
 
-	opcode_desc const *describe_code(offs_t startpc);
+	opcode_desc const *describe_code(offs_t startpc, bool little_endian);
 
 protected:
-	bool describe(opcode_desc &desc, const opcode_desc *prev);
+	bool describe(opcode_desc &desc, const opcode_desc *prev, bool little_endian);
 
 	// inlines
 	static constexpr uint32_t compute_spr(uint32_t spr) { return ((spr >> 5) | (spr << 5)) & 0x3ff; }


### PR DESCRIPTION
The PowerPC dynamic recompiler currently swizzles the address on memory access, but the same swizzle must be performed on instruction access.

This PR makes the relevant change in the frontend to honour the current little-endian mode state in the dynamic recompiler backend.

With this and my previous PR #15592 applied, code in little-endian mode successfully executes on PowerPC 601.

This was tested with the apple/macpdm emulation, using an in-progress ARC firmware port:

<img width="642" height="512" alt="image" src="https://github.com/user-attachments/assets/301a93c3-714f-4c8c-bcb7-3f0c798417e0" />

A remaining issue here is that the debugger/disassembler does not honour the current little-endian mode state (and thus each pair of instructions are swapped in the debugger/disassembler, although stepping through in debugger does execute correctly).