### PR TITLE
osd/sdl: enable SDL3 macOS click-to-focus behavior

### DIFF
--- a/src/osd/sdl3/osdsdl.cpp
+++ b/src/osd/sdl3/osdsdl.cpp
@@ -307,6 +307,10 @@ void sdl_osd_interface::init(running_machine &machine)
 #if defined(SDLMAME_ANDROID)
 	SDL_SetHint(SDL_HINT_VIDEO_EXTERNAL_CONTEXT, "1");
 #endif
+#if defined(SDLMAME_MACOSX)
+	SDL_SetHintWithPriority(SDL_HINT_MAC_BACKGROUND_APP, "0", SDL_HINT_DEFAULT);
+	SDL_SetHintWithPriority(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1", SDL_HINT_DEFAULT);
+#endif
 	/* Initialize SDL */
 
 	if (!SDL_InitSubSystem(SDL_INIT_VIDEO))


### PR DESCRIPTION
For some reason on macOS, the window sometimes doesn't receive focus. With this hint, the window focuses on click. Without this hint, I had to press Alt-Tab to focus the window.