### PR TITLE
nec/pc6001.cpp: 31 new dumps

### DIFF
--- a/hash/coleco_homebrew.xml
+++ b/hash/coleco_homebrew.xml
@@ -227,6 +227,7 @@ Unoffical software releases for the Coleco Colecovision
 		</part>
 	</software>
 
+	<!-- TODO: standardize vs. other hash sets (blckonyx) -->
 	<software name="blackonx">
 		<description>The Black Onyx</description>
 		<year>2013</year>

--- a/hash/dc.xml
+++ b/hash/dc.xml
@@ -20009,7 +20009,7 @@ Crashes after FMV on few seconds of (broken) GFXs [drc]
 		-->
 		<description>Marionette Company (Japan)</description>
 		<year>1999</year>
-		<publisher>Microcabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<notes><![CDATA[
 Built on Windows CE, requires [MMU] support
 ]]></notes>
@@ -20034,7 +20034,7 @@ Built on Windows CE, requires [MMU] support
 		-->
 		<description>Marionette Company 2 (Japan)</description>
 		<year>2000</year>
-		<publisher>Microcabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<notes><![CDATA[
 Built on Windows CE, requires [MMU] support
 ]]></notes>

--- a/hash/msx1_cart.xml
+++ b/hash/msx1_cart.xml
@@ -2584,7 +2584,7 @@ kept for now until finding out what those bytes affect...
 	<software name="blagger" supported="partial">
 		<description>Blagger MSX (Japan)</description>
 		<year>1984</year>
-		<publisher>MicroCabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<info name="alt_title" value="ブラッガー" />
 		<part name="cart" interface="msx_cart">
 			<feature name="start_page" value="1"/>
@@ -7054,7 +7054,7 @@ kept for now until finding out what those bytes affect...
 	<software name="hisha">
 		<description>Hisha (Japan)</description>
 		<year>1985</year>
-		<publisher>MicroCabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<info name="alt_title" value="飛車" />
 		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
@@ -7250,7 +7250,7 @@ kept for now until finding out what those bytes affect...
 	<software name="hfox">
 		<description>Hurry Fox MSX Special (Japan)</description>
 		<year>1986</year>
-		<publisher>MicroCabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<info name="serial" value="44780" />
 		<info name="alt_title" value="は～りぃふぉっくすＭＳＸスペシャル" />
 		<info name="gtin" value="04988608447808"/>
@@ -7268,9 +7268,9 @@ kept for now until finding out what those bytes affect...
 	</software>
 
 	<software name="hfox2">
-		<description>Hurry Fox - Yuki no Maou hen (Japan)</description>
+		<description>Hurry Fox: Yuki no Maou hen (Japan)</description>
 		<year>1985</year>
-		<publisher>MicroCabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<info name="alt_title" value="は～りぃふぉっくす雪の魔王編" />
 		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
@@ -10920,7 +10920,7 @@ Right/left cursor keys select tape baud rate 1200/2400 respectively.
 	<software name="picopico">
 		<description>Pico Pico (Japan)</description>
 		<year>1983</year>
-		<publisher>Microcabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<info name="alt_title" value="ピコピコ" />
 		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
@@ -12155,7 +12155,7 @@ Right/left cursor keys select tape baud rate 1200/2400 respectively.
 	<software name="shogimc">
 		<description>Shougi (Japan, MicroCabin)</description>
 		<year>1985</year>
-		<publisher>MicroCabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<info name="alt_title" value="将棋" />
 		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">

--- a/hash/msx1_cass.xml
+++ b/hash/msx1_cass.xml
@@ -4516,6 +4516,7 @@ license:CC0-1.0
 		<description>Dezeni Land (Japan)</description>
 		<year>1984</year>
 		<publisher>Hudson Soft</publisher>
+		<info name="alt_title" value="デゼニランド"/>
 		<info name="serial" value="MX-2003"/>
 		<info name="usage" value="Load with BLOAD&quot;CAS:&quot;,R"/>
 

--- a/hash/msx1_cass.xml
+++ b/hash/msx1_cass.xml
@@ -17047,6 +17047,7 @@ Side B
 		</part>
 	</software>
 
+	<!-- TODO: rename to tomathim -->
 	<software name="tmtprncs">
 		<description>Salad no Kuni no Tomato-hime (Japan)</description>
 		<year>1985</year>

--- a/hash/msx1_cass.xml
+++ b/hash/msx1_cass.xml
@@ -8034,7 +8034,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="hfox">
-		<description>Hurry Fox - Yuki no Maou hen (Japan)</description>
+		<description>Hurry Fox: Yuki no Maou hen (Japan)</description>
 		<year>1985</year>
 		<publisher>Micro Cabin</publisher>
 		<info name="usage" value="Load with BLOAD&quot;CAS:&quot;,R. Requires a Japanese system."/>

--- a/hash/msx2_cart.xml
+++ b/hash/msx2_cart.xml
@@ -1115,6 +1115,7 @@ LZ93A13 (32 pin) - 8KB banks
 		<description>Pac-Mania (Japan)</description>
 		<year>1989</year>
 		<publisher>Namco</publisher>
+		<info name="alt_title" value="パックマニア"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TAS-4M016-03M" />
 			<feature name="slot" value="ascii8" />

--- a/hash/pc6001_cass.xml
+++ b/hash/pc6001_cass.xml
@@ -20,6 +20,8 @@ Once in BASIC, enter CLOAD then press ENTER, then RUN then ENTER once loading co
 -->
 <softwarelist name="pc6001_cass" description="NEC PC-6001 cassette snapshots">
 
+<!-- !Games -->
+
 	<software name="amazon" supported="partial">
 		<description>The Amazon</description>
 		<year>19??</year>
@@ -40,6 +42,49 @@ Once in BASIC, enter CLOAD then press ENTER, then RUN then ENTER once loading co
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="2755">
 				<rom name="amita.cas" size="2755" crc="fbb5ec19" sha1="dc49c616fb7822f21ca895bbb5f3b16924d306d8"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ax6" supported="no">
+		<description>AX-6</description>
+		<!-- Year from tape printout -->
+		<year>1982</year>
+		<publisher>ASCII</publisher>
+		<notes><![CDATA[
+Demo: should corrupt video when AY-based speech plays back (cfr. real HW refs)
+Space Enemy, Head-On: runs too fast
+]]></notes>
+		<info name="usage" value="Mode 1, Page 1 for all but for Powered Knight (Mode 2, Page 1)"/>
+		<!-- All from Side A -->
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Demonstration"/>
+			<dataarea name="snap" size="11407">
+				<rom name="ax-6 (demo).cas" size="11407" crc="535a388c" sha1="a08ed50e4f66fcdabce019ac2c644b321d5f667e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Powered Knight"/>
+			<dataarea name="snap" size="13612">
+				<rom name="ax-6 (powered knight).cas" size="13612" crc="9252969e" sha1="e0e3b0582c8c17d7f738dd2f61a9933420435283" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="Mastermind"/>
+			<dataarea name="snap" size="6841">
+				<rom name="ax-6 (mastermind).cas" size="6841" crc="074faa75" sha1="ab0cfe272400c493d8fc563ce7d9f0f62d34ba99" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="Head-On"/>
+			<dataarea name="snap" size="5711">
+				<rom name="ax-6 (head-on).cas" size="5711" crc="91f7d594" sha1="e64442f2c32f0a7b6c62e1adcc4555fcc8149b66" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap5" interface="pc6001_snap">
+			<feature name="part_id" value="Space Enemy"/>
+			<dataarea name="snap" size="5579">
+				<rom name="ax-6 (space enemy).cas" size="5579" crc="6601f428" sha1="4d922cef648f9efe001f25920bf1874ca5cbde52" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -133,18 +178,6 @@ Once in BASIC, enter CLOAD then press ENTER, then RUN then ENTER once loading co
 		</part>
 	</software>
 
-	<software name="power" supported="partial">
-		<description>Power Knight</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
-		<info name="usage" value="Mode 1, Page 1" />
-		<part name="snap" interface="pc6001_snap">
-			<dataarea name="snap" size="13612">
-				<rom name="power.cas" size="13612" crc="9252969e" sha1="e0e3b0582c8c17d7f738dd2f61a9933420435283"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="proracer" supported="partial">
 		<description>Pro Racer</description>
 		<year>19??</year>
@@ -170,6 +203,7 @@ Once in BASIC, enter CLOAD then press ENTER, then RUN then ENTER once loading co
 		</part>
 	</software>
 
+	<!-- TODO: did ASCII really released this in standalone form? -->
 	<software name="spcenemy" supported="partial">
 		<description>Space Enemy</description>
 		<year>1982</year>
@@ -265,5 +299,6 @@ Gameplay is too fast
 			</dataarea>
 		</part>
 	</software>
+
 
 </softwarelist>

--- a/hash/pc6001_cass.xml
+++ b/hash/pc6001_cass.xml
@@ -52,8 +52,8 @@ Once in BASIC, enter CLOAD then press ENTER, then RUN then ENTER once loading co
 		<year>1982</year>
 		<publisher>ASCII</publisher>
 		<notes><![CDATA[
-Demo: should corrupt video when AY-based speech plays back (cfr. real HW refs)
-Space Enemy, Head-On: runs too fast
+Demo: [timing] should corrupt video when AY-based speech plays back (cfr. real HW refs)
+Space Enemy, Head-On: [timing] runs too fast
 ]]></notes>
 		<info name="usage" value="Mode 1, Page 1 for all but for Powered Knight (Mode 2, Page 1)"/>
 		<!-- All from Side A -->
@@ -85,6 +85,31 @@ Space Enemy, Head-On: runs too fast
 			<feature name="part_id" value="Space Enemy"/>
 			<dataarea name="snap" size="5579">
 				<rom name="ax-6 (space enemy).cas" size="5579" crc="6601f428" sha1="4d922cef648f9efe001f25920bf1874ca5cbde52" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ax8" supported="no">
+		<description>AX-8</description>
+		<!-- Year from tape printout -->
+		<year>1984</year>
+		<publisher>ASCII</publisher>
+		<notes><![CDATA[
+Cannot start a game, requires [keyboard] stop key
+]]></notes>
+		<info name="usage" value="Mode 2, Page 1"/>
+		<info name="alt_title" value="ギャラクシーミッション"/>
+		<!-- both from side A -->
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Part 1"/>
+			<dataarea name="snap" size="23444">
+				<rom name="ax-8 (galaxy mission) (part 1).cas" size="23444" crc="e6a91fd9" sha1="ed46535f9fc21a7a1753c7b8011e33bf84cc31b7" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Part 2"/>
+			<dataarea name="snap" size="25764">
+				<rom name="ax-8 (galaxy mission) (part 2).cas" size="25764" crc="049fbe65" sha1="7cfae929b6cf0c8511d59e86c15a18548686e20b" offset="0" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/pc6001_cass.xml
+++ b/hash/pc6001_cass.xml
@@ -184,6 +184,26 @@ Once in BASIC, enter CLOAD then press ENTER, then RUN then ENTER once loading co
 		</part>
 	</software>
 
+	<software name="sharrier" supported="no">
+		<description>Space Harrier</description>
+		<year>198?</year>
+		<publisher>Dempa</publisher>
+		<notes><![CDATA[
+Very sensitive with [sub] irq triggers
+[keyboard] joy triggers doesn't work properly (select F1 after loading), cannot move down
+[gfx] draws garbage on vanilla pc6001 and eventually crashes MAME
+]]></notes>
+		<info name="usage" value="Mode 2, Page 2"/>
+		<info name="developer" value="T. Matsushima"/>
+		<info name="developer" value="Yet"/>
+		<info name="alt_title" value="スペースハリアー"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="43681">
+				<rom name="space harrier.cas" size="43681" crc="56319bd8" sha1="15e6ef72b233da81dbba4d096937fc18de6ffca3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="suprball" supported="partial">
 		<description>Super Ball</description>
 		<year>19??</year>
@@ -215,10 +235,33 @@ Once in BASIC, enter CLOAD then press ENTER, then RUN then ENTER once loading co
 		<publisher>Dempa Micomsoft</publisher>
 		<info name="usage" value="Mode 4, Page 2 - PC-6001 requires N60 Extended BASIC cartridge" />
 		<info name="alt_title" value="タイニーゼビウス"/>
+		<info name="developer" value="T. Matsushima"/>
 		<sharedfeat name="requirement" value="pc6001_cart:n60basic"/>
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="17741">
 				<rom name="tiny xevious.cas" size="17741" crc="5e9e2dbf" sha1="90e2b187f3b042ef1883105a34e83fe69a58e38f"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="txevious2" supported="no">
+		<description>Tiny Xevious 2</description>
+		<!-- 1984 08. -->
+		<year>1984</year>
+		<publisher>Dempa Micomsoft</publisher>
+		<notes><![CDATA[
+Currently crashes MAME with no expansion ROM attached
+pc6001: Heavy [VDG] issues (regression? works in pc6001mk2)
+Gameplay is too fast
+]]></notes>
+		<info name="usage" value="Mode 2, Page 2, has optional support for Mode 4" />
+		<info name="alt_title" value="タイニーゼビウス2"/>
+		<info name="developer" value="T. Matsushima"/>
+		<!-- <sharedfeat name="requirement" value="pc6001_cart:n60basic"/> -->
+
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="41774">
+				<rom name="tiny xevious 2.cas" size="41774" crc="966c3a54" sha1="b69d633c7fa4b81c6b3113c2118ce1ffc83f050c"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/pc6001_cass.xml
+++ b/hash/pc6001_cass.xml
@@ -46,9 +46,213 @@ Once in BASIC, enter CLOAD then press ENTER, then RUN then ENTER once loading co
 		</part>
 	</software>
 
+	<!-- All AX entries release dates and order from tape printouts -->
+	<!-- Side B should be identical from side A -->
+
+	<software name="ax1" supported="partial">
+		<description>AX-1</description>
+		<year>1982</year>
+		<publisher>ASCII</publisher>
+		<notes><![CDATA[
+Arabian Rhapsody: pc6001mk2 draws without border colors (verify)
+]]></notes>
+		<info name="usage" value="Mode 1, Page 2 for all but Demo (Mode 1, Page 1)"/>
+
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Demonstration"/>
+			<dataarea name="snap" size="13510">
+				<rom name="ax-1 (demo) {m1p1}.cas" size="13510" crc="5a7a7321" sha1="1086d76df3e03427b0181e704186f827828ab011" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Arabian Rhapsody"/>
+			<dataarea name="snap" size="6301">
+				<rom name="ax-1 (arabian rhapsody).cas" size="6301" crc="e650de95" sha1="7bdb3586335c349230fd62a44806bb201a49c119" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="Break Out L"/>
+			<dataarea name="snap" size="4837">
+				<rom name="ax-1 (break out) {m1p2}.cas" size="4837" crc="b0bad3d9" sha1="01b2da04a6d8c5766dcd765994d142bd18dcce73" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="High Speed Barricade"/>
+			<dataarea name="snap" size="4167">
+				<rom name="ax-1 (barricade) {m1p2}.cas" size="4167" crc="a991614f" sha1="a87cac3e53fcdbf1c78ff90097b54e19b06b0512" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap5" interface="pc6001_snap">
+			<feature name="part_id" value="Simon"/>
+			<dataarea name="snap" size="4526">
+				<rom name="ax-1 (simon) {m1p2}.cas" size="4526" crc="4241fc84" sha1="91684c965e7dfd2ebf81746dce45cdc1cb7cf561" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ax2" supported="no">
+		<description>AX-2</description>
+		<year>1982</year>
+		<publisher>ASCII</publisher>
+		<notes><![CDATA[
+Nostromo, Dual Alien: MAME crash with pc6001
+Steal Alien: returns back to BASIC in pc6001
+]]></notes>
+		<info name="usage" value="Mode 1, Page 1 for Demonstration, Nostromo and Steal Alien. Mode 1, Page 2 for Dual Alien and In the Woods"/>
+
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Demonstration"/>
+			<dataarea name="snap" size="13510">
+				<rom name="ax-2 (demo).cas" size="13510" crc="6ec7beb5" sha1="1fe5b673aa916778fbd865b72fe95bc58582f832" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Nostromo"/>
+			<dataarea name="snap" size="8843">
+				<rom name="ax-2 (nostromo).cas" size="8843" crc="917001da" sha1="1728f1aafccb7e97141ffc143cb23004105bd421" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="Steal Alien"/>
+			<dataarea name="snap" size="6378">
+				<rom name="ax-2 (steal alien).cas" size="6378" crc="0c3903fe" sha1="a1f7cfbb805f1d176395e4509180d959830ce3fa" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="In the Woods"/>
+			<dataarea name="snap" size="3611">
+				<rom name="ax-2 (in the woods).cas" size="3611" crc="b4e6d9c3" sha1="7c813d25edd6ae3a2a3999414f3dc3623d9e8523" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap5" interface="pc6001_snap">
+			<feature name="part_id" value="Dual Alien"/>
+			<dataarea name="snap" size="6414">
+				<rom name="ax-2 (dual alien).cas" size="6414" crc="8a1557ab" sha1="dfbeab5d3f781b62d8be4e1d7b8a7774569001c3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ax3" supported="no">
+		<description>AX-3</description>
+		<year>1982</year>
+		<publisher>ASCII</publisher>
+		<notes><![CDATA[
+All games but Demo: punts back to How Many Pages in pc6001 (and crashes MAME with ram 64K)
+Cosmic Revo: invisible charset in pc6001
+]]></notes>
+		<info name="usage" value="Mode 1, Page 1 for Demo, Cosmic Revo, Micro Othello and Slot Poker. Mode 1, Page 2 for Inter-Fight"/>
+
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Demonstration"/>
+			<dataarea name="snap" size="13510">
+				<rom name="ax-3 (demo).cas" size="13510" crc="2b1cc972" sha1="b3c7b28f63bba39ced7274d409f394032a4e810d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Micro Othello"/>
+			<dataarea name="snap" size="9085">
+				<rom name="ax-3 (micro othello).cas" size="9085" crc="577acfd4" sha1="b6b4a3136fbd033d90121302213518c886799c75" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="Inter-Fight"/>
+			<dataarea name="snap" size="5950">
+				<rom name="ax-3 (inter-fight).cas" size="5950" crc="342f9e2a" sha1="649fe00137eb057232485998ddbb196689a2190d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="Cosmic Revo"/>
+			<dataarea name="snap" size="3426">
+				<rom name="ax-3 (cosmic revo).cas" size="3426" crc="c7f58d20" sha1="887296d1e41ea5a32587c92c345e07d10b9816a0" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap5" interface="pc6001_snap">
+			<feature name="part_id" value="Slot Poker"/>
+			<dataarea name="snap" size="5429">
+				<rom name="ax-3 (slot poker).cas" size="5429" crc="e4cdd54a" sha1="dabdc23c6b85efb8a693ef800b56f18a52de21a0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ax4" supported="no">
+		<description>AX-4</description>
+		<year>1982</year>
+		<publisher>ASCII</publisher>
+		<notes><![CDATA[
+Black Hole: non-functional [keyboard] and [joystick] inputs in pc6001
+]]></notes>
+		<info name="usage" value="Mode 1, Page 1 for Demo, American Football, Black Hole and Shut the Box. Mode 1, Page 2 for Car Race"/>
+
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Demonstration"/>
+			<dataarea name="snap" size="13510">
+				<rom name="ax-4 (demo).cas" size="13510" crc="7bd36d87" sha1="596d339f76a1ea14fc6e79cf9c4e539dbaf9b11d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Black Hole"/>
+			<dataarea name="snap" size="6084">
+				<rom name="ax-4 (black hole).cas" size="6084" crc="81936ff9" sha1="05a22e03f53142905fae6b615f69d20a88c3420e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="Car Race"/>
+			<dataarea name="snap" size="5717">
+				<rom name="ax-4 (car race).cas" size="5717" crc="a101aa0b" sha1="261cb2567546e800b3af4e3fa4bd0226198d29fd" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="American Football"/>
+			<dataarea name="snap" size="6840">
+				<rom name="ax-4 (american football).cas" size="6840" crc="fcba84bb" sha1="9dfd29f4026f28fbada54bec16d49615697d679c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap5" interface="pc6001_snap">
+			<feature name="part_id" value="Shut the Box"/>
+			<dataarea name="snap" size="5863">
+				<rom name="ax-4 (shut the box).cas" size="5863" crc="2f137847" sha1="9996049a4f7f0820cd754ae2a743dbed85996273" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ax5" supported="no">
+		<description>AX-5</description>
+		<year>1982</year>
+		<publisher>ASCII</publisher>
+		<notes><![CDATA[
+Olion: crashes MAME when pressing 'S' key in pc6001
+]]></notes>
+		<info name="usage" value="Mode 2, Page 2 for Olion. Mode 2, Page 1 for Quest"/>
+
+		<!-- Mode refers to the *GFX* mode -->
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Olion (Mode 4)"/>
+			<dataarea name="snap" size="16417">
+				<rom name="ax-5 (olion 4) {m2p2}.cas" size="16417" crc="acd6e7b6" sha1="b869eecc191e21441ccfca38c5c1049248fe3af4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Quest (Mode 4)"/>
+			<dataarea name="snap" size="29730">
+				<rom name="ax-5 (quest 4) {m2p1}.cas" size="29730" crc="2b735197" sha1="2837386bd00b9b7a9c342f53fdacdbea514a2d0f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="Olion (Mode 3)"/>
+			<dataarea name="snap" size="16923">
+				<rom name="ax-5 (olion 3).cas" size="16923" crc="35cb7301" sha1="2c0328a65e6825ba30ce28354bbd938d6629d53b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="Quest (Mode 3)"/>
+			<dataarea name="snap" size="29730">
+				<rom name="ax-5 (quest 3) {m2p1}.cas" size="29730" crc="45d891e4" sha1="46a8a7ee404751c1466a1519aa19b60dcb203f56" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="ax6" supported="no">
 		<description>AX-6</description>
-		<!-- Year from tape printout -->
 		<year>1982</year>
 		<publisher>ASCII</publisher>
 		<notes><![CDATA[
@@ -56,7 +260,7 @@ Demo: [timing] should corrupt video when AY-based speech plays back (cfr. real H
 Space Enemy, Head-On: [timing] runs too fast
 ]]></notes>
 		<info name="usage" value="Mode 1, Page 1 for all but for Powered Knight (Mode 2, Page 1)"/>
-		<!-- All from Side A -->
+
 		<part name="snap1" interface="pc6001_snap">
 			<feature name="part_id" value="Demonstration"/>
 			<dataarea name="snap" size="11407">
@@ -89,9 +293,51 @@ Space Enemy, Head-On: [timing] runs too fast
 		</part>
 	</software>
 
+	<software name="ax7" supported="no">
+		<description>AX-7</description>
+		<year>1983</year>
+		<publisher>ASCII</publisher>
+		<notes><![CDATA[
+Demonstration: [timing] may be running too fast
+Police and Gang: [timing] runs too fast
+The Asterodian: [VDG] glitch for ASCII text in title (verify)
+]]></notes>
+		<info name="usage" value="Mode 1, Page 1 for all programs. The Asterodian uses joystick in port 2"/>
+
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Demonstration"/>
+			<dataarea name="snap" size="12017">
+				<rom name="ax-7 (demo).cas" size="12017" crc="8f8bec1b" sha1="e27570d787ca206a1972cc574a49314d37207ae3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Police &amp; Gang"/>
+			<dataarea name="snap" size="6163">
+				<rom name="ax-7 (police &amp; gang).cas" size="6163" crc="6beb7e0f" sha1="284a11789e69e2ca2c78d58f781a16412eb753b3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="The Asterodian"/>
+			<dataarea name="snap" size="5477">
+				<rom name="ax-7 (the asterodian).cas" size="5477" crc="8a6ba775" sha1="4dc310922c6c20daa79f324bd2f6a1334e09d886" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="Galaxy Fight"/>
+			<dataarea name="snap" size="6801">
+				<rom name="ax-7 (galaxy fight).cas" size="6801" crc="2fbfa59f" sha1="563db18352ccc6fc9b8c2cd1e26ae2045799b972" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap5" interface="pc6001_snap">
+			<feature name="part_id" value="God Hurricane"/>
+			<dataarea name="snap" size="6944">
+				<rom name="ax-7 (god hurricane).cas" size="6944" crc="acac3902" sha1="c66bfaf5956d5ca5fb69403de7fdfe321009e79a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="ax8" supported="no">
 		<description>AX-8</description>
-		<!-- Year from tape printout -->
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<notes><![CDATA[
@@ -99,7 +345,7 @@ Cannot start a game, requires [keyboard] stop key
 ]]></notes>
 		<info name="usage" value="Mode 2, Page 1"/>
 		<info name="alt_title" value="ギャラクシーミッション"/>
-		<!-- both from side A -->
+
 		<part name="snap1" interface="pc6001_snap">
 			<feature name="part_id" value="Part 1"/>
 			<dataarea name="snap" size="23444">
@@ -114,14 +360,73 @@ Cannot start a game, requires [keyboard] stop key
 		</part>
 	</software>
 
-	<software name="block" supported="partial">
-		<description>Block</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
-		<info name="usage" value="Mode 1, Page 2" />
-		<part name="snap" interface="pc6001_snap">
-			<dataarea name="snap" size="4837">
-				<rom name="block.cas" size="4837" crc="b0bad3d9" sha1="01b2da04a6d8c5766dcd765994d142bd18dcce73"/>
+	<software name="ax9" supported="no">
+		<description>AX-9</description>
+		<year>1984</year>
+		<publisher>ASCII</publisher>
+		<notes><![CDATA[
+3D Flight Simulator: non-functional [keyboard] in gameplay
+Blue Sky: [VDG] ground cursor leaves trails when moved
+]]></notes>
+		<info name="usage" value="Mode 2, Page 1 for 3D Flight Simulator, Bounder Robo and Demonstration. Mode 2, Page 2 for Blue Sky"/>
+
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Demonstration"/>
+			<dataarea name="snap" size="23001">
+				<rom name="ax-9 (demo).cas" size="23001" crc="116056a3" sha1="d66d0c9fa5fab3b5372057e933d012d1b13e6eed" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="3D Flight Simulator"/>
+			<dataarea name="snap" size="10818">
+				<rom name="ax-9 (3d flight simulator).cas" size="10818" crc="102c36fe" sha1="02e6f5889d9a90c12cd4f5c18a029d07ea4f075e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="Blue Sky"/>
+			<dataarea name="snap" size="13609">
+				<rom name="ax-9 (blue sky).cas" size="13609" crc="afc8448f" sha1="a1a86fcdb9d166b4598f9fa7b613240a396a0649" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="Bounder Robo"/>
+			<dataarea name="snap" size="22441">
+				<rom name="ax-9 (bounder robo).cas" size="22441" crc="ac0bb163" sha1="bb86e25ef84fcdaadad3a48c7409cf4d678d39eb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ax10" supported="partial">
+		<description>AX-10</description>
+		<year>1985</year>
+		<publisher>ASCII</publisher>
+		<notes><![CDATA[
+Outlaw: [timing] runs too fast
+]]></notes>
+		<info name="usage" value="Mode 2, Page 1 for Outlaw and The Seven Bibles, Mode 2, Page 2 for Pop Hand and Risuning"/>
+
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Outlaw"/>
+			<dataarea name="snap" size="27138">
+				<rom name="ax-10 (outlaw).cas" size="27138" crc="a43a5369" sha1="29e11c2bb5b04b3fc1028cbb042e24e0ee7c611c" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="The Seven Bibles"/>
+			<dataarea name="snap" size="15107">
+				<rom name="ax-10 (the seven bibles).cas" size="15107" crc="2a155bac" sha1="9c3df6d1890a5b287d3691f1fc1c4dca0c58cfc6" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="Pop Hand"/>
+			<dataarea name="snap" size="17696">
+				<rom name="ax-10 (pop hand).cas" size="17696" crc="fa49df9b" sha1="25d7c570f21aeee2745c74cdb0b0388e941690a5" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="Risuning"/>
+			<dataarea name="snap" size="23387">
+				<rom name="ax-10 (risuning).cas" size="23387" crc="e5194e79" sha1="b55f98de74291cb59b4b98a1fd6b22096a9aa376" offset="0" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/pc6001mk2_cass.xml
+++ b/hash/pc6001mk2_cass.xml
@@ -10,6 +10,7 @@ Mode 2: N60 BASIC (32K)
 Mode 3: N60 EXTENDED BASIC (16K)
 Mode 4: N60 EXTENDED BASIC (32K)
 Mode 5: N60m BASIC (64K)
+Mode 6: N66SR BASIC (pc6001mk2sr/pc6601sr, separate SW list)
 
 This software list should ONLY be used for Mk II specific software which will require mode 5.
 Any software requiring modes 1-4 should be listed in the pc6001_cass.xml software list.
@@ -27,6 +28,38 @@ If usage specifies MONITOR:
 
 -->
 <softwarelist name="pc6001mk2_cass" description="NEC PC-6001mkII cassette snapshots">
+
+	<software name="3dgolfsv" supported="no">
+		<description>3D Golf Simulation: Super Version</description>
+		<year>1984?</year>
+		<publisher>T&amp;E Soft</publisher>
+		<notes><![CDATA[
+Requires [keyboard] key repeat
+]]></notes>
+		<info name="usage" value="Mode 5, Page 3, BASIC"/>
+		<info name="alt_title" value="3Dゴルフシミュレーションスーパーバージョン"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="51682">
+				<rom name="3d golf simulation super version.cas" size="51682" crc="e3e0e241" sha1="2b58d5405a96fdd393e42cad288601f4b3495007" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="amtruck" supported="no">
+		<description>American Truck</description>
+		<year>1985?</year>
+		<publisher>Telenet Japan</publisher>
+		<notes><![CDATA[
+Runs too fast
+]]></notes>
+		<info name="usage" value="Mode 5, Page 4, MONITOR"/>
+		<info name="alt_title" value="アメリカントラック"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="43303">
+				<rom name="american truck.cas" size="43303" crc="8b50ad46" sha1="aec8ba495b058f775b5f7bb418d430bd4ad7e0da" offset="0" />
+			</dataarea>
+		</part>
+	</software>
 
 	<software name="bokosuka" supported="partial">
 		<description>Bokosuka Wars</description>
@@ -200,6 +233,23 @@ If usage specifies MONITOR:
 		</part>
 	</software>
 
+	<software name="pacman" supported="no">
+		<description>Pac-Man</description>
+		<year>198?</year>
+		<publisher>Dempa</publisher>
+		<notes><![CDATA[
+Runs too fast
+]]></notes>
+		<info name="usage" value="Mode 5, Page 2, MONITOR R-0 then GDD74"/>
+		<info name="developer" value="H. Yomoda"/>
+		<info name="alt_title" value="パックマン"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="57671">
+				<rom name="pac-man.cas" size="57671" crc="8bdb45fa" sha1="0eb2130b65116a923a386c2d5066d40868db9536" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="pascom" supported="partial">
 		<description>Pascom Tower</description>
 		<year>1984</year>
@@ -226,8 +276,8 @@ If usage specifies MONITOR:
 		</part>
 	</software>
 
-	<software name="pbmario" supported="partial">
-		<description>Punchball Mario</description>
+	<software name="punchbal" supported="partial">
+		<description>Punch Ball Mario Bros.</description>
 		<year>1983</year>
 		<publisher>Nintendo / Hudson Soft</publisher>
 		<info name="usage" value="Mode 5, Page 4, MONITOR" />
@@ -239,7 +289,23 @@ If usage specifies MONITOR:
 		</part>
 	</software>
 
-	<software name="thunder" supported="partial">
+	<software name="tomathim" supported="no">
+		<description>Salad no Kuni no Tomato-hime</description>
+		<year>1984</year>
+		<publisher>Hudson Soft</publisher>
+		<notes><![CDATA[
+May require [keyboard] kana lock to work properly
+]]></notes>
+		<info name="usage" value="Mode 5, Page 3, MONITOR"/>
+		<info name="alt_title" value="サラダの国のトマト姫"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="42062">
+				<rom name="salad no kuni no tomato-hime.cas" size="42062" crc="65329b4d" sha1="30488c62f3b1ebaf0c5ecb81b52e9ef721b001c8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tforce" supported="partial">
 		<description>Thunder Force</description>
 		<year>1985</year>
 		<publisher>Techno Soft</publisher>
@@ -261,6 +327,19 @@ If usage specifies MONITOR:
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="11027">
 				<rom name="vegetable crash.cas" size="11027" crc="7a0569d1" sha1="932d219a2eae516d57575511a0bdb2a96bd8fa6d"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="yakyukyo" supported="partial">
+		<description>Yakyuu Kyou</description>
+		<year>1984</year>
+		<publisher>Hudson Soft</publisher>
+		<info name="usage" value="Mode 5, Page 4, MONITOR" />
+		<info name="alt_title" value="野球狂" />
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="41941">
+				<rom name="yakyuukyou.cas" size="41941" crc="566b0e1c" sha1="bbbb5bfd6ccefb2f01682842c68d528f76f7b8f7" offset="0" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/pc6001mk2_cass.xml
+++ b/hash/pc6001mk2_cass.xml
@@ -61,6 +61,23 @@ Runs too fast
 		</part>
 	</software>
 
+	<software name="attack" supported="no">
+		<description>Attack!! Hiroko-chan</description>
+		<year>198?</year>
+		<publisher>Champion Soft</publisher>
+		<notes><![CDATA[
+Not extensively tested (language barrier)
+]]></notes>
+		<info name="usage" value="Mode 5, Page 3, BASIC"/>
+		<info name="developer" value="M. Biccs"/>
+		<info name="alt_title" value="アタック!! ひろ子ちゃん"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="23440">
+				<rom name="attack hiroko chan.cas" size="23440" crc="076760d3" sha1="e8a7c8ecfac69e597ddd9cb68b0dd94cc93cffe0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="bokosuka" supported="partial">
 		<description>Bokosuka Wars</description>
 		<year>1985</year>
@@ -92,13 +109,14 @@ Runs too fast
 		<year>1986?</year>
 		<publisher>ASCII</publisher>
 		<notes><![CDATA[
-[gfx] wrong scan draw for title screen copyright text
+[gfx] wrong scan draw for title screen copyright text, bad dump?
 ]]></notes>
 		<info name="usage" value="Mode 5, Page 2, BASIC" />
 		<info name="alt_title" value="キャッスルエクセレント"/>
+		<!-- baddump: Neo Kobe set originally had a "[b]" flag -->
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="32980">
-				<rom name="castle excellent.cas" size="32980" crc="dc356757" sha1="2d33d6d3274370aae8052dee29bac993c369b4e5"/>
+				<rom name="castle excellent.cas" size="32980" crc="dc356757" sha1="2d33d6d3274370aae8052dee29bac993c369b4e5" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -143,6 +161,48 @@ Runs too fast
 		</part>
 	</software>
 
+	<software name="dezeni" supported="no">
+		<description>Dezeni Land</description>
+		<year>198?</year>
+		<publisher>Hudson Soft</publisher>
+		<notes><![CDATA[
+Unsupported [tape] saving, other chapters requires an user tape
+Requires better [keyboard] handling
+]]></notes>
+		<info name="usage" value="Mode 5, Page 4, MONITOR. Choose N at startup to start a new game"/>
+		<info name="alt_title" value="デゼニランド"/>
+        <part name="snap1" interface="pc6001_snap">
+            <feature name="part_id" value="Chapter 1"/>
+            <dataarea name="snap" size="39484">
+                <rom name="dezeni land (chapter 1).cas" size="39484" crc="d50d079c" sha1="a2f66fbb79c07602fc8564d3a28aea168052ddff" offset="0" />
+            </dataarea>
+        </part>
+        <part name="snap2" interface="pc6001_snap">
+            <feature name="part_id" value="Chapter 2"/>
+            <dataarea name="snap" size="25092">
+                <rom name="dezeni land (chapter 2).cas" size="25092" crc="c21bd420" sha1="dcd3f2730b03a2122058627149a5ab3f18dc6c53" offset="0" />
+            </dataarea>
+        </part>
+        <part name="snap3" interface="pc6001_snap">
+            <feature name="part_id" value="Chapter 3"/>
+            <dataarea name="snap" size="26102">
+                <rom name="dezeni land (chapter 3).cas" size="26102" crc="0a49d031" sha1="7f9aa1f8bc70ded09a977bccb982bfb3f6332602" offset="0" />
+            </dataarea>
+        </part>
+        <part name="snap4" interface="pc6001_snap">
+            <feature name="part_id" value="Chapter 4"/>
+            <dataarea name="snap" size="18572">
+                <rom name="dezeni land (chapter 4).cas" size="18572" crc="5964f330" sha1="a0f0f81f19fabc5929e2cdada72f15a874dc18a4" offset="0" />
+            </dataarea>
+        </part>
+        <part name="snap5" interface="pc6001_snap">
+            <feature name="part_id" value="Chapter 5"/>
+            <dataarea name="snap" size="27901">
+                <rom name="dezeni land (chapter 5).cas" size="27901" crc="925026a3" sha1="85d7b831ea98be5c10ac192b427cc130022fee1d" offset="0" />
+            </dataarea>
+        </part>
+	</software>
+
 	<software name="digdug" supported="partial">
 		<description>Dig Dug</description>
 		<year>19??</year>
@@ -156,19 +216,6 @@ Runs too fast
 		</part>
 	</software>
 
-	<software name="dsbubble" supported="partial">
-		<description>Dr. Slump Bubble Daisakusen</description>
-		<year>1984</year>
-		<publisher>Enix</publisher>
-		<info name="usage" value="Mode 5, Page 3, MONITOR" />
-		<info name="alt_title" value="スランプ バブル大作戦"/>
-		<part name="snap" interface="pc6001_snap">
-			<dataarea name="snap" size="28455">
-				<rom name="dr slump bubble daisakusen.cas" size="28455" crc="10529edc" sha1="9fadb778ef869a147956e3d8004cc84574e34bd6"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="doordoor" supported="partial">
 		<description>Door Door Mk. II</description>
 		<year>1984</year>
@@ -178,6 +225,19 @@ Runs too fast
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="71593">
 				<rom name="door door.p6" size="71593" crc="567f4190" sha1="4c82a9e4b939962a1fc703a5611f59b3f18118bb"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dsbubble" supported="partial">
+		<description>Dr. Slump Bubble Daisakusen</description>
+		<year>1984</year>
+		<publisher>Enix</publisher>
+		<info name="usage" value="Mode 5, Page 3, MONITOR" />
+		<info name="alt_title" value="スランプ バブル大作戦"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="28455">
+				<rom name="dr slump bubble daisakusen.cas" size="28455" crc="10529edc" sha1="9fadb778ef869a147956e3d8004cc84574e34bd6"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/pc6001mk2_cass.xml
+++ b/hash/pc6001mk2_cass.xml
@@ -10,7 +10,7 @@ Mode 2: N60 BASIC (32K)
 Mode 3: N60 EXTENDED BASIC (16K)
 Mode 4: N60 EXTENDED BASIC (32K)
 Mode 5: N60m BASIC (64K)
-Mode 6: N66SR BASIC (pc6001mk2sr/pc6601sr, separate SW list)
+Mode 6: N66SR BASIC (pc6001mk2sr/pc6601sr, cfr. pc6001mk2sr_cass.xml)
 
 This software list should ONLY be used for Mk II specific software which will require mode 5.
 Any software requiring modes 1-4 should be listed in the pc6001_cass.xml software list.
@@ -253,6 +253,7 @@ Requires better [keyboard] handling
 		<year>1984</year>
 		<publisher>Enix</publisher>
 		<info name="usage" value="Mode 5, Page 3, MONITOR" />
+		<info name="developer" value="K. Okamoto" />
 		<info name="alt_title" value="スランプ バブル大作戦"/>
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="28455">

--- a/hash/pc6001mk2_cass.xml
+++ b/hash/pc6001mk2_cass.xml
@@ -29,6 +29,8 @@ If usage specifies MONITOR:
 -->
 <softwarelist name="pc6001mk2_cass" description="NEC PC-6001mkII cassette snapshots">
 
+<!-- !Games -->
+
 	<software name="3dgolfsv" supported="no">
 		<description>3D Golf Simulation: Super Version</description>
 		<year>1984?</year>
@@ -74,6 +76,23 @@ Not extensively tested (language barrier)
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="23440">
 				<rom name="attack hiroko chan.cas" size="23440" crc="076760d3" sha1="e8a7c8ecfac69e597ddd9cb68b0dd94cc93cffe0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="blckonyx" supported="no">
+		<description>The Black Onyx</description>
+		<year>1984?</year>
+		<!-- TODO: may just be an ASCII published game, where BPS is credited just for "original game" -->
+		<publisher>ASCII / BPS</publisher>
+		<notes><![CDATA[
+Requires user [tape] saving, prompts user after character creation
+]]></notes>
+		<info name="usage" value="Mode 5, Page 2"/>
+		<info name="alt_title" value="ブラックオニキス" />
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="45426">
+				<rom name="the black onyx.cas" size="45426" crc="661407f3" sha1="68f52272bddc4f74ffd565397fc2b86b19e2aa98" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -171,36 +190,36 @@ Requires better [keyboard] handling
 ]]></notes>
 		<info name="usage" value="Mode 5, Page 4, MONITOR. Choose N at startup to start a new game"/>
 		<info name="alt_title" value="デゼニランド"/>
-        <part name="snap1" interface="pc6001_snap">
-            <feature name="part_id" value="Chapter 1"/>
-            <dataarea name="snap" size="39484">
-                <rom name="dezeni land (chapter 1).cas" size="39484" crc="d50d079c" sha1="a2f66fbb79c07602fc8564d3a28aea168052ddff" offset="0" />
-            </dataarea>
-        </part>
-        <part name="snap2" interface="pc6001_snap">
-            <feature name="part_id" value="Chapter 2"/>
-            <dataarea name="snap" size="25092">
-                <rom name="dezeni land (chapter 2).cas" size="25092" crc="c21bd420" sha1="dcd3f2730b03a2122058627149a5ab3f18dc6c53" offset="0" />
-            </dataarea>
-        </part>
-        <part name="snap3" interface="pc6001_snap">
-            <feature name="part_id" value="Chapter 3"/>
-            <dataarea name="snap" size="26102">
-                <rom name="dezeni land (chapter 3).cas" size="26102" crc="0a49d031" sha1="7f9aa1f8bc70ded09a977bccb982bfb3f6332602" offset="0" />
-            </dataarea>
-        </part>
-        <part name="snap4" interface="pc6001_snap">
-            <feature name="part_id" value="Chapter 4"/>
-            <dataarea name="snap" size="18572">
-                <rom name="dezeni land (chapter 4).cas" size="18572" crc="5964f330" sha1="a0f0f81f19fabc5929e2cdada72f15a874dc18a4" offset="0" />
-            </dataarea>
-        </part>
-        <part name="snap5" interface="pc6001_snap">
-            <feature name="part_id" value="Chapter 5"/>
-            <dataarea name="snap" size="27901">
-                <rom name="dezeni land (chapter 5).cas" size="27901" crc="925026a3" sha1="85d7b831ea98be5c10ac192b427cc130022fee1d" offset="0" />
-            </dataarea>
-        </part>
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Chapter 1"/>
+			<dataarea name="snap" size="39484">
+				<rom name="dezeni land (chapter 1).cas" size="39484" crc="d50d079c" sha1="a2f66fbb79c07602fc8564d3a28aea168052ddff" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Chapter 2"/>
+			<dataarea name="snap" size="25092">
+				<rom name="dezeni land (chapter 2).cas" size="25092" crc="c21bd420" sha1="dcd3f2730b03a2122058627149a5ab3f18dc6c53" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="Chapter 3"/>
+			<dataarea name="snap" size="26102">
+				<rom name="dezeni land (chapter 3).cas" size="26102" crc="0a49d031" sha1="7f9aa1f8bc70ded09a977bccb982bfb3f6332602" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="Chapter 4"/>
+			<dataarea name="snap" size="18572">
+				<rom name="dezeni land (chapter 4).cas" size="18572" crc="5964f330" sha1="a0f0f81f19fabc5929e2cdada72f15a874dc18a4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap5" interface="pc6001_snap">
+			<feature name="part_id" value="Chapter 5"/>
+			<dataarea name="snap" size="27901">
+				<rom name="dezeni land (chapter 5).cas" size="27901" crc="925026a3" sha1="85d7b831ea98be5c10ac192b427cc130022fee1d" offset="0" />
+			</dataarea>
+		</part>
 	</software>
 
 	<software name="digdug" supported="partial">
@@ -255,6 +274,23 @@ Requires better [keyboard] handling
 		</part>
 	</software>
 
+	<software name="grobda" supported="partial">
+		<description>Grobda</description>
+		<year>198?</year>
+		<publisher>Dempa</publisher>
+		<notes><![CDATA[
+[timing] According to HW refs, when "get ready" speech plays, screen should be full white but instead it's black
+]]></notes>
+		<info name="usage" value="Mode 5, Page 3, BASIC"/>
+		<info name="developer" value="T. Matsushima"/>
+		<info name="alt_title" value="グロブダー"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="42801">
+				<rom name="grobda.cas" size="42801" crc="85d9f580" sha1="86fcb03187700a1ebb00f68bfcef7eec3903c9da" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="hisya" supported="partial">
 		<description>Hisya</description>
 		<year>19??</year>
@@ -263,6 +299,57 @@ Requires better [keyboard] handling
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="30124">
 				<rom name="hisya.cas" size="30124" crc="c3d88ac6" sha1="c6a857cf88f1205b4dfff00e063739752992a7fc"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hfox" supported="no">
+		<description>Hurry Fox</description>
+		<year>1985</year>
+		<publisher>Micro Cabin</publisher>
+		<notes><![CDATA[
+Prompts for a [tape] save at startup
+]]></notes>
+		<info name="usage" value="Mode 5, Page 3, BASIC"/>
+		<info name="developer" value="Arrow Soft"/>
+		<info name="alt_title" value="はーりぃふぉっくす"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="60911">
+				<rom name="hurry fox.cas" size="60911" crc="2bd8a5c1" sha1="d619aba6783b1bb846c5277af2ac8a61af2cf39e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hfox2" supported="no">
+		<description>Hurry Fox: Yuki no Maou hen</description>
+		<year>1986</year>
+		<publisher>Micro Cabin</publisher>
+		<notes><![CDATA[
+Prompts for a [tape] save at startup
+]]></notes>
+		<info name="usage" value="Mode 5, Page 3, BASIC"/>
+		<info name="developer" value="Arrow Soft"/>
+		<info name="alt_title" value="は～りぃふぉっくす雪の魔王編" />
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="58962">
+				<rom name="hurry fox 2 - yuki no maou-hen.cas" size="58962" crc="84faa166" sha1="1fb694ec67d35e0ce0964870366663f104db7a1a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hydlide" supported="no">
+		<description>Hydlide</description>
+		<year>198?</year>
+		<publisher>T&amp;E Soft</publisher>
+		<notes><![CDATA[
+Unsupported [tape] save
+[keyboard] arrow keys doesn't work
+]]></notes>
+		<info name="usage" value="Mode 5, Page 2, BASIC. Use joystick in port 2."/>
+		<info name="alt_title" value="ハイドライド"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="44791">
+				<rom name="hydlide.cas" size="44791" crc="a2f16f83" sha1="f4b85b3d7d06e91112fe3950d9d65cd9f0f0ad3e" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -276,6 +363,25 @@ Requires better [keyboard] handling
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="28708">
 				<rom name="ice block.cas" size="28708" crc="90b5276e" sha1="422d51cf71113c29e40acf362104602728ed409c"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Original fanfun in pc8001_flop / pc8801_cass -->
+	<software name="nfanfun" supported="no">
+		<description>New Fan Fun</description>
+		<year>1984</year>
+		<publisher>Enix</publisher>
+		<notes><![CDATA[
+[keyboard] arrow keys doesn't work
+[timing] may run too fast (verify)
+]]></notes>
+		<info name="usage" value="Mode 5, Page 3, BASIC"/>
+		<info name="developer" value="Miyata"/>
+		<info name="alt_title" value="ニューファンファン"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="33114">
+				<rom name="new fan fun.cas" size="33114" crc="f210fb11" sha1="26402cd8aa8a9e4c8731028fa44c21b74218f119" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -298,7 +404,7 @@ Requires better [keyboard] handling
 		<year>198?</year>
 		<publisher>Dempa</publisher>
 		<notes><![CDATA[
-Runs too fast
+[timing] Runs too fast
 ]]></notes>
 		<info name="usage" value="Mode 5, Page 2, MONITOR R-0 then GDD74"/>
 		<info name="developer" value="H. Yomoda"/>
@@ -400,6 +506,21 @@ May require [keyboard] kana lock to work properly
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="41941">
 				<rom name="yakyuukyou.cas" size="41941" crc="566b0e1c" sha1="bbbb5bfd6ccefb2f01682842c68d528f76f7b8f7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- !Covermount -->
+
+	<software name="vitalamp" supported="partial">
+		<description>Vital Lamp</description>
+		<year>198?</year>
+		<publisher>MyCom BASIC</publisher>
+		<info name="usage" value="Mode 5, Page 2, BASIC"/>
+		<info name="developer" value="Kazuhisa Honda"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="11651">
+				<rom name="vital lamp.cas" size="11651" crc="233234b8" sha1="7e20c5c9a1cfd78c8ba152a5d417dd6976d5695d" offset="0" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/pc6001mk2_flop.xml
+++ b/hash/pc6001mk2_flop.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<!--
+Mode 5 PC-6001mkII/PC-6601 floppy disks. They autoboot at startup.
+-->
+<softwarelist name="pc6001mk2_flop" description="NEC PC-6001mkII/PC-6601 disk images">
+
+	<!-- v1.0 known to exist (same with no sound) -->
+	<software name="asalt" supported="yes">
+		<description>Asalt (v1.1, prototype)</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<notes><![CDATA[
+Looks a tech demo (time doesn't run down, has no enemies, has 1 stage)
+]]></notes>
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="153008">
+				<rom name="asalt (v1.1).d88" size="153008" crc="5649ace5" sha1="4e972be3d60979d1d6c27fb1dc83b623d8157c8b"/>
+			</dataarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/hash/pc6001mk2sr_cass.xml
+++ b/hash/pc6001mk2sr_cass.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<!--
+Mode 6 PC-6001mkIISR/PC-6601SR cassette disks. They specifically needs N66SR BASIC
+-->
+<softwarelist name="pc6001mk2sr_cass" description="NEC PC-6001mkIISR/PC-6601SR cassette snapshots">
+
+<!-- !Covermount -->
+
+	<software name="jewels" supported="no">
+		<description>Jewels</description>
+		<!-- "1987/4/12" according to LIST -->
+		<year>1987</year>
+		<publisher>MyCom BASIC</publisher>
+		<info name="usage" value="Mode 6"/>
+		<info name="developer" value="Hiroshi Hashizume"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="6258">
+				<rom name="jewels.cas" size="6258" crc="db580f1c" sha1="5c864eb364178a616a88bd5ec04145417b34d1d0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="livarmor" supported="no">
+		<description>Living Armor</description>
+		<!-- according to LIST -->
+		<year>1992</year>
+		<publisher>MyCom BASIC</publisher>
+		<notes><![CDATA[
+Doesn't boot, throws a ?SN Error at 37376 when loading part 2 (should be at 10)
+]]></notes>
+		<info name="usage" value="Mode 6"/>
+		<info name="developer" value="M-P6"/>
+
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Part 1"/>
+			<dataarea name="snap" size="4060">
+				<rom name="living armor (part 1).cas" size="4060" crc="29c329c8" sha1="194d92ffa469bc3dc9bffc1e8b5c34379c39dbdd" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Part 2"/>
+			<dataarea name="snap" size="9834">
+				<rom name="living armor (part 2).cas" size="9834" crc="dc7795ea" sha1="d159951a1b42db7ce7d609b003d46f498555cec3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pakuri" supported="no">
+		<description>Pakuridius: '88 Dragon Breath</description>
+		<!-- According to LIST -->
+		<year>1988</year>
+		<publisher>MyCom BASIC</publisher>
+		<notes><![CDATA[
+[VDG] Horizontal scrolling is non-functional (regression?)
+]]></notes>
+		<info name="usage" value="Mode 6"/>
+		<info name="developer" value="Hingo"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="6595">
+				<rom name="pakuridius.cas" size="6595" crc="d9243f9d" sha1="53543b3d88c66ae81a10106fe233ab855fc5f644" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="satan" supported="no">
+		<description>Satan</description>
+		<!-- BasicMagazine 1988.12 -->
+		<year>1988</year>
+		<publisher>MyCom BASIC</publisher>
+		<notes><![CDATA[
+Oddly scrolls horizontally during fights (verify)
+]]></notes>
+		<info name="usage" value="Mode 6"/>
+		<info name="developer" value="S.Y"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="16131">
+				<rom name="satan.cas" size="16131" crc="5e794cb2" sha1="318e84f8444522b3a52a3c369636d80e29f009d6" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/hash/pc8801_flop.xml
+++ b/hash/pc8801_flop.xml
@@ -5079,10 +5079,11 @@ ExtractDisk  [02]"ｹﾝｼﾞｬﾉﾕｲｺﾞﾝ B   " -> "Bokensha-tachi - K
 		<description>Bokosuka Wars</description>
 		<year>1984</year>
 		<publisher>アスキー (ASCII)</publisher>
-		<!-- PC8801 -->
+		<!-- PC8801mk2SR -->
 		<info name="release" value="198406xx"/>
 		<info name="alt_title" value="ボコスカウォーズ"/>
-		<info name="usage" value="Needs V2 BASIC on machines equipped with it"/>
+		<info name="usage" value="Needs BASIC V2"/>
+
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="57264">
 				<rom name="bokosuka wars.d88" size="57264" crc="410d9bb7" sha1="fa83f0e5d393c82b928180fb8cb4c2e1b3a321fb"/>
@@ -14656,14 +14657,14 @@ ExtractDisk  [02]"Gradius改       " -> "gradius kai_02.d88"
 		</part>
 	</software>
 
-	<!-- Requires OPN equipped machine (verify) -->
-	<!-- palette is ugly (parent pc8801 only, verify) -->
-	<software name="grodba" supported="partial">
+	<software name="grobda" supported="yes">
 		<description>Grobda</description>
 		<year>1986</year>
 		<publisher>電波新聞社 (Dempa Shinbunsha)</publisher>
-		<!-- PC8801 -->
+		<!-- PC8801mk2SR -->
 		<info name="alt_title" value="グロブダー"/>
+		<info name="usage" value="Needs BASIC V2"/>
+
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="348832">
 				<rom name="grodba.d88" size="348832" crc="a84c8166" sha1="98c4b6f1dc50d29877ed25797488c3544deaeab3"/>
@@ -14671,14 +14672,14 @@ ExtractDisk  [02]"Gradius改       " -> "gradius kai_02.d88"
 		</part>
 	</software>
 
-	<!-- Requires OPN equipped machine (verify) -->
-	<!-- palette is ugly (parent pc8801 only, verify) -->
-	<software name="grodbaa" cloneof="grodba" supported="partial">
+	<software name="grobdaa" cloneof="grobda" supported="yes">
 		<description>Grobda (alt)</description>
 		<year>1986</year>
 		<publisher>電波新聞社 (Dempa Shinbunsha)</publisher>
-		<!-- PC8801 -->
+		<!-- PC8801mk2SR -->
 		<info name="alt_title" value="グロブダー"/>
+		<info name="usage" value="Needs BASIC V2"/>
+
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="348560">
 				<rom name="grobda.d88" size="348560" crc="0667fbf5" sha1="d0a6c8fe16b4e9d652ffebc9a5417a330e92b7a4"/>
@@ -16437,7 +16438,7 @@ Converted to .mfm from original .hfe
 	</software>
 
 	<software name="hfox2">
-		<description>Hurry Fox - Yuki no Maou hen</description>
+		<description>Hurry Fox: Yuki no Maou hen</description>
 		<year>1986</year>
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
 		<!-- PC8801 -->

--- a/hash/pc8801_flop.xml
+++ b/hash/pc8801_flop.xml
@@ -758,7 +758,7 @@ Gameplay speed is erratic (especially noticeable on vanilla PC8801)
 	</software>
 
 	<software name="3dgolfsv">
-		<description>3D Golf Simulation - Super Version</description>
+		<description>3D Golf Simulation: Super Version</description>
 		<year>1985</year>
 		<publisher>T&amp;E Soft</publisher>
 		<!-- PC8801mk2SR -->

--- a/hash/pc8801_flop.xml
+++ b/hash/pc8801_flop.xml
@@ -3973,7 +3973,7 @@ TODO: understand how to create an user disk
 	</software>
 
 	<software name="attack">
-		<description>Attack!! Hiroko Chan</description>
+		<description>Attack!! Hiroko-chan</description>
 		<!-- 1983.9.1 -->
 		<year>1983</year>
 		<publisher>チャンピオンソフト (Champion Soft)</publisher>

--- a/hash/pc98.xml
+++ b/hash/pc98.xml
@@ -8610,12 +8610,16 @@ Errors with "Put the retail disk A into the drive", [FDC] chrn=(2, 1, -17, 512)
 		</part>
 	</software>
 
-	<!-- Black screen on boot -->
-	<software name="blckonyx">
+	<software name="blckonyx" supported="no">
 		<description>The Black Onyx</description>
 		<year>1984</year>
 		<publisher>B·P·S (Bullet-Proof Software)</publisher>
+		<notes><![CDATA[
+For pc9801f or pc9801vm
+Not extensively tested (language barrier, requires an user disk save after character creation)
+]]></notes>
 		<info name="alt_title" value="ザ・ブラックオニキス" />
+		<info name="usage" value="Needs floppy 2DD density select dip enabled. Strike CR at How Many Files, load &quot;START&quot; then run" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="688304">
 				<rom name="onyx.d88" size="688304" crc="5187be3d" sha1="9c68c5f8fb97f14a9f8f8e8f96d688dd2c8db2f8" offset="0" />

--- a/hash/saturn.xml
+++ b/hash/saturn.xml
@@ -6490,7 +6490,7 @@ Black screen, fnum reject in [CD-Block]
 	<software name="noon" supported="no">
 		<description>Noon (Japan, rev. A)</description>
 		<year>1998</year>
-		<publisher>MicroCabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<info name="serial" value="T-5206G"/>
 		<info name="release" value="19980129"/>
 		<info name="alt_title" value="ヌーン"/>
@@ -8767,7 +8767,7 @@ TODO: test Sonic 2, 3 and Knuckles
 	<software name="swordsor" supported="no">
 		<description>Sword &amp; Sorcery (Japan, 2M)</description>
 		<year>1996</year>
-		<publisher>MicroCabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<notes><![CDATA[
 Crashes after now loading screen, [CD-Block]
 ]]></notes>
@@ -17014,7 +17014,7 @@ TODO: how to reload with [mouse]?
 	<software name="gahero" supported="no">
 		<description>Eiyuu Shigan - Gal Act Heroism (Japan)</description>
 		<year>1998</year>
-		<publisher>MicroCabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<info name="serial" value="T-5204G"/>
 		<info name="release" value="19980416"/>
 		<info name="alt_title" value="英雄志願 ～Gal Act Heroism～"/>
@@ -20166,7 +20166,7 @@ Glitchy Tecnosoft logo, [SCUDSP]
 	<software name="savaki" supported="no">
 		<description>Savaki (Japan)</description>
 		<year>1998</year>
-		<publisher>MicroCabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<info name="serial" value="T-5208G"/>
 		<info name="release" value="19980416"/>
 		<info name="alt_title" value="サバキ"/>
@@ -25283,7 +25283,7 @@ Glitchy [VDP1] sprites during gameplay
 	<software name="prinmak2" supported="no">
 		<description>Princess Maker 2 (Japan)</description>
 		<year>1995</year>
-		<publisher>MicroCabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<info name="serial" value="T-5201G"/>
 		<info name="release" value="19951027"/>
 		<info name="alt_title" value="プリンセスメーカー2"/>
@@ -25299,7 +25299,7 @@ Glitchy [VDP1] sprites during gameplay
 	<software name="prinmak2sa" cloneof="prinmak2" supported="no">
 		<description>Princess Maker 2 (Japan, Satakore)</description>
 		<year>1997</year>
-		<publisher>MicroCabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<info name="serial" value="T-5203G"/>
 		<info name="release" value="19970620"/>
 		<info name="alt_title" value="プリンセスメーカー2 (サタコレ)"/>
@@ -26375,7 +26375,7 @@ Not extensively tested
 	<software name="swordsora" cloneof="swordsor" supported="no">
 		<description>Sword &amp; Sorcery (Japan)</description>
 		<year>1996</year>
-		<publisher>MicroCabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<info name="serial" value="T-5202G"/>
 		<info name="release" value="19960531"/>
 		<info name="alt_title" value="ソード&amp;ソーサリー"/>
@@ -26391,7 +26391,7 @@ Not extensively tested
 	<software name="swordsorsa" cloneof="swordsor" supported="no">
 		<description>Sword &amp; Sorcery (Japan, Satakore)</description>
 		<year>1997</year>
-		<publisher>MicroCabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<info name="serial" value="T-5207G"/>
 		<info name="release" value="19971211"/>
 		<info name="alt_title" value="ソード&amp;ソーサリー (サタコレ)"/>
@@ -28839,7 +28839,7 @@ Not extensively tested
 	<software name="gaheroa" cloneof="gahero" supported="no">
 		<description>Eiyuu Shigan - Gal Act Heroism (Japan, alt)</description>
 		<year>1998</year>
-		<publisher>MicroCabin</publisher>
+		<publisher>Micro Cabin</publisher>
 		<info name="serial" value="T-5204G"/>
 		<info name="release" value="19980416"/>
 		<info name="alt_title" value="英雄志願 ～Gal Act Heroism～"/>

--- a/hash/x1_cass.xml
+++ b/hash/x1_cass.xml
@@ -883,6 +883,7 @@ Titles, publishers and release dates taken from:
 		<description>Dezeni Land</description>
 		<year>1983?</year>
 		<publisher>ハドソン (Hudson Soft)</publisher>
+		<info name="alt_title" value="デゼニランド"/>
 		<part name="cass" interface="x1_cass">
 			<dataarea name="side1" size="3476462">
 				<rom name="dezeni land.tap" size="3476462" crc="b7554d55" sha1="5de4c54890e60473338524036ff82346e9b91dba"/>

--- a/hash/x1_flop.xml
+++ b/hash/x1_flop.xml
@@ -1124,7 +1124,7 @@ Garbage GFXs on [6845] rightmost column during intro
 	</software>
 
 	<software name="hfox2">
-		<description>Hurry Fox - Yuki no Maou hen</description>
+		<description>Hurry Fox: Yuki no Maou hen</description>
 		<year>1986</year>
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
 		<info name="release" value="198610xx"/>

--- a/src/mame/nec/pc6001.cpp
+++ b/src/mame/nec/pc6001.cpp
@@ -37,69 +37,58 @@ TODO (pc6601mk2sr):
 - pc6001mk2sr/pc6601sr: currently doesn't work without -debug enabled (?), has serious keyboard
   issues.
 
-TODO (game specific, move in SW lists):
-- (several AX* games, namely Galaxy Mission Part 1/2 and others): inputs doesn't work;
-(Mk2 mode 5 games)
-- Hurry Fox 1/2: asks you to "load something", can't do it
-   with current cassette kludge;
-- (MyCom BASIC games with multiple files): most of them refuses to run ... how to load them?
-- Grobda: when "get ready" speech plays, screen should be full white but instead it's all
-   black, same issue as AX-6 Demo?
-- The Black Onyx: dies when it attempts to save the character, that obviously means saving
-   on the tape;
-
 ===================================================================================================
 
-    PC-6001 (1981-09):
+PC-6001 (1981-09):
 
-     * CPU: Z80A @ 4 MHz
-     * ROM: 16KB + 4KB (chargen) - no kanji
-     * RAM: 16KB, it can be expanded to 32KB
-     * Text Mode: 32x16 and 2 colors
-     * Graphic Modes: 64x48 (9 colors), 128x192 (4 colors), 256x192 (2 colors)
-     * Sound: BEEP + PSG - Optional Voice Synth Cart
-     * Keyboard: JIS Keyboard with 5 function keys, control key, TAB key,
-            HOME/CLR key, INS key, DEL key, GRAPH key, Japanese syllabary
-            key, page key, STOP key, and cursor key (4 directions)
-     * 1 cartslot, optional floppy drive, optional serial 232 port, 2
-            joystick ports
-
-
-    PC-6001 mkII (1983-07):
-
-     * CPU: Z80A @ 4 MHz
-     * ROM: 32KB + 16KB (chargen) + 32KB (kanji) + 16KB (Voice Synth)
-     * RAM: 64KB
-     * Text Mode: same as PC-6001 with N60-BASIC; 40x20 and 15 colors with
-            N60M-BASIC
-     * Graphic Modes: same as PC-6001 with N60-BASIC; 80x40 (15 colors),
-            160x200 (15 colors), 320x200 (4 colors) with N60M-BASIC
-     * Sound: BEEP + PSG
-     * Keyboard: JIS Keyboard with 5 function keys, control key, TAB key,
-            HOME/CLR key, INS key, DEL key, CAPS key, GRAPH key, Japanese
-            syllabary key, page key, mode key, STOP key, and cursor key (4
-            directions)
-     * 1 cartslot, floppy drive, optional serial 232 port, 2 joystick ports
+ * CPU: Z80A @ 4 MHz
+ * ROM: 16KB + 4KB (chargen) - no kanji
+ * RAM: 16KB, it can be expanded to 32KB
+ * Text Mode: 32x16 and 2 colors
+ * Graphic Modes: 64x48 (9 colors), 128x192 (4 colors), 256x192 (2 colors)
+ * Sound: BEEP + PSG - Optional Voice Synth Cart
+ * Keyboard: JIS Keyboard with 5 function keys, control key, TAB key,
+        HOME/CLR key, INS key, DEL key, GRAPH key, Japanese syllabary
+        key, page key, STOP key, and cursor key (4 directions)
+ * 1 cartslot, optional floppy drive, optional serial 232 port, 2
+        joystick ports
 
 
-    PC-6001 mkIISR (1984-12):
+PC-6001 mkII (1983-07):
 
-     * CPU: Z80A @ 3.58 MHz
-     * ROM: 64KB + 16KB (chargen) + 32KB (kanji) + 32KB (Voice Synth)
-     * RAM: 64KB
-     * Text Mode: same as PC-6001/PC-6001mkII with N60-BASIC; 40x20, 40x25,
-            80x20, 80x25 and 15 colors with N66SR-BASIC
-     * Graphic Modes: same as PC-6001/PC-6001mkII with N60-BASIC; 80x40 (15 colors),
-            320x200 (15 colors), 640x200 (15 colors) with N66SR-BASIC
-     * Sound: BEEP + PSG + FM
-     * Keyboard: JIS Keyboard with 5 function keys, control key, TAB key,
-            HOME/CLR key, INS key, DEL key, CAPS key, GRAPH key, Japanese
-            syllabary key, page key, mode key, STOP key, and cursor key (4
-            directions)
-     * 1 cartslot, floppy drive, optional serial 232 port, 2 joystick ports
+ * CPU: Z80A @ 4 MHz
+ * ROM: 32KB + 16KB (chargen) + 32KB (kanji) + 16KB (Voice Synth)
+ * RAM: 64KB
+ * Text Mode: same as PC-6001 with N60-BASIC; 40x20 and 15 colors with
+        N60M-BASIC
+ * Graphic Modes: same as PC-6001 with N60-BASIC; 80x40 (15 colors),
+        160x200 (15 colors), 320x200 (4 colors) with N60M-BASIC
+ * Sound: BEEP + PSG
+ * Keyboard: JIS Keyboard with 5 function keys, control key, TAB key,
+        HOME/CLR key, INS key, DEL key, CAPS key, GRAPH key, Japanese
+        syllabary key, page key, mode key, STOP key, and cursor key (4
+        directions)
+ * 1 cartslot, floppy drive, optional serial 232 port, 2 joystick ports
 
 
-    info from http://www.geocities.jp/retro_zzz/machines/nec/6001/spc60.html
+PC-6001 mkIISR (1984-12):
+
+ * CPU: Z80A @ 3.58 MHz
+ * ROM: 64KB + 16KB (chargen) + 32KB (kanji) + 32KB (Voice Synth)
+ * RAM: 64KB
+ * Text Mode: same as PC-6001/PC-6001mkII with N60-BASIC; 40x20, 40x25,
+        80x20, 80x25 and 15 colors with N66SR-BASIC
+ * Graphic Modes: same as PC-6001/PC-6001mkII with N60-BASIC; 80x40 (15 colors),
+        320x200 (15 colors), 640x200 (15 colors) with N66SR-BASIC
+ * Sound: BEEP + PSG + FM
+ * Keyboard: JIS Keyboard with 5 function keys, control key, TAB key,
+        HOME/CLR key, INS key, DEL key, CAPS key, GRAPH key, Japanese
+        syllabary key, page key, mode key, STOP key, and cursor key (4
+        directions)
+ * 1 cartslot, floppy drive, optional serial 232 port, 2 joystick ports
+
+
+ info from http://www.geocities.jp/retro_zzz/machines/nec/6001/spc60.html
 
 ===================================================================================================
 

--- a/src/mame/nec/pc6001.cpp
+++ b/src/mame/nec/pc6001.cpp
@@ -29,13 +29,14 @@ TODO (pc6601):
 - current regression caused by an internal FDC sense interrupt status that expects a
   DIO high that never occurs;
 - mon r-0 type games doesn't seem to work at all on this system?
+  Update: tries to autoload cassette at startup for some reason.
 
 TODO (pc6601mk2sr):
 - Implement MK-2 compatibility mode via view handler(s)
   (it changes the memory map to behave like the older versions);
 - Video Telopper (superimposer) & TV tuner functions for later machines;
 - pc6001mk2sr/pc6601sr: currently doesn't work without -debug enabled (?), has serious keyboard
-  issues.
+  issues, BASIC based programs hangs at a $e6bb check (irq not fired regression? bp 102c,1,{pc+=2;g})
 
 ===================================================================================================
 
@@ -795,7 +796,7 @@ void pc6001mk2_state::pc6001mk2_io(address_map &map)
 
 /*****************************************
  *
- * PC-6601 specific i/o
+ * PC-6601 specific I/O
  *
  ****************************************/
 
@@ -1780,8 +1781,8 @@ void pc6001_state::pc6001(machine_config &config)
 	TIMER(config, "keyboard_timer").configure_periodic(FUNC(pc6001_state::keyboard_callback), attotime::from_hz(250));
 	TIMER(config, "cassette_timer").configure_periodic(FUNC(pc6001_state::cassette_callback), attotime::from_hz(1200/12));
 
-	SOFTWARE_LIST(config, "cart_list_pc6001").set_original("pc6001_cart");
-	SOFTWARE_LIST(config, "cass_list_pc6001").set_original("pc6001_cass");
+	SOFTWARE_LIST(config, "cart_list").set_original("pc6001_cart");
+	SOFTWARE_LIST(config, "cass_list").set_original("pc6001_cass");
 }
 
 void pc6001mk2_state::pc6001mk2(machine_config &config)
@@ -1803,7 +1804,7 @@ void pc6001mk2_state::pc6001mk2(machine_config &config)
 
 	UPD7752(config, "upd7752", PC6001_MAIN_CLOCK / 4).add_route(ALL_OUTPUTS, "mono", 1.00);
 
-	SOFTWARE_LIST(config, "cass_list_pc6001mk2").set_original("pc6001mk2_cass");
+	SOFTWARE_LIST(config, "cass_list_mk2").set_original("pc6001mk2_cass");
 }
 
 void pc6601_state::floppy_formats(format_registration &fr)
@@ -1845,6 +1846,9 @@ void pc6601_state::pc6601(machine_config &config)
 	m_maincpu->set_irq_acknowledge_callback(FUNC(pc6601_state::irq_callback));
 
 	pc6601_fdc_config(config);
+
+	// TODO: move this option to both regular mk2 and mk2sr
+	SOFTWARE_LIST(config, "flop_list_pc6001mk2").set_original("pc6001mk2_flop");
 }
 
 void pc6001mk2sr_state::pc6001mk2sr(machine_config &config)
@@ -1877,8 +1881,11 @@ void pc6001mk2sr_state::pc6001mk2sr(machine_config &config)
 	m_ym->port_b_write_callback().set(FUNC(pc6001mk2sr_state::joystick_out_w));
 	m_ym->add_route(ALL_OUTPUTS, "mono", 1.00);
 
-	// TODO: 1D 3'5" floppy drive
 	// TODO: telopper board (system explicitly asks for missing tape dump tho)
+
+	SOFTWARE_LIST(config, "cass_list_mk2sr").set_original("pc6001mk2sr_cass");
+	// TODO: specific option for 3.5"
+//	SOFTWARE_LIST(config, "flop_list_mk2sr").set_original("pc6001mk2sr_flop");
 }
 
 void pc6601sr_state::pc6601sr(machine_config &config)
@@ -2013,9 +2020,9 @@ ROM_START( pc6601sr )
 	ROM_COPY( "sr_sysrom", 0x18000, 0x00000, 0x8000 )
 ROM_END
 
-COMP( 1981, pc6001,       0,      0,        pc6001,      pc6001, pc6001_state,       empty_init, "NEC",   "PC-6001 (Japan)",              MACHINE_NOT_WORKING )
-COMP( 1981, pc6001a,      pc6001, 0,        pc6001,      pc6001, pc6001_state,       empty_init, "NEC",   "PC-6001A \"NEC Trek\" (US)",   MACHINE_NOT_WORKING )
-COMP( 1983, pc6001mk2,    0,      0,        pc6001mk2,   pc6001, pc6001mk2_state,    empty_init, "NEC",   "PC-6001mkII (Japan)",          MACHINE_NOT_WORKING )
-COMP( 1983, pc6601,       pc6001, 0,        pc6601,      pc6001, pc6601_state,       empty_init, "NEC",   "PC-6601 (Japan)",              MACHINE_NOT_WORKING )
-COMP( 1984, pc6001mk2sr,  0,      0,        pc6001mk2sr, pc6001, pc6001mk2sr_state,  empty_init, "NEC",   "PC-6001mkIISR (Japan)",        MACHINE_NOT_WORKING )
-COMP( 1984, pc6601sr,     pc6001, 0,        pc6601sr,    pc6001, pc6601sr_state,     empty_init, "NEC",   "PC-6601SR \"Mr. PC\" (Japan)", MACHINE_NOT_WORKING )
+COMP( 1981, pc6001,       0,           0,        pc6001,      pc6001, pc6001_state,       empty_init, "NEC",   "PC-6001 (Japan)",              MACHINE_NOT_WORKING | MACHINE_IMPERFECT_TIMING )
+COMP( 1981, pc6001a,      pc6001,      0,        pc6001,      pc6001, pc6001_state,       empty_init, "NEC",   "PC-6001A \"NEC Trek\" (US)",   MACHINE_NOT_WORKING | MACHINE_IMPERFECT_TIMING )
+COMP( 1983, pc6001mk2,    0,           0,        pc6001mk2,   pc6001, pc6001mk2_state,    empty_init, "NEC",   "PC-6001mkII (Japan)",          MACHINE_NOT_WORKING | MACHINE_IMPERFECT_TIMING )
+COMP( 1983, pc6601,       pc6001mk2,   0,        pc6601,      pc6001, pc6601_state,       empty_init, "NEC",   "PC-6601 (Japan)",              MACHINE_NOT_WORKING | MACHINE_IMPERFECT_TIMING )
+COMP( 1984, pc6001mk2sr,  0,           0,        pc6001mk2sr, pc6001, pc6001mk2sr_state,  empty_init, "NEC",   "PC-6001mkIISR (Japan)",        MACHINE_NOT_WORKING | MACHINE_IMPERFECT_TIMING )
+COMP( 1984, pc6601sr,     pc6001mk2sr, 0,        pc6601sr,    pc6001, pc6601sr_state,     empty_init, "NEC",   "PC-6601SR \"Mr. PC\" (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_TIMING )

--- a/src/mame/nec/pc6001.cpp
+++ b/src/mame/nec/pc6001.cpp
@@ -39,18 +39,9 @@ TODO (pc6601mk2sr):
 
 TODO (game specific, move in SW lists):
 - (several AX* games, namely Galaxy Mission Part 1/2 and others): inputs doesn't work;
-- AX6 - Demo: When AY-based speech talks, other emus emulates the screen drawing to be
-   a solid green (plain PC-6001) or solid white (Mk2 version), but according to an
-   original video reference, that screen should actually some kind of weird garbage on it;
-- AX6 - Powered Knight: doesn't work too well, according to the asm code it asks the
-   player to press either 'B' or 'C' then a number but nothing is shown on screen,
-   other emus behaves the same, bad dump?
 (Mk2 mode 5 games)
-- Dezeni Land (ALL versions) / Hurry Fox 1/2: asks you to "load something", can't do it
-   with current cassette kludge, also, for Dezeni Land(s) keyboard irqs doesn't seem to
-   work too well with halt opcode execution?
-- Dezeni Land 1/4: dies after loading of main program;
-- Dezeni Land 2: dies at the "load something" screen with presumably wrong stack opcodes
+- Hurry Fox 1/2: asks you to "load something", can't do it
+   with current cassette kludge;
 - (MyCom BASIC games with multiple files): most of them refuses to run ... how to load them?
 - Grobda: when "get ready" speech plays, screen should be full white but instead it's all
    black, same issue as AX-6 Demo?

--- a/src/mame/nec/pc6001.cpp
+++ b/src/mame/nec/pc6001.cpp
@@ -46,8 +46,6 @@ TODO (game specific, move in SW lists):
    player to press either 'B' or 'C' then a number but nothing is shown on screen,
    other emus behaves the same, bad dump?
 (Mk2 mode 5 games)
-- 3D Golf Simulation Super Version: gameplay / inputs seems broken;
-- American Truck: Screen is offset at the loading screen, loading bug?
 - Dezeni Land (ALL versions) / Hurry Fox 1/2: asks you to "load something", can't do it
    with current cassette kludge, also, for Dezeni Land(s) keyboard irqs doesn't seem to
    work too well with halt opcode execution?
@@ -56,14 +54,8 @@ TODO (game specific, move in SW lists):
 - (MyCom BASIC games with multiple files): most of them refuses to run ... how to load them?
 - Grobda: when "get ready" speech plays, screen should be full white but instead it's all
    black, same issue as AX-6 Demo?
-- Pac-Man / Tiny Xevious 2: gameplay is too fast (unrelated with timer irq);
-- Salad no Kunino Tomato-Hime: can't start a play;
-- Space Harrier: very sensitive with sub irq triggers, keyboard joy triggers doesn't work
-  properly (select F1 after loading), draws garbage on vanilla pc6001 and eventually crashes
-  MAME;
 - The Black Onyx: dies when it attempts to save the character, that obviously means saving
    on the tape;
-- Yakyukyo / Punchball Mario: waits for an irq (fixed, wrong timer enable behaviour);
 
 ===================================================================================================
 
@@ -1832,7 +1824,6 @@ void pc6001mk2_state::pc6001mk2(machine_config &config)
 	UPD7752(config, "upd7752", PC6001_MAIN_CLOCK / 4).add_route(ALL_OUTPUTS, "mono", 1.00);
 
 	SOFTWARE_LIST(config, "cass_list_pc6001mk2").set_original("pc6001mk2_cass");
-
 }
 
 void pc6601_state::floppy_formats(format_registration &fr)


### PR DESCRIPTION
nec/pc6001.cpp: kick off pc6001mk2_flop and pc6001mk2sr_cass SW lists
hash/pc6001_cass.xml: remove "power", part of the AX-6 set as Powered Knight
hash/pc6001_cass.xml: remove "block", part of the AX-1 set as Break Out L
hash/pc6001mk2_cass.xml: mark castleex as bad dump

New working software list items
-------------------------------
pc6001_cass: AX-1, AX-10 [Neo Kobe]
pc6001mk2_cass: Grobda, Vital Lamp, Yakyuu Kyou [Neo Kobe]
pc6001mk2_flop: Asalt (v1.1) [Neo Kobe]

New software list items marked not working
------------------------------------------
pc6001_cass: AX-2, AX-3, AX-4, AX-5, AX-6, AX-7, AX-8, AX-9, Space Harrier, Tiny Xevious 2 [Neo Kobe]
pc6001mk2_cass: 3D Golf Simulation: Super Version, American Truck, Attack!! Hiroko-chan, The Black Onyx, Dezeni Land, Hurry Fox, Hurry Fox: Yuki no Maou hen, Hydlide, New Fan Fun, Pac-Man, Salad no Kuni no Tomato-hime [Neo Kobe]
pc6001mk2sr_cass: Jewels, Living Armor, Pakuridius: '88 Dragon Breath, Satan [Neo Kobe]
