### PR TITLE
upd7810 and variants: rework HLT instruction behavior

### DIFF
--- a/src/devices/cpu/upd7810/upd7810.cpp
+++ b/src/devices/cpu/upd7810/upd7810.cpp
@@ -835,11 +835,8 @@ void upd7810_device::write_smh(uint8_t data)
 void upd7810_device::upd7810_take_irq()
 {
 	uint16_t vector = 0;
+	uint16_t irr_mask = 0;
 	int irqline = 0;
-
-	/* global interrupt disable? */
-	if (0 == IFF && !(IRR & INTFNMI))
-		return;
 
 	/* check the interrupts in priority sequence */
 	if (IRR & INTFNMI)
@@ -847,21 +844,21 @@ void upd7810_device::upd7810_take_irq()
 		/* Nonmaskable interrupt */
 		irqline = INPUT_LINE_NMI;
 		vector = 0x0004;
-		IRR &= ~INTFNMI;
+		irr_mask = INTFNMI;
 	}
 	else
 	if ((IRR & INTFT0)  && 0 == (MKL & 0x02))
 	{
 		vector = 0x0008;
 		if (0 != (MKL & 0x04))
-			IRR&=~INTFT0;
+			irr_mask = INTFT0;
 	}
 	else
 	if ((IRR & INTFT1)  && 0 == (MKL & 0x04))
 	{
 		vector = 0x0008;
 		if (0 != (MKL & 0x02))
-			IRR&=~INTFT1;
+			irr_mask = INTFT1;
 	}
 	else
 	if ((IRR & INTF1)   && 0 == (MKL & 0x08))
@@ -869,7 +866,7 @@ void upd7810_device::upd7810_take_irq()
 		irqline = UPD7810_INTF1;
 		vector = 0x0010;
 		if (0 != (MKL & 0x10))
-			IRR&=~INTF1;
+			irr_mask = INTF1;
 	}
 	else
 	if ((IRR & INTF2)   && 0 == (MKL & 0x10))
@@ -877,53 +874,60 @@ void upd7810_device::upd7810_take_irq()
 		irqline = UPD7810_INTF2;
 		vector = 0x0010;
 		if (0 != (MKL & 0x08))
-			IRR&=~INTF2;
+			irr_mask = INTF2;
 	}
 	else
 	if ((IRR & INTFE0)  && 0 == (MKL & 0x20))
 	{
 		vector = 0x0018;
 		if (0 != (MKL & 0x40))
-			IRR&=~INTFE0;
+			irr_mask = INTFE0;
 	}
 	else
 	if ((IRR & INTFE1)  && 0 == (MKL & 0x40))
 	{
 		vector = 0x0018;
 		if (0 != (MKL & 0x20))
-			IRR&=~INTFE1;
+			irr_mask = INTFE1;
 	}
 	else
 	if ((IRR & INTFEIN) && 0 == (MKL & 0x80))
 	{
 		vector = 0x0020;
 		if (0 != (MKH & 0x01))
-			IRR&=~INTFEIN;
+			irr_mask = INTFEIN;
 	}
 	else
 	if ((IRR & INTFAD)  && 0 == (MKH & 0x01))
 	{
 		vector = 0x0020;
 		if (0 != (MKL & 0x80))
-			IRR&=~INTFAD;
+			irr_mask = INTFAD;
 	}
 	else
 	if ((IRR & INTFSR)  && 0 == (MKH & 0x02))
 	{
 		vector = 0x0028;
 		if (0 != (MKH & 0x04))
-			IRR&=~INTFSR;
+			irr_mask = INTFSR;
 	}
 	else
 	if ((IRR & INTFST)  && 0 == (MKH & 0x04))
 	{
 		vector = 0x0028;
 		if (0 != (MKH & 0x02))
-			IRR&=~INTFST;
+			irr_mask = INTFST;
 	}
 
 	if (vector)
 	{
+		// release halt on any non-masked interrupt even when IFF = 0
+		m_halt = 0;
+
+		/* global interrupt disable? */
+		if (0 == IFF && !(IRR & INTFNMI))
+			return;
+
 		/* acknowledge external IRQ */
 		if (irqline)
 			standard_irq_callback(irqline, PC);
@@ -934,6 +938,7 @@ void upd7810_device::upd7810_take_irq()
 		SP--;
 		WM( SP, PCL );
 		IFF = m_iff_pending = 0;
+		IRR &= ~irr_mask;
 		PSW &= ~(SK|L0|L1);
 		PC = vector;
 	}
@@ -942,11 +947,8 @@ void upd7810_device::upd7810_take_irq()
 void upd7801_device::upd7810_take_irq()
 {
 	uint16_t vector = 0;
+	uint16_t irr_mask = 0;
 	int irqline = 0;
-
-	/* global interrupt disable? */
-	if (0 == IFF)
-		return;
 
 	/* 1 - SOFTI - vector at 0x0060 */
 	/* 2 - INT0 - Masked by MK0 bit */
@@ -959,31 +961,38 @@ void upd7801_device::upd7810_take_irq()
 	if ( IRR & INTFT0 && 0 == ( MKL & 0x02 ) )
 	{
 		vector = 0x0008;
-		IRR &= ~INTFT0;
+		irr_mask = INTFT0;
 	}
 	/* 4 - INT1 - Masked by MK1 bit */
 	if ( IRR & INTF1 && 0 == ( MKL & 0x04 ) )
 	{
 		irqline = UPD7810_INTF1;
 		vector = 0x0010;
-		IRR &= ~INTF1;
+		irr_mask = INTF1;
 	}
 	/* 5 - INT2 - Masked by MK2 bit */
 	if ( IRR & INTF2 && 0 == ( MKL & 0x08 ) )
 	{
 		irqline = UPD7810_INTF2;
 		vector = 0x0020;
-		IRR &= ~INTF2;
+		irr_mask = INTF2;
 	}
 	/* 6 - INTS - Masked by MKS bit */
 	if ( IRR & INTFST && 0 == ( MKL & 0x10 ) )
 	{
 		vector = 0x0040;
-		IRR &= ~INTFST;
+		irr_mask = INTFST;
 	}
 
 	if (vector)
 	{
+		// release halt on any non-masked interrupt even when IFF = 0
+		m_halt = 0;
+
+		/* global interrupt disable? */
+		if (0 == IFF)
+			return;
+
 		/* acknowledge external IRQ */
 		if (irqline)
 			standard_irq_callback(irqline, PC);
@@ -994,6 +1003,7 @@ void upd7801_device::upd7810_take_irq()
 		SP--;
 		WM( SP, PCL );
 		IFF = m_iff_pending = 0;
+		IRR &= ~irr_mask;
 		PSW &= ~(SK|L0|L1);
 		PC = vector;
 	}
@@ -1754,6 +1764,7 @@ void upd7810_device::base_device_start()
 	save_item(NAME(m_nmi));
 	save_item(NAME(m_int1));
 	save_item(NAME(m_int2));
+	save_item(NAME(m_halt));
 
 	save_item(NAME(m_txs));
 	save_item(NAME(m_rxs));
@@ -1993,6 +2004,7 @@ void upd7810_device::device_reset()
 	m_nmi = 0;
 	m_int1 = 0;
 	m_int2 = 1; // physical (inverted) INT2 line state
+	m_halt = 0;
 
 	m_txs = 0;
 	m_rxs = ~0;
@@ -2036,6 +2048,16 @@ void upd7810_device::execute_run()
 {
 	do
 	{
+		if (m_halt)
+		{
+			debugger_wait_hook();
+			// continue running peripherals until a pending (internal or external) interrupt
+			m_icount--;
+			handle_timers(1);
+			upd7810_take_irq();
+			continue;
+		}
+
 		int cc;
 
 		PPC = PC;

--- a/src/devices/cpu/upd7810/upd7810.h
+++ b/src/devices/cpu/upd7810/upd7810.h
@@ -314,6 +314,7 @@ protected:
 	int     m_nmi;    /* keep track of current nmi state. Needed for 7810 irq checking. */
 	int     m_int1;   /* keep track of current int1 state. Needed for irq checking. */
 	int     m_int2;   /* keep track to current int2 state. Needed for irq checking. */
+	uint8_t m_halt;
 
 	/* internal helper variables */
 	uint16_t  m_txs;    /* transmitter shift register */
@@ -392,7 +393,7 @@ protected:
 	void RLD();
 	void RRD();
 	void NEGA();
-	void HALT();
+	void HLT();
 	void DIV_A();
 	void DIV_B();
 	void DIV_C();

--- a/src/devices/cpu/upd7810/upd7810_dasm.cpp
+++ b/src/devices/cpu/upd7810/upd7810_dasm.cpp
@@ -135,7 +135,7 @@ const char *const upd7810_base_disassembler::dasm_s::token_names[] =
 	"GTAX",
 	"GTI",
 	"GTIW",
-	"HALT",
+	"HLT",
 	"IN",   /* 7801 */
 	"INR",
 	"INRW",
@@ -1133,7 +1133,7 @@ const upd7810_base_disassembler::dasm_s upd7810_disassembler::d48_7810[256] =
 	{RLD,    nullptr   }, // 38: 0100 1000 0011 1000
 	{RRD,    nullptr   }, // 39: 0100 1000 0011 1001
 	{NEGA,   nullptr   }, // 3a: 0100 1000 0011 1010
-	{HALT,   nullptr   }, // 3b: 0100 1000 0011 1011
+	{HLT,    nullptr   }, // 3b: 0100 1000 0011 1011
 	{                  }, // 3c: 0100 1000 0011 1100
 	{DIV,    "A"       }, // 3d: 0100 1000 0011 1101
 	{DIV,    "B"       }, // 3e: 0100 1000 0011 1110
@@ -2517,7 +2517,7 @@ const upd7810_base_disassembler::dasm_s upd7807_disassembler::d48_7807[256] =
 	{RLD,    nullptr   }, // 38: 0100 1000 0011 1000
 	{RRD,    nullptr   }, // 39: 0100 1000 0011 1001
 	{NEGA,   nullptr   }, // 3a: 0100 1000 0011 1010
-	{HALT,   nullptr   }, // 3b: 0100 1000 0011 1011
+	{HLT,    nullptr   }, // 3b: 0100 1000 0011 1011
 	{                  }, // 3c: 0100 1000 0011 1100
 	{DIV,    "A"       }, // 3d: 0100 1000 0011 1101
 	{DIV,    "B"       }, // 3e: 0100 1000 0011 1110
@@ -4437,7 +4437,7 @@ const upd7810_base_disassembler::dasm_s upd7801_disassembler::d74_7801[256] = {
 
 const upd7810_base_disassembler::dasm_s upd7801_disassembler::XX_7801[256] = {
 	// 0x00 - 0x3F
-	{ NOP,     nullptr }, { HALT,    nullptr }, { INX,     "SP"    }, { DCX,     "SP"    },
+	{ NOP,     nullptr }, { HLT,     nullptr }, { INX,     "SP"    }, { DCX,     "SP"    },
 	{ LXI,     "SP,%w" }, { ANIW,    "%a,%b" }, {                  }, { ANI,     "A,%b"  },
 	{ RET,     nullptr }, { SIO,     nullptr }, { MOV,     "A,B"   }, { MOV,     "A,C"   },
 	{ MOV,     "A,D"   }, { MOV,     "A,E"   }, { MOV,     "A,H"   }, { MOV,     "A,L"   },
@@ -5131,7 +5131,7 @@ const upd7810_base_disassembler::dasm_s upd78c05_disassembler::d74_78c05[256] = 
 
 const upd7810_base_disassembler::dasm_s upd78c05_disassembler::XX_78c05[256] = {
 	// 0x00 - 0x3F
-	{ NOP,     nullptr }, { HALT,    nullptr }, { INX,     "SP"    }, { DCX,     "SP"    },
+	{ NOP,     nullptr }, { HLT,     nullptr }, { INX,     "SP"    }, { DCX,     "SP"    },
 	{ LXI,     "SP,%w" }, { ANIW,    "%a,%b" }, {                  }, { ANI,     "A,%b"  },
 	{ RET,     nullptr }, { SIO,     nullptr }, { MOV,     "A,B"   }, { MOV,     "A,C"   },
 	{ MOV,     "A,D"   }, { MOV,     "A,E"   }, { MOV,     "A,H"   }, { MOV,     "A,L"   },

--- a/src/devices/cpu/upd7810/upd7810_dasm.h
+++ b/src/devices/cpu/upd7810/upd7810_dasm.h
@@ -112,7 +112,7 @@ public:
 		GTAX,
 		GTI,
 		GTIW,
-		HALT,
+		HLT,
 		IN,     /* 7801 */
 		INR,
 		INRW,

--- a/src/devices/cpu/upd7810/upd7810_opcodes.cpp
+++ b/src/devices/cpu/upd7810/upd7810_opcodes.cpp
@@ -290,12 +290,9 @@ void upd7810_device::NEGA()
 }
 
 /* 48 3b: 0100 1000 0011 1011 */
-void upd7810_device::HALT()
+void upd7810_device::HLT()
 {
-	int cycles = (m_icount / 4) * 4;
-	m_icount -= cycles;
-	handle_timers(cycles);
-	PC -= 1;        /* continue executing HALT */
+	m_halt = 1;
 }
 
 /* 48 3d: 0100 1000 0011 1101 */
@@ -829,7 +826,7 @@ void upd7810_device::STOP()
 	int cycles = (m_icount / 4) * 4;
 	m_icount -= cycles;
 	handle_timers(cycles);
-	PC -= 1;
+	PC -= 2;
 }
 
 /* 48 c0: 0100 1000 1100 0000 */

--- a/src/devices/cpu/upd7810/upd7810_table.cpp
+++ b/src/devices/cpu/upd7810/upd7810_table.cpp
@@ -78,7 +78,7 @@ const struct upd7810_device::opcode_s upd7810_device::s_op48[256] =
 	{&upd7810_device::RLD,           2,17, 8,L0|L1}, /* 38: 0100 1000 0011 1000                      */
 	{&upd7810_device::RRD,           2,17, 8,L0|L1}, /* 39: 0100 1000 0011 1001                      */
 	{&upd7810_device::NEGA,          2, 8, 8,L0|L1}, /* 3a: 0100 1000 0011 1010                      */
-	{&upd7810_device::HALT,          2,12, 8,L0|L1}, /* 3b: 0100 1000 0011 1011                      */ /* Mnemonic should be HLT? Note the timing differs between the upd7810 and upd78c10: 7810 takes 11 cycles, 78c10 takes 12; both take 8 when skipped */
+	{&upd7810_device::HLT,           2,12, 8,L0|L1}, /* 3b: 0100 1000 0011 1011                      */ /* Note the timing differs between the upd7810 and upd78c10: 7810 takes 11 cycles, 78c10 takes 12; both take 8 when skipped */
 	{&upd7810_device::illegal2,      2, 8, 8,L0|L1}, /* 3c: 0100 1000 0011 1100                      */
 	{&upd7810_device::DIV_A,         2,59, 8,L0|L1}, /* 3d: 0100 1000 0011 1101                      */
 	{&upd7810_device::DIV_B,         2,59, 8,L0|L1}, /* 3e: 0100 1000 0011 1110                      */
@@ -3605,7 +3605,7 @@ const struct upd7810_device::opcode_s upd7810_device::s_op74_7801[256] =
 const struct upd7810_device::opcode_s upd7810_device::s_opXX_7801[256] =
 {
 	/* 0x00 - 0x1F */
-	{&upd7810_device::NOP,           1, 4, 4,L0|L1}, {&upd7810_device::HALT,          1, 6, 6,L0|L1},
+	{&upd7810_device::NOP,           1, 4, 4,L0|L1}, {&upd7810_device::HLT,           1, 6, 6,L0|L1},
 	{&upd7810_device::INX_SP,        1, 7, 7,L0|L1}, {&upd7810_device::DCX_SP,        1, 7, 7,L0|L1},
 	{&upd7810_device::LXI_S_w,       3,10,10,L0|L1}, {&upd7810_device::ANIW_wa_xx,    3,16,16,L0|L1},
 	{&upd7810_device::illegal,       1, 4, 4,L0|L1}, {&upd7810_device::ANI_A_xx,      2, 7, 7,L0|L1},
@@ -4855,7 +4855,7 @@ const struct upd7810_device::opcode_s upd7810_device::s_op74_78c05[256] =
 const struct upd7810_device::opcode_s upd7810_device::s_opXX_78c05[256] =
 {
 	/* 0x00 - 0x1F */
-	{&upd7810_device::NOP,           1, 4, 4,L0|L1}, {&upd7810_device::HALT,          1, 6, 6,L0|L1},
+	{&upd7810_device::NOP,           1, 4, 4,L0|L1}, {&upd7810_device::HLT,           1, 6, 6,L0|L1},
 	{&upd7810_device::INX_SP,        1, 7, 7,L0|L1}, {&upd7810_device::DCX_SP,        1, 7, 7,L0|L1},
 	{&upd7810_device::LXI_S_w,       3,10,10,L0|L1}, {&upd7810_device::ANIW_wa_xx,    3,16,16,L0|L1},
 	{&upd7810_device::illegal,       1, 4, 4,L0|L1}, {&upd7810_device::ANI_A_xx,      2, 7, 7,L0|L1},
@@ -6106,7 +6106,7 @@ const struct upd7810_device::opcode_s upd7810_device::s_op74_78c06[256] =
 const struct upd7810_device::opcode_s upd7810_device::s_opXX_78c06[256] =
 {
 	/* 0x00 - 0x1F */
-	{&upd7810_device::NOP,           1, 6, 6,L0|L1}, {&upd7810_device::HALT,          1, 6, 6,L0|L1},
+	{&upd7810_device::NOP,           1, 6, 6,L0|L1}, {&upd7810_device::HLT,           1, 6, 6,L0|L1},
 	{&upd7810_device::INX_SP,        1, 9, 9,L0|L1}, {&upd7810_device::DCX_SP,        1, 9, 9,L0|L1},
 	{&upd7810_device::LXI_S_w,       3,16,16,L0|L1}, {&upd7810_device::ANIW_wa_xx,    3,22,22,L0|L1},
 	{&upd7810_device::illegal,       1, 6, 6,L0|L1}, {&upd7810_device::ANI_A_xx,      2,11,11,L0|L1},


### PR DESCRIPTION
`HLT` now responds to interrupts correctly. Needed for the sub->main CPU comms in #15701 to work.

(`STOP` should be similarly reworked at some point to respond to NMI, but the timing there is a bit more involved, and AFAIK nothing currently uses it anyway. It's at least been changed to decrement PC by the correct amount now.)