### PR TITLE
GPL16250 cleanup checkpoint / milestone

### DIFF
--- a/src/devices/machine/generalplus_gpl1625x_soc.cpp
+++ b/src/devices/machine/generalplus_gpl1625x_soc.cpp
@@ -5,7 +5,7 @@
 #include "generalplus_gpl1625x_soc.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// GPL16250A register list
+// GPL16250 register list
 //
 // 7000 - Tx3_X_Position
 // 7001 - Tx3_Y_Position
@@ -585,6 +585,11 @@ u16 generalplus_gpac800_device::nand_data_r()
 	return m_nand_data_in();
 }
 
+void generalplus_gpac800_device::nand_data_w(u16 data)
+{
+	m_nand_data_out(data & 0xff);
+}
+
 // 7998
 
 void generalplus_gpac800_device::nand_command_w(u16 data)
@@ -607,6 +612,11 @@ void generalplus_gpac800_device::nand_addr_high_w(u16 data)
 
 	// documentation indicates that the NAND Interface won't write the address to the NAND, even if only 2 bytes are needed
 	// unless this address is written, so presumably all 4 address bytes get sent after the write here
+
+	// m_nand_dma_ctrl is 8600 when this is written, which would indicate the 4th byte isn't used
+	// but it's needed? (eg. jak_gtg going to title screen) so maybe doesn't realte to these bytes
+
+	// the timing of these writes on hardware is unclear
 	m_nand_address_out(m_nand_addr_low & 0xff);
 	m_nand_address_out(m_nand_addr_low >> 8);
 	m_nand_address_out(m_nand_addr_high & 0xff);
@@ -827,11 +837,14 @@ void generalplus_gpac800_device::gpac800_internal_map(address_map &map)
 	map(0x007851, 0x007851).w(FUNC(generalplus_gpac800_device::nand_command_w)); // NAND Command Reg
 	map(0x007852, 0x007852).w(FUNC(generalplus_gpac800_device::nand_addr_low_w)); // NAND Low Address Reg
 	map(0x007853, 0x007853).w(FUNC(generalplus_gpac800_device::nand_addr_high_w)); // NAND High Address Reg
-	map(0x007854, 0x007854).r(FUNC(generalplus_gpac800_device::nand_data_r)); // NAND Data Reg
+	map(0x007854, 0x007854).rw(FUNC(generalplus_gpac800_device::nand_data_r), FUNC(generalplus_gpac800_device::nand_data_w)); // NAND Data Reg
 	map(0x007855, 0x007855).w(FUNC(generalplus_gpac800_device::nand_dma_ctrl_w)); // NAND DMA / INT Control
 	map(0x007856, 0x007856).w(FUNC(generalplus_gpac800_device::nand_bch_ctrl_w)); // usually 0x0021?
 
 	map(0x007857, 0x007857).w(FUNC(generalplus_gpac800_device::nand_ecc_ctrl_w));
+
+	// 7858 - 785f can have a different meaning if nand_bch_ctrl bit 0 is set!
+	
 	// 7858 - ECC_LPRL_LB
 	// 7859 - ECC_LPRH_LB
 	// 785a - ECC_CPR_LB
@@ -843,7 +856,7 @@ void generalplus_gpac800_device::gpac800_internal_map(address_map &map)
 
 	map(0x007943, 0x007943).r(FUNC(generalplus_gpac800_device::spi_rxstatus_r));
 
-	map(0x007ae2, 0x007ae2).r(FUNC(generalplus_gpac800_device::efuse2_r));
+	map(0x007ae2, 0x007ae2).r(FUNC(generalplus_gpac800_device::efuse2_r)); // checked by the internal boot ROM
 
 	// 128kwords internal ROM
 	//map(0x08000, 0x0ffff).rom().region("internal", 0); // lower 32kwords of internal ROM is visible / shadowed depending on boot pins and register

--- a/src/devices/machine/generalplus_gpl1625x_soc.cpp
+++ b/src/devices/machine/generalplus_gpl1625x_soc.cpp
@@ -5,7 +5,7 @@
 #include "generalplus_gpl1625x_soc.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// GPAC800A register list
+// GPL16250A register list
 //
 // 7000 - Tx3_X_Position
 // 7001 - Tx3_Y_Position
@@ -222,21 +222,23 @@
 // 7854 - NF_Data
 // 7855 - NF_INT_Ctrl
 
+// 7856 - P_BCH_Control 
 // 7857 - ECC_Ctrl
-// 7858 - ECC_LPRL_LB
-// 7859 - ECC_LPRH_LB
-// 785a - ECC_CPR_LB
-// 785b - ECC_LPR_CKL_LB
-// 785c - ECC_LPR_CKH_LB
-// 785d - ECC_CPCKR_LB
-// 785e - ECC_ERR0_LB
-// 785f - ECC_ERR1_LB
+
+// 7858 - ECC_LPRL_LB or BCH Error Flag Register
+// 7859 - ECC_LPRH_LB or BCH Parity Register 0
+// 785a - ECC_CPR_LB or BCH Parity Register 1
+// 785b - ECC_LPR_CKL_LB or BCH Parity Register 2
+// 785c - ECC_LPR_CKH_LB or BCH Parity Register 3
+// 785d - ECC_CPCKR_LB or BCH Parity Register 4
+// 785e - ECC_ERR0_LB or BCH Parity Register 5
+// 785f - ECC_ERR1_LB or BCH Parity Register 6
 
 // 7860 - IOA_Data
 // 7861 - IOA_Buffer
 // 7862 - IOA_Dir
 // 7863 - IOA_Attrib
-// 7854 - IOA_Drv
+// 7864 - IOA_Drv
 //
 // 7868 - IOB_Data
 // 7869 - IOB_Buffer
@@ -566,142 +568,36 @@
 // 7c00 - 7dff Sound Attribute
 // 7e00 - 7fff Sound Phase
 
-DEFINE_DEVICE_TYPE(GPAC800,   generalplus_gpac800_device,  "gpac800",    "GeneralPlus GPL1625x System-on-a-Chip (with NAND handling)")
-DEFINE_DEVICE_TYPE(GP_SPISPI, generalplus_gpspispi_device, "gpac800spi", "GeneralPlus GPL1625x System-on-a-Chip (with SPI handling)")
+DEFINE_DEVICE_TYPE(GPL16250,   generalplus_gpac800_device,  "gpl16250",    "GeneralPlus GPL1625x / GPAC800 System-on-a-Chip")
 
 generalplus_gpac800_device::generalplus_gpac800_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
-	sunplus_gcm394_base_device(mconfig, GPAC800, tag, owner, clock, address_map_constructor(FUNC(generalplus_gpac800_device::gpac800_internal_map), this))
+	sunplus_gcm394_base_device(mconfig, GPL16250, tag, owner, clock, address_map_constructor(FUNC(generalplus_gpac800_device::gpac800_internal_map), this))
 {
 }
-
-generalplus_gpspispi_device::generalplus_gpspispi_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
-	sunplus_gcm394_base_device(mconfig, GP_SPISPI, tag, owner, clock, address_map_constructor(FUNC(generalplus_gpspispi_device::gpspispi_internal_map), this))
-{
-}
-
 
 // GPR27P512A   = C2 76
 // HY27UF081G2A = AD F1 80 1D
 // H27U518S2C   = AD 76
 
-u16 generalplus_gpac800_device::nand_7854_r()
+u16 generalplus_gpac800_device::nand_data_r()
 {
-	// TODO: use actual NAND / Smart Media devices once this is better understood.
-	// The games have extensive checks on startup to determine the flash types, but then it appears that
-	// certain games (eg jak_tsm) will only function correctly with specific ones, even if the code
-	// continues regardless.  Others will bail early if they don't get what they want.
-
-	// I think some unSP core maths bugs are causing severe issues after the initial load for jak_tsm
-	// at the moment, possibly the same ones that are causing rendering issues in the jak_gtg bitmap
-	// test and seemingly incorrect road data for jak_car2, either that or the hookup here is very
-	// non-standard outside of the ident codes
-
-	// real TSM code starts at 4c000
-
-
-	//logerror("%s:sunplus_gcm394_base_device::nand_7854_r\n", machine().describe_context());
-
-	if (m_nandcommand == 0x90) // read ident
-	{
-		logerror("%s:sunplus_gcm394_base_device::nand_7854_r   READ IDENT byte %d\n", machine().describe_context(), m_curblockaddr);
-
-		u8 data = 0x00;
-
-		if (m_romtype == 0)
-		{
-			if (m_curblockaddr == 0)
-				data = 0xc2;
-			else
-				data = 0x76;
-		}
-		else if (m_romtype == 1)
-		{
-			if (m_curblockaddr == 0)
-				data = 0xad;
-			else if (m_curblockaddr == 1)
-				data = 0x76;
-		}
-		else
-		{
-			if (m_curblockaddr == 0)
-				data = 0xad;
-			else if (m_curblockaddr == 1)
-				data = 0xf1;
-			else if (m_curblockaddr == 2)
-				data = 0x80;
-			else if (m_curblockaddr == 3)
-				data = 0x1d;
-		}
-
-		m_curblockaddr++;
-
-		return data;
-	}
-	else if (m_nandcommand == 0x00 || m_nandcommand == 0x01 || m_nandcommand  == 0x50)
-	{
-		//logerror("%s:sunplus_gcm394_base_device::nand_7854_r   READ DATA byte %d\n", machine().describe_context(), m_curblockaddr);
-
-		u8 data = m_nand_read_cb(m_effectiveaddress + m_curblockaddr);
-
-		m_curblockaddr++;
-
-		return data;
-	}
-	else if (m_nandcommand == 0x70) // read status
-	{
-		logerror("%s:sunplus_gcm394_base_device::nand_7854_r   READ STATUS byte %d\n", machine().describe_context(), m_curblockaddr);
-
-		return 0xffff;
-	}
-	else
-	{
-		logerror("%s:sunplus_gcm394_base_device::nand_7854_r   READ UNKNOWN byte %d\n", machine().describe_context(), m_curblockaddr);
-		return 0xffff;
-	}
-
-	return 0x0000;
+	// straight trampoline for now, but this is talking to the NAND controller, which in turn talks to the NAND
+	return m_nand_data_in();
 }
 
 // 7998
 
 void generalplus_gpac800_device::nand_command_w(u16 data)
 {
+	// documentation indicate this is a 16-bit port, but NAND commands are 8-bit?
 	logerror("%s:sunplus_gcm394_base_device::nand_command_w %04x\n", machine().describe_context(), data);
-	m_nandcommand = data;
+	m_nand_command_out(data & 0xff);
 }
 
 void generalplus_gpac800_device::nand_addr_low_w(u16 data)
 {
 	logerror("%s:sunplus_gcm394_base_device::nand_addr_low_w %04x\n", machine().describe_context(), data);
 	m_nand_addr_low = data;
-	m_curblockaddr = 0;
-}
-
-void generalplus_gpac800_device::recalculate_calculate_effective_nand_address()
-{
-	u8 type = m_nand_7856 & 0xf;
-	u8 shift = 0;
-	u32 page_offset = 0;
-
-	if (type == 7)
-		shift = 4;
-	else if (type == 11)
-		shift = 5;
-
-	if (m_nandcommand == 0x01)
-		page_offset = 256;
-	else if (m_nandcommand == 0x50)
-		page_offset = 512;
-
-	u32 nandaddress = (m_nand_addr_high << 16) | m_nand_addr_low;
-
-	if (m_nand_7850 & 0x4000)
-		nandaddress *= 2;
-
-	u32 page = type ? nandaddress : /*(m_nand_7850 & 0x4000) ?*/ nandaddress >> 8 /*: nandaddress >> 9*/;
-	m_effectiveaddress = (page * 528 + page_offset) << shift;
-
-	logerror("%s: Requested address is %08x, translating to %08x\n", machine().describe_context(), nandaddress, m_effectiveaddress);
 }
 
 void generalplus_gpac800_device::nand_addr_high_w(u16 data)
@@ -709,10 +605,35 @@ void generalplus_gpac800_device::nand_addr_high_w(u16 data)
 	logerror("%s:sunplus_gcm394_base_device::nand_addr_high_w %04x\n", machine().describe_context(), data);
 	m_nand_addr_high = data;
 
-	recalculate_calculate_effective_nand_address();
-
-	m_curblockaddr = 0;
+	// documentation indicates that the NAND Interface won't write the address to the NAND, even if only 2 bytes are needed
+	// unless this address is written, so presumably all 4 address bytes get sent after the write here
+	m_nand_address_out(m_nand_addr_low & 0xff);
+	m_nand_address_out(m_nand_addr_low >> 8);
+	m_nand_address_out(m_nand_addr_high & 0xff);
+	m_nand_address_out(m_nand_addr_high >> 8);
 }
+
+// 0x7855 - P_NF_INT_Ctrl ( DMA/INT Control Register )
+//
+// 15  REQF/C
+// 14  DMAEN
+// 13  INTEN
+// 12
+//
+// 11  ADR4EN  - enables 4th byte of address
+// 10  ADR3EN  - enables 3rd byte of address
+//  9  ADR2EN  - enables 2nd byte of address
+//  8
+//
+//  7
+//  6
+//  5
+//  4
+//
+//  3
+//  2
+//  1
+//  0
 
 void generalplus_gpac800_device::nand_dma_ctrl_w(u16 data)
 {
@@ -720,60 +641,102 @@ void generalplus_gpac800_device::nand_dma_ctrl_w(u16 data)
 	m_nand_dma_ctrl = data;
 }
 
+// 0x7850 - P_NF_Ctrl ( NAND Flash Control Register )
+//
+// 15  NFBF - Read Back Busy Status (1 = Ready) (RO)
+// 14
+// 13  OLDTYPE - Old-Type NAND Flash Read Support 
+// 12
+//
+// 11
+// 10
+//  9
+//  8
+//
+//  7
+//  6  NFCTRL[6] - tREA[2]
+//  5  NFCTRL[5] - tREA[1]
+//  4  NFCTRL[4] - tREA[0]
+//
+//  3  NFCTRL[3] - tWH[1] / tREH[1]
+//  2  NFCTRL[2] - tWH[0] / tREH[0]
+//  1  NFCTRL[1] - tWP[1]
+//  0  NFCTRL[0] - tWP[0]
+
 u16 generalplus_gpac800_device::nand_7850_status_r()
 {
+	// TODO, talks to the NAND controller, which talks to the NAND
+	// so the status byte here should reflect that
 	// 0x8000 = ready
-	return m_nand_7850 | 0x8000;
+	return m_nand_ctrl | 0x8000;
 }
 
 void generalplus_gpac800_device::nand_7850_w(u16 data)
 {
 	logerror("%s:sunplus_gcm394_base_device::nand_7850_w %04x\n", machine().describe_context(), data);
-	m_nand_7850 = data;
+	m_nand_ctrl = data;
 }
 
-void generalplus_gpac800_device::nand_7856_type_w(u16 data)
+// 0x7856 - P_BCH_Control ( BCH Control Register )
+// 
+// 15
+// 14
+// 13
+// 12
+//
+// 11
+// 10  PAGE_SEL [2] - Read parity page selection (R/W)
+//  9  PAGE_SEL [1]
+//  8  PAGE_SEL [0]
+// 
+//  7
+//  6
+//  5  PARITY_CLR - Write pairy clear flag (WO)
+//  4  BCH_WR - Page read/write control (1 = write, 0 = read) (R/W)
+//
+//  3  PAGE_SIZE[1] - NAND flash page size selection. (0 = 528 bytes, 1 = 2112 bytes, 2 = 4224 bytes, 3 = reserved)
+//  2  PAGE_SIZE[0]
+//  1  BCH_8 - BCH 4/8-bit control register (0 = 4 bits, 1 = 8-bits)
+//  0  BCH_EN - BCH Controller enable register. (1 = enable)
+
+void generalplus_gpac800_device::nand_bch_ctrl_w(u16 data)
 {
-	logerror("%s:sunplus_gcm394_base_device::nand_7856_type_w %04x\n", machine().describe_context(), data);
-	m_nand_7856 = data;
-
-	recalculate_calculate_effective_nand_address();
-
-	m_curblockaddr = 0;
+	logerror("%s:sunplus_gcm394_base_device::nand_bch_ctrl_w %04x\n", machine().describe_context(), data);
+	m_nand_bch_ctrl = data;
 }
 
-void generalplus_gpac800_device::nand_7857_w(u16 data)
+void generalplus_gpac800_device::nand_ecc_ctrl_w(u16 data)
 {
-	logerror("%s:sunplus_gcm394_base_device::nand_7857_w %04x\n", machine().describe_context(), data);
-	m_nand_7857 = data;
+	logerror("%s:sunplus_gcm394_base_device::nand_ecc_ctrl_w %04x\n", machine().describe_context(), data);
+	m_nand_ecc_ctrl = data;
 }
 
-void generalplus_gpac800_device::nand_785b_w(u16 data)
+void generalplus_gpac800_device::nand_ecc_lpr_ckl_lb_w(u16 data)
 {
-	logerror("%s:sunplus_gcm394_base_device::nand_785b_w %04x\n", machine().describe_context(), data);
-	m_nand_785b = data;
+	logerror("%s:sunplus_gcm394_base_device::nand_ecc_lpr_ckl_lb_w %04x\n", machine().describe_context(), data);
+	m_nand_ecc_lpr_ckl_lb = data;
 }
 
-void generalplus_gpac800_device::nand_785c_w(u16 data)
+void generalplus_gpac800_device::nand_ecc_lpr_ckh_lb_w(u16 data)
 {
-	logerror("%s:sunplus_gcm394_base_device::nand_785c_w %04x\n", machine().describe_context(), data);
-	m_nand_785c = data;
+	logerror("%s:sunplus_gcm394_base_device::nand_ecc_lpr_ckh_lb_w %04x\n", machine().describe_context(), data);
+	m_nand_ecc_lpr_ckh_lb = data;
 }
 
-void generalplus_gpac800_device::nand_785d_w(u16 data)
+void generalplus_gpac800_device::nand_ecc_cpckr_lb_w(u16 data)
 {
-	logerror("%s:sunplus_gcm394_base_device::nand_785d_w %04x\n", machine().describe_context(), data);
-	m_nand_785d = data;
+	logerror("%s:sunplus_gcm394_base_device::nand_ecc_cpckr_lb_w %04x\n", machine().describe_context(), data);
+	m_nand_ecc_cpckr_lb = data;
 }
 
 // [:maincpu] ':maincpu' (00146D)  jak_tsm
-u16 generalplus_gpac800_device::nand_785e_r()
+u16 generalplus_gpac800_device::nand_ecc_err0_lb_r()
 {
 	return 0x0000;
 }
 
 //[:maincpu] ':maincpu' (001490)  jak_tsm
-u16 generalplus_gpac800_device::nand_ecc_low_byte_error_flag_1_r()
+u16 generalplus_gpac800_device::nand_ecc_err1_lb_r()
 {
 	return 0x0000;
 }
@@ -782,7 +745,7 @@ u16 generalplus_gpac800_device::nand_ecc_low_byte_error_flag_1_r()
 UNMAPPED reads  writes
 
 jak_tsm uses these (all iniitalized near start)
-unclear if these are specific to the GPAC800 type, or present in the older types
+unclear if these are specific to the GPL16250 type, or present in the older types
 
 [:maincpu] ':maincpu' (00043F):sunplus_gcm394_base_device::unk_w @ 0x780a (data 0x0000)
 [:maincpu] ':maincpu' (000442):sunplus_gcm394_base_device::unk_w @ 0x7808 (data 0x0000)
@@ -864,22 +827,29 @@ void generalplus_gpac800_device::gpac800_internal_map(address_map &map)
 	map(0x007851, 0x007851).w(FUNC(generalplus_gpac800_device::nand_command_w)); // NAND Command Reg
 	map(0x007852, 0x007852).w(FUNC(generalplus_gpac800_device::nand_addr_low_w)); // NAND Low Address Reg
 	map(0x007853, 0x007853).w(FUNC(generalplus_gpac800_device::nand_addr_high_w)); // NAND High Address Reg
-	map(0x007854, 0x007854).r(FUNC(generalplus_gpac800_device::nand_7854_r)); // NAND Data Reg
+	map(0x007854, 0x007854).r(FUNC(generalplus_gpac800_device::nand_data_r)); // NAND Data Reg
 	map(0x007855, 0x007855).w(FUNC(generalplus_gpac800_device::nand_dma_ctrl_w)); // NAND DMA / INT Control
-	map(0x007856, 0x007856).w(FUNC(generalplus_gpac800_device::nand_7856_type_w)); // usually 0x0021?
-	map(0x007857, 0x007857).w(FUNC(generalplus_gpac800_device::nand_7857_w));
+	map(0x007856, 0x007856).w(FUNC(generalplus_gpac800_device::nand_bch_ctrl_w)); // usually 0x0021?
 
-	// most of these are likely ECC stuff for testing the ROM?
-	map(0x00785b, 0x00785b).w(FUNC(generalplus_gpac800_device::nand_785b_w));
-	map(0x00785c, 0x00785c).w(FUNC(generalplus_gpac800_device::nand_785c_w));
-	map(0x00785d, 0x00785d).w(FUNC(generalplus_gpac800_device::nand_785d_w));
-	map(0x00785e, 0x00785e).r(FUNC(generalplus_gpac800_device::nand_785e_r)); // also ECC status related?
-	map(0x00785f, 0x00785f).r(FUNC(generalplus_gpac800_device::nand_ecc_low_byte_error_flag_1_r)); // ECC Low Byte Error Flag 1 (maybe)
+	map(0x007857, 0x007857).w(FUNC(generalplus_gpac800_device::nand_ecc_ctrl_w));
+	// 7858 - ECC_LPRL_LB
+	// 7859 - ECC_LPRH_LB
+	// 785a - ECC_CPR_LB
+	map(0x00785b, 0x00785b).w(FUNC(generalplus_gpac800_device::nand_ecc_lpr_ckl_lb_w));
+	map(0x00785c, 0x00785c).w(FUNC(generalplus_gpac800_device::nand_ecc_lpr_ckh_lb_w));
+	map(0x00785d, 0x00785d).w(FUNC(generalplus_gpac800_device::nand_ecc_cpckr_lb_w));
+	map(0x00785e, 0x00785e).r(FUNC(generalplus_gpac800_device::nand_ecc_err0_lb_r)); // ECC Low Byte Error Flag 0
+	map(0x00785f, 0x00785f).r(FUNC(generalplus_gpac800_device::nand_ecc_err1_lb_r)); // ECC Low Byte Error Flag 1
+
+	map(0x007943, 0x007943).r(FUNC(generalplus_gpac800_device::spi_rxstatus_r));
+
+	map(0x007ae2, 0x007ae2).r(FUNC(generalplus_gpac800_device::efuse2_r));
 
 	// 128kwords internal ROM
 	//map(0x08000, 0x0ffff).rom().region("internal", 0); // lower 32kwords of internal ROM is visible / shadowed depending on boot pins and register
 	map(0x08000, 0x0ffff).r(FUNC(generalplus_gpac800_device::internalrom_lower32_r)).nopw();
-	map(0x10000, 0x27fff).rom().region("internal", 0x10000); // upper 96kwords of internal ROM is always visible
+	map(0x10000, 0x17fff).rom().region("internal", 0x10000); // upper words of internal ROM is always visible
+	//map(0x18000, 0x27fff).rom().region("internal", 0x20000); // ? apparently more upper words, but nothing is here?
 	map(0x28000, 0x2ffff).noprw(); // reserved
 	// 0x30000+ is CS access
 
@@ -894,27 +864,41 @@ void generalplus_gpac800_device::device_reset()
 	m_nand_addr_low = 0x0000;
 	m_nand_addr_high = 0x0000;
 	m_nand_dma_ctrl = 0x0000;
-	m_nand_7850 = 0x0000;
-	m_nand_785d = 0x0000;
-	m_nand_785c = 0x0000;
-	m_nand_785b = 0x0000;
-	m_nand_7856 = 0x0000;
-	m_nand_7857 = 0x0000;
+	m_nand_ctrl = 0x0000;
+	m_nand_ecc_cpckr_lb = 0x0000;
+	m_nand_ecc_lpr_ckh_lb = 0x0000;
+	m_nand_ecc_lpr_ckl_lb = 0x0000;
+	m_nand_bch_ctrl = 0x0000;
+	m_nand_ecc_ctrl = 0x0000;
 }
 
-
-u16 generalplus_gpspispi_device::spi_unk_7943_r()
+u16 generalplus_gpac800_device::spi_rxstatus_r()
 {
 	return 0x0007;
 }
 
-void generalplus_gpspispi_device::gpspispi_internal_map(address_map &map)
+u16 generalplus_gpac800_device::efuse2_r()
 {
-	sunplus_gcm394_base_device::base_internal_map(map);
-
-	map(0x007943, 0x007943).r(FUNC(generalplus_gpspispi_device::spi_unk_7943_r));
-
-	map(0x008000, 0x00ffff).rom().region("internal", 0);
+	logerror("%s:generalplus_gpac800_device::efuse2_r\n", machine().describe_context());
+	return 0x0300;
 }
 
 
+// it is not clear if these are just different revisions of a standard internal boot ROM, assuming so for now
+// they appear to be for the 'A' models at least, because there are hardcoded addresses which would be above
+// the RAM area of the 'B' models
+//
+// not currently used by the emulation as we overwrite this with our own bootstrap logic
+ROM_START( gpl16250 )
+	ROM_REGION16_BE( 0x20000, "internal", 0 )
+	ROM_DEFAULT_BIOS("v7")
+	ROM_SYSTEM_BIOS( 0, "v7", "GPL16250 internal ROM (v7)" )
+	ROMX_LOAD("gpl16250v_bootrom_v7.bin",              0x00000, 0x20000, CRC(fc4d0e32) SHA1(4dad40aae258b54fd816590ee769a1c6059b1d4c), ROM_GROUPWORD | ROM_REVERSE | ROM_BIOS(0) ) // from jewelpet music pod
+	ROM_SYSTEM_BIOS( 1, "unk", "GPL16250 internal ROM (unknown version)" )
+	ROMX_LOAD("gpl16250v_bootrom_unknown_version.bin", 0x00000, 0x20000, CRC(975ece00) SHA1(988e0befd33884b05aeccd6821e5cdd53f6a849f), ROM_GROUPWORD | ROM_REVERSE | ROM_BIOS(1) ) // from dragon quest adventure
+ROM_END
+
+const tiny_rom_entry *generalplus_gpac800_device::device_rom_region() const
+{
+	return ROM_NAME( gpl16250 );
+}

--- a/src/devices/machine/generalplus_gpl1625x_soc.cpp
+++ b/src/devices/machine/generalplus_gpl1625x_soc.cpp
@@ -222,7 +222,7 @@
 // 7854 - NF_Data
 // 7855 - NF_INT_Ctrl
 
-// 7856 - P_BCH_Control 
+// 7856 - P_BCH_Control
 // 7857 - ECC_Ctrl
 
 // 7858 - ECC_LPRL_LB or BCH Error Flag Register
@@ -655,7 +655,7 @@ void generalplus_gpac800_device::nand_dma_ctrl_w(u16 data)
 //
 // 15  NFBF - Read Back Busy Status (1 = Ready) (RO)
 // 14
-// 13  OLDTYPE - Old-Type NAND Flash Read Support 
+// 13  OLDTYPE - Old-Type NAND Flash Read Support
 // 12
 //
 // 11
@@ -688,7 +688,7 @@ void generalplus_gpac800_device::nand_7850_w(u16 data)
 }
 
 // 0x7856 - P_BCH_Control ( BCH Control Register )
-// 
+//
 // 15
 // 14
 // 13
@@ -698,7 +698,7 @@ void generalplus_gpac800_device::nand_7850_w(u16 data)
 // 10  PAGE_SEL [2] - Read parity page selection (R/W)
 //  9  PAGE_SEL [1]
 //  8  PAGE_SEL [0]
-// 
+//
 //  7
 //  6
 //  5  PARITY_CLR - Write pairy clear flag (WO)
@@ -844,7 +844,7 @@ void generalplus_gpac800_device::gpac800_internal_map(address_map &map)
 	map(0x007857, 0x007857).w(FUNC(generalplus_gpac800_device::nand_ecc_ctrl_w));
 
 	// 7858 - 785f can have a different meaning if nand_bch_ctrl bit 0 is set!
-	
+
 	// 7858 - ECC_LPRL_LB
 	// 7859 - ECC_LPRH_LB
 	// 785a - ECC_CPR_LB

--- a/src/devices/machine/generalplus_gpl1625x_soc.h
+++ b/src/devices/machine/generalplus_gpl1625x_soc.h
@@ -22,73 +22,47 @@ public:
 
 	generalplus_gpac800_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
+
 protected:
 	void gpac800_internal_map(address_map &map) ATTR_COLD;
 
 	//virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 
-private:
-	void recalculate_calculate_effective_nand_address();
+	virtual const tiny_rom_entry *device_rom_region() const override ATTR_COLD;
 
+private:
 	u16 nand_7850_status_r();
-	u16 nand_7854_r();
+	u16 nand_data_r();
 	void nand_dma_ctrl_w(u16 data);
 	void nand_7850_w(u16 data);
 	void nand_command_w(u16 data);
 	void nand_addr_low_w(u16 data);
 	void nand_addr_high_w(u16 data);
-	u16 nand_ecc_low_byte_error_flag_1_r();
-	void nand_7856_type_w(u16 data);
-	void nand_7857_w(u16 data);
-	void nand_785b_w(u16 data);
-	void nand_785c_w(u16 data);
-	void nand_785d_w(u16 data);
-	u16 nand_785e_r();
+	u16 nand_ecc_err1_lb_r();
+	void nand_bch_ctrl_w(u16 data);
+	void nand_ecc_ctrl_w(u16 data);
+	void nand_ecc_lpr_ckl_lb_w(u16 data);
+	void nand_ecc_lpr_ckh_lb_w(u16 data);
+	void nand_ecc_cpckr_lb_w(u16 data);
+	u16 nand_ecc_err0_lb_r();
 
-	u16 m_nandcommand;
+	u16 spi_rxstatus_r();
+
+	u16 efuse2_r();
 
 	u16 m_nand_addr_low;
 	u16 m_nand_addr_high;
 
 	u16 m_nand_dma_ctrl;
-	u16 m_nand_7850;
-	u16 m_nand_785d;
-	u16 m_nand_785c;
-	u16 m_nand_785b;
-	u16 m_nand_7856;
-	u16 m_nand_7857;
-
-	int m_curblockaddr;
-	u32 m_effectiveaddress;
+	u16 m_nand_ctrl;
+	u16 m_nand_ecc_cpckr_lb;
+	u16 m_nand_ecc_lpr_ckh_lb;
+	u16 m_nand_ecc_lpr_ckl_lb;
+	u16 m_nand_bch_ctrl;
+	u16 m_nand_ecc_ctrl;
 };
 
-
-class generalplus_gpspispi_device : public sunplus_gcm394_base_device
-{
-public:
-	template <typename T>
-	generalplus_gpspispi_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, T &&screen_tag) :
-		generalplus_gpspispi_device(mconfig, tag, owner, clock)
-	{
-		m_screen.set_tag(std::forward<T>(screen_tag));
-		m_csbase = 0x30000;
-	}
-
-	generalplus_gpspispi_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
-
-protected:
-	void gpspispi_internal_map(address_map &map) ATTR_COLD;
-
-	//virtual void device_start() override ATTR_COLD;
-	//virtual void device_reset() override ATTR_COLD;
-
-private:
-	u16 spi_unk_7943_r();
-};
-
-DECLARE_DEVICE_TYPE(GPAC800, generalplus_gpac800_device)
-DECLARE_DEVICE_TYPE(GP_SPISPI, generalplus_gpspispi_device)
-
+DECLARE_DEVICE_TYPE(GPL16250, generalplus_gpac800_device)
 
 #endif // MAME_MACHINE_GENERALPLUS_GPL1625X_SOC_H

--- a/src/devices/machine/generalplus_gpl1625x_soc.h
+++ b/src/devices/machine/generalplus_gpl1625x_soc.h
@@ -34,6 +34,7 @@ protected:
 private:
 	u16 nand_7850_status_r();
 	u16 nand_data_r();
+	void nand_data_w(u16 data);
 	void nand_dma_ctrl_w(u16 data);
 	void nand_7850_w(u16 data);
 	void nand_command_w(u16 data);

--- a/src/devices/machine/generalplus_gpl162xx_soc.cpp
+++ b/src/devices/machine/generalplus_gpl162xx_soc.cpp
@@ -35,7 +35,7 @@
 #include "logmacro.h"
 
 
-DEFINE_DEVICE_TYPE(GCM394, sunplus_gcm394_device, "gcm394", "GeneralPlus GPL16250 System-on-a-Chip")
+DEFINE_DEVICE_TYPE(GCM394, sunplus_gcm394_device, "gcm394", "GeneralPlus GPL1622x/GPL1623x/GPL1624x System-on-a-Chip")
 
 sunplus_gcm394_base_device::sunplus_gcm394_base_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, address_map_constructor internal) :
 	unsp_20_device(mconfig, type, tag, owner, clock, internal),
@@ -53,10 +53,12 @@ sunplus_gcm394_base_device::sunplus_gcm394_base_device(const machine_config &mco
 	m_portb_out(*this),
 	m_portc_out(*this),
 	m_portd_out(*this),
-	m_nand_read_cb(*this, 0),
+	m_nand_command_out(*this),
+	m_nand_address_out(*this),
+	m_nand_data_out(*this),
+	m_nand_data_in(*this, 0),
 	m_cs_space(*this, finder_base::DUMMY_TAG, -1),
 	m_csbase(0x20000),
-	m_romtype(0),
 	m_space_read_cb(*this, 0),
 	m_space_write_cb(*this),
 	m_dma_complete_cb(*this),
@@ -1829,7 +1831,6 @@ void sunplus_gcm394_base_device::device_start()
 	save_item(NAME(m_adc_setup));
 	save_item(NAME(m_madc_ctrl));
 	save_item(NAME(m_csbase));
-	save_item(NAME(m_romtype));
 	save_item(NAME(m_timera_ctrl));
 	save_item(NAME(m_timerb_ctrl));
 }

--- a/src/devices/machine/generalplus_gpl162xx_soc.h
+++ b/src/devices/machine/generalplus_gpl162xx_soc.h
@@ -45,7 +45,13 @@ public:
 	auto space_write_callback() { return m_space_write_cb.bind(); }
 	auto dma_complete_callback() { return m_dma_complete_cb.bind(); }
 
-	auto nand_read_callback() { return m_nand_read_cb.bind(); }
+	// currently used by GPL16250, but GPL16230 adds NAND support too
+	auto nand_command_out() { return m_nand_command_out.bind(); }
+	auto nand_address_out() { return m_nand_address_out.bind(); }
+	auto nand_data_out() { return m_nand_data_out.bind(); }
+
+	auto nand_data_in() { return m_nand_data_in.bind(); }
+
 
 	// hack for beijuehh / bornkidh
 	void disable_timebase_interrupts() { m_disable_timebase_interrupts = true; }
@@ -68,8 +74,6 @@ public:
 
 	void set_legacy_video_mode() { m_spg_video->set_legacy_video_mode(); }
 	void set_disallow_resolution_control() { m_spg_video->set_disallow_resolution_control(); }
-
-	void set_romtype(int romtype) { m_romtype = romtype; }
 
 	u16 get_ram_addr(u32 addr) { return m_mainram[addr]; }
 
@@ -102,7 +106,12 @@ protected:
 	devcb_write16 m_portc_out;
 	devcb_write16 m_portd_out;
 
-	devcb_read16 m_nand_read_cb;
+	devcb_write8 m_nand_command_out;
+	devcb_write8 m_nand_address_out;
+	devcb_write8 m_nand_data_out;
+
+	devcb_read8 m_nand_data_in;
+
 	optional_address_space m_cs_space;
 	u32 m_csbase;
 
@@ -171,7 +180,6 @@ protected:
 	void cs_space_w(offs_t offset, u16 data);
 	u16 cs_bank_space_r(offs_t offset);
 	void cs_bank_space_w(offs_t offset, u16 data);
-	int m_romtype;
 
 protected:
 	devcb_read16 m_space_read_cb;

--- a/src/devices/machine/nandflash.cpp
+++ b/src/devices/machine/nandflash.cpp
@@ -29,6 +29,12 @@ DEFINE_DEVICE_TYPE(SAMSUNG_K9F1G08U0M,  samsung_k9f1g08u0m_device,  "samsung_k9f
 DEFINE_DEVICE_TYPE(SAMSUNG_K9LAG08U0M,  samsung_k9lag08u0m_device,  "samsung_k9lag08u0m",  "Samsung K9LAG08U0M")
 DEFINE_DEVICE_TYPE(SAMSUNG_K9F2G08U0M,  samsung_k9f2g08u0m_device,  "samsung_k9f2g08u0m",  "Samsung K9F2G08U0M")
 DEFINE_DEVICE_TYPE(TOSHIBA_TC58256AFT,  toshiba_tc58256aft_device,  "toshiba_tc58256aft",  "Toshiba TC58256AFT")
+DEFINE_DEVICE_TYPE(GENERALPLUS_GPR27P512A,  generalplus_gpr27p512a,  "generalplus_gpr27p512a",  "GeneralPlus GPR27P512A")
+DEFINE_DEVICE_TYPE(SANDISK_NAND_128MB_512_DEVICE,  sandisk_nand_128mb_512_device,  "sandisk_nand_128mb_512",  "Sandisk 128Mbyte NAND (512+16 block size)") // found on JAKKS Pacific units, part number was erased
+DEFINE_DEVICE_TYPE(SANDISK_NAND_256MB_512_DEVICE,  sandisk_nand_256mb_512_device,  "sandisk_nand_256mb_512",  "Sandisk 256Mbyte NAND (512+16 block size)") // found on JAKKS Pacific units, part number was erased
+DEFINE_DEVICE_TYPE(HYNIX_HY27UF084G2M,  hynix_hy27uf084g2m_device,  "hynix_hy27uf084g2m",  "Hynix HY27UF084G2M")
+
+
 
 nand_device::nand_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: nand_device(mconfig, NAND, tag, owner, clock)
@@ -183,6 +189,24 @@ samsung_k9f2g08u0m_device::samsung_k9f2g08u0m_device(const machine_config &mconf
 	m_sequential_row_read = 0;
 }
 
+hynix_hy27uf084g2m_device::hynix_hy27uf084g2m_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: nand_device(mconfig, HYNIX_HY27UF084G2M, tag, owner, clock)
+{
+	m_id_len = 4;
+	m_id[0] = 0xad;
+	m_id[1] = 0xdc;
+	m_id[2] = 0x80;
+	m_id[3] = 0x95;
+	m_page_data_size = 2048;
+	m_page_total_size = 2048 + 64;
+	m_log2_pages_per_block = compute_log2(64);
+	m_num_pages = 64 * 4096;
+	m_col_address_cycles = 2;
+	m_row_address_cycles = 3;
+	m_sequential_row_read = 1; // uncertain
+}
+
+
 toshiba_tc58256aft_device::toshiba_tc58256aft_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: nand_device(mconfig, TOSHIBA_TC58256AFT, tag, owner, clock)
 {
@@ -197,6 +221,53 @@ toshiba_tc58256aft_device::toshiba_tc58256aft_device(const machine_config &mconf
 	m_row_address_cycles = 2;
 	m_sequential_row_read = 0;
 }
+
+generalplus_gpr27p512a::generalplus_gpr27p512a(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: nand_device(mconfig, GENERALPLUS_GPR27P512A, tag, owner, clock)
+{
+	m_id_len = 2;
+	m_id[0] = 0xc2;
+	m_id[1] = 0x76;
+	m_page_data_size = 512;
+	m_page_total_size = 512 + 16;
+	m_log2_pages_per_block = compute_log2(32);
+	m_num_pages = 32 * 4096;
+	m_col_address_cycles = 1;
+	m_row_address_cycles = 3;
+	m_sequential_row_read = 1;
+}
+
+sandisk_nand_128mb_512_device::sandisk_nand_128mb_512_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: nand_device(mconfig, SANDISK_NAND_128MB_512_DEVICE, tag, owner, clock)
+{
+	m_id_len = 2;
+	m_id[0] = 0x45;
+	m_id[1] = 0x79;
+	m_page_data_size = 512;
+	m_page_total_size = 512 + 16;
+	m_log2_pages_per_block = compute_log2(32);
+	m_num_pages = 32 * 8192;
+	m_col_address_cycles = 1;
+	m_row_address_cycles = 3;
+	m_sequential_row_read = 1;
+}
+
+sandisk_nand_256mb_512_device::sandisk_nand_256mb_512_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: nand_device(mconfig, SANDISK_NAND_256MB_512_DEVICE, tag, owner, clock)
+{
+	m_id_len = 2;
+	m_id[0] = 0x45;
+	m_id[1] = 0xda;
+	m_page_data_size = 512;
+	m_page_total_size = 512 + 16;
+	m_log2_pages_per_block = compute_log2(32);
+	m_num_pages = 32 * 16384;
+	m_col_address_cycles = 1;
+	m_row_address_cycles = 3;
+	m_sequential_row_read = 1; // uncertain
+}
+
+
 
 void nand_device::device_start()
 {

--- a/src/devices/machine/nandflash.cpp
+++ b/src/devices/machine/nandflash.cpp
@@ -35,7 +35,6 @@ DEFINE_DEVICE_TYPE(SANDISK_NAND_256MB_512_DEVICE,  sandisk_nand_256mb_512_device
 DEFINE_DEVICE_TYPE(HYNIX_HY27UF084G2M,  hynix_hy27uf084g2m_device,  "hynix_hy27uf084g2m",  "Hynix HY27UF084G2M")
 
 
-
 nand_device::nand_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: nand_device(mconfig, NAND, tag, owner, clock)
 {
@@ -206,7 +205,6 @@ hynix_hy27uf084g2m_device::hynix_hy27uf084g2m_device(const machine_config &mconf
 	m_sequential_row_read = 1; // uncertain
 }
 
-
 toshiba_tc58256aft_device::toshiba_tc58256aft_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: nand_device(mconfig, TOSHIBA_TC58256AFT, tag, owner, clock)
 {
@@ -266,7 +264,6 @@ sandisk_nand_256mb_512_device::sandisk_nand_256mb_512_device(const machine_confi
 	m_row_address_cycles = 3;
 	m_sequential_row_read = 1; // uncertain
 }
-
 
 
 void nand_device::device_start()

--- a/src/devices/machine/nandflash.h
+++ b/src/devices/machine/nandflash.h
@@ -33,6 +33,12 @@ public:
 	void address_w(uint8_t data);
 	void data_w(uint8_t data);
 
+	// used for bootstrap HLE where it helps to know the page sizes
+	uint32_t page_data_size() { return m_page_data_size;  }
+	uint32_t page_total_size() { return m_page_total_size; }
+	u8* nand_data() { return &m_feeprom_data[0]; }
+	uint32_t nand_size() { return m_page_total_size * m_num_pages; }
+
 protected:
 	enum sm_mode_t : uint8_t
 	{
@@ -148,11 +154,37 @@ public:
 	samsung_k9f2g08u0m_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 };
 
+class hynix_hy27uf084g2m_device : public nand_device
+{
+public:
+	hynix_hy27uf084g2m_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+};
+
+
 class toshiba_tc58256aft_device : public nand_device
 {
 public:
 	toshiba_tc58256aft_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 };
+
+class generalplus_gpr27p512a : public nand_device
+{
+public:
+	generalplus_gpr27p512a(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+};
+
+class sandisk_nand_128mb_512_device : public nand_device
+{
+public:
+	sandisk_nand_128mb_512_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+};
+
+class sandisk_nand_256mb_512_device : public nand_device
+{
+public:
+	sandisk_nand_256mb_512_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+};
+
 
 // device type definition
 DECLARE_DEVICE_TYPE(NAND, nand_device)
@@ -164,6 +196,10 @@ DECLARE_DEVICE_TYPE(SAMSUNG_K9F1G08U0B, samsung_k9f1g08u0b_device)
 DECLARE_DEVICE_TYPE(SAMSUNG_K9F1G08U0M, samsung_k9f1g08u0m_device)
 DECLARE_DEVICE_TYPE(SAMSUNG_K9LAG08U0M, samsung_k9lag08u0m_device)
 DECLARE_DEVICE_TYPE(SAMSUNG_K9F2G08U0M, samsung_k9f2g08u0m_device)
+DECLARE_DEVICE_TYPE(HYNIX_HY27UF084G2M, hynix_hy27uf084g2m_device)
 DECLARE_DEVICE_TYPE(TOSHIBA_TC58256AFT, toshiba_tc58256aft_device)
+DECLARE_DEVICE_TYPE(GENERALPLUS_GPR27P512A, generalplus_gpr27p512a)
+DECLARE_DEVICE_TYPE(SANDISK_NAND_128MB_512_DEVICE, sandisk_nand_128mb_512_device)
+DECLARE_DEVICE_TYPE(SANDISK_NAND_256MB_512_DEVICE, sandisk_nand_256mb_512_device)
 
 #endif // MAME_MACHINE_NANDFLASH_H

--- a/src/mame/tvgames/generalplus_gpl16250_mobigo.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_mobigo.cpp
@@ -113,7 +113,7 @@ void mobigo2_state::mobigo2(machine_config &config)
 {
 	set_addrmap(0, &mobigo2_state::cs_map_base);
 
-	GPAC800(config, m_maincpu, 96000000/2, m_screen);  // Doesn't have GPnandnand header in NAND tho, so non-standard bootloader
+	GPL16250(config, m_maincpu, 96000000/2, m_screen);  // Doesn't have GPnandnand header in NAND tho, so non-standard bootloader
 	m_maincpu->porta_in().set(FUNC(mobigo2_state::porta_r));
 	m_maincpu->portb_in().set(FUNC(mobigo2_state::portb_r));
 	m_maincpu->portc_in().set(FUNC(mobigo2_state::portc_r));
@@ -125,8 +125,6 @@ void mobigo2_state::mobigo2(machine_config &config)
 	m_maincpu->add_route(ALL_OUTPUTS, "speaker", 0.5, 1);
 	m_maincpu->set_bootmode(0); // boot from internal ROM (NAND bootstrap)
 	m_maincpu->set_cs_config_callback(FUNC(mobigo2_state::cs_callback));
-
-	m_maincpu->nand_read_callback().set(FUNC(mobigo2_state::read_nand));
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_refresh_hz(60);
@@ -143,6 +141,8 @@ void mobigo2_state::mobigo2(machine_config &config)
 	//m_cart->set_must_be_loaded(true);
 
 	SOFTWARE_LIST(config, "cart_list").set_original("mobigo_cart");
+
+	SAMSUNG_K9F1G08U0M(config, m_nand); // 128Mbyte part, with 0x800+0x40 sized pages
 }
 
 void mobigo_state::init_mobigo()
@@ -168,8 +168,8 @@ ROM_END
 
 
 ROM_START( mobigo2 )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // doesn't have GPnandnand header in NAND, so bootstrap is likely custom
+	//ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
+	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // doesn't have GPnandnand header in NAND, so bootstrap is likely custom
 
 	ROM_REGION( 0x8400000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "mobigo2_bios_ger.bin", 0x00000, 0x8400000, CRC(d5ab613d) SHA1(6fb104057dc3484fa958e2cb20c5dd0c19589f75) ) // SPANSION S34ML01G100TF100
@@ -180,4 +180,4 @@ ROM_END
 
 CONS( 2010, mobigo,  0,      0, mobigo,   mobigo, mobigo_state,  init_mobigo , "VTech", "MobiGo (USA)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 CONS( 2011, mobigos, mobigo, 0, mobigo,   mobigo, mobigo_state,  init_mobigo , "VTech", "MobiGo (Spain)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-CONS( 2013, mobigo2, 0,      0, mobigo2,  mobigo, mobigo2_state, nand_init840, "VTech", "MobiGo 2 (Germany)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2013, mobigo2, 0,      0, mobigo2,  mobigo, mobigo2_state, nand_init,    "VTech", "MobiGo 2 (Germany)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/tvgames/generalplus_gpl16250_nand.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_nand.cpp
@@ -51,27 +51,6 @@ void generalplus_gpac800_game_state::cs1_w(offs_t offset, u16 data)
 	m_sdram[offset & (m_sdram_kwords-1)] = data;
 }
 
-
-u8 generalplus_gpac800_game_state::nand_data_in(offs_t offset)
-{
-	return m_nand->data_r();
-}
-
-void generalplus_gpac800_game_state::nand_data_out(offs_t offset, u8 data)
-{
-	logerror("nand_data_out %02x\n", data);
-}
-
-void generalplus_gpac800_game_state::nand_address_out(offs_t offset, u8 data)
-{
-	m_nand->address_w(data);
-}
-
-void generalplus_gpac800_game_state::nand_command_out(offs_t offset, u8 data)
-{
-	m_nand->command_w(data);
-}
-
 void generalplus_gpac800_game_state::dma_complete_hacks(int state)
 {
 	// HACKS to get into service mode for debugging (needed for testing as many of these require input sequences on the not yet emulated custom controls)
@@ -121,10 +100,10 @@ void generalplus_gpac800_game_state::generalplus_gpac800(machine_config &config)
 	m_maincpu->set_cs_config_callback(FUNC(gcm394_game_state::cs_callback));
 	m_maincpu->set_cs_space(DEVICE_SELF, 0);
 	m_maincpu->dma_complete_callback().set(FUNC(generalplus_gpac800_game_state::dma_complete_hacks));
-	m_maincpu->nand_command_out().set(FUNC(generalplus_gpac800_game_state::nand_command_out));
-	m_maincpu->nand_address_out().set(FUNC(generalplus_gpac800_game_state::nand_address_out));
-	m_maincpu->nand_data_out().set(FUNC(generalplus_gpac800_game_state::nand_data_out));
-	m_maincpu->nand_data_in().set(FUNC(generalplus_gpac800_game_state::nand_data_in));
+	m_maincpu->nand_command_out().set(m_nand, FUNC(nand_device::command_w));
+	m_maincpu->nand_address_out().set(m_nand, FUNC(nand_device::address_w));
+	m_maincpu->nand_data_out().set(m_nand, FUNC(nand_device::data_w));
+	m_maincpu->nand_data_in().set(m_nand, FUNC(nand_device::data_r));
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_refresh_hz(60);

--- a/src/mame/tvgames/generalplus_gpl16250_nand.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_nand.cpp
@@ -51,23 +51,27 @@ void generalplus_gpac800_game_state::cs1_w(offs_t offset, u16 data)
 	m_sdram[offset & (m_sdram_kwords-1)] = data;
 }
 
-u8 generalplus_gpac800_game_state::read_nand(offs_t offset)
+
+u8 generalplus_gpac800_game_state::nand_data_in(offs_t offset)
 {
-	if (!m_nandregion)
-		return 0x0000;
-
-	if (offset < m_size)
-	{
-		return m_nandregion[offset];
-	}
-	else
-	{
-		popmessage("read outside of NAND ROM space (offset %08x) (size %08x)\n", offset, m_size);
-		return 0xff;
-	}
-
-	return 0x00;
+	return m_nand->data_r();
 }
+
+void generalplus_gpac800_game_state::nand_data_out(offs_t offset, u8 data)
+{
+	logerror("nand_data_out %02x\n", data);
+}
+
+void generalplus_gpac800_game_state::nand_address_out(offs_t offset, u8 data)
+{
+	m_nand->address_w(data);
+}
+
+void generalplus_gpac800_game_state::nand_command_out(offs_t offset, u8 data)
+{
+	m_nand->command_w(data);
+}
+
 void generalplus_gpac800_game_state::dma_complete_hacks(int state)
 {
 	// HACKS to get into service mode for debugging (needed for testing as many of these require input sequences on the not yet emulated custom controls)
@@ -103,7 +107,7 @@ void generalplus_gpac800_game_state::generalplus_gpac800(machine_config &config)
 {
 	set_addrmap(0, &generalplus_gpac800_game_state::cs_map_base);
 
-	GPAC800(config, m_maincpu, 96000000/2, m_screen);
+	GPL16250(config, m_maincpu, 96000000/2, m_screen);
 	m_maincpu->porta_in().set(FUNC(generalplus_gpac800_game_state::porta_r));
 	m_maincpu->portb_in().set(FUNC(generalplus_gpac800_game_state::portb_r));
 	m_maincpu->portc_in().set(FUNC(generalplus_gpac800_game_state::portc_r));
@@ -117,8 +121,10 @@ void generalplus_gpac800_game_state::generalplus_gpac800(machine_config &config)
 	m_maincpu->set_cs_config_callback(FUNC(gcm394_game_state::cs_callback));
 	m_maincpu->set_cs_space(DEVICE_SELF, 0);
 	m_maincpu->dma_complete_callback().set(FUNC(generalplus_gpac800_game_state::dma_complete_hacks));
-
-	m_maincpu->nand_read_callback().set(FUNC(generalplus_gpac800_game_state::read_nand));
+	m_maincpu->nand_command_out().set(FUNC(generalplus_gpac800_game_state::nand_command_out));
+	m_maincpu->nand_address_out().set(FUNC(generalplus_gpac800_game_state::nand_address_out));
+	m_maincpu->nand_data_out().set(FUNC(generalplus_gpac800_game_state::nand_data_out));
+	m_maincpu->nand_data_in().set(FUNC(generalplus_gpac800_game_state::nand_data_in));
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_refresh_hz(60);
@@ -128,6 +134,36 @@ void generalplus_gpac800_game_state::generalplus_gpac800(machine_config &config)
 	m_screen->screen_vblank().set(m_maincpu, FUNC(sunplus_gcm394_device::vblank));
 
 	SPEAKER(config, "speaker", 2).front();
+}
+
+void generalplus_gpac800_game_state::generalplus_gpac800_nand64mbyte(machine_config &config)
+{
+	generalplus_gpac800(config);
+	GENERALPLUS_GPR27P512A(config, m_nand); // 64Mbyte part, with 0x200+0x10 sized pages (accepts many compatible devices)
+}
+
+void generalplus_gpac800_game_state::generalplus_gpac800_nand128mbyte(machine_config &config)
+{
+	generalplus_gpac800(config);
+	SANDISK_NAND_128MB_512_DEVICE(config, m_nand); // 128Mbyte part, with 0x200+0x10 sized pages (accepts many compatible devices)
+}
+
+void generalplus_gpac800_game_state::generalplus_gpac800_nand256mbyte(machine_config &config)
+{
+	generalplus_gpac800(config);
+	SANDISK_NAND_256MB_512_DEVICE(config, m_nand); // 256Mbyte part, with 0x200+0x10 sized pages (accepts many compatible devices)
+}
+
+void generalplus_gpac800_game_state::generalplus_gpac800_nand128mbyte_2048(machine_config &config)
+{
+	generalplus_gpac800(config);
+	SAMSUNG_K9F1G08U0M(config, m_nand); // 128Mbyte part, with 0x800+0x40 sized pages
+}
+
+void generalplus_gpac800_game_state::generalplus_gpac800_nand512mbyte_2048(machine_config &config)
+{
+	generalplus_gpac800(config);
+	HYNIX_HY27UF084G2M(config, m_nand); // 512Mbyte part, with 0x800+0x40 sized pages
 }
 
 DEVICE_IMAGE_LOAD_MEMBER(generalplus_gpac800_vbaby_game_state::cart_load)
@@ -140,9 +176,9 @@ DEVICE_IMAGE_LOAD_MEMBER(generalplus_gpac800_vbaby_game_state::cart_load)
 	return std::make_pair(std::error_condition(), std::string());
 }
 
-void generalplus_gpac800_vbaby_game_state::generalplus_gpac800_vbaby(machine_config &config)
+void generalplus_gpac800_vbaby_game_state::generalplus_gpac800_nand128mbyte_2048_vbaby(machine_config &config)
 {
-	generalplus_gpac800_game_state::generalplus_gpac800(config);
+	generalplus_gpac800_game_state::generalplus_gpac800_nand128mbyte_2048(config);
 
 	GENERIC_CARTSLOT(config, m_cart, generic_plain_slot, "vbaby_cart");
 	m_cart->set_width(GENERIC_ROM16_WIDTH);
@@ -481,34 +517,22 @@ INPUT_PORTS_END
 
 
 ROM_START( wlsair60 )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x8400000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "wlsair60.nand", 0x0000, 0x8400000, CRC(eec23b97) SHA1(1bb88290cf54579a5bb51c08a02d793cd4d79f7a) )
 ROM_END
 
 ROM_START( kiugames )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x21000000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "hy27084g2m.u2", 0x0000, 0x21000000, CRC(65cc3864) SHA1(b759ec9816fe98a33ee7d5e12e5492f0160c5b31) )
 ROM_END
 
 
 ROM_START( jak_gtg )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x4200000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "goldentee.bin", 0x0000, 0x4200000, CRC(87d5e815) SHA1(5dc46cd753b791449cc41d5eff4928c0dcaf35c0) )
 ROM_END
 
 ROM_START( jak_car2 )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x4200000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "cars2.bin", 0x0000, 0x4200000, CRC(4d610e09) SHA1(bc59f5f7f676a8f2a78dfda7fb62c804bbf850b6) )
 ROM_END
@@ -543,9 +567,6 @@ One of the games has pin 2 grounded, and the other 2 have it N/C.  I'm not sure 
 */
 
 ROM_START( jak_sspop )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	/* TSOP32 NAND ROM
 
 	S976172-1
@@ -564,9 +585,6 @@ ROM_START( jak_sspop )
 ROM_END
 
 ROM_START( jak_hmhsm )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	/* TSOP32 NAND ROM
 
 	5769522.1
@@ -585,42 +603,27 @@ ROM_START( jak_hmhsm )
 ROM_END
 
 ROM_START( jak_camp )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x10800000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "camprockguitar1_sandisk11352-256b_45da.bin", 0x0000, 0x10800000, CRC(f52a4289) SHA1(d027ae274cd4ac97924d2344df1a96456e8e7c55) )
 ROM_END
 
 ROM_START( jak_hmpt )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x10800000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "hmsecretstar_sandisk11270_9876.bin", 0x0000, 0x10800000, CRC(fbe09633) SHA1(169a1546072f53c2da19ce97396cacd25412c5f2) )
 ROM_END
 
 ROM_START( jak_hsmg2 )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x4200000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "hsm_as_hy27ys08121a_9876.bin", 0x0000, 0x4200000, CRC(4da61056) SHA1(d6c529a6df2703dd55b864e9d7c655203206f8b6) )
 ROM_END
 
 ROM_START( jak_hmg2 )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x4200000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "hm_as_hy27us08121a_9876_fixed.bin", 0x0000, 0x4200000, BAD_DUMP CRC(ba97fcd6) SHA1(c02a6878910b1312009b21220d51d7c1c3adb767) ) // 4 blocks had to be fixed using data from jak_hmhsm
 ROM_END
 
 
 ROM_START( jak_umdf )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	/* TSOP32 NAND ROM
 
 	S744565-1
@@ -640,76 +643,49 @@ ROM_END
 
 
 ROM_START( jak_tsm )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x4200000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "toystorymania.bin", 0x0000, 0x4200000, CRC(183b20a5) SHA1(eb4fa5ee9dfac58f5244d00d4e833b1e461cc52c) )
 ROM_END
 
 
 ROM_START( jak_duck )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x4200000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "duckcommander_gpr27p512a_c276_as_hy27us08121a.bin", 0x0000, 0x4200000, CRC(d9356d5b) SHA1(aca05525b4a504f7ad264ae9bbc2f1f8f399c4ca) )
 ROM_END
 
 ROM_START( jak_swc )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x4200000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "jakksstarwarspistol_gpr27p512a_c276_as_hy27us08121a.bin", 0x0000, 0x4200000, CRC(024d49b8) SHA1(9694f4c7cd083c976ffbbcfa6f626fc6b4bc8d91) )
 ROM_END
 
 ROM_START( jak_wdzh )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x4200000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "walkingdeadrifle_gpr27p512a_c276_as_hy27us08121a.bin", 0x0000, 0x4200000, CRC(b2c762f0) SHA1(7e10df517cc24924e0ec55e2a263563023d945f8) )
 ROM_END
 
 ROM_START( jak_wdbg )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x4200000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "amcwalkingdeadcrossbow_gpr27p512a_c276_as_hy27us08121a.bin", 0x0000, 0x4200000, CRC(66510fd4) SHA1(3ad6347c5a7758c035654cb3e96858320875b97a) )
 ROM_END
 
 
 ROM_START( vbaby )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x8400000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "vbaby.bin", 0x0000, 0x8400000, CRC(d904441b) SHA1(3742bc4e1e403f061ce2813ecfafc6f30a44d287) )
 ROM_END
 
 ROM_START( tiviboo )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x8400000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "hy27uf081g2a.u3", 0x0000, 0x8400000, CRC(69d08014) SHA1(d290c646c8223b3a47c0579e19d15a6717c7e4a8) )
 ROM_END
 
 
 ROM_START( mgtfit )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x8400000, "nandrom", ROMREGION_ERASE00 ) // Samsung 937 K9F1G08U0D  Ident: 0xEC 0xF1 Full Ident: 0xECF1001540
 	ROM_LOAD( "k9f1g08u0d.bin", 0x0000, 0x8400000, CRC(1ca5ac09) SHA1(c2e123085d2198999c2c0edb1df4895361c00a99) )
 ROM_END
 
 ROM_START( beambox )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION( 0x4200000, "nandrom", ROMREGION_ERASE00 )
 	ROM_LOAD( "beambox.bin", 0x0000, 0x4200000, CRC(a486f04e) SHA1(73c7d99d8922eba58d94e955e254b9c3baa4443e) )
 ROM_END
@@ -724,20 +700,19 @@ void generalplus_gpac800_game_state::machine_start()
 
 void generalplus_gpac800_game_state::nand_create_stripped_region()
 {
-	u8 *rom = m_nandregion;
-	int size = memregion("nandrom")->bytes();
-	m_size = size;
+	u8 *rom = m_nand->nand_data();
+	uint32_t size = m_nand->nand_size();
 
-	int numblocks = size / m_nandblocksize;
-	m_strippedsize = numblocks * m_nandblocksize_stripped;
-	m_strippedrom.resize(m_strippedsize);
+	int numblocks = size / m_nand->page_total_size();
+	uint32_t strippedsize = numblocks * m_nand->page_data_size();
+	m_strippedrom.resize(strippedsize);
 
 	for (int i = 0; i < numblocks; i++)
 	{
-		const int base = i * m_nandblocksize;
-		const int basestripped = i * m_nandblocksize_stripped;
+		const int base = i * m_nand->page_total_size();
+		const int basestripped = i * m_nand->page_data_size();
 
-		for (int j = 0; j < m_nandblocksize_stripped; j++)
+		for (int j = 0; j < m_nand->page_data_size(); j++)
 		{
 			m_strippedrom[basestripped + j] = rom[(base + j)];
 		}
@@ -750,7 +725,7 @@ void generalplus_gpac800_game_state::nand_create_stripped_region()
 		auto fp = fopen(filename.c_str(), "w+b");
 		if (fp)
 		{
-			fwrite(&m_strippedrom[0], m_nandblocksize_stripped * numblocks, 1, fp);
+			fwrite(&m_strippedrom[0], m_nand->page_data_size() * numblocks, 1, fp);
 			fclose(fp);
 		}
 	}
@@ -766,7 +741,7 @@ void generalplus_gpac800_game_state::machine_reset()
 	mem.write_word(0x007823, 0x0047);
 	mem.write_word(0x007824, 0x0047);
 
-	if (m_nandregion)
+	if (m_nand)
 	{
 		nand_create_stripped_region();
 
@@ -866,6 +841,7 @@ void generalplus_gpac800_game_state::machine_reset()
 		internal[0x7ffd] = 0xff10;
 		internal[0x7ffe] = 0xff12;
 		internal[0x7fff] = 0xff14;
+
 	}
 
 	m_maincpu->reset(); // reset CPU so vector gets read etc.
@@ -874,52 +850,35 @@ void generalplus_gpac800_game_state::machine_reset()
 }
 
 
-void generalplus_gpac800_game_state::nand_init210()
+void generalplus_gpac800_game_state::nand_init()
 {
 	m_sdram.resize(m_sdram_kwords);
 	m_sdram2.resize(0x10000);
-
-	m_nandblocksize = 0x210;
-	m_nandblocksize_stripped = 0x200;
-
 	m_vectorbase = 0x6fe0;
 }
 
-void generalplus_gpac800_game_state::nand_init210_32mb()
+void generalplus_gpac800_game_state::nand_init_32mb()
 {
 	m_sdram_kwords = 0x400000 * 4;
-	nand_init210();
-}
-
-void generalplus_gpac800_game_state::nand_init840()
-{
-	m_sdram.resize(m_sdram_kwords);
-	m_sdram2.resize(0x10000);
-
-	m_nandblocksize = 0x840;
-	m_nandblocksize_stripped = 0x800;
-
-	m_vectorbase = 0x6fe0;
+	nand_init();
 }
 
 void generalplus_gpac800_game_state::nand_wlsair60()
 {
-	nand_init840();
+	nand_init();
 	m_initial_copy_words = 0x2800;
 }
 
 void generalplus_gpac800_game_state::nand_kiugames()
 {
-	nand_init840();
+	nand_init();
 	m_initial_copy_words = 0x10000;
 }
 
-
 void generalplus_gpac800_game_state::nand_vbaby()
 {
-	nand_init840();
+	nand_init();
 	m_initial_copy_words = 0x1000;
-	m_maincpu->set_romtype(2);
 }
 
 void generalplus_gpac800_game_state::nand_tsm()
@@ -932,43 +891,49 @@ void generalplus_gpac800_game_state::nand_tsm()
 
 	// the addresses written to the NAND device don't compensate for these data repeats, however dump seems ok as no other data is being repeated?
 	// reads after startup still need checking
-	nand_init210();
-	m_maincpu->set_romtype(1);
+	nand_init();
 }
 
 void generalplus_gpac800_game_state::nand_beambox()
 {
-	nand_init210();
+	nand_init();
 	m_vectorbase = 0x2fe0;
 }
 
 // NAND dumps w/ internal bootstrap (and u'nSP 2.0 extended opcodes)  (have gpnandnand strings)
 // the JAKKS ones seem to be known as 'Generalplus GPAC800' hardware
-CONS(2010, wlsair60,   0, 0, generalplus_gpac800,       jak_car2, generalplus_gpac800_game_state,       nand_wlsair60,      "Jungle Soft / Kids Station Toys Inc",      "Wireless Air 60",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // some of the games seem to be based on ones found in the 'Millennium Arcade' multigames (WinFun related) so might have the same external timer check
-CONS(200?, beambox,    0, 0, generalplus_gpac800,       jak_car2, generalplus_gpac800_game_state,       nand_beambox,       "Hasbro",                                   "Playskool Heroes Transformers Rescue Bots Beam Box (Spain)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
-CONS(200?, mgtfit,     0, 0, generalplus_gpac800,       jak_car2, generalplus_gpac800_game_state,       nand_wlsair60,      "MGT",                                      "Fitness Konsole (NC1470)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // probably has other names in English too? menus don't appear to be in German
-CONS(200?, vbaby,      0, 0, generalplus_gpac800_vbaby, jak_car2, generalplus_gpac800_vbaby_game_state, nand_vbaby,         "VTech",                                    "V.Baby", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
-CONS(200?, tiviboo,    0, 0, generalplus_gpac800,       jak_car2, generalplus_gpac800_game_state,       nand_vbaby,         "VTech",                                    "Tivi Boo (France)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
-CONS(200?, kiugames,   0, 0, generalplus_gpac800,       jak_car2, generalplus_gpac800_game_state,       nand_kiugames,      "VideoJet",                                 "Kiu Games",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // probably has other names in English too? menus don't appear to be in German
-
-CONS(2011, jak_gtg,    0, 0, generalplus_gpac800,       jak_gtg,  generalplus_gpac800_game_state,       nand_init210,       "JAKKS Pacific Inc / HotGen Ltd",           "Golden Tee Golf (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
-CONS(200?, jak_car2,   0, 0, generalplus_gpac800,       jak_car2, generalplus_gpac800_game_state,       nand_init210,       "JAKKS Pacific Inc / HotGen Ltd",           "Cars 2 (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
-CONS(2010, jak_tsm,    0, 0, generalplus_gpac800,       jak_car2, generalplus_gpac800_game_state,       nand_tsm,           "JAKKS Pacific Inc / Schell Games",         "Toy Story Mania (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
-CONS(2009, jak_sspop,  0, 0, generalplus_gpac800,       jak_hsm,  generalplus_gpac800_game_state,       nand_init210_32mb,  "JAKKS Pacific Inc / HotGen Ltd",           "Sing Scene Pop (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
-CONS(2008, jak_hmg2,   0, 0, generalplus_gpac800,       jak_hsm,  generalplus_gpac800_game_state,       nand_init210_32mb,  "JAKKS Pacific Inc / HotGen Ltd",           "Hannah Montana G2 Deluxe - All in One (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // Jul 9 2008 11:50:08
-CONS(2008, jak_hsmg2,  0, 0, generalplus_gpac800,       jak_hsm,  generalplus_gpac800_game_state,       nand_init210_32mb,  "JAKKS Pacific Inc / HotGen Ltd",           "High School Musical G2 Deluxe - All in One (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // Jun 25 2008 14:53:14
-CONS(2008, jak_hmhsm,  0, 0, generalplus_gpac800,       jak_hsm,  generalplus_gpac800_game_state,       nand_init210_32mb,  "JAKKS Pacific Inc / HotGen Ltd",           "Hannah Montana G2 Deluxe / High School Musical G2 Deluxe - Two in One (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // Sep 12 2008 18:48:14 (Menu/HM) / Sep 12 2008 18:50:45 (HSM)
-CONS(2008, jak_umdf,   0, 0, generalplus_gpac800,       jak_hsm,  generalplus_gpac800_game_state,       nand_init210_32mb,  "JAKKS Pacific Inc / Handheld Games",       "Ultimotion - Disney Fairies Sleeping Beauty & TinkerBell (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS(2011, jak_gtg,    0, 0, generalplus_gpac800_nand64mbyte,       jak_gtg,  generalplus_gpac800_game_state,       nand_init,       "JAKKS Pacific Inc / HotGen Ltd",           "Golden Tee Golf (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS(200?, jak_car2,   0, 0, generalplus_gpac800_nand64mbyte,       jak_car2, generalplus_gpac800_game_state,       nand_init,       "JAKKS Pacific Inc / HotGen Ltd",           "Cars 2 (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS(2010, jak_tsm,    0, 0, generalplus_gpac800_nand64mbyte,       jak_car2, generalplus_gpac800_game_state,       nand_tsm,           "JAKKS Pacific Inc / Schell Games",         "Toy Story Mania (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS(2009, jak_sspop,  0, 0, generalplus_gpac800_nand128mbyte,      jak_hsm,  generalplus_gpac800_game_state,       nand_init_32mb,  "JAKKS Pacific Inc / HotGen Ltd",           "Sing Scene Pop (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS(2008, jak_hmg2,   0, 0, generalplus_gpac800_nand64mbyte,       jak_hsm,  generalplus_gpac800_game_state,       nand_init_32mb,  "JAKKS Pacific Inc / HotGen Ltd",           "Hannah Montana G2 Deluxe - All in One (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // Jul 9 2008 11:50:08
+CONS(2008, jak_hsmg2,  0, 0, generalplus_gpac800_nand64mbyte,       jak_hsm,  generalplus_gpac800_game_state,       nand_init_32mb,  "JAKKS Pacific Inc / HotGen Ltd",           "High School Musical G2 Deluxe - All in One (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // Jun 25 2008 14:53:14
+CONS(2008, jak_hmhsm,  0, 0, generalplus_gpac800_nand256mbyte,      jak_hsm,  generalplus_gpac800_game_state,       nand_init_32mb,  "JAKKS Pacific Inc / HotGen Ltd",           "Hannah Montana G2 Deluxe / High School Musical G2 Deluxe - Two in One (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // Sep 12 2008 18:48:14 (Menu/HM) / Sep 12 2008 18:50:45 (HSM)
+CONS(2008, jak_umdf,   0, 0, generalplus_gpac800_nand256mbyte,      jak_hsm,  generalplus_gpac800_game_state,       nand_init_32mb,  "JAKKS Pacific Inc / Handheld Games",       "Ultimotion - Disney Fairies Sleeping Beauty & TinkerBell (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
 // Ultimotion Swing Zone is SPG29xx instead
-CONS(2008, jak_camp,   0, 0, generalplus_gpac800,       jak_hsm,  generalplus_gpac800_game_state,       nand_init210_32mb,  "JAKKS Pacific Inc / HotGen Ltd",           "Camp Rock - Guitar Video Game (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS(2008, jak_camp,   0, 0, generalplus_gpac800_nand256mbyte,      jak_hsm,  generalplus_gpac800_game_state,       nand_init_32mb,  "JAKKS Pacific Inc / HotGen Ltd",           "Camp Rock - Guitar Video Game (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
 
 // 2 blocks fail the hidden ROM test in jak_hmpt set below, however this seems to be an error in the test mode, not the dump
 // a different set, https://www.youtube.com/watch?v=XiEMtLzcTFw showing a date of May 14 2008 10:05:22 shows exactly the same failures
-CONS(2008, jak_hmpt,   0, 0, generalplus_gpac800,       jak_hsm,  generalplus_gpac800_game_state,       nand_init210_32mb,  "JAKKS Pacific Inc / HotGen Ltd",           "Hannah Montana Pop Tour - Guitar Video Game (JAKKS Pacific TV Game) (May 16 2008)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // May 16 2008 10:36:59
+CONS(2008, jak_hmpt,   0, 0, generalplus_gpac800_nand256mbyte,      jak_hsm,  generalplus_gpac800_game_state,       nand_init_32mb,  "JAKKS Pacific Inc / HotGen Ltd",           "Hannah Montana Pop Tour - Guitar Video Game (JAKKS Pacific TV Game) (May 16 2008)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // May 16 2008 10:36:59
 
 // There were 1 player and 2 player versions for several of the JAKKS guns.  The 2nd gun appears to be simply a controller (no AV connectors) but as they were separate products with the 2 player versions being released up to a year after the original, the code could differ.
 // If they differ, it is currently uncertain which versions these ROMs are from
-CONS(2012, jak_wdzh,   0, 0, generalplus_gpac800,       jak_car2, generalplus_gpac800_game_state,       nand_init210,       "JAKKS Pacific Inc / Merge Interactive",    "The Walking Dead: Zombie Hunter (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // gun games all had Atmel 16CM (24C16).
-CONS(2013, jak_duck,   0, 0, generalplus_gpac800,       jak_car2, generalplus_gpac800_game_state,       nand_init210_32mb,  "JAKKS Pacific Inc / Merge Interactive",    "Duck Commander (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // no 2 Player version was released
-CONS(2013, jak_swc,    0, 0, generalplus_gpac800,       jak_car2, generalplus_gpac800_game_state,       nand_init210_32mb,  "JAKKS Pacific Inc / Merge Interactive",    "Star Wars Clone Trooper (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
-CONS(2014, jak_wdbg,   0, 0, generalplus_gpac800,       jak_car2, generalplus_gpac800_game_state,       nand_init210_32mb,  "JAKKS Pacific Inc / Super Happy Fun Fun",  "The Walking Dead: Battleground (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS(2012, jak_wdzh,   0, 0, generalplus_gpac800_nand64mbyte,       jak_car2, generalplus_gpac800_game_state,       nand_init,       "JAKKS Pacific Inc / Merge Interactive",    "The Walking Dead: Zombie Hunter (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // gun games all had Atmel 16CM (24C16).
+CONS(2013, jak_duck,   0, 0, generalplus_gpac800_nand64mbyte,       jak_car2, generalplus_gpac800_game_state,       nand_init_32mb,  "JAKKS Pacific Inc / Merge Interactive",    "Duck Commander (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // no 2 Player version was released
+CONS(2013, jak_swc,    0, 0, generalplus_gpac800_nand64mbyte,       jak_car2, generalplus_gpac800_game_state,       nand_init_32mb,  "JAKKS Pacific Inc / Merge Interactive",    "Star Wars Clone Trooper (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS(2014, jak_wdbg,   0, 0, generalplus_gpac800_nand64mbyte,       jak_car2, generalplus_gpac800_game_state,       nand_init_32mb,  "JAKKS Pacific Inc / Super Happy Fun Fun",  "The Walking Dead: Battleground (JAKKS Pacific TV Game)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+
+
+// these are probably a GPL162xxB as they expect code to be copied to a lower address, and set the stack just below 0x3000
+// B models have only 12K words of RAM, but the GPL16250 boot ROMs we've seen are hardcoded to look for vectors above that
+CONS(200?, beambox,    0, 0, generalplus_gpac800_nand64mbyte,       jak_car2, generalplus_gpac800_game_state,       nand_beambox,       "Hasbro",                                   "Playskool Heroes Transformers Rescue Bots Beam Box (Spain)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS(2010, wlsair60,   0, 0, generalplus_gpac800_nand128mbyte_2048, jak_car2, generalplus_gpac800_game_state,       nand_wlsair60,      "Jungle Soft / Kids Station Toys Inc",      "Wireless Air 60",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // some of the games seem to be based on ones found in the 'Millennium Arcade' multigames (WinFun related) so might have the same external timer check
+
+// these might also be B models
+CONS(200?, mgtfit,     0, 0, generalplus_gpac800_nand128mbyte_2048,       jak_car2, generalplus_gpac800_game_state,       nand_wlsair60,      "MGT",                                      "Fitness Konsole (NC1470)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // probably has other names in English too? menus don't appear to be in German
+CONS(200?, vbaby,      0, 0, generalplus_gpac800_nand128mbyte_2048_vbaby, jak_car2, generalplus_gpac800_vbaby_game_state, nand_vbaby,         "VTech",                                    "V.Baby", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS(200?, tiviboo,    0, 0, generalplus_gpac800_nand128mbyte_2048,       jak_car2, generalplus_gpac800_game_state,       nand_vbaby,         "VTech",                                    "Tivi Boo (France)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+
+// this one is strange, the area specified in the header to copy the code to is an unmapped area?
+CONS(200?, kiugames,   0, 0, generalplus_gpac800_nand512mbyte_2048,      jak_car2, generalplus_gpac800_game_state,       nand_kiugames,      "VideoJet",                                 "Kiu Games",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING) // probably has other names in English too? menus don't appear to be in German

--- a/src/mame/tvgames/generalplus_gpl16250_nand.h
+++ b/src/mame/tvgames/generalplus_gpl16250_nand.h
@@ -10,6 +10,7 @@
 #include "bus/generic/carts.h"
 #include "bus/generic/slot.h"
 #include "machine/generalplus_gpl1625x_soc.h"
+#include "machine/nandflash.h"
 
 #include "screen.h"
 #include "speaker.h"
@@ -20,17 +21,22 @@ class generalplus_gpac800_game_state : public gcm394_game_state
 public:
 	generalplus_gpac800_game_state(const machine_config &mconfig, device_type type, const char *tag) :
 		gcm394_game_state(mconfig, type, tag),
-		m_nandregion(*this, "nandrom"),
+		m_nand(*this, "nandrom"),
 		m_sdram_kwords(0x400000), // 0x400000 words (0x800000 bytes)
 		m_initial_copy_words(0x2000)
 	{
 	}
 
 	void generalplus_gpac800(machine_config &config) ATTR_COLD;
+	void generalplus_gpac800_nand64mbyte(machine_config &config) ATTR_COLD;
+	void generalplus_gpac800_nand128mbyte(machine_config &config) ATTR_COLD;
+	void generalplus_gpac800_nand256mbyte(machine_config &config) ATTR_COLD;
 
-	void nand_init210() ATTR_COLD;
-	void nand_init210_32mb() ATTR_COLD;
-	void nand_init840() ATTR_COLD;
+	void generalplus_gpac800_nand128mbyte_2048(machine_config &config) ATTR_COLD;
+	void generalplus_gpac800_nand512mbyte_2048(machine_config &config) ATTR_COLD;
+
+	void nand_init() ATTR_COLD;
+	void nand_init_32mb() ATTR_COLD;
 	void nand_wlsair60() ATTR_COLD;
 	void nand_vbaby() ATTR_COLD;
 	void nand_tsm() ATTR_COLD;
@@ -41,8 +47,6 @@ protected:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
-	u8 read_nand(offs_t offset);
-
 	virtual u16 cs0_r(offs_t offset) override;
 	virtual void cs0_w(offs_t offset, u16 data) override;
 	virtual u16 cs1_r(offs_t offset) override;
@@ -51,22 +55,24 @@ protected:
 	std::vector<u16> m_sdram;
 	std::vector<u16> m_sdram2;
 
+	required_device<nand_device> m_nand;
+
 private:
 	void nand_create_stripped_region();
 
 	void dma_complete_hacks(int state);
 
-	optional_region_ptr<u8> m_nandregion;
-
 	std::vector<u8> m_strippedrom;
-	int m_strippedsize = 0;
-	int m_size = 0;
-	int m_nandblocksize = 0;
-	int m_nandblocksize_stripped = 0;
 
 	int m_sdram_kwords;
 	int m_initial_copy_words;
 	int m_vectorbase = 0;
+
+	u8 nand_data_in(offs_t offset);
+	void nand_data_out(offs_t offset, u8 data);
+	void nand_address_out(offs_t offset, u8 data);
+	void nand_command_out(offs_t offset, u8 data);
+
 };
 
 
@@ -79,7 +85,7 @@ public:
 	{
 	}
 
-	void generalplus_gpac800_vbaby(machine_config &config) ATTR_COLD;
+	void generalplus_gpac800_nand128mbyte_2048_vbaby(machine_config &config) ATTR_COLD;
 
 protected:
 	DECLARE_DEVICE_IMAGE_LOAD_MEMBER(cart_load);

--- a/src/mame/tvgames/generalplus_gpl16250_nand.h
+++ b/src/mame/tvgames/generalplus_gpl16250_nand.h
@@ -67,12 +67,6 @@ private:
 	int m_sdram_kwords;
 	int m_initial_copy_words;
 	int m_vectorbase = 0;
-
-	u8 nand_data_in(offs_t offset);
-	void nand_data_out(offs_t offset, u8 data);
-	void nand_address_out(offs_t offset, u8 data);
-	void nand_command_out(offs_t offset, u8 data);
-
 };
 
 

--- a/src/mame/tvgames/generalplus_gpl16250_spi.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_spi.cpp
@@ -120,65 +120,41 @@ void generalplus_gpspispi_bkrankp_game_state::generalplus_gpspispi_bkrankp(machi
 
 
 ROM_START( bkrankp )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only
-
 	ROM_REGION(0x400000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "unit_mx25l3206e_c22016.bin", 0x0000, 0x400000, CRC(7efad116) SHA1(427d707e97586ae6ab5fe08f29ca450ddc7ad36e) )
 ROM_END
 
 ROM_START( prailpls )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x2000000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "mx25l25635f.u9", 0x0000, 0x2000000, CRC(17faefb0) SHA1(1d31c5aa1a37882f74c08414f69c4285149352b7) )
 ROM_END
 
 ROM_START( vmastspi )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x2000000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "mx25l25635f.sfrom1", 0x0000, 0x2000000, CRC(f30af4a2) SHA1(99526156c6e72eda9ea1ef93b9e825da069e050f) )
 ROM_END
 
 ROM_START( anpanbd )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x1000000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "mx25l12835f.u2", 0x0000, 0x1000000, CRC(c4be09d7) SHA1(c9098d0c1c9db649a010f67469f500b69407372f) )
 ROM_END
 
 ROM_START( anpanm15 )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x1000000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "mx25l12835f.ic3", 0x0000, 0x1000000, CRC(47c36cbd) SHA1(f1cae506e21c1795401004d79f6bb1b1d982d657) )
 ROM_END
 
 ROM_START( anpaneng )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x1000000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "w25q128fv.u11", 0x0000, 0x1000000, CRC(d204d646) SHA1(0b2f9f2d91a078b5fba687d73079b2b5665b33d4) )
 ROM_END
 
 ROM_START( jspodred )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x400000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "gpr5l322.sfrom1", 0x0000, 0x400000, CRC(5bd08294) SHA1(3a4a76b7b30c0dcf8184cb94d75819c382c1c668) )
 ROM_END
 
 ROM_START( wildking )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x1000000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "mx25l12835f.sfrom1", 0x0000, 0x1000000, CRC(bc4cace6) SHA1(1fc2e28b194a59ddb1ed9a63978064d2d0a6ab8c) )
 
@@ -189,17 +165,11 @@ ROM_END
 
 
 ROM_START( pokegach )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x1000000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "mx25l12835f.u4", 0x0000, 0x1000000, CRC(85bc9716) SHA1(3de7f0fd92e8f6084eb0b82ec293be3166c800ac) )
 ROM_END
 
 ROM_START( pokegac2 )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x800000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "red_mx25l6445e.u4", 0x0000, 0x800000, CRC(f20bb213) SHA1(787ae27e36352525e6ffebe25da4329cb156b219) )
 
@@ -208,9 +178,6 @@ ROM_START( pokegac2 )
 ROM_END
 
 ROM_START( pokegac2y )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x800000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "yellow_mx25l6445e.u4", 0x0000, 0x800000, CRC(587310fa) SHA1(4334b91b7f9f599bc21b354b267b132fd470f53c) )
 
@@ -220,57 +187,36 @@ ROM_END
 
 
 ROM_START( bk139in1 )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x4000000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD( "25q512.bin", 0x0000, 0x4000000, CRC(0cd111a4) SHA1(70553a44c3d946e5d23c09f04e0627a5dbaa3e4d) )
 ROM_END
 
 ROM_START( lxcyrace )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x1000000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD( "25q128.u2", 0x0000, 0x1000000, CRC(4489c99d) SHA1(792d6d224584fe1f3349c64a59aa79a587dd8c17) )
 ROM_END
 
 ROM_START( lxcymsm )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x2000000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD( "25q256.bin", 0x0000, 0x2000000, CRC(96b3ee5c) SHA1(f1e6bf46a4503877074310506d1acc4607dac331) )
 ROM_END
 
 ROM_START( lxcympp )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x2000000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD( "25q256.bin", 0x0000, 0x2000000, CRC(570b669c) SHA1(e7fcae662c8c8cae18cf1151d6caefacfe1e9fda) )
 ROM_END
 
 ROM_START( lxcymls )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x2000000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD( "25q256.bin", 0x0000, 0x2000000, CRC(76c89fe5) SHA1(99668cbce2ace6ec972ee4e72fec8b93862a0ef4) )
 ROM_END
 
 ROM_START( dgun3944 )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x1000000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD( "by25q128as.bin", 0x0000, 0x1000000, CRC(cf2bfc98) SHA1(f8c984f0278506d74b0b6337d2e96bb9d3a58148) )
 ROM_END
 
 ROM_START( starbuck )
-	ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // used as bootstrap only (if it exists at all)
-
 	ROM_REGION(0x200000, "maincpu", ROMREGION_ERASE00)
 	ROM_LOAD( "by25q16est.bin", 0x0000, 0x200000,  CRC(926c1499) SHA1(edd88b11f350e0016ee7dc76e872f9ae8c00aa6c) )
 ROM_END

--- a/src/mame/tvgames/generalplus_gpl16250_spi.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_spi.cpp
@@ -73,7 +73,7 @@ void generalplus_gpspispi_game_state::generalplus_gpspispi(machine_config &confi
 {
 	set_addrmap(0, &generalplus_gpspispi_game_state::cs_map_base);
 
-	GP_SPISPI(config, m_maincpu, 96000000/2, m_screen);
+	GPL16250(config, m_maincpu, 96000000/2, m_screen);
 	m_maincpu->porta_in().set(FUNC(generalplus_gpspispi_game_state::porta_r));
 	m_maincpu->portb_in().set(FUNC(generalplus_gpspispi_game_state::portb_r));
 	m_maincpu->portc_in().set(FUNC(generalplus_gpspispi_game_state::portc_r));


### PR DESCRIPTION
- added 2 internal ROMs from GPL16250 devices (assumed to be generic for GPL16250 parts for the time being) [cyanic]
- removed sketchy NAND handling logic from gpl16250_soc and pump through the nandflash.cpp device instead [David Haywood]
- removed the NAND/SPI split from gpl16250_soc, all GPL16250 chips support both (as do some earlier chips) [David Haywood]
- added some NAND types needed for the JAKKS games etc. to nandflash.cpp [David Haywood]
- added a few getters to nandflash.cpp so that we can manually get data out of the device for the existing bootstrap simulations now that a device is being used [David Haywood]
- attempted to identify which GPL162xx model a few sets are [David Haywood]
- misc cleanups [David Haywood]