### PR TITLE
gaelco3d.cpp: graphics off-by-one fixes

### DIFF
--- a/src/mame/gaelco/gaelco3d_v.cpp
+++ b/src/mame/gaelco/gaelco3d_v.cpp
@@ -204,7 +204,7 @@ void gaelco3d_state::gaelco3d_renderer::render_poly(screen_device &screen, uint3
 
 void gaelco3d_state::gaelco3d_renderer::render_noz_noperspective(int32_t scanline, const extent_t &extent, const gaelco3d_object_data &object, int threadid)
 {
-	float const zbase = recip_approx(object.ooz_base);
+	float const zbase = 1.0f / object.ooz_base;
 	float const uoz_step = object.uoz_dx * zbase;
 	float const voz_step = object.voz_dx * zbase;
 	int const zbufval = (int)(-object.z0 * zbase);
@@ -261,7 +261,7 @@ void gaelco3d_state::gaelco3d_renderer::render_normal(int32_t scanline, const ex
 		if (ooz > 0)
 		{
 			/* compute Z and check the Z buffer value first */
-			float const z = recip_approx(ooz);
+			float const z = 1.0f / ooz;
 			int zbufval = (int)(z0 * z);
 			if (zbufval < zbuf[x])
 			{
@@ -310,7 +310,7 @@ void gaelco3d_state::gaelco3d_renderer::render_alphablend(int32_t scanline, cons
 		if (ooz > 0)
 		{
 			/* compute Z and check the Z buffer value first */
-			float const z = recip_approx(ooz);
+			float const z = 1.0f / ooz;
 			int const zbufval = (int)(z0 * z);
 			if (zbufval < zbuf[x])
 			{

--- a/src/mame/gaelco/gaelco3d_v.cpp
+++ b/src/mame/gaelco/gaelco3d_v.cpp
@@ -182,6 +182,17 @@ void gaelco3d_state::gaelco3d_renderer::render_poly(screen_device &screen, uint3
 	/* if we have a valid number of verts, render them */
 	if (vertnum >= 3)
 	{
+		/* Prevent poly.h down-rounding from discarding the outermost vert coord */
+		float const maxx = float(screen.width());
+		float const maxy = float(screen.height());
+		for (int i = 0; i < vertnum; i++)
+		{
+			if (vert[i].x > maxx - 1.0f && vert[i].x < maxx)
+				vert[i].x = maxx;
+			if (vert[i].y > maxy - 1.0f && vert[i].y < maxy)
+				vert[i].y = maxy;
+		}
+
 		const rectangle &visarea = screen.visible_area();
 
 		/* special case: no Z buffering and no perspective correction */


### PR DESCRIPTION
This PR fixes [MT03342](https://mametesters.org/view.php?id=3342). 

It traces back to rounding errors introduced by SSE recip_approx, which caused the 64-bit build to have shifted polys at the time. Since MAME 0.193+ requiring SSE, both builds have been wrong. Taking the old exact reciprocal path fixes it.

This PR also fixes the single line issues at the outermost edges in radikalb. As gaelco3d has no 2D HW, it uses full screen covering polys. These polys are center alligned (the +0.5f), which gets rounded down on the edges by poly.h. So we round those up now.

Master:
<img width="255" alt="0000" src="https://github.com/user-attachments/assets/0098b8f7-2a63-44f9-bfe5-4667259fee3f" /><img width="255" alt="0001" src="https://github.com/user-attachments/assets/22f9924f-e217-46e3-b68d-3df1aedd62a0" /><img width="255" alt="0011" src="https://github.com/user-attachments/assets/3a0fef11-2d6f-47d1-88dd-edd75b191d6e" />

This PR:
<img width="255" alt="0000" src="https://github.com/user-attachments/assets/b843f4e6-fe3d-4bff-b07e-5f132cdeaf23" /><img width="255" alt="0006" src="https://github.com/user-attachments/assets/6bd2a2aa-3c6f-45c6-a7e3-0705fd347341" /><img width="255" alt="0002" src="https://github.com/user-attachments/assets/1b45629e-b3a5-4da1-af7a-0ba63596bea2" />


