### PR TITLE
ns32000: fetch module static base after PSR restore on RETT/RETI

### DIFF
--- a/src/devices/cpu/ns32000/ns32000.cpp
+++ b/src/devices/cpu/ns32000/ns32000.cpp
@@ -1169,13 +1169,8 @@ template <int HighBits, int Width> void ns32000_device<HighBits, Width>::execute
 
 						if (!(m_cfg & CFG_DE))
 						{
-							u16 const mod = mem_read<u16>(ns32000::ST_ODT, SP() + 4);
-							u32 const sb = mem_read<u32>(ns32000::ST_ODT, mod);
-
-							m_mod = mod;
-							m_sb = sb;
-
-							tex = top(SIZE_D, SP()) + top(SIZE_W, SP()) * 2 + top(SIZE_D, mod) + 35;
+							m_mod = mem_read<u16>(ns32000::ST_ODT, SP() + 4);
+							tex = top(SIZE_D, SP()) + top(SIZE_W, SP()) * 2 + top(SIZE_D, m_mod) + 35;
 						}
 						else
 							tex = top(SIZE_D, SP()) + top(SIZE_W, SP()) + 35;
@@ -1184,6 +1179,13 @@ template <int HighBits, int Width> void ns32000_device<HighBits, Width>::execute
 
 						m_pc = pc;
 						m_psr = psr;
+
+						// the static base is fetched from the module table AFTER the PSR is
+						// restored: a return to user mode reads the USER address space's module
+						// table (dual-space translation), not the supervisor's
+						if (!(m_cfg & CFG_DE))
+							m_sb = mem_read<u32>(ns32000::ST_ODT, m_mod);
+
 						SP() += constant;
 
 						m_sequential = false;
@@ -1215,12 +1217,7 @@ template <int HighBits, int Width> void ns32000_device<HighBits, Width>::execute
 
 						if (!(m_cfg & CFG_DE))
 						{
-							u16 const mod = mem_read<u16>(ns32000::ST_ODT, SP() + 4);
-							u32 const sb = mem_read<u32>(ns32000::ST_ODT, mod);
-
-							m_mod = mod;
-							m_sb = sb;
-
+							m_mod = mem_read<u16>(ns32000::ST_ODT, SP() + 4);
 							tex = top(SIZE_B) + top(SIZE_W, SP()) * 3 + top(SIZE_D) * 3 + 39;
 						}
 						else
@@ -1230,6 +1227,12 @@ template <int HighBits, int Width> void ns32000_device<HighBits, Width>::execute
 
 						m_pc = pc;
 						m_psr = psr;
+
+						// as with RETT: the static base is fetched from the module table AFTER the
+						// PSR is restored, so a return to user mode reads the USER address space's
+						// module table under dual-space translation
+						if (!(m_cfg & CFG_DE))
+							m_sb = mem_read<u32>(ns32000::ST_ODT, m_mod);
 
 						m_sequential = false;
 					}


### PR DESCRIPTION
On RETT and RETI, the module static base (SB) is now loaded from the module table *after* the PSR is restored, not before.

The Series 32000 Programmer's Reference Manual specifies the operation order for both instructions as: pop PC, pop MOD, pop PSR, then copy the double-word at the address in MOD into the SB register. The PSR pop can change the S/U mode. The previous code loaded SB before restoring the PSR, so on a return to user mode a dual-space MMU translated the module-table read through the supervisor address space instead of the user space selected by the restored PSR.

Both handlers now defer the SB fetch until after the PSR write, matching the documented order.

No effect on single-space configurations, or in direct-exception mode (which skips module addressing entirely): the fetched value only differs when the user and supervisor mappings diverge; only the ordering relative to the PSR write changed. Checked against a normal pc532 boot (unchanged) and a dual-space System V build on the Siemens PC-MX2 (NS32016), where the user-space module-table read is required.
