### PR TITLE
h8: update active DMA channel on start/stop

### DIFF
--- a/src/devices/cpu/h8/h8_dma.cpp
+++ b/src/devices/cpu/h8/h8_dma.cpp
@@ -70,19 +70,25 @@ void h8gen_dma_device::set_input(int inputnum, int state)
 
 void h8gen_dma_device::start_stop_test()
 {
+	bool changed = false;
 	u8 chnmap = active_channels();
 	for(int i=0; i != 8; i++) {
 		if(BIT(chnmap, i)) {
-			if(!(m_dmach[i >> 1]->m_state[i & 1].m_flags & h8_dma_state::ACTIVE))
+			if(!(m_dmach[i >> 1]->m_state[i & 1].m_flags & h8_dma_state::ACTIVE)) {
 				m_dmach[i >> 1]->start(i & 1);
+				changed = true;
+			}
 
 		} else {
 			if(m_dmach[i >> 1] && (m_dmach[i >> 1]->m_state[i & 1].m_flags & h8_dma_state::ACTIVE)) {
 				logerror("forced abort %d\n", i);
 				m_dmach[i >> 1]->abort(i & 1);
+				changed = true;
 			}
 		}
 	}
+	if(changed)
+		m_cpu->update_active_dma_channel();
 }
 
 
@@ -549,7 +555,10 @@ void h8h_dma_channel_device::dtcrb_w(u8 data)
 
 void h8h_dma_channel_device::dma_done(int submodule)
 {
-	m_dtcr[submodule] &= ~0x80;
+	if(m_state[submodule].m_flags & h8_dma_state::FAE)
+		m_dtcr[0] &= ~0x80;
+	else
+		m_dtcr[submodule] &= ~0x80;
 	h8gen_dma_channel_device::dma_done(submodule);
 }
 


### PR DESCRIPTION
This fixes a regression that prevents Brother `lw840` and `lw700i` from completing startup.

Both machines start an H8H DMA transfer and then poll `DTCRA` for completion. On current builds, the transfer does not run/complete as expected, so the firmware keeps polling. `lw840` remains on a mostly white screen with small black artifacts in the upper-left corner, and `lw700i` shows the same DMA polling pattern in the log.

The fix does two things:

- notify the H8 CPU when `start_stop_test()` starts or aborts a DMA channel, so the active DMA channel is recomputed
- restore the H8H full-address-mode completion behavior where `DTCRA` is cleared

Tested with a focused build:

```sh
make SUBTARGET=brothertest SOURCES=src/mame/brother/lw840.cpp,src/mame/brother/lw700i.cpp REGENIE=1 NOWERROR=1 -j8
```

Smoke-tested:

```sh
./brothertest lw840 -nothrottle -video soft -seconds_to_run 5 -log
./brothertest lw700i -nothrottle -video soft -seconds_to_run 5 -log
```

After the patch, both runs complete the startup DMA polling sequence. The logs show DMA setup followed by `dtcra_r 06` and `dtcrb_w 00`, rather than repeated `dtcra_r 86` polling.