### PR TITLE
Revert "gridcomp: upgraded bubble memory driver to i7110"

### DIFF
--- a/src/devices/machine/i7110.cpp
+++ b/src/devices/machine/i7110.cpp
@@ -7,6 +7,7 @@
 
     **** TODO ****
     - Commands to be tested: WR_BLR, WR_BL, RD_FSA_STAT, RCD
+    - More than 1 MBM
 
 *********************************************************************/
 
@@ -773,7 +774,6 @@ ibubble_device::ibubble_device(const machine_config &mconfig, const char *tag, d
 	, m_select_b(false)
 	, m_dirty(false)
 {
-	set_must_be_loaded(true);
 }
 
 void ibubble_device::field_rotate(int state)
@@ -1115,19 +1115,17 @@ void ibubble_device::device_add_mconfig(machine_config &config)
 //     else
 //       goto read_mbm_changed
 //   else
-//     mbm_select_changed = check_mbm_change()
+//     ar = (ar + 1) & 0x7fff
+//     mbm_select_changed = selected_mbms != fsa_ch_mask(nfc,mbm_select)
 //     if n_pages == 0
 //       set_op_complete()
 //       fsa_to_bmc_xfer()
-//       ar = (ar + 1) & 0x7fff
 //       leave_read_bubble()
 //     else if mbm_select_changed
 //       fsa_to_bmc_xfer() @S19
-//       cmd_w(selected_mbms, FSA_CMD_SWRESET) + delay
-//       ar = (ar + 1) & 0x7fff
+//       cmd_w(selected_mbms, FSA_CMD_SWRESET) + delay @S1
 //       goto read_mbm_changed
 //     else
-//       ar = (ar + 1) & 0x7fff
 //       delay 320 clocks @S4
 //       goto read_loop
 //   fn read_seek()
@@ -1816,7 +1814,7 @@ void i7220_1_device::update_drq()
 {
 	bool new_drq;
 
-	if (get_busy_state() && m_cmdr != cmds::CMDS_RESET_FIFO) {
+	if (get_busy_state()) {
 		if (BIT(m_en, EN_DMA)) {
 			if (m_read_cmd) {
 				new_drq = !m_fifo.empty();
@@ -2345,14 +2343,13 @@ void i7220_1_device::do_rd_data()
 				delay(CLKS_CMD, S14);
 			}
 		} else {
-			m_mbm_select_changed = check_mbm_change();
+			m_mbm_select_changed = inc_ar();
 			if (get_n_pages() == 0) {
 				set_op_complete();
 				call_subcmd(cmds::SUBCMD_FSA_BMC_XFER, S20);
 			} else if (m_mbm_select_changed) {
 				call_subcmd(cmds::SUBCMD_FSA_BMC_XFER, S19);
 			} else {
-				inc_ar();
 				delay(320, S4);
 			}
 		}
@@ -2384,7 +2381,7 @@ void i7220_1_device::do_rd_data()
 	case S15:
 		if (!BIT(m_str, STAT_UNCORRERR)) {
 			if (BIT(m_en, EN_INT_ERR)) {
-				m_fsm_state = S21;
+				m_fsm_state = S20;
 			} else {
 				cmd_w(m_selected_chs, fsa_channel_device::FSA_CMD_RCD);
 				delay(CLKS_CMD, S16);
@@ -2411,10 +2408,10 @@ void i7220_1_device::do_rd_data()
 			} else {
 				set_op_fail();
 			}
-			m_fsm_state = S21;
+			m_fsm_state = S20;
 		} else if (BIT(m_str, STAT_UNCORRERR)) {
 			set_op_fail();
-			m_fsm_state = S21;
+			m_fsm_state = S20;
 		} else {
 			m_fsm_state = S1;
 		}
@@ -2422,21 +2419,15 @@ void i7220_1_device::do_rd_data()
 
 	case S19:
 		cmd_w(m_selected_chs, fsa_channel_device::FSA_CMD_SWRESET);
-		inc_ar();
 		delay(CLKS_CMD, S1);
 		break;
 
 	case S20:
-		inc_ar();
-		m_fsm_state = S21;
+		cmd_w(m_selected_chs, fsa_channel_device::FSA_CMD_NOP);
+		delay(CLKS_CMD, S21);
 		break;
 
 	case S21:
-		cmd_w(m_selected_chs, fsa_channel_device::FSA_CMD_NOP);
-		delay(CLKS_CMD, S22);
-		break;
-
-	case S22:
 		leave();
 		break;
 
@@ -3366,15 +3357,10 @@ uint16_t i7220_1_device::get_la() const
 
 bool i7220_1_device::inc_ar()
 {
-	bool mbm_change = check_mbm_change();
+	auto old_mbm = get_mbm_select();
 	m_ar = (m_ar + 1) & AR_MASK;
 	LOGFSM("AR: %04x\n", m_ar);
-	return mbm_change;
-}
-
-bool i7220_1_device::check_mbm_change() const
-{
-	return (m_ar & LA_MASK) == LA_MASK;
+	return old_mbm != get_mbm_select();
 }
 
 void i7220_1_device::select_chs()

--- a/src/devices/machine/i7110.h
+++ b/src/devices/machine/i7110.h
@@ -576,8 +576,7 @@ private:
 		S18,
 		S19,
 		S20,
-		S21,
-		S22
+		S21
 	};
 
 	// Commands & sub-commands
@@ -752,7 +751,6 @@ private:
 	void dec_n_pages();
 	uint16_t get_la() const;
 	bool inc_ar();
-	bool check_mbm_change() const;
 	void select_chs();
 	unsigned fsa_n_channels() const;
 	unsigned fsa_1st_ch() const;

--- a/src/mame/gridcomp/gridcomp.cpp
+++ b/src/mame/gridcomp/gridcomp.cpp
@@ -71,7 +71,7 @@
 #include "bus/rs232/printer.h"
 #include "bus/rs232/rs232.h"
 #include "cpu/i86/i86.h"
-#include "machine/i7110.h"
+#include "machine/i7220.h"
 #include "machine/i80130.h"
 #include "machine/i8087.h"
 #include "machine/i8255.h"
@@ -114,7 +114,6 @@ public:
 		, m_ram(*this, RAM_TAG)
 		, m_tms9914(*this, "hpib")
 		, m_test_rom(*this, "test_rom")
-		, m_bmc(*this, "bmc")
 		, m_app_roms(*this, "app_rom%u", 0U)
 	{ }
 
@@ -141,7 +140,6 @@ private:
 	required_device<ram_device> m_ram;
 	required_device<tms9914_device> m_tms9914;
 	required_device<gridrom_socket_device> m_test_rom;
-	required_device<i7220_1_device> m_bmc;
 	optional_device_array<gridrom_socket_device, 4> m_app_roms;
 
 	bool m_kbd_ready = false;
@@ -150,12 +148,6 @@ private:
 	uint16_t *m_videoram = nullptr;
 
 	IRQ_CALLBACK_MEMBER(irq_callback);
-
-	void bubble_irq_w(int state);
-	void bubble_drq_w(int state);
-
-	bool m_drq;
-	bool m_irq;
 
 	uint16_t grid_9ff0_r(offs_t offset);
 	uint16_t grid_keyb_r(offs_t offset);
@@ -325,8 +317,6 @@ void gridcomp_state::machine_start()
 void gridcomp_state::machine_reset()
 {
 	m_kbd_ready = false;
-	m_irq = false;
-	m_drq = false;
 }
 
 IRQ_CALLBACK_MEMBER(gridcomp_state::irq_callback)
@@ -334,24 +324,13 @@ IRQ_CALLBACK_MEMBER(gridcomp_state::irq_callback)
 	return m_osp->inta_r();
 }
 
-void gridcomp_state::bubble_irq_w(int state)
-{
-	m_irq = state != 0;
-	m_osp->ir1_w(m_irq || m_drq);
-}
-
-void gridcomp_state::bubble_drq_w(int state)
-{
-	m_drq = state != 0;
-	m_osp->ir1_w(m_irq || m_drq);
-}
 
 void gridcomp_state::grid1101_map(address_map &map)
 {
 	map.unmap_value_high();
 	map(0xc0000, 0xcffff).r(m_test_rom, FUNC(gridrom_socket_device::read));
 	map(0xdfe40, 0xdfe4f).w(FUNC(gridcomp_state::grid_sound_w));  // modem controller??
-	map(0xdfe80, 0xdfe83).rw(m_bmc, FUNC(i7220_1_device::read), FUNC(i7220_1_device::write)).umask16(0x00ff);
+	map(0xdfe80, 0xdfe83).rw("i7220", FUNC(i7220_device::read), FUNC(i7220_device::write)).umask16(0x00ff);
 	map(0xdfea0, 0xdfeaf).unmaprw(); // ??
 	map(0xdfec0, 0xdfecf).rw(FUNC(gridcomp_state::grid_modem_r), FUNC(gridcomp_state::grid_modem_w)).umask16(0x00ff); // incl. DTMF generator
 	map(0xdff00, 0xdff1f).rw(m_uart8274, FUNC(i8274_device::cd_ba_r), FUNC(i8274_device::cd_ba_w)).umask16(0x00ff);
@@ -371,7 +350,7 @@ void gridcomp_state::grid1121_map(address_map &map)
 	map(0xdfa00, 0xdfdff).rw(FUNC(gridcomp_state::grid_dma_r), FUNC(gridcomp_state::grid_dma_w)); // DMA
 	map(0xdfe00, 0xdfe1f).unmaprw(); // ??
 	map(0xdfe40, 0xdfe4f).w(FUNC(gridcomp_state::grid_sound_w));  // modem controller??
-	map(0xdfe80, 0xdfe83).rw(m_bmc, FUNC(i7220_1_device::read), FUNC(i7220_1_device::write)).umask16(0x00ff);
+	map(0xdfe80, 0xdfe83).rw("i7220", FUNC(i7220_device::read), FUNC(i7220_device::write)).umask16(0x00ff);
 	map(0xdfea0, 0xdfeaf).unmaprw(); // ??
 	map(0xdfec0, 0xdfecf).rw(FUNC(gridcomp_state::grid_modem_r), FUNC(gridcomp_state::grid_modem_w)).umask16(0x00ff); // incl. DTMF generator
 	map(0xdff00, 0xdff1f).rw(m_uart8274, FUNC(i8274_device::cd_ba_r), FUNC(i8274_device::cd_ba_w)).umask16(0x00ff);
@@ -434,61 +413,11 @@ void gridcomp_state::grid1101(machine_config &config)
 	grid_keyboard_device &keyboard(GRID_KEYBOARD(config, "keyboard"));
 	keyboard.set_keyboard_callback(FUNC(gridcomp_state::kbd_put));
 
-	I7220_1(config, m_bmc, XTAL(4'000'000));
-	m_bmc->irq_callback().set(FUNC(gridcomp_state::bubble_irq_w));
-	m_bmc->drq_callback().set(FUNC(gridcomp_state::bubble_drq_w));
-
-	ibubble_device& mbm0(IBUBBLE(config, "mbm0", XTAL(4'000'000)));
-	ibubble_device& mbm1(IBUBBLE(config, "mbm1", XTAL(4'000'000)));
-	ibubble_device& mbm2(IBUBBLE(config, "mbm2", XTAL(4'000'000)));
-
-	m_bmc->field_rotate_callback().set(mbm0, FUNC(ibubble_device::field_rotate));
-	m_bmc->field_rotate_callback().append(mbm1, FUNC(ibubble_device::field_rotate));
-	m_bmc->field_rotate_callback().append(mbm2, FUNC(ibubble_device::field_rotate));
-
-	m_bmc->select_w_callback().set(mbm0, FUNC(ibubble_device::select_w));
-	mbm0.select_w_callback().set(mbm1, FUNC(ibubble_device::select_w));
-	mbm1.select_w_callback().set(mbm2, FUNC(ibubble_device::select_w));
-
-	m_bmc->cmd_w_callback().set(mbm0, FUNC(ibubble_device::cmd_w));
-	m_bmc->cmd_w_callback().append(mbm1, FUNC(ibubble_device::cmd_w));
-	m_bmc->cmd_w_callback().append(mbm2, FUNC(ibubble_device::cmd_w));
-
-	m_bmc->dio_w_callback().set(mbm0, FUNC(ibubble_device::dio_w));
-	mbm0.dio_w_callback().set(mbm1, FUNC(ibubble_device::dio_w));
-	mbm1.dio_w_callback().set(mbm2, FUNC(ibubble_device::dio_w));
-
-	m_bmc->dio_r_callback().set(mbm0, FUNC(ibubble_device::dio_r));
-	mbm0.dio_r_callback().set(mbm1, FUNC(ibubble_device::dio_r));
-	mbm1.dio_r_callback().set(mbm2, FUNC(ibubble_device::dio_r));
-
-	m_bmc->status_r_callback().set(mbm0, FUNC(ibubble_device::status_r));
-	mbm0.status_r_callback().set(mbm1, FUNC(ibubble_device::status_r));
-	mbm1.status_r_callback().set(mbm2, FUNC(ibubble_device::status_r));
-
-	m_bmc->shiftclk_callback().set(mbm0, FUNC(ibubble_device::shiftclk));
-	m_bmc->shiftclk_callback().append(mbm1, FUNC(ibubble_device::shiftclk));
-	m_bmc->shiftclk_callback().append(mbm2, FUNC(ibubble_device::shiftclk));
-
-	m_bmc->bubble_replicate_callback().set(mbm0, FUNC(ibubble_device::bubble_replicate));
-	m_bmc->bubble_replicate_callback().append(mbm1, FUNC(ibubble_device::bubble_replicate));
-	m_bmc->bubble_replicate_callback().append(mbm2, FUNC(ibubble_device::bubble_replicate));
-
-	m_bmc->bootloop_replicate_callback().set(mbm0, FUNC(ibubble_device::bootloop_replicate));
-	m_bmc->bootloop_replicate_callback().append(mbm1, FUNC(ibubble_device::bootloop_replicate));
-	m_bmc->bootloop_replicate_callback().append(mbm2, FUNC(ibubble_device::bootloop_replicate));
-
-	m_bmc->bubble_swap_callback().set(mbm0, FUNC(ibubble_device::bubble_swap));
-	m_bmc->bubble_swap_callback().append(mbm1, FUNC(ibubble_device::bubble_swap));
-	m_bmc->bubble_swap_callback().append(mbm2, FUNC(ibubble_device::bubble_swap));
-
-	m_bmc->bootloop_swap_callback().set(mbm0, FUNC(ibubble_device::bootloop_swap));
-	m_bmc->bootloop_swap_callback().append(mbm1, FUNC(ibubble_device::bootloop_swap));
-	m_bmc->bootloop_swap_callback().append(mbm2, FUNC(ibubble_device::bootloop_swap));
-
-	m_bmc->errflg_r_callback().set(mbm0, FUNC(ibubble_device::errflg_r));
-	mbm0.errflg_r_callback().set(mbm1, FUNC(ibubble_device::errflg_r));
-	mbm1.errflg_r_callback().set(mbm2, FUNC(ibubble_device::errflg_r));
+	i7220_device &i7220(I7220(config, "i7220", XTAL(4'000'000)));
+	i7220.set_data_size(3); // 3 1-Mbit MBM's
+	i7220.set_must_be_loaded(true);
+	i7220.irq_callback().set(I80130_TAG, FUNC(i80130_device::ir1_w));
+	i7220.drq_callback().set(I80130_TAG, FUNC(i80130_device::ir1_w));
 
 	tms9914_device &hpib(TMS9914(config, m_tms9914, XTAL(4'000'000)));
 	hpib.int_write_cb().set(I80130_TAG, FUNC(i80130_device::ir5_w));


### PR DESCRIPTION
Reverts mamedev/mame#15395. Closes mamedev/mame#15601.

The new implementation of Bubble Memory emulation, while more correct, has introduced two big problems: GRiD Compass II no longer boots from Bubble Memory, and the old img images no longer work.

The imbm format is inconvenient for everyday use: no CCFS image manipulation utilities support it, and instead of 10-15 img files I now have 30-45 imbm files, along with a command line twice as long to launch mame.

As a temporary solution, I suggest reverting the changes so that the Compass in MAME can be used as before, and I can continue my work.