### PR TITLE
some Mobigo changes (moved Mobigo 2 to it's own driver, added a missing boot ROM, added a French MobiGo 1 set)

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -47508,6 +47508,15 @@ tvbg3c
 tvbg6a
 tvbg6b
 
+@source:tvgames/bk139in1.cpp
+bk139in1
+dgun3944
+lxcymls
+lxcympp
+lxcymsm
+lxcyrace
+starbuck
+
 @source:tvgames/elan_eu3a05.cpp
 airblsjs
 bratzra
@@ -47556,6 +47565,8 @@ tomyeggb
 @source:tvgames/generalplus_gpl16250_mobigo.cpp
 mobigo
 mobigos
+
+@source:tvgames/generalplus_gpl16250_mobigo2.cpp
 mobigo2
 
 @source:tvgames/generalplus_gpl16250_nand.cpp
@@ -47622,19 +47633,12 @@ wrlshunt
 anpanbd
 anpaneng
 anpanm15
-bk139in1
 bkrankp
-dgun3944
 jspodred
-lxcymls
-lxcympp
-lxcymsm
-lxcyrace
 pokegac2
 pokegac2y
 pokegach
 prailpls
-starbuck
 vmastspi
 wildking
 

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -47564,6 +47564,7 @@ tomyeggb
 
 @source:tvgames/generalplus_gpl16250_mobigo.cpp
 mobigo
+mobigof
 mobigos
 
 @source:tvgames/generalplus_gpl16250_mobigo2.cpp

--- a/src/mame/tvgames/bk139in1.cpp
+++ b/src/mame/tvgames/bk139in1.cpp
@@ -1,0 +1,115 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+
+// possibly SPG293 (S+Core) or ARM, but the code is encrypted (probably AES)
+// the NES emulation seems comparable to other SPG293 platforms
+
+#include "emu.h"
+
+#include "screen.h"
+#include "speaker.h"
+
+
+class bk139in1_state : public driver_device
+{
+public:
+	bk139in1_state(const machine_config &mconfig, device_type type, const char *tag) :
+		driver_device(mconfig, type, tag),
+		m_screen(*this, "screen")
+	{
+	}
+
+	void bk139in1(machine_config &config) ATTR_COLD;
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+	virtual void machine_reset() override ATTR_COLD;
+
+private:
+	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+
+	required_device<screen_device> m_screen;
+};
+
+uint32_t bk139in1_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	return 0;
+}
+
+void bk139in1_state::machine_start()
+{
+}
+
+void bk139in1_state::machine_reset()
+{
+}
+
+static INPUT_PORTS_START( bk139in1 )
+INPUT_PORTS_END
+
+void bk139in1_state::bk139in1(machine_config &config)
+{
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
+	m_screen->set_refresh_hz(60);
+	m_screen->set_size(320, 262);
+	m_screen->set_visarea(0, 320-1, 0, 240-1);
+	m_screen->set_screen_update(FUNC(bk139in1_state::screen_update));
+
+	SPEAKER(config, "speaker", 2).front();
+}
+
+ROM_START( bk139in1 )
+	ROM_REGION(0x4000000, "maincpu", ROMREGION_ERASE00)
+	ROM_LOAD( "25q512.bin", 0x0000, 0x4000000, CRC(0cd111a4) SHA1(70553a44c3d946e5d23c09f04e0627a5dbaa3e4d) )
+ROM_END
+
+ROM_START( lxcyrace )
+	ROM_REGION(0x1000000, "maincpu", ROMREGION_ERASE00)
+	ROM_LOAD( "25q128.u2", 0x0000, 0x1000000, CRC(4489c99d) SHA1(792d6d224584fe1f3349c64a59aa79a587dd8c17) )
+ROM_END
+
+ROM_START( lxcymsm )
+	ROM_REGION(0x2000000, "maincpu", ROMREGION_ERASE00)
+	ROM_LOAD( "25q256.bin", 0x0000, 0x2000000, CRC(96b3ee5c) SHA1(f1e6bf46a4503877074310506d1acc4607dac331) )
+ROM_END
+
+ROM_START( lxcympp )
+	ROM_REGION(0x2000000, "maincpu", ROMREGION_ERASE00)
+	ROM_LOAD( "25q256.bin", 0x0000, 0x2000000, CRC(570b669c) SHA1(e7fcae662c8c8cae18cf1151d6caefacfe1e9fda) )
+ROM_END
+
+ROM_START( lxcymls )
+	ROM_REGION(0x2000000, "maincpu", ROMREGION_ERASE00)
+	ROM_LOAD( "25q256.bin", 0x0000, 0x2000000, CRC(76c89fe5) SHA1(99668cbce2ace6ec972ee4e72fec8b93862a0ef4) )
+ROM_END
+
+ROM_START( dgun3944 )
+	ROM_REGION(0x1000000, "maincpu", ROMREGION_ERASE00)
+	ROM_LOAD( "by25q128as.bin", 0x0000, 0x1000000, CRC(cf2bfc98) SHA1(f8c984f0278506d74b0b6337d2e96bb9d3a58148) )
+ROM_END
+
+ROM_START( starbuck )
+	ROM_REGION(0x200000, "maincpu", ROMREGION_ERASE00)
+	ROM_LOAD( "by25q16est.bin", 0x0000, 0x200000,  CRC(926c1499) SHA1(edd88b11f350e0016ee7dc76e872f9ae8c00aa6c) )
+ROM_END
+
+
+// This can be found listed as a ZHISHAN / Aojiao / Bornkid 32 Bit Preloaded 139-in-1 Handheld Game Console
+// but these just seem to be brands, manufacturer is unknown.
+// Various case styles are available, the unit here was styled after a Nintendo Switch
+//
+// Architecture is unknown, it contains many of the games in beijuehh / bornkidh (generalplus_gpl16250_rom.cpp)
+// but is running from SPI flash and has 'Loading' screens between menus and after selecting a game.
+//
+// While those are GeneralPlus based platforms, it's possible the games were ported to something else, the SPI
+// appears to contain a filesystem, but data looks to be compressed / encrypted with no obvious code.
+// There is no GPspi header in the SPI ROM.
+CONS(202?, bk139in1,  0, 0, bk139in1, bk139in1, bk139in1_state, empty_init, "<unknown>", "BornKid 32 Bit Preloaded 139-in-1 Handheld Game Console", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+// same unknown hardware as above, fewer games
+CONS(2021, lxcyrace,  0, 0, bk139in1, bk139in1, bk139in1_state, empty_init, "Lexibook", "Cyber Arcade Racing (JL3150)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, lxcymsm,   0, 0, bk139in1, bk139in1, bk139in1_state, empty_init, "Lexibook", "Cyber Arcade Motion - Superman (JL3180SU)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, lxcympp,   0, 0, bk139in1, bk139in1, bk139in1_state, empty_init, "Lexibook", "Cyber Arcade Motion - Paw Patrol (JL3180PA)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, lxcymls,   0, 0, bk139in1, bk139in1, bk139in1_state, empty_init, "Lexibook", "Cyber Arcade Motion - Lilo & Stitch (JL3180D_01)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, dgun3944,  0, 0, bk139in1, bk139in1, bk139in1_state, empty_init, "dreamGEAR", "My Arcade All Star Sports (Pixel Pocket, DGUNL3944)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+// sold by Starbucks China, contains a bunch of NES hacks (including a version of Super Mario Bros) probably running on an emulator
+CONS(2022, starbuck,  0, 0, bk139in1, bk139in1, bk139in1_state, empty_init, "Subor",     "Starbucks x Subor (OEM Q2, China)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)

--- a/src/mame/tvgames/generalplus_gpl16250_mobigo.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_mobigo.cpp
@@ -38,21 +38,6 @@
 
 namespace {
 
-class mobigo2_state : public generalplus_gpac800_game_state
-{
-public:
-	mobigo2_state(const machine_config &mconfig, device_type type, const char *tag) :
-		generalplus_gpac800_game_state(mconfig, type, tag),
-		m_cart(*this, "cartslot")
-	{ }
-
-	void mobigo2(machine_config &config) ATTR_COLD;
-
-protected:
-	DECLARE_DEVICE_IMAGE_LOAD_MEMBER(cart_load);
-
-	required_device<generic_slot_device> m_cart;
-};
 
 class mobigo_state : public wrlshunt_game_state
 {
@@ -80,13 +65,6 @@ INPUT_PORTS_END
 
 
 
-DEVICE_IMAGE_LOAD_MEMBER(mobigo2_state::cart_load)
-{
-	u32 const size = m_cart->common_get_size("rom");
-	m_cart->rom_alloc(size, GENERIC_ROM16_WIDTH, ENDIANNESS_LITTLE);
-	m_cart->common_load_rom(m_cart->get_rom_base(), size, "rom");
-	return std::make_pair(std::error_condition(), std::string());
-}
 
 DEVICE_IMAGE_LOAD_MEMBER(mobigo_state::cart_load)
 {
@@ -107,42 +85,6 @@ void mobigo_state::mobigo(machine_config &config)
 	//m_cart->set_must_be_loaded(true);
 
 	SOFTWARE_LIST(config, "cart_list").set_original("mobigo_cart");
-}
-
-void mobigo2_state::mobigo2(machine_config &config)
-{
-	set_addrmap(0, &mobigo2_state::cs_map_base);
-
-	GPL16250(config, m_maincpu, 96000000/2, m_screen);  // Doesn't have GPnandnand header in NAND tho, so non-standard bootloader
-	m_maincpu->porta_in().set(FUNC(mobigo2_state::porta_r));
-	m_maincpu->portb_in().set(FUNC(mobigo2_state::portb_r));
-	m_maincpu->portc_in().set(FUNC(mobigo2_state::portc_r));
-	m_maincpu->porta_out().set(FUNC(mobigo2_state::porta_w));
-	m_maincpu->space_read_callback().set(FUNC(mobigo2_state::read_external_space));
-	m_maincpu->space_write_callback().set(FUNC(mobigo2_state::write_external_space));
-	m_maincpu->set_irq_acknowledge_callback(m_maincpu, FUNC(sunplus_gcm394_base_device::irq_vector_cb));
-	m_maincpu->add_route(ALL_OUTPUTS, "speaker", 0.5, 0);
-	m_maincpu->add_route(ALL_OUTPUTS, "speaker", 0.5, 1);
-	m_maincpu->set_bootmode(0); // boot from internal ROM (NAND bootstrap)
-	m_maincpu->set_cs_config_callback(FUNC(mobigo2_state::cs_callback));
-
-	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
-	m_screen->set_refresh_hz(60);
-	m_screen->set_size(320*2, 262*2);
-	m_screen->set_visarea(0, (320*2)-1, 0, (240*2)-1);
-	m_screen->set_screen_update("maincpu", FUNC(sunplus_gcm394_device::screen_update));
-	m_screen->screen_vblank().set(m_maincpu, FUNC(sunplus_gcm394_device::vblank));
-
-	SPEAKER(config, "speaker", 2).front();
-
-	GENERIC_CARTSLOT(config, m_cart, generic_plain_slot, "mobigo_cart");
-	m_cart->set_width(GENERIC_ROM16_WIDTH);
-	m_cart->set_device_load(FUNC(mobigo2_state::cart_load));
-	//m_cart->set_must_be_loaded(true);
-
-	SOFTWARE_LIST(config, "cart_list").set_original("mobigo_cart");
-
-	SAMSUNG_K9F1G08U0M(config, m_nand); // 128Mbyte part, with 0x800+0x40 sized pages
 }
 
 void mobigo_state::init_mobigo()
@@ -166,18 +108,7 @@ ROM_START( mobigos )
 	ROM_LOAD16_WORD_SWAP("mobigospanish.bin", 0x0000, 0x200000, CRC(462b4f9d) SHA1(1541152f1a359bc18de4d4f3d5038a954c9a3ad4))
 ROM_END
 
-
-ROM_START( mobigo2 )
-	//ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
-	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP ) // doesn't have GPnandnand header in NAND, so bootstrap is likely custom
-
-	ROM_REGION( 0x8400000, "nandrom", ROMREGION_ERASE00 )
-	ROM_LOAD( "mobigo2_bios_ger.bin", 0x00000, 0x8400000, CRC(d5ab613d) SHA1(6fb104057dc3484fa958e2cb20c5dd0c19589f75) ) // SPANSION S34ML01G100TF100
-ROM_END
-
 } // anonymous namespace
 
-
-CONS( 2010, mobigo,  0,      0, mobigo,   mobigo, mobigo_state,  init_mobigo , "VTech", "MobiGo (USA)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-CONS( 2011, mobigos, mobigo, 0, mobigo,   mobigo, mobigo_state,  init_mobigo , "VTech", "MobiGo (Spain)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-CONS( 2013, mobigo2, 0,      0, mobigo2,  mobigo, mobigo2_state, nand_init,    "VTech", "MobiGo 2 (Germany)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2010, mobigo,  0,      0, mobigo,   mobigo, mobigo_state,  init_mobigo, "VTech", "MobiGo (USA)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2011, mobigos, mobigo, 0, mobigo,   mobigo, mobigo_state,  init_mobigo, "VTech", "MobiGo (Spain)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/tvgames/generalplus_gpl16250_mobigo.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_mobigo.cpp
@@ -12,17 +12,13 @@
 
     GPL16250 Mobigo support
     the original Mobigo is ROM+RAM config
-    the Mobigo 2 is NAND+RAM config
+    the Mobigo 2 is SPI+RAM+NAND config (see generalplus_gpl16250_mobigo2.cpp)
     cartridges are compatible
 
     Known Undumped:
-    MobiGo 2 (USA, English)
     MobiGo (UK and Australia, English)
-    MobiGo 2 (UK and Australia, English)
     MobiGo (Canada, English)
-    MobiGo 2 (Canada, English)
     MobiGo (Canada, French)
-
 */
 
 #include "emu.h"
@@ -108,7 +104,19 @@ ROM_START( mobigos )
 	ROM_LOAD16_WORD_SWAP("mobigospanish.bin", 0x0000, 0x200000, CRC(462b4f9d) SHA1(1541152f1a359bc18de4d4f3d5038a954c9a3ad4))
 ROM_END
 
+ROM_START( mobigof )
+	//ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 ) // not on this model? (or at least not this size, as CS base is different)
+	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP )
+
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00)
+	ROM_LOAD16_WORD_SWAP("mobigo_fr.u5", 0x0000, 0x200000, CRC(61d739aa) SHA1(d23d4c806f1b60058c57ea9b339a7c5e3124bafa))
+
+	ROM_REGION( 0x800000, "spi", ROMREGION_ERASE00) // for built-in games and/or downloads? (not a boot ROM)
+	ROM_LOAD16_WORD_SWAP("mx25l1606e.u3", 0x0000, 0x200000, CRC(31110b90) SHA1(b6a3b707d9ff688635be8bc01221b4db503ce159))
+ROM_END
+
 } // anonymous namespace
 
 CONS( 2010, mobigo,  0,      0, mobigo,   mobigo, mobigo_state,  init_mobigo, "VTech", "MobiGo (USA)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 CONS( 2011, mobigos, mobigo, 0, mobigo,   mobigo, mobigo_state,  init_mobigo, "VTech", "MobiGo (Spain)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2011, mobigof, mobigo, 0, mobigo,   mobigo, mobigo_state,  init_mobigo, "VTech", "MobiGo (France)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/tvgames/generalplus_gpl16250_mobigo2.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_mobigo2.cpp
@@ -1,0 +1,79 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+
+#include "emu.h"
+
+#include "generalplus_gpl16250_spi.h"
+
+#include "bus/generic/carts.h"
+#include "bus/generic/slot.h"
+#include "machine/nandflash.h"
+
+#include "softlist_dev.h"
+
+namespace {
+
+class generalplus_mobigo2_state : public generalplus_gpspispi_game_state
+{
+public:
+	generalplus_mobigo2_state(const machine_config &mconfig, device_type type, const char *tag) :
+		generalplus_gpspispi_game_state(mconfig, type, tag),
+		m_cart(*this, "cartslot"),
+		m_nand(*this, "nandrom")
+	{
+	}
+
+	void mobigo2(machine_config &config) ATTR_COLD;
+
+private:
+	DECLARE_DEVICE_IMAGE_LOAD_MEMBER(cart_load);
+
+	required_device<generic_slot_device> m_cart;
+	required_device<nand_device> m_nand;
+};
+
+static INPUT_PORTS_START( mobigo2 )
+	PORT_START("IN0")
+	PORT_START("IN1")
+	PORT_START("IN2")
+INPUT_PORTS_END
+
+
+DEVICE_IMAGE_LOAD_MEMBER(generalplus_mobigo2_state::cart_load)
+{
+	u32 const size = m_cart->common_get_size("rom");
+	m_cart->rom_alloc(size, GENERIC_ROM16_WIDTH, ENDIANNESS_LITTLE);
+	m_cart->common_load_rom(m_cart->get_rom_base(), size, "rom");
+	return std::make_pair(std::error_condition(), std::string());
+}
+
+
+void generalplus_mobigo2_state::mobigo2(machine_config &config)
+{
+	generalplus_gpspispi(config);
+
+	GENERIC_CARTSLOT(config, m_cart, generic_plain_slot, "mobigo_cart");
+	m_cart->set_width(GENERIC_ROM16_WIDTH);
+	m_cart->set_device_load(FUNC(generalplus_mobigo2_state::cart_load));
+	//m_cart->set_must_be_loaded(true);
+
+	SOFTWARE_LIST(config, "cart_list").set_original("mobigo_cart");
+
+	SAMSUNG_K9F1G08U0M(config, m_nand); // 128Mbyte part, with 0x800+0x40 sized pages
+}
+
+
+ROM_START( mobigo2 )
+	//ROM_REGION16_BE( 0x40000, "maincpu:internal", ROMREGION_ERASE00 )
+	//ROM_LOAD16_WORD_SWAP( "internal.rom", 0x00000, 0x40000, NO_DUMP )
+
+	ROM_REGION( 0x200000, "maincpu", ROMREGION_ERASE00)	// appears to be the boot ROM, has GPspispi header
+	ROM_LOAD16_WORD_SWAP( "n25s16.u3", 0x00000, 0x200000, CRC(dfbf5029) SHA1(2a079ddd8a13c5f3d8f40fa6d6c3de2dc1573449) )
+
+	ROM_REGION( 0x8400000, "nandrom", ROMREGION_ERASE00 ) // no GPnandnand header so not a boot device
+	ROM_LOAD( "mobigo2_bios_ger.bin", 0x00000, 0x8400000, CRC(d5ab613d) SHA1(6fb104057dc3484fa958e2cb20c5dd0c19589f75) ) // SPANSION S34ML01G100TF100
+ROM_END
+
+} // anonymous namespace
+
+CONS( 2013, mobigo2, 0,      0, mobigo2,  mobigo2, generalplus_mobigo2_state, init_spi, "VTech", "MobiGo 2 (Germany)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/tvgames/generalplus_gpl16250_mobigo2.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_mobigo2.cpp
@@ -1,6 +1,13 @@
 // license:BSD-3-Clause
 // copyright-holders:David Haywood
 
+/*
+	Known Undumped:
+	MobiGo 2 (USA, English)
+	MobiGo 2 (UK and Australia, English)
+    MobiGo 2 (Canada, English)
+*/
+
 #include "emu.h"
 
 #include "generalplus_gpl16250_spi.h"

--- a/src/mame/tvgames/generalplus_gpl16250_spi.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_spi.cpp
@@ -8,46 +8,8 @@
 */
 
 #include "emu.h"
-#include "generalplus_gpl16250.h"
+#include "generalplus_gpl16250_spi.h"
 #include "softlist_dev.h"
-
-
-namespace {
-
-class generalplus_gpspispi_game_state : public gcm394_game_state
-{
-public:
-	generalplus_gpspispi_game_state(const machine_config &mconfig, device_type type, const char *tag) :
-		gcm394_game_state(mconfig, type, tag)
-	{
-	}
-
-	void generalplus_gpspispi(machine_config &config) ATTR_COLD;
-
-	void init_spi() ATTR_COLD;
-
-protected:
-	virtual void machine_start() override ATTR_COLD;
-	virtual void machine_reset() override ATTR_COLD;
-};
-
-
-class generalplus_gpspispi_bkrankp_game_state : public generalplus_gpspispi_game_state
-{
-public:
-	generalplus_gpspispi_bkrankp_game_state(const machine_config &mconfig, device_type type, const char *tag) :
-		generalplus_gpspispi_game_state(mconfig, type, tag),
-		m_cart(*this, "cartslot")
-	{
-	}
-
-	void generalplus_gpspispi_bkrankp(machine_config &config) ATTR_COLD;
-
-protected:
-	DECLARE_DEVICE_IMAGE_LOAD_MEMBER(cart_load);
-
-	required_device<generic_slot_device> m_cart;
-};
 
 
 void generalplus_gpspispi_game_state::machine_start()
@@ -186,41 +148,6 @@ ROM_START( pokegac2y )
 ROM_END
 
 
-ROM_START( bk139in1 )
-	ROM_REGION(0x4000000, "maincpu", ROMREGION_ERASE00)
-	ROM_LOAD( "25q512.bin", 0x0000, 0x4000000, CRC(0cd111a4) SHA1(70553a44c3d946e5d23c09f04e0627a5dbaa3e4d) )
-ROM_END
-
-ROM_START( lxcyrace )
-	ROM_REGION(0x1000000, "maincpu", ROMREGION_ERASE00)
-	ROM_LOAD( "25q128.u2", 0x0000, 0x1000000, CRC(4489c99d) SHA1(792d6d224584fe1f3349c64a59aa79a587dd8c17) )
-ROM_END
-
-ROM_START( lxcymsm )
-	ROM_REGION(0x2000000, "maincpu", ROMREGION_ERASE00)
-	ROM_LOAD( "25q256.bin", 0x0000, 0x2000000, CRC(96b3ee5c) SHA1(f1e6bf46a4503877074310506d1acc4607dac331) )
-ROM_END
-
-ROM_START( lxcympp )
-	ROM_REGION(0x2000000, "maincpu", ROMREGION_ERASE00)
-	ROM_LOAD( "25q256.bin", 0x0000, 0x2000000, CRC(570b669c) SHA1(e7fcae662c8c8cae18cf1151d6caefacfe1e9fda) )
-ROM_END
-
-ROM_START( lxcymls )
-	ROM_REGION(0x2000000, "maincpu", ROMREGION_ERASE00)
-	ROM_LOAD( "25q256.bin", 0x0000, 0x2000000, CRC(76c89fe5) SHA1(99668cbce2ace6ec972ee4e72fec8b93862a0ef4) )
-ROM_END
-
-ROM_START( dgun3944 )
-	ROM_REGION(0x1000000, "maincpu", ROMREGION_ERASE00)
-	ROM_LOAD( "by25q128as.bin", 0x0000, 0x1000000, CRC(cf2bfc98) SHA1(f8c984f0278506d74b0b6337d2e96bb9d3a58148) )
-ROM_END
-
-ROM_START( starbuck )
-	ROM_REGION(0x200000, "maincpu", ROMREGION_ERASE00)
-	ROM_LOAD( "by25q16est.bin", 0x0000, 0x200000,  CRC(926c1499) SHA1(edd88b11f350e0016ee7dc76e872f9ae8c00aa6c) )
-ROM_END
-
 void generalplus_gpspispi_game_state::init_spi()
 {
 	int vectorbase = 0x2fe0;
@@ -267,7 +194,6 @@ void generalplus_gpspispi_game_state::init_spi()
 	internal[0x7fff] = vectorbase + 0x1e;
 }
 
-} // anonymous namespace
 
 // ぼくはプラレール運転士 新幹線で行こう！プラス  (I am a Plarail driver Let's go by Shinkansen! Plus)
 CONS(2015, prailpls, 0, 0, generalplus_gpspispi,         gcm394, generalplus_gpspispi_game_state,         init_spi, "Takara Tomy", "Boku wa Plarail Untenshi Shinkansen de Ikou! Plus (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND) // has built-in screen, but can be connected to a TV
@@ -298,23 +224,3 @@ CONS(2015, pokegach,  0,        0, generalplus_gpspispi_bkrankp, gcm394, general
 // the 2nd release comes in 2 colours and they can communicate?
 CONS(2015, pokegac2,  0,        0, generalplus_gpspispi_bkrankp, gcm394, generalplus_gpspispi_bkrankp_game_state, init_spi, "Tomy", "Pokegacha V2 Red (20151230, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 CONS(2015, pokegac2y, pokegach, 0, generalplus_gpspispi_bkrankp, gcm394, generalplus_gpspispi_bkrankp_game_state, init_spi, "Tomy", "Pokegacha V2 Yellow (20151230, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-
-// This can be found listed as a ZHISHAN / Aojiao / Bornkid 32 Bit Preloaded 139-in-1 Handheld Game Console
-// but these just seem to be brands, manufacturer is unknown.
-// Various case styles are available, the unit here was styled after a Nintendo Switch
-//
-// Architecture is unknown, it contains many of the games in beijuehh / bornkidh (generalplus_gpl16250_rom.cpp)
-// but is running from SPI flash and has 'Loading' screens between menus and after selecting a game.
-//
-// While those are GeneralPlus based platforms, it's possible the games were ported to something else, the SPI
-// appears to contain a filesystem, but data looks to be compressed / encrypted with no obvious code.
-// There is no GPspi header in the SPI ROM.
-CONS(202?, bk139in1,  0, 0, generalplus_gpspispi, gcm394, generalplus_gpspispi_game_state, empty_init, "<unknown>", "BornKid 32 Bit Preloaded 139-in-1 Handheld Game Console", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-// same unknown hardware as above, fewer games
-CONS(2021, lxcyrace,  0, 0, generalplus_gpspispi, gcm394, generalplus_gpspispi_game_state, empty_init, "Lexibook", "Cyber Arcade Racing (JL3150)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS(2021, lxcymsm,   0, 0, generalplus_gpspispi, gcm394, generalplus_gpspispi_game_state, empty_init, "Lexibook", "Cyber Arcade Motion - Superman (JL3180SU)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS(2021, lxcympp,   0, 0, generalplus_gpspispi, gcm394, generalplus_gpspispi_game_state, empty_init, "Lexibook", "Cyber Arcade Motion - Paw Patrol (JL3180PA)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS(2021, lxcymls,   0, 0, generalplus_gpspispi, gcm394, generalplus_gpspispi_game_state, empty_init, "Lexibook", "Cyber Arcade Motion - Lilo & Stitch (JL3180D_01)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-CONS(2021, dgun3944,  0, 0, generalplus_gpspispi, gcm394, generalplus_gpspispi_game_state, empty_init, "dreamGEAR", "My Arcade All Star Sports (Pixel Pocket, DGUNL3944)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
-// sold by Starbucks China, contains a bunch of NES hacks (including a version of Super Mario Bros) probably running on an emulator
-CONS(2022, starbuck,  0, 0, generalplus_gpspispi, gcm394, generalplus_gpspispi_game_state, empty_init, "Subor",     "Starbucks x Subor (OEM Q2, China)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)

--- a/src/mame/tvgames/generalplus_gpl16250_spi.h
+++ b/src/mame/tvgames/generalplus_gpl16250_spi.h
@@ -1,0 +1,54 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+#ifndef MAME_TVGAMES_GENERALPLUS_GPL16250_SPI_H
+#define MAME_TVGAMES_GENERALPLUS_GPL16250_SPI_H
+
+#pragma once
+
+#include "generalplus_gpl16250.h"
+
+#include "bus/generic/carts.h"
+#include "bus/generic/slot.h"
+#include "machine/generalplus_gpl162xx_soc.h"
+
+#include "screen.h"
+#include "speaker.h"
+
+
+class generalplus_gpspispi_game_state : public gcm394_game_state
+{
+public:
+	generalplus_gpspispi_game_state(const machine_config &mconfig, device_type type, const char *tag) :
+		gcm394_game_state(mconfig, type, tag)
+	{
+	}
+
+	void generalplus_gpspispi(machine_config &config) ATTR_COLD;
+
+	void init_spi() ATTR_COLD;
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+	virtual void machine_reset() override ATTR_COLD;
+};
+
+
+class generalplus_gpspispi_bkrankp_game_state : public generalplus_gpspispi_game_state
+{
+public:
+	generalplus_gpspispi_bkrankp_game_state(const machine_config &mconfig, device_type type, const char *tag) :
+		generalplus_gpspispi_game_state(mconfig, type, tag),
+		m_cart(*this, "cartslot")
+	{
+	}
+
+	void generalplus_gpspispi_bkrankp(machine_config &config) ATTR_COLD;
+
+protected:
+	DECLARE_DEVICE_IMAGE_LOAD_MEMBER(cart_load);
+
+	required_device<generic_slot_device> m_cart;
+};
+
+
+#endif // MAME_TVGAMES_GENERALPLUS_GPL16250_SPI_H


### PR DESCRIPTION
- added missing SPI ROM to mobigo2 set, this appears to be the boot ROM which explains why the NAND had no GPnandnand header
- identified that (at least some) Mobigo 1 units have an SPI ROM too, but it isn't used for booting, but instead either user content, or built in games
- moved mobigo2 to it's own file due to the differences in hardware setup compared to the original mobigo
- moved a few things out of generalplus_gpl16250_spi.cpp that do not actually appear to be gpl16250 after further research on them

new NOT WORKING clones
--------
MobiGo (France) [Team Europe]