### PR TITLE
Sinclair QL Microdrive working

### DIFF
--- a/src/devices/imagedev/microdrv.cpp
+++ b/src/devices/imagedev/microdrv.cpp
@@ -151,6 +151,12 @@ void microdrive_image_device::tape_from_image(const uint8_t *image)
 
 		// copy data
 		pos += MDV_PAIRS_BLOCK_GAP;
+
+		// a slot with a header but no block sync is header-only tape:
+		// keep the block region erased rather than loading dead zeros
+		if (sec[MDV_OFFSET_BLOCK_PREAMBLE + 10] != 0xff || sec[MDV_OFFSET_BLOCK_PREAMBLE + 11] != 0xff)
+			continue;
+
 		for (int i = 0; i < MDV_PAIRS_BLOCK; i++, pos++)
 		{
 			m_left[pos] = sec[MDV_OFFSET_BLOCK_PREAMBLE + 2 * i];
@@ -181,8 +187,20 @@ bool read_tape_record_header(uint8_t *image, const std::vector<uint8_t> &tape_da
 	return true;
 }
 
+void fill_image_data_record(uint8_t *image, const uint8_t *data_header, const uint8_t *data, int slot)
+{
+	uint8_t *sector = image + slot * MDV_SECTOR_LENGTH;
+	sector[MDV_OFFSET_BLOCK_PREAMBLE + 10] = 0xff;
+	sector[MDV_OFFSET_BLOCK_PREAMBLE + 11] = 0xff;
+	memcpy(sector + MDV_OFFSET_BLOCK_HEADER, data_header, 4);
+	sector[MDV_OFFSET_DATA_PREAMBLE + 6] = 0xff;
+	sector[MDV_OFFSET_DATA_PREAMBLE + 7] = 0xff;
+	memcpy(sector + MDV_OFFSET_DATA, data, 514);
+};
+
+
 bool read_tape_record_data(uint8_t *image, const std::vector<uint8_t> &tape_data,
-                           const int &slot, size_t &p)
+                           const int &slot, size_t &p, std::vector<uint8_t> &orphan)
 {
 	if (p + 4 > tape_data.size()) {
 		return false;
@@ -205,20 +223,18 @@ bool read_tape_record_data(uint8_t *image, const std::vector<uint8_t> &tape_data
 		if (d + payload_size > tape_data.size()) {
 			return true; // it seems ROM can produce header only sectors (orphans?)
 		}
-		if (slot >= 0) // if we see a data record before a header at start of tape, we skip it
+		if (slot >= 0)
 		{
-			uint8_t *sector = image + slot * MDV_SECTOR_LENGTH;
-
-			// first preamble + data header
-			sector[MDV_OFFSET_BLOCK_PREAMBLE + 10] = 0xff;
-			sector[MDV_OFFSET_BLOCK_PREAMBLE + 11] = 0xff;
-			memcpy(sector + MDV_OFFSET_BLOCK_HEADER, data_header, 4);
-
-			// inner smaller preamble, + payload
-			sector[MDV_OFFSET_DATA_PREAMBLE + 6] = 0xff;
-			sector[MDV_OFFSET_DATA_PREAMBLE + 7] = 0xff;
-			memcpy(sector + MDV_OFFSET_DATA, tape_data.data() + d, payload_size);
+			fill_image_data_record(image, data_header, tape_data.data() + d, slot);
 		}
+		else if (orphan.empty())
+		{
+			// a data record arrived before any header at start of tape
+			// keep it aside to pair it later with the last header on tape
+			orphan.assign(data_header, data_header + 4);
+			orphan.insert(orphan.end(), tape_data.data() + d, tape_data.data() + d + 514);
+		}
+
 		p = d + payload_size;
 	}
 	// no data record found: leave p after the block header
@@ -227,7 +243,7 @@ bool read_tape_record_data(uint8_t *image, const std::vector<uint8_t> &tape_data
 }
 
 bool read_tape_record(uint8_t *image, const std::vector<uint8_t> &tape_data,
-	int &slot, int &next_slot, size_t &p)
+	int &slot, int &next_slot, size_t &p, std::vector<uint8_t> &orphan)
 {
 	if (p >= tape_data.size())
 	{
@@ -241,7 +257,7 @@ bool read_tape_record(uint8_t *image, const std::vector<uint8_t> &tape_data,
 			return false;
 		}
 	}
-	else if (!read_tape_record_data(image, tape_data, slot, p))
+	else if (!read_tape_record_data(image, tape_data, slot, p, orphan))
 	{
 		return false;
 	}
@@ -275,6 +291,11 @@ void microdrive_image_device::tape_to_image(uint8_t *image) const
 	int slot = -1; // QLAY slot of the last sector header found (tape order)
 	int next_slot = 0;
 
+	// As the tape is circular, a data block might arrive before the first
+	// detected header. This data will be set into orphan and associated to
+	// the last header read.
+	std::vector<uint8_t> orphan;
+
 	int tape_index = 0;
 	while (tape_index < MDV_TAPE_PAIRS)
 	{
@@ -302,7 +323,7 @@ void microdrive_image_device::tape_to_image(uint8_t *image) const
 			if (flat_data[p] == 0x00 && flat_data[p + 1] == 0xff && flat_data[p + 2] == 0xff)
 			{
 				p += 3; // point to the record
-				if (read_tape_record(image, flat_data, slot, next_slot, p))
+				if (read_tape_record(image, flat_data, slot, next_slot, p, orphan))
 					break;
 			}
 			else
@@ -310,6 +331,11 @@ void microdrive_image_device::tape_to_image(uint8_t *image) const
 				p++;
 			}
 		}
+	}
+
+	if (!orphan.empty() && next_slot > 0)
+	{
+		fill_image_data_record(image, orphan.data(), orphan.data() + 4, next_slot - 1);
 	}
 }
 

--- a/src/devices/imagedev/microdrv.cpp
+++ b/src/devices/imagedev/microdrv.cpp
@@ -17,22 +17,27 @@
     CONSTANTS
 ***************************************************************************/
 
-#define LOG 0
+#define LOG 1
+#define LOG_COMMS 0
 
 #define MDV_SECTOR_COUNT            255
 #define MDV_SECTOR_LENGTH           686
 #define MDV_IMAGE_LENGTH            (MDV_SECTOR_COUNT * MDV_SECTOR_LENGTH)
 
-#define MDV_PREAMBLE_LENGTH         12
-#define MDV_GAP_LENGTH              120
-
 #define MDV_OFFSET_HEADER_PREAMBLE  0
 #define MDV_OFFSET_HEADER           MDV_OFFSET_HEADER_PREAMBLE + MDV_PREAMBLE_LENGTH
 #define MDV_OFFSET_DATA_PREAMBLE    28
 #define MDV_OFFSET_DATA             MDV_OFFSET_DATA_PREAMBLE + MDV_PREAMBLE_LENGTH
-#define MDV_OFFSET_GAP              566
+#define MDV_OFFSET_FILLER           566
 
-#define MDV_BITRATE                 120000 // invalid, from ZX microdrive
+// 40us/byte from Minerva sources; both tracks shift one bit per tick, so a
+// byte pair (two stream bytes) takes 8 ticks = 80us -> 100kHz per track
+#define MDV_BITRATE                 100000
+
+// Physical gaps (erased tape regions) are not stored in QLAY images, they
+// have to be synthesized. Durations are in bit ticks (10us each).
+#define MDV_GAP_SECTOR_TICKS        480 // 4.8ms inter-sector gap
+#define MDV_GAP_BLOCK_TICKS         280 // 2.8ms gap between sector header and block preamble
 
 /***************************************************************************
     TYPE DEFINITIONS
@@ -47,7 +52,10 @@ DEFINE_DEVICE_TYPE(MICRODRIVE, microdrive_image_device, "microdrive_image", "Sin
 
 microdrive_image_device::microdrive_image_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	microtape_image_device(mconfig, MICRODRIVE, tag, owner, clock),
-	m_write_comms_out(*this)
+	m_write_comms_out(*this),
+	m_write_data1_out(*this),
+	m_write_data2_out(*this),
+	m_write_gap_out(*this)
 {
 }
 
@@ -74,6 +82,15 @@ void microdrive_image_device::device_start()
 	m_clk = 0;
 	m_comms_in = 0;
 	m_comms_out = 0;
+	m_gap_ticks = 0;
+
+	// register for state saving
+	save_item(NAME(m_clk));
+	save_item(NAME(m_comms_in));
+	save_item(NAME(m_comms_out));
+	save_item(NAME(m_bit_offset));
+	save_item(NAME(m_byte_offset));
+	save_item(NAME(m_gap_ticks));
 }
 
 std::pair<std::error_condition, std::string> microdrive_image_device::call_load()
@@ -81,21 +98,28 @@ std::pair<std::error_condition, std::string> microdrive_image_device::call_load(
 	if (length() != MDV_IMAGE_LENGTH)
 		return std::make_pair(image_error::INVALIDLENGTH, std::string());
 
-	// huh
 	for (int i = 0; i < MDV_IMAGE_LENGTH / 2; i++)
 	{
-		fread(m_left.get(), 1);
-		fread(m_right.get(), 1);
+		fread(m_left.get() + i, 1);
+		fread(m_right.get() + i, 1);
 	}
 
 	m_bit_offset = 0;
 	m_byte_offset = 0;
+	m_clk = 0;
+	m_gap_ticks = 0;
 
 	return std::make_pair(std::error_condition(), std::string());
 }
 
 void microdrive_image_device::call_unload()
 {
+	m_bit_timer->enable(false);
+
+	// ejecting while the drive is selected leaves the head over nothing
+	if (m_comms_out)
+		m_write_gap_out(1);
+
 	if (m_left.get())
 		memset(m_left.get(), 0, MDV_IMAGE_LENGTH / 2);
 
@@ -105,6 +129,18 @@ void microdrive_image_device::call_unload()
 
 TIMER_CALLBACK_MEMBER(microdrive_image_device::bit_timer)
 {
+	// Synthesized gap: the head is over an erased region
+	if (m_gap_ticks > 0)
+	{
+		m_gap_ticks--;
+		if (m_gap_ticks == 0)
+			m_write_gap_out(0); // End of gap, preamble will follow
+		return;
+	}
+
+	m_write_data1_out(BIT(m_left[m_byte_offset], 7 - m_bit_offset));
+	m_write_data2_out(BIT(m_right[m_byte_offset], 7 - m_bit_offset));
+
 	m_bit_offset++;
 
 	if (m_bit_offset == 8)
@@ -112,41 +148,75 @@ TIMER_CALLBACK_MEMBER(microdrive_image_device::bit_timer)
 		m_bit_offset = 0;
 		m_byte_offset++;
 
-		if (m_byte_offset == MDV_IMAGE_LENGTH)
-		{
+		// Infinite loop of the tape
+		if (m_byte_offset == MDV_IMAGE_LENGTH / 2)
 			m_byte_offset = 0;
+
+		int sector_offset = m_byte_offset % (MDV_SECTOR_LENGTH / 2);
+
+		if (sector_offset == MDV_OFFSET_DATA_PREAMBLE / 2)
+		{
+			// Gap between the sector header and the block preamble
+			m_write_gap_out(1);
+			m_gap_ticks = MDV_GAP_BLOCK_TICKS;
+		}
+		else if (sector_offset == MDV_OFFSET_FILLER / 2)
+		{
+			// The QLAY filler replaces the erased part between sectors
+			// skip it and emit a gap
+			m_byte_offset += (MDV_SECTOR_LENGTH - MDV_OFFSET_FILLER) / 2;
+			if (m_byte_offset >= MDV_IMAGE_LENGTH / 2)
+				m_byte_offset = 0;
+			m_write_gap_out(1);
+			m_gap_ticks = MDV_GAP_SECTOR_TICKS;
 		}
 	}
 }
 
 void microdrive_image_device::clk_w(int state)
 {
-	if (LOG) logerror("Microdrive '%s' CLK: %u\n", tag(), state);
-	if (!m_clk && state)
+	if (LOG_COMMS) logerror("Microdrive '%s' CLK: %u\n", tag(), state);
+
+	if (m_clk && !state) // Falling edge
 	{
 		m_comms_out = m_comms_in;
 		if (LOG) logerror("Microdrive '%s' COMMS OUT: %u\n", tag(), m_comms_out);
-		m_write_comms_out(m_comms_out);
-		m_bit_timer->enable(m_comms_out);
+		m_write_comms_out(m_comms_out); // daisy chain for drive selection
+
+		if (m_comms_out && is_loaded())
+		{
+			if (LOG) logerror("Microdrive '%s' motor ON\n", tag());
+			m_bit_timer->enable(true);
+		}
+		else if (m_comms_out && !is_loaded())
+		{
+			// no cartridge: the head sees a gap
+			if (LOG) logerror("Microdrive '%s' selected, no cartridge, gap set\n", tag());
+			m_write_gap_out(1);
+		}
+		else if (!m_comms_out && is_loaded()) {
+			if (LOG) logerror("Microdrive '%s' motor OFF\n", tag());
+			m_bit_timer->enable(false);
+		}
 	}
 	m_clk = state;
 }
 
 void microdrive_image_device::comms_in_w(int state)
 {
-	if (LOG) logerror("Microdrive '%s' COMMS IN: %u\n", tag(), state);
+	if (LOG_COMMS) logerror("Microdrive '%s' COMMS IN: %u\n", tag(), state);
 	m_comms_in = state;
 }
 
 void microdrive_image_device::erase_w(int state)
 {
-	if (LOG) logerror("Microdrive '%s' ERASE: %u\n", tag(), state);
+	if (LOG_COMMS) logerror("Microdrive '%s' ERASE: %u\n", tag(), state);
 	m_erase = state;
 }
 
 void microdrive_image_device::read_write_w(int state)
 {
-	if (LOG) logerror("Microdrive '%s' READ/WRITE: %u\n", tag(), state);
+	if (LOG_COMMS) logerror("Microdrive '%s' READ/WRITE: %u (1=read)\n", tag(), state);
 	m_read_write = state;
 }
 

--- a/src/devices/imagedev/microdrv.cpp
+++ b/src/devices/imagedev/microdrv.cpp
@@ -15,12 +15,14 @@
 
 #include <vector>
 
+#define LOG_COMMS (1U << 1)   // per-line chatter: CLK, COMMS IN, ERASE, READ/WRITE
+
+// #define VERBOSE (LOG_GENERAL | LOG_COMMS)
+#include "logmacro.h"
+
 /***************************************************************************
     CONSTANTS
 ***************************************************************************/
-
-#define LOG 1
-#define LOG_COMMS 0
 
 #define MDV_SECTOR_COUNT            255
 #define MDV_SECTOR_LENGTH           686
@@ -349,7 +351,7 @@ void microdrive_image_device::save_image()
 	tape_to_image(image.data());
 	fseek(0, SEEK_SET);
 	fwrite(image.data(), MDV_IMAGE_LENGTH);
-	if (LOG) logerror("Microdrive '%s' image saved\n", tag());
+	LOG("image saved\n");
 }
 
 std::pair<std::error_condition, std::string> microdrive_image_device::call_load()
@@ -482,28 +484,27 @@ TIMER_CALLBACK_MEMBER(microdrive_image_device::bit_timer)
 
 void microdrive_image_device::clk_w(int state)
 {
-	if (LOG_COMMS) logerror("Microdrive '%s' CLK: %u\n", tag(), state);
+	LOGMASKED(LOG_COMMS, "CLK: %u\n", state);
 
 	if (m_clk && !state) // Falling edge
 	{
 		m_comms_out = m_comms_in;
-		if (LOG) logerror("Microdrive '%s' COMMS OUT: %u\n", tag(), m_comms_out);
-		m_write_comms_out(m_comms_out); // daisy chain for drive selection
-
+		LOG("COMMS OUT: %u\n", m_comms_out);
+		m_write_comms_out(m_comms_out);
 		if (m_comms_out && is_loaded())
 		{
-			if (LOG) logerror("Microdrive '%s' motor ON\n", tag());
+			LOG("motor ON\n");
 			m_gap_level = -1; // force a gap emission on the first tick
 			m_bit_timer->enable(true);
 		}
 		else if (m_comms_out && !is_loaded())
 		{
 			// no cartridge: the head sees a gap
-			if (LOG) logerror("Microdrive '%s' selected, no cartridge, gap set\n", tag());
+			LOG("selected, no cartridge, gap set\n");
 			m_write_gap_out(1);
 		}
 		else if (!m_comms_out && is_loaded()) {
-			if (LOG) logerror("Microdrive '%s' motor OFF\n", tag());
+			LOG("motor OFF\n");
 			m_bit_timer->enable(false);
 		}
 	}
@@ -512,19 +513,19 @@ void microdrive_image_device::clk_w(int state)
 
 void microdrive_image_device::comms_in_w(int state)
 {
-	if (LOG_COMMS) logerror("Microdrive '%s' COMMS IN: %u\n", tag(), state);
+	LOGMASKED(LOG_COMMS, "COMMS IN: %u\n", state);
 	m_comms_in = state;
 }
 
 void microdrive_image_device::erase_w(int state)
 {
-	if (LOG_COMMS) logerror("Microdrive '%s' ERASE: %u\n", tag(), state);
+	LOGMASKED(LOG_COMMS, "ERASE: %u\n", state);
 	m_erase = state;
 }
 
 void microdrive_image_device::read_write_w(int state)
 {
-	if (LOG_COMMS) logerror("Microdrive '%s' READ/WRITE: %u (1=write)\n", tag(), state);
+	LOGMASKED(LOG_COMMS, "READ/WRITE: %u (1=write)\n", state);
 	m_read_write = state;
 }
 

--- a/src/devices/imagedev/microdrv.cpp
+++ b/src/devices/imagedev/microdrv.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Curt Coder
+// copyright-holders:Curt Coder, Sylvain Glaize
 /*********************************************************************
 
     microdrv.cpp
@@ -24,33 +24,42 @@
     CONSTANTS
 ***************************************************************************/
 
-#define MDV_SECTOR_COUNT            255
-#define MDV_SECTOR_LENGTH           686
-#define MDV_IMAGE_LENGTH            (MDV_SECTOR_COUNT * MDV_SECTOR_LENGTH)
+namespace {
+	constexpr int MDV_SECTOR_COUNT           = 255;
+	constexpr int MDV_SECTOR_LENGTH          = 686;
+	constexpr int MDV_IMAGE_LENGTH           = MDV_SECTOR_COUNT * MDV_SECTOR_LENGTH;
 
-// QLAY image format: sector byte layout
-#define MDV_OFFSET_HEADER_PREAMBLE  0   // 10x00 + 2xFF (unused, only for reference)
-#define MDV_OFFSET_HEADER           12  // sflag, sno, name[10], rand[2], csum[2]
-#define MDV_OFFSET_BLOCK_PREAMBLE   28  // 10x00 + 2xFF
-#define MDV_OFFSET_BLOCK_HEADER     40  // fno, bno, csum[2]
-#define MDV_OFFSET_DATA_PREAMBLE    44  // 6x00 + 2xFF
-#define MDV_OFFSET_DATA             52  // 512 data + csum[2]
-#define MDV_OFFSET_FILLER           566 // (unused, only for reference)
+	// QLAY image format: sector byte layout
+	[[maybe_unused]]
+	constexpr int MDV_OFFSET_HEADER_PREAMBLE = 0;   // 10x00 + 2xFF (unused, only for reference)
+	constexpr int MDV_OFFSET_HEADER          = 12;  // sflag, sno, name[10], rand[2], csum[2]
+	constexpr int MDV_OFFSET_BLOCK_PREAMBLE  = 28;  // 10x00 + 2xFF
+	constexpr int MDV_OFFSET_BLOCK_HEADER    = 40;  // fno, bno, csum[2]
+	constexpr int MDV_OFFSET_DATA_PREAMBLE   = 44;  // 6x00 + 2xFF
+	constexpr int MDV_OFFSET_DATA            = 52;  // 512 data + csum[2]
+	[[maybe_unused]]
+	constexpr int MDV_OFFSET_FILLER          = 566; // (unused, only for reference)
 
-// 40us/byte deduced from Minerva ROM sources
-// Both tracks shift one bit per tick, so a byte pair takes 8 ticks
-// 80us -> 100kHz per track
-#define MDV_BITRATE                 100000
+	// record sizes on tape (after the preamble sync)
+	constexpr int MDV_HEADER_LENGTH          = 16;  // sflag, sno, name[10], rand[2], csum[2]
+	constexpr int MDV_BLOCK_HEADER_LENGTH    = 4;   // fno, bno, csum[2]
+	constexpr int MDV_DATA_LENGTH            = 514; // 512 data + csum[2]
 
-// Tape timeline in byte-pair positions.
-// QLAY images store no erased regions, they have to be reconstructed
-// One byte pair is 80us
-#define MDV_PAIRS_HEADER            14  // QLAY bytes 0-27
-#define MDV_PAIRS_BLOCK_GAP         35  // 2.8ms erased gap between header and block
-#define MDV_PAIRS_BLOCK             269 // QLAY bytes 28-565
-#define MDV_PAIRS_SECTOR_GAP        60  // 4.8ms erased gap (filler)
-#define MDV_PAIRS_PER_SECTOR        (MDV_PAIRS_HEADER + MDV_PAIRS_BLOCK_GAP + MDV_PAIRS_BLOCK + MDV_PAIRS_SECTOR_GAP)
-#define MDV_TAPE_PAIRS              (MDV_SECTOR_COUNT * MDV_PAIRS_PER_SECTOR)
+	// 40us/byte deduced from Minerva ROM sources
+	// Both tracks shift one bit per tick, so a byte pair takes 8 ticks
+	// 80us -> 100kHz per track
+	constexpr int MDV_BITRATE                = 100000;
+
+	// Tape timeline in byte-pair positions.
+	// QLAY images store no erased regions, they have to be reconstructed
+	// One byte pair is 80us
+	constexpr int MDV_PAIRS_HEADER           = 14;  // QLAY bytes 0-27
+	constexpr int MDV_PAIRS_BLOCK_GAP        = 35;  // 2.8ms erased gap between header and block
+	constexpr int MDV_PAIRS_BLOCK            = 269; // QLAY bytes 28-565
+	constexpr int MDV_PAIRS_SECTOR_GAP       = 60;  // 4.8ms erased gap (filler)
+	constexpr int MDV_PAIRS_PER_SECTOR       = MDV_PAIRS_HEADER + MDV_PAIRS_BLOCK_GAP + MDV_PAIRS_BLOCK + MDV_PAIRS_SECTOR_GAP;
+	constexpr int MDV_TAPE_PAIRS             = MDV_SECTOR_COUNT * MDV_PAIRS_PER_SECTOR;
+} // anonymous namespace
 
 /***************************************************************************
     TYPE DEFINITIONS
@@ -58,10 +67,6 @@
 
 // device type definition
 DEFINE_DEVICE_TYPE(MICRODRIVE, microdrive_image_device, "microdrive_image", "Sinclair Microdrive")
-
-//-------------------------------------------------
-//  microdrive_image_device - constructor
-//-------------------------------------------------
 
 microdrive_image_device::microdrive_image_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	microtape_image_device(mconfig, MICRODRIVE, tag, owner, clock),
@@ -72,15 +77,6 @@ microdrive_image_device::microdrive_image_device(const machine_config &mconfig, 
 	m_read_tx_pair(*this, 0)
 {
 }
-
-//-------------------------------------------------
-//  microdrive_image_device - destructor
-//-------------------------------------------------
-
-microdrive_image_device::~microdrive_image_device()
-{
-}
-
 
 void microdrive_image_device::device_start()
 {
@@ -101,9 +97,9 @@ void microdrive_image_device::device_start()
 	m_erase = 0;
 	m_read_write = 0;
 	m_bit_offset = 0;
-	m_byte_offset = 0;
+	m_byte_pair_offset = 0;
 	m_gap_level = -1;
-	m_dirty = 0;
+	m_dirty = false;
 
 	// register for state saving
 	save_item(NAME(m_clk));
@@ -112,7 +108,7 @@ void microdrive_image_device::device_start()
 	save_item(NAME(m_erase));
 	save_item(NAME(m_read_write));
 	save_item(NAME(m_bit_offset));
-	save_item(NAME(m_byte_offset));
+	save_item(NAME(m_byte_pair_offset));
 	save_item(NAME(m_gap_level));
 	save_item(NAME(m_dirty));
 	save_pointer(NAME(m_left), MDV_TAPE_PAIRS);
@@ -173,7 +169,7 @@ void microdrive_image_device::tape_from_image(const uint8_t *image)
 bool read_tape_record_header(uint8_t *image, const std::vector<uint8_t> &tape_data,
 	int &slot, int &next_slot, size_t &p)
 {
-	if (p + 16 > tape_data.size() || next_slot >= MDV_SECTOR_COUNT) {
+	if (p + MDV_HEADER_LENGTH > tape_data.size() || next_slot >= MDV_SECTOR_COUNT) {
 	    return false;
 	}
 
@@ -183,8 +179,8 @@ bool read_tape_record_header(uint8_t *image, const std::vector<uint8_t> &tape_da
 	uint8_t *sector = image + slot * MDV_SECTOR_LENGTH;
 	sector[10] = 0xff;
 	sector[11] = 0xff;
-	memcpy(sector + MDV_OFFSET_HEADER, tape_data.data() + p, 16);
-	p += 16;
+	memcpy(sector + MDV_OFFSET_HEADER, tape_data.data() + p, MDV_HEADER_LENGTH);
+	p += MDV_HEADER_LENGTH;
 
 	return true;
 }
@@ -194,23 +190,23 @@ void fill_image_data_record(uint8_t *image, const uint8_t *data_header, const ui
 	uint8_t *sector = image + slot * MDV_SECTOR_LENGTH;
 	sector[MDV_OFFSET_BLOCK_PREAMBLE + 10] = 0xff;
 	sector[MDV_OFFSET_BLOCK_PREAMBLE + 11] = 0xff;
-	memcpy(sector + MDV_OFFSET_BLOCK_HEADER, data_header, 4);
+	memcpy(sector + MDV_OFFSET_BLOCK_HEADER, data_header, MDV_BLOCK_HEADER_LENGTH);
 	sector[MDV_OFFSET_DATA_PREAMBLE + 6] = 0xff;
 	sector[MDV_OFFSET_DATA_PREAMBLE + 7] = 0xff;
-	memcpy(sector + MDV_OFFSET_DATA, data, 514);
+	memcpy(sector + MDV_OFFSET_DATA, data, MDV_DATA_LENGTH);
 };
 
 
 bool read_tape_record_data(uint8_t *image, const std::vector<uint8_t> &tape_data,
                            const int &slot, size_t &p, std::vector<uint8_t> &orphan)
 {
-	if (p + 4 > tape_data.size()) {
+	if (p + MDV_BLOCK_HEADER_LENGTH > tape_data.size()) {
 		return false;
 	}
 
 	// keep data header pointer, it's copied only if a valid data is found
 	const uint8_t *data_header = tape_data.data() + p;
-	p += 4;
+	p += MDV_BLOCK_HEADER_LENGTH;
 
 	// sync on the inner (smaller) preamble
 	size_t d = p;
@@ -218,11 +214,10 @@ bool read_tape_record_data(uint8_t *image, const std::vector<uint8_t> &tape_data
 		d++;
 	}
 
-	constexpr size_t payload_size = 514;
 	if (d + 1 < tape_data.size() && tape_data[d] == 0xff && tape_data[d + 1] == 0xff)
 	{
 		d += 2;
-		if (d + payload_size > tape_data.size()) {
+		if (d + MDV_DATA_LENGTH > tape_data.size()) {
 			return true; // it seems ROM can produce header only sectors (orphans?)
 		}
 		if (slot >= 0)
@@ -233,11 +228,11 @@ bool read_tape_record_data(uint8_t *image, const std::vector<uint8_t> &tape_data
 		{
 			// a data record arrived before any header at start of tape
 			// keep it aside to pair it later with the last header on tape
-			orphan.assign(data_header, data_header + 4);
-			orphan.insert(orphan.end(), tape_data.data() + d, tape_data.data() + d + 514);
+			orphan.assign(data_header, data_header + MDV_BLOCK_HEADER_LENGTH);
+			orphan.insert(orphan.end(), tape_data.data() + d, tape_data.data() + d + MDV_DATA_LENGTH);
 		}
 
-		p = d + payload_size;
+		p = d + MDV_DATA_LENGTH;
 	}
 	// no data record found: leave p after the block header
 	// and resync on the next preamble
@@ -309,6 +304,7 @@ void microdrive_image_device::tape_to_image(uint8_t *image) const
 
 		// read the bytes from the two tracks into a flat buffer
 		std::vector<uint8_t> flat_data;
+		flat_data.reserve(MDV_PAIRS_PER_SECTOR * 2); // most probable size of the sector
 		while (tape_index < MDV_TAPE_PAIRS && !m_erased[(origin_on_tape + tape_index) % MDV_TAPE_PAIRS])
 		{
 			const int pos = (origin_on_tape + tape_index) % MDV_TAPE_PAIRS;
@@ -337,7 +333,7 @@ void microdrive_image_device::tape_to_image(uint8_t *image) const
 
 	if (!orphan.empty() && next_slot > 0)
 	{
-		fill_image_data_record(image, orphan.data(), orphan.data() + 4, next_slot - 1);
+		fill_image_data_record(image, orphan.data(), orphan.data() + MDV_BLOCK_HEADER_LENGTH, next_slot - 1);
 	}
 }
 
@@ -370,10 +366,10 @@ std::pair<std::error_condition, std::string> microdrive_image_device::call_load(
 	tape_from_image(image.data());
 
 	m_bit_offset = 0;
-	m_byte_offset = 0;
+	m_byte_pair_offset = 0;
 	m_clk = 0;
 	m_gap_level = -1;
-	m_dirty = 0;
+	m_dirty = false;
 
 	return std::make_pair(std::error_condition(), std::string());
 }
@@ -390,10 +386,10 @@ std::pair<std::error_condition, std::string> microdrive_image_device::call_creat
 	tape_from_image(image.data());
 
 	m_bit_offset = 0;
-	m_byte_offset = 0;
+	m_byte_pair_offset = 0;
 	m_clk = 0;
 	m_gap_level = -1;
-	m_dirty = 0;
+	m_dirty = false;
 
 	return std::make_pair(std::error_condition(), std::string());
 }
@@ -406,7 +402,7 @@ void microdrive_image_device::call_unload()
 	{
 		save_image();
 	}
-	m_dirty = 0;
+	m_dirty = false;
 
 	// ejecting while the drive is selected leaves the head over nothing
 	if (m_comms_out)
@@ -439,24 +435,24 @@ TIMER_CALLBACK_MEMBER(microdrive_image_device::bit_timer)
 		if (m_bit_offset == 0)
 		{
 			const uint16_t pair = m_read_tx_pair();
-			m_left[m_byte_offset] = pair >> 8;
-			m_right[m_byte_offset] = pair & 0xff;
-			m_erased[m_byte_offset] = 0;
-			m_dirty = 1;
+			m_left[m_byte_pair_offset] = pair >> 8;
+			m_right[m_byte_pair_offset] = pair & 0xff;
+			m_erased[m_byte_pair_offset] = 0;
+			m_dirty = true;
 		}
 	}
 	else if (m_erase)
 	{
 		// erase-only
-		m_left[m_byte_offset] = 0;
-		m_right[m_byte_offset] = 0;
-		m_erased[m_byte_offset] = 1;
-		m_dirty = 1;
+		m_left[m_byte_pair_offset] = 0;
+		m_right[m_byte_pair_offset] = 0;
+		m_erased[m_byte_pair_offset] = 1;
+		m_dirty = true;
 	}
 	else
 	{
 		// read mode
-		const int gap = m_erased[m_byte_offset] ? 1 : 0;
+		const int gap = m_erased[m_byte_pair_offset] ? 1 : 0;
 		if (gap != m_gap_level)
 		{
 			m_gap_level = gap;
@@ -464,8 +460,8 @@ TIMER_CALLBACK_MEMBER(microdrive_image_device::bit_timer)
 		}
 		if (!gap)
 		{
-			m_write_data1_out(BIT(m_left[m_byte_offset], 7 - m_bit_offset));
-			m_write_data2_out(BIT(m_right[m_byte_offset], 7 - m_bit_offset));
+			m_write_data1_out(BIT(m_left[m_byte_pair_offset], 7 - m_bit_offset));
+			m_write_data2_out(BIT(m_right[m_byte_pair_offset], 7 - m_bit_offset));
 		}
 	}
 
@@ -474,11 +470,11 @@ TIMER_CALLBACK_MEMBER(microdrive_image_device::bit_timer)
 	if (m_bit_offset == 8)
 	{
 		m_bit_offset = 0;
-		m_byte_offset++;
+		m_byte_pair_offset++;
 
 		// Infinite loop of the tape
-		if (m_byte_offset == MDV_TAPE_PAIRS)
-			m_byte_offset = 0;
+		if (m_byte_pair_offset == MDV_TAPE_PAIRS)
+			m_byte_pair_offset = 0;
 	}
 }
 
@@ -529,22 +525,12 @@ void microdrive_image_device::read_write_w(int state)
 	m_read_write = state;
 }
 
-void microdrive_image_device::data1_w(int state)
-{
-	// unused: data goes through the bit timer, to remove
-}
-
-void microdrive_image_device::data2_w(int state)
-{
-	// unused: data goes through the bit timer, to remove
-}
-
 int microdrive_image_device::data1_r() const
 {
 	int data = 0;
-	if (m_comms_out && !m_read_write && !m_erased[m_byte_offset])
+	if (m_comms_out && !m_read_write && !m_erased[m_byte_pair_offset])
 	{
-		data = BIT(m_left[m_byte_offset], 7 - m_bit_offset);
+		data = BIT(m_left[m_byte_pair_offset], 7 - m_bit_offset);
 	}
 	return data;
 }
@@ -552,9 +538,9 @@ int microdrive_image_device::data1_r() const
 int microdrive_image_device::data2_r() const
 {
 	int data = 0;
-	if (m_comms_out && !m_read_write && !m_erased[m_byte_offset])
+	if (m_comms_out && !m_read_write && !m_erased[m_byte_pair_offset])
 	{
-		data = BIT(m_right[m_byte_offset], 7 - m_bit_offset);
+		data = BIT(m_right[m_byte_pair_offset], 7 - m_bit_offset);
 	}
 	return data;
 }

--- a/src/devices/imagedev/microdrv.cpp
+++ b/src/devices/imagedev/microdrv.cpp
@@ -13,6 +13,8 @@
 #include "emu.h"
 #include "microdrv.h"
 
+#include <vector>
+
 /***************************************************************************
     CONSTANTS
 ***************************************************************************/
@@ -24,20 +26,29 @@
 #define MDV_SECTOR_LENGTH           686
 #define MDV_IMAGE_LENGTH            (MDV_SECTOR_COUNT * MDV_SECTOR_LENGTH)
 
-#define MDV_OFFSET_HEADER_PREAMBLE  0
-#define MDV_OFFSET_HEADER           MDV_OFFSET_HEADER_PREAMBLE + MDV_PREAMBLE_LENGTH
-#define MDV_OFFSET_DATA_PREAMBLE    28
-#define MDV_OFFSET_DATA             MDV_OFFSET_DATA_PREAMBLE + MDV_PREAMBLE_LENGTH
-#define MDV_OFFSET_FILLER           566
+// QLAY image format: sector byte layout
+#define MDV_OFFSET_HEADER_PREAMBLE  0   // 10x00 + 2xFF (unused, only for reference)
+#define MDV_OFFSET_HEADER           12  // sflag, sno, name[10], rand[2], csum[2]
+#define MDV_OFFSET_BLOCK_PREAMBLE   28  // 10x00 + 2xFF
+#define MDV_OFFSET_BLOCK_HEADER     40  // fno, bno, csum[2]
+#define MDV_OFFSET_DATA_PREAMBLE    44  // 6x00 + 2xFF
+#define MDV_OFFSET_DATA             52  // 512 data + csum[2]
+#define MDV_OFFSET_FILLER           566 // (unused, only for reference)
 
-// 40us/byte from Minerva sources; both tracks shift one bit per tick, so a
-// byte pair (two stream bytes) takes 8 ticks = 80us -> 100kHz per track
+// 40us/byte deduced from Minerva ROM sources
+// Both tracks shift one bit per tick, so a byte pair takes 8 ticks
+// 80us -> 100kHz per track
 #define MDV_BITRATE                 100000
 
-// Physical gaps (erased tape regions) are not stored in QLAY images, they
-// have to be synthesized. Durations are in bit ticks (10us each).
-#define MDV_GAP_SECTOR_TICKS        480 // 4.8ms inter-sector gap
-#define MDV_GAP_BLOCK_TICKS         280 // 2.8ms gap between sector header and block preamble
+// Tape timeline in byte-pair positions.
+// QLAY images store no erased regions, they have to be reconstructed
+// One byte pair is 80us
+#define MDV_PAIRS_HEADER            14  // QLAY bytes 0-27
+#define MDV_PAIRS_BLOCK_GAP         35  // 2.8ms erased gap between header and block
+#define MDV_PAIRS_BLOCK             269 // QLAY bytes 28-565
+#define MDV_PAIRS_SECTOR_GAP        60  // 4.8ms erased gap (filler)
+#define MDV_PAIRS_PER_SECTOR        (MDV_PAIRS_HEADER + MDV_PAIRS_BLOCK_GAP + MDV_PAIRS_BLOCK + MDV_PAIRS_SECTOR_GAP)
+#define MDV_TAPE_PAIRS              (MDV_SECTOR_COUNT * MDV_PAIRS_PER_SECTOR)
 
 /***************************************************************************
     TYPE DEFINITIONS
@@ -55,7 +66,8 @@ microdrive_image_device::microdrive_image_device(const machine_config &mconfig, 
 	m_write_comms_out(*this),
 	m_write_data1_out(*this),
 	m_write_data2_out(*this),
-	m_write_gap_out(*this)
+	m_write_gap_out(*this),
+	m_read_tx_pair(*this, 0)
 {
 }
 
@@ -70,44 +82,290 @@ microdrive_image_device::~microdrive_image_device()
 
 void microdrive_image_device::device_start()
 {
-	// allocate track buffers
-	m_left = std::make_unique<uint8_t[]>(MDV_IMAGE_LENGTH / 2);
-	m_right = std::make_unique<uint8_t[]>(MDV_IMAGE_LENGTH / 2);
+	// allocate the tape timeline
+	m_left = std::make_unique<uint8_t[]>(MDV_TAPE_PAIRS);
+	m_right = std::make_unique<uint8_t[]>(MDV_TAPE_PAIRS);
+	m_erased = std::make_unique<uint8_t[]>(MDV_TAPE_PAIRS);
+	memset(m_erased.get(), 1, MDV_TAPE_PAIRS); // no tape == all erased
 
 	// allocate timers
 	m_bit_timer = timer_alloc(FUNC(microdrive_image_device::bit_timer), this);
 	m_bit_timer->adjust(attotime::zero, 0, attotime::from_hz(MDV_BITRATE));
-	m_bit_timer->enable(0);
+	m_bit_timer->enable(false);
 
 	m_clk = 0;
 	m_comms_in = 0;
 	m_comms_out = 0;
-	m_gap_ticks = 0;
+	m_erase = 0;
+	m_read_write = 0;
+	m_bit_offset = 0;
+	m_byte_offset = 0;
+	m_gap_level = -1;
+	m_dirty = 0;
 
 	// register for state saving
 	save_item(NAME(m_clk));
 	save_item(NAME(m_comms_in));
 	save_item(NAME(m_comms_out));
+	save_item(NAME(m_erase));
+	save_item(NAME(m_read_write));
 	save_item(NAME(m_bit_offset));
 	save_item(NAME(m_byte_offset));
-	save_item(NAME(m_gap_ticks));
+	save_item(NAME(m_gap_level));
+	save_item(NAME(m_dirty));
+	save_pointer(NAME(m_left), MDV_TAPE_PAIRS);
+	save_pointer(NAME(m_right), MDV_TAPE_PAIRS);
+	save_pointer(NAME(m_erased), MDV_TAPE_PAIRS);
+}
+
+//-------------------------------------------------
+//  tape_from_image
+//  Loads a QLAY format image on a internal tape timeline
+//  Reconstructs the GAPs
+//-------------------------------------------------
+
+void microdrive_image_device::tape_from_image(const uint8_t *image)
+{
+	for (int sector = 0; sector < MDV_SECTOR_COUNT; sector++)
+	{
+		const uint8_t *sec = image + sector * MDV_SECTOR_LENGTH;
+		const int base = sector * MDV_PAIRS_PER_SECTOR;
+
+		// sector is unformatted/no data by default
+		memset(m_left.get() + base, 0, MDV_PAIRS_PER_SECTOR);
+		memset(m_right.get() + base, 0, MDV_PAIRS_PER_SECTOR);
+		memset(m_erased.get() + base, 1, MDV_PAIRS_PER_SECTOR);
+
+		// if no preamble on the header, it's considered unformatted
+		if (sec[10] != 0xff || sec[11] != 0xff)
+			continue;
+
+		// copy header
+		int pos = base;
+		for (int i = 0; i < MDV_PAIRS_HEADER; i++, pos++)
+		{
+			m_left[pos] = sec[2 * i];
+			m_right[pos] = sec[2 * i + 1];
+			m_erased[pos] = 0;
+		}
+
+		// copy data
+		pos += MDV_PAIRS_BLOCK_GAP;
+		for (int i = 0; i < MDV_PAIRS_BLOCK; i++, pos++)
+		{
+			m_left[pos] = sec[MDV_OFFSET_BLOCK_PREAMBLE + 2 * i];
+			m_right[pos] = sec[MDV_OFFSET_BLOCK_PREAMBLE + 2 * i + 1];
+			m_erased[pos] = 0;
+		}
+	}
+}
+
+// Helper functions for tape_to_image
+
+bool read_tape_record_header(uint8_t *image, const std::vector<uint8_t> &tape_data,
+	int &slot, int &next_slot, size_t &p)
+{
+	if (p + 16 > tape_data.size() || next_slot >= MDV_SECTOR_COUNT) {
+	    return false;
+	}
+
+	slot = next_slot;
+	next_slot += 1;
+
+	uint8_t *sector = image + slot * MDV_SECTOR_LENGTH;
+	sector[10] = 0xff;
+	sector[11] = 0xff;
+	memcpy(sector + MDV_OFFSET_HEADER, tape_data.data() + p, 16);
+	p += 16;
+
+	return true;
+}
+
+bool read_tape_record_data(uint8_t *image, const std::vector<uint8_t> &tape_data,
+                           const int &slot, size_t &p)
+{
+	if (p + 4 > tape_data.size()) {
+		return false;
+	}
+
+	// keep data header pointer, it's copied only if a valid data is found
+	const uint8_t *data_header = tape_data.data() + p;
+	p += 4;
+
+	// sync on the inner (smaller) preamble
+	size_t d = p;
+	while (d + 1 < tape_data.size() && tape_data[d] == 0x00) {
+		d++;
+	}
+
+	constexpr size_t payload_size = 514;
+	if (d + 1 < tape_data.size() && tape_data[d] == 0xff && tape_data[d + 1] == 0xff)
+	{
+		d += 2;
+		if (d + payload_size > tape_data.size()) {
+			return true; // it seems ROM can produce header only sectors (orphans?)
+		}
+		if (slot >= 0) // if we see a data record before a header at start of tape, we skip it
+		{
+			uint8_t *sector = image + slot * MDV_SECTOR_LENGTH;
+
+			// first preamble + data header
+			sector[MDV_OFFSET_BLOCK_PREAMBLE + 10] = 0xff;
+			sector[MDV_OFFSET_BLOCK_PREAMBLE + 11] = 0xff;
+			memcpy(sector + MDV_OFFSET_BLOCK_HEADER, data_header, 4);
+
+			// inner smaller preamble, + payload
+			sector[MDV_OFFSET_DATA_PREAMBLE + 6] = 0xff;
+			sector[MDV_OFFSET_DATA_PREAMBLE + 7] = 0xff;
+			memcpy(sector + MDV_OFFSET_DATA, tape_data.data() + d, payload_size);
+		}
+		p = d + payload_size;
+	}
+	// no data record found: leave p after the block header
+	// and resync on the next preamble
+	return true;
+}
+
+bool read_tape_record(uint8_t *image, const std::vector<uint8_t> &tape_data,
+	int &slot, int &next_slot, size_t &p)
+{
+	if (p >= tape_data.size())
+	{
+		return false;
+	}
+
+	if (tape_data[p] == 0xff)
+	{
+		if (!read_tape_record_header(image, tape_data, slot, next_slot, p))
+		{
+			return false;
+		}
+	}
+	else if (!read_tape_record_data(image, tape_data, slot, p))
+	{
+		return false;
+	}
+	return true;
+}
+
+//-------------------------------------------------
+//  tape_to_image
+//  Reconstruct a QLAY format image from the internal tape timeline
+//  Data written by the ROM are not at specific positions on the tape
+//  So the tape is scanned, mimicking the way the ROM finds the data
+//  (using the erased parts (GAPs) and preambles.
+//-------------------------------------------------
+
+void microdrive_image_device::tape_to_image(uint8_t *image) const
+{
+	memset(image, 0, MDV_IMAGE_LENGTH);
+
+	// synchronize on the first not erased part and store the origin
+	// (because it's an infinite tape)
+	int origin_on_tape = 0;
+	for (int i = 0; i < MDV_TAPE_PAIRS; i++)
+	{
+		if (m_erased[i])
+		{
+			origin_on_tape = i;
+			break;
+		}
+	}
+
+	int slot = -1; // QLAY slot of the last sector header found (tape order)
+	int next_slot = 0;
+
+	int tape_index = 0;
+	while (tape_index < MDV_TAPE_PAIRS)
+	{
+		// forward to the next non-erased run
+		while (tape_index < MDV_TAPE_PAIRS && m_erased[(origin_on_tape + tape_index) % MDV_TAPE_PAIRS])
+		{
+			tape_index++;
+		}
+
+		// read the bytes from the two tracks into a flat buffer
+		std::vector<uint8_t> flat_data;
+		while (tape_index < MDV_TAPE_PAIRS && !m_erased[(origin_on_tape + tape_index) % MDV_TAPE_PAIRS])
+		{
+			const int pos = (origin_on_tape + tape_index) % MDV_TAPE_PAIRS;
+			flat_data.push_back(m_left[pos]);
+			flat_data.push_back(m_right[pos]);
+			tape_index++;
+		}
+
+		// parse the records from the flat data buffer
+		size_t p = 0;
+		while (p + 2 < flat_data.size())
+		{
+			// search preamble: zeros then the FF/FF sync pair
+			if (flat_data[p] == 0x00 && flat_data[p + 1] == 0xff && flat_data[p + 2] == 0xff)
+			{
+				p += 3; // point to the record
+				if (read_tape_record(image, flat_data, slot, next_slot, p))
+					break;
+			}
+			else
+			{
+				p++;
+			}
+		}
+	}
+}
+
+//-------------------------------------------------
+//  save_image - write the tape back to the file
+//-------------------------------------------------
+
+void microdrive_image_device::save_image()
+{
+	std::vector<uint8_t> image(MDV_IMAGE_LENGTH);
+	tape_to_image(image.data());
+	fseek(0, SEEK_SET);
+	fwrite(image.data(), MDV_IMAGE_LENGTH);
+	if (LOG) logerror("Microdrive '%s' image saved\n", tag());
 }
 
 std::pair<std::error_condition, std::string> microdrive_image_device::call_load()
 {
 	if (length() != MDV_IMAGE_LENGTH)
-		return std::make_pair(image_error::INVALIDLENGTH, std::string());
-
-	for (int i = 0; i < MDV_IMAGE_LENGTH / 2; i++)
 	{
-		fread(m_left.get() + i, 1);
-		fread(m_right.get() + i, 1);
+		return std::make_pair(image_error::INVALIDLENGTH, std::string());
 	}
+
+	std::vector<uint8_t> image(MDV_IMAGE_LENGTH);
+	if (fread(image.data(), MDV_IMAGE_LENGTH) != MDV_IMAGE_LENGTH)
+	{
+		return std::make_pair(std::errc::io_error, std::string());
+	}
+
+	tape_from_image(image.data());
 
 	m_bit_offset = 0;
 	m_byte_offset = 0;
 	m_clk = 0;
-	m_gap_ticks = 0;
+	m_gap_level = -1;
+	m_dirty = 0;
+
+	return std::make_pair(std::error_condition(), std::string());
+}
+
+std::pair<std::error_condition, std::string> microdrive_image_device::call_create(int format_type, util::option_resolution *format_options)
+{
+	const std::vector<uint8_t> image(MDV_IMAGE_LENGTH, 0);
+	if (fwrite(image.data(), MDV_IMAGE_LENGTH) != MDV_IMAGE_LENGTH)
+	{
+		return std::make_pair(std::errc::io_error, std::string());
+	}
+
+	// a blank image loads as a fully unformatted tape
+	tape_from_image(image.data());
+
+	m_bit_offset = 0;
+	m_byte_offset = 0;
+	m_clk = 0;
+	m_gap_level = -1;
+	m_dirty = 0;
 
 	return std::make_pair(std::error_condition(), std::string());
 }
@@ -116,30 +374,72 @@ void microdrive_image_device::call_unload()
 {
 	m_bit_timer->enable(false);
 
+	if (m_dirty && !is_readonly())
+	{
+		save_image();
+	}
+	m_dirty = 0;
+
 	// ejecting while the drive is selected leaves the head over nothing
 	if (m_comms_out)
+	{
 		m_write_gap_out(1);
+	}
 
-	if (m_left.get())
-		memset(m_left.get(), 0, MDV_IMAGE_LENGTH / 2);
-
-	if (m_right.get())
-		memset(m_right.get(), 0, MDV_IMAGE_LENGTH / 2);
+	if (m_erased)
+	{
+		memset(m_erased.get(), 1, MDV_TAPE_PAIRS);
+	}
+	if (m_left)
+	{
+		memset(m_left.get(), 0, MDV_TAPE_PAIRS);
+	}
+	if (m_right)
+	{
+		memset(m_right.get(), 0, MDV_TAPE_PAIRS);
+	}
 }
 
 TIMER_CALLBACK_MEMBER(microdrive_image_device::bit_timer)
 {
-	// Synthesized gap: the head is over an erased region
-	if (m_gap_ticks > 0)
+	if (m_read_write)
 	{
-		m_gap_ticks--;
-		if (m_gap_ticks == 0)
-			m_write_gap_out(0); // End of gap, preamble will follow
-		return;
+		// write (technically, it's erase + write because the erase
+		// head is ahead of writing head, here we don't care)
+		// every 8 bits, gets a byte paire from zx8302 and write
+		// it on tape.
+		if (m_bit_offset == 0)
+		{
+			const uint16_t pair = m_read_tx_pair();
+			m_left[m_byte_offset] = pair >> 8;
+			m_right[m_byte_offset] = pair & 0xff;
+			m_erased[m_byte_offset] = 0;
+			m_dirty = 1;
+		}
 	}
-
-	m_write_data1_out(BIT(m_left[m_byte_offset], 7 - m_bit_offset));
-	m_write_data2_out(BIT(m_right[m_byte_offset], 7 - m_bit_offset));
+	else if (m_erase)
+	{
+		// erase-only
+		m_left[m_byte_offset] = 0;
+		m_right[m_byte_offset] = 0;
+		m_erased[m_byte_offset] = 1;
+		m_dirty = 1;
+	}
+	else
+	{
+		// read mode
+		const int gap = m_erased[m_byte_offset] ? 1 : 0;
+		if (gap != m_gap_level)
+		{
+			m_gap_level = gap;
+			m_write_gap_out(gap);
+		}
+		if (!gap)
+		{
+			m_write_data1_out(BIT(m_left[m_byte_offset], 7 - m_bit_offset));
+			m_write_data2_out(BIT(m_right[m_byte_offset], 7 - m_bit_offset));
+		}
+	}
 
 	m_bit_offset++;
 
@@ -149,27 +449,8 @@ TIMER_CALLBACK_MEMBER(microdrive_image_device::bit_timer)
 		m_byte_offset++;
 
 		// Infinite loop of the tape
-		if (m_byte_offset == MDV_IMAGE_LENGTH / 2)
+		if (m_byte_offset == MDV_TAPE_PAIRS)
 			m_byte_offset = 0;
-
-		int sector_offset = m_byte_offset % (MDV_SECTOR_LENGTH / 2);
-
-		if (sector_offset == MDV_OFFSET_DATA_PREAMBLE / 2)
-		{
-			// Gap between the sector header and the block preamble
-			m_write_gap_out(1);
-			m_gap_ticks = MDV_GAP_BLOCK_TICKS;
-		}
-		else if (sector_offset == MDV_OFFSET_FILLER / 2)
-		{
-			// The QLAY filler replaces the erased part between sectors
-			// skip it and emit a gap
-			m_byte_offset += (MDV_SECTOR_LENGTH - MDV_OFFSET_FILLER) / 2;
-			if (m_byte_offset >= MDV_IMAGE_LENGTH / 2)
-				m_byte_offset = 0;
-			m_write_gap_out(1);
-			m_gap_ticks = MDV_GAP_SECTOR_TICKS;
-		}
 	}
 }
 
@@ -186,6 +467,7 @@ void microdrive_image_device::clk_w(int state)
 		if (m_comms_out && is_loaded())
 		{
 			if (LOG) logerror("Microdrive '%s' motor ON\n", tag());
+			m_gap_level = -1; // force a gap emission on the first tick
 			m_bit_timer->enable(true);
 		}
 		else if (m_comms_out && !is_loaded())
@@ -216,40 +498,34 @@ void microdrive_image_device::erase_w(int state)
 
 void microdrive_image_device::read_write_w(int state)
 {
-	if (LOG_COMMS) logerror("Microdrive '%s' READ/WRITE: %u (1=read)\n", tag(), state);
+	if (LOG_COMMS) logerror("Microdrive '%s' READ/WRITE: %u (1=write)\n", tag(), state);
 	m_read_write = state;
 }
 
 void microdrive_image_device::data1_w(int state)
 {
-	if (m_comms_out && !m_read_write)
-	{
-		// TODO
-	}
+	// unused: data goes through the bit timer, to remove
 }
 
 void microdrive_image_device::data2_w(int state)
 {
-	if (m_comms_out && !m_read_write)
-	{
-		// TODO
-	}
+	// unused: data goes through the bit timer, to remove
 }
 
-int microdrive_image_device::data1_r()
+int microdrive_image_device::data1_r() const
 {
 	int data = 0;
-	if (m_comms_out && m_read_write)
+	if (m_comms_out && !m_read_write && !m_erased[m_byte_offset])
 	{
 		data = BIT(m_left[m_byte_offset], 7 - m_bit_offset);
 	}
 	return data;
 }
 
-int microdrive_image_device::data2_r()
+int microdrive_image_device::data2_r() const
 {
 	int data = 0;
-	if (m_comms_out && m_read_write)
+	if (m_comms_out && !m_read_write && !m_erased[m_byte_offset])
 	{
 		data = BIT(m_right[m_byte_offset], 7 - m_bit_offset);
 	}

--- a/src/devices/imagedev/microdrv.h
+++ b/src/devices/imagedev/microdrv.h
@@ -38,6 +38,9 @@ public:
 	virtual ~microdrive_image_device();
 
 	auto comms_out_wr_callback() { return m_write_comms_out.bind(); }
+	auto data1_out_wr_callback() { return m_write_data1_out.bind(); }
+	auto data2_out_wr_callback() { return m_write_data2_out.bind(); }
+	auto gap_out_wr_callback() { return m_write_gap_out.bind(); }
 
 	// device_image_interface implementation
 	virtual std::pair<std::error_condition, std::string> call_load() override;
@@ -65,6 +68,9 @@ protected:
 
 private:
 	devcb_write_line m_write_comms_out;
+	devcb_write_line m_write_data1_out;
+	devcb_write_line m_write_data2_out;
+	devcb_write_line m_write_gap_out;
 
 	int m_clk;
 	int m_comms_in;
@@ -77,6 +83,7 @@ private:
 
 	int m_bit_offset;
 	int m_byte_offset;
+	int m_gap_ticks;
 
 	emu_timer *m_bit_timer;
 };

--- a/src/devices/imagedev/microdrv.h
+++ b/src/devices/imagedev/microdrv.h
@@ -41,12 +41,14 @@ public:
 	auto data1_out_wr_callback() { return m_write_data1_out.bind(); }
 	auto data2_out_wr_callback() { return m_write_data2_out.bind(); }
 	auto gap_out_wr_callback() { return m_write_gap_out.bind(); }
+	auto tx_pair_rd_callback() { return m_read_tx_pair.bind(); }
 
 	// device_image_interface implementation
 	virtual std::pair<std::error_condition, std::string> call_load() override;
 	virtual void call_unload() override;
+	virtual std::pair<std::error_condition, std::string> call_create(int format_type, util::option_resolution *format_options) override;
 
-	virtual bool is_creatable() const noexcept override { return false; }
+	virtual bool is_creatable() const noexcept override { return true; }
 	virtual const char *image_interface() const noexcept override { return "ql_cass"; }
 	virtual const char *file_extensions() const noexcept override { return "mdv,mdr"; }
 
@@ -57,8 +59,8 @@ public:
 	void read_write_w(int state);
 	void data1_w(int state);
 	void data2_w(int state);
-	int data1_r();
-	int data2_r();
+	int data1_r() const;
+	int data2_r() const;
 
 protected:
 	// device_t implementation
@@ -67,10 +69,15 @@ protected:
 	TIMER_CALLBACK_MEMBER(bit_timer);
 
 private:
+	void tape_from_image(const uint8_t *image);
+	void tape_to_image(uint8_t *image) const;
+	void save_image();
+
 	devcb_write_line m_write_comms_out;
 	devcb_write_line m_write_data1_out;
 	devcb_write_line m_write_data2_out;
 	devcb_write_line m_write_gap_out;
+	devcb_read16 m_read_tx_pair;
 
 	int m_clk;
 	int m_comms_in;
@@ -78,12 +85,15 @@ private:
 	int m_erase;
 	int m_read_write;
 
+	// tape timeline: one entry per byte pair position
 	std::unique_ptr<uint8_t[]> m_left;
 	std::unique_ptr<uint8_t[]> m_right;
+	std::unique_ptr<uint8_t[]> m_erased;
 
 	int m_bit_offset;
 	int m_byte_offset;
-	int m_gap_ticks;
+	int m_gap_level;
+	int m_dirty;
 
 	emu_timer *m_bit_timer;
 };

--- a/src/devices/imagedev/microdrv.h
+++ b/src/devices/imagedev/microdrv.h
@@ -16,14 +16,6 @@
 #include "magtape.h"
 
 
-//**************************************************************************
-//  INTERFACE CONFIGURATION MACROS
-//**************************************************************************
-
-#define MDV_1 "mdv1"
-#define MDV_2 "mdv2"
-
-
 /***************************************************************************
     TYPE DEFINITIONS
 ***************************************************************************/
@@ -35,7 +27,7 @@ class microdrive_image_device : public microtape_image_device
 public:
 	// construction/destruction
 	microdrive_image_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
-	virtual ~microdrive_image_device();
+	~microdrive_image_device() override = default;
 
 	auto comms_out_wr_callback() { return m_write_comms_out.bind(); }
 	auto data1_out_wr_callback() { return m_write_data1_out.bind(); }
@@ -44,27 +36,25 @@ public:
 	auto tx_pair_rd_callback() { return m_read_tx_pair.bind(); }
 
 	// device_image_interface implementation
-	virtual std::pair<std::error_condition, std::string> call_load() override;
-	virtual void call_unload() override;
-	virtual std::pair<std::error_condition, std::string> call_create(int format_type, util::option_resolution *format_options) override;
+	std::pair<std::error_condition, std::string> call_load() override;
+	void call_unload() override;
+	std::pair<std::error_condition, std::string> call_create(int format_type, util::option_resolution *format_options) override;
 
-	virtual bool is_creatable() const noexcept override { return true; }
-	virtual const char *image_interface() const noexcept override { return "ql_cass"; }
-	virtual const char *file_extensions() const noexcept override { return "mdv,mdr"; }
+	bool is_creatable() const noexcept override { return true; }
+	const char *image_interface() const noexcept override { return "ql_cass"; }
+	const char *file_extensions() const noexcept override { return "mdv,mdr"; }
 
 	// specific implementation
 	void clk_w(int state);
 	void comms_in_w(int state);
 	void erase_w(int state);
 	void read_write_w(int state);
-	void data1_w(int state);
-	void data2_w(int state);
 	int data1_r() const;
 	int data2_r() const;
 
 protected:
 	// device_t implementation
-	virtual void device_start() override ATTR_COLD;
+	void device_start() override ATTR_COLD;
 
 	TIMER_CALLBACK_MEMBER(bit_timer);
 
@@ -91,9 +81,9 @@ private:
 	std::unique_ptr<uint8_t[]> m_erased;
 
 	int m_bit_offset;
-	int m_byte_offset;
+	int m_byte_pair_offset;
 	int m_gap_level;
-	int m_dirty;
+	bool m_dirty;
 
 	emu_timer *m_bit_timer;
 };

--- a/src/mame/sinclair/ql.cpp
+++ b/src/mame/sinclair/ql.cpp
@@ -232,19 +232,20 @@ uint8_t ql_state::read(offs_t offset)
 	}
 	if (offset >= 0x18000 && offset <= 0x18003)
 	{
-		data = m_zx8302->rtc_r(offset & 0x03);
+		data = m_zx8302->rtc_r(offset & 0x03); // pc_clock
 	}
 	if (offset == 0x18020)
 	{
-		data = m_zx8302->status_r();
+		data = m_zx8302->status_r(); // pc_ipcrd
 	}
 	if (offset == 0x18021)
 	{
-		data = m_zx8302->irq_status_r();
+		data = m_zx8302->irq_status_r(); // pc_intr
 	}
 	if (offset >= 0x18022 && offset <= 0x18023)
 	{
-		data = m_zx8302->mdv_track_r();
+		// pc_trak1 (0x18022) and pc_trak2 (0x18023)
+		data = m_zx8302->mdv_track_r(offset & 1);
 	}
 	if (offset >= 0x20000 && offset < 0x40000)
 	{
@@ -279,27 +280,29 @@ void ql_state::write(offs_t offset, uint8_t data)
 {
 	if (offset >= 0x18000 && offset <= 0x18001)
 	{
+		// pc_clc0 (not implemented -> resets the clock)
+		// pc_clc1
 		m_zx8302->rtc_w(data);
 	}
 	if (offset == 0x18002)
 	{
-		m_zx8302->control_w(data);
+		m_zx8302->control_w(data); // pc_tctrl
 	}
 	if (offset == 0x18003)
 	{
-		m_zx8302->ipc_command_w(data);
+		m_zx8302->ipc_command_w(data); // pc_ipcwr
 	}
 	if (offset == 0x18020)
 	{
-		m_zx8302->mdv_control_w(data);
+		m_zx8302->mdv_control_w(data); // pc_mctrl
 	}
 	if (offset == 0x18021)
 	{
-		m_zx8302->irq_acknowledge_w(data);
+		m_zx8302->irq_acknowledge_w(data); // pc_intr
 	}
 	if (offset == 0x18022)
 	{
-		m_zx8302->data_w(data);
+		m_zx8302->data_w(data); // pc_tdata
 	}
 	if (offset == 0x18063)
 	{
@@ -949,8 +952,14 @@ void ql_state::ql(machine_config &config)
 	m_zx8302->in_raw2_callback().set(FUNC(ql_state::zx8302_raw2_r));
 
 	MICRODRIVE(config, m_mdv1);
-	m_mdv1->comms_out_wr_callback().set(m_mdv2, FUNC(microdrive_image_device::comms_in_w));
+	m_mdv1->comms_out_wr_callback().set(m_mdv2, FUNC(microdrive_image_device::comms_in_w)); // Select daisy chain mdv1 -> mdv2
+	m_mdv1->data1_out_wr_callback().set(m_zx8302, FUNC(zx8302_device::raw1_w));
+	m_mdv1->data2_out_wr_callback().set(m_zx8302, FUNC(zx8302_device::raw2_w));
+	m_mdv1->gap_out_wr_callback().set(m_zx8302, FUNC(zx8302_device::gap_w));
 	MICRODRIVE(config, m_mdv2);
+	m_mdv2->data1_out_wr_callback().set(m_zx8302, FUNC(zx8302_device::raw1_w));
+	m_mdv2->data2_out_wr_callback().set(m_zx8302, FUNC(zx8302_device::raw2_w));
+	m_mdv2->gap_out_wr_callback().set(m_zx8302, FUNC(zx8302_device::gap_w));
 
 	RS232_PORT(config, m_ser1, default_rs232_devices, nullptr); // wired as DCE
 	RS232_PORT(config, m_ser2, default_rs232_devices, nullptr); // wired as DTE

--- a/src/mame/sinclair/ql.cpp
+++ b/src/mame/sinclair/ql.cpp
@@ -10,7 +10,6 @@
 
     TODO:
 
-    - microdrive
     - ZX8301 memory access slowdown
     - use resnet.h to create palette
     - Tyche bios is broken

--- a/src/mame/sinclair/ql.cpp
+++ b/src/mame/sinclair/ql.cpp
@@ -956,10 +956,12 @@ void ql_state::ql(machine_config &config)
 	m_mdv1->data1_out_wr_callback().set(m_zx8302, FUNC(zx8302_device::raw1_w));
 	m_mdv1->data2_out_wr_callback().set(m_zx8302, FUNC(zx8302_device::raw2_w));
 	m_mdv1->gap_out_wr_callback().set(m_zx8302, FUNC(zx8302_device::gap_w));
+	m_mdv1->tx_pair_rd_callback().set(m_zx8302, FUNC(zx8302_device::mdv_tx_pop));
 	MICRODRIVE(config, m_mdv2);
 	m_mdv2->data1_out_wr_callback().set(m_zx8302, FUNC(zx8302_device::raw1_w));
 	m_mdv2->data2_out_wr_callback().set(m_zx8302, FUNC(zx8302_device::raw2_w));
 	m_mdv2->gap_out_wr_callback().set(m_zx8302, FUNC(zx8302_device::gap_w));
+	m_mdv2->tx_pair_rd_callback().set(m_zx8302, FUNC(zx8302_device::mdv_tx_pop));
 
 	RS232_PORT(config, m_ser1, default_rs232_devices, nullptr); // wired as DCE
 	RS232_PORT(config, m_ser2, default_rs232_devices, nullptr); // wired as DTE

--- a/src/mame/sinclair/ql.cpp
+++ b/src/mame/sinclair/ql.cpp
@@ -106,7 +106,6 @@ namespace {
 
 #define X1 XTAL(15'000'000)
 #define X2 XTAL(32'768)
-#define X3 XTAL_4_436MHz
 #define X4 XTAL(11'000'000)
 
 class ql_state : public driver_device
@@ -119,8 +118,8 @@ public:
 		m_zx8301(*this, ZX8301_TAG),
 		m_zx8302(*this, ZX8302_TAG),
 		m_speaker(*this, "speaker"),
-		m_mdv1(*this, MDV_1),
-		m_mdv2(*this, MDV_2),
+		m_mdv1(*this, "mdv1"),
+		m_mdv2(*this, "mdv2"),
 		m_ser1(*this, RS232_A_TAG),
 		m_ser2(*this, RS232_B_TAG),
 		m_ram(*this, RAM_TAG),
@@ -180,10 +179,6 @@ private:
 	void zx8302_mdselck_w(int state);
 	void zx8302_mdrdw_w(int state);
 	void zx8302_erase_w(int state);
-	void zx8302_raw1_w(int state);
-	int zx8302_raw1_r();
-	void zx8302_raw2_w(int state);
-	int zx8302_raw2_r();
 	void exp_extintl_w(int state);
 	void qimi_extintl_w(int state);
 
@@ -829,28 +824,6 @@ void ql_state::zx8302_erase_w(int state)
 	m_mdv2->erase_w(state);
 }
 
-void ql_state::zx8302_raw1_w(int state)
-{
-	m_mdv1->data1_w(state);
-	m_mdv2->data1_w(state);
-}
-
-int ql_state::zx8302_raw1_r()
-{
-	return m_mdv1->data1_r() | m_mdv2->data1_r();
-}
-
-void ql_state::zx8302_raw2_w(int state)
-{
-	m_mdv1->data2_w(state);
-	m_mdv2->data2_w(state);
-}
-
-int ql_state::zx8302_raw2_r()
-{
-	return m_mdv1->data2_r() | m_mdv2->data2_r();
-}
-
 void ql_state::update_interrupt()
 {
 	m_zx8302->extint_w(m_extintl || m_qimi_extint);
@@ -945,10 +918,6 @@ void ql_state::ql(machine_config &config)
 	m_zx8302->out_mdseld_callback().set(m_mdv1, FUNC(microdrive_image_device::comms_in_w));
 	m_zx8302->out_mdrdw_callback().set(FUNC(ql_state::zx8302_mdrdw_w));
 	m_zx8302->out_erase_callback().set(FUNC(ql_state::zx8302_erase_w));
-	m_zx8302->out_raw1_callback().set(FUNC(ql_state::zx8302_raw1_w));
-	m_zx8302->in_raw1_callback().set(FUNC(ql_state::zx8302_raw1_r));
-	m_zx8302->out_raw2_callback().set(FUNC(ql_state::zx8302_raw2_w));
-	m_zx8302->in_raw2_callback().set(FUNC(ql_state::zx8302_raw2_r));
 
 	MICRODRIVE(config, m_mdv1);
 	m_mdv1->comms_out_wr_callback().set(m_mdv2, FUNC(microdrive_image_device::comms_in_w)); // Select daisy chain mdv1 -> mdv2

--- a/src/mame/sinclair/zx8301.cpp
+++ b/src/mame/sinclair/zx8301.cpp
@@ -27,6 +27,7 @@
 //**************************************************************************
 
 #define LOG 0
+#define LOG_RAM 1
 
 
 // low resolution palette
@@ -214,6 +215,9 @@ uint8_t zx8301_device::data_r(offs_t offset)
 		m_cpu->spin_until_time(screen().time_until_pos(256, 0));
 	}
 
+	if (LOG_RAM && offset == 0x91C3)
+		logerror("ZX8301 RAM Read md_estat: %02x\n", readbyte(offset));
+
 	return readbyte(offset);
 }
 
@@ -230,6 +234,9 @@ void zx8301_device::data_w(offs_t offset, uint8_t data)
 	{
 		m_cpu->spin_until_time(screen().time_until_pos(256, 0));
 	}
+
+	if (LOG_RAM && offset == 0x91C3)
+		logerror("ZX8301 RAM Write md_estat: %02x\n", data);
 
 	writebyte(offset, data);
 }

--- a/src/mame/sinclair/zx8301.cpp
+++ b/src/mame/sinclair/zx8301.cpp
@@ -26,8 +26,10 @@
 //  MACROS / CONSTANTS
 //**************************************************************************
 
-#define LOG 0
-#define LOG_RAM 1
+#define LOG_RAM   (1U << 1)   // every RAM read/write access
+
+// #define VERBOSE (LOG_GENERAL)
+#include "logmacro.h"
 
 
 // low resolution palette
@@ -189,7 +191,7 @@ void zx8301_device::control_w(uint8_t data)
 
 	*/
 
-	if (LOG) logerror("ZX8301 Control: %02x\n", data);
+	LOG("Control: %02x\n", data);
 
 	// display off
 	m_dispoff = BIT(data, 1);
@@ -208,15 +210,12 @@ void zx8301_device::control_w(uint8_t data)
 
 uint8_t zx8301_device::data_r(offs_t offset)
 {
-	if (LOG) logerror("ZX8301 RAM Read: %06x\n", offset);
+	LOGMASKED(LOG_RAM, "RAM Read: %06x\n", offset);
 
 	if (m_vda)
 	{
 		m_cpu->spin_until_time(screen().time_until_pos(256, 0));
 	}
-
-	if (LOG_RAM && offset == 0x91C3)
-		logerror("ZX8301 RAM Read md_estat: %02x\n", readbyte(offset));
 
 	return readbyte(offset);
 }
@@ -228,15 +227,12 @@ uint8_t zx8301_device::data_r(offs_t offset)
 
 void zx8301_device::data_w(offs_t offset, uint8_t data)
 {
-	if (LOG) logerror("ZX8301 RAM Write: %06x = %02x\n", offset, data);
+	LOGMASKED(LOG_RAM, "RAM Write: %06x = %02x\n", offset, data);
 
 	if (m_vda)
 	{
 		m_cpu->spin_until_time(screen().time_until_pos(256, 0));
 	}
-
-	if (LOG_RAM && offset == 0x91C3)
-		logerror("ZX8301 RAM Write md_estat: %02x\n", data);
 
 	writebyte(offset, data);
 }

--- a/src/mame/sinclair/zx8302.cpp
+++ b/src/mame/sinclair/zx8302.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Curt Coder
+// copyright-holders:Curt Coder, Sylvain Glaize
 /**********************************************************************
 
     Sinclair ZX8302 emulation
@@ -18,8 +18,6 @@
 
 #include "emu.h"
 #include "zx8302.h"
-
-#include "imagedev/microdrv.h"
 
 #include <ctime>
 
@@ -146,10 +144,6 @@ zx8302_device::zx8302_device(const machine_config &mconfig, const char *tag, dev
 		m_out_mdseld_cb(*this),
 		m_out_mdrdw_cb(*this),
 		m_out_erase_cb(*this),
-		m_out_raw1_cb(*this),
-		m_in_raw1_cb(*this, 0),
-		m_out_raw2_cb(*this),
-		m_in_raw2_cb(*this, 0),
 		m_dtr1(0),
 		m_cts2(0),
 		m_idr(1),

--- a/src/mame/sinclair/zx8302.cpp
+++ b/src/mame/sinclair/zx8302.cpp
@@ -31,7 +31,9 @@
 //  MACROS / CONSTANTS
 //**************************************************************************
 
-#define LOG 0
+#define LOG     1
+#define LOG_IPC 1
+#define LOG_CLK 0
 
 
 // Monday 1st January 1979 00:00:00 UTC
@@ -95,7 +97,7 @@ inline void zx8302_device::transmit_ipc_data()
 	switch (m_ipc_state)
 	{
 	case IPC_START:
-		if (LOG) logerror("ZX8302 '%s' COMDATA Start Bit\n", tag());
+		if (LOG_IPC) logerror("ZX8302 '%s' COMDATA Start Bit\n", tag());
 
 		m_out_comdata_cb(BIT(m_idr, 0));
 		m_ipc_busy = 1;
@@ -103,7 +105,7 @@ inline void zx8302_device::transmit_ipc_data()
 		break;
 
 	case IPC_DATA:
-		if (LOG) logerror("ZX8302 '%s' COMDATA Data Bit: %x\n", tag(), BIT(m_idr, 1));
+		if (LOG_IPC) logerror("ZX8302 '%s' COMDATA Data Bit: %x\n", tag(), BIT(m_idr, 1));
 
 		m_comdata_to_ipc = BIT(m_idr, 1);
 		m_out_comdata_cb(m_comdata_to_ipc);
@@ -111,7 +113,7 @@ inline void zx8302_device::transmit_ipc_data()
 		break;
 
 	case IPC_STOP:
-		if (LOG) logerror("ZX8302 '%s' COMDATA Stop Bit\n", tag());
+		if (LOG_IPC) logerror("ZX8302 '%s' COMDATA Stop Bit\n", tag());
 
 		m_out_comdata_cb(BIT(m_idr, 2));
 		m_ipc_busy = 0;
@@ -151,8 +153,9 @@ zx8302_device::zx8302_device(const machine_config &mconfig, const char *tag, dev
 		m_cts2(0),
 		m_idr(1),
 		m_irq(0),
+		m_irq_mask(0),
 		m_ctr(time(nullptr) + RTC_BASE_ADJUST),
-		m_status(0),
+		m_status(STATUS_MICRODRIVE_GAP),
 		m_comdata_from_ipc(1),
 		m_comdata_to_cpu(1),
 		m_comdata_to_ipc(1),
@@ -160,7 +163,9 @@ zx8302_device::zx8302_device(const machine_config &mconfig, const char *tag, dev
 		m_ipc_state(0),
 		m_ipc_busy(0),
 		m_baudx4(0),
-		m_track(0)
+		m_mdv_shift{0, 0},
+		m_mdv_bit_count(0),
+		m_mdv_sync_state(MDV_SYNC_IDLE)
 {
 }
 
@@ -174,10 +179,8 @@ void zx8302_device::device_start()
 	// allocate timers
 	m_baudx4_timer = timer_alloc(FUNC(zx8302_device::baudx4_tick), this);
 	m_rtc_timer = timer_alloc(FUNC(zx8302_device::rtc_tick), this);
-	m_gap_timer = timer_alloc(FUNC(zx8302_device::trigger_gap_int), this);
 
 	m_rtc_timer->adjust(attotime::zero, 0, attotime::from_hz(m_rtc_clock / 32768));
-	m_gap_timer->adjust(attotime::zero, 0, attotime::from_msec(31));
 
 	// register for state saving
 	save_item(NAME(m_dtr1));
@@ -186,6 +189,7 @@ void zx8302_device::device_start()
 	save_item(NAME(m_tcr));
 	save_item(NAME(m_tdr));
 	save_item(NAME(m_irq));
+	save_item(NAME(m_irq_mask));
 	save_item(NAME(m_ctr));
 	save_item(NAME(m_status));
 	save_item(NAME(m_comdata_from_ipc));
@@ -196,7 +200,9 @@ void zx8302_device::device_start()
 	save_item(NAME(m_ipc_busy));
 	save_item(NAME(m_baudx4));
 	save_item(NAME(m_mdv_data));
-	save_item(NAME(m_track));
+	save_item(NAME(m_mdv_shift));
+	save_item(NAME(m_mdv_bit_count));
+	save_item(NAME(m_mdv_sync_state));
 }
 
 
@@ -213,11 +219,6 @@ TIMER_CALLBACK_MEMBER(zx8302_device::baudx4_tick)
 TIMER_CALLBACK_MEMBER(zx8302_device::rtc_tick)
 {
 	m_ctr++;
-}
-
-TIMER_CALLBACK_MEMBER(zx8302_device::trigger_gap_int)
-{
-	trigger_interrupt(INT_GAP);
 }
 
 
@@ -347,13 +348,23 @@ void zx8302_device::control_w(uint8_t data)
 //  mdv_track_r - microdrive track data
 //-------------------------------------------------
 
-uint8_t zx8302_device::mdv_track_r()
+uint8_t zx8302_device::mdv_track_r(offs_t offset)
 {
-	if (LOG) logerror("ZX8302 '%s' Microdrive Track %u: %02x\n", tag(), m_track, m_mdv_data[m_track]);
+	int track = offset & 1;
+	uint8_t data = m_mdv_data[track];
 
-	uint8_t data = m_mdv_data[m_track];
+	if (LOG)
+	{
+		static int s_mdv_read_count = 0;
+		logerror("ZX8302 '%s' MDV Track %u #%d: %02x (rxfull=%d)\n",
+			tag(), track + 1, s_mdv_read_count, data,
+			(m_status & STATUS_RX_BUFFER_FULL) ? 1 : 0);
+		s_mdv_read_count++;
+	}
 
-	m_track = !m_track;
+	// reading track 2 (pc_trak2) releases the buffer for the next byte pair
+	if (track == 1)
+		m_status &= ~STATUS_RX_BUFFER_FULL;
 
 	return data;
 }
@@ -384,10 +395,8 @@ uint8_t zx8302_device::status_r()
 
 	// TODO network port
 
-	// serial status
+	// serial + MDV status
 	data |= m_status;
-
-	// TODO microdrive GAP
 
 	// data terminal ready
 	data |= m_dtr1 << 4;
@@ -401,7 +410,7 @@ uint8_t zx8302_device::status_r()
 	// COMDATA
 	data |= m_comdata_to_cpu << 7;
 
-	if (LOG) logerror("ZX8302 '%s' Status: %02x\n", tag(), data);
+	if (LOG_IPC) logerror("ZX8302 '%s' Read Status: %02x\n", tag(), data);
 
 	return data;
 }
@@ -423,7 +432,7 @@ uint8_t zx8302_device::status_r()
 
 void zx8302_device::ipc_command_w(uint8_t data)
 {
-	if (LOG) logerror("ZX8302 '%s' IPC Command: %02x\n", tag(), data);
+	if (LOG_IPC) logerror("ZX8302 '%s' IPC Command: %02x\n", tag(), data);
 
 	m_idr = data;
 	m_ipc_state = IPC_START;
@@ -453,7 +462,7 @@ void zx8302_device::mdv_control_w(uint8_t data)
 
 	*/
 
-	if (LOG) logerror("ZX8302 '%s' Microdrive Control: %02x\n", tag(), data);
+	if (LOG_CLK) logerror("ZX8302 '%s' Microdrive Control: %02x\n", tag(), data);
 
 	m_out_mdseld_cb(BIT(data, 0));
 	m_out_mdselck_cb(BIT(data, 1));
@@ -462,7 +471,15 @@ void zx8302_device::mdv_control_w(uint8_t data)
 
 	if (BIT(data, 1))
 	{
+		// MDSELCK: clears RX buffer and arms preamble sync search.
+		// The ZX8302 hardware then waits for 0xFF/0xFF in the bit stream
+		// before delivering bytes to the CPU.
 		m_status &= ~STATUS_RX_BUFFER_FULL;
+		m_mdv_sync_state = MDV_SYNC_SEARCH;
+		m_mdv_bit_count = 0;
+		m_mdv_shift[0] = 0;
+		m_mdv_shift[1] = 0;
+		if (LOG) logerror("ZX8302 '%s' MDV sync armed (MDSELCK)\n", tag());
 	}
 }
 
@@ -473,7 +490,7 @@ void zx8302_device::mdv_control_w(uint8_t data)
 
 uint8_t zx8302_device::irq_status_r()
 {
-	if (LOG) logerror("ZX8302 '%s' Interrupt Status: %02x\n", tag(), m_irq);
+	if (LOG_IPC) logerror("ZX8302 '%s' Interrupt Status: %02x\n", tag(), m_irq);
 
 	return m_irq;
 }
@@ -485,13 +502,22 @@ uint8_t zx8302_device::irq_status_r()
 
 void zx8302_device::irq_acknowledge_w(uint8_t data)
 {
-	if (LOG) logerror("ZX8302 '%s' Interrupt Acknowledge: %02x\n", tag(), data);
+	if (LOG_CLK) logerror("ZX8302 '%s' Interrupt Acknowledge: %02x\n", tag(), data);
 
-	m_irq &= ~data;
+	// bits 7-5 are the interrupt mask, bits 4-0 clear pending interrupts
+	m_irq_mask = data & 0xe0;
+	m_irq &= ~(data & 0x1f);
 
 	if (!m_irq)
 	{
 		m_out_ipl1l_cb(CLEAR_LINE);
+	}
+
+	// The gap interrupt regenerates as long as the gap level is present and
+	// the mask is enabled. Minerva relies on this.
+	if ((m_irq_mask & MASK_GAP) && (m_status & STATUS_MICRODRIVE_GAP))
+	{
+		trigger_interrupt(INT_GAP);
 	}
 }
 
@@ -517,7 +543,7 @@ void zx8302_device::vsync_w(int state)
 {
 	if (state)
 	{
-		if (LOG) logerror("ZX8302 '%s' Frame Interrupt\n", tag());
+		if (LOG_CLK) logerror("ZX8302 '%s' Frame Interrupt\n", tag());
 
 		trigger_interrupt(INT_FRAME);
 	}
@@ -530,7 +556,7 @@ void zx8302_device::vsync_w(int state)
 
 void zx8302_device::comctl_w(int state)
 {
-	if (LOG) logerror("ZX8302 '%s' COMCTL: %x\n", tag(), state);
+	if (LOG_IPC) logerror("ZX8302 '%s' COMCTL: %x\n", tag(), state);
 
 	if (state)
 	{
@@ -548,7 +574,7 @@ void zx8302_device::comctl_w(int state)
 
 void zx8302_device::comdata_w(int state)
 {
-	if (LOG) logerror("ZX8302 '%s' COMDATA->CPU(pending): %x\n", tag(), state);
+	if (LOG_IPC) logerror("ZX8302 '%s' COMDATA->CPU(pending): %x\n", tag(), state);
 
 	m_comdata_from_ipc = state;
 }
@@ -582,4 +608,80 @@ void zx8302_device::write_dtr1(int state)
 void zx8302_device::write_cts2(int state)
 {
 	m_cts2 = state;
+}
+
+
+//-------------------------------------------------
+//  raw1_w - receive bit from microdrive track 1
+//-------------------------------------------------
+
+void zx8302_device::raw1_w(int state)
+{
+	m_mdv_shift[0] = (m_mdv_shift[0] << 1) | (state & 1);
+}
+
+
+//-------------------------------------------------
+//  raw2_w - receive bit from microdrive track 2.
+//-------------------------------------------------
+
+void zx8302_device::raw2_w(int state)
+{
+	m_mdv_shift[1] = (m_mdv_shift[1] << 1) | (state & 1);
+
+	switch (m_mdv_sync_state)
+	{
+	case MDV_SYNC_IDLE:
+		return;
+
+	case MDV_SYNC_SEARCH:
+		// The preamble is consumed, never delivered to the CPU.
+		if (m_mdv_shift[0] == 0xFF && m_mdv_shift[1] == 0xFF)
+		{
+			m_mdv_sync_state = MDV_SYNC_DELIVER;
+			m_mdv_bit_count = 0;
+			if (LOG) logerror("ZX8302 '%s' MDV preamble sync found\n", tag());
+		}
+		return;
+
+	case MDV_SYNC_DELIVER:
+		m_mdv_bit_count++;
+		if (m_mdv_bit_count < 8)
+			return;
+
+		m_mdv_bit_count = 0;
+		m_mdv_data[0] = m_mdv_shift[0];
+		m_mdv_data[1] = m_mdv_shift[1];
+		m_status |= STATUS_RX_BUFFER_FULL;
+
+		if (LOG)
+		{
+			static int s_mdv_byte_count = 0;
+			logerror("ZX8302 '%s' MDV byte#%d: t1=%02x t2=%02x\n",
+				tag(), s_mdv_byte_count, m_mdv_data[0], m_mdv_data[1]);
+			s_mdv_byte_count++;
+		}
+		return;
+	}
+}
+
+
+//-------------------------------------------------
+//  gap_w - gap signal from microdrive
+//-------------------------------------------------
+
+void zx8302_device::gap_w(int state)
+{
+	if (state)
+	{
+		if (LOG) logerror("ZX8302 '%s' MDV gap HIGH\n", tag());
+		m_status |= STATUS_MICRODRIVE_GAP;
+		if (m_irq_mask & MASK_GAP)
+			trigger_interrupt(INT_GAP);
+	}
+	else
+	{
+		if (LOG) logerror("ZX8302 '%s' MDV gap LOW\n", tag());
+		m_status &= ~STATUS_MICRODRIVE_GAP;
+	}
 }

--- a/src/mame/sinclair/zx8302.cpp
+++ b/src/mame/sinclair/zx8302.cpp
@@ -29,7 +29,12 @@
 //  MACROS / CONSTANTS
 //**************************************************************************
 
-#define LOG 1
+#define LOG_MDV (1U << 1)   // microdrive path
+#define LOG_IPC (1U << 2)   // IPC link per-bit (very high frequency)
+#define LOG_IRQ (1U << 3)   // Interrupts
+
+// #define VERBOSE (LOG_GENERAL | LOG_MDV)
+#include "logmacro.h"
 
 
 // Monday 1st January 1979 00:00:00 UTC
@@ -93,7 +98,7 @@ inline void zx8302_device::transmit_ipc_data()
 	switch (m_ipc_state)
 	{
 	case IPC_START:
-		if (LOG) logerror("ZX8302 '%s' COMDATA Start Bit\n", tag());
+		LOGMASKED(LOG_IPC, "COMDATA Start Bit\n");
 
 		m_out_comdata_cb(BIT(m_idr, 0));
 		m_ipc_busy = 1;
@@ -101,7 +106,7 @@ inline void zx8302_device::transmit_ipc_data()
 		break;
 
 	case IPC_DATA:
-		if (LOG) logerror("ZX8302 '%s' COMDATA Data Bit: %x\n", tag(), BIT(m_idr, 1));
+		LOGMASKED(LOG_IPC, "COMDATA Data Bit: %x\n", BIT(m_idr, 1));
 
 		m_comdata_to_ipc = BIT(m_idr, 1);
 		m_out_comdata_cb(m_comdata_to_ipc);
@@ -109,7 +114,7 @@ inline void zx8302_device::transmit_ipc_data()
 		break;
 
 	case IPC_STOP:
-		if (LOG) logerror("ZX8302 '%s' COMDATA Stop Bit\n", tag());
+		LOGMASKED(LOG_IPC, "COMDATA Stop Bit\n");
 
 		m_out_comdata_cb(BIT(m_idr, 2));
 		m_ipc_busy = 0;
@@ -320,7 +325,7 @@ uint8_t zx8302_device::rtc_r(offs_t offset)
 
 void zx8302_device::rtc_w(uint8_t data)
 {
-	if (LOG) logerror("ZX8302 '%s' Set Real Time Clock: %02x\n", tag(), data);
+	LOG("Set Real Time Clock: %02x\n", data);
 }
 
 
@@ -330,7 +335,7 @@ void zx8302_device::rtc_w(uint8_t data)
 
 void zx8302_device::control_w(uint8_t data)
 {
-	if (LOG) logerror("ZX8302 '%s' Transmit Control: %02x\n", tag(), data);
+	LOG("Transmit Control: %02x\n", data);
 
 	int baud = (19200 >> (data & BAUD_MASK));
 	int baudx4 = baud * 4;
@@ -353,12 +358,8 @@ uint8_t zx8302_device::mdv_track_r(offs_t offset)
 	const int track = offset & 1;
 	uint8_t data = m_mdv_data[track];
 
-	if (LOG)
-	{
-		logerror("ZX8302 '%s' MDV Track %u: %02x (rxfull=%d)\n",
-			tag(), track + 1, data,
-			(m_status & STATUS_RX_BUFFER_FULL) ? 1 : 0);
-	}
+	LOGMASKED(LOG_MDV, "MDV Track %u: %02x (rxfull=%d)\n",
+		track + 1, data, (m_status & STATUS_RX_BUFFER_FULL) ? 1 : 0);
 
 	if (!machine().side_effects_disabled())
 	{
@@ -413,7 +414,7 @@ uint8_t zx8302_device::status_r()
 	// COMDATA
 	data |= m_comdata_to_cpu << 7;
 
-	if (LOG) logerror("ZX8302 '%s' Read Status: %02x\n", tag(), data);
+	LOGMASKED(LOG_IPC, "Read Status: %02x\n", data);
 
 	return data;
 }
@@ -435,7 +436,7 @@ uint8_t zx8302_device::status_r()
 
 void zx8302_device::ipc_command_w(uint8_t data)
 {
-	if (LOG) logerror("ZX8302 '%s' IPC Command: %02x\n", tag(), data);
+	LOGMASKED(LOG_IPC, "IPC Command: %02x\n", data);
 
 	m_idr = data;
 	m_ipc_state = IPC_START;
@@ -465,7 +466,7 @@ void zx8302_device::mdv_control_w(uint8_t data)
 
 	*/
 
-	if (LOG) logerror("ZX8302 '%s' Microdrive Control: %02x\n", tag(), data);
+	LOGMASKED(LOG_MDV, "Microdrive Control: %02x\n", data);
 
 	m_out_mdseld_cb(BIT(data, 0));
 	m_out_mdselck_cb(BIT(data, 1));
@@ -482,7 +483,7 @@ void zx8302_device::mdv_control_w(uint8_t data)
 		m_mdv_bit_count = 0;
 		m_mdv_shift[0] = 0;
 		m_mdv_shift[1] = 0;
-		if (LOG) logerror("ZX8302 '%s' MDV sync armed (MDSELCK)\n", tag());
+		LOGMASKED(LOG_MDV, "MDV sync armed (MDSELCK)\n");
 	}
 
 	if (!BIT(data, 2))
@@ -522,7 +523,7 @@ uint16_t zx8302_device::mdv_tx_pop()
 
 uint8_t zx8302_device::irq_status_r()
 {
-	if (LOG) logerror("ZX8302 '%s' Interrupt Status: %02x\n", tag(), m_irq);
+	LOGMASKED(LOG_IRQ, "Interrupt Status: %02x\n", m_irq);
 
 	return m_irq;
 }
@@ -534,7 +535,7 @@ uint8_t zx8302_device::irq_status_r()
 
 void zx8302_device::irq_acknowledge_w(uint8_t data)
 {
-	if (LOG) logerror("ZX8302 '%s' Interrupt Acknowledge: %02x\n", tag(), data);
+	LOGMASKED(LOG_IRQ, "Interrupt Acknowledge: %02x\n", data);
 
 	// bits 7-5 are the interrupt mask, bits 4-0 clear pending interrupts
 	m_irq_mask = data & 0xe0;
@@ -560,7 +561,7 @@ void zx8302_device::irq_acknowledge_w(uint8_t data)
 
 void zx8302_device::data_w(uint8_t data)
 {
-	if (LOG) logerror("ZX8302 '%s' Data Register: %02x\n", tag(), data);
+	LOGMASKED(LOG_MDV, "Data Register: %02x\n", data);
 
 	if ((m_tcr & MODE_MASK) == MODE_MDV)
 	{
@@ -571,7 +572,7 @@ void zx8302_device::data_w(uint8_t data)
 		}
 		else
 		{
-			logerror("ZX8302 '%s' MDV TX overflow, byte %02x lost\n", tag(), data);
+			logerror("MDV TX overflow, byte %02x lost\n", data);
 		}
 
 		if (m_mdv_tx_count == 2)
@@ -596,7 +597,7 @@ void zx8302_device::vsync_w(int state)
 {
 	if (state)
 	{
-		if (LOG) logerror("ZX8302 '%s' Frame Interrupt\n", tag());
+		LOGMASKED(LOG_IRQ, "Frame Interrupt\n");
 
 		trigger_interrupt(INT_FRAME);
 	}
@@ -609,7 +610,7 @@ void zx8302_device::vsync_w(int state)
 
 void zx8302_device::comctl_w(int state)
 {
-	if (LOG) logerror("ZX8302 '%s' COMCTL: %x\n", tag(), state);
+	LOGMASKED(LOG_IPC, "COMCTL: %x\n", state);
 
 	if (state)
 	{
@@ -627,7 +628,7 @@ void zx8302_device::comctl_w(int state)
 
 void zx8302_device::comdata_w(int state)
 {
-	if (LOG) logerror("ZX8302 '%s' COMDATA->CPU(pending): %x\n", tag(), state);
+	LOGMASKED(LOG_IPC, "COMDATA->CPU(pending): %x\n", state);
 
 	m_comdata_from_ipc = state;
 }
@@ -639,7 +640,7 @@ void zx8302_device::comdata_w(int state)
 
 void zx8302_device::extint_w(int state)
 {
-	if (LOG) logerror("ZX8302 '%s' EXTINT: %x\n", tag(), state);
+	LOGMASKED(LOG_IRQ, "EXTINT: %x\n", state);
 
 	if (state == ASSERT_LINE)
 	{
@@ -693,7 +694,7 @@ void zx8302_device::raw2_w(int state)
 		{
 			m_mdv_sync_state = MDV_SYNC_DELIVER;
 			m_mdv_bit_count = 0;
-			if (LOG) logerror("ZX8302 '%s' MDV preamble sync found\n", tag());
+			LOGMASKED(LOG_MDV, "MDV preamble sync found\n");
 		}
 		return;
 
@@ -707,11 +708,7 @@ void zx8302_device::raw2_w(int state)
 		m_mdv_data[1] = m_mdv_shift[1];
 		m_status |= STATUS_RX_BUFFER_FULL;
 
-		if (LOG)
-		{
-			logerror("ZX8302 '%s' MDV byte: t1=%02x t2=%02x\n",
-				tag(), m_mdv_data[0], m_mdv_data[1]);
-		}
+		LOGMASKED(LOG_MDV, "MDV byte: t1=%02x t2=%02x\n", m_mdv_data[0], m_mdv_data[1]);
 	}
 }
 
@@ -724,14 +721,14 @@ void zx8302_device::gap_w(int state)
 {
 	if (state)
 	{
-		if (LOG) logerror("ZX8302 '%s' MDV gap HIGH\n", tag());
+		LOGMASKED(LOG_MDV, "MDV gap HIGH\n");
 		m_status |= STATUS_MICRODRIVE_GAP;
 		if (m_irq_mask & MASK_GAP)
 			trigger_interrupt(INT_GAP);
 	}
 	else
 	{
-		if (LOG) logerror("ZX8302 '%s' MDV gap LOW\n", tag());
+		LOGMASKED(LOG_MDV, "MDV gap LOW\n");
 		m_status &= ~STATUS_MICRODRIVE_GAP;
 	}
 }

--- a/src/mame/sinclair/zx8302.cpp
+++ b/src/mame/sinclair/zx8302.cpp
@@ -11,8 +11,6 @@
     TODO:
 
     - set time
-    - read from microdrive
-    - write to microdrive
     - DTR/CTS handling
     - network
 
@@ -31,9 +29,7 @@
 //  MACROS / CONSTANTS
 //**************************************************************************
 
-#define LOG     1
-#define LOG_IPC 1
-#define LOG_CLK 0
+#define LOG 1
 
 
 // Monday 1st January 1979 00:00:00 UTC
@@ -97,7 +93,7 @@ inline void zx8302_device::transmit_ipc_data()
 	switch (m_ipc_state)
 	{
 	case IPC_START:
-		if (LOG_IPC) logerror("ZX8302 '%s' COMDATA Start Bit\n", tag());
+		if (LOG) logerror("ZX8302 '%s' COMDATA Start Bit\n", tag());
 
 		m_out_comdata_cb(BIT(m_idr, 0));
 		m_ipc_busy = 1;
@@ -105,7 +101,7 @@ inline void zx8302_device::transmit_ipc_data()
 		break;
 
 	case IPC_DATA:
-		if (LOG_IPC) logerror("ZX8302 '%s' COMDATA Data Bit: %x\n", tag(), BIT(m_idr, 1));
+		if (LOG) logerror("ZX8302 '%s' COMDATA Data Bit: %x\n", tag(), BIT(m_idr, 1));
 
 		m_comdata_to_ipc = BIT(m_idr, 1);
 		m_out_comdata_cb(m_comdata_to_ipc);
@@ -113,7 +109,7 @@ inline void zx8302_device::transmit_ipc_data()
 		break;
 
 	case IPC_STOP:
-		if (LOG_IPC) logerror("ZX8302 '%s' COMDATA Stop Bit\n", tag());
+		if (LOG) logerror("ZX8302 '%s' COMDATA Stop Bit\n", tag());
 
 		m_out_comdata_cb(BIT(m_idr, 2));
 		m_ipc_busy = 0;
@@ -354,21 +350,24 @@ void zx8302_device::control_w(uint8_t data)
 
 uint8_t zx8302_device::mdv_track_r(offs_t offset)
 {
-	int track = offset & 1;
+	const int track = offset & 1;
 	uint8_t data = m_mdv_data[track];
 
 	if (LOG)
 	{
-		static int s_mdv_read_count = 0;
-		logerror("ZX8302 '%s' MDV Track %u #%d: %02x (rxfull=%d)\n",
-			tag(), track + 1, s_mdv_read_count, data,
+		logerror("ZX8302 '%s' MDV Track %u: %02x (rxfull=%d)\n",
+			tag(), track + 1, data,
 			(m_status & STATUS_RX_BUFFER_FULL) ? 1 : 0);
-		s_mdv_read_count++;
 	}
 
-	// reading track 2 (pc_trak2) releases the buffer for the next byte pair
-	if (track == 1)
-		m_status &= ~STATUS_RX_BUFFER_FULL;
+	if (!machine().side_effects_disabled())
+	{
+		if (track == 1)
+		{
+			// reading track 2 (pc_trak2) releases the buffer for the next byte pair
+			m_status &= ~STATUS_RX_BUFFER_FULL;
+		}
+	}
 
 	return data;
 }
@@ -414,7 +413,7 @@ uint8_t zx8302_device::status_r()
 	// COMDATA
 	data |= m_comdata_to_cpu << 7;
 
-	if (LOG_IPC) logerror("ZX8302 '%s' Read Status: %02x\n", tag(), data);
+	if (LOG) logerror("ZX8302 '%s' Read Status: %02x\n", tag(), data);
 
 	return data;
 }
@@ -436,7 +435,7 @@ uint8_t zx8302_device::status_r()
 
 void zx8302_device::ipc_command_w(uint8_t data)
 {
-	if (LOG_IPC) logerror("ZX8302 '%s' IPC Command: %02x\n", tag(), data);
+	if (LOG) logerror("ZX8302 '%s' IPC Command: %02x\n", tag(), data);
 
 	m_idr = data;
 	m_ipc_state = IPC_START;
@@ -466,7 +465,7 @@ void zx8302_device::mdv_control_w(uint8_t data)
 
 	*/
 
-	if (LOG_CLK) logerror("ZX8302 '%s' Microdrive Control: %02x\n", tag(), data);
+	if (LOG) logerror("ZX8302 '%s' Microdrive Control: %02x\n", tag(), data);
 
 	m_out_mdseld_cb(BIT(data, 0));
 	m_out_mdselck_cb(BIT(data, 1));
@@ -523,7 +522,7 @@ uint16_t zx8302_device::mdv_tx_pop()
 
 uint8_t zx8302_device::irq_status_r()
 {
-	if (LOG_IPC) logerror("ZX8302 '%s' Interrupt Status: %02x\n", tag(), m_irq);
+	if (LOG) logerror("ZX8302 '%s' Interrupt Status: %02x\n", tag(), m_irq);
 
 	return m_irq;
 }
@@ -535,7 +534,7 @@ uint8_t zx8302_device::irq_status_r()
 
 void zx8302_device::irq_acknowledge_w(uint8_t data)
 {
-	if (LOG_CLK) logerror("ZX8302 '%s' Interrupt Acknowledge: %02x\n", tag(), data);
+	if (LOG) logerror("ZX8302 '%s' Interrupt Acknowledge: %02x\n", tag(), data);
 
 	// bits 7-5 are the interrupt mask, bits 4-0 clear pending interrupts
 	m_irq_mask = data & 0xe0;
@@ -597,7 +596,7 @@ void zx8302_device::vsync_w(int state)
 {
 	if (state)
 	{
-		if (LOG_CLK) logerror("ZX8302 '%s' Frame Interrupt\n", tag());
+		if (LOG) logerror("ZX8302 '%s' Frame Interrupt\n", tag());
 
 		trigger_interrupt(INT_FRAME);
 	}
@@ -610,7 +609,7 @@ void zx8302_device::vsync_w(int state)
 
 void zx8302_device::comctl_w(int state)
 {
-	if (LOG_IPC) logerror("ZX8302 '%s' COMCTL: %x\n", tag(), state);
+	if (LOG) logerror("ZX8302 '%s' COMCTL: %x\n", tag(), state);
 
 	if (state)
 	{
@@ -628,7 +627,7 @@ void zx8302_device::comctl_w(int state)
 
 void zx8302_device::comdata_w(int state)
 {
-	if (LOG_IPC) logerror("ZX8302 '%s' COMDATA->CPU(pending): %x\n", tag(), state);
+	if (LOG) logerror("ZX8302 '%s' COMDATA->CPU(pending): %x\n", tag(), state);
 
 	m_comdata_from_ipc = state;
 }
@@ -710,12 +709,9 @@ void zx8302_device::raw2_w(int state)
 
 		if (LOG)
 		{
-			static int s_mdv_byte_count = 0;
-			logerror("ZX8302 '%s' MDV byte#%d: t1=%02x t2=%02x\n",
-				tag(), s_mdv_byte_count, m_mdv_data[0], m_mdv_data[1]);
-			s_mdv_byte_count++;
+			logerror("ZX8302 '%s' MDV byte: t1=%02x t2=%02x\n",
+				tag(), m_mdv_data[0], m_mdv_data[1]);
 		}
-		return;
 	}
 }
 

--- a/src/mame/sinclair/zx8302.cpp
+++ b/src/mame/sinclair/zx8302.cpp
@@ -165,7 +165,9 @@ zx8302_device::zx8302_device(const machine_config &mconfig, const char *tag, dev
 		m_baudx4(0),
 		m_mdv_shift{0, 0},
 		m_mdv_bit_count(0),
-		m_mdv_sync_state(MDV_SYNC_IDLE)
+		m_mdv_sync_state(MDV_SYNC_IDLE),
+		m_mdv_tx_buffer{0, 0},
+		m_mdv_tx_count(0)
 {
 }
 
@@ -203,6 +205,8 @@ void zx8302_device::device_start()
 	save_item(NAME(m_mdv_shift));
 	save_item(NAME(m_mdv_bit_count));
 	save_item(NAME(m_mdv_sync_state));
+	save_item(NAME(m_mdv_tx_buffer));
+	save_item(NAME(m_mdv_tx_count));
 }
 
 
@@ -481,6 +485,35 @@ void zx8302_device::mdv_control_w(uint8_t data)
 		m_mdv_shift[1] = 0;
 		if (LOG) logerror("ZX8302 '%s' MDV sync armed (MDSELCK)\n", tag());
 	}
+
+	if (!BIT(data, 2))
+	{
+		// write line dropped: drop current data
+		m_mdv_tx_count = 0;
+		m_status &= ~STATUS_TX_BUFFER_FULL;
+	}
+}
+
+
+//-------------------------------------------------
+//  mdv_tx_pop
+//
+//  gets the current written pair (or 0 if not entirely pushed yet)
+//  also resets the buffer
+//-------------------------------------------------
+
+uint16_t zx8302_device::mdv_tx_pop()
+{
+	uint16_t pair = 0;
+
+	if (m_mdv_tx_count == 2)
+	{
+		pair = (m_mdv_tx_buffer[0] << 8) | m_mdv_tx_buffer[1];
+		m_mdv_tx_count = 0;
+		m_status &= ~STATUS_TX_BUFFER_FULL;
+	}
+
+	return pair;
 }
 
 
@@ -530,6 +563,27 @@ void zx8302_device::data_w(uint8_t data)
 {
 	if (LOG) logerror("ZX8302 '%s' Data Register: %02x\n", tag(), data);
 
+	if ((m_tcr & MODE_MASK) == MODE_MDV)
+	{
+		// fills the write buffer for the microdrive
+		if (m_mdv_tx_count < 2)
+		{
+			m_mdv_tx_buffer[m_mdv_tx_count++] = data;
+		}
+		else
+		{
+			logerror("ZX8302 '%s' MDV TX overflow, byte %02x lost\n", tag(), data);
+		}
+
+		if (m_mdv_tx_count == 2)
+		{
+			m_status |= STATUS_TX_BUFFER_FULL;
+		}
+
+		return;
+	}
+
+	// previous code for other modes than microdrive
 	m_tdr = data;
 	m_status |= STATUS_TX_BUFFER_FULL;
 }

--- a/src/mame/sinclair/zx8302.h
+++ b/src/mame/sinclair/zx8302.h
@@ -62,10 +62,6 @@ public:
 	auto out_mdseld_callback() { return m_out_mdseld_cb.bind(); }
 	auto out_mdrdw_callback() { return m_out_mdrdw_cb.bind(); }
 	auto out_erase_callback() { return m_out_erase_cb.bind(); }
-	auto out_raw1_callback() { return m_out_raw1_cb.bind(); }
-	auto in_raw1_callback() { return m_in_raw1_cb.bind(); }
-	auto out_raw2_callback() { return m_out_raw2_cb.bind(); }
-	auto in_raw2_callback() { return m_in_raw2_cb.bind(); }
 
 	uint8_t rtc_r(offs_t offset);
 	void rtc_w(uint8_t data);
@@ -92,13 +88,13 @@ public:
 
 protected:
 	// device-level overrides
-	virtual void device_start() override ATTR_COLD;
+	void device_start() override ATTR_COLD;
 
 	// device_serial_interface overrides
-	virtual void tra_callback() override;
-	virtual void tra_complete() override;
-	virtual void rcv_callback() override;
-	virtual void rcv_complete() override;
+	void tra_callback() override;
+	void tra_complete() override;
+	void rcv_callback() override;
+	void rcv_complete() override;
 
 	TIMER_CALLBACK_MEMBER(baudx4_tick);
 	TIMER_CALLBACK_MEMBER(rtc_tick);
@@ -182,10 +178,6 @@ private:
 	devcb_write_line    m_out_mdseld_cb;
 	devcb_write_line    m_out_mdrdw_cb;
 	devcb_write_line    m_out_erase_cb;
-	devcb_write_line    m_out_raw1_cb;
-	devcb_read_line     m_in_raw1_cb;
-	devcb_write_line    m_out_raw2_cb;
-	devcb_read_line     m_in_raw2_cb;
 
 	int m_rs232_rx;
 	int m_dtr1;

--- a/src/mame/sinclair/zx8302.h
+++ b/src/mame/sinclair/zx8302.h
@@ -70,7 +70,7 @@ public:
 	uint8_t rtc_r(offs_t offset);
 	void rtc_w(uint8_t data);
 	void control_w(uint8_t data);
-	uint8_t mdv_track_r();
+	uint8_t mdv_track_r(offs_t offset);
 	uint8_t status_r();
 	void ipc_command_w(uint8_t data);
 	void mdv_control_w(uint8_t data);
@@ -85,6 +85,9 @@ public:
 	void write_netin(int state);
 	void write_dtr1(int state);
 	void write_cts2(int state);
+	void raw1_w(int state);
+	void raw2_w(int state);
+	void gap_w(int state);
 
 protected:
 	// device-level overrides
@@ -98,7 +101,6 @@ protected:
 
 	TIMER_CALLBACK_MEMBER(baudx4_tick);
 	TIMER_CALLBACK_MEMBER(rtc_tick);
-	TIMER_CALLBACK_MEMBER(trigger_gap_int);
 
 	inline void trigger_interrupt(uint8_t line);
 	inline void transmit_ipc_data();
@@ -144,10 +146,24 @@ private:
 
 	enum
 	{
+		MASK_GAP                = 0x20,
+		MASK_INTERFACE          = 0x40,
+		MASK_TRANSMIT           = 0x80
+	};
+
+	enum
+	{
 		STATUS_NETWORK_PORT     = 0x01,
 		STATUS_TX_BUFFER_FULL   = 0x02,
 		STATUS_RX_BUFFER_FULL   = 0x04,
 		STATUS_MICRODRIVE_GAP   = 0x08
+	};
+
+	enum
+	{
+		MDV_SYNC_IDLE    = 0, // not looking for data
+		MDV_SYNC_SEARCH  = 1, // searching for 0xFF/0xFF preamble end
+		MDV_SYNC_DELIVER = 2  // assembling and delivering bytes
 	};
 
 	int m_rtc_clock;              // the RTC clock (pin 30) of the chip
@@ -179,6 +195,7 @@ private:
 	uint8_t m_tcr;                    // transfer control register
 	uint8_t m_tdr;                    // transfer data register
 	uint8_t m_irq;                    // interrupt register
+	uint8_t m_irq_mask;               // interrupt mask register
 	uint32_t m_ctr;                   // counter register
 	uint8_t m_status;                 // status register
 
@@ -192,13 +209,14 @@ private:
 	int m_baudx4;                   // IPC baud x4
 
 	// microdrive state
-	uint8_t m_mdv_data[2];            // track data register
-	int m_track;                    // current track
+	uint8_t m_mdv_data[2];          // track data registers
+	uint8_t m_mdv_shift[2];         // bit shift registers for assembling bytes
+	int m_mdv_bit_count;            // bits received so far in current byte (DELIVER mode)
+	int m_mdv_sync_state;           // preamble sync state machine
 
 	// timers
 	emu_timer *m_baudx4_timer;      // baud x4 timer
 	emu_timer *m_rtc_timer;         // real time clock timer
-	emu_timer *m_gap_timer;         // microdrive gap timer
 };
 
 

--- a/src/mame/sinclair/zx8302.h
+++ b/src/mame/sinclair/zx8302.h
@@ -71,6 +71,7 @@ public:
 	void rtc_w(uint8_t data);
 	void control_w(uint8_t data);
 	uint8_t mdv_track_r(offs_t offset);
+	uint16_t mdv_tx_pop();
 	uint8_t status_r();
 	void ipc_command_w(uint8_t data);
 	void mdv_control_w(uint8_t data);
@@ -213,6 +214,8 @@ private:
 	uint8_t m_mdv_shift[2];         // bit shift registers for assembling bytes
 	int m_mdv_bit_count;            // bits received so far in current byte (DELIVER mode)
 	int m_mdv_sync_state;           // preamble sync state machine
+	uint8_t m_mdv_tx_buffer[2];     // microdrive transmit buffer (one byte pair)
+	int m_mdv_tx_count;             // bytes pending in the transmit buffer
 
 	// timers
 	emu_timer *m_baudx4_timer;      // baud x4 timer


### PR DESCRIPTION
Read, Write and Format are working with Minerva and JS ROMs at least.

Works with QLAY microdrive images.

No influence on IF1 Sinclair Interface, which is only stubbed.

Started as a continuation of previous work but then changed the internal representation to allow format/write.

Also did some cleaning/upgrade to the driver (but did not touch the serial communication and clock parts of the zx8302)

Interactively rebased/squashed the CLs to show the different steps.