### PR TITLE
bugfix: Fix sound output channel in channelf_a.cpp

### DIFF
--- a/src/mame/fairchild/channelf_a.cpp
+++ b/src/mame/fairchild/channelf_a.cpp
@@ -98,7 +98,7 @@ void channelf_sound_device::sound_stream_update(sound_stream &stream)
 		if ((m_forced_ontime > 0) || ((m_sample_counter & mask) == target))   //  change made for improved sound
 			stream.put_int(0, sampindex, m_envelope, 32768);
 		else
-			stream.put(1, sampindex, 0);
+			stream.put(0, sampindex, 0);
 		m_sample_counter += m_incr;
 		m_envelope *= m_decay_mult;
 		if (m_forced_ontime > 0)          //  added for improved sound


### PR DESCRIPTION
This fixes a Segmentation-Fault crash on playing sound with ChannelF and SABA Videoplay machines. 
Corrected stream.put arguments for sound output, to allocated stream.
