### PR TITLE
apple2gs: comment where hardware behavior differs from documentation

### DIFF
--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -1715,7 +1715,7 @@ u8 apple2gs_state::c000_r(offs_t offset)
 			return m_speed;
 
 		case 0x3c:  // SOUNDCTL
-			return m_sndglu_ctrl | 0x1f;
+			return m_sndglu_ctrl | 0x1f; // "write only" bits read as 1
 
 		case 0x3d:  // SOUNDDATA
 			ret = m_sndglu_dummy_read;
@@ -2029,7 +2029,7 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			break;
 
 		case 0x35:  // SHADOW
-			m_shadow = data;
+			m_shadow = data; // bits 5,7 are not forced to zero
 
 			// handle I/O and language card inhibit bits here
 			if (m_shadow & SHAD_IOLC)
@@ -2045,7 +2045,7 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			break;
 
 		case 0x36:  // SPEED
-			m_speed = data;
+			m_speed = data; // bits 5-6 are not forced to zero
 
 			if (m_speed & SPEED_ALLBANKS)
 			{


### PR DESCRIPTION
followup #15626, per feedback

C035 and C036 are documented as "must **write** 0" whereas the other registers are "must **be** zero", but this is easy to misinterpret, so comment.

C03C really acts differently from the other registers; comment read behavior of write-only bits.