### PR TITLE
ieee488/grid2102.cpp: fix simultaneous 210x device work and refactor

### DIFF
--- a/src/devices/bus/ieee488/grid2102.cpp
+++ b/src/devices/bus/ieee488/grid2102.cpp
@@ -185,6 +185,18 @@ static const grid210x_device::disk_status hdd_status
 };
 
 
+static constexpr uint8_t GPIB_CMD_GROUP_MASK = 0xe0;
+static constexpr uint8_t GPIB_CMD_ADDR_MASK = 0x1f;
+static constexpr uint8_t GPIB_CMD_DCL = 0x14;
+static constexpr uint8_t GPIB_CMD_SPE = 0x18;
+static constexpr uint8_t GPIB_CMD_SPD = 0x19;
+static constexpr uint8_t GPIB_CMD_MLA = 0x20;
+static constexpr uint8_t GPIB_CMD_MTA = 0x40;
+static constexpr uint8_t GPIB_CMD_UNL = 0x3f;
+static constexpr uint8_t GPIB_CMD_UNT = 0x5f;
+
+static constexpr uint8_t GPIB_STATUS_RQS = 0x40;
+
 #define GRID2101_HARDDISK_DEV_ADDR 4
 #define GRID2102_DEV_ADDR 6
 
@@ -350,7 +362,7 @@ void grid210x_device::start_talking_if_ready() {
 			has_srq = false;
 			m_bus->srq_w(this, 1);
 		}
-		m_byte_to_send = serial_poll_byte | (had_srq ? 0x40 : 0);
+		m_byte_to_send = serial_poll_byte | (had_srq ? GPIB_STATUS_RQS : 0);
 		serial_poll_byte = 0;
 		m_send_eoi = 1;
 		m_gpib_loop_state = GRID210X_GPIB_STATE_SEND_DATA_START;
@@ -390,48 +402,41 @@ void grid210x_device::ieee488_dav(int state) {
 		m_gpib_loop_state = GRID210X_GPIB_STATE_IDLE;
 
 		if (m_last_recv_atn) {
-			if ((m_last_recv_byte & 0xe0) == 0x20) {
-				if ((m_last_recv_byte & 0x1f) == bus_addr) {
-					// dev-id = 5
+			const uint8_t command_group = m_last_recv_byte & GPIB_CMD_GROUP_MASK;
+			const uint8_t command_addr = m_last_recv_byte & GPIB_CMD_ADDR_MASK;
+
+			if (command_group == GPIB_CMD_MLA) {
+				m_data_buffer.clear();
+				listening = false;
+				talking = false;
+				if (command_addr == bus_addr) {
 					listening = true;
-					talking = false;
-					m_data_buffer.clear();
 					m_ignore_state = GRID210X_IGNORE_STATE_NONE;
 					LOG_GPIB_STATE("grid210x_device now listening\n");
-				} else if((m_last_recv_byte & 0x1f) == 0x1f) {
-					// reset listen
-					listening = false;
-					m_data_buffer.clear();
+				} else if (m_last_recv_byte == GPIB_CMD_UNL) {
 					LOG_GPIB_STATE("grid210x_device now not listening\n");
 				} else {
-					listening = false;
-					m_data_buffer.clear();
 					m_ignore_state = GRID210X_IGNORE_STATE_WAIT_ATN_HIGH;
-					LOG_GPIB_STATE("grid210x_device ignoring transfer for listener %u\n", (unsigned)(m_last_recv_byte & 0x1f));
+					LOG_GPIB_STATE("grid210x_device ignoring transfer for listener %u\n", (unsigned)command_addr);
 				}
-			} else if ((m_last_recv_byte & 0xe0) == 0x40) {
-				if ((m_last_recv_byte & 0x1f) == bus_addr) {
-					// dev-id = 5
+			} else if (command_group == GPIB_CMD_MTA) {
+				m_data_buffer.clear();
+				talking = false;
+				listening = false;
+				if (command_addr == bus_addr) {
 					talking = true;
-					listening = false;
-					m_data_buffer.clear();
 					m_ignore_state = GRID210X_IGNORE_STATE_NONE;
 					LOG_GPIB_STATE("grid210x_device now talking\n");
-				} else if ((m_last_recv_byte & 0x1f) == 0x1f) {
-					// reset talk
-					talking = false;
+				} else if (m_last_recv_byte == GPIB_CMD_UNT) {
 					LOG_GPIB_STATE("grid210x_device now not talking\n");
 				} else {
-					// reset talk
-					talking = false;
-					LOG_GPIB_STATE("grid210x_device now not talking\n");
 					m_ignore_state = GRID210X_IGNORE_STATE_WAIT_ATN_HIGH;
-					LOG_GPIB_STATE("grid210x_device ignoring transfer for talker %u\n", (unsigned)(m_last_recv_byte & 0x1f));
+					LOG_GPIB_STATE("grid210x_device ignoring transfer for talker %u\n", (unsigned)command_addr);
 				}
-			} else if (m_last_recv_byte == 0x18) {
+			} else if (m_last_recv_byte == GPIB_CMD_SPE) {
 				// serial poll enable
 				serial_polling = true;
-			} else if (m_last_recv_byte == 0x19) {
+			} else if (m_last_recv_byte == GPIB_CMD_SPD) {
 				// serial poll disable
 				serial_polling = false;
 			}

--- a/src/devices/bus/ieee488/grid2102.cpp
+++ b/src/devices/bus/ieee488/grid2102.cpp
@@ -89,12 +89,14 @@ protected:
 	virtual const char *image_brief_type_name() const noexcept override { return "flop"; }
 
 	void accept_transfer();
-	void update_ndac(int atn);
+	void start_talking_if_ready();
+	void update_handshake(int atn);
 
 	virtual disk_status get_status() = 0;
 
 private:
 	TIMER_CALLBACK_MEMBER(delay_tick);
+	TIMER_CALLBACK_MEMBER(talk_tick);
 
 	int m_gpib_loop_state;
 	int m_floppy_loop_state;
@@ -104,6 +106,7 @@ private:
 	uint8_t m_byte_to_send;
 	int m_send_eoi;
 	bool listening, talking, serial_polling;
+	int m_ignore_state;
 	bool has_srq;
 	uint8_t serial_poll_byte;
 	uint32_t floppy_sector_number;
@@ -112,6 +115,7 @@ private:
 	std::queue<uint8_t> m_output_data_buffer;
 	uint16_t io_size;
 	emu_timer *m_delay_timer;
+	emu_timer *m_talk_timer;
 
 protected:
 	attotime read_delay;
@@ -189,6 +193,10 @@ static const grid210x_device::disk_status hdd_status
 #define GRID210X_GPIB_STATE_SEND_DATA_START 2
 #define GRID210X_GPIB_STATE_WAIT_NDAC_FALSE 3
 
+#define GRID210X_IGNORE_STATE_NONE 0
+#define GRID210X_IGNORE_STATE_WAIT_ATN_HIGH 1
+#define GRID210X_IGNORE_STATE_WAIT_ATN_LOW 2
+
 #define GRID210X_STATE_IDLE 0
 #define GRID210X_STATE_READING_DATA 1
 #define GRID210X_STATE_WRITING_DATA 2
@@ -223,6 +231,7 @@ grid210x_device::grid210x_device(const machine_config &mconfig, device_type type
 	listening(false),
 	talking(false),
 	serial_polling(false),
+	m_ignore_state(GRID210X_IGNORE_STATE_NONE),
 	has_srq(false),
 	serial_poll_byte(0),
 	bus_addr(bus_addr),
@@ -235,6 +244,7 @@ void grid210x_device::device_start() {
 	m_bus->ndac_w(this, 1);
 	m_bus->nrfd_w(this, 1);
 	m_delay_timer = timer_alloc(FUNC(grid210x_device::delay_tick), this);
+	m_talk_timer = timer_alloc(FUNC(grid210x_device::talk_tick), this);
 }
 
 TIMER_CALLBACK_MEMBER(grid210x_device::delay_tick) {
@@ -272,6 +282,12 @@ TIMER_CALLBACK_MEMBER(grid210x_device::delay_tick) {
 	has_srq = true;
 	m_bus->srq_w(this, 0);
 	m_floppy_loop_state = GRID210X_STATE_IDLE;
+}
+
+TIMER_CALLBACK_MEMBER(grid210x_device::talk_tick) {
+	if (m_gpib_loop_state == GRID210X_GPIB_STATE_SEND_DATA_START) {
+		ieee488_nrfd(m_bus->nrfd_r());
+	}
 }
 
 void grid210x_device::ieee488_eoi(int state) {
@@ -323,7 +339,38 @@ void grid210x_device::accept_transfer() {
 	}
 }
 
+void grid210x_device::start_talking_if_ready() {
+	if (m_gpib_loop_state != GRID210X_GPIB_STATE_IDLE || m_ignore_state != GRID210X_IGNORE_STATE_NONE || !talking || !m_bus->atn_r()) {
+		return;
+	}
+
+	if (serial_polling) {
+		bool had_srq = has_srq;
+		if (has_srq) {
+			has_srq = false;
+			m_bus->srq_w(this, 1);
+		}
+		m_byte_to_send = serial_poll_byte | (had_srq ? 0x40 : 0);
+		serial_poll_byte = 0;
+		m_send_eoi = 1;
+		m_gpib_loop_state = GRID210X_GPIB_STATE_SEND_DATA_START;
+		m_talk_timer->adjust(attotime::zero);
+	} else if (!m_output_data_buffer.empty()) {
+		m_byte_to_send = m_output_data_buffer.front();
+		m_output_data_buffer.pop();
+		m_send_eoi = m_output_data_buffer.empty() ? 1 : 0;
+		m_gpib_loop_state = GRID210X_GPIB_STATE_SEND_DATA_START;
+		m_talk_timer->adjust(attotime::zero);
+	}
+}
+
 void grid210x_device::ieee488_dav(int state) {
+	if (m_ignore_state != GRID210X_IGNORE_STATE_NONE) {
+		m_bus->nrfd_w(this, 1);
+		m_bus->ndac_w(this, 1);
+		return;
+	}
+
 	if(state == 0 && m_gpib_loop_state == GRID210X_GPIB_STATE_IDLE) {
 		// read data and wait for transfer end
 		int atn = m_bus->atn_r() ^ 1;
@@ -341,28 +388,45 @@ void grid210x_device::ieee488_dav(int state) {
 		// m_bus->ndac_w(this, 0);
 		m_bus->nrfd_w(this, 1);
 		m_gpib_loop_state = GRID210X_GPIB_STATE_IDLE;
-		update_ndac(m_bus->atn_r() ^ 1);
 
 		if (m_last_recv_atn) {
 			if ((m_last_recv_byte & 0xe0) == 0x20) {
 				if ((m_last_recv_byte & 0x1f) == bus_addr) {
 					// dev-id = 5
 					listening = true;
+					talking = false;
+					m_data_buffer.clear();
+					m_ignore_state = GRID210X_IGNORE_STATE_NONE;
 					LOG_GPIB_STATE("grid210x_device now listening\n");
 				} else if((m_last_recv_byte & 0x1f) == 0x1f) {
 					// reset listen
 					listening = false;
+					m_data_buffer.clear();
 					LOG_GPIB_STATE("grid210x_device now not listening\n");
+				} else {
+					listening = false;
+					m_data_buffer.clear();
+					m_ignore_state = GRID210X_IGNORE_STATE_WAIT_ATN_HIGH;
+					LOG_GPIB_STATE("grid210x_device ignoring transfer for listener %u\n", (unsigned)(m_last_recv_byte & 0x1f));
 				}
 			} else if ((m_last_recv_byte & 0xe0) == 0x40) {
 				if ((m_last_recv_byte & 0x1f) == bus_addr) {
 					// dev-id = 5
 					talking = true;
+					listening = false;
+					m_data_buffer.clear();
+					m_ignore_state = GRID210X_IGNORE_STATE_NONE;
 					LOG_GPIB_STATE("grid210x_device now talking\n");
+				} else if ((m_last_recv_byte & 0x1f) == 0x1f) {
+					// reset talk
+					talking = false;
+					LOG_GPIB_STATE("grid210x_device now not talking\n");
 				} else {
 					// reset talk
 					talking = false;
 					LOG_GPIB_STATE("grid210x_device now not talking\n");
+					m_ignore_state = GRID210X_IGNORE_STATE_WAIT_ATN_HIGH;
+					LOG_GPIB_STATE("grid210x_device ignoring transfer for talker %u\n", (unsigned)(m_last_recv_byte & 0x1f));
 				}
 			} else if (m_last_recv_byte == 0x18) {
 				// serial poll enable
@@ -379,29 +443,13 @@ void grid210x_device::ieee488_dav(int state) {
 			}
 		}
 
-		if (talking) {
-			if (serial_polling) {
-				bool had_srq = has_srq;
-				if (has_srq) {
-					has_srq = false;
-					m_bus->srq_w(this, 1);
-				}
-				m_byte_to_send = serial_poll_byte | (had_srq ? 0x40 : 0);
-				serial_poll_byte = 0;
-				m_send_eoi = 1;
-				m_gpib_loop_state = GRID210X_GPIB_STATE_SEND_DATA_START;
-			} else if (!m_output_data_buffer.empty()) {
-				m_byte_to_send = m_output_data_buffer.front();
-				m_output_data_buffer.pop();
-				m_send_eoi = m_output_data_buffer.empty() ? 1 : 0;
-				m_gpib_loop_state = GRID210X_GPIB_STATE_SEND_DATA_START;
-			}
-		}
+		update_handshake(m_bus->atn_r() ^ 1);
+		start_talking_if_ready();
 	}
 }
 
 void grid210x_device::ieee488_nrfd(int state) {
-	if (state == 1 && m_gpib_loop_state == GRID210X_GPIB_STATE_SEND_DATA_START) {
+	if (state == 1 && m_gpib_loop_state == GRID210X_GPIB_STATE_SEND_DATA_START && m_bus->atn_r()) {
 		// set dio and assert dav
 		m_bus->host_dio_w(m_byte_to_send ^ 0xff);
 		m_bus->eoi_w(this, m_send_eoi ^ 1);
@@ -425,14 +473,8 @@ void grid210x_device::ieee488_ndac(int state) {
 		if (serial_polling) {
 			talking = false;
 		}
-		update_ndac(m_bus->atn_r() ^ 1);
-
-		if (!serial_polling && talking && !m_output_data_buffer.empty()) {
-			m_byte_to_send = m_output_data_buffer.front();
-			m_output_data_buffer.pop();
-			m_send_eoi = m_output_data_buffer.empty() ? 1 : 0;
-			m_gpib_loop_state = GRID210X_GPIB_STATE_SEND_DATA_START;
-		}
+		update_handshake(m_bus->atn_r() ^ 1);
+		start_talking_if_ready();
 	}
 	// logerror("grid210x_device ndac state set to %d\n", state);
 }
@@ -447,12 +489,27 @@ void grid210x_device::ieee488_srq(int state) {
 
 void grid210x_device::ieee488_atn(int state) {
 	// logerror("grid210x_device atn state set to %d\n", state);
-	update_ndac(state ^ 1);
+	if (m_ignore_state == GRID210X_IGNORE_STATE_WAIT_ATN_HIGH) {
+		if (state) {
+			m_ignore_state = GRID210X_IGNORE_STATE_WAIT_ATN_LOW;
+		}
+	} else if (m_ignore_state == GRID210X_IGNORE_STATE_WAIT_ATN_LOW) {
+		if (!state) {
+			m_ignore_state = GRID210X_IGNORE_STATE_NONE;
+		}
+	}
+	update_handshake(state ^ 1);
+	if (state) {
+		start_talking_if_ready();
+	}
 }
 
-void grid210x_device::update_ndac(int atn) {
+void grid210x_device::update_handshake(int atn) {
 	if (m_gpib_loop_state == GRID210X_GPIB_STATE_IDLE) {
-		if (atn) {
+		if (m_ignore_state != GRID210X_IGNORE_STATE_NONE) {
+			m_bus->nrfd_w(this, 1);
+			m_bus->ndac_w(this, 1);
+		} else if (atn) {
 			// pull NDAC low
 			m_bus->ndac_w(this, 0);
 		} else {

--- a/src/devices/bus/ieee488/grid2102.cpp
+++ b/src/devices/bus/ieee488/grid2102.cpp
@@ -55,9 +55,6 @@ static constexpr int STATUS_RESPONSE_LENGTH = 7;
 // GRiD GPIB disk devices always use 512-byte sectors, other sector sizes are not supported.
 static constexpr uint16_t SECTOR_SIZE = 512;
 
-static constexpr int GRID2101_HARDDISK_DEV_ADDR = 4;
-static constexpr int GRID2102_DEV_ADDR = 6;
-
 enum class grid210x_gpib_state
 {
 	idle,
@@ -402,7 +399,7 @@ void grid210x_device::accept_transfer() {
 		} // else something is wrong, ignore
 	} else if (m_floppy_loop_state == grid210x_state::writing_data) {
 		// write
-		if (floppy_sector_number < 0xfffF) {
+		if (floppy_sector_number < 0xffffF) {
 			fseek(floppy_sector_number * SECTOR_SIZE, SEEK_SET);
 			fwrite(m_data_buffer.data(), m_data_buffer.size());
 		} else {

--- a/src/devices/bus/ieee488/grid2102.cpp
+++ b/src/devices/bus/ieee488/grid2102.cpp
@@ -21,18 +21,92 @@
 #include <string_view>
 #include <vector>
 
-#define LOG_BYTES_MASK    (LOG_GENERAL << 1)
-#define LOG_GPIB_STATE_MASK (LOG_GENERAL << 2)
+#define LOG_BYTES_MASK       (LOG_GENERAL << 1)
+#define LOG_GPIB_STATE_MASK  (LOG_GENERAL << 2)
+#define LOG_GPIB_LINES_MASK  (LOG_GENERAL << 3)
+#define LOG_DISK_OPS_MASK    (LOG_GENERAL << 4)
 
-#define LOG_BYTES(...)    LOGMASKED(LOG_BYTES_MASK, __VA_ARGS__)
-
-#define LOG_GPIB_STATE(...) LOGMASKED(LOG_GPIB_STATE_MASK, __VA_ARGS__)
+#define LOG_BYTES(...)       LOGMASKED(LOG_BYTES_MASK, __VA_ARGS__)
+#define LOG_GPIB_STATE(...)  LOGMASKED(LOG_GPIB_STATE_MASK, __VA_ARGS__)
+#define LOG_GPIB_LINES(...)  LOGMASKED(LOG_GPIB_LINES_MASK, __VA_ARGS__)
+#define LOG_DISK_OPS(...)    LOGMASKED(LOG_DISK_OPS_MASK, __VA_ARGS__)
 
 #define VERBOSE (LOG_GENERAL)
 #include "logmacro.h"
 
 
 namespace {
+
+static constexpr uint8_t GPIB_CMD_GROUP_MASK = 0xe0;
+static constexpr uint8_t GPIB_CMD_ADDR_MASK = 0x1f;
+static constexpr uint8_t GPIB_CMD_DCL = 0x14;
+static constexpr uint8_t GPIB_CMD_SPE = 0x18;
+static constexpr uint8_t GPIB_CMD_SPD = 0x19;
+static constexpr uint8_t GPIB_CMD_MLA = 0x20;
+static constexpr uint8_t GPIB_CMD_MTA = 0x40;
+static constexpr uint8_t GPIB_CMD_UNL = 0x3f;
+static constexpr uint8_t GPIB_CMD_UNT = 0x5f;
+
+static constexpr uint8_t GPIB_STATUS_RQS = 0x40;
+
+static constexpr int REQUEST_LENGTH = 10;
+static constexpr int STATUS_RESPONSE_LENGTH = 7;
+
+// GRiD GPIB disk devices always use 512-byte sectors, other sector sizes are not supported.
+static constexpr uint16_t SECTOR_SIZE = 512;
+
+static constexpr int GRID2101_HARDDISK_DEV_ADDR = 4;
+static constexpr int GRID2102_DEV_ADDR = 6;
+
+enum class grid210x_gpib_state
+{
+	idle,
+	wait_dav_false,
+	send_data_start,
+	wait_ndac_false,
+};
+
+enum class grid210x_ignore_state
+{
+	none,
+	wait_atn_high,
+	wait_atn_low,
+};
+
+enum class grid210x_state
+{
+	idle,
+	reading_data,
+	writing_data,
+	writing_data_wait,
+	formatting,
+};
+
+enum class disk_command : uint8_t
+{
+	initialize = 0,
+	get_status = 1,
+	read = 4,
+	write = 5,
+	format = 17,
+};
+
+bool parse_disk_command(uint8_t value, disk_command &command)
+{
+	switch (value)
+	{
+	case uint8_t(disk_command::initialize):
+	case uint8_t(disk_command::get_status):
+	case uint8_t(disk_command::read):
+	case uint8_t(disk_command::write):
+	case uint8_t(disk_command::format):
+		command = disk_command(value);
+		return true;
+
+	default:
+		return false;
+	}
+}
 
 //**************************************************************************
 //  TYPE DEFINITIONS
@@ -98,15 +172,15 @@ private:
 	TIMER_CALLBACK_MEMBER(delay_tick);
 	TIMER_CALLBACK_MEMBER(talk_tick);
 
-	int m_gpib_loop_state;
-	int m_floppy_loop_state;
+	grid210x_gpib_state m_gpib_loop_state;
+	grid210x_state m_floppy_loop_state;
 	uint8_t m_last_recv_byte;
 	int m_last_recv_eoi;
 	int m_last_recv_atn;
 	uint8_t m_byte_to_send;
 	int m_send_eoi;
 	bool listening, talking, serial_polling;
-	int m_ignore_state;
+	grid210x_ignore_state m_ignore_state;
 	bool has_srq;
 	uint8_t serial_poll_byte;
 	uint32_t floppy_sector_number;
@@ -154,66 +228,36 @@ protected:
 
 static const grid210x_device::disk_status fdd_status
 {
-	512,
+	SECTOR_SIZE,
 	504,
-	360 * 1024 / 512,  // 360KiB, 5.25  DS/DD
+	360 * 1024 / SECTOR_SIZE,  // 360KiB, 5.25  DS/DD
 	1,  // ok
 	0x120,
 	0x121,
 	1,
 	0,
 	"48 TPI DS DD FLOPPY 30237-00",
-	512,
+	SECTOR_SIZE,
 	9,
 	2,
 };
 
 static const grid210x_device::disk_status hdd_status
 {
-	512,
+	SECTOR_SIZE,
 	504,
-	(10 * 1024 * 1024) / 512,  // 10 MB by default
+	(10 * 1024 * 1024) / SECTOR_SIZE,  // 10 MB by default
 	1,  // ok
 	0x2400,
 	0x2420,
 	10,
 	0,
 	"MAME HARD DISK DRIVE",
-	512,
+	SECTOR_SIZE,
 	10,
 	4,
 };
 
-
-static constexpr uint8_t GPIB_CMD_GROUP_MASK = 0xe0;
-static constexpr uint8_t GPIB_CMD_ADDR_MASK = 0x1f;
-static constexpr uint8_t GPIB_CMD_DCL = 0x14;
-static constexpr uint8_t GPIB_CMD_SPE = 0x18;
-static constexpr uint8_t GPIB_CMD_SPD = 0x19;
-static constexpr uint8_t GPIB_CMD_MLA = 0x20;
-static constexpr uint8_t GPIB_CMD_MTA = 0x40;
-static constexpr uint8_t GPIB_CMD_UNL = 0x3f;
-static constexpr uint8_t GPIB_CMD_UNT = 0x5f;
-
-static constexpr uint8_t GPIB_STATUS_RQS = 0x40;
-
-#define GRID2101_HARDDISK_DEV_ADDR 4
-#define GRID2102_DEV_ADDR 6
-
-#define GRID210X_GPIB_STATE_IDLE 0
-#define GRID210X_GPIB_STATE_WAIT_DAV_FALSE 1
-#define GRID210X_GPIB_STATE_SEND_DATA_START 2
-#define GRID210X_GPIB_STATE_WAIT_NDAC_FALSE 3
-
-#define GRID210X_IGNORE_STATE_NONE 0
-#define GRID210X_IGNORE_STATE_WAIT_ATN_HIGH 1
-#define GRID210X_IGNORE_STATE_WAIT_ATN_LOW 2
-
-#define GRID210X_STATE_IDLE 0
-#define GRID210X_STATE_READING_DATA 1
-#define GRID210X_STATE_WRITING_DATA 2
-#define GRID210X_STATE_WRITING_DATA_WAIT 3
-#define GRID210X_STATE_FORMATTING 4
 
 std::array<uint8_t, 52> grid210x_device::disk_status::serialize() const
 {
@@ -238,12 +282,12 @@ grid210x_device::grid210x_device(const machine_config &mconfig, device_type type
 	device_t(mconfig, type, tag, owner, clock),
 	device_ieee488_interface(mconfig, *this),
 	device_image_interface(mconfig, *this),
-	m_gpib_loop_state(GRID210X_GPIB_STATE_IDLE),
-	m_floppy_loop_state(GRID210X_STATE_IDLE),
+	m_gpib_loop_state(grid210x_gpib_state::idle),
+	m_floppy_loop_state(grid210x_state::idle),
 	listening(false),
 	talking(false),
 	serial_polling(false),
-	m_ignore_state(GRID210X_IGNORE_STATE_NONE),
+	m_ignore_state(grid210x_ignore_state::none),
 	has_srq(false),
 	serial_poll_byte(0),
 	bus_addr(bus_addr),
@@ -260,30 +304,30 @@ void grid210x_device::device_start() {
 }
 
 TIMER_CALLBACK_MEMBER(grid210x_device::delay_tick) {
-	if (m_floppy_loop_state == GRID210X_STATE_READING_DATA) {
+	if (m_floppy_loop_state == grid210x_state::reading_data) {
 		std::unique_ptr<uint8_t[]> data(new uint8_t[io_size]);
-		fseek(floppy_sector_number * 512, SEEK_SET);
+		fseek(floppy_sector_number * SECTOR_SIZE, SEEK_SET);
 		fread(data.get(), io_size);
 		for (int i = 0; i < io_size; i++) {
 			m_output_data_buffer.push(data[i]);
 		}
-	} else if (m_floppy_loop_state == GRID210X_STATE_FORMATTING) {
+	} else if (m_floppy_loop_state == grid210x_state::formatting) {
 		const uint32_t sector_total = get_status().sector_count;
 
-		uint8_t buf[512];
+		uint8_t buf[SECTOR_SIZE];
 		std::fill(std::begin(buf), std::end(buf), 0xe5);
 		std::fill_n(std::begin(buf), 8, 0xff);
 
 		for (uint32_t sec = 0; sec < sector_total; sec++) {
-			fseek(s64(sec) * 512, SEEK_SET);
-			fwrite(buf, 512);
+			fseek(s64(sec) * SECTOR_SIZE, SEEK_SET);
+			fwrite(buf, SECTOR_SIZE);
 		}
 
-		for (int i = 0; i < 7; i++) {
+		for (int i = 0; i < STATUS_RESPONSE_LENGTH; i++) {
 			m_output_data_buffer.push(0);
 		}
-	} else if (m_floppy_loop_state == GRID210X_STATE_WRITING_DATA_WAIT) {
-		for (int i = 0; i < 7; i++) {
+	} else if (m_floppy_loop_state == grid210x_state::writing_data_wait) {
+		for (int i = 0; i < STATUS_RESPONSE_LENGTH; i++) {
 			m_output_data_buffer.push(0);
 		}
 	} else {
@@ -293,66 +337,86 @@ TIMER_CALLBACK_MEMBER(grid210x_device::delay_tick) {
 	serial_poll_byte = 0x0f;
 	has_srq = true;
 	m_bus->srq_w(this, 0);
-	m_floppy_loop_state = GRID210X_STATE_IDLE;
+	m_floppy_loop_state = grid210x_state::idle;
 }
 
 TIMER_CALLBACK_MEMBER(grid210x_device::talk_tick) {
-	if (m_gpib_loop_state == GRID210X_GPIB_STATE_SEND_DATA_START) {
+	if (m_gpib_loop_state == grid210x_gpib_state::send_data_start) {
 		ieee488_nrfd(m_bus->nrfd_r());
 	}
 }
 
 void grid210x_device::ieee488_eoi(int state) {
-	// logerror("grid210x_device eoi state set to %d\n", state);
+	LOG_GPIB_LINES("grid210x_device eoi state set to %d\n", state);
 }
 
 void grid210x_device::accept_transfer() {
-	if (m_floppy_loop_state == GRID210X_STATE_IDLE) {
-		if (m_data_buffer.size() >= 0xa) {
-			uint8_t command = m_data_buffer[0];
+	if (m_floppy_loop_state == grid210x_state::idle) {
+		if (m_data_buffer.size() == REQUEST_LENGTH) {
+			const uint8_t command_byte = m_data_buffer[0];
+			disk_command command;
 			uint32_t sector_number = get_u32le(&m_data_buffer[3]);
 			uint16_t data_size = get_u16le(&m_data_buffer[7]);
-			LOG("grid210x_device command %u, data size %u, sector no %u\n", (unsigned)command, (unsigned)data_size, (unsigned)sector_number);
+			LOG("grid210x_device command %u, data size %u, sector no %u\n", (unsigned)command_byte, (unsigned)data_size, (unsigned)sector_number);
+			if (!parse_disk_command(command_byte, command)) {
+				LOG("grid210x_device ignoring unsupported command %u, data size %u, sector no %u\n", (unsigned)command_byte, (unsigned)data_size, (unsigned)sector_number);
+				return;
+			}
+
 			(void)(sector_number);
-			if (command == 0x0) { // ddInitialize
-				for (int i = 0; i < 7; i++) { // just OK
+			switch (command) {
+			case disk_command::initialize:
+				for (int i = 0; i < STATUS_RESPONSE_LENGTH; i++) { // just OK
 					m_output_data_buffer.push(0);
 				}
-			} else if (command == 0x1) { // ddGetStatus
+				break;
+
+			case disk_command::get_status:
 				for (uint8_t b : get_status().serialize()) {
 					m_output_data_buffer.push(b);
 				}
-			} else if (command == 0x4) { // ddRead
+				break;
+
+			case disk_command::read:
 				floppy_sector_number = sector_number;
 				io_size = data_size;
-				m_floppy_loop_state = GRID210X_STATE_READING_DATA;
+				m_floppy_loop_state = grid210x_state::reading_data;
 				m_delay_timer->adjust(read_delay);
-			} else if (command == 0x5) {
+				break;
+
+			case disk_command::write:
 				floppy_sector_number = sector_number;
 				io_size = data_size;
-				m_floppy_loop_state = GRID210X_STATE_WRITING_DATA;
-			} else if (command == 0x11) { // ddFormat
-				m_floppy_loop_state = GRID210X_STATE_FORMATTING;
+				m_floppy_loop_state = grid210x_state::writing_data;
+				break;
+
+			case disk_command::format:
+				m_floppy_loop_state = grid210x_state::formatting;
 				m_delay_timer->adjust(read_delay);
+				break;
+
+			default:
+				LOG("grid210x_device unhandled command %u, data size %u, sector no %u\n", (unsigned)command_byte, (unsigned)data_size, (unsigned)sector_number);
+				break;
 			}
 		} // else something is wrong, ignore
-	} else if (m_floppy_loop_state == GRID210X_STATE_WRITING_DATA) {
+	} else if (m_floppy_loop_state == grid210x_state::writing_data) {
 		// write
 		if (floppy_sector_number < 0xfffF) {
-			fseek(floppy_sector_number * 512, SEEK_SET);
+			fseek(floppy_sector_number * SECTOR_SIZE, SEEK_SET);
 			fwrite(m_data_buffer.data(), m_data_buffer.size());
 		} else {
 			// TODO: set status
 		}
-		// logerror("grid210x_device write sector %d\n", floppy_sector_number);
+		LOG_DISK_OPS("grid210x_device write sector %u\n", floppy_sector_number);
 		// wait
-		m_floppy_loop_state = GRID210X_STATE_WRITING_DATA_WAIT;
+		m_floppy_loop_state = grid210x_state::writing_data_wait;
 		m_delay_timer->adjust(read_delay);
 	}
 }
 
 void grid210x_device::start_talking_if_ready() {
-	if (m_gpib_loop_state != GRID210X_GPIB_STATE_IDLE || m_ignore_state != GRID210X_IGNORE_STATE_NONE || !talking || !m_bus->atn_r()) {
+	if (m_gpib_loop_state != grid210x_gpib_state::idle || m_ignore_state != grid210x_ignore_state::none || !talking || !m_bus->atn_r()) {
 		return;
 	}
 
@@ -365,25 +429,25 @@ void grid210x_device::start_talking_if_ready() {
 		m_byte_to_send = serial_poll_byte | (had_srq ? GPIB_STATUS_RQS : 0);
 		serial_poll_byte = 0;
 		m_send_eoi = 1;
-		m_gpib_loop_state = GRID210X_GPIB_STATE_SEND_DATA_START;
+		m_gpib_loop_state = grid210x_gpib_state::send_data_start;
 		m_talk_timer->adjust(attotime::zero);
 	} else if (!m_output_data_buffer.empty()) {
 		m_byte_to_send = m_output_data_buffer.front();
 		m_output_data_buffer.pop();
 		m_send_eoi = m_output_data_buffer.empty() ? 1 : 0;
-		m_gpib_loop_state = GRID210X_GPIB_STATE_SEND_DATA_START;
+		m_gpib_loop_state = grid210x_gpib_state::send_data_start;
 		m_talk_timer->adjust(attotime::zero);
 	}
 }
 
 void grid210x_device::ieee488_dav(int state) {
-	if (m_ignore_state != GRID210X_IGNORE_STATE_NONE) {
+	if (m_ignore_state != grid210x_ignore_state::none) {
 		m_bus->nrfd_w(this, 1);
 		m_bus->ndac_w(this, 1);
 		return;
 	}
 
-	if(state == 0 && m_gpib_loop_state == GRID210X_GPIB_STATE_IDLE) {
+	if(state == 0 && m_gpib_loop_state == grid210x_gpib_state::idle) {
 		// read data and wait for transfer end
 		int atn = m_bus->atn_r() ^ 1;
 		m_bus->nrfd_w(this, 0);
@@ -394,12 +458,12 @@ void grid210x_device::ieee488_dav(int state) {
 		m_last_recv_atn = atn;
 		m_last_recv_eoi = eoi;
 		m_bus->ndac_w(this, 1);
-		m_gpib_loop_state = GRID210X_GPIB_STATE_WAIT_DAV_FALSE;
-	} else if (state == 1 && m_gpib_loop_state == GRID210X_GPIB_STATE_WAIT_DAV_FALSE) {
+		m_gpib_loop_state = grid210x_gpib_state::wait_dav_false;
+	} else if (state == 1 && m_gpib_loop_state == grid210x_gpib_state::wait_dav_false) {
 		// restore initial state
 		// m_bus->ndac_w(this, 0);
 		m_bus->nrfd_w(this, 1);
-		m_gpib_loop_state = GRID210X_GPIB_STATE_IDLE;
+		m_gpib_loop_state = grid210x_gpib_state::idle;
 
 		if (m_last_recv_atn) {
 			const uint8_t command_group = m_last_recv_byte & GPIB_CMD_GROUP_MASK;
@@ -411,12 +475,12 @@ void grid210x_device::ieee488_dav(int state) {
 				talking = false;
 				if (command_addr == bus_addr) {
 					listening = true;
-					m_ignore_state = GRID210X_IGNORE_STATE_NONE;
+					m_ignore_state = grid210x_ignore_state::none;
 					LOG_GPIB_STATE("grid210x_device now listening\n");
 				} else if (m_last_recv_byte == GPIB_CMD_UNL) {
 					LOG_GPIB_STATE("grid210x_device now not listening\n");
 				} else {
-					m_ignore_state = GRID210X_IGNORE_STATE_WAIT_ATN_HIGH;
+					m_ignore_state = grid210x_ignore_state::wait_atn_high;
 					LOG_GPIB_STATE("grid210x_device ignoring transfer for listener %u\n", (unsigned)command_addr);
 				}
 			} else if (command_group == GPIB_CMD_MTA) {
@@ -425,12 +489,12 @@ void grid210x_device::ieee488_dav(int state) {
 				listening = false;
 				if (command_addr == bus_addr) {
 					talking = true;
-					m_ignore_state = GRID210X_IGNORE_STATE_NONE;
+					m_ignore_state = grid210x_ignore_state::none;
 					LOG_GPIB_STATE("grid210x_device now talking\n");
 				} else if (m_last_recv_byte == GPIB_CMD_UNT) {
 					LOG_GPIB_STATE("grid210x_device now not talking\n");
 				} else {
-					m_ignore_state = GRID210X_IGNORE_STATE_WAIT_ATN_HIGH;
+					m_ignore_state = grid210x_ignore_state::wait_atn_high;
 					LOG_GPIB_STATE("grid210x_device ignoring transfer for talker %u\n", (unsigned)command_addr);
 				}
 			} else if (m_last_recv_byte == GPIB_CMD_SPE) {
@@ -454,53 +518,53 @@ void grid210x_device::ieee488_dav(int state) {
 }
 
 void grid210x_device::ieee488_nrfd(int state) {
-	if (state == 1 && m_gpib_loop_state == GRID210X_GPIB_STATE_SEND_DATA_START && m_bus->atn_r()) {
+	if (state == 1 && m_gpib_loop_state == grid210x_gpib_state::send_data_start && m_bus->atn_r()) {
 		// set dio and assert dav
 		m_bus->host_dio_w(m_byte_to_send ^ 0xff);
 		m_bus->eoi_w(this, m_send_eoi ^ 1);
 		m_bus->dav_w(this, 0);
 		m_bus->ndac_w(this, 1);
-		m_gpib_loop_state = GRID210X_GPIB_STATE_WAIT_NDAC_FALSE;
+		m_gpib_loop_state = grid210x_gpib_state::wait_ndac_false;
 		LOG_BYTES("grid210x_device byte send %02x eoi %d\n", m_byte_to_send, m_send_eoi);
 		ieee488_ndac(m_bus->ndac_r());
 	}
-	// logerror("grid210x_device nrfd state set to %d\n", state);
+	LOG_GPIB_LINES("grid210x_device nrfd state set to %d\n", state);
 }
 
 void grid210x_device::ieee488_ndac(int state) {
-	if (state == 1 && m_gpib_loop_state == GRID210X_GPIB_STATE_WAIT_NDAC_FALSE) {
+	if (state == 1 && m_gpib_loop_state == grid210x_gpib_state::wait_ndac_false) {
 		// restore initial state
-		// logerror("grid210x_device restore ndac nrfd dav eoi\n");
+		LOG_GPIB_LINES("grid210x_device restore ndac nrfd dav eoi\n");
 		m_bus->nrfd_w(this, 1);
 		m_bus->dav_w(this, 1);
 		m_bus->eoi_w(this, 1);
-		m_gpib_loop_state = GRID210X_GPIB_STATE_IDLE;
+		m_gpib_loop_state = grid210x_gpib_state::idle;
 		if (serial_polling) {
 			talking = false;
 		}
 		update_handshake(m_bus->atn_r() ^ 1);
 		start_talking_if_ready();
 	}
-	// logerror("grid210x_device ndac state set to %d\n", state);
+	LOG_GPIB_LINES("grid210x_device ndac state set to %d\n", state);
 }
 
 void grid210x_device::ieee488_ifc(int state) {
-	// logerror("grid210x_device ifc state set to %d\n", state);
+	LOG_GPIB_LINES("grid210x_device ifc state set to %d\n", state);
 }
 
 void grid210x_device::ieee488_srq(int state) {
-	// logerror("grid210x_device srq state set to %d\n", state);
+	LOG_GPIB_LINES("grid210x_device srq state set to %d\n", state);
 }
 
 void grid210x_device::ieee488_atn(int state) {
-	// logerror("grid210x_device atn state set to %d\n", state);
-	if (m_ignore_state == GRID210X_IGNORE_STATE_WAIT_ATN_HIGH) {
+	LOG_GPIB_LINES("grid210x_device atn state set to %d\n", state);
+	if (m_ignore_state == grid210x_ignore_state::wait_atn_high) {
 		if (state) {
-			m_ignore_state = GRID210X_IGNORE_STATE_WAIT_ATN_LOW;
+			m_ignore_state = grid210x_ignore_state::wait_atn_low;
 		}
-	} else if (m_ignore_state == GRID210X_IGNORE_STATE_WAIT_ATN_LOW) {
+	} else if (m_ignore_state == grid210x_ignore_state::wait_atn_low) {
 		if (!state) {
-			m_ignore_state = GRID210X_IGNORE_STATE_NONE;
+			m_ignore_state = grid210x_ignore_state::none;
 		}
 	}
 	update_handshake(state ^ 1);
@@ -510,8 +574,8 @@ void grid210x_device::ieee488_atn(int state) {
 }
 
 void grid210x_device::update_handshake(int atn) {
-	if (m_gpib_loop_state == GRID210X_GPIB_STATE_IDLE) {
-		if (m_ignore_state != GRID210X_IGNORE_STATE_NONE) {
+	if (m_gpib_loop_state == grid210x_gpib_state::idle) {
+		if (m_ignore_state != grid210x_ignore_state::none) {
 			m_bus->nrfd_w(this, 1);
 			m_bus->ndac_w(this, 1);
 		} else if (atn) {


### PR DESCRIPTION
This PR fixes simultaneous work of multiple 210x devices by properly handling MLA/MTA and releasing the handshake lines when the laptop is communicating with another device.

I also refactored constants and states to make the code a bit clearer. During the refactor, I found and fixed a bug where data was not written past sector `0xfff`.

All changes are split into commits. I can split this into multiple PRs if that would make maintainer review easier.