### PR TITLE
apple2gs: fix reserved I/O bits

### DIFF
--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -1715,7 +1715,7 @@ u8 apple2gs_state::c000_r(offs_t offset)
 			return m_speed;
 
 		case 0x3c:  // SOUNDCTL
-			return m_sndglu_ctrl;
+			return m_sndglu_ctrl | 0x1f;
 
 		case 0x3d:  // SOUNDDATA
 			ret = m_sndglu_dummy_read;
@@ -1966,7 +1966,7 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			}
 
 			m_vgcint &= 0xf0;
-			m_vgcint |= (data & 0x0f);
+			m_vgcint |= (data & 0x07);
 			//printf("%02x to VGCINT, now %02x\n", data, m_vgcint);
 			break;
 
@@ -1981,15 +1981,15 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			break;
 
 		case 0x29:  // NEWVIDEO
-			m_video->set_newvideo(data);
+			m_video->set_newvideo(data & 0xe1);
 			break;
 
 		case 0x2b:  // LANGSEL
-			m_video->set_GS_langsel(data);
+			m_video->set_GS_langsel(data & 0xf8);
 			break;
 
 		case 0x2d:  // SLOTROMSEL
-			m_slotromsel = data;
+			m_slotromsel = data & 0xf6;
 			break;
 
 		case 0x31:  // DISKREG
@@ -2002,7 +2002,7 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			{
 				m_cur_floppy->ss_w(BIT(data, DISKREG_HDSEL));
 			}
-			m_diskreg = data;
+			m_diskreg = data & 0xc0;
 			break;
 
 		case 0x32:  // VGCINTCLEAR
@@ -2019,7 +2019,7 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			{
 				m_screen->update_now();
 			}
-			m_clock_control = data & 0x7f;
+			m_clock_control = data & 0x6f;
 			m_video->set_GS_border(data & 0xf);
 			m_rtc->ce_w(BIT(data, 7) ^ 1);
 			if (data & 0x80)


### PR DESCRIPTION
(minor problems noticed during #15619 SLTROMSEL debugging)

This PR fixes several I/O registers to force bits to zero or one, matching hardware behavior (which slightly differs from [Apple's documentation](https://archive.org/details/Apple_IIGS_Firmware_Reference_1987_Adn-Wesley_Publishing/page/n297/mode/2up).)

A new MUSTBE0 test verifies all the documented bits (source included):
(updated 260731 to restore C021 state.  Now [included](https://github.com/mamedev/mame/pull/15803#:~:text=older%20tests%20are%20also%20included) in MEMSTATE.po) 

Before this PR, MAME allowed writing arbitrary data to most of these bits:
<img width="704" height="462" alt="MUSTBE0_gs_288_before" src="https://github.com/user-attachments/assets/37e2c04a-4576-432b-98fe-a33843e7fd9c" />

After this PR, everything matches hardware behavior (thanks to @colinleroy for ROM1 hardware testing.)
<br>

This is mostly pedantic, but two of the registers are interesting:
* C034 bit 4 is always forced to zero.  This means that [looping INC C034](https://github.com/mamedev/mame/pull/15313#:~:text=A%20trivial%20example) is actually safe on hardware, whereas before this PR it would spill over into the RTC register on MAME.

* C03C bit 4 is documented as "must be 0" and bits 0-3 are the sound GLU volume, [documented as "write only"](https://archive.org/details/Apple_IIGS_Firmware_Reference_1987_Adn-Wesley_Publishing/page/n305/mode/2up).  Actual hardware behavior is to always return 1 for all five of these bits.  This is poorly documented and error-prone: Apple [warns to not use RMW commands](https://archive.org/details/Apple_IIgs_Hardware_Reference_HiRes/page/104/mode/2up) on this register, but does not explain why, or how to safely restore the user's volume preference (one way is to read the BRAM shadow @ E1/02C0 + 1E.)  A blind LDA/STA will force maximum volume, and is an easy programming mistake to make.  MAME now replicates this behavior.
