### PR TITLE
sega/model1: Various improvements for NetMerc

### DIFF
--- a/src/mame/sega/model1.cpp
+++ b/src/mame/sega/model1.cpp
@@ -859,6 +859,13 @@ u8 model1_state::irq_mask_r()
 void model1_state::irq_mask_w(u8 data)
 {
 	m_irq_mask = data;
+	sound_ready_w(0);
+}
+
+void model1_state::sound_ready_w(int state)
+{
+	if ((m_m1uart->txrdy_r() || m_m1uart->rxrdy_r()) && !BIT(m_irq_mask, 3))
+		irq_raise(3);
 }
 
 // IRQ vectors in use:
@@ -900,12 +907,10 @@ TIMER_DEVICE_CALLBACK_MEMBER(model1_state::model1_interrupt)
 	}
 	else if(scanline == 384/2)
 	{
-		// Periodic (timer?) source, wired to levels 0 and 3; each game
-		// unmasks at most one of them for its uart/sound queue pump.
+		// Kludge: IRQ0 is an unemulated programmable timer (registers 0xe00006-0xe0000f).
+		// We fire it mid-frame temporarily to keep the games running.
 		if (!BIT(m_irq_mask, 0))
 			irq_raise(0);
-		if (!BIT(m_irq_mask, 3))
-			irq_raise(3);
 	}
 }
 
@@ -1802,6 +1807,8 @@ void model1_state::model1(machine_config &config)
 
 	I8251(config, m_m1uart, 8000000); // uPD71051C, clock unknown
 	m_m1uart->txd_handler().set(m_m1audio, FUNC(segam1audio_device::write_txd));
+	m_m1uart->rxrdy_handler().set(FUNC(model1_state::sound_ready_w));
+	m_m1uart->txrdy_handler().set(FUNC(model1_state::sound_ready_w));
 
 	clock_device &m1uart_clock(CLOCK(config, "m1uart_clock", 16_MHz_XTAL / 2 / 16)); // 16 times 31.25kHz (standard Sega/MIDI sound data rate)
 	m1uart_clock.signal_handler().set(m_m1uart, FUNC(i8251_device::write_txc));

--- a/src/mame/sega/model1.cpp
+++ b/src/mame/sega/model1.cpp
@@ -833,19 +833,50 @@ void model1_state::irq_control_w(u8 data)
 	}
 }
 
+// E00002: per-level IRQ mask, active low (bit n set = IRQ level n masked).
+// Assumed to power up with all levels masked; every game programs it before
+// enabling interrupts in the PSW, so the reset value is not observable
+// (swa/wingwar write it in the instruction immediately preceding
+// updpsw #0x40000, the others earlier in their init).
+//
+// - vf/vr:   write 0xff then 0xfd at init - vblank only. vf additionally
+//            unmasks level 3 ("and.b #0xf7") while its sound queue is
+//            non-empty and masks it again ("or.b #8") once it drains - its
+//            level 3 handler pumps the queue to the uart.
+// - swa:     writes 0x3c - unmasks levels 0/1; level 0 is its uart pump.
+// - wingwar: writes 0x3d - unmasks level 1 only.
+// - netmerc: writes 0xff at boot, then "and.b #0xfd" - unmasks level 1 only.
+//            All its other vectors point to a debug routine that cycles the
+//            backdrop colour, which must never run.
+u8 model1_state::irq_mask_r()
+{
+	return m_irq_mask;
+}
+
+void model1_state::irq_mask_w(u8 data)
+{
+	m_irq_mask = data;
+}
+
+// IRQ vectors in use:
 // vf
-// 1 = fe3ed4
-// 3 = fe3f5c
+// 1 = fe3ed4 (vblank)
+// 3 = fe3f5c (uart queue pump)
 // other = fe3ec8 / fe3ebc
 
 // vr
-// 1 = fe02bc
-// other = f302a4 / fe02b0
+// 1 = fe02bc (vblank)
+// other = fe02a4 / fe02b0
 
 // swa
-// 1 = ff504
+// 0 = ff558 (uart queue pump)
+// 1 = ff504 (vblank)
 // 3 = ff54c
 // other = ff568/ff574
+
+// netmerc
+// 1 = ffe000 (vblank)
+// other = ffe10c (debug backdrop cycler, always masked)
 
 void model1_state::irq_init()
 {
@@ -861,12 +892,17 @@ TIMER_DEVICE_CALLBACK_MEMBER(model1_state::model1_interrupt)
 	{
 		if (m_m1comm != nullptr)
 			m_m1comm->check_vint_irq();
-		irq_raise(1);
+		if (!BIT(m_irq_mask, 1))
+			irq_raise(1);
 	}
 	else if(scanline == 384/2)
 	{
-		if (m_sound_irq <= 7)
-			irq_raise(m_sound_irq);
+		// Periodic (timer?) source, wired to levels 0 and 3; each game
+		// unmasks at most one of them for its uart/sound queue pump.
+		if (!BIT(m_irq_mask, 0))
+			irq_raise(0);
+		if (!BIT(m_irq_mask, 3))
+			irq_raise(3);
 	}
 }
 
@@ -878,16 +914,10 @@ void model1_state::machine_reset()
 
 	m_irq_status = 0;
 	m_last_irq = 0;
+	m_irq_mask = 0xff;
 
-	if (!strcmp(machine().system().name, "swa") ||
-		!strcmp(machine().system().name, "swaj"))
+	if (!strcmp(machine().system().name, "netmerc"))
 	{
-		m_sound_irq = 0;
-	}
-	else if (!strcmp(machine().system().name, "netmerc"))
-	{
-		m_sound_irq = 0xff; // Netmerc ignores midframe irq, avoid stomping pen 0
-		
 		if (m_nvram)
 		{
 			auto &space = m_maincpu->space(AS_PROGRAM);
@@ -911,10 +941,6 @@ void model1_state::machine_reset()
 				m_dpram->left_w(0x81 + i*2, (pose[i] >> 8) & 0xff);
 			}
 		}
-	}
-	else
-	{
-		m_sound_irq = 3;
 	}
 }
 
@@ -956,8 +982,9 @@ void model1_state::model1_mem(address_map &map)
 	/*      */ map(0xdc0000, 0xdc0003).r(FUNC(model1_state::fifoin_status_r)).mirror(0x1fffc);
 
 	/* GLUE */ map(0xe00000, 0xe00000).w(FUNC(model1_state::irq_control_w));
+	/*      */ map(0xe00002, 0xe00002).rw(FUNC(model1_state::irq_mask_r), FUNC(model1_state::irq_mask_w));
 	/*      */ map(0xe00004, 0xe00005).w(FUNC(model1_state::bank_w));
-	/*      */ map(0xe0000c, 0xe0000f).nopw();
+	/*      */ map(0xe00006, 0xe0000f).nopw(); // Unemulated timer? (E0000A: period, E0000C: free-running count, also read back; E0000E: unknown)
 
 	/* ROM0 */ map(0xf80000, 0xffffff).rom();
 }

--- a/src/mame/sega/model1.cpp
+++ b/src/mame/sega/model1.cpp
@@ -868,6 +868,55 @@ void model1_state::sound_ready_w(int state)
 		irq_raise(3);
 }
 
+u16 model1_state::timer_r(offs_t offset, u16 mem_mask)
+{
+	if (offset == 3 || offset == 4)
+	{
+		int tnum = offset - 3;
+		if (m_irq0_timer[tnum]->enabled())
+		{
+			uint32_t ticks = m_irq0_timer[tnum]->remaining().as_ticks(m_maincpu->clock());
+			m_timer_val[tnum] = ticks / 0x800;
+		}
+		return m_timer_val[tnum];
+	}
+	return 0xffff;
+}
+
+void model1_state::timer_w(offs_t offset, u16 data, u16 mem_mask)
+{
+	if (offset == 1 || offset == 2)
+	{
+		int tnum = offset - 1;
+		COMBINE_DATA(&m_timer_period[tnum]);
+		if (m_timer_period[tnum])
+		{
+			attotime period = attotime::from_ticks(0x800 * m_timer_period[tnum], m_maincpu->clock());
+			m_irq0_timer[tnum]->adjust(period, tnum);
+		}
+		else
+		{
+			m_irq0_timer[tnum]->adjust(attotime::never);
+		}
+	}
+	else if (offset == 0)
+	{
+		COMBINE_DATA(&m_timer_mode[0]);
+	}
+}
+
+TIMER_CALLBACK_MEMBER(model1_state::irq0_timer_tick)
+{
+	if (!BIT(m_irq_mask, 0))
+		irq_raise(0);
+
+	if (m_timer_period[param])
+	{
+		attotime period = attotime::from_ticks(0x800 * m_timer_period[param], m_maincpu->clock());
+		m_irq0_timer[param]->adjust(period, param);
+	}
+}
+
 // IRQ vectors in use:
 // vf
 // 1 = fe3ed4 (vblank)
@@ -905,13 +954,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(model1_state::model1_interrupt)
 		if (!BIT(m_irq_mask, 1))
 			irq_raise(1);
 	}
-	else if(scanline == 384/2)
-	{
-		// Kludge: IRQ0 is an unemulated programmable timer (registers 0xe00006-0xe0000f).
-		// We fire it mid-frame temporarily to keep the games running.
-		if (!BIT(m_irq_mask, 0))
-			irq_raise(0);
-	}
+
 }
 
 void model1_state::machine_reset()
@@ -979,7 +1022,7 @@ void model1_state::model1_mem(address_map &map)
 	/* GLUE */ map(0xe00000, 0xe00000).w(FUNC(model1_state::irq_control_w));
 	/*      */ map(0xe00002, 0xe00002).rw(FUNC(model1_state::irq_mask_r), FUNC(model1_state::irq_mask_w));
 	/*      */ map(0xe00004, 0xe00005).w(FUNC(model1_state::bank_w));
-	/*      */ map(0xe00006, 0xe0000f).nopw(); // Unemulated timer? (E0000A: period, E0000C: free-running count, also read back; E0000E: unknown)
+	/*      */ map(0xe00006, 0xe0000f).rw(FUNC(model1_state::timer_r), FUNC(model1_state::timer_w)); // Unemulated timer? (E0000A: period, E0000C: count; E0000E: ?)
 
 	/* ROM0 */ map(0xf80000, 0xffffff).rom();
 }

--- a/src/mame/sega/model1.cpp
+++ b/src/mame/sega/model1.cpp
@@ -848,6 +848,9 @@ void model1_state::irq_control_w(u8 data)
 // - netmerc: writes 0xff at boot, then "and.b #0xfd" - unmasks level 1 only.
 //            All its other vectors point to a debug routine that cycles the
 //            backdrop colour, which must never run.
+//
+// Note: The games (e.g., netmerc) do perform read operations on this register,
+// likely for read-modify-write bit manipulations. It must remain readable.
 u8 model1_state::irq_mask_r()
 {
 	return m_irq_mask;

--- a/src/mame/sega/model1.cpp
+++ b/src/mame/sega/model1.cpp
@@ -915,17 +915,19 @@ void model1_state::machine_reset()
 	m_irq_status = 0;
 	m_last_irq = 0;
 	m_irq_mask = 0xff;
+}
 
-	if (!strcmp(machine().system().name, "netmerc"))
+void netmerc_state::machine_reset()
+{
+	model1_state::machine_reset();
+
+	if (m_dpram)
 	{
-		if (m_dpram)
+		int16_t pose[6] = {0, 0, 0, 12868, 25736, 12868};
+		for (int i = 0; i < 6; i++)
 		{
-			int16_t pose[6] = {0, 0, 0, 12868, 25736, 12868};
-			for (int i = 0; i < 6; i++)
-			{
-				m_dpram->left_w(0x80 + i*2, pose[i] & 0xff);
-				m_dpram->left_w(0x81 + i*2, (pose[i] >> 8) & 0xff);
-			}
+			m_dpram->left_w(0x80 + i*2, pose[i] & 0xff);
+			m_dpram->left_w(0x81 + i*2, (pose[i] >> 8) & 0xff);
 		}
 	}
 }
@@ -1951,4 +1953,4 @@ GAME( 1994, wingwar,    0,       wingwar,    wingwar,    model1_state, empty_ini
 GAME( 1994, wingwaru,   wingwar, wingwar,    wingwar,    model1_state, empty_init, ROT0,     "Sega",  "Wing War (US)",            0 )
 GAME( 1994, wingwarj,   wingwar, wingwar,    wingwar,    model1_state, empty_init, ROT0,     "Sega",  "Wing War (Japan)",         0 )
 GAME( 1994, wingwar360, wingwar, wingwar360, wingwar360, model1_state, empty_init, ROT0,     "Sega",  "Wing War R360 (US)",       0 )
-GAME( 1993, netmerc,    0,       netmerc,    netmerc,    model1_state, empty_init, ROT0,     "Sega",  "Sega NetMerc",             MACHINE_NOT_WORKING )
+GAME( 1993, netmerc,    0,       netmerc,    netmerc,    netmerc_state, empty_init, ROT0,     "Sega",  "Sega NetMerc",             MACHINE_NOT_WORKING )

--- a/src/mame/sega/model1.cpp
+++ b/src/mame/sega/model1.cpp
@@ -921,14 +921,13 @@ void netmerc_state::machine_reset()
 {
 	model1_state::machine_reset();
 
-	if (m_dpram)
+	// Initial HMD (VR glasses) pose: camera orientation vector
+	// 12868 ≈ 90°, 25736 ≈ 180° — points the camera forward
+	constexpr int16_t pose[6] = {0, 0, 0, 12868, 25736, 12868};
+	for (int i = 0; i < 6; i++)
 	{
-		int16_t pose[6] = {0, 0, 0, 12868, 25736, 12868};
-		for (int i = 0; i < 6; i++)
-		{
-			m_dpram->left_w(0x80 + i*2, pose[i] & 0xff);
-			m_dpram->left_w(0x81 + i*2, (pose[i] >> 8) & 0xff);
-		}
+		m_dpram->left_w(0x80 + i * 2, pose[i] & 0xff);
+		m_dpram->left_w(0x81 + i * 2, (pose[i] >> 8) & 0xff);
 	}
 }
 

--- a/src/mame/sega/model1.cpp
+++ b/src/mame/sega/model1.cpp
@@ -918,20 +918,6 @@ void model1_state::machine_reset()
 
 	if (!strcmp(machine().system().name, "netmerc"))
 	{
-		if (m_nvram)
-		{
-			auto &space = m_maincpu->space(AS_PROGRAM);
-			if (space.read_byte(0x400038) == 0xFF && space.read_byte(0x40003c) == 0xFF &&
-				space.read_byte(0x400040) == 0xFF && space.read_byte(0x400044) == 0xFF)
-			{
-				space.write_byte(0x400038, 0x00);
-				space.write_byte(0x40003c, 0xFF);
-				space.write_byte(0x400040, 0x00);
-				space.write_byte(0x400044, 0xFF);
-				logerror("NetMerc: seeded default gun calibration\n");
-			}
-		}
-
 		if (m_dpram)
 		{
 			int16_t pose[6] = {0, 0, 0, 12868, 25736, 12868};
@@ -1762,6 +1748,9 @@ ROM_START( netmerc )
 	ROM_REGION( 0x8000, "polhemus", 0 ) /* POLHEMUS board */
 	ROM_LOAD16_BYTE( "u1", 0x0000, 0x4000, CRC(7073a312) SHA1(d2582f9520b8c8c051708dd372633112af59206e) )
 	ROM_LOAD16_BYTE( "u2", 0x0001, 0x4000, CRC(c589f428) SHA1(98dc0114a5f89636b4e237ed954e19f1cfd186ab) )
+
+	ROM_REGION( 0x10000, "nvram", 0 ) /* default NVRAM */
+	ROM_LOAD( "netmerc_nvram.bin", 0, 0x10000, CRC(09866826) SHA1(411134c1e6307f2e32c3b4b372597b45b14a9834) )
 ROM_END
 
 void model1_state::model1(machine_config &config)

--- a/src/mame/sega/model1.cpp
+++ b/src/mame/sega/model1.cpp
@@ -868,40 +868,35 @@ void model1_state::sound_ready_w(int state)
 		irq_raise(3);
 }
 
-u16 model1_state::timer_r(offs_t offset, u16 mem_mask)
+u16 model1_state::timer_r(offs_t offset)
 {
-	if (offset == 3 || offset == 4)
+	u16 result = m_timer_val[offset];
+	if (m_irq0_timer[offset]->enabled())
 	{
-		int tnum = offset - 3;
-		if (m_irq0_timer[tnum]->enabled())
-		{
-			uint32_t ticks = m_irq0_timer[tnum]->remaining().as_ticks(m_maincpu->clock());
-			m_timer_val[tnum] = ticks / 0x800;
-		}
-		return m_timer_val[tnum];
+		uint32_t ticks = m_irq0_timer[offset]->remaining().as_ticks(m_maincpu->clock());
+		result = ticks / 0x800;
+		if (!machine().side_effects_disabled())
+			m_timer_val[offset] = result;
 	}
-	return 0xffff;
+	return result;
 }
 
-void model1_state::timer_w(offs_t offset, u16 data, u16 mem_mask)
+void model1_state::timer_mode_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	if (offset == 1 || offset == 2)
+	COMBINE_DATA(&m_timer_mode);
+}
+
+void model1_state::timer_period_w(offs_t offset, u16 data, u16 mem_mask)
+{
+	COMBINE_DATA(&m_timer_period[offset]);
+	if (m_timer_period[offset])
 	{
-		int tnum = offset - 1;
-		COMBINE_DATA(&m_timer_period[tnum]);
-		if (m_timer_period[tnum])
-		{
-			attotime period = attotime::from_ticks(0x800 * m_timer_period[tnum], m_maincpu->clock());
-			m_irq0_timer[tnum]->adjust(period, tnum);
-		}
-		else
-		{
-			m_irq0_timer[tnum]->adjust(attotime::never);
-		}
+		attotime period = attotime::from_ticks(0x800 * m_timer_period[offset], m_maincpu->clock());
+		m_irq0_timer[offset]->adjust(period, offset);
 	}
-	else if (offset == 0)
+	else
 	{
-		COMBINE_DATA(&m_timer_mode[0]);
+		m_irq0_timer[offset]->adjust(attotime::never);
 	}
 }
 
@@ -1022,7 +1017,9 @@ void model1_state::model1_mem(address_map &map)
 	/* GLUE */ map(0xe00000, 0xe00000).w(FUNC(model1_state::irq_control_w));
 	/*      */ map(0xe00002, 0xe00002).rw(FUNC(model1_state::irq_mask_r), FUNC(model1_state::irq_mask_w));
 	/*      */ map(0xe00004, 0xe00005).w(FUNC(model1_state::bank_w));
-	/*      */ map(0xe00006, 0xe0000f).rw(FUNC(model1_state::timer_r), FUNC(model1_state::timer_w)); // Unemulated timer? (E0000A: period, E0000C: count; E0000E: ?)
+	/*      */ map(0xe00006, 0xe00007).w(FUNC(model1_state::timer_mode_w));
+	/*      */ map(0xe00008, 0xe0000b).w(FUNC(model1_state::timer_period_w));
+	/*      */ map(0xe0000c, 0xe0000f).r(FUNC(model1_state::timer_r)).nopw(); // vf/swa write 0 to the count registers at init
 
 	/* ROM0 */ map(0xf80000, 0xffffff).rom();
 }

--- a/src/mame/sega/model1.cpp
+++ b/src/mame/sega/model1.cpp
@@ -902,11 +902,14 @@ void model1_state::machine_reset()
 			}
 		}
 
-		int16_t pose[6] = {0, 0, 0, 12868, 25736, 12868};
-		for (int i = 0; i < 6; i++)
+		if (m_dpram)
 		{
-			m_dpram->left_w(0x80 + i*2, pose[i] >> 8);
-			m_dpram->left_w(0x81 + i*2, pose[i] & 0xff);
+			int16_t pose[6] = {0, 0, 0, 12868, 25736, 12868};
+			for (int i = 0; i < 6; i++)
+			{
+				m_dpram->left_w(0x80 + i*2, pose[i] & 0xff);
+				m_dpram->left_w(0x81 + i*2, (pose[i] >> 8) & 0xff);
+			}
 		}
 	}
 	else
@@ -1182,7 +1185,7 @@ static INPUT_PORTS_START( netmerc )
 	PORT_BIT( 0xf8, IP_ACTIVE_LOW, IPT_UNUSED )
 
 	PORT_START("STICKX")
-	PORT_BIT( 0xff, 0x7f, IPT_AD_STICK_X ) PORT_SENSITIVITY(100) PORT_KEYDELTA(4) PORT_REVERSE
+	PORT_BIT( 0xff, 0x7f, IPT_AD_STICK_X ) PORT_SENSITIVITY(100) PORT_KEYDELTA(4)
 
 	PORT_START("STICKY")
 	PORT_BIT( 0xff, 0x7f, IPT_AD_STICK_Y ) PORT_SENSITIVITY(100) PORT_KEYDELTA(4) PORT_REVERSE

--- a/src/mame/sega/model1.cpp
+++ b/src/mame/sega/model1.cpp
@@ -865,7 +865,8 @@ TIMER_DEVICE_CALLBACK_MEMBER(model1_state::model1_interrupt)
 	}
 	else if(scanline == 384/2)
 	{
-		irq_raise(m_sound_irq);
+		if (m_sound_irq <= 7)
+			irq_raise(m_sound_irq);
 	}
 }
 
@@ -882,6 +883,31 @@ void model1_state::machine_reset()
 		!strcmp(machine().system().name, "swaj"))
 	{
 		m_sound_irq = 0;
+	}
+	else if (!strcmp(machine().system().name, "netmerc"))
+	{
+		m_sound_irq = 0xff; // Netmerc ignores midframe irq, avoid stomping pen 0
+		
+		if (m_nvram)
+		{
+			auto &space = m_maincpu->space(AS_PROGRAM);
+			if (space.read_byte(0x400038) == 0xFF && space.read_byte(0x40003c) == 0xFF &&
+				space.read_byte(0x400040) == 0xFF && space.read_byte(0x400044) == 0xFF)
+			{
+				space.write_byte(0x400038, 0x00);
+				space.write_byte(0x40003c, 0xFF);
+				space.write_byte(0x400040, 0x00);
+				space.write_byte(0x400044, 0xFF);
+				logerror("NetMerc: seeded default gun calibration\n");
+			}
+		}
+
+		int16_t pose[6] = {0, 0, 0, 12868, 25736, 12868};
+		for (int i = 0; i < 6; i++)
+		{
+			m_dpram->left_w(0x80 + i*2, pose[i] >> 8);
+			m_dpram->left_w(0x81 + i*2, pose[i] & 0xff);
+		}
 	}
 	else
 	{

--- a/src/mame/sega/model1.cpp
+++ b/src/mame/sega/model1.cpp
@@ -694,7 +694,7 @@ void model1_state::wingwar360_outputs_w(uint8_t data)
 	machine().bookkeeping().coin_counter_w(0, BIT(data, 0));
 }
 
-void model1_state::netmerc_outputs_w(uint8_t data)
+void netmerc_state::netmerc_outputs_w(uint8_t data)
 {
 	// 76------  unknown (not used?)
 	// --54----  mvd backlights
@@ -1970,11 +1970,11 @@ void model1_state::polhemus_map(address_map &map)
 	map(0xf8000, 0xfffff).rom().region("polhemus", 0);
 }
 
-void model1_state::netmerc(machine_config &config)
+void netmerc_state::netmerc(machine_config &config)
 {
 	model1(config);
 	i386sx_device &polhemus(I386SX(config, "polhemus", 16000000));
-	polhemus.set_addrmap(AS_PROGRAM, &model1_state::polhemus_map);
+	polhemus.set_addrmap(AS_PROGRAM, &netmerc_state::polhemus_map);
 
 	model1io2_device &ioboard(SEGA_MODEL1IO2(config.replace(), "ioboard", 0));
 	ioboard.set_default_bios_tag("epr18021");
@@ -1984,8 +1984,8 @@ void model1_state::netmerc(machine_config &config)
 	ioboard.in_callback<1>().set_ioport("IN.1");
 	ioboard.an_callback<0>().set_ioport("STICKX");
 	ioboard.an_callback<2>().set_ioport("STICKY");
-	ioboard.output_callback().set(FUNC(model1_state::netmerc_outputs_w));
-	ioboard.output_callback().append(FUNC(model1_state::gen_outputs_w));
+	ioboard.output_callback().set(FUNC(netmerc_state::netmerc_outputs_w));
+	ioboard.output_callback().append(FUNC(netmerc_state::gen_outputs_w));
 
 	config.set_default_layout(layout_model1io2);
 }

--- a/src/mame/sega/model1.h
+++ b/src/mame/sega/model1.h
@@ -193,6 +193,7 @@ protected:
 		float translation[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 		glm::vec3 light;
 		lightparam_t lightparams[256];
+		bool spec_enable = false;
 	};
 
 	void model1_io(address_map &map) ATTR_COLD;
@@ -336,7 +337,7 @@ protected:
 
 	static float    min4f(float a, float b, float c, float d);
 	static float    max4f(float a, float b, float c, float d);
-	static float    compute_specular(glm::vec3& normal, glm::vec3& light, float diffuse,int lmode);
+	float   compute_specular(glm::vec3& normal, glm::vec3& light, float diffuse, int lmode);
 
 	int push_direct(int list_offset);
 	int draw_direct(bitmap_rgb32 &bitmap, const rectangle &cliprect, int list_offset);

--- a/src/mame/sega/model1.h
+++ b/src/mame/sega/model1.h
@@ -193,9 +193,6 @@ protected:
 		float translation[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 		glm::vec3 light;
 		lightparam_t lightparams[256];
-		bool lightparam_set[256]{};
-		int light_bank = 0;
-		bool lightparams_hi_seen = false;
 	};
 
 	void model1_io(address_map &map) ATTR_COLD;

--- a/src/mame/sega/model1.h
+++ b/src/mame/sega/model1.h
@@ -16,6 +16,7 @@
 #include "machine/i8251.h"
 #include "machine/gen_fifo.h"
 #include "machine/mb8421.h"
+#include "machine/nvram.h"
 #include "machine/timer.h"
 
 #include "emupal.h"
@@ -358,7 +359,7 @@ private:
 	void apply_overlay_stencil(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
 	optional_shared_ptr<uint16_t> m_paletteram16;
-	optional_shared_ptr<uint16_t> m_nvram;
+	required_device<nvram_device> m_nvram;
 	required_device<palette_device> m_palette;
 	required_device<segas24_tile_device> m_tiles;
 

--- a/src/mame/sega/model1.h
+++ b/src/mame/sega/model1.h
@@ -217,6 +217,14 @@ protected:
 	void irq_control_w(u8 data);
 	u8 irq_mask_r();
 	void irq_mask_w(u8 data);
+	u16 timer_r(offs_t offset, u16 mem_mask);
+	void timer_w(offs_t offset, u16 data, u16 mem_mask);
+	TIMER_CALLBACK_MEMBER(irq0_timer_tick);
+
+	emu_timer *m_irq0_timer[2] = { nullptr, nullptr };
+	uint16_t m_timer_period[2] = { 0, 0 };
+	uint16_t m_timer_val[2] = { 0, 0 };
+	uint16_t m_timer_mode[2] = { 0, 0 };
 	void sound_ready_w(int state);
 
 	uint8_t m_irq_status = 0;

--- a/src/mame/sega/model1.h
+++ b/src/mame/sega/model1.h
@@ -96,7 +96,7 @@ public:
 		int col = 0;
 	};
 
-private:
+protected:
 	// Machine
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
@@ -376,6 +376,18 @@ private:
 	void wingwar360_outputs_w(uint8_t data);
 	void netmerc_outputs_w(uint8_t data);
 	void drive_board_w(uint8_t data);
+};
+
+class netmerc_state : public model1_state
+{
+public:
+	netmerc_state(const machine_config &mconfig, device_type type, const char *tag)
+		: model1_state(mconfig, type, tag)
+	{
+	}
+
+protected:
+	virtual void machine_reset() override ATTR_COLD;
 };
 
 #endif // MAME_SEGA_MODEL1_H

--- a/src/mame/sega/model1.h
+++ b/src/mame/sega/model1.h
@@ -394,10 +394,11 @@ public:
 
 	void netmerc(machine_config &config);
 
-	void netmerc_outputs_w(uint8_t data);
-
 protected:
 	virtual void machine_reset() override ATTR_COLD;
+
+private:
+	void netmerc_outputs_w(uint8_t data);
 };
 
 #endif // MAME_SEGA_MODEL1_H

--- a/src/mame/sega/model1.h
+++ b/src/mame/sega/model1.h
@@ -64,7 +64,6 @@ public:
 	void swa(machine_config &config);
 	void wingwar(machine_config &config);
 	void wingwar360(machine_config &config);
-	void netmerc(machine_config &config);
 
 	struct spoint_t
 	{
@@ -383,7 +382,6 @@ protected:
 	void swa_outputs_w(uint8_t data);
 	void wingwar_outputs_w(uint8_t data);
 	void wingwar360_outputs_w(uint8_t data);
-	void netmerc_outputs_w(uint8_t data);
 	void drive_board_w(uint8_t data);
 };
 
@@ -394,6 +392,10 @@ public:
 		: model1_state(mconfig, type, tag)
 	{
 	}
+
+	void netmerc(machine_config &config);
+
+	void netmerc_outputs_w(uint8_t data);
 
 protected:
 	virtual void machine_reset() override ATTR_COLD;

--- a/src/mame/sega/model1.h
+++ b/src/mame/sega/model1.h
@@ -214,8 +214,11 @@ private:
 	void irq_raise(int level);
 	void irq_init();
 	void irq_control_w(u8 data);
+	u8 irq_mask_r();
+	void irq_mask_w(u8 data);
 
 	uint8_t m_irq_status = 0;
+	uint8_t m_irq_mask = 0xff;
 	int m_last_irq = 0;
 
 	// Devices
@@ -236,9 +239,6 @@ private:
 	required_shared_ptr<uint16_t> m_display_list0;
 	required_shared_ptr<uint16_t> m_display_list1;
 	required_shared_ptr<uint16_t> m_color_xlat;
-
-	// Sound
-	int m_sound_irq = 0;
 
 	// TGP FIFO
 	void    fifoout_push(uint32_t data);

--- a/src/mame/sega/model1.h
+++ b/src/mame/sega/model1.h
@@ -281,6 +281,13 @@ private:
 	uint16_t  m_v60_copro_ram_latch[2]{};
 	std::unique_ptr<uint32_t[]> m_copro_ram_data;
 	uint16_t  m_listctl[2]{};
+	// Flat-z "reuse" register (poly zmode 0 = keep previous poly's sort z).
+	// Rasterizer state that persists ACROSS objects within a display-list
+	// walk: NetMerc's garage door wings (all-zmode-0 dynamic objects) must
+	// inherit the ~325k z of the preceding object so the z~40k wall occludes
+	// them (real-hardware capture); resetting per object made them sort at
+	// z=0 (nearest) and paint through the wall. Reset per walk in tgp_render.
+	float m_dl_old_z = 0;
 	uint16_t  *m_glist = nullptr;
 	bool    m_render_done = false;
 

--- a/src/mame/sega/model1.h
+++ b/src/mame/sega/model1.h
@@ -47,6 +47,7 @@ public:
 		, m_display_list1(*this, "display_list1")
 		, m_color_xlat(*this, "color_xlat")
 		, m_paletteram16(*this, "palette")
+		, m_nvram(*this, "nvram")
 		, m_palette(*this, "palette")
 		, m_tiles(*this, "tile")
 		, m_digits(*this, "digit%u", 0U)
@@ -350,6 +351,7 @@ private:
 	void apply_overlay_stencil(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
 	optional_shared_ptr<uint16_t> m_paletteram16;
+	optional_shared_ptr<uint16_t> m_nvram;
 	required_device<palette_device> m_palette;
 	required_device<segas24_tile_device> m_tiles;
 

--- a/src/mame/sega/model1.h
+++ b/src/mame/sega/model1.h
@@ -217,6 +217,7 @@ protected:
 	void irq_control_w(u8 data);
 	u8 irq_mask_r();
 	void irq_mask_w(u8 data);
+	void sound_ready_w(int state);
 
 	uint8_t m_irq_status = 0;
 	uint8_t m_irq_mask = 0xff;

--- a/src/mame/sega/model1.h
+++ b/src/mame/sega/model1.h
@@ -214,14 +214,15 @@ protected:
 	void irq_control_w(u8 data);
 	u8 irq_mask_r();
 	void irq_mask_w(u8 data);
-	u16 timer_r(offs_t offset, u16 mem_mask);
-	void timer_w(offs_t offset, u16 data, u16 mem_mask);
+	u16 timer_r(offs_t offset);
+	void timer_mode_w(offs_t offset, u16 data, u16 mem_mask);
+	void timer_period_w(offs_t offset, u16 data, u16 mem_mask);
 	TIMER_CALLBACK_MEMBER(irq0_timer_tick);
 
 	emu_timer *m_irq0_timer[2] = { nullptr, nullptr };
 	uint16_t m_timer_period[2] = { 0, 0 };
 	uint16_t m_timer_val[2] = { 0, 0 };
-	uint16_t m_timer_mode[2] = { 0, 0 };
+	uint16_t m_timer_mode = 0;
 	void sound_ready_w(int state);
 
 	uint8_t m_irq_status = 0;

--- a/src/mame/sega/model1.h
+++ b/src/mame/sega/model1.h
@@ -289,13 +289,6 @@ protected:
 	uint16_t  m_v60_copro_ram_latch[2]{};
 	std::unique_ptr<uint32_t[]> m_copro_ram_data;
 	uint16_t  m_listctl[2]{};
-	// Flat-z "reuse" register (poly zmode 0 = keep previous poly's sort z).
-	// Rasterizer state that persists ACROSS objects within a display-list
-	// walk: NetMerc's garage door wings (all-zmode-0 dynamic objects) must
-	// inherit the ~325k z of the preceding object so the z~40k wall occludes
-	// them (real-hardware capture); resetting per object made them sort at
-	// z=0 (nearest) and paint through the wall. Reset per walk in tgp_render.
-	float m_dl_old_z = 0;
 	uint16_t  *m_glist = nullptr;
 	bool    m_render_done = false;
 
@@ -343,7 +336,7 @@ protected:
 	int push_direct(int list_offset);
 	int draw_direct(bitmap_rgb32 &bitmap, const rectangle &cliprect, int list_offset);
 	int skip_direct(int list_offset) const;
-	void    push_object(uint32_t tex_adr, uint32_t poly_adr, uint32_t size);
+	void    push_object(uint32_t tex_adr, uint32_t poly_adr, uint32_t size, float &old_z);
 	void    draw_objects(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
 	void set_current_render_list();

--- a/src/mame/sega/model1.h
+++ b/src/mame/sega/model1.h
@@ -191,7 +191,10 @@ private:
 		float vxx = 0, vyy = 0, vzz = 0, ayy = 0, ayyc = 0, ayys = 0;
 		float translation[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 		glm::vec3 light;
-		lightparam_t lightparams[32];
+		lightparam_t lightparams[256];
+		bool lightparam_set[256]{};
+		int light_bank = 0;
+		bool lightparams_hi_seen = false;
 	};
 
 	void model1_io(address_map &map) ATTR_COLD;

--- a/src/mame/sega/model1_m.cpp
+++ b/src/mame/sega/model1_m.cpp
@@ -18,6 +18,11 @@ void model1_state::machine_start()
 	save_item(NAME(m_v60_copro_ram_adr));
 	save_item(NAME(m_v60_copro_ram_latch));
 
+	m_irq0_timer[0] = timer_alloc(FUNC(model1_state::irq0_timer_tick), this);
+	m_irq0_timer[1] = timer_alloc(FUNC(model1_state::irq0_timer_tick), this);
+	save_item(NAME(m_timer_period));
+	save_item(NAME(m_timer_mode));
+
 	m_copro_fifo_in->setup(16,
 						   [this]() { m_tgp_copro->stall(); },
 						   [this]() { m_tgp_copro->set_input_line(INPUT_LINE_HALT, ASSERT_LINE); },

--- a/src/mame/sega/model1_v.cpp
+++ b/src/mame/sega/model1_v.cpp
@@ -904,9 +904,12 @@ void model1_state::push_object(uint32_t tex_adr, uint32_t poly_adr, uint32_t siz
 
 		if (flags & 0x00001000)
 			tex_adr++;
-		int lightmode = ((flags >> 17) & 15) | m_view->light_bank;
-		if (!m_view->lightparam_set[lightmode] && m_view->lightparam_set[lightmode | 0x80])
-			lightmode |= 0x80;
+		// Flags bit 22 selects the second light parameter bank. netmerc uploads
+		// two banks (0x00-0x0c organic/terrain, 0x80-0x9e metal) and mixes
+		// polygons from both within a single display list; the other games
+		// never set the bit. In the Model 2 GEO attribute word this same bit
+		// is the top bit of the texture parameter index.
+		int lightmode = ((flags >> 17) & 15) | ((flags & 0x00400000) ? 0x80 : 0);
 
 		point_t *p0 = m_pointpt++;
 		point_t *p1 = m_pointpt++;
@@ -1361,9 +1364,6 @@ void model1_state::view_t::set_viewport(float xcenter, float ycenter, float xl, 
 
 void model1_state::view_t::set_lightparam(int index, float diffuse, float ambient, float specular, int power)
 {
-	if (index >= 0x80)
-		lightparams_hi_seen = true;
-	lightparam_set[index] = true;
 	lightparams[index].d = diffuse;
 	lightparams[index].a = ambient;
 	lightparams[index].s = specular;
@@ -1410,7 +1410,6 @@ void model1_state::tgp_render(bitmap_rgb32 &bitmap, const rectangle &cliprect, r
 		LOGMASKED(LOG_TGP, "VIDEO: render list %d\n", get_list_number());
 
 		m_view->init_translation_matrix();
-		m_view->light_bank = 0;
 		m_dl_old_z = 0;
 
 		int list_offset = 0;
@@ -1507,7 +1506,6 @@ void model1_state::tgp_render(bitmap_rgb32 &bitmap, const rectangle &cliprect, r
 			}
 			case 7:
 				LOGMASKED(LOG_TGP, "VIDEO:   code 7 (%d)\n", readi(list_offset + 2));
-				m_view->light_bank = (readi(list_offset + 2) == 0 && m_view->lightparams_hi_seen) ? 0x80 : 0;
 				list_offset += 4;
 				break;
 			case 8:

--- a/src/mame/sega/model1_v.cpp
+++ b/src/mame/sega/model1_v.cpp
@@ -782,32 +782,26 @@ static const uint8_t num_of_times[]={1,1,1,1,2,2,2,3};
 #endif
 float model1_state::compute_specular(glm::vec3& normal, glm::vec3& light, float diffuse, int lmode)
 {
-#if 0
-	int p = m_view->lightparams[lmode].p & 7;
-	float sv = m_view->lightparams[lmode].s;
-
-	//This is how it should be according to model2 geo program, but doesn't work fine
-	float s = 2 * (diffuse * normal.z - light.z);
-	for (int i = 0; i < num_of_times[p]; i++)
-	{
-		s *= s;
-	}
-	s *= sv;
-	if (s < 0.0f)
-	{
+	if (!m_view->spec_enable)
 		return 0.0f;
-	}
-	if (s > 1.0f)
-	{
-		return 1.0f;
-	}
-	return s;
 
-	// ???
-	//return fabs(diffuse)*sv;
-#endif
+	const lightparam_t &lp = m_view->lightparams[lmode];
+	if (lp.p == 0 || lp.s <= 0.0f)
+		return 0.0f;
 
-	return 0;
+	// z component of the reflected light vector, as computed by the Model 2
+	// GEO program: R.z = 2*(N.L)*N.z - L.z, raised to a power of two selected
+	// by the power field and scaled by the specular scale.
+	float s = 2.0f * diffuse * normal.z - light.z;
+	if (s <= 0.0f)
+		return 0.0f;
+	if (lp.p >= 2)
+		s *= s;
+	if (lp.p >= 4)
+		s *= s;
+	if (lp.p >= 7)
+		s *= s;
+	return std::min(s * lp.s, 1.0f);
 }
 
 void model1_state::push_object(uint32_t tex_adr, uint32_t poly_adr, uint32_t size)
@@ -1505,7 +1499,12 @@ void model1_state::tgp_render(bitmap_rgb32 &bitmap, const rectangle &cliprect, r
 				break;
 			}
 			case 7:
-				LOGMASKED(LOG_TGP, "VIDEO:   code 7 (%d)\n", readi(list_offset + 2));
+				// Mode word, as in the Model 2 GEO command 7: bit 0 enables the
+				// specular term (netmerc toggles it mid-list, on for the enemy
+				// mechs and off for terrain/cockpit); bit 1 tracks the display
+				// list double buffer parity.
+				LOGMASKED(LOG_TGP, "VIDEO:   mode word (%d)\n", readi(list_offset + 2));
+				m_view->spec_enable = BIT(readi(list_offset + 2), 0);
 				list_offset += 4;
 				break;
 			case 8:

--- a/src/mame/sega/model1_v.cpp
+++ b/src/mame/sega/model1_v.cpp
@@ -883,7 +883,7 @@ void model1_state::push_object(uint32_t tex_adr, uint32_t poly_adr, uint32_t siz
 		old_p1->s.x = old_p1->s.y = 0;
 	}
 
-	float old_z = 0;
+	float old_z = m_dl_old_z; // persists across objects within a DL walk
 
 	poly_adr += 6;
 
@@ -997,6 +997,7 @@ void model1_state::push_object(uint32_t tex_adr, uint32_t poly_adr, uint32_t siz
 				cquad.z = 0.0;
 				break;
 		}
+		m_dl_old_z = old_z;
 
 		{
 #if 0
@@ -1410,6 +1411,7 @@ void model1_state::tgp_render(bitmap_rgb32 &bitmap, const rectangle &cliprect, r
 
 		m_view->init_translation_matrix();
 		m_view->light_bank = 0;
+		m_dl_old_z = 0;
 
 		int list_offset = 0;
 		for (;;) {

--- a/src/mame/sega/model1_v.cpp
+++ b/src/mame/sega/model1_v.cpp
@@ -919,6 +919,13 @@ void model1_state::push_object(uint32_t tex_adr, uint32_t poly_adr, uint32_t siz
 		p1->y = poly_data[poly_adr + 8];
 		p1->z = poly_data[poly_adr + 9];
 
+		if (type == 2)
+		{
+			p1->x = p0->x;
+			p1->y = p0->y;
+			p1->z = p0->z;
+		}
+
 		int link = (flags >> 8) & 3;
 
 		m_view->transform_vector(vn);

--- a/src/mame/sega/model1_v.cpp
+++ b/src/mame/sega/model1_v.cpp
@@ -904,7 +904,9 @@ void model1_state::push_object(uint32_t tex_adr, uint32_t poly_adr, uint32_t siz
 
 		if (flags & 0x00001000)
 			tex_adr++;
-		int lightmode = (flags >> 17) & 15;
+		int lightmode = ((flags >> 17) & 15) | m_view->light_bank;
+		if (!m_view->lightparam_set[lightmode] && m_view->lightparam_set[lightmode | 0x80])
+			lightmode |= 0x80;
 
 		point_t *p0 = m_pointpt++;
 		point_t *p1 = m_pointpt++;
@@ -1351,6 +1353,9 @@ void model1_state::view_t::set_viewport(float xcenter, float ycenter, float xl, 
 
 void model1_state::view_t::set_lightparam(int index, float diffuse, float ambient, float specular, int power)
 {
+	if (index >= 0x80)
+		lightparams_hi_seen = true;
+	lightparam_set[index] = true;
 	lightparams[index].d = diffuse;
 	lightparams[index].a = ambient;
 	lightparams[index].s = specular;
@@ -1397,6 +1402,7 @@ void model1_state::tgp_render(bitmap_rgb32 &bitmap, const rectangle &cliprect, r
 		LOGMASKED(LOG_TGP, "VIDEO: render list %d\n", get_list_number());
 
 		m_view->init_translation_matrix();
+		m_view->light_bank = 0;
 
 		int list_offset = 0;
 		for (;;) {
@@ -1492,6 +1498,7 @@ void model1_state::tgp_render(bitmap_rgb32 &bitmap, const rectangle &cliprect, r
 			}
 			case 7:
 				LOGMASKED(LOG_TGP, "VIDEO:   code 7 (%d)\n", readi(list_offset + 2));
+				m_view->light_bank = (readi(list_offset + 2) == 0 && m_view->lightparams_hi_seen) ? 0x80 : 0;
 				list_offset += 4;
 				break;
 			case 8:
@@ -1780,7 +1787,7 @@ uint32_t model1_state::screen_update_model1(screen_device &screen, bitmap_rgb32 
 	view->ayys = sin(view->ayy);
 
 	screen.priority().fill(0);
-	bitmap.fill(m_palette->pen(0x400), cliprect);
+	bitmap.fill(m_palette->pen(0), cliprect);
 
 	// draw tilemap B as opaque
 	m_tiles->draw(screen, bitmap, cliprect, 6, 0, TILEMAP_DRAW_OPAQUE);

--- a/src/mame/sega/model1_v.cpp
+++ b/src/mame/sega/model1_v.cpp
@@ -804,7 +804,13 @@ float model1_state::compute_specular(glm::vec3& normal, glm::vec3& light, float 
 	return std::min(s * lp.s, 1.0f);
 }
 
-void model1_state::push_object(uint32_t tex_adr, uint32_t poly_adr, uint32_t size)
+// old_z is the flat-z "reuse" register (poly zmode 0 = keep previous poly's
+// sort z). It persists ACROSS objects within a display-list walk: NetMerc's
+// garage door wings (all-zmode-0 dynamic objects) must inherit the ~325k z of
+// the preceding object so the z~40k wall occludes them (real-hardware
+// capture); resetting per object made them sort at z=0 (nearest) and paint
+// through the wall.
+void model1_state::push_object(uint32_t tex_adr, uint32_t poly_adr, uint32_t size, float &old_z)
 {
 	// Protect against bad data when attacking a super destroyer
 	if(tex_adr == 0xffffffff || size >= 0x1000000)
@@ -876,8 +882,6 @@ void model1_state::push_object(uint32_t tex_adr, uint32_t poly_adr, uint32_t siz
 	{
 		old_p1->s.x = old_p1->s.y = 0;
 	}
-
-	float old_z = m_dl_old_z; // persists across objects within a DL walk
 
 	poly_adr += 6;
 
@@ -994,7 +998,6 @@ void model1_state::push_object(uint32_t tex_adr, uint32_t poly_adr, uint32_t siz
 				cquad.z = 0.0;
 				break;
 		}
-		m_dl_old_z = old_z;
 
 		{
 #if 0
@@ -1404,7 +1407,7 @@ void model1_state::tgp_render(bitmap_rgb32 &bitmap, const rectangle &cliprect, r
 		LOGMASKED(LOG_TGP, "VIDEO: render list %d\n", get_list_number());
 
 		m_view->init_translation_matrix();
-		m_dl_old_z = 0;
+		float old_z = 0;
 
 		int list_offset = 0;
 		for (;;) {
@@ -1418,13 +1421,13 @@ void model1_state::tgp_render(bitmap_rgb32 &bitmap, const rectangle &cliprect, r
 			case 1:
 				// command 0x01 = object drawn below the cat1 HUD tilemaps
 				if (pass == RENDER_BELOW_HUD)
-					push_object(readi(list_offset + 2), readi(list_offset + 4), readi(list_offset + 6));
+					push_object(readi(list_offset + 2), readi(list_offset + 4), readi(list_offset + 6), old_z);
 				list_offset += 8;
 				break;
 			case 0x41:
 				// command 0x41 = object drawn above the HUD (e.g. SWA radar blips)
 				if (pass == RENDER_ABOVE_HUD)
-					push_object(readi(list_offset + 2), readi(list_offset + 4), readi(list_offset + 6));
+					push_object(readi(list_offset + 2), readi(list_offset + 4), readi(list_offset + 6), old_z);
 				list_offset += 8;
 				break;
 			case 2:


### PR DESCRIPTION
This PR ports various improvements to the Sega Model 1 emulator for the game NetMerc:

* Expands lightbanks to 256 for proper lighting parsing.
* Fixes the background fill color to use pen 0 instead of pen 0x400.
* Implements the fix for degenerate triangle polygons where `p1 = p0`.
* Corrects the gun tracking analog inputs by removing `PORT_REVERSE` from `STICKX`.
* Injects the HMD neutral pose at `machine_reset()` to fix the camera rotation.
* Inhibits midframe IRQ to prevent stomping over the dynamically updated pen 0 background.
* Seeds default NVRAM calibration for the gun to prevent the mesh from being culled.

Now it looks playable

<img width="1607" height="1165" alt="image" src="https://github.com/user-attachments/assets/85ee9799-a46f-4f95-a472-e010a18e5aff" />
<img width="1607" height="1165" alt="image copy" src="https://github.com/user-attachments/assets/f35404a3-69dd-4341-83cf-86863005f9b7" />
<img width="1607" height="1165" alt="image copy 2" src="https://github.com/user-attachments/assets/44c63829-1046-4b59-b736-f194c4c8fdd6" />

nvram [netmerc_nvram.zip](https://github.com/user-attachments/files/29659125/netmerc_nvram.zip)

Note: The development of these changes was done with the assistance of Claude Opus 4.8 in Geometrizer, and the adaptation to MAME was done via Gemini 3.1 Pro.
