### PR TITLE
imagedev/snapquik.cpp: Allowed to use quickload together with -state

### DIFF
--- a/src/devices/imagedev/snapquik.cpp
+++ b/src/devices/imagedev/snapquik.cpp
@@ -87,6 +87,12 @@ void snapshot_image_device::device_start()
 	m_timer = timer_alloc(FUNC(snapshot_image_device::process_snapshot_or_quickload), this);
 }
 
+void snapshot_image_device::device_post_load()
+{
+	if (exists())
+		call_load();
+}
+
 /*-------------------------------------------------
     call_load
 -------------------------------------------------*/

--- a/src/devices/imagedev/snapquik.h
+++ b/src/devices/imagedev/snapquik.h
@@ -64,6 +64,7 @@ protected:
 
 	// device-level overrides
 	virtual void device_start() override ATTR_COLD;
+	virtual void device_post_load() override ATTR_COLD;
 
 	// device_image_interface implementation
 	virtual const software_list_loader &get_software_list_loader() const override;


### PR DESCRIPTION
`-state` provide time from saved state and this prevent `-dump` to be executed on top of it.