### PR TITLE
cpu/ns32000: disassemble NS32532 CINV; correct LMR/SMR MMU register names

### DIFF
--- a/src/devices/cpu/ns32000/ns32000.cpp
+++ b/src/devices/cpu/ns32000/ns32000.cpp
@@ -4051,7 +4051,8 @@ template <int HighBits, int Width> bool ns32000_device<HighBits, Width>::memory_
 
 template <int HighBits, int Width> std::unique_ptr<util::disasm_interface> ns32000_device<HighBits, Width>::create_disassembler()
 {
-	return std::make_unique<ns32000_disassembler>();
+	return std::make_unique<ns32000_disassembler>(
+		(type() == NS32532) ? ns32000_disassembler::model::ns32532 : ns32000_disassembler::model::ns32032);
 }
 
 template <int HighBits, int Width> u16 ns32000_device<HighBits, Width>::slave(u8 opbyte, u16 opword, addr_mode op1, addr_mode op2)

--- a/src/devices/cpu/ns32000/ns32000d.cpp
+++ b/src/devices/cpu/ns32000/ns32000d.cpp
@@ -8,6 +8,11 @@
 char const *const cond_code[] = { "EQ", "NE", "CS", "CC", "HI", "LS", "GT", "LE", "FS", "FC", "LO", "HS", "LT", "GE", "R", "N" };
 char const size_char[] = { 'B','W',' ','D' };
 
+ns32000_disassembler::ns32000_disassembler(model variant)
+	: m_model(variant)
+{
+}
+
 s32 ns32000_disassembler::displacement(offs_t pc, data_buffer const &opcodes, unsigned &bytes)
 {
 	u32 const byte0 = opcodes.r8(pc + bytes++);
@@ -615,8 +620,12 @@ offs_t ns32000_disassembler::disassemble(std::ostream &stream, offs_t pc, data_b
 	case 0x1e:
 		// format 14: xxxx xsss s0oo ooii 0001 1110
 		{
-			// TODO: different mmu registers for 32332 and 32532
-			char const *const mmureg[] = { "BPR0", "BPR1", "", "", "PF0", "PF1", "", "", "SC", "", "MSR", "BCNT", "PTB0", "PTB1", "", "EIA" };
+			// LMR/SMR address a different register set depending on the MMU: the
+			// external NS32082 (used by the NS32008/016/032; the NS32332/NS32382
+			// pair is still a TODO) versus the NS32532's on-chip MMU.
+			static char const *const mmureg_ext[] = { "BPR0", "BPR1", "", "", "PF0", "PF1", "", "", "SC", "", "MSR", "BCNT", "PTB0", "PTB1", "", "EIA" };
+			static char const *const mmureg_532[] = { "", "", "", "", "", "", "", "", "", "MCR", "MSR", "TEAR", "PTB0", "PTB1", "IVAR0", "IVAR1" };
+			char const *const *const mmureg = (m_model == model::ns32532) ? mmureg_532 : mmureg_ext;
 
 			u16 const opword = opcodes.r16(pc + bytes); bytes += 2;
 
@@ -634,6 +643,26 @@ offs_t ns32000_disassembler::disassemble(std::ostream &stream, offs_t pc, data_b
 			case 1: util::stream_format(stream, "WRVAL   %s", mode[0].mode); break;
 			case 2: util::stream_format(stream, "LMR     %s, %s", mmureg[quick], mode[0].mode); break;
 			case 3: util::stream_format(stream, "SMR     %s, %s", mmureg[quick], mode[0].mode); break;
+			case 9:
+				// CINV options, src (NS32532 only): invalidate cache line(s) or,
+				// with A, the entire cache.  Options in the short field: A = 0x4
+				// (all), I = 0x2 (instruction cache), D = 0x1 (data cache).
+				if (m_model == model::ns32532)
+				{
+					static char const *const cinv_opt[] = { "A", "I", "D" };
+					std::string opts;
+					for (unsigned i = 0; i < 3; i++)
+						if (BIT(quick, 2 - i))
+						{
+							if (!opts.empty())
+								opts.append(",");
+							opts.append(cinv_opt[i]);
+						}
+					util::stream_format(stream, "CINV    [%s], %s", opts, mode[0].mode);
+				}
+				else
+					bytes = 1;
+				break;
 			default: bytes = 1; break;
 			}
 		}

--- a/src/devices/cpu/ns32000/ns32000d.h
+++ b/src/devices/cpu/ns32000/ns32000d.h
@@ -9,7 +9,12 @@
 class ns32000_disassembler : public util::disasm_interface
 {
 public:
-	ns32000_disassembler() = default;
+	// CPU model.  ns32032 selects the external-MMU (NS32082) Format-14 register
+	// names used by the NS32008/016/032/332; ns32532 selects the NS32532's
+	// on-chip MMU register set and enables its CINV instruction.
+	enum class model { ns32032, ns32532 };
+
+	ns32000_disassembler(model variant = model::ns32032);
 	virtual ~ns32000_disassembler() = default;
 
 	virtual u32 opcode_alignment() const override { return 1; }
@@ -47,6 +52,9 @@ protected:
 	void decode(addr_mode *mode, offs_t pc, data_buffer const &opcodes, unsigned &bytes);
 	std::string reglist(u8 imm);
 	std::string config(u8 imm);
+
+private:
+	model const m_model;
 };
 
 #endif // MAME_CPU_NS32000_NS32000D_H

--- a/src/tools/unidasm.cpp
+++ b/src/tools/unidasm.cpp
@@ -569,6 +569,7 @@ static const dasm_table_entry dasm_table[] =
 	{ "nios2",           le,  0, []() -> util::disasm_interface * { return new nios2_disassembler; } },
 	{ "nova",            be, -1, []() -> util::disasm_interface * { return new nova_disassembler; } },
 	{ "ns32000",         le,  0, []() -> util::disasm_interface * { return new ns32000_disassembler; } },
+	{ "ns32532",         le,  0, []() -> util::disasm_interface * { return new ns32000_disassembler(ns32000_disassembler::model::ns32532); } },
 	{ "nuon",            be,  0, []() -> util::disasm_interface * { return new nuon_disassembler; } },
 	{ "nsc8105",         be,  0, []() -> util::disasm_interface * { return new m680x_disassembler(8105); } },
 	{ "nx8_500s",        le,  0, []() -> util::disasm_interface * { return new nx8_500s_disassembler; } },


### PR DESCRIPTION
## Summary

The NS32000 disassembler decoded Format-14 (`LMR`/`SMR`) with a single MMU
register-name table and did not decode the NS32532's `CINV`. This adds a CPU
`model` to the disassembler and uses it to:

- select the correct Format-14 MMU register names — the external NS32082 set
  (NS32008/016/032) versus the NS32532's on-chip MMU (`MCR`, `MSR`, `TEAR`,
  `PTB0/1`, `IVAR0/1`); and
- decode the NS32532-only `CINV` instruction (Format-14, op 9), with the
  cache-option bits in the short field (`A` = 0x4 all, `I` = 0x2 instruction
  cache, `D` = 0x1 data cache) rendered as `CINV [A,I,D], <src>`.

`ns32000_device::create_disassembler()` passes `model::ns32532` for the
`NS32532` type; every other type keeps the default `ns32032` behaviour, so
existing disassembly is unchanged. A `ns32532` entry is added to unidasm.

This resolves the `// TODO: different mmu registers for 32332 and 32532` in the
Format-14 handler. The NS32332/NS32382 register set differs again and is left
as a separate TODO.

## Verification

The `CINV` cache-option bit assignments (`A` = 0x4, `I` = 0x2, `D` = 0x1) match
the GNU binutils NS32K `opt_C` table. The new register table and the `CINV`
case are both gated on `model::ns32532`, so the NS32008/016/032 path is
unchanged by construction.
