### PR TITLE
6821pia: add masked input setters for ports A and B

### DIFF
--- a/src/devices/machine/6821pia.cpp
+++ b/src/devices/machine/6821pia.cpp
@@ -858,6 +858,17 @@ void pia6821_device::set_a_input(uint8_t data)
 
 
 //-------------------------------------------------
+//  set_a_input
+//-------------------------------------------------
+
+void pia6821_device::set_a_input(uint8_t data, uint8_t mask)
+{
+	uint8_t combined_data = (m_in_a & ~mask) | (data & mask);
+	set_a_input(combined_data);
+}
+
+
+//-------------------------------------------------
 //  porta_w
 //-------------------------------------------------
 
@@ -1003,6 +1014,26 @@ void pia6821_device::write_portb_line(int line, bool state)
 		portb_w(m_in_b | mask);
 	else
 		portb_w(m_in_b & ~mask);
+}
+
+
+//-------------------------------------------------
+//  set_b_input
+//-------------------------------------------------
+
+void pia6821_device::set_b_input(uint8_t data)
+{
+	portb_w(data);
+}
+
+//-------------------------------------------------
+//  set_b_input
+//-------------------------------------------------
+
+void pia6821_device::set_b_input(uint8_t data, uint8_t mask)
+{
+	uint8_t new_in_b = (m_in_b & ~mask) | (data & mask);
+	set_b_input(new_in_b);
 }
 
 

--- a/src/devices/machine/6821pia.cpp
+++ b/src/devices/machine/6821pia.cpp
@@ -861,7 +861,7 @@ void pia6821_device::set_a_input(uint8_t data)
 //  set_a_input
 //-------------------------------------------------
 
-void pia6821_device::set_a_input(uint8_t data, uint8_t mask)
+void pia6821_device::set_a_input_mask(uint8_t data, uint8_t mask)
 {
 	uint8_t combined_data = (m_in_a & ~mask) | (data & mask);
 	set_a_input(combined_data);

--- a/src/devices/machine/6821pia.h
+++ b/src/devices/machine/6821pia.h
@@ -60,6 +60,7 @@ public:
 	void porta_w(uint8_t data);
 	void write_porta_line(int line, bool state);
 	void set_a_input(uint8_t data);
+	void set_a_input(uint8_t data, uint8_t mask);
 	uint8_t a_output();
 	void set_port_a_input_overrides_output_mask(uint8_t mask) { m_a_input_overrides_output_mask = mask; }
 
@@ -80,6 +81,8 @@ public:
 
 	void portb_w(uint8_t data);
 	void write_portb_line(int line, bool state);
+	void set_b_input(uint8_t data);
+	void set_b_input(uint8_t data, uint8_t mask);
 	uint8_t b_output();
 
 	void pb0_w(int state) { write_portb_line(0, state); }

--- a/src/devices/machine/6821pia.h
+++ b/src/devices/machine/6821pia.h
@@ -60,7 +60,7 @@ public:
 	void porta_w(uint8_t data);
 	void write_porta_line(int line, bool state);
 	void set_a_input(uint8_t data);
-	void set_a_input(uint8_t data, uint8_t mask);
+	void set_a_input_mask(uint8_t data, uint8_t mask);
 	uint8_t a_output();
 	void set_port_a_input_overrides_output_mask(uint8_t mask) { m_a_input_overrides_output_mask = mask; }
 


### PR DESCRIPTION
After working on a coco driver refactor for a while I've found these helpers helpful. This is to gauge interest and acceptability.

Add set_a_input(data, mask) and set_b_input(data, mask) to update only the bits selected by mask, for cases where multiple independent sources drive different bits of the same PIA input port.

Each masked setter forwards to its port's existing input-latch setter (set_a_input(data) for A, the new set_b_input(data) for B, which wraps portb_w) rather than adding a new input path.

set_b_input(data) is added for naming parity with set_a_input(data); port B had no matching single-arg setter before.

AI disclosure: Gemini 4.5 flash assisted in writing this patch.