### PR TITLE
bus/coco/cocossc.cpp: Refine sound activity circuit implementation

### DIFF
--- a/src/devices/bus/coco/coco_ssc.cpp
+++ b/src/devices/bus/coco/coco_ssc.cpp
@@ -137,12 +137,18 @@ namespace
 		// sound stream update overrides
 		virtual void sound_stream_update(sound_stream &stream) override;
 
-		// Power of 2
-		static constexpr int BUFFER_SIZE = 4;
+		static constexpr float HPF_ALPHA    = 0.99f;
+		static constexpr float ATTACK_COEFF = 0.0026f;  // fast charge
+		static constexpr float DECAY_COEFF  = 0.0003f; // slow drain
+		static constexpr float THRESH_ON    = 0.05f;
+		static constexpr float THRESH_OFF   = 0.01f;
+
 	private:
 		sound_stream*  m_stream;
-		float m_rms[BUFFER_SIZE];
-		int m_index;
+		bool m_sound_active;
+		float m_envelope;
+		float m_hpf_prev_in;
+		float m_hpf_prev_out;
 	};
 };
 
@@ -476,14 +482,15 @@ void coco_ssc_device::ssc_port_d_w(u8 data)
 //-------------------------------------------------
 
 cocossc_sac_device::cocossc_sac_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: device_t(mconfig, COCOSSC_SAC, tag, owner, clock),
-		device_sound_interface(mconfig, *this),
-		m_stream(nullptr),
-		m_index(0)
+	: device_t(mconfig, COCOSSC_SAC, tag, owner, clock)
+		, device_sound_interface(mconfig, *this)
+		, m_stream(nullptr)
+		, m_sound_active(false)
+		, m_envelope(0.0f)
+		, m_hpf_prev_in(0.0f)
+		, m_hpf_prev_out(0.0f)
 {
-	std::fill(std::begin(m_rms), std::end(m_rms), 0.0f);
 }
-
 
 //-------------------------------------------------
 //  device_start - device-specific startup
@@ -492,8 +499,12 @@ cocossc_sac_device::cocossc_sac_device(const machine_config &mconfig, const char
 void cocossc_sac_device::device_start()
 {
 	m_stream = stream_alloc(1, 1, machine().sample_rate());
-}
 
+	save_item(NAME(m_sound_active));
+	save_item(NAME(m_envelope));
+	save_item(NAME(m_hpf_prev_in));
+	save_item(NAME(m_hpf_prev_out));
+}
 
 //-------------------------------------------------
 //  sound_stream_update - handle a stream update
@@ -502,25 +513,26 @@ void cocossc_sac_device::device_start()
 void cocossc_sac_device::sound_stream_update(sound_stream &stream)
 {
 	int count = stream.samples();
-	m_rms[m_index] = 0;
 
-	if( count > 0 )
+	for (int sampindex = 0; sampindex < count; sampindex++)
 	{
-		for( int sampindex = 0; sampindex < count; sampindex++ )
-		{
-			auto source_sample = stream.get(0, sampindex);
-			m_rms[m_index] += source_sample * source_sample;
-			stream.put(0, sampindex, source_sample);
-		}
+		float x = stream.get(0, sampindex);
 
-		m_rms[m_index] = m_rms[m_index] / count;
-		m_rms[m_index] = sqrt(m_rms[m_index]);
+		// High pass filter to remove DC offset
+		float y = HPF_ALPHA * (m_hpf_prev_out + x - m_hpf_prev_in);
+		m_hpf_prev_in = x;
+		m_hpf_prev_out = y;
+
+		// Envelope follower, asymmetric attack/decay
+		float rect = std::abs(y);
+		if (rect > m_envelope)
+			m_envelope += (rect - m_envelope) * ATTACK_COEFF;
+		else
+			m_envelope += (rect - m_envelope) * DECAY_COEFF;
+
+		stream.put(0, sampindex, x);
 	}
-
-	m_index++;
-	m_index &= (BUFFER_SIZE-1);
 }
-
 
 //-------------------------------------------------
 //  sound_activity_circuit_output - making sound
@@ -528,8 +540,12 @@ void cocossc_sac_device::sound_stream_update(sound_stream &stream)
 
 bool cocossc_sac_device::sound_activity_circuit_output()
 {
-	float sum = std::accumulate(std::begin(m_rms), std::end(m_rms), 0.0f);
-	float average = (sum / BUFFER_SIZE);
+	m_stream->update();
 
-	return average < 0.317f;
+	if (m_sound_active && m_envelope < THRESH_OFF)
+		m_sound_active = false;
+	else if (m_envelope > THRESH_ON)
+		m_sound_active = true;
+
+	return !m_sound_active;
 }


### PR DESCRIPTION
Refine the SAC algorithm to better mimic the circuit. Verified against real hardware.
Claude Sonnet 4.6 was used as a development aid when writing and debugging this code.