### PR TITLE
video/mc6845.cpp: hpixels_per_column must be non-zero

### DIFF
--- a/src/devices/video/mc6845.cpp
+++ b/src/devices/video/mc6845.cpp
@@ -46,6 +46,7 @@
 #define LOG_SETUP   (1U << 1)
 #define LOG_REGS    (1U << 2)
 #define LOG_CONF    (1U << 3)
+#define LOG_RAW     (1U << 4) // a set_raw friendly version of CONF
 
 //#define VERBOSE (LOG_SETUP|LOG_CONF|LOG_REGS)
 //#define LOG_OUTPUT_FUNC osd_printf_info
@@ -55,22 +56,23 @@
 #define LOGSETUP(...)   LOGMASKED(LOG_SETUP,  __VA_ARGS__)
 #define LOGREGS(...)    LOGMASKED(LOG_REGS,  __VA_ARGS__)
 #define LOGCONF(...)    LOGMASKED(LOG_CONF,  __VA_ARGS__)
+#define LOGRAW(...)     LOGMASKED(LOG_RAW,  __VA_ARGS__)
 
 DEFINE_DEVICE_TYPE(MC6845,   mc6845_device,   "mc6845",   "Motorola MC6845 CRTC")
 DEFINE_DEVICE_TYPE(MC6845_1, mc6845_1_device, "mc6845_1", "Motorola MC6845-1 CRTC")
 DEFINE_DEVICE_TYPE(R6545_1,  r6545_1_device,  "r6545_1",  "Rockwell R6545-1 CRTC")
 DEFINE_DEVICE_TYPE(C6545_1,  c6545_1_device,  "c6545_1",  "C6545-1 CRTC")
-DEFINE_DEVICE_TYPE(HD6845S,  hd6845s_device,  "hd6845s",  "Hitachi HD6845S CRTC") // same as HD46505S
 DEFINE_DEVICE_TYPE(SY6545_1, sy6545_1_device, "sy6545_1", "Synertek SY6545-1 CRTC")
 DEFINE_DEVICE_TYPE(SY6845E,  sy6845e_device,  "sy6845e",  "Synertek SY6845E CRTC")
-DEFINE_DEVICE_TYPE(HD6345,   hd6345_device,   "hd6345",   "Hitachi HD6345 CRTC-II")
 DEFINE_DEVICE_TYPE(AMS40489, ams40489_device, "ams40489", "AMS40489 ASIC (CRTC)")
+DEFINE_DEVICE_TYPE(HD6845S,  hd6845s_device,  "hd6845s",  "Hitachi HD6845S CRTC") // same as HD46505S
+DEFINE_DEVICE_TYPE(HD6345,   hd6345_device,   "hd6345",   "Hitachi HD6345 CRTC-II")
 
 
 /* mode macros */
 #define MODE_TRANSPARENT            ((m_mode_control & 0x08) != 0)
 #define MODE_TRANSPARENT_PHI2       ((m_mode_control & 0x88) == 0x88)
-/* FIXME: not supported yet */
+// TODO: not supported yet
 #define MODE_TRANSPARENT_BLANK      ((m_mode_control & 0x88) == 0x08)
 #define MODE_UPDATE_STROBE          ((m_mode_control & 0x40) != 0)
 #define MODE_CURSOR_SKEW            ((m_mode_control & 0x20) != 0)
@@ -268,119 +270,6 @@ void mc6845_device::register_w(uint8_t data)
 }
 
 
-void hd6345_device::address_w(uint8_t data)
-{
-	m_register_address_latch = data & 0x3f;
-}
-
-
-uint8_t hd6345_device::register_r()
-{
-	uint8_t ret = 0;
-
-	switch (m_register_address_latch)
-	{
-		case 0x0c:  ret = (m_disp_start_addr  >> 8) & 0xff; break;
-		case 0x0d:  ret = (m_disp_start_addr  >> 0) & 0xff; break;
-		case 0x0e:  ret = (m_cursor_addr      >> 8) & 0xff; break;
-		case 0x0f:  ret = (m_cursor_addr      >> 0) & 0xff; break;
-		case 0x10:  ret = (m_light_pen_addr   >> 8) & 0xff; m_light_pen_latched = false; break;
-		case 0x11:  ret = (m_light_pen_addr   >> 0) & 0xff; m_light_pen_latched = false; break;
-		case 0x12:  ret = m_disp2_pos; break;
-		case 0x13:  ret = (m_disp2_start_addr >> 8) & 0xff; break;
-		case 0x14:  ret = (m_disp2_start_addr >> 0) & 0xff; break;
-		case 0x15:  ret = m_disp3_pos; break;
-		case 0x16:  ret = (m_disp3_start_addr >> 8) & 0xff; break;
-		case 0x17:  ret = (m_disp3_start_addr >> 0) & 0xff; break;
-		case 0x18:  ret = m_disp4_pos; break;
-		case 0x19:  ret = (m_disp4_start_addr >> 8) & 0xff; break;
-		case 0x1a:  ret = (m_disp4_start_addr >> 0) & 0xff; break;
-		case 0x1b:  ret = m_vert_sync_pos_adj; break;
-		case 0x1c: /* TODO: light pen raster */ break;
-		case 0x1d:  ret = m_smooth_scroll_ras; break;
-		case 0x1f: /* TODO: status */ break;
-		case 0x21:  ret = m_mem_width_offs; break;
-		case 0x24:  ret = (m_cursor2_addr     >> 8) & 0xff; break;
-		case 0x25:  ret = (m_cursor2_addr     >> 0) & 0xff; break;
-		case 0x26:  ret = m_cursor_width; break;
-		case 0x27:  ret = m_cursor2_width; break;
-	}
-
-	return ret;
-}
-
-void hd6345_device::register_w(uint8_t data)
-{
-	LOGREGS("%s:HD6345 reg 0x%02x = 0x%02x\n", machine().describe_context(), m_register_address_latch, data);
-
-	/* Omits LOGSETUP logs of cursor registers as they tend to be spammy */
-	if (m_register_address_latch < 0x28 &&
-		m_register_address_latch != 0x0a && m_register_address_latch != 0x0a &&
-		m_register_address_latch != 0x0e && m_register_address_latch != 0x0f)
-		LOGSETUP(" * %02x <= %3u [%02x] %s\n", m_register_address_latch, data, data, std::array<char const *, 40>
-		 {{ "R0 - Horizontal Total",            "R1 - Horizontal Displayed",        "R2 - Horizontal Sync Position",
-			"R3 - Sync Width",                  "R4 - Vertical Total",              "R5 - Vertical Total Adjust",
-			"R6 - Vertical Displayed",          "R7 - Vertical Sync Position",      "R8 - Interlace Mode & Skew",
-			"R9 - Maximum Raster Address",      "R10 - Cursor 1 Start",             "R11 - Cursor 1 End",
-			"R12 - Screen 1 Start Address (H)", "R13 - Screen 1 Start Address (L)", "R14 - Cursor 1 Address (H)",
-			"R15 - Cursor 1 Address (L)",       "R16 - Light Pen (H)",              "R17 - Light Pen (L)",
-			"R18 - Screen 2 Start Position",    "R19 - Screen 2 Start Address (H)", "R20 - Screen 2 Start Address (L)",
-			"R21 - Screen 3 Start Position",    "R22 - Screen 3 Start Address (H)", "R23 - Screen 3 Start Address (L)",
-			"R24 - Screen 4 Start Position",    "R25 - Screen 4 Start Address (H)", "R26 - Screen 4 Start Address (L)",
-			"R27 - Vertical Sync Position Adj", "R28 - Light Pen Raster",           "R29 - Smooth Scrolling",
-			"R30 - Control 1",                  "R31 - Control 2",                  "R32 - Control 3",
-			"R33 - Memory Width Offset",        "R34 - Cursor 2 Start",             "R35 - Cursor 2 End",
-			"R36 - Cursor 2 Address (H)",       "R37 - Cursor 2 Address (L)",       "R38 - Cursor 1 Width",
-			"R39 - Cursor 2 Width" }}[(m_register_address_latch & 0x3f)]);
-
-	switch (m_register_address_latch)
-	{
-		case 0x00:  m_horiz_char_total =   data & 0xff; break;
-		case 0x01:  m_horiz_disp       =   data & 0xff; break;
-		case 0x02:  m_horiz_sync_pos   =   data & 0xff; break;
-		case 0x03:  m_sync_width       =   data & 0xff; break;
-		case 0x04:  m_vert_char_total  =   data & 0xff; break;
-		case 0x05:  m_vert_total_adj   =   data & 0x1f; break;
-		case 0x06:  m_vert_disp        =   data & 0xff; break;
-		case 0x07:  m_vert_sync_pos    =   data & 0xff; break;
-		case 0x08:  m_mode_control     =   data & 0xf3; break;
-		case 0x09:  m_max_ras_addr     =   data & 0x1f; break;
-		case 0x0a:  m_cursor_start_ras =   data & 0x7f; break;
-		case 0x0b:  m_cursor_end_ras   =   data & 0x1f; break;
-		case 0x0c:  m_disp_start_addr  = ((data & 0x3f) << 8) | (m_disp_start_addr & 0x00ff); break;
-		case 0x0d:  m_disp_start_addr  = ((data & 0xff) << 0) | (m_disp_start_addr & 0xff00); break;
-		case 0x0e:  m_cursor_addr      = ((data & 0x3f) << 8) | (m_cursor_addr & 0x00ff); break;
-		case 0x0f:  m_cursor_addr      = ((data & 0xff) << 0) | (m_cursor_addr & 0xff00); break;
-		case 0x10: /* read-only */ break;
-		case 0x11: /* read-only */ break;
-		case 0x12:  m_disp2_pos         =   data & 0xff; break;
-		case 0x13:  m_disp2_start_addr  = ((data & 0x3f) << 8) | (m_disp2_start_addr & 0x00ff); break;
-		case 0x14:  m_disp2_start_addr  = ((data & 0xff) << 0) | (m_disp2_start_addr & 0xff00); break;
-		case 0x15:  m_disp3_pos         =   data & 0xff; break;
-		case 0x16:  m_disp3_start_addr  = ((data & 0x3f) << 8) | (m_disp3_start_addr & 0x00ff); break;
-		case 0x17:  m_disp3_start_addr  = ((data & 0xff) << 0) | (m_disp3_start_addr & 0xff00); break;
-		case 0x18:  m_disp4_pos         =   data & 0xff; break;
-		case 0x19:  m_disp4_start_addr  = ((data & 0x3f) << 8) | (m_disp4_start_addr & 0x00ff); break;
-		case 0x1a:  m_disp4_start_addr  = ((data & 0xff) << 0) | (m_disp4_start_addr & 0xff00); break;
-		case 0x1b:  m_vert_sync_pos_adj =   data & 0x1f; break;
-		case 0x1c: /* read-only */ break;
-		case 0x1d:  m_smooth_scroll_ras =   data & 0x1f; break;
-		case 0x1e:  m_control1          =   data & 0xff; break;
-		case 0x1f:  m_control2          =   data & 0xf8; break;
-		case 0x20:  m_control3          =   data & 0xfe; break;
-		case 0x21:  m_mem_width_offs    =   data & 0xff; break;
-		case 0x22:  m_cursor2_start_ras =   data & 0x7f; break;
-		case 0x23:  m_cursor2_end_ras   =   data & 0x1f; break;
-		case 0x24:  m_cursor2_addr      = ((data & 0x3f) << 8) | (m_cursor2_addr & 0x00ff); break;
-		case 0x25:  m_cursor2_addr      = ((data & 0xff) << 0) | (m_cursor2_addr & 0xff00); break;
-		case 0x26:  m_cursor_width      =   data & 0xff; break;
-		case 0x27:  m_cursor2_width     =   data & 0xff; break;
-	}
-
-	recompute_parameters(false);
-}
-
-
 int mc6845_device::de_r()
 {
 	return m_de;
@@ -485,6 +374,7 @@ void mc6845_device::recompute_parameters(bool postload)
 
 			LOGCONF("M6845 config screen: HTOTAL: %d  VTOTAL: %d  MAX_X: %d  MAX_Y: %d  HSYNC: %d-%d  VSYNC: %d-%d  Freq: %ffps\n",
 				horiz_pix_total, vert_pix_total, max_visible_x, max_visible_y, hsync_on_pos, hsync_off_pos - 1, vsync_on_pos, vsync_off_pos - 1, refresh.as_hz());
+			LOGRAW("screen.set_raw(%lu, %d, 0, %d, %d, 0, %d);\n", this->clock() * m_hpixels_per_column, horiz_pix_total, max_visible_x + 1, vert_pix_total, max_visible_y + 1);
 
 			if (has_screen())
 				screen().configure(horiz_pix_total, vert_pix_total, visarea, refresh.as_attoseconds());
@@ -1127,6 +1017,50 @@ void mc6845_device::device_start()
 }
 
 
+void mc6845_device::device_reset()
+{
+	/* internal registers other than status remain unchanged, all outputs go low */
+	m_out_de_cb(false);
+
+	m_out_hsync_cb(false);
+
+	m_out_vsync_cb(false);
+
+	if (!m_line_timer->enabled() && m_has_valid_parameters)
+	{
+		m_line_timer->adjust(cclks_to_attotime(m_horiz_char_total + 1));
+	}
+
+	m_light_pen_latched = false;
+
+	// TODO: as per the note above, none of these should reset unless otherwise proven.
+	m_cursor_addr = 0;
+	m_line_address = 0;
+	// bml3 in particular disagrees with these two.
+	//m_horiz_disp = 0;
+	//m_mode_control = 0;
+	m_cursor_x = 0;
+	m_register_address_latch = 0;
+	m_update_addr = 0;
+	m_light_pen_addr = 0;
+}
+
+void mc6845_device::device_validity_check(validity_checker &valid) const
+{
+	if (!m_hpixels_per_column)
+		osd_printf_error("No hpixel per column defined!");
+}
+
+/*
+ * Motorola MC6845-1
+ *
+ */
+
+mc6845_1_device::mc6845_1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: mc6845_device(mconfig, MC6845_1, tag, owner, clock)
+{
+}
+
 void mc6845_1_device::device_start()
 {
 	mc6845_device::device_start();
@@ -1139,19 +1073,15 @@ void mc6845_1_device::device_start()
 	m_supports_transparent = false;
 }
 
+/*
+ * Rockwell R6545-1
+ *
+ */
 
-void c6545_1_device::device_start()
+r6545_1_device::r6545_1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: mc6845_device(mconfig, R6545_1, tag, owner, clock)
 {
-	mc6845_device::device_start();
-
-	m_supports_disp_start_addr_r = false;
-	m_supports_vert_sync_width = true;
-	m_supports_status_reg_d5 = true;
-	m_supports_status_reg_d6 = true;
-	m_supports_status_reg_d7 = false;
-	m_supports_transparent = false;
 }
-
 
 void r6545_1_device::device_start()
 {
@@ -1165,6 +1095,108 @@ void r6545_1_device::device_start()
 	m_supports_transparent = true;
 }
 
+/*
+ * C6545-1
+ *
+ */
+
+c6545_1_device::c6545_1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: mc6845_device(mconfig, C6545_1, tag, owner, clock)
+{
+}
+
+void c6545_1_device::device_start()
+{
+	mc6845_device::device_start();
+
+	m_supports_disp_start_addr_r = false;
+	m_supports_vert_sync_width = true;
+	m_supports_status_reg_d5 = true;
+	m_supports_status_reg_d6 = true;
+	m_supports_status_reg_d7 = false;
+	m_supports_transparent = false;
+}
+
+/*
+ * Synertek SY6545-1
+ *
+ */
+
+sy6545_1_device::sy6545_1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: mc6845_device(mconfig, SY6545_1, tag, owner, clock)
+{
+}
+
+void sy6545_1_device::device_start()
+{
+	mc6845_device::device_start();
+
+	m_supports_disp_start_addr_r = false;
+	m_supports_vert_sync_width = true;
+	m_supports_status_reg_d5 = true;
+	m_supports_status_reg_d6 = true;
+	m_supports_status_reg_d7 = true;
+	m_supports_transparent = true;
+}
+
+/*
+ * Synertek SY6845E
+ *
+ */
+
+sy6845e_device::sy6845e_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: mc6845_device(mconfig, SY6845E, tag, owner, clock)
+{
+}
+
+void sy6845e_device::device_start()
+{
+	mc6845_device::device_start();
+
+	m_supports_disp_start_addr_r = false;
+	m_supports_vert_sync_width = true;
+	m_supports_status_reg_d5 = true;
+	m_supports_status_reg_d6 = true;
+	m_supports_status_reg_d7 = true;
+	m_supports_transparent = true;
+}
+
+/*
+ * AMS40489 ASIC
+ *
+ */
+
+ams40489_device::ams40489_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: mc6845_device(mconfig, AMS40489, tag, owner, clock)
+{
+}
+
+void ams40489_device::device_start()
+{
+	mc6845_device::device_start();
+
+	m_supports_disp_start_addr_r = true;
+	m_supports_vert_sync_width = false;
+	m_supports_status_reg_d5 = false;
+	m_supports_status_reg_d6 = false;
+	m_supports_status_reg_d7 = false;
+	m_supports_transparent = false;
+}
+
+/*
+ * Hitachi HD6845S / HD46505S
+ *
+ */
+
+hd6845s_device::hd6845s_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
+	: mc6845_device(mconfig, type, tag, owner, clock)
+{
+}
+
+hd6845s_device::hd6845s_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: mc6845_device(mconfig, HD6845S, tag, owner, clock)
+{
+}
 
 void hd6845s_device::device_start()
 {
@@ -1183,32 +1215,15 @@ void hd6845s_device::device_start()
 	m_interlace_adjust = 2;
 }
 
+/*
+ * Hitachi HD6345 / HD6445 "CRTC-II"
+ *
+ */
 
-void sy6545_1_device::device_start()
+hd6345_device::hd6345_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: hd6845s_device(mconfig, HD6345, tag, owner, clock)
 {
-	mc6845_device::device_start();
-
-	m_supports_disp_start_addr_r = false;
-	m_supports_vert_sync_width = true;
-	m_supports_status_reg_d5 = true;
-	m_supports_status_reg_d6 = true;
-	m_supports_status_reg_d7 = true;
-	m_supports_transparent = true;
 }
-
-
-void sy6845e_device::device_start()
-{
-	mc6845_device::device_start();
-
-	m_supports_disp_start_addr_r = false;
-	m_supports_vert_sync_width = true;
-	m_supports_status_reg_d5 = true;
-	m_supports_status_reg_d6 = true;
-	m_supports_status_reg_d7 = true;
-	m_supports_transparent = true;
-}
-
 
 void hd6345_device::device_start()
 {
@@ -1248,56 +1263,6 @@ void hd6345_device::device_start()
 	save_item(NAME(m_cursor2_width));
 }
 
-
-void ams40489_device::device_start()
-{
-	mc6845_device::device_start();
-
-	m_supports_disp_start_addr_r = true;
-	m_supports_vert_sync_width = false;
-	m_supports_status_reg_d5 = false;
-	m_supports_status_reg_d6 = false;
-	m_supports_status_reg_d7 = false;
-	m_supports_transparent = false;
-}
-
-
-void mc6845_device::device_reset()
-{
-	/* internal registers other than status remain unchanged, all outputs go low */
-	m_out_de_cb(false);
-
-	m_out_hsync_cb(false);
-
-	m_out_vsync_cb(false);
-
-	if (!m_line_timer->enabled() && m_has_valid_parameters)
-	{
-		m_line_timer->adjust(cclks_to_attotime(m_horiz_char_total + 1));
-	}
-
-	m_light_pen_latched = false;
-
-	// TODO: as per the note above, none of these should reset unless otherwise proven.
-	m_cursor_addr = 0;
-	m_line_address = 0;
-	// bml3 in particular disagrees with these two.
-	//m_horiz_disp = 0;
-	//m_mode_control = 0;
-	m_cursor_x = 0;
-	m_register_address_latch = 0;
-	m_update_addr = 0;
-	m_light_pen_addr = 0;
-}
-
-// TODO: don't trampoline like this
-void r6545_1_device::device_reset() { mc6845_device::device_reset(); }
-void mc6845_1_device::device_reset() { mc6845_device::device_reset(); }
-void hd6845s_device::device_reset() { mc6845_device::device_reset(); }
-void c6545_1_device::device_reset() { mc6845_device::device_reset(); }
-void sy6545_1_device::device_reset() { mc6845_device::device_reset(); }
-void sy6845e_device::device_reset() { mc6845_device::device_reset(); }
-
 void hd6345_device::device_reset()
 {
 	hd6845s_device::device_reset();
@@ -1307,63 +1272,114 @@ void hd6345_device::device_reset()
 	m_control3 = 0;
 }
 
-void ams40489_device::device_reset() { mc6845_device::device_reset(); }
-
-void mc6845_device::device_validity_check(validity_checker &valid) const
+void hd6345_device::address_w(uint8_t data)
 {
-	if (!m_hpixels_per_column)
-		osd_printf_error("No hpixel per column defined!");
+	m_register_address_latch = data & 0x3f;
 }
 
-r6545_1_device::r6545_1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: mc6845_device(mconfig, R6545_1, tag, owner, clock)
+uint8_t hd6345_device::register_r()
 {
+	uint8_t ret = 0;
+
+	switch (m_register_address_latch)
+	{
+		case 0x0c:  ret = (m_disp_start_addr  >> 8) & 0xff; break;
+		case 0x0d:  ret = (m_disp_start_addr  >> 0) & 0xff; break;
+		case 0x0e:  ret = (m_cursor_addr      >> 8) & 0xff; break;
+		case 0x0f:  ret = (m_cursor_addr      >> 0) & 0xff; break;
+		case 0x10:  ret = (m_light_pen_addr   >> 8) & 0xff; m_light_pen_latched = false; break;
+		case 0x11:  ret = (m_light_pen_addr   >> 0) & 0xff; m_light_pen_latched = false; break;
+		case 0x12:  ret = m_disp2_pos; break;
+		case 0x13:  ret = (m_disp2_start_addr >> 8) & 0xff; break;
+		case 0x14:  ret = (m_disp2_start_addr >> 0) & 0xff; break;
+		case 0x15:  ret = m_disp3_pos; break;
+		case 0x16:  ret = (m_disp3_start_addr >> 8) & 0xff; break;
+		case 0x17:  ret = (m_disp3_start_addr >> 0) & 0xff; break;
+		case 0x18:  ret = m_disp4_pos; break;
+		case 0x19:  ret = (m_disp4_start_addr >> 8) & 0xff; break;
+		case 0x1a:  ret = (m_disp4_start_addr >> 0) & 0xff; break;
+		case 0x1b:  ret = m_vert_sync_pos_adj; break;
+		case 0x1c: /* TODO: light pen raster */ break;
+		case 0x1d:  ret = m_smooth_scroll_ras; break;
+		case 0x1f: /* TODO: status */ break;
+		case 0x21:  ret = m_mem_width_offs; break;
+		case 0x24:  ret = (m_cursor2_addr     >> 8) & 0xff; break;
+		case 0x25:  ret = (m_cursor2_addr     >> 0) & 0xff; break;
+		case 0x26:  ret = m_cursor_width; break;
+		case 0x27:  ret = m_cursor2_width; break;
+	}
+
+	return ret;
 }
 
-
-mc6845_1_device::mc6845_1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: mc6845_device(mconfig, MC6845_1, tag, owner, clock)
+void hd6345_device::register_w(uint8_t data)
 {
+	LOGREGS("%s:HD6345 reg 0x%02x = 0x%02x\n", machine().describe_context(), m_register_address_latch, data);
+
+	/* Omits LOGSETUP logs of cursor registers as they tend to be spammy */
+	if (m_register_address_latch < 0x28 &&
+		m_register_address_latch != 0x0a && m_register_address_latch != 0x0a &&
+		m_register_address_latch != 0x0e && m_register_address_latch != 0x0f)
+		LOGSETUP(" * %02x <= %3u [%02x] %s\n", m_register_address_latch, data, data, std::array<char const *, 40>
+		 {{ "R0 - Horizontal Total",            "R1 - Horizontal Displayed",        "R2 - Horizontal Sync Position",
+			"R3 - Sync Width",                  "R4 - Vertical Total",              "R5 - Vertical Total Adjust",
+			"R6 - Vertical Displayed",          "R7 - Vertical Sync Position",      "R8 - Interlace Mode & Skew",
+			"R9 - Maximum Raster Address",      "R10 - Cursor 1 Start",             "R11 - Cursor 1 End",
+			"R12 - Screen 1 Start Address (H)", "R13 - Screen 1 Start Address (L)", "R14 - Cursor 1 Address (H)",
+			"R15 - Cursor 1 Address (L)",       "R16 - Light Pen (H)",              "R17 - Light Pen (L)",
+			"R18 - Screen 2 Start Position",    "R19 - Screen 2 Start Address (H)", "R20 - Screen 2 Start Address (L)",
+			"R21 - Screen 3 Start Position",    "R22 - Screen 3 Start Address (H)", "R23 - Screen 3 Start Address (L)",
+			"R24 - Screen 4 Start Position",    "R25 - Screen 4 Start Address (H)", "R26 - Screen 4 Start Address (L)",
+			"R27 - Vertical Sync Position Adj", "R28 - Light Pen Raster",           "R29 - Smooth Scrolling",
+			"R30 - Control 1",                  "R31 - Control 2",                  "R32 - Control 3",
+			"R33 - Memory Width Offset",        "R34 - Cursor 2 Start",             "R35 - Cursor 2 End",
+			"R36 - Cursor 2 Address (H)",       "R37 - Cursor 2 Address (L)",       "R38 - Cursor 1 Width",
+			"R39 - Cursor 2 Width" }}[(m_register_address_latch & 0x3f)]);
+
+	switch (m_register_address_latch)
+	{
+		case 0x00:  m_horiz_char_total =   data & 0xff; break;
+		case 0x01:  m_horiz_disp       =   data & 0xff; break;
+		case 0x02:  m_horiz_sync_pos   =   data & 0xff; break;
+		case 0x03:  m_sync_width       =   data & 0xff; break;
+		case 0x04:  m_vert_char_total  =   data & 0xff; break;
+		case 0x05:  m_vert_total_adj   =   data & 0x1f; break;
+		case 0x06:  m_vert_disp        =   data & 0xff; break;
+		case 0x07:  m_vert_sync_pos    =   data & 0xff; break;
+		case 0x08:  m_mode_control     =   data & 0xf3; break;
+		case 0x09:  m_max_ras_addr     =   data & 0x1f; break;
+		case 0x0a:  m_cursor_start_ras =   data & 0x7f; break;
+		case 0x0b:  m_cursor_end_ras   =   data & 0x1f; break;
+		case 0x0c:  m_disp_start_addr  = ((data & 0x3f) << 8) | (m_disp_start_addr & 0x00ff); break;
+		case 0x0d:  m_disp_start_addr  = ((data & 0xff) << 0) | (m_disp_start_addr & 0xff00); break;
+		case 0x0e:  m_cursor_addr      = ((data & 0x3f) << 8) | (m_cursor_addr & 0x00ff); break;
+		case 0x0f:  m_cursor_addr      = ((data & 0xff) << 0) | (m_cursor_addr & 0xff00); break;
+		case 0x10: /* read-only */ break;
+		case 0x11: /* read-only */ break;
+		case 0x12:  m_disp2_pos         =   data & 0xff; break;
+		case 0x13:  m_disp2_start_addr  = ((data & 0x3f) << 8) | (m_disp2_start_addr & 0x00ff); break;
+		case 0x14:  m_disp2_start_addr  = ((data & 0xff) << 0) | (m_disp2_start_addr & 0xff00); break;
+		case 0x15:  m_disp3_pos         =   data & 0xff; break;
+		case 0x16:  m_disp3_start_addr  = ((data & 0x3f) << 8) | (m_disp3_start_addr & 0x00ff); break;
+		case 0x17:  m_disp3_start_addr  = ((data & 0xff) << 0) | (m_disp3_start_addr & 0xff00); break;
+		case 0x18:  m_disp4_pos         =   data & 0xff; break;
+		case 0x19:  m_disp4_start_addr  = ((data & 0x3f) << 8) | (m_disp4_start_addr & 0x00ff); break;
+		case 0x1a:  m_disp4_start_addr  = ((data & 0xff) << 0) | (m_disp4_start_addr & 0xff00); break;
+		case 0x1b:  m_vert_sync_pos_adj =   data & 0x1f; break;
+		case 0x1c: /* read-only */ break;
+		case 0x1d:  m_smooth_scroll_ras =   data & 0x1f; break;
+		case 0x1e:  m_control1          =   data & 0xff; break;
+		case 0x1f:  m_control2          =   data & 0xf8; break;
+		case 0x20:  m_control3          =   data & 0xfe; break;
+		case 0x21:  m_mem_width_offs    =   data & 0xff; break;
+		case 0x22:  m_cursor2_start_ras =   data & 0x7f; break;
+		case 0x23:  m_cursor2_end_ras   =   data & 0x1f; break;
+		case 0x24:  m_cursor2_addr      = ((data & 0x3f) << 8) | (m_cursor2_addr & 0x00ff); break;
+		case 0x25:  m_cursor2_addr      = ((data & 0xff) << 0) | (m_cursor2_addr & 0xff00); break;
+		case 0x26:  m_cursor_width      =   data & 0xff; break;
+		case 0x27:  m_cursor2_width     =   data & 0xff; break;
+	}
+
+	recompute_parameters(false);
 }
 
-
-hd6845s_device::hd6845s_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
-	: mc6845_device(mconfig, type, tag, owner, clock)
-{
-}
-
-
-hd6845s_device::hd6845s_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: mc6845_device(mconfig, HD6845S, tag, owner, clock)
-{
-}
-
-
-c6545_1_device::c6545_1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: mc6845_device(mconfig, C6545_1, tag, owner, clock)
-{
-}
-
-
-sy6545_1_device::sy6545_1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: mc6845_device(mconfig, SY6545_1, tag, owner, clock)
-{
-}
-
-
-sy6845e_device::sy6845e_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: mc6845_device(mconfig, SY6845E, tag, owner, clock)
-{
-}
-
-
-hd6345_device::hd6345_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: hd6845s_device(mconfig, HD6345, tag, owner, clock)
-{
-}
-
-
-ams40489_device::ams40489_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: mc6845_device(mconfig, AMS40489, tag, owner, clock)
-{
-}

--- a/src/devices/video/mc6845.cpp
+++ b/src/devices/video/mc6845.cpp
@@ -1290,7 +1290,7 @@ void mc6845_device::device_reset()
 	m_light_pen_addr = 0;
 }
 
-
+// TODO: don't trampoline like this
 void r6545_1_device::device_reset() { mc6845_device::device_reset(); }
 void mc6845_1_device::device_reset() { mc6845_device::device_reset(); }
 void hd6845s_device::device_reset() { mc6845_device::device_reset(); }
@@ -1309,6 +1309,11 @@ void hd6345_device::device_reset()
 
 void ams40489_device::device_reset() { mc6845_device::device_reset(); }
 
+void mc6845_device::device_validity_check(validity_checker &valid) const
+{
+	if (!m_hpixels_per_column)
+		osd_printf_error("No hpixel per column defined!");
+}
 
 r6545_1_device::r6545_1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: mc6845_device(mconfig, R6545_1, tag, owner, clock)

--- a/src/devices/video/mc6845.h
+++ b/src/devices/video/mc6845.h
@@ -135,6 +135,7 @@ protected:
 	virtual void device_reset() override ATTR_COLD;
 	virtual void device_post_load() override;
 	virtual void device_clock_changed() override;
+	virtual void device_validity_check(validity_checker &valid) const override;
 
 	attotime cclks_to_attotime(uint64_t clocks) const { return clocks_to_attotime(clocks * m_clk_scale); }
 	uint64_t attotime_to_cclks(const attotime &duration) const { return attotime_to_clocks(duration) / m_clk_scale; }

--- a/src/devices/video/mc6845.h
+++ b/src/devices/video/mc6845.h
@@ -89,7 +89,8 @@ public:
 	virtual void address_w(uint8_t data);
 
 	/* read from the status register */
-	uint8_t status_r();
+	// NOTE: subclassed by mos8563
+	virtual uint8_t status_r();
 
 	/* read from the currently selected register */
 	virtual uint8_t register_r();

--- a/src/devices/video/mc6845.h
+++ b/src/devices/video/mc6845.h
@@ -86,16 +86,16 @@ public:
 	auto out_vsync_callback() { return m_out_vsync_cb.bind(); }
 
 	/* select one of the registers for reading or writing */
-	void address_w(uint8_t data);
+	virtual void address_w(uint8_t data);
 
 	/* read from the status register */
 	uint8_t status_r();
 
 	/* read from the currently selected register */
-	uint8_t register_r();
+	virtual uint8_t register_r();
 
 	/* write to the currently selected register */
-	void register_w(uint8_t data);
+	virtual void register_w(uint8_t data);
 
 	// read display enable line state
 	int de_r();
@@ -302,7 +302,7 @@ public:
 
 protected:
 	virtual void device_start() override ATTR_COLD;
-	virtual void device_reset() override ATTR_COLD;
+//	virtual void device_reset() override ATTR_COLD;
 };
 
 class r6545_1_device : public mc6845_device
@@ -312,7 +312,7 @@ public:
 
 protected:
 	virtual void device_start() override ATTR_COLD;
-	virtual void device_reset() override ATTR_COLD;
+//	virtual void device_reset() override ATTR_COLD;
 };
 
 class c6545_1_device : public mc6845_device
@@ -322,7 +322,37 @@ public:
 
 protected:
 	virtual void device_start() override ATTR_COLD;
-	virtual void device_reset() override ATTR_COLD;
+//	virtual void device_reset() override ATTR_COLD;
+};
+
+class sy6545_1_device : public mc6845_device
+{
+public:
+	sy6545_1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+//	virtual void device_reset() override ATTR_COLD;
+};
+
+class sy6845e_device : public mc6845_device
+{
+public:
+	sy6845e_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+//	virtual void device_reset() override ATTR_COLD;
+};
+
+class ams40489_device : public mc6845_device
+{
+public:
+	ams40489_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+//	virtual void device_reset() override ATTR_COLD;
 };
 
 class hd6845s_device : public mc6845_device
@@ -334,28 +364,8 @@ protected:
 	hd6845s_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
 	virtual void device_start() override ATTR_COLD;
-	virtual void device_reset() override ATTR_COLD;
+//	virtual void device_reset() override ATTR_COLD;
 	virtual bool check_cursor_visible(uint16_t ra, uint16_t line_addr) override;
-};
-
-class sy6545_1_device : public mc6845_device
-{
-public:
-	sy6545_1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-protected:
-	virtual void device_start() override ATTR_COLD;
-	virtual void device_reset() override ATTR_COLD;
-};
-
-class sy6845e_device : public mc6845_device
-{
-public:
-	sy6845e_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-protected:
-	virtual void device_start() override ATTR_COLD;
-	virtual void device_reset() override ATTR_COLD;
 };
 
 class hd6345_device : public hd6845s_device
@@ -363,9 +373,9 @@ class hd6345_device : public hd6845s_device
 public:
 	hd6345_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	void address_w(uint8_t data);
-	uint8_t register_r();
-	void register_w(uint8_t data);
+	virtual void address_w(uint8_t data) override;
+	virtual uint8_t register_r() override;
+	virtual void register_w(uint8_t data) override;
 
 protected:
 	virtual void device_start() override ATTR_COLD;
@@ -393,25 +403,14 @@ protected:
 	virtual uint8_t draw_scanline(int y, bitmap_rgb32 &bitmap, const rectangle &cliprect) override;
 };
 
-class ams40489_device : public mc6845_device
-{
-public:
-	ams40489_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-protected:
-	virtual void device_start() override ATTR_COLD;
-	virtual void device_reset() override ATTR_COLD;
-};
-
-
 DECLARE_DEVICE_TYPE(MC6845,   mc6845_device)
 DECLARE_DEVICE_TYPE(MC6845_1, mc6845_1_device)
 DECLARE_DEVICE_TYPE(R6545_1,  r6545_1_device)
 DECLARE_DEVICE_TYPE(C6545_1,  c6545_1_device)
-DECLARE_DEVICE_TYPE(HD6845S,  hd6845s_device)
 DECLARE_DEVICE_TYPE(SY6545_1, sy6545_1_device)
 DECLARE_DEVICE_TYPE(SY6845E,  sy6845e_device)
-DECLARE_DEVICE_TYPE(HD6345,   hd6345_device)
 DECLARE_DEVICE_TYPE(AMS40489, ams40489_device)
+DECLARE_DEVICE_TYPE(HD6845S,  hd6845s_device)
+DECLARE_DEVICE_TYPE(HD6345,   hd6345_device)
 
 #endif // MAME_VIDEO_MC6845_H

--- a/src/devices/video/mos8563.h
+++ b/src/devices/video/mos8563.h
@@ -27,10 +27,10 @@ class mos8563_device : public mc6845_device,
 public:
 	mos8563_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	void address_w(uint8_t data);
-	uint8_t status_r();
-	uint8_t register_r();
-	void register_w(uint8_t data);
+	virtual void address_w(uint8_t data) override;
+	virtual uint8_t status_r() override;
+	virtual uint8_t register_r() override;
+	virtual void register_w(uint8_t data) override;
 
 	inline uint8_t read_videoram(offs_t offset);
 	inline void write_videoram(offs_t offset, uint8_t data);

--- a/src/mame/misc/rcorsair.cpp
+++ b/src/mame/misc/rcorsair.cpp
@@ -74,9 +74,10 @@ class rcorsair_state : public driver_device
 {
 public:
 	rcorsair_state(const machine_config &mconfig, device_type type, const char *tag)
-	: driver_device(mconfig, type, tag),
-	m_maincpu(*this, "maincpu"),
-	m_subcpu(*this, "subcpu")
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_subcpu(*this, "subcpu")
+		, m_crtc(*this, "crtc")
 	{ }
 
 	void rcorsair(machine_config &config);
@@ -89,13 +90,51 @@ private:
 	// devices
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_subcpu;
+	required_device<hd6845s_device> m_crtc;
 
+	void palette_init(palette_device &palette) const;
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 	void rcorsair_main_map(address_map &map) ATTR_COLD;
 	void rcorsair_sub_io_map(address_map &map) ATTR_COLD;
 	void rcorsair_sub_map(address_map &map) ATTR_COLD;
 };
+
+void rcorsair_state::video_start()
+{
+}
+
+uint32_t rcorsair_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+{
+	return 0;
+}
+
+void rcorsair_state::palette_init(palette_device &palette) const
+{
+	const uint8_t *color_prom = memregion("proms")->base();
+
+	// TODO: hookup unconfirmed
+	for (int i = 0; i < palette.entries(); i++)
+	{
+		int bit0, bit1, bit2;
+
+		bit0 = BIT(color_prom[i], 0);
+		bit1 = BIT(color_prom[i], 1);
+		bit2 = BIT(color_prom[i], 2);
+		int const r = 0x21 * bit0 + 0x47 * bit1 + 0x97 * bit2;
+
+		bit0 = BIT(color_prom[i], 3);
+		bit1 = BIT(color_prom[i | 0x100], 0);
+		bit2 = BIT(color_prom[i | 0x100], 1);
+		int const g = 0x21 * bit0 + 0x47 * bit1 + 0x97 * bit2;
+
+		bit0 = BIT(color_prom[i | 0x100], 2);
+		bit1 = BIT(color_prom[i | 0x100], 3);
+		int const b = 0x52 * bit0 + 0xad * bit1;
+
+		palette.set_pen_color(i, rgb_t(r, g, b));
+	}
+}
 
 
 void rcorsair_state::rcorsair_main_map(address_map &map)
@@ -113,7 +152,7 @@ void rcorsair_state::rcorsair_sub_io_map(address_map &map)
 {
 }
 
-static INPUT_PORTS_START( inports )
+static INPUT_PORTS_START( rcorsair )
 	PORT_START("IN0")
 	PORT_DIPNAME(   0x01, 0x01, DEF_STR( Unknown ) )
 	PORT_DIPSETTING(      0x01, DEF_STR( Off ) )
@@ -153,27 +192,20 @@ static const gfx_layout tiles8x8_layout =
 };
 
 static GFXDECODE_START( gfx_rcorsair )
-	GFXDECODE_ENTRY( "gfx1", 0, tiles8x8_layout, 0, 16 )
+	GFXDECODE_ENTRY( "gfx1", 0, tiles8x8_layout, 0, 32 )
 GFXDECODE_END
 
-void rcorsair_state::video_start()
-{
-}
-
-uint32_t rcorsair_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
 
 void rcorsair_state::rcorsair(machine_config &config)
 {
 	// Main CPU is probably inside Custom Block with program code, unknown type
 
-	Z80(config, m_maincpu, 8000000);
+	// TODO: clocks (was 8 MHz for both, very unlikely)
+	Z80(config, m_maincpu, 8000000 / 2);
 	m_maincpu->set_addrmap(AS_PROGRAM, &rcorsair_state::rcorsair_main_map);
 	//m_maincpu->set_vblank_int("screen", FUNC(rcorsair_state::irq0_line_hold));
 
-	I8035(config, m_subcpu, 8000000);
+	I8035(config, m_subcpu, 8000000 / 2);
 	m_subcpu->set_addrmap(AS_PROGRAM, &rcorsair_state::rcorsair_sub_map);
 	m_subcpu->set_addrmap(AS_IO, &rcorsair_state::rcorsair_sub_io_map);
 
@@ -188,9 +220,12 @@ void rcorsair_state::rcorsair(machine_config &config)
 	screen.set_palette("palette");
 
 	GFXDECODE(config, "gfxdecode", "palette", gfx_rcorsair);
-	PALETTE(config, "palette").set_entries(0x100);
+	PALETTE(config, "palette", FUNC(rcorsair_state::palette_init)).set_entries(0x100);
 
-	HD6845S(config, "crtc", 8000000 / 8).set_screen("screen");
+	HD6845S(config, m_crtc, 8000000 / 16);
+	m_crtc->set_screen("screen");
+	m_crtc->set_show_border_area(false);
+	m_crtc->set_char_width(8); // assumed from GFXs
 
 	SPEAKER(config, "speaker").front_center();
 
@@ -213,12 +248,12 @@ ROM_START( rcorsair )
 	ROM_LOAD( "rcd1_2c.bin", 0x2000, 0x2000, CRC(9ec5dd51) SHA1(84939799f64d9d3e9a67b51046dd0c3403904d97) )
 	ROM_LOAD( "rcd0_2d.bin", 0x4000, 0x2000, CRC(b86fe547) SHA1(30dc51f65d2bd807d2498829087ba1a8eaa2e146) )
 
-	ROM_REGION( 0x40000, "proms", 0 )
-	ROM_LOAD( "prom_3d.bin", 0x00000, 0x100, CRC(fd8bc85b) SHA1(79324a6cecea652bc920ec762e7a30044003ed3f) ) // ?
-	ROM_LOAD( "prom_3c.bin", 0x00000, 0x100, CRC(edca1d4a) SHA1(a5ff659cffcd09cc161960da8f5cdd234e0db92c) ) // ?
+	ROM_REGION( 0x200, "proms", 0 )
+	ROM_LOAD( "prom_3d.bin", 0x000, 0x100, CRC(fd8bc85b) SHA1(79324a6cecea652bc920ec762e7a30044003ed3f) ) // ?
+	ROM_LOAD( "prom_3c.bin", 0x100, 0x100, CRC(edca1d4a) SHA1(a5ff659cffcd09cc161960da8f5cdd234e0db92c) ) // ?
 ROM_END
 
 } // anonymous namespace
 
 
-GAME( 1984, rcorsair,  0,    rcorsair, inports, rcorsair_state, empty_init, ROT90, "Nakasawa", "Red Corsair", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+GAME( 1984, rcorsair,  0,    rcorsair, rcorsair, rcorsair_state, empty_init, ROT90, "Nakasawa", "Red Corsair", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/technos/ssozumo.cpp
+++ b/src/mame/technos/ssozumo.cpp
@@ -66,7 +66,7 @@ private:
 	TILE_GET_INFO_MEMBER(get_bg_tile_info);
 	TILE_GET_INFO_MEMBER(get_fg_tile_info);
 
-	void palette(palette_device &palette) const;
+	void palette_init(palette_device &palette) const;
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 	void main_map(address_map &map) ATTR_COLD;
@@ -93,7 +93,7 @@ private:
 
 /**************************************************************************/
 
-void ssozumo_state::palette(palette_device &palette) const
+void ssozumo_state::palette_init(palette_device &palette) const
 {
 	const uint8_t *color_prom = memregion("proms")->base();
 
@@ -431,7 +431,7 @@ void ssozumo_state::ssozumo(machine_config &config)
 	screen.set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_ssozumo);
-	PALETTE(config, m_palette, FUNC(ssozumo_state::palette), 64 + 16);
+	PALETTE(config, m_palette, FUNC(ssozumo_state::palette_init), 64 + 16);
 
 	// sound hardware
 	SPEAKER(config, "speaker").front_center();


### PR DESCRIPTION
A zero value causes implicit no setup in CRTC parameters, make it a mandatory parameter thru `-validate`.

Other changes:
* reorder device blocks
* remove empty device_reset trampolines
* mark register/data methods as virtual (CRTC-II and MOS8563 overrides them)
* misc/rcorsair.cpp: fix 6845 validation, attempt at decoding color proms, fix CPU clocks