### PR TITLE
mc68681: restore TxRDY when the transmitter goes idle

### DIFF
--- a/src/devices/machine/mc68681.cpp
+++ b/src/devices/machine/mc68681.cpp
@@ -1429,17 +1429,18 @@ void duart_channel::rx_fifo_push(uint8_t data, uint8_t errors)
 void duart_channel::tra_complete()
 {
 	// The transmit shift register has just emptied.  If another character is
-	// waiting in the THR, transfer it to the shift register and assert TxRDY:
-	// per the datasheet the THR->shift transfer is where the TxRDY conditions
-	// are re-asserted, providing "one full character time of buffering".  If the
-	// THR is empty the transmitter is now idle, so set TxEMT (TxRDY is already
-	// set from the previous transfer).
+	// waiting in the THR, transfer it to the shift register and assert TxRDY
+	// here: per the datasheet the THR->shift transfer is where the TxRDY
+	// conditions are re-asserted, providing "one full character time of
+	// buffering".  Firmware that pipelines on TxRDY (e.g. the Ensoniq VFX
+	// inter-board link and MIDI) depends on TxRDY appearing at this point rather
+	// than one character later.
 	//
-	// Asserting TxRDY here, at the transfer -- rather than in the idle branch --
-	// both prevents the transmitter from deadlocking when TxRDY would otherwise
-	// fail to re-assert on a CPU-write / final-bit-time race, and preserves the
-	// one-character buffering window that firmware polling or pipelining on TxRDY
-	// relies on.
+	// If the THR is empty the transmitter is now idle: assert both TxRDY (THR
+	// empty) and TxEMT (shift register empty).  Asserting TxRDY unconditionally
+	// when going idle is essential -- it guarantees a polled transmitter can
+	// never be left spinning with TxRDY clear and the transmit clock stopped
+	// (the pc532 console hang).
 	if (m_tx_data_in_buffer)
 	{
 		transmit_register_setup(m_tx_data);
@@ -1450,7 +1451,7 @@ void duart_channel::tra_complete()
 	}
 	else
 	{
-		SR |= STATUS_TRANSMITTER_EMPTY;
+		SR |= STATUS_TRANSMITTER_READY | STATUS_TRANSMITTER_EMPTY;
 		update_interrupts();
 	}
 }


### PR DESCRIPTION
#15613 asserted TxRDY at the THR->shift transfer to fix the Ensoniq VFX
(`sd132`) timing, but it also changed `tra_complete`'s idle branch from
`SR |= TxRDY | TxEMT` to `TxEMT` only.

When the transmitter reaches the idle branch with TxRDY clear, it is left
spinning with the transmit clock stopped. The pc532 System V console hangs
as a result.

This restores TxRDY in the idle branch.  The THR is empty when the transmitter
goes idle, so TxRDY is correct there. It is a strict superset of #15564's 
TxRDY assertions, so it preserves both the deadlock cure and the VFX timing fix.

### Regression tested

Patrick was correct.  Many systems depend on this device, and testing
is absolutely essential.  So, I picked polled and interrupt-driven systems
to test against.  I incidentally tested against the ICM3216.

| Machine | DUART | CPU | Result |
|---|---|---|---|
| f15se (F-15 Strike Eagle) | MC68681 | 68000 | power-on diagnostic reports **TI UART: PASS** |
| ms14 (IGT Multistar 14) | SC28C94 QUART | i960 | full diagnostic output through the QUART |
| dectalk (DTC-01) | SCN2681 | 68000 | boots to normal operating state |
| lb186 (Ampro Little Board/186) | SCN2681 | 80186 | boots IBM DOS 3.30 |
| pc532 | SCN2681 ×4 | NS32532 | boots System V to a prompt (the #15613 hang) |
| sd132 (Ensoniq VFX) | SCN2681 | 68000 | panel + MIDI intact (#15613's fix preserved) |
