### PR TITLE
luaengine: Overload device output() to allow synthetic (custom) state output creation

### DIFF
--- a/src/emu/output.h
+++ b/src/emu/output.h
@@ -33,6 +33,13 @@
 
 class output_manager
 {
+public:
+	// public proxy interfaces
+	template <typename X, unsigned... N> class output_finder;
+	template <typename X> class output_finder<X>;
+	class output_proxy;
+	class item_creator_proxy;
+
 private:
 	template <typename Input, std::make_unsigned_t<Input> DefaultMask> friend class devcb_write;
 
@@ -172,7 +179,6 @@ private:
 	using qualified_name_set = std::unordered_set<item_reference, qualified_name_hash, qualified_name_equal>;
 	using unqualified_name_set = std::unordered_set<item_reference, unqualified_name_hash, unqualified_name_equal>;
 
-	class item_creator_proxy;
 	template <unsigned M, unsigned... N> struct item_proxy_array { typedef typename item_proxy_array<N...>::type type[M]; };
 	template <unsigned N> struct item_proxy_array<N> { typedef item_creator_proxy type[N]; };
 	template <unsigned... N> using item_proxy_array_t = typename item_proxy_array<N...>::type;
@@ -196,10 +202,6 @@ private:
 	std::unique_ptr<s32 []>     m_save_data;
 
 public:
-	template <typename X, unsigned... N> class output_finder;
-	template <typename X> class output_finder<X>;
-	class output_proxy;
-
 	// construction/destruction
 	output_manager(running_machine &machine);
 

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -10,6 +10,7 @@
 
 #include "emu.h"
 #include "luaengine.ipp"
+#include "output.ipp"
 
 #include "mame.h"
 #include "pluginopts.h"
@@ -1567,7 +1568,14 @@ void lua_engine::initialize()
 	device_type.set_function("memshare", &device_t::memshare);
 	device_type.set_function("membank", &device_t::membank);
 	device_type.set_function("ioport", &device_t::ioport);
-	device_type.set_function("output", [] (device_t &d, std::string_view name) { return output_proxy(d, name); });
+	device_type.set_function("output", sol::overload(
+			[] (device_t &d, std::string_view name) { return output_proxy(d, name); },
+			[] (device_t &d, std::string_view name, int value) 
+			{ 
+				output_manager::item_creator_proxy creator;
+				creator.resolve(d, name);
+				creator = value;
+			}));
 	device_type.set_function("subdevice", static_cast<device_t *(device_t::*)(std::string_view) const>(&device_t::subdevice));
 	device_type.set_function("siblingdevice", static_cast<device_t *(device_t::*)(std::string_view) const>(&device_t::siblingdevice));
 	device_type.set_function("parameter", &device_t::parameter);


### PR DESCRIPTION
The recent architectural shift toward device-scoped `output_proxy` objects delivers state outputs in an organised manner (commit [2f859cd](https://github.com/mamedev/mame/commit/2f859cd448cf326431759f0b5094d2438fbd70c0)), but this new implementation currently lacks the function for Lua scripts/plugins to generate synthetic (custom) state outputs. This happens because `output_proxy` safely traps unrecognised strings in `m_local_value` when a native hardware `osd::output_item` cannot be found.

This logic impacts network telemetry projects (such as MAMEhooker and [MAME State Output Project](https://github.com/djGLiTCH/MAME-LUA-SCRIPT-STATE-OUTPUTS)) that rely on generating ad-hoc state outputs that are not present in the physical machine driver so they can be broadcast to windows/network outputs.

To support the new device-scoped paradigm for these external tools while maintaining the new logic intent, this PR adds overload to `device:output(name, value)` in `luaengine.cpp` to utilise the core's existing `item_creator_proxy` in `output.h`. This change allows Lua scripts/plugins to explicitly register a synthetic output to a specific device (e.g. the root device) at boot, ensuring windows/network is notified, while continuing to utilise `output_proxy`.

Additionally, to support this Lua binding, `class item_creator_proxy` has been moved from private to public in `output.h`.

All code changes have been successfully verified in a working MAME build without compromising official state output support while continuing to enforce the adoption of the new output proxy method.