### PR TITLE
frontend/mame/ui/filesel.cpp: Improved navigation in media selector.

### DIFF
--- a/src/frontend/mame/ui/filesel.cpp
+++ b/src/frontend/mame/ui/filesel.cpp
@@ -17,11 +17,13 @@
 #include "ui/ui.h"
 #include "ui/utils.h"
 
+#include "emuopts.h"
+#include "fileio.h"
 #include "imagedev/floppy.h"
-
 #include "uiinput.h"
 
 #include "util/corestr.h"
+#include "util/path.h"
 #include "util/zippath.h"
 
 #include "bus/midi/midiinport.h"
@@ -72,6 +74,7 @@ menu_file_selector::menu_file_selector(
 	, m_has_create(has_create)
 	, m_is_midi((image.device().type() == MIDIIN) || (image.device().type() == MIDIOUT))
 	, m_clicked_directory(std::string::npos, std::string::npos)
+	, m_file_extensions(image.file_extensions() ? image.file_extensions() : "")
 {
 	set_process_flags(PROCESS_IGNOREPAUSE);
 }
@@ -279,6 +282,8 @@ menu_file_selector::file_selector_entry *menu_file_selector::append_dirent_entry
 	switch (dirent->type)
 	{
 	case osd::directory::entry::entry_type::FILE:
+		if (m_filter_extensions && !is_archive(dirent->name) && !extension_matches(dirent->name))
+			return nullptr;
 		entry_type = SELECTOR_ENTRY_TYPE_FILE;
 		break;
 
@@ -386,10 +391,11 @@ void menu_file_selector::select_item(const file_selector_entry &entry)
 				break;
 			}
 		}
-		m_current_directory = entry.fullpath;
-		m_path_layout.reset();
-		m_clicked_directory = std::make_pair(std::string::npos, std::string::npos);
-		reset(reset_options::SELECT_FIRST);
+	m_current_directory = entry.fullpath;
+	m_filename.clear();
+	m_path_layout.reset();
+	m_clicked_directory = std::make_pair(std::string::npos, std::string::npos);
+	reset(reset_options::SELECT_FIRST);
 		break;
 
 	case SELECTOR_ENTRY_TYPE_FILE:
@@ -408,39 +414,7 @@ void menu_file_selector::select_item(const file_selector_entry &entry)
 void menu_file_selector::update_search()
 {
 	ui().popup_time(ERROR_MESSAGE_TIME, "%s", m_filename);
-
-	file_selector_entry const *const cur_selected(reinterpret_cast<file_selector_entry const *>(get_selection_ref()));
-
-	// if it's a perfect match for the current selection, don't move it
-	if (!cur_selected || core_strnicmp(cur_selected->basename.c_str(), m_filename.c_str(), m_filename.size()))
-	{
-		std::string::size_type bestmatch(0);
-		file_selector_entry const *selected_entry(cur_selected);
-		for (auto &entry : m_entrylist)
-		{
-			// TODO: more efficient "common prefix" code
-			std::string::size_type match(0);
-			for (std::string::size_type i = 1; m_filename.size() >= i; ++i)
-			{
-				if (!core_strnicmp(entry.basename.c_str(), m_filename.c_str(), i))
-					match = i;
-				else
-					break;
-			}
-
-			if (match > bestmatch)
-			{
-				bestmatch = match;
-				selected_entry = &entry;
-			}
-		}
-
-		if (selected_entry && (selected_entry != cur_selected))
-		{
-			set_selection((void *)selected_entry);
-			centre_selection();
-		}
-	}
+	reset(reset_options::REMEMBER_POSITION);
 }
 
 
@@ -472,6 +446,61 @@ std::pair<size_t, size_t> menu_file_selector::get_directory_range(float x, float
 	return std::make_pair(std::string::npos, std::string::npos);
 }
 
+//-------------------------------------------------
+//  extension_matches - check if filename has one
+//  of the configured extensions
+//-------------------------------------------------
+
+bool menu_file_selector::extension_matches(std::string_view filename) const
+{
+	if (m_file_extensions.empty())
+		return true;
+
+	auto const dot = filename.rfind('.');
+	if (dot == std::string_view::npos)
+		return false;
+
+	std::string_view const ext = filename.substr(dot + 1);
+
+	std::string_view exts(m_file_extensions);
+	while (!exts.empty())
+	{
+		auto const comma = exts.find(',');
+		std::string_view const cur = exts.substr(0, comma);
+		if (cur.length() == ext.length())
+		{
+			bool match = true;
+			for (size_t i = 0; i < ext.length(); ++i)
+			{
+				if (std::tolower(static_cast<unsigned char>(cur[i])) != std::tolower(static_cast<unsigned char>(ext[i])))
+				{
+					match = false;
+					break;
+				}
+			}
+			if (match)
+				return true;
+		}
+		if (comma == std::string_view::npos)
+			break;
+		exts.remove_prefix(comma + 1);
+	}
+
+	return false;
+}
+
+//-------------------------------------------------
+//  is_archive - check if filename is a known
+//  archive type (zip, imz, 7z)
+//-------------------------------------------------
+
+bool menu_file_selector::is_archive(std::string_view filename)
+{
+	return core_filename_ends_with(filename, ".zip") ||
+		core_filename_ends_with(filename, ".imz") ||
+		core_filename_ends_with(filename, ".7z");
+}
+
 
 //-------------------------------------------------
 //  populate
@@ -479,10 +508,29 @@ std::pair<size_t, size_t> menu_file_selector::get_directory_range(float x, float
 
 void menu_file_selector::populate()
 {
-	const file_selector_entry *selected_entry = nullptr;
+	std::size_t selected_index = 0;
+	bool have_selection = false;
 
 	// clear out the menu entries
 	m_entrylist.clear();
+
+	// set heading - centered, padded symmetrically to match breadcrumb width
+	std::string heading_text = m_filename.empty()
+		? std::string(_("File Manager"))
+		: util::string_format(_("Search: %1$s_"), m_filename);
+	float const heading_w = get_string_width(heading_text);
+	float const path_w = get_string_width(m_current_directory);
+	if (heading_w < path_w)
+	{
+		float const space_w = get_string_width(" ");
+		if (space_w > 0.0F)
+		{
+			int const padding = int((path_w - heading_w) / space_w / 2) + 1;
+			std::string const pad(padding, ' ');
+			heading_text = pad + heading_text + pad;
+		}
+	}
+	set_heading(std::move(heading_text));
 
 	// open the directory
 	util::zippath_directory::ptr directory;
@@ -500,13 +548,38 @@ void menu_file_selector::populate()
 	if (m_has_create && directory && !directory->is_archive())
 		append_entry(SELECTOR_ENTRY_TYPE_CREATE, "", "");
 
-	// add and select the "[software list]" entry if available
+	// add the "[software list]" entry if available
 	if (m_has_softlist)
-		selected_entry = &append_entry(SELECTOR_ENTRY_TYPE_SOFTWARE_LIST, "", "");
+		append_entry(SELECTOR_ENTRY_TYPE_SOFTWARE_LIST, "", "");
 
 	// add the drives
 	for (std::string const &volume_name : osd_get_volume_names())
 		append_entry(SELECTOR_ENTRY_TYPE_DRIVE, volume_name, volume_name);
+
+	// add the user's home directory
+	char const *home = osd_getenv("HOME");
+	if (!home || !*home)
+		home = osd_getenv("USERPROFILE");
+	if (home && *home)
+		append_entry(SELECTOR_ENTRY_TYPE_DIRECTORY, home, home);
+
+	// add software path entries from swpath option (semicolon-separated)
+	// paths may be relative - resolve to full path so navigation works
+	std::string const swpath(machine().options().sw_path());
+	if (!swpath.empty())
+	{
+		path_iterator iter(swpath);
+		std::string path;
+		while (iter.next(path))
+		{
+			if (!path.empty())
+			{
+				std::string fullpath;
+				if (!osd_get_full_path(fullpath, path))
+					append_entry(SELECTOR_ENTRY_TYPE_DIRECTORY, fullpath, fullpath);
+			}
+		}
+	}
 
 	// mark first filename entry
 	std::size_t const first = m_entrylist.size() + 1;
@@ -522,46 +595,113 @@ void menu_file_selector::populate()
 	{
 		for (osd::directory::entry const *dirent = directory->readdir(); dirent; dirent = directory->readdir())
 		{
-			// append a dirent entry
-			file_selector_entry const *entry = append_dirent_entry(dirent);
-			if (entry)
+			bool const is_parent = !strcmp(dirent->name, "..");
+			if (!m_filename.empty() && !is_parent)
 			{
-				// set the selected item to be the first non-parent directory or file
-				if (!selected_entry && strcmp(dirent->name, ".."))
-					selected_entry = entry;
-
-				// do we have to select this file?
-				if (!core_stricmp(m_current_file, dirent->name))
-					selected_entry = entry;
+				if (subsequence_rank(dirent->name, m_filename) == 0)
+					continue;
 			}
+			append_dirent_entry(dirent);
 		}
 	}
-	directory.reset();
 
 	if (m_entrylist.size() > first)
 	{
-		// sort the menu entries
+		// sort the menu entries - by search rank when filtering, else alphabetical
 		std::locale const lcl;
 		std::collate<wchar_t> const &coll = std::use_facet<std::collate<wchar_t> >(lcl);
-		std::sort(
-				m_entrylist.begin() + first,
-				m_entrylist.end(),
-				[&coll] (file_selector_entry const &x, file_selector_entry const &y)
-				{
-					std::wstring const xstr = wstring_from_utf8(x.basename);
-					std::wstring const ystr = wstring_from_utf8(y.basename);
-					return coll.compare(xstr.data(), xstr.data() + xstr.size(), ystr.data(), ystr.data() + ystr.size()) < 0;
-				});
+		auto const alpha_less = [&coll] (file_selector_entry const &x, file_selector_entry const &y)
+		{
+			std::wstring const xstr = wstring_from_utf8(x.basename);
+			std::wstring const ystr = wstring_from_utf8(y.basename);
+			return coll.compare(xstr.data(), xstr.data() + xstr.size(), ystr.data(), ystr.data() + ystr.size()) < 0;
+		};
+
+		if (m_filename.empty())
+		{
+			std::sort(m_entrylist.begin() + first, m_entrylist.end(), alpha_less);
+		}
+		else
+		{
+			// rank 1 = prefix (best), 2 = subsequence; parent ".." always first
+			std::stable_sort(
+					m_entrylist.begin() + first,
+					m_entrylist.end(),
+					[this, &coll] (file_selector_entry const &x, file_selector_entry const &y)
+					{
+						bool const x_parent = (x.basename == "..");
+						bool const y_parent = (y.basename == "..");
+						if (x_parent != y_parent)
+							return x_parent;
+						if (x_parent)
+							return false;
+						int const xr = subsequence_rank(x.basename, m_filename);
+						int const yr = subsequence_rank(y.basename, m_filename);
+						if (xr != yr)
+							return xr < yr;
+						// same rank: alphabetical
+						std::wstring const xs = wstring_from_utf8(x.basename);
+						std::wstring const ys = wstring_from_utf8(y.basename);
+						return coll.compare(xs.data(), xs.data() + xs.size(), ys.data(), ys.data() + ys.size()) < 0;
+					});
+		}
+	}
+
+	// resolve selection after sort - find first non-parent directory item
+	// or the matching current file
+	if (m_entrylist.size() >= first)
+	{
+		for (std::size_t i = first - 1; i < m_entrylist.size(); i++)
+		{
+			file_selector_entry const &e = m_entrylist[i];
+			bool const is_parent = (e.basename == "..");
+
+			if (!have_selection && !is_parent)
+			{
+				selected_index = i;
+				have_selection = true;
+			}
+
+			if (!m_current_file.empty() && !core_stricmp(m_current_file.c_str(), e.basename.c_str()))
+			{
+				selected_index = i;
+				have_selection = true;
+				break;
+			}
+		}
+	}
+
+	// fallback: select software list entry if no directory item was selected
+	if (!have_selection && m_has_softlist)
+	{
+		for (std::size_t i = 0; i < m_entrylist.size(); i++)
+		{
+			if (m_entrylist[i].type == SELECTOR_ENTRY_TYPE_SOFTWARE_LIST)
+			{
+				selected_index = i;
+				have_selection = true;
+				break;
+			}
+		}
 	}
 
 	// append all of the menu entries
-	for (file_selector_entry const &entry : m_entrylist)
-		append_entry_menu_item(&entry);
+	bool const have_directory_items = (m_entrylist.size() >= first);
+	bool separator_inserted = false;
+	for (std::size_t i = 0; i < m_entrylist.size(); i++)
+	{
+		if (have_directory_items && !separator_inserted && (i + 1 >= first))
+		{
+			item_append(menu_item_type::SEPARATOR);
+			separator_inserted = true;
+		}
+		append_entry_menu_item(&m_entrylist[i]);
+	}
 	item_append(menu_item_type::SEPARATOR);
 
-	// set the selection (if we have one)
-	if (selected_entry)
-		set_selection((void *)selected_entry);
+	// set the selection (if we have one) - resolve index to valid pointer
+	if (have_selection && selected_index < m_entrylist.size())
+		set_selection((void *)&m_entrylist[selected_index]);
 }
 
 
@@ -598,6 +738,27 @@ bool menu_file_selector::handle(event const *ev)
 		{
 			m_filename.clear();
 			ui().popup_time(ERROR_MESSAGE_TIME, "%s", m_filename);
+			reset(reset_options::REMEMBER_POSITION);
+			return true;
+		}
+	}
+	else if (ev->iptkey == IPT_UI_CLEAR)
+	{
+		if (!m_file_extensions.empty())
+		{
+			m_filter_extensions = !m_filter_extensions;
+			if (m_filter_extensions)
+			{
+				ui().popup_time(3, "%s", util::string_format(
+					"%s\n%s",
+					util::string_format(_("Filter: %s"), _("on")),
+					util::string_format(_("Extensions: %s"), m_file_extensions)));
+			}
+			else
+			{
+				ui().popup_time(3, "%s", util::string_format(_("Filter: %s"), _("off")));
+			}
+			reset(reset_options::REMEMBER_POSITION);
 			return true;
 		}
 	}

--- a/src/frontend/mame/ui/filesel.h
+++ b/src/frontend/mame/ui/filesel.h
@@ -97,6 +97,8 @@ private:
 	std::vector<file_selector_entry>    m_entrylist;
 	std::string                         m_filename;
 	std::pair<size_t, size_t>           m_clicked_directory;
+	std::string                         m_file_extensions;          // comma-separated, e.g. "tap,tzx,wav"
+	bool                                m_filter_extensions = true;
 
 	virtual void populate() override;
 	virtual bool handle(event const *ev) override;
@@ -109,6 +111,8 @@ private:
 	void select_item(const file_selector_entry &entry);
 	void update_search();
 	std::pair<size_t, size_t> get_directory_range(float x, float y);
+	bool extension_matches(std::string_view filename) const;
+	static bool is_archive(std::string_view filename);
 };
 
 

--- a/src/frontend/mame/ui/utils.cpp
+++ b/src/frontend/mame/ui/utils.cpp
@@ -1980,6 +1980,25 @@ software_filter::ptr software_filter::create(util::core_file &file, software_fil
 	return nullptr;
 }
 
+int subsequence_rank(std::string_view name, std::string_view query)
+{
+	if (query.empty())
+		return 1;
+
+	// prefix match (case-insensitive) -> top group
+	if (name.size() >= query.size() && !core_strnicmp(name.data(), query.data(), query.size()))
+		return 1;
+
+	// subsequence match (ordered, case-insensitive) -> bottom group
+	size_t qi = 0;
+	for (size_t ni = 0; ni < name.size() && qi < query.size(); ++ni)
+	{
+		if (tolower(name[ni]) == tolower(query[qi]))
+			++qi;
+	}
+	return (qi == query.size()) ? 2 : 0;
+}
+
 } // namesapce ui
 
 

--- a/src/frontend/mame/ui/utils.cpp
+++ b/src/frontend/mame/ui/utils.cpp
@@ -1985,18 +1985,28 @@ int subsequence_rank(std::string_view name, std::string_view query)
 	if (query.empty())
 		return 1;
 
-	// prefix match (case-insensitive) -> top group
+	// prefix match (case-insensitive) -> best
 	if (name.size() >= query.size() && !core_strnicmp(name.data(), query.data(), query.size()))
 		return 1;
 
-	// subsequence match (ordered, case-insensitive) -> bottom group
+	// contiguous substring match (case-insensitive) -> good
+	if (name.size() >= query.size())
+	{
+		for (size_t i = 0; i + query.size() <= name.size(); ++i)
+		{
+			if (!core_strnicmp(name.data() + i, query.data(), query.size()))
+				return 2;
+		}
+	}
+
+	// subsequence match (ordered, case-insensitive) -> weakest
 	size_t qi = 0;
 	for (size_t ni = 0; ni < name.size() && qi < query.size(); ++ni)
 	{
 		if (tolower(name[ni]) == tolower(query[qi]))
 			++qi;
 	}
-	return (qi == query.size()) ? 2 : 0;
+	return (qi == query.size()) ? 3 : 0;
 }
 
 } // namesapce ui

--- a/src/frontend/mame/ui/utils.h
+++ b/src/frontend/mame/ui/utils.h
@@ -486,7 +486,7 @@ bool paste_text(std::string &buffer, F &&filter)
 
 //-------------------------------------------------
 //  subsequence_rank - rank a name against a query
-//  returns 0 = no match, 1 = prefix, 2 = subsequence
+//  returns 0 = no match, 1 = prefix, 2 = substring, 3 = subsequence
 //-------------------------------------------------
 
 int subsequence_rank(std::string_view name, std::string_view query);

--- a/src/frontend/mame/ui/utils.h
+++ b/src/frontend/mame/ui/utils.h
@@ -483,6 +483,14 @@ bool paste_text(std::string &buffer, F &&filter)
 	return paste_text(buffer, size, std::forward<F>(filter));
 }
 
+
+//-------------------------------------------------
+//  subsequence_rank - rank a name against a query
+//  returns 0 = no match, 1 = prefix, 2 = subsequence
+//-------------------------------------------------
+
+int subsequence_rank(std::string_view name, std::string_view query);
+
 } // namespace ui
 
 #endif // MAME_FRONTEND_UI_UTILS_H


### PR DESCRIPTION
 File Manager UX Changes

 Filtering
 - Type letters to filter the list (hides non-matching items) — not just cursor jump
 - Subsequence matching: ga matches gameboy, amiga
 - Results ranked: prefix matches first, then subsequence, then alphabetical
 - .. always shown while filtering (navigate up)
 - CLEAR toggles extension filter on/off (only show files matching device extensions; archives always shown)
 - CANCEL clears the typed filter

 Shortcuts (always shown, unfiltered)
 - Drives ([DRIVE])
 - Home directory ([DIR] — shows full path)
 - swpath entries ([DIR] — full resolved path, relative paths expanded)
 - [software list] entry
 - Separator drawn between shortcuts and directory contents

 Navigation
 - Selecting any [DIR]/[DRIVE] shortcut lands cursor on first directory item (skips ..)
 - Filter cleared on directory change

 Heading: centered "File Manager" or "Search: …" padded to breadcrumb width

 Reusable: ui::subsequence_rank(name, query) in utils.h/utils.cpp — available for softlist and other menus