### PR TITLE
emu/addrmap.cpp: Allow to map shares with offset. Performed size validation for union of partial ranges.

### DIFF
--- a/src/emu/addrmap.cpp
+++ b/src/emu/addrmap.cpp
@@ -40,6 +40,7 @@ address_map_entry::address_map_entry(device_t &device, address_map &map, offs_t 
 	, m_cswidth(0)
 	, m_flags(0)
 	, m_share(nullptr)
+	, m_share_offset(0)
 	, m_region(nullptr)
 	, m_rgnoffs(0)
 	, m_before_time(device)

--- a/src/emu/addrmap.h
+++ b/src/emu/addrmap.h
@@ -103,7 +103,7 @@ public:
 	address_map_entry &mirror(offs_t _mirror) { m_addrmirror = _mirror; return *this; }
 	address_map_entry &select(offs_t _select) { m_addrselect = _select; return *this; }
 	address_map_entry &region(const char *tag, offs_t offset) { m_region = tag; m_rgnoffs = offset; return *this; }
-	address_map_entry &share(const char *tag) { m_share = tag; return *this; }
+	address_map_entry &share(const char *tag, offs_t offset = 0) { m_share = tag; m_share_offset = offset; return *this; }
 
 	// slightly less simple inline setters
 	template<bool _reqd> address_map_entry &region(const memory_region_finder<_reqd> &finder, offs_t offset) {
@@ -116,15 +116,15 @@ public:
 		assert(&target.first == &m_devbase);
 		return region(target.second, offset);
 	}
-	template<typename _ptrt, bool _reqd> address_map_entry &share(const shared_ptr_finder<_ptrt, _reqd> &finder) {
+	template<typename _ptrt, bool _reqd> address_map_entry &share(const shared_ptr_finder<_ptrt, _reqd> &finder, offs_t offset = 0) {
 		const std::pair<device_t &, const char *> target(finder.finder_target());
 		assert(&target.first == &m_devbase);
-		return share(target.second);
+		return share(target.second, offset);
 	}
-	template<typename _ptrt> address_map_entry &share(const memory_share_creator<_ptrt> &finder) {
+	template<typename _ptrt> address_map_entry &share(const memory_share_creator<_ptrt> &finder, offs_t offset = 0) {
 		const std::pair<device_t &, const char *> target(finder.finder_target());
 		assert(&target.first == &m_devbase);
-		return share(target.second);
+		return share(target.second, offset);
 	}
 
 	address_map_entry &rom() { m_read.m_type = AMH_ROM; return *this; }
@@ -437,6 +437,7 @@ public:
 	map_handler_data        m_read;                 // data for read handler
 	map_handler_data        m_write;                // data for write handler
 	const char *            m_share;                // tag of a shared memory block
+	offs_t                  m_share_offset;         // offset of this range within the share
 	const char *            m_region;               // tag of region containing the memory backing this entry
 	offs_t                  m_rgnoffs;              // offset within the region
 	ws_time_delegate        m_before_time;          // before-time wait-state

--- a/src/emu/devfind.h
+++ b/src/emu/devfind.h
@@ -257,6 +257,12 @@ public:
 	/// subsequently removes or replaces devices.
 	virtual void end_configuration() = 0;
 
+	/// \brief Whether this finder creates a memory share
+	///
+	/// Returns true for memory_share_creator finders that need to be
+	/// resolved before memory maps are prepared.
+	virtual bool is_share_creator() const { return false; }
+
 protected:
 	/// \brief Designated constructor
 	///
@@ -1401,6 +1407,7 @@ public:
 protected:
 	virtual bool findit(validity_checker *valid) override ATTR_COLD;
 	virtual void end_configuration() override ATTR_COLD;
+	virtual bool is_share_creator() const override { return true; }
 
 	/// \brief Pointer to target object
 	///

--- a/src/emu/device.cpp
+++ b/src/emu/device.cpp
@@ -502,6 +502,11 @@ void device_t::resolve_pre_map()
 	// prepare the logerror buffer
 	if (m_machine->allow_logging())
 		m_string_buffer.reserve(1024);
+
+	// resolve share creators so shares exist at declared size before memory maps are prepared
+	for (auto *autodev = m_auto_finder_list; autodev; autodev = autodev->next())
+		if (autodev->is_share_creator())
+			autodev->findit(nullptr);
 }
 
 

--- a/src/emu/emumem.cpp
+++ b/src/emu/emumem.cpp
@@ -313,6 +313,14 @@ void memory_manager::initialize()
 	for (auto const memory : memories)
 		memory->populate_from_maps();
 
+	// validate that shares referenced from maps are fully covered
+	for (auto const &[name, share] : m_sharelist)
+	{
+		std::string const result = share->validate_mapping();
+		if (!result.empty())
+			fatalerror("%s\n", result);
+	}
+
 	// disable logging of unmapped access when no one receives it
 	if (!machine().options().log() && !machine().options().oslog() && !(machine().debug_flags & DEBUG_FLAG_ENABLED))
 		for (auto const memory : memories)
@@ -1145,5 +1153,32 @@ std::string memory_share::compare(u8 width, size_t bytes, endianness_t endiannes
 		return util::string_format("share %s found with unexpected endianness (expected %s, found %s)", m_name,
 								   endianness == ENDIANNESS_LITTLE ? "little" : "big",
 								   m_endianness == ENDIANNESS_LITTLE ? "little" : "big");
+	return "";
+}
+
+void memory_share::record_mapping(size_t offset, size_t bytes)
+{
+	if (!m_mapped)
+	{
+		m_mapped_min = offset;
+		m_mapped_max = offset + bytes - 1;
+		m_mapped = true;
+	}
+	else
+	{
+		if (offset < m_mapped_min)
+			m_mapped_min = offset;
+		if (offset + bytes - 1 > m_mapped_max)
+			m_mapped_max = offset + bytes - 1;
+	}
+}
+
+std::string memory_share::validate_mapping() const
+{
+	if (!m_mapped)
+		return "";
+	if (m_mapped_min != 0 || m_mapped_max + 1 != m_bytes)
+		return util::string_format("share %s mapped range %x-%x does not cover declared size %x",
+								   m_name, m_mapped_min, m_mapped_max, m_bytes);
 	return "";
 }

--- a/src/emu/emumem.h
+++ b/src/emu/emumem.h
@@ -2553,6 +2553,9 @@ public:
 
 	std::string compare(u8 width, size_t bytes, endianness_t endianness) const;
 
+	void record_mapping(size_t offset, size_t bytes);
+	std::string validate_mapping() const;
+
 private:
 	// internal state
 	std::string             m_name;                 // share name
@@ -2562,6 +2565,10 @@ private:
 	u8                      m_bitwidth;             // width of the shared region in bits
 	u8                      m_bytewidth;            // width in bytes, rounded up to a power of 2
 
+	// range tracking for validation
+	bool                    m_mapped = false;       // any range recorded?
+	size_t                  m_mapped_min = 0;       // minimum offset recorded
+	size_t                  m_mapped_max = 0;       // maximum offset + size - 1 recorded
 };
 
 

--- a/src/emu/emumem_aspace.cpp
+++ b/src/emu/emumem_aspace.cpp
@@ -645,20 +645,17 @@ void address_space::prepare_map_generic(address_map &map, bool allow_alloc)
 			// if we can't find it, add it to our map if we're allowed to
 			std::string fulltag = entry.m_devbase.subtag(entry.m_share);
 			memory_share *share = m_manager.share_find(fulltag);
+			size_t const range_bytes = address_to_byte(entry.m_addrend + 1 - entry.m_addrstart);
+			size_t const share_offset = address_to_byte(entry.m_share_offset);
 			if (!share)
 			{
 				if (!allow_alloc)
 					fatalerror("Trying to create share '%s' too late\n", fulltag);
 				VPRINTF("Creating share '%s' of length 0x%X\n", fulltag, entry.m_addrend + 1 - entry.m_addrstart);
-				share = m_manager.share_alloc(m_device, fulltag, m_config.data_width(), address_to_byte(entry.m_addrend + 1 - entry.m_addrstart), endianness());
+				share = m_manager.share_alloc(m_device, fulltag, m_config.data_width(), range_bytes, endianness());
 			}
-			else
-			{
-				std::string result = share->compare(m_config.data_width(), address_to_byte(entry.m_addrend + 1 - entry.m_addrstart), endianness());
-				if (!result.empty())
-					fatalerror("%s\n", result);
-			}
-			entry.m_memory = share->ptr();
+			share->record_mapping(share_offset, range_bytes);
+			entry.m_memory = static_cast<u8 *>(share->ptr()) + share_offset;
 		}
 
 		// if this is a ROM handler without a specified region and not shared, attach it to the implicit region

--- a/src/emu/emumem_mview.cpp
+++ b/src/emu/emumem_mview.cpp
@@ -377,20 +377,17 @@ void memory_view::memory_view_entry::prepare_map_generic(address_map &map, bool 
 			// if we can't find it, add it to our map if we're allowed to
 			std::string fulltag = entry.m_devbase.subtag(entry.m_share);
 			memory_share *share = m_manager.share_find(fulltag);
+			size_t const range_bytes = m_config.addr2byte(entry.m_addrend + 1 - entry.m_addrstart);
+			size_t const share_offset = m_config.addr2byte(entry.m_share_offset);
 			if (!share)
 			{
 				if (!allow_alloc)
 					fatalerror("Trying to create share '%s' too late\n", fulltag);
 				VPRINTF("Creating share '%s' of length 0x%X\n", fulltag, entry.m_addrend + 1 - entry.m_addrstart);
-				share = m_manager.share_alloc(m_view.m_device, fulltag, m_config.data_width(), address_to_byte(entry.m_addrend + 1 - entry.m_addrstart), endianness());
+				share = m_manager.share_alloc(m_view.m_device, fulltag, m_config.data_width(), range_bytes, endianness());
 			}
-			else
-			{
-				std::string result = share->compare(m_config.data_width(), address_to_byte(entry.m_addrend + 1 - entry.m_addrstart), endianness());
-				if (!result.empty())
-					fatalerror("%s\n", result);
-			}
-			entry.m_memory = share->ptr();
+			share->record_mapping(share_offset, range_bytes);
+			entry.m_memory = static_cast<u8 *>(share->ptr()) + share_offset;
 		}
 
 		// if this is a ROM handler without a specified region and not shared, attach it to the implicit region

--- a/src/mame/sinclair/next/specnext.cpp
+++ b/src/mame/sinclair/next/specnext.cpp
@@ -3076,18 +3076,14 @@ void specnext_state::map_mem(address_map &map)
 		views[i].get()[1](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).bankr(m_bank_ram[i]);
 
 		// bank5
-		views[i].get()[0x02a](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).lrw8(
-			NAME([this](offs_t offset) { return m_bram_bank5[offset & 0x1fff]; }),
+		views[i].get()[0x02a](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).ram().share(m_bram_bank5).lw8(
 			NAME([this](offs_t offset, u8 data) { m_screen->update_now(); m_bram_bank5[offset & 0x1fff] = data; })
 		);
-		views[i].get()[0x12a](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).lr8(
-			NAME([this](offs_t offset) { return m_bram_bank5[offset & 0x1fff]; }));
-		views[i].get()[0x02b](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).lrw8(
-			NAME([this](offs_t offset) { return m_bram_bank5[0x2000 + (offset & 0x1fff)]; }),
+		views[i].get()[0x12a](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).readonly().share(m_bram_bank5);
+		views[i].get()[0x02b](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).ram().share(m_bram_bank5, 0x2000).lw8(
 			NAME([this](offs_t offset, u8 data) { m_screen->update_now(); m_bram_bank5[0x2000 + (offset & 0x1fff)] = data; })
 		);
-		views[i].get()[0x12b](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).lr8(
-			NAME([this](offs_t offset) { return m_bram_bank5[0x2000 + (offset & 0x1fff)]; }));
+		views[i].get()[0x12b](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).readonly().share(m_bram_bank5, 0x2000);
 		// bank7
 		views[i].get()[0x02e](0x0000 + i * 0x2000, 0x1fff + i * 0x2000).ram().share(m_bram_bank7).lw8(
 			NAME([this](offs_t offset, u8 data) { m_screen->update_now(); m_bram_bank7[offset & 0x1fff] = data; })


### PR DESCRIPTION
Added .share(tag, offset) to map a share across multiple address ranges.
Validation now checks that the union of all mapped ranges fully covers the declared share size, instead of requiring each entry to match exactly.
covers the issue raised in https://github.com/mamedev/mame/commit/2c61e52f4dc2cd54e19b569608c965abcfb9c803#r191250347