### PR TITLE
apple2/e/gs: fix slot arbitration

### DIFF
--- a/src/mame/apple/apple2.cpp
+++ b/src/mame/apple/apple2.cpp
@@ -79,6 +79,8 @@ namespace {
 #define A2_UPPERBANK_TAG "inhbank"
 #define A2_VIDEO_TAG "a2video"
 
+static constexpr int CNXX_UNCLAIMED = -1;
+
 class apple2_state : public driver_device
 {
 public:
@@ -323,7 +325,7 @@ void apple2_state::machine_start()
 void apple2_state::machine_reset()
 {
 	// m_inh_slot is not reset here since bootable cards may want to override the monitor
-	m_cnxx_slot = -1;
+	m_cnxx_slot = CNXX_UNCLAIMED;
 	m_strobe = 0;
 	m_kbd->ack_w(0);
 }
@@ -510,12 +512,11 @@ void apple2_state::c080_w(offs_t offset, u8 data)
 
 u8 apple2_state::c100_r(offs_t offset)
 {
-	int slotnum;
-
-	slotnum = ((offset>>8) & 0xf) + 1;
+	const int slotnum = ((offset>>8) & 0xf) + 1;
 
 	if (m_slotdevice[slotnum] != nullptr)
 	{
+		// a bus fight here is resolved as "last-one-wins"
 		if ((m_slotdevice[slotnum]->take_c800()) && (!machine().side_effects_disabled()))
 		{
 			m_cnxx_slot = slotnum;
@@ -529,9 +530,7 @@ u8 apple2_state::c100_r(offs_t offset)
 
 void apple2_state::c100_w(offs_t offset, u8 data)
 {
-	int slotnum;
-
-	slotnum = ((offset>>8) & 0xf) + 1;
+	const int slotnum = ((offset>>8) & 0xf) + 1;
 
 	if (m_slotdevice[slotnum] != nullptr)
 	{
@@ -546,26 +545,16 @@ void apple2_state::c100_w(offs_t offset, u8 data)
 
 u8 apple2_state::c800_r(offs_t offset)
 {
-	if (offset == 0x7ff)
+	const int slot = m_cnxx_slot;
+
+	if ((offset == 0x7ff) && !machine().side_effects_disabled())
 	{
-		u8 rv = 0xff;
-
-		if ((m_cnxx_slot != -1) && (m_slotdevice[m_cnxx_slot] != nullptr))
-		{
-			rv = m_slotdevice[m_cnxx_slot]->read_c800(offset&0xfff);
-		}
-
-		if (!machine().side_effects_disabled())
-		{
-			m_cnxx_slot = -1;
-		}
-
-		return rv;
+		m_cnxx_slot = CNXX_UNCLAIMED;
 	}
 
-	if ((m_cnxx_slot != -1) && (m_slotdevice[m_cnxx_slot] != nullptr))
+	if ((slot != CNXX_UNCLAIMED) && (m_slotdevice[slot] != nullptr))
 	{
-		return m_slotdevice[m_cnxx_slot]->read_c800(offset&0xfff);
+		return m_slotdevice[slot]->read_c800(offset&0xfff);
 	}
 
 	return read_floatingbus();
@@ -573,19 +562,14 @@ u8 apple2_state::c800_r(offs_t offset)
 
 void apple2_state::c800_w(offs_t offset, u8 data)
 {
-	if ((m_cnxx_slot != -1) && (m_slotdevice[m_cnxx_slot] != nullptr))
+	if ((m_cnxx_slot != CNXX_UNCLAIMED) && (m_slotdevice[m_cnxx_slot] != nullptr))
 	{
 		m_slotdevice[m_cnxx_slot]->write_c800(offset&0xfff, data);
 	}
 
-	if (offset == 0x7ff)
+	if ((offset == 0x7ff) && !machine().side_effects_disabled())
 	{
-		if (!machine().side_effects_disabled())
-		{
-			m_cnxx_slot = -1;
-		}
-
-		return;
+		m_cnxx_slot = CNXX_UNCLAIMED;
 	}
 }
 
@@ -1042,7 +1026,6 @@ ROM_END
 /*
     J-Plus ROM numbers confirmed by:
     http://mirrors.apple2.org.za/Apple%20II%20Documentation%20Project/Computers/Apple%20II/Apple%20II%20j-plus/Photos/Apple%20II%20j-plus%20-%20Motherboard.jpg
-
 */
 
 ROM_START(apple2jp)

--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -204,8 +204,7 @@ namespace {
 #define MOUSE_XAXIS_TAG     "mse_x"
 #define MOUSE_YAXIS_TAG     "mse_y"
 
-#define CNXX_UNCLAIMED  -1
-#define CNXX_INTROM     -2
+static constexpr int CNXX_UNCLAIMED = -1;
 
 static constexpr int IRQ_SLOT = 0;
 static constexpr int IRQ_VBL = 1;
@@ -486,13 +485,13 @@ private:
 
 	bool m_intcxrom;
 	bool m_slotc3rom;
+	bool m_intc8rom;
 	bool m_altzp;
 	bool m_ramrd, m_ramwrt;
 	bool m_lcram, m_lcram2, m_lcprewrite, m_lcwriteenable;
 	bool m_ioudis;
 	bool m_romswitch;
 	bool m_mockingboard4c;
-	bool m_intc8rom;
 	bool m_reset_latch;
 
 	bool m_isiic, m_isiicplus, m_iscec, m_iscecm, m_iscec2000;
@@ -1146,6 +1145,7 @@ void apple2e_state::machine_start()
 	save_item(NAME(m_an3));
 	save_item(NAME(m_intcxrom));
 	save_item(NAME(m_slotc3rom));
+	save_item(NAME(m_intc8rom));
 	save_item(NAME(m_altzp));
 	save_item(NAME(m_ramrd));
 	save_item(NAME(m_ramwrt));
@@ -1181,7 +1181,6 @@ void apple2e_state::machine_start()
 	save_item(NAME(m_lcprewrite));
 	save_item(NAME(m_lcwriteenable));
 	save_item(NAME(m_mockingboard4c));
-	save_item(NAME(m_intc8rom));
 	save_item(NAME(m_cec_bank));
 	save_item(NAME(m_35sel));
 	save_item(NAME(m_hdsel));
@@ -2239,7 +2238,7 @@ u8 apple2e_state::c000_r(offs_t offset)
 
 			if (m_accel_unlocked) switch(offset)
 			{
-				case 0x58: return 0xC0; // undocumented, not floating bus
+				case 0x58: return 0xc0; // undocumented, not floating bus
 				case 0x59: return 0x20;
 				case 0x5a: return 0x00;
 				case 0x5d: return 0x00;
@@ -2963,10 +2962,11 @@ void apple2e_state::c080_w(offs_t offset, u8 data)
 
 u8 apple2e_state::read_slot_rom(int slotbias, int offset)
 {
-	int slotnum = ((offset>>8) & 0xf) + slotbias;
+	const int slotnum = ((offset>>8) & 0xf) + slotbias;
 
 	if (m_slotdevice[slotnum] != nullptr)
 	{
+		// a bus fight here is resolved as "first-one-wins"
 		if ((m_cnxx_slot == CNXX_UNCLAIMED) && (m_slotdevice[slotnum]->take_c800()) && (!machine().side_effects_disabled()))
 		{
 			m_cnxx_slot = slotnum;
@@ -2981,9 +2981,9 @@ u8 apple2e_state::read_slot_rom(int slotbias, int offset)
 
 void apple2e_state::write_slot_rom(int slotbias, int offset, u8 data)
 {
-	int slotnum = ((offset>>8) & 0xf) + slotbias;
+	const int slotnum = ((offset>>8) & 0xf) + slotbias;
 
-	if ((m_iscec) && (m_iscecm) && ( slotnum == 6 ) && (!m_intcxrom) )
+	if ((m_iscec) && (m_iscecm) && (slotnum == 6) && (!m_intcxrom))
 	{
 		if (data != m_cec_bank)
 		{
@@ -3017,7 +3017,7 @@ void apple2e_state::write_slot_rom(int slotbias, int offset, u8 data)
 
 u8 apple2e_state::read_int_rom(int slotbias, int offset)
 {
-	int slot = ((slotbias + offset) >> 8) & 0xf;
+	const int slot = ((slotbias + offset) >> 8) & 0xf;
 
 	// slot 4 can't remap because the IRQ handler is there
 	if ((m_isace500) && (m_ace_cnxx_bank) && (slot != 4))
@@ -3128,24 +3128,19 @@ void apple2e_state::c400_cec_w(offs_t offset, u8 data)
 
 u8 apple2e_state::c800_r(offs_t offset)
 {
+	const int slot = m_cnxx_slot;
+
 	if ((offset == 0x7ff) && !machine().side_effects_disabled())
 	{
-		u8 rv = 0xff;
-
-		if ((m_cnxx_slot > 0) && (m_slotdevice[m_cnxx_slot] != nullptr))
-		{
-			rv = m_slotdevice[m_cnxx_slot]->read_c800(offset&0xfff);
-		}
 		m_cnxx_slot = CNXX_UNCLAIMED;
 		m_intc8rom = false;
 		update_slotrom_banks();
-		return rv;
 	}
 
-	if ((m_cnxx_slot > 0) && (m_slotdevice[m_cnxx_slot] != nullptr))
+	if ((slot > 0) && (m_slotdevice[slot] != nullptr))
 	{
-		laser_slot(m_cnxx_slot);
-		return m_slotdevice[m_cnxx_slot]->read_c800(offset&0xfff);
+		laser_slot(slot);
+		return m_slotdevice[slot]->read_c800(offset&0xfff);
 	}
 
 	return read_floatingbus();
@@ -3217,6 +3212,8 @@ void apple2e_state::ace500_c0bx_w(offs_t offset, u8 data)
 
 u8 apple2e_state::c800_int_r(offs_t offset)
 {
+	const int slot = m_cnxx_slot;
+
 	if ((offset == 0x7ff) && !machine().side_effects_disabled())
 	{
 		m_cnxx_slot = CNXX_UNCLAIMED;
@@ -3234,8 +3231,8 @@ u8 apple2e_state::c800_int_r(offs_t offset)
 		return m_rom_ptr[m_ace500rombank + offset];
 	}
 
-	if (m_cnxx_slot > 0)
-		laser_slot(m_cnxx_slot);
+	if (slot > 0)
+		laser_slot(slot);
 	return m_rom_ptr[0x800 + offset];
 }
 
@@ -5540,7 +5537,7 @@ void apple2e_state::ace2200(machine_config &config)
 
 	// The Ace 2000 series has 3 physical slots, 2, 4/7, and 5.
 	// 4/7 can be slot 4 or 7 via a jumper; we fix it to slot 7 here
-	// because that's most useful (for e.g. cffa2).
+	// because that's most useful (for e.g. cffa202).
 	config.device_remove("sl1");
 	config.device_remove("sl2");
 	config.device_remove("sl3");

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -215,7 +215,6 @@ private:
 	required_ioport m_sysconfig;
 
 	static constexpr int CNXX_UNCLAIMED = -1;
-	static constexpr int CNXX_INTROM = -2;
 
 	enum glu_reg_names
 	{
@@ -446,6 +445,7 @@ private:
 
 	bool m_intcxrom = false;
 	bool m_slotc3rom = false;
+	bool m_intc8rom = false;
 	bool m_altzp = false;
 	bool m_ramrd = false, m_ramwrt = false;
 	bool m_lcram = false, m_lcram2 = false, m_lcprewrite = false, m_lcwriteenable = false;
@@ -758,8 +758,8 @@ void apple2gs_state::machine_start()
 	save_item(NAME(m_an2));
 	save_item(NAME(m_an3));
 	save_item(NAME(m_intcxrom));
-	save_item(NAME(m_rombank));
 	save_item(NAME(m_slotc3rom));
+	save_item(NAME(m_intc8rom));
 	save_item(NAME(m_altzp));
 	save_item(NAME(m_ramrd));
 	save_item(NAME(m_ramwrt));
@@ -769,6 +769,7 @@ void apple2gs_state::machine_start()
 	save_item(NAME(m_lcram2));
 	save_item(NAME(m_lcprewrite));
 	save_item(NAME(m_lcwriteenable));
+	save_item(NAME(m_rombank));
 	save_item(NAME(m_shadow));
 	save_item(NAME(m_speed));
 	save_item(NAME(m_clock_control));
@@ -824,14 +825,15 @@ void apple2gs_state::machine_reset()
 	m_gameio->an2_w(0);
 	m_gameio->an3_w(0);
 	m_vbl = false;
-	m_slotc3rom = false;
 	m_irqmask = 0;
 	m_intcxrom = false;
-	m_rombank = false;
+	m_slotc3rom = false;
+	m_intc8rom = false;
 	m_video->a80store_w(false);
 	m_altzp = false;
 	m_ramrd = false;
 	m_ramwrt = false;
+	m_rombank = false;
 	m_video->set_newvideo(0x01); // verified on ROM03 hardware
 	m_slot_irq = false;
 	m_clkdata = 0;
@@ -1228,10 +1230,9 @@ void apple2gs_state::auxbank_update()
 
 void apple2gs_state::update_slotrom_banks()
 {
-	//printf("update_slotrom_banks: intcxrom %d cnxx_slot %d SLOT %02x\n", m_intcxrom, m_cnxx_slot, m_slotromsel);
+	//printf("update_slotrom_banks: intcxrom %d slotc3rom %d\n", m_intcxrom, m_slotc3rom);
 
-	// slot 3 ROM is controlled exclusively by SLOTC3ROM
-	if (!m_slotc3rom)
+	if ((m_intcxrom) || (!m_slotc3rom))
 	{
 		m_c300bank->set_bank(1);
 	}
@@ -1815,7 +1816,7 @@ u8 apple2gs_state::c000_r(offs_t offset)
 
 			if (m_accel_unlocked) switch(offset)
 			{
-				case 0x58: return 0xFF; // undocumented, not floating bus
+				case 0x58: return 0xff; // undocumented, not floating bus
 				case 0x5d: return 0x00; // "bank"
 				case 0x5e: return 0x00; // cache tag
 				case 0x5f: return 0x00; // clears C05B bit 6
@@ -2376,11 +2377,10 @@ u8 apple2gs_state::read_slot_rom(int slotbias, int offset)
 
 	if (m_slotdevice[slotnum] != nullptr)
 	{
-//      printf("slotdevice is not null\n");
+		// a bus fight here is resolved as "first-one-wins"
 		if ((m_cnxx_slot == CNXX_UNCLAIMED) && (m_slotdevice[slotnum]->take_c800()) && (!machine().side_effects_disabled()))
 		{
 			m_cnxx_slot = slotnum;
-			update_slotrom_banks();
 		}
 
 		return m_slotdevice[slotnum]->read_cnxx(offset&0xff);
@@ -2400,30 +2400,19 @@ void apple2gs_state::write_slot_rom(int slotbias, int offset, u8 data)
 		if ((m_cnxx_slot == CNXX_UNCLAIMED) && (m_slotdevice[slotnum]->take_c800()) && !machine().side_effects_disabled())
 		{
 			m_cnxx_slot = slotnum;
-			update_slotrom_banks();
 		}
 
 		m_slotdevice[slotnum]->write_cnxx(offset&0xff, data);
 	}
 }
 
-u8 apple2gs_state::read_int_rom(int slotbias, int offset)
-{
-	if ((m_cnxx_slot == CNXX_UNCLAIMED) && (!machine().side_effects_disabled()))
-	{
-		m_cnxx_slot = CNXX_INTROM;
-		update_slotrom_banks();
-	}
-
-	return m_rom[slotbias + offset];
-}
+u8 apple2gs_state::read_int_rom(int slotbias, int offset) { return m_rom[slotbias + offset]; }
 
 u8 apple2gs_state::c100_r(offs_t offset)
 {
 	const int slot = ((offset>>8) & 0xf) + 1;
 
-	// SETSLOTCXROM is disabled, so the $C02D SLOT register controls what's in each slot
-	if (!BIT(m_slotromsel, slot))
+	if (m_intcxrom || !BIT(m_slotromsel, slot))
 	{
 		return read_int_rom(0x3c100, offset);
 	}
@@ -2435,13 +2424,22 @@ void apple2gs_state::c100_w(offs_t offset, u8 data)
 {
 	const int slot = ((offset>>8) & 0xf) + 1;
 
-	if (BIT(m_slotromsel, slot))
+	if (!m_intcxrom && BIT(m_slotromsel, slot))
 	{
 		write_slot_rom(1, offset, data);
 	}
 }
 
-u8 apple2gs_state::c300_int_r(offs_t offset)  { return read_int_rom(0x3c300, offset); }
+u8 apple2gs_state::c300_int_r(offs_t offset)
+{
+	if ((!m_slotc3rom) && !machine().side_effects_disabled())
+	{
+		m_intc8rom = true;
+	}
+
+	return read_int_rom(0x3c300, offset);
+}
+
 u8 apple2gs_state::c300_r(offs_t offset)  { return read_slot_rom(3, offset); }
 void apple2gs_state::c300_w(offs_t offset, u8 data) { write_slot_rom(3, offset, data); }
 
@@ -2449,7 +2447,7 @@ u8 apple2gs_state::c400_r(offs_t offset)
 {
 	const int slot = ((offset>>8) & 0xf) + 4;
 
-	if (!BIT(m_slotromsel, slot))
+	if (m_intcxrom || !BIT(m_slotromsel, slot))
 	{
 		return read_int_rom(0x3c400, offset);
 	}
@@ -2461,7 +2459,7 @@ void apple2gs_state::c400_w(offs_t offset, u8 data)
 {
 	const int slot = ((offset>>8) & 0xf) + 4;
 
-	if (BIT(m_slotromsel, slot))
+	if (!m_intcxrom && BIT(m_slotromsel, slot))
 	{
 		write_slot_rom(4, offset, data);
 	}
@@ -2469,25 +2467,27 @@ void apple2gs_state::c400_w(offs_t offset, u8 data)
 
 u8 apple2gs_state::c800_r(offs_t offset)
 {
+	const int slot = m_cnxx_slot;
+	const int internal = (m_intcxrom) || (m_intc8rom);
+
 	if ((offset == 0x7ff) && !machine().side_effects_disabled())
 	{
 		m_cnxx_slot = CNXX_UNCLAIMED;
-		update_slotrom_banks();
-		return 0xff;
+		m_intc8rom = false;
 	}
 
-	if (m_cnxx_slot == CNXX_INTROM)
+	if (internal)
 	{
 		return m_rom[offset + 0x3c800];
 	}
 
-	if ((m_cnxx_slot > 0) && (m_slotdevice[m_cnxx_slot] != nullptr))
+	if ((slot > 0) && (m_slotdevice[slot] != nullptr))
 	{
 		slow_cycle();
-		return m_slotdevice[m_cnxx_slot]->read_c800(offset&0xfff);
+		return m_slotdevice[slot]->read_c800(offset&0xfff);
 	}
 
-	return 0xff;
+	return read_floatingbus();
 }
 
 void apple2gs_state::c800_w(offs_t offset, u8 data)
@@ -2501,7 +2501,7 @@ void apple2gs_state::c800_w(offs_t offset, u8 data)
 	if (offset == 0x7ff)
 	{
 		m_cnxx_slot = CNXX_UNCLAIMED;
-		update_slotrom_banks();
+		m_intc8rom = false;
 		return;
 	}
 }
@@ -3364,6 +3364,7 @@ void apple2gs_state::adbmicro_p2_out(u8 data)
 		m_lcwriteenable = true;
 		m_intcxrom = false;
 		m_slotc3rom = false;
+		m_intc8rom = false;
 		m_video->a80store_w(false);
 		m_altzp = false;
 		m_ramrd = false;


### PR DESCRIPTION
(side-quest auditing memory banking after #15464)

This PR fixes multiple problems with slot arbitration:

* apple2gs: implement INTCXROM (it overrides SLOTC3ROM and SLTROMSEL)
	Per IIgs Hardware Ref, [page 193 Note](https://archive.org/details/Apple_IIgs_Hardware_Reference_HiRes/page/192/mode/2up).  See Testing.

* apple2gs: implement INTC8ROM (propagate 8bf4bac)
	Testing shows the IIgs behaves the same as [UtA2e 5-28](https://archive.org/details/Understanding_the_Apple_IIe/page/5-28/mode/2up).

* apple2gs: undo 9dee876, unpopulated C800 returns floating bus.
	Verifying floating bus is tricky on the IIgs.  See Testing.

* apple2/e/gs: stop special-casing CFFF reads (followup #15247)
	Some cards do return a usable byte of ROM during a read that disables C800 expansion ROM.  See TODO.

These changes don't affect the (slotless) apple2c.
<br>
Code comments:<details>

Some archeology:

8bf4bac was correct for apple2e; similar changes are applied here for apple2gs.
But, I'm not sure why [writes to internal firmware](https://github.com/mamedev/mame/blob/b7c9e20c67b1337ed12e899e91ed0385e318221d/src/mame/apple/apple2e.cpp#L3560) are allowed to go to external slots?
Also, CNXX_INTROM was orphaned by that change, tidied up here.
<br>

9dee876 says "SLOTROMSEL overrules INTCXROMON" and "When no card claims $C800, reads return 0xff" but both of these statements are demonstrably false, see Testing.

If the motivation there was "Fixes listing card ROMs in the Monitor", then with `apple2gs -sl1 grapplus`:
`* C02D:82 N C100L`  disassembles the Grappler 256 byte firmware
`* C02D:80 N C100L`  disassembles the internal printer firmware
This continues to work after this PR, matching hardware.

For the C800 ROMs, with the 80-column firmware _OFF_ (Esc-Ctrl-Q, flashing cursor) you can un-latch whatever is already in C800, re-latch, and then view:
`* C02D:82 N CFFF C100 C800L`
This continues to work after this PR, matching hardware (but see TODO for the implications of CFxx.) 
With the 80-column firmware _ON_ (solid cursor), the Monitor [keeps re-latching](https://groups.google.com/g/comp.sys.apple2/c/4uf5BTe0BDM/m/AoBQzOGKBQAJ#:~:text=more%20aggressive) while printing (via INTC8ROM) so you can't see card expansion ROM.  This matches hardware behavior.
<br>

In `read_slot_rom()` where `m_cnxx_slot` is acquired, the behavior differs between apple2e/gs (which check CNXX_UNCLAIMED) and apple2 (which does not.)  On hardware, if two cards attempt to put C800 on the bus due to [misbehaving software](https://web.archive.org/web/20050425130214/https://web.pdx.edu/~heiss/technotes/misc/tn.misc.03.html#:~:text=slot%20data%20bus%20conflict) skipping a CFFF access, this creates a bus fight.  The result is undefined behavior (see Testing), so either implementation is correct.  It's slightly useful to have the machines produce different results for undefined behavior, so instead of making them consistent, I've just commented the different bus fight policies.

</details>

<br>
Testing:<details>

I wrote three unit tests to visualize the various slot arbitration behaviors (source included):
(updated 260701 to fix ROMBANK inversion, after testing on ROM1 IIgs)
(updated 260731 to fix SLOTROM state restore.  Now [included](https://github.com/mamedev/mame/pull/15803#:~:text=older%20tests%20are%20also%20included) in MEMSTATE.po)

Brief overview:
(1) CLRROM looks at the CFxx expansion disable behavior, and
\* identifies the lowest address where a card disables C800
\* shows if the bytes returned by those final reads are floating bus, or not
...for all slots, internal firmware, and aux ROMBANK, where possible.
This shows card-specific behavior.

(2) SLOTROM shows the CSxx ROM plus the expansion ROM after IOSEL and after CFFF disable.
...for all slots, internal firmware (INTCX, not INTC3), and aux ROMBANK, where possible.
...and on the IIgs, forces C02D all-internal on the left, and all-slots on the right.
This shows the full truth-table of how the slot/internal ROM (or floating bus) is visible, with each combination of interacting softswitch state and IOSEL assertion.

(3) INTC8ROM shows a matrix of bus fights
\* by asserting IOSEL on a pair of slots without a CFFF disable in between
...for all combinations of slots, and internal firmware (INTC3-only, then INTCX-only)
...and on the IIgs, forces C02D all-internal on the left, and all-slots on the right.
This shows the simple case of one card's firmware replacing an empty slot, and the INTC8ROM behavior where slot 3 internal firmware overrides any slot (empty or not.)  But when two cards collide, the bus fight winner is undefined.

In each test, the floating bus behavior is carefully verified like this:
(1) clear HGR1 to all-FB, HGR2 to all-04.  Then when reading a byte of ROM:
(2) with PAGE1, read Cxxx (might disable C800, and might float)
(3) with PAGE2, read Cxxx again
(4) with PAGE1, read Cxxx again
If (2) == (3) then this byte didn't disable C800
If (4) was FB and (3) != (4), then we're reading the floating bus after this byte.
...and each "read" also constrains timing to within active video on the IIgs, to avoid [HBL noise](https://github.com/mamedev/mame/pull/15247#:~:text=adds%20emulation%20of%20the%20open%2Dbus%20Mega%20II%20cycles).
<br>

Here are reference hardware results, from an Apple IIgs ROM3 with a Grappler+ in slot 1 and an Xdrive in slot 7:
CLRROM:
<img width="720" height="270" alt="CLRROM_gs_grapplus_xdrive" src="https://github.com/user-attachments/assets/c77de1a7-509d-4a18-b8e5-e331a6968ea0" />
(the cards disable C800 on different address ranges, and only the Xdrive returns floating bus during that disable cycle.)

SLOTROM:
<img width="720" height="540" alt="SLOTROM_gs_grapplus_xdrive" src="https://github.com/user-attachments/assets/60cda049-ae53-4b63-a4e4-e2f8dda8a079" />
(with C02D set to internal so the CSxx internal firmware is visible, C800 firmware is _not_ visible when INTCX is off)
(ROMBANK has no effect here, on ROM3.)
(ROMBANK does affect the ROM1 IIgs, thanks to Colin Leroy-Mira for hardware testing.)

INTC8ROM:
<img width="720" height="540" alt="INTC8ROM_gs_grapplus_xdrive" src="https://github.com/user-attachments/assets/76c3a3a8-d5ff-48b3-8ed0-1e91528b323b" />
(at SLOT row1 column7 and row7 column1, the Xdrive wins bus fights with the Grappler+)
(at INT3 row3 and column3, the internal firmware overrides slots 1 and 7)
<br>

And for comparison, an Enhanced Apple //e with a Buffered Grappler+ in slot 2, an Apple Mouse Interface in slot 4, and a Disk ][ Interface in slot 6:
CLRROM:
<img width="720" height="270" alt="CLRROM_ee_bufgrap_mouse_diskii" src="https://github.com/user-attachments/assets/be10c0c4-83a4-41ca-9f7d-ff80ae18fd47" />
(the Buffered Grappler+ returns ROM bytes during the disable cycle)

SLOTROM:
<img width="720" height="540" alt="SLOTROM_ee_bufgrap_mouse_diskii" src="https://github.com/user-attachments/assets/5cbc53cd-55f4-48f2-8e90-6aafcff88ab0" />
(the //e functions like the IIgs when forcing C02D all-slots on the right)

INTC8ROM:
<img width="720" height="540" alt="INTC8ROM_ee_bufgrap_mouse_diskii" src="https://github.com/user-attachments/assets/e27c2f70-13a1-4482-bc27-a314dbb4ca67" />
(at INT3 row3 and column3, the internal firmware overrides slot 2)
<br>
Finally, here is INTC8ROM on an Apple ][+ (thanks to @retro-mike), with:
slot 1: Apple Super Serial Card
slot 2: Grappler+
slot 3: Videx
slot 4: Grappler
slot 5: Liron
<img width="720" height="240" alt="INTC8ROM_2p_scc_grapplus_videx_grappler_liron" src="https://github.com/user-attachments/assets/eae41743-6661-437a-9b6b-26d417eaee02" />
(the bus-fight results here are more complex: slot1 and slot5 beat the others, but when slot1 and slot5 collide, the result is the AND of their ROM bytes!)
<br>

Before this PR, MAME's behavior deviated from hardware in several ways.  Using `apple2gs -sl1 grapplus -sl7 cffa` as a similar configuration:

CLRROM:
<img width="704" height="462" alt="CLRROM_gs_288_before" src="https://github.com/user-attachments/assets/a963d0a4-056f-4649-a299-247a416549fa" />
(FF was hardcoded instead of the floating bus, and for CFFF.  apple2 and apple2e were similar, but returned floating bus for empty slot ROM, _except_ for CFFF.)

SLOTROM:
<img width="704" height="462" alt="SLOTROM_gs_288_before" src="https://github.com/user-attachments/assets/99bb6e43-8d10-40b0-a278-6994581c6ef5" />
(INTCXROM being unimplemented means slot ROM was incorrectly visible on the bottom right-hand side forcing C02D to all-slots, when INTCXROM is on.)
(INTCXROM being unimplemented means C800 internal ROM was incorrectly visible on the top left-hand side forcing C02D to all-internal, when INTCXROM is off.)
(INTCXROM not overriding INTC3ROM means slot3 internal firmware was missing on the bottom left-hand side forcing C02D to all-internal, when INTCXROM is on.)

INTC8ROM:
<img width="704" height="462" alt="INTC8ROM_gs_288_before" src="https://github.com/user-attachments/assets/35e4f665-00f1-4b7c-8b4a-9c3c5868ebf2" />
(in addition to the above problems, INTC8ROM not being implemented means internal slot 3 firmware did not override slot 1 and 7 ROMs, in the INT3 rows on right-hand side.)
<br>

After this PR, SLOTROM and INTC8ROM match hardware behavior.  CLRROM matches except for the CFxx details; see TODO.
<br>

Regression testing:
I spot-checked these changes against a suite of software, including:
* GS/OS, Rastan, AppleWorks GS, Dreamgrafix, FTA & Ninjaforce demos
* A2Desktop, Total Replay, AppleWorks, DazzleDraw, French Touch & deater demos
* a2audit, Card Cat, Apple Diagnostics, builtin self-tests
...with a range of machines, clones, slot device, and Your Card configurations.

There are no user visible changes.

That probably means that although the previous implementation was wrong, it didn't interfere with default system ROM operation: common usages like PR#1 toggle INTCX off before jumping to C100, so that you get slot or internal, whatever the user's Your Card setting says.  And Apple discourages changing C02D other than via the Control Panel, so maybe it is extremely rare to see the state combinations that were broken in MAME.

</details>
<br>
TODO:<details>

apple2e `m_c100bank` and friends have `c100_w()` etc [mapped for internal firmware banking](https://github.com/mamedev/mame/blob/b7c9e20c67b1337ed12e899e91ed0385e318221d/src/mame/apple/apple2e.cpp#L3539), which seems wrong?  This was explicitly added back in ceb4e0b.  It means that writes to internal firmware ROM are redirected to i.e. a Videx's banked RAM, is that intentional?
<br>

The behavior of CFFF CLRROM is inaccurate, but is not dealt with here:
As shown above in Testing, the IOPROBE address decoding to disable C800 expansion ROM, and the decision of driving the bus or not during that disable cycle, are card-implementation specific.  More examples:
<img width="720" height="240" alt="CLRROM_2p_scc_grapplus_videx_grappler_liron" src="https://github.com/user-attachments/assets/4d7ad96b-4b47-40b3-a7eb-bc85124ecd7a" />
* SSC II    disables on CF00 and returns FF
* Grappler+ disables on CFF0 and returns FF
* Videx     disables on CE00 and returns floating bus
* Grappler disables on CFF0 and returns floating bus
* Liron     disables on CFFE and returns floating bus
(Thanks to @retro-mike for [hardware testing](https://apple2infinitum.slack.com/archives/CPS2TG28L/p1782515158153979) of various cards)

MAME hardcodes CFFF in the apple2/e/gs motherboard emulation. To pedantically implement faithful hardware behavior, `a2bus` would need to allow cards to signal their CLRROM address range (a config u16 would suffice) and some method of returning floating bus, and then every `a2bus` device would need auditing ^_^;

This is pedantic; Apple only documents CFFF so no software should rely on the CFxx behavior.  AppleWin has [the same issue](https://github.com/AppleWin/AppleWin/issues/1075).  However there is implication for folks dumping (or disassembling) card ROMs: _do not assume it is safe to read C800...CFFF via software!_  A [naive read loop](https://groups.google.com/g/comp.sys.apple2/c/NxWOfrzaRvo/m/FTV4L3LRAgAJ) may result in a tail of junk.  A C800 ROM can contain useful data all the way through CFFF, accessible via CSxx firmware continually re-asserting IOSEL.

</details>
