### PR TITLE
konami/ddribble.cpp: implement sprite X wraparound

### DIFF
--- a/src/mame/konami/ddribble.cpp
+++ b/src/mame/konami/ddribble.cpp
@@ -236,12 +236,16 @@ void ddribble_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprec
 	{
 		int number = source[0] | ((source[1] & 0x07) << 8);       // sprite number
 		int const attr = source[4];                               // attributes
-		int sx = source[3] | ((attr & 0x01) << 8);                // vertical position
-		int sy = source[2];                                       // horizontal position
+		int sx = source[3] | ((attr & 0x01) << 8);                // sprite X position
+		int sy = source[2];                                       // sprite Y position
 		int flipx = attr & 0x20;                                  // flip x
 		int flipy = attr & 0x40;                                  // flip y
 		int const color = (source[1] & 0xf0) >> 4;                // color
 		int width, height;
+
+		// sprites wrap back at the start after px 255
+		if (sx & 0x100)
+			sx -= 0x200;
 
 		if (flipscreen)
 		{


### PR DESCRIPTION
Fold the 9-bit X to signed before drawing to reproduce an hardware wrap. Verified against video of original hardware
https://www.youtube.com/watch?v=aPylbn7BC28
Sprites exit the left side smoothly instead of disappearing abruptly when approaching the left side.

I compile only the ddribble driver and tested it a bit:
<img width="256" height="224" alt="image" src="https://github.com/user-attachments/assets/cb45b8ae-51df-4834-92be-1fae907e3d66" />

I can see the sprites going out from the left correctly now.

This is my first contribution, i m not sure i can base this change on strong hardware verifications basis.
I happened to work on a verilog implementation of this game, but the 05885 chip is not decapped, so when i noticed this strange behavior in the mame source code i compared with an existing verilog created for iron horse and it allowed for the sprites to behave as the original hardware videos.

