### PR TITLE
mc68681: assert TxRDY at the THR->shift transfer (fix VFX regression from #15564)

### DIFF
--- a/src/devices/machine/mc68681.cpp
+++ b/src/devices/machine/mc68681.cpp
@@ -1428,31 +1428,29 @@ void duart_channel::rx_fifo_push(uint8_t data, uint8_t errors)
 
 void duart_channel::tra_complete()
 {
-	// The transmit shift register has just emptied.  Decide the next state from
-	// whether another byte is queued in the THR, not from the current TxRDY bit.
+	// The transmit shift register has just emptied.  If another character is
+	// waiting in the THR, transfer it to the shift register and assert TxRDY:
+	// per the datasheet the THR->shift transfer is where the TxRDY conditions
+	// are re-asserted, providing "one full character time of buffering".  If the
+	// THR is empty the transmitter is now idle, so set TxEMT (TxRDY is already
+	// set from the previous transfer).
 	//
-	// The previous code keyed off TxRDY:
-	//     if (!(SR & TxRDY)) { if (m_tx_data_in_buffer) load_next(); }
-	//     else               { SR |= TxEMT; }
-	// which could deadlock the transmitter on a race between a CPU THR write and
-	// the final bit-time of the byte in the shift register: (1) reaching here with
-	// TxRDY set and a byte buffered took the else branch and dropped the buffered
-	// byte; (2) reaching here with TxRDY clear and nothing buffered did nothing,
-	// leaving the transmitter idle with TxRDY and TxEMT both clear.  In either case
-	// TxRDY never re-asserts and the transmit clock stays stopped, so a byte never
-	// drains and a polled transmitter never completes.
+	// Asserting TxRDY here, at the transfer -- rather than in the idle branch --
+	// both prevents the transmitter from deadlocking when TxRDY would otherwise
+	// fail to re-assert on a CPU-write / final-bit-time race, and preserves the
+	// one-character buffering window that firmware polling or pipelining on TxRDY
+	// relies on.
 	if (m_tx_data_in_buffer)
 	{
-		// another byte is queued in the THR: move it into the shift register
 		transmit_register_setup(m_tx_data);
 		m_bits_transmitted = 0;
 		m_tx_data_in_buffer = false;
+		SR |= STATUS_TRANSMITTER_READY;
+		update_interrupts();
 	}
 	else
 	{
-		// nothing queued: the transmitter is idle, so report both THR empty
-		// (TxRDY) and shift register empty (TxEMT)
-		SR |= STATUS_TRANSMITTER_READY | STATUS_TRANSMITTER_EMPTY;
+		SR |= STATUS_TRANSMITTER_EMPTY;
 		update_interrupts();
 	}
 }


### PR DESCRIPTION
GitHub PR #15564 cured a transmitter deadlock but asserted TxRDY at the wrong
point, regressing the Ensoniq VFX family (`sd132`): inter-board / MIDI output
truncates and the panel shows `SYSTEM ERROR 144` (reported by @cbrunschen).

**Root cause.** #15564 asserted TxRDY (together with TxEMT) only in
`tra_complete`'s *idle* branch, i.e. at end-of-transmission. Per the
SCN2681 / MC68681 datasheet, TxRDY is asserted at the **THR -> shift-register
transfer**, which is "one full character time of buffering" earlier. Firmware
that pipelines on TxRDY (the VFX inter-board link and MIDI) sees the ready
window a character time late and drops bytes.

**Fix.** Assert TxRDY in the *reload* branch, where the queued THR byte
transfers into the shift register; the idle branch sets TxEMT only. This keeps
#15564's deadlock cure (TxRDY still re-asserts whenever a byte is queued) while
restoring the correct one-character buffering window.

**Tested.**
- `sd132` (VFX): channel-A MIDI stream restored to full length; no SYSTEM ERROR 144.
- `pc532` System V (4x SCN2681 console DUARTs): transmitter does not deadlock --
  polled console TX flows, zero discarded bytes -- i.e. the case #15564 cured.
