### PR TITLE
nec/v5x.cpp: make V50 to derive V33 opcode clocks

### DIFF
--- a/src/devices/cpu/nec/v5x.cpp
+++ b/src/devices/cpu/nec/v5x.cpp
@@ -586,7 +586,7 @@ v40_device::v40_device(const machine_config &mconfig, const char *tag, device_t 
 }
 
 v50_device::v50_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: v50_base_device(mconfig, V50, tag, owner, clock, true, 6, 2, V30_TYPE)
+	: v50_base_device(mconfig, V50, tag, owner, clock, true, 6, 2, V33_TYPE)
 {
 }
 


### PR DESCRIPTION
Rationale:
`pc88va2 hatisora` during attract mode: 

1. with V30_TYPE BGM ends more or less midway thru the opening;
1. with V33_TYPE BGM ends at the end of the opening, where the title displays again;