### PR TITLE
sound/cem3394.cpp: Incorporated va_vco oscillator implementation.

### DIFF
--- a/src/devices/sound/cem3394.cpp
+++ b/src/devices/sound/cem3394.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Aaron Giles
+// copyright-holders:Aaron Giles,m1macrophage
 /***************************************************************************
 
     Curtis Electromusic Specialties CEM3394 µP-Controllable Synthesizer Voice
@@ -10,12 +10,10 @@
 
 #include "emu.h"
 #include "cem3394.h"
+#include "sound/flt_rc.h"
 
-#include <algorithm>
-
-
-#define ENABLE_FILTER       1
-#define ENABLE_AC_COUPLING  1
+#include <limits>
+#include <unordered_set>
 
 
 // logging
@@ -38,13 +36,6 @@ static constexpr double TRIANGLE_VOLUME = SAWTOOTH_VOLUME * 1.27f;
 
 // external input is unknown but let's make it the same as the pulse
 static constexpr double EXTERNAL_VOLUME = PULSE_VOLUME;
-
-
-// waveform generation parameters
-#define ENABLE_PULSE        1
-#define ENABLE_TRIANGLE     1
-#define ENABLE_SAWTOOTH     1
-#define ENABLE_EXTERNAL     1
 
 
 /********************************************************************************
@@ -114,217 +105,168 @@ DEFINE_DEVICE_TYPE(CEM3394, cem3394_device, "cem3394", "CEM3394 Synthesizer Voic
 //  LIVE DEVICE
 //**************************************************************************
 
-//-------------------------------------------------
-//  cem3394_device - constructor and configuration
-//-------------------------------------------------
 
 cem3394_device::cem3394_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
-	device_t(mconfig, CEM3394, tag, owner, clock),
-	device_sound_interface(mconfig, *this),
-	m_vcf(*this, "vcf"),
-	m_stream(nullptr),
-	m_inv_sample_rate(1.0 / 48000.0),
-	m_vco_zero_freq(500.0),
-	m_filter_zero_freq(1300.0),
-	m_hpf_k(0),
-	m_values{-1}, // will be initialized in device_start()
-	m_wave_select(0),
-	m_volume(0),
-	m_mixer_internal(0),
-	m_mixer_external(0),
-	m_vco_position(0),
-	m_vco_step(0),
-	m_filter_frequency(1300),
-	m_filter_modulation(0),
-	m_filter_resonance(0),
-	m_pulse_width(0),
-	m_hpf_mem(0)
+	cem3394_device(mconfig, tag, owner, components(), input_array{})
 {
-	// configuring with the example values in the datasheet
-	configure(270E3, 2E-9, 33E-9, 4.7E-6);
 }
 
-cem3394_device &cem3394_device::configure(double r_vco, double c_vco, double c_vcf, double c_ac)
-{
+cem3394_device::cem3394_device(const machine_config &mconfig, const char *tag, device_t *owner, const components &comps, const input_array& inputs) :
+	device_t(mconfig, CEM3394, tag, owner, 0),
+	device_sound_interface(mconfig, *this),
+	m_stream_inputs(inputs),
+	m_components(comps),
 	// datasheet equation for Fout at CV = 0
-	m_vco_zero_freq = 1.3 / (5.0 * r_vco * c_vco);
-
-	// VCO can range up to pow(2, 4.0/.75) = ~40.3 * zero-voltage-freq
-	const double sample_rate = m_vco_zero_freq * pow(2, 4.0 / 0.75) * 5;
-	m_inv_sample_rate = 1.0 / sample_rate;
-
+	m_vco_zero_freq(1.3 / (5.0 * comps.r_vco * comps.c_vco)),
 	// datasheet equation for Pzcv
 	// Note that "4.3 x 10E-5" in the equation should be 4.3E-5. The surrounding
 	// text and the example walkthrough use the correct value.
-	m_filter_zero_freq = 4.3E-5 / c_vcf;
-
-	// See hpf() for more info
-	constexpr double R_AC = 11E3;  // internal AC coupling resistor
-	m_hpf_k = 1.0 - exp((-1 / (R_AC * c_ac)) * m_inv_sample_rate);
-
-	LOGMASKED(LOG_CONFIG, "CEM3394 config - vco zero freq: %f, filter zero freq: %f, sample rate: %d\n",
-			  m_vco_zero_freq, m_filter_zero_freq, int(sample_rate));
-	return *this;
-}
-
-
-//-------------------------------------------------
-//  hpf - apply AC coupling to the output of the
-//  filter, before the signal gets routed to the VCA.
-//-------------------------------------------------
-
-double cem3394_device::hpf(double input)
+	m_filter_zero_freq(4.3E-5 / comps.c_vcf),
+	m_stream(nullptr),
+	m_vco(*this, "vco"),
+	m_filt_freq(*this, "filt_freq"),
+	m_filt_fm(*this, "filt_fm"),
+	m_vcf(*this, "vcf"),
+	m_vca(*this, "vca"),
+	m_values{},
+	m_wave_select(0),
+	m_vco_frequency(500.0),
+	m_pulse_width(0),
+	m_volume(0),
+	m_mixer_internal(0),
+	m_mixer_external(0),
+	m_filter_frequency(1300),
+	m_filter_modulation(0),
+	m_filter_resonance(0)
 {
-	// The filter's output is AC-coupled to the VCA input.
-
-	// Based on the block diagram in the datasheet, the AC coupling (high-pass
-	// filtering) is implemented by subtracting a low-pass-filtered signal
-	// from the original signal.
-
-	// The capacitor of the LPF RC is attached to pin 17, whereas the resistor
-	// (11 KOhm) is internal to the chip.
-
-	// The LPF code was obtained from sound/flt_rc.cpp.
-
-	m_hpf_mem += (input - m_hpf_mem) * m_hpf_k; // low-pass filtered signal
-	return input - m_hpf_mem; // HPFed signal = signal - LPFed signal
 }
-
-
-//-------------------------------------------------
-//  sound_stream_update - generate sound to the mix
-//  buffer in mono
-//-------------------------------------------------
 
 void cem3394_device::sound_stream_update(sound_stream &stream)
 {
-	if (m_wave_select == 0 && m_mixer_external == 0)
-		LOGMASKED(LOG_VALUES, "%f V didn't cut it\n", m_values[WAVE_SELECT]);
-
-	const u64 input_mask = get_sound_requested_inputs_mask();
-	const bool streaming_cv = input_mask & 0x1fe;
-
-	// loop over samples
-	for (int sampindex = 0; sampindex < stream.samples(); sampindex++)
-	{
-		// take into account any streaming voltage inputs
-		if (streaming_cv)
-		{
-			for (int i = 1; i < INPUT_COUNT; i++)
-			{
-				if (BIT(input_mask, i))
-					set_voltage_internal(i, stream.get(i, sampindex));
-			}
-		}
-
-		// get the current VCO position and step it forward
-		double vco_position = m_vco_position;
-		m_vco_position += m_vco_step;
-
-		// clamp VCO position to a fraction
-		if (m_vco_position >= 1.0)
-			m_vco_position -= floor(m_vco_position);
-
-		// handle the pulse component
-		double result = 0;
-		if (ENABLE_PULSE && (m_wave_select & WAVE_PULSE))
-		{
-			// The datasheet mentions a "unique circuit [...] that keeps the
-			// average DC level [...] constant regardless of duty cycle". The
-			// block diagram shows the pulse signal being subtracted from the
-			// pulse width. Here, the pulse width is subtracted from the signal
-			// instead, to ensure a phase consistent with the rest of the signal.
-			if (vco_position < m_pulse_width)
-				result += (1 - m_pulse_width) * PULSE_VOLUME * m_mixer_internal;
-			else
-				result += (0 - m_pulse_width) * PULSE_VOLUME * m_mixer_internal;
-		}
-
-		// handle the sawtooth component
-		if (ENABLE_SAWTOOTH && (m_wave_select & WAVE_SAWTOOTH))
-			result += SAWTOOTH_VOLUME * m_mixer_internal * (vco_position - 0.5);
-
-		// always compute the triangle waveform which is also used for filter modulation
-		double triangle = 2.0 * vco_position;
-		if (triangle > 1.0)
-			triangle = 2.0 - triangle;
-		triangle -= 0.5;
-
-		// handle the triangle component
-		if (ENABLE_TRIANGLE && (m_wave_select & WAVE_TRIANGLE))
-			result += TRIANGLE_VOLUME * m_mixer_internal * triangle;
-
-		// convert from [-0.5, 0.5] to [-1, 1]
-		result *= 2;
-
-		// compute extension input (for Bally/Sente this is the noise)
-		if (ENABLE_EXTERNAL && BIT(input_mask, AUDIO_INPUT))
-			result += EXTERNAL_VOLUME * m_mixer_external * stream.get(AUDIO_INPUT, sampindex);
-
-		// compute the modulated filter frequency and apply the filter
-		// modulation tracks the VCO triangle
-		if (ENABLE_FILTER)
-		{
-			m_vcf->set_fixed_freq_cv(m_filter_frequency * (1 + m_filter_modulation * triangle));
-			m_vcf->set_fixed_res_cv(m_filter_resonance);
-			result = m_vcf->process_sample(result);
-		}
-
-		// apply AC coupling
-		if (ENABLE_AC_COUPLING)
-			result = hpf(result);
-
-		// write the sample
-		stream.put(0, sampindex, result * m_volume);
-	}
+	stream.copy(0, 0);
 }
-
-
-//-------------------------------------------------
-//  device_start - device-specific startup
-//-------------------------------------------------
 
 void cem3394_device::device_add_mconfig(machine_config &config)
 {
-	VA_LPF4(config, m_vcf).configure_drive(1.0);
+	const std::unordered_set<int> SUPPORTED_STREAM_INPUTS =
+	{
+		AUDIO_INPUT, FILTER_FREQUENCY, FINAL_GAIN,
+	};
+	for (int i = 0; i < m_stream_inputs.size(); ++i)
+	{
+		if (m_stream_inputs[i] != nullptr && !SUPPORTED_STREAM_INPUTS.contains(i))
+			fatalerror("%s unsupported streaming input: %d\n", tag(), i);
+	}
 
-	// According to the datasheet, the filter maintains the apparent loudness
-	// constant as resonance increases. The value below was selected by trial
-	// and error, to qualitatively match the preceding statement.
-	m_vcf->configure_bass_gain_comp(0.2);
+	// Set up the VCO.
+	// Route gains will be adjusted in update_mix().
+	VA_VCO(config, m_vco)
+		.configure_pulse_from_tri(true)
+		.configure_pulse_dc_comp(true)
+		.add_route(va_vco_device::OUTPUT_RAMP, m_vcf, 1.0, va_lpf4_device::INPUT_AUDIO)
+		.add_route(va_vco_device::OUTPUT_PULSE, m_vcf, 1.0, va_lpf4_device::INPUT_AUDIO)
+		.add_route(va_vco_device::OUTPUT_TRIANGLE, m_vcf, 1.0, va_lpf4_device::INPUT_AUDIO)
+		.add_route(va_vco_device::OUTPUT_TRIANGLE, m_filt_fm, 1.0, va_vca_device::INPUT_AUDIO);
+
+	// Set up the external input.
+	if (m_stream_inputs[AUDIO_INPUT] != nullptr)
+	{
+		// Route gain will be adjusted in update_mix().
+		m_stream_inputs[AUDIO_INPUT]->add_route(0, m_vcf, 1.0, va_lpf4_device::INPUT_AUDIO);
+	}
+
+	// Set up frequency control.
+	device_sound_interface *filt_freq = nullptr;
+	if (m_stream_inputs[FILTER_FREQUENCY] != nullptr)
+	{
+		m_stream_inputs[FILTER_FREQUENCY]->add_route(0, "cv2filtfreq", 1.0);
+		filt_freq = &VA_LAMBDA(config, "cv2filtfreq", [this] (float cv) { return stream_op_filter_freq(cv); });
+	}
+	else
+	{
+		filt_freq = &VA_CONST(config, m_filt_freq);
+	}
+
+	// When the filter's cutoff frequency is modulated, its frequency is:
+	//   filt_freq * (1 + filt_mod_amount * triangle) -- triangle's range: [-0.5, 0.5]
+	//   = filt_freq + filt_freq * filt_mod_amount * 0.5 * triangle  -- triangle's range: [-1, 1].
+	// The two terms in the equation above are summed in m_vcf's INPUT_FREQ node.
+
+	// First term:
+	filt_freq->add_route(0, m_vcf, 1.0, va_lpf4_device::INPUT_FREQ);
+
+	// Second term, computed by the m_filt_fm VCA:
+	// - The triangle wave (range: [-1, 1]) is applied to m_filt_fm's INPUT_AUDIO
+	//   (see VCO configuration above).
+	// - The route gain of the above is set to filt_mod_amount * 0.5 (see update_mix()).
+	// - filt_freq is applied to INPUT_GAIN (see right below).
+	// The above make m_filt_fm's output: filt_freq * filt_mod_amount * 0.5 * triangle
+	filt_freq->add_route(0, m_filt_fm, 1.0, va_vca_device::INPUT_GAIN);
+	VA_VCA(config, m_filt_fm).add_route(0, m_vcf, 1.0, va_lpf4_device::INPUT_FREQ);
+
+	// Set up the VCF.
+	VA_LPF4(config, m_vcf)
+		.configure_drive(1.0)
+		// According to the datasheet, the filter maintains the apparent loudness
+		// constant as resonance increases. The value below was selected by trial
+		// and error, to qualitatively match the preceding statement.
+		.configure_bass_gain_comp(0.2)
+		.add_route(0, "ac_couple", 1.0);
+
+	// Set up AC coupling.
+	constexpr double R_AC = 11E3;  // internal AC coupling resistor
+	FILTER_RC(config, "ac_couple")
+		.set_rc(filter_rc_device::HIGHPASS, R_AC, 0, 0, m_components.c_ac)
+		.add_route(0, m_vca, 1.0, va_vca_device::INPUT_AUDIO);
+
+	// Set up the VCA.
+	if (m_stream_inputs[FINAL_GAIN] != nullptr)
+	{
+		m_stream_inputs[FINAL_GAIN]->add_route(0, "cv2ampgain", 1.0);
+		VA_LAMBDA(config, "cv2ampgain", [this] (float cv) { return stream_op_amp_gain(cv); })
+			.add_route(0, m_vca, 1.0, va_vca_device::INPUT_GAIN);
+	}
+	VA_VCA(config, m_vca).add_route(0, *this, 1.0);
 }
 
 void cem3394_device::device_start()
 {
-	// compute a sample rate
-	const int sample_rate = int(round(1.0 / m_inv_sample_rate));
-	m_vcf->configure_streamless(sample_rate);
-
 	// allocate stream channels
-	m_stream = stream_alloc(get_sound_requested_inputs(), 1, sample_rate);
+	m_stream = stream_alloc(1, 1, machine().sample_rate());
 
 	save_item(NAME(m_values));
+
 	save_item(NAME(m_wave_select));
+	save_item(NAME(m_vco_frequency));
+	save_item(NAME(m_pulse_width));
 
 	save_item(NAME(m_volume));
 	save_item(NAME(m_mixer_internal));
 	save_item(NAME(m_mixer_external));
 
-	save_item(NAME(m_vco_position));
-	save_item(NAME(m_vco_step));
-
 	save_item(NAME(m_filter_frequency));
 	save_item(NAME(m_filter_modulation));
 	save_item(NAME(m_filter_resonance));
+}
 
-	save_item(NAME(m_pulse_width));
-
-	save_item(NAME(m_hpf_mem));
-
+void cem3394_device::device_reset()
+{
 	// Ensures that m_values, and member variables derived from m_values, are
 	// properly initialized. Index 0 is unused.
 	for (int i = 1; i < INPUT_COUNT; i++)
-		set_voltage_internal(i, 0);
+	{
+		const double value = m_values[i];
+
+		// Skip early exits in set_voltage*() functions. Force all calculations.
+		m_values[i] = std::numeric_limits<double>::quiet_NaN();
+
+		if (m_stream_inputs[i] != nullptr)
+			set_voltage_internal(i, value);
+		else
+			set_voltage(i, value);
+	}
+
+	update_mix();
 }
 
 
@@ -364,8 +306,6 @@ sound_stream::sample_t cem3394_device::compute_db_volume(double voltage)
 
 void cem3394_device::set_voltage_internal(int input, double voltage)
 {
-	double temp;
-
 	// don't do anything if no change
 	if (voltage == m_values[input])
 		return;
@@ -376,9 +316,8 @@ void cem3394_device::set_voltage_internal(int input, double voltage)
 	{
 		// frequency varies from -4.0 to +4.0, at 0.75V/octave
 		case VCO_FREQUENCY:
-			temp = m_vco_zero_freq * pow(2.0, -voltage * (1.0 / 0.75));
-			m_vco_step = temp * m_inv_sample_rate;
-			LOGMASKED(LOG_CONTROL_CHANGES, "VCO_FREQ=%6.3fV -> freq=%f\n", voltage, temp);
+			m_vco_frequency = m_vco_zero_freq * pow(2.0, -voltage * (1.0 / 0.75));
+			LOGMASKED(LOG_CONTROL_CHANGES, "VCO_FREQ=%6.3fV -> freq=%f\n", voltage, m_vco_frequency);
 			break;
 
 		// Wave select chooses between triangle, sawtooth, both, or neither.
@@ -484,12 +423,46 @@ void cem3394_device::set_voltage_internal(int input, double voltage)
 }
 
 
+void cem3394_device::update_mix()
+{
+	const double tri_gain = (m_wave_select & WAVE_TRIANGLE) ? (TRIANGLE_VOLUME * m_mixer_internal) : 0;
+	m_vco->set_route_gain(va_vco_device::OUTPUT_TRIANGLE, m_vcf, va_lpf4_device::INPUT_AUDIO, tri_gain);
+
+	const double saw_gain = (m_wave_select & WAVE_SAWTOOTH) ? (SAWTOOTH_VOLUME * m_mixer_internal) : 0;
+	m_vco->set_route_gain(va_vco_device::OUTPUT_RAMP, m_vcf, va_lpf4_device::INPUT_AUDIO, saw_gain);
+
+	const double pulse_gain = (m_wave_select & WAVE_PULSE) ? (PULSE_VOLUME * m_mixer_internal) : 0;
+	m_vco->set_route_gain(va_vco_device::OUTPUT_PULSE, m_vcf, va_lpf4_device::INPUT_AUDIO, pulse_gain);
+
+	// See m_filt_fm setup in device_add_mconfig().
+	const double mod_amount = 0.5 * m_filter_modulation;
+	m_vco->set_route_gain(va_vco_device::OUTPUT_TRIANGLE, m_filt_fm, va_vca_device::INPUT_AUDIO, mod_amount);
+
+	if (m_stream_inputs[AUDIO_INPUT] != nullptr)
+	{
+		const double ext_gain = EXTERNAL_VOLUME * m_mixer_external;
+		m_stream_inputs[AUDIO_INPUT]->set_route_gain(0, m_vcf, va_lpf4_device::INPUT_AUDIO, ext_gain);
+	}
+}
+
+float cem3394_device::stream_op_filter_freq(float voltage)
+{
+	set_voltage_internal(FILTER_FREQUENCY, voltage);
+	return m_filter_frequency;
+}
+
+float cem3394_device::stream_op_amp_gain(float voltage)
+{
+	set_voltage_internal(FINAL_GAIN, voltage);
+	return m_volume;
+}
+
 void cem3394_device::set_voltage(int input, double voltage)
 {
 	if (input < 1 || input >= INPUT_COUNT)
 		fatalerror("%s - Invalid input to set_voltage(): %d\n", tag(), input);
 
-	if (BIT(get_sound_requested_inputs_mask(), input))
+	if (m_stream_inputs[input] != nullptr)
 		fatalerror("%s - Cannot call set_voltage(%d, ...). %d is a streaming input.\n", tag(), input, input);
 
 	if (voltage == m_values[input])
@@ -497,6 +470,31 @@ void cem3394_device::set_voltage(int input, double voltage)
 
 	m_stream->update();
 	set_voltage_internal(input, voltage);
+
+	switch (input)
+	{
+		case VCO_FREQUENCY:
+			m_vco->set_freq_ctrl(m_vco_frequency);
+			break;
+		case MODULATION_AMOUNT:
+		case WAVE_SELECT:
+		case MIXER_BALANCE:
+			update_mix();
+			break;
+		case PULSE_WIDTH:
+			m_vco->set_pw_ctrl(m_pulse_width);
+			update_mix();
+			break;
+		case FILTER_RESONANCE:
+			m_vcf->set_fixed_res_cv(m_filter_resonance);
+			break;
+		case FILTER_FREQUENCY:
+			m_filt_freq->set_value(m_filter_frequency);
+			break;
+		case FINAL_GAIN:
+			m_vca->set_fixed_gain_cv(m_volume);
+			break;
+	}
 }
 
 double cem3394_device::get_voltage(int input)
@@ -504,7 +502,7 @@ double cem3394_device::get_voltage(int input)
 	if (input < 1 || input >= INPUT_COUNT)
 		fatalerror("%s - Invalid input to get_voltage(): %d\n", tag(), input);
 
-	if (BIT(get_sound_requested_inputs_mask(), input))
+	if (m_stream_inputs[input] != nullptr)
 		m_stream->update();
 
 	return m_values[input];

--- a/src/devices/sound/cem3394.h
+++ b/src/devices/sound/cem3394.h
@@ -5,7 +5,10 @@
 
 #pragma once
 
+#include "sound/va_ops.h"
+#include "sound/va_vca.h"
 #include "sound/va_vcf.h"
+#include "sound/va_vco.h"
 
 class cem3394_device : public device_t, public device_sound_interface
 {
@@ -27,20 +30,30 @@ public:
 		INPUT_COUNT
 	};
 
-	cem3394_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0) ATTR_COLD;
+	// external component values
+	struct components
+	{
+		// The default values below are the ones used in the datasheet.
+		// Pin 1 - Resistor to VEE. Sets reference current for the VCO internals.
+		double r_vco = 270E3;
+		// Pin 4 - VCO timing capacitor.
+		double c_vco = 2E-9;
+		// Pin 12 (or 13, or 14, they should be equal) - VCF capacitor.
+		double c_vcf = 33E-9;
+		// Pin 17 - AC-coupling capacitor on the VCF output.
+		double c_ac = 4.7E-6;
+	};
 
-	// The constructor will initialize components values to those recommended
-	// in the datasheet. configure() can be used to change those.
-	// r_vco: Pin 1 - Resistor to VEE. Sets reference current for the VCO internals.
-	// c_vco: Pin 4 - VCO timing capacitor.
-	// c_vcf: Pin 12 (or 13, or 14, they should be equal) - VCF capacitor.
-	// c_ac: Pin 17 - AC-coupling capacitor on the VCF output.
-	cem3394_device &configure(double r_vco, double c_vco, double c_vcf, double c_ac) ATTR_COLD;
+	using input_array = std::array<device_sound_interface *, INPUT_COUNT>;
+
+	cem3394_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0) ATTR_COLD;
+	cem3394_device(const machine_config &mconfig, const char *tag, device_t *owner, const components &comps, const input_array& inputs) ATTR_COLD;
 
 protected:
 	// device-level overrides
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
 
 	// sound stream update overrides
 	virtual void sound_stream_update(sound_stream &stream) override;
@@ -70,37 +83,39 @@ private:
 	sound_stream::sample_t compute_db_volume(double voltage);
 
 	void set_voltage_internal(int input, double voltage);
+	void update_mix();
 
-	double hpf(double input);
-
-	required_device<va_lpf4_device> m_vcf;
+	float stream_op_filter_freq(float voltage);
+	float stream_op_amp_gain(float voltage);
 
 	// device configuration, not needed in save state
+	const input_array m_stream_inputs;// streaming inputs
+	const components m_components;    // external components
+	const double m_vco_zero_freq;     // frequency of VCO at 0.0V
+	const double m_filter_zero_freq;  // frequency of filter at 0.0V
 	sound_stream *m_stream;           // our stream
-	double m_inv_sample_rate;         // 1/current sample rate
-	double m_vco_zero_freq;           // frequency of VCO at 0.0V
-	double m_filter_zero_freq;        // frequency of filter at 0.0V
-	double m_hpf_k;                   // RC filter coefficient for AC coupling
+
+	required_device<va_vco_device> m_vco;
+	optional_device<va_const_device> m_filt_freq;
+	required_device<va_vca_device> m_filt_fm;
+	required_device<va_lpf4_device> m_vcf;
+	required_device<va_vca_device> m_vca;
 
 	// device state
 
 	double m_values[INPUT_COUNT];     // raw values of registers
+
 	u8 m_wave_select;                 // flags which waveforms are enabled
+	double m_vco_frequency;           // current VCO frequency
+	double m_pulse_width;             // fractional pulse width
 
 	double m_volume;                  // linear overall volume (0-1)
 	double m_mixer_internal;          // linear internal volume (0-1)
 	double m_mixer_external;          // linear external volume (0-1)
 
-	double m_vco_position;            // current VCO frequency position (always < 1.0)
-	double m_vco_step;                // per-sample VCO step
-
 	double m_filter_frequency;        // baseline filter frequency
 	double m_filter_modulation;       // depth of modulation (up to 1.0)
 	double m_filter_resonance;        // depth of modulation (up to 1.0)
-
-	double m_pulse_width;             // fractional pulse width
-
-	double m_hpf_mem;                 // AC coupling filter memory
 };
 
 DECLARE_DEVICE_TYPE(CEM3394, cem3394_device)

--- a/src/devices/sound/va_ops.cpp
+++ b/src/devices/sound/va_ops.cpp
@@ -128,6 +128,33 @@ void va_comparator_device::sound_stream_update(sound_stream &stream)
 }
 
 
+va_lambda_device::va_lambda_device(const machine_config &mconfig, const char *tag, device_t *owner, func_t func)
+	: device_t(mconfig, VA_LAMBDA, tag, owner, 0)
+	, device_sound_interface(mconfig, *this)
+	, m_stream(nullptr)
+	, m_func(func)
+{
+}
+
+va_lambda_device::va_lambda_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: va_lambda_device(mconfig, tag, owner, [] (float x) { return x; })
+{
+}
+
+void va_lambda_device::device_start()
+{
+	m_stream = stream_alloc(1, 1, SAMPLE_RATE_INPUT_ADAPTIVE);
+}
+
+void va_lambda_device::sound_stream_update(sound_stream &stream)
+{
+	const int n = stream.samples();
+	for (int i = 0; i < n; ++i)
+		stream.put(0, i, m_func(stream.get(0, i)));
+}
+
+
 DEFINE_DEVICE_TYPE(VA_CONST, va_const_device, "va_const", "Constant value stream")
 DEFINE_DEVICE_TYPE(VA_SCALE_OFFSET, va_scale_offset_device, "va_scale_offset", "Stream scale and offset")
 DEFINE_DEVICE_TYPE(VA_COMPARATOR, va_comparator_device, "va_comparator", "Stream comparator")
+DEFINE_DEVICE_TYPE(VA_LAMBDA, va_lambda_device, "va_lambda", "Generic computation")

--- a/src/devices/sound/va_ops.h
+++ b/src/devices/sound/va_ops.h
@@ -14,6 +14,7 @@
 DECLARE_DEVICE_TYPE(VA_CONST, va_const_device)
 DECLARE_DEVICE_TYPE(VA_SCALE_OFFSET, va_scale_offset_device)
 DECLARE_DEVICE_TYPE(VA_COMPARATOR, va_comparator_device)
+DECLARE_DEVICE_TYPE(VA_LAMBDA, va_lambda_device)
 
 
 // Outputs a constant value to a stream. This is meant for things like
@@ -115,5 +116,23 @@ private:
 	bool m_state;
 };
 
+
+// Processes each sample in the input stream with an arbitrary function.
+class va_lambda_device : public device_t, public device_sound_interface
+{
+public:
+	using func_t = std::function<float (float)>;
+
+	va_lambda_device(const machine_config &mconfig, const char *tag, device_t *owner, func_t func) ATTR_COLD;
+	va_lambda_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0) ATTR_COLD;
+
+protected:
+	void device_start() override ATTR_COLD;
+	void sound_stream_update(sound_stream &stream) override;
+
+private:
+	sound_stream *m_stream;
+	func_t m_func;
+};
 
 #endif  // MAME_SOUND_VA_OPS_H

--- a/src/mame/bally/sente6vb.cpp
+++ b/src/mame/bally/sente6vb.cpp
@@ -140,12 +140,21 @@ void sente6vb_device::device_add_mconfig(machine_config &config)
 	filter_rc_device &ac_noise(FILTER_RC(config, "ac_noise"));
 	ac_noise.set_rc(filter_rc_device::HIGHPASS, RES_K(68) + RES_K(1), 0, 0, CAP_U(2.2)); // R19, R20, C115
 
+	cem3394_device::components comps =
+	{
+		.r_vco = RES_K(301),   // R1
+		.c_vco = CAP_U(0.002), // C1
+		.c_vcf = CAP_U(0.033), // C11
+		.c_ac = CAP_U(10),     // C3
+	};
+
+	cem3394_device::input_array inputs{};
+	inputs[cem3394_device::AUDIO_INPUT] = &ac_noise;
+
 	for (auto &cem_device : m_cem_device)
 	{
-		CEM3394(config, cem_device);
-		cem_device->configure(RES_K(301), CAP_U(0.002), CAP_U(0.033), CAP_U(10)); // R1, C1, C11, C3 on voice 0 (U1)
+		CEM3394(config, cem_device, comps, inputs);
 		cem_device->add_route(ALL_OUTPUTS, "mono", 0.50);
-		ac_noise.add_route(0, *cem_device, 1.0);
 	}
 }
 

--- a/src/mame/sequential/sixtrak.cpp
+++ b/src/mame/sequential/sixtrak.cpp
@@ -857,17 +857,23 @@ void sixtrak_state::sixtrak_common(machine_config &config, device_sound_interfac
 
 	for (int i = 0; i < 6; ++i)
 	{
-		noise.add_route(0, m_voices[i], 1.0, cem3394_device::AUDIO_INPUT);
-
 		VA_RC_EG(config, m_gain_rc[i]).set_r(RES_M(1));
-		m_gain_rc[i]->add_route(0, m_voices[i], 1.0, cem3394_device::FINAL_GAIN);
-
 		VA_RC_EG(config, m_freq_rc[i]).set_r(RES_M(1));
-		m_freq_rc[i]->add_route(0, m_voices[i], 1.0, cem3394_device::FILTER_FREQUENCY);
 
-		CEM3394(config, m_voices[i]);
-		const double c_vco = C_VCO + C_VCO * C_VCO_JITTER[i] * 0.025;  // +/- 2.5%.
-		m_voices[i]->configure(RES_K(301), c_vco, CAP_U(0.033), CAP_U(10));
+		cem3394_device::components comps =
+		{
+			.r_vco = RES_K(301),
+			.c_vco = C_VCO + C_VCO * C_VCO_JITTER[i] * 0.025,  // +/- 2.5%.
+			.c_vcf = CAP_U(0.033),
+			.c_ac = CAP_U(10),
+		};
+
+		cem3394_device::input_array voice_inputs{};
+		voice_inputs[cem3394_device::AUDIO_INPUT] = &noise;
+		voice_inputs[cem3394_device::FINAL_GAIN] = m_gain_rc[i].target();
+		voice_inputs[cem3394_device::FILTER_FREQUENCY] = m_freq_rc[i].target();
+
+		CEM3394(config, m_voices[i], comps, voice_inputs);
 		m_voices[i]->add_route(0, "voicemixer", CEM3394_IOUT_MAX);
 	}
 


### PR DESCRIPTION
Improvements:
* Reduces aliasing.
  * Using the band-limitted implementation in va_vco.
* Corrects some patches.
  * Deriving the pulse waveform from a triangle (like the real CEM3394) rather than a saw (previous implementation).
  * Noticeable on patches that mix the pulse waveform with others. For example, patches 11, 12, 28 on the `sixtrak`, and the bassline in `stocker`, to name a few.

Also:
* Fixed parameter initialization at startup.
* Moved external component configuration to the constructor, since it is now required in `device_add_mconfig()`.

This implementation treats the CEM3394 like a "composite" sound device, consisting of an entire sound processing pipeline. That's similar to how the voice circuits of the DMX and prophet5 are emulated.

----
An alternative implementation can be found in PR #15623.

That one splits out the core VCO functionality into a "streamless" device that can be used as a building block in other `device_sound_interface` classes. This was one option discussed in #14904. It is also easy to convert this to one of the other variants discussed in #14904:
* Turn `va_vco_streamless_device` into a non-device class which will be used via composition.
* Turn `va_vco_streamless_device` into an interface that will be used via inheritance. Note that this won't work for devices that include multiple oscillators, unless the oscillator state is moved to a struct which is passed around across all functions.

----
I personally prefer the approach I've implemented in this PR.

It is more flexible in using other `device_sound_interface` devices, without having to extract the "streamless" part. In some cases, performance is a bit worse (e.g. stocker @ 96Khz: 640% vs 670%, sixtrak @ 96KHz 960% vs 1040%), though in others it is a wash (e.g. sixtrak at default sample rate) because it is easy to restrict upsampling to specific stages.

But if you prefer the alternative approach, or one of its variants mentioned above, let me know.

EDIT: Of course, no decision is binding. It is always possible to change strategies in the future.