### PR TITLE
devices/machine/wd1002_05.cpp: Support all documented floppy sector sizes

### DIFF
--- a/src/devices/machine/wd1002_05.cpp
+++ b/src/devices/machine/wd1002_05.cpp
@@ -31,7 +31,8 @@ enum : uint8_t {
 // host task-file commands (WD1010 opcodes) the front-end routes to the WD2797
 enum : uint8_t {
 	HOST_READ    = 0x20,
-	HOST_WRITE   = 0x30
+	HOST_WRITE   = 0x30,
+	HOST_FORMAT  = 0x50  // format a track (INIT's c.format); WD1015 builds the track from the skew
 };
 
 // host status byte the WD1015 front-end presents at register 7
@@ -47,10 +48,11 @@ constexpr uint8_t HERR_NOT_FOUND = 0x10; // host error register: sector not foun
 
 // WD2797 commands the front-end issues (read/write carry the E head-load settle)
 enum : uint8_t {
-	FDC_RESTORE  = 0x00,
-	FDC_SEEK     = 0x10,
-	FDC_READ     = 0x84,
-	FDC_WRITE    = 0xa4
+	FDC_RESTORE     = 0x00,
+	FDC_SEEK        = 0x10,
+	FDC_READ        = 0x8c, // read sector: E settle + bit3 (L) selects 128<<N sector length, as real 16/8 media uses
+	FDC_WRITE       = 0xac, // write sector: E settle + bit3 (L)
+	FDC_WRITE_TRACK = 0xf4  // format the whole track (E head-load settle)
 };
 
 constexpr uint8_t WDFDC_NOT_FOUND = 0x10; // WD2797 status: record not found
@@ -68,13 +70,17 @@ wd1002_05_device::wd1002_05_device(const machine_config &mconfig, const char *ta
 	: wd1002_hd0_device(mconfig, WD1002_05, tag, owner, clock)
 	, m_fdc(*this, "fdc")
 	, m_floppy(*this, "fd%u", 0U)
-	, m_secno(0), m_cyllo(0), m_cylhi(0), m_sdh(0)
+	, m_secno(0), m_cyllo(0), m_cylhi(0), m_sdh(0), m_secnt(0)
 	, m_fop(FOP_IDLE)
 	, m_f_write(false)
+	, m_f_format(false)
 	, m_f_wr_pending(false)
+	, m_f_fmt_pending(false)
 	, m_f_cyl(0), m_f_head(0), m_f_sec(0), m_f_drive(0)
 	, m_floppy_cyl{ 0xff, 0xff }
 	, m_f_err(0)
+	, m_fmt_buf{ }
+	, m_fmt_len(0), m_fmt_ptr(0)
 {
 }
 
@@ -100,22 +106,31 @@ void wd1002_05_device::device_start()
 	save_item(NAME(m_cyllo));
 	save_item(NAME(m_cylhi));
 	save_item(NAME(m_sdh));
+	save_item(NAME(m_secnt));
 	save_item(NAME(m_fop));
 	save_item(NAME(m_f_write));
+	save_item(NAME(m_f_format));
 	save_item(NAME(m_f_wr_pending));
+	save_item(NAME(m_f_fmt_pending));
 	save_item(NAME(m_f_cyl));
 	save_item(NAME(m_f_head));
 	save_item(NAME(m_f_sec));
 	save_item(NAME(m_f_drive));
 	save_item(NAME(m_floppy_cyl));
 	save_item(NAME(m_f_err));
+	save_item(NAME(m_fmt_buf));
+	save_item(NAME(m_fmt_len));
+	save_item(NAME(m_fmt_ptr));
 }
 
 void wd1002_05_device::device_reset()
 {
 	wd1002_hd0_device::device_reset();
 	m_fop = FOP_IDLE;
+	m_f_write = false;
+	m_f_format = false;
 	m_f_wr_pending = false;
+	m_f_fmt_pending = false;
 	m_floppy_cyl[0] = m_floppy_cyl[1] = 0xff;
 }
 
@@ -133,6 +148,9 @@ uint8_t wd1002_05_device::read(offs_t offset)
 	}
 	if ((offset & 7) == 1 && floppy)
 		return m_f_err; // floppy error register (WD1015 front-end, not the WD1010's)
+	if ((offset & 7) == 6 && floppy)
+		return m_sdh; // present the shadowed SDH: the WD1010 base masks the drive-select bits,
+		              // but INIT reads the SDH back to add side/size before issuing FORMAT
 	return wd1002_hd0_device::read(offset); // buffer (0) + rigid task file / status
 }
 
@@ -145,14 +163,26 @@ void wd1002_05_device::write(offs_t offset, uint8_t data)
 		{
 			if (m_ptr < BUFFER_SIZE)
 				m_buf[m_ptr++] = data;
-			if (m_ptr >= BUFFER_SIZE) // a full sector has arrived -> hand it to the WD2797
+			if (m_ptr >= floppy_seclen()) // a full selected-size sector has arrived -> hand it to the WD2797
 			{
 				m_f_wr_pending = false;
-				f_start(true);
+				f_start(true, false);
+			}
+			return;
+		}
+		if (m_f_fmt_pending) // a floppy format is streaming its skew table (2 bytes per sector)
+		{
+			if (m_ptr < BUFFER_SIZE)
+				m_buf[m_ptr++] = data;
+			if (m_ptr >= uint32_t(m_secnt) * 2) // whole skew table in -> build + write the track
+			{
+				m_f_fmt_pending = false;
+				f_start(true, true);
 			}
 			return;
 		}
 		break; // rigid: the base buffers it
+	case 2: m_secnt = data; break; // shadow sector count (skew-table length for the floppy format)
 	case 3: m_secno = data; break; // shadow the task file for the floppy path,
 	case 4: m_cyllo = data; break; // and fall through so the WD1010 gets it too
 	case 5: m_cylhi = data; break;
@@ -168,10 +198,15 @@ void wd1002_05_device::write(offs_t offset, uint8_t data)
 			m_f_drive = (m_sdh & SDH_DRIVE) ? 1 : 0; // bit1 = drive 0/1
 			m_f_sec   = m_secno;
 			m_ptr     = 0;
+			m_f_err   = 0; // a fresh command clears the prior error -- the WD1015 status is per-command
+			                // (the EM ROM's SEEK-then-READ probe reads the error via a shared WAIT/RSTAT,
+			                //  so a stale RNF from a failed probe must not carry into the next command)
 			if (cmd == HOST_READ)            // READ: start the WD2797 now; host polls then reads buf
-				f_start(false);
+				f_start(false, false);
 			else if (cmd == HOST_WRITE)      // WRITE: buffer the host data first, then start the FDC
 				m_f_wr_pending = true;
+			else if (cmd == HOST_FORMAT)     // FORMAT: collect the skew table, then WRITE TRACK
+				m_f_fmt_pending = true;
 			// restore/seek/diag: nothing to do (status already not-BSY)
 			return;
 		}
@@ -187,6 +222,12 @@ void wd1002_05_device::write(offs_t offset, uint8_t data)
 //  its interrupt/DRQ callbacks; BSY (status read) holds the host off meanwhile
 //-------------------------------------------------
 
+uint32_t wd1002_05_device::floppy_seclen() const
+{
+	static constexpr uint16_t k[4] = { 256, 512, 1024, 128 }; // SDH bits 6-5 select bytes/sector
+	return k[(m_sdh >> 5) & 3];
+}
+
 void wd1002_05_device::f_select(int drive, int head)
 {
 	floppy_image_device *const fd = m_floppy[drive]->get_device();
@@ -199,9 +240,10 @@ void wd1002_05_device::f_select(int drive, int head)
 	}
 }
 
-void wd1002_05_device::f_start(bool write)
+void wd1002_05_device::f_start(bool write, bool format)
 {
 	m_f_write = write;
+	m_f_format = format;
 	f_select(m_f_drive, m_f_head);
 
 	if (m_floppy_cyl[m_f_drive] == 0xff) // this drive's head position unknown: recalibrate first
@@ -220,7 +262,7 @@ void wd1002_05_device::f_issue_seek()
 {
 	if (m_fdc->track_r() == m_f_cyl)
 	{
-		f_issue_rw();
+		f_issue_transfer();
 		return;
 	}
 	m_fop = FOP_SEEK;
@@ -228,29 +270,92 @@ void wd1002_05_device::f_issue_seek()
 	m_fdc->cmd_w(FDC_SEEK);
 }
 
+void wd1002_05_device::f_issue_transfer()
+{
+	if (m_f_format)
+		f_issue_format();
+	else
+		f_issue_rw();
+}
+
 void wd1002_05_device::f_issue_rw()
 {
 	m_fop = FOP_RW;
 	m_ptr = 0; // transfer starts at the head of the shared buffer
 	m_fdc->sector_w(m_f_sec);
-	m_fdc->cmd_w(m_f_write ? FDC_WRITE : FDC_READ); // single sector, E=1 (head-load settle)
+	// the WD2797 drives its side-select output (and thus the drive's active side)
+	// from command bit 1, so the head must be encoded there -- a preceding ss_w()
+	// is overridden when the read/write command latches.
+	m_fdc->cmd_w((m_f_write ? FDC_WRITE : FDC_READ) | (m_f_head ? 0x02 : 0)); // single sector, E=1 (head-load settle)
+}
+
+void wd1002_05_device::f_issue_format()
+{
+	m_fop = FOP_FORMAT;
+	build_format_track();  // lay out the whole track image; the WD2797 pulls it byte-by-byte via DRQ
+	m_fmt_ptr = 0;
+	m_fdc->cmd_w(FDC_WRITE_TRACK | (m_f_head ? 0x02 : 0)); // SSO from bit 1, as for read/write
+}
+
+//-------------------------------------------------
+//  build a standard IBM System-34 MFM track image for the WD2797 WRITE TRACK command.
+//  the physical sector order is the skew table INIT streamed (entry i = [flag, sector],
+//  2 bytes each); cylinder/head/size/count come from the shadowed task file.  the WD2797
+//  interprets 0xf5->A1, 0xf6->C2, 0xf7->two CRC bytes and writes everything else verbatim.
+//-------------------------------------------------
+
+void wd1002_05_device::build_format_track()
+{
+	int const spt = m_secnt;
+	int const szval = (m_sdh >> 5) & 3;              // SDH bits 5-6 select bytes per sector
+	int const szcode = (szval == 3) ? 0 : szval + 1; // 00=256, 01=512, 10=1024, 11=128 -> N field
+	int const seclen = 128 << szcode;
+
+	m_fmt_len = 0;
+	auto const put = [this] (uint8_t b, int n) { while (n-- > 0 && m_fmt_len < m_fmt_buf.size()) m_fmt_buf[m_fmt_len++] = b; };
+
+	put(0x4e, 80);                                   // gap 4a
+	put(0x00, 12); put(0xf6, 3); put(0xfc, 1);       // index address mark
+	put(0x4e, 50);                                   // gap 1
+	for (int i = 0; i < spt; i++)
+	{
+		uint8_t const sec = m_buf[(i * 2 + 1) & (BUFFER_SIZE - 1)]; // sector number from the skew entry
+		put(0x00, 12); put(0xf5, 3); put(0xfe, 1);   // ID address mark
+		put(uint8_t(m_f_cyl), 1); put(uint8_t(m_f_head), 1); put(sec, 1); put(uint8_t(szcode), 1); // C,H,R,N (standard IBM N = 128<<N, matching real 16/8 media; read/write use bit3 to decode it)
+		put(0xf7, 1);                                // ID CRC
+		put(0x4e, 22);                               // gap 2
+		put(0x00, 12); put(0xf5, 3); put(0xfb, 1);   // data address mark
+		put(0xe5, seclen);                           // data field (formatted fill)
+		put(0xf7, 1);                                // data CRC
+		put(0x4e, 54);                               // gap 3
+	}
+	// gap 4b: fdc_drq_w streams 0x4e past m_fmt_len until the WD2797 hits the index and stops
 }
 
 void wd1002_05_device::fdc_drq_w(int state)
 {
-	if (!state || m_fop != FOP_RW)
+	if (!state)
 		return;
 
+	if (m_fop == FOP_FORMAT) // format: stream the built track image, then 0x4e gap to the index
+	{
+		m_fdc->data_w(m_fmt_ptr < m_fmt_len ? m_fmt_buf[m_fmt_ptr++] : 0x4e);
+		return;
+	}
+	if (m_fop != FOP_RW)
+		return;
+
+	uint32_t const seclen = floppy_seclen();
 	if (!m_f_write) // read: WD2797 -> shared buffer
 	{
-		if (m_ptr < BUFFER_SIZE)
+		if (m_ptr < seclen)
 			m_buf[m_ptr++] = m_fdc->data_r();
 		else
 			m_fdc->data_r();
 	}
 	else            // write: shared buffer -> WD2797
 	{
-		if (m_ptr < BUFFER_SIZE)
+		if (m_ptr < seclen)
 			m_fdc->data_w(m_buf[m_ptr++]);
 		else
 			m_fdc->data_w(0x00);
@@ -271,13 +376,22 @@ void wd1002_05_device::fdc_intrq_w(int state)
 
 	case FOP_SEEK:
 		m_floppy_cyl[m_f_drive] = m_fdc->track_r();
-		f_issue_rw();
+		f_issue_transfer();
 		break;
 
 	case FOP_RW:
-		// reflect a WD2797 record-not-found failure to the host as an error
+		// Reflect a WD2797 record-not-found to the host.  A size mismatch must NOT fault: the EM
+		// ROM's geometry probe (DETSPT) reads a 512-byte sector at 256, escalating on the sector-
+		// NUMBER not-found (sector 17 absent on a 9-sector disk), so a short read has to succeed
+		// and simply hand back the selected size.
 		m_f_err = (m_fdc->status_r() & WDFDC_NOT_FOUND) ? HERR_NOT_FOUND : 0;
 		m_ptr = 0;            // rewind so the host reads the buffer from the start
+		m_fop = FOP_IDLE;    // done: BSY clears
+		break;
+
+	case FOP_FORMAT:
+		// the only WRITE TRACK failure the host tests for is write protection (status bit 6)
+		m_f_err = (m_fdc->status_r() & 0x40) ? HERR_NOT_FOUND : 0;
 		m_fop = FOP_IDLE;    // done: BSY clears
 		break;
 

--- a/src/devices/machine/wd1002_05.h
+++ b/src/devices/machine/wd1002_05.h
@@ -40,26 +40,34 @@ protected:
 private:
 	// the floppy section runs the WD2797 at the flux level; a read/write is deferred
 	// and completes via the FDC callback chain (the task-file BSY bit holds the host off)
-	enum : uint8_t { FOP_IDLE, FOP_RESTORE, FOP_SEEK, FOP_RW }; // floppy operation phase
+	enum : uint8_t { FOP_IDLE, FOP_RESTORE, FOP_SEEK, FOP_RW, FOP_FORMAT }; // floppy operation phase
 	void f_select(int drive, int head);
-	void f_start(bool write);
+	void f_start(bool write, bool format);
 	void f_issue_seek();
+	void f_issue_transfer();
 	void f_issue_rw();
+	void f_issue_format();
+	void build_format_track();
 	void fdc_intrq_w(int state);
 	void fdc_drq_w(int state);
+	uint32_t floppy_seclen() const; // selected floppy sector length from SDH bits 6-5 (256/512/1024/128)
 
 	required_device<wd2797_device> m_fdc;
 	required_device_array<floppy_connector, 2> m_floppy; // two 5.25" drives (A: and B:)
 
 	// task-file shadow needed for the floppy path (the base keeps the rigid copy)
-	uint8_t m_secno, m_cyllo, m_cylhi, m_sdh;
+	uint8_t m_secno, m_cyllo, m_cylhi, m_sdh, m_secnt;
 
 	uint8_t  m_fop;
 	bool     m_f_write;
+	bool     m_f_format;        // current floppy op is a track format (WD2797 write-track)
 	bool     m_f_wr_pending; // a floppy write command is buffering host data
+	bool     m_f_fmt_pending;   // a floppy format command is collecting its skew table
 	int      m_f_cyl, m_f_head, m_f_sec, m_f_drive;
 	uint8_t  m_floppy_cyl[2]; // per-drive head position (0xff = unknown -> restore)
 	uint8_t  m_f_err;            // floppy error register (WD1015 front-end status)
+	std::array<uint8_t, 6400> m_fmt_buf; // generated IBM-MFM track image fed to the WD2797 WRITE TRACK
+	uint32_t m_fmt_len, m_fmt_ptr;        // length of that image, and the byte the FDC is consuming
 };
 
 DECLARE_DEVICE_TYPE(WD1002_05, wd1002_05_device)

--- a/src/devices/machine/wd1002_hd0.h
+++ b/src/devices/machine/wd1002_hd0.h
@@ -55,7 +55,7 @@ protected:
 	virtual void device_reset() override ATTR_COLD;
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
 
-	static constexpr unsigned BUFFER_SIZE = 0x200; // 512-byte board sector buffer (TMM2016 SRAM)
+	static constexpr unsigned BUFFER_SIZE = 0x400; // 1K board sector buffer (WD1015 SRAM); holds one 128/256/512/1024-byte sector
 
 	// shared sector buffer (the WD1002-05 floppy section fills/drains it the same way)
 	uint8_t buf_in();             // controller -> host buffer (drained on a write-to-media)


### PR DESCRIPTION
The WD1015 front-end selects the floppy sector size from SDH bits 6-5
(00=256, 01=512, 10=1024, 11=128) and routes the command to the WD2797.
The floppy read/write/format paths were fixed at 512 bytes and encoded the
WD2797 sector length without the length (L) bit, so real Xerox 16/8 media
(IBM 128<<N, ID N=2 = 512) read back as 1024 and the Expansion Module II
INIT utility could not format a disk.

This change:

- derives the selected sector length from SDH bits 6-5 for the host
  read/write/format byte counts and the buffer bound;
- issues the WD2797 read/write with the L bit set (128<<N), matching 16/8 media;
- clears the per-command floppy error before each command (the box ROM's
  geometry probe issues SEEK-then-READ through a shared status poll, so a
  stale record-not-found must not abort the following command);
- widens the shared WD1002-HD0 board sector buffer to 1K, per the manual.

Verified on xerox16/8 (x168em): INIT formats an EM-II 5.25" floppy with 0
defective sectors, and real 16/8 media reads back correctly.
