### PR TITLE
ax80: subcpu uses the same internal ROM as maincpu; hook up subcpu and keys

### DIFF
--- a/src/mame/akai/akaiax80.cpp
+++ b/src/mame/akai/akaiax80.cpp
@@ -8,7 +8,7 @@
     ROMs provided by Arashikage
 
     Hardware:
-        CPU: uPD7811 with internal ROM
+        CPU: 2x uPD7811 with internal ROM
         Other H/W: 8253 PIT (x6), 8255 PPI (x2), 8279 keyboard/display controller
         Voices (x8):
             NJM4558D sawtooth generator (x2)
@@ -21,12 +21,10 @@
     Service manual incl. schematics at:
     https://archive.org/download/AkaiAX80ServiceManual/Akai%20AX80%20Service%20Manual.pdf
 
-    There's a 2nd UPD7811 (IC1) to scan the keyboard. Its internal rom is undumped.
-    Ports A/B/C go to the keyboard, Port D (d0-6) connects 1-to-1 to Port A of IC2
-    (Main CPU). Ports F and AN are unused. PD7 goes to /INT2 of IC2, /NMI goes to PA7
-    of IC2.
-
     Both CPUs are hardwired as MODE 1, and both share a CSA120MT crystal.
+    They both use the same internal ROM, but the PC5 pin selects internal or external ROM.
+    (According to the service manual, the main CPU in earlier units may also use a different
+    internal ROM, but the main CPU's internal ROM is almost entirely unused to begin with.)
 
     RAM is backed up by a CR2430-T battery.
 
@@ -38,6 +36,7 @@
 
 #include "emu.h"
 #include "cpu/upd7810/upd7810.h"
+#include "machine/gen_latch.h"
 #include "machine/pit8253.h"
 #include "machine/i8255.h"
 #include "machine/i8279.h"
@@ -60,6 +59,8 @@ public:
 	ax80_state(const machine_config &mconfig, device_type type, const char *tag)
 	: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
+		, m_subcpu(*this, "subcpu")
+		, m_keys(*this, "KEY%u", 0)
 	{ }
 
 	void ax80(machine_config &config);
@@ -67,9 +68,26 @@ public:
 private:
 	void ax80_map(address_map &map) ATTR_COLD;
 
+	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
+
+	void keys_w(u8 data) { m_key_sel = data; }
+	u8 keys_r();
+
 	required_device<upd7810_device> m_maincpu;
+	required_device<upd7810_device> m_subcpu;
+
+	required_ioport_array<8> m_keys;
+
+	u8 m_key_sel;
 };
+
+void ax80_state::machine_start()
+{
+	m_key_sel = 0;
+
+	save_item(NAME(m_key_sel));
+}
 
 void ax80_state::machine_reset()
 {
@@ -96,9 +114,21 @@ void ax80_state::ax80_map(address_map &map)
 
 void ax80_state::ax80(machine_config &config)
 {
-	UPD7811(config, m_maincpu, XTAL(12'000'000));
+	UPD7811(config, m_maincpu, 12_MHz_XTAL);
 	m_maincpu->set_addrmap(AS_PROGRAM, &ax80_state::ax80_map);
-	//m_maincpu->set_addrmap(AS_IO, &ax80_state::ax80_io);
+	m_maincpu->pc_in_cb().set_constant(0x00); // PC5 low = use external program
+
+	UPD7811(config, m_subcpu, 12_MHz_XTAL);
+	m_subcpu->pa_in_cb().set(FUNC(ax80_state::keys_r));
+	m_subcpu->pb_in_cb().set(FUNC(ax80_state::keys_r)); // secondary contacts, used for velocity sensing
+	m_subcpu->pc_out_cb().set(FUNC(ax80_state::keys_w));
+	m_subcpu->pc_in_cb().set_constant(0x20); // PC5 high = use internal program
+
+	auto &latch(GENERIC_LATCH_8(config, "latch"));
+	m_maincpu->pa_in_cb().set(latch, FUNC(generic_latch_8_device::read));
+	m_maincpu->pa_out_cb().set_inputline(m_subcpu, INPUT_LINE_NMI).bit(7).invert();
+	m_subcpu->pd_out_cb().set(latch, FUNC(generic_latch_8_device::write));
+	m_subcpu->pd_out_cb().append_inputline(m_maincpu, UPD7810_INTF2).bit(7).invert();
 
 	PIT8253(config, PIT0_TAG);
 	PIT8253(config, PIT1_TAG);
@@ -119,23 +149,113 @@ void ax80_state::ax80(machine_config &config)
 	//kdc.in_ctrl_callback().set_constant(1);                           // not connected
 }
 
+u8 ax80_state::keys_r()
+{
+	u8 data = 0xff;
+	for (int i = 0; i < 8; i++)
+		if (!BIT(m_key_sel, i))
+			data &= m_keys[i]->read();
+
+	return data;
+}
+
 static INPUT_PORTS_START( ax80 )
+	PORT_START("KEY0")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("C2")
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("C#2")
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("D2")
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("D#2")
+	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("E2")
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("F2")
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("F#2")
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("G2")
+
+	PORT_START("KEY1")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("G#2")
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("A2")
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("A#2")
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("B2")
+	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("C3")
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("C#3")
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("D3")
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("D#3")
+
+	PORT_START("KEY2")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("E3")
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("F3")
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("F#3")
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("G3")
+	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("G#3")
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("A3")
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("A#3")
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("B3")
+
+	PORT_START("KEY3")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("C4")
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("C#4")
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("D4")
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("D#4")
+	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("E4")
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("F4")
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("F#4")
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("G4")
+
+	PORT_START("KEY4")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("G#4")
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("A4")
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("A#4")
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("B4")
+	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("C5")
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("C#5")
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("D5")
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("D#5")
+
+	PORT_START("KEY5")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("E5")
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("F5")
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("F#5")
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("G5")
+	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("G#5")
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("A5")
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("A#5")
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("B5")
+
+	PORT_START("KEY6")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("C6")
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("C#6")
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("D6")
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("D#6")
+	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("E6")
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("F6")
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("F#6")
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("G6")
+
+	PORT_START("KEY7")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("G#6")
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("A6")
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("A#6")
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("B6")
+	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME("C7")
+	PORT_BIT( 0xe0, IP_ACTIVE_LOW, IPT_UNUSED )
 INPUT_PORTS_END
 
 ROM_START( ax80 )
 	ROM_REGION(0x1000, "maincpu", 0) // CPU internal mask
-	ROM_LOAD( "akai ax80 main cpu mask rom.ic2", 0x000000, 0x001000, CRC(241c078f) SHA1(7f5d0d718f2d03ec446568ae440beaff0aac6bfd) )
+	ROM_LOAD( "akai ax80 main cpu mask rom.ic2", 0x0000, 0x1000, CRC(241c078f) SHA1(7f5d0d718f2d03ec446568ae440beaff0aac6bfd) )
+
+	ROM_REGION(0x1000, "subcpu", 0)
+	ROM_COPY( "maincpu", 0x0000, 0x0000, 0x1000 )
 
 	ROM_REGION(0x2000, "program", 0) // external program EPROM
 	ROM_SYSTEM_BIOS( 0, "k", "REV.K" )
-	ROMX_LOAD( "ax-80k.ic4", 0x000000, 0x002000, CRC(a2f95ccf) SHA1(4e5f2c4c9a08ec1d38146cae786b400261a3dbb7), ROM_BIOS(0) )
+	ROMX_LOAD( "ax-80k.ic4", 0x0000, 0x2000, CRC(a2f95ccf) SHA1(4e5f2c4c9a08ec1d38146cae786b400261a3dbb7), ROM_BIOS(0) )
 	ROM_SYSTEM_BIOS( 1, "l", "REV.L" )
-	ROMX_LOAD( "ax-80l.ic4", 0x000000, 0x002000, CRC(bc3d21bd) SHA1(d6730ec33b28e705a0ff88946b7860fadcc37793), ROM_BIOS(1) )
+	ROMX_LOAD( "ax-80l.ic4", 0x0000, 0x2000, CRC(bc3d21bd) SHA1(d6730ec33b28e705a0ff88946b7860fadcc37793), ROM_BIOS(1) )
 	ROM_SYSTEM_BIOS( 2, "i", "REV.I" )
-	ROMX_LOAD( "ax-80i.ic4", 0x000000, 0x002000, CRC(d616e435) SHA1(84820522e6a96fc29966f82e76254e54df15d7e6), ROM_BIOS(2) )
+	ROMX_LOAD( "ax-80i.ic4", 0x0000, 0x2000, CRC(d616e435) SHA1(84820522e6a96fc29966f82e76254e54df15d7e6), ROM_BIOS(2) )
 ROM_END
 
 } // anonymous namespace
 
 
-CONS( 1984, ax80, 0, 0, ax80, ax80, ax80_state, empty_init, "Akai", "AX80", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+CONS( 1984, ax80, 0, 0, ax80, ax80, ax80_state, empty_init, "Akai", "AX80 Programmable Polyphonic Synthesizer", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )


### PR DESCRIPTION
After looking at the service manual and a brief disassembly, the sub CPU internal ROM is actually the same as the already-dumped main CPU ROM; depending on whether one of the port pins is pulled high or low, it either jumps to external ROM or doesn't, sort of like the counterpart in the X7000 and MPC60.

(This needs a rework of the 7811's `HLT` instruction to actually work correctly, but I'll be PR-ing that separately)