### PR TITLE
osd/sound/coreaudio_sound.cpp: fix a deadlock on exit

### DIFF
--- a/src/osd/modules/sound/coreaudio_sound.cpp
+++ b/src/osd/modules/sound/coreaudio_sound.cpp
@@ -1183,8 +1183,9 @@ void sound_coreaudio::coreaudio_stream::close()
 {
 	if (m_graph)
 	{
-		std::lock_guard<std::mutex> steam_guard(m_stream_mutex);
+		// stop the graph before locking m_stream_mutex, else AUGraphStop deadlocks against the render callback that also takes it
 		AUGraphStop(m_graph);
+		std::lock_guard<std::mutex> steam_guard(m_stream_mutex);
 		AUGraphUninitialize(m_graph);
 		DisposeAUGraph(m_graph);
 		m_graph = nullptr;


### PR DESCRIPTION
coreaudio_stream::close() took m_stream_mutex before calling AUGraphStop.
AUGraphStop blocks until the CoreAudio I/O thread finishes any in-flight
sink_render callback, and that callback also takes m_stream_mutex -- so
holding the mutex across AUGraphStop deadlocks: this thread waits for the
callback to finish, the callback waits for the mutex.

Stop the graph first (which quiesces the I/O thread, so no further callbacks
fire), then take the mutex for the rest of the teardown.
