### PR TITLE
sound/cem3394.cpp: replaced CV dispatching function with multiple setter functions.

### DIFF
--- a/src/devices/sound/cem3394.cpp
+++ b/src/devices/sound/cem3394.cpp
@@ -13,15 +13,11 @@
 #include "sound/flt_rc.h"
 
 #include <limits>
-#include <unordered_set>
 
 
 // logging
 #define LOG_CONTROL_CHANGES (1U << 1)
-#define LOG_NANS            (1U << 2)
-#define LOG_VALUES          (1U << 3)
-#define LOG_CONFIG          (1U << 4)
-#define VERBOSE (LOG_NANS)
+#define VERBOSE (0)
 #include "logmacro.h"
 
 
@@ -92,12 +88,6 @@ static constexpr double EXTERNAL_VOLUME = PULSE_VOLUME;
 ********************************************************************************/
 
 
-// various waveforms
-#define WAVE_TRIANGLE       1
-#define WAVE_SAWTOOTH       2
-#define WAVE_PULSE          4
-
-
 // device type definition
 DEFINE_DEVICE_TYPE(CEM3394, cem3394_device, "cem3394", "CEM3394 Synthesizer Voice")
 
@@ -107,11 +97,11 @@ DEFINE_DEVICE_TYPE(CEM3394, cem3394_device, "cem3394", "CEM3394 Synthesizer Voic
 
 
 cem3394_device::cem3394_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
-	cem3394_device(mconfig, tag, owner, components(), input_array{})
+	cem3394_device(mconfig, tag, owner, components(), stream_inputs())
 {
 }
 
-cem3394_device::cem3394_device(const machine_config &mconfig, const char *tag, device_t *owner, const components &comps, const input_array& inputs) :
+cem3394_device::cem3394_device(const machine_config &mconfig, const char *tag, device_t *owner, const components &comps, const stream_inputs& inputs) :
 	device_t(mconfig, CEM3394, tag, owner, 0),
 	device_sound_interface(mconfig, *this),
 	m_stream_inputs(inputs),
@@ -122,14 +112,24 @@ cem3394_device::cem3394_device(const machine_config &mconfig, const char *tag, d
 	// Note that "4.3 x 10E-5" in the equation should be 4.3E-5. The surrounding
 	// text and the example walkthrough use the correct value.
 	m_filter_zero_freq(4.3E-5 / comps.c_vcf),
+	m_initialized(false),
 	m_stream(nullptr),
 	m_vco(*this, "vco"),
 	m_filt_freq(*this, "filt_freq"),
 	m_filt_fm(*this, "filt_fm"),
 	m_vcf(*this, "vcf"),
 	m_vca(*this, "vca"),
-	m_values{},
-	m_wave_select(0),
+	m_vco_freq_cv(std::numeric_limits<double>::quiet_NaN()),
+	m_mod_amount_cv(std::numeric_limits<double>::quiet_NaN()),
+	m_wave_select_cv(std::numeric_limits<double>::quiet_NaN()),
+	m_pulse_width_cv(std::numeric_limits<double>::quiet_NaN()),
+	m_mixer_balance_cv(std::numeric_limits<double>::quiet_NaN()),
+	m_filt_res_cv(std::numeric_limits<double>::quiet_NaN()),
+	m_filt_freq_cv(std::numeric_limits<double>::quiet_NaN()),
+	m_final_gain_cv(std::numeric_limits<double>::quiet_NaN()),
+	m_tri(false),
+	m_saw(false),
+	m_pulse(false),
 	m_vco_frequency(500.0),
 	m_pulse_width(0),
 	m_volume(0),
@@ -148,16 +148,6 @@ void cem3394_device::sound_stream_update(sound_stream &stream)
 
 void cem3394_device::device_add_mconfig(machine_config &config)
 {
-	const std::unordered_set<int> SUPPORTED_STREAM_INPUTS =
-	{
-		AUDIO_INPUT, FILTER_FREQUENCY, FINAL_GAIN,
-	};
-	for (int i = 0; i < m_stream_inputs.size(); ++i)
-	{
-		if (m_stream_inputs[i] != nullptr && !SUPPORTED_STREAM_INPUTS.contains(i))
-			fatalerror("%s unsupported streaming input: %d\n", tag(), i);
-	}
-
 	// Set up the VCO.
 	// Route gains will be adjusted in update_mix().
 	VA_VCO(config, m_vco)
@@ -169,17 +159,17 @@ void cem3394_device::device_add_mconfig(machine_config &config)
 		.add_route(va_vco_device::OUTPUT_TRIANGLE, m_filt_fm, 1.0, va_vca_device::INPUT_AUDIO);
 
 	// Set up the external input.
-	if (m_stream_inputs[AUDIO_INPUT] != nullptr)
+	if (m_stream_inputs.ext_input != nullptr)
 	{
 		// Route gain will be adjusted in update_mix().
-		m_stream_inputs[AUDIO_INPUT]->add_route(0, m_vcf, 1.0, va_lpf4_device::INPUT_AUDIO);
+		m_stream_inputs.ext_input->add_route(0, m_vcf, 1.0, va_lpf4_device::INPUT_AUDIO);
 	}
 
 	// Set up frequency control.
 	device_sound_interface *filt_freq = nullptr;
-	if (m_stream_inputs[FILTER_FREQUENCY] != nullptr)
+	if (m_stream_inputs.filt_freq_cv != nullptr)
 	{
-		m_stream_inputs[FILTER_FREQUENCY]->add_route(0, "cv2filtfreq", 1.0);
+		m_stream_inputs.filt_freq_cv->add_route(0, "cv2filtfreq", 1.0);
 		filt_freq = &VA_LAMBDA(config, "cv2filtfreq", [this] (float cv) { return stream_op_filter_freq(cv); });
 	}
 	else
@@ -220,9 +210,9 @@ void cem3394_device::device_add_mconfig(machine_config &config)
 		.add_route(0, m_vca, 1.0, va_vca_device::INPUT_AUDIO);
 
 	// Set up the VCA.
-	if (m_stream_inputs[FINAL_GAIN] != nullptr)
+	if (m_stream_inputs.final_gain_cv != nullptr)
 	{
-		m_stream_inputs[FINAL_GAIN]->add_route(0, "cv2ampgain", 1.0);
+		m_stream_inputs.final_gain_cv->add_route(0, "cv2ampgain", 1.0);
 		VA_LAMBDA(config, "cv2ampgain", [this] (float cv) { return stream_op_amp_gain(cv); })
 			.add_route(0, m_vca, 1.0, va_vca_device::INPUT_GAIN);
 	}
@@ -234,16 +224,23 @@ void cem3394_device::device_start()
 	// allocate stream channels
 	m_stream = stream_alloc(1, 1, machine().sample_rate());
 
-	save_item(NAME(m_values));
+	save_item(NAME(m_vco_freq_cv));
+	save_item(NAME(m_mod_amount_cv));
+	save_item(NAME(m_wave_select_cv));
+	save_item(NAME(m_pulse_width_cv));
+	save_item(NAME(m_mixer_balance_cv));
+	save_item(NAME(m_filt_res_cv));
+	save_item(NAME(m_filt_freq_cv));
+	save_item(NAME(m_final_gain_cv));
 
-	save_item(NAME(m_wave_select));
+	save_item(NAME(m_tri));
+	save_item(NAME(m_saw));
+	save_item(NAME(m_pulse));
 	save_item(NAME(m_vco_frequency));
 	save_item(NAME(m_pulse_width));
-
 	save_item(NAME(m_volume));
 	save_item(NAME(m_mixer_internal));
 	save_item(NAME(m_mixer_external));
-
 	save_item(NAME(m_filter_frequency));
 	save_item(NAME(m_filter_modulation));
 	save_item(NAME(m_filter_resonance));
@@ -251,22 +248,245 @@ void cem3394_device::device_start()
 
 void cem3394_device::device_reset()
 {
-	// Ensures that m_values, and member variables derived from m_values, are
-	// properly initialized. Index 0 is unused.
-	for (int i = 1; i < INPUT_COUNT; i++)
+	if (!m_initialized)
 	{
-		const double value = m_values[i];
+		// This initialization is only required on startup, not on reset. But it
+		// can't be done in device_start() because it requires the owned devices
+		// to be running. Using m_initialized to ensure this is only done once.
 
-		// Skip early exits in set_voltage*() functions. Force all calculations.
-		m_values[i] = std::numeric_limits<double>::quiet_NaN();
+		set_vco_freq_cv(0.0);
+		set_mod_amount_cv(0.0);
+		set_wave_select_cv(0.0);
+		set_pulse_width_cv(0.0);
+		set_mixer_balance_cv(0.0);
+		set_filt_res_cv(0.0);
 
-		if (m_stream_inputs[i] != nullptr)
-			set_voltage_internal(i, value);
+		if (m_stream_inputs.filt_freq_cv != nullptr)
+			set_filt_freq_cv_internal(0.0);
 		else
-			set_voltage(i, value);
+			set_filt_freq_cv(0.0);
+
+		if (m_stream_inputs.final_gain_cv != nullptr)
+			set_final_gain_cv_internal(0.0);
+		else
+			set_final_gain_cv(0.0);
+
+		update_mix();
+		m_initialized = true;
 	}
+}
+
+
+void cem3394_device::set_vco_freq_cv(double cv)
+{
+	if (cv == m_vco_freq_cv)
+		return;
+
+	m_stream->update();
+	m_vco_freq_cv = cv;
+
+	// frequency varies from -4.0 to +4.0, at 0.75V/octave
+	m_vco_frequency = m_vco_zero_freq * pow(2.0, -cv * (1.0 / 0.75));
+	LOGMASKED(LOG_CONTROL_CHANGES, "VCO_FREQ=%6.3fV -> freq=%f\n", cv, m_vco_frequency);
+
+	m_vco->set_freq_ctrl(m_vco_frequency);
+}
+
+void cem3394_device::set_mod_amount_cv(double cv)
+{
+	if (cv == m_mod_amount_cv)
+		return;
+
+	m_stream->update();
+	m_mod_amount_cv = cv;
+
+	// At max depth, the frequency is modulated from 0.01x to 2.0x. This
+	// implementation modulates from 0.01x to 1.99x, for simpler math. 0%
+	// modulation is achieved when the CV is below -0.3 - +0.1 V. Using a
+	// threshold of 0.01 here, to ensure the min CV set by the sixtrak results
+	// in 0% modulation. 100% modulation is achieved when the CV is above 3 - 4 V.
+	// Using the midpoint (3.5) as the threshold here.
+	if (cv < 0.01)
+		m_filter_modulation = 0;
+	else if (cv > 3.5)
+		m_filter_modulation = 1.98;
+	else
+		m_filter_modulation = 1.98 * (cv - 0.01) / (3.5 - 0.01);
+	LOGMASKED(LOG_CONTROL_CHANGES, "FLT_MODU=%6.3fV -> mod=%f\n", cv, m_filter_modulation);
 
 	update_mix();
+}
+
+void cem3394_device::set_wave_select_cv(double cv)
+{
+	if (cv == m_wave_select_cv)
+		return;
+
+	m_stream->update();
+	m_wave_select_cv = cv;
+
+	// Wave select chooses between triangle, sawtooth, both, or neither.
+	// The waveform selection voltages, as specified in the datasheet, are:
+	// - none:                 less than -0.5
+	// - triangle:            -0.5  - -0.2
+	// - triangle + sawtooth:  0.9  -  1.5
+	// - sawtooth:             2.3  -  3.9
+	// However, some systems (such as the Six-Trak) use voltages outside those
+	// ranges. The logic below uses the midpoint of two boundaries as the
+	// transition point.
+	m_tri = (cv >= -0.5 && cv < 1.9);
+	m_saw = (cv >= 0.35);
+	LOGMASKED(LOG_CONTROL_CHANGES, "WAVE_SEL=%6.3fV -> tri=%d saw=%d\n", cv, m_tri, m_saw);
+
+	update_mix();
+}
+
+void cem3394_device::set_pulse_width_cv(double cv)
+{
+	if (cv == m_pulse_width_cv)
+		return;
+
+	m_stream->update();
+	m_pulse_width_cv = cv;
+
+	// pulse width determines duty cycle; 0.0 means 0%, 2.0 means 100%
+	if (cv < 0.0)
+	{
+		m_pulse_width = 0.0;
+		m_pulse = false;
+	}
+	else if (cv > 2.0)
+	{
+		m_pulse_width = 1.0;
+		m_pulse = false;
+	}
+	else
+	{
+		m_pulse_width = cv * 0.5;
+		m_pulse = true;
+	}
+	LOGMASKED(LOG_CONTROL_CHANGES, "PULSE_WI=%6.3fV -> raw=%f adj=%f\n", cv, cv * 0.5, m_pulse_width);
+
+	m_vco->set_pw_ctrl(m_pulse_width);
+	update_mix();
+}
+
+void cem3394_device::set_mixer_balance_cv(double cv)
+{
+	if (cv == m_mixer_balance_cv)
+		return;
+
+	m_stream->update();
+	m_mixer_balance_cv = cv;
+
+	// mixer balance is a pan between the external input and the internal input
+	// 0.0 is equal parts of both; positive values favor external, negative favor internal
+	if (cv >= 0.0)
+	{
+		m_mixer_internal = compute_db_volume(3.55 - cv);
+		m_mixer_external = compute_db_volume(3.55 + 0.45 * (cv * 0.25));
+	}
+	else
+	{
+		m_mixer_internal = compute_db_volume(3.55 - 0.45 * (cv * 0.25));
+		m_mixer_external = compute_db_volume(3.55 + cv);
+	}
+	LOGMASKED(LOG_CONTROL_CHANGES, " BALANCE=%6.3fV -> int=%f ext=%f\n", cv, m_mixer_internal, m_mixer_external);
+
+	update_mix();
+}
+
+void cem3394_device::set_filt_res_cv(double cv)
+{
+	if (cv == m_filt_res_cv)
+		return;
+
+	m_stream->update();
+	m_filt_res_cv = cv;
+
+	// According to the datasheet, the "no resonance" CV threshold is between
+	// 0V and 0.3V, and oscillation starts between 2.0 and 3.0 V, with a typical
+	// threshold of 2.5V. So 2.5V will map to a resonance gain of 4.
+	if (cv < 0.0)
+		m_filter_resonance = 0.0;
+	else
+		m_filter_resonance = 4.0 * cv / 2.5;
+	LOGMASKED(LOG_CONTROL_CHANGES, "FLT_RESO=%6.3fV -> mod=%f\n", cv, m_filter_resonance);
+
+	m_vcf->set_fixed_res_cv(m_filter_resonance);
+}
+
+void cem3394_device::set_filt_freq_cv_internal(double cv)
+{
+	if (cv == m_filt_freq_cv)
+		return;
+
+	m_filt_freq_cv = cv;
+
+	// filter frequency varies from -3.0 to +4.0, at 0.375V/octave
+	m_filter_frequency = m_filter_zero_freq * pow(2.0, -cv * (1.0 / 0.375));
+	LOGMASKED(LOG_CONTROL_CHANGES, "FLT_FREQ=%6.3fV -> freq=%f\n", cv, m_filter_frequency);
+}
+
+void cem3394_device::set_filt_freq_cv(double cv)
+{
+	if (m_stream_inputs.filt_freq_cv != nullptr)
+		fatalerror("%s - Cannot call set_fill_freq_cv() when filt_freq is a streaming input.\n", tag());
+	if (cv == m_filt_freq_cv)
+		return;
+
+	m_stream->update();
+	set_filt_freq_cv_internal(cv);
+	m_filt_freq->set_value(m_filter_frequency);
+}
+
+void cem3394_device::set_final_gain_cv_internal(double cv)
+{
+	if (cv == m_final_gain_cv)
+		return;
+
+	m_final_gain_cv = cv;
+
+	// final gain is pretty self-explanatory; 0.0 means ~90dB, 4.0 means 0dB
+	m_volume = compute_db_volume(cv);
+	LOGMASKED(LOG_CONTROL_CHANGES, "TOT_GAIN=%6.3fV -> vol=%f\n", cv, m_volume);
+}
+
+void cem3394_device::set_final_gain_cv(double cv)
+{
+	if (m_stream_inputs.final_gain_cv != nullptr)
+		fatalerror("%s - Cannot call set_final_gain_cv() when final_gain is a streaming input.\n", tag());
+	if (cv == m_final_gain_cv)
+		return;
+
+	m_stream->update();
+	set_final_gain_cv_internal(cv);
+	m_vca->set_fixed_gain_cv(m_volume);
+}
+
+
+double cem3394_device::vco_freq()
+{
+	return m_vco_frequency;
+}
+
+double cem3394_device::filt_res()
+{
+	return m_filter_resonance;
+}
+
+double cem3394_device::filt_freq()
+{
+	if (m_stream_inputs.filt_freq_cv != nullptr)
+		m_stream->update();
+	return m_filter_frequency;
+}
+
+double cem3394_device::final_gain()
+{
+	if (m_stream_inputs.final_gain_cv != nullptr)
+		m_stream->update();
+	return m_volume;
 }
 
 
@@ -296,262 +516,43 @@ double cem3394_device::compute_db(double voltage)
 	}
 }
 
-
 sound_stream::sample_t cem3394_device::compute_db_volume(double voltage)
 {
 	// convert from dB to volume and return
 	return powf(0.891251f, compute_db(voltage));
 }
 
-
-void cem3394_device::set_voltage_internal(int input, double voltage)
-{
-	// don't do anything if no change
-	if (voltage == m_values[input])
-		return;
-	m_values[input] = voltage;
-
-	// switch off the input
-	switch (input)
-	{
-		// frequency varies from -4.0 to +4.0, at 0.75V/octave
-		case VCO_FREQUENCY:
-			m_vco_frequency = m_vco_zero_freq * pow(2.0, -voltage * (1.0 / 0.75));
-			LOGMASKED(LOG_CONTROL_CHANGES, "VCO_FREQ=%6.3fV -> freq=%f\n", voltage, m_vco_frequency);
-			break;
-
-		// Wave select chooses between triangle, sawtooth, both, or neither.
-		// The waveform selection voltages, as specified in the datasheet, are:
-		// - none:                 less than -0.5
-		// - triangle:            -0.5  - -0.2
-		// - triangle + sawtooth:  0.9  -  1.5
-		// - sawtooth:             2.3  -  3.9
-		// However, some systems (such as the Six-Trak) use voltages outside
-		// those ranges. The logic below uses the midpoint of two boundaries as
-		// the transition point.
-		case WAVE_SELECT:
-			m_wave_select &= ~(WAVE_TRIANGLE | WAVE_SAWTOOTH);
-			if (voltage >= -0.5 && voltage < 0.35)
-				m_wave_select |= WAVE_TRIANGLE;
-			else if (voltage >= 0.35 && voltage < 1.9)
-				m_wave_select |= WAVE_TRIANGLE | WAVE_SAWTOOTH;
-			else if (voltage >= 1.9)
-				m_wave_select |= WAVE_SAWTOOTH;
-			LOGMASKED(LOG_CONTROL_CHANGES, "WAVE_SEL=%6.3fV -> tri=%d saw=%d\n", voltage, (m_wave_select & WAVE_TRIANGLE) ? 1 : 0, (m_wave_select & WAVE_SAWTOOTH) ? 1 : 0);
-			break;
-
-		// pulse width determines duty cycle; 0.0 means 0%, 2.0 means 100%
-		case PULSE_WIDTH:
-			if (voltage < 0.0)
-			{
-				m_pulse_width = 0;
-				m_wave_select &= ~WAVE_PULSE;
-			}
-			else if (voltage > 2.0)
-			{
-				m_pulse_width = 1;
-				m_wave_select &= ~WAVE_PULSE;
-			}
-			else
-			{
-				m_pulse_width = voltage * 0.5;
-				m_wave_select |= WAVE_PULSE;
-			}
-			LOGMASKED(LOG_CONTROL_CHANGES, "PULSE_WI=%6.3fV -> raw=%f adj=%f\n", voltage, voltage * 0.5, m_pulse_width);
-			break;
-
-		// final gain is pretty self-explanatory; 0.0 means ~90dB, 4.0 means 0dB
-		case FINAL_GAIN:
-			m_volume = compute_db_volume(voltage);
-			LOGMASKED(LOG_CONTROL_CHANGES, "TOT_GAIN=%6.3fV -> vol=%f\n", voltage, m_volume);
-			break;
-
-		// mixer balance is a pan between the external input and the internal input
-		// 0.0 is equal parts of both; positive values favor external, negative favor internal
-		case MIXER_BALANCE:
-			if (voltage >= 0.0)
-			{
-				m_mixer_internal = compute_db_volume(3.55 - voltage);
-				m_mixer_external = compute_db_volume(3.55 + 0.45 * (voltage * 0.25));
-			}
-			else
-			{
-				m_mixer_internal = compute_db_volume(3.55 - 0.45 * (voltage * 0.25));
-				m_mixer_external = compute_db_volume(3.55 + voltage);
-			}
-			LOGMASKED(LOG_CONTROL_CHANGES, " BALANCE=%6.3fV -> int=%f ext=%f\n", voltage, m_mixer_internal, m_mixer_external);
-			break;
-
-		// filter frequency varies from -3.0 to +4.0, at 0.375V/octave
-		case FILTER_FREQUENCY:
-			m_filter_frequency = m_filter_zero_freq * pow(2.0, -voltage * (1.0 / 0.375));
-			LOGMASKED(LOG_CONTROL_CHANGES, "FLT_FREQ=%6.3fV -> freq=%f\n", voltage, m_filter_frequency);
-			break;
-
-		// At max depth, the frequency is modulated from 0.01x to 2.0x. This
-		// implementation modulates from 0.01x to 1.99x, for simpler math.
-		// 0% modulation is achieved when the CV is below -0.3 - +0.1 V. Using
-		// a threshold of 0.01 here, to ensure the min CV set by the sixtrak
-		// results in 0% modulation.
-		// 100% modulation is achieved when the CV is above 3 - 4 V. Using the
-		// midpoint (3.5) as the threshold here.
-		case MODULATION_AMOUNT:
-			if (voltage < 0.01)
-				m_filter_modulation = 0;
-			else if (voltage > 3.5)
-				m_filter_modulation = 1.98;
-			else
-				m_filter_modulation = 1.98 * (voltage - 0.01) / (3.5 - 0.01);
-			LOGMASKED(LOG_CONTROL_CHANGES, "FLT_MODU=%6.3fV -> mod=%f\n", voltage, m_filter_modulation);
-			break;
-
-		// According to the datasheet, the "no resonance" CV threshold is between
-		// 0V and 0.3V, and oscillation starts between 2.0 and 3.0 V, with a
-		// typical threshold of 2.5V. So 2.5V will map to a resonance gain of 4.
-		case FILTER_RESONANCE:
-			if (voltage < 0.0)
-				m_filter_resonance = 0.0;
-			else
-				m_filter_resonance = 4.0 * voltage / 2.5;
-			LOGMASKED(LOG_CONTROL_CHANGES, "FLT_RESO=%6.3fV -> mod=%f\n", voltage, m_filter_resonance);
-			break;
-
-		default:
-			fatalerror("%s - unrecognized input: %d\n", tag(), input);
-			break;
-	}
-}
-
-
 void cem3394_device::update_mix()
 {
-	const double tri_gain = (m_wave_select & WAVE_TRIANGLE) ? (TRIANGLE_VOLUME * m_mixer_internal) : 0;
+	const double tri_gain = m_tri ? (TRIANGLE_VOLUME * m_mixer_internal) : 0;
 	m_vco->set_route_gain(va_vco_device::OUTPUT_TRIANGLE, m_vcf, va_lpf4_device::INPUT_AUDIO, tri_gain);
 
-	const double saw_gain = (m_wave_select & WAVE_SAWTOOTH) ? (SAWTOOTH_VOLUME * m_mixer_internal) : 0;
+	const double saw_gain = m_saw ? (SAWTOOTH_VOLUME * m_mixer_internal) : 0;
 	m_vco->set_route_gain(va_vco_device::OUTPUT_RAMP, m_vcf, va_lpf4_device::INPUT_AUDIO, saw_gain);
 
-	const double pulse_gain = (m_wave_select & WAVE_PULSE) ? (PULSE_VOLUME * m_mixer_internal) : 0;
+	const double pulse_gain = m_pulse ? (PULSE_VOLUME * m_mixer_internal) : 0;
 	m_vco->set_route_gain(va_vco_device::OUTPUT_PULSE, m_vcf, va_lpf4_device::INPUT_AUDIO, pulse_gain);
 
 	// See m_filt_fm setup in device_add_mconfig().
 	const double mod_amount = 0.5 * m_filter_modulation;
 	m_vco->set_route_gain(va_vco_device::OUTPUT_TRIANGLE, m_filt_fm, va_vca_device::INPUT_AUDIO, mod_amount);
 
-	if (m_stream_inputs[AUDIO_INPUT] != nullptr)
+	if (m_stream_inputs.ext_input != nullptr)
 	{
 		const double ext_gain = EXTERNAL_VOLUME * m_mixer_external;
-		m_stream_inputs[AUDIO_INPUT]->set_route_gain(0, m_vcf, va_lpf4_device::INPUT_AUDIO, ext_gain);
+		m_stream_inputs.ext_input->set_route_gain(0, m_vcf, va_lpf4_device::INPUT_AUDIO, ext_gain);
 	}
 }
 
 float cem3394_device::stream_op_filter_freq(float voltage)
 {
-	set_voltage_internal(FILTER_FREQUENCY, voltage);
+	set_filt_freq_cv_internal(voltage);
 	return m_filter_frequency;
 }
 
 float cem3394_device::stream_op_amp_gain(float voltage)
 {
-	set_voltage_internal(FINAL_GAIN, voltage);
+	set_final_gain_cv_internal(voltage);
 	return m_volume;
 }
 
-void cem3394_device::set_voltage(int input, double voltage)
-{
-	if (input < 1 || input >= INPUT_COUNT)
-		fatalerror("%s - Invalid input to set_voltage(): %d\n", tag(), input);
-
-	if (m_stream_inputs[input] != nullptr)
-		fatalerror("%s - Cannot call set_voltage(%d, ...). %d is a streaming input.\n", tag(), input, input);
-
-	if (voltage == m_values[input])
-		return;
-
-	m_stream->update();
-	set_voltage_internal(input, voltage);
-
-	switch (input)
-	{
-		case VCO_FREQUENCY:
-			m_vco->set_freq_ctrl(m_vco_frequency);
-			break;
-		case MODULATION_AMOUNT:
-		case WAVE_SELECT:
-		case MIXER_BALANCE:
-			update_mix();
-			break;
-		case PULSE_WIDTH:
-			m_vco->set_pw_ctrl(m_pulse_width);
-			update_mix();
-			break;
-		case FILTER_RESONANCE:
-			m_vcf->set_fixed_res_cv(m_filter_resonance);
-			break;
-		case FILTER_FREQUENCY:
-			m_filt_freq->set_value(m_filter_frequency);
-			break;
-		case FINAL_GAIN:
-			m_vca->set_fixed_gain_cv(m_volume);
-			break;
-	}
-}
-
-double cem3394_device::get_voltage(int input)
-{
-	if (input < 1 || input >= INPUT_COUNT)
-		fatalerror("%s - Invalid input to get_voltage(): %d\n", tag(), input);
-
-	if (m_stream_inputs[input] != nullptr)
-		m_stream->update();
-
-	return m_values[input];
-}
-
-double cem3394_device::get_parameter(int input)
-{
-	const double voltage = get_voltage(input);
-
-	switch (input)
-	{
-		case VCO_FREQUENCY:
-			return m_vco_zero_freq * pow(2.0, -voltage * (1.0 / 0.75));
-
-		case WAVE_SELECT:
-			return voltage;
-
-		case PULSE_WIDTH:
-			if (voltage <= 0.0)
-				return 0.0;
-			else if (voltage >= 2.0)
-				return 1.0;
-			else
-				return voltage * 0.5;
-
-		case FINAL_GAIN:
-			return compute_db(voltage);
-
-		case MIXER_BALANCE:
-			return voltage * 0.25;
-
-		case MODULATION_AMOUNT:
-			if (voltage < 0.0)
-				return 0.01;
-			else if (voltage > 3.5)
-				return 1.99;
-			else
-				return (voltage * (1.0 / 3.5)) * 1.98 + 0.01;
-
-		case FILTER_RESONANCE:
-			if (voltage < 0.0)
-				return 0.0;
-			else if (voltage > 2.5)
-				return 1.0;
-			else
-				return voltage * (1.0 / 2.5);
-
-		case FILTER_FREQUENCY:
-			return m_filter_zero_freq * pow(2.0, -voltage * (1.0 / 0.375));
-	}
-	return 0.0;
-}

--- a/src/devices/sound/cem3394.h
+++ b/src/devices/sound/cem3394.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Aaron Giles
+// copyright-holders:Aaron Giles,m1macrophage
 #ifndef MAME_SOUND_CEM3394_H
 #define MAME_SOUND_CEM3394_H
 
@@ -13,23 +13,6 @@
 class cem3394_device : public device_t, public device_sound_interface
 {
 public:
-	// inputs
-	// Each of these CV inputs can either be specified with `set_voltage()`, or
-	// provided via a sound stream.
-	enum
-	{
-		AUDIO_INPUT = 0,  // not valid for set_voltage()
-		VCO_FREQUENCY,
-		MODULATION_AMOUNT,
-		WAVE_SELECT,
-		PULSE_WIDTH,
-		MIXER_BALANCE,
-		FILTER_RESONANCE,
-		FILTER_FREQUENCY,
-		FINAL_GAIN,
-		INPUT_COUNT
-	};
-
 	// external component values
 	struct components
 	{
@@ -44,10 +27,37 @@ public:
 		double c_ac = 4.7E-6;
 	};
 
-	using input_array = std::array<device_sound_interface *, INPUT_COUNT>;
+	// optional streaming inputs
+	struct stream_inputs
+	{
+		device_sound_interface *ext_input = nullptr;      // pin 9
+		device_sound_interface *filt_freq_cv = nullptr;   // pin 16
+		device_sound_interface *final_gain_cv = nullptr;  // pin 18
+	};
 
 	cem3394_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0) ATTR_COLD;
-	cem3394_device(const machine_config &mconfig, const char *tag, device_t *owner, const components &comps, const input_array& inputs) ATTR_COLD;
+	cem3394_device(const machine_config &mconfig, const char *tag, device_t *owner, const components &comps, const stream_inputs& inputs) ATTR_COLD;
+
+	// control voltage setters
+	// Cannot not be called when the corresponding CV is configured as a
+	// streaming input (see stream_inputs).
+	void set_vco_freq_cv(double cv);       // pin 2
+	void set_mod_amount_cv(double cv);     // pin 5
+	void set_wave_select_cv(double cv);    // pin 6
+	void set_pulse_width_cv(double cv);    // pin 7
+	void set_mixer_balance_cv(double cv);  // pin 10
+	void set_filt_res_cv(double cv);       // pin 11
+	void set_filt_freq_cv(double cv);      // pin 16
+	void set_final_gain_cv(double cv);     // pin 18
+
+	// internal state accessors
+	// Note that these do not return the raw CVs. They return values derived
+	// from CVs. See per-function comments.
+	// Calling these might trigger a stream update.
+	double vco_freq();    // in Hz
+	double filt_res();    // feedback gain (0: no resonance, ~4: self-oscillation. Could be > 4)
+	double filt_freq();   // in Hz
+	double final_gain();  // linear (0: quiet, 1: no attenuation)
 
 protected:
 	// device-level overrides
@@ -58,42 +68,24 @@ protected:
 	// sound stream update overrides
 	virtual void sound_stream_update(sound_stream &stream) override;
 
-public:
-	// Set the voltage going to a particular parameter
-	void set_voltage(int input, double voltage);
-
-	// Requesting a streaming voltage will force a stream update.
-	double get_voltage(int input);
-
-	// Get the translated parameter associated with the given input as follows:
-	//    VCO_FREQUENCY:      frequency in Hz
-	//    MODULATION_AMOUNT:  scale factor, 0.0 to 2.0
-	//    WAVE_SELECT:        voltage from this line
-	//    PULSE_WIDTH:        width fraction, from 0.0 to 1.0
-	//    MIXER_BALANCE:      balance, from -1.0 to 1.0
-	//    FILTER_RESONANCE:   resonance, from 0.0 to 1.0
-	//    FILTER_FREQUENCY:   frequency, in Hz
-	//    FINAL_GAIN:         gain, in dB
-	// Requesting a parameter associated with a streaming input will force a
-	// stream update.
-	double get_parameter(int input);
-
 private:
 	double compute_db(double voltage);
 	sound_stream::sample_t compute_db_volume(double voltage);
 
-	void set_voltage_internal(int input, double voltage);
+	void set_filt_freq_cv_internal(double cv);
+	void set_final_gain_cv_internal(double cv);
 	void update_mix();
 
 	float stream_op_filter_freq(float voltage);
 	float stream_op_amp_gain(float voltage);
 
 	// device configuration, not needed in save state
-	const input_array m_stream_inputs;// streaming inputs
-	const components m_components;    // external components
-	const double m_vco_zero_freq;     // frequency of VCO at 0.0V
-	const double m_filter_zero_freq;  // frequency of filter at 0.0V
-	sound_stream *m_stream;           // our stream
+	const stream_inputs m_stream_inputs;  // streaming inputs
+	const components m_components;        // external components
+	const double m_vco_zero_freq;         // frequency of VCO at 0.0V
+	const double m_filter_zero_freq;      // frequency of filter at 0.0V
+	bool m_initialized;                   // parameters initialized
+	sound_stream *m_stream;               // our stream
 
 	required_device<va_vco_device> m_vco;
 	optional_device<va_const_device> m_filt_freq;
@@ -103,16 +95,25 @@ private:
 
 	// device state
 
-	double m_values[INPUT_COUNT];     // raw values of registers
+	// raw control voltages for the chip's parameters
+	double m_vco_freq_cv;
+	double m_mod_amount_cv;
+	double m_wave_select_cv;
+	double m_pulse_width_cv;
+	double m_mixer_balance_cv;
+	double m_filt_res_cv;
+	double m_filt_freq_cv;
+	double m_final_gain_cv;
 
-	u8 m_wave_select;                 // flags which waveforms are enabled
+	// parameters derived from control voltages
+	bool m_tri;                       // triangle waveform enabled
+	bool m_saw;                       // sawtooth waveform enabled
+	bool m_pulse;                     // pulse waveform enabled
 	double m_vco_frequency;           // current VCO frequency
 	double m_pulse_width;             // fractional pulse width
-
 	double m_volume;                  // linear overall volume (0-1)
 	double m_mixer_internal;          // linear internal volume (0-1)
 	double m_mixer_external;          // linear external volume (0-1)
-
 	double m_filter_frequency;        // baseline filter frequency
 	double m_filter_modulation;       // depth of modulation (up to 1.0)
 	double m_filter_resonance;        // depth of modulation (up to 1.0)

--- a/src/mame/bally/sente6vb.cpp
+++ b/src/mame/bally/sente6vb.cpp
@@ -65,11 +65,6 @@
 
 #include "speaker.h"
 
-#define LOG_CEM_WRITES (1U << 1)
-
-#define VERBOSE (0)
-#include "logmacro.h"
-
 
 DEFINE_DEVICE_TYPE(SENTE6VB, sente6vb_device, "sente6vb", "Bally Sente 6VB Audio Board")
 
@@ -148,8 +143,8 @@ void sente6vb_device::device_add_mconfig(machine_config &config)
 		.c_ac = CAP_U(10),     // C3
 	};
 
-	cem3394_device::input_array inputs{};
-	inputs[cem3394_device::AUDIO_INPUT] = &ac_noise;
+	cem3394_device::stream_inputs inputs;
+	inputs.ext_input = &ac_noise;
 
 	for (auto &cem_device : m_cem_device)
 	{
@@ -299,17 +294,17 @@ void sente6vb_device::update_counter_0_timer()
 	// find the counter with the maximum frequency
 	// this is used to calibrate the timers at startup
 	for (i = 0; i < 6; i++)
-		if (m_cem_device[i]->get_parameter(cem3394_device::FINAL_GAIN) < 10.0)
+		if (m_cem_device[i]->final_gain() > 0.1)
 		{
 			double tempfreq;
 
 			// if the filter resonance is high, then they're calibrating the filter frequency
-			if (m_cem_device[i]->get_parameter(cem3394_device::FILTER_RESONANCE) > 0.9)
-				tempfreq = m_cem_device[i]->get_parameter(cem3394_device::FILTER_FREQUENCY);
+			if (m_cem_device[i]->filt_res() > 3)
+				tempfreq = m_cem_device[i]->filt_freq();
 
 			// otherwise, they're calibrating the VCO frequency
 			else
-				tempfreq = m_cem_device[i]->get_parameter(cem3394_device::VCO_FREQUENCY);
+				tempfreq = m_cem_device[i]->vco_freq();
 
 			if (tempfreq > maxfreq) maxfreq = tempfreq;
 		}
@@ -397,21 +392,8 @@ void sente6vb_device::counter_control_w(uint8_t data)
 
 void sente6vb_device::chip_select_w(uint8_t data)
 {
-	static constexpr uint8_t register_map[8] =
-	{
-		cem3394_device::VCO_FREQUENCY,
-		cem3394_device::FINAL_GAIN,
-		cem3394_device::FILTER_RESONANCE,
-		cem3394_device::FILTER_FREQUENCY,
-		cem3394_device::MIXER_BALANCE,
-		cem3394_device::MODULATION_AMOUNT,
-		cem3394_device::PULSE_WIDTH,
-		cem3394_device::WAVE_SELECT
-	};
-
 	double voltage = (double)m_dac_value * (8.0 / 4096.0) - 4.0;
 	int diffchip = data ^ m_chip_select, i;
-	int reg = register_map[m_dac_register];
 
 	// remember the new select value
 	m_chip_select = data;
@@ -420,27 +402,17 @@ void sente6vb_device::chip_select_w(uint8_t data)
 	for (i = 0; i < 6; i++)
 		if ((diffchip & (1 << i)) && (data & (1 << i)))
 		{
-			// remember the previous value
-			double temp = m_cem_device[i]->get_parameter(reg);
-
 			// set the voltage
-			m_cem_device[i]->set_voltage(reg, voltage);
-
-			// only log changes
-			if (temp != m_cem_device[i]->get_parameter(reg))
+			switch (m_dac_register)
 			{
-				static const char *const names[] =
-				{
-					"VCO_FREQUENCY",
-					"FINAL_GAIN",
-					"FILTER_RESONANCE",
-					"FILTER_FREQUENCY",
-					"MIXER_BALANCE",
-					"MODULATION_AMOUNT",
-					"PULSE_WIDTH",
-					"WAVE_SELECT"
-				};
-				LOGMASKED(LOG_CEM_WRITES, "s%04X:   CEM#%d:%s=%f\n", m_audiocpu->pcbase(), i, names[m_dac_register], voltage);
+				case 0: m_cem_device[i]->set_vco_freq_cv(voltage);      break;
+				case 1: m_cem_device[i]->set_final_gain_cv(voltage);    break;
+				case 2: m_cem_device[i]->set_filt_res_cv(voltage);      break;
+				case 3: m_cem_device[i]->set_filt_freq_cv(voltage);     break;
+				case 4: m_cem_device[i]->set_mixer_balance_cv(voltage); break;
+				case 5: m_cem_device[i]->set_mod_amount_cv(voltage);    break;
+				case 6: m_cem_device[i]->set_pulse_width_cv(voltage);   break;
+				case 7: m_cem_device[i]->set_wave_select_cv(voltage);   break;
 			}
 		}
 

--- a/src/mame/sequential/sixtrak.cpp
+++ b/src/mame/sequential/sixtrak.cpp
@@ -97,14 +97,13 @@ For all other functionality, see the owner's manual.
 
 #include "sequential_sixtrak.lh"
 
-#define LOG_CV              (1U << 1)
-#define LOG_KEYS            (1U << 2)
-#define LOG_ADC_VALUE_KNOB  (1U << 3)
-#define LOG_ADC_PITCH_WHEEL (1U << 4)
-#define LOG_VOLUME          (1U << 5)
-#define LOG_AUTOTUNE        (1U << 6)
-#define LOG_CALIBRATION     (1U << 7)
-#define LOG_WHEEL_RC        (1U << 8)
+#define LOG_KEYS            (1U << 1)
+#define LOG_ADC_VALUE_KNOB  (1U << 2)
+#define LOG_ADC_PITCH_WHEEL (1U << 3)
+#define LOG_VOLUME          (1U << 4)
+#define LOG_AUTOTUNE        (1U << 5)
+#define LOG_CALIBRATION     (1U << 6)
+#define LOG_WHEEL_RC        (1U << 7)
 
 #define VERBOSE (LOG_CALIBRATION)
 //#define LOG_OUTPUT_FUNC osd_printf_info

--- a/src/mame/sequential/sixtrak.cpp
+++ b/src/mame/sequential/sixtrak.cpp
@@ -375,25 +375,7 @@ void sixtrak_state::update_sh_rc(bool sampling, double cv, va_rc_eg_device &rc)
 
 void sixtrak_state::update_cvs()
 {
-	constexpr int PARAM2CVIN[8] =
-	{
-		cem3394_device::VCO_FREQUENCY,
-		cem3394_device::FINAL_GAIN,
-		cem3394_device::FILTER_RESONANCE,
-		cem3394_device::FILTER_FREQUENCY,
-		cem3394_device::MIXER_BALANCE,
-		cem3394_device::MODULATION_AMOUNT,
-		cem3394_device::PULSE_WIDTH,
-		cem3394_device::WAVE_SELECT,
-	};
-
-	constexpr const char *PARAMNAMES[8] =
-	{
-		"pitch", "gain", "resonance", "cutoff", "mixer", "mod", "PW", "waveform"
-	};
-
 	assert(m_sh_param < 8);
-	const int cv_input = PARAM2CVIN[m_sh_param];
 	const double cv = get_voltage_mux_out();
 
 	for (int voice = 0; voice < 6; ++voice)
@@ -418,14 +400,19 @@ void sixtrak_state::update_cvs()
 			continue;
 
 		cem3394_device *v = m_voices[voice];
-		if (v->get_voltage(cv_input) == cv)
-			continue;
-
-		v->set_voltage(cv_input, cv);
-		LOGMASKED(LOG_CV, "CV - voice: %u, param: %u (%s), cv: %f - %03x - %x\n",
-				  voice, m_sh_param, PARAMNAMES[m_sh_param], cv, m_dac_value, m_voltage_mux_input);
-		if (m_sh_param == 0)
-			LOGMASKED(LOG_CV, "Pitch %d: %f\n", voice, v->get_parameter(cem3394_device::VCO_FREQUENCY));
+		switch (m_sh_param)
+		{
+			// Parameters 1 (final gain) and 3 (filter frequency) are streaming
+			// inputs and are handled above.
+			case 0: v->set_vco_freq_cv(cv);      break;
+			case 2: v->set_filt_res_cv(cv);      break;
+			case 4: v->set_mixer_balance_cv(cv); break;
+			case 5: v->set_mod_amount_cv(cv);    break;
+			case 6: v->set_pulse_width_cv(cv);   break;
+			case 7: v->set_wave_select_cv(cv);   break;
+			default:
+				fatalerror("Invalid CEM3394 fixed CV address: %d\n", m_sh_param);
+		}
 	}
 }
 
@@ -546,15 +533,15 @@ void sixtrak_state::update_tuning_timer()
 
 	int active_voices = 0;
 	int loudest_voice = -1;
-	double max_gain_cv = -1;
+	double max_gain = -1;
 	for (int voice = 0; voice < m_voices.size(); ++voice)
 	{
-		const double gain_cv = m_voices[voice]->get_voltage(cem3394_device::FINAL_GAIN);
-		if (gain_cv > 0.1)
+		const double gain = m_voices[voice]->final_gain();
+		if (gain > 0.1)
 			++active_voices;
-		if (gain_cv > max_gain_cv)
+		if (gain > max_gain)
 		{
-			max_gain_cv = gain_cv;
+			max_gain = gain;
 			loudest_voice = voice;
 		}
 	}
@@ -573,14 +560,14 @@ void sixtrak_state::update_tuning_timer()
 	cem3394_device *voice = m_voices[loudest_voice];
 	double freq = 0;
 	bool tuning_filter = false;
-	if (voice->get_parameter(cem3394_device::FILTER_RESONANCE) > 0.9)
+	if (voice->filt_res() > 3)
 	{
-		freq = voice->get_parameter(cem3394_device::FILTER_FREQUENCY);
+		freq = voice->filt_freq();
 		tuning_filter = true;
 	}
 	else
 	{
-		freq = voice->get_parameter(cem3394_device::VCO_FREQUENCY);
+		freq = voice->vco_freq();
 		tuning_filter = false;
 	}
 
@@ -868,10 +855,10 @@ void sixtrak_state::sixtrak_common(machine_config &config, device_sound_interfac
 			.c_ac = CAP_U(10),
 		};
 
-		cem3394_device::input_array voice_inputs{};
-		voice_inputs[cem3394_device::AUDIO_INPUT] = &noise;
-		voice_inputs[cem3394_device::FINAL_GAIN] = m_gain_rc[i].target();
-		voice_inputs[cem3394_device::FILTER_FREQUENCY] = m_freq_rc[i].target();
+		cem3394_device::stream_inputs voice_inputs;
+		voice_inputs.ext_input = &noise;
+		voice_inputs.final_gain_cv = m_gain_rc[i].target();
+		voice_inputs.filt_freq_cv = m_freq_rc[i].target();
 
 		CEM3394(config, m_voices[i], comps, voice_inputs);
 		m_voices[i]->add_route(0, "voicemixer", CEM3394_IOUT_MAX);


### PR DESCRIPTION
Changes:
* Replaced dispatcher with individual setter functions for each CV.
  * The implementation of the individual `set_*_cv()` methods was (mostly) copy-pasted from the `switch` in `set_voltage_internal()`.
* Replaced dispatching getter with individual getters.
* Replaced input stream array with a struct for the supported inputs.
  * Got rid of relevant consistency checks.
* Used bools instead of a uint mask to track enabled waveforms.
* Adapted `sixtrak.cpp` and `sente6vb.cpp` to the changes.
* Removed relevant logging from `sixtrak.cpp` and `sente6vb.cpp`.
  * It is redundant with the logging in cem3394.cpp, and would require additional bookkeeping.

Tests:
* Verified long `stocker` `-playback` session generates identical .wav files before and after the changes.
* Verified no audible differences on `sixtrak` (the `sixtrak` doesn't produce bit-identical .wav files between runs, even if there are no changes. Need to hunt that down).
  * EDIT: deleting the nvram before each run results in bit-identical .wav files.
