### PR TITLE
emu: Add -rtc command-line option for fixed baseline time overrides

### DIFF
--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -4116,6 +4116,22 @@ Core Misc Options
 
             mame galaga88 -nonvram_save
 
+.. _mame-commandline-rtc:
+
+**-rtc <value>**
+
+    Specifies a fixed baseline time to initialize the real-time clock (RTC) chips
+    emulated by MAME. By default, MAME initializes RTC chips using your host
+    computer's current system time.
+
+    The option accepts a 14-digit formatted date and time string for `<value>`
+    in the format **YYYYMMDDhhmmss** (e.g., ``20260709070000`` for July 9, 2026,
+    at 07:00:00).
+
+.. Tip:: If an input macro playback file (such as with **-playback**) is active,
+         it takes absolute precedence to prevent input desynchronization. The
+         **-rtc** command-line option will be ignored, and a warning will be
+         displayed in the console.
 
 .. _mame-commandline-scripting:
 

--- a/docs/source/commandline/commandline-index.rst
+++ b/docs/source/commandline/commandline-index.rst
@@ -331,6 +331,7 @@ Core Misc Options
 | :ref:`[no]ui_mouse <mame-commandline-uimouse>`
 | :ref:`language <mame-commandline-language>`
 | :ref:`[no]nvram_save <mame-commandline-nvramsave>`
+| :ref:`rtc <mame-commandline-rtc>`
 
 
 Scripting Options

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -211,6 +211,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_UI_MOUSE,                                   "1",         core_options::option_type::BOOLEAN,    "display UI mouse cursor" },
 	{ OPTION_LANGUAGE ";lang",                           "",          core_options::option_type::STRING,     "set UI display language" },
 	{ OPTION_NVRAM_SAVE ";nvwrite",                      "1",         core_options::option_type::BOOLEAN,    "save NVRAM data on exit" },
+	{ OPTION_RTC_TIME,                                   nullptr,     core_options::option_type::STRING,     "start emulation with time" },
 
 	{ nullptr,                                           nullptr,     core_options::option_type::HEADER,     "SCRIPTING OPTIONS" },
 	{ OPTION_AUTOBOOT_COMMAND ";ab",                     nullptr,     core_options::option_type::STRING,     "command to execute after machine boot" },

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -176,6 +176,7 @@
 #define OPTION_UI                   "ui"
 #define OPTION_RAMSIZE              "ramsize"
 #define OPTION_NVRAM_SAVE           "nvram_save"
+#define OPTION_RTC_TIME             "rtc"
 
 // core comm options
 #define OPTION_COMM_LOCAL_HOST      "comm_localhost"
@@ -459,6 +460,7 @@ public:
 	ui_option ui() const { return m_ui; }
 	const char *ram_size() const { return value(OPTION_RAMSIZE); }
 	bool nvram_save() const { return bool_value(OPTION_NVRAM_SAVE); }
+	const char *rtc_time() const { return value(OPTION_RTC_TIME); }
 
 	// core comm options
 	const char *comm_localhost() const { return value(OPTION_COMM_LOCAL_HOST); }

--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -166,15 +166,72 @@ void running_machine::start()
 	m_ui = manager().create_ui(*this);
 	m_ui->set_startup_text("Initializing...", true);
 
-	// initialize the base time (needed for doing record/playback)
 	::time(&m_base_time);
 
-	// initialize the input system and input ports for the game
-	// this must be done before memory_init in order to allow specifying
-	// callbacks based on input port tags
+	// check for input playback files (highest precedence)
 	time_t newbase = m_ioport.initialize();
 	if (newbase != 0)
+	{
 		m_base_time = newbase;
+
+		std::string rtc_str = options().rtc_time();
+		if (!rtc_str.empty() && rtc_str != "0")
+		{
+			osd_printf_warning("RTC: Input playback is active. Ignoring -rtc command line option.\n");
+		}
+	}
+	// if no playback file is active, look for the command-line override
+	else
+	{
+		std::string rtc_str = options().rtc_time();
+		if (!rtc_str.empty() && rtc_str != "0")
+		{
+			time_t old_base = m_base_time;
+			bool parsed_successfully = false;
+
+			// validate format: exactly 14 digits (YYYYMMDDhhmmss)
+			if (rtc_str.length() == 14 && rtc_str.find_first_not_of("0123456789") == std::string::npos)
+			{
+				int year = 0, month = 0, day = 0, hour = 0, min = 0, sec = 0;
+				if (sscanf(rtc_str.c_str(), "%4d%2d%2d%2d%2d%2d",
+					&year, &month, &day, &hour, &min, &sec) == 6)
+				{
+					struct tm t;
+					std::memset(&t, 0, sizeof(t));
+
+					t.tm_year = year - 1900;
+					t.tm_mon  = month - 1;
+					t.tm_mday = day;
+					t.tm_hour = hour;
+					t.tm_min  = min;
+					t.tm_sec  = sec;
+					t.tm_isdst = -1;
+
+					time_t parsed_time = mktime(&t);
+					if (parsed_time != (time_t)-1)
+					{
+						m_base_time = parsed_time;
+						osd_printf_verbose("RTC Override: Parsed '%s' successfully.\n", rtc_str.c_str());
+						parsed_successfully = true;
+					}
+				}
+			}
+
+			if (!parsed_successfully)
+			{
+				osd_printf_error("RTC Override Error: '%s' is not a valid YYYYMMDDhhmmss string.\n", rtc_str.c_str());
+			}
+
+			// print the final result to confirm it changed
+			if (m_base_time != old_base)
+			{
+				struct tm *final_tm = std::localtime(&m_base_time);
+				char time_buffer[64];
+				std::strftime(time_buffer, sizeof(time_buffer), "%Y-%m-%d %H:%M:%S", final_tm);
+				osd_printf_verbose("RTC Override Success: Base time set to %lld (%s)\n", (long long)m_base_time, time_buffer);
+			}
+		}
+	}
 
 	// initialize natural keyboard support after ports have been initialized
 	m_natkeyboard = std::make_unique<natural_keyboard>(*this);

--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -169,7 +169,9 @@ void running_machine::start()
 	// initialize the base time (needed for doing record/playback)
 	::time(&m_base_time);
 
-	// check for input playback files (highest precedence)
+	// initialize the input system and input ports for the game
+	// this must be done before memory_init in order to allow specifying
+	// callbacks based on input port tags
 	time_t newbase = m_ioport.initialize();
 	if (newbase != 0)
 	{

--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -166,6 +166,7 @@ void running_machine::start()
 	m_ui = manager().create_ui(*this);
 	m_ui->set_startup_text("Initializing...", true);
 
+	// initialize the base time (needed for doing record/playback)
 	::time(&m_base_time);
 
 	// check for input playback files (highest precedence)


### PR DESCRIPTION
Adds a new `-rtc <YYYYMMDDhhmmss>` command-line option to specify a fixed baseline date and time for emulated real-time clock chips, bypassing the default host system time. 

Key changes:
* Validates a strict 14-digit format to ensure predictable time injection.
* Automagically yields to `-playback` macros to avoid input desynchronization, printing a warning to the console instead.
* Includes documentation updates in Sphinx format.

*Assisted by Gemini (Google AI).*