### PR TITLE
Revert "ns32000: fetch module static base after PSR restore on RETT/RETI"

### DIFF
--- a/src/devices/cpu/ns32000/ns32000.cpp
+++ b/src/devices/cpu/ns32000/ns32000.cpp
@@ -1169,8 +1169,13 @@ template <int HighBits, int Width> void ns32000_device<HighBits, Width>::execute
 
 						if (!(m_cfg & CFG_DE))
 						{
-							m_mod = mem_read<u16>(ns32000::ST_ODT, SP() + 4);
-							tex = top(SIZE_D, SP()) + top(SIZE_W, SP()) * 2 + top(SIZE_D, m_mod) + 35;
+							u16 const mod = mem_read<u16>(ns32000::ST_ODT, SP() + 4);
+							u32 const sb = mem_read<u32>(ns32000::ST_ODT, mod);
+
+							m_mod = mod;
+							m_sb = sb;
+
+							tex = top(SIZE_D, SP()) + top(SIZE_W, SP()) * 2 + top(SIZE_D, mod) + 35;
 						}
 						else
 							tex = top(SIZE_D, SP()) + top(SIZE_W, SP()) + 35;
@@ -1179,13 +1184,6 @@ template <int HighBits, int Width> void ns32000_device<HighBits, Width>::execute
 
 						m_pc = pc;
 						m_psr = psr;
-
-						// the static base is fetched from the module table AFTER the PSR is
-						// restored: a return to user mode reads the USER address space's module
-						// table (dual-space translation), not the supervisor's
-						if (!(m_cfg & CFG_DE))
-							m_sb = mem_read<u32>(ns32000::ST_ODT, m_mod);
-
 						SP() += constant;
 
 						m_sequential = false;
@@ -1217,7 +1215,12 @@ template <int HighBits, int Width> void ns32000_device<HighBits, Width>::execute
 
 						if (!(m_cfg & CFG_DE))
 						{
-							m_mod = mem_read<u16>(ns32000::ST_ODT, SP() + 4);
+							u16 const mod = mem_read<u16>(ns32000::ST_ODT, SP() + 4);
+							u32 const sb = mem_read<u32>(ns32000::ST_ODT, mod);
+
+							m_mod = mod;
+							m_sb = sb;
+
 							tex = top(SIZE_B) + top(SIZE_W, SP()) * 3 + top(SIZE_D) * 3 + 39;
 						}
 						else
@@ -1227,12 +1230,6 @@ template <int HighBits, int Width> void ns32000_device<HighBits, Width>::execute
 
 						m_pc = pc;
 						m_psr = psr;
-
-						// as with RETT: the static base is fetched from the module table AFTER the
-						// PSR is restored, so a return to user mode reads the USER address space's
-						// module table under dual-space translation
-						if (!(m_cfg & CFG_DE))
-							m_sb = mem_read<u32>(ns32000::ST_ODT, m_mod);
 
 						m_sequential = false;
 					}


### PR DESCRIPTION
Reverts #15633.

The reordering was based on a misdiagnosis. Module descriptors reside in supervisor space: an operating system's module table is not, in general, mapped in user space, so fetching SB after the PSR restore makes every interrupt or trap return to user mode read the module table through user translation and load an unrelated value into SB. Any dual-space NS32000 System V build fails at the first interrupt taken by a user process: ICM-3216, PD32 and Opus System V (all binaries that ran on real hardware) enter an SVC loop immediately after boot with #15633 in place, and boot normally with it reverted.

The PC-MX2 behavior cited in #15633 turned out to be ordinary demand paging, not a user-space fetch requirement; it boots init correctly with the restored order. The NS32532 pc532 boots identically under both orders.

Validated with the revert: NetBSD 1.5.3/pc532 (3/3 boots to single user + raw disk reads), System V/pc532 (3/3 boots + build/IO exercise), and System V on the ICM-3216, PD32 and Opus models to single user.
