### PR TITLE
namco/namcos23.cpp: fix crszone input and disable idle debug-UART clock

### DIFF
--- a/src/mame/namco/namcos23.cpp
+++ b/src/mame/namco/namcos23.cpp
@@ -115,7 +115,7 @@ c8000000:
         raceon              Locks up after POST.
         aking               Inputs unresponsive.
         500gp               Occasional lockups.
-        crszone(all)        Input issues.
+        crszone(all)        Some visual glitches.
 
 ****************************************************************************
 
@@ -6867,6 +6867,8 @@ void crszone_state::crszone(machine_config &config)
 {
 	ss23(config);
 
+	m_subcpu->read_port7().set_constant(0x80);
+
 	/* basic machine hardware */
 	m_maincpu->set_clock(BUSCLOCK * 6);
 	m_maincpu->set_addrmap(AS_PROGRAM, &crszone_state::mips_map);
@@ -6881,6 +6883,7 @@ void crszone_state::crszone(machine_config &config)
 	clock_device &acia_clock(CLOCK(config, "acia_clock", 1'843'200));
 	acia_clock.signal_handler().set("acia", FUNC(acia6850_device::write_txc));
 	acia_clock.signal_handler().append("acia", FUNC(acia6850_device::write_rxc));
+	acia_clock.set_unscaled_clock(0); // unused debug UART
 
 	rs232_port_device &rs232(RS232_PORT(config, "rs232", default_rs232_devices, nullptr));
 	rs232.rxd_handler().set(m_acia, FUNC(acia6850_device::write_rxd));


### PR DESCRIPTION
Tested on AMD 5600X cpu, linux build.

Two minimalistic fixes:

- Input: the sub-H8 port 7 read is stubbed to 0, leaving a status bit set so the game runs its built-in auto-pedal/demo over player input; driving port 7 bit 7 high clears it and triggers the game as it should. All inputs work.
- Speed: disabling the debug ACIA's 1.843 MHz baud clock free-runs with nothing attached to the RS232 port, roughly halving emulation on this 2-CPU board (device kept wired just in case for something in the future, not removed).

Before: ~49% speed
After: ~96% (almost full speed)

Stays in `crszone_state::crszone` because it only affects Crisis Zone. No other game touched. Possibly now in playable state like Time Crisis II (only played first level). Found some visual glitches.

EDIT: if disabling the clock is a concern, it can be gated instead right in `crszone_state::machine_start():`
```
      if (subdevice<rs232_port_device>("rs232")->get_card_device() == nullptr)
          subdevice<clock_device>("acia_clock")->set_unscaled_clock(0);
```
This idles it by default (where nothing is connected). If `-rs232` is used, then the baud clock (and the serial port) runs normally. Same idiom as tv910.cpp and hp2640.cpp in mainline.