### PR TITLE
frontend/mame/ui/filesel.cpp: Improved navigation in media selector

### DIFF
--- a/src/frontend/mame/ui/filesel.cpp
+++ b/src/frontend/mame/ui/filesel.cpp
@@ -23,6 +23,7 @@
 
 #include "util/corestr.h"
 #include "util/zippath.h"
+#include "util/path.h"
 
 #include "bus/midi/midiinport.h"
 #include "bus/midi/midioutport.h"
@@ -71,9 +72,10 @@ menu_file_selector::menu_file_selector(
 	, m_has_softlist(has_softlist)
 	, m_has_create(has_create)
 	, m_is_midi((image.device().type() == MIDIIN) || (image.device().type() == MIDIOUT))
+	, m_file_extensions(image.file_extensions() ? image.file_extensions() : "")
 	, m_clicked_directory(std::string::npos, std::string::npos)
 {
-	set_process_flags(PROCESS_IGNOREPAUSE);
+	set_process_flags(PROCESS_IGNOREPAUSE | PROCESS_LR_ALWAYS);
 }
 
 
@@ -97,7 +99,7 @@ void menu_file_selector::recompute_metrics(uint32_t width, uint32_t height, floa
 	m_path_layout.reset();
 	m_clicked_directory = std::make_pair(std::string::npos, std::string::npos);
 
-	set_custom_space(line_height() + 3.0F * tb_border(), 0.0F);
+	set_custom_space(2.0F * line_height() + 6.0F * tb_border(), 0.0F);
 }
 
 
@@ -107,7 +109,7 @@ void menu_file_selector::recompute_metrics(uint32_t width, uint32_t height, floa
 
 void menu_file_selector::custom_render(uint32_t flags, void *selectedref, float top, float bottom, float origx1, float origy1, float origx2, float origy2)
 {
-	// lay out extra text
+	// lay out breadcrumb text
 	if (!m_path_layout)
 	{
 		m_path_layout.emplace(create_layout());
@@ -120,16 +122,38 @@ void menu_file_selector::custom_render(uint32_t flags, void *selectedref, float 
 		m_path_layout->restyle(0, m_current_directory.length(), &fgcolor, &bgcolor);
 	}
 
-	// position this extra text
-	float x2, y2;
-	extra_text_position(origx1, origx2, origy1, top, *m_path_layout, -1, m_path_position.first, m_path_position.second, x2, y2);
+	// compute shared width: max of breadcrumb text, shortcut text, and menu
+	float const path_text_w = m_path_layout->actual_width();
+	float const menu_w = origx2 - origx1;
 
-	// draw a box
-	ui().draw_outlined_box(container(), m_path_position.first, m_path_position.second, x2, y2, ui().colors().background_color());
+	std::string combined;
+	m_shortcut_offsets.clear();
+	for (size_t i = 0; i < m_shortcuts.size(); i++)
+	{
+		if (i > 0)
+			combined += "   ";
+		size_t const start = combined.size();
+		combined += m_shortcuts[i].label;
+		m_shortcut_offsets.push_back({start, combined.size()});
+	}
+	m_shortcut_layout.emplace(create_layout());
+	m_shortcut_layout->add_text(combined);
+	float const sc_text_w = m_shortcuts.empty() ? 0.0F : m_shortcut_layout->actual_width();
 
-	// take off the borders
-	m_path_position.first += lr_border();
-	m_path_position.second += tb_border();
+	// all panels share the widest width
+	float const panel_w = std::max({path_text_w + 2.0F * lr_border(),
+	                                 sc_text_w + 2.0F * lr_border(),
+	                                 menu_w});
+	float const panel_x1 = 0.5F - 0.5F * panel_w;
+	float const panel_x2 = panel_x1 + panel_w;
+
+	// compute breadcrumb box
+	float const path_y1 = origy1 - top;
+	float const path_y2 = path_y1 + line_height() + 2.0F * tb_border();
+	m_path_position.first = panel_x1 + lr_border();
+	m_path_position.second = path_y1 + tb_border();
+
+	ui().draw_outlined_box(container(), panel_x1, path_y1, panel_x2, path_y2, ui().colors().background_color());
 
 	if (m_clicked_directory.second > m_clicked_directory.first)
 	{
@@ -159,8 +183,34 @@ void menu_file_selector::custom_render(uint32_t flags, void *selectedref, float 
 		}
 	}
 
-	// draw the text within it
+	// draw the breadcrumb text
 	m_path_layout->emit(container(), m_path_position.first, m_path_position.second);
+
+	// draw shortcut bar directly below breadcrumb box
+	if (!m_shortcuts.empty())
+	{
+		if (m_clicked_shortcut >= 0)
+		{
+			auto const &[off_start, off_end] = m_shortcut_offsets[m_clicked_shortcut];
+			rgb_t const fg = ui().colors().selected_color();
+			rgb_t const bg = ui().colors().selected_bg_color();
+			m_shortcut_layout->restyle(off_start, off_end - off_start, &fg, &bg);
+		}
+		else if (m_shortcut_mode || m_shortcut_armed)
+		{
+			auto const &[off_start, off_end] = m_shortcut_offsets[m_shortcut_focus];
+			rgb_t const fg = ui().colors().selected_color();
+			rgb_t const bg = ui().colors().selected_bg_color();
+			m_shortcut_layout->restyle(off_start, off_end - off_start, &fg, &bg);
+		}
+
+		float const sc_y1 = path_y2 + tb_border();
+		float const sc_y2 = sc_y1 + line_height() + 2.0F * tb_border();
+		ui().draw_outlined_box(container(), panel_x1, sc_y1, panel_x2, sc_y2, ui().colors().background_color());
+		m_shortcut_position.first = panel_x1 + lr_border();
+		m_shortcut_position.second = sc_y1 + tb_border();
+		m_shortcut_layout->emit(container(), m_shortcut_position.first, m_shortcut_position.second);
+	}
 }
 
 
@@ -207,21 +257,61 @@ std::tuple<int, bool, bool> menu_file_selector::custom_pointer_updated(bool chan
 		}
 	}
 
+	// track pointer after clicking a shortcut
+	if (m_clicked_shortcut >= 0)
+	{
+		if (ui_event::type::POINTER_ABORT == uievt.event_type)
+		{
+			m_clicked_shortcut = -1;
+			return std::make_tuple(IPT_INVALID, false, true);
+		}
+		else if (uievt.pointer_released & 0x01)
+		{
+			auto const [x, y] = pointer_location();
+			if (get_shortcut_at(x, y) == m_clicked_shortcut)
+				return std::make_tuple(IPT_CUSTOM, false, true);
+			m_clicked_shortcut = -1;
+			return std::make_tuple(IPT_INVALID, false, true);
+		}
+		else if (uievt.pointer_buttons & ~u32(1))
+		{
+			m_clicked_shortcut = -1;
+			return std::make_tuple(IPT_INVALID, false, true);
+		}
+		else
+		{
+			return std::make_tuple(IPT_INVALID, true, false);
+		}
+	}
+
 	// check for clicks if we have up-to-date content on-screen
-	if (m_path_layout && pointer_idle() && (uievt.pointer_buttons & 0x01) && !(uievt.pointer_buttons & ~u32(0x01)))
+	if (pointer_idle() && (uievt.pointer_buttons & 0x01) && !(uievt.pointer_buttons & ~u32(0x01)))
 	{
 		auto const [x, y] = pointer_location();
-		auto const [target_dir_start, target_dir_end] = get_directory_range(x, y);
-		if (target_dir_end > target_dir_start)
+		// check breadcrumb click
+		if (m_path_layout)
 		{
-			m_clicked_directory = std::make_pair(target_dir_start, target_dir_end);
-			return std::make_tuple(IPT_INVALID, true, true);
+			auto const [target_dir_start, target_dir_end] = get_directory_range(x, y);
+			if (target_dir_end > target_dir_start)
+			{
+				m_clicked_directory = std::make_pair(target_dir_start, target_dir_end);
+				return std::make_tuple(IPT_INVALID, true, true);
+			}
+		}
+		// check shortcut bar click
+		if (!m_shortcuts.empty())
+		{
+			int const sc = get_shortcut_at(x, y);
+			if (sc >= 0)
+			{
+				m_clicked_shortcut = sc;
+				return std::make_tuple(IPT_INVALID, true, true);
+			}
 		}
 	}
 
 	return std::make_tuple(IPT_INVALID, false, false);
 }
-
 
 //-------------------------------------------------
 //  menu_activated - menu has gained focus
@@ -230,6 +320,7 @@ std::tuple<int, bool, bool> menu_file_selector::custom_pointer_updated(bool chan
 void menu_file_selector::menu_activated()
 {
 	m_clicked_directory = std::make_pair(std::string::npos, std::string::npos);
+	m_clicked_shortcut = -1;
 }
 
 
@@ -279,10 +370,18 @@ menu_file_selector::file_selector_entry *menu_file_selector::append_dirent_entry
 	switch (dirent->type)
 	{
 	case osd::directory::entry::entry_type::FILE:
+		if (m_filter_extensions && !is_archive(dirent->name) && !extension_matches(dirent->name))
+			return nullptr;
 		entry_type = SELECTOR_ENTRY_TYPE_FILE;
 		break;
 
 	case osd::directory::entry::entry_type::DIR:
+		if (m_filter_extensions && !m_file_extensions.empty() && strcmp(dirent->name, "..") && !is_volume_root(m_current_directory))
+		{
+			std::string const dir_path = util::zippath_combine(m_current_directory, dirent->name);
+			if (!directory_has_matching_files(dir_path, 1))
+				return nullptr;
+		}
 		entry_type = SELECTOR_ENTRY_TYPE_DIRECTORY;
 		break;
 
@@ -335,6 +434,10 @@ void menu_file_selector::append_entry_menu_item(const file_selector_entry *entry
 			subtext = "[DRIVE]";
 			break;
 
+		case SELECTOR_ENTRY_TYPE_HOME:
+			text = _("[home]");
+			break;
+
 		case SELECTOR_ENTRY_TYPE_DIRECTORY:
 			text = entry->basename;
 			subtext = "[DIR]";
@@ -374,6 +477,7 @@ void menu_file_selector::select_item(const file_selector_entry &entry)
 		break;
 
 	case SELECTOR_ENTRY_TYPE_DRIVE:
+	case SELECTOR_ENTRY_TYPE_HOME:
 	case SELECTOR_ENTRY_TYPE_DIRECTORY:
 		{
 			// drive/directory - first check the path
@@ -402,45 +506,142 @@ void menu_file_selector::select_item(const file_selector_entry &entry)
 
 
 //-------------------------------------------------
+//  extension_matches - check if filename has one
+//  of the configured extensions
+//-------------------------------------------------
+
+bool menu_file_selector::extension_matches(std::string_view filename) const
+{
+	if (m_file_extensions.empty())
+		return true;
+
+	auto const dot = filename.rfind('.');
+	if (dot == std::string_view::npos)
+		return false;
+
+	std::string_view const ext = filename.substr(dot + 1);
+
+	std::string_view exts(m_file_extensions);
+	while (!exts.empty())
+	{
+		auto const comma = exts.find(',');
+		std::string_view const cur = exts.substr(0, comma);
+		if (cur.length() == ext.length())
+		{
+			bool match = true;
+			for (size_t i = 0; i < ext.length(); ++i)
+			{
+				if (std::tolower(static_cast<unsigned char>(cur[i])) != std::tolower(static_cast<unsigned char>(ext[i])))
+				{
+					match = false;
+					break;
+				}
+			}
+			if (match)
+				return true;
+		}
+		exts = (comma == std::string_view::npos) ? std::string_view() : exts.substr(comma + 1);
+	}
+
+	return false;
+}
+
+//-------------------------------------------------
+//  is_volume_root - check if path is a drive/volume
+//-------------------------------------------------
+
+bool menu_file_selector::is_volume_root(std::string_view path) const
+{
+	for (std::string const &vol : osd_get_volume_names())
+		if (path == vol)
+			return true;
+	return false;
+}
+
+//-------------------------------------------------
+//  is_archive - check if filename is a known
+//  archive type (zip, imz, 7z)
+//-------------------------------------------------
+
+bool menu_file_selector::is_archive(std::string_view filename)
+{
+	return core_filename_ends_with(filename, ".zip") ||
+		core_filename_ends_with(filename, ".imz") ||
+		core_filename_ends_with(filename, ".7z");
+}
+
+//-------------------------------------------------
+//  search_rank - rank filename against query
+//  returns 0 = no match, 1 = prefix, 2 = subsequence
+//-------------------------------------------------
+
+int menu_file_selector::search_rank(std::string_view name, std::string_view query)
+{
+	if (query.empty())
+		return 1;
+
+	auto const last_sep = name.find_last_of(PATH_SEPARATOR);
+	std::string_view const base = (last_sep != std::string_view::npos)
+		? name.substr(last_sep + 1)
+		: name;
+
+	// prefix match (case-insensitive) -> top group
+	if (base.size() >= query.size() && !core_strnicmp(base.data(), query.data(), query.size()))
+		return 1;
+
+	// subsequence match (ordered, case-insensitive) -> bottom group
+	size_t qi = 0;
+	for (size_t ni = 0; ni < base.size() && qi < query.size(); ++ni)
+	{
+		if (tolower(base[ni]) == tolower(query[qi]))
+			++qi;
+	}
+	return (qi == query.size()) ? 2 : 0;
+}
+
+//-------------------------------------------------
+//  directory_has_matching_files - check if a
+//  directory contains any files matching the
+//  extension filter, recursing into subdirectories
+//-------------------------------------------------
+
+bool menu_file_selector::directory_has_matching_files(std::string_view path, int depth) const
+{
+	if (depth > DIR_CHECK_MAX_DEPTH)
+		return true; // tree deeper than MAX_DEPTH - might contain matching files
+
+	auto dir = osd::directory::open(std::string(path));
+	if (!dir)
+		return false;
+
+	while (osd::directory::entry const *const dirent = dir->read())
+	{
+		if (!strcmp(dirent->name, ".") || !strcmp(dirent->name, ".."))
+			continue;
+
+		if (dirent->type == osd::directory::entry::entry_type::FILE)
+		{
+			if (extension_matches(dirent->name))
+				return true;
+		}
+		else if (dirent->type == osd::directory::entry::entry_type::DIR)
+		{
+			std::string const subpath = util::zippath_combine(std::string(path), dirent->name);
+			if (directory_has_matching_files(subpath, depth + 1))
+				return true;
+		}
+	}
+
+	return false;
+}
+
+//-------------------------------------------------
 //  update_search
 //-------------------------------------------------
 
 void menu_file_selector::update_search()
 {
-	ui().popup_time(ERROR_MESSAGE_TIME, "%s", m_filename);
-
-	file_selector_entry const *const cur_selected(reinterpret_cast<file_selector_entry const *>(get_selection_ref()));
-
-	// if it's a perfect match for the current selection, don't move it
-	if (!cur_selected || core_strnicmp(cur_selected->basename.c_str(), m_filename.c_str(), m_filename.size()))
-	{
-		std::string::size_type bestmatch(0);
-		file_selector_entry const *selected_entry(cur_selected);
-		for (auto &entry : m_entrylist)
-		{
-			// TODO: more efficient "common prefix" code
-			std::string::size_type match(0);
-			for (std::string::size_type i = 1; m_filename.size() >= i; ++i)
-			{
-				if (!core_strnicmp(entry.basename.c_str(), m_filename.c_str(), i))
-					match = i;
-				else
-					break;
-			}
-
-			if (match > bestmatch)
-			{
-				bestmatch = match;
-				selected_entry = &entry;
-			}
-		}
-
-		if (selected_entry && (selected_entry != cur_selected))
-		{
-			set_selection((void *)selected_entry);
-			centre_selection();
-		}
-	}
+	reset(reset_options::REMEMBER_POSITION);
 }
 
 
@@ -472,6 +673,98 @@ std::pair<size_t, size_t> menu_file_selector::get_directory_range(float x, float
 	return std::make_pair(std::string::npos, std::string::npos);
 }
 
+//-------------------------------------------------
+//  get_shortcut_at - hit-test shortcut bar
+//  returns shortcut index or -1
+//-------------------------------------------------
+
+int menu_file_selector::get_shortcut_at(float x, float y)
+{
+	if (m_shortcuts.empty() || !m_shortcut_layout)
+		return -1;
+
+	size_t start = 0, span = 0;
+	if (m_shortcut_layout->hit_test(x - m_shortcut_position.first, y - m_shortcut_position.second, start, span))
+	{
+		for (size_t i = 0; i < m_shortcut_offsets.size(); i++)
+		{
+			if (start >= m_shortcut_offsets[i].first && (start + span) <= m_shortcut_offsets[i].second)
+				return int(i);
+		}
+	}
+	return -1;
+}
+
+
+//-------------------------------------------------
+//  auto_descend - skip through chains of single-
+//  subdirectory folders with no relevant content
+//-------------------------------------------------
+
+bool menu_file_selector::auto_descend()
+{
+	bool const navigating_up = !m_prev_directory.empty() &&
+		m_current_directory.length() < m_prev_directory.length();
+	if (navigating_up)
+		return false;
+
+	if (is_volume_root(m_current_directory))
+		return false;
+
+	bool descended = false;
+	for (;;)
+	{
+		auto dir = osd::directory::open(m_current_directory);
+		if (!dir)
+			break;
+
+		int subdir_count = 0;
+		std::string subdir_name;
+		bool has_content = false;
+
+		while (osd::directory::entry const *const dirent = dir->read())
+		{
+			if (!strcmp(dirent->name, ".") || !strcmp(dirent->name, ".."))
+				continue;
+
+			if (dirent->type == osd::directory::entry::entry_type::FILE)
+			{
+				if (!m_filter_extensions || extension_matches(dirent->name))
+				{
+					has_content = true;
+					break;
+				}
+			}
+			else if (dirent->type == osd::directory::entry::entry_type::DIR)
+			{
+				// with extension filter on, only count subdirs that have matching content
+				if (m_filter_extensions && !m_file_extensions.empty())
+				{
+					std::string const subpath = util::zippath_combine(m_current_directory, dirent->name);
+					if (!directory_has_matching_files(subpath, 1))
+						continue;
+				}
+				subdir_count++;
+				if (subdir_count == 1)
+					subdir_name = dirent->name;
+				else
+					break;
+			}
+		}
+		dir.reset();
+
+		if (!has_content && subdir_count == 1)
+		{
+			m_current_directory = util::zippath_combine(m_current_directory, subdir_name);
+			m_path_layout.reset();
+			descended = true;
+		}
+		else
+			break;
+	}
+
+	return descended;
+}
 
 //-------------------------------------------------
 //  populate
@@ -483,31 +776,59 @@ void menu_file_selector::populate()
 
 	// clear out the menu entries
 	m_entrylist.clear();
+	auto_descend();
+
 
 	// open the directory
 	util::zippath_directory::ptr directory;
 	std::error_condition const err = util::zippath_directory::open(m_current_directory, directory);
 
-	// add the "[empty slot]" entry if available
+	// collect special entries into shortcut bar instead of the file list
+	m_shortcuts.clear();
 	if (m_has_empty)
-		append_entry(SELECTOR_ENTRY_TYPE_EMPTY, "", "");
-
-	// add the "[midi port]" entry if available
+		m_shortcuts.push_back({ SELECTOR_ENTRY_TYPE_EMPTY, _("[empty slot]"), "" });
 	if (m_is_midi)
-		append_entry(SELECTOR_ENTRY_TYPE_MIDI, "", "");
-
-	// add the "[create]" entry
+		m_shortcuts.push_back({ SELECTOR_ENTRY_TYPE_MIDI, _("[MIDI port]"), "" });
 	if (m_has_create && directory && !directory->is_archive())
-		append_entry(SELECTOR_ENTRY_TYPE_CREATE, "", "");
-
-	// add and select the "[software list]" entry if available
+		m_shortcuts.push_back({ SELECTOR_ENTRY_TYPE_CREATE, _("[create]"), "" });
 	if (m_has_softlist)
-		selected_entry = &append_entry(SELECTOR_ENTRY_TYPE_SOFTWARE_LIST, "", "");
-
-	// add the drives
+		m_shortcuts.push_back({ SELECTOR_ENTRY_TYPE_SOFTWARE_LIST, _("[software list]"), "" });
 	for (std::string const &volume_name : osd_get_volume_names())
-		append_entry(SELECTOR_ENTRY_TYPE_DRIVE, volume_name, volume_name);
+		m_shortcuts.push_back({ SELECTOR_ENTRY_TYPE_DRIVE, volume_name, volume_name });
 
+	char const *home = osd_getenv("HOME");
+	if (!home || !*home)
+		home = osd_getenv("USERPROFILE");
+	if (home && *home)
+		m_shortcuts.push_back({ SELECTOR_ENTRY_TYPE_HOME, std::string(_("[home]")), home });
+
+	if (m_shortcut_focus >= int(m_shortcuts.size()))
+		m_shortcut_focus = std::max(0, int(m_shortcuts.size()) - 1);
+
+	std::string heading_text = m_filename.empty()
+		? std::string(_("File Manager"))
+		: util::string_format(_("Search: %1$s_"), m_filename);
+	float panel_text_w = get_string_width(m_current_directory);
+	std::string combined;
+	for (size_t i = 0; i < m_shortcuts.size(); i++)
+	{
+		if (i > 0)
+			combined += "   ";
+		combined += m_shortcuts[i].label;
+	}
+	panel_text_w = std::max(panel_text_w, get_string_width(combined));
+	float heading_w = get_string_width(heading_text);
+	if (heading_w < panel_text_w)
+	{
+		float space_w = get_string_width(" ");
+		if (space_w > 0.0F)
+		{
+			int padding = int((panel_text_w - heading_w) / space_w / 2) + 1;
+			std::string pad(padding, ' ');
+			heading_text = pad + heading_text + pad;
+		}
+	}
+	set_heading(std::move(heading_text));
 	// mark first filename entry
 	std::size_t const first = m_entrylist.size() + 1;
 
@@ -538,32 +859,100 @@ void menu_file_selector::populate()
 	}
 	directory.reset();
 
+	bool const searching = !m_filename.empty();
 	if (m_entrylist.size() > first)
 	{
-		// sort the menu entries
 		std::locale const lcl;
 		std::collate<wchar_t> const &coll = std::use_facet<std::collate<wchar_t> >(lcl);
+		auto collator = [&coll] (file_selector_entry const &x, file_selector_entry const &y)
+		{
+			std::wstring const xstr = wstring_from_utf8(x.basename);
+			std::wstring const ystr = wstring_from_utf8(y.basename);
+			return coll.compare(xstr.data(), xstr.data() + xstr.size(), ystr.data(), ystr.data() + ystr.size()) < 0;
+		};
 		std::sort(
 				m_entrylist.begin() + first,
 				m_entrylist.end(),
-				[&coll] (file_selector_entry const &x, file_selector_entry const &y)
+				[&] (file_selector_entry const &x, file_selector_entry const &y)
 				{
-					std::wstring const xstr = wstring_from_utf8(x.basename);
-					std::wstring const ystr = wstring_from_utf8(y.basename);
-					return coll.compare(xstr.data(), xstr.data() + xstr.size(), ystr.data(), ystr.data() + ystr.size()) < 0;
+					if (searching)
+					{
+						int const rx = search_rank(x.basename, m_filename);
+						int const ry = search_rank(y.basename, m_filename);
+						if (rx != ry)
+							return rx < ry;
+					}
+					bool const x_is_dir = (x.type == SELECTOR_ENTRY_TYPE_DIRECTORY || x.type == SELECTOR_ENTRY_TYPE_DRIVE || x.type == SELECTOR_ENTRY_TYPE_HOME);
+					bool const y_is_dir = (y.type == SELECTOR_ENTRY_TYPE_DIRECTORY || y.type == SELECTOR_ENTRY_TYPE_DRIVE || y.type == SELECTOR_ENTRY_TYPE_HOME);
+					if (x_is_dir != y_is_dir)
+						return x_is_dir;
+					return collator(x, y);
 				});
 	}
 
-	// append all of the menu entries
+	// append all of the menu entries, applying search filter if active
 	for (file_selector_entry const &entry : m_entrylist)
+	{
+		bool const is_special = (entry.type != SELECTOR_ENTRY_TYPE_FILE &&
+		                         entry.type != SELECTOR_ENTRY_TYPE_DIRECTORY);
+		if (searching && !is_special)
+		{
+			if (search_rank(entry.basename, m_filename) == 0)
+				continue;
+		}
 		append_entry_menu_item(&entry);
+	}
 	item_append(menu_item_type::SEPARATOR);
 
 	// set the selection (if we have one)
 	if (selected_entry)
 		set_selection((void *)selected_entry);
+
+	m_prev_directory = m_current_directory;
 }
 
+
+//-------------------------------------------------
+bool menu_file_selector::handle_keys(uint32_t flags, int &iptkey)
+{
+	if (m_shortcut_mode)
+	{
+		if ((iptkey == IPT_INVALID) && exclusive_input_pressed(iptkey, IPT_UI_UP, 6))
+		{
+			m_shortcut_mode = false;
+			m_shortcut_armed = false;
+			select_last_item();
+			return true;
+		}
+		if ((iptkey == IPT_INVALID) && exclusive_input_pressed(iptkey, IPT_UI_DOWN, 6))
+		{
+			m_shortcut_mode = false;
+			m_shortcut_armed = false;
+			select_first_item();
+			return true;
+		}
+	}
+	else if (!m_shortcuts.empty() && (iptkey == IPT_INVALID))
+	{
+		if (is_first_selected() && exclusive_input_pressed(iptkey, IPT_UI_UP, 6))
+		{
+			m_shortcut_mode = true;
+			m_shortcut_armed = true;
+			return true;
+		}
+		if (is_last_selected() && exclusive_input_pressed(iptkey, IPT_UI_DOWN, 6))
+		{
+			m_shortcut_mode = true;
+			m_shortcut_armed = true;
+			return true;
+		}
+	}
+
+	if (m_shortcut_armed && (iptkey == IPT_INVALID) && exclusive_input_pressed(iptkey, IPT_UI_SELECT, 0))
+		return true;
+
+	return menu::handle_keys(flags, iptkey);
+}
 
 //-------------------------------------------------
 //  handle
@@ -593,11 +982,50 @@ bool menu_file_selector::handle(event const *ev)
 	}
 	else if (ev->iptkey == IPT_UI_CANCEL)
 	{
-		// reset the char buffer also in this case
+		// if search filter is active, clear it and repopulate
 		if (!m_filename.empty())
 		{
 			m_filename.clear();
-			ui().popup_time(ERROR_MESSAGE_TIME, "%s", m_filename);
+			update_search();
+			return true;
+		}
+	}
+	else if (ev->iptkey == IPT_UI_LEFT && !m_shortcuts.empty())
+	{
+		m_shortcut_armed = true;
+		m_shortcut_focus = (m_shortcut_focus - 1 + int(m_shortcuts.size())) % int(m_shortcuts.size());
+		return true;
+	}
+	else if (ev->iptkey == IPT_UI_RIGHT && !m_shortcuts.empty())
+	{
+		m_shortcut_armed = true;
+		m_shortcut_focus = (m_shortcut_focus + 1) % int(m_shortcuts.size());
+		return true;
+	}
+	else if (ev->iptkey == IPT_UI_CLEAR)
+	{
+		if (!m_filename.empty())
+		{
+			m_filename.clear();
+			reset(reset_options::REMEMBER_POSITION);
+			return true;
+		}
+		else if (!m_file_extensions.empty())
+		{
+			m_filter_extensions = !m_filter_extensions;
+			if (m_filter_extensions)
+			{
+				ui().popup_time(3, "%s", util::string_format(
+					"%s\n%s\n%s",
+					util::string_format(_("Filter: %s"), _("on")),
+					util::string_format(_("Extensions: %s"), m_file_extensions),
+					util::string_format(_("Scan depth: %d"), DIR_CHECK_MAX_DEPTH)));
+			}
+			else
+			{
+				ui().popup_time(3, "%s", util::string_format(_("Filter: %s"), _("off")));
+			}
+			reset(reset_options::REMEMBER_POSITION);
 			return true;
 		}
 	}
@@ -612,14 +1040,46 @@ bool menu_file_selector::handle(event const *ev)
 			reset(reset_options::SELECT_FIRST);
 			return true;
 		}
-	}
-	else if (ev->itemref && (ev->iptkey == IPT_UI_SELECT))
-	{
-		// reset search when selecting an item
-		m_filename.clear();
 
-		select_item(*reinterpret_cast<file_selector_entry const *>(ev->itemref));
-		return true;
+		if (m_clicked_shortcut >= 0)
+		{
+			auto const &sc = m_shortcuts[m_clicked_shortcut];
+			file_selector_entry fake;
+			fake.type = sc.type;
+			fake.basename = sc.label;
+			fake.fullpath = sc.fullpath;
+			m_clicked_shortcut = -1;
+			m_filename.clear();
+			m_shortcut_armed = false;
+			m_shortcut_mode = false;
+			select_item(fake);
+			return true;
+		}
+	}
+	else if (ev->iptkey == IPT_UI_SELECT)
+	{
+		if (m_shortcut_armed && !m_shortcuts.empty())
+		{
+			// activate the focused shortcut
+			auto const &sc = m_shortcuts[m_shortcut_focus];
+			file_selector_entry fake;
+			fake.type = sc.type;
+			fake.basename = sc.label;
+			fake.fullpath = sc.fullpath;
+			m_filename.clear();
+			m_shortcut_armed = false;
+			m_shortcut_mode = false;
+			select_item(fake);
+			return true;
+		}
+		else if (ev->itemref)
+		{
+			// reset search when selecting an item
+			m_filename.clear();
+			m_shortcut_armed = false;
+			select_item(*reinterpret_cast<file_selector_entry const *>(ev->itemref));
+			return true;
+		}
 	}
 
 	return false;

--- a/src/frontend/mame/ui/filesel.h
+++ b/src/frontend/mame/ui/filesel.h
@@ -69,6 +69,7 @@ private:
 		SELECTOR_ENTRY_TYPE_CREATE,
 		SELECTOR_ENTRY_TYPE_SOFTWARE_LIST,
 		SELECTOR_ENTRY_TYPE_DRIVE,
+		SELECTOR_ENTRY_TYPE_HOME,
 		SELECTOR_ENTRY_TYPE_DIRECTORY,
 		SELECTOR_ENTRY_TYPE_FILE
 	};
@@ -96,10 +97,30 @@ private:
 	bool const                          m_is_midi;
 	std::vector<file_selector_entry>    m_entrylist;
 	std::string                         m_filename;
+
+	std::string                         m_file_extensions;          // comma-separated, e.g. "tap,tzx,wav"
+	bool                                m_filter_extensions = true; // toggle with CLEAR (Del) key
 	std::pair<size_t, size_t>           m_clicked_directory;
+	std::string                         m_prev_directory;
+
+	struct shortcut_entry
+	{
+		file_selector_entry_type type;
+		std::string              label;
+		std::string              fullpath;
+	};
+	std::vector<shortcut_entry>            m_shortcuts;
+	int                                    m_shortcut_focus = 0;     // index of highlighted shortcut
+	bool                                   m_shortcut_mode = false;  // true when focus is on shortcut bar (line 0)
+	bool                                   m_shortcut_armed = false; // true when SELECT should activate shortcut
+	std::vector<std::pair<size_t, size_t>> m_shortcut_offsets;       // char ranges in combined text
+	std::pair<float, float>                m_shortcut_position;      // where shortcut text starts (x, y)
+	std::optional<text_layout>             m_shortcut_layout;        // persistent shortcut bar layout for hit testing
+	int                                    m_clicked_shortcut = -1;  // index of shortcut being clicked
 
 	virtual void populate() override;
 	virtual bool handle(event const *ev) override;
+	virtual bool handle_keys(uint32_t flags, int &iptkey) override;
 
 	// methods
 	file_selector_entry &append_entry(file_selector_entry_type entry_type, const std::string &entry_basename, const std::string &entry_fullpath);
@@ -107,8 +128,16 @@ private:
 	file_selector_entry *append_dirent_entry(const osd::directory::entry *dirent);
 	void append_entry_menu_item(const file_selector_entry *entry);
 	void select_item(const file_selector_entry &entry);
-	void update_search();
 	std::pair<size_t, size_t> get_directory_range(float x, float y);
+	int get_shortcut_at(float x, float y);
+	void update_search();
+	bool extension_matches(std::string_view filename) const;
+	static bool is_archive(std::string_view filename);
+	bool is_volume_root(std::string_view path) const;
+	static int search_rank(std::string_view name, std::string_view query);
+	static constexpr int DIR_CHECK_MAX_DEPTH = 3;
+	bool directory_has_matching_files(std::string_view path, int depth) const;
+	bool auto_descend();
 };
 
 


### PR DESCRIPTION
* Special entries moved to shortcut bar — DRIVE/HOME/SOFTLIST/CREATE/EMPTY/MIDI no longer appear as list items; horizontal bar below breadcrumb
* User's HOME shortcut added
* LEFT/RIGHT cycle shortcuts — changes which shortcut is armed; browser cursor stays put
* Auto-filtering based on extension
* DEL is dual-mode — clears search if typing, otherwise toggles extension filter