### PR TITLE
cpu/nec: update carry and overflow after division based on observed HW behavior

### DIFF
--- a/src/devices/cpu/nec/necinstr.hxx
+++ b/src/devices/cpu/nec/necinstr.hxx
@@ -747,8 +747,28 @@ OP( 0xf6, i_f6pre ) { uint32_t tmp; uint32_t uresult,uresult2; int32_t result,re
 		case 0x18: m_CarryVal=(tmp!=0); tmp=(~tmp)+1; SetSZPF_Byte(tmp); PutbackRMByte(ModRM,tmp&0xff); CLK((ModRM >= 0xc0) ? 2 : 16); break; /* NEG */
 		case 0x20: uresult = Breg(AL)*tmp; Wreg(AW)=(WORD)uresult; m_CarryVal=m_OverVal=(Breg(AH)!=0); CLKM(30,30,8,36,36,12); break; /* MULU */
 		case 0x28: result = (int16_t)((int8_t)Breg(AL))*(int16_t)((int8_t)tmp); Wreg(AW)=(WORD)result; m_CarryVal=m_OverVal=(Breg(AH)!=0); CLKM(47,47,8,57,53,12); break; /* MUL */
-		case 0x30: if (tmp) DIVUB else nec_interrupt(NEC_DIVIDE_VECTOR, BRK); CLKM(25,25,11,35,31,15); break;
-		case 0x38: if (tmp) DIVB else nec_interrupt(NEC_DIVIDE_VECTOR, BRK); CLKM(43,43,17,53,49,20); break;
+		case 0x30:
+			if (tmp)
+				DIVUB
+			else
+			{
+				m_CarryVal = m_OverVal = 0;
+				nec_interrupt(NEC_DIVIDE_VECTOR, BRK);
+			}
+
+			CLKM(25,25,11,35,31,15);
+			break;
+		case 0x38:
+			if (tmp)
+				DIVB
+			else
+			{
+				m_CarryVal = m_OverVal = 0;
+				nec_interrupt(NEC_DIVIDE_VECTOR, BRK);
+			}
+
+			CLKM(43,43,17,53,49,20);
+			break;
 	}
 }
 
@@ -761,8 +781,27 @@ OP( 0xf7, i_f7pre   ) { uint32_t tmp,tmp2; uint32_t uresult,uresult2; int32_t re
 		case 0x18: m_CarryVal=(tmp!=0); tmp=(~tmp)+1; SetSZPF_Word(tmp); PutbackRMWord(ModRM,tmp&0xffff); CLK((ModRM >= 0xc0) ? 2 : 16); break; /* NEG */
 		case 0x20: uresult = Wreg(AW)*tmp; Wreg(AW)=uresult&0xffff; Wreg(DW)=((uint32_t)uresult)>>16; m_CarryVal=m_OverVal=(Wreg(DW)!=0); CLKM(30,30,12,36,36,16); break; /* MULU */
 		case 0x28: result = (int32_t)((int16_t)Wreg(AW))*(int32_t)((int16_t)tmp); Wreg(AW)=result&0xffff; Wreg(DW)=result>>16; m_CarryVal=m_OverVal=(Wreg(DW)!=0); CLKM(47,47,12,57,53,16); break; /* MUL */
-		case 0x30: if (tmp) DIVUW else nec_interrupt(NEC_DIVIDE_VECTOR, BRK); CLKM(25,25,19,35,31,23); break;
-		case 0x38: if (tmp) DIVW else nec_interrupt(NEC_DIVIDE_VECTOR, BRK); CLKM(43,43,24,53,49,28); break;
+		case 0x30:
+			if (tmp)
+				DIVUW
+			else
+			{
+				m_CarryVal = m_OverVal = 0;
+				nec_interrupt(NEC_DIVIDE_VECTOR, BRK);
+			}
+
+			CLKM(25,25,19,35,31,23);
+			break;
+		case 0x38:
+			if (tmp)
+				DIVW
+			else
+			{
+				m_CarryVal = m_OverVal = 0;
+				nec_interrupt(NEC_DIVIDE_VECTOR, BRK);
+			}
+			CLKM(43,43,24,53,49,28);
+			break;
 	}
 }
 

--- a/src/devices/cpu/nec/necmacro.h
+++ b/src/devices/cpu/nec/necmacro.h
@@ -176,6 +176,7 @@
 	uresult2 = uresult % tmp;                            \
 	uresult /= tmp;                                      \
 	bool overflow = uresult > 0xff;                      \
+	m_CarryVal = m_OverVal = !overflow;                  \
 	if (overflow)                                        \
 		nec_interrupt(NEC_DIVIDE_VECTOR, BRK);           \
 	if (!overflow || m_chip_type == V33_TYPE) {          \
@@ -189,6 +190,7 @@
 	result2 = result % (int16_t)((int8_t)tmp);           \
 	result /= (int16_t)((int8_t)tmp);                    \
 	bool overflow = result > 0x7f || result < -0x7f;     \
+	m_CarryVal = m_OverVal = !overflow;                  \
 	if (overflow)                                        \
 		nec_interrupt(NEC_DIVIDE_VECTOR, BRK);           \
 	if (!overflow || m_chip_type == V33_TYPE) {          \
@@ -202,6 +204,7 @@
 	uresult2 = uresult % tmp;                            \
 	uresult /= tmp;                                      \
 	bool overflow = uresult > 0xffff;                    \
+	m_CarryVal = m_OverVal = !overflow;                  \
 	if (overflow)                                        \
 		nec_interrupt(NEC_DIVIDE_VECTOR, BRK);           \
 	if (!overflow || m_chip_type == V33_TYPE) {          \
@@ -215,6 +218,7 @@
 	result2 = result % (int32_t)((int16_t)tmp);          \
 	result /= (int32_t)((int16_t)tmp);                   \
 	bool overflow = result > 0x7fff || result < -0x7fff; \
+	m_CarryVal = m_OverVal = !overflow;                  \
 	if (overflow)                                        \
 		nec_interrupt(NEC_DIVIDE_VECTOR, BRK);           \
 	if (!overflow || m_chip_type == V33_TYPE) {          \


### PR DESCRIPTION
On a real V20 (and presumably V30), division normally sets the carry and overflow flags, or clears them if an exception occurred (either via overflow or division by zero). As I wrote about in https://github.com/mamedev/mame/commit/f8e7909a28b8f7192b433eefafc2d11276f081f9, the S900 depends on this behavior due to a (seemingly misplaced) `jnb` following a division which will cause a crash if the branch is ever taken.