### PR TITLE
sound/cem3340.cpp, sequential/prophet5.cpp: emulated oscillator scale trimmers.

### DIFF
--- a/src/devices/sound/cem3340.cpp
+++ b/src/devices/sound/cem3340.cpp
@@ -13,11 +13,8 @@ constexpr float VT = 25.7E-3F;  // Thermal voltage constant at 25 deg C.
 
 constexpr float VCC = 15.0F;  // Positive supply voltage.
 constexpr float RS = 1.8E3F;  // Resistor between pin 18 and GND.
-constexpr float RT = 5.6E3F;  // Resistor between pin 2 and pin 3.
 
-// According to the datasheet, RZ should be trimmed so that:
-// pin 2 current = pin 1 current. Or: 22 * VT / RT = 3 / RZ
-constexpr float RZ = 3 * RT / (22 * VT);  // Total resistance between pin 1 and pin 3.
+constexpr float RT_DEFAULT = 5.6E3F;  // Resistor between pin 2 and pin 3.
 
 constexpr float PW_MAX = VCC / 3.0F;
 
@@ -45,6 +42,8 @@ cem3340_device::cem3340_device(const machine_config &mconfig, const char *tag, d
 	: va_vco_device(mconfig, CEM3340, tag, owner, 0)
 	, m_cf(cf)
 	, m_rr(rr)
+	, m_rz(rz_optimal(RT_DEFAULT))
+	, m_rt(RT_DEFAULT)
 {
 	configure_ramp_range(RAMP_MIN, RAMP_MAX);
 	configure_pulse_range(PULSE_MIN, PULSE_MAX);
@@ -57,11 +56,28 @@ cem3340_device::cem3340_device(const machine_config &mconfig, const char *tag, d
 {
 }
 
+cem3340_device &cem3340_device::set_tempco_gen_res(float rz, float rt)
+{
+	if (rz == m_rz && rt == m_rt)
+		return *this;
+	update_stream();
+	m_rz = rz;
+	m_rt = rt;
+	return *this;
+}
+
+float cem3340_device::rz_optimal(float rt)
+{
+	// According to the datasheet, RZ should be trimmed so that:
+	// pin 2 current = pin 1 current. Or: 22 * VT / RT = 3 / RZ
+	return 3.0F * rt / (22.0F * VT);
+}
+
 float cem3340_device::ctrl2freq(float freq_ctrl) const
 {
 	// Equations shown and/or described in the datasheet.
 	// freq_ctrl is the current into pin 15.
-	const float iom = (22.0F * VT / RT) * (1.0F - freq_ctrl * RZ / 3.0F);  // Output current of the multiplier.
+	const float iom = (22.0F * VT / m_rt) * (1.0F - freq_ctrl * m_rz / 3.0F);  // Output current of the multiplier.
 	const float vb = iom * RS;  // Voltage at the base of the exponential converter.
 	const float iref = VCC / m_rr;  // Reference input current at pin 13.
 	const float ieg = iref * expf(-vb / VT);  // Output current of the exponential converter.
@@ -91,6 +107,9 @@ void cem3340_device::device_start()
 		fatalerror("%s: Unsupported outputs connected. Unsupported output mask: %x\n",
 				   tag(), get_sound_requested_outputs_mask() & ~SUPPORTED_OUTPUTS);
 	}
+
+	save_item(NAME(m_rz));
+	save_item(NAME(m_rt));
 }
 
 DEFINE_DEVICE_TYPE(CEM3340, cem3340_device, "cem3340", "CEM3340 Voltage Controlled Oscillator")

--- a/src/devices/sound/cem3340.h
+++ b/src/devices/sound/cem3340.h
@@ -29,8 +29,7 @@ DECLARE_DEVICE_TYPE(CEM3340, cem3340_device)
 // - Other types of sync.
 // - Linear FM input.
 // - High frequency tracking input.
-// - A lot of external components are hardcoded to the recommended values. Make
-//   them configurable as needed.
+// - Configurable range of pulse waveform.
 class cem3340_device : public va_vco_device
 {
 public:
@@ -38,6 +37,15 @@ public:
 	// rr - reference current resistor between pin 13 and V+.
 	cem3340_device(const machine_config &mconfig, const char *tag, device_t *owner, float cf, float rr) ATTR_COLD;
 	cem3340_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) ATTR_COLD;
+
+	// rz - total resistance between pin 1 and pin 3 (RZ in the datasheet).
+	// rt - total resistance between pin 2 and pin 3 (RT in the datasheet).
+	// By default, `rt` will be the recommended value in the datasheet, and `rz`
+	// will be perfectly trimmed as per instructions in the datasheet.
+	cem3340_device &set_tempco_gen_res(float rz, float rt);
+
+	// Returns the optimally trimmed RZ, given RT.
+	static float rz_optimal(float rt);
 
 protected:
 	void device_start() override ATTR_COLD;
@@ -49,8 +57,11 @@ protected:
 	float ctrl2pw(float pw_ctrl) const override;
 
 private:
-	const float m_cf;
-	const float m_rr;
+	const float m_cf;  // Timing capacitor between pin 11 and GND.
+	const float m_rr;  // Reference current resistor between pin 13 and V+.
+
+	float m_rz;  // Total resistance between pin 1 and pin 3.
+	float m_rt;  // Total resistance between pin 2 and pin 3.
 };
 
 #endif  // MAME_SOUND_CEM3340_H

--- a/src/devices/sound/va_vco.cpp
+++ b/src/devices/sound/va_vco.cpp
@@ -91,6 +91,12 @@ float va_vco_device::ctrl2pw(float pw_ctrl) const
 	return pw_ctrl;
 }
 
+void va_vco_device::update_stream()
+{
+	if (m_stream)
+		m_stream->update();
+}
+
 void va_vco_device::set_freq_ctrl_internal(float freq_ctrl)
 {
 	if (freq_ctrl == m_freq_ctrl)

--- a/src/devices/sound/va_vco.h
+++ b/src/devices/sound/va_vco.h
@@ -147,6 +147,8 @@ protected:
 	virtual float ctrl2freq(float freq_ctrl) const;
 	virtual float ctrl2pw(float pw_ctrl) const;
 
+	void update_stream();
+
 private:
 	// Information about an oscillator sync event.
 	struct sync_event_t

--- a/src/mame/sequential/prophet5.cpp
+++ b/src/mame/sequential/prophet5.cpp
@@ -455,11 +455,14 @@ public:
 	void filt_res_w(double cv);
 	void filt_env_amt_w(double cc);
 
+	DECLARE_INPUT_CHANGED_MEMBER(osc_trimmer_changed) { update_osc_scale_calibration(); }
 	DECLARE_INPUT_CHANGED_MEMBER(filter_trimmer_changed) { update_filter_freq_calibration(); }
 	DECLARE_INPUT_CHANGED_MEMBER(volume_trimmer_changed) { m_volume_changed_cb(0); }
 	DECLARE_INPUT_CHANGED_MEMBER(voice_balance_trimmer_changed) { voice_update_balance_calibration(); }
 
 	const char *trimmer_name_volume() const ATTR_COLD { return m_volume_name.c_str(); }
+	const char *trimmer_name_osc_a_scale() const ATTR_COLD { return m_osc_a_scale_name.c_str(); }
+	const char *trimmer_name_osc_b_scale() const ATTR_COLD { return m_osc_b_scale_name.c_str(); }
 	const char *trimmer_name_filt_scale() const ATTR_COLD { return m_filt_scale_name.c_str(); }
 	const char *trimmer_name_filt_offset() const ATTR_COLD { return m_filt_offset_name.c_str(); }
 	const char *trimmer_name_filt_env_bal() const ATTR_COLD { return m_filt_env_bal_name.c_str(); }
@@ -479,10 +482,13 @@ private:
 	static double jittered(double x, double random, double tolerance);
 
 	void update_osc_b_mix();
+	void update_osc_scale_calibration();
 	void update_filter_freq_calibration();
 	void voice_update_balance_calibration();
 
 	const std::string m_volume_name;
+	const std::string m_osc_a_scale_name;
+	const std::string m_osc_b_scale_name;
 	const std::string m_filt_scale_name;
 	const std::string m_filt_offset_name;
 	const std::string m_filt_env_bal_name;
@@ -529,6 +535,8 @@ private:
 	devcb_write8 m_volume_changed_cb;
 
 	required_ioport m_volume;  // R4529
+	required_ioport m_osc_a_scale;  // R4294
+	required_ioport m_osc_b_scale;  // R4186
 	required_ioport m_filt_scale;  // R4133
 	required_ioport m_filt_offset;  // R4501
 	required_ioport m_filt_env_bal;  // R495
@@ -549,6 +557,14 @@ INPUT_PORTS_START(prophet5_voice_trimmers)
 	PORT_START("trimmer_volume")
 	PORT_ADJUSTER(100, voice.trimmer_name_volume())
 		PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(prophet5_voice_device::volume_trimmer_changed), 0);
+
+	PORT_START("trimmer_osc_a_scale")
+	PORT_ADJUSTER(62, voice.trimmer_name_osc_a_scale())
+		PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(prophet5_voice_device::osc_trimmer_changed), 0)
+
+	PORT_START("trimmer_osc_b_scale")
+	PORT_ADJUSTER(62, voice.trimmer_name_osc_b_scale())
+		PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(prophet5_voice_device::osc_trimmer_changed), 0)
 
 	PORT_START("trimmer_filt_scale")
 	PORT_ADJUSTER(14, voice.trimmer_name_filt_scale())
@@ -593,6 +609,8 @@ prophet5_voice_device::prophet5_voice_device(
 	: device_t(mconfig, PROPHET5_VOICE, tag, owner, 0)
 	, device_sound_interface(mconfig, *this)
 	, m_volume_name(util::string_format("%s TRIMMER: VOLUME", strmakeupper(basetag())))
+	, m_osc_a_scale_name(util::string_format("%s TRIMMER: OSC A SCALE", strmakeupper(basetag())))
+	, m_osc_b_scale_name(util::string_format("%s TRIMMER: OSC B SCALE", strmakeupper(basetag())))
 	, m_filt_scale_name(util::string_format("%s TRIMMER: FILT SCALE", strmakeupper(basetag())))
 	, m_filt_offset_name(util::string_format("%s TRIMMER: FILT OFFSET", strmakeupper(basetag())))
 	, m_filt_env_bal_name(util::string_format("%s TRIMMER: FILT ENV BALANCE", strmakeupper(basetag())))
@@ -628,6 +646,8 @@ prophet5_voice_device::prophet5_voice_device(
 	, m_vca(*this, "vca")
 	, m_volume_changed_cb(*this)
 	, m_volume(*this, "trimmer_volume")
+	, m_osc_a_scale(*this, "trimmer_osc_a_scale")
+	, m_osc_b_scale(*this, "trimmer_osc_b_scale")
 	, m_filt_scale(*this, "trimmer_filt_scale")
 	, m_filt_offset(*this, "trimmer_filt_offset")
 	, m_filt_env_bal(*this, "trimmer_filt_env_balance")
@@ -847,6 +867,7 @@ void prophet5_voice_device::device_start()
 void prophet5_voice_device::device_reset()
 {
 	update_osc_b_mix();
+	update_osc_scale_calibration();
 	update_filter_freq_calibration();
 	voice_update_balance_calibration();
 }
@@ -1127,6 +1148,23 @@ void prophet5_voice_device::update_osc_b_mix()
 	}
 	m_osc_b_tri_center->set_scale(tri_scale);
 	m_osc_b_tri_center->set_offset(tri_offset);
+}
+
+void prophet5_voice_device::update_osc_scale_calibration()
+{
+	constexpr double R_TRIMMER = RES_K(5);  // R4294, R4186
+	constexpr double RT = RES_K(5.62);  // R4293 (1%), R4185 (1%)
+	constexpr double RZ1 = RES_K(26.7);  // R4292 (1%), R4184 (1%)
+
+	const double rz_a = normalized(m_osc_a_scale) * R_TRIMMER + RZ1;
+	m_osc_a->set_tempco_gen_res(rz_a, RT);
+	LOGMASKED(LOG_CALIBRATION | LOG_OSC, "%s: Osc scale A - optimal: %f, actual: %f\n",
+			  tag(), m_osc_a->rz_optimal(RT), rz_a);
+
+	const double rz_b = normalized(m_osc_b_scale) * R_TRIMMER + RZ1;
+	m_osc_b->set_tempco_gen_res(rz_b, RT);
+	LOGMASKED(LOG_CALIBRATION | LOG_OSC, "%s: Osc scale B - optimal: %f, actual: %f\n",
+			  tag(), m_osc_b->rz_optimal(RT), rz_b);
 }
 
 void prophet5_voice_device::update_filter_freq_calibration()
@@ -1465,6 +1503,7 @@ void prophet5_audio_device::device_add_mconfig(machine_config &config)
 	// modulation by the LFO. Many of the route gains, and the triangle scale
 	// and offset are computed in update_lfo_mix().
 	CEM3340(config, m_lfo, CAP_U(0.1), RES_M(2.21))  // U376 - C382 (mylar, 5%), R3138 (1%)
+		.set_tempco_gen_res(RES_K(30.1), RES_K(5.62))  // R3107 (1%), R3108 (1%)
 		.add_route(cem3340_device::OUTPUT_TRIANGLE, m_lfo_tri_center, 1.0)
 		.add_route(cem3340_device::OUTPUT_RAMP, m_lfo_vca, 1.0)
 		.add_route(cem3340_device::OUTPUT_PULSE, m_lfo_vca, 1.0);
@@ -3262,10 +3301,14 @@ INPUT_PORTS_START(prophet5)
 	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_OTHER) PORT_NAME("REL FT SW")
 
 	PORT_START("test_points")
-	// According to the schematic, TP301 and TP304 have pull-down resistors, and
-	// TP306 does not have a resistor.
-	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("TP301") PORT_CODE(KEYCODE_T)
+	// TP301 is connected to a pull-down resistor. Tying TP301 to +5V when the
+	// machine boots will enter the "VCO scale trim" procedure. Removing the
+	// connection will exit the procedure after the next key is pressed.
+	// See "4-16 VCO SCALE TRIM" in the technical manual.
+	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("TP301 - VCO SCALE TRIM") PORT_TOGGLE
+	// TP304 is connected to a pull-down resistor.
 	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("TP304")
+	// TP306 does not seem to be connected to a resistor.
 	PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("TP306")
 
 	// All knob potentiometers are 10K linear, unless otherwise noted.


### PR DESCRIPTION
* Made resistors for the CEM3340 "tempco generator" configurable.
* Used the above on the prophet5 LFO, and to implement the scale trimmers of the VCOs.