### PR TITLE
cpu/sh/sh7709s.cpp : Fix up background cycle accounting and bank conflict checks

### DIFF
--- a/src/devices/cpu/sh/sh.h
+++ b/src/devices/cpu/sh/sh.h
@@ -420,7 +420,7 @@ public:
 	virtual bool generate_group_12_TRAPA(drcuml_block &block, compiler_state &compiler, const opcode_desc *desc, uint16_t opcode, int in_delay_slot, uint32_t ovrpc);
 
 
-	bool generate_opcode(drcuml_block &block, compiler_state &compiler, const opcode_desc *desc, uint32_t ovrpc);
+	virtual bool generate_opcode(drcuml_block &block, compiler_state &compiler, const opcode_desc *desc, uint32_t ovrpc);
 	virtual bool generate_group_0(drcuml_block &block, compiler_state &compiler, const opcode_desc *desc, uint16_t opcode, int in_delay_slot, uint32_t ovrpc);
 	bool generate_group_2(drcuml_block &block, compiler_state &compiler, const opcode_desc *desc, uint16_t opcode, int in_delay_slot, uint32_t ovrpc);
 	bool generate_group_3(drcuml_block &block, compiler_state &compiler, const opcode_desc *desc, uint16_t opcode, uint32_t ovrpc);

--- a/src/devices/cpu/sh/sh7709s.cpp
+++ b/src/devices/cpu/sh/sh7709s.cpp
@@ -38,6 +38,11 @@
 *   the register value is read, IRQ2 is masked out of that value, then that masked value is written back.
 *   Documentation does mention in an addendum that this behavior can lead to lost IRQ's but luckily these
 *   games don't seem to actually use them in the release versions.
+*
+* - A quirk according to the docs for the sh7709s is that all areas must have the same bus width to use
+*   bank active mode. The cv1k board uses a 16 bit rom in area 0 which means the SDRAM is now stuck
+*   using auto precharge mode that forces a row close after every access which leads to some extra
+*   delays when cache misses collide on the same bank back to back.
 */
 
 #include "emu.h"
@@ -64,7 +69,7 @@ void sh7709s_device::device_reset()
 	m_last_area_accessed = 0;
 	m_last_area_accessed_was_write = false;
 	m_wb_active_cycles = 0;
-	m_last_sdram_page = 0;
+	m_last_sdram_bank = 0;
 	m_precharge_remaining_cycles = 0;
 }
 
@@ -77,7 +82,7 @@ void sh7709s_device::device_start()
 	m_last_area_accessed = 0;
 	m_last_area_accessed_was_write = false;
 	m_wb_active_cycles = 0;
-	m_last_sdram_page = 0;
+	m_last_sdram_bank = 0;
 	m_precharge_remaining_cycles = 0;
 
 	for (int i = 0; i < SH7709S_CACHE_BLOCKS; i++)
@@ -92,10 +97,11 @@ void sh7709s_device::device_start()
 	save_item(NAME(m_last_area_accessed));
 	save_item(NAME(m_last_area_accessed_was_write));
 	save_item(NAME(m_wb_active_cycles));
-	save_item(NAME(m_last_sdram_page));
+	save_item(NAME(m_last_sdram_bank));
 	save_item(NAME(m_precharge_remaining_cycles));
 }
 
+// Top 3 region bits allow for aliasing cached/uncached pointers to the same physical address
 bool is_cacheable(uint32_t address)
 {
 	// 0x00000000 - 0x80000000 2GB cacheable virtual space
@@ -264,8 +270,27 @@ uint32_t sh7709s_device::get_wcr2_timing(uint32_t address)
 	return 2; // Unreachable
 }
 
-// TODO : Update tpc handling to use the address multiplexer bits in mcr
-// instead of the sdram page as the precharge command holds up the whole bank
+uint32_t sh7709s_device::sdram_bank(uint32_t address)
+{
+	uint32_t amx = (m_mcr >> 3) & 0xf;
+
+	switch (amx)
+	{
+	case 0x4: // row begins with A9: 1M x 16-bit x 4-bank
+	case 0x7: // row begins with A9: 512k x 32-bit x 4-bank
+		return (address >> 7) & 0x3;   // A8:A7
+
+	case 0x5: // row begins with A10: 2M x 8/16-bit x 4-bank
+	case 0xd: // row begins with A10: 4M x 16-bit x 4-bank
+		return (address >> 8) & 0x3;   // A9:A8
+
+	case 0xa: // row begins with A11: 8M x 16-bit x 4-bank
+		return (address >> 9) & 0x3;   // A10:A9
+	}
+
+	return 0;
+}
+
 uint32_t sh7709s_device::mcr_tpc()
 {
 	return ((m_mcr >> 14) & 0x3) + 1;
@@ -303,8 +328,6 @@ uint32_t sh7709s_device::cache_line_fetch_count(uint32_t address)
 	return SH7709S_CACHE_LINE_SIZE >> bcr2_val;
 }
 
-#define SDRAM_PAGE_SIZE (1024) // Hardcoded for cv1k
-
 // CPU cycles
 #define CACHE_MISS_STALL (1) // Miss detection in 1 cycle, the rest of the ops (wb buffer movement, etc..) happen in the background
 // Bus cycles
@@ -330,7 +353,7 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	// Penalty calculations for SDRAM access
 	unsigned int bus_penalty = BUS_ACCESS_PENALTY + BURST_READ_WORD_PENALTY + mcr_rcd() + get_wcr2_timing(address);
 	unsigned int cpu_penalty = is_cacheable(address) ? CACHE_MISS_STALL : 0;
-	unsigned int page_read = address / SDRAM_PAGE_SIZE;
+	unsigned int bank_read = sdram_bank(address);
 
 	// Penalty calculations for non-sdram access
 	if (!is_sdram_region(address))
@@ -355,7 +378,7 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	m_last_area_accessed = area;
 
 	// CPU is in auto precharge mode, since we hit a bank conflict and the last precharge isn't done we stall
-	if (is_sdram_region(address) && page_read == m_last_sdram_page && m_precharge_remaining_cycles > 0)
+	if (is_sdram_region(address) && bank_read == m_last_sdram_bank && m_precharge_remaining_cycles > 0)
 		cpu_penalty += m_precharge_remaining_cycles;
 
 	m_precharge_remaining_cycles = 0;
@@ -369,19 +392,19 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	}
 
 	if (is_sdram_region(address))
-		m_last_sdram_page = page_read;
+		m_last_sdram_bank = bank_read;
 
 	// We had a dirty writeback eviction, total up the background cost penalty we'll pay on subsequent cycles
 	if (m_wb_address != 0)
 	{
 		if (is_sdram_region(address))
 		{
-			unsigned int page_write = m_wb_address / SDRAM_PAGE_SIZE;
+			uint32_t bank_write = sdram_bank(m_wb_address);
 			// Bank collision in auto precharge mode, we have to wait for precharge to finish before starting
-			if (page_read == page_write)
+			if (bank_read == bank_write)
 				m_wb_active_cycles += mcr_tpc() * 2;
 			m_wb_active_cycles += (BUS_ACCESS_PENALTY + get_wcr1_timing(address) + BURST_WRITE_WORD_PENALTY + mcr_rcd() + mcr_trwl()) * 2;
-			m_last_sdram_page = page_write;
+			m_last_sdram_bank = bank_write;
 		}
 		else
 		{

--- a/src/devices/cpu/sh/sh7709s.cpp
+++ b/src/devices/cpu/sh/sh7709s.cpp
@@ -10,8 +10,8 @@
 // - Write locking of cache lines
 // - Prefix instruction fetch timing + cache handling
 // - Checks for certain area specifics : bank mode timing for sdram access, area check for sdram, area check for burst mode + burst size
-// - TLB simulation + timing and lookups
-// - Branch predicition/mispredict penalties - Needs a branch target buffer and some basic tracking, didn't make a huge difference for cv1k when I threw one together
+// - TLB simulation + timing and lookups - Unused by cv1k
+// - Branch predicition/mispredict penalties
 
 /* cv1k notes
 *
@@ -214,7 +214,6 @@ uint32_t sh7709s_device::get_wcr2_timing(uint32_t address)
 {
 	uint32_t area = get_area(address);
 	uint16_t wcr2 = m_wcr2;
-	bool burst_capable = can_use_burst(address);
 
 	if (area > 6 || area == 1)
 		return 0;
@@ -241,33 +240,16 @@ uint32_t sh7709s_device::get_wcr2_timing(uint32_t address)
 		area_val = wcr2 & 0x7;
 	}
 
-	if (burst_capable)
+	switch (area_val)
 	{
-		switch (area_val)
-		{
-		case 0: return 2;
-		case 1: return 2;
-		case 2: return 3;
-		case 3: return 4;
-		case 4: return 4;
-		case 5: return 6;
-		case 6: return 8;
-		case 7: return 10;
-		}
-	}
-	else
-	{
-		switch (area_val)
-		{
-		case 0: return 0;
-		case 1: return 1;
-		case 2: return 2;
-		case 3: return 3;
-		case 4: return 4;
-		case 5: return 6;
-		case 6: return 8;
-		case 7: return 10;
-		}
+	case 0: return 0;
+	case 1: return 1;
+	case 2: return 2;
+	case 3: return 3;
+	case 4: return 4;
+	case 5: return 6;
+	case 6: return 8;
+	case 7: return 10;
 	}
 
 	return 2; // Unreachable
@@ -331,18 +313,7 @@ uint32_t sh7709s_device::cache_line_fetch_count(uint32_t address)
 	return SH7709S_CACHE_LINE_SIZE >> bcr2_val;
 }
 
-// CPU cycles
-#define CACHE_MISS_STALL (1) // Miss detection in 1 cycle, the rest of the ops (wb buffer movement, etc..) happen in the background
-// Bus cycles
-// TODO : Verify the bus stall here. These Renesas docs (https://resource.renesas.com/lib/eng/e_learnig/superh_e_learning/29/contents.html)
-// refer to a 3 bus cycle penalty for a cache line fill but the other documents don't seem to mention it.
-// For now this can cover the bsc clock sync + actv + read/write command cycles
-#define BUS_ACCESS_PENALTY (3)
-// TODO : CPU does critical word first handling here, so the first access causing the fetch
-// can amortize a couple of the remaining cyles of the read. These don't amount to too much for
-// now though
-#define BURST_READ_WORD_PENALTY (3)
-#define BURST_WRITE_WORD_PENALTY (3)
+#define CACHE_MISS_STALL (1) // Miss detection in 1 cpu cycle, the rest of the ops (wb buffer movement, etc..) happen in the background
 
 static uint64_t remaining_cycles(uint64_t elapsed, uint64_t cycles)
 {
@@ -352,33 +323,50 @@ static uint64_t remaining_cycles(uint64_t elapsed, uint64_t cycles)
 // cpu->bus cycle conversion hardcoded to 2x as cv1k sh3 runs the bus at 50mhz
 unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 {
-	uint32_t area = get_area(address);
 	bool is_in_cache = cache_access(address, write);
-	uint64_t elapsed_cycles = total_cycles() - m_last_op_cycle_count;
 
 	if (is_in_cache)
 		return 0;
 
-	// Penalty calculations for SDRAM access
-	unsigned int bus_penalty = BUS_ACCESS_PENALTY + BURST_READ_WORD_PENALTY + mcr_rcd() + get_wcr2_timing(address);
-	unsigned int cpu_penalty = is_cacheable(address) ? CACHE_MISS_STALL : 0;
-	unsigned int bank_read = sdram_bank(address);
+	uint32_t area = get_area(address);
+	uint64_t elapsed_cycles = total_cycles() - m_last_op_cycle_count;
+	uint32_t cpu_penalty = is_cacheable(address) ? CACHE_MISS_STALL : 0;
+	uint32_t bank_read = sdram_bank(address);
+	uint32_t bus_penalty = 0;
 
-	// Penalty calculations for non-sdram access
-	if (!is_sdram_region(address))
+	// SDRAM timing based on SH7709S documentation
+	// These are copied from the timing charts. These are all in bus cycles
+	// CAS for SDRAM is stored in WCR2
+	//
+	// Burst read  (cache fill, 4 longwords): Tr(ACTV) + Trw(RCD-1) + Tc1-Tc4 + CAS + Td2-Td4
+	// 1 + RCD + CAS + 3
+	//
+	// CPU does critical word first so it should only actually stall until:
+	// 1 + RCD + CAS
+	//
+	// Single read (uncached): Tr + Tc1(READA) + Td1
+	// 1 + RCD + CAS
+	//
+	// Single write(uncached): Tr + Tc1(WRITA) + Trwl
+	// 1 + RCD + TRWL
+	//
+	// Burst write (cache eviction writeback, 4 longwords): Tr + Tc1(WRITA) + Td2-Td4 + Trwl
+	// 1 + RCD + TRWL + 3
+	//
+	// Non-SDRAM areas : T1(address) + T2(data) + WCR2 wait states
+	// 2 + WCR2
+
+	// Critical word first handling, only stall until the critical word
+	// Right now we just stall until the first word lands which isn't quite right but is probably fine
+
+	if (is_sdram_region(address))
+		bus_penalty = 1 + mcr_rcd() + get_wcr2_timing(address);
+	else
 	{
-		// If it's not cacheable we're going to just do the single access
-		if (!is_cacheable(address))
-			bus_penalty = BUS_ACCESS_PENALTY + get_wcr2_timing(address);
-		else // Cacheable access, fetch the whole cache line
-			bus_penalty = (BUS_ACCESS_PENALTY + get_wcr2_timing(address)) * cache_line_fetch_count(address);
-	}
-	else if (!is_cacheable(address)) // non-cacheable sdram access
-	{
-		if (!write)
-			bus_penalty = BUS_ACCESS_PENALTY + mcr_rcd() + get_wcr2_timing(address);
+		if (is_cacheable(address))
+			bus_penalty = (2 + get_wcr2_timing(address)) * cache_line_fetch_count(address);
 		else
-			bus_penalty = BUS_ACCESS_PENALTY + mcr_rcd() + mcr_trwl();
+			bus_penalty = 2 + get_wcr2_timing(address);
 	}
 
 	if (area != m_last_area_accessed)
@@ -415,28 +403,44 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 		if (is_sdram_region(m_wb_address))
 		{
 			uint32_t bank_write = sdram_bank(m_wb_address);
-			// Bank collision in auto precharge mode, we have to wait for precharge to finish before starting
 			if (bank_read == bank_write)
-				m_wb_active_cycles += mcr_tpc() * 2;
-			m_wb_active_cycles += (BUS_ACCESS_PENALTY + get_wcr1_timing(m_wb_address) + BURST_WRITE_WORD_PENALTY + mcr_rcd() + mcr_trwl()) * 2;
+			{
+				if (is_cacheable(address))
+					m_wb_active_cycles += (3 + mcr_tpc()) * 2;
+				else
+					m_wb_active_cycles += mcr_tpc() * 2;
+			}
+			m_wb_active_cycles += (1 + mcr_rcd() + 3 + mcr_trwl() + mcr_tpc() + get_wcr1_timing(m_wb_address)) * 2;
 			m_last_sdram_bank = bank_write;
 		}
 		else
 		{
 			m_wb_active_cycles += get_wcr1_timing(m_wb_address) * 2;
-			m_wb_active_cycles += ((BUS_ACCESS_PENALTY + get_wcr2_timing(m_wb_address)) * cache_line_fetch_count(m_wb_address)) * 2;
+			m_wb_active_cycles += ((2 + get_wcr2_timing(m_wb_address)) * cache_line_fetch_count(m_wb_address)) * 2;
 		}
 
 		m_wb_address = 0;
 	}
 	else if (is_sdram_region(address)) // Account for the read close after burst read if we hit the same bank, writebacks include the cost in the background cycles if there is a conflict
-		m_precharge_remaining_cycles = mcr_tpc() * 2;
+	{
+		if (is_cacheable(address))
+			m_precharge_remaining_cycles = (3 + mcr_tpc()) * 2;
+		else
+			m_precharge_remaining_cycles = mcr_tpc() * 2;
+	}
 
 	return cpu_penalty + (bus_penalty * 2);
 }
 
 void sh7709s_device::update_access_cycles(uint32_t address, bool write)
 {
+	// For now only handle cacheable instruction fetch sampling when we do
+	// data accesses. The majority of uncached instruction fetches is
+	// handled in the cache flush timing
+	if (is_cacheable(m_sh2_state->pc)) {
+		m_sh2_state->icount -= access_penalty(m_sh2_state->pc, false);
+		m_last_op_cycle_count = total_cycles();
+	}
 	m_sh2_state->icount -= access_penalty(address, write);
 	m_last_op_cycle_count = total_cycles();
 }
@@ -453,15 +457,6 @@ void sh7709s_device::drc_memory_access_write()
 	update_access_cycles(address, true);
 }
 
-void sh7709s_device::drc_update_icache()
-{
-	// Assume the instruction prefetch is perfect for now
-	// we'll still pay a bit of penalty for the access and
-	// handle cache writeback when the icache fetch causes
-	// a dirty line eviction
-	update_access_cycles(m_sh2_state->pc, false);
-}
-
 static void cfunc_drc_memory_access_read(void *param)
 {
 	((sh7709s_device*)param)->drc_memory_access_read();
@@ -472,42 +467,8 @@ static void cfunc_drc_memory_access_write(void* param)
 	((sh7709s_device*)param)->drc_memory_access_write();
 }
 
-static void cfunc_drc_update_icache(void* param)
-{
-	((sh7709s_device*)param)->drc_update_icache();
-}
-
-// Have each instruction update the icache when executed since it's a shared icache+dcache
-// TODO : Ideally this uses generate_opcode but that seems to be quite cpu heavy
-// Check if there's another way of handling it that isn't as heavy. The CPU accesses
-// for instructions aren't a huge cause of slowdown related access other than the loop on cv1k
-// that handles cache invalidation that executes 1024 times which can add up.
-// Also need to double check how the uncached instruction fetch is handled if 32 bit reads are done
-bool sh7709s_device::generate_group_0(drcuml_block& block, compiler_state& compiler, const opcode_desc* desc, uint16_t opcode, int in_delay_slot, uint32_t ovrpc)
-{
-	UML_CALLC(block, cfunc_drc_update_icache, this);
-
-	return sh3_base_device::generate_group_0(block, compiler, desc, opcode, in_delay_slot, ovrpc);
-}
-
-bool sh7709s_device::generate_group_4(drcuml_block& block, compiler_state& compiler, const opcode_desc* desc, uint16_t opcode, int in_delay_slot, uint32_t ovrpc)
-{
-	UML_CALLC(block, cfunc_drc_update_icache, this);
-
-	return sh3_base_device::generate_group_4(block, compiler, desc, opcode, in_delay_slot, ovrpc);
-}
-
-bool sh7709s_device::generate_group_15(drcuml_block& block, compiler_state& compiler, const opcode_desc* desc, uint16_t opcode, int in_delay_slot, uint32_t ovrpc)
-{
-	UML_CALLC(block, cfunc_drc_update_icache, this);
-
-	return sh3_base_device::generate_group_15(block, compiler, desc, opcode, in_delay_slot, ovrpc);
-}
-
 // Same as static_generate_memory_accessor from sh4.cpp but with added read/write penalty tracking
 // Address of access stored in arg0, size in arg1 (unused for now)
-// TODO : Some accesses go through read/write byte,word,etc... might need to handle those
-// via overrides and only handle the fastram accesses here
 void sh7709s_device::static_generate_memory_accessor(int size, int iswrite, const char* name, uml::code_handle*& handleptr)
 {
 	/* on entry, address is in I0; data for writes is in I1 */
@@ -665,6 +626,19 @@ void sh7709s_device::ccr_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 		// enforced and not handled by the hardware
 		memset(m_cache, 0, sizeof(m_cache));
 		LOG("SH7709S cache invalidate\n");
+		// We want to account for some of the uncached instruction
+		// fetches that happen here but instrumenting every instruction
+		// is too cpu intensive. Since this causes a decent amount of
+		// fetches in the cache flush loop just total an approximation
+		// up here
+
+		// Main loop body (2 instruction fetches per loop due to 32 bit reads):
+		// MOV.L R0, @R1
+		// DT R2
+		// BFS $AC002A66
+		// ADD #$10, R1
+		m_sh2_state->icount -= (2 /*fetches*/ * 2 /*bus cycle convert*/ * 1024 /*loop iterations*/) *
+			(1 + mcr_rcd() + get_wcr2_timing(m_sh2_state->pc) + mcr_tpc());
 	}
 	COMBINE_DATA(&m_ccr);
 	logerror("'%s' (%08x): CCN unmapped internal write %08x & %08x (CCR)\n", tag(), m_sh2_state->pc, data, mem_mask);
@@ -703,7 +677,7 @@ void sh7709s_device::cache_address_array_w(offs_t offset, uint32_t data, uint32_
 			uint32_t wb_address = m_cache[entry_block][way].tag * SH7709S_CACHE_LINE_SIZE;
 			m_cache[entry_block][way].dirty = 0;
 			// Always add wcr1 timing here, accesses to the cache address mappings have to be done via instruction from an uncached region
-			m_sh2_state->icount -= (BUS_ACCESS_PENALTY + BURST_WRITE_WORD_PENALTY + get_wcr1_timing(wb_address) + mcr_rcd() + mcr_trwl()) * 2;
+			m_sh2_state->icount -= (1 + mcr_rcd() + 3 + mcr_trwl() + mcr_tpc() + get_wcr1_timing(wb_address)) * 2;
 			// Followup access is likely to area swap as well so those will also need to pay the wait state cost in wcr1 on the instruction fetch
 			m_last_area_accessed = get_area(wb_address);
 			LOG("Flushing dirty cache entry idx: %u\n", cache_entry_index);

--- a/src/devices/cpu/sh/sh7709s.cpp
+++ b/src/devices/cpu/sh/sh7709s.cpp
@@ -412,19 +412,19 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	// We had a dirty writeback eviction, total up the background cost penalty we'll pay on subsequent cycles
 	if (m_wb_address != 0)
 	{
-		if (is_sdram_region(address))
+		if (is_sdram_region(m_wb_address))
 		{
 			uint32_t bank_write = sdram_bank(m_wb_address);
 			// Bank collision in auto precharge mode, we have to wait for precharge to finish before starting
 			if (bank_read == bank_write)
 				m_wb_active_cycles += mcr_tpc() * 2;
-			m_wb_active_cycles += (BUS_ACCESS_PENALTY + get_wcr1_timing(address) + BURST_WRITE_WORD_PENALTY + mcr_rcd() + mcr_trwl()) * 2;
+			m_wb_active_cycles += (BUS_ACCESS_PENALTY + get_wcr1_timing(m_wb_address) + BURST_WRITE_WORD_PENALTY + mcr_rcd() + mcr_trwl()) * 2;
 			m_last_sdram_bank = bank_write;
 		}
 		else
 		{
-			m_wb_active_cycles += get_wcr1_timing(address) * 2;
-			m_wb_active_cycles += ((BUS_ACCESS_PENALTY + get_wcr2_timing(address)) * cache_line_fetch_count(address)) * 2;
+			m_wb_active_cycles += get_wcr1_timing(m_wb_address) * 2;
+			m_wb_active_cycles += ((BUS_ACCESS_PENALTY + get_wcr2_timing(m_wb_address)) * cache_line_fetch_count(m_wb_address)) * 2;
 		}
 
 		m_wb_address = 0;

--- a/src/devices/cpu/sh/sh7709s.cpp
+++ b/src/devices/cpu/sh/sh7709s.cpp
@@ -316,7 +316,7 @@ uint32_t sh7709s_device::cache_line_fetch_count(uint32_t address)
 // can amortize a couple of the remaining cyles of the read. These don't amount to too much for
 // now though
 #define BURST_READ_WORD_PENALTY (3)
-#define BURST_WRITE_WORD_PENALTY (4)
+#define BURST_WRITE_WORD_PENALTY (3)
 
 // cpu->bus cycle conversion hardcoded to 2x as cv1k sh3 runs the bus at 50mhz
 unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)

--- a/src/devices/cpu/sh/sh7709s.cpp
+++ b/src/devices/cpu/sh/sh7709s.cpp
@@ -71,6 +71,7 @@ void sh7709s_device::device_reset()
 	m_wb_active_cycles = 0;
 	m_last_sdram_bank = 0;
 	m_precharge_remaining_cycles = 0;
+	m_last_op_cycle_count = 0;
 }
 
 void sh7709s_device::device_start()
@@ -84,6 +85,7 @@ void sh7709s_device::device_start()
 	m_wb_active_cycles = 0;
 	m_last_sdram_bank = 0;
 	m_precharge_remaining_cycles = 0;
+	m_last_op_cycle_count = 0;
 
 	for (int i = 0; i < SH7709S_CACHE_BLOCKS; i++)
 		for (int j = 0; j < SH7709S_CACHE_ASSOCIATIVITY; j++)
@@ -99,6 +101,7 @@ void sh7709s_device::device_start()
 	save_item(NAME(m_wb_active_cycles));
 	save_item(NAME(m_last_sdram_bank));
 	save_item(NAME(m_precharge_remaining_cycles));
+	save_item(NAME(m_last_op_cycle_count));
 }
 
 // Top 3 region bits allow for aliasing cached/uncached pointers to the same physical address
@@ -341,11 +344,17 @@ uint32_t sh7709s_device::cache_line_fetch_count(uint32_t address)
 #define BURST_READ_WORD_PENALTY (3)
 #define BURST_WRITE_WORD_PENALTY (3)
 
+static uint64_t remaining_cycles(uint64_t elapsed, uint64_t cycles)
+{
+	return (elapsed < cycles) ? (cycles - elapsed) : 0;
+}
+
 // cpu->bus cycle conversion hardcoded to 2x as cv1k sh3 runs the bus at 50mhz
 unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 {
 	uint32_t area = get_area(address);
 	bool is_in_cache = cache_access(address, write);
+	uint64_t elapsed_cycles = total_cycles() - m_last_op_cycle_count;
 
 	if (is_in_cache)
 		return 0;
@@ -377,17 +386,23 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 
 	m_last_area_accessed = area;
 
-	// CPU is in auto precharge mode, since we hit a bank conflict and the last precharge isn't done we stall
+	// CPU is in auto precharge mode, check how many cycles to stall if not enough time has elapsed on a bank conflict
 	if (is_sdram_region(address) && bank_read == m_last_sdram_bank && m_precharge_remaining_cycles > 0)
-		cpu_penalty += m_precharge_remaining_cycles;
+		cpu_penalty += remaining_cycles(elapsed_cycles, m_precharge_remaining_cycles);
 
 	m_precharge_remaining_cycles = 0;
 
-	// We hit another bus operation before a writeback eviction finished, stall until that's done
-	// We already account for the precharge bank conflict above
+	// We hit another bus operation before a writeback eviction finished, calculate remaining stall time
 	if (m_wb_active_cycles > 0)
 	{
-		cpu_penalty += m_wb_active_cycles;
+		uint64_t wb_cycles_left = remaining_cycles(elapsed_cycles, m_wb_active_cycles);
+		cpu_penalty += wb_cycles_left;
+		// If there was a bank conflict also calculate remaining cycles for the precharge
+		if (m_last_sdram_bank == bank_read)
+		{
+			uint64_t tpc_cycles_left = (wb_cycles_left == 0) ? elapsed_cycles - m_wb_active_cycles : 0;
+			cpu_penalty += remaining_cycles(tpc_cycles_left, mcr_tpc() * 2);
+		}
 		m_wb_active_cycles = 0;
 	}
 
@@ -420,34 +435,31 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	return cpu_penalty + (bus_penalty * 2);
 }
 
+void sh7709s_device::update_access_cycles(uint32_t address, bool write)
+{
+	m_sh2_state->icount -= access_penalty(address, write);
+	m_last_op_cycle_count = total_cycles();
+}
+
 void sh7709s_device::drc_memory_access_read()
 {
 	uint32_t address = m_sh2_state->arg0;
-	m_sh2_state->icount -= access_penalty(address, false);
+	update_access_cycles(address, false);
 }
 
 void sh7709s_device::drc_memory_access_write()
 {
 	uint32_t address = m_sh2_state->arg0;
-	m_sh2_state->icount -= access_penalty(address, true);
+	update_access_cycles(address, true);
 }
 
 void sh7709s_device::drc_update_icache()
 {
-	if (m_wb_active_cycles > 0)
-	{
-		m_wb_active_cycles--;
-		// If we had an active wb complete set the remaining precharge cycles in case of bank conflict
-		if (m_wb_active_cycles == 0)
-			m_precharge_remaining_cycles = mcr_tpc() * 2;
-	}
-	else if (m_precharge_remaining_cycles > 0)
-		m_precharge_remaining_cycles--;
 	// Assume the instruction prefetch is perfect for now
 	// we'll still pay a bit of penalty for the access and
 	// handle cache writeback when the icache fetch causes
 	// a dirty line eviction
-	m_sh2_state->icount -= access_penalty(m_sh2_state->pc, false);
+	update_access_cycles(m_sh2_state->pc, false);
 }
 
 static void cfunc_drc_memory_access_read(void *param)

--- a/src/devices/cpu/sh/sh7709s.cpp
+++ b/src/devices/cpu/sh/sh7709s.cpp
@@ -82,6 +82,7 @@ void sh7709s_device::device_reset()
 	m_wb_active_cycles = 0;
 	m_last_sdram_bank = 0;
 	m_precharge_remaining_cycles = 0;
+	m_burst_continuation_remaining_cycles = 0;
 	m_last_op_cycle_count = 0;
 }
 
@@ -96,6 +97,7 @@ void sh7709s_device::device_start()
 	m_wb_active_cycles = 0;
 	m_last_sdram_bank = 0;
 	m_precharge_remaining_cycles = 0;
+	m_burst_continuation_remaining_cycles = 0;
 	m_last_op_cycle_count = 0;
 
 	for (int i = 0; i < SH7709S_CACHE_BLOCKS; i++)
@@ -324,6 +326,12 @@ uint32_t sh7709s_device::cache_line_fetch_count(uint32_t address)
 	return SH7709S_CACHE_LINE_SIZE >> bcr2_val;
 }
 
+
+static unsigned int get_burst_word(uint32_t address)
+{
+	return (address % 16) / 4;
+}
+
 #define CACHE_MISS_STALL (1) // Miss detection in 1 cpu cycle, the rest of the ops (wb buffer movement, etc..) happen in the background
 
 static uint64_t remaining_cycles(uint64_t elapsed, uint64_t cycles)
@@ -367,11 +375,13 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	// Non-SDRAM areas : T1(address) + T2(data) + WCR2 wait states
 	// 2 + WCR2
 
-	// Critical word first handling, only stall until the critical word
-	// Right now we just stall until the first word lands which isn't quite right but is probably fine
+	// Critical word first: the CPU stalls only until the critical word lands.
+	// The remaining burst words keep transferring on the bus after that and
+	// must block any subsequent bus access; that's tracked separately below
+	// via m_burst_continuation_remaining_cycles.
 
 	if (is_sdram_region(address))
-		bus_penalty = 1 + mcr_rcd() + get_wcr2_timing(address);
+		bus_penalty = 1 + mcr_rcd() + get_wcr2_timing(address) + (is_cacheable(address) ? burst_word : 0);
 	else
 	{
 		if (is_cacheable(address))
@@ -388,10 +398,20 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	// only need to handle non-cacheable + write for this check
 	m_last_area_accessed_was_write = (!is_cacheable(address) && write);
 
-	// CPU is in auto precharge mode, check how many cycles to stall if not enough time has elapsed on a bank conflict
-	if (is_sdram_region(address) && bank_read == m_last_sdram_bank && m_precharge_remaining_cycles > 0)
-		cpu_penalty += remaining_cycles(elapsed_cycles, m_precharge_remaining_cycles);
+	// The remaining burst words of a prior cache fill still occupy the bus, so
+	// any subsequent access must wait for them to drain regardless of bank.
+	uint64_t burst_cycles_left = remaining_cycles(elapsed_cycles, m_burst_continuation_remaining_cycles);
+	cpu_penalty += burst_cycles_left;
 
+	// The burst bank precharge only starts after the burst drains, so measure its
+	// remaining cycles from burst completion instead of from the access start.
+	if (is_sdram_region(address) && bank_read == m_last_sdram_bank && m_precharge_remaining_cycles > 0)
+	{
+		uint64_t precharge_cycles_left = (burst_cycles_left == 0) ? elapsed_cycles - m_burst_continuation_remaining_cycles : elapsed_cycles;
+		cpu_penalty += remaining_cycles(precharge_cycles_left, m_precharge_remaining_cycles);
+	}
+
+	m_burst_continuation_remaining_cycles = 0;
 	m_precharge_remaining_cycles = 0;
 
 	// We hit another bus operation before a writeback eviction finished, calculate remaining stall time
@@ -420,9 +440,13 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 			if (bank_read == bank_write)
 			{
 				if (is_cacheable(address))
-					m_wb_active_cycles += (3 + mcr_tpc()) * 2;
+					m_wb_active_cycles += (3 - burst_word + mcr_tpc()) * 2;
 				else
 					m_wb_active_cycles += mcr_tpc() * 2;
+			}
+			else
+			{
+				m_wb_active_cycles += (3 - burst_word) * 2; // no tpc wait if there's no bank conflict, wait on burst completion
 			}
 			m_wb_active_cycles += (1 + mcr_rcd() + 3 + mcr_trwl() + mcr_tpc() + get_wcr1_timing(m_wb_address)) * 2;
 			m_last_sdram_bank = bank_write;
@@ -434,11 +458,17 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 		}
 
 		m_wb_address = 0;
+		m_last_area_accessed_was_write = true;
 	}
-	else if (is_sdram_region(address)) // Account for the read close after burst read if we hit the same bank, writebacks include the cost in the background cycles if there is a conflict
+	else if (is_sdram_region(address)) // Account for the burst continuation and read close after the critical word lands, writebacks include the cost in the background cycles if there is a conflict
 	{
 		if (is_cacheable(address))
-			m_precharge_remaining_cycles = (3 + mcr_tpc()) * 2;
+		{
+			// Remaining burst words occupy the bus, blocking subsequent accesses regardless of bank
+			m_burst_continuation_remaining_cycles = (3 - burst_word) * 2;
+			// Auto precharge of this bank after the burst, only blocks accesses to the same bank
+			m_precharge_remaining_cycles = mcr_tpc() * 2;
+		}
 		else
 			m_precharge_remaining_cycles = mcr_tpc() * 2;
 	}

--- a/src/devices/cpu/sh/sh7709s.cpp
+++ b/src/devices/cpu/sh/sh7709s.cpp
@@ -326,7 +326,6 @@ uint32_t sh7709s_device::cache_line_fetch_count(uint32_t address)
 	return SH7709S_CACHE_LINE_SIZE >> bcr2_val;
 }
 
-
 static unsigned int get_burst_word(uint32_t address)
 {
 	return (address % 16) / 4;
@@ -352,6 +351,7 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	uint32_t cpu_penalty = is_cacheable(address) ? CACHE_MISS_STALL : 0;
 	uint32_t bank_read = sdram_bank(address);
 	uint32_t bus_penalty = 0;
+	unsigned int burst_word = get_burst_word(address);
 
 	// SDRAM timing based on SH7709S documentation
 	// These are copied from the timing charts. These are all in bus cycles
@@ -402,13 +402,16 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	// any subsequent access must wait for them to drain regardless of bank.
 	uint64_t burst_cycles_left = remaining_cycles(elapsed_cycles, m_burst_continuation_remaining_cycles);
 	cpu_penalty += burst_cycles_left;
+	elapsed_cycles -= std::min<uint64_t>(elapsed_cycles, m_burst_continuation_remaining_cycles);
 
 	// The burst bank precharge only starts after the burst drains, so measure its
 	// remaining cycles from burst completion instead of from the access start.
 	if (is_sdram_region(address) && bank_read == m_last_sdram_bank && m_precharge_remaining_cycles > 0)
 	{
 		uint64_t precharge_cycles_left = (burst_cycles_left == 0) ? elapsed_cycles - m_burst_continuation_remaining_cycles : elapsed_cycles;
-		cpu_penalty += remaining_cycles(precharge_cycles_left, m_precharge_remaining_cycles);
+		uint64_t precharge_penalty = remaining_cycles(precharge_cycles_left, m_precharge_remaining_cycles);
+		cpu_penalty += precharge_penalty;
+		elapsed_cycles -= std::min<uint64_t>(precharge_cycles_left, m_precharge_remaining_cycles);
 	}
 
 	m_burst_continuation_remaining_cycles = 0;
@@ -419,11 +422,14 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	{
 		uint64_t wb_cycles_left = remaining_cycles(elapsed_cycles, m_wb_active_cycles);
 		cpu_penalty += wb_cycles_left;
+		elapsed_cycles -= std::min<uint64_t>(elapsed_cycles, m_wb_active_cycles);
 		// If there was a bank conflict also calculate remaining cycles for the precharge
 		if (m_last_sdram_bank == bank_read)
 		{
 			uint64_t tpc_cycles_left = (wb_cycles_left == 0) ? elapsed_cycles - m_wb_active_cycles : 0;
-			cpu_penalty += remaining_cycles(tpc_cycles_left, mcr_tpc() * 2);
+			uint64_t tpc_penalty = remaining_cycles(tpc_cycles_left, mcr_tpc() * 2);
+			cpu_penalty += tpc_penalty;
+			elapsed_cycles -= std::min<uint64_t>(tpc_cycles_left, mcr_tpc() * 2);
 		}
 		m_wb_active_cycles = 0;
 	}
@@ -463,14 +469,8 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	else if (is_sdram_region(address)) // Account for the burst continuation and read close after the critical word lands, writebacks include the cost in the background cycles if there is a conflict
 	{
 		if (is_cacheable(address))
-		{
-			// Remaining burst words occupy the bus, blocking subsequent accesses regardless of bank
 			m_burst_continuation_remaining_cycles = (3 - burst_word) * 2;
-			// Auto precharge of this bank after the burst, only blocks accesses to the same bank
-			m_precharge_remaining_cycles = mcr_tpc() * 2;
-		}
-		else
-			m_precharge_remaining_cycles = mcr_tpc() * 2;
+		m_precharge_remaining_cycles = mcr_tpc() * 2;
 	}
 
 	return cpu_penalty + (bus_penalty * 2);

--- a/src/devices/cpu/sh/sh7709s.cpp
+++ b/src/devices/cpu/sh/sh7709s.cpp
@@ -43,6 +43,17 @@
 *   bank active mode. The cv1k board uses a 16 bit rom in area 0 which means the SDRAM is now stuck
 *   using auto precharge mode that forces a row close after every access which leads to some extra
 *   delays when cache misses collide on the same bank back to back.
+*
+* - Slowdown oddities:
+*	- In titles where rank decides bullet speed more than bullet count this leads to situations where
+*     the lower your rank the more slowdown there is as a result of bullets remaining on screen longer
+*     rather than being a deliberate result of some code
+*   - The games only check for collisions every other frame to save some time, the other optimization
+*     they do is that rather than check every bullet they have a candidate list of bullets that comprises
+*     of bullets within a certain distance of the player ship that then gets retested once they move closer.
+*     There are a handful of sections where you can manipulate slowdown by being closer (more slowdown) or
+*     farther (less slowdown) especially on patterns where bullets fly at angles around the screen rather
+*     than directly at the ship
 */
 
 #include "emu.h"
@@ -342,7 +353,7 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	// 1 + RCD + CAS + 3
 	//
 	// CPU does critical word first so it should only actually stall until:
-	// 1 + RCD + CAS
+	// 1 + RCD + CAS + critical word cycle
 	//
 	// Single read (uncached): Tr + Tc1(READA) + Td1
 	// 1 + RCD + CAS
@@ -369,10 +380,13 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 			bus_penalty = 2 + get_wcr2_timing(address);
 	}
 
-	if (area != m_last_area_accessed)
+	if (area != m_last_area_accessed || (!m_last_area_accessed_was_write && !is_cacheable(address) && write))
 		bus_penalty += get_wcr1_timing(address);
 
 	m_last_area_accessed = area;
+	// cacheable access miss will be a read, write flag set in writeback
+	// only need to handle non-cacheable + write for this check
+	m_last_area_accessed_was_write = (!is_cacheable(address) && write);
 
 	// CPU is in auto precharge mode, check how many cycles to stall if not enough time has elapsed on a bank conflict
 	if (is_sdram_region(address) && bank_read == m_last_sdram_bank && m_precharge_remaining_cycles > 0)
@@ -434,6 +448,7 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 
 void sh7709s_device::update_access_cycles(uint32_t address, bool write)
 {
+#if SH7709S_ICACHE_TRACKING_HEAVY == 0
 	// For now only handle cacheable instruction fetch sampling when we do
 	// data accesses. The majority of uncached instruction fetches is
 	// handled in the cache flush timing
@@ -441,6 +456,7 @@ void sh7709s_device::update_access_cycles(uint32_t address, bool write)
 		m_sh2_state->icount -= access_penalty(m_sh2_state->pc, false);
 		m_last_op_cycle_count = total_cycles();
 	}
+#endif
 	m_sh2_state->icount -= access_penalty(address, write);
 	m_last_op_cycle_count = total_cycles();
 }
@@ -466,6 +482,28 @@ static void cfunc_drc_memory_access_write(void* param)
 {
 	((sh7709s_device*)param)->drc_memory_access_write();
 }
+
+#if SH7709S_ICACHE_TRACKING_HEAVY == 1
+
+void sh7709s_device::drc_update_icache()
+{
+	// instruction fetches done 2 at a time
+	if ((m_sh2_state->pc & 0x3) == 0)
+		update_access_cycles(m_sh2_state->pc, false);
+}
+
+static void cfunc_drc_update_icache(void* param)
+{
+	((sh7709s_device*)param)->drc_update_icache();
+}
+
+bool sh7709s_device::generate_opcode(drcuml_block& block, compiler_state& compiler, const opcode_desc* desc, uint32_t ovrpc)
+{
+	UML_CALLC(block, cfunc_drc_update_icache, this);
+	return sh3_base_device::generate_opcode(block, compiler, desc, ovrpc);
+}
+
+#endif
 
 // Same as static_generate_memory_accessor from sh4.cpp but with added read/write penalty tracking
 // Address of access stored in arg0, size in arg1 (unused for now)
@@ -626,6 +664,7 @@ void sh7709s_device::ccr_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 		// enforced and not handled by the hardware
 		memset(m_cache, 0, sizeof(m_cache));
 		LOG("SH7709S cache invalidate\n");
+#if SH7709S_ICACHE_TRACKING_HEAVY == 0
 		// We want to account for some of the uncached instruction
 		// fetches that happen here but instrumenting every instruction
 		// is too cpu intensive. Since this causes a decent amount of
@@ -639,6 +678,7 @@ void sh7709s_device::ccr_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 		// ADD #$10, R1
 		m_sh2_state->icount -= (2 /*fetches*/ * 2 /*bus cycle convert*/ * 1024 /*loop iterations*/) *
 			(1 + mcr_rcd() + get_wcr2_timing(m_sh2_state->pc) + mcr_tpc());
+#endif
 	}
 	COMBINE_DATA(&m_ccr);
 	logerror("'%s' (%08x): CCN unmapped internal write %08x & %08x (CCR)\n", tag(), m_sh2_state->pc, data, mem_mask);

--- a/src/devices/cpu/sh/sh7709s.cpp
+++ b/src/devices/cpu/sh/sh7709s.cpp
@@ -326,11 +326,6 @@ uint32_t sh7709s_device::cache_line_fetch_count(uint32_t address)
 	return SH7709S_CACHE_LINE_SIZE >> bcr2_val;
 }
 
-static unsigned int get_burst_word(uint32_t address)
-{
-	return (address % 16) / 4;
-}
-
 #define CACHE_MISS_STALL (1) // Miss detection in 1 cpu cycle, the rest of the ops (wb buffer movement, etc..) happen in the background
 
 static uint64_t remaining_cycles(uint64_t elapsed, uint64_t cycles)
@@ -351,7 +346,6 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	uint32_t cpu_penalty = is_cacheable(address) ? CACHE_MISS_STALL : 0;
 	uint32_t bank_read = sdram_bank(address);
 	uint32_t bus_penalty = 0;
-	unsigned int burst_word = get_burst_word(address);
 
 	// SDRAM timing based on SH7709S documentation
 	// These are copied from the timing charts. These are all in bus cycles
@@ -366,8 +360,8 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	// Burst read  (cache fill, 4 longwords): Tr(ACTV) + Trw(RCD-1) + Tc1-Tc4 + CAS + Td2-Td4
 	// 1 + RCD + CAS + 3
 	//
-	// CPU does critical word first so it should only actually stall until:
-	// 1 + RCD + CAS + critical word cycle
+	// CPU does critical word first (with wraparound) so it should only actually stall until:
+	// 1 + RCD + CAS
 	//
 	// Single read (uncached): Tr + Tc1(READA) + Td1
 	// 1 + RCD + CAS
@@ -387,7 +381,7 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	// via m_burst_continuation_remaining_cycles.
 
 	if (is_sdram_region(address))
-		bus_penalty = 1 + mcr_rcd() + get_wcr2_timing(address) + (is_cacheable(address) ? burst_word : 0);
+		bus_penalty = 1 + mcr_rcd() + get_wcr2_timing(address);
 	else
 	{
 		if (is_cacheable(address))
@@ -448,7 +442,9 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 			if (bank_read == bank_write)
 				m_wb_active_cycles += mcr_tpc() * 2;
 			// wait on burst completion of the read
-			m_wb_active_cycles += (3 - burst_word) * 2;
+			m_wb_active_cycles += 3 * 2;
+			// Write back folded the cost in for the burst wait
+			m_burst_continuation_remaining_cycles = 0;
 			// since this is a dirty cache line eviction we always add wcr1 as it's handled after the miss fetch read
 			// and we're switching from read->write
 			m_wb_active_cycles += (1 + mcr_rcd() + 4 + mcr_trwl() + get_wcr1_timing(m_wb_address)) * 2;
@@ -465,7 +461,7 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	}
 	// Account for the burst continuation and read close after the critical word lands, writebacks include the cost in the background cycles if there is a conflict
 	else if (is_sdram_region(address) && is_cacheable(address))
-		m_burst_continuation_remaining_cycles = (3 - burst_word) * 2;
+		m_burst_continuation_remaining_cycles = 3 * 2;
 
 	return cpu_penalty + (bus_penalty * 2);
 }

--- a/src/devices/cpu/sh/sh7709s.cpp
+++ b/src/devices/cpu/sh/sh7709s.cpp
@@ -21,11 +21,8 @@
 *   to the iconic slingshotting in early titles such as Mushihimesama + Futari where you go from
 *   sections of slowdown right back to regular speed as bullets leave the screen.
 *
-* - There seems to be a bug in the ROM read code in cv1k titles that is present in all of them.
-*   This code when ROM reads are queued for whatever reason doesn't check if a read or write
-*   is done and always ends up doing an expensive cache flush + invalidate that isn't required.
-*   The processor ends up churning a bunch of cycles on uncached fetches and then also has to repopulate
-*   the cache.
+* - Graphics contents are stored compressed in the ROM and must be pulled into SDRAM, uncompressed,
+*   and flushed to SDRAM before upload to the blitter.
 *
 *   This requires looping 1024 times over every cache entry from an uncached aliased mapping in SDRAM
 *   which comes with hefty access penalties due to all the instruction fetches + some data fetches.
@@ -320,10 +317,12 @@ uint32_t sh7709s_device::cache_line_fetch_count(uint32_t address)
 
 	uint32_t bcr2_val = (m_bcr2 >> (area * 2)) & 0x3;
 
-	return SH7709S_CACHE_LINE_SIZE >> bcr2_val;
+	return SH7709S_CACHE_LINE_SIZE >> (bcr2_val - 1);
 }
 
-#define CACHE_MISS_STALL (1) // Miss detection in 1 cpu cycle, the rest of the ops (wb buffer movement, etc..) happen in the background
+// Unconfirmed behavior but the math works out based on comparison of misses in a frame to pcb footage
+// This covers a pipeline where we go from miss detect -> victim select -> address to BSC
+#define CACHE_MISS_STALL (3)
 
 static uint64_t remaining_cycles(uint64_t elapsed, uint64_t cycles)
 {
@@ -342,7 +341,7 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	uint64_t elapsed_cycles = total_cycles() - m_last_op_cycle_count;
 	uint32_t cpu_penalty = is_cacheable(address) ? CACHE_MISS_STALL : 0;
 	uint32_t bank_read = sdram_bank(address);
-	uint32_t bus_penalty = 0;
+	uint32_t bus_penalty = 1; // CPU -> BSC sync cost
 
 	// SDRAM timing based on SH7709S documentation
 	// These are copied from the timing charts. These are all in bus cycles
@@ -376,22 +375,31 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	// The remaining burst words keep transferring on the bus after that and
 	// must block any subsequent bus access; that's tracked separately below
 	// via m_burst_continuation_remaining_cycles.
+	// Unconfirmed : precharge likely not tracked per bank on this cpu, its possible you can
+	// have multiple banks active in bank active mode but a tpc holds up some internal engine state
+	// This is only based on observation comparing gameplay footage to cache miss/eviction count
+	// in a good bit of sampled frames
 
 	if (is_sdram_region(address))
-		bus_penalty = 1 + mcr_rcd() + get_wcr2_timing(address);
+	{
+		if (is_cacheable(address) || !write)
+			bus_penalty += 1 + mcr_rcd() + get_wcr2_timing(address);
+		else
+			bus_penalty += 1 + mcr_rcd() + mcr_trwl();
+	}
 	else
 	{
 		if (is_cacheable(address))
-			bus_penalty = (2 + get_wcr2_timing(address)) * cache_line_fetch_count(address);
+			bus_penalty += (2 + get_wcr2_timing(address)) * cache_line_fetch_count(address);
 		else
-			bus_penalty = 2 + get_wcr2_timing(address);
+			bus_penalty += 2 + get_wcr2_timing(address);
 	}
 
 	// add wcr1 on area swap, because this fetch is a cache miss read wcr1 doesnt apply from write->read swap
 	// only handle the case where uncached write follows a read, writeback handles wcr1 after read fetch below
 	if (area != m_last_area_accessed || (!m_last_area_accessed_was_write && !is_cacheable(address) && write))
 	{
-		uint32_t wcr1_idle_cycles = get_wcr1_timing(m_last_area_accessed) * 2;
+		uint32_t wcr1_idle_cycles = get_wcr1_timing(area) * 2;
 		uint64_t wcr1_idle_cycles_left = remaining_cycles(elapsed_cycles, wcr1_idle_cycles);
 		cpu_penalty += wcr1_idle_cycles_left;
 		elapsed_cycles -= std::min<uint64_t>(elapsed_cycles, wcr1_idle_cycles);
@@ -403,22 +411,13 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	m_last_area_accessed_was_write = (!is_cacheable(address) && write);
 
 	// The remaining burst words of a prior cache fill still occupy the bus, so
-	// any subsequent access must wait for them to drain regardless of bank.
+	// any subsequent access must wait for them to drain
 	if (m_burst_continuation_remaining_cycles > 0)
 	{
 		uint64_t burst_cycles_left = remaining_cycles(elapsed_cycles, m_burst_continuation_remaining_cycles);
 		cpu_penalty += burst_cycles_left;
 		elapsed_cycles -= std::min<uint64_t>(elapsed_cycles, m_burst_continuation_remaining_cycles);
 		m_burst_continuation_remaining_cycles = 0;
-	}
-
-	// The burst bank precharge only starts after the burst drains, so measure its
-	// remaining cycles from burst completion instead of from the access start.
-	if (is_sdram_region(address) && bank_read == m_last_sdram_bank)
-	{
-		uint64_t precharge_cycles_left = remaining_cycles(elapsed_cycles, (mcr_tpc() * 2));
-		cpu_penalty += precharge_cycles_left;
-		elapsed_cycles -= std::min<uint64_t>(precharge_cycles_left, (mcr_tpc() * 2));
 	}
 
 	// We hit another bus operation before a writeback eviction finished, calculate remaining stall time
@@ -439,22 +438,19 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	{
 		if (is_sdram_region(m_wb_address))
 		{
-			uint32_t bank_write = sdram_bank(m_wb_address);
-			// no tpc wait if there's no bank conflict
-			if (bank_read == bank_write)
-				m_wb_active_cycles += mcr_tpc() * 2;
+			// stall waiting on read precharge close
+			m_wb_active_cycles += mcr_tpc() * 2;
 			// wait on burst completion of the read
 			m_wb_active_cycles += 3 * 2;
 			// Write back folded the cost in for the burst wait
 			m_burst_continuation_remaining_cycles = 0;
 			// since this is a dirty cache line eviction we always add wcr1 as it's handled after the miss fetch read
 			// and we're switching from read->write
-			m_wb_active_cycles += (1 + mcr_rcd() + 4 + mcr_trwl() + get_wcr1_timing(3)) * 2;
-			m_last_sdram_bank = bank_write;
+			m_wb_active_cycles += (2 + mcr_rcd() + 4 + mcr_trwl() + get_wcr1_timing(area) + mcr_tpc()) * 2;
 		}
 		else
 		{
-			m_wb_active_cycles += get_wcr1_timing(3) * 2;
+			m_wb_active_cycles += get_wcr1_timing(area) * 2;
 			m_wb_active_cycles += ((2 + get_wcr2_timing(m_wb_address)) * cache_line_fetch_count(m_wb_address)) * 2;
 		}
 
@@ -463,7 +459,7 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	}
 	// Account for the burst continuation and read close after the critical word lands, writebacks include the cost in the background cycles if there is a conflict
 	else if (is_sdram_region(address) && is_cacheable(address))
-		m_burst_continuation_remaining_cycles = 3 * 2;
+		m_burst_continuation_remaining_cycles = (3 + mcr_tpc()) * 2;
 
 	return cpu_penalty + (bus_penalty * 2);
 }
@@ -699,7 +695,7 @@ void sh7709s_device::ccr_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 		// BFS $AC002A66
 		// ADD #$10, R1
 		m_sh2_state->icount -= (2 /*fetches*/ * 2 /*bus cycle convert*/ * 1024 /*loop iterations*/) *
-			(1 + mcr_rcd() + get_wcr2_timing(m_sh2_state->pc) + mcr_tpc());
+			(2 + mcr_rcd() + get_wcr2_timing(m_sh2_state->pc) + mcr_tpc());
 #endif
 	}
 	COMBINE_DATA(&m_ccr);
@@ -739,8 +735,7 @@ void sh7709s_device::cache_address_array_w(offs_t offset, uint32_t data, uint32_
 			uint32_t wb_address = m_cache[entry_block][way].tag * SH7709S_CACHE_LINE_SIZE;
 			m_cache[entry_block][way].dirty = 0;
 			// Always add wcr1 timing here, accesses to the cache address mappings have to be done via instruction from an uncached region
-			m_sh2_state->icount -= (1 + mcr_rcd() + 4 + mcr_trwl() + mcr_tpc() + get_wcr1_timing(3)) * 2;
-			// Followup access is likely to area swap as well so those will also need to pay the wait state cost in wcr1 on the instruction fetch
+			m_sh2_state->icount -= (2 + mcr_rcd() + 4 + mcr_trwl() + mcr_tpc() + get_wcr1_timing(3)) * 2;
 			m_last_area_accessed = get_area(wb_address);
 			LOG("Flushing dirty cache entry idx: %u\n", cache_entry_index);
 		}

--- a/src/devices/cpu/sh/sh7709s.cpp
+++ b/src/devices/cpu/sh/sh7709s.cpp
@@ -208,10 +208,8 @@ bool can_use_burst(uint32_t address)
 	return is_sdram_region(address);
 }
 
-uint32_t sh7709s_device::get_wcr1_timing(uint32_t address)
+uint32_t sh7709s_device::get_wcr1_timing(uint32_t area)
 {
-	uint32_t area = get_area(address);
-
 	if (area > 6 || area == 1)
 		return 0;
 
@@ -392,7 +390,12 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	// add wcr1 on area swap, because this fetch is a cache miss read wcr1 doesnt apply from write->read swap
 	// only handle the case where uncached write follows a read, writeback handles wcr1 after read fetch below
 	if (area != m_last_area_accessed || (!m_last_area_accessed_was_write && !is_cacheable(address) && write))
-		bus_penalty += get_wcr1_timing(address);
+	{
+		uint32_t wcr1_idle_cycles = get_wcr1_timing(m_last_area_accessed) * 2;
+		uint64_t wcr1_idle_cycles_left = remaining_cycles(elapsed_cycles, wcr1_idle_cycles);
+		cpu_penalty += wcr1_idle_cycles_left;
+		elapsed_cycles -= std::min<uint64_t>(elapsed_cycles, wcr1_idle_cycles);
+	}
 
 	m_last_area_accessed = area;
 	// cacheable access miss will be a read, write flag set in writeback
@@ -446,12 +449,12 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 			m_burst_continuation_remaining_cycles = 0;
 			// since this is a dirty cache line eviction we always add wcr1 as it's handled after the miss fetch read
 			// and we're switching from read->write
-			m_wb_active_cycles += (1 + mcr_rcd() + 4 + mcr_trwl() + get_wcr1_timing(m_wb_address)) * 2;
+			m_wb_active_cycles += (1 + mcr_rcd() + 4 + mcr_trwl() + get_wcr1_timing(3)) * 2;
 			m_last_sdram_bank = bank_write;
 		}
 		else
 		{
-			m_wb_active_cycles += get_wcr1_timing(m_wb_address) * 2;
+			m_wb_active_cycles += get_wcr1_timing(3) * 2;
 			m_wb_active_cycles += ((2 + get_wcr2_timing(m_wb_address)) * cache_line_fetch_count(m_wb_address)) * 2;
 		}
 
@@ -736,7 +739,7 @@ void sh7709s_device::cache_address_array_w(offs_t offset, uint32_t data, uint32_
 			uint32_t wb_address = m_cache[entry_block][way].tag * SH7709S_CACHE_LINE_SIZE;
 			m_cache[entry_block][way].dirty = 0;
 			// Always add wcr1 timing here, accesses to the cache address mappings have to be done via instruction from an uncached region
-			m_sh2_state->icount -= (1 + mcr_rcd() + 4 + mcr_trwl() + mcr_tpc() + get_wcr1_timing(wb_address)) * 2;
+			m_sh2_state->icount -= (1 + mcr_rcd() + 4 + mcr_trwl() + mcr_tpc() + get_wcr1_timing(3)) * 2;
 			// Followup access is likely to area swap as well so those will also need to pay the wait state cost in wcr1 on the instruction fetch
 			m_last_area_accessed = get_area(wb_address);
 			LOG("Flushing dirty cache entry idx: %u\n", cache_entry_index);

--- a/src/devices/cpu/sh/sh7709s.cpp
+++ b/src/devices/cpu/sh/sh7709s.cpp
@@ -274,16 +274,15 @@ uint32_t sh7709s_device::sdram_bank(uint32_t address)
 
 	switch (amx)
 	{
-	case 0x4: // row begins with A9: 1M x 16-bit x 4-bank
-	case 0x7: // row begins with A9: 512k x 32-bit x 4-bank
-		return (address >> 7) & 0x3;   // A8:A7
-
-	case 0x5: // row begins with A10: 2M x 8/16-bit x 4-bank
-	case 0xd: // row begins with A10: 4M x 16-bit x 4-bank
-		return (address >> 8) & 0x3;   // A9:A8
-
-	case 0xa: // row begins with A11: 8M x 16-bit x 4-bank
-		return (address >> 9) & 0x3;   // A10:A9
+	case 0x4: // 1M x 16-bit x 4-bank : A23:A22
+		return (address >> 22) & 0x3;
+	case 0x5: // 2M x 8/16-bit x 4-bank : A24:A23
+		return (address >> 23) & 0x3;
+	case 0x7: // 512k x 32-bit x 4-bank : A22:A21
+		return (address >> 21) & 0x3;
+	case 0xd: // 4M x 16-bit x 4-bank : A25:A24
+	case 0xe: // 8M x 16-bit x 4-bank : A25:A24
+		return (address >> 24) & 0x3;
 	}
 
 	return 0;

--- a/src/devices/cpu/sh/sh7709s.cpp
+++ b/src/devices/cpu/sh/sh7709s.cpp
@@ -357,6 +357,12 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	// These are copied from the timing charts. These are all in bus cycles
 	// CAS for SDRAM is stored in WCR2
 	//
+	// Burst read : CAS to critical word is from the READ command that submitted it, this
+	// works the same even if the CPU does READA+burst len or READ,READ,READ,READA
+	//
+	// Burst write : WRITA + 4 data words will clock the same as WRITE,WRITE,WRITE,WRITA
+	// overlapping data with commands
+	//
 	// Burst read  (cache fill, 4 longwords): Tr(ACTV) + Trw(RCD-1) + Tc1-Tc4 + CAS + Td2-Td4
 	// 1 + RCD + CAS + 3
 	//
@@ -370,7 +376,7 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 	// 1 + RCD + TRWL
 	//
 	// Burst write (cache eviction writeback, 4 longwords): Tr + Tc1(WRITA) + Td2-Td4 + Trwl
-	// 1 + RCD + TRWL + 3
+	// 1 + RCD + TRWL + 4
 	//
 	// Non-SDRAM areas : T1(address) + T2(data) + WCR2 wait states
 	// 2 + WCR2
@@ -390,6 +396,8 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 			bus_penalty = 2 + get_wcr2_timing(address);
 	}
 
+	// add wcr1 on area swap, because this fetch is a cache miss read wcr1 doesnt apply from write->read swap
+	// only handle the case where uncached write follows a read, writeback handles wcr1 after read fetch below
 	if (area != m_last_area_accessed || (!m_last_area_accessed_was_write && !is_cacheable(address) && write))
 		bus_penalty += get_wcr1_timing(address);
 
@@ -400,37 +408,30 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 
 	// The remaining burst words of a prior cache fill still occupy the bus, so
 	// any subsequent access must wait for them to drain regardless of bank.
-	uint64_t burst_cycles_left = remaining_cycles(elapsed_cycles, m_burst_continuation_remaining_cycles);
-	cpu_penalty += burst_cycles_left;
-	elapsed_cycles -= std::min<uint64_t>(elapsed_cycles, m_burst_continuation_remaining_cycles);
+	if (m_burst_continuation_remaining_cycles > 0)
+	{
+		uint64_t burst_cycles_left = remaining_cycles(elapsed_cycles, m_burst_continuation_remaining_cycles);
+		cpu_penalty += burst_cycles_left;
+		elapsed_cycles -= std::min<uint64_t>(elapsed_cycles, m_burst_continuation_remaining_cycles);
+		m_burst_continuation_remaining_cycles = 0;
+	}
 
 	// The burst bank precharge only starts after the burst drains, so measure its
 	// remaining cycles from burst completion instead of from the access start.
-	if (is_sdram_region(address) && bank_read == m_last_sdram_bank && m_precharge_remaining_cycles > 0)
+	if (is_sdram_region(address) && bank_read == m_last_sdram_bank)
 	{
-		uint64_t precharge_cycles_left = (burst_cycles_left == 0) ? elapsed_cycles - m_burst_continuation_remaining_cycles : elapsed_cycles;
-		uint64_t precharge_penalty = remaining_cycles(precharge_cycles_left, m_precharge_remaining_cycles);
-		cpu_penalty += precharge_penalty;
-		elapsed_cycles -= std::min<uint64_t>(precharge_cycles_left, m_precharge_remaining_cycles);
+		uint64_t precharge_cycles_left = remaining_cycles(elapsed_cycles, (mcr_tpc() * 2));
+		cpu_penalty += precharge_cycles_left;
+		elapsed_cycles -= std::min<uint64_t>(precharge_cycles_left, (mcr_tpc() * 2));
 	}
-
-	m_burst_continuation_remaining_cycles = 0;
-	m_precharge_remaining_cycles = 0;
 
 	// We hit another bus operation before a writeback eviction finished, calculate remaining stall time
 	if (m_wb_active_cycles > 0)
 	{
+		// writeback path sets last_sdram_bank so check above handles tpc wait
 		uint64_t wb_cycles_left = remaining_cycles(elapsed_cycles, m_wb_active_cycles);
 		cpu_penalty += wb_cycles_left;
 		elapsed_cycles -= std::min<uint64_t>(elapsed_cycles, m_wb_active_cycles);
-		// If there was a bank conflict also calculate remaining cycles for the precharge
-		if (m_last_sdram_bank == bank_read)
-		{
-			uint64_t tpc_cycles_left = (wb_cycles_left == 0) ? elapsed_cycles - m_wb_active_cycles : 0;
-			uint64_t tpc_penalty = remaining_cycles(tpc_cycles_left, mcr_tpc() * 2);
-			cpu_penalty += tpc_penalty;
-			elapsed_cycles -= std::min<uint64_t>(tpc_cycles_left, mcr_tpc() * 2);
-		}
 		m_wb_active_cycles = 0;
 	}
 
@@ -443,18 +444,14 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 		if (is_sdram_region(m_wb_address))
 		{
 			uint32_t bank_write = sdram_bank(m_wb_address);
+			// no tpc wait if there's no bank conflict
 			if (bank_read == bank_write)
-			{
-				if (is_cacheable(address))
-					m_wb_active_cycles += (3 - burst_word + mcr_tpc()) * 2;
-				else
-					m_wb_active_cycles += mcr_tpc() * 2;
-			}
-			else
-			{
-				m_wb_active_cycles += (3 - burst_word) * 2; // no tpc wait if there's no bank conflict, wait on burst completion
-			}
-			m_wb_active_cycles += (1 + mcr_rcd() + 3 + mcr_trwl() + mcr_tpc() + get_wcr1_timing(m_wb_address)) * 2;
+				m_wb_active_cycles += mcr_tpc() * 2;
+			// wait on burst completion of the read
+			m_wb_active_cycles += (3 - burst_word) * 2;
+			// since this is a dirty cache line eviction we always add wcr1 as it's handled after the miss fetch read
+			// and we're switching from read->write
+			m_wb_active_cycles += (1 + mcr_rcd() + 4 + mcr_trwl() + get_wcr1_timing(m_wb_address)) * 2;
 			m_last_sdram_bank = bank_write;
 		}
 		else
@@ -466,12 +463,9 @@ unsigned int sh7709s_device::access_penalty(uint32_t address, bool write)
 		m_wb_address = 0;
 		m_last_area_accessed_was_write = true;
 	}
-	else if (is_sdram_region(address)) // Account for the burst continuation and read close after the critical word lands, writebacks include the cost in the background cycles if there is a conflict
-	{
-		if (is_cacheable(address))
-			m_burst_continuation_remaining_cycles = (3 - burst_word) * 2;
-		m_precharge_remaining_cycles = mcr_tpc() * 2;
-	}
+	// Account for the burst continuation and read close after the critical word lands, writebacks include the cost in the background cycles if there is a conflict
+	else if (is_sdram_region(address) && is_cacheable(address))
+		m_burst_continuation_remaining_cycles = (3 - burst_word) * 2;
 
 	return cpu_penalty + (bus_penalty * 2);
 }
@@ -747,7 +741,7 @@ void sh7709s_device::cache_address_array_w(offs_t offset, uint32_t data, uint32_
 			uint32_t wb_address = m_cache[entry_block][way].tag * SH7709S_CACHE_LINE_SIZE;
 			m_cache[entry_block][way].dirty = 0;
 			// Always add wcr1 timing here, accesses to the cache address mappings have to be done via instruction from an uncached region
-			m_sh2_state->icount -= (1 + mcr_rcd() + 3 + mcr_trwl() + mcr_tpc() + get_wcr1_timing(wb_address)) * 2;
+			m_sh2_state->icount -= (1 + mcr_rcd() + 4 + mcr_trwl() + mcr_tpc() + get_wcr1_timing(wb_address)) * 2;
 			// Followup access is likely to area swap as well so those will also need to pay the wait state cost in wcr1 on the instruction fetch
 			m_last_area_accessed = get_area(wb_address);
 			LOG("Flushing dirty cache entry idx: %u\n", cache_entry_index);

--- a/src/devices/cpu/sh/sh7709s.h
+++ b/src/devices/cpu/sh/sh7709s.h
@@ -22,7 +22,6 @@ public:
 	// DRC functions used to update the cache state
 	void drc_memory_access_read();
 	void drc_memory_access_write();
-	void drc_update_icache();
 
 protected:
 	virtual void sh3_register_map(address_map& map) override ATTR_COLD;
@@ -30,9 +29,6 @@ protected:
 	virtual void device_reset() override ATTR_COLD;
 
 	virtual void static_generate_memory_accessor(int size, int iswrite, const char* name, uml::code_handle*& handleptr) override;
-	virtual bool generate_group_0(drcuml_block& block, compiler_state& compiler, const opcode_desc* desc, uint16_t opcode, int in_delay_slot, uint32_t ovrpc) override;
-	virtual bool generate_group_4(drcuml_block& block, compiler_state& compiler, const opcode_desc* desc, uint16_t opcode, int in_delay_slot, uint32_t ovrpc) override;
-	virtual bool generate_group_15(drcuml_block& block, compiler_state& compiler, const opcode_desc* desc, uint16_t opcode, int in_delay_slot, uint32_t ovrpc) override;
 
 	virtual uint32_t ccr_r(offs_t offset, uint32_t mem_mask) override;
 	virtual void ccr_w(offs_t offset, uint32_t data, uint32_t mem_mask) override;

--- a/src/devices/cpu/sh/sh7709s.h
+++ b/src/devices/cpu/sh/sh7709s.h
@@ -55,9 +55,11 @@ private:
 	unsigned int m_wb_active_cycles; // Track any background cycles for writeback and precharge waits on the same bank
 	unsigned int m_last_sdram_bank; // Last accessed sdram bank, used to track when to have to pay tpc(precharge) cost
 	unsigned int m_precharge_remaining_cycles;
+	uint64_t m_last_op_cycle_count; // Track the last cycle we did a memory operation for background accounting
 
 	bool cache_access(uint32_t address, bool write);
 	unsigned int access_penalty(uint32_t address, bool write);
+	void update_access_cycles(uint32_t address, bool write);
 
 	// Timing calculation/decode related functions
 	uint32_t get_wcr1_timing(uint32_t address);

--- a/src/devices/cpu/sh/sh7709s.h
+++ b/src/devices/cpu/sh/sh7709s.h
@@ -53,7 +53,7 @@ private:
 	uint8_t m_last_area_accessed; // last memory area accessed for WCR1 timing purposes
 	bool m_last_area_accessed_was_write; // last memory area accessed operation also for WCR1 timing purposes
 	unsigned int m_wb_active_cycles; // Track any background cycles for writeback and precharge waits on the same bank
-	unsigned int m_last_sdram_page; // Last accessed sdram page, used to track when to have to pay tpc(precharge) cost
+	unsigned int m_last_sdram_bank; // Last accessed sdram bank, used to track when to have to pay tpc(precharge) cost
 	unsigned int m_precharge_remaining_cycles;
 
 	bool cache_access(uint32_t address, bool write);
@@ -67,6 +67,7 @@ private:
 	uint32_t mcr_trwl();
 	uint32_t mcr_tras();
 	uint32_t cache_line_fetch_count(uint32_t address);
+	uint32_t sdram_bank(uint32_t address);
 };
 
 DECLARE_DEVICE_TYPE(SH7709S, sh7709s_device)

--- a/src/devices/cpu/sh/sh7709s.h
+++ b/src/devices/cpu/sh/sh7709s.h
@@ -6,6 +6,10 @@
 
 #include "sh4.h"
 
+// When enabled switches from icache sampling + heuristic to full icache tracking
+// Heavy on CPU usage but useful for debugging icache penalties if your cpu can handle it
+#define SH7709S_ICACHE_TRACKING_HEAVY (0)
+
 // U bit tracked in the dirty field, V bit currently untracked
 struct sh7709s_cache_entry
 {
@@ -24,6 +28,11 @@ public:
 	void drc_memory_access_write();
 
 	void update_access_cycles(uint32_t address, bool write);
+
+#if SH7709S_ICACHE_TRACKING_HEAVY == 1
+	void drc_update_icache();
+	bool generate_opcode(drcuml_block& block, compiler_state& compiler, const opcode_desc* desc, uint32_t ovrpc) override;
+#endif
 
 protected:
 	virtual void sh3_register_map(address_map& map) override ATTR_COLD;

--- a/src/devices/cpu/sh/sh7709s.h
+++ b/src/devices/cpu/sh/sh7709s.h
@@ -62,6 +62,7 @@ private:
 	unsigned int m_wb_active_cycles; // Track any background cycles for writeback and precharge waits on the same bank
 	unsigned int m_last_sdram_bank; // Last accessed sdram bank, used to track when to have to pay tpc(precharge) cost
 	unsigned int m_precharge_remaining_cycles;
+	unsigned int m_burst_continuation_remaining_cycles; // Remaining burst words still occupying the bus after the critical word lands
 	uint64_t m_last_op_cycle_count; // Track the last cycle we did a memory operation for background accounting
 
 	bool cache_access(uint32_t address, bool write);

--- a/src/devices/cpu/sh/sh7709s.h
+++ b/src/devices/cpu/sh/sh7709s.h
@@ -23,6 +23,8 @@ public:
 	void drc_memory_access_read();
 	void drc_memory_access_write();
 
+	void update_access_cycles(uint32_t address, bool write);
+
 protected:
 	virtual void sh3_register_map(address_map& map) override ATTR_COLD;
 	virtual void device_start() override ATTR_COLD;
@@ -55,7 +57,6 @@ private:
 
 	bool cache_access(uint32_t address, bool write);
 	unsigned int access_penalty(uint32_t address, bool write);
-	void update_access_cycles(uint32_t address, bool write);
 
 	// Timing calculation/decode related functions
 	uint32_t get_wcr1_timing(uint32_t address);

--- a/src/devices/cpu/sh/sh7709s.h
+++ b/src/devices/cpu/sh/sh7709s.h
@@ -69,7 +69,7 @@ private:
 	unsigned int access_penalty(uint32_t address, bool write);
 
 	// Timing calculation/decode related functions
-	uint32_t get_wcr1_timing(uint32_t address);
+	uint32_t get_wcr1_timing(uint32_t area);
 	uint32_t get_wcr2_timing(uint32_t address);
 	uint32_t mcr_tpc();
 	uint32_t mcr_rcd();

--- a/src/devices/machine/nandflash.cpp
+++ b/src/devices/machine/nandflash.cpp
@@ -53,6 +53,8 @@ nand_device::nand_device(const machine_config &mconfig, device_type type, const 
 	m_col_address_cycles(0),
 	m_row_address_cycles(0),
 	m_sequential_row_read(0),
+	m_read_time(attotime::never),
+	m_busy_until(attotime::never),
 	m_write_rnb(*this)
 {
 	memset(m_id, 0, sizeof(m_id));
@@ -151,6 +153,9 @@ samsung_k9f1g08u0m_device::samsung_k9f1g08u0m_device(const machine_config &mconf
 	m_col_address_cycles = 2;
 	m_row_address_cycles = 2;
 	m_sequential_row_read = 0;
+	// Taken from the documentation for worst case read time, may require more measuring on a real pcb
+	// but the majority of cycle cost comes from reading the data out once it's ready
+	m_read_time = attotime::from_usec(25);
 }
 
 samsung_k9lag08u0m_device::samsung_k9lag08u0m_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
@@ -339,6 +344,9 @@ int nand_device::is_protected()
 
 int nand_device::is_busy()
 {
+	if (m_busy_until != attotime::never && machine().time() < m_busy_until)
+		return 1;
+
 	return (m_status & 0x40) == 0;
 }
 
@@ -350,6 +358,7 @@ void nand_device::command_w(uint8_t data)
 	switch (data)
 	{
 	case 0xff: // Reset
+		m_busy_until = attotime::never;
 		m_mode = SM_M_INIT;
 		m_pointer_mode = SM_PM_A;
 		m_status = (m_status & 0x80) | 0x40;
@@ -478,7 +487,10 @@ void nand_device::command_w(uint8_t data)
 			else
 			{
 				m_write_rnb(0);
-				m_write_rnb(1);
+				if (m_read_time != attotime::never)
+					m_busy_until = machine().time() + m_read_time;
+				else
+					m_write_rnb(1);
 			}
 		}
 		break;
@@ -513,7 +525,11 @@ void nand_device::command_w(uint8_t data)
 		}
 		else
 		{
-			// do nothing
+			m_write_rnb(0);
+			if (m_read_time != attotime::never)
+				m_busy_until = machine().time() + m_read_time;
+			else
+				m_write_rnb(1);
 		}
 		break;
 	case 0x85: // Random Data Input

--- a/src/devices/machine/nandflash.cpp
+++ b/src/devices/machine/nandflash.cpp
@@ -48,6 +48,8 @@ nand_device::nand_device(const machine_config &mconfig, device_type type, const 
 	m_col_address_cycles(0),
 	m_row_address_cycles(0),
 	m_sequential_row_read(0),
+	m_read_time(attotime::never),
+	m_busy_until(attotime::never),
 	m_write_rnb(*this)
 {
 	memset(m_id, 0, sizeof(m_id));
@@ -146,6 +148,9 @@ samsung_k9f1g08u0m_device::samsung_k9f1g08u0m_device(const machine_config &mconf
 	m_col_address_cycles = 2;
 	m_row_address_cycles = 2;
 	m_sequential_row_read = 0;
+	// Taken from the documentation for worst case read time, may require more measuring on a real pcb
+	// but the majority of cycle cost comes from reading the data out once it's ready
+	m_read_time = attotime::from_usec(25);
 }
 
 samsung_k9lag08u0m_device::samsung_k9lag08u0m_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
@@ -271,6 +276,9 @@ int nand_device::is_protected()
 
 int nand_device::is_busy()
 {
+	if (m_busy_until != attotime::never && machine().time() < m_busy_until)
+		return 1;
+
 	return (m_status & 0x40) == 0;
 }
 
@@ -282,6 +290,7 @@ void nand_device::command_w(uint8_t data)
 	switch (data)
 	{
 	case 0xff: // Reset
+		m_busy_until = attotime::never;
 		m_mode = SM_M_INIT;
 		m_pointer_mode = SM_PM_A;
 		m_status = (m_status & 0x80) | 0x40;
@@ -410,7 +419,10 @@ void nand_device::command_w(uint8_t data)
 			else
 			{
 				m_write_rnb(0);
-				m_write_rnb(1);
+				if (m_read_time != attotime::never)
+					m_busy_until = machine().time() + m_read_time;
+				else
+					m_write_rnb(1);
 			}
 		}
 		break;
@@ -445,7 +457,11 @@ void nand_device::command_w(uint8_t data)
 		}
 		else
 		{
-			// do nothing
+			m_write_rnb(0);
+			if (m_read_time != attotime::never)
+				m_busy_until = machine().time() + m_read_time;
+			else
+				m_write_rnb(1);
 		}
 		break;
 	case 0x85: // Random Data Input

--- a/src/devices/machine/nandflash.h
+++ b/src/devices/machine/nandflash.h
@@ -103,6 +103,10 @@ protected:
 	uint32_t m_row_address_cycles;
 	uint32_t m_sequential_row_read;
 
+	// timing parameters
+	attotime m_read_time;      // tR: random read access time (cell to register)
+	attotime m_busy_until;     // time when busy period ends (attotime::never = not busy)
+
 	devcb_write_line m_write_rnb;
 };
 

--- a/src/devices/machine/nandflash.h
+++ b/src/devices/machine/nandflash.h
@@ -97,6 +97,10 @@ protected:
 	uint32_t m_row_address_cycles;
 	uint32_t m_sequential_row_read;
 
+	// timing parameters
+	attotime m_read_time;      // tR: random read access time (cell to register)
+	attotime m_busy_until;     // time when busy period ends (attotime::never = not busy)
+
 	devcb_write_line m_write_rnb;
 };
 

--- a/src/mame/cave/cv1k.cpp
+++ b/src/mame/cave/cv1k.cpp
@@ -217,6 +217,7 @@ public:
 		m_blitter(*this, "blitter"),
 		m_nand(*this, "nand"),
 		m_eeprom(*this, "eeprom"),
+		m_ymz770(*this, "ymz770"),
 		m_ram(*this, "mainram"),
 		m_rombase(*this, "maincpu"),
 		m_eepromout(*this, "EEPROMOUT"),
@@ -243,6 +244,7 @@ private:
 	required_device<cv1k_blitter_device> m_blitter;
 	required_device<samsung_k9f1g08u0m_device> m_nand;
 	required_device<rtc9701_device> m_eeprom;
+	required_device<ymz770_device> m_ymz770;
 
 	required_shared_ptr<u64> m_ram;
 	required_region_ptr<u64> m_rombase;
@@ -256,6 +258,7 @@ private:
 	void flash_io_w(offs_t offset, u8 data);
 	u8 serial_rtc_eeprom_r(offs_t offset);
 	void serial_rtc_eeprom_w(offs_t offset, u8 data);
+	void sound_w(offs_t offset, u8 data);
 	u64 flash_port_e_r();
 
 	u64 speedup_r();
@@ -272,11 +275,22 @@ private:
 
 // FLASH interface
 
+// cv1k flash timing notes:
+// - For early titles this has less of an impact
+// - The times this is mostly visible is during midboss final patterns and certain boss patterns
+// - Latter titles lean more and more on mid stage load sequences where combined with the
+//   unneeded cache flush cause a lot of stage slowdown
+// - This behavior is exhibited in quite a bit of bosses, one big example is Pink Sweets final
+//   boss rainbow pattern where it causes the game to pause for an extended number of frames
+//   resulting in very staggered slowdown. Knowingly or unknowingly this in some cases causes
+//   or smooths some slowdown such as some patterns on the Mushi Futari Stage 5 boss
+// - Flash ready time doesn't account for a ton of time (~2500 cycles) but once the flash is ready
+//   to be read each read is done a byte at a time from an uncached area each taking ~10 cycles
+//   (2 base + 3 wait states) = 5 bus cycles -> 10 cpu cycles
 u64 cv1k_state::flash_port_e_r()
 {
 	return ((!m_nand->is_busy() ? 0x20 : 0x00)) | 0xdf;
 }
-
 
 u8 cv1k_state::flash_io_r(offs_t offset)
 {
@@ -295,12 +309,14 @@ u8 cv1k_state::flash_io_r(offs_t offset)
 			return 0xff;
 
 		case 0x00:
+			m_maincpu->update_access_cycles(0x10000000 + offset, false);
 			return m_nand->data_r();
 	}
 }
 
 void cv1k_state::flash_io_w(offs_t offset, u8 data)
 {
+	m_maincpu->update_access_cycles(0x10000000 + offset, true);
 	switch (offset)
 	{
 		default:
@@ -355,14 +371,20 @@ void cv1k_state::serial_rtc_eeprom_w(offs_t offset, u8 data)
 	}
 }
 
+// Sound writes are also done to an uncached area so they should take a penalty hit
+void cv1k_state::sound_w(offs_t offset, u8 data)
+{
+	m_maincpu->update_access_cycles(0x10400000 + offset, true);
+	m_ymz770->write(offset, data);
+}
 
 void cv1k_state::base_map(address_map &map)
 {
 	map(0x10000000, 0x10000007).rw(FUNC(cv1k_state::flash_io_r), FUNC(cv1k_state::flash_io_w));
-	map(0x10400000, 0x10400007).w("ymz770", FUNC(ymz770_device::write));
+	map(0x10400000, 0x10400007).w(FUNC(cv1k_state::sound_w));
 	map(0x10c00000, 0x10c00007).rw(FUNC(cv1k_state::serial_rtc_eeprom_r), FUNC(cv1k_state::serial_rtc_eeprom_w));
 //  map(0x18000000, 0x18000057) // blitter, installed on reset
-	map(0xf0000000, 0xf0ffffff).ram(); // mem mapped cache (sh3 internal?)
+	map(0xf0000000, 0xf0ffffff).ram(); // Memory mapped sh3 cache entry array
 }
 
 void cv1k_state::cv1k_map(address_map &map)

--- a/src/mame/cave/cv1k.cpp
+++ b/src/mame/cave/cv1k.cpp
@@ -343,6 +343,7 @@ void cv1k_state::flash_io_w(offs_t offset, u8 data)
 // if this code returns bad values it has gfx corruption.  the ibarablka set doesn't do this?!
 u8 cv1k_state::serial_rtc_eeprom_r(offs_t offset)
 {
+	m_maincpu->update_access_cycles(0x10c00000 + offset, false);
 	switch (offset)
 	{
 		case 0x01:
@@ -355,6 +356,7 @@ u8 cv1k_state::serial_rtc_eeprom_r(offs_t offset)
 
 void cv1k_state::serial_rtc_eeprom_w(offs_t offset, u8 data)
 {
+	m_maincpu->update_access_cycles(0x10c00000 + offset, true);
 	switch (offset)
 	{
 		case 0x01:

--- a/src/mame/cave/cv1k.cpp
+++ b/src/mame/cave/cv1k.cpp
@@ -292,8 +292,11 @@ u64 cv1k_state::flash_port_e_r()
 	return ((!m_nand->is_busy() ? 0x20 : 0x00)) | 0xdf;
 }
 
+// The cv1k_map is in physical addresses, the titles access registers from
+// uncached region 5 0xB...
 u8 cv1k_state::flash_io_r(offs_t offset)
 {
+	m_maincpu->update_access_cycles(0xB0000000 + offset, false);
 	switch (offset)
 	{
 		default:
@@ -309,14 +312,13 @@ u8 cv1k_state::flash_io_r(offs_t offset)
 			return 0xff;
 
 		case 0x00:
-			m_maincpu->update_access_cycles(0x10000000 + offset, false);
 			return m_nand->data_r();
 	}
 }
 
 void cv1k_state::flash_io_w(offs_t offset, u8 data)
 {
-	m_maincpu->update_access_cycles(0x10000000 + offset, true);
+	m_maincpu->update_access_cycles(0xB0000000 + offset, true);
 	switch (offset)
 	{
 		default:
@@ -343,7 +345,7 @@ void cv1k_state::flash_io_w(offs_t offset, u8 data)
 // if this code returns bad values it has gfx corruption.  the ibarablka set doesn't do this?!
 u8 cv1k_state::serial_rtc_eeprom_r(offs_t offset)
 {
-	m_maincpu->update_access_cycles(0x10c00000 + offset, false);
+	m_maincpu->update_access_cycles(0xB0c00000 + offset, false);
 	switch (offset)
 	{
 		case 0x01:
@@ -356,7 +358,7 @@ u8 cv1k_state::serial_rtc_eeprom_r(offs_t offset)
 
 void cv1k_state::serial_rtc_eeprom_w(offs_t offset, u8 data)
 {
-	m_maincpu->update_access_cycles(0x10c00000 + offset, true);
+	m_maincpu->update_access_cycles(0xB0c00000 + offset, true);
 	switch (offset)
 	{
 		case 0x01:
@@ -376,7 +378,7 @@ void cv1k_state::serial_rtc_eeprom_w(offs_t offset, u8 data)
 // Sound writes are also done to an uncached area so they should take a penalty hit
 void cv1k_state::sound_w(offs_t offset, u8 data)
 {
-	m_maincpu->update_access_cycles(0x10400000 + offset, true);
+	m_maincpu->update_access_cycles(0xB0400000 + offset, true);
 	m_ymz770->write(offset, data);
 }
 

--- a/src/mame/cave/cv1k.cpp
+++ b/src/mame/cave/cv1k.cpp
@@ -218,6 +218,7 @@ public:
 		m_blitter(*this, "blitter"),
 		m_nand(*this, "nand"),
 		m_eeprom(*this, "eeprom"),
+		m_ymz770(*this, "ymz770"),
 		m_ram(*this, "mainram"),
 		m_rombase(*this, "maincpu"),
 		m_eepromout(*this, "EEPROMOUT"),
@@ -244,6 +245,7 @@ private:
 	required_device<cv1k_blitter_device> m_blitter;
 	required_device<samsung_k9f1g08u0m_device> m_nand;
 	required_device<rtc9701_device> m_eeprom;
+	required_device<ymz770_device> m_ymz770;
 
 	required_shared_ptr<u64> m_ram;
 	required_region_ptr<u64> m_rombase;
@@ -257,6 +259,7 @@ private:
 	void flash_io_w(offs_t offset, u8 data);
 	u8 serial_rtc_eeprom_r(offs_t offset);
 	void serial_rtc_eeprom_w(offs_t offset, u8 data);
+	void sound_w(offs_t offset, u8 data);
 	u64 flash_port_e_r();
 
 	u64 speedup_r();
@@ -273,11 +276,22 @@ private:
 
 // FLASH interface
 
+// cv1k flash timing notes:
+// - For early titles this has less of an impact
+// - The times this is mostly visible is during midboss final patterns and certain boss patterns
+// - Latter titles lean more and more on mid stage load sequences where combined with the
+//   unneeded cache flush cause a lot of stage slowdown
+// - This behavior is exhibited in quite a bit of bosses, one big example is Pink Sweets final
+//   boss rainbow pattern where it causes the game to pause for an extended number of frames
+//   resulting in very staggered slowdown. Knowingly or unknowingly this in some cases causes
+//   or smooths some slowdown such as some patterns on the Mushi Futari Stage 5 boss
+// - Flash ready time doesn't account for a ton of time (~2500 cycles) but once the flash is ready
+//   to be read each read is done a byte at a time from an uncached area each taking ~10 cycles
+//   (2 base + 3 wait states) = 5 bus cycles -> 10 cpu cycles
 u64 cv1k_state::flash_port_e_r()
 {
 	return ((!m_nand->is_busy() ? 0x20 : 0x00)) | 0xdf;
 }
-
 
 u8 cv1k_state::flash_io_r(offs_t offset)
 {
@@ -296,12 +310,14 @@ u8 cv1k_state::flash_io_r(offs_t offset)
 			return 0xff;
 
 		case 0x00:
+			m_maincpu->update_access_cycles(0x10000000 + offset, false);
 			return m_nand->data_r();
 	}
 }
 
 void cv1k_state::flash_io_w(offs_t offset, u8 data)
 {
+	m_maincpu->update_access_cycles(0x10000000 + offset, true);
 	switch (offset)
 	{
 		default:
@@ -356,14 +372,20 @@ void cv1k_state::serial_rtc_eeprom_w(offs_t offset, u8 data)
 	}
 }
 
+// Sound writes are also done to an uncached area so they should take a penalty hit
+void cv1k_state::sound_w(offs_t offset, u8 data)
+{
+	m_maincpu->update_access_cycles(0x10400000 + offset, true);
+	m_ymz770->write(offset, data);
+}
 
 void cv1k_state::base_map(address_map &map)
 {
 	map(0x10000000, 0x10000007).rw(FUNC(cv1k_state::flash_io_r), FUNC(cv1k_state::flash_io_w));
-	map(0x10400000, 0x10400007).w("ymz770", FUNC(ymz770_device::write));
+	map(0x10400000, 0x10400007).w(FUNC(cv1k_state::sound_w));
 	map(0x10c00000, 0x10c00007).rw(FUNC(cv1k_state::serial_rtc_eeprom_r), FUNC(cv1k_state::serial_rtc_eeprom_w));
 //  map(0x18000000, 0x18000057) // blitter, installed on reset
-	map(0xf0000000, 0xf0ffffff).ram(); // mem mapped cache (sh3 internal?)
+	map(0xf0000000, 0xf0ffffff).ram(); // Memory mapped sh3 cache entry array
 }
 
 void cv1k_state::cv1k_map(address_map &map)

--- a/src/mame/cave/cv1k.cpp
+++ b/src/mame/cave/cv1k.cpp
@@ -596,6 +596,7 @@ void cv1k_state::cv1k(machine_config &config)
 	YMZ770(config, "ymz770", 16.384_MHz_XTAL).add_route(1, "mono", 1.0); // only Right output used, Left is not connected
 
 	CV1K_BLITTER(config, m_blitter);
+	m_blitter->set_maincpu(m_maincpu); // timing tracking of uncached blitter r/w access
 	m_blitter->set_screen("screen");
 	m_blitter->port_r_callback().set_ioport("DSW");
 	m_blitter->set_mainramsize(0x800000);

--- a/src/mame/cave/cv1k_v.cpp
+++ b/src/mame/cave/cv1k_v.cpp
@@ -908,6 +908,7 @@ u32 cv1k_blitter_device::screen_update(screen_device &screen, bitmap_rgb32 &bitm
 
 u32 cv1k_blitter_device::blitter_r(offs_t offset, u32 mem_mask)
 {
+	m_maincpu->update_access_cycles(0xB8000000 + offset, false);
 	switch (offset * 4)
 	{
 		case 0x10:
@@ -933,6 +934,7 @@ u32 cv1k_blitter_device::blitter_r(offs_t offset, u32 mem_mask)
 
 void cv1k_blitter_device::blitter_w(address_space &space, offs_t offset, u32 data, u32 mem_mask)
 {
+	m_maincpu->update_access_cycles(0xB8000000 + offset, true);
 	switch (offset * 4)
 	{
 		case 0x04:

--- a/src/mame/cave/cv1k_v.h
+++ b/src/mame/cave/cv1k_v.h
@@ -10,6 +10,8 @@
 
 #define CV1K_DEBUG_VRAM_VIEWER 0 // VRAM viewer for debug
 
+#include "cpu/sh/sh7709s.h"
+
 class cv1k_blitter_device : public device_t, public device_video_interface
 {
 public:
@@ -36,11 +38,20 @@ public:
 	u32 blitter_r(offs_t offset, u32 mem_mask = ~0);
 	void blitter_w(address_space &space, offs_t offset, u32 data, u32 mem_mask = ~0);
 
+	void set_maincpu(sh7709s_device* cpu)
+	{
+		m_maincpu = cpu;
+	}
+
 protected:
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 
 private:
+	// CPU used for tracking accesses to blitter address space for
+	// uncached access penalties
+	sh7709s_device* m_maincpu;
+
 	// Number of bytes that are read each time Blitter fetches operations from SRAM.
 	static inline constexpr int OPERATION_CHUNK_SIZE_BYTES = 64;
 


### PR DESCRIPTION
* Overall timing fixes
* Use icache sampling as the default, a lot less CPU intensive. Added compile time option to sample every instruction for debugging
* Implements nandflash timing which influences slowdown in some gameplay sections where background loads occur
* Fixup critical word first handling
* Adds a couple more notes about slowdown behavior related to how the game handles bullet checks and how flash timing affects slowdown during background loads